### PR TITLE
Ignore unknown sigalgs and groups in the configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,13 +30,14 @@ OpenSSL 3.3
 
  * Unknown entries in TLS SignatureAlgorithms, ClientSignatureAlgorithms
    config options and the respective calls to SSL[_CTX]_set1_sigalgs() and
-   SSL[_CTX]_set1_client_sigalgs() that are marked with `?` character are
+   SSL[_CTX]_set1_client_sigalgs() that start with `?` character are
    ignored and the configuration will still be used.
-   Similarly unknown entries that are marked with `?` character in a TLS
+
+   Similarly unknown entries that start with `?` character in a TLS
    Groups config option or set with SSL[_CTX]_set1_groups_list() are ignored
    and the configuration will still be used.
 
-   In all of these cases if the resulting list is empty, an error is returned.
+   In both cases if the resulting list is empty, an error is returned.
 
    *Tomáš Mráz*
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,17 @@ OpenSSL 3.3
 
 ### Changes between 3.2 and 3.3 [xx XXX xxxx]
 
+ * Unknown entries in TLS SignatureAlgorithms, ClientSignatureAlgorithms
+   config options and the respective calls to SSL[_CTX]_set1_sigalgs() and
+   SSL[_CTX]_set1_client_sigalgs() are ignored and the configuration will
+   still be used.
+   Similarly unknown entries in TLS Groups config option and the
+   SSL[_CTX]_set1_groups_list() are ignored and the configuration will
+   still be used.
+   In all of these cases if the resulting list is empty, an error is returned.
+
+   *Tomáš Mráz*
+
  * The EVP_PKEY_fromdata function has been augmented to allow for the derivation
    of CRT (Chinese Remainder Theorem) parameters when requested.  See the
    OSSL_PKEY_PARAM_RSA_DERIVE_FROM_PQ param in the EVP_PKEY-RSA documentation.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,11 +30,12 @@ OpenSSL 3.3
 
  * Unknown entries in TLS SignatureAlgorithms, ClientSignatureAlgorithms
    config options and the respective calls to SSL[_CTX]_set1_sigalgs() and
-   SSL[_CTX]_set1_client_sigalgs() are ignored and the configuration will
-   still be used.
-   Similarly unknown entries in TLS Groups config option and the
-   SSL[_CTX]_set1_groups_list() are ignored and the configuration will
-   still be used.
+   SSL[_CTX]_set1_client_sigalgs() that are marked with `?` character are
+   ignored and the configuration will still be used.
+   Similarly unknown entries that are marked with `?` character in a TLS
+   Groups config option or set with SSL[_CTX]_set1_groups_list() are ignored
+   and the configuration will still be used.
+
    In all of these cases if the resulting list is empty, an error is returned.
 
    *Tomáš Mráz*

--- a/doc/man3/SSL_CTX_set1_curves.pod
+++ b/doc/man3/SSL_CTX_set1_curves.pod
@@ -142,6 +142,9 @@ The curve functions were added in OpenSSL 1.0.2. The equivalent group
 functions were added in OpenSSL 1.1.1. The SSL_get_negotiated_group() function
 was added in OpenSSL 3.0.0.
 
+Since OpenSSL 3.3 the SSL_CTX_set1_groups_list() and SSL_set1_groups_list()
+functions ignore unknown groups in B<list>.
+
 =head1 COPYRIGHT
 
 Copyright 2013-2022 The OpenSSL Project Authors. All Rights Reserved.

--- a/doc/man3/SSL_CTX_set1_curves.pod
+++ b/doc/man3/SSL_CTX_set1_curves.pod
@@ -58,7 +58,8 @@ string B<list>. The string is a colon separated list of group names, for example
 are B<P-256>, B<P-384>, B<P-521>, B<X25519>, B<X448>, B<brainpoolP256r1tls13>,
 B<brainpoolP384r1tls13>, B<brainpoolP512r1tls13>, B<ffdhe2048>, B<ffdhe3072>,
 B<ffdhe4096>, B<ffdhe6144> and B<ffdhe8192>. Support for other groups may be
-added by external providers.
+added by external providers. If a group name is preceded with the C<?>
+character, it will be ignored if an implementation is missing.
 
 SSL_set1_groups() and SSL_set1_groups_list() are similar except they set
 supported groups for the SSL structure B<ssl>.
@@ -142,8 +143,8 @@ The curve functions were added in OpenSSL 1.0.2. The equivalent group
 functions were added in OpenSSL 1.1.1. The SSL_get_negotiated_group() function
 was added in OpenSSL 3.0.0.
 
-Since OpenSSL 3.3 the SSL_CTX_set1_groups_list() and SSL_set1_groups_list()
-functions ignore unknown groups in B<list>.
+Support for ignoring unknown groups in SSL_CTX_set1_groups_list() and
+SSL_set1_groups_list() was added in OpenSSL 3.3.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set1_sigalgs.pod
+++ b/doc/man3/SSL_CTX_set1_sigalgs.pod
@@ -106,6 +106,12 @@ using a string:
 L<ssl(7)>, L<SSL_get_shared_sigalgs(3)>,
 L<SSL_CONF_CTX_new(3)>
 
+=head1 HISTORY
+
+Since OpenSSL 3.3 the SSL_CTX_set1_sigalgs_list(), SSL_set1_sigalgs_list(),
+SSL_CTX_set1_client_sigalgs_list() and SSL_set1_client_sigalgs_list()
+functions ignore unknown signature algorithms in B<str>.
+
 =head1 COPYRIGHT
 
 Copyright 2015-2018 The OpenSSL Project Authors. All Rights Reserved.

--- a/doc/man3/SSL_CTX_set1_sigalgs.pod
+++ b/doc/man3/SSL_CTX_set1_sigalgs.pod
@@ -33,7 +33,9 @@ signature algorithms for B<ctx> or B<ssl>. The B<str> parameter
 must be a null terminated string consisting of a colon separated list of
 elements, where each element is either a combination of a public key
 algorithm and a digest separated by B<+>, or a TLS 1.3-style named
-SignatureScheme such as rsa_pss_pss_sha256.
+SignatureScheme such as rsa_pss_pss_sha256. If a list entry is preceded
+with the C<?> character, it will be ignored if an implementation is missing.
+
 
 SSL_CTX_set1_client_sigalgs(), SSL_set1_client_sigalgs(),
 SSL_CTX_set1_client_sigalgs_list() and SSL_set1_client_sigalgs_list() set
@@ -108,9 +110,10 @@ L<SSL_CONF_CTX_new(3)>
 
 =head1 HISTORY
 
-Since OpenSSL 3.3 the SSL_CTX_set1_sigalgs_list(), SSL_set1_sigalgs_list(),
+Support for ignoring unknown signature algorithms in
+SSL_CTX_set1_sigalgs_list(), SSL_set1_sigalgs_list(),
 SSL_CTX_set1_client_sigalgs_list() and SSL_set1_client_sigalgs_list()
-functions ignore unknown signature algorithms in B<str>.
+was added in OpenSSL 3.3.
 
 =head1 COPYRIGHT
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2881,7 +2881,7 @@ static int sig_cb(const char *elem, int len, void *arg)
     const SIGALG_LOOKUP *s;
     char etmp[TLS_MAX_SIGSTRING_LEN], *p;
     int sig_alg = NID_undef, hash_alg = NID_undef;
-    int ignore_unknown;
+    int ignore_unknown = 0;
 
     if (elem == NULL)
         return 0;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -9519,7 +9519,17 @@ static int test_unknown_sigalgs_groups(void)
                                               0))
         goto end;
 
+    if (!TEST_int_le(SSL_CTX_set1_groups_list(ctx,
+                                              "?nonexistent1:?nonexistent2:?nonexistent3"),
+                                              0))
+        goto end;
+
 #ifndef OPENSSL_NO_EC
+    if (!TEST_int_le(SSL_CTX_set1_groups_list(ctx,
+                                              "P-256:nonexistent"),
+                                              0))
+        goto end;
+
     if (!TEST_int_gt(SSL_CTX_set1_groups_list(ctx,
                                               "P-384:?nonexistent:?P-521"),
                                               0))

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -3148,7 +3148,7 @@ static const sigalgs_list testsigalgs[] = {
     {validlist3, OSSL_NELEM(validlist3), NULL, 1, 0},
 # endif
     {NULL, 0, "RSA+SHA256", 1, 1},
-    {NULL, 0, "RSA+SHA256:Invalid", 1, 1},
+    {NULL, 0, "RSA+SHA256:?Invalid", 1, 1},
 # ifndef OPENSSL_NO_EC
     {NULL, 0, "RSA+SHA256:ECDSA+SHA512", 1, 1},
     {NULL, 0, "ECDSA+SHA512", 1, 0},
@@ -3159,6 +3159,7 @@ static const sigalgs_list testsigalgs[] = {
     {invalidlist4, OSSL_NELEM(invalidlist4), NULL, 0, 0},
     {NULL, 0, "RSA", 0, 0},
     {NULL, 0, "SHA256", 0, 0},
+    {NULL, 0, "RSA+SHA256:SHA256", 0, 0},
     {NULL, 0, "Invalid", 0, 0}
 };
 
@@ -9496,7 +9497,7 @@ static int test_unknown_sigalgs_groups(void)
         goto end;
 
     if (!TEST_int_gt(SSL_CTX_set1_sigalgs_list(ctx,
-                                               "RSA+SHA256:nonexistent:RSA+SHA512"),
+                                               "RSA+SHA256:?nonexistent:?RSA+SHA512"),
                                                0))
         goto end;
     if (!TEST_size_t_eq(ctx->cert->conf_sigalgslen, 2)
@@ -9505,7 +9506,7 @@ static int test_unknown_sigalgs_groups(void)
         goto end;
 
     if (!TEST_int_gt(SSL_CTX_set1_client_sigalgs_list(ctx,
-                                                      "RSA+SHA256:nonexistent:RSA+SHA512"),
+                                                      "RSA+SHA256:?nonexistent:?RSA+SHA512"),
                                                       0))
         goto end;
     if (!TEST_size_t_eq(ctx->cert->client_sigalgslen, 2)
@@ -9520,7 +9521,7 @@ static int test_unknown_sigalgs_groups(void)
 
 #ifndef OPENSSL_NO_EC
     if (!TEST_int_gt(SSL_CTX_set1_groups_list(ctx,
-                                              "P-384:nonexistent:P-521"),
+                                              "P-384:?nonexistent:?P-521"),
                                               0))
         goto end;
     if (!TEST_size_t_eq(ctx->ext.supportedgroups_len, 2)

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -39,6 +39,7 @@
 #include "testutil.h"
 #include "testutil/output.h"
 #include "internal/nelem.h"
+#include "internal/tlsgroups.h"
 #include "internal/ktls.h"
 #include "../ssl/ssl_local.h"
 #include "../ssl/record/methods/recmethod_local.h"
@@ -3147,6 +3148,7 @@ static const sigalgs_list testsigalgs[] = {
     {validlist3, OSSL_NELEM(validlist3), NULL, 1, 0},
 # endif
     {NULL, 0, "RSA+SHA256", 1, 1},
+    {NULL, 0, "RSA+SHA256:Invalid", 1, 1},
 # ifndef OPENSSL_NO_EC
     {NULL, 0, "RSA+SHA256:ECDSA+SHA512", 1, 1},
     {NULL, 0, "ECDSA+SHA512", 1, 0},
@@ -3157,7 +3159,6 @@ static const sigalgs_list testsigalgs[] = {
     {invalidlist4, OSSL_NELEM(invalidlist4), NULL, 0, 0},
     {NULL, 0, "RSA", 0, 0},
     {NULL, 0, "SHA256", 0, 0},
-    {NULL, 0, "RSA+SHA256:SHA256", 0, 0},
     {NULL, 0, "Invalid", 0, 0}
 };
 
@@ -9486,6 +9487,54 @@ static int test_servername(int tst)
     return testresult;
 }
 
+static int test_unknown_sigalgs_groups(void)
+{
+    int ret = 0;
+    SSL_CTX *ctx = NULL;
+
+    if (!TEST_ptr(ctx = SSL_CTX_new_ex(libctx, NULL, TLS_server_method())))
+        goto end;
+
+    if (!TEST_int_gt(SSL_CTX_set1_sigalgs_list(ctx,
+                                               "RSA+SHA256:nonexistent:RSA+SHA512"),
+                                               0))
+        goto end;
+    if (!TEST_size_t_eq(ctx->cert->conf_sigalgslen, 2)
+        || !TEST_int_eq(ctx->cert->conf_sigalgs[0], TLSEXT_SIGALG_rsa_pkcs1_sha256)
+        || !TEST_int_eq(ctx->cert->conf_sigalgs[1], TLSEXT_SIGALG_rsa_pkcs1_sha512))
+        goto end;
+
+    if (!TEST_int_gt(SSL_CTX_set1_client_sigalgs_list(ctx,
+                                                      "RSA+SHA256:nonexistent:RSA+SHA512"),
+                                                      0))
+        goto end;
+    if (!TEST_size_t_eq(ctx->cert->client_sigalgslen, 2)
+        || !TEST_int_eq(ctx->cert->client_sigalgs[0], TLSEXT_SIGALG_rsa_pkcs1_sha256)
+        || !TEST_int_eq(ctx->cert->client_sigalgs[1], TLSEXT_SIGALG_rsa_pkcs1_sha512))
+        goto end;
+
+    if (!TEST_int_le(SSL_CTX_set1_groups_list(ctx,
+                                              "nonexistent"),
+                                              0))
+        goto end;
+
+#ifndef OPENSSL_NO_EC
+    if (!TEST_int_gt(SSL_CTX_set1_groups_list(ctx,
+                                              "P-384:nonexistent:P-521"),
+                                              0))
+        goto end;
+    if (!TEST_size_t_eq(ctx->ext.supportedgroups_len, 2)
+        || !TEST_int_eq(ctx->ext.supportedgroups[0], OSSL_TLS_GROUP_ID_secp384r1)
+        || !TEST_int_eq(ctx->ext.supportedgroups[1], OSSL_TLS_GROUP_ID_secp521r1))
+        goto end;
+#endif
+
+    ret = 1;
+ end:
+    SSL_CTX_free(ctx);
+    return ret;
+}
+
 #if !defined(OPENSSL_NO_EC) \
     && (!defined(OSSL_NO_USABLE_TLS1_3) || !defined(OPENSSL_NO_TLS1_2))
 /*
@@ -11732,6 +11781,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_multiblock_write, OSSL_NELEM(multiblock_cipherlist_data));
 #endif
     ADD_ALL_TESTS(test_servername, 10);
+    ADD_TEST(test_unknown_sigalgs_groups);
 #if !defined(OPENSSL_NO_EC) \
     && (!defined(OSSL_NO_USABLE_TLS1_3) || !defined(OPENSSL_NO_TLS1_2))
     ADD_ALL_TESTS(test_sigalgs_available, 6);


### PR DESCRIPTION
Related to #20789
    
Unknown signature algorithms and groups in the configuration should not be fatal errors. The handling should be similar to handling of ciphers. I.e., there should be a failure only in case the configuration produces no valid sigalgs or groups.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
