### PR TITLE
Fix off-by-one in ebcdic2ascii()

### DIFF
--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -247,7 +247,7 @@ static int buf2hexstr_sep(char *str, size_t str_n, size_t *strlength,
     *q = CH_ZERO;
 
 #ifdef CHARSET_EBCDIC
-    ebcdic2ascii(str, str, q - str - 1);
+    ebcdic2ascii(str, str, q - str);
 #endif
     return 1;
 }


### PR DESCRIPTION
Fixes #23363

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
