### PR TITLE
QUIC Conformance Updates: ACK Handling

### DIFF
--- a/include/internal/quic_ackm.h
+++ b/include/internal/quic_ackm.h
@@ -38,6 +38,23 @@ void ossl_ackm_set_ack_deadline_callback(OSSL_ACKM *ackm,
                                                     void *arg),
                                          void *arg);
 
+/*
+ * Configures the RX-side maximum ACK delay. This is the maximum amount of time
+ * the peer is allowed to delay sending an ACK frame after receiving an
+ * ACK-eliciting packet. The peer communicates this value via a transport
+ * parameter and it must be provided to the ACKM.
+ */
+void ossl_ackm_set_rx_max_ack_delay(OSSL_ACKM *ackm, OSSL_TIME rx_max_ack_delay);
+
+/*
+ * Configures the TX-side maximum ACK delay. This is the maximum amount of time
+ * we are allowed to delay sending an ACK frame after receiving an ACK-eliciting
+ * packet. Note that this cannot be changed after a connection is established as
+ * it must be accurately reported in the transport parameters we send to our
+ * peer.
+ */
+void ossl_ackm_set_tx_max_ack_delay(OSSL_ACKM *ackm, OSSL_TIME tx_max_ack_delay);
+
 typedef struct ossl_ackm_tx_pkt_st OSSL_ACKM_TX_PKT;
 struct ossl_ackm_tx_pkt_st {
     /* The packet number of the transmitted packet. */

--- a/include/internal/quic_statm.h
+++ b/include/internal/quic_statm.h
@@ -16,13 +16,13 @@
 # ifndef OPENSSL_NO_QUIC
 
 typedef struct ossl_statm_st {
-    OSSL_TIME smoothed_rtt, latest_rtt, min_rtt, rtt_variance, max_ack_delay;
+    OSSL_TIME smoothed_rtt, latest_rtt, min_rtt, rtt_variance;
     char      have_first_sample;
 } OSSL_STATM;
 
 typedef struct ossl_rtt_info_st {
     /* As defined in RFC 9002. */
-    OSSL_TIME smoothed_rtt, latest_rtt, rtt_variance, min_rtt, max_ack_delay;
+    OSSL_TIME smoothed_rtt, latest_rtt, rtt_variance, min_rtt;
 } OSSL_RTT_INFO;
 
 int ossl_statm_init(OSSL_STATM *statm);
@@ -34,8 +34,6 @@ void ossl_statm_get_rtt_info(OSSL_STATM *statm, OSSL_RTT_INFO *rtt_info);
 void ossl_statm_update_rtt(OSSL_STATM *statm,
                            OSSL_TIME ack_delay,
                            OSSL_TIME override_latest_rtt);
-
-void ossl_statm_set_max_ack_delay(OSSL_STATM *statm, OSSL_TIME max_ack_delay);
 
 # endif
 

--- a/include/internal/quic_txp.h
+++ b/include/internal/quic_txp.h
@@ -68,10 +68,10 @@ typedef void (ossl_quic_initial_token_free_fn)(const unsigned char *buf,
 void ossl_quic_tx_packetiser_free(OSSL_QUIC_TX_PACKETISER *txp);
 
 /* Generate normal packets containing most frame types. */
-#define TX_PACKETISER_ARCHETYPE_NORMAL      0
-/* Generate ACKs only. */
-#define TX_PACKETISER_ARCHETYPE_ACK_ONLY    1
-#define TX_PACKETISER_ARCHETYPE_NUM         2
+#define TX_PACKETISER_ARCHETYPE_NORMAL              0
+/* Generate ACKs and PINGs only. */
+#define TX_PACKETISER_ARCHETYPE_ACK_AND_PING_ONLY   1
+#define TX_PACKETISER_ARCHETYPE_NUM                 2
 
 /*
  * Generates a datagram by polling the various ELs to determine if they want to

--- a/ssl/quic/quic_ackm.c
+++ b/ssl/quic/quic_ackm.c
@@ -488,6 +488,9 @@ static int rx_pkt_history_bump_watermark(struct rx_pkt_history_st *h,
 /* The maximum number of times we allow PTO to be doubled. */
 #define MAX_PTO_COUNT          16
 
+/* Default maximum amount of time to leave an ACK-eliciting packet un-ACK'd. */
+#define DEFAULT_TX_MAX_ACK_DELAY       ossl_ms2time(QUIC_DEFAULT_MAX_ACK_DELAY)
+
 struct ossl_ackm_st {
     /* Our list of transmitted packets. Corresponds to RFC 9002 sent_packets. */
     struct tx_pkt_history_st tx_history[QUIC_PN_SPACE_NUM];
@@ -580,6 +583,19 @@ struct ossl_ackm_st {
      */
     OSSL_TIME       rx_ack_flush_deadline[QUIC_PN_SPACE_NUM];
 
+    /*
+     * The RX maximum ACK delay (the maximum amount of time our peer might
+     * wait to send us an ACK after receiving an ACK-eliciting packet).
+     */
+    OSSL_TIME       rx_max_ack_delay;
+
+    /*
+     * The TX maximum ACK delay (the maximum amount of time we allow ourselves
+     * to wait before generating an ACK after receiving an ACK-eliciting
+     * packet).
+     */
+    OSSL_TIME       tx_max_ack_delay;
+
     /* Callbacks for deadline updates. */
     void (*loss_detection_deadline_cb)(OSSL_TIME deadline, void *arg);
     void *loss_detection_deadline_cb_arg;
@@ -593,7 +609,7 @@ static ossl_inline uint32_t min_u32(uint32_t x, uint32_t y)
     return x < y ? x : y;
 }
 
-/* 
+/*
  * Get TX history for a given packet number space. Must not have been
  * discarded.
  */
@@ -848,13 +864,13 @@ static OSSL_TIME ackm_get_pto_time_and_space(OSSL_ACKM *ackm, int *space)
                 break;
 
             /* Include max_ack_delay and backoff for app data. */
-            if (!ossl_time_is_infinite(rtt.max_ack_delay)) {
+            if (!ossl_time_is_infinite(ackm->rx_max_ack_delay)) {
                 uint64_t factor
                     = (uint64_t)1 << min_u32(ackm->pto_count, MAX_PTO_COUNT);
 
                 duration
                     = ossl_time_add(duration,
-                                    ossl_time_multiply(rtt.max_ack_delay,
+                                    ossl_time_multiply(ackm->rx_max_ack_delay,
                                                        factor));
             }
         }
@@ -1028,6 +1044,10 @@ OSSL_ACKM *ossl_ackm_new(OSSL_TIME (*now)(void *arg),
     ackm->statm     = statm;
     ackm->cc_method = cc_method;
     ackm->cc_data   = cc_data;
+
+    ackm->rx_max_ack_delay = ossl_ms2time(QUIC_DEFAULT_MAX_ACK_DELAY);
+    ackm->tx_max_ack_delay = DEFAULT_TX_MAX_ACK_DELAY;
+
     return ackm;
 
 err:
@@ -1169,12 +1189,8 @@ int ossl_ackm_on_rx_ack_frame(OSSL_ACKM *ackm, const OSSL_QUIC_FRAME_ACK *ack,
 
         /* Enforce maximum ACK delay. */
         ack_delay = ack->delay_time;
-        if (ackm->handshake_confirmed) {
-            OSSL_RTT_INFO rtt;
-
-            ossl_statm_get_rtt_info(ackm->statm, &rtt);
-            ack_delay = ossl_time_min(ack_delay, rtt.max_ack_delay);
-        }
+        if (ackm->handshake_confirmed)
+            ack_delay = ossl_time_min(ack_delay, ackm->rx_max_ack_delay);
 
         ossl_statm_update_rtt(ackm->statm, ack_delay,
                               ossl_time_subtract(now, na_pkts->time));
@@ -1342,8 +1358,6 @@ int ossl_ackm_get_largest_unacked(OSSL_ACKM *ackm, int pkt_space, QUIC_PN *pn)
 
 /* Number of ACK-eliciting packets RX'd before we always emit an ACK. */
 #define PKTS_BEFORE_ACK     2
-/* Maximum amount of time to leave an ACK-eliciting packet un-ACK'd. */
-#define MAX_ACK_DELAY       ossl_ms2time(25)
 
 /*
  * Return 1 if emission of an ACK frame is currently desired.
@@ -1496,12 +1510,12 @@ static void ackm_on_rx_ack_eliciting(OSSL_ACKM *ackm,
      */
     if (ossl_time_is_infinite(ackm->rx_ack_flush_deadline[pkt_space]))
         ackm_set_flush_deadline(ackm, pkt_space,
-                                ossl_time_add(rx_time, MAX_ACK_DELAY));
+                                ossl_time_add(rx_time, ackm->tx_max_ack_delay));
     else
         ackm_set_flush_deadline(ackm, pkt_space,
                                 ossl_time_min(ackm->rx_ack_flush_deadline[pkt_space],
                                               ossl_time_add(rx_time,
-                                                            MAX_ACK_DELAY)));
+                                                            ackm->tx_max_ack_delay)));
 }
 
 int ossl_ackm_on_rx_packet(OSSL_ACKM *ackm, const OSSL_ACKM_RX_PKT *pkt)
@@ -1676,8 +1690,8 @@ OSSL_TIME ossl_ackm_get_pto_duration(OSSL_ACKM *ackm)
     duration = ossl_time_add(rtt.smoothed_rtt,
                              ossl_time_max(ossl_time_multiply(rtt.rtt_variance, 4),
                                            ossl_ticks2time(K_GRANULARITY)));
-    if (!ossl_time_is_infinite(rtt.max_ack_delay))
-        duration = ossl_time_add(duration, rtt.max_ack_delay);
+    if (!ossl_time_is_infinite(ackm->rx_max_ack_delay))
+        duration = ossl_time_add(duration, ackm->rx_max_ack_delay);
 
     return duration;
 }
@@ -1685,4 +1699,14 @@ OSSL_TIME ossl_ackm_get_pto_duration(OSSL_ACKM *ackm)
 QUIC_PN ossl_ackm_get_largest_acked(OSSL_ACKM *ackm, int pkt_space)
 {
     return ackm->largest_acked_pkt[pkt_space];
+}
+
+void ossl_ackm_set_rx_max_ack_delay(OSSL_ACKM *ackm, OSSL_TIME rx_max_ack_delay)
+{
+    ackm->rx_max_ack_delay = rx_max_ack_delay;
+}
+
+void ossl_ackm_set_tx_max_ack_delay(OSSL_ACKM *ackm, OSSL_TIME tx_max_ack_delay)
+{
+    ackm->tx_max_ack_delay = tx_max_ack_delay;
 }

--- a/ssl/quic/quic_ackm.c
+++ b/ssl/quic/quic_ackm.c
@@ -951,18 +951,18 @@ static void ackm_on_pkts_lost(OSSL_ACKM *ackm, int pkt_space,
 
             if (p->pkt_num > largest_pn_lost)
                 largest_pn_lost = p->pkt_num;
-        }
 
-        if (!pseudo) {
-            /*
-             * If this is pseudo-loss (e.g. during connection retry) we do not
-             * inform the CC as it is not a real loss and not reflective of
-             * network conditions.
-             */
-            loss_info.tx_time = p->time;
-            loss_info.tx_size = p->num_bytes;
+            if (!pseudo) {
+                /*
+                 * If this is pseudo-loss (e.g. during connection retry) we do not
+                 * inform the CC as it is not a real loss and not reflective of
+                 * network conditions.
+                 */
+                loss_info.tx_time = p->time;
+                loss_info.tx_size = p->num_bytes;
 
-            ackm->cc_method->on_data_lost(ackm->cc_data, &loss_info);
+                ackm->cc_method->on_data_lost(ackm->cc_data, &loss_info);
+            }
         }
 
         p->on_lost(p->cb_arg);
@@ -1012,7 +1012,8 @@ static void ackm_on_pkts_acked(OSSL_ACKM *ackm, const OSSL_ACKM_TX_PKT *apkt)
         anext = apkt->anext;
         apkt->on_acked(apkt->cb_arg); /* may free apkt */
 
-        ackm->cc_method->on_data_acked(ackm->cc_data, &ainfo);
+        if (apkt->is_inflight)
+            ackm->cc_method->on_data_acked(ackm->cc_data, &ainfo);
     }
 }
 

--- a/ssl/quic/quic_channel_local.h
+++ b/ssl/quic/quic_channel_local.h
@@ -138,6 +138,7 @@ struct quic_channel_st {
     uint64_t                        tx_init_max_stream_data_bidi_local;
     uint64_t                        tx_init_max_stream_data_bidi_remote;
     uint64_t                        tx_init_max_stream_data_uni;
+    uint64_t                        tx_max_ack_delay; /* ms */
 
     /* Transport parameter values received from server. */
     uint64_t                        rx_init_max_stream_data_bidi_local;

--- a/ssl/quic/quic_statm.c
+++ b/ssl/quic/quic_statm.c
@@ -59,7 +59,6 @@ int ossl_statm_init(OSSL_STATM *statm)
     statm->min_rtt                  = ossl_time_infinite();
     statm->rtt_variance             = ossl_time_divide(K_INITIAL_RTT, 2);
     statm->have_first_sample        = 0;
-    statm->max_ack_delay            = ossl_time_infinite();
     return 1;
 }
 
@@ -68,16 +67,10 @@ void ossl_statm_destroy(OSSL_STATM *statm)
     /* No-op. */
 }
 
-void ossl_statm_set_max_ack_delay(OSSL_STATM *statm, OSSL_TIME max_ack_delay)
-{
-    statm->max_ack_delay = max_ack_delay;
-}
-
 void ossl_statm_get_rtt_info(OSSL_STATM *statm, OSSL_RTT_INFO *rtt_info)
 {
     rtt_info->min_rtt           = statm->min_rtt;
     rtt_info->latest_rtt        = statm->latest_rtt;
     rtt_info->smoothed_rtt      = statm->smoothed_rtt;
     rtt_info->rtt_variance      = statm->rtt_variance;
-    rtt_info->max_ack_delay     = statm->max_ack_delay;
 }

--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -661,10 +661,10 @@ static const struct archetype_data archetypes[QUIC_ENC_LEVEL_NUM][TX_PACKETISER_
             /*allow_new_token                 =*/ 0,
             /*allow_force_ack_eliciting       =*/ 1,
         },
-        /* EL 0(INITIAL) - Archetype 1(ACK_ONLY) */
+        /* EL 0(INITIAL) - Archetype 1(ACK_AND_PING_ONLY) */
         {
             /*allow_ack                       =*/ 1,
-            /*allow_ping                      =*/ 0,
+            /*allow_ping                      =*/ 1,
             /*allow_crypto                    =*/ 0,
             /*allow_handshake_done            =*/ 0,
             /*allow_path_challenge            =*/ 0,
@@ -698,10 +698,10 @@ static const struct archetype_data archetypes[QUIC_ENC_LEVEL_NUM][TX_PACKETISER_
             /*allow_new_token                 =*/ 0,
             /*allow_force_ack_eliciting       =*/ 1,
         },
-        /* EL 1(HANDSHAKE) - Archetype 1(ACK_ONLY) */
+        /* EL 1(HANDSHAKE) - Archetype 1(ACK_AND_PING_ONLY) */
         {
             /*allow_ack                       =*/ 1,
-            /*allow_ping                      =*/ 0,
+            /*allow_ping                      =*/ 1,
             /*allow_crypto                    =*/ 0,
             /*allow_handshake_done            =*/ 0,
             /*allow_path_challenge            =*/ 0,
@@ -735,10 +735,10 @@ static const struct archetype_data archetypes[QUIC_ENC_LEVEL_NUM][TX_PACKETISER_
             /*allow_new_token                 =*/ 0,
             /*allow_force_ack_eliciting       =*/ 0,
         },
-        /* EL 2(0RTT) - Archetype 1(ACK_ONLY) */
+        /* EL 2(0RTT) - Archetype 1(ACK_AND_PING_ONLY) */
         {
             /*allow_ack                       =*/ 0,
-            /*allow_ping                      =*/ 0,
+            /*allow_ping                      =*/ 1,
             /*allow_crypto                    =*/ 0,
             /*allow_handshake_done            =*/ 0,
             /*allow_path_challenge            =*/ 0,
@@ -772,10 +772,10 @@ static const struct archetype_data archetypes[QUIC_ENC_LEVEL_NUM][TX_PACKETISER_
             /*allow_new_token                 =*/ 1,
             /*allow_force_ack_eliciting       =*/ 1,
         },
-        /* EL 3(1RTT) - Archetype 1(ACK_ONLY) */
+        /* EL 3(1RTT) - Archetype 1(ACK_AND_PING_ONLY) */
         {
             /*allow_ack                       =*/ 1,
-            /*allow_ping                      =*/ 0,
+            /*allow_ping                      =*/ 1,
             /*allow_crypto                    =*/ 0,
             /*allow_handshake_done            =*/ 0,
             /*allow_path_challenge            =*/ 0,
@@ -999,10 +999,13 @@ static int txp_generate_for_el(OSSL_QUIC_TX_PACKETISER *txp, uint32_t enc_level,
     /* Determine the limit CC imposes on what we can send. */
     if (!cc_can_send) {
         /*
-         * If we are called when we cannot send, this must be because we want
-         * to generate a probe. In this circumstance, don't clamp based on CC.
+         * If we are called when we cannot send, this must be because we want to
+         * generate a probe. In this circumstance, don't clamp based on CC, but
+         * don't add application data and limit ourselves to generating a small
+         * packet containing only PING and ACK frames.
          */
-        cc_limit = SIZE_MAX;
+        cc_limit  = SIZE_MAX;
+        archetype = TX_PACKETISER_ARCHETYPE_ACK_AND_PING_ONLY;
     } else {
         /* Allow CC to clamp how much we can send. */
         cc_limit_ = txp->args.cc_method->get_tx_allowance(txp->args.cc_data);

--- a/test/quic_ackm_test.c
+++ b/test/quic_ackm_test.c
@@ -1056,7 +1056,7 @@ static int test_rx_ack_actual(int tidx, int space)
             break;
 
         case RX_OPK_SKIP_IF_PN_SPACE:
-            if (space == s->pn) {
+            if (space == (int)s->pn) {
                 testresult = 1;
                 goto err;
             }

--- a/test/quic_ackm_test.c
+++ b/test/quic_ackm_test.c
@@ -618,7 +618,8 @@ enum {
     RX_OPK_CHECK_STATE,      /* check is_desired/deadline */
     RX_OPK_CHECK_ACKS,       /* check ACK ranges */
     RX_OPK_TX,               /* TX packet */
-    RX_OPK_RX_ACK            /* RX ACK frame */
+    RX_OPK_RX_ACK,           /* RX ACK frame */
+    RX_OPK_SKIP_IF_PN_SPACE  /* skip for a given PN space */
 };
 
 struct rx_test_op {
@@ -685,6 +686,12 @@ struct rx_test_op {
       0, 0, NULL, 0, 0                                              \
     },
 
+#define RX_OP_SKIP_IF_PN_SPACE(pn_space)                            \
+    {                                                               \
+      RX_OPK_SKIP_IF_PN_SPACE, 0, (pn_space), 0,                    \
+      0, 0, NULL, 0, 0                                              \
+    },
+
 #define RX_OP_END                                                   \
     { RX_OPK_END }
 
@@ -715,7 +722,7 @@ static const struct rx_test_op rx_script_1[] = {
     RX_OP_END
 };
 
-/* RX 2. Simple Test with ACK Not Yet Desired (Packet Threshold) */
+/* RX 2. Simple Test with ACK Not Yet Desired (Packet Threshold) (1-RTT) */
 static const OSSL_QUIC_ACK_RANGE rx_ack_ranges_2a[] = {
     { 0, 0 }
 };
@@ -725,6 +732,14 @@ static const OSSL_QUIC_ACK_RANGE rx_ack_ranges_2b[] = {
 };
 
 static const struct rx_test_op rx_script_2[] = {
+    /*
+     * We skip this for INITIAL/HANDSHAKE and use a separate version
+     * (rx_script_4) for those spaces as those spaces should not delay ACK
+     * generation, so a different RX_OP_CHECK_STATE test is needed.
+     */
+    RX_OP_SKIP_IF_PN_SPACE(QUIC_PN_SPACE_INITIAL)
+    RX_OP_SKIP_IF_PN_SPACE(QUIC_PN_SPACE_HANDSHAKE)
+
     RX_OP_CHECK_STATE   (0, 0, 0)   /* no threshold yet */
     RX_OP_CHECK_PROC    (0, 0, 3)
 
@@ -826,10 +841,57 @@ static const struct rx_test_op rx_script_3[] = {
     RX_OP_END
 };
 
+/*
+ * RX 4. Simple Test with ACK Not Yet Desired (Packet Threshold)
+ * (Initial/Handshake)
+ */
+static const OSSL_QUIC_ACK_RANGE rx_ack_ranges_4a[] = {
+    { 0, 1 }
+};
+
+static const struct rx_test_op rx_script_4[] = {
+    /* The application PN space is tested in rx_script_2. */
+    RX_OP_SKIP_IF_PN_SPACE(QUIC_PN_SPACE_APP)
+
+    RX_OP_CHECK_STATE   (0, 0, 0)   /* no threshold yet */
+    RX_OP_CHECK_PROC    (0, 0, 3)
+
+    /* First packet always generates an ACK so get it out of the way. */
+    RX_OP_PKT           (0, 0, 1)
+    RX_OP_CHECK_UNPROC  (0, 0, 1)
+    RX_OP_CHECK_PROC    (0, 1, 1)
+    RX_OP_CHECK_STATE   (0, 1, 0)   /* first packet always causes ACK */
+    RX_OP_CHECK_ACKS    (0, rx_ack_ranges_2a) /* clears packet counter */
+    RX_OP_CHECK_STATE   (0, 0, 0)   /* desired state should have been cleared */
+
+    /*
+     * Second packet should cause ACK-desired state because we are
+     * INITIAL/HANDSHAKE (RFC 9000 s. 13.2.1)
+     */
+    RX_OP_PKT           (0, 1, 1)   /* just one packet, threshold is 2 */
+    RX_OP_CHECK_UNPROC  (0, 0, 2)
+    RX_OP_CHECK_PROC    (0, 2, 1)
+    RX_OP_CHECK_STATE   (0, 1, 1)
+    RX_OP_CHECK_ACKS    (0, rx_ack_ranges_4a)
+    RX_OP_CHECK_STATE   (0, 0, 0)   /* desired state should have been cleared */
+
+    /* At this point we would generate e.g. a packet with an ACK. */
+    RX_OP_TX            (0, 0, 1)   /* ACKs all */
+    RX_OP_CHECK_ACKS    (0, rx_ack_ranges_4a) /* not provably ACKed yet */
+    RX_OP_RX_ACK        (0, 0, 1)   /* TX'd packet is ACK'd */
+
+    RX_OP_CHECK_NO_ACKS (0)         /* nothing more to ACK */
+    RX_OP_CHECK_UNPROC  (0, 0, 2)   /* still unprocessable */
+    RX_OP_CHECK_PROC    (0, 2, 1)   /* still processable */
+
+    RX_OP_END
+};
+
 static const struct rx_test_op *const rx_test_scripts[] = {
     rx_script_1,
     rx_script_2,
-    rx_script_3
+    rx_script_3,
+    rx_script_4
 };
 
 static void on_ack_deadline_callback(OSSL_TIME deadline,
@@ -850,6 +912,7 @@ static int test_rx_ack_actual(int tidx, int space)
     struct pkt_info *pkts = NULL;
     OSSL_ACKM_TX_PKT *txs = NULL, *tx;
     OSSL_TIME ack_deadline[QUIC_PN_SPACE_NUM];
+    size_t opn = 0;
 
     for (i = 0; i < QUIC_PN_SPACE_NUM; ++i)
         ack_deadline[i] = ossl_time_infinite();
@@ -880,7 +943,7 @@ static int test_rx_ack_actual(int tidx, int space)
         goto err;
 
     /* Run script. */
-    for (s = script; s->kind != RX_OPK_END; ++s) {
+    for (s = script; s->kind != RX_OPK_END; ++s, ++opn) {
         fake_time = ossl_time_add(fake_time,
                                   ossl_ticks2time(s->time_advance));
         switch (s->kind) {
@@ -992,6 +1055,14 @@ static int test_rx_ack_actual(int tidx, int space)
 
             break;
 
+        case RX_OPK_SKIP_IF_PN_SPACE:
+            if (space == s->pn) {
+                testresult = 1;
+                goto err;
+            }
+
+            break;
+
         default:
             goto err;
         }
@@ -999,6 +1070,9 @@ static int test_rx_ack_actual(int tidx, int space)
 
     testresult = 1;
 err:
+    if (!testresult)
+        TEST_error("error in ACKM RX script %d, op %zu", tidx + 1, opn + 1);
+
     helper_destroy(&h);
     OPENSSL_free(pkts);
     OPENSSL_free(txs);


### PR DESCRIPTION
```
51faba5561 QUIC TXP: Handle non-inflight-eligible packets correctly
67cab10c20 QUIC ACKM: Don't record non-inflight packets in CC
403df59d26 QUIC TXP: Do not generate full-size packets when sending CC-excess probes
8562a19bac QUIC ACKM: RFC 9000 s. 13.2.1: max_ack_delay taken as 0 in INITIAL/HANDSHAKE
01e328b589 QUIC CHANNEL: Initialise max_ack_delay values properly
81c355ab50 QUIC ACKM: Clean up max_ack_delay tracking and separate TX and RX values
a902065ffc QUIC STATM: Move max_ack_delay tracking out of STATM
```