### PR TITLE
Fix handling of the "0:" label in arm-xlate.pl

### DIFF
--- a/crypto/perlasm/arm-xlate.pl
+++ b/crypto/perlasm/arm-xlate.pl
@@ -170,9 +170,8 @@ while(my $line=<>) {
     }
 
     {
-	$line =~ s|(^[\.\w]+)\:\s*||;
-	my $label = $1;
-	if ($label) {
+	if ($line =~ s|(^[\.\w]+)\:\s*||) {
+	    my $label = $1;
 	    printf "%s:",($GLOBALS{$label} or $label);
 	}
     }


### PR DESCRIPTION
When `$label eq "0"`, `$label `is not truthy, so `if ($label)` thinks there isn't a label. Correct this by looking at the result of the `s///` operator.

Verified that there are no changes in the .S files created during a normal build, and that the "0:" labels appear in the translation given in the error report (and they are the only difference in the before and after output).

Fixes #21647

Should apply cleanly to 3.0 and 3.1 as well as master