### PR TITLE
Add a deprecation warning for SSL_get_peer_certificate() inside the documentation

### DIFF
--- a/doc/man3/SSL_get_peer_certificate.pod
+++ b/doc/man3/SSL_get_peer_certificate.pod
@@ -10,9 +10,14 @@ SSL_get1_peer_certificate - get the X509 certificate of the peer
 
  #include <openssl/ssl.h>
 
- X509 *SSL_get_peer_certificate(const SSL *ssl);
  X509 *SSL_get0_peer_certificate(const SSL *ssl);
  X509 *SSL_get1_peer_certificate(const SSL *ssl);
+
+The following function has been deprecated since OpenSSL 3.0,
+and can be hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable 
+version value, see L<openssl_user_macros(7)>:
+
+ X509 *SSL_get_peer_certificate(const SSL *ssl);
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
Fixes: #22972 

CLA: trivial

##### Checklist
- [x] documentation is added or updated
