### PR TITLE
Fix provider compatibility check crash in evp_test [3.0]

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -1408,7 +1408,7 @@ static int mac_test_run_mac(EVP_TEST *t)
     EVP_MAC_CTX *ctx = NULL;
     unsigned char *got = NULL;
     size_t got_len = 0, size = 0;
-    size_t size_before_init, size_after_init, size_val = 0;
+    size_t size_before_init = 0, size_after_init, size_val = 0;
     int i, block_size = -1, output_size = -1;
     OSSL_PARAM params[21], sizes[3], *psizes = sizes;
     size_t params_n = 0;
@@ -1516,7 +1516,8 @@ static int mac_test_run_mac(EVP_TEST *t)
         t->err = "MAC_CREATE_ERROR";
         goto err;
     }
-    size_before_init = EVP_MAC_CTX_get_mac_size(ctx);
+    if (fips_provider_version_gt(libctx, 3, 0, 12))
+        size_before_init = EVP_MAC_CTX_get_mac_size(ctx);
     if (!EVP_MAC_init(ctx, expected->key, expected->key_len, params)) {
         t->err = "MAC_INIT_ERROR";
         goto err;


### PR DESCRIPTION
EVP_MAC_CTX_get_mac_size() cannot be called on older unfixed versions before EVP_MAC_init().

Same as #23006 but for 3.0 branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
