### PR TITLE
Update tls13ccstest.c, removal of deadcode

### DIFF
--- a/test/tls13ccstest.c
+++ b/test/tls13ccstest.c
@@ -471,10 +471,6 @@ static int test_tls13ccs(int tst)
                 || !TEST_size_t_gt(chsessidlen, 0))
             goto err;
         break;
-
-    default:
-        TEST_error("Invalid test value");
-        goto err;
     }
 
     ret = 1;


### PR DESCRIPTION
tst has been already checked for invalid value in the start of the function with switch statement.

Checked again here, so removed deadcode

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
