### PR TITLE
doc: fix "the a" typos

### DIFF
--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -237,12 +237,12 @@ This sets the RSA padding mode. Acceptable values for I<mode> are B<pkcs1> for
 PKCS#1 padding, B<none> for no padding, B<oaep>
 for B<OAEP> mode, B<x931> for X9.31 mode and B<pss> for PSS.
 
-In PKCS#1 padding if the message digest is not set then the supplied data is
+In PKCS#1 padding, if the message digest is not set, then the supplied data is
 signed or verified directly instead of using a B<DigestInfo> structure. If a
-digest is set then the a B<DigestInfo> structure is used and its the length
+digest is set, then the B<DigestInfo> structure is used and its length
 must correspond to the digest type.
 
-Note, for B<pkcs1> padding, as a protection against Bleichenbacher attack,
+Note, for B<pkcs1> padding, as a protection against the Bleichenbacher attack,
 the decryption will not fail in case of padding check failures. Use B<none>
 and manual inspection of the decrypted message to verify if the decrypted
 value has correct PKCS#1 v1.5 padding.

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -289,7 +289,7 @@ It is implied by the B<-CA> option.
 This option implies the B<-new> flag if B<-in> is not given.
 
 If an existing request is specified with the B<-in> option, it is converted
-to the a certificate; otherwise a request is created from scratch.
+to a certificate; otherwise a request is created from scratch.
 
 Unless specified using the B<-set_serial> option,
 a large random number will be used for the serial number.

--- a/doc/man3/BIO_f_md.pod
+++ b/doc/man3/BIO_f_md.pod
@@ -36,7 +36,7 @@ BIO_set_md() sets the message digest of BIO B<b> to B<md>: this
 must be called to initialize a digest BIO before any data is
 passed through it. It is a BIO_ctrl() macro.
 
-BIO_get_md() places the a pointer to the digest BIOs digest method
+BIO_get_md() places a pointer to the digest BIOs digest method
 in B<mdp>, it is a BIO_ctrl() macro.
 
 BIO_get_md_ctx() returns the digest BIOs context into B<mdcp>.

--- a/doc/man3/BIO_f_md.pod
+++ b/doc/man3/BIO_f_md.pod
@@ -19,7 +19,7 @@ BIO_f_md, BIO_set_md, BIO_get_md, BIO_get_md_ctx - message digest BIO filter
 =head1 DESCRIPTION
 
 BIO_f_md() returns the message digest BIO method. This is a filter
-BIO that digests any data passed through it, it is a BIO wrapper
+BIO that digests any data passed through it.  It is a BIO wrapper
 for the digest routines EVP_DigestInit(), EVP_DigestUpdate()
 and EVP_DigestFinal().
 
@@ -37,7 +37,7 @@ must be called to initialize a digest BIO before any data is
 passed through it. It is a BIO_ctrl() macro.
 
 BIO_get_md() places a pointer to the digest BIOs digest method
-in B<mdp>, it is a BIO_ctrl() macro.
+in B<mdp>.  It is a BIO_ctrl() macro.
 
 BIO_get_md_ctx() returns the digest BIOs context into B<mdcp>.
 

--- a/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
@@ -42,8 +42,8 @@ ticket construction state according to RFC5077 Section 4 such that per session
 state is unnecessary and a small set of cryptographic variables needs to be
 maintained by the callback function implementation.
 
-In order to reuse a session, a TLS client must send the a session ticket
-extension to the server. The client can only send exactly one session ticket.
+In order to reuse a session, a TLS client must send the session ticket
+extension to the server. The client must send exactly one session ticket.
 The server, through the callback function, either agrees to reuse the session
 ticket information or it starts a full TLS handshake to create a new session
 ticket.


### PR DESCRIPTION
I grepped for "the a " and found a few typos in the documentation.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
