### PR TITLE
Fix a possible memleak in opt_verify

### DIFF
--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -726,7 +726,12 @@ int opt_verify(int opt, X509_VERIFY_PARAM *vpm)
             opt_printf_stderr("%s: Invalid Policy %s\n", prog, opt_arg());
             return 0;
         }
-        X509_VERIFY_PARAM_add0_policy(vpm, otmp);
+        if (!X509_VERIFY_PARAM_add0_policy(vpm, otmp)) {
+            ASN1_OBJECT_free(otmp);
+            opt_printf_stderr("%s: Internal error adding Policy %s\n",
+                              prog, opt_arg());
+            return 0;
+        }
         break;
     case OPT_V_PURPOSE:
         /* purpose name -> purpose index */


### PR DESCRIPTION
THe ASN1_OBJECT otmp was leaked if X509_VERIFY_PARAM_add0_policy fails.
