### PR TITLE
Version the ossl-modules directory

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -318,7 +318,7 @@ LIBDIR={- our $libdir = $config{libdir};
 libdir={- file_name_is_absolute($libdir)
           ? $libdir : '$(INSTALLTOP)/$(LIBDIR)' -}
 ENGINESDIR=$(libdir)/engines-{- $sover_dirname -}
-MODULESDIR=$(libdir)/ossl-modules
+MODULESDIR=$(libdir)/ossl-modules-{- $sover_dirname -}
 
 # Convenience variable for those who want to set the rpath in shared
 # libraries and applications

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -228,7 +228,7 @@ MODULESDIR_dev={- use File::Spec::Functions qw(:DEFAULT splitpath catpath);
                       splitpath($modulesprefix, 1);
                   our $modulesdir_dev = $modulesprefix_dev;
                   our $modulesdir_dir =
-                      catdir($modulesprefix_dir, "ossl-modules");
+                      catdir($modulesprefix_dir, "ossl-modules-$sover_dirname");
                   our $modulesdir = catpath($modulesdir_dev, $modulesdir_dir);
                   our $enginesdir_dev = $modulesprefix_dev;
                   our $enginesdir_dir =

--- a/README-FIPS.md
+++ b/README-FIPS.md
@@ -63,8 +63,8 @@ the FIPS provider independently, without installing the rest of OpenSSL.
 The Installation of the FIPS provider consists of two steps. In the first step,
 the shared library is copied to its installed location, which by default is
 
-    /usr/local/lib/ossl-modules/fips.so                  on Unix, and
-    C:\Program Files\OpenSSL\lib\ossl-modules\fips.dll   on Windows.
+    /usr/local/lib/ossl-modules-3.2/fips.so                  on Unix, and
+    C:\Program Files\OpenSSL\lib\ossl-modules-3.2\fips.dll   on Windows.
 
 In the second step, the `openssl fipsinstall` command is executed, which completes
 the installation by doing the following two things:
@@ -80,7 +80,7 @@ you must not copy the FIPS module config file output data from one machine to an
 
 On Unix, the `openssl fipsinstall` command will be invoked as follows by default:
 
-    $ openssl fipsinstall -out /usr/local/ssl/fipsmodule.cnf -module /usr/local/lib/ossl-modules/fips.so
+    $ openssl fipsinstall -out /usr/local/ssl/fipsmodule.cnf -module /usr/local/lib/ossl-modules-3.2/fips.so
 
 If you configured OpenSSL to be installed to a different location, the paths will
 vary accordingly. In the rare case that you need to install the fipsmodule.cnf


### PR DESCRIPTION
The engines directory is already versioned so that the directory name changes if the ABI breaks. In order to safely support provider modules that come from a source other than the main openssl build, version the provider module directory as well.

In Ubuntu we would like to package our FIPS provider in a separate package. This would help us make sure that we can safely do this without getting ABI conflicts.