### PR TITLE
Fix an intermittent test failure in sslapitest

### DIFF
--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -396,6 +396,7 @@ static int tls_prov_get_capabilities(void *provctx, const char *capability,
 
         for (i = 0; i < NUM_DUMMY_GROUPS; i++) {
             OSSL_PARAM dummygroup[OSSL_NELEM(xor_group_params)];
+            unsigned int grpid;
 
             memcpy(dummygroup, xor_group_params, sizeof(xor_group_params));
 
@@ -411,7 +412,8 @@ static int tls_prov_get_capabilities(void *provctx, const char *capability,
             dummygroup[0].data = dummy_group_names[i];
             dummygroup[0].data_size = strlen(dummy_group_names[i]) + 1;
             /* assign unique group IDs also to dummy groups for registration */
-            *((int *)(dummygroup[3].data)) = 65279 - NUM_DUMMY_GROUPS + i;
+            grpid = 65279 - NUM_DUMMY_GROUPS + i;
+            dummygroup[3].data = &grpid;
             ret &= cb(dummygroup, arg);
         }
     }


### PR DESCRIPTION
PR #23659 modified the tls-provider to assign group ids to the various dummy groups.

The group id for each dummy group was stored in the int * value from xor_group_params[3].data. This pointer is actually the location of the global variable xor_group.group_id which is normally used to store the group id for "xorgroup".

The group data is created by the tls_prov_get_capabilities function which gets called every time an SSL_CTX is created by the calling application. The first time it is called the xor_group.group_id has been initialised to the correct value and xorgroup gets assigned the correct group id- but the tls_prov_get_capabilities function overwrites it with a different value before it exits. This means that the second and any subsequent times it gets called, it starts off with the wrong value and xorgroup gets associated with this incorrect value.

In the test that fails two SSL_CTX objects are created. They end up getting different values for xorgroup and the test fails. The failure is intermittent based on the test ordering. If the tests are run in a different order then it can happen to work because tls-provider has already been loaded into the libctx by an earlier test and SSL_CTXs have previously been created. Therefore the xorgroup value ends up being the same (wrong) value in the two SSL_CTX values that are created in the test - and the test passes by accident.
