### PR TITLE
Fix a merge mistake in engne_list_add

### DIFF
--- a/crypto/engine/eng_list.c
+++ b/crypto/engine/eng_list.c
@@ -82,7 +82,6 @@ static int engine_list_add(ENGINE *e)
          * The first time the list allocates, we should register the cleanup.
          */
         if (!engine_cleanup_add_last(engine_list_cleanup)) {
-            CRYPTO_DOWN_REF(&e->struct_ref, &ref);
             ERR_raise(ERR_LIB_ENGINE, ENGINE_R_INTERNAL_LIST_ERROR);
             return 0;
         }


### PR DESCRIPTION
master version increments the struct_ref early
and needs to decrement the struct_ref on error,
while 3.1 and 3.0 increment the struct_ref later.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
