### PR TITLE
backporting openssl's master .gitignore to openssl-3.2's .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,13 +6,20 @@
 /Makefile
 /MINFO
 /TABLE
-/*.pc
 /rehash.time
 /inc.*
 /makefile.*
 /out.*
 /tmp.*
 /configdata.pm
+/builddata.pm
+/installdata.pm
+
+# Exporters
+/*.pc
+/OpenSSLConfig*.cmake
+/exporters/*.pc
+/exporters/OpenSSLConfig*.cmake
 
 # Links under apps
 /apps/CA.pl


### PR DESCRIPTION
CLA: trivial

updated openssl-3.2's .gitignore to match the master branches .gitignore (backporting) 

Fixes #23574 - https://github.com/openssl/openssl/issues/23574 
--------

You can see the two original files here. I am updating the openssl-3.2 gitignore file to include the statements (backporting) in the master's gitignore file.

Deleted in line 10: 

`/*.pc
`

Added after line 16:

```
/builddata.pm
/installdata.pm

# Exporters
/*.pc
/OpenSSLConfig*.cmake
/exporters/*.pc
/exporters/OpenSSLConfig*.cmake
```

@bbbrumley - faculty at RIT who would like to track my PR progress :) 