### PR TITLE
Error in s_server when -rev option is used with dtls.

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1714,6 +1714,11 @@ int s_server_main(int argc, char *argv[])
         BIO_printf(bio_err, "Can only use -listen with DTLS\n");
         goto end;
     }
+
+    if (rev && socket_type == SOCK_DGRAM) {
+        BIO_printf(bio_err, "Can't use -rev with DTLS\n");
+        goto end;
+    }
 #endif
 
     if (tfo && socket_type != SOCK_STREAM) {


### PR DESCRIPTION
While developing the dtls functionality in TLSProxy I hit an existing issue:
https://github.com/openssl/openssl/issues/19422

To save others from spending time on debugging I propose we error s_server when `-rev` is used with dtls.