### PR TITLE
evp_test.c: There are now 3 parameters possible for digests

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -458,7 +458,7 @@ static int digest_test_run(EVP_TEST *t)
     unsigned int got_len;
     size_t size = 0;
     int xof = 0;
-    OSSL_PARAM params[3], *p = &params[0];
+    OSSL_PARAM params[4], *p = &params[0];
 
     t->err = "TEST_FAILURE";
     if (!TEST_ptr(mctx = EVP_MD_CTX_new()))


### PR DESCRIPTION
In digest_test_run() there are now 3 parameters possible plus the sentinel value. In reality we will never use all three at once but Coverity rightfully complains that it is possible to overflow the params array.

Fixes Coverity 1548054

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
