### PR TITLE
Add notes on use of `strdup`

### DIFF
--- a/crypto/conf/conf_lib.c
+++ b/crypto/conf/conf_lib.c
@@ -421,6 +421,12 @@ OPENSSL_INIT_SETTINGS *OPENSSL_INIT_new(void)
 
 
 #ifndef OPENSSL_NO_STDIO
+/*
+ * If CRYPTO_set_mem_functions is called after this, then
+ * memory allocation and deallocation in this function can
+ * become disjointed. Avoid this by always using standard
+ * strdup & free instead of OPENSSL_strdup & OPENSSL_free.
+ */
 int OPENSSL_INIT_set_config_filename(OPENSSL_INIT_SETTINGS *settings,
                                      const char *filename)
 {
@@ -444,6 +450,12 @@ void OPENSSL_INIT_set_config_file_flags(OPENSSL_INIT_SETTINGS *settings,
     settings->flags = flags;
 }
 
+/*
+ * If CRYPTO_set_mem_functions is called after this, then
+ * memory allocation and deallocation in this function can
+ * become disjointed. Avoid this by always using standard
+ * strdup & free instead of OPENSSL_strdup & OPENSSL_free.
+ */
 int OPENSSL_INIT_set_config_appname(OPENSSL_INIT_SETTINGS *settings,
                                     const char *appname)
 {


### PR DESCRIPTION
There are some platforms that do not have support for `strdup`. OpenSSL has its own built-in function that functions the same as `strdup` named `OPENSSL_strdup` which can be used to replace the `strdup` function calls used in the OpenSSL codebase.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
