### PR TITLE
test/bad_dtls_test.c: Add checks for the EVP_MD_CTX_get_size()

### DIFF
--- a/test/bad_dtls_test.c
+++ b/test/bad_dtls_test.c
@@ -370,6 +370,7 @@ static int send_finished(SSL *s, BIO *rbio)
         /* Finished MAC (12 bytes) */
     };
     unsigned char handshake_hash[EVP_MAX_MD_SIZE];
+    int md_size;
 
     /* Derive key material */
     do_PRF(TLS_MD_KEY_EXPANSION_CONST, TLS_MD_KEY_EXPANSION_CONST_SIZE,
@@ -381,8 +382,11 @@ static int send_finished(SSL *s, BIO *rbio)
     if (!EVP_DigestFinal_ex(handshake_md, handshake_hash, NULL))
         return 0;
 
+    md_size = EVP_MD_CTX_get_size(handshake_md);
+    if (md_size <= 0)
+        return 0;
     do_PRF(TLS_MD_SERVER_FINISH_CONST, TLS_MD_SERVER_FINISH_CONST_SIZE,
-           handshake_hash, EVP_MD_CTX_get_size(handshake_md),
+           handshake_hash, md_size,
            NULL, 0,
            finished_msg + DTLS1_HM_HEADER_LENGTH, TLS1_FINISH_MAC_LENGTH);
 


### PR DESCRIPTION
Add the check for the EVP_MD_CTX_get_size() to avoid integer overflow when it is implicitly casted from int to size_t in evp_pkey_ctx_store_cached_data(). The call path is do_PRF() -> EVP_PKEY_CTX_add1_tls1_prf_seed() -> evp_pkey_ctx_set1_octet_string() -> EVP_PKEY_CTX_ctrl() -> evp_pkey_ctx_store_cached_data().

Fixes: 16938284cf ("Add basic test for Cisco DTLS1_BAD_VER and record replay handling")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
