### PR TITLE
Set secure defaults for the SHAKE 128/256 digest output length.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,19 @@ OpenSSL Releases
  - [OpenSSL 1.0.0](#openssl-100)
  - [OpenSSL 0.9.x](#openssl-09x)
 
+OpenSSL 3.4
+-----------
+
+### Changes between 3.3 and 3.4 [xx XXX xxxx]
+
+ * When using EVP_DigestFinal() with either SHAKE-128 or SHAKE-256 the default
+   output length was incorrectly set to only half the required security strength.
+   The default security strength for these algorithms has been changed to 128 bits
+   and 256 bits respectively. Users may either set the xoflen OR use
+   EVP_DigestFinalXOF() to override the default.
+
+   *Shane Lontis*
+
 OpenSSL 3.3
 -----------
 

--- a/crypto/sha/sha3.c
+++ b/crypto/sha/sha3.c
@@ -34,7 +34,7 @@ int ossl_sha3_init(KECCAK1600_CTX *ctx, unsigned char pad, size_t bitlen)
     return 0;
 }
 
-int ossl_keccak_kmac_init(KECCAK1600_CTX *ctx, unsigned char pad, size_t bitlen)
+int ossl_keccak_init(KECCAK1600_CTX *ctx, unsigned char pad, size_t bitlen)
 {
     int ret = ossl_sha3_init(ctx, pad, bitlen);
 

--- a/doc/man7/EVP_MD-SHAKE.pod
+++ b/doc/man7/EVP_MD-SHAKE.pod
@@ -61,14 +61,7 @@ settable for an B<EVP_MD_CTX> with L<EVP_MD_CTX_set_params(3)>:
 
 Sets the digest length for extendable output functions.
 The length of the "xoflen" parameter should not exceed that of a B<size_t>.
-
-For backwards compatibility reasons the default xoflen length for SHAKE-128 is
-16 (bytes) which results in a security strength of only 64 bits. To ensure the
-maximum security strength of 128 bits, the xoflen should be set to at least 32.
-
-For backwards compatibility reasons the default xoflen length for SHAKE-256 is
-32 (bytes) which results in a security strength of only 128 bits. To ensure the
-maximum security strength of 256 bits, the xoflen should be set to at least 64.
+The default xoflen length is 32 bytes for SHAKE-128, and 64 bytes for SHAKE-256.
 
 This parameter may be used when calling either EVP_DigestFinal_ex() or
 EVP_DigestFinal(), since these functions were not designed to handle variable
@@ -91,7 +84,7 @@ L<EVP_MD_CTX_set_params(3)>, L<provider-digest(7)>, L<OSSL_PROVIDER-default(7)>
 
 =head1 COPYRIGHT
 
-Copyright 2020-2023 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2020-2024 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/internal/sha3.h
+++ b/include/internal/sha3.h
@@ -51,8 +51,7 @@ struct keccak_st {
 
 void ossl_sha3_reset(KECCAK1600_CTX *ctx);
 int ossl_sha3_init(KECCAK1600_CTX *ctx, unsigned char pad, size_t bitlen);
-int ossl_keccak_kmac_init(KECCAK1600_CTX *ctx, unsigned char pad,
-                          size_t bitlen);
+int ossl_keccak_init(KECCAK1600_CTX *ctx, unsigned char pad, size_t bitlen);
 int ossl_sha3_update(KECCAK1600_CTX *ctx, const void *_inp, size_t len);
 int ossl_sha3_final(KECCAK1600_CTX *ctx, unsigned char *out, size_t outlen);
 int ossl_sha3_squeeze(KECCAK1600_CTX *ctx, unsigned char *out, size_t outlen);

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -483,7 +483,7 @@ static void *name##_newctx(void *provctx)                                      \
                                                                                \
     if (ctx == NULL)                                                           \
         return NULL;                                                           \
-    ossl_sha3_init(ctx, pad, bitlen);                                          \
+    ossl_keccak_init(ctx, pad, bitlen);                                        \
     SHAKE_SET_MD(uname, typ)                                                   \
     return ctx;                                                                \
 }
@@ -497,7 +497,7 @@ static void *uname##_newctx(void *provctx)                                     \
                                                                                \
     if (ctx == NULL)                                                           \
         return NULL;                                                           \
-    ossl_keccak_kmac_init(ctx, pad, bitlen);                                   \
+    ossl_keccak_init(ctx, pad, bitlen);                                        \
     KMAC_SET_MD(bitlen)                                                        \
     return ctx;                                                                \
 }

--- a/test/evp_xof_test.c
+++ b/test/evp_xof_test.c
@@ -211,7 +211,7 @@ static int shake_kat_digestfinal_test(void)
     if (!TEST_true(EVP_DigestUpdate(ctx, shake256_input,
                    sizeof(shake256_input)))
         || !TEST_true(EVP_DigestFinal(ctx, out, &digest_length))
-        || !TEST_uint_eq(digest_length, 32)
+        || !TEST_uint_eq(digest_length, 64)
         || !TEST_mem_eq(out, digest_length,
                         shake256_output, digest_length)
         || !TEST_false(EVP_DigestFinalXOF(ctx, out, sizeof(out))))


### PR DESCRIPTION
This is a breaking change that affects using SHAKE with EVP_DigestFinal().

This should be resolved BEFORE we add support for signing with SHAKE, See (PR #23114) which is currently dependant on PR #22684 (Support for fixed output length SHAKE algorithms). This was going to be used by LMS also.

Leaving the code as it was may allow backwards compatability, but it would not interop nicely with signatures coming from another toolkit, and would be inconsistent with the Fixed output length SHAKE algorithms. Note that the algorithms will also map back to OIDS (so having 2 names for SHAKE-256, (one that mays back to a bad output size and one that is the correct size) does not allow a nice mapping back to a single OID.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
