### PR TITLE
Removed default case as it was a dead code

### DIFF
--- a/test/evp_pkey_provided_test.c
+++ b/test/evp_pkey_provided_test.c
@@ -1471,8 +1471,6 @@ static int test_fromdata_ecx(int tst)
         size = ED448_SIGSIZE;
         alg = "ED448";
         break;
-    default:
-        goto err;
     }
 
     ctx = EVP_PKEY_CTX_new_from_name(NULL, alg, NULL);


### PR DESCRIPTION
The switch governing value tst & 3 cannot reach the default case.

[CLA: trivial]

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
