### PR TITLE
OSSL_STORE: Fix error flag clearing and setting (provider path only)

### DIFF
--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -428,14 +428,14 @@ OSSL_STORE_INFO *OSSL_STORE_load(OSSL_STORE_CTX *ctx)
 
             load_data.v = NULL;
             load_data.ctx = ctx;
+            ctx->error_flag = 0;
 
             if (!ctx->fetched_loader->p_load(ctx->loader_ctx,
                                              ossl_store_handle_load_result,
                                              &load_data,
                                              ossl_pw_passphrase_callback_dec,
                                              &ctx->pwdata)) {
-                if (!OSSL_STORE_eof(ctx))
-                    ctx->error_flag = 1;
+                ctx->error_flag = 1;
                 return NULL;
             }
             v = load_data.v;


### PR DESCRIPTION
When the provider's load function returned with an error, the libcrypto
error flag was only set if EOF hadn't been reached.  This is troublesome,
as an error can very well occur during the last load before EOF is reached!

Also, the error flag was never reset, even though documentation specifies
that it should indicate an error in the last load (i.e. not the one before
that).

Fixes #21968
