### PR TITLE
Fix ChaCha assembly code on 32-bit HPUX itanium systems

### DIFF
--- a/crypto/chacha/asm/chacha-ia64.pl
+++ b/crypto/chacha/asm/chacha-ia64.pl
@@ -46,6 +46,8 @@ ChaCha20_ctr32:
 	ADDP		@k[11]=4,$key
 	.save		ar.lc,r3
 	mov		r3=ar.lc		}
+{ .mmi;	ADDP		$out=0,$out
+	ADDP		$inp=0,$inp		}
 { .mmi;	ADDP		$key=0,$key
 	ADDP		$counter=0,$counter
 	.save		pr,r14


### PR DESCRIPTION
This fixes the reported crashes 32-bit HPUX systems due to raw out and inp pointer values, and adds one nop instruction on 64-bit systems, like it is done in other assembly modules for those systems.

The fix was tested by @johnkohl-hcl see:
https://github.com/openssl/openssl/issues/17067#issuecomment-1668468033

Fixes #17067

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
