### PR TITLE
Fix an assertion failure in tls_common.c

### DIFF
--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -544,6 +544,8 @@ void ossl_quic_free(SSL *s)
     }
 #endif
 
+    SSL_free(ctx.qc->tls);
+
     ossl_quic_channel_free(ctx.qc->ch);
     ossl_quic_port_free(ctx.qc->port);
     ossl_quic_engine_free(ctx.qc->engine);
@@ -551,13 +553,15 @@ void ossl_quic_free(SSL *s)
     BIO_free_all(ctx.qc->net_rbio);
     BIO_free_all(ctx.qc->net_wbio);
 
-    /* Note: SSL_free calls OPENSSL_free(qc) for us */
-
-    SSL_free(ctx.qc->tls);
     quic_unlock(ctx.qc); /* tsan doesn't like freeing locked mutexes */
 #if defined(OPENSSL_THREADS)
     ossl_crypto_mutex_free(&ctx.qc->mutex);
 #endif
+
+    /*
+     * Note: SSL_free (that called this function) calls OPENSSL_free(ctx.qc) for
+     * us
+     */
 }
 
 /* SSL method init */

--- a/ssl/quic/quic_tserver.c
+++ b/ssl/quic/quic_tserver.c
@@ -173,13 +173,13 @@ void ossl_quic_tserver_free(QUIC_TSERVER *srv)
     if (srv == NULL)
         return;
 
+    SSL_free(srv->tls);
     ossl_quic_channel_free(srv->ch);
     ossl_quic_port_free(srv->port);
     ossl_quic_engine_free(srv->engine);
     BIO_free_all(srv->args.net_rbio);
     BIO_free_all(srv->args.net_wbio);
     OPENSSL_free(srv->ssl);
-    SSL_free(srv->tls);
     SSL_CTX_free(srv->ctx);
 #if defined(OPENSSL_THREADS)
     ossl_crypto_mutex_free(&srv->mutex);

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -25,14 +25,29 @@ void RECORD_LAYER_init(RECORD_LAYER *rl, SSL_CONNECTION *s)
     rl->s = s;
 }
 
-void RECORD_LAYER_clear(RECORD_LAYER *rl)
+int RECORD_LAYER_clear(RECORD_LAYER *rl)
 {
+    int ret = 1;
+
+    /* Clear any buffered records we no longer need */
+    while (rl->curr_rec < rl->num_recs)
+        ret &= ssl_release_record(rl->s,
+                                  &(rl->tlsrecs[rl->curr_rec++]),
+                                  0);
+
+
     rl->wnum = 0;
     memset(rl->handshake_fragment, 0, sizeof(rl->handshake_fragment));
     rl->handshake_fragment_len = 0;
     rl->wpend_tot = 0;
     rl->wpend_type = 0;
     rl->wpend_buf = NULL;
+    rl->alert_count = 0;
+    rl->num_recs = 0;
+    rl->curr_rec = 0;
+
+    BIO_free(rl->rrlnext);
+    rl->rrlnext = NULL;
 
     if (rl->rrlmethod != NULL)
         rl->rrlmethod->free(rl->rrl); /* Ignore return value */
@@ -47,6 +62,35 @@ void RECORD_LAYER_clear(RECORD_LAYER *rl)
 
     if (rl->d)
         DTLS_RECORD_LAYER_clear(rl);
+
+    return ret;
+}
+
+int RECORD_LAYER_reset(RECORD_LAYER *rl)
+{
+    int ret;
+
+    ret = RECORD_LAYER_clear(rl);
+
+    /* We try and reset both record layers even if one fails */
+    ret &= ssl_set_new_record_layer(rl->s,
+                                    SSL_CONNECTION_IS_DTLS(rl->s)
+                                        ? DTLS_ANY_VERSION : TLS_ANY_VERSION,
+                                    OSSL_RECORD_DIRECTION_READ,
+                                    OSSL_RECORD_PROTECTION_LEVEL_NONE, NULL, 0,
+                                    NULL, 0, NULL, 0, NULL,  0, NULL, 0,
+                                    NID_undef, NULL, NULL, NULL);
+
+    ret &= ssl_set_new_record_layer(rl->s,
+                                    SSL_CONNECTION_IS_DTLS(rl->s)
+                                        ? DTLS_ANY_VERSION : TLS_ANY_VERSION,
+                                    OSSL_RECORD_DIRECTION_WRITE,
+                                    OSSL_RECORD_PROTECTION_LEVEL_NONE, NULL, 0,
+                                    NULL, 0, NULL, 0, NULL,  0, NULL, 0,
+                                    NID_undef, NULL, NULL, NULL);
+
+    /* SSLfatal already called in the event of failure */
+    return ret;
 }
 
 /* Checks if we have unprocessed read ahead data pending */

--- a/ssl/record/record.h
+++ b/ssl/record/record.h
@@ -140,7 +140,8 @@ typedef struct record_layer_st {
 #define DTLS_RECORD_LAYER_get_w_epoch(rl)       ((rl)->d->w_epoch)
 
 void RECORD_LAYER_init(RECORD_LAYER *rl, SSL_CONNECTION *s);
-void RECORD_LAYER_clear(RECORD_LAYER *rl);
+int RECORD_LAYER_clear(RECORD_LAYER *rl);
+int RECORD_LAYER_reset(RECORD_LAYER *rl);
 int RECORD_LAYER_read_pending(const RECORD_LAYER *rl);
 int RECORD_LAYER_processed_read_pending(const RECORD_LAYER *rl);
 int RECORD_LAYER_write_pending(const RECORD_LAYER *rl);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -558,50 +558,6 @@ static int ssl_check_allowed_versions(int min_version, int max_version)
 void OPENSSL_VPROC_FUNC(void) {}
 #endif
 
-static int clear_record_layer(SSL_CONNECTION *s)
-{
-    int ret = 1;
-
-    /* Clear any buffered records we no longer need */
-    while (s->rlayer.curr_rec < s->rlayer.num_recs)
-        ret &= ssl_release_record(s,
-                                  &(s->rlayer.tlsrecs[s->rlayer.curr_rec ++]),
-                                  0);
-
-    BIO_free(s->rlayer.rrlnext);
-    s->rlayer.rrlnext = NULL;
-
-    /* Reset various fields */
-    s->rlayer.wnum = 0;
-    s->rlayer.handshake_fragment_len = 0;
-    s->rlayer.wpend_tot = 0;
-    s->rlayer.wpend_type = 0;
-    s->rlayer.wpend_buf = NULL;
-    s->rlayer.alert_count = 0;
-    s->rlayer.num_recs = 0;
-    s->rlayer.curr_rec = 0;
-
-    /* We try and reset both record layers even if one fails */
-    ret &= ssl_set_new_record_layer(s,
-                                    SSL_CONNECTION_IS_DTLS(s) ? DTLS_ANY_VERSION
-                                                              : TLS_ANY_VERSION,
-                                    OSSL_RECORD_DIRECTION_READ,
-                                    OSSL_RECORD_PROTECTION_LEVEL_NONE, NULL, 0,
-                                    NULL, 0, NULL, 0, NULL,  0, NULL, 0,
-                                    NID_undef, NULL, NULL, NULL);
-
-    ret &= ssl_set_new_record_layer(s,
-                                    SSL_CONNECTION_IS_DTLS(s) ? DTLS_ANY_VERSION
-                                                              : TLS_ANY_VERSION,
-                                    OSSL_RECORD_DIRECTION_WRITE,
-                                    OSSL_RECORD_PROTECTION_LEVEL_NONE, NULL, 0,
-                                    NULL, 0, NULL, 0, NULL,  0, NULL, 0,
-                                    NID_undef, NULL, NULL, NULL);
-
-    /* SSLfatal already called in the event of failure */
-    return ret;
-}
-
 int SSL_clear(SSL *s)
 {
     if (s->method == NULL) {
@@ -687,11 +643,7 @@ int ossl_ssl_connection_reset(SSL *s)
             return 0;
     }
 
-    RECORD_LAYER_clear(&sc->rlayer);
-    BIO_free(sc->rlayer.rrlnext);
-    sc->rlayer.rrlnext = NULL;
-
-    if (!clear_record_layer(sc))
+    if (!RECORD_LAYER_reset(&sc->rlayer))
         return 0;
 
     return 1;
@@ -1455,6 +1407,7 @@ void ossl_ssl_connection_free(SSL *ssl)
     /* Ignore return value */
     ssl_free_wbio_buffer(s);
 
+    /* Ignore return value */
     RECORD_LAYER_clear(&s->rlayer);
 
     BUF_MEM_free(s->init_buf);
@@ -4783,7 +4736,7 @@ void SSL_set_accept_state(SSL *s)
     ossl_statem_clear(sc);
     sc->handshake_func = s->method->ssl_accept;
     /* Ignore return value. Its a void public API function */
-    clear_record_layer(sc);
+    RECORD_LAYER_reset(&sc->rlayer);
 }
 
 void SSL_set_connect_state(SSL *s)
@@ -4802,7 +4755,7 @@ void SSL_set_connect_state(SSL *s)
     ossl_statem_clear(sc);
     sc->handshake_func = s->method->ssl_connect;
     /* Ignore return value. Its a void public API function */
-    clear_record_layer(sc);
+    RECORD_LAYER_reset(&sc->rlayer);
 }
 
 int ssl_undefined_function(SSL *s)

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1979,16 +1979,17 @@ int ssl_version_supported(const SSL_CONNECTION *s, int version,
     for (vent = table;
          vent->version != 0 && ssl_version_cmp(s, version, vent->version) <= 0;
          ++vent) {
-        const SSL_METHOD *thismeth = s->server ? vent->smeth() : vent->cmeth();
+        const SSL_METHOD *(*thismeth)(void) = s->server ? vent->smeth
+                                                        : vent->cmeth;
 
         if (thismeth != NULL
                 && ssl_version_cmp(s, version, vent->version) == 0
-                && ssl_method_error(s, thismeth) == 0
+                && ssl_method_error(s, thismeth()) == 0
                 && (!s->server
                     || version != TLS1_3_VERSION
                     || is_tls13_capable(s))) {
             if (meth != NULL)
-                *meth = thismeth;
+                *meth = thismeth();
             return 1;
         }
     }

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1981,12 +1981,13 @@ int ssl_version_supported(const SSL_CONNECTION *s, int version,
          ++vent) {
         if (vent->cmeth != NULL
                 && ssl_version_cmp(s, version, vent->version) == 0
-                && ssl_method_error(s, vent->cmeth()) == 0
+                && ssl_method_error(s, s->server ? vent->smeth()
+                                                 : vent->cmeth()) == 0
                 && (!s->server
                     || version != TLS1_3_VERSION
                     || is_tls13_capable(s))) {
             if (meth != NULL)
-                *meth = vent->cmeth();
+                *meth = s->server ? vent->smeth() : vent->cmeth();
             return 1;
         }
     }

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1979,15 +1979,16 @@ int ssl_version_supported(const SSL_CONNECTION *s, int version,
     for (vent = table;
          vent->version != 0 && ssl_version_cmp(s, version, vent->version) <= 0;
          ++vent) {
-        if (vent->cmeth != NULL
+        const SSL_METHOD *thismeth = s->server ? vent->smeth() : vent->cmeth();
+
+        if (thismeth != NULL
                 && ssl_version_cmp(s, version, vent->version) == 0
-                && ssl_method_error(s, s->server ? vent->smeth()
-                                                 : vent->cmeth()) == 0
+                && ssl_method_error(s, thismeth) == 0
                 && (!s->server
                     || version != TLS1_3_VERSION
                     || is_tls13_capable(s))) {
             if (meth != NULL)
-                *meth = s->server ? vent->smeth() : vent->cmeth();
+                *meth = thismeth;
             return 1;
         }
     }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -7003,8 +7003,8 @@ static int test_key_update_local_in_read(int tst)
 /*
  * Test clearing a connection via SSL_clear(), or resetting it via
  * SSL_set_connect_state()/SSL_set_accept_state()
- * Test 0: SSL_set_conect_state, TLSv1.3
- * Test 1: SSL_set_conect_state, TLSv1.2
+ * Test 0: SSL_set_connect_state, TLSv1.3
+ * Test 1: SSL_set_connect_state, TLSv1.2
  * Test 2: SSL_set_accept_state, TLSv1.3
  * Test 3: SSL_set_accept_state, TLSv1.2
  * Test 4: SSL_clear (client), TLSv1.3

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -7125,7 +7125,6 @@ static int test_ssl_clear(int idx)
     return testresult;
 }
 
-
 /* Parse CH and retrieve any MFL extension value if present */
 static int get_MFL_from_client_hello(BIO *bio, int *mfl_codemfl_code)
 {


### PR DESCRIPTION
When we clear the record layer, we better make sure we clear all relevant fields, otherwise we can get ourselves into an unexpected state.

Fixes #23255
