### PR TITLE
Ignore OSSL_MAC_PARAM_DIGEST_NOINIT/OSSL_MAC_PARAM_DIGEST_ONESHOT

### DIFF
--- a/doc/man3/EVP_MAC.pod
+++ b/doc/man3/EVP_MAC.pod
@@ -279,14 +279,16 @@ This option is used by KMAC.
 A simple flag to set the MAC digest to not initialise the
 implementation specific data. The value 0 or 1 is expected.
 
-This option is used by HMAC.
+This option is deprecated and will be removed in a future release.
+The option may be set, but is ignored.
 
 =item "digest-oneshot" (B<OSSL_MAC_PARAM_DIGEST_ONESHOT>) <integer>
 
 A simple flag to set the MAC digest to be a oneshot operation.
 The value 0 or 1 is expected.
 
-This option is used by HMAC.
+This option is deprecated and will be removed in a future release.
+The option may be set, but is ignored.
 
 =item "properties" (B<OSSL_MAC_PARAM_PROPERTIES>) <UTF8 string>
 

--- a/doc/man7/EVP_MAC-HMAC.pod
+++ b/doc/man7/EVP_MAC-HMAC.pod
@@ -51,11 +51,15 @@ B<OSSL_MAC_PARAM_DIGEST>) to be considered valid.
 A flag to set the MAC digest to not initialise the implementation
 specific data.
 The value 0 or 1 is expected.
+This option is deprecated and will be removed in a future release.
+It may be set but is currently ignored
 
 =item "digest-oneshot" (B<OSSL_MAC_PARAM_DIGEST_ONESHOT>) <integer>
 
 A flag to set the MAC digest to be a one-shot operation.
 The value 0 or 1 is expected.
+This option is deprecated and will be removed in a future release.
+It may be set but is currently ignored.
 
 =item "tls-data-size" (B<OSSL_MAC_PARAM_TLS_DATA_SIZE>) <unsigned integer>
 

--- a/providers/implementations/macs/hmac_prov.c
+++ b/providers/implementations/macs/hmac_prov.c
@@ -274,23 +274,6 @@ static const OSSL_PARAM *hmac_settable_ctx_params(ossl_unused void *ctx,
     return known_settable_ctx_params;
 }
 
-static int set_flag(const OSSL_PARAM params[], const char *key, int mask,
-                    int *flags)
-{
-    const OSSL_PARAM *p = OSSL_PARAM_locate_const(params, key);
-    int flag = 0;
-
-    if (p != NULL) {
-        if (!OSSL_PARAM_get_int(p, &flag))
-            return 0;
-        if (flag == 0)
-            *flags &= ~mask;
-        else
-            *flags |= mask;
-    }
-    return 1;
-}
-
 /*
  * ALL parameters should be set before init().
  */
@@ -299,22 +282,12 @@ static int hmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
     struct hmac_data_st *macctx = vmacctx;
     OSSL_LIB_CTX *ctx = PROV_LIBCTX_OF(macctx->provctx);
     const OSSL_PARAM *p;
-    int flags = 0;
 
     if (params == NULL)
         return 1;
 
     if (!ossl_prov_digest_load_from_params(&macctx->digest, params, ctx))
         return 0;
-
-    if (!set_flag(params, OSSL_MAC_PARAM_DIGEST_NOINIT, EVP_MD_CTX_FLAG_NO_INIT,
-                  &flags))
-        return 0;
-    if (!set_flag(params, OSSL_MAC_PARAM_DIGEST_ONESHOT, EVP_MD_CTX_FLAG_ONESHOT,
-                  &flags))
-        return 0;
-    if (flags)
-        HMAC_CTX_set_flags(macctx->ctx, flags);
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_MAC_PARAM_KEY)) != NULL) {
         if (p->data_type != OSSL_PARAM_OCTET_STRING)


### PR DESCRIPTION
The hmac flags OSSL_MAC_PARAM_DIGEST_NOINIT and
OSSL_MAC_PARAM_DIGEST_ONESHOT dont add any real value to the provider, and the former causes a segfault when the provider attempts to call EVP_MAC_init on an EVP_MAC object that has been instructed not to be initalized (as the update function will not have been set in the MAC object, which is unilaterally called from EVP_MAC_init

Remove the tests for the above flags, and document them as being deprecated and ignored.


##### Checklist
- [x] documentation is added or updated
