### PR TITLE
Bind provider search property to ssl object

### DIFF
--- a/doc/man3/SSL_new.pod
+++ b/doc/man3/SSL_new.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-SSL_dup, SSL_new, SSL_up_ref - create an SSL structure for a connection
+SSL_dup, SSL_new, SSL_new_ex, SSL_up_ref - create an SSL structure for a connection
 
 =head1 SYNOPSIS
 
@@ -10,12 +10,15 @@ SSL_dup, SSL_new, SSL_up_ref - create an SSL structure for a connection
 
  SSL *SSL_dup(SSL *s);
  SSL *SSL_new(SSL_CTX *ctx);
+ SSL *SSL_new_ex(SSL_CTX *ctx, const char* propq);
  int SSL_up_ref(SSL *s);
 
 =head1 DESCRIPTION
 
-SSL_new() creates a new B<SSL> structure which is needed to hold the
-data for a TLS/SSL connection. The new structure inherits the settings
+SSL_new() and SSL_new_ex() creates a new B<SSL> structure which is needed to hold the
+data for a TLS/SSL connection. Using SSL_new_ex() allows the user to define the 
+provider search property used by the SSL object.
+The new structure inherits the settings
 of the underlying context B<ctx>: connection method,
 options, verification settings, timeout settings. An B<SSL> structure is
 reference counted. Creating an B<SSL> structure for the first time increments

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -1796,6 +1796,7 @@ __owur int SSL_CTX_set_session_id_context(SSL_CTX *ctx,
                                           const unsigned char *sid_ctx,
                                           unsigned int sid_ctx_len);
 
+SSL *SSL_new_ex(SSL_CTX *ctx, const char* propq);
 SSL *SSL_new(SSL_CTX *ctx);
 int SSL_up_ref(SSL *s);
 int SSL_is_dtls(const SSL *s);

--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -30,8 +30,8 @@ static int ssl3_generate_key_block(SSL_CONNECTION *s, unsigned char *km, int num
     c = os_toascii[c];          /* 'A' in ASCII */
 #endif
     k = 0;
-    md5 = ssl_evp_md_fetch(sctx->libctx, NID_md5, sctx->propq);
-    sha1 = ssl_evp_md_fetch(sctx->libctx, NID_sha1, sctx->propq);
+    md5 = ssl_evp_md_fetch(sctx->libctx, NID_md5, SSL_CONNECTION_PROV_QUERRY(s));
+    sha1 = ssl_evp_md_fetch(sctx->libctx, NID_sha1, SSL_CONNECTION_PROV_QUERRY(s));
     m5 = EVP_MD_CTX_new();
     s1 = EVP_MD_CTX_new();
     if (md5 == NULL || sha1 == NULL || m5 == NULL || s1 == NULL) {

--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -30,8 +30,8 @@ static int ssl3_generate_key_block(SSL_CONNECTION *s, unsigned char *km, int num
     c = os_toascii[c];          /* 'A' in ASCII */
 #endif
     k = 0;
-    md5 = ssl_evp_md_fetch(sctx->libctx, NID_md5, SSL_CONNECTION_PROV_QUERRY(s));
-    sha1 = ssl_evp_md_fetch(sctx->libctx, NID_sha1, SSL_CONNECTION_PROV_QUERRY(s));
+    md5 = ssl_evp_md_fetch(sctx->libctx, NID_md5, ssl_connection_prov_querry(s));
+    sha1 = ssl_evp_md_fetch(sctx->libctx, NID_sha1, ssl_connection_prov_querry(s));
     m5 = EVP_MD_CTX_new();
     s1 = EVP_MD_CTX_new();
     if (md5 == NULL || sha1 == NULL || m5 == NULL || s1 == NULL) {

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4747,7 +4747,7 @@ EVP_PKEY *ssl_generate_pkey(SSL_CONNECTION *s, EVP_PKEY *pm)
 
     if (pm == NULL)
         return NULL;
-    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, pm, sctx->propq);
+    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, pm, SSL_CONNECTION_PROV_QUERRY(s));
     if (pctx == NULL)
         goto err;
     if (EVP_PKEY_keygen_init(pctx) <= 0)
@@ -4776,7 +4776,7 @@ EVP_PKEY *ssl_generate_pkey_group(SSL_CONNECTION *s, uint16_t id)
     }
 
     pctx = EVP_PKEY_CTX_new_from_name(sctx->libctx, ginf->algorithm,
-                                      sctx->propq);
+                                      SSL_CONNECTION_PROV_QUERRY(s));
 
     if (pctx == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
@@ -4815,7 +4815,7 @@ EVP_PKEY *ssl_generate_param_group(SSL_CONNECTION *s, uint16_t id)
         goto err;
 
     pctx = EVP_PKEY_CTX_new_from_name(sctx->libctx, ginf->algorithm,
-                                      sctx->propq);
+                                      SSL_CONNECTION_PROV_QUERRY(s));
 
     if (pctx == NULL)
         goto err;
@@ -4875,7 +4875,7 @@ int ssl_derive(SSL_CONNECTION *s, EVP_PKEY *privkey, EVP_PKEY *pubkey, int gense
         return 0;
     }
 
-    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, privkey, sctx->propq);
+    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, privkey, SSL_CONNECTION_PROV_QUERRY(s));
 
     if (EVP_PKEY_derive_init(pctx) <= 0
         || EVP_PKEY_derive_set_peer(pctx, pubkey) <= 0
@@ -4931,7 +4931,7 @@ int ssl_decapsulate(SSL_CONNECTION *s, EVP_PKEY *privkey,
         return 0;
     }
 
-    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, privkey, sctx->propq);
+    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, privkey, SSL_CONNECTION_PROV_QUERRY(s));
 
     if (EVP_PKEY_decapsulate_init(pctx, NULL) <= 0
             || EVP_PKEY_decapsulate(pctx, NULL, &pmslen, ct, ctlen) <= 0) {
@@ -4982,7 +4982,7 @@ int ssl_encapsulate(SSL_CONNECTION *s, EVP_PKEY *pubkey,
         return 0;
     }
 
-    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, pubkey, sctx->propq);
+    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, pubkey, SSL_CONNECTION_PROV_QUERRY(s));
 
     if (EVP_PKEY_encapsulate_init(pctx, NULL) <= 0
             || EVP_PKEY_encapsulate(pctx, NULL, &ctlen, NULL, &pmslen) <= 0

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4747,7 +4747,7 @@ EVP_PKEY *ssl_generate_pkey(SSL_CONNECTION *s, EVP_PKEY *pm)
 
     if (pm == NULL)
         return NULL;
-    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, pm, SSL_CONNECTION_PROV_QUERRY(s));
+    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, pm, ssl_connection_prov_querry(s));
     if (pctx == NULL)
         goto err;
     if (EVP_PKEY_keygen_init(pctx) <= 0)
@@ -4776,7 +4776,7 @@ EVP_PKEY *ssl_generate_pkey_group(SSL_CONNECTION *s, uint16_t id)
     }
 
     pctx = EVP_PKEY_CTX_new_from_name(sctx->libctx, ginf->algorithm,
-                                      SSL_CONNECTION_PROV_QUERRY(s));
+                                      ssl_connection_prov_querry(s));
 
     if (pctx == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
@@ -4815,7 +4815,7 @@ EVP_PKEY *ssl_generate_param_group(SSL_CONNECTION *s, uint16_t id)
         goto err;
 
     pctx = EVP_PKEY_CTX_new_from_name(sctx->libctx, ginf->algorithm,
-                                      SSL_CONNECTION_PROV_QUERRY(s));
+                                      ssl_connection_prov_querry(s));
 
     if (pctx == NULL)
         goto err;
@@ -4875,7 +4875,7 @@ int ssl_derive(SSL_CONNECTION *s, EVP_PKEY *privkey, EVP_PKEY *pubkey, int gense
         return 0;
     }
 
-    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, privkey, SSL_CONNECTION_PROV_QUERRY(s));
+    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, privkey, ssl_connection_prov_querry(s));
 
     if (EVP_PKEY_derive_init(pctx) <= 0
         || EVP_PKEY_derive_set_peer(pctx, pubkey) <= 0
@@ -4931,7 +4931,7 @@ int ssl_decapsulate(SSL_CONNECTION *s, EVP_PKEY *privkey,
         return 0;
     }
 
-    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, privkey, SSL_CONNECTION_PROV_QUERRY(s));
+    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, privkey, ssl_connection_prov_querry(s));
 
     if (EVP_PKEY_decapsulate_init(pctx, NULL) <= 0
             || EVP_PKEY_decapsulate(pctx, NULL, &pmslen, ct, ctlen) <= 0) {
@@ -4982,7 +4982,7 @@ int ssl_encapsulate(SSL_CONNECTION *s, EVP_PKEY *pubkey,
         return 0;
     }
 
-    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, pubkey, SSL_CONNECTION_PROV_QUERRY(s));
+    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, pubkey, ssl_connection_prov_querry(s));
 
     if (EVP_PKEY_encapsulate_init(pctx, NULL) <= 0
             || EVP_PKEY_encapsulate(pctx, NULL, &ctlen, NULL, &pmslen) <= 0

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -437,7 +437,7 @@ static int ssl_verify_internal(SSL_CONNECTION *s, STACK_OF(X509) *sk, EVP_PKEY *
     else
         verify_store = sctx->cert_store;
 
-    ctx = X509_STORE_CTX_new_ex(sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s));
+    ctx = X509_STORE_CTX_new_ex(sctx->libctx, ssl_connection_prov_querry(s));
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_SSL, ERR_R_X509_LIB);
         return 0;
@@ -1023,7 +1023,7 @@ int ssl_build_cert_chain(SSL_CONNECTION *s, SSL_CTX *ctx, int flags)
             untrusted = cpk->chain;
     }
 
-    xs_ctx = X509_STORE_CTX_new_ex(real_ctx->libctx, (s != NULL ? SSL_CONNECTION_PROV_QUERRY(s) : real_ctx->propq));
+    xs_ctx = X509_STORE_CTX_new_ex(real_ctx->libctx, (s != NULL ? ssl_connection_prov_querry(s) : real_ctx->propq));
     if (xs_ctx == NULL) {
         ERR_raise(ERR_LIB_SSL, ERR_R_X509_LIB);
         goto err;

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -437,7 +437,7 @@ static int ssl_verify_internal(SSL_CONNECTION *s, STACK_OF(X509) *sk, EVP_PKEY *
     else
         verify_store = sctx->cert_store;
 
-    ctx = X509_STORE_CTX_new_ex(sctx->libctx, sctx->propq);
+    ctx = X509_STORE_CTX_new_ex(sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s));
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_SSL, ERR_R_X509_LIB);
         return 0;
@@ -1023,7 +1023,7 @@ int ssl_build_cert_chain(SSL_CONNECTION *s, SSL_CTX *ctx, int flags)
             untrusted = cpk->chain;
     }
 
-    xs_ctx = X509_STORE_CTX_new_ex(real_ctx->libctx, real_ctx->propq);
+    xs_ctx = X509_STORE_CTX_new_ex(real_ctx->libctx, (s != NULL ? SSL_CONNECTION_PROV_QUERRY(s) : real_ctx->propq));
     if (xs_ctx == NULL) {
         ERR_raise(ERR_LIB_SSL, ERR_R_X509_LIB);
         goto err;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3049,7 +3049,7 @@ long ossl_ctrl_internal(SSL *s, int cmd, long larg, void *parg, int no_quic)
     }
 }
 
-const char *ssl_connection_prov_querry(SSL_CONNECTION *ssl_conn)
+const char *ssl_connection_prov_querry(const SSL_CONNECTION *ssl_conn)
 {
     /* Return propq from SSL object prior when set,
      * otherwise use the SSL_CTX propq.

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1203,6 +1203,7 @@ struct ssl_st {
     CRYPTO_RWLOCK *lock;
     /* extra application data */
     CRYPTO_EX_DATA ex_data;
+    char *propq;
 };
 
 struct ssl_connection_st {
@@ -1815,6 +1816,13 @@ struct ssl_connection_st {
     SSL_CONNECTION_FROM_SSL_ONLY_int(ssl, const)
 # define SSL_CONNECTION_GET_CTX(sc) ((sc)->ssl.ctx)
 # define SSL_CONNECTION_GET_SSL(sc) (&(sc)->ssl)
+# define SSL_CONNECTION_PROV_QUERRY(spq) \
+      (spq != NULL ? \
+          (SSL_CONNECTION_GET_SSL(spq) && SSL_CONNECTION_GET_SSL(spq)->propq != NULL ? \
+          SSL_CONNECTION_GET_SSL(spq)->propq : SSL_CONNECTION_GET_CTX(spq)->propq) : NULL)
+# define SSL_PROV_QUERRY(s) \
+      (s != NULL ? (s->propq ? s->propq : s->ctx->propq) : NULL)
+
 # ifndef OPENSSL_NO_QUIC
 #  include "quic/quic_local.h"
 #  define SSL_CONNECTION_FROM_SSL_int(ssl, c)                      \

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1816,12 +1816,8 @@ struct ssl_connection_st {
     SSL_CONNECTION_FROM_SSL_ONLY_int(ssl, const)
 # define SSL_CONNECTION_GET_CTX(sc) ((sc)->ssl.ctx)
 # define SSL_CONNECTION_GET_SSL(sc) (&(sc)->ssl)
-# define SSL_CONNECTION_PROV_QUERRY(spq) \
-      (spq != NULL ? \
-          (SSL_CONNECTION_GET_SSL(spq) && SSL_CONNECTION_GET_SSL(spq)->propq != NULL ? \
-          SSL_CONNECTION_GET_SSL(spq)->propq : SSL_CONNECTION_GET_CTX(spq)->propq) : NULL)
 # define SSL_PROV_QUERRY(s) \
-      (s != NULL ? (s->propq ? s->propq : s->ctx->propq) : NULL)
+      (s != NULL ? (s->propq != NULL ? s->propq : s->ctx->propq) : NULL)
 
 # ifndef OPENSSL_NO_QUIC
 #  include "quic/quic_local.h"
@@ -2998,6 +2994,7 @@ void ossl_ssl_set_custom_record_layer(SSL_CONNECTION *s,
                                       void *rlarg);
 
 long ossl_ctrl_internal(SSL *s, int cmd, long larg, void *parg, int no_quic);
+const char *ssl_connection_prov_querry(SSL_CONNECTION *ssl_con);
 
 /*
  * Options which no longer have any effect, but which can be implemented

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2994,7 +2994,7 @@ void ossl_ssl_set_custom_record_layer(SSL_CONNECTION *s,
                                       void *rlarg);
 
 long ossl_ctrl_internal(SSL *s, int cmd, long larg, void *parg, int no_quic);
-const char *ssl_connection_prov_querry(SSL_CONNECTION *ssl_con);
+const char *ssl_connection_prov_querry(const SSL_CONNECTION *ssl_con);
 
 /*
  * Options which no longer have any effect, but which can be implemented

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -476,7 +476,7 @@ static int use_certificate_chain_file(SSL_CTX *ctx, SSL *ssl, const char *file)
     }
 
     propq = real_ctx->propq;
-    if (ssl && ssl->propq)
+    if (ssl != NULL && ssl->propq != NULL)
         propq = ssl->propq;
 
     x = X509_new_ex(real_ctx->libctx, propq);

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1657,7 +1657,7 @@ int tls_psk_do_binder(SSL_CONNECTION *s, const EVP_MD *md,
     }
 
     mackey = EVP_PKEY_new_raw_private_key_ex(sctx->libctx, "HMAC",
-                                             SSL_CONNECTION_PROV_QUERRY(s), finishedkey,
+                                             ssl_connection_prov_querry(s), finishedkey,
                                              hashsize);
     if (mackey == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
@@ -1669,7 +1669,7 @@ int tls_psk_do_binder(SSL_CONNECTION *s, const EVP_MD *md,
 
     bindersize = hashsize;
     if (EVP_DigestSignInit_ex(mctx, NULL, EVP_MD_get0_name(md), sctx->libctx,
-                              SSL_CONNECTION_PROV_QUERRY(s), mackey, NULL) <= 0
+                              ssl_connection_prov_querry(s), mackey, NULL) <= 0
             || EVP_DigestSignUpdate(mctx, hash, hashsize) <= 0
             || EVP_DigestSignFinal(mctx, binderout, &bindersize) <= 0
             || bindersize != hashsize) {

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1657,7 +1657,7 @@ int tls_psk_do_binder(SSL_CONNECTION *s, const EVP_MD *md,
     }
 
     mackey = EVP_PKEY_new_raw_private_key_ex(sctx->libctx, "HMAC",
-                                             sctx->propq, finishedkey,
+                                             SSL_CONNECTION_PROV_QUERRY(s), finishedkey,
                                              hashsize);
     if (mackey == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
@@ -1669,7 +1669,7 @@ int tls_psk_do_binder(SSL_CONNECTION *s, const EVP_MD *md,
 
     bindersize = hashsize;
     if (EVP_DigestSignInit_ex(mctx, NULL, EVP_MD_get0_name(md), sctx->libctx,
-                              sctx->propq, mackey, NULL) <= 0
+                              SSL_CONNECTION_PROV_QUERRY(s), mackey, NULL) <= 0
             || EVP_DigestSignUpdate(mctx, hash, hashsize) <= 0
             || EVP_DigestSignFinal(mctx, binderout, &bindersize) <= 0
             || bindersize != hashsize) {

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -740,7 +740,7 @@ int tls_parse_ctos_cookie(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
     /* Verify the HMAC of the cookie */
     hctx = EVP_MD_CTX_create();
     pkey = EVP_PKEY_new_raw_private_key_ex(sctx->libctx, "HMAC",
-                                           sctx->propq,
+                                           SSL_CONNECTION_PROV_QUERRY(s),
                                            s->session_ctx->ext.cookie_hmac_key,
                                            sizeof(s->session_ctx->ext.cookie_hmac_key));
     if (hctx == NULL || pkey == NULL) {
@@ -752,7 +752,7 @@ int tls_parse_ctos_cookie(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
 
     hmaclen = SHA256_DIGEST_LENGTH;
     if (EVP_DigestSignInit_ex(hctx, NULL, "SHA2-256", sctx->libctx,
-                              sctx->propq, pkey, NULL) <= 0
+                              SSL_CONNECTION_PROV_QUERRY(s), pkey, NULL) <= 0
             || EVP_DigestSign(hctx, hmac, &hmaclen, data,
                               rawlen - SHA256_DIGEST_LENGTH) <= 0
             || hmaclen != SHA256_DIGEST_LENGTH) {
@@ -1831,7 +1831,7 @@ EXT_RETURN tls_construct_stoc_cookie(SSL_CONNECTION *s, WPACKET *pkt,
     /* HMAC the cookie */
     hctx = EVP_MD_CTX_create();
     pkey = EVP_PKEY_new_raw_private_key_ex(sctx->libctx, "HMAC",
-                                           sctx->propq,
+                                           SSL_CONNECTION_PROV_QUERRY(s),
                                            s->session_ctx->ext.cookie_hmac_key,
                                            sizeof(s->session_ctx->ext.cookie_hmac_key));
     if (hctx == NULL || pkey == NULL) {
@@ -1840,7 +1840,7 @@ EXT_RETURN tls_construct_stoc_cookie(SSL_CONNECTION *s, WPACKET *pkt,
     }
 
     if (EVP_DigestSignInit_ex(hctx, NULL, "SHA2-256", sctx->libctx,
-                              sctx->propq, pkey, NULL) <= 0
+                              SSL_CONNECTION_PROV_QUERRY(s), pkey, NULL) <= 0
             || EVP_DigestSign(hctx, hmac, &hmaclen, cookie,
                               totcookielen) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -740,7 +740,7 @@ int tls_parse_ctos_cookie(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
     /* Verify the HMAC of the cookie */
     hctx = EVP_MD_CTX_create();
     pkey = EVP_PKEY_new_raw_private_key_ex(sctx->libctx, "HMAC",
-                                           SSL_CONNECTION_PROV_QUERRY(s),
+                                           ssl_connection_prov_querry(s),
                                            s->session_ctx->ext.cookie_hmac_key,
                                            sizeof(s->session_ctx->ext.cookie_hmac_key));
     if (hctx == NULL || pkey == NULL) {
@@ -752,7 +752,7 @@ int tls_parse_ctos_cookie(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
 
     hmaclen = SHA256_DIGEST_LENGTH;
     if (EVP_DigestSignInit_ex(hctx, NULL, "SHA2-256", sctx->libctx,
-                              SSL_CONNECTION_PROV_QUERRY(s), pkey, NULL) <= 0
+                              ssl_connection_prov_querry(s), pkey, NULL) <= 0
             || EVP_DigestSign(hctx, hmac, &hmaclen, data,
                               rawlen - SHA256_DIGEST_LENGTH) <= 0
             || hmaclen != SHA256_DIGEST_LENGTH) {
@@ -1831,7 +1831,7 @@ EXT_RETURN tls_construct_stoc_cookie(SSL_CONNECTION *s, WPACKET *pkt,
     /* HMAC the cookie */
     hctx = EVP_MD_CTX_create();
     pkey = EVP_PKEY_new_raw_private_key_ex(sctx->libctx, "HMAC",
-                                           SSL_CONNECTION_PROV_QUERRY(s),
+                                           ssl_connection_prov_querry(s),
                                            s->session_ctx->ext.cookie_hmac_key,
                                            sizeof(s->session_ctx->ext.cookie_hmac_key));
     if (hctx == NULL || pkey == NULL) {
@@ -1840,7 +1840,7 @@ EXT_RETURN tls_construct_stoc_cookie(SSL_CONNECTION *s, WPACKET *pkt,
     }
 
     if (EVP_DigestSignInit_ex(hctx, NULL, "SHA2-256", sctx->libctx,
-                              SSL_CONNECTION_PROV_QUERRY(s), pkey, NULL) <= 0
+                              ssl_connection_prov_querry(s), pkey, NULL) <= 0
             || EVP_DigestSign(hctx, hmac, &hmaclen, cookie,
                               totcookielen) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1998,7 +1998,7 @@ MSG_PROCESS_RETURN tls_process_server_certificate(SSL_CONNECTION *s,
         }
 
         certstart = certbytes;
-        x = X509_new_ex(sctx->libctx, sctx->propq);
+        x = X509_new_ex(sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s));
         if (x == NULL) {
             SSLfatal(s, SSL_AD_DECODE_ERROR, ERR_R_ASN1_LIB);
             goto err;
@@ -2282,7 +2282,7 @@ static int tls_process_ske_dhe(SSL_CONNECTION *s, PACKET *pkt, EVP_PKEY **pkey)
         goto err;
     }
 
-    pctx = EVP_PKEY_CTX_new_from_name(sctx->libctx, "DH", sctx->propq);
+    pctx = EVP_PKEY_CTX_new_from_name(sctx->libctx, "DH", SSL_CONNECTION_PROV_QUERRY(s));
     if (pctx == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;
@@ -2294,7 +2294,7 @@ static int tls_process_ske_dhe(SSL_CONNECTION *s, PACKET *pkt, EVP_PKEY **pkey)
     }
 
     EVP_PKEY_CTX_free(pctx);
-    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, peer_tmp, sctx->propq);
+    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, peer_tmp, SSL_CONNECTION_PROV_QUERRY(s));
     if (pctx == NULL
             /*
              * EVP_PKEY_param_check() will verify that the DH params are using
@@ -2502,7 +2502,7 @@ MSG_PROCESS_RETURN tls_process_key_exchange(SSL_CONNECTION *s, PACKET *pkt)
 
         if (EVP_DigestVerifyInit_ex(md_ctx, &pctx,
                                     md == NULL ? NULL : EVP_MD_get0_name(md),
-                                    sctx->libctx, sctx->propq, pkey,
+                                    sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s), pkey,
                                     NULL) <= 0) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
             goto err;
@@ -2799,7 +2799,7 @@ MSG_PROCESS_RETURN tls_process_new_session_ticket(SSL_CONNECTION *s,
      * elsewhere in OpenSSL. The session ID is set to the SHA256 hash of the
      * ticket.
      */
-    sha256 = EVP_MD_fetch(sctx->libctx, "SHA2-256", sctx->propq);
+    sha256 = EVP_MD_fetch(sctx->libctx, "SHA2-256", SSL_CONNECTION_PROV_QUERRY(s));
     if (sha256 == NULL) {
         /* Error is already recorded */
         SSLfatal_alert(s, SSL_AD_INTERNAL_ERROR);
@@ -3106,7 +3106,7 @@ static int tls_construct_cke_rsa(SSL_CONNECTION *s, WPACKET *pkt)
         goto err;
     }
 
-    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, pkey, sctx->propq);
+    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, pkey, SSL_CONNECTION_PROV_QUERRY(s));
     if (pctx == NULL || EVP_PKEY_encrypt_init(pctx) <= 0
         || EVP_PKEY_encrypt(pctx, NULL, &enclen, pms, pmslen) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
@@ -3279,7 +3279,7 @@ static int tls_construct_cke_gost(SSL_CONNECTION *s, WPACKET *pkt)
 
     pkey_ctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx,
                                           pkey,
-                                          sctx->propq);
+                                          SSL_CONNECTION_PROV_QUERRY(s));
     if (pkey_ctx == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
         return 0;
@@ -3377,7 +3377,7 @@ int ossl_gost_ukm(const SSL_CONNECTION *s, unsigned char *dgst_buf)
     unsigned int md_len;
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
     const EVP_MD *md = ssl_evp_md_fetch(sctx->libctx, NID_id_GostR3411_2012_256,
-                                        sctx->propq);
+                                        SSL_CONNECTION_PROV_QUERRY(s));
 
     if (md == NULL)
         return 0;
@@ -3444,7 +3444,7 @@ static int tls_construct_cke_gost18(SSL_CONNECTION *s, WPACKET *pkt)
 
     pkey_ctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx,
                                           pkey,
-                                          sctx->propq);
+                                          SSL_CONNECTION_PROV_QUERRY(s));
     if (pkey_ctx == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
         goto err;

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1998,7 +1998,7 @@ MSG_PROCESS_RETURN tls_process_server_certificate(SSL_CONNECTION *s,
         }
 
         certstart = certbytes;
-        x = X509_new_ex(sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s));
+        x = X509_new_ex(sctx->libctx, ssl_connection_prov_querry(s));
         if (x == NULL) {
             SSLfatal(s, SSL_AD_DECODE_ERROR, ERR_R_ASN1_LIB);
             goto err;
@@ -2282,7 +2282,7 @@ static int tls_process_ske_dhe(SSL_CONNECTION *s, PACKET *pkt, EVP_PKEY **pkey)
         goto err;
     }
 
-    pctx = EVP_PKEY_CTX_new_from_name(sctx->libctx, "DH", SSL_CONNECTION_PROV_QUERRY(s));
+    pctx = EVP_PKEY_CTX_new_from_name(sctx->libctx, "DH", ssl_connection_prov_querry(s));
     if (pctx == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;
@@ -2294,7 +2294,7 @@ static int tls_process_ske_dhe(SSL_CONNECTION *s, PACKET *pkt, EVP_PKEY **pkey)
     }
 
     EVP_PKEY_CTX_free(pctx);
-    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, peer_tmp, SSL_CONNECTION_PROV_QUERRY(s));
+    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, peer_tmp, ssl_connection_prov_querry(s));
     if (pctx == NULL
             /*
              * EVP_PKEY_param_check() will verify that the DH params are using
@@ -2502,7 +2502,7 @@ MSG_PROCESS_RETURN tls_process_key_exchange(SSL_CONNECTION *s, PACKET *pkt)
 
         if (EVP_DigestVerifyInit_ex(md_ctx, &pctx,
                                     md == NULL ? NULL : EVP_MD_get0_name(md),
-                                    sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s), pkey,
+                                    sctx->libctx, ssl_connection_prov_querry(s), pkey,
                                     NULL) <= 0) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
             goto err;
@@ -2799,7 +2799,7 @@ MSG_PROCESS_RETURN tls_process_new_session_ticket(SSL_CONNECTION *s,
      * elsewhere in OpenSSL. The session ID is set to the SHA256 hash of the
      * ticket.
      */
-    sha256 = EVP_MD_fetch(sctx->libctx, "SHA2-256", SSL_CONNECTION_PROV_QUERRY(s));
+    sha256 = EVP_MD_fetch(sctx->libctx, "SHA2-256", ssl_connection_prov_querry(s));
     if (sha256 == NULL) {
         /* Error is already recorded */
         SSLfatal_alert(s, SSL_AD_INTERNAL_ERROR);
@@ -3106,7 +3106,7 @@ static int tls_construct_cke_rsa(SSL_CONNECTION *s, WPACKET *pkt)
         goto err;
     }
 
-    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, pkey, SSL_CONNECTION_PROV_QUERRY(s));
+    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, pkey, ssl_connection_prov_querry(s));
     if (pctx == NULL || EVP_PKEY_encrypt_init(pctx) <= 0
         || EVP_PKEY_encrypt(pctx, NULL, &enclen, pms, pmslen) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
@@ -3279,7 +3279,7 @@ static int tls_construct_cke_gost(SSL_CONNECTION *s, WPACKET *pkt)
 
     pkey_ctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx,
                                           pkey,
-                                          SSL_CONNECTION_PROV_QUERRY(s));
+                                          ssl_connection_prov_querry(s));
     if (pkey_ctx == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
         return 0;
@@ -3377,7 +3377,7 @@ int ossl_gost_ukm(const SSL_CONNECTION *s, unsigned char *dgst_buf)
     unsigned int md_len;
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
     const EVP_MD *md = ssl_evp_md_fetch(sctx->libctx, NID_id_GostR3411_2012_256,
-                                        SSL_CONNECTION_PROV_QUERRY(s));
+                                        ssl_connection_prov_querry(s));
 
     if (md == NULL)
         return 0;
@@ -3444,7 +3444,7 @@ static int tls_construct_cke_gost18(SSL_CONNECTION *s, WPACKET *pkt)
 
     pkey_ctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx,
                                           pkey,
-                                          SSL_CONNECTION_PROV_QUERRY(s));
+                                          ssl_connection_prov_querry(s));
     if (pkey_ctx == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
         goto err;

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -356,7 +356,7 @@ CON_FUNC_RETURN tls_construct_cert_verify(SSL_CONNECTION *s, WPACKET *pkt)
 
     if (EVP_DigestSignInit_ex(mctx, &pctx,
                               md == NULL ? NULL : EVP_MD_get0_name(md),
-                              sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s), pkey,
+                              sctx->libctx, ssl_connection_prov_querry(s), pkey,
                               NULL) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
         goto err;
@@ -534,7 +534,7 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL_CONNECTION *s, PACKET *pkt)
 
     if (EVP_DigestVerifyInit_ex(mctx, &pctx,
                                 md == NULL ? NULL : EVP_MD_get0_name(md),
-                                sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s), pkey,
+                                sctx->libctx, ssl_connection_prov_querry(s), pkey,
                                 NULL) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
         goto err;
@@ -1026,7 +1026,7 @@ static int ssl_add_cert_chain(SSL_CONNECTION *s, WPACKET *pkt, CERT_PKEY *cpk, i
 
     if (chain_store != NULL) {
         X509_STORE_CTX *xs_ctx = X509_STORE_CTX_new_ex(sctx->libctx,
-                                                       SSL_CONNECTION_PROV_QUERRY(s));
+                                                       ssl_connection_prov_querry(s));
 
         if (xs_ctx == NULL) {
             if (!for_comp)

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -356,7 +356,7 @@ CON_FUNC_RETURN tls_construct_cert_verify(SSL_CONNECTION *s, WPACKET *pkt)
 
     if (EVP_DigestSignInit_ex(mctx, &pctx,
                               md == NULL ? NULL : EVP_MD_get0_name(md),
-                              sctx->libctx, sctx->propq, pkey,
+                              sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s), pkey,
                               NULL) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
         goto err;
@@ -534,7 +534,7 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL_CONNECTION *s, PACKET *pkt)
 
     if (EVP_DigestVerifyInit_ex(mctx, &pctx,
                                 md == NULL ? NULL : EVP_MD_get0_name(md),
-                                sctx->libctx, sctx->propq, pkey,
+                                sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s), pkey,
                                 NULL) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
         goto err;
@@ -1026,7 +1026,7 @@ static int ssl_add_cert_chain(SSL_CONNECTION *s, WPACKET *pkt, CERT_PKEY *cpk, i
 
     if (chain_store != NULL) {
         X509_STORE_CTX *xs_ctx = X509_STORE_CTX_new_ex(sctx->libctx,
-                                                       sctx->propq);
+                                                       SSL_CONNECTION_PROV_QUERRY(s));
 
         if (xs_ctx == NULL) {
             if (!for_comp)

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2791,7 +2791,7 @@ CON_FUNC_RETURN tls_construct_server_key_exchange(SSL_CONNECTION *s,
 
         if (EVP_DigestSignInit_ex(md_ctx, &pctx,
                                   md == NULL ? NULL : EVP_MD_get0_name(md),
-                                  sctx->libctx, sctx->propq, pkey,
+                                  sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s), pkey,
                                   NULL) <= 0) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
             goto err;
@@ -3004,7 +3004,7 @@ static int tls_process_cke_rsa(SSL_CONNECTION *s, PACKET *pkt)
         return 0;
     }
 
-    ctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, rsa, sctx->propq);
+    ctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, rsa, SSL_CONNECTION_PROV_QUERRY(s));
     if (ctx == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
         goto err;
@@ -3347,7 +3347,7 @@ static int tls_process_cke_gost18(SSL_CONNECTION *s, PACKET *pkt)
         goto err;
     }
 
-    pkey_ctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, pk, sctx->propq);
+    pkey_ctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, pk, SSL_CONNECTION_PROV_QUERRY(s));
     if (pkey_ctx == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
         goto err;
@@ -3670,7 +3670,7 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL_CONNECTION *s,
         }
 
         certstart = certbytes;
-        x = X509_new_ex(sctx->libctx, sctx->propq);
+        x = X509_new_ex(sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s));
         if (x == NULL) {
             SSLfatal(s, SSL_AD_DECODE_ERROR, ERR_R_X509_LIB);
             goto err;
@@ -3993,7 +3993,7 @@ static CON_FUNC_RETURN construct_stateless_ticket(SSL_CONNECTION *s,
      */
     const_p = senc;
     sess = d2i_SSL_SESSION_ex(NULL, &const_p, slen_full, sctx->libctx,
-                              sctx->propq);
+                              SSL_CONNECTION_PROV_QUERRY(s));
     if (sess == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;
@@ -4069,7 +4069,7 @@ static CON_FUNC_RETURN construct_stateless_ticket(SSL_CONNECTION *s,
         }
     } else {
         EVP_CIPHER *cipher = EVP_CIPHER_fetch(sctx->libctx, "AES-256-CBC",
-                                              sctx->propq);
+                                              SSL_CONNECTION_PROV_QUERRY(s));
 
         if (cipher == NULL) {
             /* Error is already recorded */

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2791,7 +2791,7 @@ CON_FUNC_RETURN tls_construct_server_key_exchange(SSL_CONNECTION *s,
 
         if (EVP_DigestSignInit_ex(md_ctx, &pctx,
                                   md == NULL ? NULL : EVP_MD_get0_name(md),
-                                  sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s), pkey,
+                                  sctx->libctx, ssl_connection_prov_querry(s), pkey,
                                   NULL) <= 0) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
             goto err;
@@ -3004,7 +3004,7 @@ static int tls_process_cke_rsa(SSL_CONNECTION *s, PACKET *pkt)
         return 0;
     }
 
-    ctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, rsa, SSL_CONNECTION_PROV_QUERRY(s));
+    ctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, rsa, ssl_connection_prov_querry(s));
     if (ctx == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
         goto err;
@@ -3347,7 +3347,7 @@ static int tls_process_cke_gost18(SSL_CONNECTION *s, PACKET *pkt)
         goto err;
     }
 
-    pkey_ctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, pk, SSL_CONNECTION_PROV_QUERRY(s));
+    pkey_ctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, pk, ssl_connection_prov_querry(s));
     if (pkey_ctx == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
         goto err;
@@ -3670,7 +3670,7 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL_CONNECTION *s,
         }
 
         certstart = certbytes;
-        x = X509_new_ex(sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s));
+        x = X509_new_ex(sctx->libctx, ssl_connection_prov_querry(s));
         if (x == NULL) {
             SSLfatal(s, SSL_AD_DECODE_ERROR, ERR_R_X509_LIB);
             goto err;
@@ -3993,7 +3993,7 @@ static CON_FUNC_RETURN construct_stateless_ticket(SSL_CONNECTION *s,
      */
     const_p = senc;
     sess = d2i_SSL_SESSION_ex(NULL, &const_p, slen_full, sctx->libctx,
-                              SSL_CONNECTION_PROV_QUERRY(s));
+                              ssl_connection_prov_querry(s));
     if (sess == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;
@@ -4069,7 +4069,7 @@ static CON_FUNC_RETURN construct_stateless_ticket(SSL_CONNECTION *s,
         }
     } else {
         EVP_CIPHER *cipher = EVP_CIPHER_fetch(sctx->libctx, "AES-256-CBC",
-                                              SSL_CONNECTION_PROV_QUERRY(s));
+                                              ssl_connection_prov_querry(s));
 
         if (cipher == NULL) {
             /* Error is already recorded */

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -47,7 +47,7 @@ static int tls1_PRF(SSL_CONNECTION *s,
     }
     kdf = EVP_KDF_fetch(SSL_CONNECTION_GET_CTX(s)->libctx,
                         OSSL_KDF_NAME_TLS1_PRF,
-                        SSL_CONNECTION_GET_CTX(s)->propq);
+                        SSL_CONNECTION_PROV_QUERRY(s));
     if (kdf == NULL)
         goto err;
     kctx = EVP_KDF_CTX_new(kdf);

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -47,7 +47,7 @@ static int tls1_PRF(SSL_CONNECTION *s,
     }
     kdf = EVP_KDF_fetch(SSL_CONNECTION_GET_CTX(s)->libctx,
                         OSSL_KDF_NAME_TLS1_PRF,
-                        SSL_CONNECTION_PROV_QUERRY(s));
+                        ssl_connection_prov_querry(s));
     if (kdf == NULL)
         goto err;
     kctx = EVP_KDF_CTX_new(kdf);

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2316,7 +2316,7 @@ SSL_TICKET_STATUS tls_decrypt_ticket(SSL_CONNECTION *s,
         }
 
         aes256cbc = EVP_CIPHER_fetch(sctx->libctx, "AES-256-CBC",
-                                     SSL_CONNECTION_PROV_QUERRY(s));
+                                     ssl_connection_prov_querry(s));
         if (aes256cbc == NULL
             || ssl_hmac_init(hctx, tctx->ext.secure->tick_hmac_key,
                              sizeof(tctx->ext.secure->tick_hmac_key),
@@ -2384,7 +2384,7 @@ SSL_TICKET_STATUS tls_decrypt_ticket(SSL_CONNECTION *s,
     slen += declen;
     p = sdec;
 
-    sess = d2i_SSL_SESSION_ex(NULL, &p, slen, sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s));
+    sess = d2i_SSL_SESSION_ex(NULL, &p, slen, sctx->libctx, ssl_connection_prov_querry(s));
     slen -= p - sdec;
     OPENSSL_free(sdec);
     if (sess) {
@@ -3409,7 +3409,7 @@ EVP_PKEY *ssl_get_auto_dh(SSL_CONNECTION *s)
     if (p == NULL)
         goto err;
 
-    pctx = EVP_PKEY_CTX_new_from_name(sctx->libctx, "DH", SSL_CONNECTION_PROV_QUERRY(s));
+    pctx = EVP_PKEY_CTX_new_from_name(sctx->libctx, "DH", ssl_connection_prov_querry(s));
     if (pctx == NULL
             || EVP_PKEY_fromdata_init(pctx) != 1)
         goto err;
@@ -3572,7 +3572,7 @@ static int check_cert_usable(SSL_CONNECTION *s, const SIGALG_LOOKUP *sig,
         mdname = OBJ_nid2sn(sig->hash);
     supported = EVP_PKEY_digestsign_supports_digest(pkey, sctx->libctx,
                                                     mdname,
-                                                    SSL_CONNECTION_PROV_QUERRY(s));
+                                                    ssl_connection_prov_querry(s));
     if (supported <= 0)
         return 0;
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2316,7 +2316,7 @@ SSL_TICKET_STATUS tls_decrypt_ticket(SSL_CONNECTION *s,
         }
 
         aes256cbc = EVP_CIPHER_fetch(sctx->libctx, "AES-256-CBC",
-                                     sctx->propq);
+                                     SSL_CONNECTION_PROV_QUERRY(s));
         if (aes256cbc == NULL
             || ssl_hmac_init(hctx, tctx->ext.secure->tick_hmac_key,
                              sizeof(tctx->ext.secure->tick_hmac_key),
@@ -2384,7 +2384,7 @@ SSL_TICKET_STATUS tls_decrypt_ticket(SSL_CONNECTION *s,
     slen += declen;
     p = sdec;
 
-    sess = d2i_SSL_SESSION_ex(NULL, &p, slen, sctx->libctx, sctx->propq);
+    sess = d2i_SSL_SESSION_ex(NULL, &p, slen, sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s));
     slen -= p - sdec;
     OPENSSL_free(sdec);
     if (sess) {
@@ -3409,7 +3409,7 @@ EVP_PKEY *ssl_get_auto_dh(SSL_CONNECTION *s)
     if (p == NULL)
         goto err;
 
-    pctx = EVP_PKEY_CTX_new_from_name(sctx->libctx, "DH", sctx->propq);
+    pctx = EVP_PKEY_CTX_new_from_name(sctx->libctx, "DH", SSL_CONNECTION_PROV_QUERRY(s));
     if (pctx == NULL
             || EVP_PKEY_fromdata_init(pctx) != 1)
         goto err;
@@ -3572,7 +3572,7 @@ static int check_cert_usable(SSL_CONNECTION *s, const SIGALG_LOOKUP *sig,
         mdname = OBJ_nid2sn(sig->hash);
     supported = EVP_PKEY_digestsign_supports_digest(pkey, sctx->libctx,
                                                     mdname,
-                                                    sctx->propq);
+                                                    SSL_CONNECTION_PROV_QUERRY(s));
     if (supported <= 0)
         return 0;
 

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -1285,7 +1285,7 @@ static int ssl_print_certificate(BIO *bio, const SSL_CONNECTION *sc, int indent,
     q = p + 3;
     BIO_indent(bio, indent, 80);
     BIO_printf(bio, "ASN.1Cert, length=%d", (int)clen);
-    x = X509_new_ex(ctx->libctx, SSL_CONNECTION_PROV_QUERRY(sc));
+    x = X509_new_ex(ctx->libctx, ssl_connection_prov_querry(sc));
     if (x != NULL && d2i_X509(&x, &q, clen) == NULL) {
         X509_free(x);
         x = NULL;
@@ -1330,7 +1330,7 @@ static int ssl_print_raw_public_key(BIO *bio, const SSL *ssl, int server,
     BIO_printf(bio, "raw_public_key, length=%d\n", (int)clen);
 
     propq = ssl->ctx->propq;
-    if (ssl && ssl->propq)
+    if (ssl != NULL && ssl->propq != NULL)
         propq = ssl->propq;
     pkey = d2i_PUBKEY_ex(NULL, &msg, clen, ssl->ctx->libctx, propq);
     if (pkey == NULL)

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -1285,7 +1285,7 @@ static int ssl_print_certificate(BIO *bio, const SSL_CONNECTION *sc, int indent,
     q = p + 3;
     BIO_indent(bio, indent, 80);
     BIO_printf(bio, "ASN.1Cert, length=%d", (int)clen);
-    x = X509_new_ex(ctx->libctx, ctx->propq);
+    x = X509_new_ex(ctx->libctx, SSL_CONNECTION_PROV_QUERRY(sc));
     if (x != NULL && d2i_X509(&x, &q, clen) == NULL) {
         X509_free(x);
         x = NULL;
@@ -1316,6 +1316,7 @@ static int ssl_print_raw_public_key(BIO *bio, const SSL *ssl, int server,
     size_t clen;
     const unsigned char *msg = *pmsg;
     size_t msglen = *pmsglen;
+    const char *propq = NULL;
 
     if (msglen < 3)
         return 0;
@@ -1328,7 +1329,10 @@ static int ssl_print_raw_public_key(BIO *bio, const SSL *ssl, int server,
     BIO_indent(bio, indent, 80);
     BIO_printf(bio, "raw_public_key, length=%d\n", (int)clen);
 
-    pkey = d2i_PUBKEY_ex(NULL, &msg, clen, ssl->ctx->libctx, ssl->ctx->propq);
+    propq = ssl->ctx->propq;
+    if (ssl && ssl->propq)
+        propq = ssl->propq;
+    pkey = d2i_PUBKEY_ex(NULL, &msg, clen, ssl->ctx->libctx, propq);
     if (pkey == NULL)
         return 0;
     EVP_PKEY_print_public(bio, pkey, indent + 2, NULL);

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -105,7 +105,7 @@ int tls13_hkdf_expand(SSL_CONNECTION *s, const EVP_MD *md,
     int ret;
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 
-    ret = tls13_hkdf_expand_ex(sctx->libctx, sctx->propq, md,
+    ret = tls13_hkdf_expand_ex(sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s), md,
                                secret, label, labellen, data, datalen,
                                out, outlen, !fatal);
     if (ret == 0 && fatal)
@@ -178,7 +178,7 @@ int tls13_generate_secret(SSL_CONNECTION *s, const EVP_MD *md,
     static const char derived_secret_label[] = "\x64\x65\x72\x69\x76\x65\x64";
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 
-    kdf = EVP_KDF_fetch(sctx->libctx, OSSL_KDF_NAME_TLS1_3_KDF, sctx->propq);
+    kdf = EVP_KDF_fetch(sctx->libctx, OSSL_KDF_NAME_TLS1_3_KDF, SSL_CONNECTION_PROV_QUERRY(s));
     kctx = EVP_KDF_CTX_new(kdf);
     EVP_KDF_free(kdf);
     if (kctx == NULL) {
@@ -273,9 +273,9 @@ size_t tls13_final_finish_mac(SSL_CONNECTION *s, const char *str, size_t slen,
         return 0;
 
     /* Safe to cast away const here since we're not "getting" any data */
-    if (sctx->propq != NULL)
+    if (SSL_CONNECTION_PROV_QUERRY(s) != NULL)
         *p++ = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_PROPERTIES,
-                                                (char *)sctx->propq,
+                                                (char *)SSL_CONNECTION_PROV_QUERRY(s),
                                                 0);
     *p = OSSL_PARAM_construct_end();
 
@@ -296,7 +296,7 @@ size_t tls13_final_finish_mac(SSL_CONNECTION *s, const char *str, size_t slen,
         key = finsecret;
     }
 
-    if (!EVP_Q_mac(sctx->libctx, "HMAC", sctx->propq, mdname,
+    if (!EVP_Q_mac(sctx->libctx, "HMAC", SSL_CONNECTION_PROV_QUERRY(s), mdname,
                    params, key, hashlen, hash, hashlen,
                    /* outsize as per sizeof(peer_finish_md) */
                    out, EVP_MAX_MD_SIZE * 2, &len)) {

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -105,7 +105,7 @@ int tls13_hkdf_expand(SSL_CONNECTION *s, const EVP_MD *md,
     int ret;
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 
-    ret = tls13_hkdf_expand_ex(sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s), md,
+    ret = tls13_hkdf_expand_ex(sctx->libctx, ssl_connection_prov_querry(s), md,
                                secret, label, labellen, data, datalen,
                                out, outlen, !fatal);
     if (ret == 0 && fatal)
@@ -178,7 +178,7 @@ int tls13_generate_secret(SSL_CONNECTION *s, const EVP_MD *md,
     static const char derived_secret_label[] = "\x64\x65\x72\x69\x76\x65\x64";
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 
-    kdf = EVP_KDF_fetch(sctx->libctx, OSSL_KDF_NAME_TLS1_3_KDF, SSL_CONNECTION_PROV_QUERRY(s));
+    kdf = EVP_KDF_fetch(sctx->libctx, OSSL_KDF_NAME_TLS1_3_KDF, ssl_connection_prov_querry(s));
     kctx = EVP_KDF_CTX_new(kdf);
     EVP_KDF_free(kdf);
     if (kctx == NULL) {
@@ -273,9 +273,9 @@ size_t tls13_final_finish_mac(SSL_CONNECTION *s, const char *str, size_t slen,
         return 0;
 
     /* Safe to cast away const here since we're not "getting" any data */
-    if (SSL_CONNECTION_PROV_QUERRY(s) != NULL)
+    if (ssl_connection_prov_querry(s) != NULL)
         *p++ = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_PROPERTIES,
-                                                (char *)SSL_CONNECTION_PROV_QUERRY(s),
+                                                (char *)ssl_connection_prov_querry(s),
                                                 0);
     *p = OSSL_PARAM_construct_end();
 
@@ -296,7 +296,7 @@ size_t tls13_final_finish_mac(SSL_CONNECTION *s, const char *str, size_t slen,
         key = finsecret;
     }
 
-    if (!EVP_Q_mac(sctx->libctx, "HMAC", SSL_CONNECTION_PROV_QUERRY(s), mdname,
+    if (!EVP_Q_mac(sctx->libctx, "HMAC", ssl_connection_prov_querry(s), mdname,
                    params, key, hashlen, hash, hashlen,
                    /* outsize as per sizeof(peer_finish_md) */
                    out, EVP_MAX_MD_SIZE * 2, &len)) {

--- a/ssl/tls_srp.c
+++ b/ssl/tls_srp.c
@@ -221,7 +221,7 @@ int ssl_srp_server_param_with_username_intern(SSL_CONNECTION *s, int *ad)
 
     return ((s->srp_ctx.B =
              SRP_Calc_B_ex(s->srp_ctx.b, s->srp_ctx.N, s->srp_ctx.g,
-                           s->srp_ctx.v, sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s))) !=
+                           s->srp_ctx.v, sctx->libctx, ssl_connection_prov_querry(s))) !=
             NULL) ? SSL_ERROR_NONE : SSL3_AL_FATAL;
 }
 
@@ -333,7 +333,7 @@ int srp_generate_server_master_secret(SSL_CONNECTION *s)
     if (!SRP_Verify_A_mod_N(s->srp_ctx.A, s->srp_ctx.N))
         goto err;
     if ((u = SRP_Calc_u_ex(s->srp_ctx.A, s->srp_ctx.B, s->srp_ctx.N,
-                           sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s))) == NULL)
+                           sctx->libctx, ssl_connection_prov_querry(s))) == NULL)
         goto err;
     if ((K = SRP_Calc_server_key(s->srp_ctx.A, s->srp_ctx.v, u, s->srp_ctx.b,
                                  s->srp_ctx.N)) == NULL)
@@ -367,7 +367,7 @@ int srp_generate_client_master_secret(SSL_CONNECTION *s)
      */
     if (SRP_Verify_B_mod_N(s->srp_ctx.B, s->srp_ctx.N) == 0
             || (u = SRP_Calc_u_ex(s->srp_ctx.A, s->srp_ctx.B, s->srp_ctx.N,
-                                  sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s)))
+                                  sctx->libctx, ssl_connection_prov_querry(s)))
                == NULL
             || s->srp_ctx.SRP_give_srp_client_pwd_callback == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
@@ -380,12 +380,12 @@ int srp_generate_client_master_secret(SSL_CONNECTION *s)
         goto err;
     }
     if ((x = SRP_Calc_x_ex(s->srp_ctx.s, s->srp_ctx.login, passwd,
-                           sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s))) == NULL
+                           sctx->libctx, ssl_connection_prov_querry(s))) == NULL
             || (K = SRP_Calc_client_key_ex(s->srp_ctx.N, s->srp_ctx.B,
                                            s->srp_ctx.g, x,
                                            s->srp_ctx.a, u,
                                            sctx->libctx,
-                                           SSL_CONNECTION_PROV_QUERRY(s))) == NULL) {
+                                           ssl_connection_prov_querry(s))) == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;
     }

--- a/ssl/tls_srp.c
+++ b/ssl/tls_srp.c
@@ -221,7 +221,7 @@ int ssl_srp_server_param_with_username_intern(SSL_CONNECTION *s, int *ad)
 
     return ((s->srp_ctx.B =
              SRP_Calc_B_ex(s->srp_ctx.b, s->srp_ctx.N, s->srp_ctx.g,
-                           s->srp_ctx.v, sctx->libctx, sctx->propq)) !=
+                           s->srp_ctx.v, sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s))) !=
             NULL) ? SSL_ERROR_NONE : SSL3_AL_FATAL;
 }
 
@@ -259,7 +259,7 @@ int SSL_set_srp_server_param_pw(SSL *s, const char *user, const char *pass,
     sc->srp_ctx.s = NULL;
     if (!SRP_create_verifier_BN_ex(user, pass, &sc->srp_ctx.s, &sc->srp_ctx.v,
                                    sc->srp_ctx.N, sc->srp_ctx.g, s->ctx->libctx,
-                                   s->ctx->propq))
+                                   SSL_PROV_QUERRY(s)))
         return -1;
 
     return 1;
@@ -333,7 +333,7 @@ int srp_generate_server_master_secret(SSL_CONNECTION *s)
     if (!SRP_Verify_A_mod_N(s->srp_ctx.A, s->srp_ctx.N))
         goto err;
     if ((u = SRP_Calc_u_ex(s->srp_ctx.A, s->srp_ctx.B, s->srp_ctx.N,
-                           sctx->libctx, sctx->propq)) == NULL)
+                           sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s))) == NULL)
         goto err;
     if ((K = SRP_Calc_server_key(s->srp_ctx.A, s->srp_ctx.v, u, s->srp_ctx.b,
                                  s->srp_ctx.N)) == NULL)
@@ -367,7 +367,7 @@ int srp_generate_client_master_secret(SSL_CONNECTION *s)
      */
     if (SRP_Verify_B_mod_N(s->srp_ctx.B, s->srp_ctx.N) == 0
             || (u = SRP_Calc_u_ex(s->srp_ctx.A, s->srp_ctx.B, s->srp_ctx.N,
-                                  sctx->libctx, sctx->propq))
+                                  sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s)))
                == NULL
             || s->srp_ctx.SRP_give_srp_client_pwd_callback == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
@@ -380,12 +380,12 @@ int srp_generate_client_master_secret(SSL_CONNECTION *s)
         goto err;
     }
     if ((x = SRP_Calc_x_ex(s->srp_ctx.s, s->srp_ctx.login, passwd,
-                           sctx->libctx, sctx->propq)) == NULL
+                           sctx->libctx, SSL_CONNECTION_PROV_QUERRY(s))) == NULL
             || (K = SRP_Calc_client_key_ex(s->srp_ctx.N, s->srp_ctx.B,
                                            s->srp_ctx.g, x,
                                            s->srp_ctx.a, u,
                                            sctx->libctx,
-                                           sctx->propq)) == NULL) {
+                                           SSL_CONNECTION_PROV_QUERRY(s))) == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;
     }

--- a/test/asynciotest.c
+++ b/test/asynciotest.c
@@ -323,7 +323,7 @@ static int test_asyncio(int test)
 
     /* BIOs get freed on error */
     if (!TEST_true(create_ssl_objects(serverctx, clientctx, &serverssl,
-                                      &clientssl, s_to_c_fbio, c_to_s_fbio))
+                                      &clientssl, NULL, s_to_c_fbio, c_to_s_fbio))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                           SSL_ERROR_NONE)))
         goto end;

--- a/test/cert_comp_test.c
+++ b/test/cert_comp_test.c
@@ -190,7 +190,7 @@ static int test_ssl_cert_comp(int test)
     }
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL)))
+                                      NULL, NULL, NULL)))
         goto end;
 
     if (!TEST_true(SSL_set_app_data(clientssl, &client_seen)))

--- a/test/dtls_mtu_test.c
+++ b/test/dtls_mtu_test.c
@@ -60,7 +60,7 @@ static int mtu_test(SSL_CTX *ctx, const char *cs, int no_etm)
     memset(buf, 0x5a, sizeof(buf));
 
     if (!TEST_true(create_ssl_objects(ctx, ctx, &srvr_ssl, &clnt_ssl,
-                                      NULL, NULL)))
+                                      NULL, NULL, NULL)))
         goto end;
 
     if (no_etm)
@@ -209,7 +209,7 @@ static int test_server_mtu_larger_than_max_fragment_length(void)
 #endif
 
     if (!TEST_true(create_ssl_objects(ctx, ctx, &srvr_ssl, &clnt_ssl,
-                                      NULL, NULL)))
+                                      NULL, NULL, NULL)))
         goto end;
 
     SSL_set_options(srvr_ssl, SSL_OP_NO_QUERY_MTU);

--- a/test/dtlstest.c
+++ b/test/dtlstest.c
@@ -100,7 +100,7 @@ static int test_dtls_unprocessed(int testidx)
 
     /* BIO is freed by create_ssl_connection on error */
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl1, &clientssl1,
-                                      NULL, c_to_s_fbio)))
+                                      NULL, NULL, c_to_s_fbio)))
         goto end;
 
     DTLS_set_timer_cb(clientssl1, timer_cb);
@@ -223,7 +223,7 @@ static int test_dtls_drop_records(int idx)
     if (idx >= TOTAL_FULL_HAND_RECORDS) {
         /* We're going to do a resumption handshake. Get a session first. */
         if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                          NULL, NULL))
+                                          NULL, NULL, NULL))
                 || !TEST_true(create_ssl_connection(serverssl, clientssl,
                               SSL_ERROR_NONE))
                 || !TEST_ptr(sess = SSL_get1_session(clientssl)))
@@ -253,7 +253,7 @@ static int test_dtls_drop_records(int idx)
 
     /* BIO is freed by create_ssl_connection on error */
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, c_to_s_fbio)))
+                                      NULL, NULL, c_to_s_fbio)))
         goto end;
 
     if (sess != NULL) {
@@ -331,7 +331,7 @@ static int test_cookie(void)
 #endif
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL))
+                                      NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
         goto end;
@@ -367,7 +367,7 @@ static int test_dtls_duplicate_records(void)
 #endif
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL)))
+                                      NULL, NULL, NULL)))
         goto end;
 
     DTLS_set_timer_cb(clientssl, timer_cb);
@@ -502,7 +502,7 @@ static int test_swap_records(int idx)
 #endif
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &sssl, &cssl,
-                                      NULL, NULL)))
+                                      NULL, NULL, NULL)))
         goto end;
 
     /* Send flight 1: ClientHello */
@@ -612,7 +612,7 @@ static int test_listen(void)
     SSL_CTX_set_cookie_verify_cb(sctx, verify_cookie_cb);
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL)))
+                                      NULL, NULL, NULL)))
         goto end;
 
     DTLS_set_timer_cb(clientssl, timer_cb);

--- a/test/fatalerrtest.c
+++ b/test/fatalerrtest.c
@@ -44,7 +44,7 @@ static int test_fatalerr(void)
             || !TEST_true(SSL_CTX_set_ciphersuites(cctx,
                                                    "TLS_AES_256_GCM_SHA384"))
             || !TEST_true(create_ssl_objects(sctx, cctx, &sssl, &cssl, NULL,
-                          NULL)))
+                          NULL, NULL)))
         goto err;
 
     wbio = SSL_get_wbio(cssl);

--- a/test/helpers/ssltestlib.h
+++ b/test/helpers/ssltestlib.h
@@ -17,7 +17,7 @@ int create_ssl_ctx_pair(OSSL_LIB_CTX *libctx, const SSL_METHOD *sm,
                         int max_proto_version, SSL_CTX **sctx, SSL_CTX **cctx,
                         char *certfile, char *privkeyfile);
 int create_ssl_objects(SSL_CTX *serverctx, SSL_CTX *clientctx, SSL **sssl,
-                       SSL **cssl, BIO *s_to_c_fbio, BIO *c_to_s_fbio);
+                       SSL **cssl, char *propq, BIO *s_to_c_fbio, BIO *c_to_s_fbio);
 int create_bare_ssl_connection(SSL *serverssl, SSL *clientssl, int want,
                                int read, int listen);
 int create_ssl_objects2(SSL_CTX *serverctx, SSL_CTX *clientctx, SSL **sssl,

--- a/test/recordlentest.c
+++ b/test/recordlentest.c
@@ -120,7 +120,7 @@ static int test_record_overflow(int idx)
     }
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL)))
+                                      NULL, NULL, NULL)))
         goto end;
 
     serverbio = SSL_get_rbio(serverssl);

--- a/test/rpktest.c
+++ b/test/rpktest.c
@@ -253,7 +253,7 @@ static int test_rpk(int idx)
     SSL_CTX_set_verify(cctx, SSL_VERIFY_PEER, rpk_verify_client_cb);
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL)))
+                                      NULL, NULL, NULL)))
         goto end;
 
     if (!TEST_int_gt(SSL_dane_enable(serverssl, NULL), 0))
@@ -529,7 +529,7 @@ static int test_rpk(int idx)
         serverssl = clientssl = NULL;
 
         if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                          NULL, NULL))
+                                          NULL, NULL, NULL))
                 || !TEST_true(SSL_set_session(clientssl, client_sess)))
             goto end;
 

--- a/test/servername_test.c
+++ b/test/servername_test.c
@@ -210,7 +210,7 @@ static int server_setup_sni(void)
                                        TLS1_VERSION, 0,
                                        &sctx, &cctx, cert, privkey))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL)))
+                                             NULL, NULL, NULL)))
         goto end;
 
     /* set SNI at server side */

--- a/test/ssl_handshake_rtt_test.c
+++ b/test/ssl_handshake_rtt_test.c
@@ -67,7 +67,7 @@ static int test_handshake_rtt(int tst)
                                                   : TLS1_3_VERSION,
                                        &sctx, &cctx, cert, privkey))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL)))
+                                             NULL, NULL, NULL)))
         goto end;
 
     s = SSL_CONNECTION_FROM_SSL(tst % 2 == 0 ? clientssl : serverssl);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -11469,9 +11469,9 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_key_update_peer_in_read, 2);
     ADD_ALL_TESTS(test_key_update_local_in_write, 2);
     ADD_ALL_TESTS(test_key_update_local_in_read, 2);
+    ADD_ALL_TESTS(test_ssl_new_ex, 2);
 #endif
     ADD_ALL_TESTS(test_ssl_clear, 2);
-    ADD_ALL_TESTS(test_ssl_new_ex, 2);
     ADD_ALL_TESTS(test_max_fragment_len_ext, OSSL_NELEM(max_fragment_len_test));
 #if !defined(OPENSSL_NO_SRP) && !defined(OPENSSL_NO_TLS1_2)
     ADD_ALL_TESTS(test_srp, 6);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -390,7 +390,7 @@ static int test_keylog(void)
 
     /* Now do a handshake and check that the logs have been written to. */
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL))
+                                      &clientssl, NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE))
             || !TEST_false(error_writing_log)
@@ -469,7 +469,7 @@ static int test_keylog_no_master_key(void)
 
     /* Now do a handshake and check that the logs have been written to. */
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL))
+                                      &clientssl, NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE))
             || !TEST_false(error_writing_log))
@@ -507,7 +507,7 @@ static int test_keylog_no_master_key(void)
     server_log_buffer_index = 0;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL))
+                                      &clientssl, NULL, NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl, sess))
             /* Here writing 0 length early data is enough. */
             || !TEST_true(SSL_write_early_data(clientssl, NULL, 0, &written))
@@ -591,7 +591,7 @@ static int test_client_cert_verify_cb(void)
     SSL_CTX_set_verify(cctx, SSL_VERIFY_PEER, NULL);
     SSL_CTX_set_cert_verify_callback(cctx, verify_retry_cb, NULL);
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL)))
+                                      &clientssl, NULL, NULL, NULL)))
         goto end;
 
     /* attempt SSL_connect() with incomplete server chain */
@@ -769,7 +769,7 @@ static int test_client_hello_cb(void)
     if (!TEST_true(SSL_CTX_set_cipher_list(cctx,
                         "AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384"))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                             &clientssl, NULL, NULL))
+                                             &clientssl, NULL, NULL, NULL))
             || !TEST_false(create_ssl_connection(serverssl, clientssl,
                         SSL_ERROR_WANT_CLIENT_HELLO_CB))
                 /*
@@ -808,7 +808,7 @@ static int test_no_ems(void)
 
     SSL_CTX_set_options(sctx, SSL_OP_NO_EXTENDED_MASTER_SECRET);
 
-    if (!create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL, NULL)) {
+    if (!create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL, NULL, NULL)) {
         printf("Unable to create SSL objects\n");
         goto end;
     }
@@ -870,7 +870,7 @@ static int test_ccs_change_cipher(void)
                                        &sctx, &cctx, cert, privkey))
             || !TEST_true(SSL_CTX_set_options(sctx, SSL_OP_NO_TICKET))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                          NULL, NULL))
+                          NULL, NULL, NULL))
             || !TEST_true(SSL_set_cipher_list(clientssl, "AES128-GCM-SHA256"))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE))
@@ -884,7 +884,7 @@ static int test_ccs_change_cipher(void)
     /* Resume, preferring a different cipher. Our server will force the
      * same cipher to be used as the initial handshake. */
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                          NULL, NULL))
+                          NULL, NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl, sess))
             || !TEST_true(SSL_set_cipher_list(clientssl, "AES256-GCM-SHA384:AES128-GCM-SHA256"))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
@@ -904,7 +904,7 @@ static int test_ccs_change_cipher(void)
      * cipher on it.
      */
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL))
+                                      NULL, NULL, NULL))
             || !TEST_true(SSL_set_cipher_list(clientssl, "AES128-GCM-SHA256"))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE))
@@ -1040,7 +1040,7 @@ static int execute_test_large_message(const SSL_METHOD *smeth,
         goto end;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL))
+                                      NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
         goto end;
@@ -1662,7 +1662,7 @@ static int test_large_app_data(int tst)
     }
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL)))
+                                      &clientssl, NULL, NULL, NULL)))
         goto end;
 
     if ((tst & 1) != 0) {
@@ -1755,7 +1755,7 @@ static int execute_cleanse_plaintext(const SSL_METHOD *smeth,
 # endif
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL)))
+                                      NULL, NULL, NULL)))
         goto end;
 
     if (!TEST_true(SSL_set_options(serverssl, SSL_OP_CLEANSE_PLAINTEXT)))
@@ -1953,7 +1953,7 @@ static int test_tlsext_status_type(void)
     SSL_CTX_set_tlsext_status_cb(sctx, ocsp_server_cb);
     SSL_CTX_set_tlsext_status_arg(sctx, &cdummyarg);
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL))
+                                      &clientssl, NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE))
             || !TEST_true(ocsp_client_called)
@@ -1969,7 +1969,7 @@ static int test_tlsext_status_type(void)
     ocsp_server_called = 0;
     cdummyarg = 0;
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL))
+                                      &clientssl, NULL, NULL, NULL))
                 /* This should fail because the callback will fail */
             || !TEST_false(create_ssl_connection(serverssl, clientssl,
                                                  SSL_ERROR_NONE))
@@ -1989,7 +1989,7 @@ static int test_tlsext_status_type(void)
     ocsp_server_called = 0;
     cdummyarg = 2;
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL)))
+                                      &clientssl, NULL, NULL, NULL)))
         goto end;
 
     /*
@@ -2113,7 +2113,7 @@ static int execute_test_session(int maxprot, int use_int_cache,
     }
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl1, &clientssl1,
-                                      NULL, NULL))
+                                      NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl1, clientssl1,
                                                 SSL_ERROR_NONE))
             || !TEST_ptr(sess1 = SSL_get1_session(clientssl1)))
@@ -2130,7 +2130,7 @@ static int execute_test_session(int maxprot, int use_int_cache,
 
     new_called = remove_called = 0;
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl2,
-                                      &clientssl2, NULL, NULL))
+                                      &clientssl2, NULL, NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl2, sess1))
             || !TEST_true(create_ssl_connection(serverssl2, clientssl2,
                                                 SSL_ERROR_NONE))
@@ -2166,7 +2166,7 @@ static int execute_test_session(int maxprot, int use_int_cache,
 
     new_called = remove_called = 0;
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl2,
-                                      &clientssl2, NULL, NULL))
+                                      &clientssl2, NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl2, clientssl2,
                                                 SSL_ERROR_NONE)))
         goto end;
@@ -2213,7 +2213,7 @@ static int execute_test_session(int maxprot, int use_int_cache,
     /* Force a connection failure */
     SSL_CTX_set_max_proto_version(sctx, TLS1_1_VERSION);
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl3,
-                                      &clientssl3, NULL, NULL))
+                                      &clientssl3, NULL, NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl3, sess1))
             /* This should fail because of the mismatched protocol versions */
             || !TEST_false(create_ssl_connection(serverssl3, clientssl3,
@@ -2263,7 +2263,7 @@ static int execute_test_session(int maxprot, int use_int_cache,
         SSL_CTX_set_options(sctx, SSL_OP_NO_TICKET);
     new_called = remove_called = get_called = 0;
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl1, &clientssl1,
-                                      NULL, NULL))
+                                      NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl1, clientssl1,
                                                 SSL_ERROR_NONE))
             || !TEST_ptr(sess1 = SSL_get1_session(clientssl1))
@@ -2313,7 +2313,7 @@ static int execute_test_session(int maxprot, int use_int_cache,
     new_called = remove_called = get_called = 0;
     get_sess_val = sess2;
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl2,
-                                      &clientssl2, NULL, NULL))
+                                      &clientssl2, NULL, NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl2, sess1))
             || !TEST_true(create_ssl_connection(serverssl2, clientssl2,
                                                 SSL_ERROR_NONE))
@@ -2505,7 +2505,7 @@ static int check_resumption(int idx, SSL_CTX *sctx, SSL_CTX *cctx, int succ)
     for (i = 0; i < idx * 2; i++) {
         new_called = 0;
         if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                              &clientssl, NULL, NULL))
+                                              &clientssl, NULL, NULL, NULL))
                 || !TEST_true(SSL_set_session(clientssl, sesscache[i])))
             goto end;
 
@@ -2569,7 +2569,7 @@ static int test_tickets(int stateful, int idx)
         goto end;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                          &clientssl, NULL, NULL)))
+                                          &clientssl, NULL, NULL, NULL)))
         goto end;
 
     if (!TEST_true(create_ssl_connection(serverssl, clientssl,
@@ -2613,7 +2613,7 @@ static int test_tickets(int stateful, int idx)
         goto end;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                          &clientssl, NULL, NULL)))
+                                          &clientssl, NULL, NULL, NULL)))
         goto end;
 
     SSL_set_post_handshake_auth(clientssl, 1);
@@ -2696,7 +2696,7 @@ static int test_psk_tickets(void)
     new_called = 0;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL)))
+                                      NULL, NULL, NULL)))
         goto end;
     clientpsk = serverpsk = create_a_psk(clientssl, SHA384_DIGEST_LENGTH);
     if (!TEST_ptr(clientpsk))
@@ -2751,7 +2751,7 @@ static int test_extra_tickets(int idx)
     SSL_CTX_sess_set_new_cb(cctx, new_session_cb);
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                          &clientssl, NULL, NULL)))
+                                          &clientssl, NULL, NULL, NULL)))
         goto end;
 
     /*
@@ -2982,7 +2982,7 @@ static int test_ssl_set_bio(int idx)
     }
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL)))
+                                      NULL, NULL, NULL)))
         goto end;
 
     if (initrbio == USE_BIO_1
@@ -3219,7 +3219,7 @@ static int test_set_sigalgs(int idx)
     }
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL)))
+                                      &clientssl, NULL, NULL, NULL)))
         goto end;
 
     if (!testctx) {
@@ -3490,7 +3490,7 @@ static int setupearly_data_test(SSL_CTX **cctx, SSL_CTX **sctx, SSL **clientssl,
     }
 
     if (!TEST_true(create_ssl_objects(*sctx, *cctx, serverssl, clientssl,
-                                      NULL, NULL)))
+                                      NULL, NULL, NULL)))
         return 0;
 
     /*
@@ -3555,7 +3555,7 @@ static int setupearly_data_test(SSL_CTX **cctx, SSL_CTX **sctx, SSL **clientssl,
         return 0;
 
     if (!TEST_true(create_ssl_objects(*sctx, *cctx, serverssl,
-                                      clientssl, NULL, NULL))
+                                      clientssl, NULL, NULL, NULL))
             || !TEST_true(SSL_set_session(*clientssl, *sess)))
         return 0;
 
@@ -3726,7 +3726,7 @@ static int test_early_data_read_write(int idx)
     SSL_free(clientssl);
     serverssl = clientssl = NULL;
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL))
+                                      &clientssl, NULL, NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl, sess)))
         goto end;
 
@@ -3856,7 +3856,7 @@ static int test_early_data_replay_int(int idx, int usecb, int confopt)
     serverssl = clientssl = NULL;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL))
+                                      &clientssl, NULL, NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl, sess)))
         goto end;
 
@@ -4721,7 +4721,7 @@ static int test_set_ciphersuite(int idx)
     }
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                          &clientssl, NULL, NULL)))
+                                          &clientssl, NULL, NULL, NULL)))
         goto end;
 
     if (idx == 8 || idx == 9) {
@@ -4777,7 +4777,7 @@ static int test_ciphersuite_change(void)
         goto end;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL))
+                                      NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
         goto end;
@@ -4795,7 +4795,7 @@ static int test_ciphersuite_change(void)
     if (!TEST_true(SSL_CTX_set_ciphersuites(cctx,
                                             "TLS_AES_128_CCM_SHA256"))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                             &clientssl, NULL, NULL))
+                                             &clientssl, NULL, NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl, clntsess))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE))
@@ -4816,7 +4816,7 @@ static int test_ciphersuite_change(void)
      */
     if (!TEST_true(SSL_CTX_set_ciphersuites(cctx, "TLS_AES_256_GCM_SHA384"))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL))
+                                             NULL, NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl, clntsess))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_SSL))
@@ -4834,7 +4834,7 @@ static int test_ciphersuite_change(void)
     /* Create a session based on SHA384 */
     if (!TEST_true(SSL_CTX_set_ciphersuites(cctx, "TLS_AES_256_GCM_SHA384"))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                          &clientssl, NULL, NULL))
+                                          &clientssl, NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
         goto end;
@@ -4851,7 +4851,7 @@ static int test_ciphersuite_change(void)
             || !TEST_true(SSL_CTX_set_ciphersuites(sctx,
                                                    "TLS_AES_256_GCM_SHA384"))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL))
+                                             NULL, NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl, clntsess))
                /*
                 * We use SSL_ERROR_WANT_READ below so that we can pause the
@@ -5034,7 +5034,7 @@ static int test_key_exchange(int idx)
 # endif
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL)))
+                                             NULL, NULL, NULL)))
         goto end;
 
     if (!TEST_true(SSL_set1_groups(serverssl, kexch_groups, kexch_groups_size))
@@ -5201,7 +5201,7 @@ static int test_negotiated_group(int idx)
         goto end;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL)))
+                                             NULL, NULL, NULL)))
         goto end;
 
     if (!TEST_true(set_ssl_groups(serverssl, clientssl, clientmulti, isecdhe,
@@ -5227,7 +5227,7 @@ static int test_negotiated_group(int idx)
 
     /* First resumption attempt; use the same config as initial handshake */
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL))
+                                             NULL, NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl, origsess))
             || !TEST_true(set_ssl_groups(serverssl, clientssl, clientmulti,
                                          isecdhe, idx)))
@@ -5273,7 +5273,7 @@ static int test_negotiated_group(int idx)
             expectednid = 0;
     }
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL))
+                                             NULL, NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl, origsess))
             || !TEST_true(set_ssl_groups(serverssl, clientssl, clientmulti,
                                          isecdhe, idx)))
@@ -5387,7 +5387,7 @@ static int test_tls13_ciphersuite(int idx)
             }
 
             if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                              &clientssl, NULL, NULL)))
+                                              &clientssl, NULL, NULL, NULL)))
                 goto end;
 
             if (set_at_ssl) {
@@ -5524,7 +5524,7 @@ static int test_tls13_psk(int idx)
          * PSK
          */
         if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                                 NULL, NULL))
+                                                 NULL, NULL, NULL))
                 || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                     SSL_ERROR_NONE))
                 || !TEST_false(SSL_session_reused(clientssl))
@@ -5555,7 +5555,7 @@ static int test_tls13_psk(int idx)
     }
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL)))
+                                             NULL, NULL, NULL)))
         goto end;
 
     /* Create the PSK */
@@ -5598,7 +5598,7 @@ static int test_tls13_psk(int idx)
     psk_client_cb_cnt = psk_server_cb_cnt = 0;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL)))
+                                             NULL, NULL, NULL)))
         goto end;
 
     /* Force an HRR */
@@ -5645,7 +5645,7 @@ static int test_tls13_psk(int idx)
          */
         srvid = "Dummy Identity";
         if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                                 NULL, NULL))
+                                                 NULL, NULL, NULL))
                 || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                     SSL_ERROR_NONE))
                 || !TEST_false(SSL_session_reused(clientssl))
@@ -5741,7 +5741,7 @@ static int test_stateless(void)
     SSL_CTX_clear_options(cctx, SSL_OP_ENABLE_MIDDLEBOX_COMPAT);
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL))
+                                      NULL, NULL, NULL))
                /* Send the first ClientHello */
             || !TEST_false(create_ssl_connection(serverssl, clientssl,
                                                  SSL_ERROR_WANT_READ))
@@ -5765,7 +5765,7 @@ static int test_stateless(void)
      * object).
      */
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL))
+                                             NULL, NULL, NULL))
                /* Send the first ClientHello */
             || !TEST_false(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_WANT_READ))
@@ -5782,7 +5782,7 @@ static int test_stateless(void)
      * object
      */
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL))
+                                             NULL, NULL, NULL))
                /* Send the first ClientHello */
             || !TEST_false(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_WANT_READ))
@@ -6070,7 +6070,7 @@ static int test_custom_exts(int tst)
     }
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL))
+                                      &clientssl, NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
         goto end;
@@ -6118,7 +6118,7 @@ static int test_custom_exts(int tst)
     }
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL))
+                                      NULL, NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl, sess))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                SSL_ERROR_NONE)))
@@ -6278,7 +6278,7 @@ static int test_serverinfo_custom(const int idx)
                                           serverinfo_custom_parse_cb,
                                           &cb_result))
         || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                         NULL, NULL))
+                                         NULL, NULL, NULL))
         || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                             SSL_ERROR_NONE))
         || !TEST_int_eq(SSL_do_handshake(clientssl), 1))
@@ -6357,7 +6357,7 @@ static int test_export_key_mat(int tst)
         || !SSL_CTX_set_cipher_list(sctx, "DEFAULT:@SECLEVEL=0")))
         goto end;
 
-    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL,
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL, NULL,
                                       NULL)))
         goto end;
 
@@ -6562,7 +6562,7 @@ static int test_key_update(void)
                                        0,
                                        &sctx, &cctx, cert, privkey))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL))
+                                             NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
         goto end;
@@ -6625,7 +6625,7 @@ static int test_key_update_peer_in_write(int tst)
                                               0,
                                               &sctx, &cctx, cert, privkey))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL))
+                                             NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
         goto end;
@@ -6709,7 +6709,7 @@ static int test_key_update_peer_in_read(int tst)
                                               0,
                                               &sctx, &cctx, cert, privkey))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL))
+                                             NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
         goto end;
@@ -6794,7 +6794,7 @@ static int test_key_update_local_in_write(int tst)
                                               0,
                                               &sctx, &cctx, cert, privkey))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL))
+                                             NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
         goto end;
@@ -6883,7 +6883,7 @@ static int test_key_update_local_in_read(int tst)
                                               0,
                                               &sctx, &cctx, cert, privkey))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL))
+                                             NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
         goto end;
@@ -6964,7 +6964,7 @@ static int test_ssl_clear(int idx)
                 && !TEST_true(SSL_CTX_set_max_proto_version(cctx,
                                                             TLS1_2_VERSION)))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                          &clientssl, NULL, NULL))
+                                          &clientssl, NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
         goto end;
@@ -6979,7 +6979,7 @@ static int test_ssl_clear(int idx)
         goto end;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL))
+                                             NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE))
             || !TEST_true(SSL_session_reused(clientssl)))
@@ -6987,6 +6987,56 @@ static int test_ssl_clear(int idx)
 
     SSL_shutdown(clientssl);
     SSL_shutdown(serverssl);
+
+    testresult = 1;
+
+ end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+
+    return testresult;
+}
+
+static int test_ssl_new_ex(int idx)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    int testresult = 0;
+
+    /* Create an initial connection */
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+                                       TLS_client_method(), TLS1_VERSION, 0,
+                                       &sctx, &cctx, cert, privkey))
+            || !TEST_true(SSL_CTX_set_max_proto_version(cctx,
+                                                        TLS1_2_VERSION)))
+        goto end;
+
+    switch (idx) {
+    case 0:
+        /* Positive test case with valid provider parameter */
+        if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
+                                      &clientssl, "provider=default", NULL, NULL))
+        || !TEST_true(create_ssl_connection(serverssl, clientssl,
+                                            SSL_ERROR_NONE)))
+            goto end;
+        break;
+    case 1:
+        /* Negative test case with invalid provider parameter */
+        if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
+                                      &clientssl, "provider=lola", NULL, NULL))
+        || !TEST_false(create_ssl_connection(serverssl, clientssl,
+                                            SSL_ERROR_NONE)))
+            goto end;
+        break;
+    }
+
+    SSL_shutdown(clientssl);
+    SSL_shutdown(serverssl);
+
+    if (!TEST_true(SSL_clear(clientssl)))
+        goto end;
 
     testresult = 1;
 
@@ -7132,7 +7182,7 @@ static int test_pha_key_update(void)
     SSL_CTX_set_post_handshake_auth(cctx, 1);
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL)))
+                                      NULL, NULL, NULL)))
         goto end;
 
     if (!TEST_true(create_ssl_connection(serverssl, clientssl,
@@ -7362,7 +7412,7 @@ static int test_srp(int tst)
     }
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL)))
+                                      NULL, NULL, NULL)))
         goto end;
 
     ret = create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE);
@@ -7658,7 +7708,7 @@ static int test_info_callback(int tst)
     }
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                          &clientssl, NULL, NULL))
+                                          &clientssl, NULL, NULL, NULL))
         || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                             SSL_ERROR_NONE))
         || !TEST_false(info_cb_failed))
@@ -7675,7 +7725,7 @@ static int test_info_callback(int tst)
 
     /* Now do a resumption */
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL,
-                                      NULL))
+                                      NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl, clntsess))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE))
@@ -7738,7 +7788,7 @@ static int test_ssl_pending(int tst)
     }
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL))
+                                             NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
         goto end;
@@ -7900,7 +7950,7 @@ static int int_test_ssl_get_shared_ciphers(int tst, int clnt)
 
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL))
+                                             NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
         goto end;
@@ -8181,7 +8231,7 @@ static int test_ticket_callbacks(int tst)
     }
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL))
+                                             NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
         goto end;
@@ -8208,7 +8258,7 @@ static int test_ticket_callbacks(int tst)
 
     /* Now do a resumption */
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL,
-                                      NULL))
+                                      NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl, clntsess))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
@@ -8271,7 +8321,7 @@ static int test_incorrect_shutdown(int tst)
         SSL_CTX_set_options(sctx, SSL_OP_IGNORE_UNEXPECTED_EOF);
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                            NULL, NULL)))
+                                            NULL, NULL, NULL)))
         goto end;
 
     if (!TEST_true(create_ssl_connection(serverssl, clientssl,
@@ -8344,7 +8394,7 @@ static int test_shutdown(int tst)
         SSL_CTX_set_post_handshake_auth(cctx, 1);
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL)))
+                                             NULL, NULL, NULL)))
         goto end;
 
     if (tst == 3) {
@@ -8483,7 +8533,7 @@ static int test_async_shutdown(void)
         goto end;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL,
-                                      NULL)))
+                                      NULL, NULL)))
         goto end;
 
     if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
@@ -8675,7 +8725,7 @@ static int test_cert_cb_int(int prot, int tst)
     SSL_CTX_set_cert_cb(sctx, cert_cb, snictx);
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL)))
+                                      NULL, NULL, NULL)))
         goto end;
 
     if (tst == 4) {
@@ -8799,7 +8849,7 @@ static int test_client_cert_cb(int tst)
                        verify_cb);
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL))
+                                      NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
         goto end;
@@ -8882,7 +8932,7 @@ static int test_ca_names_int(int prot, int tst)
     }
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL))
+                                      NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
         goto end;
@@ -9012,7 +9062,7 @@ static int test_multiblock_write(int test_index)
         goto end;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL)))
+                                      NULL, NULL, NULL)))
             goto end;
 
     /* settings to force it to use AES-CBC-HMAC_SHA */
@@ -9207,7 +9257,7 @@ static int test_servername(int tst)
                                                   : TLS1_3_VERSION,
                                        &sctx, &cctx, cert, privkey))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL)))
+                                             NULL, NULL, NULL)))
         goto end;
 
     if (tst != 1 && tst != 6) {
@@ -9245,7 +9295,7 @@ static int test_servername(int tst)
     clientssl = serverssl = NULL;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL,
-                                      NULL)))
+                                      NULL, NULL)))
         goto end;
 
     if (!TEST_true(SSL_set_session(clientssl, sess)))
@@ -9445,7 +9495,7 @@ static int test_sigalgs_available(int idx)
         goto end;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL)))
+                                      NULL, NULL, NULL)))
         goto end;
 
     if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
@@ -9511,7 +9561,7 @@ static int test_pluggable_group(int idx)
                                        TLS1_3_VERSION,
                                        &sctx, &cctx, cert, privkey))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL)))
+                                             NULL, NULL, NULL)))
         goto end;
 
     if (!TEST_true(SSL_set1_groups_list(serverssl, group_name))
@@ -9621,7 +9671,7 @@ static int test_pluggable_signature(int idx)
                                        TLS1_3_VERSION,
                                        &sctx, &cctx, certfilename, privkeyfilename))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL)))
+                                             NULL, NULL, NULL)))
         goto end;
 
     /* Enable RPK for server cert */
@@ -9678,7 +9728,7 @@ static int test_ssl_dup(void)
         goto end;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL)))
+                                             NULL, NULL, NULL)))
         goto end;
 
     if (!TEST_true(SSL_set_min_proto_version(clientssl, TLS1_2_VERSION))
@@ -9882,7 +9932,7 @@ static int test_set_tmp_dh(int idx)
 #  endif
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL)))
+                                      NULL, NULL, NULL)))
         goto end;
 
     if ((idx & 1) == 0 && idx != 0) {
@@ -10009,7 +10059,7 @@ static int test_dh_auto(int idx)
         goto end;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                      NULL, NULL)))
+                                      NULL, NULL, NULL)))
         goto end;
 
     if (!TEST_true(SSL_set_dh_auto(serverssl, 1))
@@ -10086,7 +10136,7 @@ static int test_sni_tls13(void)
      * certificates configured.
      */
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL))
+                                      &clientssl, NULL, NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
         goto end;
@@ -10135,7 +10185,7 @@ static int test_ticket_lifetime(int idx)
         goto end;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL)))
+                                      &clientssl, NULL, NULL, NULL)))
         goto end;
 
     /*
@@ -10502,7 +10552,7 @@ static int test_read_ahead_key_change(void)
     SSL_CTX_set_read_ahead(sctx, 1);
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL)))
+                                      &clientssl, NULL, NULL, NULL)))
         goto end;
 
     if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
@@ -10613,7 +10663,7 @@ static int test_tls13_record_padding(int idx)
     }
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL)))
+                                      &clientssl, NULL, NULL, NULL)))
         goto end;
 
     if (idx == 1) {
@@ -10717,7 +10767,7 @@ static int test_pipelining(int idx)
         goto end;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL)))
+                                      &clientssl, NULL, NULL, NULL)))
         goto end;
 
     if (!TEST_true(SSL_set_cipher_list(clientssl, "AES128-SHA")))
@@ -10971,7 +11021,7 @@ static int test_version(int idx)
         goto end;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL)))
+                                      &clientssl, NULL, NULL, NULL)))
         goto end;
 
     if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
@@ -11035,7 +11085,7 @@ static int test_rstate_string(void)
         goto end;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL)))
+                                      &clientssl, NULL, NULL, NULL)))
         goto end;
 
     if (!TEST_str_eq(SSL_rstate_string(serverssl), "RH")
@@ -11139,7 +11189,7 @@ static int test_handshake_retry(int idx)
         set_always_retry_err_val(0);
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL)))
+                                      &clientssl, NULL, NULL, NULL)))
         goto end;
 
     tmp = SSL_get_wbio(serverssl);
@@ -11421,6 +11471,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_key_update_local_in_read, 2);
 #endif
     ADD_ALL_TESTS(test_ssl_clear, 2);
+    ADD_ALL_TESTS(test_ssl_new_ex, 2);
     ADD_ALL_TESTS(test_max_fragment_len_ext, OSSL_NELEM(max_fragment_len_test));
 #if !defined(OPENSSL_NO_SRP) && !defined(OPENSSL_NO_TLS1_2)
     ADD_ALL_TESTS(test_srp, 6);

--- a/test/sslbuffertest.c
+++ b/test/sslbuffertest.c
@@ -70,7 +70,7 @@ static int test_func(int test)
     char buf[sizeof(testdata)];
 
     if (!TEST_true(create_ssl_objects(serverctx, clientctx, &serverssl, &clientssl,
-                                      NULL, NULL))) {
+                                      NULL, NULL, NULL))) {
         TEST_error("Test %d failed: Create SSL objects failed\n", test);
         goto end;
     }

--- a/test/sslcorrupttest.c
+++ b/test/sslcorrupttest.c
@@ -219,7 +219,7 @@ static int test_ssl_corrupt(int testidx)
         goto end;
 
     /* BIO is freed by create_ssl_connection on error */
-    if (!TEST_true(create_ssl_objects(sctx, cctx, &server, &client, NULL,
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &server, &client, NULL, NULL,
                                       c_to_s_fbio)))
         goto end;
 

--- a/test/tls13ccstest.c
+++ b/test/tls13ccstest.c
@@ -300,7 +300,7 @@ static int test_tls13ccs(int tst)
 
     if (tst >= 6) {
         /* Get a session suitable for early_data */
-        if (!TEST_true(create_ssl_objects(sctx, cctx, &sssl, &cssl, NULL, NULL))
+        if (!TEST_true(create_ssl_objects(sctx, cctx, &sssl, &cssl, NULL, NULL, NULL))
                 || !TEST_true(create_ssl_connection(sssl, cssl, SSL_ERROR_NONE)))
             goto err;
         sess = SSL_get1_session(cssl);
@@ -336,7 +336,7 @@ static int test_tls13ccs(int tst)
     }
 
     /* BIOs get freed on error */
-    if (!TEST_true(create_ssl_objects(sctx, cctx, &sssl, &cssl, s_to_c_fbio,
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &sssl, &cssl, NULL, s_to_c_fbio,
                                       c_to_s_fbio)))
         goto err;
 

--- a/test/tls13secretstest.c
+++ b/test/tls13secretstest.c
@@ -413,7 +413,7 @@ int setup_tests(void)
     return 1;
 }
 
-const char *ssl_connection_prov_querry(SSL_CONNECTION *ssl_conn)
+const char *ssl_connection_prov_querry(const SSL_CONNECTION *ssl_conn)
 {
     /* Return propq from SSL object prior when set,
      * otherwise use the SSL_CTX propq.

--- a/test/tls13secretstest.c
+++ b/test/tls13secretstest.c
@@ -412,3 +412,17 @@ int setup_tests(void)
     ADD_TEST(test_handshake_secrets);
     return 1;
 }
+
+const char *ssl_connection_prov_querry(SSL_CONNECTION *ssl_conn)
+{
+    /* Return propq from SSL object prior when set,
+     * otherwise use the SSL_CTX propq.
+     */
+    if (ssl_conn != NULL) {
+        if (SSL_CONNECTION_GET_SSL(ssl_conn) != NULL)
+            return SSL_CONNECTION_GET_SSL(ssl_conn)->propq;
+        else if (SSL_CONNECTION_GET_CTX(ssl_conn) != NULL)
+            return SSL_CONNECTION_GET_CTX(ssl_conn)->propq;
+    }
+    return NULL;
+}

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -577,3 +577,4 @@ SSL_handle_events                       ?	3_2_0	EXIST::FUNCTION:
 SSL_get_event_timeout                   ?	3_2_0	EXIST::FUNCTION:
 SSL_get0_group_name                     ?	3_2_0	EXIST::FUNCTION:
 SSL_is_stream_local                     ?	3_2_0	EXIST::FUNCTION:
+SSL_new_ex                              ?	3_2_0	EXIST::FUNCTION:


### PR DESCRIPTION
The SSL_CTX is created with the library context which can contain multiple providers.
At this stage the SSL_CTX object contains the provider query parameter and all the settings for SSL connection.

It makes sense for developer to create a SSL_CTX early at the application entry and apply all the settings before creating the SSL object. However, it can be the case that the app needs to toggle between provider preference when creating SSL objects.
This pull request will add the possibility to bind the provider query parameter to the SSL object by using a new SSL_new_ex API.
During the SSL connection, the provider query parameter from the SSL object will be used when set otherwise the SSL_CTX provider query parameter will be used (which is the current way).
 
