### PR TITLE
Prevent 80-test_cmp_http from accidentally killing perl in error.

### DIFF
--- a/test/recipes/80-test_cmp_http.t
+++ b/test/recipes/80-test_cmp_http.t
@@ -311,7 +311,7 @@ sub start_server {
         }
     }
     unless ($server_port > 0) {
-        stop_server($server_name, $pid);
+        stop_server($server_name, $pid) if $pid;
         print "Cannot get expected output from the $server_name server";
         return 0;
     }


### PR DESCRIPTION
If there is an issue with setting up the test environment in this test, pid is not set so stop_server kills the perl process. A guard has been added to prevent this situation.

Fixes: #22014
