### PR TITLE
test/tls13secretstest.c: Add checks for the EVP_MD_get_size()

### DIFF
--- a/test/tls13secretstest.c
+++ b/test/tls13secretstest.c
@@ -282,7 +282,7 @@ static int test_handshake_secrets(void)
     SSL *ssl = NULL;
     SSL_CONNECTION *s;
     int ret = 0;
-    size_t hashsize;
+    int hashsize;
     unsigned char out_master_secret[EVP_MAX_MD_SIZE];
     size_t master_secret_length;
 
@@ -321,7 +321,9 @@ static int test_handshake_secrets(void)
         goto err;
 
     hashsize = EVP_MD_get_size(ssl_handshake_md(s));
-    if (!TEST_size_t_eq(sizeof(client_hts), hashsize))
+    if (hashsize <= 0)
+        goto err;
+    if (!TEST_size_t_eq(sizeof(client_hts), (size_t)hashsize))
         goto err;
     if (!TEST_size_t_eq(sizeof(client_hts_key), KEYLEN))
         goto err;


### PR DESCRIPTION
Add checks for the EVP_MD_get_size() to avoid integer overflow and then explicitly cast from int to size_t.

Fixes: 134bfe56c4 ("Add a test for the TLS1.3 secret generation")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
