### PR TITLE
Don't run the self-hosted workflows when not available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   self-hosted:
+    if: github.repository == 'openssl/openssl'
     strategy:
       matrix:
         os: [freebsd-13.2, ubuntu-arm64-22.04]


### PR DESCRIPTION
It is rather annoying because I always have self-hosted workflows which do not complete on my personal github account.
This tries to make them skipped unless the CI workflow is expected to use "self-hosted" runners.