### PR TITLE
Check for NULL when freeing the QUIC_TLS object

### DIFF
--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -654,6 +654,8 @@ QUIC_TLS *ossl_quic_tls_new(const QUIC_TLS_ARGS *args)
 
 void ossl_quic_tls_free(QUIC_TLS *qtls)
 {
+    if (qtls == NULL)
+        return;
     OSSL_ERR_STATE_free(qtls->error_state);
     OPENSSL_free(qtls);
 }


### PR DESCRIPTION
Free functions are expected to be tolerant of a NULL pointer being passed.

Fixes the problem in
https://github.com/openssl/openssl/pull/21668#issuecomment-1782718328
