### PR TITLE
Remove the source directory .num targets

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1387,18 +1387,16 @@ renumber: build_generated
                 --renumber \
                 $(SSLHEADERS)
 
-$(SRCDIR)/util/libcrypto.num: $(CRYPTOHEADERS) $(SRCDIR)/include/openssl/symhacks.h
+.PHONY: ordinals
+ordinals: build_generated
 	$(PERL) $(SRCDIR)/util/mknum.pl --version $(VERSION_NUMBER) --no-warnings \
                 --ordinals $(SRCDIR)/util/libcrypto.num \
                 --symhacks $(SRCDIR)/include/openssl/symhacks.h \
                 $(CRYPTOHEADERS)
-$(SRCDIR)/util/libssl.num: $(SSLHEADERS) $(SRCDIR)/include/openssl/symhacks.h
 	$(PERL) $(SRCDIR)/util/mknum.pl --version $(VERSION_NUMBER) --no-warnings \
                 --ordinals $(SRCDIR)/util/libssl.num \
                 --symhacks $(SRCDIR)/include/openssl/symhacks.h \
                 $(SSLHEADERS)
-.PHONY: ordinals
-ordinals: build_generated $(SRCDIR)/util/libcrypto.num $(SRCDIR)/util/libssl.num
 
 test_ordinals:
 	$(MAKE) run_tests TESTS=test_ordinals


### PR DESCRIPTION
`$(SRCDIR)/util/libcrypto.num` and `$(SRCDIR)/util/libssl.num` were made their
own targets to have 'make ordinals' reproduce them (run `mknum.pl`) only if
needed.

Unfortunately, because the shared library linker scripts depend on these
.num files, we suddenly have `mknum.pl` run at random times when building.
Furthermore, this created a diamond dependency, which disturbs parallell
building because multiple `mknum.pl` on the same file could run at the same
time.

This reverts commit 0e55c3ab8d702ffc897c9beb51d19b14b7896182.

Partially fixes #22841
