### PR TITLE
QUIC: Shutdown Drainage

### DIFF
--- a/include/internal/quic_channel.h
+++ b/include/internal/quic_channel.h
@@ -353,6 +353,9 @@ int ossl_quic_channel_has_pending(const QUIC_CHANNEL *ch);
 /* Force transmission of an ACK-eliciting packet. */
 int ossl_quic_channel_ping(QUIC_CHANNEL *ch);
 
+/* For testing use. While enabled, ticking is not performed. */
+void ossl_quic_channel_set_inhibit_tick(QUIC_CHANNEL *ch, int inhibit);
+
 # endif
 
 #endif

--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -99,6 +99,9 @@ uint64_t ossl_quic_set_options(SSL *s, uint64_t opts);
 uint64_t ossl_quic_clear_options(SSL *s, uint64_t opts);
 uint64_t ossl_quic_get_options(const SSL *s);
 
+/* Modifies write buffer size for a stream. */
+__owur int ossl_quic_set_write_buffer_size(SSL *s, size_t size);
+
 /*
  * Used to override ossl_time_now() for debug purposes. While this may be
  * overridden at any time, expect strange results if you change it after

--- a/ssl/quic/quic_channel_local.h
+++ b/ssl/quic/quic_channel_local.h
@@ -404,6 +404,9 @@ struct quic_channel_st {
     /* Permanent net error encountered */
     unsigned int                    net_error                           : 1;
 
+    /* Inhibit tick for testing purposes? */
+    unsigned int                    inhibit_tick                        : 1;
+
     /* Saved error stack in case permanent error was encountered */
     ERR_STATE                       *err_state;
 };

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -55,6 +55,12 @@ static int block_until_pred(QUIC_CONNECTION *qc,
 
     assert(qc->ch != NULL);
 
+    /*
+     * Any attempt to block auto-disables tick inhibition as otherwise we will
+     * hang around forever.
+     */
+    ossl_quic_channel_set_inhibit_tick(qc->ch, 0);
+
     rtor = ossl_quic_channel_get_reactor(qc->ch);
     return ossl_quic_reactor_block_until_pred(rtor, pred, pred_arg, flags,
                                               qc->mutex);

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -182,6 +182,13 @@ struct quic_conn_st {
     /* Have we created a default XSO yet? */
     unsigned int                    default_xso_created     : 1;
 
+    /*
+     * Pre-TERMINATING shutdown phase in which we are flushing streams.
+     * Monotonically transitions to 1.
+     * New streams cannot be created in this state.
+     */
+    unsigned int                    shutting_down           : 1;
+
     /* Default stream type. Defaults to SSL_DEFAULT_STREAM_MODE_AUTO_BIDI. */
     uint32_t                        default_stream_mode;
 

--- a/ssl/quic/quic_tserver.c
+++ b/ssl/quic/quic_tserver.c
@@ -215,9 +215,6 @@ int ossl_quic_tserver_read(QUIC_TSERVER *srv,
     int is_fin = 0;
     QUIC_STREAM *qs;
 
-    if (!ossl_quic_channel_is_active(srv->ch))
-        return 0;
-
     qs = ossl_quic_stream_map_get_by_id(ossl_quic_channel_get_qsm(srv->ch),
                                         stream_id);
     if (qs == NULL) {
@@ -227,10 +224,11 @@ int ossl_quic_tserver_read(QUIC_TSERVER *srv,
 
         /*
          * A client-initiated stream might spontaneously come into existence, so
-         * allow trying to read on a client-initiated stream before it exists.
+         * allow trying to read on a client-initiated stream before it exists,
+         * assuming the connection is still active.
          * Otherwise, fail.
          */
-        if (!is_client_init)
+        if (!is_client_init || !ossl_quic_channel_is_active(srv->ch))
             return 0;
 
         *bytes_read = 0;

--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -2969,8 +2969,9 @@ OSSL_TIME ossl_quic_tx_packetiser_get_deadline(OSSL_QUIC_TX_PACKETISER *txp)
         }
 
     /* When will CC let us send more? */
-    deadline = ossl_time_min(deadline,
-                             txp->args.cc_method->get_wakeup_deadline(txp->args.cc_data));
+    if (txp->args.cc_method->get_tx_allowance(txp->args.cc_data) == 0)
+        deadline = ossl_time_min(deadline,
+                                 txp->args.cc_method->get_wakeup_deadline(txp->args.cc_data));
 
     return deadline;
 }

--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -2141,6 +2141,13 @@ static int txp_generate_stream_frames(OSSL_QUIC_TX_PACKETISER *txp,
         if (shdr->is_fin)
             chunks[(i + 1) % 2].valid = 0;
 
+        /*
+         * We are now committed to our length (shdr->len can't change).
+         * If we truncated the chunk, clear the FIN bit.
+         */
+        if (shdr->len < orig_len)
+            shdr->is_fin = 0;
+
         /* Truncate IOVs to match our chosen length. */
         ossl_quic_sstream_adjust_iov((size_t)shdr->len, chunks[i % 2].iov,
                                      chunks[i % 2].num_stream_iovec);

--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -337,8 +337,17 @@ int qtest_create_quic_connection(QUIC_TSERVER *qtserv, SSL *clientssl)
 int qtest_shutdown(QUIC_TSERVER *qtserv, SSL *clientssl)
 {
     /* Busy loop in non-blocking mode. It should be quick because its local */
-    while (SSL_shutdown(clientssl) != 1)
+    for (;;) {
+        int rc = SSL_shutdown(clientssl);
+
+        if (rc == 1)
+            break;
+
+        if (rc < 0)
+            return 0;
+
         ossl_quic_tserver_tick(qtserv);
+    }
 
     return 1;
 }

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -792,7 +792,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
             first           = 0;
             offset          = 0;
             op_start_time   = ossl_time_now();
-            op_deadline     = ossl_time_add(op_start_time, ossl_ms2time(2000));
+            op_deadline     = ossl_time_add(op_start_time, ossl_ms2time(8000));
         }
 
         if (!TEST_int_le(ossl_time_compare(ossl_time_now(), op_deadline), 0)) {
@@ -2880,7 +2880,7 @@ static const struct script_op script_40[] = {
     OP_C_WRITE              (a, "apple", 5)
 
     OP_C_INHIBIT_TICK       (1)
-    OP_C_SET_WRITE_BUF_SIZE (a, 1024 * 100)
+    OP_C_SET_WRITE_BUF_SIZE (a, 1024 * 100 * 3)
 
     OP_BEGIN_REPEAT         (100)
 
@@ -2957,7 +2957,7 @@ static int test_script(int idx)
     int free_order = idx & 1;
     char script_name[64];
 
-    snprintf(script_name, sizeof(script_name), "script %d", idx);
+    snprintf(script_name, sizeof(script_name), "script %d", script_idx + 1);
 
     TEST_info("Running script %d (order=%d)", script_idx + 1, free_order);
     return run_script(scripts[script_idx], script_name, free_order);

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -119,7 +119,7 @@ struct script_op {
 #define OPK_C_FREE_STREAM                           18
 #define OPK_C_SET_DEFAULT_STREAM_MODE               19
 #define OPK_C_SET_INCOMING_STREAM_POLICY            20
-#define OPK_C_SHUTDOWN                              21
+#define OPK_C_SHUTDOWN_WAIT                         21
 #define OPK_C_EXPECT_CONN_CLOSE_INFO                22
 #define OPK_S_EXPECT_CONN_CLOSE_INFO                23
 #define OPK_S_BIND_STREAM_ID                        24
@@ -142,6 +142,8 @@ struct script_op {
 #define OPK_S_READ_FAIL                             41
 #define OPK_S_SET_INJECT_PLAIN                      42
 #define OPK_SET_INJECT_WORD                         43
+#define OPK_C_INHIBIT_TICK                          44
+#define OPK_C_SET_WRITE_BUF_SIZE                    45
 
 #define EXPECT_CONN_CLOSE_APP       (1U << 0)
 #define EXPECT_CONN_CLOSE_REMOTE    (1U << 1)
@@ -205,8 +207,8 @@ struct script_op {
     {OPK_C_SET_DEFAULT_STREAM_MODE, NULL, (mode), NULL, NULL},
 #define OP_C_SET_INCOMING_STREAM_POLICY(policy) \
     {OPK_C_SET_INCOMING_STREAM_POLICY, NULL, (policy), NULL, NULL},
-#define OP_C_SHUTDOWN() \
-    {OPK_C_SHUTDOWN, NULL, 0, NULL, NULL},
+#define OP_C_SHUTDOWN_WAIT() \
+    {OPK_C_SHUTDOWN_WAIT, NULL, 0, NULL, NULL},
 #define OP_C_EXPECT_CONN_CLOSE_INFO(ec, app, remote)                \
     {OPK_C_EXPECT_CONN_CLOSE_INFO, NULL,                            \
         ((app) ? EXPECT_CONN_CLOSE_APP : 0) |                       \
@@ -257,6 +259,10 @@ struct script_op {
     {OPK_S_SET_INJECT_PLAIN, NULL, 0, NULL, NULL, 0, (f)},
 #define OP_SET_INJECT_WORD(w0, w1) \
     {OPK_SET_INJECT_WORD, NULL, (w0), NULL, NULL, (w1), NULL},
+#define OP_C_INHIBIT_TICK(inhibit) \
+    {OPK_C_INHIBIT_TICK, NULL, (inhibit), NULL, NULL, 0, NULL},
+#define OP_C_SET_WRITE_BUF_SIZE(stream_name, size) \
+    {OPK_C_SET_WRITE_BUF_SIZE, NULL, (size), NULL, #stream_name},
 
 static OSSL_TIME get_time(void *arg)
 {
@@ -1247,9 +1253,12 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
             }
             break;
 
-        case OPK_C_SHUTDOWN:
+        case OPK_C_SHUTDOWN_WAIT:
             {
                 int ret;
+                QUIC_CHANNEL *ch = ossl_quic_conn_get_channel(h->c_conn);
+
+                ossl_quic_channel_set_inhibit_tick(ch, 0);
 
                 if (!TEST_ptr(c_tgt))
                     goto out;
@@ -1258,6 +1267,8 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                 if (!TEST_int_ge(ret, 0))
                     goto out;
 
+                if (ret == 0)
+                    SPIN_AGAIN();
             }
             break;
 
@@ -1498,6 +1509,23 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
         case OPK_SET_INJECT_WORD:
             h->inject_word0 = op->arg1;
             h->inject_word1 = op->arg2;
+            break;
+
+        case OPK_C_INHIBIT_TICK:
+            {
+                QUIC_CHANNEL *ch = ossl_quic_conn_get_channel(h->c_conn);
+
+                ossl_quic_channel_set_inhibit_tick(ch, op->arg1);
+            }
+            break;
+
+        case OPK_C_SET_WRITE_BUF_SIZE:
+            if (!TEST_ptr(c_tgt))
+                goto out;
+
+            if (!TEST_true(ossl_quic_set_write_buffer_size(c_tgt, op->arg1)))
+                goto out;
+
             break;
 
         default:
@@ -1817,7 +1845,7 @@ static const struct script_op script_10[] = {
     OP_S_BIND_STREAM_ID     (a, C_BIDI_ID(0))
     OP_S_READ_EXPECT        (a, "apple", 5)
 
-    OP_C_SHUTDOWN           ()
+    OP_C_SHUTDOWN_WAIT      ()
     OP_C_EXPECT_CONN_CLOSE_INFO(0, 1, 0)
     OP_S_EXPECT_CONN_CLOSE_INFO(0, 1, 1)
 
@@ -2836,6 +2864,46 @@ static const struct script_op script_39[] = {
     OP_S_WRITE              (a, "orange", 5)
 
     OP_C_EXPECT_CONN_CLOSE_INFO(QUIC_ERR_FRAME_ENCODING_ERROR,0,0)
+
+    OP_END
+};
+
+/* 40. Shutdown flush test */
+static const unsigned char script_40_data[1024] = "strawberry";
+
+static const struct script_op script_40[] = {
+    OP_C_SET_ALPN           ("ossltest")
+    OP_C_CONNECT_WAIT       ()
+    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_NONE)
+
+    OP_C_NEW_STREAM_BIDI    (a, C_BIDI_ID(0))
+    OP_C_WRITE              (a, "apple", 5)
+
+    OP_C_INHIBIT_TICK       (1)
+    OP_C_SET_WRITE_BUF_SIZE (a, 1024 * 100)
+
+    OP_BEGIN_REPEAT         (100)
+
+    OP_C_WRITE              (a, script_40_data, sizeof(script_40_data))
+
+    OP_END_REPEAT           ()
+
+    OP_C_CONCLUDE           (a)
+    OP_C_SHUTDOWN_WAIT      ()  /* disengages tick inhibition */
+
+    OP_S_BIND_STREAM_ID     (a, C_BIDI_ID(0))
+    OP_S_READ_EXPECT        (a, "apple", 5)
+
+    OP_BEGIN_REPEAT         (100)
+
+    OP_S_READ_EXPECT        (a, script_40_data, sizeof(script_40_data))
+
+    OP_END_REPEAT           ()
+
+    OP_S_EXPECT_FIN         (a)
+
+    OP_C_EXPECT_CONN_CLOSE_INFO(0, 1, 0)
+    OP_S_EXPECT_CONN_CLOSE_INFO(0, 1, 1)
 
     OP_END
 };

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -133,8 +133,13 @@ static int test_quic_write_read(int idx)
             goto end;
     }
 
-    if (!TEST_true(qtest_shutdown(qtserv, clientquic)))
-        goto end;
+    if (idx < 1)
+        /*
+         * Blocking SSL_shutdown cannot be tested here due to requirement to
+         * tick TSERVER during drainage.
+         */
+        if (!TEST_true(qtest_shutdown(qtserv, clientquic)))
+            goto end;
 
     ret = 1;
 


### PR DESCRIPTION
Built on TXP refactor.

```
f9fab70d02 QUIC APL: Mask API operations when in shutdown flush
de7fffcdfb QUIC MULTISTREAM TEST: Shutdown flush test
7f56873488 QUIC MULTISTREAM TEST: Better failure logging with failing script ID
0b02c068ec QUIC APL: Shutdown Stream Flush Functionality
7b17d639a7 QUIC TXP: Fix bug relating to STREAM FIN generation
94bf6809e9 QUIC APL: Ensure tick inhibition is not used during blocking
02c71a3498 QUIC TSERVER: Allow reading from a stream after connection termination
9aa94ba521 QUIC QSM: Infrastructure for tracking shutdown flush eligible streams
46e0f98a74 QUIC APL: Add internal call to allow changing send buffer size
e733910f5e QUIC CHANNEL: Allow ticking to be inhibited for testing purposes
```

Fixes #21165.