### PR TITLE
Fix typos found by codespell in man pages

### DIFF
--- a/doc/man1/openssl-rand.pod.in
+++ b/doc/man1/openssl-rand.pod.in
@@ -25,7 +25,7 @@ multiple of KiB/MiB/GiB/TiB respectively. Note that suffixes are case
 sensitive, and that the suffixes represent binary multiples
 (K = 1024 bytes, M = 1024*1024 bytes, etc).
 
-The string 'max' may be substituted for a numercial value in num, to request the
+The string 'max' may be substituted for a numerical value in num, to request the
 maximum number of bytes the CSPRNG can produce per instantiation.  Currently,
 this is restricted to 2^61 bytes as per NIST SP 800-90C.
 

--- a/doc/man3/OSSL_CMP_SRV_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_SRV_CTX_new.pod
@@ -127,7 +127,7 @@ OSSL_CMP_SRV_CTX_init_trans() sets in I<srv_ctx> the optional callback
 functions for initiating delayed delivery and cleaning up a transaction.
 If the <delay> function is NULL then delivery of responses is never delayed.
 Otherwise I<delay> takes a custom server context and a request message as input.
-It must return 1 if delivery of the respecive response shall be delayed,
+It must return 1 if delivery of the respective response shall be delayed,
 0 if not, and -1 on error.
 If the <clean> function is NULL then no specific cleanup is performed.
 Otherwise I<clean> takes a custom server context and a transaction ID pointer

--- a/doc/man7/EVP_KDF-ARGON2.pod
+++ b/doc/man7/EVP_KDF-ARGON2.pod
@@ -21,7 +21,7 @@ primary seek to address trade-off (side-channel) attacks.
 
 Argon2id is a hybrid construction which, in the first two slices of the first
 pass, generates reference addresses data-independently as in Argon2i, whereas
-in later slices and next passess it generates them data-dependently as in
+in later slices and next passes it generates them data-dependently as in
 Argon2d.
 
 Sbox-hardened version Argon2ds is not supported.

--- a/doc/man7/ossl-guide-tls-client-block.pod
+++ b/doc/man7/ossl-guide-tls-client-block.pod
@@ -348,7 +348,7 @@ connection.
 To send data to the server we use the L<SSL_write_ex(3)> function and to receive
 data from the server we use the L<SSL_read_ex(3)> function. In HTTP 1.0 the
 client always writes data first. Our HTTP request will include the hostname that
-we are connecting to. For simplicitly, we write the HTTP request in three
+we are connecting to. For simplicity, we write the HTTP request in three
 chunks. First we write the start of the request. Secondly we write the hostname
 we are sending the request to. Finally we send the end of the request.
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
