### PR TITLE
QUIC qlog: Fix Windows and add Windows to CI

### DIFF
--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -145,7 +145,7 @@ jobs:
       run: mkdir _build
     - name: config
       working-directory: _build
-      run: perl ..\Configure --banner=Configured no-makedepend enable-fips
+      run: perl ..\Configure --banner=Configured no-makedepend enable-fips enable-unstable-qlog
     - name: config dump
       working-directory: _build
       run: ./configdata.pm --dump

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,9 +22,9 @@ jobs:
           - windows-2022
         platform:
           - arch: win64
-            config: enable-fips
+            config: enable-fips enable-unstable-qlog
           - arch: win32
-            config: --strict-warnings no-fips
+            config: --strict-warnings no-fips enable-unstable-qlog
     runs-on: ${{ github.server_url == 'https://github.com' && matrix.os || format('{0}-self-hosted', matrix.os) }}
     steps:
     - uses: actions/checkout@v4
@@ -155,7 +155,7 @@ jobs:
 #          - windows-2022
         platform:
           - arch: win64
-            config: -DCMAKE_C_COMPILER=gcc --strict-warnings no-fips
+            config: -DCMAKE_C_COMPILER=gcc --strict-warnings no-fips enable-unstable-qlog
 # are we really learning sth new from win32? So let's save some CO2 for now disabling this
 #          - arch: win32
 #            config: -DCMAKE_C_COMPILER=gcc --strict-warnings no-fips

--- a/ssl/quic/qlog.c
+++ b/ssl/quic/qlog.c
@@ -316,9 +316,12 @@ static void qlog_event_seq_header(QLOG *qlog)
                         ossl_json_key(&qlog->json, "process_id");
                         ossl_json_u64(&qlog->json, qlog->info.override_process_id);
                     } else {
-#if defined(OPENSSL_SYS_UNIX) || defined(OPENSSL_SYS_WINDOWS)
+#if defined(OPENSSL_SYS_UNIX)
                         ossl_json_key(&qlog->json, "process_id");
                         ossl_json_u64(&qlog->json, (uint64_t)getpid());
+#elif defined(OPENSSL_SYS_WINDOWS)
+                        ossl_json_key(&qlog->json, "process_id");
+                        ossl_json_u64(&qlog->json, (uint64_t)GetCurrentProcessId());
 #endif
                     }
                 } /* system_info */

--- a/ssl/quic/qlog_event_helpers.c
+++ b/ssl/quic/qlog_event_helpers.c
@@ -204,7 +204,7 @@ static void ignore_res(int x) {}
  * data on what frames it contained.
  */
 static int log_frame_actual(QLOG *qlog_instance, PACKET *pkt,
-                            uint64_t *need_skip)
+                            size_t *need_skip)
 {
     uint64_t frame_type;
     OSSL_QUIC_FRAME_ACK ack;
@@ -295,7 +295,7 @@ static int log_frame_actual(QLOG *qlog_instance, PACKET *pkt,
             QLOG_STR("frame_type", "crypto");
             QLOG_U64("offset", f.offset);
             QLOG_U64("payload_length", f.len);
-            *need_skip += f.len;
+            *need_skip += (size_t)f.len;
         }
         break;
     case OSSL_QUIC_FRAME_TYPE_STREAM:
@@ -319,7 +319,8 @@ static int log_frame_actual(QLOG *qlog_instance, PACKET *pkt,
             QLOG_BOOL("explicit_length", f.has_explicit_len);
             if (f.is_fin)
                 QLOG_BOOL("fin", 1);
-            *need_skip = f.has_explicit_len ? *need_skip + f.len : UINT64_MAX;
+            *need_skip = f.has_explicit_len
+                ? *need_skip + (size_t)f.len : SIZE_MAX;
         }
         break;
     case OSSL_QUIC_FRAME_TYPE_MAX_DATA:
@@ -512,7 +513,7 @@ unknown:
 }
 
 static void log_frame(QLOG *qlog_instance, PACKET *pkt,
-                      uint64_t *need_skip)
+                      size_t *need_skip)
 {
     size_t rem_before, rem_after;
 
@@ -531,7 +532,7 @@ static int log_frames(QLOG *qlog_instance,
 {
     size_t i;
     PACKET pkt;
-    uint64_t need_skip = 0;
+    size_t need_skip = 0;
 
     for (i = 0; i < num_iovec; ++i) {
         if (!PACKET_buf_init(&pkt, iovec[i].buf, iovec[i].buf_len))

--- a/test/json_test.c
+++ b/test/json_test.c
@@ -128,8 +128,8 @@ typedef void (*fp_pz_type)(OSSL_JSON_ENC *, const void *, size_t);
 #define BEGIN_SCRIPT(name, title, flags)                                       \
     static const struct script_info *get_script_##name(void)                   \
     {                                                                          \
-        const char *const script_name = #name;                                 \
-        const char *const script_title = #title;                               \
+        static const char script_name[] = #name;                               \
+        static const char script_title[] = #title;                             \
                                                                                \
         static const struct script_word script_words[] = {                     \
             OP_INIT_FLAGS(flags)

--- a/util/platform_symbols/windows-symbols.txt
+++ b/util/platform_symbols/windows-symbols.txt
@@ -229,3 +229,4 @@ qsort
 _stat64i32
 atoi
 __stdio_common_vsprintf
+_dclass


### PR DESCRIPTION
- QUIC qlog: Enable qlog in Windows CI
- JSON_ENC: Fix unit test for MSVC


Previously scripts were defined like this:

    {
        static const char *const script_name = "xxx";

        static const struct script_info script_info = {
            script_name, ...
        };

        return &script_info;
    }

MSVC cannot handle this, presumably because this technically involves a
load from a variable to determine that script_name equals "xxx" and it
is unable to do this during evaluation of a constant initializer list.
Resolve this by changing script_name and script_title to be arrays
instead, allowing the correct pointer values to be filled into
script_info as symbol addresses/relocations rather than dereferences.

We weren't testing qlog in Windows CI which we should have been.

Repo mirroring seems slow again.

Fixes https://github.com/openssl/openssl/issues/23516