### PR TITLE
test/quic_multistream_test.c: Diverse fixes

### DIFF
--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -692,7 +692,8 @@ static int helper_init(struct helper *h, const char *script_name,
             &ina, sizeof(ina), 0)))
         goto err;
 
-    if (!TEST_true(BIO_bind(h->s_fd, h->s_net_bio_orig_addr, 0)))
+    if (!TEST_true(BIO_bind(h->s_fd, h->s_net_bio_orig_addr,
+                            BIO_SOCK_REUSEADDR)))
         goto err;
 
     info.addr = h->s_net_bio_addr;


### PR DESCRIPTION
- test/quic_multistream_test.c: Bind with the address reuse option

  This should clear test_quic_multistream failures on some platforms, where
  bind() returns with the error "address already in use".

-----

More to be added...
