### PR TITLE
Workaround the relocation truncated to fit problem on m68k builds

### DIFF
--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -126,7 +126,7 @@ jobs:
           }, {
             arch: m68k-linux-gnu,
             libs: libc6-dev-m68k-cross,
-            target: -mcfv4e linux-latomic -Wno-stringop-overflow no-quic,
+            target: -mcfv4e -mxgot linux-latomic -Wno-stringop-overflow no-quic,
             tests: none
           }, {
             arch: mips-linux-gnu,


### PR DESCRIPTION
We add `-mxgot` to use 32bit GOT type.
