### PR TITLE
downgrade upload-artifact action to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
     - name: make test
       run: .github/workflows/make-test
     - name: save artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: "ci@basic-gcc"
         path: artifacts/
@@ -115,7 +115,7 @@ jobs:
     - name: make test
       run: .github/workflows/make-test
     - name: save artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: "ci@basic-clang"
         path: artifacts/
@@ -140,7 +140,7 @@ jobs:
     - name: make test
       run: .github/workflows/make-test
     - name: save artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: "ci@self-hosted-${{ matrix.os }}"
         path: artifacts/
@@ -162,7 +162,7 @@ jobs:
     - name: make test
       run: .github/workflows/make-test
     - name: save artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: "ci@minimal"
         path: artifacts/
@@ -185,7 +185,7 @@ jobs:
     - name: make test
       run: .github/workflows/make-test
     - name: save artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: "ci@no-deprecated"
         path: artifacts/
@@ -207,7 +207,7 @@ jobs:
     - name: make test
       run: .github/workflows/make-test
     - name: save artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: "ci@no-shared-ubuntu"
         path: artifacts/
@@ -234,7 +234,7 @@ jobs:
     - name: make test
       run: .github/workflows/make-test
     - name: save artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: "ci@no-shared-${{ matrix.os }}"
         path: artifacts/
@@ -260,7 +260,7 @@ jobs:
     - name: make test
       run: .github/workflows/make-test OPENSSL_TEST_RAND_ORDER=0 TESTS="-test_fuzz* -test_ssl_* -test_sslapi -test_evp -test_cmp_http -test_verify -test_cms -test_store -test_enc -[01][0-9]"
     - name: save artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: "ci@non-caching"
         path: artifacts/
@@ -286,7 +286,7 @@ jobs:
     - name: make test
       run: .github/workflows/make-test OPENSSL_TEST_RAND_ORDER=0
     - name: save artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: "ci@address_ub_sanitizer"
         path: artifacts/
@@ -312,7 +312,7 @@ jobs:
     - name: make test
       run: .github/workflows/make-test OPENSSL_TEST_RAND_ORDER=0 TESTS="test_fuzz*"
     - name: save artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: "ci@fuzz_tests"
         path: artifacts/
@@ -340,7 +340,7 @@ jobs:
     - name: make test
       run: .github/workflows/make-test OPENSSL_TEST_RAND_ORDER=0
     - name: save artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: "ci@memory_sanitizer"
         path: artifacts/
@@ -366,7 +366,7 @@ jobs:
     - name: make test
       run: .github/workflows/make-test V=1 TESTS="test_threads test_internal_provider test_provfetch test_provider test_pbe test_evp_kdf test_pkcs12 test_store test_evp test_quic*"
     - name: save artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: "ci@threads_sanitizer"
         path: artifacts/
@@ -390,7 +390,7 @@ jobs:
     - name: make test
       run: .github/workflows/make-test
     - name: save artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: "ci@enable_non-default_options"
         path: artifacts/
@@ -420,7 +420,7 @@ jobs:
     - name: make test
       run: .github/workflows/make-test
     - name: save artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: "ci@full_featured"
         path: artifacts/
@@ -442,7 +442,7 @@ jobs:
     - name: make test
       run: .github/workflows/make-test
     - name: save artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: "ci@no-legacy"
         path: artifacts/
@@ -464,7 +464,7 @@ jobs:
     - name: make test
       run: .github/workflows/make-test
     - name: save artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: "ci@legacy"
         path: artifacts/
@@ -506,7 +506,7 @@ jobs:
       run: ../source/.github/workflows/make-test
       working-directory: ./build
     - name: save artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: "ci@out-of-readonly-source-and-install-ubuntu"
         path: build/artifacts/
@@ -551,7 +551,7 @@ jobs:
       run: ../source/.github/workflows/make-test
       working-directory: ./build
     - name: save artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: "ci@out-of-readonly-source-and-install-${{ matrix.os }}"
         path: build/artifacts/

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -217,7 +217,7 @@ jobs:
                   TESTS="test_evp*" \
                   QEMU_LD_PREFIX=/usr/${{ matrix.platform.arch }}
     - name: save artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: "cross-compiles@${{ matrix.platform.arch }}"
         path: artifacts/

--- a/.github/workflows/fips-checksums.yml
+++ b/.github/workflows/fips-checksums.yml
@@ -69,7 +69,7 @@ jobs:
       - name: save PR number
         run: echo ${{ github.event.number }} > ./artifact/pr_num
       - name: save artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: fips_checksum
           path: artifact/
@@ -113,7 +113,7 @@ jobs:
       - name: save PR number
         run: echo ${{ github.event.number }} > ./artifact/pr_num
       - name: save artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: abidiff
           path: artifact/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         fuzz-seconds: 600
         dry-run: false
     - name: Upload Crash
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: artifacts

--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -93,7 +93,7 @@ jobs:
                                                  -providers
         working-directory: ${{ matrix.release.dir }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.release.tgz }}
           path: ${{ matrix.release.tgz }}
@@ -169,7 +169,7 @@ jobs:
         run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
         working-directory: ${{ matrix.branch.dir }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.branch.tgz }}
           path: ${{ matrix.branch.tgz }}


### PR DESCRIPTION
GitHub Enterprise Server is not compatible with upload-artifact@v4+.

https://github.com/actions/upload-artifact/tree/v4

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
