### PR TITLE
Ignore ping deadline when calculating tick deadline if we can't send

### DIFF
--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -2590,6 +2590,13 @@ static OSSL_TIME ch_determine_next_tick_deadline(QUIC_CHANNEL *ch)
                                                                     ossl_quic_enc_level_to_pn_space(i)));
             }
         }
+
+        /*
+         * When do we need to send an ACK-eliciting packet to reset the idle
+         * deadline timer for the peer?
+         */
+        if (!ossl_time_is_infinite(ch->ping_deadline))
+            deadline = ossl_time_min(deadline, ch->ping_deadline);
     }
 
     /* Apply TXP wakeup deadline. */
@@ -2603,14 +2610,6 @@ static OSSL_TIME ch_determine_next_tick_deadline(QUIC_CHANNEL *ch)
     else if (!ossl_time_is_infinite(ch->idle_deadline))
         deadline = ossl_time_min(deadline,
                                  ch->idle_deadline);
-
-    /*
-     * When do we need to send an ACK-eliciting packet to reset the idle
-     * deadline timer for the peer?
-     */
-    if (!ossl_time_is_infinite(ch->ping_deadline))
-        deadline = ossl_time_min(deadline,
-                                 ch->ping_deadline);
 
     /* When does the RXKU process complete? */
     if (ch->rxku_in_progress)


### PR DESCRIPTION
If the CC TX allowance is zero then we cannot send a PING frame at the moment, so do not take into account the ping deadline when calculating the tick deadline in that case.

This avoids the hang found by the fuzzer mentioned in https://github.com/openssl/openssl/pull/22368#issuecomment-1765131727

