### PR TITLE
Avoid having another copy of key schedule in PROV_GCM_CTX

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_gcm_hw_vaes_avx512.inc
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw_vaes_avx512.inc
@@ -48,7 +48,6 @@ static int vaes_gcm_setkey(PROV_GCM_CTX *ctx, const unsigned char *key,
     PROV_AES_GCM_CTX *actx = (PROV_AES_GCM_CTX *)ctx;
     AES_KEY *ks = &actx->ks.ks;
 
-    ctx->ks = ks;
     aesni_set_encrypt_key(key, keylen * 8, ks);
     memset(gcmctx, 0, sizeof(*gcmctx));
     gcmctx->key = ks;
@@ -77,7 +76,7 @@ static int vaes_gcm_setiv(PROV_GCM_CTX *ctx, const unsigned char *iv,
     if (ivlen > (U64(1) << 61))
         return 0;
 
-    ossl_aes_gcm_setiv_avx512(ctx->ks, gcmctx, iv, ivlen);
+    ossl_aes_gcm_setiv_avx512(gcmctx->key, gcmctx, iv, ivlen);
 
     return 1;
 }
@@ -162,9 +161,9 @@ static int vaes_gcm_cipherupdate(PROV_GCM_CTX *ctx, const unsigned char *in,
     }
 
     if (ctx->enc)
-        ossl_aes_gcm_encrypt_avx512(ctx->ks, gcmctx, &gcmctx->mres, in, len, out);
+        ossl_aes_gcm_encrypt_avx512(gcmctx->key, gcmctx, &gcmctx->mres, in, len, out);
     else
-        ossl_aes_gcm_decrypt_avx512(ctx->ks, gcmctx, &gcmctx->mres, in, len, out);
+        ossl_aes_gcm_decrypt_avx512(gcmctx->key, gcmctx, &gcmctx->mres, in, len, out);
 
     return 1;
 }

--- a/providers/implementations/ciphers/cipher_sm4_gcm_hw.c
+++ b/providers/implementations/ciphers/cipher_sm4_gcm_hw.c
@@ -15,7 +15,6 @@
 #include "crypto/sm4_platform.h"
 
 # define SM4_GCM_HW_SET_KEY_CTR_FN(ks, fn_set_enc_key, fn_block, fn_ctr)       \
-    ctx->ks = ks;                                                              \
     fn_set_enc_key(key, ks);                                                   \
     CRYPTO_gcm128_init(&ctx->gcm, ks, (block128_f)fn_block);                   \
     ctx->ctr = (ctr128_f)fn_ctr;                                               \

--- a/providers/implementations/include/prov/ciphercommon_gcm.h
+++ b/providers/implementations/include/prov/ciphercommon_gcm.h
@@ -79,7 +79,6 @@ typedef struct prov_gcm_ctx_st {
     const PROV_GCM_HW *hw;  /* hardware specific methods */
     GCM128_CONTEXT gcm;
     ctr128_f ctr;
-    const void *ks;
 } PROV_GCM_CTX;
 
 PROV_CIPHER_FUNC(int, GCM_setkey, (PROV_GCM_CTX *ctx, const unsigned char *key,
@@ -126,7 +125,6 @@ int ossl_gcm_cipher_update(PROV_GCM_CTX *ctx, const unsigned char *in,
                            size_t len, unsigned char *out);
 
 # define GCM_HW_SET_KEY_CTR_FN(ks, fn_set_enc_key, fn_block, fn_ctr)            \
-    ctx->ks = ks;                                                              \
     fn_set_enc_key(key, keylen * 8, ks);                                       \
     CRYPTO_gcm128_init(&ctx->gcm, ks, (block128_f)fn_block);                   \
     ctx->ctr = (ctr128_f)fn_ctr;                                               \


### PR DESCRIPTION
This copy would need an update on dupctx but
rather than doing it just remove the copy.

This fixes failures of evp_test on Windows with
new CPUs.
