### PR TITLE
fips-label.yml: Cleanup the FIPS artifact before downloading ABIDIFF one

### DIFF
--- a/.github/workflows/fips-label.yml
+++ b/.github/workflows/fips-label.yml
@@ -79,6 +79,8 @@ jobs:
                 }
               }
             }
+      - name: 'Cleanup artifact'
+        run: rm artifact.zip pr_num
 
       - name: 'Download abidiff artifact'
         if: ${{ github.event.workflow_run.conclusion == 'success' }}


### PR DESCRIPTION
Marking as urgent otherwise the ABIDIFF labelling doesn't work.
