### PR TITLE
ci.yml: Replace actions-rs/toolchain@v1 with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,12 +488,9 @@ jobs:
       uses: actions/setup-python@v5.0.0
       with:
         python-version: ${{ matrix.PYTHON }}
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
-        profile: minimal
         toolchain: ${{ matrix.RUST }}
-        override: true
-        default: true
     - name: get cpu info
       run: |
         cat /proc/cpuinfo
@@ -511,11 +508,7 @@ jobs:
       run: ./config --banner=Configured --strict-warnings enable-external-tests && perl configdata.pm --dump
     - name: make
       run: make -s -j4
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: default
-        toolchain: stable
-        default: true
+    - uses: dtolnay/rust-toolchain@stable
     - name: get cpu info
       run: |
         cat /proc/cpuinfo


### PR DESCRIPTION
actions-rs/toolchain is unmaintained and generates warnings
