### PR TITLE
man EVP_PKEY_CTX_set_params: document params is a list

### DIFF
--- a/doc/man3/EVP_PKEY_CTX_set_params.pod
+++ b/doc/man3/EVP_PKEY_CTX_set_params.pod
@@ -23,7 +23,9 @@ The EVP_PKEY_CTX_get_params() and EVP_PKEY_CTX_set_params() functions allow
 transfer of arbitrary key parameters to and from providers.
 Not all parameters may be supported by all providers.
 See L<OSSL_PROVIDER(3)> for more information on providers.
-See L<OSSL_PARAM(3)> for more information on parameters.
+The I<params> field is a pointer to a list of B<OSSL_PARAM> structures,
+terminated with a L<OSSL_PARAM_END(3)> struct.
+See L<OSSL_PARAM(3)> for information about passing parameters.
 These functions must only be called after the EVP_PKEY_CTX has been initialised
 for use in an operation.
 These methods replace the EVP_PKEY_CTX_ctrl() mechanism. (EVP_PKEY_CTX_ctrl now


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

Make it clear in the man page that the parameters field in `EVP_PKEY_CTX_set_params` are a pointer to a list, not to a single struct.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
