### PR TITLE
Add limited support for WebAssembly WASI target

### DIFF
--- a/crypto/bio/bss_log.c
+++ b/crypto/bio/bss_log.c
@@ -24,6 +24,8 @@
 
 #if defined(OPENSSL_SYS_WINCE)
 #elif defined(OPENSSL_SYS_WIN32)
+#elif defined(__wasi__)
+# define NO_SYSLOG
 #elif defined(OPENSSL_SYS_VMS)
 # include <opcdef.h>
 # include <descrip.h>

--- a/providers/implementations/rands/seeding/rand_unix.c
+++ b/providers/implementations/rands/seeding/rand_unix.c
@@ -395,6 +395,10 @@ static ssize_t syscall_random(void *buf, size_t buflen)
 #  elif (defined(__DragonFly__)  && __DragonFly_version >= 500700) \
      || (defined(__NetBSD__) && __NetBSD_Version >= 1000000000)
     return getrandom(buf, buflen, 0);
+#  elif defined(__wasi__)
+    if (getentropy(buf, buflen) == 0)
+      return (ssize_t)buflen;
+    return -1;
 #  else
     errno = ENOSYS;
     return -1;


### PR DESCRIPTION
As part of experiments regarding [compiling CURL into WebAssembly/WASI](https://github.com/loganek/webassembly-curl-ssl) and running on [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime/) (socket API is not standardized yet) I had to make a few fixes to make an HTTPS call to a server. The change probably doesn't cover all the usecases, but it's a good start I guess.

If the community in general agrees with the approach, I'll update the CI scripts so we can make sure the WASM/WASI experience doesn't degrade. For now I'm just testing the water - feedback is very welcome.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
