### PR TITLE
Bad bit shift operation

### DIFF
--- a/crypto/whrlpool/wp_dgst.c
+++ b/crypto/whrlpool/wp_dgst.c
@@ -173,7 +173,7 @@ void WHIRLPOOL_BitUpdate(WHIRLPOOL_CTX *c, const void *_inp, size_t bits)
             } else
 #endif
             if (bits > 8) {
-                b = ((inp[0] << inpgap) | (inp[1] >> (8 - inpgap)));
+                b = inpgap ? ((inp[0] << inpgap) | (inp[1] >> (8 - inpgap))) : (inp[0] << inpgap);
                 b &= 0xff;
                 if (bitrem)
                     c->data[byteoff++] |= b >> bitrem;


### PR DESCRIPTION
In following expression, if inggap == 0 then right shifting inp[1] by more than 7 bits always yields zero.

b = ((inp[0] << inpgap) | (inp[1] >> (8 - inpgap)));

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
