### PR TITLE
QUIC: Explicit Event Handling Control

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -111,6 +111,12 @@ OpenSSL 3.3
 
    *Hugo Landau*
 
+ * Added APIs to allow disabling implicit QUIC event processing for
+   QUIC SSL objects, allowing applications to control when event handling
+   occurs. Refer to the SSL_get_value_uint(3) manpage for details.
+
+   *Hugo Landau*
+
 OpenSSL 3.2
 -----------
 

--- a/doc/man3/SSL_get_value_uint.pod
+++ b/doc/man3/SSL_get_value_uint.pod
@@ -204,17 +204,17 @@ defaults to this setting.
 
 =item B<SSL_VALUE_EVENT_HANDLING_MODE_IMPLICIT> (Implicit event handling)
 
-If set to this value (the default), the implicit event handling model is used.
-Under this model, QUIC objects will automatically perform background event
-processing (equivalent to a call to L<SSL_handle_events(3)>) when calls to I/O
-functions such as L<SSL_read_ex(3)> or L<SSL_write_ex(3)> are made on a QUIC SSL
-object. This helps to maintain the health of the QUIC connection and ensures
-that incoming datagrams and timeout events are processed.
+If set to this value, the implicit event handling model is used. Under this
+model, QUIC objects will automatically perform background event processing
+(equivalent to a call to L<SSL_handle_events(3)>) when calls to I/O functions
+such as L<SSL_read_ex(3)> or L<SSL_write_ex(3)> are made on a QUIC SSL object.
+This helps to maintain the health of the QUIC connection and ensures that
+incoming datagrams and timeout events are processed.
 
 =item B<SSL_VALUE_EVENT_HANDLING_MODE_EXPLICIT> (Explicit event handling)
 
-If set to 0, the explicit event handling model is used. Under this model,
-B<nonblocking> calls to I/O functions such as L<SSL_read_ex(3)> or
+If set to this value, the explicit event handling model is used. Under this
+model, B<nonblocking> calls to I/O functions such as L<SSL_read_ex(3)> or
 L<SSL_write_ex(3)> do not result in the automatic processing of QUIC events. Any
 new incoming network traffic is not handled; no new outgoing network traffic is
 generated, and pending timeout events are not processed. This allows an

--- a/doc/man3/SSL_get_value_uint.pod
+++ b/doc/man3/SSL_get_value_uint.pod
@@ -11,8 +11,14 @@ SSL_get_quic_stream_uni_remote_avail, SSL_VALUE_CLASS_GENERIC,
 SSL_VALUE_CLASS_FEATURE_REQUEST, SSL_VALUE_CLASS_FEATURE_PEER_REQUEST,
 SSL_VALUE_CLASS_FEATURE_NEGOTIATED, SSL_VALUE_QUIC_STREAM_BIDI_LOCAL_AVAIL,
 SSL_VALUE_QUIC_STREAM_BIDI_REMOTE_AVAIL, SSL_VALUE_QUIC_STREAM_UNI_LOCAL_AVAIL,
-SSL_VALUE_QUIC_STREAM_UNI_REMOTE_AVAIL, SSL_VALUE_QUIC_IDLE_TIMEOUT - manage
-negotiable features and configuration values for a SSL object
+SSL_VALUE_QUIC_STREAM_UNI_REMOTE_AVAIL, SSL_VALUE_QUIC_IDLE_TIMEOUT,
+SSL_VALUE_EVENT_HANDLING_MODE,
+SSL_VALUE_EVENT_HANDLING_MODE_INHERIT,
+SSL_VALUE_EVENT_HANDLING_MODE_EXPLICIT,
+SSL_VALUE_EVENT_HANDLING_MODE_IMPLICIT,
+SSL_get_event_handling_mode,
+SSL_set_event_handling_mode -
+manage negotiable features and configuration values for a SSL object
 
 =head1 SYNOPSIS
 
@@ -34,6 +40,11 @@ negotiable features and configuration values for a SSL object
  #define SSL_VALUE_QUIC_STREAM_UNI_REMOTE_AVAIL
  #define SSL_VALUE_QUIC_IDLE_TIMEOUT
 
+ #define SSL_VALUE_EVENT_HANDLING_MODE
+ #define SSL_VALUE_EVENT_HANDLING_MODE_INHERIT
+ #define SSL_VALUE_EVENT_HANDLING_MODE_EXPLICIT
+ #define SSL_VALUE_EVENT_HANDLING_MODE_IMPLICIT
+
 The following convenience macros can also be used:
 
  int SSL_get_generic_value_uint(SSL *ssl, uint32_t id, uint64_t *value);
@@ -49,6 +60,9 @@ The following convenience macros can also be used:
  int SSL_get_quic_stream_bidi_remote_avail(SSL *ssl, uint64_t *value);
  int SSL_get_quic_stream_uni_local_avail(SSL *ssl, uint64_t *value);
  int SSL_get_quic_stream_uni_remote_avail(SSL *ssl, uint64_t *value);
+
+ int SSL_get_event_handling_mode(SSL *ssl, uint64_t *value);
+ int SSL_set_event_handling_mode(SSL *ssl, uint64_t value);
 
 =head1 DESCRIPTION
 
@@ -119,11 +133,13 @@ SSL_get_feature_negotiated_uint() for brevity.
 
 =head1 CONFIGURABLE VALUES FOR QUIC CONNECTIONS
 
-The following configurable values are supported for QUIC connection SSL objects:
+The following configurable values are supported for QUIC SSL objects. Whether a
+value is supported for a QUIC connection SSL object or a QUIC stream SSL object
+is indicated in the heading for each value:
 
 =over 4
 
-=item B<SSL_VALUE_QUIC_IDLE_TIMEOUT>
+=item B<SSL_VALUE_QUIC_IDLE_TIMEOUT> (connection object)
 
 Negotiated feature value. This configures the desired QUIC idle timeout in
 milliseconds, where 0 represents a lack of an idle timeout. This feature can
@@ -133,7 +149,7 @@ changed.
 This release of OpenSSL uses a default value of 30 seconds. This default value
 may change between releases of OpenSSL.
 
-=item B<SSL_VALUE_QUIC_STREAM_BIDI_LOCAL_AVAIL>
+=item B<SSL_VALUE_QUIC_STREAM_BIDI_LOCAL_AVAIL> (connection object)
 
 Generic read-only statistical value. The number of bidirectional,
 locally-initiated streams available to be created (but not yet created). For
@@ -144,7 +160,7 @@ block or fail due to backpressure.
 Can be queried using the convenience macro
 SSL_get_quic_stream_bidi_local_avail().
 
-=item B<SSL_VALUE_QUIC_STREAM_UNI_LOCAL_AVAIL>
+=item B<SSL_VALUE_QUIC_STREAM_UNI_LOCAL_AVAIL> (connection object)
 
 As above, but provides the number of unidirectional, locally-initiated streams
 available to be created (but not yet created).
@@ -152,7 +168,7 @@ available to be created (but not yet created).
 Can be queried using the convenience macro
 SSL_get_quic_stream_uni_local_avail().
 
-=item B<SSL_VALUE_QUIC_STREAM_BIDI_REMOTE_AVAIL>
+=item B<SSL_VALUE_QUIC_STREAM_BIDI_REMOTE_AVAIL> (connection object)
 
 As above, but provides the number of bidirectional, remotely-initiated streams
 available to be created (but not yet created) by the peer. This represents the
@@ -162,7 +178,7 @@ of QUIC stream creation flow control.
 Can be queried using the convenience macro
 SSL_get_quic_stream_bidi_remote_avail().
 
-=item B<SSL_VALUE_QUIC_STREAM_UNI_REMOTE_AVAIL>
+=item B<SSL_VALUE_QUIC_STREAM_UNI_REMOTE_AVAIL> (connection object)
 
 As above, but provides the number of unidirectional, remotely-initiated streams
 available to be created (but not yet created).
@@ -170,10 +186,74 @@ available to be created (but not yet created).
 Can be queried using the convenience macro
 SSL_get_quic_stream_uni_remote_avail().
 
+=item B<SSL_VALUE_EVENT_HANDLING_MODE> (connection or stream object)
+
+Generic value. This is an integer value which takes one of the following values,
+and determines the event handling mode in use:
+
+=over 4
+
+=item B<SSL_VALUE_EVENT_HANDLING_MODE_INHERIT>
+
+When set, the event handling mode used is inherited from the value set on the
+parent connection (for a stream), or, for a connection, defaults to the implicit
+event handling model.
+
+When a new connection is created, or a new stream is created or accepted, it
+defaults to this setting.
+
+=item B<SSL_VALUE_EVENT_HANDLING_MODE_IMPLICIT> (Implicit event handling)
+
+If set to this value (the default), the implicit event handling model is used.
+Under this model, QUIC objects will automatically perform background event
+processing (equivalent to a call to L<SSL_handle_events(3)>) when calls to I/O
+functions such as L<SSL_read_ex(3)> or L<SSL_write_ex(3)> are made on a QUIC SSL
+object. This helps to maintain the health of the QUIC connection and ensures
+that incoming datagrams and timeout events are processed.
+
+=item B<SSL_VALUE_EVENT_HANDLING_MODE_EXPLICIT> (Explicit event handling)
+
+If set to 0, the explicit event handling model is used. Under this model,
+B<nonblocking> calls to I/O functions such as L<SSL_read_ex(3)> or
+L<SSL_write_ex(3)> do not result in the automatic processing of QUIC events. Any
+new incoming network traffic is not handled; no new outgoing network traffic is
+generated, and pending timeout events are not processed. This allows an
+application to obtain greater control over the circumstances in which QUIC event
+processing occurs. If this event handling model is used, it is the application's
+responsibility to call L<SSL_handle_events(3)> as and when called for by the
+QUIC implementation; see the L<SSL_get_rpoll_descriptor(3)> man page for more
+information.
+
+Selecting this model does not affect the operation of blocking I/O calls, which
+will continue to use the implicit event handling model. Therefore, applications
+using this model will generally want to disable blocking operation using
+L<SSL_set_blocking_mode(3)>.
+
 =back
 
-No configurable values are currently defined for QUIC stream SSL objects or for
-other kinds of SSL object.
+Can be configured using the convenience macros SSL_get_event_handling_mode() and
+SSL_set_event_handling_mode().
+
+A call to SSL_set_value_uint() which causes this value to switch back to the
+implicit event handling model does not in itself cause implicit event handling
+to occur; such handling will occur on the next I/O API call. Equally, a call to
+SSL_set_value_uint() which causes this value to switch to the explicit event
+handling model will not cause event handling to occur before making that
+transition.
+
+This value controls whether implicit event handling occurs when making an I/O
+API call on the SSL object it is set on. However, event processing is not
+confined to state which relates to only that object. For example, if you
+configure explicit event handling on QUIC stream SSL object "A" and configure
+implicit event handling on QUIC stream SSL object "B", a call to an I/O function
+on "B" may result in state changes to "A". In other words, if event handling
+does happen as a result of an API call to an object related to a connection,
+processing of background events (for example, received QUIC network traffic) may
+also affect the state of any other object related to a connection.
+
+=back
+
+No configurable values are currently defined for non-QUIC SSL objects.
 
 =head1 RETURN VALUES
 

--- a/include/internal/quic_fifd.h
+++ b/include/internal/quic_fifd.h
@@ -46,7 +46,8 @@ struct quic_fifd_st {
     void          (*sstream_updated)(uint64_t stream_id,
                                    void *arg);
     void           *sstream_updated_arg;
-    QLOG           *qlog;
+    QLOG         *(*get_qlog_cb)(void *arg);
+    void           *get_qlog_cb_arg;
 };
 
 int ossl_quic_fifd_init(QUIC_FIFD *fifd,
@@ -72,13 +73,15 @@ int ossl_quic_fifd_init(QUIC_FIFD *fifd,
                         void (*sstream_updated)(uint64_t stream_id,
                                                 void *arg),
                         void *sstream_updated_arg,
-                        QLOG *qlog);
+                        QLOG *(*get_qlog_cb)(void *arg),
+                        void *get_qlog_cb_arg);
 
 void ossl_quic_fifd_cleanup(QUIC_FIFD *fifd); /* (no-op) */
 
 int ossl_quic_fifd_pkt_commit(QUIC_FIFD *fifd, QUIC_TXPIM_PKT *pkt);
 
-void ossl_quic_fifd_set0_qlog(QUIC_FIFD *fifd, QLOG *qlog);
+void ossl_quic_fifd_set_qlog_cb(QUIC_FIFD *fifd, QLOG *(*get_qlog_cb)(void *arg),
+                                void *arg);
 
 # endif
 

--- a/include/internal/quic_record_tx.h
+++ b/include/internal/quic_record_tx.h
@@ -49,8 +49,9 @@ typedef struct ossl_qtx_args_st {
     /* Maximum datagram payload length (MDPL) for TX purposes. */
     size_t          mdpl;
 
-    /* QLOG instance to use, or NULL. */
-    QLOG           *qlog;
+    /* Callback returning QLOG instance to use, or NULL. */
+    QLOG           *(*get_qlog_cb)(void *arg);
+    void           *get_qlog_cb_arg;
 } OSSL_QTX_ARGS;
 
 /* Instantiates a new QTX. */
@@ -68,8 +69,9 @@ void ossl_qtx_set_msg_callback(OSSL_QTX *qtx, ossl_msg_cb msg_callback,
                                SSL *msg_callback_ssl);
 void ossl_qtx_set_msg_callback_arg(OSSL_QTX *qtx, void *msg_callback_arg);
 
-/* Change QLOG instance in use after instantiation. */
-void ossl_qtx_set0_qlog(OSSL_QTX *qtx, QLOG *qlog);
+/* Change QLOG instance retrieval callback in use after instantiation. */
+void ossl_qtx_set_qlog_cb(OSSL_QTX *qtx, QLOG *(*get_qlog_cb)(void *arg),
+                          void *get_qlog_cb_arg);
 
 /*
  * Secret Management

--- a/include/internal/quic_txp.h
+++ b/include/internal/quic_txp.h
@@ -50,7 +50,8 @@ typedef struct ossl_quic_tx_packetiser_args_st {
     OSSL_CC_DATA    *cc_data;   /* QUIC Congestion Controller Instance */
     OSSL_TIME       (*now)(void *arg);  /* Callback to get current time. */
     void            *now_arg;
-    QLOG            *qlog;      /* Optional QLOG instance */
+    QLOG            *(*get_qlog_cb)(void *arg); /* Optional QLOG retrieval func */
+    void            *get_qlog_cb_arg;
 
     /*
      * Injected dependencies - crypto streams.
@@ -139,10 +140,11 @@ int ossl_quic_tx_packetiser_set_peer(OSSL_QUIC_TX_PACKETISER *txp,
                                      const BIO_ADDR *peer);
 
 /*
- * Change the QLOG instance in use after instantiation.
+ * Change the QLOG instance retrieval function in use after instantiation.
  */
-void ossl_quic_tx_packetiser_set0_qlog(OSSL_QUIC_TX_PACKETISER *txp,
-                                       QLOG *qlog);
+void ossl_quic_tx_packetiser_set_qlog_cb(OSSL_QUIC_TX_PACKETISER *txp,
+                                         QLOG *(*get_qlog_cb)(void *arg),
+                                         void *get_qlog_cb_arg);
 
 /*
  * Inform the TX packetiser that an EL has been discarded. Idempotent.

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2377,6 +2377,11 @@ __owur int SSL_get_conn_close_info(SSL *ssl,
 # define SSL_VALUE_QUIC_STREAM_UNI_LOCAL_AVAIL      3
 # define SSL_VALUE_QUIC_STREAM_UNI_REMOTE_AVAIL     4
 # define SSL_VALUE_QUIC_IDLE_TIMEOUT                5
+# define SSL_VALUE_EVENT_HANDLING_MODE              6
+
+# define SSL_VALUE_EVENT_HANDLING_MODE_INHERIT      0
+# define SSL_VALUE_EVENT_HANDLING_MODE_IMPLICIT     1
+# define SSL_VALUE_EVENT_HANDLING_MODE_EXPLICIT     2
 
 int SSL_get_value_uint(SSL *s, uint32_t class_, uint32_t id, uint64_t *v);
 int SSL_set_value_uint(SSL *s, uint32_t class_, uint32_t id, uint64_t v);
@@ -2405,6 +2410,13 @@ int SSL_set_value_uint(SSL *s, uint32_t class_, uint32_t id, uint64_t v);
                                (value))
 # define SSL_get_quic_stream_uni_remote_avail(ssl, value) \
     SSL_get_generic_value_uint((ssl), SSL_VALUE_QUIC_STREAM_UNI_REMOTE_AVAIL, \
+                               (value))
+
+# define SSL_get_event_handling_mode(ssl, value) \
+    SSL_get_generic_value_uint((ssl), SSL_VALUE_EVENT_HANDLING_MODE, \
+                               (value))
+# define SSL_set_event_handling_mode(ssl, value) \
+    SSL_set_generic_value_uint((ssl), SSL_VALUE_EVENT_HANDLING_MODE, \
                                (value))
 
 # define SSL_POLL_EVENT_NONE        0

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -3307,14 +3307,11 @@ static int qctx_should_autotick(QCTX *ctx)
     if (ctx->is_stream) {
         event_handling_mode = ctx->xso->event_handling_mode;
         if (event_handling_mode != SSL_VALUE_EVENT_HANDLING_MODE_INHERIT)
-            return event_handling_mode == SSL_VALUE_EVENT_HANDLING_MODE_IMPLICIT;
+            return event_handling_mode != SSL_VALUE_EVENT_HANDLING_MODE_EXPLICIT;
     }
 
     event_handling_mode = ctx->qc->event_handling_mode;
-    if (event_handling_mode == SSL_VALUE_EVENT_HANDLING_MODE_INHERIT)
-        event_handling_mode = SSL_VALUE_EVENT_HANDLING_MODE_IMPLICIT;
-
-    return event_handling_mode == SSL_VALUE_EVENT_HANDLING_MODE_IMPLICIT;
+    return event_handling_mode != SSL_VALUE_EVENT_HANDLING_MODE_EXPLICIT;
 }
 
 QUIC_NEEDS_LOCK

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -3356,9 +3356,9 @@ static int qc_getset_event_handling(QCTX *ctx, uint32_t class_,
 
         value_out = *p_value_in;
         if (ctx->is_stream)
-            ctx->xso->event_handling_mode = value_out;
+            ctx->xso->event_handling_mode = (int)value_out;
         else
-            ctx->qc->event_handling_mode = value_out;
+            ctx->qc->event_handling_mode = (int)value_out;
     } else {
         value_out = ctx->is_stream
             ? ctx->xso->event_handling_mode

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -83,6 +83,10 @@ struct quic_xso_st {
      */
     /* Is an AON write in progress? */
     unsigned int                    aon_write_in_progress   : 1;
+
+    /* Event handling mode. One of SSL_QUIC_VALUE_EVENT_HANDLING. */
+    unsigned int                    event_handling_mode     : 2;
+
     /*
      * The base buffer pointer the caller passed us for the initial AON write
      * call. We use this for validation purposes unless
@@ -216,6 +220,9 @@ struct quic_conn_st {
     /* Are we using addressed mode (BIO_sendmmsg with non-NULL peer)? */
     unsigned int                    addressed_mode_w        : 1;
     unsigned int                    addressed_mode_r        : 1;
+
+    /* Event handling mode. One of SSL_QUIC_VALUE_EVENT_HANDLING. */
+    unsigned int                    event_handling_mode     : 2;
 
     /* Default stream type. Defaults to SSL_DEFAULT_STREAM_MODE_AUTO_BIDI. */
     uint32_t                        default_stream_mode;

--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -482,7 +482,8 @@ OSSL_QUIC_TX_PACKETISER *ossl_quic_tx_packetiser_new(const OSSL_QUIC_TX_PACKETIS
                              on_regen_notify, txp,
                              on_confirm_notify, txp,
                              on_sstream_updated, txp,
-                             args->qlog)) {
+                             args->get_qlog_cb,
+                             args->get_qlog_cb_arg)) {
         OPENSSL_free(txp);
         return NULL;
     }
@@ -626,10 +627,12 @@ void ossl_quic_tx_packetiser_set_ack_tx_cb(OSSL_QUIC_TX_PACKETISER *txp,
     txp->ack_tx_cb_arg  = cb_arg;
 }
 
-void ossl_quic_tx_packetiser_set0_qlog(OSSL_QUIC_TX_PACKETISER *txp,
-                                       QLOG *qlog)
+void ossl_quic_tx_packetiser_set_qlog_cb(OSSL_QUIC_TX_PACKETISER *txp,
+                                         QLOG *(*get_qlog_cb)(void *arg),
+                                         void *get_qlog_cb_arg)
 {
-    ossl_quic_fifd_set0_qlog(&txp->fifd, qlog);
+    ossl_quic_fifd_set_qlog_cb(&txp->fifd, get_qlog_cb, get_qlog_cb_arg);
+
 }
 
 int ossl_quic_tx_packetiser_discard_enc_level(OSSL_QUIC_TX_PACKETISER *txp,

--- a/test/quic_fifd_test.c
+++ b/test/quic_fifd_test.c
@@ -339,7 +339,7 @@ static int test_fifd(int idx)
                                           regen_frame, NULL,
                                           confirm_frame, NULL,
                                           sstream_updated, NULL,
-                                          NULL)))
+                                          NULL, NULL)))
         goto err;
 
     for (i = 0; i < OSSL_NELEM(info.sstream); ++i)

--- a/util/other.syms
+++ b/util/other.syms
@@ -664,6 +664,8 @@ SSL_get_quic_stream_bidi_local_avail    define
 SSL_get_quic_stream_bidi_remote_avail   define
 SSL_get_quic_stream_uni_local_avail     define
 SSL_get_quic_stream_uni_remote_avail    define
+SSL_get_event_handling_mode             define
+SSL_set_event_handling_mode             define
 SSL_CONN_CLOSE_FLAG_LOCAL               define
 SSL_CONN_CLOSE_FLAG_TRANSPORT           define
 SSLv23_client_method                    define
@@ -725,6 +727,10 @@ SSL_VALUE_QUIC_STREAM_BIDI_LOCAL_AVAIL  define
 SSL_VALUE_QUIC_STREAM_BIDI_REMOTE_AVAIL define
 SSL_VALUE_QUIC_STREAM_UNI_LOCAL_AVAIL   define
 SSL_VALUE_QUIC_STREAM_UNI_REMOTE_AVAIL  define
+SSL_VALUE_EVENT_HANDLING_MODE           define
+SSL_VALUE_EVENT_HANDLING_MODE_INHERIT   define
+SSL_VALUE_EVENT_HANDLING_MODE_IMPLICIT  define
+SSL_VALUE_EVENT_HANDLING_MODE_EXPLICIT  define
 TLS_DEFAULT_CIPHERSUITES                define deprecated 3.0.0
 X509_CRL_http_nbio                      define deprecated 3.0.0
 X509_http_nbio                          define deprecated 3.0.0


### PR DESCRIPTION
Allow implicit calling of `SSL_handle_events` ("autotick") to be turned off.

- QUIC: Add docs for SSL_VALUE_EVENT_HANDLING_MODE
- QUIC: Add API for SSL_VALUE_EVENT_HANDLING_MODE
- QUIC APL: Add implementation of SSL_VALUE_EVENT_HANDLING_MODE
- QUIC MULTISTREAM TEST: Test explicit event handling mode
- QUIC MULTISTREAM TEST: Fix env var usage

Fixes https://github.com/openssl/project/issues/450