### PR TITLE
ffc/ffc_params_generate.c: Add the check for the EVP_MD_get_size()

### DIFF
--- a/crypto/ffc/ffc_params_generate.c
+++ b/crypto/ffc/ffc_params_generate.c
@@ -814,6 +814,7 @@ int ossl_ffc_params_FIPS186_2_gen_verify(OSSL_LIB_CTX *libctx,
     BIGNUM *r0, *test, *tmp, *g = NULL, *q = NULL, *p = NULL;
     BN_MONT_CTX *mont = NULL;
     EVP_MD *md = NULL;
+    int md_size;
     size_t qsize;
     int n = 0, m = 0;
     int counter = 0, pcounter = 0, use_random_seed;
@@ -842,8 +843,11 @@ int ossl_ffc_params_FIPS186_2_gen_verify(OSSL_LIB_CTX *libctx,
     }
     if (md == NULL)
         goto err;
+    md_size = EVP_MD_get_size(md);
+    if (md_size <= 0)
+        goto err;
     if (N == 0)
-        N = EVP_MD_get_size(md) * 8;
+        N = md_size * 8;
     qsize = N >> 3;
 
     /*


### PR DESCRIPTION
Add the check for the EVP_MD_get_size() to avoid invalid negative numbers.

Fixes: 4f2271d58a ("Add ACVP fips module tests")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
