### PR TITLE
Add X509_STORE_CTX_set_get_crl and X509_STORE_CTX_set_current_reasons

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -2614,6 +2614,12 @@ void X509_STORE_CTX_set_time(X509_STORE_CTX *ctx, unsigned long flags,
     X509_VERIFY_PARAM_set_time(ctx->param, t);
 }
 
+void X509_STORE_CTX_set_current_reasons(X509_STORE_CTX *ctx,
+                                        unsigned int current_reasons)
+{
+   ctx->current_reasons = current_reasons;
+}
+
 X509 *X509_STORE_CTX_get0_cert(const X509_STORE_CTX *ctx)
 {
     return ctx->cert;
@@ -2683,6 +2689,12 @@ X509_STORE_CTX_get_check_revocation(const X509_STORE_CTX *ctx)
 X509_STORE_CTX_get_crl_fn X509_STORE_CTX_get_get_crl(const X509_STORE_CTX *ctx)
 {
     return ctx->get_crl;
+}
+
+void X509_STORE_CTX_set_get_crl(X509_STORE_CTX *ctx,
+                                X509_STORE_CTX_get_crl_fn get_crl)
+{
+   ctx->get_crl = get_crl;
 }
 
 X509_STORE_CTX_check_crl_fn

--- a/doc/man3/X509_STORE_CTX_set_verify_cb.pod
+++ b/doc/man3/X509_STORE_CTX_set_verify_cb.pod
@@ -9,13 +9,15 @@ X509_STORE_CTX_get_check_policy,
 X509_STORE_CTX_get_cert_crl,
 X509_STORE_CTX_get_check_crl,
 X509_STORE_CTX_get_get_crl,
+X509_STORE_CTX_set_get_crl,
 X509_STORE_CTX_get_check_revocation,
 X509_STORE_CTX_get_check_issued,
 X509_STORE_CTX_get_get_issuer,
 X509_STORE_CTX_get_verify_cb,
 X509_STORE_CTX_set_verify_cb,
 X509_STORE_CTX_verify_cb,
-X509_STORE_CTX_print_verify_cb
+X509_STORE_CTX_print_verify_cb,
+X509_STORE_CTX_set_current_reasons
 - get and set X509_STORE_CTX components such as verification callback
 
 =head1 SYNOPSIS
@@ -33,13 +35,20 @@ X509_STORE_CTX_print_verify_cb
  X509_STORE_CTX_get_issuer_fn X509_STORE_CTX_get_get_issuer(X509_STORE_CTX *ctx);
  X509_STORE_CTX_check_issued_fn X509_STORE_CTX_get_check_issued(X509_STORE_CTX *ctx);
  X509_STORE_CTX_check_revocation_fn X509_STORE_CTX_get_check_revocation(X509_STORE_CTX *ctx);
+
  X509_STORE_CTX_get_crl_fn X509_STORE_CTX_get_get_crl(X509_STORE_CTX *ctx);
+
+ void X509_STORE_CTX_set_get_crl(X509_STORE_CTX *ctx,
+                                 X509_STORE_CTX_get_crl_fn get_crl);
+
  X509_STORE_CTX_check_crl_fn X509_STORE_CTX_get_check_crl(X509_STORE_CTX *ctx);
  X509_STORE_CTX_cert_crl_fn X509_STORE_CTX_get_cert_crl(X509_STORE_CTX *ctx);
  X509_STORE_CTX_check_policy_fn X509_STORE_CTX_get_check_policy(X509_STORE_CTX *ctx);
  X509_STORE_CTX_lookup_certs_fn X509_STORE_CTX_get_lookup_certs(X509_STORE_CTX *ctx);
  X509_STORE_CTX_lookup_crls_fn X509_STORE_CTX_get_lookup_crls(X509_STORE_CTX *ctx);
  X509_STORE_CTX_cleanup_fn X509_STORE_CTX_get_cleanup(X509_STORE_CTX *ctx);
+ void X509_STORE_CTX_set_current_reasons(X509_STORE_CTX *ctx,
+                                         unsigned int current_reasons);
 
 =head1 DESCRIPTION
 
@@ -82,6 +91,17 @@ X509_STORE_CTX_get_lookup_certs(), X509_STORE_CTX_get_lookup_crls()
 and X509_STORE_CTX_get_cleanup() return the function pointers cached
 from the corresponding B<X509_STORE>, please see
 L<X509_STORE_set_verify(3)> for more information.
+
+X509_STORE_CTX_set_get_crl() sets the function to get the crl for a given
+certificate I<x>.
+When found, the crl must be assigned to I<*crl>.
+This function must return 0 on failure and 1 on success.
+I<If no function to get the issuer is provided, the internal default
+function will be used instead.>
+
+X509_STORE_CTX_set_current_reasons() is used in conjunction with
+X509_STORE_CTX_get_crl_fn. The X509_STORE_CTX_get_crl_fn callback must
+use this method to set the reason why the certificate is invalid.
 
 
 =head1 WARNINGS

--- a/include/openssl/x509_vfy.h.in
+++ b/include/openssl/x509_vfy.h.in
@@ -486,6 +486,8 @@ X509_STORE_CTX_verify_fn X509_STORE_CTX_get_verify(const X509_STORE_CTX *ctx);
 X509_STORE_CTX_get_issuer_fn X509_STORE_CTX_get_get_issuer(const X509_STORE_CTX *ctx);
 X509_STORE_CTX_check_issued_fn X509_STORE_CTX_get_check_issued(const X509_STORE_CTX *ctx);
 X509_STORE_CTX_check_revocation_fn X509_STORE_CTX_get_check_revocation(const X509_STORE_CTX *ctx);
+void X509_STORE_CTX_set_get_crl(X509_STORE_CTX *ctx,
+                                X509_STORE_CTX_get_crl_fn get_crl);
 X509_STORE_CTX_get_crl_fn X509_STORE_CTX_get_get_crl(const X509_STORE_CTX *ctx);
 X509_STORE_CTX_check_crl_fn X509_STORE_CTX_get_check_crl(const X509_STORE_CTX *ctx);
 X509_STORE_CTX_cert_crl_fn X509_STORE_CTX_get_cert_crl(const X509_STORE_CTX *ctx);
@@ -679,6 +681,8 @@ int X509_STORE_CTX_purpose_inherit(X509_STORE_CTX *ctx, int def_purpose,
 void X509_STORE_CTX_set_flags(X509_STORE_CTX *ctx, unsigned long flags);
 void X509_STORE_CTX_set_time(X509_STORE_CTX *ctx, unsigned long flags,
                              time_t t);
+void X509_STORE_CTX_set_current_reasons(X509_STORE_CTX *ctx,
+                                        unsigned int current_reasons);
 
 X509_POLICY_TREE *X509_STORE_CTX_get0_policy_tree(const X509_STORE_CTX *ctx);
 int X509_STORE_CTX_get_explicit_policy(const X509_STORE_CTX *ctx);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5530,3 +5530,5 @@ OSSL_ERR_STATE_restore                  ?	3_2_0	EXIST::FUNCTION:
 OSSL_ERR_STATE_free                     ?	3_2_0	EXIST::FUNCTION:
 ERR_count_to_mark                       ?	3_2_0	EXIST::FUNCTION:
 OSSL_ERR_STATE_save_to_mark             ?	3_2_0	EXIST::FUNCTION:
+X509_STORE_CTX_set_get_crl              ?	3_2_0	EXIST::FUNCTION:
+X509_STORE_CTX_set_current_reasons      ?	3_2_0	EXIST::FUNCTION:


### PR DESCRIPTION
This change is for feature request #21679.

Adds a couple of setters to aid with custom CRL validation.

- [x] documentation is added or updated
