### PR TITLE
APPS: fix two CMP options and diagnostics of DN parsing and cert loading

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2648,7 +2648,7 @@ static int get_opts(int argc, char **argv)
             }
             break;
         case OPT_CSR:
-            opt_csr = opt_arg();
+            opt_csr = opt_str();
             break;
         case OPT_OUT_TRUSTED:
             opt_out_trusted = opt_str();
@@ -2681,7 +2681,7 @@ static int get_opts(int argc, char **argv)
             opt_issuer = opt_str();
             break;
         case OPT_SERIAL:
-            opt_serial = opt_arg();
+            opt_serial = opt_str();
             break;
         case OPT_CERTFORM:
             opt_certform_s = opt_str();

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -987,7 +987,7 @@ int load_key_certs_crls(const char *uri, int format, int maybe_stdin,
 
         if (!maybe_stdin) {
             if (!quiet)
-                BIO_printf(bio_err, "No filename or uri specified for loading");
+                BIO_printf(bio_err, "No filename or uri specified for loading\n");
             goto end;
         }
         uri = "<stdin>";
@@ -1003,11 +1003,8 @@ int load_key_certs_crls(const char *uri, int format, int maybe_stdin,
         ctx = OSSL_STORE_open_ex(uri, libctx, propq, get_ui_method(), &uidata,
                                  params, NULL, NULL);
     }
-    if (ctx == NULL) {
-        if (!quiet)
-            BIO_printf(bio_err, "Could not open file or uri for loading");
+    if (ctx == NULL)
         goto end;
-    }
     if (expect > 0 && !OSSL_STORE_expect(ctx, expect))
         goto end;
 

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1977,16 +1977,17 @@ X509_NAME *parse_name(const char *cp, int chtype, int canmulti,
         nid = OBJ_txt2nid(typestr);
         if (nid == NID_undef) {
             BIO_printf(bio_err,
-                       "%s: Skipping unknown %s name attribute \"%s\"\n",
+                       "%s warning: Skipping unknown %s name attribute \"%s\"\n",
                        opt_getprog(), desc, typestr);
             if (ismulti)
                 BIO_printf(bio_err,
-                           "Hint: a '+' in a value string needs be escaped using '\\' else a new member of a multi-valued RDN is expected\n");
+                           "%s hint: a '+' in a value string needs be escaped using '\\' else a new member of a multi-valued RDN is expected\n",
+                           opt_getprog());
             continue;
         }
         if (*valstr == '\0') {
             BIO_printf(bio_err,
-                       "%s: No value provided for %s name attribute \"%s\", skipped\n",
+                       "%s warning: No value provided for %s name attribute \"%s\", skipped\n",
                        opt_getprog(), desc, typestr);
             continue;
         }


### PR DESCRIPTION
* `apps/cmp.c`: fix glitch not allowing to reset `-csr` and `-serial` option values
* `apps.c`: improve warning texts of `parse_name()` when skipping RDN input
* `apps.c`: fix error messages (newline and needless text) in `load_key_certs_crls()`