### PR TITLE
kdfs/hmacdrbg_kdf.c: Add checks for the EVP_MD_get_size()

### DIFF
--- a/providers/implementations/kdfs/hmacdrbg_kdf.c
+++ b/providers/implementations/kdfs/hmacdrbg_kdf.c
@@ -183,6 +183,7 @@ static int hmac_drbg_kdf_set_ctx_params(void *vctx,
     const OSSL_PARAM *p;
     void *ptr = NULL;
     size_t size = 0;
+    int md_size;
 
     if (params == NULL)
         return 1;
@@ -220,7 +221,10 @@ static int hmac_drbg_kdf_set_ctx_params(void *vctx,
                 ERR_raise(ERR_LIB_PROV, PROV_R_XOF_DIGESTS_NOT_ALLOWED);
                 return 0;
             }
-            drbg->blocklen = EVP_MD_get_size(md);
+            md_size = EVP_MD_get_size(md);
+            if (md_size <= 0)
+                return 0;
+            drbg->blocklen = (size_t)md_size;
         }
         return ossl_prov_macctx_load_from_params(&drbg->ctx, params,
                                                  "HMAC", NULL, NULL, libctx);


### PR DESCRIPTION
Add checks for the EVP_MD_get_size() to avoid integer overflow and then explicitly cast from int to size_t.

Fixes: f3090fc710 ("Implement deterministic ECDSA sign (RFC6979)")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
