### PR TITLE
Resolve assembler complains when including loongarch_arch.h

### DIFF
--- a/crypto/loongarch_arch.h
+++ b/crypto/loongarch_arch.h
@@ -9,7 +9,10 @@
 #ifndef OSSL_CRYPTO_LOONGARCH_ARCH_H
 # define OSSL_CRYPTO_LOONGARCH_ARCH_H
 
+# ifndef __ASSEMBLER__
 extern unsigned int OPENSSL_loongarch_hwcap_P;
+# endif
+
 # define LOONGARCH_HWCAP_LSX  (1 << 4)
 # define LOONGARCH_HWCAP_LASX (1 << 5)
 


### PR DESCRIPTION
The assembler will complain when we include loongarch_arch.h in an assembly file as following:

crypto/loongarch_arch.h: Assembler messages:
crypto/loongarch_arch.h:12: Fatal error: no match insn: extern	unsigned int OPENSSL_loongarch_hwcap_P

So, the sentence of `extern unsigned int OPENSSL_loongarch_hwcap_P` should be guarded with "#ifndef __ASSEMBLER__".

Fixes #21838.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
