### PR TITLE
Adding missing NULL pointer check

### DIFF
--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -149,8 +149,8 @@ OSSL_STORE_open_ex(const char *uri, OSSL_LIB_CTX *libctx, const char *propq,
                                               ossl_pw_passphrase_callback_dec,
                                               &pwdata);
             } else {
-                loader_ctx = fetched_loader->p_open(provctx, uri);
-                if (loader_ctx != NULL &&
+                if (fetched_loader->p_open != NULL && 
+                    (loader_ctx = fetched_loader->p_open(provctx, uri)) != NULL &&
                     !loader_set_params(fetched_loader, loader_ctx,
                                        params, propq)) {
                     (void)fetched_loader->p_close(loader_ctx);
@@ -1037,6 +1037,7 @@ OSSL_STORE_CTX *OSSL_STORE_attach(BIO *bp, const char *scheme,
         OSSL_CORE_BIO *cbio = ossl_core_bio_new_from_bio(bp);
 
         if (cbio == NULL
+            || fetched_loader->p_attach == NULL
             || (loader_ctx = fetched_loader->p_attach(provctx, cbio)) == NULL) {
             OSSL_STORE_LOADER_free(fetched_loader);
             fetched_loader = NULL;


### PR DESCRIPTION
CLA: trivial
In the provider store API, it is not necessary to provide both open and attach method at the same time and providing at least one of them is enough. Adding some null pointer checks to prevent exceptions in case of not providing both methods at the same time.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
