### PR TITLE
fix error: relocation truncated to fit: R_RISCV_JAL against symbol  `AES_set_encrypt_key'.

### DIFF
--- a/crypto/aes/asm/aes-riscv64.pl
+++ b/crypto/aes/asm/aes-riscv64.pl
@@ -1066,7 +1066,8 @@ AES_set_decrypt_key:
     addi    sp,sp,-16
     sd      $KEYP,0(sp) # We need to hold onto this!
     sd      ra,8(sp)
-    jal     ra,AES_set_encrypt_key
+    la      t0,AES_set_encrypt_key
+    jalr    ra,t0
     ld      $KEYP,0(sp)
     ld      ra,8(sp)
     addi    sp,sp,16


### PR DESCRIPTION
This pr is used to fix link errors in the aes assembly algorithm under riscv64.

---
The following message is reported when connecting under riscv64:
```
/works/fibjs/bin/Linux_riscv64_release/libopenssl.a(aes-riscv64.s.o): in function `.Ltmp14':
(.text+0x946): relocation truncated to fit: R_RISCV_JAL against symbol `AES_set_encrypt_key' defined in .text section in /works/fibjs/bin/Linux_riscv64_release/libopenssl.a(aes-riscv64.s.o)
```
---
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated

CLA: trivial
