### PR TITLE
Enable ARMv8.2 accelerated SHA3 on compatible Apple CPUs

### DIFF
--- a/crypto/arm_arch.h
+++ b/crypto/arm_arch.h
@@ -85,6 +85,7 @@ extern unsigned int OPENSSL_armv8_rsa_neonized;
 # define ARMV8_UNROLL8_EOR3      (1<<12)
 # define ARMV8_SVE       (1<<13)
 # define ARMV8_SVE2      (1<<14)
+# define ARMV8_WORTH_USING_SHA3  (1<<15)
 
 /*
  * MIDR_EL1 system register

--- a/crypto/arm_arch.h
+++ b/crypto/arm_arch.h
@@ -98,6 +98,7 @@ extern unsigned int OPENSSL_armv8_rsa_neonized;
 
 # define ARM_CPU_IMP_ARM           0x41
 # define HISI_CPU_IMP              0x48
+# define ARM_CPU_IMP_APPLE         0x61
 
 # define ARM_CPU_PART_CORTEX_A72   0xD08
 # define ARM_CPU_PART_N1           0xD0C
@@ -105,6 +106,19 @@ extern unsigned int OPENSSL_armv8_rsa_neonized;
 # define ARM_CPU_PART_N2           0xD49
 # define HISI_CPU_PART_KP920       0xD01
 # define ARM_CPU_PART_V2           0xD4F
+
+# define APPLE_CPU_PART_M1_ICESTORM         0x022
+# define APPLE_CPU_PART_M1_FIRESTORM        0x023
+# define APPLE_CPU_PART_M1_ICESTORM_PRO     0x024
+# define APPLE_CPU_PART_M1_FIRESTORM_PRO    0x025
+# define APPLE_CPU_PART_M1_ICESTORM_MAX     0x028
+# define APPLE_CPU_PART_M1_FIRESTORM_MAX    0x029
+# define APPLE_CPU_PART_M2_BLIZZARD         0x032
+# define APPLE_CPU_PART_M2_AVALANCHE        0x033
+# define APPLE_CPU_PART_M2_BLIZZARD_PRO     0x034
+# define APPLE_CPU_PART_M2_AVALANCHE_PRO    0x035
+# define APPLE_CPU_PART_M2_BLIZZARD_MAX     0x038
+# define APPLE_CPU_PART_M2_AVALANCHE_MAX    0x039
 
 # define MIDR_PARTNUM_SHIFT       4
 # define MIDR_PARTNUM_MASK        (0xfffU << MIDR_PARTNUM_SHIFT)

--- a/crypto/arm_arch.h
+++ b/crypto/arm_arch.h
@@ -85,7 +85,7 @@ extern unsigned int OPENSSL_armv8_rsa_neonized;
 # define ARMV8_UNROLL8_EOR3      (1<<12)
 # define ARMV8_SVE       (1<<13)
 # define ARMV8_SVE2      (1<<14)
-# define ARMV8_WORTH_USING_SHA3  (1<<15)
+# define ARMV8_HAVE_SHA3_AND_WORTH_USING     (1<<15)
 
 /*
  * MIDR_EL1 system register

--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -300,7 +300,7 @@ void OPENSSL_cpuid_setup(void)
                ((strncmp(uarch, "Apple M1", 8) == 0) ||
                 (strncmp(uarch, "Apple M2", 8) == 0))) {
                 OPENSSL_armcap_P |= ARMV8_UNROLL8_EOR3;
-                OPENSSL_armcap_P |= ARMV8_WORTH_USING_SHA3;
+                OPENSSL_armcap_P |= ARMV8_HAVE_SHA3_AND_WORTH_USING;
             }
         }
     }
@@ -433,7 +433,7 @@ void OPENSSL_cpuid_setup(void)
          MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M2_AVALANCHE_MAX) ||
          MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M2_BLIZZARD_MAX)) &&
         (OPENSSL_armcap_P & ARMV8_SHA3))
-        OPENSSL_armcap_P |= ARMV8_WORTH_USING_SHA3;
+        OPENSSL_armcap_P |= ARMV8_HAVE_SHA3_AND_WORTH_USING;
 # endif
 }
 #endif /* _WIN32, __ARM_MAX_ARCH__ >= 7 */

--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -300,6 +300,7 @@ void OPENSSL_cpuid_setup(void)
                ((strncmp(uarch, "Apple M1", 8) == 0) ||
                 (strncmp(uarch, "Apple M2", 8) == 0))) {
                 OPENSSL_armcap_P |= ARMV8_UNROLL8_EOR3;
+                OPENSSL_armcap_P |= ARMV8_WORTH_USING_SHA3;
             }
         }
     }
@@ -419,6 +420,20 @@ void OPENSSL_cpuid_setup(void)
          MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_V2)) &&
         (OPENSSL_armcap_P & ARMV8_SHA3))
         OPENSSL_armcap_P |= ARMV8_UNROLL8_EOR3;
+    if ((MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M1_FIRESTORM)     ||
+         MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M1_ICESTORM)      ||
+         MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M1_FIRESTORM_PRO) ||
+         MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M1_ICESTORM_PRO)  ||
+         MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M1_FIRESTORM_MAX) ||
+         MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M1_ICESTORM_MAX)  ||
+         MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M2_AVALANCHE)     ||
+         MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M2_BLIZZARD)      ||
+         MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M2_AVALANCHE_PRO) ||
+         MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M2_BLIZZARD_PRO)  ||
+         MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M2_AVALANCHE_MAX) ||
+         MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M2_BLIZZARD_MAX)) &&
+        (OPENSSL_armcap_P & ARMV8_SHA3))
+        OPENSSL_armcap_P |= ARMV8_WORTH_USING_SHA3;
 # endif
 }
 #endif /* _WIN32, __ARM_MAX_ARCH__ >= 7 */

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -249,6 +249,65 @@ static PROV_SHA3_METHOD kmac_s390x_md =
     } else {                                                                   \
         ctx->meth = sha3_generic_md;                                           \
     }
+#elif defined(__aarch64__)
+# include "arm_arch.h"
+
+static sha3_absorb_fn armsha3_sha3_absorb;
+
+size_t SHA3_absorb_cext(uint64_t A[5][5], const unsigned char *inp, size_t len,
+                    size_t r);
+/*-
+ * Hardware-assisted ARMv8.2 SHA3 extension version of the absorb()
+ */
+static size_t armsha3_sha3_absorb(void *vctx, const void *inp, size_t len)
+{
+    KECCAK1600_CTX *ctx = vctx;
+
+    return SHA3_absorb_cext(ctx->A, inp, len, ctx->block_size);
+}
+
+static PROV_SHA3_METHOD sha3_ARMSHA3_md =
+{
+    armsha3_sha3_absorb,
+    generic_sha3_final
+};
+/* Detection on Apple operating systems */
+# if defined(__APPLE__)
+#  define ARM_SHA3_CAPABLE (OPENSSL_armcap_P & ARMV8_SHA3)
+#  define SHA3_SET_MD(uname, typ)                                              \
+    if (ARM_SHA3_CAPABLE) {                                                    \
+        ctx->meth = sha3_ARMSHA3_md;                                           \
+    } else {                                                                   \
+        ctx->meth = sha3_generic_md;                                           \
+    }
+#  define KMAC_SET_MD(bitlen)                                                  \
+    if (ARM_SHA3_CAPABLE) {                                                    \
+        ctx->meth = sha3_ARMSHA3_md;                                           \
+    } else {                                                                   \
+        ctx->meth = sha3_generic_md;                                           \
+    }
+/* Detection on other operating systems */
+# else
+#  define ARM_HAS_FASTER_SHA3                                                                  \
+    (MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M1_FIRESTORM)     ||\
+     MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M1_FIRESTORM_PRO) ||\
+     MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M1_FIRESTORM_MAX) ||\
+     MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M2_AVALANCHE)     ||\
+     MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M2_AVALANCHE_PRO) ||\
+     MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M2_AVALANCHE_MAX))
+#  define SHA3_SET_MD(uname, typ)                                              \
+    if (ARM_HAS_FASTER_SHA3) {                                                 \
+        ctx->meth = sha3_ARMSHA3_md;                                           \
+    } else {                                                                   \
+        ctx->meth = sha3_generic_md;                                           \
+    }
+#  define KMAC_SET_MD(bitlen)                                                  \
+    if (ARM_HAS_FASTER_SHA3) {                                                 \
+        ctx->meth = sha3_ARMSHA3_md;                                           \
+    } else {                                                                   \
+        ctx->meth = sha3_generic_md;                                           \
+    }
+# endif /* APPLE */
 #else
 # define SHA3_SET_MD(uname, typ) ctx->meth = sha3_generic_md;
 # define KMAC_SET_MD(bitlen) ctx->meth = sha3_generic_md;

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -271,18 +271,14 @@ static PROV_SHA3_METHOD sha3_ARMSHA3_md =
     armsha3_sha3_absorb,
     generic_sha3_final
 };
-/* Users can switch back to the generic code by clearing either of the bits */
-# define ARM_SHA3_CAPABLE                                                      \
-    ((OPENSSL_armcap_P & ARMV8_SHA3) &&                                        \
-     (OPENSSL_armcap_P & ARMV8_WORTH_USING_SHA3))
 # define SHA3_SET_MD(uname, typ)                                               \
-    if (ARM_SHA3_CAPABLE) {                                                    \
+    if (OPENSSL_armcap_P & ARMV8_HAVE_SHA3_AND_WORTH_USING) {                  \
         ctx->meth = sha3_ARMSHA3_md;                                           \
     } else {                                                                   \
         ctx->meth = sha3_generic_md;                                           \
     }
 # define KMAC_SET_MD(bitlen)                                                   \
-    if (ARM_SHA3_CAPABLE) {                                                    \
+    if (OPENSSL_armcap_P & ARMV8_HAVE_SHA3_AND_WORTH_USING) {                  \
         ctx->meth = sha3_ARMSHA3_md;                                           \
     } else {                                                                   \
         ctx->meth = sha3_generic_md;                                           \

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -271,43 +271,22 @@ static PROV_SHA3_METHOD sha3_ARMSHA3_md =
     armsha3_sha3_absorb,
     generic_sha3_final
 };
-/* Detection on Apple operating systems */
-# if defined(__APPLE__)
-#  define ARM_SHA3_CAPABLE (OPENSSL_armcap_P & ARMV8_SHA3)
-#  define SHA3_SET_MD(uname, typ)                                              \
+/* Users can switch back to the generic code by clearing either of the bits */
+# define ARM_SHA3_CAPABLE                                                      \
+    ((OPENSSL_armcap_P & ARMV8_SHA3) &&                                        \
+     (OPENSSL_armcap_P & ARMV8_WORTH_USING_SHA3))
+# define SHA3_SET_MD(uname, typ)                                               \
     if (ARM_SHA3_CAPABLE) {                                                    \
         ctx->meth = sha3_ARMSHA3_md;                                           \
     } else {                                                                   \
         ctx->meth = sha3_generic_md;                                           \
     }
-#  define KMAC_SET_MD(bitlen)                                                  \
+# define KMAC_SET_MD(bitlen)                                                   \
     if (ARM_SHA3_CAPABLE) {                                                    \
         ctx->meth = sha3_ARMSHA3_md;                                           \
     } else {                                                                   \
         ctx->meth = sha3_generic_md;                                           \
     }
-/* Detection on other operating systems */
-# else
-#  define ARM_HAS_FASTER_SHA3                                                                  \
-    (MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M1_FIRESTORM)     ||\
-     MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M1_FIRESTORM_PRO) ||\
-     MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M1_FIRESTORM_MAX) ||\
-     MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M2_AVALANCHE)     ||\
-     MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M2_AVALANCHE_PRO) ||\
-     MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_APPLE, APPLE_CPU_PART_M2_AVALANCHE_MAX))
-#  define SHA3_SET_MD(uname, typ)                                              \
-    if (ARM_HAS_FASTER_SHA3) {                                                 \
-        ctx->meth = sha3_ARMSHA3_md;                                           \
-    } else {                                                                   \
-        ctx->meth = sha3_generic_md;                                           \
-    }
-#  define KMAC_SET_MD(bitlen)                                                  \
-    if (ARM_HAS_FASTER_SHA3) {                                                 \
-        ctx->meth = sha3_ARMSHA3_md;                                           \
-    } else {                                                                   \
-        ctx->meth = sha3_generic_md;                                           \
-    }
-# endif /* APPLE */
 #else
 # define SHA3_SET_MD(uname, typ) ctx->meth = sha3_generic_md;
 # define KMAC_SET_MD(bitlen) ctx->meth = sha3_generic_md;


### PR DESCRIPTION
The hardware-assisted ARMv8.2 implementation is already in keccak1600-armv8.pl. It is not called because the author mentioned that it's not actually obvious that it will provide performance improvements. The test on Apple M1 Firestorm shows that the ARMv8.2 implementation could improve about 36% for large blocks. So let's enable ARMv8.2 accelerated SHA3 on Apple CPU family.

M1 Firestorm master

```
$ DYLD_LIBRARY_PATH=. apps/openssl speed -evp sha3-256                          
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
sha3-256         48099.35k   192855.72k   479891.18k   566828.18k   643850.10k   651480.44k
```

M1 Firestorm ARM SHA3 extension enabled

```
$ DYLD_LIBRARY_PATH=. apps/openssl speed -evp sha3-256
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
sha3-256         47984.92k   192821.83k   527154.17k   738713.60k   874018.13k   890705.24k
```

M1 Icestorm master

```
$ taskpolicy -c background bash -c "DYLD_LIBRARY_PATH=. apps/openssl speed -evp sha3-256"
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
sha3-256         11461.94k    47571.66k   121608.50k   144754.32k   126859.74k   164252.42k
```

M1 Icestorm ARM SHA3 extension enabled

```
$ taskpolicy -c background bash -c "DYLD_LIBRARY_PATH=. apps/openssl speed -evp sha3-256"
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
sha3-256          8561.96k    34054.53k    93464.84k   133518.93k   159627.74k   164587.15k
```

~The ARM SHA3 extension version does not work well on M1 Icestorm, so only~
~enable the code on Apple's big cores, i.e. Firestorm and Avalanche.~

> It's not worth distinguishing between big and little cores, since processes can be migrated between them.

See below.

Fixes #21380

~Is it OK without a CLA?~

~CLA: trivial~