### PR TITLE
Move a CVE reference in CHANGES/NEWS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -160,6 +160,13 @@ OpenSSL 3.2
 
    *Rohan McLure*
 
+ * Disable building QUIC server utility when OpenSSL is configured with
+   `no-apps`.
+
+   *Vitalii Koshura*
+
+### Changes between 3.1 and 3.2.0 [23 Nov 2023]
+
  * Fix excessive time spent in DH check / generation with large Q parameter
    value.
 
@@ -173,13 +180,6 @@ OpenSSL 3.2
    ([CVE-2023-5678])
 
    *Richard Levitte*
-
- * Disable building QUIC server utility when OpenSSL is configured with
-   `no-apps`.
-
-   *Vitalii Koshura*
-
-### Changes between 3.1 and 3.2.0 [23 Nov 2023]
 
  * The BLAKE2b hash algorithm supports a configurable output length
    by setting the "size" parameter.

--- a/NEWS.md
+++ b/NEWS.md
@@ -43,9 +43,6 @@ This release incorporates the following bug fixes and mitigations:
   * Fixed POLY1305 MAC implementation corrupting vector registers on PowerPC
     CPUs which support PowerISA 2.07
     ([CVE-2023-6129])
-  * Fixed excessive time spent in DH check / generation with large Q parameter
-    value
-    [(CVE-2023-5678)]
 
 ### Major changes between OpenSSL 3.1 and OpenSSL 3.2.0 [23 Nov 2023]
 
@@ -120,6 +117,12 @@ This release incorporates the following documentation enhancements:
     on writing various clients (using TLS and QUIC protocols) with libssl
 
     See [OpenSSL Guide].
+
+This release incorporates the following bug fixes and mitigations:
+
+  * Fixed excessive time spent in DH check / generation with large Q parameter
+    value
+    [(CVE-2023-5678)]
 
 A more detailed list of changes in this release can be found in the
 [CHANGES.md] file.

--- a/NEWS.md
+++ b/NEWS.md
@@ -122,7 +122,7 @@ This release incorporates the following bug fixes and mitigations:
 
   * Fixed excessive time spent in DH check / generation with large Q parameter
     value
-    [(CVE-2023-5678)]
+    ([CVE-2023-5678])
 
 A more detailed list of changes in this release can be found in the
 [CHANGES.md] file.


### PR DESCRIPTION
master/3.2 was never vulnerable to CVE-2023-5678 since it was fixed before it was released.

