### PR TITLE
provider-keymgmt.pod: fix typo

### DIFF
--- a/doc/man7/provider-keymgmt.pod
+++ b/doc/man7/provider-keymgmt.pod
@@ -376,7 +376,7 @@ length is specific to the key cryptosystem.
 
 The value should be the maximum size that a caller should allocate to
 safely store a signature (called I<sig> in L<provider-signature(7)>),
-the result of asymmetric encryption / decryption (I<out> in
+the result of asymmmetric encryption / decryption (I<out> in
 L<provider-asym_cipher(7)>, a derived secret (I<secret> in
 L<provider-keyexch(7)>, and similar data).
 

--- a/doc/man7/provider-keymgmt.pod
+++ b/doc/man7/provider-keymgmt.pod
@@ -376,7 +376,7 @@ length is specific to the key cryptosystem.
 
 The value should be the maximum size that a caller should allocate to
 safely store a signature (called I<sig> in L<provider-signature(7)>),
-the result of asymmmetric encryption / decryption (I<out> in
+the result of asymmetric encryption / decryption (I<out> in
 L<provider-asym_cipher(7)>, a derived secret (I<secret> in
 L<provider-keyexch(7)>, and similar data).
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

In openssl/doc/man7/provider-keymgmt.pod, from asymmmetric to asymmetric (the previous one adds one extra "m").