### PR TITLE
Removed logically dead code from function i2r_issuer_sign_tool

### DIFF
--- a/crypto/x509/v3_ist.c
+++ b/crypto/x509/v3_ist.c
@@ -103,9 +103,6 @@ static int i2r_issuer_sign_tool(X509V3_EXT_METHOD *method,
         return 0;
     }
     if (ist->signTool != NULL) {
-        if (new_line == 1) {
-            BIO_write(out, "\n", 1);
-        }
         BIO_printf(out, "%*ssignTool    : ", indent, "");
         BIO_write(out, ist->signTool->data, ist->signTool->length);
         new_line = 1;


### PR DESCRIPTION
Since new_line is assigned with 0 in the very begging of the function check added at line no. 106 will never become true. Hence removing.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
