### PR TITLE
Handle tls and dtls server version selection similarly

### DIFF
--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1734,16 +1734,9 @@ static int tls_early_post_process_client_hello(SSL_CONNECTION *s)
         /* SSLv3/TLS */
         s->client_version = clienthello->legacy_version;
     }
-    /*
-     * Do SSL/TLS version negotiation if applicable.
-     */
-    if (SSL_CONNECTION_IS_DTLS(s)
-            && ssl->method->version != DTLS_ANY_VERSION
-            && DTLS_VERSION_LT((int)clienthello->legacy_version, s->version)) {
-        protverr = SSL_R_VERSION_TOO_LOW;
-    } else {
-        protverr = ssl_choose_server_version(s, clienthello, &dgrd);
-    }
+
+    /* Choose the server SSL/TLS/DTLS version. */
+    protverr = ssl_choose_server_version(s, clienthello, &dgrd);
 
     if (protverr) {
         if (SSL_IS_FIRST_HANDSHAKE(s)) {

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1735,16 +1735,14 @@ static int tls_early_post_process_client_hello(SSL_CONNECTION *s)
         s->client_version = clienthello->legacy_version;
     }
     /*
-     * Do SSL/TLS version negotiation if applicable. For DTLS we just check
-     * versions are potentially compatible. Version negotiation comes later.
+     * Do SSL/TLS version negotiation if applicable.
      */
-    if (!SSL_CONNECTION_IS_DTLS(s)) {
-        protverr = ssl_choose_server_version(s, clienthello, &dgrd);
-    } else if (ssl->method->version != DTLS_ANY_VERSION &&
-               DTLS_VERSION_LT((int)clienthello->legacy_version, s->version)) {
+    if (SSL_CONNECTION_IS_DTLS(s)
+            && ssl->method->version != DTLS_ANY_VERSION
+            && DTLS_VERSION_LT((int)clienthello->legacy_version, s->version)) {
         protverr = SSL_R_VERSION_TOO_LOW;
     } else {
-        protverr = 0;
+        protverr = ssl_choose_server_version(s, clienthello, &dgrd);
     }
 
     if (protverr) {
@@ -1782,14 +1780,6 @@ static int tls_early_post_process_client_hello(SSL_CONNECTION *s)
                 goto err;
             }
             s->d1->cookie_verified = 1;
-        }
-        if (ssl->method->version == DTLS_ANY_VERSION) {
-            protverr = ssl_choose_server_version(s, clienthello, &dgrd);
-            if (protverr != 0) {
-                s->version = s->client_version;
-                SSLfatal(s, SSL_AD_PROTOCOL_VERSION, protverr);
-                goto err;
-            }
         }
     }
 


### PR DESCRIPTION
The motivation is to do the subsequent TLS 1.3 check for DTLS 1.3 as well, but I think the fix could be applied directly to master