### PR TITLE
cleanse stack variable in kdf_pbkdf1_do_derive

### DIFF
--- a/providers/implementations/kdfs/pbkdf1.c
+++ b/providers/implementations/kdfs/pbkdf1.c
@@ -84,6 +84,7 @@ static int kdf_pbkdf1_do_derive(const unsigned char *pass, size_t passlen,
     memcpy(out, md_tmp, n);
     ret = 1;
 err:
+    OPENSSL_cleanse(md_tmp, EVP_MAX_MD_SIZE);
     EVP_MD_CTX_free(ctx);
     return ret;
 }


### PR DESCRIPTION
kdf_pbkdf1_do_derive stores key derivation information in a stack variable, which is left uncleansed prior to returning.  Ensure that the stack information is zeroed prior to return to avoid potential leaks of key information

No tests are added here as significant infrastructure would need to be added to the test harness to scan the stack for leaked information.  Instead, in a separate PR we should consider adding static analysis to check for sensitive functions that leave data on the stack during return
