### PR TITLE
Add test for including all provider configuration files in given directory

### DIFF
--- a/test/conf_include_test.c
+++ b/test/conf_include_test.c
@@ -37,28 +37,32 @@
 #endif
 
 /* changes path to that of the filename */
-static int change_path(const char *file)
+static char *change_path(const char *file)
 {
     char *s = OPENSSL_strdup(file);
     char *p = s;
     char *last = NULL;
     int ret = 0;
+    char *new_config_name = NULL;
 
     if (s == NULL)
-        return -1;
+        return NULL;
 
     while ((p = strpbrk(p, DIRSEP)) != NULL) {
         last = p++;
     }
     if (last == NULL)
         goto err;
-    last[DIRSEP_PRESERVE] = 0;
 
+    last[DIRSEP_PRESERVE] = 0;
     TEST_note("changing path to %s", s);
+
     ret = chdir(s);
+    if (ret == 0)
+        new_config_name = strdup(last + DIRSEP_PRESERVE + 1);
  err:
     OPENSSL_free(s);
-    return ret;
+    return new_config_name;
 }
 
 /*
@@ -68,6 +72,9 @@ static int change_path(const char *file)
 static CONF *conf;
 static BIO *in;
 static int expect_failure = 0;
+static int test_providers = 0;
+static OSSL_LIB_CTX *libctx = NULL;
+static char *rel_conf_file = NULL;
 
 static int test_load_config(void)
 {
@@ -116,6 +123,27 @@ static int test_load_config(void)
         return 0;
     }
 
+    if (test_providers != 0) {
+        /* test for `active` directive in configuration file */
+        val = 0;
+        if (!TEST_int_eq(NCONF_get_number(conf, "null_sect", "activate", &val), 1)
+            || !TEST_int_eq(val, 1)) {
+            TEST_note("null provider not activated");
+            return 0;
+        }
+        val = 0;
+        if (!TEST_int_eq(NCONF_get_number(conf, "default_sect", "activate", &val), 1)
+            || !TEST_int_eq(val, 1)) {
+            TEST_note("default provider not activated");
+            return 0;
+        }
+        val = 0;
+        if (!TEST_int_eq(NCONF_get_number(conf, "legacy_sect", "activate", &val), 1)
+            || !TEST_int_eq(val, 1)) {
+            TEST_note("legacy provider not activated");
+            return 0;
+        }
+    }
     return 1;
 }
 
@@ -174,10 +202,33 @@ static int test_check_overflow(void)
     return 1;
 }
 
+static int test_available_providers(void)
+{
+    libctx = OSSL_LIB_CTX_new();
+    if (!TEST_ptr(libctx))
+        return 0;
+
+    if (!TEST_ptr(rel_conf_file) || !OSSL_LIB_CTX_load_config(libctx, rel_conf_file)) {
+        TEST_note("Failed to load config");
+        return 0;
+    }
+
+    if (OSSL_PROVIDER_available(libctx, "default") != 1) {
+        TEST_note("Default provider is missing");
+        return 0;
+    }
+    if (OSSL_PROVIDER_available(libctx, "legacy") != 1) {
+        TEST_note("Legacy provider is missing");
+        return 0;
+    }
+    return 1;
+}
+
 typedef enum OPTION_choice {
     OPT_ERR = -1,
     OPT_EOF = 0,
     OPT_FAIL,
+    OPT_TEST_PROV,
     OPT_TEST_ENUM
 } OPTION_CHOICE;
 
@@ -186,6 +237,8 @@ const OPTIONS *test_get_options(void)
     static const OPTIONS test_options[] = {
         OPT_TEST_OPTIONS_WITH_EXTRA_USAGE("conf_file\n"),
         { "f", OPT_FAIL, '-', "A failure is expected" },
+        { "providers", OPT_TEST_PROV, '-',
+          "Test for activated default and legacy providers"},
         { NULL }
     };
     return test_options;
@@ -193,7 +246,7 @@ const OPTIONS *test_get_options(void)
 
 int setup_tests(void)
 {
-    const char *conf_file;
+    char *conf_file = NULL;
     OPTION_CHOICE o;
 
     if (!TEST_ptr(conf = NCONF_new(NULL)))
@@ -204,6 +257,8 @@ int setup_tests(void)
         case OPT_FAIL:
             expect_failure = 1;
             break;
+        case OPT_TEST_PROV:
+            test_providers = 1;
         case OPT_TEST_CASES:
             break;
         default:
@@ -222,16 +277,24 @@ int setup_tests(void)
      * For this test we need to chdir as we use relative
      * path names in the config files.
      */
-    change_path(conf_file);
+    rel_conf_file = change_path(conf_file);
+    if (!TEST_ptr(rel_conf_file)) {
+        TEST_note("Unable to change path");
+        return 0;
+    }
 
     ADD_TEST(test_load_config);
     ADD_TEST(test_check_null_numbers);
     ADD_TEST(test_check_overflow);
+    if (test_providers != 0)
+        ADD_TEST(test_available_providers);
+
     return 1;
 }
 
 void cleanup_tests(void)
 {
+    OPENSSL_free(rel_conf_file);
     BIO_vfree(in);
     NCONF_free(conf);
     CONF_modules_unload(1);

--- a/test/recipes/90-test_includes.t
+++ b/test/recipes/90-test_includes.t
@@ -2,8 +2,9 @@
 
 use strict;
 use warnings;
-use OpenSSL::Test qw/:DEFAULT data_file/;
+use OpenSSL::Test qw/:DEFAULT bldtop_dir data_file/;
 use OpenSSL::Test::Utils;
+use Cwd qw(abs_path);
 
 setup("test_includes");
 
@@ -13,8 +14,10 @@ plan skip_all => "test_includes doesn't work without posix-io"
 delete $ENV{OPENSSL_CONF_INCLUDE};
 
 plan tests =>                   # The number of tests being performed
-    6
+    7
     + ($^O eq "VMS" ? 2 : 0);
+
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("providers"));
 
 ok(run(test(["conf_include_test", data_file("includes.cnf")])), "test directory includes");
 ok(run(test(["conf_include_test", data_file("includes-file.cnf")])), "test file includes");
@@ -28,3 +31,10 @@ if ($^O eq "VMS") {
 }
 ok(run(test(["conf_include_test", "-f", data_file("includes-broken.cnf")])), "test broken includes");
 ok(run(test(["conf_include_test",  "-f", data_file("incdir.cnf")])), "test includedir");
+
+SKIP: {
+    skip "Skipping legacy test", 1
+        if disabled("legacy");
+    ok(run(test(["conf_include_test", "-providers", data_file("includes-prov-dir.cnf")])),
+       "test directory includes with provider configs");
+}

--- a/test/recipes/90-test_includes_data/conf-includes-prov/inc-default.cnf
+++ b/test/recipes/90-test_includes_data/conf-includes-prov/inc-default.cnf
@@ -1,0 +1,5 @@
+[provider_sect]
+default = default_sect
+
+[default_sect]
+activate = 1

--- a/test/recipes/90-test_includes_data/conf-includes-prov/inc-legacy.cnf
+++ b/test/recipes/90-test_includes_data/conf-includes-prov/inc-legacy.cnf
@@ -1,0 +1,5 @@
+[provider_sect]
+legacy = legacy_sect
+
+[legacy_sect]
+activate = 1

--- a/test/recipes/90-test_includes_data/includes-prov-dir.cnf
+++ b/test/recipes/90-test_includes_data/includes-prov-dir.cnf
@@ -1,0 +1,17 @@
+#
+# Example configuration file using includes to load providers.
+#
+
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+null = null_sect
+
+[null_sect]
+activate = 1
+
+.include conf-includes
+.include conf-includes-prov


### PR DESCRIPTION
This PR adds a test for `.include` directive that includes all provider configuration files from a given directory. The test aims to check that providers are successfully loaded when the provider section for the provider is part of the included configuration files. The details are discussed in #22148.

##### Checklist
- [ ] documentation is added or updated
- [ ] tests are added or updated
