### PR TITLE
Fixed windows compilation issue

### DIFF
--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -10,6 +10,7 @@
 # define OSSL_INTERNAL_REFCOUNT_H
 # pragma once
 
+# include <assert.h>
 # include <openssl/e_os2.h>
 # include <openssl/trace.h>
 
@@ -134,6 +135,7 @@ static __inline int CRYPTO_DOWN_REF(volatile int *val, int *ret,
 static __inline int CRYPTO_UP_REF(volatile int *val, int *ret,
                                   ossl_unused void *lock)
 {
+    assert(sizeof(int) == sizeof(long));
     *ret = _InterlockedExchangeAdd((long volatile *)val, 1) + 1;
     return 1;
 }
@@ -141,6 +143,7 @@ static __inline int CRYPTO_UP_REF(volatile int *val, int *ret,
 static __inline int CRYPTO_DOWN_REF(volatile int *val, int *ret,
                                     ossl_unused void *lock)
 {
+    assert(sizeof(int) == sizeof(long));
     *ret = _InterlockedExchangeAdd((long volatile *)val, -1) - 1;
     return 1;
 }

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -134,14 +134,14 @@ static __inline int CRYPTO_DOWN_REF(volatile int *val, int *ret,
 static __inline int CRYPTO_UP_REF(volatile int *val, int *ret,
                                   ossl_unused void *lock)
 {
-    *ret = _InterlockedExchangeAdd((long volatile*) val, 1) + 1;
+    *ret = _InterlockedExchangeAdd((long volatile *)val, 1) + 1;
     return 1;
 }
 
 static __inline int CRYPTO_DOWN_REF(volatile int *val, int *ret,
                                     ossl_unused void *lock)
 {
-    *ret = _InterlockedExchangeAdd((long volatile*) val, -1) - 1;
+    *ret = _InterlockedExchangeAdd((long volatile *)val, -1) - 1;
     return 1;
 }
 #   endif

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -134,14 +134,14 @@ static __inline int CRYPTO_DOWN_REF(volatile int *val, int *ret,
 static __inline int CRYPTO_UP_REF(volatile int *val, int *ret,
                                   ossl_unused void *lock)
 {
-    *ret = _InterlockedExchangeAdd(val, 1) + 1;
+    *ret = _InterlockedExchangeAdd((long volatile*) val, 1) + 1;
     return 1;
 }
 
 static __inline int CRYPTO_DOWN_REF(volatile int *val, int *ret,
                                     ossl_unused void *lock)
 {
-    *ret = _InterlockedExchangeAdd(val, -1) - 1;
+    *ret = _InterlockedExchangeAdd((long volatile*) val, -1) - 1;
     return 1;
 }
 #   endif

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -10,7 +10,6 @@
 # define OSSL_INTERNAL_REFCOUNT_H
 # pragma once
 
-# include <assert.h>
 # include <openssl/e_os2.h>
 # include <openssl/trace.h>
 
@@ -135,7 +134,6 @@ static __inline int CRYPTO_DOWN_REF(volatile int *val, int *ret,
 static __inline int CRYPTO_UP_REF(volatile int *val, int *ret,
                                   ossl_unused void *lock)
 {
-    assert(sizeof(int) == sizeof(long));
     *ret = _InterlockedExchangeAdd((long volatile *)val, 1) + 1;
     return 1;
 }
@@ -143,7 +141,6 @@ static __inline int CRYPTO_UP_REF(volatile int *val, int *ret,
 static __inline int CRYPTO_DOWN_REF(volatile int *val, int *ret,
                                     ossl_unused void *lock)
 {
-    assert(sizeof(int) == sizeof(long));
     *ret = _InterlockedExchangeAdd((long volatile *)val, -1) - 1;
     return 1;
 }


### PR DESCRIPTION
Fixed - Windows compilation issue - unbale to find correct definitions of _InterlockedExchangeAdd. Issue number - https://github.com/openssl/openssl/issues/21080 

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
