### PR TITLE
Rearrange terms in gf_mul to prevent segfault

### DIFF
--- a/crypto/ec/curve448/arch_64/f_impl64.c
+++ b/crypto/ec/curve448/arch_64/f_impl64.c
@@ -45,9 +45,9 @@ void ossl_gf_mul(gf_s * RESTRICT cs, const gf as, const gf bs)
             accum0 += widemul(a[j + 4], b[i - j + 4]);
         }
         for (; j < 4; j++) {
-            accum2 += widemul(a[j], b[i - j + 8]);
-            accum1 += widemul(aa[j], bbb[i - j + 4]);
-            accum0 += widemul(a[j + 4], bb[i - j + 4]);
+            accum2 += widemul(a[j], b[i + 8 - j]);
+            accum1 += widemul(aa[j], bbb[i + 4 - j]);
+            accum0 += widemul(a[j + 4], bb[i + 4 - j]);
         }
 
         accum1 -= accum2;


### PR DESCRIPTION
CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
Fixes #23364 

Segfault was encountered with Dignus compiled OpenSSL 3.0, rearranging the terms solved the issue.
