### PR TITLE
Fix EVP_CIPHER_CTX_get_*iv so that it doesnt raise an error when it passes.

### DIFF
--- a/crypto/params.c
+++ b/crypto/params.c
@@ -1491,6 +1491,27 @@ int OSSL_PARAM_set_octet_ptr(OSSL_PARAM *p, const void *val,
     return set_ptr_internal(p, val, OSSL_PARAM_OCTET_PTR, used_len);
 }
 
+int OSSL_PARAM_set_octet_string_or_ptr(OSSL_PARAM *p,
+                                       const void *val, size_t len)
+{
+    if (p == NULL) {
+        err_null_argument;
+        return 0;
+    }
+    p->return_size = 0;
+
+    if (p->data_type == OSSL_PARAM_OCTET_PTR) {
+        return set_ptr_internal(p, val, OSSL_PARAM_OCTET_PTR, len);
+    } else {
+        if (val == NULL) {
+            err_null_argument;
+            return 0;
+        }
+        return set_string_internal(p, val, len, OSSL_PARAM_OCTET_STRING);
+    }
+}
+
+
 OSSL_PARAM OSSL_PARAM_construct_utf8_ptr(const char *key, char **buf,
                                          size_t bsize)
 {

--- a/doc/man3/OSSL_PARAM_int.pod
+++ b/doc/man3/OSSL_PARAM_int.pod
@@ -31,6 +31,7 @@ OSSL_PARAM_set_time_t, OSSL_PARAM_set_uint, OSSL_PARAM_set_uint32,
 OSSL_PARAM_set_uint64, OSSL_PARAM_set_ulong, OSSL_PARAM_set_BN,
 OSSL_PARAM_set_utf8_string, OSSL_PARAM_set_octet_string,
 OSSL_PARAM_set_utf8_ptr, OSSL_PARAM_set_octet_ptr,
+OSSL_PARAM_set_octet_string_or_ptr,
 OSSL_PARAM_UNMODIFIED, OSSL_PARAM_modified, OSSL_PARAM_set_all_unmodified
 - OSSL_PARAM helpers
 
@@ -99,6 +100,8 @@ OSSL_PARAM_UNMODIFIED, OSSL_PARAM_modified, OSSL_PARAM_set_all_unmodified
                               size_t *used_len);
  int OSSL_PARAM_set_octet_ptr(OSSL_PARAM *p, const void *val,
                               size_t used_len);
+ int OSSL_PARAM_set_octet_string_or_ptr(OSSL_PARAM *p,
+                                        const void *val, size_t len)
 
  int OSSL_PARAM_get_utf8_string_ptr(const OSSL_PARAM *p, const char **val);
  int OSSL_PARAM_get_octet_string_ptr(const OSSL_PARAM *p, const void **val,
@@ -287,6 +290,13 @@ OSSL_PARAM_set_octet_ptr() sets the OCTET string pointer in the parameter
 referenced by I<p> to the values I<val>.
 The length of the OCTET string is provided by I<used_len>.
 
+OSSL_PARAM_set_octet_string_or_ptr() uses the data_type in the parameter
+referenced by I<p> to internally call either OSSL_PARAM_set_octet_string() or
+OSSL_PARAM_set_octet_ptr().
+This is equivalent to the following code
+OSSL_PARAM_set_octet_string(p, val, len) || OSSL_PARAM_set_octet_ptr(p, val, len)
+except that an error is not raised if the data_type is octet_ptr.
+
 OSSL_PARAM_get_utf8_string_ptr() retrieves the pointer to a UTF8 string from
 the parameter pointed to by I<p>, and stores that pointer in I<*val>.
 This is different from OSSL_PARAM_get_utf8_string(), which copies the
@@ -398,7 +408,8 @@ L<openssl-core.h(7)>, L<OSSL_PARAM(3)>
 
 =head1 HISTORY
 
-These APIs were introduced in OpenSSL 3.0.
+The function OSSL_PARAM_set_octet_string_or_ptr() was added in OpenSSL 3.3
+All other APIs were added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -134,6 +134,8 @@ int OSSL_PARAM_set_utf8_string(OSSL_PARAM *p, const char *val);
 int OSSL_PARAM_get_octet_string(const OSSL_PARAM *p, void **val, size_t max_len,
                                 size_t *used_len);
 int OSSL_PARAM_set_octet_string(OSSL_PARAM *p, const void *val, size_t len);
+int OSSL_PARAM_set_octet_string_or_ptr(OSSL_PARAM *p,
+                                       const void *val, size_t len);
 
 int OSSL_PARAM_get_utf8_ptr(const OSSL_PARAM *p, const char **val);
 int OSSL_PARAM_set_utf8_ptr(OSSL_PARAM *p, const char *val);

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
@@ -271,15 +271,15 @@ static int aes_get_ctx_params(void *vctx, OSSL_PARAM params[])
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IV);
     if (p != NULL
-        && !OSSL_PARAM_set_octet_string(p, ctx->base.oiv, ctx->base.ivlen)
-        && !OSSL_PARAM_set_octet_ptr(p, &ctx->base.oiv, ctx->base.ivlen)) {
+        && !OSSL_PARAM_set_octet_string_or_ptr(p, &ctx->base.iv,
+                                               ctx->base.ivlen)) {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
         return 0;
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_UPDATED_IV);
     if (p != NULL
-        && !OSSL_PARAM_set_octet_string(p, ctx->base.iv, ctx->base.ivlen)
-        && !OSSL_PARAM_set_octet_ptr(p, &ctx->base.iv, ctx->base.ivlen)) {
+        && !OSSL_PARAM_set_octet_string_or_ptr(p, ctx->base.iv,
+                                               ctx->base.ivlen)) {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
         return 0;
     }

--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -432,8 +432,8 @@ static int aes_ocb_get_ctx_params(void *vctx, OSSL_PARAM params[])
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
             return 0;
         }
-        if (!OSSL_PARAM_set_octet_string(p, ctx->base.oiv, ctx->base.ivlen)
-            && !OSSL_PARAM_set_octet_ptr(p, &ctx->base.oiv, ctx->base.ivlen)) {
+        if (!OSSL_PARAM_set_octet_string_or_ptr(p, ctx->base.oiv,
+                                                ctx->base.ivlen)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return 0;
         }
@@ -444,8 +444,8 @@ static int aes_ocb_get_ctx_params(void *vctx, OSSL_PARAM params[])
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
             return 0;
         }
-        if (!OSSL_PARAM_set_octet_string(p, ctx->base.iv, ctx->base.ivlen)
-            && !OSSL_PARAM_set_octet_ptr(p, &ctx->base.iv, ctx->base.ivlen)) {
+        if (!OSSL_PARAM_set_octet_string_or_ptr(p, ctx->base.iv,
+                                                ctx->base.ivlen)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return 0;
         }

--- a/providers/implementations/ciphers/ciphercommon.c
+++ b/providers/implementations/ciphers/ciphercommon.c
@@ -557,15 +557,13 @@ int ossl_cipher_generic_get_ctx_params(void *vctx, OSSL_PARAM params[])
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IV);
     if (p != NULL
-        && !OSSL_PARAM_set_octet_ptr(p, &ctx->oiv, ctx->ivlen)
-        && !OSSL_PARAM_set_octet_string(p, &ctx->oiv, ctx->ivlen)) {
+        && !OSSL_PARAM_set_octet_string_or_ptr(p, &ctx->oiv, ctx->ivlen)) {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
         return 0;
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_UPDATED_IV);
     if (p != NULL
-        && !OSSL_PARAM_set_octet_ptr(p, &ctx->iv, ctx->ivlen)
-        && !OSSL_PARAM_set_octet_string(p, &ctx->iv, ctx->ivlen)) {
+        && !OSSL_PARAM_set_octet_string_or_ptr(p, &ctx->iv, ctx->ivlen)) {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
         return 0;
     }

--- a/providers/implementations/ciphers/ciphercommon_ccm.c
+++ b/providers/implementations/ciphers/ciphercommon_ccm.c
@@ -168,8 +168,7 @@ int ossl_ccm_get_ctx_params(void *vctx, OSSL_PARAM params[])
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
             return 0;
         }
-        if (!OSSL_PARAM_set_octet_string(p, ctx->iv, p->data_size)
-            && !OSSL_PARAM_set_octet_ptr(p, &ctx->iv, p->data_size)) {
+        if (!OSSL_PARAM_set_octet_string_or_ptr(p, ctx->iv, p->data_size)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return 0;
         }
@@ -181,8 +180,7 @@ int ossl_ccm_get_ctx_params(void *vctx, OSSL_PARAM params[])
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
             return 0;
         }
-        if (!OSSL_PARAM_set_octet_string(p, ctx->iv, p->data_size)
-            && !OSSL_PARAM_set_octet_ptr(p, &ctx->iv, p->data_size)) {
+        if (!OSSL_PARAM_set_octet_string_or_ptr(p, ctx->iv, p->data_size)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return 0;
         }

--- a/providers/implementations/ciphers/ciphercommon_gcm.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c
@@ -187,8 +187,7 @@ int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
                 ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
                 return 0;
             }
-            if (!OSSL_PARAM_set_octet_string(p, ctx->iv, ctx->ivlen)
-                && !OSSL_PARAM_set_octet_ptr(p, &ctx->iv, ctx->ivlen)) {
+            if (!OSSL_PARAM_set_octet_string_or_ptr(p, ctx->iv, ctx->ivlen)) {
                 ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
                 return 0;
             }
@@ -201,8 +200,7 @@ int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
                 ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
                 return 0;
             }
-            if (!OSSL_PARAM_set_octet_string(p, ctx->iv, ctx->ivlen)
-                && !OSSL_PARAM_set_octet_ptr(p, &ctx->iv, ctx->ivlen)) {
+            if (!OSSL_PARAM_set_octet_string_or_ptr(p, ctx->iv, ctx->ivlen)) {
                 ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
                 return 0;
             }

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -528,6 +528,7 @@ static int test_param_construct(int tstid)
     size_t j, k, s;
     double d, d2;
     BIGNUM *bn = NULL, *bn2 = NULL;
+    unsigned char teststr[] = "abcdefghi";
 
     params[n++] = OSSL_PARAM_construct_int("int", &i);
     params[n++] = OSSL_PARAM_construct_uint("uint", &u);
@@ -542,8 +543,8 @@ static int test_param_construct(int tstid)
     params[n++] = OSSL_PARAM_construct_BN("bignum", ubuf, sizeof(ubuf));
     params[n++] = OSSL_PARAM_construct_utf8_string("utf8str", buf, sizeof(buf));
     params[n++] = OSSL_PARAM_construct_octet_string("octstr", buf, sizeof(buf));
-    params[n++] = OSSL_PARAM_construct_utf8_ptr("utf8ptr", &bufp, 0);
     params[n++] = OSSL_PARAM_construct_octet_ptr("octptr", &vp, 0);
+    params[n++] = OSSL_PARAM_construct_utf8_ptr("utf8ptr", &bufp, 0);
     params[n] = OSSL_PARAM_construct_end();
 
     switch (tstid) {
@@ -627,6 +628,13 @@ static int test_param_construct(int tstid)
                                                   sizeof("abcdefghi")))
         || !TEST_size_t_eq(cp->return_size, sizeof("abcdefghi")))
         goto err;
+    /* OCTET string */
+    if (!TEST_ptr(cp = OSSL_PARAM_locate(p, "octstr"))
+        || !TEST_true(OSSL_PARAM_set_octet_string_or_ptr(cp, "abcdefghi",
+                                                         sizeof("abcdefghi")))
+        || !TEST_size_t_eq(cp->return_size, sizeof("abcdefghi")))
+        goto err;
+
     /* Match the return size to avoid trailing garbage bytes */
     cp->data_size = cp->return_size;
     if (!TEST_true(OSSL_PARAM_get_octet_string(cp, &vpn, 0, &s))
@@ -647,6 +655,15 @@ static int test_param_construct(int tstid)
         || !TEST_size_t_eq(cp->return_size, sizeof(ul))
         || (tstid <= 1 && !TEST_ptr_eq(vp, &ul)))
         goto err;
+    /* OCTET pointer */
+    vp = &buf;
+    if (!TEST_ptr(cp = OSSL_PARAM_locate(p, "octptr"))
+        || !TEST_true(OSSL_PARAM_set_octet_string_or_ptr(cp, &ul, sizeof(ul)))
+        || !TEST_size_t_eq(cp->return_size, sizeof(ul))
+        || (tstid <= 1 && !TEST_ptr_eq(vp, &ul)))
+        goto err;
+
+
     /* Match the return size to avoid trailing garbage bytes */
     cp->data_size = cp->return_size;
     if (!TEST_true(OSSL_PARAM_get_octet_ptr(cp, (const void **)&vp2, &k))

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -528,7 +528,6 @@ static int test_param_construct(int tstid)
     size_t j, k, s;
     double d, d2;
     BIGNUM *bn = NULL, *bn2 = NULL;
-    unsigned char teststr[] = "abcdefghi";
 
     params[n++] = OSSL_PARAM_construct_int("int", &i);
     params[n++] = OSSL_PARAM_construct_uint("uint", &u);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5536,3 +5536,4 @@ X509_STORE_CTX_set_get_crl              ?	3_2_0	EXIST::FUNCTION:
 X509_STORE_CTX_set_current_reasons      ?	3_2_0	EXIST::FUNCTION:
 OSSL_STORE_delete                       ?	3_2_0	EXIST::FUNCTION:
 BIO_ADDR_copy                           ?	3_2_0	EXIST::FUNCTION:SOCK
+OSSL_PARAM_set_octet_string_or_ptr      ?	3_2_0	EXIST::FUNCTION:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

    There are some deprecated EVP_CIPHER_CTX_*iv() calls which use
    OSSL_PARAM_construct_octet_ptr(), and there are also some newer API calls
    which use OSSL_PARAM_construct_octet_string().
    Because of this the provider cipher getters need to handle both cases
    i.e.
    ````
        p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_UPDATED_IV);
        if (!OSSL_PARAM_set_octet_string(p, &ctx->iv, ctx->ivlen)
                && !OSSL_PARAM_set_octet_ptr(p, &ctx->iv, ctx->ivlen))
            return 0;
    ````
    Both setters raise an error if the data_type is incorrect, which means
    that set_octet_string() will raise an error if the type is octet ptr.
    
    Note: There are some places where these setters are called in the reverse order.
    which means set_octet_ptr() will also raise an error if the type is
    octet string.
    
    Having a new API that can do both operations without raising an error
    seems like the best approach to fix this issue.



##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
