### PR TITLE
Force Nonstop to use fcntl(F_GETFL) in BIO_sock_nbio

### DIFF
--- a/crypto/bio/bio_sock.c
+++ b/crypto/bio/bio_sock.c
@@ -354,7 +354,7 @@ int BIO_socket_nbio(int s, int mode)
     int l;
 
     l = mode;
-# ifdef FIONBIO
+# if defined(FIONBIO) && !defined(OPENSSL_SYS_TANDEM)
     l = mode;
 
     ret = BIO_socket_ioctl(s, FIONBIO, &l);


### PR DESCRIPTION
In tracking down a hang, we found that nonstop platforms were falling into the if #ifdef FIONBIO clause in the implementation of BIO_sock_nbio.  While the platform defines this macro, sockets set with this continued to operate in blocking mode.  Given that the platform also support O_NONBLOCK, adjust the ifdef to have the nonstop platform use that method to ensure that sockets enter blocking mode

Related-To #22588

