### PR TITLE
A non-null value can exist beyond arguments array, implying that loop…

### DIFF
--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -1005,12 +1005,7 @@ char **opt_rest(void)
 /* How many items in remaining args? */
 int opt_num_rest(void)
 {
-    int i = 0;
-    char **pp;
-
-    for (pp = opt_rest(); *pp; pp++, i++)
-        continue;
-    return i;
+    return argc - opt_index - 1;
 }
 
 /* Return a string describing the parameter type. */


### PR DESCRIPTION
… termination condition is not correct in opt_num_rest(). Correct way is to subtract the used arguments count, i.e. opt_index + 1, from the total arguments count, i.e. argc.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
