### PR TITLE
Move discovery of the legacy alg type into the keymgmt

### DIFF
--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -95,6 +95,8 @@ struct evp_keymgmt_st {
     int id;                      /* libcrypto internal */
 
     int name_id;
+    /* NID for the legacy alg if there is one */
+    int legacy_alg;
     char *type_name;
     const char *description;
     OSSL_PROVIDER *prov;

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -133,24 +133,6 @@ EVP_PKEY_METHOD *EVP_PKEY_meth_new(int id, int flags)
     pmeth->flags = flags | EVP_PKEY_FLAG_DYNAMIC;
     return pmeth;
 }
-
-static void help_get_legacy_alg_type_from_keymgmt(const char *keytype,
-                                                  void *arg)
-{
-    int *type = arg;
-
-    if (*type == NID_undef)
-        *type = evp_pkey_name2type(keytype);
-}
-
-static int get_legacy_alg_type_from_keymgmt(const EVP_KEYMGMT *keymgmt)
-{
-    int type = NID_undef;
-
-    EVP_KEYMGMT_names_do_all(keymgmt, help_get_legacy_alg_type_from_keymgmt,
-                             &type);
-    return type;
-}
 #endif /* FIPS_MODULE */
 
 int evp_pkey_ctx_state(const EVP_PKEY_CTX *ctx)
@@ -288,7 +270,7 @@ static EVP_PKEY_CTX *int_ctx_new(OSSL_LIB_CTX *libctx,
          * directly.
          */
         if (keymgmt != NULL) {
-            int tmp_id = get_legacy_alg_type_from_keymgmt(keymgmt);
+            int tmp_id = evp_keymgmt_get_legacy_alg(keymgmt);
 
             if (tmp_id != NID_undef) {
                 if (id == -1) {

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -951,6 +951,7 @@ int evp_kdf_get_number(const EVP_KDF *kdf);
 int evp_kem_get_number(const EVP_KEM *wrap);
 int evp_keyexch_get_number(const EVP_KEYEXCH *keyexch);
 int evp_keymgmt_get_number(const EVP_KEYMGMT *keymgmt);
+int evp_keymgmt_get_legacy_alg(const EVP_KEYMGMT *keymgmt);
 int evp_mac_get_number(const EVP_MAC *mac);
 int evp_md_get_number(const EVP_MD *md);
 int evp_rand_get_number(const EVP_RAND *rand);


### PR DESCRIPTION
During creation of the EVP_PKEY_CTX we were trying to discover what legacy alg the keymgmt corresponds to every time which was slow. Instead we move this into the construction of the EVP_KEYMGMT.

I did some testing with s_time to see what effect this might have. The effect is small but measurable.
I used s_time from 1.1.1 to test s_server from master with and without this patch. s_time does repeated handshakes and downloads a file from the server each time (I used a small 10 byte file for this test). s_time repeats the test for both new and reused sessions. I repeated the test 6 times for each configuration and values below represent the average connections/user sec result reported from s_time (higher is better)

  | master | master with patch |  
-- | -- | -- | --
New | 4578.60 | 4651.74 | 1.60%
Reused | 6879.77 | 6917.44 | 0.55%


