### PR TITLE
Fix documentation regarding KMAC sizes

### DIFF
--- a/doc/man7/EVP_MAC-KMAC.pod
+++ b/doc/man7/EVP_MAC-KMAC.pod
@@ -51,7 +51,7 @@ It is an optional value with a length of at most 512 bytes, and is empty by defa
 =item "size" (B<OSSL_MAC_PARAM_SIZE>) <unsigned integer>
 
 Sets the MAC size.
-By default, it is 16 for C<KMAC-128> and 32 for C<KMAC-256>.
+By default, it is 32 for C<KMAC-128> and 64 for C<KMAC-256>.
 
 =item "block-size" (B<OSSL_MAC_PARAM_SIZE>) <unsigned integer>
 


### PR DESCRIPTION
As per recommendation by @jfinkhaeuser, this documents the defaults for KMAC-128 as 32 and for KMAC-256 as 64. The code already accomodates for these values, so no changes are needed there.

Fixes #22381

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
