### PR TITLE
Fix test/recipes/01-test_symbol_presence.t (multiple issues)

### DIFF
--- a/test/recipes/01-test_symbol_presence.t
+++ b/test/recipes/01-test_symbol_presence.t
@@ -114,23 +114,38 @@ foreach (sort keys %stlibname) {
     my @arrays = ( \@stlib_lines );
     push @arrays, \@shlib_lines unless disabled('shared');
     foreach (@arrays) {
+        my %commons;
+        foreach (@$_) {
+            if (m|^(.*) C .*|) {
+                $commons{$1}++;
+            }
+        }
+        foreach (sort keys %commons) {
+            note "Common symbol: $_";
+        }
+
         @$_ =
             sort
-            map {
-                # Drop the first space and everything following it
-                s| .*||;
-                # Drop OpenSSL dynamic version information if there is any
-                s|\@\@.+$||;
-                # Return the result
-                $_
-            }
-            # Drop any symbol starting with a double underscore, they
-            # are reserved for the compiler / system ABI and are none
-            # of our business
-            grep !m|^__|,
-            # Only look at external definitions
-            grep m|.* [BCDST] .*|,
-            @$_ ),
+            ( map {
+                  # Drop the first space and everything following it
+                  s| .*||;
+                  # Drop OpenSSL dynamic version information if there is any
+                  s|\@\@.+$||;
+                  # Drop any symbol starting with a double underscore, they
+                  # are reserved for the compiler / system ABI and are none
+                  # of our business
+                  s|^__||;
+                  # Return the result
+                  $_
+              }
+              # Drop any symbol starting with a double underscore, they
+              # are reserved for the compiler / system ABI and are none
+              # of our business
+              grep !m|^__|,
+              # Only look at external definitions
+              grep m|.* [BDST] .*|,
+              @$_ ),
+            keys %commons;
     }
 
     # Massage the mkdef.pl output to only contain global symbols

--- a/test/recipes/01-test_symbol_presence.t
+++ b/test/recipes/01-test_symbol_presence.t
@@ -124,7 +124,13 @@ foreach (sort keys %stlibname) {
                 # Return the result
                 $_
             }
-            grep(m|.* [BCDST] .*|, @$_);
+            # Drop any symbol starting with a double underscore, they
+            # are reserved for the compiler / system ABI and are none
+            # of our business
+            grep !m|^__|,
+            # Only look at external definitions
+            grep m|.* [BCDST] .*|,
+            @$_ ),
     }
 
     # Massage the mkdef.pl output to only contain global symbols


### PR DESCRIPTION
On some platforms, the compiler may add symbols that aren't ours and that we should ignore.

They are generally expected to start with a double underscore, and thereby easy to detect.

Furthermore, we find ourselves with a common symbol (type 'C' in the 'nm' output) on some platforms (x86, for example).  They are allowed to be defined more than once, so make this test recipe reflect that.

Fixes #22869
Fixes #22837
