### PR TITLE
Correct ssl_old_test stream handling

### DIFF
--- a/test/ssl_old_test.c
+++ b/test/ssl_old_test.c
@@ -992,6 +992,7 @@ int main(int argc, char *argv[])
         if (strcmp(*argv, "-F") == 0) {
             fprintf(stderr,
                     "not compiled with FIPS support, so exiting without running.\n");
+            ret = EXIT_SUCCESS;
             goto end;
         } else if (strcmp(*argv, "-server_auth") == 0)
             server_auth = 1;

--- a/test/ssl_old_test.c
+++ b/test/ssl_old_test.c
@@ -56,6 +56,7 @@
 #endif
 #include <openssl/provider.h>
 #include "testutil.h"
+#include "testutil/output.h"
 
 /*
  * Or gethostname won't be declared properly
@@ -945,7 +946,8 @@ int main(int argc, char *argv[])
     verbose = 0;
     debug = 0;
 
-    bio_err = BIO_new_fp(stderr, BIO_NOCLOSE | BIO_FP_TEXT);
+    test_open_streams();
+
     bio_stdout = BIO_new_fp(stdout, BIO_NOCLOSE | BIO_FP_TEXT);
 
     s_cctx = SSL_CONF_CTX_new();
@@ -990,7 +992,7 @@ int main(int argc, char *argv[])
         if (strcmp(*argv, "-F") == 0) {
             fprintf(stderr,
                     "not compiled with FIPS support, so exiting without running.\n");
-            EXIT(0);
+            goto end;
         } else if (strcmp(*argv, "-server_auth") == 0)
             server_auth = 1;
         else if (strcmp(*argv, "-client_auth") == 0)
@@ -1257,7 +1259,7 @@ int main(int argc, char *argv[])
     if (ssl3 + tls1 + tls1_1 + tls1_2 + dtls + dtls1 + dtls12 > 1) {
         fprintf(stderr, "At most one of -ssl3, -tls1, -tls1_1, -tls1_2, -dtls, -dtls1 or -dtls12 should "
                 "be requested.\n");
-        EXIT(1);
+        goto end;
     }
 
 #ifdef OPENSSL_NO_SSL3
@@ -1310,7 +1312,7 @@ int main(int argc, char *argv[])
                 "the test anyway (and\n-d to see what happens), "
                 "or add one of -ssl3, -tls1, -tls1_1, -tls1_2, -dtls, -dtls1, -dtls12, -reuse\n"
                 "to avoid protocol mismatch.\n");
-        EXIT(1);
+        goto end;
     }
 
     if (print_time) {
@@ -1922,7 +1924,8 @@ int main(int argc, char *argv[])
     OSSL_PROVIDER_unload(thisprov);
     OSSL_LIB_CTX_free(libctx);
 
-    BIO_free(bio_err);
+    test_close_streams();
+
     EXIT(ret);
 }
 


### PR DESCRIPTION
The ssl_old_test has not been fully converted to the test framework but it still reuses some test framework utilities. Notably it was creating it's own copy of the global bio_err object directly (which is normally created and owned by the test framework). This causes a problem because ever since commit 2fa9044 access to the bio_err object is controlled by a lock. Since ssl_old_test was circumventing the normal creation and destruction of bio_err, the lock was not being created resulting in a crash under certain error conditions.

We fix this by creating and destroying the bio_err object using the test framework functions designed for that purpose.

Fixes #23184

