### PR TITLE
Fix to expected bool type in clash compiled void

### DIFF
--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -997,9 +997,13 @@ int BN_security_bits(int L, int N)
 
 void* BN_zero_ex(BIGNUM *a)
 {
-    a->neg = 0;
-    a->top = 0;
-    a->flags &= ~BN_FLG_FIXED_TOP;
+    if (a != NULL)
+    {
+        a->neg = 0;
+        a->top = 0;
+        a->flags &= ~BN_FLG_FIXED_TOP;
+    }
+    return a;
 }
 
 int BN_abs_is_word(const BIGNUM *a, const BN_ULONG w)

--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -995,7 +995,7 @@ int BN_security_bits(int L, int N)
     return bits >= secbits ? secbits : bits;
 }
 
-void BN_zero_ex(BIGNUM *a)
+void* BN_zero_ex(BIGNUM *a)
 {
     a->neg = 0;
     a->top = 0;

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -196,7 +196,7 @@ int BN_is_odd(const BIGNUM *a);
 
 # define BN_one(a)       (BN_set_word((a),1))
 
-bool BN_zero_ex(BIGNUM *a);
+void* BN_zero_ex(BIGNUM *a);
 
 # if OPENSSL_API_LEVEL > 908
 #  define BN_zero(a)      BN_zero_ex(a)

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -196,7 +196,7 @@ int BN_is_odd(const BIGNUM *a);
 
 # define BN_one(a)       (BN_set_word((a),1))
 
-void BN_zero_ex(BIGNUM *a);
+bool BN_zero_ex(BIGNUM *a);
 
 # if OPENSSL_API_LEVEL > 908
 #  define BN_zero(a)      BN_zero_ex(a)


### PR DESCRIPTION
compiling crash at

```cpp
/home/ibraries/fc/src/crypto/elliptic_r1.cpp:119:14: error: could not convert 'BN_zero_ex(zero)' from 'void' to 'bool'
  119 |         if (!BN_zero(zero)) { ret=-1; goto err; }
      |              ^~~~~~~
      |              |
      |              void
```

expecting a bool type instead of void, looks like working after updating

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
