### PR TITLE
Do not include sparse_array.o in libssl

### DIFF
--- a/crypto/build.info
+++ b/crypto/build.info
@@ -97,8 +97,6 @@ $UTIL_COMMON=\
         context.c sparse_array.c asn1_dsa.c packet.c param_build.c \
         param_build_set.c der_writer.c threads_lib.c params_dup.c
 
-SHARED_SOURCE[../libssl]=sparse_array.c
-
 SOURCE[../libcrypto]=$UTIL_COMMON \
         mem.c mem_sec.c \
         cversion.c info.c cpt_err.c ebcdic.c uid.c o_time.c o_dir.c \


### PR DESCRIPTION
sparse_array.o is not needed in libssl at 3.0.x version.

fix #22113 
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
