### PR TITLE
Fix no-des failure in test_cms

### DIFF
--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -1193,7 +1193,7 @@ subtest "encrypt to three recipients with RSA-OAEP, key only decrypt" => sub {
 
     ok(run(app(['openssl', 'cms',
 		@defaultprov,
-		'-encrypt',
+		'-encrypt', '-aes128',
 		'-in', $pt,
 		'-out', $ct,
 		'-stream',
@@ -1207,7 +1207,7 @@ subtest "encrypt to three recipients with RSA-OAEP, key only decrypt" => sub {
        "encrypt to three recipients with RSA-OAEP (avoid openssl/project issue#380)");
     ok(run(app(['openssl', 'cms',
 		@defaultprov,
-		'-decrypt',
+		'-decrypt', '-aes128',
 		'-in', $ct,
 		'-out', $ptpt,
 		'-inkey', catfile($smdir, "smrsa3-key.pem"),


### PR DESCRIPTION
The newly introduced test case do not work
when configured with no-des, fix that by
choosing -aes128 as cipher.

Fixes ffed597882ba ("cms: avoid intermittent test failure")
