### PR TITLE
Add two missing entries to the OCSP CRLReason table

### DIFF
--- a/crypto/ocsp/ocsp_prn.c
+++ b/crypto/ocsp/ocsp_prn.c
@@ -79,7 +79,9 @@ const char *OCSP_crl_reason_str(long s)
         {OCSP_REVOKED_STATUS_SUPERSEDED, "superseded"},
         {OCSP_REVOKED_STATUS_CESSATIONOFOPERATION, "cessationOfOperation"},
         {OCSP_REVOKED_STATUS_CERTIFICATEHOLD, "certificateHold"},
-        {OCSP_REVOKED_STATUS_REMOVEFROMCRL, "removeFromCRL"}
+        {OCSP_REVOKED_STATUS_REMOVEFROMCRL, "removeFromCRL"},
+        {OCSP_REVOKED_STATUS_PRIVILEGEWITHDRAWN, "privilegeWithdrawn"},
+        {OCSP_REVOKED_STATUS_AACOMPROMISE, "aACompromise"}
     };
     return table2string(s, reason_tbl);
 }


### PR DESCRIPTION
This PR adds two CRLReasons (privilegeWithdrawn and aACompromise) that are missing from `reason_tbl` in `OCSP_crl_reason_str()` (crypto/ocsp/ocsp_prn.c) but present in https://datatracker.ietf.org/doc/html/rfc5280#section-5.3.1.

These two CRLReasons were absent in https://datatracker.ietf.org/doc/html/rfc2459#section-5.3.1 and X.509 (08/97), which is presumably why they were missing from ocsp_prn.c.  Interestingly though, the corresponding #defines do already exist (in include/openssl/ocsp.h.in).

The use of reason codes in CRL entries and OCSP responses has increased amongst WebPKI CAs recently, and I'm aware of several people that have been confused by the missing privilegeWithdrawn entry (that this PR adds) when using "openssl ocsp" to print OCSP responses.