### PR TITLE
Adapt C compiler detection for VSI C on x86_64

### DIFF
--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -359,8 +359,15 @@ sub determine_compiler_settings {
                 # However, other letters have been seen as well (for example X),
                 # and it's documented that HP (now VSI) reserve the letter W, X,
                 # Y and Z for their own uses.
-                my ($vendor, $version) =
-                    ( $v =~ m/^([A-Z]+) C [VWXYZ]([0-9\.-]+)(:? +\(.*?\))? on / );
+                my ($vendor, $arch, $version, $extra) =
+                    ( $v =~ m/^
+                              ([A-Z]+)                  # Usually VSI
+                              \s+ C
+                              (?:\s+(.*?))?             # Possible build arch
+                              \s+ [VWXYZ]([0-9\.-]+)    # Version
+                              (?:\s+\((.*?)\))?         # Possible extra data
+                              \s+ on
+                             /x );
                 my ($major, $minor, $patch) =
                     ( $version =~ m/^([0-9]+)\.([0-9]+)-0*?(0|[1-9][0-9]*)$/ );
                 $CC = 'CC';


### PR DESCRIPTION
VSI C on OpenVMS for x86_64 has a bit more information than on other
hardware.  This is no doubt because it's based on LLVM which leaves an
opening for cross compilation.

VSI C on Itanium:

    $ CC/VERSION
    VSI C V7.4-001 on OpenVMS IA64 V8.4-2L3

VSI C on x86_64:

    $ CC/VERSION
    VSI C x86-64 X7.4-843 (GEM 50XB9) on OpenVMS x86_64 V9.2-1
