### PR TITLE
Configure: do not check for an absolute prefix in cross-builds

### DIFF
--- a/Configure
+++ b/Configure
@@ -980,8 +980,6 @@ while (@argvcopy)
                 if (/^--prefix=(.*)$/)
                         {
                         $config{prefix}=$1;
-                        die "Directory given with --prefix MUST be absolute\n"
-                                unless file_name_is_absolute($config{prefix});
                         }
                 elsif (/^--api=(.*)$/)
                         {
@@ -1439,6 +1437,11 @@ foreach (keys %useradd) {
 }
 # At this point, we can forget everything about %user and %useradd,
 # because it's now all been merged into the corresponding $config entry
+
+if ($config{prefix} && !$config{CROSS_COMPILE}) {
+    die "Directory given with --prefix MUST be absolute\n"
+        unless file_name_is_absolute($config{prefix});
+}
 
 if (grep { $_ =~ /(?:^|\s)-static(?:\s|$)/ } @{$config{LDFLAGS}}) {
     disable('static', 'pic', 'threads');


### PR DESCRIPTION
The check is always made according to the host platform's rules, which may not be true for true when the target platform is different, e.g. when cross-building for Windows on a Linux machine. So skip this check when used together with the `--cross-compile-prefix=` option.

Fixes https://github.com/openssl/openssl/issues/9520
