### PR TITLE
Improve behavior of BIO_s_mem when NOCLOSE is set

### DIFF
--- a/doc/man3/BIO_s_mem.pod
+++ b/doc/man3/BIO_s_mem.pod
@@ -114,6 +114,19 @@ preceding that write operation cannot be undone.
 Calling BIO_get_mem_ptr() prior to a BIO_reset() call with
 BIO_FLAGS_NONCLEAR_RST set has the same effect as a write operation.
 
+Calling this function implies claiming ownership of the data pointer in
+the BIO.  Regardless of the state of BIO_set_close(), it is the responsibility of
+the caller to free the returned pointer to prevent leaks
+
+Calling BIO_free on a BIO for which BIO_set_close() with BIO_NOCLOSE has been
+called without first calling BIO_get_mem_ptr(), or
+BIO_set_mem_ptr()  will result in an erro being returned from
+BIO_free, as the underlying BUF_MEM structure would have leaked.
+If you plan to orphan the BUF_MEM structure using BIO_set_close(bio,
+BIO_NOCLOSE), first retrieve the pointer to the BUF_MEM.  The error details are
+raised and available via the ERR api, and it is safe to access the BIO after
+this failure.
+
 =head1 BUGS
 
 There should be an option to set the maximum size of a memory BIO.

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -208,6 +208,8 @@ extern "C" {
 # define BIO_FLAGS_MEM_RDONLY    0x200
 # define BIO_FLAGS_NONCLEAR_RST  0x400
 # define BIO_FLAGS_IN_EOF        0x800
+# define BIO_FLAGS_MEMBUF_FETCH  0x8000
+# define BIO_FLAGS_DATA_FETCH    0x10000
 
 /* the BIO FLAGS values 0x1000 to 0x4000 are reserved for internal KTLS flags */
 


### PR DESCRIPTION

BIO_s_mem instances have a propensity to leak.  This was returned from a recent valgrind run in an application I was working on:
    ==1007580== at 0x483C815: malloc (vg_replace_malloc.c:431)
    ==1007580== by 0x2C2689: CRYPTO_zalloc (in /home/vien/microedge-c/test)
    ==1007580== by 0x295A17: BUF_MEM_new (in /home/vien/microedge-c/test)
    ==1007580== by 0x295A78: BUF_MEM_new_ex (in /home/vien/microedge-c/test)
    ==1007580== by 0x28CACE: mem_new (in /home/vien/microedge-c/test)
    ==1007580== by 0x285EA8: BIO_new_ex (in /home/vien/microedge-c/test)
    ==1007580== by 0x231894: convert_pubkey_ECC (tpm2_driver.c:221)
    ==1007580== by 0x232B73: create_ephemeral_key (tpm2_driver.c:641)
    ==1007580== by 0x232E1F: tpm_gen_keypair (tpm2_driver.c:695)
    ==1007580== by 0x22D60A: gen_keypair (se_driver_api.c:275)
    ==1007580== by 0x21FF35: generate_keypair (dhkey.c:142)
    ==1007580== by 0x24D4C8: __test_dhkey (dhkey_test.c:55)

The problem is described in detail in the changelogs, but the executive summary is that:
a) When BIO_NOCLOSE is set on the BIO, if the user hasn't retrieved the BUF_MEM structure via BIO_get_mem_ptr or BIO_set_mem_ptr, it will leak
b) It is counter-intuitive that a call to BIO_get_mem_data doesn't assign ownership of the data pointer to the caller, leading, as when BIO_NOCLOSE is set, the application also must call BIO_[get|set]_mem_ptr to prevent a BUF_MEM leak, or worse, encounter a double free in the event that the pointer returned from BIO_get_mem_data is considered by the application to be orphaned when BIO_CLOSE is set.

This patch series is an attempt to reconcile those problem and create a more intuitive user experience

##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated
