### PR TITLE
Fix openssl req with -addext subjectAltName=dirName

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -573,7 +573,7 @@ int req_main(int argc, char **argv)
         X509V3_CTX ctx;
 
         X509V3_set_ctx_test(&ctx);
-        X509V3_set_nconf(&ctx, addext_conf);
+        X509V3_set_nconf(&ctx, req_conf);
         if (!X509V3_EXT_add_nconf(addext_conf, &ctx, "default", NULL)) {
             BIO_printf(bio_err, "Error checking extensions defined using -addext\n");
             goto end;

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -15,7 +15,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_req");
 
-plan tests => 107;
+plan tests => 108;
 
 require_ok(srctop_file('test', 'recipes', 'tconversion.pl'));
 
@@ -53,6 +53,7 @@ ok(!run(app([@addext_args, "-addext", $val, "-addext", $val2])));
 ok(!run(app([@addext_args, "-addext", $val, "-addext", $val3])));
 ok(!run(app([@addext_args, "-addext", $val2, "-addext", $val3])));
 ok(run(app([@addext_args, "-addext", "SXNetID=1:one, 2:two, 3:three"])));
+ok(run(app([@addext_args, "-addext", "subjectAltName=dirName:dirname_sec"])));
 
 # If a CSR is provided with neither of -key or -CA/-CAkey, this should fail.
 ok(!run(app(["openssl", "req", "-x509",

--- a/test/test.cnf
+++ b/test/test.cnf
@@ -72,3 +72,9 @@ commonName			= CN field
 commonName_value		= Eric Young
 emailAddress			= email field
 emailAddress_value		= eay@mincom.oz.au
+
+[ dirname_sec ]
+C  = UK
+O  = My Organization
+OU = My Unit
+CN = My Name


### PR DESCRIPTION
The syntax check of the -addext fails because the
X509V3_CTX is used to lookup the referenced section, but the wrong configuration file is used, where only a default section with all passed in -addext lines is available. Thus it was not possible to use the subjectAltName=dirName:section as an -addext parameter.  Probably other extensions as well.

This change affects only the syntax check, the real extension was already created with correct parameters.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
