### PR TITLE
Make the external tests CI less dependent on GH runners environment specifics

### DIFF
--- a/test/recipes/95-test_external_gost_engine_data/gost_engine.sh
+++ b/test/recipes/95-test_external_gost_engine_data/gost_engine.sh
@@ -45,7 +45,7 @@ echo "   OPENSSL_ROOT_DIR:   $OPENSSL_ROOT_DIR"
 echo "   OpenSSL version:    $OPENSSL_VERSION"
 echo "------------------------------------------------------------------"
 
-cmake $SRCTOP/gost-engine -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT_DIR"
+cmake $SRCTOP/gost-engine -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT_DIR" -DOPENSSL_ENGINES_DIR="$OPENSSL_ROOT_DIR/engines"
 make
 export CTEST_OUTPUT_ON_FAILURE=1
 export HARNESS_OSSL_PREFIX=''

--- a/test/recipes/95-test_external_tlsfuzzer_data/tlsfuzzer.sh
+++ b/test/recipes/95-test_external_tlsfuzzer_data/tlsfuzzer.sh
@@ -11,6 +11,7 @@
 # OpenSSL external testing using the TLSFuzzer test suite
 #
 set -e
+set -x
 
 PWD="$(pwd)"
 
@@ -31,11 +32,12 @@ export PATH="$O_EXE:$PATH"
 export LD_LIBRARY_PATH="$O_LIB:$LD_LIBRARY_PATH"
 export OPENSSL_ROOT_DIR="$O_LIB"
 
-# Check/Set openssl version
-OPENSSL_VERSION=$(${O_EXE}/openssl version | cut -f 2 -d ' ')
 
 CLI="${O_EXE}/openssl"
 SERV="${O_EXE}/openssl"
+
+# Check/Set openssl version
+OPENSSL_VERSION=$($CLI version | cut -f 2 -d ' ')
 
 TMPFILE="${PWD}/tls-fuzzer.$$.tmp"
 PSKFILE="${PWD}/tls-fuzzer.psk.$$.tmp"
@@ -51,6 +53,7 @@ echo "   BLDTOP:             $BLDTOP"
 echo "   OPENSSL_ROOT_DIR:   $OPENSSL_ROOT_DIR"
 echo "   Python:             $PYTHON"
 echo "   TESTDATADIR:        $TESTDATADIR"
+echo "   OPENSSL_VERSION:    $OPENSSL_VERSION"
 echo "------------------------------------------------------------------"
 
 cd "${SRCTOP}/tlsfuzzer"

--- a/test/recipes/95-test_external_tlsfuzzer_data/tlsfuzzer.sh
+++ b/test/recipes/95-test_external_tlsfuzzer_data/tlsfuzzer.sh
@@ -32,7 +32,7 @@ export LD_LIBRARY_PATH="$O_LIB:$LD_LIBRARY_PATH"
 export OPENSSL_ROOT_DIR="$O_LIB"
 
 # Check/Set openssl version
-OPENSSL_VERSION=`openssl version | cut -f 2 -d ' '`
+OPENSSL_VERSION=$(${O_EXE}/openssl version | cut -f 2 -d ' ')
 
 CLI="${O_EXE}/openssl"
 SERV="${O_EXE}/openssl"

--- a/test/recipes/95-test_external_tlsfuzzer_data/tlsfuzzer.sh
+++ b/test/recipes/95-test_external_tlsfuzzer_data/tlsfuzzer.sh
@@ -42,7 +42,7 @@ OPENSSL_VERSION=$($CLI version | cut -f 2 -d ' ')
 TMPFILE="${PWD}/tls-fuzzer.$$.tmp"
 PSKFILE="${PWD}/tls-fuzzer.psk.$$.tmp"
 
-PYTHON=`which python`
+PYTHON=`which python3`
 PORT=4433
 
 echo "------------------------------------------------------------------"


### PR DESCRIPTION
This PR makes it possible to run the external tests CI job on other runners.
