### PR TITLE
quic: documentation and demo nits

### DIFF
--- a/demos/guide/quic-client-block.c
+++ b/demos/guide/quic-client-block.c
@@ -210,8 +210,9 @@ int main(void)
         goto end;
     }
 
-    /* Connect to the server and perform the TLS handshake */
-    if ((ret = SSL_connect(ssl)) < 1) {
+    /* Do the handshake with the server */
+    if (SSL_connect(ssl) < 1) {
+        printf("Failed to connect to the server\n");
         /*
          * If the failure is due to a verification error we can get more
          * information about it from SSL_get_verify_result().

--- a/demos/guide/quic-multi-stream.c
+++ b/demos/guide/quic-multi-stream.c
@@ -47,7 +47,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
      */
     for (ai = res; ai != NULL; ai = BIO_ADDRINFO_next(ai)) {
         /*
-         * Create a TCP socket. We could equally use non-OpenSSL calls such
+         * Create a UDP socket. We could equally use non-OpenSSL calls such
          * as "socket" here for this and the subsequent connect and close
          * functions. But for portability reasons and also so that we get
          * errors on the OpenSSL stack in the event of a failure we use
@@ -82,7 +82,6 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
         }
     }
 
-
     /* Free the address information resources we allocated earlier */
     BIO_ADDRINFO_free(res);
 
@@ -96,6 +95,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
         BIO_closesocket(sock);
         return NULL;
     }
+
     /*
      * Associate the newly created BIO with the underlying socket. By
      * passing BIO_CLOSE here the socket will be automatically closed when
@@ -222,8 +222,9 @@ int main(void)
         goto end;
     }
 
-    /* Connect to the server and perform the TLS handshake */
-    if ((ret = SSL_connect(ssl)) < 1) {
+    /* Do the handshake with the server */
+    if (SSL_connect(ssl) < 1) {
+        printf("Failed to connect to the server\n");
         /*
          * If the failure is due to a verification error we can get more
          * information about it from SSL_get_verify_result().

--- a/demos/guide/tls-client-block.c
+++ b/demos/guide/tls-client-block.c
@@ -74,7 +74,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port)
     if (sock == -1)
         return NULL;
 
-    /* Create a BIO to wrap the socket*/
+    /* Create a BIO to wrap the socket */
     bio = BIO_new(BIO_s_socket());
     if (bio == NULL) {
         BIO_closesocket(sock);

--- a/doc/man7/ossl-guide-quic-multi-stream.pod
+++ b/doc/man7/ossl-guide-quic-multi-stream.pod
@@ -62,7 +62,7 @@ passes the connection B<SSL> object as a parameter.
 
 If a client application calls L<SSL_write_ex(3)> or L<SSL_write(3)> first then
 (by default) the default stream will be a client-initiated bi-directional
-stream. If the client applications call L<SSL_read_ex(3)> or L<SSL_read(3)>
+stream. If a client application calls L<SSL_read_ex(3)> or L<SSL_read(3)>
 first then the first stream initiated by the server will be used as the default
 stream (whether it is bi-directional or uni-directional).
 
@@ -285,7 +285,7 @@ these different cases.
      * QUIC terms this means that the peer has sent FIN on the stream to
      * indicate that no further data will be sent.
      */
-    switch (SSL_get_error(ssl, 0)) {
+    switch (SSL_get_error(stream1, 0)) {
     case SSL_ERROR_ZERO_RETURN:
         /* Normal completion of the stream */
         break;
@@ -295,7 +295,7 @@ these different cases.
          * Some stream fatal error occurred. This could be because of a stream
          * reset - or some failure occurred on the underlying connection.
          */
-        switch (SSL_get_stream_read_state(ssl)) {
+        switch (SSL_get_stream_read_state(stream1)) {
         case SSL_STREAM_STATE_RESET_REMOTE:
             printf("Stream reset occurred\n");
             /* The stream has been reset but the connection is still healthy. */


### PR DESCRIPTION
The code for the quic demos (under `demos/guide`) is discussed in the
guide as modifications of `tls-client-block.c` (a tls demo).  Drop unneeded assignments to `ret` in the quic code so it better matches the tls code.

Also fix a couple of minor typos.

This partly resolves openssl/project#253

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
