### PR TITLE
sslapitest: add cast to avoid compiler error

### DIFF
--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -11156,7 +11156,7 @@ static int test_data_retry(void)
         goto end;
 
     for (i = 0; i < sizeof(inbuf); i++)
-        inbuf[i] = i;
+        inbuf[i] = (unsigned char)(0xff & i);
     memset(outbuf, 0, sizeof(outbuf));
 
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),


### PR DESCRIPTION
e.g. in [this build](https://github.com/openssl/openssl/actions/runs/6636860020/job/18030076433?pr=22499)

```
..\test\sslapitest.c(11159): error C2220: the following warning is treated as an error
..\test\sslapitest.c(11159): warning C4267: '=': conversion from 'size_t' to 'unsigned char', possible loss of data
NMAKE : fatal error U1077: '"cl"  /Zi /Fdapp.pdb /Gs0 /GF /Gy /MD /W3 /wd4090 /nologo /O2 /WX -I"include" -I"apps\include" -I"." -I"..\include" -I"..\apps\include" -I".." -D"OPENSSL_BUILDING_OPENSSL" -D"OPENSSL_SYS_WIN32" -D"WIN32_LEAN_AND_MEAN" -D"UNICODE" -D"_UNICODE" -D"_CRT_SECURE_NO_DEPRECATE" -D"_WINSOCK_DEPRECATED_NO_WARNINGS" -D"NDEBUG"   -c /Fotest\sslapitest-bin-sslapitest.obj "..\test\sslapitest.c"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\bin\HostX86\x86\nmake.exe" /S                  _build_sw' : return code '0x2'
```

- [ ] documentation is added or updated
- [x] tests are added or updated
