### PR TITLE
Fix a few incorrect paths in some build.info files

### DIFF
--- a/crypto/aes/build.info
+++ b/crypto/aes/build.info
@@ -87,7 +87,7 @@ DEFINE[../../providers/libdefault.a]=$AESDEF
 # already gets everything that the static libcrypto.a has, and doesn't need it
 # added again.
 IF[{- !$disabled{module} && !$disabled{shared} -}]
-  DEFINE[../providers/liblegacy.a]=$AESDEF
+  DEFINE[../../providers/liblegacy.a]=$AESDEF
 ENDIF
 
 GENERATE[aes-ia64.s]=asm/aes-ia64.S

--- a/crypto/ec/build.info
+++ b/crypto/ec/build.info
@@ -103,7 +103,7 @@ DEFINE[../../providers/libdefault.a]=$ECDEF
 # Otherwise, it already gets everything that the static libcrypto.a
 # has, and doesn't need it added again.
 IF[{- !$disabled{module} && !$disabled{shared} -}]
-  DEFINE[../providers/liblegacy.a]=$ECDEF
+  DEFINE[../../providers/liblegacy.a]=$ECDEF
 ENDIF
 
 GENERATE[ecp_nistz256-x86.S]=asm/ecp_nistz256-x86.pl

--- a/crypto/sha/build.info
+++ b/crypto/sha/build.info
@@ -88,7 +88,7 @@ DEFINE[../../providers/libdefault.a]=$SHA1DEF $KECCAK1600DEF
 # linked with libcrypto.  Otherwise, it already gets everything that
 # the static libcrypto.a has, and doesn't need it added again.
 IF[{- !$disabled{module} && !$disabled{shared} -}]
-  DEFINE[../providers/liblegacy.a]=$SHA1DEF $KECCAK1600DEF
+  DEFINE[../../providers/liblegacy.a]=$SHA1DEF $KECCAK1600DEF
 ENDIF
 
 GENERATE[sha1-586.S]=asm/sha1-586.pl

--- a/crypto/sm4/build.info
+++ b/crypto/sm4/build.info
@@ -25,7 +25,7 @@ DEFINE[../../providers/libdefault.a]=$SM4DEF
 # already gets everything that the static libcrypto.a has, and doesn't need it
 # added again.
 IF[{- !$disabled{module} && !$disabled{shared} -}]
-  DEFINE[../providers/liblegacy.a]=$SM4DEF
+  DEFINE[../../providers/liblegacy.a]=$SM4DEF
 ENDIF
 
 GENERATE[sm4-armv8.S]=asm/sm4-armv8.pl


### PR DESCRIPTION
The following files referred to ../liblegacy.a when they should have
referred to ../../liblegacy.a.  This cause the creation of a mysterious
directory 'crypto/providers', and because of an increased strictness
with regards to where directories are created, configuration failure
on some platforms.

Fixes #23436
