### PR TITLE
`OSSL_HTTP_REQ_CTX_set_request_line()`: backward compat w.r.t. `path` parameter

### DIFF
--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -167,7 +167,8 @@ void OSSL_HTTP_REQ_CTX_set_max_response_length(OSSL_HTTP_REQ_CTX *rctx,
 
 /*
  * Create request line using |rctx| and |path| (or "/" in case |path| is NULL).
- * Server name (and port) must be given if and only if plain HTTP proxy is used.
+ * Server name (and optional port) must be given if and only if
+ * a plain HTTP proxy is used and |path| does not begin with 'http://'.
  */
 int OSSL_HTTP_REQ_CTX_set_request_line(OSSL_HTTP_REQ_CTX *rctx, int method_POST,
                                        const char *server, const char *port,
@@ -196,11 +197,17 @@ int OSSL_HTTP_REQ_CTX_set_request_line(OSSL_HTTP_REQ_CTX *rctx, int method_POST,
             return 0;
     }
 
-    /* Make sure path includes a forward slash */
-    if (path == NULL)
+    /* Make sure path includes a forward slash (abs_path) */
+    if (path == NULL)  {
         path = "/";
-    if (path[0] != '/' && BIO_printf(rctx->mem, "/") <= 0)
+    } else if (HAS_PREFIX(path, "http://")) { /* absoluteURI for proxy use */
+        if (server != NULL) {
+            ERR_raise(ERR_LIB_HTTP, ERR_R_PASSED_INVALID_ARGUMENT);
+            return 0;
+        }
+    } else if (path[0] != '/' && BIO_printf(rctx->mem, "/") <= 0) {
         return 0;
+    }
     /*
      * Add (the rest of) the path and the HTTP version,
      * which is fixed to 1.0 for straightforward implementation of keep-alive

--- a/doc/man3/OSSL_HTTP_REQ_CTX.pod
+++ b/doc/man3/OSSL_HTTP_REQ_CTX.pod
@@ -72,12 +72,16 @@ which collects the HTTP request header lines.
 OSSL_HTTP_REQ_CTX_free() frees up the HTTP request context I<rctx>.
 The I<rbio> is not free'd, I<wbio> will be free'd if I<free_wbio> is set.
 
-OSSL_HTTP_REQ_CTX_set_request_line() adds the HTTP request line to the context.
+OSSL_HTTP_REQ_CTX_set_request_line() adds the 1st HTTP request line to I<rctx>.
 The HTTP method is determined by I<method_POST>,
 which should be 1 to indicate C<POST> or 0 to indicate C<GET>.
-I<server> and I<port> may be set to indicate a proxy server and port
-that the request should go through, otherwise they should be left NULL.
-I<path> is the HTTP request path; if left NULL, C</> is used.
+I<server> and I<port> may be set to give the server and the optional port that
+an HTTP proxy shall forward the request to, otherwise they must be left NULL.
+I<path> provides the HTTP request path; if left NULL, C</> is used.
+For backward compatibility, I<path> may begin with C<http://> and thus convey
+an absoluteURI. In this case it indicates HTTP proxy use and provides also the
+server (and optionally the port) that the proxy shall forward the request to.
+In this case the I<server> and I<port> arguments must be NULL.
 
 OSSL_HTTP_REQ_CTX_add1_header() adds header I<name> with value I<value> to the
 context I<rctx>. It can be called more than once to add multiple header lines.

--- a/doc/man3/OSSL_HTTP_transfer.pod
+++ b/doc/man3/OSSL_HTTP_transfer.pod
@@ -161,8 +161,11 @@ NULL) to print additional diagnostic information in a user-oriented way.
 
 OSSL_HTTP_set1_request() sets up in I<rctx> the request header and content data
 and expectations on the response using the following parameters.
-If <rctx> indicates using a proxy for HTTP (but not HTTPS), the server hostname
-(and optionally port) needs to be placed in the header and thus must be present.
+If <rctx> indicates using a proxy for HTTP (but not HTTPS), the server host
+(and optionally port) needs to be placed in the header; thus it must be present
+in I<rctx>.
+For backward compatibility, the server (and optional port) may also be given in
+the I<path> argument beginning with C<http://> (thus giving an absoluteURI).
 If I<path> is NULL it defaults to "/".
 If I<req> is NULL the HTTP GET method will be used to send the request
 else HTTP POST with the contents of I<req> and optional I<content_type>, where


### PR DESCRIPTION
Fixes #17923 as discussed there for backward compatibility with undocumented proxy support feature, which can be reached by creative use of the `path` parameter.
Document this also for `OSSL_HTTP_set1_request()`.
As mentioned, also fix documentation of `server` and `port` parameters.


