### PR TITLE
Fix a memory leak in tls_new_record_layer

### DIFF
--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1411,7 +1411,7 @@ tls_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
 
  err:
     if (ret != OSSL_RECORD_RETURN_SUCCESS) {
-        OPENSSL_free(*retrl);
+        tls_int_free(*retrl);
         *retrl = NULL;
     }
     return ret;


### PR DESCRIPTION
If setting the crypto state has failed then memory might have been partially allocated to fields within the partially constructed record layer. We need to call tls_int_free() to properly free it.

Found by the reproducible error patch in openssl#21668

