### PR TITLE
quicserver.c: Fix build with no-ssl-trace

### DIFF
--- a/util/quicserver.c
+++ b/util/quicserver.c
@@ -217,7 +217,12 @@ int main(int argc, char *argv[])
     bio = NULL;
 
     if (trace)
+#ifndef OPENSSL_NO_SSL_TRACE
         ossl_quic_tserver_set_msg_callback(qtserv, SSL_trace, bio_err);
+#else
+        BIO_printf(bio_err,
+                   "Warning: -trace specified but no SSL tracing support present\n");
+#endif
 
     /* Wait for handshake to complete */
     ossl_quic_tserver_tick(qtserv);


### PR DESCRIPTION
Marking as urgent as this is needed to fix https://github.com/openssl/openssl/actions/runs/6069710453/job/16464523594
