### PR TITLE
Decoder key export fixes

### DIFF
--- a/crypto/encode_decode/decoder_pkey.c
+++ b/crypto/encode_decode/decoder_pkey.c
@@ -155,7 +155,11 @@ static int decoder_construct_pkey(OSSL_DECODER_INSTANCE *decoder_inst,
 
             import_data.keymgmt = keymgmt;
             import_data.keydata = NULL;
-            import_data.selection = data->selection;
+            if (data->selection == 0)
+                /* import/export functions do not tolerate 0 selection */
+                import_data.selection = OSSL_KEYMGMT_SELECT_ALL;
+            else
+                import_data.selection = data->selection;
 
             /*
              * No need to check for errors here, the value of

--- a/providers/implementations/encode_decode/decode_der2key.c
+++ b/providers/implementations/encode_decode/decode_der2key.c
@@ -185,7 +185,12 @@ static int der2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
     void *key = NULL;
     int ok = 0;
 
-    ctx->selection = selection;
+    if (selection == 0)
+        /* import/export functions do not tolerate 0 selection */
+        ctx->selection = OSSL_KEYMGMT_SELECT_ALL;
+    else
+        ctx->selection = selection;
+
     /*
      * The caller is allowed to specify 0 as a selection mark, to have the
      * structure and key type guessed.  For type-specific structures, this

--- a/providers/implementations/encode_decode/decode_der2key.c
+++ b/providers/implementations/encode_decode/decode_der2key.c
@@ -185,12 +185,7 @@ static int der2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
     void *key = NULL;
     int ok = 0;
 
-    if (selection == 0)
-        /* import/export functions do not tolerate 0 selection */
-        ctx->selection = OSSL_KEYMGMT_SELECT_ALL;
-    else
-        ctx->selection = selection;
-
+    ctx->selection = selection;
     /*
      * The caller is allowed to specify 0 as a selection mark, to have the
      * structure and key type guessed.  For type-specific structures, this
@@ -322,10 +317,14 @@ static int der2key_export_object(void *vctx,
     void *keydata;
 
     if (reference_sz == sizeof(keydata) && export != NULL) {
+        int selection = ctx->selection;
+
+        if (selection == 0)
+            selection = OSSL_KEYMGMT_SELECT_ALL;
         /* The contents of the reference is the address to our object */
         keydata = *(void **)reference;
 
-        return export(keydata, ctx->selection, export_cb, export_cbarg);
+        return export(keydata, selection, export_cb, export_cbarg);
     }
     return 0;
 }

--- a/providers/implementations/encode_decode/decode_msblob2key.c
+++ b/providers/implementations/encode_decode/decode_msblob2key.c
@@ -107,7 +107,12 @@ static int msblob2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
     if (!ok)
         goto next;
 
-    ctx->selection = selection;
+    if (selection == 0)
+        /* import/export functions do not tolerate 0 selection */
+        ctx->selection = OSSL_KEYMGMT_SELECT_ALL;
+    else
+        ctx->selection = selection;
+
     ok = 0;                      /* Assume that we fail */
 
     if ((isdss && ctx->desc->type != EVP_PKEY_DSA)

--- a/providers/implementations/encode_decode/decode_msblob2key.c
+++ b/providers/implementations/encode_decode/decode_msblob2key.c
@@ -107,12 +107,7 @@ static int msblob2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
     if (!ok)
         goto next;
 
-    if (selection == 0)
-        /* import/export functions do not tolerate 0 selection */
-        ctx->selection = OSSL_KEYMGMT_SELECT_ALL;
-    else
-        ctx->selection = selection;
-
+    ctx->selection = selection;
     ok = 0;                      /* Assume that we fail */
 
     if ((isdss && ctx->desc->type != EVP_PKEY_DSA)
@@ -214,10 +209,14 @@ msblob2key_export_object(void *vctx,
     void *keydata;
 
     if (reference_sz == sizeof(keydata) && export != NULL) {
+        int selection = ctx->selection;
+
+        if (selection == 0)
+            selection = OSSL_KEYMGMT_SELECT_ALL;
         /* The contents of the reference is the address to our object */
         keydata = *(void **)reference;
 
-        return export(keydata, ctx->selection, export_cb, export_cbarg);
+        return export(keydata, selection, export_cb, export_cbarg);
     }
     return 0;
 }

--- a/providers/implementations/encode_decode/decode_pvk2key.c
+++ b/providers/implementations/encode_decode/decode_pvk2key.c
@@ -91,11 +91,7 @@ static int pvk2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
     if (in == NULL)
         return 0;
 
-    if (selection == 0)
-        /* import/export functions do not tolerate 0 selection */
-        ctx->selection = OSSL_KEYMGMT_SELECT_ALL;
-    else
-        ctx->selection = selection;
+    ctx->selection = selection;
 
     if ((selection == 0
          || (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)
@@ -183,10 +179,14 @@ static int pvk2key_export_object(void *vctx,
     void *keydata;
 
     if (reference_sz == sizeof(keydata) && export != NULL) {
+        int selection = ctx->selection;
+
+        if (selection == 0)
+            selection = OSSL_KEYMGMT_SELECT_ALL;
         /* The contents of the reference is the address to our object */
         keydata = *(void **)reference;
 
-        return export(keydata, ctx->selection, export_cb, export_cbarg);
+        return export(keydata, selection, export_cb, export_cbarg);
     }
     return 0;
 }

--- a/providers/implementations/encode_decode/decode_pvk2key.c
+++ b/providers/implementations/encode_decode/decode_pvk2key.c
@@ -91,7 +91,11 @@ static int pvk2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
     if (in == NULL)
         return 0;
 
-    ctx->selection = selection;
+    if (selection == 0)
+        /* import/export functions do not tolerate 0 selection */
+        ctx->selection = OSSL_KEYMGMT_SELECT_ALL;
+    else
+        ctx->selection = selection;
 
     if ((selection == 0
          || (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -222,11 +222,14 @@ static int dh_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
     if (!ossl_prov_is_running() || dh == NULL)
         return 0;
 
+    if ((selection & DH_POSSIBLE_SELECTIONS) == 0)
+        return 0;
+
     tmpl = OSSL_PARAM_BLD_new();
     if (tmpl == NULL)
         return 0;
 
-    if ((selection & OSSL_KEYMGMT_SELECT_ALL_PARAMETERS) != 0)
+    if ((selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) != 0)
         ok = ok && ossl_dh_params_todata(dh, tmpl, NULL);
 
     if ((selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0) {

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -229,7 +229,7 @@ static int dh_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
     if (tmpl == NULL)
         return 0;
 
-    if ((selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) != 0)
+    if ((selection & OSSL_KEYMGMT_SELECT_ALL_PARAMETERS) != 0)
         ok = ok && ossl_dh_params_todata(dh, tmpl, NULL);
 
     if ((selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0) {

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -223,6 +223,9 @@ static int dsa_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
     if (!ossl_prov_is_running() || dsa == NULL)
         return 0;
 
+    if ((selection & DSA_POSSIBLE_SELECTIONS) == 0)
+        return 0;
+
     tmpl = OSSL_PARAM_BLD_new();
     if (tmpl == NULL)
         return 0;

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -241,6 +241,9 @@ static int ecx_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
     if (!ossl_prov_is_running() || key == NULL)
         return 0;
 
+    if ((selection & OSSL_KEYMGMT_SELECT_KEYPAIR) == 0)
+        return 0;
+
     tmpl = OSSL_PARAM_BLD_new();
     if (tmpl == NULL)
         return 0;

--- a/providers/implementations/keymgmt/mac_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/mac_legacy_kmgmt.c
@@ -275,6 +275,9 @@ static int mac_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
     if (!ossl_prov_is_running() || key == NULL)
         return 0;
 
+    if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) == 0)
+        return 0;
+
     tmpl = OSSL_PARAM_BLD_new();
     if (tmpl == NULL)
         return 0;


### PR DESCRIPTION
This corrects two serious problems - one in decoders where we try to export/import things with 0 selection which is not meaningful and the second in the actual keymgmt export functions which instead of failing on such export call, they produce bogus (empty) keys.

Fixes #21493
