### PR TITLE
doc: fix description of mac "block-size" parameter

### DIFF
--- a/doc/man7/EVP_MAC-BLAKE2.pod
+++ b/doc/man7/EVP_MAC-BLAKE2.pod
@@ -27,7 +27,8 @@ properties, to be used with EVP_MAC_fetch():
 The general description of these parameters can be found in
 L<EVP_MAC(3)/PARAMETERS>.
 
-All these parameters can be set with EVP_MAC_CTX_set_params().
+All these parameters (except for "block-size") can be set with
+EVP_MAC_CTX_set_params().
 Furthermore, the "size" parameter can be retrieved with
 EVP_MAC_CTX_get_params(), or with EVP_MAC_CTX_get_mac_size().
 The length of the "size" parameter should not exceed that of a B<size_t>.
@@ -45,7 +46,7 @@ Setting this parameter is identical to passing a I<key> to L<EVP_MAC_init(3)>.
 
 =item "custom" (B<OSSL_MAC_PARAM_CUSTOM>) <octet string>
 
-Sets the custom value.
+Sets the customization/personalization string.
 It is an optional value of at most 16 bytes for BLAKE2BMAC or 8 for
 BLAKE2SMAC, and is empty by default.
 
@@ -62,10 +63,10 @@ It can be any number between 1 and 32 for EVP_MAC_BLAKE2S or between 1
 and 64 for EVP_MAC_BLAKE2B.
 It is 32 and 64 respectively by default.
 
-=item "block-size" (B<OSSL_MAC_PARAM_SIZE>) <unsigned integer>
+=item "block-size" (B<OSSL_MAC_PARAM_BLOCK_SIZE>) <unsigned integer>
 
 Gets the MAC block size.
-By default, it is 64 for EVP_MAC_BLAKE2S and 128 for EVP_MAC_BLAKE2B.
+It is 64 for EVP_MAC_BLAKE2S and 128 for EVP_MAC_BLAKE2B.
 
 =back
 

--- a/doc/man7/EVP_MAC-CMAC.pod
+++ b/doc/man7/EVP_MAC-CMAC.pod
@@ -63,7 +63,7 @@ The length of the "size" parameter is equal to that of an B<unsigned int>.
 
 =over 4
 
-=item "block-size" (B<OSSL_MAC_PARAM_SIZE>) <unsigned integer>
+=item "block-size" (B<OSSL_MAC_PARAM_BLOCK_SIZE>) <unsigned integer>
 
 Gets the MAC block size.  The "block-size" parameter can also be retrieved with
 EVP_MAC_CTX_get_block_size().

--- a/doc/man7/EVP_MAC-HMAC.pod
+++ b/doc/man7/EVP_MAC-HMAC.pod
@@ -76,7 +76,7 @@ The length of the "size" parameter is equal to that of an B<unsigned int>.
 
 =over 4
 
-=item "block-size" (B<OSSL_MAC_PARAM_SIZE>) <unsigned integer>
+=item "block-size" (B<OSSL_MAC_PARAM_BLOCK_SIZE>) <unsigned integer>
 
 Gets the MAC block size.  The "block-size" parameter can also be retrieved with
 EVP_MAC_CTX_get_block_size().

--- a/doc/man7/EVP_MAC-KMAC.pod
+++ b/doc/man7/EVP_MAC-KMAC.pod
@@ -27,7 +27,8 @@ properties, to be used with EVP_MAC_fetch():
 The general description of these parameters can be found in
 L<EVP_MAC(3)/PARAMETERS>.
 
-All these parameters can be set with EVP_MAC_CTX_set_params().
+All these parameters (except for "block-size") can be set with
+EVP_MAC_CTX_set_params().
 Furthermore, the "size" parameter can be retrieved with
 EVP_MAC_CTX_get_params(), or with EVP_MAC_CTX_get_mac_size().
 The length of the "size" parameter should not exceed that of a B<size_t>.
@@ -45,18 +46,19 @@ The length of the key (in bytes) must be in the range 4...512.
 
 =item "custom" (B<OSSL_MAC_PARAM_CUSTOM>) <octet string>
 
-Sets the custom value.
-It is an optional value with a length of at most 512 bytes, and is empty by default.
+Sets the customization string.
+It is an optional value with a length of at most 512 bytes, and is
+empty by default.
 
 =item "size" (B<OSSL_MAC_PARAM_SIZE>) <unsigned integer>
 
 Sets the MAC size.
 By default, it is 32 for C<KMAC-128> and 64 for C<KMAC-256>.
 
-=item "block-size" (B<OSSL_MAC_PARAM_SIZE>) <unsigned integer>
+=item "block-size" (B<OSSL_MAC_PARAM_BLOCK_SIZE>) <unsigned integer>
 
 Gets the MAC block size.
-By default, it is 168 for C<KMAC-128> and 136 for C<KMAC-256>.
+It is 168 for C<KMAC-128> and 136 for C<KMAC-256>.
 
 =item "xof" (B<OSSL_MAC_PARAM_XOF>) <integer>
 


### PR DESCRIPTION
Minor documentation updates to some mac manual pages:

-the macro for "block-size" is `OSSL_MAC_PARAM_BLOCK_SIZE`, and this parameter is not settable.
-change "custom value" to "customization string" (in the Blake2 spec, this is called the personalization string).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
