### PR TITLE
Backporting master's .gitignore to openssl-3.1's .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,13 +6,20 @@
 /Makefile
 /MINFO
 /TABLE
-/*.pc
 /rehash.time
 /inc.*
 /makefile.*
 /out.*
 /tmp.*
 /configdata.pm
+/builddata.pm
+/installdata.pm
+
+# Exporters
+/*.pc
+/OpenSSLConfig*.cmake
+/exporters/*.pc
+/exporters/OpenSSLConfig*.cmake
 
 # Links under apps
 /apps/CA.pl
@@ -48,6 +55,11 @@
 /include/openssl/x509.h
 /include/openssl/x509v3.h
 /include/openssl/x509_vfy.h
+/include/openssl/core_names.h
+/include/internal/param_names.h
+
+# Auto generated parameter name files
+/crypto/params_idx.c
 
 # Auto generated doc files
 doc/man1/openssl-*.pod
@@ -127,6 +139,7 @@ providers/common/include/prov/der_sm2.h
 /tools/c_rehash.pl
 /util/shlib_wrap.sh
 /util/wrap.pl
+/util/quicserver
 /tags
 /TAGS
 *.map
@@ -231,6 +244,7 @@ Makefile.save
 *.bak
 cscope.*
 *.d
+!.ctags.d
 *.d.tmp
 pod2htmd.tmp
 MAKE0[0-9][0-9][0-9].@@@
@@ -238,3 +252,7 @@ MAKE0[0-9][0-9][0-9].@@@
 # Windows manifest files
 *.manifest
 doc-nits
+
+# LSP (Language Server Protocol) support
+.cache/
+compile_commands.json


### PR DESCRIPTION
updated openssl-3.1's .gitignore to match the master branches .gitignore (backporting) 

Fixes #23574 - https://github.com/openssl/openssl/issues/23574 
--------

I am updating the openssl-3.1's .gitignore file to include the statements (backporting) in the master's .gitignore file.

Deleted in line 10: 

`/*.pc
`

Added after line 16:

```
/builddata.pm
/installdata.pm

# Exporters
/*.pc
/OpenSSLConfig*.cmake
/exporters/*.pc
/exporters/OpenSSLConfig*.cmake
```

Added after line 59: 

```
/include/openssl/core_names.h
/include/internal/param_names.h

# Auto generated parameter name files
/crypto/params_idx.c
```

Added after line 143: 

`/util/quicserver
`

Added after line 248: 

`!.ctags.d
`

Added after line 257: 

```
# LSP (Language Server Protocol) support
.cache/
compile_commands.json
```

@bbbrumley - faculty at RIT who would like to track my PR progress :) 