### PR TITLE
Add X509_STORE_get1_objects

### DIFF
--- a/doc/man3/X509_STORE_get0_param.pod
+++ b/doc/man3/X509_STORE_get0_param.pod
@@ -3,7 +3,7 @@
 =head1 NAME
 
 X509_STORE_get0_param, X509_STORE_set1_param,
-X509_STORE_get0_objects, X509_STORE_get1_all_certs
+X509_STORE_get1_objects, X509_STORE_get0_objects, X509_STORE_get1_all_certs
 - X509_STORE setter and getter functions
 
 =head1 SYNOPSIS
@@ -12,6 +12,7 @@ X509_STORE_get0_objects, X509_STORE_get1_all_certs
 
  X509_VERIFY_PARAM *X509_STORE_get0_param(const X509_STORE *xs);
  int X509_STORE_set1_param(X509_STORE *xs, const X509_VERIFY_PARAM *pm);
+ STACK_OF(X509_OBJECT) *X509_STORE_get1_objects(X509_STORE *xs);
  STACK_OF(X509_OBJECT) *X509_STORE_get0_objects(const X509_STORE *xs);
  STACK_OF(X509) *X509_STORE_get1_all_certs(X509_STORE *xs);
 
@@ -23,9 +24,15 @@ X509_STORE_get0_param() retrieves an internal pointer to the verification
 parameters for I<xs>. The returned pointer must not be freed by the
 calling application
 
+X509_STORE_get1_objects() returns a snapshot of all objects in the store's X509
+cache. The cache contains B<X509> and B<X509_CRL> objects. The caller is
+responsible for freeing the returned list.
+
 X509_STORE_get0_objects() retrieves an internal pointer to the store's
 X509 object cache. The cache contains B<X509> and B<X509_CRL> objects. The
-returned pointer must not be freed by the calling application.
+returned pointer must not be freed by the calling application. If the store is
+shared across multiple threads, it is not safe to use the result of this
+function. Use X509_STORE_get1_objects() instead, which avoids this problem.
 
 X509_STORE_get1_all_certs() returns a list of all certificates in the store.
 The caller is responsible for freeing the returned list.
@@ -36,6 +43,9 @@ X509_STORE_get0_param() returns a pointer to an
 B<X509_VERIFY_PARAM> structure.
 
 X509_STORE_set1_param() returns 1 for success and 0 for failure.
+
+X509_STORE_get1_objects() returns a pointer to a stack of the retrieved
+objects on success, else NULL.
 
 X509_STORE_get0_objects() returns a pointer to a stack of B<X509_OBJECT>.
 
@@ -51,6 +61,7 @@ L<X509_STORE_new(3)>
 B<X509_STORE_get0_param> and B<X509_STORE_get0_objects> were added in
 OpenSSL 1.1.0.
 B<X509_STORE_get1_certs> was added in OpenSSL 3.0.
+B<X509_STORE_get1_objects> was added in OpenSSL 3.3.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/x509_vfy.h.in
+++ b/include/openssl/x509_vfy.h.in
@@ -400,6 +400,7 @@ int X509_STORE_lock(X509_STORE *xs);
 int X509_STORE_unlock(X509_STORE *xs);
 int X509_STORE_up_ref(X509_STORE *xs);
 STACK_OF(X509_OBJECT) *X509_STORE_get0_objects(const X509_STORE *xs);
+STACK_OF(X509_OBJECT) *X509_STORE_get1_objects(X509_STORE *xs);
 STACK_OF(X509) *X509_STORE_get1_all_certs(X509_STORE *xs);
 STACK_OF(X509) *X509_STORE_CTX_get1_certs(X509_STORE_CTX *xs,
                                           const X509_NAME *nm);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5543,3 +5543,4 @@ OSSL_CMP_ITAV_get0_certProfile          ?	3_3_0	EXIST::FUNCTION:CMP
 OSSL_CMP_SRV_CTX_init_trans             ?	3_3_0	EXIST::FUNCTION:CMP
 EVP_DigestSqueeze                       ?	3_3_0	EXIST::FUNCTION:
 ERR_pop                                 ?	3_3_0	EXIST::FUNCTION:
+X509_STORE_get1_objects                 ?	3_3_0	EXIST::FUNCTION:


### PR DESCRIPTION
`X509_STORE_get0_objects` returns a pointer to the `X509_STORE`'s storage, but this function is a bit deceptive. It is practically unusable in a multi-threaded program. See, for example, [RUSTSEC-2023-0072](https://rustsec.org/advisories/RUSTSEC-2023-0072.html), a security vulnerability caused by this OpenSSL API.

One might think that, if no other threads are mutating the `X509_STORE`, it is safe to read the resulting list. However, the documention does not mention that other logically-const operations on the `X509_STORE`, notably certifcate verifications when a hash_dir is installed, will, under a lock, write to the `X509_STORE`. The `X509_STORE` also internally re-sorts the list on the first query.

If the caller knows to call `X509_STORE_lock` and `X509_STORE_unlock`, it can work around this. But this is not obvious, and the documentation does not discuss how `X509_STORE_lock` is very rarely safe to use. E.g. one cannot call any APIs like `X509_STORE_add_cert` or `X509_STORE_CTX_get1_issuer` while holding the lock because those functions internally expect to take the lock. Conversely, if a function happens not to take the lock, but then later it does, this becomes a breaking change for anyone using it with `X509_STORE_lock`! `X509_STORE_lock` is another such API which is not safe to export as public API.

Rather than leave all this to the caller to figure out, the API should have returned a shallow copy of the list, refcounting the values. Then it could be internally locked and the caller can freely inspect the result without synchronization with the `X509_STORE`.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
