### PR TITLE
Correctly free the QUIC_CONNECTION on failure during construction

### DIFF
--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -450,14 +450,11 @@ SSL *ossl_quic_new(SSL_CTX *ctx)
     return ssl_base;
 
 err:
-    if (qc != NULL) {
-#if defined(OPENSSL_THREADS)
-        ossl_crypto_mutex_free(qc->mutex);
-#endif
-        ossl_quic_channel_free(qc->ch);
-        SSL_free(qc->tls);
-    }
-    OPENSSL_free(qc);
+    if (ssl_base != NULL)
+        SSL_free(ssl_base);
+    else
+        OPENSSL_free(qc);
+
     return NULL;
 }
 


### PR DESCRIPTION
We need to ensure we clear any references to the SSL_CTX and crypto_ex data.

Addresses the issue found in:
 https://github.com/openssl/openssl/pull/21668#issuecomment-1787221129
