### PR TITLE
Make DH_check set all error bits in recently added error

### DIFF
--- a/crypto/dh/dh_check.c
+++ b/crypto/dh/dh_check.c
@@ -155,6 +155,7 @@ int DH_check(const DH *dh, int *ret)
     /* Don't do any checks at all with an excessively large modulus */
     if (BN_num_bits(dh->params.p) > OPENSSL_DH_CHECK_MAX_MODULUS_BITS) {
         ERR_raise(ERR_LIB_DH, DH_R_MODULUS_TOO_LARGE);
+        *ret = DH_MODULUS_TOO_LARGE | DH_CHECK_P_NOT_PRIME;
         return 0;
     }
 


### PR DESCRIPTION
The pre-existing error cases where DH_check returned zero are not related to the dh params in any way, but are only triggered by out-of-memory errors, therefore having *ret set to zero feels right, but since the new error case is triggered by too large p values that is something different. On the other hand some callers of this function might not be prepared to handle the return value correctly but only rely on *ret. Therefore we set all bits in *reg as an additional saftety measure.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
