### PR TITLE
Remove calls with unused return value

### DIFF
--- a/crypto/pkcs12/p12_npas.c
+++ b/crypto/pkcs12/p12_npas.c
@@ -212,8 +212,7 @@ static int alg_get(const X509_ALGOR *alg, int *pnid, int *piter,
         if (pbe2 == NULL)
             goto done;
 
-        X509_ALGOR_get0(&aoid, &aparamtype, &aparam, pbe2->keyfunc);
-        pbenid = OBJ_obj2nid(aoid);
+        X509_ALGOR_get0(NULL, &aparamtype, &aparam, pbe2->keyfunc);
         X509_ALGOR_get0(&aoid, NULL, NULL, pbe2->encryption);
         encnid = OBJ_obj2nid(aoid);
 


### PR DESCRIPTION
Found by Linux Verification Center (linuxtesting.org) with SVACE.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
