### PR TITLE
ENGINE_load_private_key(): Do foreign key detection without side effects

### DIFF
--- a/crypto/engine/eng_pkey.c
+++ b/crypto/engine/eng_pkey.c
@@ -10,6 +10,7 @@
 /* We need to use some engine deprecated APIs */
 #define OPENSSL_SUPPRESS_DEPRECATED
 
+#include "crypto/evp.h"
 #include "eng_local.h"
 
 /* Basic get/set stuff */
@@ -79,48 +80,8 @@ EVP_PKEY *ENGINE_load_private_key(ENGINE *e, const char *key_id,
         ERR_raise(ERR_LIB_ENGINE, ENGINE_R_FAILED_LOADING_PRIVATE_KEY);
         return NULL;
     }
-    /* We enforce check for legacy key */
-    switch (EVP_PKEY_get_id(pkey)) {
-    case EVP_PKEY_RSA:
-        {
-        RSA *rsa = EVP_PKEY_get1_RSA(pkey);
-        EVP_PKEY_set1_RSA(pkey, rsa);
-        RSA_free(rsa);
-        }
-        break;
-#  ifndef OPENSSL_NO_EC
-    case EVP_PKEY_SM2:
-    case EVP_PKEY_EC:
-        {
-        EC_KEY *ec = EVP_PKEY_get1_EC_KEY(pkey);
-        EVP_PKEY_set1_EC_KEY(pkey, ec);
-        EC_KEY_free(ec);
-        }
-        break;
-#  endif
-#  ifndef OPENSSL_NO_DSA
-    case EVP_PKEY_DSA:
-        {
-        DSA *dsa = EVP_PKEY_get1_DSA(pkey);
-        EVP_PKEY_set1_DSA(pkey, dsa);
-        DSA_free(dsa);
-        }
-        break;
-#endif
-#  ifndef OPENSSL_NO_DH
-    case EVP_PKEY_DH:
-        {
-        DH *dh = EVP_PKEY_get1_DH(pkey);
-        EVP_PKEY_set1_DH(pkey, dh);
-        DH_free(dh);
-        }
-        break;
-#endif
-    default:
-        /*Do nothing */
-        break;
-    }
 
+    ossl_detect_foreign_pkey(pkey);
     return pkey;
 }
 

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -721,7 +721,7 @@ ENGINE *EVP_PKEY_get0_engine(const EVP_PKEY *pkey)
 # endif
 
 # ifndef OPENSSL_NO_DEPRECATED_3_0
-static void detect_foreign_key(EVP_PKEY *pkey)
+void ossl_detect_foreign_pkey(EVP_PKEY *pkey)
 {
     switch (pkey->type) {
     case EVP_PKEY_RSA:
@@ -783,7 +783,7 @@ int EVP_PKEY_assign(EVP_PKEY *pkey, int type, void *key)
         return 0;
 
     pkey->pkey.ptr = key;
-    detect_foreign_key(pkey);
+    ossl_detect_foreign_pkey(pkey);
 
     return (key != NULL);
 }

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -731,7 +731,6 @@ void ossl_detect_foreign_pkey(EVP_PKEY *pkey)
         break;
 #  ifndef OPENSSL_NO_EC
     case EVP_PKEY_SM2:
-        break;
     case EVP_PKEY_EC:
         pkey->foreign = pkey->pkey.ec != NULL
                         && ossl_ec_key_is_foreign(pkey->pkey.ec);

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -937,11 +937,14 @@ int evp_pkey_ctx_get_params_to_ctrl(EVP_PKEY_CTX *ctx, OSSL_PARAM *params);
 /* This must ONLY be called for legacy EVP_PKEYs */
 int evp_pkey_get_params_to_ctrl(const EVP_PKEY *pkey, OSSL_PARAM *params);
 
-/* Same as the public get0 functions but are not const */
 # ifndef OPENSSL_NO_DEPRECATED_3_0
+/* Same as the public get0 functions but are not const */
 DH *evp_pkey_get0_DH_int(const EVP_PKEY *pkey);
 EC_KEY *evp_pkey_get0_EC_KEY_int(const EVP_PKEY *pkey);
 RSA *evp_pkey_get0_RSA_int(const EVP_PKEY *pkey);
+
+/* Sets the foreign flag in pkey as appropriate */
+void ossl_detect_foreign_pkey(EVP_PKEY *pkey);
 # endif
 
 /* Get internal identification number routines */


### PR DESCRIPTION
Doing set1()/get1() has unwanted side effects.
Instead just set the foreign flag appropriately.

Fixes #22945
