### PR TITLE
Added check for the return value of the RAND_bytes() function

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -4747,8 +4747,7 @@ static void multiblock_speed(const EVP_CIPHER *evp_cipher, int lengths_single,
             } else {
                 int pad;
 
-                if (RAND_bytes(out, 16) > 0)
-                {
+                if (RAND_bytes(out, 16) > 0) {
                     len += 16;
                     aad[11] = (unsigned char)(len >> 8);
                     aad[12] = (unsigned char)(len);

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -4747,14 +4747,14 @@ static void multiblock_speed(const EVP_CIPHER *evp_cipher, int lengths_single,
             } else {
                 int pad;
 
-                if (RAND_bytes(out, 16) > 0) {
-                    len += 16;
-                    aad[11] = (unsigned char)(len >> 8);
-                    aad[12] = (unsigned char)(len);
-                    pad = EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_TLS1_AAD,
-                                              EVP_AEAD_TLS1_AAD_LEN, aad);
-                    ciph_success = EVP_Cipher(ctx, out, inp, len + pad);
-                }
+                if (RAND_bytes(inp, 16) <= 0)
+                    app_bail_out("error setting random bytes\n");
+                len += 16;
+                aad[11] = (unsigned char)(len >> 8);
+                aad[12] = (unsigned char)(len);
+                pad = EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_TLS1_AAD,
+                                            EVP_AEAD_TLS1_AAD_LEN, aad);
+                ciph_success = EVP_Cipher(ctx, out, inp, len + pad);
             }
         }
         d = Time_F(STOP);

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -4747,13 +4747,15 @@ static void multiblock_speed(const EVP_CIPHER *evp_cipher, int lengths_single,
             } else {
                 int pad;
 
-                RAND_bytes(out, 16);
-                len += 16;
-                aad[11] = (unsigned char)(len >> 8);
-                aad[12] = (unsigned char)(len);
-                pad = EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_TLS1_AAD,
-                                          EVP_AEAD_TLS1_AAD_LEN, aad);
-                ciph_success = EVP_Cipher(ctx, out, inp, len + pad);
+                if (RAND_bytes(out, 16) > 0)
+                {
+                    len += 16;
+                    aad[11] = (unsigned char)(len >> 8);
+                    aad[12] = (unsigned char)(len);
+                    pad = EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_TLS1_AAD,
+                                              EVP_AEAD_TLS1_AAD_LEN, aad);
+                    ciph_success = EVP_Cipher(ctx, out, inp, len + pad);
+                }
             }
         }
         d = Time_F(STOP);

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -4753,7 +4753,7 @@ static void multiblock_speed(const EVP_CIPHER *evp_cipher, int lengths_single,
                 aad[11] = (unsigned char)(len >> 8);
                 aad[12] = (unsigned char)(len);
                 pad = EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_TLS1_AAD,
-                                            EVP_AEAD_TLS1_AAD_LEN, aad);
+                                          EVP_AEAD_TLS1_AAD_LEN, aad);
                 ciph_success = EVP_Cipher(ctx, out, inp, len + pad);
             }
         }


### PR DESCRIPTION
The return value of the `RAND_bytes()` function is not checked. At the same time, the function might return `0` without changing the value of the `out` variable passed to it. This variable will be used later on, so a check for the function's return value has been added.


Perhaps this would be more correct:
```
  if (RAND_bytes(out, 16) <= 0)
        goto err;
```

