### PR TITLE
Fix a possible use-after-free in custom_exts_free

### DIFF
--- a/ssl/statem/extensions_cust.c
+++ b/ssl/statem/extensions_cust.c
@@ -342,6 +342,8 @@ void custom_exts_free(custom_ext_methods *exts)
         OPENSSL_free(meth->parse_arg);
     }
     OPENSSL_free(exts->meths);
+    exts->meths = NULL;
+    exts->meths_count = 0;
 }
 
 /* Return true if a client custom extension exists, false otherwise */


### PR DESCRIPTION
This may happen when ssl_cert_dup calls custom_exts_copy, where a possible memory allocation error causes custom_exts_free to be called twice: once in the error handling of custom_exts_copy and a second time in the error handling of ssl_cert_dup.
