### PR TITLE
Update .gitignore with LSP files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,3 +245,7 @@ MAKE0[0-9][0-9][0-9].@@@
 # Windows manifest files
 *.manifest
 doc-nits
+
+# LSP (Language Server Protocol) support
+.cache/
+compile_commands.json


### PR DESCRIPTION
This does not provide files for LSP support, but ignores them so they aren't accidentally checked in by developers.

LSP (Language Server Protocol) is a tools that can be used with various editors to make navigating source code easier. It is more advanced than `cscope` and supports completion, for example.

A common LSP for C/C++ is `clangd`, and it creates a `.cache` directory within the project to store data.

The tool `bear` can be used with `make` to assist `clangd` in determining where the source code is (specifically headers). This is critical as OpenSSL uses the `<>` form of `#include` rather than the `""` form. The `<>` form will cause `clangd` to look in e.g. `/usr/include` for header files, rather than `include/openssl`. The `bear` tool will create `compile_commands.json` that `clangd` can use to find include files.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

