### PR TITLE
added the checking of insert into provider's stack

### DIFF
--- a/apps/list.c
+++ b/apps/list.c
@@ -1209,11 +1209,9 @@ static int provider_cmp(const OSSL_PROVIDER * const *a,
 static int collect_providers(OSSL_PROVIDER *provider, void *stack)
 {
     STACK_OF(OSSL_PROVIDER) *provider_stack = stack;
-    /*
-	 * If OK - result is the index of inserted data
-	 * Error - result is -1 or 0
-	 */
-    return sk_OSSL_PROVIDER_push(provider_stack, provider) > 0 ? 1 : 0;
+
+    sk_OSSL_PROVIDER_push(provider_stack, provider);
+    return 1;
 }
 
 static void list_provider_info(void)
@@ -1228,13 +1226,8 @@ static void list_provider_info(void)
         BIO_printf(bio_err, "ERROR: Memory allocation\n");
         return;
     }
-
-    if (OSSL_PROVIDER_do_all(NULL, &collect_providers, providers) != 1) {
-        BIO_printf(bio_err, "ERROR: Memory allocation\n");
-        return;
-    }
-
     BIO_printf(bio_out, "Providers:\n");
+    OSSL_PROVIDER_do_all(NULL, &collect_providers, providers);
     sk_OSSL_PROVIDER_sort(providers);
     for (i = 0; i < sk_OSSL_PROVIDER_num(providers); i++) {
         const OSSL_PROVIDER *prov = sk_OSSL_PROVIDER_value(providers, i);

--- a/apps/list.c
+++ b/apps/list.c
@@ -1209,9 +1209,11 @@ static int provider_cmp(const OSSL_PROVIDER * const *a,
 static int collect_providers(OSSL_PROVIDER *provider, void *stack)
 {
     STACK_OF(OSSL_PROVIDER) *provider_stack = stack;
-
-    sk_OSSL_PROVIDER_push(provider_stack, provider);
-    return 1;
+    /*
+	 * If OK - result is the index of inserted data
+	 * Error - result is -1 or 0
+	 */
+    return sk_OSSL_PROVIDER_push(provider_stack, provider) > 0 ? 1 : 0;
 }
 
 static void list_provider_info(void)
@@ -1226,8 +1228,13 @@ static void list_provider_info(void)
         BIO_printf(bio_err, "ERROR: Memory allocation\n");
         return;
     }
+
+    if (OSSL_PROVIDER_do_all(NULL, &collect_providers, providers) != 1) {
+        BIO_printf(bio_err, "ERROR: Memory allocation\n");
+        return;
+    }
+
     BIO_printf(bio_out, "Providers:\n");
-    OSSL_PROVIDER_do_all(NULL, &collect_providers, providers);
     sk_OSSL_PROVIDER_sort(providers);
     for (i = 0; i < sk_OSSL_PROVIDER_num(providers); i++) {
         const OSSL_PROVIDER *prov = sk_OSSL_PROVIDER_value(providers, i);

--- a/apps/list.c
+++ b/apps/list.c
@@ -1210,9 +1210,9 @@ static int collect_providers(OSSL_PROVIDER *provider, void *stack)
 {
     STACK_OF(OSSL_PROVIDER) *provider_stack = stack;
     /*
-	 * If OK - result is the index of inserted data
-	 * Error - result is -1 or 0
-	 */
+     * If OK - result is the index of inserted data
+     * Error - result is -1 or 0
+     */
     return sk_OSSL_PROVIDER_push(provider_stack, provider) > 0 ? 1 : 0;
 }
 

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1348,7 +1348,7 @@ static int set_client_ciphersuite(SSL *s, const unsigned char *cipherchars)
         if (SSL_IS_TLS13(s)) {
             const EVP_MD *md = ssl_md(s->ctx, c->algorithm2);
            /*
-            * This code eliminates UB if in sslapitest.c at the line #4790
+            * This code eliminates UB if in sslapitest.c at the line #4780
             * clntsess->cipher = NULL;
             */
             if (s->session->cipher == NULL) {

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1347,14 +1347,7 @@ static int set_client_ciphersuite(SSL *s, const unsigned char *cipherchars)
     if (s->hit && (s->session->cipher_id != c->id)) {
         if (SSL_IS_TLS13(s)) {
             const EVP_MD *md = ssl_md(s->ctx, c->algorithm2);
-           /*
-            * This code eliminates UB if in sslapitest.c at the line #4780
-            * clntsess->cipher = NULL;
-            */
-            if (s->session->cipher == NULL) {
-                 SSLfatal( s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR );
-                 return EXT_RETURN_FAIL;
-            }
+
             /*
              * In TLSv1.3 it is valid for the server to select a different
              * ciphersuite as long as the hash is the same.

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1347,7 +1347,14 @@ static int set_client_ciphersuite(SSL *s, const unsigned char *cipherchars)
     if (s->hit && (s->session->cipher_id != c->id)) {
         if (SSL_IS_TLS13(s)) {
             const EVP_MD *md = ssl_md(s->ctx, c->algorithm2);
-
+           /*
+            * This code eliminates UB if in sslapitest.c at the line #4790
+            * clntsess->cipher = NULL;
+            */
+            if (s->session->cipher == NULL) {
+                 SSLfatal( s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR );
+                 return EXT_RETURN_FAIL;
+            }
             /*
              * In TLSv1.3 it is valid for the server to select a different
              * ciphersuite as long as the hash is the same.


### PR DESCRIPTION
Code to fix collect_providers method to return the result of sk_OSSL_PROVIDER_push.
The result is using in OSSL_PROVIDER_do_all and protects it from memory limitation error.