### PR TITLE
Statically link legacy provider to evp_extra_test [3.0,3.1]

### DIFF
--- a/crypto/build.info
+++ b/crypto/build.info
@@ -74,8 +74,8 @@ DEFINE[../providers/libfips.a]=$CPUIDDEF
 # already gets everything that the static libcrypto.a has, and doesn't need it
 # added again.
 IF[{- !$disabled{module} && !$disabled{shared} -}]
-  SOURCE[../providers/liblegacy.a]=$CPUID_COMMON
-  DEFINE[../providers/liblegacy.a]=$CPUIDDEF
+  SOURCE[../providers/legacy]=$CPUID_COMMON
+  DEFINE[../providers/legacy]=$CPUIDDEF
 ENDIF
 
 # Implementations are now spread across several libraries, so the CPUID define

--- a/test/build.info
+++ b/test/build.info
@@ -172,6 +172,14 @@ IF[{- !$disabled{tests} -}]
   SOURCE[evp_extra_test]=evp_extra_test.c
   INCLUDE[evp_extra_test]=../include ../apps/include
   DEPEND[evp_extra_test]=../libcrypto.a libtestutil.a
+  IF[{- !$disabled{module} && !$disabled{legacy} -}]
+    DEFINE[evp_extra_test]=STATIC_LEGACY
+    SOURCE[evp_extra_test]=../providers/legacyprov.c
+    INCLUDE[evp_extra_test]=../providers/common/include \
+                            ../providers/implementations/include
+    DEPEND[evp_extra_test]=../providers/liblegacy.a \
+                           ../providers/libcommon.a
+  ENDIF
 
   SOURCE[evp_extra_test2]=evp_extra_test2.c
   INCLUDE[evp_extra_test2]=../include ../apps/include

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -37,6 +37,10 @@
 #include "internal/sizes.h"
 #include "crypto/evp.h"
 
+#ifdef STATIC_LEGACY
+OSSL_provider_init_fn ossl_legacy_provider_init;
+#endif
+
 static OSSL_LIB_CTX *testctx = NULL;
 static char *testpropq = NULL;
 
@@ -5237,6 +5241,15 @@ int setup_tests(void)
             testctx = OSSL_LIB_CTX_new();
             if (!TEST_ptr(testctx))
                 return 0;
+#ifdef STATIC_LEGACY
+	    /*
+	     * This test is always statically linked against libcrypto. We must not
+	     * attempt to load legacy.so that might be dynamically linked against
+	     * libcrypto. Instead we use a built-in version of the legacy provider.
+	     */
+	    if (!OSSL_PROVIDER_add_builtin(testctx, "legacy", ossl_legacy_provider_init))
+		return 0;
+#endif
             /* Swap the libctx to test non-default context only */
             nullprov = OSSL_PROVIDER_load(NULL, "null");
             deflprov = OSSL_PROVIDER_load(testctx, "default");


### PR DESCRIPTION
Like in #17345, evp_extra_test links libcrypto statically, but also has a dynamic/shared load via the legacy provider, which leads to ambiguous behavior in evp_extra_test on some platforms, usually a crash (SIGSEGV) on exit via the atexit handlers.  Statically link the legacy provider to avoid this.

Fixes #22819

Helped-by: Neil Horman <nhorman@openssl.org>
Helped-by: Tomas Mraz <tomas@openssl.org>
