### PR TITLE
Improve the documentation on TLS record compression

### DIFF
--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -630,7 +630,11 @@ Disables support for receiving TLSv1.3 compressed certificate.
 Enables support for SSL/TLS compression.
 This option was introduced in OpenSSL 1.1.0.
 TLS compression is not recommended and is off by default as of
-OpenSSL 1.1.0.
+OpenSSL 1.1.0. TLS compression can only be used in security level 1 or
+lower. From OpenSSL 3.2.0 and above the default security level is 2, so this
+option will have no effect without also changing the security level. Use the
+B<-cipher> option to change the security level. See L<openssl-ciphers(1)> for
+more information.
 
 =item B<-no_comp>
 

--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -627,10 +627,14 @@ OpenSSL 1.1.0.
 
 =item B<-comp>
 
-Enable negotiation of TLS compression.
+Enables support for SSL/TLS compression.
 This option was introduced in OpenSSL 1.1.0.
 TLS compression is not recommended and is off by default as of
-OpenSSL 1.1.0.
+OpenSSL 1.1.0. TLS compression can only be used in security level 1 or
+lower. From OpenSSL 3.2.0 and above the default security level is 2, so this
+option will have no effect without also changing the security level. Use the
+B<-cipher> option to change the security level. See L<openssl-ciphers(1)> for
+more information.
 
 =item B<-no_ticket>
 

--- a/doc/man3/COMP_CTX_new.pod
+++ b/doc/man3/COMP_CTX_new.pod
@@ -123,7 +123,8 @@ Zstandard may be found at L<https://github.com/facebook/zstd>.
 Compression of SSL/TLS records is not recommended, as it has been
 shown to lead to the CRIME attack L<https://en.wikipedia.org/wiki/CRIME>.
 It is disabled by default, and may be enabled by clearing the
-SSL_OP_NO_COMPRESSION options of the L<SSL_CTX_set_options(3)> or
+SSL_OP_NO_COMPRESSION option and setting the security level as appropriate.
+See the documentation for the L<SSL_CTX_set_options(3)> and
 L<SSL_set_options(3)> functions.
 
 Compression is also used to support certificate compression as described

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -46,7 +46,10 @@ As of OpenSSL 1.1.0, compression is off by default.
 Enables support for SSL/TLS compression, same as clearing
 B<SSL_OP_NO_COMPRESSION>.
 This command was introduced in OpenSSL 1.1.0.
-As of OpenSSL 1.1.0, compression is off by default.
+As of OpenSSL 1.1.0, compression is off by default. TLS compression can only be
+used in security level 1 or lower. From OpenSSL 3.2.0 and above the default
+security level is 2, so this option will have no effect without also changing
+the security level. See L<SSL_CTX_set_security_level(3)>.
 
 =item B<-no_ticket>
 

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -256,8 +256,12 @@ and compressed certificates will not be accepted from the peer.
 
 =item SSL_OP_NO_COMPRESSION
 
-Do not use compression even if it is supported. This option is set by default.
-To switch it off use SSL_clear_options().
+Do not use TLS record compression even if it is supported. This option is set by
+default. To switch it off use SSL_clear_options(). Note that TLS record
+compression is not recommended and is not available at security level 2 or
+above. From OpenSSL 3.2 the default security level is 2, so clearing this option
+will have no effect without also changing the default security level. See
+L<SSL_CTX_set_security_level(3)>.
 
 =item SSL_OP_NO_ENCRYPT_THEN_MAC
 


### PR DESCRIPTION
TLS record compression is off by default. Even if you switch it on, it cannot be used at security level 2 which is the default in OpenSSL 3.2 and above. Update the docs to point this out.