### PR TITLE
ossl_property_list_to_string: handle quoted strings

### DIFF
--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -588,15 +588,38 @@ static void put_char(char ch, char **buf, size_t *remain, size_t *needed)
 
 static void put_str(const char *str, char **buf, size_t *remain, size_t *needed)
 {
-    size_t olen, len;
+    size_t olen, len, i;
+    char quote = '\0';
+    int quotes;
 
     len = olen = strlen(str);
     *needed += len;
 
-    if (*remain == 0)
-        return;
+    /*
+     * Check to see if we need quotes or not.
+     * Characters that are legal in a PropertyName don't need quoting.
+     * We simply assume all others require quotes.
+     */
+    for (i = 0; i < len; i++)
+        if (!ossl_isalnum(str[i]) && str[i] != '.' && str[i] != '_') {
+            /* Default to single quotes ... */
+            if (quote == '\0')
+                quote = '\'';
+            /* ... but use double quotes if a single is present */
+            if (str[i] == '\'')
+                quote = '"';
+        }
 
-    if (*remain < len + 1)
+    quotes = quote != '\0';
+    if (*remain == 0) {
+        *needed += 2 * quotes;
+        return;
+    }
+
+    if (quotes)
+        put_char(quote, buf, remain, needed);
+
+    if (*remain < len + 1 + quotes)
         len = *remain - 1;
 
     if (len > 0) {
@@ -604,6 +627,9 @@ static void put_str(const char *str, char **buf, size_t *remain, size_t *needed)
         *buf += len;
         *remain -= len;
     }
+
+    if (quotes)
+        put_char(quote, buf, remain, needed);
 
     if (len < olen && *remain == 1) {
         **buf = '\0';

--- a/test/property_test.c
+++ b/test/property_test.c
@@ -645,6 +645,9 @@ static struct {
     { "", "" },
     { "fips=3", "fips=3" },
     { "fips=-3", "fips=-3" },
+    { "provider='foo bar'", "provider='foo bar'" },
+    { "provider=\"foo bar'\"", "provider=\"foo bar'\"" },
+    { "provider=abc***", "provider='abc***'" },
     { NULL, "" }
 };
 


### PR DESCRIPTION
ossl_property_list_to_string() didn't quote strings correctly which could result in a generated property string being unparsable.


- [ ] documentation is added or updated
- [x] tests are added or updated
