### PR TITLE
ciphers/signatures: Reject update if module isn't operational

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -237,7 +237,7 @@ static int aes_ocb_block_update(void *vctx, unsigned char *out, size_t *outl,
     size_t *buflen;
     OSSL_ocb_cipher_fn fn;
 
-    if (!ctx->key_set || !update_iv(ctx))
+    if (!ossl_prov_is_running() || !ctx->key_set || !update_iv(ctx))
         return 0;
 
     if (inl == 0) {

--- a/providers/implementations/ciphers/cipher_aes_xts.c
+++ b/providers/implementations/ciphers/cipher_aes_xts.c
@@ -193,6 +193,9 @@ static int aes_xts_stream_update(void *vctx, unsigned char *out, size_t *outl,
 {
     PROV_AES_XTS_CTX *ctx = (PROV_AES_XTS_CTX *)vctx;
 
+    if (!ossl_prov_is_running())
+        return 0;
+
     if (outsize < inl) {
         ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
         return 0;

--- a/providers/implementations/ciphers/cipher_cts.c
+++ b/providers/implementations/ciphers/cipher_cts.c
@@ -48,6 +48,7 @@
 
 #include <openssl/core_names.h>
 #include "prov/ciphercommon.h"
+#include "prov/providercommon.h"
 #include "internal/nelem.h"
 #include "cipher_cts.h"
 
@@ -331,6 +332,9 @@ int ossl_cipher_cbc_cts_block_update(void *vctx, unsigned char *out, size_t *out
 {
     PROV_CIPHER_CTX *ctx = (PROV_CIPHER_CTX *)vctx;
     size_t sz = 0;
+
+    if (!ossl_prov_is_running())
+        return 0;
 
     if (inl < CTS_BLOCK_SIZE) /* There must be at least one block for CTS mode */
         return 0;

--- a/providers/implementations/ciphers/cipher_sm4_xts.c
+++ b/providers/implementations/ciphers/cipher_sm4_xts.c
@@ -167,6 +167,9 @@ static int sm4_xts_stream_update(void *vctx, unsigned char *out, size_t *outl,
 {
     PROV_SM4_XTS_CTX *ctx = (PROV_SM4_XTS_CTX *)vctx;
 
+    if (!ossl_prov_is_running())
+        return 0;
+
     if (outsize < inl) {
         ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
         return 0;

--- a/providers/implementations/ciphers/cipher_tdes_wrap.c
+++ b/providers/implementations/ciphers/cipher_tdes_wrap.c
@@ -153,6 +153,9 @@ static int tdes_wrap_update(void *vctx, unsigned char *out, size_t *outl,
                             size_t inl)
 {
     *outl = 0;
+    if (!ossl_prov_is_running())
+        return 0;
+
     if (inl == 0)
         return 1;
     if (outsize < inl) {

--- a/providers/implementations/ciphers/ciphercommon.c
+++ b/providers/implementations/ciphers/ciphercommon.c
@@ -249,6 +249,9 @@ int ossl_cipher_generic_block_update(void *vctx, unsigned char *out,
     size_t blksz = ctx->blocksize;
     size_t nextblocks;
 
+    if (!ossl_prov_is_running())
+        return 0;
+
     if (ctx->tlsversion > 0) {
         /*
          * Each update call corresponds to a TLS record and is individually
@@ -455,6 +458,9 @@ int ossl_cipher_generic_stream_update(void *vctx, unsigned char *out,
                                       const unsigned char *in, size_t inl)
 {
     PROV_CIPHER_CTX *ctx = (PROV_CIPHER_CTX *)vctx;
+
+    if (!ossl_prov_is_running())
+        return 0;
 
     if (inl == 0) {
         *outl = 0;

--- a/providers/implementations/ciphers/ciphercommon_ccm.c
+++ b/providers/implementations/ciphers/ciphercommon_ccm.c
@@ -269,6 +269,9 @@ int ossl_ccm_stream_update(void *vctx, unsigned char *out, size_t *outl,
 {
     PROV_CCM_CTX *ctx = (PROV_CCM_CTX *)vctx;
 
+    if (!ossl_prov_is_running())
+        return 0;
+
     if (outsize < inl) {
         ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
         return 0;

--- a/providers/implementations/signature/dsa_sig.c
+++ b/providers/implementations/signature/dsa_sig.c
@@ -327,7 +327,7 @@ int dsa_digest_signverify_update(void *vpdsactx, const unsigned char *data,
 {
     PROV_DSA_CTX *pdsactx = (PROV_DSA_CTX *)vpdsactx;
 
-    if (pdsactx == NULL || pdsactx->mdctx == NULL)
+    if (!ossl_prov_is_running() || pdsactx == NULL || pdsactx->mdctx == NULL)
         return 0;
 
     return EVP_DigestUpdate(pdsactx->mdctx, data, datalen);

--- a/providers/implementations/signature/ecdsa_sig.c
+++ b/providers/implementations/signature/ecdsa_sig.c
@@ -337,7 +337,7 @@ int ecdsa_digest_signverify_update(void *vctx, const unsigned char *data,
 {
     PROV_ECDSA_CTX *ctx = (PROV_ECDSA_CTX *)vctx;
 
-    if (ctx == NULL || ctx->mdctx == NULL)
+    if (!ossl_prov_is_running() || ctx == NULL || ctx->mdctx == NULL)
         return 0;
 
     return EVP_DigestUpdate(ctx->mdctx, data, datalen);

--- a/providers/implementations/signature/rsa_sig.c
+++ b/providers/implementations/signature/rsa_sig.c
@@ -896,7 +896,7 @@ static int rsa_digest_signverify_update(void *vprsactx,
 {
     PROV_RSA_CTX *prsactx = (PROV_RSA_CTX *)vprsactx;
 
-    if (prsactx == NULL || prsactx->mdctx == NULL)
+    if (!ossl_prov_is_running() || prsactx == NULL || prsactx->mdctx == NULL)
         return 0;
 
     return EVP_DigestUpdate(prsactx->mdctx, data, datalen);


### PR DESCRIPTION
When a FIPS self-test such as for example a pair-wise consistency test fails, the module should go into an error state and refuse any further cryptographic operations.

This is not the case for the RSA or ECDSA pair-wise consistency test, after which EVP_DigestUpdate() and EVP_EncryptUpdate() can still be called.

Add invocations of ossl_prov_is_running() to provider functions called by EVP_DigestUpdate() and EVP_EncryptUpdate() to fix this.

I am aware that new contexts cannot be created, and existing contexts cannot be finalized because the init and final variants of those APIs have the `ossl_is_prov_running()` call, but our lab claims that is not sufficient, and the update API must also not work on PCT failure.

We added an `abort()` downstream for these cases, since it's really a corner case that essentially never happens outside of bit-flips, but that's clearly not appropriate upstream, and neither is it a clean solution. In order to reduce our downstream patches, I'm proposing this instead.