### PR TITLE
CMP: fix #23706 and add warning notes on `OSSL_CMP_OPT_PERMIT_TA_IN_EXTRACERTS_FOR_IR`

### DIFF
--- a/crypto/cmp/cmp_vfy.c
+++ b/crypto/cmp/cmp_vfy.c
@@ -632,7 +632,7 @@ int OSSL_CMP_validate_msg(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg)
     default:
         scrt = ctx->srvCert;
         if (scrt == NULL) {
-            if (ctx->trusted == NULL) {
+            if (ctx->trusted == NULL && ctx->secretValue != NULL) {
                 ossl_cmp_info(ctx, "no trust store nor pinned server cert available for verifying signature-based CMP message protection");
                 ERR_raise(ERR_LIB_CMP, CMP_R_MISSING_TRUST_ANCHOR);
                 return 0;

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -343,6 +343,11 @@ RFC 4210.
 
         Allow retrieving a trust anchor from extraCerts and using that
         to validate the certificate chain of an IP message.
+        This is a quirk option added to support 3GPP TS 33.310.
+
+        Note that using this option is dangerous as the certificate obtained
+        this way has not been authenticated (at least not at CMP level).
+        Taking it over as a trust anchor implements trust-on-first-use (TOFU).
 
 =item B<OSSL_CMP_OPT_NO_CACHE_EXTRACERTS>
 

--- a/doc/man3/OSSL_CMP_validate_msg.pod
+++ b/doc/man3/OSSL_CMP_validate_msg.pod
@@ -42,11 +42,14 @@ using any trust store set via L<OSSL_CMP_CTX_set0_trusted(3)>.
 
 If the option OSSL_CMP_OPT_PERMIT_TA_IN_EXTRACERTS_FOR_IR was set by calling
 L<OSSL_CMP_CTX_set_option(3)>, for an Initialization Response (IP) message
-any self-issued certificate from the I<msg> extraCerts field may also be used
-as trust anchor for the path verification of an acceptable cert if it can be
+any self-issued certificate from the I<msg> extraCerts field may be used
+as a trust anchor for the path verification of an 'acceptable' cert if it can be
 used also to validate the issued certificate returned in the IP message. This is
 according to TS 33.310 [Network Domain Security (NDS); Authentication Framework
 (AF)] document specified by the The 3rd Generation Partnership Project (3GPP).
+Note that using this option is dangerous as the certificate obtained this way
+has not been authenticated (at least not at CMP level).
+Taking it over as a trust anchor implements trust-on-first-use (TOFU).
 
 Any cert that has been found as described above is cached and tried first when
 validating the signatures of subsequent messages in the same transaction.


### PR DESCRIPTION
Fixes #23706
and adds warning notes on the use of that 3GPP quirk
