### PR TITLE
Revert "Improved detection of engine-provided private "classic" keys"

### DIFF
--- a/crypto/engine/eng_pkey.c
+++ b/crypto/engine/eng_pkey.c
@@ -79,48 +79,6 @@ EVP_PKEY *ENGINE_load_private_key(ENGINE *e, const char *key_id,
         ERR_raise(ERR_LIB_ENGINE, ENGINE_R_FAILED_LOADING_PRIVATE_KEY);
         return NULL;
     }
-    /* We enforce check for legacy key */
-    switch (EVP_PKEY_get_id(pkey)) {
-    case EVP_PKEY_RSA:
-        {
-        RSA *rsa = EVP_PKEY_get1_RSA(pkey);
-        EVP_PKEY_set1_RSA(pkey, rsa);
-        RSA_free(rsa);
-        }
-        break;
-#  ifndef OPENSSL_NO_EC
-    case EVP_PKEY_SM2:
-    case EVP_PKEY_EC:
-        {
-        EC_KEY *ec = EVP_PKEY_get1_EC_KEY(pkey);
-        EVP_PKEY_set1_EC_KEY(pkey, ec);
-        EC_KEY_free(ec);
-        }
-        break;
-#  endif
-#  ifndef OPENSSL_NO_DSA
-    case EVP_PKEY_DSA:
-        {
-        DSA *dsa = EVP_PKEY_get1_DSA(pkey);
-        EVP_PKEY_set1_DSA(pkey, dsa);
-        DSA_free(dsa);
-        }
-        break;
-#endif
-#  ifndef OPENSSL_NO_DH
-    case EVP_PKEY_DH:
-        {
-        DH *dh = EVP_PKEY_get1_DH(pkey);
-        EVP_PKEY_set1_DH(pkey, dh);
-        DH_free(dh);
-        }
-        break;
-#endif
-    default:
-        /*Do nothing */
-        break;
-    }
-
     return pkey;
 }
 

--- a/doc/man7/ossl-guide-migration.pod
+++ b/doc/man7/ossl-guide-migration.pod
@@ -157,12 +157,13 @@ To ensure the future compatibility, the engines should be turned to providers.
 To prefer the provider-based hardware offload, you can specify the default
 properties to prefer your provider.
 
-Setting engine-based default low-level crypto method such as B<RSA_METHOD> or
-B<EC_KEY_METHOD> is still possible and keys inside the default provider will
-use the engine-based implementation for the crypto operations. However
-B<EVP_PKEY>s created in such circumstances will be provider-based. To create
-a fully legacy B<EVP_PKEY>s L<EVP_PKEY_set1_RSA(3)>,
-L<EVP_PKEY_set1_EC_KEY(3)> or similar functions must be used.
+Setting engine-based or application-based default low-level crypto method such
+as B<RSA_METHOD> or B<EC_KEY_METHOD> is still possible and keys inside the
+default provider will use the engine-based implementation for the crypto
+operations. However B<EVP_PKEY>s created by decoding by using B<OSSL_DECODER>,
+B<PEM_> or B<d2i_> APIs will be provider-based. To create a fully legacy
+B<EVP_PKEY>s L<EVP_PKEY_set1_RSA(3)>, L<EVP_PKEY_set1_EC_KEY(3)> or similar
+functions must be used.
 
 =head3 Versioning Scheme
 

--- a/doc/man7/ossl-guide-migration.pod
+++ b/doc/man7/ossl-guide-migration.pod
@@ -157,6 +157,13 @@ To ensure the future compatibility, the engines should be turned to providers.
 To prefer the provider-based hardware offload, you can specify the default
 properties to prefer your provider.
 
+Setting engine-based default low-level crypto method such as B<RSA_METHOD> or
+B<EC_KEY_METHOD> is still possible and keys inside the default provider will
+use the engine-based implementation for the crypto operations. However
+B<EVP_PKEY>s created in such circumstances will be provider-based. To create
+a fully legacy B<EVP_PKEY>s L<EVP_PKEY_set1_RSA(3)>,
+L<EVP_PKEY_set1_EC_KEY(3)> or similar functions must be used.
+
 =head3 Versioning Scheme
 
 The OpenSSL versioning scheme has changed with the OpenSSL 3.0 release. The new


### PR DESCRIPTION
The commit was wrong. With 3.x versions the engines are responsible for creating their EVP_PKEYs in a way that they are legacy. The fix has caused more problems than it solved.

This reverts commit 2b74e75331a27fc89cad9c8ea6a26c70019300b5.

Fixes #22945
