### PR TITLE
Add null check before calling alg_do_one

### DIFF
--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -474,7 +474,8 @@ static void alg_do_each(ossl_uintmax_t idx, ALGORITHM *alg, void *arg)
     for (i = 0; i < end; i++) {
         IMPLEMENTATION *impl = sk_IMPLEMENTATION_value(alg->impls, i);
 
-        alg_do_one(alg, impl, data->fn, data->fnarg);
+        if (impl != NULL)
+            alg_do_one(alg, impl, data->fn, data->fnarg);
     }
 }
 


### PR DESCRIPTION
impl could be NULL in some condition. Add null check to prevent crash issue. 

CLA: trivial

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
