### PR TITLE
Allow provider sigalgs in SignatureAlgorithms conf

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3685,13 +3685,13 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         return tls1_set_sigalgs(sc->cert, parg, larg, 0);
 
     case SSL_CTRL_SET_SIGALGS_LIST:
-        return tls1_set_sigalgs_list(sc->cert, parg, 0);
+        return tls1_set_sigalgs_list(s->ctx, sc->cert, parg, 0);
 
     case SSL_CTRL_SET_CLIENT_SIGALGS:
         return tls1_set_sigalgs(sc->cert, parg, larg, 1);
 
     case SSL_CTRL_SET_CLIENT_SIGALGS_LIST:
-        return tls1_set_sigalgs_list(sc->cert, parg, 1);
+        return tls1_set_sigalgs_list(s->ctx, sc->cert, parg, 1);
 
     case SSL_CTRL_GET_CLIENT_CERT_TYPES:
         {
@@ -3968,13 +3968,13 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
         return tls1_set_sigalgs(ctx->cert, parg, larg, 0);
 
     case SSL_CTRL_SET_SIGALGS_LIST:
-        return tls1_set_sigalgs_list(ctx->cert, parg, 0);
+        return tls1_set_sigalgs_list(ctx, ctx->cert, parg, 0);
 
     case SSL_CTRL_SET_CLIENT_SIGALGS:
         return tls1_set_sigalgs(ctx->cert, parg, larg, 1);
 
     case SSL_CTRL_SET_CLIENT_SIGALGS_LIST:
-        return tls1_set_sigalgs_list(ctx->cert, parg, 1);
+        return tls1_set_sigalgs_list(ctx, ctx->cert, parg, 1);
 
     case SSL_CTRL_SET_CLIENT_CERT_TYPES:
         return ssl3_set_req_cert_type(ctx->cert, parg, larg);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3061,7 +3061,7 @@ long SSL_CTX_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
             return tls1_set_groups_list(ctx, NULL, NULL, parg);
         case SSL_CTRL_SET_SIGALGS_LIST:
         case SSL_CTRL_SET_CLIENT_SIGALGS_LIST:
-            return tls1_set_sigalgs_list(NULL, parg, 0);
+            return tls1_set_sigalgs_list(ctx, NULL, parg, 0);
         default:
             return 0;
         }

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2801,7 +2801,7 @@ __owur int tls_use_ticket(SSL_CONNECTION *s);
 
 void ssl_set_sig_mask(uint32_t *pmask_a, SSL_CONNECTION *s, int op);
 
-__owur int tls1_set_sigalgs_list(CERT *c, const char *str, int client);
+__owur int tls1_set_sigalgs_list(SSL_CTX *ctx, CERT *c, const char *str, int client);
 __owur int tls1_set_raw_sigalgs(CERT *c, const uint16_t *psigs, size_t salglen,
                                 int client);
 __owur int tls1_set_sigalgs(CERT *c, const int *salg, size_t salglen,

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -714,6 +714,7 @@ int ssl_load_sigalgs(SSL_CTX *ctx)
 
     /* now populate ctx->ssl_cert_info */
     if (ctx->sigalg_list_len > 0) {
+        OPENSSL_free(ctx->ssl_cert_info);
         ctx->ssl_cert_info = OPENSSL_zalloc(sizeof(lu) * ctx->sigalg_list_len);
         if (ctx->ssl_cert_info == NULL)
             return 0;

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2910,9 +2910,11 @@ static int sig_cb(const char *elem, int len, void *arg)
     if (p == NULL) {
         /* First check the providers */
         SSL_CTX *ctx_helper = OPENSSL_zalloc(sizeof(*ctx_helper));
+
         /* Load provider sigalgs */
         if (!ctx_helper || !ssl_load_sigalgs(ctx_helper)) {
           ERR_raise(ERR_LIB_SSL, ERR_R_SSL_LIB);
+          SSL_CTX_free(ctx_helper);
           return 0;
         }
         /* Check if a provider supports the sigalg */
@@ -2920,8 +2922,17 @@ static int sig_cb(const char *elem, int len, void *arg)
           if (ctx_helper->sigalg_list[i].sigalg_name != NULL
               && strcmp(etmp, ctx_helper->sigalg_list[i].sigalg_name) == 0) {
             sarg->sigalgs[sarg->sigalgcnt++] = ctx_helper->sigalg_list[i].code_point;
-            SSL_CTX_free(ctx_helper);
-            return 1;
+            break;
+          }
+        }
+        /* Check the built-in sigalgs */
+        if (i == ctx_helper->sigalg_list_len) {
+          for (i = 0, s = sigalg_lookup_tbl; i < OSSL_NELEM(sigalg_lookup_tbl);
+               i++, s++) {
+            if (s->name != NULL && strcmp(etmp, s->name) == 0) {
+              sarg->sigalgs[sarg->sigalgcnt++] = s->sigalg;
+              break;
+            }
           }
         }
         SSL_CTX_free(ctx_helper);

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2881,7 +2881,6 @@ static int sig_cb(const char *elem, int len, void *arg)
 {
     sig_cb_st *sarg = arg;
     size_t i = 0;
-    int load_success = 0;
     const SIGALG_LOOKUP *s;
     char etmp[TLS_MAX_SIGSTRING_LEN], *p;
     int sig_alg = NID_undef, hash_alg = NID_undef;
@@ -2912,23 +2911,20 @@ static int sig_cb(const char *elem, int len, void *arg)
      */
     if (p == NULL) {
         /* Load provider sigalgs */
-        if (sarg->ctx) {
-            load_success = ssl_load_sigalgs(sarg->ctx);
-        }
-        if (load_success) {
+        if (sarg->ctx != NULL) {
             /* Check if a provider supports the sigalg */
             for (i = 0; i < sarg->ctx->sigalg_list_len; i++) {
                 if (sarg->ctx->sigalg_list[i].sigalg_name != NULL
                     && strcmp(etmp,
                               sarg->ctx->sigalg_list[i].sigalg_name) == 0) {
                     sarg->sigalgs[sarg->sigalgcnt++] =
-                            sarg->ctx->sigalg_list[i].code_point;
+                        sarg->ctx->sigalg_list[i].code_point;
                     break;
                 }
             }
         }
         /* Check the built-in sigalgs */
-        if (!sarg->ctx || !load_success || i == sarg->ctx->sigalg_list_len) {
+        if (sarg->ctx == NULL || i == sarg->ctx->sigalg_list_len) {
             for (i = 0, s = sigalg_lookup_tbl;
                  i < OSSL_NELEM(sigalg_lookup_tbl); i++, s++) {
                 if (s->name != NULL && strcmp(etmp, s->name) == 0) {
@@ -2983,7 +2979,10 @@ int tls1_set_sigalgs_list(SSL_CTX *ctx, CERT *c, const char *str, int client)
 {
     sig_cb_st sig;
     sig.sigalgcnt = 0;
-    sig.ctx = ctx;
+
+    if (ctx != NULL && ssl_load_sigalgs(ctx)) {
+        sig.ctx = ctx;
+    }
     if (!CONF_parse_list(str, ':', 1, sig_cb, &sig))
         return 0;
     if (sig.sigalgcnt == 0) {

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2880,7 +2880,7 @@ static void get_sigorhash(int *psig, int *phash, const char *str)
 static int sig_cb(const char *elem, int len, void *arg)
 {
     sig_cb_st *sarg = arg;
-    size_t i;
+    size_t i = 0;
     const SIGALG_LOOKUP *s;
     char etmp[TLS_MAX_SIGSTRING_LEN], *p;
     int sig_alg = NID_undef, hash_alg = NID_undef;


### PR DESCRIPTION
Though support for provider-based signature algorithms was added in ee58915 this functionality did not work with the SignatureAlgorithms configuration command. If SignatureAlgorithms is set then the provider sigalgs are not used and instead it used the default value.

This PR adds a check against the provider-base sigalg list when parsing the SignatureAlgorithms value.

Based-on-patch-by: Martin Schmatz <mrt@zurich.ibm.com>
Fixes #22761