### PR TITLE
Fix coverity alert on use of uninitialised data (take 2)

### DIFF
--- a/providers/implementations/digests/blake2_prov.c
+++ b/providers/implementations/digests/blake2_prov.c
@@ -23,8 +23,11 @@ static int ossl_blake2s256_init(void *ctx)
 static int ossl_blake2b512_init(void *ctx)
 {
     struct blake2b_md_data_st *mdctx = ctx;
+    uint8_t digest_length = mdctx->params.digest_length;
 
     ossl_blake2b_param_init(&mdctx->params);
+    if (digest_length != 0)
+        mdctx->params.digest_length = digest_length;
     return ossl_blake2b_init(&mdctx->ctx, &mdctx->params);
 }
 

--- a/providers/implementations/digests/blake2b_prov.c
+++ b/providers/implementations/digests/blake2b_prov.c
@@ -121,8 +121,7 @@ static void blake2b_init_param(BLAKE2B_CTX *S, const BLAKE2B_PARAM *P)
 /* Initialize the parameter block with default values */
 void ossl_blake2b_param_init(BLAKE2B_PARAM *P)
 {
-    if (P->digest_length == 0)
-        P->digest_length = BLAKE2B_DIGEST_LENGTH;
+    P->digest_length = BLAKE2B_DIGEST_LENGTH;
     P->key_length    = 0;
     P->fanout        = 1;
     P->depth         = 1;


### PR DESCRIPTION
The function `ossl_blake2b_param_init` should initialise only, and not read the data it is initialising

This is an alternative fix to #22103.