### PR TITLE
Mitigate buffer overflow issue in SSL_get_shared_ciphers()

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3397,14 +3397,14 @@ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int size)
         if (sk_SSL_CIPHER_find(srvrsk, c) < 0)
             continue;
 
-        n = strlen(c->name);
-        if (n + 1 > size) {
+        n = OPENSSL_strnlen(c->name, size);
+        if (n >= size) {
             if (p != buf)
                 --p;
             *p = '\0';
             return buf;
         }
-        strcpy(p, c->name);
+        memcpy(p, c->name, n);
         p += n;
         *(p++) = ':';
         size -= n + 1;


### PR DESCRIPTION
Replace strcpy() with strncpy() in the SSL_get_shared_ciphers() function to prevent potential buffer overflow issues. strncpy() now checks the length of the cipher name and ensures it doesn't exceed the buffer size.

CLA: trivial

Fixes #19837

