### PR TITLE
Keep sending datagrams while we have data to send

### DIFF
--- a/include/internal/quic_txpim.h
+++ b/include/internal/quic_txpim.h
@@ -40,6 +40,7 @@ typedef struct quic_txpim_pkt_st {
     unsigned int        had_max_streams_bidi_frame  : 1;
     unsigned int        had_max_streams_uni_frame   : 1;
     unsigned int        had_ack_frame               : 1;
+    unsigned int        had_conn_close              : 1;
 
     /* Private data follows. */
 } QUIC_TXPIM_PKT;

--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -1804,6 +1804,7 @@ static int txp_generate_pre_token(OSSL_QUIC_TX_PACKETISER *txp,
             if (!tx_helper_commit(h))
                 return 0;
 
+            tpkt->had_conn_close = 1;
             *can_be_non_inflight = 0;
         } else {
             tx_helper_rollback(h);
@@ -2943,6 +2944,9 @@ static int txp_pkt_commit(OSSL_QUIC_TX_PACKETISER *txp,
 
     if (tpkt->had_ack_frame)
         txp->want_ack &= ~(1UL << pn_space);
+
+    if (tpkt->had_conn_close)
+        txp->want_conn_close = 0;
 
     /*
      * Decrement probe request counts if we have sent a packet that meets

--- a/ssl/quic/quic_txpim.c
+++ b/ssl/quic/quic_txpim.c
@@ -115,6 +115,7 @@ static void txpim_clear(QUIC_TXPIM_PKT_EX *ex)
     ex->public.had_max_streams_bidi_frame  = 0;
     ex->public.had_max_streams_uni_frame   = 0;
     ex->public.had_ack_frame               = 0;
+    ex->public.had_conn_close              = 0;
 }
 
 QUIC_TXPIM_PKT *ossl_quic_txpim_pkt_alloc(QUIC_TXPIM *txpim)

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -949,6 +949,60 @@ static int test_back_pressure(void)
     return testresult;
 }
 
+
+static int dgram_ctr = 0;
+
+static void dgram_cb(int write_p, int version, int content_type,
+                     const void *buf, size_t msglen, SSL *ssl, void *arg)
+{
+    if (!write_p)
+        return;
+
+    if (content_type != SSL3_RT_QUIC_DATAGRAM)
+        return;
+
+    dgram_ctr++;
+}
+
+/* Test that we send multiple datagrams in one go when appropriate */
+static int test_multiple_dgrams(void)
+{
+    SSL_CTX *cctx = SSL_CTX_new_ex(libctx, NULL, OSSL_QUIC_client_method());
+    SSL *clientquic = NULL;
+    QUIC_TSERVER *qtserv = NULL;
+    int testresult = 0;
+    unsigned char *buf;
+    const size_t buflen = 1400;
+    size_t written;
+
+    buf = OPENSSL_zalloc(buflen);
+
+    if (!TEST_ptr(cctx)
+            || !TEST_ptr(buf)
+            || !TEST_true(qtest_create_quic_objects(libctx, cctx, NULL, cert,
+                                                    privkey, 0, &qtserv,
+                                                    &clientquic, NULL))
+            || !TEST_true(qtest_create_quic_connection(qtserv, clientquic)))
+        goto err;
+
+    dgram_ctr = 0;
+    SSL_set_msg_callback(clientquic, dgram_cb);
+    if (!TEST_true(SSL_write_ex(clientquic, buf, buflen, &written))
+            || !TEST_size_t_eq(written, buflen)
+               /* We wrote enough data for 2 datagrams */
+            || !TEST_int_eq(dgram_ctr, 2))
+        goto err;
+
+    testresult = 1;
+ err:
+    OPENSSL_free(buf);
+    SSL_free(clientquic);
+    ossl_quic_tserver_free(qtserv);
+    SSL_CTX_free(cctx);
+
+    return testresult;
+}
+
 OPT_TEST_DECLARE_USAGE("provider config certsdir datadir\n")
 
 int setup_tests(void)
@@ -1017,6 +1071,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_quic_set_fd, 3);
     ADD_TEST(test_bio_ssl);
     ADD_TEST(test_back_pressure);
+    ADD_TEST(test_multiple_dgrams);
     return 1;
  err:
     cleanup_tests();

--- a/test/recipes/75-test_quicapi_data/ssltraceref.txt
+++ b/test/recipes/75-test_quicapi_data/ssltraceref.txt
@@ -81,6 +81,8 @@ Sent Datagram
   Length: 1200
 Received Datagram
   Length: 1200
+Received Datagram
+  Length: 234
 Received Packet
   Packet Type: Initial
   Version: 0x00000001
@@ -123,8 +125,18 @@ Received Packet
   Version: 0x00000001
   Destination Conn Id: <zero length id>
   Source Conn Id: 0x????????????????
+  Payload length: 213
+  Packet Number: 0x00000001
+Received Packet
+  Packet Type: Handshake
+  Version: 0x00000001
+  Destination Conn Id: <zero length id>
+  Source Conn Id: 0x????????????????
   Payload length: 1042
   Packet Number: 0x00000000
+Received Frame: Crypto
+    Offset: 1022
+    Len: 192
 Received Frame: Crypto
     Offset: 0
     Len: 1022
@@ -233,40 +245,6 @@ YeeuLO02zToHhnQ6KbPXOrQAqcL1kngO4g+j/ru+4AZThFkdkGnltvk=
 ------------------
         No extensions
 
-Sent Frame: Ack  (without ECN)
-    Largest acked: 0
-    Ack delay (raw) 0
-    Ack range count: 0
-    First ack range: 0
-Sent Frame: Ack  (without ECN)
-    Largest acked: 0
-    Ack delay (raw) 0
-    Ack range count: 0
-    First ack range: 0
-Sent Frame: Padding
-Sent Packet
-  Packet Type: Initial
-  Version: 0x00000001
-  Destination Conn Id: 0x????????????????
-  Source Conn Id: <zero length id>
-  Payload length: 1137
-  Token: <zero length token>
-  Packet Number: 0x00000001
-
-Sent Datagram
-  Length: 1200
-Received Datagram
-  Length: 234
-Received Packet
-  Packet Type: Handshake
-  Version: 0x00000001
-  Destination Conn Id: <zero length id>
-  Source Conn Id: 0x????????????????
-  Payload length: 213
-  Packet Number: 0x00000001
-Received Frame: Crypto
-    Offset: 1022
-    Len: 192
 Received TLS Record
 Header:
   Version = TLS 1.2 (0x303)
@@ -290,6 +268,11 @@ Header:
       verify_data (len=32): ????????????????????????????????????????????????????????????????
 
 Sent Frame: Ack  (without ECN)
+    Largest acked: 0
+    Ack delay (raw) 0
+    Ack range count: 0
+    First ack range: 0
+Sent Frame: Ack  (without ECN)
     Largest acked: 1
     Ack delay (raw) 0
     Ack range count: 0
@@ -297,12 +280,21 @@ Sent Frame: Ack  (without ECN)
 Sent Frame: Crypto
     Offset: 0
     Len: 36
+Sent Frame: Padding
+Sent Packet
+  Packet Type: Initial
+  Version: 0x00000001
+  Destination Conn Id: 0x????????????????
+  Source Conn Id: <zero length id>
+  Payload length: 1097
+  Token: <zero length token>
+  Packet Number: 0x00000001
 Sent Packet
   Packet Type: Handshake
   Version: 0x00000001
   Destination Conn Id: 0x????????????????
   Source Conn Id: <zero length id>
   Payload length: 60
-  Packet Number: 0x00000001
+  Packet Number: 0x00000000
 Sent Datagram
-  Length: 81
+  Length: 1200


### PR DESCRIPTION
If we've got more data to send than will fit in a single datagram we should keep generating those datagrams until we've sent it all.

Making this change triggered a related problem which meant that every time we created a datagram we added a CONNECTION_CLOSE frame if one was scheduled. We weren't remembering that we had already sent it. This issue (probably) wasn't triggerable before so was not a problem.