### PR TITLE
Fix BLAKE2s reporting the same EVP_MD_get_size() as BLAKE2b (64)

### DIFF
--- a/providers/implementations/digests/blake2_prov.c
+++ b/providers/implementations/digests/blake2_prov.c
@@ -160,7 +160,7 @@ static int blake##variantsize##_internal_final(void *ctx, unsigned char *out, \
  \
 static int blake##variantsize##_get_params(OSSL_PARAM params[]) \
 { \
-    return ossl_digest_default_get_params(params, BLAKE##VARIANT##_BLOCKBYTES, 64, 0); \
+    return ossl_digest_default_get_params(params, BLAKE##VARIANT##_BLOCKBYTES, BLAKE##VARIANT##_OUTBYTES, 0); \
 } \
  \
 const OSSL_DISPATCH ossl_blake##variantsize##_functions[] = { \

--- a/test/recipes/30-test_evp_data/evpkdf_hkdf.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_hkdf.txt
@@ -213,3 +213,11 @@ Ctrl.info = hexinfo:c1c2c3
 Ctrl.info = hexinfo:c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9
 Ctrl.info = hexinfo:dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
 Output = 0bd770a74d1160f7c9f12cd5912a06ebff6adcae899d92191fe4305673ba2ffe8fa3f1a4e5ad79f3f334b3b202b2173c486ea37ce3d397ed034c7f9dfeb15c5e927336d0441f4c4300e2cff0d0900b52d3b4
+
+Availablein = default
+KDF = HKDF
+Ctrl.digest = digest:BLAKE2S-256
+Ctrl.IKM = hexkey:1a2d
+Ctrl.salt = hexsalt:000000000000000000000000000000000000000000000000000000000000000000
+Ctrl.info = info:
+Output = 62f99231760bedd72319cc6cad


### PR DESCRIPTION
Fixes: commit 6d1e730a1ea2c64bdffa88c6b3bee4c3f5bed602 ("Implement BLAKE2s with the same macro as BLAKE2b")
Closes: #22708