### PR TITLE
Update OPENSSL_buf2hexstr() to use DEFAULT_SEPARATOR.

### DIFF
--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -279,13 +279,13 @@ char *ossl_buf2hexstr_sep(const unsigned char *buf, long buflen, char sep)
 
 
 /*
- * Given a buffer of length 'len' return a OPENSSL_malloc'ed string with its
- * hex representation @@@ (Contents of buffer are always kept in ASCII, also
- * on EBCDIC machines)
+ * Given a buffer of length 'buflen' return a OPENSSL_malloc'ed string with
+ * its hex representation @@@ (Contents of buffer are always kept in ASCII,
+ * also on EBCDIC machines)
  */
 char *OPENSSL_buf2hexstr(const unsigned char *buf, long buflen)
 {
-    return ossl_buf2hexstr_sep(buf, buflen, ':');
+    return ossl_buf2hexstr_sep(buf, buflen, DEFAULT_SEPARATOR);
 }
 
 int openssl_strerror_r(int errnum, char *buf, size_t buflen)


### PR DESCRIPTION
let o_str.c OPENSSL_buf2hexstr follow DEFAULT_SEPARATOR, not static :

CLA: trivial