### PR TITLE
Xpout and Xqout checked in wrong fashion

### DIFF
--- a/crypto/rsa/rsa_sp800_56b_gen.c
+++ b/crypto/rsa/rsa_sp800_56b_gen.c
@@ -30,7 +30,6 @@
  *     test Object used for CAVS testing only.that contains..
  *       p1, p2 The returned auxiliary primes for p.
  *              If NULL they are not returned.
- *       Xpout An optionally returned random number used during generation of p.
  *       Xp An optional passed in value (that is random number used during
  *          generation of p).
  *       Xp1, Xp2 Optionally passed in randomly generated numbers from which
@@ -38,7 +37,6 @@
  *                are generated internally.
  *       q1, q2 The returned auxiliary primes for q.
  *              If NULL they are not returned.
- *       Xqout An optionally returned random number used during generation of q.
  *       Xq An optional passed in value (that is random number used during
  *          generation of q).
  *       Xq1, Xq2 Optionally passed in randomly generated numbers from which
@@ -50,7 +48,7 @@
  *     cb An optional BIGNUM callback.
  * Returns: 1 if successful, or  0 otherwise.
  * Notes:
- *     p1, p2, q1, q2, Xpout, Xqout are returned if they are not NULL.
+ *     p1, p2, q1, q2 are returned if they are not NULL.
  *     Xp, Xp1, Xp2, Xq, Xq1, Xq2 are optionally passed in.
  *     (Required for CAVS testing).
  */
@@ -65,7 +63,6 @@ int ossl_rsa_fips186_4_gen_prob_primes(RSA *rsa, RSA_ACVP_TEST *test,
     BIGNUM *p1 = NULL, *p2 = NULL;
     BIGNUM *q1 = NULL, *q2 = NULL;
     /* Intermediate BIGNUMS that can be input for testing */
-    BIGNUM *Xpout = NULL, *Xqout = NULL;
     BIGNUM *Xp = NULL, *Xp1 = NULL, *Xp2 = NULL;
     BIGNUM *Xq = NULL, *Xq1 = NULL, *Xq2 = NULL;
 
@@ -150,9 +147,9 @@ int ossl_rsa_fips186_4_gen_prob_primes(RSA *rsa, RSA_ACVP_TEST *test,
     ret = 1;
 err:
     /* Zeroize any internally generated values that are not returned */
-    if (Xpo != Xpout)
+    if (Xpo != NULL)
         BN_clear(Xpo);
-    if (Xqo != Xqout)
+    if (Xqo != NULL)
         BN_clear(Xqo);
     BN_clear(tmp);
 

--- a/crypto/rsa/rsa_sp800_56b_gen.c
+++ b/crypto/rsa/rsa_sp800_56b_gen.c
@@ -105,8 +105,8 @@ int ossl_rsa_fips186_4_gen_prob_primes(RSA *rsa, RSA_ACVP_TEST *test,
 
     BN_CTX_start(ctx);
     tmp = BN_CTX_get(ctx);
-    Xpo = (Xpout != NULL) ? Xpout : BN_CTX_get(ctx);
-    Xqo = (Xqout != NULL) ? Xqout : BN_CTX_get(ctx);
+    Xpo = BN_CTX_get(ctx);
+    Xqo = BN_CTX_get(ctx);
     if (tmp == NULL || Xpo == NULL || Xqo == NULL)
         goto err;
     BN_set_flags(Xpo, BN_FLG_CONSTTIME);


### PR DESCRIPTION
In the starting of the module ossl_rsa_fips186_4_gen_prob_primes, local variables are assigned as NULL i.e.

BIGNUM *Xpout = NULL, *Xqout = NULL;

while assigning to Xpo and Xqo they have been checked if they are NULL or not which is of no USE as they are already assigned with NULL.

Removed that check.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
