### PR TITLE
KDF doc: expand on 'salt' and 'info' parameters

### DIFF
--- a/doc/man1/openssl-kdf.pod.in
+++ b/doc/man1/openssl-kdf.pod.in
@@ -96,7 +96,7 @@ the password is specified in hexadecimal form (two hex digits per byte).
 
 =item B<salt:>I<string>
 
-Specifies a non-secret random cryptographic salt as an alphanumeric string
+Specifies a non-secret unique cryptographic salt as an alphanumeric string
 (use if it contains printable characters only).
 The length must conform to any restrictions of the KDF algorithm.
 A salt parameter is required for several KDF algorithms,

--- a/doc/man1/openssl-kdf.pod.in
+++ b/doc/man1/openssl-kdf.pod.in
@@ -66,8 +66,7 @@ cases.
 =item B<-kdfopt> I<nm>:I<v>
 
 Passes options to the KDF algorithm.
-A comprehensive list of parameters can be found in the L<EVP_KDF(3)/PARAMETERS>
-implementation documentation.
+A comprehensive list of parameters can be found in L<EVP_KDF(3)/PARAMETERS>.
 Common parameter names used by EVP_KDF_CTX_set_params() are:
 
 =over 4
@@ -110,8 +109,9 @@ specifies the cryptographic salt in hexadecimal form (two hex digits per byte).
 
 =item B<info:>I<string>
 
-Some KDF implementations such as HKDF take an 'info' parameter for binding
-the derived key material to application- and context-specific information.
+Some KDF implementations such as L<EVP_KDF-HKDF(7)> take an 'info' parameter
+for binding the derived key material
+to application- and context-specific information.
 Specifies the info, fixed info, other info or shared info argument
 as an alphanumeric string (use if it contains printable characters only).
 The length must conform to any restrictions of the KDF algorithm.

--- a/doc/man1/openssl-kdf.pod.in
+++ b/doc/man1/openssl-kdf.pod.in
@@ -80,8 +80,8 @@ A key must be specified for most KDF algorithms.
 
 =item B<hexkey:>I<string>
 
-Similar to the B<key:> option, but
-specifies the secret key in hexadecimal form (two hex digits per byte).
+Alternative to the B<key:> option where
+the secret key is specified in hexadecimal form (two hex digits per byte).
 
 =item B<pass:>I<string>
 
@@ -91,8 +91,8 @@ The password must be specified for PBKDF2 and scrypt.
 
 =item B<hexpass:>I<string>
 
-Similar to the B<pass:> option, but
-specifies the password in hexadecimal form (two hex digits per byte).
+Alternative to the B<pass:> option where
+the password is specified in hexadecimal form (two hex digits per byte).
 
 =item B<salt:>I<string>
 
@@ -104,12 +104,12 @@ such as L<EVP_KDF-PBKDF2(7)>.
 
 =item B<hexsalt:>I<string>
 
-Similar to the B<salt:> option, but
-specifies the cryptographic salt in hexadecimal form (two hex digits per byte).
+Alternative to the B<salt:> option where
+the salt is specified in hexadecimal form (two hex digits per byte).
 
 =item B<info:>I<string>
 
-Some KDF implementations such as L<EVP_KDF-HKDF(7)> take an 'info' parameter
+Some KDF implementations, such as L<EVP_KDF-HKDF(7)>, take an 'info' parameter
 for binding the derived key material
 to application- and context-specific information.
 Specifies the info, fixed info, other info or shared info argument
@@ -118,8 +118,8 @@ The length must conform to any restrictions of the KDF algorithm.
 
 =item B<hexinfo:>I<string>
 
-Similar to the B<info:> option,
-but specifies the info in hexadecimal form (two hex digits per byte).
+Alternative to the B<info:> option where
+the info is specified in hexadecimal form (two hex digits per byte).
 
 =item B<digest:>I<string>
 

--- a/doc/man1/openssl-kdf.pod.in
+++ b/doc/man1/openssl-kdf.pod.in
@@ -66,7 +66,7 @@ cases.
 =item B<-kdfopt> I<nm>:I<v>
 
 Passes options to the KDF algorithm.
-A comprehensive list of parameters can be found in the L<EVP_KDF(3)>
+A comprehensive list of parameters can be found in the L<EVP_KDF(3)/PARAMETERS>
 implementation documentation.
 Common parameter names used by EVP_KDF_CTX_set_params() are:
 
@@ -81,7 +81,7 @@ A key must be specified for most KDF algorithms.
 
 =item B<hexkey:>I<string>
 
-As before, but
+Similar to the B<key:> option, but
 specifies the secret key in hexadecimal form (two hex digits per byte).
 
 =item B<pass:>I<string>
@@ -92,7 +92,7 @@ The password must be specified for PBKDF2 and scrypt.
 
 =item B<hexpass:>I<string>
 
-As before, but
+Similar to the B<pass:> option, but
 specifies the password in hexadecimal form (two hex digits per byte).
 
 =item B<salt:>I<string>
@@ -100,11 +100,12 @@ specifies the password in hexadecimal form (two hex digits per byte).
 Specifies a non-secret random cryptographic salt as an alphanumeric string
 (use if it contains printable characters only).
 The length must conform to any restrictions of the KDF algorithm.
-A salt parameter is required for several KDF algorithms, such as PBKDF2.
+A salt parameter is required for several KDF algorithms,
+such as L<EVP_KDF-PBKDF2(7)>.
 
 =item B<hexsalt:>I<string>
 
-As before, but
+Similar to the B<salt:> option, but
 specifies the cryptographic salt in hexadecimal form (two hex digits per byte).
 
 =item B<info:>I<string>
@@ -117,7 +118,8 @@ The length must conform to any restrictions of the KDF algorithm.
 
 =item B<hexinfo:>I<string>
 
-As before, but specifies the info in hexadecimal form (two hex digits per byte).
+Similar to the B<info:> option,
+but specifies the info in hexadecimal form (two hex digits per byte).
 
 =item B<digest:>I<string>
 

--- a/doc/man1/openssl-kdf.pod.in
+++ b/doc/man1/openssl-kdf.pod.in
@@ -66,7 +66,7 @@ cases.
 =item B<-kdfopt> I<nm>:I<v>
 
 Passes options to the KDF algorithm.
-A comprehensive list of parameters can be found in the EVP_KDF_CTX
+A comprehensive list of parameters can be found in the L<EVP_KDF(3)>
 implementation documentation.
 Common parameter names used by EVP_KDF_CTX_set_params() are:
 
@@ -81,9 +81,8 @@ A key must be specified for most KDF algorithms.
 
 =item B<hexkey:>I<string>
 
-Specifies the secret key in hexadecimal form (two hex digits per byte).
-The key length must conform to any restrictions of the KDF algorithm.
-A key must be specified for most KDF algorithms.
+As before, but
+specifies the secret key in hexadecimal form (two hex digits per byte).
 
 =item B<pass:>I<string>
 
@@ -93,8 +92,32 @@ The password must be specified for PBKDF2 and scrypt.
 
 =item B<hexpass:>I<string>
 
-Specifies the password in hexadecimal form (two hex digits per byte).
-The password must be specified for PBKDF2 and scrypt.
+As before, but
+specifies the password in hexadecimal form (two hex digits per byte).
+
+=item B<salt:>I<string>
+
+Specifies a non-secret random cryptographic salt as an alphanumeric string
+(use if it contains printable characters only).
+The length must conform to any restrictions of the KDF algorithm.
+A salt parameter is required for several KDF algorithms, such as PBKDF2.
+
+=item B<hexsalt:>I<string>
+
+As before, but
+specifies the cryptographic salt in hexadecimal form (two hex digits per byte).
+
+=item B<info:>I<string>
+
+Some KDF implementations such as HKDF take an 'info' parameter for binding
+the derived key material to application- and context-specific information.
+Specifies the info, fixed info, other info or shared info argument
+as an alphanumeric string (use if it contains printable characters only).
+The length must conform to any restrictions of the KDF algorithm.
+
+=item B<hexinfo:>I<string>
+
+As before, but specifies the info in hexadecimal form (two hex digits per byte).
 
 =item B<digest:>I<string>
 

--- a/doc/man3/EVP_KDF.pod
+++ b/doc/man3/EVP_KDF.pod
@@ -229,7 +229,7 @@ sets the key.
 
 =item "info" (B<OSSL_KDF_PARAM_INFO>) <octet string>
 
-Some KDF implementations such as L<EVP_KDF-HKDF(7)> take an 'info' parameter
+Some KDF implementations, such as L<EVP_KDF-HKDF(7)>, take an 'info' parameter
 for binding the derived key material
 to application- and context-specific information.
 This parameter sets the info, fixed info, other info or shared info argument.

--- a/doc/man3/EVP_KDF.pod
+++ b/doc/man3/EVP_KDF.pod
@@ -229,8 +229,9 @@ sets the key.
 
 =item "info" (B<OSSL_KDF_PARAM_INFO>) <octet string>
 
-Some KDF implementations such as HKDF take an 'info' parameter for binding
-the derived key material to application- and context-specific information.
+Some KDF implementations such as L<EVP_KDF-HKDF(7)> take an 'info' parameter
+for binding the derived key material
+to application- and context-specific information.
 This parameter sets the info, fixed info, other info or shared info argument.
 You can specify this parameter multiple times, and each instance will
 be concatenated to form the final value.

--- a/doc/man3/EVP_KDF.pod
+++ b/doc/man3/EVP_KDF.pod
@@ -191,7 +191,7 @@ For those KDF implementations that support it, this parameter sets the password.
 
 =item "salt" (B<OSSL_KDF_PARAM_SALT>) <octet string>
 
-Some KDF implementations can take a salt.
+Some KDF implementations can take a non-secret random cryptographic salt.
 For those KDF implementations that support it, this parameter sets the salt.
 
 The default value, if any, is implementation dependent.
@@ -229,7 +229,9 @@ sets the key.
 
 =item "info" (B<OSSL_KDF_PARAM_INFO>) <octet string>
 
-This parameter sets the info, fixed info, other info or shared info value.
+Some KDF implementations such as HKDF take an 'info' parameter for binding
+the derived key material to application- and context-specific information.
+This parameter sets the info, fixed info, other info or shared info argument.
 You can specify this parameter multiple times, and each instance will
 be concatenated to form the final value.
 

--- a/doc/man3/EVP_KDF.pod
+++ b/doc/man3/EVP_KDF.pod
@@ -191,7 +191,7 @@ For those KDF implementations that support it, this parameter sets the password.
 
 =item "salt" (B<OSSL_KDF_PARAM_SALT>) <octet string>
 
-Some KDF implementations can take a non-secret random cryptographic salt.
+Some KDF implementations can take a non-secret unique cryptographic salt.
 For those KDF implementations that support it, this parameter sets the salt.
 
 The default value, if any, is implementation dependent.


### PR DESCRIPTION
 * `EVP_KDF.pod:` extend text on 'salt' and 'info' parameters
* `openssl-kdf.pod.in:` add text on 'salt' and 'info' parameters; small further improvements
