### PR TITLE
Add openssl/pem.h inclusion for d2i_PKCS8PrivateKey

### DIFF
--- a/doc/man3/d2i_PKCS8PrivateKey_bio.pod
+++ b/doc/man3/d2i_PKCS8PrivateKey_bio.pod
@@ -9,6 +9,7 @@ i2d_PKCS8PrivateKey_nid_bio, i2d_PKCS8PrivateKey_nid_fp - PKCS#8 format private 
 =head1 SYNOPSIS
 
  #include <openssl/evp.h>
+ #include <openssl/pem.h>
 
  EVP_PKEY *d2i_PKCS8PrivateKey_bio(BIO *bp, EVP_PKEY **x, pem_password_cb *cb, void *u);
  EVP_PKEY *d2i_PKCS8PrivateKey_fp(FILE *fp, EVP_PKEY **x, pem_password_cb *cb, void *u);


### PR DESCRIPTION
Include the necessary header file openssl/pem.h in the documentation to ensure that all functions related to d2i_PKCS8PrivateKey are correctly defined.

Closes openssl#22188