### PR TITLE
Add cleanup and construct NULL check to OSSL_ENCODER_to_bio()

### DIFF
--- a/crypto/encode_decode/encoder_lib.c
+++ b/crypto/encode_decode/encoder_lib.c
@@ -399,6 +399,11 @@ static int encoder_process(struct encoder_process_data_st *data)
     int ok = -1;  /* -1 signifies that the lookup loop gave nothing */
     int top = 0;
 
+    if (data->ctx->cleanup == NULL) {
+        ERR_raise(ERR_LIB_OSSL_ENCODER, ERR_R_INVALID_PROVIDER_FUNCTIONS);
+        return -1;
+    }
+
     if (data->next_encoder_inst == NULL) {
         /* First iteration, where we prepare for what is to come */
 

--- a/crypto/encode_decode/encoder_lib.c
+++ b/crypto/encode_decode/encoder_lib.c
@@ -59,6 +59,11 @@ int OSSL_ENCODER_to_bio(OSSL_ENCODER_CTX *ctx, BIO *out)
         return 0;
     }
 
+    if (ctx->cleanup == NULL || ctx->construct == NULL) {
+        ERR_raise(ERR_LIB_OSSL_ENCODER, ERR_R_INIT_FAIL);
+        return 0;
+    }
+
     return encoder_process(&data) > 0;
 }
 
@@ -398,11 +403,6 @@ static int encoder_process(struct encoder_process_data_st *data)
     int i;
     int ok = -1;  /* -1 signifies that the lookup loop gave nothing */
     int top = 0;
-
-    if (data->ctx->cleanup == NULL) {
-        ERR_raise(ERR_LIB_OSSL_ENCODER, ERR_R_INVALID_PROVIDER_FUNCTIONS);
-        return -1;
-    }
 
     if (data->next_encoder_inst == NULL) {
         /* First iteration, where we prepare for what is to come */


### PR DESCRIPTION
Add checks for full context mgmt in kdf provider loading
    
    Docs for kdf providers indicate that the following methods are needed
    for a kdf provider:
    OSSL_FUNC_kdf_newctx(),
    OSSL_FUNC_kdf_freectx(),
    OSSL_FUNC_kdf_set_ctx_params()
    OSSL_FUNC_kdf_derive()
    
    The kdf-meth code path didn't check for all of them, nor did it check to
    make sure the the function pointers associated with their method id's
    were null after assignment.
    
    Update evp_kdf_from_algorithm to check for the full suite of
    requirements, and ensure they are not null post assignment.

Additionally
    Check for NULL cleanup function before using it in encoder_process
    
    encoder_process assumes a cleanup function has been set in the currently
    in-use encoder during processing, which can lead to segfaults if said
    function hasn't been set
    
    Add a NULL check for this condition, returning -1 if it is not set and
    add positive/negative tests to ensure it works properly
##### Checklist
- [] tests are added or updated
