### PR TITLE
Do not define L_ENDIAN (for now) when we guessed linux64-loongarch64

### DIFF
--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -691,7 +691,6 @@ EOF
                 $disable = [];
             }
             return { target => "linux64-loongarch64",
-                     defines => [ 'L_ENDIAN' ],
                      disable => $disable, };
         }
       ],


### PR DESCRIPTION
In 160f48941d14 I made L_ENDIAN defined when the system is guessed to be linux64-loongarch64.  Unfortunately now I found it problematic:

1. This should be added into Configurations/10-main.conf, not here. Having it here causes a different configuration when linux64-loongarch64 is explicitly specified than guessed.
2. With LTO enabled, this causes many test failures on linux64-loongarch64 due to #12247.

So I think we should remove it for now (master and 3.2 branch), and reintroduce it to Configurations/10-main.conf when we finally sort out #12247.