### PR TITLE
store/store_lib.c: Add the checks for the EVP_MD_CTX_get_size()

### DIFF
--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -933,15 +933,20 @@ OSSL_STORE_SEARCH *OSSL_STORE_SEARCH_by_key_fingerprint(const EVP_MD *digest,
                                                         *bytes, size_t len)
 {
     OSSL_STORE_SEARCH *search = OPENSSL_zalloc(sizeof(*search));
+    int md_size;
 
     if (search == NULL)
         return NULL;
 
-    if (digest != NULL && len != (size_t)EVP_MD_get_size(digest)) {
+    md_size = EVP_MD_get_size(digest);
+    if (md_size <= 0)
+        return NULL;
+
+    if (digest != NULL && len != (size_t)md_size) {
         ERR_raise_data(ERR_LIB_OSSL_STORE,
                        OSSL_STORE_R_FINGERPRINT_SIZE_DOES_NOT_MATCH_DIGEST,
                        "%s size is %d, fingerprint size is %zu",
-                       EVP_MD_get0_name(digest), EVP_MD_get_size(digest), len);
+                       EVP_MD_get0_name(digest), md_size, len);
         OPENSSL_free(search);
         return NULL;
     }

--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -939,8 +939,10 @@ OSSL_STORE_SEARCH *OSSL_STORE_SEARCH_by_key_fingerprint(const EVP_MD *digest,
         return NULL;
 
     md_size = EVP_MD_get_size(digest);
-    if (md_size <= 0)
+    if (md_size <= 0) {
+        OPENSSL_free(search);
         return NULL;
+    }
 
     if (digest != NULL && len != (size_t)md_size) {
         ERR_raise_data(ERR_LIB_OSSL_STORE,


### PR DESCRIPTION
Add the checks for the return value of EVP_MD_CTX_get_size() before explicitly cast them to size_t to avoid the integer overflow.

Fixes: fac8673b8a ("STORE: Add the possibility to search for specific information")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
