### PR TITLE
Correct ossl_sleep for threaded model by introducing sleep() - 3.0,3.1,3.2

### DIFF
--- a/e_os.h
+++ b/e_os.h
@@ -296,20 +296,18 @@ static ossl_inline void ossl_sleep(unsigned long millis)
     ts.tv_sec = (long int) (millis / 1000);
     ts.tv_nsec = (long int) (millis % 1000) * 1000000ul;
     nanosleep(&ts, NULL);
-# elif defined(__TANDEM)
-#  if !defined(_REENTRANT)
+# elif defined(__TANDEM) && !defined(_REENTRANT)
 #   include <cextdecs.h(PROCESS_DELAY_)>
+
     /* HPNS does not support usleep for non threaded apps */
     PROCESS_DELAY_(millis * 1000);
-#  elif defined(_SPT_MODEL_)
-#   include <spthread.h>
-#   include <spt_extensions.h>
-    usleep(millis * 1000);
-#  else
-    usleep(millis * 1000);
-#  endif
 # else
-    usleep(millis * 1000);
+    unsigned int s = (unsigned int)(millis / 1000);
+    unsigned int us = (unsigned int)((millis % 1000) * 1000);
+
+    if (s > 0)
+        sleep(s);
+    usleep(us);
 # endif
 }
 #elif defined(_WIN32)


### PR DESCRIPTION
This fix handles situations where ossl_sleep() receives a millis value equal or greater than 1000, which breaks platforms where this is not legal.

Fixes: #23961