### PR TITLE
Fix stack allocations on ppc asm for secp384r1

### DIFF
--- a/crypto/ec/asm/ecp_nistp384-ppc64.pl
+++ b/crypto/ec/asm/ecp_nistp384-ppc64.pl
@@ -62,51 +62,6 @@ sub endproc($)
 ___
 }
 
-
-sub push_vrs($$)
-{
-    my ($min, $max) = @_;
-
-    my $count = $max - $min + 1;
-
-    $code.=<<___;
-    mr      $savesp,$sp
-    stdu        $sp,-16*`$count+1`($sp)
-
-___
-        for (my $i = $min; $i <= $max; $i++) {
-            my $mult = $max - $i + 1;
-            $code.=<<___;
-    stxv        $i,-16*$mult($savesp)
-___
-
-    }
-
-    $code.=<<___;
-
-___
-}
-
-sub pop_vrs($$)
-{
-    my ($min, $max) = @_;
-
-    $code.=<<___;
-    ld      $savesp,0($sp)
-___
-    for (my $i = $min; $i <= $max; $i++) {
-        my $mult = $max - $i + 1;
-        $code.=<<___;
-    lxv     $i,-16*$mult($savesp)
-___
-    }
-
-    $code.=<<___;
-    mr      $sp,$savesp
-
-___
-}
-
 sub load_vrs($$)
 {
     my ($pointer, $reg_list) = @_;
@@ -161,8 +116,6 @@ ___
         my @in2 = map("v$_",(35..41));
 
         startproc("p384_felem_mul");
-
-        push_vrs(52, 63);
 
         $code.=<<___;
     vspltisw    $vzero,0
@@ -267,8 +220,6 @@ ___
         my @inx2 = map("v$_",(35..41));
 
         startproc("p384_felem_square");
-
-        push_vrs(52, 63);
 
         $code.=<<___;
     vspltisw    $vzero,0

--- a/crypto/ec/ecp_nistp384.c
+++ b/crypto/ec/ecp_nistp384.c
@@ -540,7 +540,7 @@ static void felem_reduce(felem out, const widefelem in)
     acc[7] += in[12] >> 8;
     acc[6] += (in[12] & 0xff) << 48;
     acc[6] -= in[12] >> 16;
-    acc[5] -= ((in[12] & 0xffff) << 40);
+    acc[5] -= (in[12] & 0xffff) << 40;
     acc[6] += in[12] >> 48;
     acc[5] += (in[12] & 0xffffffffffff) << 8;
 
@@ -549,7 +549,7 @@ static void felem_reduce(felem out, const widefelem in)
     acc[6] += in[11] >> 8;
     acc[5] += (in[11] & 0xff) << 48;
     acc[5] -= in[11] >> 16;
-    acc[4] -= ((in[11] & 0xffff) << 40);
+    acc[4] -= (in[11] & 0xffff) << 40;
     acc[5] += in[11] >> 48;
     acc[4] += (in[11] & 0xffffffffffff) << 8;
 
@@ -558,7 +558,7 @@ static void felem_reduce(felem out, const widefelem in)
     acc[5] += in[10] >> 8;
     acc[4] += (in[10] & 0xff) << 48;
     acc[4] -= in[10] >> 16;
-    acc[3] -= ((in[10] & 0xffff) << 40);
+    acc[3] -= (in[10] & 0xffff) << 40;
     acc[4] += in[10] >> 48;
     acc[3] += (in[10] & 0xffffffffffff) << 8;
 
@@ -567,7 +567,7 @@ static void felem_reduce(felem out, const widefelem in)
     acc[4] += in[9] >> 8;
     acc[3] += (in[9] & 0xff) << 48;
     acc[3] -= in[9] >> 16;
-    acc[2] -= ((in[9] & 0xffff) << 40);
+    acc[2] -= (in[9] & 0xffff) << 40;
     acc[3] += in[9] >> 48;
     acc[2] += (in[9] & 0xffffffffffff) << 8;
 
@@ -582,7 +582,7 @@ static void felem_reduce(felem out, const widefelem in)
     acc[3] += acc[8] >> 8;
     acc[2] += (acc[8] & 0xff) << 48;
     acc[2] -= acc[8] >> 16;
-    acc[1] -= ((acc[8] & 0xffff) << 40);
+    acc[1] -= (acc[8] & 0xffff) << 40;
     acc[2] += acc[8] >> 48;
     acc[1] += (acc[8] & 0xffffffffffff) << 8;
 
@@ -591,7 +591,7 @@ static void felem_reduce(felem out, const widefelem in)
     acc[2] += acc[7] >> 8;
     acc[1] += (acc[7] & 0xff) << 48;
     acc[1] -= acc[7] >> 16;
-    acc[0] -= ((acc[7] & 0xffff) << 40);
+    acc[0] -= (acc[7] & 0xffff) << 40;
     acc[1] += acc[7] >> 48;
     acc[0] += (acc[7] & 0xffffffffffff) << 8;
 


### PR DESCRIPTION
Fix unmatched stack allocation in assembly for `felem_{mul,square}()`. This should always present as a bug.