### PR TITLE
Fix remaining errors reported in issue 21935

### DIFF
--- a/crypto/param_build_set.c
+++ b/crypto/param_build_set.c
@@ -100,14 +100,17 @@ int ossl_param_build_set_multi_key_bn(OSSL_PARAM_BLD *bld, OSSL_PARAM *params,
                                       STACK_OF(BIGNUM_const) *stk)
 {
     int i, sz = sk_BIGNUM_const_num(stk);
+    const BIGNUM *value = NULL;
     OSSL_PARAM *p;
 
 
     if (bld != NULL) {
         for (i = 0; i < sz && names[i] != NULL; ++i) {
-            if (!OSSL_PARAM_BLD_push_BN(bld, names[i],
-                                        sk_BIGNUM_const_value(stk, i)))
-                return 0;
+            value = sk_BIGNUM_const_value(stk, i);
+            if (value)
+                if (!OSSL_PARAM_BLD_push_BN(bld, names[i],
+                                            sk_BIGNUM_const_value(stk, i)))
+                    return 0;
         }
         return 1;
     }
@@ -115,8 +118,10 @@ int ossl_param_build_set_multi_key_bn(OSSL_PARAM_BLD *bld, OSSL_PARAM *params,
     for (i = 0; i < sz && names[i] != NULL; ++i) {
         p = OSSL_PARAM_locate(params, names[i]);
         if (p != NULL) {
-            if (!OSSL_PARAM_set_BN(p, sk_BIGNUM_const_value(stk, i)))
-                return 0;
+            value = sk_BIGNUM_const_value(stk, i);
+            if (value)
+                if (!OSSL_PARAM_set_BN(p, sk_BIGNUM_const_value(stk, i)))
+                    return 0;
         }
     }
     return 1;

--- a/crypto/rsa/rsa_backend.c
+++ b/crypto/rsa/rsa_backend.c
@@ -141,18 +141,6 @@ int ossl_rsa_todata(RSA *rsa, OSSL_PARAM_BLD *bld, OSSL_PARAM params[],
 
     /* Check private key data integrity */
     if (include_private && rsa_d != NULL) {
-        int numprimes = sk_BIGNUM_const_num(factors);
-        int numexps = sk_BIGNUM_const_num(exps);
-        int numcoeffs = sk_BIGNUM_const_num(coeffs);
-
-        /*
-         * It's permissible to have zero primes, i.e. no CRT params.
-         * Otherwise, there must be at least two, as many exponents,
-         * and one coefficient less.
-         */
-        if (numprimes != 0
-            && (numprimes < 2 || numexps < 2 || numcoeffs < 1))
-            goto err;
 
         if (!ossl_param_build_set_bn(bld, params, OSSL_PKEY_PARAM_RSA_D,
                                      rsa_d)


### PR DESCRIPTION
@t8m identified 3 issues in #21195 
1. OSSL_PARAM_BLD_push_BN() must not segfault when the bn argument is NULL - that should push 0 number instead as it does on <= 3.1
2. ossl_param_build_set_multi_key_bn() should not push missing bignums as NULL
3. It should be possible to export RSA key with d, p, q and without CRT params to provider, there is no point in disallowing that.

He fixed the first one in https://github.com/openssl/openssl/pull/21945

This PR fixes the remaining 2

