### PR TITLE
augment man pages with information about PKCS12KDF in FIPS mode

### DIFF
--- a/doc/man3/PKCS12_create.pod
+++ b/doc/man3/PKCS12_create.pod
@@ -57,7 +57,8 @@ can all be set to zero and sensible defaults will be used.
 These defaults are: AES password based encryption (PBES2 with PBKDF2 and
 AES-256-CBC) for private keys and certificates, the PBKDF2 and MAC key
 derivation iteration count of B<PKCS12_DEFAULT_ITER> (currently 2048), and
-MAC algorithm HMAC with SHA2-256.
+MAC algorithm HMAC with SHA2-256. The MAC key derivation algorithm used
+for the outer PKCS#12 structure is is PKCS12KDF.
 
 The default MAC iteration count is 1 in order to retain compatibility with
 old software which did not interpret MAC iteration counts. If such compatibility
@@ -83,6 +84,8 @@ I<nid_key> or I<nid_cert> can be set to -1 indicating that no encryption
 should be used.
 
 I<mac_iter> can be set to -1 and the MAC will then be omitted entirely.
+This can be useful when running with the FIPS provider as the PKCS12KDF
+is not a FIPS approved algorithm.
 
 PKCS12_create() makes assumptions regarding the encoding of the given pass
 phrase.
@@ -101,7 +104,9 @@ IETF RFC 7292 (L<https://tools.ietf.org/html/rfc7292>)
 
 =head1 SEE ALSO
 
+L<EVP_KDF-PKCS12KDF(3)>,
 L<d2i_PKCS12(3)>,
+L<OSSL_PROVIDER-FIPS(7)>,
 L<passphrase-encoding(7)>
 
 =head1 HISTORY

--- a/doc/man3/PKCS12_create.pod
+++ b/doc/man3/PKCS12_create.pod
@@ -104,7 +104,7 @@ IETF RFC 7292 (L<https://tools.ietf.org/html/rfc7292>)
 
 =head1 SEE ALSO
 
-L<EVP_KDF-PKCS12KDF(3)>,
+L<EVP_KDF-PKCS12KDF(7)>,
 L<d2i_PKCS12(3)>,
 L<OSSL_PROVIDER-FIPS(7)>,
 L<passphrase-encoding(7)>

--- a/doc/man3/PKCS12_create.pod
+++ b/doc/man3/PKCS12_create.pod
@@ -58,7 +58,7 @@ These defaults are: AES password based encryption (PBES2 with PBKDF2 and
 AES-256-CBC) for private keys and certificates, the PBKDF2 and MAC key
 derivation iteration count of B<PKCS12_DEFAULT_ITER> (currently 2048), and
 MAC algorithm HMAC with SHA2-256. The MAC key derivation algorithm used
-for the outer PKCS#12 structure is is PKCS12KDF.
+for the outer PKCS#12 structure is PKCS12KDF.
 
 The default MAC iteration count is 1 in order to retain compatibility with
 old software which did not interpret MAC iteration counts. If such compatibility

--- a/doc/man3/PKCS12_create.pod
+++ b/doc/man3/PKCS12_create.pod
@@ -85,7 +85,7 @@ should be used.
 
 I<mac_iter> can be set to -1 and the MAC will then be omitted entirely.
 This can be useful when running with the FIPS provider as the PKCS12KDF
-is not a FIPS approved algorithm.
+is not a FIPS approvable algorithm.
 
 PKCS12_create() makes assumptions regarding the encoding of the given pass
 phrase.

--- a/doc/man3/PKCS12_gen_mac.pod
+++ b/doc/man3/PKCS12_gen_mac.pod
@@ -20,8 +20,9 @@ PKCS12_verify_mac - Functions to create and manipulate a PKCS#12 structure
 
 =head1 DESCRIPTION
 
-PKCS12_gen_mac() generates an HMAC over the entire PKCS#12 object using the
+PKCS12_gen_mac() generates a HMAC over the entire PKCS#12 object using the
 supplied password along with a set of already configured parameters.
+The default key generation mechanism used is PKCS12KDF.
 
 PKCS12_verify_mac() verifies the PKCS#12 object's HMAC using the supplied
 password.
@@ -57,6 +58,7 @@ IETF RFC 7292 (L<https://tools.ietf.org/html/rfc7292>)
 =head1 SEE ALSO
 
 L<d2i_PKCS12(3)>,
+L<EVP_KDF-PKCS12KDF(3)>,
 L<PKCS12_create(3)>,
 L<passphrase-encoding(7)>
 

--- a/doc/man3/PKCS12_gen_mac.pod
+++ b/doc/man3/PKCS12_gen_mac.pod
@@ -20,7 +20,7 @@ PKCS12_verify_mac - Functions to create and manipulate a PKCS#12 structure
 
 =head1 DESCRIPTION
 
-PKCS12_gen_mac() generates a HMAC over the entire PKCS#12 object using the
+PKCS12_gen_mac() generates an HMAC over the entire PKCS#12 object using the
 supplied password along with a set of already configured parameters.
 The default key generation mechanism used is PKCS12KDF.
 

--- a/doc/man3/PKCS12_gen_mac.pod
+++ b/doc/man3/PKCS12_gen_mac.pod
@@ -58,7 +58,7 @@ IETF RFC 7292 (L<https://tools.ietf.org/html/rfc7292>)
 =head1 SEE ALSO
 
 L<d2i_PKCS12(3)>,
-L<EVP_KDF-PKCS12KDF(3)>,
+L<EVP_KDF-PKCS12KDF(7)>,
 L<PKCS12_create(3)>,
 L<passphrase-encoding(7)>
 

--- a/doc/man7/EVP_KDF-PKCS12KDF.pod
+++ b/doc/man7/EVP_KDF-PKCS12KDF.pod
@@ -47,7 +47,7 @@ RFC 7292 section B.3.
 =head1 NOTES
 
 This algorithm is not available in the FIPS provider as it is not FIPS
-approved.
+approvable.
 
 A typical application of this algorithm is to derive keying material for an
 encryption algorithm from a password in the "pass", a salt in "salt",

--- a/doc/man7/EVP_KDF-PKCS12KDF.pod
+++ b/doc/man7/EVP_KDF-PKCS12KDF.pod
@@ -46,6 +46,9 @@ RFC 7292 section B.3.
 
 =head1 NOTES
 
+This algorithm is not available in the FIPS provider as it is not FIPS
+approved.
+
 A typical application of this algorithm is to derive keying material for an
 encryption algorithm from a password in the "pass", a salt in "salt",
 and an iteration count.
@@ -68,7 +71,8 @@ L<EVP_KDF_CTX_new(3)>,
 L<EVP_KDF_CTX_free(3)>,
 L<EVP_KDF_CTX_set_params(3)>,
 L<EVP_KDF_derive(3)>,
-L<EVP_KDF(3)/PARAMETERS>
+L<EVP_KDF(3)/PARAMETERS>,
+L<OSSL_PROVIDER-FIPS(7)>
 
 =head1 HISTORY
 

--- a/doc/man7/ossl-guide-migration.pod
+++ b/doc/man7/ossl-guide-migration.pod
@@ -330,7 +330,7 @@ L<EVP_PBE_CipherInit_ex(3)>, L<EVP_PBE_find_ex(3)> and L<EVP_PBE_scrypt_ex(3)>.
 =head4 PKCS#12 KDF versus FIPS
 
 Unlike in 1.x, the PKCS12KDF algorithm used when a PKCS#12 structure is created
-with MAC does not work with the FIPS provider as the PKCS12KDF
+with a MAC that does not work with the FIPS provider as the PKCS12KDF
 is not a FIPS approvable mechanism.
 
 See L<EVP_KDF-PKCS12KDF(7)>, L<PKCS12_create(3)>, L<openssl-pkcs12(1)>,

--- a/doc/man7/ossl-guide-migration.pod
+++ b/doc/man7/ossl-guide-migration.pod
@@ -327,13 +327,13 @@ context and property query and will call an extended version of the key/IV
 derivation function which supports these parameters. This includes
 L<EVP_PBE_CipherInit_ex(3)>, L<EVP_PBE_find_ex(3)> and L<EVP_PBE_scrypt_ex(3)>.
 
-=head4 PKCS#12 KDF vs. FIPS
+=head4 PKCS#12 KDF versus FIPS
 
 Unlike in 1.x, due to code restructuring, the PKCS12KDF algorithm used when
 a PKCS#12 structure is created with MAC does not work with the FIPS provider
 as the PKCS12KDF is not a FIPS approved mechanism.
 
-See L<EVP_KDF-PKCS12KDF(3)>, L<PKCS12_create(3)>, L<openssl-pkcs12(1)>,
+See L<EVP_KDF-PKCS12KDF(7)>, L<PKCS12_create(3)>, L<openssl-pkcs12(1)>,
 L<OSSL_PROVIDER-FIPS(7)>.
 
 =head4 Windows thread synchronization changes

--- a/doc/man7/ossl-guide-migration.pod
+++ b/doc/man7/ossl-guide-migration.pod
@@ -329,8 +329,8 @@ L<EVP_PBE_CipherInit_ex(3)>, L<EVP_PBE_find_ex(3)> and L<EVP_PBE_scrypt_ex(3)>.
 
 =head4 PKCS#12 KDF versus FIPS
 
-Unlike in 1.x, the PKCS12KDF algorithm used when a PKCS#12 structure is created
-with a MAC that does not work with the FIPS provider as the PKCS12KDF
+Unlike in 1.x.y, the PKCS12KDF algorithm used when a PKCS#12 structure
+is created with a MAC that does not work with the FIPS provider as the PKCS12KDF
 is not a FIPS approvable mechanism.
 
 See L<EVP_KDF-PKCS12KDF(7)>, L<PKCS12_create(3)>, L<openssl-pkcs12(1)>,

--- a/doc/man7/ossl-guide-migration.pod
+++ b/doc/man7/ossl-guide-migration.pod
@@ -329,9 +329,9 @@ L<EVP_PBE_CipherInit_ex(3)>, L<EVP_PBE_find_ex(3)> and L<EVP_PBE_scrypt_ex(3)>.
 
 =head4 PKCS#12 KDF versus FIPS
 
-Unlike in 1.x, due to code restructuring, the PKCS12KDF algorithm used when
-a PKCS#12 structure is created with MAC does not work with the FIPS provider
-as the PKCS12KDF is not a FIPS approved mechanism.
+Unlike in 1.x, the PKCS12KDF algorithm used when a PKCS#12 structure is created
+with MAC does not work with the FIPS provider as the PKCS12KDF
+is not a FIPS approvable mechanism.
 
 See L<EVP_KDF-PKCS12KDF(7)>, L<PKCS12_create(3)>, L<openssl-pkcs12(1)>,
 L<OSSL_PROVIDER-FIPS(7)>.

--- a/doc/man7/ossl-guide-migration.pod
+++ b/doc/man7/ossl-guide-migration.pod
@@ -327,6 +327,15 @@ context and property query and will call an extended version of the key/IV
 derivation function which supports these parameters. This includes
 L<EVP_PBE_CipherInit_ex(3)>, L<EVP_PBE_find_ex(3)> and L<EVP_PBE_scrypt_ex(3)>.
 
+=head4 PKCS#12 KDF vs. FIPS
+
+Unlike in 1.x, due to code restructuring, the PKCS12KDF algorithm used when
+a PKCS#12 structure is created with MAC does not work with the FIPS provider
+as the PKCS12KDF is not a FIPS approved mechanism.
+
+See L<EVP_KDF-PKCS12KDF(3)>, L<PKCS12_create(3)>, L<openssl-pkcs12(1)>,
+L<OSSL_PROVIDER-FIPS(7)>.
+
 =head4 Windows thread synchronization changes
 
 Windows thread synchronization uses read/write primitives (SRWLock) when


### PR DESCRIPTION
Recently I [too](https://github.com/openssl/openssl/issues/20427) [fell](https://github.com/openssl/openssl/issues/19997) [into](https://github.com/openssl/openssl/issues/19798) [the](https://github.com/openssl/openssl/issues/17720) [rabbit](https://github.com/openssl/openssl/issues/14057) hole of PKCS12KDF vs FIPS. I felt that more should be said about that in the man pages, hence this change.