### PR TITLE
Add NULL check before accessing PKCS7 encrypted algorithm

### DIFF
--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -901,7 +901,11 @@ int dump_certs_keys_p12(BIO *out, const PKCS12 *p12, const char *pass,
         } else if (bagnid == NID_pkcs7_encrypted) {
             if (options & INFO) {
                 BIO_printf(bio_err, "PKCS7 Encrypted data: ");
-                alg_print(p7->d.encrypted->enc_data->algorithm);
+                if (p7->d.encrypted == NULL) {
+                    BIO_printf(bio_err, "<no data>\n");
+                } else {
+                    alg_print(p7->d.encrypted->enc_data->algorithm);
+                }
             }
             bags = PKCS12_unpack_p7encdata(p7, pass, passlen);
         } else {

--- a/test/recipes/80-test_pkcs12.t
+++ b/test/recipes/80-test_pkcs12.t
@@ -54,7 +54,7 @@ if (eval { require Win32::API; 1; }) {
 }
 $ENV{OPENSSL_WIN32_UTF8}=1;
 
-plan tests => 28;
+plan tests => 31;
 
 # Test different PKCS#12 formats
 ok(run(test(["pkcs12_format_test"])), "test pkcs12 formats");
@@ -184,11 +184,23 @@ with({ exit_checker => sub { return shift == 1; } },
                     "-nomacver"])),
            "test bad pkcs12 file 1 (nomacver)");
 
+        ok(run(app(["openssl", "pkcs12", "-in", $bad1, "-password", "pass:",
+                    "-info"])),
+           "test bad pkcs12 file 1 (info)");
+
         ok(run(app(["openssl", "pkcs12", "-in", $bad2, "-password", "pass:"])),
            "test bad pkcs12 file 2");
 
+        ok(run(app(["openssl", "pkcs12", "-in", $bad2, "-password", "pass:",
+                    "-info"])),
+           "test bad pkcs12 file 2 (info)");
+
         ok(run(app(["openssl", "pkcs12", "-in", $bad3, "-password", "pass:"])),
            "test bad pkcs12 file 3");
+
+        ok(run(app(["openssl", "pkcs12", "-in", $bad3, "-password", "pass:",
+                    "-info"])),
+           "test bad pkcs12 file 3 (info)");
      });
 
 # Test with Oracle Trusted Key Usage specified in openssl.cnf


### PR DESCRIPTION
Printing content of an invalid test certificate causes application crash, because of NULL dereference:

```
user@user:~/openssl$ openssl pkcs12 -in test/recipes/80-test_pkcs12_data/bad2.p12 -passin pass: -info
MAC: sha256, Iteration 2048
MAC length: 32, salt length: 8
PKCS7 Encrypted data: Segmentation fault (core dumped)
```
