### PR TITLE
Move freeing of an old enc_write_ctx/write_hash to dtls1_clear_sent_buffer (3.1/3.0)

### DIFF
--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -130,6 +130,23 @@ void dtls1_clear_sent_buffer(SSL *s)
 
     while ((item = pqueue_pop(s->d1->sent_messages)) != NULL) {
         frag = (hm_fragment *)item->data;
+
+        if (frag->msg_header.is_ccs) {
+            /*
+            * If we're freeing the CCS then we're done with the old
+            * enc_write_ctx/write_hash and they can be freed
+            */
+            if (s->enc_write_ctx
+                    != frag->msg_header.saved_retransmit_state.enc_write_ctx)
+                EVP_CIPHER_CTX_free(frag->msg_header.saved_retransmit_state
+                                                    .enc_write_ctx);
+
+            if (s->write_hash
+                    != frag->msg_header.saved_retransmit_state.write_hash)
+                EVP_MD_CTX_free(frag->msg_header.saved_retransmit_state
+                                                .write_hash);
+        }
+
         dtls1_hm_fragment_free(frag);
         pitem_free(item);
     }

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -133,9 +133,9 @@ void dtls1_clear_sent_buffer(SSL *s)
 
         if (frag->msg_header.is_ccs) {
             /*
-            * If we're freeing the CCS then we're done with the old
-            * enc_write_ctx/write_hash and they can be freed
-            */
+             * If we're freeing the CCS then we're done with the old
+             * enc_write_ctx/write_hash and they can be freed
+             */
             if (s->enc_write_ctx
                     != frag->msg_header.saved_retransmit_state.enc_write_ctx)
                 EVP_CIPHER_CTX_free(frag->msg_header.saved_retransmit_state

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1212,8 +1212,6 @@ void SSL_free(SSL *s)
     SSL_SESSION_free(s->psksession);
     OPENSSL_free(s->psksession_id);
 
-    clear_ciphers(s);
-
     ssl_cert_free(s->cert);
     OPENSSL_free(s->shared_sigalgs);
     /* Free up if allocated */
@@ -1248,6 +1246,12 @@ void SSL_free(SSL *s)
 
     if (s->method != NULL)
         s->method->ssl_free(s);
+
+    /*
+     * Must occur after s->method->ssl_free(). The DTLS sent_messages queue
+     * may reference the EVP_CIPHER_CTX/EVP_MD_CTX that are freed here.
+     */
+    clear_ciphers(s);
 
     SSL_CTX_free(s->ctx);
 

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -59,7 +59,7 @@ static hm_fragment *dtls1_hm_fragment_new(size_t frag_len, int reassembly)
     unsigned char *buf = NULL;
     unsigned char *bitmask = NULL;
 
-    if ((frag = OPENSSL_malloc(sizeof(*frag))) == NULL) {
+    if ((frag = OPENSSL_zalloc(sizeof(*frag))) == NULL) {
         ERR_raise(ERR_LIB_SSL, ERR_R_MALLOC_FAILURE);
         return NULL;
     }

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -95,11 +95,7 @@ void dtls1_hm_fragment_free(hm_fragment *frag)
 {
     if (!frag)
         return;
-    if (frag->msg_header.is_ccs) {
-        EVP_CIPHER_CTX_free(frag->msg_header.
-                            saved_retransmit_state.enc_write_ctx);
-        EVP_MD_CTX_free(frag->msg_header.saved_retransmit_state.write_hash);
-    }
+
     OPENSSL_free(frag->fragment);
     OPENSSL_free(frag->reassembly);
     OPENSSL_free(frag);


### PR DESCRIPTION
When we are clearing the sent messages queue we should ensure we free any
old enc_write_ctx/write_hash that are no longer in use. Previously this
logic was in dtls1_hm_fragment_free() - but this can end up freeing the
current enc_write_ctx/write_hash under certain error conditions.
    
Fixes #22664

We also fix an issue during allocation of a new hm_fragment to ensure the data is initialised (commit from @nhorman originall in PR https://github.com/openssl/openssl/pull/22677)