### PR TITLE
crypto/{CMS,PKCS7,OCSP,TS,X509}: constify cert list parameters; tidy up app code

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -653,8 +653,9 @@ int cms_main(int argc, char **argv)
                 goto opthelp;
             }
             if (key_param == NULL || key_param->idx != keyidx) {
-                cms_key_param *nparam;
-                nparam = app_malloc(sizeof(*nparam), "key param buffer");
+                cms_key_param *nparam =
+                    app_malloc(sizeof(*nparam), "key param buffer");
+
                 if ((nparam->param = sk_OPENSSL_STRING_new_null()) == NULL) {
                     OPENSSL_free(nparam);
                     goto end;
@@ -927,8 +928,8 @@ int cms_main(int argc, char **argv)
             }
         }
         if (certsoutfile != NULL) {
-            STACK_OF(X509) *allcerts;
-            allcerts = CMS_get1_certs(cms);
+            STACK_OF(X509) *allcerts = CMS_get1_certs(cms);
+
             if (!save_certs(certsoutfile, allcerts)) {
                 BIO_printf(bio_err,
                            "Error writing certs to %s\n", certsoutfile);
@@ -976,6 +977,7 @@ int cms_main(int argc, char **argv)
         cms = CMS_compress(in, -1, flags);
     } else if (operation == SMIME_ENCRYPT) {
         int i;
+
         flags |= CMS_PARTIAL;
         cms = CMS_encrypt_ex(NULL, in, cipher, flags, libctx, app_get0_propq());
         if (cms == NULL)
@@ -984,7 +986,7 @@ int cms_main(int argc, char **argv)
             CMS_RecipientInfo *ri;
             cms_key_param *kparam;
             int tflags = flags | CMS_KEY_PARAM;
-            /* This flag enforces allocating the EVP_PKEY_CTX for the recipient here */
+            /* This flag enforces allocating EVP_PKEY_CTX for the recipient */
             EVP_PKEY_CTX *pctx;
             X509 *x = sk_X509_value(encerts, i);
             int res;
@@ -1012,8 +1014,8 @@ int cms_main(int argc, char **argv)
 
             if (CMS_RecipientInfo_type(ri) == CMS_RECIPINFO_AGREE
                     && wrap_cipher != NULL) {
-                EVP_CIPHER_CTX *wctx;
-                wctx = CMS_RecipientInfo_kari_get0_ctx(ri);
+                EVP_CIPHER_CTX *wctx = CMS_RecipientInfo_kari_get0_ctx(ri);
+
                 if (EVP_EncryptInit_ex(wctx, wrap_cipher, NULL, NULL, NULL) != 1)
                     goto end;
             }
@@ -1044,14 +1046,14 @@ int cms_main(int argc, char **argv)
                 goto end;
         }
     } else if (operation == SMIME_ENCRYPTED_ENCRYPT) {
-        cms = CMS_EncryptedData_encrypt_ex(in, cipher, secret_key,
-                                           secret_keylen, flags, libctx, app_get0_propq());
+        cms = CMS_EncryptedData_encrypt_ex(in, cipher, secret_key, secret_keylen,
+                                           flags, libctx, app_get0_propq());
 
     } else if (operation == SMIME_SIGN_RECEIPT) {
         CMS_ContentInfo *srcms = NULL;
-        STACK_OF(CMS_SignerInfo) *sis;
         CMS_SignerInfo *si;
-        sis = CMS_get0_SignerInfos(cms);
+        STACK_OF(CMS_SignerInfo) *sis = CMS_get0_SignerInfos(cms);
+
         if (sis == NULL)
             goto end;
         si = sk_CMS_SignerInfo_value(sis, 0);
@@ -1062,6 +1064,7 @@ int cms_main(int argc, char **argv)
         cms = srcms;
     } else if (operation & SMIME_SIGNERS) {
         int i;
+
         /*
          * If detached data content and not signing pre-computed digest, we
          * enable streaming if S/MIME output format.
@@ -1073,7 +1076,8 @@ int cms_main(int argc, char **argv)
                     flags |= CMS_STREAM;
             }
             flags |= CMS_PARTIAL;
-            cms = CMS_sign_ex(NULL, NULL, other, in, flags, libctx, app_get0_propq());
+            cms = CMS_sign_ex(NULL, NULL, other, in, flags,
+                              libctx, app_get0_propq());
             if (cms == NULL)
                 goto end;
             if (econtent_type != NULL)
@@ -1092,6 +1096,7 @@ int cms_main(int argc, char **argv)
             CMS_SignerInfo *si;
             cms_key_param *kparam;
             int tflags = flags;
+
             signerfile = sk_OPENSSL_STRING_value(sksigners, i);
             keyfile = sk_OPENSSL_STRING_value(skkeys, i);
 
@@ -1116,8 +1121,8 @@ int cms_main(int argc, char **argv)
             if (si == NULL)
                 goto end;
             if (kparam != NULL) {
-                EVP_PKEY_CTX *pctx;
-                pctx = CMS_SignerInfo_get0_pkey_ctx(si);
+                EVP_PKEY_CTX *pctx = CMS_SignerInfo_get0_pkey_ctx(si);
+
                 if (!cms_set_pkey_param(pctx, kparam->param))
                     goto end;
             }
@@ -1230,6 +1235,7 @@ int cms_main(int argc, char **argv)
         if (noout) {
             if (print) {
                 ASN1_PCTX *pctx = NULL;
+
                 if (get_nameopt() != XN_FLAG_ONELINE) {
                     pctx = ASN1_PCTX_new();
                     if (pctx != NULL) { /* Print anyway if malloc failed */
@@ -1283,6 +1289,7 @@ int cms_main(int argc, char **argv)
     sk_OPENSSL_STRING_free(rr_from);
     for (key_param = key_first; key_param;) {
         cms_key_param *tparam;
+
         sk_OPENSSL_STRING_free(key_param->param);
         tparam = key_param->next;
         OPENSSL_free(key_param);
@@ -1313,6 +1320,7 @@ static int save_certs(char *signerfile, STACK_OF(X509) *signers)
 {
     int i;
     BIO *tmp;
+
     if (signerfile == NULL)
         return 1;
     tmp = BIO_new_file(signerfile, "w");
@@ -1364,14 +1372,14 @@ static void gnames_stack_print(STACK_OF(GENERAL_NAMES) *gns)
 
 static void receipt_request_print(CMS_ContentInfo *cms)
 {
-    STACK_OF(CMS_SignerInfo) *sis;
     CMS_SignerInfo *si;
     CMS_ReceiptRequest *rr;
     int allorfirst;
     STACK_OF(GENERAL_NAMES) *rto, *rlist;
     ASN1_STRING *scid;
     int i, rv;
-    sis = CMS_get0_SignerInfos(cms);
+    STACK_OF(CMS_SignerInfo) *sis = CMS_get0_SignerInfos(cms);
+
     for (i = 0; i < sk_CMS_SignerInfo_num(sis); i++) {
         si = sk_CMS_SignerInfo_value(sis, i);
         rv = CMS_get1_ReceiptRequest(si, &rr);
@@ -1384,6 +1392,7 @@ static void receipt_request_print(CMS_ContentInfo *cms)
         } else {
             const char *id;
             int idlen;
+
             CMS_ReceiptRequest_get0_values(rr, &scid, &allorfirst,
                                            &rlist, &rto);
             BIO_puts(bio_err, "  Signed Content ID:\n");
@@ -1411,14 +1420,15 @@ static void receipt_request_print(CMS_ContentInfo *cms)
 static STACK_OF(GENERAL_NAMES) *make_names_stack(STACK_OF(OPENSSL_STRING) *ns)
 {
     int i;
-    STACK_OF(GENERAL_NAMES) *ret;
     GENERAL_NAMES *gens = NULL;
     GENERAL_NAME *gen = NULL;
-    ret = sk_GENERAL_NAMES_new_null();
+    STACK_OF(GENERAL_NAMES) *ret = sk_GENERAL_NAMES_new_null();
+
     if (ret == NULL)
         goto err;
     for (i = 0; i < sk_OPENSSL_STRING_num(ns); i++) {
         char *str = sk_OPENSSL_STRING_value(ns, i);
+
         gen = a2i_GENERAL_NAME(NULL, NULL, NULL, GEN_EMAIL, str, 0);
         if (gen == NULL)
             goto err;
@@ -1470,6 +1480,7 @@ static int cms_set_pkey_param(EVP_PKEY_CTX *pctx,
 {
     char *keyopt;
     int i;
+
     if (sk_OPENSSL_STRING_num(param) <= 0)
         return 1;
     for (i = 0; i < sk_OPENSSL_STRING_num(param); i++) {

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -400,14 +400,13 @@ int smime_main(int argc, char **argv)
             goto opthelp;
     }
     if (!opt_cipher_any(ciphername, &cipher))
-            goto opthelp;
+        goto opthelp;
     if (!(operation & SMIME_SIGNERS) && (skkeys != NULL || sksigners != NULL)) {
         BIO_puts(bio_err, "Multiple signers or keys not allowed\n");
         goto opthelp;
     }
     if (!operation) {
-        BIO_puts(bio_err,
-                "No operation (-encrypt|-sign|...) specified\n");
+        BIO_puts(bio_err, "No operation (-encrypt|-sign|...) specified\n");
         goto opthelp;
     }
 
@@ -490,11 +489,10 @@ int smime_main(int argc, char **argv)
         }
     }
 
-    if (certfile != NULL) {
-        if (!load_certs(certfile, 0, &other, NULL, "certificates")) {
-            ERR_print_errors(bio_err);
-            goto end;
-        }
+    if (certfile != NULL
+        && !load_certs(certfile, 0, &other, NULL, "certificates")) {
+        ERR_print_errors(bio_err);
+        goto end;
     }
 
     if (recipfile != NULL && (operation == SMIME_DECRYPT)) {
@@ -575,9 +573,11 @@ int smime_main(int argc, char **argv)
     if (operation == SMIME_ENCRYPT) {
         if (indef)
             flags |= PKCS7_STREAM;
-        p7 = PKCS7_encrypt_ex(encerts, in, cipher, flags, libctx, app_get0_propq());
+        p7 = PKCS7_encrypt_ex(encerts, in, cipher, flags,
+                              libctx, app_get0_propq());
     } else if (operation & SMIME_SIGNERS) {
         int i;
+
         /*
          * If detached data content we only enable streaming if S/MIME output
          * format.
@@ -590,15 +590,13 @@ int smime_main(int argc, char **argv)
                 flags |= PKCS7_STREAM;
             }
             flags |= PKCS7_PARTIAL;
-            p7 = PKCS7_sign_ex(NULL, NULL, other, in, flags, libctx, app_get0_propq());
+            p7 = PKCS7_sign_ex(NULL, NULL, other, in, flags,
+                               libctx, app_get0_propq());
             if (p7 == NULL)
                 goto end;
-            if (flags & PKCS7_NOCERTS) {
-                for (i = 0; i < sk_X509_num(other); i++) {
-                    X509 *x = sk_X509_value(other, i);
-                    PKCS7_add_certificate(p7, x);
-                }
-            }
+            if ((flags & PKCS7_NOCERTS) != 0)
+                for (i = 0; i < sk_X509_num(other); i++)
+                    PKCS7_add_certificate(p7, sk_X509_value(other, i));
         } else {
             flags |= PKCS7_REUSE_DIGEST;
         }
@@ -639,9 +637,10 @@ int smime_main(int argc, char **argv)
         }
     } else if (operation == SMIME_VERIFY) {
         STACK_OF(X509) *signers;
-        if (PKCS7_verify(p7, other, store, indata, out, flags))
+
+        if (PKCS7_verify(p7, other, store, indata, out, flags)) {
             BIO_printf(bio_err, "Verification successful\n");
-        else {
+        } else {
             BIO_printf(bio_err, "Verification failure\n");
             goto end;
         }

--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -515,7 +515,7 @@ int OSSL_CMP_certConf_cb(OSSL_CMP_CTX *ctx, X509 *cert, int fail_info,
         if (X509_verify_cert(csc) <= 0)
             goto err;
 
-        if (!ossl_x509_add_certs_new(&chain,  X509_STORE_CTX_get0_chain(csc),
+        if (!ossl_x509_add_certs_new(&chain, X509_STORE_CTX_get0_chain(csc),
                                      X509_ADD_FLAG_UP_REF | X509_ADD_FLAG_NO_DUP
                                      | X509_ADD_FLAG_NO_SS)) {
             sk_X509_free(chain);

--- a/crypto/cmp/cmp_local.h
+++ b/crypto/cmp/cmp_local.h
@@ -898,7 +898,8 @@ OSSL_CMP_MSG *ossl_cmp_certreq_new(OSSL_CMP_CTX *ctx, int bodytype,
 OSSL_CMP_MSG *ossl_cmp_certrep_new(OSSL_CMP_CTX *ctx, int bodytype,
                                    int certReqId, const OSSL_CMP_PKISI *si,
                                    X509 *cert, const X509 *encryption_recip,
-                                   STACK_OF(X509) *chain, STACK_OF(X509) *caPubs,
+                                   const STACK_OF(X509) *chain,
+                                   STACK_OF(X509) *caPubs,
                                    int unprotectedErrors);
 OSSL_CMP_MSG *ossl_cmp_rr_new(OSSL_CMP_CTX *ctx);
 OSSL_CMP_MSG *ossl_cmp_rp_new(OSSL_CMP_CTX *ctx, const OSSL_CMP_PKISI *si,

--- a/crypto/cmp/cmp_msg.c
+++ b/crypto/cmp/cmp_msg.c
@@ -444,7 +444,8 @@ OSSL_CMP_MSG *ossl_cmp_certreq_new(OSSL_CMP_CTX *ctx, int type,
 OSSL_CMP_MSG *ossl_cmp_certrep_new(OSSL_CMP_CTX *ctx, int bodytype,
                                    int certReqId, const OSSL_CMP_PKISI *si,
                                    X509 *cert, const X509 *encryption_recip,
-                                   STACK_OF(X509) *chain, STACK_OF(X509) *caPubs,
+                                   const STACK_OF(X509) *chain,
+                                   STACK_OF(X509) *caPubs,
                                    int unprotectedErrors)
 {
     OSSL_CMP_MSG *msg = NULL;

--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -633,7 +633,7 @@ int CMS_SignerInfo_cert_cmp(CMS_SignerInfo *si, X509 *cert)
     return ossl_cms_SignerIdentifier_cert_cmp(si->sid, cert);
 }
 
-int CMS_set1_signers_certs(CMS_ContentInfo *cms, STACK_OF(X509) *scerts,
+int CMS_set1_signers_certs(CMS_ContentInfo *cms, const STACK_OF(X509) *scerts,
                            unsigned int flags)
 {
     CMS_SignedData *sd;
@@ -1052,8 +1052,9 @@ int CMS_SignerInfo_verify_content(CMS_SignerInfo *si, BIO *chain)
 }
 
 BIO *CMS_SignedData_verify(CMS_SignedData *sd, BIO *detached_data,
-                           STACK_OF(X509) *scerts, X509_STORE *store,
-                           STACK_OF(X509) *extra, STACK_OF(X509_CRL) *crls,
+                           const STACK_OF(X509) *scerts, X509_STORE *store,
+                           const STACK_OF(X509) *extra,
+                           const STACK_OF(X509_CRL) *crls,
                            unsigned int flags,
                            OSSL_LIB_CTX *libctx, const char *propq)
 {

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -302,7 +302,7 @@ static int cms_signerinfo_verify_cert(CMS_SignerInfo *si,
 }
 
 /* This strongly overlaps with PKCS7_verify() */
-int CMS_verify(CMS_ContentInfo *cms, STACK_OF(X509) *certs,
+int CMS_verify(CMS_ContentInfo *cms, const STACK_OF(X509) *certs,
                X509_STORE *store, BIO *dcont, BIO *out, unsigned int flags)
 {
     CMS_SignerInfo *si;
@@ -488,7 +488,7 @@ int CMS_verify(CMS_ContentInfo *cms, STACK_OF(X509) *certs,
 }
 
 int CMS_verify_receipt(CMS_ContentInfo *rcms, CMS_ContentInfo *ocms,
-                       STACK_OF(X509) *certs,
+                       const STACK_OF(X509) *certs,
                        X509_STORE *store, unsigned int flags)
 {
     int r;
@@ -501,7 +501,7 @@ int CMS_verify_receipt(CMS_ContentInfo *rcms, CMS_ContentInfo *ocms,
 }
 
 CMS_ContentInfo *CMS_sign_ex(X509 *signcert, EVP_PKEY *pkey,
-                             STACK_OF(X509) *certs, BIO *data,
+                             const STACK_OF(X509) *certs, BIO *data,
                              unsigned int flags, OSSL_LIB_CTX *libctx,
                              const char *propq)
 {
@@ -548,7 +548,8 @@ CMS_ContentInfo *CMS_sign_ex(X509 *signcert, EVP_PKEY *pkey,
     return NULL;
 }
 
-CMS_ContentInfo *CMS_sign(X509 *signcert, EVP_PKEY *pkey, STACK_OF(X509) *certs,
+CMS_ContentInfo *CMS_sign(X509 *signcert, EVP_PKEY *pkey,
+                          const STACK_OF(X509) *certs,
                           BIO *data, unsigned int flags)
 {
     return CMS_sign_ex(signcert, pkey, certs, data, flags, NULL, NULL);
@@ -556,7 +557,8 @@ CMS_ContentInfo *CMS_sign(X509 *signcert, EVP_PKEY *pkey, STACK_OF(X509) *certs,
 
 CMS_ContentInfo *CMS_sign_receipt(CMS_SignerInfo *si,
                                   X509 *signcert, EVP_PKEY *pkey,
-                                  STACK_OF(X509) *certs, unsigned int flags)
+                                  const STACK_OF(X509) *certs,
+                                  unsigned int flags)
 {
     CMS_SignerInfo *rct_si;
     CMS_ContentInfo *cms = NULL;
@@ -626,7 +628,7 @@ CMS_ContentInfo *CMS_sign_receipt(CMS_SignerInfo *si,
 
 }
 
-CMS_ContentInfo *CMS_encrypt_ex(STACK_OF(X509) *certs, BIO *data,
+CMS_ContentInfo *CMS_encrypt_ex(const STACK_OF(X509) *certs, BIO *data,
                                 const EVP_CIPHER *cipher, unsigned int flags,
                                 OSSL_LIB_CTX *libctx, const char *propq)
 {
@@ -664,7 +666,7 @@ CMS_ContentInfo *CMS_encrypt_ex(STACK_OF(X509) *certs, BIO *data,
     return NULL;
 }
 
-CMS_ContentInfo *CMS_encrypt(STACK_OF(X509) *certs, BIO *data,
+CMS_ContentInfo *CMS_encrypt(const STACK_OF(X509) *certs, BIO *data,
                              const EVP_CIPHER *cipher, unsigned int flags)
 {
     return CMS_encrypt_ex(certs, data, cipher, flags, NULL, NULL);

--- a/crypto/ocsp/ocsp_cl.c
+++ b/crypto/ocsp/ocsp_cl.c
@@ -81,7 +81,7 @@ int OCSP_request_sign(OCSP_REQUEST *req,
                       X509 *signer,
                       EVP_PKEY *key,
                       const EVP_MD *dgst,
-                      STACK_OF(X509) *certs, unsigned long flags)
+                      const STACK_OF(X509) *certs, unsigned long flags)
 {
     if (!OCSP_request_set1_name(req, X509_get_subject_name(signer)))
         goto err;

--- a/crypto/ocsp/ocsp_srv.c
+++ b/crypto/ocsp/ocsp_srv.c
@@ -166,7 +166,7 @@ int OCSP_basic_add1_cert(OCSP_BASICRESP *resp, X509 *cert)
  */
 int OCSP_basic_sign_ctx(OCSP_BASICRESP *brsp,
                     X509 *signer, EVP_MD_CTX *ctx,
-                    STACK_OF(X509) *certs, unsigned long flags)
+                    const STACK_OF(X509) *certs, unsigned long flags)
 {
     OCSP_RESPID *rid;
     EVP_PKEY *pkey;
@@ -214,7 +214,7 @@ int OCSP_basic_sign_ctx(OCSP_BASICRESP *brsp,
 
 int OCSP_basic_sign(OCSP_BASICRESP *brsp,
                     X509 *signer, EVP_PKEY *key, const EVP_MD *dgst,
-                    STACK_OF(X509) *certs, unsigned long flags)
+                    const STACK_OF(X509) *certs, unsigned long flags)
 {
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
     EVP_PKEY_CTX *pkctx = NULL;

--- a/crypto/ocsp/ocsp_vfy.c
+++ b/crypto/ocsp/ocsp_vfy.c
@@ -14,8 +14,8 @@
 #include "ocsp_local.h"
 
 static int ocsp_find_signer(X509 **psigner, OCSP_BASICRESP *bs,
-                            STACK_OF(X509) *certs, unsigned long flags);
-static X509 *ocsp_find_signer_sk(STACK_OF(X509) *certs, OCSP_RESPID *id);
+                            const STACK_OF(X509) *certs, unsigned long flags);
+static X509 *ocsp_find_signer_sk(const STACK_OF(X509) *certs, OCSP_RESPID *id);
 static int ocsp_check_issuer(OCSP_BASICRESP *bs, STACK_OF(X509) *chain);
 static int ocsp_check_ids(STACK_OF(OCSP_SINGLERESP) *sresp,
                           OCSP_CERTID **ret);
@@ -23,13 +23,14 @@ static int ocsp_match_issuerid(X509 *cert, OCSP_CERTID *cid,
                                STACK_OF(OCSP_SINGLERESP) *sresp);
 static int ocsp_check_delegated(X509 *x);
 static int ocsp_req_find_signer(X509 **psigner, OCSP_REQUEST *req,
-                                const X509_NAME *nm, STACK_OF(X509) *certs,
+                                const X509_NAME *nm, const STACK_OF(X509) *certs,
                                 unsigned long flags);
 
 /* Returns 1 on success, 0 on failure, or -1 on fatal error */
 static int ocsp_verify_signer(X509 *signer, int response,
                               X509_STORE *st, unsigned long flags,
-                              STACK_OF(X509) *untrusted, STACK_OF(X509) **chain)
+                              STACK_OF(X509) *untrusted,
+                              STACK_OF(X509) **chain)
 {
     X509_STORE_CTX *ctx = X509_STORE_CTX_new();
     X509_VERIFY_PARAM *vp;
@@ -95,7 +96,7 @@ static int ocsp_verify(OCSP_REQUEST *req, OCSP_BASICRESP *bs,
 }
 
 /* Verify a basic response message */
-int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs,
+int OCSP_basic_verify(OCSP_BASICRESP *bs, const STACK_OF(X509) *certs,
                       X509_STORE *st, unsigned long flags)
 {
     X509 *signer, *x;
@@ -160,13 +161,13 @@ int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs,
 }
 
 int OCSP_resp_get0_signer(OCSP_BASICRESP *bs, X509 **signer,
-                          STACK_OF(X509) *extra_certs)
+                          const STACK_OF(X509) *extra_certs)
 {
     return ocsp_find_signer(signer, bs, extra_certs, 0) > 0;
 }
 
 static int ocsp_find_signer(X509 **psigner, OCSP_BASICRESP *bs,
-                            STACK_OF(X509) *certs, unsigned long flags)
+                            const STACK_OF(X509) *certs, unsigned long flags)
 {
     X509 *signer;
     OCSP_RESPID *rid = &bs->tbsResponseData.responderId;
@@ -186,7 +187,7 @@ static int ocsp_find_signer(X509 **psigner, OCSP_BASICRESP *bs,
     return 0;
 }
 
-static X509 *ocsp_find_signer_sk(STACK_OF(X509) *certs, OCSP_RESPID *id)
+static X509 *ocsp_find_signer_sk(const STACK_OF(X509) *certs, OCSP_RESPID *id)
 {
     int i, r;
     unsigned char tmphash[SHA_DIGEST_LENGTH], *keyhash;
@@ -382,7 +383,7 @@ static int ocsp_check_delegated(X509 *x)
  * Just find the signer's certificate and verify it against a given trust value.
  * Returns 1 on success, 0 on failure and on fatal error.
  */
-int OCSP_request_verify(OCSP_REQUEST *req, STACK_OF(X509) *certs,
+int OCSP_request_verify(OCSP_REQUEST *req, const STACK_OF(X509) *certs,
                         X509_STORE *store, unsigned long flags)
 {
     X509 *signer;
@@ -419,8 +420,8 @@ int OCSP_request_verify(OCSP_REQUEST *req, STACK_OF(X509) *certs,
 }
 
 static int ocsp_req_find_signer(X509 **psigner, OCSP_REQUEST *req,
-                                const X509_NAME *nm, STACK_OF(X509) *certs,
-                                unsigned long flags)
+                                const X509_NAME *nm, const
+                                STACK_OF(X509) *certs, unsigned long flags)
 {
     X509 *signer;
 

--- a/crypto/pkcs7/pk7_smime.c
+++ b/crypto/pkcs7/pk7_smime.c
@@ -20,9 +20,9 @@
 
 static int pkcs7_copy_existing_digest(PKCS7 *p7, PKCS7_SIGNER_INFO *si);
 
-PKCS7 *PKCS7_sign_ex(X509 *signcert, EVP_PKEY *pkey, STACK_OF(X509) *certs,
-                     BIO *data, int flags, OSSL_LIB_CTX *libctx,
-                     const char *propq)
+PKCS7 *PKCS7_sign_ex(X509 *signcert, EVP_PKEY *pkey,
+                     const STACK_OF(X509) *certs, BIO *data, int flags,
+                     OSSL_LIB_CTX *libctx, const char *propq)
 {
     PKCS7 *p7;
     int i;
@@ -64,7 +64,7 @@ PKCS7 *PKCS7_sign_ex(X509 *signcert, EVP_PKEY *pkey, STACK_OF(X509) *certs,
     return NULL;
 }
 
-PKCS7 *PKCS7_sign(X509 *signcert, EVP_PKEY *pkey, STACK_OF(X509) *certs,
+PKCS7 *PKCS7_sign(X509 *signcert, EVP_PKEY *pkey, const STACK_OF(X509) *certs,
                   BIO *data, int flags)
 {
     return PKCS7_sign_ex(signcert, pkey, certs, data, flags, NULL, NULL);
@@ -211,7 +211,7 @@ static int pkcs7_copy_existing_digest(PKCS7 *p7, PKCS7_SIGNER_INFO *si)
 }
 
 /* This strongly overlaps with CMS_verify(), partly with PKCS7_dataVerify() */
-int PKCS7_verify(PKCS7 *p7, STACK_OF(X509) *certs, X509_STORE *store,
+int PKCS7_verify(PKCS7 *p7, const STACK_OF(X509) *certs, X509_STORE *store,
                  BIO *indata, BIO *out, int flags)
 {
     STACK_OF(X509) *signers;
@@ -357,7 +357,7 @@ int PKCS7_verify(PKCS7 *p7, STACK_OF(X509) *certs, X509_STORE *store,
     return ret;
 }
 
-STACK_OF(X509) *PKCS7_get0_signers(PKCS7 *p7, STACK_OF(X509) *certs,
+STACK_OF(X509) *PKCS7_get0_signers(PKCS7 *p7, const STACK_OF(X509) *certs,
                                    int flags)
 {
     STACK_OF(X509) *signers;
@@ -420,7 +420,7 @@ STACK_OF(X509) *PKCS7_get0_signers(PKCS7 *p7, STACK_OF(X509) *certs,
 
 /* Build a complete PKCS#7 enveloped data */
 
-PKCS7 *PKCS7_encrypt_ex(STACK_OF(X509) *certs, BIO *in,
+PKCS7 *PKCS7_encrypt_ex(const STACK_OF(X509) *certs, BIO *in,
                         const EVP_CIPHER *cipher, int flags,
                         OSSL_LIB_CTX *libctx, const char *propq)
 {
@@ -463,8 +463,8 @@ PKCS7 *PKCS7_encrypt_ex(STACK_OF(X509) *certs, BIO *in,
 
 }
 
-PKCS7 *PKCS7_encrypt(STACK_OF(X509) *certs, BIO *in, const EVP_CIPHER *cipher,
-                     int flags)
+PKCS7 *PKCS7_encrypt(const STACK_OF(X509) *certs, BIO *in,
+                     const EVP_CIPHER *cipher, int flags)
 {
     return PKCS7_encrypt_ex(certs, in, cipher, flags, NULL, NULL);
 }

--- a/crypto/ts/ts_rsp_verify.c
+++ b/crypto/ts/ts_rsp_verify.c
@@ -85,7 +85,7 @@ static struct {
  *      - Verify the signature value.
  *      - Returns the signer certificate in 'signer', if 'signer' is not NULL.
  */
-int TS_RESP_verify_signature(PKCS7 *token, STACK_OF(X509) *certs,
+int TS_RESP_verify_signature(PKCS7 *token, const STACK_OF(X509) *certs,
                              X509_STORE *store, X509 **signer_out)
 {
     STACK_OF(PKCS7_SIGNER_INFO) *sinfos = NULL;

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -224,7 +224,7 @@ int X509_add_cert(STACK_OF(X509) *sk, X509 *cert, int flags)
     return 1;
 }
 
-int X509_add_certs(STACK_OF(X509) *sk, STACK_OF(X509) *certs, int flags)
+int X509_add_certs(STACK_OF(X509) *sk, const STACK_OF(X509) *certs, int flags)
 /* compiler would allow 'const' for the certs, yet they may get up-ref'ed */
 {
     if (sk == NULL) {
@@ -234,7 +234,7 @@ int X509_add_certs(STACK_OF(X509) *sk, STACK_OF(X509) *certs, int flags)
     return ossl_x509_add_certs_new(&sk, certs, flags);
 }
 
-int ossl_x509_add_certs_new(STACK_OF(X509) **p_sk, STACK_OF(X509) *certs,
+int ossl_x509_add_certs_new(STACK_OF(X509) **p_sk, const STACK_OF(X509) *certs,
                             int flags)
 /* compiler would allow 'const' for the certs, yet they may get up-ref'ed */
 {
@@ -345,7 +345,7 @@ unsigned long X509_NAME_hash_old(const X509_NAME *x)
 #endif
 
 /* Search a stack of X509 for a match */
-X509 *X509_find_by_issuer_and_serial(STACK_OF(X509) *sk, const X509_NAME *name,
+X509 *X509_find_by_issuer_and_serial(const STACK_OF(X509) *sk, const X509_NAME *name,
                                      const ASN1_INTEGER *serial)
 {
     int i;
@@ -365,7 +365,7 @@ X509 *X509_find_by_issuer_and_serial(STACK_OF(X509) *sk, const X509_NAME *name,
     return NULL;
 }
 
-X509 *X509_find_by_subject(STACK_OF(X509) *sk, const X509_NAME *name)
+X509 *X509_find_by_subject(const STACK_OF(X509) *sk, const X509_NAME *name)
 {
     X509 *x509;
     int i;

--- a/doc/man3/CMS_encrypt.pod
+++ b/doc/man3/CMS_encrypt.pod
@@ -8,10 +8,10 @@ CMS_encrypt_ex, CMS_encrypt - create a CMS envelopedData structure
 
  #include <openssl/cms.h>
 
- CMS_ContentInfo *CMS_encrypt_ex(STACK_OF(X509) *certs, BIO *in,
+ CMS_ContentInfo *CMS_encrypt_ex(const STACK_OF(X509) *certs, BIO *in,
                                  const EVP_CIPHER *cipher, unsigned int flags,
                                  OSSL_LIB_CTX *libctx, const char *propq);
- CMS_ContentInfo *CMS_encrypt(STACK_OF(X509) *certs, BIO *in,
+ CMS_ContentInfo *CMS_encrypt(const STACK_OF(X509) *certs, BIO *in,
                               const EVP_CIPHER *cipher, unsigned int flags);
 
 =head1 DESCRIPTION

--- a/doc/man3/CMS_sign_receipt.pod
+++ b/doc/man3/CMS_sign_receipt.pod
@@ -9,7 +9,7 @@ CMS_sign_receipt - create a CMS signed receipt
  #include <openssl/cms.h>
 
  CMS_ContentInfo *CMS_sign_receipt(CMS_SignerInfo *si, X509 *signcert,
-                                   EVP_PKEY *pkey, STACK_OF(X509) *certs,
+                                   EVP_PKEY *pkey, const STACK_OF(X509) *certs,
                                    unsigned int flags);
 
 =head1 DESCRIPTION

--- a/doc/man3/CMS_verify.pod
+++ b/doc/man3/CMS_verify.pod
@@ -9,11 +9,13 @@ CMS_get0_signers - verify a CMS SignedData structure
 
  #include <openssl/cms.h>
 
- int CMS_verify(CMS_ContentInfo *cms, STACK_OF(X509) *certs, X509_STORE *store,
+ int CMS_verify(CMS_ContentInfo *cms, const STACK_OF(X509) *certs,
+                X509_STORE *store,
                 BIO *detached_data, BIO *out, unsigned int flags);
  BIO *CMS_SignedData_verify(CMS_SignedData *sd, BIO *detached_data,
-                            STACK_OF(X509) *scerts, X509_STORE *store,
-                            STACK_OF(X509) *extra, STACK_OF(X509_CRL) *crls,
+                            const STACK_OF(X509) *scerts, X509_STORE *store,
+                            const STACK_OF(X509) *extra,
+                            const STACK_OF(X509_CRL) *crls,
                             unsigned int flags,
                             OSSL_LIB_CTX *libctx, const char *propq);
 

--- a/doc/man3/CMS_verify_receipt.pod
+++ b/doc/man3/CMS_verify_receipt.pod
@@ -9,7 +9,7 @@ CMS_verify_receipt - verify a CMS signed receipt
  #include <openssl/cms.h>
 
  int CMS_verify_receipt(CMS_ContentInfo *rcms, CMS_ContentInfo *ocms,
-                        STACK_OF(X509) *certs, X509_STORE *store,
+                        const STACK_OF(X509) *certs, X509_STORE *store,
                         unsigned int flags);
 
 =head1 DESCRIPTION

--- a/doc/man3/OCSP_REQUEST_new.pod
+++ b/doc/man3/OCSP_REQUEST_new.pod
@@ -17,7 +17,7 @@ OCSP_request_onereq_get0 - OCSP request functions
 
  int OCSP_request_sign(OCSP_REQUEST *req,
                        X509 *signer, EVP_PKEY *key, const EVP_MD *dgst,
-                       STACK_OF(X509) *certs, unsigned long flags);
+                       const STACK_OF(X509) *certs, unsigned long flags);
 
  int OCSP_request_add1_cert(OCSP_REQUEST *req, X509 *cert);
 

--- a/doc/man3/OCSP_resp_find_status.pod
+++ b/doc/man3/OCSP_resp_find_status.pod
@@ -51,7 +51,7 @@ OCSP_check_validity, OCSP_basic_verify
                          ASN1_GENERALIZEDTIME *nextupd,
                          long sec, long maxsec);
 
- int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs,
+ int OCSP_basic_verify(OCSP_BASICRESP *bs, const STACK_OF(X509) *certs,
                       X509_STORE *st, unsigned long flags);
 
 =head1 DESCRIPTION

--- a/doc/man3/OCSP_response_status.pod
+++ b/doc/man3/OCSP_response_status.pod
@@ -26,10 +26,10 @@ OCSP_RESPID_match, OCSP_basic_sign, OCSP_basic_sign_ctx
  int OCSP_RESPID_match(OCSP_RESPID *respid, X509 *cert);
 
  int OCSP_basic_sign(OCSP_BASICRESP *brsp, X509 *signer, EVP_PKEY *key,
-                     const EVP_MD *dgst, STACK_OF(X509) *certs,
+                     const EVP_MD *dgst, const STACK_OF(X509) *certs,
                      unsigned long flags);
  int OCSP_basic_sign_ctx(OCSP_BASICRESP *brsp, X509 *signer, EVP_MD_CTX *ctx,
-                         STACK_OF(X509) *certs, unsigned long flags);
+                         const STACK_OF(X509) *certs, unsigned long flags);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/PKCS7_encrypt.pod
+++ b/doc/man3/PKCS7_encrypt.pod
@@ -9,11 +9,11 @@ PKCS7_encrypt_ex, PKCS7_encrypt
 
  #include <openssl/pkcs7.h>
 
- PKCS7 *PKCS7_encrypt_ex(STACK_OF(X509) *certs, BIO *in,
+ PKCS7 *PKCS7_encrypt_ex(const STACK_OF(X509) *certs, BIO *in,
                          const EVP_CIPHER *cipher, int flags,
                          OSSL_LIB_CTX *libctx, const char *propq);
- PKCS7 *PKCS7_encrypt(STACK_OF(X509) *certs, BIO *in, const EVP_CIPHER *cipher,
-                      int flags);
+ PKCS7 *PKCS7_encrypt(const STACK_OF(X509) *certs, BIO *in,
+                      const EVP_CIPHER *cipher, int flags);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/PKCS7_sign.pod
+++ b/doc/man3/PKCS7_sign.pod
@@ -9,10 +9,11 @@ PKCS7_sign_ex, PKCS7_sign
 
  #include <openssl/pkcs7.h>
 
- PKCS7 *PKCS7_sign_ex(X509 *signcert, EVP_PKEY *pkey, STACK_OF(X509) *certs,
+ PKCS7 *PKCS7_sign_ex(X509 *signcert, EVP_PKEY *pkey,
+                      const STACK_OF(X509) *certs,
                       BIO *data, int flags, OSSL_LIB_CTX *libctx,
                       const char *propq);
- PKCS7 *PKCS7_sign(X509 *signcert, EVP_PKEY *pkey, STACK_OF(X509) *certs,
+ PKCS7 *PKCS7_sign(X509 *signcert, EVP_PKEY *pkey, const STACK_OF(X509) *certs,
                    BIO *data, int flags);
 
 =head1 DESCRIPTION

--- a/doc/man3/PKCS7_verify.pod
+++ b/doc/man3/PKCS7_verify.pod
@@ -8,10 +8,11 @@ PKCS7_verify, PKCS7_get0_signers - verify a PKCS#7 signedData structure
 
  #include <openssl/pkcs7.h>
 
- int PKCS7_verify(PKCS7 *p7, STACK_OF(X509) *certs, X509_STORE *store,
+ int PKCS7_verify(PKCS7 *p7, const STACK_OF(X509) *certs, X509_STORE *store,
                   BIO *indata, BIO *out, int flags);
 
- STACK_OF(X509) *PKCS7_get0_signers(PKCS7 *p7, STACK_OF(X509) *certs, int flags);
+ STACK_OF(X509) *PKCS7_get0_signers(PKCS7 *p7, const STACK_OF(X509) *certs,
+                                    int flags);
 
 =head1 DESCRIPTION
 
@@ -28,7 +29,7 @@ Otherwise I<indata> should be NULL, and then the signed data must be in I<p7>.
 The content is written to the BIO I<out> unless it is NULL.
 I<flags> is an optional set of flags, which can be used to modify the operation.
 
-PKCS7_get0_signers() retrieves the signer's certificates from I<p7>, it does
+PKCS7_get0_signers() retrieves the signer certificates from I<p7>, it does
 B<not> check their validity or whether any signatures are valid. The I<certs>
 and I<flags> parameters have the same meanings as in PKCS7_verify().
 

--- a/doc/man3/X509_add_cert.pod
+++ b/doc/man3/X509_add_cert.pod
@@ -11,7 +11,7 @@ X509 certificate list addition functions
  #include <openssl/x509.h>
 
  int X509_add_cert(STACK_OF(X509) *sk, X509 *cert, int flags);
- int X509_add_certs(STACK_OF(X509) *sk, STACK_OF(X509) *certs, int flags);
+ int X509_add_certs(STACK_OF(X509) *sk, const STACK_OF(X509) *certs, int flags);
 
 =head1 DESCRIPTION
 

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -325,7 +325,7 @@ int ossl_asn1_item_digest_ex(const ASN1_ITEM *it, const EVP_MD *type,
                              void *data, unsigned char *md, unsigned int *len,
                              OSSL_LIB_CTX *libctx, const char *propq);
 int ossl_x509_add_cert_new(STACK_OF(X509) **sk, X509 *cert, int flags);
-int ossl_x509_add_certs_new(STACK_OF(X509) **p_sk, STACK_OF(X509) *certs,
+int ossl_x509_add_certs_new(STACK_OF(X509) **p_sk, const STACK_OF(X509) *certs,
                             int flags);
 
 STACK_OF(X509_ATTRIBUTE) *ossl_x509at_dup(const STACK_OF(X509_ATTRIBUTE) *x);

--- a/include/openssl/cms.h.in
+++ b/include/openssl/cms.h.in
@@ -128,16 +128,16 @@ int CMS_final_digest(CMS_ContentInfo *cms,
                      unsigned int flags);
 
 CMS_ContentInfo *CMS_sign(X509 *signcert, EVP_PKEY *pkey,
-                          STACK_OF(X509) *certs, BIO *data,
+                          const STACK_OF(X509) *certs, BIO *data,
                           unsigned int flags);
 CMS_ContentInfo *CMS_sign_ex(X509 *signcert, EVP_PKEY *pkey,
-                             STACK_OF(X509) *certs, BIO *data,
+                             const STACK_OF(X509) *certs, BIO *data,
                              unsigned int flags, OSSL_LIB_CTX *libctx,
                              const char *propq);
 
-CMS_ContentInfo *CMS_sign_receipt(CMS_SignerInfo *si,
-                                  X509 *signcert, EVP_PKEY *pkey,
-                                  STACK_OF(X509) *certs, unsigned int flags);
+CMS_ContentInfo *CMS_sign_receipt(CMS_SignerInfo *si, X509 *signcert,
+                                  EVP_PKEY *pkey, const STACK_OF(X509) *certs,
+                                  unsigned int flags);
 
 int CMS_data(CMS_ContentInfo *cms, BIO *out, unsigned int flags);
 CMS_ContentInfo *CMS_data_create(BIO *in, unsigned int flags);
@@ -167,18 +167,18 @@ CMS_ContentInfo *CMS_EncryptedData_encrypt_ex(BIO *in, const EVP_CIPHER *cipher,
 int CMS_EncryptedData_set1_key(CMS_ContentInfo *cms, const EVP_CIPHER *ciph,
                                const unsigned char *key, size_t keylen);
 
-int CMS_verify(CMS_ContentInfo *cms, STACK_OF(X509) *certs,
+int CMS_verify(CMS_ContentInfo *cms, const STACK_OF(X509) *certs,
                X509_STORE *store, BIO *dcont, BIO *out, unsigned int flags);
 
 int CMS_verify_receipt(CMS_ContentInfo *rcms, CMS_ContentInfo *ocms,
-                       STACK_OF(X509) *certs,
+                       const STACK_OF(X509) *certs,
                        X509_STORE *store, unsigned int flags);
 
 STACK_OF(X509) *CMS_get0_signers(CMS_ContentInfo *cms);
 
-CMS_ContentInfo *CMS_encrypt(STACK_OF(X509) *certs, BIO *in,
+CMS_ContentInfo *CMS_encrypt(const STACK_OF(X509) *certs, BIO *in,
                              const EVP_CIPHER *cipher, unsigned int flags);
-CMS_ContentInfo *CMS_encrypt_ex(STACK_OF(X509) *certs, BIO *in,
+CMS_ContentInfo *CMS_encrypt_ex(const STACK_OF(X509) *certs, BIO *in,
                                 const EVP_CIPHER *cipher, unsigned int flags,
                                 OSSL_LIB_CTX *libctx, const char *propq);
 
@@ -288,7 +288,7 @@ int CMS_SignerInfo_get0_signer_id(CMS_SignerInfo *si,
                                   ASN1_OCTET_STRING **keyid,
                                   X509_NAME **issuer, ASN1_INTEGER **sno);
 int CMS_SignerInfo_cert_cmp(CMS_SignerInfo *si, X509 *cert);
-int CMS_set1_signers_certs(CMS_ContentInfo *cms, STACK_OF(X509) *certs,
+int CMS_set1_signers_certs(CMS_ContentInfo *cms, const STACK_OF(X509) *certs,
                            unsigned int flags);
 void CMS_SignerInfo_get0_algs(CMS_SignerInfo *si, EVP_PKEY **pk,
                               X509 **signer, X509_ALGOR **pdig,
@@ -298,8 +298,9 @@ int CMS_SignerInfo_sign(CMS_SignerInfo *si);
 int CMS_SignerInfo_verify(CMS_SignerInfo *si);
 int CMS_SignerInfo_verify_content(CMS_SignerInfo *si, BIO *chain);
 BIO *CMS_SignedData_verify(CMS_SignedData *sd, BIO *detached_data,
-                           STACK_OF(X509) *scerts, X509_STORE *store,
-                           STACK_OF(X509) *extra, STACK_OF(X509_CRL) *crls,
+                           const STACK_OF(X509) *scerts, X509_STORE *store,
+                           const STACK_OF(X509) *extra,
+                           const STACK_OF(X509_CRL) *crls,
                            unsigned int flags,
                            OSSL_LIB_CTX *libctx, const char *propq);
 

--- a/include/openssl/ocsp.h.in
+++ b/include/openssl/ocsp.h.in
@@ -219,7 +219,7 @@ int OCSP_request_sign(OCSP_REQUEST *req,
                       X509 *signer,
                       EVP_PKEY *key,
                       const EVP_MD *dgst,
-                      STACK_OF(X509) *certs, unsigned long flags);
+                      const STACK_OF(X509) *certs, unsigned long flags);
 
 int OCSP_response_status(OCSP_RESPONSE *resp);
 OCSP_BASICRESP *OCSP_response_get1_basic(OCSP_RESPONSE *resp);
@@ -228,7 +228,7 @@ const ASN1_OCTET_STRING *OCSP_resp_get0_signature(const OCSP_BASICRESP *bs);
 const X509_ALGOR *OCSP_resp_get0_tbs_sigalg(const OCSP_BASICRESP *bs);
 const OCSP_RESPDATA *OCSP_resp_get0_respdata(const OCSP_BASICRESP *bs);
 int OCSP_resp_get0_signer(OCSP_BASICRESP *bs, X509 **signer,
-                          STACK_OF(X509) *extra_certs);
+                          const STACK_OF(X509) *extra_certs);
 
 int OCSP_resp_count(OCSP_BASICRESP *bs);
 OCSP_SINGLERESP *OCSP_resp_get0(OCSP_BASICRESP *bs, int idx);
@@ -254,7 +254,7 @@ int OCSP_resp_find_status(OCSP_BASICRESP *bs, OCSP_CERTID *id, int *status,
 int OCSP_check_validity(ASN1_GENERALIZEDTIME *thisupd,
                         ASN1_GENERALIZEDTIME *nextupd, long sec, long maxsec);
 
-int OCSP_request_verify(OCSP_REQUEST *req, STACK_OF(X509) *certs,
+int OCSP_request_verify(OCSP_REQUEST *req, const STACK_OF(X509) *certs,
                         X509_STORE *store, unsigned long flags);
 
 #  define OCSP_parse_url(url, host, port, path, ssl) \
@@ -280,10 +280,10 @@ OCSP_SINGLERESP *OCSP_basic_add1_status(OCSP_BASICRESP *rsp,
 int OCSP_basic_add1_cert(OCSP_BASICRESP *resp, X509 *cert);
 int OCSP_basic_sign(OCSP_BASICRESP *brsp,
                     X509 *signer, EVP_PKEY *key, const EVP_MD *dgst,
-                    STACK_OF(X509) *certs, unsigned long flags);
+                    const STACK_OF(X509) *certs, unsigned long flags);
 int OCSP_basic_sign_ctx(OCSP_BASICRESP *brsp,
                         X509 *signer, EVP_MD_CTX *ctx,
-                        STACK_OF(X509) *certs, unsigned long flags);
+                        const STACK_OF(X509) *certs, unsigned long flags);
 int OCSP_RESPID_set_by_name(OCSP_RESPID *respid, X509 *cert);
 int OCSP_RESPID_set_by_key_ex(OCSP_RESPID *respid, X509 *cert,
                               OSSL_LIB_CTX *libctx, const char *propq);
@@ -376,7 +376,7 @@ const char *OCSP_crl_reason_str(long s);
 int OCSP_REQUEST_print(BIO *bp, OCSP_REQUEST *a, unsigned long flags);
 int OCSP_RESPONSE_print(BIO *bp, OCSP_RESPONSE *o, unsigned long flags);
 
-int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs,
+int OCSP_basic_verify(OCSP_BASICRESP *bs, const STACK_OF(X509) *certs,
                       X509_STORE *st, unsigned long flags);
 
 

--- a/include/openssl/pkcs7.h.in
+++ b/include/openssl/pkcs7.h.in
@@ -314,24 +314,24 @@ int PKCS7_set_signed_attributes(PKCS7_SIGNER_INFO *p7si,
 int PKCS7_set_attributes(PKCS7_SIGNER_INFO *p7si,
                          STACK_OF(X509_ATTRIBUTE) *sk);
 
-PKCS7 *PKCS7_sign(X509 *signcert, EVP_PKEY *pkey, STACK_OF(X509) *certs,
+PKCS7 *PKCS7_sign(X509 *signcert, EVP_PKEY *pkey, const STACK_OF(X509) *certs,
                   BIO *data, int flags);
-PKCS7 *PKCS7_sign_ex(X509 *signcert, EVP_PKEY *pkey, STACK_OF(X509) *certs,
-                     BIO *data, int flags, OSSL_LIB_CTX *libctx,
-                     const char *propq);
+PKCS7 *PKCS7_sign_ex(X509 *signcert, EVP_PKEY *pkey,
+                     const STACK_OF(X509) *certs, BIO *data, int flags,
+                     OSSL_LIB_CTX *libctx, const char *propq);
 
 PKCS7_SIGNER_INFO *PKCS7_sign_add_signer(PKCS7 *p7,
                                          X509 *signcert, EVP_PKEY *pkey,
                                          const EVP_MD *md, int flags);
 
 int PKCS7_final(PKCS7 *p7, BIO *data, int flags);
-int PKCS7_verify(PKCS7 *p7, STACK_OF(X509) *certs, X509_STORE *store,
+int PKCS7_verify(PKCS7 *p7, const STACK_OF(X509) *certs, X509_STORE *store,
                  BIO *indata, BIO *out, int flags);
-STACK_OF(X509) *PKCS7_get0_signers(PKCS7 *p7, STACK_OF(X509) *certs,
+STACK_OF(X509) *PKCS7_get0_signers(PKCS7 *p7, const STACK_OF(X509) *certs,
                                    int flags);
-PKCS7 *PKCS7_encrypt(STACK_OF(X509) *certs, BIO *in, const EVP_CIPHER *cipher,
-                     int flags);
-PKCS7 *PKCS7_encrypt_ex(STACK_OF(X509) *certs, BIO *in,
+PKCS7 *PKCS7_encrypt(const STACK_OF(X509) *certs, BIO *in,
+                     const EVP_CIPHER *cipher, int flags);
+PKCS7 *PKCS7_encrypt_ex(const STACK_OF(X509) *certs, BIO *in,
                         const EVP_CIPHER *cipher, int flags,
                         OSSL_LIB_CTX *libctx, const char *propq);
 int PKCS7_decrypt(PKCS7 *p7, EVP_PKEY *pkey, X509 *cert, BIO *data,

--- a/include/openssl/ts.h
+++ b/include/openssl/ts.h
@@ -359,7 +359,7 @@ TS_RESP *TS_RESP_create_response(TS_RESP_CTX *ctx, BIO *req_bio);
  * they are defined in ts/ts_resp_verify.c.
  */
 
-int TS_RESP_verify_signature(PKCS7 *token, STACK_OF(X509) *certs,
+int TS_RESP_verify_signature(PKCS7 *token, const STACK_OF(X509) *certs,
                              X509_STORE *store, X509 **signer_out);
 
 /* Context structure for the generic verify method. */

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -793,7 +793,7 @@ unsigned long X509_subject_name_hash_old(X509 *x);
 # define X509_ADD_FLAG_NO_DUP   0x4
 # define X509_ADD_FLAG_NO_SS    0x8
 int X509_add_cert(STACK_OF(X509) *sk, X509 *cert, int flags);
-int X509_add_certs(STACK_OF(X509) *sk, STACK_OF(X509) *certs, int flags);
+int X509_add_certs(STACK_OF(X509) *sk, const STACK_OF(X509) *certs, int flags);
 
 int X509_cmp(const X509 *a, const X509 *b);
 int X509_NAME_cmp(const X509_NAME *a, const X509_NAME *b);
@@ -1005,9 +1005,10 @@ int EVP_PKEY_add1_attr_by_txt(EVP_PKEY *key,
                               const unsigned char *bytes, int len);
 
 /* lookup a cert from a X509 STACK */
-X509 *X509_find_by_issuer_and_serial(STACK_OF(X509) *sk, const X509_NAME *name,
+X509 *X509_find_by_issuer_and_serial(const STACK_OF(X509) *sk,
+                                     const X509_NAME *name,
                                      const ASN1_INTEGER *serial);
-X509 *X509_find_by_subject(STACK_OF(X509) *sk, const X509_NAME *name);
+X509 *X509_find_by_subject(const STACK_OF(X509) *sk, const X509_NAME *name);
 
 DECLARE_ASN1_FUNCTIONS(PBEPARAM)
 DECLARE_ASN1_FUNCTIONS(PBE2PARAM)


### PR DESCRIPTION
This is spin-off from #18916, with two commits:
* `crypto/{CMS,PKCS7,OCSP,TS,X509}`: constify various cert list parameters
* `apps/{cms.c,smime.c}`: improve code layout according to coding guidelines

This is pure refactoring, so does not include any changes of behavior.
