### PR TITLE
Removed hard coded value for cap in function ossl_rsa_multip_cap

### DIFF
--- a/crypto/rsa/rsa_mp.c
+++ b/crypto/rsa/rsa_mp.c
@@ -97,7 +97,7 @@ int ossl_rsa_multip_calc_product(RSA *rsa)
 
 int ossl_rsa_multip_cap(int bits)
 {
-    int cap = 5;
+    int cap = RSA_MAX_PRIME_NUM;
 
     if (bits < 1024)
         cap = 2;


### PR DESCRIPTION
As suggested at https://github.com/openssl/openssl/pull/23280#discussion_r1452113014, removing hard coded value for cap.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
