### PR TITLE
Enable QUIC by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: config
-      run: ./config --banner=Configured --strict-warnings enable-fips enable-quic && perl configdata.pm --dump
+      run: ./config --banner=Configured --strict-warnings enable-fips && perl configdata.pm --dump
     - name: make build_generated
       run: make -s build_generated
     - name: make update
@@ -46,7 +46,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: config
-      run: ./config --banner=Configured --strict-warnings enable-fips enable-quic && perl configdata.pm --dump
+      run: ./config --banner=Configured --strict-warnings enable-fips && perl configdata.pm --dump
     - name: make build_generated
       run: make -s build_generated
     - name: make doc-nits
@@ -66,7 +66,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: config
-      run: CPPFLAGS=-ansi ./config --banner=Configured no-asm no-makedepend enable-buildtest-c++ enable-fips enable-quic --strict-warnings -D_DEFAULT_SOURCE && perl configdata.pm --dump
+      run: CPPFLAGS=-ansi ./config --banner=Configured no-asm no-makedepend enable-buildtest-c++ enable-fips --strict-warnings -D_DEFAULT_SOURCE && perl configdata.pm --dump
     - name: make
       run: make -s -j4
 
@@ -79,7 +79,7 @@ jobs:
     - name: localegen
       run: sudo locale-gen tr_TR.UTF-8
     - name: config
-      run: CC=gcc ./config --banner=Configured enable-fips enable-quic --strict-warnings && perl configdata.pm --dump
+      run: CC=gcc ./config --banner=Configured enable-fips --strict-warnings && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -118,7 +118,7 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
-      run: ./config --banner=Configured --strict-warnings no-deprecated enable-fips enable-quic && perl configdata.pm --dump
+      run: ./config --banner=Configured --strict-warnings no-deprecated enable-fips && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -160,7 +160,7 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
-      run: ./config --banner=Configured --debug enable-asan enable-ubsan enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-fips enable-quic -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION && perl configdata.pm --dump
+      run: ./config --banner=Configured --debug enable-asan enable-ubsan enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-fips -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -174,7 +174,7 @@ jobs:
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
       # --debug -O1 is to produce a debug build that runs in a reasonable amount of time
-      run: CC=clang ./config --banner=Configured --debug -O1 -fsanitize=memory -DOSSL_SANITIZE_MEMORY -fno-optimize-sibling-calls enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-fips enable-quic && perl configdata.pm --dump
+      run: CC=clang ./config --banner=Configured --debug -O1 -fsanitize=memory -DOSSL_SANITIZE_MEMORY -fno-optimize-sibling-calls enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-fips && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -187,7 +187,7 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
-      run: CC=clang ./config --banner=Configured no-fips --strict-warnings -fsanitize=thread enable-quic && perl configdata.pm --dump
+      run: CC=clang ./config --banner=Configured no-fips --strict-warnings -fsanitize=thread && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -202,7 +202,7 @@ jobs:
     - name: modprobe tls
       run: sudo modprobe tls
     - name: config
-      run: ./config --banner=Configured --strict-warnings no-ec enable-ssl-trace enable-zlib enable-zlib-dynamic enable-crypto-mdebug enable-crypto-mdebug-backtrace enable-egd enable-ktls enable-fips enable-quic no-threads && perl configdata.pm --dump
+      run: ./config --banner=Configured --strict-warnings no-ec enable-ssl-trace enable-zlib enable-zlib-dynamic enable-crypto-mdebug enable-crypto-mdebug-backtrace enable-egd enable-ktls enable-fips no-threads && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -217,7 +217,7 @@ jobs:
     - name: modprobe tls
       run: sudo modprobe tls
     - name: config
-      run: ./config --banner=Configured --strict-warnings enable-ktls enable-fips enable-quic && perl configdata.pm --dump
+      run: ./config --banner=Configured --strict-warnings enable-ktls enable-fips && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -321,7 +321,7 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
-      run: ./config --banner=Configured --strict-warnings no-legacy enable-fips enable-quic && perl configdata.pm --dump
+      run: ./config --banner=Configured --strict-warnings no-legacy enable-fips && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -350,7 +350,7 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
-      run: CC=gcc ./config --banner=Configured enable-tfo enable-quic --strict-warnings && perl configdata.pm --dump
+      run: CC=gcc ./config --banner=Configured enable-tfo --strict-warnings && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -460,7 +460,7 @@ jobs:
       with:
         submodules: recursive
     - name: Configure OpenSSL
-      run: ./config --banner=Configured --strict-warnings enable-external-tests enable-quic && perl configdata.pm --dump
+      run: ./config --banner=Configured --strict-warnings enable-external-tests && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,8 @@ jobs:
     - name: localegen
       run: sudo locale-gen tr_TR.UTF-8
     - name: config
-      run: CC=gcc ./config --banner=Configured enable-fips --strict-warnings && perl configdata.pm --dump
+      # enable-quic is on by default, but we leave it here to check we're testing the explicit enable somewhere
+      run: CC=gcc ./config --banner=Configured enable-fips enable-quic --strict-warnings && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -34,7 +34,7 @@ jobs:
             extra_config: enable-fips
           }, {
             branch: master,
-            extra_config: no-afalgeng enable-fips enable-tfo enable-quic
+            extra_config: no-afalgeng enable-fips enable-tfo
           }
         ]
     runs-on: ubuntu-latest

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -126,7 +126,7 @@ jobs:
           }, {
             arch: m68k-linux-gnu,
             libs: libc6-dev-m68k-cross,
-            target: -mcfv4e linux-latomic -Wno-stringop-overflow,
+            target: -mcfv4e linux-latomic -Wno-stringop-overflow no-quic,
             tests: none
           }, {
             arch: mips-linux-gnu,

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -44,7 +44,7 @@ jobs:
         fi
 
         CC=${{ matrix.cc }} ./config --banner=Configured no-shared \
-            -Wall -Werror enable-fips enable-quic --strict-warnings -DOPENSSL_USE_IPV6=0 ${extra_cflags}
+            -Wall -Werror enable-fips --strict-warnings -DOPENSSL_USE_IPV6=0 ${extra_cflags}
 
     - name: config dump
       run: ./configdata.pm --dump
@@ -71,7 +71,7 @@ jobs:
     - name: config
       run: |
         CC=${{ matrix.zoo.cc }} ./config --banner=Configured \
-            -Wall -Werror --strict-warnings enable-fips enable-quic
+            -Wall -Werror --strict-warnings enable-fips
     - name: config dump
       run: ./configdata.pm --dump
     - name: make
@@ -99,7 +99,7 @@ jobs:
     - name: config
       working-directory: _build
       run: |
-        perl ..\Configure --banner=Configured no-makedepend enable-fips enable-quic
+        perl ..\Configure --banner=Configured no-makedepend enable-fips
     - name: config dump
       working-directory: _build
       run: ./configdata.pm --dump

--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -40,6 +40,7 @@ jobs:
           enable-trace enable-fips,
           no-ts,
           no-ui,
+          no-quic
         ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,9 +22,9 @@ jobs:
           - windows-2022
         platform:
           - arch: win64
-            config: enable-fips enable-quic
+            config: enable-fips
           - arch: win32
-            config: --strict-warnings no-fips enable-quic
+            config: --strict-warnings no-fips
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v3
@@ -101,7 +101,7 @@ jobs:
     - name: config
       working-directory: _build
       run: |
-        perl ..\Configure --banner=Configured no-makedepend no-bulk no-deprecated no-fips no-asm no-threads enable-quic -DOPENSSL_SMALL_FOOTPRINT
+        perl ..\Configure --banner=Configured no-makedepend no-bulk no-deprecated no-fips no-asm no-threads -DOPENSSL_SMALL_FOOTPRINT
         perl configdata.pm --dump
     - name: build
       working-directory: _build
@@ -119,10 +119,10 @@ jobs:
 #          - windows-2022
         platform:
           - arch: win64
-            config: -DCMAKE_C_COMPILER=gcc --strict-warnings no-fips enable-quic
+            config: -DCMAKE_C_COMPILER=gcc --strict-warnings no-fips
 # are we really learning sth new from win32? So let's save some CO2 for now disabling this
 #          - arch: win32
-#            config: -DCMAKE_C_COMPILER=gcc --strict-warnings no-fips enable-quic
+#            config: -DCMAKE_C_COMPILER=gcc --strict-warnings no-fips
     runs-on: ${{matrix.os}}
     env:
       CYGWIN_NOWINPATH: 1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,10 @@ OpenSSL 3.2
 
 ### Changes between 3.1 and 3.2 [xx XXX xxxx]
 
+ * Added client side support for QUIC
+
+   *Hugo Landau*
+
  * Added SHA256/192 algorithm support.
 
    *Fergus Dall*

--- a/Configure
+++ b/Configure
@@ -622,6 +622,7 @@ my @disable_cascades = (
     "tls"               => [ @tls ],
     sub { 0 == scalar grep { !$disabled{$_} } @tls }
                         => [ "tls" ],
+    "tls1_3"            => [ "quic" ],
 
     "crypto-mdebug"     => [ "crypto-mdebug-backtrace" ],
 

--- a/Configure
+++ b/Configure
@@ -94,8 +94,7 @@ EOF
 # zlib-dynamic  Like "zlib", but the zlib library is expected to be a shared
 #               library and will be loaded at run-time by the OpenSSL library.
 # sctp          include SCTP support
-# enable-quic   include QUIC support (currently just for developers as the
-#               implementation is by no means complete and usable)
+# no-quic       disable QUIC support
 # no-uplink     Don't build support for UPLINK interface.
 # enable-weak-ssl-ciphers
 #               Enable weak ciphers that are disabled by default.
@@ -570,7 +569,6 @@ our %disabled = ( # "what"         => "comment"
                   "ktls"                => "default",
                   "md2"                 => "default",
                   "msan"                => "default",
-                  "quic"                => "default",
                   "rc5"                 => "default",
                   "sctp"                => "default",
                   "ssl3"                => "default",

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -971,10 +971,9 @@ Don't build test programs or run any tests.
 
 Build with support for TCP Fast Open (RFC7413). Supported on Linux, macOS and FreeBSD.
 
-### enable-quic
+### no-quic
 
-Build with QUIC support. This is currently just for developers as the
-implementation is by no means complete and usable.
+Don't build with QUIC support.
 
 ### no-threads
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@ OpenSSL 3.2
 
 ### Major changes between OpenSSL 3.1 and OpenSSL 3.2 [under development]
 
+  * Added client side support for QUIC.
   * Add Raw Public Key (RFC7250) support.
   * Added support for certificate compression (RFC8879), including
     library support for Brotli and Zstandard compression.

--- a/crypto/thread/build.info
+++ b/crypto/thread/build.info
@@ -1,17 +1,19 @@
 LIBS=../../libcrypto
 
+$THREADS_ARCH=\
+      arch.c  \
+      arch/thread_win.c arch/thread_posix.c arch/thread_none.c
+
 IF[{- !$disabled{'thread-pool'} -}]
-  $THREADS_ARCH=\
-        arch.c  \
-        arch/thread_win.c arch/thread_posix.c arch/thread_none.c
-
-  $THREADS=\
-        api.c internal.c $THREADS_ARCH
-
   IF[{- !$disabled{quic} -}]
     SHARED_SOURCE[../../libssl]=$THREADS_ARCH
   ENDIF
+  $THREADS=\
+        api.c internal.c $THREADS_ARCH
 ELSE
+  IF[{- !$disabled{quic} -}]
+    SOURCE[../../libssl]=$THREADS_ARCH
+  ENDIF
   $THREADS=api.c
 ENDIF
 

--- a/ssl/quic/quic_thread_assist.c
+++ b/ssl/quic/quic_thread_assist.c
@@ -14,7 +14,7 @@
 #include "internal/thread_arch.h"
 #include "internal/quic_thread_assist.h"
 
-#if !defined(OPENSSL_NO_QUIC) && defined(OPENSSL_THREADS)
+#if !defined(OPENSSL_NO_QUIC_THREAD_ASSIST)
 
 /* Main loop for the QUIC assist thread. */
 static unsigned int assist_thread_main(void *arg)

--- a/ssl/quic/quic_trace.c
+++ b/ssl/quic/quic_trace.c
@@ -355,7 +355,7 @@ static int frame_path_challenge(BIO *bio, PACKET *pkt)
     if (!ossl_quic_wire_decode_frame_path_challenge(pkt, &data))
         return 0;
 
-    BIO_printf(bio, "    Data: %016lx\n", data);
+    BIO_printf(bio, "    Data: %016llx\n", (unsigned long long)data);
 
     return 1;
 }
@@ -367,7 +367,7 @@ static int frame_path_response(BIO *bio, PACKET *pkt)
     if (!ossl_quic_wire_decode_frame_path_response(pkt, &data))
         return 0;
 
-    BIO_printf(bio, "    Data: %016lx\n", data);
+    BIO_printf(bio, "    Data: %016llx\n", (unsigned long long)data);
 
     return 1;
 }

--- a/ssl/quic/quic_trace.c
+++ b/ssl/quic/quic_trace.c
@@ -588,7 +588,8 @@ int ossl_quic_trace(int write_p, int version, int content_type,
             BIO_puts(bio, " Packet\n");
             BIO_printf(bio, "  Packet Type: %s\n", packet_type(hdr.type));
             if (hdr.type != QUIC_PKT_TYPE_1RTT)
-                BIO_printf(bio, "  Version: 0x%08x\n", hdr.version);
+                BIO_printf(bio, "  Version: 0x%08lx\n",
+                           (unsigned long)hdr.version);
             BIO_puts(bio, "  Destination Conn Id: ");
             put_conn_id(bio, &hdr.dst_conn_id);
             BIO_puts(bio, "\n");

--- a/test/helpers/quictestlib.h
+++ b/test/helpers/quictestlib.h
@@ -24,15 +24,25 @@ typedef struct qtest_fault_encrypted_extensions {
     size_t extensionslen;
 } QTEST_ENCRYPTED_EXTENSIONS;
 
+/* Flags for use with qtest_create_quic_objects() */
+
+/* Indicates whether we are using blocking mode or not */
+#define QTEST_FLAG_BLOCK        1
+/* Use fake time rather than real time */
+#define QTEST_FLAG_FAKE_TIME    2
+
 /*
  * Given an SSL_CTX for the client and filenames for the server certificate and
  * keyfile, create a server and client instances as well as a fault injector
- * instance. |block| indicates whether we are using blocking mode or not.
+ * instance. |flags| is the logical or of flags defined above, or 0 if none.
  */
 int qtest_create_quic_objects(OSSL_LIB_CTX *libctx, SSL_CTX *clientctx,
-                              char *certfile, char *keyfile, int block,
+                              char *certfile, char *keyfile, int flags,
                               QUIC_TSERVER **qtserv, SSL **cssl,
                               QTEST_FAULT **fault);
+
+/* Where QTEST_FLAG_FAKE_TIME is used, add millis to the current time */
+void qtest_add_time(uint64_t millis);
 
 /*
  * Free up a Fault Injector instance

--- a/test/quic_cc_test.c
+++ b/test/quic_cc_test.c
@@ -444,8 +444,10 @@ static int test_simulate(void)
 
         double error = ((double)estimated_capacity / (double)actual_capacity) - 1.0;
 
-        TEST_info("est = %6lu kB/s, act=%6lu kB/s (error=%.02f%%)\n",
-                  estimated_capacity, actual_capacity, error * 100.0);
+        TEST_info("est = %6llu kB/s, act=%6llu kB/s (error=%.02f%%)\n",
+                  (unsigned long long)estimated_capacity,
+                  (unsigned long long)actual_capacity,
+                  error * 100.0);
 
         /* Max 5% error */
         if (!TEST_double_le(error, 0.05))

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -747,7 +747,8 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                     break;
 
                 default:
-                    TEST_error("opcode %d not allowed on child thread", op->op);
+                    TEST_error("opcode %lu not allowed on child thread",
+                               (unsigned long)op->op);
                     goto out;
             }
         }

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -57,8 +57,8 @@ static int test_quic_write_read(int idx)
 
     if (!TEST_ptr(cctx)
             || !TEST_true(qtest_create_quic_objects(libctx, cctx, cert, privkey,
-                                                    idx, &qtserv, &clientquic,
-                                                    NULL))
+                                                    idx == 1 ? QTEST_FLAG_BLOCK : 0,
+                                                    &qtserv, &clientquic, NULL))
             || !TEST_true(SSL_set_tlsext_host_name(clientquic, "localhost"))
             || !TEST_true(qtest_create_quic_connection(qtserv, clientquic)))
         goto end;

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -27,6 +27,13 @@ static char *datadir = NULL;
 
 static int is_fips = 0;
 
+/* The ssltrace test assumes some options are switched on/off */
+#if !defined(OPENSSL_NO_SSL_TRACE) && !defined(OPENSSL_NO_EC) \
+    && defined(OPENSSL_NO_ZLIB) && defined(OPENSSL_NO_BROTLI) \
+    && defined(OPENSSL_NO_ZSTD)
+# define DO_SSL_TRACE_TEST
+#endif
+
 /*
  * Test that we read what we've written.
  * Test 0: Non-blocking
@@ -207,7 +214,7 @@ static int test_version(void)
     return testresult;
 }
 
-#if !defined(OPENSSL_NO_SSL_TRACE) && !defined(OPENSSL_NO_EC) && defined(OPENSSL_NO_ZLIB)
+#if defined(DO_SSL_TRACE_TEST)
 static void strip_line_ends(char *str)
 {
     size_t i;
@@ -371,7 +378,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_quic_write_read, 2);
     ADD_TEST(test_ciphersuites);
     ADD_TEST(test_version);
-#if !defined(OPENSSL_NO_SSL_TRACE) && !defined(OPENSSL_NO_EC) && defined(OPENSSL_NO_ZLIB)
+#if defined(DO_SSL_TRACE_TEST)
     ADD_TEST(test_ssl_trace);
 #endif
 

--- a/test/quicfaultstest.c
+++ b/test/quicfaultstest.c
@@ -273,8 +273,9 @@ static int test_corrupted_data(int idx)
     if (!TEST_ptr(cctx))
         goto err;
 
-    if (!TEST_true(qtest_create_quic_objects(NULL, cctx, cert, privkey, 0,
-                                             &qtserv, &cssl, &fault)))
+    if (!TEST_true(qtest_create_quic_objects(NULL, cctx, cert, privkey,
+                                             QTEST_FLAG_FAKE_TIME, &qtserv,
+                                             &cssl, &fault)))
         goto err;
 
     if (idx == 0) {
@@ -315,16 +316,9 @@ static int test_corrupted_data(int idx)
      * Introduce a small delay so that the above packet has time to be detected
      * as lost. Loss detection times are based on RTT which should be very
      * fast for us since there isn't really a network. The loss delay timer is
-     * always at least 1ms though. We sleep for 100ms.
-     * TODO(QUIC): This assumes the calculated RTT will always be way less than
-     * 100ms - which it should be...but can we always guarantee this? An
-     * alternative might be to put in our own ossl_time_now() implementation for
-     * these tests and control the timer as part of the test. This approach has
-     * the added advantage that the test will behave reliably when run in a
-     * debugger. Without it may get unreliable debugging results. This would
-     * require some significant refactoring of the ssl/quic code though.
+     * always at least 1ms though. We skip forward 100ms
      */
-    OSSL_sleep(100);
+    qtest_add_time(100);
 
     /* Send rest of message */
     if (!TEST_true(ossl_quic_tserver_write(qtserv, sid, (unsigned char *)msg + 5,


### PR DESCRIPTION
Ensure builds enable QUIC without explicitly having to ask for it. To disable QUIC pass "no-quic" to Configure.

As a result we can remove all use of "enable-quic" from the various CI runs.

We also add a CHANGES and NEWS entry for QUIC support.

