### PR TITLE
Fixing memory leak in openssl/test/v3ext

### DIFF
--- a/test/v3ext.c
+++ b/test/v3ext.c
@@ -307,6 +307,7 @@ static int test_addr_fam_len(void)
     testresult = 1;
   end:
     sk_IPAddressFamily_pop_free(addr, IPAddressFamily_free);
+    IPAddressFamily_free(f1);
     ASN1_OCTET_STRING_free(ip1);
     ASN1_OCTET_STRING_free(ip2);
     return testresult;


### PR DESCRIPTION
At line 233 in the file openssl/test/v3ext.c, a pointer named f1 is defined. This pointer allocates a dynamic memory region at line 262 through the function IPAddressFamily_new. When the if statement at line 262 returns false, it indicates successful allocation of dynamic memory for f1. Subsequently, at line 265, the program allocates a dynamic memory region for the ipAddressChoice member of pointer f1 through the function IPAddressChoice_new. If the if statement at line 265 returns true, the program will jump to the end label at line 308 from line 266, thereby bypassing the IPAddressFamily_free(f1) operation at line 281. The end label does not release the dynamic memory region pointed to by f1, thus constituting a memory leak defect. The diagram below illustrates the detailed path of the defect:https://github.com/LuMingYinDetect/openssl_defects/blob/main/openssl_2.png

Fixes #23897

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
