### PR TITLE
enc: "bad decrypt" only in decryption

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -701,7 +701,10 @@ int enc_main(int argc, char **argv)
             break;
     }
     if (!BIO_flush(wbio)) {
-        BIO_printf(bio_err, "bad decrypt\n");
+        if (enc)
+            BIO_printf(bio_err, "bad encrypt\n");
+        else
+            BIO_printf(bio_err, "bad decrypt\n");
         goto end;
     }
 


### PR DESCRIPTION
Hi,

In this PR we solve the issue raised in #21439 - locally tested:
```
$ echo jebs | openssl enc -e -aes-256-cbc -pass pass:password -pbkdf2  -nopad
bad encrypt
$ cat ./foo | openssl enc -d -aes-256-cbc -pass pass:password -pbkdf2
bad decrypt
```

Fixes: https://github.com/openssl/openssl/issues/21439

EDIT: I assume it's a trivial change.
