### PR TITLE
Always apply all configuration settings from the ssl section

### DIFF
--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -902,9 +902,12 @@ static int ctrl_switch_option(SSL_CONF_CTX *cctx, const ssl_conf_cmd_tbl *cmd)
     /* Find index of command in table */
     size_t idx = cmd - ssl_conf_cmds;
     const ssl_switch_tbl *scmd;
+
     /* Sanity check index */
-    if (idx >= OSSL_NELEM(ssl_cmd_switches))
+    if (idx >= OSSL_NELEM(ssl_cmd_switches)) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
         return 0;
+    }
     /* Obtain switches entry with same index */
     scmd = ssl_cmd_switches + idx;
     ssl_set_option(cctx, scmd->name_flags, scmd->option_value, 1);
@@ -920,28 +923,33 @@ int SSL_CONF_cmd(SSL_CONF_CTX *cctx, const char *cmd, const char *value)
     }
 
     if (!ssl_conf_cmd_skip_prefix(cctx, &cmd))
-        return -2;
+        goto unknown_cmd;
 
     runcmd = ssl_conf_cmd_lookup(cctx, cmd);
 
     if (runcmd) {
-        int rv;
+        int rv = -3;
+
         if (runcmd->value_type == SSL_CONF_TYPE_NONE) {
             return ctrl_switch_option(cctx, runcmd);
         }
         if (value == NULL)
-            return -3;
+            goto bad_value;
         rv = runcmd->cmd(cctx, value);
         if (rv > 0)
             return 2;
-        if (rv == -2)
-            return -2;
+        if (rv != -2)
+            rv = 0;
+
+ bad_value:
         if (cctx->flags & SSL_CONF_FLAG_SHOW_ERRORS)
             ERR_raise_data(ERR_LIB_SSL, SSL_R_BAD_VALUE,
-                           "cmd=%s, value=%s", cmd, value);
-        return 0;
+                           "cmd=%s, value=%s", cmd,
+                           value != NULL ? value : "<EMPTY>");
+        return rv;
     }
 
+ unknown_cmd:
     if (cctx->flags & SSL_CONF_FLAG_SHOW_ERRORS)
         ERR_raise_data(ERR_LIB_SSL, SSL_R_UNKNOWN_CMD_NAME, "cmd=%s", cmd);
 

--- a/ssl/ssl_mcnf.c
+++ b/ssl/ssl_mcnf.c
@@ -73,13 +73,8 @@ static int ssl_do_config(SSL *s, SSL_CTX *ctx, const char *name, int system)
 
         conf_ssl_get_cmd(cmds, i, &cmdstr, &arg);
         rv = SSL_CONF_cmd(cctx, cmdstr, arg);
-        if (rv <= 0) {
-            int errcode = rv == -2 ? SSL_R_UNKNOWN_COMMAND : SSL_R_BAD_VALUE;
-
-            ERR_raise_data(ERR_LIB_SSL, errcode,
-                           "section=%s, cmd=%s, arg=%s", name, cmdstr, arg);
+        if (rv <= 0)
             ++err;
-        }
     }
     if (!SSL_CONF_CTX_finish(cctx))
         ++err;

--- a/test/sysdefault.cnf
+++ b/test/sysdefault.cnf
@@ -18,5 +18,6 @@ new-sig-oid = 1.1.1.1.1.1.1.1.1.1.1.1.1.1
 system_default = ssl_default_sect
 
 [ssl_default_sect]
+SignatureAlgorithms = RSA+SHA256:nonex
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2


### PR DESCRIPTION
Even if some configuration entry is incorrect, do not skip the remaining ones.

Fixes #20789

Also consolidate raising errors in SSL_CONF_cmd() as suggested by @nhorman 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
