### PR TITLE
CLA: trivial

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -301,7 +301,7 @@ RCOUTFLAG={- $target{rcoutflag} -}$(OSSL_EMPTY)
 
 CNF_ASFLAGS={- join(' ', $target{asflags} || (),
                          @{$config{asflags}}) -}
-CNF_CPPFLAGS={- our $cppfags2 =
+CNF_CPPFLAGS={- our $cppflags2 =
                     join(' ', $target{cppflags} || (),
                               (map { '-D'.quotify1($_) } @{$target{defines}},
                                                          @{$config{defines}}),


### PR DESCRIPTION
CLA: trivial

spelling error cppfags2 => cppflags2 in Configurations/windows-makefile.tmpl

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
