### PR TITLE
Add a missing space in an error message

### DIFF
--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -266,7 +266,7 @@ static int do_file(const char *filename, const char *fullpath, enum Hash h)
 
     if (sk_X509_INFO_num(inf) != 1) {
         BIO_printf(bio_err,
-                   "%s: warning: skipping %s,"
+                   "%s: warning: skipping %s, "
                    "it does not contain exactly one certificate or CRL\n",
                    opt_getprog(), filename);
         /* This is not an error. */


### PR DESCRIPTION
For the error message about "skipping %s,it does not contain exactly one certificate or CRL", add a missing space between the comma and the word that follows.