### PR TITLE
Fix memory leaks in ssl_old_test.c

### DIFF
--- a/test/ssl_old_test.c
+++ b/test/ssl_old_test.c
@@ -1535,8 +1535,10 @@ int main(int argc, char *argv[])
             ERR_print_errors(bio_err);
             goto end;
         }
-        SSL_CTX_set0_tmp_dh_pkey(s_ctx, dhpkey);
-        SSL_CTX_set0_tmp_dh_pkey(s_ctx2, dhpkey);
+        if (!SSL_CTX_set0_tmp_dh_pkey(s_ctx, dhpkey))
+            EVP_PKEY_free(dhpkey);
+        if (!SSL_CTX_set0_tmp_dh_pkey(s_ctx2, dhpkey))
+            EVP_PKEY_free(dhpkey);
     }
 #endif
 


### PR DESCRIPTION
This fixes a few memory leaks reported in #22049.

If SSL_CTX_set0_tmp_dh_pkey rejects the temp dh key due to security restrictions (even when @SECLEVEL=0 is used!) then the caller has to delete the PKEY object.
That is different to how the deprecated
SSL_CTX_set_tmp_dh_pkey was designed to work.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
