### PR TITLE
[Issue-23171] SSL_add_dir_cert_subjects_to_stack(): Return values undocumented

### DIFF
--- a/doc/man3/SSL_load_client_CA_file.pod
+++ b/doc/man3/SSL_load_client_CA_file.pod
@@ -66,6 +66,14 @@ The operation failed, check out the error stack for the reason.
 
 Pointer to the subject names of the successfully read certificates.
 
+=item 0
+
+The operation failed.
+
+=item 1
+
+The operation succeeded.
+
 =back
 
 =head1 EXAMPLES

--- a/doc/man3/SSL_load_client_CA_file.pod
+++ b/doc/man3/SSL_load_client_CA_file.pod
@@ -54,7 +54,8 @@ it is not limited to CA certificates.
 
 =head1 RETURN VALUES
 
-The following return values can occur:
+The following return values can occur for SSL_load_client_CA_file_ex(), and
+SSL_load_client_CA_file():
 
 =over 4
 
@@ -65,6 +66,12 @@ The operation failed, check out the error stack for the reason.
 =item Pointer to STACK_OF(X509_NAME)
 
 Pointer to the subject names of the successfully read certificates.
+
+
+The following return values can occur for SSL_add_file_cert_subjects_to_stack(),
+SSL_add_dir_cert_subjects_to_stack(), and SSL_add_store_cert_subjects_to_stack():
+
+=over 4
 
 =item 0
 

--- a/doc/man3/SSL_load_client_CA_file.pod
+++ b/doc/man3/SSL_load_client_CA_file.pod
@@ -67,17 +67,18 @@ The operation failed, check out the error stack for the reason.
 
 Pointer to the subject names of the successfully read certificates.
 
+=back
 
 The following return values can occur for SSL_add_file_cert_subjects_to_stack(),
 SSL_add_dir_cert_subjects_to_stack(), and SSL_add_store_cert_subjects_to_stack():
 
 =over 4
 
-=item 0
+=item 0 (Failure)
 
 The operation failed.
 
-=item 1
+=item 1 (Success)
 
 The operation succeeded.
 


### PR DESCRIPTION
…

In the man page for SSL_add_dir_cert_subjects_to_stack(), the functions returning int have undocumented return values.

https://www.openssl.org/docs/man3.2/man3/SSL_add_dir_cert_subjects_to_stack.html

#23171
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
