### PR TITLE
windows: don't echo password when stdin is not a tty

### DIFF
--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -280,7 +280,12 @@ static int read_string_inner(UI *ui, UI_STRING *uis, int echo, int strip_nl)
     int ok;
     char result[BUFSIZ];
     int maxsize = BUFSIZ - 1;
-# if !defined(OPENSSL_SYS_WINCE)
+    /*
+     * _WIN32_WCE is probably never defined without OPENSSL_SYS_WINCE,
+     * making it redundant at the condition, but because h_conin below
+     * doesn't exist when _WIN32_WCE is defined, test it explicitly.
+     */
+# if !defined(OPENSSL_SYS_WINCE) && !defined(_WIN32_WCE)
     char *p = NULL;
     int echo_eol = !echo;
 


### PR DESCRIPTION
The first commit is the essence of this PR, and hopefully a straight forward bugfix.

The second commit is trivial, and hopefully no-op/not-required, but it took most of my effort because I couldn't reach a definitive conclusion, hence the way too long commit message with suggested reasoning.

In a nutshell, the first commit won't compile on Windows CE unless
```c
#if !defined(OPENSSL_SYS_WINCE)
```
and
```c
#if !defined(OPENSSL_SYS_WINCE) && !defined(_WIN32_WCE)
```
Are equivalent - and this is the change that is the 2nd commit.

I.e. if _WIN32_WCE cannot be defined when OPENSSL_SYS_WINCE is not defined, then it's no-op, but I couldn't conclude that this is indeed the case.

If someone can give me a reason why _WIN32_WCE  is never defined unless OPENSSL_SYS_WINCE is also defined, then I'll replace the second commit message with this two-lines explanation, or maybe drop the second commit and only add a comment at the first commit.