### PR TITLE
Fix dtls epoch handling

### DIFF
--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -679,3 +679,14 @@ void dtls1_increment_epoch(SSL_CONNECTION *s, int rw)
         s->rlayer.d->w_epoch++;
     }
 }
+
+uint16_t dtls1_get_epoch(SSL_CONNECTION *s, int rw) {
+    uint16_t epoch;
+
+    if (rw & SSL3_CC_READ)
+        epoch = s->rlayer.d->r_epoch;
+    else
+        epoch = s->rlayer.d->w_epoch;
+
+    return epoch;
+}

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1320,7 +1320,7 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
             prev = s->rlayer.rrlnext;
             if (SSL_CONNECTION_IS_DTLS(s)
                     && level != OSSL_RECORD_PROTECTION_LEVEL_NONE)
-                epoch =  DTLS_RECORD_LAYER_get_r_epoch(&s->rlayer) + 1; /* new epoch */
+                epoch = dtls1_get_epoch(s, SSL3_CC_READ); /* new epoch */
 
 #ifndef OPENSSL_NO_DGRAM
             if (SSL_CONNECTION_IS_DTLS(s))
@@ -1337,7 +1337,7 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
         } else {
             if (SSL_CONNECTION_IS_DTLS(s)
                     && level != OSSL_RECORD_PROTECTION_LEVEL_NONE)
-                epoch =  DTLS_RECORD_LAYER_get_w_epoch(&s->rlayer) + 1; /* new epoch */
+                epoch = dtls1_get_epoch(s, SSL3_CC_WRITE); /* new epoch */
         }
 
         /*

--- a/ssl/record/record.h
+++ b/ssl/record/record.h
@@ -139,7 +139,6 @@ typedef struct record_layer_st {
 
 #define RECORD_LAYER_set_read_ahead(rl, ra)     ((rl)->read_ahead = (ra))
 #define RECORD_LAYER_get_read_ahead(rl)         ((rl)->read_ahead)
-#define DTLS_RECORD_LAYER_get_w_epoch(rl)       ((rl)->d->w_epoch)
 
 void RECORD_LAYER_init(RECORD_LAYER *rl, SSL_CONNECTION *s);
 void RECORD_LAYER_clear(RECORD_LAYER *rl);
@@ -165,6 +164,7 @@ __owur int dtls1_write_bytes(SSL_CONNECTION *s, uint8_t type, const void *buf,
 int do_dtls1_write(SSL_CONNECTION *s, uint8_t type, const unsigned char *buf,
                    size_t len, size_t *written);
 void dtls1_increment_epoch(SSL_CONNECTION *s, int rw);
+uint16_t dtls1_get_epoch(SSL_CONNECTION *s, int rw);
 int ssl_release_record(SSL_CONNECTION *s, TLS_RECORD *rr, size_t length);
 
 # define HANDLE_RLAYER_READ_RETURN(s, ret) \

--- a/ssl/record/record_local.h
+++ b/ssl/record/record_local.h
@@ -15,7 +15,3 @@
  *****************************************************************************/
 
 #define MAX_WARN_ALERT_COUNT    5
-
-/* Functions/macros provided by the RECORD_LAYER component */
-
-#define DTLS_RECORD_LAYER_get_r_epoch(rl)       ((rl)->d->r_epoch)

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -865,13 +865,6 @@ WORK_STATE ossl_statem_client_post_work(SSL_CONNECTION *s, WORK_STATE wst)
             return WORK_ERROR;
         }
 
-        /*
-         * Increment epoch before changing cipher state because the cipher
-         * state will create a new record layer that reads the updated epoch
-         */
-        if (SSL_CONNECTION_IS_DTLS(s))
-            dtls1_increment_epoch(s, SSL3_CC_WRITE);
-
         if (!ssl->method->ssl3_enc->change_cipher_state(s,
                                           SSL3_CHANGE_CIPHER_CLIENT_WRITE)) {
             /* SSLfatal() already called */

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -808,15 +808,7 @@ MSG_PROCESS_RETURN tls_process_change_cipher_spec(SSL_CONNECTION *s,
         return MSG_PROCESS_ERROR;
     }
 
-    /*
-     * Increment epoch before changing cipher state because the cipher
-     * state will create a new record layer that reads the updated epoch
-     */
-    if (SSL_CONNECTION_IS_DTLS(s))
-        dtls1_increment_epoch(s, SSL3_CC_READ);
-
     s->s3.change_cipher_spec = 1;
-
     if (!ssl3_do_change_cipher_spec(s)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return MSG_PROCESS_ERROR;

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -808,15 +808,21 @@ MSG_PROCESS_RETURN tls_process_change_cipher_spec(SSL_CONNECTION *s,
         return MSG_PROCESS_ERROR;
     }
 
+    /*
+     * Increment epoch before changing cipher state because the cipher
+     * state will create a new record layer that reads the updated epoch
+     */
+    if (SSL_CONNECTION_IS_DTLS(s))
+        dtls1_increment_epoch(s, SSL3_CC_READ);
+
     s->s3.change_cipher_spec = 1;
+
     if (!ssl3_do_change_cipher_spec(s)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return MSG_PROCESS_ERROR;
     }
 
     if (SSL_CONNECTION_IS_DTLS(s)) {
-        dtls1_increment_epoch(s, SSL3_CC_READ);
-
         if (s->version == DTLS1_BAD_VER)
             s->d1->handshake_read_seq++;
 

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -989,14 +989,18 @@ WORK_STATE ossl_statem_server_post_work(SSL_CONNECTION *s, WORK_STATE wst)
                      0, NULL);
         }
 #endif
+        /*
+        * Increment epoch before changing cipher state because the cipher
+        * state will create a new record layer that depends on the updated epoch
+        */
+        if (SSL_CONNECTION_IS_DTLS(s))
+            dtls1_increment_epoch(s, SSL3_CC_WRITE);
+
         if (!ssl->method->ssl3_enc->change_cipher_state(s,
                                 SSL3_CHANGE_CIPHER_SERVER_WRITE)) {
             /* SSLfatal() already called */
             return WORK_ERROR;
         }
-
-        if (SSL_CONNECTION_IS_DTLS(s))
-            dtls1_increment_epoch(s, SSL3_CC_WRITE);
         break;
 
     case TLS_ST_SW_SRVR_DONE:

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -989,13 +989,6 @@ WORK_STATE ossl_statem_server_post_work(SSL_CONNECTION *s, WORK_STATE wst)
                      0, NULL);
         }
 #endif
-        /*
-        * Increment epoch before changing cipher state because the cipher
-        * state will create a new record layer that depends on the updated epoch
-        */
-        if (SSL_CONNECTION_IS_DTLS(s))
-            dtls1_increment_epoch(s, SSL3_CC_WRITE);
-
         if (!ssl->method->ssl3_enc->change_cipher_state(s,
                                 SSL3_CHANGE_CIPHER_SERVER_WRITE)) {
             /* SSLfatal() already called */

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -228,6 +228,9 @@ int tls1_change_cipher_state(SSL_CONNECTION *s, int which)
         direction = OSSL_RECORD_DIRECTION_WRITE;
     }
 
+    if (SSL_CONNECTION_IS_DTLS(s))
+        dtls1_increment_epoch(s, which);
+
     if (!ssl_set_new_record_layer(s, s->version, direction,
                                     OSSL_RECORD_PROTECTION_LEVEL_APPLICATION,
                                     NULL, 0, key, cl, iv, (size_t)k, mac_secret,


### PR DESCRIPTION
Previously we did some workarounds to get the correct epoch values when creating the new record layer. This change is a more robust way to use and modify the epoch counters.