### PR TITLE
Fix the encoding of SM2 keys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,12 +28,6 @@ OpenSSL 3.3
 
 ### Changes between 3.2 and 3.3 [xx XXX xxxx]
 
- * Restore the encoding of SM2 PrivateKeyInfo and SubjectPublicKeyInfo to
-   have the contained AlgorithmIdentifier.algorithm set to id-ecPublicKey
-   rather than SM2.
-
-   *Richard Levitte*
-
  * The activate and soft_load configuration settings for providers in
    openssl.cnf have been updated to require a value of [1|yes|true|on]
    (in lower or UPPER case) to enable the setting. Conversely a value
@@ -80,6 +74,12 @@ OpenSSL 3.2
 -----------
 
 ### Changes between 3.2.0 and 3.2.1 [xx XXX xxxx]
+
+ * Restore the encoding of SM2 PrivateKeyInfo and SubjectPublicKeyInfo to
+   have the contained AlgorithmIdentifier.algorithm set to id-ecPublicKey
+   rather than SM2.
+
+   *Richard Levitte*
 
  * The POLY1305 MAC (message authentication code) implementation in OpenSSL
    for PowerPC CPUs saves the contents of vector registers in different

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,12 @@ OpenSSL 3.3
 
 ### Changes between 3.2 and 3.3 [xx XXX xxxx]
 
+ * Restore the encoding of SM2 PrivateKeyInfo and SubjectPublicKeyInfo to
+   have the contained AlgorithmIdentifier.algorithm set to id-ecPublicKey
+   rather than SM2.
+
+   *Richard Levitte*
+
  * The activate and soft_load configuration settings for providers in
    openssl.cnf have been updated to require a value of [1|yes|true|on]
    (in lower or UPPER case) to enable the setting. Conversely a value

--- a/providers/implementations/encode_decode/encode_key2any.c
+++ b/providers/implementations/encode_decode/encode_key2any.c
@@ -740,7 +740,12 @@ static int ec_pki_priv_to_der(const void *veckey, unsigned char **pder)
 # define ec_pem_type            "EC"
 
 # ifndef OPENSSL_NO_SM2
-#  define sm2_evp_type          EVP_PKEY_SM2
+/*
+ * SM2 is really an ECC key, and where it matters for encoding (in all places
+ * where an AlgorithmIdentifier is produced, such as PrivateKeyInfo and
+ * SubjectPublicKeyInfo), that's the algorithm OID that should be used.
+ */
+#  define sm2_evp_type          ec_evp_type
 #  define sm2_input_type        "SM2"
 #  define sm2_pem_type          "SM2"
 # endif

--- a/providers/implementations/encode_decode/encode_key2any.c
+++ b/providers/implementations/encode_decode/encode_key2any.c
@@ -741,9 +741,12 @@ static int ec_pki_priv_to_der(const void *veckey, unsigned char **pder)
 
 # ifndef OPENSSL_NO_SM2
 /*
- * SM2 is really an ECC key, and where it matters for encoding (in all places
- * where an AlgorithmIdentifier is produced, such as PrivateKeyInfo and
- * SubjectPublicKeyInfo), that's the algorithm OID that should be used.
+ * Albeit SM2 is a slightly different algorithm than ECDSA, the key type
+ * encoding (in all places where an AlgorithmIdentifier is produced, such
+ * as PrivateKeyInfo and SubjectPublicKeyInfo) is the same as for ECC keys
+ * according to the example in GM/T 0015-2012, appendix D.2.
+ * This leaves the distinction of SM2 keys to the EC group (which is found
+ * in AlgorithmIdentified.params).
  */
 #  define sm2_evp_type          ec_evp_type
 #  define sm2_input_type        "SM2"

--- a/test/recipes/15-test_gensm2.t
+++ b/test/recipes/15-test_gensm2.t
@@ -33,11 +33,11 @@ plan tests => 2;
 
 my $sm2_re = qr|
    ^
-   .*?\Qcons: SEQUENCE\E\s+?\n
-   .*?\Qprim:  INTEGER           :00\E\n
-   .*?\Qcons:  SEQUENCE\E\s+?\n
-   .*?\Qprim:   OBJECT            :id-ecPublicKey\E\n
-   .*?\Qprim:   OBJECT            :sm2\E\n
+   .*?\Qcons: SEQUENCE\E\s+?\R
+   .*?\Qprim:  INTEGER           :00\E\R
+   .*?\Qcons:  SEQUENCE\E\s+?\R
+   .*?\Qprim:   OBJECT            :id-ecPublicKey\E\R
+   .*?\Qprim:   OBJECT            :sm2\E\R
    .*?\Qprim:  OCTET STRING      [HEX DUMP]:\E
    |mx;
 
@@ -54,7 +54,7 @@ my $result_ec = join("", run(pipe($cmd_genec, $cmd_asn1parse),
 like($result_ec, $sm2_re,
      "Check that 'genpkey -algorithm EC' resulted in a correctly encoded SM2 key");
 
-my $result_sm2 = join("", run(pipe($cmd_genec, $cmd_asn1parse),
+my $result_sm2 = join("", run(pipe($cmd_gensm2, $cmd_asn1parse),
                               capture => 1));
 
 like($result_sm2, $sm2_re,

--- a/test/recipes/15-test_gensm2.t
+++ b/test/recipes/15-test_gensm2.t
@@ -1,0 +1,61 @@
+#! /usr/bin/env perl
+# Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use strict;
+use warnings;
+
+use File::Spec;
+use OpenSSL::Test qw(:DEFAULT pipe);
+use OpenSSL::Test::Utils;
+
+# These are special key generation tests for SM2 keys specifically,
+# as they could be said to be a bit special in their encoding.
+# This is an auxilliary test to 15-test_genec.t
+
+setup("test_gensm2");
+
+plan skip_all => "This test is unsupported in a no-sm2 build"
+    if disabled("sm2");
+
+plan tests => 2;
+
+# According to the example in  GM/T 0015-2012, appendix D.2,
+# generating an EC key with the named SM2 curve or generating
+# an SM2 key should end up with the same encoding (apart from
+# key private key field itself).  This regular expressions
+# shows us what 'openssl asn1parse' should display.
+
+my $sm2_re = qr|
+   ^
+   .*?\Qcons: SEQUENCE\E\s+?\n
+   .*?\Qprim:  INTEGER           :00\E\n
+   .*?\Qcons:  SEQUENCE\E\s+?\n
+   .*?\Qprim:   OBJECT            :id-ecPublicKey\E\n
+   .*?\Qprim:   OBJECT            :sm2\E\n
+   .*?\Qprim:  OCTET STRING      [HEX DUMP]:\E
+   |mx;
+
+my $cmd_genec = app([ 'openssl', 'genpkey',
+                      '-algorithm', 'EC',
+                      '-pkeyopt', 'ec_paramgen_curve:SM2',
+                      '-pkeyopt', 'ec_param_enc:named_curve' ]);
+my $cmd_gensm2 = app([ 'openssl', 'genpkey', '-algorithm', 'SM2' ]);
+my $cmd_asn1parse = app([ 'openssl', 'asn1parse', '-i' ]);
+
+my $result_ec = join("", run(pipe($cmd_genec, $cmd_asn1parse),
+                             capture => 1));
+
+like($result_ec, $sm2_re,
+     "Check that 'genpkey -algorithm EC' resulted in a correctly encoded SM2 key");
+
+my $result_sm2 = join("", run(pipe($cmd_genec, $cmd_asn1parse),
+                              capture => 1));
+
+like($result_sm2, $sm2_re,
+     "Check that 'genpkey -algorithm SM2' resulted in a correctly encoded SM2 key");


### PR DESCRIPTION
OpenSSL's encoding of SM2 keys used the SM2 OID for the algorithm OID
where an AlgorithmIdentifier is encoded (for encoding into the structures
PrivateKeyInfo and SubjectPublicKeyInfo).

Such keys should be encoded as ECC keys.

Fixes #22184
