### PR TITLE
Fix implementation of `PreferNoDHEKEX` option. `tls_parse_ctos_key_sh…

### DIFF
--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1393,8 +1393,7 @@ static int final_key_share(SSL_CONNECTION *s, unsigned int context, int sent)
      *             the client sent a key_share extension
      *             AND
      *             (we are not resuming
-     *              OR (the kex_mode allows key_share resumes
-     *                  AND (kex_mode doesn't allow non-dh resumes OR non-dh is not preferred)))
+     *              OR the kex_mode allows key_share resumes)
      *             AND
      *             a shared group exists
      *         THEN
@@ -1429,18 +1428,10 @@ static int final_key_share(SSL_CONNECTION *s, unsigned int context, int sent)
             }
         } else {
             /* No suitable key_share */
-
-            /* Do DHE PSK? */
-            int dhe_psk =
-                /* kex_mode allows key_share resume */
-                (((s->ext.psk_kex_mode & TLSEXT_KEX_MODE_FLAG_KE_DHE) != 0)
-
-                /* and psk-only is not available or not explicitly preferred */
-                && ((((s->ext.psk_kex_mode & TLSEXT_KEX_MODE_FLAG_KE) == 0)
-                    || (s->options & SSL_OP_PREFER_NO_DHE_KEX) == 0)));
-
             if (s->hello_retry_request == SSL_HRR_NONE && sent
-                    && (!s->hit || dhe_psk)) {
+                    && (!s->hit
+                        || (s->ext.psk_kex_mode & TLSEXT_KEX_MODE_FLAG_KE_DHE)
+                           != 0)) {
                 const uint16_t *pgroups, *clntgroups;
                 size_t num_groups, clnt_num_groups, i;
                 unsigned int group_id = 0;


### PR DESCRIPTION
This PR fixes an issue with the `PreferNoDHEKEX` option introduced recently (see #22794). The TLS1.3 handshake might fail in following case:

* Server has `AllowNoDHEKEX` and `PreferNoDHEKEX` configured.
* Client sends ClientHello containing
  * Key Share
  * PSK
  * Both PSK Key Exchange modes (DHE and non-DHE).

E.g.

*Server*
```sh
openssl s_server -tls1_3 -key *** -cert *** -accept *** -WWW -allow_no_dhe_kex -prefer_no_dhe_kex
```

*Client*
```sh
openssl s_client -connect *** -allow_no_dhe_kex -sess_in ***
```


The problem was introduced with #22794. In particular [`tls_parse_ctos_key_share()` did not handle the new option](https://github.com/openssl/openssl/blob/dfc836c346cc6001534eaf9ed3a151b7aa658335/ssl/statem/extensions_srvr.c#L595)  where it should have done so.

This PR changes the way `PreferNoDHEKEX` is implemented. If the client sends both PSK KEX modes, `tls_parse_ctos_psk_kex_modes()` used to add both to `struct ssl_connection_st.ext.ext.psk_kex_mode`. Code using the field then had to evaluate `SSL_OP_PREFER_NO_DHE_KEX` to find out which one to use. With this PR the approach is changed in that `tls_parse_ctos_psk_kex_modes()` does the final evaluation of `SSL_OP_PREFER_NO_DHE_KEX`. If PSK-only should be used, then `TLSEXT_KEX_MODE_FLAG_KE_DHE` is removed from the list of extensions, even if it had been sent in the ClientHello. This way no other code has to deal with `SSL_OP_PREFER_NO_DHE_KEX`, which reduces the overall complexity. This code therefore reverts some of the changes made by the original PR.