### PR TITLE
Fix ddd-01-conn-blocking demo for quic

### DIFF
--- a/doc/designs/ddd/ddd-01-conn-blocking.c
+++ b/doc/designs/ddd/ddd-01-conn-blocking.c
@@ -148,7 +148,7 @@ int main(int argc, char **argv)
         goto fail;
     }
 
-    snprintf(host_port, sizeof(host_port), "%s:%s\n", argv[1], argv[2]);
+    snprintf(host_port, sizeof(host_port), "%s:%s", argv[1], argv[2]);
     snprintf(msg, sizeof(msg),
              "GET / HTTP/1.0\r\nHost: %s\r\n\r\n", argv[1]);
 


### PR DESCRIPTION
This demo constructs a host:port formatted string for use in the new_conn function but adds a newline to said string, which causes BIO_lookup_addr to return an error when the connection is parsed.  Remove the newline to allow proper parsing

