### PR TITLE
Deprecate SPT threading support on NonStop.

### DIFF
--- a/Configurations/50-nonstop.conf
+++ b/Configurations/50-nonstop.conf
@@ -170,24 +170,6 @@
                              '_REENTRANT', '_THREAD_SUPPORT_FUNCTIONS'],
         ex_libs          => '-lput',
     },
-    'nonstop-model-spt' => {
-        template         => 1,
-        cflags           => add('-Wnowarn=140'),
-        defines          => ['_SPT_MODEL_',
-                             'SPT_THREAD_AWARE_NONBLOCK',
-                             '_REENTRANT'],
-        ex_libs          => '-lspt',
-    },
-
-    # Additional floss model that can be combined with any of the other models.
-    # If used without any of the other models, the entry that does so must
-    # disable threads.
-    'nonstop-model-floss' => {
-        template         => 1,
-        defines          => ['OPENSSL_TANDEM_FLOSS', '_ENABLE_FLOSS_THREADS'],
-        includes         => ['/usr/local/include'],
-        ex_libs          => '-lfloss',
-    },
 
     ######################################################################
     # Now for the entries themselves, let's combine things!
@@ -224,25 +206,6 @@
                               'nonstop-model-put' ],
         multilib         => '64-put',
         multibin         => '64-put',
-    },
-    'nonstop-nsx_spt' => {
-        inherit_from     => [ 'nonstop-common',
-                              'nonstop-archenv-x86_64-oss',
-                              'nonstop-ilp32',
-                              'nonstop-efloat-x86_64',
-                              'nonstop-model-spt' ],
-        multilib         => '-spt',
-        multibin         => '-spt',
-    },
-    'nonstop-nsx_spt_floss' => {
-        inherit_from     => [ 'nonstop-common',
-                              'nonstop-archenv-x86_64-oss',
-                              'nonstop-ilp32',
-                              'nonstop-efloat-x86_64',
-                              'nonstop-model-floss',
-                              'nonstop-model-spt'],
-        multilib         => '-spt',
-        multibin         => '-spt',
     },
     'nonstop-nsx_g' => {
         inherit_from     => [ 'nonstop-common',
@@ -292,24 +255,6 @@
                               'nonstop-model-put' ],
         multilib         => '64-put',
         multibin         => '64-put',
-    },
-    'nonstop-nse_spt' => {
-        inherit_from     => [ 'nonstop-common',
-                              'nonstop-archenv-itanium-oss',
-                              'nonstop-ilp32',
-                              'nonstop-efloat-itanium',
-                              'nonstop-model-spt' ],
-        multilib         => '-spt',
-        multibin         => '-spt',
-    },
-    'nonstop-nse_spt_floss' => {
-        inherit_from     => [ 'nonstop-common',
-                              'nonstop-archenv-itanium-oss',
-                              'nonstop-ilp32',
-                              'nonstop-efloat-itanium',
-                              'nonstop-model-floss', 'nonstop-model-spt' ],
-        multilib         => '-spt',
-        multibin         => '-spt',
     },
     'nonstop-nse_g' => {
         inherit_from     => [ 'nonstop-common',

--- a/NOTES-NONSTOP.md
+++ b/NOTES-NONSTOP.md
@@ -26,15 +26,16 @@ is the only FLOSS variant that has been broadly tested.
 Threading Models
 ----------------
 
-OpenSSL can be built using unthreaded, POSIX User Threads (PUT), or Standard
-POSIX Threads (SPT). Select the following build configuration for each on
-the TNS/X (L-Series) platform:
+OpenSSL can be built either using the POSIX User Threads (PUT) threading model,
+or with threading support disabled. Select the following build configuration
+for each on the TNS/X (L-Series) platform:
 
- * `nonstop-nsx` or default will select an unthreaded build.
+ * `nonstop-nsx` or default will select an unthreaded 32-bit build.
+ * `nonstop-nsx_64` selects an unthreaded 64-bit memory and file length build.
  * `nonstop-nsx_put` selects the PUT build.
- * `nonstop-nsx_64_put` selects the 64 bit file length PUT build.
- * `nonstop-nsx_spt_floss` selects the SPT build with FLOSS. FLOSS is
-   required for SPT builds because of a known hang when using SPT on its own.
+ * `nonstop-nsx_64_put` selects the 64-bit memory and file length PUT build.
+
+The SPT threading model is no longer supported as of OpenSSL 3.2.
 
 ### TNS/E Considerations
 
@@ -145,9 +146,7 @@ update this list:
 - nonstop-nsx_64_put
 
 **Note:** Cross-compile builds for TNS/E have not been attempted, but should
-follow the same considerations as for TNS/X above. SPT builds generally require
-FLOSS, which is not available for workstation builds. As a result, SPT builds
-of OpenSSL cannot be cross-compiled.
+follow the same considerations as for TNS/X above.
 
 Also see the NSDEE discussion below for more historical information.
 
@@ -223,9 +222,6 @@ assumes that your PWD is set according to your installation standards.
     ./Configure nonstop-nsx_put       --prefix=${PWD} \
         --openssldir=${PWD}/ssl threads "-D_REENTRANT" \
         --with-rand-seed=rdcpu ${CIPHENABLES} ${DBGFLAG} ${SYSTEMLIBS}
-    ./Configure nonstop-nsx_spt_floss --prefix=${PWD} \
-        --openssldir=${PWD}/ssl threads "-D_REENTRANT" \
-        --with-rand-seed=rdcpu ${CIPHENABLES} ${DBGFLAG} ${SYSTEMLIBS}
     ./Configure nonstop-nsx_64        --prefix=${PWD} \
         --openssldir=${PWD}/ssl no-threads \
         --with-rand-seed=rdcpu ${CIPHENABLES} ${DBGFLAG} ${SYSTEMLIBS}
@@ -243,9 +239,6 @@ assumes that your PWD is set according to your installation standards.
         --openssldir=${PWD}/ssl no-threads \
         --with-rand-seed=egd ${CIPHENABLES} ${DBGFLAG} ${SYSTEMLIBS}
     ./Configure nonstop-nse_put       --prefix=${PWD} \
-        --openssldir=${PWD}/ssl threads "-D_REENTRANT" \
-        --with-rand-seed=egd ${CIPHENABLES} ${DBGFLAG} ${SYSTEMLIBS}
-    ./Configure nonstop-nse_spt_floss --prefix=${PWD} \
         --openssldir=${PWD}/ssl threads "-D_REENTRANT" \
         --with-rand-seed=egd ${CIPHENABLES} ${DBGFLAG} ${SYSTEMLIBS}
     ./Configure nonstop-nse_64        --prefix=${PWD} \

--- a/crypto/bio/bio_sock.c
+++ b/crypto/bio/bio_sock.c
@@ -354,7 +354,7 @@ int BIO_socket_nbio(int s, int mode)
     int l;
 
     l = mode;
-# if defined(FIONBIO) && !defined(OPENSSL_SYS_TANDEM)
+# ifdef FIONBIO
     l = mode;
 
     ret = BIO_socket_ioctl(s, FIONBIO, &l);


### PR DESCRIPTION
This fix removes explicit support for the SPT threading model in configurations. This also reverts commit f63e1b48ac893dd6110452e70ed08f191547cd89 that were required for SPT but broke other models.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

