### PR TITLE
apps/rehash.c: ignore printf format warning [-Wformat]

### DIFF
--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -427,9 +427,16 @@ static int do_dir(const char *dirname, enum Hash h)
                     while (bit_isset(idmask, nextid))
                         nextid++;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat"
+                    /*
+                     * false positive (implemented in _dopr() function):
+                     * warning: '%n' specifier not supported on this platform
+                     */
                     BIO_snprintf(buf, buflen, "%s%s%n%08x.%s%d",
                                  dirname, pathsep, &n, bp->hash,
                                  suffixes[bp->type], nextid);
+#pragma GCC diagnostic pop
                     if (verbose)
                         BIO_printf(bio_out, "link %s -> %s\n",
                                    ep->filename, &buf[n]);
@@ -449,9 +456,16 @@ static int do_dir(const char *dirname, enum Hash h)
                     bit_set(idmask, nextid);
                 } else if (remove_links) {
                     /* Link to be deleted */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat"
+                    /*
+                     * false positive (implemented in _dopr() function):
+                     * warning: '%n' specifier not supported on this platform
+                     */
                     BIO_snprintf(buf, buflen, "%s%s%n%08x.%s%d",
                                  dirname, pathsep, &n, bp->hash,
                                  suffixes[bp->type], ep->old_id);
+#pragma GCC diagnostic pop
                     if (verbose)
                         BIO_printf(bio_out, "unlink %s\n",
                                    &buf[n]);


### PR DESCRIPTION
The `aarch64-linux-android33-clang` cross-compiler (v14.0.6) complains twice about an unsupported '%n' format specifier, preventing a successful `--strict-warnings` build:

    error: '%n' specifier not supported on this platform [-Werror,-Wformat]
                BIO_snprintf(buf, buflen, "%s%s%n%08x.%s%d",

This is a false positive, because BIO_snprintf() implements its own format parsing (which is implemented in the _dopr() function).

To disable the warning, use a GCC pragma instead of a clang pragma, because the former is recognized by both compilers according to the [clang manual page][1].

[1]: https://clang.llvm.org/docs/UsersManual.html#controlling-diagnostics-via-pragmas


_(Classified as a bug and marked for backporting, because it prevents a successful `--strict-warnings` build.)_