### PR TITLE
apps: Don't print hostname on bio_out during connect.

### DIFF
--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -208,7 +208,7 @@ int init_client(int *sock, const char *host, const char *port,
 
         hostname = BIO_ADDR_hostname_string(BIO_ADDRINFO_address(ai), 1);
         if (hostname != NULL) {
-            BIO_printf(bio_out, "Connecting to %s\n", hostname);
+            BIO_printf(bio_err, "Connecting to %s\n", hostname);
             OPENSSL_free(hostname);
         }
         /* Remove any stale errors from previous connection attempts */


### PR DESCRIPTION
Printing the hostname on bio_out clutters the output and breaks pipe like forwarding via openssl.

Print the hostname via bio_err.

Fixes #23013