### PR TITLE
Misc fixes for s_client with QUIC

### DIFF
--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -1993,9 +1993,6 @@ int ossl_quic_write(SSL *s, const void *buf, size_t len, size_t *written)
 
     *written = 0;
 
-    if (len == 0)
-        return 1;
-
     if (!expect_quic_with_stream_lock(s, /*remote_init=*/0, &ctx))
         return 0;
 
@@ -2018,6 +2015,11 @@ int ossl_quic_write(SSL *s, const void *buf, size_t len, size_t *written)
     /* Ensure correct stream state, stream send part not concluded, etc. */
     if (!quic_validate_for_write(ctx.xso, &err)) {
         ret = QUIC_RAISE_NON_NORMAL_ERROR(&ctx, err, NULL);
+        goto out;
+    }
+
+    if (len == 0) {
+        ret = 1;
         goto out;
     }
 

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -2289,8 +2289,14 @@ static size_t ossl_quic_pending_int(const SSL *s, int check_channel)
     size_t avail = 0;
     int fin = 0;
 
-    if (!expect_quic_with_stream_lock(s, /*remote_init=*/-1, &ctx))
+
+    if (!expect_quic(s, &ctx))
         return 0;
+
+    quic_lock(ctx.qc);
+
+    if (ctx.xso == NULL)
+        goto out;
 
     if (ctx.xso->stream == NULL
         || !ossl_quic_stream_has_recv_buffer(ctx.xso->stream))

--- a/util/quicserver.c
+++ b/util/quicserver.c
@@ -210,11 +210,11 @@ int main(int argc, char *argv[])
 
         ossl_quic_tserver_tick(qtserv);
 
-        if (ossl_quic_tserver_read(qtserv, 0, reqbuf, sizeof(reqbuf),
-                                    &numbytes)) {
-            if (numbytes > 0) {
-                fwrite(reqbuf, 1, numbytes, stdout);
-            }
+        if (ossl_quic_tserver_read(qtserv, 0, reqbuf + reqbytes,
+                                   sizeof(reqbuf) - reqbytes,
+                                   &numbytes)) {
+            if (numbytes > 0)
+                fwrite(reqbuf + reqbytes, 1, numbytes, stdout);
             reqbytes += numbytes;
         }
     } while (reqbytes < sizeof(reqterm)


### PR DESCRIPTION
This same out of trying to make s_client try to play nicely with the quicserver utility (util/quicserver.c).

It turns out that the s_client QUIC functionality was broken sometime after it was implemented by changes in the QUIC code. We need to find a reasonable way of testing s_client in QUIC mode in the test framework (we can't do this at the moment).

I also fixed one error in quicserver which I found when connecting to it from s_client.