### PR TITLE
Add RSA Signature restrictions for X9.31 padding in the FIPS provider.

### DIFF
--- a/crypto/rsa/rsa_ossl.c
+++ b/crypto/rsa/rsa_ossl.c
@@ -769,6 +769,7 @@ static int rsa_ossl_public_decrypt(int flen, const unsigned char *from,
                                rsa->_method_mod_n))
         goto err;
 
+    /* For X9.31: Assuming e is odd it does a 12 mod 16 test */
     if ((padding == RSA_X931_PADDING) && ((bn_get_words(ret)[0] & 0xf) != 12))
         if (!BN_sub(ret, rsa->n, ret))
             goto err;

--- a/crypto/rsa/rsa_x931.c
+++ b/crypto/rsa/rsa_x931.c
@@ -19,6 +19,27 @@
 #include <openssl/rsa.h>
 #include <openssl/objects.h>
 
+/*
+ * X9.31 Embeds the hash inside the following data structure
+ *
+ * header (4 bits = 0x6)
+ * padding (consisting of zero or more 4 bit values of a sequence of 0xB,
+ *          ending with the terminator 0xA)
+ * hash(Msg) hash of a message (the output size is related to the hash function)
+ * trailer (consists of 2 bytes)
+ *         The 1st byte is related to a part number for a hash algorithm
+ *         (See RSA_X931_hash_id()), followed by the fixed value 0xCC
+ *
+ * The RSA modulus size n (which for X9.31 is 1024 + 256*s) is the size of the data
+ * structure, which determines the padding size.
+ * i.e. len(padding) = n - len(header) - len(hash) - len(trailer)
+ *
+ * Params:
+ *     to The output buffer to write the data structure to.
+ *     tolen The size of 'to' in bytes (it is the size of the n)
+ *     from The input hash followed by the 1st byte of the trailer.
+ *     flen The size of the input hash + 1 (trailer byte)
+ */
 int RSA_padding_add_X931(unsigned char *to, int tlen,
                          const unsigned char *from, int flen)
 {
@@ -26,10 +47,9 @@ int RSA_padding_add_X931(unsigned char *to, int tlen,
     unsigned char *p;
 
     /*
-     * Absolute minimum amount of padding is 1 header nibble, 1 padding
-     * nibble and 2 trailer bytes: but 1 hash if is already in 'from'.
+     * We need at least 1 byte for header + padding (0x6A)
+     * And 2 trailer bytes (but we subtract 1 since flen includes 1 trailer byte)
      */
-
     j = tlen - flen - 2;
 
     if (j < 0) {
@@ -101,7 +121,12 @@ int RSA_padding_check_X931(unsigned char *to, int tlen,
     return j;
 }
 
-/* Translate between X931 hash ids and NIDs */
+/*
+ * Translate between X9.31 hash ids and NIDs
+ * The returned values relate to ISO/IEC 10118 part numbers which consist of
+ * a hash algorithm and hash number. The returned values are used as the
+ * first byte of the 'trailer'.
+ */
 
 int RSA_X931_hash_id(int nid)
 {

--- a/doc/man1/openssl-fipsinstall.pod.in
+++ b/doc/man1/openssl-fipsinstall.pod.in
@@ -33,6 +33,7 @@ B<openssl fipsinstall>
 [B<-dsa_sign_disabled>]
 [B<-no_short_mac>]
 [B<-tdes_encrypt_disabled>]
+[B<-rsa_sign_x931_disabled>]
 [B<-self_test_onload>]
 [B<-self_test_oninstall>]
 [B<-corrupt_desc> I<selftest_description>]
@@ -250,6 +251,11 @@ still allowed). See FIPS 140-3 IG C.K for details.
 Configure the module to not allow Triple-DES encryption.
 Triple-DES decryption is still allowed for legacy purposes.
 See SP800-131Ar2 for details.
+
+=item B<-rsa_sign_x931_disabled>
+
+Configure the module to not allow X9.31 padding be used when signing with RSA.
+See FIPS 140-3 IG C.K for details.
 
 =item B<-self_test_onload>
 

--- a/doc/man7/EVP_SIGNATURE-RSA.pod
+++ b/doc/man7/EVP_SIGNATURE-RSA.pod
@@ -27,6 +27,8 @@ using EVP_PKEY_sign_init_ex() or EVP_PKEY_verify_init_ex().
 
 =item "digest-check" (B<OSSL_SIGNATURE_PARAM_FIPS_DIGEST_CHECK>) <integer>
 
+=item "sign-x931-pad-check" (B<SIGNATURE_PARAM_FIPS_SIGN_X931_PAD_CHECK>) <int>
+
 These common parameters are described in L<provider-signature(7)>.
 
 =item "pad-mode" (B<OSSL_SIGNATURE_PARAM_PAD_MODE>) <UTF8 string>
@@ -40,6 +42,10 @@ The type of padding to be used. Its value can be one of the following:
 =item "pkcs1" (B<OSSL_PKEY_RSA_PAD_MODE_PKCSV15>)
 
 =item "x931" (B<OSSL_PKEY_RSA_PAD_MODE_X931>)
+
+This padding mode is no longer supported by the FIPS provider for signature
+generation, but may be used for signature verification for legacy use cases.
+(This is a FIPS 140-3 requirement)
 
 =item "pss" (B<OSSL_PKEY_RSA_PAD_MODE_PSS>)
 

--- a/doc/man7/OSSL_PROVIDER-FIPS.pod
+++ b/doc/man7/OSSL_PROVIDER-FIPS.pod
@@ -152,6 +152,10 @@ This is an unapproved algorithm.
 
 =item RSA, see L<EVP_SIGNATURE-RSA(7)>
 
+The B<X931> padding mode "OSSL_PKEY_RSA_PAD_MODE_X931" is no longer supported
+for signature generation, but may be used for verification for legacy use cases.
+(This is a FIPS 140-3 requirement)
+
 =item DSA, see L<EVP_SIGNATURE-DSA(7)>
 
 =item ED25519, see L<EVP_SIGNATURE-ED25519(7)>

--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -420,6 +420,13 @@ If required this parameter should be set early via an init function.
 The default value of 1 causes an error when a signing algorithm is used. (This
 is triggered by deprecated signing algorithms).
 Setting this to 0 will ignore the error and set the approved "fips-indicator" to 0.
+
+=item "sign-x931-pad-check" (B<SIGNATURE_PARAM_FIPS_SIGN_X931_PAD_CHECK>) <int>
+
+If required this parameter should be set before the padding mode is set
+The default value of 1 causes an error if the padding mode is set to X9.31 padding
+for a RSA signing operation. Setting this to 0 will ignore the error and set the
+approved "fips-indicator" to 0.
 This option is used by the OpenSSL FIPS provider, and breaks FIPS compliance if
 set to 0.
 

--- a/include/openssl/fips_names.h
+++ b/include/openssl/fips_names.h
@@ -141,6 +141,15 @@ extern "C" {
  */
 # define OSSL_PROV_FIPS_PARAM_TDES_ENCRYPT_DISABLED "tdes-encrypt-disabled"
 
+/*
+ * A boolean that determines if X9.31 padding can be used for RSA signing.
+ * X9.31 RSA has been removed from FIPS 186-5, and is no longer approved for
+ * signing. it may still be used for verification for legacy purposes.
+ * This is disabled by default.
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+# define OSSL_PROV_FIPS_PARAM_RSA_SIGN_X931_PAD_DISABLED "rsa-sign-x931-pad-disabled"
+
 # ifdef __cplusplus
 }
 # endif

--- a/providers/common/include/prov/fipscommon.h
+++ b/providers/common/include/prov/fipscommon.h
@@ -22,5 +22,6 @@ int FIPS_sskdf_digest_check(OSSL_LIB_CTX *libctx);
 int FIPS_x963kdf_digest_check(OSSL_LIB_CTX *libctx);
 int FIPS_dsa_sign_check(OSSL_LIB_CTX *libctx);
 int FIPS_tdes_encrypt_check(OSSL_LIB_CTX *libctx);
+int FIPS_rsa_sign_x931_disallowed(OSSL_LIB_CTX *libctx);
 
 #endif

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -97,6 +97,7 @@ typedef struct fips_global_st {
     FIPS_OPTION fips_x963kdf_digest_check;
     FIPS_OPTION fips_dsa_sign_disallowed;
     FIPS_OPTION fips_tdes_encrypt_disallowed;
+    FIPS_OPTION fips_rsa_sign_x931_disallowed;
 } FIPS_GLOBAL;
 
 static void init_fips_option(FIPS_OPTION *opt, int enabled)
@@ -123,6 +124,7 @@ void *ossl_fips_prov_ossl_ctx_new(OSSL_LIB_CTX *libctx)
     init_fips_option(&fgbl->fips_x963kdf_digest_check, 0);
     init_fips_option(&fgbl->fips_dsa_sign_disallowed, 0);
     init_fips_option(&fgbl->fips_tdes_encrypt_disallowed, 0);
+    init_fips_option(&fgbl->fips_rsa_sign_x931_disallowed, 0);
     return fgbl;
 }
 
@@ -157,6 +159,8 @@ static const OSSL_PARAM fips_param_types[] = {
                     NULL, 0),
     OSSL_PARAM_DEFN(OSSL_PROV_PARAM_TDES_ENCRYPT_DISABLED, OSSL_PARAM_INTEGER,
                     NULL, 0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_RSA_SIGN_X931_PAD_DISABLED,
+                    OSSL_PARAM_INTEGER, NULL, 0),
     OSSL_PARAM_END
 };
 
@@ -227,6 +231,8 @@ static int fips_get_params_from_core(FIPS_GLOBAL *fgbl)
                         fips_dsa_sign_disallowed);
     FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_TDES_ENCRYPT_DISABLED,
                         fips_tdes_encrypt_disallowed);
+    FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_RSA_SIGN_X931_PAD_DISABLED,
+                        fips_rsa_sign_x931_disallowed);
 #undef FIPS_FEATURE_OPTION
 
     *p = OSSL_PARAM_construct_end();
@@ -292,6 +298,8 @@ static int fips_get_params(void *provctx, OSSL_PARAM params[])
                      fips_dsa_sign_disallowed);
     FIPS_FEATURE_GET(fgbl, OSSL_PROV_PARAM_TDES_ENCRYPT_DISABLED,
                      fips_tdes_encrypt_disallowed);
+    FIPS_FEATURE_GET(fgbl, OSSL_PROV_PARAM_RSA_SIGN_X931_PAD_DISABLED,
+                     fips_rsa_sign_x931_disallowed);
 #undef FIPS_FEATURE_GET
     return 1;
 }
@@ -835,6 +843,7 @@ int OSSL_provider_init_int(const OSSL_CORE_HANDLE *handle,
     FIPS_SET_OPTION(fgbl, fips_x963kdf_digest_check);
     FIPS_SET_OPTION(fgbl, fips_dsa_sign_disallowed);
     FIPS_SET_OPTION(fgbl, fips_tdes_encrypt_disallowed);
+    FIPS_SET_OPTION(fgbl, fips_rsa_sign_x931_disallowed);
 #undef FIPS_SET_OPTION
 
     ossl_prov_cache_exported_algorithms(fips_ciphers, exported_fips_ciphers);
@@ -1045,6 +1054,8 @@ FIPS_FEATURE_CHECK(FIPS_sskdf_digest_check, fips_sskdf_digest_check)
 FIPS_FEATURE_CHECK(FIPS_x963kdf_digest_check, fips_x963kdf_digest_check)
 FIPS_FEATURE_CHECK(FIPS_dsa_sign_check, fips_dsa_sign_disallowed)
 FIPS_FEATURE_CHECK(FIPS_tdes_encrypt_check, fips_tdes_encrypt_disallowed)
+FIPS_FEATURE_CHECK(FIPS_rsa_sign_x931_disallowed,
+                   fips_rsa_sign_x931_disallowed)
 
 #undef FIPS_FEATURE_CHECK
 

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -207,6 +207,7 @@ static const OSSL_PARAM settable_ctx_params[] = {
     OSSL_PARAM_int("ems_check", NULL),
     OSSL_PARAM_int("sign-check", NULL),
     OSSL_PARAM_int("encrypt-check", NULL),
+    OSSL_PARAM_int("sign-x931-pad-check", NULL),
     OSSL_PARAM_END
 };
 

--- a/test/recipes/30-test_evp_data/evppkey_rsa_common.txt
+++ b/test/recipes/30-test_evp_data/evppkey_rsa_common.txt
@@ -1966,6 +1966,14 @@ Key = RSA-512
 Input = "Hello"
 Result = DIGESTVERIFYINIT_ERROR
 
+# RSA Signing with X931 is not approved in FIPS 140-3
+FIPSversion = >=3.4.0
+Sign = RSA-2048
+Ctrl = rsa_padding_mode:x931
+Input = "0123456789ABCDEF123456789ABC"
+Output = c09d402423cbf233d26cae21f954547bc43fe80fd41360a0336cfdbe9aedad05bef6fd2eaee6cd60089a52482d4809a238149520df3bdde4cb9e23d9307b05c0a6f327052325a29adf2cc95b66523be7024e2a585c3d4db15dfbe146efe0ecdc0402e33fe5d40324ee96c5c3edd374a15cdc0f5d84aa243c0f07e188c6518fbfceae158a9943be398e31097da81b62074f626eff738be6160741d5a26957a482b3251fd85d8df78b98148459de10aa93305dbb4a5230aa1da291a9b0e481918f99b7638d72bb687f97661d304ae145d64a474437a4ef39d7b8059332ddeb07e92bf6e0e3acaf8afedc93795e4511737ec1e7aab6d5bc9466afc950c1c17b48ad
+Result = PKEY_CTRL_ERROR
+
 ##################################################
 # Check that the indicator callback is triggered
 
@@ -2008,3 +2016,13 @@ CtrlInit = key-check:0
 Key = RSA-512
 Input = "Hello"
 Result = VERIFY_ERROR
+
+# RSA Signing with X931 is not approved in FIPS 140-3
+FIPSversion = >=3.4.0
+Sign = RSA-2048
+Unapproved = 1
+CtrlInit = sign-x931-pad-check:0
+Ctrl = digest:SHA256
+Ctrl = rsa_padding_mode:x931
+Input = "0123456789ABCDEF123456789ABCDEFG"
+Output = 4b75f521e2e6eeda3f2dcb84ebdacbadeab8ffc1ecdf06c7c4e38727e082a8f5e71be66cdee6d14da1d3a0f18ff20914f71b5308363c81e7471688f4f201e82603ea6a7f31da89cd846b30e2893fd956e76b3d23d40f733e0358e3883526158c74577ba43cc664eaeb909818e75b89fc764cf4575517f87251f8d3cf29b1532f33e6183d454bddd6f255d0ca4415d957eb90dbc55d047f48a01c6e68d5ab46327a158ff7a3383b5b0446b8cd4a91b8859abd3285020a1613ef17d3f8562147828bb36be65505eeec77e968d04e172e2851ff1d7ef523b4022deb72d5fbf78db6738d170098586b904d1c369cedb5e3fe1b909a8dd8ac3beb521af2510d044580

--- a/util/mk-fipsmodule-cnf.pl
+++ b/util/mk-fipsmodule-cnf.pl
@@ -18,6 +18,7 @@ my $drgb_no_trunc_dgst = 1;
 my $kdf_digest_check = 1;
 my $dsa_sign_disabled = 1;
 my $tdes_encrypt_disabled = 1;
+my $rsa_sign_x931_pad_disabled = 1;
 
 my $activate = 1;
 my $version = 1;
@@ -63,4 +64,5 @@ sshkdf-digest-check = $kdf_digest_check
 sskdf-digest-check = $kdf_digest_check
 x963kdf-digest-check = $kdf_digest_check
 tdes-encrypt-disabled = $tdes_encrypt_disabled
+rsa-sign-x931-pad-disabled = $rsa_sign_x931_pad_disabled
 _____

--- a/util/perl/OpenSSL/paramnames.pm
+++ b/util/perl/OpenSSL/paramnames.pm
@@ -42,6 +42,7 @@ my %params = (
     'PROV_PARAM_X963KDF_DIGEST_CHECK' =>   "x963kdf-digest-check",   # uint
     'PROV_PARAM_DSA_SIGN_DISABLED' =>      "dsa-sign-disabled",      # uint
     'PROV_PARAM_TDES_ENCRYPT_DISABLED' =>  "tdes-encrypt-disabled",  # uint
+    'PROV_PARAM_RSA_SIGN_X931_PAD_DISABLED' =>  "rsa-sign-x931-pad-disabled",   # uint
 
 # Self test callback parameters
     'PROV_PARAM_SELF_TEST_PHASE' =>  "st-phase",# utf8_string
@@ -414,6 +415,7 @@ my %params = (
     'SIGNATURE_PARAM_FIPS_DIGEST_CHECK' =>  '*PKEY_PARAM_FIPS_DIGEST_CHECK',
     'SIGNATURE_PARAM_FIPS_KEY_CHECK' =>     '*PKEY_PARAM_FIPS_KEY_CHECK',
     'SIGNATURE_PARAM_FIPS_SIGN_CHECK' =>    "sign-check",
+    'SIGNATURE_PARAM_FIPS_SIGN_X931_PAD_CHECK' => "sign-x931-pad-check",
     'SIGNATURE_PARAM_FIPS_APPROVED_INDICATOR' => '*ALG_PARAM_FIPS_APPROVED_INDICATOR',
 
 # Asym cipher parameters


### PR DESCRIPTION
In FIPS 140-3, RSA Signing with X931 padding is not approved,
but verification is allowed for legacy purposes. An indicator has been added
for RSA signing with X931 padding.

A strict restriction on the size of the RSA modulus has been added
i.e. It must be 1024 + 256 * s (which is part of the ANSI X9.31 spec).

Added implementation comments to the X931 padding code

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
