### PR TITLE
pcy_tree: Fix deref of null in function tree_prune()

### DIFF
--- a/crypto/x509/pcy_tree.c
+++ b/crypto/x509/pcy_tree.c
@@ -423,6 +423,10 @@ static int tree_prune(X509_POLICY_TREE *tree, X509_POLICY_LEVEL *curr)
         nodes = curr->nodes;
         for (i = sk_X509_POLICY_NODE_num(nodes) - 1; i >= 0; i--) {
             node = sk_X509_POLICY_NODE_value(nodes, i);
+
+			if (node == NULL)
+				return X509_PCY_TREE_INTERNAL;
+
             if (node->nchild == 0) {
                 node->parent->nchild--;
                 OPENSSL_free(node);


### PR DESCRIPTION
Pointer `node` returned from function `sk_X509_POLICY_NODE_value` is not checked for NULL before dereferenced. Added check, function return code error `X509_PCY_TREE_INTERNAL` if pointer is NULL.

CLA: trivial