### PR TITLE
When DH_check() finds P to be excessively large, only set that flag

### DIFF
--- a/crypto/dh/dh_check.c
+++ b/crypto/dh/dh_check.c
@@ -155,7 +155,7 @@ int DH_check(const DH *dh, int *ret)
     /* Don't do any checks at all with an excessively large modulus */
     if (BN_num_bits(dh->params.p) > OPENSSL_DH_CHECK_MAX_MODULUS_BITS) {
         ERR_raise(ERR_LIB_DH, DH_R_MODULUS_TOO_LARGE);
-        *ret = DH_MODULUS_TOO_LARGE | DH_CHECK_P_NOT_PRIME;
+        *ret = DH_MODULUS_TOO_LARGE;
         return 0;
     }
 


### PR DESCRIPTION
When DH_check() found that P is excessively large, it set both
DH_MODULUS_TOO_LARGE and DH_CHECK_P_NOT_PRIME.  However, that test can't
determine if P is prime or not, so that flag shouldn't be set.
