### PR TITLE
Ignore retry packets that arrive too late

### DIFF
--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -2225,7 +2225,7 @@ static void ch_rx_handle_packet(QUIC_CHANNEL *ch)
          * Initial or Retry packet from the server, it MUST discard any
          * subsequent Retry packets that it receives.
          */
-        if ((ch->el_discarded & (1U << QUIC_ENC_LEVEL_INITIAL)) != 0)
+        if (ch->have_received_enc_pkt)
             return;
 
         if (ch->qrx_pkt->hdr->len <= QUIC_RETRY_INTEGRITY_TAG_LEN)

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -2220,6 +2220,14 @@ static void ch_rx_handle_packet(QUIC_CHANNEL *ch)
              */
             return;
 
+        /*
+         * RFC 9000 s 17.2.5.2: After the client has received and processed an
+         * Initial or Retry packet from the server, it MUST discard any
+         * subsequent Retry packets that it receives.
+         */
+        if ((ch->el_discarded & (1U << QUIC_ENC_LEVEL_INITIAL)) != 0)
+            return;
+
         if (ch->qrx_pkt->hdr->len <= QUIC_RETRY_INTEGRITY_TAG_LEN)
             /* Packets with zero-length Retry Tokens are invalid. */
             return;


### PR DESCRIPTION
RFC 9000 s 17.2.5.2 says

> After the client has received and processed an Initial or Retry packet
> from the server, it MUST discard any subsequent Retry packets that it
> receives.

We were checking for multiple Retry packets, but not if we had already processed an Initial packet.

Fixes the assertion failure noted in
https://github.com/openssl/openssl/pull/22368#issuecomment-1765618884

