### PR TITLE
doc: clarify SSL_CIPHER_description allocation

### DIFF
--- a/doc/man3/SSL_CIPHER_get_name.pod
+++ b/doc/man3/SSL_CIPHER_get_name.pod
@@ -109,7 +109,7 @@ cipher B<c>.
 
 SSL_CIPHER_description() returns a textual description of the cipher used
 into the buffer B<buf> of length B<len> provided.  If B<buf> is provided, it
-must be at least 128 bytes, otherwise a buffer will be allocated using
+must be at least 128 bytes. If B<buf> is NULL it will be allocated using
 OPENSSL_malloc().  If the provided buffer is too small, or the allocation fails,
 B<NULL> is returned.
 


### PR DESCRIPTION
Previously the documentation for `SSL_CIPHER_description` said:
> If buf is provided, it must be at least 128 bytes, otherwise a buffer will be allocated using OPENSSL_malloc().

[In reality](https://github.com/openssl/openssl/blob/dc9bc6c8e1bd329ead703417a2235ab3e97557ec/ssl/ssl_ciph.c#L1713-L1719), `OPENSSL_malloc` is only invoked if the provided `buf` argument is `NULL`. If the `buf` arg is not `NULL`, but smaller than 128 bytes, the function returns `NULL` without attempting to allocate a new buffer for the description.

This commit adjusts the documentation to better describe the implemented behaviour.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
- [X] documentation is added or updated
