### PR TITLE
Fix regression of enable-crypto-mdebug on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
     - name: modprobe tls
       run: sudo modprobe tls
     - name: config
-      run: ./config --banner=Configured --strict-warnings no-ec enable-ssl-trace enable-zlib enable-zlib-dynamic enable-crypto-mdebug enable-crypto-mdebug-backtrace enable-egd enable-ktls enable-fips no-threads && perl configdata.pm --dump
+      run: ./config --banner=Configured --strict-warnings no-ec enable-ssl-trace enable-zlib enable-zlib-dynamic enable-crypto-mdebug enable-egd enable-ktls enable-fips no-threads && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: get cpu info

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -87,7 +87,7 @@ jobs:
     - name: config
       working-directory: _build
       run: |
-        perl ..\Configure --banner=Configured no-makedepend no-shared no-fips VC-WIN64A-masm
+        perl ..\Configure --banner=Configured no-makedepend no-shared no-fips enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-trace enable-crypto-mdebug VC-WIN64A-masm
         perl configdata.pm --dump
     - name: build
       working-directory: _build

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -122,12 +122,13 @@ static void parseit(void)
 }
 
 /*
- * Windows doesn't have random(), but it has rand()
+ * Windows doesn't have random() and srandom(), but it has rand() and srand().
  * Some rand() implementations aren't good, but we're not
  * dealing with secure randomness here.
  */
 # ifdef _WIN32
 #  define random() rand()
+#  define srandom(seed) srand(seed)
 # endif
 /*
  * See if the current malloc should fail.

--- a/test/trace_api_test.c
+++ b/test/trace_api_test.c
@@ -84,14 +84,14 @@ static int put_trace_output(void)
     int res = 1;
 
     OSSL_TRACE_BEGIN(HTTP) {
-        res = TEST_int_eq(BIO_printf(trc_out, OSSL_HELLO), strlen(OSSL_HELLO))
-            + TEST_int_eq(trace_string(0, 0, OSSL_STR80), strlen(OSSL_STR80))
-            + TEST_int_eq(trace_string(0, 0, OSSL_STR81), strlen(OSSL_STR80))
-            + TEST_int_eq(trace_string(1, 1, OSSL_CTRL), strlen(OSSL_CTRL))
-            + TEST_int_eq(trace_string(0, 1, OSSL_MASKED), strlen(OSSL_MASKED)
-                          + 1) /* newline added */
-            + TEST_int_eq(BIO_printf(trc_out, OSSL_BYE), strlen(OSSL_BYE))
-            == 6;
+        res = TEST_int_eq(BIO_printf(trc_out, OSSL_HELLO), strlen(OSSL_HELLO));
+        res += TEST_int_eq(trace_string(0, 0, OSSL_STR80), strlen(OSSL_STR80));
+        res += TEST_int_eq(trace_string(0, 0, OSSL_STR81), strlen(OSSL_STR80));
+        res += TEST_int_eq(trace_string(1, 1, OSSL_CTRL), strlen(OSSL_CTRL));
+        res += TEST_int_eq(trace_string(0, 1, OSSL_MASKED), strlen(OSSL_MASKED)
+                           + 1); /* newline added */
+        res += TEST_int_eq(BIO_printf(trc_out, OSSL_BYE), strlen(OSSL_BYE));
+        res = res == 6;
         /* not using '&&' but '+' to catch potentially multiple test failures */
     } OSSL_TRACE_END(HTTP);
     return res;


### PR DESCRIPTION
Some of the non-default options that enable more
code to be built need to be enabled in one of the
Windows builds to avoid regressions.
