### PR TITLE
Implement the BIO_ADDR_copy() public API function

### DIFF
--- a/crypto/bio/bio_addr.c
+++ b/crypto/bio/bio_addr.c
@@ -65,14 +65,29 @@ void BIO_ADDR_free(BIO_ADDR *ap)
     OPENSSL_free(ap);
 }
 
+int BIO_ADDR_copy(BIO_ADDR *dst, const BIO_ADDR *src)
+{
+    if (dst == NULL || src == NULL)
+        return 0;
+
+    if (src->sa.sa_family == AF_UNSPEC) {
+        BIO_ADDR_clear(dst);
+        return 1;
+    }
+
+    return BIO_ADDR_make(dst, &src->sa);
+}
+
 BIO_ADDR *BIO_ADDR_dup(const BIO_ADDR *ap)
 {
     BIO_ADDR *ret = NULL;
 
     if (ap != NULL) {
         ret = BIO_ADDR_new();
-        if (ret != NULL)
-            BIO_ADDR_make(ret, &ap->sa);
+        if (ret != NULL && !BIO_ADDR_copy(ret, ap)) {
+            BIO_ADDR_free(ret);
+            ret = NULL;
+        }
     }
     return ret;
 }

--- a/doc/man3/BIO_ADDR.pod
+++ b/doc/man3/BIO_ADDR.pod
@@ -2,8 +2,8 @@
 
 =head1 NAME
 
-BIO_ADDR, BIO_ADDR_new, BIO_ADDR_dup, BIO_ADDR_clear, BIO_ADDR_free,
-BIO_ADDR_rawmake,
+BIO_ADDR, BIO_ADDR_new, BIO_ADDR_copy, BIO_ADDR_dup, BIO_ADDR_clear,
+BIO_ADDR_free, BIO_ADDR_rawmake,
 BIO_ADDR_family, BIO_ADDR_rawaddress, BIO_ADDR_rawport,
 BIO_ADDR_hostname_string, BIO_ADDR_service_string,
 BIO_ADDR_path_string - BIO_ADDR routines
@@ -16,6 +16,7 @@ BIO_ADDR_path_string - BIO_ADDR routines
  typedef union bio_addr_st BIO_ADDR;
 
  BIO_ADDR *BIO_ADDR_new(void);
+ int BIO_ADDR_copy(BIO_ADDR *dst, const BIO_ADDR *src);
  BIO_ADDR *BIO_ADDR_dup(const BIO_ADDR *ap);
  void BIO_ADDR_free(BIO_ADDR *);
  void BIO_ADDR_clear(BIO_ADDR *ap);
@@ -38,6 +39,9 @@ available on the platform at hand.
 BIO_ADDR_new() creates a new unfilled B<BIO_ADDR>, to be used
 with routines that will fill it with information, such as
 BIO_accept_ex().
+
+BIO_ADDR_copy() copies the contents of B<src> into B<dst>. Neither B<src> or
+B<dst> can be NULL.
 
 BIO_ADDR_dup() creates a new B<BIO_ADDR>, with a copy of the
 address data in B<ap>.
@@ -112,6 +116,8 @@ BIO_ADDR_service_string() and BIO_ADDR_path_string() will
 return B<NULL> on error and leave an error indication on the
 OpenSSL error stack.
 
+BIO_ADDR_copy() returns 1 on success or 0 on error.
+
 All other functions described here return 0 or B<NULL> when the
 information they should return isn't available.
 
@@ -121,7 +127,7 @@ L<BIO_connect(3)>, L<BIO_s_connect(3)>
 
 =head1 HISTORY
 
-BIO_ADDR_dup() was added in OpenSSL 3.2.
+BIO_ADDR_copy() and BIO_ADDR_dup() were added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -806,6 +806,7 @@ int BIO_hex_string(BIO *out, int indent, int width, const void *data,
 
 # ifndef OPENSSL_NO_SOCK
 BIO_ADDR *BIO_ADDR_new(void);
+int BIO_ADDR_copy(BIO_ADDR *dst, const BIO_ADDR *src);
 BIO_ADDR *BIO_ADDR_dup(const BIO_ADDR *ap);
 int BIO_ADDR_rawmake(BIO_ADDR *ap, int family,
                      const void *where, size_t wherelen, unsigned short port);

--- a/test/bio_addr_test.c
+++ b/test/bio_addr_test.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/bio.h>
+#include "internal/e_os.h"
+#include "internal/sockets.h"
+#include "testutil.h"
+
+static int families[] = {
+    AF_INET,
+#if OPENSSL_USE_IPV6
+    AF_INET6,
+#endif
+#ifndef OPENSSL_NO_UNIX_SOCK
+    AF_UNIX
+#endif
+};
+
+static BIO_ADDR *make_dummy_addr(int family)
+{
+    BIO_ADDR *addr;
+    union {
+        struct sockaddr_in sin;
+#if OPENSSL_USE_IPV6
+        struct sockaddr_in6 sin6;
+#endif
+#ifndef OPENSSL_NO_UNIX_SOCK
+        struct sockaddr_un sun;
+#endif
+    } sa;
+    void *where;
+    size_t wherelen;
+
+    /* Fill with a dummy address */
+    switch(family) {
+    case AF_INET:
+        where = &(sa.sin.sin_addr);
+        wherelen = sizeof(sa.sin.sin_addr);
+        break;
+#if OPENSSL_USE_IPV6
+    case AF_INET6:
+        where = &(sa.sin6.sin6_addr);
+        wherelen = sizeof(sa.sin6.sin6_addr);
+        break;
+#endif
+#ifndef OPENSSL_NO_UNIX_SOCK
+    case AF_UNIX:
+        where = &(sa.sun.sun_path);
+        /* BIO_ADDR_rawmake needs an extra byte for a NUL-terminator*/
+        wherelen = sizeof(sa.sun.sun_path) - 1;
+        break;
+#endif
+    default:
+        TEST_error("Unsupported address family");
+        return 0;
+    }
+    /*
+     * Could be any data, but we make it printable because BIO_ADDR_rawmake
+     * expects the AF_UNIX address to be a string.
+     */
+    memset(where, 'a', wherelen);
+
+    addr = BIO_ADDR_new();
+    if (!TEST_ptr(addr))
+        return NULL;
+
+    if (!TEST_true(BIO_ADDR_rawmake(addr, family, where, wherelen, 1000))) {
+        BIO_ADDR_free(addr);
+        return NULL;
+    }
+
+    return addr;
+}
+
+static int bio_addr_is_eq(const BIO_ADDR *a, const BIO_ADDR *b)
+{
+    struct sockaddr_storage adata, bdata;
+    size_t alen, blen;
+
+    /* True even if a and b are NULL */
+    if (a == b)
+        return 1;
+
+    /* If one is NULL the other cannot be due to the test above */
+    if (a == NULL || b == NULL)
+        return 0;
+
+    if (BIO_ADDR_family(a) != BIO_ADDR_family(b))
+        return 0;
+
+    /* Works even with AF_UNIX/AF_UNSPEC which just returns 0 */
+    if (BIO_ADDR_rawport(a) != BIO_ADDR_rawport(b))
+        return 0;
+
+    if (!BIO_ADDR_rawaddress(a, NULL, &alen)
+            || alen > sizeof(adata)
+            || !BIO_ADDR_rawaddress(a, &adata, &alen))
+        return 0;
+
+    if (!BIO_ADDR_rawaddress(a, NULL, &blen)
+            || blen > sizeof(bdata)
+            || !BIO_ADDR_rawaddress(a, &bdata, &blen))
+        return 0;
+
+    if (alen != blen)
+        return 0;
+
+    if (alen == 0)
+        return 1;
+
+    return memcmp(&adata, &bdata, alen) == 0;
+}
+
+static int test_bio_addr_copy_dup(int idx)
+{
+    BIO_ADDR *src = NULL, *dst = NULL;
+    int ret = 0;
+    int docopy = idx & 1;
+
+    idx >>= 1;
+
+    src = make_dummy_addr(families[idx]);
+    if (!TEST_ptr(src))
+        return 0;
+
+    if (docopy) {
+        dst = BIO_ADDR_new();
+        if (!TEST_ptr(dst))
+            goto err;
+
+        if (!TEST_true(BIO_ADDR_copy(dst, src)))
+            goto err;
+    } else {
+        dst = BIO_ADDR_dup(src);
+        if (!TEST_ptr(dst))
+            goto err;
+    }
+
+    if (!TEST_true(bio_addr_is_eq(src, dst)))
+        goto err;
+
+    ret = 1;
+ err:
+    BIO_ADDR_free(src);
+    BIO_ADDR_free(dst);
+    return ret;
+}
+
+int setup_tests(void)
+{
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
+    ADD_ALL_TESTS(test_bio_addr_copy_dup, OSSL_NELEM(families) * 2);
+    return 1;
+}

--- a/test/build.info
+++ b/test/build.info
@@ -522,6 +522,12 @@ IF[{- !$disabled{tests} -}]
       INCLUDE[http_test]=../include ../apps/include
       DEPEND[http_test]=../libcrypto libtestutil.a
     ENDIF
+
+    PROGRAMS{noinst}=bio_addr_test
+
+    SOURCE[bio_addr_test]=bio_addr_test.c
+    INCLUDE[bio_addr_test]=../include ../apps/include
+    DEPEND[bio_addr_test]=../libcrypto libtestutil.a
   ENDIF
 
   SOURCE[dtlstest]=dtlstest.c helpers/ssltestlib.c

--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -1086,44 +1086,6 @@ int qtest_fault_resize_datagram(QTEST_FAULT *fault, size_t newlen)
     return 1;
 }
 
-/* There isn't a public function to do BIO_ADDR_copy() so we create one */
-int bio_addr_copy(BIO_ADDR *dst, BIO_ADDR *src)
-{
-    size_t len;
-    void *data = NULL;
-    int res = 0;
-    int family;
-
-    if (src == NULL || dst == NULL)
-        return 0;
-
-    family = BIO_ADDR_family(src);
-    if (family == AF_UNSPEC) {
-        BIO_ADDR_clear(dst);
-        return 1;
-    }
-
-    if (!BIO_ADDR_rawaddress(src, NULL, &len))
-        return 0;
-
-    if (len > 0) {
-        data = OPENSSL_malloc(len);
-        if (!TEST_ptr(data))
-            return 0;
-    }
-
-    if (!BIO_ADDR_rawaddress(src, data, &len))
-        goto err;
-
-    if (!BIO_ADDR_rawmake(src, family, data, len, BIO_ADDR_rawport(src)))
-        goto err;
-
-    res = 1;
- err:
-    OPENSSL_free(data);
-    return res;
-}
-
 int bio_msg_copy(BIO_MSG *dst, BIO_MSG *src)
 {
     /*
@@ -1135,13 +1097,13 @@ int bio_msg_copy(BIO_MSG *dst, BIO_MSG *src)
     dst->flags = src->flags;
     if (dst->local != NULL) {
         if (src->local != NULL) {
-            if (!TEST_true(bio_addr_copy(dst->local, src->local)))
+            if (!TEST_true(BIO_ADDR_copy(dst->local, src->local)))
                 return 0;
         } else {
             BIO_ADDR_clear(dst->local);
         }
     }
-    if (!TEST_true(bio_addr_copy(dst->peer, src->peer)))
+    if (!TEST_true(BIO_ADDR_copy(dst->peer, src->peer)))
         return 0;
 
     return 1;

--- a/test/helpers/quictestlib.h
+++ b/test/helpers/quictestlib.h
@@ -242,9 +242,6 @@ int qtest_fault_set_datagram_listener(QTEST_FAULT *fault,
  */
 int qtest_fault_resize_datagram(QTEST_FAULT *fault, size_t newlen);
 
-/* Copy a BIO_ADDR */
-int bio_addr_copy(BIO_ADDR *dst, BIO_ADDR *src);
-
 /* Copy a BIO_MSG */
 int bio_msg_copy(BIO_MSG *dst, BIO_MSG *src);
 

--- a/test/recipes/61-test_bio_addr.t
+++ b/test/recipes/61-test_bio_addr.t
@@ -1,0 +1,20 @@
+#! /usr/bin/env perl
+# Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test;
+use OpenSSL::Test::Utils;
+
+setup("test_bio_addr");
+
+plan skip_all => "No sockets in this configuration"
+    if disabled("sock");
+
+plan tests => 1;
+
+ok(run(test(["bio_addr_test"])), "running bio_addr_test");

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5535,3 +5535,4 @@ OSSL_ERR_STATE_save_to_mark             ?	3_2_0	EXIST::FUNCTION:
 X509_STORE_CTX_set_get_crl              ?	3_2_0	EXIST::FUNCTION:
 X509_STORE_CTX_set_current_reasons      ?	3_2_0	EXIST::FUNCTION:
 OSSL_STORE_delete                       ?	3_2_0	EXIST::FUNCTION:
+BIO_ADDR_copy                           ?	3_2_0	EXIST::FUNCTION:SOCK


### PR DESCRIPTION
We already have BIO_ADDR_dup() but in some contexts that is not sufficent.
We implement BIO_ADDR_copy() and make BIO_ADDR_dup() use it.

Fixes openssl/project#220

This is built on top of #22157 and includes the commits from there. First commit in this PR is "Implement a public BIO_ADDR_copy() function"
