### PR TITLE
CLA: trivial   Update o_str.c  OPENSSL_buf2hexstr

### DIFF
--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -285,7 +285,7 @@ char *ossl_buf2hexstr_sep(const unsigned char *buf, long buflen, char sep)
  */
 char *OPENSSL_buf2hexstr(const unsigned char *buf, long buflen)
 {
-    return ossl_buf2hexstr_sep(buf, buflen, ':');
+    return ossl_buf2hexstr_sep(buf, buflen, DEFAULT_SEPARATOR);
 }
 
 int openssl_strerror_r(int errnum, char *buf, size_t buflen)


### PR DESCRIPTION
let OPENSSL_buf2hexstr follow DEFAULT_SEPARATOR, not static ':'

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
