### PR TITLE
Fix SM2 signature, should set default user id

### DIFF
--- a/crypto/sm2/sm2_sign.c
+++ b/crypto/sm2/sm2_sign.c
@@ -23,7 +23,7 @@
 int ossl_sm2_compute_z_digest(uint8_t *out,
                               const EVP_MD *digest,
                               const uint8_t *id,
-                              const size_t id_len,
+                              size_t id_len,
                               const EC_KEY *key)
 {
     int rc = 0;
@@ -72,6 +72,11 @@ int ossl_sm2_compute_z_digest(uint8_t *out,
     }
 
     /* Z = h(ENTL || ID || a || b || xG || yG || xA || yA) */
+
+    if (id == NULL) {
+        id = (const uint8_t *)SM2_DEFAULT_USERID;
+        id_len = strlen(SM2_DEFAULT_USERID);
+    }
 
     if (id_len >= (UINT16_MAX / 8)) {
         /* too large */

--- a/include/crypto/sm2.h
+++ b/include/crypto/sm2.h
@@ -28,7 +28,7 @@ int ossl_sm2_key_private_check(const EC_KEY *eckey);
 int ossl_sm2_compute_z_digest(uint8_t *out,
                               const EVP_MD *digest,
                               const uint8_t *id,
-                              const size_t id_len,
+                              size_t id_len,
                               const EC_KEY *key);
 
 /*


### PR DESCRIPTION
According to GM/T 0009-2012 (or GB/T 35276-2017), the default user id for SM2 signature is "1234567812345678".

So when signing a new certificate, if the user doesn't set "distid" in sigopt, the default user id should be set. Also the same for the verify process.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
