### PR TITLE
Add an SSL BIO test for QUIC

### DIFF
--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -88,9 +88,12 @@ int qtest_create_quic_objects(OSSL_LIB_CTX *libctx, SSL_CTX *clientctx,
     *qtserv = NULL;
     if (fault != NULL)
         *fault = NULL;
-    *cssl = SSL_new(clientctx);
-    if (!TEST_ptr(*cssl))
-        return 0;
+
+    if (*cssl == NULL) {
+        *cssl = SSL_new(clientctx);
+        if (!TEST_ptr(*cssl))
+            return 0;
+    }
 
     /* SSL_set_alpn_protos returns 0 for success! */
     if (!TEST_false(SSL_set_alpn_protos(*cssl, alpn, sizeof(alpn))))

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -705,7 +705,12 @@ static int test_bio_ssl(void)
         if (i == 1)
             break;
 
-        /* Now create a new stream and repeat */
+        /*
+         * Now create a new stream and repeat. The bottom two bits of the stream
+         * id represents whether the stream is bidi and whether it is client
+         * initiated or not. For client initiated bidi they are both 0. So the
+         * first client initiated bidi stream is 0 and the next one is 4.
+         */
         sid = 4;
         stream = SSL_new_stream(clientquic, 0);
         if (!TEST_ptr(stream))
@@ -727,8 +732,8 @@ static int test_bio_ssl(void)
 
     testresult = 1;
  err:
-    BIO_free(cbio);
-    BIO_free(strbio);
+    BIO_free_all(cbio);
+    BIO_free_all(strbio);
     SSL_free(stream);
     ossl_quic_tserver_free(qtserv);
     SSL_CTX_free(cctx);

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -693,11 +693,7 @@ static int test_bio_ssl(void)
                                                msglen, &written)))
             goto err;
         ossl_quic_tserver_tick(qtserv);
-        /*
-        * TODO(QUIC): BIO_read_ex() doesn't seem to automatically tick???
-        * See issue #21365
-        */
-        SSL_handle_events(clientquic);
+
         if (!TEST_true(BIO_read_ex(thisbio, buf, sizeof(buf), &readbytes))
                 || !TEST_mem_eq(msg, msglen, buf, readbytes))
             goto err;

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -60,7 +60,7 @@ static int test_quic_write_read(int idx)
 
     if (!TEST_ptr(cctx)
             || !TEST_true(qtest_create_quic_objects(libctx, cctx, cert, privkey,
-                                                    idx == 1 ? QTEST_FLAG_BLOCK : 0,
+                                                    idx >= 1 ? QTEST_FLAG_BLOCK : 0,
                                                     &qtserv, &clientquic, NULL))
             || !TEST_true(SSL_set_tlsext_host_name(clientquic, "localhost"))
             || !TEST_true(qtest_create_quic_connection(qtserv, clientquic)))


### PR DESCRIPTION
We create an SSL BIO using a QUIC based SSL_CTX and then use that BIO to create a connection and read/write data from streams.
