### PR TITLE
Disable building quicserver utility when OpenSSL is configured with `no-apps` option.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,11 @@ OpenSSL 3.3
 
 ### Changes between 3.2 and 3.3 [xx XXX xxxx]
 
+ * Disable building QUIC server utility when OpenSSL is configured with
+   `no-apps`
+
+   *Vitalii Koshura*
+
  * The activate and soft_load configuration settings for providers in
    openssl.cnf have been updated to require a value of [1|yes|true|on]
    (in lower or UPPER case) to enable the setting. Conversely a value

--- a/util/build.info
+++ b/util/build.info
@@ -6,9 +6,9 @@ SCRIPTS{noinst}=wrap.pl
 SOURCE[wrap.pl]=wrap.pl.in
 DEPEND[wrap.pl]=../configdata.pm
 
-IF[{- !$disabled{quic} && !$disabled{stdio} -}]
+IF[{- !$disabled{quic} && !$disabled{stdio} && !$disabled{apps} -}]
   PROGRAMS{noinst}=quicserver
   SOURCE[quicserver]=quicserver.c
-INCLUDE[quicserver]=../include ../apps/include
-DEPEND[quicserver]=../libcrypto.a ../libssl.a
+  INCLUDE[quicserver]=../include ../apps/include
+  DEPEND[quicserver]=../libcrypto.a ../libssl.a
 ENDIF


### PR DESCRIPTION
This utility isn't required when building library only, but before this PR there was no way to disable its build.

##### Checklist

- [x] documentation is added or updated
