### PR TITLE
Fix potential UAF when duplicating the sig ctx

### DIFF
--- a/providers/implementations/signature/dsa_sig.c
+++ b/providers/implementations/signature/dsa_sig.c
@@ -98,7 +98,6 @@ typedef struct {
 
     /* The Algorithm Identifier of the combined signature algorithm */
     unsigned char aid_buf[OSSL_MAX_ALGORITHM_ID_SIZE];
-    unsigned char *aid;
     size_t  aid_len;
 
     /* main digest */
@@ -160,6 +159,7 @@ static int dsa_setup_md(PROV_DSA_CTX *ctx,
         WPACKET pkt;
         int md_nid;
         size_t mdname_len = strlen(mdname);
+        unsigned char *aid = NULL;
 
         md = EVP_MD_fetch(ctx->libctx, mdname, mdprops);
         md_nid = ossl_digest_get_approved_nid(md);
@@ -223,9 +223,11 @@ static int dsa_setup_md(PROV_DSA_CTX *ctx,
                                                           md_nid)
             && WPACKET_finish(&pkt)) {
             WPACKET_get_total_written(&pkt, &ctx->aid_len);
-            ctx->aid = WPACKET_get_curr(&pkt);
+            aid = WPACKET_get_curr(&pkt);
         }
         WPACKET_cleanup(&pkt);
+        if (aid != NULL && ctx->aid_len != 0)
+            memmove(ctx->aid_buf, aid, ctx->aid_len);
 
         ctx->mdctx = NULL;
         ctx->md = md;
@@ -674,7 +676,9 @@ static int dsa_get_ctx_params(void *vpdsactx, OSSL_PARAM *params)
 
     p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_ALGORITHM_ID);
     if (p != NULL
-        && !OSSL_PARAM_set_octet_string(p, pdsactx->aid, pdsactx->aid_len))
+        && !OSSL_PARAM_set_octet_string(p,
+                                        pdsactx->aid_len == 0 ? NULL : pdsactx->aid_buf,
+                                        pdsactx->aid_len))
         return 0;
 
     p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_DIGEST);

--- a/providers/implementations/signature/ecdsa_sig.c
+++ b/providers/implementations/signature/ecdsa_sig.c
@@ -95,7 +95,6 @@ typedef struct {
 
     /* The Algorithm Identifier of the combined signature algorithm */
     unsigned char aid_buf[OSSL_MAX_ALGORITHM_ID_SIZE];
-    unsigned char *aid;
     size_t  aid_len;
 
     /* main digest */
@@ -172,6 +171,7 @@ static int ecdsa_setup_md(PROV_ECDSA_CTX *ctx,
     size_t mdname_len;
     int md_nid, md_size;
     WPACKET pkt;
+    unsigned char *aid = NULL;
 
     if (mdname == NULL)
         return 1;
@@ -242,9 +242,12 @@ static int ecdsa_setup_md(PROV_ECDSA_CTX *ctx,
                                                         md_nid)
         && WPACKET_finish(&pkt)) {
         WPACKET_get_total_written(&pkt, &ctx->aid_len);
-        ctx->aid = WPACKET_get_curr(&pkt);
+        aid = WPACKET_get_curr(&pkt);
     }
     WPACKET_cleanup(&pkt);
+    if (aid != NULL && ctx->aid_len != 0)
+        memmove(ctx->aid_buf, aid, ctx->aid_len);
+
     ctx->mdctx = NULL;
     ctx->md = md;
     ctx->mdsize = (size_t)md_size;
@@ -670,7 +673,9 @@ static int ecdsa_get_ctx_params(void *vctx, OSSL_PARAM *params)
         return 0;
 
     p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_ALGORITHM_ID);
-    if (p != NULL && !OSSL_PARAM_set_octet_string(p, ctx->aid, ctx->aid_len))
+    if (p != NULL && !OSSL_PARAM_set_octet_string(p,
+                                                  ctx->aid_len == 0 ? NULL : ctx->aid_buf,
+                                                  ctx->aid_len))
         return 0;
 
     p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_DIGEST_SIZE);

--- a/providers/implementations/signature/sm2_sig.c
+++ b/providers/implementations/signature/sm2_sig.c
@@ -77,7 +77,6 @@ typedef struct {
 
     /* The Algorithm Identifier of the combined signature algorithm */
     unsigned char aid_buf[OSSL_MAX_ALGORITHM_ID_SIZE];
-    unsigned char *aid;
     size_t  aid_len;
 
     /* main digest */
@@ -213,6 +212,7 @@ static int sm2sig_digest_signverify_init(void *vpsm2ctx, const char *mdname,
     int md_nid;
     WPACKET pkt;
     int ret = 0;
+    unsigned char *aid = NULL;
 
     if (!sm2sig_signature_init(vpsm2ctx, ec, params)
         || !sm2sig_set_mdname(ctx, mdname))
@@ -238,9 +238,11 @@ static int sm2sig_digest_signverify_init(void *vpsm2ctx, const char *mdname,
         && ossl_DER_w_algorithmIdentifier_SM2_with_MD(&pkt, -1, ctx->ec, md_nid)
         && WPACKET_finish(&pkt)) {
         WPACKET_get_total_written(&pkt, &ctx->aid_len);
-        ctx->aid = WPACKET_get_curr(&pkt);
+        aid = WPACKET_get_curr(&pkt);
     }
     WPACKET_cleanup(&pkt);
+    if (aid != NULL && ctx->aid_len != 0)
+        memmove(ctx->aid_buf, aid, ctx->aid_len);
 
     if (!EVP_DigestInit_ex2(ctx->mdctx, ctx->md, params))
         goto error;
@@ -404,7 +406,9 @@ static int sm2sig_get_ctx_params(void *vpsm2ctx, OSSL_PARAM *params)
 
     p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_ALGORITHM_ID);
     if (p != NULL
-        && !OSSL_PARAM_set_octet_string(p, psm2ctx->aid, psm2ctx->aid_len))
+        && !OSSL_PARAM_set_octet_string(p,
+                                        psm2ctx->aid_len == 0 ? NULL : psm2ctx->aid_buf,
+                                        psm2ctx->aid_len))
         return 0;
 
     p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_DIGEST_SIZE);


### PR DESCRIPTION
When copy the signature context, dstctx->aid points to srcctx->aid_buf, which is dangerous and may cause Use-After-Free.
The affected functions is dsa_dupctx, ecdsa_dupctx, eddsa_dupctx, sm2sig_dupctx.

Now I set dstctx->aid using pointer offset. Of course, aid-related information can also be recalculated for dstctx. Which is better?