### PR TITLE
contributing-doc: give example commit message with "CLA: trivial"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,20 @@ guidelines:
  1. Anything other than a trivial contribution requires a [Contributor
     License Agreement] (CLA), giving us permission to use your code.
     If your contribution is too small to require a CLA (e.g. fixing a spelling
-    mistake), place the text "`CLA: trivial`" on a line by itself separated by
-    an empty line from the rest of the commit message. It is not sufficient to
-    only place the text in the GitHub pull request description.
+    mistake), then place the text "`CLA: trivial`" on a line by itself below
+    the rest of your commit message separated by an empty line, like this:
+
+    ```
+        One-line summary of trivial change
+
+        Optional main body of commit message. It might contain a sentence
+        or two explaining the trivial change.
+
+        CLA: trivial
+    ```
+
+    It is not sufficient to only place the text "`CLA: trivial`" in the GitHub
+    pull request description.
 
     [Contributor License Agreement]: <https://www.openssl.org/policies/cla.html>
 
@@ -33,7 +44,7 @@ guidelines:
     ```
         git commit --amend
         [add the line, save and quit the editor]
-        git push -f
+        git push -f <repository> <branch>
     ```
 
  2. All source files should start with the following text (with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,8 @@ guidelines:
 
     ```
         git commit --amend
-        [add the line, save and quit the editor]
-        git push -f <repository> <branch>
+        # add the line, save and quit the editor
+        git push -f [<repository> [<branch>]]
     ```
 
  2. All source files should start with the following text (with


### PR DESCRIPTION
The text "CLA: trivial" should go at the bottom of the commit message. Also, update the force-push command to include the repository and branch, which can avoid unexpected force-push results.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
