### PR TITLE
x509: add ASN1_STRING_set() check result

### DIFF
--- a/crypto/x509/v3_ist.c
+++ b/crypto/x509/v3_ist.c
@@ -50,43 +50,38 @@ static ISSUER_SIGN_TOOL *v2i_issuer_sign_tool(X509V3_EXT_METHOD *method, X509V3_
         }
         if (strcmp(cnf->name, "signTool") == 0) {
             ist->signTool = ASN1_UTF8STRING_new();
-            if (ist->signTool == NULL) {
+            if (ist->signTool == NULL || !ASN1_STRING_set(ist->signTool, cnf->value, strlen(cnf->value))) {
                 ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
-                ISSUER_SIGN_TOOL_free(ist);
-                return NULL;
+                goto err;
             }
-            ASN1_STRING_set(ist->signTool, cnf->value, strlen(cnf->value));
         } else if (strcmp(cnf->name, "cATool") == 0) {
             ist->cATool = ASN1_UTF8STRING_new();
-            if (ist->cATool == NULL) {
+            if (ist->cATool == NULL || !ASN1_STRING_set(ist->cATool, cnf->value, strlen(cnf->value))) {
                 ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
-                ISSUER_SIGN_TOOL_free(ist);
-                return NULL;
+                goto err;
             }
-            ASN1_STRING_set(ist->cATool, cnf->value, strlen(cnf->value));
         } else if (strcmp(cnf->name, "signToolCert") == 0) {
             ist->signToolCert = ASN1_UTF8STRING_new();
-            if (ist->signToolCert == NULL) {
+            if (ist->signToolCert == NULL || !ASN1_STRING_set(ist->signToolCert, cnf->value, strlen(cnf->value))) {
                 ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
-                ISSUER_SIGN_TOOL_free(ist);
-                return NULL;
+                goto err;
             }
-            ASN1_STRING_set(ist->signToolCert, cnf->value, strlen(cnf->value));
         } else if (strcmp(cnf->name, "cAToolCert") == 0) {
             ist->cAToolCert = ASN1_UTF8STRING_new();
-            if (ist->cAToolCert == NULL) {
+            if (ist->cAToolCert == NULL || !ASN1_STRING_set(ist->cAToolCert, cnf->value, strlen(cnf->value))) {
                 ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
-                ISSUER_SIGN_TOOL_free(ist);
-                return NULL;
+                goto err;
             }
-            ASN1_STRING_set(ist->cAToolCert, cnf->value, strlen(cnf->value));
         } else {
             ERR_raise(ERR_LIB_X509V3, ERR_R_PASSED_INVALID_ARGUMENT);
-            ISSUER_SIGN_TOOL_free(ist);
-            return NULL;
+            goto err;
         }
     }
     return ist;
+
+err:
+    ISSUER_SIGN_TOOL_free(ist);
+    return NULL;
 }
 
 static int i2r_issuer_sign_tool(X509V3_EXT_METHOD *method,


### PR DESCRIPTION
Fixes #21492 

Function `v2i_issuer_sign_tool()` (crypto\x509\v3_ist.c) uses function `ASN1_STRING_set()` to set the ASN1 string, but the result of `ASN1_STRING_set()` execution is not checked, although it may fail.

Added `ASN1_STRING_set()` check result.
