### PR TITLE
doc/man3: fix typo OPENSSH_ -> OPENSSL_

### DIFF
--- a/doc/man3/OPENSSL_LH_stats.pod
+++ b/doc/man3/OPENSSL_LH_stats.pod
@@ -48,7 +48,7 @@ record a miss.
 OPENSSL_LH_stats_bio(), OPENSSL_LH_node_stats_bio() and OPENSSL_LH_node_usage_stats_bio()
 are the same as the above, except that the output goes to a B<BIO>.
 
-OPENSSH_LH_stats() and OPENSSH_LH_stats_bio() are deprecated and should no
+OPENSSL_LH_stats() and OPENSSL_LH_stats_bio() are deprecated and should no
 longer be used.
 
 =head1 RETURN VALUES
@@ -61,7 +61,7 @@ These calls should be made under a read lock. Refer to
 L<OPENSSL_LH_COMPFUNC(3)/NOTE> for more details about the locks required
 when using the LHASH data structure.
 
-The functions OPENSSH_LH_stats() and OPENSSH_LH_stats_bio() were deprecated in
+The functions OPENSSL_LH_stats() and OPENSSL_LH_stats_bio() were deprecated in
 version 3.2.
 
 =head1 SEE ALSO


### PR DESCRIPTION
Found by by pure chance, accidentally mistyping `env | grep SSH_` as `git grep SSH_`  :laughing: 


@hlandau  is there anything else you concealed in your job interview which we need to know?  :wink: 



