### PR TITLE
QUIC: server fixes for s_client compatibility

### DIFF
--- a/include/internal/quic_stream_map.h
+++ b/include/internal/quic_stream_map.h
@@ -504,10 +504,11 @@ static ossl_inline ossl_unused int ossl_quic_stream_recv_get_final_size(const QU
 }
 
 /*
- * Determines the number of bytes available still to be read, and whether a FIN
- * has yet to be read.
+ * Determines the number of bytes available still to be read, and (if
+ * include_fin is 1) whether a FIN or reset has yet to be read.
  */
-static ossl_inline ossl_unused int ossl_quic_stream_recv_pending(const QUIC_STREAM *s)
+static ossl_inline ossl_unused int ossl_quic_stream_recv_pending(const QUIC_STREAM *s,
+                                                                 int include_fin)
 {
     size_t avail;
     int fin = 0;
@@ -523,13 +524,13 @@ static ossl_inline ossl_unused int ossl_quic_stream_recv_pending(const QUIC_STRE
         if (!ossl_quic_rstream_available(s->rstream, &avail, &fin))
             avail = 0;
 
-        if (avail == 0 && fin)
+        if (avail == 0 && include_fin && fin)
             avail = 1;
 
         return avail;
 
     case QUIC_RSTREAM_STATE_RESET_RECVD:
-        return 1;
+        return include_fin;
 
     case QUIC_RSTREAM_STATE_DATA_READ:
     case QUIC_RSTREAM_STATE_RESET_READ:

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -1800,7 +1800,6 @@ static int ch_generate_transport_params(QUIC_CHANNEL *ch)
     ch->local_transport_params = (unsigned char *)buf_mem->data;
     buf_mem->data = NULL;
 
-
     if (!ossl_quic_tls_set_transport_params(ch->qtls, ch->local_transport_params,
                                             buf_len))
         goto err;
@@ -1869,6 +1868,10 @@ void ossl_quic_channel_subtick(QUIC_CHANNEL *ch, QUIC_TICK_RESULT *res,
      *   - generate any packets which need to be sent;
      *   - determine the time at which we should next be ticked.
      */
+
+    /* Nothing to do yet if connection has not been started. */
+    if (ch->state == QUIC_CHANNEL_STATE_IDLE)
+        return;
 
     /* If we are in the TERMINATED state, there is nothing to do. */
     if (ossl_quic_channel_is_terminated(ch)) {

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -291,7 +291,7 @@ static int ossl_unused expect_quic_with_stream_lock(const SSL *s, int remote_ini
             /* ossl_quic_do_handshake raised error here */
             goto err;
 
-        if (remote_init == ctx->qc->as_server) {
+        if (remote_init == 0) {
             if (!qc_try_create_default_xso_for_write(ctx))
                 goto err;
         } else {

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -2986,11 +2986,13 @@ static size_t ossl_quic_pending_int(const SSL *s, int check_channel)
     }
 
     if (check_channel)
-        avail = ossl_quic_stream_recv_pending(ctx.xso->stream)
+        avail = ossl_quic_stream_recv_pending(ctx.xso->stream,
+                                              /*include_fin=*/1)
              || ossl_quic_channel_has_pending(ctx.qc->ch)
              || ossl_quic_channel_is_term_any(ctx.qc->ch);
     else
-        avail = ossl_quic_stream_recv_pending(ctx.xso->stream);
+        avail = ossl_quic_stream_recv_pending(ctx.xso->stream,
+                                              /*include_fin=*/0);
 
 out:
     qctx_unlock(&ctx);

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -2581,8 +2581,8 @@ static int quic_write_nonblocking_epw(QCTX *ctx, const void *buf, size_t len,
     quic_post_write(xso, *written > 0, *written == len, flags,
                     qctx_should_autotick(ctx));
     if (*written == 0)
-        /* SSL_write_ex returns 0 if it didn't read anything .*/
-        return QUIC_RAISE_NORMAL_ERROR(ctx, SSL_ERROR_WANT_READ);
+        /* SSL_write_ex returns 0 if it didn't write anything. */
+        return QUIC_RAISE_NORMAL_ERROR(ctx, SSL_ERROR_WANT_WRITE);
 
     return 1;
 }

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -2577,6 +2577,10 @@ static int quic_write_nonblocking_epw(QCTX *ctx, const void *buf, size_t len,
 
     quic_post_write(xso, *written > 0, *written == len, flags,
                     qctx_should_autotick(ctx));
+    if (*written == 0)
+        /* SSL_write_ex returns 0 if it didn't read anything .*/
+        return QUIC_RAISE_NORMAL_ERROR(ctx, SSL_ERROR_WANT_READ);
+
     return 1;
 }
 

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -52,6 +52,9 @@ struct quic_tls_st {
 
     /* Set if the handshake has completed */
     unsigned int complete : 1;
+
+    /* Set if we have consumed the local transport parameters yet. */
+    unsigned int local_transport_params_consumed : 1;
 };
 
 struct ossl_record_layer_st {
@@ -606,6 +609,7 @@ static int add_transport_params_cb(SSL *s, unsigned int ext_type,
 
     *out = qtls->local_transport_params;
     *outlen = qtls->local_transport_params_len;
+    qtls->local_transport_params_consumed = 1;
     return 1;
 }
 
@@ -833,6 +837,9 @@ int ossl_quic_tls_set_transport_params(QUIC_TLS *qtls,
                                        const unsigned char *transport_params,
                                        size_t transport_params_len)
 {
+    if (qtls->local_transport_params_consumed)
+        return 0;
+
     qtls->local_transport_params       = transport_params;
     qtls->local_transport_params_len   = transport_params_len;
     return 1;


### PR DESCRIPTION
- Fix SSL_has_pending behaviour for compatibility with s_client. Since s_client uses SSL_has_pending to determine if I/O calls will be fruitful, returning 0 from SSL_has_pending can cause s_client to stall in server-writes-first scenarios, even if e.g. a FIN is waiting to be read.
- Fix server-side default stream creation.
- Ensure connections are not accidentally started before an application requests it.