### PR TITLE
Add quic client fuzzer (extended)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,23 @@ jobs:
     - name: make test
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4} OPENSSL_TEST_RAND_ORDER=0
 
+  fuzz_tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: checkout fuzz/corpora submodule
+      run: git submodule update --init --depth 1 fuzz/corpora
+    - name: config
+      run: ./config --banner=Configured --debug -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION enable-asan enable-ubsan enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-weak-ssl-ciphers enable-ssl3 enable-ssl3-method enable-nextprotoneg && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: get cpu info
+      run: |
+        cat /proc/cpuinfo
+        ./util/opensslwrap.sh version -c
+    - name: make test
+      run: make test HARNESS_JOBS=${HARNESS_JOBS:-4} OPENSSL_TEST_RAND_ORDER=0 TESTS="test_fuzz*"
+
   memory_sanitizer:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
-      run: ./config --banner=Configured --debug enable-asan enable-ubsan enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-fips -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION && perl configdata.pm --dump
+      run: ./config --banner=Configured --debug enable-asan enable-ubsan enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-fips && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: get cpu info
@@ -345,7 +345,7 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
-      run: ./config --banner=Configured --debug enable-asan enable-ubsan enable-comp enable-brotli -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -DPEDANTIC && perl configdata.pm --dump
+      run: ./config --banner=Configured --debug enable-asan enable-ubsan enable-comp enable-brotli -DPEDANTIC && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: get cpu info
@@ -367,7 +367,7 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
-      run: ./config --banner=Configured --debug enable-asan enable-ubsan enable-comp enable-zstd -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -DPEDANTIC && perl configdata.pm --dump
+      run: ./config --banner=Configured --debug enable-asan enable-ubsan enable-comp enable-zstd -DPEDANTIC && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: get cpu info

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -26,7 +26,7 @@ jobs:
              --post-data "token=${{ secrets.COVERITY_TOKEN }}&project=openssl%2Fopenssl" \
              --progress=dot:giga -O coverity_tool.tgz
     - name: config
-      run: CC=gcc ./config --banner=Configured --debug enable-fips enable-rc5 enable-md2 enable-ssl3 enable-nextprotoneg enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 no-shared enable-buildtest-c++ enable-external-tests -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+      run: CC=gcc ./config --banner=Configured --debug enable-fips enable-rc5 enable-md2 enable-ssl3 enable-nextprotoneg enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 no-shared enable-buildtest-c++ enable-external-tests -DPEDANTIC
     - name: config dump
       run: ./configdata.pm --dump
     - name: tool install

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -834,7 +834,8 @@ void ERR_add_error_vdata(int num, va_list args)
      * If err_data is allocated already, reuse the space.
      * Otherwise, allocate a small new buffer.
      */
-    if ((es->err_data_flags[i] & flags) == flags) {
+    if ((es->err_data_flags[i] & flags) == flags
+            && ossl_assert(es->err_data[i] != NULL)) {
         str = es->err_data[i];
         size = es->err_data_size[i];
 

--- a/crypto/err/err_save.c
+++ b/crypto/err/err_save.c
@@ -85,16 +85,18 @@ void OSSL_ERR_STATE_save_to_mark(ERR_STATE *es)
         es->err_line[i]         = thread_es->err_line[j];
         es->err_func[i]         = thread_es->err_func[j];
 
-        thread_es->err_flags[j]     = 0;
-        thread_es->err_buffer[j]    = 0;
-        thread_es->err_data[j]      = NULL;
-        thread_es->err_data_size[j] = 0;
-        thread_es->err_file[j]      = NULL;
-        thread_es->err_line[j]      = 0;
-        thread_es->err_func[j]      = NULL;
+        thread_es->err_flags[j]      = 0;
+        thread_es->err_buffer[j]     = 0;
+        thread_es->err_data[j]       = NULL;
+        thread_es->err_data_size[j]  = 0;
+        thread_es->err_data_flags[j] = 0;
+        thread_es->err_file[j]       = NULL;
+        thread_es->err_line[j]       = 0;
+        thread_es->err_func[j]       = NULL;
     }
 
     if (i > 0) {
+        thread_es->top = top;
         /* If we moved anything, es's stack always starts at [0]. */
         es->top     = i - 1;
         es->bottom  = ERR_NUM_ERRORS - 1;

--- a/doc/man3/OSSL_ERR_STATE_save.pod
+++ b/doc/man3/OSSL_ERR_STATE_save.pod
@@ -70,6 +70,10 @@ missing the auxiliary error data.
 
 L<ERR_raise(3)>, L<ERR_get_error(3)>, L<ERR_clear_error(3)>
 
+=head1 HISTORY
+
+All of these functions were added in OpenSSL 3.2.
+
 =head1 COPYRIGHT
 
 Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -32,6 +32,34 @@ to the `libFuzzer` library file while configuring; this is represented as
             enable-ssl3 enable-ssl3-method enable-nextprotoneg \
             --debug
 
+Clang uses the gcc libstdc++ library so this must also be installed. You can
+check which version of gcc clang is using like this:
+
+    $ clang --verbose
+    Ubuntu clang version 14.0.0-1ubuntu1.1
+    Target: x86_64-pc-linux-gnu
+    Thread model: posix
+    InstalledDir: /usr/bin
+    Found candidate GCC installation: /usr/bin/../lib/gcc/i686-linux-gnu/12
+    Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/10
+    Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/11
+    Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/12
+    Selected GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/12
+    Candidate multilib: .;@m64
+    Selected multilib: .;@m64
+
+So, in the above example clang is using gcc version 12. Ensure that the selected
+gcc version has the relevant libstdc++ files installed:
+
+    $ ls /usr/lib/gcc/x86_64-linux-gnu/12 | grep stdc++
+    libstdc++.a
+    libstdc++fs.a
+    libstdc++.so
+
+On Ubuntu for gcc-12 this requires the libstdc++-12-dev package installed.
+
+    $ sudo apt-get install libstdc++-12-dev
+
 Compile:
 
     sudo apt-get install make

--- a/fuzz/build.info
+++ b/fuzz/build.info
@@ -95,7 +95,7 @@ IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
 
   SOURCE[quic-client]=quic-client.c driver.c fuzz_rand.c
   INCLUDE[quic-client]=../include {- $ex_inc -}
-  DEPEND[quic-client]=../libcrypto ../libssl {- $ex_lib -}
+  DEPEND[quic-client]=../libcrypto.a ../libssl.a {- $ex_lib -}
 
   SOURCE[server]=server.c driver.c fuzz_rand.c
   INCLUDE[server]=../include {- $ex_inc -}
@@ -194,7 +194,7 @@ IF[{- !$disabled{tests} -}]
 
   SOURCE[quic-client-test]=quic-client.c test-corpus.c fuzz_rand.c
   INCLUDE[quic-client-test]=../include
-  DEPEND[quic-client-test]=../libcrypto ../libssl
+  DEPEND[quic-client-test]=../libcrypto.a ../libssl.a
 
   SOURCE[server-test]=server.c test-corpus.c fuzz_rand.c
   INCLUDE[server-test]=../include

--- a/fuzz/build.info
+++ b/fuzz/build.info
@@ -29,6 +29,10 @@ IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
     PROGRAMS{noinst}=x509
   ENDIF
 
+  IF[{- !$disabled{"quic"} -}]
+    PROGRAMS{noinst}=quic-client
+  ENDIF
+
   SOURCE[asn1]=asn1.c driver.c fuzz_rand.c
   INCLUDE[asn1]=../include {- $ex_inc -}
   DEPEND[asn1]=../libcrypto ../libssl {- $ex_lib -}
@@ -89,6 +93,10 @@ IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
   INCLUDE[v3name]=../include {- $ex_inc -}
   DEPEND[v3name]=../libcrypto.a {- $ex_lib -}
 
+  SOURCE[quic-client]=quic-client.c driver.c fuzz_rand.c
+  INCLUDE[quic-client]=../include {- $ex_inc -}
+  DEPEND[quic-client]=../libcrypto ../libssl {- $ex_lib -}
+
   SOURCE[server]=server.c driver.c fuzz_rand.c
   INCLUDE[server]=../include {- $ex_inc -}
   DEPEND[server]=../libcrypto ../libssl {- $ex_lib -}
@@ -117,6 +125,10 @@ IF[{- !$disabled{tests} -}]
 
   IF[{- !$disabled{"ocsp"} -}]
     PROGRAMS{noinst}=x509-test
+  ENDIF
+
+  IF[{- !$disabled{"quic"} -}]
+    PROGRAMS{noinst}=quic-client-test
   ENDIF
 
   SOURCE[asn1-test]=asn1.c test-corpus.c fuzz_rand.c
@@ -179,6 +191,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[v3name-test]=v3name.c test-corpus.c
   INCLUDE[v3name-test]=../include
   DEPEND[v3name-test]=../libcrypto.a
+
+  SOURCE[quic-client-test]=quic-client.c test-corpus.c fuzz_rand.c
+  INCLUDE[quic-client-test]=../include
+  DEPEND[quic-client-test]=../libcrypto ../libssl
 
   SOURCE[server-test]=server.c test-corpus.c fuzz_rand.c
   INCLUDE[server-test]=../include

--- a/fuzz/quic-client.c
+++ b/fuzz/quic-client.c
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2016-2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.openssl.org/source/license.html
+ * or in the file LICENSE in the source distribution.
+ */
+
+#include <time.h>
+#include <openssl/rand.h>
+#include <openssl/ssl.h>
+#include <openssl/rsa.h>
+#include <openssl/dsa.h>
+#include <openssl/ec.h>
+#include <openssl/dh.h>
+#include <openssl/err.h>
+#include "fuzzer.h"
+#include "internal/sockets.h"
+
+/* unused, to avoid warning. */
+static int idx;
+
+#define FUZZTIME 1485898104
+
+#define TIME_IMPL(t) { if (t != NULL) *t = FUZZTIME; return FUZZTIME; }
+
+/*
+ * This might not work in all cases (and definitely not on Windows
+ * because of the way linkers are) and callees can still get the
+ * current time instead of the fixed time. This will just result
+ * in things not being fully reproducible and have a slightly
+ * different coverage.
+ */
+#if !defined(_WIN32)
+time_t time(time_t *t) TIME_IMPL(t)
+#endif
+
+int FuzzerInitialize(int *argc, char ***argv)
+{
+    STACK_OF(SSL_COMP) *comp_methods;
+
+    FuzzerSetRand();
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS | OPENSSL_INIT_ASYNC, NULL);
+    OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, NULL);
+    ERR_clear_error();
+    CRYPTO_free_ex_index(0, -1);
+    idx = SSL_get_ex_data_X509_STORE_CTX_idx();
+    comp_methods = SSL_COMP_get_compression_methods();
+    if (comp_methods != NULL)
+        sk_SSL_COMP_sort(comp_methods);
+
+    return 1;
+}
+
+int FuzzerTestOneInput(const uint8_t *buf, size_t len)
+{
+    SSL *client = NULL;
+    BIO *in;
+    BIO *out;
+    SSL_CTX *ctx;
+    BIO_ADDR *peer_addr = NULL;
+    struct in_addr ina = {0};
+
+    if (len == 0)
+        return 0;
+
+    /* This only fuzzes the initial flow from the client so far. */
+    ctx = SSL_CTX_new(OSSL_QUIC_client_method());
+    if (ctx == NULL)
+        goto end;
+
+    client = SSL_new(ctx);
+    if (client == NULL)
+        goto end;
+
+    peer_addr = BIO_ADDR_new();
+    if (peer_addr == NULL)
+        goto end;
+
+    ina.s_addr = htonl(0x7f000001UL);
+
+    if (!BIO_ADDR_rawmake(peer_addr, AF_INET, &ina, sizeof(ina),
+                                    htons(4433)))
+       goto end;
+
+    /*
+    OPENSSL_assert(SSL_set_min_proto_version(client, 0) == 1);
+    OPENSSL_assert(SSL_set_cipher_list(client, "ALL:eNULL:@SECLEVEL=0") == 1);
+    */
+    SSL_set_tlsext_host_name(client, "localhost");
+    in = BIO_new(BIO_s_dgram_mem());
+    if (in == NULL)
+        goto end;
+    out = BIO_new(BIO_s_dgram_mem());
+    if (out == NULL) {
+        BIO_free(in);
+        goto end;
+    }
+    if (SSL_set_alpn_protos(client, (const unsigned char *)"\x08quicfuzz", 9) != 0)
+        goto end;
+    SSL_set_bio(client, in, out);
+    if (SSL_set1_initial_peer_addr(client, peer_addr) != 1)
+        goto end;
+    SSL_set_connect_state(client);
+    while (len > 3)
+    {
+        size_t size = buf[0] + (buf[1] << 8);
+
+        if (size > len - 2)
+            break;
+
+        if (size > 0)
+            /* OPENSSL_assert((size_t)BIO_write(in, buf+2, size) == size); */
+            BIO_write(in, buf+2, size);
+        len -= size + 2;
+        buf += size + 2;
+
+        if (SSL_do_handshake(client) == 1) {
+            /* Keep reading application data until error or EOF. */
+            uint8_t tmp[1024];
+            if (SSL_read(client, tmp, sizeof(tmp)) <= 0)
+                break;
+        }
+    }
+ end:
+    SSL_free(client);
+    ERR_clear_error();
+    SSL_CTX_free(ctx);
+    BIO_ADDR_free(peer_addr);
+
+    return 0;
+}
+
+void FuzzerCleanup(void)
+{
+    FuzzerClearRand();
+}

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -1311,11 +1311,13 @@ static int ch_on_transport_params(const unsigned char *params,
                 goto malformed;
             }
 
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
             /* Must match our initial DCID. */
             if (!ossl_quic_conn_id_eq(&ch->init_dcid, &cid)) {
                 reason = TP_REASON_EXPECTED_VALUE("ORIG_DCID");
                 goto malformed;
             }
+#endif
 
             got_orig_dcid = 1;
             break;

--- a/ssl/quic/quic_record_tx.c
+++ b/ssl/quic/quic_record_tx.c
@@ -543,6 +543,11 @@ static int qtx_encrypt_into_txe(OSSL_QTX *qtx, struct iovec_cur *cur, TXE *txe,
             return 0;
         }
 
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        /* Ignore what we just encrypted and overwrite it with the plaintext */
+        memcpy(txe_data(txe) + txe->data_len, src, l);
+#endif
+
         assert(l > 0 && src_len == (size_t)l);
         txe->data_len += src_len;
     }

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -85,6 +85,7 @@ struct ossl_record_layer_st {
 };
 
 static int quic_set1_bio(OSSL_RECORD_LAYER *rl, BIO *bio);
+static int quic_free(OSSL_RECORD_LAYER *r);
 
 static int
 quic_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
@@ -189,7 +190,7 @@ quic_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
     return 1;
  err:
     *retrl = NULL;
-    OPENSSL_free(rl);
+    quic_free(rl);
     return 0;
 }
 

--- a/ssl/quic/quic_wire_pkt.c
+++ b/ssl/quic/quic_wire_pkt.c
@@ -115,6 +115,11 @@ static int hdr_generate_mask(QUIC_HDR_PROTECTOR *hpr,
         return 0;
     }
 
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    /* No matter what we did above we use the same mask in fuzzing mode */
+    memset(mask, 0, 5);
+#endif
+
     return 1;
 }
 

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -575,6 +575,11 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL_CONNECTION *s, PACKET *pkt)
         }
     } else {
         j = EVP_DigestVerify(mctx, data, len, hdata, hdatalen);
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        /* Ignore bad signatures when fuzzing */
+        if (SSL_IS_QUIC_HANDSHAKE(s))
+            j = 1;
+#endif
         if (j <= 0) {
             SSLfatal(s, SSL_AD_DECRYPT_ERROR, SSL_R_BAD_SIGNATURE);
             goto err;

--- a/test/errtest.c
+++ b/test/errtest.c
@@ -334,7 +334,12 @@ static int test_clear_error(void)
     return res;
 }
 
-static int test_save_restore(void)
+/*
+ * Test saving and restoring error state.
+ * Test 0: Save using OSSL_ERR_STATE_save()
+ * Test 1: Save using OSSL_ERR_STATE_save_to_mark()
+ */
+static int test_save_restore(int idx)
 {
     ERR_STATE *es;
     int res = 0, i, flags = -1;
@@ -350,15 +355,25 @@ static int test_save_restore(void)
     if (!TEST_ulong_gt(mallocfail, 0))
         goto err;
 
+    if (idx == 1 && !TEST_int_eq(ERR_set_mark(), 1))
+        goto err;
+
     ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR, testdata);
     interr = ERR_peek_last_error();
     if (!TEST_ulong_ne(mallocfail, ERR_peek_last_error()))
         goto err;
 
-    OSSL_ERR_STATE_save(es);
+    if (idx == 0) {
+        OSSL_ERR_STATE_save(es);
 
-    if (!TEST_ulong_eq(ERR_peek_last_error(), 0))
-        goto err;
+        if (!TEST_ulong_eq(ERR_peek_last_error(), 0))
+            goto err;
+    } else {
+        OSSL_ERR_STATE_save_to_mark(es);
+
+        if (!TEST_ulong_ne(ERR_peek_last_error(), 0))
+            goto err;
+    }
 
     for (i = 0; i < 2; i++) {
         OSSL_ERR_STATE_restore(es);
@@ -374,27 +389,32 @@ static int test_save_restore(void)
         OSSL_ERR_STATE_restore(es);
 
         /* verify them all */
-        if (!TEST_ulong_eq(ERR_get_error_all(NULL, NULL, NULL,
-                                             &data, &flags), mallocfail)
-            || !TEST_int_ne(flags, ERR_TXT_STRING | ERR_TXT_MALLOCED))
-            goto err;
+        if (idx == 0 || i == 0) {
+            if (!TEST_ulong_eq(ERR_get_error_all(NULL, NULL, NULL,
+                                                &data, &flags), mallocfail)
+                || !TEST_int_ne(flags, ERR_TXT_STRING | ERR_TXT_MALLOCED))
+                goto err;
+        }
 
         if (!TEST_ulong_eq(ERR_get_error_all(NULL, NULL, NULL,
-                                             &data, &flags), interr)
+                                            &data, &flags), interr)
             || !TEST_str_eq(data, testdata)
             || !TEST_int_eq(flags, ERR_TXT_STRING | ERR_TXT_MALLOCED))
             goto err;
 
-        if (!TEST_ulong_eq(ERR_get_error_all(NULL, NULL, NULL,
-                                             &data, &flags), mallocfail)
-            || !TEST_int_ne(flags, ERR_TXT_STRING | ERR_TXT_MALLOCED))
-            goto err;
+        if (idx == 0) {
+            if (!TEST_ulong_eq(ERR_get_error_all(NULL, NULL, NULL,
+                                                &data, &flags), mallocfail)
+                || !TEST_int_ne(flags, ERR_TXT_STRING | ERR_TXT_MALLOCED))
+                goto err;
+        }
 
         if (!TEST_ulong_eq(ERR_get_error_all(NULL, NULL, NULL,
-                                             &data, &flags), interr)
+                                            &data, &flags), interr)
             || !TEST_str_eq(data, testdata)
             || !TEST_int_eq(flags, ERR_TXT_STRING | ERR_TXT_MALLOCED))
             goto err;
+
 
         if (!TEST_ulong_eq(ERR_get_error(), 0))
             goto err;
@@ -415,7 +435,7 @@ int setup_tests(void)
     ADD_TEST(test_print_error_format);
 #endif
     ADD_TEST(test_marks);
-    ADD_TEST(test_save_restore);
+    ADD_ALL_TESTS(test_save_restore, 2);
     ADD_TEST(test_clear_error);
     return 1;
 }

--- a/test/errtest.c
+++ b/test/errtest.c
@@ -391,30 +391,29 @@ static int test_save_restore(int idx)
         /* verify them all */
         if (idx == 0 || i == 0) {
             if (!TEST_ulong_eq(ERR_get_error_all(NULL, NULL, NULL,
-                                                &data, &flags), mallocfail)
+                                                 &data, &flags), mallocfail)
                 || !TEST_int_ne(flags, ERR_TXT_STRING | ERR_TXT_MALLOCED))
                 goto err;
         }
 
         if (!TEST_ulong_eq(ERR_get_error_all(NULL, NULL, NULL,
-                                            &data, &flags), interr)
+                                             &data, &flags), interr)
             || !TEST_str_eq(data, testdata)
             || !TEST_int_eq(flags, ERR_TXT_STRING | ERR_TXT_MALLOCED))
             goto err;
 
         if (idx == 0) {
             if (!TEST_ulong_eq(ERR_get_error_all(NULL, NULL, NULL,
-                                                &data, &flags), mallocfail)
+                                                 &data, &flags), mallocfail)
                 || !TEST_int_ne(flags, ERR_TXT_STRING | ERR_TXT_MALLOCED))
                 goto err;
         }
 
         if (!TEST_ulong_eq(ERR_get_error_all(NULL, NULL, NULL,
-                                            &data, &flags), interr)
+                                             &data, &flags), interr)
             || !TEST_str_eq(data, testdata)
             || !TEST_int_eq(flags, ERR_TXT_STRING | ERR_TXT_MALLOCED))
             goto err;
-
 
         if (!TEST_ulong_eq(ERR_get_error(), 0))
             goto err;

--- a/test/recipes/99-test_fuzz_quic_client.t
+++ b/test/recipes/99-test_fuzz_quic_client.t
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+# Copyright 2016-2020 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+use OpenSSL::Test::Utils;
+
+my $fuzzer = "quic-client";
+setup("test_fuzz_${fuzzer}");
+
+plan tests => 2; # one more due to below require_ok(...)
+
+require_ok(srctop_file('test','recipes','fuzz.pl'));
+
+fuzz_ok($fuzzer);

--- a/test/recipes/99-test_fuzz_quic_client.t
+++ b/test/recipes/99-test_fuzz_quic_client.t
@@ -15,6 +15,9 @@ use OpenSSL::Test::Utils;
 my $fuzzer = "quic-client";
 setup("test_fuzz_${fuzzer}");
 
+plan skip_all => "This test requires quic support"
+    if disabled("quic");
+
 plan tests => 2; # one more due to below require_ok(...)
 
 require_ok(srctop_file('test','recipes','fuzz.pl'));


### PR DESCRIPTION
This takes the QUIC client fuzzer written by @kroeckx in #19743 and adds additional commits and updates to enable the fuzzer to complete a full handshake and read data from a stream.

We also fix two bugs that the fuzzer identified. One was in the save/restore of error state which could lead to the error data getting into an inconsistent state (which led to undefined behaviour). The second is a use-after-free in `qrx_process_pkt`.

Some initial corpora files are in openssl/fuzz-corpora#16. This includes a "happy path" corpora file that achieves a full handshake and a read of data.