### PR TITLE
plug potential memory leak in error code path

### DIFF
--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -372,6 +372,7 @@ static CONF_MODULE *module_add(DSO *dso, const char *name,
         OPENSSL_free(tmod->name);
         OPENSSL_free(tmod);
     }
+    sk_CONF_MODULE_free(new_modules);
     return NULL;
 }
 


### PR DESCRIPTION
Function `module_add()` may leak stack of modules when it fails to initialize newly added module.

Fixes #23835

