### PR TITLE
Check whether the pubkey exists in ossl_ecx_key_dup

### DIFF
--- a/crypto/ec/ecx_backend.c
+++ b/crypto/ec/ecx_backend.c
@@ -114,7 +114,7 @@ ECX_KEY *ossl_ecx_key_dup(const ECX_KEY *key, int selection)
         return NULL;
 
     ret->libctx = key->libctx;
-    ret->haspubkey = key->haspubkey;
+    ret->haspubkey = 0;
     ret->keylen = key->keylen;
     ret->type = key->type;
 
@@ -127,8 +127,11 @@ ECX_KEY *ossl_ecx_key_dup(const ECX_KEY *key, int selection)
             goto err;
     }
 
-    if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0)
+    if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0
+        && key->haspubkey == 1) {
         memcpy(ret->pubkey, key->pubkey, sizeof(ret->pubkey));
+        ret->haspubkey = 1;
+    }
 
     if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0
         && key->privkey != NULL) {

--- a/test/evp_pkey_provided_test.c
+++ b/test/evp_pkey_provided_test.c
@@ -1131,6 +1131,12 @@ static int test_fromdata_ecx(int tst)
                /* This should succeed because there are no parameters to copy */
             || !TEST_true(EVP_PKEY_copy_parameters(copy_pk, pk)))
             goto err;
+        if (!TEST_ptr(ctx2 = EVP_PKEY_CTX_new_from_pkey(NULL, copy_pk, NULL))
+               /* This should fail because copy_pk has no pubkey */
+            || !TEST_int_le(EVP_PKEY_public_check(ctx2), 0))
+            goto err;
+        EVP_PKEY_CTX_free(ctx2);
+        ctx2 = NULL;
         EVP_PKEY_free(copy_pk);
         copy_pk = NULL;
 


### PR DESCRIPTION
Sometimes we don't want to copy the pubkey, but haspubkey may be set to 1 in ossl_ecx_key_dup function, such as call the EVP_PKEY_copy_parameters function.
