### PR TITLE
Fixes an issue where:

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -4005,7 +4005,7 @@ skip_hmac:
             loopargs[i].sig_max_sig_len[testnum] = max_sig_len;
             loopargs[i].sig_act_sig_len[testnum] = sig_len;
             loopargs[i].sig_sig[testnum] = sig;
-            break;
+            continue;
 
         sig_err_break:
             ERR_print_errors(bio_err);


### PR DESCRIPTION
When using speed option -async_jobs n (n > 1), loopargs[i].sig* params are only set for the first instance, and subsequent instances are NULL or Invalid.

This ultimately causes a failure in SIG_sign_loop() when app_malloc() is called to allocate zero bytes.

Test with:
	openssl speed -async_jobs 2 -seconds 1 rsa2048

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
