### PR TITLE
Correct order of ossl_condvar_signal in quic_multistream_test

### DIFF
--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -429,21 +429,22 @@ int qtest_wait_for_timeout(SSL *s, QUIC_TSERVER *qtserv)
      */
     if (!SSL_get_event_timeout(s, &tv, &cinf))
         return 0;
-    if (using_fake_time) {
+
+    if (using_fake_time)
         now = qtest_get_time();
-    } else {
+    else
         now = ossl_time_now();
-    }
+
     ctimeout = cinf ? ossl_time_infinite() : ossl_time_from_timeval(tv);
     stimeout = ossl_time_subtract(ossl_quic_tserver_get_deadline(qtserv), now);
     mintimeout = ossl_time_min(ctimeout, stimeout);
     if (ossl_time_is_infinite(mintimeout))
         return 0;
-    if (using_fake_time) {
+
+    if (using_fake_time)
         qtest_add_time(ossl_time2ms(mintimeout));
-    } else {
+    else
         OSSL_sleep(ossl_time2ms(mintimeout));
-    }
 
     return 1;
 }

--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -356,7 +356,7 @@ static OSSL_TIME qtest_get_time(void)
 
 static void qtest_reset_time(void)
 {
-    if (!CRYPTO_THREAD_read_lock(fake_now_lock))
+    if (!CRYPTO_THREAD_write_lock(fake_now_lock))
         return;
     fake_now = ossl_time_zero();
     CRYPTO_THREAD_unlock(fake_now_lock);

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2658,8 +2658,8 @@ static int script_20_trigger(struct helper *h, volatile uint64_t *counter)
 #if defined(OPENSSL_THREADS)
     ossl_crypto_mutex_lock(h->misc_m);
     ++*counter;
-    ossl_crypto_mutex_unlock(h->misc_m);
     ossl_crypto_condvar_broadcast(h->misc_cv);
+    ossl_crypto_mutex_unlock(h->misc_m);
 #endif
     return 1;
 }

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -497,8 +497,8 @@ static int join_server_thread(struct helper *h)
 
     ossl_crypto_mutex_lock(h->server_thread.m);
     h->server_thread.stop = 1;
-    ossl_crypto_mutex_unlock(h->server_thread.m);
     ossl_crypto_condvar_signal(h->server_thread.c);
+    ossl_crypto_mutex_unlock(h->server_thread.m);
 
     ossl_crypto_thread_native_join(h->server_thread.t, &rv);
     ossl_crypto_thread_native_clean(h->server_thread.t);
@@ -1079,8 +1079,8 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
             else if (h->blocking && !h->server_thread.ready) {
                 ossl_crypto_mutex_lock(h->server_thread.m);
                 h->server_thread.ready = 1;
-                ossl_crypto_mutex_unlock(h->server_thread.m);
                 ossl_crypto_condvar_signal(h->server_thread.c);
+                ossl_crypto_mutex_unlock(h->server_thread.m);
             }
             if (h->blocking)
                 assert(h->s == NULL);


### PR DESCRIPTION
quic_multistream test was issuing a signal on a condvar after dropping the corresponding mutex, not before, leading to potential race conditions in the reading of the associated data

Related to #22588


