### PR TITLE
ossl_decoder_cache_flush(): Do not raise an error if there is no cache

### DIFF
--- a/crypto/encode_decode/decoder_pkey.c
+++ b/crypto/encode_decode/decoder_pkey.c
@@ -721,10 +721,9 @@ int ossl_decoder_cache_flush(OSSL_LIB_CTX *libctx)
     DECODER_CACHE *cache
         = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_DECODER_CACHE_INDEX);
 
-    if (cache == NULL) {
-        ERR_raise(ERR_LIB_OSSL_DECODER, ERR_R_OSSL_DECODER_LIB);
+    if (cache == NULL)
         return 0;
-    }
+
 
     if (!CRYPTO_THREAD_write_lock(cache->lock)) {
         ERR_raise(ERR_LIB_OSSL_DECODER, ERR_R_OSSL_DECODER_LIB);


### PR DESCRIPTION
This function can be called during OPENSSL_cleanup() when the cache was already flushed and deallocated.

Fixes #22939
