### PR TITLE
Fix a failure in bio_dgram_test on the NonStop platform

### DIFF
--- a/crypto/bio/bss_dgram_pair.c
+++ b/crypto/bio/bss_dgram_pair.c
@@ -279,8 +279,9 @@ static int dgram_pair_init(BIO *bio)
     if (b == NULL)
         return 0;
 
-    b->req_buf_len = 17*1024; /* default buffer size */
     b->mtu         = 1472;    /* conservative default MTU */
+    /* default buffer size */
+    b->req_buf_len = 9 * (sizeof(struct dgram_hdr) + b->mtu);
 
     b->lock = CRYPTO_THREAD_lock_new();
     if (b->lock == NULL) {

--- a/test/bio_dgram_test.c
+++ b/test/bio_dgram_test.c
@@ -562,13 +562,10 @@ static int test_bio_dgram_pair(int idx)
      * The number of datagrams we can fit depends on the size of the default
      * write buffer size, the size of the datagram header and the size of the
      * payload data we send in each datagram. The max payload data is based on
-     * the mtu (1472). On most systems we expect the header size to be small,
-     * but on one platform (NonStop) we had a report of a very large header
-     * (2064 bytes) - probably driven by sizeof(BIO_ADDR). The default write
-     * buffer size is 17408. So in the very worst case we should be able to fit
-     * at least 4 datagrams into the write buffer.
+     * the mtu. The default write buffer size is 9 * (sizeof(header) + mtu) so
+     * we expect at least 9 maximally sized datagrams to fit in the buffer.
      */
-    if (!TEST_int_ge(i, 4))
+    if (!TEST_int_ge(i, 9))
         goto err;
 
     /* Check we read back the same data */

--- a/test/bio_dgram_test.c
+++ b/test/bio_dgram_test.c
@@ -559,10 +559,16 @@ static int test_bio_dgram_pair(int idx)
         goto err;
 
     /*
-     * Should be able to fit at least 9 datagrams in default write buffer size
-     * in worst case
+     * The number of datagrams we can fit depends on the size of the default
+     * write buffer size, the size of the datagram header and the size of the
+     * payload data we send in each datagram. The max payload data is based on
+     * the mtu (1472). On most systems we expect the header size to be small,
+     * but on one platform (NonStop) we had a report of a very large header
+     * (2064 bytes) - probably driven by sizeof(BIO_ADDR). The default write
+     * buffer size is 17408. So in the very worst case we should be able to fit
+     * at least 4 datagrams into the write buffer.
      */
-    if (!TEST_int_ge(i, 9))
+    if (!TEST_int_ge(i, 4))
         goto err;
 
     /* Check we read back the same data */


### PR DESCRIPTION
The size of the datagram header is significantly larger that we might expect on NonStop (probably driven by sizeof(BIO_ADDR)). We adjust the assumptions in the test about how many datagrams we can fit into the default buffer size.

Fixes #22013

