### PR TITLE
Allow short reads in asn1_d2i_read_bio()

### DIFF
--- a/crypto/asn1/a_d2i_fp.c
+++ b/crypto/asn1/a_d2i_fp.c
@@ -148,6 +148,9 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
                     goto err;
                 }
                 len += i;
+                if ((size_t)i < want)
+                    continue;
+
             }
         }
         /* else data already loaded */


### PR DESCRIPTION
This resolves the problem discussed in https://github.com/openssl/openssl/discussions/22484

I am unsure whether this should be treated as a bug or feature.