### PR TITLE
CI: add Clang 17

### DIFF
--- a/.github/workflows/compiler-zoo.yml
+++ b/.github/workflows/compiler-zoo.yml
@@ -75,6 +75,10 @@ jobs:
             cc: clang-16,
             distro: ubuntu-22.04,
             llvm-ppa-name: jammy
+          }, {
+            cc: clang-17,
+            distro: ubuntu-22.04,
+            llvm-ppa-name: jammy
           }
         ]
     # We set per-compiler now to allow testing with both older and newer sets


### PR DESCRIPTION
Standard CI update as usual, this time for Clang 17.
