### PR TITLE
LoongArch64 assembly pack: Really implement OPENSSL_rdtsc

### DIFF
--- a/crypto/loongarch64cpuid.pl
+++ b/crypto/loongarch64cpuid.pl
@@ -101,8 +101,8 @@ $code.=<<___;
 .globl OPENSSL_rdtsc
 .type   OPENSSL_rdtsc,\@function
 OPENSSL_rdtsc:
-    move    $a0,$zero
-    jr      $ra
+    rdtimel.w $a0,$zero
+    jr        $ra
 ___
 }
 


### PR DESCRIPTION
LoongArch [rdtimel.w][1] instruction reads the low 32 bits of the 64-bit stable counter, implement OPENSSL_rdtsc with it instead of always returning 0.

[1]:https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html#_rdtimelh_w_rdtime_d
