### PR TITLE
signature/sm2_sig.c: Add the check for the EVP_MD_CTX_get_size()

### DIFF
--- a/providers/implementations/signature/sm2_sig.c
+++ b/providers/implementations/signature/sm2_sig.c
@@ -313,6 +313,7 @@ int sm2sig_digest_verify_final(void *vpsm2ctx, const unsigned char *sig,
 
     if (psm2ctx == NULL
         || psm2ctx->mdctx == NULL
+        || EVP_MD_get_size(psm2ctx->md) <= 0
         || EVP_MD_get_size(psm2ctx->md) > (int)sizeof(digest))
         return 0;
 

--- a/providers/implementations/signature/sm2_sig.c
+++ b/providers/implementations/signature/sm2_sig.c
@@ -310,11 +310,13 @@ int sm2sig_digest_verify_final(void *vpsm2ctx, const unsigned char *sig,
     PROV_SM2_CTX *psm2ctx = (PROV_SM2_CTX *)vpsm2ctx;
     unsigned char digest[EVP_MAX_MD_SIZE];
     unsigned int dlen = 0;
+    int md_size;
 
-    if (psm2ctx == NULL
-        || psm2ctx->mdctx == NULL
-        || EVP_MD_get_size(psm2ctx->md) <= 0
-        || EVP_MD_get_size(psm2ctx->md) > (int)sizeof(digest))
+    if (psm2ctx == NULL || psm2ctx->mdctx == NULL)
+        return 0;
+
+    md_size = EVP_MD_get_size(psm2ctx->md);
+    if (md_size <= 0 || md_size > (int)sizeof(digest))
         return 0;
 
     if (!(sm2sig_compute_z_digest(psm2ctx)


### PR DESCRIPTION
Add the check for the return value of EVP_MD_CTX_get_size() to avoid invalid negative numbers.

Fixes: d0b79f8631 ("Add SM2 signature algorithm to default provider")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
