### PR TITLE
remove duplicated typedef for u64

### DIFF
--- a/crypto/aes/aes_x86core.c
+++ b/crypto/aes/aes_x86core.c
@@ -81,13 +81,10 @@ static void prefetch256(const void *table)
 #define GETU32(p) (*((u32*)(p)))
 
 #if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)
-typedef unsigned __int64 u64;
 #define U64(C)  C##UI64
 #elif defined(__arch64__)
-typedef unsigned long u64;
 #define U64(C)  C##UL
 #else
-typedef unsigned long long u64;
 #define U64(C)  C##ULL
 #endif
 


### PR DESCRIPTION
This typedef is already created in aes_local.h as `typedef uint64_t u64;`.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
