### PR TITLE
QUIC: Report connection failure reasons in multistream test

### DIFF
--- a/doc/man3/SSL_get_conn_close_info.pod
+++ b/doc/man3/SSL_get_conn_close_info.pod
@@ -14,7 +14,7 @@ closed
  #define SSL_CONN_CLOSE_FLAG_TRANSPORT
 
  typedef struct ssl_conn_close_info_st {
-     uint64_t error_code;
+     uint64_t error_code, frame_type;
      char     *reason;
      size_t   reason_len;
      uint32_t flags;
@@ -41,6 +41,13 @@ This is a 62-bit QUIC error code. It is either a 62-bit application error code
 (if B<SSL_CONN_CLOSE_FLAG_TRANSPORT> not set in I<flags>) or a  62-bit standard
 QUIC transport error code (if B<SSL_CONN_CLOSE_FLAG_TRANSPORT> is set in
 I<flags>).
+
+=item I<frame_type>
+
+If B<SSL_CONN_CLOSE_FLAG_TRANSPORT> is set, this may be set to a QUIC frame type
+number which caused the connection to be closed. It may also be set to 0 if no
+frame type was specified as causing the connection to be closed. If
+B<SSL_CONN_CLOSE_FLAG_TRANSPORT> is not set, this is set to 0.
 
 =item I<reason>
 

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2348,7 +2348,7 @@ __owur int SSL_get_stream_write_error_code(SSL *ssl, uint64_t *app_error_code);
 #define SSL_CONN_CLOSE_FLAG_TRANSPORT   (1U << 1)
 
 typedef struct ssl_conn_close_info_st {
-    uint64_t    error_code;
+    uint64_t    error_code, frame_type;
     const char  *reason;
     size_t      reason_len;
     uint32_t    flags;

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -3441,6 +3441,7 @@ int ossl_quic_get_conn_close_info(SSL *ssl,
         return 0;
 
     info->error_code    = tc->error_code;
+    info->frame_type    = tc->frame_type;
     info->reason        = tc->reason;
     info->reason_len    = tc->reason_len;
     info->flags         = 0;

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -1943,6 +1943,8 @@ out:
     s_unlock(h, hl); /* idempotent */
     if (!testresult) {
         size_t i;
+        const QUIC_TERMINATE_CAUSE *tcause;
+        const char *e_str, *f_str;
 
         TEST_error("failed in script \"%s\" at op %zu, thread %d\n",
                    script_name, op_idx + 1, thread_idx);
@@ -1952,6 +1954,56 @@ out:
                       repeat_stack_done[i],
                       repeat_stack_limit[i],
                       repeat_stack_idx[i]);
+
+        ERR_print_errors_fp(stderr);
+
+        if (h->c_conn != NULL) {
+            SSL_CONN_CLOSE_INFO cc_info = {0};
+
+            if (SSL_get_conn_close_info(h->c_conn, &cc_info, sizeof(cc_info))) {
+                e_str = ossl_quic_err_to_string(cc_info.error_code);
+                f_str = ossl_quic_frame_type_to_string(cc_info.frame_type);
+
+                if (e_str == NULL)
+                    e_str = "?";
+                if (f_str == NULL)
+                    f_str = "?";
+
+                TEST_info("client side is closed: %llu(%s)/%llu(%s), "
+                          "%s, %s, reason: \"%s\"",
+                          (unsigned long long)cc_info.error_code,
+                          e_str,
+                          (unsigned long long)cc_info.frame_type,
+                          f_str,
+                          (cc_info.flags & SSL_CONN_CLOSE_FLAG_LOCAL) != 0
+                            ? "local" : "remote",
+                          (cc_info.flags & SSL_CONN_CLOSE_FLAG_TRANSPORT) != 0
+                            ? "transport" : "app",
+                          cc_info.reason != NULL ? cc_info.reason : "-");
+            }
+        }
+
+        tcause = (h->s != NULL
+                  ? ossl_quic_tserver_get_terminate_cause(h->s) : NULL);
+        if (tcause != NULL) {
+            e_str = ossl_quic_err_to_string(tcause->error_code);
+            f_str = ossl_quic_frame_type_to_string(tcause->frame_type);
+
+            if (e_str == NULL)
+                e_str = "?";
+            if (f_str == NULL)
+                f_str = "?";
+
+            TEST_info("server side is closed: %llu(%s)/%llu(%s), "
+                     "%s, %s, reason: \"%s\"",
+                      (unsigned long long)tcause->error_code,
+                      e_str,
+                      (unsigned long long)tcause->frame_type,
+                      f_str,
+                      tcause->remote ? "remote" : "local",
+                      tcause->app ? "app" : "transport",
+                      tcause->reason != NULL ? tcause->reason : "-");
+        }
     }
 
     OPENSSL_free(tmp_buf);


### PR DESCRIPTION
This should help us to debug the intermittent failure we're currently seeing (#22348).

Also, we weren't exposing `frame_type` in `SSL_CONN_CLOSE_INFO`. Do this before beta.