### PR TITLE
Make IV/buf in prov_cipher_ctx_st aligned [3.0]

### DIFF
--- a/providers/implementations/include/prov/ciphercommon.h
+++ b/providers/implementations/include/prov/ciphercommon.h
@@ -42,6 +42,13 @@ typedef int (PROV_CIPHER_HW_FN)(PROV_CIPHER_CTX *dat, unsigned char *out,
 #define PROV_CIPHER_FLAG_INVERSE_CIPHER   0x0200
 
 struct prov_cipher_ctx_st {
+    /* place buffer at the beginning for memory alignment */
+    /* The original value of the iv */
+    unsigned char oiv[GENERIC_BLOCK_SIZE];
+    /* Buffer of partial blocks processed via update calls */
+    unsigned char buf[GENERIC_BLOCK_SIZE];
+    unsigned char iv[GENERIC_BLOCK_SIZE];
+
     block128_f block;
     union {
         cbc128_f cbc;
@@ -83,12 +90,6 @@ struct prov_cipher_ctx_st {
      * manage partial blocks themselves.
      */
     unsigned int num;
-
-    /* The original value of the iv */
-    unsigned char oiv[GENERIC_BLOCK_SIZE];
-    /* Buffer of partial blocks processed via update calls */
-    unsigned char buf[GENERIC_BLOCK_SIZE];
-    unsigned char iv[GENERIC_BLOCK_SIZE];
     const PROV_CIPHER_HW *hw; /* hardware specific functions */
     const void *ks; /* Pointer to algorithm specific key data */
     OSSL_LIB_CTX *libctx;


### PR DESCRIPTION
Make IV/buf aligned will drastically improve performance as some architecture performs badly on misaligned memory access.

Ref to
https://gist.github.com/ZenithalHourlyRate/7b5175734f87acb73d0bbc53391d7140#file-2-openssl-long-md Ref to
openssl#18197

Signed-off-by: Hongren (Zenithal) Zheng <i@zenithal.me>

Reviewed-by: Paul Dale <pauli@openssl.org>
Reviewed-by: Tomas Mraz <tomas@openssl.org>
(Merged from https://github.com/openssl/openssl/pull/18267)

(cherry picked from commit 2787a709c984d3884e1726383c2f2afca428d795)

This was approved for cherry-picking to 3.0 long ago in https://github.com/openssl/technical-policies/issues/70 but the decision wasn't implemented.
