### PR TITLE
Fix socket descriptor checks on Windows

### DIFF
--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -965,8 +965,12 @@ static int bio_wait(BIO *bio, time_t max_time, unsigned int nap_milliseconds)
         return 1;
 
 #ifndef OPENSSL_NO_SOCK
-    if (BIO_get_fd(bio, &fd) > 0 && fd < FD_SETSIZE)
-        return BIO_socket_wait(fd, BIO_should_read(bio), max_time);
+    if (BIO_get_fd(bio, &fd) > 0) {
+        int ret = BIO_socket_wait(fd, BIO_should_read(bio), max_time);
+
+        if (ret != -1)
+            return ret;
+    }
 #endif
     /* fall back to polling since no sockets are available */
 

--- a/crypto/bio/bio_sock.c
+++ b/crypto/bio/bio_sock.c
@@ -435,7 +435,11 @@ int BIO_socket_wait(int fd, int for_read, time_t max_time)
     struct timeval tv;
     time_t now;
 
+#ifdef _WIN32
+    if ((SOCKET)fd == INVALID_SOCKET)
+#else
     if (fd < 0 || fd >= FD_SETSIZE)
+#endif
         return -1;
     if (max_time == 0)
         return 1;


### PR DESCRIPTION
The socket range checks introduced in https://github.com/openssl/openssl/commit/e98c7350bfaf0ae1f2b72d68d4c5721de24a478f break non-blocking socket operations on Windows.  This causes random `WSAENOTCONN` errors in subsequent read/write attempts.

1. In the implementation of the `socket()` function in Windows, the nfds parameter is ignored and included only for compatibility with Berkeley sockets.  On Windows, the `FD_SETSIZE` value contains the maximum total number of sockets in fd_set rather than the limit for for `FD_SET()` and `FD_CLR()` macros.
https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-select

2. Also, the Winsock invalid SOCKET value is `INVALID_SOCKET`, and not any integer < 0 as on Unix.
https://learn.microsoft.com/en-us/windows/win32/winsock/socket-data-type-2

My PR fixes checking Windows socket value according to Microsoft documentation. 
