### PR TITLE
Add atexit configuration option to using atexit() in libcrypto at build

### DIFF
--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         opt: [
+          no-atexit,
           no-cmp,
           no-cms,
           no-dgram,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,12 @@ OpenSSL 3.2
 
 ### Changes between 3.2.1 and 3.2.2 [xx XXX xxxx]
 
+ * New atexit configuration switch, which controls whether the OPENSSL_cleanup
+   is registered when libcrypto is unloaded. This can be used on platforms
+   where using atexit() from shared libraries causes crashes on exit.
+
+   *Randall S. Becker*
+
  * Fixed bug where SSL_export_keying_material() could not be used with QUIC
    connections. (#23560)
 

--- a/Configure
+++ b/Configure
@@ -414,6 +414,7 @@ my @disablables = (
     "asan",
     "asm",
     "async",
+    "atexit",
     "autoalginit",
     "autoerrinit",
     "autoload-config",

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -600,6 +600,13 @@ be used even with this option.
 
 Do not build support for async operations.
 
+### no-atexit
+
+Do not use `atexit()` in libcrypto builds.
+
+`atexit()` has varied semantics between platforms and can cause SIGSEGV in some
+circumstances. This options disables the atexit registration of OPENSSL_cleanup.
+
 ### no-autoalginit
 
 Don't automatically load all supported ciphers and digests.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -605,7 +605,7 @@ Do not build support for async operations.
 Do not use `atexit()` in libcrypto builds.
 
 `atexit()` has varied semantics between platforms and can cause SIGSEGV in some
-circumstances. This options disables the atexit registration of OPENSSL_cleanup.
+circumstances. This option disables the atexit registration of OPENSSL_cleanup.
 
 ### no-autoalginit
 

--- a/NOTES-NONSTOP.md
+++ b/NOTES-NONSTOP.md
@@ -57,7 +57,10 @@ relating to `atexit()` processing when a shared library is unloaded and when
 the program terminates. This limitation applies to all OpenSSL shared library
 components.
 
-A resolution to this situation is under investigation.
+It is possible to configure the build with `no-atexit` to avoid the SIGSEGV.
+Preferably, you can explicitly call `OPENSSL_cleanup()` from your application.
+It is not mandatory as it just deallocates various global data structures
+OpenSSL allocated.
 
 About Prefix and OpenSSLDir
 ---------------------------

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -97,17 +97,19 @@ static int win32atexit(void)
 
 DEFINE_RUN_ONCE_STATIC(ossl_init_register_atexit)
 {
-#ifdef OPENSSL_INIT_DEBUG
+#ifndef OPENSSL_NO_ATEXIT
+# ifdef OPENSSL_INIT_DEBUG
     fprintf(stderr, "OPENSSL_INIT: ossl_init_register_atexit()\n");
-#endif
-#ifndef OPENSSL_SYS_UEFI
-# if defined(_WIN32) && !defined(__BORLANDC__)
+# endif
+# ifndef OPENSSL_SYS_UEFI
+#  if defined(_WIN32) && !defined(__BORLANDC__)
     /* We use _onexit() in preference because it gets called on DLL unload */
     if (_onexit(win32atexit) == NULL)
         return 0;
-# else
+#  else
     if (atexit(OPENSSL_cleanup) != 0)
         return 0;
+#  endif
 # endif
 #endif
 

--- a/test/recipes/90-test_shlibload.t
+++ b/test/recipes/90-test_shlibload.t
@@ -23,6 +23,7 @@ plan skip_all => "Test is disabled on AIX" if config('target') =~ m|^aix|;
 plan skip_all => "Test is disabled on NonStop" if config('target') =~ m|^nonstop|;
 plan skip_all => "Test only supported in a dso build" if disabled("dso");
 plan skip_all => "Test is disabled in an address sanitizer build" unless disabled("asan");
+plan skip_all => "Test is disabled if no-atexit is specified" if disabled("atexit");
 
 plan tests => 10;
 

--- a/test/recipes/90-test_shlibload.t
+++ b/test/recipes/90-test_shlibload.t
@@ -23,7 +23,7 @@ plan skip_all => "Test is disabled on AIX" if config('target') =~ m|^aix|;
 plan skip_all => "Test is disabled on NonStop" if config('target') =~ m|^nonstop|;
 plan skip_all => "Test only supported in a dso build" if disabled("dso");
 plan skip_all => "Test is disabled in an address sanitizer build" unless disabled("asan");
-plan skip_all => "Test is disabled if no-atexit is specified" if disabled("atexit");
+plan skip_all => "Test is disabled in no-atexit build" if disabled("atexit");
 
 plan tests => 10;
 


### PR DESCRIPTION
This fixes an issue with a mix of atexit() usage in DLL and statically linked libcrypto that came out in the test suite on NonStop, which has slightly different DLL unload processing semantics compared to Linux. The change allows a build configuration to select whether to register OPENSSL_cleanup() with atexit() or not, so avoid situations where atexit() registration causes SIGSEGV.

INSTALL.md and CHANGES.md have been modified to include and describe this option.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
