### PR TITLE
Document SSL_R_UNEXPECTED_EOF_WHILE_READING (3.1)

### DIFF
--- a/doc/man3/SSL_get_error.pod
+++ b/doc/man3/SSL_get_error.pod
@@ -32,7 +32,9 @@ Some TLS implementations do not send a close_notify alert on shutdown.
 On an unexpected EOF, versions before OpenSSL 3.0 returned
 B<SSL_ERROR_SYSCALL>, nothing was added to the error stack, and errno was 0.
 Since OpenSSL 3.0 the returned error is B<SSL_ERROR_SSL> with a meaningful
-error on the error stack.
+error on the error stack (SSL_R_UNEXPECTED_EOF_WHILE_READING). This error reason
+code may be used for control flow decisions (see the man page for
+L<ERR_GET_REASON(3)> for further details on this).
 
 =head1 RETURN VALUES
 

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -300,6 +300,10 @@ int ssl3_read_n(SSL *s, size_t n, size_t max, int extend, int clearold,
                     SSL_set_shutdown(s, SSL_RECEIVED_SHUTDOWN);
                     s->s3.warn_alert = SSL_AD_CLOSE_NOTIFY;
                 } else {
+                    /*
+                     * This reason code is part of the API and may be used by
+                     * applications for control flow decisions.
+                     */
                     SSLfatal(s, SSL_AD_DECODE_ERROR,
                              SSL_R_UNEXPECTED_EOF_WHILE_READING);
                 }


### PR DESCRIPTION
Also document that it is ok to use this for control flow decisions.

Backport of #23304 to 3.1/3.0