### PR TITLE
gate calling of evp_method_id on having a non-zero name id

### DIFF
--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -318,13 +318,26 @@ inner_evp_generic_fetch(struct evp_method_data_st *methdata,
              * there is a correct name_id and meth_id, since those have
              * already been calculated in get_evp_method_from_store() and
              * put_evp_method_in_store() above.
+             * Note that there is a corner case here, in which, if a user
+             * passes a name of the form name1:name2:..., then the construction
+             * will create a method against all names, but the lookup will fail
+             * as ossl_namemap_name2num treats the name string as a single name
+             * rather than introducing new features where in the EVP_<obj>_fetch
+             * parses the string and querys for each, return an error.
              */
             if (name_id == 0)
                 name_id = ossl_namemap_name2num(namemap, name);
-            meth_id = evp_method_id(name_id, operation_id);
-            if (name_id != 0)
-                ossl_method_store_cache_set(store, prov, meth_id, propq,
-                                            method, up_ref_method, free_method);
+            if (name_id == 0) {
+                ERR_raise_data(ERR_LIB_EVP, ERR_R_FETCH_FAILED,
+                               "Algorithm %s cannot be found", name);
+                free_method(method);
+                method = NULL;
+            } else {
+                meth_id = evp_method_id(name_id, operation_id);
+                if (name_id != 0)
+                    ossl_method_store_cache_set(store, prov, meth_id, propq,
+                                                method, up_ref_method, free_method);
+            }
         }
 
         /*

--- a/doc/man7/ossl-guide-libcrypto-introduction.pod
+++ b/doc/man7/ossl-guide-libcrypto-introduction.pod
@@ -88,6 +88,10 @@ L<OSSL_PROVIDER-FIPS(7)/OPERATIONS AND ALGORITHMS>,
 L<OSSL_PROVIDER-legacy(7)/OPERATIONS AND ALGORITHMS> and
 L<OSSL_PROVIDER-base(7)/OPERATIONS AND ALGORITHMS>.
 
+Note, while providers may register algorithms against a list of names using a
+string with a colon separated list of names, fetching algorithms using that
+format is currently unsupported.
+
 =item A property query string
 
 The property query string used to guide selection of the algorithm

--- a/test/evp_extra_test2.c
+++ b/test/evp_extra_test2.c
@@ -1336,7 +1336,7 @@ static int evp_test_name_parsing(void)
 {
     EVP_MD *md;
 
-    if (TEST_ptr(md = EVP_MD_fetch(mainctx, "SHA256:BogusName", NULL))) {
+    if (!TEST_ptr_null(md = EVP_MD_fetch(mainctx, "SHA256:BogusName", NULL))) {
         EVP_MD_free(md);
         return 0;
     }

--- a/test/evp_extra_test2.c
+++ b/test/evp_extra_test2.c
@@ -1326,6 +1326,24 @@ err:
 }
 #endif
 
+/*
+ * Currently, EVP_<OBJ>_fetch doesn't support
+ * colon separated alternative names for lookup
+ * so add a test here to ensure that when one is provided
+ * libcrypo returns an error
+ */
+static int evp_test_name_parsing(void)
+{
+    EVP_MD *md;
+
+    if (TEST_ptr(md = EVP_MD_fetch(NULL, "SHA256:BogusName", NULL))) {
+        EVP_MD_free(md);
+        return 0;
+    }
+
+    return 1;
+}
+
 int setup_tests(void)
 {
     if (!test_get_libctx(&mainctx, &nullprov, NULL, NULL, NULL)) {
@@ -1334,6 +1352,7 @@ int setup_tests(void)
         return 0;
     }
 
+    ADD_TEST(evp_test_name_parsing);
     ADD_TEST(test_alternative_default);
     ADD_ALL_TESTS(test_d2i_AutoPrivateKey_ex, OSSL_NELEM(keydata));
 #ifndef OPENSSL_NO_EC

--- a/test/evp_extra_test2.c
+++ b/test/evp_extra_test2.c
@@ -1330,13 +1330,13 @@ err:
  * Currently, EVP_<OBJ>_fetch doesn't support
  * colon separated alternative names for lookup
  * so add a test here to ensure that when one is provided
- * libcrypo returns an error
+ * libcrypto returns an error
  */
 static int evp_test_name_parsing(void)
 {
     EVP_MD *md;
 
-    if (TEST_ptr(md = EVP_MD_fetch(NULL, "SHA256:BogusName", NULL))) {
+    if (TEST_ptr(md = EVP_MD_fetch(mainctx, "SHA256:BogusName", NULL))) {
         EVP_MD_free(md);
         return 0;
     }

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -4148,24 +4148,6 @@ static int run_file_tests(int i)
     return c == 0;
 }
 
-/*
- * Currently, EVP_<OBJ>_fetch doesn't support
- * colon separated alternative names for lookup
- * so add a test here to ensure that when one is provided
- * libcrypo returns an error
- */
-static int evp_test_name_parsing(void)
-{
-    EVP_MD *md;
-
-    if (TEST_ptr(md = EVP_MD_fetch(libctx, "SHA256:BogusName", propquery))) {
-        EVP_MD_free(md);
-        return 0;
-    }
-
-    return 1;
-}
-
 const OPTIONS *test_get_options(void)
 {
     static const OPTIONS test_options[] = {
@@ -4229,7 +4211,6 @@ int setup_tests(void)
     if (n == 0)
         return 0;
 
-    ADD_TEST(evp_test_name_parsing);
     ADD_ALL_TESTS(run_file_tests, n);
     return 1;
 }

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -4148,6 +4148,24 @@ static int run_file_tests(int i)
     return c == 0;
 }
 
+/*
+ * Currently, EVP_<OBJ>_fetch doesn't support
+ * colon separated alternative names for lookup
+ * so add a test here to ensure that when one is provided
+ * libcrypo returns an error
+ */
+static int evp_test_name_parsing(void)
+{
+    EVP_MD *md;
+
+    if (TEST_ptr(md = EVP_MD_fetch(libctx, "SHA256:BogusName", propquery))) {
+        EVP_MD_free(md);
+        return 0;
+    }
+
+    return 1;
+}
+
 const OPTIONS *test_get_options(void)
 {
     static const OPTIONS test_options[] = {
@@ -4211,6 +4229,7 @@ int setup_tests(void)
     if (n == 0)
         return 0;
 
+    ADD_TEST(evp_test_name_parsing);
     ADD_ALL_TESTS(run_file_tests, n);
     return 1;
 }


### PR DESCRIPTION
If a name is passed to EVP_<OBJ>_fetch of the form: name1:name2:name3

The names are parsed on the separator ':' and added to the store, but during the lookup in inner_evp_generic_fetch, the subsequent search of the store uses the full name1:name2:name3 string, which fails lookup, and causes subsequent assertion failures in evp_method_id.

instead catch the failure in inner_evp_generic_fetch and return an error code if the name_id against a colon separated list of names fails.  This provides a graceful error return path without asserts, and leaves room for a future feature in which such formatted names can be parsed and searched for iteratively

Add a simple test to verify that providing a colon separated name results in an error indicating an invalid lookup.


##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated
