### PR TITLE
issue-21718: remove setting of PTHREAD_MUTEX_NORMAL

### DIFF
--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -70,8 +70,6 @@ CRYPTO_RWLOCK *CRYPTO_THREAD_lock_new(void)
 #  if !defined (__TANDEM) && !defined (_SPT_MODEL_)
 #   if !defined(NDEBUG) && !defined(OPENSSL_NO_MUTEX_ERRORCHECK)
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
-#   else
-    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_NORMAL);
 #   endif
 #  else
     /* The SPT Thread Library does not define MUTEX attributes. */


### PR DESCRIPTION
issue: https://github.com/openssl/openssl/issues/21718

build break reported:
crypto/threads_pthread.c:76:5: warning: implicit declaration of function 'pthread_mutexattr_settype'; did you mean 'pthread_mutexattr_destroy'? [-Wimplicit-function-declaration]
   76 |     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_NORMAL);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
      |     pthread_mutexattr_destroy
crypto/threads_pthread.c:76:38: error: 'PTHREAD_MUTEX_NORMAL' undeclared (first use in this function); did you mean 'PTHREAD_MUTEX_TIMED_NP'?
   76 |     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_NORMAL);
      |                                      ^~~~~~~~~~~~~~~~~~~~
      |                                      PTHREAD_MUTEX_TIMED_NP

This occurs because PTHREAD_MUTEX_NORMAL is only defined in glibc if __USE_UNIX98 or __USE_XOPEN2K8 is defined, which is derived from setting __USE_POSIX_C_SOURCE or __XOPEN_SOURCE is selected in the glibc feature set for a build.  Since openssl selects no specific feature set from glibc, the build break occurs

We could select a feature set of course, but that seems like a significant discussion to have prior to doing so. Instead, the simpler solution is to just not set the mutex type at all, given that pthread_mutexattr_init sets the default mutex type, which should be akin to normal anyway (i.e. no mutex error checking or allowed-recursive behavior)

