### PR TITLE
Issue 22076 - Fix regressions in dupctx testing #22082

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_gcm.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm.c
@@ -37,10 +37,16 @@ static void *aes_gcm_newctx(void *provctx, size_t keybits)
 static void *aes_gcm_dupctx(void *provctx)
 {
     PROV_AES_GCM_CTX *ctx = provctx;
+    PROV_AES_GCM_CTX *dctx = NULL;
 
     if (ctx == NULL)
         return NULL;
-    return OPENSSL_memdup(ctx, sizeof(*ctx));
+
+    dctx = OPENSSL_memdup(ctx, sizeof(*ctx));
+    if (dctx != NULL && dctx->base.gcm.key != NULL)
+        dctx->base.gcm.key = &dctx->ks.ks;
+
+    return dctx;
 }
 
 static OSSL_FUNC_cipher_freectx_fn aes_gcm_freectx;

--- a/providers/implementations/ciphers/cipher_aria_ccm.c
+++ b/providers/implementations/ciphers/cipher_aria_ccm.c
@@ -31,10 +31,16 @@ static void *aria_ccm_newctx(void *provctx, size_t keybits)
 static void *aria_ccm_dupctx(void *provctx)
 {
     PROV_ARIA_CCM_CTX *ctx = provctx;
+    PROV_ARIA_CCM_CTX *dctx = NULL;
 
     if (ctx == NULL)
         return NULL;
-    return OPENSSL_memdup(ctx, sizeof(*ctx));
+
+    dctx = OPENSSL_memdup(ctx, sizeof(*ctx));
+    if (dctx != NULL && dctx->base.ccm_ctx.key != NULL)
+        dctx->base.ccm_ctx.key = &dctx->ks.ks;
+
+    return dctx;
 }
 
 static void aria_ccm_freectx(void *vctx)

--- a/providers/implementations/ciphers/cipher_aria_gcm.c
+++ b/providers/implementations/ciphers/cipher_aria_gcm.c
@@ -30,10 +30,16 @@ static void *aria_gcm_newctx(void *provctx, size_t keybits)
 static void *aria_gcm_dupctx(void *provctx)
 {
     PROV_ARIA_GCM_CTX *ctx = provctx;
+    PROV_ARIA_GCM_CTX *dctx = NULL;
 
     if (ctx == NULL)
         return NULL;
-    return OPENSSL_memdup(ctx, sizeof(*ctx));
+
+    dctx =  OPENSSL_memdup(ctx, sizeof(*ctx));
+    if (dctx != NULL && dctx->base.gcm.key != NULL)
+        dctx->base.gcm.key = &dctx->ks.ks;
+
+    return dctx;
 }
 
 static OSSL_FUNC_cipher_freectx_fn aria_gcm_freectx;

--- a/providers/implementations/ciphers/cipher_sm4_ccm.c
+++ b/providers/implementations/ciphers/cipher_sm4_ccm.c
@@ -31,10 +31,16 @@ static void *sm4_ccm_newctx(void *provctx, size_t keybits)
 static void *sm4_ccm_dupctx(void *provctx)
 {
     PROV_SM4_CCM_CTX *ctx = provctx;
+    PROV_SM4_CCM_CTX *dctx = NULL;
 
     if (ctx == NULL)
         return NULL;
-    return OPENSSL_memdup(ctx, sizeof(*ctx));
+
+    dctx = OPENSSL_memdup(ctx, sizeof(*ctx));
+    if (dctx != NULL && dctx->base.ccm_ctx.key != NULL)
+        dctx->base.ccm_ctx.key = &dctx->ks.ks;
+
+    return dctx;
 }
 
 static void sm4_ccm_freectx(void *vctx)

--- a/providers/implementations/ciphers/cipher_sm4_gcm.c
+++ b/providers/implementations/ciphers/cipher_sm4_gcm.c
@@ -32,10 +32,16 @@ static void *sm4_gcm_newctx(void *provctx, size_t keybits)
 static void *sm4_gcm_dupctx(void *provctx)
 {
     PROV_SM4_GCM_CTX *ctx = provctx;
+    PROV_SM4_GCM_CTX *dctx = NULL;
 
     if (ctx == NULL)
         return NULL;
-    return OPENSSL_memdup(ctx, sizeof(*ctx));
+
+    dctx = OPENSSL_memdup(ctx, sizeof(*ctx));
+    if (dctx != NULL && dctx->base.gcm.key != NULL)
+        dctx->base.gcm.key = &dctx->ks.ks;
+
+    return dctx;
 }
 
 static void sm4_gcm_freectx(void *vctx)

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -877,6 +877,11 @@ static int cipher_test_enc(EVP_TEST *t, int enc, size_t out_misalign,
         } else {
             TEST_info("Allowing copy fail as an old fips provider is in use.");
         }
+        EVP_CIPHER_CTX_free(ctx);
+        ctx = ctx_base;
+    } else {
+        EVP_CIPHER_CTX_free(ctx_base);
+        ctx_base = NULL;
     }
     /* Likewise for dup */
     duped = EVP_CIPHER_CTX_dup(ctx);


### PR DESCRIPTION
Hit a few regressions in dupctx tests from my addition of those methods in the various ciphers. Fix them up

##### Checklist
- [x] tests are added or updated
