### PR TITLE
After initializing a provider, check if its output dispatch table is NULL

### DIFF
--- a/apps/list.c
+++ b/apps/list.c
@@ -1238,6 +1238,9 @@ static void list_provider_info(void)
     sk_OSSL_PROVIDER_sort(providers);
     for (i = 0; i < sk_OSSL_PROVIDER_num(providers); i++) {
         const OSSL_PROVIDER *prov = sk_OSSL_PROVIDER_value(providers, i);
+        const char *provname = OSSL_PROVIDER_get0_name(prov);
+
+        BIO_printf(bio_out, "  %s\n", provname);
 
         /* Query the "known" information parameters, the order matches below */
         params[0] = OSSL_PARAM_construct_utf8_ptr(OSSL_PROV_PARAM_NAME,
@@ -1250,23 +1253,23 @@ static void list_provider_info(void)
         params[4] = OSSL_PARAM_construct_end();
         OSSL_PARAM_set_all_unmodified(params);
         if (!OSSL_PROVIDER_get_params(prov, params)) {
-            BIO_printf(bio_err, "ERROR: Unable to query provider parameters\n");
-            return;
-        }
-
-        /* Print out the provider information, the params order matches above */
-        BIO_printf(bio_out, "  %s\n", OSSL_PROVIDER_get0_name(prov));
-        if (OSSL_PARAM_modified(params))
-            BIO_printf(bio_out, "    name: %s\n", name);
-        if (OSSL_PARAM_modified(params + 1))
-            BIO_printf(bio_out, "    version: %s\n", version);
-        if (OSSL_PARAM_modified(params + 2))
-            BIO_printf(bio_out, "    status: %sactive\n", status ? "" : "in");
-        if (verbose) {
-            if (OSSL_PARAM_modified(params + 3))
-                BIO_printf(bio_out, "    build info: %s\n", buildinfo);
-            print_param_types("gettable provider parameters",
-                              OSSL_PROVIDER_gettable_params(prov), 4);
+            BIO_printf(bio_err,
+                       "WARNING: Unable to query provider parameters for %s\n",
+                       provname);
+        } else {
+            /* Print out the provider information, the params order matches above */
+            if (OSSL_PARAM_modified(params))
+                BIO_printf(bio_out, "    name: %s\n", name);
+            if (OSSL_PARAM_modified(params + 1))
+                BIO_printf(bio_out, "    version: %s\n", version);
+            if (OSSL_PARAM_modified(params + 2))
+                BIO_printf(bio_out, "    status: %sactive\n", status ? "" : "in");
+            if (verbose) {
+                if (OSSL_PARAM_modified(params + 3))
+                    BIO_printf(bio_out, "    build info: %s\n", buildinfo);
+                print_param_types("gettable provider parameters",
+                                  OSSL_PROVIDER_gettable_params(prov), 4);
+            }
         }
     }
     sk_OSSL_PROVIDER_free(providers);

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -970,45 +970,46 @@ static int provider_init(OSSL_PROVIDER *prov)
     prov->provctx = tmp_provctx;
     prov->dispatch = provider_dispatch;
 
-    for (; provider_dispatch->function_id != 0; provider_dispatch++) {
-        switch (provider_dispatch->function_id) {
-        case OSSL_FUNC_PROVIDER_TEARDOWN:
-            prov->teardown =
-                OSSL_FUNC_provider_teardown(provider_dispatch);
-            break;
-        case OSSL_FUNC_PROVIDER_GETTABLE_PARAMS:
-            prov->gettable_params =
-                OSSL_FUNC_provider_gettable_params(provider_dispatch);
-            break;
-        case OSSL_FUNC_PROVIDER_GET_PARAMS:
-            prov->get_params =
-                OSSL_FUNC_provider_get_params(provider_dispatch);
-            break;
-        case OSSL_FUNC_PROVIDER_SELF_TEST:
-            prov->self_test =
-                OSSL_FUNC_provider_self_test(provider_dispatch);
-            break;
-        case OSSL_FUNC_PROVIDER_GET_CAPABILITIES:
-            prov->get_capabilities =
-                OSSL_FUNC_provider_get_capabilities(provider_dispatch);
-            break;
-        case OSSL_FUNC_PROVIDER_QUERY_OPERATION:
-            prov->query_operation =
-                OSSL_FUNC_provider_query_operation(provider_dispatch);
-            break;
-        case OSSL_FUNC_PROVIDER_UNQUERY_OPERATION:
-            prov->unquery_operation =
-                OSSL_FUNC_provider_unquery_operation(provider_dispatch);
-            break;
+    if (provider_dispatch != NULL)
+        for (; provider_dispatch->function_id != 0; provider_dispatch++) {
+            switch (provider_dispatch->function_id) {
+            case OSSL_FUNC_PROVIDER_TEARDOWN:
+                prov->teardown =
+                    OSSL_FUNC_provider_teardown(provider_dispatch);
+                break;
+            case OSSL_FUNC_PROVIDER_GETTABLE_PARAMS:
+                prov->gettable_params =
+                    OSSL_FUNC_provider_gettable_params(provider_dispatch);
+                break;
+            case OSSL_FUNC_PROVIDER_GET_PARAMS:
+                prov->get_params =
+                    OSSL_FUNC_provider_get_params(provider_dispatch);
+                break;
+            case OSSL_FUNC_PROVIDER_SELF_TEST:
+                prov->self_test =
+                    OSSL_FUNC_provider_self_test(provider_dispatch);
+                break;
+            case OSSL_FUNC_PROVIDER_GET_CAPABILITIES:
+                prov->get_capabilities =
+                    OSSL_FUNC_provider_get_capabilities(provider_dispatch);
+                break;
+            case OSSL_FUNC_PROVIDER_QUERY_OPERATION:
+                prov->query_operation =
+                    OSSL_FUNC_provider_query_operation(provider_dispatch);
+                break;
+            case OSSL_FUNC_PROVIDER_UNQUERY_OPERATION:
+                prov->unquery_operation =
+                    OSSL_FUNC_provider_unquery_operation(provider_dispatch);
+                break;
 #ifndef OPENSSL_NO_ERR
 # ifndef FIPS_MODULE
-        case OSSL_FUNC_PROVIDER_GET_REASON_STRINGS:
-            p_get_reason_strings =
-                OSSL_FUNC_provider_get_reason_strings(provider_dispatch);
-            break;
+            case OSSL_FUNC_PROVIDER_GET_REASON_STRINGS:
+                p_get_reason_strings =
+                    OSSL_FUNC_provider_get_reason_strings(provider_dispatch);
+                break;
 # endif
 #endif
-        }
+            }
     }
 
 #ifndef OPENSSL_NO_ERR

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -970,7 +970,7 @@ static int provider_init(OSSL_PROVIDER *prov)
     prov->provctx = tmp_provctx;
     prov->dispatch = provider_dispatch;
 
-    if (provider_dispatch != NULL)
+    if (provider_dispatch != NULL) {
         for (; provider_dispatch->function_id != 0; provider_dispatch++) {
             switch (provider_dispatch->function_id) {
             case OSSL_FUNC_PROVIDER_TEARDOWN:
@@ -1010,6 +1010,7 @@ static int provider_init(OSSL_PROVIDER *prov)
 # endif
 #endif
             }
+        }
     }
 
 #ifndef OPENSSL_NO_ERR

--- a/test/build.info
+++ b/test/build.info
@@ -1038,6 +1038,13 @@ IF[{- !$disabled{tests} -}]
       SOURCE[p_test]=p_test.ld
       GENERATE[p_test.ld]=../util/providers.num
     ENDIF
+    MODULES{noinst}=p_minimal
+    SOURCE[p_minimal]=p_minimal.c
+    INCLUDE[p_minimal]=../include ..
+    IF[{- defined $target{shared_defflag} -}]
+      SOURCE[p_minimal]=p_minimal.ld
+      GENERATE[p_minimal.ld]=../util/providers.num
+    ENDIF
   ENDIF
   IF[{- $disabled{module} || !$target{dso_scheme} -}]
     DEFINE[provider_test]=NO_PROVIDER_MODULE

--- a/test/p_minimal.c
+++ b/test/p_minimal.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019-2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * This is the most minimal provider imaginable.  It can be loaded, and does
+ * absolutely nothing else.
+ */
+
+#include <openssl/core.h>
+
+OSSL_provider_init_fn OSSL_provider_init; /* Check the function signature */
+int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
+                       const OSSL_DISPATCH *oin,
+                       const OSSL_DISPATCH **out,
+                       void **provctx)
+{
+    return 1;
+}

--- a/test/recipes/04-test_provider.t
+++ b/test/recipes/04-test_provider.t
@@ -12,10 +12,17 @@ use OpenSSL::Test::Utils;
 
 setup("test_provider");
 
-plan tests => 2;
+plan tests => 3;
 
 ok(run(test(['provider_test'])), "provider_test");
 
 $ENV{"OPENSSL_MODULES"} = bldtop_dir("test");
 
 ok(run(test(['provider_test', '-loaded'])), "provider_test -loaded");
+
+ SKIP: {
+     skip "no module support", 1 if disabled("module");
+
+     ok(run(app(['openssl', 'list', '-provider', 'p_minimal',
+                 '-providers', '-verbose'])));
+}


### PR DESCRIPTION
If the provider's output dispatch table is NULL, trying to parse it causes a
crash.  Let's not do that.

This also slightly modifies `openssl list`, so it doesn't stop listing
providers just because one failed to return provider parameters.
