### PR TITLE
Replace unsigned with int

### DIFF
--- a/demos/digest/EVP_MD_demo.c
+++ b/demos/digest/EVP_MD_demo.c
@@ -83,7 +83,7 @@ int demonstrate_digest(void)
     const char *option_properties = NULL;
     EVP_MD *message_digest = NULL;
     EVP_MD_CTX *digest_context = NULL;
-    unsigned int digest_length;
+    int digest_length;
     unsigned char *digest_value = NULL;
     int j;
 

--- a/demos/digest/EVP_MD_stdin.c
+++ b/demos/digest/EVP_MD_stdin.c
@@ -38,7 +38,7 @@ int demonstrate_digest(BIO *input)
     const char *option_properties = NULL;
     EVP_MD *message_digest = NULL;
     EVP_MD_CTX *digest_context = NULL;
-    unsigned int digest_length;
+    int digest_length;
     unsigned char *digest_value = NULL;
     unsigned char buffer[512];
     int ii;


### PR DESCRIPTION
Replace the type of "digest_length" with int to avoid implicit conversion when it is assigned by EVP_MD_get_size(). Otherwise, it may pass the following check and cause the integer overflow error when EVP_MD_get_size() returns negative numbers.

Fixes: 29ce1066bc ("Update the demos/README file because it is really old. New demos should provide best practice for API use. Add demonstration for computing a SHA3-512 digest - digest/EVP_MD_demo")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
