### PR TITLE
NOTES-WINDOWS: fix named anchor links in table of contents

### DIFF
--- a/NOTES-WINDOWS.md
+++ b/NOTES-WINDOWS.md
@@ -1,9 +1,9 @@
 Notes for Windows platforms
 ===========================
 
- - [Native builds using Visual C++](#native-builds-using-visual-c++)
+ - [Native builds using Visual C++](#native-builds-using-visual-c)
  - [Native builds using Embarcadero C++Builder](
-   #native-builds-using-embarcadero-c++-builder)
+   #native-builds-using-embarcadero-cbuilder)
  - [Native builds using MinGW](#native-builds-using-mingw)
  - [Linking native applications](#linking-native-applications)
  - [Hosted builds using Cygwin](#hosted-builds-using-cygwin)


### PR DESCRIPTION
Those links were probably broken by some changes to the sanitizer of the [github/markup] module.

[github/markup]: https://github.com/github/markup/#github-markup


*You can test it for yourself in your browser:*
- [NOTES-WINDOWS (master, broken)](https://github.com/mspncp/openssl/blob/master/NOTES-WINDOWS.md)
- [NOTES-WINDOWS (this pull request, fixed)](https://github.com/mspncp/openssl/blob/5610dc86a85c9f84b3abb92d71f9d1fd4abbd944/NOTES-WINDOWS.md) 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
