### PR TITLE
Fix remaining provider config settings to be decisive in value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,12 @@ OpenSSL 3.3
 
 ### Changes between 3.2 and 3.3 [xx XXX xxxx]
 
+ * In provider_conf_load, changed the soft_load setting to require a fixed set
+   of values to activate/deactivate (1/0, yes/no, true/false, on/off), in either
+   all lower or all uppercase.  All other values return an error.
+
+   *Neil Horman*
+
  * The activate configuration setting for providers in openssl.cnf has been
    updated to require a value of [1|yes|true|on] (in lower or UPPER case) to
    activate the provider.  Conversely a setting [0|no|false|off] will prevent

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,9 +28,9 @@ OpenSSL 3.3
 
 ### Changes between 3.2 and 3.3 [xx XXX xxxx]
 
- * The activate and soft_load configuration setting for providers in
-   openssl.cnf has been updated to require a value of [1|yes|true|on]
-   (in lower or UPPER case) to enable the setting. Conversely a setting
+ * The activate and soft_load configuration settings for providers in
+   openssl.cnf have been updated to require a value of [1|yes|true|on]
+   (in lower or UPPER case) to enable the setting. Conversely a value
    of [0|no|false|off] will disable the setting. All other values, or the
    omission of a value for these settings will result in an error.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,17 +28,11 @@ OpenSSL 3.3
 
 ### Changes between 3.2 and 3.3 [xx XXX xxxx]
 
- * In provider_conf_load, changed the soft_load setting to require a fixed set
-   of values to activate/deactivate (1/0, yes/no, true/false, on/off), in either
-   all lower or all uppercase.  All other values return an error.
-
-   *Neil Horman*
-
- * The activate configuration setting for providers in openssl.cnf has been
-   updated to require a value of [1|yes|true|on] (in lower or UPPER case) to
-   activate the provider.  Conversely a setting [0|no|false|off] will prevent
-   provider activation.  All other values, or the omission of a value for this
-   setting will result in an error.
+ * The activate and soft_load configuration setting for providers in
+   openssl.cnf has been updated to require a value of [1|yes|true|on]
+   (in lower or UPPER case) to enable the setting. Conversely a setting
+   of [0|no|false|off] will disable the setting. All other values, or the
+   omission of a value for these settings will result in an error.
 
     *Neil Horman*
 

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -203,6 +203,42 @@ static int provider_conf_activate(OSSL_LIB_CTX *libctx, const char *name,
     return ok;
 }
 
+static int provider_conf_parse_bool_setting(const char *confname,
+                                            const char *confvalue, int *val)
+{
+
+    if (confvalue == NULL) {
+        ERR_raise_data(ERR_LIB_CRYPTO, CRYPTO_R_PROVIDER_SECTION_ERROR,
+                               "directive %s set to unrecognized value",
+                               confname);
+        return 0;
+    }
+    if ((strcmp(confvalue, "1") == 0)
+        || (strcmp(confvalue, "yes") == 0)
+        || (strcmp(confvalue, "YES") == 0)
+        || (strcmp(confvalue, "true") == 0)
+        || (strcmp(confvalue, "TRUE") == 0)
+        || (strcmp(confvalue, "on") == 0)
+        || (strcmp(confvalue, "ON") == 0)) {
+            *val = 1;
+    } else if ((strcmp(confvalue, "0") == 0)
+               || (strcmp(confvalue, "no") == 0)
+               || (strcmp(confvalue, "NO") == 0)
+               || (strcmp(confvalue, "false") == 0)
+               || (strcmp(confvalue, "FALSE") == 0)
+               || (strcmp(confvalue, "off") == 0)
+               || (strcmp(confvalue, "OFF") == 0)) {
+            *val = 0;
+    } else {
+        ERR_raise_data(ERR_LIB_CRYPTO, CRYPTO_R_PROVIDER_SECTION_ERROR,
+                               "directive %s set to unrecognized value",
+                               confname);
+        return 0;
+    }
+
+    return 1;
+}
+
 static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
                               const char *value, const CONF *cnf)
 {
@@ -210,7 +246,7 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
     STACK_OF(CONF_VALUE) *ecmds;
     int soft = 0;
     const char *path = NULL;
-    long activate = 0;
+    int activate = 0;
     int ok = 0;
 
     name = skip_dot(name);
@@ -239,39 +275,16 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
         if (strcmp(confname, "identity") == 0) {
             name = confvalue;
         } else if (strcmp(confname, "soft_load") == 0) {
-            soft = 1;
+            if (!provider_conf_parse_bool_setting(confname,
+                                                  confvalue, &soft))
+                return 0;
         /* Load a dynamic PROVIDER */
         } else if (strcmp(confname, "module") == 0) {
             path = confvalue;
         } else if (strcmp(confname, "activate") == 0) {
-            if (confvalue == NULL) {
-                ERR_raise_data(ERR_LIB_CRYPTO, CRYPTO_R_PROVIDER_SECTION_ERROR,
-                               "section=%s activate set to unrecognized value",
-                               value);
+            if (!provider_conf_parse_bool_setting(confname,
+                                                  confvalue, &activate))
                 return 0;
-            }
-            if ((strcmp(confvalue, "1") == 0)
-                || (strcmp(confvalue, "yes") == 0)
-                || (strcmp(confvalue, "YES") == 0)
-                || (strcmp(confvalue, "true") == 0)
-                || (strcmp(confvalue, "TRUE") == 0)
-                || (strcmp(confvalue, "on") == 0)
-                || (strcmp(confvalue, "ON") == 0)) {
-                activate = 1;
-            } else if ((strcmp(confvalue, "0") == 0)
-                       || (strcmp(confvalue, "no") == 0)
-                       || (strcmp(confvalue, "NO") == 0)
-                       || (strcmp(confvalue, "false") == 0)
-                       || (strcmp(confvalue, "FALSE") == 0)
-                       || (strcmp(confvalue, "off") == 0)
-                       || (strcmp(confvalue, "OFF") == 0)) {
-                activate = 0;
-            } else {
-                ERR_raise_data(ERR_LIB_CRYPTO, CRYPTO_R_PROVIDER_SECTION_ERROR,
-                               "section=%s activate set to unrecognized value",
-                               value);
-                return 0;
-            }
         }
     }
 

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -271,6 +271,14 @@ provider will be activated. Conversely, setting this value to no, off, false, or
 or uppercase. Setting activate to any other setting, or omitting a setting
 value will result in an error.
 
+= item B<soft_load>
+
+If enabled, informs the library to clear the error stack on failure to activate
+requested provider.  A value of 1, yes, true or on (in lower or uppercase) will
+activate this setting, while a value of 0, no, false, of off (again in lower or
+uppercase) will disable this setting.  Any other value will produce an error.
+Note this setting defaults to off if not provided
+
 =back
 
 All parameters in the section as well as sub-sections are made


### PR DESCRIPTION
There is one remaining config setting for providers, soft_load, which is enabled when provided in a config, regardless of its value.  Augment it to require a decisive value 1/0, yes/no, on/off, true/false, as we've recently done for the activate setting.

Also, since it wasn't previously documented, add docs for it.

Fixes #23105

##### Checklist
- [x] documentation is added or updated

