### PR TITLE
Fixed default value of the "ess_cert_id_alg" option

### DIFF
--- a/apps/openssl-vms.cnf
+++ b/apps/openssl-vms.cnf
@@ -330,8 +330,8 @@ tsa_name		= yes	# Must the TSA name be included in the reply?
 				# (optional, default: no)
 ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
 				# (optional, default: no)
-ess_cert_id_alg		= sha1	# algorithm to compute certificate
-				# identifier (optional, default: sha1)
+ess_cert_id_alg		= sha256	# algorithm to compute certificate
+				# identifier (optional, default: sha256)
 
 [insta] # CMP using Insta Demo CA
 # Message transfer

--- a/apps/openssl.cnf
+++ b/apps/openssl.cnf
@@ -330,8 +330,8 @@ tsa_name		= yes	# Must the TSA name be included in the reply?
 				# (optional, default: no)
 ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
 				# (optional, default: no)
-ess_cert_id_alg		= sha1	# algorithm to compute certificate
-				# identifier (optional, default: sha1)
+ess_cert_id_alg		= sha256	# algorithm to compute certificate
+				# identifier (optional, default: sha256)
 
 [insta] # CMP using Insta Demo CA
 # Message transfer

--- a/crypto/ts/ts_conf.c
+++ b/crypto/ts/ts_conf.c
@@ -481,7 +481,7 @@ int TS_CONF_set_ess_cert_id_digest(CONF *conf, const char *section,
     const char *md = NCONF_get_string(conf, section, ENV_ESS_CERT_ID_ALG);
 
     if (md == NULL)
-        md = "sha1";
+        md = "sha256";
 
     cert_md = EVP_get_digestbyname(md);
     if (cert_md == NULL) {

--- a/doc/man1/openssl-ts.pod.in
+++ b/doc/man1/openssl-ts.pod.in
@@ -490,7 +490,7 @@ Default is no.  (Optional)
 =item B<ess_cert_id_alg>
 
 This option specifies the hash function to be used to calculate the TSA's
-public key certificate identifier. Default is sha1. (Optional)
+public key certificate identifier. Default is sha256. (Optional)
 
 =back
 

--- a/test/CAtsa.cnf
+++ b/test/CAtsa.cnf
@@ -144,7 +144,7 @@ tsa_name		= yes	# Must the TSA name be included in the reply?
 ess_cert_id_chain	= yes	# Must the ESS cert id chain be included?
 				# (optional, default: no)
 ess_cert_id_alg		= sha256	# algorithm to compute certificate
-					# identifier (optional, default: sha1)
+					# identifier (optional, default: sha256)
 
 [ tsa_config2 ]
 


### PR DESCRIPTION
The "ess_cert_id_alg" option specifies the hash function to be used to calculate the TSA's public key certificate identifier. 
The man page says default is sha256.