### PR TITLE
QUIC: Fix SSL_export_keying_material()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,10 @@ OpenSSL 3.2
 
 ### Changes between 3.2.1 and 3.2.2 [xx XXX xxxx]
 
- * none yet
+ * Fixed bug where SSL_export_keying_material() could not be used with QUIC
+   connections. (#23560)
+
+   *Hugo Landau*
 
 ### Changes between 3.2.0 and 3.2.1 [30 Jan 2024]
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3754,9 +3754,10 @@ int SSL_export_keying_material(SSL *s, unsigned char *out, size_t olen,
         || (sc->version < TLS1_VERSION && sc->version != DTLS1_BAD_VER))
         return -1;
 
-    return s->method->ssl3_enc->export_keying_material(sc, out, olen, label,
-                                                       llen, context,
-                                                       contextlen, use_context);
+    return sc->ssl.method->ssl3_enc->export_keying_material(sc, out, olen, label,
+                                                            llen, context,
+                                                            contextlen,
+                                                            use_context);
 }
 
 int SSL_export_keying_material_early(SSL *s, unsigned char *out, size_t olen,

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -53,7 +53,7 @@ static int test_quic_write_read(int idx)
     SSL *clientquic = NULL;
     QUIC_TSERVER *qtserv = NULL;
     int j, k, ret = 0;
-    unsigned char buf[20];
+    unsigned char buf[20], scratch[64];
     static char *msg = "A test message";
     size_t msglen = strlen(msg);
     size_t numbytes = 0;
@@ -152,6 +152,12 @@ static int test_quic_write_read(int idx)
                     || !TEST_mem_eq(buf, numbytes + 1, msg, msglen))
                 goto end;
         }
+
+        /* Test that exporters work. */
+        if (!TEST_true(SSL_export_keying_material(clientquic, scratch,
+                        sizeof(scratch), "test", 4, (unsigned char *)"ctx", 3,
+                        1)))
+            goto end;
 
         if (sess == NULL) {
             /* We didn't supply a session so we're not expecting resumption */


### PR DESCRIPTION
Fixes https://github.com/openssl/openssl/issues/23560