### PR TITLE
Fix error handling in CMS_EncryptedData_encrypt

### DIFF
--- a/crypto/cms/cms_asn1.c
+++ b/crypto/cms/cms_asn1.c
@@ -322,6 +322,9 @@ static int cms_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
         break;
 
     case ASN1_OP_FREE_PRE:
+        OPENSSL_free(cms->ctx.propq);
+        if (cms->d.other == NULL)
+            break;
         switch (OBJ_obj2nid(cms->contentType)) {
             case NID_pkcs7_encrypted:
                 ec = cms->d.encryptedData->encryptedContentInfo;
@@ -330,13 +333,11 @@ static int cms_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                 ec = cms->d.envelopedData->encryptedContentInfo;
                 break;
             case NID_id_smime_ct_authEnvelopedData:
-                if (cms->d.authEnvelopedData != NULL)
-                    ec = cms->d.authEnvelopedData->authEncryptedContentInfo;
+                ec = cms->d.authEnvelopedData->authEncryptedContentInfo;
                 break;
         }
         if (ec != NULL && ec->key != NULL)
             OPENSSL_clear_free(ec->key, ec->keylen);
-        OPENSSL_free(cms->ctx.propq);
         break;
 
     }

--- a/crypto/cms/cms_asn1.c
+++ b/crypto/cms/cms_asn1.c
@@ -330,7 +330,8 @@ static int cms_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                 ec = cms->d.envelopedData->encryptedContentInfo;
                 break;
             case NID_id_smime_ct_authEnvelopedData:
-                ec = cms->d.authEnvelopedData->authEncryptedContentInfo;
+                if (cms->d.authEnvelopedData != NULL)
+                    ec = cms->d.authEnvelopedData->authEncryptedContentInfo;
                 break;
         }
         if (ec != NULL && ec->key != NULL)

--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -51,15 +51,6 @@ static int cms_get_enveloped_type(const CMS_ContentInfo *cms)
     return ret;
 }
 
-void ossl_cms_env_enc_content_free(const CMS_ContentInfo *cinf)
-{
-    if (cms_get_enveloped_type_simple(cinf) != 0) {
-        CMS_EncryptedContentInfo *ec = ossl_cms_get0_env_enc_content(cinf);
-        if (ec != NULL)
-            OPENSSL_clear_free(ec->key, ec->keylen);
-    }
-}
-
 CMS_EnvelopedData *ossl_cms_get0_enveloped(CMS_ContentInfo *cms)
 {
     if (OBJ_obj2nid(cms->contentType) != NID_pkcs7_enveloped) {

--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -289,8 +289,10 @@ BIO *CMS_EnvelopedData_decrypt(CMS_EnvelopedData *env, BIO *detached_data,
                       secret == NULL ? cert : NULL, detached_data, bio, flags);
 
  end:
-    if (ci != NULL)
+    if (ci != NULL) {
         ci->d.envelopedData = NULL; /* do not indirectly free |env| */
+        ci->contentType = NULL;
+    }
     CMS_ContentInfo_free(ci);
     if (!res) {
         BIO_free(bio);

--- a/crypto/cms/cms_lib.c
+++ b/crypto/cms/cms_lib.c
@@ -73,11 +73,7 @@ CMS_ContentInfo *CMS_ContentInfo_new(void)
 
 void CMS_ContentInfo_free(CMS_ContentInfo *cms)
 {
-    if (cms != NULL) {
-        ossl_cms_env_enc_content_free(cms);
-        OPENSSL_free(cms->ctx.propq);
-        ASN1_item_free((ASN1_VALUE *)cms, ASN1_ITEM_rptr(CMS_ContentInfo));
-    }
+    ASN1_item_free((ASN1_VALUE *)cms, ASN1_ITEM_rptr(CMS_ContentInfo));
 }
 
 const CMS_CTX *ossl_cms_get0_cmsctx(const CMS_ContentInfo *cms)

--- a/crypto/cms/cms_lib.c
+++ b/crypto/cms/cms_lib.c
@@ -21,6 +21,7 @@
 static STACK_OF(CMS_CertificateChoices)
 **cms_get0_certificate_choices(CMS_ContentInfo *cms);
 
+IMPLEMENT_ASN1_ALLOC_FUNCTIONS(CMS_ContentInfo)
 IMPLEMENT_ASN1_PRINT_FUNCTION(CMS_ContentInfo)
 
 CMS_ContentInfo *d2i_CMS_ContentInfo(CMS_ContentInfo **a,
@@ -64,16 +65,6 @@ CMS_ContentInfo *CMS_ContentInfo_new_ex(OSSL_LIB_CTX *libctx, const char *propq)
         }
     }
     return ci;
-}
-
-CMS_ContentInfo *CMS_ContentInfo_new(void)
-{
-    return CMS_ContentInfo_new_ex(NULL, NULL);
-}
-
-void CMS_ContentInfo_free(CMS_ContentInfo *cms)
-{
-    ASN1_item_free((ASN1_VALUE *)cms, ASN1_ITEM_rptr(CMS_ContentInfo));
 }
 
 const CMS_CTX *ossl_cms_get0_cmsctx(const CMS_ContentInfo *cms)

--- a/crypto/cms/cms_local.h
+++ b/crypto/cms/cms_local.h
@@ -366,6 +366,7 @@ struct CMS_Receipt_st {
 
 DECLARE_ASN1_FUNCTIONS(CMS_ContentInfo)
 DECLARE_ASN1_ITEM(CMS_SignerInfo)
+DECLARE_ASN1_ITEM(CMS_EncryptedContentInfo)
 DECLARE_ASN1_ITEM(CMS_IssuerAndSerialNumber)
 DECLARE_ASN1_ITEM(CMS_Attributes_Sign)
 DECLARE_ASN1_ITEM(CMS_Attributes_Verify)

--- a/crypto/cms/cms_local.h
+++ b/crypto/cms/cms_local.h
@@ -448,7 +448,6 @@ BIO *ossl_cms_EnvelopedData_init_bio(CMS_ContentInfo *cms);
 int ossl_cms_EnvelopedData_final(CMS_ContentInfo *cms, BIO *chain);
 BIO *ossl_cms_AuthEnvelopedData_init_bio(CMS_ContentInfo *cms);
 int ossl_cms_AuthEnvelopedData_final(CMS_ContentInfo *cms, BIO *cmsbio);
-void ossl_cms_env_enc_content_free(const CMS_ContentInfo *cinf);
 CMS_EnvelopedData *ossl_cms_get0_enveloped(CMS_ContentInfo *cms);
 CMS_AuthEnvelopedData *ossl_cms_get0_auth_enveloped(CMS_ContentInfo *cms);
 CMS_EncryptedContentInfo *ossl_cms_get0_env_enc_content(const CMS_ContentInfo *cms);

--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -505,6 +505,7 @@ CMS_SignerInfo *CMS_add1_signer(CMS_ContentInfo *cms,
                                          ossl_cms_ctx_get0_libctx(ctx),
                                          ossl_cms_ctx_get0_propq(ctx),
                                          pk, NULL) <= 0) {
+            si->pctx = NULL;
             goto err;
         }
         else {
@@ -926,8 +927,10 @@ int CMS_SignerInfo_verify(CMS_SignerInfo *si)
         si->pctx = NULL;
     }
     if (EVP_DigestVerifyInit_ex(mctx, &si->pctx, EVP_MD_get0_name(md), libctx,
-                                propq, si->pkey, NULL) <= 0)
+                                propq, si->pkey, NULL) <= 0) {
+        si->pctx = NULL;
         goto err;
+    }
     EVP_MD_CTX_set_flags(mctx, EVP_MD_CTX_FLAG_KEEP_PKEY_CTX);
 
     if (!cms_sd_asn1_ctrl(si, 1))

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -236,7 +236,7 @@ CMS_ContentInfo *CMS_EncryptedData_encrypt_ex(BIO *in, const EVP_CIPHER *cipher,
     if (cms == NULL)
         return NULL;
     if (!CMS_EncryptedData_set1_key(cms, cipher, key, keylen))
-        return NULL;
+        goto err;
 
     if (!(flags & CMS_DETACHED))
         CMS_set_detached(cms, 0);
@@ -245,6 +245,7 @@ CMS_ContentInfo *CMS_EncryptedData_encrypt_ex(BIO *in, const EVP_CIPHER *cipher,
         || CMS_final(cms, in, NULL, flags))
         return cms;
 
+ err:
     CMS_ContentInfo_free(cms);
     return NULL;
 }

--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -392,6 +392,13 @@ my @smime_cms_tests = (
         "-out", "{output}.txt" ],
       \&final_compare
     ],
+
+    [ "encrypted content test streaming PEM format -noout, 128 bit AES key",
+      [ "{cmd1}", @prov, "-EncryptedData_encrypt", "-in", $smcont, "-outform", "PEM",
+	"-aes128", "-secretkey", "000102030405060708090A0B0C0D0E0F",
+	"-stream", "-noout" ],
+      [ "{cmd2}", @prov, "-help" ]
+    ],
 );
 
 my @smime_cms_cades_tests = (


### PR DESCRIPTION
That caused several memory leaks in case of error. Also when the CMS object that is created by CMS_EncryptedData_encrypt is not used in the normal way, but instead just deleted by CMS_ContentInfo_free some memory was lost.

Fixes #21985

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
