### PR TITLE
validate requested key length in kdf_pbkdf1_do_derive

### DIFF
--- a/providers/implementations/kdfs/pbkdf1.c
+++ b/providers/implementations/kdfs/pbkdf1.c
@@ -72,6 +72,11 @@ static int kdf_pbkdf1_do_derive(const unsigned char *pass, size_t passlen,
     mdsize = EVP_MD_size(md_type);
     if (mdsize < 0)
         goto err;
+    if (n > (size_t)mdsize) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_LENGTH_TOO_LARGE);
+        goto err;
+    }
+
     for (i = 1; i < iter; i++) {
         if (!EVP_DigestInit_ex(ctx, md_type, NULL))
             goto err;


### PR DESCRIPTION
When using pbkdf1 key deriviation, it is possible to request a key length larger than the maximum digest size a given digest can produce, leading to a read of random stack memory.

fix it by returning an error if the requested key size n is larger than the EVP_MD_size of the digest

##### Checklist
- [ ] documentation is added or updated
- [x] tests are added or updated
