### PR TITLE
Round up nano secs when converting OSSL_TIME to struct timeval

### DIFF
--- a/test/build.info
+++ b/test/build.info
@@ -34,7 +34,7 @@ IF[{- !$disabled{tests} -}]
           confdump \
           versions \
           aborttest test_test pkcs12_format_test pkcs12_api_test \
-          sanitytest rsa_complex exdatatest bntest \
+          sanitytest time_test rsa_complex exdatatest bntest \
           ecstresstest gmdifftest pbelutest \
           destest mdc2test sha_test \
           exptest pbetest localetest evp_pkey_ctx_new_from_name \
@@ -96,6 +96,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[sanitytest]=sanitytest.c
   INCLUDE[sanitytest]=../include ../apps/include
   DEPEND[sanitytest]=../libcrypto.a libtestutil.a
+
+  SOURCE[time_test]=time_test.c
+  INCLUDE[time_test]=../include ../apps/include
+  DEPEND[time_test]=../libcrypto.a libtestutil.a
 
   SOURCE[rand_test]=rand_test.c
   INCLUDE[rand_test]=../include ../apps/include

--- a/test/recipes/02-test_time.t
+++ b/test/recipes/02-test_time.t
@@ -1,0 +1,12 @@
+#! /usr/bin/env perl
+# Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_time", "time_test");

--- a/test/time_test.c
+++ b/test/time_test.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "testutil.h"
+#include "internal/time.h"
+
+static int test_time_to_timeval(void)
+{
+    OSSL_TIME a;
+    struct timeval tv;
+
+    a = ossl_time_zero();
+
+    tv = ossl_time_to_timeval(a);
+    if (!TEST_long_eq(tv.tv_sec, 0) || !TEST_long_eq(tv.tv_usec, 0))
+        return 0;
+
+    /* Test that zero round trips */
+    if (!TEST_true(ossl_time_is_zero(ossl_time_from_timeval(tv))))
+        return 0;
+
+    /* We should round up nano secs to the next usec */
+    a = ossl_ticks2time(1);
+    tv = ossl_time_to_timeval(a);
+    if (!TEST_long_eq(tv.tv_sec, 0) || !TEST_long_eq(tv.tv_usec, 1))
+        return 0;
+    a = ossl_ticks2time(999);
+    tv = ossl_time_to_timeval(a);
+    if (!TEST_long_eq(tv.tv_sec, 0) || !TEST_long_eq(tv.tv_usec, 1))
+        return 0;
+    a = ossl_ticks2time(1000);
+    tv = ossl_time_to_timeval(a);
+    if (!TEST_long_eq(tv.tv_sec, 0) || !TEST_long_eq(tv.tv_usec, 1))
+        return 0;
+    a = ossl_ticks2time(1001);
+    tv = ossl_time_to_timeval(a);
+    if (!TEST_long_eq(tv.tv_sec, 0) || !TEST_long_eq(tv.tv_usec, 2))
+        return 0;
+    a = ossl_ticks2time(999000);
+    tv = ossl_time_to_timeval(a);
+    if (!TEST_long_eq(tv.tv_sec, 0) || !TEST_long_eq(tv.tv_usec, 999))
+        return 0;
+    a = ossl_ticks2time(999999001);
+    tv = ossl_time_to_timeval(a);
+    if (!TEST_long_eq(tv.tv_sec, 1) || !TEST_long_eq(tv.tv_usec, 0))
+        return 0;
+    a = ossl_ticks2time(999999999);
+    tv = ossl_time_to_timeval(a);
+    if (!TEST_long_eq(tv.tv_sec, 1) || !TEST_long_eq(tv.tv_usec, 0))
+        return 0;
+    a = ossl_ticks2time(1000000000);
+    tv = ossl_time_to_timeval(a);
+    if (!TEST_long_eq(tv.tv_sec, 1) || !TEST_long_eq(tv.tv_usec, 0))
+        return 0;
+    a = ossl_ticks2time(1000000001);
+    tv = ossl_time_to_timeval(a);
+    if (!TEST_long_eq(tv.tv_sec, 1) || !TEST_long_eq(tv.tv_usec, 1))
+        return 0;
+
+    /*
+     * Note that we don't currently support infinity round tripping. Instead
+     * callers need to explicitly test for infinity.
+     */
+
+    return 1;
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(test_time_to_timeval);
+
+    return 1;
+}


### PR DESCRIPTION
struct timeval doesn't support nanosecs but OSSL_TIME does. We round up any nanosecs to ensure that a non-zero input always results in a non-zero output.

This fixes a quic-client fuzzer hang.

Fixes https://github.com/openssl/openssl/issues/22437
