### PR TITLE
`cmp_vfy.c`: Use verification callback if `cert_acceptable()` finds expired cert

### DIFF
--- a/doc/man3/OSSL_CMP_validate_msg.pod
+++ b/doc/man3/OSSL_CMP_validate_msg.pod
@@ -30,10 +30,12 @@ is preferably the one provided by a call to L<OSSL_CMP_CTX_set1_srvCert(3)>.
 If no such sender cert has been pinned then candidate sender certificates are
 taken from the list of certificates received in the I<msg> extraCerts, then any
 certificates provided before via L<OSSL_CMP_CTX_set1_untrusted(3)>, and
-then all trusted certificates provided via L<OSSL_CMP_CTX_set0_trusted(3)>,
-where a candidate is acceptable only if has not expired, its subject DN matches
+then all trusted certificates provided via L<OSSL_CMP_CTX_set0_trusted(3)>.
+A candidate certificate is acceptable only if it is currently valid
+(or the trust store contains a verification callback that overrides the verdict
+that the certificate is expired or not yet valid), its subject DN matches
 the I<msg> sender DN (as far as present), and its subject key identifier
-is present and matches the senderKID (as far as the latter present).
+is present and matches the senderKID (as far as the latter is present).
 Each acceptable cert is tried in the given order to see if the message
 signature check succeeds and the cert and its path can be verified
 using any trust store set via L<OSSL_CMP_CTX_set0_trusted(3)>.


### PR DESCRIPTION
This little feature is needed by one of our customers.

On this occasion also simplify the code, removing the need for `static int no_log_cb()`.
