### PR TITLE
Fix unreachable code in cms_main() in apps

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -830,19 +830,18 @@ int cms_main(int argc, char **argv)
         }
 
         if (*argv != NULL) {
-            if (operation == SMIME_ENCRYPT) {
-                for (; *argv != NULL; argv++) {
-                    cert = load_cert(*argv, FORMAT_UNDEF,
-                                     "recipient certificate file");
-                    if (cert == NULL)
-                        goto end;
-                    sk_X509_push(encerts, cert);
-                    cert = NULL;
-                }
-            } else {
-                BIO_printf(bio_err, "Warning: recipient certificate file parameters ignored for operation other than -encrypt\n");
+            for (; *argv != NULL; argv++) {
+                cert = load_cert(*argv, FORMAT_UNDEF,
+                                 "recipient certificate file");
+                if (cert == NULL)
+                    goto end;
+                sk_X509_push(encerts, cert);
+                cert = NULL;
             }
         }
+    } else {
+        if (*argv != NULL)
+            BIO_printf(bio_err, "Warning: recipient certificate file parameters ignored for operation other than -encrypt\n");
     }
 
     if (certfile != NULL) {


### PR DESCRIPTION
I suggest changing code so that there is no unreachable code.
There is a warning in cms_main() on line 843, but it is unreachable 
because on line 817 there is a check 'if (operation == SMIME_ENCRYPT)', and line 843 is in this loop and condition to hit the line 843 is 'operation != SMIME_ENCRYPT'