### PR TITLE
Add locking to CRYPTO_secure_used

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -269,8 +269,6 @@ size_t CRYPTO_secure_used(void)
     ret = secure_mem_used;
 
     CRYPTO_THREAD_unlock(sec_malloc_lock);
-#else
-    ret = 0;
 #endif /* OPENSSL_NO_SECURE_MEMORY */
     return ret;
 }

--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -260,11 +260,19 @@ int CRYPTO_secure_allocated(const void *ptr)
 
 size_t CRYPTO_secure_used(void)
 {
+    size_t ret = 0;
+
 #ifndef OPENSSL_NO_SECURE_MEMORY
-    return secure_mem_used;
+    if (!CRYPTO_THREAD_read_lock(sec_malloc_lock))
+        return 0;
+
+    ret = secure_mem_used;
+
+    CRYPTO_THREAD_unlock(sec_malloc_lock);
 #else
-    return 0;
+    ret = 0;
 #endif /* OPENSSL_NO_SECURE_MEMORY */
+    return ret;
 }
 
 size_t CRYPTO_secure_actual_size(void *ptr)


### PR DESCRIPTION
Coverity issue 1551719 noted CRYPTO_secure_used referenced a shared variable without taking the appropriate read lock.  Add that.

