### PR TITLE
Drop the legacy name pilfering scheme for namemaps

### DIFF
--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -371,156 +371,16 @@ end:
 }
 
 /*-
- * Pre-population
- * ==============
- */
-
-#ifndef FIPS_MODULE
-#include <openssl/evp.h>
-
-/* Creates an initial namemap with names found in the legacy method db */
-static void get_legacy_evp_names(int base_nid, int nid, const char *pem_name,
-    void *arg)
-{
-    int num = 0;
-    ASN1_OBJECT *obj;
-
-    if (base_nid != NID_undef) {
-        num = ossl_namemap_add_name(arg, num, OBJ_nid2sn(base_nid));
-        num = ossl_namemap_add_name(arg, num, OBJ_nid2ln(base_nid));
-    }
-
-    if (nid != NID_undef) {
-        num = ossl_namemap_add_name(arg, num, OBJ_nid2sn(nid));
-        num = ossl_namemap_add_name(arg, num, OBJ_nid2ln(nid));
-        if ((obj = OBJ_nid2obj(nid)) != NULL) {
-            char txtoid[OSSL_MAX_NAME_SIZE];
-
-            if (OBJ_obj2txt(txtoid, sizeof(txtoid), obj, 1) > 0)
-                num = ossl_namemap_add_name(arg, num, txtoid);
-        }
-    }
-    if (pem_name != NULL)
-        num = ossl_namemap_add_name(arg, num, pem_name);
-}
-
-static void get_legacy_cipher_names(const OBJ_NAME *on, void *arg)
-{
-    const EVP_CIPHER *cipher = (void *)OBJ_NAME_get(on->name, on->type);
-
-    if (cipher != NULL)
-        get_legacy_evp_names(NID_undef, EVP_CIPHER_get_type(cipher), NULL, arg);
-}
-
-static void get_legacy_md_names(const OBJ_NAME *on, void *arg)
-{
-    const EVP_MD *md = (void *)OBJ_NAME_get(on->name, on->type);
-
-    if (md != NULL)
-        get_legacy_evp_names(NID_undef, EVP_MD_get_type(md), NULL, arg);
-}
-
-#ifndef OPENSSL_NO_DEPRECATED_3_6
-static void get_legacy_pkey_meth_names(const EVP_PKEY_ASN1_METHOD *ameth,
-    void *arg)
-{
-    int nid = 0, base_nid = 0, flags = 0;
-    const char *pem_name = NULL;
-
-    evp_pkey_asn1_get0_info(&nid, &base_nid, &flags, NULL, &pem_name, ameth);
-    if (nid != NID_undef) {
-        if ((flags & ASN1_PKEY_ALIAS) == 0) {
-            switch (nid) {
-            case EVP_PKEY_DHX:
-                /* We know that the name "DHX" is used too */
-                get_legacy_evp_names(0, nid, "DHX", arg);
-                /* FALLTHRU */
-            default:
-                get_legacy_evp_names(0, nid, pem_name, arg);
-            }
-        } else {
-            /*
-             * Treat aliases carefully, some of them are undesirable, or
-             * should not be treated as such for providers.
-             */
-
-            switch (nid) {
-            case EVP_PKEY_SM2:
-                /*
-                 * SM2 is a separate keytype with providers, not an alias for
-                 * EC.
-                 */
-                get_legacy_evp_names(0, nid, pem_name, arg);
-                break;
-            default:
-                /* Use the short name of the base nid as the common reference */
-                get_legacy_evp_names(base_nid, nid, pem_name, arg);
-            }
-        }
-    }
-}
-#endif /* OPENSSL_NO_DEPRECATED_3_6 */
-#endif
-
-/*-
  * Constructors / destructors
  * ==========================
  */
 
 OSSL_NAMEMAP *ossl_namemap_stored(OSSL_LIB_CTX *libctx)
 {
-#ifndef FIPS_MODULE
-    int nms;
-#endif
     OSSL_NAMEMAP *namemap = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_NAMEMAP_INDEX);
 
     if (namemap == NULL)
         return NULL;
-
-#ifndef FIPS_MODULE
-    nms = ossl_namemap_empty(namemap);
-    if (nms < 0) {
-        /*
-         * Could not get lock to make the count, so maybe internal objects
-         * weren't added. This seems safest.
-         */
-        return NULL;
-    }
-    if (nms == 1) {
-        int num;
-
-        /* Before pilfering, we make sure the legacy database is populated */
-        OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS
-                | OPENSSL_INIT_ADD_ALL_DIGESTS,
-            NULL);
-
-        OBJ_NAME_do_all(OBJ_NAME_TYPE_CIPHER_METH,
-            get_legacy_cipher_names, namemap);
-        OBJ_NAME_do_all(OBJ_NAME_TYPE_MD_METH,
-            get_legacy_md_names, namemap);
-
-        /*
-         * Some old providers (<= 3.5) may not have the rsassaPSS alias which
-         * may cause problems in some cases. We add it manually here
-         */
-        num = ossl_namemap_add_name(namemap, 0, "RSA-PSS");
-        if (num != 0) {
-            ossl_namemap_add_name(namemap, num, "rsassaPss");
-            /* Add other RSA-PSS aliases as well */
-            ossl_namemap_add_name(namemap, num, "RSASSA-PSS");
-            ossl_namemap_add_name(namemap, num, "1.2.840.113549.1.1.10");
-        }
-#ifndef OPENSSL_NO_DEPRECATED_3_6
-        {
-            int i, end;
-
-            /* We also pilfer data from the legacy EVP_PKEY_ASN1_METHODs */
-            for (i = 0, end = evp_pkey_asn1_get_count(); i < end; i++)
-                get_legacy_pkey_meth_names(evp_pkey_asn1_get0(i), namemap);
-        }
-#endif
-    }
-#endif
 
     return namemap;
 }

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -848,6 +848,15 @@ static void *evp_md_from_algorithm(int name_id,
         md->flags |= EVP_MD_FLAG_NO_STORE;
 
 #ifndef FIPS_MODULE
+    /*
+     * set_legacy_nid() looks up names in the legacy method database, so
+     * that must be populated first.
+     */
+    if (!OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_DIGESTS, NULL)) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_INTERNAL_ERROR);
+        goto err;
+    }
+
     md->type = NID_undef;
     if (!evp_names_do_all(prov, name_id, set_legacy_nid, &md->type)
         || md->type == -1) {

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1389,6 +1389,15 @@ static void *evp_cipher_from_algorithm(const int name_id,
         cipher->flags |= EVP_CIPH_FLAG_NO_STORE;
 
 #ifndef FIPS_MODULE
+    /*
+     * set_legacy_nid() looks up names in the legacy method database, so
+     * that must be populated first.
+     */
+    if (!OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS, NULL)) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_INTERNAL_ERROR);
+        goto err;
+    }
+
     cipher->nid = NID_undef;
     if (!evp_names_do_all(prov, name_id, set_legacy_nid, &cipher->nid)
         || cipher->nid == -1) {

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -764,8 +764,20 @@ int evp_is_a(OSSL_PROVIDER *prov, int number,
     OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
 
-    if (prov == NULL)
+    if (prov == NULL) {
+        /*
+         * When a legacy implementation is compared with its own name,
+         * it's trivially "a".  This must remain true when the namemap
+         * has no information yet.
+         */
+        if (name != NULL && legacy_name != NULL
+            && OPENSSL_strcasecmp(legacy_name, name) == 0)
+            return 1;
         number = ossl_namemap_name2num(namemap, legacy_name);
+        /* An unresolved legacy name can never make a positive match */
+        if (number == 0)
+            return 0;
+    }
     return ossl_namemap_name2num(namemap, name) == number;
 }
 


### PR DESCRIPTION
We've lived with the legacy aliases for long enough, it's time to drop them,
especially since since of them aren't quite right for providers.

If there are things breaking because of this, we need to review what's missing
in our providers' algorithm name strings.
