### PR TITLE
Uninitialized array variable

### DIFF
--- a/test/siphash_internal_test.c
+++ b/test/siphash_internal_test.c
@@ -257,7 +257,7 @@ static int test_siphash(int idx)
 static int test_siphash_basic(void)
 {
     SIPHASH siphash = { 0, };
-    unsigned char key[SIPHASH_KEY_SIZE] = {0};
+    static const unsigned char key[SIPHASH_KEY_SIZE] = {0};
     unsigned char output[SIPHASH_MAX_DIGEST_SIZE];
 
     /* Use invalid hash size */

--- a/test/siphash_internal_test.c
+++ b/test/siphash_internal_test.c
@@ -257,7 +257,7 @@ static int test_siphash(int idx)
 static int test_siphash_basic(void)
 {
     SIPHASH siphash = { 0, };
-    unsigned char key[SIPHASH_KEY_SIZE];
+    unsigned char key[SIPHASH_KEY_SIZE] = {0};
     unsigned char output[SIPHASH_MAX_DIGEST_SIZE];
 
     /* Use invalid hash size */


### PR DESCRIPTION
array"key" is uninitialized and it is being read directly in function SipHash_Init() as per the below statements making a way for the garbage values : uint64_t k0 = U8TO64_LE(k);
uint64_t k1 = U8TO64_LE(k + 8);

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
