### PR TITLE
Define L_ENDIAN for linux64-loongarch64

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -821,12 +821,13 @@ my %targets = (
         asm_arch         => 'riscv32',
     },
 
-    # loongarch64 below refers to contemporary LOONGARCH Architecture
+    # loongarch64 below refers to contemporary LoongArch Architecture
     # specifications,
     "linux64-loongarch64" => {
         inherit_from     => [ "linux-generic64"],
         perlasm_scheme   => "linux64",
         asm_arch         => 'loongarch64',
+        lib_cppflags     => add("-DL_ENDIAN"),
     },
 
     #### IA-32 targets...


### PR DESCRIPTION
In commit d7c0fc5b1a7b5cb2219f8d89a861f3879582fc16 we removed L_ENDIAN definition for guessed linux64-loongarch64 as it had caused an inconsistency between configurations with and without explicit specifying linux64-loongarch64.  Now add it back to the proper location.

Unlike MIPS or RISC-V, LoongArch is always little-endian [1].

By the way, change "LOONGARCH" to "LoongArch" in a comment as LOONGARCH should only appear in the identifiers of macros, constants, etc.

[1]:https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html#endian