### PR TITLE
uplink-x86_64.pl: make x86_64-xlate.pl accept $flavour parameter

### DIFF
--- a/ms/uplink-x86_64.pl
+++ b/ms/uplink-x86_64.pl
@@ -8,9 +8,10 @@
 
 # $output is the last argument if it looks like a file (it has an extension)
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
+$flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
-open OUT,"| \"$^X\" \"${dir}../crypto/perlasm/x86_64-xlate.pl\" \"$output\""
+open OUT,"| \"$^X\" \"${dir}../crypto/perlasm/x86_64-xlate.pl\" $flavour \"$output\""
     or die "can't call ${dir}../crypto/perlasm/x86_64-xlate.pl: $!";
 *STDOUT=*OUT;
 push(@INC,"${dir}.");


### PR DESCRIPTION
Match behavior of all other x86_64 asm.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
_N/A_
