### PR TITLE
Unintentional variable seems to be used here.

### DIFF
--- a/ssl/quic/uint_set.c
+++ b/ssl/quic/uint_set.c
@@ -237,7 +237,7 @@ int ossl_uint_set_insert(UINT_SET *s, const UINT_RANGE *range)
                  * If this closes a gap we now need to merge
                  * consecutive nodes.
                  */
-                uint_set_merge_adjacent(s, z);
+                uint_set_merge_adjacent(s, zprev);
             } else {
                 /*
                  * The new interval is between intervals without overlapping or


### PR DESCRIPTION
uint_set_merge_adjacent should be called with zprev as second argument as "z" parameter is already being processed in the above corresponding if loop.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
