### PR TITLE
bump  perl-actions/install-with-cpanm action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,7 +449,7 @@ jobs:
         sudo apt-get update
         sudo apt-get -yq install bison gettext keyutils ldap-utils libldap2-dev libkeyutils-dev python3 python3-paste python3-pyrad slapd tcsh python3-virtualenv virtualenv python3-kdcproxy
     - name: install cpanm and Test2::V0 for gost_engine testing
-      uses: perl-actions/install-with-cpanm@v1
+      uses: perl-actions/install-with-cpanm@v1.5
       with:
         install: Test2::V0
     - name: setup hostname workaround

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -50,7 +50,7 @@ jobs:
         sudo apt-get -yq install lcov
         sudo apt-get -yq install bison gettext keyutils ldap-utils libldap2-dev libkeyutils-dev python3 python3-paste python3-pyrad slapd tcsh python3-virtualenv virtualenv python3-kdcproxy
     - name: install Test2::V0 for gost_engine testing
-      uses: perl-actions/install-with-cpanm@v1
+      uses: perl-actions/install-with-cpanm@v1.5
       with:
         install: Test2::V0
     - name: setup hostname workaround


### PR DESCRIPTION
Jobs with `perl-actions/install-with-cpanm@v1` action complain about old Node.js version.

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: perl-actions/install-with-cpanm@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.