### PR TITLE
evp-cmac: do not seg-fault when getting mac-size before init

### DIFF
--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -387,7 +387,7 @@ int evp_cipher_cache_constants(EVP_CIPHER *cipher)
 
 int EVP_CIPHER_get_block_size(const EVP_CIPHER *cipher)
 {
-    return cipher != NULL ? cipher->block_size : 0;
+    return cipher->block_size;
 }
 
 int EVP_CIPHER_CTX_get_block_size(const EVP_CIPHER_CTX *ctx)

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -387,7 +387,7 @@ int evp_cipher_cache_constants(EVP_CIPHER *cipher)
 
 int EVP_CIPHER_get_block_size(const EVP_CIPHER *cipher)
 {
-    return cipher->block_size;
+    return cipher != NULL ? cipher->block_size : 0;
 }
 
 int EVP_CIPHER_CTX_get_block_size(const EVP_CIPHER_CTX *ctx)

--- a/providers/implementations/macs/cmac_prov.c
+++ b/providers/implementations/macs/cmac_prov.c
@@ -101,8 +101,12 @@ static void *cmac_dup(void *vsrc)
 static size_t cmac_size(void *vmacctx)
 {
     struct cmac_data_st *macctx = vmacctx;
+    const EVP_CIPHER_CTX *cipherctx = CMAC_CTX_get0_cipher_ctx(macctx->ctx);
 
-    return EVP_CIPHER_CTX_get_block_size(CMAC_CTX_get0_cipher_ctx(macctx->ctx));
+    if (EVP_CIPHER_CTX_get0_cipher(cipherctx) == NULL)
+        return 0;
+
+    return EVP_CIPHER_CTX_get_block_size(cipherctx);
 }
 
 static int cmac_setkey(struct cmac_data_st *macctx,


### PR DESCRIPTION
Add null check to avoid seg-fault encountered with cmac when `EVP_MAC_CTX_get_mac_size()` is called before init.

Extend mac testing in `evp_test.c` to check that the sizes returned by `EVP_MAC_CTX_get_mac_size()` before and after init make sense (this also checks that we no longer seg-fault).

Fixes #22842

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
