### PR TITLE
Fix loading more than one certificate in PEM format in the X509_load_cert_file_ex() function

### DIFF
--- a/crypto/x509/by_file.c
+++ b/crypto/x509/by_file.c
@@ -128,6 +128,17 @@ int X509_load_cert_file_ex(X509_LOOKUP *ctx, const char *file, int type,
                 count = 0;
                 goto err;
             }
+            /*
+             * X509_STORE_add_cert() added a reference rather than a copy,
+             * so we need a fresh X509 object.
+             */
+            X509_free(x);
+            x = X509_new_ex(libctx, propq);
+            if (x == NULL) {
+                ERR_raise(ERR_LIB_X509, ERR_R_ASN1_LIB);
+                count = 0;
+                goto err;
+            }
             count++;
         }
     } else if (type == X509_FILETYPE_ASN1) {

--- a/test/build.info
+++ b/test/build.info
@@ -63,7 +63,7 @@ IF[{- !$disabled{tests} -}]
           provfetchtest prov_config_test rand_test ca_internals_test \
           bio_tfo_test membio_test bio_dgram_test list_test fips_version_test \
           x509_test hpke_test pairwise_fail_test nodefltctxtest \
-          evp_xof_test
+          evp_xof_test x509_load_cert_file_test
 
   IF[{- !$disabled{'rpk'} -}]
     PROGRAMS{noinst}=rpktest
@@ -594,6 +594,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[x509_dup_cert_test]=x509_dup_cert_test.c
   INCLUDE[x509_dup_cert_test]=../include ../apps/include
   DEPEND[x509_dup_cert_test]=../libcrypto libtestutil.a
+
+  SOURCE[x509_load_cert_file_test]=x509_load_cert_file_test.c
+  INCLUDE[x509_load_cert_file_test]=../include ../apps/include
+  DEPEND[x509_load_cert_file_test]=../libcrypto libtestutil.a
 
   SOURCE[x509_check_cert_pkey_test]=x509_check_cert_pkey_test.c
   INCLUDE[x509_check_cert_pkey_test]=../include ../apps/include

--- a/test/recipes/60-test_x509_load_cert_file.t
+++ b/test/recipes/60-test_x509_load_cert_file.t
@@ -1,0 +1,15 @@
+#! /usr/bin/env perl
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+
+setup("test_load_cert_file");
+
+plan tests => 1;
+
+ok(run(test(["x509_load_cert_file_test", srctop_file("test", "certs", "leaf-chain.pem")])));

--- a/test/x509_load_cert_file_test.c
+++ b/test/x509_load_cert_file_test.c
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdio.h>
+#include <openssl/err.h>
+#include <openssl/x509_vfy.h>
+
+#include "testutil.h"
+
+static int test_load_cert_file(int n)
+{
+    int ret = 0;
+    X509_STORE *store = NULL;
+    X509_LOOKUP *lookup = NULL;
+    STACK_OF(X509) *certs = NULL;
+    const char *chain = test_get_argument(n);
+
+    if (TEST_ptr(store = X509_STORE_new())
+        && TEST_ptr(lookup = X509_STORE_add_lookup(store, X509_LOOKUP_file()))
+        && TEST_true(X509_load_cert_file(lookup, chain, X509_FILETYPE_PEM))
+        && TEST_ptr(certs = X509_STORE_get1_all_certs(store))
+        && TEST_int_eq(sk_X509_num(certs), 4))
+        ret = 1;
+
+    OSSL_STACK_OF_X509_free(certs);
+    X509_STORE_free(store);
+    return ret;
+}
+
+OPT_TEST_DECLARE_USAGE("cert.pem...\n")
+
+int setup_tests(void)
+{
+    size_t n;
+
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
+    n = test_get_argument_count();
+    if (!TEST_int_gt(n, 0))
+        return 0;
+
+    ADD_ALL_TESTS(test_load_cert_file, n);
+    return 1;
+}

--- a/test/x509_load_cert_file_test.c
+++ b/test/x509_load_cert_file_test.c
@@ -11,13 +11,14 @@
 
 #include "testutil.h"
 
-static int test_load_cert_file(int n)
+static const char *chain;
+
+static int test_load_cert_file(void)
 {
     int ret = 0;
     X509_STORE *store = NULL;
     X509_LOOKUP *lookup = NULL;
     STACK_OF(X509) *certs = NULL;
-    const char *chain = test_get_argument(n);
 
     if (TEST_ptr(store = X509_STORE_new())
         && TEST_ptr(lookup = X509_STORE_add_lookup(store, X509_LOOKUP_file()))
@@ -35,17 +36,15 @@ OPT_TEST_DECLARE_USAGE("cert.pem...\n")
 
 int setup_tests(void)
 {
-    size_t n;
-
     if (!test_skip_common_options()) {
         TEST_error("Error parsing test options\n");
         return 0;
     }
 
-    n = test_get_argument_count();
-    if (!TEST_int_gt(n, 0))
+    chain = test_get_argument(0);
+    if (chain == NULL)
         return 0;
 
-    ADD_ALL_TESTS(test_load_cert_file, n);
+    ADD_TEST(test_load_cert_file);
     return 1;
 }


### PR DESCRIPTION
`X509_load_cert_file_ex()` was broken by commit https://github.com/openssl/openssl/commit/ae29622f39f7deb0599624cc7a771bfc05f1353f in PR #21545.

The following code shows this error. 
```
#include <openssl/x509_vfy.h>

int main()
{
    const char *cafile = "./ca-certificates.crt";
    X509_STORE *store;
    X509_LOOKUP *lookup;
    STACK_OF(X509) *certs;
    int i;

    store = X509_STORE_new();
    lookup = X509_STORE_add_lookup(store, X509_LOOKUP_file());
    X509_load_cert_file(lookup, cafile, X509_FILETYPE_PEM);
    certs = X509_STORE_get1_all_certs(store);
    for(i=0; i<sk_X509_num(certs); i++) {
        char *name=X509_NAME_oneline(X509_get_subject_name(sk_X509_value(certs, i)), NULL, 0);
        printf("#%d: %s\n", i, name);
        OPENSSL_free(name);
    }
    sk_X509_pop_free(certs, X509_free);
    X509_STORE_free(store);
}
```

The `ca-certificates.crt` file contains 5 sample certificates in PEM format.
This PoC shows that there is only one certificate in the store, the last one in the file.
```
#0: /serialNumber=G63287510/C=ES/O=ANF Autoridad de Certificacion/OU=ANF CA Raiz/CN=ANF Secure Server Root CA
```
My PR fixes this by freeing an X509 object before any further use.
Additionally, it allocates and initializes an X509 structure with a library context and property query for all certificates.
```
#0: /C=ES/O=FNMT-RCM/OU=AC RAIZ FNMT-RCM
#1: /CN=ACCVRAIZ1/OU=PKIACCV/O=ACCV/C=ES
#2: /O=mkcert development CA/OU=mo@localhost-live.home/CN=mkcert mo@localhost-live.home
#3: /C=ES/O=FNMT-RCM/OU=Ceres/organizationIdentifier=VATES-Q2826004J/CN=AC RAIZ FNMT-RCM SERVIDORES SEGUROS
#4: /serialNumber=G63287510/C=ES/O=ANF Autoridad de Certificacion/OU=ANF CA Raiz/CN=ANF Secure Server Root CA
```
Fix #22895