### PR TITLE
Fix segfault if OSSL_PARAM_BLD_push_BN_pad() is called with NULL BN

### DIFF
--- a/crypto/param_build.c
+++ b/crypto/param_build.c
@@ -233,8 +233,8 @@ static int push_BN(OSSL_PARAM_BLD *bld, const char *key,
 int OSSL_PARAM_BLD_push_BN(OSSL_PARAM_BLD *bld, const char *key,
                            const BIGNUM *bn)
 {
-    if (BN_is_negative(bn))
-        return push_BN(bld, key, bn, bn == NULL ? 0 : BN_num_bytes(bn) + 1,
+    if (bn != NULL && BN_is_negative(bn))
+        return push_BN(bld, key, bn, BN_num_bytes(bn) + 1,
                        OSSL_PARAM_INTEGER);
     return push_BN(bld, key, bn, bn == NULL ? 0 : BN_num_bytes(bn),
                    OSSL_PARAM_UNSIGNED_INTEGER);
@@ -243,8 +243,8 @@ int OSSL_PARAM_BLD_push_BN(OSSL_PARAM_BLD *bld, const char *key,
 int OSSL_PARAM_BLD_push_BN_pad(OSSL_PARAM_BLD *bld, const char *key,
                                const BIGNUM *bn, size_t sz)
 {
-    if (BN_is_negative(bn))
-        return push_BN(bld, key, bn, bn == NULL ? 0 : BN_num_bytes(bn),
+    if (bn != NULL && BN_is_negative(bn))
+        return push_BN(bld, key, bn, BN_num_bytes(bn),
                        OSSL_PARAM_INTEGER);
     return push_BN(bld, key, bn, sz, OSSL_PARAM_UNSIGNED_INTEGER);
 }

--- a/test/param_build_test.c
+++ b/test/param_build_test.c
@@ -16,7 +16,7 @@
 
 static const OSSL_PARAM params_empty[] = { OSSL_PARAM_END };
 
-static int template_public_single_zero_test(void)
+static int template_public_single_zero_test(int idx)
 {
     OSSL_PARAM_BLD *bld = NULL;
     OSSL_PARAM *params = NULL, *params_blt = NULL, *p;
@@ -25,7 +25,8 @@ static int template_public_single_zero_test(void)
 
     if (!TEST_ptr(bld = OSSL_PARAM_BLD_new())
         || !TEST_ptr(zbn = BN_new())
-        || !TEST_true(OSSL_PARAM_BLD_push_BN(bld, "zeronumber", zbn))
+        || !TEST_true(OSSL_PARAM_BLD_push_BN(bld, "zeronumber",
+                                             idx == 0 ? zbn : NULL))
         || !TEST_ptr(params_blt = OSSL_PARAM_BLD_to_param(bld)))
         goto err;
 
@@ -550,7 +551,7 @@ err:
 
 int setup_tests(void)
 {
-    ADD_TEST(template_public_single_zero_test);
+    ADD_ALL_TESTS(template_public_single_zero_test, 2);
     ADD_ALL_TESTS(template_public_test, 5);
     /* Only run the secure memory testing if we have secure memory available */
     if (CRYPTO_secure_malloc_init(1<<16, 16)) {


### PR DESCRIPTION
Related to #21935

This fixes the segfault on the master branch but there is still one remaining issue which is on all branches.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
