### PR TITLE
Fix GCC compilation -Waggressive-loop-optimizations

### DIFF
--- a/crypto/bn/rsaz_exp_x2.c
+++ b/crypto/bn/rsaz_exp_x2.c
@@ -576,11 +576,7 @@ static void to_words52(BN_ULONG *out, int out_len,
         out_len--;
     }
 
-    while (out_len > 0) {
-        *out = 0;
-        out_len--;
-        out++;
-    }
+    memset(out, 0, out_len * sizeof(BN_ULONG));
 }
 
 static ossl_inline void put_digit(uint8_t *out, int out_len, uint64_t digit)


### PR DESCRIPTION
GCC 13.1.0 were reporting a compilation warning with -O2/3 and -Waggressive-loop-optimizations. GCC is raising an undefined behavior in the while loop, so this workaround asserts that `out_len` isn't supposed to go negative.

Fixes #21088 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
