### PR TITLE
Clarify the PKCS12 docs

### DIFF
--- a/doc/man3/PKCS12_create.pod
+++ b/doc/man3/PKCS12_create.pod
@@ -72,9 +72,15 @@ export grade software which could use signing only keys of arbitrary size but
 had restrictions on the permissible sizes of keys which could be used for
 encryption.
 
-If a certificate contains an I<alias> or I<keyid> then this will be
-used for the corresponding B<friendlyName> or B<localKeyID> in the
-PKCS12 structure.
+If I<name> is B<NULL> and I<cert> contains an I<alias> then this will be
+used for the corresponding B<friendlyName> in the PKCS12 structure instead.
+Similarly, if I<pkey> is NULL and I<cert> contains a I<keyid> then this will be
+used for the corresponding B<localKeyID> in the PKCS12 structure instead of the
+id calculated from the I<pkey>.
+
+For all certificates in I<ca> then if a certificate contains an I<alias> or
+I<keyid> then this will be used for the corresponding B<friendlyName> or
+B<localKeyID> in the PKCS12 structure.
 
 Either I<pkey>, I<cert> or both can be B<NULL> to indicate that no key or
 certificate is required. In previous versions both had to be present or


### PR DESCRIPTION
Issue #23151 asks a question about the meaning of the PKCS12 documentation. This PR attempts to clarify how friendlyName and localKeyID are added to the PKCS12 structure.

Fixes #23151