### PR TITLE
x509: add X509_STORE_lock() check result

### DIFF
--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -348,7 +348,8 @@ static int get_cert_by_subject_ex(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
          *       sorted and sorting the would result in O(n^2 log n) complexity.
          */
         if (k > 0) {
-            X509_STORE_lock(xl->store_ctx);
+            if (!X509_STORE_lock(xl->store_ctx))
+                goto finish;
             j = sk_X509_OBJECT_find(xl->store_ctx->objs, &stmp);
             tmp = sk_X509_OBJECT_value(xl->store_ctx->objs, j);
             X509_STORE_unlock(xl->store_ctx);
@@ -420,9 +421,10 @@ static int get_cert_by_subject_ex(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
  finish:
     /* If we changed anything, resort the objects for faster lookup */
     if (!sk_X509_OBJECT_is_sorted(xl->store_ctx->objs)) {
-        X509_STORE_lock(xl->store_ctx);
-        sk_X509_OBJECT_sort(xl->store_ctx->objs);
-        X509_STORE_unlock(xl->store_ctx);
+        if(X509_STORE_lock(xl->store_ctx)) {
+            sk_X509_OBJECT_sort(xl->store_ctx->objs);
+            X509_STORE_unlock(xl->store_ctx);
+        }
     }
 
     BUF_MEM_free(b);

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -421,7 +421,7 @@ static int get_cert_by_subject_ex(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
  finish:
     /* If we changed anything, resort the objects for faster lookup */
     if (!sk_X509_OBJECT_is_sorted(xl->store_ctx->objs)) {
-        if(X509_STORE_lock(xl->store_ctx)) {
+        if (X509_STORE_lock(xl->store_ctx)) {
             sk_X509_OBJECT_sort(xl->store_ctx->objs);
             X509_STORE_unlock(xl->store_ctx);
         }


### PR DESCRIPTION
Fixes #21502

Function `get_cert_by_subject_ex()` (crypto\x509\by_dir.c) uses function `X509_STORE_lock()` to lock the store, but the result of `X509_STORE_lock()` execution is not checked, although it may fail.

Added `X509_STORE_lock()`() check result.