### PR TITLE
Fix quicserver binding when duplicate entries exist

### DIFF
--- a/util/quicserver.c
+++ b/util/quicserver.c
@@ -104,6 +104,7 @@ static BIO *create_dgram_bio(int family, const char *hostname, const char *port)
             continue;
         }
         bound_socks++;
+        break; /* stop searching if we found an addr */
     }
 
     /* Free the address information resources we allocated earlier */

--- a/util/quicserver.c
+++ b/util/quicserver.c
@@ -70,7 +70,6 @@ static BIO *create_dgram_bio(int family, const char *hostname, const char *port)
     BIO_ADDRINFO *res;
     const BIO_ADDRINFO *ai = NULL;
     BIO *bio;
-    int bound_socks = 0;
 
     if (BIO_sock_init() != 1)
         return NULL;
@@ -103,7 +102,7 @@ static BIO *create_dgram_bio(int family, const char *hostname, const char *port)
             BIO_closesocket(sock);
             continue;
         }
-        bound_socks++;
+
         break; /* stop searching if we found an addr */
     }
 
@@ -111,7 +110,7 @@ static BIO *create_dgram_bio(int family, const char *hostname, const char *port)
     BIO_ADDRINFO_free(res);
 
     /* If we didn't bind any sockets, fail */
-    if (bound_socks == 0)
+    if (ai == NULL)
         return NULL;
 
     /* Create a BIO to wrap the socket */


### PR DESCRIPTION
In testing the quic demos, I found that the quicserver refused to start for me, indicating an inability to bind a socket to listen on

The problem turned out to be that getaddrinfo on my system was returning multiple entries, due to the fact that /etc/host maps the localhost host name to both ipv4 (127.0.0.1) and ipv6 (::1), but returns the latter as an ipv4 mapped address (specifying family == AF_INET)

It seems like the proper fix would be to modify the /etc/hosts file to not make that mapping, and indeed that works.  However, since several distribution ship with this setup, it seems like it is worthwhile to manage it in the server code.

its also that some other application may be bound to a given address/port leading to failure, which I think could be considered erroneous, as any failure for the full addrinfo list in quicserver would lead to a complete failure

Fix this by modifying the create_dgram_bio function to count the number of sockets is successfully binds/listens on, skipping any failures, and only exit the application if the number of bound sockets is zero.

Fixes openssl/project#253

