### PR TITLE
apps: Print out a proper message when a store cannot be opened

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1011,8 +1011,6 @@ int load_key_certs_crls(const char *uri, int format, int maybe_stdin,
     if (expect > 0 && !OSSL_STORE_expect(ctx, expect)) {
         if (!quiet)
             BIO_printf(bio_err, "Could not find");
-        if (failed == NULL)
-            failed = "anything";
         goto end;
     }
 

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1003,10 +1003,16 @@ int load_key_certs_crls(const char *uri, int format, int maybe_stdin,
         ctx = OSSL_STORE_open_ex(uri, libctx, propq, get_ui_method(), &uidata,
                                  params, NULL, NULL);
     }
-    if (ctx == NULL)
+    if (ctx == NULL) {
+        if (!quiet)
+            BIO_printf(bio_err, "Could not open file or uri for loading");
         goto end;
-    if (expect > 0 && !OSSL_STORE_expect(ctx, expect))
+    }
+    if (expect > 0 && !OSSL_STORE_expect(ctx, expect)) {
+        if (!quiet)
+            BIO_printf(bio_err, "Could not read");
         goto end;
+    }
 
     failed = NULL;
     while ((ppkey != NULL || ppubkey != NULL || pparams != NULL

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1010,7 +1010,9 @@ int load_key_certs_crls(const char *uri, int format, int maybe_stdin,
     }
     if (expect > 0 && !OSSL_STORE_expect(ctx, expect)) {
         if (!quiet)
-            BIO_printf(bio_err, "Could not read");
+            BIO_printf(bio_err, "Could not find");
+        if (failed == NULL)
+            failed = "anything";
         goto end;
     }
 

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1010,7 +1010,7 @@ int load_key_certs_crls(const char *uri, int format, int maybe_stdin,
     }
     if (expect > 0 && !OSSL_STORE_expect(ctx, expect)) {
         if (!quiet)
-            BIO_printf(bio_err, "Could not find");
+            BIO_printf(bio_err, "Internal error trying to load");
         goto end;
     }
 

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1106,8 +1106,6 @@ int load_key_certs_crls(const char *uri, int format, int maybe_stdin,
         failed = FAIL_NAME;
         if (failed != NULL && !quiet)
             BIO_printf(bio_err, "Could not find");
-    } else if (!quiet) {
-        BIO_printf(bio_err, "Could not read");
     }
     if (failed != NULL && !quiet) {
         unsigned long err = ERR_peek_last_error();


### PR DESCRIPTION
Fixes #22306

This reverts some of the recent changes in load_key_certs_crls() as they were incorrect.
