### PR TITLE
Correct the default of "ess_cert_id_alg" option in the documentation

### DIFF
--- a/doc/man1/openssl-ts.pod.in
+++ b/doc/man1/openssl-ts.pod.in
@@ -490,7 +490,7 @@ Default is no.  (Optional)
 =item B<ess_cert_id_alg>
 
 This option specifies the hash function to be used to calculate the TSA's
-public key certificate identifier. Default is sha256. (Optional)
+public key certificate identifier. Default is sha1. (Optional)
 
 =back
 


### PR DESCRIPTION
Targeted at 3.1/3.0 branches
Related with #21794

CLA: trivial

- [x] documentation is added or updated