### PR TITLE
Fix references for GOST TLS 1.2 ciphersuite draft with rfc9189

### DIFF
--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -749,7 +749,7 @@ static STRINT_PAIR tlsext_types[] = {
     {NULL}
 };
 
-/* from rfc8446 4.2.3. + gost (https://tools.ietf.org/id/draft-smyshlyaev-tls12-gost-suites-04.html) */
+/* from rfc8446 4.2.3. */
 static STRINT_PAIR signature_tls13_scheme_list[] = {
     {"rsa_pkcs1_sha1",         0x0201 /* TLSEXT_SIGALG_rsa_pkcs1_sha1 */},
     {"ecdsa_sha1",             0x0203 /* TLSEXT_SIGALG_ecdsa_sha1 */},
@@ -770,8 +770,9 @@ static STRINT_PAIR signature_tls13_scheme_list[] = {
     {"rsa_pss_pss_sha384",     0x080a /* TLSEXT_SIGALG_rsa_pss_pss_sha384 */},
     {"rsa_pss_pss_sha512",     0x080b /* TLSEXT_SIGALG_rsa_pss_pss_sha512 */},
     {"gostr34102001",          0xeded /* TLSEXT_SIGALG_gostr34102001_gostr3411 */},
-    {"gostr34102012_256",      0xeeee /* TLSEXT_SIGALG_gostr34102012_256_gostr34112012_256 */},
-    {"gostr34102012_512",      0xefef /* TLSEXT_SIGALG_gostr34102012_512_gostr34112012_512 */},
+    /* rfc9189 */
+    {"gostr34102012_256",      0x0840 /* TLSEXT_SIGALG_gostr34102012_256_gostr34112012_256 */},
+    {"gostr34102012_512",      0x0841 /* TLSEXT_SIGALG_gostr34102012_512_gostr34112012_512 */},
     {NULL}
 };
 

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -94,7 +94,7 @@
 # define SSL_kRSAPSK             0x00000040U
 # define SSL_kECDHEPSK           0x00000080U
 # define SSL_kDHEPSK             0x00000100U
-/* GOST KDF key exchange, draft-smyshlyaev-tls12-gost-suites */
+/* GOST KDF key exchange, rfc9189 */
 # define SSL_kGOST18             0x00000200U
 
 /* all PSK */
@@ -231,7 +231,7 @@
  */
 # define TLS1_STREAM_MAC 0x10000
 /*
- * TLSTREE cipher/mac key derivation from draft-smyshlyaev-tls12-gost-suites
+ * TLSTREE cipher/mac key derivation from rfc9189
  * (currently this also  goes into algorithm2)
  */
 # define TLS1_TLSTREE 0x20000


### PR DESCRIPTION
Fixes #23231