### PR TITLE
Add 'documentation policy' link to CONTRIBUTING guide.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,8 @@ guidelines:
     often. We do not accept merge commits, you will have to remove them
     (usually by rebasing) before it will be acceptable.
 
- 4. Code provided should follow our [coding style] and compile without warnings.
+ 4. Code provided should follow our [coding style] and [documentation policy]
+    and compile without warnings.
     There is a [Perl tool](util/check-format.pl) that helps
     finding code formatting mistakes and other coding style nits.
     Where `gcc` or `clang` is available, you should use the
@@ -77,6 +78,7 @@ guidelines:
     whenever a PR is created or updated by committers.
 
     [coding style]: https://www.openssl.org/policies/technical/coding-style.html
+    [documentation policy]: https://openssl.org/policies/technical/documentation-policy.html
 
  5. When at all possible, code contributions should include tests. These can
     either be added to an existing test, or completely new.  Please see


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
