### PR TITLE
Avoid memory leak in x509_test error path (#23897)

### DIFF
--- a/test/v3ext.c
+++ b/test/v3ext.c
@@ -269,17 +269,20 @@ static int test_addr_fam_len(void)
         goto end;
     if (!ASN1_OCTET_STRING_set(f1->addressFamily, key, keylen))
         goto end;
+
+    /* Push and transfer memory ownership to stack */
     if (!sk_IPAddressFamily_push(addr, f1))
         goto end;
+    f1 = NULL;
 
     /* Shouldn't be able to canonize this as the len is > 3*/
     if (!TEST_false(X509v3_addr_canonize(addr)))
         goto end;
 
-    /* Create a well formed IPAddressFamily */
-    f1 = sk_IPAddressFamily_pop(addr);
-    IPAddressFamily_free(f1);
+    /* Pop and free the new stack element */
+    IPAddressFamily_free(sk_IPAddressFamily_pop(addr));
 
+    /* Create a well-formed IPAddressFamily */
     key[0] = (afi >> 8) & 0xFF;
     key[1] = afi & 0xFF;
     key[2] = 0x1;
@@ -297,8 +300,11 @@ static int test_addr_fam_len(void)
 
     /* Mark this as inheritance so we skip some of the is_canonize checks */
     f1->ipAddressChoice->type = IPAddressChoice_inherit;
+
+    /* Push and transfer memory ownership to stack */
     if (!sk_IPAddressFamily_push(addr, f1))
         goto end;
+    f1 = NULL;
 
     /* Should be able to canonize now */
     if (!TEST_true(X509v3_addr_canonize(addr)))
@@ -306,7 +312,10 @@ static int test_addr_fam_len(void)
 
     testresult = 1;
   end:
+    /* Free stack and any memory owned by detached element */
+    IPAddressFamily_free(f1);
     sk_IPAddressFamily_pop_free(addr, IPAddressFamily_free);
+
     ASN1_OCTET_STRING_free(ip1);
     ASN1_OCTET_STRING_free(ip2);
     return testresult;


### PR DESCRIPTION
Fixes #23897

- [x] tests are added or updated

(This is a test code error path bugfix, so no test-tests).

The fix emulates a C++ "move" semantics via a couple of macros that hopefull aid clarity/consistency. They could be open-coded, if just repeating the code a couple of times is deemed more clear.
