### PR TITLE
Fix SSL_group_to_name docs to match api defintion

### DIFF
--- a/doc/man3/SSL_group_to_name.pod
+++ b/doc/man3/SSL_group_to_name.pod
@@ -8,7 +8,7 @@ SSL_group_to_name - get name of group
 
  #include <openssl/ssl.h>
 
- const char *SSL_group_to_name(const SSL *ssl, int id);
+ const char *SSL_group_to_name(SSL *ssl, int id);
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
SSL_group_to_name documents the first parameter SSL as being const, but the header files don't match that, bring them into line

Fixes #23775

