### PR TITLE
Enable AES and SHA3 optimisations on Apple Silicon M3-based macOS systems

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -298,7 +298,8 @@ void OPENSSL_cpuid_setup(void)
             size_t len = sizeof(uarch);
             if ((sysctlbyname("machdep.cpu.brand_string", uarch, &len, NULL, 0) == 0) &&
                ((strncmp(uarch, "Apple M1", 8) == 0) ||
-                (strncmp(uarch, "Apple M2", 8) == 0))) {
+                (strncmp(uarch, "Apple M2", 8) == 0) ||
+                (strncmp(uarch, "Apple M3", 8) == 0))) {
                 OPENSSL_armcap_P |= ARMV8_UNROLL8_EOR3;
                 OPENSSL_armcap_P |= ARMV8_HAVE_SHA3_AND_WORTH_USING;
             }


### PR DESCRIPTION
AES gets a performance enhancement of 19-36%, similar to the M1 and M2.

SHA3 gets an improvement of 4-7% on buffers 256 bytes or larger.

Tested on an M3 Pro, but the CPU cores are the same on M3 and M3 Max.
