### PR TITLE
Changed memcpy to memmove as source and destination were overlapping …

### DIFF
--- a/crypto/aes/aes_ige.c
+++ b/crypto/aes/aes_ige.c
@@ -136,7 +136,7 @@ void AES_ige_encrypt(const unsigned char *in, unsigned char *out,
                 in += AES_BLOCK_SIZE;
                 out += AES_BLOCK_SIZE;
             }
-            memcpy(ivec, ivp->data, AES_BLOCK_SIZE);
+            memmove(ivec, ivp->data, AES_BLOCK_SIZE);
             memcpy(ivec + AES_BLOCK_SIZE, iv2p->data, AES_BLOCK_SIZE);
         } else {
             aes_block_t tmp, tmp2;


### PR DESCRIPTION
…memory.

Changed memcpy to memmove as source and destination were overlapping memory.  Copy of overlapping memory was happening.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
