### PR TITLE
Fix memory leak in SXNET_add_id_asc

### DIFF
--- a/crypto/x509/v3_sxnet.c
+++ b/crypto/x509/v3_sxnet.c
@@ -117,13 +117,19 @@ static SXNET *sxnet_v2i(X509V3_EXT_METHOD *method, X509V3_CTX *ctx,
 
 int SXNET_add_id_asc(SXNET **psx, const char *zone, const char *user, int userlen)
 {
+    int rc;
     ASN1_INTEGER *izone;
 
     if ((izone = s2i_ASN1_INTEGER(NULL, zone)) == NULL) {
         ERR_raise(ERR_LIB_X509V3, X509V3_R_ERROR_CONVERTING_ZONE);
         return 0;
     }
-    return SXNET_add_id_INTEGER(psx, izone, user, userlen);
+
+    rc = SXNET_add_id_INTEGER(psx, izone, user, userlen);
+    if (rc == 0)
+        ASN1_INTEGER_free(izone);
+
+    return rc;
 }
 
 /* Add an id given the zone as an unsigned long */


### PR DESCRIPTION
Coverity noted a memory leak in SXNET_add_id_asc. A failure in the call to SXNET_add_id_INTEGER would leak the izone variable allocated above

Fix it by freeing the izone allocation if the addition fails


