### PR TITLE
Adding interop tests

### DIFF
--- a/.github/workflows/interop-tests.yml
+++ b/.github/workflows/interop-tests.yml
@@ -1,3 +1,8 @@
+# Notes:
+# /__w/openssl is the path that github bind-mounts into the container so the ci
+# filesystem for this job can be reached.  Please note that any changes made to
+# this job involving file system paths should be made prefixed with, or relative
+# to that directory
 name: Interoperability tests with GnuTLS and NSS
 on:
   schedule:

--- a/.github/workflows/interop-tests.yml
+++ b/.github/workflows/interop-tests.yml
@@ -1,0 +1,44 @@
+name: Interoperability tests with GnuTLS and NSS
+on: [pull_request, push]
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    container:
+      image: docker.io/fedora:39
+      options: --sysctl net.ipv6.conf.lo.disable_ipv6=0
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        COMPONENT: [openssl-upstream-gnutls, openssl-upstream-nss]
+    env:
+      COMPONENT: ${{ matrix.COMPONENT }}
+    # Code below inspired by https://fedoramagazine.org/github-actions-use-podman-to-run-fedora-linux/
+    steps:
+      - uses: actions/checkout@v4
+      - name : Install needed tools
+        run: |
+          dnf -y install perl gcc rpmdevtools dnf-utils make tmt-all beakerlib \
+                 fips-mode-setup crypto-policies-scripts
+      - name: install interop tests
+        run: |
+          cd /__w/openssl/openssl
+          git clone --branch=openssl --depth=1 https://gitlab.com/redhat-crypto/tests/interop.git
+      - name: build openssl as an rpm
+        run: |
+          mkdir -p /build/SPECS && cd /build && echo -e "%_topdir /build\n%_lto_cflags %{nil}" >~/.rpmmacros && rpmdev-setuptree
+          cd /build && cp /__w/openssl/openssl/interop/openssl.spec SPECS/ && \
+          cd SPECS/ && source /__w/openssl/openssl/VERSION.dat && \
+          sed -i "s/^Version: .*\$/Version: $MAJOR.$MINOR.$PATCH/" openssl.spec && \
+          sed -i 's/^Release: .*$/Release: dev/' openssl.spec
+          yum-builddep -y /build/SPECS/openssl.spec # just for sure nothing is missing
+          mkdir -p /build/SOURCES
+          tar --transform "s/^__w\/openssl\/openssl/openssl-$MAJOR.$MINOR.$PATCH/" -czf /build/SOURCES/openssl-$MAJOR.$MINOR.$PATCH.tar.gz /__w/openssl/openssl/
+          rpmbuild -bb /build/SPECS/openssl.spec
+          dnf install -y /build/RPMS/x86_64/openssl-*
+      - name: Run interop tests
+        run: |
+          cd interop
+          tmt run -av plans -n $COMPONENT tests -f "tag: interop-openssl" provision -h local execute -h tmt --interactive
+          openssl version
+          echo "Finished - important to prevent unwanted output truncating"

--- a/.github/workflows/interop-tests.yml
+++ b/.github/workflows/interop-tests.yml
@@ -1,5 +1,5 @@
 name: Interoperability tests with GnuTLS and NSS
-on: [pull_request, push]
+on: [push]
 jobs:
   test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/interop-tests.yml
+++ b/.github/workflows/interop-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        COMPONENT: [openssl-upstream-gnutls, openssl-upstream-nss]
+        COMPONENT: [gnutls, nss]
     env:
       COMPONENT: ${{ matrix.COMPONENT }}
     # Code below inspired by https://fedoramagazine.org/github-actions-use-podman-to-run-fedora-linux/
@@ -39,6 +39,6 @@ jobs:
       - name: Run interop tests
         run: |
           cd interop
-          tmt run -av plans -n $COMPONENT tests -f "tag: interop-openssl" provision -h local execute -h tmt --interactive
+          tmt run -av plans -n interop tests -f "tag: interop-openssl & tag: interop-$COMPONENT" provision -h local execute -h tmt --interactive
           openssl version
           echo "Finished - important to prevent unwanted output truncating"

--- a/.github/workflows/interop-tests.yml
+++ b/.github/workflows/interop-tests.yml
@@ -15,7 +15,6 @@ jobs:
         COMPONENT: [gnutls, nss]
     env:
       COMPONENT: ${{ matrix.COMPONENT }}
-    # Code below inspired by https://fedoramagazine.org/github-actions-use-podman-to-run-fedora-linux/
     steps:
       - uses: actions/checkout@v4
       - name : Install needed tools

--- a/.github/workflows/interop-tests.yml
+++ b/.github/workflows/interop-tests.yml
@@ -1,5 +1,7 @@
 name: Interoperability tests with GnuTLS and NSS
-on: [push]
+on:
+  schedule:
+    - cron: '0 6 * * *'
 jobs:
   test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/interop-tests.yml
+++ b/.github/workflows/interop-tests.yml
@@ -22,19 +22,21 @@ jobs:
       COMPONENT: ${{ matrix.COMPONENT }}
     steps:
       - uses: actions/checkout@v4
+      - name: Display environment
+        run: export
       - name : Install needed tools
         run: |
           dnf -y install perl gcc rpmdevtools dnf-utils make tmt-all beakerlib \
                  fips-mode-setup crypto-policies-scripts
       - name: install interop tests
         run: |
-          cd /__w/openssl/openssl
+          cd ${GITHUB_WORKSPACE}
           git clone --branch=openssl --depth=1 https://gitlab.com/redhat-crypto/tests/interop.git
       - name: build openssl as an rpm
         run: |
           mkdir -p /build/SPECS && cd /build && echo -e "%_topdir /build\n%_lto_cflags %{nil}" >~/.rpmmacros && rpmdev-setuptree
-          cd /build && cp /__w/openssl/openssl/interop/openssl.spec SPECS/ && \
-          cd SPECS/ && source /__w/openssl/openssl/VERSION.dat && \
+          cd /build && cp ${GITHUB_WORKSPACE}/interop/openssl.spec SPECS/ && \
+          cd SPECS/ && source ${GITHUB_WORKSPACE}/VERSION.dat && \
           sed -i "s/^Version: .*\$/Version: $MAJOR.$MINOR.$PATCH/" openssl.spec && \
           sed -i 's/^Release: .*$/Release: dev/' openssl.spec
           yum-builddep -y /build/SPECS/openssl.spec # just for sure nothing is missing


### PR DESCRIPTION
Fedora has some fairly nice interoperability tests that we can leverage  to build a PR and test it against gnutls and nss libraries.  This PR adds the interop-tests.yml ci job to do that work, and runs the interop tests from beaker.

Fixes #20685 