### PR TITLE
Make OPENSSL_sk_push return only 0 or 1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,11 @@ OpenSSL 3.3
 
     *Neil Horman*
 
+ * OPENSSL_sk_push() and sk_<TYPE>_push() functions now return 0 instead of -1
+   if called with a NULL stack argument.
+
+   *Tomáš Mráz*
+
  * In `openssl speed`, changed the default hash function used with `hmac` from
    `md5` to `sha256`.
 

--- a/crypto/stack/stack.c
+++ b/crypto/stack/stack.c
@@ -397,7 +397,7 @@ int OPENSSL_sk_find_all(OPENSSL_STACK *st, const void *data, int *pnum)
 int OPENSSL_sk_push(OPENSSL_STACK *st, const void *data)
 {
     if (st == NULL)
-        return -1;
+        return 0;
     return OPENSSL_sk_insert(st, data, st->num);
 }
 

--- a/doc/man3/DEFINE_STACK_OF.pod
+++ b/doc/man3/DEFINE_STACK_OF.pod
@@ -270,7 +270,6 @@ on error.
 
 B<sk_I<TYPE>_insert>(), B<sk_I<TYPE>_push>() and B<sk_I<TYPE>_unshift>() return
 the total number of elements in the stack and 0 if an error occurred.
-B<sk_I<TYPE>_push>() further returns -1 if I<sk> is NULL.
 
 B<sk_I<TYPE>_set>() returns a pointer to the replacement element or NULL on
 error.
@@ -296,6 +295,9 @@ From OpenSSL 3.2.0, the B<sk_I<TYPE>_find>(), B<sk_I<TYPE>_find_ex>()
 and B<sk_I<TYPE>_find_all>() calls are read-only and do not sort the
 stack.  To avoid any performance implications this change introduces,
 B<sk_I<TYPE>_sort>() should be called before these find operations.
+
+Before OpenSSL 3.3.0 B<sk_I<TYPE>_push>() returned -1 if I<sk> was NULL. It
+was changed to return 0 in this condition as for other errors.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
Most of the callers do not actually check for
the special -1 return condition because they do not pass NULL to it. It is also extremely improbable that any code depends on this -1 return value in this condition so it can be safely changed to 0 return.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
