### PR TITLE
Fix no-ecx

### DIFF
--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -31,7 +31,7 @@ static int is_fips = 0;
 /* The ssltrace test assumes some options are switched on/off */
 #if !defined(OPENSSL_NO_SSL_TRACE) && !defined(OPENSSL_NO_EC) \
     && defined(OPENSSL_NO_ZLIB) && defined(OPENSSL_NO_BROTLI) \
-    && defined(OPENSSL_NO_ZSTD)
+    && defined(OPENSSL_NO_ZSTD) && !defined(OPENSSL_NO_ECX)
 # define DO_SSL_TRACE_TEST
 #endif
 

--- a/test/recipes/70-test_tls13hrr.t
+++ b/test/recipes/70-test_tls13hrr.t
@@ -73,7 +73,7 @@ $proxy->clear();
 if (disabled("ec")) {
     $proxy->serverflags("-curves ffdhe3072");
 } else {
-    $proxy->serverflags("-curves P-256");
+    $proxy->serverflags("-curves P-384");
 }
 $testtype = DUPLICATE_HRR;
 $proxy->start();


### PR DESCRIPTION
In the case of no-ecx test 3 in test_tls13hrr was failing because it was
setting the server side support groups to on P-256 in order to induce an
HRR. However with no-ecx the client insteads issues an initial key share
using P-256 anyway and so an HRR is not used. We swap to use P-384 instead.

no-ecx also causes SSL_trace to give different output. The QUIC ssl trace test compares
the output to a reference sample - so we disable it in the case of no-ecx.