### PR TITLE
cleanse stack variable in blake2[b|s] finalization

### DIFF
--- a/providers/implementations/digests/blake2b_prov.c
+++ b/providers/implementations/digests/blake2b_prov.c
@@ -324,8 +324,10 @@ int ossl_blake2b_final(unsigned char *md, BLAKE2B_CTX *c)
     for (i = 0; i < iter; ++i)
         store64(target + sizeof(c->h[i]) * i, c->h[i]);
 
-    if (target != md)
+    if (target != md) {
         memcpy(md, target, c->outlen);
+        OPENSSL_cleanse(target, sizeof(outbuffer));
+    }
 
     OPENSSL_cleanse(c, sizeof(BLAKE2B_CTX));
     return 1;

--- a/providers/implementations/digests/blake2s_prov.c
+++ b/providers/implementations/digests/blake2s_prov.c
@@ -314,8 +314,10 @@ int ossl_blake2s_final(unsigned char *md, BLAKE2S_CTX *c)
     for (i = 0; i < iter; ++i)
         store32(target + sizeof(c->h[i]) * i, c->h[i]);
 
-    if (target != md)
+    if (target != md) {
         memcpy(md, target, c->outlen);
+        OPENSSL_cleanse(target, sizeof(outbuffer));
+    }
 
     OPENSSL_cleanse(c, sizeof(BLAKE2S_CTX));
     return 1;


### PR DESCRIPTION
If the output of a blake2[b|s] digest isn't a multipl of 8, then a stack buffer is used to compute the final output, which is left un-zeroed prior to return, allowing the potential leak of key data.  Ensure that, if the stack variable is used, it gets cleared prior to return.


