### PR TITLE
Add CVE-2023-4807 fix to CHANGES.md and NEWS.md 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -457,7 +457,27 @@ OpenSSL 3.1
 
 ### Changes between 3.1.2 and 3.1.3 [xx XXX xxxx]
 
- * none yet
+ * Fix POLY1305 MAC implementation corrupting XMM registers on Windows.
+
+   The POLY1305 MAC (message authentication code) implementation in OpenSSL
+   does not save the contents of non-volatile XMM registers on Windows 64
+   platform when calculating the MAC of data larger than 64 bytes. Before
+   returning to the caller all the XMM registers are set to zero rather than
+   restoring their previous content. The vulnerable code is used only on newer
+   x86_64 processors supporting the AVX512-IFMA instructions.
+
+   The consequences of this kind of internal application state corruption can
+   be various - from no consequences, if the calling application does not
+   depend on the contents of non-volatile XMM registers at all, to the worst
+   consequences, where the attacker could get complete control of the
+   application process. However given the contents of the registers are just
+   zeroized so the attacker cannot put arbitrary values inside, the most likely
+   consequence, if any, would be an incorrect result of some application
+   dependent calculations or a crash leading to a denial of service.
+
+   ([CVE-2023-4807])
+
+   *Bernd Edlinger*
 
 ### Changes between 3.1.1 and 3.1.2 [1 Aug 2023]
 
@@ -20253,6 +20273,7 @@ ndif
 
 <!-- Links -->
 
+[CVE-2023-4807]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-4807
 [CVE-2023-3817]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-3817
 [CVE-2023-3446]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-3446
 [CVE-2023-2975]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-2975

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -455,6 +455,10 @@ OpenSSL 3.2
 OpenSSL 3.1
 -----------
 
+### Changes between 3.1.2 and 3.1.3 [xx XXX xxxx]
+
+ * none yet
+
 ### Changes between 3.1.1 and 3.1.2 [1 Aug 2023]
 
  * Fix excessive time spent checking DH q parameter value.

--- a/NEWS.md
+++ b/NEWS.md
@@ -54,7 +54,8 @@ OpenSSL 3.1
 
 ### Major changes between OpenSSL 3.1.2 and OpenSSL 3.1.3 [under development]
 
-  * none
+  * Fix POLY1305 MAC implementation corrupting XMM registers on Windows
+    ([CVE-2023-4807])
 
 ### Major changes between OpenSSL 3.1.1 and OpenSSL 3.1.2 [1 Aug 2023]
 
@@ -1501,6 +1502,7 @@ OpenSSL 0.9.x
 
 <!-- Links -->
 
+[CVE-2023-4807]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-4807
 [CVE-2023-3817]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-3817
 [CVE-2023-3446]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-3446
 [CVE-2023-2975]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-2975

--- a/NEWS.md
+++ b/NEWS.md
@@ -52,7 +52,11 @@ OpenSSL 3.2
 OpenSSL 3.1
 -----------
 
-### Major changes between OpenSSL 3.1.1 and OpenSSL 3.1.2 [under development]
+### Major changes between OpenSSL 3.1.2 and OpenSSL 3.1.3 [under development]
+
+  * none
+
+### Major changes between OpenSSL 3.1.1 and OpenSSL 3.1.2 [1 Aug 2023]
 
   * Fix excessive time spent checking DH q parameter value ([CVE-2023-3817])
   * Fix DH_check() excessive time with over sized modulus ([CVE-2023-3446])


### PR DESCRIPTION
The second commit should cherry-pick to 3.1 cleanly and to 3.0 with a trivial adjustment - moving the added text to the right place.
