### PR TITLE
evp_test.c: Fix provider compat tests CI failure

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -1516,7 +1516,9 @@ static int mac_test_run_mac(EVP_TEST *t)
         t->err = "MAC_CREATE_ERROR";
         goto err;
     }
-    if (fips_provider_version_gt(libctx, 3, 1, 4))
+    if (fips_provider_version_gt(libctx, 3, 1, 4)
+        || (fips_provider_version_lt(libctx, 3, 1, 0)
+            && fips_provider_version_gt(libctx, 3, 0, 12)))
         size_before_init = EVP_MAC_CTX_get_mac_size(ctx);
     if (!EVP_MAC_init(ctx, expected->key, expected->key_len, params)) {
         t->err = "MAC_INIT_ERROR";

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -1516,7 +1516,7 @@ static int mac_test_run_mac(EVP_TEST *t)
         t->err = "MAC_CREATE_ERROR";
         goto err;
     }
-    if (fips_provider_version_gt(libctx, 3, 0, 12))
+    if (fips_provider_version_gt(libctx, 3, 1, 4))
         size_before_init = EVP_MAC_CTX_get_mac_size(ctx);
     if (!EVP_MAC_init(ctx, expected->key, expected->key_len, params)) {
         t->err = "MAC_INIT_ERROR";


### PR DESCRIPTION
As in the provider compatibility tests we also run the 3.1.2 fips provider against the up-to-date 3.0 branch the CI would still fail as 3.1.2 provider would be expected to pass this check.

Update the required fips provider version to be >3.1.4 instead.
