### PR TITLE
crypto: Separate text and rodata section for armv8

### DIFF
--- a/crypto/aes/asm/aesv8-armx.pl
+++ b/crypto/aes/asm/aesv8-armx.pl
@@ -107,11 +107,17 @@ my ($zero,$rcon,$mask,$in0,$in1,$tmp,$key)=
 
 
 $code.=<<___;
+#ifdef __aarch64__
+.pushsection ".rodata", "a"
+#endif
 .align	5
 .Lrcon:
 .long	0x01,0x01,0x01,0x01
 .long	0x0c0f0e0d,0x0c0f0e0d,0x0c0f0e0d,0x0c0f0e0d	// rotate-n-splat
 .long	0x1b,0x1b,0x1b,0x1b
+#ifdef __aarch64__
+.popsection
+#endif
 
 .globl	${prefix}_set_encrypt_key
 .type	${prefix}_set_encrypt_key,%function
@@ -139,7 +145,12 @@ $code.=<<___;
 	tst	$bits,#0x3f
 	b.ne	.Lenc_key_abort
 
+#ifdef __aarch64__
+	adrp    $ptr,.Lrcon
+	add     $ptr,$ptr,#:lo12:.Lrcon
+#else
 	adr	$ptr,.Lrcon
+#endif
 	cmp	$bits,#192
 
 	veor	$zero,$zero,$zero

--- a/crypto/aes/asm/vpaes-armv8.pl
+++ b/crypto/aes/asm/vpaes-armv8.pl
@@ -57,6 +57,7 @@ $code.=<<___;
 
 .text
 
+.pushsection ".rodata", "a"
 .type	_vpaes_consts,%object
 .align	7	// totally strategic alignment
 _vpaes_consts:
@@ -145,6 +146,7 @@ _vpaes_consts:
 
 .asciz  "Vector Permutation AES for ARMv8, Mike Hamburg (Stanford University)"
 .size	_vpaes_consts,.-_vpaes_consts
+.popsection
 .align	6
 ___
 
@@ -165,7 +167,8 @@ $code.=<<___;
 .type	_vpaes_encrypt_preheat,%function
 .align	4
 _vpaes_encrypt_preheat:
-	adr	x10, .Lk_inv
+	adrp	x10, .Lk_inv
+	add	x10, x10, #:lo12:.Lk_inv
 	movi	v17.16b, #0x0f
 	ld1	{v18.2d-v19.2d}, [x10],#32	// .Lk_inv
 	ld1	{v20.2d-v23.2d}, [x10],#64	// .Lk_ipt, .Lk_sbo
@@ -193,7 +196,8 @@ _vpaes_encrypt_preheat:
 _vpaes_encrypt_core:
 	mov	x9, $key
 	ldr	w8, [$key,#240]			// pull rounds
-	adr	x11, .Lk_mc_forward+16
+	adrp	x11, .Lk_mc_forward+16
+	add	x11, x11, #:lo12:.Lk_mc_forward+16
 						// vmovdqa	.Lk_ipt(%rip),	%xmm2	# iptlo
 	ld1	{v16.2d}, [x9], #16		// vmovdqu	(%r9),	%xmm5		# round0 key
 	and	v1.16b, v7.16b, v17.16b		// vpand	%xmm9,	%xmm0,	%xmm1
@@ -280,7 +284,8 @@ vpaes_encrypt:
 _vpaes_encrypt_2x:
 	mov	x9, $key
 	ldr	w8, [$key,#240]			// pull rounds
-	adr	x11, .Lk_mc_forward+16
+	adrp	x11, .Lk_mc_forward+16
+	add	x11, x11, #:lo12:.Lk_mc_forward+16
 						// vmovdqa	.Lk_ipt(%rip),	%xmm2	# iptlo
 	ld1	{v16.2d}, [x9], #16		// vmovdqu	(%r9),	%xmm5		# round0 key
 	and	v1.16b,  v14.16b,  v17.16b	// vpand	%xmm9,	%xmm0,	%xmm1
@@ -383,9 +388,11 @@ _vpaes_encrypt_2x:
 .type	_vpaes_decrypt_preheat,%function
 .align	4
 _vpaes_decrypt_preheat:
-	adr	x10, .Lk_inv
+	adrp	x10, .Lk_inv
+	add	x10, x10, #:lo12:.Lk_inv
 	movi	v17.16b, #0x0f
-	adr	x11, .Lk_dipt
+	adrp	x11, .Lk_dipt
+	add	x11, x11, #:lo12:.Lk_dipt
 	ld1	{v18.2d-v19.2d}, [x10],#32	// .Lk_inv
 	ld1	{v20.2d-v23.2d}, [x11],#64	// .Lk_dipt, .Lk_dsbo
 	ld1	{v24.2d-v27.2d}, [x11],#64	// .Lk_dsb9, .Lk_dsbd
@@ -407,10 +414,12 @@ _vpaes_decrypt_core:
 						// vmovdqa	.Lk_dipt(%rip), %xmm2	# iptlo
 	lsl	x11, x8, #4			// mov	%rax,	%r11;	shl	\$4, %r11
 	eor	x11, x11, #0x30			// xor		\$0x30,	%r11
-	adr	x10, .Lk_sr
+	adrp	x10, .Lk_sr
+	add	x10, x10, #:lo12:.Lk_sr
 	and	x11, x11, #0x30			// and		\$0x30,	%r11
 	add	x11, x11, x10
-	adr	x10, .Lk_mc_forward+48
+	adrp	x10, .Lk_mc_forward+48
+	add	x10, x10, #:lo12:.Lk_mc_forward+48
 
 	ld1	{v16.2d}, [x9],#16		// vmovdqu	(%r9),	%xmm4		# round0 key
 	and	v1.16b, v7.16b, v17.16b		// vpand	%xmm9,	%xmm0,	%xmm1
@@ -518,10 +527,12 @@ _vpaes_decrypt_2x:
 						// vmovdqa	.Lk_dipt(%rip), %xmm2	# iptlo
 	lsl	x11, x8, #4			// mov	%rax,	%r11;	shl	\$4, %r11
 	eor	x11, x11, #0x30			// xor		\$0x30,	%r11
-	adr	x10, .Lk_sr
+	adrp	x10, .Lk_sr
+	add	x10, x10, #:lo12:.Lk_sr
 	and	x11, x11, #0x30			// and		\$0x30,	%r11
 	add	x11, x11, x10
-	adr	x10, .Lk_mc_forward+48
+	adrp	x10, .Lk_mc_forward+48
+	add	x10, x10, #:lo12:.Lk_mc_forward+48
 
 	ld1	{v16.2d}, [x9],#16		// vmovdqu	(%r9),	%xmm4		# round0 key
 	and	v1.16b,  v14.16b, v17.16b	// vpand	%xmm9,	%xmm0,	%xmm1
@@ -657,14 +668,18 @@ $code.=<<___;
 .type	_vpaes_key_preheat,%function
 .align	4
 _vpaes_key_preheat:
-	adr	x10, .Lk_inv
+	adrp	x10, .Lk_inv
+	add	x10, x10, #:lo12:.Lk_inv
 	movi	v16.16b, #0x5b			// .Lk_s63
-	adr	x11, .Lk_sb1
+	adrp	x11, .Lk_sb1
+	add	x11, x11, #:lo12:.Lk_sb1
 	movi	v17.16b, #0x0f			// .Lk_s0F
 	ld1	{v18.2d-v21.2d}, [x10]		// .Lk_inv, .Lk_ipt
-	adr	x10, .Lk_dksd
+	adrp	x10, .Lk_dksd
+	add	x10, x10, #:lo12:.Lk_dksd
 	ld1	{v22.2d-v23.2d}, [x11]		// .Lk_sb1
-	adr	x11, .Lk_mc_forward
+	adrp	x11, .Lk_mc_forward
+	add	x11, x11, #:lo12:.Lk_mc_forward
 	ld1	{v24.2d-v27.2d}, [x10],#64	// .Lk_dksd, .Lk_dksb
 	ld1	{v28.2d-v31.2d}, [x10],#64	// .Lk_dkse, .Lk_dks9
 	ld1	{v8.2d}, [x10]			// .Lk_rcon
@@ -688,7 +703,8 @@ _vpaes_schedule_core:
 	bl	_vpaes_schedule_transform
 	mov	v7.16b, v0.16b			// vmovdqa	%xmm0,	%xmm7
 
-	adr	x10, .Lk_sr			// lea	.Lk_sr(%rip),%r10
+	adrp	x10, .Lk_sr			// lea	.Lk_sr(%rip),%r10
+	add	x10, x10, #:lo12:.Lk_sr
 	add	x8, x8, x10
 	cbnz	$dir, .Lschedule_am_decrypting
 
@@ -814,12 +830,14 @@ _vpaes_schedule_core:
 .align	4
 .Lschedule_mangle_last:
 	// schedule last round key from xmm0
-	adr	x11, .Lk_deskew			// lea	.Lk_deskew(%rip),%r11	# prepare to deskew
+	adrp	x11, .Lk_deskew			// lea	.Lk_deskew(%rip),%r11	# prepare to deskew
+	add	x11, x11, #:lo12:.Lk_deskew
 	cbnz	$dir, .Lschedule_mangle_last_dec
 
 	// encrypting
 	ld1	{v1.2d}, [x8]			// vmovdqa	(%r8,%r10),%xmm1
-	adr	x11, .Lk_opt			// lea	.Lk_opt(%rip),	%r11		# prepare to output transform
+	adrp	x11, .Lk_opt			// lea	.Lk_opt(%rip),	%r11		# prepare to output transform
+	add	x11, x11, #:lo12:.Lk_opt
 	add	$out, $out, #32			// add	\$32,	%rdx
 	tbl	v0.16b, {v0.16b}, v1.16b	// vpshufb	%xmm1,	%xmm0,	%xmm0		# output permute
 

--- a/crypto/bn/asm/armv8-mont.pl
+++ b/crypto/bn/asm/armv8-mont.pl
@@ -1898,7 +1898,9 @@ __bn_mul4x_mont:
 ___
 }
 $code.=<<___;
+.pushsection ".rodata", "a"
 .asciz	"Montgomery Multiplication for ARMv8, CRYPTOGAMS by <appro\@openssl.org>"
+.popsection
 .align	4
 ___
 

--- a/crypto/chacha/asm/chacha-armv8.pl
+++ b/crypto/chacha/asm/chacha-armv8.pl
@@ -142,6 +142,7 @@ $code.=<<___;
 
 .text
 
+.pushsection ".rodata", "a"
 .align	5
 .Lsigma:
 .quad	0x3320646e61707865,0x6b20657479622d32		// endian-neutral
@@ -150,6 +151,7 @@ $code.=<<___;
 .Lrot24:
 .long	0x02010003,0x06050407,0x0a09080b,0x0e0d0c0f
 .asciz	"ChaCha20 for ARMv8, CRYPTOGAMS by \@dot-asm"
+.popsection
 
 .globl	ChaCha20_ctr32_dflt
 .type	ChaCha20_ctr32_dflt,%function
@@ -170,7 +172,8 @@ ChaCha20_ctr32_dflt:
 	stp	x29,x30,[sp,#-96]!
 	add	x29,sp,#0
 
-	adr	@x[0],.Lsigma
+	adrp	@x[0],.Lsigma
+	add	@x[0],@x[0],#:lo12:.Lsigma
 	stp	x19,x20,[sp,#16]
 	stp	x21,x22,[sp,#32]
 	stp	x23,x24,[sp,#48]
@@ -473,7 +476,8 @@ ChaCha20_neon:
 	stp	x29,x30,[sp,#-96]!
 	add	x29,sp,#0
 
-	adr	@x[0],.Lsigma
+	adrp	@x[0],.Lsigma
+	add	@x[0],@x[0],#:lo12:.Lsigma
 	stp	x19,x20,[sp,#16]
 	stp	x21,x22,[sp,#32]
 	stp	x23,x24,[sp,#48]
@@ -884,7 +888,8 @@ ChaCha20_512_neon:
 	stp	x29,x30,[sp,#-96]!
 	add	x29,sp,#0
 
-	adr	@x[0],.Lsigma
+	adrp	@x[0],.Lsigma
+	add	@x[0],@x[0],#:lo12:.Lsigma
 	stp	x19,x20,[sp,#16]
 	stp	x21,x22,[sp,#32]
 	stp	x23,x24,[sp,#48]

--- a/crypto/ec/asm/ecp_nistz256-armv8.pl
+++ b/crypto/ec/asm/ecp_nistz256-armv8.pl
@@ -78,6 +78,7 @@ close TABLE;
 die "insane number of elements" if ($#arr != 64*16*37-1);
 
 $code.=<<___;
+.pushsection ".rodata", "a"
 .globl	ecp_nistz256_precomputed
 .type	ecp_nistz256_precomputed,%object
 .align	12
@@ -116,6 +117,7 @@ $code.=<<___;
 .LordK:
 .quad	0xccd1c8aaee00bc4f
 .asciz	"ECP_NISTZ256 for ARMv8, CRYPTOGAMS by <appro\@openssl.org>"
+.popsection
 
 // void	ecp_nistz256_to_mont(BN_ULONG x0[4],const BN_ULONG x1[4]);
 .globl	ecp_nistz256_to_mont
@@ -127,12 +129,19 @@ ecp_nistz256_to_mont:
 	add	x29,sp,#0
 	stp	x19,x20,[sp,#16]
 
-	ldr	$bi,.LRR		// bp[0]
+	adrp	$bi,.LRR
+	add	$bi,$bi,#:lo12:.LRR
+	ldr	$bi,[$bi]		// bp[0]
 	ldp	$a0,$a1,[$ap]
 	ldp	$a2,$a3,[$ap,#16]
-	ldr	$poly1,.Lpoly+8
-	ldr	$poly3,.Lpoly+24
-	adr	$bp,.LRR		// &bp[0]
+	adrp	$poly1,.Lpoly+8
+	add	$poly1,$poly1,#:lo12:.Lpoly+8
+	ldr	$poly1,[$poly1]
+	adrp	$poly3,.Lpoly+24
+	add	$poly3,$poly3,#:lo12:.Lpoly+24
+	ldr	$poly3,[$poly3]
+	adrp	$bp,.LRR		// &bp[0]
+	add	$bp,$bp,#:lo12:.LRR	// &bp[0]
 
 	bl	__ecp_nistz256_mul_mont
 
@@ -155,9 +164,14 @@ ecp_nistz256_from_mont:
 	mov	$bi,#1			// bp[0]
 	ldp	$a0,$a1,[$ap]
 	ldp	$a2,$a3,[$ap,#16]
-	ldr	$poly1,.Lpoly+8
-	ldr	$poly3,.Lpoly+24
-	adr	$bp,.Lone		// &bp[0]
+	adrp	$poly1,.Lpoly+8
+	add	$poly1,$poly1,#:lo12:.Lpoly+8
+	ldr	$poly1,[$poly1]
+	adrp	$poly3,.Lpoly+24
+	add	$poly3,$poly3,#:lo12:.Lpoly+24
+	ldr	$poly3,[$poly3]
+	adrp	$bp,.Lone		// &bp[0]
+	add	$bp,$bp,#:lo12:.Lone	// &bp[0]
 
 	bl	__ecp_nistz256_mul_mont
 
@@ -181,8 +195,12 @@ ecp_nistz256_mul_mont:
 	ldr	$bi,[$bp]		// bp[0]
 	ldp	$a0,$a1,[$ap]
 	ldp	$a2,$a3,[$ap,#16]
-	ldr	$poly1,.Lpoly+8
-	ldr	$poly3,.Lpoly+24
+	adrp	$poly1,.Lpoly+8
+	add	$poly1,$poly1,#:lo12:.Lpoly+8
+	ldr	$poly1,[$poly1]
+	adrp	$poly3,.Lpoly+24
+	add	$poly3,$poly3,#:lo12:.Lpoly+24
+	ldr	$poly3,[$poly3]
 
 	bl	__ecp_nistz256_mul_mont
 
@@ -204,8 +222,12 @@ ecp_nistz256_sqr_mont:
 
 	ldp	$a0,$a1,[$ap]
 	ldp	$a2,$a3,[$ap,#16]
-	ldr	$poly1,.Lpoly+8
-	ldr	$poly3,.Lpoly+24
+	adrp	$poly1,.Lpoly+8
+	add	$poly1,$poly1,#:lo12:.Lpoly+8
+	ldr	$poly1,[$poly1]
+	adrp	$poly3,.Lpoly+24
+	add	$poly3,$poly3,#:lo12:.Lpoly+24
+	ldr	$poly3,[$poly3]
 
 	bl	__ecp_nistz256_sqr_mont
 
@@ -229,8 +251,12 @@ ecp_nistz256_add:
 	ldp	$t0,$t1,[$bp]
 	ldp	$acc2,$acc3,[$ap,#16]
 	ldp	$t2,$t3,[$bp,#16]
-	ldr	$poly1,.Lpoly+8
-	ldr	$poly3,.Lpoly+24
+	adrp	$poly1,.Lpoly+8
+	add	$poly1,$poly1,#:lo12:.Lpoly+8
+	ldr	$poly1,[$poly1]
+	adrp	$poly3,.Lpoly+24
+	add	$poly3,$poly3,#:lo12:.Lpoly+24
+	ldr	$poly3,[$poly3]
 
 	bl	__ecp_nistz256_add
 
@@ -250,8 +276,12 @@ ecp_nistz256_div_by_2:
 
 	ldp	$acc0,$acc1,[$ap]
 	ldp	$acc2,$acc3,[$ap,#16]
-	ldr	$poly1,.Lpoly+8
-	ldr	$poly3,.Lpoly+24
+	adrp	$poly1,.Lpoly+8
+	add	$poly1,$poly1,#:lo12:.Lpoly+8
+	ldr	$poly1,[$poly1]
+	adrp	$poly3,.Lpoly+24
+	add	$poly3,$poly3,#:lo12:.Lpoly+24
+	ldr	$poly3,[$poly3]
 
 	bl	__ecp_nistz256_div_by_2
 
@@ -271,8 +301,12 @@ ecp_nistz256_mul_by_2:
 
 	ldp	$acc0,$acc1,[$ap]
 	ldp	$acc2,$acc3,[$ap,#16]
-	ldr	$poly1,.Lpoly+8
-	ldr	$poly3,.Lpoly+24
+	adrp	$poly1,.Lpoly+8
+	add	$poly1,$poly1,#:lo12:.Lpoly+8
+	ldr	$poly1,[$poly1]
+	adrp	$poly3,.Lpoly+24
+	add	$poly3,$poly3,#:lo12:.Lpoly+24
+	ldr	$poly3,[$poly3]
 	mov	$t0,$acc0
 	mov	$t1,$acc1
 	mov	$t2,$acc2
@@ -296,8 +330,12 @@ ecp_nistz256_mul_by_3:
 
 	ldp	$acc0,$acc1,[$ap]
 	ldp	$acc2,$acc3,[$ap,#16]
-	ldr	$poly1,.Lpoly+8
-	ldr	$poly3,.Lpoly+24
+	adrp	$poly1,.Lpoly+8
+	add	$poly1,$poly1,#:lo12:.Lpoly+8
+	ldr	$poly1,[$poly1]
+	adrp	$poly3,.Lpoly+24
+	add	$poly3,$poly3,#:lo12:.Lpoly+24
+	ldr	$poly3,[$poly3]
 	mov	$t0,$acc0
 	mov	$t1,$acc1
 	mov	$t2,$acc2
@@ -333,8 +371,12 @@ ecp_nistz256_sub:
 
 	ldp	$acc0,$acc1,[$ap]
 	ldp	$acc2,$acc3,[$ap,#16]
-	ldr	$poly1,.Lpoly+8
-	ldr	$poly3,.Lpoly+24
+	adrp	$poly1,.Lpoly+8
+	add	$poly1,$poly1,#:lo12:.Lpoly+8
+	ldr	$poly1,[$poly1]
+	adrp	$poly3,.Lpoly+24
+	add	$poly3,$poly3,#:lo12:.Lpoly+24
+	ldr	$poly3,[$poly3]
 
 	bl	__ecp_nistz256_sub_from
 
@@ -357,8 +399,12 @@ ecp_nistz256_neg:
 	mov	$acc1,xzr
 	mov	$acc2,xzr
 	mov	$acc3,xzr
-	ldr	$poly1,.Lpoly+8
-	ldr	$poly3,.Lpoly+24
+	adrp	$poly1,.Lpoly+8
+	add	$poly1,$poly1,#:lo12:.Lpoly+8
+	ldr	$poly1,[$poly1]
+	adrp	$poly3,.Lpoly+24
+	add	$poly3,$poly3,#:lo12:.Lpoly+24
+	ldr	$poly3,[$poly3]
 
 	bl	__ecp_nistz256_sub_from
 
@@ -736,9 +782,13 @@ ecp_nistz256_point_double:
 	 mov	$rp_real,$rp
 	ldp	$acc2,$acc3,[$ap,#48]
 	 mov	$ap_real,$ap
-	 ldr	$poly1,.Lpoly+8
+	adrp	$poly1,.Lpoly+8
+	add	$poly1,$poly1,#:lo12:.Lpoly+8
+	ldr	$poly1,[$poly1]
 	mov	$t0,$acc0
-	 ldr	$poly3,.Lpoly+24
+	adrp	$poly3,.Lpoly+24
+	add	$poly3,$poly3,#:lo12:.Lpoly+24
+	ldr	$poly3,[$poly3]
 	mov	$t1,$acc1
 	 ldp	$a0,$a1,[$ap_real,#64]	// forward load for p256_sqr_mont
 	mov	$t2,$acc2
@@ -897,8 +947,12 @@ ecp_nistz256_point_add:
 	 mov	$rp_real,$rp
 	 mov	$ap_real,$ap
 	 mov	$bp_real,$bp
-	 ldr	$poly1,.Lpoly+8
-	 ldr	$poly3,.Lpoly+24
+	adrp	$poly1,.Lpoly+8
+	add	$poly1,$poly1,#:lo12:.Lpoly+8
+	ldr	$poly1,[$poly1]
+	adrp	$poly3,.Lpoly+24
+	add	$poly3,$poly3,#:lo12:.Lpoly+24
+	ldr	$poly3,[$poly3]
 	orr	$t0,$a0,$a1
 	orr	$t2,$a2,$a3
 	orr	$in2infty,$t0,$t2
@@ -1151,8 +1205,12 @@ ecp_nistz256_point_add_affine:
 	mov	$rp_real,$rp
 	mov	$ap_real,$ap
 	mov	$bp_real,$bp
-	ldr	$poly1,.Lpoly+8
-	ldr	$poly3,.Lpoly+24
+	adrp	$poly1,.Lpoly+8
+	add	$poly1,$poly1,#:lo12:.Lpoly+8
+	ldr	$poly1,[$poly1]
+	adrp	$poly3,.Lpoly+24
+	add	$poly3,$poly3,#:lo12:.Lpoly+24
+	ldr	$poly3,[$poly3]
 
 	ldp	$a0,$a1,[$ap,#64]	// in1_z
 	ldp	$a2,$a3,[$ap,#64+16]
@@ -1303,7 +1361,8 @@ $code.=<<___;
 	stp	$acc2,$acc3,[$rp_real,#$i+16]
 ___
 $code.=<<___	if ($i == 0);
-	adr	$bp_real,.Lone_mont-64
+	adrp	$bp_real,.Lone_mont-64
+	add	$bp_real,$bp_real,#:lo12:.Lone_mont-64
 ___
 }
 $code.=<<___;
@@ -1354,7 +1413,8 @@ ecp_nistz256_ord_mul_mont:
 	stp	x21,x22,[sp,#32]
 	stp	x23,x24,[sp,#48]
 
-	adr	$ordk,.Lord
+	adrp	$ordk,.Lord
+	add	$ordk,$ordk,#:lo12:.Lord
 	ldr	$bi,[$bp]		// bp[0]
 	ldp	$a0,$a1,[$ap]
 	ldp	$a2,$a3,[$ap,#16]
@@ -1497,7 +1557,8 @@ ecp_nistz256_ord_sqr_mont:
 	stp	x21,x22,[sp,#32]
 	stp	x23,x24,[sp,#48]
 
-	adr	$ordk,.Lord
+	adrp	$ordk,.Lord
+	add	$ordk,$ordk,#:lo12:.Lord
 	ldp	$a0,$a1,[$ap]
 	ldp	$a2,$a3,[$ap,#16]
 

--- a/crypto/modes/asm/aes-gcm-armv8_64.pl
+++ b/crypto/modes/asm/aes-gcm-armv8_64.pl
@@ -6035,7 +6035,9 @@ ___
 }
 
 $code.=<<___;
+.pushsection ".rodata", "a"
 .asciz  "GHASH for ARMv8, CRYPTOGAMS by <appro\@openssl.org>"
+.popsection
 .align  2
 #endif
 ___

--- a/crypto/modes/asm/ghashv8-armx.pl
+++ b/crypto/modes/asm/ghashv8-armx.pl
@@ -810,7 +810,9 @@ ___
 }
 
 $code.=<<___;
+.pushsection ".rodata", "a"
 .asciz  "GHASH for ARMv8, CRYPTOGAMS by <appro\@openssl.org>"
+.popsection
 .align  2
 #endif
 ___

--- a/crypto/poly1305/asm/poly1305-armv8.pl
+++ b/crypto/poly1305/asm/poly1305-armv8.pl
@@ -442,7 +442,8 @@ poly1305_blocks_neon:
 	ldr	x30,[sp,#8]
 
 	add	$in2,$inp,#32
-	adr	$zeros,.Lzeros
+	adrp	$zeros,.Lzeros
+	add	$zeros,$zeros,#:lo12:.Lzeros
 	subs	$len,$len,#64
 	csel	$in2,$zeros,$in2,lo
 
@@ -454,7 +455,8 @@ poly1305_blocks_neon:
 .align	4
 .Leven_neon:
 	add	$in2,$inp,#32
-	adr	$zeros,.Lzeros
+	adrp	$zeros,.Lzeros
+	add	$zeros,$zeros,#:lo12:.Lzeros
 	subs	$len,$len,#64
 	csel	$in2,$zeros,$in2,lo
 
@@ -937,10 +939,12 @@ poly1305_emit_neon:
 	ret
 .size	poly1305_emit_neon,.-poly1305_emit_neon
 
+.pushsection ".rodata", "a"
 .align	5
 .Lzeros:
 .long	0,0,0,0,0,0,0,0
 .asciz	"Poly1305 for ARMv8, CRYPTOGAMS by <appro\@openssl.org>"
+.popsection
 .align	2
 ___
 

--- a/crypto/sha/asm/keccak1600-armv8.pl
+++ b/crypto/sha/asm/keccak1600-armv8.pl
@@ -84,6 +84,7 @@ $code.=<<___;
 
 .text
 
+.pushsection ".rodata", "a"
 .align 8	// strategic alignment and padding that allows to use
 		// address value as loop termination condition...
 	.quad	0,0,0,0,0,0,0,0
@@ -114,6 +115,7 @@ iotas:
 	.quad	0x0000000080000001
 	.quad	0x8000000080008008
 .size	iotas,.-iotas
+.popsection
 ___
 								{{{
 my @A = map([ "x$_", "x".($_+1), "x".($_+2), "x".($_+3), "x".($_+4) ],
@@ -127,7 +129,8 @@ $code.=<<___;
 .align	5
 KeccakF1600_int:
 	AARCH64_SIGN_LINK_REGISTER
-	adr	$C[2],iotas
+	adrp	$C[2],iotas
+	add	$C[2],$C[2],#:lo12:iotas
 	stp	$C[2],x30,[sp,#16]		// 32 bytes on top are mine
 	b	.Loop
 .align	4
@@ -556,7 +559,8 @@ $code.=<<___;
 .align	5
 KeccakF1600_ce:
 	mov	x9,#24
-	adr	x10,iotas
+	adrp	x10,iotas
+	add	x10,x10,#:lo12:iotas
 	b	.Loop_ce
 .align	4
 .Loop_ce:
@@ -849,7 +853,9 @@ SHA3_squeeze_cext:
 ___
 }								}}}
 $code.=<<___;
+.pushsection ".rodata", "a"
 .asciz	"Keccak-1600 absorb and squeeze for ARMv8, CRYPTOGAMS by <appro\@openssl.org>"
+.popsection
 ___
 
 {   my  %opcode = (

--- a/crypto/sha/asm/sha1-armv8.pl
+++ b/crypto/sha/asm/sha1-armv8.pl
@@ -259,7 +259,8 @@ sha1_block_armv8:
 	stp	x29,x30,[sp,#-16]!
 	add	x29,sp,#0
 
-	adr	x4,.Lconst
+	adrp	x4,.Lconst
+	add	x4,x4,#:lo12:.Lconst
 	eor	$E,$E,$E
 	ld1.32	{$ABCD},[$ctx],#16
 	ld1.32	{$E}[0],[$ctx]
@@ -319,6 +320,7 @@ $code.=<<___;
 	ldr	x29,[sp],#16
 	ret
 .size	sha1_block_armv8,.-sha1_block_armv8
+.pushsection ".rodata", "a"
 .align	6
 .Lconst:
 .long	0x5a827999,0x5a827999,0x5a827999,0x5a827999	//K_00_19
@@ -326,6 +328,7 @@ $code.=<<___;
 .long	0x8f1bbcdc,0x8f1bbcdc,0x8f1bbcdc,0x8f1bbcdc	//K_40_59
 .long	0xca62c1d6,0xca62c1d6,0xca62c1d6,0xca62c1d6	//K_60_79
 .asciz	"SHA1 block transform for ARMv8, CRYPTOGAMS by <appro\@openssl.org>"
+.popsection
 .align	2
 ___
 }}}

--- a/crypto/sha/asm/sha512-armv8.pl
+++ b/crypto/sha/asm/sha512-armv8.pl
@@ -235,7 +235,8 @@ $code.=<<___;
 	ldp	$E,$F,[$ctx,#4*$SZ]
 	add	$num,$inp,$num,lsl#`log(16*$SZ)/log(2)`	// end of input
 	ldp	$G,$H,[$ctx,#6*$SZ]
-	adr	$Ktbl,.LK$BITS
+	adrp	$Ktbl,.LK$BITS
+	add	$Ktbl,$Ktbl,#:lo12:.LK$BITS
 	stp	$ctx,$num,[x29,#96]
 
 .Loop:
@@ -285,6 +286,7 @@ $code.=<<___;
 	ret
 .size	$func,.-$func
 
+.pushsection ".rodata", "a"
 .align	6
 .type	.LK$BITS,%object
 .LK$BITS:
@@ -354,6 +356,7 @@ ___
 $code.=<<___;
 .size	.LK$BITS,.-.LK$BITS
 .asciz	"SHA$BITS block transform for ARMv8, CRYPTOGAMS by <appro\@openssl.org>"
+.popsection
 .align	2
 ___
 
@@ -376,7 +379,8 @@ sha256_block_armv8:
 	add		x29,sp,#0
 
 	ld1.32		{$ABCD,$EFGH},[$ctx]
-	adr		$Ktbl,.LK256
+	adrp		$Ktbl,.LK256
+	add		$Ktbl,$Ktbl,#:lo12:.LK256
 
 .Loop_hw:
 	ld1		{@MSG[0]-@MSG[3]},[$inp],#64
@@ -641,7 +645,8 @@ sha256_block_neon:
 	mov	x29, sp
 	sub	sp,sp,#16*4
 
-	adr	$Ktbl,.LK256
+	adrp	$Ktbl,.LK256
+	add	$Ktbl,$Ktbl,#:lo12:.LK256
 	add	$num,$inp,$num,lsl#6	// len to point at the end of inp
 
 	ld1.8	{@X[0]},[$inp], #16
@@ -755,7 +760,8 @@ sha512_block_armv8:
 	ld1		{@MSG[4]-@MSG[7]},[$inp],#64
 
 	ld1.64		{@H[0]-@H[3]},[$ctx]		// load context
-	adr		$Ktbl,.LK512
+	adrp		$Ktbl,.LK512
+	add		$Ktbl,$Ktbl,#:lo12:.LK512
 
 	rev64		@MSG[0],@MSG[0]
 	rev64		@MSG[1],@MSG[1]


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

Separate data in `.text` section to `.rodata` section to support eXecute-Only-Memory(XOM) feature.

Fixes:#23911
