### PR TITLE
Redundant if loop

### DIFF
--- a/test/helpers/pkcs12.c
+++ b/test/helpers/pkcs12.c
@@ -90,9 +90,6 @@ static EVP_PKEY *load_pkey_asn1(const unsigned char *bytes, int len)
     EVP_PKEY *pkey = NULL;
 
     pkey = d2i_AutoPrivateKey(NULL, &bytes, len);
-    if (!TEST_ptr(pkey))
-        goto err;
-err:
     return pkey;
 }
 


### PR DESCRIPTION
The same code is executed whether the following condition is true or false.

if (!TEST_ptr(pkey))
    goto err;
err:
    return pkey;

CLA: trivial
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
