### PR TITLE
posix_async: FreeBSD also defines {make|swap|get|set}context

### DIFF
--- a/crypto/async/arch/async_posix.h
+++ b/crypto/async/arch/async_posix.h
@@ -18,7 +18,7 @@
 # include <unistd.h>
 
 # if _POSIX_VERSION >= 200112L \
-     && (_POSIX_VERSION < 200809L || defined(__GLIBC__))
+    && (_POSIX_VERSION < 200809L || defined(__GLIBC__) || defined(__FreeBSD__))
 
 # include <pthread.h>
 


### PR DESCRIPTION
FreeBSD also defines {make|swap|get|set}context for backward compatibility, despite also exposing POSIX_VERSION 200809L in FreeBSD 15-current.

Note: There's no fallback for _POSIX_VERSION 200809 without these routines, so maybe that should be a #error?

FreeBSD currently defines _POSIX_VERSION to be 200112, but I'm changing that to 200809L and noticed this issue. Either definition will work with this #ifdef, and FreeBSD has supported 200112L level since about 2004 if I'm reading the logs right, so ~20 years, so that's sufficient.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
