### PR TITLE
add check against NULL before calling EVP_DigestInit_ex to avoid NULL…

### DIFF
--- a/crypto/evp/bio_md.c
+++ b/crypto/evp/bio_md.c
@@ -140,6 +140,12 @@ static long md_ctrl(BIO *b, int cmd, long num, void *ptr)
     ctx = BIO_get_data(b);
     next = BIO_next(b);
 
+    // add check against NULL
+    if(!ctx)
+    {
+        return 0;
+    }
+
     switch (cmd) {
     case BIO_CTRL_RESET:
         if (BIO_get_init(b))


### PR DESCRIPTION
… deref

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->


