### PR TITLE
Don't build the QUIC ssl trace when DH is disabled

### DIFF
--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -31,7 +31,8 @@ static int is_fips = 0;
 /* The ssltrace test assumes some options are switched on/off */
 #if !defined(OPENSSL_NO_SSL_TRACE) && !defined(OPENSSL_NO_EC) \
     && defined(OPENSSL_NO_ZLIB) && defined(OPENSSL_NO_BROTLI) \
-    && defined(OPENSSL_NO_ZSTD) && !defined(OPENSSL_NO_ECX)
+    && defined(OPENSSL_NO_ZSTD) && !defined(OPENSSL_NO_ECX) \
+    && !defined(OPENSSL_NO_DH)
 # define DO_SSL_TRACE_TEST
 #endif
 


### PR DESCRIPTION
The test assumes certain options are on/off. DH must be on for this test.
