### PR TITLE
ppc64le: Optimised reduction, differences in secp384r1 for P9/10

### DIFF
--- a/crypto/ec/asm/ecp_nistp384-ppc64.pl
+++ b/crypto/ec/asm/ecp_nistp384-ppc64.pl
@@ -75,18 +75,6 @@ ___
     }
 }
 
-sub store_vrs($$)
-{
-    my ($pointer, $reg_list) = @_;
-
-    for (my $i = 0; $i <= 12; $i++) {
-        my $offset = $i * 16;
-        $code.=<<___;
-    stxv        $reg_list->[$i],$offset($pointer)
-___
-    }
-}
-
 sub forward_vrs($$)
 {
     my ($dst_vrs, $src_vrs) = @_;

--- a/crypto/ec/asm/ecp_nistp384-ppc64.pl
+++ b/crypto/ec/asm/ecp_nistp384-ppc64.pl
@@ -72,10 +72,6 @@ sub load_vrs($$)
     lxsd        $reg_list->[$i],$offset($pointer)
 ___
     }
-
-    $code.=<<___;
-
-___
 }
 
 sub store_vrs($$)
@@ -88,10 +84,6 @@ sub store_vrs($$)
     stxv        $reg_list->[$i],$offset($pointer)
 ___
     }
-
-    $code.=<<___;
-
-___
 }
 
 $code.=<<___;
@@ -119,7 +111,6 @@ ___
 
         $code.=<<___;
     vspltisw    $vzero,0
-
 ___
 
         load_vrs($in1p, \@in1);
@@ -223,7 +214,6 @@ ___
 
         $code.=<<___;
     vspltisw    $vzero,0
-
 ___
 
         load_vrs($inp, \@in);

--- a/crypto/ec/ecp_nistp384.c
+++ b/crypto/ec/ecp_nistp384.c
@@ -677,28 +677,18 @@ static ossl_inline void felem_square_reduce_ref(felem out, const felem in);
 static ossl_inline void felem_mul_reduce_ref(felem out, const felem in1, const felem in2);
 
 #if defined(ECP_NISTP384_ASM)
-static void felem_square_wrapper(widefelem out, const felem in);
-static void felem_mul_wrapper(widefelem out, const felem in1, const felem in2);
-static void felem_reduce_wrapper(felem out, const widefelem in);
-static void felem_diff_128_64_wrapper(widefelem out, const felem in);
-static void felem_diff128_wrapper(widefelem out, const widefelem in);
+# define LINK_ENTRY(name, ...)                              \
+    static void name##_wrapper(__VA_ARGS__);                \
+    static void (*name##_p)(__VA_ARGS__) = name##_wrapper;  \
+    void p384_##name(__VA_ARGS__);
 
-static void (*felem_square_p)(widefelem out, const felem in) =
-    felem_square_wrapper;
-static void (*felem_mul_p)(widefelem out, const felem in1, const felem in2) =
-    felem_mul_wrapper;
-static void (*felem_reduce_p)(felem out, const widefelem in) =
-    felem_reduce_wrapper;
-static void (*felem_diff_128_64_p)(widefelem out, const felem in) =
-    felem_diff_128_64_wrapper;
-static void (*felem_diff128_p)(widefelem out, const widefelem in) =
-    felem_diff128_wrapper;
-
-void p384_felem_square(widefelem out, const felem in);
-void p384_felem_mul(widefelem out, const felem in1, const felem in2);
-void p384_felem_reduce(felem out, const widefelem in);
-void p384_felem_diff_128_64(widefelem out, const felem in);
-void p384_felem_diff128(widefelem out, const widefelem in);
+LINK_ENTRY(felem_square, widefelem out, const felem in);
+LINK_ENTRY(felem_mul, widefelem out, const felem in1, const felem in2);
+LINK_ENTRY(felem_square_reduce, felem out, const felem in);
+LINK_ENTRY(felem_mul_reduce, felem out, const felem in1, const felem in2);
+LINK_ENTRY(felem_reduce, felem out, const widefelem in);
+LINK_ENTRY(felem_diff_128_64, widefelem out, const felem in);
+LINK_ENTRY(felem_diff128, widefelem out, const widefelem in);
 
 # if defined(_ARCH_PPC64)
 #  include "crypto/ppc_arch.h"

--- a/crypto/ec/ecp_nistp384.c
+++ b/crypto/ec/ecp_nistp384.c
@@ -1696,7 +1696,6 @@ int ossl_ec_GFp_nistp384_point_get_affine_coordinates(const EC_GROUP *group,
                                                       BN_CTX *ctx)
 {
     felem z1, z2, x_in, y_in, x_out, y_out;
-    widefelem tmp;
 
     if (EC_POINT_is_at_infinity(group, point)) {
         ERR_raise(ERR_LIB_EC, EC_R_POINT_AT_INFINITY);
@@ -1706,10 +1705,8 @@ int ossl_ec_GFp_nistp384_point_get_affine_coordinates(const EC_GROUP *group,
         (!BN_to_felem(z1, point->Z)))
         return 0;
     felem_inv(z2, z1);
-    felem_square(tmp, z2);
-    felem_reduce(z1, tmp);
-    felem_mul(tmp, x_in, z1);
-    felem_reduce(x_in, tmp);
+    felem_square_reduce(z1, z2);
+    felem_mul_reduce(x_in, x_in, z1);
     felem_contract(x_out, x_in);
     if (x != NULL) {
         if (!felem_to_BN(x, x_out)) {
@@ -1717,10 +1714,8 @@ int ossl_ec_GFp_nistp384_point_get_affine_coordinates(const EC_GROUP *group,
             return 0;
         }
     }
-    felem_mul(tmp, z1, z2);
-    felem_reduce(z1, tmp);
-    felem_mul(tmp, y_in, z1);
-    felem_reduce(y_in, tmp);
+    felem_mul_reduce(z1, z1, z2);
+    felem_mul_reduce(y_in, y_in, z1);
     felem_contract(y_out, y_in);
     if (y != NULL) {
         if (!felem_to_BN(y, y_out)) {

--- a/crypto/perlasm/ppc-xlate.pl
+++ b/crypto/perlasm/ppc-xlate.pl
@@ -200,10 +200,16 @@ my $vsl		= sub { vsr2vr("vsl",		3, @_); };
 my $vspltisb	= sub { vsr2vr("vspltisb",	1, @_); };
 my $vspltisw	= sub { vsr2vr("vspltisw",	1, @_); };
 my $vsr		= sub { vsr2vr("vsr",		3, @_); };
+my $vslo	= sub { vsr2vr("vslo",		3, @_); };
 my $vsro	= sub { vsr2vr("vsro",		3, @_); };
+my $vor     = sub { vsr2vr("vor",       3, @_); };
+my $vsldoi  = sub { vsr2vr("vsldoi",    3, @_); };
 
 # ISA 3.0
 my $lxsd	= sub { vsr2vr("lxsd",		1, @_); };
+my $lvx	    = sub { vsr2vr("lvx",       3, @_); };
+my $stxsd   = sub { vsr2vr("stxsd",     1, @_); };
+my $stvx    = sub { vsr2vr("stvx",      3, @_); };
 
 ################################################################
 # simplified mnemonics not handled by at least one assembler
@@ -251,7 +257,13 @@ my $extrdi = sub {
 };
 my $vmr = sub {
     my ($f,$vx,$vy) = @_;
+    $vx = vsr2vr1($vx);
+    $vy = vsr2vr1($vy);
     "	vor	$vx,$vy,$vy";
+};
+my $xxmr = sub {
+    my ($f,$vx,$vy) = @_;
+    "	xxlor	$vx,$vy,$vy";
 };
 
 # Some ABIs specify vrsave, special-purpose register #256, as reserved
@@ -336,6 +348,7 @@ my $vrld	= sub { vcrypto_op(@_, 196);  };
 my $vsld	= sub { vcrypto_op(@_, 1476); };
 my $vsrd	= sub { vcrypto_op(@_, 1732); };
 my $vsubudm	= sub { vcrypto_op(@_, 1216); };
+my $vsubuqm	= sub { vcrypto_op(@_, 1280); };
 my $vaddcuq	= sub { vcrypto_op(@_, 320);  };
 my $vaddeuqm	= sub { vfour_vsr(@_,60); };
 my $vaddecuq	= sub { vfour_vsr(@_,61); };
@@ -348,6 +361,10 @@ my $mtsle	= sub {
 };
 
 # VSX instructions masqueraded as AltiVec/VMX
+my $mtvrdd = sub {
+    my ($f, $vrt, $ra, $rb) = @_;
+    "	.long	".sprintf "0x%X",(31<<26)|($vrt<<21)|($ra<<16)|($rb<<15)|(435<<1)|1;
+};
 my $mtvrd	= sub {
     my ($f, $vrt, $ra) = @_;
     "	.long	".sprintf "0x%X",(31<<26)|($vrt<<21)|($ra<<16)|(179<<1)|1;


### PR DESCRIPTION
Perform some (hopefully) last optimisations for >= ISA 3.0.0 cores with vector extensions, including:

- Optimised `felem_reduce()` using quadword bitshifts and byte permutations
- Optimised difference routines using quadword adds/subtracts
- Fused `felem_{square,mul}_reduce()` routines

As well as providing a common infrastructure for runtime selection of these routines.

Following on from the acceptance of the PR where I introduced a Solinas'  implementation of secp384r1 with some ISA 3.0.0 opimisations for `felem_{square,mul}()` [1], we see an additional 28% and 38% performance speedup on signature generation and verification respectively with these new assembly routines.

In total, we are seeing speedups of 6.62x and 2.70x on generation and verification respectively on a P10 over the C implementations using montgomery multiplication. 

A similar implementation I have authored is available through `ipcri` [2].

Links:
[1]: https://github.com/openssl/openssl/pull/21471
[2]: https://github.com/IBM/ipcri/blob/main/ecc/secp384r1.c