### PR TITLE
Remove a redundant point mul from ossl_ec_key_public_check()

### DIFF
--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -581,11 +581,6 @@ int ossl_ec_key_public_check(const EC_KEY *eckey, BN_CTX *ctx)
         ERR_raise(ERR_LIB_EC, ERR_R_EC_LIB);
         goto err;
     }
-    /* Perform a second check on the public key */
-    if (!EC_POINT_mul(eckey->group, point, NULL, eckey->pub_key, order, ctx)) {
-        ERR_raise(ERR_LIB_EC, ERR_R_EC_LIB);
-        goto err;
-    }
     if (!EC_POINT_is_at_infinity(eckey->group, point)) {
         ERR_raise(ERR_LIB_EC, EC_R_WRONG_ORDER);
         goto err;


### PR DESCRIPTION
This code was added in error and is entirely redundant. It is also an expensive operation (e.g. see #21833).

Fixes #21834
