### PR TITLE
Security hardening: Expose Build flags for Position Independed Execution (PIE)

### DIFF
--- a/.github/workflows/run-checker-merge.yml
+++ b/.github/workflows/run-checker-merge.yml
@@ -35,6 +35,7 @@ jobs:
           no-ts,
           enable-weak-ssl-ciphers,
           enable-zlib,
+          enable-pie,
         ]
     runs-on: ubuntu-latest
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,14 @@ OpenSSL 3.4
 
    *Damian Hobson-Garcia*
 
+ * Added support to build Position Independent Executables (PIE). Configuration
+   option `enable-pie` configures the cflag '-fPIE' and ldflag '-pie' to
+   support Address Space Layout Randomization (ASLR) in the openssl executable,
+   removes reliance on external toolchain configurations.
+
+   *Craig Lorentzen*
+
+
 OpenSSL 3.3
 -----------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,7 +66,6 @@ OpenSSL 3.4
 
    *Craig Lorentzen*
 
-
 OpenSSL 3.3
 -----------
 

--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -76,6 +76,22 @@ my %targets=(
         AR              => "ar",
         ARFLAGS         => "qc",
         CC              => "cc",
+        bin_cflags      =>
+            sub {
+                my @flags = ();
+                if (!defined($disabled{pie})) {
+                    push(@flags, "-fPIE");
+                }
+                return join(" ", @flags);
+            },
+        bin_lflags      =>
+            sub {
+                my @flags = ();
+                if (!defined($disabled{pie})) {
+                    push(@flags, "-pie");
+                }
+                return join(" ", @flags);
+            },
         lflags          =>
             sub {
                 my @libs = ();

--- a/Configure
+++ b/Configure
@@ -492,6 +492,7 @@ my @disablables = (
     "ocsp",
     "padlockeng",
     "pic",
+    "pie",
     "pinshared",
     "poly1305",
     "posix-io",
@@ -584,6 +585,7 @@ our %disabled = ( # "what"         => "comment"
                   "external-tests"      => "default",
                   "fuzz-afl"            => "default",
                   "fuzz-libfuzzer"      => "default",
+                  "pie"                 => "default",
                   "ktls"                => "default",
                   "md2"                 => "default",
                   "msan"                => "default",
@@ -942,6 +944,10 @@ while (@argvcopy)
                 elsif ($1 eq "brotli-dynamic")
                         {
                         delete $disabled{"brotli"};
+                        }
+                elsif ($1 eq "pie")
+                        {
+                        delete $disabled{"pie"};
                         }
                 elsif ($1 eq "zstd-dynamic")
                         {

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -870,6 +870,10 @@ As synonym for `no-padlockeng`.  Deprecated and should not be used.
 
 Don't build with support for Position Independent Code.
 
+### enable-pie
+
+Build with support for Position Independent Execution.
+
 ### no-pinshared
 
 Don't pin the shared libraries.


### PR DESCRIPTION
Security hardening: Expose Build flags for Position Independed Execution (PIE)

Adds build flags to allow enabling support for ASLR in Openssl binaries via the Configure process.

~~CLA: trivial~~

By default Openssl does have the option to enforced the PIE hardening standard to support ASLR for binaries such as `openssl`

* Testing done on Amazon Linux 2023
```
sudo yum groupinstall "Development Tools"

git clone https://github.com/openssl/openssl.git

cd openssl
./Configure --strict-warnings enable-pie
make

# After the change PIE enabled (LSB pie executable)
file apps/openssl
apps/openssl: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=17ec32ebd630804e5dcfee3ef5dba72ece707334, for GNU/Linux 3.2.0, not stripped

# Confirm with no flag we maintain no-PIE (LSB executable)
./Configure --strict-warnings 
make clean
make
file apps/openssl
apps/openssl: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=11f5f229eec64a45e9f63da88a3065368eba6227, for GNU/Linux 3.2.0, not stripped
```

Some OS distributions enable PIE by default, e.g. Ubuntu https://wiki.ubuntu.com/ToolChain/CompilerFlags, and the OS distribution of openssl is generally built with PIE enabled, however, the default from OpenSSL does not implement the PIE hardening feature enabling ASLR functionality for the openssl binaries.
