### PR TITLE
Document usage of standard IANA cipher suite names in cipher lists

### DIFF
--- a/doc/man1/openssl-ciphers.pod.in
+++ b/doc/man1/openssl-ciphers.pod.in
@@ -417,10 +417,13 @@ B<SSL_IDEA>, B<SSL_AES128>, B<SSL_AES256>, B<SSL_CAMELLIA128>, B<SSL_CAMELLIA256
 
 =head1 CIPHER SUITE NAMES
 
-The following lists give the SSL or TLS cipher suites names from the
-relevant specification and their OpenSSL equivalents. It should be noted,
-that several cipher suite names do not include the authentication used,
-e.g. DES-CBC3-SHA. In these cases, RSA authentication is used.
+The following lists give the standard SSL or TLS cipher suites names from the
+relevant specification and their OpenSSL equivalents. You can use either 
+standard names or OpenSSL names in cipher lists, or a mix of both.
+
+It should be noted, that several cipher suite names do not include the
+authentication used, e.g. DES-CBC3-SHA. In these cases, RSA authentication
+is used.
 
 =head2 SSL v3.0 cipher suites
 
@@ -795,6 +798,9 @@ The B<-stdname> is only available if OpenSSL is built with tracing enabled
 (B<enable-ssl-trace> argument to Configure) before OpenSSL 1.1.1.
 
 The B<-convert> option was added in OpenSSL 1.1.1.
+
+Support for standard IANA names in cipher lists was added in
+OpenSSL 3.2.0.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
This documentation improvement proposal is loosely related to #21785, but I do not think that it fixes that issue.

I've tried to make the documentation regarding IANA cipher suite names more consistent. The CIPHER LIST FORMAT section had already mentioned that IANA names may be used. But the CIPHER SUITE NAMES section was missing this information. Imho, it should be mentioned there as well. Otherwise readers might assume that manual mapping from IANA names to OpenSSL names is still required (as has been the case historically).

The [change log](/openssl/openssl/blob/master/CHANGES.md?plain=1#L509-L510) says, IANA names support is new in version 3.2.0. Therefore I've added added a respective remark in the HISTORY section.

##### Checklist

- [x] documentation is added or updated