### PR TITLE
Fix a possible memleak in CMS_sign_receipt

### DIFF
--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -560,7 +560,7 @@ CMS_ContentInfo *CMS_sign_receipt(CMS_SignerInfo *si,
 {
     CMS_SignerInfo *rct_si;
     CMS_ContentInfo *cms = NULL;
-    ASN1_OCTET_STRING **pos, *os;
+    ASN1_OCTET_STRING **pos, *os = NULL;
     BIO *rct_cont = NULL;
     int r = 0;
     const CMS_CTX *ctx = si->cms_ctx;
@@ -622,6 +622,7 @@ CMS_ContentInfo *CMS_sign_receipt(CMS_SignerInfo *si,
     if (r)
         return cms;
     CMS_ContentInfo_free(cms);
+    ASN1_OCTET_STRING_free(os);
     return NULL;
 
 }


### PR DESCRIPTION
When an error happens after cms_encode_Receipt
the ASN1_OCTET_STRING object "os" may be leaked.
