### PR TITLE
doc: correct the SSL_CTX_set_info_callback(3) manual page

### DIFF
--- a/doc/man3/SSL_CTX_set_info_callback.pod
+++ b/doc/man3/SSL_CTX_set_info_callback.pod
@@ -12,10 +12,12 @@ SSL_get_info_callback
 
  #include <openssl/ssl.h>
 
- void SSL_CTX_set_info_callback(SSL_CTX *ctx, void (*callback)());
+ void SSL_CTX_set_info_callback(SSL_CTX *ctx,
+                                void (*callback) (const SSL *ssl, int type, int val));
  void (*SSL_CTX_get_info_callback(const SSL_CTX *ctx))();
 
- void SSL_set_info_callback(SSL *ssl, void (*callback)());
+ void SSL_set_info_callback(SSL *ssl,
+                            void (*callback) (const SSL *ssl, int type, int val));
  void (*SSL_get_info_callback(const SSL *ssl))();
 
 =head1 DESCRIPTION
@@ -119,7 +121,7 @@ SSL_get_info_callback() returns the current setting.
 The following example callback function prints state strings, information
 about alerts being handled and error messages to the B<bio_err> BIO.
 
- void apps_ssl_info_callback(SSL *s, int where, int ret)
+ void apps_ssl_info_callback(const SSL *s, int where, int ret)
  {
      const char *str;
      int w = where & ~SSL_ST_MASK;

--- a/doc/man3/SSL_CTX_set_info_callback.pod
+++ b/doc/man3/SSL_CTX_set_info_callback.pod
@@ -14,11 +14,13 @@ SSL_get_info_callback
 
  void SSL_CTX_set_info_callback(SSL_CTX *ctx,
                                 void (*callback) (const SSL *ssl, int type, int val));
- void (*SSL_CTX_get_info_callback(const SSL_CTX *ctx))();
+
+ void (*SSL_CTX_get_info_callback(SSL_CTX *ctx)) (const SSL *ssl, int type, int val);
 
  void SSL_set_info_callback(SSL *ssl,
                             void (*callback) (const SSL *ssl, int type, int val));
- void (*SSL_get_info_callback(const SSL *ssl))();
+
+ void (*SSL_get_info_callback(const SSL *ssl)) (const SSL *ssl, int type, int val);
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
The info callback is not prototyped correctly, and the code example fails to compile because of const-incorrectness.