### PR TITLE
Make the generated params_idx.c file deterministic if run multiple

### DIFF
--- a/util/perl/OpenSSL/paramnames.pm
+++ b/util/perl/OpenSSL/paramnames.pm
@@ -563,7 +563,7 @@ sub generate_trie {
     my $nodes = 0;
     my $chars = 0;
 
-    foreach my $name (keys %params) {
+    foreach my $name (sort keys %params) {
         my $val = $params{$name};
         if (substr($val, 0, 1) ne '*') {
             my $cursor = \%trie;


### PR DESCRIPTION
times.

Fixes #23672

There are many name/value pairs currently that have duplicate names e.g.

    'CAPABILITY_TLS_GROUP_MAX_TLS' =>           "tls-max-tls",
    'CAPABILITY_TLS_SIGALG_MAX_TLS' =>          "tls-max-tls",

Stripping the .pm file down to just the above entries and running multiple times gives different results for the produce_decoder.

On multiple runs any iterations over the unordered hash table keys using foreach my $name (keys %params) results in a different order on multiple runs. Because of this the mapping from the hash 'value' back to the 'key' will be different.

Note that the code also uses another mechanism in places that uses "name1" => "value"
"name2" => "*name1"
Rather than fix all the strings the change done was to sort the keys. If we were to chose to fix the strings then the perl code should be changed to detect duplicates.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
