### PR TITLE
Fix integer overflow in ossl_asn1_time_from_tm

### DIFF
--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -295,16 +295,23 @@ ASN1_TIME *ossl_asn1_time_from_tm(ASN1_TIME *s, struct tm *ts, int type)
     tmps->type = type;
     p = (char*)tmps->data;
 
-    if (type == V_ASN1_GENERALIZEDTIME)
+    if (ts->tm_mon > INT_MAX - 1) {
+        goto err;
+    }
+    if (type == V_ASN1_GENERALIZEDTIME) {
+        if (ts->tm_year > INT_MAX - 1900) {
+            goto err;
+        }
         tmps->length = BIO_snprintf(p, len, "%04d%02d%02d%02d%02d%02dZ",
                                     ts->tm_year + 1900, ts->tm_mon + 1,
                                     ts->tm_mday, ts->tm_hour, ts->tm_min,
                                     ts->tm_sec);
-    else
+    } else {
         tmps->length = BIO_snprintf(p, len, "%02d%02d%02d%02d%02d%02dZ",
                                     ts->tm_year % 100, ts->tm_mon + 1,
                                     ts->tm_mday, ts->tm_hour, ts->tm_min,
                                     ts->tm_sec);
+    }
 
 #ifdef CHARSET_EBCDIC
     ebcdic2ascii(tmps->data, tmps->data, tmps->length);

--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -295,13 +295,12 @@ ASN1_TIME *ossl_asn1_time_from_tm(ASN1_TIME *s, struct tm *ts, int type)
     tmps->type = type;
     p = (char*)tmps->data;
 
-    if (ts->tm_mon > INT_MAX - 1) {
+    if (ts->tm_mon > INT_MAX - 1)
         goto err;
-    }
+
     if (type == V_ASN1_GENERALIZEDTIME) {
-        if (ts->tm_year > INT_MAX - 1900) {
+        if (ts->tm_year > INT_MAX - 1900)
             goto err;
-        }
         tmps->length = BIO_snprintf(p, len, "%04d%02d%02d%02d%02d%02dZ",
                                     ts->tm_year + 1900, ts->tm_mon + 1,
                                     ts->tm_mday, ts->tm_hour, ts->tm_min,

--- a/test/asn1_time_test.c
+++ b/test/asn1_time_test.c
@@ -443,6 +443,24 @@ static int convert_asn1_to_time_t(int idx)
     return 1;
 }
 
+/*
+ * this test is here to exercise ossl_asn1_time_from_tm
+ * with an integer year close to INT_MAX.
+ */
+static int convert_tm_to_asn1_time()
+{
+  /* we need 64 bit time_t */
+#if ( (ULONG_MAX >> 31) >> 31 ) >= 1
+    TEST_int_ge(sizeof(time_t) * CHAR_BIT, 64);
+    time_t t = 67768011791126057ULL;
+    ASN1_TIME* at = ASN1_TIME_set(NULL, t);
+    if (at != NULL) {
+      ASN1_STRING_free(at);
+    }
+#endif
+    return 1;
+}
+
 int setup_tests(void)
 {
     /*
@@ -479,5 +497,6 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_table_compare, OSSL_NELEM(tbl_compare_testdata));
     ADD_TEST(test_time_dup);
     ADD_ALL_TESTS(convert_asn1_to_time_t, OSSL_NELEM(asn1_to_utc));
+    ADD_TEST(convert_tm_to_asn1_time);
     return 1;
 }

--- a/test/asn1_time_test.c
+++ b/test/asn1_time_test.c
@@ -447,7 +447,7 @@ static int convert_asn1_to_time_t(int idx)
  * this test is here to exercise ossl_asn1_time_from_tm
  * with an integer year close to INT_MAX.
  */
-static int convert_tm_to_asn1_time()
+static int convert_tm_to_asn1_time(void)
 {
   /* we need 64 bit time_t */
 #if ( (ULONG_MAX >> 31) >> 31 ) >= 1

--- a/test/asn1_time_test.c
+++ b/test/asn1_time_test.c
@@ -451,10 +451,10 @@ static int convert_tm_to_asn1_time(void)
 {
   /* we need 64 bit time_t */
 #if ( (ULONG_MAX >> 31) >> 31 ) >= 1
-    TEST_int_ge(sizeof(time_t) * CHAR_BIT, 64);
     time_t t;
     ASN1_TIME* at;
 
+    TEST_int_ge(sizeof(time_t) * CHAR_BIT, 64);
     t = 67768011791126057ULL;
     at = ASN1_TIME_set(NULL, t);
     if (at != NULL)

--- a/test/asn1_time_test.c
+++ b/test/asn1_time_test.c
@@ -9,6 +9,7 @@
 
 /* Time tests for the asn1 module */
 
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -449,16 +450,20 @@ static int convert_asn1_to_time_t(int idx)
  */
 static int convert_tm_to_asn1_time(void)
 {
-  /* we need 64 bit time_t */
-#if ( (ULONG_MAX >> 31) >> 31 ) >= 1
+    /* we need 64 bit time_t */
+#if ((ULONG_MAX >> 31) >> 31) >= 1
     time_t t;
-    ASN1_TIME* at;
+    ASN1_TIME *at;
 
-    TEST_int_ge(sizeof(time_t) * CHAR_BIT, 64);
-    t = 67768011791126057ULL;
-    at = ASN1_TIME_set(NULL, t);
-    if (at != NULL)
-      ASN1_STRING_free(at);
+    if (sizeof(time_t) * CHAR_BIT >= 64) {
+        t = 67768011791126057ULL;
+        at = ASN1_TIME_set(NULL, t);
+        /*
+         * If ASN1_TIME_set returns NULL, it means it could not handle the input
+         * which is fine for this edge case.
+         */
+        ASN1_STRING_free(at);
+    }
 #endif
     return 1;
 }

--- a/test/asn1_time_test.c
+++ b/test/asn1_time_test.c
@@ -452,11 +452,13 @@ static int convert_tm_to_asn1_time(void)
   /* we need 64 bit time_t */
 #if ( (ULONG_MAX >> 31) >> 31 ) >= 1
     TEST_int_ge(sizeof(time_t) * CHAR_BIT, 64);
-    time_t t = 67768011791126057ULL;
-    ASN1_TIME* at = ASN1_TIME_set(NULL, t);
-    if (at != NULL) {
+    time_t t;
+    ASN1_TIME* at;
+
+    t = 67768011791126057ULL;
+    at = ASN1_TIME_set(NULL, t);
+    if (at != NULL)
       ASN1_STRING_free(at);
-    }
 #endif
     return 1;
 }


### PR DESCRIPTION
This adds overflow checks inside ossl_asn1_time_from_tm to
prevent an integer overflow.

The problem can be triggered on systems with >=64 bit time_t and 32 bit int using
the following code:

```c
#include <time.h>
#include <openssl/asn1.h>
int main() {
  time_t t = 67768011791126057ULL;
  ASN1_TIME* at = ASN1_TIME_set(NULL, t);
}
```

A test is added, I  was not sure about how to portably check that for time_t being 64 bit. If building openssl
with ubsan, the test outputs the following warning:

> crypto/asn1/a_time.c:299:24: runtime error: signed integer overflow: 2147482874 + 1900 cannot be represented in type 'int'

I was also unsure if you prefer the test to be added before the fix, or vice versa. 

I have a CLA [since 2021](https://github.com/openssl/openssl/pull/10541#issuecomment-905243301).

##### Checklist
- [X] tests are added or updated