### PR TITLE
Fix test_cms if DSA is not supported

### DIFF
--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -1144,9 +1144,13 @@ with({ exit_checker => sub { return shift == 6; } },
 # Test case for return value mis-check reported in #21986
 with({ exit_checker => sub { return shift == 3; } },
     sub {
-        ok(run(app(['openssl', 'cms', '-sign',
-                    '-in', srctop_file("test", "smcont.txt"),
-                    '-signer', srctop_file("test/smime-certs", "smdsa1.pem"),
-                    '-md', 'SHAKE256'])),
-           "issue#21986");
+        SKIP: {
+          skip "DSA is not supported in this build", 1 if $no_dsa;
+
+          ok(run(app(['openssl', 'cms', '-sign',
+                      '-in', srctop_file("test", "smcont.txt"),
+                      '-signer', srctop_file("test/smime-certs", "smdsa1.pem"),
+                      '-md', 'SHAKE256'])),
+            "issue#21986");
+        }
     });


### PR DESCRIPTION
test_cms test fails if DSA is not enabled.

Reproduction example:
```bash
./config no-dsa
make TESTS="test_cms" test
```

This fails with:
```
[...]
80-test_cms.t .. 10/? 
Could not find private key of signing key from ../../test/smime-certs/smdsa1.pem
4007ABB8727F0000:error:1608010C:STORE routines:ossl_store_handle_load_result:unsupported:crypto/store/store_result.c:151:
../../util/wrap.pl ../../apps/openssl cms -sign -in ../../test/smcont.txt -signer ../../test/smime-certs/smdsa1.pem -md SHAKE256 => 2
not ok 21 - issue\#21986
# ------------------------------------------------------------------------------
#   Failed test 'issue#21986'
#   at test/recipes/80-test_cms.t line 1147.
80-test_cms.t .. Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/21 subtests
```

This PR adds a skip if DSA is disabled.

CLA: trivial

##### Checklist
- [x] tests are added or updated
