### PR TITLE
Fixed a typo and grammar in openssl-ts.pod

### DIFF
--- a/doc/man1/openssl-ts.pod.in
+++ b/doc/man1/openssl-ts.pod.in
@@ -163,9 +163,9 @@ use its own default policy. (Optional)
 =item B<-no_nonce>
 
 No nonce is specified in the request if this option is
-given. Otherwise a 64 bit long pseudo-random none is
-included in the request. It is recommended to use nonce to
-protect against replay-attacks. (Optional)
+given. Otherwise, a 64-bit long pseudo-random nonce is
+included in the request. It is recommended to use a nonce to
+protect against replay attacks. (Optional)
 
 =item B<-cert>
 


### PR DESCRIPTION
CLA: trivial

- [x] documentation is added or updated
