### PR TITLE
cms demos: print signingTime attributes (3.1)

### DIFF
--- a/demos/bio/client-arg.c
+++ b/demos/bio/client-arg.c
@@ -22,6 +22,7 @@ int main(int argc, char **argv)
     char **args = argv + 1;
     const char *connect_str = "localhost:4433";
     int nargs = argc - 1;
+    int ret = EXIT_FAILURE;
 
     ctx = SSL_CTX_new(TLS_client_method());
     cctx = SSL_CONF_CTX_new();
@@ -100,9 +101,10 @@ int main(int argc, char **argv)
             break;
         BIO_write(out, tmpbuf, len);
     }
+    ret = EXIT_SUCCESS;
  end:
     SSL_CONF_CTX_free(cctx);
     BIO_free_all(sbio);
     BIO_free(out);
-    return 0;
+    return ret;
 }

--- a/demos/bio/client-conf.c
+++ b/demos/bio/client-conf.c
@@ -25,6 +25,7 @@ int main(int argc, char **argv)
     CONF_VALUE *cnf;
     const char *connect_str = "localhost:4433";
     long errline = -1;
+    int ret = EXIT_FAILURE;
 
     conf = NCONF_new(NULL);
 
@@ -108,10 +109,12 @@ int main(int argc, char **argv)
             break;
         BIO_write(out, tmpbuf, len);
     }
+    ret = EXIT_SUCCESS;
+
  end:
     SSL_CONF_CTX_free(cctx);
     BIO_free_all(sbio);
     BIO_free(out);
     NCONF_free(conf);
-    return 0;
+    return ret;
 }

--- a/demos/cipher/aesccm.c
+++ b/demos/cipher/aesccm.c
@@ -229,10 +229,10 @@ err:
 int main(int argc, char **argv)
 {
     if (!aes_ccm_encrypt())
-        return 1;
+        return EXIT_FAILURE;
 
     if (!aes_ccm_decrypt())
-        return 1;
+        return EXIT_FAILURE;
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/demos/cipher/aesgcm.c
+++ b/demos/cipher/aesgcm.c
@@ -219,10 +219,10 @@ err:
 int main(int argc, char **argv)
 {
     if (!aes_gcm_encrypt())
-        return 1;
+        return EXIT_FAILURE;
 
     if (!aes_gcm_decrypt())
-        return 1;
+        return EXIT_FAILURE;
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/demos/cipher/aeskeywrap.c
+++ b/demos/cipher/aeskeywrap.c
@@ -171,11 +171,10 @@ err:
 int main(int argc, char **argv)
 {
     if (!aes_wrap_encrypt())
-       return 1;
+       return EXIT_FAILURE;
 
     if (!aes_wrap_decrypt())
-        return 1;
+        return EXIT_FAILURE;
 
-    return 0;
+    return EXIT_SUCCESS;
 }
-

--- a/demos/cipher/ariacbc.c
+++ b/demos/cipher/ariacbc.c
@@ -169,10 +169,10 @@ err:
 int main(int argc, char **argv)
 {
     if (!aria_cbc_encrypt())
-       return 1;
+        return EXIT_FAILURE;
 
     if (!aria_cbc_decrypt())
-        return 1;
+        return EXIT_FAILURE;
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/demos/cms/Makefile
+++ b/demos/cms/Makefile
@@ -1,0 +1,35 @@
+#
+# To run the demos when linked with a shared library (default) ensure that
+# libcrypto is on the library path. For example, to run the
+# cms_enc demo:
+#
+#    LD_LIBRARY_PATH=../.. ./cms_enc
+
+TESTS = cms_comp \
+        cms_ddec \
+        cms_dec \
+        cms_denc \
+        cms_enc \
+        cms_sign \
+        cms_sign2 \
+        cms_uncomp \
+        cms_ver
+
+CFLAGS  = -I../../include -g
+LDFLAGS = -L../..
+LDLIBS  = -lcrypto
+
+all: $(TESTS)
+
+clean:
+	$(RM) $(TESTS) *.o
+
+cms_%: cms_%.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o "$@" "$<" $(LDLIBS)
+
+test: all
+	@echo "\nCMS tests:"
+	LD_LIBRARY_PATH=../.. ./cms_enc
+	LD_LIBRARY_PATH=../.. ./cms_dec
+	LD_LIBRARY_PATH=../.. ./cms_sign2
+	LD_LIBRARY_PATH=../.. ./cms_ver

--- a/demos/cms/cms_comp.c
+++ b/demos/cms/cms_comp.c
@@ -16,7 +16,7 @@ int main(int argc, char **argv)
 {
     BIO *in = NULL, *out = NULL;
     CMS_ContentInfo *cms = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     /*
      * On OpenSSL 1.0.0+ only:
@@ -48,11 +48,11 @@ int main(int argc, char **argv)
     if (!SMIME_write_CMS(out, cms, in, flags))
         goto err;
 
-    ret = 0;
+    ret = EXIT_SUCCESS;
 
  err:
 
-    if (ret) {
+    if (ret != EXIT_SUCCESS) {
         fprintf(stderr, "Error Compressing Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/cms/cms_ddec.c
+++ b/demos/cms/cms_ddec.c
@@ -21,7 +21,7 @@ int main(int argc, char **argv)
     X509 *rcert = NULL;
     EVP_PKEY *rkey = NULL;
     CMS_ContentInfo *cms = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
@@ -68,11 +68,11 @@ int main(int argc, char **argv)
     if (!CMS_decrypt(cms, rkey, rcert, dcont, out, 0))
         goto err;
 
-    ret = 0;
+    ret = EXIT_SUCCESS;
 
  err:
 
-    if (ret) {
+    if (ret != EXIT_SUCCESS) {
         fprintf(stderr, "Error Decrypting Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/cms/cms_dec.c
+++ b/demos/cms/cms_dec.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     X509 *rcert = NULL;
     EVP_PKEY *rkey = NULL;
     CMS_ContentInfo *cms = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
@@ -59,11 +59,10 @@ int main(int argc, char **argv)
     if (!CMS_decrypt(cms, rkey, rcert, NULL, out, 0))
         goto err;
 
-    ret = 0;
+    ret = EXIT_SUCCESS;
 
  err:
-
-    if (ret) {
+    if (ret != EXIT_SUCCESS) {
         fprintf(stderr, "Error Decrypting Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/cms/cms_dec.c
+++ b/demos/cms/cms_dec.c
@@ -59,6 +59,8 @@ int main(int argc, char **argv)
     if (!CMS_decrypt(cms, rkey, rcert, NULL, out, 0))
         goto err;
 
+    printf("Decryption Successful\n");
+
     ret = EXIT_SUCCESS;
 
  err:

--- a/demos/cms/cms_denc.c
+++ b/demos/cms/cms_denc.c
@@ -21,7 +21,7 @@ int main(int argc, char **argv)
     X509 *rcert = NULL;
     STACK_OF(X509) *recips = NULL;
     CMS_ContentInfo *cms = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     int flags = CMS_STREAM | CMS_DETACHED;
 
@@ -77,11 +77,9 @@ int main(int argc, char **argv)
     if (!PEM_write_bio_CMS(out, cms))
         goto err;
 
-    ret = 0;
-
+    ret = EXIT_SUCCESS;
  err:
-
-    if (ret) {
+    if (ret != EXIT_SUCCESS) {
         fprintf(stderr, "Error Encrypting Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/cms/cms_enc.c
+++ b/demos/cms/cms_enc.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     X509 *rcert = NULL;
     STACK_OF(X509) *recips = NULL;
     CMS_ContentInfo *cms = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     /*
      * On OpenSSL 1.0.0 and later only:
@@ -73,11 +73,9 @@ int main(int argc, char **argv)
     if (!SMIME_write_CMS(out, cms, in, flags))
         goto err;
 
-    ret = 0;
-
+    ret = EXIT_SUCCESS;
  err:
-
-    if (ret) {
+    if (ret != EXIT_SUCCESS) {
         fprintf(stderr, "Error Encrypting Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/cms/cms_enc.c
+++ b/demos/cms/cms_enc.c
@@ -73,6 +73,8 @@ int main(int argc, char **argv)
     if (!SMIME_write_CMS(out, cms, in, flags))
         goto err;
 
+    printf("Encryption Successful\n");
+
     ret = EXIT_SUCCESS;
  err:
     if (ret != EXIT_SUCCESS) {

--- a/demos/cms/cms_sign.c
+++ b/demos/cms/cms_sign.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     X509 *scert = NULL;
     EVP_PKEY *skey = NULL;
     CMS_ContentInfo *cms = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     /*
      * For simple S/MIME signing use CMS_DETACHED. On OpenSSL 1.0.0 only: for
@@ -69,11 +69,9 @@ int main(int argc, char **argv)
     if (!SMIME_write_CMS(out, cms, in, flags))
         goto err;
 
-    ret = 0;
-
+    ret = EXIT_SUCCESS;
  err:
-
-    if (ret) {
+    if (ret != EXIT_SUCCESS) {
         fprintf(stderr, "Error Signing Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/cms/cms_sign2.c
+++ b/demos/cms/cms_sign2.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     X509 *scert = NULL, *scert2 = NULL;
     EVP_PKEY *skey = NULL, *skey2 = NULL;
     CMS_ContentInfo *cms = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
@@ -77,11 +77,9 @@ int main(int argc, char **argv)
     if (!SMIME_write_CMS(out, cms, in, CMS_STREAM))
         goto err;
 
-    ret = 0;
-
+    ret = EXIT_SUCCESS;
  err:
-
-    if (ret) {
+    if (ret != EXIT_SUCCESS) {
         fprintf(stderr, "Error Signing Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/cms/cms_sign2.c
+++ b/demos/cms/cms_sign2.c
@@ -77,6 +77,8 @@ int main(int argc, char **argv)
     if (!SMIME_write_CMS(out, cms, in, CMS_STREAM))
         goto err;
 
+    printf("Signing Successful\n");
+
     ret = EXIT_SUCCESS;
  err:
     if (ret != EXIT_SUCCESS) {

--- a/demos/cms/cms_uncomp.c
+++ b/demos/cms/cms_uncomp.c
@@ -16,7 +16,7 @@ int main(int argc, char **argv)
 {
     BIO *in = NULL, *out = NULL;
     CMS_ContentInfo *cms = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
@@ -42,11 +42,9 @@ int main(int argc, char **argv)
     if (!CMS_uncompress(cms, out, NULL, 0))
         goto err;
 
-    ret = 0;
-
+    ret = EXIT_SUCCESS;
  err:
-
-    if (ret) {
+    if (ret != EXIT_SUCCESS) {
         fprintf(stderr, "Error Uncompressing Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/cms/cms_ver.c
+++ b/demos/cms/cms_ver.c
@@ -18,8 +18,7 @@ int main(int argc, char **argv)
     X509_STORE *st = NULL;
     X509 *cacert = NULL;
     CMS_ContentInfo *cms = NULL;
-
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
@@ -69,11 +68,9 @@ int main(int argc, char **argv)
 
     fprintf(stderr, "Verification Successful\n");
 
-    ret = 0;
-
+    ret = EXIT_SUCCESS;
  err:
-
-    if (ret) {
+    if (ret != EXIT_SUCCESS) {
         fprintf(stderr, "Error Verifying Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/digest/BIO_f_md.c
+++ b/demos/digest/BIO_f_md.c
@@ -36,15 +36,14 @@
 
 int main(int argc, char * argv[])
 {
-    int result = 1;
+    int ret = EXIT_FAILURE;
     OSSL_LIB_CTX *library_context = NULL;
     BIO *input = NULL;
-    BIO *bio_digest = NULL;
+    BIO *bio_digest = NULL, *reading = NULL;
     EVP_MD *md = NULL;
     unsigned char buffer[512];
-    size_t readct, writect;
     size_t digest_size;
-    char *digest_value=NULL;
+    char *digest_value = NULL;
     int j;
 
     input = BIO_new_fd( fileno(stdin), 1 );
@@ -89,9 +88,9 @@ int main(int argc, char * argv[])
      * We will use BIO chaining so that as we read, the digest gets updated
      * See the man page for BIO_push
      */
-    BIO *reading = BIO_push( bio_digest, input );
-    
-    while( BIO_read(reading, buffer, sizeof(buffer)) > 0 )
+    reading = BIO_push(bio_digest, input);
+
+    while (BIO_read(reading, buffer, sizeof(buffer)) > 0)
         ;
 
     /*-
@@ -106,10 +105,10 @@ int main(int argc, char * argv[])
         fprintf(stdout, "%02x", (unsigned char)digest_value[j]);
     }
     fprintf(stdout, "\n");
-    result = 0;
+    ret = EXIT_SUCCESS;
     
 cleanup:
-    if (result != 0) 
+    if (ret != EXIT_SUCCESS)
         ERR_print_errors_fp(stderr);
 
     OPENSSL_free(digest_value);
@@ -118,5 +117,5 @@ cleanup:
     EVP_MD_free(md);
     OSSL_LIB_CTX_free(library_context);
 
-    return result;
+    return ret;
 }

--- a/demos/digest/EVP_MD_demo.c
+++ b/demos/digest/EVP_MD_demo.c
@@ -79,7 +79,7 @@ const unsigned char known_answer[] = {
 int demonstrate_digest(void)
 {
     OSSL_LIB_CTX *library_context;
-    int result = 0;
+    int ret = 0;
     const char *option_properties = NULL;
     EVP_MD *message_digest = NULL;
     EVP_MD_CTX *digest_context = NULL;
@@ -161,12 +161,11 @@ int demonstrate_digest(void)
         fprintf(stdout, "\nDigest does not match known answer\n");
     } else {
         fprintf(stdout, "Digest computed properly.\n");
-        result = 1;
+        ret = 1;
     }
 
-
 cleanup:
-    if (result != 1)
+    if (ret != 1)
         ERR_print_errors_fp(stderr);
     /* OpenSSL free functions will ignore NULL arguments */
     EVP_MD_CTX_free(digest_context);
@@ -174,10 +173,10 @@ cleanup:
     EVP_MD_free(message_digest);
 
     OSSL_LIB_CTX_free(library_context);
-    return result;
+    return ret;
 }
 
 int main(void)
 {
-    return demonstrate_digest() == 0;
+    return demonstrate_digest() ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/demos/digest/EVP_MD_stdin.c
+++ b/demos/digest/EVP_MD_stdin.c
@@ -34,7 +34,7 @@
 int demonstrate_digest(BIO *input)
 {
     OSSL_LIB_CTX *library_context = NULL;
-    int result = 0;
+    int ret = 0;
     const char * option_properties = NULL;
     EVP_MD *message_digest = NULL;
     EVP_MD_CTX *digest_context = NULL;
@@ -103,14 +103,14 @@ int demonstrate_digest(BIO *input)
         fprintf(stderr, "EVP_DigestFinal() failed.\n");
         goto cleanup;
     }
-    result = 1;
+    ret = 1;
     for (ii=0; ii<digest_length; ii++) {
         fprintf(stdout, "%02x", digest_value[ii]);
     }
     fprintf(stdout, "\n");
 
 cleanup:
-    if (result != 1)
+    if (ret != 1)
         ERR_print_errors_fp(stderr);
     /* OpenSSL free functions will ignore NULL arguments */
     EVP_MD_CTX_free(digest_context);
@@ -118,17 +118,19 @@ cleanup:
     EVP_MD_free(message_digest);
 
     OSSL_LIB_CTX_free(library_context);
-    return result;
+    return ret;
 }
 
 int main(void)
 {
-    int result = 1;
+    int ret = EXIT_FAILURE;
     BIO *input = BIO_new_fd( fileno(stdin), 1 );
 
     if (input != NULL) {
-        result = demonstrate_digest(input);
+        ret = (demonstrate_digest(input) ? EXIT_SUCCESS : EXIT_FAILURE);
         BIO_free(input);
     }
-    return result;
+    if (ret != EXIT_SUCCESS)
+        ERR_print_errors_fp(stderr);
+    return ret;
 }

--- a/demos/digest/EVP_MD_xof.c
+++ b/demos/digest/EVP_MD_xof.c
@@ -43,7 +43,7 @@ static const char *propq = NULL;
 
 int main(int argc, char **argv)
 {
-    int rv = 1;
+    int ret = EXIT_FAILURE;
     OSSL_LIB_CTX *libctx = NULL;
     EVP_MD *md = NULL;
     EVP_MD_CTX *ctx = NULL;
@@ -122,11 +122,11 @@ int main(int argc, char **argv)
         }
     }
 
-    rv = 0;
+    ret = EXIT_SUCCESS;
 end:
     OPENSSL_free(digest);
     EVP_MD_CTX_free(ctx);
     EVP_MD_free(md);
     OSSL_LIB_CTX_free(libctx);
-    return rv;
+    return ret;
 }

--- a/demos/encode/ec_encode.c
+++ b/demos/encode/ec_encode.c
@@ -28,7 +28,7 @@ static const char *propq = NULL;
  */
 static EVP_PKEY *load_key(OSSL_LIB_CTX *libctx, FILE *f, const char *passphrase)
 {
-    int rv = 0;
+    int ret = 0;
     EVP_PKEY *pkey = NULL;
     OSSL_DECODER_CTX *dctx = NULL;
     int selection = 0;
@@ -75,7 +75,7 @@ static EVP_PKEY *load_key(OSSL_LIB_CTX *libctx, FILE *f, const char *passphrase)
         goto cleanup;
     }
 
-    rv = 1;
+    ret = 1;
 cleanup:
     OSSL_DECODER_CTX_free(dctx);
 
@@ -84,7 +84,7 @@ cleanup:
      * might fail subsequently, so ensure it's properly freed
      * in this case.
      */
-    if (rv == 0) {
+    if (ret == 0) {
         EVP_PKEY_free(pkey);
         pkey = NULL;
     }
@@ -100,7 +100,7 @@ cleanup:
  */
 static int store_key(EVP_PKEY *pkey, FILE *f, const char *passphrase)
 {
-    int rv = 0;
+    int ret = 0;
     int selection;
     OSSL_ENCODER_CTX *ectx = NULL;
 
@@ -165,15 +165,15 @@ static int store_key(EVP_PKEY *pkey, FILE *f, const char *passphrase)
         goto cleanup;
     }
 
-    rv = 1;
+    ret = 1;
 cleanup:
     OSSL_ENCODER_CTX_free(ectx);
-    return rv;
+    return ret;
 }
 
 int main(int argc, char **argv)
 {
-    int rv = 1;
+    int ret = EXIT_FAILURE;
     OSSL_LIB_CTX *libctx = NULL;
     EVP_PKEY *pkey = NULL;
     const char *passphrase_in = NULL, *passphrase_out = NULL;
@@ -197,9 +197,9 @@ int main(int argc, char **argv)
         goto cleanup;
     }
 
-    rv = 0;
+    ret = EXIT_SUCCESS;
 cleanup:
     EVP_PKEY_free(pkey);
     OSSL_LIB_CTX_free(libctx);
-    return rv;
+    return ret;
 }

--- a/demos/encode/rsa_encode.c
+++ b/demos/encode/rsa_encode.c
@@ -28,7 +28,7 @@ static const char *propq = NULL;
  */
 static EVP_PKEY *load_key(OSSL_LIB_CTX *libctx, FILE *f, const char *passphrase)
 {
-    int rv = 0;
+    int ret = 0;
     EVP_PKEY *pkey = NULL;
     OSSL_DECODER_CTX *dctx = NULL;
     int selection = 0;
@@ -75,7 +75,7 @@ static EVP_PKEY *load_key(OSSL_LIB_CTX *libctx, FILE *f, const char *passphrase)
         goto cleanup;
     }
 
-    rv = 1;
+    ret = 1;
 cleanup:
     OSSL_DECODER_CTX_free(dctx);
 
@@ -84,7 +84,7 @@ cleanup:
      * might fail subsequently, so ensure it's properly freed
      * in this case.
      */
-    if (rv == 0) {
+    if (ret == 0) {
         EVP_PKEY_free(pkey);
         pkey = NULL;
     }
@@ -100,7 +100,7 @@ cleanup:
  */
 static int store_key(EVP_PKEY *pkey, FILE *f, const char *passphrase)
 {
-    int rv = 0;
+    int ret = 0;
     int selection;
     OSSL_ENCODER_CTX *ectx = NULL;
 
@@ -162,15 +162,15 @@ static int store_key(EVP_PKEY *pkey, FILE *f, const char *passphrase)
         goto cleanup;
     }
 
-    rv = 1;
+    ret = 1;
 cleanup:
     OSSL_ENCODER_CTX_free(ectx);
-    return rv;
+    return ret;
 }
 
 int main(int argc, char **argv)
 {
-    int rv = 1;
+    int ret = EXIT_FAILURE;
     OSSL_LIB_CTX *libctx = NULL;
     EVP_PKEY *pkey = NULL;
     const char *passphrase_in = NULL, *passphrase_out = NULL;
@@ -194,9 +194,9 @@ int main(int argc, char **argv)
         goto cleanup;
     }
 
-    rv = 0;
+    ret = EXIT_SUCCESS;
 cleanup:
     EVP_PKEY_free(pkey);
     OSSL_LIB_CTX_free(libctx);
-    return rv;
+    return ret;
 }

--- a/demos/kdf/hkdf.c
+++ b/demos/kdf/hkdf.c
@@ -43,7 +43,7 @@ static unsigned char hkdf_okm[] = {
 
 int main(int argc, char **argv)
 {
-    int rv = 1;
+    int ret = EXIT_FAILURE;
     EVP_KDF *kdf = NULL;
     EVP_KDF_CTX *kctx = NULL;
     unsigned char out[42];
@@ -95,10 +95,10 @@ int main(int argc, char **argv)
         goto end;
     }
 
-    rv = 0;
+    ret = EXIT_SUCCESS;
 end:
     EVP_KDF_CTX_free(kctx);
     EVP_KDF_free(kdf);
     OSSL_LIB_CTX_free(library_context);
-    return rv;
+    return ret;
 }

--- a/demos/kdf/pbkdf2.c
+++ b/demos/kdf/pbkdf2.c
@@ -57,7 +57,7 @@ static const unsigned char expected_output[] = {
 
 int main(int argc, char **argv)
 {
-    int rv = 1;
+    int ret = EXIT_FAILURE;
     EVP_KDF *kdf = NULL;
     EVP_KDF_CTX *kctx = NULL;
     unsigned char out[64];
@@ -108,10 +108,10 @@ int main(int argc, char **argv)
         goto end;
     }
 
-    rv = 0;
+    ret = EXIT_SUCCESS;
 end:
     EVP_KDF_CTX_free(kctx);
     EVP_KDF_free(kdf);
     OSSL_LIB_CTX_free(library_context);
-    return rv;
+    return ret;
 }

--- a/demos/kdf/scrypt.c
+++ b/demos/kdf/scrypt.c
@@ -59,7 +59,7 @@ static const unsigned char expected_output[] = {
 
 int main(int argc, char **argv)
 {
-    int rv = 1;
+    int ret = EXIT_FAILURE;
     EVP_KDF *kdf = NULL;
     EVP_KDF_CTX *kctx = NULL;
     unsigned char out[64];
@@ -111,10 +111,10 @@ int main(int argc, char **argv)
         goto end;
     }
 
-    rv = 0;
+    ret = EXIT_SUCCESS;
 end:
     EVP_KDF_CTX_free(kctx);
     EVP_KDF_free(kdf);
     OSSL_LIB_CTX_free(library_context);
-    return rv;
+    return ret;
 }

--- a/demos/keyexch/x25519.c
+++ b/demos/keyexch/x25519.c
@@ -65,7 +65,7 @@ static int keyexch_x25519_before(
     const unsigned char *kat_privk_data,
     PEER_DATA *local_peer)
 {
-    int rv = 0;
+    int ret = 0;
     size_t pubk_data_len = 0;
 
     /* Generate or load X25519 key for the peer */
@@ -99,14 +99,14 @@ static int keyexch_x25519_before(
         goto end;
     }
 
-    rv = 1;
+    ret = 1;
 end:
-    if (rv == 0) {
+    if (ret == 0) {
         EVP_PKEY_free(local_peer->privk);
         local_peer->privk = NULL;
     }
 
-    return rv;
+    return ret;
 }
 
 /*
@@ -120,7 +120,7 @@ static int keyexch_x25519_after(
     PEER_DATA *local_peer,
     const unsigned char *remote_peer_pubk_data)
 {
-    int rv = 0;
+    int ret = 0;
     EVP_PKEY *remote_peer_pubk = NULL;
     EVP_PKEY_CTX *ctx = NULL;
 
@@ -188,21 +188,21 @@ static int keyexch_x25519_after(
     BIO_dump_indent_fp(stdout, local_peer->secret, local_peer->secret_len, 2);
     putchar('\n');
 
-    rv = 1;
+    ret = 1;
 end:
     EVP_PKEY_CTX_free(ctx);
     EVP_PKEY_free(remote_peer_pubk);
-    if (rv == 0) {
+    if (ret == 0) {
         OPENSSL_clear_free(local_peer->secret, local_peer->secret_len);
         local_peer->secret = NULL;
     }
 
-    return rv;
+    return ret;
 }
 
 static int keyexch_x25519(int use_kat)
 {
-    int rv = 0;
+    int ret = 0;
     OSSL_LIB_CTX *libctx = NULL;
     PEER_DATA peer1 = {"peer 1"}, peer2 = {"peer 2"};
 
@@ -250,7 +250,7 @@ static int keyexch_x25519(int use_kat)
         goto end;
     }
 
-    rv = 1;
+    ret = 1;
 end:
     /* The secrets are sensitive, so ensure they are erased before freeing. */
     OPENSSL_clear_free(peer1.secret, peer1.secret_len);
@@ -259,7 +259,7 @@ end:
     EVP_PKEY_free(peer1.privk);
     EVP_PKEY_free(peer2.privk);
     OSSL_LIB_CTX_free(libctx);
-    return rv;
+    return ret;
 }
 
 int main(int argc, char **argv)
@@ -267,12 +267,12 @@ int main(int argc, char **argv)
     /* Test X25519 key exchange with known result. */
     printf("Key exchange using known answer (deterministic):\n");
     if (keyexch_x25519(1) == 0)
-        return 1;
+        return EXIT_FAILURE;
 
     /* Test X25519 key exchange with random keys. */
     printf("Key exchange using random keys:\n");
     if (keyexch_x25519(0) == 0)
-        return 1;
+        return EXIT_FAILURE;
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/demos/mac/cmac-aes256.c
+++ b/demos/mac/cmac-aes256.c
@@ -65,7 +65,7 @@ static const char *propq = NULL;
 
 int main(void)
 {
-    int rv = EXIT_FAILURE;
+    int ret = EXIT_FAILURE;
     OSSL_LIB_CTX *library_context = NULL;
     EVP_MAC *mac = NULL;
     EVP_MAC_CTX *mctx = NULL;
@@ -141,14 +141,14 @@ int main(void)
         goto end;
     }
 
-    rv = EXIT_SUCCESS;
+    ret = EXIT_SUCCESS;
 end:
-    if (rv != EXIT_SUCCESS)
+    if (ret != EXIT_SUCCESS)
         ERR_print_errors_fp(stderr);
     /* OpenSSL free functions will ignore NULL arguments */
     OPENSSL_free(out);
     EVP_MAC_CTX_free(mctx);
     EVP_MAC_free(mac);
     OSSL_LIB_CTX_free(library_context);
-    return rv;
+    return ret;
 }

--- a/demos/mac/gmac.c
+++ b/demos/mac/gmac.c
@@ -57,7 +57,7 @@ static char *propq = NULL;
 
 int main(int argc, char **argv)
 {
-    int rv = EXIT_FAILURE;
+    int ret = EXIT_FAILURE;
     EVP_MAC *mac = NULL;
     EVP_MAC_CTX *mctx = NULL;
     unsigned char out[16];
@@ -134,12 +134,12 @@ int main(int argc, char **argv)
         goto end;
     }
 
-    rv = EXIT_SUCCESS;
+    ret = EXIT_SUCCESS;
 end:
     EVP_MAC_CTX_free(mctx);
     EVP_MAC_free(mac);
     OSSL_LIB_CTX_free(library_context);
-    if (rv != EXIT_SUCCESS)
+    if (ret != EXIT_SUCCESS)
         ERR_print_errors_fp(stderr);
-    return rv;
+    return ret;
 }

--- a/demos/mac/hmac-sha512.c
+++ b/demos/mac/hmac-sha512.c
@@ -75,7 +75,7 @@ static const char *propq = NULL;
 
 int main(void)
 {
-    int rv = EXIT_FAILURE;
+    int ret = EXIT_FAILURE;
     OSSL_LIB_CTX *library_context = NULL;
     EVP_MAC *mac = NULL;
     EVP_MAC_CTX *mctx = NULL;
@@ -152,9 +152,9 @@ int main(void)
         goto end;
     }
 
-    rv = EXIT_SUCCESS;
+    ret = EXIT_SUCCESS;
 end:
-    if (rv != EXIT_SUCCESS)
+    if (ret != EXIT_SUCCESS)
         ERR_print_errors_fp(stderr);
     /* OpenSSL free functions will ignore NULL arguments */
     OPENSSL_free(out);
@@ -162,5 +162,5 @@ end:
     EVP_MAC_CTX_free(mctx);
     EVP_MAC_free(mac);
     OSSL_LIB_CTX_free(library_context);
-    return rv;
+    return ret;
 }

--- a/demos/mac/poly1305.c
+++ b/demos/mac/poly1305.c
@@ -83,7 +83,7 @@ static char *propq = NULL;
 
 int main(int argc, char **argv)
 {
-    int rv = EXIT_FAILURE;
+    int ret = EXIT_FAILURE;
     EVP_CIPHER *aes = NULL;
     EVP_CIPHER_CTX *aesctx = NULL;
     EVP_MAC *mac = NULL;
@@ -196,14 +196,14 @@ int main(int argc, char **argv)
         goto end;
     }
 
-    rv = EXIT_SUCCESS;
+    ret = EXIT_SUCCESS;
 end:
     EVP_CIPHER_CTX_free(aesctx);
     EVP_CIPHER_free(aes);
     EVP_MAC_CTX_free(mctx);
     EVP_MAC_free(mac);
     OSSL_LIB_CTX_free(library_context);
-    if (rv != EXIT_SUCCESS)
+    if (ret != EXIT_SUCCESS)
         ERR_print_errors_fp(stderr);
-    return rv;
+    return ret;
 }

--- a/demos/mac/siphash.c
+++ b/demos/mac/siphash.c
@@ -44,7 +44,7 @@ static char *propq = NULL;
 
 int main(int argc, char **argv)
 {
-    int rv = EXIT_FAILURE;
+    int ret = EXIT_FAILURE;
     EVP_MAC *mac = NULL;
     EVP_MAC_CTX *mctx = NULL;
     unsigned char out[8];
@@ -118,12 +118,12 @@ int main(int argc, char **argv)
         goto end;
     }
 
-    rv = EXIT_SUCCESS;
+    ret = EXIT_SUCCESS;
 end:
     EVP_MAC_CTX_free(mctx);
     EVP_MAC_free(mac);
     OSSL_LIB_CTX_free(library_context);
-    if (rv != EXIT_SUCCESS)
+    if (ret != EXIT_SUCCESS)
         ERR_print_errors_fp(stderr);
-    return rv;
+    return ret;
 }

--- a/demos/pkcs12/pkwrite.c
+++ b/demos/pkcs12/pkwrite.c
@@ -23,13 +23,13 @@ int main(int argc, char **argv)
     PKCS12 *p12;
     if (argc != 5) {
         fprintf(stderr, "Usage: pkwrite infile password name p12file\n");
-        exit(1);
+        exit(EXIT_FAILURE);
     }
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
     if ((fp = fopen(argv[1], "r")) == NULL) {
         fprintf(stderr, "Error opening file %s\n", argv[1]);
-        exit(1);
+        exit(EXIT_FAILURE);
     }
     cert = PEM_read_X509(fp, NULL, NULL, NULL);
     rewind(fp);
@@ -39,15 +39,15 @@ int main(int argc, char **argv)
     if (!p12) {
         fprintf(stderr, "Error creating PKCS#12 structure\n");
         ERR_print_errors_fp(stderr);
-        exit(1);
+        exit(EXIT_FAILURE);
     }
     if ((fp = fopen(argv[4], "wb")) == NULL) {
         fprintf(stderr, "Error opening file %s\n", argv[4]);
         ERR_print_errors_fp(stderr);
-        exit(1);
+        exit(EXIT_FAILURE);
     }
     i2d_PKCS12_fp(fp, p12);
     PKCS12_free(p12);
     fclose(fp);
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/demos/pkey/EVP_PKEY_DSA_keygen.c
+++ b/demos/pkey/EVP_PKEY_DSA_keygen.c
@@ -45,7 +45,7 @@ cleanup:
 
 int main(int argc, char **argv)
 {
-    int rv = EXIT_FAILURE;
+    int ret = EXIT_FAILURE;
     OSSL_LIB_CTX *libctx = NULL;
     const char *propq = NULL;
     EVP_PKEY *dsaparamskey = NULL;
@@ -74,10 +74,10 @@ int main(int argc, char **argv)
     if (!dsa_print_key(dsakey, 1, libctx, propq))
         goto cleanup;
 
-    rv = EXIT_SUCCESS;
+    ret = EXIT_SUCCESS;
 cleanup:
     EVP_PKEY_free(dsakey);
     EVP_PKEY_free(dsaparamskey);
     EVP_PKEY_CTX_free(ctx);
-    return rv;
+    return ret;
 }

--- a/demos/pkey/EVP_PKEY_DSA_paramfromdata.c
+++ b/demos/pkey/EVP_PKEY_DSA_paramfromdata.c
@@ -19,7 +19,7 @@
 
 int main(int argc, char **argv)
 {
-    int rv = EXIT_FAILURE;
+    int ret = EXIT_FAILURE;
     OSSL_LIB_CTX *libctx = NULL;
     const char *propq = NULL;
     EVP_PKEY_CTX *ctx = NULL;
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
     if (!dsa_print_key(dsaparamkey, 0, libctx, propq))
         goto cleanup;
 
-    rv = EXIT_SUCCESS;
+    ret = EXIT_SUCCESS;
 cleanup:
     EVP_PKEY_free(dsaparamkey);
     EVP_PKEY_CTX_free(ctx);
@@ -71,5 +71,5 @@ cleanup:
     BN_free(q);
     BN_free(p);
 
-    return rv;
+    return ret;
 }

--- a/demos/pkey/EVP_PKEY_DSA_paramgen.c
+++ b/demos/pkey/EVP_PKEY_DSA_paramgen.c
@@ -17,7 +17,7 @@
 
 int main(int argc, char **argv)
 {
-    int rv = EXIT_FAILURE;
+    int ret = EXIT_FAILURE;
     OSSL_LIB_CTX *libctx = NULL;
     const char *propq = NULL;
     EVP_PKEY_CTX *ctx = NULL;
@@ -58,9 +58,9 @@ int main(int argc, char **argv)
     if (!dsa_print_key(dsaparamkey, 0, libctx, propq))
         goto cleanup;
 
-    rv = EXIT_SUCCESS;
+    ret = EXIT_SUCCESS;
 cleanup:
     EVP_PKEY_free(dsaparamkey);
     EVP_PKEY_CTX_free(ctx);
-    return rv;
+    return ret;
 }

--- a/demos/pkey/EVP_PKEY_DSA_paramvalidate.c
+++ b/demos/pkey/EVP_PKEY_DSA_paramvalidate.c
@@ -102,7 +102,7 @@ cleanup:
 
 int main(int argc, char **argv)
 {
-    int rv = EXIT_FAILURE;
+    int ret = EXIT_FAILURE;
     OSSL_LIB_CTX *libctx = NULL;
     const char *propq = NULL;
     EVP_PKEY *dsaparamskey = NULL;
@@ -191,12 +191,12 @@ int main(int argc, char **argv)
     if (!dsa_print_key(EVP_PKEY_CTX_get0_pkey(ctx2), 0, libctx, propq))
         goto cleanup;
 
-    rv = EXIT_SUCCESS;
+    ret = EXIT_SUCCESS;
 cleanup:
     EVP_PKEY_free(dsaparamskey);
     EVP_PKEY_CTX_free(ctx2);
     EVP_PKEY_CTX_free(ctx1);
     EVP_PKEY_CTX_free(ctx);
     BIO_free(in);
-    return rv;
+    return ret;
 }

--- a/demos/pkey/EVP_PKEY_EC_keygen.c
+++ b/demos/pkey/EVP_PKEY_EC_keygen.c
@@ -84,7 +84,7 @@ cleanup:
  */
 static int get_key_values(EVP_PKEY *pkey)
 {
-    int result = 0;
+    int ret = 0;
     char out_curvename[80];
     unsigned char out_pubkey[80];
     unsigned char out_privkey[80];
@@ -122,16 +122,16 @@ static int get_key_values(EVP_PKEY *pkey)
     fprintf(stdout, "Private Key:\n");
     BIO_dump_indent_fp(stdout, out_privkey, out_privkey_len, 2);
 
-    result = 1;
+    ret = 1;
 cleanup:
     /* Zeroize the private key data when we free it */
     BN_clear_free(out_priv);
-    return result;
+    return ret;
 }
 
 int main(void)
 {
-    int result = 0;
+    int ret = EXIT_FAILURE;
     EVP_PKEY *pkey;
 
     pkey = do_ec_keygen();
@@ -145,11 +145,11 @@ int main(void)
      * At this point we can write out the generated key using
      * i2d_PrivateKey() and i2d_PublicKey() if required.
      */
-    result = 1;
+    ret = EXIT_SUCCESS;
 cleanup:
-    if (result != 1)
+    if (ret != EXIT_SUCCESS)
         ERR_print_errors_fp(stderr);
 
     EVP_PKEY_free(pkey);
-    return result == 0;
+    return ret;
 }

--- a/demos/pkey/EVP_PKEY_RSA_keygen.c
+++ b/demos/pkey/EVP_PKEY_RSA_keygen.c
@@ -123,7 +123,7 @@ static EVP_PKEY *generate_rsa_key_short(OSSL_LIB_CTX *libctx, unsigned int bits)
  */
 static int dump_key(const EVP_PKEY *pkey)
 {
-    int rv = 0;
+    int ret = 0;
     int bits = 0;
     BIGNUM *n = NULL, *e = NULL, *d = NULL, *p = NULL, *q = NULL;
 
@@ -227,19 +227,19 @@ static int dump_key(const EVP_PKEY *pkey)
         goto cleanup;
     }
 
-    rv = 1;
+    ret = 1;
 cleanup:
     BN_free(n); /* not secret */
     BN_free(e); /* not secret */
     BN_clear_free(d); /* secret - scrub before freeing */
     BN_clear_free(p); /* secret - scrub before freeing */
     BN_clear_free(q); /* secret - scrub before freeing */
-    return rv;
+    return ret;
 }
 
 int main(int argc, char **argv)
 {
-    int rv = 1;
+    int ret = EXIT_FAILURE;
     OSSL_LIB_CTX *libctx = NULL;
     EVP_PKEY *pkey = NULL;
     unsigned int bits = 4096;
@@ -256,7 +256,7 @@ int main(int argc, char **argv)
         bits_i = atoi(argv[1]);
         if (bits < 512) {
             fprintf(stderr, "Invalid RSA key size\n");
-            return 1;
+            return EXIT_FAILURE;
         }
 
         bits = (unsigned int)bits_i;
@@ -281,9 +281,9 @@ int main(int argc, char **argv)
         goto cleanup;
     }
 
-    rv = 0;
+    ret = EXIT_SUCCESS;
 cleanup:
     EVP_PKEY_free(pkey);
     OSSL_LIB_CTX_free(libctx);
-    return rv;
+    return ret;
 }

--- a/demos/signature/EVP_DSA_Signature_demo.c
+++ b/demos/signature/EVP_DSA_Signature_demo.c
@@ -46,7 +46,7 @@ static const char * const PROPQUERY = NULL;
 static int generate_dsa_params(OSSL_LIB_CTX *libctx,
                                EVP_PKEY **p_params)
 {
-    int result = 0;
+    int ret = 0;
 
     EVP_PKEY_CTX *pkey_ctx = NULL;
     EVP_PKEY *params = NULL;
@@ -65,9 +65,9 @@ static int generate_dsa_params(OSSL_LIB_CTX *libctx,
     if (params == NULL)
         goto end;
 
-    result = 1;
+    ret = 1;
 end:
-    if(result != 1) {
+    if(ret != 1) {
         EVP_PKEY_free(params);
         params = NULL;
     }
@@ -77,14 +77,14 @@ end:
     EVP_PKEY_print_params_fp(stdout, params, 4, NULL);
     fprintf(stdout, "\n");
 
-    return result;
+    return ret;
 }
 
 static int generate_dsa_key(OSSL_LIB_CTX *libctx,
                             EVP_PKEY *params,
                             EVP_PKEY **p_pkey)
 {
-    int result = 0;
+    int ret = 0;
 
     EVP_PKEY_CTX *ctx = NULL;
     EVP_PKEY *pkey = NULL;
@@ -101,9 +101,9 @@ static int generate_dsa_key(OSSL_LIB_CTX *libctx,
     if (pkey == NULL)
         goto end;
 
-    result = 1;
+    ret = 1;
 end:
-    if(result != 1) {
+    if(ret != 1) {
         EVP_PKEY_free(pkey);
         pkey = NULL;
     }
@@ -117,54 +117,54 @@ end:
     EVP_PKEY_print_params_fp(stdout, pkey, 4, NULL);
     fprintf(stdout, "\n");
 
-    return result;
+    return ret;
 }
 
 static int extract_public_key(const EVP_PKEY *pkey,
                               OSSL_PARAM **p_public_key)
 {
-    int result = 0;
+    int ret = 0;
     OSSL_PARAM *public_key = NULL;
 
     if (EVP_PKEY_todata(pkey, EVP_PKEY_PUBLIC_KEY, &public_key) != 1)
         goto end;
 
-    result = 1;
+    ret = 1;
 end:
-    if (result != 1) {
+    if (ret != 1) {
         OSSL_PARAM_free(public_key);
         public_key = NULL;
     }
     *p_public_key = public_key;
 
-    return result;
+    return ret;
 }
 
 static int extract_keypair(const EVP_PKEY *pkey,
                            OSSL_PARAM **p_keypair)
 {
-    int result = 0;
+    int ret = 0;
     OSSL_PARAM *keypair = NULL;
 
     if (EVP_PKEY_todata(pkey, EVP_PKEY_KEYPAIR, &keypair) != 1)
         goto end;
 
-    result = 1;
+    ret = 1;
 end:
-    if (result != 1) {
+    if (ret != 1) {
         OSSL_PARAM_free(keypair);
         keypair = NULL;
     }
     *p_keypair = keypair;
 
-    return result;
+    return ret;
 }
 
 static int demo_sign(OSSL_LIB_CTX *libctx,
                      size_t *p_sig_len, unsigned char **p_sig_value,
                      OSSL_PARAM keypair[])
 {
-    int result = 0;
+    int ret = 0;
     size_t sig_len = 0;
     unsigned char *sig_value = NULL;
     EVP_MD_CTX *ctx = NULL;
@@ -206,10 +206,10 @@ static int demo_sign(OSSL_LIB_CTX *libctx,
     if (EVP_DigestSignFinal(ctx, sig_value, &sig_len) != 1)
         goto end;
 
-    result = 1;
+    ret = 1;
 end:
     EVP_MD_CTX_free(ctx);
-    if (result != 1) {
+    if (ret != 1) {
         OPENSSL_free(sig_value);
         sig_len = 0;
         sig_value = NULL;
@@ -222,14 +222,14 @@ end:
     fprintf(stdout, "Generating signature:\n");
     BIO_dump_indent_fp(stdout, sig_value, sig_len, 2);
     fprintf(stdout, "\n");
-    return result;
+    return ret;
 }
 
 static int demo_verify(OSSL_LIB_CTX *libctx,
                        size_t sig_len, unsigned char *sig_value,
                        OSSL_PARAM public_key[])
 {
-    int result = 0;
+    int ret = 0;
     EVP_MD_CTX *ctx = NULL;
     EVP_PKEY_CTX *pkey_ctx = NULL;
     EVP_PKEY *pkey = NULL;
@@ -258,17 +258,17 @@ static int demo_verify(OSSL_LIB_CTX *libctx,
     if (EVP_DigestVerifyFinal(ctx, sig_value, sig_len) != 1)
         goto end;
 
-    result = 1;
+    ret = 1;
 end:
     EVP_PKEY_free(pkey);
     EVP_PKEY_CTX_free(pkey_ctx);
     EVP_MD_CTX_free(ctx);
-    return result;
+    return ret;
 }
 
 int main(void)
 {
-    int result = 0;
+    int ret = EXIT_FAILURE;
     OSSL_LIB_CTX *libctx = NULL;
     EVP_PKEY *params = NULL;
     EVP_PKEY *pkey = NULL;
@@ -301,9 +301,9 @@ int main(void)
     if (demo_verify(libctx, sig_len, sig_value, public_key) != 1)
         goto end;
 
-    result = 1;
+    ret = EXIT_SUCCESS;
 end:
-    if (result != 1)
+    if (ret != EXIT_SUCCESS)
         ERR_print_errors_fp(stderr);
 
     OPENSSL_free(sig_value);
@@ -313,5 +313,5 @@ end:
     OSSL_PARAM_free(keypair);
     OSSL_LIB_CTX_free(libctx);
 
-    return result ? 0 : 1;
+    return ret;
 }

--- a/demos/signature/EVP_EC_Signature_demo.c
+++ b/demos/signature/EVP_EC_Signature_demo.c
@@ -70,7 +70,7 @@ static EVP_PKEY *get_key(OSSL_LIB_CTX *libctx, const char *propq, int public)
 static int demo_sign(OSSL_LIB_CTX *libctx,  const char *sig_name,
                      size_t *sig_out_len, unsigned char **sig_out_value)
 {
-    int result = 0, public = 0;
+    int ret = 0, public = 0;
     size_t sig_len;
     unsigned char *sig_value = NULL;
     const char *propq = NULL;
@@ -136,21 +136,21 @@ static int demo_sign(OSSL_LIB_CTX *libctx,  const char *sig_name,
     fprintf(stdout, "Generating signature:\n");
     BIO_dump_indent_fp(stdout, sig_value, sig_len, 2);
     fprintf(stdout, "\n");
-    result = 1;
+    ret = 1;
 
 cleanup:
     /* OpenSSL free functions will ignore NULL arguments */
-    if (!result)
+    if (!ret)
         OPENSSL_free(sig_value);
     EVP_PKEY_free(priv_key);
     EVP_MD_CTX_free(sign_context);
-    return result;
+    return ret;
 }
 
 static int demo_verify(OSSL_LIB_CTX *libctx, const char *sig_name,
                        size_t sig_len, unsigned char *sig_value)
 {
-    int result = 0, public = 1;
+    int ret = 0, public = 1;
     const char *propq = NULL;
     EVP_MD_CTX *verify_context = NULL;
     EVP_PKEY *pub_key = NULL;
@@ -193,13 +193,13 @@ static int demo_verify(OSSL_LIB_CTX *libctx, const char *sig_name,
         goto cleanup;
     }
     fprintf(stdout, "Signature verified.\n");
-    result = 1;
+    ret = 1;
 
 cleanup:
     /* OpenSSL free functions will ignore NULL arguments */
     EVP_PKEY_free(pub_key);
     EVP_MD_CTX_free(verify_context);
-    return result;
+    return ret;
 }
 
 int main(void)
@@ -208,7 +208,7 @@ int main(void)
     const char *sig_name = "SHA3-512";
     size_t sig_len = 0;
     unsigned char *sig_value = NULL;
-    int result = 0;
+    int ret = EXIT_FAILURE;
 
     libctx = OSSL_LIB_CTX_new();
     if (libctx == NULL) {
@@ -223,13 +223,13 @@ int main(void)
         fprintf(stderr, "demo_verify failed.\n");
         goto cleanup;
     }
-    result = 1;
+    ret = EXIT_SUCCESS;
 
 cleanup:
-    if (result != 1)
+    if (ret != EXIT_SUCCESS)
         ERR_print_errors_fp(stderr);
     /* OpenSSL free functions will ignore NULL arguments */
     OSSL_LIB_CTX_free(libctx);
     OPENSSL_free(sig_value);
-    return result == 0;
+    return ret;
 }

--- a/demos/signature/rsa_pss_direct.c
+++ b/demos/signature/rsa_pss_direct.c
@@ -37,7 +37,7 @@ static const char *propq = NULL;
  */
 static int sign(OSSL_LIB_CTX *libctx, unsigned char **sig, size_t *sig_len)
 {
-    int rv = 0;
+    int ret = 0;
     EVP_PKEY *pkey = NULL;
     EVP_PKEY_CTX *ctx = NULL;
     EVP_MD *md = NULL;
@@ -105,16 +105,16 @@ static int sign(OSSL_LIB_CTX *libctx, unsigned char **sig, size_t *sig_len)
         goto end;
     }
 
-    rv = 1;
+    ret = 1;
 end:
     EVP_PKEY_CTX_free(ctx);
     EVP_PKEY_free(pkey);
     EVP_MD_free(md);
 
-    if (rv == 0)
+    if (ret == 0)
         OPENSSL_free(*sig);
 
-    return rv;
+    return ret;
 }
 
 /*
@@ -123,7 +123,7 @@ end:
  */
 static int verify(OSSL_LIB_CTX *libctx, const unsigned char *sig, size_t sig_len)
 {
-    int rv = 0;
+    int ret = 0;
     const unsigned char *ppub_key = NULL;
     EVP_PKEY *pkey = NULL;
     EVP_PKEY_CTX *ctx = NULL;
@@ -175,17 +175,17 @@ static int verify(OSSL_LIB_CTX *libctx, const unsigned char *sig, size_t sig_len
         goto end;
     }
 
-    rv = 1;
+    ret = 1;
 end:
     EVP_PKEY_CTX_free(ctx);
     EVP_PKEY_free(pkey);
     EVP_MD_free(md);
-    return rv;
+    return ret;
 }
 
 int main(int argc, char **argv)
 {
-    int rv = 1;
+    int ret = EXIT_FAILURE;
     OSSL_LIB_CTX *libctx = NULL;
     unsigned char *sig = NULL;
     size_t sig_len = 0;
@@ -196,9 +196,9 @@ int main(int argc, char **argv)
     if (verify(libctx, sig, sig_len) == 0)
         goto end;
 
-    rv = 0;
+    ret = EXIT_SUCCESS;
 end:
     OPENSSL_free(sig);
     OSSL_LIB_CTX_free(libctx);
-    return rv;
+    return ret;
 }

--- a/demos/signature/rsa_pss_hash.c
+++ b/demos/signature/rsa_pss_hash.c
@@ -32,7 +32,7 @@ static const char *propq = NULL;
  */
 static int sign(OSSL_LIB_CTX *libctx, unsigned char **sig, size_t *sig_len)
 {
-    int rv = 0;
+    int ret = 0;
     EVP_PKEY *pkey = NULL;
     EVP_MD_CTX *mctx = NULL;
     OSSL_PARAM params[2], *p = params;
@@ -95,15 +95,15 @@ static int sign(OSSL_LIB_CTX *libctx, unsigned char **sig, size_t *sig_len)
         goto end;
     }
 
-    rv = 1;
+    ret = 1;
 end:
     EVP_MD_CTX_free(mctx);
     EVP_PKEY_free(pkey);
 
-    if (rv == 0)
+    if (ret == 0)
         OPENSSL_free(*sig);
 
-    return rv;
+    return ret;
 }
 
 /*
@@ -113,7 +113,7 @@ end:
  */
 static int verify(OSSL_LIB_CTX *libctx, const unsigned char *sig, size_t sig_len)
 {
-    int rv = 0;
+    int ret = 0;
     EVP_PKEY *pkey = NULL;
     EVP_MD_CTX *mctx = NULL;
     OSSL_PARAM params[2], *p = params;
@@ -161,16 +161,16 @@ static int verify(OSSL_LIB_CTX *libctx, const unsigned char *sig, size_t sig_len
         goto end;
     }
 
-    rv = 1;
+    ret = 1;
 end:
     EVP_MD_CTX_free(mctx);
     EVP_PKEY_free(pkey);
-    return rv;
+    return ret;
 }
 
 int main(int argc, char **argv)
 {
-    int rv = 1;
+    int ret = EXIT_FAILURE;
     OSSL_LIB_CTX *libctx = NULL;
     unsigned char *sig = NULL;
     size_t sig_len = 0;
@@ -181,9 +181,9 @@ int main(int argc, char **argv)
     if (verify(libctx, sig, sig_len) == 0)
         goto end;
 
-    rv = 0;
+    ret = EXIT_SUCCESS;
 end:
     OPENSSL_free(sig);
     OSSL_LIB_CTX_free(libctx);
-    return rv;
+    return ret;
 }

--- a/demos/smime/smdec.c
+++ b/demos/smime/smdec.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     X509 *rcert = NULL;
     EVP_PKEY *rkey = NULL;
     PKCS7 *p7 = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
@@ -59,10 +59,10 @@ int main(int argc, char **argv)
     if (!PKCS7_decrypt(p7, rkey, rcert, out, 0))
         goto err;
 
-    ret = 0;
+    ret = EXIT_SUCCESS;
 
  err:
-    if (ret) {
+    if (ret != EXIT_SUCCESS) {
         fprintf(stderr, "Error Signing Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/smime/smenc.c
+++ b/demos/smime/smenc.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     X509 *rcert = NULL;
     STACK_OF(X509) *recips = NULL;
     PKCS7 *p7 = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     /*
      * On OpenSSL 0.9.9 only:
@@ -73,10 +73,10 @@ int main(int argc, char **argv)
     if (!SMIME_write_PKCS7(out, p7, in, flags))
         goto err;
 
-    ret = 0;
+    ret = EXIT_SUCCESS;
 
  err:
-    if (ret) {
+    if (ret != EXIT_SUCCESS) {
         fprintf(stderr, "Error Encrypting Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/smime/smsign.c
+++ b/demos/smime/smsign.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     X509 *scert = NULL;
     EVP_PKEY *skey = NULL;
     PKCS7 *p7 = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     /*
      * For simple S/MIME signing use PKCS7_DETACHED. On OpenSSL 0.9.9 only:
@@ -69,10 +69,10 @@ int main(int argc, char **argv)
     if (!SMIME_write_PKCS7(out, p7, in, flags))
         goto err;
 
-    ret = 0;
+    ret = EXIT_SUCCESS;
 
  err:
-    if (ret) {
+    if (ret != EXIT_SUCCESS) {
         fprintf(stderr, "Error Signing Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/smime/smsign2.c
+++ b/demos/smime/smsign2.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     X509 *scert = NULL, *scert2 = NULL;
     EVP_PKEY *skey = NULL, *skey2 = NULL;
     PKCS7 *p7 = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
@@ -77,10 +77,10 @@ int main(int argc, char **argv)
     if (!SMIME_write_PKCS7(out, p7, in, PKCS7_STREAM))
         goto err;
 
-    ret = 0;
+    ret = EXIT_SUCCESS;
 
  err:
-    if (ret) {
+    if (ret != EXIT_SUCCESS) {
         fprintf(stderr, "Error Signing Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/smime/smver.c
+++ b/demos/smime/smver.c
@@ -18,8 +18,7 @@ int main(int argc, char **argv)
     X509_STORE *st = NULL;
     X509 *cacert = NULL;
     PKCS7 *p7 = NULL;
-
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
@@ -69,10 +68,10 @@ int main(int argc, char **argv)
 
     fprintf(stderr, "Verification Successful\n");
 
-    ret = 0;
+    ret = EXIT_SUCCESS;
 
  err:
-    if (ret) {
+    if (ret != EXIT_SUCCESS) {
         fprintf(stderr, "Error Verifying Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/sslecho/main.c
+++ b/demos/sslecho/main.c
@@ -123,7 +123,7 @@ void usage()
     printf("       --or--\n");
     printf("       sslecho c ip\n");
     printf("       c=client, s=server, ip=dotted ip of server\n");
-    exit(1);
+    exit(EXIT_FAILURE);
 }
 
 int main(int argc, char **argv)
@@ -322,7 +322,7 @@ int main(int argc, char **argv)
             ERR_print_errors_fp(stderr);
         }
     }
-    exit:
+exit:
     /* Close up */
     if (ssl != NULL) {
         SSL_shutdown(ssl);
@@ -340,5 +340,5 @@ int main(int argc, char **argv)
 
     printf("sslecho exiting\n");
 
-    return 0;
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
backport 09ff84bd and 9257a89b to 3.1, as discussed in PR #22618.

cms demos: print signingTime attributes

Add a makefile for the cms demos, and add a routine to `cms_ver.c` to print any signingTime attributes from the CMS_ContentInfo object.  This provides an example that could be extended if an application wants to examine the purported signing times.

Part of #8026

Testing:

```
$ cd demos/cms
$ make test
```
