### PR TITLE
Correct 50-nonstop.conf to support QUIC tests under SPT threading models

### DIFF
--- a/Configurations/50-nonstop.conf
+++ b/Configurations/50-nonstop.conf
@@ -172,8 +172,10 @@
     },
     'nonstop-model-spt' => {
         template         => 1,
+        cflags           => add('-Wnowarn=140'),
         defines          => ['_SPT_MODEL_',
-                             '_REENTRANT', '_ENABLE_FLOSS_THREADS'],
+                             'SPT_THREAD_AWARE_NONBLOCK',
+                             '_REENTRANT'],
         ex_libs          => '-lspt',
     },
 
@@ -182,7 +184,7 @@
     # disable threads.
     'nonstop-model-floss' => {
         template         => 1,
-        defines          => ['OPENSSL_TANDEM_FLOSS'],
+        defines          => ['OPENSSL_TANDEM_FLOSS', '_ENABLE_FLOSS_THREADS'],
         includes         => ['/usr/local/include'],
         ex_libs          => '-lfloss',
     },


### PR DESCRIPTION
This fix also separates the FLOSS from SPT configurations which should not have been conflated in the 3.0 series.

Related-to: #22588