### PR TITLE
VMS build: avoid issues with catfile adding trailing dots

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -365,8 +365,8 @@ HTMLDOCS3={- join(", ", map { "-\n\t".$_ } @{$unified_info{htmldocs}->{man3}}) -
 HTMLDOCS5={- join(", ", map { "-\n\t".$_ } @{$unified_info{htmldocs}->{man5}}) -}
 HTMLDOCS7={- join(", ", map { "-\n\t".$_ } @{$unified_info{htmldocs}->{man7}}) -}
 
-APPS_OPENSSL="{- use File::Spec::Functions;
-                 catfile("apps","openssl") -}"
+APPS_OPENSSL="[.apps]openssl"
+# avoid catfile adding a '.' - after all it's just a config key for progs.pl
 
 # DESTDIR is for package builders so that they can configure for, say,
 # SYS$COMMON:[OPENSSL] and yet have everything installed in STAGING:[USER].

--- a/Configure
+++ b/Configure
@@ -1912,7 +1912,10 @@ if ($builder eq "unified") {
         # Make sure the directories we're building in exists
         mkpath($d);
 
+        # VMS catfile adds trailing dots, if found turns into ^. (libcrypto^.^..)
+        $f =~ s/\.$// if $^O eq 'VMS';
         my $res = abs2rel(catfile(absolutedir($d), $f), rel2abs($relativeto));
+        $res =~ s/\.$// if $^O eq 'VMS';
         #print STDERR "DEBUG[cleanfile]: $d , $f => $res\n";
         return $res;
     }


### PR DESCRIPTION
VMS build: avoid issues with catfile adding trailing dots

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->