### PR TITLE
Fix EVP_CIPHER_CTX_get_block_size() calls to check for -1.

### DIFF
--- a/crypto/cms/cms_pwri.c
+++ b/crypto/cms/cms_pwri.c
@@ -201,14 +201,15 @@ static int kek_unwrap_key(unsigned char *out, size_t *outlen,
                           const unsigned char *in, size_t inlen,
                           EVP_CIPHER_CTX *ctx)
 {
-    size_t blocklen = EVP_CIPHER_CTX_get_block_size(ctx);
+    int blocksz = EVP_CIPHER_CTX_get_block_size(ctx);
+    size_t blocklen = blocksz;
     unsigned char *tmp;
     int outl, rv = 0;
     if (inlen < 2 * blocklen) {
         /* too small */
         return 0;
     }
-    if (inlen % blocklen) {
+    if (blocksz <= 0 || inlen % blocklen) {
         /* Invalid size */
         return 0;
     }
@@ -254,9 +255,14 @@ static int kek_wrap_key(unsigned char *out, size_t *outlen,
                         const unsigned char *in, size_t inlen,
                         EVP_CIPHER_CTX *ctx, const CMS_CTX *cms_ctx)
 {
-    size_t blocklen = EVP_CIPHER_CTX_get_block_size(ctx);
+    int blocksz = EVP_CIPHER_CTX_get_block_size(ctx);
+    size_t blocklen;
     size_t olen;
     int dummy;
+
+    if (blocksz <= 0)
+        return 0;
+    blocklen = blocksz;
     /*
      * First decide length of output buffer: need header and round up to
      * multiple of block length.

--- a/crypto/evp/bio_enc.c
+++ b/crypto/evp/bio_enc.c
@@ -132,6 +132,8 @@ static int enc_read(BIO *b, char *out, int outl)
     }
 
     blocksize = EVP_CIPHER_CTX_get_block_size(ctx->cipher);
+    if (blocksize < 0)
+        return 0;
     if (blocksize == 1)
         blocksize = 0;
 

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -415,7 +415,7 @@ int EVP_Cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         size_t outl = 0;
         int blocksize = EVP_CIPHER_CTX_get_block_size(ctx);
 
-        if (blocksize < 0)
+        if (blocksize <= 0)
             return 0;
         if (ctx->cipher->ccipher != NULL)
             ret =  ctx->cipher->ccipher(ctx->algctx, out, &outl,

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -413,8 +413,10 @@ int EVP_Cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
          */
         int ret = -1;
         size_t outl = 0;
-        size_t blocksize = EVP_CIPHER_CTX_get_block_size(ctx);
+        int blocksize = EVP_CIPHER_CTX_get_block_size(ctx);
 
+        if (blocksize < 0)
+            return 0;
         if (ctx->cipher->ccipher != NULL)
             ret =  ctx->cipher->ccipher(ctx->algctx, out, &outl,
                                         inl + (blocksize == 1 ? 0 : blocksize),

--- a/include/internal/recordmethod.h
+++ b/include/internal/recordmethod.h
@@ -306,7 +306,7 @@ struct ossl_record_method_st {
 
     /*
      * The maximum expansion in bytes that the record layer might add while
-     * writing a record
+     * writing a record. A return value of zero indicates an error.
      */
     size_t (*get_max_record_overhead)(OSSL_RECORD_LAYER *rl);
 

--- a/providers/implementations/kdfs/krb5kdf.c
+++ b/providers/implementations/kdfs/krb5kdf.c
@@ -387,7 +387,7 @@ static int KRB5KDF(const EVP_CIPHER *cipher, ENGINE *engine,
 #ifndef OPENSSL_NO_DES
     int des3_no_fixup = 0;
 #endif
-    int ret;
+    int ret = 0, blksz;
 
     if (key_len != okey_len) {
 #ifndef OPENSSL_NO_DES
@@ -409,16 +409,17 @@ static int KRB5KDF(const EVP_CIPHER *cipher, ENGINE *engine,
     if (ctx == NULL)
         return 0;
 
-    ret = cipher_init(ctx, cipher, engine, key, key_len);
-    if (!ret)
+    if (!cipher_init(ctx, cipher, engine, key, key_len))
+        goto out;
+
+    blksz = EVP_CIPHER_CTX_get_block_size(ctx);
+    if (blksz < 0)
         goto out;
 
     /* Initialize input block */
-    blocksize = EVP_CIPHER_CTX_get_block_size(ctx);
-
+    blocksize = blksz;
     if (constant_len > blocksize) {
         ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_CONSTANT_LENGTH);
-        ret = 0;
         goto out;
     }
 

--- a/providers/implementations/macs/cmac_prov.c
+++ b/providers/implementations/macs/cmac_prov.c
@@ -111,12 +111,12 @@ static int cmac_setkey(struct cmac_data_st *macctx,
 static int cmac_setsize(CMAC_CTX *cmacctx, OSSL_PARAM *p)
 {
     EVP_CIPHER_CTX *ctx = CMAC_CTX_get0_cipher_ctx(cmacctx);
-    int sz = -1;
+    int sz = 0;
 
-    if (ctx != NULL)
+    if (ctx != NULL && EVP_CIPHER_CTX_get0_cipher(ctx) != NULL)
         sz = EVP_CIPHER_CTX_get_block_size(ctx);
-    return sz > 0
-           && OSSL_PARAM_set_size_t(p, sz);
+
+    return OSSL_PARAM_set_size_t(p, sz >= 0 ? sz : 0);
 }
 
 static int cmac_init(void *vmacctx, const unsigned char *key,

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -742,14 +742,15 @@ int dtls_post_encryption_processing(OSSL_RECORD_LAYER *rl,
 
 static size_t dtls_get_max_record_overhead(OSSL_RECORD_LAYER *rl)
 {
-    int blksz = 0;
     size_t blocksize = 0;
 
     if (rl->enc_ctx != NULL &&
         (EVP_CIPHER_CTX_get_mode(rl->enc_ctx) == EVP_CIPH_CBC_MODE)) {
-        blksz = EVP_CIPHER_CTX_get_block_size(rl->enc_ctx);
-        assert(blksz >= 0);
-        blocksize = (blksz >= 0 ? blksz : 0);
+        int blksz = EVP_CIPHER_CTX_get_block_size(rl->enc_ctx);
+
+        if (blksz <= 0)
+            return 0;   /* Error */
+        blocksize = blksz;
     }
 
     /*

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -742,11 +742,15 @@ int dtls_post_encryption_processing(OSSL_RECORD_LAYER *rl,
 
 static size_t dtls_get_max_record_overhead(OSSL_RECORD_LAYER *rl)
 {
+    int blksz = 0;
     size_t blocksize = 0;
 
     if (rl->enc_ctx != NULL &&
-        (EVP_CIPHER_CTX_get_mode(rl->enc_ctx) == EVP_CIPH_CBC_MODE))
-        blocksize = EVP_CIPHER_CTX_get_block_size(rl->enc_ctx);
+        (EVP_CIPHER_CTX_get_mode(rl->enc_ctx) == EVP_CIPH_CBC_MODE)) {
+        blksz = EVP_CIPHER_CTX_get_block_size(rl->enc_ctx);
+        assert(blksz >= 0);
+        blocksize = (blksz >= 0 ? blksz : 0);
+    }
 
     /*
      * If we have a cipher in place then the tag is mandatory. If the cipher is

--- a/ssl/record/methods/ssl3_meth.c
+++ b/ssl/record/methods/ssl3_meth.c
@@ -98,6 +98,7 @@ static int ssl3_cipher(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *inrecs,
     size_t bs;
     const EVP_CIPHER *enc;
     int provided;
+    int blocksz;
 
     rec = inrecs;
     /*
@@ -113,7 +114,10 @@ static int ssl3_cipher(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *inrecs,
     provided = (EVP_CIPHER_get0_provider(enc) != NULL);
 
     l = rec->length;
-    bs = EVP_CIPHER_CTX_get_block_size(ds);
+    blocksz = EVP_CIPHER_CTX_get_block_size(ds);
+    if (blocksz <= 0)
+        return 0;
+    bs = blocksz;
 
     /* COMPRESS */
 

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -127,6 +127,8 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
     }
 
     overhead = s->rlayer.wrlmethod->get_max_record_overhead(s->rlayer.wrl);
+    if (overhead == 0)
+        return -1;
 
     frag_off = 0;
     s->rwstate = SSL_NOTHING;

--- a/test/build.info
+++ b/test/build.info
@@ -1079,6 +1079,12 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[provider_pkey_test]=../include ../apps/include
   DEPEND[provider_pkey_test]=../libcrypto libtestutil.a
 
+  PROGRAMS{noinst}=provider_cipher_test
+  SOURCE[provider_cipher_test]=provider_cipher_test.c fake_cipherprov.c
+  INCLUDE[provider_cipher_test]=../include ../apps/include \
+                                ../providers/implementations/include
+  DEPEND[provider_cipher_test]=../libcrypto.a libtestutil.a
+
   PROGRAMS{noinst}=provider_default_search_path_test
   SOURCE[provider_default_search_path_test]=provider_default_search_path_test.c
   INCLUDE[provider_default_search_path_test]=../include ../apps/include

--- a/test/fake_cipherprov.c
+++ b/test/fake_cipherprov.c
@@ -213,7 +213,6 @@ static const OSSL_DISPATCH fake_good_cipher_functions[] = {
     OSSL_DISPATCH_END
 };
 
-
 static const OSSL_ALGORITHM fake_cipher_algs[] = {
     { "Good", "provider=fake-cipher", fake_good_cipher_functions, "Fake Cipher" },
     { "Bad", "provider=fake-cipher", fake_bad_cipher_functions, "Fake Cipher" },

--- a/test/fake_cipherprov.c
+++ b/test/fake_cipherprov.c
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.openssl.org/source/license.html
+ * or in the file LICENSE in the source distribution.
+ */
+
+#include <string.h>
+#include <openssl/core_names.h>
+#include <openssl/core_object.h>
+#include <openssl/rand.h>
+#include <openssl/provider.h>
+#include "prov/ciphercommon.h"
+#include "testutil.h"
+#include "fake_cipherprov.h"
+
+typedef struct prov_fake_cipher_ctx_st {
+    int enc;
+    size_t tlsmacsize;
+    const unsigned char *tlsmac;
+} PROV_FAKE_CIPHER_CTX;
+
+static OSSL_FUNC_cipher_newctx_fn fake_cipher_newctx;
+static OSSL_FUNC_cipher_freectx_fn fake_cipher_freectx;
+static OSSL_FUNC_cipher_encrypt_init_fn fake_cipher_einit;
+static OSSL_FUNC_cipher_decrypt_init_fn fake_cipher_dinit;
+static OSSL_FUNC_cipher_cipher_fn fake_cipher_cipher;
+static OSSL_FUNC_cipher_final_fn fake_cipher_final;
+static OSSL_FUNC_cipher_get_params_fn fake_cipher_get_params;
+static OSSL_FUNC_cipher_get_params_fn fake_cipher_bad_get_params;
+static OSSL_FUNC_cipher_gettable_ctx_params_fn fake_cipher_gettable_ctx_params;
+static OSSL_FUNC_cipher_settable_ctx_params_fn fake_cipher_settable_ctx_params;
+static OSSL_FUNC_cipher_set_ctx_params_fn fake_cipher_set_ctx_params;
+static OSSL_FUNC_cipher_get_ctx_params_fn fake_cipher_get_ctx_params;
+
+static void *fake_cipher_newctx(void *provctx)
+{
+    return OPENSSL_zalloc(sizeof(PROV_FAKE_CIPHER_CTX));
+}
+
+static void fake_cipher_freectx(void *vctx)
+{
+    OPENSSL_free(vctx);
+}
+
+static int fake_cipher_einit(void *vctx, const unsigned char *key, size_t keylen,
+                             const unsigned char *iv, size_t ivlen,
+                             const OSSL_PARAM params[])
+{
+    PROV_FAKE_CIPHER_CTX *ctx = (PROV_FAKE_CIPHER_CTX *)vctx;
+
+    ctx->enc = 1;
+    return 1;
+}
+
+
+static int fake_cipher_dinit(void *vctx, const unsigned char *key, size_t keylen,
+                             const unsigned char *iv, size_t ivlen,
+                             const OSSL_PARAM params[])
+{
+    return 1;
+}
+
+static int fake_cipher_cipher(void *vctx,
+                              unsigned char *out, size_t *outl, size_t outsize,
+                              const unsigned char *in, size_t inl)
+{
+    PROV_FAKE_CIPHER_CTX *ctx = (PROV_FAKE_CIPHER_CTX *)vctx;
+
+    if (!ctx->enc && ctx->tlsmacsize > 0) {
+        if (inl < ctx->tlsmacsize)
+            return 0;
+        ctx->tlsmac = in + inl - ctx->tlsmacsize;
+        inl -= ctx->tlsmacsize;
+    }
+    if (outsize < inl)
+        return 0;
+    if (in != out && out != NULL)
+        memcpy(out, in, inl);
+    if (outl != NULL)
+        *outl = inl;
+    return 1;
+}
+
+static int fake_cipher_final(void *vctx, unsigned char *out, size_t *outl,
+                             size_t outsize)
+{
+    *outl = 0;
+    return 1;
+}
+
+static int fake_cipher_bad_get_params(OSSL_PARAM params[])
+{
+    OSSL_PARAM *p;
+
+    if (!ossl_cipher_generic_get_params(params, 0, 0, 16*8, 0, 16*8))
+        return 0;
+    /* Setup a invalid blocksize */
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_BLOCK_SIZE);
+    if (p != NULL && !OSSL_PARAM_set_size_t(p, -1))
+        return 0;
+    return 1;
+}
+
+static int fake_cipher_get_params(OSSL_PARAM params[])
+{
+    return ossl_cipher_generic_get_params(params, 0, 0, 16*8, 8, 16*8);
+}
+
+static const OSSL_PARAM known_gettable_ctx_params[] = {
+    OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_KEYLEN, NULL),
+    OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_IVLEN, NULL),
+    { OSSL_CIPHER_PARAM_TLS_MAC, OSSL_PARAM_OCTET_PTR, NULL, 0,
+      OSSL_PARAM_UNMODIFIED },
+    OSSL_PARAM_END
+};
+
+static const OSSL_PARAM *fake_cipher_gettable_ctx_params(ossl_unused void *cctx,
+                                                         ossl_unused void *provctx)
+{
+    return known_gettable_ctx_params;
+}
+
+static int fake_cipher_get_ctx_params(void *vctx, OSSL_PARAM params[])
+{
+    PROV_FAKE_CIPHER_CTX *ctx = (PROV_FAKE_CIPHER_CTX *)vctx;
+    OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IVLEN);
+    if (p != NULL && !OSSL_PARAM_set_size_t(p, 16))
+        return 0;
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_KEYLEN);
+    if (p != NULL && !OSSL_PARAM_set_size_t(p, 16))
+        return 0;
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_TLS_MAC);
+    if (p != NULL
+            && !OSSL_PARAM_set_octet_ptr(p, ctx->tlsmac, ctx->tlsmacsize))
+        return 0;
+    return 1;
+}
+
+static const OSSL_PARAM known_settable_ctx_params[] = {
+    OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_TLS_MAC_SIZE, NULL),
+    OSSL_PARAM_END
+};
+
+static const OSSL_PARAM *fake_cipher_settable_ctx_params(ossl_unused void *cctx,
+                                                         ossl_unused void *provctx)
+{
+    return known_settable_ctx_params;
+}
+
+static int fake_cipher_set_ctx_params(void *vctx, const OSSL_PARAM params[])
+{
+    PROV_FAKE_CIPHER_CTX *ctx = (PROV_FAKE_CIPHER_CTX *)vctx;
+    const OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate_const(params, OSSL_CIPHER_PARAM_TLS_MAC_SIZE);
+    if (p != NULL
+            && !OSSL_PARAM_get_size_t(p, &ctx->tlsmacsize))
+        return 0;
+
+    return 1;
+}
+
+/* This cipher is used to test an invalid blocksize being used by API's */
+const OSSL_DISPATCH fake_bad_cipher_functions[] = {
+    { OSSL_FUNC_CIPHER_NEWCTX,
+      (void (*)(void)) fake_cipher_newctx },
+    { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void)) fake_cipher_freectx },
+    { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))fake_cipher_einit },
+    { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))fake_cipher_dinit },
+    { OSSL_FUNC_CIPHER_UPDATE, (void (*)(void))fake_cipher_cipher },
+    { OSSL_FUNC_CIPHER_FINAL, (void (*)(void))fake_cipher_final },
+    { OSSL_FUNC_CIPHER_CIPHER, (void (*)(void))fake_cipher_cipher },
+    { OSSL_FUNC_CIPHER_GET_PARAMS, (void (*)(void)) fake_cipher_bad_get_params },
+    { OSSL_FUNC_CIPHER_GETTABLE_PARAMS,
+      (void (*)(void))ossl_cipher_generic_gettable_params },
+    { OSSL_FUNC_CIPHER_GET_CTX_PARAMS,
+      (void (*)(void))fake_cipher_get_ctx_params },
+    { OSSL_FUNC_CIPHER_GETTABLE_CTX_PARAMS,
+      (void (*)(void))fake_cipher_gettable_ctx_params },
+    { OSSL_FUNC_CIPHER_SET_CTX_PARAMS,
+      (void (*)(void))fake_cipher_set_ctx_params },
+    { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,
+      (void (*)(void))fake_cipher_settable_ctx_params },
+    OSSL_DISPATCH_END
+};
+
+const OSSL_DISPATCH fake_good_cipher_functions[] = {
+    { OSSL_FUNC_CIPHER_NEWCTX,
+      (void (*)(void)) fake_cipher_newctx },
+    { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void)) fake_cipher_freectx },
+    { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))fake_cipher_einit },
+    { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))fake_cipher_dinit },
+    { OSSL_FUNC_CIPHER_UPDATE, (void (*)(void))fake_cipher_cipher },
+    { OSSL_FUNC_CIPHER_FINAL, (void (*)(void))fake_cipher_final },
+    { OSSL_FUNC_CIPHER_CIPHER, (void (*)(void))fake_cipher_cipher },
+    { OSSL_FUNC_CIPHER_GET_PARAMS, (void (*)(void)) fake_cipher_get_params },
+    { OSSL_FUNC_CIPHER_GETTABLE_PARAMS,
+      (void (*)(void))ossl_cipher_generic_gettable_params },
+    { OSSL_FUNC_CIPHER_GET_CTX_PARAMS,
+      (void (*)(void))fake_cipher_get_ctx_params },
+    { OSSL_FUNC_CIPHER_GETTABLE_CTX_PARAMS,
+      (void (*)(void))fake_cipher_gettable_ctx_params },
+    { OSSL_FUNC_CIPHER_SET_CTX_PARAMS,
+      (void (*)(void))fake_cipher_set_ctx_params },
+    { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,
+      (void (*)(void))fake_cipher_settable_ctx_params },
+    OSSL_DISPATCH_END
+};
+
+
+static const OSSL_ALGORITHM fake_cipher_algs[] = {
+    { "Good", "provider=fake-cipher", fake_good_cipher_functions, "Fake Cipher" },
+    { "Bad", "provider=fake-cipher", fake_bad_cipher_functions, "Fake Cipher" },
+    { NULL, NULL, NULL, NULL }
+};
+
+static const OSSL_ALGORITHM *fake_cipher_query(void *provctx,
+                                               int operation_id,
+                                               int *no_cache)
+{
+    *no_cache = 0;
+    if (operation_id == OSSL_OP_CIPHER)
+        return fake_cipher_algs;
+    return NULL;
+}
+
+/* Functions we provide to the core */
+static const OSSL_DISPATCH fake_cipher_method[] = {
+    { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))OSSL_LIB_CTX_free },
+    { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))fake_cipher_query },
+    OSSL_DISPATCH_END
+};
+
+static int fake_cipher_provider_init(const OSSL_CORE_HANDLE *handle,
+                                     const OSSL_DISPATCH *in,
+                                     const OSSL_DISPATCH **out, void **provctx)
+{
+    if (!TEST_ptr(*provctx = OSSL_LIB_CTX_new()))
+        return 0;
+    *out = fake_cipher_method;
+    return 1;
+}
+
+OSSL_PROVIDER *fake_cipher_start(OSSL_LIB_CTX *libctx)
+{
+    OSSL_PROVIDER *p;
+
+    if (!TEST_true(OSSL_PROVIDER_add_builtin(libctx, "fake-cipher",
+                                             fake_cipher_provider_init))
+            || !TEST_ptr(p = OSSL_PROVIDER_try_load(libctx, "fake-cipher", 1)))
+        return NULL;
+
+    return p;
+}
+
+void fake_cipher_finish(OSSL_PROVIDER *p)
+{
+    OSSL_PROVIDER_unload(p);
+}

--- a/test/fake_cipherprov.c
+++ b/test/fake_cipherprov.c
@@ -167,7 +167,7 @@ static int fake_cipher_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 }
 
 /* This cipher is used to test an invalid blocksize being used by API's */
-const OSSL_DISPATCH fake_bad_cipher_functions[] = {
+static const OSSL_DISPATCH fake_bad_cipher_functions[] = {
     { OSSL_FUNC_CIPHER_NEWCTX,
       (void (*)(void)) fake_cipher_newctx },
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void)) fake_cipher_freectx },
@@ -190,7 +190,7 @@ const OSSL_DISPATCH fake_bad_cipher_functions[] = {
     OSSL_DISPATCH_END
 };
 
-const OSSL_DISPATCH fake_good_cipher_functions[] = {
+static const OSSL_DISPATCH fake_good_cipher_functions[] = {
     { OSSL_FUNC_CIPHER_NEWCTX,
       (void (*)(void)) fake_cipher_newctx },
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void)) fake_cipher_freectx },

--- a/test/fake_cipherprov.h
+++ b/test/fake_cipherprov.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/core_dispatch.h>
+
+/* Fake Cipher provider implementation */
+OSSL_PROVIDER *fake_cipher_start(OSSL_LIB_CTX *libctx);
+void fake_cipher_finish(OSSL_PROVIDER *p);

--- a/test/provider_cipher_test.c
+++ b/test/provider_cipher_test.c
@@ -137,6 +137,7 @@ end:
     return ret;
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 /*
  * A dummy PBE keygen - For the tests purposes all it is required to do is set
  * up the cipher in the ctx
@@ -149,7 +150,6 @@ static int dummy_pbe_keygen(EVP_CIPHER_CTX *ctx, const char *pass,
     return EVP_CipherInit_ex2(ctx, cipher, NULL, NULL, 1, NULL);
 }
 
-#ifndef OPENSSL_NO_DEPRECATED_3_0
 /* Test that PKCS12_pbe_crypt_ex() handles an invalid blocksize */
 static int pkcs12_pbe_cipher_bad_blocksize_test(void)
 {

--- a/test/provider_cipher_test.c
+++ b/test/provider_cipher_test.c
@@ -149,6 +149,7 @@ static int dummy_pbe_keygen(EVP_CIPHER_CTX *ctx, const char *pass,
     return EVP_CipherInit_ex2(ctx, cipher, NULL, NULL, 1, NULL);
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 /* Test that PKCS12_pbe_crypt_ex() handles an invalid blocksize */
 static int pkcs12_pbe_cipher_bad_blocksize_test(void)
 {
@@ -193,6 +194,7 @@ err:
     X509_ALGOR_free(algor);
     return ret;
 }
+#endif
 
 int setup_tests(void)
 {
@@ -223,8 +225,9 @@ int setup_tests(void)
     ADD_TEST(evp_cipher_bad_blocksize_test);
     ADD_TEST(bio_cipher_read_bad_blocksize_test);
     ADD_TEST(krb5kdf_cipher_bad_blocksize_test);
+#ifndef OPENSSL_NO_DEPRECATED_3_0
     ADD_TEST(pkcs12_pbe_cipher_bad_blocksize_test);
-
+#endif
     return 1;
 }
 

--- a/test/provider_cipher_test.c
+++ b/test/provider_cipher_test.c
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#define OPENSSL_SUPPRESS_DEPRECATED
+
+#include <openssl/core_names.h>
+#include <openssl/evp.h>
+#include <openssl/kdf.h>
+#include <openssl/pkcs12.h>
+#include "testutil.h"
+#include "fake_cipherprov.h"
+
+static OSSL_LIB_CTX *libctx = NULL;
+static OSSL_PROVIDER *defltprov = NULL;
+static OSSL_PROVIDER *fakeprov = NULL;
+static EVP_CIPHER_CTX *cipherctx = NULL;
+static EVP_CIPHER *cipherbad = NULL;
+static EVP_CIPHER *ciphergood = NULL;
+
+/* Fetch CIPHER method using a libctx and propq */
+static EVP_CIPHER *fetch_cipher(OSSL_LIB_CTX *ctx,
+                                const char *alg, const char *propq,
+                                OSSL_PROVIDER *expected_prov)
+{
+    const OSSL_PROVIDER *prov;
+    EVP_CIPHER *cipher = EVP_CIPHER_fetch(ctx, alg, propq);
+
+    if (!TEST_ptr(cipher))
+        return NULL;
+
+    if (!TEST_ptr(prov = EVP_CIPHER_get0_provider(cipher)))
+        goto end;
+
+    if (!TEST_ptr_eq(prov, expected_prov)) {
+        TEST_info("Fetched provider: %s, Expected provider: %s",
+                  OSSL_PROVIDER_get0_name(prov),
+                  OSSL_PROVIDER_get0_name(expected_prov));
+        goto end;
+    }
+
+    return cipher;
+end:
+    EVP_CIPHER_free(cipher);
+    return NULL;
+}
+
+static int evp_cipher_bad_blocksize_test(void)
+{
+    int ret = 0;
+    static const unsigned char msg[] = "Hello";
+
+    if (!TEST_true(EVP_EncryptInit_ex2(cipherctx, cipherbad, NULL, NULL, NULL)))
+        goto end;
+
+    if (!TEST_int_eq(EVP_Cipher(cipherctx, NULL, msg, sizeof(msg)), 0))
+        goto end;
+
+    if (!TEST_true(EVP_EncryptInit_ex2(cipherctx, ciphergood, NULL, NULL, NULL)))
+        goto end;
+
+    if (!TEST_int_eq(EVP_Cipher(cipherctx, NULL, msg, sizeof(msg)), sizeof(msg)))
+        goto end;
+    ret = 1;
+
+end:
+    return ret;
+}
+
+#define BUF_SIZE 32
+/* Test that enc_read() handles an invalid cipher blocksize */
+static int bio_cipher_read_bad_blocksize_test(void)
+{
+    int ret = 0;
+    BIO *cipherbio, *membio;
+    unsigned char buf[BUF_SIZE] = { 0 };
+    unsigned char in[BUF_SIZE];
+
+    if (!TEST_ptr(cipherbio = BIO_new(BIO_f_cipher())))
+        return 0;
+    if (!TEST_true(BIO_set_cipher(cipherbio, cipherbad, NULL, NULL, 1)))
+        goto err;
+    if (!TEST_ptr(membio = BIO_new_mem_buf(buf, sizeof(buf))))
+        goto err;
+    if (!TEST_ptr(BIO_push(cipherbio, membio))) {
+        BIO_free(membio);
+        goto err;
+    }
+    if (!TEST_int_eq(BIO_read(cipherbio, in, sizeof(in)), 0))
+        goto err;
+    ret = 1;
+err:
+    BIO_free_all(cipherbio);
+    return ret;
+}
+
+/* Test that EVP_Cipher() fails if a cipher has a invalid blocksize */
+static int krb5kdf_cipher_bad_blocksize_test(void)
+{
+    int ret = 0;
+    EVP_KDF *kdf = NULL;
+    EVP_KDF_CTX *kctx = NULL;
+    OSSL_PARAM params[4], *p = params;
+    unsigned char out[16];
+    static unsigned char key[] = {
+        0x42, 0x26, 0x3C, 0x6E, 0x89, 0xF4, 0xFC, 0x28,
+        0xB8, 0xDF, 0x68, 0xEE, 0x09, 0x79, 0x9F, 0x15
+    };
+    static unsigned char constant[] = {
+        0x00, 0x00, 0x00, 0x02, 0x99
+    };
+
+    if (!TEST_ptr(kdf = EVP_KDF_fetch(libctx, OSSL_KDF_NAME_KRB5KDF, NULL)))
+        return 0;
+    if (!TEST_ptr(kctx = EVP_KDF_CTX_new(kdf)))
+        goto end;
+
+    *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_CIPHER,
+                                            (char *)"Bad", 0);
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY, key,
+                                             sizeof(key));
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_CONSTANT,
+                                             constant, sizeof(constant));
+    *p = OSSL_PARAM_construct_end();
+
+    if (!TEST_int_eq(EVP_KDF_derive(kctx, out, sizeof(out), params), 0))
+        goto end;
+    ret = 1;
+end:
+    EVP_KDF_free(kdf);
+    EVP_KDF_CTX_free(kctx);
+    return ret;
+}
+
+/*
+ * A dummy PBE keygen - For the tests purposes all it is required to do is set
+ * up the cipher in the ctx
+ */
+static int dummy_pbe_keygen(EVP_CIPHER_CTX *ctx, const char *pass,
+                            int passlen, ASN1_TYPE *param,
+                            const EVP_CIPHER *cipher, const EVP_MD *md,
+                            int en_de)
+{
+    return EVP_CipherInit_ex2(ctx, cipher, NULL, NULL, 1, NULL);
+}
+
+/* Test that PKCS12_pbe_crypt_ex() handles an invalid blocksize */
+static int pkcs12_pbe_cipher_bad_blocksize_test(void)
+{
+    int ret = 0;
+    EVP_CIPHER *cipher = NULL;
+    unsigned char salt[16] = { 0 };
+    X509_ALGOR *algor = NULL;
+    int nid;
+    unsigned char *data = NULL;
+    int datalen = 0;
+    const unsigned char in[]= {
+        0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06,
+        0x03, 0x2b, 0x65, 0x6e, 0x04, 0x22, 0x04, 0x20,
+        0x77, 0x07, 0x6d, 0x0a, 0x73, 0x18, 0xa5, 0x7d,
+        0x3c, 0x16, 0xc1, 0x72, 0x51, 0xb2, 0x66, 0x45,
+        0xdf, 0x4c, 0x2f, 0x87, 0xeb, 0xc0, 0x99, 0x2a,
+        0xb1, 0x77, 0xfb, 0xa5, 0x1d, 0xb9, 0x2c, 0x2a
+    };
+
+    nid = OBJ_txt2nid("Bad");
+    if (!TEST_int_ne(nid, NID_undef))
+        return 0;
+    if (!TEST_ptr(cipher = EVP_CIPHER_meth_new(nid, 16, 16)))
+        return 0;
+
+    if (!TEST_true(EVP_add_cipher(cipher)))
+        goto err;
+
+    if (!TEST_true(EVP_PBE_alg_add_type(EVP_PBE_TYPE_OUTER, NID_pbes2, nid,
+                                        NID_sha256, dummy_pbe_keygen)))
+        goto err;
+
+    if (!TEST_ptr(algor = PKCS5_pbe2_set(cipher, 1000, salt, sizeof(salt))))
+        goto err;
+
+    if (!TEST_ptr_null(PKCS12_pbe_crypt_ex(algor, "Pass", 4, in, sizeof(in),
+                                           &data, &datalen, 1, libctx, NULL)))
+        goto err;
+    ret = 1;
+err:
+    EVP_CIPHER_meth_free(cipher);
+    X509_ALGOR_free(algor);
+    return ret;
+}
+
+int setup_tests(void)
+{
+    if (!TEST_ptr(libctx = OSSL_LIB_CTX_new()))
+        return 0;
+
+    if (!TEST_ptr(cipherctx = EVP_CIPHER_CTX_new()))
+        return 0;
+
+    if (!TEST_ptr(fakeprov = fake_cipher_start(libctx)))
+        return 0;
+
+    if (!TEST_ptr(defltprov = OSSL_PROVIDER_load(libctx, "default")))
+        return 0;
+
+    if (!OBJ_create("1.3.6.1.4.1.16604.998866.2", "Bad", "Bad"))
+        return 0;
+
+    /* Do a direct fetch to see it works */
+    if (!TEST_ptr(cipherbad = fetch_cipher(libctx, "Bad",
+                                           "provider=fake-cipher", fakeprov)))
+        return 0;
+
+    if (!TEST_ptr(ciphergood = fetch_cipher(libctx, "Good",
+                                            "provider=fake-cipher", fakeprov)))
+        return 0;
+
+    ADD_TEST(evp_cipher_bad_blocksize_test);
+    ADD_TEST(bio_cipher_read_bad_blocksize_test);
+    ADD_TEST(krb5kdf_cipher_bad_blocksize_test);
+    ADD_TEST(pkcs12_pbe_cipher_bad_blocksize_test);
+
+    return 1;
+}
+
+void cleanup_tests(void)
+{
+    EVP_CIPHER_free(cipherbad);
+    EVP_CIPHER_free(ciphergood);
+    EVP_CIPHER_CTX_free(cipherctx);
+    fake_cipher_finish(fakeprov);
+    OSSL_PROVIDER_unload(defltprov);
+    OSSL_LIB_CTX_free(libctx);
+}

--- a/test/recipes/04-test_provider_cipher.t
+++ b/test/recipes/04-test_provider_cipher.t
@@ -1,0 +1,18 @@
+#! /usr/bin/env perl
+# Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use File::Spec;
+use OpenSSL::Test::Simple;
+
+# We must ensure that OPENSSL_CONF points at an empty file.  Otherwise, we
+# risk that the configuration file contains statements that load providers,
+# which defeats the purpose of this test.  The NUL device is good enough.
+$ENV{OPENSSL_CONF} = File::Spec->devnull();
+
+simple_test("test_provider_cipher", "provider_cipher_test");


### PR DESCRIPTION
EVP_CIPHER_CTX_get_block_size() returns an int which can be -1.
Fix all the calls that cast it to a size_t.

This is a follow on from reviewing https://github.com/openssl/openssl/pull/22995
which makes it more obvious that EVP_CIPHER_CTX_get_block_size() can return -1.

There are a couple of places in the code that already check for this, but the rest do bad things.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
