### PR TITLE
Fix use of sleep() so that it is not called in threaded code with 0 value.

### DIFF
--- a/crypto/sleep.c
+++ b/crypto/sleep.c
@@ -31,7 +31,8 @@ void OSSL_sleep(uint64_t millis)
     unsigned int s = (unsigned int)(millis / 1000);
     unsigned int us = (unsigned int)((millis % 1000) * 1000);
 
-    sleep(s);
+    if (s > 0)
+        sleep(s);
     usleep(us);
 # endif
 }


### PR DESCRIPTION
This change ensures that sleep(0) is not invoked to cause unexpected duplicate thread context switches when _REENTRANT is specified.

Fixes: #24009

Signed-off-by: Randall S. Becker <randall.becker@nexbridge.ca>