### PR TITLE
Fix typo in openssl-pkeyutl(1)

### DIFF
--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -301,7 +301,7 @@ These have the same meaning as the B<RSA> algorithm with some additional
 restrictions. The padding mode can only be set to B<pss> which is the
 default value.
 
-If the key has parameter restrictions than the digest, MGF1
+If the key has parameter restrictions then the digest, MGF1
 digest and salt length are set to the values specified in the parameters.
 The digest and MG cannot be changed and the salt length cannot be set to a
 value less than the minimum restriction.


### PR DESCRIPTION
Changed "than" to "then" for improved clarity and correctness.

CLA: trivial

Fixes #21543