### PR TITLE
Add missing sm4_ccm_dupctx() and sm4_gcm_dupctx() from master branch

### DIFF
--- a/providers/implementations/ciphers/cipher_sm4_ccm.c
+++ b/providers/implementations/ciphers/cipher_sm4_ccm.c
@@ -28,6 +28,21 @@ static void *sm4_ccm_newctx(void *provctx, size_t keybits)
     return ctx;
 }
 
+static void *sm4_ccm_dupctx(void *provctx)
+{
+    PROV_SM4_CCM_CTX *ctx = provctx;
+    PROV_SM4_CCM_CTX *dctx = NULL;
+
+    if (ctx == NULL)
+        return NULL;
+
+    dctx = OPENSSL_memdup(ctx, sizeof(*ctx));
+    if (dctx != NULL && dctx->base.ccm_ctx.key != NULL)
+        dctx->base.ccm_ctx.key = &dctx->ks.ks;
+
+    return dctx;
+}
+
 static void sm4_ccm_freectx(void *vctx)
 {
     PROV_SM4_CCM_CTX *ctx = (PROV_SM4_CCM_CTX *)vctx;

--- a/providers/implementations/ciphers/cipher_sm4_gcm.c
+++ b/providers/implementations/ciphers/cipher_sm4_gcm.c
@@ -29,6 +29,21 @@ static void *sm4_gcm_newctx(void *provctx, size_t keybits)
     return ctx;
 }
 
+static void *sm4_gcm_dupctx(void *provctx)
+{
+    PROV_SM4_GCM_CTX *ctx = provctx;
+    PROV_SM4_GCM_CTX *dctx = NULL;
+
+    if (ctx == NULL)
+        return NULL;
+
+    dctx = OPENSSL_memdup(ctx, sizeof(*ctx));
+    if (dctx != NULL && dctx->base.gcm.key != NULL)
+        dctx->base.gcm.key = &dctx->ks.ks;
+
+    return dctx;
+}
+
 static void sm4_gcm_freectx(void *vctx)
 {
     PROV_SM4_GCM_CTX *ctx = (PROV_SM4_GCM_CTX *)vctx;


### PR DESCRIPTION
This fixes a broken build of openssl-3.1 branch caused by my broken cherry-pick of the dupctx support from the 3.0 branch.

Urgent as 3.1 does not build currently so all CI fails.
