### PR TITLE
QUIC: Fix #22348 (stochastic Windows multistream script 39 failure)

### DIFF
--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -3316,8 +3316,15 @@ static const struct script_op script_38[] = {
     OP_C_CONNECT_WAIT       ()
     OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_NONE)
 
-    OP_S_NEW_STREAM_UNI     (b, S_UNI_ID(0))
+    OP_C_NEW_STREAM_UNI     (a, C_UNI_ID(0))
+    OP_C_WRITE              (a, "apple", 5)
+
+    OP_S_BIND_STREAM_ID     (a, C_UNI_ID(0))
+    OP_S_READ_EXPECT        (a, "apple", 5)
+
     OP_SET_INJECT_WORD      (C_BIDI_ID(0) + 1, OSSL_QUIC_FRAME_TYPE_STREAM_DATA_BLOCKED)
+
+    OP_S_NEW_STREAM_UNI     (b, S_UNI_ID(0))
     OP_S_WRITE              (b, "orange", 5)
 
     OP_C_EXPECT_CONN_CLOSE_INFO(QUIC_ERR_STREAM_STATE_ERROR,0,0)

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2832,7 +2832,7 @@ static int script_23_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
     unsigned char frame_buf[16];
     size_t written;
 
-    if (h->inject_word0 == 0)
+    if (h->inject_word0 == 0 || hdr->type != QUIC_PKT_TYPE_1RTT)
         return 1;
 
     if (!TEST_true(WPACKET_init_static_len(&wpkt, frame_buf,
@@ -2885,7 +2885,7 @@ static int script_24_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
     unsigned char frame_buf[16];
     size_t written;
 
-    if (h->inject_word0 == 0)
+    if (h->inject_word0 == 0 || hdr->type != QUIC_PKT_TYPE_1RTT)
         return 1;
 
     if (!TEST_true(WPACKET_init_static_len(&wpkt, frame_buf,
@@ -2995,7 +2995,7 @@ static int script_28_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
     unsigned char frame_buf[32];
     size_t written;
 
-    if (h->inject_word0 == 0)
+    if (h->inject_word0 == 0 || hdr->type != QUIC_PKT_TYPE_1RTT)
         return 1;
 
     if (!TEST_true(WPACKET_init_static_len(&wpkt, frame_buf,
@@ -3129,6 +3129,9 @@ static int script_32_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
     unsigned char frame_buf[64];
     size_t written;
     uint64_t type = OSSL_QUIC_FRAME_TYPE_STREAM_OFF_LEN, offset, flen, i;
+
+    if (hdr->type != QUIC_PKT_TYPE_1RTT)
+        return 1;
 
     switch (h->inject_word1) {
     default:
@@ -3344,6 +3347,9 @@ static int script_39_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
     QUIC_CONN_ID new_cid = {0};
     QUIC_CHANNEL *ch = ossl_quic_tserver_get_channel(h->s_priv);
 
+    if (hdr->type != QUIC_PKT_TYPE_1RTT)
+        return 1;
+
     switch (h->inject_word1) {
     case 0:
         return 1;
@@ -3487,7 +3493,7 @@ static int script_41_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
     unsigned char frame_buf[16];
     size_t written;
 
-    if (h->inject_word0 == 0)
+    if (h->inject_word0 == 0 || hdr->type != QUIC_PKT_TYPE_1RTT)
         return 1;
 
     if (!TEST_true(WPACKET_init_static_len(&wpkt, frame_buf,
@@ -3681,7 +3687,7 @@ static int script_44_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
     unsigned char frame_buf[16];
     size_t written;
 
-    if (h->inject_word0 == 0)
+    if (h->inject_word0 == 0 || hdr->type != QUIC_PKT_TYPE_1RTT)
         return 1;
 
     if (!TEST_true(WPACKET_init_static_len(&wpkt, frame_buf,
@@ -3993,7 +3999,7 @@ static int script_52_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
     WPACKET wpkt;
     uint64_t type = h->inject_word1;
 
-    if (h->inject_word0 == 0)
+    if (h->inject_word0 == 0 || hdr->type != QUIC_PKT_TYPE_1RTT)
         return 1;
 
     --h->inject_word0;
@@ -4082,7 +4088,7 @@ static int script_53_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
     unsigned char *frame_buf = NULL;
     size_t frame_len, i;
 
-    if (h->inject_word0 == 0)
+    if (h->inject_word0 == 0 || hdr->type != QUIC_PKT_TYPE_1RTT)
         return 1;
 
     h->inject_word0 = 0;
@@ -4254,7 +4260,7 @@ static int script_58_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
     size_t written;
     WPACKET wpkt;
 
-    if (h->inject_word0 == 0)
+    if (h->inject_word0 == 0 || hdr->type != QUIC_PKT_TYPE_1RTT)
         return 1;
 
     if (!TEST_true(WPACKET_init_static_len(&wpkt, frame_buf,
@@ -4377,7 +4383,7 @@ static int script_61_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
     unsigned char frame_buf[32];
     size_t written;
 
-    if (h->inject_word0 == 0)
+    if (h->inject_word0 == 0 || hdr->type != QUIC_PKT_TYPE_1RTT)
         return 1;
 
     if (!TEST_true(WPACKET_init_static_len(&wpkt, frame_buf,
@@ -4557,7 +4563,7 @@ static int script_66_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
     unsigned char frame_buf[64];
     size_t written;
 
-    if (h->inject_word0 == 0)
+    if (h->inject_word0 == 0 || hdr->type != QUIC_PKT_TYPE_1RTT)
         return 1;
 
     if (!TEST_true(WPACKET_init_static_len(&wpkt, frame_buf,


### PR DESCRIPTION
We finally had [another instance of the failure here](https://github.com/openssl/openssl/actions/runs/6707613653/job/18226575701?pr=22569) which has allowed the issue to be diagnosed. It was caused by injecting a fault-injector-injected frame into the wrong packet type due to connection handshaking not being fully complete yet.

## QUIC MULTISTREAM TEST: Fix script 38 stochastic failure on Windows

The QUIC fault injector frame injection functionality injects injected
    frames on whatever EL we happen to be using to generate a packet in.
    This means we sometimes inject the frame into a packet type it is not
    allowed to be in, causing a different error code to be generated.
    
Fix this by making sure the connection is fully established before
    trying to generate the frame in question.
    
Fixes #22348.

## QUIC MULTISTREAM TEST: Ensure frames are only injected into correct packet types

Although the previous commit is enough to fix the immediate cause of the
    stochastic failure on Windows, this is a more resilient fix; make sure
    we only inject a given frame into the correct packet type for our
    various injection functions.