### PR TITLE
Add Ipv6 option to quic demos

### DIFF
--- a/demos/guide/quic-client-block.c
+++ b/demos/guide/quic-client-block.c
@@ -137,6 +137,10 @@ int main(int argc, char *argv[])
     }
 
     if (!strcmp(argv[argnext], "-6")) {
+        if (argc < 4) {
+            printf("Usage: quic-client-block [-6] hostname port\n");
+            goto end;
+        }
         ipv6 = 1;
         argnext++;
     }

--- a/demos/guide/quic-client-block.c
+++ b/demos/guide/quic-client-block.c
@@ -27,7 +27,7 @@
 
 /* Helper function to create a BIO connected to the server */
 static BIO *create_socket_bio(const char *hostname, const char *port,
-                              BIO_ADDR **peer_addr)
+                              int family, BIO_ADDR **peer_addr)
 {
     int sock = -1;
     BIO_ADDRINFO *res;
@@ -37,7 +37,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
     /*
      * Lookup IP address info for the server.
      */
-    if (!BIO_lookup_ex(hostname, port, BIO_LOOKUP_CLIENT, 0, SOCK_DGRAM, 0,
+    if (!BIO_lookup_ex(hostname, port, BIO_LOOKUP_CLIENT, family, SOCK_DGRAM, 0,
                        &res))
         return NULL;
 
@@ -128,14 +128,20 @@ int main(int argc, char *argv[])
     char buf[160];
     BIO_ADDR *peer_addr = NULL;
     char *hostname, *port;
+    int argnext = 1;
+    int ipv6 = 0;
 
-    if (argc != 3) {
-        printf("Usage: quic-client-block hostname port\n");
+    if (argc < 3) {
+        printf("Usage: quic-client-block [-6] hostname port\n");
         goto end;
     }
 
-    hostname = argv[1];
-    port = argv[2];
+    if (!strcmp(argv[argnext], "-6")) {
+        ipv6 = 1;
+        argnext++;
+    }
+    hostname = argv[argnext++];
+    port = argv[argnext];
 
     /*
      * Create an SSL_CTX which we can use to create SSL objects from. We
@@ -172,7 +178,7 @@ int main(int argc, char *argv[])
      * Create the underlying transport socket/BIO and associate it with the
      * connection.
      */
-    bio = create_socket_bio(hostname, port, &peer_addr);
+    bio = create_socket_bio(hostname, port, ipv6 ? AF_INET6 : AF_INET, &peer_addr);
     if (bio == NULL) {
         printf("Failed to crete the BIO\n");
         goto end;

--- a/demos/guide/quic-client-non-block.c
+++ b/demos/guide/quic-client-non-block.c
@@ -245,6 +245,10 @@ int main(int argc, char *argv[])
     }
 
     if (!strcmp(argv[argnext], "-6")) {
+        if (argc < 4) {
+            printf("Usage: quic-client-non-block [-6] hostname port\n");
+            goto end;
+        }
         ipv6 = 1;
         argnext++;
     }

--- a/demos/guide/quic-multi-stream.c
+++ b/demos/guide/quic-multi-stream.c
@@ -27,7 +27,7 @@
 
 /* Helper function to create a BIO connected to the server */
 static BIO *create_socket_bio(const char *hostname, const char *port,
-                              BIO_ADDR **peer_addr)
+                              int family, BIO_ADDR **peer_addr)
 {
     int sock = -1;
     BIO_ADDRINFO *res;
@@ -37,7 +37,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
     /*
      * Lookup IP address info for the server.
      */
-    if (!BIO_lookup_ex(hostname, port, BIO_LOOKUP_CLIENT, 0, SOCK_DGRAM, 0,
+    if (!BIO_lookup_ex(hostname, port, BIO_LOOKUP_CLIENT, family, SOCK_DGRAM, 0,
                        &res))
         return NULL;
 
@@ -148,14 +148,20 @@ int main(int argc, char *argv[])
     char buf[160];
     BIO_ADDR *peer_addr = NULL;
     char *hostname, *port;
+    int argnext = 1;
+    int ipv6 = 0;
 
-    if (argc != 3) {
-        printf("Usage: quic-client-non-block hostname port\n");
+    if (argc < 3) {
+        printf("Usage: quic-client-non-block [-6] hostname port\n");
         goto end;
     }
 
-    hostname = argv[1];
-    port = argv[2];
+    if (!strcmp(argv[argnext], "-6")) {
+        ipv6 = 1;
+        argnext++;
+    }
+    hostname = argv[argnext++];
+    port = argv[argnext];
 
     /*
      * Create an SSL_CTX which we can use to create SSL objects from. We
@@ -201,7 +207,7 @@ int main(int argc, char *argv[])
      * Create the underlying transport socket/BIO and associate it with the
      * connection.
      */
-    bio = create_socket_bio(hostname, port, &peer_addr);
+    bio = create_socket_bio(hostname, port, ipv6 ? AF_INET6 : AF_INET, &peer_addr);
     if (bio == NULL) {
         printf("Failed to crete the BIO\n");
         goto end;

--- a/demos/guide/quic-multi-stream.c
+++ b/demos/guide/quic-multi-stream.c
@@ -157,6 +157,10 @@ int main(int argc, char *argv[])
     }
 
     if (!strcmp(argv[argnext], "-6")) {
+        if (argc < 4) {
+            printf("Usage: quic-client-non-block [-6] hostname port\n");
+            goto end;
+        }
         ipv6 = 1;
         argnext++;
     }

--- a/demos/guide/tls-client-block.c
+++ b/demos/guide/tls-client-block.c
@@ -26,7 +26,7 @@
 #include <openssl/err.h>
 
 /* Helper function to create a BIO connected to the server */
-static BIO *create_socket_bio(const char *hostname, const char *port)
+static BIO *create_socket_bio(const char *hostname, const char *port, int family)
 {
     int sock = -1;
     BIO_ADDRINFO *res;
@@ -36,7 +36,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port)
     /*
      * Lookup IP address info for the server.
      */
-    if (!BIO_lookup_ex(hostname, port, BIO_LOOKUP_CLIENT, 0, SOCK_STREAM, 0,
+    if (!BIO_lookup_ex(hostname, port, BIO_LOOKUP_CLIENT, family, SOCK_STREAM, 0,
                        &res))
         return NULL;
 
@@ -109,14 +109,24 @@ int main(int argc, char *argv[])
     size_t written, readbytes;
     char buf[160];
     char *hostname, *port;
+    int argnext = 1;
+    int ipv6 = 0;
 
-    if (argc != 3) {
-        printf("Usage: tls-client-block hostname port\n");
+    if (argc < 3) {
+        printf("Usage: tls-client-block [-6]  hostname port\n");
         goto end;
     }
 
-    hostname = argv[1];
-    port = argv[2];
+    if (!strcmp(argv[argnext], "-6")) {
+        if (argc < 4) {
+            printf("Usage: tls-client-block [-6]  hostname port\n");
+            goto end;
+        }
+        ipv6 = 1;
+        argnext++;
+    }
+    hostname = argv[argnext++];
+    port = argv[argnext];
 
     /*
      * Create an SSL_CTX which we can use to create SSL objects from. We
@@ -162,7 +172,7 @@ int main(int argc, char *argv[])
      * Create the underlying transport socket/BIO and associate it with the
      * connection.
      */
-    bio = create_socket_bio(hostname, port);
+    bio = create_socket_bio(hostname, port, ipv6 == 0 ? AF_INET : AF_INET6);
     if (bio == NULL) {
         printf("Failed to crete the BIO\n");
         goto end;

--- a/demos/guide/tls-client-block.c
+++ b/demos/guide/tls-client-block.c
@@ -172,7 +172,7 @@ int main(int argc, char *argv[])
      * Create the underlying transport socket/BIO and associate it with the
      * connection.
      */
-    bio = create_socket_bio(hostname, port, ipv6 == 0 ? AF_INET : AF_INET6);
+    bio = create_socket_bio(hostname, port, ipv6 ? AF_INET6 : AF_INET);
     if (bio == NULL) {
         printf("Failed to crete the BIO\n");
         goto end;

--- a/demos/guide/tls-client-non-block.c
+++ b/demos/guide/tls-client-non-block.c
@@ -251,7 +251,7 @@ int main(int argc, char *argv[])
      * Create the underlying transport socket/BIO and associate it with the
      * connection.
      */
-    bio = create_socket_bio(hostname, port, ipv6 == 0 ? AF_INET : AF_INET6);
+    bio = create_socket_bio(hostname, port, ipv6 ? AF_INET6 : AF_INET);
     if (bio == NULL) {
         printf("Failed to crete the BIO\n");
         goto end;

--- a/demos/guide/tls-client-non-block.c
+++ b/demos/guide/tls-client-non-block.c
@@ -27,7 +27,7 @@
 #include <openssl/err.h>
 
 /* Helper function to create a BIO connected to the server */
-static BIO *create_socket_bio(const char *hostname, const char *port)
+static BIO *create_socket_bio(const char *hostname, const char *port, int family)
 {
     int sock = -1;
     BIO_ADDRINFO *res;
@@ -37,7 +37,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port)
     /*
      * Lookup IP address info for the server.
      */
-    if (!BIO_lookup_ex(hostname, port, BIO_LOOKUP_CLIENT, 0, SOCK_STREAM, 0,
+    if (!BIO_lookup_ex(hostname, port, BIO_LOOKUP_CLIENT, family, SOCK_STREAM, 0,
                        &res))
         return NULL;
 
@@ -187,14 +187,25 @@ int main(int argc, char *argv[])
     char buf[160];
     int eof = 0;
     char *hostname, *port;
+    int argnext = 1;
+    int ipv6 = 0;
 
-    if (argc != 3) {
-        printf("Usage: tls-client-non-block hostname port\n");
+    if (argc < 3) {
+        printf("Usage: tls-client-non-block [-6] hostname port\n");
         goto end;
     }
 
-    hostname = argv[1];
-    port = argv[2];
+    if (!strcmp(argv[argnext], "-6")) {
+        if (argc < 4) {
+            printf("Usage: tls-client-non-block [-6]  hostname port\n");
+            goto end;
+        }
+        ipv6 = 1;
+        argnext++;
+    }
+
+    hostname = argv[argnext++];
+    port = argv[argnext];
 
     /*
      * Create an SSL_CTX which we can use to create SSL objects from. We
@@ -240,7 +251,7 @@ int main(int argc, char *argv[])
      * Create the underlying transport socket/BIO and associate it with the
      * connection.
      */
-    bio = create_socket_bio(hostname, port);
+    bio = create_socket_bio(hostname, port, ipv6 == 0 ? AF_INET : AF_INET6);
     if (bio == NULL) {
         printf("Failed to crete the BIO\n");
         goto end;

--- a/doc/man7/ossl-guide-quic-client-block.pod
+++ b/doc/man7/ossl-guide-quic-client-block.pod
@@ -94,7 +94,7 @@ for TCP).
     /*
      * Lookup IP address info for the server.
      */
-    if (!BIO_lookup_ex(hostname, port, BIO_LOOKUP_CLIENT, 0, SOCK_DGRAM, 0,
+    if (!BIO_lookup_ex(hostname, port, BIO_LOOKUP_CLIENT, family, SOCK_DGRAM, 0,
                        &res))
         return NULL;
 

--- a/doc/man7/ossl-guide-tls-client-block.pod
+++ b/doc/man7/ossl-guide-tls-client-block.pod
@@ -174,7 +174,7 @@ integrate into the OpenSSL error system to log error data, e.g.
     /*
      * Lookup IP address info for the server.
      */
-    if (!BIO_lookup_ex(hostname, port, BIO_LOOKUP_CLIENT, 0, SOCK_STREAM, 0,
+    if (!BIO_lookup_ex(hostname, port, BIO_LOOKUP_CLIENT, family, SOCK_STREAM, 0,
                        &res))
         return NULL;
 
@@ -212,7 +212,9 @@ See L<BIO_lookup_ex(3)>, L<BIO_socket(3)>, L<BIO_connect(3)>,
 L<BIO_closesocket(3)>, L<BIO_ADDRINFO_next(3)>, L<BIO_ADDRINFO_address(3)> and
 L<BIO_ADDRINFO_free(3)> for further information on the functions used here. In
 the above example code the B<hostname> and B<port> variables are strings, e.g.
-"www.example.com" and "443".
+"www.example.com" and "443".  Note also the use of the family variable, which
+can take the values of AF_INET or AF_INET6 based on the command line -6 option,
+to allow specific connections to an ipv4 or ipv6 enabled host.
 
 Sockets created using the methods described above will automatically be blocking
 sockets - which is exactly what we want for this example.


### PR DESCRIPTION

The quicserver demo server supports the explicit selection of ipv4/ipv6 address families for listening, which is good, but the quic demo clients only specify AF_UNSPEC as the family selector, meaning both ipv4 and ipv6 addresses are returned from getaddrinfo, with preference to the latter.

In an environment in which ipv6 is enabled, this implies that a server will by default listen on ipv4, while a client will attempt (and fail to connect) against an ipv6 address.

Correct this by mirroring the ipv6 address option in the client demos, so the connection family can be coordinated.  

Note, this PR is predicated on https://github.com/openssl/openssl/pull/22552 and should not be merged until it is in place.  Only new commit in this PR is baaaf91710357010c787947db55713a01202ad1c