### PR TITLE
Move freeing of an old record layer to dtls1_clear_sent_buffer

### DIFF
--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -154,15 +154,15 @@ void dtls1_free(SSL *ssl)
     if (s == NULL)
         return;
 
-    DTLS_RECORD_LAYER_free(&s->rlayer);
-
-    ssl3_free(ssl);
-
     if (s->d1 != NULL) {
         dtls1_clear_queues(s);
         pqueue_free(s->d1->buffered_messages);
         pqueue_free(s->d1->sent_messages);
     }
+
+    DTLS_RECORD_LAYER_free(&s->rlayer);
+
+    ssl3_free(ssl);
 
     OPENSSL_free(s->d1);
     s->d1 = NULL;

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -135,9 +135,9 @@ void dtls1_clear_sent_buffer(SSL_CONNECTION *s)
                 && frag->msg_header.saved_retransmit_state.wrlmethod != NULL
                 && s->rlayer.wrl != frag->msg_header.saved_retransmit_state.wrl) {
             /*
-            * If we're freeing the CCS then we're done with the old wrl and it
-            * can bee freed
-            */
+             * If we're freeing the CCS then we're done with the old wrl and it
+             * can bee freed
+             */
             frag->msg_header.saved_retransmit_state.wrlmethod->free(frag->msg_header.saved_retransmit_state.wrl);
         }
 

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -130,6 +130,17 @@ void dtls1_clear_sent_buffer(SSL_CONNECTION *s)
 
     while ((item = pqueue_pop(s->d1->sent_messages)) != NULL) {
         frag = (hm_fragment *)item->data;
+
+        if (frag->msg_header.is_ccs
+                && frag->msg_header.saved_retransmit_state.wrlmethod != NULL
+                && s->rlayer.wrl != frag->msg_header.saved_retransmit_state.wrl) {
+            /*
+            * If we're freeing the CCS then we're done with the old wrl and it
+            * can bee freed
+            */
+            frag->msg_header.saved_retransmit_state.wrlmethod->free(frag->msg_header.saved_retransmit_state.wrl);
+        }
+
         dtls1_hm_fragment_free(frag);
         pitem_free(item);
     }

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -94,14 +94,7 @@ void dtls1_hm_fragment_free(hm_fragment *frag)
 {
     if (!frag)
         return;
-    if (frag->msg_header.is_ccs) {
-        /*
-         * If we're freeing the CCS then we're done with the old wrl and it
-         * can bee freed
-         */
-        if (frag->msg_header.saved_retransmit_state.wrlmethod != NULL)
-            frag->msg_header.saved_retransmit_state.wrlmethod->free(frag->msg_header.saved_retransmit_state.wrl);
-    }
+
     OPENSSL_free(frag->fragment);
     OPENSSL_free(frag->reassembly);
     OPENSSL_free(frag);

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -62,7 +62,7 @@ static hm_fragment *dtls1_hm_fragment_new(size_t frag_len, int reassembly)
     unsigned char *buf = NULL;
     unsigned char *bitmask = NULL;
 
-    if ((frag = OPENSSL_malloc(sizeof(*frag))) == NULL)
+    if ((frag = OPENSSL_zalloc(sizeof(*frag))) == NULL)
         return NULL;
 
     if (frag_len) {


### PR DESCRIPTION
When we are clearing the sent messages queue we should ensure we free any
old write record layers that are no longer in use. Previously this logic
was in dtls1_hm_fragment_free() - but this can end up freeing the current
record layer under certain error conditions.

Fixes https://github.com/openssl/openssl/issues/22664

We also fix an issue during allocation of a new hm_fragment to ensure the data is initialised (commit from @nhorman originall in PR #22677)

