### PR TITLE
Fix test/recipes/01-test_symbol_presence.t (multiple issues) [3.1 & 3.0]

### DIFF
--- a/test/recipes/01-test_symbol_presence.t
+++ b/test/recipes/01-test_symbol_presence.t
@@ -80,7 +80,13 @@ foreach my $libname (@libnames) {
                 # Return the result
                 $_
             }
-            grep(m|.* [BCDST] .*|, @nm_lines);
+            # Drop any symbol starting with a double underscore, they
+            # are reserved for the compiler / system ABI and are none
+            # of our business
+            grep !m|^__|,
+            # Only look at external definitions
+            grep m|.* [BCDST] .*|,
+            @nm_lines;
 
         # Massage the mkdef.pl output to only contain global symbols
         # The output we got is in Unix .map format, which has a global

--- a/test/recipes/01-test_symbol_presence.t
+++ b/test/recipes/01-test_symbol_presence.t
@@ -70,23 +70,35 @@ foreach my $libname (@libnames) {
         note "Number of lines in \@def_lines before massaging: ", scalar @def_lines;
 
         # Massage the nm output to only contain defined symbols
+        # Common symbols need separate treatment
+        my %commons;
+        foreach (@nm_lines) {
+            if (m|^(.*) C .*|) {
+                $commons{$1}++;
+            }
+        }
+        foreach (sort keys %commons) {
+            note "Common symbol: $_";
+        }
+
         @nm_lines =
             sort
-            map {
-                # Drop the first space and everything following it
-                s| .*||;
-                # Drop OpenSSL dynamic version information if there is any
-                s|\@\@.+$||;
-                # Return the result
-                $_
-            }
-            # Drop any symbol starting with a double underscore, they
-            # are reserved for the compiler / system ABI and are none
-            # of our business
-            grep !m|^__|,
-            # Only look at external definitions
-            grep m|.* [BCDST] .*|,
-            @nm_lines;
+            ( map {
+                  # Drop the first space and everything following it
+                  s| .*||;
+                  # Drop OpenSSL dynamic version information if there is any
+                  s|\@\@.+$||;
+                  # Return the result
+                  $_
+              }
+              # Drop any symbol starting with a double underscore, they
+              # are reserved for the compiler / system ABI and are none
+              # of our business
+              grep !m|^__|,
+              # Only look at external definitions
+              grep m|.* [BDST] .*|,
+              @nm_lines ),
+            keys %commons;
 
         # Massage the mkdef.pl output to only contain global symbols
         # The output we got is in Unix .map format, which has a global


### PR DESCRIPTION
On some platforms, the compiler may add symbols that aren't ours and that we should ignore.

They are generally expected to start with a double underscore, and thereby easy to detect.

Furthermore, we find ourselves with a common symbol (type 'C' in the 'nm' output) on some platforms (x86, for example). They are allowed to be defined more than once, so make this test recipe reflect that.

*NOTE: This is a backport of #22880 for OpenSSL 3.1 and 3.0.*
