### PR TITLE
[design] Functions for explicitly fetched signature algorithms

### DIFF
--- a/doc/designs/fetching-composite-algorithms.md
+++ b/doc/designs/fetching-composite-algorithms.md
@@ -20,19 +20,19 @@ Public API - Add variants of `EVP_PKEY_CTX` initializers
 
 As far as this design is concerned, these API sets are affected:
 
-- SIGNATURE (DigestSign and DigestVerify)
+- SIGNATURE
 - ASYM_CIPHER
 - KEYEXCH
 
-The proposal is to add these functions:
+The proposal is to add these initializer functions:
 
 ``` C
-EVP_DigestSignInit_ex2(EVP_PKEY_CTX **pctx,
-                       EVP_SIGNATURE *sig, EVP_PKEY *pkey,
-                       OSSL_LIB_CTX *libctx, const OSSL_PARAM params[]);
-EVP_DigestVerifyInit_ex2(EVP_PKEY_CTX **pctx,
-                         EVP_SIGNATURE *sig, EVP_PKEY *pkey,
-                         OSSL_LIB_CTX *libctx, const OSSL_PARAM params[]);
+int EVP_PKEY_sign_init_ex2(EVP_PKEY_CTX *pctx,
+                           EVP_SIGNATURE *algo, const OSSL_PARAM params[]);
+int EVP_PKEY_verify_init_ex2(EVP_PKEY_CTX *pctx,
+                             EVP_SIGNATURE *algo, const OSSL_PARAM params[]);
+int EVP_PKEY_verify_recover_init_ex2(EVP_PKEY_CTX *pctx,
+                                     EVP_SIGNATURE *algo, const OSSL_PARAM params[]);
 
 int EVP_PKEY_encrypt_init_ex2(EVP_PKEY_CTX *ctx, EVP_ASYM_CIPHER *asymciph,
                               const OSSL_PARAM params[]);
@@ -43,68 +43,12 @@ int EVP_PKEY_derive_init_ex2(EVP_PKEY_CTX *ctx, EVP_KEYEXCH *exchange,
                              const OSSL_PARAM params[]);
 ```
 
-Because `EVP_SIGNATURE`, `EVP_ASYM_CIPHER` and `EVP_KEYEXCH` aren't limited
-to composite algorithms, these functions can be used just as well with
-explicit fetches of simple algorithms, say "RSA".  In that case, the caller
-will need to pass necessary auxiliary parameters through the `OSSL_PARAM` or
-a call to a corresponding `set_params` function.
+Detailed proposal for these APIs will are prepared in other design
+documents:
 
-Requirements on the providers
------------------------------
-
-Because it's not immediately obvious from a composite algorithm name what
-key type it requires / supports, at least in code, allowing the use of an
-explicitly fetched implementation of a composite algorithm requires that
-providers cooperate by declaring what key type is required / supported by
-each algorithm.
-
-For non-composite operation algorithms (like "RSA"), this is not necessary,
-see the fallback strategies below.
-
-There are two ways this could be implemented:
-
-1.  through an added provider function that would work like keymgmt's
-    `query_operation_name` function, but would return a key type name
-    instead:
-
-    ``` C
-    # define OSSL_FUNC_SIGNATURE_QUERY_KEY_TYPE         26
-    OSSL_CORE_MAKE_FUNC(const char *, signature_query_key_type, (void))
-
-    # define OSSL_FUNC ASYM_CIPHER_QUERY_KEY_TYPE       12
-    OSSL_CORE_MAKE_FUNC(const char *, asym_cipher_query_key_type, (void))
-
-    # define OSSL_FUNC_KEYEXCH_QUERY_KEY_TYPE           11
-    OSSL_CORE_MAKE_FUNC(const char *, keyexch_query_key_type, (void))
-    ```
-
-2.  through a gettable `OSSL_PARAM`, using the param identity "keytype"
-
-Fallback strategies
--------------------
-
-Because existing providers haven't been updated to declare composite
-algorithms, or to respond to the key type query, some fallback strategies
-will be needed to find out if the `EVP_PKEY` key type is possible to use
-with the fetched algorithm:
-
--   Check if the fetched operation name matches the key type (keymgmt name)
-    of the `EVP_PKEY` that's involved in the operation.  For example, this
-    is useful when someone fetched the `EVP_SIGNATURE` "RSA".
--   Check if the fetched algorithm name matches the name returned by the
-    keymgmt's `query_operation_name` function.  For example, this is useful
-    when someone fetched the `EVP_SIGNATURE` "ECDSA", for which the key type
-    to use is "EC".
--   libcrypto currently has knowledge of some composite algorithm names and
-    what they are composed of, accessible with `OBJ_find_sigid_algs` and
-    similar functionality.  This knowledge is regarded legacy, but can be
-    used to figure out the key type.
-
-If none of these strategies work out, the operation initialization should
-fail.
-
-These strategies have their limitations, but the built-in legacy knowledge
-we currently have in libcrypto should be enough to cover most bases.
+- [Functions for explicitly fetched signature algorithms]
+- [Functions for explicitly fetched asym-cipher algorithms] (not yet designed)
+- [Functions for explicitly fetched keyexch algorithms] (not yet designed)
 
 -----
 
@@ -185,3 +129,7 @@ This is hurtful in multiple ways:
     use the result.
 -   It fails discoverability, for example through the `openssl list`
     command.
+
+<!-- links -->
+[Functions for explicitly fetched signature algorithms]:
+    functions-for-explicitly-fetched-signature-algorithms.md

--- a/doc/designs/fetching-composite-algorithms.md
+++ b/doc/designs/fetching-composite-algorithms.md
@@ -43,7 +43,7 @@ int EVP_PKEY_derive_init_ex2(EVP_PKEY_CTX *ctx, EVP_KEYEXCH *exchange,
                              const OSSL_PARAM params[]);
 ```
 
-Detailed proposal for these APIs will are prepared in other design
+Detailed proposal for these APIs will be or are prepared in other design
 documents:
 
 - [Functions for explicitly fetched signature algorithms]

--- a/doc/designs/functions-for-explicitly-fetched-signature-algorithms.md
+++ b/doc/designs/functions-for-explicitly-fetched-signature-algorithms.md
@@ -1,0 +1,155 @@
+Functions for explicitly fetched PKEY algorithms
+================================================
+
+Quick background
+----------------
+
+There are several proposed designs that end up revolving around the same
+basic need, explicitly fetched signature algorithms.  The following method
+type is affected by this document:
+
+- `EVP_SIGNATURE`
+
+Public API - Add variants of `EVP_PKEY_CTX` functionality
+---------------------------------------------------------
+
+Through OTC discussions, it's been determined that the most suitable APIs to
+touch is the collection of `EVP_PKEY_` functions.  In this case, it involves
+`EVP_PKEY_sign()`, `EVP_PKEY_verify()`, `EVP_PKEY_verify_recover()` with
+associated functions.  They can be extended to accept an explicitly fetched
+algorithm of the right type, and to be able to process infinite amounts of
+data if the fetched algorithm permits it (typically, algorithms like ED25519
+or RSA-SHA256).
+
+It must be made clear that the added functionality can not be used to
+compose an algorithm from different parts.  For example, it's not possible
+to specify a `EVP_SIGNATURE` "RSA" and combine it with a parameter that
+specifies the hash "SHA256" to get the "RSA-SHA256" functionality.  For an
+`EVP_SIGNATURE` "RSA", the input is still expected to be a digest, or some
+other input that's limited to the modulus size of the RSA pkey.
+
+### For signing with `EVP_SIGNATURE`
+
+New initializers:
+
+``` C
+int EVP_PKEY_sign_init_ex2(EVP_PKEY_CTX *pctx,
+                           EVP_SIGNATURE *algo, const OSSL_PARAM params[]);
+```
+
+Added stream functionality:
+
+``` C
+int EVP_PKEY_sign_update(EVP_PKEY_CTX *ctx, unsigned char *in, size_t *inlen);
+int EVP_PKEY_sign_final(EVP_PKEY_CTX *ctx,
+                        unsigned char *sig, size_t *siglen, size_t sigsize);
+```
+
+### For verifying with `EVP_SIGNATURE`
+
+With verifying, recent development has shown a need to set the signature to
+be verified against separately.  This proposal reflects that.
+
+New initializers:
+
+``` C
+int EVP_PKEY_verify_init_ex2(EVP_PKEY_CTX *pctx,
+                             EVP_SIGNATURE *algo, const OSSL_PARAM params[]);
+int EVP_PKEY_verify_recover_init_ex2(EVP_PKEY_CTX *pctx,
+                                     EVP_SIGNATURE *algo, const OSSL_PARAM params[]);
+```
+
+New signature setter:
+
+``` C
+int EVP_PKEY_CTX_set_signature(EVP_PKEY_CTX *pctx,
+                               unsigned char *sig, size_t *siglen, size_t sigsize);
+```
+
+Added stream functionality:
+
+``` C
+int EVP_PKEY_verify_update(EVP_PKEY_CTX *ctx, unsigned char *in, size_t *inlen);
+int EVP_PKEY_verify_final(EVP_PKEY_CTX *ctx);
+
+int EVP_PKEY_verify_recover_update(EVP_PKEY_CTX *ctx, unsigned char *in, size_t *inlen);
+int EVP_PKEY_verify_recover_final(EVP_PKEY_CTX *ctx,
+                                  unsigned char *rout, size_t *routlen);
+```
+
+Requirements on the providers
+-----------------------------
+
+Because it's not immediately obvious from a composite algorithm name what
+key type it requires / supports, at least in code, allowing the use of an
+explicitly fetched implementation of a composite algorithm requires that
+providers cooperate by declaring what key type is required / supported by
+each algorithm.
+
+For non-composite operation algorithms (like "RSA"), this is not necessary,
+see the fallback strategies below.
+
+This is to be implemented through an added provider function that would work
+like keymgmt's `query_operation_name` function, but would return a NULL
+terminated array of key type name instead:
+
+``` C
+# define OSSL_FUNC_SIGNATURE_QUERY_KEY_TYPE         26
+OSSL_CORE_MAKE_FUNC(const char **, signature_query_key_type, (void))
+```
+
+Furthermore, the public API above requires added provider functionality:
+
+``` C
+# define OSSL_FUNC_SIGNATURE_SIGN_UPDATE            26
+# define OSSL_FUNC_SIGNATURE_SIGN_FINAL             27
+OSSL_CORE_MAKE_FUNC(int, signature_sign_update, (void *ctx,
+                                                 const unsigned char *in,
+                                                 size_t inlen))
+OSSL_CORE_MAKE_FUNC(int, signature_sign_final, (void *ctx,  unsigned char *sig,
+                                                size_t *siglen, size_t sigsize))
+
+# define OSSL_FUNC_SIGNATURE_VERIFY_UPDATE          28
+# define OSSL_FUNC_SIGNATURE_VERIFY_FINAL           29
+OSSL_CORE_MAKE_FUNC(int, signature_verify_update,
+                    (void *ctx, const unsigned char *in, size_t inlen))
+/*
+ * signature_verify_final requires that the signature to be verified against
+ * is specified via an OSSL_PARAM.
+ */
+OSSL_CORE_MAKE_FUNC(int, signature_verify_final, (void *ctx))
+
+# define OSSL_FUNC_SIGNATURE_VERIFY_RECOVER_UPDATE  30
+# define OSSL_FUNC_SIGNATURE_VERIFY_RECOVER_FINAL   31
+OSSL_CORE_MAKE_FUNC(int, signature_verify_recover_update,
+                    (void *ctx, const unsigned char *in, size_t inlen))
+/*
+ * signature_verify_recover_final requires that the signature to be verified
+ * against is specified via an OSSL_PARAM.
+ */
+OSSL_CORE_MAKE_FUNC(int, signature_verify_recover_final,
+                    (void *ctx, unsigned char *rout, size_t *routlen))
+```
+
+Fallback strategies
+-------------------
+
+Because existing providers haven't been updated to respond to the key type
+query, some fallback strategies will be needed to find out if the `EVP_PKEY`
+key type is possible to use with the fetched algorithm.  This is only
+possible to do with simple (non-composite) algorithms.
+
+-   Check if the fetched operation name matches the key type (keymgmt name)
+    of the `EVP_PKEY` that's involved in the operation.  For example, this
+    is useful when someone fetched the `EVP_SIGNATURE` "RSA".  This requires
+    very little modification, as this is already done with the initializer
+    functions that fetch the algorithm implicitly.
+-   Check if the fetched algorithm name matches the name returned by the
+    keymgmt's `query_operation_name` function.  For example, this is useful
+    when someone fetched the `EVP_SIGNATURE` "ECDSA", for which the key type
+    to use is "EC".  This requires very little modification, as this is
+    already done with the initializer functions that fetch the algorithm
+    implicitly.
+
+If none of these strategies work out, the operation initialization should
+fail.

--- a/doc/designs/functions-for-explicitly-fetched-signature-algorithms.md
+++ b/doc/designs/functions-for-explicitly-fetched-signature-algorithms.md
@@ -110,7 +110,7 @@ int EVP_PKEY_verify_message_update(EVP_PKEY_CTX *ctx,
 int EVP_PKEY_verify_message_final(EVP_PKEY_CTX *ctx);
 
 #define EVP_PKEY_verify_message(ctx,sig,siglen,tbs,tbslen) \
-    EVP_PKEY_sign(ctx,sig,siglen,tbs,tbslen)
+    EVP_PKEY_verify(ctx,sig,siglen,tbs,tbslen)
 ```
 
 ### For verify_recover with `EVP_SIGNATURE`

--- a/doc/designs/functions-for-explicitly-fetched-signature-algorithms.md
+++ b/doc/designs/functions-for-explicitly-fetched-signature-algorithms.md
@@ -128,7 +128,6 @@ int EVP_PKEY_verify_update(EVP_PKEY_CTX *ctx,
 int EVP_PKEY_verify_final(EVP_PKEY_CTX *ctx);
 ```
 
-
 Requirements on the providers
 -----------------------------
 

--- a/doc/designs/functions-for-explicitly-fetched-signature-algorithms.md
+++ b/doc/designs/functions-for-explicitly-fetched-signature-algorithms.md
@@ -45,7 +45,7 @@ Discussions have revealed that it is potentially confusing to confound the
 current functionality with streaming style functionality into the same name,
 so this design separates those out with specific init / update / final
 functions for that purpose.  For oneshot functionality, `EVP_PKEY_sign()`
-and `EVP_PKEY_verify()` remain supported, possibly through an alias for the
+and `EVP_PKEY_verify()` remain supported, through an alias for the
 application.
 
 [^1]: the term "primitive" is borrowed from [PKCS#1](https://www.rfc-editor.org/rfc/rfc8017#section-5)
@@ -80,6 +80,8 @@ int EVP_PKEY_sign_message_update(EVP_PKEY_CTX *ctx,
 int EVP_PKEY_sign_message_final(EVP_PKEY_CTX *ctx,
                                 unsigned char *sig,
                                 size_t *siglen);
+#define EVP_PKEY_sign_message(ctx,sig,siglen,tbs,tbslen) \
+    EVP_PKEY_sign(ctx,sig,siglen,tbs,tbslen)
 ```
 
 ### For limited input size / oneshot verification with `EVP_SIGNATURE`
@@ -106,6 +108,9 @@ int EVP_PKEY_verify_message_update(EVP_PKEY_CTX *ctx,
                                    const unsigned char *in,
                                    size_t inlen);
 int EVP_PKEY_verify_message_final(EVP_PKEY_CTX *ctx);
+
+#define EVP_PKEY_verify_message(ctx,sig,siglen,tbs,tbslen) \
+    EVP_PKEY_sign(ctx,sig,siglen,tbs,tbslen)
 ```
 
 ### For verify_recover with `EVP_SIGNATURE`

--- a/doc/designs/functions-for-explicitly-fetched-signature-algorithms.md
+++ b/doc/designs/functions-for-explicitly-fetched-signature-algorithms.md
@@ -160,22 +160,33 @@ OSSL_CORE_MAKE_FUNC(int, signature_sign_init_for_digest,
                     (void *ctx, void *provkey, const OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(int, signature_sign_init_for_message,
                     (void *ctx, void *provkey, const OSSL_PARAM params[]))
+
+#define OSSL_FUNC_SIGNATURE_VERIFY_INIT_FOR_DIGEST  29
+#define OSSL_FUNC_SIGNATURE_VERIFY_INIT_FOR_MESSAGE 30
+OSSL_CORE_MAKE_FUNC(int, signature_verify_init_for_digest,
+                    (void *ctx, void *provkey, const OSSL_PARAM params[]))
+OSSL_CORE_MAKE_FUNC(int, signature_verify_init_for_message,
+                    (void *ctx, void *provkey, const OSSL_PARAM params[]))
+
+#define OSSL_FUNC_SIGNATURE_VERIFY_RECOVER_INIT_FOR_DIGEST 31
+OSSL_CORE_MAKE_FUNC(int, signature_verify_recover_init_for_digest,
+                    (void *ctx, void *provkey, const OSSL_PARAM params[]))
 ```
 
 Furthermore, the public API above requires added provider functionality,
 which we try to keep to a minimum:
 
 ``` C
-# define OSSL_FUNC_SIGNATURE_SIGN_UPDATE            29
-# define OSSL_FUNC_SIGNATURE_SIGN_FINAL             30
+# define OSSL_FUNC_SIGNATURE_SIGN_UPDATE            32
+# define OSSL_FUNC_SIGNATURE_SIGN_FINAL             33
 OSSL_CORE_MAKE_FUNC(int, signature_sign_update, (void *ctx,
                                                  const unsigned char *in,
                                                  size_t inlen))
 OSSL_CORE_MAKE_FUNC(int, signature_sign_final, (void *ctx,  unsigned char *sig,
                                                 size_t *siglen, size_t sigsize))
 
-# define OSSL_FUNC_SIGNATURE_VERIFY_UPDATE          31
-# define OSSL_FUNC_SIGNATURE_VERIFY_FINAL           32
+# define OSSL_FUNC_SIGNATURE_VERIFY_UPDATE          34
+# define OSSL_FUNC_SIGNATURE_VERIFY_FINAL           35
 OSSL_CORE_MAKE_FUNC(int, signature_verify_update,
                     (void *ctx, const unsigned char *in, size_t inlen))
 /*


### PR DESCRIPTION
This design goes into more details what was outlined in the design for
[fetching composite (PKEY) algorithms and using them].

It also changes what functionality will be used for this.  The design for
signature was originally to add modified initializers for DigestSign and
DigestVerify, but recent OTC discussions redirected us to have a closer look
at `EVP_PKEY_sign()` and `EVP_PKEY_verify()`.

Finally, it also takes into account the need to specify the signature
to be verified against with `EVP_PKEY_verify()` streaming functions,
which has been discussed in #22357.

Related to #22357 (in progress), #22129 (merged), and openssl/project#231

[fetching composite (PKEY) algorithms and using them]:
    https://github.com/openssl/openssl/blob/07c769d8267ae6f9066d76e403accc0b94082d6e/doc/designs/fetching-composite-algorithms.md