### PR TITLE
Add check for xor_get_aid()

### DIFF
--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -2687,6 +2687,10 @@ static int xor_sig_setup_md(PROV_XORSIG_CTX *ctx,
     OPENSSL_free(ctx->aid);
     ctx->aid = NULL;
     ctx->aid_len = xor_get_aid(&(ctx->aid), ctx->sig->tls_name);
+    if (ctx->aid_len <= 0) {
+        EVP_MD_free(md);
+        return 0;
+    }
 
     ctx->mdctx = NULL;
     ctx->md = md;


### PR DESCRIPTION
Add check for the return value of xor_get_aid() in order to avoid NULL pointer deference.

For example, "algor" could be NULL if the allocation of X509_ALGOR_new() fails. As a result, i2d_X509_ALGOR() will return 0 and "ctx->aid" will be an invalid value NULL.

Fixes: f4ed6eed2c ("SSL_set1_groups_list(): Fix memory corruption with 40 groups and more")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
