### PR TITLE
Replace size_t with int and add the check for the EVP_MD_get_size()

### DIFF
--- a/demos/digest/BIO_f_md.c
+++ b/demos/digest/BIO_f_md.c
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
     BIO *bio_digest = NULL, *reading = NULL;
     EVP_MD *md = NULL;
     unsigned char buffer[512];
-    size_t digest_size;
+    int digest_size;
     char *digest_value = NULL;
     int j;
 
@@ -68,6 +68,11 @@ int main(int argc, char *argv[])
         goto cleanup;
     }
     digest_size = EVP_MD_get_size(md);
+    if (digest_size <= 0) {
+        fprintf(stderr, "EVP_MD_get_size returned invalid size.\n");
+        goto cleanup;
+    }
+
     digest_value = OPENSSL_malloc(digest_size);
     if (digest_value == NULL) {
         fprintf(stderr, "Can't allocate %lu bytes for the digest value.\n", (unsigned long)digest_size);


### PR DESCRIPTION
Replace the type of "digest_size" with int to avoid implicit conversion when it is assigned by EVP_MD_get_size(). Moreover, add the check for the "digest_size".

Fixes: 29ce1066bc ("Update the demos/README file because it is really old. New demos should provide best practice for API use. Add demonstration for computing a SHA3-512 digest - digest/EVP_MD_demo")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
