### PR TITLE
Change PBES2 PBKDF2 default salt length to 16 bytes.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,16 @@ OpenSSL 3.2
 
 ### Changes between 3.1 and 3.2 [xx XXX xxxx]
 
+ * Changed the default salt length used by PBES2 KDF's (PBKDF2 and scrypt)
+   from 8 bytes to 16 bytes.
+   The PKCS5 (RFC 8018) standard uses a 64 bit salt length for PBE, and
+   recommends a minimum of 64 bits for PBES2. For FIPS compliance PBKDF2
+   requires a salt length of 128 bits. This affects OpenSSL command line
+   applications such as "genrsa" and "pkcs8" and API's such as
+   PEM_write_bio_PrivateKey() that are reliant on the default value.
+
+   *Shane Lontis*
+
  * Changed the default value of the `ess_cert_id_alg` configuration
    option which is used to calculate the TSA's public key certificate
    identifier. The default algorithm is updated to be sha256 instead

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,9 @@ OpenSSL 3.2
    requires a salt length of 128 bits. This affects OpenSSL command line
    applications such as "genrsa" and "pkcs8" and API's such as
    PEM_write_bio_PrivateKey() that are reliant on the default value.
+   The additional commandline option 'saltlen' has been added to the
+   OpenSSL command line applications for "pkcs8" and "enc" to allow the
+   salt length to be set to a non default value.
 
    *Shane Lontis*
 

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -326,8 +326,8 @@ int enc_main(int argc, char **argv)
         goto opthelp;
     if (!app_RAND_load())
         goto end;
-    if (saltlen == 0)
-        saltlen = (pbkdf2 == 0 ? PKCS5_SALT_LEN : sizeof(salt));
+    if (saltlen == 0 || pbkdf2 == 0)
+        saltlen = PKCS5_SALT_LEN;
 
     /* Get the cipher name, either from progname (if set) or flag. */
     if (!opt_cipher(ciphername, &cipher))

--- a/crypto/asn1/p5_pbe.c
+++ b/crypto/asn1/p5_pbe.c
@@ -12,6 +12,7 @@
 #include <openssl/asn1t.h>
 #include <openssl/x509.h>
 #include <openssl/rand.h>
+#include "crypto/evp.h"
 
 /* PKCS#5 password based encryption structure */
 
@@ -45,7 +46,7 @@ int PKCS5_pbe_set0_algor_ex(X509_ALGOR *algor, int alg, int iter,
         goto err;
     }
     if (!saltlen)
-        saltlen = PKCS5_SALT_LEN;
+        saltlen = PKCS5_DEFAULT_PBE1_SALT_LEN;
     if (saltlen < 0)
         goto err;
 

--- a/crypto/asn1/p5_pbev2.c
+++ b/crypto/asn1/p5_pbev2.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #include "crypto/asn1.h"
+#include "crypto/evp.h"
 #include <openssl/asn1t.h>
 #include <openssl/core.h>
 #include <openssl/core_names.h>
@@ -196,7 +197,7 @@ X509_ALGOR *PKCS5_pbkdf2_set_ex(int iter, unsigned char *salt, int saltlen,
         goto err;
     }
     if (saltlen == 0)
-        saltlen = PKCS5_SALT_LEN;
+        saltlen = PKCS5_DEFAULT_PBE2_SALT_LEN;
     if ((osalt->data = OPENSSL_malloc(saltlen)) == NULL)
         goto err;
 

--- a/crypto/asn1/p5_scrypt.c
+++ b/crypto/asn1/p5_scrypt.c
@@ -166,7 +166,7 @@ static X509_ALGOR *pkcs5_scrypt_set(const unsigned char *salt, size_t saltlen,
     }
 
     if (!saltlen)
-        saltlen = PKCS5_SALT_LEN;
+        saltlen = PKCS5_DEFAULT_PBE2_SALT_LEN;
 
     /* This will either copy salt or grow the buffer */
     if (ASN1_STRING_set(sparam->salt, salt, saltlen) == 0) {

--- a/doc/man1/openssl-enc.pod.in
+++ b/doc/man1/openssl-enc.pod.in
@@ -31,6 +31,7 @@ B<openssl> B<enc>|I<cipher>
 [B<-md> I<digest>]
 [B<-iter> I<count>]
 [B<-pbkdf2>]
+[B<-saltlen> I<size>]
 [B<-p>]
 [B<-P>]
 [B<-bufsize> I<number>]
@@ -132,6 +133,14 @@ This option enables the use of PBKDF2 algorithm to derive the key.
 Use PBKDF2 algorithm with a default iteration count of 10000
 unless otherwise specified by the B<-iter> command line option.
 
+=item B<-saltlen>
+
+Set the salt length to use when using the B<-pbkdf2> option.
+The default is 16 bytes. The maximum value is currently 16 bytes.
+If the B<-pbkdf2> option is not used, then this option is ignored
+and a fixed salt length of 8 is used. The salt length used when
+encrypting must also be used when decrypting.
+
 =item B<-nosalt>
 
 Don't use a salt in the key derivation routines. This option B<SHOULD NOT> be
@@ -147,7 +156,8 @@ encrypting, this is the default.
 
 The actual salt to use: this must be represented as a string of hex digits.
 If this option is used while encrypting, the same exact value will be needed
-again during decryption.
+again during decryption. This salt may be truncated or zero padded to
+match the salt length (See B<-saltlen>).
 
 =item B<-K> I<key>
 
@@ -465,9 +475,13 @@ The B<-list> option was added in OpenSSL 1.1.1e.
 
 The B<-ciphers> and B<-engine> options were deprecated in OpenSSL 3.0.
 
+The B<-saltlen> option was added in OpenSSL 3.2. Note that the default
+KDF salt length used for PBES2 (PBKDF2 and scrypt) was also changed
+from 8 bytes to 16 bytes.
+
 =head1 COPYRIGHT
 
-Copyright 2000-2022 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2023 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man1/openssl-enc.pod.in
+++ b/doc/man1/openssl-enc.pod.in
@@ -136,7 +136,8 @@ unless otherwise specified by the B<-iter> command line option.
 =item B<-saltlen>
 
 Set the salt length to use when using the B<-pbkdf2> option.
-The default is 16 bytes. The maximum value is currently 16 bytes.
+For compatibility reasons, the default is 8 bytes.
+The maximum value is currently 16 bytes.
 If the B<-pbkdf2> option is not used, then this option is ignored
 and a fixed salt length of 8 is used. The salt length used when
 encrypting must also be used when decrypting.
@@ -475,9 +476,7 @@ The B<-list> option was added in OpenSSL 1.1.1e.
 
 The B<-ciphers> and B<-engine> options were deprecated in OpenSSL 3.0.
 
-The B<-saltlen> option was added in OpenSSL 3.2. Note that the default
-KDF salt length used for PBES2 (PBKDF2 and scrypt) was also changed
-from 8 bytes to 16 bytes.
+The B<-saltlen> option was added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/openssl-pkcs8.pod.in
+++ b/doc/man1/openssl-pkcs8.pod.in
@@ -27,6 +27,7 @@ B<openssl> B<pkcs8>
 [B<-scrypt_N> I<N>]
 [B<-scrypt_r> I<r>]
 [B<-scrypt_p> I<p>]
+[B<-saltlen> I<size>]
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
@@ -147,6 +148,12 @@ B<-scrypt_p> and B<-v2> options.
 =item B<-scrypt_N> I<N>, B<-scrypt_r> I<r>, B<-scrypt_p> I<p>
 
 Sets the scrypt I<N>, I<r> or I<p> parameters.
+
+=item B<-saltlen>
+
+Sets the length (in bytes) of the salt to use for the PBE algorithm.
+If this value is not specified, the default for PBES2 is 16 (128 bits)
+and 8 (64 bits) for PBES1.
 
 {- $OpenSSL::safe::opt_r_item -}
 

--- a/doc/man3/PKCS5_PBE_keyivgen.pod
+++ b/doc/man3/PKCS5_PBE_keyivgen.pod
@@ -127,6 +127,12 @@ associated parameters for the PBKDF2 algorithm.
 PKCS5_pbe_set0_algor() and PKCS5_pbe_set0_algor_ex() set the PBE algorithm OID and
 parameters into the supplied B<X509_ALGOR>.
 
+If I<salt> is NULL, then I<saltlen> specifies the size in bytes of the random salt to
+generate. If I<saltlen> is 0 then a default size is used.
+For PBE related functions such as PKCS5_pbe_set_ex() the default salt length is 8 bytes.
+For PBE2 related functions that use PBKDF2 such as PKCS5_pbkdf2_set(),
+PKCS5_pbe2_set_scrypt() and PKCS5_pbe2_set() the default salt length is 16 bytes.
+
 =head1 NOTES
 
 The *_keyivgen() functions are typically used in PKCS#12 to encrypt objects.
@@ -164,6 +170,10 @@ PKCS5_pbkdf2_set_ex() were added in OpenSSL 3.0.
 
 From OpenSSL 3.0 the PBKDF1 algorithm used in PKCS5_PBE_keyivgen() and
 PKCS5_PBE_keyivgen_ex() has been moved to the legacy provider as an EVP_KDF.
+
+In OpenSSL 3.2 the default salt length changed from 8 bytes to 16 bytes for PBE2
+related functions such as PKCS5_pbe2_set() if the I<saltlen> is 0.
+This is required for PBKDF2 FIPS compliance.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/PKCS5_PBE_keyivgen.pod
+++ b/doc/man3/PKCS5_PBE_keyivgen.pod
@@ -172,12 +172,12 @@ From OpenSSL 3.0 the PBKDF1 algorithm used in PKCS5_PBE_keyivgen() and
 PKCS5_PBE_keyivgen_ex() has been moved to the legacy provider as an EVP_KDF.
 
 In OpenSSL 3.2 the default salt length changed from 8 bytes to 16 bytes for PBE2
-related functions such as PKCS5_pbe2_set() if the I<saltlen> is 0.
+related functions such as PKCS5_pbe2_set().
 This is required for PBKDF2 FIPS compliance.
 
 =head1 COPYRIGHT
 
-Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2021-2023 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -17,6 +17,15 @@
 # include "crypto/ecx.h"
 
 /*
+ * Default PKCS5 PBE KDF salt lengths
+ * In RFC 8018, PBE1 uses 8 bytes (64 bits) for its salt length.
+ * It also specifies to use at least 8 bytes for PBES2.
+ * The NIST requirement for PBKDF2 is 128 bits so we use this as the
+ * default for PBE2 (scrypt and HKDF2)
+ */
+# define PKCS5_DEFAULT_PBE1_SALT_LEN     PKCS5_SALT_LEN
+# define PKCS5_DEFAULT_PBE2_SALT_LEN     16
+/*
  * Don't free up md_ctx->pctx in EVP_MD_CTX_reset, use the reserved flag
  * values in evp.h
  */

--- a/test/recipes/15-test_genrsa.t
+++ b/test/recipes/15-test_genrsa.t
@@ -25,7 +25,7 @@ my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
 plan tests =>
     ($no_fips ? 0 : 5)          # Extra FIPS related tests
-    + 15;
+    + 16;
 
 # We want to know that an absurdly small number of bits isn't support
 is(run(app([ 'openssl', 'genpkey', '-out', 'genrsatest.pem',
@@ -106,6 +106,13 @@ ok(run(app([ 'openssl', 'rsa', '-check', '-in', 'genrsatest.pem', '-noout' ])),
 ok(run(app([ 'openssl', 'rsa', '-in', 'genrsatest.pem', '-out', 'genrsatest-enc.pem',
    '-aes256', '-passout', 'pass:x' ])),
    "rsa encrypt");
+# Check the default salt length for PBKDF2 is 16 bytes
+# We expect the output to be of the form "0:d=0  hl=2 l=  16 prim: OCTET STRING      [HEX DUMP]:FAC7F37508E6B7A805BF4B13861B3687"
+# i.e. 2 byte header + 16 byte salt.
+ok(run(app(([ 'openssl', 'asn1parse',
+              '-in', 'genrsatest-enc.pem',
+              '-offset', '34', '-length', '18']))),
+   "Check the default size of the PBKDF2 PARAM 'salt length' is 16");
 ok(run(app([ 'openssl', 'rsa', '-in', 'genrsatest-enc.pem', '-passin', 'pass:x' ])),
    "rsa decrypt");
 

--- a/test/recipes/20-test_enc.t
+++ b/test/recipes/20-test_enc.t
@@ -73,21 +73,21 @@ plan tests => 5 + (scalar @ciphers)*2;
          }
      }
      ok(run(app([$cmd, "enc", "-in", $test, "-aes256", "-pbkdf2", "-out",
-                 "salted16.cipher", "-pass", "pass:password"]))
-        && run(app([$cmd, "enc", "-d", "-in", "salted16.cipher", "-aes256", "-pbkdf2",
-                    "-saltlen", "16", "-out", "salted16.clear", "-pass", "pass:password"]))
-        && compare_text($test,"salted16.clear") == 0,
-        "Check that the default salt length of 16 bytes is used for PKDF2");
+                 "salted_default.cipher", "-pass", "pass:password"]))
+        && run(app([$cmd, "enc", "-d", "-in", "salted_default.cipher", "-aes256", "-pbkdf2",
+                    "-saltlen", "8", "-out", "salted_default.clear", "-pass", "pass:password"]))
+        && compare_text($test,"salted_default.clear") == 0,
+        "Check that the default salt length of 8 bytes is used for PKDF2");
 
-     ok(!run(app([$cmd, "enc", "-d", "-in", "salted16.cipher", "-aes256", "-pbkdf2",
-                  "-saltlen", "8", "-out", "salted16_fail.clear", "-pass", "pass:password"])),
+     ok(!run(app([$cmd, "enc", "-d", "-in", "salted_default.cipher", "-aes256", "-pbkdf2",
+                  "-saltlen", "16", "-out", "salted_fail.clear", "-pass", "pass:password"])),
         "Check the decrypt fails if the saltlen is incorrect");
 
-     ok(run(app([$cmd, "enc", "-in", $test, "-aes256", "-pbkdf2", "-saltlen", "8",
+     ok(run(app([$cmd, "enc", "-in", $test, "-aes256", "-pbkdf2", "-saltlen", "16",
                  "-out", "salted.cipher", "-pass", "pass:password"]))
         && run(app([$cmd, "enc", "-d", "-in", "salted.cipher", "-aes256", "-pbkdf2",
-                    "-saltlen", "8", "-out", "salted.clear", "-pass", "pass:password"]))
+                    "-saltlen", "16", "-out", "salted.clear", "-pass", "pass:password"]))
         && compare_text($test,"salted.clear") == 0,
-        "Check that we can still use the old salt length of 8 bytes for PKDF2");
+        "Check that we can still use a salt length of 16 bytes for PKDF2");
 
 }

--- a/test/recipes/25-test_pkcs8.t
+++ b/test/recipes/25-test_pkcs8.t
@@ -15,7 +15,58 @@ use OpenSSL::Test qw/:DEFAULT srctop_file ok_nofips is_nofips/;
 
 setup("test_pkcs8");
 
-plan tests => 3;
+plan tests => 9;
+
+ok(run(app(([ 'openssl', 'pkcs8', '-topk8',
+              '-in', srctop_file('test', 'certs', 'pc5-key.pem'),
+              '-out', 'pbkdf2_default_saltlen.pem',
+              '-passout', 'pass:password']))),
+   "Convert a private key to PKCS5 v2.0 format using PBKDF2 with the default saltlen");
+
+# We expect the output to be of the form "0:d=0  hl=2 l=  16 prim: OCTET STRING      [HEX DUMP]:FAC7F37508E6B7A805BF4B13861B3687"
+# i.e. 2 byte header + 16 byte salt.
+ok(run(app(([ 'openssl', 'asn1parse',
+              '-in', 'pbkdf2_default_saltlen.pem',
+              '-offset', '34', '-length', '18']))),
+   "Check the default size of the PBKDF2 PARAM 'salt length' is 16");
+
+SKIP: {
+    skip "scrypt is not supported by this OpenSSL build", 2
+        if disabled("scrypt");
+
+    ok(run(app(([ 'openssl', 'pkcs8', '-topk8',
+                  '-in', srctop_file('test', 'certs', 'pc5-key.pem'),
+                  '-scrypt',
+                  '-out', 'scrypt_default_saltlen.pem',
+                  '-passout', 'pass:password']))),
+       "Convert a private key to PKCS5 v2.0 format using scrypt with the default saltlen");
+
+# We expect the output to be of the form "0:d=0  hl=2 l=  8 prim: OCTET STRING      [HEX DUMP]:FAC7F37508E6B7A805BF4B13861B3687"
+# i.e. 2 byte header + 16 byte salt.
+    ok(run(app(([ 'openssl', 'asn1parse',
+                  '-in', 'scrypt_default_saltlen.pem',
+                  '-offset', '34', '-length', '18']))),
+       "Check the default size of the SCRYPT PARAM 'salt length' = 16");
+}
+
+SKIP: {
+    skip "legacy provider is not supported by this OpenSSL build", 2
+        if disabled('legacy') || disabled("des");
+
+    ok(run(app(([ 'openssl', 'pkcs8', '-topk8',
+                  '-in', srctop_file('test', 'certs', 'pc5-key.pem'),
+                  '-v1', "PBE-MD5-DES",
+                  '-provider', 'legacy',
+                  '-provider', 'default',
+                  '-out', 'pbe1.pem',
+                  '-passout', 'pass:password']))),
+       "Convert a private key to PKCS5 v1.5 format using pbeWithMD5AndDES-CBC with the default saltlen");
+
+    ok(run(app(([ 'openssl', 'asn1parse',
+                  '-in', 'pbe1.pem',
+                  '-offset', '19', '-length', '10']))),
+       "Check the default size of the PBE PARAM 'salt length' = 8");
+};
 
 SKIP: {
     skip "SM2, SM3 or SM4 is not supported by this OpenSSL build", 3


### PR DESCRIPTION
The PKCS5 (RFC 8018) standard uses a 64 bit salt length for PBE, and recommends a minimum of 64 bits for PBES2. For FIPS compliance PBKDF2 requires a salt length of 128 bits.
This affects OpenSSL command line applications such as "genrsa" and "pkcs8" and API's such as PEM_write_bio_PrivateKey() that are reliant on the default value.

The "pkcs8" and "enc" applications now have an extra "saltlen" option which allows the user to set the lenght of the salt.
Note that "genrsa" can only use defaults since it has no way of passing the saltlen down thru the API's.. If you wanted to change the saltlen you could always use "genrsa" followed by a "pkcs8" (with the salt length set to non default).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
