### PR TITLE
Unchecked function result

### DIFF
--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -1318,7 +1318,8 @@ int ssl_load_stores(SSL_CTX *ctx,
         if (vfyCAstore != NULL && !X509_STORE_load_store(vfy, vfyCAstore))
             goto err;
         add_crls_store(vfy, crls);
-        SSL_CTX_set1_verify_cert_store(ctx, vfy);
+        if (SSL_CTX_set1_verify_cert_store(ctx, vfy) == 0)
+            goto err;
         if (crl_download)
             store_setup_crl_download(vfy);
     }
@@ -1332,7 +1333,8 @@ int ssl_load_stores(SSL_CTX *ctx,
             goto err;
         if (chCAstore != NULL && !X509_STORE_load_store(ch, chCAstore))
             goto err;
-        SSL_CTX_set1_chain_cert_store(ctx, ch);
+        if (SSL_CTX_set1_chain_cert_store(ctx, ch) == 0)
+            goto err;
     }
     rv = 1;
  err:


### PR DESCRIPTION
Return value of function 'SSL_CTX_ctrl', that called at SSL_CTX_set1_verify_cert_store() and SSL_CTX_set1_chain_cert_store(), is not checked, but it is usually checked for this function.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
