### PR TITLE
Update IPAddressOrRange_cmp function to handle switch case[CLA: trivial]

### DIFF
--- a/crypto/x509/v3_addr.c
+++ b/crypto/x509/v3_addr.c
@@ -300,6 +300,8 @@ static int IPAddressOrRange_cmp(const IPAddressOrRange *a,
             return -1;
         prefixlen_a = length * 8;
         break;
+    default:
+        return -1;
     }
 
     switch (b->type) {
@@ -313,6 +315,8 @@ static int IPAddressOrRange_cmp(const IPAddressOrRange *a,
             return -1;
         prefixlen_b = length * 8;
         break;
+    default:
+        return -1;
     }
 
     if ((r = memcmp(addr_a, addr_b, length)) != 0)


### PR DESCRIPTION
As there is no default case for a->type or b->type in the switch() statements, If the code does not fail to any case then memcmp() will be done on garbage data. This will encounter the incorrect return of the function. So I initialize the char array.

So, adding default case in switch.
[CLA: trivial]
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
