### PR TITLE
riscv: Clarify dual-licensing wording for GCM and AES

### DIFF
--- a/crypto/aes/asm/aes-riscv32-zkn.pl
+++ b/crypto/aes/asm/aes-riscv32-zkn.pl
@@ -1,13 +1,14 @@
 #! /usr/bin/env perl
+# This file is dual-licensed, meaning that you can use it under your
+# choice of either of the following two licenses:
+#
 # Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
 #
-# Licensed under the Apache License 2.0 (the "License").  You may not use
-# this file except in compliance with the License.  You can obtain a copy
-# in the file LICENSE in the source distribution or at
+# Licensed under the Apache License 2.0 (the "License"). You can obtain
+# a copy in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
-
-# This file is dual-licensed and is also available under the following
-# terms:
+#
+# or
 #
 # Copyright (c) 2022, Hongren (Zenithal) Zheng <i@zenithal.me>
 # All rights reserved.

--- a/crypto/aes/asm/aes-riscv64-zkn.pl
+++ b/crypto/aes/asm/aes-riscv64-zkn.pl
@@ -1,13 +1,14 @@
 #! /usr/bin/env perl
+# This file is dual-licensed, meaning that you can use it under your
+# choice of either of the following two licenses:
+#
 # Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
 #
-# Licensed under the Apache License 2.0 (the "License").  You may not use
-# this file except in compliance with the License.  You can obtain a copy
-# in the file LICENSE in the source distribution or at
+# Licensed under the Apache License 2.0 (the "License"). You can obtain
+# a copy in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
-
-# This file is dual-licensed and is also available under the following
-# terms:
+#
+# or
 #
 # Copyright (c) 2022, Hongren (Zenithal) Zheng <i@zenithal.me>
 # All rights reserved.

--- a/crypto/modes/asm/ghash-riscv64.pl
+++ b/crypto/modes/asm/ghash-riscv64.pl
@@ -1,13 +1,14 @@
 #! /usr/bin/env perl
+# This file is dual-licensed, meaning that you can use it under your
+# choice of either of the following two licenses:
+#
 # Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
 #
-# Licensed under the Apache License 2.0 (the "License").  You may not use
-# this file except in compliance with the License.  You can obtain a copy
-# in the file LICENSE in the source distribution or at
+# Licensed under the Apache License 2.0 (the "License"). You can obtain
+# a copy in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
-
-# This file is dual-licensed and is also available under the following
-# terms:
+#
+# or
 #
 # Copyright (c) 2023, Christoph Müllner <christoph.muellner@vrull.eu>
 # All rights reserved.

--- a/crypto/perlasm/riscv.pm
+++ b/crypto/perlasm/riscv.pm
@@ -1,13 +1,14 @@
 #! /usr/bin/env perl
+# This file is dual-licensed, meaning that you can use it under your
+# choice of either of the following two licenses:
+#
 # Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
 #
-# Licensed under the Apache License 2.0 (the "License").  You may not use
-# this file except in compliance with the License.  You can obtain a copy
-# in the file LICENSE in the source distribution or at
+# Licensed under the Apache License 2.0 (the "License"). You can obtain
+# a copy in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
-
-# This file is dual-licensed and is also available under the following
-# terms:
+#
+# or
 #
 # Copyright (c) 2023, Christoph Müllner <christoph.muellner@vrull.eu>
 # All rights reserved.


### PR DESCRIPTION
The original text for the Apache + BSD dual licensing for riscv GCM and AES perlasm was taken from other openSSL users like crypto/crypto/LPdir_unix.c .

Though Eric pointed out that the dual-licensing text could be read in a way negating the second license [0] and suggested to clarify the text even more.

So do this here for all of the GCM, AES and shared riscv.pm .

We already had the agreement of all involved developers for the actual dual licensing in [0] and [1], so this is only a better clarification for this.

[0] https://github.com/openssl/openssl/pull/20649#issuecomment-1589558790
[1] https://github.com/openssl/openssl/pull/21018


@ebiggers : hopefully the wording is better now
