### PR TITLE
OSSL_PROVIDER_load_ex

### DIFF
--- a/crypto/provider.c
+++ b/crypto/provider.c
@@ -15,15 +15,15 @@
 #include "internal/provider.h"
 #include "provider_local.h"
 
-OSSL_PROVIDER *OSSL_PROVIDER_try_load(OSSL_LIB_CTX *libctx, const char *name,
-                                      int retain_fallbacks)
+OSSL_PROVIDER *OSSL_PROVIDER_try_load_ex(OSSL_LIB_CTX *libctx, const char *name,
+                                         OSSL_PARAM *params, int retain_fallbacks)
 {
     OSSL_PROVIDER *prov = NULL, *actual;
     int isnew = 0;
 
     /* Find it or create it */
     if ((prov = ossl_provider_find(libctx, name, 0)) == NULL) {
-        if ((prov = ossl_provider_new(libctx, name, NULL, 0)) == NULL)
+        if ((prov = ossl_provider_new(libctx, name, NULL, params, 0)) == NULL)
             return NULL;
         isnew = 1;
     }
@@ -49,12 +49,23 @@ OSSL_PROVIDER *OSSL_PROVIDER_try_load(OSSL_LIB_CTX *libctx, const char *name,
     return actual;
 }
 
-OSSL_PROVIDER *OSSL_PROVIDER_load(OSSL_LIB_CTX *libctx, const char *name)
+OSSL_PROVIDER *OSSL_PROVIDER_try_load(OSSL_LIB_CTX *libctx, const char *name,
+                                      int retain_fallbacks)
+{
+    return OSSL_PROVIDER_try_load_ex(libctx, name, NULL, retain_fallbacks);
+}
+
+OSSL_PROVIDER *OSSL_PROVIDER_load_ex(OSSL_LIB_CTX *libctx, const char *name, OSSL_PARAM *params)
 {
     /* Any attempt to load a provider disables auto-loading of defaults */
     if (ossl_provider_disable_fallback_loading(libctx))
-        return OSSL_PROVIDER_try_load(libctx, name, 0);
+        return OSSL_PROVIDER_try_load_ex(libctx, name, params, 0);
     return NULL;
+}
+
+OSSL_PROVIDER *OSSL_PROVIDER_load(OSSL_LIB_CTX *libctx, const char *name)
+{
+    return OSSL_PROVIDER_load_ex(libctx, name, NULL);
 }
 
 int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov)

--- a/crypto/provider_child.c
+++ b/crypto/provider_child.c
@@ -132,7 +132,7 @@ static int provider_create_child_cb(const OSSL_CORE_HANDLE *prov, void *cbdata)
          * init children
          */
         if ((cprov = ossl_provider_new(ctx, provname, ossl_child_provider_init,
-                                       1)) == NULL)
+                                       NULL, 1)) == NULL)
             goto err;
 
         if (!ossl_provider_activate(cprov, 0, 0)) {

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -158,7 +158,7 @@ static int provider_conf_activate(OSSL_LIB_CTX *libctx, const char *name,
         }
         prov = ossl_provider_find(libctx, name, 1);
         if (prov == NULL)
-            prov = ossl_provider_new(libctx, name, NULL, 1);
+            prov = ossl_provider_new(libctx, name, NULL, NULL, 1);
         if (prov == NULL) {
             CRYPTO_THREAD_unlock(pcgbl->lock);
             if (soft)

--- a/doc/designs/prov_loadex.md
+++ b/doc/designs/prov_loadex.md
@@ -35,7 +35,7 @@ Real-world cases
 ----------------
 
 Many applications use PKCS#11 API with a specific drivers. OpenSSL PKCS#11
-provider (https://github.com/latchset/pkcs11-provider) also provides a set of
+provider <https://github.com/latchset/pkcs11-provider> also provides a set of
 tweaks usable in particular situations. So there are at least several scenarios
 I have in mind:
 

--- a/doc/designs/prov_loadex.md
+++ b/doc/designs/prov_loadex.md
@@ -1,0 +1,78 @@
+Providers run-time configuration
+================================
+
+Currently any provider run-time activation requires presence of the
+initialization parameters in the OpenSSL configuration file. Otherwise the
+provider will be activated with some "default" settings, that may or may not
+work for a particular application. For real-world systems it may require
+providing a specially designed OpenSSL config and passing it somehow (e.g. via
+environment) that has its obvious drawbacks.
+
+We need a possibility to initialize providers on per-application level
+according to per-application parameters. It's necessary for example for PKCS#11
+provider (where different applications may use different devices with different
+drivers) and will be useful for some other providers. In case of Red Hat it is
+also usable for FIPS provider.
+
+OpenSSL 3.2 introduces the API
+
+```C
+OSSL_PROVIDER *OSSL_PROVIDER_load_ex(OSSL_LIB_CTX *libctx, const char *name,
+                                     OSSL_PARAM params[]);
+```
+
+intended to configure the provider in load time.
+
+It accepts only parameters of type `OSSL_PARAM_UTF8_STRING` because any
+provider can be initialized from the config file where the values are
+represented as strings and provider init function has to deal with it.
+
+Explicitly configured parameters can contradict the parameters named in the
+configuration file. Here are the current design decisions and some possible
+future steps.
+
+Real-world cases
+----------------
+
+Many applications use PKCS#11 API with a specific drivers. OpenSSL PKCS#11
+provider (https://github.com/latchset/pkcs11-provider) also provides a set of
+tweaks usable in particular situations. So there are at least several scenarios
+I have in mind:
+
+1. Configure a provider in the config file, activate on demand
+2. Load/activate a provider run-time with parameters
+
+Current design
+--------------
+
+When the provider is loaded in the current library context and activated, the
+currently loaded provider will be returned as the result of
+`OSSL_PROVIDER_load_ex` call.
+
+When the provider is loaded in the current library context and NOT activated,
+the parameters provided int the `OSSL_PROVIDER_load_ex` call will have the
+preference.
+
+Separate instances of the provider can be loaded in the separate library
+contexts.
+
+Several instances of the same provider in the same context using different
+section names, module names (e.g. via symlinks) and provider names. But unless
+the provider does not support some configuration options, the algorithms in
+this case will have the same `provider` property and the result of fetching is
+not determined. We strongly discourage against this trick.
+
+The run-time change of the loaded provider configuration is not supported. If
+it is necessary, the calls to `OSSL_PROVIDER_unload` with the following call to
+the `OSSL_PROVIDER_load` or `OSSL_PROVIDER_load_ex` should be used.
+
+Possible future steps
+---------------------
+
+1. We should provide some API function accessing the configuration parameters
+   of a particular provider. Having it, the application will be able to combine
+   some default values with the app-specific ones in more or less intellectual
+   way.
+
+2. We probably should remove the `INFOPAIR` structure and use the `OSSL_PARAM`
+   one instead.

--- a/doc/man3/OSSL_PROVIDER.pod
+++ b/doc/man3/OSSL_PROVIDER.pod
@@ -5,6 +5,7 @@
 OSSL_PROVIDER_set_default_search_path,
 OSSL_PROVIDER_get0_default_search_path,
 OSSL_PROVIDER, OSSL_PROVIDER_load, OSSL_PROVIDER_try_load, OSSL_PROVIDER_unload,
+OSSL_PROVIDER_load_ex, OSSL_PROVIDER_try_load_ex,
 OSSL_PROVIDER_available, OSSL_PROVIDER_do_all,
 OSSL_PROVIDER_gettable_params, OSSL_PROVIDER_get_params,
 OSSL_PROVIDER_query_operation, OSSL_PROVIDER_unquery_operation,
@@ -24,8 +25,13 @@ OSSL_PROVIDER_self_test
  const char *OSSL_PROVIDER_get0_default_search_path(OSSL_LIB_CTX *libctx);
 
  OSSL_PROVIDER *OSSL_PROVIDER_load(OSSL_LIB_CTX *libctx, const char *name);
+ OSSL_PROVIDER *OSSL_PROVIDER_load_ex(OSSL_LIB_CTX *, const char *name,
+                                      OSSL_PARAM *params);
  OSSL_PROVIDER *OSSL_PROVIDER_try_load(OSSL_LIB_CTX *libctx, const char *name,
                                        int retain_fallbacks);
+ OSSL_PROVIDER *OSSL_PROVIDER_try_load_ex(OSSL_LIB_CTX *, const char *name,
+                                          OSSL_PARAM *params,
+                                          int retain_fallbacks);
  int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov);
  int OSSL_PROVIDER_available(OSSL_LIB_CTX *libctx, const char *name);
  int OSSL_PROVIDER_do_all(OSSL_LIB_CTX *ctx,
@@ -100,6 +106,13 @@ it does not disable the fallback providers if the provider cannot be
 loaded and initialized or if I<retain_fallbacks> is nonzero.
 If the provider loads successfully and I<retain_fallbacks> is zero, the
 fallback providers are disabled.
+
+OSSL_PROVIDER_load_ex() and OSSL_PROVIDER_try_load_ex() are the variants
+of the previous functions accepting an C<OSSL_PARAM> array of the parameters
+that are passed as the configuration of the loaded provider. The parameters
+of any type but C<OSSL_PARAM_UTF8_STRING> are silently ignored. If the
+parameters are provided, they replace B<all> the ones specified in the
+configuration file.
 
 OSSL_PROVIDER_unload() unloads the given provider.
 For a provider added with OSSL_PROVIDER_add_builtin(), this simply
@@ -220,6 +233,9 @@ L<openssl-core.h(7)>, L<OSSL_LIB_CTX(3)>, L<provider(7)>
 =head1 HISTORY
 
 The type and functions described here were added in OpenSSL 3.0.
+
+The I<OSSL_PROVIDER_load_ex> and I<OSSL_PROVIDER_try_load_ex> functions were
+added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -32,7 +32,7 @@ OSSL_PROVIDER *ossl_provider_find(OSSL_LIB_CTX *libctx, const char *name,
                                   int noconfig);
 OSSL_PROVIDER *ossl_provider_new(OSSL_LIB_CTX *libctx, const char *name,
                                  OSSL_provider_init_fn *init_function,
-                                 int noconfig);
+                                 OSSL_PARAM *params, int noconfig);
 int ossl_provider_up_ref(OSSL_PROVIDER *prov);
 void ossl_provider_free(OSSL_PROVIDER *prov);
 

--- a/include/openssl/provider.h
+++ b/include/openssl/provider.h
@@ -23,8 +23,13 @@ const char *OSSL_PROVIDER_get0_default_search_path(OSSL_LIB_CTX *libctx);
 
 /* Load and unload a provider */
 OSSL_PROVIDER *OSSL_PROVIDER_load(OSSL_LIB_CTX *, const char *name);
+OSSL_PROVIDER *OSSL_PROVIDER_load_ex(OSSL_LIB_CTX *, const char *name,
+                                     OSSL_PARAM *params);
 OSSL_PROVIDER *OSSL_PROVIDER_try_load(OSSL_LIB_CTX *, const char *name,
                                       int retain_fallbacks);
+OSSL_PROVIDER *OSSL_PROVIDER_try_load_ex(OSSL_LIB_CTX *, const char *name,
+                                         OSSL_PARAM *params,
+                                         int retain_fallbacks);
 int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov);
 int OSSL_PROVIDER_available(OSSL_LIB_CTX *, const char *name);
 int OSSL_PROVIDER_do_all(OSSL_LIB_CTX *ctx,

--- a/test/provider_internal_test.c
+++ b/test/provider_internal_test.c
@@ -64,7 +64,7 @@ static int test_builtin_provider(void)
 
     ret =
         TEST_ptr(prov =
-                 ossl_provider_new(NULL, name, PROVIDER_INIT_FUNCTION_NAME, 0))
+                 ossl_provider_new(NULL, name, PROVIDER_INIT_FUNCTION_NAME, NULL, 0))
         && test_provider(prov, expected_greeting1(name));
 
     EVP_set_default_properties(NULL, "");
@@ -79,7 +79,7 @@ static int test_loaded_provider(void)
     OSSL_PROVIDER *prov = NULL;
 
     return
-        TEST_ptr(prov = ossl_provider_new(NULL, name, NULL, 0))
+        TEST_ptr(prov = ossl_provider_new(NULL, name, NULL, NULL, 0))
         && test_provider(prov, expected_greeting1(name));
 }
 

--- a/test/provider_test.c
+++ b/test/provider_test.c
@@ -9,6 +9,7 @@
 
 #include <stddef.h>
 #include <openssl/provider.h>
+#include <openssl/param_build.h>
 #include "testutil.h"
 
 extern OSSL_provider_init_fn PROVIDER_INIT_FUNCTION_NAME;
@@ -157,6 +158,60 @@ static int test_provider(OSSL_LIB_CTX **libctx, const char *name,
     return ok;
 }
 
+#ifndef NO_PROVIDER_MODULE
+static int test_provider_ex(OSSL_LIB_CTX **libctx, const char *name)
+{
+    OSSL_PROVIDER *prov = NULL;
+    const char *greeting = NULL;
+    int ok = 0;
+    long err;
+    const char custom_buf[] = "Custom greeting";
+    OSSL_PARAM_BLD *bld = OSSL_PARAM_BLD_new();
+    OSSL_PARAM *params = NULL;
+
+    OSSL_PARAM_BLD_push_utf8_string(bld, "greeting", custom_buf, strlen(custom_buf));
+    params = OSSL_PARAM_BLD_to_param(bld);
+
+    OSSL_PARAM_BLD_free(bld);
+
+    if (!TEST_ptr(prov = OSSL_PROVIDER_load_ex(*libctx, name, params)))
+        goto err;
+
+    if (!TEST_true(OSSL_PROVIDER_get_params(prov, greeting_request))
+            || !TEST_ptr(greeting = greeting_request[0].data)
+            || !TEST_size_t_gt(greeting_request[0].data_size, 0)
+            || !TEST_str_eq(greeting, custom_buf))
+        goto err;
+
+    /* Make sure we got the error we were expecting */
+    err = ERR_peek_last_error();
+    if (!TEST_int_gt(err, 0)
+            || !TEST_int_eq(ERR_GET_REASON(err), 1))
+        goto err;
+
+    if (!TEST_true(OSSL_PROVIDER_unload(prov)))
+        goto err;
+    prov = NULL;
+
+    /*
+     * We must free the libctx to force the provider to really be unloaded from
+     * memory
+     */
+    OSSL_LIB_CTX_free(*libctx);
+    *libctx = NULL;
+
+    /* We print out all the data to make sure it can still be accessed */
+    ERR_print_errors_fp(stderr);
+    ok = 1;
+ err:
+    OSSL_PARAM_free(params);
+    OSSL_PROVIDER_unload(prov);
+    OSSL_LIB_CTX_free(*libctx);
+    *libctx = NULL;
+    return ok;
+}
+#endif
+
 static int test_builtin_provider(void)
 {
     OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new();
@@ -211,12 +266,22 @@ static int test_loaded_provider(void)
 {
     OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new();
     const char *name = "p_test";
+    int res = 0;
 
     if (!TEST_ptr(libctx))
         return 0;
 
     /* test_provider will free libctx as part of the test */
-    return test_provider(&libctx, name, NULL);
+    res = test_provider(&libctx, name, NULL);
+
+    libctx = OSSL_LIB_CTX_new();
+    if (!TEST_ptr(libctx))
+        return 0;
+
+    /* test_provider_ex will free libctx as part of the test */
+    res = res && test_provider_ex(&libctx, name);
+
+    return res;
 }
 #endif
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5529,6 +5529,8 @@ OSSL_ERR_STATE_save                     ?	3_2_0	EXIST::FUNCTION:
 OSSL_ERR_STATE_restore                  ?	3_2_0	EXIST::FUNCTION:
 OSSL_ERR_STATE_free                     ?	3_2_0	EXIST::FUNCTION:
 ERR_count_to_mark                       ?	3_2_0	EXIST::FUNCTION:
+OSSL_PROVIDER_load_ex                   ?	3_2_0	EXIST::FUNCTION:
+OSSL_PROVIDER_try_load_ex               ?	3_2_0	EXIST::FUNCTION:
 OSSL_ERR_STATE_save_to_mark             ?	3_2_0	EXIST::FUNCTION:
 X509_STORE_CTX_set_get_crl              ?	3_2_0	EXIST::FUNCTION:
 X509_STORE_CTX_set_current_reasons      ?	3_2_0	EXIST::FUNCTION:


### PR DESCRIPTION
to configure provider in load-time.
The tests are to be written, the documentation is also to be written.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
