### PR TITLE
Have legacy blake2 EVP structure use base blake2 implementation

### DIFF
--- a/crypto/evp/legacy_blake2.c
+++ b/crypto/evp/legacy_blake2.c
@@ -11,11 +11,31 @@
 #include "prov/blake2.h"        /* diverse BLAKE2 macros */
 #include "legacy_meth.h"
 
-#define ossl_blake2b_init ossl_blake2b512_init
-#define ossl_blake2s_init ossl_blake2s256_init
+/*
+ * Local hack to adapt the BLAKE2 init functions to what the
+ * legacy function signatures demand.
+ */
+static int blake2s_init(BLAKE2S_CTX *C)
+{
+    BLAKE2S_PARAM P;
 
-IMPLEMENT_LEGACY_EVP_MD_METH_LC(blake2s_int, ossl_blake2s)
-IMPLEMENT_LEGACY_EVP_MD_METH_LC(blake2b_int, ossl_blake2b)
+    ossl_blake2s_param_init(&P);
+    return ossl_blake2s_init(C, &P);
+}
+static int blake2b_init(BLAKE2B_CTX *C)
+{
+    BLAKE2B_PARAM P;
+
+    ossl_blake2b_param_init(&P);
+    return ossl_blake2b_init(C, &P);
+}
+#define blake2s_update ossl_blake2s_update
+#define blake2b_update ossl_blake2b_update
+#define blake2s_final ossl_blake2s_final
+#define blake2b_final ossl_blake2b_final
+
+IMPLEMENT_LEGACY_EVP_MD_METH_LC(blake2s_int, blake2s)
+IMPLEMENT_LEGACY_EVP_MD_METH_LC(blake2b_int, blake2b)
 
 static const EVP_MD blake2b_md = {
     NID_blake2b512,

--- a/providers/implementations/digests/blake2_prov.c
+++ b/providers/implementations/digests/blake2_prov.c
@@ -12,7 +12,7 @@
 #include "prov/digestcommon.h"
 #include "prov/implementations.h"
 
-int ossl_blake2s256_init(void *ctx)
+static int ossl_blake2s256_init(void *ctx)
 {
     BLAKE2S_PARAM P;
 
@@ -20,7 +20,7 @@ int ossl_blake2s256_init(void *ctx)
     return ossl_blake2s_init((BLAKE2S_CTX *)ctx, &P);
 }
 
-int ossl_blake2b512_init(void *ctx)
+static int ossl_blake2b512_init(void *ctx)
 {
     struct blake2b_md_data_st *mdctx = ctx;
 

--- a/providers/implementations/include/prov/blake2.h
+++ b/providers/implementations/include/prov/blake2.h
@@ -88,9 +88,6 @@ struct blake2b_md_data_st {
     BLAKE2B_PARAM params;
 };
 
-int ossl_blake2s256_init(void *ctx);
-int ossl_blake2b512_init(void *ctx);
-
 int ossl_blake2b_init(BLAKE2B_CTX *c, const BLAKE2B_PARAM *P);
 int ossl_blake2b_init_key(BLAKE2B_CTX *c, const BLAKE2B_PARAM *P,
                           const void *key);


### PR DESCRIPTION
For some reason, the code here was made to got through the provider
specific init functions.  This is very very dangerous if the provider
specific functions were to change in any way (such as changes to the
implementation context structure).

Instead, use the init functions from the base blake2 implementations
directly.
