### PR TITLE
Fix test_quic_write_read()

### DIFF
--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -60,7 +60,7 @@ static int test_quic_write_read(int idx)
 
     if (!TEST_ptr(cctx)
             || !TEST_true(qtest_create_quic_objects(libctx, cctx, cert, privkey,
-                                                    idx == 1 ? QTEST_FLAG_BLOCK : 0,
+                                                    idx >= 1 ? QTEST_FLAG_BLOCK : 0,
                                                     &qtserv, &clientquic, NULL))
             || !TEST_true(SSL_set_tlsext_host_name(clientquic, "localhost"))
             || !TEST_true(qtest_create_quic_connection(qtserv, clientquic)))


### PR DESCRIPTION
Fix the "test 2" case of test_quic_write_read(). It is intended to be run in blocking mode.

The result of a bad interaction between #21087 and #21332

