### PR TITLE
test: evp_extra: test signing with legacy app method based keys 

### DIFF
--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -194,7 +194,6 @@ static int dh_bn_mod_exp(const DH *dh, BIGNUM *r,
 static int dh_init(DH *dh)
 {
     dh->flags |= DH_FLAG_CACHE_MONT_P;
-    ossl_ffc_params_init(&dh->params);
     dh->dirty_cnt++;
     return 1;
 }

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -119,6 +119,8 @@ static DH *dh_new_intern(ENGINE *engine, OSSL_LIB_CTX *libctx)
         goto err;
 #endif /* FIPS_MODULE */
 
+    ossl_ffc_params_init(&ret->params);
+
     if ((ret->meth->init != NULL) && !ret->meth->init(ret)) {
         ERR_raise(ERR_LIB_DH, ERR_R_INIT_FAIL);
         goto err;

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -179,6 +179,8 @@ static DSA *dsa_new_intern(ENGINE *engine, OSSL_LIB_CTX *libctx)
         goto err;
 #endif
 
+    ossl_ffc_params_init(&ret->params);
+
     if ((ret->meth->init != NULL) && !ret->meth->init(ret)) {
         ERR_raise(ERR_LIB_DSA, ERR_R_INIT_FAIL);
         goto err;

--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -462,7 +462,6 @@ static int dsa_do_verify(const unsigned char *dgst, int dgst_len,
 static int dsa_init(DSA *dsa)
 {
     dsa->flags |= DSA_FLAG_CACHE_MONT_P;
-    ossl_ffc_params_init(&dsa->params);
     dsa->dirty_cnt++;
     return 1;
 }

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1267,11 +1267,11 @@ static int test_EVP_PKEY_sign(int tst)
 
     if (tst == 0) {
         if (!TEST_ptr(pkey = load_example_rsa_key()))
-                goto out;
+            goto out;
     } else if (tst == 1) {
 #ifndef OPENSSL_NO_DSA
         if (!TEST_ptr(pkey = load_example_dsa_key()))
-                goto out;
+            goto out;
 #else
         ret = 1;
         goto out;
@@ -1279,7 +1279,7 @@ static int test_EVP_PKEY_sign(int tst)
     } else {
 #ifndef OPENSSL_NO_EC
         if (!TEST_ptr(pkey = load_example_ec_key()))
-                goto out;
+            goto out;
 #else
         ret = 1;
         goto out;

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1313,6 +1313,88 @@ static int test_EVP_PKEY_sign(int tst)
     return ret;
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+static int test_EVP_PKEY_sign_with_app_method(int tst)
+{
+    int ret = 0;
+    EVP_PKEY *pkey = NULL;
+    RSA *rsa = NULL;
+    RSA_METHOD *rsa_meth = NULL;
+#ifndef OPENSSL_NO_DSA
+    DSA *dsa = NULL;
+    DSA_METHOD *dsa_meth = NULL;
+#endif
+    unsigned char *sig = NULL;
+    size_t sig_len = 0, shortsig_len = 1;
+    EVP_PKEY_CTX *ctx = NULL;
+    unsigned char tbs[] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+        0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13
+    };
+
+    if (tst == 0) {
+        if (!TEST_ptr(pkey = load_example_rsa_key()))
+            goto out;
+        if (!TEST_ptr(rsa_meth = RSA_meth_dup(RSA_get_default_method())))
+            goto out;
+
+        if (!TEST_ptr(rsa = EVP_PKEY_get1_RSA(pkey))
+            || !TEST_int_gt(RSA_set_method(rsa, rsa_meth), 0)
+            || !TEST_int_gt(EVP_PKEY_assign_RSA(pkey, rsa), 0))
+            goto out;
+        rsa = NULL; /* now owned by the pkey */
+    } else {
+#ifndef OPENSSL_NO_DSA
+        if (!TEST_ptr(pkey = load_example_dsa_key()))
+                goto out;
+        if (!TEST_ptr(dsa_meth = DSA_meth_dup(DSA_get_default_method())))
+            goto out;
+
+        if (!TEST_ptr(dsa = EVP_PKEY_get1_DSA(pkey))
+            || !TEST_int_gt(DSA_set_method(dsa, dsa_meth), 0)
+            || !TEST_int_gt(EVP_PKEY_assign_DSA(pkey, dsa), 0))
+            goto out;
+        dsa = NULL; /* now owned by the pkey */
+#else
+        ret = 1;
+        goto out;
+#endif
+    }
+
+    ctx = EVP_PKEY_CTX_new_from_pkey(testctx, pkey, NULL);
+    if (!TEST_ptr(ctx)
+            || !TEST_int_gt(EVP_PKEY_sign_init(ctx), 0)
+            || !TEST_int_gt(EVP_PKEY_sign(ctx, NULL, &sig_len, tbs,
+                                          sizeof(tbs)), 0))
+        goto out;
+    sig = OPENSSL_malloc(sig_len);
+    if (!TEST_ptr(sig)
+            /* Test sending a signature buffer that is too short is rejected */
+            || !TEST_int_le(EVP_PKEY_sign(ctx, sig, &shortsig_len, tbs,
+                                          sizeof(tbs)), 0)
+            || !TEST_int_gt(EVP_PKEY_sign(ctx, sig, &sig_len, tbs, sizeof(tbs)),
+                            0)
+            /* Test the signature round-trips */
+            || !TEST_int_gt(EVP_PKEY_verify_init(ctx), 0)
+            || !TEST_int_gt(EVP_PKEY_verify(ctx, sig, sig_len, tbs, sizeof(tbs)),
+                            0))
+        goto out;
+
+    ret = 1;
+ out:
+    EVP_PKEY_CTX_free(ctx);
+    OPENSSL_free(sig);
+    EVP_PKEY_free(pkey);
+    RSA_free(rsa);
+    RSA_meth_free(rsa_meth);
+#ifndef OPENSSL_NO_DSA
+    DSA_free(dsa);
+    DSA_meth_free(dsa_meth);
+#endif
+    return ret;
+}
+#endif /* !OPENSSL_NO_DEPRECATED_3_0 */
+
 /*
  * n = 0 => test using legacy cipher
  * n = 1 => test using fetched cipher
@@ -4973,6 +5055,9 @@ int setup_tests(void)
     ADD_TEST(test_EVP_Digest);
     ADD_TEST(test_EVP_md_null);
     ADD_ALL_TESTS(test_EVP_PKEY_sign, 3);
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+    ADD_ALL_TESTS(test_EVP_PKEY_sign_with_app_method, 2);
+#endif
     ADD_ALL_TESTS(test_EVP_Enveloped, 2);
     ADD_ALL_TESTS(test_d2i_AutoPrivateKey, OSSL_NELEM(keydata));
     ADD_TEST(test_privatekey_to_pkcs8);


### PR DESCRIPTION
# test_EVP_PKEY_sign_with_app_method

This pull request adds `test_EVP_PKEY_sign_with_app_method`, a regression test for the bug fix in commit 1acc3e8cc3c6 (pull request #22163). It is analogous to `test_EVP_PKEY_sign`, only with a fake app method based key.

To use as much as possible of  `test_EVP_PKEY_sign`'s implementation, the EVP keys are loaded with `load_example_{rsa,dsa}_key()` and then their `{RSA,DSA}_METHOD`s are replaced, respectively. (The EC key test case was omitted, because there is no `EC_KEY_METHOD_dup` method.)

## Testing the regression test (with `no-engine`)

To verify that the detects the regression, you need to `git revert 1acc3e8cc3c6` and configure and build with `no-engine`. Then, run the evp_extra test:

    make test V=1 TESTS=test_evp_extra

It will fail twice with an 'unsupported algorithm' error:

    # Subtest: test_EVP_PKEY_sign_with_app_method
    1..2
    # ERROR: (ptr) 'ctx != NULL' failed @ test/evp_extra_test.c:1365
    # 0x0
    # 80EB60A4627F0000:error:0300009C:digital envelope routines:int_ctx_new:unsupported algorithm:crypto/evp/pmeth_lib.c:312:
    # OPENSSL_TEST_RAND_SEED=1695633019
    not ok 34 - iteration 1
    # ERROR: (ptr) 'ctx != NULL' failed @ test/evp_extra_test.c:1365
    # 0x0
    # 80EB60A4627F0000:error:0300009C:digital envelope routines:int_ctx_new:unsupported algorithm:crypto/evp/pmeth_lib.c:312:
    # OPENSSL_TEST_RAND_SEED=1695633019
    not ok 35 - iteration 2



## A bug in `EVP_PKEY_assign_DSA`?

With `enable-engine` (and `git revert 1acc3e8cc3c6`), the test succeds with the RSA key (as expected), but it fails with the DSA key. The functions `EVP_PKEY_assign_RSA` and `EVP_PKEY_assign_DSA` behave differently and to me it seems that there is a bug in the DSA implementation. Or am I using the API incorrectly?


### EVP_PKEY_assign_RSA

After calling `EVP_PKEY_assign_RSA`, all RSA parameters are set correctly:

```
Breakpoint 3, test_EVP_PKEY_sign_with_app_method (tst=0) at test/evp_extra_test.c:1345
1345	        rsa = NULL; /* now owned by the pkey */
(gdb) p *pkey->pkey.rsa
$1 = {
  dummy_zero = 0,
  libctx = 0x555555a72d20 <default_context_int>,
  version = 0,
  meth = 0x555555aa7350,
  engine = 0x0,
  n = 0x555555accee0,
  e = 0x555555accec0,
  d = 0x555555accfe0,
  p = 0x555555a961d0,
  q = 0x555555ac8e10,
  dmp1 = 0x555555acc820,
  dmq1 = 0x555555acc990,
  iqmp = 0x555555ac93a0,
  pss_params = {
    hash_algorithm_nid = 0,
    mask_gen = {
      algorithm_nid = 0,
      hash_algorithm_nid = 0
    },
    salt_len = 0,
    trailer_field = 0
  },
  pss = 0x0,
  prime_infos = 0x0,
  ex_data = {
    ctx = 0x0,
    sk = 0x0
  },
  references = {
    val = 1
  },
  flags = 6,
  _method_mod_n = 0x0,
  _method_mod_p = 0x0,
  _method_mod_q = 0x0,
  blinding = 0x0,
  mt_blinding = 0x0,
  lock = 0x555555acd230,
  dirty_cnt = 4
}
```

### EVP_PKEY_assign_DSA

After calling `EVP_PKEY_assign_DSA`, all DSA parameters are unassigned:

```
Breakpoint 4, test_EVP_PKEY_sign_with_app_method (tst=1) at test/evp_extra_test.c:1357
1357	        dsa = NULL; /* now owned by the pkey */
(gdb) p *pkey->pkey.dsa
$2 = {
  pad = 0,
  version = 0,
  params = {
    p = 0x0,
    q = 0x0,
    g = 0x0,
    j = 0x0,
    seed = 0x0,
    seedlen = 0,
    pcounter = -1,
    nid = 0,
    gindex = -1,
    h = 0,
    flags = 3,
    mdname = 0x0,
    mdprops = 0x0,
    keylength = 0
  },
  pub_key = 0x555555a961d0,
  priv_key = 0x555555acce30,
  flags = 1,
  method_mont_p = 0x0,
  references = {
    val = 1
  },
  ex_data = {
    ctx = 0x555555a72d20 <default_context_int>,
    sk = 0x0
  },
  meth = 0x555555acb480,
  engine = 0x0,
  lock = 0x555555accd00,
  libctx = 0x555555a72d20 <default_context_int>,
  dirty_cnt = 4
}
```

As a consequence, `EVP_PKEY_sign` fails with an 'invalid key' error:

```
#0  ERR_new () at crypto/err/err_blocks.c:20
#1  0x000055555564ddb2 in EVP_PKEY_sign (ctx=0x555555a977b0, sig=0x0, siglen=0x7fffffffcd98, tbs=0x7fffffffcd70 "", tbslen=20) at crypto/evp/signature.c:656
#2  0x00005555555be317 in test_EVP_PKEY_sign_with_app_method (tst=1) at test/evp_extra_test.c:1367
#3  0x00005555555d0e93 in run_tests (test_prog_name=0x7fffffffe272 "/home/msp/src/openssl/master/test/evp_extra_test") at test/testutil/driver.c:377
#4  0x00005555555d12e3 in main (argc=1, argv=0x7fffffffdf78) at test/testutil/main.c:31
(gdb) c
Continuing.
    # ERROR: (int) 'EVP_PKEY_sign(ctx, NULL, &sig_len, tbs, sizeof(tbs)) > 0' failed @ test/evp_extra_test.c:1367
    # [0] compared to [0]
    # 40E7DCF7FF7F0000:error:030000A3:digital envelope routines:EVP_PKEY_sign:invalid key:crypto/evp/signature.c:656:
    # OPENSSL_TEST_RAND_SEED=1695630154
    not ok 35 - iteration 2
```
