### PR TITLE
Document which cipher modes do not support streaming

### DIFF
--- a/doc/man7/EVP_CIPHER-AES.pod
+++ b/doc/man7/EVP_CIPHER-AES.pod
@@ -65,9 +65,16 @@ L<EVP_EncryptInit(3)/PARAMETERS>.
 
 =head1 NOTES
 
-The XTS, SIV and WRAP mode implementations do not support streaming. That
+The AES-SIV and AES-WRAP mode implementations do not support streaming. That
 means to obtain correct results there can be only one L<EVP_EncryptUpdate(3)>
 or L<EVP_DecryptUpdate(3)> call after the initialization of the context.
+
+The AES-XTS implementations allow streaming to be performed, but each
+L<EVP_EncryptUpdate(3)> or L<EVP_DecryptUpdate(3)> call requires each input
+to be a multiple of the blocksize. Only the final EVP_EncryptUpdate() or
+EVP_DecryptUpdate() call can optionally have an input that is not a multiple
+of the blocksize but is larger than one block. In that case ciphertext
+stealing (CTS) is used to fill the block.
 
 =head1 SEE ALSO
 

--- a/doc/man7/EVP_CIPHER-AES.pod
+++ b/doc/man7/EVP_CIPHER-AES.pod
@@ -63,6 +63,12 @@ FIPS provider:
 This implementation supports the parameters described in
 L<EVP_EncryptInit(3)/PARAMETERS>.
 
+=head1 NOTES
+
+The XTS, SIV and WRAP mode implementations do not support streaming. That
+means to obtain correct results there can be only one L<EVP_EncryptUpdate(3)>
+or L<EVP_DecryptUpdate(3)> call after the initialization of the context.
+
 =head1 SEE ALSO
 
 L<provider-cipher(7)>, L<OSSL_PROVIDER-FIPS(7)>, L<OSSL_PROVIDER-default(7)>

--- a/doc/man7/EVP_CIPHER-SM4.pod
+++ b/doc/man7/EVP_CIPHER-SM4.pod
@@ -39,9 +39,12 @@ L<EVP_EncryptInit(3)/PARAMETERS>.
 
 =head1 NOTES
 
-The XTS mode implementation does not support streaming. That means to obtain
-correct results there can be only one L<EVP_EncryptUpdate(3)> or
-L<EVP_DecryptUpdate(3)> call after the initialization of the context.
+The SM4-XTS implementation allows streaming to be performed, but each
+L<EVP_EncryptUpdate(3)> or L<EVP_DecryptUpdate(3)> call requires each input
+to be a multiple of the blocksize. Only the final EVP_EncryptUpdate() or
+EVP_DecryptUpdate() call can optionally have an input that is not a multiple
+of the blocksize but is larger than one block. In that case ciphertext
+stealing (CTS) is used to fill the block.
 
 =head1 SEE ALSO
 

--- a/doc/man7/EVP_CIPHER-SM4.pod
+++ b/doc/man7/EVP_CIPHER-SM4.pod
@@ -37,6 +37,12 @@ The following algorithms are available in the default provider:
 This implementation supports the parameters described in
 L<EVP_EncryptInit(3)/PARAMETERS>.
 
+=head1 NOTES
+
+The XTS mode implementation does not support streaming. That means to obtain
+correct results there can be only one L<EVP_EncryptUpdate(3)> or
+L<EVP_DecryptUpdate(3)> call after the initialization of the context.
+
 =head1 SEE ALSO
 
 L<provider-cipher(7)>, L<OSSL_PROVIDER-default(7)>


### PR DESCRIPTION
The first commit is applicable only to master and 3.2. The second one to all 3.x branches.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
