### PR TITLE
QUIC: Fix multistream script 19 stochastic test failure

### DIFF
--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -1943,7 +1943,6 @@ static const struct script_op script_18[] = {
      * 1 packet above, which is absurd; thus this ensures we only actually
      * generate TXKUs when we are allowed to.
      */
-    OP_CHECK                (check_key_update_ge, 4)
     OP_CHECK                (check_key_update_lt, 240)
 
     /*
@@ -1968,6 +1967,12 @@ static const struct script_op script_19[] = {
 
     OP_S_BIND_STREAM_ID     (a, C_BIDI_ID(0))
     OP_S_READ_EXPECT        (a, "apple", 5)
+
+    OP_C_WRITE              (DEFAULT, "orange", 6)
+    OP_S_READ_EXPECT        (a, "orange", 6)
+
+    OP_S_WRITE              (a, "strawberry", 10)
+    OP_C_READ_EXPECT        (DEFAULT, "strawberry", 10)
 
     OP_CHECK                (check_key_update_lt, 1)
     OP_CHECK                (trigger_key_update, 0)


### PR DESCRIPTION
Urgent due to CI breakage on FreeBSD.