### PR TITLE
Remove uneeded cast to unsigned int[CLA: trivial]

### DIFF
--- a/engines/e_devcrypto.c
+++ b/engines/e_devcrypto.c
@@ -334,7 +334,7 @@ static int ctr_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     }
 
     /* full blocks */
-    if (inl > (unsigned int) cipher_ctx->blocksize) {
+    if (inl > cipher_ctx->blocksize) {
         nblocks = inl/cipher_ctx->blocksize;
         len = nblocks * cipher_ctx->blocksize;
         if (cipher_do_cipher(ctx, out, in, len) < 1)


### PR DESCRIPTION
CLA: trivial

cipher_ctx->blocksize is already unsigned.