### PR TITLE
Removed unnecessary brace in ktls_configure_crypto

### DIFF
--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -95,7 +95,7 @@ int ktls_configure_crypto(OSSL_LIB_CTX *libctx, int version, const EVP_CIPHER *c
             return 0;
         if (EVP_MD_is_a(md, "SHA1"))
             crypto_info->auth_algorithm = CRYPTO_SHA1_HMAC;
-        else if (EVP_MD_is_a(md, "SHA2-256")) {
+        else if (EVP_MD_is_a(md, "SHA2-256"))
             crypto_info->auth_algorithm = CRYPTO_SHA2_256_HMAC;
         else if (EVP_MD_is_a(md, "SHA2-384"))
             crypto_info->auth_algorithm = CRYPTO_SHA2_384_HMAC;


### PR DESCRIPTION
Fixes [#21498](https://github.com/openssl/openssl/issues/21498)

CLA: trivial
