### PR TITLE
QUIC: Test connection with large client and server cert chains

### DIFF
--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -26,7 +26,7 @@
  */
 
 #define INIT_DCID_LEN           8
-#define INIT_CRYPTO_BUF_LEN     8192
+#define INIT_CRYPTO_BUF_LEN     65536
 #define INIT_APP_BUF_LEN        8192
 
 /*

--- a/test/helpers/ssltestlib.h
+++ b/test/helpers/ssltestlib.h
@@ -68,4 +68,8 @@ DEFINE_STACK_OF(MEMPACKET)
 
 SSL_SESSION *create_a_psk(SSL *ssl, size_t mdsize);
 
+/* Add cert from `cert_file` multiple times to create large extra cert chain */
+int ssl_ctx_add_large_cert_chain(OSSL_LIB_CTX *libctx, SSL_CTX *sctx,
+                                 const char *cert_file);
+
 #endif /* OSSL_TEST_SSLTESTLIB_H */

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -1230,6 +1230,12 @@ static int test_client_auth(int idx)
                                              &clientquic, NULL, NULL)))
         goto err;
 
+    if (idx > 1) {
+        if (!TEST_true(ssl_ctx_add_large_cert_chain(libctx, cctx, ccert))
+            || !TEST_true(ssl_ctx_add_large_cert_chain(libctx, sctx, cert)))
+            goto err;
+    }
+
     if (idx == 0) {
         if (!TEST_false(qtest_create_quic_connection(qtserv, clientquic)))
             goto err;
@@ -1583,7 +1589,7 @@ int setup_tests(void)
     ADD_TEST(test_multiple_dgrams);
     ADD_ALL_TESTS(test_non_io_retry, 2);
     ADD_TEST(test_quic_psk);
-    ADD_ALL_TESTS(test_client_auth, 2);
+    ADD_ALL_TESTS(test_client_auth, 3);
     ADD_ALL_TESTS(test_alpn, 2);
     ADD_ALL_TESTS(test_noisy_dgram, 2);
 


### PR DESCRIPTION
I had to raise the initial crypto buffer size, but that is probably not the right fix.
Please suggest how to handle this.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
