### PR TITLE
doc: fix list display in man page

### DIFF
--- a/doc/man3/OSSL_PARAM_int.pod
+++ b/doc/man3/OSSL_PARAM_int.pod
@@ -112,7 +112,7 @@ OSSL_PARAM_UNMODIFIED, OSSL_PARAM_modified, OSSL_PARAM_set_all_unmodified
 A collection of utility functions that simplify and add type safety to the
 L<OSSL_PARAM(3)> arrays.  The following B<I<TYPE>> names are supported:
 
-=over 1
+=over 2
 
 =item *
 


### PR DESCRIPTION
`=over 1` is too small (see the screenshot below).

Use `=over 2` so that list items are displayed correctly in the generated man-page.

You can check the man-page using the following command:

```bash
cd doc && pod2man man3/OSSL_PARAM_int.pod | man /dev/stdin
```

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x ] documentation is added or updated
- [ ] tests are added or updated

![list-format-20231207_102208](https://github.com/openssl/openssl/assets/5332385/255e134e-794d-4c53-89d0-987f2d90808a)
