### PR TITLE
os-zoo.yml: Do not add enable-unstable-qlog as this CI tests all branches

### DIFF
--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -145,7 +145,7 @@ jobs:
       run: mkdir _build
     - name: config
       working-directory: _build
-      run: perl ..\Configure --banner=Configured no-makedepend enable-fips enable-unstable-qlog
+      run: perl ..\Configure --banner=Configured no-makedepend enable-fips
     - name: config dump
       working-directory: _build
       run: ./configdata.pm --dump


### PR DESCRIPTION
The enable-unstable-qlog is enabled in windows.yml, which is sufficient for testing it on Windows.

This is urgent as the CI is broken.