### PR TITLE
Make hash functions take void pointers and do explicit casts

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -444,13 +444,17 @@ static int do_cmd(LHASH_OF(FUNCTION) *prog, int argc, char *argv[])
     return 1;
 }
 
-static int function_cmp(const FUNCTION *a, const FUNCTION *b)
+static int function_cmp(const void *da, const void *db)
 {
+    const FUNCTION *a = (const FUNCTION *)da;
+    const FUNCTION *b = (const FUNCTION *)db;
+
     return strncmp(a->name, b->name, 8);
 }
 
-static unsigned long function_hash(const FUNCTION *a)
+static unsigned long function_hash(const void *d)
 {
+    const FUNCTION *a = (const FUNCTION *)d;
     return OPENSSL_LH_strhash(a->name);
 }
 

--- a/apps/req.c
+++ b/apps/req.c
@@ -173,13 +173,18 @@ const OPTIONS req_options[] = {
 /*
  * An LHASH of strings, where each string is an extension name.
  */
-static unsigned long ext_name_hash(const OPENSSL_STRING *a)
+static unsigned long ext_name_hash(const void *da)
 {
+    const OPENSSL_STRING *a = (const OPENSSL_STRING *)da;
+
     return OPENSSL_LH_strhash((const char *)a);
 }
 
-static int ext_name_cmp(const OPENSSL_STRING *a, const OPENSSL_STRING *b)
+static int ext_name_cmp(const void *da, const void *db)
 {
+    const OPENSSL_STRING *a = (const OPENSSL_STRING *)da;
+    const OPENSSL_STRING *b = (const OPENSSL_STRING *)db;
+
     return strcmp((const char *)a, (const char *)b);
 }
 

--- a/crypto/conf/conf_api.c
+++ b/crypto/conf/conf_api.c
@@ -95,13 +95,18 @@ char *_CONF_get_string(const CONF *conf, const char *section,
     return v->value;
 }
 
-static unsigned long conf_value_hash(const CONF_VALUE *v)
+static unsigned long conf_value_hash(const void *dv)
 {
+    const CONF_VALUE *v = (const CONF_VALUE *)dv;
+
     return (OPENSSL_LH_strhash(v->section) << 2) ^ OPENSSL_LH_strhash(v->name);
 }
 
-static int conf_value_cmp(const CONF_VALUE *a, const CONF_VALUE *b)
+static int conf_value_cmp(const void *da, const void *db)
 {
+    const CONF_VALUE *a = (const CONF_VALUE *)da;
+    const CONF_VALUE *b = (const CONF_VALUE *)db;
+
     int i;
 
     if (a->section != b->section) {

--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -42,13 +42,17 @@ struct ossl_namemap_st {
 
 /* LHASH callbacks */
 
-static unsigned long namenum_hash(const NAMENUM_ENTRY *n)
+static unsigned long namenum_hash(const void *d)
 {
+    const NAMENUM_ENTRY *n = (const NAMENUM_ENTRY *)d;
     return ossl_lh_strcasehash(n->name);
 }
 
-static int namenum_cmp(const NAMENUM_ENTRY *a, const NAMENUM_ENTRY *b)
+static int namenum_cmp(const void *da, const void *db)
 {
+    const NAMENUM_ENTRY *a = (const NAMENUM_ENTRY *)da;
+    const NAMENUM_ENTRY *b = (const NAMENUM_ENTRY *)db;
+
     return OPENSSL_strcasecmp(a->name, b->name);
 }
 

--- a/crypto/encode_decode/decoder_pkey.c
+++ b/crypto/encode_decode/decoder_pkey.c
@@ -613,8 +613,9 @@ static void decoder_cache_entry_free(DECODER_CACHE_ENTRY *entry)
     OPENSSL_free(entry);
 }
 
-static unsigned long decoder_cache_entry_hash(const DECODER_CACHE_ENTRY *cache)
+static unsigned long decoder_cache_entry_hash(const void *d)
 {
+    const DECODER_CACHE_ENTRY *cache = (const DECODER_CACHE_ENTRY *)d;
     unsigned long hash = 17;
 
     hash = (hash * 23)
@@ -654,9 +655,11 @@ static ossl_inline int nullstrcmp(const char *a, const char *b, int casecmp)
     }
 }
 
-static int decoder_cache_entry_cmp(const DECODER_CACHE_ENTRY *a,
-                                   const DECODER_CACHE_ENTRY *b)
+static int decoder_cache_entry_cmp(const void *da,
+                                   const void *db)
 {
+    const DECODER_CACHE_ENTRY *a = (const DECODER_CACHE_ENTRY *)da;
+    const DECODER_CACHE_ENTRY *b = (const DECODER_CACHE_ENTRY *)db;
     int cmp;
 
     if (a->selection != b->selection)

--- a/crypto/engine/eng_table.c
+++ b/crypto/engine/eng_table.c
@@ -52,13 +52,16 @@ void ENGINE_set_table_flags(unsigned int flags)
 }
 
 /* Internal functions for the "piles" hash table */
-static unsigned long engine_pile_hash(const ENGINE_PILE *c)
+static unsigned long engine_pile_hash(const void *d)
 {
+    const ENGINE_PILE *c = (const ENGINE_PILE *)d;
     return c->nid;
 }
 
-static int engine_pile_cmp(const ENGINE_PILE *a, const ENGINE_PILE *b)
+static int engine_pile_cmp(const void *da, const void *db)
 {
+    const ENGINE_PILE *a = (const ENGINE_PILE *)da;
+    const ENGINE_PILE *b = (const ENGINE_PILE *)db;
     return a->nid - b->nid;
 }
 

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -168,8 +168,9 @@ static unsigned long get_error_values(ERR_GET_ACTION g,
                                       int *flags);
 
 #ifndef OPENSSL_NO_ERR
-static unsigned long err_string_data_hash(const ERR_STRING_DATA *a)
+static unsigned long err_string_data_hash(const void *da)
 {
+    const ERR_STRING_DATA *a = (const ERR_STRING_DATA *)da;
     unsigned long ret, l;
 
     l = a->error;
@@ -177,9 +178,12 @@ static unsigned long err_string_data_hash(const ERR_STRING_DATA *a)
     return (ret ^ ret % 19 * 13);
 }
 
-static int err_string_data_cmp(const ERR_STRING_DATA *a,
-                               const ERR_STRING_DATA *b)
+static int err_string_data_cmp(const void *da,
+                               const void *db)
 {
+    const ERR_STRING_DATA *a = (const ERR_STRING_DATA *)da;
+    const ERR_STRING_DATA *b = (const ERR_STRING_DATA *)db;
+
     if (a->error == b->error)
         return 0;
     return a->error > b->error ? 1 : -1;

--- a/crypto/lhash/lhash.c
+++ b/crypto/lhash/lhash.c
@@ -288,7 +288,7 @@ static OPENSSL_LH_NODE **getrn(OPENSSL_LHASH *lh,
     unsigned long hash, nn;
     OPENSSL_LH_COMPFUNC cf;
 
-    hash = (*(lh->hash)) (data);
+    hash = lh->hash(data);
     *rhash = hash;
 
     nn = hash % lh->pmax;

--- a/crypto/objects/o_names.c
+++ b/crypto/objects/o_names.c
@@ -43,8 +43,8 @@ static STACK_OF(NAME_FUNCS) *name_funcs_stack;
  * casting without the need for macro-generated wrapper functions.
  */
 
-static unsigned long obj_name_hash(const OBJ_NAME *a);
-static int obj_name_cmp(const OBJ_NAME *a, const OBJ_NAME *b);
+static unsigned long obj_name_hash(const void *d);
+static int obj_name_cmp(const void *da, const void *db);
 
 static CRYPTO_ONCE init = CRYPTO_ONCE_STATIC_INIT;
 DEFINE_RUN_ONCE_STATIC(o_names_init)
@@ -116,8 +116,11 @@ out:
     return ret;
 }
 
-static int obj_name_cmp(const OBJ_NAME *a, const OBJ_NAME *b)
+static int obj_name_cmp(const void *da, const void *db)
 {
+    const OBJ_NAME *a = (const OBJ_NAME *)da;
+    const OBJ_NAME *b = (const OBJ_NAME *)db;
+
     int ret;
 
     ret = a->type - b->type;
@@ -132,8 +135,9 @@ static int obj_name_cmp(const OBJ_NAME *a, const OBJ_NAME *b)
     return ret;
 }
 
-static unsigned long obj_name_hash(const OBJ_NAME *a)
+static unsigned long obj_name_hash(const void *d)
 {
+    const OBJ_NAME *a = (const OBJ_NAME *)d;
     unsigned long ret;
 
     if ((name_funcs_stack != NULL)

--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -118,8 +118,9 @@ static int ln_cmp(const ASN1_OBJECT *const *a, const unsigned int *b)
 
 IMPLEMENT_OBJ_BSEARCH_CMP_FN(const ASN1_OBJECT *, unsigned int, ln);
 
-static unsigned long added_obj_hash(const ADDED_OBJ *ca)
+static unsigned long added_obj_hash(const void *d)
 {
+    const ADDED_OBJ *ca = (const ADDED_OBJ *)d;
     const ASN1_OBJECT *a;
     int i;
     unsigned long ret = 0;
@@ -151,8 +152,10 @@ static unsigned long added_obj_hash(const ADDED_OBJ *ca)
     return ret;
 }
 
-static int added_obj_cmp(const ADDED_OBJ *ca, const ADDED_OBJ *cb)
+static int added_obj_cmp(const void *da, const void *db)
 {
+    const ADDED_OBJ *ca = (const ADDED_OBJ *)da;
+    const ADDED_OBJ *cb = (const ADDED_OBJ *)db;
     ASN1_OBJECT *a, *b;
     int i;
 

--- a/crypto/property/defn_cache.c
+++ b/crypto/property/defn_cache.c
@@ -31,14 +31,18 @@ typedef struct {
 
 DEFINE_LHASH_OF_EX(PROPERTY_DEFN_ELEM);
 
-static unsigned long property_defn_hash(const PROPERTY_DEFN_ELEM *a)
+static unsigned long property_defn_hash(const void *d)
 {
+    const PROPERTY_DEFN_ELEM *a = (const PROPERTY_DEFN_ELEM *)d;
     return OPENSSL_LH_strhash(a->prop);
 }
 
-static int property_defn_cmp(const PROPERTY_DEFN_ELEM *a,
-                             const PROPERTY_DEFN_ELEM *b)
+static int property_defn_cmp(const void *da,
+                             const void *db)
 {
+    const PROPERTY_DEFN_ELEM *a = (const PROPERTY_DEFN_ELEM *)da;
+    const PROPERTY_DEFN_ELEM *b = (const PROPERTY_DEFN_ELEM *)db;
+
     return strcmp(a->prop, b->prop);
 }
 

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -181,13 +181,17 @@ static int ossl_property_unlock(OSSL_METHOD_STORE *p)
     return p != 0 ? CRYPTO_THREAD_unlock(p->lock) : 0;
 }
 
-static unsigned long query_hash(const QUERY *a)
+static unsigned long query_hash(const void *d)
 {
+    const QUERY *a = (const QUERY *)d;
     return OPENSSL_LH_strhash(a->query);
 }
 
-static int query_cmp(const QUERY *a, const QUERY *b)
+static int query_cmp(const void *da, const void *db)
 {
+    const QUERY *a = (const QUERY *)da;
+    const QUERY *b = (const QUERY *)db;
+
     int res = strcmp(a->query, b->query);
 
     if (res == 0 && a->provider != NULL && b->provider != NULL)

--- a/crypto/property/property_string.c
+++ b/crypto/property/property_string.c
@@ -47,13 +47,17 @@ typedef struct {
 #endif
 } PROPERTY_STRING_DATA;
 
-static unsigned long property_hash(const PROPERTY_STRING *a)
+static unsigned long property_hash(const void *d)
 {
+    const PROPERTY_STRING *a = (const PROPERTY_STRING *)d;
     return OPENSSL_LH_strhash(a->s);
 }
 
-static int property_cmp(const PROPERTY_STRING *a, const PROPERTY_STRING *b)
+static int property_cmp(const void *da, const void *db)
 {
+    const PROPERTY_STRING *a = (const PROPERTY_STRING *)da;
+    const PROPERTY_STRING *b = (const PROPERTY_STRING *)db;
+
     return strcmp(a->s, b->s);
 }
 

--- a/crypto/store/store_register.c
+++ b/crypto/store/store_register.c
@@ -136,14 +136,18 @@ int OSSL_STORE_LOADER_set_close(OSSL_STORE_LOADER *loader,
  *  Functions for registering OSSL_STORE_LOADERs
  */
 
-static unsigned long store_loader_hash(const OSSL_STORE_LOADER *v)
+static unsigned long store_loader_hash(const void *d)
 {
+    const OSSL_STORE_LOADER *v = (OSSL_STORE_LOADER *)d;
     return OPENSSL_LH_strhash(v->scheme);
 }
 
-static int store_loader_cmp(const OSSL_STORE_LOADER *a,
-                            const OSSL_STORE_LOADER *b)
+static int store_loader_cmp(const void *da,
+                            const void *db)
 {
+    const OSSL_STORE_LOADER *a = (const OSSL_STORE_LOADER *)da;
+    const OSSL_STORE_LOADER *b = (const OSSL_STORE_LOADER *)db;
+
     assert(a->scheme != NULL && b->scheme != NULL);
     return strcmp(a->scheme, b->scheme);
 }

--- a/include/openssl/lhash.h.in
+++ b/include/openssl/lhash.h.in
@@ -141,8 +141,8 @@ OSSL_DEPRECATEDIN_3_1 void OPENSSL_LH_node_usage_stats_bio(const OPENSSL_LHASH *
     LHASH_OF(type) { \
         union lh_##type##_dummy { void* d1; unsigned long d2; int d3; } dummy; \
     }; \
-    typedef int (*lh_##type##_compfunc)(const type *a, const type *b); \
-    typedef unsigned long (*lh_##type##_hashfunc)(const type *a); \
+    typedef int (*lh_##type##_compfunc)(const void *a, const void *b); \
+    typedef unsigned long (*lh_##type##_hashfunc)(const void *a); \
     typedef void (*lh_##type##_doallfunc)(type *a); \
     static ossl_unused ossl_inline type *\
     ossl_check_##type##_lh_plain_type(type *ptr) \
@@ -207,8 +207,8 @@ OSSL_DEPRECATEDIN_3_1 void OPENSSL_LH_node_usage_stats_bio(const OPENSSL_LHASH *
         union lh_##type##_dummy { void* d1; unsigned long d2; int d3; } dummy; \
     }; \
     static ossl_unused ossl_inline LHASH_OF(type) * \
-    lh_##type##_new(unsigned long (*hfn)(const type *), \
-                    int (*cfn)(const type *, const type *)) \
+    lh_##type##_new(unsigned long (*hfn)(const void *), \
+                    int (*cfn)(const void *, const void *)) \
     { \
         return (LHASH_OF(type) *) \
             OPENSSL_LH_new((OPENSSL_LH_HASHFUNC)hfn, (OPENSSL_LH_COMPFUNC)cfn); \

--- a/ssl/quic/quic_ackm.c
+++ b/ssl/quic/quic_ackm.c
@@ -58,15 +58,19 @@ struct tx_pkt_history_st {
 
 DEFINE_LHASH_OF_EX(OSSL_ACKM_TX_PKT);
 
-static unsigned long tx_pkt_info_hash(const OSSL_ACKM_TX_PKT *pkt)
+static unsigned long tx_pkt_info_hash(const void *d)
 {
+    const OSSL_ACKM_TX_PKT *pkt = (const OSSL_ACKM_TX_PKT *)d;
     /* Using low bits of the packet number as the hash should be enough */
     return (unsigned long)pkt->pkt_num;
 }
 
-static int tx_pkt_info_compare(const OSSL_ACKM_TX_PKT *a,
-                               const OSSL_ACKM_TX_PKT *b)
+static int tx_pkt_info_compare(const void *da,
+                               const void *db)
 {
+    const OSSL_ACKM_TX_PKT *a = (const OSSL_ACKM_TX_PKT *)da;
+    const OSSL_ACKM_TX_PKT *b = (const OSSL_ACKM_TX_PKT *)db;
+
     if (a->pkt_num < b->pkt_num)
         return -1;
     if (a->pkt_num > b->pkt_num)

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -123,8 +123,9 @@ static int gen_rand_conn_id(OSSL_LIB_CTX *libctx, size_t len, QUIC_CONN_ID *cid)
     return 1;
 }
 
-static unsigned long chan_reset_token_hash(const QUIC_SRT_ELEM *a)
+static unsigned long chan_reset_token_hash(const void *d)
 {
+    const QUIC_SRT_ELEM *a = (const QUIC_SRT_ELEM *)d;
     unsigned long h;
 
     assert(sizeof(h) <= sizeof(a->token));
@@ -132,8 +133,11 @@ static unsigned long chan_reset_token_hash(const QUIC_SRT_ELEM *a)
     return h;
 }
 
-static int chan_reset_token_cmp(const QUIC_SRT_ELEM *a, const QUIC_SRT_ELEM *b)
+static int chan_reset_token_cmp(const void *da, const void *db)
 {
+    const QUIC_SRT_ELEM *a = (const QUIC_SRT_ELEM *)da;
+    const QUIC_SRT_ELEM *b = (const QUIC_SRT_ELEM *)db;
+
     /* RFC 9000 s. 10.3.1:
      *      When comparing a datagram to stateless reset token values,
      *      endpoints MUST perform the comparison without leaking

--- a/ssl/quic/quic_demux.c
+++ b/ssl/quic/quic_demux.c
@@ -33,8 +33,9 @@ struct quic_demux_conn_st {
 
 DEFINE_LHASH_OF_EX(QUIC_DEMUX_CONN);
 
-static unsigned long demux_conn_hash(const QUIC_DEMUX_CONN *conn)
+static unsigned long demux_conn_hash(const void *d)
 {
+    const QUIC_DEMUX_CONN *conn = (const QUIC_DEMUX_CONN *)d;
     size_t i;
     unsigned long v = 0;
 
@@ -47,8 +48,11 @@ static unsigned long demux_conn_hash(const QUIC_DEMUX_CONN *conn)
     return v;
 }
 
-static int demux_conn_cmp(const QUIC_DEMUX_CONN *a, const QUIC_DEMUX_CONN *b)
+static int demux_conn_cmp(const void *da, const void *db)
 {
+    const QUIC_DEMUX_CONN *a = (const QUIC_DEMUX_CONN *)da;
+    const QUIC_DEMUX_CONN *b = (const QUIC_DEMUX_CONN *)db;
+
     return !ossl_quic_conn_id_eq(&a->dst_conn_id, &b->dst_conn_id);
 }
 

--- a/ssl/quic/quic_srtm.c
+++ b/ssl/quic/quic_srtm.c
@@ -66,18 +66,23 @@ struct quic_srtm_st {
     unsigned int                alloc_failed : 1;
 };
 
-static unsigned long items_fwd_hash(const SRTM_ITEM *item)
+static unsigned long items_fwd_hash(const void *d)
 {
+    const SRTM_ITEM *item = (const SRTM_ITEM *)d;
     return (unsigned long)(uintptr_t)item->opaque;
 }
 
-static int items_fwd_cmp(const SRTM_ITEM *a, const SRTM_ITEM *b)
+static int items_fwd_cmp(const void *da, const void *db)
 {
+    const SRTM_ITEM *a = (const SRTM_ITEM *)da;
+    const SRTM_ITEM *b = (const SRTM_ITEM *)db;
+
     return a->opaque != b->opaque;
 }
 
-static unsigned long items_rev_hash(const SRTM_ITEM *item)
+static unsigned long items_rev_hash(const void *d)
 {
+    const SRTM_ITEM *item = (const SRTM_ITEM *)d;
     /*
      * srt_blinded has already been through a crypto-grade hash function, so we
      * can just use bits from that.
@@ -88,8 +93,11 @@ static unsigned long items_rev_hash(const SRTM_ITEM *item)
     return l;
 }
 
-static int items_rev_cmp(const SRTM_ITEM *a, const SRTM_ITEM *b)
+static int items_rev_cmp(const void *da, const void *db)
 {
+    const SRTM_ITEM *a = (const SRTM_ITEM *)da;
+    const SRTM_ITEM *b = (const SRTM_ITEM *)db;
+
     /*
      * We don't need to use CRYPTO_memcmp here as the relationship of
      * srt_blinded to srt is already cryptographically obfuscated.

--- a/ssl/quic/quic_stream_map.c
+++ b/ssl/quic/quic_stream_map.c
@@ -73,13 +73,17 @@ static QUIC_STREAM *list_next(QUIC_STREAM_LIST_NODE *l, QUIC_STREAM_LIST_NODE *n
 #define ready_for_gc_head(l)    list_next((l), (l), \
                                           offsetof(QUIC_STREAM, ready_for_gc_node))
 
-static unsigned long hash_stream(const QUIC_STREAM *s)
+static unsigned long hash_stream(const void *d)
 {
+    const QUIC_STREAM *s = (const QUIC_STREAM *)d;
     return (unsigned long)s->id;
 }
 
-static int cmp_stream(const QUIC_STREAM *a, const QUIC_STREAM *b)
+static int cmp_stream(const void *da, const void *db)
 {
+    const QUIC_STREAM *a = (const QUIC_STREAM *)da;
+    const QUIC_STREAM *b = (const QUIC_STREAM *)db;
+
     if (a->id < b->id)
         return -1;
     if (a->id > b->id)

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -700,8 +700,11 @@ int SSL_CTX_add_client_CA(SSL_CTX *ctx, X509 *x)
     return add_ca_name(&ctx->client_ca_names, x);
 }
 
-static int xname_cmp(const X509_NAME *a, const X509_NAME *b)
+static int xname_cmp(const void *da, const void *db)
 {
+    const X509_NAME *a = (const X509_NAME *)da;
+    const X509_NAME *b = (const X509_NAME *)db;
+
     unsigned char *abuf = NULL, *bbuf = NULL;
     int alen, blen, ret;
 
@@ -729,8 +732,9 @@ static int xname_sk_cmp(const X509_NAME *const *a, const X509_NAME *const *b)
     return xname_cmp(*a, *b);
 }
 
-static unsigned long xname_hash(const X509_NAME *a)
+static unsigned long xname_hash(const void *d)
 {
+    const X509_NAME *a = (const X509_NAME *)d;
     /* This returns 0 also if SHA1 is not available */
     return X509_NAME_hash_ex((X509_NAME *)a, NULL, NULL, NULL);
 }

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3805,8 +3805,9 @@ int SSL_export_keying_material_early(SSL *s, unsigned char *out, size_t olen,
                                               context, contextlen);
 }
 
-static unsigned long ssl_session_hash(const SSL_SESSION *a)
+static unsigned long ssl_session_hash(const void *d)
 {
+    const SSL_SESSION *a = (const SSL_SESSION *)d;
     const unsigned char *session_id = a->session_id;
     unsigned long l;
     unsigned char tmp_storage[4];
@@ -3832,8 +3833,11 @@ static unsigned long ssl_session_hash(const SSL_SESSION *a)
  * being able to construct an SSL_SESSION that will collide with any existing
  * session with a matching session ID.
  */
-static int ssl_session_cmp(const SSL_SESSION *a, const SSL_SESSION *b)
+static int ssl_session_cmp(const void *da, const void *db)
 {
+    const SSL_SESSION *a = (const SSL_SESSION *)da;
+    const SSL_SESSION *b = (const SSL_SESSION *)db;
+
     if (a->ssl_version != b->ssl_version)
         return 1;
     if (a->session_id_length != b->session_id_length)

--- a/test/lhash_test.c
+++ b/test/lhash_test.c
@@ -35,13 +35,17 @@ static const unsigned int n_int_tests = OSSL_NELEM(int_tests);
 static short int_found[OSSL_NELEM(int_tests)];
 static short int_not_found;
 
-static unsigned long int int_hash(const int *p)
+static unsigned long int int_hash(const void *d)
 {
+    const int *p = (const int *)d;
     return 3 & *p;      /* To force collisions */
 }
 
-static int int_cmp(const int *p, const int *q)
+static int int_cmp(const void *da, const void *db)
 {
+    const int *p = (const int *)da;
+    const int *q = (const int *)db;
+
     return *p != *q;
 }
 
@@ -180,8 +184,9 @@ end:
     return testresult;
 }
 
-static unsigned long int stress_hash(const int *p)
+static unsigned long int stress_hash(const void *d)
 {
+    const int *p = (const int *)d;
     return *p;
 }
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -435,13 +435,17 @@ static int check_key_update_lt(struct helper *h, struct helper_local *hl)
     return 1;
 }
 
-static unsigned long stream_info_hash(const STREAM_INFO *info)
+static unsigned long stream_info_hash(const void *d)
 {
+    const STREAM_INFO *info = (const STREAM_INFO *)d;
     return OPENSSL_LH_strhash(info->name);
 }
 
-static int stream_info_cmp(const STREAM_INFO *a, const STREAM_INFO *b)
+static int stream_info_cmp(const void *da, const void *db)
 {
+    const STREAM_INFO *a = (const STREAM_INFO *)da;
+    const STREAM_INFO *b = (const STREAM_INFO *)db;
+
     return strcmp(a->name, b->name);
 }
 


### PR DESCRIPTION
ubsan on clang17 has started warning about the following undefined behavior:

crypto/lhash/lhash.c:299:12: runtime error: call to function err_string_data_hash through pointer to incorrect function type 'unsigned long (*)(const void *)' [...]/crypto/err/err.c:184: note: err_string_data_hash defined here
    #0 0x7fa569e3a434 in getrn [...]/crypto/lhash/lhash.c:299:12
    #1 0x7fa569e39a46 in OPENSSL_LH_insert [...]/crypto/lhash/lhash.c:119:10
    #2 0x7fa569d866ee in err_load_strings [...]/crypto/err/err.c:280:15
[...]

The issue occurs because, the generic hash functions (OPENSSL_LH_*) will occasionaly call back to the type specific registered functions for hash generation/comparison/free/etc, using functions of the (example) prototype:

[return value] <hash|cmp|free> (void *, [void *], ...)

While the functions implementing hash|cmp|free|etc are defined as [return value] <fnname> (TYPE *, [TYPE *], ...)

The compiler, not knowing the type signature of the function pointed to by the implementation, performs no type conversion on the function arguments

While this is nominally not an issue for general run time usage (a pointer to void can be used as a pointer to a specific type, as long as the pointer respects the constraints of the C language specification), it can be problematic for ancilliary tools that expect the compiler to detect when a type conversion occurs (even if it is a no-op, CFI being an expemplar case).

As such, ubsan warns us about this issue to avoid breakages in such conditions.

There could be several fixes for it, such as including some per-type type thunking code, to make the conversion prior to the callback, but such solutions are very involved and require a significant amount of code.

A more general solution (which is provided here), is to convert all the call backs and function callback type definition to only pass void pointers, and make the needed conversion in the callbacks themselves.

Fixes #22896



##### Checklist
- [ ] documentation is added or updated
- [ ] tests are added or updated
