### PR TITLE
Fix memory inconsistency/default group crash (#23624)

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1049,8 +1049,8 @@ static int gid_cb(const char *elem, int len, void *arg)
         return 0;
     if (garg->gidcnt == garg->gidmax) {
         uint16_t *tmp =
-            OPENSSL_realloc(garg->gid_arr, garg->gidmax +
-                                 GROUPLIST_INCREMENT * sizeof(*garg->gid_arr));
+            OPENSSL_realloc(garg->gid_arr, (garg->gidmax +
+                                 GROUPLIST_INCREMENT) * sizeof(*garg->gid_arr));
         if (tmp == NULL)
             return 0;
         garg->gidmax += GROUPLIST_INCREMENT;

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1049,8 +1049,8 @@ static int gid_cb(const char *elem, int len, void *arg)
         return 0;
     if (garg->gidcnt == garg->gidmax) {
         uint16_t *tmp =
-            OPENSSL_realloc(garg->gid_arr, (garg->gidmax +
-                                 GROUPLIST_INCREMENT) * sizeof(*garg->gid_arr));
+            OPENSSL_realloc(garg->gid_arr,
+                            (garg->gidmax + GROUPLIST_INCREMENT) * sizeof(*garg->gid_arr));
         if (tmp == NULL)
             return 0;
         garg->gidmax += GROUPLIST_INCREMENT;

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1049,7 +1049,8 @@ static int gid_cb(const char *elem, int len, void *arg)
         return 0;
     if (garg->gidcnt == garg->gidmax) {
         uint16_t *tmp =
-            OPENSSL_realloc(garg->gid_arr, garg->gidmax + GROUPLIST_INCREMENT);
+            OPENSSL_realloc(garg->gid_arr, garg->gidmax +
+                                 GROUPLIST_INCREMENT * sizeof(*garg->gid_arr));
         if (tmp == NULL)
             return 0;
         garg->gidmax += GROUPLIST_INCREMENT;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -9651,6 +9651,7 @@ static int test_pluggable_group(int idx)
     int testresult = 0;
     OSSL_PROVIDER *tlsprov = OSSL_PROVIDER_load(libctx, "tls-provider");
     /* Check that we are not impacted by a provider without any groups */
+    OSSL_PROVIDER *legacyprov = OSSL_PROVIDER_load(libctx, "legacy");
     const char *group_name = idx == 0 ? "xorkemgroup" : "xorgroup";
 
     if (!TEST_ptr(tlsprov))
@@ -9690,6 +9691,7 @@ static int test_pluggable_group(int idx)
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
     OSSL_PROVIDER_unload(tlsprov);
+    OSSL_PROVIDER_unload(legacyprov);
 
     return testresult;
 }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -9652,7 +9652,7 @@ static int test_pluggable_group(int idx)
     OSSL_PROVIDER *tlsprov = OSSL_PROVIDER_load(libctx, "tls-provider");
     /* Check that we are not impacted by a provider without any groups */
     OSSL_PROVIDER *legacyprov = OSSL_PROVIDER_load(libctx, "legacy");
-    const char *group_name = idx == 0 ? "xorgroup" : "xorkemgroup";
+    const char *group_name = idx == 0 ? "xorkemgroup" : "xorgroup";
 
     if (!TEST_ptr(tlsprov))
         goto end;
@@ -9675,7 +9675,9 @@ static int test_pluggable_group(int idx)
                                              NULL, NULL)))
         goto end;
 
-    if (!TEST_true(SSL_set1_groups_list(serverssl, group_name))
+    /* triggers failure as long as GROUPLIST_INCREMENT remains 40: */
+    if (!TEST_true(SSL_set1_groups_list(serverssl, "xorgroup:xorkemgroup:dummy1:dummy2:dummy3:dummy4:dummy5:dummy6:dummy7:dummy8:dummy9:dummy10:dummy11:dummy12:dummy13:dummy14:dummy15:dummy16:dummy17:dummy18:dummy19:dummy20:dummy21:dummy22:dummy23:dummy24:dummy25:dummy26:dummy27:dummy28:dummy29:dummy30:dummy31:dummy32:dummy33:dummy34:dummy35:dummy36:dummy37:dummy38:dummy39:dummy40:dummy41:dummy42:dummy43"))
+    /* removing a single algorithm from the list makes the test pass */
             || !TEST_true(SSL_set1_groups_list(clientssl, group_name)))
         goto end;
 

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -9665,7 +9665,7 @@ static int test_pluggable_group(int idx)
                                              NULL, NULL)))
         goto end;
 
-    /* triggers failure as long as GROUPLIST_INCREMENT remains 40: */
+    /* ensure GROUPLIST_INCREMENT (=40) logic triggers: */
     if (!TEST_true(SSL_set1_groups_list(serverssl, "xorgroup:xorkemgroup:dummy1:dummy2:dummy3:dummy4:dummy5:dummy6:dummy7:dummy8:dummy9:dummy10:dummy11:dummy12:dummy13:dummy14:dummy15:dummy16:dummy17:dummy18:dummy19:dummy20:dummy21:dummy22:dummy23:dummy24:dummy25:dummy26:dummy27:dummy28:dummy29:dummy30:dummy31:dummy32:dummy33:dummy34:dummy35:dummy36:dummy37:dummy38:dummy39:dummy40:dummy41:dummy42:dummy43"))
     /* removing a single algorithm from the list makes the test pass */
             || !TEST_true(SSL_set1_groups_list(clientssl, group_name)))

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -9651,20 +9651,10 @@ static int test_pluggable_group(int idx)
     int testresult = 0;
     OSSL_PROVIDER *tlsprov = OSSL_PROVIDER_load(libctx, "tls-provider");
     /* Check that we are not impacted by a provider without any groups */
-    OSSL_PROVIDER *legacyprov = OSSL_PROVIDER_load(libctx, "legacy");
     const char *group_name = idx == 0 ? "xorkemgroup" : "xorgroup";
 
     if (!TEST_ptr(tlsprov))
         goto end;
-
-    if (legacyprov == NULL) {
-        /*
-         * In this case we assume we've been built with "no-legacy" and skip
-         * this test (there is no OPENSSL_NO_LEGACY)
-         */
-        testresult = 1;
-        goto end;
-    }
 
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
                                        TLS_client_method(),
@@ -9700,7 +9690,6 @@ static int test_pluggable_group(int idx)
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
     OSSL_PROVIDER_unload(tlsprov);
-    OSSL_PROVIDER_unload(legacyprov);
 
     return testresult;
 }

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -410,6 +410,8 @@ static int tls_prov_get_capabilities(void *provctx, const char *capability,
             }
             dummygroup[0].data = dummy_group_names[i];
             dummygroup[0].data_size = strlen(dummy_group_names[i]) + 1;
+            /* assign unique group IDs also to dummy groups for registration */
+            *((int *)(dummygroup[3].data)) = 65279-NUM_DUMMY_GROUPS+i;
             ret &= cb(dummygroup, arg);
         }
     }
@@ -3185,9 +3187,10 @@ unsigned int randomize_tls_alg_id(OSSL_LIB_CTX *libctx)
         return 0;
     /*
      * Ensure id is within the IANA Reserved for private use range
-     * (65024-65279)
+     * (65024-65279).
+     * Carve out NUM_DUMMY_GROUPS ids for properly registering those.
      */
-    id %= 65279 - 65024;
+    id %= 65279 - NUM_DUMMY_GROUPS - 65024;
     id += 65024;
 
     /* Ensure we did not already issue this id */

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -411,7 +411,7 @@ static int tls_prov_get_capabilities(void *provctx, const char *capability,
             dummygroup[0].data = dummy_group_names[i];
             dummygroup[0].data_size = strlen(dummy_group_names[i]) + 1;
             /* assign unique group IDs also to dummy groups for registration */
-            *((int *)(dummygroup[3].data)) = 65279-NUM_DUMMY_GROUPS+i;
+            *((int *)(dummygroup[3].data)) = 65279 - NUM_DUMMY_GROUPS + i;
             ret &= cb(dummygroup, arg);
         }
     }


### PR DESCRIPTION
This test enhancement triggers the error reported in https://github.com/openssl/openssl/issues/23624 and may be used to confirm a possible fix.