### PR TITLE
Augment rand argument parsing to allow scaling

### DIFF
--- a/apps/rand.c
+++ b/apps/rand.c
@@ -198,7 +198,10 @@ int rand_main(int argc, char **argv)
     while (scaled_num > 0) {
         long chunk;
 
-        chunk = (scaled_num > buflen) ? buflen : scaled_num;
+        chunk = buflen;
+        if ((long)scaled_num < chunk)
+            chunk = (long)scaled_num;
+
         r = RAND_bytes(buf, chunk);
         if (r <= 0)
             goto end;

--- a/apps/rand.c
+++ b/apps/rand.c
@@ -55,7 +55,7 @@ int rand_main(int argc, char **argv)
     int format = FORMAT_BINARY, r, i, ret = 1;
     size_t buflen = (1 << 16); /* max rand chunk size is 2^16 bytes */
     long num = -1;
-    size_t scaled_num = 0;
+    uint64_t scaled_num = 0;
     uint8_t *buf = NULL;
 
     prog = opt_init(argc, argv, rand_options);
@@ -109,7 +109,7 @@ int rand_main(int argc, char **argv)
              * 2^61 bytes is the limit of random output
              * per drbg instantiation
              */
-            scaled_num = SIZE_MAX >> 3;
+            scaled_num = UINT64_MAX >> 3;
         } else {
             /*
              * iterate over the value and check to see if there are
@@ -162,13 +162,13 @@ int rand_main(int argc, char **argv)
 
         if (shift != 0) {
             /* check for overflow */
-            if ((SIZE_MAX >> shift) < (size_t)num) {
+            if ((UINT64_MAX >> shift) < (size_t)num) {
                 BIO_printf(bio_err, "%lu bytes with suffix overflows\n",
                            num);
                 goto opthelp;
             }
             scaled_num = num << shift;
-            if (scaled_num > (SIZE_MAX >> 3)) {
+            if (scaled_num > (UINT64_MAX >> 3)) {
                 BIO_printf(bio_err, "Request exceeds max allowed output\n");
                 goto opthelp;
             }

--- a/apps/rand.c
+++ b/apps/rand.c
@@ -25,7 +25,7 @@ typedef enum OPTION_choice {
 } OPTION_CHOICE;
 
 const OPTIONS rand_options[] = {
-    {OPT_HELP_STR, 1, '-', "Usage: %s [options] num[k|m|g|t]\n"},
+    {OPT_HELP_STR, 1, '-', "Usage: %s [options] num[K|M|G|T]\n"},
 
     OPT_SECTION("General"),
     {"help", OPT_HELP, '-', "Display this summary"},
@@ -99,67 +99,78 @@ int rand_main(int argc, char **argv)
     if (argc == 1) {
         int factoridx = 0;
         int shift = 0;
-        /*
-         * iterate over the value and check to see if there are
-         * any non-numerical chars
-         * A non digit suffix indicates we need to shift the
-         * number of requested bytes by a factor of:
-         * k = 1024^1 (1 << (10 * 1))
-         * m = 1024^2 (1 << (10 * 2))
-         * g = 1024^3 (1 << (10 * 3))
-         * t = 1024^4 (1 << (10 * 4))
-         * which can be achieved by bit-shifting the number
-         */
-        while (argv[0][factoridx]) {
-            if (!isdigit((int)(argv[0][factoridx]))) {
-                switch(argv[0][factoridx]) {
-                case 'k':
-                case 'K':
-                    shift = 10;
-                    break;
-                case 'm':
-                case 'M':
-                    shift = 20;
-                    break;
-                case 'g':
-                case 'G':
-                    shift = 30;
-                    break;
-                case 't':
-                case 'T':
-                    shift = 40;
-                    break;
-                default:
-                    BIO_printf(bio_err, "Invalid size suffix %s\n",
-                               &argv[0][factoridx]);
-                    goto opthelp;
-                }
-                break;
-            }
-            factoridx++;
-        }
 
-        if (factoridx && strlen(&argv[0][factoridx]) != 1) {
-            BIO_printf(bio_err, "Invalid size suffix %s\n", &argv[0][factoridx]);
-            goto opthelp;
+        /*
+         * special case for requesting the max allowed
+         * number of random bytes to be generated
+         */
+        if (!strcmp(argv[0], "max")) {
+            scaled_num = SIZE_MAX;
+        } else {
+            /*
+             * iterate over the value and check to see if there are
+             * any non-numerical chars
+             * A non digit suffix indicates we need to shift the
+             * number of requested bytes by a factor of:
+             * k = 1024^1 (1 << (10 * 1))
+             * m = 1024^2 (1 << (10 * 2))
+             * g = 1024^3 (1 << (10 * 3))
+             * t = 1024^4 (1 << (10 * 4))
+             * which can be achieved by bit-shifting the number
+             */
+            while (argv[0][factoridx]) {
+                if (!isdigit((int)(argv[0][factoridx]))) {
+                    switch(argv[0][factoridx]) {
+                    case 'k':
+                    case 'K':
+                        shift = 10;
+                        break;
+                    case 'm':
+                    case 'M':
+                        shift = 20;
+                        break;
+                    case 'g':
+                    case 'G':
+                        shift = 30;
+                        break;
+                    case 't':
+                    case 'T':
+                        shift = 40;
+                        break;
+                    default:
+                        BIO_printf(bio_err, "Invalid size suffix %s\n",
+                                   &argv[0][factoridx]);
+                        goto opthelp;
+                    }
+                    break;
+                }
+                factoridx++;
+            }
+
+            if (shift != 0 && strlen(&argv[0][factoridx]) != 1) {
+                BIO_printf(bio_err, "Invalid size suffix %s\n",
+                           &argv[0][factoridx]);
+                goto opthelp;
+            }
         }
         /* Remove the suffix from the arg so that opt_long works */
         if (shift != 0)
             argv[0][factoridx] = '\0';
 
-        if (!opt_long(argv[0], &num) || num <= 0)
+        if ((scaled_num != SIZE_MAX) && (!opt_long(argv[0], &num) || num <= 0))
             goto opthelp;
 
         if (shift != 0) {
             /* check for overflow */
             if ((SIZE_MAX >> shift) < (size_t)num) {
-                BIO_printf(bio_err, "%lu bytes with provided suffix overflows\n",
+                BIO_printf(bio_err, "%lu bytes with suffix overflows\n",
                            num);
                 goto opthelp;
             }
             scaled_num = num << shift;
         } else {
-            scaled_num = num;
+            if (scaled_num == 0)
+                scaled_num = num;
         }
     } else if (!opt_check_rest_arg(NULL)) {
         goto opthelp;

--- a/apps/rand.c
+++ b/apps/rand.c
@@ -125,19 +125,15 @@ int rand_main(int argc, char **argv)
             while (argv[0][factoridx]) {
                 if (!isdigit((int)(argv[0][factoridx]))) {
                     switch(argv[0][factoridx]) {
-                    case 'k':
                     case 'K':
                         shift = 10;
                         break;
-                    case 'm':
                     case 'M':
                         shift = 20;
                         break;
-                    case 'g':
                     case 'G':
                         shift = 30;
                         break;
-                    case 't':
                     case 'T':
                         shift = 40;
                         break;

--- a/apps/rand.c
+++ b/apps/rand.c
@@ -196,12 +196,9 @@ int rand_main(int argc, char **argv)
 
     buf = app_malloc(buflen, "buffer for output file");
     while (scaled_num > 0) {
-        long chunk;
+        int chunk;
 
-        chunk = buflen;
-        if ((long)scaled_num < chunk)
-            chunk = (long)scaled_num;
-
+        chunk = scaled_num > buflen ? (int)buflen : (int)scaled_num;
         r = RAND_bytes(buf, chunk);
         if (r <= 0)
             goto end;

--- a/apps/rand.c
+++ b/apps/rand.c
@@ -105,7 +105,11 @@ int rand_main(int argc, char **argv)
          * number of random bytes to be generated
          */
         if (!strcmp(argv[0], "max")) {
-            scaled_num = SIZE_MAX;
+            /*
+             * 2^61 bytes is the limit of random output
+             * per drbg instantiation
+             */
+            scaled_num = SIZE_MAX >> 3;
         } else {
             /*
              * iterate over the value and check to see if there are
@@ -157,7 +161,7 @@ int rand_main(int argc, char **argv)
         if (shift != 0)
             argv[0][factoridx] = '\0';
 
-        if ((scaled_num != SIZE_MAX) && (!opt_long(argv[0], &num) || num <= 0))
+        if ((scaled_num == 0) && (!opt_long(argv[0], &num) || num <= 0))
             goto opthelp;
 
         if (shift != 0) {
@@ -168,6 +172,10 @@ int rand_main(int argc, char **argv)
                 goto opthelp;
             }
             scaled_num = num << shift;
+            if (scaled_num > (SIZE_MAX >> 3)) {
+                BIO_printf(bio_err, "Request exceeds max allowed output\n");
+                goto opthelp;
+            }
         } else {
             if (scaled_num == 0)
                 scaled_num = num;

--- a/apps/rand.c
+++ b/apps/rand.c
@@ -116,10 +116,10 @@ int rand_main(int argc, char **argv)
              * any non-numerical chars
              * A non digit suffix indicates we need to shift the
              * number of requested bytes by a factor of:
-             * k = 1024^1 (1 << (10 * 1))
-             * m = 1024^2 (1 << (10 * 2))
-             * g = 1024^3 (1 << (10 * 3))
-             * t = 1024^4 (1 << (10 * 4))
+             * K = 1024^1 (1 << (10 * 1))
+             * M = 1024^2 (1 << (10 * 2))
+             * G = 1024^3 (1 << (10 * 3))
+             * T = 1024^4 (1 << (10 * 4))
              * which can be achieved by bit-shifting the number
              */
             while (argv[0][factoridx]) {

--- a/doc/man1/openssl-rand.pod.in
+++ b/doc/man1/openssl-rand.pod.in
@@ -27,7 +27,7 @@ insensitive, and that the suffixes represent binary multiples
 
 The string 'max' may be substituted for a numercial value in num, to request the
 maximum number of bytes the CSPRNG can produce per instantiation.  Currently,
-this is restricted to 2^64 bytes as per NIST SP 800-90C.
+this is restricted to 2^61 bytes as per NIST SP 800-90C.
 
 The random bytes are generated using the L<RAND_bytes(3)> function,
 which provides a security level of 256 bits, provided it managed to

--- a/doc/man1/openssl-rand.pod.in
+++ b/doc/man1/openssl-rand.pod.in
@@ -14,12 +14,14 @@ B<openssl rand>
 [B<-hex>]
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
-I<num>
+I<num>[k|m|g|t]
 
 =head1 DESCRIPTION
 
 This command generates I<num> random bytes using a cryptographically
-secure pseudo random number generator (CSPRNG).
+secure pseudo random number generator (CSPRNG). the suffix k, m, g or t may be
+added to the num value to indicate the request value be scaled as a multiple of
+kiB/MiB/GiB/TiB respectively. Note that suffixes are case insensitive.
 
 The random bytes are generated using the L<RAND_bytes(3)> function,
 which provides a security level of 256 bits, provided it managed to

--- a/doc/man1/openssl-rand.pod.in
+++ b/doc/man1/openssl-rand.pod.in
@@ -14,14 +14,20 @@ B<openssl rand>
 [B<-hex>]
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
-I<num>[k|m|g|t]
+I<num>[K|M|G|T]
 
 =head1 DESCRIPTION
 
 This command generates I<num> random bytes using a cryptographically
-secure pseudo random number generator (CSPRNG). the suffix k, m, g or t may be
-added to the num value to indicate the request value be scaled as a multiple of
-kiB/MiB/GiB/TiB respectively. Note that suffixes are case insensitive.
+secure pseudo random number generator (CSPRNG). A suffix [K|M|G|T] may be
+appended to the num value to indicate the requested value be scaled as a
+multiple of KiB/MiB/GiB/TiB respectively. Note that suffixes are case
+insensitive, and that the suffixes represent binary multiples
+(KiB = 1024 bytes, MiB = 1024*1024 bytes, etc).
+
+The string 'max' may be substituted for a numercial value in num, to request the
+maximum number of bytes the CSPRNG can produce per instantiation.  Currently,
+this is restricted to 2^64 bytes as per NIST SP 800-90C.
 
 The random bytes are generated using the L<RAND_bytes(3)> function,
 which provides a security level of 256 bits, provided it managed to

--- a/doc/man1/openssl-rand.pod.in
+++ b/doc/man1/openssl-rand.pod.in
@@ -22,8 +22,8 @@ This command generates I<num> random bytes using a cryptographically
 secure pseudo random number generator (CSPRNG). A suffix [K|M|G|T] may be
 appended to the num value to indicate the requested value be scaled as a
 multiple of KiB/MiB/GiB/TiB respectively. Note that suffixes are case
-insensitive, and that the suffixes represent binary multiples
-(KiB = 1024 bytes, MiB = 1024*1024 bytes, etc).
+sensitive, and that the suffixes represent binary multiples
+(K = 1024 bytes, M = 1024*1024 bytes, etc).
 
 The string 'max' may be substituted for a numercial value in num, to request the
 maximum number of bytes the CSPRNG can produce per instantiation.  Currently,

--- a/test/recipes/05-test_rand.t
+++ b/test/recipes/05-test_rand.t
@@ -32,6 +32,10 @@ SKIP: {
     ok($success && $randdata[0] eq $expected,
        "rand with ossltest: Check rand output is as expected");
 
+    @randdata = run(app(['openssl', 'rand', '-hex', '2k' ]),
+                    capture => 1, statusvar => \$success);
+    chomp(@randdata);
+
     @randdata = run(app(['openssl', 'rand', '-engine', 'dasync', '-hex', '16' ]),
                     capture => 1, statusvar => \$success);
     chomp(@randdata);

--- a/test/recipes/05-test_rand.t
+++ b/test/recipes/05-test_rand.t
@@ -32,7 +32,7 @@ SKIP: {
     ok($success && $randdata[0] eq $expected,
        "rand with ossltest: Check rand output is as expected");
 
-    @randdata = run(app(['openssl', 'rand', '-hex', '2k' ]),
+    @randdata = run(app(['openssl', 'rand', '-hex', '2K' ]),
                     capture => 1, statusvar => \$success);
     chomp(@randdata);
 


### PR DESCRIPTION
Extend opts parsing to parse long long values, and use it to have openssl rand accept requests for more than 2^32-1 bytes of data

Fixes #22622

