### PR TITLE
Adapt VMS builds to DCL extended parsing

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -15,13 +15,21 @@
   our $builddir = $config{builddir};
   sub make_unix_path {
       # Split the native path
-      (my $vol, my $dirs, my $file) = File::Spec->splitpath($_[0]);
+      my $path = $_[0];
+      # Convert any path of the VMS form VOLUME:[DIR1.DIR2]FILE to the
+      # Unix form /VOLUME/DIR1/DIR2/FILE
+
+      # Start with splitting the native path
+      (my $vol, my $dirs, my $file) = File::Spec->splitpath($path);
       my @dirs = File::Spec->splitdir($dirs);
 
       # Reassemble it as a Unix path
       $vol =~ s|:$||;
-      return File::Spec::Unix->catpath(
-          '', File::Spec::Unix->catdir('', $vol ? $vol : (), @dirs), $file);
+      $dirs = File::Spec::Unix->catdir('', $vol, @dirs);
+      $path = File::Spec::Unix->catpath('', $dirs, $file);
+      # Unescape VMS ODS-5 file name escapes (^)
+      $path =~ s|\^||g;
+      return $path;
   }
   sub sourcefile {
       catfile($sourcedir, @_);

--- a/exporters/cmake/OpenSSLConfig.cmake.in
+++ b/exporters/cmake/OpenSSLConfig.cmake.in
@@ -38,7 +38,9 @@
        # according to the conventions of the platform.
        $volume =~ s|^(.*?):$|/$1| if $^O eq "vms"; # On VMS, DEV: -> /DEV
 
-       return $volume . File::Spec::Unix->catpath('', $directories, $no_file ? () : $file);
+       $path = $volume . File::Spec::Unix->catpath('', $directories, $no_file ? () : $file);
+       # Unescape VMS ODS-5 file name escapes (^) on VMS
+       $path =~ s|\^||g if $^O eq "vms";
    }
    ""
 -}


### PR DESCRIPTION
DCL has an extended parsing mode that we aren't well adapted to.  The most
notable feature of that parsing mode is that directory and file names may
have periods in the (they aren't considered to be separators between parts
such as directories in a directory specification, or between a file's base
name and extension).

DCL solves that by allowing them to be escaped with a ^.  For example, the
uncompressed tarball for an OpenSSL release looks like this:

    openssl-3^.1^.4.tar
