### PR TITLE
fix: restore missing --help in Configure, clean up output and show enabled/disabled flags, warn user of possible incorrect usage

### DIFF
--- a/Configure
+++ b/Configure
@@ -1112,10 +1112,10 @@ while (@argvcopy)
                         if (/^--(no|with|without|enable|disable)-(\S+)/)
                                 {
                                 # Ideally this would also cover cascades, but I lack Perl-fu.
-                                if (grep (/$2/, @disablables) or exists $deprecated_disablables{$2})
+                                if (grep ($_ eq $2, @disablables) or exists $deprecated_disablables{$2})
                                         {
-                                        print STDERR "NOTE: Flag --$1-$2 will be passed to compiler.  It looks similar to a Configure\n";
-                                        print STDERR "      option, though.  If that is what you meant to do, drop the leading '--'.\n";
+                                        print STDERR "NOTE: Flag --$1-$2 will be passed to the compiler.  It looks similar to a Configure\n";
+                                        print STDERR "      option, though.  If the latter is what you meant to do, drop the leading '--'.\n";
                                         }
                                 }
                         }

--- a/Configure
+++ b/Configure
@@ -3324,6 +3324,8 @@ sub usage
                 }
         print STDERR "\n";
 
+        disable();
+
         # Do some color wizardry.  Ideally, this would be done by a library and
         # would use proper termcap/terminfo, but we would rather avoid external
         # dependencies.  It's disabled by default unless you define CLICOLOR in

--- a/Configure
+++ b/Configure
@@ -27,7 +27,7 @@ use OpenSSL::config;
 my $orig_death_handler = $SIG{__DIE__};
 $SIG{__DIE__} = \&death_handler;
 
-my $usage="Usage: Configure [no-<feature> ...] [enable-<feature> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]thread-pool] [[no-]default-thread-pool] [[no-]shared] [[no-]zlib|zlib-dynamic] [no-asm] [no-egd] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--with-xxx[=vvv]] [--config=FILE] os/compiler[:flags]\n";
+my $usage="Usage: Configure [no-<feature> ...] [enable-<feature> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]thread-pool] [[no-]default-thread-pool] [[no-]shared] [[no-]zlib|zlib-dynamic] [no-asm] [no-egd] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--with-xxx[=vvv]] [--config=FILE] [--help] os/compiler[:flags]\n";
 
 my $banner = <<"EOF";
 
@@ -1097,6 +1097,10 @@ while (@argvcopy)
                         {
                         push @{$useradd{CPPFLAGS}}, $1;
                         }
+                elsif (/^--help$/)
+                        {
+                        &usage;
+                        }
                 else    # common if (/^[-+]/), just pass down...
                         {
                         # Treat %xx as an ASCII code (e.g. replace %20 by a space character).
@@ -1105,6 +1109,15 @@ while (@argvcopy)
                         $_ =~ s/%([0-9a-f]{1,2})/chr(hex($1))/gei;
                         push @{$useradd{CFLAGS}}, $_;
                         push @{$useradd{CXXFLAGS}}, $_;
+                        if (/^--(no|with|without|enable|disable)-(\S+)/)
+                                {
+                                # Ideally this would also cover cascades, but I lack Perl-fu.
+                                if (grep (/$2/, @disablables) or exists $deprecated_disablables{$2})
+                                        {
+                                        print STDERR "NOTE: Flag --$1-$2 will be passed to compiler.  It looks similar to a Configure\n";
+                                        print STDERR "      option, though.  If that is what you meant to do, drop the leading '--'.\n";
+                                        }
+                                }
                         }
                 }
         elsif (m|^/|)
@@ -3280,33 +3293,72 @@ sub usage
         {
         print STDERR $usage;
         print STDERR "\npick os/compiler from:\n";
-        my $j=0;
         my $i;
         my $k=0;
+        print STDERR "  ";
         foreach $i (sort keys %table)
                 {
                 next if $table{$i}->{template};
                 next if $i =~ /^debug/;
-                $k += length($i) + 1;
+                $k += length($i);
                 if ($k > 78)
                         {
-                        print STDERR "\n";
-                        $k=length($i);
+                        print STDERR "\n  ";
+                        $k=length($i) + 2;
                         }
+                $k += 1;
                 print STDERR $i . " ";
                 }
         foreach $i (sort keys %table)
                 {
                 next if $table{$i}->{template};
                 next if $i !~ /^debug/;
-                $k += length($i) + 1;
+                $k += length($i);
                 if ($k > 78)
                         {
-                        print STDERR "\n";
-                        $k=length($i);
+                        print STDERR "\n  ";
+                        $k=length($i) + 2;
                         }
+                $k += 1;
                 print STDERR $i . " ";
                 }
+        print STDERR "\n";
+
+        # Do some color wizardry.  Ideally, this would be done by a library and
+        # would use proper termcap/terminfo, but we would rather avoid external
+        # dependencies.  It's disabled by default unless you define CLICOLOR in
+        # your env.  (We approximate ls(1)'s behavior in BSD in this regard.)
+        my $en_color="";
+        my $dis_color="";
+        my $reset_color="";
+        my $this_color;
+        if ( defined $ENV{'CLICOLOR'} and (defined $ENV{'CLICOLOR_FORCE'} or -t 2) )
+                {
+                $en_color="\e[1;32m";  # bold green
+                $dis_color="\e[3;2m";  # dim italic
+                $reset_color="\e[0;0m";
+                }
+
+        print STDERR "The following ${en_color}ENABLED${reset_color} and ${dis_color}disabled${reset_color} flags are available:\n  ";
+        $k = 2;
+        foreach $i (sort @disablables)
+                {
+                $this_color=$dis_color;
+                $k += length($i);
+                if (not exists $disabled{$i})
+                        {
+                        $this_color=$en_color;
+                        $i = uc $i;
+                        }
+                if ($k > 78)
+                        {
+                        print STDERR "\n  ";
+                        $k=length($i) + 2;
+                        }
+                $k += 1;
+                print STDERR "${this_color}${i}${reset_color} ";
+                }
+        print STDERR "\n";
         exit(1);
         }
 


### PR DESCRIPTION
In 081436bf732c0889b2649426df4e1c23c671d6d7 (from https://github.com/openssl/openssl/pull/11230), the ability to use `--help` as a flag to `config` and `Configure` was lost.  The flag would be worth restoring on its own merits, but it's also needed to restore the accuracy of [references to it on the Wiki](https://wiki.openssl.org/index.php/Compilation_and_Installation#Configure_.26_Config).

This PR restores the ability to get `--help`.  While we're at it, we also include a few helpful related features/fixes:

1. Add missing `\n` to the end of usage output to stderr.
2. The os/compiler list was a bit of a wall of text; it's now gently indented.
3. Available enable/disable flags are now shown along with their status (based on configured defaults and the args as parsed up to that point).  This can help debug e.g. surprising disable_cascade behavior.
4. At some point, any flags not recognized by Configure started being passed to `CFLAGS`/`CXXFLAGS`.  However, this can lead to confusion, since autoconf and friends use flag syntax (e.g. `--with-zlib`), whereas Configure uses bareword (`with-zlib`).  Indeed, in this regard, the Wiki continues to be incorrect even after this PR is merged ("If you provide a [sic] **option not known to configure** or ask for help, then you get a brief help message", emphasis mine).  As changed here, when the user passes an argument like `--enable-zstd`, if it would have been a valid Configure flag without the leading `--`, Configure will now issue a "NOTE" to the user on stderr.

A brief postscript: please remember when reviewing this patch that I bear no responsibility for the style of indentation chosen in this file, though I did my best to follow it faithfully.

<details><summary>Output of new version</summary>

```console
$ ./config --help
Usage: Configure [no-<feature> ...] [enable-<feature> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]thread-pool] [[no-]default-thread-pool] [[no-]shared] [[no-]zlib|zlib-dynamic] [no-asm] [no-egd] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--with-xxx[=vvv]] [--config=FILE] [--help] os/compiler[:flags]

pick os/compiler from:
  BC-32 BS2000-OSD BSD-aarch64 BSD-armv4 BSD-generic32 BSD-generic64 BSD-ia64 
  BSD-nodef-generic32 BSD-nodef-generic64 BSD-nodef-ia64 BSD-nodef-sparc64 
  BSD-nodef-sparcv8 BSD-nodef-x86 BSD-nodef-x86-elf BSD-nodef-x86_64 BSD-ppc 
  BSD-ppc64 BSD-ppc64le BSD-riscv32 BSD-riscv64 BSD-sparc64 BSD-sparcv8 
  BSD-x86 BSD-x86-elf BSD-x86_64 Cygwin Cygwin-i386 Cygwin-i486 Cygwin-i586 
  Cygwin-i686 Cygwin-x86 Cygwin-x86_64 DJGPP MPE/iX-gcc OS390-Unix UEFI 
  UEFI-x86 UEFI-x86_64 UWIN VC-CE VC-CLANG-WIN64-CLANGASM-ARM VC-WIN32 
  VC-WIN32-ARM VC-WIN32-ARM-UWP VC-WIN32-HYBRIDCRT VC-WIN32-ONECORE 
  VC-WIN32-UWP VC-WIN64-ARM VC-WIN64-ARM-UWP VC-WIN64-CLANGASM-ARM VC-WIN64A 
  VC-WIN64A-HYBRIDCRT VC-WIN64A-ONECORE VC-WIN64A-UWP VC-WIN64A-masm VC-WIN64I 
  aix-cc aix-gcc aix64-cc aix64-gcc aix64-gcc-as android-arm android-arm64 
  android-armeabi android-mips android-mips64 android-x86 android-x86_64 
  android64 android64-aarch64 android64-mips64 android64-x86_64 bsdi-elf-gcc 
  cc darwin-i386 darwin-i386-cc darwin-ppc darwin-ppc-cc darwin64-arm64 
  darwin64-arm64-cc darwin64-ppc darwin64-ppc-cc darwin64-x86_64 
  darwin64-x86_64-cc gcc haiku-x86 haiku-x86_64 hpux-ia64-cc hpux-ia64-gcc 
  hpux-parisc-cc hpux-parisc-gcc hpux-parisc1_1-cc hpux-parisc1_1-gcc 
  hpux64-ia64-cc hpux64-ia64-gcc hpux64-parisc2-cc hpux64-parisc2-gcc 
  hurd-generic32 hurd-generic64 hurd-x86 hurd-x86_64 ios-cross ios-xcrun 
  ios64-cross ios64-xcrun iossimulator-arm64-xcrun iossimulator-i386-xcrun 
  iossimulator-x86_64-xcrun iossimulator-xcrun iphoneos-cross irix-mips3-cc 
  irix-mips3-gcc irix64-mips4-cc irix64-mips4-gcc linux-aarch64 
  linux-alpha-gcc linux-aout linux-arm64ilp32 linux-armv4 linux-c64xplus 
  linux-elf linux-generic32 linux-generic64 linux-ia64 linux-latomic 
  linux-mips32 linux-mips64 linux-ppc linux-ppc64 linux-ppc64le linux-sparcv8 
  linux-sparcv9 linux-x32 linux-x86 linux-x86-clang linux-x86-latomic 
  linux-x86_64 linux-x86_64-clang linux32-riscv32 linux32-s390x 
  linux64-loongarch64 linux64-mips64 linux64-riscv64 linux64-s390x 
  linux64-sparcv9 mingw mingw64 nonstop-nse nonstop-nse_64 nonstop-nse_64_put 
  nonstop-nse_g nonstop-nse_g_tandem nonstop-nse_put nonstop-nse_spt 
  nonstop-nse_spt_floss nonstop-nsv nonstop-nsx nonstop-nsx_64 
  nonstop-nsx_64_put nonstop-nsx_g nonstop-nsx_g_tandem nonstop-nsx_put 
  nonstop-nsx_spt nonstop-nsx_spt_floss sco5-cc sco5-gcc solaris-sparcv7-cc 
  solaris-sparcv7-gcc solaris-sparcv8-cc solaris-sparcv8-gcc 
  solaris-sparcv9-cc solaris-sparcv9-gcc solaris-x86-gcc solaris64-sparcv9-cc 
  solaris64-sparcv9-gcc solaris64-x86_64-cc solaris64-x86_64-gcc 
  tru64-alpha-cc tru64-alpha-gcc uClinux-dist uClinux-dist64 unixware-2.0 
  unixware-2.1 unixware-7 unixware-7-gcc vms-alpha vms-alpha-p32 vms-alpha-p64 
  vms-ia64 vms-ia64-p32 vms-ia64-p64 vms-x86_64 vms-x86_64-cross-ia64 vos-gcc 
  vxworks-mips vxworks-ppc405 vxworks-ppc60x vxworks-ppc750 
  vxworks-ppc750-debug vxworks-ppc860 vxworks-ppcgen vxworks-simlinux 
The following ENABLED and disabled flags are available:
  ACVP-TESTS AFALGENG APPS ARGON2 ARIA asan ASM ASYNC AUTOALGINIT AUTOERRINIT 
  AUTOLOAD-CONFIG BF BLAKE2 brotli brotli-dynamic buildtest-c++ BULK 
  CACHED-FETCH CAMELLIA CAPIENG CAST CHACHA CMAC CMP CMS COMP crypto-mdebug CT 
  DEFAULT-THREAD-POOL DEPRECATED DES devcryptoeng DGRAM DH DOCS DSA DSO DTLS 
  DTLS1 DTLS1-METHOD DTLS1_2 DTLS1_2-METHOD DYNAMIC-ENGINE EC EC2M 
  ec_nistp_64_gcc_128 ECDH ECDSA ECX egd ENGINE ERR external-tests FILENAMES 
  fips FIPS-SECURITYCHECKS fuzz-afl fuzz-libfuzzer GOST HTTP IDEA ktls LEGACY 
  LOADERENG MAKEDEPEND md2 MD4 MDC2 MODULE msan MULTIBLOCK NEXTPROTONEG OCB 
  OCSP PADLOCKENG PIC PINSHARED POLY1305 POSIX-IO PSK QUIC RC2 RC4 rc5 RDRAND 
  RFC3779 RMD160 SCRYPT sctp SECURE-MEMORY SEED SHARED SIPHASH SIV SM2 
  SM2-PRECOMP SM3 SM4 SOCK SRP SRTP SSE2 SSL SSL-TRACE ssl3 ssl3-method 
  STATIC-ENGINE STDIO TESTS tfo THREAD-POOL THREADS TLS TLS1 TLS1-METHOD 
  TLS1_1 TLS1_1-METHOD TLS1_2 TLS1_2-METHOD TLS1_3 trace TS ubsan UI-CONSOLE 
  unit-test UPLINK weak-ssl-ciphers WHIRLPOOL WINSTORE zlib zlib-dynamic zstd 
  zstd-dynamic 
```

</details>

<details><summary>Output of new version with CLICOLOR enabled</summary>

![Image showing output of new version being run as "CLICOLOR=1 ./config --help".  With CLICOLOR enabled, disabled flags are now rendered as dim and italicized, and enabled flags are bright-green and in ALL CAPS](https://github.com/openssl/openssl/assets/881372/62494556-1be8-442b-8f68-2e9b3bfaf553)

</details>

<details><summary>Output of new version reflecting a disable_cascade argument having been applied</summary>

![Image showing output of new version being run as "CLICOLOR=1 ./config disable-bulk --help", reflecting a disable_cascade argument having been applied.  As above, but now many more flags are shows in the lowercase, italicized, dim font reflecting that they have been disbled](https://github.com/openssl/openssl/assets/881372/347d0986-c402-4b29-b9da-cb48d88edc22)

</details>

<details><summary>Output of new version related to feature/fix numbered 4, above:</summary>

* User is warned when preceding a valid `Configure` parameter with `--`:
```console
$ ./Configure --with-zlib
NOTE: Flag --with-zlib will be passed to compiler.  It looks similar to a Configure
      option, though.  If that is what you meant to do, drop the leading '--'.
Configuring OpenSSL version 3.3.0-dev for target linux-x86_64
Using os-specific seed configuration
```
* Having multiple possible mistakes gives multiple warnings, even if correct bareword options are intermixed:
```console
$ ./Configure sctp --with-zlib --with-trace
NOTE: Flag --with-zlib will be passed to compiler.  It looks similar to a Configure
      option, though.  If that is what you meant to do, drop the leading '--'.
NOTE: Flag --with-trace will be passed to compiler.  It looks similar to a Configure
      option, though.  If that is what you meant to do, drop the leading '--'.
Configuring OpenSSL version 3.3.0-dev for target linux-x86_64
Using os-specific seed configuration
^C
$ ./Configure --with-zlib sctp --with-trace 
NOTE: Flag --with-zlib will be passed to compiler.  It looks similar to a Configure
      option, though.  If that is what you meant to do, drop the leading '--'.
NOTE: Flag --with-trace will be passed to compiler.  It looks similar to a Configure
      option, though.  If that is what you meant to do, drop the leading '--'.
Configuring OpenSSL version 3.3.0-dev for target linux-x86_64
Using os-specific seed configuration
^C
$ ./Configure --with-zlib --with-trace sctp
NOTE: Flag --with-zlib will be passed to compiler.  It looks similar to a Configure
      option, though.  If that is what you meant to do, drop the leading '--'.
NOTE: Flag --with-trace will be passed to compiler.  It looks similar to a Configure
      option, though.  If that is what you meant to do, drop the leading '--'.
Configuring OpenSSL version 3.3.0-dev for target linux-x86_64
Using os-specific seed configuration
```
* User is _not_ warned when preceding a valid `Configure` parameter with `--` if it is unambiguously not meant for Configure to consume:
```console
$ ./Configure --with-zlib=/usr/local/lib
Configuring OpenSSL version 3.3.0-dev for target linux-x86_64
Using os-specific seed configuration
```
* Specifying an unsupported option once again results in script faiilure as expected/documented:
```console
$ ./Configure with-something-fake
Configuring OpenSSL version 3.3.0-dev for target with-something-fake
Using os-specific seed configuration
Usage: Configure [no-<feature> ...] [enable-<feature> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]thread-pool] [[no-]default-thread-pool] [[no-]shared] [[no-]zlib|zlib-dynamic] [no-asm] [no-egd] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--with-xxx[=vvv]] [--config=FILE] [--help] os/compiler[:flags]

pick os/compiler from:
  BC-32 BS2000-OSD BSD-aarch64 BSD-armv4 BSD-generic32 BSD-generic64 BSD-ia64 
<...>
$ echo $?
1
```
* No warnings are issued for a passed option that does not match any `Configure` parameter:
```console
$ ./Configure --with-something-fake
Configuring OpenSSL version 3.3.0-dev for target linux-x86_64
Using os-specific seed configuration
^C
```
</details>

CLA is signed.