### PR TITLE
Windows CI: Continue on error during cpuinfo

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,6 +54,7 @@ jobs:
         target: _build/coreinfo/
     - name: get cpu info
       working-directory: _build
+      continue-on-error: true
       run: |
         7z.exe x coreinfo/Coreinfo.zip
         ./Coreinfo64.exe -accepteula -f
@@ -98,6 +99,7 @@ jobs:
         target: _build/coreinfo/
     - name: get cpu info
       working-directory: _build
+      continue-on-error: true
       run: |
         7z.exe x coreinfo/Coreinfo.zip
         ./Coreinfo64.exe -accepteula -f
@@ -135,6 +137,7 @@ jobs:
         target: _build/coreinfo/
     - name: get cpu info
       working-directory: _build
+      continue-on-error: true
       run: |
         7z.exe x coreinfo/Coreinfo.zip
         ./Coreinfo64.exe -accepteula -f

--- a/.github/workflows/windows_comp.yml
+++ b/.github/workflows/windows_comp.yml
@@ -7,13 +7,13 @@
 
 name: Windows Compression GitHub CI
 
-on:
-  pull_request:
-    paths:
-      - 'crypto/comp/*.c'
-  push:
-    paths:
-      - '**.c'
+on: [pull_request]
+#  pull_request:
+#    paths:
+#      - 'crypto/comp/*.c'
+#  push:
+#    paths:
+#      - '**.c'
 
 permissions:
   contents: read

--- a/.github/workflows/windows_comp.yml
+++ b/.github/workflows/windows_comp.yml
@@ -48,6 +48,7 @@ jobs:
         target: _build/coreinfo/
     - name: get cpu info
       working-directory: _build
+      continue-on-error: true
       run: |
         7z.exe x coreinfo/Coreinfo.zip
         ./Coreinfo64.exe -accepteula -f
@@ -86,6 +87,7 @@ jobs:
         target: _build/coreinfo/
     - name: get cpu info
       working-directory: _build
+      continue-on-error: true
       run: |
         7z.exe x coreinfo/Coreinfo.zip
         ./Coreinfo64.exe -accepteula -f


### PR DESCRIPTION
We recently see errors during the cpuinfo commands on windows runners. This would allow some further investigation.
