### PR TITLE
Add more fixes for WebAssembly/WASI build

### DIFF
--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -595,7 +595,7 @@ int ASN1_TIME_compare(const ASN1_TIME *a, const ASN1_TIME *b)
 # define timezone _timezone
 #endif
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__wasi__)
 # define USE_TIMEGM
 #endif
 

--- a/crypto/uid.c
+++ b/crypto/uid.c
@@ -10,7 +10,7 @@
 #include <openssl/crypto.h>
 #include <openssl/opensslconf.h>
 
-#if defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_VXWORKS) || defined(OPENSSL_SYS_UEFI)
+#if defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_VXWORKS) || defined(OPENSSL_SYS_UEFI) || defined(__wasi__)
 
 int OPENSSL_issetugid(void)
 {


### PR DESCRIPTION
* force use timegm - WASI does not have timezone tables
* use basic implementation for `OPENSSL_issetugid()` - WASI doesn't support forking processes

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
