### PR TITLE
Two CI failure fixes

### DIFF
--- a/include/internal/recordmethod.h
+++ b/include/internal/recordmethod.h
@@ -63,7 +63,7 @@ typedef struct ossl_record_layer_st OSSL_RECORD_LAYER;
  * buffer of payload data in |buf| of length |buflen|.
  */
 struct ossl_record_template_st {
-    int type;
+    unsigned char type;
     unsigned int version;
     const unsigned char *buf;
     size_t buflen;

--- a/ssl/quic/quic_wire_pkt.c
+++ b/ssl/quic/quic_wire_pkt.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "internal/common.h"
 #include "internal/quic_wire_pkt.h"
 
 int ossl_quic_hdr_protector_init(QUIC_HDR_PROTECTOR *hpr,
@@ -433,6 +434,9 @@ int ossl_quic_wire_encode_pkt_hdr(WPACKET *pkt,
         return 0;
 
     if (ptrs != NULL) {
+        /* ptrs would not be stable on non-static WPACKET */
+        if (!ossl_assert(pkt->staticbuf != NULL))
+            return 0;
         ptrs->raw_start         = NULL;
         ptrs->raw_sample        = NULL;
         ptrs->raw_sample_len    = 0;


### PR DESCRIPTION
ossl_quic_wire_encode_pkt_hdr(): Assign ptrs only on static buf wpkt

Pointers can be invalidated when the underlying BUF_MEM grows.

quicapitest: Fix SSL_trace() test on big endian platforms

The structure member (of int type) is used as single byte value which works only on little endian platforms. Use the correct type.