### PR TITLE
QUIC: Run multistream tests in blocking mode as well

### DIFF
--- a/crypto/thread/arch/thread_win.c
+++ b/crypto/thread/arch/thread_win.c
@@ -173,58 +173,360 @@ static int determine_timeout(OSSL_TIME deadline, DWORD *w_timeout_p)
 }
 
 # if defined(OPENSSL_THREADS_WINNT_LEGACY)
+#  include <assert.h>
+
+/*
+ * Win32, before Vista, did not have an OS-provided condition variable
+ * construct. This leads to the need to construct our own condition variable
+ * construct in order to support Windows XP.
+ *
+ * It is difficult to construct a condition variable construct using the
+ * OS-provided primitives in a way that is both correct (avoiding race
+ * conditions where broadcasts get lost) and fair.
+ *
+ * CORRECTNESS:
+ *   A blocked thread is a thread which is calling wait(), between the
+ *   precise instants at which the external mutex passed to wait() is
+ *   unlocked and the instant at which it is relocked.
+ *
+ *   a)
+ *     - If broadcast() is called, ALL blocked threads MUST be unblocked.
+ *     - If signal() is called, at least one blocked thread MUST be unblocked.
+ *
+ *     (i.e.: a signal or broadcast must never get 'lost')
+ *
+ *   b)
+ *     - If broadcast() or signal() is called, this must not cause a thread
+ *       which is not blocked to return immediately from a subsequent
+ *       call to wait().
+ *
+ * FAIRNESS:
+ *   If broadcast() is called at time T1, all blocked threads must be unblocked
+ *   before any thread which subsequently calls wait() at time T2 > T1 is
+ *   unblocked.
+ *
+ *   An example of an implementation which lacks fairness is as follows:
+ *
+ *     t1 enters wait()
+ *     t2 enters wait()
+ *
+ *     tZ calls broadcast()
+ *
+ *     t1 exits wait()
+ *     t1 enters wait()
+ *
+ *     tZ calls broadcast()
+ *
+ *     t1 exits wait()
+ *
+ * IMPLEMENTATION:
+ *
+ *   The most suitable primitives available to us in Windows XP are semaphores,
+ *   auto-reset events and manual-reset events. A solution based on semaphores
+ *   is chosen.
+ *
+ *   PROBLEM. Designing a solution based on semaphores is non-trivial because,
+ *   while it is easy to track the number of waiters in an interlocked data
+ *   structure and then add that number to the semaphore, this does not
+ *   guarantee fairness or correctness. Consider the following situation:
+ *
+ *     - t1 enters wait(), adding 1 to the wait counter & blocks on the semaphore
+ *     - t2 enters wait(), adding 1 to the wait counter & blocks on the semaphore
+ *     - tZ calls broadcast(), finds the wait counter is 2, adds 2 to the semaphore
+ *
+ *     - t1 exits wait()
+ *     - t1 immediately reenters wait() and blocks on the semaphore
+ *     - The semaphore is still positive due to also having been signalled
+ *       for t2, therefore it is decremented
+ *     - t1 exits wait() immediately; t2 is never woken
+ *
+ *   GENERATION COUNTERS. One naive solution to this is to use a generation
+ *   counter. Each broadcast() invocation increments a generation counter. If
+ *   the generation counter has not changed during a semaphore wait operation
+ *   inside wait(), this indicates that no broadcast() call has been made in
+ *   the meantime; therefore, the successful semaphore decrement must have
+ *   'stolen' a wakeup from another thread which was waiting to wakeup from the
+ *   prior broadcast() call but which had not yet had a chance to do so. The
+ *   semaphore can then be reincremented and the wait() operation repeated.
+ *
+ *   However, this suffers from the obvious problem that without OS guarantees
+ *   as to how semaphore readiness events are distributed amongst threads,
+ *   there is no particular guarantee that the semaphore readiness event will
+ *   not be immediately redistributed back to the same thread t1.
+ *
+ *   SOLUTION. A solution is chosen as follows. In its initial state, a
+ *   condition variable can accept waiters, who wait for the semaphore
+ *   normally. However, once broadcast() is called, the condition
+ *   variable becomes 'closed'. Any existing blocked threads are unblocked,
+ *   but any new calls to wait() will instead enter a blocking pre-wait stage.
+ *   Pre-wait threads are not considered to be waiting (and the external
+ *   mutex remains held). A call to wait() in pre-wait cannot progress
+ *   to waiting until all threads due to be unblocked by the prior broadcast()
+ *   call have returned and had a chance to execute.
+ *
+ *   This pre-wait does not affect a thread if it does not call wait()
+ *   again until after all threads have had a chance to execute.
+ *
+ *   RESOURCE USAGE. Aside from an allocation for the condition variable
+ *   structure, this solution uses two Win32 semaphores.
+ *
+ * FUTURE OPTIMISATIONS:
+ *
+ *   An optimised multi-generation implementation is possible at the cost of
+ *   higher Win32 resource usage. Multiple 'buckets' could be defined, with
+ *   usage rotating between buckets internally as buckets become closed.
+ *   This would avoid the need for the prewait in more cases, depending
+ *   on intensity of usage.
+ *
+ */
+typedef struct legacy_condvar_st {
+    CRYPTO_MUTEX    *int_m;       /* internal mutex */
+    HANDLE          sema;         /* main wait semaphore */
+    HANDLE          prewait_sema; /* prewait semaphore */
+    /*
+     * All of the following fields are protected by int_m.
+     *
+     * num_wake only ever increases by virtue of a corresponding decrease in
+     * num_wait. num_wait can decrease for other reasons (for example due to a
+     * wait operation timing out).
+     */
+    size_t          num_wait;     /* Num. threads currently blocked */
+    size_t          num_wake;     /* Num. threads due to wake up */
+    size_t          num_prewait;  /* Num. threads in prewait */
+    size_t          gen;          /* Prewait generation */
+    int             closed;       /* Is closed? */
+} LEGACY_CONDVAR;
 
 CRYPTO_CONDVAR *ossl_crypto_condvar_new(void)
 {
-    HANDLE h;
+    LEGACY_CONDVAR *cv;
 
-    if ((h = CreateEventA(NULL, FALSE, FALSE, NULL)) == NULL)
+    if ((cv = OPENSSL_malloc(sizeof(LEGACY_CONDVAR))) == NULL)
         return NULL;
 
-    return (CRYPTO_CONDVAR *)h;
+    if ((cv->int_m = ossl_crypto_mutex_new()) == NULL) {
+        OPENSSL_free(cv);
+        return NULL;
+    }
+
+    if ((cv->sema = CreateSemaphoreA(NULL, 0, LONG_MAX, NULL)) == NULL) {
+        ossl_crypto_mutex_free(&cv->int_m);
+        OPENSSL_free(cv);
+        return NULL;
+    }
+
+    if ((cv->prewait_sema = CreateSemaphoreA(NULL, 0, LONG_MAX, NULL)) == NULL) {
+        CloseHandle(cv->sema);
+        ossl_crypto_mutex_free(&cv->int_m);
+        OPENSSL_free(cv);
+        return NULL;
+    }
+
+    cv->num_wait      = 0;
+    cv->num_wake      = 0;
+    cv->num_prewait   = 0;
+    cv->closed        = 0;
+
+    return (CRYPTO_CONDVAR *)cv;
 }
 
-void ossl_crypto_condvar_wait(CRYPTO_CONDVAR *cv, CRYPTO_MUTEX *mutex)
+void ossl_crypto_condvar_free(CRYPTO_CONDVAR **cv_p)
 {
-    ossl_crypto_mutex_unlock(mutex);
-    WaitForSingleObject((HANDLE)cv, INFINITE);
-    ossl_crypto_mutex_lock(mutex);
+    if (*cv_p != NULL) {
+        LEGACY_CONDVAR *cv = *(LEGACY_CONDVAR **)cv_p;
+
+        CloseHandle(cv->sema);
+        CloseHandle(cv->prewait_sema);
+        ossl_crypto_mutex_free(&cv->int_m);
+        OPENSSL_free(cv);
+    }
+
+    *cv_p = NULL;
 }
 
-void ossl_crypto_condvar_wait_timeout(CRYPTO_CONDVAR *cv, CRYPTO_MUTEX *mutex,
-                                      OSSL_TIME deadline)
+static uint32_t obj_wait(HANDLE h, OSSL_TIME deadline)
 {
     DWORD timeout;
 
     if (!determine_timeout(deadline, &timeout))
         timeout = 1;
 
-    ossl_crypto_mutex_unlock(mutex);
-    WaitForSingleObject((HANDLE)cv, timeout);
-    ossl_crypto_mutex_lock(mutex);
+    return WaitForSingleObject(h, timeout);
 }
 
-void ossl_crypto_condvar_broadcast(CRYPTO_CONDVAR *cv)
+void ossl_crypto_condvar_wait_timeout(CRYPTO_CONDVAR *cv_, CRYPTO_MUTEX *ext_m,
+                                      OSSL_TIME deadline)
 {
-    /* Not supported */
+    LEGACY_CONDVAR *cv = (LEGACY_CONDVAR *)cv_;
+    int closed, set_prewait = 0, have_orig_gen = 0;
+    uint32_t rc;
+    size_t orig_gen;
+
+    /* Admission control - prewait until we can enter our actual wait phase. */
+    do {
+        ossl_crypto_mutex_lock(cv->int_m);
+
+        closed = cv->closed;
+
+        /*
+         * Once prewait is over the prewait semaphore is signalled and
+         * num_prewait is set to 0. Use a generation counter to track if we need
+         * to remove a value we added to num_prewait when exiting (e.g. due to
+         * timeout or failure of WaitForSingleObject).
+         */
+        if (!have_orig_gen) {
+            orig_gen = cv->gen;
+            have_orig_gen = 1;
+        } else if (cv->gen != orig_gen) {
+            set_prewait = 0;
+            orig_gen = cv->gen;
+        }
+
+        if (!closed) {
+            /* We can now be admitted. */
+            ++cv->num_wait;
+            if (set_prewait) {
+                --cv->num_prewait;
+                set_prewait = 0;
+            }
+        } else if (!set_prewait) {
+            ++cv->num_prewait;
+            set_prewait = 1;
+        }
+
+        ossl_crypto_mutex_unlock(cv->int_m);
+
+        if (closed)
+            if (obj_wait(cv->prewait_sema, deadline) != WAIT_OBJECT_0) {
+                /*
+                 * If we got WAIT_OBJECT_0 we are safe - num_prewait has been
+                 * set to 0 and the semaphore has been consumed. On the other
+                 * hand if we timed out, there may be a residual posting that
+                 * was made just after we timed out. However in the worst case
+                 * this will just cause an internal spurious wakeup here in the
+                 * future, so we do not care too much about this. We treat
+                 * failure and timeout cases as the same, and simply exit in
+                 * this case.
+                 */
+                ossl_crypto_mutex_lock(cv->int_m);
+                if (set_prewait && cv->gen == orig_gen)
+                    --cv->num_prewait;
+                ossl_crypto_mutex_unlock(cv->int_m);
+                return;
+            }
+    } while (closed);
+
+    /*
+     * Unlock external mutex. Do not do this until we have been admitted, as we
+     * must guarantee we wake if broadcast is called at any time after ext_m is
+     * unlocked.
+     */
+    ossl_crypto_mutex_unlock(ext_m);
+
+    for (;;) {
+        /* Wait. */
+        rc = obj_wait(cv->sema, deadline);
+
+        /* Reacquire internal mutex and probe state. */
+        ossl_crypto_mutex_lock(cv->int_m);
+
+        if (cv->num_wake > 0) {
+            /*
+             * A wake token is available, so we can wake up. Consume the token
+             * and get out of here. We don't care what WaitForSingleObject
+             * returned here (e.g. if it timed out coincidentally). In the
+             * latter case a signal might be left in the semaphore which causes
+             * a future WaitForSingleObject call to return immediately, but in
+             * this case we will just loop again.
+             */
+            --cv->num_wake;
+            if (cv->num_wake == 0 && cv->closed) {
+                /*
+                 * We consumed the last wake token, so we can now open the
+                 * condition variable for new admissions.
+                 */
+                cv->closed = 0;
+                if (cv->num_prewait > 0) {
+                    ReleaseSemaphore(cv->prewait_sema, (LONG)cv->num_prewait, NULL);
+                    cv->num_prewait = 0;
+                    ++cv->gen;
+                }
+            }
+        } else if (rc == WAIT_OBJECT_0) {
+            /*
+             * We got a wakeup from the semaphore but we did not have any wake
+             * tokens. This ideally does not happen, but might if during a
+             * previous wait() call the semaphore is posted just after
+             * WaitForSingleObject returns due to a timeout (such that the
+             * num_wake > 0 case is taken above). Just spin again. (It is worth
+             * noting that repeated WaitForSingleObject calls is the only method
+             * documented for decrementing a Win32 semaphore, so this is
+             * basically the best possible strategy.)
+             */
+            ossl_crypto_mutex_unlock(cv->int_m);
+            continue;
+        } else {
+            /*
+             * Assume we timed out. The WaitForSingleObject call may also have
+             * failed for some other reason, which we treat as a timeout.
+             */
+            assert(cv->num_wait > 0);
+            --cv->num_wait;
+        }
+
+        break;
+    }
+
+    ossl_crypto_mutex_unlock(cv->int_m);
+    ossl_crypto_mutex_lock(ext_m);
 }
 
-void ossl_crypto_condvar_signal(CRYPTO_CONDVAR *cv)
+void ossl_crypto_condvar_wait(CRYPTO_CONDVAR *cv, CRYPTO_MUTEX *ext_m)
 {
-    HANDLE *cv_p = (HANDLE *)cv;
-
-    SetEvent(cv_p);
+    ossl_crypto_condvar_wait_timeout(cv, ext_m, ossl_time_infinite());
 }
 
-void ossl_crypto_condvar_free(CRYPTO_CONDVAR **cv)
+void ossl_crypto_condvar_broadcast(CRYPTO_CONDVAR *cv_)
 {
-    HANDLE **cv_p;
+    LEGACY_CONDVAR *cv = (LEGACY_CONDVAR *)cv_;
+    size_t num_wake;
 
-    cv_p = (HANDLE **)cv;
-    if (*cv_p != NULL)
-        CloseHandle(*cv_p);
+    ossl_crypto_mutex_lock(cv->int_m);
 
-    *cv_p = NULL;
+    num_wake = cv->num_wait;
+    if (num_wake == 0) {
+        ossl_crypto_mutex_unlock(cv->int_m);
+        return;
+    }
+
+    cv->num_wake  += num_wake;
+    cv->num_wait  -= num_wake;
+    cv->closed     = 1;
+
+    ossl_crypto_mutex_unlock(cv->int_m);
+    ReleaseSemaphore(cv->sema, num_wake, NULL);
+}
+
+void ossl_crypto_condvar_signal(CRYPTO_CONDVAR *cv_)
+{
+    LEGACY_CONDVAR *cv = (LEGACY_CONDVAR *)cv_;
+
+    ossl_crypto_mutex_lock(cv->int_m);
+
+    if (cv->num_wait == 0) {
+        ossl_crypto_mutex_unlock(cv->int_m);
+        return;
+    }
+
+    /*
+     * We do not close the condition variable when merely signalling, as there
+     * are no guaranteed fairness semantics here, unlike for a broadcast.
+     */
+    --cv->num_wait;
+    ++cv->num_wake;
+
+    ossl_crypto_mutex_unlock(cv->int_m);
+    ReleaseSemaphore(cv->sema, 1, NULL);
 }
 
 # else

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2577,15 +2577,18 @@ static const struct script_op script_19[] = {
 /* 20. Multiple threads accept stream with socket forcibly closed (error test) */
 static int script_20_trigger(struct helper *h, volatile uint64_t *counter)
 {
+#if defined(OPENSSL_THREADS)
     ossl_crypto_mutex_lock(h->misc_m);
     ++*counter;
     ossl_crypto_mutex_unlock(h->misc_m);
     ossl_crypto_condvar_broadcast(h->misc_cv);
+#endif
     return 1;
 }
 
 static int script_20_wait(struct helper *h, volatile uint64_t *counter, uint64_t threshold)
 {
+#if defined(OPENSSL_THREADS)
     int stop = 0;
 
     ossl_crypto_mutex_lock(h->misc_m);
@@ -2598,6 +2601,7 @@ static int script_20_wait(struct helper *h, volatile uint64_t *counter, uint64_t
     }
 
     ossl_crypto_mutex_unlock(h->misc_m);
+#endif
     return 1;
 }
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -64,6 +64,8 @@ struct helper {
 #if defined(OPENSSL_THREADS)
     struct child_thread_args    *threads;
     size_t                      num_threads;
+    CRYPTO_MUTEX		*misc_m;
+    CRYPTO_CONDVAR		*misc_cv;
 #endif
 
     OSSL_TIME       start_time;
@@ -634,6 +636,8 @@ static void helper_cleanup(struct helper *h)
     h->time_lock = NULL;
 
 #if defined(OPENSSL_THREADS)
+    ossl_crypto_mutex_free(&h->misc_m);
+    ossl_crypto_condvar_free(&h->misc_cv);
     ossl_crypto_mutex_free(&h->server_thread.m);
     ossl_crypto_condvar_free(&h->server_thread.c);
 #endif
@@ -765,6 +769,13 @@ static int helper_init(struct helper *h, int free_order, int blocking,
 
     if (!TEST_true(SSL_set_blocking_mode(h->c_conn, h->blocking)))
         goto err;
+
+#if defined(OPENSSL_THREADS)
+    if (!TEST_ptr(h->misc_m = ossl_crypto_mutex_new()))
+      goto err;
+    if (!TEST_ptr(h->misc_cv = ossl_crypto_condvar_new()))
+      goto err;
+#endif
 
     if (h->blocking) {
 #if defined(OPENSSL_THREADS)
@@ -1059,6 +1070,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
             /* Only allow certain opcodes on child threads. */
             switch (op->op) {
                 case OPK_END:
+                case OPK_CHECK:
                 case OPK_C_ACCEPT_STREAM_WAIT:
                 case OPK_C_NEW_STREAM:
                 case OPK_C_READ_EXPECT:
@@ -1159,7 +1171,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                 ok = op->check_func(h, hl);
                 hl->check_op = NULL;
 
-                if (h->check_spin_again) {
+                if (thread_idx < 0 && h->check_spin_again) {
                     h->check_spin_again = 0;
                     S_SPIN_AGAIN();
                 }
@@ -2563,11 +2575,58 @@ static const struct script_op script_19[] = {
 };
 
 /* 20. Multiple threads accept stream with socket forcibly closed (error test) */
+static int script_20_trigger(struct helper *h, volatile uint64_t *counter)
+{
+    ossl_crypto_mutex_lock(h->misc_m);
+    ++*counter;
+    ossl_crypto_mutex_unlock(h->misc_m);
+    ossl_crypto_condvar_broadcast(h->misc_cv);
+    return 1;
+}
+
+static int script_20_wait(struct helper *h, volatile uint64_t *counter, uint64_t threshold)
+{
+    int stop = 0;
+
+    ossl_crypto_mutex_lock(h->misc_m);
+    while (!stop) {
+        stop = (*counter >= threshold);
+        if (stop)
+            break;
+
+        ossl_crypto_condvar_wait(h->misc_cv, h->misc_m);
+    }
+
+    ossl_crypto_mutex_unlock(h->misc_m);
+    return 1;
+}
+
+static int script_20_trigger1(struct helper *h, struct helper_local *hl)
+{
+    return script_20_trigger(h, &h->scratch0);
+}
+
+static int script_20_wait1(struct helper *h, struct helper_local *hl)
+{
+    return script_20_wait(h, &h->scratch0, hl->check_op->arg2);
+}
+
+static int script_20_trigger2(struct helper *h, struct helper_local *hl)
+{
+    return script_20_trigger(h, &h->scratch1);
+}
+
+static int script_20_wait2(struct helper *h, struct helper_local *hl)
+{
+    return script_20_wait(h, &h->scratch1, hl->check_op->arg2);
+}
+
 static const struct script_op script_20_child[] = {
     OP_C_ACCEPT_STREAM_WAIT (a)
     OP_C_READ_EXPECT        (a, "foo", 3)
 
-    OP_SLEEP                (500)
+    OP_CHECK                (script_20_trigger1, 0)
+    OP_CHECK                (script_20_wait2, 1)
 
     OP_C_READ_FAIL_WAIT     (a)
     OP_C_EXPECT_SSL_ERR     (a, SSL_ERROR_SYSCALL)
@@ -2593,9 +2652,10 @@ static const struct script_op script_20[] = {
 
     OP_END_REPEAT           ()
 
-    OP_SLEEP                (100)
+    OP_CHECK                (script_20_wait1, 5)
 
     OP_C_CLOSE_SOCKET       ()
+    OP_CHECK                (script_20_trigger2, 0)
 
     OP_END
 };

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -32,6 +32,7 @@ struct child_thread_args {
     CRYPTO_MUTEX *m;
     int testresult;
     int done;
+    int s_checked_out;
 };
 #endif
 
@@ -47,7 +48,11 @@ struct helper {
     int                     s_fd;
     BIO                     *s_net_bio, *s_net_bio_own, *s_qtf_wbio, *s_qtf_wbio_own;
     BIO_ADDR                *s_net_bio_addr;
-    QUIC_TSERVER            *s;
+    /*
+     * When doing a blocking mode test run, s_priv always points to the TSERVER
+     * and s is NULL when the main thread should not be touching s_priv.
+     */
+    QUIC_TSERVER            *s, *s_priv;
     LHASH_OF(STREAM_INFO)   *s_streams;
 
     int                     c_fd;
@@ -84,19 +89,29 @@ struct helper {
                            BIO_MSG *m, size_t stride);
     uint64_t inject_word0, inject_word1;
     uint64_t scratch0, scratch1, fail_count;
+#if defined(OPENSSL_THREADS)
+    struct {
+        CRYPTO_THREAD   *t;
+        CRYPTO_MUTEX    *m;
+        CRYPTO_CONDVAR  *c;
+        int             ready, stop;
+    } server_thread;
+    int s_checked_out;
+#endif
 };
 
 struct helper_local {
     struct helper           *h;
     LHASH_OF(STREAM_INFO)   *c_streams;
     int                     thread_idx;
+    const struct script_op  *check_op;
 };
 
 struct script_op {
     uint32_t        op;
     const void      *arg0;
     size_t          arg1;
-    int             (*check_func)(struct helper *h, const struct script_op *op);
+    int             (*check_func)(struct helper *h, struct helper_local *hl);
     const char      *stream_name;
     uint64_t        arg2;
     int             (*qtf_packet_plain_cb)(struct helper *h, QUIC_PKT_HDR *hdr,
@@ -311,23 +326,28 @@ static OSSL_TIME get_time(void *arg)
     return t;
 }
 
-static int skip_time_ms(struct helper *h, const struct script_op *op)
+static int skip_time_ms(struct helper *h, struct helper_local *hl)
 {
     if (!TEST_true(CRYPTO_THREAD_write_lock(h->time_lock)))
         return 0;
 
-    h->time_slip = ossl_time_add(h->time_slip, ossl_ms2time(op->arg2));
+    h->time_slip = ossl_time_add(h->time_slip, ossl_ms2time(hl->check_op->arg2));
 
     CRYPTO_THREAD_unlock(h->time_lock);
     return 1;
 }
 
-static int check_rejected(struct helper *h, const struct script_op *op)
-{
-    uint64_t stream_id = op->arg2;
+static QUIC_TSERVER *s_lock(struct helper *h, struct helper_local *hl);
+static void s_unlock(struct helper *h, struct helper_local *hl);
 
-    if (!ossl_quic_tserver_stream_has_peer_stop_sending(h->s, stream_id, NULL)
-        || !ossl_quic_tserver_stream_has_peer_reset_stream(h->s, stream_id, NULL)) {
+#define ACQUIRE_S() s_lock(h, hl)
+
+static int check_rejected(struct helper *h, struct helper_local *hl)
+{
+    uint64_t stream_id = hl->check_op->arg2;
+
+    if (!ossl_quic_tserver_stream_has_peer_stop_sending(ACQUIRE_S(), stream_id, NULL)
+        || !ossl_quic_tserver_stream_has_peer_reset_stream(ACQUIRE_S(), stream_id, NULL)) {
         h->check_spin_again = 1;
         return 0;
     }
@@ -335,11 +355,11 @@ static int check_rejected(struct helper *h, const struct script_op *op)
     return 1;
 }
 
-static int check_stream_reset(struct helper *h, const struct script_op *op)
+static int check_stream_reset(struct helper *h, struct helper_local *hl)
 {
-    uint64_t stream_id = op->arg2, aec = 0;
+    uint64_t stream_id = hl->check_op->arg2, aec = 0;
 
-    if (!ossl_quic_tserver_stream_has_peer_reset_stream(h->s, stream_id, &aec)) {
+    if (!ossl_quic_tserver_stream_has_peer_reset_stream(ACQUIRE_S(), stream_id, &aec)) {
         h->check_spin_again = 1;
         return 0;
     }
@@ -347,11 +367,11 @@ static int check_stream_reset(struct helper *h, const struct script_op *op)
     return TEST_uint64_t_eq(aec, 42);
 }
 
-static int check_stream_stopped(struct helper *h, const struct script_op *op)
+static int check_stream_stopped(struct helper *h, struct helper_local *hl)
 {
-    uint64_t stream_id = op->arg2;
+    uint64_t stream_id = hl->check_op->arg2;
 
-    if (!ossl_quic_tserver_stream_has_peer_stop_sending(h->s, stream_id, NULL)) {
+    if (!ossl_quic_tserver_stream_has_peer_stop_sending(ACQUIRE_S(), stream_id, NULL)) {
         h->check_spin_again = 1;
         return 0;
     }
@@ -359,15 +379,15 @@ static int check_stream_stopped(struct helper *h, const struct script_op *op)
     return 1;
 }
 
-static int override_key_update(struct helper *h, const struct script_op *op)
+static int override_key_update(struct helper *h, struct helper_local *hl)
 {
     QUIC_CHANNEL *ch = ossl_quic_conn_get_channel(h->c_conn);
 
-    ossl_quic_channel_set_txku_threshold_override(ch, op->arg2);
+    ossl_quic_channel_set_txku_threshold_override(ch, hl->check_op->arg2);
     return 1;
 }
 
-static int trigger_key_update(struct helper *h, const struct script_op *op)
+static int trigger_key_update(struct helper *h, struct helper_local *hl)
 {
     if (!TEST_true(SSL_key_update(h->c_conn, SSL_KEY_UPDATE_REQUESTED)))
         return 0;
@@ -375,7 +395,7 @@ static int trigger_key_update(struct helper *h, const struct script_op *op)
     return 1;
 }
 
-static int check_key_update_ge(struct helper *h, const struct script_op *op)
+static int check_key_update_ge(struct helper *h, struct helper_local *hl)
 {
     QUIC_CHANNEL *ch = ossl_quic_conn_get_channel(h->c_conn);
     int64_t txke = (int64_t)ossl_quic_channel_get_tx_key_epoch(ch);
@@ -390,19 +410,19 @@ static int check_key_update_ge(struct helper *h, const struct script_op *op)
         return 0;
 
     /* Caller specifies a minimum number of RXKEs which must have happened. */
-    if (!TEST_uint64_t_ge((uint64_t)rxke, op->arg2))
+    if (!TEST_uint64_t_ge((uint64_t)rxke, hl->check_op->arg2))
         return 0;
 
     return 1;
 }
 
-static int check_key_update_lt(struct helper *h, const struct script_op *op)
+static int check_key_update_lt(struct helper *h, struct helper_local *hl)
 {
     QUIC_CHANNEL *ch = ossl_quic_conn_get_channel(h->c_conn);
     uint64_t txke = ossl_quic_channel_get_tx_key_epoch(ch);
 
     /* Caller specifies a maximum number of TXKEs which must have happened. */
-    if (!TEST_uint64_t_lt(txke, op->arg2))
+    if (!TEST_uint64_t_lt(txke, hl->check_op->arg2))
         return 0;
 
     return 1;
@@ -460,12 +480,105 @@ static int join_threads(struct child_thread_args *threads, size_t num_threads)
 
     return ok;
 }
+
+static int join_server_thread(struct helper *h)
+{
+    CRYPTO_THREAD_RETVAL rv;
+
+    if (h->server_thread.t == NULL)
+        return 1;
+
+    ossl_crypto_mutex_lock(h->server_thread.m);
+    h->server_thread.stop = 1;
+    ossl_crypto_mutex_unlock(h->server_thread.m);
+    ossl_crypto_condvar_signal(h->server_thread.c);
+
+    ossl_crypto_thread_native_join(h->server_thread.t, &rv);
+    ossl_crypto_thread_native_clean(h->server_thread.t);
+    h->server_thread.t = NULL;
+    return 1;
+}
+
+/* Ensure the server-state lock is currently held. Idempotent. */
+static int *s_checked_out_p(struct helper *h, int thread_idx)
+{
+    return (thread_idx < 0) ? &h->s_checked_out
+        : &h->threads[thread_idx].s_checked_out;
+}
+
+static QUIC_TSERVER *s_lock(struct helper *h, struct helper_local *hl)
+{
+    int *p_checked_out = s_checked_out_p(h, hl->thread_idx);
+
+    if (h->server_thread.m == NULL || *p_checked_out)
+        return h->s;
+
+    ossl_crypto_mutex_lock(h->server_thread.m);
+    h->s = h->s_priv;
+    *p_checked_out = 1;
+    return h->s;
+}
+
+/* Ensure the server-state lock is currently not held. Idempotent. */
+static void s_unlock(struct helper *h, struct helper_local *hl)
+{
+    int *p_checked_out = s_checked_out_p(h, hl->thread_idx);
+
+    if (h->server_thread.m == NULL || !*p_checked_out)
+        return;
+
+    *p_checked_out = 0;
+    h->s = NULL;
+    ossl_crypto_mutex_unlock(h->server_thread.m);
+}
+
+static unsigned int server_helper_thread(void *arg)
+{
+    struct helper *h = arg;
+
+    ossl_crypto_mutex_lock(h->server_thread.m);
+
+    for (;;) {
+        int ready, stop;
+
+        ready   = h->server_thread.ready;
+        stop    = h->server_thread.stop;
+
+        if (stop)
+            break;
+
+        if (!ready) {
+            ossl_crypto_condvar_wait(h->server_thread.c, h->server_thread.m);
+            continue;
+        }
+
+        ossl_quic_tserver_tick(h->s_priv);
+        ossl_crypto_mutex_unlock(h->server_thread.m);
+        OSSL_sleep(1);
+        ossl_crypto_mutex_lock(h->server_thread.m);
+    }
+
+    ossl_crypto_mutex_unlock(h->server_thread.m);
+    return 1;
+}
+
+#else
+
+static QUIC_TSERVER *s_lock(struct helper *h)
+{
+    return h->s;
+}
+
+static void s_unlock(struct helper *h)
+{}
+
 #endif
 
 static void helper_cleanup(struct helper *h)
 {
 #if defined(OPENSSL_THREADS)
     join_threads(h->threads, h->num_threads);
+    join_server_thread(h);
     OPENSSL_free(h->threads);
     h->threads = NULL;
     h->num_threads = 0;
@@ -486,8 +599,8 @@ static void helper_cleanup(struct helper *h)
     }
 
     helper_cleanup_streams(&h->s_streams);
-    ossl_quic_tserver_free(h->s);
-    h->s = NULL;
+    ossl_quic_tserver_free(h->s_priv);
+    h->s_priv = h->s = NULL;
 
     BIO_free(h->s_net_bio_own);
     h->s_net_bio_own = NULL;
@@ -519,9 +632,15 @@ static void helper_cleanup(struct helper *h)
 
     CRYPTO_THREAD_lock_free(h->time_lock);
     h->time_lock = NULL;
+
+#if defined(OPENSSL_THREADS)
+    ossl_crypto_mutex_free(&h->server_thread.m);
+    ossl_crypto_condvar_free(&h->server_thread.c);
+#endif
 }
 
-static int helper_init(struct helper *h, int free_order, int need_injector)
+static int helper_init(struct helper *h, int free_order, int blocking,
+                       int need_injector)
 {
     short port = 8186;
     struct in_addr ina = {0};
@@ -531,6 +650,7 @@ static int helper_init(struct helper *h, int free_order, int need_injector)
     h->c_fd = -1;
     h->s_fd = -1;
     h->free_order = free_order;
+    h->blocking = blocking;
     h->need_injector = need_injector;
     h->time_slip = ossl_time_zero();
 
@@ -592,11 +712,14 @@ static int helper_init(struct helper *h, int free_order, int need_injector)
     s_args.now_cb_arg   = h;
     s_args.ctx          = NULL;
 
-    if (!TEST_ptr(h->s = ossl_quic_tserver_new(&s_args, certfile, keyfile)))
+    if (!TEST_ptr(h->s_priv = ossl_quic_tserver_new(&s_args, certfile, keyfile)))
         goto err;
 
+    if (!blocking)
+        h->s = h->s_priv;
+
     if (need_injector) {
-        h->qtf = qtest_create_injector(h->s);
+        h->qtf = qtest_create_injector(h->s_priv);
         if (!TEST_ptr(h->qtf))
             goto err;
 
@@ -640,8 +763,26 @@ static int helper_init(struct helper *h, int free_order, int need_injector)
 
     SSL_set0_wbio(h->c_conn, h->c_net_bio);
 
-    if (!TEST_true(SSL_set_blocking_mode(h->c_conn, 0)))
+    if (!TEST_true(SSL_set_blocking_mode(h->c_conn, h->blocking)))
         goto err;
+
+    if (h->blocking) {
+#if defined(OPENSSL_THREADS)
+        if (!TEST_ptr(h->server_thread.m = ossl_crypto_mutex_new()))
+            goto err;
+
+        if (!TEST_ptr(h->server_thread.c = ossl_crypto_condvar_new()))
+            goto err;
+
+        h->server_thread.t
+            = ossl_crypto_thread_native_start(server_helper_thread, h, 1);
+        if (!TEST_ptr(h->server_thread.t))
+            goto err;
+#else
+        TEST_error("cannot support blocking mode without threads");
+        goto err;
+#endif
+    }
 
     h->start_time   = ossl_time_now();
     h->init         = 1;
@@ -843,20 +984,30 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
     int end_wait_warning = 0;
 #endif
     OSSL_TIME op_start_time = ossl_time_zero(), op_deadline = ossl_time_zero();
-    struct helper_local hl;
+    struct helper_local hl_, *hl = &hl_;
 #define REPEAT_SLOTS 8
     size_t repeat_stack_idx[REPEAT_SLOTS], repeat_stack_done[REPEAT_SLOTS];
     size_t repeat_stack_limit[REPEAT_SLOTS];
     size_t repeat_stack_len = 0;
 
-    if (!TEST_true(helper_local_init(&hl, h, thread_idx)))
+    if (!TEST_true(helper_local_init(hl, h, thread_idx)))
         goto out;
 
-#define SPIN_AGAIN() { OSSL_sleep(1); no_advance = 1; continue; }
+#define S_SPIN_AGAIN() { OSSL_sleep(1); no_advance = 1; continue; }
+#define C_SPIN_AGAIN()                                  \
+    {                                                   \
+        if (h->blocking) {                              \
+            TEST_error("spin again in blocking mode");  \
+            goto out;                                   \
+        }                                               \
+        S_SPIN_AGAIN();                                 \
+    }
 
     for (;;) {
         SSL *c_tgt              = h->c_conn;
         uint64_t s_stream_id    = UINT64_MAX;
+
+        s_unlock(h, hl);
 
         if (no_advance) {
             no_advance = 0;
@@ -878,15 +1029,25 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
         op = &script[op_idx];
 
         if (op->stream_name != NULL) {
-            c_tgt = helper_local_get_c_stream(&hl, op->stream_name);
+            c_tgt = helper_local_get_c_stream(hl, op->stream_name);
             if (thread_idx < 0)
                 s_stream_id = helper_get_s_stream(h, op->stream_name);
             else
                 s_stream_id = UINT64_MAX;
         }
 
-        if (thread_idx < 0)
-            ossl_quic_tserver_tick(h->s);
+        if (thread_idx < 0) {
+            if (!h->blocking) {
+                ossl_quic_tserver_tick(h->s);
+            } else if (h->blocking && !h->server_thread.ready) {
+                ossl_crypto_mutex_lock(h->server_thread.m);
+                h->server_thread.ready = 1;
+                ossl_crypto_mutex_unlock(h->server_thread.m);
+                ossl_crypto_condvar_signal(h->server_thread.c);
+            }
+            if (h->blocking)
+                assert(h->s == NULL);
+        }
 
         if (thread_idx >= 0 || connect_started)
             SSL_handle_events(h->c_conn);
@@ -942,7 +1103,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                             end_wait_warning = 1;
                         }
 
-                        SPIN_AGAIN();
+                        S_SPIN_AGAIN();
                     }
                 }
             }
@@ -989,10 +1150,12 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
 
         case OPK_CHECK:
             {
-                int ok = op->check_func(h, op);
+                hl->check_op = op;
+                int ok = op->check_func(h, hl);
+                hl->check_op = NULL;
                 if (h->check_spin_again) {
                     h->check_spin_again = 0;
-                    SPIN_AGAIN();
+                    S_SPIN_AGAIN();
                 }
 
                 if (!TEST_true(ok))
@@ -1033,7 +1196,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                     goto out;
                 if (ret != 1) {
                     if (!h->blocking && is_want(h->c_conn, ret))
-                        SPIN_AGAIN();
+                        C_SPIN_AGAIN();
 
                     if (op->arg1 == 0 && !TEST_int_eq(ret, 1))
                         goto out;
@@ -1064,7 +1227,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                 if (!TEST_uint64_t_ne(s_stream_id, UINT64_MAX))
                     goto out;
 
-                if (!TEST_true(ossl_quic_tserver_write(h->s, s_stream_id,
+                if (!TEST_true(ossl_quic_tserver_write(ACQUIRE_S(), s_stream_id,
                                                        op->arg0, op->arg1,
                                                        &bytes_written))
                     || !TEST_size_t_eq(bytes_written, op->arg1))
@@ -1084,7 +1247,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                 if (!TEST_uint64_t_ne(s_stream_id, UINT64_MAX))
                     goto out;
 
-                ossl_quic_tserver_conclude(h->s, s_stream_id);
+                ossl_quic_tserver_conclude(ACQUIRE_S(), s_stream_id);
             }
             break;
 
@@ -1098,7 +1261,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
 
                 if (!SSL_peek_ex(c_tgt, buf, sizeof(buf), &bytes_read)
                     || bytes_read == 0)
-                    SPIN_AGAIN();
+                    C_SPIN_AGAIN();
             }
             break;
 
@@ -1117,11 +1280,11 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                     goto out;
 
                 if (!r)
-                    SPIN_AGAIN();
+                    C_SPIN_AGAIN();
 
                 if (bytes_read + offset != op->arg1) {
                     offset += bytes_read;
-                    SPIN_AGAIN();
+                    C_SPIN_AGAIN();
                 }
 
                 if (op->arg1 > 0
@@ -1144,7 +1307,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                     && !TEST_ptr(tmp_buf = OPENSSL_malloc(op->arg1)))
                     goto out;
 
-                if (!TEST_true(ossl_quic_tserver_read(h->s, s_stream_id,
+                if (!TEST_true(ossl_quic_tserver_read(ACQUIRE_S(), s_stream_id,
                                                       tmp_buf + offset,
                                                       op->arg1 - offset,
                                                       &bytes_read)))
@@ -1152,7 +1315,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
 
                 if (bytes_read + offset != op->arg1) {
                     offset += bytes_read;
-                    SPIN_AGAIN();
+                    S_SPIN_AGAIN();
                 }
 
                 if (op->arg1 > 0
@@ -1177,7 +1340,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                     goto out;
 
                 if (is_want(c_tgt, 0))
-                    SPIN_AGAIN();
+                    C_SPIN_AGAIN();
 
                 if (!TEST_int_eq(SSL_get_error(c_tgt, 0),
                                  SSL_ERROR_ZERO_RETURN))
@@ -1193,8 +1356,8 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                 if (!TEST_uint64_t_ne(s_stream_id, UINT64_MAX))
                     goto out;
 
-                if (!ossl_quic_tserver_has_read_ended(h->s, s_stream_id))
-                    SPIN_AGAIN();
+                if (!ossl_quic_tserver_has_read_ended(ACQUIRE_S(), s_stream_id))
+                    S_SPIN_AGAIN();
             }
             break;
 
@@ -1211,7 +1374,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                 if (!TEST_ptr(c_stream = ossl_quic_detach_stream(h->c_conn)))
                     goto out;
 
-                if (!TEST_true(helper_local_set_c_stream(&hl, op->stream_name, c_stream)))
+                if (!TEST_true(helper_local_set_c_stream(hl, op->stream_name, c_stream)))
                     goto out;
             }
             break;
@@ -1227,7 +1390,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                 if (!TEST_true(ossl_quic_attach_stream(h->c_conn, c_tgt)))
                     goto out;
 
-                if (!TEST_true(helper_local_set_c_stream(&hl, op->stream_name, NULL)))
+                if (!TEST_true(helper_local_set_c_stream(hl, op->stream_name, NULL)))
                     goto out;
             }
             break;
@@ -1264,7 +1427,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                                          op->arg2))
                     goto out;
 
-                if (!TEST_true(helper_local_set_c_stream(&hl, op->stream_name, c_stream)))
+                if (!TEST_true(helper_local_set_c_stream(hl, op->stream_name, c_stream)))
                     goto out;
             }
             break;
@@ -1279,7 +1442,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                 if (!TEST_ptr(op->stream_name))
                     goto out;
 
-                if (!TEST_true(ossl_quic_tserver_stream_new(h->s,
+                if (!TEST_true(ossl_quic_tserver_stream_new(ACQUIRE_S(),
                                                             op->arg1 > 0,
                                                             &stream_id)))
                     goto out;
@@ -1305,9 +1468,9 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                     goto out;
 
                 if ((c_stream = SSL_accept_stream(h->c_conn, 0)) == NULL)
-                    SPIN_AGAIN();
+                    C_SPIN_AGAIN();
 
-                if (!TEST_true(helper_local_set_c_stream(&hl, op->stream_name,
+                if (!TEST_true(helper_local_set_c_stream(hl, op->stream_name,
                                                           c_stream)))
                     goto out;
             }
@@ -1323,9 +1486,9 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                 if (!TEST_ptr(op->stream_name))
                     goto out;
 
-                new_stream_id = ossl_quic_tserver_pop_incoming_stream(h->s);
+                new_stream_id = ossl_quic_tserver_pop_incoming_stream(ACQUIRE_S());
                 if (new_stream_id == UINT64_MAX)
-                    SPIN_AGAIN();
+                    S_SPIN_AGAIN();
 
                 if (!TEST_true(helper_set_s_stream(h, op->stream_name, new_stream_id)))
                     goto out;
@@ -1336,7 +1499,8 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
             {
                 SSL *c_stream;
 
-                if (!TEST_ptr_null(c_stream = SSL_accept_stream(h->c_conn, 0))) {
+                if (!TEST_ptr_null(c_stream = SSL_accept_stream(h->c_conn,
+                                                                SSL_ACCEPT_STREAM_NO_BLOCK))) {
                     SSL_free(c_stream);
                     goto out;
                 }
@@ -1352,7 +1516,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                 if (!TEST_ptr(op->stream_name))
                     goto out;
 
-                if (!TEST_true(helper_local_set_c_stream(&hl, op->stream_name, NULL)))
+                if (!TEST_true(helper_local_set_c_stream(hl, op->stream_name, NULL)))
                     goto out;
 
                 SSL_free(c_tgt);
@@ -1399,13 +1563,13 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                     goto out;
 
                 if (ret == 0)
-                    SPIN_AGAIN();
+                    C_SPIN_AGAIN();
             }
             break;
 
         case OPK_S_SHUTDOWN:
             {
-                ossl_quic_tserver_shutdown(h->s, op->arg1);
+                ossl_quic_tserver_shutdown(ACQUIRE_S(), op->arg1);
             }
             break;
 
@@ -1420,7 +1584,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                     goto out;
 
                 if (!SSL_get_conn_close_info(c_tgt, &cc_info, sizeof(cc_info)))
-                    SPIN_AGAIN();
+                    C_SPIN_AGAIN();
 
                 if (!TEST_int_eq(expect_app,
                                  (cc_info.flags
@@ -1440,12 +1604,12 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                 int expect_remote = (op->arg1 & EXPECT_CONN_CLOSE_REMOTE) != 0;
                 uint64_t error_code = op->arg2;
 
-                if (!ossl_quic_tserver_is_term_any(h->s)) {
-                    ossl_quic_tserver_ping(h->s);
-                    SPIN_AGAIN();
+                if (!ossl_quic_tserver_is_term_any(ACQUIRE_S())) {
+                    ossl_quic_tserver_ping(ACQUIRE_S());
+                    S_SPIN_AGAIN();
                 }
 
-                if (!TEST_ptr(tc = ossl_quic_tserver_get_terminate_cause(h->s)))
+                if (!TEST_ptr(tc = ossl_quic_tserver_get_terminate_cause(ACQUIRE_S())))
                     goto out;
 
                 if (!TEST_uint64_t_eq(error_code, tc->error_code)
@@ -1503,7 +1667,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                 if (!TEST_uint64_t_ne(s_stream_id, UINT64_MAX))
                     goto out;
 
-                if (!TEST_false(ossl_quic_tserver_write(h->s, s_stream_id,
+                if (!TEST_false(ossl_quic_tserver_write(ACQUIRE_S(), s_stream_id,
                                                        (const unsigned char *)"apple", 5,
                                                        &bytes_written)))
                     goto out;
@@ -1543,7 +1707,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                     goto out;
 
                 if (is_want(c_tgt, 0))
-                    SPIN_AGAIN();
+                    C_SPIN_AGAIN();
             }
             break;
 
@@ -1555,7 +1719,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                 if (!TEST_uint64_t_ne(s_stream_id, UINT64_MAX))
                     goto out;
 
-                if (!TEST_false(ossl_quic_tserver_read(h->s, s_stream_id,
+                if (!TEST_false(ossl_quic_tserver_read(ACQUIRE_S(), s_stream_id,
                                                       buf, sizeof(buf),
                                                       &bytes_read)))
                     goto out;
@@ -1690,6 +1854,11 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
             break;
 
         case OPK_SET_INJECT_WORD:
+            /*
+             * Must hold server tick lock - callbacks can be called from other
+             * thread when running test in blocking mode (tsan).
+             */
+            ACQUIRE_S();
             h->inject_word0 = op->arg1;
             h->inject_word1 = op->arg2;
             break;
@@ -1712,7 +1881,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
             break;
 
         case OPK_S_NEW_TICKET:
-            if (!TEST_true(ossl_quic_tserver_new_ticket(h->s)))
+            if (!TEST_true(ossl_quic_tserver_new_ticket(ACQUIRE_S())))
                 goto out;
             break;
 
@@ -1723,6 +1892,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
     }
 
 out:
+    s_unlock(h, hl); /* idempotent */
     if (!testresult) {
         size_t i;
 
@@ -1737,18 +1907,19 @@ out:
     }
 
     OPENSSL_free(tmp_buf);
-    helper_local_cleanup(&hl);
+    helper_local_cleanup(hl);
     return testresult;
 }
 
 static int run_script(const struct script_op *script,
                       const char *script_name,
-                      int free_order)
+                      int free_order,
+                      int blocking)
 {
     int testresult = 0;
     struct helper h;
 
-    if (!TEST_true(helper_init(&h, free_order, 1)))
+    if (!TEST_true(helper_init(&h, free_order, blocking, 1)))
         goto out;
 
     if (!TEST_true(run_script_worker(&h, script, script_name, -1)))
@@ -3010,7 +3181,7 @@ static int script_39_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
     size_t i, written;
     uint64_t seq_no = 0, retire_prior_to = 0;
     QUIC_CONN_ID new_cid = {0};
-    QUIC_CHANNEL *ch = ossl_quic_tserver_get_channel(h->s);
+    QUIC_CHANNEL *ch = ossl_quic_tserver_get_channel(h->s_priv);
 
     switch (h->inject_word1) {
     case 0:
@@ -3219,13 +3390,13 @@ static void script_41_trace(int write_p, int version, int content_type,
    ++h->scratch0;
 }
 
-static int script_41_setup(struct helper *h, const struct script_op *op)
+static int script_41_setup(struct helper *h, struct helper_local *hl)
 {
-    ossl_quic_tserver_set_msg_callback(h->s, script_41_trace, h);
+    ossl_quic_tserver_set_msg_callback(ACQUIRE_S(), script_41_trace, h);
     return 1;
 }
 
-static int script_41_check(struct helper *h, const struct script_op *op)
+static int script_41_check(struct helper *h, struct helper_local *hl)
 {
     /* At least one valid challenge/response echo? */
     if (!TEST_uint64_t_gt(h->scratch0, 0))
@@ -3392,21 +3563,21 @@ static const struct script_op script_44[] = {
 };
 
 /* 45. PING must generate ACK */
-static int force_ping(struct helper *h, const struct script_op *op)
+static int force_ping(struct helper *h, struct helper_local *hl)
 {
-    QUIC_CHANNEL *ch = ossl_quic_tserver_get_channel(h->s);
+    QUIC_CHANNEL *ch = ossl_quic_tserver_get_channel(ACQUIRE_S());
 
     h->scratch0 = ossl_quic_channel_get_diag_num_rx_ack(ch);
 
-    if (!TEST_true(ossl_quic_tserver_ping(h->s)))
+    if (!TEST_true(ossl_quic_tserver_ping(ACQUIRE_S())))
         return 0;
 
     return 1;
 }
 
-static int wait_incoming_acks_increased(struct helper *h, const struct script_op *op)
+static int wait_incoming_acks_increased(struct helper *h, struct helper_local *hl)
 {
-    QUIC_CHANNEL *ch = ossl_quic_tserver_get_channel(h->s);
+    QUIC_CHANNEL *ch = ossl_quic_tserver_get_channel(ACQUIRE_S());
     uint16_t count;
 
     count = ossl_quic_channel_get_diag_num_rx_ack(ch);
@@ -3996,7 +4167,7 @@ static const struct script_op script_59[] = {
 /* 60. Connection close reason truncation */
 static char long_reason[2048];
 
-static int init_reason(struct helper *h, const struct script_op *op)
+static int init_reason(struct helper *h, struct helper_local *hl)
 {
     memset(long_reason, '~', sizeof(long_reason));
     memcpy(long_reason, "This is a long reason string.", 29);
@@ -4004,9 +4175,9 @@ static int init_reason(struct helper *h, const struct script_op *op)
     return 1;
 }
 
-static int check_shutdown_reason(struct helper *h, const struct script_op *op)
+static int check_shutdown_reason(struct helper *h, struct helper_local *hl)
 {
-    const QUIC_TERMINATE_CAUSE *tc = ossl_quic_tserver_get_terminate_cause(h->s);
+    const QUIC_TERMINATE_CAUSE *tc = ossl_quic_tserver_get_terminate_cause(ACQUIRE_S());
 
     if (tc == NULL) {
         h->check_spin_again = 1;
@@ -4396,11 +4567,11 @@ static const struct script_op script_69[] = {
     OP_END
 };
 
-static int set_max_early_data(struct helper *h, const struct script_op *op)
+static int set_max_early_data(struct helper *h, struct helper_local *hl)
 {
 
-    if (!TEST_true(ossl_quic_tserver_set_max_early_data(h->s,
-                                                        (uint32_t)op->arg2)))
+    if (!TEST_true(ossl_quic_tserver_set_max_early_data(ACQUIRE_S(),
+                                                        (uint32_t)hl->check_op->arg2)))
         return 0;
 
     return 1;
@@ -4446,7 +4617,7 @@ static const struct script_op script_71[] = {
 };
 
 /* 72. Test that APL stops handing out streams after limit reached (bidi) */
-static int script_72_check(struct helper *h, const struct script_op *op)
+static int script_72_check(struct helper *h, struct helper_local *hl)
 {
     if (!TEST_uint64_t_ge(h->fail_count, 50))
         return 0;
@@ -4465,7 +4636,7 @@ static const struct script_op script_72[] = {
      */
     OP_BEGIN_REPEAT         (200)
 
-    OP_C_NEW_STREAM_BIDI_EX (a, ANY_ID, ALLOW_FAIL)
+    OP_C_NEW_STREAM_BIDI_EX (a, ANY_ID, ALLOW_FAIL | SSL_STREAM_FLAG_NO_BLOCK)
     OP_C_SKIP_IF_UNBOUND    (a, 2)
     OP_C_WRITE              (a, "apple", 5)
     OP_C_FREE_STREAM        (a)
@@ -4489,7 +4660,7 @@ static const struct script_op script_73[] = {
      */
     OP_BEGIN_REPEAT         (200)
 
-    OP_C_NEW_STREAM_UNI_EX  (a, ANY_ID, ALLOW_FAIL)
+    OP_C_NEW_STREAM_UNI_EX  (a, ANY_ID, ALLOW_FAIL | SSL_STREAM_FLAG_NO_BLOCK)
     OP_C_SKIP_IF_UNBOUND    (a, 2)
     OP_C_WRITE              (a, "apple", 5)
     OP_C_FREE_STREAM        (a)
@@ -4598,10 +4769,12 @@ static const struct script_op script_75[] = {
     OP_END
 };
 
-/* 74. Test peer-initiated shutdown wait */
-static int script_76_check(struct helper *h, const struct script_op *op)
+/* 76. Test peer-initiated shutdown wait */
+static int script_76_check(struct helper *h, struct helper_local *hl)
 {
-    if (!TEST_false(SSL_shutdown_ex(h->c_conn, SSL_SHUTDOWN_FLAG_WAIT_PEER,
+    if (!TEST_false(SSL_shutdown_ex(h->c_conn,
+                                    SSL_SHUTDOWN_FLAG_WAIT_PEER
+                                    | SSL_SHUTDOWN_FLAG_NO_BLOCK,
                                     NULL, 0)))
         return 0;
 
@@ -4710,14 +4883,32 @@ static const struct script_op *const scripts[] = {
 
 static int test_script(int idx)
 {
-    int script_idx = idx >> 1;
-    int free_order = idx & 1;
+    int script_idx, free_order, blocking;
     char script_name[64];
+
+    free_order = idx % 2;
+    idx /= 2;
+
+    blocking = idx % 2;
+    idx /= 2;
+
+    script_idx = idx;
+
+    if (blocking && free_order)
+        return 1; /* don't need to test free_order twice */
+
+#if !defined(OPENSSL_THREADS)
+    if (blocking) {
+        TEST_skip("cannot test in blocking mode without threads");
+        return 1;
+    }
+#endif
 
     snprintf(script_name, sizeof(script_name), "script %d", script_idx + 1);
 
-    TEST_info("Running script %d (order=%d)", script_idx + 1, free_order);
-    return run_script(scripts[script_idx], script_name, free_order);
+    TEST_info("Running script %d (order=%d, blocking=%d)", script_idx + 1,
+              free_order, blocking);
+    return run_script(scripts[script_idx], script_name, free_order, blocking);
 }
 
 /* Dynamically generated tests. */
@@ -4801,7 +4992,7 @@ static ossl_unused int test_dyn_frame_types(int idx)
     snprintf(script_name, sizeof(script_name),
              "dyn script %d", idx);
 
-    return run_script(dyn_frame_types_script, script_name, 0);
+    return run_script(dyn_frame_types_script, script_name, 0, 0);
 }
 
 OPT_TEST_DECLARE_USAGE("certfile privkeyfile\n")
@@ -4818,6 +5009,6 @@ int setup_tests(void)
         return 0;
 
     ADD_ALL_TESTS(test_dyn_frame_types, OSSL_NELEM(forbidden_frame_types));
-    ADD_ALL_TESTS(test_script, OSSL_NELEM(scripts) * 2);
+    ADD_ALL_TESTS(test_script, OSSL_NELEM(scripts) * 2 * 2);
     return 1;
 }

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -556,6 +556,10 @@ static unsigned int server_helper_thread(void *arg)
 
         ossl_quic_tserver_tick(h->s_priv);
         ossl_crypto_mutex_unlock(h->server_thread.m);
+        /*
+         * Give the main thread an opportunity to get the mutex, which is
+         * sometimes necessary in some script operations.
+         */
         OSSL_sleep(1);
         ossl_crypto_mutex_lock(h->server_thread.m);
     }


### PR DESCRIPTION
This expands the multistream test to run everything in both blocking and non-blocking mode using the same set of scripts. This should dramatically increase our test coverage for our APIs in blocking mode.

Internally this works by spinning up an extra thread to tick the TSERVER so that we can enter a blocking call in the main thread.

Built on the WAIT_PEER PR.