### PR TITLE
Fix the double free of kem pointer.

### DIFF
--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -87,6 +87,7 @@ static int evp_kem_init(EVP_PKEY_CTX *ctx, int operation,
          * iteration we're on.
          */
         EVP_KEM_free(kem);
+        kem = NULL;
         EVP_KEYMGMT_free(tmp_keymgmt);
 
         switch (iter) {
@@ -142,7 +143,10 @@ static int evp_kem_init(EVP_PKEY_CTX *ctx, int operation,
     }
 
     if (provkey == NULL) {
-        EVP_KEM_free(kem);
+        if(kem == NULL) {
+           EVP_KEM_free(kem);
+           kem = NULL;
+        }
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         goto err;
     }

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -143,10 +143,8 @@ static int evp_kem_init(EVP_PKEY_CTX *ctx, int operation,
     }
 
     if (provkey == NULL) {
-        if (kem != NULL) {
-            EVP_KEM_free(kem);
-            kem = NULL;
-        }
+        EVP_KEM_free(kem);
+        kem = NULL;
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         goto err;
     }

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -143,9 +143,9 @@ static int evp_kem_init(EVP_PKEY_CTX *ctx, int operation,
     }
 
     if (provkey == NULL) {
-        if(kem == NULL) {
-           EVP_KEM_free(kem);
-           kem = NULL;
+        if (kem != NULL) {
+            EVP_KEM_free(kem);
+            kem = NULL;
         }
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         goto err;


### PR DESCRIPTION
kem pointer is being freed at line 89 and in case provkey is NULL then it's being freed again. Also kem is not assigned to NULL after issuing EVP_KEM_free(kem), so in case kem is already freed but not assigned to NULL then it may still have a garbage value and another EVP_KEM_free(kem) may have unexpected results.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
