### PR TITLE
Exclude include of poll.h from NonStop builds - not defined on platform.

### DIFF
--- a/include/internal/sockets.h
+++ b/include/internal/sockets.h
@@ -117,7 +117,9 @@ typedef size_t socklen_t;        /* Currently appears to be missing on VMS */
 #  endif
 
 #  ifdef OPENSSL_SYS_UNIX
-#    include <poll.h>
+#    ifndef OPENSSL_SYS_TANDEM
+#     include <poll.h>
+#    endif
 #    include <errno.h>
 #  endif
 


### PR DESCRIPTION
socket.h has been modified so that poll.h is omitted for OPENSSL_SYS_NONSTOP builds. The platform configuration is derived from UNIX so the include is only omitted for NonStop but kept in the OPENSSL_SYS_UNIX include block.

Fixes: #22001
