### PR TITLE
Don't print excessively long ASN1 items in fuzzer

### DIFF
--- a/fuzz/asn1.c
+++ b/fuzz/asn1.c
@@ -312,10 +312,16 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
         ASN1_VALUE *o = ASN1_item_d2i(NULL, &b, len, i);
 
         if (o != NULL) {
-            BIO *bio = BIO_new(BIO_s_null());
-            if (bio != NULL) {
-                ASN1_item_print(bio, o, 4, i, pctx);
-                BIO_free(bio);
+            /*
+             * Don't print excessively long output to prevent spurious fuzzer
+             * timeouts.
+             */
+            if (b - buf < 10000) {
+                BIO *bio = BIO_new(BIO_s_null());
+                if (bio != NULL) {
+                    ASN1_item_print(bio, o, 4, i, pctx);
+                    BIO_free(bio);
+                }
             }
             if (ASN1_item_i2d(o, &der, i) > 0) {
                 OPENSSL_free(der);


### PR DESCRIPTION
Prevent spurious fuzzer timeouts by not printing ASN1 which is excessively long.

This fixes a false positive encountered by OSS-Fuzz.
