### PR TITLE
Fix a possible memory leak in ossl_x509_algor_md_to_mgf1

### DIFF
--- a/crypto/asn1/x_algor.c
+++ b/crypto/asn1/x_algor.c
@@ -179,7 +179,11 @@ int ossl_x509_algor_md_to_mgf1(X509_ALGOR **palg, const EVP_MD *mgf1md)
     *palg = X509_ALGOR_new();
     if (*palg == NULL)
         goto err;
-    X509_ALGOR_set0(*palg, OBJ_nid2obj(NID_mgf1), V_ASN1_SEQUENCE, stmp);
+    if (!X509_ALGOR_set0(*palg, OBJ_nid2obj(NID_mgf1), V_ASN1_SEQUENCE, stmp)) {
+        X509_ALGOR_free(*palg);
+        *palg = NULL;
+        goto err;
+    }
     stmp = NULL;
  err:
     ASN1_STRING_free(stmp);


### PR DESCRIPTION
Add a missing check of the return code of X509_ALGOR_set0. otherwise a memory leak may occur.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
