### PR TITLE
Performance improvement in multi-thread scenario when using OpenSSL 1.1.1

### DIFF
--- a/crypto/engine/eng_local.h
+++ b/crypto/engine/eng_local.h
@@ -161,7 +161,7 @@ struct engine_st {
      * (de)allocation of this structure. Hence, running_ref <= struct_ref at
      * all times.
      */
-    int funct_ref;
+    CRYPTO_REF_COUNT funct_ref;
     /* A place to store per-ENGINE data */
     CRYPTO_EX_DATA ex_data;
     /* Used to maintain the linked-list of engines. */

--- a/crypto/engine/eng_table.c
+++ b/crypto/engine/eng_table.c
@@ -208,7 +208,6 @@ ENGINE *engine_table_select_tmp(ENGINE_TABLE **table, int nid, const char *f,
         return NULL;
     }
     ERR_set_mark();
-    CRYPTO_THREAD_write_lock(global_engine_lock);
     /*
      * Check again inside the lock otherwise we could race against cleanup
      * operations. But don't worry about a fprintf(stderr).
@@ -279,7 +278,6 @@ ENGINE *engine_table_select_tmp(ENGINE_TABLE **table, int nid, const char *f,
         fprintf(stderr, "engine_table_dbg: %s:%d, nid=%d, caching "
                 "'no matching ENGINE'\n", f, l, nid);
 #endif
-    CRYPTO_THREAD_unlock(global_engine_lock);
     /*
      * Whatever happened, any failed init()s are not failures in this
      * context, so clear our error state.


### PR DESCRIPTION
Remove the lock from engine_table_select. This improves performance in multi-threaded scenarios, especially for HAProxy.

