### PR TITLE
ssl_lib: added pointer SSL_CONNECTION check to NULL before dereferencing it in ossl_ctrl_internal()

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2928,7 +2928,7 @@ long ossl_ctrl_internal(SSL *s, int cmd, long larg, void *parg, int no_quic)
     if (!no_quic && IS_QUIC(s))
         return s->method->ssl_ctrl(s, cmd, larg, parg);
 
-    SSL_CONNECTION* sc = SSL_CONNECTION_FROM_SSL(s);
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
 
     if (sc == NULL)
         return 0;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2908,6 +2908,9 @@ long ossl_ctrl_internal(SSL *s, int cmd, long larg, void *parg, int no_quic)
     long l;
     SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
 
+    if (sc == NULL)
+        return 0;
+
     /*
      * Routing of ctrl calls for QUIC is a little counterintuitive:
      *

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2906,8 +2906,9 @@ long SSL_ctrl(SSL *s, int cmd, long larg, void *parg)
 long ossl_ctrl_internal(SSL *s, int cmd, long larg, void *parg, int no_quic)
 {
     long l;
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
 
-    if (s == NULL)
+    if (sc == NULL)
         return 0;
 
     /*
@@ -2927,11 +2928,6 @@ long ossl_ctrl_internal(SSL *s, int cmd, long larg, void *parg, int no_quic)
      */
     if (!no_quic && IS_QUIC(s))
         return s->method->ssl_ctrl(s, cmd, larg, parg);
-
-    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
-
-    if (sc == NULL)
-        return 0;
 
     switch (cmd) {
     case SSL_CTRL_GET_READ_AHEAD:

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2906,9 +2906,8 @@ long SSL_ctrl(SSL *s, int cmd, long larg, void *parg)
 long ossl_ctrl_internal(SSL *s, int cmd, long larg, void *parg, int no_quic)
 {
     long l;
-    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
 
-    if (sc == NULL)
+    if (s == NULL)
         return 0;
 
     /*
@@ -2928,6 +2927,11 @@ long ossl_ctrl_internal(SSL *s, int cmd, long larg, void *parg, int no_quic)
      */
     if (!no_quic && IS_QUIC(s))
         return s->method->ssl_ctrl(s, cmd, larg, parg);
+
+    SSL_CONNECTION* sc = SSL_CONNECTION_FROM_SSL(s);
+
+    if (sc == NULL)
+        return 0;
 
     switch (cmd) {
     case SSL_CTRL_GET_READ_AHEAD:


### PR DESCRIPTION
Fixes: #22466 

In ssl_lib.c added pointer SSL_CONNECTION check to NULL before dereferencing it in ossl_ctrl_internal()
