### PR TITLE
Make s_client -quic -debug work

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2969,10 +2969,13 @@ int s_client_main(int argc, char **argv)
             } while (!write_ssl
                      && cbuf_len == 0
                      && user_data_has_data(&user_data));
-            if (cbuf_len > 0)
+            if (cbuf_len > 0) {
                 read_tty = 0;
-            else
+                timeout.tv_sec = 0;
+                timeout.tv_usec = 0;
+            } else {
                 read_tty = 1;
+            }
         }
 
         ssl_pending = read_ssl && SSL_has_pending(con);
@@ -3266,6 +3269,7 @@ int s_client_main(int argc, char **argv)
                 ret = 0;
                 goto shut;
             }
+
             if (i > 0 && !user_data_add(&user_data, i)) {
                 ret = 0;
                 goto shut;

--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -418,8 +418,8 @@ int BIO_sendmmsg(BIO *b, BIO_MSG *msg,
         args.msgs_processed = msgs_processed;
 
         ret = (size_t)bio_call_callback(b, BIO_CB_SENDMMSG, (void *)&args,
-                                        0, 0, 0, 0, NULL);
-        if (ret == 0)
+                                        0, 0, 0, 1, NULL);
+        if (ret <= 0)
             return 0;
     }
 
@@ -433,7 +433,7 @@ int BIO_sendmmsg(BIO *b, BIO_MSG *msg,
 
     if (HAS_CALLBACK(b))
         ret = (size_t)bio_call_callback(b, BIO_CB_SENDMMSG | BIO_CB_RETURN,
-                                        (void *)&args, ret, 0, 0, 0, NULL);
+                                        (void *)&args, ret, 0, 0, ret, NULL);
 
     return ret;
 }
@@ -465,8 +465,8 @@ int BIO_recvmmsg(BIO *b, BIO_MSG *msg,
         args.msgs_processed = msgs_processed;
 
         ret = bio_call_callback(b, BIO_CB_RECVMMSG, (void *)&args,
-                                0, 0, 0, 0, NULL);
-        if (ret == 0)
+                                0, 0, 0, 1, NULL);
+        if (ret <= 0)
             return 0;
     }
 
@@ -480,7 +480,7 @@ int BIO_recvmmsg(BIO *b, BIO_MSG *msg,
 
     if (HAS_CALLBACK(b))
         ret = (size_t)bio_call_callback(b, BIO_CB_RECVMMSG | BIO_CB_RETURN,
-                                        (void *)&args, ret, 0, 0, 0, NULL);
+                                        (void *)&args, ret, 0, 0, ret, NULL);
 
     return ret;
 }


### PR DESCRIPTION
The callback that makes -debug print the data sent/received needed extending
for the new QUIC callback codes.

We also fix a bug in s_client which made it pause unnecessarily when writing data collected from the user.