### PR TITLE
OPENSSL_init_crypto load config into initial global default library context

### DIFF
--- a/crypto/conf/conf_sap.c
+++ b/crypto/conf/conf_sap.c
@@ -65,7 +65,8 @@ int ossl_config_int(const OPENSSL_INIT_SETTINGS *settings)
 #endif
 
 #ifndef OPENSSL_SYS_UEFI
-    ret = CONF_modules_load_file(filename, appname, flags);
+    ret = CONF_modules_load_file_ex(OSSL_LIB_CTX_get0_global_default(),
+                                    filename, appname, flags);
 #else
     ret = 1;
 #endif


### PR DESCRIPTION
As discussed in https://github.com/openssl/openssl/discussions/21864

OPENSSL_init_crypto() with OPENSSL_INIT_LOAD_CONFIG must load the configuration into the initial global default library context, not the currently set default library context.

OPENSSL_init_crypto() with OPENSSL_INIT_LOAD_CONFIG may be called within other OpenSSL API functions, e.g. from within EVP_PKEY_CTX_new_xxx() when initializing a pkey context, to perform implicit initialization, if it has not been initialized yet. This implicit initialization may happen at a time when an application has already create its own library context and made it the default library context. So loading the config into the current default library context would load it into the applications library context.