### PR TITLE
signature/dsa_sig.c: Add checks for the EVP_MD_get_size()

### DIFF
--- a/providers/implementations/signature/dsa_sig.c
+++ b/providers/implementations/signature/dsa_sig.c
@@ -93,8 +93,14 @@ typedef struct {
 
 static size_t dsa_get_md_size(const PROV_DSA_CTX *pdsactx)
 {
-    if (pdsactx->md != NULL)
-        return EVP_MD_get_size(pdsactx->md);
+    int md_size;
+
+    if (pdsactx->md != NULL) {
+        md_size = EVP_MD_get_size(pdsactx->md);
+        if (md_size <= 0)
+            return 0;
+        return (size_t)md_size;
+    }
     return 0;
 }
 


### PR DESCRIPTION
Add checks for the EVP_MD_get_size() to avoid integer overflow and then explicitly cast from int to size_t.

Fixes: 45a845e40b ("Add EVP_DigestSign/EVP_DigestVerify support for DSA")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
