### PR TITLE
Add include of e_os2.h in quictestlib.c to allow symbol definition consistency.

### DIFF
--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -10,6 +10,7 @@
 #include <assert.h>
 #include <openssl/configuration.h>
 #include <openssl/bio.h>
+#include "internal/e_os.h" /* For struct timeval */
 #include "quictestlib.h"
 #include "ssltestlib.h"
 #include "../testutil.h"


### PR DESCRIPTION
Fixes: #22178

Signed-of-by: Randall S. Becker <randall.becker@nexbridge.ca>
