### PR TITLE
Skip shlibload tests if no-atexit is configured

### DIFF
--- a/test/recipes/90-test_shlibload.t
+++ b/test/recipes/90-test_shlibload.t
@@ -23,6 +23,7 @@ plan skip_all => "Test is disabled on AIX" if config('target') =~ m|^aix|;
 plan skip_all => "Test is disabled on NonStop" if config('target') =~ m|^nonstop|;
 plan skip_all => "Test only supported in a dso build" if disabled("dso");
 plan skip_all => "Test is disabled in an address sanitizer build" unless disabled("asan");
+plan skip_all => "Test is disabled if no-atexit is specified" if disabled("atexit");
 
 plan tests => 10;
 


### PR DESCRIPTION
the shared library load tests fail if no-atexit is configured.  The entire test suite relies on atexit handling to indicate an at exit handler has run, by producing a file that the test recipe then reads. With no-atexit that never happens, and the test fails

If no-atexit is specified, skip all the tests


##### Checklist
- [x] tests are added or updated
