### PR TITLE
crypto/evp/legacy_blake2.c: Fix coverity alert on use of uninitialised data

### DIFF
--- a/crypto/evp/legacy_blake2.c
+++ b/crypto/evp/legacy_blake2.c
@@ -17,14 +17,14 @@
  */
 static int blake2s_init(BLAKE2S_CTX *C)
 {
-    BLAKE2S_PARAM P;
+    BLAKE2S_PARAM P = { 0, };
 
     ossl_blake2s_param_init(&P);
     return ossl_blake2s_init(C, &P);
 }
 static int blake2b_init(BLAKE2B_CTX *C)
 {
-    BLAKE2B_PARAM P;
+    BLAKE2B_PARAM P = { 0, };
 
     ossl_blake2b_param_init(&P);
     return ossl_blake2b_init(C, &P);


### PR DESCRIPTION
ossl_blake2b_param_init() looks at the contents of the contents of the
passed BLAKE2B_PARAM reference.  That structure therefore needs to be
initiliazed beforehand.

Just to be safe, the same is done with BLAKE2S_PARAM.
