### PR TITLE
quic http3 demo: minor updates

### DIFF
--- a/demos/http3/Makefile
+++ b/demos/http3/Makefile
@@ -1,11 +1,17 @@
-CFLAGS = -I../../include -g -Wall
+#
+# To run the demo when linked with a shared library (default) ensure that
+# libcrypto and libssl are on the library path. For example:
+#
+#    LD_LIBRARY_PATH=../.. ./ossl-nghttp3-demo www.example.com:443
+
+CFLAGS  = -I../../include -g -Wall -Wsign-compare
 LDFLAGS = -L../..
-LDLIBS = -lcrypto -lssl -lnghttp3
+LDLIBS  = -lcrypto -lssl -lnghttp3
 
 all: ossl-nghttp3-demo
 
 clean:
-	$(RM) -f ossl-nghttp3-demo *.o
+	$(RM) ossl-nghttp3-demo *.o
 
 ossl-nghttp3-demo: ossl-nghttp3-demo.o ossl-nghttp3.o
 	$(CC) $(CFLAGS) -o "$@" $^ $(LDFLAGS) $(LDLIBS)

--- a/demos/http3/README.md
+++ b/demos/http3/README.md
@@ -12,7 +12,8 @@ The demo is structured into two parts:
   layer (`ossl-nghttp3-demo.c`).
 
 The Makefile in this directory can be used to build the demo on \*nix-style
-systems. You will need to have the `nghttp3` library available.
+systems.  You will need the `nghttp3` library and header file.  On
+Ubuntu, these can be obtained by installing the package `libnghttp3-dev`.
 
 Running the Demo
 ----------------
@@ -26,7 +27,7 @@ port as the sole argument:
 
 ```shell
 $ make
-$ ./ossl-nghttp3-demo www.google.com:443
+$ LD_LIBRARY_PATH=../.. ./ossl-nghttp3-demo www.google.com:443
 ```
 
 The demo produces the HTTP response headers in textual form as output followed


### PR DESCRIPTION
-update run command to include LD_LIBRARY_PATH
-suggest installing libnghttp3-dev on Ubuntu

Part of https://github.com/openssl/project/issues/253
