### PR TITLE
Handle the case where the read buffer is empty but we have received FIN

### DIFF
--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -2237,6 +2237,9 @@ static int quic_read_actual(QCTX *ctx,
                                               stream);
     }
 
+    if (*bytes_read == 0 && is_fin)
+        return QUIC_RAISE_NORMAL_ERROR(ctx, SSL_ERROR_ZERO_RETURN);
+
     return 1;
 }
 


### PR DESCRIPTION
In some cases where a FIN has been received but with no data quic_read_actual
was failing to raise SSL_ERROR_ZERO_RETURN. This meant that we could end up
blocking in SSL_read(_ex) for too long.