### PR TITLE
Fix a possible memleak in eckey_priv_encode

### DIFF
--- a/crypto/ec/ec_ameth.c
+++ b/crypto/ec/ec_ameth.c
@@ -256,24 +256,32 @@ static int eckey_priv_encode(PKCS8_PRIV_KEY_INFO *p8, const EVP_PKEY *pkey)
 
     eplen = i2d_ECPrivateKey(&ec_key, NULL);
     if (!eplen) {
+        if (ptype == V_ASN1_SEQUENCE)
+            ASN1_STRING_free(pval);
         ECerr(EC_F_ECKEY_PRIV_ENCODE, ERR_R_EC_LIB);
         return 0;
     }
     ep = OPENSSL_malloc(eplen);
     if (ep == NULL) {
+        if (ptype == V_ASN1_SEQUENCE)
+            ASN1_STRING_free(pval);
         ECerr(EC_F_ECKEY_PRIV_ENCODE, ERR_R_MALLOC_FAILURE);
         return 0;
     }
     p = ep;
     if (!i2d_ECPrivateKey(&ec_key, &p)) {
-        OPENSSL_free(ep);
+        OPENSSL_clear_free(ep, eplen);
+        if (ptype == V_ASN1_SEQUENCE)
+            ASN1_STRING_free(pval);
         ECerr(EC_F_ECKEY_PRIV_ENCODE, ERR_R_EC_LIB);
         return 0;
     }
 
     if (!PKCS8_pkey_set0(p8, OBJ_nid2obj(NID_X9_62_id_ecPublicKey), 0,
                          ptype, pval, ep, eplen)) {
-        OPENSSL_free(ep);
+        OPENSSL_clear_free(ep, eplen);
+        if (ptype == V_ASN1_SEQUENCE)
+            ASN1_STRING_free(pval);
         return 0;
     }
 

--- a/crypto/ec/ec_ameth.c
+++ b/crypto/ec/ec_ameth.c
@@ -38,7 +38,6 @@ static int eckey_param2type(int *pptype, void **ppval, const EC_KEY *ec_key)
         ASN1_OBJECT *asn1obj = OBJ_nid2obj(nid);
 
         if (asn1obj == NULL || OBJ_length(asn1obj) == 0) {
-            ASN1_OBJECT_free(asn1obj);
             ECerr(EC_F_ECKEY_PARAM2TYPE, EC_R_MISSING_OID);
             return 0;
         }
@@ -98,9 +97,7 @@ static int eckey_pub_encode(X509_PUBKEY *pk, const EVP_PKEY *pkey)
                                ptype, pval, penc, penclen))
         return 1;
  err:
-    if (ptype == V_ASN1_OBJECT)
-        ASN1_OBJECT_free(pval);
-    else
+    if (ptype == V_ASN1_SEQUENCE)
         ASN1_STRING_free(pval);
     OPENSSL_free(penc);
     return 0;

--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -82,13 +82,16 @@ static int rsa_pub_encode(X509_PUBKEY *pk, const EVP_PKEY *pkey)
     if (!rsa_param_encode(pkey, &str, &strtype))
         return 0;
     penclen = i2d_RSAPublicKey(pkey->pkey.rsa, &penc);
-    if (penclen <= 0)
+    if (penclen <= 0) {
+        ASN1_STRING_free(str);
         return 0;
+    }
     if (X509_PUBKEY_set0_param(pk, OBJ_nid2obj(pkey->ameth->pkey_id),
                                strtype, str, penc, penclen))
         return 1;
 
     OPENSSL_free(penc);
+    ASN1_STRING_free(str);
     return 0;
 }
 

--- a/test/recipes/15-test_rsapss.t
+++ b/test/recipes/15-test_rsapss.t
@@ -16,7 +16,7 @@ use OpenSSL::Test::Utils;
 
 setup("test_rsapss");
 
-plan tests => 5;
+plan tests => 7;
 
 #using test/testrsa.pem which happens to be a 512 bit RSA
 ok(run(app(['openssl', 'dgst', '-sign', srctop_file('test', 'testrsa.pem'), '-sha1',
@@ -47,3 +47,11 @@ ok(run(app(['openssl', 'dgst', '-prverify', srctop_file('test', 'testrsa.pem'), 
             srctop_file('test', 'testrsa.pem')])),
    "openssl dgst -prverify");
 unlink 'testrsapss.sig';
+
+ok(run(app(['openssl', 'genpkey', '-algorithm', 'RSA-PSS', '-pkeyopt', 'rsa_keygen_bits:1024',
+            '-pkeyopt', 'rsa_pss_keygen_md:SHA256', '-pkeyopt', 'rsa_pss_keygen_saltlen:10',
+            '-out', 'testrsapss.pem'])),
+   "openssl genpkey RSA-PSS with pss parameters");
+ok(run(app(['openssl', 'pkey', '-in', 'testrsapss.pem', '-pubout', '-text'])),
+   "openssl pkey, execute rsa_pub_encode with pss parameters");
+unlink 'testrsapss.pem';


### PR DESCRIPTION
Additionally use OPENSSL_clear_free on the private key data in case of error.

master has the memory leak already fixed, just the clear free on the private key is missing.