### PR TITLE
04-test_encoder_decoder.t: Use algorithm that is non-fips also on 3.0.0

### DIFF
--- a/test/recipes/04-test_encoder_decoder.t
+++ b/test/recipes/04-test_encoder_decoder.t
@@ -50,10 +50,10 @@ unless ($no_fips) {
 
     my $no_des = disabled("des");
 SKIP: {
-    skip "DES disabled", 2 if disabled("des");
-    ok(run(app([ 'openssl', 'genrsa', '-des3', '-out', 'epki.pem',
-                 '-passout', 'pass:pass' ])),
-       "rsa encrypt using a non fips algorithm");
+    skip "MD5 disabled", 2 if disabled("md5");
+    ok(run(app([ 'openssl', 'genrsa', '-aes128', '-out', 'epki.pem',
+                 '-traditional', '-passout', 'pass:pass' ])),
+       "rsa encrypted using a non fips algorithm MD5 in pbe");
 
     my $conf2 = srctop_file("test", "default-and-fips.cnf");
     ok(run(test(['decoder_propq_test', '-config', $conf2,


### PR DESCRIPTION
The test encrypted RSA key with DES3 which is still allowed in the 3.0 fips provider.

Instead use the traditional key format that uses MD5 to create the password based key. MD5 is disallowed in the 3.0 fips provider.

This should fix Provider compatibility CI:
https://github.com/openssl/openssl/actions/runs/6075083978/job/16480942800

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
