### PR TITLE
Add support in configuration for android-riscv64

### DIFF
--- a/Configurations/15-android.conf
+++ b/Configurations/15-android.conf
@@ -12,6 +12,7 @@
         arm64  => "aarch64-linux-android",
         mips   => "mipsel-linux-android",
         mips64 => "mips64el-linux-android",
+        riscv64 => "riscv64-linux-android",
         x86    => "i686-linux-android",
         x86_64 => "x86_64-linux-android",
     );
@@ -268,6 +269,12 @@ my %targets = (
         bn_ops           => add("RC4_INT"),
         asm_arch         => 'x86_64',
         perlasm_scheme   => "elf",
+    },
+
+    "android-riscv64" => {
+        inherit_from     => [ "android" ],
+        asm_arch         => 'riscv64',
+        perlasm_scheme   => "linux64",
     },
 
     ####################################################################

--- a/NOTES-ANDROID.md
+++ b/NOTES-ANDROID.md
@@ -17,8 +17,8 @@ Notes for Android platforms
  Android is a cross-compiled target and you can't rely on `./Configure`
  to find out the configuration target for you.  You have to name your
  target explicitly; there are `android-arm`, `android-arm64`, `android-mips`,
- `android-mip64`, `android-x86` and `android-x86_64` (`*MIPS` targets are no
- longer supported with NDK R20+).
+ `android-mip64`, `android-x86`, `android-x86_64` and `android-riscv64`
+ (`*MIPS` targets are no longer supported with NDK R20+).
 
  Do not pass --cross-compile-prefix (as you might be tempted), as it
  will be "calculated" automatically based on chosen platform. However,

--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -859,6 +859,7 @@ EOF
                                     cflags => [ '-march=armv7-a' ],
                                     cxxflags => [ '-march=armv7-a' ] } ],
       [ 'arm.*-.*-android',       { target => "android-armeabi" } ],
+      [ 'riscv64-.*-android',     { target => "android-riscv64" } ],
       [ '.*-hpux1.*',
         sub {
             my $KERNEL_BITS = $ENV{KERNEL_BITS};


### PR DESCRIPTION
Android is enabling support for the riscv64 ISA. Add a configuration option to support building for it, aligned with the existing linux-riscv64 configuration.

##### Checklist
- [x] documentation is added or updated