### PR TITLE
Add EVP_DigestSqueeze() API for architecture s390x

### DIFF
--- a/crypto/sha/asm/keccak1600-s390x.pl
+++ b/crypto/sha/asm/keccak1600-s390x.pl
@@ -472,7 +472,7 @@ SHA3_absorb:
 .size	SHA3_absorb,.-SHA3_absorb
 ___
 }
-{ my ($A_flat,$out,$len,$bsz) = map("%r$_",(2..5));
+{ my ($A_flat,$out,$len,$bsz,$next) = map("%r$_",(2..6));
 
 $code.=<<___;
 .globl	SHA3_squeeze
@@ -484,6 +484,7 @@ SHA3_squeeze:
 	lghi	%r14,8
 	st${g}	$bsz,5*$SIZE_T($sp)
 	la	%r1,0($A_flat)
+	cijne	$next,0,.Lnext_block
 
 	j	.Loop_squeeze
 
@@ -501,6 +502,7 @@ SHA3_squeeze:
 
 	brct	$bsz,.Loop_squeeze	# bsz--
 
+.Lnext_block:
 	stm${g}	$out,$len,3*$SIZE_T($sp)
 	bras	%r14,.LKeccakF1600
 	lm${g}	$out,$bsz,3*$SIZE_T($sp)

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -267,7 +267,8 @@ static int s390x_kmac_final(void *vctx, unsigned char *out, size_t outlen)
 static PROV_SHA3_METHOD sha3_s390x_md =
 {
     s390x_sha3_absorb,
-    s390x_sha3_final
+    s390x_sha3_final,
+    NULL,
 };
 
 static PROV_SHA3_METHOD keccak_s390x_md =

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -188,6 +188,10 @@ static size_t s390x_sha3_absorb(void *vctx, const void *inp, size_t len)
     KECCAK1600_CTX *ctx = vctx;
     size_t rem = len % ctx->block_size;
 
+    if (!(ctx->xof_state == XOF_STATE_INIT ||
+          ctx->xof_state == XOF_STATE_ABSORB))
+        return 0;
+    ctx->xof_state = XOF_STATE_ABSORB;
     s390x_kimd(inp, len - rem, ctx->pad, ctx->A);
     return rem;
 }

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -303,6 +303,55 @@ static int s390x_kmac_final(void *vctx, unsigned char *out, size_t outlen)
     return s390x_keccakc_final(vctx, out, outlen, 0x04);
 }
 
+static int s390x_keccakc_squeeze(void *vctx, unsigned char *out, size_t outlen,
+                                 int padding)
+{
+    KECCAK1600_CTX *ctx = vctx;
+    size_t len;
+
+    if (!ossl_prov_is_running())
+        return 0;
+    if (ctx->xof_state == XOF_STATE_FINAL)
+        return 0;
+    /*
+     * On the first squeeze call, finish the absorb process
+     * by adding the trailing padding and then doing
+     * a final absorb.
+     */
+    if (ctx->xof_state != XOF_STATE_SQUEEZE) {
+        len = ctx->block_size - ctx->bufsz;
+        memset(ctx->buf + ctx->bufsz, 0, len);
+        ctx->buf[ctx->bufsz] = padding;
+        ctx->buf[ctx->block_size - 1] |= 0x80;
+        s390x_kimd(ctx->buf, ctx->block_size, ctx->pad, ctx->A);
+        ctx->bufsz = 0;
+        /* reuse ctx->bufsz to count bytes squeezed from current sponge */
+    }
+    if (ctx->bufsz != 0 || ctx->xof_state != XOF_STATE_SQUEEZE) {
+        len = ctx->block_size - ctx->bufsz;
+        if (outlen < len)
+            len = outlen;
+        memcpy(out, (char *)ctx->A + ctx->bufsz, len);
+        out += len;
+        outlen -= len;
+        ctx->bufsz += len;
+        if (ctx->bufsz == ctx->block_size)
+            ctx->bufsz = 0;
+    }
+    ctx->xof_state = XOF_STATE_SQUEEZE;
+    if (outlen == 0)
+        return 1;
+    s390x_klmd(NULL, 0, out, outlen, ctx->pad | S390X_KLMD_PS, ctx->A);
+    ctx->bufsz = outlen % ctx->block_size;
+
+    return 1;
+}
+
+static int s390x_keccak_squeeze(void *vctx, unsigned char *out, size_t outlen)
+{
+     return s390x_keccakc_squeeze(vctx, out, outlen, 0x01);
+}
+
 static PROV_SHA3_METHOD sha3_s390x_md =
 {
     s390x_sha3_absorb,
@@ -314,6 +363,7 @@ static PROV_SHA3_METHOD keccak_s390x_md =
 {
     s390x_sha3_absorb,
     s390x_keccak_final,
+    s390x_keccak_squeeze,
 };
 
 static PROV_SHA3_METHOD shake_s390x_md =

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -202,6 +202,10 @@ static int s390x_sha3_final(void *vctx, unsigned char *out, size_t outlen)
 
     if (!ossl_prov_is_running())
         return 0;
+    if (!(ctx->xof_state == XOF_STATE_INIT ||
+          ctx->xof_state == XOF_STATE_ABSORB))
+        return 0;
+    ctx->xof_state = XOF_STATE_FINAL;
     s390x_klmd(ctx->buf, ctx->bufsz, NULL, 0, ctx->pad, ctx->A);
     memcpy(out, ctx->A, outlen);
     return 1;

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -217,6 +217,10 @@ static int s390x_shake_final(void *vctx, unsigned char *out, size_t outlen)
 
     if (!ossl_prov_is_running())
         return 0;
+    if (!(ctx->xof_state == XOF_STATE_INIT ||
+          ctx->xof_state == XOF_STATE_ABSORB))
+        return 0;
+    ctx->xof_state = XOF_STATE_FINAL;
     s390x_klmd(ctx->buf, ctx->bufsz, out, outlen, ctx->pad, ctx->A);
     return 1;
 }

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -352,6 +352,11 @@ static int s390x_keccak_squeeze(void *vctx, unsigned char *out, size_t outlen)
      return s390x_keccakc_squeeze(vctx, out, outlen, 0x01);
 }
 
+static int s390x_kmac_squeeze(void *vctx, unsigned char *out, size_t outlen)
+{
+     return s390x_keccakc_squeeze(vctx, out, outlen, 0x04);
+}
+
 static PROV_SHA3_METHOD sha3_s390x_md =
 {
     s390x_sha3_absorb,
@@ -376,7 +381,8 @@ static PROV_SHA3_METHOD shake_s390x_md =
 static PROV_SHA3_METHOD kmac_s390x_md =
 {
     s390x_sha3_absorb,
-    s390x_kmac_final
+    s390x_kmac_final,
+    s390x_kmac_squeeze,
 };
 
 # define SHAKE_SET_MD(uname, typ)                                              \

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -143,6 +143,10 @@ static size_t generic_sha3_absorb(void *vctx, const void *inp, size_t len)
 {
     KECCAK1600_CTX *ctx = vctx;
 
+    if (!(ctx->xof_state == XOF_STATE_INIT ||
+          ctx->xof_state == XOF_STATE_ABSORB))
+        return 0;
+    ctx->xof_state = XOF_STATE_ABSORB;
     return SHA3_absorb(ctx->A, inp, len, ctx->block_size);
 }
 

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -235,6 +235,10 @@ static int s390x_keccakc_final(void *vctx, unsigned char *out, size_t outlen,
 
     if (!ossl_prov_is_running())
         return 0;
+    if (!(ctx->xof_state == XOF_STATE_INIT ||
+          ctx->xof_state == XOF_STATE_ABSORB))
+        return 0;
+    ctx->xof_state = XOF_STATE_FINAL;
     if (outlen == 0)
         return 1;
     memset(ctx->buf + num, 0, bsz - num);


### PR DESCRIPTION
This PR is based on  PR #21511 (which adds the new EVP_DigestSqueeze() API). This RP adds the s390x-related implementation for this new API.

The new API requires changes in the low-level asm implementation of SHA3_Squeeze(), as well as the in the default provider for sha3-digests. Both is covered in this PR. The patches are in separate commits for better readability, but will be folded later.

test_evp_xof can be used to test the new API. For testing the low-level implementation of SHA3_Squeeze(), the CPACF instructions must be by-passed (by setting environment variable `OPENSSL_s390xcap=stfle:0:0:0`  for the tests).

##### Checklist
- [ ] documentation is added or updated
- [ ] tests are added or updated
