### PR TITLE
no-module should not imply disabling DSO loading support

### DIFF
--- a/Configure
+++ b/Configure
@@ -626,8 +626,7 @@ my @disable_cascades = (
 
     "crypto-mdebug"     => [ "crypto-mdebug-backtrace" ],
 
-    # If no modules, then no dynamic engines either
-    "module"            => [ "dynamic-engine" ],
+    "module"            => [ "dynamic-engine", "fips" ],
 
     # Without shared libraries, dynamic engines aren't possible.
     # This is due to them having to link with libcrypto and register features
@@ -644,8 +643,6 @@ my @disable_cascades = (
     # Without position independent code, there can be no shared libraries
     # or modules.
     "pic"               => [ "shared", "module" ],
-
-    "module"            => [ "fips", "dso" ],
 
     "engine"            => [ "dynamic-engine", grep(/eng$/, @disablables) ],
     "dynamic-engine"    => [ "loadereng" ],


### PR DESCRIPTION
In my opinion this is a bug fix as there is currently no way to get the legacy provider built-in but also support loading 3rd party providers or the fips provider from another build.

One can of course disable dso explicitly but there is no reason to be disabling it implicitly with no-module. There is no code dependency or anything.

