### PR TITLE
riscv: Fix mispelling of extension test macro

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_xts_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_xts_hw.c
@@ -285,7 +285,7 @@ static const PROV_CIPHER_HW aes_xts_rv32i_zbkb_zknd_zkne = {                   \
 # define PROV_CIPHER_HW_select_xts()                                           \
 if (RISCV_HAS_ZBKB_AND_ZKND_AND_ZKNE())                                        \
     return &aes_xts_rv32i_zbkb_zknd_zkne;                                      \
-if (RISCV_HAS_ZKND_ZKNE())                                                     \
+if (RISCV_HAS_ZKND_AND_ZKNE())                                                 \
     return &aes_xts_rv32i_zknd_zkne;
 # else
 /* The generic case */


### PR DESCRIPTION
When refactoring the riscv extension test macros,
RISCV_HAS_ZKND_AND_ZKNE was mispelled.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
None apply

---

Resolves the following error when building for the linux32-riscv32 target:
```
Configuring OpenSSL version 3.2.0 for target linux32-riscv32
...
/home/builder/buildroot/buildroot/output/host/bin/riscv32-buildroot-linux-gnu-gcc  -I. -Icrypto -Iinclude -Iproviders/implementations/include -Iproviders/common/include  -DOPENSSL_CPUID_OBJ -fPIC -pthread -Wa,--noexecstack -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -O2 -g0 -D_FORTIFY_SOURCE=1 -DOPENSSL_USE_NODELETE -DOPENSSL_PIC -DOPENSSLDIR="\"/etc/ssl\"" -DENGINESDIR="\"/usr/lib/engines-3\"" -DMODULESDIR="\"/usr/lib/ossl-modules\"" -DOPENSSL_BUILDING_OPENSSL -DNDEBUG -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -MMD -MF providers/implementations/ciphers/libdefault-lib-cipher_tdes_common.d.tmp -MT providers/implementations/ciphers/libdefault-lib-cipher_tdes_common.o -c -o providers/implementations/ciphers/libdefault-lib-cipher_tdes_common.o providers/implementations/ciphers/cipher_tdes_common.c
providers/implementations/ciphers/cipher_aes_xts_hw.c: In function 'ossl_prov_cipher_hw_aes_xts':
providers/implementations/ciphers/cipher_aes_xts_hw.c:228:5: warning: implicit declaration of function 'RISCV_HAS_ZKND_ZKNE'; did you mean 'RISCV_HAS_ZKND_AND_ZKNE'? [-Wimplicit-function-declaration]
  228 | if (RISCV_HAS_ZKND_ZKNE())                                                     \
      |     ^~~~~~~~~~~~~~~~~~~
providers/implementations/ciphers/cipher_aes_xts_hw.c:244:5: note: in expansion of macro 'PROV_CIPHER_HW_select_xts'
  244 |     PROV_CIPHER_HW_select_xts()
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
...
/home/builder/buildroot/buildroot/output/host/lib/gcc/riscv32-buildroot-linux-gnu/12.3.0/../../../../riscv32-buildroot-linux-gnu/bin/ld: libcrypto.a(libdefault-lib-cipher_aes_xts_hw.o): in function `.L0 ':
cipher_aes_xts_hw.c:(.text+0x20c): undefined reference to `RISCV_HAS_ZKND_ZKNE'
collect2: error: ld returned 1 exit status
```
---

The implementation of `PROV_CIPHER_HW_select_xts()` for riscv64 already uses `RISCV_HAS_ZKND_AND_ZKNE`:
```
# define PROV_CIPHER_HW_select_xts()                                           \
if (RISCV_HAS_ZVBB() && RISCV_HAS_ZVKG() && RISCV_HAS_ZVKNED() &&              \
    riscv_vlen() >= 128)                                                       \
    return &aes_xts_rv64i_zvbb_zvkg_zvkned;                                    \
if (RISCV_HAS_ZVKNED() && riscv_vlen() >= 128)                                 \
    return &aes_xts_rv64i_zvkned;                                              \
else if (RISCV_HAS_ZKND_AND_ZKNE())                                            \
    return &aes_xts_rv64i_zknd_zkne;
```