### PR TITLE
Don't include winsock2.h if any Winsock header has already been included

### DIFF
--- a/include/openssl/e_ostime.h
+++ b/include/openssl/e_ostime.h
@@ -22,7 +22,15 @@
  */
 
 # if defined(OPENSSL_SYS_WINDOWS)
-#  include <winsock2.h>
+#  if !defined(_WINSOCKAPI_)
+    /*
+     * winsock2.h defines _WINSOCK2API_ and both winsock2.h and winsock.h define
+     * _WINSOCKAPI_. Both of these provide struct timeval. Don't include
+     * winsock2.h if either header has been included to avoid breakage with
+     * applications that prefer to use <winsock.h> over <winsock2.h>.
+     */
+#   include <winsock2.h>
+#  endif
 # else
 #  include <sys/time.h>
 # endif


### PR DESCRIPTION
Fixes #22811