### PR TITLE
No cast integer overflow

### DIFF
--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -125,7 +125,7 @@ static int add_entry(enum Type type, unsigned int hash, const char *filename,
     static HENTRY nilhentry;
     BUCKET *bp;
     HENTRY *ep, *found = NULL;
-    unsigned int ndx = (type + hash) % OSSL_NELEM(hash_table);
+    unsigned int ndx = (type + (unsigned long)(hash)) % OSSL_NELEM(hash_table);
 
     for (bp = hash_table[ndx]; bp; bp = bp->next)
         if (bp->type == type && bp->hash == hash)


### PR DESCRIPTION
The value of an arithmetic expression 'type + hash' is a subject to overflow because its operands are not cast to a larger data type before perfoming arithmetic. Static analyzer detected this error. More detailed analysis and build with sanitizers confirmed the overflow when "hash=UINT_MAX" and "type=1". Found by Linux Verification Center (linuxtesting.org) with SVACE.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
