### PR TITLE
Add a -trace option to quicserver to enable tracing of the communication

### DIFF
--- a/ssl/quic/quic_tserver.c
+++ b/ssl/quic/quic_tserver.c
@@ -159,6 +159,7 @@ void ossl_quic_tserver_free(QUIC_TSERVER *srv)
     ossl_quic_channel_free(srv->ch);
     BIO_free(srv->args.net_rbio);
     BIO_free(srv->args.net_wbio);
+    OPENSSL_free(srv->ssl);
     SSL_free(srv->tls);
     SSL_CTX_free(srv->ctx);
 #if defined(OPENSSL_THREADS)

--- a/ssl/quic/quic_tserver.c
+++ b/ssl/quic/quic_tserver.c
@@ -12,6 +12,7 @@
 #include "internal/quic_statm.h"
 #include "internal/common.h"
 #include "internal/time.h"
+#include "quic_local.h"
 
 /*
  * QUIC Test Server Module
@@ -19,6 +20,9 @@
  */
 struct quic_tserver_st {
     QUIC_TSERVER_ARGS   args;
+
+    /* Dummy SSL object for this QUIC connection for use by msg_callback */
+    SSL *ssl;
 
     /*
      * The QUIC channel providing the core QUIC connection implementation.
@@ -72,6 +76,7 @@ QUIC_TSERVER *ossl_quic_tserver_new(const QUIC_TSERVER_ARGS *args,
 {
     QUIC_TSERVER *srv = NULL;
     QUIC_CHANNEL_ARGS ch_args = {0};
+    QUIC_CONNECTION *qc = NULL;
 
     if (args->net_rbio == NULL || args->net_wbio == NULL)
         goto err;
@@ -121,6 +126,13 @@ QUIC_TSERVER *ossl_quic_tserver_new(const QUIC_TSERVER_ARGS *args,
         || !ossl_quic_channel_set_net_wbio(srv->ch, srv->args.net_wbio))
         goto err;
 
+    qc = OPENSSL_zalloc(sizeof(*qc));
+    if (qc == NULL)
+        goto err;
+    srv->ssl = (SSL *)qc;
+    qc->ch = srv->ch;
+    srv->ssl->type = SSL_TYPE_QUIC_CONNECTION;
+
     return srv;
 
 err:
@@ -132,6 +144,7 @@ err:
 #if defined(OPENSSL_THREADS)
         ossl_crypto_mutex_free(&srv->mutex);
 #endif
+        OPENSSL_free(qc);
     }
 
     OPENSSL_free(srv);
@@ -526,8 +539,10 @@ void ossl_quic_tserver_set_msg_callback(QUIC_TSERVER *srv,
                                                   SSL *ssl, void *arg),
                                         void *arg)
 {
-    ossl_quic_channel_set_msg_callback(srv->ch, f, NULL);
+    ossl_quic_channel_set_msg_callback(srv->ch, f, srv->ssl);
     ossl_quic_channel_set_msg_callback_arg(srv->ch, arg);
+    SSL_set_msg_callback(srv->tls, f);
+    SSL_set_msg_callback_arg(srv->tls, arg);
 }
 
 int ossl_quic_tserver_new_ticket(QUIC_TSERVER *srv)

--- a/util/quicserver.c
+++ b/util/quicserver.c
@@ -132,14 +132,14 @@ static BIO *create_dgram_bio(int family, const char *hostname, const char *port)
 
 static void usage(void)
 {
-    BIO_printf(bio_err, "quicserver [-6] hostname port certfile keyfile\n");
+    BIO_printf(bio_err, "quicserver [-6][-trace] hostname port certfile keyfile\n");
 }
 
 int main(int argc, char *argv[])
 {
     QUIC_TSERVER_ARGS tserver_args = {0};
     QUIC_TSERVER *qtserv = NULL;
-    int ipv6 = 0;
+    int ipv6 = 0, trace = 0;
     int argnext = 1;
     BIO *bio = NULL;
     char *hostname, *port, *certfile, *keyfile;
@@ -162,6 +162,8 @@ int main(int argc, char *argv[])
             break;
         if (strcmp(argv[argnext], "-6") == 0) {
             ipv6 = 1;
+        } else if(strcmp(argv[argnext], "-trace") == 0) {
+            trace = 1;
         } else {
             BIO_printf(bio_err, "Unrecognised argument %s\n", argv[argnext]);
             usage();
@@ -206,6 +208,9 @@ int main(int argc, char *argv[])
 
     /* Ownership of the BIO is passed to qtserv */
     bio = NULL;
+
+    if (trace)
+        ossl_quic_tserver_set_msg_callback(qtserv, SSL_trace, bio_err);
 
     /* Read the request */
     do {


### PR DESCRIPTION
Trace output of the communication with the client is dumped to stderr if
the -trace options is supplied