### PR TITLE
Mark OPENSSL_armcap_P .hidden in arm asm

### DIFF
--- a/crypto/armv4cpuid.pl
+++ b/crypto/armv4cpuid.pl
@@ -293,6 +293,7 @@ atomic_add_spinlock:
 #endif
 
 .extern	OPENSSL_armcap_P
+.hidden	OPENSSL_armcap_P
 ___
 
 print $code;

--- a/crypto/bn/asm/armv4-gf2m.pl
+++ b/crypto/bn/asm/armv4-gf2m.pl
@@ -326,6 +326,7 @@ $code.=<<___;
 
 #if __ARM_MAX_ARCH__>=7
 .extern	OPENSSL_armcap_P
+.hidden	OPENSSL_armcap_P
 #endif
 ___
 

--- a/crypto/bn/asm/armv4-mont.pl
+++ b/crypto/bn/asm/armv4-mont.pl
@@ -750,6 +750,7 @@ $code.=<<___;
 .align	2
 #if __ARM_MAX_ARCH__>=7
 .extern	OPENSSL_armcap_P
+.hidden	OPENSSL_armcap_P
 #endif
 ___
 

--- a/crypto/chacha/asm/chacha-armv4.pl
+++ b/crypto/chacha/asm/chacha-armv4.pl
@@ -1155,6 +1155,7 @@ $code.=<<___;
 	ldmia		sp!,{r4-r11,pc}
 .size	ChaCha20_neon,.-ChaCha20_neon
 .extern	OPENSSL_armcap_P
+.hidden	OPENSSL_armcap_P
 #endif
 ___
 }}}

--- a/crypto/poly1305/asm/poly1305-armv4.pl
+++ b/crypto/poly1305/asm/poly1305-armv4.pl
@@ -1240,6 +1240,7 @@ $code.=<<___;
 .align	2
 #if	__ARM_MAX_ARCH__>=7
 .extern   OPENSSL_armcap_P
+.hidden   OPENSSL_armcap_P
 #endif
 ___
 

--- a/crypto/sha/asm/sha1-armv4-large.pl
+++ b/crypto/sha/asm/sha1-armv4-large.pl
@@ -708,6 +708,7 @@ ___
 $code.=<<___;
 #if __ARM_MAX_ARCH__>=7
 .extern	OPENSSL_armcap_P
+.hidden	OPENSSL_armcap_P
 #endif
 ___
 

--- a/crypto/sha/asm/sha256-armv4.pl
+++ b/crypto/sha/asm/sha256-armv4.pl
@@ -694,6 +694,7 @@ $code.=<<___;
 .align	2
 #if __ARM_MAX_ARCH__>=7 && !defined(__KERNEL__)
 .extern   OPENSSL_armcap_P
+.hidden   OPENSSL_armcap_P
 #endif
 ___
 

--- a/crypto/sha/asm/sha512-armv4.pl
+++ b/crypto/sha/asm/sha512-armv4.pl
@@ -661,6 +661,7 @@ $code.=<<___;
 .align	2
 #if __ARM_MAX_ARCH__>=7 && !defined(__KERNEL__)
 .extern	OPENSSL_armcap_P
+.hidden	OPENSSL_armcap_P
 #endif
 ___
 


### PR DESCRIPTION
Fixes https://github.com/openssl/openssl/pull/21583#issuecomment-1727057735:
~~~
ld: error: relocation R_ARM_REL32 cannot be used against symbol 'OPENSSL_armcap_P'; recompile with -fPIC
~~~
when linking a static build of openssl to a shared library for 32 bit arm on Android,
since https://github.com/openssl/openssl/pull/21583.

This source change has one observable change in readelf output (e.g. for `crypto/sha/libcrypto-lib-sha512-armv4.o`):
~~~diff
 Symbol table '.symtab' contains 12 entries:
    Num:    Value  Size Type    Bind   Vis      Ndx Name
      0: 00000000     0 NOTYPE  LOCAL  DEFAULT  UND 
      1: 00000000     0 SECTION LOCAL  DEFAULT    2 
      2: 00000000   640 OBJECT  LOCAL  DEFAULT    2 K512
      3: 00000000     0 NOTYPE  LOCAL  DEFAULT    2 $d.0
      4: 000002a0     0 NOTYPE  LOCAL  DEFAULT    2 $t.1
      5: 0000183a     0 NOTYPE  LOCAL  DEFAULT    2 $d.2
      6: 00000000     0 SECTION LOCAL  DEFAULT    6 
      7: 00000000     0 SECTION LOCAL  DEFAULT    8 
      8: 00000000     0 SECTION LOCAL  DEFAULT   11 
-     9: 00000000     0 NOTYPE  GLOBAL DEFAULT  UND OPENSSL_armcap_P
+     9: 00000000     0 NOTYPE  GLOBAL HIDDEN   UND OPENSSL_armcap_P
     10: 000002a1  1134 FUNC    GLOBAL DEFAULT    2 sha512_block_data_order
     11: 00000711  4394 FUNC    GLOBAL DEFAULT    2 sha512_block_data_order_n
 
~~~

This change was automated using
~~~
sed -e '/[.]hidden.*OPENSSL_armcap_P/d; /[.]extern.*OPENSSL_armcap_P/ {p; s/extern/hidden/ }' -i -- crypto/*arm*pl crypto/*/asm/*arm*pl
~~~
with the filepath patterns derived from https://github.com/openssl/openssl/pull/21583.