### PR TITLE
Test that dropping/delaying/reordering datagrams is correctly handled in QUIC

### DIFF
--- a/doc/designs/quic-design/quic-fault-injector.md
+++ b/doc/designs/quic-design/quic-fault-injector.md
@@ -215,7 +215,7 @@ typedef struct ossl_qf_encrypted_extensions {
 int qtest_create_quic_objects(OSSL_LIB_CTX *libctx, SSL_CTX *clientctx,
                               SSL_CTX *serverctx, char *certfile, char *keyfile,
                               int block, QUIC_TSERVER **qtserv, SSL **cssl,
-                              OSSL_QUIC_FAULT **fault);
+                              OSSL_QUIC_FAULT **fault, BIO **tracebio);
 
 /*
  * Free up a Fault Injector instance
@@ -440,7 +440,7 @@ static int test_unknown_frame(void)
         goto err;
 
     if (!TEST_true(qtest_create_quic_objects(NULL, cctx, NULL, cert, privkey, 0,
-                                             &qtserv, &cssl, &fault)))
+                                             &qtserv, &cssl, &fault, NULL)))
         goto err;
 
     if (!TEST_true(qtest_create_quic_connection(qtserv, cssl)))
@@ -523,7 +523,7 @@ static int test_no_transport_params(void)
         goto err;
 
     if (!TEST_true(qtest_create_quic_objects(NULL, cctx, NULL, cert, privkey, 0,
-                                             &qtserv, &cssl, &fault)))
+                                             &qtserv, &cssl, &fault, NULL)))
         goto err;
 
     if (!TEST_true(ossl_quic_fault_set_hand_enc_ext_listener(fault,

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -545,8 +545,8 @@ void ossl_quic_free(SSL *s)
 
     ossl_quic_channel_free(ctx.qc->ch);
 
-    BIO_free(ctx.qc->net_rbio);
-    BIO_free(ctx.qc->net_wbio);
+    BIO_free_all(ctx.qc->net_rbio);
+    BIO_free_all(ctx.qc->net_wbio);
 
     /* Note: SSL_free calls OPENSSL_free(qc) for us */
 
@@ -876,7 +876,7 @@ void ossl_quic_conn_set0_net_rbio(SSL *s, BIO *net_rbio)
     if (!ossl_quic_channel_set_net_rbio(ctx.qc->ch, net_rbio))
         return;
 
-    BIO_free(ctx.qc->net_rbio);
+    BIO_free_all(ctx.qc->net_rbio);
     ctx.qc->net_rbio = net_rbio;
 
     if (net_rbio != NULL)
@@ -903,7 +903,7 @@ void ossl_quic_conn_set0_net_wbio(SSL *s, BIO *net_wbio)
     if (!ossl_quic_channel_set_net_wbio(ctx.qc->ch, net_wbio))
         return;
 
-    BIO_free(ctx.qc->net_wbio);
+    BIO_free_all(ctx.qc->net_wbio);
     ctx.qc->net_wbio = net_wbio;
 
     if (net_wbio != NULL)

--- a/ssl/quic/quic_tserver.c
+++ b/ssl/quic/quic_tserver.c
@@ -159,8 +159,8 @@ void ossl_quic_tserver_free(QUIC_TSERVER *srv)
         return;
 
     ossl_quic_channel_free(srv->ch);
-    BIO_free(srv->args.net_rbio);
-    BIO_free(srv->args.net_wbio);
+    BIO_free_all(srv->args.net_rbio);
+    BIO_free_all(srv->args.net_wbio);
     OPENSSL_free(srv->ssl);
     SSL_free(srv->tls);
     SSL_CTX_free(srv->ctx);

--- a/test/build.info
+++ b/test/build.info
@@ -339,7 +339,9 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[quic_client_test]=../include ../apps/include
   DEPEND[quic_client_test]=../libcrypto.a ../libssl.a libtestutil.a
 
-  SOURCE[quic_multistream_test]=quic_multistream_test.c helpers/ssltestlib.c helpers/quictestlib.c helpers/noisydgrambio.c
+  $QUICTESTHELPERS=helpers/quictestlib.c helpers/noisydgrambio.c helpers/pktsplitbio.c
+
+  SOURCE[quic_multistream_test]=quic_multistream_test.c helpers/ssltestlib.c $QUICTESTHELPERS
   INCLUDE[quic_multistream_test]=../include ../apps/include
   DEPEND[quic_multistream_test]=../libcrypto.a ../libssl.a libtestutil.a
 
@@ -818,15 +820,15 @@ IF[{- !$disabled{tests} -}]
       INCLUDE[event_queue_test]=../include ../apps/include
       DEPEND[event_queue_test]=../libcrypto ../libssl.a libtestutil.a
 
-      SOURCE[quicfaultstest]=quicfaultstest.c helpers/ssltestlib.c helpers/quictestlib.c helpers/noisydgrambio.c
+      SOURCE[quicfaultstest]=quicfaultstest.c helpers/ssltestlib.c $QUICTESTHELPERS
       INCLUDE[quicfaultstest]=../include ../apps/include ..
       DEPEND[quicfaultstest]=../libcrypto.a ../libssl.a libtestutil.a
 
-      SOURCE[quicapitest]=quicapitest.c helpers/ssltestlib.c helpers/quictestlib.c helpers/noisydgrambio.c
+      SOURCE[quicapitest]=quicapitest.c helpers/ssltestlib.c $QUICTESTHELPERS
       INCLUDE[quicapitest]=../include ../apps/include
       DEPEND[quicapitest]=../libcrypto.a ../libssl.a libtestutil.a
 
-      SOURCE[quic_newcid_test]=quic_newcid_test.c helpers/ssltestlib.c helpers/quictestlib.c helpers/noisydgrambio.c
+      SOURCE[quic_newcid_test]=quic_newcid_test.c helpers/ssltestlib.c $QUICTESTHELPERS
       INCLUDE[quic_newcid_test]=../include ../apps/include ..
       DEPEND[quic_newcid_test]=../libcrypto.a ../libssl.a libtestutil.a
     ENDIF

--- a/test/build.info
+++ b/test/build.info
@@ -339,7 +339,7 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[quic_client_test]=../include ../apps/include
   DEPEND[quic_client_test]=../libcrypto.a ../libssl.a libtestutil.a
 
-  SOURCE[quic_multistream_test]=quic_multistream_test.c helpers/ssltestlib.c helpers/quictestlib.c
+  SOURCE[quic_multistream_test]=quic_multistream_test.c helpers/ssltestlib.c helpers/quictestlib.c helpers/noisydgrambio.c
   INCLUDE[quic_multistream_test]=../include ../apps/include
   DEPEND[quic_multistream_test]=../libcrypto.a ../libssl.a libtestutil.a
 
@@ -818,15 +818,15 @@ IF[{- !$disabled{tests} -}]
       INCLUDE[event_queue_test]=../include ../apps/include
       DEPEND[event_queue_test]=../libcrypto ../libssl.a libtestutil.a
 
-      SOURCE[quicfaultstest]=quicfaultstest.c helpers/ssltestlib.c helpers/quictestlib.c
+      SOURCE[quicfaultstest]=quicfaultstest.c helpers/ssltestlib.c helpers/quictestlib.c helpers/noisydgrambio.c
       INCLUDE[quicfaultstest]=../include ../apps/include ..
       DEPEND[quicfaultstest]=../libcrypto.a ../libssl.a libtestutil.a
 
-      SOURCE[quicapitest]=quicapitest.c helpers/ssltestlib.c helpers/quictestlib.c
+      SOURCE[quicapitest]=quicapitest.c helpers/ssltestlib.c helpers/quictestlib.c helpers/noisydgrambio.c
       INCLUDE[quicapitest]=../include ../apps/include
       DEPEND[quicapitest]=../libcrypto.a ../libssl.a libtestutil.a
 
-      SOURCE[quic_newcid_test]=quic_newcid_test.c helpers/ssltestlib.c helpers/quictestlib.c
+      SOURCE[quic_newcid_test]=quic_newcid_test.c helpers/ssltestlib.c helpers/quictestlib.c helpers/noisydgrambio.c
       INCLUDE[quic_newcid_test]=../include ../apps/include ..
       DEPEND[quic_newcid_test]=../libcrypto.a ../libssl.a libtestutil.a
     ENDIF

--- a/test/helpers/noisydgrambio.c
+++ b/test/helpers/noisydgrambio.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/bio.h>
+#include "quictestlib.h"
+
+static int noisy_dgram_read(BIO *bio, char *out, int outl)
+{
+    /* We don't support this - not needed anyway */
+    return -1;
+}
+
+static int noisy_dgram_write(BIO *bio, const char *in, int inl)
+{
+    /* We don't support this - not needed anyway */
+    return -1;
+}
+
+static long noisy_dgram_ctrl(BIO *bio, int cmd, long num, void *ptr)
+{
+    long ret;
+    BIO *next = BIO_next(bio);
+
+    if (next == NULL)
+        return 0;
+
+    switch (cmd) {
+    case BIO_CTRL_DUP:
+        ret = 0L;
+        break;
+    default:
+        ret = BIO_ctrl(next, cmd, num, ptr);
+        break;
+    }
+    return ret;
+}
+
+static int noisy_dgram_gets(BIO *bio, char *buf, int size)
+{
+    /* We don't support this - not needed anyway */
+    return -1;
+}
+
+static int noisy_dgram_puts(BIO *bio, const char *str)
+{
+    /* We don't support this - not needed anyway */
+    return -1;
+}
+
+static int noisy_dgram_sendmmsg(BIO *bio, BIO_MSG *msg, size_t stride,
+                                size_t num_msg, uint64_t flags,
+                                size_t *msgs_processed)
+{
+    BIO *next = BIO_next(bio);
+
+    if (next == NULL)
+        return 0;
+
+    /*
+     * We only introduce noise when receiving messages. We just pass this on
+     * to the underlying BIO.
+     */
+    return BIO_sendmmsg(next, msg, stride, num_msg, flags, msgs_processed);
+}
+
+static int noisy_dgram_recvmmsg(BIO *bio, BIO_MSG *msg, size_t stride,
+                                size_t num_msg, uint64_t flags,
+                                size_t *msgs_processed)
+{
+    BIO *next = BIO_next(bio);
+
+    if (next == NULL)
+        return 0;
+
+    /*
+     * We will introduce noise here. None implemented yet.
+     */
+    return BIO_recvmmsg(next, msg, stride, num_msg, flags, msgs_processed);
+}
+
+static int noisy_dgram_new(BIO *bio)
+{
+    BIO_set_init(bio, 1);
+
+    return 1;
+}
+
+static int noisy_dgram_free(BIO *bio)
+{
+    BIO_set_init(bio, 0);
+
+    return 1;
+}
+
+/* Choose a sufficiently large type likely to be unused for this custom BIO */
+#define BIO_TYPE_NOISY_DGRAM_FILTER  (0x80 | BIO_TYPE_FILTER)
+
+static BIO_METHOD *method_noisy_dgram = NULL;
+
+/* Note: Not thread safe! */
+const BIO_METHOD *bio_f_noisy_dgram_filter(void)
+{
+    if (method_noisy_dgram == NULL) {
+        method_noisy_dgram = BIO_meth_new(BIO_TYPE_NOISY_DGRAM_FILTER,
+                                          "Nosiy datagram filter");
+        if (method_noisy_dgram == NULL
+            || !BIO_meth_set_write(method_noisy_dgram, noisy_dgram_write)
+            || !BIO_meth_set_read(method_noisy_dgram, noisy_dgram_read)
+            || !BIO_meth_set_puts(method_noisy_dgram, noisy_dgram_puts)
+            || !BIO_meth_set_gets(method_noisy_dgram, noisy_dgram_gets)
+            || !BIO_meth_set_ctrl(method_noisy_dgram, noisy_dgram_ctrl)
+            || !BIO_meth_set_sendmmsg(method_noisy_dgram, noisy_dgram_sendmmsg)
+            || !BIO_meth_set_recvmmsg(method_noisy_dgram, noisy_dgram_recvmmsg)
+            || !BIO_meth_set_create(method_noisy_dgram, noisy_dgram_new)
+            || !BIO_meth_set_destroy(method_noisy_dgram, noisy_dgram_free))
+            return NULL;
+    }
+    return method_noisy_dgram;
+}
+
+void bio_f_noisy_dgram_filter_free(void)
+{
+    BIO_meth_free(method_noisy_dgram);
+}

--- a/test/helpers/noisydgrambio.c
+++ b/test/helpers/noisydgrambio.c
@@ -19,18 +19,6 @@ struct noisy_dgram_st {
     uint64_t delayed_dgram;
 };
 
-static int noisy_dgram_read(BIO *bio, char *out, int outl)
-{
-    /* We don't support this - not needed anyway */
-    return -1;
-}
-
-static int noisy_dgram_write(BIO *bio, const char *in, int inl)
-{
-    /* We don't support this - not needed anyway */
-    return -1;
-}
-
 static long noisy_dgram_ctrl(BIO *bio, int cmd, long num, void *ptr)
 {
     long ret;
@@ -48,18 +36,6 @@ static long noisy_dgram_ctrl(BIO *bio, int cmd, long num, void *ptr)
         break;
     }
     return ret;
-}
-
-static int noisy_dgram_gets(BIO *bio, char *buf, int size)
-{
-    /* We don't support this - not needed anyway */
-    return -1;
-}
-
-static int noisy_dgram_puts(BIO *bio, const char *str)
-{
-    /* We don't support this - not needed anyway */
-    return -1;
 }
 
 static int noisy_dgram_sendmmsg(BIO *bio, BIO_MSG *msg, size_t stride,
@@ -298,10 +274,6 @@ const BIO_METHOD *bio_f_noisy_dgram_filter(void)
         method_noisy_dgram = BIO_meth_new(BIO_TYPE_NOISY_DGRAM_FILTER,
                                           "Nosiy datagram filter");
         if (method_noisy_dgram == NULL
-            || !BIO_meth_set_write(method_noisy_dgram, noisy_dgram_write)
-            || !BIO_meth_set_read(method_noisy_dgram, noisy_dgram_read)
-            || !BIO_meth_set_puts(method_noisy_dgram, noisy_dgram_puts)
-            || !BIO_meth_set_gets(method_noisy_dgram, noisy_dgram_gets)
             || !BIO_meth_set_ctrl(method_noisy_dgram, noisy_dgram_ctrl)
             || !BIO_meth_set_sendmmsg(method_noisy_dgram, noisy_dgram_sendmmsg)
             || !BIO_meth_set_recvmmsg(method_noisy_dgram, noisy_dgram_recvmmsg)

--- a/test/helpers/noisydgrambio.c
+++ b/test/helpers/noisydgrambio.c
@@ -9,6 +9,11 @@
 
 #include <openssl/bio.h>
 #include "quictestlib.h"
+#include "../testutil.h"
+
+struct noisy_dgram_st {
+    size_t this_dgram;
+};
 
 static int noisy_dgram_read(BIO *bio, char *out, int outl)
 {
@@ -69,23 +74,136 @@ static int noisy_dgram_sendmmsg(BIO *bio, BIO_MSG *msg, size_t stride,
     return BIO_sendmmsg(next, msg, stride, num_msg, flags, msgs_processed);
 }
 
+static int should_drop(BIO *bio)
+{
+    struct noisy_dgram_st *data = BIO_get_data(bio);
+
+    if (data == NULL)
+        return 0;
+
+    /*
+     * Drop datagram 1 for now.
+     * TODO(QUIC): Provide more control over this behaviour.
+     */
+    if (data->this_dgram == 1)
+        return 1;
+
+    return 0;
+}
+
+/* There isn't a public function to do BIO_ADDR_copy() so we create one */
+static int bio_addr_copy(BIO_ADDR *dst, BIO_ADDR *src)
+{
+    size_t len;
+    void *data = NULL;
+    int res = 0;
+    int family;
+
+    if (src == NULL || dst == NULL)
+        return 0;
+
+    family = BIO_ADDR_family(src);
+    if (family == AF_UNSPEC) {
+        BIO_ADDR_clear(dst);
+        return 1;
+    }
+
+    if (!BIO_ADDR_rawaddress(src, NULL, &len))
+        return 0;
+
+    if (len > 0) {
+        data = OPENSSL_malloc(len);
+        if (!TEST_ptr(data))
+            return 0;
+    }
+
+    if (!BIO_ADDR_rawaddress(src, data, &len))
+        goto err;
+
+    if (!BIO_ADDR_rawmake(src, family, data, len, BIO_ADDR_rawport(src)))
+        goto err;
+
+    res = 1;
+ err:
+    OPENSSL_free(data);
+    return res;
+}
+
 static int noisy_dgram_recvmmsg(BIO *bio, BIO_MSG *msg, size_t stride,
                                 size_t num_msg, uint64_t flags,
                                 size_t *msgs_processed)
 {
     BIO *next = BIO_next(bio);
+    size_t i, data_len = 0, drop_cnt = 0;
+    BIO_MSG *src, *dst;
+    struct noisy_dgram_st *data;
 
-    if (next == NULL)
+    if (!TEST_ptr(next))
+        return 0;
+
+    data = BIO_get_data(bio);
+    if (!TEST_ptr(data))
         return 0;
 
     /*
-     * We will introduce noise here. None implemented yet.
+     * For simplicity we assume that all elements in the msg array have the
+     * same data_len. They are not required to by the API, but it would be quite
+     * strange for that not to be the case - and our code that calls
+     * BIO_recvmmsg does do this (which is all that is important for this test
+     * code). We test the invariant here.
      */
-    return BIO_recvmmsg(next, msg, stride, num_msg, flags, msgs_processed);
+    for (i = 0; i < num_msg; i++) {
+        if (i == 0)
+            data_len = msg[i].data_len;
+        else if (!TEST_size_t_eq(msg[i].data_len, data_len))
+            return 0;
+    }
+
+    if (!BIO_recvmmsg(next, msg, stride, num_msg, flags, msgs_processed))
+        return 0;
+
+    /* Drop any messages */
+    for (i = 0, src = msg, dst = msg;
+         i < *msgs_processed;
+         i++, src++, data->this_dgram++) {
+        if (should_drop(bio)) {
+            drop_cnt++;
+            continue;
+        }
+
+        if (src != dst) {
+            /* Copy the src BIO_MSG to the dst BIO_MSG */
+            memcpy(dst->data, src->data, src->data_len);
+            dst->data_len = src->data_len;
+            dst->flags = src->flags;
+            if (src->local != NULL
+                    && !TEST_true(bio_addr_copy(dst->local, src->local)))
+                return 0;
+            if (!TEST_true(bio_addr_copy(dst->peer, src->peer)))
+                return 0;
+        }
+
+        dst++;
+    }
+
+    *msgs_processed -= drop_cnt;
+
+    if (*msgs_processed == 0) {
+        ERR_raise(ERR_LIB_BIO, BIO_R_NON_FATAL);
+        return 0;
+    }
+
+    return 1;
 }
 
 static int noisy_dgram_new(BIO *bio)
 {
+    struct noisy_dgram_st *data = OPENSSL_zalloc(sizeof(*data));
+
+    if (!TEST_ptr(data))
+        return 0;
+
+    BIO_set_data(bio, data);
     BIO_set_init(bio, 1);
 
     return 1;
@@ -93,6 +211,8 @@ static int noisy_dgram_new(BIO *bio)
 
 static int noisy_dgram_free(BIO *bio)
 {
+    OPENSSL_free(BIO_get_data(bio));
+    BIO_set_data(bio, NULL);
     BIO_set_init(bio, 0);
 
     return 1;

--- a/test/helpers/pktsplitbio.c
+++ b/test/helpers/pktsplitbio.c
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/bio.h>
+#include "quictestlib.h"
+#include "../testutil.h"
+
+static int pkt_split_dgram_read(BIO *bio, char *out, int outl)
+{
+    /* We don't support this - not needed anyway */
+    return -1;
+}
+
+static int pkt_split_dgram_write(BIO *bio, const char *in, int inl)
+{
+    /* We don't support this - not needed anyway */
+    return -1;
+}
+
+static long pkt_split_dgram_ctrl(BIO *bio, int cmd, long num, void *ptr)
+{
+    long ret;
+    BIO *next = BIO_next(bio);
+
+    if (next == NULL)
+        return 0;
+
+    switch (cmd) {
+    case BIO_CTRL_DUP:
+        ret = 0L;
+        break;
+    default:
+        ret = BIO_ctrl(next, cmd, num, ptr);
+        break;
+    }
+    return ret;
+}
+
+static int pkt_split_dgram_gets(BIO *bio, char *buf, int size)
+{
+    /* We don't support this - not needed anyway */
+    return -1;
+}
+
+static int pkt_split_dgram_puts(BIO *bio, const char *str)
+{
+    /* We don't support this - not needed anyway */
+    return -1;
+}
+
+static int pkt_split_dgram_sendmmsg(BIO *bio, BIO_MSG *msg, size_t stride,
+                                    size_t num_msg, uint64_t flags,
+                                    size_t *msgs_processed)
+{
+    BIO *next = BIO_next(bio);
+
+    if (next == NULL)
+        return 0;
+
+    /*
+     * We only introduce noise when receiving messages. We just pass this on
+     * to the underlying BIO.
+     */
+    return BIO_sendmmsg(next, msg, stride, num_msg, flags, msgs_processed);
+}
+
+static int pkt_split_dgram_recvmmsg(BIO *bio, BIO_MSG *msg, size_t stride,
+                                    size_t num_msg, uint64_t flags,
+                                    size_t *msgs_processed)
+{
+    BIO *next = BIO_next(bio);
+    size_t i, j, data_len = 0, msg_cnt = 0;
+    BIO_MSG *thismsg;
+
+    if (!TEST_ptr(next))
+        return 0;
+
+    /*
+     * For simplicity we assume that all elements in the msg array have the
+     * same data_len. They are not required to by the API, but it would be quite
+     * strange for that not to be the case - and our code that calls
+     * BIO_recvmmsg does do this (which is all that is important for this test
+     * code). We test the invariant here.
+     */
+    for (i = 0; i < num_msg; i++) {
+        if (i == 0)
+            data_len = msg[i].data_len;
+        else if (!TEST_size_t_eq(msg[i].data_len, data_len))
+            return 0;
+    }
+
+    if (!BIO_recvmmsg(next, msg, stride, num_msg, flags, msgs_processed))
+        return 0;
+
+    msg_cnt = *msgs_processed;
+    if (msg_cnt == num_msg)
+        return 1; /* We've used all our slots and can't split any more */
+    assert(msg_cnt < num_msg);
+
+    for (i = 0, thismsg = msg; i < msg_cnt; i++, thismsg++) {
+        QUIC_PKT_HDR hdr;
+        PACKET pkt;
+        size_t remain;
+
+        if (!PACKET_buf_init(&pkt, thismsg->data, thismsg->data_len))
+            return 0;
+
+        /* Decode the packet header */
+        /*
+         * TODO(QUIC SERVER): We need to query the short connection id len
+         * here, e.g. via some API SSL_get_short_conn_id_len()
+         */
+        if (ossl_quic_wire_decode_pkt_hdr(&pkt, 0, 0, 0, &hdr, NULL) != 1)
+            return 0;
+        remain = PACKET_remaining(&pkt);
+        if (remain > 0) {
+            for (j = msg_cnt; j > i; j--) {
+                if (!bio_msg_copy(&msg[j], &msg[j - 1]))
+                    return 0;
+            }
+            thismsg->data_len -= remain;
+            msg[i + 1].data_len = remain;
+            memmove(msg[i + 1].data,
+                    (unsigned char *)msg[i + 1].data + thismsg->data_len,
+                    remain);
+            msg_cnt++;
+        }
+    }
+
+    *msgs_processed = msg_cnt;
+    return 1;
+}
+
+/* Choose a sufficiently large type likely to be unused for this custom BIO */
+#define BIO_TYPE_PKT_SPLIT_DGRAM_FILTER  (0x81 | BIO_TYPE_FILTER)
+
+static BIO_METHOD *method_pkt_split_dgram = NULL;
+
+/* Note: Not thread safe! */
+const BIO_METHOD *bio_f_pkt_split_dgram_filter(void)
+{
+    if (method_pkt_split_dgram == NULL) {
+        method_pkt_split_dgram = BIO_meth_new(BIO_TYPE_PKT_SPLIT_DGRAM_FILTER,
+                                              "Packet splitting datagram filter");
+        if (method_pkt_split_dgram == NULL
+            || !BIO_meth_set_write(method_pkt_split_dgram, pkt_split_dgram_write)
+            || !BIO_meth_set_read(method_pkt_split_dgram, pkt_split_dgram_read)
+            || !BIO_meth_set_puts(method_pkt_split_dgram, pkt_split_dgram_puts)
+            || !BIO_meth_set_gets(method_pkt_split_dgram, pkt_split_dgram_gets)
+            || !BIO_meth_set_ctrl(method_pkt_split_dgram, pkt_split_dgram_ctrl)
+            || !BIO_meth_set_sendmmsg(method_pkt_split_dgram,
+                                      pkt_split_dgram_sendmmsg)
+            || !BIO_meth_set_recvmmsg(method_pkt_split_dgram,
+                                      pkt_split_dgram_recvmmsg))
+            return NULL;
+    }
+    return method_pkt_split_dgram;
+}
+
+void bio_f_pkt_split_dgram_filter_free(void)
+{
+    BIO_meth_free(method_pkt_split_dgram);
+}

--- a/test/helpers/pktsplitbio.c
+++ b/test/helpers/pktsplitbio.c
@@ -11,18 +11,6 @@
 #include "quictestlib.h"
 #include "../testutil.h"
 
-static int pkt_split_dgram_read(BIO *bio, char *out, int outl)
-{
-    /* We don't support this - not needed anyway */
-    return -1;
-}
-
-static int pkt_split_dgram_write(BIO *bio, const char *in, int inl)
-{
-    /* We don't support this - not needed anyway */
-    return -1;
-}
-
 static long pkt_split_dgram_ctrl(BIO *bio, int cmd, long num, void *ptr)
 {
     long ret;
@@ -40,18 +28,6 @@ static long pkt_split_dgram_ctrl(BIO *bio, int cmd, long num, void *ptr)
         break;
     }
     return ret;
-}
-
-static int pkt_split_dgram_gets(BIO *bio, char *buf, int size)
-{
-    /* We don't support this - not needed anyway */
-    return -1;
-}
-
-static int pkt_split_dgram_puts(BIO *bio, const char *str)
-{
-    /* We don't support this - not needed anyway */
-    return -1;
 }
 
 static int pkt_split_dgram_sendmmsg(BIO *bio, BIO_MSG *msg, size_t stride,
@@ -149,10 +125,6 @@ const BIO_METHOD *bio_f_pkt_split_dgram_filter(void)
         method_pkt_split_dgram = BIO_meth_new(BIO_TYPE_PKT_SPLIT_DGRAM_FILTER,
                                               "Packet splitting datagram filter");
         if (method_pkt_split_dgram == NULL
-            || !BIO_meth_set_write(method_pkt_split_dgram, pkt_split_dgram_write)
-            || !BIO_meth_set_read(method_pkt_split_dgram, pkt_split_dgram_read)
-            || !BIO_meth_set_puts(method_pkt_split_dgram, pkt_split_dgram_puts)
-            || !BIO_meth_set_gets(method_pkt_split_dgram, pkt_split_dgram_gets)
             || !BIO_meth_set_ctrl(method_pkt_split_dgram, pkt_split_dgram_ctrl)
             || !BIO_meth_set_sendmmsg(method_pkt_split_dgram,
                                       pkt_split_dgram_sendmmsg)

--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -1044,3 +1044,64 @@ int qtest_fault_resize_datagram(QTEST_FAULT *fault, size_t newlen)
 
     return 1;
 }
+
+/* There isn't a public function to do BIO_ADDR_copy() so we create one */
+int bio_addr_copy(BIO_ADDR *dst, BIO_ADDR *src)
+{
+    size_t len;
+    void *data = NULL;
+    int res = 0;
+    int family;
+
+    if (src == NULL || dst == NULL)
+        return 0;
+
+    family = BIO_ADDR_family(src);
+    if (family == AF_UNSPEC) {
+        BIO_ADDR_clear(dst);
+        return 1;
+    }
+
+    if (!BIO_ADDR_rawaddress(src, NULL, &len))
+        return 0;
+
+    if (len > 0) {
+        data = OPENSSL_malloc(len);
+        if (!TEST_ptr(data))
+            return 0;
+    }
+
+    if (!BIO_ADDR_rawaddress(src, data, &len))
+        goto err;
+
+    if (!BIO_ADDR_rawmake(src, family, data, len, BIO_ADDR_rawport(src)))
+        goto err;
+
+    res = 1;
+ err:
+    OPENSSL_free(data);
+    return res;
+}
+
+int bio_msg_copy(BIO_MSG *dst, BIO_MSG *src)
+{
+    /*
+     * Note it is assumed that the originally allocated data sizes for dst and
+     * src are the same
+     */
+    memcpy(dst->data, src->data, src->data_len);
+    dst->data_len = src->data_len;
+    dst->flags = src->flags;
+    if (dst->local != NULL) {
+        if (src->local != NULL) {
+            if (!TEST_true(bio_addr_copy(dst->local, src->local)))
+                return 0;
+        } else {
+            BIO_ADDR_clear(dst->local);
+        }
+    }
+    if (!TEST_true(bio_addr_copy(dst->peer, src->peer)))
+        return 0;
+
+    return 1;
+}

--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -141,6 +141,14 @@ int qtest_create_quic_objects(OSSL_LIB_CTX *libctx, SSL_CTX *clientctx,
             goto err;
     }
 
+    if ((flags & QTEST_FLAG_PACKET_SPLIT) != 0) {
+        BIO *pktsplitbio = BIO_new(bio_f_pkt_split_dgram_filter());
+
+        if (!TEST_ptr(pktsplitbio))
+            goto err;
+        cbio = BIO_push(pktsplitbio, cbio);
+    }
+
     if ((flags & QTEST_FLAG_NOISE) != 0) {
         BIO *noisebio = BIO_new(bio_f_noisy_dgram_filter());
 

--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -140,6 +140,14 @@ int qtest_create_quic_objects(OSSL_LIB_CTX *libctx, SSL_CTX *clientctx,
             goto err;
     }
 
+    if ((flags & QTEST_FLAG_NOISE) != 0) {
+        BIO *noisebio = BIO_new(bio_f_noisy_dgram_filter());
+
+        if (!TEST_ptr(noisebio))
+            goto err;
+        cbio = BIO_push(noisebio, cbio);
+    }
+
     SSL_set_bio(*cssl, cbio, cbio);
 
     if (!TEST_true(SSL_set_blocking_mode(*cssl,

--- a/test/helpers/quictestlib.h
+++ b/test/helpers/quictestlib.h
@@ -27,9 +27,11 @@ typedef struct qtest_fault_encrypted_extensions {
 /* Flags for use with qtest_create_quic_objects() */
 
 /* Indicates whether we are using blocking mode or not */
-#define QTEST_FLAG_BLOCK        1
+#define QTEST_FLAG_BLOCK        (1 << 0)
 /* Use fake time rather than real time */
-#define QTEST_FLAG_FAKE_TIME    2
+#define QTEST_FLAG_FAKE_TIME    (1 << 1)
+/* Introduce noise in the BIO */
+#define QTEST_FLAG_NOISE        (1 << 2)
 
 /*
  * Given an SSL_CTX for the client and filenames for the server certificate and
@@ -230,3 +232,9 @@ int qtest_fault_set_datagram_listener(QTEST_FAULT *fault,
  * exceeds the over allocation.
  */
 int qtest_fault_resize_datagram(QTEST_FAULT *fault, size_t newlen);
+
+/* BIO filter for simulating a noisy UDP socket */
+const BIO_METHOD *bio_f_noisy_dgram_filter(void);
+
+/* Free the BIO filter method object */
+void bio_f_noisy_dgram_filter_free(void);

--- a/test/helpers/quictestlib.h
+++ b/test/helpers/quictestlib.h
@@ -34,7 +34,8 @@ typedef struct qtest_fault_encrypted_extensions {
 #define QTEST_FLAG_NOISE        (1 << 2)
 /* Split datagrams such that each datagram contains one packet */
 #define QTEST_FLAG_PACKET_SPLIT (1 << 3)
-
+/* Turn on client side tracing */
+#define QTEST_FLAG_CLIENT_TRACE (1 << 4)
 /*
  * Given an SSL_CTX for the client and filenames for the server certificate and
  * keyfile, create a server and client instances as well as a fault injector
@@ -43,7 +44,7 @@ typedef struct qtest_fault_encrypted_extensions {
 int qtest_create_quic_objects(OSSL_LIB_CTX *libctx, SSL_CTX *clientctx,
                               SSL_CTX *serverctx, char *certfile, char *keyfile,
                               int flags, QUIC_TSERVER **qtserv, SSL **cssl,
-                              QTEST_FAULT **fault);
+                              QTEST_FAULT **fault, BIO **tracebio);
 
 /* Where QTEST_FLAG_FAKE_TIME is used, add millis to the current time */
 void qtest_add_time(uint64_t millis);

--- a/test/helpers/quictestlib.h
+++ b/test/helpers/quictestlib.h
@@ -68,6 +68,12 @@ int qtest_supports_blocking(void);
 int qtest_create_quic_connection(QUIC_TSERVER *qtserv, SSL *clientssl);
 
 /*
+ * Check if both client and server have no data to read and are waiting on a
+ * timeout. If so, wait until the timeout has expired.
+ */
+int qtest_wait_for_timeout(SSL *s, QUIC_TSERVER *qtserv);
+
+/*
  * Same as qtest_create_quic_connection but will stop (successfully) if the
  * clientssl indicates SSL_ERROR_WANT_XXX as specified by |wanterr|
  */

--- a/test/helpers/quictestlib.h
+++ b/test/helpers/quictestlib.h
@@ -233,8 +233,23 @@ int qtest_fault_set_datagram_listener(QTEST_FAULT *fault,
  */
 int qtest_fault_resize_datagram(QTEST_FAULT *fault, size_t newlen);
 
+/* Copy a BIO_ADDR */
+int bio_addr_copy(BIO_ADDR *dst, BIO_ADDR *src);
+
+/* Copy a BIO_MSG */
+int bio_msg_copy(BIO_MSG *dst, BIO_MSG *src);
+
 /* BIO filter for simulating a noisy UDP socket */
 const BIO_METHOD *bio_f_noisy_dgram_filter(void);
 
 /* Free the BIO filter method object */
 void bio_f_noisy_dgram_filter_free(void);
+
+/*
+ * BIO filter for splitting QUIC datagrams containing multiple packets into
+ * individual datagrams.
+ */
+const BIO_METHOD *bio_f_pkt_split_dgram_filter(void);
+
+/* Free the BIO filter method object */
+void bio_f_pkt_split_dgram_filter_free(void);

--- a/test/helpers/quictestlib.h
+++ b/test/helpers/quictestlib.h
@@ -32,6 +32,8 @@ typedef struct qtest_fault_encrypted_extensions {
 #define QTEST_FLAG_FAKE_TIME    (1 << 1)
 /* Introduce noise in the BIO */
 #define QTEST_FLAG_NOISE        (1 << 2)
+/* Split datagrams such that each datagram contains one packet */
+#define QTEST_FLAG_PACKET_SPLIT (1 << 3)
 
 /*
  * Given an SSL_CTX for the client and filenames for the server certificate and

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -746,10 +746,8 @@ static int helper_init(struct helper *h, int free_order, int blocking,
         BIO_set_data(h->s_qtf_wbio, h->qtf);
     }
 
-    if (!need_injector)
-        h->s_net_bio_own = NULL;
-
-    h->s_qtf_wbio_own   = NULL;
+    h->s_net_bio_own = NULL;
+    h->s_qtf_wbio_own = NULL;
 
     h->c_fd = BIO_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 0);
     if (!TEST_int_ge(h->c_fd, 0))

--- a/test/quic_newcid_test.c
+++ b/test/quic_newcid_test.c
@@ -68,7 +68,7 @@ static int test_ncid_frame(int fail)
         goto err;
 
     if (!TEST_true(qtest_create_quic_objects(NULL, cctx, NULL, cert, privkey, 0,
-                                             &qtserv, &cssl, &fault)))
+                                             &qtserv, &cssl, &fault, NULL)))
         goto err;
 
     if (!TEST_true(qtest_create_quic_connection(qtserv, cssl)))

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -1250,7 +1250,7 @@ static int test_alpn(int idx)
     return testresult;
 }
 
-#define MAX_LOOPS   40
+#define MAX_LOOPS   2000
 
 /*
  * Keep retrying SSL_read_ex until it succeeds or we give up. Accept a stream

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -69,7 +69,7 @@ static int test_quic_write_read(int idx)
                                                             ? QTEST_FLAG_BLOCK
                                                             : 0,
                                                         &qtserv, &clientquic,
-                                                        NULL))
+                                                        NULL, NULL))
                 || !TEST_true(SSL_set_tlsext_host_name(clientquic, "localhost")))
             goto end;
 
@@ -220,7 +220,7 @@ static int test_fin_only_blocking(void)
                                                     cert, privkey,
                                                     QTEST_FLAG_BLOCK,
                                                     &qtserv, &clientquic,
-                                                    NULL))
+                                                    NULL, NULL))
             || !TEST_true(SSL_set_tlsext_host_name(clientquic, "localhost")))
         goto end;
 
@@ -380,7 +380,7 @@ static int test_version(void)
     if (!TEST_ptr(cctx)
             || !TEST_true(qtest_create_quic_objects(libctx, cctx, NULL, cert,
                                                     privkey, 0, &qtserv,
-                                                    &clientquic, NULL))
+                                                    &clientquic, NULL, NULL))
             || !TEST_true(qtest_create_quic_connection(qtserv, clientquic)))
         goto err;
 
@@ -502,7 +502,7 @@ static int test_ssl_trace(void)
                                                     privkey,
                                                     QTEST_FLAG_FAKE_TIME,
                                                     &qtserv,
-                                                    &clientquic, NULL)))
+                                                    &clientquic, NULL, NULL)))
         goto err;
 
     SSL_set_msg_callback(clientquic, SSL_trace);
@@ -829,7 +829,8 @@ static int test_bio_ssl(void)
         goto err;
 
     if (!TEST_true(qtest_create_quic_objects(libctx, NULL, NULL, cert, privkey,
-                                             0, &qtserv, &clientquic, NULL)))
+                                             0, &qtserv, &clientquic, NULL,
+                                             NULL)))
         goto err;
 
     msglen = strlen(msg);
@@ -946,7 +947,7 @@ static int test_back_pressure(void)
     if (!TEST_ptr(cctx)
             || !TEST_true(qtest_create_quic_objects(libctx, cctx, NULL, cert,
                                                     privkey, 0, &qtserv,
-                                                    &clientquic, NULL))
+                                                    &clientquic, NULL, NULL))
             || !TEST_true(qtest_create_quic_connection(qtserv, clientquic)))
         goto err;
 
@@ -1024,7 +1025,7 @@ static int test_multiple_dgrams(void)
             || !TEST_ptr(buf)
             || !TEST_true(qtest_create_quic_objects(libctx, cctx, NULL, cert,
                                                     privkey, 0, &qtserv,
-                                                    &clientquic, NULL))
+                                                    &clientquic, NULL, NULL))
             || !TEST_true(qtest_create_quic_connection(qtserv, clientquic)))
         goto err;
 
@@ -1088,7 +1089,8 @@ static int test_non_io_retry(int idx)
 
     flags = (idx >= 1) ? QTEST_FLAG_BLOCK : 0;
     if (!TEST_true(qtest_create_quic_objects(libctx, cctx, NULL, cert, privkey,
-                                             flags, &qtserv, &clientquic, NULL))
+                                             flags, &qtserv, &clientquic, NULL,
+                                             NULL))
             || !TEST_true(qtest_create_quic_connection_ex(qtserv, clientquic,
                             SSL_ERROR_WANT_RETRY_VERIFY))
             || !TEST_int_eq(SSL_want(clientquic), SSL_RETRY_VERIFY)
@@ -1156,7 +1158,7 @@ static int test_quic_psk(void)
                /* No cert or private key for the server, i.e. PSK only */
             || !TEST_true(qtest_create_quic_objects(libctx, cctx, NULL, NULL,
                                                     NULL, 0, &qtserv,
-                                                    &clientquic, NULL)))
+                                                    &clientquic, NULL, NULL)))
         goto end;
 
     SSL_set_psk_use_session_callback(clientquic, use_session_cb);
@@ -1215,7 +1217,7 @@ static int test_alpn(int idx)
                                                     privkey,
                                                     QTEST_FLAG_FAKE_TIME,
                                                     &qtserv,
-                                                    &clientquic, NULL)))
+                                                    &clientquic, NULL, NULL)))
         goto err;
 
     if (idx == 0) {
@@ -1328,7 +1330,7 @@ static int test_noisy_dgram(int idx)
             || !TEST_true(qtest_create_quic_objects(libctx, cctx, NULL, cert,
                                                     privkey, flags,
                                                     &qtserv,
-                                                    &clientquic, NULL)))
+                                                    &clientquic, NULL, NULL)))
         goto err;
 
     if (!TEST_true(qtest_create_quic_connection(qtserv, clientquic)))

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -1276,7 +1276,7 @@ static int unreliable_client_read(SSL *clientquic, SSL **stream, void *buf,
                 return 0;
         }
         ossl_quic_tserver_tick(qtserv);
-        OSSL_sleep(10);
+        qtest_add_time(1);
     }
 
     return 0;
@@ -1295,7 +1295,7 @@ static int unreliable_server_read(QUIC_TSERVER *qtserv, uint64_t sid,
             return 1;
         ossl_quic_tserver_tick(qtserv);
         SSL_handle_events(clientquic);
-        OSSL_sleep(10);
+        qtest_add_time(1);
     }
 
     return 0;
@@ -1315,7 +1315,8 @@ static int test_noisy_dgram(void)
     if (!TEST_ptr(cctx)
             || !TEST_true(qtest_create_quic_objects(libctx, cctx, NULL, cert,
                                                     privkey,
-                                                    QTEST_FLAG_NOISE,
+                                                    QTEST_FLAG_NOISE
+                                                    | QTEST_FLAG_FAKE_TIME,
                                                     &qtserv,
                                                     &clientquic, NULL)))
         goto err;
@@ -1334,6 +1335,7 @@ static int test_noisy_dgram(void)
         if (!TEST_true(ossl_quic_tserver_stream_new(qtserv, 0, &sid)))
             goto err;
         ossl_quic_tserver_tick(qtserv);
+        qtest_add_time(1);
 
         /*
         * Send data from the server to the client. Some datagrams may get lost,
@@ -1347,6 +1349,7 @@ static int test_noisy_dgram(void)
                     || !TEST_size_t_eq(msglen, written))
                 goto err;
             ossl_quic_tserver_tick(qtserv);
+            qtest_add_time(1);
 
             /*
             * Since the underlying BIO is now noisy we may get failures that
@@ -1368,6 +1371,8 @@ static int test_noisy_dgram(void)
                 goto err;
 
             ossl_quic_tserver_tick(qtserv);
+            qtest_add_time(1);
+
             /*
             * Since the underlying BIO is now noisy we may get failures that
             * need to be retried - so we use unreliable_server_read() to handle

--- a/test/quicfaultstest.c
+++ b/test/quicfaultstest.c
@@ -35,7 +35,7 @@ static int test_basic(void)
         goto err;
 
     if (!TEST_true(qtest_create_quic_objects(NULL, cctx, NULL, cert, privkey, 0,
-                                             &qtserv, &cssl, NULL)))
+                                             &qtserv, &cssl, NULL, NULL)))
         goto err;
 
     if (!TEST_true(qtest_create_quic_connection(qtserv, cssl)))
@@ -105,7 +105,7 @@ static int test_unknown_frame(void)
         goto err;
 
     if (!TEST_true(qtest_create_quic_objects(NULL, cctx, NULL, cert, privkey, 0,
-                                             &qtserv, &cssl, &fault)))
+                                             &qtserv, &cssl, &fault, NULL)))
         goto err;
 
     if (!TEST_true(qtest_create_quic_connection(qtserv, cssl)))
@@ -187,7 +187,7 @@ static int test_drop_extensions(int idx)
         goto err;
 
     if (!TEST_true(qtest_create_quic_objects(NULL, cctx, NULL, cert, privkey, 0,
-                                             &qtserv, &cssl, &fault)))
+                                             &qtserv, &cssl, &fault, NULL)))
         goto err;
 
     if (idx == 0) {
@@ -275,7 +275,7 @@ static int test_corrupted_data(int idx)
 
     if (!TEST_true(qtest_create_quic_objects(NULL, cctx, NULL, cert, privkey,
                                              QTEST_FLAG_FAKE_TIME, &qtserv,
-                                             &cssl, &fault)))
+                                             &cssl, &fault, NULL)))
         goto err;
 
     if (idx == 0) {


### PR DESCRIPTION
We introduce a BIO filter that simulates network noise by randomly dropping/delaying/reordering datagrams and test that a QUIC connection can be established and data exchanged reliably.

We use `test_random()` to generate the randomness so any test failures can be reliably reproduced.


