### PR TITLE
THREADING: Make CRYPTO_MUTEX and CRYPTO_CONDVAR typesafe

### DIFF
--- a/include/internal/quic_reactor.h
+++ b/include/internal/quic_reactor.h
@@ -12,6 +12,7 @@
 # include "internal/time.h"
 # include "internal/sockets.h"
 # include "internal/quic_predef.h"
+# include "internal/thread_arch.h"
 # include <openssl/bio.h>
 
 # ifndef OPENSSL_NO_QUIC
@@ -191,7 +192,7 @@ int ossl_quic_reactor_tick(QUIC_REACTOR *rtor, uint32_t flags);
 int ossl_quic_reactor_block_until_pred(QUIC_REACTOR *rtor,
                                        int (*pred)(void *arg), void *pred_arg,
                                        uint32_t flags,
-                                       CRYPTO_RWLOCK *mutex);
+                                       CRYPTO_MUTEX *mutex);
 
 # endif
 

--- a/include/internal/thread_arch.h
+++ b/include/internal/thread_arch.h
@@ -37,8 +37,8 @@
 
 # include <openssl/crypto.h>
 
-typedef void CRYPTO_MUTEX;
-typedef void CRYPTO_CONDVAR;
+typedef struct crypto_mutex_st CRYPTO_MUTEX;
+typedef struct crypto_condvar_st CRYPTO_CONDVAR;
 
 CRYPTO_MUTEX *ossl_crypto_mutex_new(void);
 void ossl_crypto_mutex_lock(CRYPTO_MUTEX *mutex);

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -453,7 +453,7 @@ SSL *ossl_quic_new(SSL_CTX *ctx)
 err:
     if (ssl_base == NULL) {
 #if defined(OPENSSL_THREADS)
-        ossl_crypto_mutex_free(qc->mutex);
+        ossl_crypto_mutex_free(&qc->mutex);
 #endif
         OPENSSL_free(qc);
     } else {

--- a/ssl/quic/quic_thread_assist.c
+++ b/ssl/quic/quic_thread_assist.c
@@ -91,7 +91,7 @@ int ossl_quic_thread_assist_init_start(QUIC_THREAD_ASSIST *qta,
     qta->t = ossl_crypto_thread_native_start(assist_thread_main,
                                              qta, /*joinable=*/1);
     if (qta->t == NULL) {
-        ossl_crypto_condvar_free(qta->cv);
+        ossl_crypto_condvar_free(&qta->cv);
         return 0;
     }
 


### PR DESCRIPTION
There was really no need for this to be void and it made bugs very easy
to introduce accidentally, especially given that the free functions
needed to be passed a pointer to the pointer.

Also fix some bugs in the QUIC code detected immediately by this change.
