### PR TITLE
doc/man3: fix misnamed function name

### DIFF
--- a/doc/man3/DSA_generate_parameters.pod
+++ b/doc/man3/DSA_generate_parameters.pod
@@ -51,7 +51,7 @@ called as shown below. For information on the BN_GENCB structure and the
 BN_GENCB_call function discussed below, refer to
 L<BN_generate_prime(3)>.
 
-DSA_generate_prime() is similar to DSA_generate_prime_ex() but
+DSA_generate_parameters() is similar to DSA_generate_parameters_ex() but
 expects an old-style callback function; see
 L<BN_generate_prime(3)> for information on the old-style callback.
 


### PR DESCRIPTION
Rename `DSA_generate_prime[_ex]` to `DSA_generate_parameters[_ex]`, fixing a copy&paste error from the `BN_generate_prime[_ex]` paragraph in commit b3696a55a5ed.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
