### PR TITLE
Link libatomic on riscv32

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -816,7 +816,7 @@ my %targets = (
     },
 
     "linux32-riscv32" => {
-        inherit_from     => [ "linux-generic32"],
+        inherit_from     => [ "linux-latomic" ],
         perlasm_scheme   => "linux32",
         asm_arch         => 'riscv32',
     },


### PR DESCRIPTION
GCC toolchains on linux are not able to build libcrypto without linking to libatomic as it does not have all needed atomics implemented as intrinsics

Fixes errors like

| ld: ./libcrypto.so: undefined reference to `__atomic_is_lock_free'

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
