### PR TITLE
Fix compilation on Windows using icc

### DIFF
--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -101,7 +101,7 @@ static __inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
     return 1;
 }
 
-static __inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *val, int *refcnt)
+static __inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
     *ret = _InterlockedExchangeAdd((void *)&refcnt->val, -1) - 1;
     return 1;


### PR DESCRIPTION
The parameter list for CRYPTO_DOWN_REF for the icc on windows build was incorrect.

This issue was introduced by 99fd5b2b10

Note I do not have access to this environment to test this...

Fixes #23414