### PR TITLE
OpenSSL License still applied instead of the Apache 2 license

### DIFF
--- a/crypto/chacha/asm/chacha-loongarch64.pl
+++ b/crypto/chacha/asm/chacha-loongarch64.pl
@@ -1,5 +1,6 @@
 #! /usr/bin/env perl
-# Copyright 2021-2023 The OpenSSL Project Authors. All Rights Reserved.
+# Author: Min Zhou <zhoumin@loongson.cn>
+# Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy

--- a/crypto/chacha/asm/chacha-loongarch64.pl
+++ b/crypto/chacha/asm/chacha-loongarch64.pl
@@ -1,8 +1,7 @@
 #! /usr/bin/env perl
-# Author: Min Zhou <zhoumin@loongson.cn>
-# Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2021-2023 The OpenSSL Project Authors. All Rights Reserved.
 #
-# Licensed under the OpenSSL license (the "License").  You may not use
+# Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html

--- a/crypto/ec/asm/ecp_sm2p256-armv8.pl
+++ b/crypto/ec/asm/ecp_sm2p256-armv8.pl
@@ -1,7 +1,7 @@
 #! /usr/bin/env perl
-# Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2021-2023 The OpenSSL Project Authors. All Rights Reserved.
 #
-# Licensed under the OpenSSL license (the "License").  You may not use
+# Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html

--- a/crypto/ec/asm/ecp_sm2p256-armv8.pl
+++ b/crypto/ec/asm/ecp_sm2p256-armv8.pl
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 2021-2023 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy

--- a/crypto/hpke/hpke.c
+++ b/crypto/hpke/hpke.c
@@ -1,6 +1,5 @@
 /*
- * Copyright 2000-2023 The OpenSSL Project Authors. All Rights Reserved.
- * Copyright Siemens AG 2018-2020
+ * Copyright 2022-2023 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy

--- a/crypto/hpke/hpke.c
+++ b/crypto/hpke/hpke.c
@@ -1,7 +1,8 @@
 /*
- * Copyright 2022-2023 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2000-2023 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright Siemens AG 2018-2020
  *
- * Licensed under the OpenSSL license (the "License").  You may not use
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
  * in the file LICENSE in the source distribution or at
  * https://www.openssl.org/source/license.html

--- a/include/openssl/hpke.h
+++ b/include/openssl/hpke.h
@@ -1,6 +1,5 @@
 /*
- * Copyright 2000-2023 The OpenSSL Project Authors. All Rights Reserved.
- * Copyright Siemens AG 2018-2020
+ * Copyright 2022-2023 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy

--- a/include/openssl/hpke.h
+++ b/include/openssl/hpke.h
@@ -1,7 +1,8 @@
 /*
- * Copyright 2022-2023 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2000-2023 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright Siemens AG 2018-2020
  *
- * Licensed under the OpenSSL license (the "License").  You may not use
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
  * in the file LICENSE in the source distribution or at
  * https://www.openssl.org/source/license.html


### PR DESCRIPTION
Found in OpenSSL 3.2.1 and master branch.

The following files

include/openssl/hpke.h
crypto/hpke/hpke.c
crypto/ec/asm/ecp_sm2p256-armv8.pl
crypto/chacha/asm/chacha-loongarch64.pl
still seem to be released under the OpenSSL License instead of the Apache 2 license.

Fixes #23570

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
