### PR TITLE
(Reopened PR) Add constant-time implementation for `ossl_cipher_unpadblock`

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -877,7 +877,11 @@ void ERR_add_error_vdata(int num, va_list args)
         OPENSSL_free(str);
 }
 
-void err_clear_last_constant_time(int clear)
+/*
+ * Expected usage pattern is to unconditionally set error and then
+ * wipe it if there was no actual error. |clear| is 1 or 0.
+ */
+void ERR_clear_last_constant_time(int clear)
 {
     ERR_STATE *es;
     int top;

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -28,6 +28,7 @@
 #include "internal/refcount.h"
 #include "internal/bio.h"
 #include "internal/core.h"
+#include "internal/constant_time.h"
 #include "provider_local.h"
 #include "crypto/context.h"
 #ifndef FIPS_MODULE
@@ -1920,6 +1921,7 @@ static OSSL_FUNC_core_set_error_debug_fn core_set_error_debug;
 static OSSL_FUNC_core_vset_error_fn core_vset_error;
 static OSSL_FUNC_core_set_error_mark_fn core_set_error_mark;
 static OSSL_FUNC_core_clear_last_error_mark_fn core_clear_last_error_mark;
+static OSSL_FUNC_core_clear_last_constant_time_fn core_clear_last_constant_time;
 static OSSL_FUNC_core_pop_error_to_mark_fn core_pop_error_to_mark;
 OSSL_FUNC_BIO_new_file_fn ossl_core_bio_new_file;
 OSSL_FUNC_BIO_new_membuf_fn ossl_core_bio_new_mem_buf;
@@ -2089,6 +2091,11 @@ static int core_clear_last_error_mark(const OSSL_CORE_HANDLE *handle)
     return ERR_clear_last_mark();
 }
 
+static void core_clear_last_constant_time(const OSSL_CORE_HANDLE *handle, int clear)
+{
+    ERR_clear_last_constant_time(clear);
+}
+
 static int core_pop_error_to_mark(const OSSL_CORE_HANDLE *handle)
 {
     return ERR_pop_to_mark();
@@ -2242,6 +2249,7 @@ static const OSSL_DISPATCH core_dispatch_[] = {
     { OSSL_FUNC_CORE_SET_ERROR_MARK, (void (*)(void))core_set_error_mark },
     { OSSL_FUNC_CORE_CLEAR_LAST_ERROR_MARK,
       (void (*)(void))core_clear_last_error_mark },
+    { OSSL_FUNC_CORE_CLEAR_LAST_CONSTANT_TIME, (void (*)(void))core_clear_last_constant_time },
     { OSSL_FUNC_CORE_POP_ERROR_TO_MARK, (void (*)(void))core_pop_error_to_mark },
     { OSSL_FUNC_BIO_NEW_FILE, (void (*)(void))ossl_core_bio_new_file },
     { OSSL_FUNC_BIO_NEW_MEMBUF, (void (*)(void))ossl_core_bio_new_mem_buf },

--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -306,7 +306,7 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
      * in case of padding failure in the FIPS provider.
      */
     ERR_raise(ERR_LIB_RSA, RSA_R_OAEP_DECODING_ERROR);
-    err_clear_last_constant_time(1 & good);
+    ERR_clear_last_constant_time(1 & good);
 #endif
  cleanup:
     OPENSSL_cleanse(seed, sizeof(seed));

--- a/crypto/rsa/rsa_ossl.c
+++ b/crypto/rsa/rsa_ossl.c
@@ -643,7 +643,7 @@ static int rsa_ossl_private_decrypt(int flen, const unsigned char *from,
      * in case of padding failure in the FIPS provider.
      */
     ERR_raise(ERR_LIB_RSA, RSA_R_PADDING_CHECK_FAILED);
-    err_clear_last_constant_time(1 & ~constant_time_msb(r));
+    ERR_clear_last_constant_time(1 & ~constant_time_msb(r));
 #endif
 
  err:

--- a/crypto/rsa/rsa_pk1.c
+++ b/crypto/rsa/rsa_pk1.c
@@ -269,7 +269,7 @@ int RSA_padding_check_PKCS1_type_2(unsigned char *to, int tlen,
      * in case of padding failure in the FIPS provider.
      */
     ERR_raise(ERR_LIB_RSA, RSA_R_PKCS_DECODING_ERROR);
-    err_clear_last_constant_time(1 & good);
+    ERR_clear_last_constant_time(1 & good);
 #endif
 
     return constant_time_select_int(good, mlen, -1);

--- a/doc/build.info
+++ b/doc/build.info
@@ -1071,6 +1071,10 @@ DEPEND[html/man3/ERR_clear_error.html]=man3/ERR_clear_error.pod
 GENERATE[html/man3/ERR_clear_error.html]=man3/ERR_clear_error.pod
 DEPEND[man/man3/ERR_clear_error.3]=man3/ERR_clear_error.pod
 GENERATE[man/man3/ERR_clear_error.3]=man3/ERR_clear_error.pod
+DEPEND[html/man3/ERR_clear_last_constant_time.html]=man3/ERR_clear_last_constant_time.pod
+GENERATE[html/man3/ERR_clear_last_constant_time.html]=man3/ERR_clear_last_constant_time.pod
+DEPEND[man/man3/ERR_clear_last_constant_time.3]=man3/ERR_clear_last_constant_time.pod
+GENERATE[man/man3/ERR_clear_last_constant_time.3]=man3/ERR_clear_last_constant_time.pod
 DEPEND[html/man3/ERR_error_string.html]=man3/ERR_error_string.pod
 GENERATE[html/man3/ERR_error_string.html]=man3/ERR_error_string.pod
 DEPEND[man/man3/ERR_error_string.3]=man3/ERR_error_string.pod
@@ -3191,6 +3195,7 @@ html/man3/EC_POINT_new.html \
 html/man3/ENGINE_add.html \
 html/man3/ERR_GET_LIB.html \
 html/man3/ERR_clear_error.html \
+html/man3/ERR_clear_last_constant_time.html \
 html/man3/ERR_error_string.html \
 html/man3/ERR_get_error.html \
 html/man3/ERR_load_crypto_strings.html \
@@ -3834,6 +3839,7 @@ man/man3/EC_POINT_new.3 \
 man/man3/ENGINE_add.3 \
 man/man3/ERR_GET_LIB.3 \
 man/man3/ERR_clear_error.3 \
+man/man3/ERR_clear_last_constant_time.3 \
 man/man3/ERR_error_string.3 \
 man/man3/ERR_get_error.3 \
 man/man3/ERR_load_crypto_strings.3 \

--- a/doc/man3/ERR_clear_last_constant_time.pod
+++ b/doc/man3/ERR_clear_last_constant_time.pod
@@ -1,0 +1,35 @@
+=pod
+
+=head1 NAME
+
+ERR_clear_last_constant_time - clear last error in constant time
+
+=head1 SYNOPSIS
+
+ #include <openssl/err.h>
+
+ void ERR_clear_last_constant_time(int clear);
+
+=head1 DESCRIPTION
+
+ERR_clear_last_constant_time() removes the last error raised by L<ERR_raise(3)>
+from the error stack in constant time. It takes a parameter I<clear> that is either
+0 (error is not cleared) or 1 (error is cleared).
+
+Expected usage pattern for ERR_clear_last_constant_time() is to unconditionally set 
+error and then wipe it if there was no actual error.
+
+=head1 RETURN VALUES
+
+ERR_clear_last_constant_time does not return any values.
+
+=head1 COPYRIGHT
+
+Copyright 2003-2021 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/internal/constant_time.h
+++ b/include/internal/constant_time.h
@@ -15,6 +15,17 @@
 # include <string.h>
 # include <openssl/e_os2.h>              /* For 'ossl_inline' */
 
+#define CONSTTIME_TRUE (unsigned)(~0)
+#define CONSTTIME_FALSE 0
+#define CONSTTIME_TRUE_8 0xff
+#define CONSTTIME_FALSE_8 0
+#define CONSTTIME_TRUE_S ~((size_t)0)
+#define CONSTTIME_FALSE_S 0
+#define CONSTTIME_TRUE_32 (uint32_t)(~(uint32_t)0)
+#define CONSTTIME_FALSE_32 0
+#define CONSTTIME_TRUE_64 (uint64_t)(~(uint64_t)0)
+#define CONSTTIME_FALSE_64 0
+
 /*-
  * The boolean methods return a bitmask of all ones (0xff...f) for true
  * and 0 for false. This is useful for choosing a value based on the result
@@ -411,11 +422,5 @@ static ossl_inline void constant_time_lookup(void *out,
             *(outc + j) |= constant_time_select_8(mask, *(tablec++), 0);
     }
 }
-
-/*
- * Expected usage pattern is to unconditionally set error and then
- * wipe it if there was no actual error. |clear| is 1 or 0.
- */
-void err_clear_last_constant_time(int clear);
 
 #endif                          /* OSSL_INTERNAL_CONSTANT_TIME_H */

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -97,6 +97,10 @@ OSSL_CORE_MAKE_FUNC(int, core_pop_error_to_mark, (const OSSL_CORE_HANDLE *prov))
 #define OSSL_FUNC_CORE_OBJ_ADD_SIGID          11
 #define OSSL_FUNC_CORE_OBJ_CREATE             12
 
+#define OSSL_FUNC_CORE_CLEAR_LAST_CONSTANT_TIME 13
+OSSL_CORE_MAKE_FUNC(void, core_clear_last_constant_time,
+                    (const OSSL_CORE_HANDLE *prov, int clear))
+
 OSSL_CORE_MAKE_FUNC(int, core_obj_add_sigid,
                     (const OSSL_CORE_HANDLE *prov, const char  *sign_name,
                      const char *digest_name, const char *pkey_name))

--- a/include/openssl/err.h.in
+++ b/include/openssl/err.h.in
@@ -494,6 +494,8 @@ void OSSL_ERR_STATE_save_to_mark(ERR_STATE *es);
 void OSSL_ERR_STATE_restore(const ERR_STATE *es);
 void OSSL_ERR_STATE_free(ERR_STATE *es);
 
+void ERR_clear_last_constant_time(int clear);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -15,6 +15,7 @@
 #include <openssl/rand.h> /* RAND_get0_public() */
 #include <openssl/proverr.h>
 #include "internal/cryptlib.h"
+#include "internal/constant_time.h"
 #include "prov/implementations.h"
 #include "prov/names.h"
 #include "prov/provider_ctx.h"
@@ -62,6 +63,7 @@ static OSSL_FUNC_core_set_error_debug_fn *c_set_error_debug;
 static OSSL_FUNC_core_vset_error_fn *c_vset_error;
 static OSSL_FUNC_core_set_error_mark_fn *c_set_error_mark;
 static OSSL_FUNC_core_clear_last_error_mark_fn *c_clear_last_error_mark;
+static OSSL_FUNC_core_clear_last_constant_time_fn *c_clear_last_constant_time;
 static OSSL_FUNC_core_pop_error_to_mark_fn *c_pop_error_to_mark;
 static OSSL_FUNC_CRYPTO_malloc_fn *c_CRYPTO_malloc;
 static OSSL_FUNC_CRYPTO_zalloc_fn *c_CRYPTO_zalloc;
@@ -626,6 +628,9 @@ int OSSL_provider_init_int(const OSSL_CORE_HANDLE *handle,
             set_func(c_clear_last_error_mark,
                      OSSL_FUNC_core_clear_last_error_mark(in));
             break;
+        case OSSL_FUNC_CORE_CLEAR_LAST_CONSTANT_TIME:
+            set_func(c_clear_last_constant_time, OSSL_FUNC_core_clear_last_constant_time(in));
+            break;
         case OSSL_FUNC_CORE_POP_ERROR_TO_MARK:
             set_func(c_pop_error_to_mark, OSSL_FUNC_core_pop_error_to_mark(in));
             break;
@@ -848,6 +853,11 @@ int ERR_set_mark(void)
 int ERR_clear_last_mark(void)
 {
     return c_clear_last_error_mark(NULL);
+}
+
+void ERR_clear_last_constant_time(int clear)
+{
+    c_clear_last_constant_time(NULL, clear);
 }
 
 int ERR_pop_to_mark(void)

--- a/test/constant_time_test.c
+++ b/test/constant_time_test.c
@@ -15,17 +15,6 @@
 #include "testutil.h"
 #include "internal/numbers.h"
 
-static const unsigned int CONSTTIME_TRUE = (unsigned)(~0);
-static const unsigned int CONSTTIME_FALSE = 0;
-static const unsigned char CONSTTIME_TRUE_8 = 0xff;
-static const unsigned char CONSTTIME_FALSE_8 = 0;
-static const size_t CONSTTIME_TRUE_S = ~((size_t)0);
-static const size_t CONSTTIME_FALSE_S = 0;
-static uint32_t CONSTTIME_TRUE_32 = (uint32_t)(~(uint32_t)0);
-static uint32_t CONSTTIME_FALSE_32 = 0;
-static uint64_t CONSTTIME_TRUE_64 = (uint64_t)(~(uint64_t)0);
-static uint64_t CONSTTIME_FALSE_64 = 0;
-
 static unsigned int test_values[] = {
     0, 1, 1024, 12345, 32000, UINT_MAX / 2 - 1,
     UINT_MAX / 2, UINT_MAX / 2 + 1, UINT_MAX - 1,

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5544,3 +5544,4 @@ OSSL_CMP_SRV_CTX_init_trans             ?	3_3_0	EXIST::FUNCTION:CMP
 EVP_DigestSqueeze                       ?	3_3_0	EXIST::FUNCTION:
 ERR_pop                                 ?	3_3_0	EXIST::FUNCTION:
 X509_STORE_get1_objects                 ?	3_3_0	EXIST::FUNCTION:
+ERR_clear_last_constant_time            ?	3_3_0	EXIST::FUNCTION:


### PR DESCRIPTION
This PR implements the remaining TODOs from the closed PR https://github.com/openssl/openssl/pull/16323.

*Original PR author*: @ntauth
*Original PR description*: This PR refers to issue #16230 (ossl_cipher_unpadblock is not constant-time). Before this fix, ossl_cipher_unpadblock would unpad (i.e., remove the padding) the final block in non-constant time. This PR proposes a constant-time implementation for the function in question as well as additional minor changes to referencing functions, EVP_DecryptFinal_ex and ossl_cipher_generic_block_final, such that constant-timedness is preserved. It is worth noting that calls to ERR_raise have been removed since raising errors mandates branching on secret values (e.g., whether the padding is good). This is further corroborated by the implementations of SSL and TLS unpadding, namely ssl3_cbc_remove_padding_and_mac and tls1_cbc_remove_padding_and_mac, both referenced by ossl_cipher_tlsunpadblock, where ERR_raise is not called.
