### PR TITLE
Fix typos found by codespell

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1896,7 +1896,7 @@ breaking changes, and mappings for the large list of deprecated functions.
    3-prime RSA1536, and DSA1024 as a result of this defect would be very
    difficult to perform and are not believed likely. Attacks against DH512
    are considered just feasible. However, for an attack the target would
-   have to re-use the DH512 private key, which is not recommended anyway.
+   have to reuse the DH512 private key, which is not recommended anyway.
    Also applications directly using the low-level API BN_mod_exp may be
    affected if they use BN_FLG_CONSTTIME.
    ([CVE-2019-1551])

--- a/apps/lib/tlssrp_depr.c
+++ b/apps/lib/tlssrp_depr.c
@@ -87,7 +87,7 @@ static int ssl_srp_verify_param_cb(SSL *s, void *arg)
                        "SRP param N and g are not known params, going to check deeper.\n");
 
         /*
-         * The srp_moregroups is a real debugging feature. Implementors
+         * The srp_moregroups is a real debugging feature. Implementers
          * should rather add the value to the known ones. The minimal size
          * has already been tested.
          */

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3564,7 +3564,7 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
             break;
     }
  end:
-    /* make sure we re-use sessions */
+    /* make sure we reuse sessions */
     do_ssl_shutdown(con);
 
  err:
@@ -3721,7 +3721,7 @@ static int rev_body(int s, int stype, int prot, unsigned char *context)
         }
     }
  end:
-    /* make sure we re-use sessions */
+    /* make sure we reuse sessions */
     do_ssl_shutdown(con);
 
  err:

--- a/crypto/aes/asm/bsaes-armv8.pl
+++ b/crypto/aes/asm/bsaes-armv8.pl
@@ -1852,7 +1852,7 @@ ossl_bsaes_xts_encrypt:
         sub     x6, x21, #0x10
         // Penultimate plaintext block produces final ciphertext part-block
         // plus remaining part of final plaintext block. Move ciphertext part
-        // to final position and re-use penultimate ciphertext block buffer to
+        // to final position and reuse penultimate ciphertext block buffer to
         // construct final plaintext block
 .Lxts_enc_steal:
         ldrb    w0, [x20], #1
@@ -2329,7 +2329,7 @@ ossl_bsaes_xts_decrypt:
         mov     x6, x21
         // Penultimate ciphertext block produces final plaintext part-block
         // plus remaining part of final ciphertext block. Move plaintext part
-        // to final position and re-use penultimate plaintext block buffer to
+        // to final position and reuse penultimate plaintext block buffer to
         // construct final ciphertext block
 .Lxts_dec_steal:
         ldrb    w1, [x21]

--- a/crypto/evp/ctrl_params_translate.c
+++ b/crypto/evp/ctrl_params_translate.c
@@ -779,7 +779,7 @@ static int fix_cipher_md(enum state state,
 
     if (state == POST_CTRL_TO_PARAMS && ctx->action_type == GET) {
         /*
-         * Here's how we re-use |ctx->orig_p2| that was set in the
+         * Here's how we reuse |ctx->orig_p2| that was set in the
          * PRE_CTRL_TO_PARAMS state above.
          */
         *(void **)ctx->orig_p2 =

--- a/crypto/poly1305/poly1305_ieee754.c
+++ b/crypto/poly1305/poly1305_ieee754.c
@@ -10,7 +10,7 @@
 /*
  * This module is meant to be used as template for non-x87 floating-
  * point assembly modules. The template itself is x86_64-specific
- * though, as it was debugged on x86_64. So that implementor would
+ * though, as it was debugged on x86_64. So that implementer would
  * have to recognize platform-specific parts, UxTOy and inline asm,
  * and act accordingly.
  *

--- a/crypto/whrlpool/wp_dgst.c
+++ b/crypto/whrlpool/wp_dgst.c
@@ -120,7 +120,7 @@ void WHIRLPOOL_BitUpdate(WHIRLPOOL_CTX *c, const void *_inp, size_t bits)
             } else {
                 unsigned int byteoff = bitoff / 8;
 
-                bitrem = WHIRLPOOL_BBLOCK - bitoff; /* re-use bitrem */
+                bitrem = WHIRLPOOL_BBLOCK - bitoff; /* reuse bitrem */
                 if (bits >= bitrem) {
                     bits -= bitrem;
                     bitrem /= 8;

--- a/doc/designs/ddd/WINDOWS.md
+++ b/doc/designs/ddd/WINDOWS.md
@@ -72,7 +72,7 @@ Evaluation of the existing demos and their applicability to Windows IOCP:
 
 Further, a cursory examination of code on GitHub seems to suggest that when
 people do use IOCP with libssl, they do it using memory BIOs passed to libssl.
-So ddd-05 and ddd-06 essentially demonstate this use case, especially ddd-06 as
+So ddd-05 and ddd-06 essentially demonstrate this use case, especially ddd-06 as
 it uses IOCP internally on Windows.
 
 My conclusion here is that since libssl does not support IOCP in the first

--- a/doc/man1/openssl-dhparam.pod.in
+++ b/doc/man1/openssl-dhparam.pod.in
@@ -89,7 +89,7 @@ I<numbits>. It must be the last option. If this option is present then
 the input file is ignored and parameters are generated instead. If
 this option is not present but a generator (B<-2>, B<-3> or B<-5>) is
 present, parameters are generated with a default length of 2048 bits.
-The minimim length is 512 bits. The maximum length is 10000 bits.
+The minimum length is 512 bits. The maximum length is 10000 bits.
 
 =item B<-noout>
 

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -487,7 +487,7 @@ unless the B<-new> option is given, which generates a certificate from scratch.
 
 =item B<-CAform> B<DER>|B<PEM>|B<P12>,
 
-The format for the CA certificate; unspecifed by default.
+The format for the CA certificate; unspecified by default.
 See L<openssl-format-options(1)> for details.
 
 =item B<-CAkey> I<filename>|I<uri>

--- a/doc/man3/ASYNC_WAIT_CTX_new.pod
+++ b/doc/man3/ASYNC_WAIT_CTX_new.pod
@@ -83,7 +83,7 @@ will be populated with the list of added and deleted fds respectively. Similarly
 to ASYNC_WAIT_CTX_get_all_fds() either of these can be NULL, but if they are not
 NULL then the caller is responsible for ensuring sufficient memory is allocated.
 
-Implementors of async aware code (e.g. engines) are encouraged to return a
+Implementers of async aware code (e.g. engines) are encouraged to return a
 stable fd for the lifetime of the B<ASYNC_WAIT_CTX> in order to reduce the
 "churn" of regularly changing fds - although no guarantees of this are provided
 to applications.

--- a/doc/man3/CMS_verify.pod
+++ b/doc/man3/CMS_verify.pod
@@ -38,7 +38,7 @@ I<flags> is an optional set of flags, which can be used to modify the operation.
 CMS_SignedData_verify() is like CMS_verify() except that
 it operates on B<CMS SignedData> input in the I<sd> argument,
 it has some additional parameters described next,
-and on success it returns the verfied content as a memory BIO.
+and on success it returns the verified content as a memory BIO.
 The optional I<extra> parameter may be used to provide untrusted CA
 certificates that may be helpful for chain building in certificate validation.
 This list of certificates must not contain duplicates.
@@ -132,7 +132,7 @@ timestamp).
 
 CMS_verify() returns 1 for a successful verification and 0 if an error occurred.
 
-CMS_SignedData_verify() returns a memory BIO containing the verfied content,
+CMS_SignedData_verify() returns a memory BIO containing the verified content,
 or NULL on error.
 
 CMS_get0_signers() returns all signers or NULL if an error occurred.

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -193,7 +193,7 @@ clearing the internal CMP transaction (aka session) status, PKIStatusInfo,
 and any previous results (newCert, newChain, caPubs, and extraCertsIn)
 from the last executed transaction.
 It also clears any ITAVs that were added by OSSL_CMP_CTX_push0_genm_ITAV().
-All other field values (i.e., CMP options) are retained for potential re-use.
+All other field values (i.e., CMP options) are retained for potential reuse.
 
 OSSL_CMP_CTX_get0_libctx() returns the I<libctx> argument that was used
 when constructing I<ctx> with OSSL_CMP_CTX_new(), which may be NULL.

--- a/doc/man3/OSSL_HPKE_CTX_new.pod
+++ b/doc/man3/OSSL_HPKE_CTX_new.pod
@@ -189,7 +189,7 @@ modes> and L</Sender-authenticated HPKE Modes>.
 
 HPKE contexts have a role - either sender or receiver. This is used 
 to control which functions can be called and so that senders do not
-re-use a key and nonce with different plaintexts.
+reuse a key and nonce with different plaintexts.
 
 OSSL_HPKE_CTX_free(), OSSL_HPKE_export(), OSSL_HPKE_CTX_set1_psk(), 
 and OSSL_HPKE_CTX_get_seq() can be called regardless of role.
@@ -406,7 +406,7 @@ I<seq> output) that will be used in the next call to seal or open. That would
 return 0 before the first call a sender made to OSSL_HPKE_seal() and 1 after
 that first call.
 
-Note that re-use of the same nonce and key with different plaintexts would
+Note that reuse of the same nonce and key with different plaintexts would
 be very dangerous and could lead to loss of confidentiality and integrity.
 We therefore only support application control over I<seq> for decryption
 (i.e. OSSL_HPKE_open()) operations.

--- a/doc/man3/OSSL_SELF_TEST_new.pod
+++ b/doc/man3/OSSL_SELF_TEST_new.pod
@@ -22,7 +22,7 @@ OSSL_SELF_TEST_onend - functionality to trigger a callback during a self test
 
 =head1 DESCRIPTION
 
-These methods are intended for use by provider implementors, to display
+These methods are intended for use by provider implementers, to display
 diagnostic information during self testing.
 
 OSSL_SELF_TEST_new() allocates an opaque B<OSSL_SELF_TEST> object that has a

--- a/doc/man3/SSL_CTX_new.pod
+++ b/doc/man3/SSL_CTX_new.pod
@@ -100,7 +100,7 @@ provide serialization of access for these cases.
 
 =head1 NOTES
 
-On session estabilishment, by default, no peer credentials verification is done.
+On session establishment, by default, no peer credentials verification is done.
 This must be explicitly requested, typically using L<SSL_CTX_set_verify(3)>.
 For verifying peer certificates many options can be set using various functions
 such as L<SSL_CTX_load_verify_locations(3)> and L<SSL_CTX_set1_param(3)>.

--- a/doc/man3/SSL_new.pod
+++ b/doc/man3/SSL_new.pod
@@ -35,7 +35,7 @@ MUST NOT have yet started the SSL handshake.  For connections that are not in
 their initial state SSL_dup() just increments an internal
 reference count and returns the I<same> handle.  It may be possible to
 use L<SSL_clear(3)> to recycle an SSL handle that is not in its initial
-state for re-use, but this is best avoided.  Instead, save and restore
+state for reuse, but this is best avoided.  Instead, save and restore
 the session, if desired, and construct a fresh handle for each connection.
 
 The subset of settings in I<s> that are duplicated are:

--- a/engines/e_capi.txt
+++ b/engines/e_capi.txt
@@ -6,10 +6,10 @@
 # https://www.openssl.org/source/license.html
 
 #Reason codes
-CAPI_R_CANT_CREATE_HASH_OBJECT:100:cant create hash object
-CAPI_R_CANT_FIND_CAPI_CONTEXT:101:cant find capi context
-CAPI_R_CANT_GET_KEY:102:cant get key
-CAPI_R_CANT_SET_HASH_VALUE:103:cant set hash value
+CAPI_R_CANT_CREATE_HASH_OBJECT:100:can't create hash object
+CAPI_R_CANT_FIND_CAPI_CONTEXT:101:can't find capi context
+CAPI_R_CANT_GET_KEY:102:can't get key
+CAPI_R_CANT_SET_HASH_VALUE:103:can't set hash value
 CAPI_R_CRYPTACQUIRECONTEXT_ERROR:104:cryptacquirecontext error
 CAPI_R_CRYPTENUMPROVIDERS_ERROR:105:cryptenumproviders error
 CAPI_R_DECRYPT_ERROR:106:decrypt error

--- a/engines/e_capi_err.c
+++ b/engines/e_capi_err.c
@@ -14,10 +14,10 @@
 #ifndef OPENSSL_NO_ERR
 
 static ERR_STRING_DATA CAPI_str_reasons[] = {
-    {ERR_PACK(0, 0, CAPI_R_CANT_CREATE_HASH_OBJECT), "cant create hash object"},
-    {ERR_PACK(0, 0, CAPI_R_CANT_FIND_CAPI_CONTEXT), "cant find capi context"},
-    {ERR_PACK(0, 0, CAPI_R_CANT_GET_KEY), "cant get key"},
-    {ERR_PACK(0, 0, CAPI_R_CANT_SET_HASH_VALUE), "cant set hash value"},
+    {ERR_PACK(0, 0, CAPI_R_CANT_CREATE_HASH_OBJECT), "can't create hash object"},
+    {ERR_PACK(0, 0, CAPI_R_CANT_FIND_CAPI_CONTEXT), "can't find capi context"},
+    {ERR_PACK(0, 0, CAPI_R_CANT_GET_KEY), "can't get key"},
+    {ERR_PACK(0, 0, CAPI_R_CANT_SET_HASH_VALUE), "can't set hash value"},
     {ERR_PACK(0, 0, CAPI_R_CRYPTACQUIRECONTEXT_ERROR),
     "cryptacquirecontext error"},
     {ERR_PACK(0, 0, CAPI_R_CRYPTENUMPROVIDERS_ERROR),

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -89,7 +89,7 @@ extern "C" {
 
 /*
  * DLL settings.  This part is a bit tough, because it's up to the
- * application implementor how he or she will link the application, so it
+ * application implementer how he or she will link the application, so it
  * requires some macro to be used.
  */
 # ifdef OPENSSL_SYS_WINDOWS


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
About `re-use` → `reuse`: `reuse` is found in all dictionaries, and more importantly, it already occurs > 100 times in the repository, so this is more a question of consistency than correctness.

Not sure about `implementor` → `implementer`. Both seem acceptable, but most dictionaries suggest `implementer` alone or as a first choice ([Cambridge](https://dictionary.cambridge.org/fr/dictionnaire/anglais/implementer), [Meriam-Webster](https://www.merriam-webster.com/dictionary/implementor)) and the Google Books Ngram database suggests that `implementer` outdistanced `implementor` around 2000, and curiously even more in American than British English:
https://books.google.com/ngrams/graph?content=implementer%2Cimplementor&year_start=1800&year_end=2019&corpus=en-2019

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
