### PR TITLE
Removed check which will never going to be met

### DIFF
--- a/test/p_test.c
+++ b/test/p_test.c
@@ -108,15 +108,11 @@ static int p_get_params(void *provctx, OSSL_PARAM params[])
             opensslv = provname = greeting = NULL;
 
             if (c_get_params(hand, counter_request)) {
-                if (greeting) {
-                    strcpy(buf, greeting);
-                } else {
-                    const char *versionp = *(void **)counter_request[0].data;
-                    const char *namep = *(void **)counter_request[1].data;
+                const char *versionp = *(void **)counter_request[0].data;
+                const char *namep = *(void **)counter_request[1].data;
 
-                    sprintf(buf, "Hello OpenSSL %.20s, greetings from %s!",
-                            versionp, namep);
-                }
+                sprintf(buf, "Hello OpenSSL %.20s, greetings from %s!",
+                        versionp, namep);
             } else {
                 sprintf(buf, "Howdy stranger...");
             }


### PR DESCRIPTION
greeting
Condition if (greeting) will never be true as greeting is to NULL at line 108. Hence removing this check.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
