### PR TITLE
Add missing genpkey -rand support

### DIFF
--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -24,7 +24,7 @@ typedef enum OPTION_choice {
     OPT_ENGINE, OPT_OUTFORM, OPT_OUT, OPT_PASS, OPT_PARAMFILE,
     OPT_ALGORITHM, OPT_PKEYOPT, OPT_GENPARAM, OPT_TEXT, OPT_CIPHER,
     OPT_VERBOSE, OPT_QUIET, OPT_CONFIG, OPT_OUTPUBKEY,
-    OPT_PROV_ENUM
+    OPT_PROV_ENUM, OPT_R_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS genpkey_options[] = {
@@ -51,6 +51,7 @@ const OPTIONS genpkey_options[] = {
     {"", OPT_CIPHER, '-', "Cipher to use to encrypt the key"},
 
     OPT_PROV_OPTIONS,
+    OPT_R_OPTIONS,
 
     /* This is deliberately last. */
     {OPT_HELP_STR, 1, 1,
@@ -188,12 +189,19 @@ int genpkey_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        case OPT_R_CASES:
+            if (!opt_rand(o))
+                goto end;
+            break;
         }
     }
 
     /* No extra arguments. */
     if (!opt_check_rest_arg(NULL))
         goto opthelp;
+
+    if (!app_RAND_load())
+        goto end;
 
     /* Fetch cipher, etc. */
     if (paramfile != NULL) {

--- a/doc/man1/openssl-genpkey.pod.in
+++ b/doc/man1/openssl-genpkey.pod.in
@@ -25,7 +25,9 @@ B<openssl> B<genpkey>
 [B<-pkeyopt> I<opt>:I<value>]
 [B<-genparam>]
 [B<-text>]
-{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 {- $OpenSSL::safe::opt_config_synopsis -}
 
 =head1 DESCRIPTION
@@ -118,6 +120,8 @@ are mutually exclusive.
 
 Print an (unencrypted) text representation of private and public keys and
 parameters along with the PEM or DER structure.
+
+{- $OpenSSL::safe::opt_r_item -}
 
 {- $OpenSSL::safe::opt_engine_item -}
 


### PR DESCRIPTION
The `openssl-genpkey(1)` command, unlike `genrsa`, did not support `-rand`. This looks to be an oversight.  No meaningful tests come to mind (none currently present for any of the other commands, and the implementation is shared across them all).

##### Checklist
- [x] documentation is added or updated

