### PR TITLE
follow up change on PR #23781

### DIFF
--- a/doc/man3/OSSL_HTTP_REQ_CTX.pod
+++ b/doc/man3/OSSL_HTTP_REQ_CTX.pod
@@ -198,7 +198,8 @@ I/O error when trying to send the next request via I<rctx>.
 The OSSL_HTTP_REQ_CTX_set_max_response_hdr_lines() function changes the limit
 for the number of HTTP headers which can be received in a response. The default
 value is 256.  If the number of HTTP headers in a response exceeds the limit,
-then the HTTP_R_RESPONSE_TOO_MANY_HDRLINES error is indicated.
+then the HTTP_R_RESPONSE_TOO_MANY_HDRLINES error is indicated. Setting the
+limit to 0 disables the check.
 
 =head1 WARNINGS
 

--- a/test/http_test.c
+++ b/test/http_test.c
@@ -432,7 +432,6 @@ static int test_http_resp_hdr_limit(size_t limit)
     mock_args.content_type = "text/plain";
     mock_args.version = '1';
     mock_args.out = rbio;
-    mock_args.content_type = "text/plain";
 
     BIO_set_callback_ex(wbio, http_bio_cb_ex);
     BIO_set_callback_arg(wbio, (char *)&mock_args);
@@ -448,6 +447,10 @@ static int test_http_resp_hdr_limit(size_t limit)
     OSSL_HTTP_REQ_CTX_set_max_response_hdr_lines(rctx, limit);
     mem = OSSL_HTTP_REQ_CTX_exchange(rctx);
 
+    /*
+     * Note the server sends 4 http response headers, thus we expect to
+     * see failure here when we set header limit in http response to 1.
+     */
     if (limit == 1)
         res = TEST_ptr_null(mem);
     else


### PR DESCRIPTION
Also add a comment to test_http_resp_hdr_limit() unit test to explain why we expect
see an error when limit for number of http response headers is set to 1.

Change also removes extra-assignment  test_http_resp_hdr_limit().

All issues were pointed out by @DDvO in my earlier PR #23781 which has
introduced OSSL_HTTP_REQ_CTX_set_max_response_hdr_lines().

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
