### PR TITLE
Removed unnecessary goto statement

### DIFF
--- a/test/helpers/pkcs12.c
+++ b/test/helpers/pkcs12.c
@@ -79,9 +79,8 @@ static X509 *load_cert_asn1(const unsigned char *bytes, int len)
     X509 *cert = NULL;
 
     cert = d2i_X509(NULL, &bytes, len);
-    if (!TEST_ptr(cert))
-        goto err;
-err:
+    TEST_ptr(cert);
+
     return cert;
 }
 
@@ -90,9 +89,8 @@ static EVP_PKEY *load_pkey_asn1(const unsigned char *bytes, int len)
     EVP_PKEY *pkey = NULL;
 
     pkey = d2i_AutoPrivateKey(NULL, &bytes, len);
-    if (!TEST_ptr(pkey))
-        goto err;
-err:
+    TEST_ptr(pkey);
+
     return pkey;
 }
 


### PR DESCRIPTION
The same code is executed when the condition !test_ptr() is true or false, because the code in the if-then block and after the if statement is identical. So, removing the goto statement.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
