### PR TITLE
Fix typos found by codespell in openssl-3.3 doc

### DIFF
--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -1044,7 +1044,7 @@ If the transaction contains more requests, the remaining ones are not saved.
 =item B<-reqout_only> I<filename>
 
 Save the first CMP requests created by the client to the given file and exit.
-Any options related to CMP servers and their reponses are ignored.
+Any options related to CMP servers and their responses are ignored.
 
 This option is useful for supporting offline scenarios where the certificate
 request (or any other CMP request) is produced beforehand and sent out later.

--- a/doc/man3/OSSL_CMP_MSG_get0_header.pod
+++ b/doc/man3/OSSL_CMP_MSG_get0_header.pod
@@ -36,7 +36,7 @@ OSSL_CMP_MSG_get0_header() returns the header of the given CMP message.
 OSSL_CMP_MSG_get_bodytype() returns the body type of the given CMP message.
 
 OSSL_CMP_MSG_get0_certreq_publickey() expects that I<msg> is a certificate request
-messsage and returns the public key in its certificate template if present.
+message and returns the public key in its certificate template if present.
 
 OSSL_CMP_MSG_update_transactionID() updates the transactionID field
 in the header of the given message according to the CMP_CTX.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
