### PR TITLE
[Ignore] test use of ldar rather than ldapr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,6 +545,9 @@ jobs:
     - name: get cpu info
       run: |
         sysctl machdep.cpu
+        sysctl hw.cachesize
+        sysctl hw.l2cachesize
+        sysctl hw.physicalcpu
         ./util/opensslwrap.sh version -c
       working-directory: ./build
     - name: make test

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -558,7 +558,13 @@ int ossl_rcu_call(CRYPTO_RCU_LOCK *lock, rcu_cb_fn cb, void *data)
 
 void *ossl_rcu_uptr_deref(void **p)
 {
+#ifdef __arm64__
+    void *ret;
+    __asm volatile("ldar %0, [%1]" : "=r" (ret): "r" (p):);
+    return ret;
+#else
     return (void *)ATOMIC_LOAD_N(p, __ATOMIC_ACQUIRE);
+#endif
 }
 
 void ossl_rcu_assign_uptr(void **p, void **v)

--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -284,7 +284,6 @@ static int torture_rw_high(void)
 }
 
 
-# ifndef OPENSSL_SYS_MACOSX 
 static CRYPTO_RCU_LOCK *rcu_lock = NULL;
 
 static int writer1_done = 0;
@@ -465,7 +464,6 @@ static int torture_rcu_high(void)
     contention = 1;
     return _torture_rcu();
 }
-# endif
 #endif
 
 static CRYPTO_ONCE once_run = CRYPTO_ONCE_STATIC_INIT;
@@ -1230,10 +1228,8 @@ int setup_tests(void)
 #if defined(OPENSSL_THREADS)
     ADD_TEST(torture_rw_low);
     ADD_TEST(torture_rw_high);
-# ifndef OPENSSL_SYS_MACOSX
     ADD_TEST(torture_rcu_low);
     ADD_TEST(torture_rcu_high);
-# endif
 #endif
     ADD_TEST(test_once);
     ADD_TEST(test_thread_local);


### PR DESCRIPTION
Please ignore - conducting a test of ldar vs ldapr in CI on a virtualized mac