### PR TITLE
Modify 50-nonstop.conf to enable c99 extensions for uintptr_t.

### DIFF
--- a/Configurations/50-nonstop.conf
+++ b/Configurations/50-nonstop.conf
@@ -14,6 +14,7 @@
                                 '_XOPEN_SOURCE',
                                 '_XOPEN_SOURCE_EXTENDED=1',
                                 '_TANDEM_SOURCE',
+                                '__NSK_OPTIONAL_TYPES__',
                                 'B_ENDIAN'),
         perl             => '/usr/bin/perl',
         shared_target    => 'nonstop-shared',


### PR DESCRIPTION
This is done using the define __NSK_OPTIONAL_TYPES__ and is specific to the NonStop platform builds.

Fixes: #22002
