### PR TITLE
Adds DTLS1.3 to ssl protocol to text structs

### DIFF
--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -318,7 +318,8 @@ static int protocol_from_string(const char *value)
         {"TLSv1.2", TLS1_2_VERSION},
         {"TLSv1.3", TLS1_3_VERSION},
         {"DTLSv1", DTLS1_VERSION},
-        {"DTLSv1.2", DTLS1_2_VERSION}
+        {"DTLSv1.2", DTLS1_2_VERSION},
+        {"DTLSv1.3", DTLS1_3_VERSION}
     };
     size_t i;
     size_t n = OSSL_NELEM(versions);

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -285,7 +285,8 @@ static int cmd_Protocol(SSL_CONF_CTX *cctx, const char *value)
         SSL_FLAG_TBL_INV("TLSv1.2", SSL_OP_NO_TLSv1_2),
         SSL_FLAG_TBL_INV("TLSv1.3", SSL_OP_NO_TLSv1_3),
         SSL_FLAG_TBL_INV("DTLSv1", SSL_OP_NO_DTLSv1),
-        SSL_FLAG_TBL_INV("DTLSv1.2", SSL_OP_NO_DTLSv1_2)
+        SSL_FLAG_TBL_INV("DTLSv1.2", SSL_OP_NO_DTLSv1_2),
+        SSL_FLAG_TBL_INV("DTLSv1.3", SSL_OP_NO_DTLSv1_3)
     };
     cctx->tbl = ssl_protocol_list;
     cctx->ntbl = OSSL_NELEM(ssl_protocol_list);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4819,6 +4819,9 @@ const char *ssl_protocol_to_string(int version)
     case DTLS1_2_VERSION:
         return "DTLSv1.2";
 
+    case DTLS1_3_VERSION:
+        return "DTLSv1.3";
+
     default:
         return "unknown";
     }

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -68,6 +68,7 @@ static const ssl_trace_tbl ssl_version_tbl[] = {
     {TLS1_3_VERSION, "TLS 1.3"},
     {DTLS1_VERSION, "DTLS 1.0"},
     {DTLS1_2_VERSION, "DTLS 1.2"},
+    {DTLS1_3_VERSION, "DTLS 1.3"},
     {DTLS1_BAD_VER, "DTLS 1.0 (bad)"}
 };
 

--- a/test/helpers/ssl_test_ctx.c
+++ b/test/helpers/ssl_test_ctx.c
@@ -156,6 +156,7 @@ static const test_enum ssl_protocols[] = {
      {"SSLv3", SSL3_VERSION},
      {"DTLSv1", DTLS1_VERSION},
      {"DTLSv1.2", DTLS1_2_VERSION},
+     {"DTLSv1.3", DTLS1_3_VERSION},
 };
 
 __owur static int parse_protocol(SSL_TEST_CTX *test_ctx, const char *value)

--- a/test/ssl_old_test.c
+++ b/test/ssl_old_test.c
@@ -826,7 +826,8 @@ static int protocol_from_string(const char *value)
         {"tls1.2", TLS1_2_VERSION},
         {"tls1.3", TLS1_3_VERSION},
         {"dtls1", DTLS1_VERSION},
-        {"dtls1.2", DTLS1_2_VERSION}};
+        {"dtls1.2", DTLS1_2_VERSION},
+        {"dtls1.3", DTLS1_3_VERSION}};
     size_t i;
     size_t n = OSSL_NELEM(versions);
 


### PR DESCRIPTION
Another dtls 1.3 specific update. It is dependent on https://github.com/openssl/openssl/pull/22259