### PR TITLE
Include e_os.h for missing struct timeval

### DIFF
--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -16,6 +16,7 @@
 #if defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG)
 # include "../threadstest.h"
 #endif
+#include "internal/e_os.h" /* For struct timeval */
 #include "internal/quic_ssl.h"
 #include "internal/quic_wire_pkt.h"
 #include "internal/quic_record_tx.h"

--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -8,6 +8,7 @@
  */
 
 #include <assert.h>
+#include <openssl/e_os2.h>
 #include <openssl/configuration.h>
 #include <openssl/bio.h>
 #include "quictestlib.h"


### PR DESCRIPTION
quictestlib now uses struct timeval. We need to include "e_os.h" to get it.

Fixes #22178

This is an alternative to #22179