### PR TITLE
QUIC: Fix crypto stream buffering

### DIFF
--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -1951,6 +1951,15 @@ static void ch_tick(QUIC_TICK_RESULT *res, void *arg, uint32_t flags)
             int pn_space = ossl_quic_enc_level_to_pn_space(ch->tx_enc_level);
 
             ossl_quic_tx_packetiser_schedule_ack_eliciting(ch->txp, pn_space);
+
+            /*
+             * If we have no CC budget at this time we cannot process the above
+             * PING request immediately. In any case we have scheduled the
+             * request so bump the ping deadline. If we don't do this we will
+             * busy-loop endlessly as the above deadline comparison condition
+             * will still be met.
+             */
+            ch_update_ping_deadline(ch);
         }
 
         /* Write any data to the network due to be sent. */

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -25,9 +25,10 @@
  * TODO(QUIC SERVER): Implement retry logic
  */
 
-#define INIT_DCID_LEN           8
-#define INIT_CRYPTO_BUF_LEN     8192
-#define INIT_APP_BUF_LEN        8192
+#define INIT_DCID_LEN                   8
+#define INIT_CRYPTO_RECV_BUF_LEN    16384
+#define INIT_CRYPTO_SEND_BUF_LEN    16384
+#define INIT_APP_BUF_LEN             8192
 
 /*
  * Interval before we force a PING to ensure NATs don't timeout. This is based
@@ -323,7 +324,7 @@ static int ch_init(QUIC_CHANNEL *ch)
 
     for (pn_space = QUIC_PN_SPACE_INITIAL; pn_space < QUIC_PN_SPACE_NUM; ++pn_space)
         if (!ossl_quic_rxfc_init_standalone(&ch->crypto_rxfc[pn_space],
-                                            INIT_CRYPTO_BUF_LEN,
+                                            INIT_CRYPTO_RECV_BUF_LEN,
                                             get_time, ch))
             goto err;
 
@@ -375,7 +376,7 @@ static int ch_init(QUIC_CHANNEL *ch)
     txp_args.now_arg                = ch;
 
     for (pn_space = QUIC_PN_SPACE_INITIAL; pn_space < QUIC_PN_SPACE_NUM; ++pn_space) {
-        ch->crypto_send[pn_space] = ossl_quic_sstream_new(INIT_CRYPTO_BUF_LEN);
+        ch->crypto_send[pn_space] = ossl_quic_sstream_new(INIT_CRYPTO_SEND_BUF_LEN);
         if (ch->crypto_send[pn_space] == NULL)
             goto err;
 

--- a/ssl/quic/quic_channel_local.h
+++ b/ssl/quic/quic_channel_local.h
@@ -388,6 +388,11 @@ struct quic_channel_st {
      */
     unsigned int                    have_new_rx_secret      : 1;
 
+    /* Have we ever called QUIC_TLS yet during RX processing? */
+    unsigned int                    did_tls_tick            : 1;
+    /* Has any CRYPTO frame been processed during this tick? */
+    unsigned int                    did_crypto_frame        : 1;
+
     /*
      * Have we sent an ack-eliciting packet since the last successful packet
      * reception? Used to determine when to bump idle timer (see RFC 9000 s.

--- a/ssl/quic/quic_record_rx.c
+++ b/ssl/quic/quic_record_rx.c
@@ -280,7 +280,7 @@ static void qrx_requeue_deferred(OSSL_QRX *qrx)
 
     while ((e = ossl_list_urxe_head(&qrx->urx_deferred)) != NULL) {
         ossl_list_urxe_remove(&qrx->urx_deferred, e);
-        ossl_list_urxe_insert_head(&qrx->urx_pending, e);
+        ossl_list_urxe_insert_tail(&qrx->urx_pending, e);
     }
 }
 

--- a/ssl/quic/quic_rx_depack.c
+++ b/ssl/quic/quic_rx_depack.c
@@ -317,6 +317,7 @@ static int depack_do_frame_crypto(PACKET *pkt, QUIC_CHANNEL *ch,
         return 0;
     }
 
+    ch->did_crypto_frame = 1;
     *datalen = f.len;
 
     return 1;
@@ -1421,6 +1422,8 @@ int ossl_quic_handle_frames(QUIC_CHANNEL *ch, OSSL_QRX_PKT *qpacket)
 
     if (ch == NULL)
         goto end;
+
+    ch->did_crypto_frame = 0;
 
     /* Initialize |ackm_data| (and reinitialize |ok|)*/
     memset(&ackm_data, 0, sizeof(ackm_data));

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -294,8 +294,10 @@ int ssl3_write_bytes(SSL *ssl, uint8_t type, const void *buf_, size_t len,
         /* Retry needed */
         i = HANDLE_RLAYER_WRITE_RETURN(s,
                 s->rlayer.wrlmethod->retry_write_records(s->rlayer.wrl));
-        if (i <= 0)
+        if (i <= 0) {
+            s->rlayer.wnum = tot;
             return i;
+        }
         tot += s->rlayer.wpend_tot;
         s->rlayer.wpend_tot = 0;
     } /* else no retry required */
@@ -321,6 +323,7 @@ int ssl3_write_bytes(SSL *ssl, uint8_t type, const void *buf_, size_t len,
         i = ssl->method->ssl_dispatch_alert(ssl);
         if (i <= 0) {
             /* SSLfatal() already called if appropriate */
+            s->rlayer.wnum = tot;
             return i;
         }
         /* if it went, fall through and send more stuff */

--- a/test/helpers/ssltestlib.h
+++ b/test/helpers/ssltestlib.h
@@ -68,4 +68,8 @@ DEFINE_STACK_OF(MEMPACKET)
 
 SSL_SESSION *create_a_psk(SSL *ssl, size_t mdsize);
 
+/* Add cert from `cert_file` multiple times to create large extra cert chain */
+int ssl_ctx_add_large_cert_chain(OSSL_LIB_CTX *libctx, SSL_CTX *sctx,
+                                 const char *cert_file);
+
 #endif /* OSSL_TEST_SSLTESTLIB_H */

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -1230,6 +1230,12 @@ static int test_client_auth(int idx)
                                              &clientquic, NULL, NULL)))
         goto err;
 
+    if (idx > 1) {
+        if (!TEST_true(ssl_ctx_add_large_cert_chain(libctx, cctx, ccert))
+            || !TEST_true(ssl_ctx_add_large_cert_chain(libctx, sctx, cert)))
+            goto err;
+    }
+
     if (idx == 0) {
         if (!TEST_false(qtest_create_quic_connection(qtserv, clientquic)))
             goto err;
@@ -1629,7 +1635,7 @@ int setup_tests(void)
     ADD_TEST(test_multiple_dgrams);
     ADD_ALL_TESTS(test_non_io_retry, 2);
     ADD_TEST(test_quic_psk);
-    ADD_ALL_TESTS(test_client_auth, 2);
+    ADD_ALL_TESTS(test_client_auth, 3);
     ADD_ALL_TESTS(test_alpn, 2);
     ADD_ALL_TESTS(test_noisy_dgram, 2);
     ADD_TEST(test_get_shutdown);

--- a/test/recipes/75-test_quicapi_data/ssltraceref-zlib.txt
+++ b/test/recipes/75-test_quicapi_data/ssltraceref-zlib.txt
@@ -139,9 +139,6 @@ Received Packet
 Received Frame: Crypto
     Offset: 0
     Len: 1022
-Received Frame: Crypto
-    Offset: 1022
-    Len: 192
 Received TLS Record
 Header:
   Version = TLS 1.2 (0x303)
@@ -247,6 +244,9 @@ YeeuLO02zToHhnQ6KbPXOrQAqcL1kngO4g+j/ru+4AZThFkdkGnltvk=
 ------------------
         No extensions
 
+Received Frame: Crypto
+    Offset: 1022
+    Len: 192
 Received TLS Record
 Header:
   Version = TLS 1.2 (0x303)

--- a/test/recipes/75-test_quicapi_data/ssltraceref-zlib.txt
+++ b/test/recipes/75-test_quicapi_data/ssltraceref-zlib.txt
@@ -127,21 +127,21 @@ Received Packet
   Version: 0x00000001
   Destination Conn Id: <zero length id>
   Source Conn Id: 0x????????????????
-  Payload length: 213
-  Packet Number: 0x00000001
+  Payload length: 1042
+  Packet Number: 0x00000000
 Received Packet
   Packet Type: Handshake
   Version: 0x00000001
   Destination Conn Id: <zero length id>
   Source Conn Id: 0x????????????????
-  Payload length: 1042
-  Packet Number: 0x00000000
-Received Frame: Crypto
-    Offset: 1022
-    Len: 192
+  Payload length: 213
+  Packet Number: 0x00000001
 Received Frame: Crypto
     Offset: 0
     Len: 1022
+Received Frame: Crypto
+    Offset: 1022
+    Len: 192
 Received TLS Record
 Header:
   Version = TLS 1.2 (0x303)

--- a/test/recipes/75-test_quicapi_data/ssltraceref.txt
+++ b/test/recipes/75-test_quicapi_data/ssltraceref.txt
@@ -125,21 +125,21 @@ Received Packet
   Version: 0x00000001
   Destination Conn Id: <zero length id>
   Source Conn Id: 0x????????????????
-  Payload length: 213
-  Packet Number: 0x00000001
+  Payload length: 1042
+  Packet Number: 0x00000000
 Received Packet
   Packet Type: Handshake
   Version: 0x00000001
   Destination Conn Id: <zero length id>
   Source Conn Id: 0x????????????????
-  Payload length: 1042
-  Packet Number: 0x00000000
-Received Frame: Crypto
-    Offset: 1022
-    Len: 192
+  Payload length: 213
+  Packet Number: 0x00000001
 Received Frame: Crypto
     Offset: 0
     Len: 1022
+Received Frame: Crypto
+    Offset: 1022
+    Len: 192
 Received TLS Record
 Header:
   Version = TLS 1.2 (0x303)

--- a/test/recipes/75-test_quicapi_data/ssltraceref.txt
+++ b/test/recipes/75-test_quicapi_data/ssltraceref.txt
@@ -137,9 +137,6 @@ Received Packet
 Received Frame: Crypto
     Offset: 0
     Len: 1022
-Received Frame: Crypto
-    Offset: 1022
-    Len: 192
 Received TLS Record
 Header:
   Version = TLS 1.2 (0x303)
@@ -245,6 +242,9 @@ YeeuLO02zToHhnQ6KbPXOrQAqcL1kngO4g+j/ru+4AZThFkdkGnltvk=
 ------------------
         No extensions
 
+Received Frame: Crypto
+    Offset: 1022
+    Len: 192
 Received TLS Record
 Header:
   Version = TLS 1.2 (0x303)


### PR DESCRIPTION
Following on from #22295

Built on @mattcaswell's fixes and @t8m's large chain PR:

- Make sure we remember how much data we sent in the event of a retry (#22473)
- When requeueing deferred URXEs retain the order (#22452)
- QUIC: Test connection with large client and server cert chains (#22295)

Changes:

- QUIC TLS: Ensure QUIC_TLS is ticked between each processed RX packet
  We tick TLS in between all packet processing, allowing it to train the receive-side crypto stream as soon as (in-order) data is received on it. If no data arrives for QUIC_TLS we give it one tick anyway, in case it wants to spontaneously do something.

- QUIC CHANNEL: Correct timeout calculation for ACKs
  ACKs are not restricted by CC, so next tick deadline should not stop us from generating an ACK just because of CC.

- QUIC CHANNEL: Tweak crypto buffer sizes
  Increase crypto buffer sizes to 16 KiB. This size was chosen on the grounds that our current congestion control implementation limits us from sending more than about 11 KiB at t=0 of a connection anyway, so more on the send side isn't going to help much and more on the receive side only becomes relevant due to packet reordering with the above fixes.

RXFC behaviour was investigated and found to be as desired.

Note that congestion control is applicable to crypto streams and this can offer some backpressure conditions. So as things stand there is actually a control keeping our own implementation from sending more than ~11 KiB of crypto stream data initially, which can't overflow our 16 KiB receive buffer anyway, even in the event of reordering/loss/etc. Of course this doesn't mean other implementations will behave the same way, though our congestion control is the reference implementation so one hopes other implementations will behave similarly.

The other backpressure condition of interest is the send stream buffer filling up. Since we can't cull data from it until it is acknowledged, proving we won't need to retransmit it, this means the sender receiving ACKs essentially controls how fast it can send crypto stream data. Currently we ACK incoming Initial/Handshake EL packets immediately without waiting for an ACK delay (in fact the RFC says we MUST do so). So throughput on crypto streams is limited by the RTT. This limits throughput to 16/RTT KiB/s. Of course again other implementations may behave differently.

Thanks to @mattcaswell for investigation of a bug in the TLS record layer. (#22473)