### PR TITLE
Fix typos found by codespell in openssl-3.1

### DIFF
--- a/doc/man1/openssl-cms.pod.in
+++ b/doc/man1/openssl-cms.pod.in
@@ -391,7 +391,7 @@ option.
 =item I<recipient-cert> ...
 
 This is an alternative to using the B<-recip> option when encrypting a message.
-One or more certificate filennames may be given.
+One or more certificate filenames may be given.
 
 =item B<-I<cipher>>
 

--- a/doc/man3/EVP_MAC.pod
+++ b/doc/man3/EVP_MAC.pod
@@ -181,7 +181,7 @@ EVP_MAC_CTX_set_params() passes chosen parameters to the underlying
 context, given a context I<ctx>.
 The set of parameters given with I<params> determine exactly what
 parameters are passed down.
-If I<params> are NULL, the unterlying context should do nothing and return 1.
+If I<params> are NULL, the underlying context should do nothing and return 1.
 Note that a parameter that is unknown in the underlying context is
 simply ignored.
 Also, what happens when a needed parameter isn't passed down is

--- a/doc/man3/EVP_SIGNATURE.pod
+++ b/doc/man3/EVP_SIGNATURE.pod
@@ -61,7 +61,7 @@ EVP_SIGNATURE_get0_provider() returns the provider that I<signature> was
 fetched from.
 
 EVP_SIGNATURE_do_all_provided() traverses all SIGNATURE implemented by all
-activated roviders in the given library context I<libctx>, and for each of the
+activated providers in the given library context I<libctx>, and for each of the
 implementations, calls the given function I<fn> with the implementation method
 and the given I<arg> as argument.
 

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -182,7 +182,7 @@ clearing the internal CMP transaction (aka session) status, PKIStatusInfo,
 and any previous results (newCert, newChain, caPubs, and extraCertsIn)
 from the last executed transaction.
 It also clears any ITAVs that were added by OSSL_CMP_CTX_push0_genm_ITAV().
-All other field values (i.e., CMP options) are retained for potential re-use.
+All other field values (i.e., CMP options) are retained for potential reuse.
 
 OSSL_CMP_CTX_set_option() sets the given value for the given option
 (e.g., OSSL_CMP_OPT_IMPLICIT_CONFIRM) in the given OSSL_CMP_CTX structure.

--- a/doc/man3/SSL_new.pod
+++ b/doc/man3/SSL_new.pod
@@ -35,7 +35,7 @@ MUST NOT have yet started the SSL handshake.  For connections that are not in
 their initial state SSL_dup() just increments an internal
 reference count and returns the I<same> handle.  It may be possible to
 use L<SSL_clear(3)> to recycle an SSL handle that is not in its initial
-state for re-use, but this is best avoided.  Instead, save and restore
+state for reuse, but this is best avoided.  Instead, save and restore
 the session, if desired, and construct a fresh handle for each connection.
 
 The subset of settings in I<s> that are duplicated are:

--- a/doc/man5/x509v3_config.pod
+++ b/doc/man5/x509v3_config.pod
@@ -93,7 +93,7 @@ numeric identifier, as shown here:
  email.2 = steve@example.org
 
 The syntax of raw extensions is defined by the source code that parses
-the extension but should be documened.
+the extension but should be documented.
 See L</Certificate Policies> for an example of a raw extension.
 
 If an extension type is unsupported, then the I<arbitrary> extension syntax


### PR DESCRIPTION
Only modify `doc/man*` in the [openssl-3.1](https://github.com/openssl/openssl/tree/openssl-3.1) branch.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
- [ ] tests are added or updated
