### PR TITLE
Fix AES-NI detection in aesni_set_encrypt_key

### DIFF
--- a/crypto/aes/asm/aesni-x86_64.pl
+++ b/crypto/aes/asm/aesni-x86_64.pl
@@ -4378,7 +4378,7 @@ __aesni_set_encrypt_key:
 	test	$key,$key
 	jz	.Lenc_key_ret
 
-	mov	\$`1<<28|1<<11`,%r10d	# AVX and XOP bits
+	mov	\$`1<<28|1<<25`,%r10d	# AVX and AES-NI bits
 	movups	($inp),%xmm0		# pull first 128 bits of *userKey
 	xorps	%xmm4,%xmm4		# low dword of xmm4 is assumed 0
 	and	OPENSSL_ia32cap_P+4(%rip),%r10d
@@ -4392,7 +4392,7 @@ __aesni_set_encrypt_key:
 
 .L10rounds:
 	mov	\$9,$bits			# 10 rounds for 128-bit key
-	cmp	\$`1<<28`,%r10d			# AVX, bit no XOP
+	cmp	\$`1<<28`,%r10d			# AVX, bit no AES-NI
 	je	.L10rounds_alt
 
 	$movkey	%xmm0,($key)			# round 0


### PR DESCRIPTION
aesni_set_encrypt_key checks for CPUID EAX=1 ECX bit 11 (AMD XOP).
If the bit is set, it proceeds to AES-NI instructions. 

However:
- the XOP bit is forced to zero on Intel (meaning aesni_set_encrypt_key never uses the aeskeygenassist instruction on Intel). This might actually be intended by the author, as aeskeygenassist is microcoded on newer Intel CPUs.
- On AMD the check seems dubious: If XOP is supported, it uses the aeskeygenassist instruction. XOP precedes AES-NI so this is safe, but AES-NI outlived XOP -- On Zen-based CPUs, XOP no longer exists.

Remaining questions:
- Is microcoded aeskeygenassist faster than the AVX path on recent Intel CPUs? (Might be due to L1I cache footprint) 
- Is aeskeygenassist microcoded on AMD Zen and onwards?

This patch updates the CPUID detection to check for AES-NI instead of XOP. 
However, due to these open questions, I am marking the PR as draft for now.

I would kindly suggest to the original author to add comments explaining the reasoning behind these checks.