### PR TITLE
QUIC: Fix incompatible merges causing CI breakage (urgent)

### DIFF
--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -808,9 +808,9 @@ static int test_back_pressure(void)
     int i;
 
     if (!TEST_ptr(cctx)
-            || !TEST_true(qtest_create_quic_objects(libctx, cctx, cert, privkey,
-                                                    0, &qtserv, &clientquic,
-                                                    NULL))
+            || !TEST_true(qtest_create_quic_objects(libctx, cctx, NULL, cert,
+                                                    privkey, 0, &qtserv,
+                                                    &clientquic, NULL))
             || !TEST_true(qtest_create_quic_connection(qtserv, clientquic)))
         goto err;
 


### PR DESCRIPTION
Fix CI breakage in master caused by interaction of two different PRs. Urgent due to CI breakage.