### PR TITLE
Diverse VMS fixes

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -211,7 +211,10 @@
   # format, relative to the directory where the .c file is located.  The logic
   # is that any inclusion, merged with one of these relative directories, will
   # find the requested inclusion file.
-  foreach (grep /\[\.crypto\.async\.arch\].*\.o$/, keys %{$unified_info{sources}}) {
+  # In the regexps, it's advisable to always start the file name with .*?, as
+  # the C source to OBJ file translation adds stuff at the beginning of the,
+  # name, such as [.ssl]bio_ssl.c -> [.ssl]libssl-shlib-bio_ssl.OBJ
+  foreach (grep /\[\.crypto\.async\.arch\].*?\.o$/, keys %{$unified_info{sources}}) {
       my $obj = platform->obj($_);
       push @{$unified_info{includes_extra}->{$obj}}, qw(../);
   }
@@ -229,15 +232,14 @@
       # like "record/record.h".  Adding "./" as an inclusion directory helps
       # making this sort of header from these directories.
       push @{$unified_info{includes_extra}->{$obj}}, qw(./);
-  }
-  foreach (grep /\[\.ssl\].*?ssl_lib\.o$/, keys %{$unified_info{sources}}) {
-      my $obj = platform->obj($_);
-      # Some files in [.ssl] include "quic/quic_local.h", which in turn
-      # includes "../ssl_local.h".  Adding "./quic" as an inclusion directory
-      # helps making this sort of header from these directories.
+
+      # Additionally, an increasing amount of files in [.ssl] include
+      # "quic/quic_local.h", which in turn includes "../ssl_local.h".  Adding
+      # "./quic" as an inclusion directory helps making this sort of header
+      # from these directories.
       push @{$unified_info{includes_extra}->{$obj}}, qw(./quic);
   }
-  foreach (grep /\[\.ssl\.(?:record|statem)\].*?\.o$/, keys %{$unified_info{sources}}) {
+  foreach (grep /\[\.ssl\.(?:quic|record|statem)\].*?\.o$/, keys %{$unified_info{sources}}) {
       my $obj = platform->obj($_);
       # Most of the files in [.ssl.record] and [.ssl.statem] include
       # "../ssl_local.h", which includes things like "record/record.h".
@@ -251,8 +253,10 @@
       # Most of the files in [.ssl.record.methods] include "../../ssl_local.h"
       # which includes things like "record/record.h".  Adding "../../" as an
       # inclusion directory helps making this sort of header from these
-      # directories.
-      push @{$unified_info{includes_extra}->{$obj}}, qw(../../);
+      # directories.  But this gets worse; through a series of inclusions,
+      # all of them based on the relative directory of the object file, there's
+      # a need to deal with an inclusion of "../ssl_local.h" as well.
+      push @{$unified_info{includes_extra}->{$obj}}, qw(../../), qw(../);
   }
   foreach (grep /\[\.test\].*?\.o$/, keys %{$unified_info{sources}}) {
       my $obj = platform->obj($_);
@@ -264,6 +268,10 @@
       # directly, but that would end up with more whack-a-mole of this sort, so
       # nah, we do it broadly.
       push @{$unified_info{includes_extra}->{$obj}}, qw(../ssl/record/methods);
+      # Similarly, some include "../ssl/ssl_local.h", and somewhere down the
+      # line, "quic/quic_local.h" gets included, which includes "../ssl_local.h"
+      # The problem is fixed by adding ../ssl/quic too.
+      push @{$unified_info{includes_extra}->{$obj}}, qw(../ssl/quic);
   }
   foreach (grep /\[\.test\.helpers\].*?\.o$/, keys %{$unified_info{sources}}) {
       my $obj = platform->obj($_);

--- a/include/internal/numbers.h
+++ b/include/internal/numbers.h
@@ -61,6 +61,31 @@
 #  define UINT64_MAX __MAXUINT__(uint64_t)
 # endif
 
+/*
+ * 64-bit processor with LP64 ABI
+ */
+# ifdef SIXTY_FOUR_BIT_LONG
+#  ifndef UINT32_C
+#   define UINT32_C(c) (c)
+#  endif
+#  ifndef UINT64_C
+#   define UINT64_C(c) (c##UL)
+#  endif
+# endif
+
+/*
+ * 64-bit processor other than LP64 ABI
+ */
+# ifdef SIXTY_FOUR_BIT
+#  ifndef UINT32_C
+#   define UINT32_C(c) (c##UL)
+#  endif
+#  ifndef UINT64_C
+#   define UINT64_C(c) (c##ULL)
+#  endif
+# endif
+
+
 # ifndef INT128_MAX
 #  if defined(__SIZEOF_INT128__) && __SIZEOF_INT128__ == 16
 typedef __int128_t int128_t;

--- a/include/internal/sockets.h
+++ b/include/internal/sockets.h
@@ -89,6 +89,9 @@ struct servent *PASCAL getservbyname(const char *, const char *);
 #  endif
 
 #  include <netdb.h>
+#  if defined(OPENSSL_SYS_VMS)
+typedef size_t socklen_t;        /* Currently appears to be missing on VMS */
+#  endif
 #  if defined(OPENSSL_SYS_VMS_NODECC)
 #   include <socket.h>
 #   include <in.h>

--- a/ssl/quic/quic_cfq.c
+++ b/ssl/quic/quic_cfq.c
@@ -8,6 +8,7 @@
  */
 
 #include "internal/quic_cfq.h"
+#include "internal/numbers.h"
 
 typedef struct quic_cfq_item_ex_st QUIC_CFQ_ITEM_EX;
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -18,6 +18,7 @@
 #if defined(OPENSSL_THREADS)
 # include "internal/thread_arch.h"
 #endif
+#include "internal/numbers.h"  /* UINT64_C */
 
 static const char *certfile, *keyfile;
 


### PR DESCRIPTION
- VMS: More header inclusion compensation for VMS C compiler
- VMS: Add a fallback definition of socklen_t
- Include #include "internal/numbers.h" in ssl/quic/quic_cfq.c
- internal/numbers.h: Add fallback implementation for UINT32_C and UINT64_C
