### PR TITLE
rsa: Add BN_free() for BN_secure_new()

### DIFF
--- a/crypto/rsa/rsa_sp800_56b_gen.c
+++ b/crypto/rsa/rsa_sp800_56b_gen.c
@@ -146,6 +146,12 @@ int ossl_rsa_fips186_4_gen_prob_primes(RSA *rsa, RSA_ACVP_TEST *test,
     rsa->dirty_cnt++;
     ret = 1;
 err:
+    if (ret != 1) {
+        BN_free(rsa->p);
+        rsa->p = NULL;
+        BN_free(rsa->q);
+        rsa->q = NULL;
+    }
     /* Zeroize any internally generated values that are not returned */
     if (Xpo != NULL)
         BN_clear(Xpo);


### PR DESCRIPTION
Add the BN_free() in the error handler to release the "rsa->p" and "rsa->q" allocated by BN_secure_new(), like the one in ossl_rsa_sp800_56b_derive_params_from_pq().

Fixes: 8240d5fa65 ("FIPS 186-4 RSA Generation & Validation")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
