### PR TITLE
Only add jdkTrustedKeyUsage attr. to chain cert. in PKCS12

### DIFF
--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -878,6 +878,15 @@ static int jdk_trust(PKCS12_SAFEBAG *bag, void *cbarg)
     if (cbarg == NULL)
         return 1;
 
+    /* only add to X509 certBag without localKeyID (no associated key)
+     * and no existing trustedkeyusage
+     */
+    if(PKCS12_SAFEBAG_get_nid(bag)!=NID_certBag
+            || PKCS12_SAFEBAG_get_bag_nid(bag)!=NID_x509Certificate
+            || !!PKCS12_SAFEBAG_get0_attr(bag, NID_localKeyID)
+            || !!PKCS12_SAFEBAG_get0_attr(bag, NID_oracle_jdk_trustedkeyusage))
+        return 1;
+
     /* Get the current attrs */
     attrs = (STACK_OF(X509_ATTRIBUTE)*)PKCS12_SAFEBAG_get0_attrs(bag);
 


### PR DESCRIPTION
Allows `openssl pkcs12 ...` to produce PKCS12 files which produce almost identical output from java `keytool`, and are usable with at least one java application.

Following the round-trip and comparison process outlined in #21791.  The resulting diff of `keytool -v -list` output for the `-alias server1` entry is identical, showing the full chain of trust `rootCA -> intermediateCA -> server1`.  The other two entries differ by not having friendlyName attributes, which does not seem to have any functional effect.
