### PR TITLE
Fix some invalid use of sscanf

### DIFF
--- a/apps/errstr.c
+++ b/apps/errstr.c
@@ -62,7 +62,7 @@ int errstr_main(int argc, char **argv)
     /* All remaining arg are error code. */
     ret = 0;
     for (argv = opt_rest(); *argv != NULL; argv++) {
-        if (sscanf(*argv, "%lx", &l) == 0) {
+        if (sscanf(*argv, "%lx", &l) <= 0) {
             ret++;
         } else {
             ERR_error_string_n(l, buf, sizeof(buf));

--- a/crypto/http/http_lib.c
+++ b/crypto/http/http_lib.c
@@ -118,7 +118,7 @@ int OSSL_parse_url(const char *url, char **pscheme, char **puser, char **phost,
         port = ++p;
     /* remaining port spec handling is also done for the default values */
     /* make sure a decimal port number is given */
-    if (!sscanf(port, "%u", &portnum) || portnum > 65535) {
+    if (sscanf(port, "%u", &portnum) <= 0 || portnum > 65535) {
         ERR_raise_data(ERR_LIB_HTTP, HTTP_R_INVALID_PORT_NUMBER, "%s", port);
         goto err;
     }

--- a/test/http_test.c
+++ b/test/http_test.c
@@ -347,7 +347,8 @@ static int test_http_url_invalid_prefix(void)
 
 static int test_http_url_invalid_port(void)
 {
-    return test_http_url_invalid("https://1.2.3.4:65536/pkix");
+    return test_http_url_invalid("https://1.2.3.4:65536/pkix")
+           && test_http_url_invalid("https://1.2.3.4:");
 }
 
 static int test_http_url_invalid_path(void)


### PR DESCRIPTION
sscanf can return -1 on an empty input string. We need to appropriately
handle such an invalid case.

The instance in OSSL_HTTP_parse_url could cause an uninitialised read of
sizeof(unsigned int) bytes (typically 4). In many cases this uninit read
will immediately fail on the following check (i.e. if the read value
>65535).

If the top 2 bytes of a 4 byte unsigned int are zero then the value will
be <=65535 and the uninitialised value will be returned to the caller and
could represent arbitrary data on the application stack.

The OpenSSL security team has assessed this issue and consider it to be
a bug only (i.e. not a CVE).
