### PR TITLE
Fix typos found by codespell in openssl-3.1

### DIFF
--- a/doc/internal/man3/ossl_method_construct.pod
+++ b/doc/internal/man3/ossl_method_construct.pod
@@ -93,7 +93,7 @@ This default store should be stored in the library context I<libctx>.
 The method to be looked up should be identified with data found in I<data>
 (which is the I<mcm_data> that was passed to ossl_construct_method()).
 In other words, the ossl_method_construct() caller is entirely responsible
-for ensuring the necesssary data is made available.
+for ensuring the necessary data is made available.
 
 Optionally, I<prov> may be given as a search criterion, to narrow down the
 search of a method belonging to just one provider.

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -291,7 +291,7 @@ in a bitstring that's internal to I<provider>.
 
 ossl_provider_test_operation_bit() checks if the bit operation I<bitnum>
 is set (1) or not (0) in the internal I<provider> bitstring, and sets
-I<*result> to 1 or 0 accorddingly.
+I<*result> to 1 or 0 accordingly.
 
 ossl_provider_init_as_child() stores in the library context I<ctx> references to
 the necessary upcalls for managing child providers. The I<handle> and I<in>


### PR DESCRIPTION
Only modify `doc/man*` in the [openssl-3.1](https://github.com/openssl/openssl/tree/openssl-3.1) branch.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
