### PR TITLE
Use the untrusted server certificate chain to create a valid certificate ID for OCSP_request

### DIFF
--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -231,6 +231,8 @@ See L<openssl-format-options(1)> for details.
 
 A file or URI of untrusted certificates to use when attempting to build the
 certificate chain related to the certificate specified via the B<-cert> option.
+These untrusted certificates are sent to clients and used for generating
+certificate status (aka OCSP stapling) requests.
 The input can be in PEM, DER, or PKCS#12 format.
 
 =item B<-build_chain>
@@ -512,6 +514,8 @@ Enables certificate status request support (aka OCSP stapling).
 
 Enables certificate status request support (aka OCSP stapling) and gives
 a verbose printout of the OCSP response.
+Use the B<-cert_chain> option to specify the certificate of the server's
+certificate signer that is required for certificate status requests.
 
 =item B<-status_timeout> I<int>
 


### PR DESCRIPTION
The `openssl s_server` command-line tool does not use the untrusted certificate chain for building OCSP requests.

Let's consider the following `openssl s_server` options:
```
-cert infile
	The certificate to use.
-cert_chain
	A file or URI of untrusted certificates to use when attempting to build the certificate chain related to the certificate specified via the -cert option.
-CAfile file
	A file of trusted certificates.
```

An issuer certificate is required to create an OCSP_CERTID structure. This ID is placed in the OCSP request.
The issuer certificate can be untrusted, although any issuer can be designated as a trusted root authority.

Start the OCSP responder:
```
openssl ocsp -port 19254 -index index.txt -rsigner ocsp.pem -CA intermediateCA.pem
```

The following doesn't work but it should:
```
openssl s_server -accept 4433 -cert server.pem -cert_chain intermediateCA.pem -status_verbose
Using default temp DH parameters
ACCEPT
cert_status: callback called
cert_status: AIA URL: http://127.0.0.1:19254/ocsp
cert_status: Can't retrieve issuer certificate.
(...)
```

The following workaround works, but it requires trusting an untrusted certificate:
```
openssl s_server -accept 4433 -cert server.pem -CAfile intermediateCA.pem -status_verbose
Using default temp DH parameters
ACCEPT
cert_status: callback called
cert_status: AIA URL: http://127.0.0.1:19254/ocsp
cert_status: ocsp response sent:
OCSP Response Data:
    OCSP Response Status: successful (0x0)
    Response Type: Basic OCSP Response
    Version: 1 (0x0)
    Responder Id: C = PL, O = Stunnel Developers, OU = Intermediate CA, CN = Intermediate CA
    Produced At: Sep 15 12:07:08 2023 GMT
    Responses:
    Certificate ID:
      Hash Algorithm: sha1
      Issuer Name Hash: 48BDDBF0D915E576EE31434E57A6FAA988FADEB2
      Issuer Key Hash: AF74BB9A5BBE5FAF4650E3D0F6FE4F49DB3DBADA
      Serial Number: 3168B44D3E67DA3B9D7A7B40E08793F616EEF669
    Cert Status: good
    This Update: Sep 15 12:07:08 2023 GMT
	(...)
```

This PR enables the untrusted server certificate chain to find the issuer certificate.
```
openssl s_server -accept 4433 -cert server.pem -cert_chain intermediateCA.pem -status_verbose 
Using default temp DH parameters
ACCEPT
cert_status: callback called
cert_status: AIA URL: http://127.0.0.1:19254/ocsp
cert_status: ocsp response sent:
OCSP Response Data:
    OCSP Response Status: successful (0x0)
    Response Type: Basic OCSP Response
    Version: 1 (0x0)
    Responder Id: C = PL, O = Stunnel Developers, OU = Intermediate CA, CN = Intermediate CA
    Produced At: Sep 15 12:08:46 2023 GMT
    Responses:
    Certificate ID:
      Hash Algorithm: sha1
      Issuer Name Hash: 48BDDBF0D915E576EE31434E57A6FAA988FADEB2
      Issuer Key Hash: AF74BB9A5BBE5FAF4650E3D0F6FE4F49DB3DBADA
      Serial Number: 3168B44D3E67DA3B9D7A7B40E08793F616EEF669
    Cert Status: good
    This Update: Sep 15 12:08:46 2023 GMT
	(...)
```