### PR TITLE
Don't apply max_frag_len checking if no Max Fragment Length extension

### DIFF
--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -80,6 +80,12 @@ static ossl_inline int ktls_start(int fd, ktls_crypto_info_t *tls_en, int is_tx)
 #   endif
 }
 
+/* Not supported on FreeBSD */
+static ossl_inline int ktls_enable_tx_zerocopy_sendfile(int fd)
+{
+    return 0;
+}
+
 /*
  * Send a TLS record using the tls_en provided in ktls_start and use
  * record_type instead of the default SSL3_RT_APPLICATION_DATA.


### PR DESCRIPTION
Don't check the Max Fragment Length if the it hasn't been negotiated. We
were checking it anyway, and using the default value
(SSL3_RT_MAX_PLAIN_LENGTH). This works in most cases but KTLS can cause the
record length to actually exceed this in some cases.

Fixes https://github.com/openssl/openssl/issues/23169

While investigating this I encountered a build error on FreeBSD if KTLS is enabled, so I have fixed that too.

The test is tentative. I expected the test would reproduce the failure - but it didn't. I currently don't know under what conditions the failure occurs.
