### PR TITLE
Enable BTI feature for md5 on aarch64

### DIFF
--- a/crypto/md5/asm/md5-aarch64.pl
+++ b/crypto/md5/asm/md5-aarch64.pl
@@ -28,10 +28,13 @@ open OUT,"| \"$^X\" $xlate $flavour \"$output\""
 *STDOUT=*OUT;
 
 $code .= <<EOF;
+#include "arm_arch.h"
+
 .text
 .globl  ossl_md5_block_asm_data_order
 .type   ossl_md5_block_asm_data_order,\@function
 ossl_md5_block_asm_data_order:
+        AARCH64_VALID_CALL_TARGET
         // Save all callee-saved registers
         stp     x19,x20,[sp,#-80]!
         stp     x21,x22,[sp,#16]


### PR DESCRIPTION
This PR is to enable BTI feature for md5-aarch64.pl. It can fix #22959. 