### PR TITLE
Regexp modifier "r" needs perl 5.14; OpenSSL should build with 5.11, …

### DIFF
--- a/Configurations/50-win-hybridcrt.conf
+++ b/Configurations/50-win-hybridcrt.conf
@@ -11,7 +11,8 @@
 sub remove_from_flags {
     my ($toRemove, $flags) = @_;
     
-    return $flags =~ s/$toRemove//r;
+    $flags =~ s/$toRemove//;
+    return $flags;
 }
 
 my %targets = (


### PR DESCRIPTION
…so do not use the "r" shortcut.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
