### PR TITLE
`X509_dup.pod`: add caveat that extra data is not copied and hint to use e.g. `X509_up_ref()`

### DIFF
--- a/doc/man3/X509_dup.pod
+++ b/doc/man3/X509_dup.pod
@@ -364,10 +364,11 @@ may contain extra data besides the ASN.1 structure.
 For instance, an B<X509> object usually is augmented
 by cached information on X.509v3 extensions, etc.
 Such extra data is not copied.
-If it needs to be retained, maybe better use B<I<TYPE>_up_ref>().
+If it needs to be retained, it may be better to use B<I<TYPE>_up_ref>().
 For the case of B<X509> objects, an alternative to using L<X509_up_ref(3)>
-is to still call, e.g., I<copied_cert = X509_dup(cert)>, yet followed by
-I<X509_check_purpose(copied_cert, -1, 0)>, which re-builds the cached data.
+is to still call B<I<TYPE>_dup>(), e.g., I<copied_cert = X509_dup(cert)>,
+followed by I<X509_check_purpose(copied_cert, -1, 0)>,
+which re-builds the cached data.
 
 B<I<TYPE>_free>() releases the object and all pointers and sub-objects
 within it.

--- a/doc/man3/X509_dup.pod
+++ b/doc/man3/X509_dup.pod
@@ -360,13 +360,12 @@ binary data using B<d2i_I<TYPE>>().
 
 B<I<TYPE>_dup>() copies an existing object, leaving it untouched.
 Note, however, that the internal representation of the object
-may contain extra data besides the ASN.1 structure.
-For instance, an B<X509> object usually is augmented
-by cached information on X.509v3 extensions, etc.
-Such extra data is not copied.
-If it needs to be retained, it may be better to use B<I<TYPE>_up_ref>().
+may contain besides the ASN.1 structure further data, which is not copied.
+For instance, an B<X509> object usually is augmented by cached information
+on X.509v3 extensions, etc., and losing it can lead to wrong validation results.
+To avoid such situations, better use B<I<TYPE>_up_ref>() if available.
 For the case of B<X509> objects, an alternative to using L<X509_up_ref(3)>
-is to still call B<I<TYPE>_dup>(), e.g., I<copied_cert = X509_dup(cert)>,
+may be to still call B<I<TYPE>_dup>(), e.g., I<copied_cert = X509_dup(cert)>,
 followed by I<X509_check_purpose(copied_cert, -1, 0)>,
 which re-builds the cached data.
 

--- a/doc/man3/X509_dup.pod
+++ b/doc/man3/X509_dup.pod
@@ -359,6 +359,15 @@ algorithms from providers. This created object can then be used when loading
 binary data using B<d2i_I<TYPE>>().
 
 B<I<TYPE>_dup>() copies an existing object, leaving it untouched.
+Note, however, that the internal representation of the object
+may contain extra data besides the ASN.1 structure.
+For instance, an B<X509> object usually is augmented
+by cached information on X.509v3 extensions, etc.
+Such extra data is not copied.
+If it needs to be retained, maybe better use B<I<TYPE>_up_ref>().
+For the case of B<X509> objects, an alternative to using L<X509_up_ref(3)>
+is to still call, e.g., I<copied_cert = X509_dup(cert)>, yet followed by
+I<X509_check_purpose(copied_cert, -1, 0)>, which re-builds the cached data.
 
 B<I<TYPE>_free>() releases the object and all pointers and sub-objects
 within it.
@@ -375,6 +384,10 @@ B<I<TYPE>_new>(), B<I<TYPE>_new_ex>() and B<I<TYPE>_dup>() return a pointer to
 the object or NULL on failure.
 
 B<I<TYPE>_print_ctx>() returns 1 on success or zero on failure.
+
+=head1 SEE ALSO
+
+L<X509_up_ref(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/X509_dup.pod
+++ b/doc/man3/X509_dup.pod
@@ -360,7 +360,7 @@ binary data using B<d2i_I<TYPE>>().
 
 B<I<TYPE>_dup>() copies an existing object, leaving it untouched.
 Note, however, that the internal representation of the object
-may contain besides the ASN.1 structure further data, which is not copied.
+may contain (besides the ASN.1 structure) further data, which is not copied.
 For instance, an B<X509> object usually is augmented by cached information
 on X.509v3 extensions, etc., and losing it can lead to wrong validation results.
 To avoid such situations, better use B<I<TYPE>_up_ref>() if available.


### PR DESCRIPTION
Extend:

`B<I<TYPE>_dup>() copies an existing object, leaving it untouched.`

by:
```
Note, however, that the internal representation of the object
may contain extra data besides the ASN.1 structure.
For instance, an B<X509> object usually is augmented
by cached information on X.509v3 extensions, etc.
Such extra data is not copied.
If it needs to be retained, maybe better use B<I<TYPE>_up_ref>().
For the case of B<X509> objects, an alternative to using L<X509_up_ref(3)>
is to still call, e.g., I<copied_cert = X509_dup(cert)>, yet followed by
I<X509_check_purpose(copied_cert, -1, 0)>, which re-builds the cached data.
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
