### PR TITLE
Enable the ability to seed the test RNG without randomising test ordering

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -149,17 +149,33 @@ To run up to four tests in parallel at any given time:
 
     $ make HARNESS_JOBS=4 test
 
+Random numbers in tests
+-----------------------
+
+Some tests use random numbers as part of the test. In some cases a test failure
+may occur for some random numbers, but not for others. The seed used for the
+rand number generator can be set via the `OPENSSL_TEST_RAND_SEED` environment
+variable. It can also be set via the `OPENSSL_TEST_RAND_ORDER` environment
+variable which additionally randomises the order tests are run in (see below).
+
+When a test fails the test harness will display the seed used during the test
+(displaying either the `OPENSSL_TEST_RAND_SEED` or `OPENSSL_TEST_RAND_ORDER`
+environment variable value that must be used to recreate the results), e.g.
+
+    $ make OPENSSL_TEST_RAND_SEED=42 test
+
 Randomisation of Test Ordering
 ------------------------------
 
 By default, the test harness will execute tests in the order they were added.
 By setting the `OPENSSL_TEST_RAND_ORDER` environment variable to zero, the
-test ordering will be randomised.  If a randomly ordered test fails, the
-seed value used will be reported.  Setting the `OPENSSL_TEST_RAND_ORDER`
-environment variable to this value will rerun the tests in the same
-order.  This assures repeatability of randomly ordered test runs.
-This repeatability is independent of the operating system, processor or
-platform used.
+test ordering will be randomised. This additionally seeds the random number
+generator used within the tests as described in the section above. If a randomly
+ordered test fails, the seed value used will be reported.  Setting the
+`OPENSSL_TEST_RAND_ORDER` environment variable to this value will rerun the
+tests in the same order and will also seed the test random number generator.
+This assures repeatability of randomly ordered test runs. This repeatability is
+independent of the operating system, processor or platform used.
 
 To randomise the test ordering:
 

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -102,15 +102,18 @@ static void set_seed(int s)
 
 int setup_test_framework(int argc, char *argv[])
 {
-    char *test_seed = getenv("OPENSSL_TEST_RAND_ORDER");
+    char *test_rand_order = getenv("OPENSSL_TEST_RAND_ORDER");
+    char *test_rand_seed = getenv("OPENSSL_TEST_RAND_SEED");
     char *TAP_levels = getenv("HARNESS_OSSL_LEVEL");
 
     if (TAP_levels != NULL)
         level = 4 * atoi(TAP_levels);
     test_adjust_streams_tap_level(level);
-    if (test_seed != NULL) {
+    if (test_rand_order != NULL) {
         rand_order = 1;
-        set_seed(atoi(test_seed));
+        set_seed(atoi(test_rand_order));
+    } else if (test_rand_seed != NULL) {
+        set_seed(atoi(test_rand_seed));
     } else {
         set_seed(0);
     }
@@ -264,8 +267,12 @@ PRINTF_FORMAT(2, 3) static void test_verdict(int verdict,
     test_flush_stdout();
     test_flush_stderr();
 
-    if (verdict == 0 && seed != 0)
-        test_printf_tapout("# OPENSSL_TEST_RAND_ORDER=%d\n", seed);
+    if (verdict == 0) {
+        if (rand_order)
+            test_printf_tapout("# OPENSSL_TEST_RAND_ORDER=%d\n", seed);
+        else
+            test_printf_tapout("# OPENSSL_TEST_RAND_SEED=%d\n", seed);
+    }
     test_printf_tapout("%s ", verdict != 0 ? "ok" : "not ok");
     va_start(ap, description);
     test_vprintf_tapout(description, ap);


### PR DESCRIPTION
Numerous tests use the test_random() function to get a random number. If a
test fails then the seed that was used for the test RNG is displayed.
Setting the seed to the same value in a future run is supposed to cause the
same random numbers to be generated again.

The way to set the RNG seed again is to use the `OPENSSL_TEST_RAND_ORDER`
environment variable. However setting this environment variable *also*
randomises the test ordering as well as seeding the RNG. This in itself
calls test_random() so, in fact, when the test finally runs it gets
different random numbers to when it originally run (defeating the
repeatability objective).

This means that only way repeatability can be obtained is if the test was
originally run with `OPENSSL_TEST_RAND_ORDER` set to 0. If that wasn't done
then the seed printed when the test failed is not useful.

We introduce a new environment variable `OPENSSL_TEST_RAND_SEED` which can
be used to independently seed the test RNG without randomising the test
ordering. This can be used to get repeatability in cases where test ordering
randomisation was not done in the first place.
