### PR TITLE
Fix parsing sets/sequences with 0 length, encoded in the long-form.

### DIFF
--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -129,7 +129,7 @@ static int asn1_get_length(const unsigned char **pp, int *inf, long *rl,
         *inf = 0;
         i = *p & 0x7f;
         if (*p++ & 0x80) {
-            if (max < i + 1)
+            if (max < i)
                 return 0;
             /* Skip leading zeroes */
             while (i > 0 && *p == 0) {

--- a/test/asn1_decode_test.c
+++ b/test/asn1_decode_test.c
@@ -220,6 +220,38 @@ err:
     return ret;
 }
 
+static int test_empty_sequence(void)
+{
+    static unsigned char empty_set[] = { 0x30, 0x84, 0x0, 0x0, 0x0, 0x0 };
+    int ret = 0;
+    unsigned char const *p = empty_set;
+
+    ASN1_SEQUENCE_ANY *obj = d2i_ASN1_SEQUENCE_ANY(NULL, &p, sizeof(empty_set));
+    /* Create an object out of the empty sequence */
+    if (!TEST_ptr(obj))
+        goto err;
+    ret = 1;
+err:
+    sk_ASN1_TYPE_free(obj);
+    return ret;
+}
+
+static int test_empty_set(void)
+{
+    static unsigned char empty_set[] = { 0x31, 0x84, 0x0, 0x0, 0x0, 0x0 };
+    int ret = 0;
+    unsigned char const *p = empty_set;
+
+    ASN1_SEQUENCE_ANY *obj = d2i_ASN1_SET_ANY(NULL, &p, sizeof(empty_set));
+    /* Create an object out of the empty set */
+    if (!TEST_ptr(obj))
+        goto err;
+    ret = 1;
+err:
+    sk_ASN1_TYPE_free(obj);
+    return ret;
+}
+
 int setup_tests(void)
 {
 #ifndef OPENSSL_NO_DEPRECATED_3_0
@@ -231,5 +263,7 @@ int setup_tests(void)
     ADD_TEST(test_uint64);
     ADD_TEST(test_invalid_template);
     ADD_TEST(test_reuse_asn1_object);
+    ADD_TEST(test_empty_sequence);
+    ADD_TEST(test_empty_set);
     return 1;
 }


### PR DESCRIPTION
The length parsing required a max len of long form encoding + 1, this does not work when the encoded set/sequence is empty. Thus the parser would reject valid input.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
