### PR TITLE
cms demos: print signingTime attributes

### DIFF
--- a/demos/Makefile
+++ b/demos/Makefile
@@ -1,4 +1,4 @@
-MODULES=bio digest encode encrypt kdf keyexch mac pkey signature sslecho
+MODULES=cms digest encode encrypt kdf keyexch pkey signature sslecho
 
 all:
 	@set -e; for i in $(MODULES); do \

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -1,4 +1,4 @@
-MODULES=cms digest encode encrypt kdf keyexch pkey signature sslecho
+MODULES=bio digest encode encrypt kdf keyexch mac pkey signature sslecho
 
 all:
 	@set -e; for i in $(MODULES); do \

--- a/demos/cms/Makefile
+++ b/demos/cms/Makefile
@@ -1,0 +1,35 @@
+#
+# To run the demos when linked with a shared library (default) ensure that
+# libcrypto is on the library path. For example, to run the
+# cms_enc demo:
+#
+#    LD_LIBRARY_PATH=../.. ./cms_enc
+
+TESTS = cms_comp \
+        cms_ddec \
+        cms_dec \
+        cms_denc \
+        cms_enc \
+        cms_sign \
+        cms_sign2 \
+        cms_uncomp \
+        cms_ver
+
+CFLAGS  = -I../../include -g
+LDFLAGS = -L../..
+LDLIBS  = -lcrypto
+
+all: $(TESTS)
+
+clean:
+	$(RM) $(TESTS) *.o
+
+cms_%: cms_%.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o "$@" "$<" $(LDLIBS)
+
+test: all
+	@echo "\nCMS tests:"
+	LD_LIBRARY_PATH=../.. ./cms_enc
+	LD_LIBRARY_PATH=../.. ./cms_dec
+	LD_LIBRARY_PATH=../.. ./cms_sign2
+	LD_LIBRARY_PATH=../.. ./cms_ver

--- a/demos/cms/cms_dec.c
+++ b/demos/cms/cms_dec.c
@@ -59,6 +59,8 @@ int main(int argc, char **argv)
     if (!CMS_decrypt(cms, rkey, rcert, NULL, out, 0))
         goto err;
 
+    printf("Decryption Successful\n");
+
     ret = EXIT_SUCCESS;
 
  err:

--- a/demos/cms/cms_enc.c
+++ b/demos/cms/cms_enc.c
@@ -73,6 +73,8 @@ int main(int argc, char **argv)
     if (!SMIME_write_CMS(out, cms, in, flags))
         goto err;
 
+    printf("Encryption Successful\n");
+
     ret = EXIT_SUCCESS;
  err:
     if (ret != EXIT_SUCCESS) {

--- a/demos/cms/cms_sign2.c
+++ b/demos/cms/cms_sign2.c
@@ -77,6 +77,8 @@ int main(int argc, char **argv)
     if (!SMIME_write_CMS(out, cms, in, CMS_STREAM))
         goto err;
 
+    printf("Signing Successful\n");
+
     ret = EXIT_SUCCESS;
  err:
     if (ret != EXIT_SUCCESS) {


### PR DESCRIPTION
Add a makefile for the cms demos, and add a routine to `cms_ver.c` to print any signingTime attributes from the CMS_ContentInfo object. This provides an example that could be extended if an application wants to validate the purported signing times.

Fixes #8026

Testing:
```
  $ cd demos/cms
  $ make \
      && LD_LIBRARY_PATH=../.. ./cms_sign2 \
      && LD_LIBRARY_PATH=../.. ./cms_ver
```