### PR TITLE
QUIC: Fix send buffer sizing to avoid pathological performance under high RTT

### DIFF
--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -2177,6 +2177,11 @@ struct quic_write_again_args {
     int                 err;
 };
 
+/*
+ * Absolute maximum write buffer size, enforced to prevent a rogue peer from
+ * deliberately inducing DoS. This has been chosen based on the optimal buffer
+ * size for an RTT of 500ms and a bandwidth of 100 Mb/s.
+ */
 #define MAX_WRITE_BUF_SIZE      (6 * 1024 * 1024)
 
 /*


### PR DESCRIPTION
Previously, we did not determine write buffer admission based on signalled FC; we used a hardcoded buffer size which did not vary with regards to RTT. Because data cannot be culled from the send buffer until it has been acknowledged by the peer, in case it needs to be retransmitted, the optimal send buffer size is a function of RTT, and a fixed size will exhibit pathologically low throughput for high RTT paths.

This prevented QUIC flow control from achieving its purpose, which is to determine the permitted buffering based (amongst other factors) on RTT to ensure that it is not the bottleneck. This PR automatically resizes send buffers as needed to ensure that the cadence dictated by QUIC flow control is achievable.

Also fix a bug where the TXP did not determine stream exhaustion correctly.

Throughput was tested before and after this PR between servers in London and Sydney (~305ms RTT):

- Before this PR: application data peak throughput in one direction: 25.9 KiB/s
- After this PR: application data peak throughput in one direction: 5.80 MiB/s

This is over a residential internet connection limited to 6.56 MiB/s (55 Mb/s cable modem sync rate) not counting any per-packet overheads.

Buffer resizing is performed as the determination of QUIC flow control indicates. A hard cap of 6 MiB is imposed to prevent DoS by a rogue peer. This value was chosen as the optimal buffer size needed for a RTT of 500ms and a bandwidth of 100 Mb/s.