### PR TITLE
Fix timeouts in the quic_multistream test script 13

### DIFF
--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -1053,7 +1053,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
             first           = 0;
             offset          = 0;
             op_start_time   = ossl_time_now();
-            op_deadline     = ossl_time_add(op_start_time, ossl_ms2time(8000));
+            op_deadline     = ossl_time_add(op_start_time, ossl_ms2time(60000));
         }
 
         if (!TEST_int_le(ossl_time_compare(ossl_time_now(), op_deadline), 0)) {


### PR DESCRIPTION
Script 13 is a stress test which can timeout on some low powered platforms or with some options that significantly slow performance.

We increase the timeout.

