### PR TITLE
QUIC: Do not discard the INITIAL el too early

### DIFF
--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -1828,8 +1828,10 @@ static int ch_rx(QUIC_CHANNEL *ch)
             ossl_quic_tx_packetiser_record_received_closing_bytes(
                     ch->txp, ch->qrx_pkt->hdr->len);
 
-        if (!handled_any)
+        if (!handled_any) {
             ch_update_idle(ch);
+            ch_update_ping_deadline(ch);
+        }
 
         ch_rx_handle_packet(ch); /* best effort */
 

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -2020,7 +2020,7 @@ static void ch_rx_handle_packet(QUIC_CHANNEL *ch)
     case QUIC_PKT_TYPE_INITIAL:
     case QUIC_PKT_TYPE_HANDSHAKE:
     case QUIC_PKT_TYPE_1RTT:
-        if (ch->qrx_pkt->hdr->type == QUIC_PKT_TYPE_HANDSHAKE)
+        if (ch->is_server && ch->qrx_pkt->hdr->type == QUIC_PKT_TYPE_HANDSHAKE)
             /*
              * We automatically drop INITIAL EL keys when first successfully
              * decrypting a HANDSHAKE packet, as per the RFC.

--- a/ssl/quic/quic_trace.c
+++ b/ssl/quic/quic_trace.c
@@ -68,7 +68,7 @@ static void put_conn_id(BIO *bio, QUIC_CONN_ID *id)
 static void put_token(BIO *bio, const uint8_t *token, size_t token_len)
 {
     if (token_len == 0)
-        BIO_puts(bio, "<zerlo length token>");
+        BIO_puts(bio, "<zero length token>");
     else
         put_data(bio, token, token_len);
 }

--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -16,6 +16,7 @@
 #if defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG)
 # include "../threadstest.h"
 #endif
+#include "internal/quic_ssl.h"
 #include "internal/quic_wire_pkt.h"
 #include "internal/quic_record_tx.h"
 #include "internal/quic_error.h"
@@ -172,7 +173,10 @@ int qtest_create_quic_objects(OSSL_LIB_CTX *libctx, SSL_CTX *clientctx,
     tserver_args.ctx = serverctx;
     if ((flags & QTEST_FLAG_FAKE_TIME) != 0) {
         fake_now = ossl_time_zero();
+        /* zero time can have a special meaning, bump it */
+        qtest_add_time(1);
         tserver_args.now_cb = fake_now_cb;
+        (void)ossl_quic_conn_set_override_now_cb(*cssl, fake_now_cb, NULL);
     }
 
     if (!TEST_ptr(*qtserv = ossl_quic_tserver_new(&tserver_args, certfile,

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -379,7 +379,9 @@ static int test_ssl_trace(void)
     if (!TEST_ptr(cctx)
             || !TEST_ptr(bio)
             || !TEST_true(qtest_create_quic_objects(libctx, cctx, NULL, cert,
-                                                    privkey, 0, &qtserv,
+                                                    privkey,
+                                                    QTEST_FLAG_FAKE_TIME,
+                                                    &qtserv,
                                                     &clientquic, NULL)))
         goto err;
 

--- a/test/recipes/75-test_quicapi_data/ssltraceref.txt
+++ b/test/recipes/75-test_quicapi_data/ssltraceref.txt
@@ -233,6 +233,22 @@ YeeuLO02zToHhnQ6KbPXOrQAqcL1kngO4g+j/ru+4AZThFkdkGnltvk=
 ------------------
         No extensions
 
+Sent Frame: Ack  (without ECN)
+    Largest acked: 0
+    Ack delay (raw) 0
+    Ack range count: 0
+    First ack range: 0
+Sent Frame: Padding
+Sent Packet
+  Packet Type: Initial
+  Version: 0x00000001
+  Destination Conn Id: 0x????????????????
+  Source Conn Id: <zero length id>
+  Payload length: 1178
+  Token: <zerlo length token>
+  Packet Number: 0x00000001
+Sent Datagram
+  Length: 1200
 Received Datagram
   Length: 234
 Received Packet

--- a/test/recipes/75-test_quicapi_data/ssltraceref.txt
+++ b/test/recipes/75-test_quicapi_data/ssltraceref.txt
@@ -75,7 +75,7 @@ Sent Packet
   Destination Conn Id: 0x????????????????
   Source Conn Id: <zero length id>
   Payload length: 1178
-  Token: <zerlo length token>
+  Token: <zero length token>
   Packet Number: 0x00000000
 Sent Datagram
   Length: 1200
@@ -87,7 +87,7 @@ Received Packet
   Destination Conn Id: <zero length id>
   Source Conn Id: 0x????????????????
   Payload length: 115
-  Token: <zerlo length token>
+  Token: <zero length token>
   Packet Number: 0x00000000
 Received Frame: Ack  (without ECN)
     Largest acked: 0
@@ -245,7 +245,7 @@ Sent Packet
   Destination Conn Id: 0x????????????????
   Source Conn Id: <zero length id>
   Payload length: 1178
-  Token: <zerlo length token>
+  Token: <zero length token>
   Packet Number: 0x00000001
 Sent Datagram
   Length: 1200


### PR DESCRIPTION
RFC says that successful decryption of HANDSHAKE el packet triggers the discard on server side only.

On client we discard INITIAL el when we successfully send a HANDSHAKE packet.

Fixes #21607
