### PR TITLE
Fix memory leak of conn in new_conn()

### DIFF
--- a/doc/designs/ddd/ddd-02-conn-nonblocking-threads.c
+++ b/doc/designs/ddd/ddd-02-conn-nonblocking-threads.c
@@ -119,6 +119,7 @@ APP_CONN *new_conn(SSL_CTX *ctx, const char *hostname)
     if (SSL_set_alpn_protos(ssl, alpn, sizeof(alpn))) {
         /* Note: SSL_set_alpn_protos returns 1 for failure. */
         BIO_free_all(out);
+        free(conn);
         return NULL;
     }
 #endif


### PR DESCRIPTION
fix the Memory leak: conn

Signed-off-by: zengwei zengwei1@uniontech.com

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
