### PR TITLE
Backport crypto/armcap.c from master branch at 7b508cd1e1 together with .pl fixes

### DIFF
--- a/crypto/arm_arch.h
+++ b/crypto/arm_arch.h
@@ -102,6 +102,7 @@ extern unsigned int OPENSSL_armv8_rsa_neonized;
 # define ARM_CPU_PART_N1           0xD0C
 # define ARM_CPU_PART_V1           0xD40
 # define ARM_CPU_PART_N2           0xD49
+# define ARM_CPU_PART_V2           0xD4F
 
 # define MIDR_PARTNUM_SHIFT       4
 # define MIDR_PARTNUM_MASK        (0xfffU << MIDR_PARTNUM_SHIFT)

--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2022 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2011-2023 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,17 +10,18 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <setjmp.h>
-#include <signal.h>
 #include <openssl/crypto.h>
 #ifdef __APPLE__
 #include <sys/sysctl.h>
+#else
+#include <setjmp.h>
+#include <signal.h>
 #endif
 #include "internal/cryptlib.h"
-#ifndef _WIN32
-#include <unistd.h>
-#else
+#ifdef _WIN32
 #include <windows.h>
+#else
+#include <unistd.h>
 #endif
 #include "arm_arch.h"
 
@@ -46,7 +47,7 @@ uint32_t OPENSSL_rdtsc(void)
 {
     return 0;
 }
-#elif __ARM_MAX_ARCH__<7
+#elif __ARM_MAX_ARCH__ < 7
 void OPENSSL_cpuid_setup(void)
 {
 }
@@ -55,73 +56,11 @@ uint32_t OPENSSL_rdtsc(void)
 {
     return 0;
 }
-#else
-static sigset_t all_masked;
+#else /* !_WIN32 && __ARM_MAX_ARCH__ >= 7 */
 
-static sigjmp_buf ill_jmp;
-static void ill_handler(int sig)
-{
-    siglongjmp(ill_jmp, sig);
-}
+ /* 3 ways of handling things here: __APPLE__,  getauxval() or SIGILL detect */
 
-/*
- * Following subroutines could have been inlined, but it's not all
- * ARM compilers support inline assembler...
- */
-void _armv7_neon_probe(void);
-void _armv8_aes_probe(void);
-void _armv8_sha1_probe(void);
-void _armv8_sha256_probe(void);
-void _armv8_pmull_probe(void);
-# ifdef __aarch64__
-void _armv8_sm3_probe(void);
-void _armv8_sm4_probe(void);
-void _armv8_eor3_probe(void);
-void _armv8_sha512_probe(void);
-unsigned int _armv8_cpuid_probe(void);
-void _armv8_sve_probe(void);
-void _armv8_sve2_probe(void);
-void _armv8_rng_probe(void);
-
-size_t OPENSSL_rndr_asm(unsigned char *buf, size_t len);
-size_t OPENSSL_rndrrs_asm(unsigned char *buf, size_t len);
-
-size_t OPENSSL_rndr_bytes(unsigned char *buf, size_t len);
-size_t OPENSSL_rndrrs_bytes(unsigned char *buf, size_t len);
-
-static size_t OPENSSL_rndr_wrapper(size_t (*func)(unsigned char *, size_t), unsigned char *buf, size_t len)
-{
-    size_t buffer_size = 0;
-    int i;
-
-    for (i = 0; i < 8; i++) {
-        buffer_size = func(buf, len);
-        if (buffer_size == len)
-            break;
-        usleep(5000);  /* 5000 microseconds (5 milliseconds) */
-    }
-    return buffer_size;
-}
-
-size_t OPENSSL_rndr_bytes(unsigned char *buf, size_t len)
-{
-    return OPENSSL_rndr_wrapper(OPENSSL_rndr_asm, buf, len);
-}
-
-size_t OPENSSL_rndrrs_bytes(unsigned char *buf, size_t len)
-{
-    return OPENSSL_rndr_wrapper(OPENSSL_rndrrs_asm, buf, len);
-}
-# endif
-uint32_t _armv7_tick(void);
-
-uint32_t OPENSSL_rdtsc(void)
-{
-    if (OPENSSL_armcap_P & ARMV7_TICK)
-        return _armv7_tick();
-    else
-        return 0;
-}
+ /* First determine if getauxval() is available (OSSL_IMPLEMENT_GETAUXVAL) */
 
 # if defined(__GNUC__) && __GNUC__>=2
 void OPENSSL_cpuid_setup(void) __attribute__ ((constructor));
@@ -161,10 +100,10 @@ static unsigned long getauxval(unsigned long key)
  * Android: according to https://developer.android.com/ndk/guides/cpu-features,
  * getauxval is supported starting with API level 18
  */
-#  if defined(__ANDROID__) && defined(__ANDROID_API__) && __ANDROID_API__ >= 18
-#   include <sys/auxv.h>
-#   define OSSL_IMPLEMENT_GETAUXVAL
-#  endif
+# if defined(__ANDROID__) && defined(__ANDROID_API__) && __ANDROID_API__ >= 18
+#  include <sys/auxv.h>
+#  define OSSL_IMPLEMENT_GETAUXVAL
+# endif
 
 /*
  * ARM puts the feature bits for Crypto Extensions in AT_HWCAP2, whereas
@@ -177,40 +116,144 @@ static unsigned long getauxval(unsigned long key)
 #  define AT_HWCAP2              26
 # endif
 # if defined(__arm__) || defined (__arm)
-#  define HWCAP                  AT_HWCAP
-#  define HWCAP_NEON             (1 << 12)
+#  define OSSL_HWCAP                  AT_HWCAP
+#  define OSSL_HWCAP_NEON             (1 << 12)
 
-#  define HWCAP_CE               AT_HWCAP2
-#  define HWCAP_CE_AES           (1 << 0)
-#  define HWCAP_CE_PMULL         (1 << 1)
-#  define HWCAP_CE_SHA1          (1 << 2)
-#  define HWCAP_CE_SHA256        (1 << 3)
+#  define OSSL_HWCAP_CE               AT_HWCAP2
+#  define OSSL_HWCAP_CE_AES           (1 << 0)
+#  define OSSL_HWCAP_CE_PMULL         (1 << 1)
+#  define OSSL_HWCAP_CE_SHA1          (1 << 2)
+#  define OSSL_HWCAP_CE_SHA256        (1 << 3)
 # elif defined(__aarch64__)
-#  define HWCAP                  AT_HWCAP
-#  define HWCAP_NEON             (1 << 1)
+#  define OSSL_HWCAP                  AT_HWCAP
+#  define OSSL_HWCAP_NEON             (1 << 1)
 
-#  define HWCAP_CE               HWCAP
-#  define HWCAP_CE_AES           (1 << 3)
-#  define HWCAP_CE_PMULL         (1 << 4)
-#  define HWCAP_CE_SHA1          (1 << 5)
-#  define HWCAP_CE_SHA256        (1 << 6)
-#  define HWCAP_CPUID            (1 << 11)
-#  define HWCAP_SHA3             (1 << 17)
-#  define HWCAP_CE_SM3           (1 << 18)
-#  define HWCAP_CE_SM4           (1 << 19)
-#  define HWCAP_CE_SHA512        (1 << 21)
-#  define HWCAP_SVE              (1 << 22)
-                                  /* AT_HWCAP2 */
-#  define HWCAP2                 26
-#  define HWCAP2_SVE2            (1 << 1)
-#  define HWCAP2_RNG             (1 << 16)
+#  define OSSL_HWCAP_CE               AT_HWCAP
+#  define OSSL_HWCAP_CE_AES           (1 << 3)
+#  define OSSL_HWCAP_CE_PMULL         (1 << 4)
+#  define OSSL_HWCAP_CE_SHA1          (1 << 5)
+#  define OSSL_HWCAP_CE_SHA256        (1 << 6)
+#  define OSSL_HWCAP_CPUID            (1 << 11)
+#  define OSSL_HWCAP_SHA3             (1 << 17)
+#  define OSSL_HWCAP_CE_SM3           (1 << 18)
+#  define OSSL_HWCAP_CE_SM4           (1 << 19)
+#  define OSSL_HWCAP_CE_SHA512        (1 << 21)
+#  define OSSL_HWCAP_SVE              (1 << 22)
+                                      /* AT_HWCAP2 */
+#  define OSSL_HWCAP2                 26
+#  define OSSL_HWCAP2_SVE2            (1 << 1)
+#  define OSSL_HWCAP2_RNG             (1 << 16)
+# endif
+
+uint32_t _armv7_tick(void);
+
+uint32_t OPENSSL_rdtsc(void)
+{
+    if (OPENSSL_armcap_P & ARMV7_TICK)
+        return _armv7_tick();
+    else
+        return 0;
+}
+
+# ifdef __aarch64__
+size_t OPENSSL_rndr_asm(unsigned char *buf, size_t len);
+size_t OPENSSL_rndrrs_asm(unsigned char *buf, size_t len);
+
+size_t OPENSSL_rndr_bytes(unsigned char *buf, size_t len);
+size_t OPENSSL_rndrrs_bytes(unsigned char *buf, size_t len);
+
+static size_t OPENSSL_rndr_wrapper(size_t (*func)(unsigned char *, size_t), unsigned char *buf, size_t len)
+{
+    size_t buffer_size = 0;
+    int i;
+
+    for (i = 0; i < 8; i++) {
+        buffer_size = func(buf, len);
+        if (buffer_size == len)
+            break;
+        usleep(5000);  /* 5000 microseconds (5 milliseconds) */
+    }
+    return buffer_size;
+}
+
+size_t OPENSSL_rndr_bytes(unsigned char *buf, size_t len)
+{
+    return OPENSSL_rndr_wrapper(OPENSSL_rndr_asm, buf, len);
+}
+
+size_t OPENSSL_rndrrs_bytes(unsigned char *buf, size_t len)
+{
+    return OPENSSL_rndr_wrapper(OPENSSL_rndrrs_asm, buf, len);
+}
+# endif
+
+# if !defined(__APPLE__) && !defined(OSSL_IMPLEMENT_GETAUXVAL)
+static sigset_t all_masked;
+
+static sigjmp_buf ill_jmp;
+static void ill_handler(int sig)
+{
+    siglongjmp(ill_jmp, sig);
+}
+
+/*
+ * Following subroutines could have been inlined, but not all
+ * ARM compilers support inline assembler, and we'd then have to
+ * worry about the compiler optimising out the detection code...
+ */
+void _armv7_neon_probe(void);
+void _armv8_aes_probe(void);
+void _armv8_sha1_probe(void);
+void _armv8_sha256_probe(void);
+void _armv8_pmull_probe(void);
+#  ifdef __aarch64__
+void _armv8_sm3_probe(void);
+void _armv8_sm4_probe(void);
+void _armv8_sha512_probe(void);
+void _armv8_eor3_probe(void);
+void _armv8_sve_probe(void);
+void _armv8_sve2_probe(void);
+void _armv8_rng_probe(void);
+#  endif
+# endif /* !__APPLE__ && !OSSL_IMPLEMENT_GETAUXVAL */
+
+/* We only call _armv8_cpuid_probe() if (OPENSSL_armcap_P & ARMV8_CPUID) != 0 */
+unsigned int _armv8_cpuid_probe(void);
+
+# if defined(__APPLE__)
+/*
+ * Checks the specified integer sysctl, returning `value` if it's 1, otherwise returning 0.
+ */
+static unsigned int sysctl_query(const char *name, unsigned int value)
+{
+    unsigned int sys_value = 0;
+    size_t len = sizeof(sys_value);
+
+    return (sysctlbyname(name, &sys_value, &len, NULL, 0) == 0 && sys_value == 1) ? value : 0;
+}
+# elif !defined(OSSL_IMPLEMENT_GETAUXVAL)
+/*
+ * Calls a provided probe function, which may SIGILL. If it doesn't, return `value`, otherwise return 0.
+ */
+static unsigned int arm_probe_for(void (*probe)(void), volatile unsigned int value)
+{
+    if (sigsetjmp(ill_jmp, 1) == 0) {
+        probe();
+        return value;
+    } else {
+        /* The probe function gave us SIGILL */
+        return 0;
+    }
+}
 # endif
 
 void OPENSSL_cpuid_setup(void)
 {
     const char *e;
+# if !defined(__APPLE__) && !defined(OSSL_IMPLEMENT_GETAUXVAL)
     struct sigaction ill_oact, ill_act;
     sigset_t oset;
+# endif
     static int trigger = 0;
 
     if (trigger)
@@ -225,7 +268,7 @@ void OPENSSL_cpuid_setup(void)
     }
 
 # if defined(__APPLE__)
-#   if !defined(__aarch64__)
+#  if !defined(__aarch64__)
     /*
      * Capability probing by catching SIGILL appears to be problematic
      * on iOS. But since Apple universe is "monocultural", it's actually
@@ -235,77 +278,82 @@ void OPENSSL_cpuid_setup(void)
         OPENSSL_armcap_P = ARMV7_NEON;
         return;
     }
-    /*
-     * One could do same even for __aarch64__ iOS builds. It's not done
-     * exclusively for reasons of keeping code unified across platforms.
-     * Unified code works because it never triggers SIGILL on Apple
-     * devices...
-     */
-#   else
+#  else
     {
-        unsigned int feature;
-        size_t len = sizeof(feature);
-        char uarch[64];
+        /*
+         * From
+         * https://github.com/llvm/llvm-project/blob/412237dcd07e5a2afbb1767858262a5f037149a3/llvm/lib/Target/AArch64/AArch64.td#L719
+         * all of these have been available on 64-bit Apple Silicon from the
+         * beginning (the A7).
+         */
+        OPENSSL_armcap_P |= ARMV7_NEON | ARMV8_PMULL | ARMV8_AES | ARMV8_SHA1 | ARMV8_SHA256;
 
-        if (sysctlbyname("hw.optional.armv8_2_sha512", &feature, &len, NULL, 0) == 0 && feature == 1)
-            OPENSSL_armcap_P |= ARMV8_SHA512;
-        feature = 0;
-        if (sysctlbyname("hw.optional.armv8_2_sha3", &feature, &len, NULL, 0) == 0 && feature == 1) {
-            OPENSSL_armcap_P |= ARMV8_SHA3;
-            len = sizeof(uarch);
+        /* More recent extensions are indicated by sysctls */
+        OPENSSL_armcap_P |= sysctl_query("hw.optional.armv8_2_sha512", ARMV8_SHA512);
+        OPENSSL_armcap_P |= sysctl_query("hw.optional.armv8_2_sha3", ARMV8_SHA3);
+
+        if (OPENSSL_armcap_P & ARMV8_SHA3) {
+            char uarch[64];
+
+            size_t len = sizeof(uarch);
             if ((sysctlbyname("machdep.cpu.brand_string", uarch, &len, NULL, 0) == 0) &&
-                (strncmp(uarch, "Apple M1", 8) == 0))
+               ((strncmp(uarch, "Apple M1", 8) == 0) ||
+                (strncmp(uarch, "Apple M2", 8) == 0))) {
                 OPENSSL_armcap_P |= ARMV8_UNROLL8_EOR3;
+            }
         }
     }
-#   endif
-# endif
+#  endif       /* __aarch64__ */
 
-# ifdef OSSL_IMPLEMENT_GETAUXVAL
-    if (getauxval(HWCAP) & HWCAP_NEON) {
-        unsigned long hwcap = getauxval(HWCAP_CE);
+# elif defined(OSSL_IMPLEMENT_GETAUXVAL)
+
+    if (getauxval(OSSL_HWCAP) & OSSL_HWCAP_NEON) {
+        unsigned long hwcap = getauxval(OSSL_HWCAP_CE);
 
         OPENSSL_armcap_P |= ARMV7_NEON;
 
-        if (hwcap & HWCAP_CE_AES)
+        if (hwcap & OSSL_HWCAP_CE_AES)
             OPENSSL_armcap_P |= ARMV8_AES;
 
-        if (hwcap & HWCAP_CE_PMULL)
+        if (hwcap & OSSL_HWCAP_CE_PMULL)
             OPENSSL_armcap_P |= ARMV8_PMULL;
 
-        if (hwcap & HWCAP_CE_SHA1)
+        if (hwcap & OSSL_HWCAP_CE_SHA1)
             OPENSSL_armcap_P |= ARMV8_SHA1;
 
-        if (hwcap & HWCAP_CE_SHA256)
+        if (hwcap & OSSL_HWCAP_CE_SHA256)
             OPENSSL_armcap_P |= ARMV8_SHA256;
 
 #  ifdef __aarch64__
-        if (hwcap & HWCAP_CE_SM4)
+        if (hwcap & OSSL_HWCAP_CE_SM4)
             OPENSSL_armcap_P |= ARMV8_SM4;
 
-        if (hwcap & HWCAP_CE_SHA512)
+        if (hwcap & OSSL_HWCAP_CE_SHA512)
             OPENSSL_armcap_P |= ARMV8_SHA512;
 
-        if (hwcap & HWCAP_CPUID)
+        if (hwcap & OSSL_HWCAP_CPUID)
             OPENSSL_armcap_P |= ARMV8_CPUID;
 
-        if (hwcap & HWCAP_CE_SM3)
+        if (hwcap & OSSL_HWCAP_CE_SM3)
             OPENSSL_armcap_P |= ARMV8_SM3;
-        if (hwcap & HWCAP_SHA3)
+        if (hwcap & OSSL_HWCAP_SHA3)
             OPENSSL_armcap_P |= ARMV8_SHA3;
 #  endif
     }
 #  ifdef __aarch64__
-        if (getauxval(HWCAP) & HWCAP_SVE)
+        if (getauxval(OSSL_HWCAP) & OSSL_HWCAP_SVE)
             OPENSSL_armcap_P |= ARMV8_SVE;
 
-        if (getauxval(HWCAP2) & HWCAP2_SVE2)
+        if (getauxval(OSSL_HWCAP2) & OSSL_HWCAP2_SVE2)
             OPENSSL_armcap_P |= ARMV8_SVE2;
 
-        if (getauxval(HWCAP2) & HWCAP2_RNG)
+        if (getauxval(OSSL_HWCAP2) & OSSL_HWCAP2_RNG)
             OPENSSL_armcap_P |= ARMV8_RNG;
 #  endif
-# endif
+
+# else /* !__APPLE__ && !OSSL_IMPLEMENT_GETAUXVAL */
+
+    /* If all else fails, do brute force SIGILL-based feature detection */
 
     sigfillset(&all_masked);
     sigdelset(&all_masked, SIGILL);
@@ -321,73 +369,41 @@ void OPENSSL_cpuid_setup(void)
     sigprocmask(SIG_SETMASK, &ill_act.sa_mask, &oset);
     sigaction(SIGILL, &ill_act, &ill_oact);
 
-    /* If we used getauxval, we already have all the values */
-# ifndef OSSL_IMPLEMENT_GETAUXVAL
-    if (sigsetjmp(ill_jmp, 1) == 0) {
-        _armv7_neon_probe();
-        OPENSSL_armcap_P |= ARMV7_NEON;
-        if (sigsetjmp(ill_jmp, 1) == 0) {
-            _armv8_pmull_probe();
-            OPENSSL_armcap_P |= ARMV8_PMULL | ARMV8_AES;
-        } else if (sigsetjmp(ill_jmp, 1) == 0) {
-            _armv8_aes_probe();
-            OPENSSL_armcap_P |= ARMV8_AES;
-        }
-        if (sigsetjmp(ill_jmp, 1) == 0) {
-            _armv8_sha1_probe();
-            OPENSSL_armcap_P |= ARMV8_SHA1;
-        }
-        if (sigsetjmp(ill_jmp, 1) == 0) {
-            _armv8_sha256_probe();
-            OPENSSL_armcap_P |= ARMV8_SHA256;
-        }
-#  if defined(__aarch64__) && !defined(__APPLE__)
-        if (sigsetjmp(ill_jmp, 1) == 0) {
-            _armv8_sm4_probe();
-            OPENSSL_armcap_P |= ARMV8_SM4;
+    OPENSSL_armcap_P |= arm_probe_for(_armv7_neon_probe, ARMV7_NEON);
+
+    if (OPENSSL_armcap_P & ARMV7_NEON) {
+
+        OPENSSL_armcap_P |= arm_probe_for(_armv8_pmull_probe, ARMV8_PMULL | ARMV8_AES);
+        if (!(OPENSSL_armcap_P & ARMV8_AES)) {
+            OPENSSL_armcap_P |= arm_probe_for(_armv8_aes_probe, ARMV8_AES);
         }
 
-        if (sigsetjmp(ill_jmp, 1) == 0) {
-            _armv8_sha512_probe();
-            OPENSSL_armcap_P |= ARMV8_SHA512;
-        }
+        OPENSSL_armcap_P |= arm_probe_for(_armv8_sha1_probe, ARMV8_SHA1);
+        OPENSSL_armcap_P |= arm_probe_for(_armv8_sha256_probe, ARMV8_SHA256);
 
-        if (sigsetjmp(ill_jmp, 1) == 0) {
-            _armv8_sm3_probe();
-            OPENSSL_armcap_P |= ARMV8_SM3;
-        }
-        if (sigsetjmp(ill_jmp, 1) == 0) {
-            _armv8_eor3_probe();
-            OPENSSL_armcap_P |= ARMV8_SHA3;
-        }
+#  if defined(__aarch64__)
+        OPENSSL_armcap_P |= arm_probe_for(_armv8_sm3_probe, ARMV8_SM3);
+        OPENSSL_armcap_P |= arm_probe_for(_armv8_sm4_probe, ARMV8_SM4);
+        OPENSSL_armcap_P |= arm_probe_for(_armv8_sha512_probe, ARMV8_SHA512);
+        OPENSSL_armcap_P |= arm_probe_for(_armv8_eor3_probe, ARMV8_SHA3);
 #  endif
     }
-#  if defined(__aarch64__) && !defined(__APPLE__)
-    if (sigsetjmp(ill_jmp, 1) == 0) {
-        _armv8_sve_probe();
-        OPENSSL_armcap_P |= ARMV8_SVE;
-    }
-
-    if (sigsetjmp(ill_jmp, 1) == 0) {
-        _armv8_sve2_probe();
-        OPENSSL_armcap_P |= ARMV8_SVE2;
-    }
-
-    if (sigsetjmp(ill_jmp, 1) == 0) {
-        _armv8_rng_probe();
-        OPENSSL_armcap_P |= ARMV8_RNG;
-    }
+#  ifdef __aarch64__
+    OPENSSL_armcap_P |= arm_probe_for(_armv8_sve_probe, ARMV8_SVE);
+    OPENSSL_armcap_P |= arm_probe_for(_armv8_sve2_probe, ARMV8_SVE2);
+    OPENSSL_armcap_P |= arm_probe_for(_armv8_rng_probe, ARMV8_RNG);
 #  endif
-# endif
 
     /*
      * Probing for ARMV7_TICK is known to produce unreliable results,
-     * so we will only use the feature when the user explicitly enables
-     * it with OPENSSL_armcap.
+     * so we only use the feature when the user explicitly enables it
+     * with OPENSSL_armcap.
      */
 
     sigaction(SIGILL, &ill_oact, NULL);
     sigprocmask(SIG_SETMASK, &oset, NULL);
+
+# endif /* __APPLE__, OSSL_IMPLEMENT_GETAUXVAL */
 
 # ifdef __aarch64__
     if (OPENSSL_armcap_P & ARMV8_CPUID)
@@ -399,9 +415,10 @@ void OPENSSL_cpuid_setup(void)
             OPENSSL_armv8_rsa_neonized = 1;
     }
     if ((MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_V1) ||
-         MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_N2)) &&
+         MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_N2) ||
+         MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_V2)) &&
         (OPENSSL_armcap_P & ARMV8_SHA3))
         OPENSSL_armcap_P |= ARMV8_UNROLL8_EOR3;
 # endif
 }
-#endif
+#endif /* _WIN32, __ARM_MAX_ARCH__ >= 7 */

--- a/crypto/armv4cpuid.pl
+++ b/crypto/armv4cpuid.pl
@@ -292,8 +292,7 @@ atomic_add_spinlock:
 .word	0
 #endif
 
-.comm	OPENSSL_armcap_P,4,4
-.hidden	OPENSSL_armcap_P
+.extern	OPENSSL_armcap_P
 ___
 
 print $code;

--- a/crypto/bn/asm/armv4-gf2m.pl
+++ b/crypto/bn/asm/armv4-gf2m.pl
@@ -325,7 +325,7 @@ $code.=<<___;
 .align	5
 
 #if __ARM_MAX_ARCH__>=7
-.comm	OPENSSL_armcap_P,4,4
+.extern	OPENSSL_armcap_P
 #endif
 ___
 

--- a/crypto/bn/asm/armv4-mont.pl
+++ b/crypto/bn/asm/armv4-mont.pl
@@ -749,7 +749,7 @@ $code.=<<___;
 .asciz	"Montgomery multiplication for ARMv4/NEON, CRYPTOGAMS by <appro\@openssl.org>"
 .align	2
 #if __ARM_MAX_ARCH__>=7
-.comm	OPENSSL_armcap_P,4,4
+.extern	OPENSSL_armcap_P
 #endif
 ___
 

--- a/crypto/chacha/asm/chacha-armv4.pl
+++ b/crypto/chacha/asm/chacha-armv4.pl
@@ -1154,7 +1154,7 @@ $code.=<<___;
 	add		sp,sp,#4*(16+3)
 	ldmia		sp!,{r4-r11,pc}
 .size	ChaCha20_neon,.-ChaCha20_neon
-.comm	OPENSSL_armcap_P,4,4
+.extern	OPENSSL_armcap_P
 #endif
 ___
 }}}

--- a/crypto/poly1305/asm/poly1305-armv4.pl
+++ b/crypto/poly1305/asm/poly1305-armv4.pl
@@ -1239,7 +1239,7 @@ $code.=<<___;
 .asciz	"Poly1305 for ARMv4/NEON, CRYPTOGAMS by <appro\@openssl.org>"
 .align	2
 #if	__ARM_MAX_ARCH__>=7
-.comm   OPENSSL_armcap_P,4,4
+.extern   OPENSSL_armcap_P
 #endif
 ___
 

--- a/crypto/sha/asm/sha1-armv4-large.pl
+++ b/crypto/sha/asm/sha1-armv4-large.pl
@@ -707,7 +707,7 @@ ___
 }}}
 $code.=<<___;
 #if __ARM_MAX_ARCH__>=7
-.comm	OPENSSL_armcap_P,4,4
+.extern	OPENSSL_armcap_P
 #endif
 ___
 

--- a/crypto/sha/asm/sha256-armv4.pl
+++ b/crypto/sha/asm/sha256-armv4.pl
@@ -693,7 +693,7 @@ $code.=<<___;
 .asciz  "SHA256 block transform for ARMv4/NEON/ARMv8, CRYPTOGAMS by <appro\@openssl.org>"
 .align	2
 #if __ARM_MAX_ARCH__>=7 && !defined(__KERNEL__)
-.comm   OPENSSL_armcap_P,4,4
+.extern   OPENSSL_armcap_P
 #endif
 ___
 

--- a/crypto/sha/asm/sha512-armv4.pl
+++ b/crypto/sha/asm/sha512-armv4.pl
@@ -660,7 +660,7 @@ $code.=<<___;
 .asciz	"SHA512 block transform for ARMv4/NEON, CRYPTOGAMS by <appro\@openssl.org>"
 .align	2
 #if __ARM_MAX_ARCH__>=7 && !defined(__KERNEL__)
-.comm	OPENSSL_armcap_P,4,4
+.extern	OPENSSL_armcap_P
 #endif
 ___
 


### PR DESCRIPTION
This PR has been reviewed and tested for 3.1 only - I will look at 3.0 next.

`crypto/armcap.c` does capability detection for Arm and AArch64 systems on Linux, Apple Silicon-based Darwin (iOS, macOS, etc), Windows, and other operating systems.

On 3.1 and earlier it uses a combination of `sysctl()`, `getauxval()` and `SIGILL`-based capability detection that has grown organically and `SIGILL` handling is done in all nearly cases. This has caused problems on both Apple Silicon and Linux-based systems: `lldb` on Apple Silicon is unable to step over any failing `SIGILL`-based tests, which can thwart developing iOS apps under Xcode; and signals are inherently not thread-safe, causing issues in multi-threaded programs (both macOS and Linux).

`crypto/armcap.c` was significantly refactored in `master`, and will be released in OpenSSL 3.2, but was deemed too great a risk for backporting to 3.0 and 3.1. However, that decision only considered the "debugging-under-Darwin" issues, and not the multi-threaded issues.

While it would be possible to make a smaller update to `armcap.c` than the original refactor, the majority of the work was done in separating out the flows for Apple, `getauxval()` and `SIGILL` rather than the `arm_probe_for()` part of the refactoring.

Making that smaller change in 3.1 (or 3.0) would have almost all the risk that went with doing it in `master` originally, as it would be new code.

The version of `armcap.c` in master has now been used for several months - and indeed some minor problems were found on non-AArch64 systems, but we have fixes for those.

So the approach with least risk appears to be to bring in `armcap.c` from `master` with the associated fixes.

The versions of crypto/armcap.c in master and the 3.1 branch have diverged somewhat.

master:
```
m0 - ba9472c1c1   Update with `ARMV8_HAVE_SHA3_AND_WORTH_USING`
m1 - 08e6eb216c   Move CPU detection to armcap.c
m2 - 7b508cd1e1   Ensure there's only one copy of OPENSSL_armcap_P in libcrypto.a
m3 - 93370db1fc   Avoid duplication of OPENSSL_armcap_P on 32bit ARM
m4 - 52a38144b0   Tidy up aarch64 feature detection code in armcap.c
m5 - 513e103f14   Apply aes-gcm unroll8+eor3 optimization patch to Neoverse V2
m6 - d79bb5316e   Enable AES optimisation on Apple Silicon M2-based systems
m7 - f97ddfc305 * Fix the code used to detect aarch64 capabilities when we don't have getauxval()
```

3.1:
```
b0 - 50af7294e5   Don't do SIGILL capability detection on Apple Silicon
b1 - a6e5003051 * Fix the code used to detect aarch64 capabilities when we don't have getauxval()
b2 - 0703f3f9df   Add two new build targets to enable the possibility of using clang-cl as an assembler for Windows on Arm builds...
b3 - 2e7f6ca65d   Apply the AES-GCM unroll8 optimization patch to Neoverse N2
b4 - a14eff6319   Acceleration of chacha20 on aarch64 by SVE
b5 - 34ca334e5d   Optimize AES-GCM for uarchs with unroll and new instructions
b6 - 37f1828d87   SM4 optimization for ARM by HW instruction
b7 - 654490cebf   SM3 acceleration with SM3 hardware instruction on aarch64
```

`* diff -u armcap-f97ddfc305.c armcap-a6e5003051.c` -- these two versions are identical

The last identical versions are at `f97ddfc305` in master ('m7') and `a6e5003051` in 3.1 ('b1').  The only change following that in 3.1 was a minor change to not use the `SIGILL` capability testing on Apple Silicon, but that doesn't help us on Linux.

In terms of risk, it would be possible to rewrite `armcap.c` on 3.1 differently, with less of a refactor, but the changes would be significant.

The rewrite that went into master was thoroughly tested, and preprocessor output looked at under multiple combinations of compilation options and processor types. One issue was subsequently found, which was partly fixed in `93370db1fc` ('m3') and fully fixed in `7b508cd1e1` ('m2'), although this fixed required (straightforward) changes in multiple assembly (`.pl`) files.

This pull request takes the version of `crypto/armcap.c` at `7b508cd1e1` ('m2') and bringing it into 3.1 as-is with the corresponding assembly changes.

(Note `armcap.c` at `52a38144b0` ('m4') and `7b508cd1e1` ('m2') are identical - the fix was required in the assembly files.)

While this means some performance improvements for Apple Silicon M2 will also come in, in terms of reducing risk having the code as similar as possible will mean any future fixes needed to `armcap.c` can be easily applied.

This version of `armcap.c` will not do `SIGILL` capability detection on Apple Silicon (so matching the latest bug fix on 3.1) and will also not do that on Linux where `getauxval()` is present. This improves stability when debugging on Darwin (macOS/iOS/etc) and in multi-threaded programs (both Darwin and Linux).
