### PR TITLE
Initialise variables to avoid linking issues

### DIFF
--- a/crypto/bio/bio_addr.c
+++ b/crypto/bio/bio_addr.c
@@ -32,7 +32,7 @@
 #include <openssl/buffer.h>
 #include "internal/thread_once.h"
 
-CRYPTO_RWLOCK *bio_lookup_lock;
+CRYPTO_RWLOCK *bio_lookup_lock = NULL;
 static CRYPTO_ONCE bio_lookup_init = CRYPTO_ONCE_STATIC_INIT;
 
 /*

--- a/crypto/bio/bio_meth.c
+++ b/crypto/bio/bio_meth.c
@@ -10,7 +10,7 @@
 #include "bio_local.h"
 #include "internal/thread_once.h"
 
-CRYPTO_REF_COUNT bio_type_count;
+CRYPTO_REF_COUNT bio_type_count = { .val = 0 };
 static CRYPTO_ONCE bio_type_init = CRYPTO_ONCE_STATIC_INIT;
 
 DEFINE_RUN_ONCE_STATIC(do_bio_type_init)

--- a/crypto/cpuid.c
+++ b/crypto/cpuid.c
@@ -156,7 +156,7 @@ void OPENSSL_cpuid_setup(void)
     OPENSSL_ia32cap_P[1] = (unsigned int)(vec >> 32);
 }
 # else
-unsigned int OPENSSL_ia32cap_P[4];
+unsigned int OPENSSL_ia32cap_P[4] = { NULL };
 # endif
 #endif
 

--- a/crypto/engine/eng_lib.c
+++ b/crypto/engine/eng_lib.c
@@ -12,7 +12,7 @@
 #include <openssl/rand.h>
 #include "internal/refcount.h"
 
-CRYPTO_RWLOCK *global_engine_lock;
+CRYPTO_RWLOCK *global_engine_lock = NULL;
 
 CRYPTO_ONCE engine_lock_init = CRYPTO_ONCE_STATIC_INIT;
 


### PR DESCRIPTION
With legacy toolchains, uninitialised variables cause issues such as duplicate symbols when it comes to linking.

Fixes #23540
Perhaps also fixes #23528 

CLA: trivial


