### PR TITLE
Update thread_win.c to support Embarcadero's clang based compilers

### DIFF
--- a/crypto/thread/arch/thread_win.c
+++ b/crypto/thread/arch/thread_win.c
@@ -32,6 +32,17 @@ static unsigned __stdcall thread_start_thunk(LPVOID vthread)
     return 0;
 }
 
+// To support Embarcadero's clang based compilers
+#if defined(__BORLANDC__) && defined(__clang__) && defined(_WIN32) 
+__forceinline void MemoryBarrier(void)
+{
+    long barrier;
+    __asm {
+        xchg barrier, eax
+    }
+}
+#endif
+
 int ossl_crypto_thread_native_spawn(CRYPTO_THREAD *thread)
 {
     HANDLE *handle;


### PR DESCRIPTION
CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

To support Embarcadero's clang-based compilers the following code was added to the file crypto/thread/arch/thread_win.c just before function void ossl_crypto_mem_barrier(void).

```cpp
#if defined(__BORLANDC__) && defined(__clang__) && defined(_WIN32) 
__forceinline void MemoryBarrier(void)
{
    long barrier;
    __asm {
        xchg barrier, eax
    }
}
#endif
```

Without this change, library creation fails because it cannot find the _MemoryBarrier function,
