### PR TITLE
test/recipes/05-test_rand.t: replace 'and' with '&&'

### DIFF
--- a/test/recipes/05-test_rand.t
+++ b/test/recipes/05-test_rand.t
@@ -29,12 +29,12 @@ SKIP: {
     @randdata = run(app(['openssl', 'rand', '-engine', 'ossltest', '-hex', '16' ]),
                     capture => 1, statusvar => \$success);
     chomp(@randdata);
-    ok($success and $randdata[0] eq $expected,
+    ok($success && $randdata[0] eq $expected,
        "rand with ossltest: Check rand output is as expected");
 
     @randdata = run(app(['openssl', 'rand', '-engine', 'dasync', '-hex', '16' ]),
                     capture => 1, statusvar => \$success);
     chomp(@randdata);
-    ok($success and length($randdata[0]) == 32,
+    ok($success && length($randdata[0]) == 32,
        "rand with dasync: Check rand output is of expected length");
 }


### PR DESCRIPTION
The lower priority 'and' seems to have some "interesting" interactions with
function argument parsing in some perl versions (presumably because 'and' is
lower priority than the comma).

For the lines that are changed here, perl v5.20.1 says this:

    Useless use of string eq in void context at [.test.recipes]05-test_rand.t line 33.
    Useless use of numeric eq (==) in void context at [.test.recipes]05-test_rand.t line 39.

Replacing 'and' with '&&' in these two cases fixes the problem.

Replacing
