### PR TITLE
Add BN_get_word_ex() function

### DIFF
--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -413,6 +413,11 @@ BN_ULONG BN_get_word(const BIGNUM *a)
     return 0;
 }
 
+BN_ULONG BN_get_word_ex(const BIGNUM *a)
+{
+    return a->top ? a->d[0] : 0;
+}
+
 int BN_set_word(BIGNUM *a, BN_ULONG w)
 {
     bn_check_top(a);

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -300,6 +300,7 @@ int BN_add_word(BIGNUM *a, BN_ULONG w);
 int BN_sub_word(BIGNUM *a, BN_ULONG w);
 int BN_set_word(BIGNUM *a, BN_ULONG w);
 BN_ULONG BN_get_word(const BIGNUM *a);
+BN_ULONG BN_get_word_ex(const BIGNUM *a);
 
 int BN_cmp(const BIGNUM *a, const BIGNUM *b);
 void BN_free(BIGNUM *a);


### PR DESCRIPTION
Add BN_get_word_ex() which gives the low word of the BIGNUM even if it is larger than a single BN_ULONG. There is no error condition as there is with BN_get_word().

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
