### PR TITLE
fix compile error (SIZE_MAX not found) on HP-UX

### DIFF
--- a/ssl/priority_queue.c
+++ b/ssl/priority_queue.c
@@ -12,6 +12,7 @@
 #include <assert.h>
 #include "internal/priority_queue.h"
 #include "internal/safe_math.h"
+#include "internal/numbers.h"
 
 OSSL_SAFE_MATH_UNSIGNED(size_t, size_t)
 


### PR DESCRIPTION
Fixes #21554

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
