### PR TITLE
no-engine: fix signing with legacy app method based keys

### DIFF
--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -247,10 +247,11 @@ static EVP_PKEY_CTX *int_ctx_new(OSSL_LIB_CTX *libctx,
      */
     if (e != NULL)
         pmeth = ENGINE_get_pkey_meth(e, id);
-    else if (pkey != NULL && pkey->foreign)
+    else
+# endif /* OPENSSL_NO_ENGINE */
+    if (pkey != NULL && pkey->foreign)
         pmeth = EVP_PKEY_meth_find(id);
     else
-# endif
         app_pmeth = pmeth = evp_pkey_meth_find_added_by_application(id);
 
     /* END legacy */


### PR DESCRIPTION
Signing with an app method based key (i.e. an `EVP_PKEY` which wraps an `RSA` key with an application defined `RSA_METHOD`) used to work in 1.1.1. That feature was broken in commit 60488d2434, but later on fixed by @t8m in commit b247113c05 (see #14859).

This commit corrects a  minor flaw of the fix, which affects only `no-engine` builds: the special treatment for foreign keys is guarded by an `OPENSSL_NO_ENGINE` check.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated