### PR TITLE
Handle non IO based retry errors in QUIC

### DIFF
--- a/doc/designs/quic-design/quic-fault-injector.md
+++ b/doc/designs/quic-design/quic-fault-injector.md
@@ -229,6 +229,13 @@ void ossl_quic_fault_free(OSSL_QUIC_FAULT *fault);
 int qtest_create_quic_connection(QUIC_TSERVER *qtserv, SSL *clientssl);
 
 /*
+ * Same as qtest_create_quic_connection but will stop (successfully) if the
+ * clientssl indicates SSL_ERROR_WANT_XXX as specified by |wanterr|
+ */
+int qtest_create_quic_connection_ex(QUIC_TSERVER *qtserv, SSL *clientssl,
+                                    int wanterr);
+
+/*
  * Confirm that the server has received the given transport error code.
  */
 int qtest_check_server_transport_err(QUIC_TSERVER *qtserv, uint64_t code);

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -798,6 +798,9 @@ int ossl_quic_tls_tick(QUIC_TLS *qtls)
         switch (err) {
         case SSL_ERROR_WANT_READ:
         case SSL_ERROR_WANT_WRITE:
+        case SSL_ERROR_WANT_CLIENT_HELLO_CB:
+        case SSL_ERROR_WANT_X509_LOOKUP:
+        case SSL_ERROR_WANT_RETRY_VERIFY:
             ERR_pop_to_mark();
             return 1;
 

--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -239,6 +239,7 @@ int qtest_supports_blocking(void)
 
 #if defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG)
 static int globserverret = 0;
+static TSAN_QUALIFIER int abortserverthread = 0;
 static QUIC_TSERVER *globtserv;
 static const thread_t thread_zero;
 
@@ -253,7 +254,8 @@ static void run_server_thread(void)
 }
 #endif
 
-int qtest_create_quic_connection(QUIC_TSERVER *qtserv, SSL *clientssl)
+int qtest_create_quic_connection_ex(QUIC_TSERVER *qtserv, SSL *clientssl,
+                                    int wanterr)
 {
     int retc = -1, rets = 0, abortctr = 0, ret = 0;
     int clienterr = 0, servererr = 0;
@@ -264,6 +266,9 @@ int qtest_create_quic_connection(QUIC_TSERVER *qtserv, SSL *clientssl)
      */
     thread_t t = thread_zero;
 #endif
+
+    if (clientssl != NULL)
+        abortserverthread = 0;
 
     if (!TEST_ptr(qtserv)) {
         goto err;
@@ -295,10 +300,19 @@ int qtest_create_quic_connection(QUIC_TSERVER *qtserv, SSL *clientssl)
             if (retc <= 0) {
                 err = SSL_get_error(clientssl, retc);
 
-                if (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE) {
-                    TEST_info("SSL_connect() failed %d, %d", retc, err);
-                    TEST_openssl_errors();
-                    clienterr = 1;
+                if (err == wanterr) {
+                    retc = 1;
+                    if (qtserv == NULL && rets > 0)
+                        tsan_store(&abortserverthread, 1);
+                    else
+                        rets = 1;
+                } else {
+                    if (err != SSL_ERROR_WANT_READ
+                            && err != SSL_ERROR_WANT_WRITE) {
+                        TEST_info("SSL_connect() failed %d, %d", retc, err);
+                        TEST_openssl_errors();
+                        clienterr = 1;
+                    }
                 }
             }
         }
@@ -312,6 +326,7 @@ int qtest_create_quic_connection(QUIC_TSERVER *qtserv, SSL *clientssl)
          */
         if (!clienterr && retc <= 0)
             SSL_handle_events(clientssl);
+
         if (!servererr && rets <= 0) {
             qtest_add_time(1);
             ossl_quic_tserver_tick(qtserv);
@@ -327,7 +342,8 @@ int qtest_create_quic_connection(QUIC_TSERVER *qtserv, SSL *clientssl)
             TEST_info("No progress made");
             goto err;
         }
-    } while ((retc <= 0 && !clienterr) || (rets <= 0 && !servererr));
+    } while ((retc <= 0 && !clienterr)
+             || (rets <= 0 && !servererr && !tsan_load(&abortserverthread)));
 
     if (qtserv == NULL && rets > 0) {
 #if defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG)
@@ -343,6 +359,11 @@ int qtest_create_quic_connection(QUIC_TSERVER *qtserv, SSL *clientssl)
         ret = 1;
  err:
     return ret;
+}
+
+int qtest_create_quic_connection(QUIC_TSERVER *qtserv, SSL *clientssl)
+{
+    return qtest_create_quic_connection_ex(qtserv, clientssl, SSL_ERROR_NONE);
 }
 
 #if defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG)

--- a/test/helpers/quictestlib.h
+++ b/test/helpers/quictestlib.h
@@ -63,6 +63,13 @@ int qtest_supports_blocking(void);
 int qtest_create_quic_connection(QUIC_TSERVER *qtserv, SSL *clientssl);
 
 /*
+ * Same as qtest_create_quic_connection but will stop (successfully) if the
+ * clientssl indicates SSL_ERROR_WANT_XXX as specified by |wanterr|
+ */
+int qtest_create_quic_connection_ex(QUIC_TSERVER *qtserv, SSL *clientssl,
+                                    int wanterr);
+
+/*
  * Shutdown the client SSL object gracefully
  */
 int qtest_shutdown(QUIC_TSERVER *qtserv, SSL *clientssl);


### PR DESCRIPTION
SSL_get_error() may respond with some retry errors that are not IO related.
In particular SSL_ERROR_WANT_RETRY_VERIFY and SSL_ERROR_WANT_X509_LOOKUP.
These can occur during a TLS handshake. If they occur when a QUIC Connection
is performing a TLS handshake then we need to propagate these up to the QCSO.

We also handle SSL_ERROR_WANT_CLIENT_HELLO_CB. This one will only ever
occur on the server side which we don't currently support. However adding
the handling for it now is identical to all the other handling so including
it is no cost, and will be needed when we do add server support.

We are not concerned with SSL_ERROR_WANT_ASYNC or SSL_ERROR_WANT_ASYNC_JOB
since we do not support async operation with QUIC.

Fixes https://github.com/openssl/project/issues/199

This is built on top of #21915
