### PR TITLE
When abidiff fails print out the XML diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,7 @@ jobs:
     - name: make test
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
-  fips_and_ktls:
+  full_feat_w_abidiff:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -287,9 +287,17 @@ jobs:
         cat /proc/cpuinfo
         ./util/opensslwrap.sh version -c
     - name: Check ABI compatibility for libcrypto
-      run: abidiff ./.github/workflows/libcrypto-abi.xml ./libcrypto.so
+      run: |
+        if ! abidiff ./.github/workflows/libcrypto-abi.xml ./libcrypto.so ; then
+          abidw --out-file libcrypto-abi-new.xml ./libcrypto.so
+          diff -u ./.github/workflows/libcrypto-abi.xml libcrypto-abi-new.xml
+        fi
     - name: Check ABI compatibility for libssl
-      run: abidiff ./.github/workflows/libssl-abi.xml ./libssl.so
+      run: |
+        if ! abidiff ./.github/workflows/libssl-abi.xml ./libssl.so ; then
+          abidw --out-file libssl-abi-new.xml ./libssl.so
+          diff -u ./.github/workflows/libssl-abi.xml libssl-abi-new.xml
+        fi
     - name: make test
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 


### PR DESCRIPTION
This can be useful for fixing the CI if needed
without the necessity to run abidw locally.

Also rename the CI job to make its purpose clearer.
