### PR TITLE
QUIC SSTREAM: Fix bug in ossl_quic_sstream_is_totally_acked

### DIFF
--- a/ssl/quic/quic_sstream.c
+++ b/ssl/quic/quic_sstream.c
@@ -379,8 +379,13 @@ int ossl_quic_sstream_is_totally_acked(QUIC_SSTREAM *qss)
     UINT_RANGE r;
     uint64_t cur_size;
 
-    if ((qss->have_final_size && !qss->acked_final_size)
-        || ossl_list_uint_set_num(&qss->acked_set) != 1)
+    if (qss->have_final_size && !qss->acked_final_size)
+        return 0;
+
+    if (ossl_quic_sstream_get_cur_size(qss) == 0)
+        return 1;
+
+    if (ossl_list_uint_set_num(&qss->acked_set) != 1)
         return 0;
 
     r = ossl_list_uint_set_head(&qss->acked_set)->range;

--- a/test/quic_stream_test.c
+++ b/test/quic_stream_test.c
@@ -48,6 +48,10 @@ static int test_sstream_simple(void)
     if (!TEST_ptr(sstream = ossl_quic_sstream_new(init_size)))
         goto err;
 
+    /* A stream with nothing yet appended is totally acked */
+    if (!TEST_true(ossl_quic_sstream_is_totally_acked(sstream)))
+        goto err;
+
     /* Should not have any data yet */
     num_iov = OSSL_NELEM(iov);
     if (!TEST_false(ossl_quic_sstream_get_stream_frame(sstream, 0, &hdr, iov,
@@ -58,6 +62,10 @@ static int test_sstream_simple(void)
     if (!TEST_true(ossl_quic_sstream_append(sstream, data_1, sizeof(data_1),
                                             &wr))
         || !TEST_size_t_eq(wr, sizeof(data_1)))
+        goto err;
+
+    /* No longer totally acked */
+    if (!TEST_false(ossl_quic_sstream_is_totally_acked(sstream)))
         goto err;
 
     /* Read data */
@@ -194,6 +202,9 @@ static int test_sstream_simple(void)
 
     /* Acknowledge fin. */
     if (!TEST_true(ossl_quic_sstream_mark_acked_fin(sstream)))
+        goto err;
+
+    if (!TEST_true(ossl_quic_sstream_is_totally_acked(sstream)))
         goto err;
 
     testresult = 1;


### PR DESCRIPTION
ossl_quic_sstream_is_totally_acked would return 0 if no data had been appended to the stream yet. Fixed and added tests. Fixes the s_client failure hang issue mentioned in https://github.com/openssl/openssl/issues/22551.