### PR TITLE
QUIC Final API Remediation

### DIFF
--- a/doc/designs/quic-design/quic-api-ssl-funcs.md
+++ b/doc/designs/quic-design/quic-api-ssl-funcs.md
@@ -156,7 +156,7 @@ Notes:
 | **⇒ Method Manipulation** | |
 | `SSL_CTX_get_ssl_method` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
 | `SSL_get_ssl_method` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
-| `SSL_set_ssl_method` | Object | 🟩U | 🟩A | 🟥FC | 🟢Done |
+| `SSL_set_ssl_method` | Object | 🟩U | 🟥FC | 🟧QSI | 🟢Done |
 | **⇒ SRTP** | |
 | `SSL_get_selected_srtp_profile` | HL | 🟩U | 🟧NO | 🟨C\* | 🟢Done |
 | `SSL_get_srtp_profiles` | HL | 🟩U | 🟧NO | 🟨C\* | 🟢Done |
@@ -612,8 +612,8 @@ Notes:
 | `SSL_set_fd` | NDP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_key_update` | RL | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_get_key_update_type` | RL | 🟩U | 🟩A | 🟧QSI | 🟢Done |
-| `SSL_clear`  (connection) | CSSM | 🟩U | 🟩A | 🟥FC | 🟢Done |
-| `SSL_clear`  (stream) | CSSM | 🟩U | 🟩A | 🟥FC | 🟢Done |
+| `SSL_clear`  (connection) | CSSM | 🟩U | 🟥FC | 🟧QSI | 🟢Done |
+| `SSL_clear`  (stream) | CSSM | 🟩U | 🟥FC | 🟧QSI | 🟢Done |
 | `SSL_shutdown` | CSSM | 🟧C | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_want` | ADP | 🟧C | 🟩A | 🟧QSI | 🟢Done |
 | `BIO_new_ssl_connect` | Global | 🟩U | 🟩A | 🟧QSI | 🟢Done |

--- a/doc/designs/quic-design/quic-api-ssl-funcs.md
+++ b/doc/designs/quic-design/quic-api-ssl-funcs.md
@@ -156,7 +156,7 @@ Notes:
 | **⇒ Method Manipulation** | |
 | `SSL_CTX_get_ssl_method` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
 | `SSL_get_ssl_method` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
-| `SSL_set_ssl_method` | Object | 🟥TBD | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_set_ssl_method` | Object | 🟩U | 🟩A | 🟥FC | 🟢Done |
 | **⇒ SRTP** | |
 | `SSL_get_selected_srtp_profile` | HL | 🟩U | 🟧NO | 🟨C\* | 🟢Done |
 | `SSL_get_srtp_profiles` | HL | 🟩U | 🟧NO | 🟨C\* | 🟢Done |
@@ -186,9 +186,9 @@ Notes:
 | `SSL_get_signature_nid` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
 | `SSL_get_signature_type_nid` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
 | **⇒ ALPN** | †2 |
-| `SSL_SESSION_set1_alpn_selected` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟡TODO |
-| `SSL_SESSION_get0_alpn_selected` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟡TODO |
-| `SSL_CTX_set_alpn_select_cb` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟡TODO |
+| `SSL_SESSION_set1_alpn_selected` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟢Done |
+| `SSL_SESSION_get0_alpn_selected` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟢Done |
+| `SSL_CTX_set_alpn_select_cb` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟢Done |
 | `SSL_set_alpn_protos` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟢Done |
 | `SSL_get0_alpn_selected` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟢Done |
 | `SSL_CTX_set_alpn_protos` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟢Done |
@@ -594,7 +594,7 @@ Notes:
 | `SSL_write_ex` | ADP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_sendfile` | ADP | 🟩U | 🟥FC | 🟩NC\* | 🟢Done |
 | `SSL_pending` | ADP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
-| `SSL_has_pending` | ADP | TBD | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_has_pending` | ADP | 🟧C | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_accept` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_connect` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_do_handshake` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟢Done |
@@ -603,7 +603,7 @@ Notes:
 | `SSL_set_bio` | NDP | 🟧C | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_get_wbio` | NDP | 🟧C | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_get_rbio` | NDP | 🟧C | 🟩A | 🟧QSI | 🟢Done |
-| `SSL_get_error` | NDP | 🟩U | 🟩A | 🟧QSI | Done — needs review |
+| `SSL_get_error` | NDP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_get_rfd` | NDP | 🟩U | 🟩A | 🟩NC | 🟢Done |
 | `SSL_get_wfd` | NDP | 🟩U | 🟩A | 🟩NC | 🟢Done |
 | `SSL_get_fd` | NDP | 🟩U | 🟩A | 🟩NC | 🟢Done |
@@ -612,42 +612,46 @@ Notes:
 | `SSL_set_fd` | NDP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_key_update` | RL | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_get_key_update_type` | RL | 🟩U | 🟩A | 🟧QSI | 🟢Done |
-| `SSL_clear`  (connection) | CSSM | TBD | 🟩A | 🟥FC | 🟢Done |
-| `SSL_clear`  (stream) | CSSM | TBD | 🟩A | 🟧QSI | 🟠Design TBD |
-| `SSL_shutdown` | CSSM | 🟧C | 🟩A | 🟧QSI | 🟡TODO |
+| `SSL_clear`  (connection) | CSSM | 🟩U | 🟩A | 🟥FC | 🟢Done |
+| `SSL_clear`  (stream) | CSSM | 🟩U | 🟩A | 🟥FC | 🟢Done |
+| `SSL_shutdown` | CSSM | 🟧C | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_want` | ADP | 🟧C | 🟩A | 🟧QSI | 🟢Done |
-| `BIO_new_ssl_connect` | Global | 🟩U | 🟩A | 🟧QSI | 🟡TODO |
-| `BIO_new_buffer_ssl_connect` | Global | 🟩U | 🟦U | 🟧QSI | 🟡TODO |
-| `SSL_get_shutdown` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
-| `SSL_set_shutdown` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
+| `BIO_new_ssl_connect` | Global | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `BIO_new_buffer_ssl_connect` | Global | 🟩U | 🟦U | 🟧QSI | 🟢Done |
+| `SSL_get_shutdown` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_set_shutdown` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | **⇒ New APIs** | |
-| `SSL_tick` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
-| `SSL_get_tick_timeout` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_is_tls` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_is_quic` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_handle_events` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_get_event_timeout` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
 | `SSL_get_blocking_mode` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
 | `SSL_set_blocking_mode` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
 | `SSL_get_rpoll_descriptor` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
 | `SSL_get_wpoll_descriptor` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
-| `SSL_want_net_read` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
-| `SSL_want_net_write` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_net_read_desired` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_net_write_desired` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
 | `SSL_set1_initial_peer_addr` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
-| `SSL_shutdown_ex` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_stream_conclude` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_stream_reset` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_get_stream_read_state` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_get_stream_write_state` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_get_stream_read_error_code` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_get_stream_write_error_code` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_get_conn_close_info` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_shutdown_ex` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_stream_conclude` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_stream_reset` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_get_stream_read_state` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_get_stream_write_state` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_get_stream_read_error_code` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_get_stream_write_error_code` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_get_conn_close_info` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_inject_net_dgram` | NDP | 🟦N | 🟩A | 🟥QSA | 🟢Done |
 | **⇒ New APIs for Multi-Stream** | |
-| `SSL_get0_connection` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_is_connection` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_get_stream_id` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_get_stream_type` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_new_stream` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_accept_stream` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_get_accept_stream_queue_len` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_set_default_stream_mode` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_set_incoming_stream_policy` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_get0_connection` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_is_connection` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_get_stream_id` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_get_stream_type` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_is_stream_local` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_new_stream` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_accept_stream` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_get_accept_stream_queue_len` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_set_default_stream_mode` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_set_incoming_stream_policy` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
 | **⇒ Currently Not Supported** | |
 | `SSL_copy_session_id` | Special | 🟩U | 🟥FC | 🟨C* | 🟢Done |
 | `BIO_ssl_copy_session_id` | Special | 🟩U | 🟥FC | 🟨C* | 🟢Done |

--- a/doc/designs/quic-design/quic-api.md
+++ b/doc/designs/quic-design/quic-api.md
@@ -830,12 +830,14 @@ unidirectional stream), returns -1.
 | New       | Never         | No        | C             |
 
 ```c
+#define SSL_CONN_CLOSE_FLAG_LOCAL
+#define SSL_CONN_CLOSE_FLAG_TRANSPORT
+
 typedef struct ssl_conn_close_info_st {
     uint64_t error_code;
     char     *reason;
     size_t   reason_len;
-    int      is_local;
-    int      is_transport;
+    uint32_t flags;
 } SSL_CONN_CLOSE_INFO;
 
 int SSL_get_conn_close_info(SSL *ssl,
@@ -854,11 +856,12 @@ always be zero terminated, but since it is received from a potentially untrusted
 peer, may also contain zero bytes. `info->reason_len` is the true length of the
 reason string in bytes.
 
-`info->is_local` is 1 if the connection closure was locally initiated.
+`info->flags` has `SSL_CONN_CLOSE_FLAG_LOCAL` set if the connection closure was
+locally initiated.
 
-`info->is_transport` is 1 if the connection closure was initiated by QUIC, and 0
-if it was initiated by the application. The namespace of `info->error_code` is
-determined by this parameter.
+`info->flags` has `SSL_CONN_CLOSE_FLAG_TRANSPORT` if the connection closure was
+initiated by QUIC, and 0 if it was initiated by the application. The namespace
+of `info->error_code` is determined by this parameter.
 
 ### New APIs for Multi-Stream Operation
 

--- a/doc/designs/quic-design/quic-api.md
+++ b/doc/designs/quic-design/quic-api.md
@@ -51,6 +51,7 @@ designs and the relevant design decisions.
       - [`SSL_is_connection`](#-ssl-is-connection-)
       - [`SSL_get_stream_type`](#-ssl-get-stream-type-)
       - [`SSL_get_stream_id`](#-ssl-get-stream-id-)
+      - [`SSL_is_stream_local`](#-ssl-is-stream-local-)
       - [`SSL_new_stream`](#-ssl-new-stream-)
       - [`SSL_accept_stream`](#-ssl-accept-stream-)
       - [`SSL_get_accept_stream_queue_len`](#-ssl-get-accept-stream-queue-len-)
@@ -88,9 +89,9 @@ for details on SSL object APIs.
 
 | Semantics | API                             | Status |
 |-----------|---------------------------------|--------|
-| TBD       | `BIO_s_connect`                 | TODO  |
-| TBD       | `BIO_set_conn_hostname`         | TODO   |
-| TBD       | `BIO_new_bio_pair`              | TODO   |
+| Changed   | `BIO_s_connect`                 | Done  |
+| Unchanged | `BIO_set_conn_hostname`         | Done   |
+| N/A       | `BIO_new_bio_pair`              | N/A (see `BIO_new_bio_dgram_pair`)   |
 | New       | `BIO_s_dgram_pair`              | Done   |
 | Unchanged | `BIO_dgram_get_mtu`             | Done   |
 | Unchanged | `BIO_dgram_set_mtu`             | Done   |
@@ -982,6 +983,21 @@ __owur int SSL_get_stream_type(SSL *ssl);
 __owur uint64_t SSL_get_stream_id(SSL *ssl);
 ```
 
+#### `SSL_is_stream_local`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| New       | Never         | No        | S             |
+
+```c
+/*
+ * QUIC: Returns 1 if the stream was locally initiated, or 0 otherwise.
+ *
+ * TLS, DTLS: Returns -1.
+ */
+__owur int SSL_is_stream_local(SSL *ssl);
+```
+
 #### `SSL_new_stream`
 
 | Semantics | `SSL_get_error` | Can Tick? | CSHL          |
@@ -1530,7 +1546,8 @@ calls.
 
 **Q. How should `STOP_SENDING` be supported?**
 
-TODO: Determine how `STOP_SENDING` should be supported.
+We trigger `STOP_SENDING` automatically if an application frees the associated
+QUIC stream SSL object.
 
 **Q. Can data be received on a locally initiated bidirectional stream before any
 data is sent on that stream?**

--- a/doc/man3/BIO_get_rpoll_descriptor.pod
+++ b/doc/man3/BIO_get_rpoll_descriptor.pod
@@ -10,10 +10,11 @@ can be used to determine when a BIO object can next be read or written
  #include <openssl/bio.h>
 
  typedef struct bio_poll_descriptor_st {
-     int type;
+     uint32_t type;
      union {
-         int     fd;
-         void    *custom;
+         int        fd;
+         void       *custom;
+         uintptr_t  custom_ui;
      } value;
  } BIO_POLL_DESCRIPTOR;
 
@@ -71,9 +72,8 @@ complete a BIO_write() operation.
 =item BIO_POLL_DESCRIPTOR_CUSTOM_START
 
 Type values beginning with this value (inclusive) are reserved for application
-allocation for custom poll descriptor types. The field I<value.custom> in the
-B<BIO_POLL_DESCRIPTOR> is an opaque pointer which can be used by the application
-arbitrarily.
+allocation for custom poll descriptor types. Any of the definitions in the union
+field I<value> can be used by the application arbitrarily as opaque values.
 
 =back
 

--- a/doc/man3/BIO_sendmmsg.pod
+++ b/doc/man3/BIO_sendmmsg.pod
@@ -197,6 +197,10 @@ transient error, many of which are system specific.
 
 =back
 
+Third parties implementing custom BIOs supporting the BIO_sendmmsg() or
+BIO_recvmmsg() methods should note that it is a required part of the API
+contract that an error is always raised when either of these functions return 0.
+
 BIO_dgram_set_local_addr_enable() returns 1 if local address support was
 successfully enabled or disabled and 0 otherwise.
 

--- a/doc/man3/CRYPTO_THREAD_run_once.pod
+++ b/doc/man3/CRYPTO_THREAD_run_once.pod
@@ -8,7 +8,8 @@ CRYPTO_THREAD_unlock, CRYPTO_THREAD_lock_free,
 CRYPTO_atomic_add, CRYPTO_atomic_or, CRYPTO_atomic_load,
 CRYPTO_atomic_load_int,
 OSSL_set_max_threads, OSSL_get_max_threads,
-OSSL_get_thread_support_flags - OpenSSL thread support
+OSSL_get_thread_support_flags, OSSL_THREAD_SUPPORT_FLAG_THREAD_POOL,
+OSSL_THREAD_SUPPORT_FLAG_DEFAULT_SPAWN - OpenSSL thread support
 
 =head1 SYNOPSIS
 
@@ -32,6 +33,9 @@ OSSL_get_thread_support_flags - OpenSSL thread support
  int OSSL_set_max_threads(OSSL_LIB_CTX *ctx, uint64_t max_threads);
  uint64_t OSSL_get_max_threads(OSSL_LIB_CTX *ctx);
  uint32_t OSSL_get_thread_support_flags(void);
+
+ #define OSSL_THREAD_SUPPORT_FLAG_THREAD_POOL
+ #define OSSL_THREAD_SUPPORT_FLAG_DEFAULT_SPAWN
 
 =head1 DESCRIPTION
 
@@ -121,6 +125,17 @@ spawned unless (and until) there is demand. Thread polling is disabled by
 default. To enable threading you must call OSSL_set_max_threads() explicitly.
 Under no circumstances is this done for you.
 
+=item *
+
+OSSL_get_thread_support_flags() determines what thread pool functionality
+OpenSSL is compiled with and is able to support in the current run time
+environment. B<OSSL_THREAD_SUPPORT_FLAG_THREAD_POOL> indicates that the base
+thread pool functionality is available, and
+B<OSSL_THREAD_SUPPORT_FLAG_DEFAULT_SPAWN> indicates that the default thread pool
+model is available. The default thread pool model is currently the only model
+available, therefore both of these flags must be set for thread pool
+functionality to be used.
+
 =back
 
 =head1 RETURN VALUES
@@ -139,6 +154,9 @@ necessary support).
 OSSL_get_max_threads() returns the maximum number of threads currently allowed
 to be used by the thread pool. If thread pooling is disabled or not available,
 returns 0.
+
+OSSL_get_thread_support_flags() returns zero or more B<OSSL_THREAD_SUPPORT_FLAG>
+values.
 
 The other functions return 1 on success, or 0 on error.
 

--- a/doc/man3/SSL_get_conn_close_info.pod
+++ b/doc/man3/SSL_get_conn_close_info.pod
@@ -2,18 +2,22 @@
 
 =head1 NAME
 
-SSL_get_conn_close_info - get information about why a QUIC connection was closed
+SSL_get_conn_close_info, SSL_CONN_CLOSE_FLAG_LOCAL,
+SSL_CONN_CLOSE_FLAG_TRANSPORT - get information about why a QUIC connection was
+closed
 
 =head1 SYNOPSIS
 
  #include <openssl/ssl.h>
 
+ #define SSL_CONN_CLOSE_FLAG_LOCAL
+ #define SSL_CONN_CLOSE_FLAG_TRANSPORT
+
  typedef struct ssl_conn_close_info_st {
      uint64_t error_code;
      char     *reason;
      size_t   reason_len;
-     int      is_local;
-     int      is_transport;
+     uint32_t flags;
  } SSL_CONN_CLOSE_INFO;
 
  int SSL_get_conn_close_info(SSL *ssl, SSL_CONN_CLOSE_INFO *info,
@@ -34,8 +38,9 @@ The following fields are set:
 =item I<error_code>
 
 This is a 62-bit QUIC error code. It is either a 62-bit application error code
-(if I<is_transport> is 0) or a  62-bit standard QUIC transport error code (if
-I<is_transport> is 1).
+(if B<SSL_CONN_CLOSE_FLAG_TRANSPORT> not set in I<flags>) or a  62-bit standard
+QUIC transport error code (if B<SSL_CONN_CLOSE_FLAG_TRANSPORT> is set in
+I<flags>).
 
 =item I<reason>
 
@@ -49,20 +54,22 @@ of I<reason_len> is recommended.
 While it is intended as per the QUIC protocol that this be a UTF-8 string, there
 is no guarantee that this is the case for strings received from the peer.
 
-=item I<is_local>
+=item B<SSL_CONN_CLOSE_FLAG_LOCAL>
 
-If 1, connection closure was locally triggered. This could be due to an
-application request (e.g. if I<is_transport> is 0), or (if I<is_transport> is 1)
-due to logic internal to the QUIC implementation (for example, if the peer
-engages in a protocol violation, or an idle timeout occurs).
+If I<flags> has B<SSL_CONN_CLOSE_FLAG_LOCAL> set, connection closure was locally
+triggered. This could be due to an application request (e.g. if
+B<SSL_CONN_CLOSE_FLAG_TRANSPORT> is unset), or (if
+I<SSL_CONN_CLOSE_FLAG_TRANSPORT> is set) due to logic internal to the QUIC
+implementation (for example, if the peer engages in a protocol violation, or an
+idle timeout occurs).
 
-If 0, connection closure was remotely triggered.
+If unset, connection closure was remotely triggered.
 
-=item I<is_transport>
+=item B<SSL_CONN_CLOSE_FLAG_TRANSPORT>
 
-If 1, connection closure was triggered for QUIC protocol reasons.
-
-If 0, connection closure was triggered by the local or remote application.
+If I<flags> has B<SSL_CONN_CLOSE_FLAG_TRANSPORT> set, connection closure was
+triggered for QUIC protocol reasons. Otherwise, connection closure was triggered
+by the local or remote application.
 
 =back
 

--- a/doc/man3/SSL_get_stream_id.pod
+++ b/doc/man3/SSL_get_stream_id.pod
@@ -3,8 +3,8 @@
 =head1 NAME
 
 SSL_get_stream_id, SSL_get_stream_type, SSL_STREAM_TYPE_NONE,
-SSL_STREAM_TYPE_READ, SSL_STREAM_TYPE_WRITE, SSL_STREAM_TYPE_BIDI - get QUIC
-stream ID and stream type information
+SSL_STREAM_TYPE_READ, SSL_STREAM_TYPE_WRITE, SSL_STREAM_TYPE_BIDI,
+SSL_is_stream_local - get QUIC stream ID and stream type information
 
 =head1 SYNOPSIS
 
@@ -17,6 +17,8 @@ stream ID and stream type information
  #define SSL_STREAM_TYPE_READ
  #define SSL_STREAM_TYPE_WRITE
  int SSL_get_stream_type(SSL *ssl);
+
+ int SSL_is_stream_local(SSL *ssl);
 
 =head1 DESCRIPTION
 
@@ -55,12 +57,16 @@ from.
 
 =back
 
+The SSL_is_stream_local() function determines whether a stream was locally
+created.
+
 =head1 NOTES
 
 While QUICv1 assigns specific meaning to the low two bits of a QUIC stream ID,
 QUIC stream IDs in future versions of QUIC are not required to have the same
 semantics. Do not determine stream properties using these bits. Instead, use
-SSL_get_stream_type() to determine the stream type.
+SSL_get_stream_type() to determine the stream type and SSL_get_stream_origin()
+to determine the stream initiator.
 
 The SSL_get_stream_type() identifies the type of a QUIC stream based on its
 identity, and does not indicate whether an operation can currently be
@@ -78,6 +84,11 @@ object without a default stream attached. Note that valid QUIC stream IDs are
 always below 2**62.
 
 SSL_get_stream_type() returns one of the B<SSL_STREAM_TYPE> values.
+
+SSL_is_stream_local() returns 1 if called on a QUIC stream SSL object which
+represents a stream which was locally initiated. It returns 0 if called on a
+QUIC stream SSL object which represents a stream which was remotely initiated by
+a peer, and -1 if called on any other kind of SSL object.
 
 =head1 SEE ALSO
 

--- a/doc/man3/SSL_get_stream_id.pod
+++ b/doc/man3/SSL_get_stream_id.pod
@@ -65,7 +65,7 @@ created.
 While QUICv1 assigns specific meaning to the low two bits of a QUIC stream ID,
 QUIC stream IDs in future versions of QUIC are not required to have the same
 semantics. Do not determine stream properties using these bits. Instead, use
-SSL_get_stream_type() to determine the stream type and SSL_get_stream_origin()
+SSL_get_stream_type() to determine the stream type and SSL_get_stream_is_local()
 to determine the stream initiator.
 
 The SSL_get_stream_type() identifies the type of a QUIC stream based on its

--- a/doc/man3/SSL_set_shutdown.pod
+++ b/doc/man3/SSL_set_shutdown.pod
@@ -57,6 +57,8 @@ If a close_notify was received, SSL_RECEIVED_SHUTDOWN will be set,
 for setting SSL_SENT_SHUTDOWN the application must however still call
 L<SSL_shutdown(3)> or SSL_set_shutdown() itself.
 
+These functions are not supported for QUIC SSL objects.
+
 =head1 RETURN VALUES
 
 SSL_set_shutdown() does not return diagnostic information.

--- a/doc/man3/SSL_want.pod
+++ b/doc/man3/SSL_want.pod
@@ -99,6 +99,10 @@ SSL_want_x509_lookup(), SSL_want_retry_verify(),
 SSL_want_async(), SSL_want_async_job(), and SSL_want_client_hello_cb()
 return 1 when the corresponding condition is true or 0 otherwise.
 
+=head1 QUIC-SPECIFIC CONSIDERATIONS
+
+For QUIC, these functions relate only to the TLS handshake layer.
+
 =head1 SEE ALSO
 
 L<ssl(7)>, L<SSL_get_error(3)>

--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -73,6 +73,7 @@ __owur SSL *ossl_quic_conn_stream_new(SSL *s, uint64_t flags);
 __owur SSL *ossl_quic_get0_connection(SSL *s);
 __owur int ossl_quic_get_stream_type(SSL *s);
 __owur uint64_t ossl_quic_get_stream_id(SSL *s);
+__owur int ossl_quic_is_stream_local(SSL *s);
 __owur int ossl_quic_set_default_stream_mode(SSL *s, uint32_t mode);
 __owur SSL *ossl_quic_detach_stream(SSL *s);
 __owur int ossl_quic_attach_stream(SSL *conn, SSL *stream);

--- a/include/internal/ssl.h
+++ b/include/internal/ssl.h
@@ -18,4 +18,7 @@ typedef void (*ossl_msg_cb)(int write_p, int version, int content_type,
 
 int ossl_ssl_get_error(const SSL *s, int i, int check_err);
 
+/* Set if this is the QUIC handshake layer */
+# define TLS1_FLAGS_QUIC                         0x2000
+
 #endif

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -386,10 +386,11 @@ typedef struct bio_mmsg_cb_args_st {
 #define BIO_POLL_DESCRIPTOR_CUSTOM_START    8192
 
 typedef struct bio_poll_descriptor_st {
-    int type;
+    uint32_t type;
     union {
-        int     fd;
-        void    *custom;
+        int         fd;
+        void        *custom;
+        uintptr_t   custom_ui;
     } value;
 } BIO_POLL_DESCRIPTOR;
 

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2343,11 +2343,14 @@ __owur int SSL_get_stream_write_state(SSL *ssl);
 __owur int SSL_get_stream_read_error_code(SSL *ssl, uint64_t *app_error_code);
 __owur int SSL_get_stream_write_error_code(SSL *ssl, uint64_t *app_error_code);
 
+#define SSL_CONN_CLOSE_FLAG_LOCAL       (1U << 0)
+#define SSL_CONN_CLOSE_FLAG_TRANSPORT   (1U << 1)
+
 typedef struct ssl_conn_close_info_st {
     uint64_t    error_code;
     const char  *reason;
     size_t      reason_len;
-    int         is_local, is_transport;
+    uint32_t    flags;
 } SSL_CONN_CLOSE_INFO;
 
 __owur int SSL_get_conn_close_info(SSL *ssl,

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2278,6 +2278,7 @@ __owur int SSL_is_connection(SSL *s);
 __owur int SSL_get_stream_type(SSL *s);
 
 __owur uint64_t SSL_get_stream_id(SSL *s);
+__owur int SSL_is_stream_local(SSL *s);
 
 #define SSL_DEFAULT_STREAM_MODE_NONE        0
 #define SSL_DEFAULT_STREAM_MODE_AUTO_BIDI   1

--- a/include/openssl/ssl3.h
+++ b/include/openssl/ssl3.h
@@ -307,6 +307,8 @@ extern "C" {
 /* Set if extended master secret extension required on renegotiation */
 # define TLS1_FLAGS_REQUIRED_EXTMS               0x1000
 
+/* 0x2000 is reserved for TLS1_FLAGS_QUIC (internal) */
+
 # define SSL3_MT_HELLO_REQUEST                   0
 # define SSL3_MT_CLIENT_HELLO                    1
 # define SSL3_MT_SERVER_HELLO                    2

--- a/include/openssl/ssl3.h
+++ b/include/openssl/ssl3.h
@@ -307,9 +307,6 @@ extern "C" {
 /* Set if extended master secret extension required on renegotiation */
 # define TLS1_FLAGS_REQUIRED_EXTMS               0x1000
 
-/* Set if this is the QUIC handshake layer */
-# define TLS1_FLAGS_QUIC                         0x2000
-
 # define SSL3_MT_HELLO_REQUEST                   0
 # define SSL3_MT_CLIENT_HELLO                    1
 # define SSL3_MT_SERVER_HELLO                    2

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -2695,6 +2695,25 @@ uint64_t ossl_quic_get_stream_id(SSL *s)
 }
 
 /*
+ * SSL_is_stream_local
+ * -------------------
+ */
+QUIC_TAKES_LOCK
+int ossl_quic_is_stream_local(SSL *s)
+{
+    QCTX ctx;
+    int is_local;
+
+    if (!expect_quic_with_stream_lock(s, /*remote_init=*/-1, &ctx))
+        return -1;
+
+    is_local = ossl_quic_stream_is_local_init(ctx.xso->stream);
+    quic_unlock(ctx.qc);
+
+    return is_local;
+}
+
+/*
  * SSL_set_default_stream_mode
  * ---------------------------
  */

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -565,8 +565,8 @@ int ossl_quic_clear(SSL *s)
     if (!expect_quic(s, &ctx))
         return 0;
 
-    /* TODO(QUIC FUTURE): Currently a no-op. */
-    return 1;
+    ERR_raise(ERR_LIB_SSL, ERR_R_UNSUPPORTED);
+    return 0;
 }
 
 int ossl_quic_conn_set_override_now_cb(SSL *s,

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -3230,7 +3230,7 @@ int ossl_quic_get_conn_close_info(SSL *ssl,
     info->reason_len    = tc->reason_len;
     info->flags         = 0;
     if (!tc->remote)
-       info->flags |= SSL_CONN_CLOSE_FLAG_LOCAL;
+        info->flags |= SSL_CONN_CLOSE_FLAG_LOCAL;
     if (!tc->app)
         info->flags |= SSL_CONN_CLOSE_FLAG_TRANSPORT;
     return 1;

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -2704,7 +2704,7 @@ int ossl_quic_is_stream_local(SSL *s)
     QCTX ctx;
     int is_local;
 
-    if (!expect_quic_with_stream_lock(s, /*remote_init=*/-1, &ctx))
+    if (!expect_quic_with_stream_lock(s, /*remote_init=*/-1, /*io=*/0, &ctx))
         return -1;
 
     is_local = ossl_quic_stream_is_local_init(ctx.xso->stream);

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -3228,8 +3228,11 @@ int ossl_quic_get_conn_close_info(SSL *ssl,
     info->error_code    = tc->error_code;
     info->reason        = tc->reason;
     info->reason_len    = tc->reason_len;
-    info->is_local      = !tc->remote;
-    info->is_transport  = !tc->app;
+    info->flags         = 0;
+    if (!tc->remote)
+       info->flags |= SSL_CONN_CLOSE_FLAG_LOCAL;
+    if (!tc->app)
+        info->flags |= SSL_CONN_CLOSE_FLAG_TRANSPORT;
     return 1;
 }
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7474,6 +7474,18 @@ uint64_t SSL_get_stream_id(SSL *s)
 #endif
 }
 
+int SSL_is_stream_local(SSL *s)
+{
+#ifndef OPENSSL_NO_QUIC
+    if (!IS_QUIC(s))
+        return -1;
+
+    return ossl_quic_is_stream_local(s);
+#else
+    return -1;
+#endif
+}
+
 int SSL_set_default_stream_mode(SSL *s, uint32_t mode)
 {
 #ifndef OPENSSL_NO_QUIC

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -1385,8 +1385,12 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                 if (!SSL_get_conn_close_info(c_tgt, &cc_info, sizeof(cc_info)))
                     SPIN_AGAIN();
 
-                if (!TEST_int_eq(expect_app, !cc_info.is_transport)
-                    || !TEST_int_eq(expect_remote, !cc_info.is_local)
+                if (!TEST_int_eq(expect_app,
+                                 (cc_info.flags
+                                  & SSL_CONN_CLOSE_FLAG_TRANSPORT) == 0)
+                    || !TEST_int_eq(expect_remote,
+                                    (cc_info.flags
+                                     & SSL_CONN_CLOSE_FLAG_LOCAL) == 0)
                     || !TEST_uint64_t_eq(error_code, cc_info.error_code))
                     goto out;
             }

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -576,3 +576,4 @@ SSL_set_incoming_stream_policy          ?	3_2_0	EXIST::FUNCTION:
 SSL_handle_events                       ?	3_2_0	EXIST::FUNCTION:
 SSL_get_event_timeout                   ?	3_2_0	EXIST::FUNCTION:
 SSL_get0_group_name                     ?	3_2_0	EXIST::FUNCTION:
+SSL_is_stream_local                     ?	3_2_0	EXIST::FUNCTION:

--- a/util/other.syms
+++ b/util/other.syms
@@ -693,6 +693,8 @@ OSSL_TRACE_CANCEL                       define
 OSSL_TRACE1                             define
 OSSL_TRACE2                             define
 OSSL_TRACE9                             define
+OSSL_THREAD_SUPPORT_FLAG_THREAD_POOL    define
+OSSL_THREAD_SUPPORT_FLAG_DEFAULT_SPAWN  define
 TS_VERIFY_CTS_set_certs                 define deprecated 3.0.0
 EVP_PKEY_get1_tls_encodedpoint          define deprecated 3.0.0
 EVP_PKEY_set1_tls_encodedpoint          define deprecated 3.0.0

--- a/util/other.syms
+++ b/util/other.syms
@@ -643,6 +643,8 @@ SSL_want_read                           define
 SSL_want_retry_verify                   define
 SSL_want_write                          define
 SSL_want_x509_lookup                    define
+SSL_CONN_CLOSE_FLAG_LOCAL               define
+SSL_CONN_CLOSE_FLAG_TRANSPORT           define
 SSLv23_client_method                    define
 SSLv23_method                           define
 SSLv23_server_method                    define


### PR DESCRIPTION
- Design document updates
- Documentation updates
- Make `BIO_POLL_DESCRIPTOR` more flexible for third parties
- Introduce `SSL_is_stream_local` to determine if a stream was remotely initiated (overlooked)
- Change `SSL_CONN_CLOSE_INFO` to have a more standard design using flags
- Hide some things which shouldn't be in public headers

I have looked over all new QUIC-related APIs and I'm happy with them with these changes applied.

# Readiness of Existing API Implementation

I have looked over the existing APIs we implement for QUIC with reference to the SSL APIs design document updated in this PR. Most of these concern the handshake layer and are of little concern.

One major concern was around how `SSL_get_error` was to work but I believe we have now more or less ironed this out. 

I believe the outstanding issue now is:

- :red_circle: We do not have `SSL_want` wired for streams. We probably should. We seem to have overlooked this.

Since others have more knowledge of the existing SSL APIs than me, I would highly advise people to take a look at the SSL API overview document which is updated in this PR and see if anything looks concerning to them.

# Summary of New QUIC-Related APIs in 3.2

BIO
---

Summary of changes:

- (OK) New `BIO_s_dgram_pair(void)`
- (OK) New `BIO_s_dgram_mem(void)`
- (OK) New `BIO_new_bio_dgram_pair()`
- (OK) New `BIO_CTRL_DGRAM_GET_LOCAL_ADDR_CAP`
    (`int BIO_dgram_get_local_addr_cap(BIO *bio)`)
- (OK) New `BIO_CTRL_DGRAM_GET_LOCAL_ADDR_ENABLE`
    (`int BIO_dgram_get_local_addr_enable(BIO *bio, int *enabled)`)
- (OK) New `BIO_CTRL_DGRAM_SET_LOCAL_ADDR_ENABLE`
    (`int BIO_dgram_set_local_addr_enable(BIO *bio, int enabled)`)
- (OK) New `BIO_CTRL_DGRAM_GET_EFFECTIVE_CAPS`
    (`int BIO_dgram_get_effective_caps(BIO *bio)`)
- (OK) New `BIO_CTRL_DGRAM_GET_CAPS`
    (`int BIO_dgram_get_caps(BIO *bio)`)
- (OK) New `BIO_CTRL_DGRAM_SET_CAPS`
    (`int BIO_dgram_set_caps(BIO *bio, long caps)`)
- (OK) New `BIO_CTRL_DGRAM_GET_NO_TRUNC`
    (`int BIO_dgram_get_no_trunc(BIO *bio)`)
- (OK) New `BIO_CTRL_DGRAM_SET_NO_TRUNC`
    (`int BIO_dgram_set_no_trunc(BIO *bio, int enable)`)
- (OK) New `BIO_CTRL_DGRAM_GET_RPOLL_DESCRIPTOR`
    (`int BIO_get_rpoll_descriptor(BIO *b, BIO_POLL_DESCRIPTOR *desc)`)
- (OK) New `BIO_CTRL_DGRAM_GET_WPOLL_DESCRIPTOR`
    (`int BIO_get_wpoll_descriptor(BIO *b, BIO_POLL_DESCRIPTOR *desc)`)
- (OK) New capability `BIO_DGRAM_CAP_HANDLES_SRC_ADDR`
- (OK) New capability `BIO_DGRAM_CAP_HANDLES_DST_ADDR`
- (OK) New capability `BIO_DGRAM_CAP_PROVIDES_SRC_ADDR`
- (OK) New capability `BIO_DGRAM_CAP_PROVIDES_DST_ADDR`
- (OK) New method `BIO_sendmmsg` and `BIO_METHOD`-related APIs
- (OK) New method `BIO_recvmmsg` and `BIO_METHOD`-related APIs
- (OK) New `BIO_MSG`
- (REMEDIATED) New `BIO_POLL_DESCRIPTOR`
- (OK) New `BIO_err_is_non_fatal`
- (OK) New `BIO_ADDR_dup`
- (OK) Expanded use of existing `BIO_CTRL_DGRAM_GET_MTU`
- (OK) Expanded use of existing `BIO_CTRL_DGRAM_SET_MTU`
- New errors:
  - (OK) `BIO_R_LOCAL_ADDR_NOT_AVAILABLE`
  - (OK) `BIO_R_NON_FATAL`
  - (OK) `BIO_R_PORT_MISMATCH`
  - (OK) `BIO_R_PEER_ADDR_NOT_AVAILABLE`

CRYPTO
------

Summary of changes:

- (OK) New `CRYPTO_atomic_load_int`
- New thread pool support
  - (REMEDIATED) `OSSL_get_thread_support_flags`
  - (OK) `OSSL_set_max_threads`
  - (OK) `OSSL_get_max_threads`

ERR
---

Summary of changes:

- New ERR save/restore functionality:
  - (OK) `int ERR_count_to_mark(void)`
  - (OK) `ERR_STATE *OSSL_ERR_STATE_new(void)`
  - (OK) `void OSSL_ERR_STATE_save(ERR_STATE *es)`
  - (OK) `void OSSL_ERR_STATE_save_to_mark(ERR_STATE *es)`
  - (OK) `void OSSL_ERR_STATE_restore(const ERR_STATE *es)`
  - (OK) `void OSSL_ERR_state_free(ERR_STATE *es)`

libssl
------

Summary of changes:

- (OK) New `OSSL_QUIC_client_method(void)`
- (OK) New `OSSL_QUIC_client_thread_method(void)`
- (OK) New `SSL_is_tls(const SSL *s)`
- (OK) New `SSL_is_quic(const SSL *s)`
- (OK) New `SSL_is_connection(SSL *s)`
- (OK) New `SSL_handle_events(SSL *s)`
- (OK) New `SSL_get_event_timeout(SSL 8s, struct timeval *tv, int *is_infinite)`
- (OK) New `SSL_get_rpoll_descriptor(SSL *s, BIO_POLL_DESCRIPTOR *desc)`
- (OK) New `SSL_get_wpoll_descriptor(SSL *s, BIO_POLL_DESCRIPTOR *desc)`
- (OK) New `SSL_net_read_desired(SSL *s)`
- (OK) New `SSL_net_write_desired(SSL *s)`
- (OK) New `SSL_set_blocking_mode(SSL *s, int blocking)`
- (OK) New `SSL_get_blocking_mode(SSL *s)`
- (OK) New `SSL_set1_initial_peer_addr(SSL *s, const BIO_ADDR *peer_addr)`
- (OK) New `SSL *SSL_get0_connection(SSL *s)`
- (OK) New `SSL_get_stream_type(SSL *s)`
- (NEW-OK) New `SSL_is_stream_local(SSL *s)`
- New stream types:
  - (OK) `SSL_STREAM_TYPE_READ`
  - (OK) `SSL_STREAM_TYPE_WRITE`
  - (OK) `SSL_STREAM_TYPE_BIDI`
- (OK) New `SSL_get_stream_id(SSL *s)`
- (OK) New `SSL_set_default_stream_mode(SSL *s, uint32_t mode)`
- New stream modes:
  - (OK) `SSL_DEFAULT_STREAM_MODE_NONE`,
  - (OK) `SSL_DEFAULT_STREAM_MODE_AUTO_BIDI`,
  - (OK) `SSL_DEFAULT_STREAM_MODE_AUTO_UNI`
- (OK) New `SSL_new_stream(SSL *s, uint64_t flags)`
- New stream creation flags:
  - (OK) `SSL_STREAM_FLAG_UNI`
  - (OK) `SSL_STREAM_FLAG_NO_BLOCK`
  - (OK) `SSL_STREAM_FLAG_ADVANCE`
- (OK) New `SSL_set_incoming_stream_policy(SSL *s, int policy, uint64_t aec)`
- New incoming stream policies:
  - (OK) `SSL_INCOMING_STREAM_POLICY_AUTO`
  - (OK) `SSL_INCOMING_STREAM_POLICY_ACCEPT`
  - (OK) `SSL_ACCEPT_STREAM_POLICY_REJECT`
- (OK) New `SSL_accept_stream(SSL *s, uint64_t flags)`
- New accept stream flags:
  - (OK) `SSL_ACCEPT_STREAM_NO_BLOCK`
- (OK) New `SSL_get_accept_stream_queue_len(SSL *s)`
- (OK) New `SSL_inject_net_dgram()`
- (OK) New `SSL_shutdown_ex()`
- (OK) New `SSL_stream_conclude(SSL *s, uint64_t flags)`
- (OK) New `SSL_stream_reset()`
- (OK) New `SSL_get_stream_read_state(SSL *ssl)`
- (OK) New `SSL_get_stream_write_state(SSL *ssl)`
- New stream states:
  - (OK) `SSL_STREAM_STATE_NONE`
  - (OK) `SSL_STREAM_STATE_OK`
  - (OK) `SSL_STREAM_STATE_WRONG_DIR`
  - (OK) `SSL_STREAM_STATE_FINISHED`
  - (OK) `SSL_STREAM_STATE_RESET_LOCAL`
  - (OK) `SSL_STREAM_STATE_RESET_REMOTE`
  - (OK) `SSL_STREAM_STATE_CONN_CLOSED`
- (OK) New `SSL_get_stream_read_error_code(SSL *ssl)`
- (OK) New `SSL_get_stream_write_error_code(SSL *ssl)`
- (REMEDIATED) New `SSL_get_conn_close_info()`
- New tracing psuedo-types:
  - (OK) `SSL3_RT_QUIC_DATAGRAM`
  - (OK) `SSL3_RT_QUIC_PACKET`
  - (OK) `SSL3_RT_QUIC_FRAME_FULL`
  - (OK) `SSL3_RT_QUIC_FRAME_HEADER`
  - (OK) `SSL3_RT_QUIC_FRAME_PADDING`
- New constants:
  - (REMEDIATED) `TLS1_FLAGS_QUIC`
  - (OK) `TLSEXT_TYPE_quic_transport_parameters`
- New errors:
  - (OK) `SSL_R_CONN_USE_ONLY`
  - (OK) `SSL_R_MAXIMUM_ENCRYPTED_PKTS_REACHED`
  - (OK) `SSL_R_QUIC_HANDSHAKE_LAYER_ERROR`
  - (OK) `SSL_R_QUIC_NETWORK_ERROR`
  - (OK) `SSL_R_QUIC_PROTOCOL_ERROR`
  - (OK) `SSL_R_REMOTE_PEER_ADDRESS_NOT_SET`
  - (OK) `SSL_R_STREAM_COUNT_LIMITED`
  - (OK) `SSL_R_STREAM_FINISHED`
  - (OK) `SSL_R_STREAM_RECV_ONLY`
  - (OK) `SSL_R_STREAM_RESET`
  - (OK) `SSL_R_STREAM_SEND_ONLY`

