### PR TITLE
set module path from template

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -573,16 +573,17 @@ OSSL_PROVIDER *ossl_provider_new(OSSL_LIB_CTX *libctx, const char *name,
 
     /* provider_new() generates an error, so no need here */
     prov = provider_new(name, template.init, template.parameters);
-    if (!ossl_provider_set_module_path(prov, template.path)) {
-        ossl_provider_free(prov);
-        return NULL;
-    }
 
     if (params != NULL) /* We copied the parameters, let's free them */
         sk_INFOPAIR_pop_free(template.parameters, infopair_free);
 
     if (prov == NULL)
         return NULL;
+
+    if (!ossl_provider_set_module_path(prov, template.path)) {
+        ossl_provider_free(prov);
+        return NULL;
+    }
 
     prov->libctx = libctx;
 #ifndef FIPS_MODULE

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -573,6 +573,10 @@ OSSL_PROVIDER *ossl_provider_new(OSSL_LIB_CTX *libctx, const char *name,
 
     /* provider_new() generates an error, so no need here */
     prov = provider_new(name, template.init, template.parameters);
+    if (!ossl_provider_set_module_path(prov, template.path)) {
+        ossl_provider_free(prov);
+        return NULL;
+    }
 
     if (params != NULL) /* We copied the parameters, let's free them */
         sk_INFOPAIR_pop_free(template.parameters, infopair_free);

--- a/test/build.info
+++ b/test/build.info
@@ -1092,6 +1092,7 @@ IF[{- !$disabled{tests} -}]
   ENDIF
   IF[{- $disabled{module} || !$target{dso_scheme} -}]
     DEFINE[provider_test]=NO_PROVIDER_MODULE
+    DEFINE[prov_config_test]=NO_PROVIDER_MODULE
     DEFINE[provider_internal_test]=NO_PROVIDER_MODULE
   ENDIF
   DEPEND[]=provider_internal_test.cnf

--- a/test/pathed.cnf
+++ b/test/pathed.cnf
@@ -1,0 +1,22 @@
+openssl_conf = openssl_init
+
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+legacy  = legacy_sect
+test    = test_sect
+
+[test_sect]
+module = ../test/p_test.so
+activate = false
+
+[default_sect]
+activate = true
+
+[legacy_sect]
+activate = false

--- a/test/prov_config_test.c
+++ b/test/prov_config_test.c
@@ -72,14 +72,27 @@ static int test_recursive_config(void)
     return testresult;
 }
 
+#define P_TEST_PATH "/../test/p_test.so"
 static int test_path_config(void)
 {
     OSSL_LIB_CTX *ctx = NULL;
     OSSL_PROVIDER *prov;
     int testresult = 0;
     struct stat sbuf;
+    char *module_path = getenv("OPENSSL_MODULES");
+    char *full_path = NULL;
+    int rc;
 
-    if (stat("../test/p_test.so", &sbuf) == -1)
+    full_path = OPENSSL_zalloc(strlen(module_path)+strlen(P_TEST_PATH)+1);
+    if (!TEST_ptr(full_path))
+        return 0;
+
+    strcpy(full_path, module_path);
+    full_path = strcat(full_path, P_TEST_PATH);
+    TEST_info("full path is %s", full_path);
+    rc = stat(full_path, &sbuf);
+    OPENSSL_free(full_path);
+    if (rc == -1)
         return TEST_skip("Skipping modulepath test as provider not present");
 
     if (!TEST_ptr(pathedconfig))

--- a/test/prov_config_test.c
+++ b/test/prov_config_test.c
@@ -83,7 +83,7 @@ static int test_path_config(void)
     char *full_path = NULL;
     int rc;
 
-    full_path = OPENSSL_zalloc(strlen(module_path)+strlen(P_TEST_PATH)+1);
+    full_path = OPENSSL_zalloc(strlen(module_path) + strlen(P_TEST_PATH) + 1);
     if (!TEST_ptr(full_path))
         return 0;
 

--- a/test/prov_config_test.c
+++ b/test/prov_config_test.c
@@ -13,6 +13,7 @@
 
 static char *configfile = NULL;
 static char *recurseconfigfile = NULL;
+static char *pathedconfig = NULL;
 
 /*
  * Test to make sure there are no leaks or failures from loading the config
@@ -70,6 +71,34 @@ static int test_recursive_config(void)
     return testresult;
 }
 
+#if !defined(OPENSSL_SYS_WINDOWS) && !defined(OPENSSL_SYS_MACOSX) && !defined(NO_PROVIDER_MODULE)
+static int test_path_config(void)
+{
+    OSSL_LIB_CTX *ctx = OSSL_LIB_CTX_new();
+    OSSL_PROVIDER *prov;
+    int testresult = 0;
+
+    if (!TEST_ptr(pathedconfig))
+        return 0;
+    if (!TEST_ptr(ctx))
+        return 0;
+
+    if (!TEST_true(OSSL_LIB_CTX_load_config(ctx, pathedconfig)))
+        goto err;
+
+    /* attempt to manually load the test provider */
+    if (!TEST_ptr(prov = OSSL_PROVIDER_load(ctx, "test")))
+        goto err;
+
+    OSSL_PROVIDER_unload(prov);
+
+    testresult = 1;
+ err:
+    OSSL_LIB_CTX_free(ctx);
+    return testresult;
+}
+#endif
+
 OPT_TEST_DECLARE_USAGE("configfile\n")
 
 int setup_tests(void)
@@ -85,7 +114,20 @@ int setup_tests(void)
     if (!TEST_ptr(recurseconfigfile = test_get_argument(1)))
         return 0;
 
+    if (!TEST_ptr(pathedconfig = test_get_argument(2)))
+        return 0;
+
     ADD_TEST(test_recursive_config);
     ADD_TEST(test_double_config);
+#if !defined(OPENSSL_SYS_WINDOWS) && !defined(OPENSSL_SYS_MACOSX) && !defined(NO_PROVIDER_MODULE)
+    /*
+     * This test has to specify a module path to a file
+     * Which is setup as ../test/p_test.so
+     * Since windows/macos doesn't build with that extension
+     * just skip the test here
+     * Additionally skip it if we're not building provider modules
+     */
+    ADD_TEST(test_path_config);
+#endif
     return 1;
 }

--- a/test/recipes/30-test_prov_config.t
+++ b/test/recipes/30-test_prov_config.t
@@ -23,13 +23,15 @@ my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 plan tests => 2;
 
 ok(run(test(["prov_config_test", srctop_file("test", "default.cnf"),
-                                 srctop_file("test", "recursive.cnf")])),
+                                 srctop_file("test", "recursive.cnf"),
+                                 srctop_file("test", "pathed.cnf")])),
     "running prov_config_test default.cnf");
 
 SKIP: {
     skip "Skipping FIPS test in this build", 1 if $no_fips;
 
     ok(run(test(["prov_config_test", srctop_file("test", "fips.cnf"),
-                                     srctop_file("test", "recursive.cnf")])),
+                                     srctop_file("test", "recursive.cnf"),
+                                     srctop_file("test", "pathed.cnf")])),
        "running prov_config_test fips.cnf");
 }


### PR DESCRIPTION
Modules that aren't activated at conf load time don't seem to set the module path from the template leading to load failures.  Make sure to set that

Fixes #24020

