### PR TITLE
Brotli: Don't leave errors behind if loading library failed.

### DIFF
--- a/crypto/comp/c_brotli.c
+++ b/crypto/comp/c_brotli.c
@@ -292,6 +292,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_comp_brotli_init)
 #   define LIBBROTLIDEC "brotlidec"
 #  endif
 
+    ERR_set_mark();
     brotli_encode_dso = DSO_load(NULL, LIBBROTLIENC, NULL, 0);
     if (brotli_encode_dso != NULL) {
         p_encode_init = (encode_init_ft)DSO_bind_func(brotli_encode_dso, "BrotliEncoderCreateInstance");
@@ -319,8 +320,10 @@ DEFINE_RUN_ONCE_STATIC(ossl_comp_brotli_init)
             || p_decode_error == NULL || p_decode_error_string == NULL || p_decode_is_finished == NULL
             || p_decode_oneshot == NULL) {
         ossl_comp_brotli_cleanup();
+        ERR_pop_to_mark();
         return 0;
     }
+    ERR_clear_last_mark();
 # endif
     return 1;
 }

--- a/crypto/comp/c_zlib.c
+++ b/crypto/comp/c_zlib.c
@@ -282,6 +282,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_comp_zlib_init)
 #   endif
 #  endif
 
+    ERR_set_mark();
     zlib_dso = DSO_load(NULL, LIBZ, NULL, 0);
     if (zlib_dso != NULL) {
         p_compress = (compress_ft) DSO_bind_func(zlib_dso, "compress");
@@ -299,9 +300,11 @@ DEFINE_RUN_ONCE_STATIC(ossl_comp_zlib_init)
                 || p_deflateEnd == NULL || p_deflate == NULL
                 || p_deflateInit_ == NULL || p_zError == NULL) {
             ossl_comp_zlib_cleanup();
+            ERR_pop_to_mark();
             return 0;
         }
     }
+    ERR_clear_last_mark();
 # endif
     return 1;
 }

--- a/crypto/comp/c_zstd.c
+++ b/crypto/comp/c_zstd.c
@@ -367,6 +367,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_comp_zstd_init)
 #   define LIBZSTD  "zstd"
 #  endif
 
+    ERR_set_mark();
     zstd_dso = DSO_load(NULL, LIBZSTD, NULL, 0);
     if (zstd_dso != NULL) {
         p_createCStream = (createCStream_ft)DSO_bind_func(zstd_dso, "ZSTD_createCStream");
@@ -394,8 +395,10 @@ DEFINE_RUN_ONCE_STATIC(ossl_comp_zstd_init)
             || p_isError == NULL || p_getErrorName == NULL || p_DStreamInSize == NULL
             || p_CStreamInSize == NULL) {
         ossl_comp_zstd_cleanup();
+        ERR_pop_to_mark();
         return 0;
     }
+    ERR_clear_last_mark();
 # endif
     return 1;
 }


### PR DESCRIPTION
If brolti support is dynamic then it is loaded at runtime and may fail if the library is not available. The library can be loaded even if the user did not ask for it, for instance via SSL_CTX_new_ex() -> ossl_comp_has_alg().
Leaving an error record can have other side effects if the user is poping the stack and notices and aborts due it.

Use ERR_set_mark()/ ERR_pop_to_mark() to avoid leaving marks if library loading failed.

Fixes: #23558
