### PR TITLE
[WIP]Adjust threadstest to support Nonstop

### DIFF
--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -126,13 +126,11 @@ static CRYPTO_RWLOCK *rwtorturelock = NULL;
  *  side is designed to never block
  */
 # if defined(__TANDEM)
-# define WRITER_SLEEP 999
 # define TAKE_READ_SIDE_LOCK(x) CRYPTO_THREAD_write_lock(x)
 # define TAKE_WRITE_SIDE_LOCK(x) CRYPTO_THREAD_write_lock(x)
 # define DROP_LOCK(x) CRYPTO_THREAD_unlock(x)
 # define NONSTOP_YIELD() sched_yield()
 #else
-# define WRITER_SLEEP 1000
 # define TAKE_READ_SIDE_LOCK(x) CRYPTO_THREAD_read_lock(x)
 # define TAKE_WRITE_SIDE_LOCK(x) CRYPTO_THREAD_write_lock(x)
 # define DROP_LOCK(x) CRYPTO_THREAD_unlock(x)
@@ -149,7 +147,7 @@ static void rwwriter_fn(int id, int *iterations)
     for (count = 0; ; count++) {
         new = CRYPTO_zalloc(sizeof (int), NULL, 0);
         if (contention == 0)
-            OSSL_sleep(WRITER_SLEEP);
+            OSSL_sleep(1000);
         if (!TAKE_WRITE_SIDE_LOCK(rwtorturelock))
             abort();
         if (rwwriter_ptr != NULL) {
@@ -336,7 +334,7 @@ static void writer_fn(int id, int *iterations)
     for (count = 0; ; count++) {
         new = CRYPTO_zalloc(sizeof(int), NULL, 0);
         if (contention == 0)
-            OSSL_sleep(WRITER_SLEEP);
+            OSSL_sleep(1000);
         ossl_rcu_write_lock(rcu_lock);
         old = ossl_rcu_deref(&writer_ptr);
         TSAN_ACQUIRE(&writer_ptr);


### PR DESCRIPTION
The nonstop cooperative threading model requires some adjustments to the new threadstest tests:

1) The use of OSSL_sleep in the rwtorture and rcutorture tests
   encounters an error when specifying times of 1000ms or larger, limit
   that on nonstop to 999ms instead

2) The use of rwlocks in the tests is bad.  Because Nonstop appears to
   not consider pthread_rwlock_rdlock to be a yield point, deadlocks can
   occur when a reader thread acquires the cpu, as it will never yield.
   For Nonstop use write locks in the tests exclusively to create thread
   rescheduling events

3) For RCU, the read side by design never has to block, creating a
   simmilar problem to (2).  Insert an explicit yeild for Nonstop
   to force thread scheduling

##### Checklist
- [x] tests are added or updated
