### PR TITLE
Provide (de)serialisation for big-endian targets, allowing for use of Solinas' nistp implementations

### DIFF
--- a/crypto/ec/ec_local.h
+++ b/crypto/ec/ec_local.h
@@ -511,10 +511,6 @@ int ossl_ec_GF2m_simple_field_div(const EC_GROUP *, BIGNUM *r, const BIGNUM *a,
                                  const BIGNUM *b, BN_CTX *);
 
 #ifndef OPENSSL_NO_EC_NISTP_64_GCC_128
-# ifdef B_ENDIAN
-#  error "Can not enable ec_nistp_64_gcc_128 on big-endian systems"
-# endif
-
 /* method functions in ecp_nistp224.c */
 int ossl_ec_GFp_nistp224_group_init(EC_GROUP *group);
 int ossl_ec_GFp_nistp224_group_set_curve(EC_GROUP *group, const BIGNUM *p,

--- a/crypto/ec/ecp_nistp224.c
+++ b/crypto/ec/ecp_nistp224.c
@@ -307,6 +307,17 @@ const EC_METHOD *EC_GFp_nistp224_method(void)
 /*
  * Helper functions to convert field elements to/from internal representation
  */
+#ifdef B_ENDIAN
+static void bin28_to_felem(felem out, const u8 in[28])
+{
+    ec_nistp_pre_comp_deserialize(out, in, 56/8, 28, 224);
+}
+
+static void felem_to_bin28(u8 out[28], const felem in)
+{
+    ec_nistp_pre_comp_serialize(out, in, 56/8, 28);
+}
+#else
 static void bin28_to_felem(felem out, const u8 in[28])
 {
     out[0] = *((const limb *)(in)) & 0x00ffffffffffffff;
@@ -325,6 +336,7 @@ static void felem_to_bin28(u8 out[28], const felem in)
         out[i + 21] = in[3] >> (8 * i);
     }
 }
+#endif /* B_ENDIAN */
 
 /* From OpenSSL BIGNUM to internal representation */
 static int BN_to_felem(felem out, const BIGNUM *bn)

--- a/crypto/ec/ecp_nistp256.c
+++ b/crypto/ec/ecp_nistp256.c
@@ -122,6 +122,23 @@ static const u64 kPrime[4] =
     { 0xfffffffffffffffful, 0xffffffff, 0, 0xffffffff00000001ul };
 static const u64 bottom63bits = 0x7ffffffffffffffful;
 
+#ifdef B_ENDIAN
+static void bin32_to_felem(felem out, const u8 in[32])
+{
+    unsigned int i = 0;
+    smallfelem tmp;
+
+    ec_nistp_pre_comp_deserialize(tmp, in, 64/8, 32, 256);
+    for (i = 0; i < NLIMBS; i++) {
+        out[i] = tmp[i];
+    }
+}
+
+static void smallfelem_to_bin32(u8 out[32], const smallfelem in)
+{
+    ec_nistp_pre_comp_serialize(out, in, 64/8, 32);
+}
+#else
 /*
  * bin32_to_felem takes a little-endian byte array and converts it into felem
  * form. This assumes that the CPU is little-endian.
@@ -145,6 +162,7 @@ static void smallfelem_to_bin32(u8 out[32], const smallfelem in)
     *((u64 *)&out[16]) = in[2];
     *((u64 *)&out[24]) = in[3];
 }
+#endif /* B_ENDIAN */
 
 /* BN_to_felem converts an OpenSSL BIGNUM into an felem */
 static int BN_to_felem(felem out, const BIGNUM *bn)

--- a/crypto/ec/ecp_nistp384.c
+++ b/crypto/ec/ecp_nistp384.c
@@ -110,9 +110,20 @@ typedef limb limb_aX __attribute((__aligned__(1)));
 typedef limb felem[NLIMBS];
 typedef widelimb widefelem[2*NLIMBS-1];
 
+/* Helper functions (de)serialising reduced field elements in little endian */
+#ifdef B_ENDIAN
+static void bin48_to_felem(felem out, const u8 in[48])
+{
+    ec_nistp_pre_comp_deserialize(out, in, 56/8, 48, 384);
+}
+
+static void felem_to_bin48(u8 out[48], const felem in)
+{
+    ec_nistp_pre_comp_serialize(out, in, 56/8, 48);
+}
+#else
 static const limb bottom56bits = 0xffffffffffffff;
 
-/* Helper functions (de)serialising reduced field elements in little endian */
 static void bin48_to_felem(felem out, const u8 in[48])
 {
     memset(out, 0, 56);
@@ -136,6 +147,7 @@ static void felem_to_bin48(u8 out[48], const felem in)
     (*((limb_aX *) & out[35])) |= (in[5] & bottom56bits);
     memmove(&out[42], &in[6], 6);
 }
+#endif /* B_ENDIAN */
 
 /* BN_to_felem converts an OpenSSL BIGNUM into an felem */
 static int BN_to_felem(felem out, const BIGNUM *bn)


### PR DESCRIPTION
Provide a series of fallback routines for big-endian targets, and in doing so, extend support for the ecp_nistp{224,256,384,521}.c implementations for NIST curves to BE.

The only little-endian specific components to each of these files is the serialisation/deserialisation logic to/from precomputation tables, whose entries are stored as little-endian byte arrays. Provide bi-endian fallback routines, providing adapters for big-endian systems. These routines may be somewhat naive, but (de)serialisation does not occur in a hot path and so should suffice for now.  