### PR TITLE
`02-test_errstr.t`: add robustness on `openssl errstr` crashes

### DIFF
--- a/test/recipes/02-test_errstr.t
+++ b/test/recipes/02-test_errstr.t
@@ -134,8 +134,9 @@ sub match_opensslerr_reason {
     my @strings = @_;
 
     my $errcode_hex = sprintf "%x", $errcode;
-    my $reason =
-        ( run(app([ qw(openssl errstr), $errcode_hex ]), capture => 1) )[0];
+    my @res = run(app([ qw(openssl errstr), $errcode_hex ]), capture => 1);
+    return 0 unless $#res >= 0;
+    my $reason = $res[0];
     $reason =~ s|\R$||;
     $reason = ( split_error($reason) )[3];
 


### PR DESCRIPTION
It may happen, e.g., due to inconsistent local builds after switching branches,
that `openssl errstr` crashes. So far, this lead to much bulky and needless/confusing output like:
```
Use of uninitialized value $reason in substitution (s///) at test/recipes/02-test_errstr.t line 139.
Use of uninitialized value $_[0] in split at test/recipes/02-test_errstr.t line 97.
Use of uninitialized value $first in substitution (s///) at test/recipes/02-test_errstr.t line 116.
Use of uninitialized value $first in concatenation (.) or string at test/recipes/02-test_errstr.t line 119.
Use of uninitialized value $first in string eq at test/recipes/02-test_errstr.t line 126.
Use of uninitialized value $first in string eq at test/recipes/02-test_errstr.t line 126.
```
after lines like
```
../../util/wrap.pl ../../apps/openssl errstr 80000006 => 139
```
which after this fix do not appear any more.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
