### PR TITLE
For ASN1_STRING_set() check result and set correct error code

### DIFF
--- a/crypto/asn1/asn1_gen.c
+++ b/crypto/asn1/asn1_gen.c
@@ -698,14 +698,12 @@ static ASN1_TYPE *asn1_str2type(const char *str, int format, int utype)
             atmp->value.asn1_string->data = rdata;
             atmp->value.asn1_string->length = rdlen;
             atmp->value.asn1_string->type = utype;
-        }
-        else if (format == ASN1_GEN_FORMAT_ASCII) {
+        } else if (format == ASN1_GEN_FORMAT_ASCII) {
             if (!ASN1_STRING_set(atmp->value.asn1_string, str, -1)) {
                 ERR_raise(ERR_LIB_ASN1, ERR_R_MALLOC_FAILURE);
                 goto bad_str;
             }
-        }
-        else if ((format == ASN1_GEN_FORMAT_BITLIST)
+        } else if ((format == ASN1_GEN_FORMAT_BITLIST)
                  && (utype == V_ASN1_BIT_STRING)) {
             if (!CONF_parse_list
                 (str, ',', 1, bitstr_cb, atmp->value.bit_string)) {

--- a/crypto/asn1/asn1_gen.c
+++ b/crypto/asn1/asn1_gen.c
@@ -700,7 +700,7 @@ static ASN1_TYPE *asn1_str2type(const char *str, int format, int utype)
             atmp->value.asn1_string->type = utype;
         }
         else if (format == ASN1_GEN_FORMAT_ASCII) {
-            ASN1_STRING_set(atmp->value.asn1_string, str, -1) {
+            if (!ASN1_STRING_set(atmp->value.asn1_string, str, -1)) {
                 ERR_raise(ERR_LIB_ASN1, ERR_R_MALLOC_FAILURE);
                 goto bad_str;
             }

--- a/crypto/asn1/asn1_gen.c
+++ b/crypto/asn1/asn1_gen.c
@@ -698,8 +698,13 @@ static ASN1_TYPE *asn1_str2type(const char *str, int format, int utype)
             atmp->value.asn1_string->data = rdata;
             atmp->value.asn1_string->length = rdlen;
             atmp->value.asn1_string->type = utype;
-        } else if (format == ASN1_GEN_FORMAT_ASCII)
-            ASN1_STRING_set(atmp->value.asn1_string, str, -1);
+        }
+        else if (format == ASN1_GEN_FORMAT_ASCII) {
+            ASN1_STRING_set(atmp->value.asn1_string, str, -1) {
+                ERR_raise(ERR_LIB_ASN1, ERR_R_MALLOC_FAILURE);
+                goto bad_str;
+            }
+        }
         else if ((format == ASN1_GEN_FORMAT_BITLIST)
                  && (utype == V_ASN1_BIT_STRING)) {
             if (!CONF_parse_list

--- a/crypto/x509/v3_ist.c
+++ b/crypto/x509/v3_ist.c
@@ -51,25 +51,25 @@ static ISSUER_SIGN_TOOL *v2i_issuer_sign_tool(X509V3_EXT_METHOD *method, X509V3_
         if (strcmp(cnf->name, "signTool") == 0) {
             ist->signTool = ASN1_UTF8STRING_new();
             if (ist->signTool == NULL || !ASN1_STRING_set(ist->signTool, cnf->value, strlen(cnf->value))) {
-                ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
+                ERR_raise(ERR_LIB_X509V3, ERR_R_MALLOC_FAILURE);
                 goto err;
             }
         } else if (strcmp(cnf->name, "cATool") == 0) {
             ist->cATool = ASN1_UTF8STRING_new();
             if (ist->cATool == NULL || !ASN1_STRING_set(ist->cATool, cnf->value, strlen(cnf->value))) {
-                ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
+                ERR_raise(ERR_LIB_X509V3, ERR_R_MALLOC_FAILURE);
                 goto err;
             }
         } else if (strcmp(cnf->name, "signToolCert") == 0) {
             ist->signToolCert = ASN1_UTF8STRING_new();
             if (ist->signToolCert == NULL || !ASN1_STRING_set(ist->signToolCert, cnf->value, strlen(cnf->value))) {
-                ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
+                ERR_raise(ERR_LIB_X509V3, ERR_R_MALLOC_FAILURE);
                 goto err;
             }
         } else if (strcmp(cnf->name, "cAToolCert") == 0) {
             ist->cAToolCert = ASN1_UTF8STRING_new();
             if (ist->cAToolCert == NULL || !ASN1_STRING_set(ist->cAToolCert, cnf->value, strlen(cnf->value))) {
-                ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
+                ERR_raise(ERR_LIB_X509V3, ERR_R_MALLOC_FAILURE);
                 goto err;
             }
         } else {


### PR DESCRIPTION
This PR is only needed for the 3.0 and 3.1 branches.
The PR was created following the discussion in PR #21587. 
Also, in PR #21497 was incorrectly added to the 3.0 and 3.1 branches `ERR_raise(..., ERR_R_ASN1_LIB)` and I suggest making changes for this case as well.

Found by Linux Verification Center (linuxtesting.org) with SVACE.