### PR TITLE
Don't free aliased pointers in ctx cmp_ctx tests

### DIFF
--- a/test/cmp_ctx_test.c
+++ b/test/cmp_ctx_test.c
@@ -462,6 +462,7 @@ execute_CTX_##SETN##_##GETN##_##FIELD(OSSL_CMP_CTX_TEST_FIXTURE *fixture) \
     } else { \
         if (DUP && val3_read == val2_read) { \
             TEST_error("third get did not create a new dup"); \
+            val3_read = 0; \
             res = 0; \
         } \
     } \


### PR DESCRIPTION
Coverity recorded issues 1551739 and 1551737, a potential double free in the tests.  It occurs when the DUP operation fails in such a way val3_read is returned as the same pointer as val2_read.  Ideally it should never happen, but resetting val3_read to 0 should satisfy coverity that there is no issue here

