### PR TITLE
Move ALIGN32 and ALIGN64 into common.h, and fix for clang-cl.exe

### DIFF
--- a/crypto/bn/rsaz_exp.c
+++ b/crypto/bn/rsaz_exp.c
@@ -13,6 +13,7 @@
  */
 
 #include <openssl/opensslconf.h>
+#include "internal/common.h"
 #include "rsaz_exp.h"
 
 #ifndef RSAZ_ENABLED
@@ -31,16 +32,8 @@ void rsaz_1024_scatter5_avx2(void *tbl, const void *val, int i);
 void rsaz_1024_gather5_avx2(void *val, const void *tbl, int i);
 void rsaz_1024_red2norm_avx2(void *norm, const void *red);
 
-#if defined(__GNUC__)
-# define ALIGN64        __attribute__((aligned(64)))
-#elif defined(_MSC_VER)
-# define ALIGN64        __declspec(align(64))
-#elif defined(__SUNPRO_C)
-# define ALIGN64
+#if defined(__SUNPRO_C)
 # pragma align 64(one,two80)
-#else
-/* not fatal, might hurt performance a little */
-# define ALIGN64
 #endif
 
 ALIGN64 static const BN_ULONG one[40] = {

--- a/crypto/ec/ecp_nistz256.c
+++ b/crypto/ec/ecp_nistz256.c
@@ -37,14 +37,6 @@
 # define TOBN(hi,lo)    ((BN_ULONG)hi<<32|lo)
 #endif
 
-#if defined(__GNUC__)
-# define ALIGN32        __attribute((aligned(32)))
-#elif defined(_MSC_VER)
-# define ALIGN32        __declspec(align(32))
-#else
-# define ALIGN32
-#endif
-
 #define ALIGNPTR(p,N)   ((unsigned char *)p+N-(size_t)p%N)
 #define P256_LIMBS      (256/BN_BITS2)
 

--- a/crypto/ec/ecp_sm2p256.c
+++ b/crypto/ec/ecp_sm2p256.c
@@ -18,18 +18,8 @@
 #include <openssl/err.h>
 #include "crypto/bn.h"
 #include "ec_local.h"
+#include "internal/common.h"
 #include "internal/constant_time.h"
-
-#if defined(__GNUC__)
-# define ALIGN32 __attribute((aligned(32)))
-# define ALIGN64 __attribute((aligned(64)))
-#elif defined(_MSC_VER)
-# define ALIGN32 __declspec(align(32))
-# define ALIGN64 __declspec(align(64))
-#else
-# define ALIGN32
-# define ALIGN64
-#endif
 
 #define P256_LIMBS (256 / BN_BITS2)
 

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -18,17 +18,28 @@
 # include "internal/e_os.h" /* ossl_inline in many files */
 # include "internal/nelem.h"
 
-#if defined(__GNUC__) || defined(__clang__)
-    #define likely(x) __builtin_expect(!!(x), 1)
-    #define unlikely(x) __builtin_expect(!!(x), 0)
-#else
-    #define likely(x) x
-    #define unlikely(x) x
-#endif
+# if defined(__GNUC__) || defined(__clang__)
+#  define likely(x)     __builtin_expect(!!(x), 1)
+#  define unlikely(x)   __builtin_expect(!!(x), 0)
+# else
+#  define likely(x)     x
+#  define unlikely(x)   x
+# endif
 
-#ifdef NDEBUG
-# define ossl_assert(x) ((x) != 0)
-#else
+# if defined(__GNUC__) || defined(__clang__)
+#  define ALIGN32       __attribute((aligned(32)))
+#  define ALIGN64       __attribute((aligned(64)))
+# elif defined(_MSC_VER)
+#  define ALIGN32       __declspec(align(32))
+#  define ALIGN64       __declspec(align(64))
+# else
+#  define ALIGN32
+#  define ALIGN64
+# endif
+
+# ifdef NDEBUG
+#  define ossl_assert(x) ((x) != 0)
+# else
 __owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
                                               const char *file, int line)
 {
@@ -38,10 +49,10 @@ __owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
     return expr;
 }
 
-# define ossl_assert(x) ossl_assert_int((x) != 0, "Assertion failed: "#x, \
+#  define ossl_assert(x) ossl_assert_int((x) != 0, "Assertion failed: "#x, \
                                          __FILE__, __LINE__)
 
-#endif
+# endif
 
 /* Check if |pre|, which must be a string literal, is a prefix of |str| */
 #define HAS_PREFIX(str, pre) (strncmp(str, pre "", sizeof(pre) - 1) == 0)


### PR DESCRIPTION
clang-cl.exe defines __clang__ and _MSC_VER but not __GNUC__, so a clang- specific guard is needed to get the correct ALIGNxx versions.

Fixes #21914

As requested [by @paulidale in this comment](https://github.com/openssl/openssl/pull/20754#discussion_r1278672599).

But also fixes the build issue noted in [this comment](https://github.com/openssl/openssl/issues/21874#issuecomment-1700674561) (which is what I separated out into #21914)

Note that rather than `e_os.h`, I've put them in `common.h` - they are not "O/S" things, and I've added them after the "likely" macros, and both are compiler things, so `common.h` seems reasonable.

I've also updated the whitespace in the two sections before and after, so that it matches how we normally do things.