### PR TITLE
Add pointer 'next' check to NULL before dereferencing it in ssl_ctrl()

### DIFF
--- a/ssl/bio_ssl.c
+++ b/ssl/bio_ssl.c
@@ -357,7 +357,10 @@ static long ssl_ctrl(BIO *b, int cmd, long num, void *ptr)
             break;
         case SSL_ERROR_WANT_CONNECT:
             BIO_set_flags(b, BIO_FLAGS_IO_SPECIAL | BIO_FLAGS_SHOULD_RETRY);
-            BIO_set_retry_reason(b, BIO_get_retry_reason(next));
+            if (next != NULL)
+                BIO_set_retry_reason(b, BIO_get_retry_reason(next));
+            else
+                BIO_set_retry_reason(b, BIO_RR_CONNECT);
             break;
         case SSL_ERROR_WANT_X509_LOOKUP:
             BIO_set_retry_special(b);


### PR DESCRIPTION
CLA: trivial

In function ssl_ctrl(), we get the pointer next. Then there is its check for NULL on the lines 252, 295, 329. But there is no check on the line 360, where it dereference in function BIO_get_retry_reason. I would like to add a check