### PR TITLE
Make no-autoload-config option work again

### DIFF
--- a/crypto/asn1/a_strnid.c
+++ b/crypto/asn1/a_strnid.c
@@ -129,8 +129,10 @@ ASN1_STRING_TABLE *ASN1_STRING_TABLE_get(int nid)
     int idx;
     ASN1_STRING_TABLE fnd;
 
+#ifndef OPENSSL_NO_AUTOLOAD_CONFIG
     /* "stable" can be impacted by config, so load the config file first */
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+#endif
 
     fnd.nid = nid;
     if (stable != NULL) {

--- a/crypto/engine/eng_table.c
+++ b/crypto/engine/eng_table.c
@@ -201,8 +201,10 @@ ENGINE *ossl_engine_table_select(ENGINE_TABLE **table, int nid,
     ENGINE_PILE tmplate, *fnd = NULL;
     int initres, loop = 0;
 
+#ifndef OPENSSL_NO_AUTOLOAD_CONFIG
     /* Load the config before trying to check if engines are available */
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+#endif
 
     if (!(*table)) {
         OSSL_TRACE3(ENGINE_TABLE,

--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -73,8 +73,10 @@ DEFINE_RUN_ONCE_STATIC(obj_lock_initialise)
 
 static ossl_inline int ossl_init_added_lock(void)
 {
+#ifndef OPENSSL_NO_AUTOLOAD_CONFIG
     /* Make sure we've loaded config before checking for any "added" objects */
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+#endif
     return RUN_ONCE(&ossl_obj_lock_init, obj_lock_initialise);
 }
 

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -124,11 +124,11 @@ void *ossl_ctx_global_properties_new(OSSL_LIB_CTX *ctx)
 }
 
 OSSL_PROPERTY_LIST **ossl_ctx_global_properties(OSSL_LIB_CTX *libctx,
-                                                int loadconfig)
+                                                ossl_unused int loadconfig)
 {
     OSSL_GLOBAL_PROPERTIES *globp;
 
-#ifndef FIPS_MODULE
+#if !defined(FIPS_MODULE) && !defined(OPENSSL_NO_AUTOLOAD_CONFIG)
     if (loadconfig && !OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL))
         return NULL;
 #endif
@@ -505,7 +505,7 @@ int ossl_method_store_fetch(OSSL_METHOD_STORE *store,
     if (nid <= 0 || method == NULL || store == NULL)
         return 0;
 
-#ifndef FIPS_MODULE
+#if !defined(FIPS_MODULE) && !defined(OPENSSL_NO_AUTOLOAD_CONFIG)
     if (ossl_lib_ctx_is_default(store->ctx)
             && !OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL))
         return 0;

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -396,7 +396,7 @@ int ossl_provider_info_add_to_store(OSSL_LIB_CTX *libctx,
 }
 
 OSSL_PROVIDER *ossl_provider_find(OSSL_LIB_CTX *libctx, const char *name,
-                                  int noconfig)
+                                  ossl_unused int noconfig)
 {
     struct provider_store_st *store = NULL;
     OSSL_PROVIDER *prov = NULL;
@@ -405,7 +405,7 @@ OSSL_PROVIDER *ossl_provider_find(OSSL_LIB_CTX *libctx, const char *name,
         OSSL_PROVIDER tmpl = { 0, };
         int i;
 
-#ifndef FIPS_MODULE
+#if !defined(FIPS_MODULE) && !defined(OPENSSL_NO_AUTOLOAD_CONFIG)
         /*
          * Make sure any providers are loaded from config before we try to find
          * them.
@@ -1387,7 +1387,7 @@ int ossl_provider_doall_activated(OSSL_LIB_CTX *ctx,
     struct provider_store_st *store = get_provider_store(ctx);
     STACK_OF(OSSL_PROVIDER) *provs = NULL;
 
-#ifndef FIPS_MODULE
+#if !defined(FIPS_MODULE) && !defined(OPENSSL_NO_AUTOLOAD_CONFIG)
     /*
      * Make sure any providers are loaded from config before we try to use
      * them.

--- a/test/README-dev.md
+++ b/test/README-dev.md
@@ -130,7 +130,11 @@ Generic form of C test executables
     int setup_tests(void)
     {
         ADD_TEST(my_test);                  /* Add each test separately     */
-        return 1;                           /* Indicate success             */
+        return 1;                           /* Indicates success.  Return 0 */
+                                            /* to produce an error with a   */
+                                            /* usage message and -1 for     */
+                                            /* failure to set up with no    */
+                                            /* usage message.               */
     }
 
 You should use the `TEST_xxx` macros provided by `testutil.h` to test all failure

--- a/test/pbetest.c
+++ b/test/pbetest.c
@@ -15,6 +15,8 @@
 #include <openssl/x509.h>
 #include <openssl/rc4.h>
 #include <openssl/md5.h>
+#include <openssl/configuration.h>
+#include <openssl/provider.h>
 
 #if !defined OPENSSL_NO_RC4 && !defined OPENSSL_NO_MD5 \
     || !defined OPENSSL_NO_DES && !defined OPENSSL_NO_SHA1
@@ -123,8 +125,27 @@ static int test_pkcs5_pbe_des_sha1(void)
 }
 #endif
 
+#ifdef OPENSSL_NO_AUTOLOAD_CONFIG
+/*
+ * For configurations where we are not autoloading configuration, we need
+ * to access the legacy provider.  The easiest way is to load both the
+ * legacy and default providers directly and unload them on termination.
+ */
+static OSSL_PROVIDER *legacy, *dflt;
+#endif
+
 int setup_tests(void)
 {
+#ifdef OPENSSL_NO_AUTOLOAD_CONFIG
+    /* Load required providers if not done via configuration */
+    legacy = OSSL_PROVIDER_load(NULL, "legacy");
+    dflt = OSSL_PROVIDER_load(NULL, "default");
+    if (!TEST_ptr(legacy) || !TEST_ptr(dflt)) {
+        cleanup_tests();
+        return -1;
+    }
+#endif
+
 #if !defined OPENSSL_NO_RC4 && !defined OPENSSL_NO_MD5
     ADD_TEST(test_pkcs5_pbe_rc4_md5);
 #endif
@@ -134,3 +155,13 @@ int setup_tests(void)
 
     return 1;
 }
+
+#ifdef OPENSSL_NO_AUTOLOAD_CONFIG
+void cleanup_tests(void)
+{
+    /* Dispose of providers */
+    OSSL_PROVIDER_unload(legacy);
+    OSSL_PROVIDER_unload(dflt);
+    legacy = dflt = NULL;
+}
+#endif

--- a/test/provider_internal_test.c
+++ b/test/provider_internal_test.c
@@ -83,6 +83,7 @@ static int test_loaded_provider(void)
         && test_provider(prov, expected_greeting1(name));
 }
 
+# ifndef OPENSSL_NO_AUTOLOAD_CONFIG
 static int test_configured_provider(void)
 {
     const char *name = "p_test_configured";
@@ -95,6 +96,7 @@ static int test_configured_provider(void)
         TEST_ptr(prov = ossl_provider_find(NULL, name, 0))
         && test_provider(prov, expected_greeting);
 }
+# endif
 #endif
 
 static int test_cache_flushes(void)
@@ -139,7 +141,9 @@ int setup_tests(void)
     ADD_TEST(test_builtin_provider);
 #ifndef NO_PROVIDER_MODULE
     ADD_TEST(test_loaded_provider);
+# ifndef OPENSSL_NO_AUTOLOAD_CONFIG
     ADD_TEST(test_configured_provider);
+# endif
 #endif
     ADD_TEST(test_cache_flushes);
     return 1;

--- a/test/recipes/30-test_defltfips.t
+++ b/test/recipes/30-test_defltfips.t
@@ -21,6 +21,9 @@ BEGIN {
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
 
+plan skip_all => "Configuration loading is turned off"
+    if disabled("autoload-config");
+
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
 plan tests =>

--- a/test/testutil/main.c
+++ b/test/testutil/main.c
@@ -15,6 +15,7 @@
 int main(int argc, char *argv[])
 {
     int ret = EXIT_FAILURE;
+    int setup_res;
 
     test_open_streams();
 
@@ -26,11 +27,11 @@ int main(int argc, char *argv[])
     if (!setup_test_framework(argc, argv))
         goto end;
 
-    if (setup_tests()) {
+    if ((setup_res = setup_tests()) > 0) {
         ret = run_tests(argv[0]);
         cleanup_tests();
         opt_check_usage();
-    } else {
+    } else if (setup_res == 0) {
         opt_help(test_get_options());
     }
 end:


### PR DESCRIPTION
The no-autoload-config option stopped working after 1.1.1.
It should work still.

- [x] documentation is added or updated
- [x] tests are added or updated
