### PR TITLE
Make the activate setting more intuitive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,7 +29,7 @@ OpenSSL 3.3
 ### Changes between 3.2 and 3.3 [xx XXX xxxx]
 
  * The activate configuration setting for providers in openssl.cnf has been
-   updated to require a value of [1|yes|true|on] (case insensitive) to
+   updated to require a value of [1|yes|true|on] (in lower or UPPER case) to
    activate the provider.  Conversely a setting [0|no|false|off] will prevent
    provider activation.  All other values, or the omission of a value for this
    setting will result in an error.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,11 @@ OpenSSL 3.3
 
 ### Changes between 3.2 and 3.3 [xx XXX xxxx]
 
+ * The activate configuration setting for providers in openssl.cnf has been
+   updated to require a value of [1|yes|true|on] to activate the provider.
+
+    *Neil Horman*
+
  * In `openssl speed`, changed the default hash function used with `hmac` from
    `md5` to `sha256`.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,7 +29,10 @@ OpenSSL 3.3
 ### Changes between 3.2 and 3.3 [xx XXX xxxx]
 
  * The activate configuration setting for providers in openssl.cnf has been
-   updated to require a value of [1|yes|true|on] to activate the provider.
+   updated to require a value of [1|yes|true|on] (case insensitive) to
+   activate the provider.  Conversely a setting [0|no|false|off] will prevent
+   provider activation.  All other values, or the omission of a value for this
+   setting will result in an error.
 
     *Neil Horman*
 

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -244,7 +244,10 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
         else if (strcmp(confname, "module") == 0)
             path = confvalue;
         else if (strcmp(confname, "activate") == 0)
-            activate = 1;
+            if ((strcmp(confvalue, "1") == 0)
+                || (strcmp(confvalue, "yes") == 0)
+                || (strcmp(confvalue, "true") == 0))
+                activate = 1;
     }
 
     if (activate) {

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -236,19 +236,43 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
         /* First handle some special pseudo confs */
 
         /* Override provider name to use */
-        if (strcmp(confname, "identity") == 0)
+        if (strcmp(confname, "identity") == 0) {
             name = confvalue;
-        else if (strcmp(confname, "soft_load") == 0)
+        } else if (strcmp(confname, "soft_load") == 0) {
             soft = 1;
         /* Load a dynamic PROVIDER */
-        else if (strcmp(confname, "module") == 0)
+        } else if (strcmp(confname, "module") == 0) {
             path = confvalue;
-        else if (strcmp(confname, "activate") == 0)
+        } else if (strcmp(confname, "activate") == 0) {
+            if (confvalue == NULL) {
+                ERR_raise_data(ERR_LIB_CRYPTO, CRYPTO_R_PROVIDER_SECTION_ERROR,
+                               "section=%s activate set to unrecognized value",
+                               value);
+                return 0;
+            }
             if ((strcmp(confvalue, "1") == 0)
                 || (strcmp(confvalue, "yes") == 0)
+                || (strcmp(confvalue, "YES") == 0)
                 || (strcmp(confvalue, "true") == 0)
-                || (strcmp(confvalue, "on") == 0))
+                || (strcmp(confvalue, "TRUE") == 0)
+                || (strcmp(confvalue, "on") == 0)
+                || (strcmp(confvalue, "ON") == 0)) {
                 activate = 1;
+            } else if ((strcmp(confvalue, "0") == 0)
+                       || (strcmp(confvalue, "no") == 0)
+                       || (strcmp(confvalue, "NO") == 0)
+                       || (strcmp(confvalue, "false") == 0)
+                       || (strcmp(confvalue, "FALSE") == 0)
+                       || (strcmp(confvalue, "off") == 0)
+                       || (strcmp(confvalue, "OFF") == 0)) {
+                activate = 0;
+            } else {
+                ERR_raise_data(ERR_LIB_CRYPTO, CRYPTO_R_PROVIDER_SECTION_ERROR,
+                               "section=%s activate set to unrecognized value",
+                               value);
+                return 0;
+            }
+        }
     }
 
     if (activate) {

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -246,7 +246,8 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
         else if (strcmp(confname, "activate") == 0)
             if ((strcmp(confvalue, "1") == 0)
                 || (strcmp(confvalue, "yes") == 0)
-                || (strcmp(confvalue, "true") == 0))
+                || (strcmp(confvalue, "true") == 0)
+                || (strcmp(confvalue, "on") == 0))
                 activate = 1;
     }
 

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -265,7 +265,7 @@ Specifies the pathname of the module (typically a shared library) to load.
 
 =item B<activate>
 
-If present and set to one of the values yes, true or 1, then the associated
+If present and set to one of the values yes, on, true or 1, then the associated
 provider will be activated.  Omitting this item, or setting it to
 any other value, will prevent the associated provider from being activated.
 Note that the above activation values are case sensitive

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -265,8 +265,10 @@ Specifies the pathname of the module (typically a shared library) to load.
 
 =item B<activate>
 
-If present, the module is activated. The value assigned to this name is not
-significant.
+If present and set to one of the values yes, true or 1, then the associated
+provider will be activated.  Omitting this item, or setting it to
+any other value, will prevent the associated provider from being activated.
+Note that the above activation values are case sensitive
 
 =back
 

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -266,9 +266,10 @@ Specifies the pathname of the module (typically a shared library) to load.
 =item B<activate>
 
 If present and set to one of the values yes, on, true or 1, then the associated
-provider will be activated.  Omitting this item, or setting it to
-any other value, will prevent the associated provider from being activated.
-Note that the above activation values are case sensitive
+provider will be activated. Conversely, setting this value to no, off, false, or
+0 will prevent the provider from being activated.  Note that the listed settings
+case insensitive.  Setting activate to any other setting, or omitting a setting
+value will result in an error.
 
 =back
 

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -267,8 +267,8 @@ Specifies the pathname of the module (typically a shared library) to load.
 
 If present and set to one of the values yes, on, true or 1, then the associated
 provider will be activated. Conversely, setting this value to no, off, false, or
-0 will prevent the provider from being activated.  Note that the listed settings
-case insensitive.  Setting activate to any other setting, or omitting a setting
+0 will prevent the provider from being activated. Settings can be given in lower
+or uppercase. Setting activate to any other setting, or omitting a setting
 value will result in an error.
 
 =back

--- a/test/default-and-fips.cnf
+++ b/test/default-and-fips.cnf
@@ -13,4 +13,4 @@ default = default_sect
 fips = fips_sect
 
 [default_sect]
-activate = 1
+activate = yes

--- a/test/default.cnf
+++ b/test/default.cnf
@@ -8,6 +8,10 @@ providers = provider_sect
 
 [provider_sect]
 default = default_sect
+legacy  = legacy_sect
 
 [default_sect]
-activate = 1
+activate = true
+
+[legacy_sect]
+activate = false

--- a/test/evp_fetch_prov_test.c
+++ b/test/evp_fetch_prov_test.c
@@ -121,6 +121,27 @@ static void unload_providers(OSSL_LIB_CTX **libctx, OSSL_PROVIDER *prov[])
     }
 }
 
+static int test_legacy_provider_unloaded(void)
+{
+    OSSL_LIB_CTX *ctx = NULL;
+    int rc = 0;
+
+    ctx = OSSL_LIB_CTX_new();
+    if (!TEST_ptr(ctx))
+        goto err;
+
+    if (!TEST_true(OSSL_LIB_CTX_load_config(ctx, config_file)))
+        goto err;
+
+    if (!TEST_int_eq(OSSL_PROVIDER_available(ctx, "legacy"), 0))
+        goto err;
+
+    rc = 1;
+err:
+    OSSL_LIB_CTX_free(ctx);
+    return rc;
+}
+
 static X509_ALGOR *make_algor(int nid)
 {
     X509_ALGOR *algor;
@@ -379,6 +400,7 @@ int setup_tests(void)
             return 0;
         }
     }
+    ADD_TEST(test_legacy_provider_unloaded);
     if (strcmp(alg, "digest") == 0) {
         ADD_TEST(test_implicit_EVP_MD_fetch);
         ADD_TEST(test_explicit_EVP_MD_fetch_by_name);


### PR DESCRIPTION
Currently, a provider is activated from our config file using the activate parameter.  However, the presence of the config parameter is sufficient to trigger activation, leading to a counterintuitive situation in which setting "activate = 0" still activates the provider

Make activation more intuitive by requiring that activate be set to one of yes|true|1 to trigger activation.  Any other value, as well as omitting the parameter entirely, prevents activation (and also maintains backward compatibility.

It seems a bit heavyweight to create a test specifically to validate the plurality of these settings.  Instead, modify the exiting openssl config files in the test directory to use variants of these settings, and augment the default.cnf file to include a provider section that is explicitly disabled



##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated
