### PR TITLE
Enable runtime filtering of asan indirect leaks

### DIFF
--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -216,13 +216,20 @@ $eres = eval {
                             my @asan_array = split("\n", $output_buffer);
                             foreach (@asan_array) {
                                 if ($_ =~ /.*Indirect leak of.*/ == 1) {
+                                    if ($in_indirect != 1) {
+                                        print "::group::Indirect Leaks\n";
+                                    }
                                     $in_indirect = 1;
-                                } else {
+                                }
+                                print "$_\n";
+                                if ($_ =~ /.*Indirect leak of.*/ != 1) {
                                     if ($_ =~ /^    #.*/ == 0) {
+                                        if ($in_indirect != 0) {
+                                            print "\n::endgroup::\n";
+                                        }
                                         $in_indirect = 0;
                                     }
                                 }
-                                print "$_\n" if !$in_indirect;
                             }
                         } else {
                             print $output_buffer if !$is_ok;

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -175,6 +175,7 @@ $eres = eval {
         my $failure_verbosity = $openssl_args{failure_verbosity};
         my @plans = (); # initial level, no plan yet
         my $output_buffer = "";
+        my $in_indirect = 0;
 
         # We rely heavily on perl closures to make failure verbosity work
         # We need to do so, because there's no way to safely pass extra
@@ -211,7 +212,21 @@ $eres = eval {
                         $output_buffer = ""; # ignore comments etc. until plan
                     } elsif ($is_test) { # result of a test
                         pop @plans if @plans && --($plans[-1]) <= 0;
-                        print $output_buffer if !$is_ok;
+                        if ($output_buffer =~ /.*Indirect leak of.*/ == 1) {
+                            my @asan_array = split("\n", $output_buffer);
+                            foreach (@asan_array) {
+                                if ($_ =~ /.*Indirect leak of.*/ == 1) {
+                                    $in_indirect = 1;
+                                } else {
+                                    if ($_ =~ /^    #.*/ == 0) {
+                                        $in_indirect = 0;
+                                    }
+                                }
+                                print "$_\n" if !$in_indirect;
+                            }
+                        } else {
+                            print $output_buffer if !$is_ok;
+                        }
                         print "\n".$self->as_string
                             if !$is_ok || $failure_verbosity == 2;
                         print "\n# ------------------------------------------------------------------------------" if !$is_ok;


### PR DESCRIPTION
There is a request to filter indirect leaks on CI runs to make finding the direct leaks a easier.  Catch asan output and filter indirect leaks when V=0.

Fixes #22303 