### PR TITLE
Added a zero check for the parameter w.

### DIFF
--- a/providers/implementations/macs/kmac_prov.c
+++ b/providers/implementations/macs/kmac_prov.c
@@ -538,7 +538,7 @@ static int bytepad(unsigned char *out, size_t *out_len,
     int len;
     unsigned char *p = out;
     int sz = w;
-    
+
     if (out == NULL) {
         if (out_len == NULL) {
             ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);

--- a/providers/implementations/macs/kmac_prov.c
+++ b/providers/implementations/macs/kmac_prov.c
@@ -535,12 +535,12 @@ static int bytepad(unsigned char *out, size_t *out_len,
                    const unsigned char *in1, size_t in1_len,
                    const unsigned char *in2, size_t in2_len, size_t w)
 {
-    if (w == 0)
-        return 0;
-
     int len;
     unsigned char *p = out;
     int sz = w;
+    
+    if (w == 0)
+        return 0;
 
     if (out == NULL) {
         if (out_len == NULL) {

--- a/providers/implementations/macs/kmac_prov.c
+++ b/providers/implementations/macs/kmac_prov.c
@@ -249,7 +249,7 @@ static int kmac_setkey(struct kmac_data_st *kctx, const unsigned char *key,
         ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
         return 0;
     }
-    if (w < 0) {
+    if (w <= 0) {
         ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DIGEST_LENGTH);
         return 0;
     }
@@ -289,7 +289,7 @@ static int kmac_init(void *vmacctx, const unsigned char *key,
         return 0;
 
     t = EVP_MD_get_block_size(ossl_prov_digest_md(&kctx->digest));
-    if (t < 0) {
+    if (t <= 0) {
         ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DIGEST_LENGTH);
         return 0;
     }
@@ -539,9 +539,6 @@ static int bytepad(unsigned char *out, size_t *out_len,
     unsigned char *p = out;
     int sz = w;
     
-    if (w == 0)
-        return 0;
-
     if (out == NULL) {
         if (out_len == NULL) {
             ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);

--- a/providers/implementations/macs/kmac_prov.c
+++ b/providers/implementations/macs/kmac_prov.c
@@ -535,6 +535,9 @@ static int bytepad(unsigned char *out, size_t *out_len,
                    const unsigned char *in1, size_t in1_len,
                    const unsigned char *in2, size_t in2_len, size_t w)
 {
+    if (w == 0)
+        return 0;
+
     int len;
     unsigned char *p = out;
     int sz = w;


### PR DESCRIPTION
In the function `static int bytepad:549` there is a division by the function parameter `w`.
If this parameter is set to zero, a division by zero will occur.

Therefore, a zero check for the parameter `w` was added at the beginning of the function.

Below is an example of the sanitizer output if the function `bytepad` is passed a parameter w of 0.

![image](https://github.com/openssl/openssl/assets/18628960/d3a6ccb2-9d9f-4118-a7e7-0a184bb9c808)
