### PR TITLE
Don't use C++ reserved word template for function arguments

### DIFF
--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -346,7 +346,7 @@ void *evp_keymgmt_gen_init(const EVP_KEYMGMT *keymgmt, int selection,
 }
 
 int evp_keymgmt_gen_set_template(const EVP_KEYMGMT *keymgmt, void *genctx,
-                                 void *template)
+                                 void *templ)
 {
     /*
      * It's arguable if we actually should return success in this case, as
@@ -356,7 +356,7 @@ int evp_keymgmt_gen_set_template(const EVP_KEYMGMT *keymgmt, void *genctx,
      */
     if (keymgmt->gen_set_template == NULL)
         return 1;
-    return keymgmt->gen_set_template(genctx, template);
+    return keymgmt->gen_set_template(genctx, templ);
 }
 
 int evp_keymgmt_gen_set_params(const EVP_KEYMGMT *keymgmt, void *genctx,

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -812,7 +812,7 @@ int evp_keymgmt_set_params(const EVP_KEYMGMT *keymgmt,
 void *evp_keymgmt_gen_init(const EVP_KEYMGMT *keymgmt, int selection,
                            const OSSL_PARAM params[]);
 int evp_keymgmt_gen_set_template(const EVP_KEYMGMT *keymgmt, void *genctx,
-                                 void *template);
+                                 void *templ);
 int evp_keymgmt_gen_set_params(const EVP_KEYMGMT *keymgmt, void *genctx,
                                const OSSL_PARAM params[]);
 void *evp_keymgmt_gen(const EVP_KEYMGMT *keymgmt, void *genctx,


### PR DESCRIPTION
Code contains reserved C++ keyword ("template") as variable name, thus it can not compile with latest MSVC when integrated to C++ projects. This is just a small fix for a variable name.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
