### PR TITLE
Fix arithmetic expression overflow

### DIFF
--- a/crypto/o_time.c
+++ b/crypto/o_time.c
@@ -178,9 +178,10 @@ static int julian_adj(const struct tm *tm, int off_day, long offset_sec,
  */
 static long date_to_julian(int y, int m, int d)
 {
-    return (1461 * (y + 4800 + (m - 14) / 12)) / 4 +
-        (367 * (m - 2 - 12 * ((m - 14) / 12))) / 12 -
-        (3 * ((y + 4900 + (m - 14) / 12) / 100)) / 4 + d - 32075;
+    long yl = y, ml = m, dl = d;
+    return (1461L * (yl + 4800L + (ml - 14L) / 12L)) / 4L +
+            (367L * (ml - 2L - 12L * ((ml - 14L) / 12L))) / 12L -
+            (3L * ((yl + 4900L + (ml - 14L) / 12L) / 100L)) / 4L + dl - 32075L;
 }
 
 static void julian_to_date(long jd, int *y, int *m, int *d)


### PR DESCRIPTION
If int is a 16-bit number and y=0, m=0, an overflow may occur. 1461 * (y + 4800 + (m - 14) / 12)

Found by Linux Verification Center (linuxtesting.org) with SVACE.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
