### PR TITLE
Corrects the defined name of the parameter "migalc" in the documentation

### DIFF
--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -502,7 +502,7 @@ EVP_MD_CTX_get_params() can be used with the following OSSL_PARAM keys:
 
 =over 4
 
-=item "micalg" (B<OSSL_PARAM_DIGEST_KEY_MICALG>) <UTF8 string>.
+=item "micalg" (B<OSSL_DIGEST_PARAM_MICALG>) <UTF8 string>.
 
 Gets the digest Message Integrity Check algorithm string. This is used when
 creating S/MIME multipart/signed messages, as specified in RFC 3851.


### PR DESCRIPTION
Corrects the defined name of the parameter "migalc" in the documentation for EVP_DigestInit.

fixes #23580

CLA: trivial

##### Checklist
- [x] documentation is added or updated
