### PR TITLE
MSVC: Fixed Visual Studio 2008 compiler errors

### DIFF
--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -14,6 +14,7 @@
 #include <openssl/err.h>
 #include "internal/propertyerr.h"
 #include "internal/property.h"
+#include "internal/numbers.h"
 #include "crypto/ctype.h"
 #include "internal/nelem.h"
 #include "property_local.h"


### PR DESCRIPTION
#### This push request fixes the following issue
OpenSSL 3.0.13 build fails when building with MSVC of Visual Studio 2008.
This is a regression since OpenSSL 3.0.12 builds on VS 2008 without requiring code patches.

#### Details
The commit 986c48c4eb26861f25bc68ea252d8f2aad592735 added overflow checks using "INT64_MAX" but didn't include the header file "internal/numbers.h".
This breaks the build on very old compilers like VS 2008 since it doesn't ship "stdint.h" which defines "INT64_MAX".
This push request adds the missing include so that this code compiles successfully on the old VS 2008 C compiler. 

#### Recommendations
This fix should also be included in the branches "openssl-3.2", "openssl-3.1" and "openssl-3.0" since it fixes a regression.

#### Compile tests
I've built the code of OpenSSL 3.0.13 with this patch successfully on my machine with VS 2008 (cl version 15.00.30729.01) and VS 2017 (cl version 19.16.27051) in debug and release mode.

#### About using more modern compilers
The company I'm working for already uses modern compilers like VS 2017 and VS 2022 but unfortunately it has to support older platforms down to VS 2008.

#### Checklist
No items from the checklist are applying for this commit.
