### PR TITLE
apps/openssl: propagate the libctx for OPENSSL_TEST_LIBCTX

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -81,6 +81,7 @@ static int apps_startup(void)
             if (app_create_libctx() == NULL)
                 return 0;
         }
+        OSSL_LIB_CTX_set0_default(app_get0_libctx());
     }
 
     return 1;

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -80,8 +80,8 @@ static int apps_startup(void)
         if (strcmp(use_libctx, "1") == 0) {
             if (app_create_libctx() == NULL)
                 return 0;
+            OSSL_LIB_CTX_set0_default(app_get0_libctx());
         }
-        OSSL_LIB_CTX_set0_default(app_get0_libctx());
     }
 
     return 1;


### PR DESCRIPTION
With OPENSSL_TEST_LIBCTX=1 a specific libctx is created and providers are loaded into this libctx.
Within libcrypto functions try to use a libctx but may fall back to some built-in default which is out of sync.
Synchronize the libctx.

Fixes #21516 
