### PR TITLE
QUIC: Demo-Driven Design Demos Update & Report

### DIFF
--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -610,6 +610,10 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
             data->connect_mode |= BIO_SOCK_NONBLOCK;
         else
             data->connect_mode &= ~BIO_SOCK_NONBLOCK;
+
+        if (data->dgram_bio != NULL)
+            ret = BIO_set_nbio(data->dgram_bio, num);
+
         break;
 #if defined(TCP_FASTOPEN) && !defined(OPENSSL_NO_TFO)
     case BIO_C_SET_TFO:

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -52,8 +52,8 @@ static long conn_callback_ctrl(BIO *h, int cmd, BIO_info_cb *);
 
 static int conn_state(BIO *b, BIO_CONNECT *c);
 static void conn_close_socket(BIO *data);
-BIO_CONNECT *BIO_CONNECT_new(void);
-void BIO_CONNECT_free(BIO_CONNECT *a);
+static BIO_CONNECT *BIO_CONNECT_new(void);
+static void BIO_CONNECT_free(BIO_CONNECT *a);
 
 #define BIO_CONN_S_BEFORE                1
 #define BIO_CONN_S_GET_ADDR              2
@@ -252,7 +252,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
     return ret;
 }
 
-BIO_CONNECT *BIO_CONNECT_new(void)
+static BIO_CONNECT *BIO_CONNECT_new(void)
 {
     BIO_CONNECT *ret;
 
@@ -263,7 +263,7 @@ BIO_CONNECT *BIO_CONNECT_new(void)
     return ret;
 }
 
-void BIO_CONNECT_free(BIO_CONNECT *a)
+static void BIO_CONNECT_free(BIO_CONNECT *a)
 {
     if (a == NULL)
         return;

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -571,6 +571,7 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
         }
         break;
     case BIO_CTRL_DGRAM_GET_PEER:
+    case BIO_CTRL_DGRAM_DETECT_PEER_ADDR:
         if (data->state != BIO_CONN_S_OK)
             conn_state(b, data); /* best effort */
 

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -971,6 +971,13 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
         *(int *)ptr = data->local_addr_enabled;
         break;
 
+    case BIO_CTRL_DGRAM_GET_EFFECTIVE_CAPS:
+        ret = (long)(BIO_DGRAM_CAP_HANDLES_DST_ADDR
+                     | BIO_DGRAM_CAP_HANDLES_SRC_ADDR
+                     | BIO_DGRAM_CAP_PROVIDES_DST_ADDR
+                     | BIO_DGRAM_CAP_PROVIDES_SRC_ADDR);
+        break;
+
     case BIO_CTRL_GET_RPOLL_DESCRIPTOR:
     case BIO_CTRL_GET_WPOLL_DESCRIPTOR:
         {

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -722,6 +722,10 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_DGRAM_SET_PEER:
         BIO_ADDR_make(&data->peer, BIO_ADDR_sockaddr((BIO_ADDR *)ptr));
         break;
+    case BIO_C_SET_NBIO:
+        if (!BIO_socket_nbio(b->num, num != 0))
+            ret = 0;
+        break;
     case BIO_CTRL_DGRAM_SET_NEXT_TIMEOUT:
         data->next_timeout = ossl_time_from_timeval(*(struct timeval *)ptr);
         break;

--- a/crypto/bio/bss_dgram_pair.c
+++ b/crypto/bio/bss_dgram_pair.c
@@ -695,7 +695,7 @@ static long dgram_mem_ctrl(BIO *bio, int cmd, long num, void *ptr)
 
     /* BIO_dgram_get_local_addr_enable */
     case BIO_CTRL_DGRAM_GET_LOCAL_ADDR_ENABLE: /* Non-threadsafe */
-        *(int *)ptr = (long)dgram_pair_ctrl_get_local_addr_enable(bio);
+        *(int *)ptr = (int)dgram_pair_ctrl_get_local_addr_enable(bio);
         break;
 
     /* BIO_dgram_set_local_addr_enable */

--- a/crypto/bio/bss_dgram_pair.c
+++ b/crypto/bio/bss_dgram_pair.c
@@ -695,7 +695,7 @@ static long dgram_mem_ctrl(BIO *bio, int cmd, long num, void *ptr)
 
     /* BIO_dgram_get_local_addr_enable */
     case BIO_CTRL_DGRAM_GET_LOCAL_ADDR_ENABLE: /* Non-threadsafe */
-        ret = (long)dgram_pair_ctrl_get_local_addr_enable(bio);
+        *(int *)ptr = (long)dgram_pair_ctrl_get_local_addr_enable(bio);
         break;
 
     /* BIO_dgram_set_local_addr_enable */

--- a/doc/designs/ddd/Makefile
+++ b/doc/designs/ddd/Makefile
@@ -3,10 +3,12 @@
 #
 #    LD_LIBRARY_PATH=../.. make test
 
-TESTS=ddd-01-conn-blocking ddd-02-conn-nonblocking ddd-03-fd-blocking ddd-04-fd-nonblocking ddd-05-mem-nonblocking ddd-06-mem-uv
+TESTS_BASE=ddd-01-conn-blocking ddd-02-conn-nonblocking ddd-02-conn-nonblocking-threads \
+		   ddd-03-fd-blocking ddd-04-fd-nonblocking ddd-05-mem-nonblocking ddd-06-mem-uv
+TESTS=$(foreach x,$(TESTS_BASE),$(x)-tls $(x)-quic)
 
-CFLAGS = -I../include -O3 -g -Wall
-LDFLAGS = -L..
+CFLAGS = -I../../../include -O3 -g -Wall
+LDFLAGS = -L../../..
 LDLIBS = -lcrypto -lssl
 
 all: $(TESTS)
@@ -14,11 +16,14 @@ all: $(TESTS)
 clean:
 	rm -f $(TESTS) *.o
 
-test: all
-	for x in $(TESTS); do echo "$$x"; LD_LIBRARY_PATH="$$(pwd)/.." ./$$x | grep -q '</html>' || { echo >&2 'Error'; exit 1; }; done
-
-ddd-06-mem-uv: ddd-06-mem-uv.c
+ddd-06-mem-uv-tls: ddd-06-mem-uv.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o "$@" "$<" $(LDLIBS) -luv
 
-ddd-%: ddd-%.c
+ddd-06-mem-uv-quic: ddd-06-mem-uv.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -DUSE_QUIC -o "$@" "$<" $(LDLIBS) -luv
+
+ddd-%-quic: ddd-%.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -DUSE_QUIC -o "$@" "$<" $(LDLIBS)
+
+ddd-%-tls: ddd-%.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o "$@" "$<" $(LDLIBS)

--- a/doc/designs/ddd/README.md
+++ b/doc/designs/ddd/README.md
@@ -50,6 +50,9 @@ certificates or other TLS functionality, the use of QUIC is unlikely to have
 implications for these APIs and demos demonstrating such functionality are
 therefore out of scope.
 
+[A report is available](REPORT.md) on the results of the DDD process following
+the completion of the development of the QUIC MVP.
+
 Background
 ----------
 

--- a/doc/designs/ddd/REPORT.md
+++ b/doc/designs/ddd/REPORT.md
@@ -151,7 +151,7 @@ The originally planned changes to enable applications for QUIC amounted to:
 - A change to how the `POLLIN`/`POLLOUT`/`POLLERR` flags to pass to poll(2)
   need to be determined.
 
-  Note that this is a subtantially smaller list of changes than for
+  Note that this is a substantially smaller list of changes than for
   ddd-02-conn-nonblocking.
 
 ### Actual changes

--- a/doc/designs/ddd/REPORT.md
+++ b/doc/designs/ddd/REPORT.md
@@ -1,0 +1,340 @@
+Report on the Conclusions of the QUIC DDD Process
+=================================================
+
+The [QUIC Demo-Driven Design process](README.md) was undertaken to meet the OMC
+requirement to develop a QUIC API that required only minimal changes to existing
+applications to be able to adapt their code to use QUIC. The demo-driven design
+process developed a set of representative demos modelling a variety of common
+OpenSSL usage patterns based on analysis of a broad spectrum of open source
+software projects using OpenSSL.
+
+As part of this process, a set of proposed diffs were produced. These proposed
+diffs were the expected changes which would be needed to the baseline demos to
+support QUIC based on theoretical analysis of the minimum requirements to be
+able to support QUIC. This analysis concluded that the changes needed to
+applications could be kept very small in many circumstances, with only minimal
+diff sizes to the baseline demos.
+
+Following the development of QUIC MVP, these demos have been revisited and the
+correspondence of our actual final API and usage patterns with the planned diffs
+have been reviewed.
+
+This document discusses the planned changes and the actual changes for each demo
+and draws conclusions on the level of disparity.
+
+Since tracking a set of diffs separately is unwieldy, both the planned and
+unplanned changes have been folded into the original baseline demo files guarded
+with `#ifdef USE_QUIC`. Viewing these files therefore is informative to
+application writers as it provides a clear view of what is different when using
+QUIC. (The originally planned changes, and the final changes, are added in
+separate, clearly-labelled commits; to view the originally planned changes only,
+view the commit history for a given demo file.)
+
+ddd-01-conn-blocking
+--------------------
+
+This demo exists to demonstrate the simplest possible usage of OpenSSL, whether
+with TLS or QUIC.
+
+### Originally planned changes
+
+The originally planned change to enable applications for QUIC amounted to just a
+single line:
+
+```diff
++    ctx = SSL_CTX_new(QUIC_client_method());
+-    ctx = SSL_CTX_new(TLS_client_method());
+```
+
+### Actual changes
+
+The following additional changes needed to be made:
+
+- `QUIC_client_method` was renamed to `OSSL_QUIC_client_method` for namespacing
+  reasons.
+
+- A call to `SSL_set_alpn_protos` to configure ALPN was added. This is necessary
+  because QUIC mandates the use of ALPN, and this was not noted during the
+  DDD process.
+
+ddd-02-conn-nonblocking
+-----------------------
+
+This demo exists to demonstrate simple non-blocking usage. As with
+ddd-01-conn-blocking, the name resolution process is managed by `BIO_s_connect`.
+
+It also arbitrarily adds a `BIO_f_buffer` pushed onto the BIO stack
+as this is a common application usage pattern.
+
+### Originally planned changes
+
+The originally planned changes to enable applications for QUIC amounted to:
+
+- Change of method (as for ddd-01-conn-blocking);
+
+- Use of a `BIO_f_dgram_buffer` BIO method instead of a `BIO_f_buffer`;
+
+- Use of a `BIO_get_poll_fd` function to get the FD to poll rather than
+  `BIO_get_fd`;
+
+- A change to how the `POLLIN`/`POLLOUT`/`POLLERR` flags to pass to poll(2)
+  need to be determined.
+
+- Additional functions in application code to determine event handling
+  timeouts related to QUIC (`get_conn_pump_timeout`) and to pump
+  the QUIC event loop (`pump`).
+
+- Timeout computation code which involves merging and comparing different
+  timeouts and calling `pump` as needed, based on deadlines reported
+  by libssl.
+
+Note that some of these changes are unnecessary when using the thread assisted
+mode (see the variant ddd-02-conn-nonblocking-threads below).
+
+### Actual changes
+
+The following additional changes needed to be made:
+
+- Change of method name (as for ddd-01-conn-blocking);
+
+- Use of ALPN (as for ddd-01-conn-blocking);
+
+- The strategy for how to expose pollable OS resource handles
+  to applications to determine I/O readiness has changed substantially since the
+  original DDD process. As such, applications now use `BIO_get_rpoll_descriptor`
+  and `BIO_get_wpoll_descriptor` to determine I/O readiness, rather than the
+  originally hypothesised `SSL_get_poll_fd`.
+
+- The strategy for how to determine when to poll for `POLLIN`, when to
+  poll for `POLLOUT`, etc. has changed since the original DDD process.
+  This information is now exposed via `SSL_net_read_desired` and
+  `SSL_net_write_desired`.
+
+- The API to expose the event handling deadline for the QUIC engine
+  has evolved since the original DDD process. The new API
+  `SSL_get_event_timeout` is used, rather than the originally hypothesised
+  `BIO_get_timeout`/`SSL_get_timeout`.
+
+- The API to perform QUIC event processing has been renamed to be
+  more descriptive. It is now called `SSL_handle_events` rather than
+  the originally hypothesised `BIO_pump`/`SSL_pump`.
+
+The following changes were foreseen to be necessary, but turned out to actually
+not be necessary:
+
+- The need to change code which pushes a `BIO_f_buffer()` after a SSL BIO
+  was foreseen as use of buffering on the network side is unworkable with
+  QUIC. This turned out not to be necessary since we can just reject the
+  BIO_push() call. The buffer should still be freed eventually when the
+  SSL BIO is freed. The buffer is not used and is unnecessary, so it is
+  still desirable for applications to remove this code.
+
+ddd-02-conn-nonblocking-threads
+-------------------------------
+
+This is a variant of the ddd-02-conn-nonblocking demo. The base is the same, but
+the changes made are different. The use of thread-assisted mode, in which an
+internal assist thread is used to perform QUIC event handling, enables an
+application to make fewer changes than are needed in the ddd-02-conn-nonblocking
+demo.
+
+### Originally planned changes
+
+The originally planned changes to enable applications for QUIC amounted to:
+
+- Change of method, this time using method `QUIC_client_thread_method` rather
+  than `QUIC_client_method`;
+
+- Use of a `BIO_get_poll_fd` function to get the FD to poll rather than
+  `BIO_get_fd`;
+
+- A change to how the `POLLIN`/`POLLOUT`/`POLLERR` flags to pass to poll(2)
+  need to be determined.
+
+  Note that this is a subtantially smaller list of changes than for
+  ddd-02-conn-nonblocking.
+
+### Actual changes
+
+The following additional changes needed to be made:
+
+- Change of method name (`QUIC_client_thread_method` was renamed to
+  `OSSL_QUIC_client_thread_method` for namespacing reasons);
+
+- Use of ALPN (as for ddd-01-conn-blocking);
+
+- Use of `BIO_get_rpoll_descriptor` rather than `BIO_get_poll_fd` (as for
+  ddd-02-conn-nonblocking).
+
+- Use of `SSL_net_read_desired` and `SSL_net_write_desired` (as for
+  ddd-02-conn-nonblocking).
+
+ddd-03-fd-blocking
+------------------
+
+This demo is similar to ddd-01-conn-blocking but uses a file descriptor passed
+directly by the application rather than BIO_s_connect.
+
+### Originally planned changes
+
+- Change of method (as for ddd-01-conn-blocking);
+
+- The arguments to the `socket(2)` call are changed from `(AF_INET, SOCK_STREAM,
+  IPPROTO_TCP)` to `(AF_INET, SOCK_DGRAM, IPPROTO_UDP)`.
+
+### Actual changes
+
+The following additional changes needed to be made:
+
+- Change of method name (as for ddd-01-conn-blocking);
+
+- Use of ALPN (as for ddd-01-conn-blocking).
+
+ddd-04-fd-nonblocking
+---------------------
+
+This demo is similar to ddd-01-conn-nonblocking but uses a file descriptor
+passed directly by the application rather than BIO_s_connect.
+
+### Originally planned changes
+
+- Change of method (as for ddd-01-conn-blocking);
+
+- The arguments to the `socket(2)` call are changed from `(AF_INET, SOCK_STREAM,
+  IPPROTO_TCP)` to `(AF_INET, SOCK_DGRAM, IPPROTO_UDP)`;
+
+- A change to how the `POLLIN`/`POLLOUT`/`POLLERR` flags to pass to poll(2)
+  need to be determined.
+
+- Additional functions in application code to determine event handling
+  timeouts related to QUIC (`get_conn_pump_timeout`) and to pump
+  the QUIC event loop (`pump`).
+
+- Timeout computation code which involves merging and comparing different
+  timeouts and calling `pump` as needed, based on deadlines reported
+  by libssl.
+
+### Actual changes
+
+The following additional changes needed to be made:
+
+- Change of method name (as for ddd-01-conn-blocking);
+
+- Use of ALPN (as for ddd-01-conn-blocking);
+
+- `SSL_get_timeout` replaced with `SSL_get_event_timeout` (as for
+  ddd-02-conn-nonblocking);
+
+- `SSL_pump` renamed to `SSL_handle_events` (as for ddd-02-conn-nonblocking);
+
+- The strategy for how to determine when to poll for `POLLIN`, when to
+  poll for `POLLOUT`, etc. has changed since the original DDD process.
+  This information is now exposed via `SSL_net_read_desired` and
+  `SSL_net_write_desired` (as for ddd-02-conn-nonblocking).
+
+ddd-05-mem-nonblocking
+----------------------
+
+This demo is more elaborate. It uses memory buffers created and managed by an
+application as an intermediary between libssl and the network, which is a common
+usage pattern for applications. Managing this pattern for QUIC is more elaborate
+since datagram semantics on the network channel need to be maintained.
+
+### Originally planned changes
+
+- Change of method (as for ddd-01-conn-blocking);
+
+- Call to `BIO_new_bio_pair` is changed to `BIO_new_dgram_pair`, which
+  provides a bidirectional memory buffer BIO with datagram semantics.
+
+- A change to how the `POLLIN`/`POLLOUT`/`POLLERR` flags to pass to poll(2)
+  need to be determined.
+
+- Potential changes to buffer sizes used by applications to buffer
+  datagrams, if those buffers are smaller than 1472 bytes.
+
+- The arguments to the `socket(2)` call are changed from `(AF_INET, SOCK_STREAM,
+  IPPROTO_TCP)` to `(AF_INET, SOCK_DGRAM, IPPROTO_UDP)`;
+
+### Actual changes
+
+The following additional changes needed to be made:
+
+- Change of method name (as for ddd-01-conn-blocking);
+
+- Use of ALPN (as for ddd-01-conn-blocking);
+
+- The API to construct a `BIO_s_dgram_pair` ended up being named
+  `BIO_new_bio_dgram_pair` rather than `BIO_new_dgram_pair`;
+
+- Use of `SSL_net_read_desired` and `SSL_net_write_desired` (as for
+  ddd-02-conn-nonblocking).
+
+ddd-06-mem-uv
+-------------
+
+This demo is the most elaborate of the set. It uses a real-world asynchronous
+I/O reactor, namely libuv (the engine used by Node.js). In doing so it seeks to
+demonstrate and prove the viability of our API design with a real-world
+asynchronous I/O system. It operates wholly in non-blocking mode and uses memory
+buffers on either side of the QUIC stack to feed data to and from the
+application and the network.
+
+### Originally planned changes
+
+- Change of method (as for ddd-01-conn-blocking);
+
+- Various changes to use of libuv needed to switch to using UDP;
+
+- Additional use of libuv to configure a timer event;
+
+- Call to `BIO_new_bio_pair` is changed to `BIO_new_dgram_pair`
+  (as for ddd-05-mem-nonblocking);
+
+- Some reordering of code required by the design of libuv.
+
+### Actual changes
+
+The following additional changes needed to be made:
+
+- Change of method name (as for ddd-01-conn-blocking);
+
+- Use of ALPN (as for ddd-01-conn-blocking);
+
+- `BIO_new_dgram_pair` renamed to `BIO_new_bio_dgram_pair` (as for
+  ddd-05-mem-nonblocking);
+
+- `SSL_get_timeout` replaced with `SSL_get_event_timeout` (as for
+  ddd-02-conn-nonblocking);
+
+- `SSL_pump` renamed to `SSL_handle_events` (as for ddd-02-conn-nonblocking);
+
+- Fixes to use of libuv based on a corrected understanding
+  of its operation, and changes that necessarily ensue.
+
+Conclusions
+-----------
+
+The DDD process has successfully delivered on the objective of delivering a QUIC
+API which can be used with only minimal API changes. The additional changes on
+top of those originally planned which were required to successfully execute the
+demos using QUIC were highly limited in scope and mostly constituted only minor
+changes. The sum total of the changes required for each demo (both planned and
+additional), as denoted in each DDD demo file under `#ifdef USE_QUIC` guards,
+are both minimal and limited in scope.
+
+“Minimal” and “limited” are distinct criteria. If inexorable technical
+requirements dictate, an enormous set of changes to an application could be
+considered “minimal”. The changes required to representative applications, as
+demonstrated by the DDD demos, are not merely minimal but also limited.
+
+For example, while the extent of these necessary changes varies by the
+sophistication of each demo and the kind of application usage pattern it
+represents, some demos in particular demonstrate exceptionally small changesets;
+for example, ddd-01-conn-blocking and ddd-02-conn-nonblocking-threads, with
+ddd-01-conn-blocking literally being enabled by a single line change assuming
+ALPN is already configured.
+
+This report concludes the DDD process for the single-stream QUIC client API
+design process, which sought to validate our API design and API ease of use for
+existing applications seeking to adopt QUIC.

--- a/doc/designs/ddd/ddd-01-conn-blocking.c
+++ b/doc/designs/ddd/ddd-01-conn-blocking.c
@@ -121,11 +121,20 @@ void teardown_ctx(SSL_CTX *ctx)
  */
 int main(int argc, char **argv)
 {
-    const char msg[] = "GET / HTTP/1.0\r\nHost: www.openssl.org\r\n\r\n";
+    static char msg[384], host_port[300];
     SSL_CTX *ctx = NULL;
     BIO *b = NULL;
     char buf[2048];
     int l, res = 1;
+
+    if (argc < 3) {
+        fprintf(stderr, "usage: %s host port\n", argv[0]);
+        goto fail;
+    }
+
+    snprintf(host_port, sizeof(host_port), "%s:%s\n", argv[1], argv[2]);
+    snprintf(msg, sizeof(msg),
+             "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", argv[1]);
 
     ctx = create_ssl_ctx();
     if (ctx == NULL) {
@@ -133,7 +142,7 @@ int main(int argc, char **argv)
         goto fail;
     }
 
-    b = new_conn(ctx, "www.openssl.org:443");
+    b = new_conn(ctx, host_port);
     if (b == NULL) {
         fprintf(stderr, "could not create conn\n");
         goto fail;

--- a/doc/designs/ddd/ddd-01-conn-blocking.c
+++ b/doc/designs/ddd/ddd-01-conn-blocking.c
@@ -20,7 +20,11 @@ SSL_CTX *create_ssl_ctx(void)
 {
     SSL_CTX *ctx;
 
+#ifdef USE_QUIC
+    ctx = SSL_CTX_new(QUIC_client_method());
+#else
     ctx = SSL_CTX_new(TLS_client_method());
+#endif
     if (ctx == NULL)
         return NULL;
 

--- a/doc/designs/ddd/ddd-02-conn-nonblocking-threads.c
+++ b/doc/designs/ddd/ddd-02-conn-nonblocking-threads.c
@@ -32,7 +32,11 @@ SSL_CTX *create_ssl_ctx(void)
 {
     SSL_CTX *ctx;
 
+#ifdef USE_QUIC
+    ctx = SSL_CTX_new(QUIC_client_thread_method());
+#else
     ctx = SSL_CTX_new(TLS_client_method());
+#endif
     if (ctx == NULL)
         return NULL;
 
@@ -170,7 +174,11 @@ int rx(APP_CONN *conn, void *buf, int buf_len)
  */
 int get_conn_fd(APP_CONN *conn)
 {
+#ifdef USE_QUIC
+    return BIO_get_poll_fd(conn->ssl_bio, NULL);
+#else
     return BIO_get_fd(conn->ssl_bio, NULL);
+#endif
 }
 
 /*
@@ -188,7 +196,11 @@ int get_conn_fd(APP_CONN *conn)
  */
 int get_conn_pending_tx(APP_CONN *conn)
 {
+#ifdef USE_QUIC
+    return POLLIN | POLLOUT | POLLERR;
+#else
     return (conn->tx_need_rx ? POLLIN : 0) | POLLOUT | POLLERR;
+#endif
 }
 
 int get_conn_pending_rx(APP_CONN *conn)

--- a/doc/designs/ddd/ddd-02-conn-nonblocking-threads.c
+++ b/doc/designs/ddd/ddd-02-conn-nonblocking-threads.c
@@ -1,0 +1,298 @@
+#include <sys/poll.h>
+#include <openssl/ssl.h>
+
+/*
+ * Demo 2: Client — Managed Connection — Asynchronous Nonblocking
+ * ==============================================================
+ *
+ * This is an example of (part of) an application which uses libssl in an
+ * asynchronous, nonblocking fashion. The functions show all interactions with
+ * libssl the application makes, and would hypothetically be linked into a
+ * larger application.
+ *
+ * In this example, libssl still makes syscalls directly using an fd, which is
+ * configured in nonblocking mode. As such, the application can still be
+ * abstracted from the details of what that fd is (is it a TCP socket? is it a
+ * UDP socket?); this code passes the application an fd and the application
+ * simply calls back into this code when poll()/etc. indicates it is ready.
+ */
+typedef struct app_conn_st {
+    SSL *ssl;
+    BIO *ssl_bio;
+    int rx_need_tx, tx_need_rx;
+} APP_CONN;
+
+/*
+ * The application is initializing and wants an SSL_CTX which it will use for
+ * some number of outgoing connections, which it creates in subsequent calls to
+ * new_conn. The application may also call this function multiple times to
+ * create multiple SSL_CTX.
+ */
+SSL_CTX *create_ssl_ctx(void)
+{
+    SSL_CTX *ctx;
+
+    ctx = SSL_CTX_new(TLS_client_method());
+    if (ctx == NULL)
+        return NULL;
+
+    /* Enable trust chain verification. */
+    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+
+    /* Load default root CA store. */
+    if (SSL_CTX_set_default_verify_paths(ctx) == 0) {
+        SSL_CTX_free(ctx);
+        return NULL;
+    }
+
+    return ctx;
+}
+
+/*
+ * The application wants to create a new outgoing connection using a given
+ * SSL_CTX.
+ *
+ * hostname is a string like "openssl.org:443" or "[::1]:443".
+ */
+APP_CONN *new_conn(SSL_CTX *ctx, const char *hostname)
+{
+    APP_CONN *conn;
+    BIO *out, *buf;
+    SSL *ssl = NULL;
+    const char *bare_hostname;
+
+    conn = calloc(1, sizeof(APP_CONN));
+    if (conn == NULL)
+        return NULL;
+
+    out = BIO_new_ssl_connect(ctx);
+    if (out == NULL) {
+        free(conn);
+        return NULL;
+    }
+
+    if (BIO_get_ssl(out, &ssl) == 0) {
+        BIO_free_all(out);
+        free(conn);
+        return NULL;
+    }
+
+    buf = BIO_new(BIO_f_buffer());
+    if (buf == NULL) {
+        BIO_free_all(out);
+        free(conn);
+        return NULL;
+    }
+
+    BIO_push(out, buf);
+
+    if (BIO_set_conn_hostname(out, hostname) == 0) {
+        BIO_free_all(out);
+        free(conn);
+        return NULL;
+    }
+
+    /* Returns the parsed hostname extracted from the hostname:port string. */
+    bare_hostname = BIO_get_conn_hostname(out);
+    if (bare_hostname == NULL) {
+        BIO_free_all(out);
+        free(conn);
+        return NULL;
+    }
+
+    /* Tell the SSL object the hostname to check certificates against. */
+    if (SSL_set1_host(ssl, bare_hostname) <= 0) {
+        BIO_free_all(out);
+        free(conn);
+        return NULL;
+    }
+
+    /* Make the BIO nonblocking. */
+    BIO_set_nbio(out, 1);
+
+    conn->ssl_bio = out;
+    return conn;
+}
+
+/*
+ * Non-blocking transmission.
+ *
+ * Returns -1 on error. Returns -2 if the function would block (corresponds to
+ * EWOULDBLOCK).
+ */
+int tx(APP_CONN *conn, const void *buf, int buf_len)
+{
+    int l;
+
+    conn->tx_need_rx = 0;
+
+    l = BIO_write(conn->ssl_bio, buf, buf_len);
+    if (l <= 0) {
+        if (BIO_should_retry(conn->ssl_bio)) {
+            conn->tx_need_rx = BIO_should_read(conn->ssl_bio);
+            return -2;
+        } else {
+            return -1;
+        }
+    }
+
+    return l;
+}
+
+/*
+ * Non-blocking reception.
+ *
+ * Returns -1 on error. Returns -2 if the function would block (corresponds to
+ * EWOULDBLOCK).
+ */
+int rx(APP_CONN *conn, void *buf, int buf_len)
+{
+    int l;
+
+    conn->rx_need_tx = 0;
+
+    l = BIO_read(conn->ssl_bio, buf, buf_len);
+    if (l <= 0) {
+        if (BIO_should_retry(conn->ssl_bio)) {
+            conn->rx_need_tx = BIO_should_write(conn->ssl_bio);
+            return -2;
+        } else {
+            return -1;
+        }
+    }
+
+    return l;
+}
+
+/*
+ * The application wants to know a fd it can poll on to determine when the
+ * SSL state machine needs to be pumped.
+ */
+int get_conn_fd(APP_CONN *conn)
+{
+    return BIO_get_fd(conn->ssl_bio, NULL);
+}
+
+/*
+ * These functions returns zero or more of:
+ *
+ *   POLLIN:    The SSL state machine is interested in socket readability events.
+ *
+ *   POLLOUT:   The SSL state machine is interested in socket writeability events.
+ *
+ *   POLLERR:   The SSL state machine is interested in socket error events.
+ *
+ * get_conn_pending_tx returns events which may cause SSL_write to make
+ * progress and get_conn_pending_rx returns events which may cause SSL_read
+ * to make progress.
+ */
+int get_conn_pending_tx(APP_CONN *conn)
+{
+    return (conn->tx_need_rx ? POLLIN : 0) | POLLOUT | POLLERR;
+}
+
+int get_conn_pending_rx(APP_CONN *conn)
+{
+    return (conn->rx_need_tx ? POLLOUT : 0) | POLLIN | POLLERR;
+}
+
+/*
+ * The application wants to close the connection and free bookkeeping
+ * structures.
+ */
+void teardown(APP_CONN *conn)
+{
+    BIO_free_all(conn->ssl_bio);
+    free(conn);
+}
+
+/*
+ * The application is shutting down and wants to free a previously
+ * created SSL_CTX.
+ */
+void teardown_ctx(SSL_CTX *ctx)
+{
+    SSL_CTX_free(ctx);
+}
+
+/*
+ * ============================================================================
+ * Example driver for the above code. This is just to demonstrate that the code
+ * works and is not intended to be representative of a real application.
+ */
+int main(int argc, char **argv)
+{
+    static char tx_msg[384], host_port[300];
+    const char *tx_p = tx_msg;
+    char rx_buf[2048];
+    int res = 1, l, tx_len = sizeof(tx_msg)-1;
+    int timeout = 2000 /* ms */;
+    APP_CONN *conn = NULL;
+    SSL_CTX *ctx = NULL;
+
+    if (argc < 3) {
+        fprintf(stderr, "usage: %s host port\n", argv[0]);
+        goto fail;
+    }
+
+    snprintf(host_port, sizeof(host_port), "%s:%s", argv[1], argv[2]);
+    snprintf(tx_msg, sizeof(tx_msg),
+             "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", argv[1]);
+
+    ctx = create_ssl_ctx();
+    if (ctx == NULL) {
+        fprintf(stderr, "cannot create SSL context\n");
+        goto fail;
+    }
+
+    conn = new_conn(ctx, host_port);
+    if (conn == NULL) {
+        fprintf(stderr, "cannot establish connection\n");
+        goto fail;
+    }
+
+    /* TX */
+    while (tx_len != 0) {
+        l = tx(conn, tx_p, tx_len);
+        if (l > 0) {
+            tx_p += l;
+            tx_len -= l;
+        } else if (l == -1) {
+            fprintf(stderr, "tx error\n");
+        } else if (l == -2) {
+            struct pollfd pfd = {0};
+            pfd.fd = get_conn_fd(conn);
+            pfd.events = get_conn_pending_tx(conn);
+            if (poll(&pfd, 1, timeout) == 0) {
+                fprintf(stderr, "tx timeout\n");
+                goto fail;
+            }
+        }
+    }
+
+    /* RX */
+    for (;;) {
+        l = rx(conn, rx_buf, sizeof(rx_buf));
+        if (l > 0) {
+            fwrite(rx_buf, 1, l, stdout);
+        } else if (l == -1) {
+            break;
+        } else if (l == -2) {
+            struct pollfd pfd = {0};
+            pfd.fd = get_conn_fd(conn);
+            pfd.events = get_conn_pending_rx(conn);
+            if (poll(&pfd, 1, timeout) == 0) {
+                fprintf(stderr, "rx timeout\n");
+                goto fail;
+            }
+        }
+    }
+
+    res = 0;
+fail:
+    if (conn != NULL)
+        teardown(conn);
+    if (ctx != NULL)
+        teardown_ctx(ctx);
+    return res;
+}

--- a/doc/designs/ddd/ddd-02-conn-nonblocking.c
+++ b/doc/designs/ddd/ddd-02-conn-nonblocking.c
@@ -222,13 +222,22 @@ void teardown_ctx(SSL_CTX *ctx)
  */
 int main(int argc, char **argv)
 {
-    const char tx_msg[] = "GET / HTTP/1.0\r\nHost: www.openssl.org\r\n\r\n";
+    static char tx_msg[384], host_port[300];
     const char *tx_p = tx_msg;
     char rx_buf[2048];
     int res = 1, l, tx_len = sizeof(tx_msg)-1;
     int timeout = 2000 /* ms */;
     APP_CONN *conn = NULL;
-    SSL_CTX *ctx;
+    SSL_CTX *ctx = NULL;
+
+    if (argc < 3) {
+        fprintf(stderr, "usage: %s host port\n", argv[0]);
+        goto fail;
+    }
+
+    snprintf(host_port, sizeof(host_port), "%s:%s", argv[1], argv[2]);
+    snprintf(tx_msg, sizeof(tx_msg),
+             "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", argv[1]);
 
     ctx = create_ssl_ctx();
     if (ctx == NULL) {
@@ -236,7 +245,7 @@ int main(int argc, char **argv)
         goto fail;
     }
 
-    conn = new_conn(ctx, "www.openssl.org:443");
+    conn = new_conn(ctx, host_port);
     if (conn == NULL) {
         fprintf(stderr, "cannot establish connection\n");
         goto fail;

--- a/doc/designs/ddd/ddd-02-conn-nonblocking.c
+++ b/doc/designs/ddd/ddd-02-conn-nonblocking.c
@@ -32,7 +32,11 @@ SSL_CTX *create_ssl_ctx(void)
 {
     SSL_CTX *ctx;
 
+#ifdef USE_QUIC
+    ctx = SSL_CTX_new(QUIC_client_method());
+#else
     ctx = SSL_CTX_new(TLS_client_method());
+#endif
     if (ctx == NULL)
         return NULL;
 
@@ -77,7 +81,11 @@ APP_CONN *new_conn(SSL_CTX *ctx, const char *hostname)
         return NULL;
     }
 
+#ifdef USE_QUIC
+    buf = BIO_new(BIO_f_dgram_buffer());
+#else
     buf = BIO_new(BIO_f_buffer());
+#endif
     if (buf == NULL) {
         BIO_free_all(out);
         free(conn);
@@ -170,7 +178,11 @@ int rx(APP_CONN *conn, void *buf, int buf_len)
  */
 int get_conn_fd(APP_CONN *conn)
 {
+#ifdef USE_QUIC
+    return BIO_get_poll_fd(conn->ssl_bio, NULL);
+#else
     return BIO_get_fd(conn->ssl_bio, NULL);
+#endif
 }
 
 /*
@@ -188,13 +200,39 @@ int get_conn_fd(APP_CONN *conn)
  */
 int get_conn_pending_tx(APP_CONN *conn)
 {
+#ifdef USE_QUIC
+    return POLLIN | POLLOUT | POLLERR;
+#else
     return (conn->tx_need_rx ? POLLIN : 0) | POLLOUT | POLLERR;
+#endif
 }
 
 int get_conn_pending_rx(APP_CONN *conn)
 {
     return (conn->rx_need_tx ? POLLOUT : 0) | POLLIN | POLLERR;
 }
+
+#ifdef USE_QUIC
+/*
+ * Returns the number of milliseconds after which some call to libssl must be
+ * made. Any call (BIO_read/BIO_write/BIO_pump) will do. Returns -1 if
+ * there is no need for such a call. This may change after the next call
+ * to libssl.
+ */
+int get_conn_pump_timeout(APP_CONN *conn)
+{
+    return BIO_get_timeout(conn->ssl_bio);
+}
+
+/*
+ * Called to advance internals of libssl state machines without having to
+ * perform an application-level read/write.
+ */
+void pump(APP_CONN *conn)
+{
+    BIO_pump(conn->ssl_bio);
+}
+#endif
 
 /*
  * The application wants to close the connection and free bookkeeping
@@ -220,15 +258,36 @@ void teardown_ctx(SSL_CTX *ctx)
  * Example driver for the above code. This is just to demonstrate that the code
  * works and is not intended to be representative of a real application.
  */
+#include <sys/time.h>
+
+static inline void ms_to_timeval(struct timeval *t, int ms)
+{
+    t->tv_sec   = ms < 0 ? -1 : ms/1000;
+    t->tv_usec  = ms < 0 ? 0 : (ms%1000)*1000;
+}
+
+static inline int timeval_to_ms(const struct timeval *t)
+{
+    return t->tv_sec*1000 + t->tv_usec/1000;
+}
+
 int main(int argc, char **argv)
 {
     static char tx_msg[384], host_port[300];
     const char *tx_p = tx_msg;
     char rx_buf[2048];
     int res = 1, l, tx_len = sizeof(tx_msg)-1;
+#ifdef USE_QUIC
+    struct timeval timeout;
+#else
     int timeout = 2000 /* ms */;
+#endif
     APP_CONN *conn = NULL;
     SSL_CTX *ctx = NULL;
+
+#ifdef USE_QUIC
+    ms_to_timeval(&timeout, 2000);
+#endif
 
     if (argc < 3) {
         fprintf(stderr, "usage: %s host port\n", argv[0]);
@@ -260,12 +319,38 @@ int main(int argc, char **argv)
         } else if (l == -1) {
             fprintf(stderr, "tx error\n");
         } else if (l == -2) {
+#ifdef USE_QUIC
+            struct timeval start, now, deadline, t;
+#endif
             struct pollfd pfd = {0};
+
+#ifdef USE_QUIC
+            ms_to_timeval(&t, get_conn_pump_timeout(conn));
+            if (t.tv_sec < 0 || timercmp(&t, &timeout, >))
+                t = timeout;
+
+            gettimeofday(&start, NULL);
+            timeradd(&start, &timeout, &deadline);
+#endif
+
             pfd.fd = get_conn_fd(conn);
             pfd.events = get_conn_pending_tx(conn);
-            if (poll(&pfd, 1, timeout) == 0) {
-                fprintf(stderr, "tx timeout\n");
-                goto fail;
+#ifdef USE_QUIC
+            if (poll(&pfd, 1, timeval_to_ms(&t)) == 0)
+#else
+            if (poll(&pfd, 1, timeout) == 0)
+#endif
+            {
+#ifdef USE_QUIC
+                pump(conn);
+
+                gettimeofday(&now, NULL);
+                if (timercmp(&now, &deadline, >=))
+#endif
+                {
+                    fprintf(stderr, "tx timeout\n");
+                    goto fail;
+                }
             }
         }
     }
@@ -278,12 +363,38 @@ int main(int argc, char **argv)
         } else if (l == -1) {
             break;
         } else if (l == -2) {
+#ifdef USE_QUIC
+            struct timeval start, now, deadline, t;
+#endif
             struct pollfd pfd = {0};
+
+#ifdef USE_QUIC
+            ms_to_timeval(&t, get_conn_pump_timeout(conn));
+            if (t.tv_sec < 0 || timercmp(&t, &timeout, >))
+                t = timeout;
+
+            gettimeofday(&start, NULL);
+            timeradd(&start, &timeout, &deadline);
+#endif
+
             pfd.fd = get_conn_fd(conn);
             pfd.events = get_conn_pending_rx(conn);
-            if (poll(&pfd, 1, timeout) == 0) {
-                fprintf(stderr, "rx timeout\n");
-                goto fail;
+#ifdef USE_QUIC
+            if (poll(&pfd, 1, timeval_to_ms(&t)) == 0)
+#else
+            if (poll(&pfd, 1, timeout) == 0)
+#endif
+            {
+#ifdef USE_QUIC
+                pump(conn);
+
+                gettimeofday(&now, NULL);
+                if (timercmp(&now, &deadline, >=))
+#endif
+                {
+                    fprintf(stderr, "rx timeout\n");
+                    goto fail;
+                }
             }
         }
     }

--- a/doc/designs/ddd/ddd-03-fd-blocking.c
+++ b/doc/designs/ddd/ddd-03-fd-blocking.c
@@ -121,11 +121,19 @@ void teardown_ctx(SSL_CTX *ctx)
 int main(int argc, char **argv)
 {
     int rc, fd = -1, l, res = 1;
-    const char msg[] = "GET / HTTP/1.0\r\nHost: www.openssl.org\r\n\r\n";
+    static char msg[300];
     struct addrinfo hints = {0}, *result = NULL;
     SSL *ssl = NULL;
-    SSL_CTX *ctx;
+    SSL_CTX *ctx = NULL;
     char buf[2048];
+
+    if (argc < 3) {
+        fprintf(stderr, "usage: %s host port\n", argv[0]);
+        goto fail;
+    }
+
+    snprintf(msg, sizeof(msg),
+             "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", argv[1]);
 
     ctx = create_ssl_ctx();
     if (ctx == NULL) {
@@ -136,7 +144,7 @@ int main(int argc, char **argv)
     hints.ai_family     = AF_INET;
     hints.ai_socktype   = SOCK_STREAM;
     hints.ai_flags      = AI_PASSIVE;
-    rc = getaddrinfo("www.openssl.org", "443", &hints, &result);
+    rc = getaddrinfo(argv[1], argv[2], &hints, &result);
     if (rc < 0) {
         fprintf(stderr, "cannot resolve\n");
         goto fail;
@@ -156,7 +164,7 @@ int main(int argc, char **argv)
         goto fail;
     }
 
-    ssl = new_conn(ctx, fd, "www.openssl.org");
+    ssl = new_conn(ctx, fd, argv[1]);
     if (ssl == NULL) {
         fprintf(stderr, "cannot create connection\n");
         goto fail;

--- a/doc/designs/ddd/ddd-03-fd-blocking.c
+++ b/doc/designs/ddd/ddd-03-fd-blocking.c
@@ -21,7 +21,11 @@ SSL_CTX *create_ssl_ctx(void)
 {
     SSL_CTX *ctx;
 
+#ifdef USE_QUIC
+    ctx = SSL_CTX_new(QUIC_client_method());
+#else
     ctx = SSL_CTX_new(TLS_client_method());
+#endif
     if (ctx == NULL)
         return NULL;
 
@@ -152,7 +156,11 @@ int main(int argc, char **argv)
 
     signal(SIGPIPE, SIG_IGN);
 
+#ifdef USE_QUIC
+    fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+#else
     fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+#endif
     if (fd < 0) {
         fprintf(stderr, "cannot create socket\n");
         goto fail;

--- a/doc/designs/ddd/ddd-05-mem-nonblocking.c
+++ b/doc/designs/ddd/ddd-05-mem-nonblocking.c
@@ -189,9 +189,9 @@ int rx(APP_CONN *conn, void *buf, int buf_len)
 
 /*
  * Called to get data which has been enqueued for transmission to the network
- * by OpenSSL. For QUIC, this always outputs a single frame.
+ * by OpenSSL. For QUIC, this always outputs a single datagram.
  *
- * IMPORTANT (QUIC): If buf_len is inadequate to hold the frame, it is truncated
+ * IMPORTANT (QUIC): If buf_len is inadequate to hold the datagram, it is truncated
  * (similar to read(2)). A buffer size of at least 1472 must be used by default
  * to guarantee this does not occur.
  */
@@ -203,7 +203,7 @@ int read_net_tx(APP_CONN *conn, void *buf, int buf_len)
 /*
  * Called to feed data which has been received from the network to OpenSSL.
  *
- * QUIC: buf must contain the entirety of a single frame. It will be consumed
+ * QUIC: buf must contain the entirety of a single datagram. It will be consumed
  * entirely (return value == buf_len) or not at all.
  */
 int write_net_rx(APP_CONN *conn, const void *buf, int buf_len)

--- a/doc/designs/ddd/ddd-05-mem-nonblocking.c
+++ b/doc/designs/ddd/ddd-05-mem-nonblocking.c
@@ -315,14 +315,23 @@ static int pump(APP_CONN *conn, int fd, int events, int timeout)
 int main(int argc, char **argv)
 {
     int rc, fd = -1, res = 1;
-    const char tx_msg[] = "GET / HTTP/1.0\r\nHost: www.openssl.org\r\n\r\n";
+    static char tx_msg[300];
     const char *tx_p = tx_msg;
     char rx_buf[2048];
     int l, tx_len = sizeof(tx_msg)-1;
     int timeout = 2000 /* ms */;
     APP_CONN *conn = NULL;
     struct addrinfo hints = {0}, *result = NULL;
-    SSL_CTX *ctx;
+    SSL_CTX *ctx = NULL;
+
+    if (argc < 3) {
+        fprintf(stderr, "usage: %s host port\n", argv[0]);
+        goto fail;
+    }
+
+    snprintf(tx_msg, sizeof(tx_msg),
+             "GET / HTTP/1.0\r\nHost: %s\r\n\r\n",
+             argv[1]);
 
     ctx = create_ssl_ctx();
     if (ctx == NULL) {
@@ -333,7 +342,7 @@ int main(int argc, char **argv)
     hints.ai_family     = AF_INET;
     hints.ai_socktype   = SOCK_STREAM;
     hints.ai_flags      = AI_PASSIVE;
-    rc = getaddrinfo("www.openssl.org", "443", &hints, &result);
+    rc = getaddrinfo(argv[1], argv[2], &hints, &result);
     if (rc < 0) {
         fprintf(stderr, "cannot resolve\n");
         goto fail;
@@ -359,7 +368,7 @@ int main(int argc, char **argv)
         goto fail;
     }
 
-    conn = new_conn(ctx, "www.openssl.org");
+    conn = new_conn(ctx, argv[1]);
     if (conn == NULL) {
         fprintf(stderr, "cannot establish connection\n");
         goto fail;

--- a/doc/designs/ddd/ddd-06-mem-uv.c
+++ b/doc/designs/ddd/ddd-06-mem-uv.c
@@ -237,11 +237,12 @@ static void on_rx_push(APP_CONN *conn)
 
         srd = SSL_read(conn->ssl, buf, buf_len);
         flush_write_buf(conn);
-        if (srd < 0) {
-            free(buf);
+        if (srd <= 0) {
             rc = SSL_get_error(conn->ssl, srd);
-            if (rc == SSL_ERROR_WANT_READ)
+            if (rc == SSL_ERROR_WANT_READ) {
+                free(buf);
                 return;
+            }
         }
 
         conn->app_read_cb(conn, buf, srd, conn->app_read_arg);

--- a/doc/man3/BIO_s_connect.pod
+++ b/doc/man3/BIO_s_connect.pod
@@ -7,7 +7,7 @@ BIO_set_conn_hostname, BIO_set_conn_port,
 BIO_set_conn_address, BIO_set_conn_ip_family,
 BIO_get_conn_hostname, BIO_get_conn_port,
 BIO_get_conn_address, BIO_get_conn_ip_family,
-BIO_set_nbio, BIO_set_sock_type, BIO_get_sock_type, BIO_get_dgram_bio,
+BIO_set_nbio, BIO_set_sock_type, BIO_get_sock_type, BIO_get0_dgram_bio,
 BIO_do_connect - connect BIO
 
 =head1 SYNOPSIS
@@ -31,7 +31,7 @@ BIO_do_connect - connect BIO
 
  int BIO_set_sock_type(BIO *b, int sock_type);
  int BIO_get_sock_type(BIO *b);
- int BIO_get_dgram_bio(BIO *B, BIO **dgram_bio);
+ int BIO_get0_dgram_bio(BIO *B, BIO **dgram_bio);
 
  long BIO_do_connect(BIO *b);
 
@@ -112,8 +112,10 @@ default) and B<SOCK_DGRAM>. If B<SOCK_DGRAM> is configured, the connection
 created is a UDP datagram socket handled via L<BIO_s_datagram(3)>.
 I/O calls such as L<BIO_read(3)> and L<BIO_write(3)> are forwarded transparently
 to an internal L<BIO_s_datagram(3)> instance. The created L<BIO_s_datagram(3)>
-instance can be retrieved using BIO_get_dgram_bio() if desired, which writes
-a pointer to the L<BIO_s_datagram(3)> instance to I<*dgram_bio>.
+instance can be retrieved using BIO_get0_dgram_bio() if desired, which writes
+a pointer to the L<BIO_s_datagram(3)> instance to I<*dgram_bio>. The lifetime
+of the internal L<BIO_s_datagram(3)> is managed by BIO_s_connect() and does not
+need to be freed by the caller.
 
 BIO_get_sock_type() retrieves the value set using BIO_set_sock_type().
 
@@ -181,7 +183,7 @@ BIO_set_sock_type() returns 1 on success or 0 on failure.
 
 BIO_get_sock_type() returns a socket type or 0 if the call is not supported.
 
-BIO_get_dgram_bio() returns 1 on success or 0 on failure.
+BIO_get0_dgram_bio() returns 1 on success or 0 on failure.
 
 =head1 EXAMPLES
 

--- a/doc/man3/BIO_s_connect.pod
+++ b/doc/man3/BIO_s_connect.pod
@@ -7,7 +7,8 @@ BIO_set_conn_hostname, BIO_set_conn_port,
 BIO_set_conn_address, BIO_set_conn_ip_family,
 BIO_get_conn_hostname, BIO_get_conn_port,
 BIO_get_conn_address, BIO_get_conn_ip_family,
-BIO_set_nbio, BIO_do_connect - connect BIO
+BIO_set_nbio, BIO_set_sock_type, BIO_get_sock_type, BIO_get_dgram_bio,
+BIO_do_connect - connect BIO
 
 =head1 SYNOPSIS
 
@@ -27,6 +28,10 @@ BIO_set_nbio, BIO_do_connect - connect BIO
  const long BIO_get_conn_ip_family(BIO *b);
 
  long BIO_set_nbio(BIO *b, long n);
+
+ int BIO_set_sock_type(BIO *b, int sock_type);
+ int BIO_get_sock_type(BIO *b);
+ int BIO_get_dgram_bio(BIO *B, BIO **dgram_bio);
 
  long BIO_do_connect(BIO *b);
 
@@ -101,6 +106,17 @@ The call BIO_should_retry() should be used for non blocking connect BIOs
 to determine if the call should be retried.
 If a connection has already been established this call has no effect.
 
+BIO_set_sock_type() can be used to set a socket type value as would be passed in
+a call to socket(2). The only currently supported values are B<SOCK_STREAM> (the
+default) and B<SOCK_DGRAM>. If B<SOCK_DGRAM> is configured, the connection
+created is a UDP datagram socket handled via L<BIO_s_datagram(3)>.
+I/O calls such as L<BIO_read(3)> and L<BIO_write(3)> are forwarded transparently
+to an internal L<BIO_s_datagram(3)> instance. The created L<BIO_s_datagram(3)>
+instance can be retrieved using BIO_get_dgram_bio() if desired, which writes
+a pointer to the L<BIO_s_datagram(3)> instance to I<*dgram_bio>.
+
+BIO_get_sock_type() retrieves the value set using BIO_set_sock_type().
+
 =head1 NOTES
 
 If blocking I/O is set then a non positive return value from any
@@ -160,6 +176,12 @@ BIO_set_nbio() returns 1 or <=0 if an error occurs.
 
 BIO_do_connect() returns 1 if the connection was successfully
 established and <=0 if the connection failed.
+
+BIO_set_sock_type() returns 1 on success or 0 on failure.
+
+BIO_get_sock_type() returns a socket type or 0 if the call is not supported.
+
+BIO_get_dgram_bio() returns 1 on success or 0 on failure.
 
 =head1 EXAMPLES
 

--- a/doc/man3/BIO_s_datagram.pod
+++ b/doc/man3/BIO_s_datagram.pod
@@ -9,6 +9,7 @@ BIO_dgram_recv_timedout,
 BIO_dgram_send_timedout,
 BIO_dgram_get_peer,
 BIO_dgram_set_peer,
+BIO_dgram_detect_peer_addr,
 BIO_dgram_get_mtu_overhead - Network BIO with datagram semantics
 
 =head1 SYNOPSIS
@@ -25,6 +26,7 @@ BIO_dgram_get_mtu_overhead - Network BIO with datagram semantics
  int BIO_dgram_get_peer(BIO *bio, BIO_ADDR *peer);
  int BIO_dgram_set_peer(BIO *bio, const BIO_ADDR *peer);
  int BIO_dgram_get_mtu_overhead(BIO *bio);
+ int BIO_dgram_detect_peer_addr(BIO *bio, BIO_ADDR *peer);
 
 =head1 DESCRIPTION
 
@@ -144,6 +146,15 @@ hazardous when used with unconnected network sockets; see above.
 This does not affect the operation of L<BIO_sendmmsg(3)>.
 L<BIO_recvmmsg(3)> does not affect the value set by BIO_dgram_set_peer().
 
+=item BIO_dgram_detect_peer_addr (BIO_CTRL_DGRAM_DETECT_PEER_ADDR)
+
+This is similar to BIO_dgram_get_peer() except that if the peer address has not
+been set on the BIO object, an OS call such as getpeername(2) will be attempted
+to try and autodetect the peer address to which the underlying socket is
+connected. Other BIOs may also implement this control if they are capable of
+sensing a peer address, without necessarily also implementing
+BIO_dgram_set_peer() and BIO_dgram_get_peer().
+
 =item BIO_dgram_recv_timeout (BIO_CTRL_DGRAM_GET_RECV_TIMER_EXP)
 
 Returns 1 if the last I/O operation performed on the BIO (for example, via a
@@ -231,8 +242,12 @@ BIO_s_datagram() returns a BIO method.
 
 BIO_new_dgram() returns a BIO on success and NULL on failure.
 
-BIO_ctrl_dgram_connect(), BIO_ctrl_set_connected(),
-BIO_dgram_get_peer(), BIO_dgram_set_peer() return 1 on success and 0 on failure.
+BIO_ctrl_dgram_connect(), BIO_ctrl_set_connected() and BIO_dgram_set_peer()
+return 1 on success and 0 on failure.
+
+BIO_dgram_get_peer() and BIO_dgram_detect_peer_addr() return 0 on failure and
+the number of bytes for the outputted address representation (a positive value)
+on success.
 
 BIO_dgram_recv_timedout() and BIO_dgram_send_timedout() return 0 or 1 depending
 on the circumstance; see discussion above.

--- a/include/internal/quic_channel.h
+++ b/include/internal/quic_channel.h
@@ -304,6 +304,12 @@ int ossl_quic_channel_set_net_rbio(QUIC_CHANNEL *ch, BIO *net_rbio);
 int ossl_quic_channel_set_net_wbio(QUIC_CHANNEL *ch, BIO *net_wbio);
 
 /*
+ * Re-poll the network BIOs already set to determine if their support
+ * for polling has changed.
+ */
+int ossl_quic_channel_update_poll_descriptors(QUIC_CHANNEL *ch);
+
+/*
  * Returns an existing stream by stream ID. Returns NULL if the stream does not
  * exist.
  */

--- a/include/internal/quic_reactor.h
+++ b/include/internal/quic_reactor.h
@@ -94,6 +94,13 @@ typedef struct quic_reactor_st {
      */
     unsigned int net_read_desired   : 1;
     unsigned int net_write_desired  : 1;
+
+    /*
+     * Are the read and write poll descriptors we are currently configured with
+     * things we can actually poll?
+     */
+    unsigned int can_poll_r : 1;
+    unsigned int can_poll_w : 1;
 } QUIC_REACTOR;
 
 void ossl_quic_reactor_init(QUIC_REACTOR *rtor,
@@ -108,12 +115,16 @@ void ossl_quic_reactor_set_poll_r(QUIC_REACTOR *rtor,
 void ossl_quic_reactor_set_poll_w(QUIC_REACTOR *rtor,
                                   const BIO_POLL_DESCRIPTOR *w);
 
-const BIO_POLL_DESCRIPTOR *ossl_quic_reactor_get_poll_r(QUIC_REACTOR *rtor);
+const BIO_POLL_DESCRIPTOR *ossl_quic_reactor_get_poll_r(const QUIC_REACTOR *rtor);
+const BIO_POLL_DESCRIPTOR *ossl_quic_reactor_get_poll_w(const QUIC_REACTOR *rtor);
 
-const BIO_POLL_DESCRIPTOR *ossl_quic_reactor_get_poll_w(QUIC_REACTOR *rtor);
+int ossl_quic_reactor_can_poll_r(const QUIC_REACTOR *rtor);
+int ossl_quic_reactor_can_poll_w(const QUIC_REACTOR *rtor);
+
+int ossl_quic_reactor_can_support_poll_descriptor(const QUIC_REACTOR *rtor,
+                                                  const BIO_POLL_DESCRIPTOR *d);
 
 int ossl_quic_reactor_net_read_desired(QUIC_REACTOR *rtor);
-
 int ossl_quic_reactor_net_write_desired(QUIC_REACTOR *rtor);
 
 OSSL_TIME ossl_quic_reactor_get_tick_deadline(QUIC_REACTOR *rtor);

--- a/include/internal/quic_txp.h
+++ b/include/internal/quic_txp.h
@@ -128,7 +128,10 @@ int ossl_quic_tx_packetiser_set_cur_dcid(OSSL_QUIC_TX_PACKETISER *txp,
 int ossl_quic_tx_packetiser_set_cur_scid(OSSL_QUIC_TX_PACKETISER *txp,
                                          const QUIC_CONN_ID *scid);
 
-/* Change the destination L4 address the TXP uses to send datagrams. */
+/*
+ * Change the destination L4 address the TXP uses to send datagrams. Specify
+ * NULL (or AF_UNSPEC) to disable use of addressed mode.
+ */
 int ossl_quic_tx_packetiser_set_peer(OSSL_QUIC_TX_PACKETISER *txp,
                                      const BIO_ADDR *peer);
 

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -190,6 +190,7 @@ extern "C" {
 
 # define BIO_CTRL_GET_RPOLL_DESCRIPTOR          90
 # define BIO_CTRL_GET_WPOLL_DESCRIPTOR          91
+# define BIO_CTRL_DGRAM_DETECT_PEER_ADDR        92
 
 # define BIO_DGRAM_CAP_NONE                 0U
 # define BIO_DGRAM_CAP_HANDLES_SRC_ADDR     (1U << 0)
@@ -639,6 +640,8 @@ int BIO_ctrl_reset_read_request(BIO *b);
          (int)BIO_ctrl(b, BIO_CTRL_DGRAM_GET_PEER, 0, (char *)(peer))
 # define BIO_dgram_set_peer(b,peer) \
          (int)BIO_ctrl(b, BIO_CTRL_DGRAM_SET_PEER, 0, (char *)(peer))
+# define BIO_dgram_detect_peer_addr(b,peer) \
+         (int)BIO_ctrl(b, BIO_CTRL_DGRAM_DETECT_PEER_ADDR, 0, (char *)(peer))
 # define BIO_dgram_get_mtu_overhead(b) \
          (unsigned int)BIO_ctrl((b), BIO_CTRL_DGRAM_GET_MTU_OVERHEAD, 0, NULL)
 # define BIO_dgram_get_local_addr_cap(b) \

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -188,9 +188,9 @@ extern "C" {
  * # define BIO_CTRL_SET_KTLS_TX_ZEROCOPY_SENDFILE 90
  */
 
-# define BIO_CTRL_GET_RPOLL_DESCRIPTOR          90
-# define BIO_CTRL_GET_WPOLL_DESCRIPTOR          91
-# define BIO_CTRL_DGRAM_DETECT_PEER_ADDR        92
+# define BIO_CTRL_GET_RPOLL_DESCRIPTOR          91
+# define BIO_CTRL_GET_WPOLL_DESCRIPTOR          92
+# define BIO_CTRL_DGRAM_DETECT_PEER_ADDR        93
 
 # define BIO_DGRAM_CAP_NONE                 0U
 # define BIO_DGRAM_CAP_HANDLES_SRC_ADDR     (1U << 0)

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -495,7 +495,7 @@ typedef struct bio_poll_descriptor_st {
 #  define BIO_set_conn_mode(b,n)        BIO_ctrl(b,BIO_C_SET_CONNECT_MODE,(n),NULL)
 #  define BIO_set_sock_type(b,t)        BIO_ctrl(b,BIO_C_SET_SOCK_TYPE,(t),NULL)
 #  define BIO_get_sock_type(b)          BIO_ctrl(b,BIO_C_GET_SOCK_TYPE,0,NULL)
-#  define BIO_get_dgram_bio(b, p)       BIO_ctrl(b,BIO_C_GET_DGRAM_BIO,0,(void *)(BIO **)(p))
+#  define BIO_get0_dgram_bio(b, p)      BIO_ctrl(b,BIO_C_GET_DGRAM_BIO,0,(void *)(BIO **)(p))
 
 /* BIO_s_accept() */
 #  define BIO_set_accept_name(b,name)   BIO_ctrl(b,BIO_C_SET_ACCEPT,0, \

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -461,6 +461,10 @@ typedef struct bio_poll_descriptor_st {
 
 # define BIO_C_SET_TFO                           156 /* like BIO_C_SET_NBIO */
 
+# define BIO_C_SET_SOCK_TYPE                     157
+# define BIO_C_GET_SOCK_TYPE                     158
+# define BIO_C_GET_DGRAM_BIO                     159
+
 # define BIO_set_app_data(s,arg)         BIO_set_ex_data(s,0,arg)
 # define BIO_get_app_data(s)             BIO_get_ex_data(s,0)
 
@@ -488,6 +492,9 @@ typedef struct bio_poll_descriptor_st {
 #  define BIO_get_conn_ip_family(b)     BIO_ctrl(b,BIO_C_GET_CONNECT,3,NULL)
 #  define BIO_get_conn_mode(b)          BIO_ctrl(b,BIO_C_GET_CONNECT,4,NULL)
 #  define BIO_set_conn_mode(b,n)        BIO_ctrl(b,BIO_C_SET_CONNECT_MODE,(n),NULL)
+#  define BIO_set_sock_type(b,t)        BIO_ctrl(b,BIO_C_SET_SOCK_TYPE,(t),NULL)
+#  define BIO_get_sock_type(b)          BIO_ctrl(b,BIO_C_GET_SOCK_TYPE,0,NULL)
+#  define BIO_get_dgram_bio(b, p)       BIO_ctrl(b,BIO_C_GET_DGRAM_BIO,0,(void *)(BIO **)(p))
 
 /* BIO_s_accept() */
 #  define BIO_set_accept_name(b,name)   BIO_ctrl(b,BIO_C_SET_ACCEPT,0, \

--- a/ssl/quic/quic_channel_local.h
+++ b/ssl/quic/quic_channel_local.h
@@ -445,6 +445,14 @@ struct quic_channel_st {
     /* Permanent net error encountered */
     unsigned int                    net_error                           : 1;
 
+    /*
+     * Protocol error encountered. Note that you should refer to the state field
+     * rather than this. This is only used so we can ignore protocol errors
+     * after the first protocol error, but still record the first protocol error
+     * if it happens during the TERMINATING state.
+     */
+    unsigned int                    protocol_error                      : 1;
+
     /* Inhibit tick for testing purposes? */
     unsigned int                    inhibit_tick                        : 1;
 

--- a/ssl/quic/quic_channel_local.h
+++ b/ssl/quic/quic_channel_local.h
@@ -456,6 +456,9 @@ struct quic_channel_st {
     /* Inhibit tick for testing purposes? */
     unsigned int                    inhibit_tick                        : 1;
 
+    /* Are we using addressed mode? */
+    unsigned int                    addressed_mode                      : 1;
+
     /* Saved error stack in case permanent error was encountered */
     ERR_STATE                       *err_state;
 };

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -1565,15 +1565,13 @@ static int quic_do_handshake(QCTX *ctx)
     if (!qc->started && !qc->addressing_probe_done) {
         long rcaps = BIO_dgram_get_effective_caps(qc->net_rbio);
         long wcaps = BIO_dgram_get_effective_caps(qc->net_wbio);
-        int can_use_addressed =
-            (wcaps & BIO_DGRAM_CAP_HANDLES_DST_ADDR) != 0
-            && (rcaps & BIO_DGRAM_CAP_PROVIDES_SRC_ADDR) != 0;
 
-        qc->addressed_mode          = can_use_addressed;
-        qc->addressing_probe_done   = 1;
+        qc->addressed_mode_r = ((rcaps & BIO_DGRAM_CAP_PROVIDES_SRC_ADDR) != 0);
+        qc->addressed_mode_w = ((wcaps & BIO_DGRAM_CAP_HANDLES_DST_ADDR) != 0);
+        qc->addressing_probe_done = 1;
     }
 
-    if (!qc->started && qc->addressed_mode
+    if (!qc->started && qc->addressed_mode_w
         && BIO_ADDR_family(&qc->init_peer_addr) == AF_UNSPEC) {
         /*
          * We are trying to connect and are using addressed mode, which means we
@@ -1595,7 +1593,7 @@ static int quic_do_handshake(QCTX *ctx)
     }
 
     if (!qc->started
-        && qc->addressed_mode
+        && qc->addressed_mode_w
         && BIO_ADDR_family(&qc->init_peer_addr) == AF_UNSPEC) {
         /*
          * If we still don't have a peer address in addressed mode, we can't do

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -851,6 +851,8 @@ void ossl_quic_conn_set0_net_rbio(SSL *s, BIO *net_rbio)
         } else {
             ctx.qc->can_poll_net_rbio = 1;
         }
+
+        BIO_set_nbio(net_rbio, 1); /* best effort autoconfig */
     }
 }
 
@@ -895,6 +897,8 @@ void ossl_quic_conn_set0_net_wbio(SSL *s, BIO *net_wbio)
             ossl_quic_channel_set_peer_addr(ctx.qc->ch,
                                             &ctx.qc->init_peer_addr);
         }
+
+        BIO_set_nbio(net_wbio, 1); /* best effort autoconfig */
     }
 }
 

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -1581,7 +1581,7 @@ static int quic_do_handshake(QCTX *ctx)
          * We do this as late as possible because some BIOs (e.g. BIO_s_connect)
          * may not be able to provide us with a peer address until they have
          * finished their own processing. They may not be able to perform this
-         * processing until an application has figured configuring that BIO
+         * processing until an application has finished configuring that BIO
          * (e.g. with setter calls), which might happen after SSL_set_bio is
          * called.
          */

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -1607,7 +1607,7 @@ static int quic_do_handshake(QCTX *ctx)
      * Start connection process. Note we may come here multiple times in
      * non-blocking mode, which is fine.
      */
-    if (!ensure_channel_started(qc)) /* raises on failure */
+    if (!ensure_channel_started(ctx)) /* raises on failure */
         return -1; /* Non-protocol error */
 
     if (ossl_quic_channel_is_handshake_complete(qc->ch))

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -199,7 +199,8 @@ struct quic_conn_st {
     unsigned int                    addressing_probe_done   : 1;
 
     /* Are we using addressed mode (BIO_sendmmsg with non-NULL peer)? */
-    unsigned int                    addressed_mode          : 1;
+    unsigned int                    addressed_mode_w        : 1;
+    unsigned int                    addressed_mode_r        : 1;
 
     /* Default stream type. Defaults to SSL_DEFAULT_STREAM_MODE_AUTO_BIDI. */
     uint32_t                        default_stream_mode;

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -41,8 +41,18 @@ struct quic_xso_st {
     /* The stream object. Always non-NULL for as long as the XSO exists. */
     QUIC_STREAM                     *stream;
 
-    /* Is this stream in blocking mode? */
-    unsigned int                    blocking                : 1;
+    /*
+     * Has this stream been logically configured into blocking mode? Only
+     * meaningful if desires_blocking_set is 1. Ignored if blocking is not
+     * currently possible given QUIC_CONNECTION configuration.
+     */
+    unsigned int                    desires_blocking        : 1;
+
+    /*
+     * Has SSL_set_blocking_mode been called on this stream? If not set, we
+     * inherit from the QUIC_CONNECTION blocking state.
+     */
+    unsigned int                    desires_blocking_set    : 1;
 
     /*
      * This state tracks SSL_write all-or-nothing (AON) write semantics
@@ -154,10 +164,6 @@ struct quic_conn_st {
     /* Have we started? */
     unsigned int                    started                 : 1;
 
-    /* Can the read and write network BIOs support blocking? */
-    unsigned int                    can_poll_net_rbio       : 1;
-    unsigned int                    can_poll_net_wbio       : 1;
-
     /*
      * This is 1 if we were instantiated using a QUIC server method
      * (for future use).
@@ -176,8 +182,8 @@ struct quic_conn_st {
     /* Do connection-level operations (e.g. handshakes) run in blocking mode? */
     unsigned int                    blocking                : 1;
 
-    /* Do newly created streams start in blocking mode? Inherited by new XSOs. */
-    unsigned int                    default_blocking        : 1;
+    /* Does the application want blocking mode? */
+    unsigned int                    desires_blocking        : 1;
 
     /* Have we created a default XSO yet? */
     unsigned int                    default_xso_created     : 1;

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -195,6 +195,12 @@ struct quic_conn_st {
      */
     unsigned int                    shutting_down           : 1;
 
+    /* Have we probed the BIOs for addressing support? */
+    unsigned int                    addressing_probe_done   : 1;
+
+    /* Are we using addressed mode (BIO_sendmmsg with non-NULL peer)? */
+    unsigned int                    addressed_mode          : 1;
+
     /* Default stream type. Defaults to SSL_DEFAULT_STREAM_MODE_AUTO_BIDI. */
     uint32_t                        default_stream_mode;
 

--- a/ssl/quic/quic_reactor.c
+++ b/ssl/quic/quic_reactor.c
@@ -24,6 +24,8 @@ void ossl_quic_reactor_init(QUIC_REACTOR *rtor,
     rtor->poll_w.type       = BIO_POLL_DESCRIPTOR_TYPE_NONE;
     rtor->net_read_desired  = 0;
     rtor->net_write_desired = 0;
+    rtor->can_poll_r        = 0;
+    rtor->can_poll_w        = 0;
     rtor->tick_deadline     = initial_tick_deadline;
 
     rtor->tick_cb           = tick_cb;
@@ -32,22 +34,50 @@ void ossl_quic_reactor_init(QUIC_REACTOR *rtor,
 
 void ossl_quic_reactor_set_poll_r(QUIC_REACTOR *rtor, const BIO_POLL_DESCRIPTOR *r)
 {
-    rtor->poll_r = *r;
+    if (r == NULL)
+        rtor->poll_r.type = BIO_POLL_DESCRIPTOR_TYPE_NONE;
+    else
+        rtor->poll_r = *r;
+
+    rtor->can_poll_r
+        = ossl_quic_reactor_can_support_poll_descriptor(rtor, &rtor->poll_r);
 }
 
 void ossl_quic_reactor_set_poll_w(QUIC_REACTOR *rtor, const BIO_POLL_DESCRIPTOR *w)
 {
-    rtor->poll_w = *w;
+    if (w == NULL)
+        rtor->poll_w.type = BIO_POLL_DESCRIPTOR_TYPE_NONE;
+    else
+        rtor->poll_w = *w;
+
+    rtor->can_poll_w
+        = ossl_quic_reactor_can_support_poll_descriptor(rtor, &rtor->poll_w);
 }
 
-const BIO_POLL_DESCRIPTOR *ossl_quic_reactor_get_poll_r(QUIC_REACTOR *rtor)
+const BIO_POLL_DESCRIPTOR *ossl_quic_reactor_get_poll_r(const QUIC_REACTOR *rtor)
 {
     return &rtor->poll_r;
 }
 
-const BIO_POLL_DESCRIPTOR *ossl_quic_reactor_get_poll_w(QUIC_REACTOR *rtor)
+const BIO_POLL_DESCRIPTOR *ossl_quic_reactor_get_poll_w(const QUIC_REACTOR *rtor)
 {
     return &rtor->poll_w;
+}
+
+int ossl_quic_reactor_can_support_poll_descriptor(const QUIC_REACTOR *rtor,
+                                                  const BIO_POLL_DESCRIPTOR *d)
+{
+    return d->type == BIO_POLL_DESCRIPTOR_TYPE_SOCK_FD;
+}
+
+int ossl_quic_reactor_can_poll_r(const QUIC_REACTOR *rtor)
+{
+    return rtor->can_poll_r;
+}
+
+int ossl_quic_reactor_can_poll_w(const QUIC_REACTOR *rtor)
+{
+    return rtor->can_poll_w;
 }
 
 int ossl_quic_reactor_net_read_desired(QUIC_REACTOR *rtor)

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -672,8 +672,8 @@ static int raise_error(QUIC_TLS *qtls, uint64_t error_code,
     ERR_new();
     ERR_set_debug(src_file, src_line, src_func);
     ERR_set_error(ERR_LIB_SSL, SSL_R_QUIC_HANDSHAKE_LAYER_ERROR,
-                  "handshake layer error, error code %llu (\"%s\")",
-                  (unsigned long long)error_code, error_msg);
+                  "handshake layer error, error code %llu (0x%llx) (\"%s\")",
+                  error_code, error_code, error_msg);
     OSSL_ERR_STATE_save_to_mark(qtls->error_state);
 
     /*
@@ -743,7 +743,8 @@ int ossl_quic_tls_tick(QUIC_TLS *qtls)
                 return RAISE_INTERNAL_ERROR(qtls);
         } else {
             if (sc->ext.alpn == NULL || sc->ext.alpn_len == 0)
-                return RAISE_INTERNAL_ERROR(qtls);
+                return RAISE_ERROR(qtls, QUIC_ERR_CRYPTO_NO_APP_PROTO,
+                                   "ALPN must be configured when using QUIC");
         }
         if (!SSL_set_min_proto_version(qtls->args.s, TLS1_3_VERSION))
             return RAISE_INTERNAL_ERROR(qtls);

--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -555,8 +555,8 @@ int ossl_quic_tx_packetiser_set_peer(OSSL_QUIC_TX_PACKETISER *txp,
                                      const BIO_ADDR *peer)
 {
     if (peer == NULL) {
-        ERR_raise(ERR_LIB_SSL, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
+        BIO_ADDR_clear(&txp->args.peer);
+        return 1;
     }
 
     txp->args.peer = *peer;

--- a/util/other.syms
+++ b/util/other.syms
@@ -169,7 +169,7 @@ BIO_dgram_set_peer                      define
 BIO_dgram_recv_timedout                 define
 BIO_dgram_send_timedout                 define
 BIO_dgram_detect_peer_addr              define
-BIO_get_dgram_bio                       define
+BIO_get0_dgram_bio                      define
 BIO_get_sock_type                       define
 BIO_set_sock_type                       define
 BIO_do_accept                           define

--- a/util/other.syms
+++ b/util/other.syms
@@ -168,6 +168,10 @@ BIO_dgram_get_peer                      define
 BIO_dgram_set_peer                      define
 BIO_dgram_recv_timedout                 define
 BIO_dgram_send_timedout                 define
+BIO_dgram_detect_peer_addr              define
+BIO_get_dgram_bio                       define
+BIO_get_sock_type                       define
+BIO_set_sock_type                       define
 BIO_do_accept                           define
 BIO_do_connect                          define
 BIO_do_handshake                        define


### PR DESCRIPTION
This updates the QUIC DDD demos which were produced as part of the API design process to minimise the API changes which would be needed for existing applications.

These updated demos are all tested and working with QUIC.

Attention is drawn to the following artefacts:

- (Old) [The original README for the DDD demos.](https://github.com/hlandau/openssl/blob/quic-ddd-update-2/doc/designs/ddd/README.md)
- (New, recommended reading) [**The final report with conclusions on the DDD process.**](https://github.com/hlandau/openssl/blob/quic-ddd-update-2/doc/designs/ddd/REPORT.md) The report summarises the planned and unplanned changes to each demo.
- The originally planned, and actually realised changes, for each demo. The planned changes were originally formulated as diffs, however for the sake of readability and maintenance, they are now represented here as guarded `#ifdef USE_QUIC` code sections:

  <table><tr><th>Demo</th><th>Planned Changes</th><th>Unplanned Changes</th></tr>
  <tr><td>ddd-01-conn-blocking</td><td><a href="https://github.com/openssl/openssl/pull/21715/commits/54251edbf90524caff942b0c35a17cf2c4abc7ac">commit</a></td><td><a href="https://github.com/openssl/openssl/pull/21715/commits/cd44ab37594c0df25c68c135bfbb7d8bed644caa">commit</a></td></tr>
  <tr><td>ddd-02-conn-nonblocking</td><td><a href="https://github.com/openssl/openssl/pull/21715/commits/b27ce91f2decfe9b01125bf8103be245467201b4">commit</a></td><td><a href="https://github.com/openssl/openssl/pull/21715/commits/5e0e97c3d76b3058628b330d29576e0ab6cd2eb1">commit</a></td></tr>
  <tr><td>ddd-03-fd-blocking</td><td><a href="https://github.com/openssl/openssl/pull/21715/commits/8b5183d62fae3784790594353d53e27628b9b04f">commit</a></td><td><a href="https://github.com/openssl/openssl/pull/21715/commits/13041ec59b807075f788fb50a67954e1aaba55da">commit</a></td></tr>
  <tr><td>ddd-04-fd-nonblocking</td><td><a href="https://github.com/openssl/openssl/pull/21715/commits/dd856c23ea77120283fa1a5a3154851a6435b06a">commit</a></td><td><a href="https://github.com/openssl/openssl/pull/21715/commits/9f5e1f3841e3ae39ca226b77da05baf339e6a5f2">commit</a></td></tr>
  <tr><td>ddd-05-mem-nonblocking</td><td><a href="https://github.com/openssl/openssl/pull/21715/commits/95d34a9c15acd44ede08adf4bfa52c43fe5b0871">commit</a></td><td><a href="https://github.com/openssl/openssl/pull/21715/commits/cac62cead88db498555d90332ae14144c57d4076">commit</a></td></tr>
  <tr><td>ddd-06-mem-uv</td><td><a href="https://github.com/openssl/openssl/pull/21715/commits/efa409741b4f606e32120033cb3542ccf0d4ff9d">commit</a></td><td><a href="https://github.com/openssl/openssl/pull/21715/commits/acda8fdba301088c86899a3fa6b39b25f1431832">commit</a></td></tr>
  </table>

This PR also incorporates changes to the QUIC code which were overlooked until now but required to get the DDD demos working as planned. In particular:

- BIO_s_connect adapted to support datagram mode
- Make BIO_ssl helper functions configure BIO_s_connect for QUIC automatically when QUIC is being used
- Automatically configure network-side BIOs as nonblocking
- Refactor of can-poll flags out of QUIC_CHANNEL and into QUIC_REACTOR.
- Refactor of QUIC APL blocking configuration to allow our determination of whether we can support blocking mode to be made as late as possible.
- Introduce concept of *addressed mode* v. *non-addressed mode* in QUIC_CHANNEL. A non-addressed QUIC connection is one used with e.g. a BIO_s_dgram_pair which is not providing L4 source/destination addresses. This kind of connection will not be able to support connection migration, multipath, etc. in the future.
- Add `BIO_dgram_detect_peer_addr` API to avoid overloading the meaning of `BIO_dgram_get_peer`.
- Wired BIO_sendmmsg/BIO_recvmmsg capability negotiation for BIO_s_datagram.

```
=== Report
f130d2d098 QUIC DDD: Final report

=== Unplanned/planned changes
4cc7decd5d QUIC DDD: ddd-02-conn-nonblocking-threads: Unplanned changes
adbf5d843d QUIC DDD: ddd-02-conn-nonblocking-threads: Planned changes
acda8fdba3 QUIC DDD: ddd-06-mem-uv: Unplanned changes
efa409741b QUIC DDD: ddd-06-mem-uv: Planned changes
cac62cead8 QUIC DDD: ddd-05-mem-nonblocking: Unplanned changes
95d34a9c15 QUIC DDD: ddd-05-mem-nonblocking: Planned changes
9f5e1f3841 QUIC DDD: ddd-04-fd-nonblocking: Unplanned changes
dd856c23ea QUIC DDD: ddd-04-fd-nonblocking: Planned changes
13041ec59b QUIC DDD: ddd-03-fd-blocking: Unplanned changes
8b5183d62f QUIC DDD: ddd-03-fd-blocking: Planned changes
5e0e97c3d7 QUIC DDD: ddd-02-conn-nonblocking: Unplanned changes
b27ce91f2d QUIC DDD: ddd-02-conn-nonblocking: Planned changes
cd44ab3759 QUIC DDD: ddd-01-conn-blocking: Unplanned changes
54251edbf9 QUIC DDD: ddd-01-conn-blocking: Planned changes

=== Minor rework of DDD demos
7f013fa310 QUIC DDD: Update makefile
b9ad93c1bc QUIC DDD: Add unchanged copy of ddd-02-conn-nonblocking to serve as base for thread-assisted variant
ea7c74166e QUIC DDD: Allow target host:port to be set from command line
226dc1326c QUIC DDD: Fix bug in ddd-06-mem-uv

=== Supporting changes
c259499e10 QUIC APL: Introduce addressed v. non-addressed mode handling
c84b251473 BIO_s_dgram_pair: Correct implementation of BIO_CTRL_DGRAM_GET_LOCAL_ADDR_ENABLE
8fddce61f3 BIO_s_datagram: Wire capability negotiation for BIO_s_datagram
96e9f81bcb BIO: Add BIO_dgram_detect_peer_addr API
fee36353f0 BIO_s_datagram: Support configuring non-blocking mode
9d18ee041d BIO_s_connect: Support configuration of non-blocking mode in datagram mode
63ed11bfa1 QUIC CHANNEL: Introduce concept of (non-)addressed mode
1f04b6d32e QUIC APL: Refactor blocking configuration to allow late blocking support detection
d71a732f72 QUIC CHANNEL: Cleanup poll descriptor management
5323505d45 QUIC REACTOR: Move can-poll flags into reactor
c00ff9ff7b QUIC APL: Autoconfigure BIOs as non-blocking
231bc4e419 BIO_ssl: Make helper functions configure BIOs for QUIC correctly
139fda5cf2 QUIC APL: Better error reporting
099068e717 QUIC CHANNEL: Only handle the first protocol error raised
1d6b5674d4 BIO_s_connect: Add support for datagram mode
277fb45d17 BIO_s_connect: Make internal functions static
e3a2f0d832 QUIC TLS: Better error message when ALPN not used
```

Fixes https://github.com/openssl/project/issues/40