### PR TITLE
tag ossl_assert not failing as being 'likely' to improve optimisation

### DIFF
--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -38,7 +38,7 @@
 # endif
 
 # ifdef NDEBUG
-#  define ossl_assert(x) ((x) != 0)
+#  define ossl_assert(x) likely((x) != 0)
 # else
 __owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
                                               const char *file, int line)


### PR DESCRIPTION
Add a likely tag to ossl_assert to help compilers produce better code.

- [ ] documentation is added or updated
- [ ] tests are added or updated
