### PR TITLE
remove m68k from cross-compiles CI

### DIFF
--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -72,12 +72,6 @@ jobs:
             fips: no,
             tests: -test_includes -test_store -test_x509_store
           }, {
-            arch: m68k-linux-gnu,
-            libs: libc6-dev-m68k-cross,
-            target: -static -m68040 linux-latomic -Wno-stringop-overflow,
-            fips: no,
-            tests: -test_includes -test_store -test_x509_store
-          }, {
             arch: mips-linux-gnu,
             libs: libc6-dev-mips-cross,
             target: -static linux-mips32,
@@ -122,11 +116,6 @@ jobs:
             arch: hppa-linux-gnu,
             libs: libc6-dev-hppa-cross,
             target: linux-generic32,
-            tests: none
-          }, {
-            arch: m68k-linux-gnu,
-            libs: libc6-dev-m68k-cross,
-            target: -mcfv4e linux-latomic -Wno-stringop-overflow no-quic,
             tests: none
           }, {
             arch: mips-linux-gnu,


### PR DESCRIPTION
m68k isn't on our platform list (neither primary, secondary, community or unadopted).  Given that we are more frequently running into CI issues in which that build fails due to GOT table exhaustion.  We could expand the GOT table with -xgot on the command line, but since we don't even list this platform anywhere on our platform page:
https://www.openssl.org/policies/general-supplemental/platforms.html

It seems like it might be better to just remove it and save a few cpu cycles in CI
