### PR TITLE
avoid sun as variable name in test/bio_addr_test.c

### DIFF
--- a/test/bio_addr_test.c
+++ b/test/bio_addr_test.c
@@ -31,7 +31,7 @@ static BIO_ADDR *make_dummy_addr(int family)
         struct sockaddr_in6 sin6;
 #endif
 #ifndef OPENSSL_NO_UNIX_SOCK
-        struct sockaddr_un sun;
+        struct sockaddr_un sunaddr;
 #endif
     } sa;
     void *where;
@@ -51,9 +51,9 @@ static BIO_ADDR *make_dummy_addr(int family)
 #endif
 #ifndef OPENSSL_NO_UNIX_SOCK
     case AF_UNIX:
-        where = &(sa.sun.sun_path);
+        where = &(sa.sunaddr.sun_path);
         /* BIO_ADDR_rawmake needs an extra byte for a NUL-terminator*/
-        wherelen = sizeof(sa.sun.sun_path) - 1;
+        wherelen = sizeof(sa.sunaddr.sun_path) - 1;
         break;
 #endif
     default:


### PR DESCRIPTION
This change fixes a build failure on Solaris 11.4 (with either GCC or Oracle Developer Studio). On Solaris `sun` is an implicit define that collides with the variable name.