### PR TITLE
applink.c: Optionally suppress preprocessor include lines

### DIFF
--- a/ms/applink.c
+++ b/ms/applink.c
@@ -34,9 +34,18 @@
 #define APPLINK_MAX     22      /* always same as last macro */
 
 #ifndef APPMACROS_ONLY
+
+/*
+ * Normally, do not define APPLINK_NO_INCLUDES.  Define it if you are using
+ * symbol preprocessing and do not want the preprocessing to affect the
+ * following included header files.  You will need to put these
+ * include lines somewhere in the file that is including applink.c.
+ */
+#ifndef APPLINK_NO_INCLUDES
 # include <stdio.h>
 # include <io.h>
 # include <fcntl.h>
+#endif
 
 # ifdef __BORLANDC__
    /* _lseek in <io.h> is a function-like macro so we can't take its address */

--- a/ms/applink.c
+++ b/ms/applink.c
@@ -41,11 +41,11 @@
  * following included header files.  You will need to put these
  * include lines somewhere in the file that is including applink.c.
  */
-#ifndef APPLINK_NO_INCLUDES
-# include <stdio.h>
-# include <io.h>
-# include <fcntl.h>
-#endif
+# ifndef APPLINK_NO_INCLUDES
+#  include <stdio.h>
+#  include <io.h>
+#  include <fcntl.h>
+# endif
 
 # ifdef __BORLANDC__
    /* _lseek in <io.h> is a function-like macro so we can't take its address */


### PR DESCRIPTION
CLA: trivial

Code that includes applink.c can now define APPLINK_NO_INCLUDES to suppress the include preprocessor lines in that file.  This might be needed if, for example, applink.c is being included into a source file that will be compiled to reference a C library built using different calling conventions.  (Example: Open Watcom.)

This pull request is intended to replace an identical pull request that I screwed up.