### PR TITLE
crypto/evp/ctrl_params_translate: honor EC_POINT_CONVERSION_FORMAT

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -495,6 +495,13 @@ OpenSSL 3.1
 
 ### Changes between 3.1.4 and 3.1.5 [xx XXX xxxx]
 
+ * Exporting `OSSL_PKEY_PARAM_PUB_KEY` with legacy keys now honor
+   `OSSL_PKEY_PARAM_EC_POINT_CONVERSION_FORMAT` instead of
+   unconditionally using `POINT_CONVERSION_COMPRESSED`.  Non-legacy
+   keys had already been honoring this setting since version 3.0.8.
+
+   *Max Kellermann*
+
  * Fix excessive time spent in DH check / generation with large Q parameter
    value.
 

--- a/crypto/evp/ctrl_params_translate.c
+++ b/crypto/evp/ctrl_params_translate.c
@@ -1636,11 +1636,12 @@ static int get_payload_public_key(enum state state,
             BN_CTX *bnctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(eckey));
             const EC_GROUP *ecg = EC_KEY_get0_group(eckey);
             const EC_POINT *point = EC_KEY_get0_public_key(eckey);
+            const point_conversion_form_t format = EC_KEY_get_conv_form(eckey);
 
             if (bnctx == NULL)
                 return 0;
             ctx->sz = EC_POINT_point2buf(ecg, point,
-                                         POINT_CONVERSION_COMPRESSED,
+                                         format,
                                          &buf, bnctx);
             ctx->p2 = buf;
             BN_CTX_free(bnctx);


### PR DESCRIPTION
There are two code paths that handle OSSL_PKEY_PARAM_PUB_KEY:

1. for "provided" keys: via common_get_params() and key_to_params()

2. for "legacy" keys: via evp_pkey_setget_params_to_ctrl() and get_payload_public_key()

The first once has been honoring
OSSL_PKEY_PARAM_EC_POINT_CONVERSION_FORMAT since commit a16e86683e8d ("Honor OSSL_PKEY_PARAM_EC_POINT_CONVERSION_FORMAT as set and default to UNCOMPRESSED"), but the second one unconditionally used UNCOMPRESSEDPOINT_CONVERSION_COMPRESSED.  I think omitting the second code path was an oversight and this patch amends it.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
