### PR TITLE
crypto(7) no longer exists; EVP_*(3) point to a five-level manual chase instead of EVP_MD-*(7)

### DIFF
--- a/doc/man3/EVP_aes_128_gcm.pod
+++ b/doc/man3/EVP_aes_128_gcm.pod
@@ -167,7 +167,7 @@ the XTS "tweak" value.
 
 Developers should be aware of the negative performance implications of
 calling these functions multiple times and should consider using
-L<EVP_CIPHER_fetch(3)> instead.
+L<EVP_CIPHER_fetch(3)> with L<EVP_CIPHER-AES(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_aria_128_gcm.pod
+++ b/doc/man3/EVP_aria_128_gcm.pod
@@ -96,7 +96,7 @@ correctly, see the L<EVP_EncryptInit(3)/AEAD Interface> section for details.
 
 Developers should be aware of the negative performance implications of
 calling these functions multiple times and should consider using
-L<EVP_CIPHER_fetch(3)> instead.
+L<EVP_CIPHER_fetch(3)> with L<EVP_CIPHER-ARIA(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_bf_cbc.pod
+++ b/doc/man3/EVP_bf_cbc.pod
@@ -41,7 +41,7 @@ Blowfish encryption algorithm in CBC, CFB, ECB and OFB modes respectively.
 
 Developers should be aware of the negative performance implications of
 calling these functions multiple times and should consider using
-L<EVP_CIPHER_fetch(3)> instead.
+L<EVP_CIPHER_fetch(3)> with L<EVP_CIPHER-BLOWFISH(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_blake2b512.pod
+++ b/doc/man3/EVP_blake2b512.pod
@@ -35,7 +35,7 @@ The BLAKE2b algorithm that produces a 512-bit output from a given input.
 
 Developers should be aware of the negative performance implications of
 calling these functions multiple times and should consider using
-L<EVP_MD_fetch(3)> instead.
+L<EVP_MD_fetch(3)> with L<EVP_MD-BLAKE2(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 While the BLAKE2b and BLAKE2s algorithms supports a variable length digest,

--- a/doc/man3/EVP_camellia_128_ecb.pod
+++ b/doc/man3/EVP_camellia_128_ecb.pod
@@ -79,7 +79,7 @@ Camellia for 128, 192 and 256 bit keys in the following modes: CBC, CFB with
 
 Developers should be aware of the negative performance implications of
 calling these functions multiple times and should consider using
-L<EVP_CIPHER_fetch(3)> instead.
+L<EVP_CIPHER_fetch(3)> with L<EVP_CIPHER-CAMELLIA(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_cast5_cbc.pod
+++ b/doc/man3/EVP_cast5_cbc.pod
@@ -41,7 +41,7 @@ CAST encryption algorithm in CBC, ECB, CFB and OFB modes respectively.
 
 Developers should be aware of the negative performance implications of
 calling these functions multiple times and should consider using
-L<EVP_CIPHER_fetch(3)> instead.
+L<EVP_CIPHER_fetch(3)> with L<EVP_CIPHER-CAST(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_chacha20.pod
+++ b/doc/man3/EVP_chacha20.pod
@@ -44,7 +44,7 @@ L<EVP_EncryptInit(3)/AEAD Interface> section for more information.
 
 Developers should be aware of the negative performance implications of
 calling these functions multiple times and should consider using
-L<EVP_CIPHER_fetch(3)> instead.
+L<EVP_CIPHER_fetch(3)> with L<EVP_CIPHER-CHACHA(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 L<RFC 7539|https://www.rfc-editor.org/rfc/rfc7539.html#section-2.4>

--- a/doc/man3/EVP_des_cbc.pod
+++ b/doc/man3/EVP_des_cbc.pod
@@ -89,7 +89,7 @@ Triple-DES key wrap according to RFC 3217 Section 3.
 
 Developers should be aware of the negative performance implications of
 calling these functions multiple times and should consider using
-L<EVP_CIPHER_fetch(3)> instead.
+L<EVP_CIPHER_fetch(3)> with L<EVP_CIPHER-DES(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_desx_cbc.pod
+++ b/doc/man3/EVP_desx_cbc.pod
@@ -31,7 +31,7 @@ implementation.
 
 Developers should be aware of the negative performance implications of
 calling this function multiple times and should consider using
-L<EVP_CIPHER_fetch(3)> instead.
+L<EVP_CIPHER_fetch(3)> with L<EVP_CIPHER-DES(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_idea_cbc.pod
+++ b/doc/man3/EVP_idea_cbc.pod
@@ -39,7 +39,7 @@ The IDEA encryption algorithm in CBC, CFB, ECB and OFB modes respectively.
 
 Developers should be aware of the negative performance implications of
 calling these functions multiple times and should consider using
-L<EVP_CIPHER_fetch(3)> instead.
+L<EVP_CIPHER_fetch(3)> with L<EVP_CIPHER-IDEA(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_md2.pod
+++ b/doc/man3/EVP_md2.pod
@@ -28,7 +28,7 @@ The MD2 algorithm which produces a 128-bit output from a given input.
 
 Developers should be aware of the negative performance implications of
 calling this function multiple times and should consider using
-L<EVP_MD_fetch(3)> instead.
+L<EVP_MD_fetch(3)> with L<EVP_MD-MD2(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_md4.pod
+++ b/doc/man3/EVP_md4.pod
@@ -29,7 +29,7 @@ The MD4 algorithm which produces a 128-bit output from a given input.
 
 Developers should be aware of the negative performance implications of
 calling this function multiple times and should consider using
-L<EVP_MD_fetch(3)> instead.
+L<EVP_MD_fetch(3)> with L<EVP_MD-MD4(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_md5.pod
+++ b/doc/man3/EVP_md5.pod
@@ -40,7 +40,7 @@ WARNING: this algorithm is not intended for non-SSL usage.
 
 Developers should be aware of the negative performance implications of
 calling these functions multiple times and should consider using
-L<EVP_MD_fetch(3)> instead.
+L<EVP_MD_fetch(3)> with L<EVP_MD-MD5(7)> or L<EVP_MD-MD5-SHA1(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_mdc2.pod
+++ b/doc/man3/EVP_mdc2.pod
@@ -30,7 +30,7 @@ The MDC-2DES algorithm of using MDC-2 with the DES block cipher. It produces a
 
 Developers should be aware of the negative performance implications of
 calling this function multiple times and should consider using
-L<EVP_MD_fetch(3)> instead.
+L<EVP_MD_fetch(3)> with L<EVP_MD-MDC2(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_rc2_cbc.pod
+++ b/doc/man3/EVP_rc2_cbc.pod
@@ -55,7 +55,7 @@ functions to set the key length and effective key length.
 
 Developers should be aware of the negative performance implications of
 calling these functions multiple times and should consider using
-L<EVP_CIPHER_fetch(3)> instead.
+L<EVP_CIPHER_fetch(3)> with L<EVP_CIPHER-RC2(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_rc4.pod
+++ b/doc/man3/EVP_rc4.pod
@@ -47,7 +47,7 @@ interface.
 
 Developers should be aware of the negative performance implications of
 calling these functions multiple times and should consider using
-L<EVP_CIPHER_fetch(3)> instead.
+L<EVP_CIPHER_fetch(3)> with L<EVP_CIPHER-RC4(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_rc5_32_12_16_cbc.pod
+++ b/doc/man3/EVP_rc5_32_12_16_cbc.pod
@@ -60,7 +60,7 @@ is an int.
 
 Developers should be aware of the negative performance implications of
 calling these functions multiple times and should consider using
-L<EVP_CIPHER_fetch(3)> instead.
+L<EVP_CIPHER_fetch(3)> with L<EVP_CIPHER-RC5(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_ripemd160.pod
+++ b/doc/man3/EVP_ripemd160.pod
@@ -29,7 +29,7 @@ The RIPEMD-160 algorithm which produces a 160-bit output from a given input.
 
 Developers should be aware of the negative performance implications of
 calling this function multiple times and should consider using
-L<EVP_MD_fetch(3)> instead.
+L<EVP_MD_fetch(3)> with L<EVP_MD-RIPEMD160(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_seed_cbc.pod
+++ b/doc/man3/EVP_seed_cbc.pod
@@ -41,7 +41,7 @@ The SEED encryption algorithm in CBC, CFB, ECB and OFB modes respectively.
 
 Developers should be aware of the negative performance implications of
 calling these functions multiple times and should consider using
-L<EVP_CIPHER_fetch(3)> instead.
+L<EVP_CIPHER_fetch(3)> with L<EVP_CIPHER-SEED(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_sha1.pod
+++ b/doc/man3/EVP_sha1.pod
@@ -29,7 +29,7 @@ The SHA-1 algorithm which produces a 160-bit output from a given input.
 
 Developers should be aware of the negative performance implications of
 calling this function multiple times and should consider using
-L<EVP_MD_fetch(3)> instead.
+L<EVP_MD_fetch(3)> with L<EVP_MD-SHA1(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_sha224.pod
+++ b/doc/man3/EVP_sha224.pod
@@ -49,7 +49,7 @@ their outputs are of the same size.
 
 Developers should be aware of the negative performance implications of
 calling these functions multiple times and should consider using
-L<EVP_MD_fetch(3)> instead.
+L<EVP_MD_fetch(3)> with L<EVP_MD-SHA2(7)>instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_sha3_224.pod
+++ b/doc/man3/EVP_sha3_224.pod
@@ -54,7 +54,7 @@ B<EVP_shake256> provides that of 256 bits.
 
 Developers should be aware of the negative performance implications of
 calling these functions multiple times and should consider using
-L<EVP_MD_fetch(3)> instead.
+L<EVP_MD_fetch(3)> with L<EVP_MD-SHA3(7)> or L<EVP_MD-SHAKE(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_sm3.pod
+++ b/doc/man3/EVP_sm3.pod
@@ -28,7 +28,7 @@ The SM3 hash function.
 
 Developers should be aware of the negative performance implications of
 calling this function multiple times and should consider using
-L<EVP_MD_fetch(3)> instead.
+L<EVP_MD_fetch(3)> with L<EVP_MD-SM3(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_sm4_cbc.pod
+++ b/doc/man3/EVP_sm4_cbc.pod
@@ -45,7 +45,7 @@ respectively.
 
 Developers should be aware of the negative performance implications of
 calling these functions multiple times and should consider using
-L<EVP_CIPHER_fetch(3)> instead.
+L<EVP_CIPHER_fetch(3)> with L<EVP_CIPHER-SM4(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_whirlpool.pod
+++ b/doc/man3/EVP_whirlpool.pod
@@ -30,7 +30,7 @@ input.
 
 Developers should be aware of the negative performance implications of
 calling this function multiple times and should consider using
-L<EVP_MD_fetch(3)> instead.
+L<EVP_MD_fetch(3)> with L<EVP_MD-WHIRLPOOL(7)> instead.
 See L<crypto(7)/Performance> for further information.
 
 =head1 RETURN VALUES


### PR DESCRIPTION
I'd wanted to fix 
![image](https://github.com/openssl/openssl/assets/6709544/9c9c972b-ffca-4926-8d1b-692b7d01db3b)
but crypto(7) doesn't exist anymore:
```
$ git show d5b7d0a6a2c7263c4bc22a9403e05bc80d324f9a --stat
commit d5b7d0a6a2c7263c4bc22a9403e05bc80d324f9a
Author: Matt Caswell <matt@openssl.org>
Date:   Thu Jul 13 15:02:40 2023 +0100

    Incorporate the crypto man page into the OpenSSL guide

    Some content has been moved out into the general libraries introduction.
    Reformat and fill in some gaps with what remains.

    Reviewed-by: Hugo Landau <hlandau@openssl.org>
    Reviewed-by: Tim Hudson <tjh@openssl.org>
    Reviewed-by: Matthias St. Pierre <Matthias.St.Pierre@ncp-e.com>
    Reviewed-by: Anton Arapov <anton@openssl.org>
    (Merged from https://github.com/openssl/openssl/pull/21560)

 doc/man7/crypto.pod                            | 580 ---------------------------------------------------------------------------------------------------------------------
 doc/man7/ossl-guide-libcrypto-introduction.pod | 398 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 398 insertions(+), 580 deletions(-)
```
and yet `git grep crypto\(7` yields  precisely 100 lines. Not great. Trivial fix, this is patch 1.

---

Earlier today I finally buckled and tried to find out what the
> Developers should be aware of the negative performance implications of calling these functions multiple times and should consider using EVP_MD_fetch(3) instead. See "Performance" in crypto(7) for further information.

paragraph means.

This took me 5 (five!) manuals:
* EVP_sha1(3)
* crypto(7)
* EVP_MD_fetch(3) (but not there! don't read that!)
* OSSL_PROVIDER-default(7)
* EVP_MD-SHA1(7)

just to find out what I'm supposed to give `EVP_MD_fetch()` (well okay, SHA was easy, but what "providers" call BLAKE2 was too nebulous to guess). Which is not great, considering these are supposed to be replacing the EVP_* functions, but what you're supposed to be replacing it *with* is deadass buried. Thus I made the paragraphs that contained "and should consider using" be
> Developers should be aware of the negative performance implications of calling these functions multiple times and should consider using EVP_MD_fetch(3) with EVP_MD-BLAKE2(7) instead.  See "Performance" in ossl-guide-libcrypto-introduction(7) for further information.

Which, I think, is useful to the developer instead of damning them for using the "legacy" function with no obvious recourse. This is patch 2.