### PR TITLE
Removed logically dead code from function ossl_rsa_multip_cap

### DIFF
--- a/crypto/rsa/rsa_mp.c
+++ b/crypto/rsa/rsa_mp.c
@@ -106,8 +106,5 @@ int ossl_rsa_multip_cap(int bits)
     else if (bits < 8192)
         cap = 4;
 
-    if (cap > RSA_MAX_PRIME_NUM)
-        cap = RSA_MAX_PRIME_NUM;
-
     return cap;
 }


### PR DESCRIPTION
Condition if (cap > RSA_MAX_PRIME_NUM) i.e. if (cap > 5) can never be true as initial value of cap is set to 5. Hence removing logically dead code.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
