### PR TITLE
Gate setting of ipi_spec_dst on not building for freebsd

### DIFF
--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -1174,7 +1174,7 @@ static int pack_local(BIO *b, MSGHDR_TYPE *mh, const BIO_ADDR *local) {
         cmsg->cmsg_type  = IP_PKTINFO;
 
         info = (struct in_pktinfo *)BIO_CMSG_DATA(cmsg);
-#   if !defined(OPENSSL_SYS_WINDOWS) && !defined(OPENSSL_SYS_CYGWIN)
+#   if !defined(OPENSSL_SYS_WINDOWS) && !defined(OPENSSL_SYS_CYGWIN) && !defined(__FreeBSD__)
         info->ipi_spec_dst      = local->s_in.sin_addr;
 #   endif
         info->ipi_addr.s_addr   = 0;


### PR DESCRIPTION
some variants of FreeBSD (notably Dells OneFS) implement IP_PKTINFO partially, and as such the build breaks for those variants. specifically, it supports IP_PKTINFO, but the in_pktinfo struct has no defined ipi_spec_dst field.  Work around this by gating the setting of that variable on not building for FreeBSD

Fixes #23739




