### PR TITLE
fips compatibility: update 3.1.1 to 3.1.2

### DIFF
--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -45,9 +45,9 @@ jobs:
             url: "https://www.openssl.org/source/openssl-3.0.9.tar.gz",
           },
           {
-            dir: openssl-3.1.1,
-            tgz: openssl-3.1.1.tar.gz,
-            url: "https://www.openssl.org/source/openssl-3.1.1.tar.gz",
+            dir: openssl-3.1.2,
+            tgz: openssl-3.1.2.tar.gz,
+            url: "https://www.openssl.org/source/openssl-3.1.2.tar.gz",
           },
         ]
 


### PR DESCRIPTION
The plan at the moment is to validate 3.1.2 all going well.

- [ ] documentation is added or updated
- [x] tests are added or updated
