### PR TITLE
Use explicit length if we emit a PATH_RESPONSE frame

### DIFF
--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -2136,7 +2136,6 @@ static int txp_generate_stream_frames(OSSL_QUIC_TX_PACKETISER *txp,
                                       QUIC_SSTREAM *sstream,
                                       QUIC_TXFC *stream_txfc,
                                       QUIC_STREAM *next_stream,
-                                      size_t min_ppl,
                                       int force_explicit,
                                       int *have_ack_eliciting,
                                       int *packet_full,
@@ -2151,7 +2150,7 @@ static int txp_generate_stream_frames(OSSL_QUIC_TX_PACKETISER *txp,
     WPACKET *wpkt;
     QUIC_TXPIM_CHUNK chunk;
     size_t i, j, space_left;
-    int needs_padding_if_implicit, can_fill_payload, use_explicit_len;
+    int can_fill_payload, use_explicit_len;
     int could_have_following_chunk;
     uint64_t orig_len;
     uint64_t hdr_len_implicit, payload_len_implicit;
@@ -2223,13 +2222,6 @@ static int txp_generate_stream_frames(OSSL_QUIC_TX_PACKETISER *txp,
         }
 
         /*
-         * If using the implicit-length representation would need padding, we
-         * can't use it.
-         */
-        needs_padding_if_implicit = (h->bytes_appended + hdr_len_implicit
-                                     + payload_len_implicit < min_ppl);
-
-        /*
          * If there is a next stream, we don't use the implicit length so we can
          * add more STREAM frames after this one, unless there is enough data
          * for this STREAM frame to fill the packet.
@@ -2245,8 +2237,7 @@ static int txp_generate_stream_frames(OSSL_QUIC_TX_PACKETISER *txp,
             = (next_stream != NULL || chunks[(i + 1) % 2].valid);
 
         /* Choose between explicit or implicit length representations. */
-        use_explicit_len = !((can_fill_payload || !could_have_following_chunk)
-                             && !needs_padding_if_implicit)
+        use_explicit_len = !((can_fill_payload || !could_have_following_chunk))
                            || force_explicit;
 
         if (use_explicit_len) {
@@ -2356,7 +2347,6 @@ static void txp_enlink_tmp(QUIC_STREAM **tmp_head, QUIC_STREAM *stream)
 
 static int txp_generate_stream_related(OSSL_QUIC_TX_PACKETISER *txp,
                                        struct txp_pkt *pkt,
-                                       size_t min_ppl,
                                        int force_explicit,
                                        int *have_ack_eliciting,
                                        QUIC_STREAM **tmp_head)
@@ -2498,7 +2488,7 @@ static int txp_generate_stream_related(OSSL_QUIC_TX_PACKETISER *txp,
             if (!txp_generate_stream_frames(txp, pkt,
                                             stream->id, stream->sstream,
                                             &stream->txfc,
-                                            snext, min_ppl, force_explicit,
+                                            snext, force_explicit,
                                             have_ack_eliciting,
                                             &packet_full,
                                             &stream->txp_txfc_new_credit_consumed)) {
@@ -2541,7 +2531,6 @@ static int txp_generate_for_el(OSSL_QUIC_TX_PACKETISER *txp,
     QUIC_CFQ_ITEM *cfq_item;
     QUIC_TXPIM_PKT *tpkt = NULL;
     struct tx_helper *h = &pkt->h;
-    size_t min_ppl = 0;
 
     /* Maximum PN reached? */
     if (!ossl_quic_pn_valid(txp->next_pn[pn_space]))
@@ -2745,7 +2734,7 @@ static int txp_generate_for_el(OSSL_QUIC_TX_PACKETISER *txp,
 
     /* Stream-specific frames */
     if (a.allow_stream_rel && txp->handshake_complete)
-        if (!txp_generate_stream_related(txp, pkt, min_ppl, force_explicit,
+        if (!txp_generate_stream_related(txp, pkt, force_explicit,
                                          &have_ack_eliciting,
                                          &pkt->stream_head))
             goto fatal_err;
@@ -2771,19 +2760,6 @@ static int txp_generate_for_el(OSSL_QUIC_TX_PACKETISER *txp,
             goto fatal_err;
 
         have_ack_eliciting = 1;
-    }
-
-    /* PADDING */
-    if (a.allow_padding && h->bytes_appended < min_ppl) {
-        WPACKET *wpkt = tx_helper_begin(h);
-        if (wpkt == NULL)
-            goto fatal_err;
-
-        if (!ossl_quic_wire_encode_padding(wpkt, min_ppl - h->bytes_appended)
-            || !tx_helper_commit(h))
-            goto fatal_err;
-
-        can_be_non_inflight = 0;
     }
 
     /*


### PR DESCRIPTION
We force stream frames to use explicit length if we have emitted a
PATH_RESPONSE frame, to enable any required padding to be added later.

Fixes #22607

While looking at this I noticed the `min_ppl` variable that is passed around in the TXP, is never set to anything other than 0. This gives us the opportunity to remove some dead code, which I have done in a separate commit.
