### PR TITLE
Set VC win64 perlasm scheme during Configure

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -9,19 +9,22 @@ sub vc_win64a_info {
             $vc_win64a_info = { AS        => "nasm",
                                 ASFLAGS   => "-g",
                                 asflags   => "-Ox -f win64 -DNEAR",
-                                asoutflag => "-o " };
+                                asoutflag => "-o ",
+                                perlasm_scheme => "nasm" };
         } elsif ($disabled{asm}) {
             # assembler is still used to compile uplink shim
             $vc_win64a_info = { AS        => "ml64",
                                 ASFLAGS   => "/nologo /Zi",
                                 asflags   => "/c /Cp /Cx",
-                                asoutflag => "/Fo" };
+                                asoutflag => "/Fo",
+                                perlasm_scheme => "masm" };
         } else {
             $die->("NASM not found - make sure it's installed and available on %PATH%\n");
             $vc_win64a_info = { AS        => "{unknown}",
                                 ASFLAGS   => "",
                                 asflags   => "",
-                                asoutflag => "" };
+                                asoutflag => "",
+                                perlasm_scheme => "auto" };
         }
     }
     return $vc_win64a_info;
@@ -1565,7 +1568,7 @@ my %targets = (
         sys_id           => "WIN64A",
         uplink_arch      => 'x86_64',
         asm_arch         => 'x86_64',
-        perlasm_scheme   => "auto",
+        perlasm_scheme   => sub { vc_win64a_info()->{perlasm_scheme} },
         multilib         => "-x64",
     },
     "VC-WIN32" => {


### PR DESCRIPTION
This is based on resolving https://github.com/microsoft/vcpkg/issues/30645.

Despite having `nasm` 2.16.01, and having its directory prepended to `PATH`, and having `AS` set to its filepath, and nasm having nasm `ASM` and `ASMFLAGS` burned into the nmake Makefile, some users faced generated asm code which couldn't be handled by nasm.

This PR just mirrors the existing behaviour for VC win32 (`vc_win32a_info`): Select the specific `perlasm_scheme` for nasm and masm instead of  `auto` when `Configure` also selects the specific asm flags for these tools. AFAIU `auto` doesn't make much sense once the specific flags are fixed.

Disclaimer: I'm not a VC user, except for vcpkg CI.