### PR TITLE
Optimize circular buffer to avoid modulo[CLA: trivial]

### DIFF
--- a/crypto/bio/bio_dump.c
+++ b/crypto/bio/bio_dump.c
@@ -141,9 +141,10 @@ int BIO_hex_string(BIO *out, int indent, int width, const void *data,
 
         BIO_printf(out, "%02X:", d[i]);
 
-        j = (j + 1) % width;
-        if (!j)
+        if (++j >= width) {
+            j = 0;
             BIO_printf(out, "\n");
+        }
     }
 
     if (i && !j)


### PR DESCRIPTION
[CLA: trivial]

Avoid doing the division via modulo where possible.