### PR TITLE
Fix testcases to run on duplicated keys

### DIFF
--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1164,7 +1164,7 @@ static int test_EC_priv_only_legacy(void)
         goto err;
     eckey = NULL;
 
-    while (dup_pk == NULL) {
+    for (;;) {
         ret = 0;
         ctx = EVP_MD_CTX_new();
         if (!TEST_ptr(ctx))
@@ -1180,6 +1180,9 @@ static int test_EC_priv_only_legacy(void)
         EVP_MD_CTX_free(ctx);
         ctx = NULL;
 
+        if (dup_pk != NULL)
+            break;
+
         if (!TEST_ptr(dup_pk = EVP_PKEY_dup(pkey)))
             goto err;
         /* EVP_PKEY_eq() returns -2 with missing public keys */
@@ -1189,6 +1192,7 @@ static int test_EC_priv_only_legacy(void)
         if (!ret)
             goto err;
     }
+    ret = 1;
 
  err:
     EVP_MD_CTX_free(ctx);

--- a/test/evp_pkey_provided_test.c
+++ b/test/evp_pkey_provided_test.c
@@ -1704,6 +1704,15 @@ static int test_fromdata_ec(void)
             || !TEST_BN_eq(group_b, b))
             goto err;
 
+        EC_GROUP_free(group);
+        group = NULL;
+        BN_free(group_p);
+        group_p = NULL;
+        BN_free(group_a);
+        group_a = NULL;
+        BN_free(group_b);
+        group_b = NULL;
+
         if (!EVP_PKEY_get_utf8_string_param(pk, OSSL_PKEY_PARAM_GROUP_NAME,
                                             out_curve_name,
                                             sizeof(out_curve_name),

--- a/test/evp_pkey_provided_test.c
+++ b/test/evp_pkey_provided_test.c
@@ -389,7 +389,7 @@ static int test_fromdata_rsa(void)
                                           fromdata_params), 1))
         goto err;
 
-    while (dup_pk == NULL) {
+    for (;;) {
         ret = 0;
         if (!TEST_int_eq(EVP_PKEY_get_bits(pk), 32)
             || !TEST_int_eq(EVP_PKEY_get_security_bits(pk), 8)
@@ -417,7 +417,10 @@ static int test_fromdata_rsa(void)
         ret = test_print_key_using_pem("RSA", pk)
               && test_print_key_using_encoder("RSA", pk);
 
-        if (!ret || !TEST_ptr(dup_pk = EVP_PKEY_dup(pk)))
+        if (!ret || dup_pk != NULL)
+            break;
+
+        if (!TEST_ptr(dup_pk = EVP_PKEY_dup(pk)))
             goto err;
         ret = ret && TEST_int_eq(EVP_PKEY_eq(pk, dup_pk), 1);
         EVP_PKEY_free(pk);
@@ -489,7 +492,7 @@ static int do_fromdata_rsa_derive(OSSL_PARAM *fromdata_params,
         check_bn = NULL;
     }
 
-    while (dup_pk == NULL) {
+    for (;;) {
         if (!TEST_int_eq(EVP_PKEY_get_bits(pk), expected_nbits)
             || !TEST_int_eq(EVP_PKEY_get_security_bits(pk), expected_sbits)
             || !TEST_int_eq(EVP_PKEY_get_size(pk), expected_ksize)
@@ -512,6 +515,9 @@ static int do_fromdata_rsa_derive(OSSL_PARAM *fromdata_params,
             goto err;
         EVP_PKEY_free(copy_pk);
         copy_pk = NULL;
+
+        if (dup_pk != NULL)
+            break;
 
         if (!TEST_ptr(dup_pk = EVP_PKEY_dup(pk)))
             goto err;
@@ -994,7 +1000,7 @@ static int test_fromdata_dh_named_group(void)
                                                       &len)))
         goto err;
 
-    while (dup_pk == NULL) {
+    for (;;) {
         ret = 0;
         if (!TEST_int_eq(EVP_PKEY_get_bits(pk), 2048)
             || !TEST_int_eq(EVP_PKEY_get_security_bits(pk), 112)
@@ -1074,7 +1080,10 @@ static int test_fromdata_dh_named_group(void)
         ret = test_print_key_using_pem("DH", pk)
               && test_print_key_using_encoder("DH", pk);
 
-        if (!ret || !TEST_ptr(dup_pk = EVP_PKEY_dup(pk)))
+        if (!ret || dup_pk != NULL)
+            break;
+
+        if (!TEST_ptr(dup_pk = EVP_PKEY_dup(pk)))
             goto err;
         ret = ret && TEST_int_eq(EVP_PKEY_eq(pk, dup_pk), 1);
         EVP_PKEY_free(pk);
@@ -1175,7 +1184,7 @@ static int test_fromdata_dh_fips186_4(void)
                                           fromdata_params), 1))
         goto err;
 
-    while (dup_pk == NULL) {
+    for (;;) {
         ret = 0;
         if (!TEST_int_eq(EVP_PKEY_get_bits(pk), 2048)
             || !TEST_int_eq(EVP_PKEY_get_security_bits(pk), 112)
@@ -1249,7 +1258,10 @@ static int test_fromdata_dh_fips186_4(void)
         ret = test_print_key_using_pem("DH", pk)
               && test_print_key_using_encoder("DH", pk);
 
-        if (!ret || !TEST_ptr(dup_pk = EVP_PKEY_dup(pk)))
+        if (!ret || dup_pk != NULL)
+            break;
+
+        if (!TEST_ptr(dup_pk = EVP_PKEY_dup(pk)))
             goto err;
         ret = ret && TEST_int_eq(EVP_PKEY_eq(pk, dup_pk), 1);
         EVP_PKEY_free(pk);
@@ -1483,7 +1495,7 @@ static int test_fromdata_ecx(int tst)
                                           fromdata_params), 1))
         goto err;
 
-    while (dup_pk == NULL) {
+    for (;;) {
         ret = 0;
         if (!TEST_int_eq(EVP_PKEY_get_bits(pk), bits)
             || !TEST_int_eq(EVP_PKEY_get_security_bits(pk), security_bits)
@@ -1532,7 +1544,10 @@ static int test_fromdata_ecx(int tst)
             ret = test_print_key_using_pem(alg, pk)
                   && test_print_key_using_encoder(alg, pk);
 
-        if (!ret || !TEST_ptr(dup_pk = EVP_PKEY_dup(pk)))
+        if (!ret || dup_pk != NULL)
+            break;
+
+        if (!TEST_ptr(dup_pk = EVP_PKEY_dup(pk)))
             goto err;
         ret = ret && TEST_int_eq(EVP_PKEY_eq(pk, dup_pk), 1);
         EVP_PKEY_free(pk);
@@ -1650,7 +1665,7 @@ static int test_fromdata_ec(void)
                                           fromdata_params), 1))
         goto err;
 
-    while (dup_pk == NULL) {
+    for (;;) {
         ret = 0;
         if (!TEST_int_eq(EVP_PKEY_get_bits(pk), 256)
             || !TEST_int_eq(EVP_PKEY_get_security_bits(pk), 128)
@@ -1717,7 +1732,10 @@ static int test_fromdata_ec(void)
         ret = test_print_key_using_pem(alg, pk)
               && test_print_key_using_encoder(alg, pk);
 
-        if (!ret || !TEST_ptr(dup_pk = EVP_PKEY_dup(pk)))
+        if (!ret || dup_pk != NULL)
+            break;
+
+        if (!TEST_ptr(dup_pk = EVP_PKEY_dup(pk)))
             goto err;
         ret = ret && TEST_int_eq(EVP_PKEY_eq(pk, dup_pk), 1);
         EVP_PKEY_free(pk);
@@ -1963,7 +1981,7 @@ static int test_fromdata_dsa_fips186_4(void)
                                           fromdata_params), 1))
         goto err;
 
-    while (dup_pk == NULL) {
+    for (;;) {
         ret = 0;
         if (!TEST_int_eq(EVP_PKEY_get_bits(pk), 2048)
             || !TEST_int_eq(EVP_PKEY_get_security_bits(pk), 112)
@@ -2012,12 +2030,12 @@ static int test_fromdata_dsa_fips186_4(void)
                                                  &pcounter_out))
             || !TEST_int_eq(pcounter, pcounter_out))
             goto err;
-        BN_free(p);
-        p = NULL;
-        BN_free(q);
-        q = NULL;
-        BN_free(g);
-        g = NULL;
+        BN_free(p_out);
+        p_out = NULL;
+        BN_free(q_out);
+        q_out = NULL;
+        BN_free(g_out);
+        g_out = NULL;
         BN_free(j_out);
         j_out = NULL;
         BN_free(pub_out);
@@ -2045,7 +2063,10 @@ static int test_fromdata_dsa_fips186_4(void)
         ret = test_print_key_using_pem("DSA", pk)
               && test_print_key_using_encoder("DSA", pk);
 
-        if (!ret || !TEST_ptr(dup_pk = EVP_PKEY_dup(pk)))
+        if (!ret || dup_pk != NULL)
+            break;
+
+        if (!TEST_ptr(dup_pk = EVP_PKEY_dup(pk)))
             goto err;
         ret = ret && TEST_int_eq(EVP_PKEY_eq(pk, dup_pk), 1);
         EVP_PKEY_free(pk);

--- a/test/keymgmt_internal_test.c
+++ b/test/keymgmt_internal_test.c
@@ -224,7 +224,7 @@ static int test_pass_rsa(FIXTURE *fixture)
         || !TEST_ptr_ne(km1, km2))
         goto err;
 
-    while (dup_pk == NULL) {
+    for (;;) {
         ret = 0;
         km = km3;
         /* Check that we can't export an RSA key into an RSA-PSS keymanager */
@@ -255,7 +255,11 @@ static int test_pass_rsa(FIXTURE *fixture)
         }
 
         ret = (ret == OSSL_NELEM(expected));
-        if (!ret || !TEST_ptr(dup_pk = EVP_PKEY_dup(pk)))
+
+        if (!ret || dup_pk != NULL)
+            break;
+
+        if (!TEST_ptr(dup_pk = EVP_PKEY_dup(pk)))
             goto err;
 
         ret = TEST_int_eq(EVP_PKEY_eq(pk, dup_pk), 1);


### PR DESCRIPTION
The existing loop pattern did not really run the expected tests on the duplicated keys.

Fixes #23129
