### PR TITLE
Fix CMS_ContentInfo_free setting "content type not enveloped data" error for signed content

### DIFF
--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -26,7 +26,7 @@ static void cms_env_set_version(CMS_EnvelopedData *env);
 #define CMS_ENVELOPED_STANDARD 1
 #define CMS_ENVELOPED_AUTH     2
 
-static int cms_get_enveloped_type(const CMS_ContentInfo *cms)
+static int cms_get_enveloped_type_simple(const CMS_ContentInfo *cms)
 {
     int nid = OBJ_obj2nid(cms->contentType);
 
@@ -38,8 +38,27 @@ static int cms_get_enveloped_type(const CMS_ContentInfo *cms)
         return CMS_ENVELOPED_AUTH;
 
     default:
-        ERR_raise(ERR_LIB_CMS, CMS_R_CONTENT_TYPE_NOT_ENVELOPED_DATA);
         return 0;
+    }
+}
+
+static int cms_get_enveloped_type(const CMS_ContentInfo *cms)
+{
+    int ret = cms_get_enveloped_type_simple(cms);
+
+    if (ret == 0)
+        ERR_raise(ERR_LIB_CMS, CMS_R_CONTENT_TYPE_NOT_ENVELOPED_DATA);
+    return ret;
+}
+
+void ossl_cms_env_enc_content_free(const CMS_ContentInfo *cinf)
+{
+    if (cms_get_enveloped_type_simple(cinf) != 0)
+    {
+            CMS_EncryptedContentInfo *ec = ossl_cms_get0_env_enc_content(cinf);
+
+            if (ec != NULL)
+                OPENSSL_clear_free(ec->key, ec->keylen);
     }
 }
 

--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -53,12 +53,10 @@ static int cms_get_enveloped_type(const CMS_ContentInfo *cms)
 
 void ossl_cms_env_enc_content_free(const CMS_ContentInfo *cinf)
 {
-    if (cms_get_enveloped_type_simple(cinf) != 0)
-    {
-            CMS_EncryptedContentInfo *ec = ossl_cms_get0_env_enc_content(cinf);
-
-            if (ec != NULL)
-                OPENSSL_clear_free(ec->key, ec->keylen);
+    if (cms_get_enveloped_type_simple(cinf) != 0) {
+        CMS_EncryptedContentInfo *ec = ossl_cms_get0_env_enc_content(cinf);
+        if (ec != NULL)
+            OPENSSL_clear_free(ec->key, ec->keylen);
     }
 }
 

--- a/crypto/cms/cms_lib.c
+++ b/crypto/cms/cms_lib.c
@@ -74,13 +74,7 @@ CMS_ContentInfo *CMS_ContentInfo_new(void)
 void CMS_ContentInfo_free(CMS_ContentInfo *cms)
 {
     if (cms != NULL) {
-        /* Check content type is enveloped data to avoid CMS_R_CONTENT_TYPE_NOT_ENVELOPED_DATA error */
-        int nid = OBJ_obj2nid(cms->contentType);
-        if (nid == NID_pkcs7_enveloped || nid == NID_id_smime_ct_authEnvelopedData) {
-            CMS_EncryptedContentInfo *ec = ossl_cms_get0_env_enc_content(cms);
-            if (ec != NULL)
-                OPENSSL_clear_free(ec->key, ec->keylen);
-        }
+        ossl_cms_env_enc_content_free(cms);
         OPENSSL_free(cms->ctx.propq);
         ASN1_item_free((ASN1_VALUE *)cms, ASN1_ITEM_rptr(CMS_ContentInfo));
     }

--- a/crypto/cms/cms_lib.c
+++ b/crypto/cms/cms_lib.c
@@ -74,10 +74,13 @@ CMS_ContentInfo *CMS_ContentInfo_new(void)
 void CMS_ContentInfo_free(CMS_ContentInfo *cms)
 {
     if (cms != NULL) {
-        CMS_EncryptedContentInfo *ec = ossl_cms_get0_env_enc_content(cms);
-
-        if (ec != NULL)
-            OPENSSL_clear_free(ec->key, ec->keylen);
+        /* Check content type is enveloped data to avoid CMS_R_CONTENT_TYPE_NOT_ENVELOPED_DATA error */
+        int nid = OBJ_obj2nid(cms->contentType);
+        if (nid == NID_pkcs7_enveloped || nid == NID_id_smime_ct_authEnvelopedData) {
+            CMS_EncryptedContentInfo *ec = ossl_cms_get0_env_enc_content(cms);
+            if (ec != NULL)
+                OPENSSL_clear_free(ec->key, ec->keylen);
+        }
         OPENSSL_free(cms->ctx.propq);
         ASN1_item_free((ASN1_VALUE *)cms, ASN1_ITEM_rptr(CMS_ContentInfo));
     }

--- a/crypto/cms/cms_local.h
+++ b/crypto/cms/cms_local.h
@@ -447,6 +447,7 @@ BIO *ossl_cms_EnvelopedData_init_bio(CMS_ContentInfo *cms);
 int ossl_cms_EnvelopedData_final(CMS_ContentInfo *cms, BIO *chain);
 BIO *ossl_cms_AuthEnvelopedData_init_bio(CMS_ContentInfo *cms);
 int ossl_cms_AuthEnvelopedData_final(CMS_ContentInfo *cms, BIO *cmsbio);
+void ossl_cms_env_enc_content_free(const CMS_ContentInfo *cinf);
 CMS_EnvelopedData *ossl_cms_get0_enveloped(CMS_ContentInfo *cms);
 CMS_AuthEnvelopedData *ossl_cms_get0_auth_enveloped(CMS_ContentInfo *cms);
 CMS_EncryptedContentInfo *ossl_cms_get0_env_enc_content(const CMS_ContentInfo *cms);

--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -65,7 +65,7 @@ static int test_encrypt_decrypt(const EVP_CIPHER *cipher)
     BIO_free(outmsgbio);
     CMS_ContentInfo_free(content);
 
-    return testresult;
+    return testresult && TEST_int_eq(ERR_peek_error(), 0);
 }
 
 static int test_encrypt_decrypt_aes_cbc(void)
@@ -312,7 +312,7 @@ static int test_d2i_CMS_bio_NULL(void)
     BIO_free(content);
     CMS_ContentInfo_free(cms);
     BIO_free(bio);
-    return ret;
+    return ret && TEST_int_eq(ERR_peek_error(), 0);
 }
 
 static unsigned char *read_all(BIO *bio, long *p_len)


### PR DESCRIPTION
CLA: provided

CMS_ContentInfo_free called ossl_cms_get0_env_enc_content, which called cms_get_enveloped_type, which raised error CMS_R_CONTENT_TYPE_NOT_ENVELOPED_DATA for the content info if it contained only signed data.

##### Checklist
- [x] tests are added or updated
