### PR TITLE
Configure: Fix ordering bug when processing split DEPENDs

### DIFF
--- a/Configure
+++ b/Configure
@@ -2473,10 +2473,11 @@ EOF
                     && $f =~ m/^(.*?)\|(.*)$/) {
                     $i = $1;
                     $m = $2;
-                    $i = cleanfile($sourced, $i, $blddir, 1);
-                    $i2 = cleanfile($buildd, $i, $blddir);
+                    # We must be very careful to modify $i last
                     $d = cleanfile($sourced, "$i/$m", $blddir, 1);
                     $d2 = cleanfile($buildd, "$i/$m", $blddir);
+                    $i2 = cleandir($buildd, $i, $blddir);
+                    $i = cleandir($sourced, $i, $blddir, 1);
                 } else {
                     $d = cleanfile($sourced, $f, $blddir, 1);
                     $d2 = cleanfile($buildd, $f, $blddir);


### PR DESCRIPTION
Configure was recently made to process this sort of line:

    DEPEND[generated]=util/perl|OpenSSL/something.pm

Unfortunately, in processing such lines, the order in which paths
were recomputed caused some resulting paths to be faulty under some
circumstances.  This change fixes that.

Fixes #22853
