### PR TITLE
Fix a bad merge in quic-multi-stream.c demo

### DIFF
--- a/demos/guide/quic-multi-stream.c
+++ b/demos/guide/quic-multi-stream.c
@@ -215,7 +215,7 @@ int main(void)
     }
 
     /* Set the IP address of the remote peer */
-    if (!SSL_set_initial_peer_addr(ssl, peer_addr)) {
+    if (!SSL_set1_initial_peer_addr(ssl, peer_addr)) {
         printf("Failed to set the initial peer address\n");
         goto end;
     }


### PR DESCRIPTION
The function SSL_set_initial_peer_addr() got renamed to SSL_set1_initial_peer_addr(). The demo missed out on the rename when it got rebased on top of it.
