### PR TITLE
Fix a regression in X509_VERIFY_PARAM_add0_policy()

### DIFF
--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -335,7 +335,10 @@ int X509_VERIFY_PARAM_add0_policy(X509_VERIFY_PARAM *param,
         if (param->policies == NULL)
             return 0;
     }
-    return sk_ASN1_OBJECT_push(param->policies, policy);
+
+    if (sk_ASN1_OBJECT_push(param->policies, policy) <= 0)
+        return 0;
+    return 1;
 }
 
 int X509_VERIFY_PARAM_set1_policies(X509_VERIFY_PARAM *param,
@@ -607,7 +610,10 @@ int X509_VERIFY_PARAM_add0_table(X509_VERIFY_PARAM *param)
             X509_VERIFY_PARAM_free(ptmp);
         }
     }
-    return sk_X509_VERIFY_PARAM_push(param_table, param);
+
+    if (sk_X509_VERIFY_PARAM_push(param_table, param) <= 0)
+        return 0;
+    return 1;
 }
 
 int X509_VERIFY_PARAM_get_count(void)


### PR DESCRIPTION
Also fixes a similar regression in X509_VERIFY_PARAM_add0_table().

Commit 38ebfc3 introduced a regression in 3.0.6 that changed the return value of the two functions above from 1 on success to the number of entries in the stack. If there are more than one entry then this is a change in behaviour which should not have been introduced into a stable release.

This reverts the behaviour back to what it was prior to the change. The code is slightly different to the original code in that we also handle a possible -1 return value from the stack push function. This should never happen in reality because we never pass a NULL stack as a parameter - but for the sake of robustness we handle it anyway.

Note that the changed behaviour exists in all versions of 3.1 (it never had the original version). But 3.1 should be fully backwards compatible with 3.0 so we should change it there too.

Fixes #21570
