### PR TITLE
Removed logically dead code from function inner_ossl_encoder_fetch

### DIFF
--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -411,9 +411,7 @@ inner_ossl_encoder_fetch(struct encoder_data_st *methdata,
 
     if ((id != 0 || name != NULL) && method == NULL) {
         int code = unsupported ? ERR_R_UNSUPPORTED : ERR_R_FETCH_FAILED;
-
-        if (name == NULL)
-            name = ossl_namemap_num2name(namemap, id, 0);
+        
         ERR_raise_data(ERR_LIB_OSSL_ENCODER, code,
                        "%s, Name (%s : %d), Properties (%s)",
                        ossl_lib_ctx_get_descriptor(methdata->libctx),


### PR DESCRIPTION
At line 412, condition will be true when id is not 0 or name is not NULL. And id can be 0 only when name is NULL. Means line no 415 will be executed only name is not NULL and check added at line 415 will never become true. Hence removing this check. 

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
