### PR TITLE
Restrict the length of key-derivation key used in KDFs

### DIFF
--- a/apps/fipsinstall.c
+++ b/apps/fipsinstall.c
@@ -49,6 +49,12 @@ typedef enum OPTION_choice {
     OPT_X963KDF_DIGEST_CHECK,
     OPT_DISALLOW_DSA_SIGN,
     OPT_DISALLOW_TDES_ENCRYPT,
+    OPT_HKDF_KEY_CHECK,
+    OPT_TLS13_KDF_KEY_CHECK,
+    OPT_TLS1_PRF_KEY_CHECK,
+    OPT_SSHKDF_KEY_CHECK,
+    OPT_SSKDF_KEY_CHECK,
+    OPT_X963KDF_KEY_CHECK,
     OPT_SELF_TEST_ONLOAD, OPT_SELF_TEST_ONINSTALL
 } OPTION_CHOICE;
 
@@ -94,6 +100,18 @@ const OPTIONS fipsinstall_options[] = {
      "Disallow Triple-DES encryption"},
     {"rsa_sign_x931_disabled", OPT_DISALLOW_SIGNATURE_X931_PADDING, '-',
      "Disallow X931 Padding for RSA signing"},
+    {"hkdf_key_check", OPT_HKDF_KEY_CHECK, '-',
+     "Enable key check for HKDF"},
+    {"tls13_kdf_key_check", OPT_TLS13_KDF_KEY_CHECK, '-',
+     "Enable key check for TLS13-KDF"},
+    {"tls1_prf_key_check", OPT_TLS1_PRF_KEY_CHECK, '-',
+     "Enable key check for TLS1-PRF"},
+    {"sshkdf_key_check", OPT_SSHKDF_KEY_CHECK, '-',
+     "Enable key check for SSHKDF"},
+    {"sskdf_key_check", OPT_SSKDF_KEY_CHECK, '-',
+     "Enable key check for SSKDF"},
+    {"x963kdf_key_check", OPT_X963KDF_KEY_CHECK, '-',
+     "Enable key check for X963KDF"},
     OPT_SECTION("Input"),
     {"in", OPT_IN, '<', "Input config file, used when verifying"},
 
@@ -126,6 +144,12 @@ typedef struct {
     unsigned int dsa_sign_disabled : 1;
     unsigned int tdes_encrypt_disabled : 1;
     unsigned int sign_x931_padding_disabled : 1;
+    unsigned int hkdf_key_check : 1;
+    unsigned int tls13_kdf_key_check : 1;
+    unsigned int tls1_prf_key_check : 1;
+    unsigned int sshkdf_key_check : 1;
+    unsigned int sskdf_key_check : 1;
+    unsigned int x963kdf_key_check : 1;
 } FIPS_OPTS;
 
 /* Pedantic FIPS compliance */
@@ -145,6 +169,12 @@ static const FIPS_OPTS pedantic_opts = {
     1,      /* dsa_sign_disabled */
     1,      /* tdes_encrypt_disabled */
     1,      /* sign_x931_padding_disabled */
+    1,      /* hkdf_key_check */
+    1,      /* tls13_kdf_key_check */
+    1,      /* tls1_prf_key_check */
+    1,      /* sshkdf_key_check */
+    1,      /* sskdf_key_check */
+    1,      /* x963kdf_key_check */
 };
 
 /* Default FIPS settings for backward compatibility */
@@ -164,6 +194,12 @@ static FIPS_OPTS fips_opts = {
     0,      /* dsa_sign_disabled */
     0,      /* tdes_encrypt_disabled */
     0,      /* sign_x931_padding_disabled */
+    0,      /* hkdf_key_check */
+    0,      /* tls13_kdf_key_check */
+    0,      /* tls1_prf_key_check */
+    0,      /* sshkdf_key_check */
+    0,      /* sskdf_key_check */
+    0,      /* x963kdf_key_check */
 };
 
 static int check_non_pedantic_fips(int pedantic, const char *name)
@@ -312,6 +348,19 @@ static int write_config_fips_section(BIO *out, const char *section,
         || BIO_printf(out, "%s = %s\n",
                       OSSL_PROV_FIPS_PARAM_RSA_SIGN_X931_PAD_DISABLED,
                       opts->sign_x931_padding_disabled ? "1" : "0") <= 0
+        || BIO_printf(out, "%s = %s\n", OSSL_PROV_FIPS_PARAM_HKDF_KEY_CHECK,
+                      opts->hkdf_key_check ? "1": "0") <= 0
+        || BIO_printf(out, "%s = %s\n",
+                      OSSL_PROV_FIPS_PARAM_TLS13_KDF_KEY_CHECK,
+                      opts->tls13_kdf_key_check ? "1": "0") <= 0
+        || BIO_printf(out, "%s = %s\n", OSSL_PROV_FIPS_PARAM_TLS1_PRF_KEY_CHECK,
+                      opts->tls1_prf_key_check ? "1": "0") <= 0
+        || BIO_printf(out, "%s = %s\n", OSSL_PROV_FIPS_PARAM_SSHKDF_KEY_CHECK,
+                      opts->sshkdf_key_check ? "1": "0") <= 0
+        || BIO_printf(out, "%s = %s\n", OSSL_PROV_FIPS_PARAM_SSKDF_KEY_CHECK,
+                      opts->sskdf_key_check ? "1": "0") <= 0
+        || BIO_printf(out, "%s = %s\n", OSSL_PROV_FIPS_PARAM_X963KDF_KEY_CHECK,
+                      opts->x963kdf_key_check ? "1": "0") <= 0
         || !print_mac(out, OSSL_PROV_FIPS_PARAM_MODULE_MAC, module_mac,
                       module_mac_len))
         goto end;
@@ -527,6 +576,24 @@ int fipsinstall_main(int argc, char **argv)
             break;
         case OPT_DISALLOW_SIGNATURE_X931_PADDING:
             fips_opts.sign_x931_padding_disabled = 1;
+            break;
+        case OPT_HKDF_KEY_CHECK:
+            fips_opts.hkdf_key_check = 1;
+            break;
+        case OPT_TLS13_KDF_KEY_CHECK:
+            fips_opts.tls13_kdf_key_check = 1;
+            break;
+        case OPT_TLS1_PRF_KEY_CHECK:
+            fips_opts.tls1_prf_key_check = 1;
+            break;
+        case OPT_SSHKDF_KEY_CHECK:
+            fips_opts.sshkdf_key_check = 1;
+            break;
+        case OPT_SSKDF_KEY_CHECK:
+            fips_opts.sskdf_key_check = 1;
+            break;
+        case OPT_X963KDF_KEY_CHECK:
+            fips_opts.x963kdf_key_check = 1;
             break;
         case OPT_QUIET:
             quiet = 1;

--- a/doc/man1/openssl-fipsinstall.pod.in
+++ b/doc/man1/openssl-fipsinstall.pod.in
@@ -34,6 +34,12 @@ B<openssl fipsinstall>
 [B<-no_short_mac>]
 [B<-tdes_encrypt_disabled>]
 [B<-rsa_sign_x931_disabled>]
+[B<-hkdf_key_check>]
+[B<-tls13_kdf_key_check>]
+[B<-tls1_prf_key_check>]
+[B<-sshkdf_key_check>]
+[B<-sskdf_key_check>]
+[B<-x963kdf_key_check>]
 [B<-self_test_onload>]
 [B<-self_test_oninstall>]
 [B<-corrupt_desc> I<selftest_description>]
@@ -256,6 +262,42 @@ See SP800-131Ar2 for details.
 
 Configure the module to not allow X9.31 padding be used when signing with RSA.
 See FIPS 140-3 IG C.K for details.
+
+=item B<-hkdf_key_check>
+
+Configure the module to enable a run-time short key-derivation key check when
+deriving a key by HKDF.
+See NIST SP 800-131Ar2 for details.
+
+=item B<-tls13_kdf_key_check>
+
+Configure the module to enable a run-time short key-derivation key check when
+deriving a key by TLS13 KDF.
+See NIST SP 800-131Ar2 for details.
+
+=item B<-tls1_prf_key_check>
+
+Configure the module to enable a run-time short key-derivation key check when
+deriving a key by TLS_PRF.
+See NIST SP 800-131Ar2 for details.
+
+=item B<-sshkdf_key_check>
+
+Configure the module to enable a run-time short key-derivation key check when
+deriving a key by SSHKDF.
+See NIST SP 800-131Ar2 for details.
+
+=item B<-sskdf_key_check>
+
+Configure the module to enable a run-time short key-derivation key check when
+deriving a key by SSKDF.
+See NIST SP 800-131Ar2 for details.
+
+=item B<-x963kdf_key_check>
+
+Configure the module to enable a run-time short key-derivation key check when
+deriving a key by X963KDF.
+See NIST SP 800-131Ar2 for details.
 
 =item B<-self_test_onload>
 

--- a/doc/man7/EVP_KDF-HKDF.pod
+++ b/doc/man7/EVP_KDF-HKDF.pod
@@ -80,6 +80,22 @@ an error will occur.
 
 =back
 
+=item "fips-indicator" (B<OSSL_KDF_PARAM_FIPS_APPROVED_INDICATOR>) <integer>
+
+A getter that returns 1 if the operation is FIPS approved, or 0 otherwise.
+This may be used after calling EVP_KDF_derive. It returns 0 if any "***-check"
+related parameter is set to 0 and the check fails.
+This option is used by the OpenSSL FIPS provider.
+
+=item "key-check" (B<OSSL_KDF_PARAM_FIPS_KEY_CHECK>) <integer>
+
+The default value of 1 causes an error during EVP_KDF_derive() if the length of
+used key-derivation key (B<OSSL_KDF_PARAM_KEY>) is shorter than 112 bits.
+Setting this to zero will ignore the error and set the approved
+"fips-indicator" to 0.
+This option is used by the OpenSSL FIPS provider, and breaks FIPS compliance if
+set to 0.
+
 =back
 
 =head1 NOTES

--- a/doc/man7/EVP_KDF-HKDF.pod
+++ b/doc/man7/EVP_KDF-HKDF.pod
@@ -89,8 +89,9 @@ This option is used by the OpenSSL FIPS provider.
 
 =item "key-check" (B<OSSL_KDF_PARAM_FIPS_KEY_CHECK>) <integer>
 
-The default value of 1 causes an error during EVP_KDF_derive() if the length of
-used key-derivation key (B<OSSL_KDF_PARAM_KEY>) is shorter than 112 bits.
+The default value of 1 causes an error during EVP_KDF_CTX_set_params() if the
+length of used key-derivation key (B<OSSL_KDF_PARAM_KEY>) is shorter than 112
+bits.
 Setting this to zero will ignore the error and set the approved
 "fips-indicator" to 0.
 This option is used by the OpenSSL FIPS provider, and breaks FIPS compliance if

--- a/doc/man7/EVP_KDF-SS.pod
+++ b/doc/man7/EVP_KDF-SS.pod
@@ -61,6 +61,22 @@ This parameter set the shared secret that is used for key derivation.
 
 This parameter sets an optional value for fixedinfo, also known as otherinfo.
 
+=item "fips-indicator" (B<OSSL_KDF_PARAM_FIPS_APPROVED_INDICATOR>) <integer>
+
+A getter that returns 1 if the operation is FIPS approved, or 0 otherwise.
+This may be used after calling EVP_KDF_derive. It returns 0 if any "***-check"
+related parameter is set to 0 and the check fails.
+This option is used by the OpenSSL FIPS provider.
+
+=item "key-check" (B<OSSL_KDF_PARAM_FIPS_KEY_CHECK>) <integer>
+
+The default value of 1 causes an error during EVP_KDF_derive() if the length of
+used key-derivation key (B<OSSL_KDF_PARAM_KEY>) is shorter than 112 bits.
+Setting this to zero will ignore the error and set the approved
+"fips-indicator" to 0.
+This option is used by the OpenSSL FIPS provider, and breaks FIPS compliance if
+set to 0.
+
 =back
 
 =head1 NOTES

--- a/doc/man7/EVP_KDF-SS.pod
+++ b/doc/man7/EVP_KDF-SS.pod
@@ -70,8 +70,9 @@ This option is used by the OpenSSL FIPS provider.
 
 =item "key-check" (B<OSSL_KDF_PARAM_FIPS_KEY_CHECK>) <integer>
 
-The default value of 1 causes an error during EVP_KDF_derive() if the length of
-used key-derivation key (B<OSSL_KDF_PARAM_KEY>) is shorter than 112 bits.
+The default value of 1 causes an error during EVP_KDF_CTX_set_params() if the
+length of used key-derivation key (B<OSSL_KDF_PARAM_KEY>) is shorter than 112
+bits.
 Setting this to zero will ignore the error and set the approved
 "fips-indicator" to 0.
 This option is used by the OpenSSL FIPS provider, and breaks FIPS compliance if

--- a/doc/man7/EVP_KDF-SSHKDF.pod
+++ b/doc/man7/EVP_KDF-SSHKDF.pod
@@ -80,14 +80,14 @@ A single char of value 70 (ASCII char 'F').
 
 =back
 
-=item "fips-indicator" (B<OSSL_KDF_PARAM_FIPS_APPROVED_INDICATOR>) <int>
+=item "fips-indicator" (B<OSSL_KDF_PARAM_FIPS_APPROVED_INDICATOR>) <integer>
 
 A getter that returns 1 if the operation is FIPS approved, or 0 otherwise.
 This may be used after calling EVP_KDF_derive. It returns 0 if any "***-check"
 related parameter is set to 0 and the check fails.
 This option is used by the OpenSSL FIPS provider.
 
-=item "digest-check" (B<OSSL_KDF_PARAM_FIPS_DIGEST_CHECK>) <int>
+=item "digest-check" (B<OSSL_KDF_PARAM_FIPS_DIGEST_CHECK>) <integer>
 
 The default value of 1 causes an error during EVP_KDF_derive() if
 used digest is not approved.
@@ -98,6 +98,15 @@ set to 0.
 
 According to SP 800-135r1, the following are approved digest algorithms: SHA-1,
 SHA2-224, SHA2-256, SHA2-384, SHA2-512.
+
+=item "key-check" (B<OSSL_KDF_PARAM_FIPS_KEY_CHECK>) <integer>
+
+The default value of 1 causes an error during EVP_KDF_derive() if the length of
+used key-derivation key (B<OSSL_KDF_PARAM_KEY>) is shorter than 112 bits.
+Setting this to zero will ignore the error and set the approved
+"fips-indicator" to 0.
+This option is used by the OpenSSL FIPS provider, and breaks FIPS compliance if
+set to 0.
 
 =back
 

--- a/doc/man7/EVP_KDF-SSHKDF.pod
+++ b/doc/man7/EVP_KDF-SSHKDF.pod
@@ -89,7 +89,7 @@ This option is used by the OpenSSL FIPS provider.
 
 =item "digest-check" (B<OSSL_KDF_PARAM_FIPS_DIGEST_CHECK>) <integer>
 
-The default value of 1 causes an error during EVP_KDF_derive() if
+The default value of 1 causes an error during EVP_KDF_CTX_set_params() if
 used digest is not approved.
 Setting this to zero will ignore the error and set the approved
 "fips-indicator" to 0.
@@ -101,8 +101,9 @@ SHA2-224, SHA2-256, SHA2-384, SHA2-512.
 
 =item "key-check" (B<OSSL_KDF_PARAM_FIPS_KEY_CHECK>) <integer>
 
-The default value of 1 causes an error during EVP_KDF_derive() if the length of
-used key-derivation key (B<OSSL_KDF_PARAM_KEY>) is shorter than 112 bits.
+The default value of 1 causes an error during EVP_KDF_CTX_set_params() if the
+length of used key-derivation key (B<OSSL_KDF_PARAM_KEY>) is shorter than 112
+bits.
 Setting this to zero will ignore the error and set the approved
 "fips-indicator" to 0.
 This option is used by the OpenSSL FIPS provider, and breaks FIPS compliance if

--- a/doc/man7/EVP_KDF-TLS13_KDF.pod
+++ b/doc/man7/EVP_KDF-TLS13_KDF.pod
@@ -54,14 +54,14 @@ Refer to RFC 8446 section 7.1 "Key Schedule" for details.
 This parameter sets the mode for the TLS 1.3 KDF operation.
 There are two modes that are currently defined:
 
-=item "fips-indicator" (B<OSSL_KDF_PARAM_FIPS_APPROVED_INDICATOR>) <int>
+=item "fips-indicator" (B<OSSL_KDF_PARAM_FIPS_APPROVED_INDICATOR>) <integer>
 
 A getter that returns 1 if the operation is FIPS approved, or 0 otherwise.
 This may be used after calling EVP_KDF_derive. It returns 0 if any "***-check"
 related parameter is set to 0 and the check fails.
 This option is used by the OpenSSL FIPS provider.
 
-=item "digest-check" (B<OSSL_KDF_PARAM_FIPS_DIGEST_CHECK>) <int>
+=item "digest-check" (B<OSSL_KDF_PARAM_FIPS_DIGEST_CHECK>) <integer>
 
 The default value of 1 causes an error during EVP_KDF_derive() if
 used digest is not approved.
@@ -72,6 +72,15 @@ set to 0.
 
 According to RFC 8446, the following are approved digest algorithms: SHA2-256,
 SHA2-384.
+
+=item "key-check" (B<OSSL_KDF_PARAM_FIPS_KEY_CHECK>) <integer>
+
+The default value of 1 causes an error during EVP_KDF_derive() if the length of
+used key-derivation key (B<OSSL_KDF_PARAM_KEY>) is shorter than 112 bits.
+Setting this to zero will ignore the error and set the approved
+"fips-indicator" to 0.
+This option is used by the OpenSSL FIPS provider, and breaks FIPS compliance if
+set to 0.
 
 =over 4
 

--- a/doc/man7/EVP_KDF-TLS13_KDF.pod
+++ b/doc/man7/EVP_KDF-TLS13_KDF.pod
@@ -63,7 +63,7 @@ This option is used by the OpenSSL FIPS provider.
 
 =item "digest-check" (B<OSSL_KDF_PARAM_FIPS_DIGEST_CHECK>) <integer>
 
-The default value of 1 causes an error during EVP_KDF_derive() if
+The default value of 1 causes an error during EVP_KDF_CTX_set_params() if
 used digest is not approved.
 Setting this to zero will ignore the error and set the approved
 "fips-indicator" to 0.
@@ -75,8 +75,9 @@ SHA2-384.
 
 =item "key-check" (B<OSSL_KDF_PARAM_FIPS_KEY_CHECK>) <integer>
 
-The default value of 1 causes an error during EVP_KDF_derive() if the length of
-used key-derivation key (B<OSSL_KDF_PARAM_KEY>) is shorter than 112 bits.
+The default value of 1 causes an error during EVP_KDF_CTX_set_params() if the
+length of used key-derivation key (B<OSSL_KDF_PARAM_KEY>) is shorter than 112
+bits.
 Setting this to zero will ignore the error and set the approved
 "fips-indicator" to 0.
 This option is used by the OpenSSL FIPS provider, and breaks FIPS compliance if

--- a/doc/man7/EVP_KDF-TLS1_PRF.pod
+++ b/doc/man7/EVP_KDF-TLS1_PRF.pod
@@ -59,7 +59,7 @@ will ignore the error and set the approved "fips-indicator" to 0.
 This option is used by the OpenSSL FIPS provider, and breaks FIPS compliance if
 set to 0.
 
-=item "digest-check" (B<OSSL_KDF_PARAM_FIPS_DIGEST_CHECK>) <int>
+=item "digest-check" (B<OSSL_KDF_PARAM_FIPS_DIGEST_CHECK>) <integer>
 
 The default value of 1 causes an error during EVP_KDF_derive() if
 used digest is not approved.
@@ -70,6 +70,15 @@ set to 0.
 
 According to SP 800-135r1, the following are approved digest algorithms:
 SHA2-256, SHA2-384, SHA2-512.
+
+=item "key-check" (B<OSSL_KDF_PARAM_FIPS_KEY_CHECK>) <integer>
+
+The default value of 1 causes an error during EVP_KDF_derive() if the length of
+used key-derivation key (B<OSSL_KDF_PARAM_SECRET>) is shorter than 112 bits.
+Setting this to zero will ignore the error and set the approved
+"fips-indicator" to 0.
+This option is used by the OpenSSL FIPS provider, and breaks FIPS compliance if
+set to 0.
 
 =back
 

--- a/doc/man7/EVP_KDF-TLS1_PRF.pod
+++ b/doc/man7/EVP_KDF-TLS1_PRF.pod
@@ -61,7 +61,7 @@ set to 0.
 
 =item "digest-check" (B<OSSL_KDF_PARAM_FIPS_DIGEST_CHECK>) <integer>
 
-The default value of 1 causes an error during EVP_KDF_derive() if
+The default value of 1 causes an error during EVP_KDF_CTX_set_params() if
 used digest is not approved.
 Setting this to zero will ignore the error and set the approved
 "fips-indicator" to 0.
@@ -73,8 +73,9 @@ SHA2-256, SHA2-384, SHA2-512.
 
 =item "key-check" (B<OSSL_KDF_PARAM_FIPS_KEY_CHECK>) <integer>
 
-The default value of 1 causes an error during EVP_KDF_derive() if the length of
-used key-derivation key (B<OSSL_KDF_PARAM_SECRET>) is shorter than 112 bits.
+The default value of 1 causes an error during EVP_KDF_CTX_set_params() if the
+length of used key-derivation key (B<OSSL_KDF_PARAM_SECRET>) is shorter than 112
+bits.
 Setting this to zero will ignore the error and set the approved
 "fips-indicator" to 0.
 This option is used by the OpenSSL FIPS provider, and breaks FIPS compliance if

--- a/doc/man7/EVP_KDF-X963.pod
+++ b/doc/man7/EVP_KDF-X963.pod
@@ -36,7 +36,7 @@ This parameter sets the secret.
 
 This parameter specifies an optional value for shared info.
 
-=item "fips-indicator" (B<OSSL_KDF_PARAM_FIPS_APPROVED_INDICATOR>) <int>
+=item "fips-indicator" (B<OSSL_KDF_PARAM_FIPS_APPROVED_INDICATOR>) <integer>
 
 A getter that returns 1 if the operation is FIPS approved, or 0 otherwise.
 This may be used after calling EVP_KDF_derive. It returns 0 if any "***-check"
@@ -55,6 +55,15 @@ set to 0.
 According to ANSI X9.63-2001, the following are approved digest algorithms:
 SHA2-224, SHA2-256, SHA2-384, SHA2-512, SHA2-512/224, SHA2-512/256, SHA3-224,
 SHA3-256, SHA3-384, SHA3-512.
+
+=item "key-check" (B<OSSL_KDF_PARAM_FIPS_KEY_CHECK>) <integer>
+
+The default value of 1 causes an error during EVP_KDF_derive() if the length of
+used key-derivation key (B<OSSL_KDF_PARAM_KEY>) is shorter than 112 bits.
+Setting this to zero will ignore the error and set the approved
+"fips-indicator" to 0.
+This option is used by the OpenSSL FIPS provider, and breaks FIPS compliance if
+set to 0.
 
 =back
 

--- a/doc/man7/EVP_KDF-X963.pod
+++ b/doc/man7/EVP_KDF-X963.pod
@@ -45,7 +45,7 @@ This option is used by the OpenSSL FIPS provider.
 
 =item "digest-check" (B<OSSL_KDF_PARAM_FIPS_DIGEST_CHECK>) <int>
 
-The default value of 1 causes an error during EVP_KDF_derive() if
+The default value of 1 causes an error during EVP_KDF_CTX_set_params() if
 used digest is not approved.
 Setting this to zero will ignore the error and set the approved
 "fips-indicator" to 0.
@@ -58,8 +58,9 @@ SHA3-256, SHA3-384, SHA3-512.
 
 =item "key-check" (B<OSSL_KDF_PARAM_FIPS_KEY_CHECK>) <integer>
 
-The default value of 1 causes an error during EVP_KDF_derive() if the length of
-used key-derivation key (B<OSSL_KDF_PARAM_KEY>) is shorter than 112 bits.
+The default value of 1 causes an error during EVP_KDF_CTX_set_params() if the
+length of used key-derivation key (B<OSSL_KDF_PARAM_KEY>) is shorter than 112
+bits.
 Setting this to zero will ignore the error and set the approved
 "fips-indicator" to 0.
 This option is used by the OpenSSL FIPS provider, and breaks FIPS compliance if

--- a/include/openssl/fips_names.h
+++ b/include/openssl/fips_names.h
@@ -150,6 +150,54 @@ extern "C" {
  */
 # define OSSL_PROV_FIPS_PARAM_RSA_SIGN_X931_PAD_DISABLED "rsa-sign-x931-pad-disabled"
 
+/*
+ * A boolean that determines if the runtime FIPS key check for HKDF is
+ * performed.
+ * This is disabled by default.
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+# define OSSL_PROV_FIPS_PARAM_HKDF_KEY_CHECK "hkdf-key-check"
+
+/*
+ * A boolean that determines if the runtime FIPS key check for TLS13 KDF is
+ * performed.
+ * This is disabled by default.
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+# define OSSL_PROV_FIPS_PARAM_TLS13_KDF_KEY_CHECK "tls13-kdf-key-check"
+
+/*
+ * A boolean that determines if the runtime FIPS key check for TLS1_PRF is
+ * performed.
+ * This is disabled by default.
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+# define OSSL_PROV_FIPS_PARAM_TLS1_PRF_KEY_CHECK "tls1-prf-key-check"
+
+/*
+ * A boolean that determines if the runtime FIPS key check for SSHKDF is
+ * performed.
+ * This is disabled by default.
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+# define OSSL_PROV_FIPS_PARAM_SSHKDF_KEY_CHECK "sshkdf-key-check"
+
+/*
+ * A boolean that determines if the runtime FIPS key check for SSKDF is
+ * performed.
+ * This is disabled by default.
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+# define OSSL_PROV_FIPS_PARAM_SSKDF_KEY_CHECK "sskdf-key-check"
+
+/*
+ * A boolean that determines if the runtime FIPS key check for X963KDF is
+ * performed.
+ * This is disabled by default.
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+# define OSSL_PROV_FIPS_PARAM_X963KDF_KEY_CHECK "x963kdf-key-check"
+
 # ifdef __cplusplus
 }
 # endif

--- a/providers/common/include/prov/fipscommon.h
+++ b/providers/common/include/prov/fipscommon.h
@@ -23,5 +23,11 @@ int FIPS_x963kdf_digest_check(OSSL_LIB_CTX *libctx);
 int FIPS_dsa_sign_check(OSSL_LIB_CTX *libctx);
 int FIPS_tdes_encrypt_check(OSSL_LIB_CTX *libctx);
 int FIPS_rsa_sign_x931_disallowed(OSSL_LIB_CTX *libctx);
+int FIPS_hkdf_key_check(OSSL_LIB_CTX *libctx);
+int FIPS_tls13_kdf_key_check(OSSL_LIB_CTX *libctx);
+int FIPS_tls1_prf_key_check(OSSL_LIB_CTX *libctx);
+int FIPS_sshkdf_key_check(OSSL_LIB_CTX *libctx);
+int FIPS_sskdf_key_check(OSSL_LIB_CTX *libctx);
+int FIPS_x963kdf_key_check(OSSL_LIB_CTX *libctx);
 
 #endif

--- a/providers/common/include/prov/securitycheck.h
+++ b/providers/common/include/prov/securitycheck.h
@@ -17,6 +17,7 @@
 /* Functions that are common */
 int ossl_rsa_key_op_get_protect(const RSA *rsa, int operation, int *outprotect);
 int ossl_rsa_check_key_size(const RSA *rsa, int protect);
+int ossl_kdf_check_key_size(size_t keylen);
 
 #ifndef OPENSSL_NO_EC
 int ossl_ec_check_curve_allowed(const EC_GROUP *group);

--- a/providers/common/securitycheck.c
+++ b/providers/common/securitycheck.c
@@ -70,6 +70,15 @@ int ossl_rsa_check_key_size(const RSA *rsa, int protect)
     return 1;
 }
 
+/*
+ * FIPS requires a minimum security strength of 112 bits for key-derivation key.
+ * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf.
+ */
+int ossl_kdf_check_key_size(size_t keylen)
+{
+    return (keylen * 8) >= 112;
+}
+
 #ifndef OPENSSL_NO_EC
 
 int ossl_ec_check_curve_allowed(const EC_GROUP *group)

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -98,6 +98,12 @@ typedef struct fips_global_st {
     FIPS_OPTION fips_dsa_sign_disallowed;
     FIPS_OPTION fips_tdes_encrypt_disallowed;
     FIPS_OPTION fips_rsa_sign_x931_disallowed;
+    FIPS_OPTION fips_hkdf_key_check;
+    FIPS_OPTION fips_tls13_kdf_key_check;
+    FIPS_OPTION fips_tls1_prf_key_check;
+    FIPS_OPTION fips_sshkdf_key_check;
+    FIPS_OPTION fips_sskdf_key_check;
+    FIPS_OPTION fips_x963kdf_key_check;
 } FIPS_GLOBAL;
 
 static void init_fips_option(FIPS_OPTION *opt, int enabled)
@@ -125,6 +131,12 @@ void *ossl_fips_prov_ossl_ctx_new(OSSL_LIB_CTX *libctx)
     init_fips_option(&fgbl->fips_dsa_sign_disallowed, 0);
     init_fips_option(&fgbl->fips_tdes_encrypt_disallowed, 0);
     init_fips_option(&fgbl->fips_rsa_sign_x931_disallowed, 0);
+    init_fips_option(&fgbl->fips_hkdf_key_check, 0);
+    init_fips_option(&fgbl->fips_tls13_kdf_key_check, 0);
+    init_fips_option(&fgbl->fips_tls1_prf_key_check, 0);
+    init_fips_option(&fgbl->fips_sshkdf_key_check, 0);
+    init_fips_option(&fgbl->fips_sskdf_key_check, 0);
+    init_fips_option(&fgbl->fips_x963kdf_key_check, 0);
     return fgbl;
 }
 
@@ -161,6 +173,18 @@ static const OSSL_PARAM fips_param_types[] = {
                     NULL, 0),
     OSSL_PARAM_DEFN(OSSL_PROV_PARAM_RSA_SIGN_X931_PAD_DISABLED,
                     OSSL_PARAM_INTEGER, NULL, 0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_HKDF_KEY_CHECK, OSSL_PARAM_INTEGER, NULL,
+                    0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_TLS13_KDF_KEY_CHECK, OSSL_PARAM_INTEGER,
+                    NULL, 0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_TLS1_PRF_KEY_CHECK, OSSL_PARAM_INTEGER,
+                    NULL, 0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_SSHKDF_KEY_CHECK, OSSL_PARAM_INTEGER, NULL,
+                    0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_SSKDF_KEY_CHECK, OSSL_PARAM_INTEGER, NULL,
+                    0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_X963KDF_KEY_CHECK, OSSL_PARAM_INTEGER, NULL,
+                    0),
     OSSL_PARAM_END
 };
 
@@ -174,7 +198,7 @@ static int fips_get_params_from_core(FIPS_GLOBAL *fgbl)
     * OSSL_PROV_FIPS_PARAM_SECURITY_CHECKS and
     * OSSL_PROV_FIPS_PARAM_TLS1_PRF_EMS_CHECK are not self test parameters.
     */
-    OSSL_PARAM core_params[20], *p = core_params;
+    OSSL_PARAM core_params[26], *p = core_params;
 
     *p++ = OSSL_PARAM_construct_utf8_ptr(
             OSSL_PROV_PARAM_CORE_MODULE_FILENAME,
@@ -233,6 +257,18 @@ static int fips_get_params_from_core(FIPS_GLOBAL *fgbl)
                         fips_tdes_encrypt_disallowed);
     FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_RSA_SIGN_X931_PAD_DISABLED,
                         fips_rsa_sign_x931_disallowed);
+    FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_HKDF_KEY_CHECK,
+                        fips_hkdf_key_check);
+    FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_TLS13_KDF_KEY_CHECK,
+                        fips_tls13_kdf_key_check);
+    FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_TLS1_PRF_KEY_CHECK,
+                        fips_tls1_prf_key_check);
+    FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_SSHKDF_KEY_CHECK,
+                        fips_sshkdf_key_check);
+    FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_SSKDF_KEY_CHECK,
+                        fips_sskdf_key_check);
+    FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_X963KDF_KEY_CHECK,
+                        fips_x963kdf_key_check);
 #undef FIPS_FEATURE_OPTION
 
     *p = OSSL_PARAM_construct_end();
@@ -300,6 +336,18 @@ static int fips_get_params(void *provctx, OSSL_PARAM params[])
                      fips_tdes_encrypt_disallowed);
     FIPS_FEATURE_GET(fgbl, OSSL_PROV_PARAM_RSA_SIGN_X931_PAD_DISABLED,
                      fips_rsa_sign_x931_disallowed);
+    FIPS_FEATURE_GET(fgbl, OSSL_PROV_PARAM_HKDF_KEY_CHECK,
+                     fips_hkdf_key_check);
+    FIPS_FEATURE_GET(fgbl, OSSL_PROV_PARAM_TLS13_KDF_KEY_CHECK,
+                     fips_tls13_kdf_key_check);
+    FIPS_FEATURE_GET(fgbl, OSSL_PROV_PARAM_TLS1_PRF_KEY_CHECK,
+                     fips_tls1_prf_key_check);
+    FIPS_FEATURE_GET(fgbl, OSSL_PROV_PARAM_SSHKDF_KEY_CHECK,
+                     fips_sshkdf_key_check);
+    FIPS_FEATURE_GET(fgbl, OSSL_PROV_PARAM_SSKDF_KEY_CHECK,
+                     fips_sskdf_key_check);
+    FIPS_FEATURE_GET(fgbl, OSSL_PROV_PARAM_X963KDF_KEY_CHECK,
+                     fips_x963kdf_key_check);
 #undef FIPS_FEATURE_GET
     return 1;
 }
@@ -844,6 +892,12 @@ int OSSL_provider_init_int(const OSSL_CORE_HANDLE *handle,
     FIPS_SET_OPTION(fgbl, fips_dsa_sign_disallowed);
     FIPS_SET_OPTION(fgbl, fips_tdes_encrypt_disallowed);
     FIPS_SET_OPTION(fgbl, fips_rsa_sign_x931_disallowed);
+    FIPS_SET_OPTION(fgbl, fips_hkdf_key_check);
+    FIPS_SET_OPTION(fgbl, fips_tls13_kdf_key_check);
+    FIPS_SET_OPTION(fgbl, fips_tls1_prf_key_check);
+    FIPS_SET_OPTION(fgbl, fips_sshkdf_key_check);
+    FIPS_SET_OPTION(fgbl, fips_sskdf_key_check);
+    FIPS_SET_OPTION(fgbl, fips_x963kdf_key_check);
 #undef FIPS_SET_OPTION
 
     ossl_prov_cache_exported_algorithms(fips_ciphers, exported_fips_ciphers);
@@ -1056,6 +1110,12 @@ FIPS_FEATURE_CHECK(FIPS_dsa_sign_check, fips_dsa_sign_disallowed)
 FIPS_FEATURE_CHECK(FIPS_tdes_encrypt_check, fips_tdes_encrypt_disallowed)
 FIPS_FEATURE_CHECK(FIPS_rsa_sign_x931_disallowed,
                    fips_rsa_sign_x931_disallowed)
+FIPS_FEATURE_CHECK(FIPS_hkdf_key_check, fips_hkdf_key_check)
+FIPS_FEATURE_CHECK(FIPS_tls13_kdf_key_check, fips_tls13_kdf_key_check)
+FIPS_FEATURE_CHECK(FIPS_tls1_prf_key_check, fips_tls1_prf_key_check)
+FIPS_FEATURE_CHECK(FIPS_sshkdf_key_check, fips_sshkdf_key_check)
+FIPS_FEATURE_CHECK(FIPS_sskdf_key_check, fips_sskdf_key_check)
+FIPS_FEATURE_CHECK(FIPS_x963kdf_key_check, fips_x963kdf_key_check)
 
 #undef FIPS_FEATURE_CHECK
 

--- a/providers/implementations/kdfs/hkdf.c
+++ b/providers/implementations/kdfs/hkdf.c
@@ -236,11 +236,6 @@ static int kdf_hkdf_derive(void *vctx, unsigned char *key, size_t keylen,
         return 0;
     }
 
-#ifdef FIPS_MODULE
-    if (!fips_hkdf_key_check_passed(ctx))
-        return 0;
-#endif
-
     switch (ctx->mode) {
     case EVP_KDF_HKDF_MODE_EXTRACT_AND_EXPAND:
     default:
@@ -344,6 +339,12 @@ static int kdf_hkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
                                             &ctx->info, &ctx->info_len,
                                             HKDF_MAXINFO) == 0)
         return 0;
+
+#ifdef FIPS_MODULE
+    if (OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_KEY) != NULL)
+        if (!fips_hkdf_key_check_passed(ctx))
+            return 0;
+#endif
 
     return 1;
 }
@@ -815,11 +816,6 @@ static int kdf_tls1_3_derive(void *vctx, unsigned char *key, size_t keylen,
         return 0;
     }
 
-#ifdef FIPS_MODULE
-    if (!fips_tls1_3_key_check_passed(ctx))
-        return 0;
-#endif
-
     switch (ctx->mode) {
     default:
         return 0;
@@ -895,6 +891,10 @@ static int kdf_tls1_3_set_ctx_params(void *vctx, const OSSL_PARAM params[])
         if (!fips_tls1_3_digest_check_passed(ctx, md))
             return 0;
     }
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_KEY)) != NULL)
+        if (!fips_tls1_3_key_check_passed(ctx))
+            return 0;
 #endif
 
     return 1;

--- a/providers/implementations/kdfs/sshkdf.c
+++ b/providers/implementations/kdfs/sshkdf.c
@@ -153,6 +153,22 @@ static int fips_digest_check_passed(KDF_SSHKDF *ctx, const EVP_MD *md)
     }
     return 1;
 }
+
+static int fips_key_check_passed(KDF_SSHKDF *ctx)
+{
+    OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(ctx->provctx);
+    int key_approved = ossl_kdf_check_key_size(ctx->key_len);
+
+    if (!key_approved) {
+        if (!OSSL_FIPS_IND_ON_UNAPPROVED(ctx, OSSL_FIPS_IND_SETTABLE1,
+                                         libctx, "SSHKDF", "Key size",
+                                         FIPS_sshkdf_key_check)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
+            return 0;
+        }
+    }
+    return 1;
+}
 #endif
 
 static int kdf_sshkdf_derive(void *vctx, unsigned char *key, size_t keylen,
@@ -186,6 +202,11 @@ static int kdf_sshkdf_derive(void *vctx, unsigned char *key, size_t keylen,
         return 0;
     }
 
+#ifdef FIPS_MODULE
+    if (!fips_key_check_passed(ctx))
+        return 0;
+#endif
+
     return SSHKDF(md, ctx->key, ctx->key_len,
                   ctx->xcghash, ctx->xcghash_len,
                   ctx->session_id, ctx->session_id_len,
@@ -203,6 +224,9 @@ static int kdf_sshkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 
     if (!OSSL_FIPS_IND_SET_CTX_PARAM(ctx, OSSL_FIPS_IND_SETTABLE0, params,
                                      OSSL_KDF_PARAM_FIPS_DIGEST_CHECK))
+        return 0;
+    if (!OSSL_FIPS_IND_SET_CTX_PARAM(ctx, OSSL_FIPS_IND_SETTABLE1, params,
+                                     OSSL_KDF_PARAM_FIPS_KEY_CHECK))
         return 0;
 
     if (OSSL_PARAM_locate_const(params, OSSL_ALG_PARAM_DIGEST) != NULL) {
@@ -266,6 +290,7 @@ static const OSSL_PARAM *kdf_sshkdf_settable_ctx_params(ossl_unused void *ctx,
         OSSL_PARAM_octet_string(OSSL_KDF_PARAM_SSHKDF_SESSION_ID, NULL, 0),
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_SSHKDF_TYPE, NULL, 0),
         OSSL_FIPS_IND_SETTABLE_CTX_PARAM(OSSL_KDF_PARAM_FIPS_DIGEST_CHECK)
+        OSSL_FIPS_IND_SETTABLE_CTX_PARAM(OSSL_KDF_PARAM_FIPS_KEY_CHECK)
         OSSL_PARAM_END
     };
     return known_settable_ctx_params;

--- a/providers/implementations/kdfs/sshkdf.c
+++ b/providers/implementations/kdfs/sshkdf.c
@@ -202,11 +202,6 @@ static int kdf_sshkdf_derive(void *vctx, unsigned char *key, size_t keylen,
         return 0;
     }
 
-#ifdef FIPS_MODULE
-    if (!fips_key_check_passed(ctx))
-        return 0;
-#endif
-
     return SSHKDF(md, ctx->key, ctx->key_len,
                   ctx->xcghash, ctx->xcghash_len,
                   ctx->session_id, ctx->session_id_len,
@@ -247,9 +242,15 @@ static int kdf_sshkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 #endif
     }
 
-    if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_KEY)) != NULL)
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_KEY)) != NULL) {
         if (!sshkdf_set_membuf(&ctx->key, &ctx->key_len, p))
             return 0;
+
+#ifdef FIPS_MODULE
+        if (!fips_key_check_passed(ctx))
+            return 0;
+#endif
+    }
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_SSHKDF_XCGHASH))
         != NULL)

--- a/providers/implementations/kdfs/sskdf.c
+++ b/providers/implementations/kdfs/sskdf.c
@@ -425,11 +425,6 @@ static int sskdf_derive(void *vctx, unsigned char *key, size_t keylen,
         return 0;
     }
 
-#ifdef FIPS_MODULE
-    if (!fips_sskdf_key_check_passed(ctx))
-        return 0;
-#endif
-
     md = ossl_prov_digest_md(&ctx->digest);
 
     if (ctx->macctx != NULL) {
@@ -545,11 +540,6 @@ static int x963kdf_derive(void *vctx, unsigned char *key, size_t keylen,
         return 0;
     }
 
-#ifdef FIPS_MODULE
-    if (!fips_x963kdf_key_check_passed(ctx))
-        return 0;
-#endif
-
     /* H(x) = hash */
     md = ossl_prov_digest_md(&ctx->digest);
     if (md == NULL) {
@@ -634,6 +624,13 @@ static int sskdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     if (!sskdf_common_set_ctx_params(ctx, params))
         return 0;
 
+#ifdef FIPS_MODULE
+    if ((OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_KEY) != NULL) ||
+        (OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_SECRET) != NULL))
+        if (!fips_sskdf_key_check_passed(ctx))
+            return 0;
+#endif
+
     return 1;
 }
 
@@ -714,6 +711,11 @@ static int x963kdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
         if (!fips_x963kdf_digest_check_passed(ctx, md))
             return 0;
     }
+
+    if ((OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_KEY) != NULL) ||
+        (OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_SECRET) != NULL))
+        if (!fips_x963kdf_key_check_passed(ctx))
+            return 0;
 #endif
 
     return 1;

--- a/providers/implementations/kdfs/tls1_prf.c
+++ b/providers/implementations/kdfs/tls1_prf.c
@@ -274,8 +274,6 @@ static int kdf_tls1_prf_derive(void *vctx, unsigned char *key, size_t keylen,
 #ifdef FIPS_MODULE
     if (!fips_ems_check_passed(ctx))
         return 0;
-    if (!fips_key_check_passed(ctx))
-        return 0;
 #endif
 
     return tls1_prf_alg(ctx->P_hash, ctx->P_sha1,
@@ -349,6 +347,11 @@ static int kdf_tls1_prf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
         ctx->sec = NULL;
         if (!OSSL_PARAM_get_octet_string(p, (void **)&ctx->sec, 0, &ctx->seclen))
             return 0;
+
+#ifdef FIPS_MODULE
+        if (!fips_key_check_passed(ctx))
+            return 0;
+#endif
     }
     /* The seed fields concatenate, so process them all */
     if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_SEED)) != NULL) {

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -3691,6 +3691,7 @@ static int pkey_kdf_test_parse(EVP_TEST *t,
 
 static int pkey_kdf_test_run(EVP_TEST *t)
 {
+    int ret = 1;
     PKEY_KDF_DATA *expected = t->data;
     unsigned char *got = NULL;
     size_t got_len = 0;
@@ -3724,6 +3725,10 @@ static int pkey_kdf_test_run(EVP_TEST *t)
         t->err = "KDF_DERIVE_ERROR";
         goto err;
     }
+    if (!pkey_check_fips_approved(expected->ctx, t)) {
+        ret = 0;
+        goto err;
+    }
     if (!TEST_mem_eq(expected->output, expected->output_len, got, got_len)) {
         t->err = "KDF_MISMATCH";
         goto err;
@@ -3732,7 +3737,7 @@ static int pkey_kdf_test_run(EVP_TEST *t)
 
  err:
     OPENSSL_free(got);
-    return 1;
+    return ret;
 }
 
 static const EVP_TEST_METHOD pkey_kdf_test_method = {

--- a/test/recipes/30-test_evp_data/evpkdf_hkdf.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_hkdf.txt
@@ -77,6 +77,7 @@ Ctrl.IKM = hexkey:19ef24a32c717b167f33a91d6f648bdf96596776afdb6377ac434c1c293ccb
 Ctrl.info = info:
 Output = 8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8
 
+Availablein = default
 KDF = HKDF
 Ctrl.digest = digest:SHA1
 Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b
@@ -84,6 +85,7 @@ Ctrl.salt = hexsalt:000102030405060708090a0b0c
 Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
 Output = 085a01ea1b10f36933068b56efa5ad81a4f14b822f5b091568a9cdd4f155fda2c22e422478d305f3f896
 
+Availablein = default
 KDF = HKDF
 Ctrl.mode = mode:EXTRACT_ONLY
 Ctrl.digest = digest:SHA1

--- a/test/recipes/30-test_evp_data/evpkdf_hkdf.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_hkdf.txt
@@ -232,3 +232,26 @@ Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 Ctrl.salt = hexsalt:000102030405060708090a0b0c
 Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
 Result = KDF_CTRL_ERROR
+
+Title = FIPS indicator tests
+
+# Test that the key whose length is shorter than 112 bits is rejected
+FIPSversion = >=3.4.0
+KDF = HKDF
+Ctrl.digest = digest:SHA1
+Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b
+Ctrl.salt = hexsalt:000102030405060708090a0b0c
+Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
+Result = KDF_DERIVE_ERROR
+
+# Test that the key whose length is shorter than 112 bits is reported as
+# unapproved
+FIPSversion = >=3.4.0
+KDF = HKDF
+Unapproved = 1
+Ctrl.key-check = key-check:0
+Ctrl.digest = digest:SHA1
+Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b
+Ctrl.salt = hexsalt:000102030405060708090a0b0c
+Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
+Output = 085a01ea1b10f36933068b56efa5ad81a4f14b822f5b091568a9cdd4f155fda2c22e422478d305f3f896

--- a/test/recipes/30-test_evp_data/evpkdf_hkdf.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_hkdf.txt
@@ -242,7 +242,7 @@ Ctrl.digest = digest:SHA1
 Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b
 Ctrl.salt = hexsalt:000102030405060708090a0b0c
 Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
-Result = KDF_DERIVE_ERROR
+Result = KDF_CTRL_ERROR
 
 # Test that the key whose length is shorter than 112 bits is reported as
 # unapproved

--- a/test/recipes/30-test_evp_data/evpkdf_ss.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_ss.txt
@@ -280,36 +280,42 @@ Ctrl.hexsecret = hexsecret:ebe28edbae5a410b87a479243db3f690
 Ctrl.hexinfo = hexinfo:e60dd8b28228ce5b9be74d3b
 Output = b4a23963e07f485382cb358a493daec1759ac7043dbeac37152c6ddf105031f0f239f270b7f30616166f10e5d2b4cb11ba8bf4ba3f2276885abfbc3e811a568d480d9192
 
+Availablein = default
 KDF = SSKDF
 Ctrl.digest = digest:SHA1
 Ctrl.hexsecret = hexsecret:d7e6
 Ctrl.hexinfo = hexinfo:0bbe1fa8722023d7c3da4fff
 Output = 31e798e9931b612a3ad1b9b1008faa8c
 
+Availablein = default
 KDF = SSKDF
 Ctrl.digest = digest:SHA1
 Ctrl.hexsecret = hexsecret:4646779d
 Ctrl.hexinfo = hexinfo:0bbe1fa8722023d7c3da4fff
 Output = 139f68bcca879b490e268e569087d04d
 
+Availablein = default
 KDF = SSKDF
 Ctrl.digest = digest:SHA1
 Ctrl.hexsecret = hexsecret:d9811c81d4c6
 Ctrl.hexinfo = hexinfo:0bbe1fa8722023d7c3da4fff
 Output = 914dc4f09cb633a76e6c389e04c64485
 
+Availablein = default
 KDF = SSKDF
 Ctrl.digest = digest:SHA1
 Ctrl.hexsecret = hexsecret:8838f9d99ec46f09
 Ctrl.hexinfo = hexinfo:0bbe1fa8722023d7c3da4fff
 Output = 4f07dfb6f7a5bf348689e08b2e29c948
 
+Availablein = default
 KDF = SSKDF
 Ctrl.digest = digest:SHA1
 Ctrl.hexsecret = hexsecret:3e0939b33f34e779f30e
 Ctrl.hexinfo = hexinfo:0bbe1fa8722023d7c3da4fff
 Output = b42c7a98c23be19d1187ff960e87557f
 
+Availablein = default
 KDF = SSKDF
 Ctrl.digest = digest:SHA1
 Ctrl.hexsecret = hexsecret:f36230cacca4d245d303058c
@@ -781,6 +787,7 @@ Ctrl.hexsalt = hexsalt:0ad52c9357c85e4781296a36ca72039c
 Ctrl.hexinfo = hexinfo:c67c389580128f18f6cf8592
 Output = be32e7d306d891028be088f213f9f947c50420d9b5a12ca69818dd9995dedd8e6137c7104d67f2ca90915dda0ab68af2f355b904f9eb0388b5b7fe193c9546d45849133d
 
+Availablein = default
 KDF = SSKDF
 Ctrl.mac = mac:HMAC
 Ctrl.digest = digest:SHA256
@@ -789,6 +796,7 @@ Ctrl.hexsalt = hexsalt:3638271ccd68a25dc24ecddd39ef3f89
 Ctrl.hexinfo = hexinfo:348a37a27ef1282f5f020dcc
 Output = 3f661ec46fcc1e110b88f33ee7dbc308
 
+Availablein = default
 KDF = SSKDF
 Ctrl.mac = mac:HMAC
 Ctrl.digest = digest:SHA256
@@ -797,6 +805,7 @@ Ctrl.hexsalt = hexsalt:3638271ccd68a25dc24ecddd39ef3f89
 Ctrl.hexinfo = hexinfo:348a37a27ef1282f5f020dcc
 Output = 73ccb357554ca44967d507518262e38d
 
+Availablein = default
 KDF = SSKDF
 Ctrl.mac = mac:HMAC
 Ctrl.digest = digest:SHA256
@@ -805,6 +814,7 @@ Ctrl.hexsalt = hexsalt:3638271ccd68a25dc24ecddd39ef3f89
 Ctrl.hexinfo = hexinfo:348a37a27ef1282f5f020dcc
 Output = c4f1cf190980b6777bb35107654b25f9
 
+Availablein = default
 KDF = SSKDF
 Ctrl.mac = mac:HMAC
 Ctrl.digest = digest:SHA256
@@ -813,6 +823,7 @@ Ctrl.hexsalt = hexsalt:3638271ccd68a25dc24ecddd39ef3f89
 Ctrl.hexinfo = hexinfo:348a37a27ef1282f5f020dcc
 Output = ddb2d7475d00cc65bff6904b4f0b54ba
 
+Availablein = default
 KDF = SSKDF
 Ctrl.mac = mac:HMAC
 Ctrl.digest = digest:SHA256
@@ -821,6 +832,7 @@ Ctrl.hexsalt = hexsalt:3638271ccd68a25dc24ecddd39ef3f89
 Ctrl.hexinfo = hexinfo:348a37a27ef1282f5f020dcc
 Output = 1100a6049ae9d8be01ab3829754cecc2
 
+Availablein = default
 KDF = SSKDF
 Ctrl.mac = mac:HMAC
 Ctrl.digest = digest:SHA256

--- a/test/recipes/30-test_evp_data/evpkdf_ss.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_ss.txt
@@ -1151,3 +1151,24 @@ Ctrl.digest = digest:SHAKE-256
 Ctrl.hexsecret = hexsecret:d09a6b1a472f930db4f5e6b967900744
 Ctrl.hexinfo = hexinfo:b117255ab5f1b6b96fc434b0
 Result = KDF_CTRL_ERROR
+
+Title = FIPS indicator tests
+
+# Test that the key whose length is shorter than 112 bits is rejected
+FIPSversion = >=3.4.0
+KDF = SSKDF
+Ctrl.digest = digest:SHA1
+Ctrl.hexsecret = hexsecret:d7e6
+Ctrl.hexinfo = hexinfo:0bbe1fa8722023d7c3da4fff
+Result = KDF_DERIVE_ERROR
+
+# Test that the key whose length is shorter than 112 bits is reported as
+# unapproved
+FIPSversion = >=3.4.0
+KDF = SSKDF
+Unapproved = 1
+Ctrl.key-check = key-check:0
+Ctrl.digest = digest:SHA1
+Ctrl.hexsecret = hexsecret:d7e6
+Ctrl.hexinfo = hexinfo:0bbe1fa8722023d7c3da4fff
+Output = 31e798e9931b612a3ad1b9b1008faa8c

--- a/test/recipes/30-test_evp_data/evpkdf_ss.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_ss.txt
@@ -1160,7 +1160,7 @@ KDF = SSKDF
 Ctrl.digest = digest:SHA1
 Ctrl.hexsecret = hexsecret:d7e6
 Ctrl.hexinfo = hexinfo:0bbe1fa8722023d7c3da4fff
-Result = KDF_DERIVE_ERROR
+Result = KDF_CTRL_ERROR
 
 # Test that the key whose length is shorter than 112 bits is reported as
 # unapproved

--- a/test/recipes/30-test_evp_data/evpkdf_ssh.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_ssh.txt
@@ -4910,3 +4910,26 @@ Ctrl.hexxcghash = hexxcghash:a4ebd45934f56792b5112dcd75a1075fdc889245
 Ctrl.hexsession_id = hexsession_id:a4ebd45934f56792b5112dcd75a1075fdc889245
 Ctrl.type = type:A
 Output = d37ea221cbcc026d95e8c10b7d28a1b41e4ec1b497bae0e4cdbc1446e5bd59e2
+
+# Test that the key whose length is shorter than 112 bits is rejected
+FIPSversion = >=3.4.0
+KDF = SSHKDF
+Ctrl.digest = digest:SHA1
+Ctrl.hexkey = hexkey:0102030405060708090a0b
+Ctrl.hexxcghash = hexxcghash:a4ebd45934f56792b5112dcd75a1075fdc889245
+Ctrl.hexsession_id = hexsession_id:a4ebd45934f56792b5112dcd75a1075fdc889245
+Ctrl.type = type:A
+Result = KDF_DERIVE_ERROR
+
+# Test that the key whose length is shorter than 112 bits is reported as
+# unapproved
+FIPSversion = >=3.4.0
+KDF = SSHKDF
+Unapproved = 1
+Ctrl.key-check = key-check:0
+Ctrl.digest = digest:SHA1
+Ctrl.hexkey = hexkey:0102030405060708090a0b
+Ctrl.hexxcghash = hexxcghash:a4ebd45934f56792b5112dcd75a1075fdc889245
+Ctrl.hexsession_id = hexsession_id:a4ebd45934f56792b5112dcd75a1075fdc889245
+Ctrl.type = type:A
+Output = 825b46b410c8b6ea

--- a/test/recipes/30-test_evp_data/evpkdf_ssh.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_ssh.txt
@@ -4919,7 +4919,7 @@ Ctrl.hexkey = hexkey:0102030405060708090a0b
 Ctrl.hexxcghash = hexxcghash:a4ebd45934f56792b5112dcd75a1075fdc889245
 Ctrl.hexsession_id = hexsession_id:a4ebd45934f56792b5112dcd75a1075fdc889245
 Ctrl.type = type:A
-Result = KDF_DERIVE_ERROR
+Result = KDF_CTRL_ERROR
 
 # Test that the key whose length is shorter than 112 bits is reported as
 # unapproved

--- a/test/recipes/30-test_evp_data/evpkdf_tls12_prf.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_tls12_prf.txt
@@ -42,6 +42,7 @@ Ctrl.client_random = hexseed:62e1fd91f23f558a605f28478c58cf72637b89784d959df7e94
 Output = d06139889fffac1e3a71865f504aa5d0d2a2e89506c6f2279b670c3e1b74f531016a2530c51a3a0f7e1d6590d0f0566b2f387f8d11fd4f731cdd572d2eae927f6f2f81410b25e6960be68985add6c38445ad9f8c64bf8068bf9a6679485d966f1ad6f68b43495b10a683755ea2b858d70ccac7ec8b053c6bd41ca299d4e51928
 
 # Missing digest.
+Availablein = default
 KDF = TLS1-PRF
 Ctrl.Secret = hexsecret:01
 Ctrl.Seed = hexseed:02

--- a/test/recipes/30-test_evp_data/evpkdf_tls12_prf.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_tls12_prf.txt
@@ -105,3 +105,27 @@ Ctrl.label = seed:extended master secret
 Ctrl.client_random = hexseed:36c129d01a3200894b9179faac589d9835d58775f9b5ea3587cb8fd0364cae8c
 Ctrl.server_random = hexseed:f6c9575ed7ddd73e1f7d16eca115415812a43c2b747daaaae043abfb50053fce
 Output = 17be20a3b4cc05524d7de353b2f125537c23372144111b0367bda166fcfc09cf1c94909a408b986f53afbdc41d93ae09
+
+
+# Test that the key whose length is shorter than 112 bits is rejected
+FIPSversion = >=3.4.0
+KDF = TLS1-PRF
+Ctrl.digest = digest:SHA256
+Ctrl.Secret = hexsecret:0102030405060708090a0b
+Ctrl.label = seed:extended master secret
+Ctrl.client_random = hexseed:36c129d01a3200894b9179faac589d9835d58775f9b5ea3587cb8fd0364cae8c
+Ctrl.server_random = hexseed:f6c9575ed7ddd73e1f7d16eca115415812a43c2b747daaaae043abfb50053fce
+Result = KDF_DERIVE_ERROR
+
+# Test that the key whose length is shorter than 112 bits is reported as
+# unapproved
+FIPSversion = >=3.4.0
+KDF = TLS1-PRF
+Unapproved = 1
+Ctrl.key-check = key-check:0
+Ctrl.digest = digest:SHA256
+Ctrl.Secret = hexsecret:0102030405060708090a0b
+Ctrl.label = seed:extended master secret
+Ctrl.client_random = hexseed:36c129d01a3200894b9179faac589d9835d58775f9b5ea3587cb8fd0364cae8c
+Ctrl.server_random = hexseed:f6c9575ed7ddd73e1f7d16eca115415812a43c2b747daaaae043abfb50053fce
+Output = 8cb203c99a13871fd96cecd2770720df3c4ebd49e1cbc956fddb400f9c051fb69b63d7abb2f996f4e4d1ac0e9153f51b

--- a/test/recipes/30-test_evp_data/evpkdf_tls12_prf.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_tls12_prf.txt
@@ -115,7 +115,7 @@ Ctrl.Secret = hexsecret:0102030405060708090a0b
 Ctrl.label = seed:extended master secret
 Ctrl.client_random = hexseed:36c129d01a3200894b9179faac589d9835d58775f9b5ea3587cb8fd0364cae8c
 Ctrl.server_random = hexseed:f6c9575ed7ddd73e1f7d16eca115415812a43c2b747daaaae043abfb50053fce
-Result = KDF_DERIVE_ERROR
+Result = KDF_CTRL_ERROR
 
 # Test that the key whose length is shorter than 112 bits is reported as
 # unapproved

--- a/test/recipes/30-test_evp_data/evpkdf_tls13_kdf.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_tls13_kdf.txt
@@ -4971,3 +4971,44 @@ Ctrl.mode = mode:EXTRACT_ONLY
 Ctrl.digest = digest:SHA512-256
 Ctrl.key = hexkey:f8af6aea2d397baf2948a25b2834200692cff17eee9165e4e27babee9edefd05
 Output = c8240b43113bb8bd211ee97c5145d389e8074f76eeeaac74eb55691062a436e4
+
+# Test that the key whose length is shorter than 112 bits is rejected
+FIPSversion = >=3.4.0
+KDF = TLS13-KDF
+Ctrl.mode = mode:EXTRACT_ONLY
+Ctrl.digest = digest:SHA2-256
+Ctrl.key = hexkey:0102030405060708090a0b
+Result = KDF_DERIVE_ERROR
+
+FIPSversion = >=3.4.0
+KDF = TLS13-KDF
+Ctrl.mode = mode:EXPAND_ONLY
+Ctrl.digest = digest:SHA2-256
+Ctrl.key = hexkey:0102030405060708090a0b
+Ctrl.data = hexdata:7c92f68bd5bf3638ea338a6494722e1b44127e1b7e8aad535f2322a644ff22b3
+Ctrl.prefix = hexprefix:746c73313320
+Ctrl.label = hexlabel:6320652074726166666963
+Result = KDF_DERIVE_ERROR
+
+# Test that the key whose length is shorter than 112 bits is reported as
+# unapproved
+FIPSversion = >=3.4.0
+KDF = TLS13-KDF
+Unapproved = 1
+Ctrl.key-check = key-check:0
+Ctrl.mode = mode:EXTRACT_ONLY
+Ctrl.digest = digest:SHA2-256
+Ctrl.key = hexkey:0102030405060708090a0b
+Output = ac5ae06e0f6bff82f6256f0fc9fb943554752ba0c93f42ee6499b99c9e5c24a8
+
+FIPSversion = >=3.4.0
+KDF = TLS13-KDF
+Unapproved = 1
+Ctrl.key-check = key-check:0
+Ctrl.mode = mode:EXPAND_ONLY
+Ctrl.digest = digest:SHA2-256
+Ctrl.key = hexkey:0b0b0b0b0b0b0b0b0b0b0b
+Ctrl.data = hexdata:7c92f68bd5bf3638ea338a6494722e1b44127e1b7e8aad535f2322a644ff22b3
+Ctrl.prefix = hexprefix:746c73313320
+Ctrl.label = hexlabel:6320652074726166666963
+Output = a8464234c7957b85460bf7abda8e20aa43b9e0944c02d76c1c28672619cf6978

--- a/test/recipes/30-test_evp_data/evpkdf_tls13_kdf.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_tls13_kdf.txt
@@ -4978,7 +4978,7 @@ KDF = TLS13-KDF
 Ctrl.mode = mode:EXTRACT_ONLY
 Ctrl.digest = digest:SHA2-256
 Ctrl.key = hexkey:0102030405060708090a0b
-Result = KDF_DERIVE_ERROR
+Result = KDF_CTRL_ERROR
 
 FIPSversion = >=3.4.0
 KDF = TLS13-KDF
@@ -4988,7 +4988,7 @@ Ctrl.key = hexkey:0102030405060708090a0b
 Ctrl.data = hexdata:7c92f68bd5bf3638ea338a6494722e1b44127e1b7e8aad535f2322a644ff22b3
 Ctrl.prefix = hexprefix:746c73313320
 Ctrl.label = hexlabel:6320652074726166666963
-Result = KDF_DERIVE_ERROR
+Result = KDF_CTRL_ERROR
 
 # Test that the key whose length is shorter than 112 bits is reported as
 # unapproved

--- a/test/recipes/30-test_evp_data/evpkdf_x963.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_x963.txt
@@ -163,7 +163,7 @@ KDF = X963KDF
 Ctrl.digest = digest:SHA224
 Ctrl.hexsecret = hexsecret:0102030405060908090a0b
 Ctrl.hexinfo = hexinfo:0102030405060708090a0b0c0d0e0f10
-Result = KDF_DERIVE_ERROR
+Result = KDF_CTRL_ERROR
 
 # Test that the key whose length is shorter than 112 bits is reported as
 # unapproved

--- a/test/recipes/30-test_evp_data/evpkdf_x963.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_x963.txt
@@ -156,3 +156,22 @@ Ctrl.digest = digest:SHA1
 Ctrl.hexsecret = hexsecret:fd17198b89ab39c4ab5d7cca363b82f9fd7e23c3984dc8a2
 Ctrl.hexinfo = hexinfo:856a53f3e36a26bbc5792879f307cce2
 Output = 6e5fad865cb4a51c95209b16df0cc490bc2c9064405c5bccd4ee4832a531fbe7f10cb79e2eab6ab1149fbd5a23cfdabc41242269c9df22f628c4424333855b64e95e2d4fb8469c669f17176c07d103376b10b384ec5763d8b8c610409f19aca8eb31f9d85cc61a8d6d4a03d03e5a506b78d6847e93d295ee548c65afedd2efec
+
+# Test that the key whose length is shorter than 112 bits is rejected
+FIPSversion = >=3.4.0
+KDF = X963KDF
+Ctrl.digest = digest:SHA224
+Ctrl.hexsecret = hexsecret:0102030405060908090a0b
+Ctrl.hexinfo = hexinfo:0102030405060708090a0b0c0d0e0f10
+Result = KDF_DERIVE_ERROR
+
+# Test that the key whose length is shorter than 112 bits is reported as
+# unapproved
+FIPSversion = >=3.4.0
+KDF = X963KDF
+Unapproved = 1
+Ctrl.key-check = key-check:0
+Ctrl.digest = digest:SHA224
+Ctrl.hexsecret = hexsecret:0102030405060908090a0b
+Ctrl.hexinfo = hexinfo:0102030405060708090a0b0c0d0e0f10
+Output = cdbb95eaacfd7df6bee013777ad8cd39129db2b61be91d20bb4a0130deccbd265e1f81c5a7112a7ac463204bd354b47eea04b63404ed4a1d8a991d3c9e17ab22c6f8a23686f3fea364a1a2b22cb6210e99ec0ed24f27779f028f68239f12fc572b23694d4dc6063f602b4496cec6f2698f69b24bbffba7127d8a1c9a49c96a83

--- a/test/recipes/30-test_evp_data/evppkey_kdf_hkdf.txt
+++ b/test/recipes/30-test_evp_data/evppkey_kdf_hkdf.txt
@@ -77,6 +77,7 @@ Ctrl.IKM = hexkey:19ef24a32c717b167f33a91d6f648bdf96596776afdb6377ac434c1c293ccb
 Ctrl.info = info:
 Output = 8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8
 
+Availablein = default
 PKEYKDF = HKDF
 Ctrl.md = md:SHA1
 Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b
@@ -84,6 +85,7 @@ Ctrl.salt = hexsalt:000102030405060708090a0b0c
 Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
 Output = 085a01ea1b10f36933068b56efa5ad81a4f14b822f5b091568a9cdd4f155fda2c22e422478d305f3f896
 
+Availablein = default
 PKEYKDF = HKDF
 Ctrl.mode = mode:EXTRACT_ONLY
 Ctrl.md = md:SHA1

--- a/test/recipes/30-test_evp_data/evppkey_kdf_hkdf.txt
+++ b/test/recipes/30-test_evp_data/evppkey_kdf_hkdf.txt
@@ -204,3 +204,26 @@ Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 Ctrl.salt = hexsalt:000102030405060708090a0b0c
 Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
 Result = PKEY_CTRL_ERROR
+
+Title = FIPS indicator tests
+
+# Test that the key whose length is shorter than 112 bits is rejected
+FIPSversion = >=3.4.0
+PKEYKDF = HKDF
+Ctrl.digest = digest:SHA1
+Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b
+Ctrl.salt = hexsalt:000102030405060708090a0b0c
+Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
+Result = KDF_DERIVE_ERROR
+
+# Test that the key whose length is shorter than 112 bits is reported as
+# unapproved
+FIPSversion = >=3.4.0
+PKEYKDF = HKDF
+Unapproved = 1
+Ctrl.key-check = key-check:0
+Ctrl.digest = digest:SHA1
+Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b
+Ctrl.salt = hexsalt:000102030405060708090a0b0c
+Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
+Output = 085a01ea1b10f36933068b56efa5ad81a4f14b822f5b091568a9cdd4f155fda2c22e422478d305f3f896

--- a/test/recipes/30-test_evp_data/evppkey_kdf_hkdf.txt
+++ b/test/recipes/30-test_evp_data/evppkey_kdf_hkdf.txt
@@ -214,7 +214,7 @@ Ctrl.digest = digest:SHA1
 Ctrl.IKM = hexkey:0b0b0b0b0b0b0b0b0b0b0b
 Ctrl.salt = hexsalt:000102030405060708090a0b0c
 Ctrl.info = hexinfo:f0f1f2f3f4f5f6f7f8f9
-Result = KDF_DERIVE_ERROR
+Result = PKEY_CTRL_ERROR
 
 # Test that the key whose length is shorter than 112 bits is reported as
 # unapproved

--- a/test/recipes/30-test_evp_data/evppkey_kdf_tls1_prf.txt
+++ b/test/recipes/30-test_evp_data/evppkey_kdf_tls1_prf.txt
@@ -103,3 +103,26 @@ Ctrl.label = seed:extended master secret
 Ctrl.client_random = hexseed:36c129d01a3200894b9179faac589d9835d58775f9b5ea3587cb8fd0364cae8c
 Ctrl.server_random = hexseed:f6c9575ed7ddd73e1f7d16eca115415812a43c2b747daaaae043abfb50053fce
 Output = 17be20a3b4cc05524d7de353b2f125537c23372144111b0367bda166fcfc09cf1c94909a408b986f53afbdc41d93ae09
+
+# Test that the key whose length is shorter than 112 bits is rejected
+FIPSversion = >=3.4.0
+PKEYKDF = TLS1-PRF
+Ctrl.digest = digest:SHA256
+Ctrl.Secret = hexsecret:0102030405060708090a0b
+Ctrl.label = seed:extended master secret
+Ctrl.client_random = hexseed:36c129d01a3200894b9179faac589d9835d58775f9b5ea3587cb8fd0364cae8c
+Ctrl.server_random = hexseed:f6c9575ed7ddd73e1f7d16eca115415812a43c2b747daaaae043abfb50053fce
+Result = KDF_DERIVE_ERROR
+
+# Test that the key whose length is shorter than 112 bits is reported as
+# unapproved
+FIPSversion = >=3.4.0
+PKEYKDF = TLS1-PRF
+Unapproved = 1
+Ctrl.key-check = key-check:0
+Ctrl.digest = digest:SHA256
+Ctrl.Secret = hexsecret:0102030405060708090a0b
+Ctrl.label = seed:extended master secret
+Ctrl.client_random = hexseed:36c129d01a3200894b9179faac589d9835d58775f9b5ea3587cb8fd0364cae8c
+Ctrl.server_random = hexseed:f6c9575ed7ddd73e1f7d16eca115415812a43c2b747daaaae043abfb50053fce
+Output = 8cb203c99a13871fd96cecd2770720df3c4ebd49e1cbc956fddb400f9c051fb69b63d7abb2f996f4e4d1ac0e9153f51b

--- a/test/recipes/30-test_evp_data/evppkey_kdf_tls1_prf.txt
+++ b/test/recipes/30-test_evp_data/evppkey_kdf_tls1_prf.txt
@@ -112,7 +112,7 @@ Ctrl.Secret = hexsecret:0102030405060708090a0b
 Ctrl.label = seed:extended master secret
 Ctrl.client_random = hexseed:36c129d01a3200894b9179faac589d9835d58775f9b5ea3587cb8fd0364cae8c
 Ctrl.server_random = hexseed:f6c9575ed7ddd73e1f7d16eca115415812a43c2b747daaaae043abfb50053fce
-Result = KDF_DERIVE_ERROR
+Result = KDF_CTRL_ERROR
 
 # Test that the key whose length is shorter than 112 bits is reported as
 # unapproved

--- a/util/mk-fipsmodule-cnf.pl
+++ b/util/mk-fipsmodule-cnf.pl
@@ -19,6 +19,7 @@ my $kdf_digest_check = 1;
 my $dsa_sign_disabled = 1;
 my $tdes_encrypt_disabled = 1;
 my $rsa_sign_x931_pad_disabled = 1;
+my $kdf_key_check = 1;
 
 my $activate = 1;
 my $version = 1;
@@ -65,4 +66,10 @@ sskdf-digest-check = $kdf_digest_check
 x963kdf-digest-check = $kdf_digest_check
 tdes-encrypt-disabled = $tdes_encrypt_disabled
 rsa-sign-x931-pad-disabled = $rsa_sign_x931_pad_disabled
+hkdf-key-check = $kdf_key_check
+tls13-kdf-key-check = $kdf_key_check
+tls1-prf-key-check = $kdf_key_check
+sshkdf-key-check = $kdf_key_check
+sskdf-key-check = $kdf_key_check
+x963kdf-key-check = $kdf_key_check
 _____

--- a/util/perl/OpenSSL/paramnames.pm
+++ b/util/perl/OpenSSL/paramnames.pm
@@ -43,6 +43,12 @@ my %params = (
     'PROV_PARAM_DSA_SIGN_DISABLED' =>      "dsa-sign-disabled",      # uint
     'PROV_PARAM_TDES_ENCRYPT_DISABLED' =>  "tdes-encrypt-disabled",  # uint
     'PROV_PARAM_RSA_SIGN_X931_PAD_DISABLED' =>  "rsa-sign-x931-pad-disabled",   # uint
+    'PROV_PARAM_HKDF_KEY_CHECK' =>         "hkdf-key-check",         # uint
+    'PROV_PARAM_TLS13_KDF_KEY_CHECK' =>    "tls13-kdf-key-check",    # uint
+    'PROV_PARAM_TLS1_PRF_KEY_CHECK' =>     "tls1-prf-key-check",     # uint
+    'PROV_PARAM_SSHKDF_KEY_CHECK' =>       "sshkdf-key-check",       # uint
+    'PROV_PARAM_SSKDF_KEY_CHECK' =>        "sskdf-key-check",        # uint
+    'PROV_PARAM_X963KDF_KEY_CHECK' =>      "x963kdf-key-check",      # uint
 
 # Self test callback parameters
     'PROV_PARAM_SELF_TEST_PHASE' =>  "st-phase",# utf8_string
@@ -207,6 +213,7 @@ my %params = (
     'KDF_PARAM_ARGON2_VERSION' => "version",                # uint32_t
     'KDF_PARAM_FIPS_EMS_CHECK' => "ems_check",              # int
     'KDF_PARAM_FIPS_DIGEST_CHECK' => '*PKEY_PARAM_FIPS_DIGEST_CHECK',
+    'KDF_PARAM_FIPS_KEY_CHECK' => '*PKEY_PARAM_FIPS_KEY_CHECK',
     'KDF_PARAM_FIPS_APPROVED_INDICATOR' => '*ALG_PARAM_FIPS_APPROVED_INDICATOR',
 
 # Known RAND names


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

According to SP 800-131Ar2, the length of the key-derivation key shall be at least 112 bits.

Use new indicator framework to implement indicators about the length of the key-derivation key used in KDFs.

In this PR, the indicators for the following KDFs are implemented:

* HKDF
* SSKDF
* X963KDF
* SSHKDF
* TLS1_PRF
* TLS13_KDF

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
