### PR TITLE
APPS/`pkeyutl`: improve `-rawin` usability and doc for EdDSA

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,13 @@ OpenSSL 3.4
 
    *Małgorzata Olszówka*
 
+ * The `-rawin` option of the `pkeyutl` command is now implied (and thus no
+   longer required) when using `-digest` or when signing or verifying with an
+   Ed25519 or Ed448 key.
+   The `-digest` and `-rawin` option may only be given with `-sign` or `verify`.
+
+   *David von Oheimb*
+
  * Optionally allow the FIPS provider to use the `JITTER` entropy source.
    Note that using this option will require the resulting FIPS provider
    to undergo entropy source validation [ESV] by the [CMVP], without this
@@ -207,11 +214,6 @@ OpenSSL 3.4
    public API. There is no command-line tool support at this time.
 
    *Damian Hobson-Garcia*
-
- * The `-rawin` option of the `pkeyutl` command is now implied (and thus no more
-   required) when signing or verifying with an Ed25519 or Ed448 key.
-
-   *David von Oheimb*
 
  * Added support to build Position Independent Executables (PIE). Configuration
    option `enable-pie` configures the cflag '-fPIE' and ldflag '-pie' to

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -208,6 +208,11 @@ OpenSSL 3.4
 
    *Damian Hobson-Garcia*
 
+ * The `-rawin` option of the `pkeyutl` command is now implied (and thus no more
+   required) when signing or verifying with an Ed25519 or Ed448 key.
+
+   *David von Oheimb*
+
  * Added support to build Position Independent Executables (PIE). Configuration
    option `enable-pie` configures the cflag '-fPIE' and ldflag '-pie' to
    support Address Space Layout Randomization (ASLR) in the openssl executable,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -150,7 +150,7 @@ OpenSSL 3.4
 
  * Added options `-not_before` and `-not_after` for explicit setting
    start and end dates of certificates created with the `req` and `x509`
-   apps. Added the same options also to `ca` app as alias for
+   commands. Added the same options also to `ca` command as alias for
    `-startdate` and `-enddate` options.
 
    *Stephan Wurm*
@@ -957,14 +957,14 @@ OpenSSL 3.2
 
    * Lutz Jänicke*
 
- * The `x509`, `ca`, and `req` apps now produce X.509 v3 certificates.
+ * The `x509`, `ca`, and `req` commands now produce X.509 v3 certificates.
    The `-x509v1` option of `req` prefers generation of X.509 v1 certificates.
    `X509_sign()` and `X509_sign_ctx()` make sure that the certificate has
    X.509 version 3 if the certificate information includes X.509 extensions.
 
    *David von Oheimb*
 
- * Fix and extend certificate handling and the apps `x509`, `verify` etc.
+ * Fix and extend certificate handling and the commands `x509`, `verify` etc.
    such as adding a trace facility for debugging certificate chain building.
 
    *David von Oheimb*
@@ -1293,7 +1293,7 @@ OpenSSL 3.1
 
    *Orr Toledano*
 
- * s_client and s_server apps now explicitly say when the TLS version
+ * `s_client` and `s_server` commands now explicitly say when the TLS version
    does not include the renegotiation mechanism. This avoids confusion
    between that scenario versus when the TLS version includes secure
    renegotiation but the peer lacks support for it.
@@ -2344,7 +2344,8 @@ breaking changes, and mappings for the large list of deprecated functions.
 
    *Nicola Tuveri*
 
- * Behavior of the `pkey` app is changed, when using the `-check` or `-pubcheck`
+ * Behavior of the `pkey` command is changed,
+   when using the `-check` or `-pubcheck`
    switches: a validation failure triggers an early exit, returning a failure
    exit status to the parent process.
 

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -490,12 +490,14 @@ int pkeyutl_main(int argc, char **argv)
 
     /* Sanity check the input if the input is not raw */
     if (!rawin
-            && buf_inlen > EVP_MAX_MD_SIZE
-            && (pkey_op == EVP_PKEY_OP_SIGN
-                || pkey_op == EVP_PKEY_OP_VERIFY)) {
-        BIO_printf(bio_err,
-                   "Error: The input data looks too long to be a hash\n");
-        goto end;
+        && (pkey_op == EVP_PKEY_OP_SIGN || pkey_op == EVP_PKEY_OP_VERIFY
+            || pkey_op == EVP_PKEY_OP_VERIFYRECOVER)) {
+        if (buf_inlen > EVP_MAX_MD_SIZE) {
+            BIO_printf(bio_err,
+                       "Error: The non-raw input data length %d is too long - max supported hashed size is %d\n",
+                       buf_inlen, EVP_MAX_MD_SIZE);
+            goto end;
+        }
     }
 
     if (pkey_op == EVP_PKEY_OP_VERIFY) {

--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -81,7 +81,7 @@ signature algorithm does not require one (for instance, EdDSA). If this option
 is omitted but the signature algorithm requires one, a default value will be
 used. For signature algorithms like RSA, DSA and ECDSA, SHA-256 will be the
 default digest algorithm. For SM2, it will be SM3.
-So far, HashEdDSA (the ph or "prehash" variant of EdDSA) is not supported,
+At this time, HashEdDSA (the ph or "prehash" variant of EdDSA) is not supported,
 so the B<-digest> option cannot be used with EdDSA).
 
 =item B<-out> I<filename>

--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -70,15 +70,17 @@ and is implied by the Ed25519 and Ed448 algorithms.
 Except with EdDSA,
 the user can specify a digest algorithm by using the B<-digest> option.
 
+The B<-digest> option implies B<-rawin>.
+
 =item B<-digest> I<algorithm>
 
-This specifies the digest algorithm which is used to hash the input data before
+This option can only be used with B<-sign> and B<-verify>.
+It specifies the digest algorithm which is used to hash the input data before
 signing or verifying it with the input key. This option could be omitted if the
 signature algorithm does not require one (for instance, EdDSA). If this option
 is omitted but the signature algorithm requires one, a default value will be
 used. For signature algorithms like RSA, DSA and ECDSA, SHA-256 will be the
-default digest algorithm. For SM2, it will be SM3. If this option is present,
-then the B<-rawin> option must be also specified.
+default digest algorithm. For SM2, it will be SM3.
 So far, HashEdDSA (the ph or "prehash" variant of EdDSA) is not supported,
 so the B<-digest> option cannot be used with EdDSA).
 
@@ -470,6 +472,10 @@ L<EVP_PKEY_CTX_set_hkdf_md(3)>,
 L<EVP_PKEY_CTX_set_tls1_prf_md(3)>,
 
 =head1 HISTORY
+
+Since OpenSSL 3.5,
+the B<-digest> option implies B<-rawin>, and these two options are
+no longer required when signing or verifying with an Ed25519 or Ed448 key.
 
 The B<-engine> option was deprecated in OpenSSL 3.0.
 

--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -63,10 +63,12 @@ if this option is not specified.
 
 =item B<-rawin>
 
-This indicates that the input data is raw data, which is not hashed by any
-message digest algorithm. The user can specify a digest algorithm by using
-the B<-digest> option. This option can only be used with B<-sign> and
-B<-verify> and must be used with the Ed25519 and Ed448 algorithms.
+This indicates that signature input data is raw data, which for most signature
+algorithms (but not EdDSA) needs to be hashed by some message digest algorithm.
+This option can only be used with B<-sign> and B<-verify>
+and is implied by the Ed25519 and Ed448 algorithms.
+Except with EdDSA,
+the user can specify a digest algorithm by using the B<-digest> option.
 
 =item B<-digest> I<algorithm>
 
@@ -77,6 +79,8 @@ is omitted but the signature algorithm requires one, a default value will be
 used. For signature algorithms like RSA, DSA and ECDSA, SHA-256 will be the
 default digest algorithm. For SM2, it will be SM3. If this option is present,
 then the B<-rawin> option must be also specified.
+So far, HashEdDSA (the ph or "prehash" variant of EdDSA) is not supported,
+so the B<-digest> option cannot be used with EdDSA).
 
 =item B<-out> I<filename>
 
@@ -128,6 +132,7 @@ The input is a certificate containing a public key.
 
 Reverse the order of the input buffer. This is useful for some libraries
 (such as CryptoAPI) which represent the buffer in little endian format.
+This cannot be used in conjunction with B<-rawin>.
 
 =item B<-sign>
 

--- a/test/recipes/20-test_pkeyutl.t
+++ b/test/recipes/20-test_pkeyutl.t
@@ -17,7 +17,7 @@ use File::Compare qw/compare_text compare/;
 
 setup("test_pkeyutl");
 
-plan tests => 19;
+plan tests => 23;
 
 # For the tests below we use the cert itself as the TBS file
 
@@ -54,19 +54,19 @@ SKIP: {
 }
 
 SKIP: {
-    skip "Skipping tests that require ECX", 4
+    skip "Skipping tests that require ECX", 6
         if disabled("ecx");
 
     # Ed25519
     ok(run(app(([ 'openssl', 'pkeyutl', '-sign', '-in',
                   srctop_file('test', 'certs', 'server-ed25519-cert.pem'),
                   '-inkey', srctop_file('test', 'certs', 'server-ed25519-key.pem'),
-                  '-out', 'Ed25519.sig', '-rawin']))),
+                  '-out', 'Ed25519.sig']))),
                   "Sign a piece of data using Ed25519");
     ok(run(app(([ 'openssl', 'pkeyutl', '-verify', '-certin', '-in',
                   srctop_file('test', 'certs', 'server-ed25519-cert.pem'),
                   '-inkey', srctop_file('test', 'certs', 'server-ed25519-cert.pem'),
-                  '-sigfile', 'Ed25519.sig', '-rawin']))),
+                  '-sigfile', 'Ed25519.sig']))),
                   "Verify an Ed25519 signature against a piece of data");
 
     # Ed448
@@ -80,6 +80,16 @@ SKIP: {
                   '-inkey', srctop_file('test', 'certs', 'server-ed448-cert.pem'),
                   '-sigfile', 'Ed448.sig', '-rawin']))),
                   "Verify an Ed448 signature against a piece of data");
+    ok(run(app(([ 'openssl', 'pkeyutl', '-sign', '-in',
+                  srctop_file('test', 'certs', 'server-ed448-cert.pem'),
+                  '-inkey', srctop_file('test', 'certs', 'server-ed448-key.pem'),
+                  '-out', 'Ed448.sig']))),
+                  "Sign a piece of data using Ed448 -rawin no more needed");
+    ok(run(app(([ 'openssl', 'pkeyutl', '-verify', '-certin', '-in',
+                  srctop_file('test', 'certs', 'server-ed448-cert.pem'),
+                  '-inkey', srctop_file('test', 'certs', 'server-ed448-cert.pem'),
+                  '-sigfile', 'Ed448.sig']))),
+                  "Verify an Ed448 signature against a piece of data, no -rawin");
 }
 
 sub tsignverify {
@@ -183,7 +193,7 @@ SKIP: {
 }
 
 SKIP: {
-    skip "EdDSA is not supported by this OpenSSL build", 2
+    skip "EdDSA is not supported by this OpenSSL build", 4
         if disabled("ecx");
 
     subtest "Ed2559 CLI signature generation and verification" => sub {
@@ -198,6 +208,18 @@ SKIP: {
                     srctop_file("test","tested448.pem"),
                     srctop_file("test","tested448pub.pem"),
                     "-rawin");
+    };
+
+    subtest "Ed2559 CLI signature generation and verification, no -rawin" => sub {
+        tsignverify("Ed25519",
+                    srctop_file("test","tested25519.pem"),
+                    srctop_file("test","tested25519pub.pem"));
+    };
+
+    subtest "Ed448 CLI signature generation and verification, no -rawin" => sub {
+        tsignverify("Ed448",
+                    srctop_file("test","tested448.pem"),
+                    srctop_file("test","tested448pub.pem"));
     };
 }
 


### PR DESCRIPTION
This improves the usability of they `pkeyutl` app when signing or verifying with Ed25519 and Ed448 keys.

When the `-rawin` option was not given with them, so far an obscure low-level error was thrown such as
```
pkeyutl: Error initializing context
80205AEC01000000:error:03000096:digital envelope routines:evp_pkey_signature_init:operation not supported for this keytype:crypto/evp/signature.c:526:
```
This PR makes sure that the `-rawin` option is implied for such scenarios, 
[**update**: also in case the `-digest` option is given, ]
also making the app more convenient to use.
Implementing this required a split of the `init_ctx()` helper function, which is now less convoluted.

Tests and doc are updated accordingly,
and on this occasion the help output and the doc of the `-rawin` option are made less confusing.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
