### PR TITLE
[Issue-23363] buf2hexstr_sep ebcdic2ascii translation off by 1

### DIFF
--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -247,7 +247,7 @@ static int buf2hexstr_sep(char *str, size_t str_n, size_t *strlength,
     *q = CH_ZERO;
 
 #ifdef CHARSET_EBCDIC
-    ebcdic2ascii(str, str, q - str - 1);
+    ebcdic2ascii(str, str, q - str);
 #endif
     return 1;
 }


### PR DESCRIPTION
**Issue:**

buf2hexstr_sep() function was updated in OpenSSL 3.0 so that the buffer q points to the last character in the buffer buf. Because of this change, the calculation for ebcdic2ascii is off by 1. q - str - 1 is 1 less than the length of buf, which results in all characters but the last to be translated in buf. 

**Solution:**
changing to ebcdic2ascii(str, str, q - str);

#23363

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
