### PR TITLE
Fix CVE-2023-3817 Excessive time spent checking DH q parameter value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -286,7 +286,24 @@ OpenSSL 3.1
 
 ### Changes between 3.1.1 and 3.1.2 [xx XXX xxxx]
 
- * Fix DH_check() excessive time with over sized modulus
+ * Fix excessive time spent checking DH q parameter value.
+
+   The function DH_check() performs various checks on DH parameters. After
+   fixing CVE-2023-3446 it was discovered that a large q parameter value can
+   also trigger an overly long computation during some of these checks.
+   A correct q value, if present, cannot be larger than the modulus p
+   parameter, thus it is unnecessary to perform these checks if q is larger
+   than p.
+
+   If DH_check() is called with such q parameter value,
+   DH_CHECK_INVALID_Q_VALUE return flag is set and the computationally
+   intensive checks are skipped.
+
+   ([CVE-2023-3817])
+
+   *Tomáš Mráz*
+
+ * Fix DH_check() excessive time with over sized modulus.
 
    The function DH_check() performs various checks on DH parameters. One of
    those checks confirms that the modulus ("p" parameter) is not too large.
@@ -323,7 +340,7 @@ OpenSSL 3.1
    has to skip calls to `EVP_DecryptUpdate()` for empty associated data
    entries.
 
-   *Tomas Mraz*
+   *Tomáš Mráz*
 
  * When building with the `enable-fips` option and using the resulting
    FIPS provider, TLS 1.2 will, by default, mandate the use of an extended
@@ -20050,6 +20067,7 @@ ndif
 
 <!-- Links -->
 
+[CVE-2023-3817]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-3817
 [CVE-2023-3446]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-3446
 [CVE-2023-2975]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-2975
 [RFC 2578 (STD 58), section 3.5]: https://datatracker.ietf.org/doc/html/rfc2578#section-3.5

--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,7 @@ OpenSSL 3.1
 
 ### Major changes between OpenSSL 3.1.1 and OpenSSL 3.1.2 [under development]
 
+  * Fix excessive time spent checking DH q parameter value ([CVE-2023-3817])
   * Fix DH_check() excessive time with over sized modulus ([CVE-2023-3446])
   * Do not ignore empty associated data entries with AES-SIV ([CVE-2023-2975])
   * When building with the `enable-fips` option and using the resulting
@@ -1481,6 +1482,7 @@ OpenSSL 0.9.x
 
 <!-- Links -->
 
+[CVE-2023-3817]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-3817
 [CVE-2023-3446]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-3446
 [CVE-2023-2975]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-2975
 [CVE-2023-2650]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-2650

--- a/crypto/dh/dh_check.c
+++ b/crypto/dh/dh_check.c
@@ -143,7 +143,7 @@ int DH_check(const DH *dh, int *ret)
 #ifdef FIPS_MODULE
     return DH_check_params(dh, ret);
 #else
-    int ok = 0, r;
+    int ok = 0, r, q_good = 0;
     BN_CTX *ctx = NULL;
     BIGNUM *t1 = NULL, *t2 = NULL;
     int nid = DH_get_nid((DH *)dh);
@@ -171,6 +171,13 @@ int DH_check(const DH *dh, int *ret)
         goto err;
 
     if (dh->params.q != NULL) {
+        if (BN_ucmp(dh->params.p, dh->params.q) > 0)
+            q_good = 1;
+        else
+            *ret |= DH_CHECK_INVALID_Q_VALUE;
+    }
+
+    if (q_good) {
         if (BN_cmp(dh->params.g, BN_value_one()) <= 0)
             *ret |= DH_NOT_SUITABLE_GENERATOR;
         else if (BN_cmp(dh->params.g, dh->params.p) >= 0)

--- a/test/dhtest.c
+++ b/test/dhtest.c
@@ -124,6 +124,15 @@ static int dh_test(void)
     /* We'll have a stale error on the queue from the above test so clear it */
     ERR_clear_error();
 
+    if (!TEST_ptr(BN_copy(q, p)) || !TEST_true(BN_add(q, q, BN_value_one())))
+        goto err3;
+
+    if (!TEST_true(DH_check(dh, &i)))
+        goto err3;
+    if (!TEST_true(i & DH_CHECK_INVALID_Q_VALUE)
+        || !TEST_false(i & DH_CHECK_Q_NOT_PRIME))
+        goto err3;
+
     /* Modulus of size: dh check max modulus bits + 1 */
     if (!TEST_true(BN_set_word(p, 1))
             || !TEST_true(BN_lshift(p, p, OPENSSL_DH_CHECK_MAX_MODULUS_BITS)))
@@ -134,6 +143,9 @@ static int dh_test(void)
      */
     if (!TEST_false(DH_check(dh, &i)))
         goto err3;
+
+    /* We'll have a stale error on the queue from the above test so clear it */
+    ERR_clear_error();
 
     /*
      * II) key generation


### PR DESCRIPTION
The function DH_check() performs various checks on DH parameters. After
fixing CVE-2023-3446 it was discovered that a large q parameter value can
also trigger an overly long computation during some of these checks.
A correct q value, if present, cannot be larger than the modulus p
parameter, thus it is unnecessary to perform these checks if q is larger
than p.

If DH_check() is called with such q parameter value,
DH_CHECK_INVALID_Q_VALUE return flag is set and the computationally
intensive checks are skipped.
