### PR TITLE
Modify the dkeyform type to support engine

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -799,7 +799,7 @@ const OPTIONS s_server_options[] = {
      "second server certificate chain file in PEM format"},
     {"dkey", OPT_DKEY, '<',
      "Second private key file to use (usually for DSA)"},
-    {"dkeyform", OPT_DKEYFORM, 'F',
+    {"dkeyform", OPT_DKEYFORM, 'f',
      "Second key file format (ENGINE, other values ignored)"},
     {"dpass", OPT_DPASS, 's',
      "Second private key and cert file pass phrase source"},


### PR DESCRIPTION
The valtype value of dkeyform defined in the s_server_options structure is F, which leads to the judgment that the engine is not supported when processing parameters in the opt_next function. This the valtype value of dkeyform should be changed to "f".

fix: #21980 

CLA: trivial
