### PR TITLE
LoongArch64: Fix PR #22817 introduced performance regression of ChaCha20

### DIFF
--- a/crypto/chacha/asm/chacha-loongarch64.pl
+++ b/crypto/chacha/asm/chacha-loongarch64.pl
@@ -71,6 +71,7 @@ ChaCha20_ctr32:
 	# $a4 = arg #5 (counter array)
 
 	beqz		$len,.Lno_data
+	ori			$t3,$zero,64
 	la.pcrel	$t0,OPENSSL_loongarch_hwcap_P
 	ld.w		$t0,$t0,0
 
@@ -461,7 +462,6 @@ EOF
 $code .= <<EOF;
 .align 6
 .LChaCha20_4x:
-	ori			$t3,$zero,64
 	addi.d		$sp,$sp,-128
 
 	# Save the initial block counter in $t4
@@ -886,7 +886,6 @@ EOF
 $code .= <<EOF;
 .align 6
 .LChaCha20_8x:
-	ori			$t3,$zero,64
 	addi.d		$sp,$sp,-128
 
 	# Save the initial block counter in $t4


### PR DESCRIPTION
In that pull request, the input length check was moved forward, but the related `ori $t3,$zero,64` instruction was missing, and it will cause input of any length down to the much slower scalar implementation. This fix that regression, and Fixes https://github.com/openssl/openssl/issues/23300.
