### PR TITLE
Single threaded version of CRYPTO_THREAD_lock_free() leaks memory

### DIFF
--- a/crypto/threads_none.c
+++ b/crypto/threads_none.c
@@ -133,7 +133,6 @@ void CRYPTO_THREAD_lock_free(CRYPTO_RWLOCK *lock) {
     if (lock == NULL)
         return;
 
-    *(unsigned int *)lock = 0;
     OPENSSL_free(lock);
 
     return;


### PR DESCRIPTION
CRYPTO_THREAD_lock_free() found in crypto/threads_none.c should just call `OPENSSL_free()`

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->