### PR TITLE
cms encrypt, better OBJ_nid2obj() return check

### DIFF
--- a/crypto/cms/cms_enc.c
+++ b/crypto/cms/cms_enc.c
@@ -81,7 +81,7 @@ BIO *ossl_cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec,
 
     if (enc) {
         calg->algorithm = OBJ_nid2obj(EVP_CIPHER_CTX_get_type(ctx));
-        if (calg->algorithm == NULL) {
+        if (calg->algorithm == NULL || calg->algorithm->nid == NID_undef) {
             ERR_raise(ERR_LIB_CMS, CMS_R_UNSUPPORTED_CONTENT_ENCRYPTION_ALGORITHM);
             goto err;
         }

--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -50,7 +50,7 @@ my ($no_des, $no_dh, $no_dsa, $no_ec, $no_ec2m, $no_rc2, $no_zlib)
 
 $no_rc2 = 1 if disabled("legacy");
 
-plan tests => 21;
+plan tests => 22;
 
 ok(run(test(["pkcs7_test"])), "test pkcs7");
 
@@ -1154,3 +1154,14 @@ with({ exit_checker => sub { return shift == 3; } },
             "issue#21986");
         }
     });
+
+# Test for problem reported in #22225
+with({ exit_checker => sub { return shift == 3; } },
+    sub {
+	ok(run(app(['openssl', 'cms', '-encrypt',
+		    '-in', srctop_file("test", "smcont.txt"),
+		    '-aes-256-ctr', '-recip',
+		    catfile($smdir, "smec1.pem"),
+		   ])),
+	   "Check for failure when cipher does not have an assigned OID (issue#22225)");
+     });


### PR DESCRIPTION
Fixes #22225

In `OBJ_nid2obj()`, if the NID does not have an OID, then a pointer to the special "undefined" ASN1_OBJECT is returned.  Check for the undefined-ASN1_OBJECT and return an error.

Testing:

```
#!/bin/bash -x

shopt -s expand_aliases

alias openssl="LD_LIBRARY_PATH=~/git/openssl ~/git/openssl/apps/openssl"

echo "This is a confidential message.  It should be encrypted." > msg.txt

## this should fail b/c there is no OID for aes-256-ctr
openssl cms -encrypt -in msg.txt -aes-256-ctr -out msg.txt.cms -recip demos/cms/signer.pem
echo $?
```
