### PR TITLE
demos: fix cert scripts

### DIFF
--- a/demos/certs/apps/mkxcerts.sh
+++ b/demos/certs/apps/mkxcerts.sh
@@ -1,29 +1,35 @@
+#!/bin/sh
 
 # Create certificates using various algorithms to test multi-certificate
 # functionality.
 
-OPENSSL=../../../apps/openssl
-CN="OpenSSL Test RSA SHA-1 cert" $OPENSSL req \
+opensslcmd() {
+    LD_LIBRARY_PATH=../../.. ../../../apps/openssl $@
+}
+
+opensslcmd version
+
+CN="OpenSSL Test RSA SHA-1 cert" opensslcmd req \
 	-config apps.cnf -extensions usr_cert -x509 -nodes \
 	-keyout tsha1.pem -out tsha1.pem -new -days 3650 -sha1
-CN="OpenSSL Test RSA SHA-256 cert" $OPENSSL req \
+CN="OpenSSL Test RSA SHA-256 cert" opensslcmd req \
 	-config apps.cnf -extensions usr_cert -x509 -nodes \
 	-keyout tsha256.pem -out tsha256.pem -new -days 3650 -sha256
-CN="OpenSSL Test RSA SHA-512 cert" $OPENSSL req \
+CN="OpenSSL Test RSA SHA-512 cert" opensslcmd req \
 	-config apps.cnf -extensions usr_cert -x509 -nodes \
 	-keyout tsha512.pem -out tsha512.pem -new -days 3650 -sha512
 
 # Create EC parameters
 
-$OPENSSL ecparam -name P-256 -out ecp256.pem
-$OPENSSL ecparam -name P-384 -out ecp384.pem
+opensslcmd ecparam -name P-256 -out ecp256.pem
+opensslcmd ecparam -name P-384 -out ecp384.pem
 
-CN="OpenSSL Test P-256 SHA-256 cert" $OPENSSL req \
+CN="OpenSSL Test P-256 SHA-256 cert" opensslcmd req \
 	-config apps.cnf -extensions ec_cert -x509 -nodes \
 	-nodes -keyout tecp256.pem -out tecp256.pem -newkey ec:ecp256.pem \
 	-days 3650 -sha256
 
-CN="OpenSSL Test P-384 SHA-384 cert" $OPENSSL req \
+CN="OpenSSL Test P-384 SHA-384 cert" opensslcmd req \
 	-config apps.cnf -extensions ec_cert -x509 -nodes \
 	-nodes -keyout tecp384.pem -out tecp384.pem -newkey ec:ecp384.pem \
 	-days 3650 -sha384

--- a/demos/certs/mkcerts.sh
+++ b/demos/certs/mkcerts.sh
@@ -1,73 +1,78 @@
 #!/bin/sh
 
-OPENSSL=../../apps/openssl
+opensslcmd() {
+    LD_LIBRARY_PATH=../.. ../../apps/openssl $@
+}
+
 OPENSSL_CONF=../../apps/openssl.cnf
 export OPENSSL_CONF
 
+opensslcmd version
+
 # Root CA: create certificate directly
-CN="Test Root CA" $OPENSSL req -config ca.cnf -x509 -nodes \
+CN="Test Root CA" opensslcmd req -config ca.cnf -x509 -nodes \
 	-keyout root.pem -out root.pem -newkey rsa:2048 -days 3650
 # Intermediate CA: request first
-CN="Test Intermediate CA" $OPENSSL req -config ca.cnf -nodes \
+CN="Test Intermediate CA" opensslcmd req -config ca.cnf -nodes \
 	-keyout intkey.pem -out intreq.pem -newkey rsa:2048
 # Sign request: CA extensions
-$OPENSSL x509 -req -in intreq.pem -CA root.pem -days 3600 \
+opensslcmd x509 -req -in intreq.pem -CA root.pem -days 3600 \
 	-extfile ca.cnf -extensions v3_ca -CAcreateserial -out intca.pem
 
 # Server certificate: create request first
-CN="Test Server Cert" $OPENSSL req -config ca.cnf -nodes \
+CN="Test Server Cert" opensslcmd req -config ca.cnf -nodes \
 	-keyout skey.pem -out req.pem -newkey rsa:1024
 # Sign request: end entity extensions
-$OPENSSL x509 -req -in req.pem -CA intca.pem -CAkey intkey.pem -days 3600 \
+opensslcmd x509 -req -in req.pem -CA intca.pem -CAkey intkey.pem -days 3600 \
 	-extfile ca.cnf -extensions usr_cert -CAcreateserial -out server.pem
 
 # Client certificate: request first
-CN="Test Client Cert" $OPENSSL req -config ca.cnf -nodes \
+CN="Test Client Cert" opensslcmd req -config ca.cnf -nodes \
 	-keyout ckey.pem -out creq.pem -newkey rsa:1024
 # Sign using intermediate CA
-$OPENSSL x509 -req -in creq.pem -CA intca.pem -CAkey intkey.pem -days 3600 \
+opensslcmd x509 -req -in creq.pem -CA intca.pem -CAkey intkey.pem -days 3600 \
 	-extfile ca.cnf -extensions usr_cert -CAcreateserial -out client.pem
 
 # Revoked certificate: request first
-CN="Test Revoked Cert" $OPENSSL req -config ca.cnf -nodes \
+CN="Test Revoked Cert" opensslcmd req -config ca.cnf -nodes \
 	-keyout revkey.pem -out rreq.pem -newkey rsa:1024
 # Sign using intermediate CA
-$OPENSSL x509 -req -in rreq.pem -CA intca.pem -CAkey intkey.pem -days 3600 \
+opensslcmd x509 -req -in rreq.pem -CA intca.pem -CAkey intkey.pem -days 3600 \
 	-extfile ca.cnf -extensions usr_cert -CAcreateserial -out rev.pem
 
 # OCSP responder certificate: request first
-CN="Test OCSP Responder Cert" $OPENSSL req -config ca.cnf -nodes \
+CN="Test OCSP Responder Cert" opensslcmd req -config ca.cnf -nodes \
 	-keyout respkey.pem -out respreq.pem -newkey rsa:1024
 # Sign using intermediate CA and responder extensions
-$OPENSSL x509 -req -in respreq.pem -CA intca.pem -CAkey intkey.pem -days 3600 \
+opensslcmd x509 -req -in respreq.pem -CA intca.pem -CAkey intkey.pem -days 3600 \
 	-extfile ca.cnf -extensions ocsp_cert -CAcreateserial -out resp.pem
 
 # Example creating a PKCS#3 DH certificate.
 
 # First DH parameters
 
-[ -f dhp.pem ] || $OPENSSL genpkey -genparam -algorithm DH -pkeyopt dh_paramgen_prime_len:1024 -out dhp.pem
+[ -f dhp.pem ] || opensslcmd genpkey -genparam -algorithm DH -pkeyopt dh_paramgen_prime_len:1024 -out dhp.pem
 
 # Now a DH private key
-$OPENSSL genpkey -paramfile dhp.pem -out dhskey.pem
+opensslcmd genpkey -paramfile dhp.pem -out dhskey.pem
 # Create DH public key file
-$OPENSSL pkey -in dhskey.pem -pubout -out dhspub.pem
+opensslcmd pkey -in dhskey.pem -pubout -out dhspub.pem
 # Certificate request, key just reuses old one as it is ignored when the
 # request is signed.
-CN="Test Server DH Cert" $OPENSSL req -config ca.cnf -new \
+CN="Test Server DH Cert" opensslcmd req -config ca.cnf -new \
 	-key skey.pem -out dhsreq.pem
 # Sign request: end entity DH extensions
-$OPENSSL x509 -req -in dhsreq.pem -CA root.pem -days 3600 \
+opensslcmd x509 -req -in dhsreq.pem -CA root.pem -days 3600 \
 	-force_pubkey dhspub.pem \
 	-extfile ca.cnf -extensions dh_cert -CAcreateserial -out dhserver.pem
 
 # DH client certificate
 
-$OPENSSL genpkey -paramfile dhp.pem -out dhckey.pem
-$OPENSSL pkey -in dhckey.pem -pubout -out dhcpub.pem
-CN="Test Client DH Cert" $OPENSSL req -config ca.cnf -new \
+opensslcmd genpkey -paramfile dhp.pem -out dhckey.pem
+opensslcmd pkey -in dhckey.pem -pubout -out dhcpub.pem
+CN="Test Client DH Cert" opensslcmd req -config ca.cnf -new \
 	-key skey.pem -out dhcreq.pem
-$OPENSSL x509 -req -in dhcreq.pem -CA root.pem -days 3600 \
+opensslcmd x509 -req -in dhcreq.pem -CA root.pem -days 3600 \
 	-force_pubkey dhcpub.pem \
 	-extfile ca.cnf -extensions dh_cert -CAcreateserial -out dhclient.pem
 
@@ -78,19 +83,19 @@ $OPENSSL x509 -req -in dhcreq.pem -CA root.pem -days 3600 \
 # Create initial crl number file
 echo 01 >crlnum.txt
 # Add entries for server and client certs
-$OPENSSL ca -valid server.pem -keyfile root.pem -cert root.pem \
+opensslcmd ca -valid server.pem -keyfile root.pem -cert root.pem \
 		-config ca.cnf -md sha1
-$OPENSSL ca -valid client.pem -keyfile root.pem -cert root.pem \
+opensslcmd ca -valid client.pem -keyfile root.pem -cert root.pem \
 		-config ca.cnf -md sha1
-$OPENSSL ca -valid rev.pem -keyfile root.pem -cert root.pem \
+opensslcmd ca -valid rev.pem -keyfile root.pem -cert root.pem \
 		-config ca.cnf -md sha1
 # Generate a CRL.
-$OPENSSL ca -gencrl -keyfile root.pem -cert root.pem -config ca.cnf \
+opensslcmd ca -gencrl -keyfile root.pem -cert root.pem -config ca.cnf \
 		-md sha1 -crldays 1 -out crl1.pem
 # Revoke a certificate
 openssl ca -revoke rev.pem -crl_reason superseded \
 		-keyfile root.pem -cert root.pem -config ca.cnf -md sha1
 # Generate another CRL
-$OPENSSL ca -gencrl -keyfile root.pem -cert root.pem -config ca.cnf \
+opensslcmd ca -gencrl -keyfile root.pem -cert root.pem -config ca.cnf \
 		-md sha1 -crldays 1 -out crl2.pem
 

--- a/demos/certs/ocspquery.sh
+++ b/demos/certs/ocspquery.sh
@@ -1,21 +1,28 @@
+#!/bin/sh
+
 # Example querying OpenSSL test responder. Assumes ocsprun.sh has been
 # called.
 
-OPENSSL=../../apps/openssl
+opensslcmd() {
+    LD_LIBRARY_PATH=../.. ../../apps/openssl $@
+}
+
 OPENSSL_CONF=../../apps/openssl.cnf
 export OPENSSL_CONF
+
+opensslcmd version
 
 # Send responder queries for each certificate.
 
 echo "Requesting OCSP status for each certificate"
-$OPENSSL ocsp -issuer intca.pem -cert client.pem -CAfile root.pem \
+opensslcmd ocsp -issuer intca.pem -cert client.pem -CAfile root.pem \
 			-url http://127.0.0.1:8888/
-$OPENSSL ocsp -issuer intca.pem -cert server.pem -CAfile root.pem \
+opensslcmd ocsp -issuer intca.pem -cert server.pem -CAfile root.pem \
 			-url http://127.0.0.1:8888/
-$OPENSSL ocsp -issuer intca.pem -cert rev.pem -CAfile root.pem \
+opensslcmd ocsp -issuer intca.pem -cert rev.pem -CAfile root.pem \
 			-url http://127.0.0.1:8888/
 # One query for all three certificates.
 echo "Requesting OCSP status for three certificates in one request"
-$OPENSSL ocsp -issuer intca.pem \
+opensslcmd ocsp -issuer intca.pem \
 	-cert client.pem -cert server.pem -cert rev.pem \
 	-CAfile root.pem -url http://127.0.0.1:8888/

--- a/demos/certs/ocsprun.sh
+++ b/demos/certs/ocsprun.sh
@@ -1,14 +1,21 @@
+#!/bin/sh
+
+opensslcmd() {
+    LD_LIBRARY_PATH=../.. ../../apps/openssl $@
+}
+
 # Example of running an querying OpenSSL test OCSP responder.
 # This assumes "mkcerts.sh" or similar has been run to set up the
 # necessary file structure.
 
-OPENSSL=../../apps/openssl
 OPENSSL_CONF=../../apps/openssl.cnf
 export OPENSSL_CONF
+
+opensslcmd version
 
 # Run OCSP responder.
 
 PORT=8888
 
-$OPENSSL ocsp -port $PORT -index index.txt -CA intca.pem \
+opensslcmd ocsp -port $PORT -index index.txt -CA intca.pem \
 	-rsigner resp.pem -rkey respkey.pem -rother intca.pem $*


### PR DESCRIPTION
set `LD_LIBRARY_PATH` so the correct libs can be found.

Testing:

```
cd demos/certs && sh mkcerts.sh
cd demos/certs/apps && sh -x mkacerts.sh
```

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
