### PR TITLE
Introduce hash thunking functions to do proper casting

### DIFF
--- a/crypto/lhash/lhash.c
+++ b/crypto/lhash/lhash.c
@@ -62,24 +62,24 @@ OPENSSL_LHASH *OPENSSL_LH_set_thunks(OPENSSL_LHASH *lh,
 
 OPENSSL_LHASH *OPENSSL_LH_new(OPENSSL_LH_HASHFUNC h, OPENSSL_LH_COMPFUNC c)
 {
-    struct lhash_st *new;
+    OPENSSL_LHASH *ret;
 
-    if ((new = OPENSSL_zalloc(sizeof(*new))) == NULL)
+    if ((ret = OPENSSL_zalloc(sizeof(*ret))) == NULL)
         return NULL;
-    if ((new->b = OPENSSL_zalloc(sizeof(*new->b) * MIN_NODES)) == NULL)
+    if ((ret->b = OPENSSL_zalloc(sizeof(*ret->b) * MIN_NODES)) == NULL)
         goto err;
-    new->comp = ((c == NULL) ? (OPENSSL_LH_COMPFUNC)strcmp : c);
-    new->hash = ((h == NULL) ? (OPENSSL_LH_HASHFUNC)OPENSSL_LH_strhash : h);
-    new->num_nodes = MIN_NODES / 2;
-    new->num_alloc_nodes = MIN_NODES;
-    new->pmax = MIN_NODES / 2;
-    new->up_load = UP_LOAD;
-    new->down_load = DOWN_LOAD;
-    return new;
+    ret->comp = ((c == NULL) ? (OPENSSL_LH_COMPFUNC)strcmp : c);
+    ret->hash = ((h == NULL) ? (OPENSSL_LH_HASHFUNC)OPENSSL_LH_strhash : h);
+    ret->num_nodes = MIN_NODES / 2;
+    ret->num_alloc_nodes = MIN_NODES;
+    ret->pmax = MIN_NODES / 2;
+    ret->up_load = UP_LOAD;
+    ret->down_load = DOWN_LOAD;
+    return ret;
 
 err:
-    OPENSSL_free(new->b);
-    OPENSSL_free(new);
+    OPENSSL_free(ret->b);
+    OPENSSL_free(ret);
     return NULL;
 }
 
@@ -324,7 +324,7 @@ static OPENSSL_LH_NODE **getrn(OPENSSL_LHASH *lh,
     OPENSSL_LH_NODE **ret, *n1;
     unsigned long hash, nn;
 
-    if (lh->hashw)
+    if (lh->hashw != NULL)
         hash = lh->hashw(data, lh->hash);
     else
         hash = lh->hash(data);
@@ -342,7 +342,7 @@ static OPENSSL_LH_NODE **getrn(OPENSSL_LHASH *lh,
             continue;
         }
 
-        if (lh->compw) {
+        if (lh->compw != NULL) {
             if (lh->compw(n1->data, data, lh->comp) == 0)
                 break;
         } else {

--- a/crypto/lhash/lhash.c
+++ b/crypto/lhash/lhash.c
@@ -218,8 +218,8 @@ void OPENSSL_LH_doall(OPENSSL_LHASH *lh, OPENSSL_LH_DOALL_FUNC func)
     if (lh == NULL)
         return;
 
-    doall_util_fn(lh, 0, lh->daw, func, (OPENSSL_LH_DOALL_FUNCARG)0,
-                  (OPENSSL_LH_DOALL_FUNCARG_THUNK)0, NULL);
+    doall_util_fn(lh, 0, lh->daw, func, (OPENSSL_LH_DOALL_FUNCARG)NULL,
+                  (OPENSSL_LH_DOALL_FUNCARG_THUNK)NULL, NULL);
 }
 
 void OPENSSL_LH_doall_arg(OPENSSL_LHASH *lh,
@@ -228,17 +228,16 @@ void OPENSSL_LH_doall_arg(OPENSSL_LHASH *lh,
     if (lh == NULL)
         return;
 
-    doall_util_fn(lh, 1, (OPENSSL_LH_DOALL_FUNC_THUNK)0,
-                          (OPENSSL_LH_DOALL_FUNC)0, func, lh->daaw, arg);
+    doall_util_fn(lh, 1, (OPENSSL_LH_DOALL_FUNC_THUNK)NULL,
+                  (OPENSSL_LH_DOALL_FUNC)NULL, func, lh->daaw, arg);
 }
 
 void OPENSSL_LH_doall_arg_thunk(OPENSSL_LHASH *lh,
-                          OPENSSL_LH_DOALL_FUNCARG_THUNK daaw,
-                          OPENSSL_LH_DOALL_FUNCARG fn, void *arg)
+                                OPENSSL_LH_DOALL_FUNCARG_THUNK daaw,
+                                OPENSSL_LH_DOALL_FUNCARG fn, void *arg)
 {
-    doall_util_fn(lh, 1,(OPENSSL_LH_DOALL_FUNC_THUNK)0,
-                        (OPENSSL_LH_DOALL_FUNC)0,
-                        fn, daaw, arg);
+    doall_util_fn(lh, 1, (OPENSSL_LH_DOALL_FUNC_THUNK)NULL,
+                  (OPENSSL_LH_DOALL_FUNC)NULL, fn, daaw, arg);
 }
 
 static int expand(OPENSSL_LHASH *lh)

--- a/crypto/lhash/lhash_local.h
+++ b/crypto/lhash/lhash_local.h
@@ -20,6 +20,10 @@ struct lhash_st {
     OPENSSL_LH_NODE **b;
     OPENSSL_LH_COMPFUNC comp;
     OPENSSL_LH_HASHFUNC hash;
+    OPENSSL_LH_HASHFUNCTHUNK hashw;
+    OPENSSL_LH_COMPFUNCTHUNK compw;
+    OPENSSL_LH_DOALL_FUNC_THUNK daw;
+    OPENSSL_LH_DOALL_FUNCARG_THUNK daaw;
     unsigned int num_nodes;
     unsigned int num_alloc_nodes;
     unsigned int p;

--- a/crypto/txt_db/txt_db.c
+++ b/crypto/txt_db/txt_db.c
@@ -160,10 +160,6 @@ int TXT_DB_create_index(TXT_DB *db, int field, int (*qual) (OPENSSL_STRING *),
         db->error = DB_ERROR_MALLOC;
         return 0;
     }
-    OPENSSL_LH_set_thunks((OPENSSL_LHASH *)idx, lh_OPENSSL_STRING_hash_thunk,
-                           lh_OPENSSL_STRING_comp_thunk,
-                           lh_OPENSSL_STRING_doall_thunk,
-                           lh_OPENSSL_STRING_doall_arg_thunk);
     n = sk_OPENSSL_PSTRING_num(db->data);
     for (i = 0; i < n; i++) {
         r = sk_OPENSSL_PSTRING_value(db->data, i);

--- a/crypto/txt_db/txt_db.c
+++ b/crypto/txt_db/txt_db.c
@@ -160,6 +160,10 @@ int TXT_DB_create_index(TXT_DB *db, int field, int (*qual) (OPENSSL_STRING *),
         db->error = DB_ERROR_MALLOC;
         return 0;
     }
+    OPENSSL_LH_set_thunks((OPENSSL_LHASH *)idx, lh_OPENSSL_STRING_hash_thunk,
+                           lh_OPENSSL_STRING_comp_thunk,
+                           lh_OPENSSL_STRING_doall_thunk,
+                           lh_OPENSSL_STRING_doall_arg_thunk);
     n = sk_OPENSSL_PSTRING_num(db->data);
     for (i = 0; i < n; i++) {
         r = sk_OPENSSL_PSTRING_value(db->data, i);

--- a/doc/man3/OPENSSL_LH_COMPFUNC.pod
+++ b/doc/man3/OPENSSL_LH_COMPFUNC.pod
@@ -242,7 +242,7 @@ B<OPENSSL_LH> functions. Most applications should not call the B<OPENSSL_LH>
 functions directly.
 
 OPENSSL_LH_set_thunks() and OPENSSL_LH_doall_arg_thunk(), while public by
-necessity, are actualy internal functions and should not be used.
+necessity, are actually internal functions and should not be used.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/OPENSSL_LH_COMPFUNC.pod
+++ b/doc/man3/OPENSSL_LH_COMPFUNC.pod
@@ -12,7 +12,8 @@ lh_TYPE_doall, lh_TYPE_doall_arg, lh_TYPE_num_items, lh_TYPE_get_down_load,
 lh_TYPE_set_down_load, lh_TYPE_error,
 OPENSSL_LH_new, OPENSSL_LH_free,  OPENSSL_LH_flush,
 OPENSSL_LH_insert, OPENSSL_LH_delete, OPENSSL_LH_retrieve,
-OPENSSL_LH_doall, OPENSSL_LH_doall_arg, OPENSSL_LH_num_items,
+OPENSSL_LH_doall, OPENSSL_LH_doall_arg, OPENSSL_LH_doall_arg_thunk,
+OPENSSL_LH_set_thunks, OPENSSL_LH_num_items,
 OPENSSL_LH_get_down_load, OPENSSL_LH_set_down_load, OPENSSL_LH_error
 - dynamic hash table
 
@@ -29,6 +30,11 @@ OPENSSL_LH_get_down_load, OPENSSL_LH_set_down_load, OPENSSL_LH_error
  LHASH_OF(TYPE) *lh_TYPE_new(OPENSSL_LH_HASHFUNC hash, OPENSSL_LH_COMPFUNC compare);
  void lh_TYPE_free(LHASH_OF(TYPE) *table);
  void lh_TYPE_flush(LHASH_OF(TYPE) *table);
+ OPENSSL_LHASH *OPENSSL_LH_set_thunks(OPENSSL_LHASH *lh,
+                                      OPENSSL_LH_HASHFUNCTHUNK hw,
+                                      OPENSSL_LH_COMPFUNCTHUNK cw,
+                                      OPENSSL_LH_DOALL_FUNC_THUNK daw,
+                                      OPENSSL_LH_DOALL_FUNCARG_THUNK daaw)
 
  TYPE *lh_TYPE_insert(LHASH_OF(TYPE) *table, TYPE *data);
  TYPE *lh_TYPE_delete(LHASH_OF(TYPE) *table, TYPE *data);
@@ -37,6 +43,9 @@ OPENSSL_LH_get_down_load, OPENSSL_LH_set_down_load, OPENSSL_LH_error
  void lh_TYPE_doall(LHASH_OF(TYPE) *table, OPENSSL_LH_DOALL_FUNC func);
  void lh_TYPE_doall_arg(LHASH_OF(TYPE) *table, OPENSSL_LH_DOALL_FUNCARG func,
                         TYPE *arg);
+ void OPENSSL_LH_doall_arg_thunk(OPENSSL_LHASH *lh,
+                                 OPENSSL_LH_DOALL_FUNCARG_THUNK daaw,
+                                 OPENSSL_LH_DOALL_FUNCARG fn, void *arg)
 
  unsigned long lh_TYPE_num_items(OPENSSL_LHASH *lh);
  unsigned long lh_TYPE_get_down_load(OPENSSL_LHASH *lh);

--- a/doc/man3/OPENSSL_LH_COMPFUNC.pod
+++ b/doc/man3/OPENSSL_LH_COMPFUNC.pod
@@ -241,6 +241,9 @@ B<lh_I<TYPE>> functions are implemented as type checked wrappers around the
 B<OPENSSL_LH> functions. Most applications should not call the B<OPENSSL_LH>
 functions directly.
 
+OPENSSL_LH_set_thunks() and OPENSSL_LH_doall_arg_thunk(), while public by
+necessity, are actualy internal functions and should not be used.
+
 =head1 RETURN VALUES
 
 B<lh_I<TYPE>_new>() and OPENSSL_LH_new() return NULL on error, otherwise a

--- a/include/openssl/lhash.h.in
+++ b/include/openssl/lhash.h.in
@@ -36,9 +36,13 @@ extern "C" {
 
 typedef struct lhash_node_st OPENSSL_LH_NODE;
 typedef int (*OPENSSL_LH_COMPFUNC) (const void *, const void *);
+typedef int (*OPENSSL_LH_COMPFUNCTHUNK) (const void *, const void *, OPENSSL_LH_COMPFUNC cfn);
 typedef unsigned long (*OPENSSL_LH_HASHFUNC) (const void *);
+typedef unsigned long (*OPENSSL_LH_HASHFUNCTHUNK) (const void *, OPENSSL_LH_HASHFUNC hfn);
 typedef void (*OPENSSL_LH_DOALL_FUNC) (void *);
+typedef void (*OPENSSL_LH_DOALL_FUNC_THUNK) (void *, OPENSSL_LH_DOALL_FUNC doall);
 typedef void (*OPENSSL_LH_DOALL_FUNCARG) (void *, void *);
+typedef void (*OPENSSL_LH_DOALL_FUNCARG_THUNK) (void *, void *, OPENSSL_LH_DOALL_FUNCARG doall);
 typedef struct lhash_st OPENSSL_LHASH;
 
 /*
@@ -84,13 +88,23 @@ typedef struct lhash_st OPENSSL_LHASH;
 
 int OPENSSL_LH_error(OPENSSL_LHASH *lh);
 OPENSSL_LHASH *OPENSSL_LH_new(OPENSSL_LH_HASHFUNC h, OPENSSL_LH_COMPFUNC c);
+OPENSSL_LHASH *OPENSSL_LH_set_thunks(OPENSSL_LHASH *lh,
+                                     OPENSSL_LH_HASHFUNCTHUNK hw,
+                                     OPENSSL_LH_COMPFUNCTHUNK cw,
+                                     OPENSSL_LH_DOALL_FUNC_THUNK daw,
+                                     OPENSSL_LH_DOALL_FUNCARG_THUNK daaw);
 void OPENSSL_LH_free(OPENSSL_LHASH *lh);
 void OPENSSL_LH_flush(OPENSSL_LHASH *lh);
 void *OPENSSL_LH_insert(OPENSSL_LHASH *lh, void *data);
 void *OPENSSL_LH_delete(OPENSSL_LHASH *lh, const void *data);
 void *OPENSSL_LH_retrieve(OPENSSL_LHASH *lh, const void *data);
 void OPENSSL_LH_doall(OPENSSL_LHASH *lh, OPENSSL_LH_DOALL_FUNC func);
-void OPENSSL_LH_doall_arg(OPENSSL_LHASH *lh, OPENSSL_LH_DOALL_FUNCARG func, void *arg);
+void OPENSSL_LH_doall_arg(OPENSSL_LHASH *lh,
+                          OPENSSL_LH_DOALL_FUNCARG func, void *arg);
+void OPENSSL_LH_doall_arg_thunk(OPENSSL_LHASH *lh,
+                          OPENSSL_LH_DOALL_FUNCARG_THUNK daaw,
+                          OPENSSL_LH_DOALL_FUNCARG fn, void *arg);
+
 unsigned long OPENSSL_LH_strhash(const char *c);
 unsigned long OPENSSL_LH_num_items(const OPENSSL_LHASH *lh);
 unsigned long OPENSSL_LH_get_down_load(const OPENSSL_LHASH *lh);
@@ -144,6 +158,26 @@ OSSL_DEPRECATEDIN_3_1 void OPENSSL_LH_node_usage_stats_bio(const OPENSSL_LHASH *
     typedef int (*lh_##type##_compfunc)(const type *a, const type *b); \
     typedef unsigned long (*lh_##type##_hashfunc)(const type *a); \
     typedef void (*lh_##type##_doallfunc)(type *a); \
+    static ossl_inline unsigned long lh_##type##_hash_thunk(const void *data, OPENSSL_LH_HASHFUNC hfn) \
+    { \
+        unsigned long (*hfn_conv)(const type *) = (unsigned long (*)(const type *))hfn; \
+        return hfn_conv((const type *)data); \
+    } \
+    static ossl_inline int lh_##type##_comp_thunk(const void *da, const void *db, OPENSSL_LH_COMPFUNC cfn) \
+    { \
+        int (*cfn_conv)(const type *, const type *) = (int (*)(const type *, const type *))cfn; \
+        return cfn_conv((const type *)da, (const type *)db); \
+    } \
+    static ossl_inline void lh_##type##_doall_thunk(void *node, OPENSSL_LH_DOALL_FUNC doall) \
+    { \
+        void (*doall_conv)(type *) = (void (*)(type *))doall; \
+        doall_conv((type *)node); \
+    } \
+    static ossl_inline void lh_##type##_doall_arg_thunk(void *node, void *arg, OPENSSL_LH_DOALL_FUNCARG doall) \
+    { \
+        void (*doall_conv)(type *, void *) = (void (*)(type *, void *))doall; \
+        doall_conv((type *)node, arg); \
+    } \
     static ossl_unused ossl_inline type *\
     ossl_check_##type##_lh_plain_type(type *ptr) \
     { \
@@ -206,12 +240,16 @@ OSSL_DEPRECATEDIN_3_1 void OPENSSL_LH_node_usage_stats_bio(const OPENSSL_LHASH *
     LHASH_OF(type) { \
         union lh_##type##_dummy { void* d1; unsigned long d2; int d3; } dummy; \
     }; \
-    static ossl_unused ossl_inline LHASH_OF(type) * \
-    lh_##type##_new(unsigned long (*hfn)(const type *), \
-                    int (*cfn)(const type *, const type *)) \
+    static unsigned long \
+    lh_##type##_hfn_thunk(const void *data, OPENSSL_LH_HASHFUNC hfn) \
     { \
-        return (LHASH_OF(type) *) \
-            OPENSSL_LH_new((OPENSSL_LH_HASHFUNC)hfn, (OPENSSL_LH_COMPFUNC)cfn); \
+        unsigned long (*hfn_conv)(const type *) = (unsigned long (*)(const type *))hfn; \
+        return hfn_conv((const type *)data); \
+    } \
+    static int lh_##type##_cfn_thunk(const void *da, const void *db, OPENSSL_LH_COMPFUNC cfn) \
+    { \
+        int (*cfn_conv)(const type *, const type *) = (int (*)(const type *, const type *))cfn; \
+        return cfn_conv((const type *)da, (const type *)db); \
     } \
     static ossl_unused ossl_inline void \
     lh_##type##_free(LHASH_OF(type) *lh) \
@@ -259,9 +297,30 @@ OSSL_DEPRECATEDIN_3_1 void OPENSSL_LH_node_usage_stats_bio(const OPENSSL_LHASH *
         OPENSSL_LH_set_down_load((OPENSSL_LHASH *)lh, dl); \
     } \
     static ossl_unused ossl_inline void \
+    lh_##type##_doall_thunk(void *node, OPENSSL_LH_DOALL_FUNC doall) \
+    { \
+        void (*doall_conv)(type *) = (void (*)(type *))doall; \
+        doall_conv((type *)node); \
+    } \
+    static ossl_unused ossl_inline void \
+    lh_##type##_doall_arg_thunk(void *node, void *arg, OPENSSL_LH_DOALL_FUNCARG doall) \
+    { \
+        void (*doall_conv)(type *, void *) = (void (*)(type *, void *))doall; \
+        doall_conv((type *)node, arg); \
+    } \
+    static ossl_unused ossl_inline void \
     lh_##type##_doall(LHASH_OF(type) *lh, void (*doall)(type *)) \
     { \
         OPENSSL_LH_doall((OPENSSL_LHASH *)lh, (OPENSSL_LH_DOALL_FUNC)doall); \
+    } \
+    static ossl_unused ossl_inline LHASH_OF(type) * \
+    lh_##type##_new(unsigned long (*hfn)(const type *), \
+                    int (*cfn)(const type *, const type *)) \
+    { \
+        return (LHASH_OF(type) *)OPENSSL_LH_set_thunks(OPENSSL_LH_new((OPENSSL_LH_HASHFUNC)hfn, (OPENSSL_LH_COMPFUNC)cfn), \
+                                lh_##type##_hfn_thunk, lh_##type##_cfn_thunk, \
+                                lh_##type##_doall_thunk, \
+                                lh_##type##_doall_arg_thunk); \
     } \
     static ossl_unused ossl_inline void \
     lh_##type##_doall_arg(LHASH_OF(type) *lh, \
@@ -285,12 +344,20 @@ OSSL_DEPRECATEDIN_3_1 void OPENSSL_LH_node_usage_stats_bio(const OPENSSL_LHASH *
 
 #define int_implement_lhash_doall(type, argtype, cbargtype) \
     static ossl_unused ossl_inline void \
+    lh_##type##_doall_##argtype##_thunk(void *node, void *arg, OPENSSL_LH_DOALL_FUNCARG fn) \
+    { \
+        void (*fn_conv)(cbargtype *, argtype *) = (void (*)(cbargtype *, argtype *))fn; \
+        fn_conv((cbargtype *)node, (argtype *)arg); \
+    } \
+    static ossl_unused ossl_inline void \
         lh_##type##_doall_##argtype(LHASH_OF(type) *lh, \
                                    void (*fn)(cbargtype *, argtype *), \
                                    argtype *arg) \
     { \
-        OPENSSL_LH_doall_arg((OPENSSL_LHASH *)lh, \
-                             (OPENSSL_LH_DOALL_FUNCARG)fn, (void *)arg); \
+        OPENSSL_LH_doall_arg_thunk((OPENSSL_LHASH *)lh, \
+                             lh_##type##_doall_##argtype##_thunk, \
+                             (OPENSSL_LH_DOALL_FUNCARG)fn, \
+                             (void *)arg); \
     } \
     LHASH_OF(type)
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5544,3 +5544,5 @@ OSSL_CMP_SRV_CTX_init_trans             ?	3_3_0	EXIST::FUNCTION:CMP
 EVP_DigestSqueeze                       ?	3_3_0	EXIST::FUNCTION:
 ERR_pop                                 ?	3_3_0	EXIST::FUNCTION:
 X509_STORE_get1_objects                 ?	3_3_0	EXIST::FUNCTION:
+OPENSSL_LH_set_thunks                   ?	3_3_0	EXIST::FUNCTION:
+OPENSSL_LH_doall_arg_thunk              ?	3_3_0	EXIST::FUNCTION:

--- a/util/perl/OpenSSL/stackhash.pm
+++ b/util/perl/OpenSSL/stackhash.pm
@@ -85,7 +85,7 @@ sub generate_lhash_macros {
 
     my $macros = <<END_MACROS;
 DEFINE_LHASH_OF_INTERNAL(${type});
-#define lh_${type}_new(hfn, cmp) ((LHASH_OF(${type}) *)OPENSSL_LH_new(ossl_check_${type}_lh_hashfunc_type(hfn), ossl_check_${type}_lh_compfunc_type(cmp)))
+#define lh_${type}_new(hfn, cmp) ((LHASH_OF(${type}) *)OPENSSL_LH_set_thunks(OPENSSL_LH_new(ossl_check_${type}_lh_hashfunc_type(hfn), ossl_check_${type}_lh_compfunc_type(cmp)), lh_${type}_hash_thunk, lh_${type}_comp_thunk, lh_${type}_doall_thunk, lh_${type}_doall_arg_thunk))
 #define lh_${type}_free(lh) OPENSSL_LH_free(ossl_check_${type}_lh_type(lh))
 #define lh_${type}_flush(lh) OPENSSL_LH_flush(ossl_check_${type}_lh_type(lh))
 #define lh_${type}_insert(lh, ptr) ((${type} *)OPENSSL_LH_insert(ossl_check_${type}_lh_type(lh), ossl_check_${type}_lh_plain_type(ptr)))


### PR DESCRIPTION
ubsan on clang17 has started warning about the following undefined behavior:

crypto/lhash/lhash.c:299:12: runtime error: call to function err_string_data_hash through pointer to incorrect function type 'unsigned long (*)(const void *)' [...]/crypto/err/err.c:184: note: err_string_data_hash defined here
    #0 0x7fa569e3a434 in getrn [...]/crypto/lhash/lhash.c:299:12
    #1 0x7fa569e39a46 in OPENSSL_LH_insert [...]/crypto/lhash/lhash.c:119:10
    #2 0x7fa569d866ee in err_load_strings [...]/crypto/err/err.c:280:15
[...]

The issue occurs because, the generic hash functions (OPENSSL_LH_*) will occasionaly call back to the type specific registered functions for hash generation/comparison/free/etc, using functions of the (example) prototype:

[return value] <hash|cmp|free> (void *, [void *], ...)

While the functions implementing hash|cmp|free|etc are defined as [return value] <fnname> (TYPE *, [TYPE *], ...)

The compiler, not knowing the type signature of the function pointed to by the implementation, performs no type conversion on the function arguments

While this is nominally not an issue for general run time usage (a pointer to void can be used as a pointer to a specific type, as long as the pointer respects the constraints of the C language specification), it can be problematic for ancilliary tools that expect the compiler to detect when a type conversion occurs (even if it is a no-op, CFI being an expemplar case).

As such, ubsan warns us about this issue to avoid breakages in such conditions.

This is an potential fix for the issue, implemented using, in effect, thunking macros.  For each hash type, an additional set of wrapper funtions is created (currently for compare and hash, but more will be added for free/doall/etc).  The corresponding thunking macros for each type cases the actuall corresponding callback to a function pointer of the proper type, and then calls that with the parameters appropriately cast, avoiding the ubsan warning

This approach is adventageous as it maintains a level of type safety, but comes at the cost of having to implement several additional functions per hash table type.

Related to #22896
