### PR TITLE
Keep track of connection credit as we add stream data

### DIFF
--- a/include/internal/quic_fc.h
+++ b/include/internal/quic_fc.h
@@ -61,16 +61,18 @@ int ossl_quic_txfc_bump_cwm(QUIC_TXFC *txfc, uint64_t cwm);
  *
  * If called on a stream-level TXFC, ossl_quic_txfc_get_credit is called on
  * the connection-level TXFC as well, and the lesser of the two values is
- * returned.
+ * returned. The consumed value is the amount already consumed on the connection
+ * level TXFC.
  */
-uint64_t ossl_quic_txfc_get_credit(QUIC_TXFC *txfc);
+uint64_t ossl_quic_txfc_get_credit(QUIC_TXFC *txfc, uint64_t consumed);
 
 /*
  * Like ossl_quic_txfc_get_credit(), but when called on a stream-level TXFC,
  * retrieves only the stream-level credit value and does not clamp it based on
- * connection-level flow control.
+ * connection-level flow control. Any credit value is reduced by the consumed
+ * amount.
  */
-uint64_t ossl_quic_txfc_get_credit_local(QUIC_TXFC *txfc);
+uint64_t ossl_quic_txfc_get_credit_local(QUIC_TXFC *txfc, uint64_t consumed);
 
 /*
  * Consume num_bytes of credit. This is the 'On TX' operation. This should be

--- a/ssl/quic/quic_stream_map.c
+++ b/ssl/quic/quic_stream_map.c
@@ -269,7 +269,7 @@ static int stream_has_data_to_send(QUIC_STREAM *s)
                                             &num_iov))
         return 0;
 
-    fc_credit = ossl_quic_txfc_get_credit(&s->txfc);
+    fc_credit = ossl_quic_txfc_get_credit(&s->txfc, 0);
     fc_swm    = ossl_quic_txfc_get_swm(&s->txfc);
     fc_limit  = fc_swm + fc_credit;
 

--- a/test/quic_fc_test.c
+++ b/test/quic_fc_test.c
@@ -40,9 +40,16 @@ static int test_txfc(int is_stream)
     if (!TEST_uint64_t_eq(ossl_quic_txfc_get_credit_local(txfc, 0), 2000))
         goto err;
 
-    if (is_stream && !TEST_uint64_t_eq(ossl_quic_txfc_get_credit(txfc, 0),
-                                       2000))
+    if (!TEST_uint64_t_eq(ossl_quic_txfc_get_credit_local(txfc, 100), 1900))
         goto err;
+
+    if (is_stream) {
+        if ( !TEST_uint64_t_eq(ossl_quic_txfc_get_credit(txfc, 0), 2000))
+            goto err;
+
+        if ( !TEST_uint64_t_eq(ossl_quic_txfc_get_credit(txfc, 100), 1900))
+            goto err;
+    }
 
     if (!TEST_false(ossl_quic_txfc_has_become_blocked(txfc, 0)))
         goto err;
@@ -138,6 +145,9 @@ static int test_txfc(int is_stream)
         ossl_quic_txfc_has_become_blocked(parent_txfc, 1);
 
     if (is_stream) {
+        if (!TEST_uint64_t_eq(ossl_quic_txfc_get_credit(txfc, 400), 0))
+            goto err;
+
         if (!TEST_true(ossl_quic_txfc_consume_credit(txfc, 399)))
             goto err;
 

--- a/test/quic_fc_test.c
+++ b/test/quic_fc_test.c
@@ -37,10 +37,10 @@ static int test_txfc(int is_stream)
     if (!TEST_uint64_t_eq(ossl_quic_txfc_get_cwm(txfc), 2000))
         goto err;
 
-    if (!TEST_uint64_t_eq(ossl_quic_txfc_get_credit_local(txfc), 2000))
+    if (!TEST_uint64_t_eq(ossl_quic_txfc_get_credit_local(txfc, 0), 2000))
         goto err;
 
-    if (is_stream && !TEST_uint64_t_eq(ossl_quic_txfc_get_credit(txfc),
+    if (is_stream && !TEST_uint64_t_eq(ossl_quic_txfc_get_credit(txfc, 0),
                                        2000))
         goto err;
 
@@ -50,10 +50,10 @@ static int test_txfc(int is_stream)
     if (!TEST_true(ossl_quic_txfc_consume_credit(txfc, 500)))
         goto err;
 
-    if (!TEST_uint64_t_eq(ossl_quic_txfc_get_credit_local(txfc), 1500))
+    if (!TEST_uint64_t_eq(ossl_quic_txfc_get_credit_local(txfc, 0), 1500))
         goto err;
 
-    if (is_stream && !TEST_uint64_t_eq(ossl_quic_txfc_get_credit(txfc),
+    if (is_stream && !TEST_uint64_t_eq(ossl_quic_txfc_get_credit(txfc, 0),
                                        1500))
         goto err;
 
@@ -69,10 +69,10 @@ static int test_txfc(int is_stream)
     if (!TEST_uint64_t_eq(ossl_quic_txfc_get_swm(txfc), 600))
         goto err;
 
-    if (!TEST_uint64_t_eq(ossl_quic_txfc_get_credit_local(txfc), 1400))
+    if (!TEST_uint64_t_eq(ossl_quic_txfc_get_credit_local(txfc, 0), 1400))
         goto err;
 
-    if (is_stream && !TEST_uint64_t_eq(ossl_quic_txfc_get_credit(txfc),
+    if (is_stream && !TEST_uint64_t_eq(ossl_quic_txfc_get_credit(txfc, 0),
                                        1400))
         goto err;
 
@@ -82,10 +82,10 @@ static int test_txfc(int is_stream)
     if (!TEST_true(ossl_quic_txfc_consume_credit(txfc, 1400)))
         goto err;
 
-    if (!TEST_uint64_t_eq(ossl_quic_txfc_get_credit_local(txfc), 0))
+    if (!TEST_uint64_t_eq(ossl_quic_txfc_get_credit_local(txfc, 0), 0))
         goto err;
 
-    if (is_stream && !TEST_uint64_t_eq(ossl_quic_txfc_get_credit(txfc),
+    if (is_stream && !TEST_uint64_t_eq(ossl_quic_txfc_get_credit(txfc, 0),
                                        0))
         goto err;
 
@@ -131,7 +131,7 @@ static int test_txfc(int is_stream)
     if (!TEST_uint64_t_eq(ossl_quic_txfc_get_swm(txfc), 2000))
         goto err;
 
-    if (!TEST_uint64_t_eq(ossl_quic_txfc_get_credit_local(txfc), 500))
+    if (!TEST_uint64_t_eq(ossl_quic_txfc_get_credit_local(txfc, 0), 500))
         goto err;
 
     if (is_stream)
@@ -144,7 +144,7 @@ static int test_txfc(int is_stream)
         if (!TEST_false(ossl_quic_txfc_has_become_blocked(txfc, 0)))
             goto err;
 
-        if (!TEST_uint64_t_eq(ossl_quic_txfc_get_credit(txfc), 1))
+        if (!TEST_uint64_t_eq(ossl_quic_txfc_get_credit(txfc, 0), 1))
             goto err;
 
         if (!TEST_true(ossl_quic_txfc_consume_credit(txfc, 1)))


### PR DESCRIPTION
If a single packet contains data from multiple streams we need to keep track
of the cummulative connection level credit consumed across all of the
streams. Once the connection level credit has been consumed we must stop
adding stream data.

Fixes https://github.com/openssl/openssl/issues/22706
