### PR TITLE
Dont run the self-hosted workflows when not available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
         os: [freebsd-13.2, ubuntu-arm64-22.04]
     runs-on: ${{ matrix.os }}-self-hosted
     continue-on-error: true
+    if: github.server_url != 'https://github.com'
     steps:
     - uses: actions/checkout@v4
     - name: config


### PR DESCRIPTION
It is rather annoying because I always have self-hosted workflows which do not complete on my personal github account.
This tries to make them skipped unless the CI workflow is expected to use "self-hosted" runners.