### PR TITLE
Fix comparison on 'next' parameter of SHA3_squeeze on PPC64

### DIFF
--- a/crypto/sha/asm/keccak1600-ppc64.pl
+++ b/crypto/sha/asm/keccak1600-ppc64.pl
@@ -668,8 +668,8 @@ SHA3_squeeze:
 	subi	$out,r4,1		; prepare for stbu
 	mr	$len,r5
 	mr	$bsz,r6
-	${UCMP}i r7,1                   ; r7 = 'next' argument
-	blt	.Lnext_block
+	${UCMP}i r7,0                   ; r7 = 'next' argument
+	bne	.Lnext_block
 	b	.Loop_squeeze
 
 .align	4


### PR DESCRIPTION
Fix the conditional on the 'next' parameter passed into SHA3_squeeze.

Link:
https://github.com/openssl/openssl/pull/21511/files#diff-349e3b57acb56d14cf60df5b53d6ab659b628e9f83c43b5c4140198ec692f12f