### PR TITLE
82-test_ocsp_cert_chain.t: restore lines removed from third while-loop

### DIFF
--- a/test/recipes/82-test_ocsp_cert_chain.t
+++ b/test/recipes/82-test_ocsp_cert_chain.t
@@ -128,6 +128,10 @@ sub run_test {
         if (/^cert_status: ocsp response sent:/) {
             $resp = 1;
             last;
+        } elsif (/^cert_status:/) {
+            ;
+        } else {
+            last;
         }
     }
     ok($resp == 1, "check s_server sent ocsp response");


### PR DESCRIPTION
fix-up to 33f6d613

Restore the lines removed from the third while-loop inside 82-test_ocsp_cert_chain.t.

That change was made so that unrecognized strings emitted to stderr (like the one emitted by the AFL toolchain) would be ignored and would not cause the check to fail.  However, that undermines the intent of the test.  Each time strings from stdout and stderr are processed inside 82-test_ocsp_cert_chain.t, it is done in a strict manner so that unrecognized strings cause a failure.  Also, removing those lines prevents the last while-loop from terminating in the event that the desired string "cert_status: ocsp response sent:" is not output (so the last check never fails; it just never returns).

Note that the AFL issue should be resolved by 12f5f26e, which sets the environment variable AFL_MAP_SIZE.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
