### PR TITLE
Extend test case for reused PEM_ASN1_read_bio

### DIFF
--- a/crypto/asn1/tasn_fre.c
+++ b/crypto/asn1/tasn_fre.c
@@ -85,8 +85,12 @@ void ossl_asn1_item_embed_free(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed
 
     case ASN1_ITYPE_NDEF_SEQUENCE:
     case ASN1_ITYPE_SEQUENCE:
-        if (ossl_asn1_do_lock(pval, -1, it) != 0) /* if error or ref-counter > 0 */
+        if (ossl_asn1_do_lock(pval, -1, it) != 0) {
+            /* if error or ref-counter > 0 */
+            OPENSSL_assert(embed == 0);
+            *pval = NULL;
             return;
+        }
         if (asn1_cb) {
             i = asn1_cb(ASN1_OP_FREE_PRE, pval, it, NULL);
             if (i == 2)

--- a/test/crltest.c
+++ b/test/crltest.c
@@ -101,6 +101,13 @@ static const char *kRevokedCRL[] = {
     NULL
 };
 
+static const char *kInvalidCRL[] = {
+    "-----BEGIN X509 CRL-----\n",
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n",
+    "-----END X509 CRL-----\n",
+    NULL
+};
+
 static const char *kBadIssuerCRL[] = {
     "-----BEGIN X509 CRL-----\n",
     "MIIBwjCBqwIBATANBgkqhkiG9w0BAQsFADBSMQswCQYDVQQGEwJVUzETMBEGA1UE\n",
@@ -371,24 +378,45 @@ static int test_unknown_critical_crl(int n)
     return r;
 }
 
-static int test_reuse_crl(void)
+static int test_reuse_crl(int idx)
 {
-    X509_CRL *reused_crl = CRL_from_strings(kBasicCRL);
+    X509_CRL *result, *reused_crl = CRL_from_strings(kBasicCRL);
     char *p;
-    BIO *b = glue2bio(kRevokedCRL, &p);
+    BIO *b = glue2bio(idx == 2 ? kRevokedCRL : kInvalidCRL + idx, &p);
+    int r = 0;
 
-    if (b == NULL) {
-        OPENSSL_free(p);
-        X509_CRL_free(reused_crl);
-        return 0;
+    if (!TEST_ptr(reused_crl)
+            || !TEST_ptr(b))
+        goto err;
+
+    result = PEM_read_bio_X509_CRL(b, &reused_crl, NULL, NULL);
+
+    switch (idx) {
+    case 0: /* valid PEM + invalid DER */
+        if (!TEST_ptr_null(result)
+                || !TEST_ptr_null(reused_crl))
+            goto err;
+        break;
+    case 1: /* invalid PEM */
+        if (!TEST_ptr_null(result)
+                || !TEST_ptr(reused_crl))
+            goto err;
+        break;
+    case 2:
+        if (!TEST_ptr(result)
+                || !TEST_ptr(reused_crl)
+                || !TEST_ptr_eq(result, reused_crl))
+            goto err;
+        break;
     }
 
-    reused_crl = PEM_read_bio_X509_CRL(b, &reused_crl, NULL, NULL);
+    r = 1;
 
+ err:
     OPENSSL_free(p);
     BIO_free(b);
     X509_CRL_free(reused_crl);
-    return 1;
+    return r;
 }
 
 int setup_tests(void)
@@ -402,7 +430,7 @@ int setup_tests(void)
     ADD_TEST(test_bad_issuer_crl);
     ADD_TEST(test_known_critical_crl);
     ADD_ALL_TESTS(test_unknown_critical_crl, OSSL_NELEM(unknown_critical_crls));
-    ADD_TEST(test_reuse_crl);
+    ADD_ALL_TESTS(test_reuse_crl, 3);
     return 1;
 }
 


### PR DESCRIPTION
This is related to #22780, simply add test cases
for the different failure modes of PEM_ASN1_read_bio. Depending on whether the PEM or the DER format is valid or not, the passed in CRL may be deleted ot not, therefore a statement like this:

reused_crl = PEM_read_bio_X509_CRL(b, &reused_crl, NULL, NULL);

must be avoided, because it can create memory leaks.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
