### PR TITLE
Correct OSSL_sleep to support larger times for NonStop PUT model by introducing sleep().

### DIFF
--- a/crypto/sleep.c
+++ b/crypto/sleep.c
@@ -22,20 +22,11 @@ void OSSL_sleep(uint64_t millis)
     ts.tv_sec = (long int) (millis / 1000);
     ts.tv_nsec = (long int) (millis % 1000) * 1000000ul;
     nanosleep(&ts, NULL);
-# elif defined(__TANDEM)
-#  if !defined(_REENTRANT)
+# elif defined(__TANDEM) && !defined(_REENTRANT)
 #   include <cextdecs.h(PROCESS_DELAY_)>
 
     /* HPNS does not support usleep for non threaded apps */
     PROCESS_DELAY_(millis * 1000);
-#  elif defined(_SPT_MODEL_)
-#   include <spthread.h>
-#   include <spt_extensions.h>
-
-    usleep(millis * 1000);
-#  else
-    usleep(millis * 1000);
-#  endif
 # else
     unsigned int s = (unsigned int)(millis / 1000);
     unsigned int us = (unsigned int)((millis % 1000) * 1000);


### PR DESCRIPTION
This fix also removes SPT model support as it was previously deprecated. Upcoming threading models on the platform should be supportable without change to this method.

Fixes: #23923
Fixes: #23927
Fixes: #23928
