### PR TITLE
interop tests: Fedora 39 config, simplify updates

### DIFF
--- a/.github/workflows/interop-tests.yml
+++ b/.github/workflows/interop-tests.yml
@@ -31,11 +31,11 @@ jobs:
       - name: install interop tests
         run: |
           cd ${GITHUB_WORKSPACE}
-          git clone --branch=openssl --depth=1 https://gitlab.com/redhat-crypto/tests/interop.git
+          git clone --branch=openssl-v0.1 --depth=1 https://gitlab.com/redhat-crypto/tests/interop.git
       - name: build openssl as an rpm
         run: |
           mkdir -p /build/SPECS && cd /build && echo -e "%_topdir /build\n%_lto_cflags %{nil}" >~/.rpmmacros && rpmdev-setuptree
-          cd /build && cp ${GITHUB_WORKSPACE}/interop/openssl.spec SPECS/ && \
+          cd /build && cp ${GITHUB_WORKSPACE}/interop/openssl/openssl.spec SPECS/ && \
           cd SPECS/ && source ${GITHUB_WORKSPACE}/VERSION.dat && \
           sed -i "s/^Version: .*\$/Version: $MAJOR.$MINOR.$PATCH/" openssl.spec && \
           sed -i 's/^Release: .*$/Release: dev/' openssl.spec
@@ -44,6 +44,7 @@ jobs:
           tar --transform "s/^__w\/openssl\/openssl/openssl-$MAJOR.$MINOR.$PATCH/" -czf /build/SOURCES/openssl-$MAJOR.$MINOR.$PATCH.tar.gz /__w/openssl/openssl/
           rpmbuild -bb /build/SPECS/openssl.spec
           dnf install -y /build/RPMS/x86_64/openssl-*
+          cp ${GITHUB_WORKSPACE}/interop/openssl/openssl.cnf /etc/pki/tls/openssl.cnf
       - name: Run interop tests
         run: |
           cd interop


### PR DESCRIPTION
Imitating Fedora 39 configuration in openssl.cnf with SECLEVEL lowered to 0 in order to be able to run
TLS 1.3 tests with TLS_AES_128_CCM_8_SHA256.

In order to make updating smoother, check out specific tag rather than the branch. This way, "old" tests can be fetched until PR pointing to "new" tests is merged, so backwards-incompatible changes can be done when needed.

Files specific for openssl upstream moved to separate directory.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
