### PR TITLE
Illegal memory access may happen

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4524,14 +4524,14 @@ void ssl_update_cache(SSL_CONNECTION *s, int mode)
                         && (s->options & SSL_OP_NO_ANTI_REPLAY) == 0)
                     || s->session_ctx->remove_session_cb != NULL
                     || (s->options & SSL_OP_NO_TICKET) != 0))
-            SSL_CTX_add_session(s->session_ctx, s->session);
+            int ret = SSL_CTX_add_session(s->session_ctx, s->session);
 
         /*
          * Add the session to the external cache. We do this even in server side
          * TLSv1.3 without early data because some applications just want to
          * know about the creation of a session and aren't doing a full cache.
          */
-        if (s->session_ctx->new_session_cb != NULL) {
+        if (s->session_ctx->new_session_cb != NULL && ret) {
             SSL_SESSION_up_ref(s->session);
             if (!s->session_ctx->new_session_cb(SSL_CONNECTION_GET_SSL(s),
                                                 s->session))


### PR DESCRIPTION
 SSL_CTX_add_session if frees s->session then it returns 0 and that return value should be checked before doing any further processing on s->session

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
