### PR TITLE
apps: req/x509 add explicit start and end date

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ appropriate release branch.
 OpenSSL Releases
 ----------------
 
+ - [OpenSSL 3.4](#openssl-34)
  - [OpenSSL 3.3](#openssl-33)
  - [OpenSSL 3.2](#openssl-32)
  - [OpenSSL 3.1](#openssl-31)
@@ -22,6 +23,18 @@ OpenSSL Releases
  - [OpenSSL 1.0.1](#openssl-101)
  - [OpenSSL 1.0.0](#openssl-100)
  - [OpenSSL 0.9.x](#openssl-09x)
+
+OpenSSL 3.4
+-----------
+
+### Changes between 3.3 and 3.4 [xx XXX xxxx]
+
+ * Added options `-not_before` and `-not_after` for explicit setting
+   start and end dates of certificates created with the `req` and `x509`
+   apps. Added the same options also to `ca` app as alias for
+   `-startdate` and `-enddate` options.
+
+   *Stephan Wurm*
 
 OpenSSL 3.3
 -----------

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -82,8 +82,12 @@ int has_stdin_waiting(void);
 # endif
 
 void corrupt_signature(const ASN1_STRING *signature);
+
+/* Helpers for setting X509v3 certificate fields notBefore and notAfter */
+int check_cert_time_string(const char *time, const char *desc);
 int set_cert_times(X509 *x, const char *startdate, const char *enddate,
-                   int days);
+                   int days, int strict_compare_times);
+
 int set_crl_lastupdate(X509_CRL *crl, const char *lastupdate);
 int set_crl_nextupdate(X509_CRL *crl, const char *nextupdate,
                        long days, long hours, long secs);

--- a/doc/man1/openssl-ca.pod.in
+++ b/doc/man1/openssl-ca.pod.in
@@ -30,7 +30,9 @@ B<openssl> B<ca>
 [B<-crlsec> I<seconds>]
 [B<-crlexts> I<section>]
 [B<-startdate> I<date>]
+[B<-not_before> I<date>]
 [B<-enddate> I<date>]
+[B<-not_after> I<date>]
 [B<-days> I<arg>]
 [B<-md> I<arg>]
 [B<-policy> I<arg>]
@@ -226,23 +228,32 @@ Don't output the text form of a certificate to the output file.
 Specify the date output format. Values are: rfc_822 and iso_8601.
 Defaults to rfc_822.
 
-=item B<-startdate> I<date>
+=item B<-startdate> I<date>, B<-not_before> I<date>
 
 This allows the start date to be explicitly set. The format of the
 date is YYMMDDHHMMSSZ (the same as an ASN1 UTCTime structure), or
 YYYYMMDDHHMMSSZ (the same as an ASN1 GeneralizedTime structure). In
 both formats, seconds SS and timezone Z must be present.
+Alternatively, you can also use "today".
 
-=item B<-enddate> I<date>
+=item B<-enddate> I<date>, B<-not_after> I<date>
 
 This allows the expiry date to be explicitly set. The format of the
 date is YYMMDDHHMMSSZ (the same as an ASN1 UTCTime structure), or
 YYYYMMDDHHMMSSZ (the same as an ASN1 GeneralizedTime structure). In
 both formats, seconds SS and timezone Z must be present.
+Alternatively, you can also use "today".
+
+This overrides the B<-days> option.
 
 =item B<-days> I<arg>
 
-The number of days to certify the certificate for.
+The number of days from today to certify the certificate for.
+
+Regardless of the option B<-not_before>, the days are always counted from
+today.
+When used together with the option B<-not_after>/B<-startdate>, the explicit
+expiry date takes precedence.
 
 =item B<-md> I<alg>
 
@@ -502,7 +513,7 @@ not necessary anymore, see the L</HISTORY> section.
 
 =item B<default_days>
 
-The same as the B<-days> option. The number of days to certify
+The same as the B<-days> option. The number of days from today to certify
 a certificate for.
 
 =item B<default_startdate>

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -36,6 +36,8 @@ B<openssl> B<req>
 [B<-x509v1>]
 [B<-CA> I<filename>|I<uri>]
 [B<-CAkey> I<filename>|I<uri>]
+[B<-not_before> I<date>]
+[B<-not_after> I<date>]
 [B<-days> I<n>]
 [B<-set_serial> I<n>]
 [B<-newhdr>]
@@ -327,11 +329,36 @@ Sets the "CA" private key to sign a certificate with.
 The private key must match the public key of the certificate given with B<-CA>.
 If this option is not provided then the key must be present in the B<-CA> input.
 
+=item B<-not_before> I<date>
+
+When B<-x509> is in use this allows the start date to be explicitly set,
+otherwise it is ignored. The format of I<date> is YYMMDDHHMMSSZ (the
+same as an ASN1 UTCTime structure), or YYYYMMDDHHMMSSZ (the same as an
+ASN1 GeneralizedTime structure). In both formats, seconds SS and
+timezone Z must be present.
+Alternatively, you can also use "today".
+
+=item B<-not_after> I<date>
+
+When B<-x509> is in use this allows the expiry date to be explicitly
+set, otherwise it is ignored. The format of I<date> is YYMMDDHHMMSSZ
+(the same as an ASN1 UTCTime structure), or YYYYMMDDHHMMSSZ (the same as
+an ASN1 GeneralizedTime structure). In both formats, seconds SS and
+timezone Z must be present.
+Alternatively, you can also use "today".
+
+This overrides the B<-days> option.
+
 =item B<-days> I<n>
 
-When B<-x509> is in use this specifies the number of
-days to certify the certificate for, otherwise it is ignored. I<n> should
+When B<-x509> is in use this specifies the number of days from today to
+certify the certificate for, otherwise it is ignored. I<n> should
 be a positive integer. The default is 30 days.
+
+Regardless of the option B<-not_before>, the days are always counted from
+today.
+When used together with the option B<-not_after>, the explicit expiry
+date takes precedence.
 
 =item B<-set_serial> I<n>
 

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -54,6 +54,8 @@ B<openssl> B<x509>
 [B<-checkip> I<ipaddr>]
 [B<-set_serial> I<n>]
 [B<-next_serial>]
+[B<-not_before> I<date>]
+[B<-not_after> I<date>]
 [B<-days> I<arg>]
 [B<-preserve_dates>]
 [B<-set_issuer> I<arg>]
@@ -183,6 +185,8 @@ It sets the issuer name to the subject name (i.e., makes it self-issued).
 Unless the B<-preserve_dates> option is supplied,
 it sets the validity start date to the current time
 and the end date to a value determined by the B<-days> option.
+Start date and end date can also be explicitly supplied with options
+B<-not_before> and B<-not_after>.
 
 =item B<-signkey> I<filename>|I<uri>
 
@@ -376,17 +380,40 @@ The serial number can be decimal or hex (if preceded by C<0x>).
 
 Set the serial to be one more than the number in the certificate.
 
+=item B<-not_before> I<date>
+
+This allows the start date to be explicitly set. The format of the
+date is YYMMDDHHMMSSZ (the same as an ASN1 UTCTime structure), or
+YYYYMMDDHHMMSSZ (the same as an ASN1 GeneralizedTime structure). In
+both formats, seconds SS and timezone Z must be present.
+Alternatively, you can also use "today".
+
+Cannot be used together with the B<-preserve_dates> option.
+
+=item B<-not_after> I<date>
+
+This allows the expiry date to be explicitly set. The format of the
+date is YYMMDDHHMMSSZ (the same as an ASN1 UTCTime structure), or
+YYYYMMDDHHMMSSZ (the same as an ASN1 GeneralizedTime structure). In
+both formats, seconds SS and timezone Z must be present.
+Alternatively, you can also use "today".
+
+Cannot be used together with the B<-preserve_dates> option.
+This overrides the option B<-days>.
+
 =item B<-days> I<arg>
 
-Specifies the number of days until a newly generated certificate expires.
+Specifies the number of days from today until a newly generated certificate expires.
 The default is 30.
-Cannot be used together with the B<-preserve_dates> option.
+
+Cannot be used together with the option B<-preserve_dates>.
+If option B<-not_after> is set, the explicit expiry date takes precedence.
 
 =item B<-preserve_dates>
 
 When signing a certificate, preserve "notBefore" and "notAfter" dates of any
 input certificate instead of adjusting them to current time and duration.
-Cannot be used together with the B<-days> option.
+Cannot be used together with the options B<-days>, B<-not_before> and B<-not_after>.
 
 =item B<-set_issuer> I<arg>
 

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -15,7 +15,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_req");
 
-plan tests => 108;
+plan tests => 109;
 
 require_ok(srctop_file('test', 'recipes', 'tconversion.pl'));
 

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -607,3 +607,15 @@ ok(run(app(["openssl", "req", "-x509", "-new", "-days", "365",
 # Verify cert
 ok(run(app(["openssl", "x509", "-in", "testreq-cert.pem",
             "-noout", "-text"])), "cert verification");
+
+# Generate cert with explicit start and end dates
+my $today = strftime("%Y-%m-%d", localtime);
+my $cert = "self-signed_explicit_date.pem";
+ok(run(app(["openssl", "req", "-x509", "-new", "-text",
+            "-config", srctop_file('test', 'test.cnf'),
+            "-key", srctop_file("test", "testrsa.pem"),
+            "-not_before", "today",
+            "-not_after", "today",
+            "-out", $cert]))
+&& get_not_before_date($cert) eq $today
+&& get_not_after_date($cert) eq $today, "explicit start and end dates");

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -16,7 +16,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_x509");
 
-plan tests => 46;
+plan tests => 51;
 
 # Prevent MSys2 filename munging for arguments that look like file paths but
 # aren't
@@ -187,20 +187,6 @@ ok(!run(app(["openssl", "x509", "-noout", "-dates", "-dateopt", "invalid_format"
 	     "-in", srctop_file("test/certs", "ca-cert.pem")])),
    "Run with invalid -dateopt format");
 
-# extracts issuer from a -text formatted-output
-sub get_issuer {
-    my $f = shift(@_);
-    my $issuer = "";
-    open my $fh, $f or die;
-    while (my $line = <$fh>) {
-        if ($line =~ /Issuer:/) {
-            $issuer = $line;
-        }
-    }
-    close $fh;
-    return $issuer;
-}
-
 # Tests for signing certs (broken in 1.1.1o)
 my $a_key = "a-key.pem";
 my $a_cert = "a-cert.pem";
@@ -224,7 +210,7 @@ ok(run(app(["openssl", "x509", "-in", $a_cert, "-CA", $ca_cert,
             "-CAkey", $ca_key, "-set_serial", "1234567890",
             "-preserve_dates", "-sha256", "-text", "-out", $a2_cert])));
 # verify issuer is CA
-ok (get_issuer($a2_cert) =~ /CN=ca.example.com/);
+ok(get_issuer($a2_cert) =~ /CN=ca.example.com/);
 
 my $in_csr = srctop_file('test', 'certs', 'x509-check.csr');
 my $in_key = srctop_file('test', 'certs', 'x509-check-key.pem');
@@ -267,6 +253,51 @@ ok(run(app(["openssl", "x509", "-req", "-text", "-CAcreateserial",
             "-CA", $ca_cert_dot_in_dir, "-CAkey", $ca_key,
             "-in", $b_csr])));
 ok(-e $ca_serial_dot_in_dir);
+
+# Tests for explict start and end dates of certificates
+my $today;
+my $enddate;
+$today = strftime("%Y-%m-%d", localtime);
+ok(run(app(["openssl", "x509", "-req", "-text",
+	    "-key", $b_key,
+	    "-not_before", "20231031000000Z",
+	    "-not_after", "today",
+            "-in", $b_csr, "-out", $b_cert]))
+&& get_not_before($b_cert) =~ /Oct 31 00:00:00 2023 GMT/
+&& get_not_after_date($b_cert) eq $today);
+# explicit start and end dates
+ok(run(app(["openssl", "x509", "-req", "-text",
+	    "-key", $b_key,
+	    "-not_before", "20231031000000Z",
+	    "-not_after", "20231231000000Z",
+	    "-days", "99",
+            "-in", $b_csr, "-out", $b_cert]))
+&& get_not_before($b_cert) =~ /Oct 31 00:00:00 2023 GMT/
+&& get_not_after($b_cert) =~ /Dec 31 00:00:00 2023 GMT/);
+# start date today and days
+$today = strftime("%Y-%m-%d", localtime);
+$enddate = strftime("%Y-%m-%d", localtime(time + 99 * 24 * 60 * 60));
+ok(run(app(["openssl", "x509", "-req", "-text",
+	    "-key", $b_key,
+	    "-not_before", "today",
+	    "-days", "99",
+            "-in", $b_csr, "-out", $b_cert]))
+&& get_not_before_date($b_cert) eq $today
+&& get_not_after_date($b_cert) eq $enddate);
+# end date before start date
+ok(!run(app(["openssl", "x509", "-req", "-text",
+	      "-key", $b_key,
+	      "-not_before", "today",
+	      "-not_after", "20231031000000Z",
+              "-in", $b_csr, "-out", $b_cert])));
+# default days option
+$today = strftime("%Y-%m-%d", localtime);
+$enddate = strftime("%Y-%m-%d", localtime(time + 30 * 24 * 60 * 60));
+ok(run(app(["openssl", "x509", "-req", "-text",
+	    "-key", $b_key,
+            "-in", $b_csr, "-out", $b_cert]))
+&& get_not_before_date($b_cert) eq $today
+&& get_not_after_date($b_cert) eq $enddate);
 
 SKIP: {
     skip "EC is not supported by this OpenSSL build", 1

--- a/test/recipes/tconversion.pl
+++ b/test/recipes/tconversion.pl
@@ -13,6 +13,8 @@ use warnings;
 use File::Compare qw/compare_text/;
 use File::Copy;
 use OpenSSL::Test qw/:DEFAULT/;
+use Time::Piece;
+use POSIX qw(strftime);
 
 my %conversionforms = (
     # Default conversion forms.  Other series may be added with
@@ -174,6 +176,46 @@ sub cert_ext_has_n_different_lines {
     is(file_n_different_lines($out), $expected, ($name ? "$name: " : "").
        "$cert '$exts' output should contain $expected different lines");
     # not unlinking $out
+}
+
+# extracts string value of certificate field from a -text formatted-output
+sub get_field {
+    my ($f, $field) = @_;
+    my $string = "";
+    open my $fh, $f or die;
+    while (my $line = <$fh>) {
+        if ($line =~ /$field:\s+(.*)/) {
+            $string = $1;
+        }
+    }
+    close $fh;
+    return $string;
+}
+
+sub get_issuer {
+    return get_field(@_, "Issuer");
+}
+
+sub get_not_before {
+    return get_field(@_, "Not Before");
+}
+
+# Date as yyyy-mm-dd
+sub get_not_before_date {
+    return Time::Piece->strptime(
+        get_not_before(@_),
+        "%b %d %T %Y %Z")->date;
+}
+
+sub get_not_after {
+    return get_field(@_, "Not After ");
+}
+
+# Date as yyyy-mm-dd
+sub get_not_after_date {
+    return Time::Piece->strptime(
+        get_not_after(@_),
+        "%b %d %T %Y %Z")->date;
 }
 
 1;


### PR DESCRIPTION
This feature adds options to explicitly set the start and end dates in X509v3 certificate creation with the `req` and `x509` apps.
I stumbled upon this several times now, and I think this adds some convenience to the apps.

For the `req` app, I borrowed the naming from the `ca` app, hence the parameters are called `-startdate` and `-enddate`. I also added the same handling for `default_startdate` and `default_enddate` to the respective configuration file section.
The `-enddate` option conflicts with the `-days` option, hence only one of both can be used. If a start date is given, but no end date, the `-days` option is processed instead. Currently, this results in an offset of days from the current date, not from the start date.

For the `x509` app, I had to select different names, as `-startdate` and `-enddate` are already in use to print the `notBefore` and `notAfter` fields of a certificate. Therefore, I called the options `-notbefore` and `-notafter`. The handling in respect to the `-days` option is similar to the `req` app, but no configuration file parameters exist.

Changes:
- removed new configuration options from `req` app.
- renamed options `-startdate` and `-enddate` to `-not_before` and `-not_after` in `req` app.
- added options `-not_before` and `-not_after` also to `x509` app.
- Ensure not_after >= not_before in both apps `req` and `x509`.
- added aliases to `ca` app: `-not_before` -> `-startdate`, `-not_after` -> `-enddate`.
- added helper function `check_cert_time_string` to `lib/apps`.
- moved redundant code to helper function `check_cert_times`.
- Improved docs.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
