### PR TITLE
If the loss detection timer has fired we may not have lost packets

### DIFF
--- a/ssl/quic/quic_ackm.c
+++ b/ssl/quic/quic_ackm.c
@@ -1301,8 +1301,8 @@ int ossl_ackm_on_timeout(OSSL_ACKM *ackm)
     if (!ossl_time_is_zero(earliest_loss_time)) {
         /* Time threshold loss detection. */
         lost_pkts = ackm_detect_and_remove_lost_pkts(ackm, pkt_space);
-        assert(lost_pkts != NULL);
-        ackm_on_pkts_lost(ackm, pkt_space, lost_pkts, /*pseudo=*/0);
+        if (lost_pkts != NULL)
+            ackm_on_pkts_lost(ackm, pkt_space, lost_pkts, /*pseudo=*/0);
         ackm_set_loss_detection_timer(ackm);
         return 1;
     }


### PR DESCRIPTION
We calculate the delay from the point that a packet arrives until it will be counted as lost based on rtt info. Looking at all the packets we can then calculate the earliest time that a packet will be counted as lost. When that timer fires the latest rtt info may have changed and therefore the packet may no longer be counted as lost yet.

We should not assume that just because the ackm timeout has fired that there will definitely be lost packets.

Fixes #22538