### PR TITLE
Remove mios-simulator-version-min from default iOS configuration

### DIFF
--- a/Configurations/15-ios.conf
+++ b/Configurations/15-ios.conf
@@ -19,14 +19,14 @@ my %targets = (
         # thus targeting iPhone pre-3GS, but it's assumed to be irrelevant
         # at this point.
         CC               => "xcrun -sdk iphoneos cc",
-        cflags           => add("-arch armv7 -mios-version-min=6.0.0 -fno-common"),
+        cflags           => add("-arch armv7 -fno-common"),
         asm_arch         => 'armv4',
         perlasm_scheme   => "ios32",
     },
     "ios64-xcrun" => {
         inherit_from     => [ "ios-common" ],
         CC               => "xcrun -sdk iphoneos cc",
-        cflags           => add("-arch arm64 -mios-version-min=7.0.0 -fno-common"),
+        cflags           => add("-arch arm64 -fno-common"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
         asm_arch         => 'aarch64',
         perlasm_scheme   => "ios64",
@@ -38,7 +38,7 @@ my %targets = (
     "iossimulator-arm64-xcrun" => {
         inherit_from     => [ "ios-common" ],
         CC               => "xcrun -sdk iphonesimulator cc",
-        cflags           => add("-arch arm64 -mios-simulator-version-min=7.0.0 -fno-common"),
+        cflags           => add("-arch arm64 -fno-common"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         asm_arch         => 'aarch64',
         perlasm_scheme   => "ios64",
@@ -46,7 +46,7 @@ my %targets = (
     "iossimulator-i386-xcrun" => {
         inherit_from     => [ "ios-common" ],
         CC               => "xcrun -sdk iphonesimulator cc",
-        cflags           => add("-arch i386 -mios-simulator-version-min=7.0.0 -fno-common"),
+        cflags           => add("-arch i386 -fno-common"),
         bn_ops           => "BN_LLONG",
         asm_arch         => 'x86',
         perlasm_scheme   => "macosx",
@@ -54,7 +54,7 @@ my %targets = (
     "iossimulator-x86_64-xcrun" => {
         inherit_from     => [ "ios-common" ],
         CC               => "xcrun -sdk iphonesimulator cc",
-        cflags           => add("-arch x86_64 -mios-simulator-version-min=7.0.0 -fno-common"),
+        cflags           => add("-arch x86_64 -fno-common"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         asm_arch         => 'x86_64',
         perlasm_scheme   => "macosx",


### PR DESCRIPTION
* iOS 6 and 7 got its last updates 2014.
* Adding -mios-simulator-version-min=14.0 to the configure command leads to two occurences of this parameter during compilation.
* So lets remove this values to allow a robust configuration from outside and avoid updates her in the future.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
