### PR TITLE
retry: updated 3.0 gitignore to match master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,13 +6,20 @@
 /Makefile
 /MINFO
 /TABLE
-/*.pc
 /rehash.time
 /inc.*
 /makefile.*
 /out.*
 /tmp.*
 /configdata.pm
+/builddata.pm
+/installdata.pm
+
+# Exporters
+/*.pc
+/OpenSSLConfig*.cmake
+/exporters/*.pc
+/exporters/OpenSSLConfig*.cmake
 
 # Links under apps
 /apps/CA.pl
@@ -48,6 +55,10 @@
 /include/openssl/x509.h
 /include/openssl/x509v3.h
 /include/openssl/x509_vfy.h
+/include/internal/param_names.h
+
+# Auto generated parameter name files
+/crypto/params_idx.c
 
 # Auto generated doc files
 doc/man1/openssl-*.pod
@@ -102,6 +113,7 @@ providers/common/include/prov/der_sm2.h
 /test/evp_extra_test2
 /test/evp_pkey_ctx_new_from_name
 /test/threadstest_fips
+/test/timing_load_creds
 
 # Certain files that get created by tests on the fly
 /test-runs
@@ -126,6 +138,7 @@ providers/common/include/prov/der_sm2.h
 /tools/c_rehash.pl
 /util/shlib_wrap.sh
 /util/wrap.pl
+/util/quicserver
 /tags
 /TAGS
 *.map
@@ -230,6 +243,7 @@ Makefile.save
 *.bak
 cscope.*
 *.d
+!.ctags.d
 *.d.tmp
 pod2htmd.tmp
 MAKE0[0-9][0-9][0-9].@@@
@@ -237,3 +251,8 @@ MAKE0[0-9][0-9][0-9].@@@
 # Windows manifest files
 *.manifest
 doc-nits
+
+# LSP (Language Server Protocol) support
+.cache/
+compile_commands.json
+


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

updated openssl-3.0's .gitignore to match the master branches .gitignore (backporting) 

Fixes #23574 - https://github.com/openssl/openssl/issues/23574 
--------

You can see the two original files here. I am updating the openssl-3.0 gitignore file to include the statements (backporting) in the master's gitignore file.

Deleted in line 10: 

`/*.pc
`

Added after line 16:

```
/builddata.pm
/installdata.pm

# Exporters
/*.pc
/OpenSSLConfig*.cmake
/exporters/*.pc
/exporters/OpenSSLConfig*.cmake
```

Added after line 59: 

```
/include/internal/param_names.h

# Auto generated parameter name files
/crypto/params_idx.c
```

Added after line 118: 

`/test/timing_load_creds
`

Added after line 143: 

`/util/quicserver
`

Added after line 248: 

`!.ctags.d
`

Added after line 257: 

```
# LSP (Language Server Protocol) support
.cache/
compile_commands.json
```

@bbbrumley - faculty at RIT who would like to track my PR progress :) 