### PR TITLE
Change updates demos/http3 so it uses `SSL_write_ex2()` together with

### DIFF
--- a/demos/http3/Makefile
+++ b/demos/http3/Makefile
@@ -4,8 +4,8 @@
 #
 #    LD_LIBRARY_PATH=../.. ./ossl-nghttp3-demo www.example.com:443
 
-CFLAGS  = -I../../include -g -Wall -Wsign-compare
-LDFLAGS = -L../..
+CFLAGS  += -I../../include -g -Wall -Wsign-compare
+LDFLAGS += -L../..
 LDLIBS  = -lcrypto -lssl -lnghttp3
 
 all: ossl-nghttp3-demo


### PR DESCRIPTION
`SSL_WRITE_FLAG_CONCLUDE`. Both were introduced by PR #23343.

Change also does a minor tweak to Makefile so I can use env. variables to reach for nghttp3 on my system.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
[quic-pkts.tgz](https://github.com/openssl/openssl/files/14296137/quic-pkts.tgz)

I'm attaching .tgz file which contains three .pcap files:

- quic.pcap packet dumps gathered for code we have in master branch
- quic-fixed.pcap packet dumps gathered for code with my change applied
- quic-broken.pcap packet dumps gathered when running client which does not attempt to conclude connection

after examining packet dumps, it seems to me new code works as expected.
[quic-pkts.tgz](https://github.com/openssl/openssl/files/14296279/quic-pkts.tgz)


