### PR TITLE
Fix error handling in CRYPTO_get_ex_new_index

### DIFF
--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -171,6 +171,8 @@ int ossl_crypto_get_ex_new_index_ex(OSSL_LIB_CTX *ctx, int class_index,
          * "app_data" routines use ex_data index zero.  See RT 3710. */
         if (ip->meth == NULL
             || !sk_EX_CALLBACK_push(ip->meth, NULL)) {
+            sk_EX_CALLBACK_free(ip->meth);
+            ip->meth = NULL;
             ERR_raise(ERR_LIB_CRYPTO, ERR_R_CRYPTO_LIB);
             goto err;
         }


### PR DESCRIPTION
If an out of memory error happens when the index zero is reserved in a newly created ip->meth stack object, that reservation is not done in a second attempt, which makes various X_set_ex_data overwrite the value of X_set_app_data.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
