### PR TITLE
Improve behavior of BIO_s_mem when NOCLOSE is set

### DIFF
--- a/doc/man3/BIO_s_mem.pod
+++ b/doc/man3/BIO_s_mem.pod
@@ -59,6 +59,8 @@ positive return value B<v> should be set to a negative value, typically -1.
 
 BIO_get_mem_data() sets *B<pp> to a pointer to the start of the memory BIOs data
 and returns the total amount of data available. It is implemented as a macro.
+Note the pointer returned by this call is informative, no transer of ownership
+of this memory is implied.  See notes on BIO_set_close()
 
 BIO_set_mem_buf() sets the internal BUF_MEM structure to B<bm> and sets the
 close flag to B<c>, that is B<c> should be either BIO_CLOSE or BIO_NOCLOSE.
@@ -114,6 +116,10 @@ preceding that write operation cannot be undone.
 Calling BIO_get_mem_ptr() prior to a BIO_reset() call with
 BIO_FLAGS_NONCLEAR_RST set has the same effect as a write operation.
 
+Calling BIO_set_close() with BIO_NOCLOSE orphans the BUF_MEM internal to the
+BIO, _not_ its actual data buffer. See the examples section for the proper
+method for claiming ownership of the data pointer for a deferred free operation
+
 =head1 BUGS
 
 There should be an option to set the maximum size of a memory BIO.
@@ -151,6 +157,21 @@ Extract the BUF_MEM structure from a memory BIO and then free up the BIO:
  BIO_set_close(mem, BIO_NOCLOSE); /* So BIO_free() leaves BUF_MEM alone */
  BIO_free(mem);
 
+Extract the BUF_MEM ptr, claim ownership of the internal data and free the BIO
+and BUF_MEM structure:
+
+ BUF_MEM *bptr;
+ char *data;
+
+ BIO_get_mem_data(bio, &data);
+ BIO_get_mem_ptr(bio, &bptr);
+ BIO_set_close(mem, BIO_NOCLOSE); /* So BIO_free orphans BUF_MEM */
+ BIO_free(bio);
+ bptr->data = NULL; /* Tell BUF_MEM to orphan data */
+ BUF_MEM_free(bptr);
+ ...
+ free(data);
+ 
 
 =head1 COPYRIGHT
 

--- a/doc/man3/BIO_s_mem.pod
+++ b/doc/man3/BIO_s_mem.pod
@@ -59,8 +59,8 @@ positive return value B<v> should be set to a negative value, typically -1.
 
 BIO_get_mem_data() sets *B<pp> to a pointer to the start of the memory BIOs data
 and returns the total amount of data available. It is implemented as a macro.
-Note the pointer returned by this call is informative, no transer of ownership
-of this memory is implied.  See notes on BIO_set_close()
+Note the pointer returned by this call is informative, no transfer of ownership
+of this memory is implied.  See notes on BIO_set_close().
 
 BIO_set_mem_buf() sets the internal BUF_MEM structure to B<bm> and sets the
 close flag to B<c>, that is B<c> should be either BIO_CLOSE or BIO_NOCLOSE.
@@ -118,7 +118,7 @@ BIO_FLAGS_NONCLEAR_RST set has the same effect as a write operation.
 
 Calling BIO_set_close() with BIO_NOCLOSE orphans the BUF_MEM internal to the
 BIO, _not_ its actual data buffer. See the examples section for the proper
-method for claiming ownership of the data pointer for a deferred free operation
+method for claiming ownership of the data pointer for a deferred free operation.
 
 =head1 BUGS
 


### PR DESCRIPTION
BIO_s_mem instances have a propensity to leak. This was returned from a recent valgrind run in an application I was working on:
==1007580== at 0x483C815: malloc (vg_replace_malloc.c:431)
==1007580== by 0x2C2689: CRYPTO_zalloc (in /home/vien/microedge-c/test)
==1007580== by 0x295A17: BUF_MEM_new (in /home/vien/microedge-c/test)
==1007580== by 0x295A78: BUF_MEM_new_ex (in /home/vien/microedge-c/test)
==1007580== by 0x28CACE: mem_new (in /home/vien/microedge-c/test)
==1007580== by 0x285EA8: BIO_new_ex (in /home/vien/microedge-c/test)
==1007580== by 0x231894: convert_pubkey_ECC (tpm2_driver.c:221)
==1007580== by 0x232B73: create_ephemeral_key (tpm2_driver.c:641)
==1007580== by 0x232E1F: tpm_gen_keypair (tpm2_driver.c:695)
==1007580== by 0x22D60A: gen_keypair (se_driver_api.c:275)
==1007580== by 0x21FF35: generate_keypair (dhkey.c:142)
==1007580== by 0x24D4C8: __test_dhkey (dhkey_test.c:55)

The problem is described in detail in the changelogs, but the executive summary is that:
a) When BIO_NOCLOSE is set on the BIO, if the user hasn't retrieved the BUF_MEM structure via BIO_get_mem_ptr or BIO_set_mem_ptr, it will leak
b) It is counter-intuitive that a call to BIO_get_mem_data doesn't assign ownership of the data pointer to the caller, leading, as when BIO_NOCLOSE is set, the application also must call BIO_[get|set]_mem_ptr to prevent a BUF_MEM leak, or worse, encounter a double free in the event that the pointer returned from BIO_get_mem_data is considered by the application to be orphaned when BIO_CLOSE is set.

This patch series is an attempt to reconcile those problem and create a more intuitive user experience

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
