### PR TITLE
Another attempt to fix the AFL fuzz CI failures

### DIFF
--- a/.github/workflows/fuzz-checker.yml
+++ b/.github/workflows/fuzz-checker.yml
@@ -73,7 +73,7 @@ jobs:
         ./util/opensslwrap.sh version -c
     - name: make test restricted
       if: matrix.fuzzy.tests != ''
-      run: AFL_MAP_SIZE=120985 make test HARNESS_JOBS=${HARNESS_JOBS:-4} TESTS="${{ matrix.fuzzy.tests }}"
+      run: AFL_MAP_SIZE=300000 make test HARNESS_JOBS=${HARNESS_JOBS:-4} TESTS="${{ matrix.fuzzy.tests }}"
     - name: make test all
       if: matrix.fuzzy.tests == ''
-      run: AFL_MAP_SIZE=120985 make test HARNESS_JOBS=${HARNESS_JOBS:-4}
+      run: AFL_MAP_SIZE=300000 make test HARNESS_JOBS=${HARNESS_JOBS:-4}

--- a/test/recipes/82-test_ocsp_cert_chain.t
+++ b/test/recipes/82-test_ocsp_cert_chain.t
@@ -128,10 +128,6 @@ sub run_test {
         if (/^cert_status: ocsp response sent:/) {
             $resp = 1;
             last;
-        } elsif (/^cert_status:/) {
-            ;
-        } else {
-            last;
         }
     }
     ok($resp == 1, "check s_server sent ocsp response");


### PR DESCRIPTION
The previous fix was not right because there needs to be a leeway in the AFL_MAP_SIZE for future growth of the necessary map size.

There is also a better fix for the failure in the test itself however it is good idea to keep the AFL_MAP_SIZE set anyway.
