### PR TITLE
Fix error reporting in EVP_PKEY_{sign,verify,verify_recover}

### DIFF
--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -400,7 +400,7 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation,
 
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
+        return -1;
     }
 
     evp_pkey_ctx_free_old_ops(ctx);
@@ -631,7 +631,7 @@ int EVP_PKEY_sign(EVP_PKEY_CTX *ctx,
 
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
+        return -1;
     }
 
     if (ctx->operation != EVP_PKEY_OP_SIGN) {
@@ -680,7 +680,7 @@ int EVP_PKEY_verify(EVP_PKEY_CTX *ctx,
 
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
+        return -1;
     }
 
     if (ctx->operation != EVP_PKEY_OP_VERIFY) {
@@ -728,7 +728,7 @@ int EVP_PKEY_verify_recover(EVP_PKEY_CTX *ctx,
 
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
+        return -1;
     }
 
     if (ctx->operation != EVP_PKEY_OP_VERIFYRECOVER) {

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -399,8 +399,8 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation,
     int iter;
 
     if (ctx == NULL) {
-        ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
     }
 
     evp_pkey_ctx_free_old_ops(ctx);
@@ -630,8 +630,8 @@ int EVP_PKEY_sign(EVP_PKEY_CTX *ctx,
     int ret;
 
     if (ctx == NULL) {
-        ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
     }
 
     if (ctx->operation != EVP_PKEY_OP_SIGN) {
@@ -641,6 +641,11 @@ int EVP_PKEY_sign(EVP_PKEY_CTX *ctx,
 
     if (ctx->op.sig.algctx == NULL)
         goto legacy;
+
+    if (ctx->op.sig.signature->sign == NULL) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
+        return -2;
+    }
 
     ret = ctx->op.sig.signature->sign(ctx->op.sig.algctx, sig, siglen,
                                       (sig == NULL) ? 0 : *siglen, tbs, tbslen);
@@ -674,8 +679,8 @@ int EVP_PKEY_verify(EVP_PKEY_CTX *ctx,
     int ret;
 
     if (ctx == NULL) {
-        ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
     }
 
     if (ctx->operation != EVP_PKEY_OP_VERIFY) {
@@ -685,6 +690,11 @@ int EVP_PKEY_verify(EVP_PKEY_CTX *ctx,
 
     if (ctx->op.sig.algctx == NULL)
         goto legacy;
+
+    if (ctx->op.sig.signature->verify == NULL) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
+        return -2;
+    }
 
     ret = ctx->op.sig.signature->verify(ctx->op.sig.algctx, sig, siglen,
                                         tbs, tbslen);
@@ -717,8 +727,8 @@ int EVP_PKEY_verify_recover(EVP_PKEY_CTX *ctx,
     int ret;
 
     if (ctx == NULL) {
-        ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
     }
 
     if (ctx->operation != EVP_PKEY_OP_VERIFYRECOVER) {
@@ -728,6 +738,11 @@ int EVP_PKEY_verify_recover(EVP_PKEY_CTX *ctx,
 
     if (ctx->op.sig.algctx == NULL)
         goto legacy;
+
+    if (ctx->op.sig.signature->verify_recover == NULL) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
+        return -2;
+    }
 
     ret = ctx->op.sig.signature->verify_recover(ctx->op.sig.algctx, rout,
                                                 routlen,


### PR DESCRIPTION
For some reason, those functions (and the _init functions too) would
raise EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE when the passed
ctx is NULL, and then not check if the provider supplied the function
that would support these libcrypto functions.

This corrects the situation, and has all those libcrypto functions
raise ERR_R_PASS_NULL_PARAMETER if ctx is NULL, and then check for the
corresponding provider supplied, and only when that one is missing,
raise EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE.
