### PR TITLE
QUIC: Implement SSL_want

### DIFF
--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -57,6 +57,7 @@ __owur int ossl_quic_get_wpoll_descriptor(SSL *s, BIO_POLL_DESCRIPTOR *d);
 __owur int ossl_quic_get_net_read_desired(SSL *s);
 __owur int ossl_quic_get_net_write_desired(SSL *s);
 __owur int ossl_quic_get_error(const SSL *s, int i);
+__owur int ossl_quic_want(const SSL *s);
 __owur int ossl_quic_conn_get_blocking_mode(const SSL *s);
 __owur int ossl_quic_conn_set_blocking_mode(SSL *s, int blocking);
 __owur int ossl_quic_conn_shutdown(SSL *s, uint64_t flags,

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -275,12 +275,11 @@ err:
  * Like expect_quic(), but fails if called on a QUIC_XSO. ctx->xso may still
  * be non-NULL if the QCSO has a default stream.
  */
-static int ossl_unused expect_quic_conn_only(const SSL *s, int in_io, QCTX *ctx)
+static int ossl_unused expect_quic_conn_only(const SSL *s, QCTX *ctx)
 {
     if (!expect_quic(s, ctx))
         return 0;
 
-    ctx->in_io = in_io;
     if (ctx->is_stream)
         return QUIC_RAISE_NON_NORMAL_ERROR(ctx, SSL_R_CONN_USE_ONLY, NULL);
 
@@ -1872,7 +1871,7 @@ SSL *ossl_quic_conn_stream_new(SSL *s, uint64_t flags)
 {
     QCTX ctx;
 
-    if (!expect_quic_conn_only(s, /*io=*/0, &ctx))
+    if (!expect_quic_conn_only(s, &ctx))
         return NULL;
 
     return quic_conn_stream_new(&ctx, flags, /*need_lock=*/1);
@@ -2703,7 +2702,7 @@ int ossl_quic_set_default_stream_mode(SSL *s, uint32_t mode)
 {
     QCTX ctx;
 
-    if (!expect_quic_conn_only(s, /*io=*/0, &ctx))
+    if (!expect_quic_conn_only(s, &ctx))
         return 0;
 
     quic_lock(ctx.qc);
@@ -2740,7 +2739,7 @@ SSL *ossl_quic_detach_stream(SSL *s)
     QCTX ctx;
     QUIC_XSO *xso = NULL;
 
-    if (!expect_quic_conn_only(s, /*io=*/0, &ctx))
+    if (!expect_quic_conn_only(s, &ctx))
         return NULL;
 
     quic_lock(ctx.qc);
@@ -2765,7 +2764,7 @@ int ossl_quic_attach_stream(SSL *conn, SSL *stream)
     QUIC_XSO *xso;
     int nref;
 
-    if (!expect_quic_conn_only(conn, /*io=*/0, &ctx))
+    if (!expect_quic_conn_only(conn, &ctx))
         return 0;
 
     if (stream == NULL || stream->type != SSL_TYPE_QUIC_XSO)
@@ -2845,7 +2844,7 @@ int ossl_quic_set_incoming_stream_policy(SSL *s, int policy,
     int ret = 1;
     QCTX ctx;
 
-    if (!expect_quic_conn_only(s, /*io=*/0, &ctx))
+    if (!expect_quic_conn_only(s, &ctx))
         return 0;
 
     quic_lock(ctx.qc);
@@ -2909,7 +2908,7 @@ SSL *ossl_quic_accept_stream(SSL *s, uint64_t flags)
     QUIC_XSO *xso;
     OSSL_RTT_INFO rtt_info;
 
-    if (!expect_quic_conn_only(s, /*io=*/0, &ctx))
+    if (!expect_quic_conn_only(s, &ctx))
         return NULL;
 
     quic_lock(ctx.qc);
@@ -2972,7 +2971,7 @@ size_t ossl_quic_get_accept_stream_queue_len(SSL *s)
     QCTX ctx;
     size_t v;
 
-    if (!expect_quic_conn_only(s, /*io=*/0, &ctx))
+    if (!expect_quic_conn_only(s, &ctx))
         return 0;
 
     quic_lock(ctx.qc);
@@ -3199,7 +3198,7 @@ int ossl_quic_get_conn_close_info(SSL *ssl,
     QCTX ctx;
     const QUIC_TERMINATE_CAUSE *tc;
 
-    if (!expect_quic_conn_only(ssl, /*io=*/0, &ctx))
+    if (!expect_quic_conn_only(ssl, &ctx))
         return -1;
 
     tc = ossl_quic_channel_get_terminate_cause(ctx.qc->ch);
@@ -3222,7 +3221,7 @@ int ossl_quic_key_update(SSL *ssl, int update_type)
 {
     QCTX ctx;
 
-    if (!expect_quic_conn_only(ssl, /*io=*/0, &ctx))
+    if (!expect_quic_conn_only(ssl, &ctx))
         return 0;
 
     switch (update_type) {
@@ -3282,7 +3281,7 @@ long ossl_quic_callback_ctrl(SSL *s, int cmd, void (*fp) (void))
 {
     QCTX ctx;
 
-    if (!expect_quic_conn_only(s, /*io=*/0, &ctx))
+    if (!expect_quic_conn_only(s, &ctx))
         return 0;
 
     switch (cmd) {
@@ -3333,7 +3332,7 @@ QUIC_CHANNEL *ossl_quic_conn_get_channel(SSL *s)
 {
     QCTX ctx;
 
-    if (!expect_quic_conn_only(s, /*io=*/0, &ctx))
+    if (!expect_quic_conn_only(s, &ctx))
         return NULL;
 
     return ctx.qc->ch;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -5501,6 +5501,11 @@ int SSL_want(const SSL *s)
 {
     const SSL_CONNECTION *sc = SSL_CONNECTION_FROM_CONST_SSL(s);
 
+#ifndef OPENSSL_NO_QUIC
+    if (IS_QUIC(s))
+        return ossl_quic_want(s);
+#endif
+
     if (sc == NULL)
         return SSL_NOTHING;
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -805,6 +805,29 @@ static int is_want(SSL *s, int ret)
     return ec == SSL_ERROR_WANT_READ || ec == SSL_ERROR_WANT_WRITE;
 }
 
+static int check_consistent_want(SSL *s, int ret)
+{
+    int ec = SSL_get_error(s, ret);
+    int w = SSL_want(s);
+
+    int ok = TEST_true(
+        (ec == SSL_ERROR_NONE                 && w == SSL_NOTHING)
+    ||  (ec == SSL_ERROR_ZERO_RETURN          && w == SSL_NOTHING)
+    ||  (ec == SSL_ERROR_SSL                  && w == SSL_NOTHING)
+    ||  (ec == SSL_ERROR_SYSCALL              && w == SSL_NOTHING)
+    ||  (ec == SSL_ERROR_WANT_READ            && w == SSL_READING)
+    ||  (ec == SSL_ERROR_WANT_WRITE           && w == SSL_WRITING)
+    ||  (ec == SSL_ERROR_WANT_CLIENT_HELLO_CB && w == SSL_CLIENT_HELLO_CB)
+    ||  (ec == SSL_ERROR_WANT_X509_LOOKUP     && w == SSL_X509_LOOKUP)
+    ||  (ec == SSL_ERROR_WANT_RETRY_VERIFY    && w == SSL_RETRY_VERIFY)
+    );
+
+    if (!ok)
+        TEST_error("got error=%d, want=%d", ec, w);
+
+    return ok;
+}
+
 static int run_script_worker(struct helper *h, const struct script_op *script,
                              const char *script_name,
                              int thread_idx)
@@ -1006,6 +1029,8 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                 connect_started = 1;
 
                 ret = SSL_connect(h->c_conn);
+                if (!check_consistent_want(c_tgt, ret))
+                    goto out;
                 if (ret != 1) {
                     if (!h->blocking && is_want(h->c_conn, ret))
                         SPIN_AGAIN();
@@ -1019,12 +1044,14 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
         case OPK_C_WRITE:
             {
                 size_t bytes_written = 0;
+                int r;
 
                 if (!TEST_ptr(c_tgt))
                     goto out;
 
-                if (!TEST_true(SSL_write_ex(c_tgt, op->arg0, op->arg1,
-                                            &bytes_written))
+                r = SSL_write_ex(c_tgt, op->arg0, op->arg1, &bytes_written);
+                if (!TEST_true(r)
+                    || !check_consistent_want(c_tgt, r)
                     || !TEST_size_t_eq(bytes_written, op->arg1))
                     goto out;
             }
@@ -1078,13 +1105,18 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
         case OPK_C_READ_EXPECT:
             {
                 size_t bytes_read = 0;
+                int r;
 
                 if (op->arg1 > 0 && tmp_buf == NULL
                     && !TEST_ptr(tmp_buf = OPENSSL_malloc(op->arg1)))
                     goto out;
 
-                if (!SSL_read_ex(c_tgt, tmp_buf + offset, op->arg1 - offset,
-                                 &bytes_read))
+                r = SSL_read_ex(c_tgt, tmp_buf + offset, op->arg1 - offset,
+                                &bytes_read);
+                if (!check_consistent_want(c_tgt, r))
+                    goto out;
+
+                if (!r)
                     SPIN_AGAIN();
 
                 if (bytes_read + offset != op->arg1) {
@@ -1136,9 +1168,11 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
             {
                 char buf[1];
                 size_t bytes_read = 0;
+                int r;
 
-                if (!TEST_false(SSL_read_ex(c_tgt, buf, sizeof(buf),
-                                            &bytes_read))
+                r = SSL_read_ex(c_tgt, buf, sizeof(buf), &bytes_read);
+                if (!check_consistent_want(c_tgt, r)
+                    || !TEST_false(r)
                     || !TEST_size_t_eq(bytes_read, 0))
                     goto out;
 
@@ -1147,6 +1181,9 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
 
                 if (!TEST_int_eq(SSL_get_error(c_tgt, 0),
                                  SSL_ERROR_ZERO_RETURN))
+                    goto out;
+
+                if (!TEST_int_eq(SSL_want(c_tgt), SSL_NOTHING))
                     goto out;
             }
             break;
@@ -1443,11 +1480,14 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
         case OPK_C_WRITE_FAIL:
             {
                 size_t bytes_written = 0;
+                int r;
 
                 if (!TEST_ptr(c_tgt))
                     goto out;
 
-                if (!TEST_false(SSL_write_ex(c_tgt, "apple", 5, &bytes_written)))
+                r = SSL_write_ex(c_tgt, "apple", 5, &bytes_written);
+                if (!TEST_false(r)
+                    || !check_consistent_want(c_tgt, r))
                     goto out;
             }
             break;
@@ -1470,11 +1510,15 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
             {
                 size_t bytes_read = 0;
                 char buf[1];
+                int r;
 
                 if (!TEST_ptr(c_tgt))
                     goto out;
 
-                if (!TEST_false(SSL_read_ex(c_tgt, buf, sizeof(buf), &bytes_read)))
+                r = SSL_read_ex(c_tgt, buf, sizeof(buf), &bytes_read);
+                if (!TEST_false(r))
+                    goto out;
+                if (!check_consistent_want(c_tgt, r))
                     goto out;
             }
             break;
@@ -1483,11 +1527,15 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
             {
                 size_t bytes_read = 0;
                 char buf[1];
+                int r;
 
                 if (!TEST_ptr(c_tgt))
                     goto out;
 
-                if (!TEST_false(SSL_read_ex(c_tgt, buf, sizeof(buf), &bytes_read)))
+                r = SSL_read_ex(c_tgt, buf, sizeof(buf), &bytes_read);
+                if (!TEST_false(r))
+                    goto out;
+                if (!check_consistent_want(c_tgt, r))
                     goto out;
 
                 if (is_want(c_tgt, 0))
@@ -1578,6 +1626,8 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
         case OPK_C_EXPECT_SSL_ERR:
             {
                 if (!TEST_size_t_eq((size_t)SSL_get_error(c_tgt, 0), op->arg1))
+                    goto out;
+                if (!TEST_int_eq(SSL_want(c_tgt), SSL_NOTHING))
                     goto out;
             }
             break;


### PR DESCRIPTION
This adds support for SSL_want. It also sets the last error variable on successful execution of any 'I/O' function, not just on failure.

We still need to decide what to do about
- `SSL_RETRY_VERIFY`
- `SSL_X509_LOOKUP`
- `SSL_CLIENT_HELLO_CB`

which are not currently supported by the QUIC_TLS code.

```
30730c8416 QUIC MULTISTREAM TEST: Test SSL_want for consistency with SSL_get_error
738ffea096 QUIC APL: Implement SSL_want
66ff948d30 QUIC APL: Revise I/O error setting so that the last error is set on success
f1ac737d91 QUIC APL: Adjust expect_quic_conn_only
```

Fixes https://github.com/openssl/project/issues/197