### PR TITLE
Change the TLS handshake keys early if we're not doing early data

### DIFF
--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -615,11 +615,15 @@ CON_FUNC_RETURN tls_construct_finished(SSL_CONNECTION *s, WPACKET *pkt)
         s->statem.cleanuphand = 1;
 
     /*
-     * We only change the keys if we didn't already do this when we sent the
-     * client certificate
+     * If we attempted to write early data or we're in middlebox compat mode
+     * then we deferred changing the handshake write keys to the last possible
+     * moment. If we didn't already do this when we sent the client certificate
+     * then we need to do it now.
      */
     if (SSL_CONNECTION_IS_TLS13(s)
             && !s->server
+            && (s->early_data_state != SSL_EARLY_DATA_NONE
+                || (s->options & SSL_OP_ENABLE_MIDDLEBOX_COMPAT) != 0)
             && s->s3.tmp.cert_req == 0
             && (!ssl->method->ssl3_enc->change_cipher_state(s,
                     SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE))) {;

--- a/test/recipes/75-test_quicapi_data/ssltraceref.txt
+++ b/test/recipes/75-test_quicapi_data/ssltraceref.txt
@@ -238,15 +238,21 @@ Sent Frame: Ack  (without ECN)
     Ack delay (raw) 0
     Ack range count: 0
     First ack range: 0
+Sent Frame: Ack  (without ECN)
+    Largest acked: 0
+    Ack delay (raw) 0
+    Ack range count: 0
+    First ack range: 0
 Sent Frame: Padding
 Sent Packet
   Packet Type: Initial
   Version: 0x00000001
   Destination Conn Id: 0x????????????????
   Source Conn Id: <zero length id>
-  Payload length: 1178
+  Payload length: 1137
   Token: <zero length token>
   Packet Number: 0x00000001
+
 Sent Datagram
   Length: 1200
 Received Datagram
@@ -297,6 +303,6 @@ Sent Packet
   Destination Conn Id: 0x????????????????
   Source Conn Id: <zero length id>
   Payload length: 60
-  Packet Number: 0x00000000
+  Packet Number: 0x00000001
 Sent Datagram
   Length: 81


### PR DESCRIPTION
We change the client TLS handshake keys as late as possible so that we don't disturb the keys if we are writing early data. However for QUIC we want to do this as early as possible (after ServerHello). Since we will never do TLS early data with QUIC we just do it as early as possible if early data is not being used.
