### PR TITLE
APPS: remove duplicate definition of `trace_data_stack`

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -157,8 +157,6 @@ static void tracedata_free(tracedata *data)
     OPENSSL_free(data);
 }
 
-static STACK_OF(tracedata) *trace_data_stack;
-
 static void cleanup_trace(void)
 {
     sk_tracedata_pop_free(trace_data_stack, tracedata_free);


### PR DESCRIPTION
Note: It seems like the C compiler doesn't care about the duplicate. (The first definition is eight lines above.) The C++ compiler however didn't like it when I reused the tracing code snippets elsewhere.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
