### PR TITLE
Restore compatibility with RSA 1.1.1 api

### DIFF
--- a/crypto/param_build_set.c
+++ b/crypto/param_build_set.c
@@ -101,21 +101,22 @@ int ossl_param_build_set_multi_key_bn(OSSL_PARAM_BLD *bld, OSSL_PARAM *params,
 {
     int i, sz = sk_BIGNUM_const_num(stk);
     OSSL_PARAM *p;
-
+    const BIGNUM *bn;
 
     if (bld != NULL) {
         for (i = 0; i < sz && names[i] != NULL; ++i) {
-            if (!OSSL_PARAM_BLD_push_BN(bld, names[i],
-                                        sk_BIGNUM_const_value(stk, i)))
+            bn = sk_BIGNUM_const_value(stk, i);
+            if (bn != NULL && !OSSL_PARAM_BLD_push_BN(bld, names[i], bn))
                 return 0;
         }
         return 1;
     }
 
     for (i = 0; i < sz && names[i] != NULL; ++i) {
+        bn = sk_BIGNUM_const_value(stk, i);
         p = OSSL_PARAM_locate(params, names[i]);
-        if (p != NULL) {
-            if (!OSSL_PARAM_set_BN(p, sk_BIGNUM_const_value(stk, i)))
+        if (p != NULL && bn != NULL) {
+            if (!OSSL_PARAM_set_BN(p, bn))
                 return 0;
         }
     }

--- a/crypto/rsa/rsa_backend.c
+++ b/crypto/rsa/rsa_backend.c
@@ -141,18 +141,6 @@ int ossl_rsa_todata(RSA *rsa, OSSL_PARAM_BLD *bld, OSSL_PARAM params[],
 
     /* Check private key data integrity */
     if (include_private && rsa_d != NULL) {
-        int numprimes = sk_BIGNUM_const_num(factors);
-        int numexps = sk_BIGNUM_const_num(exps);
-        int numcoeffs = sk_BIGNUM_const_num(coeffs);
-
-        /*
-         * It's permissible to have zero primes, i.e. no CRT params.
-         * Otherwise, there must be at least two, as many exponents,
-         * and one coefficient less.
-         */
-        if (numprimes != 0
-            && (numprimes < 2 || numexps < 2 || numcoeffs < 1))
-            goto err;
 
         if (!ossl_param_build_set_bn(bld, params, OSSL_PKEY_PARAM_RSA_D,
                                      rsa_d)

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -757,17 +757,21 @@ int ossl_rsa_set0_all_params(RSA *r, const STACK_OF(BIGNUM) *primes,
         return 0;
 
     pnum = sk_BIGNUM_num(primes);
-    if (pnum < 2
-        || pnum != sk_BIGNUM_num(exps)
-        || pnum != sk_BIGNUM_num(coeffs) + 1)
+    if (pnum < 2)
         return 0;
 
     if (!RSA_set0_factors(r, sk_BIGNUM_value(primes, 0),
-                          sk_BIGNUM_value(primes, 1))
-        || !RSA_set0_crt_params(r, sk_BIGNUM_value(exps, 0),
-                                sk_BIGNUM_value(exps, 1),
-                                sk_BIGNUM_value(coeffs, 0)))
+                          sk_BIGNUM_value(primes, 1)))
         return 0;
+
+    if (pnum == sk_BIGNUM_num(exps)
+        && pnum == sk_BIGNUM_num(coeffs) + 1) {
+
+        if (!RSA_set0_crt_params(r, sk_BIGNUM_value(exps, 0),
+                                 sk_BIGNUM_value(exps, 1),
+                                 sk_BIGNUM_value(coeffs, 0)))
+        return 0;
+    }
 
 #ifndef FIPS_MODULE
     old_infos = r->prime_infos;


### PR DESCRIPTION
RSA 1.1.1 api compatibility was broken in 3.2 for a few reasons:
1) We were allowing NULL bignums to be pushed onto BIGNUM stacks, resulting in sigsegvs
2) We were checking for the presence of CRT params on export and import of RSA keys, which are not requried.

This PR addresses both of those issues


