### PR TITLE
Ensure `$(MAKE)` commands and `CFLAGS` are appropriately quoted in the Makefile

### DIFF
--- a/Configurations/15-ios.conf
+++ b/Configurations/15-ios.conf
@@ -74,16 +74,16 @@ my %targets = (
 #
     "iphoneos-cross" => {
         inherit_from     => [ "ios-common" ],
-        cflags           => add("-isysroot \$(CROSS_TOP)/SDKs/\$(CROSS_SDK) -fno-common"),
+        cflags           => add("-isysroot \"\$(CROSS_TOP)/SDKs/\$(CROSS_SDK)\" -fno-common"),
     },
     "ios-cross" => {
         inherit_from     => [ "ios-xcrun" ],
         CC               => "cc",
-        cflags           => add("-isysroot \$(CROSS_TOP)/SDKs/\$(CROSS_SDK)"),
+        cflags           => add("-isysroot \"\$(CROSS_TOP)/SDKs/\$(CROSS_SDK)\""),
     },
     "ios64-cross" => {
         inherit_from     => [ "ios64-xcrun" ],
         CC               => "cc",
-        cflags           => add("-isysroot \$(CROSS_TOP)/SDKs/\$(CROSS_SDK)"),
+        cflags           => add("-isysroot \"\$(CROSS_TOP)/SDKs/\$(CROSS_SDK)\""),
     },
 );

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -27,7 +27,7 @@
          my $target = shift;
          my $help = shift;
 
-         return "$target: build_generated ## $help\n\t\$(MAKE) depend && \$(MAKE) _$target\n_$target";
+         return "$target: build_generated ## $help\n\t\"\$(MAKE)\" depend && \"\$(MAKE)\" _$target\n_$target";
      }
 
      our $COLUMNS = $ENV{COLUMNS};
@@ -565,7 +565,7 @@ help: ## Show this help screen
 ##@ Testing
 test: tests ## Run tests (alias of "tests")
 {- dependmagic('tests', 'Run tests'); -}: build_programs_nodep build_modules_nodep link-utils
-	$(MAKE) run_tests
+	"$(MAKE)" run_tests
 run_tests: FORCE
 	@ : {- output_off() if $disabled{tests}; "" -}
 	( SRCTOP=$(SRCDIR) \
@@ -580,7 +580,7 @@ run_tests: FORCE
 
 list-tests: ## List available tests that can be invoked via "make test TESTS=<name>"
 	@ : {- output_off() if $disabled{tests}; "" -}
-	$(MAKE) run_tests TESTS=list
+	"$(MAKE)" run_tests TESTS=list
 	@ : {- if ($disabled{tests}) { output_on(); } else { output_off(); } "" -}
 	@echo "Tests are not supported with your chosen Configure options"
 	@ : {- output_on() if !$disabled{tests}; "" -}
@@ -1255,12 +1255,12 @@ providers/fips.module.sources.new: configdata.pm
 	  cd sources-tmp \
 	  && $$srcdir/Configure --banner=Configured enable-fips -O0 \
 	  && ./configdata.pm --query 'get_sources("providers/fips")' > sources1 \
-	  && $(MAKE) -sj 4 build_generated providers/fips.so \
+	  && "$(MAKE)" -sj 4 build_generated providers/fips.so \
 	  && find . -name '*.d' | xargs cat > dep1 \
-          && $(MAKE) distclean \
+          && "$(MAKE)" distclean \
 	  && $$srcdir/Configure --banner=Configured enable-fips no-asm -O0 \
 	  && ./configdata.pm --query 'get_sources("providers/fips")' > sources2 \
-	  && $(MAKE) -sj 4 build_generated providers/fips.so \
+	  && "$(MAKE)" -sj 4 build_generated providers/fips.so \
 	  && find . -name '*.d' | xargs cat > dep2 \
 	  && cat sources1 sources2 \
 	     | grep -v ' : \\$$' | grep -v util/providers.num \
@@ -1405,7 +1405,7 @@ ordinals: build_generated
                 $(SSLHEADERS)
 
 test_ordinals:
-	$(MAKE) run_tests TESTS=test_ordinals
+	"$(MAKE)" run_tests TESTS=test_ordinals
 
 tags TAGS: FORCE
 	rm -f TAGS tags


### PR DESCRIPTION
If a user's `make` command came from a path that contained a space then both the `$(MAKE)` variable (and parts of the generated `CFLAGS`, when building for iOS) would not be properly quoted and the build would fail.