### PR TITLE
Fix misspelled deprecation macro name in comment

### DIFF
--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -158,7 +158,7 @@
 /*
  * Define macros for deprecation and simulated removal purposes.
  *
- * The macros OSSL_DEPRECATED_{major}_{minor} are always defined for
+ * The macros OSSL_DEPRECATEDIN_{major}_{minor} are always defined for
  * all OpenSSL versions we care for.  They can be used as attributes
  * in function declarations where appropriate.
  *


### PR DESCRIPTION
Commit 77c30753cd replaced the convenience macros `DEPRECATEDIN_{major}_{minor}` by `OSSL_DEPRECATEDIN_{major}_{minor}` but misspelled them in the comment.
