### PR TITLE
fix demos/sslecho/main.c so it builds on OpenBSD too

### DIFF
--- a/demos/sslecho/main.c
+++ b/demos/sslecho/main.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <signal.h>


### PR DESCRIPTION
trying to build `demos/sslecho/main.c` shipped by current openssl fails with error as follows:
```
cc -I../../include -g -Wall   -c -o main.o main.c
main.c:35:24: error: variable has incomplete type 'struct sockaddr_in'
    struct sockaddr_in addr;
                       ^
main.c:35:12: note: forward declaration of 'struct sockaddr_in'
    struct sockaddr_in addr;
           ^
main.c:46:32: error: use of undeclared identifier 'INADDR_ANY'
        addr.sin_addr.s_addr = INADDR_ANY;
                               ^
main.c:152:24: error: variable has incomplete type 'struct sockaddr_in'
    struct sockaddr_in addr;
                       ^
main.c:152:12: note: forward declaration of 'struct sockaddr_in'
    struct sockaddr_in addr;
           ^
3 errors generated.
gmake: *** [<builtin>: main.o] Error 1
```

including `netinet/in.h` fixes the build

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
