### PR TITLE
apps/x509.c: No warning reading from stdin if redirected

### DIFF
--- a/apps/x509.c
+++ b/apps/x509.c
@@ -25,6 +25,7 @@
 #ifndef OPENSSL_NO_DSA
 # include <openssl/dsa.h>
 #endif
+#include "internal/e_os.h"    /* For isatty() */
 
 #undef POSTFIX
 #define POSTFIX ".srl"
@@ -709,7 +710,7 @@ int x509_main(int argc, char **argv)
     }
 
     if (reqfile) {
-        if (infile == NULL)
+        if (infile == NULL && isatty(fileno_stdin()))
             BIO_printf(bio_err,
                        "Warning: Reading cert request from stdin since no -in option is given\n");
         req = load_csr_autofmt(infile, informat, vfyopts,
@@ -762,7 +763,7 @@ int x509_main(int argc, char **argv)
             }
         }
     } else {
-        if (infile == NULL)
+        if (infile == NULL && isatty(fileno_stdin()))
             BIO_printf(bio_err,
                        "Warning: Reading certificate from stdin since no -in or -new option is given\n");
         x = load_cert_pass(infile, informat, 1, passin, "certificate");

--- a/include/internal/e_os.h
+++ b/include/internal/e_os.h
@@ -258,6 +258,7 @@ FILE *__iob_func(void);
 #   endif
 #   define unlink _unlink
 #   define fileno _fileno
+#   define isatty _isatty
 #  endif
 # else
 #  include <strings.h>


### PR DESCRIPTION
This breaks some scripts with 3.2 version.

Fixes #22893
