### PR TITLE
exit with 1 on req -verify failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,11 @@ OpenSSL 3.3
 
 ### Changes between 3.2 and 3.3 [xx XXX xxxx]
 
+ * The `-verify` option to the `openssl crl` and `openssl req` will make
+   the program exit with 1 on failure.
+
+   *Vladimír Kotal*
+
  * The BIO_get_new_index() function can only be called 127 times before it
    reaches its upper bound of BIO_TYPE_MASK. It will now correctly return an
    error of -1 once it is exhausted. Users may need to reserve using this

--- a/apps/crl.c
+++ b/apps/crl.c
@@ -248,9 +248,10 @@ int crl_main(int argc, char **argv)
         EVP_PKEY_free(pkey);
         if (i < 0)
             goto end;
-        if (i == 0)
+        if (i == 0) {
             BIO_printf(bio_err, "verify failure\n");
-        else
+	    goto end;
+        } else
             BIO_printf(bio_err, "verify OK\n");
     }
 

--- a/apps/req.c
+++ b/apps/req.c
@@ -918,9 +918,10 @@ int req_main(int argc, char **argv)
 
         if (i < 0)
             goto end;
-        if (i == 0)
+        if (i == 0) {
             BIO_printf(bio_err, "Certificate request self-signature verify failure\n");
-        else /* i > 0 */
+	    goto end;
+        } else /* i > 0 */
             BIO_printf(bio_out, "Certificate request self-signature verify OK\n");
     }
 

--- a/doc/man1/openssl-crl.pod.in
+++ b/doc/man1/openssl-crl.pod.in
@@ -93,7 +93,9 @@ Print out the CRL in text form.
 
 =item B<-verify>
 
-Verify the signature in the CRL.
+Verify the signature in the CRL. If the verification fails,
+the program will immediately exit, i.e. further option processing
+(e.g. B<-gendelta>) is skipped.
 
 =item B<-noout>
 

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -148,7 +148,9 @@ Prints out the value of the modulus of the public key contained in the request.
 
 =item B<-verify>
 
-Verifies the self-signature on the request.
+Verifies the self-signature on the request. If the verification fails,
+the program will immediately exit, i.e. further option processing
+(e.g. B<-text>) is skipped.
 
 =item B<-new>
 


### PR DESCRIPTION
This change will make the program exit with 1 on verification failure. My original intention was to process options like `-text` etc. even after the verification failure however due to the way the code is laid out this is not really possible without extensive change. The debugging information can be gained by re-running the program without the `-verify` option.