### PR TITLE
Add reformatting commit to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Run util/openssl-format-source -v -c .
+0f113f3ee4d629ef9a4a30911b22b224772085e5


### PR DESCRIPTION
This PR adds a [`.git-blame-ignore-revs` file, so GitHub knows to ignore](https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/) the 500,000 line delta reformatting commit 0f113f3ee4d629ef9a4a30911b22b224772085e5, making archaeology a bit easier.

To enable the same ignore locally, one would run `git config blame.ignoreRevsFile .git-blame-ignore-revs`.