### PR TITLE
Align 'openssl req' string_mask docs to how the software really works

### DIFF
--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -495,16 +495,29 @@ any digest that has been set.
 =item B<string_mask>
 
 This option masks out the use of certain string types in certain
-fields. Most users will not need to change this option.
+fields. Most users will not need to change this option. It can be set to
+several values:
 
-It can be set to several values B<default> which is also the default
-option uses PrintableStrings, T61Strings and BMPStrings if the
-B<pkix> value is used then only PrintableStrings and BMPStrings will
-be used. This follows the PKIX recommendation in RFC2459. If the
-B<utf8only> option is used then only UTF8Strings will be used: this
-is the PKIX recommendation in RFC2459 after 2003. Finally the B<nombstr>
-option just uses PrintableStrings and T61Strings: certain software has
-problems with BMPStrings and UTF8Strings: in particular Netscape.
+=over 4
+
+=item B<utf8only>
+- only UTF8Strings are used (this is the default value)
+
+=item B<pkix>
+- any string type except T61Strings
+
+=item B<nombstr>
+- any string type except BMPStrings and UTF8Strings
+
+=item B<default>
+- any kind of string type
+
+=back
+
+Note that B<utf8only> is the PKIX recommendation in RFC2459 after 2003, and the
+default B<string_mask>; B<default> is not the default option. The B<nombstr>
+value is a workaround for some software that has problems with variable-sized
+BMPStrings and UTF8Strings.
 
 =item B<req_extensions>
 


### PR DESCRIPTION
The documentation for `string_mask` was not at all aligned with what `ASN1_STRING_set_default_mask_asc()` really does.

##### Checklist
- [x] documentation is added or updated
