### PR TITLE
document the format of DSA signature in EVP_SIGNATURE-DSA

### DIFF
--- a/doc/man7/EVP_SIGNATURE-DSA.pod
+++ b/doc/man7/EVP_SIGNATURE-DSA.pod
@@ -7,7 +7,9 @@ EVP_SIGNATURE-DSA
 
 =head1 DESCRIPTION
 
-Support for computing DSA signatures.
+Support for computing DSA signatures. The signature produced with
+L<EVP_PKEY_sign(3)> is DER encoded ASN.1 in the form described in
+RFC 3279, section 2.2.2.
 See L<EVP_PKEY-DSA(7)> for information related to DSA keys.
 
 =head2 Signature Parameters


### PR DESCRIPTION
This trivial change documents the DSA signature format produced with `EVP_PKEY_sign()`. I found it handy since I needed to do subsequent processing of the signature.