### PR TITLE
Fix a possible memory leak in req_main

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -704,7 +704,7 @@ int req_main(int argc, char **argv)
             }
             goto end;
         }
-        BIO_free(out);
+        BIO_free_all(out);
         out = NULL;
         BIO_printf(bio_err, "-----\n");
     }


### PR DESCRIPTION
if the private key is output to stdout using the HARNESS_OSSL_PREFIX, out is a stack of BIOs and must therefore free'd using BIO_free_all.

Steps to reproduce:

$ HARNESS_OSSL_PREFIX=x OPENSSL_CONF=apps/openssl.cnf util/shlib_wrap.sh apps/openssl req -new -keyout - -passout pass: </dev/null [...]
Direct leak of 128 byte(s) in 1 object(s) allocated from:
    #0 0x7f6f692b89cf in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7f6f686eda00 in CRYPTO_malloc crypto/mem.c:202
    #2 0x7f6f686edba0 in CRYPTO_zalloc crypto/mem.c:222
    #3 0x7f6f68471bdf in BIO_new_ex crypto/bio/bio_lib.c:83
    #4 0x7f6f68491a8f in BIO_new_fp crypto/bio/bss_file.c:95
    #5 0x555c5f58b378 in dup_bio_out apps/lib/apps.c:3014
    #6 0x555c5f58f9ac in bio_open_default_ apps/lib/apps.c:3175
    #7 0x555c5f58f9ac in bio_open_default apps/lib/apps.c:3203
    #8 0x555c5f528537 in req_main apps/req.c:683
    #9 0x555c5f50e315 in do_cmd apps/openssl.c:426
    #10 0x555c5f4c5575 in main apps/openssl.c:307
    #11 0x7f6f680461c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: 128 byte(s) leaked in 1 allocation(s).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
