### PR TITLE
Removing TEST_true check as it has no impact

### DIFF
--- a/test/evp_fetch_prov_test.c
+++ b/test/evp_fetch_prov_test.c
@@ -182,8 +182,8 @@ static int test_explicit_EVP_MD_fetch(const char *id)
             goto err;
 
         /* Also test EVP_MD_up_ref() while we're doing this */
-        if (!TEST_true(EVP_MD_up_ref(md)))
-            goto err;
+        EVP_MD_up_ref(md);
+        
         /* Ref count should now be 2. Release first one here */
         EVP_MD_free(md);
     } else {


### PR DESCRIPTION
"EVP_MD_up_ref(md)" function always return value 1 so the condition "if (!TEST_true(EVP_MD_up_ref(md)))" never seems to get TRUE and code "goto err;" will never be executed. 

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
