### PR TITLE
Fix coverity missing_lock warnings

### DIFF
--- a/include/internal/rcu.h
+++ b/include/internal/rcu.h
@@ -25,7 +25,13 @@ void ossl_synchronize_rcu(CRYPTO_RCU_LOCK *lock);
 int ossl_rcu_call(CRYPTO_RCU_LOCK *lock, rcu_cb_fn cb, void *data);
 void *ossl_rcu_uptr_deref(void **p);
 void ossl_rcu_assign_uptr(void **p, void **v);
+
+#ifdef __COVERITY__
+#define ossl_rcu_deref(p) NULL
+#else
 #define ossl_rcu_deref(p) ossl_rcu_uptr_deref((void **)p)
+#endif
+
 #define ossl_rcu_assign_ptr(p,v) ossl_rcu_assign_uptr((void **)p, (void **)v)
 
 #endif


### PR DESCRIPTION
Coverity is warning about a missing lock on the rcu read side, which is expected, as thats how rcu works.

Fix it by excluding ossl_rcu_deref from being analyzed.  Redefine ossl_rcu_deref(p) to NULL so the read of the offending variable isn't done under coverity analysis


