### PR TITLE
Write modulus value to the correct file in req command

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -975,7 +975,7 @@ int req_main(int argc, char **argv)
 
             if (!EVP_PKEY_get_bn_param(tpubkey, "n", &n))
                 goto end;
-            BN_print(out, n);
+            BN_print_fp(stdout, n);
             BN_free(n);
         } else {
             fprintf(stdout, "Wrong Algorithm type");

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -594,7 +594,7 @@ has_keyUsage($cert, 1);
 subtest "Issue 21403 - '-modulus' interaction with 'req'" => sub {
     plan tests => 2;
 
-    SKIP {
+    SKIP: {
         skip "RSA is not supported by this OpenSSL build", 2
             if disabled("rsa");
 

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -232,21 +232,3 @@ SKIP: {
         if disabled("ec");
     ok(run(test(["x509_test"])), "running x509_test");
 }
-
-{
-    # Tests for issue #21403 - within isolated variable scope
-    my $i21403_cnf = srctop_file('test', 'test.cnf');
-    my $i21403_key = srctop_file('test', 'key-21403.pem');
-    my $i21403_cert = srctop_file('test', 'cert-21403.pem');
-
-    # Create cert
-    ok(run(app(["openssl", "req", "-x509", "-new", "-newkey", "rsa:4096",
-                "-days", "365", "-nodes",
-                "-config", $i21403_cnf,
-                "-keyout", $i21403_key,
-                "-out", $i21403_cert,
-                "-modulus"])), "cert creation - issue 21403");
-    # Verify cert
-    ok(run(app(["openssl", "x509", "-in", $i21403_cert,
-                "-noout", "-text"])), "cert verification - issue 21403");
-}

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -16,7 +16,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_x509");
 
-plan tests => 37;
+plan tests => 39;
 
 # Prevent MSys2 filename munging for arguments that look like file paths but
 # aren't
@@ -231,4 +231,22 @@ SKIP: {
     skip "EC is not supported by this OpenSSL build", 1
         if disabled("ec");
     ok(run(test(["x509_test"])), "running x509_test");
+}
+
+{
+    # Tests for issue #21403 - within isolated variable scope
+    my $i21403_cnf = srctop_file('test', 'test.cnf');
+    my $i21403_key = srctop_file('test', 'key-21403.pem');
+    my $i21403_cert = srctop_file('test', 'cert-21403.pem');
+
+    # Create cert
+    ok(run(app(["openssl", "req", "-x509", "-new", "-newkey", "rsa:4096",
+                "-days", "365", "-nodes",
+                "-config", $i21403_cnf,
+                "-keyout", $i21403_key,
+                "-out", $i21403_cert,
+                "-modulus"])), "cert creation - issue 21403");
+    # Verify cert
+    ok(run(app(["openssl", "x509", "-in", $i21403_cert,
+                "-noout", "-text"])), "cert verification - issue 21403");
 }

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -16,7 +16,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_x509");
 
-plan tests => 39;
+plan tests => 37;
 
 # Prevent MSys2 filename munging for arguments that look like file paths but
 # aren't


### PR DESCRIPTION
Modulus value written to wrong file handle in req command, resulting in invalid certificate file. Changed function and file handle used.

CLA: trivial

Fixes #21403

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
