### PR TITLE
zero data in hm_fragment on alloc

### DIFF
--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -62,7 +62,7 @@ static hm_fragment *dtls1_hm_fragment_new(size_t frag_len, int reassembly)
     unsigned char *buf = NULL;
     unsigned char *bitmask = NULL;
 
-    if ((frag = OPENSSL_malloc(sizeof(*frag))) == NULL)
+    if ((frag = OPENSSL_zalloc(sizeof(*frag))) == NULL)
         return NULL;
 
     if (frag_len) {


### PR DESCRIPTION
if we allocate a new hm_frament in dtls1_buffer_message with dtls1_hm_fragment_new, the returned fragment contains uninitalized data in the msg_header field.  If an error then occurs, and we free the fragment, dtls_hm_fragment_free interrogates the msg_header field (which is garbage), and potentially references undefined values, or worse, accidentally references available memory that is not owned, leading to various corruptions.

Fixes (potentially) #22664

