### PR TITLE
X509 store ctx set purpose ex

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -2303,21 +2303,31 @@ void X509_STORE_CTX_set0_crls(X509_STORE_CTX *ctx, STACK_OF(X509_CRL) *sk)
 
 int X509_STORE_CTX_set_purpose(X509_STORE_CTX *ctx, int purpose)
 {
+    return X509_STORE_CTX_set_purpose_ex(ctx, purpose, 0);
+}
+
+int X509_STORE_CTX_set_purpose_ex(X509_STORE_CTX *ctx, int purpose, int override)
+{
     /*
      * XXX: Why isn't this function always used to set the associated trust?
      * Should there even be a VPM->trust field at all?  Or should the trust
      * always be inferred from the purpose by X509_STORE_CTX_init().
      */
-    return X509_STORE_CTX_purpose_inherit(ctx, 0, purpose, 0);
+    return X509_STORE_CTX_purpose_inherit_ex(ctx, 0, purpose, 0, override);
 }
 
 int X509_STORE_CTX_set_trust(X509_STORE_CTX *ctx, int trust)
+{
+    return X509_STORE_CTX_set_trust_ex(ctx, trust, 0);
+}
+
+int X509_STORE_CTX_set_trust_ex(X509_STORE_CTX *ctx, int trust, int override)
 {
     /*
      * XXX: See above, this function would only be needed when the default
      * trust for the purpose needs an override in a corner case.
      */
-    return X509_STORE_CTX_purpose_inherit(ctx, 0, 0, trust);
+    return X509_STORE_CTX_purpose_inherit_ex(ctx, 0, 0, trust, override);
 }
 
 /*
@@ -2332,6 +2342,15 @@ int X509_STORE_CTX_set_trust(X509_STORE_CTX *ctx, int trust)
  */
 int X509_STORE_CTX_purpose_inherit(X509_STORE_CTX *ctx, int def_purpose,
                                    int purpose, int trust)
+{
+    return X509_STORE_CTX_purpose_inherit_ex(ctx, def_purpose, purpose, trust, 0);
+}
+
+/*
+ * This "_ex" function allows to override existing values 
+ */
+int X509_STORE_CTX_purpose_inherit_ex(X509_STORE_CTX *ctx, int def_purpose,
+                                   int purpose, int trust, int override)
 {
     int idx;
 
@@ -2374,9 +2393,9 @@ int X509_STORE_CTX_purpose_inherit(X509_STORE_CTX *ctx, int def_purpose,
         }
     }
 
-    if (ctx->param->purpose == 0 && purpose != 0)
+    if ((ctx->param->purpose == 0 && purpose != 0) || override != 0)
         ctx->param->purpose = purpose;
-    if (ctx->param->trust == 0 && trust != 0)
+    if ((ctx->param->trust == 0 && trust != 0) || override != 0)
         ctx->param->trust = trust;
     return 1;
 }

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -2347,7 +2347,7 @@ int X509_STORE_CTX_purpose_inherit(X509_STORE_CTX *ctx, int def_purpose,
 }
 
 /*
- * This "_ex" function allows to override existing values 
+ * This "_ex" function allows to override existing values
  */
 int X509_STORE_CTX_purpose_inherit_ex(X509_STORE_CTX *ctx, int def_purpose,
                                    int purpose, int trust, int override)

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -2303,31 +2303,21 @@ void X509_STORE_CTX_set0_crls(X509_STORE_CTX *ctx, STACK_OF(X509_CRL) *sk)
 
 int X509_STORE_CTX_set_purpose(X509_STORE_CTX *ctx, int purpose)
 {
-    return X509_STORE_CTX_set_purpose_ex(ctx, purpose, 0);
-}
-
-int X509_STORE_CTX_set_purpose_ex(X509_STORE_CTX *ctx, int purpose, int override)
-{
     /*
      * XXX: Why isn't this function always used to set the associated trust?
      * Should there even be a VPM->trust field at all?  Or should the trust
      * always be inferred from the purpose by X509_STORE_CTX_init().
      */
-    return X509_STORE_CTX_purpose_inherit_ex(ctx, 0, purpose, 0, override);
+    return X509_STORE_CTX_purpose_inherit(ctx, 0, purpose, 0);
 }
 
 int X509_STORE_CTX_set_trust(X509_STORE_CTX *ctx, int trust)
-{
-    return X509_STORE_CTX_set_trust_ex(ctx, trust, 0);
-}
-
-int X509_STORE_CTX_set_trust_ex(X509_STORE_CTX *ctx, int trust, int override)
 {
     /*
      * XXX: See above, this function would only be needed when the default
      * trust for the purpose needs an override in a corner case.
      */
-    return X509_STORE_CTX_purpose_inherit_ex(ctx, 0, 0, trust, override);
+    return X509_STORE_CTX_purpose_inherit(ctx, 0, 0, trust);
 }
 
 /*

--- a/doc/man3/X509_STORE_CTX_new.pod
+++ b/doc/man3/X509_STORE_CTX_new.pod
@@ -17,8 +17,11 @@ X509_STORE_CTX_set_default,
 X509_STORE_CTX_set_verify,
 X509_STORE_CTX_verify_fn,
 X509_STORE_CTX_set_purpose,
+X509_STORE_CTX_set_purpose_ex,
 X509_STORE_CTX_set_trust,
-X509_STORE_CTX_purpose_inherit
+X509_STORE_CTX_set_trust_ex,
+X509_STORE_CTX_purpose_inherit,
+X509_STORE_CTX_purpose_inherit_ex
 - X509_STORE_CTX initialisation
 
 =head1 SYNOPSIS
@@ -57,9 +60,14 @@ X509_STORE_CTX_purpose_inherit
  void X509_STORE_CTX_set_verify(X509_STORE_CTX *ctx, X509_STORE_CTX_verify_fn verify);
 
  int X509_STORE_CTX_set_purpose(X509_STORE_CTX *ctx, int purpose);
+ int X509_STORE_CTX_set_purpose_ex(X509_STORE_CTX *ctx, int purpose,
+                                   int override);
  int X509_STORE_CTX_set_trust(X509_STORE_CTX *ctx, int trust);
+ int X509_STORE_CTX_set_trust_ex(X509_STORE_CTX *ctx, int trust, int override);
  int X509_STORE_CTX_purpose_inherit(X509_STORE_CTX *ctx, int def_purpose,
                                     int purpose, int trust);
+ int X509_STORE_CTX_purpose_inherit_ex(X509_STORE_CTX *ctx, int def_purpose,
+                                       int purpose, int trust, int override);
 
 =head1 DESCRIPTION
 
@@ -233,6 +241,10 @@ The purpose however is only set by X509_STORE_CTX_set_purpose(), if no purpose
 was set previously. I another purpose was already set, the new purpose is
 not set but silently ignored.
 
+X509_STORE_CTX_set_purpose_ex() extends X509_STORE_CTX_set_purpose() by
+allowing to explicitly override already existing settings for the purpose
+(and any trust implied by the purpose).
+
 X509_STORE_CTX_set_trust() sets the trust value for the target certificate
 being verified in the I<ctx>. Built-in available values for the I<trust>
 argument are B<X509_TRUST_COMPAT>, B<X509_TRUST_SSL_CLIENT>,
@@ -247,6 +259,9 @@ used.
 The trust however is only set by X509_STORE_CTX_set_trust(), if no trust
 was set previously. I another trust was already set, either explicitly or
 implicitly by setting a purpose, the new trust is not set but silently ignored.
+
+X509_STORE_CTX_set_trust_ex() extends X509_STORE_CTX_set_trust() by
+allowing to explicitly override already existing settings for the trust.
 
 It should not normally be necessary for end user applications to call
 X509_STORE_CTX_purpose_inherit() directly. Typically applications should call
@@ -267,6 +282,9 @@ If I<trust> is 0 then the trust value will be set from
 the default trust value for I<purpose>. If the default trust value for the
 purpose is I<X509_TRUST_DEFAULT> and I<trust> is 0 then the default trust value
 associated with the I<def_purpose> value is used for the trust setting instead.
+
+X509_STORE_CTX_purpose_inherit_ex() adds an additional "override" parameter
+that enforces the setting, even if the purpose was set in the I<ctx> before.
 
 =head1 NOTES
 

--- a/doc/man3/X509_STORE_CTX_new.pod
+++ b/doc/man3/X509_STORE_CTX_new.pod
@@ -229,6 +229,10 @@ at the same time. During verification, this trust setting will be verified
 to check whether it is consistent with the trust set by the system administrator
 for certificates in the chain.
 
+The purpose however is only set by X509_STORE_CTX_set_purpose(), if no purpose
+was set previously. I another purpose was already set, the new purpose is
+not set but silently ignored.
+
 X509_STORE_CTX_set_trust() sets the trust value for the target certificate
 being verified in the I<ctx>. Built-in available values for the I<trust>
 argument are B<X509_TRUST_COMPAT>, B<X509_TRUST_SSL_CLIENT>,
@@ -239,6 +243,10 @@ also sets the trust value it is normally sufficient to only call that function.
 If both are called then X509_STORE_CTX_set_trust() should be called after
 X509_STORE_CTX_set_purpose() since the trust setting of the last call will be
 used.
+
+The trust however is only set by X509_STORE_CTX_set_trust(), if no trust
+was set previously. I another trust was already set, either explicitly or
+implicitly by setting a purpose, the new trust is not set but silently ignored.
 
 It should not normally be necessary for end user applications to call
 X509_STORE_CTX_purpose_inherit() directly. Typically applications should call

--- a/doc/man3/X509_STORE_CTX_new.pod
+++ b/doc/man3/X509_STORE_CTX_new.pod
@@ -242,7 +242,7 @@ was set previously. If another purpose was already set, the new purpose is
 not set but silently ignored.
 
 X509_STORE_CTX_set_purpose_ex() extends X509_STORE_CTX_set_purpose() by
-allowing to explicitly override already existing settings for the purpose
+explicitly overriding any existing purpose setting
 (and any trust implied by the purpose).
 
 X509_STORE_CTX_set_trust() sets the trust value for the target certificate
@@ -261,7 +261,7 @@ was set previously. If another trust was already set, either explicitly or
 implicitly by setting a purpose, the new trust is not set but silently ignored.
 
 X509_STORE_CTX_set_trust_ex() extends X509_STORE_CTX_set_trust() by
-allowing to explicitly override already existing settings for the trust.
+explicitly overriding any existing trust setting.
 
 It should not normally be necessary for end user applications to call
 X509_STORE_CTX_purpose_inherit() directly. Typically applications should call

--- a/doc/man3/X509_STORE_CTX_new.pod
+++ b/doc/man3/X509_STORE_CTX_new.pod
@@ -238,7 +238,7 @@ to check whether it is consistent with the trust set by the system administrator
 for certificates in the chain.
 
 The purpose however is only set by X509_STORE_CTX_set_purpose(), if no purpose
-was set previously. I another purpose was already set, the new purpose is
+was set previously. If another purpose was already set, the new purpose is
 not set but silently ignored.
 
 X509_STORE_CTX_set_purpose_ex() extends X509_STORE_CTX_set_purpose() by
@@ -257,7 +257,7 @@ X509_STORE_CTX_set_purpose() since the trust setting of the last call will be
 used.
 
 The trust however is only set by X509_STORE_CTX_set_trust(), if no trust
-was set previously. I another trust was already set, either explicitly or
+was set previously. If another trust was already set, either explicitly or
 implicitly by setting a purpose, the new trust is not set but silently ignored.
 
 X509_STORE_CTX_set_trust_ex() extends X509_STORE_CTX_set_trust() by

--- a/include/openssl/x509_vfy.h.in
+++ b/include/openssl/x509_vfy.h.in
@@ -675,9 +675,14 @@ void X509_STORE_CTX_set0_rpk(X509_STORE_CTX *ctx, EVP_PKEY *target);
 void X509_STORE_CTX_set0_verified_chain(X509_STORE_CTX *c, STACK_OF(X509) *sk);
 void X509_STORE_CTX_set0_crls(X509_STORE_CTX *ctx, STACK_OF(X509_CRL) *sk);
 int X509_STORE_CTX_set_purpose(X509_STORE_CTX *ctx, int purpose);
+int X509_STORE_CTX_set_purpose_ex(X509_STORE_CTX *ctx, int purpose,
+                                  int override);
 int X509_STORE_CTX_set_trust(X509_STORE_CTX *ctx, int trust);
+int X509_STORE_CTX_set_trust_ex(X509_STORE_CTX *ctx, int trust, int override);
 int X509_STORE_CTX_purpose_inherit(X509_STORE_CTX *ctx, int def_purpose,
                                    int purpose, int trust);
+int X509_STORE_CTX_purpose_inherit_ex(X509_STORE_CTX *ctx, int def_purpose,
+                                      int purpose, int trust, int override);
 void X509_STORE_CTX_set_flags(X509_STORE_CTX *ctx, unsigned long flags);
 void X509_STORE_CTX_set_time(X509_STORE_CTX *ctx, unsigned long flags,
                              time_t t);

--- a/include/openssl/x509_vfy.h.in
+++ b/include/openssl/x509_vfy.h.in
@@ -675,10 +675,11 @@ void X509_STORE_CTX_set0_rpk(X509_STORE_CTX *ctx, EVP_PKEY *target);
 void X509_STORE_CTX_set0_verified_chain(X509_STORE_CTX *c, STACK_OF(X509) *sk);
 void X509_STORE_CTX_set0_crls(X509_STORE_CTX *ctx, STACK_OF(X509_CRL) *sk);
 int X509_STORE_CTX_set_purpose(X509_STORE_CTX *ctx, int purpose);
-int X509_STORE_CTX_set_purpose_ex(X509_STORE_CTX *ctx, int purpose,
-                                  int override);
+#define X509_STORE_CTX_set_purpose_ex(ctx, purpose, override) \
+                X509_STORE_CTX_purpose_inherit_ex(ctx, 0, purpose, 0, override)
 int X509_STORE_CTX_set_trust(X509_STORE_CTX *ctx, int trust);
-int X509_STORE_CTX_set_trust_ex(X509_STORE_CTX *ctx, int trust, int override);
+#define X509_STORE_CTX_set_trust_ex(ctx, trust, override) \
+                X509_STORE_CTX_purpose_inherit_ex(ctx, 0, 0, trust, 0, override)
 int X509_STORE_CTX_purpose_inherit(X509_STORE_CTX *ctx, int def_purpose,
                                    int purpose, int trust);
 int X509_STORE_CTX_purpose_inherit_ex(X509_STORE_CTX *ctx, int def_purpose,

--- a/test/verify_extra_test.c
+++ b/test/verify_extra_test.c
@@ -222,7 +222,7 @@ static int test_store_ctx(void)
     return test_self_signed(bad_f, 0, 0);
 }
 
-static int do_test_purpose(int purpose, int expected)
+static int do_test_purpose(int purpose, int purpose2, int expected)
 {
     X509 *eecert = load_cert_from_file(ee_cert); /* may result in NULL */
     X509 *untrcert = load_cert_from_file(ca_cert);
@@ -254,6 +254,11 @@ static int do_test_purpose(int purpose, int expected)
     if (!TEST_true(X509_STORE_CTX_set_purpose(ctx, purpose)))
         goto err;
 
+    if (purpose2 != 0) {
+        if (!TEST_true(X509_STORE_CTX_set_purpose(ctx, purpose2)))
+            goto err;
+    }
+        
     /*
      * X509_STORE_CTX_set0_trusted_stack() is bady named. Despite the set0 name
      * we are still responsible for freeing trusted after we have finished with
@@ -277,17 +282,22 @@ static int do_test_purpose(int purpose, int expected)
 
 static int test_purpose_ssl_client(void)
 {
-    return do_test_purpose(X509_PURPOSE_SSL_CLIENT, 0);
+    return do_test_purpose(X509_PURPOSE_SSL_CLIENT, 0, 0);
 }
 
 static int test_purpose_ssl_server(void)
 {
-    return do_test_purpose(X509_PURPOSE_SSL_SERVER, 1);
+    return do_test_purpose(X509_PURPOSE_SSL_SERVER, 0, 1);
+}
+
+static int test_purpose_ssl_client_override_fail(void)
+{
+    return do_test_purpose(X509_PURPOSE_SSL_SERVER, X509_PURPOSE_SSL_CLIENT, 1);
 }
 
 static int test_purpose_any(void)
 {
-    return do_test_purpose(X509_PURPOSE_ANY, 1);
+    return do_test_purpose(X509_PURPOSE_ANY, 0, 1);
 }
 
 OPT_TEST_DECLARE_USAGE("certs-dir\n")
@@ -321,6 +331,7 @@ int setup_tests(void)
     ADD_TEST(test_self_signed_error);
     ADD_TEST(test_purpose_ssl_client);
     ADD_TEST(test_purpose_ssl_server);
+    ADD_TEST(test_purpose_ssl_client_override_fail);
     ADD_TEST(test_purpose_any);
     return 1;
  err:

--- a/test/verify_extra_test.c
+++ b/test/verify_extra_test.c
@@ -222,7 +222,8 @@ static int test_store_ctx(void)
     return test_self_signed(bad_f, 0, 0);
 }
 
-static int do_test_purpose(int purpose, int purpose2, int expected)
+static int do_test_purpose(int purpose, int purpose2, int override,
+                           int expected)
 {
     X509 *eecert = load_cert_from_file(ee_cert); /* may result in NULL */
     X509 *untrcert = load_cert_from_file(ca_cert);
@@ -251,11 +252,11 @@ static int do_test_purpose(int purpose, int purpose2, int expected)
     if (!TEST_true(X509_STORE_CTX_init(ctx, NULL, eecert, untrusted)))
         goto err;
 
-    if (!TEST_true(X509_STORE_CTX_set_purpose(ctx, purpose)))
+    if (!TEST_true(X509_STORE_CTX_set_purpose_ex(ctx, purpose, override)))
         goto err;
 
     if (purpose2 != 0) {
-        if (!TEST_true(X509_STORE_CTX_set_purpose(ctx, purpose2)))
+        if (!TEST_true(X509_STORE_CTX_set_purpose_ex(ctx, purpose2, override)))
             goto err;
     }
         
@@ -282,22 +283,29 @@ static int do_test_purpose(int purpose, int purpose2, int expected)
 
 static int test_purpose_ssl_client(void)
 {
-    return do_test_purpose(X509_PURPOSE_SSL_CLIENT, 0, 0);
+    return do_test_purpose(X509_PURPOSE_SSL_CLIENT, 0, 0, 0);
 }
 
 static int test_purpose_ssl_server(void)
 {
-    return do_test_purpose(X509_PURPOSE_SSL_SERVER, 0, 1);
+    return do_test_purpose(X509_PURPOSE_SSL_SERVER, 0, 0, 1);
 }
 
 static int test_purpose_ssl_client_override_fail(void)
 {
-    return do_test_purpose(X509_PURPOSE_SSL_SERVER, X509_PURPOSE_SSL_CLIENT, 1);
+    return do_test_purpose(X509_PURPOSE_SSL_SERVER, X509_PURPOSE_SSL_CLIENT,
+                           0, 1);
+}
+
+static int test_purpose_ssl_client_override_pass(void)
+{
+    return do_test_purpose(X509_PURPOSE_SSL_SERVER, X509_PURPOSE_SSL_CLIENT,
+                           1, 0);
 }
 
 static int test_purpose_any(void)
 {
-    return do_test_purpose(X509_PURPOSE_ANY, 0, 1);
+    return do_test_purpose(X509_PURPOSE_ANY, 0, 0, 1);
 }
 
 OPT_TEST_DECLARE_USAGE("certs-dir\n")
@@ -332,6 +340,7 @@ int setup_tests(void)
     ADD_TEST(test_purpose_ssl_client);
     ADD_TEST(test_purpose_ssl_server);
     ADD_TEST(test_purpose_ssl_client_override_fail);
+    ADD_TEST(test_purpose_ssl_client_override_pass);
     ADD_TEST(test_purpose_any);
     return 1;
  err:

--- a/test/verify_extra_test.c
+++ b/test/verify_extra_test.c
@@ -259,7 +259,7 @@ static int do_test_purpose(int purpose, int purpose2, int override,
         if (!TEST_true(X509_STORE_CTX_set_purpose_ex(ctx, purpose2, override)))
             goto err;
     }
-        
+
     /*
      * X509_STORE_CTX_set0_trusted_stack() is bady named. Despite the set0 name
      * we are still responsible for freeing trusted after we have finished with

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5535,5 +5535,3 @@ OSSL_ERR_STATE_save_to_mark             ?	3_2_0	EXIST::FUNCTION:
 X509_STORE_CTX_set_get_crl              ?	3_2_0	EXIST::FUNCTION:
 X509_STORE_CTX_set_current_reasons      ?	3_2_0	EXIST::FUNCTION:
 X509_STORE_CTX_purpose_inherit_ex       ?	3_2_0	EXIST::FUNCTION:
-X509_STORE_CTX_set_purpose_ex           ?	3_2_0	EXIST::FUNCTION:
-X509_STORE_CTX_set_trust_ex             ?	3_2_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5534,3 +5534,6 @@ OSSL_PROVIDER_try_load_ex               ?	3_2_0	EXIST::FUNCTION:
 OSSL_ERR_STATE_save_to_mark             ?	3_2_0	EXIST::FUNCTION:
 X509_STORE_CTX_set_get_crl              ?	3_2_0	EXIST::FUNCTION:
 X509_STORE_CTX_set_current_reasons      ?	3_2_0	EXIST::FUNCTION:
+X509_STORE_CTX_purpose_inherit_ex       ?	3_2_0	EXIST::FUNCTION:
+X509_STORE_CTX_set_purpose_ex           ?	3_2_0	EXIST::FUNCTION:
+X509_STORE_CTX_set_trust_ex             ?	3_2_0	EXIST::FUNCTION:

--- a/util/other.syms
+++ b/util/other.syms
@@ -680,6 +680,8 @@ X509_LOOKUP_load_store_ex               define
 X509_NAME_hash                          define
 X509_STORE_set_lookup_crls_cb           define
 X509_STORE_set_verify_func              define
+X509_STORE_CTX_set_purpose_ex           define
+X509_STORE_CTX_set_trust_ex             define
 EVP_PKEY_CTX_set1_id                    define
 EVP_PKEY_CTX_get1_id                    define
 EVP_PKEY_CTX_get1_id_len                define


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

X509_STORE_CTX_set_purpose() and _set_trust() do not set these parameters if they have been set previously. This is due to these functions calling X509_STORE_CTX_purpose_inherit().
This pull request includes to elements: It adds documentation describing the behavior and it proides _ex() functions adding the option to override previous settings.
Use case is the verification of CAdES signature, where timestamps might be embedded. Hence the same X509 store might be used for both checking the original purpose (like code signing) and validating the time stamp.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
