### PR TITLE
Fix memory leak when BIO_NOCLOSE is set

### DIFF
--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -159,11 +159,11 @@ static int mem_buf_free(BIO *a)
     if (a == NULL)
         return 0;
 
-    if (a->shutdown && a->init && a->ptr != NULL) {
+    if (a->init && a->ptr != NULL) {
         BIO_BUF_MEM *bb = (BIO_BUF_MEM *)a->ptr;
         BUF_MEM *b = bb->buf;
 
-        if (a->flags & BIO_FLAGS_MEM_RDONLY)
+        if (!a->shutdown || a->flags & BIO_FLAGS_MEM_RDONLY)
             b->data = NULL;
         BUF_MEM_free(b);
     }


### PR DESCRIPTION


fix leaked pointer when BIO_NOCLOSE is set
    
    Was working on an application when valgrind generated this memory leak
    error for us:
    
    ==1007580== at 0x483C815: malloc (vg_replace_malloc.c:431)
    ==1007580== by 0x2C2689: CRYPTO_zalloc (in /home/vien/microedge-c/test)
    ==1007580== by 0x295A17: BUF_MEM_new (in /home/vien/microedge-c/test)
    ==1007580== by 0x295A78: BUF_MEM_new_ex (in /home/vien/microedge-c/test)
    ==1007580== by 0x28CACE: mem_new (in /home/vien/microedge-c/test)
    ==1007580== by 0x285EA8: BIO_new_ex (in /home/vien/microedge-c/test)
    ==1007580== by 0x231894: convert_pubkey_ECC (tpm2_driver.c:221)
    ==1007580== by 0x232B73: create_ephemeral_key (tpm2_driver.c:641)
    ==1007580== by 0x232E1F: tpm_gen_keypair (tpm2_driver.c:695)
    ==1007580== by 0x22D60A: gen_keypair (se_driver_api.c:275)
    ==1007580== by 0x21FF35: generate_keypair (dhkey.c:142)
    ==1007580== by 0x24D4C8: __test_dhkey (dhkey_test.c:55)
    
    The error occurs because BIO_new(BIO_s_mem()) allocates:
    1) a BIO struct
    2) a BIO_BUF_MEM struct which holds a data pointer that is
       (re)-allocated as data is written to the BIO
    
    When BIO_set_close(bio, BIO_NOCLOSE) is set in the calling program, the
    expectation is that the BIO_BUF_MEM data pointer is orphaned so that the
    calling code can take ownership of it via BIO_get_mem_data().
    
    This all works as expected.  However, on calling BIO_free, the s_mem
    implementation calls mem_free->mem_buf_free which, when BIO_NOCLOSE is
    set (shadowed via BIO->shutdown), implements the data pointer orphaning
    by just not calling BIO_BUF_free.  This properly skips the freeing of
    the data pointer, but also leaves the controlling BIO_BUF_MEM struct
    allocated, leading to the leak report above.
    
    Fix (I think) is pretty simple.  In mem_buf_free, we should always call
    BUF_MEM_free (if the corresponding pointer is not NULL), but if
    a->shutdown is 0, we should set the BIO_BUF_MEM->data pointer to NULL.
    This will cause BUF_MEM_free to deallocate the BIO_BUF_MEM data
    structure, but skip the freeing of the actual data

