### PR TITLE
[Issue-21203] X509_STORE_CTX_init manual page missing function name

### DIFF
--- a/doc/man3/X509_STORE_CTX_new.pod
+++ b/doc/man3/X509_STORE_CTX_new.pod
@@ -83,7 +83,9 @@ is no longer valid.
 If I<ctx> is NULL nothing is done.
 
 X509_STORE_CTX_init() sets up I<ctx> for a subsequent verification operation.
-It must be called before each call to L<X509_verify_cert(3)> or
+
+X509_STORE_CTX_init() initializes the internal state and resources of the 
+X509_STORE_CTX, and must be called before each call to L<X509_verify_cert(3)> or
 L<X509_STORE_CTX_verify(3)>, i.e., a context is only good for one verification.
 If you want to verify a further certificate or chain with the same I<ctx>
 then you must call X509_STORE_CTX_init() again.


### PR DESCRIPTION
**Issue:**
https://www.openssl.org/docs/man3.1/man3/X509_STORE_CTX_init.html
The text in the section covering {presumably} X509_STORE_CTX_init() does not properly name the function.
Currently:
It must be called before each call to X509_verify_cert(3) or X509_STORE_CTX_verify(3), i.e., a context is only good for one verification. [...]

**Solution:**
Should be:
X509_STORE_CTX_init() initializes the internal state and resources of the X509_STORE_CTX, and must be called before each call [...]

#21203

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
