### PR TITLE
apps/pkcs12: Not writing the privateKey.pem file until the import password is verified

### DIFF
--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -732,9 +732,6 @@ int pkcs12_main(int argc, char **argv)
     in = bio_open_default(infile, 'r', FORMAT_PKCS12);
     if (in == NULL)
         goto end;
-    out = bio_open_owner(outfile, FORMAT_PEM, private);
-    if (out == NULL)
-        goto end;
 
     p12 = PKCS12_init_ex(NID_pkcs7_data, app_get0_libctx(), app_get0_propq());
     if (p12 == NULL) {
@@ -834,6 +831,11 @@ int pkcs12_main(int argc, char **argv)
 
  dump:
     assert(private);
+
+    out = bio_open_owner(outfile, FORMAT_PEM, private);
+    if (out == NULL)
+        goto end;
+
     if (!dump_certs_keys_p12(out, p12, cpass, -1, options, passout, enc)) {
         BIO_printf(bio_err, "Error outputting keys and certificates\n");
         ERR_print_errors(bio_err);


### PR DESCRIPTION
Fixes #904

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

 Relocating the code responsible for opening the output file to the 'dump' label. All validation was performed before, and a file would not be written if any of the validation failed.