### PR TITLE
fix missing null check in kdf_test_ctrl

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -2860,7 +2860,7 @@ static int kdf_test_ctrl(EVP_TEST *t, EVP_KDF_CTX *kctx,
         return 0;
     p = strchr(name, ':');
     if (p == NULL)
-        return 0;
+        p = "";
     else
         *p++ = '\0';
 
@@ -2914,30 +2914,29 @@ static int kdf_test_ctrl(EVP_TEST *t, EVP_KDF_CTX *kctx,
     }
 
     rv = OSSL_PARAM_allocate_from_text(kdata->p, defs, name, p,
-                                       p != NULL ? strlen(p) : 0, NULL);
+                                       strlen(p), NULL);
     *++kdata->p = OSSL_PARAM_construct_end();
     if (!rv) {
         t->err = "KDF_PARAM_ERROR";
         OPENSSL_free(name);
         return 0;
     }
-    if (p != NULL && strcmp(name, "digest") == 0) {
+    if (strcmp(name, "digest") == 0) {
         if (is_digest_disabled(p)) {
             TEST_info("skipping, '%s' is disabled", p);
             t->skip = 1;
         }
         goto end;
     }
-    if (p != NULL
-        && (strcmp(name, "cipher") == 0
-            || strcmp(name, "cekalg") == 0)
+
+    if ((strcmp(name, "cipher") == 0
+        || strcmp(name, "cekalg") == 0)
         && is_cipher_disabled(p)) {
         TEST_info("skipping, '%s' is disabled", p);
         t->skip = 1;
         goto end;
     }
-    if (p != NULL
-        && (strcmp(name, "mac") == 0)
+    if ((strcmp(name, "mac") == 0)
         && is_mac_disabled(p)) {
         TEST_info("skipping, '%s' is disabled", p);
         t->skip = 1;

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -2859,7 +2859,9 @@ static int kdf_test_ctrl(EVP_TEST *t, EVP_KDF_CTX *kctx,
     if (!TEST_ptr(name = OPENSSL_strdup(value)))
         return 0;
     p = strchr(name, ':');
-    if (p != NULL)
+    if (p == NULL)
+        return 0;
+    else
         *p++ = '\0';
 
     if (strcmp(name, "r") == 0


### PR DESCRIPTION
Coverity issue 1453632 noted a missing null check in kdf_test_ctrl recently.  If a malformed value is passed in from the test file that does not contain a ':' character, the p variable will be NULL, leading to a NULL derefence prepare_from_text

