### PR TITLE
replace strstr() with strchr() for single characters

### DIFF
--- a/apps/engine.c
+++ b/apps/engine.c
@@ -251,7 +251,7 @@ static void util_do_cmds(ENGINE *e, STACK_OF(OPENSSL_STRING) *cmds,
         cmd = sk_OPENSSL_STRING_value(cmds, loop);
         res = 1;                /* assume success */
         /* Check if this command has no ":arg" */
-        if ((arg = strstr(cmd, ":")) == NULL) {
+        if ((arg = strchr(cmd, ':')) == NULL) {
             if (!ENGINE_ctrl_cmd_string(e, cmd, NULL, 0))
                 res = 0;
         } else {

--- a/crypto/dso/dso_dl.c
+++ b/crypto/dso/dso_dl.c
@@ -217,7 +217,7 @@ static char *dl_name_converter(DSO *dso, const char *filename)
 
     len = strlen(filename);
     rsize = len + 1;
-    transform = (strstr(filename, "/") == NULL);
+    transform = (strchr(filename, '/') == NULL);
     if (transform) {
         /* We will convert this to "%s.s?" or "lib%s.s?" */
         rsize += strlen(DSO_EXTENSION); /* The length of ".s?" */

--- a/crypto/dso/dso_dlfcn.c
+++ b/crypto/dso/dso_dlfcn.c
@@ -251,7 +251,7 @@ static char *dlfcn_name_converter(DSO *dso, const char *filename)
 
     len = strlen(filename);
     rsize = len + 1;
-    transform = (strstr(filename, "/") == NULL);
+    transform = (strchr(filename, '/') == NULL);
     if (transform) {
         /* We will convert this to "%s.so" or "lib%s.so" etc */
         rsize += strlen(DSO_EXTENSION);    /* The length of ".so" */

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -241,7 +241,7 @@ static int cmd_ECDHParameters(SSL_CONF_CTX *cctx, const char *value)
         return 1;
 
     /* ECDHParameters accepts a single group name */
-    if (strstr(value, ":") != NULL)
+    if (strchr(value, ':') != NULL)
         return 0;
 
     if (cctx->ctx)


### PR DESCRIPTION
strstr() is used to match multiple characters in the haystack, whereas strchr() is used to match only single character.

Files changed: `apps/engine.c`, `crypto/dso/dso_dl.c`, `crypto/dso/dso_dlfcn.c`, and `ssl/ssl_conf.c`
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->