### PR TITLE
Add provider fuzzer

### DIFF
--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -670,6 +670,9 @@ int EVP_CIPHER_get_key_length(const EVP_CIPHER *cipher)
 
 int EVP_CIPHER_CTX_get_key_length(const EVP_CIPHER_CTX *ctx)
 {
+    if (ctx->cipher == NULL)
+        return 0;
+
     if (ctx->key_len <= 0 && ctx->cipher->prov != NULL) {
         int ok;
         OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };

--- a/fuzz/build.info
+++ b/fuzz/build.info
@@ -12,6 +12,7 @@ IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
   PROGRAMS{noinst}=asn1 asn1parse bignum bndiv client conf crl server smime
   PROGRAMS{noinst}=punycode pem decoder hashtable acert
   PROGRAMS{noinst}=v3name
+  PROGRAMS{noinst}=provider
 
   IF[{- !$disabled{"cmp"} -}]
     PROGRAMS{noinst}=cmp
@@ -136,12 +137,17 @@ IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
   SOURCE[x509]=x509.c driver.c fuzz_rand.c
   INCLUDE[x509]=../include {- $ex_inc -}
   DEPEND[x509]=../libcrypto {- $ex_lib -}
+
+  SOURCE[provider]=provider.c driver.c
+  INCLUDE[provider]=../include {- $ex_inc -}
+  DEPEND[provider]=../libcrypto {- $ex_lib -}
 ENDIF
 
 IF[{- !$disabled{tests} -}]
   PROGRAMS{noinst}=asn1-test asn1parse-test bignum-test bndiv-test client-test conf-test crl-test server-test smime-test
   PROGRAMS{noinst}=punycode-test pem-test decoder-test hashtable-test acert-test
   PROGRAMS{noinst}=v3name-test
+  PROGRAMS{noinst}=provider-test
 
   IF[{- !$disabled{"cmp"} -}]
     PROGRAMS{noinst}=cmp-test
@@ -268,4 +274,8 @@ IF[{- !$disabled{tests} -}]
   SOURCE[x509-test]=x509.c test-corpus.c fuzz_rand.c
   INCLUDE[x509-test]=../include
   DEPEND[x509-test]=../libcrypto
+
+  SOURCE[provider-test]=provider.c test-corpus.c
+  INCLUDE[provider-test]=../include
+  DEPEND[provider-test]=../libcrypto
 ENDIF

--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -1,3 +1,12 @@
+/*
+ * Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.openssl.org/source/license.html
+ * or in the file LICENSE in the source distribution.
+ */
 #include <string.h>
 #include "openssl/types.h"
 #include "openssl/crypto.h"

--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -1,0 +1,636 @@
+#include <string.h>
+#include "openssl/types.h"
+#include "openssl/crypto.h"
+#include "openssl/core_names.h"
+#include "openssl/kdf.h"
+#include "openssl/evp.h"
+#include "openssl/provider.h"
+
+#define DEFINE_ALGORITHMS(name, evp) DEFINE_STACK_OF(evp) \
+    static int cmp_##evp(const evp *const *a, const evp *const *b) \
+    { \
+        return strcmp(OSSL_PROVIDER_get0_name(evp##_get0_provider(*a)), \
+                      OSSL_PROVIDER_get0_name(evp##_get0_provider(*b))); \
+    } \
+    STACK_OF(evp) * name##_collection; \
+    static void collect_##evp(evp * digest, void * stack) \
+    { \
+        STACK_OF(evp) *digest_stack = stack;  \
+        \
+        if (sk_##evp##_push(digest_stack, digest) > 0) \
+            evp##_up_ref(digest); \
+    } \
+    static void init_##name(OSSL_LIB_CTX * libctx) \
+    { \
+        name##_collection = sk_##evp##_new(cmp_##evp); \
+        evp##_do_all_provided(libctx, collect_##evp, name##_collection); \
+    } \
+    static void cleanup_##name() \
+    { \
+        sk_##evp##_free(name##_collection); \
+    }
+
+DEFINE_ALGORITHMS(digests, EVP_MD)
+
+DEFINE_ALGORITHMS(kdf, EVP_KDF)
+
+DEFINE_ALGORITHMS(cipher, EVP_CIPHER)
+
+DEFINE_ALGORITHMS(kem, EVP_KEM)
+
+DEFINE_ALGORITHMS(keyexch, EVP_KEYEXCH)
+
+DEFINE_ALGORITHMS(rand, EVP_RAND)
+
+DEFINE_ALGORITHMS(mac, EVP_MAC)
+
+DEFINE_ALGORITHMS(keymgmt, EVP_KEYMGMT)
+
+DEFINE_ALGORITHMS(signature, EVP_SIGNATURE)
+
+DEFINE_ALGORITHMS(asym_ciphers, EVP_ASYM_CIPHER)
+
+OSSL_LIB_CTX *libctx = NULL;
+STACK_OF(EVP_MD) *digests;
+
+int FuzzerInitialize(int *argc, char ***argv)
+{
+    libctx = OSSL_LIB_CTX_new();
+    if (libctx == NULL)
+        return 0;
+
+    init_digests(libctx);
+    init_kdf(libctx);
+    init_cipher(libctx);
+    init_kem(libctx);
+    init_keyexch(libctx);
+    init_rand(libctx);
+    init_mac(libctx);
+    init_keymgmt(libctx);
+    init_signature(libctx);
+    init_asym_ciphers(libctx);
+    return 1;
+}
+
+void FuzzerCleanup()
+{
+    cleanup_digests();
+    cleanup_kdf();
+    cleanup_cipher();
+    cleanup_kem();
+    cleanup_keyexch();
+    cleanup_rand();
+    cleanup_mac();
+    cleanup_keymgmt();
+    cleanup_signature();
+    cleanup_asym_ciphers();
+
+    OSSL_LIB_CTX_free(libctx);
+}
+
+int read_uint(const uint8_t **buf, size_t *len, uint64_t **res)
+{
+    int r = 1;
+
+    if (*len < sizeof(uint64_t)) {
+        r = 0;
+        goto end;
+    }
+
+    *res = (uint64_t *) *buf;
+    *buf += sizeof(uint64_t);
+    *len -= sizeof(uint64_t);
+end:
+    return r;
+}
+
+int read_int(const uint8_t **buf, size_t *len, int64_t **res)
+{
+    int r = 1;
+
+    if (*len < sizeof(int64_t)) {
+        r = 0;
+        goto end;
+    }
+
+    *res = (int64_t *) *buf;
+    *buf += sizeof(int64_t);
+    *len -= sizeof(int64_t);
+end:
+    return r;
+}
+
+int read_double(const uint8_t **buf, size_t *len, double **res)
+{
+    int r = 1;
+
+    if (*len < sizeof(double)) {
+        r = 0;
+        goto end;
+    }
+
+    *res = (double *) *buf;
+    *buf += sizeof(double);
+    *len -= sizeof(double);
+end:
+    return r;
+}
+
+int read_utf8_string(const uint8_t **buf, size_t *len, char **res)
+{
+    int r;
+    const uint8_t *ptr = *buf;
+    int found = 0;
+
+    for (size_t i = 0; i < *len; ++i) {
+        if (*ptr == 0) {
+            ptr++;
+            found = 1;
+            break;
+        }
+        ptr++;
+    }
+
+    if (!found) {
+        r = -1;
+        goto end;
+    }
+
+    *res = (char *) *buf;
+
+    r = ptr - *buf;
+    *len -= r;
+    *buf = ptr;
+
+end:
+    return r;
+}
+
+int read_utf8_ptr(const uint8_t **buf, size_t *len, char **res)
+{
+    if (*len > 0 && **buf == 0xFF) {
+        /* represent NULL somehow */
+        *res = NULL;
+        *buf += 1;
+        *len -= 1;
+        return 0;
+    }
+    return read_utf8_string(buf, len, res);
+}
+
+int read_octet_string(const uint8_t **buf, size_t *len, char **res)
+{
+    int r;
+    const uint8_t *ptr = *buf;
+    int found = 0;
+
+    for (size_t i = 0; i < *len; ++i) {
+        if (*ptr == 0xFF &&
+            (i + 1 < *len && *(ptr + 1) == 0xFF)) {
+            ptr++;
+            found = 1;
+            break;
+        }
+        ptr++;
+    }
+
+    if (!found) {
+        r = -1;
+        goto end;
+    }
+
+    *res = (char *) *buf;
+
+    r = ptr - *buf;
+    *len -= r;
+    *buf = ptr;
+
+end:
+    return r;
+}
+
+int read_octet_ptr(const uint8_t **buf, size_t *len, char **res)
+{
+    /* TODO: This representation could need an improvement potentially. */
+    if (*len > 1 && **buf == 0xFF && *(*buf + 1) == 0xFF) {
+        /* represent NULL somehow */
+        *res = NULL;
+        *buf += 2;
+        *len -= 2;
+        return 0;
+    }
+    return read_octet_string(buf, len, res);
+}
+
+static int64_t NO_PARAM = 0;
+static int64_t DFLT_INT = 0;
+static uint64_t DFLT_UINT = 0;
+static double DFLT_DOUBLE = 0;
+static char *DFLT_STR = "";
+static char *DFLT_UTF8_PTR = NULL;
+static char DFLT_OCTET_STRING[] = {};
+static char *DFLT_OCTET_PTR = NULL;
+
+static int64_t ITERS = 1;
+static uint64_t UITERS = 1;
+static int64_t BLOCKSIZE = 8;
+static uint64_t UBLOCKSIZE = 8;
+
+OSSL_PARAM *fuzz_params(OSSL_PARAM *param, const uint8_t **buf, size_t *len)
+{
+    OSSL_PARAM *p;
+    int p_num = 0;
+
+    for (p = param; p != NULL && p->key != NULL; p++) {
+        p_num++;
+    }
+
+    OSSL_PARAM *fuzzed_parameters = OPENSSL_zalloc(sizeof(OSSL_PARAM) * (p_num + 1));
+    p = fuzzed_parameters;
+
+    for (; param != NULL && param->key != NULL; param++) {
+        int64_t *use_param = NULL;
+        int64_t *p_value_int = &DFLT_INT;
+        uint64_t *p_value_uint = &DFLT_UINT;
+        double *p_value_double = &DFLT_DOUBLE;
+        char *p_value_utf8_str = DFLT_STR;
+        char *p_value_octet_str = DFLT_OCTET_PTR;
+        char *p_value_utf8_ptr = DFLT_UTF8_PTR;
+        char *p_value_octet_ptr = DFLT_OCTET_PTR;
+        int data_len = 0;
+
+        if (!read_int(buf, len, &use_param)) {
+            use_param = &NO_PARAM;
+        }
+
+        switch (param->data_type) {
+        case OSSL_PARAM_INTEGER:
+            if (*use_param && !read_int(buf, len, &p_value_int)) {
+                /* use default */
+            }
+
+            if (strcmp(param->key, OSSL_KDF_PARAM_ITER) == 0) {
+                p_value_int = &ITERS;
+            }
+
+            if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_N) == 0) {
+                p_value_int = &ITERS;
+            }
+
+            if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_R) == 0) {
+                p_value_int = &BLOCKSIZE;
+            }
+
+            if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_P) == 0) {
+                p_value_int = &BLOCKSIZE;
+            }
+
+            *p = *param;
+            p->data = p_value_int;
+            p++;
+            break;
+        case OSSL_PARAM_UNSIGNED_INTEGER:
+            if (*use_param && !read_uint(buf, len, &p_value_uint)) {
+                /* use default */
+            }
+
+            if (strcmp(param->key, OSSL_KDF_PARAM_ITER) == 0) {
+                p_value_uint = &UITERS;
+            }
+
+            if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_N) == 0) {
+                p_value_uint = &UITERS;
+            }
+
+            if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_R) == 0) {
+                p_value_uint = &UBLOCKSIZE;
+            }
+
+            if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_P) == 0) {
+                p_value_uint = &UBLOCKSIZE;
+            }
+
+            *p = *param;
+            p->data = p_value_uint;
+            p++;
+            break;
+        case OSSL_PARAM_REAL:
+            if (*use_param && !read_double(buf, len, &p_value_double)) {
+                /* use default */
+            }
+            *p = *param;
+            p->data = p_value_double;
+            p++;
+            break;
+        case OSSL_PARAM_UTF8_STRING:
+            if (*use_param && (data_len = read_utf8_string(buf, len, &p_value_utf8_str)) < 0) {
+                data_len = 0;
+            }
+            *p = *param;
+            p->data = p_value_utf8_str;
+            p->data_size = data_len;
+            p++;
+            break;
+        case OSSL_PARAM_OCTET_STRING:
+            if (*use_param && (data_len = read_octet_string(buf, len, &p_value_octet_str)) < 0) {
+                data_len = 0;
+            }
+            *p = *param;
+            p->data = p_value_octet_str;
+            p->data_size = data_len;
+            p++;
+            break;
+        case OSSL_PARAM_UTF8_PTR:
+            if (*use_param && (data_len = read_utf8_ptr(buf, len, &p_value_utf8_ptr)) < 0) {
+                data_len = 0;
+            }
+            *p = *param;
+            p->data = p_value_utf8_ptr;
+            p->data_size = data_len;
+            p++;
+            break;
+        case OSSL_PARAM_OCTET_PTR:
+            if (*use_param && (data_len = read_octet_ptr(buf, len, &p_value_octet_ptr)) < 0) {
+                data_len = 0;
+            }
+            *p = *param;
+            p->data = p_value_octet_ptr;
+            p->data_size = data_len;
+            p++;
+            break;
+        default:
+            break;
+        }
+    }
+
+    return fuzzed_parameters;
+}
+
+int do_evp_cipher(const EVP_CIPHER *evp_cipher, const OSSL_PARAM param[])
+{
+    unsigned char outbuf[1024];
+    int outlen, tmplen;
+    unsigned char key[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+    unsigned char iv[] = {1, 2, 3, 4, 5, 6, 7, 8};
+    char intext[] = "text";
+    EVP_CIPHER_CTX *ctx;
+
+    ctx = EVP_CIPHER_CTX_new();
+
+    if (!EVP_CIPHER_CTX_set_params(ctx, param)) {
+        EVP_CIPHER_CTX_free(ctx);
+        return 0;
+    }
+
+    if (!EVP_EncryptInit_ex2(ctx, evp_cipher, key, iv, NULL)) {
+        /* Error */
+        EVP_CIPHER_CTX_free(ctx);
+        return 0;
+    }
+
+    if (!EVP_EncryptUpdate(ctx, outbuf, &outlen, intext, strlen(intext))) {
+        /* Error */
+        EVP_CIPHER_CTX_free(ctx);
+        return 0;
+    }
+    /*
+     * Buffer passed to EVP_EncryptFinal() must be after data just
+     * encrypted to avoid overwriting it.
+     */
+    if (!EVP_EncryptFinal_ex(ctx, outbuf + outlen, &tmplen)) {
+        /* Error */
+        EVP_CIPHER_CTX_free(ctx);
+        return 0;
+    }
+    outlen += tmplen;
+    EVP_CIPHER_CTX_free(ctx);
+    return 1;
+}
+
+int do_evp_kdf(EVP_KDF *evp_kdf, const OSSL_PARAM params[])
+{
+    int r = 1;
+    EVP_KDF_CTX *kctx = NULL;
+    unsigned char derived[32];
+
+    kctx = EVP_KDF_CTX_new(evp_kdf);
+
+    if (kctx == NULL) {
+        r = 0;
+        goto end;
+    }
+
+    if (EVP_KDF_CTX_set_params(kctx, params) <= 0) {
+        r = 0;
+        goto end;
+    }
+
+    if (EVP_KDF_derive(kctx, derived, sizeof(derived), NULL) <= 0) {
+        r = 0;
+        goto end;
+    }
+
+end:
+    EVP_KDF_CTX_free(kctx);
+    return r;
+}
+
+int do_evp_mac(EVP_MAC *evp_mac, const OSSL_PARAM params[])
+{
+    int r = 1;
+    const char *key = "mac_key";
+    char text[] = "Some Crypto Text";
+    EVP_MAC_CTX *ctx = NULL;
+    unsigned char buf[4096];
+    size_t final_l;
+
+    if ((ctx = EVP_MAC_CTX_new(evp_mac)) == NULL
+        || !EVP_MAC_init(ctx, (const unsigned char *) key, strlen(key),
+                         params)) {
+        r = 0;
+        goto end;
+    }
+
+    if (EVP_MAC_CTX_set_params(ctx, params) <= 0) {
+        r = 0;
+        goto end;
+    }
+
+    if (!EVP_MAC_update(ctx, (unsigned char *) text, sizeof(text))) {
+        r = 0;
+        goto end;
+    }
+
+    if (!EVP_MAC_final(ctx, buf, &final_l, sizeof(buf))) {
+        r = 0;
+        goto end;
+    }
+
+end:
+    EVP_MAC_CTX_free(ctx);
+    return r;
+}
+
+int do_evp_rand(EVP_RAND *evp_rand, const OSSL_PARAM params[])
+{
+    int r = 1;
+    EVP_RAND_CTX *ctx = NULL;
+    unsigned char buf[4096];
+
+    if (!(ctx = EVP_RAND_CTX_new(evp_rand, NULL))) {
+        r = 0;
+        goto end;
+    }
+
+    if (EVP_RAND_CTX_set_params(ctx, params) <= 0) {
+        r = 0;
+        goto end;
+    }
+
+    if (!EVP_RAND_generate(ctx, buf, sizeof(buf), 0, 0, NULL, 0)) {
+        r = 0;
+        goto end;
+    }
+
+    if (!EVP_RAND_reseed(ctx, 0, 0, 0, NULL, 0)) {
+        r = 0;
+        goto end;
+    }
+
+end:
+    EVP_RAND_CTX_free(ctx);
+    return r;
+}
+
+int do_evp_sig(EVP_SIGNATURE *evp_sig, const OSSL_PARAM params[])
+{
+    return 0;
+}
+
+int do_evp_asym_cipher(EVP_ASYM_CIPHER *evp_asym_cipher, const OSSL_PARAM params[])
+{
+    return 0;
+}
+
+int do_evp_kem(EVP_KEM *evp_kem, const OSSL_PARAM params[])
+{
+    return 0;
+}
+
+int do_evp_keymgmt(EVP_KEYMGMT *evp_kdf, const OSSL_PARAM params[])
+{
+    return 0;
+}
+
+int do_evp_key_exch(EVP_KEYEXCH *evp_kdf, const OSSL_PARAM params[])
+{
+    return 0;
+}
+
+int do_evp_md(EVP_MD *evp_md, const OSSL_PARAM params[])
+{
+    int r = 1;
+    unsigned char md_value[EVP_MAX_MD_SIZE];
+    unsigned int md_len, i;
+    EVP_MD_CTX *mdctx = NULL;
+
+    if (!(mdctx = EVP_MD_CTX_new())) {
+        r = 0;
+        goto end;
+    }
+
+    if (!EVP_MD_CTX_set_params(mdctx, params)) {
+        r = 0;
+        goto end;
+    }
+
+    if (!EVP_DigestInit_ex2(mdctx, evp_md, NULL)) {
+        r = 0;
+        goto end;
+    }
+    if (!EVP_DigestUpdate(mdctx, "Test", strlen("Test"))) {
+        r = 0;
+        goto end;
+    }
+    if (!EVP_DigestFinal_ex(mdctx, md_value, &md_len)) {
+        r = 0;
+        goto end;
+    }
+
+end:
+    EVP_MD_CTX_free(mdctx);
+    return r;
+}
+
+#define EVP_FUZZ(source, evp, f) \
+    do { \
+        evp * alg = sk_##evp##_value(source, *algorithm % sk_##evp##_num(source)); \
+        \
+        if (!alg) { \
+            break; \
+        } \
+        OSSL_PARAM *fuzzed_params = fuzz_params((OSSL_PARAM*) evp##_settable_ctx_params(alg), &buf, &len); \
+        if (fuzzed_params) { \
+            f(alg, fuzzed_params); \
+        } \
+        OSSL_PARAM_free(fuzzed_params); \
+    } while (0);
+
+uint64_t DFLT_OP = 0;
+int64_t DFLT_ALG = 0;
+
+int FuzzerTestOneInput(const uint8_t *buf, size_t len)
+{
+    int r = 1;
+    uint64_t *operation = &DFLT_OP;
+    int64_t *algorithm = &DFLT_ALG;
+
+    if (!read_uint(&buf, &len, &operation)) {
+        r = 0;
+        goto end;
+    }
+
+    if (!read_int(&buf, &len, &algorithm)) {
+        r = 0;
+        goto end;
+    }
+
+    switch (*operation % 10) {
+    case 0:
+        EVP_FUZZ(digests_collection, EVP_MD, do_evp_md);
+        break;
+    case 1:
+        EVP_FUZZ(cipher_collection, EVP_CIPHER, do_evp_cipher);
+        break;
+    case 2:
+        EVP_FUZZ(kdf_collection, EVP_KDF, do_evp_kdf);
+        break;
+    case 3:
+        EVP_FUZZ(mac_collection, EVP_MAC, do_evp_mac);
+        break;
+    case 4:
+        EVP_FUZZ(kem_collection, EVP_KEM, do_evp_kem);
+        break;
+    case 5:
+        EVP_FUZZ(rand_collection, EVP_RAND, do_evp_rand);
+        break;
+    case 6:
+        EVP_FUZZ(asym_ciphers_collection, EVP_ASYM_CIPHER, do_evp_asym_cipher);
+        break;
+    case 7:
+        EVP_FUZZ(signature_collection, EVP_SIGNATURE, do_evp_sig);
+        break;
+    case 8:
+        EVP_FUZZ(keyexch_collection, EVP_KEYEXCH, do_evp_key_exch);
+        break;
+    case 9:
+        /* not yet implemented */
+        break;
+    default:
+        r = 0;
+        goto end;
+    }
+
+end:
+    return r;
+}

--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -152,10 +152,11 @@ end:
 static int read_utf8_string(const uint8_t **buf, size_t *len, char **res)
 {
     int r;
+    size_t i;
     const uint8_t *ptr = *buf;
     int found = 0;
 
-    for (size_t i = 0; i < *len; ++i) {
+    for (i = 0; i < *len; ++i) {
         if (*ptr == 0) {
             ptr++;
             found = 1;
@@ -194,10 +195,11 @@ static int read_utf8_ptr(const uint8_t **buf, size_t *len, char **res)
 static int read_octet_string(const uint8_t **buf, size_t *len, char **res)
 {
     int r;
+    size_t i;
     const uint8_t *ptr = *buf;
     int found = 0;
 
-    for (size_t i = 0; i < *len; ++i) {
+    for (i = 0; i < *len; ++i) {
         if (*ptr == 0xFF &&
             (i + 1 < *len && *(ptr + 1) == 0xFF)) {
             ptr++;
@@ -252,13 +254,14 @@ static uint64_t UBLOCKSIZE = 8;
 static OSSL_PARAM *fuzz_params(OSSL_PARAM *param, const uint8_t **buf, size_t *len)
 {
     OSSL_PARAM *p;
+    OSSL_PARAM *fuzzed_parameters;
     int p_num = 0;
 
     for (p = param; p != NULL && p->key != NULL; p++) {
         p_num++;
     }
 
-    OSSL_PARAM *fuzzed_parameters = OPENSSL_zalloc(sizeof(OSSL_PARAM) * (p_num + 1));
+    fuzzed_parameters = OPENSSL_zalloc(sizeof(OSSL_PARAM) * (p_num + 1));
     p = fuzzed_parameters;
 
     for (; param != NULL && param->key != NULL; param++) {
@@ -573,11 +576,12 @@ end:
 #define EVP_FUZZ(source, evp, f) \
     do { \
         evp * alg = sk_##evp##_value(source, *algorithm % sk_##evp##_num(source)); \
+        OSSL_PARAM *fuzzed_params; \
         \
         if (!alg) { \
             break; \
         } \
-        OSSL_PARAM *fuzzed_params = fuzz_params((OSSL_PARAM*) evp##_settable_ctx_params(alg), &buf, &len); \
+        fuzzed_params = fuzz_params((OSSL_PARAM*) evp##_settable_ctx_params(alg), &buf, &len); \
         if (fuzzed_params) { \
             f(alg, fuzzed_params); \
         } \

--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -41,7 +41,7 @@
     } \
     static void cleanup_##name(void) \
     { \
-        sk_##evp##_free(name##_collection); \
+        sk_##evp##_pop_free(name##_collection); \
     }
 
 DEFINE_ALGORITHMS(digests, EVP_MD)
@@ -407,6 +407,8 @@ static OSSL_PARAM *fuzz_params(OSSL_PARAM *param, const uint8_t **buf, size_t *l
         default:
             break;
         }
+
+        free(use_param);
     }
 
     return fuzzed_parameters;
@@ -619,14 +621,11 @@ end:
         OSSL_PARAM_free(fuzzed_params); \
     } while (0);
 
-static uint64_t DFLT_OP = 0;
-static int64_t DFLT_ALG = 0;
-
 int FuzzerTestOneInput(const uint8_t *buf, size_t len)
 {
     int r = 1;
-    uint64_t *operation = &DFLT_OP;
-    int64_t *algorithm = &DFLT_ALG;
+    uint64_t *operation = NULL;
+    int64_t *algorithm = NULL;
 
     if (!read_uint(&buf, &len, &operation)) {
         r = 0;
@@ -680,6 +679,9 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
         r = 0;
         goto end;
     }
+
+    free(operation);
+    free(algorithm);
 
 end:
     return r;

--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -680,9 +680,8 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
         goto end;
     }
 
+end:
     free(operation);
     free(algorithm);
-
-end:
     return r;
 }

--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -236,11 +236,8 @@ static int read_octet_ptr(const uint8_t **buf, size_t *len, char **res)
 }
 
 static char *DFLT_STR = "";
-//static char *DFLT_UTF8_PTR = "";
-//static char *DFLT_OCTET_STRING = "";
-//static char *DFLT_OCTET_PTR = "";
 static char *DFLT_UTF8_PTR = NULL;
-static char *DFLT_OCTET_STRING = NULL;
+static char *DFLT_OCTET_STRING = "";
 static char *DFLT_OCTET_PTR = NULL;
 
 static int64_t ITERS = 1;

--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -41,7 +41,7 @@
     } \
     static void cleanup_##name(void) \
     { \
-        sk_##evp##_pop_free(name##_collection); \
+        sk_##evp##_pop_free(name##_collection, ##evp##_free); \
     }
 
 DEFINE_ALGORITHMS(digests, EVP_MD)

--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -158,30 +158,19 @@ end:
 static int read_utf8_string(const uint8_t **buf, size_t *len, char **res)
 {
     int r;
-    size_t i;
-    const uint8_t *ptr = *buf;
-    int found = 0;
 
-    for (i = 0; i < *len; ++i) {
-        if (*ptr == 0) {
-            ptr++;
-            found = 1;
-            break;
-        }
-        ptr++;
-    }
+    r = strnlen((const char *) *buf, *len);
 
-    if (!found) {
+    if (r == *len) {
         r = -1;
         goto end;
     }
 
+    r++;
+
     *res = (char *) *buf;
-
-    r = ptr - *buf;
     *len -= r;
-    *buf = ptr;
-
+    *buf = *buf + r + 1;
 end:
     return r;
 }
@@ -244,6 +233,9 @@ static int read_octet_ptr(const uint8_t **buf, size_t *len, char **res)
 }
 
 static char *DFLT_STR = "";
+//static char *DFLT_UTF8_PTR = "";
+//static char *DFLT_OCTET_STRING = "";
+//static char *DFLT_OCTET_PTR = "";
 static char *DFLT_UTF8_PTR = NULL;
 static char *DFLT_OCTET_STRING = NULL;
 static char *DFLT_OCTET_PTR = NULL;

--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -308,7 +308,7 @@ static OSSL_PARAM *fuzz_params(OSSL_PARAM *param, const uint8_t **buf, size_t *l
                 p_value_int = OPENSSL_malloc(sizeof(ITERS));
                 *p_value_int = ITERS;
             } else if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_R) == 0) {
-                p_value_int = malOPENSSL_mallocloc(sizeof(BLOCKSIZE));
+                p_value_int = OPENSSL_malloc(sizeof(BLOCKSIZE));
                 *p_value_int = BLOCKSIZE;
             } else if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_P) == 0) {
                 p_value_int = OPENSSL_malloc(sizeof(BLOCKSIZE));

--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -302,28 +302,22 @@ static OSSL_PARAM *fuzz_params(OSSL_PARAM *param, const uint8_t **buf, size_t *l
 
         switch (param->data_type) {
         case OSSL_PARAM_INTEGER:
-            if (*use_param && !read_int(buf, len, &p_value_int)) {
-                /* use default */
-            }
-
             if (strcmp(param->key, OSSL_KDF_PARAM_ITER) == 0) {
                 p_value_int = malloc(sizeof(ITERS));
                 *p_value_int = ITERS;
-            }
-
-            if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_N) == 0) {
+            } else if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_N) == 0) {
                 p_value_int = malloc(sizeof(ITERS));
                 *p_value_int = ITERS;
-            }
-
-            if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_R) == 0) {
+            } else if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_R) == 0) {
                 p_value_int = malloc(sizeof(BLOCKSIZE));
                 *p_value_int = BLOCKSIZE;
-            }
-
-            if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_P) == 0) {
+            } else if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_P) == 0) {
                 p_value_int = malloc(sizeof(BLOCKSIZE));
                 *p_value_int = BLOCKSIZE;
+            } else {
+                if (*use_param && !read_int(buf, len, &p_value_int)) {
+                    /* use default */
+                }
             }
 
             *p = *param;
@@ -331,29 +325,22 @@ static OSSL_PARAM *fuzz_params(OSSL_PARAM *param, const uint8_t **buf, size_t *l
             p++;
             break;
         case OSSL_PARAM_UNSIGNED_INTEGER:
-            if (*use_param && !read_uint(buf, len, &p_value_uint)) {
-                /* use default */
-            }
-
             if (strcmp(param->key, OSSL_KDF_PARAM_ITER) == 0) {
                 p_value_uint = malloc(sizeof(UITERS));
                 *p_value_uint = UITERS;
-                
-            }
-
-            if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_N) == 0) {
+            } else if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_N) == 0) {
                 p_value_uint = malloc(sizeof(UITERS));
                 *p_value_uint = UITERS;
-            }
-
-            if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_R) == 0) {
+            } else if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_R) == 0) {
                 p_value_uint = malloc(sizeof(UBLOCKSIZE));
                 *p_value_uint = UBLOCKSIZE;
-            }
-
-            if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_P) == 0) {
+            } else if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_P) == 0) {
                 p_value_uint = malloc(sizeof(UBLOCKSIZE));
                 *p_value_uint = UBLOCKSIZE;
+            } else {
+                if (*use_param && !read_uint(buf, len, &p_value_uint)) {
+                    /* use default */
+                }
             }
 
             *p = *param;

--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -157,20 +157,23 @@ end:
 
 static int read_utf8_string(const uint8_t **buf, size_t *len, char **res)
 {
+    size_t found_len;
     int r;
 
-    r = strnlen((const char *) *buf, *len);
+    found_len = strnlen((const char *) *buf, *len);
 
-    if (r == *len) {
+    if (found_len == *len) {
         r = -1;
         goto end;
     }
 
-    r++;
+    found_len++; // skip over the \0 byte
+
+    r = (int) found_len;
 
     *res = (char *) *buf;
-    *len -= r;
-    *buf = *buf + r + 1;
+    *len -= found_len;
+    *buf = *buf + found_len; // continue after the \0 byte
 end:
     return r;
 }

--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -167,13 +167,13 @@ static int read_utf8_string(const uint8_t **buf, size_t *len, char **res)
         goto end;
     }
 
-    found_len++; // skip over the \0 byte
+    found_len++; /* skip over the \0 byte */
 
     r = (int) found_len;
 
     *res = (char *) *buf;
     *len -= found_len;
-    *buf = *buf + found_len; // continue after the \0 byte
+    *buf = *buf + found_len; /* continue after the \0 byte */
 end:
     return r;
 }

--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -41,7 +41,7 @@
     } \
     static void cleanup_##name(void) \
     { \
-        sk_##evp##_pop_free(name##_collection, ##evp##_free); \
+        sk_##evp##_pop_free(name##_collection, evp##_free); \
     }
 
 DEFINE_ALGORITHMS(digests, EVP_MD)

--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -275,9 +275,8 @@ static OSSL_PARAM *fuzz_params(OSSL_PARAM *param, const uint8_t **buf, size_t *l
     OSSL_PARAM *fuzzed_parameters;
     int p_num = 0;
 
-    for (p = param; p != NULL && p->key != NULL; p++) {
+    for (p = param; p != NULL && p->key != NULL; p++)
         p_num++;
-    }
 
     fuzzed_parameters = OPENSSL_zalloc(sizeof(OSSL_PARAM) *(p_num + 1));
     p = fuzzed_parameters;
@@ -345,8 +344,9 @@ static OSSL_PARAM *fuzz_params(OSSL_PARAM *param, const uint8_t **buf, size_t *l
             p++;
             break;
         case OSSL_PARAM_REAL:
-            if (*use_param && !read_double(buf, len, &p_value_double)) {
-                /* use default */
+            if (!*use_param || !read_double(buf, len, &p_value_double)) {
+                p_value_double = OPENSSL_malloc(sizeof(double));
+                *p_value_double = 0;
             }
 
             *p = *param;
@@ -354,36 +354,32 @@ static OSSL_PARAM *fuzz_params(OSSL_PARAM *param, const uint8_t **buf, size_t *l
             p++;
             break;
         case OSSL_PARAM_UTF8_STRING:
-            if (*use_param && (data_len = read_utf8_string(buf, len, &p_value_utf8_str)) < 0) {
+            if (*use_param && (data_len = read_utf8_string(buf, len, &p_value_utf8_str)) < 0)
                 data_len = 0;
-            }
             *p = *param;
             p->data = p_value_utf8_str;
             p->data_size = data_len;
             p++;
             break;
         case OSSL_PARAM_OCTET_STRING:
-            if (*use_param && (data_len = read_octet_string(buf, len, &p_value_octet_str)) < 0) {
+            if (*use_param && (data_len = read_octet_string(buf, len, &p_value_octet_str)) < 0)
                 data_len = 0;
-            }
             *p = *param;
             p->data = p_value_octet_str;
             p->data_size = data_len;
             p++;
             break;
         case OSSL_PARAM_UTF8_PTR:
-            if (*use_param && (data_len = read_utf8_ptr(buf, len, &p_value_utf8_ptr)) < 0) {
+            if (*use_param && (data_len = read_utf8_ptr(buf, len, &p_value_utf8_ptr)) < 0)
                 data_len = 0;
-            }
             *p = *param;
             p->data = p_value_utf8_ptr;
             p->data_size = data_len;
             p++;
             break;
         case OSSL_PARAM_OCTET_PTR:
-            if (*use_param && (data_len = read_octet_ptr(buf, len, &p_value_octet_ptr)) < 0) {
+            if (*use_param && (data_len = read_octet_ptr(buf, len, &p_value_octet_ptr)) < 0)
                 data_len = 0;
-            }
             *p = *param;
             p->data = p_value_octet_ptr;
             p->data_size = data_len;
@@ -595,13 +591,11 @@ end:
         evp *alg = sk_##evp##_value(source, *algorithm % sk_##evp##_num(source)); \
         OSSL_PARAM *fuzzed_params; \
         \
-        if (alg == NULL) { \
+        if (alg == NULL) \
             break; \
-        } \
         fuzzed_params = fuzz_params((OSSL_PARAM*) evp##_settable_ctx_params(alg), &buf, &len); \
-        if (fuzzed_params != NULL) { \
+        if (fuzzed_params != NULL) \
             f(alg, fuzzed_params); \
-        } \
         free_params(fuzzed_params); \
         OSSL_PARAM_free(fuzzed_params); \
     } while (0);

--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -313,10 +313,9 @@ static OSSL_PARAM *fuzz_params(OSSL_PARAM *param, const uint8_t **buf, size_t *l
             } else if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_P) == 0) {
                 p_value_int = OPENSSL_malloc(sizeof(BLOCKSIZE));
                 *p_value_int = BLOCKSIZE;
-            } else {
-                if (*use_param && !read_int(buf, len, &p_value_int)) {
-                    /* use default */
-                }
+            } else if (!*use_param || !read_int(buf, len, &p_value_int)) {
+                p_value_int = OPENSSL_malloc(sizeof(int64_t));
+                *p_value_int = 0;
             }
 
             *p = *param;
@@ -336,10 +335,9 @@ static OSSL_PARAM *fuzz_params(OSSL_PARAM *param, const uint8_t **buf, size_t *l
             } else if (strcmp(param->key, OSSL_KDF_PARAM_SCRYPT_P) == 0) {
                 p_value_uint = OPENSSL_malloc(sizeof(UBLOCKSIZE));
                 *p_value_uint = UBLOCKSIZE;
-            } else {
-                if (*use_param && !read_uint(buf, len, &p_value_uint)) {
-                    /* use default */
-                }
+            } else if (!*use_param || !read_uint(buf, len, &p_value_uint)) {
+                p_value_uint = OPENSSL_malloc(sizeof(uint64_t));
+                *p_value_uint = 0;
             }
 
             *p = *param;
@@ -350,6 +348,7 @@ static OSSL_PARAM *fuzz_params(OSSL_PARAM *param, const uint8_t **buf, size_t *l
             if (*use_param && !read_double(buf, len, &p_value_double)) {
                 /* use default */
             }
+
             *p = *param;
             p->data = p_value_double;
             p++;

--- a/test/recipes/99-test_fuzz_provider.t
+++ b/test/recipes/99-test_fuzz_provider.t
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+# Copyright 2016-2023 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+use OpenSSL::Test::Utils;
+
+my $fuzzer = "provider";
+setup("test_fuzz_${fuzzer}");
+
+plan tests => 2; # one more due to below require_ok(...)
+
+require_ok(srctop_file('test','recipes','fuzz.pl'));
+
+fuzz_ok($fuzzer);


### PR DESCRIPTION
This PR adds a new fuzzer that can instantiate various types of cryptographic objects like ciphers, hashes, and KDFs, etc.

If initializes them with random data derived. A dictionary should be used when fuzzing: 

```
grep -o '".*"' include/openssl/core_names.h > dictionary.txt
```

The `dictionary.txt` can be used as input to libfuzzer e.g. with the `-dict=dictionary.txt` flag.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
