### PR TITLE
Set max protocol version for dtls renegotiation tests to dtls1.2

### DIFF
--- a/test/ssl-tests/18-dtls-renegotiate.cnf
+++ b/test/ssl-tests/18-dtls-renegotiate.cnf
@@ -23,6 +23,7 @@ client = 0-renegotiate-client-no-resume-client
 [0-renegotiate-client-no-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT:@SECLEVEL=0
+MaxProtocol = DTLSv1.2
 Options = NoResumptionOnRenegotiation
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
@@ -51,6 +52,7 @@ client = 1-renegotiate-client-resume-client
 [1-renegotiate-client-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT:@SECLEVEL=0
+MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [1-renegotiate-client-resume-client]
@@ -78,6 +80,7 @@ client = 2-renegotiate-server-resume-client
 [2-renegotiate-server-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT:@SECLEVEL=0
+MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [2-renegotiate-server-resume-client]
@@ -105,6 +108,7 @@ client = 3-renegotiate-client-auth-require-client
 [3-renegotiate-client-auth-require-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT:@SECLEVEL=0
+MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
@@ -136,6 +140,7 @@ client = 4-renegotiate-client-auth-once-client
 [4-renegotiate-client-auth-once-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT:@SECLEVEL=0
+MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Once
@@ -172,6 +177,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [5-renegotiate-aead-to-non-aead-client]
 CipherString = AES128-GCM-SHA256
+MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -204,6 +210,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [6-renegotiate-non-aead-to-aead-client]
 CipherString = AES128-SHA
+MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -236,6 +243,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [7-renegotiate-non-aead-to-non-aead-client]
 CipherString = AES128-SHA
+MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -268,6 +276,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [8-renegotiate-aead-to-aead-client]
 CipherString = AES128-GCM-SHA256
+MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 

--- a/test/ssl-tests/18-dtls-renegotiate.cnf.in
+++ b/test/ssl-tests/18-dtls-renegotiate.cnf.in
@@ -29,6 +29,7 @@ foreach my $sctp ("No", "Yes")
         {
             name => "renegotiate-client-no-resume".$suffix,
             server => {
+                "MaxProtocol" => "DTLSv1.2",
                 "CipherString" => 'DEFAULT:@SECLEVEL=0',
                 "Options" => "NoResumptionOnRenegotiation"
             },
@@ -46,6 +47,7 @@ foreach my $sctp ("No", "Yes")
         {
             name => "renegotiate-client-resume".$suffix,
             server => {
+                "MaxProtocol" => "DTLSv1.2",
                 "CipherString" => 'DEFAULT:@SECLEVEL=0'
             },
             client => {
@@ -71,6 +73,7 @@ foreach my $sctp ("No", "Yes")
         {
             name => "renegotiate-server-resume".$suffix,
             server => {
+                "MaxProtocol" => "DTLSv1.2",
                 "CipherString" => 'DEFAULT:@SECLEVEL=0'
             },
             client => {
@@ -87,6 +90,7 @@ foreach my $sctp ("No", "Yes")
         {
             name => "renegotiate-client-auth-require".$suffix,
             server => {
+                "MaxProtocol" => "DTLSv1.2",
                 "VerifyCAFile" => test_pem("root-cert.pem"),
                 "VerifyMode" => "Require",
                 "CipherString" => 'DEFAULT:@SECLEVEL=0'
@@ -107,6 +111,7 @@ foreach my $sctp ("No", "Yes")
         {
             name => "renegotiate-client-auth-once".$suffix,
             server => {
+                "MaxProtocol" => "DTLSv1.2",
                 "VerifyCAFile" => test_pem("root-cert.pem"),
                 "VerifyMode" => "Once",
                 "CipherString" => 'DEFAULT:@SECLEVEL=0'
@@ -135,6 +140,7 @@ foreach my $sctp ("No", "Yes")
                 "Options" => "NoResumptionOnRenegotiation"
             },
             client => {
+                "MaxProtocol" => "DTLSv1.2",
                 "CipherString" => "AES128-GCM-SHA256",
                 extra => {
                     "RenegotiateCiphers" => "AES128-SHA"
@@ -154,6 +160,7 @@ foreach my $sctp ("No", "Yes")
                 "Options" => "NoResumptionOnRenegotiation"
             },
             client => {
+                "MaxProtocol" => "DTLSv1.2",
                 "CipherString" => "AES128-SHA",
                 extra => {
                     "RenegotiateCiphers" => "AES128-GCM-SHA256"
@@ -173,6 +180,7 @@ foreach my $sctp ("No", "Yes")
                 "Options" => "NoResumptionOnRenegotiation"
             },
             client => {
+                "MaxProtocol" => "DTLSv1.2",
                 "CipherString" => "AES128-SHA",
                 extra => {
                     "RenegotiateCiphers" => "AES256-SHA"
@@ -192,6 +200,7 @@ foreach my $sctp ("No", "Yes")
                 "Options" => "NoResumptionOnRenegotiation"
             },
             client => {
+                "MaxProtocol" => "DTLSv1.2",
                 "CipherString" => "AES128-GCM-SHA256",
                 extra => {
                     "RenegotiateCiphers" => "AES256-GCM-SHA384"


### PR DESCRIPTION
There's no functional change today but it reflects that renegotiation is not supported in dtls 1.3. The changes follows the same pattern applied to the tls renegotiation tests.

##### Checklist
- [x] tests are added or updated
