### PR TITLE
`test_cmp_http`: decrease risk of timeouts due to delays by underlying system

### DIFF
--- a/test/recipes/80-test_cmp_http_data/Mock/test.cnf
+++ b/test/recipes/80-test_cmp_http_data/Mock/test.cnf
@@ -1,6 +1,7 @@
 [default]
 batch = 1 # do not use stdin
-total_timeout = 20  # = 2 * msg_timeout (see below) - used to prevent, e.g., infinite polling due to error
+total_timeout = 20  # is used to prevent, e.g., infinite polling due to error;
+# should hopefully be enough to cover delays caused by the underlying system
 trusted = trusted.crt
 newkey = new.key
 newkeypass =
@@ -44,7 +45,6 @@ sleep = 0
 ############################# aspects
 
 [connection]
-msg_timeout = 10  # should be enough to hopefully cover delays caused be the underlying system but not too high as this slows down some test cases
 total_timeout =
 # reset any TLS options to default:
 tls_used =

--- a/test/recipes/80-test_cmp_http_data/Mock/test.cnf
+++ b/test/recipes/80-test_cmp_http_data/Mock/test.cnf
@@ -1,6 +1,6 @@
 [default]
 batch = 1 # do not use stdin
-total_timeout = 8 # prevent, e.g., infinite polling due to error
+total_timeout = 20  # = 2 * msg_timeout (see below) - used to prevent, e.g., infinite polling due to error
 trusted = trusted.crt
 newkey = new.key
 newkeypass =
@@ -44,7 +44,7 @@ sleep = 0
 ############################# aspects
 
 [connection]
-msg_timeout = 5
+msg_timeout = 10  # should be enough to hopefully cover delays caused be the underlying system but not too high as this slows down some test cases
 total_timeout =
 # reset any TLS options to default:
 tls_used =


### PR DESCRIPTION
Hopefully fixes #22870 for most situations (such as high load on the system running the test suite),
~while this comes at the cost that some connection-oriented test cases will take longer~.
