### PR TITLE
[NFCI] Move Keccak rhotates tables to rodata

### DIFF
--- a/crypto/sha/asm/keccak1600-avx2.pl
+++ b/crypto/sha/asm/keccak1600-avx2.pl
@@ -432,6 +432,7 @@ $code.=<<___;
 	ret
 .size	SHA3_squeeze,.-SHA3_squeeze
 
+.section .rodata
 .align	64
 rhotates_left:
 	.quad	3,	18,	36,	41	# [2][0] [4][0] [1][0] [3][0]

--- a/crypto/sha/asm/keccak1600-avx512.pl
+++ b/crypto/sha/asm/keccak1600-avx512.pl
@@ -486,6 +486,7 @@ SHA3_squeeze:
 	ret
 .size	SHA3_squeeze,.-SHA3_squeeze
 
+.section .rodata
 .align	64
 theta_perm:
 	.quad	0, 1, 2, 3, 4, 5, 6, 7		# [not used]

--- a/crypto/sha/asm/keccak1600-avx512vl.pl
+++ b/crypto/sha/asm/keccak1600-avx512vl.pl
@@ -349,6 +349,7 @@ $code.=<<___;
 	ret
 .size	SHA3_squeeze,.-SHA3_squeeze
 
+.section .rodata
 .align	64
 rhotates_left:
 	.quad	3,	18,	36,	41	# [2][0] [4][0] [1][0] [3][0]


### PR DESCRIPTION
rhotates tables are placed to .text section which confuses tools such as BOLT.
Move them to rodata to unbreak and avoid polluting icache/iTLB with data.