### PR TITLE
BIO_set_accept_name(): To accept from any interface, use *

### DIFF
--- a/apps/lib/http_server.c
+++ b/apps/lib/http_server.c
@@ -200,7 +200,7 @@ BIO *http_server_init(const char *prog, const char *port, int verb)
     int port_num;
     char name[40];
 
-    snprintf(name, sizeof(name), "[::]:%s", port); /* port may be "0" */
+    snprintf(name, sizeof(name), "*:%s", port); /* port may be "0" */
     if (verb >= 0 && !log_set_verbosity(prog, verb))
         return NULL;
     bufbio = BIO_new(BIO_f_buffer());

--- a/test/recipes/80-test_cmp_http_data/test_connection.csv
+++ b/test/recipes/80-test_cmp_http_data/test_connection.csv
@@ -3,7 +3,6 @@ expected,description, -section,val, -server,val, -proxy,val, -no_proxy,val, -tls
 ,,,,,,,,,,,,,,,,,,,
 1,default config, -section,,,,,,,,BLANK,,,,BLANK,,BLANK,,BLANK,
 1,server domain name, -section,, -server,localhost:_SERVER_PORT,,,,,,,,,,,,,,
-1,server IPv6 address, -section,, -server,[::1]:_SERVER_PORT,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,
 0,wrong server, -section,, -server,xn--rksmrgs-5wao1o.example.com:_SERVER_PORT,,,,,BLANK,,,, -msg_timeout,1,BLANK,,BLANK,
 0,wrong server port, -section,, -server,_SERVER_HOST:99,,,,,BLANK,,,, -msg_timeout,1,BLANK,,BLANK,


### PR DESCRIPTION
Using "*:{port}" is preferred to "[::]:{port}", because it won't break on IPv4-only machines.  (NOTE: {port} is, of course, a port number or service name)

This fixes test failures in `79-test_http.t` and `80-test_ssl_new.t` on machines without IPv6.
