### PR TITLE
ossl-params: check length returned by strlen()

### DIFF
--- a/crypto/param_build.c
+++ b/crypto/param_build.c
@@ -255,9 +255,9 @@ int OSSL_PARAM_BLD_push_utf8_string(OSSL_PARAM_BLD *bld, const char *key,
     OSSL_PARAM_BLD_DEF *pd;
     int secure;
 
-    if (bsize == 0) {
+    if (bsize == 0)
         bsize = strlen(buf);
-    } else if (bsize > INT_MAX) {
+    if (bsize > INT_MAX) {
         ERR_raise(ERR_LIB_CRYPTO, CRYPTO_R_STRING_TOO_LONG);
         return 0;
     }
@@ -274,9 +274,9 @@ int OSSL_PARAM_BLD_push_utf8_ptr(OSSL_PARAM_BLD *bld, const char *key,
 {
     OSSL_PARAM_BLD_DEF *pd;
 
-    if (bsize == 0) {
+    if (bsize == 0)
         bsize = strlen(buf);
-    } else if (bsize > INT_MAX) {
+    if (bsize > INT_MAX) {
         ERR_raise(ERR_LIB_CRYPTO, CRYPTO_R_STRING_TOO_LONG);
         return 0;
     }


### PR DESCRIPTION
In `push_utf8_string()` and `push_utf8_ptr()`, when `bsize` is zero, we use `strlen()` to compute the length of the string.  However, the size_t returned by `strlen()` might be too large, so check for that.

Credit to Viktor D and Tomas M for spotting these missing checks.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
