### PR TITLE
Fix error handling in pipelining test

### DIFF
--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -10424,7 +10424,7 @@ end:
     ENGINE_finish(e);
     ENGINE_free(e);
     OPENSSL_free(buf);
-    if (idx == 5)
+    if (fragsize == SSL3_RT_MAX_PLAIN_LENGTH)
         OPENSSL_free(msg);
     return testresult;
 }


### PR DESCRIPTION
When an early error happens in the test_pipelining function and idx == 5 the error handling would try to call OPENSSL_free(msg), but msg is at that time just a string constant in read-only memory, so a
crash would be the result. Fixed that by using
fragsize as an indication when to free msg.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
