### PR TITLE
Update des_cfb1_cipher function to fix uninitialized variables issue.

### DIFF
--- a/crypto/evp/e_des.c
+++ b/crypto/evp/e_des.c
@@ -149,7 +149,7 @@ static int des_cfb1_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                            const unsigned char *in, size_t inl)
 {
     size_t n, chunk = EVP_MAXCHUNK / 8;
-    unsigned char c[1], d[1];
+    unsigned char c[1] = {0}, d[1] = {0};
 
     if (inl < chunk)
         chunk = inl;


### PR DESCRIPTION
Fix uninitialized variables issue.
character array is not initialized. It may contain garbage value.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
