### PR TITLE
Wrong release version for EVP_DigestSqueeze() in documentation

### DIFF
--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -805,8 +805,9 @@ EVP_MD_CTX_get0_md() instead.
 EVP_MD_CTX_update_fn() and EVP_MD_CTX_set_update_fn() were deprecated
 in OpenSSL 3.0.
 
-The functions EVP_MD_CTX_dup() and EVP_DigestSqueeze() were added in
-OpenSSL 3.3.0.
+The EVP_MD_CTX_dup() function was added in OpenSSL 3.1.
+
+The EVP_DigestSqueeze() function was added in OpenSSL 3.3.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -806,7 +806,7 @@ EVP_MD_CTX_update_fn() and EVP_MD_CTX_set_update_fn() were deprecated
 in OpenSSL 3.0.
 
 The functions EVP_MD_CTX_dup() and EVP_DigestSqueeze() were added in
-OpenSSL 3.2.
+OpenSSL 3.3.0.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
The mentioned functions are targeted for 3.3.0

Fixes #23461

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
