### PR TITLE
aes_platform.h: add missing ppc64 define

### DIFF
--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -393,7 +393,7 @@ void gcm_init_vis3(u128 Htable[16], const u64 Xi[2]);
 void gcm_gmult_vis3(u64 Xi[2], const u128 Htable[16]);
 void gcm_ghash_vis3(u64 Xi[2], const u128 Htable[16], const u8 *inp,
                     size_t len);
-# elif defined(OPENSSL_CPUID_OBJ) && (defined(__powerpc__) || defined(__ppc__) || defined(_ARCH_PPC))
+# elif defined(OPENSSL_CPUID_OBJ) && (defined(__powerpc__) || defined(__POWERPC__) || defined(_ARCH_PPC))
 #  include "crypto/ppc_arch.h"
 #  define GHASH_ASM_PPC
 void gcm_init_p8(u128 Htable[16], const u64 Xi[2]);

--- a/include/crypto/aes_platform.h
+++ b/include/crypto/aes_platform.h
@@ -60,7 +60,7 @@ void AES_xts_decrypt(const unsigned char *inp, unsigned char *out, size_t len,
 # endif /* AES_XTS_ASM */
 
 # if defined(OPENSSL_CPUID_OBJ)
-#  if (defined(__powerpc__) || defined(__ppc__) || defined(_ARCH_PPC))
+#  if (defined(__powerpc__) || defined(__POWERPC__) || defined(_ARCH_PPC))
 #   include "crypto/ppc_arch.h"
 #   ifdef VPAES_ASM
 #    define VPAES_CAPABLE (OPENSSL_ppccap_P & PPC_ALTIVEC)


### PR DESCRIPTION
Fixes: https://github.com/openssl/openssl/issues/23220

@t8m Could you please review this?

P. S. We could get the same effect for macOS by adding `__POWERPC__`, but that gonna also include BeOS, and I have no idea if related code gonna work there or not. Perhaps `__ppc64__` is a better pick.