### PR TITLE
Fix typos found by codespell in openssl-3.0

### DIFF
--- a/doc/internal/man3/OPTIONS.pod
+++ b/doc/internal/man3/OPTIONS.pod
@@ -155,7 +155,7 @@ on multiple lines; each entry should use B<OPT_MORE_STR>, like this:
         {OPT_MORE_STR, 0, 0,
          "This flag is not really needed on Unix systems"},
         {OPT_MORE_STR, 0, 0,
-         "(Unix and descendents for ths win!)"}
+         "(Unix and descendents for the win!)"}
 
 Each subsequent line will be indented the correct amount.
 

--- a/doc/internal/man3/ossl_method_construct.pod
+++ b/doc/internal/man3/ossl_method_construct.pod
@@ -93,7 +93,7 @@ This default store should be stored in the library context I<libctx>.
 The method to be looked up should be identified with data found in I<data>
 (which is the I<mcm_data> that was passed to ossl_construct_method()).
 In other words, the ossl_method_construct() caller is entirely responsible
-for ensuring the necesssary data is made available.
+for ensuring the necessary data is made available.
 
 Optionally, I<prov> may be given as a search criterion, to narrow down the
 search of a method belonging to just one provider.

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -297,7 +297,7 @@ in a bitstring that's internal to I<provider>.
 
 ossl_provider_test_operation_bit() checks if the bit operation I<bitnum>
 is set (1) or not (0) in the internal I<provider> bitstring, and sets
-I<*result> to 1 or 0 accorddingly.
+I<*result> to 1 or 0 accordingly.
 
 ossl_provider_init_as_child() stores in the library context I<ctx> references to
 the necessary upcalls for managing child providers. The I<handle> and I<in>

--- a/doc/internal/man3/ossl_random_add_conf_module.pod
+++ b/doc/internal/man3/ossl_random_add_conf_module.pod
@@ -15,7 +15,7 @@ ossl_random_add_conf_module - internal random configuration module
 
 ossl_random_add_conf_module() adds the random configuration module
 for providers.
-This allows the type and parameters of the stardard setup of random number
+This allows the type and parameters of the standard setup of random number
 generators to be configured with an OpenSSL L<config(5)> file.
 
 =head1 RETURN VALUES

--- a/doc/internal/man7/EVP_PKEY.pod
+++ b/doc/internal/man7/EVP_PKEY.pod
@@ -19,7 +19,7 @@ private/public key pairs, but has had other uses as well.
 
 =for comment "uses" could as well be "abuses"...
 
-The private/public key pair that an B<EVP_PKEY> contains is refered to
+The private/public key pair that an B<EVP_PKEY> contains is referred to
 as its "internal key" or "origin" (the reason for "origin" is
 explained further down, in L</Export cache for provider operations>),
 and it can take one of the following forms:


### PR DESCRIPTION
Only modify `doc/man*` in the [`openssl-3.0`](https://github.com/openssl/openssl/tree/openssl-3.0) branch.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
