### PR TITLE
Don't call ossl_assert on the result of bn_wexpand

### DIFF
--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -504,7 +504,7 @@ static BIGNUM *bin2bn(const unsigned char *s, int len, BIGNUM *ret,
         return ret;
     }
     n = ((len - 1) / BN_BYTES) + 1; /* Number of resulting bignum chunks */
-    if (!ossl_assert(bn_wexpand(ret, (int)n) != NULL)) {
+    if (bn_wexpand(ret, (int)n) == NULL) {
         BN_free(bn);
         return NULL;
     }


### PR DESCRIPTION
bn_wexpand can fail as the result of a memory allocation failure. We should not be calling ossl_assert() on its result because it can fail in normal operation.

Found via the reproducible error injection in #21668
