### PR TITLE
hurd: Fix dgram_sendmmsg

### DIFF
--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -61,6 +61,11 @@
 #   define NO_RECVMMSG
 #  endif
 # endif
+# if defined(__GNU__)
+   /* GNU/Hurd does not have IP_PKTINFO yet */
+   #undef NO_RECVMSG
+   #define NO_RECVMSG
+# endif
 # if !defined(M_METHOD)
 #  if defined(OPENSSL_SYS_WINDOWS) && defined(BIO_HAVE_WSAMSG) && !defined(NO_WSARECVMSG)
 #   define M_METHOD  M_METHOD_WSARECVMSG


### PR DESCRIPTION
GNU/Hurd does not have IP_PKTINFO yet, thus SUPPORT_LOCAL_ADDR is undef,
data->local_addr_enabled never set to 1, and thus the M_METHOD_RECVMSG
method would end up raising BIO_R_LOCAL_ADDR_NOT_AVAILABLE immediately.

Fixes #22872