### PR TITLE
x509/x509_set.c: Add the check for the EVP_MD_get_size()

### DIFF
--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -212,7 +212,7 @@ int X509_get_signature_info(X509 *x, int *mdnid, int *pknid, int *secbits,
 static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
                               const ASN1_STRING *sig, const EVP_PKEY *pubkey)
 {
-    int pknid, mdnid;
+    int pknid, mdnid, md_size;
     const EVP_MD *md;
     const EVP_PKEY_ASN1_METHOD *ameth;
 
@@ -279,7 +279,12 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
             ERR_raise(ERR_LIB_X509, X509_R_ERROR_GETTING_MD_BY_NID);
             return 0;
         }
-        siginf->secbits = EVP_MD_get_size(md) * 4;
+        md_size = EVP_MD_get_size(md);
+        if (md_size <= 0) {
+            ERR_raise(ERR_LIB_X509, X509_R_INVALID_ATTRIBUTES);
+            return 0;
+        }
+        siginf->secbits = md_size * 4;
         break;
     }
     switch (mdnid) {


### PR DESCRIPTION
Add the check for the EVP_MD_get_size() to avoid invalid negative numbers.

Fixes: 786dd2c22c ("Add support for custom signature parameters")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
