### PR TITLE
Prevent 80-test_cmp_http from accidentally killing perl in error.

### DIFF
--- a/test/recipes/80-test_cmp_http.t
+++ b/test/recipes/80-test_cmp_http.t
@@ -283,7 +283,7 @@ sub start_mock_server {
         }
     }
     unless ($server_port > 0) {
-        stop_mock_server($pid);
+        stop_mock_server($pid) if $pid;
         return 0;
     }
     $server_tls = $kur_port = $pbm_port = $server_port;


### PR DESCRIPTION
If there is an issue with setting up the test environment in this test, pid is not set so stop_mock_server kills the perl process. A guard has been added to prevent this situation.

This fix applies to 3.0 and 3.1 only.

Fixes: #22014
