### PR TITLE
ssl/ssl_ciph.c: Replace size_t with int and add the checks

### DIFF
--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -2208,9 +2208,8 @@ int ssl_cipher_get_overhead(const SSL_CIPHER *c, size_t *mac_overhead,
             return 0;
 
         mac = EVP_MD_get_size(e_md);
-        if (mac <= 0) {
+        if (mac <= 0)
             return 0;
-        }
         if (c->algorithm_enc != SSL_eNULL) {
             int cipher_nid = SSL_CIPHER_get_cipher_nid(c);
             const EVP_CIPHER *e_ciph = EVP_get_cipherbynid(cipher_nid);
@@ -2223,9 +2222,8 @@ int ssl_cipher_get_overhead(const SSL_CIPHER *c, size_t *mac_overhead,
 
             in = 1; /* padding length byte */
             out = EVP_CIPHER_get_iv_length(e_ciph);
-            if (out < 0) {
+            if (out < 0)
                 return 0;
-            }
             blk = EVP_CIPHER_get_block_size(e_ciph);
             if (blk <= 0)
                 return 0;

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -2208,7 +2208,7 @@ int ssl_cipher_get_overhead(const SSL_CIPHER *c, size_t *mac_overhead,
             return 0;
 
         mac = EVP_MD_get_size(e_md);
-        if (mac < 0) {
+        if (mac <= 0) {
             return 0;
         }
         if (c->algorithm_enc != SSL_eNULL) {
@@ -2232,10 +2232,10 @@ int ssl_cipher_get_overhead(const SSL_CIPHER *c, size_t *mac_overhead,
         }
     }
 
-    *mac_overhead = mac;
-    *int_overhead = in;
-    *blocksize = blk;
-    *ext_overhead = out;
+    *mac_overhead = (size_t)mac;
+    *int_overhead = (size_t)in;
+    *blocksize = (size_t)blk;
+    *ext_overhead = (size_t)out;
 
     return 1;
 }

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -2184,7 +2184,7 @@ int ssl_cipher_get_overhead(const SSL_CIPHER *c, size_t *mac_overhead,
                             size_t *int_overhead, size_t *blocksize,
                             size_t *ext_overhead)
 {
-    size_t mac = 0, in = 0, blk = 0, out = 0;
+    int mac = 0, in = 0, blk = 0, out = 0;
 
     /* Some hard-coded numbers for the CCM/Poly1305 MAC overhead
      * because there are no handy #defines for those. */
@@ -2208,6 +2208,9 @@ int ssl_cipher_get_overhead(const SSL_CIPHER *c, size_t *mac_overhead,
             return 0;
 
         mac = EVP_MD_get_size(e_md);
+        if (mac < 0) {
+            return 0;
+        }
         if (c->algorithm_enc != SSL_eNULL) {
             int cipher_nid = SSL_CIPHER_get_cipher_nid(c);
             const EVP_CIPHER *e_ciph = EVP_get_cipherbynid(cipher_nid);
@@ -2220,8 +2223,11 @@ int ssl_cipher_get_overhead(const SSL_CIPHER *c, size_t *mac_overhead,
 
             in = 1; /* padding length byte */
             out = EVP_CIPHER_get_iv_length(e_ciph);
+            if (out < 0) {
+                return 0;
+            }
             blk = EVP_CIPHER_get_block_size(e_ciph);
-            if (blk == 0)
+            if (blk <= 0)
                 return 0;
         }
     }


### PR DESCRIPTION
Replace the type of "mac", "out", and "blk" with int to avoid implicit conversion when it is assigned by EVP_MD_get_size(), EVP_CIPHER_get_iv_length(), and EVP_CIPHER_get_block_size(). Moreover, add the checks to avoid integer overflow.

Fixes: 045bd04706 ("Add DTLS_get_data_mtu() function")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
