### PR TITLE
Make a failure in ktls_sendfile a syscall error

### DIFF
--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1917,7 +1917,7 @@ int tls_retry_write_records(OSSL_RECORD_LAYER *rl)
                 if (BIO_should_retry(rl->bio))
                     ret = OSSL_RECORD_RETURN_RETRY;
                 else {
-                    ERR_raise_data(ERR_LIB_SSL, get_last_sys_error(),
+                    ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
                                    "tls_retry_write_records failure");
                     ret = OSSL_RECORD_RETURN_FATAL;
                 }

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1916,8 +1916,11 @@ int tls_retry_write_records(OSSL_RECORD_LAYER *rl)
             } else {
                 if (BIO_should_retry(rl->bio))
                     ret = OSSL_RECORD_RETURN_RETRY;
-                else
+                else {
+                    ERR_raise_data(ERR_LIB_SSL, get_last_sys_error(),
+                                   "tls_retry_write_records failure");
                     ret = OSSL_RECORD_RETURN_FATAL;
+                }
             }
         } else {
             RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, SSL_R_BIO_NOT_SET);

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1914,9 +1914,9 @@ int tls_retry_write_records(OSSL_RECORD_LAYER *rl)
                 else
                     ret = OSSL_RECORD_RETURN_SUCCESS;
             } else {
-                if (BIO_should_retry(rl->bio))
+                if (BIO_should_retry(rl->bio)) {
                     ret = OSSL_RECORD_RETURN_RETRY;
-                else {
+                } else {
                     ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
                                    "tls_retry_write_records failure");
                     ret = OSSL_RECORD_RETURN_FATAL;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2599,7 +2599,8 @@ ossl_ssize_t SSL_sendfile(SSL *s, int fd, off_t offset, size_t size, int flags)
             BIO_set_retry_write(sc->wbio);
         else
 #endif
-            ERR_raise(ERR_LIB_SSL, SSL_R_UNINITIALIZED);
+            ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
+                           "ktls_sendfile failure");
         return ret;
     }
     sc->rwstate = SSL_NOTHING;


### PR DESCRIPTION
a failure in ktls_sendfile results in an error in ERR_LIB_SSL, but its really a syscall error, since ktls_sendfile just maps to a call to the sendfile syscall.  Encode it as such

Fixes #23722


