### PR TITLE
Avoid using gets as an argument name in a prototype

### DIFF
--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -967,7 +967,7 @@ int BIO_meth_set_puts(BIO_METHOD *biom,
                       int (*puts) (BIO *, const char *));
 int (*BIO_meth_get_gets(const BIO_METHOD *biom)) (BIO *, char *, int);
 int BIO_meth_set_gets(BIO_METHOD *biom,
-                      int (*gets) (BIO *, char *, int));
+                      int (*ossl_gets) (BIO *, char *, int));
 long (*BIO_meth_get_ctrl(const BIO_METHOD *biom)) (BIO *, int, long, void *);
 int BIO_meth_set_ctrl(BIO_METHOD *biom,
                       long (*ctrl) (BIO *, int, long, void *));


### PR DESCRIPTION
This otherwise breaks compilation of applications using ssl.h on MingW.

Fixes #22296
