### PR TITLE
Add e_os.h before ssl.h in quic_tserver_test.c to fix c99 compiles.

### DIFF
--- a/test/quic_tserver_test.c
+++ b/test/quic_tserver_test.c
@@ -6,6 +6,7 @@
  * in the file LICENSE in the source distribution or at
  * https://www.openssl.org/source/license.html
  */
+#include "internal/e_os.h"
 #include <openssl/ssl.h>
 #include <openssl/quic.h>
 #include <openssl/bio.h>


### PR DESCRIPTION
This change ensures that struct timeval is present before ssl.h is included to ensure definition consistency.

Fixes: #22309