### PR TITLE
Fix instructions for filtering tests on Windows

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -42,7 +42,7 @@ the make variable TESTS to specify them, like this:
 
     $ make TESTS='test_rsa test_dsa' test            # Unix
     $ mms/macro="TESTS=test_rsa test_dsa" test       ! OpenVMS
-    $ nmake TESTS='test_rsa test_dsa' test           # Windows
+    $ nmake TESTS="test_rsa test_dsa" test           # Windows
 
 And of course, you can combine (Unix examples shown):
 


### PR DESCRIPTION
In the command `nmake TEST='foo' test`, on Windows the runner will look for test `'foo'` and complain about the test not being found (due to the extraneous single quotes), whereas with `nmake TEST="foo" test`, the test `foo` will be correctly found

CLA: trivial