### PR TITLE
internal/common.h: rename macro `(un)likely` to `ossl_(un)likely`

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -662,7 +662,7 @@ int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
     size_t soutl, inl_ = (size_t)inl;
     int blocksize;
 
-    if (likely(outl != NULL)) {
+    if (ossl_likely(outl != NULL)) {
         *outl = 0;
     } else {
         ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
@@ -670,22 +670,22 @@ int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
     }
 
     /* Prevent accidental use of decryption context when encrypting */
-    if (unlikely(!ctx->encrypt)) {
+    if (ossl_unlikely(!ctx->encrypt)) {
         ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_OPERATION);
         return 0;
     }
 
-    if (unlikely(ctx->cipher == NULL)) {
+    if (ossl_unlikely(ctx->cipher == NULL)) {
         ERR_raise(ERR_LIB_EVP, EVP_R_NO_CIPHER_SET);
         return 0;
     }
 
-    if (unlikely(ctx->cipher->prov == NULL))
+    if (ossl_unlikely(ctx->cipher->prov == NULL))
         goto legacy;
 
     blocksize = ctx->cipher->block_size;
 
-    if (unlikely(ctx->cipher->cupdate == NULL || blocksize < 1)) {
+    if (ossl_unlikely(ctx->cipher->cupdate == NULL || blocksize < 1)) {
         ERR_raise(ERR_LIB_EVP, EVP_R_UPDATE_ERROR);
         return 0;
     }
@@ -694,7 +694,7 @@ int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
                                inl_ + (size_t)(blocksize == 1 ? 0 : blocksize),
                                in, inl_);
 
-    if (likely(ret)) {
+    if (ossl_likely(ret)) {
         if (soutl > INT_MAX) {
             ERR_raise(ERR_LIB_EVP, EVP_R_UPDATE_ERROR);
             return 0;
@@ -811,7 +811,7 @@ int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
     size_t soutl, inl_ = (size_t)inl;
     int blocksize;
 
-    if (likely(outl != NULL)) {
+    if (ossl_likely(outl != NULL)) {
         *outl = 0;
     } else {
         ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
@@ -819,21 +819,21 @@ int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
     }
 
     /* Prevent accidental use of encryption context when decrypting */
-    if (unlikely(ctx->encrypt)) {
+    if (ossl_unlikely(ctx->encrypt)) {
         ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_OPERATION);
         return 0;
     }
 
-    if (unlikely(ctx->cipher == NULL)) {
+    if (ossl_unlikely(ctx->cipher == NULL)) {
         ERR_raise(ERR_LIB_EVP, EVP_R_NO_CIPHER_SET);
         return 0;
     }
-    if (unlikely(ctx->cipher->prov == NULL))
+    if (ossl_unlikely(ctx->cipher->prov == NULL))
         goto legacy;
 
     blocksize = EVP_CIPHER_CTX_get_block_size(ctx);
 
-    if (unlikely(ctx->cipher->cupdate == NULL || blocksize < 1)) {
+    if (ossl_unlikely(ctx->cipher->cupdate == NULL || blocksize < 1)) {
         ERR_raise(ERR_LIB_EVP, EVP_R_UPDATE_ERROR);
         return 0;
     }
@@ -841,7 +841,7 @@ int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
                                inl_ + (size_t)(blocksize == 1 ? 0 : blocksize),
                                in, inl_);
 
-    if (likely(ret)) {
+    if (ossl_likely(ret)) {
         if (soutl > INT_MAX) {
             ERR_raise(ERR_LIB_EVP, EVP_R_UPDATE_ERROR);
             return 0;

--- a/crypto/rand/rand_uniform.c
+++ b/crypto/rand/rand_uniform.c
@@ -34,7 +34,7 @@ uint32_t ossl_rand_uniform_uint32(OSSL_LIB_CTX *ctx, uint32_t upper, int *err)
         *err = 0;
         return 0;
     }
-    if (unlikely(upper == 1))
+    if (ossl_unlikely(upper == 1))
         return 0;
 
     /* Get 32 bits of entropy */
@@ -56,7 +56,7 @@ uint32_t ossl_rand_uniform_uint32(OSSL_LIB_CTX *ctx, uint32_t upper, int *err)
     prod = (uint64_t)upper * rand;
     i = prod >> 32;
     f = prod & 0xffffffff;
-    if (likely(f <= 1 + ~upper))    /* 1+~upper == -upper but compilers whine */
+    if (ossl_likely(f <= 1 + ~upper))    /* 1+~upper == -upper but compilers whine */
         return i;
 
     /*
@@ -85,7 +85,7 @@ uint32_t ossl_rand_uniform_uint32(OSSL_LIB_CTX *ctx, uint32_t upper, int *err)
         if (f < f2)
             return i + 1;
         /* For not all 1 bits, there is no carry so return the result */
-        if (likely(f != 0xffffffff))
+        if (ossl_likely(f != 0xffffffff))
             return i;
         /* setup for the next word of randomness */
         f = prod & 0xffffffff;

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -19,11 +19,11 @@
 # include "internal/nelem.h"
 
 # if defined(__GNUC__) || defined(__clang__)
-#  define likely(x)     __builtin_expect(!!(x), 1)
-#  define unlikely(x)   __builtin_expect(!!(x), 0)
+#  define ossl_likely(x)     __builtin_expect(!!(x), 1)
+#  define ossl_unlikely(x)   __builtin_expect(!!(x), 0)
 # else
-#  define likely(x)     x
-#  define unlikely(x)   x
+#  define ossl_likely(x)     x
+#  define ossl_unlikely(x)   x
 # endif
 
 # if defined(__GNUC__) || defined(__clang__)
@@ -38,7 +38,7 @@
 # endif
 
 # ifdef NDEBUG
-#  define ossl_assert(x) likely((x) != 0)
+#  define ossl_assert(x) ossl_likely((x) != 0)
 # else
 __owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
                                               const char *file, int line)


### PR DESCRIPTION
The macro was introduced in commit ed6dfd1e3694 without an openssl-specific prefix as mandated by the coding style.


_(includes fix #22593, intended to be merged afterwards)_