### PR TITLE
quic: update ddd makefile and demo sources

### DIFF
--- a/doc/designs/ddd/Makefile
+++ b/doc/designs/ddd/Makefile
@@ -1,29 +1,43 @@
 #
-# To run the demos when linked with a shared library (default):
+# To run the demos when linked with a shared library (default) ensure that
+# libcrypto and libssl are on the library path. For example to run the
+# ddd-01-conn-blocking-tls demo:
 #
-#    LD_LIBRARY_PATH=../.. make test
+#    LD_LIBRARY_PATH=../../.. ./ddd-01-conn-blocking-tls
+#
+# Building ddd-06-mem-uv-tls and ddd-06-mem-uv-quic requires the
+# library libuv and header file.  On Ubuntu, they are provided by the
+# package "libuv1-dev".
 
-TESTS_BASE=ddd-01-conn-blocking ddd-02-conn-nonblocking ddd-02-conn-nonblocking-threads \
-		   ddd-03-fd-blocking ddd-04-fd-nonblocking ddd-05-mem-nonblocking ddd-06-mem-uv
-TESTS=$(foreach x,$(TESTS_BASE),$(x)-tls $(x)-quic)
+TESTS_BASE = ddd-01-conn-blocking \
+             ddd-02-conn-nonblocking \
+             ddd-02-conn-nonblocking-threads \
+             ddd-03-fd-blocking \
+             ddd-04-fd-nonblocking \
+             ddd-05-mem-nonblocking \
+             ddd-06-mem-uv
 
-CFLAGS = -I../../../include -O3 -g -Wall
+TESTS = $(foreach x,$(TESTS_BASE),$(x)-tls $(x)-quic)
+
+CFLAGS  = -I../../../include -g -Wall -Wsign-compare
 LDFLAGS = -L../../..
-LDLIBS = -lcrypto -lssl
+LDLIBS  = -lcrypto -lssl
+
+CC_CMD = $(CC) $(CFLAGS) $(LDFLAGS) -o "$@" "$<" $(LDLIBS)
 
 all: $(TESTS)
 
 clean:
 	rm -f $(TESTS) *.o
 
-ddd-06-mem-uv-tls: ddd-06-mem-uv.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -o "$@" "$<" $(LDLIBS) -luv
-
-ddd-06-mem-uv-quic: ddd-06-mem-uv.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -DUSE_QUIC -o "$@" "$<" $(LDLIBS) -luv
+ddd-%-tls: ddd-%.c
+	$(CC_CMD)
 
 ddd-%-quic: ddd-%.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -DUSE_QUIC -o "$@" "$<" $(LDLIBS)
+	$(CC_CMD) -DUSE_QUIC
 
-ddd-%-tls: ddd-%.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -o "$@" "$<" $(LDLIBS)
+ddd-%-uv-tls: ddd-%-uv.c
+	$(CC_CMD) -luv
+
+ddd-%-uv-quic: ddd-%-uv.c
+	$(CC_CMD) -luv -DUSE_QUIC

--- a/doc/designs/ddd/ddd-01-conn-blocking.c
+++ b/doc/designs/ddd/ddd-01-conn-blocking.c
@@ -141,16 +141,16 @@ int main(int argc, char **argv)
     SSL_CTX *ctx = NULL;
     BIO *b = NULL;
     char buf[2048];
-    int l, res = 1;
+    int l, mlen, res = 1;
 
     if (argc < 3) {
         fprintf(stderr, "usage: %s host port\n", argv[0]);
         goto fail;
     }
 
-    snprintf(host_port, sizeof(host_port), "%s:%s\n", argv[1], argv[2]);
-    snprintf(msg, sizeof(msg),
-             "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", argv[1]);
+    snprintf(host_port, sizeof(host_port), "%s:%s", argv[1], argv[2]);
+    mlen = snprintf(msg, sizeof(msg),
+                    "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", argv[1]);
 
     ctx = create_ssl_ctx();
     if (ctx == NULL) {
@@ -160,11 +160,12 @@ int main(int argc, char **argv)
 
     b = new_conn(ctx, host_port);
     if (b == NULL) {
-        fprintf(stderr, "could not create conn\n");
+        fprintf(stderr, "could not create connection\n");
         goto fail;
     }
 
-    if (tx(b, msg, sizeof(msg)) < sizeof(msg)) {
+    l = tx(b, msg, mlen);
+    if (l < mlen) {
         fprintf(stderr, "tx error\n");
         goto fail;
     }

--- a/doc/designs/ddd/ddd-02-conn-nonblocking-threads.c
+++ b/doc/designs/ddd/ddd-02-conn-nonblocking-threads.c
@@ -2,7 +2,7 @@
 #include <openssl/ssl.h>
 
 /*
- * Demo 2: Client — Managed Connection — Asynchronous Nonblocking
+ * Demo 2: Client — Managed Connection — Nonblocking
  * ==============================================================
  *
  * This is an example of (part of) an application which uses libssl in an
@@ -260,7 +260,7 @@ int main(int argc, char **argv)
     static char tx_msg[384], host_port[300];
     const char *tx_p = tx_msg;
     char rx_buf[2048];
-    int res = 1, l, tx_len = sizeof(tx_msg)-1;
+    int res = 1, l, tx_len;
     int timeout = 2000 /* ms */;
     APP_CONN *conn = NULL;
     SSL_CTX *ctx = NULL;
@@ -271,8 +271,8 @@ int main(int argc, char **argv)
     }
 
     snprintf(host_port, sizeof(host_port), "%s:%s", argv[1], argv[2]);
-    snprintf(tx_msg, sizeof(tx_msg),
-             "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", argv[1]);
+    tx_len = snprintf(tx_msg, sizeof(tx_msg),
+                      "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", argv[1]);
 
     ctx = create_ssl_ctx();
     if (ctx == NULL) {

--- a/doc/designs/ddd/ddd-02-conn-nonblocking.c
+++ b/doc/designs/ddd/ddd-02-conn-nonblocking.c
@@ -2,7 +2,7 @@
 #include <openssl/ssl.h>
 
 /*
- * Demo 2: Client — Managed Connection — Asynchronous Nonblocking
+ * Demo 2: Client — Managed Connection — Nonblocking
  * ==============================================================
  *
  * This is an example of (part of) an application which uses libssl in an
@@ -316,7 +316,7 @@ int main(int argc, char **argv)
     static char tx_msg[384], host_port[300];
     const char *tx_p = tx_msg;
     char rx_buf[2048];
-    int res = 1, l, tx_len = sizeof(tx_msg)-1;
+    int res = 1, l, tx_len;
 #ifdef USE_QUIC
     struct timeval timeout;
 #else
@@ -335,8 +335,8 @@ int main(int argc, char **argv)
     }
 
     snprintf(host_port, sizeof(host_port), "%s:%s", argv[1], argv[2]);
-    snprintf(tx_msg, sizeof(tx_msg),
-             "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", argv[1]);
+    tx_len = snprintf(tx_msg, sizeof(tx_msg),
+                      "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", argv[1]);
 
     ctx = create_ssl_ctx();
     if (ctx == NULL) {

--- a/doc/designs/ddd/ddd-03-fd-blocking.c
+++ b/doc/designs/ddd/ddd-03-fd-blocking.c
@@ -136,7 +136,7 @@ void teardown_ctx(SSL_CTX *ctx)
 
 int main(int argc, char **argv)
 {
-    int rc, fd = -1, l, res = 1;
+    int rc, fd = -1, l, mlen, res = 1;
     static char msg[300];
     struct addrinfo hints = {0}, *result = NULL;
     SSL *ssl = NULL;
@@ -148,8 +148,8 @@ int main(int argc, char **argv)
         goto fail;
     }
 
-    snprintf(msg, sizeof(msg),
-             "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", argv[1]);
+    mlen = snprintf(msg, sizeof(msg),
+                    "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", argv[1]);
 
     ctx = create_ssl_ctx();
     if (ctx == NULL) {
@@ -190,7 +190,8 @@ int main(int argc, char **argv)
         goto fail;
     }
 
-    if (tx(ssl, msg, sizeof(msg)-1) < sizeof(msg)-1) {
+    l = tx(ssl, msg, mlen);
+    if (l < mlen) {
         fprintf(stderr, "tx error\n");
         goto fail;
     }

--- a/doc/designs/ddd/ddd-04-fd-nonblocking.c
+++ b/doc/designs/ddd/ddd-04-fd-nonblocking.c
@@ -8,7 +8,7 @@
  * This is an example of (part of) an application which uses libssl in an
  * asynchronous, nonblocking fashion. The client is responsible for creating the
  * socket and passing it to libssl. The functions show all interactions with
- * libssl the application makes, and wouldn hypothetically be linked into a
+ * libssl the application makes, and would hypothetically be linked into a
  * larger application.
  */
 typedef struct app_conn_st {
@@ -297,7 +297,7 @@ int main(int argc, char **argv)
     static char tx_msg[300];
     const char *tx_p = tx_msg;
     char rx_buf[2048];
-    int l, tx_len = sizeof(tx_msg)-1;
+    int l, tx_len;
 #ifdef USE_QUIC
     struct timeval timeout;
 #else
@@ -316,8 +316,8 @@ int main(int argc, char **argv)
         goto fail;
     }
 
-    snprintf(tx_msg, sizeof(tx_msg),
-             "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", argv[1]);
+    tx_len = snprintf(tx_msg, sizeof(tx_msg),
+                      "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", argv[1]);
 
     ctx = create_ssl_ctx();
     if (ctx == NULL) {

--- a/doc/designs/ddd/ddd-05-mem-nonblocking.c
+++ b/doc/designs/ddd/ddd-05-mem-nonblocking.c
@@ -356,7 +356,7 @@ int main(int argc, char **argv)
     static char tx_msg[300];
     const char *tx_p = tx_msg;
     char rx_buf[2048];
-    int l, tx_len = sizeof(tx_msg)-1;
+    int l, tx_len;
     int timeout = 2000 /* ms */;
     APP_CONN *conn = NULL;
     struct addrinfo hints = {0}, *result = NULL;
@@ -367,9 +367,9 @@ int main(int argc, char **argv)
         goto fail;
     }
 
-    snprintf(tx_msg, sizeof(tx_msg),
-             "GET / HTTP/1.0\r\nHost: %s\r\n\r\n",
-             argv[1]);
+    tx_len = snprintf(tx_msg, sizeof(tx_msg),
+                      "GET / HTTP/1.0\r\nHost: %s\r\n\r\n",
+                      argv[1]);
 
     ctx = create_ssl_ctx();
     if (ctx == NULL) {

--- a/doc/designs/ddd/ddd-06-mem-uv.c
+++ b/doc/designs/ddd/ddd-06-mem-uv.c
@@ -294,7 +294,7 @@ static void net_read_alloc(uv_handle_t *handle,
 static void on_rx_push(APP_CONN *conn)
 {
     int srd, rc;
-    size_t buf_len = 4096;
+    int buf_len = 4096;
 
     do {
         if (!conn->app_read_cb)
@@ -696,6 +696,7 @@ static void post_write_get(APP_CONN *conn, int status, void *arg)
 }
 
 char tx_msg[300];
+int mlen;
 
 static void post_connect(APP_CONN *conn, int status, void *arg)
 {
@@ -707,8 +708,8 @@ static void post_connect(APP_CONN *conn, int status, void *arg)
         return;
     }
 
-    wr = app_write(conn, tx_msg, sizeof(tx_msg)-1, post_write_get, NULL);
-    if (wr < sizeof(tx_msg)-1) {
+    wr = app_write(conn, tx_msg, mlen, post_write_get, NULL);
+    if (wr < mlen) {
         fprintf(stderr, "error writing request");
         return;
     }
@@ -726,8 +727,8 @@ int main(int argc, char **argv)
         goto fail;
     }
 
-    snprintf(tx_msg, sizeof(tx_msg),
-             "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", argv[1]);
+    mlen = snprintf(tx_msg, sizeof(tx_msg),
+                    "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", argv[1]);
 
     ctx = create_ssl_ctx();
     if (!ctx)


### PR DESCRIPTION
Update makefile and fix some signedness issues in the demo sources. Also, determine the length of the message we are sending and send that many bytes (rather than send sizeof the buffer storing the message).

These changes are part of https://github.com/openssl/project/issues/253
