### PR TITLE
Always call OPENSSL_cleanup prior to exit

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -308,6 +308,7 @@ int main(int argc, char *argv[])
     BIO_free_all(bio_out);
     apps_shutdown();
     BIO_free_all(bio_err);
+    OPENSSL_cleanup();
     EXIT(ret);
 }
 


### PR DESCRIPTION
If an engine is loaded during the course of operations, and if that engine is written in C++, the data in that library will be deleted using an atexit handler prior to the execution of openssl's atexit handler, causing memory corruption/segfaults/unpredictable behavior.  The only way to avoid that is to release any reference we have to that data prior to exit, which means calling OPENSSL_cleanup prior to exit.  This patch enforces that behavior for all openssl utilities

Fixes #22508

