### PR TITLE
Fix a possible memleak in bind_afalg

### DIFF
--- a/engines/e_afalg.c
+++ b/engines/e_afalg.c
@@ -834,8 +834,10 @@ static int bind_helper(ENGINE *e, const char *id)
     if (!afalg_chk_platform())
         return 0;
 
-    if (!bind_afalg(e))
+    if (!bind_afalg(e)) {
+        afalg_destroy(e);
         return 0;
+    }
     return 1;
 }
 


### PR DESCRIPTION
bind_afalg calls afalg_aes_cbc which allocates
cipher_handle->_hidden global object(s)
but if one of them fails due to out of memory,
the function bind_afalg relies on the engine destroy method to be called.  But that does not happen
because the dynamic engine object is not destroyed in the usual way in dynamic_load in this case:

If the bind_engine function fails, there will be no further calls into the shared object.
See ./crypto/engine/eng_dyn.c near the comment:
/* Copy the original ENGINE structure back */
