### PR TITLE
Replace PKCS#1 v1.5 padding in RSA PCT

### DIFF
--- a/crypto/rsa/rsa_gen.c
+++ b/crypto/rsa/rsa_gen.c
@@ -661,7 +661,7 @@ static int rsa_keygen(OSSL_LIB_CTX *libctx, RSA *rsa, int bits, int primes,
  *    in the applicable standards. For RSA-based schemes, this is defined in
  *    SP 800-56Br2 (Section 6.4.1.1) as:
  *    "The owner shall perform a pair-wise consistency test by verifying that m
- *    = (m^e)^d mod n for some integer m satisfying 1 < m < (n − 1)."
+ *    = (m^e)^d mod n for some integer m satisfying 1 < m < (n - 1)."
  *
  * OpenSSL implements all three use cases: RSA-OAEP for key transport,
  * RSA signatures with PKCS#1 v1.5 or PSS padding, and KAS-IFC-SSC (KAS1/KAS2)
@@ -671,7 +671,7 @@ static int rsa_keygen(OSSL_LIB_CTX *libctx, RSA *rsa, int bits, int primes,
  * the keys' intended usage is not known, then any of the three PCTs described
  * in AS10.35 shall be performed on this key pair.
  *
- * Because of this allowance from the IG,  the simplest option is 3, i.e.
+ * Because of this allowance from the IG, the simplest option is 3, i.e.
  * RSA_public_encrypt() and RSA_private_decrypt() with RSA_NO_PADDING.
  */
 static int rsa_keygen_pairwise_test(RSA *rsa, OSSL_CALLBACK *cb, void *cbarg)

--- a/doc/man7/OSSL_PROVIDER-FIPS.pod
+++ b/doc/man7/OSSL_PROVIDER-FIPS.pod
@@ -337,7 +337,7 @@ The FIPS module passes the following descriptions(s) to OSSL_SELF_TEST_onbegin()
 
 "Module_Integrity" and "Install_Integrity" use this.
 
-=item "RSA" (B<OSSL_SELF_TEST_DESC_PCT_RSA_PKCS1>)
+=item "RSA" (B<OSSL_SELF_TEST_DESC_PCT_RSA>)
 
 =item "ECDSA" (B<OSSL_SELF_TEST_DESC_PCT_ECDSA>)
 

--- a/doc/man7/OSSL_PROVIDER-FIPS.pod
+++ b/doc/man7/OSSL_PROVIDER-FIPS.pod
@@ -337,6 +337,8 @@ The FIPS module passes the following descriptions(s) to OSSL_SELF_TEST_onbegin()
 
 "Module_Integrity" and "Install_Integrity" use this.
 
+=item "RSA" (B<OSSL_SELF_TEST_DESC_PCT_RSA_PKCS1>)
+
 =item "RSA" (B<OSSL_SELF_TEST_DESC_PCT_RSA>)
 
 =item "ECDSA" (B<OSSL_SELF_TEST_DESC_PCT_ECDSA>)

--- a/include/openssl/self_test.h
+++ b/include/openssl/self_test.h
@@ -44,6 +44,7 @@ extern "C" {
 /* Test event sub categories */
 # define OSSL_SELF_TEST_DESC_NONE           "None"
 # define OSSL_SELF_TEST_DESC_INTEGRITY_HMAC "HMAC"
+# define OSSL_SELF_TEST_DESC_PCT_RSA        "RSA"
 # define OSSL_SELF_TEST_DESC_PCT_RSA_PKCS1  "RSA"
 # define OSSL_SELF_TEST_DESC_PCT_ECDSA      "ECDSA"
 # define OSSL_SELF_TEST_DESC_PCT_EDDSA      "EDDSA"


### PR DESCRIPTION
After December 31, 2023, SP 800-131Ar2 [0] no longer allows PKCS#1 v1.5 padding for RSA "key-transport" (aka encryption and decryption). There's a few good options to replace this usage in the RSA PCT, but the simplest is verifying m = (m^e)^d mod n, (where 1 < m < (n − 1)). This is specified in SP 800-56Br2 (Section 6.4.1.1) [1] and allowed by FIPS 140-3 IG 10.3.A. In OpenSSL, this corresponds to RSA_NO_PADDING.

[0]: https://doi.org/10.6028/NIST.SP.800-131Ar2
[1]: https://doi.org/10.6028/NIST.SP.800-56Br2

Issue: https://github.com/openssl/project/issues/241