### PR TITLE
APPS: Add missing OPENSSL_free() and combine the error handler

### DIFF
--- a/apps/ts.c
+++ b/apps/ts.c
@@ -538,15 +538,17 @@ static int create_digest(BIO *input, const char *digest, const EVP_MD *md,
 
         *md_value = OPENSSL_hexstr2buf(digest, &digest_len);
         if (*md_value == NULL || md_value_len != digest_len) {
-            OPENSSL_free(*md_value);
-            *md_value = NULL;
             BIO_printf(bio_err, "bad digest, %d bytes "
                        "must be specified\n", md_value_len);
-            return 0;
+            goto err;
         }
     }
     rv = md_value_len;
  err:
+    if (!rv) {
+        OPENSSL_free(*md_value);
+        *md_value = NULL;
+    }
     EVP_MD_CTX_free(md_ctx);
     return rv;
 }

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -545,9 +545,10 @@ static int create_digest(BIO *input, const char *digest, const EVP_MD *md,
     }
     rv = md_value_len;
  err:
-    if (!rv) {
+    if (rv <= 0) {
         OPENSSL_free(*md_value);
         *md_value = NULL;
+        rv = 0;
     }
     EVP_MD_CTX_free(md_ctx);
     return rv;


### PR DESCRIPTION
Add the OPENSSL_free() in the error handler to release the "*md_value" allocated by app_malloc(). To make the code clear and avoid possible future errors, combine the error handler in the "err" tag. Then, we only need to use "goto err" instead of releasing the memory separately.

Fixes: c7235be6e3 ("RFC 3161 compliant time stamp request creation, response generation and response verification.")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
