### PR TITLE
Refine documentation for PKCS5_PBKDF2_HMAC

### DIFF
--- a/doc/man3/PKCS5_PBKDF2_HMAC.pod
+++ b/doc/man3/PKCS5_PBKDF2_HMAC.pod
@@ -33,7 +33,8 @@ be NULL terminated.
 
 B<iter> is the iteration count and its value should be greater than or
 equal to 1. RFC 2898 suggests an iteration count of at least 1000. Any
-B<iter> less than 1 is treated as a single iteration.
+B<iter> value less than 1 is invalid; such values will result in failure
+and raise the PROV_R_INVALID_ITERATION_COUNT error.
 
 B<digest> is the message digest function used in the derivation.
 PKCS5_PBKDF2_HMAC_SHA1() calls PKCS5_PBKDF2_HMAC() with EVP_sha1().


### PR DESCRIPTION
Remove unnecessary line in man3/PKCS5_PBKDF2_HMAC.pod to enhance clarity and conciseness.

Closes openssl#22168