### PR TITLE
x509/by_file.c: fix unreachable and redundant code

### DIFF
--- a/crypto/x509/by_file.c
+++ b/crypto/x509/by_file.c
@@ -95,8 +95,7 @@ int X509_load_cert_file_ex(X509_LOOKUP *ctx, const char *file, int type,
 
     if ((in == NULL) || (BIO_read_filename(in, file) <= 0)) {
         ERR_raise(ERR_LIB_X509, ERR_R_BIO_LIB);
-        BIO_free(in);
-        return 0;
+        goto err;
     }
 
     x = X509_new_ex(libctx, propq);
@@ -162,8 +161,7 @@ int X509_load_crl_file(X509_LOOKUP *ctx, const char *file, int type)
 
     if ((in == NULL) || (BIO_read_filename(in, file) <= 0)) {
         ERR_raise(ERR_LIB_X509, ERR_R_BIO_LIB);
-        BIO_free(in);
-        return 0;
+        goto err;
     }
 
     if (type == X509_FILETYPE_PEM) {

--- a/crypto/x509/by_file.c
+++ b/crypto/x509/by_file.c
@@ -115,9 +115,9 @@ int X509_load_cert_file_ex(X509_LOOKUP *ctx, const char *file, int type,
                     break;
                 } else {
                     ERR_clear_last_mark();
-                    if (count == 0)
+                    if (count == 0) {
                         ERR_raise(ERR_LIB_X509, X509_R_NO_CERTIFICATE_FOUND);
-                    else {
+                    } else {
                         ERR_raise(ERR_LIB_X509, ERR_R_PEM_LIB);
                         count = 0;
                     }
@@ -175,9 +175,9 @@ int X509_load_crl_file(X509_LOOKUP *ctx, const char *file, int type)
                     ERR_clear_error();
                     break;
                 } else {
-                    if (count == 0)
+                    if (count == 0) {
                         ERR_raise(ERR_LIB_X509, X509_R_NO_CRL_FOUND);
-                    else {
+                    } else {
                         ERR_raise(ERR_LIB_X509, ERR_R_PEM_LIB);
                         count = 0;
                     }

--- a/crypto/x509/by_file.c
+++ b/crypto/x509/by_file.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2021 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2023 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -58,15 +58,13 @@ static int by_file_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argp,
             if (file)
                 ok = (X509_load_cert_crl_file_ex(ctx, file, X509_FILETYPE_PEM,
                                                  libctx, propq) != 0);
-
             else
                 ok = (X509_load_cert_crl_file_ex(
                          ctx, X509_get_default_cert_file(),
                          X509_FILETYPE_PEM, libctx, propq) != 0);
 
-            if (!ok) {
+            if (!ok)
                 ERR_raise(ERR_LIB_X509, X509_R_LOADING_DEFAULTS);
-            }
         } else {
             if (argl == X509_FILETYPE_PEM)
                 ok = (X509_load_cert_crl_file_ex(ctx, argp, X509_FILETYPE_PEM,
@@ -89,22 +87,21 @@ static int by_file_ctrl(X509_LOOKUP *ctx, int cmd,
 int X509_load_cert_file_ex(X509_LOOKUP *ctx, const char *file, int type,
                            OSSL_LIB_CTX *libctx, const char *propq)
 {
-    int ret = 0;
     BIO *in = NULL;
-    int i, count = 0;
+    int count = 0;
     X509 *x = NULL;
 
     in = BIO_new(BIO_s_file());
+    if (in == NULL) {
+        ERR_raise(ERR_LIB_X509, ERR_R_BUF_LIB);
+        return 0;
+    }
 
-    if ((in == NULL) || (BIO_read_filename(in, file) <= 0)) {
+    if (BIO_read_filename(in, file) <= 0) {
         ERR_raise(ERR_LIB_X509, ERR_R_SYS_LIB);
         goto err;
     }
 
-    if (type != X509_FILETYPE_PEM && type != X509_FILETYPE_ASN1) {
-        ERR_raise(ERR_LIB_X509, X509_R_BAD_X509_FILETYPE);
-        goto err;
-    }
     x = X509_new_ex(libctx, propq);
     if (x == NULL) {
         ERR_raise(ERR_LIB_X509, ERR_R_ASN1_LIB);
@@ -121,34 +118,37 @@ int X509_load_cert_file_ex(X509_LOOKUP *ctx, const char *file, int type,
                     break;
                 } else {
                     ERR_clear_last_mark();
+                    if (count == 0)
+                        ERR_raise(ERR_LIB_X509, X509_R_NO_CERTIFICATE_FOUND);
                     goto err;
                 }
             }
             ERR_clear_last_mark();
-            i = X509_STORE_add_cert(ctx->store_ctx, x);
-            if (!i)
+            if (!X509_STORE_add_cert(ctx->store_ctx, x)) {
+                if (count == 0)
+                    ERR_raise(ERR_LIB_X509, X509_R_NO_CERTIFICATE_FOUND);
                 goto err;
+            }
             count++;
-            X509_free(x);
-            x = NULL;
         }
-        ret = count;
     } else if (type == X509_FILETYPE_ASN1) {
         if (d2i_X509_bio(in, &x) == NULL) {
             ERR_raise(ERR_LIB_X509, ERR_R_ASN1_LIB);
             goto err;
         }
-        i = X509_STORE_add_cert(ctx->store_ctx, x);
-        if (!i)
+        count = X509_STORE_add_cert(ctx->store_ctx, x);
+        if (count == 0) {
+            ERR_raise(ERR_LIB_X509, X509_R_NO_CERTIFICATE_FOUND);
             goto err;
-        ret = i;
+        }
+    } else {
+        ERR_raise(ERR_LIB_X509, X509_R_BAD_X509_FILETYPE);
+        goto err;
     }
-    if (ret == 0)
-        ERR_raise(ERR_LIB_X509, X509_R_NO_CERTIFICATE_FOUND);
- err:
+err:
     X509_free(x);
     BIO_free(in);
-    return ret;
+    return count;
 }
 
 int X509_load_cert_file(X509_LOOKUP *ctx, const char *file, int type)
@@ -158,9 +158,8 @@ int X509_load_cert_file(X509_LOOKUP *ctx, const char *file, int type)
 
 int X509_load_crl_file(X509_LOOKUP *ctx, const char *file, int type)
 {
-    int ret = 0;
     BIO *in = NULL;
-    int i, count = 0;
+    int count = 0;
     X509_CRL *x = NULL;
 
     in = BIO_new(BIO_s_file());
@@ -183,54 +182,52 @@ int X509_load_crl_file(X509_LOOKUP *ctx, const char *file, int type)
                     goto err;
                 }
             }
-            i = X509_STORE_add_crl(ctx->store_ctx, x);
-            if (!i)
+            if (!X509_STORE_add_crl(ctx->store_ctx, x)) {
+				if (count == 0)
+					ERR_raise(ERR_LIB_X509, X509_R_NO_CRL_FOUND);
                 goto err;
+            }
             count++;
-            X509_CRL_free(x);
-            x = NULL;
         }
-        ret = count;
     } else if (type == X509_FILETYPE_ASN1) {
         x = d2i_X509_CRL_bio(in, NULL);
         if (x == NULL) {
             ERR_raise(ERR_LIB_X509, ERR_R_ASN1_LIB);
             goto err;
         }
-        i = X509_STORE_add_crl(ctx->store_ctx, x);
-        if (!i)
+        count = X509_STORE_add_crl(ctx->store_ctx, x);
+        if (count == 0) {
+            ERR_raise(ERR_LIB_X509, X509_R_NO_CRL_FOUND);
             goto err;
-        ret = i;
+        }
     } else {
         ERR_raise(ERR_LIB_X509, X509_R_BAD_X509_FILETYPE);
         goto err;
     }
-    if (ret == 0)
-        ERR_raise(ERR_LIB_X509, X509_R_NO_CRL_FOUND);
  err:
     X509_CRL_free(x);
     BIO_free(in);
-    return ret;
+    return count;
 }
 
 int X509_load_cert_crl_file_ex(X509_LOOKUP *ctx, const char *file, int type,
                                OSSL_LIB_CTX *libctx, const char *propq)
 {
-    STACK_OF(X509_INFO) *inf;
-    X509_INFO *itmp;
-    BIO *in;
+    STACK_OF(X509_INFO) *inf = NULL;
+    X509_INFO *itmp = NULL;
+    BIO *in = NULL;
     int i, count = 0;
 
     if (type != X509_FILETYPE_PEM)
         return X509_load_cert_file_ex(ctx, file, type, libctx, propq);
     in = BIO_new_file(file, "r");
-    if (!in) {
-        ERR_raise(ERR_LIB_X509, ERR_R_SYS_LIB);
+    if (in == NULL) {
+        ERR_raise(ERR_LIB_X509, ERR_R_BUF_LIB);
         return 0;
     }
     inf = PEM_X509_INFO_read_bio_ex(in, NULL, NULL, "", libctx, propq);
     BIO_free(in);
-    if (!inf) {
+    if (inf == NULL) {
         ERR_raise(ERR_LIB_X509, ERR_R_PEM_LIB);
         return 0;
     }


### PR DESCRIPTION
Fixes #21534 

I tried to fix;

1. Unreachable code
    It is impossible to get to lines 146-147 and 208-209 in functions `X509_load_cert_file_ex()` and `X509_load_crl_file()`
```
if (ret == 0)
    ERR_raise(ERR_LIB_X509, X509_R_NO_CERTIFICATE_FOUND);
```
2. Lots of redundant code
For example, in function `X509_load_cert_file_ex()` on line 99, if `in == NULL` call `goto` and execute `BIO_free(in)` (it is NULL) and `X509_CRL_free(x)` (it is NULL also). 
On lines 132-133 execute `X509_CRL_free(x)`, but after that we go to the lines under `err`, where we again do `X509_CRL_free(x)`.
And similar in other places in code.

3. No oiptimal check
On lines 104-107 in `X509_load_cert_file_ex()` there is check 
```
if (type != X509_FILETYPE_PEM && type != X509_FILETYPE_ASN1) {
    ERR_raise(ERR_LIB_X509, X509_R_BAD_X509_FILETYPE);
    goto err;
}
```
but it would be more optimal to use `else {}` on line 146 instead of it

4. Breaking the code style
In function `by_file_ctrl_ex()`