### PR TITLE
Fix a possible memory leak in X509_ATTRIBUTE_set1_data

### DIFF
--- a/crypto/x509/x509_att.c
+++ b/crypto/x509/x509_att.c
@@ -322,6 +322,9 @@ int X509_ATTRIBUTE_set1_data(X509_ATTRIBUTE *attr, int attrtype,
         }
     } else {
         ASN1_TYPE_set(ttmp, atype, stmp);
+        if (atype == V_ASN1_BOOLEAN) {
+            ASN1_STRING_free(stmp);
+        }
         stmp = NULL;
     }
     if (!sk_ASN1_TYPE_push(attr->set, ttmp)) {


### PR DESCRIPTION
If attrtype is V_ASN1_BOOLEAN, we should free stmp after call ASN1_TYPE_set in X509_ATTRIBUTE_set1_data, because ASN1_TYPE_set does not preserve the stmp.