### PR TITLE
Blake2 implementation fixes

### DIFF
--- a/crypto/evp/legacy_blake2.c
+++ b/crypto/evp/legacy_blake2.c
@@ -11,11 +11,31 @@
 #include "prov/blake2.h"        /* diverse BLAKE2 macros */
 #include "legacy_meth.h"
 
-#define ossl_blake2b_init ossl_blake2b512_init
-#define ossl_blake2s_init ossl_blake2s256_init
+/*
+ * Local hack to adapt the BLAKE2 init functions to what the
+ * legacy function signatures demand.
+ */
+static int blake2s_init(BLAKE2S_CTX *C)
+{
+    BLAKE2S_PARAM P;
 
-IMPLEMENT_LEGACY_EVP_MD_METH_LC(blake2s_int, ossl_blake2s)
-IMPLEMENT_LEGACY_EVP_MD_METH_LC(blake2b_int, ossl_blake2b)
+    ossl_blake2s_param_init(&P);
+    return ossl_blake2s_init(C, &P);
+}
+static int blake2b_init(BLAKE2B_CTX *C)
+{
+    BLAKE2B_PARAM P;
+
+    ossl_blake2b_param_init(&P);
+    return ossl_blake2b_init(C, &P);
+}
+#define blake2s_update ossl_blake2s_update
+#define blake2b_update ossl_blake2b_update
+#define blake2s_final ossl_blake2s_final
+#define blake2b_final ossl_blake2b_final
+
+IMPLEMENT_LEGACY_EVP_MD_METH_LC(blake2s_int, blake2s)
+IMPLEMENT_LEGACY_EVP_MD_METH_LC(blake2b_int, blake2b)
 
 static const EVP_MD blake2b_md = {
     NID_blake2b512,

--- a/providers/implementations/digests/blake2_prov.c
+++ b/providers/implementations/digests/blake2_prov.c
@@ -8,11 +8,115 @@
  */
 
 #include <openssl/crypto.h>
+#include <openssl/core_names.h>
+#include <openssl/proverr.h>
+#include <openssl/err.h>
 #include "prov/blake2.h"
 #include "prov/digestcommon.h"
 #include "prov/implementations.h"
 
-int ossl_blake2s256_init(void *ctx)
+/*
+ * A descriptor for BLAKE2 functions we use.  This helps us avoid
+ * too much code block copying.  For all these, C may be passed a
+ * pointer to BLAKE2S_CTX or BLAKE2B_CTX, and P may be passed a
+ * pointer to BLAKE2S_PARAM or BLAKE2S_PARAM, as appropriate for
+ * each function.
+ */
+typedef int blake2sb_final_fn(unsigned char *md, void *C);
+typedef void blake2sb_set_digest_length_fn(void *C, uint8_t outlen);
+typedef uint8_t blake2sb_get_digest_length_fn(void *C);
+struct blake2sb_desc_st {
+    uint8_t max_outlen;
+    blake2sb_final_fn *final;
+    blake2sb_set_digest_length_fn *set_digest_length;
+    blake2sb_get_digest_length_fn *get_digest_length;
+};
+
+static const struct blake2sb_desc_st blake2s256_desc = {
+    BLAKE2S_DIGEST_LENGTH,
+    (blake2sb_final_fn *)ossl_blake2s_final,
+    (blake2sb_set_digest_length_fn *)ossl_blake2s_set_digest_length,
+    (blake2sb_get_digest_length_fn *)ossl_blake2s_get_digest_length
+};
+
+static const struct blake2sb_desc_st blake2b512_desc = {
+    BLAKE2B_DIGEST_LENGTH,
+    (blake2sb_final_fn *)ossl_blake2b_final,
+    (blake2sb_set_digest_length_fn *)ossl_blake2b_set_digest_length,
+    (blake2sb_get_digest_length_fn *)ossl_blake2b_get_digest_length
+};
+
+static int blake2sb_final(const struct blake2sb_desc_st *desc, void *C,
+                          unsigned char *out, size_t *outl, size_t outsz)
+{
+    uint8_t outlen = desc->get_digest_length(C);
+
+    if (!ossl_prov_is_running())
+        return 0;
+    if (outsz < outlen)
+        return 0;
+    *outl = outlen;
+    return desc->final(out, C);
+}
+
+static const OSSL_PARAM known_blake2sb_settable_ctx_params[] = {
+    {OSSL_DIGEST_PARAM_XOFLEN, OSSL_PARAM_UNSIGNED_INTEGER, NULL, 0, 0},
+    OSSL_PARAM_END
+};
+
+static const OSSL_PARAM *
+ossl_blake2sb_settable_ctx_params(ossl_unused void *pctx,
+                                  ossl_unused void *ctx)
+{
+    return known_blake2sb_settable_ctx_params;
+}
+
+static int blake2sb_set_ctx_params(const struct blake2sb_desc_st *desc,
+                                   void *C, const OSSL_PARAM params[])
+{
+    size_t xoflen;
+    const OSSL_PARAM *param;
+
+    if (C == NULL) {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+    if (params == NULL)
+        return 1;
+
+    param = OSSL_PARAM_locate_const(params, OSSL_DIGEST_PARAM_XOFLEN);
+    if (param != NULL) {
+        if (!OSSL_PARAM_get_size_t(param, &xoflen)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            return 0;
+        }
+        /*
+         * According to spec, the output length can't be less than 1.  However,
+         * OpenSSL tests do call EVP_DigestFinalXOF() with 0 for length, and
+         * EVP_DigestFinalXOF() uses that to set the xoflen unchecked, so we
+         * allow it here, and ossl_blake2[sb]_final() will do the right thing.
+         */
+        if (/* xoflen < 1 || */ xoflen > desc->max_outlen) {
+            ERR_raise_data(ERR_LIB_PROV, PROV_R_INVALID_DIGEST_LENGTH,
+                           "Must be a number from 1 to %u, is %zu",
+                           desc->max_outlen, xoflen);
+            return 0;
+        }
+        desc->set_digest_length(C, (uint8_t)xoflen);
+    }
+
+    return 1;
+}
+
+static OSSL_FUNC_digest_final_fn ossl_blake2s256_final;
+static OSSL_FUNC_digest_final_fn ossl_blake2b512_final;
+
+static OSSL_FUNC_digest_settable_ctx_params_fn ossl_blake2sb_settable_ctx_params;
+
+static OSSL_FUNC_digest_set_ctx_params_fn ossl_blake2s256_set_ctx_params;
+static OSSL_FUNC_digest_set_ctx_params_fn ossl_blake2b512_set_ctx_params;
+
+static int ossl_blake2s256_init(void *ctx)
 {
     BLAKE2S_PARAM P;
 
@@ -20,93 +124,56 @@ int ossl_blake2s256_init(void *ctx)
     return ossl_blake2s_init((BLAKE2S_CTX *)ctx, &P);
 }
 
-int ossl_blake2b512_init(void *ctx)
+static int ossl_blake2b512_init(void *ctx)
 {
-    struct blake2b_md_data_st *mdctx = ctx;
+    BLAKE2B_PARAM P;
 
-    ossl_blake2b_param_init(&mdctx->params);
-    return ossl_blake2b_init(&mdctx->ctx, &mdctx->params);
+    ossl_blake2b_param_init(&P);
+    return ossl_blake2b_init((BLAKE2B_CTX *)ctx, &P);
+}
+
+static int ossl_blake2s256_final(void *ctx,
+                                 unsigned char *out, size_t *outl, size_t outsz)
+{
+    return blake2sb_final(&blake2s256_desc, ctx, out, outl, outsz);
+}
+
+static int ossl_blake2b512_final(void *ctx,
+                                 unsigned char *out, size_t *outl, size_t outsz)
+{
+    return blake2sb_final(&blake2b512_desc, ctx, out, outl, outsz);
+}
+
+/*
+ * prov/digestcommon.h's PROV_FUNC_DIGEST_FINAL makes assumptions that do not
+ * fit the needs of BLAKE2 final, as it allows variable output lengths, which
+ * that macro isn't adapted for.  Therefore, we make it do nothing, and hack
+ * the internal names that it would produce otherwise.
+ */
+#undef PROV_FUNC_DIGEST_FINAL
+#define PROV_FUNC_DIGEST_FINAL(name, dgstsize, fin)
+#define blake2s256_internal_final ossl_blake2s256_final
+#define blake2b512_internal_final ossl_blake2b512_final
+
+
+static int ossl_blake2s256_set_ctx_params(void *ctx, const OSSL_PARAM params[])
+{
+    return blake2sb_set_ctx_params(&blake2s256_desc, ctx, params);
+}
+
+static int ossl_blake2b512_set_ctx_params(void *ctx, const OSSL_PARAM params[])
+{
+    return blake2sb_set_ctx_params(&blake2b512_desc, ctx, params);
 }
 
 /* ossl_blake2s256_functions */
-IMPLEMENT_digest_functions(blake2s256, BLAKE2S_CTX,
-                           BLAKE2S_BLOCKBYTES, BLAKE2S_DIGEST_LENGTH, 0,
-                           ossl_blake2s256_init, ossl_blake2s_update,
-                           ossl_blake2s_final)
+IMPLEMENT_digest_functions_with_settable_ctx
+(blake2s256, BLAKE2S_CTX, BLAKE2S_BLOCKBYTES, BLAKE2S_DIGEST_LENGTH, 0,
+ ossl_blake2s256_init, ossl_blake2s_update, ossl_blake2s256_final,
+ ossl_blake2sb_settable_ctx_params, ossl_blake2s256_set_ctx_params)
 
 /* ossl_blake2b512_functions */
-
-static OSSL_FUNC_digest_init_fn blake2b512_internal_init;
-static OSSL_FUNC_digest_newctx_fn blake2b512_newctx;
-static OSSL_FUNC_digest_freectx_fn blake2b512_freectx;
-static OSSL_FUNC_digest_dupctx_fn blake2b512_dupctx;
-static OSSL_FUNC_digest_final_fn blake2b512_internal_final;
-static OSSL_FUNC_digest_get_params_fn blake2b512_get_params;
-
-static int blake2b512_internal_init(void *ctx, const OSSL_PARAM params[])
-{
-    return ossl_prov_is_running() && ossl_blake2b_set_ctx_params(ctx, params)
-        && ossl_blake2b512_init(ctx);
-}
-
-static void *blake2b512_newctx(void *prov_ctx)
-{
-    struct blake2b_md_data_st *ctx;
-
-    ctx = ossl_prov_is_running() ? OPENSSL_zalloc(sizeof(*ctx)) : NULL;
-    return ctx;
-}
-
-static void blake2b512_freectx(void *vctx)
-{
-    struct blake2b_md_data_st *ctx;
-
-    ctx = (struct blake2b_md_data_st *)vctx;
-    OPENSSL_clear_free(ctx, sizeof(*ctx));
-}
-
-static void *blake2b512_dupctx(void *ctx)
-{
-    struct blake2b_md_data_st *in, *ret;
-
-    in = (struct blake2b_md_data_st *)ctx;
-    ret = ossl_prov_is_running()? OPENSSL_malloc(sizeof(*ret)) : NULL;
-    if (ret != NULL)
-        *ret = *in;
-    return ret;
-}
-
-static int blake2b512_internal_final(void *ctx, unsigned char *out,
-                                     size_t *outl, size_t outsz)
-{
-    struct blake2b_md_data_st *b_ctx;
-    
-    b_ctx = (struct blake2b_md_data_st *)ctx;
-    *outl = b_ctx->ctx.outlen;
-
-    if (!ossl_prov_is_running())
-        return 0;
-
-    return (outsz > 0) ? ossl_blake2b_final(out, ctx) : 1;
-}
-
-static int blake2b512_get_params(OSSL_PARAM params[])
-{
-    return ossl_digest_default_get_params(params, BLAKE2B_BLOCKBYTES, 64, 0);
-}
-
-const OSSL_DISPATCH ossl_blake2b512_functions[] =
-    { {OSSL_FUNC_DIGEST_NEWCTX, (void (*)(void))blake2b512_newctx},
-    {OSSL_FUNC_DIGEST_UPDATE, (void (*)(void))ossl_blake2b_update},
-    {OSSL_FUNC_DIGEST_FINAL, (void (*)(void))blake2b512_internal_final},
-    {OSSL_FUNC_DIGEST_FREECTX, (void (*)(void))blake2b512_freectx},
-    {OSSL_FUNC_DIGEST_DUPCTX, (void (*)(void))blake2b512_dupctx},
-    {OSSL_FUNC_DIGEST_GET_PARAMS, (void (*)(void))blake2b512_get_params},
-    {OSSL_FUNC_DIGEST_GETTABLE_PARAMS,
-     (void (*)(void))ossl_digest_default_gettable_params},
-    {OSSL_FUNC_DIGEST_INIT, (void (*)(void))blake2b512_internal_init},
-    {OSSL_FUNC_DIGEST_SETTABLE_CTX_PARAMS,
-     (void (*)(void))ossl_blake2b_settable_ctx_params},
-    {OSSL_FUNC_DIGEST_SET_CTX_PARAMS,
-     (void (*)(void))ossl_blake2b_set_ctx_params}, {0, NULL} };
-
+IMPLEMENT_digest_functions_with_settable_ctx
+(blake2b512, BLAKE2B_CTX, BLAKE2B_BLOCKBYTES, BLAKE2B_DIGEST_LENGTH, 0,
+ ossl_blake2b512_init, ossl_blake2b_update, ossl_blake2b512_final,
+ ossl_blake2sb_settable_ctx_params, ossl_blake2b512_set_ctx_params)

--- a/providers/implementations/digests/blake2b_prov.c
+++ b/providers/implementations/digests/blake2b_prov.c
@@ -17,47 +17,8 @@
 #include <assert.h>
 #include <string.h>
 #include <openssl/crypto.h>
-#include <openssl/core_names.h>
-#include <openssl/proverr.h>
-#include <openssl/err.h>
 #include "blake2_impl.h"
 #include "prov/blake2.h"
-
-static const OSSL_PARAM known_blake2b_settable_ctx_params[] = {
-    {OSSL_DIGEST_PARAM_XOFLEN, OSSL_PARAM_UNSIGNED_INTEGER, NULL, 0, 0},
-    OSSL_PARAM_END
-};
-
-const OSSL_PARAM *ossl_blake2b_settable_ctx_params(ossl_unused void *ctx,
-                                                   ossl_unused void *pctx)
-{
-    return known_blake2b_settable_ctx_params;
-}
-
-int ossl_blake2b_set_ctx_params(void *vctx, const OSSL_PARAM params[])
-{
-    size_t xoflen;
-    struct blake2b_md_data_st *mdctx = vctx;
-    const OSSL_PARAM *p;
-
-    BLAKE2B_CTX *ctx = &mdctx->ctx;
-
-    if (ctx == NULL)
-        return 0;
-    if (params == NULL)
-        return 1;
-
-    p = OSSL_PARAM_locate_const(params, OSSL_DIGEST_PARAM_XOFLEN);
-    if (p != NULL) {
-        if (!OSSL_PARAM_get_size_t(p, &xoflen)) {
-            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-            return 0;
-        }
-        ossl_blake2b_param_set_digest_length(&mdctx->params, (uint8_t)xoflen);
-    }
-
-    return 1;
-}
 
 static const uint64_t blake2b_IV[8] =
 {
@@ -121,8 +82,7 @@ static void blake2b_init_param(BLAKE2B_CTX *S, const BLAKE2B_PARAM *P)
 /* Initialize the parameter block with default values */
 void ossl_blake2b_param_init(BLAKE2B_PARAM *P)
 {
-    if (P->digest_length == 0)
-        P->digest_length = BLAKE2B_DIGEST_LENGTH;
+    P->digest_length = BLAKE2B_DIGEST_LENGTH;
     P->key_length    = 0;
     P->fanout        = 1;
     P->depth         = 1;
@@ -368,4 +328,14 @@ int ossl_blake2b_final(unsigned char *md, BLAKE2B_CTX *c)
 
     OPENSSL_cleanse(c, sizeof(BLAKE2B_CTX));
     return 1;
+}
+
+void ossl_blake2b_set_digest_length(BLAKE2B_CTX *c, uint8_t outlen)
+{
+    c->outlen = outlen;
+}
+
+uint8_t ossl_blake2b_get_digest_length(BLAKE2B_CTX *c)
+{
+    return c->outlen;
 }

--- a/providers/implementations/digests/blake2s_prov.c
+++ b/providers/implementations/digests/blake2s_prov.c
@@ -320,3 +320,13 @@ int ossl_blake2s_final(unsigned char *md, BLAKE2S_CTX *c)
     OPENSSL_cleanse(c, sizeof(BLAKE2S_CTX));
     return 1;
 }
+
+void ossl_blake2s_set_digest_length(BLAKE2S_CTX *c, uint8_t outlen)
+{
+    c->outlen = outlen;
+}
+
+uint8_t ossl_blake2s_get_digest_length(BLAKE2S_CTX *c)
+{
+    return c->outlen;
+}

--- a/providers/implementations/include/prov/blake2.h
+++ b/providers/implementations/include/prov/blake2.h
@@ -14,7 +14,6 @@
 
 # include <openssl/e_os2.h>
 # include <stddef.h>
-# include <crypto/evp.h>
 
 # define BLAKE2S_BLOCKBYTES    64
 # define BLAKE2S_OUTBYTES      32
@@ -83,22 +82,21 @@ struct blake2b_ctx_st {
 typedef struct blake2s_ctx_st BLAKE2S_CTX;
 typedef struct blake2b_ctx_st BLAKE2B_CTX;
 
-struct blake2b_md_data_st {
-    BLAKE2B_CTX ctx;
-    BLAKE2B_PARAM params;
-};
-
-int ossl_blake2s256_init(void *ctx);
-int ossl_blake2b512_init(void *ctx);
-
 int ossl_blake2b_init(BLAKE2B_CTX *c, const BLAKE2B_PARAM *P);
 int ossl_blake2b_init_key(BLAKE2B_CTX *c, const BLAKE2B_PARAM *P,
                           const void *key);
 int ossl_blake2b_update(BLAKE2B_CTX *c, const void *data, size_t datalen);
 int ossl_blake2b_final(unsigned char *md, BLAKE2B_CTX *c);
+void ossl_blake2b_set_digest_length(BLAKE2B_CTX *c, uint8_t outlen);
+uint8_t ossl_blake2b_get_digest_length(BLAKE2B_CTX *c);
 
-OSSL_FUNC_digest_set_ctx_params_fn ossl_blake2b_set_ctx_params;
-OSSL_FUNC_digest_settable_ctx_params_fn ossl_blake2b_settable_ctx_params;
+int ossl_blake2s_init(BLAKE2S_CTX *c, const BLAKE2S_PARAM *P);
+int ossl_blake2s_init_key(BLAKE2S_CTX *c, const BLAKE2S_PARAM *P,
+                          const void *key);
+int ossl_blake2s_update(BLAKE2S_CTX *c, const void *data, size_t datalen);
+int ossl_blake2s_final(unsigned char *md, BLAKE2S_CTX *c);
+void ossl_blake2s_set_digest_length(BLAKE2S_CTX *c, uint8_t outlen);
+uint8_t ossl_blake2s_get_digest_length(BLAKE2S_CTX *c);
 
 /*
  * These setters are internal and do not check the validity of their parameters.
@@ -112,11 +110,6 @@ void ossl_blake2b_param_set_personal(BLAKE2B_PARAM *P, const uint8_t *personal,
                                      size_t length);
 void ossl_blake2b_param_set_salt(BLAKE2B_PARAM *P, const uint8_t *salt,
                                  size_t length);
-int ossl_blake2s_init(BLAKE2S_CTX *c, const BLAKE2S_PARAM *P);
-int ossl_blake2s_init_key(BLAKE2S_CTX *c, const BLAKE2S_PARAM *P,
-                          const void *key);
-int ossl_blake2s_update(BLAKE2S_CTX *c, const void *data, size_t datalen);
-int ossl_blake2s_final(unsigned char *md, BLAKE2S_CTX *c);
 
 void ossl_blake2s_param_init(BLAKE2S_PARAM *P);
 void ossl_blake2s_param_set_digest_length(BLAKE2S_PARAM *P, uint8_t outlen);


### PR DESCRIPTION
The biggest change is a cleanup of the blake2 provider implementation

XOFLEN was only implemented for BLAKE2b, not for BLAKE2s.

Also, it was made in such a way that a call of the set_ctx_params function
to set XOFLEN only set the BLAKE2[SB]_PARAM structure, but never had an
effect on the outlen field of the corresponding BLAKE2[SB]_CTX structure,
which effectively ignored whatever was set.

Finally, it's cleaner with a provider implementation that uses
IMPLEMENT_digest_functions_with_settable_ctx(), rather than reimplementing
everything that macro does.

-----

As an aside, this also has the legacy Blake2 EVP structure use the
base blake2[sb] functions instead of going through the provider
specific implementation.  The latter is quite dangerous, considering
that the legacy code has no control over changes in the provider
implementation context.
