### PR TITLE
QUIC: Allow stream write buffer stats to be queried

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -142,6 +142,11 @@ OpenSSL 3.3
 
    *Hugo Landau*
 
+ * Added APIs to allow querying the size and utilisation of a QUIC stream's
+   write buffer. Refer to the SSL_get_value_uint(3) manpage for details.
+
+   *Hugo Landau*
+
 OpenSSL 3.2
 -----------
 

--- a/doc/man3/SSL_get_value_uint.pod
+++ b/doc/man3/SSL_get_value_uint.pod
@@ -17,7 +17,13 @@ SSL_VALUE_EVENT_HANDLING_MODE_INHERIT,
 SSL_VALUE_EVENT_HANDLING_MODE_EXPLICIT,
 SSL_VALUE_EVENT_HANDLING_MODE_IMPLICIT,
 SSL_get_event_handling_mode,
-SSL_set_event_handling_mode -
+SSL_set_event_handling_mode,
+SSL_VALUE_STREAM_WRITE_BUF_SIZE,
+SSL_get_stream_write_buf_size,
+SSL_VALUE_STREAM_WRITE_BUF_USED,
+SSL_get_stream_write_buf_used,
+SSL_VALUE_STREAM_WRITE_BUF_AVAIL,
+SSL_get_stream_write_buf_avail -
 manage negotiable features and configuration values for a SSL object
 
 =head1 SYNOPSIS
@@ -45,6 +51,10 @@ manage negotiable features and configuration values for a SSL object
  #define SSL_VALUE_EVENT_HANDLING_MODE_EXPLICIT
  #define SSL_VALUE_EVENT_HANDLING_MODE_IMPLICIT
 
+ #define SSL_VALUE_STREAM_WRITE_BUF_SIZE
+ #define SSL_VALUE_STREAM_WRITE_BUF_USED
+ #define SSL_VALUE_STREAM_WRITE_BUF_AVAIL
+
 The following convenience macros can also be used:
 
  int SSL_get_generic_value_uint(SSL *ssl, uint32_t id, uint64_t *value);
@@ -63,6 +73,10 @@ The following convenience macros can also be used:
 
  int SSL_get_event_handling_mode(SSL *ssl, uint64_t *value);
  int SSL_set_event_handling_mode(SSL *ssl, uint64_t value);
+
+ int SSL_get_stream_write_buf_size(SSL *ssl, uint64_t *value);
+ int SSL_get_stream_write_buf_avail(SSL *ssl, uint64_t *value);
+ int SSL_get_stream_write_buf_used(SSL *ssl, uint64_t *value);
 
 =head1 DESCRIPTION
 
@@ -131,11 +145,16 @@ SSL_get_feature_negotiated_uint() for brevity.
 
 =back
 
-=head1 CONFIGURABLE VALUES FOR QUIC CONNECTIONS
+=head1 CONFIGURABLE VALUES FOR QUIC OBJECTS
 
 The following configurable values are supported for QUIC SSL objects. Whether a
 value is supported for a QUIC connection SSL object or a QUIC stream SSL object
-is indicated in the heading for each value:
+is indicated in the heading for each value. Values supported for QUIC stream SSL
+objects are also supported on QUIC connection SSL objects if they have a default
+stream attached.
+
+SSL_get_value() does not cause internal event processing to occur unless the
+documentation for a specific value specifies otherwise.
 
 =over 4
 
@@ -250,6 +269,35 @@ on "B" may result in state changes to "A". In other words, if event handling
 does happen as a result of an API call to an object related to a connection,
 processing of background events (for example, received QUIC network traffic) may
 also affect the state of any other object related to a connection.
+
+=item B<SSL_VALUE_STREAM_WRITE_BUF_SIZE> (stream object)
+
+Generic read-only statistical value. The size of the write buffer allocated to
+hold data written to a stream with L<SSL_write_ex(3)> until it is transmitted
+and subsequently acknowledged by the peer. This value may change at any time, as
+buffer sizes are optimised in response to network conditions to optimise
+throughput.
+
+Can be queried using the convenience macro SSL_get_stream_write_buf_size().
+
+=item B<SSL_VALUE_STREAM_WRITE_BUF_USED> (stream object)
+
+Generic read-only statistical value. The number of bytes currently consumed
+in the write buffer which have yet to be acknowledged by the peer. Successful
+calls to L<SSL_write_ex(3)> which accept data cause this number to increase.
+This number will then decrease as data is acknowledged by the peer.
+
+Can be queried using the convenience macro SSL_get_stream_write_buf_used().
+
+=item B<SSL_VALUE_STREAM_WRITE_BUF_AVAIL> (stream object)
+
+Generic read-only statistical value. The number of bytes available in the write
+buffer which have yet to be consumed by calls to L<SSL_write_ex(3)>. Successful
+calls to L<SSL_write_ex(3)> which accept data cause this number to decrease.
+This number will increase as data is acknowledged by the peer. It may also
+change if the buffer is resized automatically to optimise throughput.
+
+Can be queried using the convenience macro SSL_get_stream_write_buf_avail().
 
 =back
 

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2381,6 +2381,9 @@ __owur int SSL_get_conn_close_info(SSL *ssl,
 # define SSL_VALUE_QUIC_STREAM_UNI_REMOTE_AVAIL     4
 # define SSL_VALUE_QUIC_IDLE_TIMEOUT                5
 # define SSL_VALUE_EVENT_HANDLING_MODE              6
+# define SSL_VALUE_STREAM_WRITE_BUF_SIZE            7
+# define SSL_VALUE_STREAM_WRITE_BUF_USED            8
+# define SSL_VALUE_STREAM_WRITE_BUF_AVAIL           9
 
 # define SSL_VALUE_EVENT_HANDLING_MODE_INHERIT      0
 # define SSL_VALUE_EVENT_HANDLING_MODE_IMPLICIT     1
@@ -2420,6 +2423,16 @@ int SSL_set_value_uint(SSL *s, uint32_t class_, uint32_t id, uint64_t v);
                                (value))
 # define SSL_set_event_handling_mode(ssl, value) \
     SSL_set_generic_value_uint((ssl), SSL_VALUE_EVENT_HANDLING_MODE, \
+                               (value))
+
+# define SSL_get_stream_write_buf_size(ssl, value) \
+    SSL_get_generic_value_uint((ssl), SSL_VALUE_STREAM_WRITE_BUF_SIZE, \
+                               (value))
+# define SSL_get_stream_write_buf_used(ssl, value) \
+    SSL_get_generic_value_uint((ssl), SSL_VALUE_STREAM_WRITE_BUF_USED, \
+                               (value))
+# define SSL_get_stream_write_buf_avail(ssl, value) \
+    SSL_get_generic_value_uint((ssl), SSL_VALUE_STREAM_WRITE_BUF_AVAIL, \
                                (value))
 
 # define SSL_POLL_EVENT_NONE        0

--- a/util/other.syms
+++ b/util/other.syms
@@ -666,6 +666,9 @@ SSL_get_quic_stream_uni_local_avail     define
 SSL_get_quic_stream_uni_remote_avail    define
 SSL_get_event_handling_mode             define
 SSL_set_event_handling_mode             define
+SSL_get_stream_write_buf_size           define
+SSL_get_stream_write_buf_used           define
+SSL_get_stream_write_buf_avail          define
 SSL_CONN_CLOSE_FLAG_LOCAL               define
 SSL_CONN_CLOSE_FLAG_TRANSPORT           define
 SSLv23_client_method                    define
@@ -731,6 +734,9 @@ SSL_VALUE_EVENT_HANDLING_MODE           define
 SSL_VALUE_EVENT_HANDLING_MODE_INHERIT   define
 SSL_VALUE_EVENT_HANDLING_MODE_IMPLICIT  define
 SSL_VALUE_EVENT_HANDLING_MODE_EXPLICIT  define
+SSL_VALUE_STREAM_WRITE_BUF_SIZE         define
+SSL_VALUE_STREAM_WRITE_BUF_USED         define
+SSL_VALUE_STREAM_WRITE_BUF_AVAIL        define
 TLS_DEFAULT_CIPHERSUITES                define deprecated 3.0.0
 X509_CRL_http_nbio                      define deprecated 3.0.0
 X509_http_nbio                          define deprecated 3.0.0


### PR DESCRIPTION
Fixes https://github.com/openssl/project/issues/411

Note: This is built on top of the explicit event handling PR, so only the top two commits belong to this PR.