### PR TITLE
Fixes for HP-UX 10.20

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -516,8 +516,8 @@ libclean:
 clean: libclean
 	$(RM) $(PROGRAMS) $(TESTPROGS) $(ENGINES) $(SCRIPTS)
 	$(RM) $(GENERATED_MANDATORY) $(GENERATED)
-	-$(RM) `find . -name '*{- $depext -}' \! -name '.*' \! -type d -print`
-	-$(RM) `find . -name '*{- $objext -}' \! -name '.*' \! -type d -print`
+	find . -name '*{- $depext -}' \! -name '.*' \! -type d -print | xargs $(RM)
+	find . -name '*{- $objext -}' \! -name '.*' \! -type d -print | xargs $(RM)
 	$(RM) core
 	$(RM) tags TAGS doc-nits
 	$(RM) -r test/test-runs

--- a/apps/s_socket.c
+++ b/apps/s_socket.c
@@ -160,7 +160,9 @@ int init_client(int *sock, const char *host, const char *port,
     if (*sock == INVALID_SOCKET) {
         if (bindaddr != NULL && !found) {
             BIO_printf(bio_err, "Can't bind %saddress for %s%s%s\n",
+#ifdef AF_INET6
                        BIO_ADDRINFO_family(res) == AF_INET6 ? "IPv6 " :
+#endif
                        BIO_ADDRINFO_family(res) == AF_INET ? "IPv4 " :
                        BIO_ADDRINFO_family(res) == AF_UNIX ? "unix " : "",
                        bindhost != NULL ? bindhost : "",
@@ -239,6 +241,7 @@ int do_server(int *accept_sock, const char *host, const char *port,
     sock_protocol = BIO_ADDRINFO_protocol(res);
     sock_address = BIO_ADDRINFO_address(res);
     next = BIO_ADDRINFO_next(res);
+#ifdef AF_INET6
     if (sock_family == AF_INET6)
         sock_options |= BIO_SOCK_V6_ONLY;
     if (next != NULL
@@ -257,6 +260,7 @@ int do_server(int *accept_sock, const char *host, const char *port,
             sock_options &= ~BIO_SOCK_V6_ONLY;
         }
     }
+#endif
 
     asock = BIO_socket(sock_family, sock_type, sock_protocol, 0);
     if (asock == INVALID_SOCKET && sock_family_fallback != AF_UNSPEC) {

--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -853,7 +853,7 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
             }
 
             if (endp != service && *endp == '\0'
-                    && portnum > 0 && portnum < 65536) {
+                    && portnum >= 0 && portnum < 65536) {
                 se_fallback.s_port = htons((unsigned short)portnum);
                 se_fallback.s_proto = proto;
                 se = &se_fallback;

--- a/crypto/bio/bio_local.h
+++ b/crypto/bio/bio_local.h
@@ -137,6 +137,10 @@ struct bio_st {
 # ifdef OPENSSL_SYS_VMS
 typedef unsigned int socklen_t;
 # endif
+# if defined(_HPUX_SOURCE) && defined(_PA_RISC1_1)
+#  undef socklen_t
+#  define socklen_t int
+# endif
 
 extern CRYPTO_RWLOCK *bio_lookup_lock;
 

--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -840,7 +840,7 @@ static uint64_t get_timer_bits(void)
     if (res != 0)
         return res;
 
-# if defined(__sun) || defined(__hpux)
+# if defined(__sun)
     return gethrtime();
 # elif defined(_AIX)
     {

--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -830,7 +830,7 @@ static uint64_t get_time_stamp(void)
  * Get an arbitrary timer value of the highest possible resolution
  *
  * The timer value is added as random noise to the additional data,
- * which is not considered a trusted entropy sourec, so any result
+ * which is not considered a trusted entropy source, so any result
  * is acceptable.
  */
 static uint64_t get_timer_bits(void)


### PR DESCRIPTION
With these changes, OpenSSL 1.1.1 compiles on HP-UX 10.20 (using gcc) and passes 'make test'.

I omitted any workarounds for the vendor-supplied compiler, HP ANSI C. That compiler has enough bugs that I think it's better to just use gcc.

The build environment used for testing was gcc 4.2.2, binutils 2.16.1, GNU Make 3.80, Perl 5.22.1, and zlib 1.2.7, and the following configuration: `./Configure hpux-parisc1_1-gcc --with-rand-seed=egd --with-zlib-include=/usr/local/include --with-zlib-lib=/usr/local/lib zlib enable-egd no-shared no-threads no-asm CPPDEFINES=OPENSSL_NO_SECURE_MEMORY CC=/usr/local/pa11_32/bin/gcc CXX=/usr/local/pa11_32/bin/g++`

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->