### PR TITLE
Store delete 3

### DIFF
--- a/crypto/store/store_local.h
+++ b/crypto/store/store_local.h
@@ -112,6 +112,7 @@ struct ossl_store_loader_st {
     OSSL_FUNC_store_eof_fn *p_eof;
     OSSL_FUNC_store_close_fn *p_close;
     OSSL_FUNC_store_export_object_fn *p_export_object;
+    OSSL_FUNC_store_delete_fn *p_delete;
 };
 DEFINE_LHASH_OF_EX(OSSL_STORE_LOADER);
 

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -219,6 +219,10 @@ static void *loader_from_algorithm(int scheme_id, const OSSL_ALGORITHM *algodef,
             if (loader->p_export_object == NULL)
                 loader->p_export_object = OSSL_FUNC_store_export_object(fns);
             break;
+        case OSSL_FUNC_STORE_DELETE:
+            if (loader->p_delete == NULL)
+                loader->p_delete = OSSL_FUNC_store_delete(fns);
+            break;
         }
     }
 
@@ -226,7 +230,7 @@ static void *loader_from_algorithm(int scheme_id, const OSSL_ALGORITHM *algodef,
         || loader->p_load == NULL
         || loader->p_eof == NULL
         || loader->p_close == NULL) {
-        /* Only set_ctx_params is optionaal */
+        /* Only set_ctx_params is optional */
         OSSL_STORE_LOADER_free(loader);
         ERR_raise(ERR_LIB_OSSL_STORE, OSSL_STORE_R_LOADER_INCOMPLETE);
         return NULL;

--- a/doc/man3/OSSL_STORE_open.pod
+++ b/doc/man3/OSSL_STORE_open.pod
@@ -4,7 +4,7 @@
 
 OSSL_STORE_CTX, OSSL_STORE_post_process_info_fn,
 OSSL_STORE_open, OSSL_STORE_open_ex,
-OSSL_STORE_ctrl, OSSL_STORE_load, OSSL_STORE_eof,
+OSSL_STORE_ctrl, OSSL_STORE_load, OSSL_STORE_eof, OSSL_STORE_delete,
 OSSL_STORE_error, OSSL_STORE_close
 - Types and functions to read objects from a URI
 
@@ -30,6 +30,9 @@ OSSL_STORE_error, OSSL_STORE_close
 
  OSSL_STORE_INFO *OSSL_STORE_load(OSSL_STORE_CTX *ctx);
  int OSSL_STORE_eof(OSSL_STORE_CTX *ctx);
+ int OSSL_STORE_delete(const char *uri, OSSL_LIB_CTX *libctx, const char *propq,
+                       const UI_METHOD *ui_method, void *ui_data,
+                       const OSSL_PARAM params[]);
  int OSSL_STORE_error(OSSL_STORE_CTX *ctx);
  int OSSL_STORE_close(OSSL_STORE_CTX *ctx);
 
@@ -104,6 +107,8 @@ Any other value is an error.
 OSSL_STORE_load() takes a B<OSSL_STORE_CTX> and tries to load the next
 available object and return it wrapped with B<OSSL_STORE_INFO>.
 
+OSSL_STORE_delete() deletes the object identified by I<uri>.
+
 OSSL_STORE_eof() takes a B<OSSL_STORE_CTX> and checks if we've reached the end
 of data.
 
@@ -152,7 +157,8 @@ or an error occurred, 0 otherwise.
 OSSL_STORE_error() returns 1 if an error occurred in an OSSL_STORE_load() call,
 otherwise 0.
 
-OSSL_STORE_ctrl() and OSSL_STORE_close() returns 1 on success, or 0 on failure.
+OSSL_STORE_delete(), OSSL_STORE_ctrl() and OSSL_STORE_close() return 1 on
+success, or 0 on failure.
 
 =head1 SEE ALSO
 
@@ -160,6 +166,8 @@ L<ossl_store(7)>, L<OSSL_STORE_INFO(3)>, L<OSSL_STORE_register_loader(3)>,
 L<passphrase-encoding(7)>
 
 =head1 HISTORY
+
+OSSL_STORE_delete() was added in OpenSSL 3.2.
 
 OSSL_STORE_open_ex() was added in OpenSSL 3.0.
 
@@ -169,8 +177,6 @@ were added in OpenSSL 1.1.1.
 
 Handling of NULL I<ctx> argument for OSSL_STORE_close()
 was introduced in OpenSSL 1.1.1h.
-
-OSSL_STORE_open_ex() was added in OpenSSL 3.0.
 
 OSSL_STORE_ctrl() and OSSL_STORE_vctrl() were deprecated in OpenSSL 3.0.
 

--- a/doc/man7/provider-storemgmt.pod
+++ b/doc/man7/provider-storemgmt.pod
@@ -28,6 +28,8 @@ provider-storemgmt - The OSSL_STORE library E<lt>-E<gt> provider functions
      (void *loaderctx, const void *objref, size_t objref_sz,
       OSSL_CALLBACK *export_cb, void *export_cbarg);
 
+ int OSSL_FUNC_store_delete(void *loaderctx)
+
 =head1 DESCRIPTION
 
 The STORE operation is the provider side of the L<ossl_store(7)> API.
@@ -70,6 +72,7 @@ in L<openssl-core_dispatch.h(7)>, as follows:
  OSSL_FUNC_store_eof                  OSSL_FUNC_STORE_EOF
  OSSL_FUNC_store_close                OSSL_FUNC_STORE_CLOSE
  OSSL_FUNC_store_export_object        OSSL_FUNC_STORE_EXPORT_OBJECT
+ OSSL_FUNC_store_delete               OSSL_FUNC_STORE_DELETE
 
 =head2 Functions
 
@@ -113,6 +116,8 @@ supports the type of the object and provides an import function.
 OSSL_FUNC_store_export_object() should export the object of size I<objref_sz>
 referenced by I<objref> as an L<OSSL_PARAM(3)> array and pass that to the
 I<export_cb> as well as the given I<export_cbarg>.
+
+OSSL_FUNC_store_delete() deletes the object from store.
 
 =head2 Load Parameters
 

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -936,6 +936,7 @@ OSSL_CORE_MAKE_FUNC(int, decoder_export_object,
 #define OSSL_FUNC_STORE_EOF                         6
 #define OSSL_FUNC_STORE_CLOSE                       7
 #define OSSL_FUNC_STORE_EXPORT_OBJECT               8
+#define OSSL_FUNC_STORE_DELETE                      9
 OSSL_CORE_MAKE_FUNC(void *, store_open, (void *provctx, const char *uri))
 OSSL_CORE_MAKE_FUNC(void *, store_attach, (void *provctx, OSSL_CORE_BIO *in))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, store_settable_ctx_params,
@@ -951,6 +952,7 @@ OSSL_CORE_MAKE_FUNC(int, store_close, (void *loaderctx))
 OSSL_CORE_MAKE_FUNC(int, store_export_object,
                     (void *loaderctx, const void *objref, size_t objref_sz,
                      OSSL_CALLBACK *export_cb, void *export_cbarg))
+OSSL_CORE_MAKE_FUNC(int, store_delete, (void *loaderctx))
 
 # ifdef __cplusplus
 }

--- a/include/openssl/store.h
+++ b/include/openssl/store.h
@@ -99,6 +99,14 @@ OSSL_DEPRECATEDIN_3_0 int OSSL_STORE_vctrl(OSSL_STORE_CTX *ctx, int cmd,
 OSSL_STORE_INFO *OSSL_STORE_load(OSSL_STORE_CTX *ctx);
 
 /*
+ * Deletes the object in the store by URI.
+ * Returns 1 on success, 0 otherwise.
+ */
+int OSSL_STORE_delete(const char *uri, OSSL_LIB_CTX *libctx, const char *propq,
+                      const UI_METHOD *ui_method, void *ui_data,
+                      const OSSL_PARAM params[]);
+
+/*
  * Check if end of data (end of file) is reached
  * Returns 1 on end, 0 otherwise.
  */

--- a/test/fake_rsaprov.h
+++ b/test/fake_rsaprov.h
@@ -13,3 +13,4 @@
 OSSL_PROVIDER *fake_rsa_start(OSSL_LIB_CTX *libctx);
 void fake_rsa_finish(OSSL_PROVIDER *p);
 OSSL_PARAM *fake_rsa_key_params(int priv);
+void fake_rsa_restore_store_state(void);

--- a/test/provider_pkey_test.c
+++ b/test/provider_pkey_test.c
@@ -18,6 +18,7 @@
 #include "fake_rsaprov.h"
 
 static OSSL_LIB_CTX *libctx = NULL;
+extern int key_deleted; /* From fake_rsaprov.c */
 
 /* Fetch SIGNATURE method using a libctx and propq */
 static int fetch_sig(OSSL_LIB_CTX *ctx, const char *alg, const char *propq,
@@ -288,6 +289,76 @@ end:
     return ret;
 }
 
+static int test_pkey_delete(void)
+{
+    OSSL_PROVIDER *deflt = NULL;
+    OSSL_PROVIDER *fake_rsa = NULL;
+    int ret = 0;
+    EVP_PKEY *pkey = NULL;
+    OSSL_STORE_LOADER *loader = NULL;
+    OSSL_STORE_CTX *ctx = NULL;
+    OSSL_STORE_INFO *info;
+    const char *propq = "?provider=fake-rsa";
+
+    /* It's important to load the default provider first for this test */
+    if (!TEST_ptr(deflt = OSSL_PROVIDER_load(libctx, "default")))
+        goto end;
+
+    if (!TEST_ptr(fake_rsa = fake_rsa_start(libctx)))
+        goto end;
+
+    if (!TEST_ptr(loader = OSSL_STORE_LOADER_fetch(libctx, "fake_rsa",
+                                                   propq)))
+        goto end;
+
+    OSSL_STORE_LOADER_free(loader);
+
+    /* First iteration: load key, check it, delete it */
+    if (!TEST_ptr(ctx = OSSL_STORE_open_ex("fake_rsa:test", libctx, propq,
+                                           NULL, NULL, NULL, NULL, NULL)))
+        goto end;
+
+    while (!OSSL_STORE_eof(ctx)
+           && (info = OSSL_STORE_load(ctx)) != NULL
+           && pkey == NULL) {
+        if (OSSL_STORE_INFO_get_type(info) == OSSL_STORE_INFO_PKEY)
+            pkey = OSSL_STORE_INFO_get1_PKEY(info);
+        OSSL_STORE_INFO_free(info);
+        info = NULL;
+    }
+
+    if (!TEST_ptr(pkey) || !TEST_int_eq(EVP_PKEY_is_a(pkey, "RSA"), 1))
+        goto end;
+    EVP_PKEY_free(pkey);
+    pkey = NULL;
+
+    if (!TEST_int_eq(OSSL_STORE_delete("fake_rsa:test", libctx, propq,
+                                       NULL, NULL, NULL), 1))
+        goto end;
+    if (!TEST_int_eq(OSSL_STORE_close(ctx), 1))
+        goto end;
+
+    /* Second iteration: load key should fail */
+    if (!TEST_ptr(ctx = OSSL_STORE_open_ex("fake_rsa:test", libctx, propq,
+                                           NULL, NULL, NULL, NULL, NULL)))
+        goto end;
+
+    while (!OSSL_STORE_eof(ctx)) {
+           info = OSSL_STORE_load(ctx);
+	   if (!TEST_ptr_null(info))
+               goto end;
+    }
+
+    ret = 1;
+
+end:
+    fake_rsa_finish(fake_rsa);
+    OSSL_PROVIDER_unload(deflt);
+    OSSL_STORE_close(ctx);
+    fake_rsa_restore_store_state();
+    return ret;
+}
+
 int setup_tests(void)
 {
     libctx = OSSL_LIB_CTX_new();
@@ -298,6 +369,7 @@ int setup_tests(void)
     ADD_TEST(test_alternative_keygen_init);
     ADD_TEST(test_pkey_eq);
     ADD_ALL_TESTS(test_pkey_store, 2);
+    ADD_TEST(test_pkey_delete);
 
     return 1;
 }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5532,3 +5532,4 @@ ERR_count_to_mark                       ?	3_2_0	EXIST::FUNCTION:
 OSSL_ERR_STATE_save_to_mark             ?	3_2_0	EXIST::FUNCTION:
 X509_STORE_CTX_set_get_crl              ?	3_2_0	EXIST::FUNCTION:
 X509_STORE_CTX_set_current_reasons      ?	3_2_0	EXIST::FUNCTION:
+OSSL_STORE_delete                       ?	3_2_0	EXIST::FUNCTION:


### PR DESCRIPTION
Trying to improve #21901 and avoid code duplication.

We create an operation context containing all the data via store_open, pass it to delete callback, and let the provider to deal with it. Then we close the store after the operation.

##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated
