### PR TITLE
Added support for RFC 6961 - Multiple Certificate Status Request Extension

### DIFF
--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -722,6 +722,7 @@ static STRINT_PAIR tlsext_types[] = {
     {"use SRTP", TLSEXT_TYPE_use_srtp},
     {"session ticket", TLSEXT_TYPE_session_ticket},
     {"renegotiation info", TLSEXT_TYPE_renegotiate},
+    {"status request v2", TLSEXT_TYPE_status_request_v2},
     {"signed certificate timestamps", TLSEXT_TYPE_signed_certificate_timestamp},
     {"client cert type", TLSEXT_TYPE_client_cert_type},
     {"server cert type", TLSEXT_TYPE_server_cert_type},

--- a/doc/man3/SSL_CTX_set_tlsext_status_cb.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_status_cb.pod
@@ -11,7 +11,9 @@ SSL_CTX_get_tlsext_status_type,
 SSL_set_tlsext_status_type,
 SSL_get_tlsext_status_type,
 SSL_get_tlsext_status_ocsp_resp,
-SSL_set_tlsext_status_ocsp_resp
+SSL_set_tlsext_status_ocsp_resp,
+SSL_get_tlsext_status_ocsp_resp_ex,
+SSL_set_tlsext_status_ocsp_resp_ex
 - OCSP Certificate Status Request functions
 
 =head1 SYNOPSIS
@@ -33,17 +35,49 @@ SSL_set_tlsext_status_ocsp_resp
  long SSL_get_tlsext_status_ocsp_resp(ssl, unsigned char **resp);
  long SSL_set_tlsext_status_ocsp_resp(ssl, unsigned char *resp, int len);
 
+ long SSL_get_tlsext_status_ocsp_resp_ex(ssl, STACK_OF(OCSP_RESPONSE) *resp);
+ long SSL_set_tlsext_status_ocsp_resp_ex(ssl, STACK_OF(OCSP_RESPONSE) *resp);
+
 =head1 DESCRIPTION
 
 A client application may request that a server send back an OCSP status response
-(also known as OCSP stapling). To do so the client should call the
+(also known as OCSP stapling). There are two TLS extensions implemented:
+
+=over 4
+
+=item
+I<status_request>: L<https://tools.ietf.org/html/rfc6066>
+
+This will request the OCSP status for only the server certificate, excluding any
+intermediate certificates in the chain.
+
+=item
+I<status_request_v2>: L<https://tools.ietf.org/html/rfc6961>
+
+This will request the OCSP status for the complete server certificate chain,
+i.e. the server certificate and all intermediate certificates.
+
+=back
+
+=head2 Client
+
+To request the OCSP status, the client should call the 
 SSL_CTX_set_tlsext_status_type() function prior to the creation of any SSL
 objects. Alternatively an application can call the SSL_set_tlsext_status_type()
 function on an individual SSL object prior to the start of the handshake.
-Currently the only supported type is B<TLSEXT_STATUSTYPE_ocsp>. This value
-should be passed in the B<type> argument. Calling
-SSL_CTX_get_tlsext_status_type() will return the type B<TLSEXT_STATUSTYPE_ocsp>
-previously set via SSL_CTX_set_tlsext_status_type() or -1 if not set.
+
+Currently the supported types are B<TLSEXT_STATUSTYPE_ocsp> and 
+B<TLSEXT_STATUSTYPE_ocsp_multi>. This value should be passed in the 
+B<type> argument. Calling SSL_CTX_get_tlsext_status_type() will return 
+the type B<TLSEXT_STATUSTYPE_ocsp> previously set via 
+SSL_CTX_set_tlsext_status_type() or -1 if not set.
+
+For interoperability with other servers and clients, internal data holder for  
+both SSL_set_tlsext_status_ocsp_resp_ex() and SSL_set_tlsext_status_ocsp_resp()
+functions is the same. So no matter the API used, OCSP responses can be transferred 
+by both TLS extensions, depending on which is requested by TLS client.
+Clients of openssl lib may use old API, but if new extension is requested, 
+it will be used, and vice-versa. 
 
 The client should additionally provide a callback function to decide what to do
 with the returned OCSP response by calling SSL_CTX_set_tlsext_status_cb(). The
@@ -58,27 +92,42 @@ SSL_CTX_get_tlsext_status_arg().
 
 On the client side SSL_get_tlsext_status_type() can be used to determine whether
 the client has previously called SSL_set_tlsext_status_type(). It will return
-B<TLSEXT_STATUSTYPE_ocsp> if it has been called or -1 otherwise. On the server
-side SSL_get_tlsext_status_type() can be used to determine whether the client
-requested OCSP stapling. If the client requested it then this function will
-return B<TLSEXT_STATUSTYPE_ocsp>, or -1 otherwise.
+B<TLSEXT_STATUSTYPE_ocsp> if it has been called or -1 otherwise. 
 
-The response returned by the server can be obtained via a call to
-SSL_get_tlsext_status_ocsp_resp(). The value B<*resp> will be updated to point
-to the OCSP response data and the return value will be the length of that data.
-Typically a callback would obtain an OCSP_RESPONSE object from this data via a
-call to the d2i_OCSP_RESPONSE() function. If the server has not provided any
+The response returned by the server can be obtained via a call to 
+B<SSL_get_tlsext_status_ocsp_resp> or B<SSL_get_tlsext_status_ocsp_resp_ex>.
+
+B<SSL_get_tlsext_status_ocsp_resp> will update the value B<*resp> to point to
+the OCSP response data in DER format, and the return value will be the length of that data.
+Typically a callback would obtain an OCSP_RESPONSE object from this data via 
+a call to the d2i_OCSP_RESPONSE() function.
+If the server has not provided any response data, then B<*resp> will be NULL 
+and the return value from SSL_get_tlsext_status_ocsp_resp() will be -1.
+
+B<SSL_get_tlsext_status_ocsp_resp_ex> will update B<*resp> to point
+to the OCSP response stack and the return value will be the number of responses
+on the stack. If the server has not provided any
 response data then B<*resp> will be NULL and the return value from
-SSL_get_tlsext_status_ocsp_resp() will be -1.
+SSL_get_tlsext_status_ocsp_resp_ex() will be -1.
+Typically a openssl client would obtain an OCSP_RESPONSE object from the stack via a
+call to sk_OCSP_RESPONSE_value().
+
+=head2 Server
+
+On the server side SSL_get_tlsext_status_type() can be used to determine whether
+the client requested OCSP stapling. If the client requested it then this
+function will return B<TLSEXT_STATUSTYPE_ocsp>, B<TLSEXT_STATUSTYPE_ocsp_multi> 
+or -1 otherwise.
 
 A server application must also call the SSL_CTX_set_tlsext_status_cb() function
 if it wants to be able to provide clients with OCSP Certificate Status
-responses. Typically the server callback would obtain the server certificate
-that is being sent back to the client via a call to SSL_get_certificate();
-obtain the OCSP response to be sent back; and then set that response data by
-calling SSL_set_tlsext_status_ocsp_resp(). A pointer to the response data should
-be provided in the B<resp> argument, and the length of that data should be in
-the B<len> argument.
+responses. Typically the server callback would obtain the server certificates
+that are being sent back to the client via calls to SSL_get_certificate() and
+SSL_get0_chain_certs(); obtain the OCSP responses to be sent back; and then set
+that response data by calling SSL_set_tlsext_status_ocsp_resp() or
+SSL_set_tlsext_status_ocsp_resp_ex(). 
+Pointers provided to both functions are used internally, and should not be freed 
+or modifyed by the caller after the call.
 
 =head1 RETURN VALUES
 
@@ -95,12 +144,16 @@ occurred).
 SSL_CTX_set_tlsext_status_cb(), SSL_CTX_set_tlsext_status_arg(),
 SSL_CTX_set_tlsext_status_type(), SSL_set_tlsext_status_type() and
 SSL_set_tlsext_status_ocsp_resp() return 0 on error or 1 on success.
+SSL_set_tlsext_status_ocsp_resp_ex() return 0 on error or 1 on success.
 
 SSL_CTX_get_tlsext_status_type() returns the value previously set by
 SSL_CTX_set_tlsext_status_type(), or -1 if not set.
 
 SSL_get_tlsext_status_ocsp_resp() returns the length of the OCSP response data
 or -1 if there is no OCSP response data.
+
+SSL_get_tlsext_status_ocsp_resp_ex() returns the number of the OCSP responses
+on the stack or -1 if there is no OCSP response data.
 
 SSL_get_tlsext_status_type() returns B<TLSEXT_STATUSTYPE_ocsp> on the client
 side if SSL_set_tlsext_status_type() was previously called, or on the server
@@ -117,9 +170,9 @@ and SSL_CTX_set_tlsext_status_type() functions were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 
-Copyright 2015-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2015-2018 The OpenSSL Project Authors. All Rights Reserved.
 
-Licensed under the Apache License 2.0 (the "License").  You may not use
+Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy
 in the file LICENSE in the source distribution or at
 L<https://www.openssl.org/source/license.html>.

--- a/include/openssl/ocsp.h.in
+++ b/include/openssl/ocsp.h.in
@@ -60,6 +60,8 @@ use OpenSSL::stackhash qw(generate_stack_macros);
 
 # ifndef OPENSSL_NO_OCSP
 
+DEFINE_STACK_OF(OCSP_RESPONSE)
+
 #  include <openssl/x509.h>
 #  include <openssl/x509v3.h>
 #  include <openssl/safestack.h>

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -1339,6 +1339,8 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 # define SSL_CTRL_SET_RETRY_VERIFY               136
 # define SSL_CTRL_GET_VERIFY_CERT_STORE          137
 # define SSL_CTRL_GET_CHAIN_CERT_STORE           138
+# define SSL_CTRL_GET_TLSEXT_STATUS_REQ_OCSP_RESP_EX        139
+# define SSL_CTRL_SET_TLSEXT_STATUS_REQ_OCSP_RESP_EX        140
 # define SSL_CERT_SET_FIRST                      1
 # define SSL_CERT_SET_NEXT                       2
 # define SSL_CERT_SET_SERVER                     3

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -116,6 +116,8 @@ extern "C" {
 /* ExtensionType value from RFC7301 */
 # define TLSEXT_TYPE_application_layer_protocol_negotiation 16
 
+/* ExtensionType value from RFC6961 */
+# define TLSEXT_TYPE_status_request_v2           17
 /*
  * Extension type for Certificate Transparency
  * https://tools.ietf.org/html/rfc6962#section-3.3.1
@@ -172,6 +174,8 @@ extern "C" {
 # define TLSEXT_NAMETYPE_host_name 0
 /* status request value from RFC3546 */
 # define TLSEXT_STATUSTYPE_ocsp 1
+/* status request v2 value from RFC6961 */
+# define TLSEXT_STATUSTYPE_ocsp_multi 2
 
 /* ECPointFormat values from RFC4492 */
 # define TLSEXT_ECPOINTFORMAT_first                      0
@@ -320,6 +324,12 @@ __owur int SSL_check_chain(SSL *s, X509 *x, EVP_PKEY *pk, STACK_OF(X509) *chain)
 
 # define SSL_set_tlsext_status_ocsp_resp(ssl, arg, arglen) \
         SSL_ctrl(ssl,SSL_CTRL_SET_TLSEXT_STATUS_REQ_OCSP_RESP,arglen,arg)
+
+# define SSL_get_tlsext_status_ocsp_resp_ex(ssl, arg) \
+        SSL_ctrl(ssl,SSL_CTRL_GET_TLSEXT_STATUS_REQ_OCSP_RESP_EX,0,arg)
+
+# define SSL_set_tlsext_status_ocsp_resp_ex(ssl, arg) \
+        SSL_ctrl(ssl,SSL_CTRL_SET_TLSEXT_STATUS_REQ_OCSP_RESP_EX,0,arg)
 
 # define SSL_CTX_set_tlsext_servername_callback(ctx, cb) \
         SSL_CTX_callback_ctrl(ctx,SSL_CTRL_SET_TLSEXT_SERVERNAME_CB,\

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -229,7 +229,15 @@ static const EXTENSION_DEFINITION ext_defs[] = {
         tls_parse_stoc_status_request, tls_construct_stoc_status_request,
         tls_construct_ctos_status_request, NULL
     },
+    {
+        TLSEXT_TYPE_status_request_v2,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_2_SERVER_HELLO,
+        init_status_request, tls_parse_ctos_status_request_v2,
+        tls_parse_stoc_status_request_v2, tls_construct_stoc_status_request_v2,
+        tls_construct_ctos_status_request_v2, NULL
+    },
 #else
+    INVALID_EXTENSION,
     INVALID_EXTENSION,
 #endif
 #ifndef OPENSSL_NO_NEXTPROTONEG
@@ -1141,9 +1149,8 @@ static int init_status_request(SSL_CONNECTION *s, unsigned int context)
          * Ensure we get sensible values passed to tlsext_status_cb in the event
          * that we don't receive a status message
          */
-        OPENSSL_free(s->ext.ocsp.resp);
-        s->ext.ocsp.resp = NULL;
-        s->ext.ocsp.resp_len = 0;
+        sk_OCSP_RESPONSE_pop_free(s->ext.ocsp.resp_ex, OCSP_RESPONSE_free);
+        s->ext.ocsp.resp_ex = NULL;
     }
 
     return 1;

--- a/ssl/statem/extensions_cust.c
+++ b/ssl/statem/extensions_cust.c
@@ -526,6 +526,7 @@ int SSL_extension_supported(unsigned int ext_type)
 #endif
 #ifndef OPENSSL_NO_OCSP
     case TLSEXT_TYPE_status_request:
+    case TLSEXT_TYPE_status_request_v2:
 #endif
 #ifndef OPENSSL_NO_CT
     case TLSEXT_TYPE_signed_certificate_timestamp:

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -996,6 +996,10 @@ static int ssl_add_cert_to_wpacket(SSL_CONNECTION *s, WPACKET *pkt,
         return 0;
     }
 
+    /* Count number of certificates added to packet handshake */
+    if(!for_comp)
+        s->s3.tmp.send_certs_prepared++;
+
     return 1;
 }
 

--- a/ssl/statem/statem_local.h
+++ b/ssl/statem/statem_local.h
@@ -312,6 +312,9 @@ int tls_parse_ctos_sig_algs(SSL_CONNECTION *s, PACKET *pkt,
 int tls_parse_ctos_status_request(SSL_CONNECTION *s, PACKET *pkt,
                                   unsigned int context,
                                   X509 *x, size_t chainidx);
+int tls_parse_ctos_status_request_v2(SSL_CONNECTION *s, PACKET *pkt,
+                                  unsigned int context,
+                                  X509 *x, size_t chainidx);
 #endif
 #ifndef OPENSSL_NO_NEXTPROTONEG
 int tls_parse_ctos_npn(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
@@ -362,10 +365,16 @@ EXT_RETURN tls_construct_stoc_session_ticket(SSL_CONNECTION *s, WPACKET *pkt,
                                              unsigned int context, X509 *x,
                                              size_t chainidx);
 #ifndef OPENSSL_NO_OCSP
+
 EXT_RETURN tls_construct_stoc_status_request(SSL_CONNECTION *s, WPACKET *pkt,
                                              unsigned int context, X509 *x,
                                              size_t chainidx);
+
+EXT_RETURN tls_construct_stoc_status_request_v2(SSL_CONNECTION *s, WPACKET *pkt,
+                                             unsigned int context, X509 *x,
+                                             size_t chainidx);
 #endif
+
 #ifndef OPENSSL_NO_NEXTPROTONEG
 EXT_RETURN tls_construct_stoc_next_proto_neg(SSL_CONNECTION *s, WPACKET *pkt,
                                              unsigned int context, X509 *x,
@@ -441,6 +450,9 @@ EXT_RETURN tls_construct_ctos_sig_algs(SSL_CONNECTION *s, WPACKET *pkt,
 EXT_RETURN tls_construct_ctos_status_request(SSL_CONNECTION *s, WPACKET *pkt,
                                              unsigned int context, X509 *x,
                                              size_t chainidx);
+EXT_RETURN tls_construct_ctos_status_request_v2(SSL_CONNECTION *s, WPACKET *pkt,
+                                             unsigned int context, X509 *x,
+                                             size_t chainidx);
 #endif
 #ifndef OPENSSL_NO_NEXTPROTONEG
 EXT_RETURN tls_construct_ctos_npn(SSL_CONNECTION *s, WPACKET *pkt,
@@ -508,6 +520,9 @@ int tls_parse_stoc_session_ticket(SSL_CONNECTION *s, PACKET *pkt,
                                   X509 *x, size_t chainidx);
 #ifndef OPENSSL_NO_OCSP
 int tls_parse_stoc_status_request(SSL_CONNECTION *s, PACKET *pkt,
+                                  unsigned int context,
+                                  X509 *x, size_t chainidx);
+int tls_parse_stoc_status_request_v2(SSL_CONNECTION *s, PACKET *pkt,
                                   unsigned int context,
                                   X509 *x, size_t chainidx);
 #endif

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -476,6 +476,7 @@ static const ssl_trace_tbl ssl_exts_tbl[] = {
     {TLSEXT_TYPE_use_srtp, "use_srtp"},
     {TLSEXT_TYPE_application_layer_protocol_negotiation,
      "application_layer_protocol_negotiation"},
+    {TLSEXT_TYPE_status_request_v2, "status_request_v2"},
     {TLSEXT_TYPE_signed_certificate_timestamp, "signed_certificate_timestamps"},
     {TLSEXT_TYPE_client_cert_type, "client_cert_type"},
     {TLSEXT_TYPE_server_cert_type, "server_cert_type"},

--- a/test/ext_internal_test.c
+++ b/test/ext_internal_test.c
@@ -14,7 +14,7 @@
 
 #define EXT_ENTRY(name) { TLSEXT_IDX_##name, TLSEXT_TYPE_##name, #name }
 #define EXT_EXCEPTION(name) { TLSEXT_IDX_##name, TLSEXT_TYPE_invalid, #name }
-#define EXT_END(name) { TLSEXT_IDX_##name, TLSEXT_TYPE_out_of_range, #name }
+#define EXT_ENTRY_END(name) { TLSEXT_IDX_##name, TLSEXT_TYPE_out_of_range, #name }
 
 typedef struct {
     size_t idx;
@@ -38,8 +38,10 @@ static EXT_LIST ext_list[] = {
     EXT_ENTRY(session_ticket),
 #ifndef OPENSSL_NO_OCSP
     EXT_ENTRY(status_request),
+    EXT_ENTRY(status_request_v2),
 #else
     EXT_EXCEPTION(status_request),
+    EXT_EXCEPTION(status_request_v2),
 #endif
 #ifndef OPENSSL_NO_NEXTPROTONEG
     EXT_ENTRY(next_proto_neg),
@@ -74,7 +76,7 @@ static EXT_LIST ext_list[] = {
     EXT_ENTRY(certificate_authorities),
     EXT_ENTRY(padding),
     EXT_ENTRY(psk),
-    EXT_END(num_builtins)
+    EXT_ENTRY_END(num_builtins)
 };
 
 static int test_extension_list(void)

--- a/util/other.syms
+++ b/util/other.syms
@@ -599,6 +599,7 @@ SSL_get_signature_nid                   define
 SSL_get_time                            define
 SSL_get_timeout                         define
 SSL_get_tlsext_status_ocsp_resp         define
+SSL_get_tlsext_status_ocsp_resp_ex      define
 SSL_get_tlsext_status_type              define
 SSL_get_tmp_key                         define
 SSL_in_accept_init                      define
@@ -636,6 +637,7 @@ SSL_set_time                            define
 SSL_set_timeout                         define
 SSL_set_tlsext_host_name                define
 SSL_set_tlsext_status_ocsp_resp         define
+SSL_set_tlsext_status_ocsp_resp_ex      define
 SSL_set_tlsext_status_type              define
 SSL_set_tmp_dh                          define
 SSL_set_tmp_ecdh                        define


### PR DESCRIPTION
Added support for RFC 6961 - Multiple Certificate Status Request Extension
Fixes openssl/openssl#4449

- [x] documentation is added or updated
- [ ] tests are added or updated
