### PR TITLE
Revert additional dupctx support in provided ciphers in 3.1

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
@@ -334,16 +334,6 @@ static void *aes_cbc_hmac_sha1_newctx(void *provctx, size_t kbits,
     return ctx;
 }
 
-static void *aes_cbc_hmac_sha1_dupctx(void *provctx)
-{
-    PROV_AES_HMAC_SHA1_CTX *ctx = provctx;
-
-    if (ctx == NULL)
-        return NULL;
-
-    return OPENSSL_memdup(ctx, sizeof(*ctx));
-}
-
 static void aes_cbc_hmac_sha1_freectx(void *vctx)
 {
     PROV_AES_HMAC_SHA1_CTX *ctx = (PROV_AES_HMAC_SHA1_CTX *)vctx;
@@ -371,13 +361,6 @@ static void *aes_cbc_hmac_sha256_newctx(void *provctx, size_t kbits,
     return ctx;
 }
 
-static void *aes_cbc_hmac_sha256_dupctx(void *provctx)
-{
-    PROV_AES_HMAC_SHA256_CTX *ctx = provctx;
-
-    return OPENSSL_memdup(ctx, sizeof(*ctx));
-}
-
 static void aes_cbc_hmac_sha256_freectx(void *vctx)
 {
     PROV_AES_HMAC_SHA256_CTX *ctx = (PROV_AES_HMAC_SHA256_CTX *)vctx;
@@ -403,7 +386,6 @@ static int nm##_##kbits##_##sub##_get_params(OSSL_PARAM params[])              \
 const OSSL_DISPATCH ossl_##nm##kbits##sub##_functions[] = {                    \
     { OSSL_FUNC_CIPHER_NEWCTX, (void (*)(void))nm##_##kbits##_##sub##_newctx },\
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))nm##_##sub##_freectx },        \
-    { OSSL_FUNC_CIPHER_DUPCTX,  (void (*)(void))nm##_##sub##_dupctx},          \
     { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))nm##_einit },             \
     { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))nm##_dinit },             \
     { OSSL_FUNC_CIPHER_UPDATE, (void (*)(void))nm##_update },                  \

--- a/providers/implementations/ciphers/cipher_aes_ccm.c
+++ b/providers/implementations/ciphers/cipher_aes_ccm.c
@@ -33,26 +33,6 @@ static void *aes_ccm_newctx(void *provctx, size_t keybits)
     return ctx;
 }
 
-static void *aes_ccm_dupctx(void *provctx)
-{
-    PROV_AES_CCM_CTX *ctx = provctx;
-    PROV_AES_CCM_CTX *dupctx = NULL;
-
-    if (ctx == NULL)
-        return NULL;
-    dupctx = OPENSSL_memdup(provctx, sizeof(*ctx));
-    if (dupctx == NULL)
-        return NULL;
-    /*
-     * ossl_cm_initctx, via the ossl_prov_aes_hw_ccm functions assign a
-     * provctx->ccm.ks.ks to the ccm context key so we need to point it to
-     * the memduped copy
-     */
-    dupctx->base.ccm_ctx.key = &dupctx->ccm.ks.ks;
-
-    return dupctx;
-}
-
 static OSSL_FUNC_cipher_freectx_fn aes_ccm_freectx;
 static void aes_ccm_freectx(void *vctx)
 {

--- a/providers/implementations/ciphers/cipher_aes_gcm.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm.c
@@ -34,15 +34,6 @@ static void *aes_gcm_newctx(void *provctx, size_t keybits)
     return ctx;
 }
 
-static void *aes_gcm_dupctx(void *provctx)
-{
-    PROV_AES_GCM_CTX *ctx = provctx;
-
-    if (ctx == NULL)
-        return NULL;
-    return OPENSSL_memdup(ctx, sizeof(*ctx));
-}
-
 static OSSL_FUNC_cipher_freectx_fn aes_gcm_freectx;
 static void aes_gcm_freectx(void *vctx)
 {

--- a/providers/implementations/ciphers/cipher_aes_wrp.c
+++ b/providers/implementations/ciphers/cipher_aes_wrp.c
@@ -66,26 +66,6 @@ static void *aes_wrap_newctx(size_t kbits, size_t blkbits,
     return wctx;
 }
 
-static void *aes_wrap_dupctx(void *wctx)
-{
-    PROV_AES_WRAP_CTX *ctx = wctx;
-    PROV_AES_WRAP_CTX *dctx = wctx;
-
-    if (ctx == NULL)
-        return NULL;
-    dctx = OPENSSL_memdup(ctx, sizeof(*ctx));
-
-    if (dctx != NULL && dctx->base.tlsmac != NULL && dctx->base.alloced) {
-        dctx->base.tlsmac = OPENSSL_memdup(dctx->base.tlsmac,
-                                           dctx->base.tlsmacsize);
-        if (dctx->base.tlsmac == NULL) {
-            OPENSSL_free(dctx);
-            dctx = NULL;
-        }
-    }
-    return dctx;
-}
-
 static void aes_wrap_freectx(void *vctx)
 {
     PROV_AES_WRAP_CTX *wctx = (PROV_AES_WRAP_CTX *)vctx;
@@ -301,7 +281,6 @@ static int aes_wrap_set_ctx_params(void *vctx, const OSSL_PARAM params[])
         { OSSL_FUNC_CIPHER_UPDATE, (void (*)(void))aes_##mode##_cipher },      \
         { OSSL_FUNC_CIPHER_FINAL, (void (*)(void))aes_##mode##_final },        \
         { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))aes_##mode##_freectx },    \
-        { OSSL_FUNC_CIPHER_DUPCTX, (void (*)(void))aes_##mode##_dupctx },      \
         { OSSL_FUNC_CIPHER_GET_PARAMS,                                         \
             (void (*)(void))aes_##kbits##_##fname##_get_params },              \
         { OSSL_FUNC_CIPHER_GETTABLE_PARAMS,                                    \

--- a/providers/implementations/ciphers/cipher_aria_ccm.c
+++ b/providers/implementations/ciphers/cipher_aria_ccm.c
@@ -28,15 +28,6 @@ static void *aria_ccm_newctx(void *provctx, size_t keybits)
     return ctx;
 }
 
-static void *aria_ccm_dupctx(void *provctx)
-{
-    PROV_ARIA_CCM_CTX *ctx = provctx;
-
-    if (ctx == NULL)
-        return NULL;
-    return OPENSSL_memdup(ctx, sizeof(*ctx));
-}
-
 static void aria_ccm_freectx(void *vctx)
 {
     PROV_ARIA_CCM_CTX *ctx = (PROV_ARIA_CCM_CTX *)vctx;

--- a/providers/implementations/ciphers/cipher_aria_gcm.c
+++ b/providers/implementations/ciphers/cipher_aria_gcm.c
@@ -27,15 +27,6 @@ static void *aria_gcm_newctx(void *provctx, size_t keybits)
     return ctx;
 }
 
-static void *aria_gcm_dupctx(void *provctx)
-{
-    PROV_ARIA_GCM_CTX *ctx = provctx;
-
-    if (ctx == NULL)
-        return NULL;
-    return OPENSSL_memdup(ctx, sizeof(*ctx));
-}
-
 static OSSL_FUNC_cipher_freectx_fn aria_gcm_freectx;
 static void aria_gcm_freectx(void *vctx)
 {

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.c
@@ -23,7 +23,6 @@
 
 static OSSL_FUNC_cipher_newctx_fn chacha20_poly1305_newctx;
 static OSSL_FUNC_cipher_freectx_fn chacha20_poly1305_freectx;
-static OSSL_FUNC_cipher_dupctx_fn chacha20_poly1305_dupctx;
 static OSSL_FUNC_cipher_encrypt_init_fn chacha20_poly1305_einit;
 static OSSL_FUNC_cipher_decrypt_init_fn chacha20_poly1305_dinit;
 static OSSL_FUNC_cipher_get_params_fn chacha20_poly1305_get_params;
@@ -57,25 +56,6 @@ static void *chacha20_poly1305_newctx(void *provctx)
         ossl_chacha20_initctx(&ctx->chacha);
     }
     return ctx;
-}
-
-static void *chacha20_poly1305_dupctx(void *provctx)
-{
-    PROV_CHACHA20_POLY1305_CTX *ctx = provctx;
-    PROV_CHACHA20_POLY1305_CTX *dctx = NULL;
-
-    if (ctx == NULL)
-        return NULL;
-    dctx = OPENSSL_memdup(ctx, sizeof(*ctx));
-    if (dctx != NULL && dctx->base.tlsmac != NULL && dctx->base.alloced) {
-        dctx->base.tlsmac = OPENSSL_memdup(dctx->base.tlsmac,
-                                           dctx->base.tlsmacsize);
-        if (dctx->base.tlsmac == NULL) {
-            OPENSSL_free(dctx);
-            dctx = NULL;
-        }
-    }
-    return dctx;
 }
 
 static void chacha20_poly1305_freectx(void *vctx)
@@ -330,7 +310,6 @@ static int chacha20_poly1305_final(void *vctx, unsigned char *out, size_t *outl,
 const OSSL_DISPATCH ossl_chacha20_ossl_poly1305_functions[] = {
     { OSSL_FUNC_CIPHER_NEWCTX, (void (*)(void))chacha20_poly1305_newctx },
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))chacha20_poly1305_freectx },
-    { OSSL_FUNC_CIPHER_DUPCTX, (void (*)(void))chacha20_poly1305_dupctx },
     { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))chacha20_poly1305_einit },
     { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))chacha20_poly1305_dinit },
     { OSSL_FUNC_CIPHER_UPDATE, (void (*)(void))chacha20_poly1305_update },

--- a/providers/implementations/ciphers/cipher_rc4_hmac_md5.c
+++ b/providers/implementations/ciphers/cipher_rc4_hmac_md5.c
@@ -34,7 +34,6 @@ static OSSL_FUNC_cipher_encrypt_init_fn rc4_hmac_md5_einit;
 static OSSL_FUNC_cipher_decrypt_init_fn rc4_hmac_md5_dinit;
 static OSSL_FUNC_cipher_newctx_fn rc4_hmac_md5_newctx;
 static OSSL_FUNC_cipher_freectx_fn rc4_hmac_md5_freectx;
-static OSSL_FUNC_cipher_dupctx_fn rc4_hmac_md5_dupctx;
 static OSSL_FUNC_cipher_get_ctx_params_fn rc4_hmac_md5_get_ctx_params;
 static OSSL_FUNC_cipher_gettable_ctx_params_fn rc4_hmac_md5_gettable_ctx_params;
 static OSSL_FUNC_cipher_set_ctx_params_fn rc4_hmac_md5_set_ctx_params;
@@ -70,15 +69,6 @@ static void rc4_hmac_md5_freectx(void *vctx)
 
     ossl_cipher_generic_reset_ctx((PROV_CIPHER_CTX *)vctx);
     OPENSSL_clear_free(ctx,  sizeof(*ctx));
-}
-
-static void *rc4_hmac_md5_dupctx(void *vctx)
-{
-    PROV_RC4_HMAC_MD5_CTX *ctx = vctx;
-
-    if (ctx == NULL)
-        return NULL;
-    return OPENSSL_memdup(ctx, sizeof(*ctx));
 }
 
 static int rc4_hmac_md5_einit(void *ctx, const unsigned char *key,
@@ -224,7 +214,6 @@ static int rc4_hmac_md5_get_params(OSSL_PARAM params[])
 const OSSL_DISPATCH ossl_rc4_hmac_ossl_md5_functions[] = {
     { OSSL_FUNC_CIPHER_NEWCTX, (void (*)(void))rc4_hmac_md5_newctx },
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))rc4_hmac_md5_freectx },
-    { OSSL_FUNC_CIPHER_DUPCTX, (void (*)(void))rc4_hmac_md5_dupctx },
     { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))rc4_hmac_md5_einit },
     { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))rc4_hmac_md5_dinit },
     { OSSL_FUNC_CIPHER_UPDATE, (void (*)(void))rc4_hmac_md5_update },

--- a/providers/implementations/ciphers/cipher_sm4_ccm.c
+++ b/providers/implementations/ciphers/cipher_sm4_ccm.c
@@ -28,15 +28,6 @@ static void *sm4_ccm_newctx(void *provctx, size_t keybits)
     return ctx;
 }
 
-static void *sm4_ccm_dupctx(void *provctx)
-{
-    PROV_SM4_CCM_CTX *ctx = provctx;
-
-    if (ctx == NULL)
-        return NULL;
-    return OPENSSL_memdup(ctx, sizeof(*ctx));
-}
-
 static void sm4_ccm_freectx(void *vctx)
 {
     PROV_SM4_CCM_CTX *ctx = (PROV_SM4_CCM_CTX *)vctx;

--- a/providers/implementations/ciphers/cipher_sm4_gcm.c
+++ b/providers/implementations/ciphers/cipher_sm4_gcm.c
@@ -29,15 +29,6 @@ static void *sm4_gcm_newctx(void *provctx, size_t keybits)
     return ctx;
 }
 
-static void *sm4_gcm_dupctx(void *provctx)
-{
-    PROV_SM4_GCM_CTX *ctx = provctx;
-
-    if (ctx == NULL)
-        return NULL;
-    return OPENSSL_memdup(ctx, sizeof(*ctx));
-}
-
 static void sm4_gcm_freectx(void *vctx)
 {
     PROV_SM4_GCM_CTX *ctx = (PROV_SM4_GCM_CTX *)vctx;

--- a/providers/implementations/include/prov/ciphercommon_aead.h
+++ b/providers/implementations/include/prov/ciphercommon_aead.h
@@ -23,14 +23,9 @@ static void * alg##kbits##lc##_newctx(void *provctx)                           \
 {                                                                              \
     return alg##_##lc##_newctx(provctx, kbits);                                \
 }                                                                              \
-static void * alg##kbits##lc##_dupctx(void *src)                               \
-{                                                                              \
-    return alg##_##lc##_dupctx(src);                                           \
-}                                                                              \
 const OSSL_DISPATCH ossl_##alg##kbits##lc##_functions[] = {                    \
     { OSSL_FUNC_CIPHER_NEWCTX, (void (*)(void))alg##kbits##lc##_newctx },      \
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))alg##_##lc##_freectx },        \
-    { OSSL_FUNC_CIPHER_DUPCTX, (void (*)(void))alg##kbits##lc##_dupctx },      \
     { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))ossl_##lc##_einit },      \
     { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))ossl_##lc##_dinit },      \
     { OSSL_FUNC_CIPHER_UPDATE, (void (*)(void))ossl_##lc##_stream_update },    \

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -709,9 +709,6 @@ static int cipher_test_enc(EVP_TEST *t, int enc,
     int ok = 0, tmplen, chunklen, tmpflen, i;
     EVP_CIPHER_CTX *ctx_base = NULL;
     EVP_CIPHER_CTX *ctx = NULL, *duped;
-    int fips_dupctx_supported = (fips_provider_version_ge(libctx, 3, 0, 11)
-                                && fips_provider_version_lt(libctx, 3, 1, 0))
-                                || fips_provider_version_ge(libctx, 3, 1, 3);
 
     t->err = "TEST_FAILURE";
     if (!TEST_ptr(ctx_base = EVP_CIPHER_CTX_new()))
@@ -842,30 +839,18 @@ static int cipher_test_enc(EVP_TEST *t, int enc,
 
     /* Test that the cipher dup functions correctly if it is supported */
     ERR_set_mark();
-    if (!EVP_CIPHER_CTX_copy(ctx, ctx_base)) {
-        if (fips_dupctx_supported) {
-            TEST_info("Doing a copy of Cipher %s Fails!\n",
-                      EVP_CIPHER_get0_name(expected->cipher));
-            ERR_print_errors_fp(stderr);
-            goto err;
-        } else {
-            TEST_info("Allowing copy fail as an old fips provider is in use.");
-        }
+    if (EVP_CIPHER_CTX_copy(ctx, ctx_base)) {
+        EVP_CIPHER_CTX_free(ctx_base);
+        ctx_base = NULL;
+    } else {
+        EVP_CIPHER_CTX_free(ctx);
+        ctx = ctx_base;
     }
     /* Likewise for dup */
     duped = EVP_CIPHER_CTX_dup(ctx);
     if (duped != NULL) {
         EVP_CIPHER_CTX_free(ctx);
         ctx = duped;
-    } else {
-        if (fips_dupctx_supported) {
-            TEST_info("Doing a dup of Cipher %s Fails!\n",
-                      EVP_CIPHER_get0_name(expected->cipher));
-            ERR_print_errors_fp(stderr);
-            goto err;
-        } else {
-            TEST_info("Allowing dup fail as an old fips provider is in use.");
-        }
     }
     ERR_pop_to_mark();
 
@@ -1050,7 +1035,6 @@ static int cipher_test_run(EVP_TEST *t)
     int rv, frag = 0;
     size_t out_misalign, inp_misalign;
 
-    TEST_info("RUNNING TEST FOR CIPHER %s\n", EVP_CIPHER_get0_name(cdat->cipher));
     if (!cdat->key) {
         t->err = "NO_KEY";
         return 0;


### PR DESCRIPTION
The CI on 3.1 is broken due to this so marking this urgent.
