### PR TITLE
Check for NULL locks

### DIFF
--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -657,6 +657,8 @@ CRYPTO_RWLOCK *CRYPTO_THREAD_lock_new(void)
 
 __owur int CRYPTO_THREAD_read_lock(CRYPTO_RWLOCK *lock)
 {
+    if (lock == NULL)
+        return 0;
 # ifdef USE_RWLOCK
     if (pthread_rwlock_rdlock(lock) != 0)
         return 0;
@@ -672,6 +674,8 @@ __owur int CRYPTO_THREAD_read_lock(CRYPTO_RWLOCK *lock)
 
 __owur int CRYPTO_THREAD_write_lock(CRYPTO_RWLOCK *lock)
 {
+    if (lock == NULL)
+        return 0;
 # ifdef USE_RWLOCK
     if (pthread_rwlock_wrlock(lock) != 0)
         return 0;
@@ -687,6 +691,8 @@ __owur int CRYPTO_THREAD_write_lock(CRYPTO_RWLOCK *lock)
 
 int CRYPTO_THREAD_unlock(CRYPTO_RWLOCK *lock)
 {
+    if (lock == NULL)
+        return 0;
 # ifdef USE_RWLOCK
     if (pthread_rwlock_unlock(lock) != 0)
         return 0;


### PR DESCRIPTION
This will happen if a library calls SSL_CTX_free() in its destructor, which runs after OpenSSL's atexit() handler OPENSSL_cleanup() has already destroyed all the locks. This commit fixes a SEGV in that case.

Related to #23575 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
