### PR TITLE
run-checker-daily.yml: If the openssl app is not built do not run it

### DIFF
--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -147,6 +147,6 @@ jobs:
     - name: get cpu info
       run: |
         cat /proc/cpuinfo
-        ./util/opensslwrap.sh version -c
+        if [ -x apps/openssl ] ; then ./util/opensslwrap.sh version -c ; fi
     - name: make test
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}


### PR DESCRIPTION
This fixes the current runchecker daily failures.
