### PR TITLE
QUIC Server Minimal Demo

### DIFF
--- a/demos/quic/server/Makefile
+++ b/demos/quic/server/Makefile
@@ -1,0 +1,30 @@
+#
+# To run the demo when linked with a shared library (default) ensure that
+# libcrypto and libssl are on the library path. For example:
+#
+#    LD_LIBRARY_PATH=../.. ./server 4444 \
+#    	../../test/certs/servercert.pem \
+#    	../../test/certs/serverkey.pem
+#
+CFLAGS  += -I../../../include -g -Wall -Wsign-compare
+LDFLAGS += -L../../..
+LDLIBS  = -lcrypto -lssl
+
+.PHONY: all server clean run s_client
+
+all: server
+
+server: server.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+
+clean:
+	$(RM) server *.o
+
+run: server
+	LD_LIBRARY_PATH=../../.. ./server 4444 \
+	    ../../../test/certs/servercert.pem \
+	    ../../../test/certs/serverkey.pem
+
+s_client:
+	LD_LIBRARY_PATH=../../.. ../../../apps/openssl \
+	    s_client -quic -quiet -alpn ossltest -connect 127.0.0.1:4444 || true

--- a/demos/quic/server/Makefile
+++ b/demos/quic/server/Makefile
@@ -6,6 +6,8 @@
 #    	../../test/certs/servercert.pem \
 #    	../../test/certs/serverkey.pem
 #
+# TODO(QUIC SERVER): Add build.info.
+#
 CFLAGS  += -I../../../include -g -Wall -Wsign-compare
 LDFLAGS += -L../../..
 LDLIBS  = -lcrypto -lssl

--- a/demos/quic/server/README.md
+++ b/demos/quic/server/README.md
@@ -8,12 +8,12 @@ Type `make` to build and `make run` to run.
 
 Usage:
 
-```
+```bash
 ./server <port-number> <certificate-file> <key-file>
 ```
 
 Example client usage:
 
-```
+```bash
 openssl s_client -quic -alpn ossltest -connect 127.0.0.1:<port-number>
 ```

--- a/demos/quic/server/README.md
+++ b/demos/quic/server/README.md
@@ -1,0 +1,19 @@
+Simple single-connection QUIC server example
+============================================
+
+This is a simple example of a QUIC server that accepts and handles one
+connection at a time. It demonstrates blocking use of the QUIC server API.
+
+Type `make` to build and `make run` to run.
+
+Usage:
+
+```
+./server <port-number> <certificate-file> <key-file>
+```
+
+Example client usage:
+
+```
+openssl s_client -quic -alpn ossltest -connect 127.0.0.1:<port-number>
+```

--- a/demos/quic/server/server.c
+++ b/demos/quic/server/server.c
@@ -1,0 +1,230 @@
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <openssl/quic.h>
+#include <netinet/in.h>
+#include <unistd.h>
+#include <assert.h>
+
+/*
+ * This is a basic demo of QUIC server functionality in which one connection at
+ * a time is accepted in a blocking loop.
+ */
+
+/* ALPN string for TLS handshake */
+static const unsigned char alpn_ossltest[] = {
+    /* "\x08ossltest" (hex for EBCDIC resilience) */
+    0x08, 0x6f, 0x73, 0x73, 0x6c, 0x74, 0x65, 0x73, 0x74
+};
+
+/* This callback validates and negotiates the desired ALPN on the server side. */
+static int select_alpn(SSL *ssl,
+                       const unsigned char **out, unsigned char *out_len,
+                       const unsigned char *in, unsigned int in_len,
+                       void *arg)
+{
+    if (SSL_select_next_proto((unsigned char **)out, out_len,
+                              alpn_ossltest, sizeof(alpn_ossltest), in, in_len)
+            != OPENSSL_NPN_NEGOTIATED)
+        return SSL_TLSEXT_ERR_ALERT_FATAL;
+
+    return SSL_TLSEXT_ERR_OK;
+}
+
+/* Create SSL_CTX. */
+static SSL_CTX *create_ctx(const char *cert_path, const char *key_path)
+{
+    SSL_CTX *ctx;
+
+    ctx = SSL_CTX_new(OSSL_QUIC_server_method());
+    if (ctx == NULL)
+        goto err;
+
+    /* Load certificate and corresponding private key. */
+    if (SSL_CTX_use_certificate_chain_file(ctx, cert_path) <= 0) {
+        fprintf(stderr, "couldn't load certificate file: %s\n", cert_path);
+        goto err;
+    }
+
+    if (SSL_CTX_use_PrivateKey_file(ctx, key_path, SSL_FILETYPE_PEM) <= 0) {
+        fprintf(stderr, "couldn't load key file: %s\n", key_path);
+        goto err;
+    }
+
+    if (!SSL_CTX_check_private_key(ctx)) {
+        fprintf(stderr, "private key check failed\n");
+        goto err;
+    }
+
+    /* Setup ALPN negotiation callback. */
+    SSL_CTX_set_alpn_select_cb(ctx, select_alpn, NULL);
+    return ctx;
+
+err:
+    SSL_CTX_free(ctx);
+    return NULL;
+}
+
+/* Create UDP socket using given port. */
+static int create_socket(uint16_t port)
+{
+    int fd = -1;
+    struct sockaddr_in6 sa = {0};
+
+    if ((fd = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
+        fprintf(stderr, "cannot create socket");
+        goto err;
+    }
+
+    sa.sin6_family  = AF_INET6;
+    sa.sin6_port    = htons(port);
+
+    if (bind(fd, (const struct sockaddr *)&sa, sizeof(sa)) < 0) {
+        fprintf(stderr, "cannot bind to %u\n", port);
+        goto err;
+    }
+
+    return fd;
+
+err:
+    if (fd >= 0)
+        BIO_closesocket(fd);
+
+    return -1;
+}
+
+/* Main loop for servicing a single incoming QUIC connection. */
+static int run_quic_conn(SSL *conn)
+{
+    size_t written = 0;
+
+    fprintf(stderr, "=> Received connection\n");
+
+    /*
+     * Write the message "hello" on the connection using a default stream
+     * and then immediately conclude the stream (end-of-stream). This
+     * demonstrates the use of SSL_write_ex2 for optimised FIN generation.
+     *
+     * Since we inherit our blocking mode from the parent QUIC SSL object (the
+     * listener) by default, this call is also blocking.
+     */
+    if (!SSL_write_ex2(conn, "hello\n", 6, SSL_WRITE_FLAG_CONCLUDE, &written)
+        || written != 6) {
+        fprintf(stderr, "couldn't write on connection\n");
+        ERR_print_errors_fp(stderr);
+        return 0;
+    }
+
+    /* Shut down the connection (blocking). */
+    if (SSL_shutdown(conn) != 1) {
+        ERR_print_errors_fp(stderr);
+        return 0;
+    }
+
+    fprintf(stderr, "=> Finished with connection\n");
+    return 1;
+}
+
+/* Main loop for server to accept QUIC connections. */
+static int run_quic_server(SSL_CTX *ctx, int fd)
+{
+    int ok = 0;
+    SSL *listener = NULL, *conn = NULL;
+
+    /* Create a new QUIC listener. */
+    if ((listener = SSL_new_listener(ctx, 0)) == NULL)
+        goto err;
+
+    /* Provide the listener with our UDP socket. */
+    if (!SSL_set_fd(listener, fd))
+        goto err;
+
+    /* Begin listening. */
+    if (!SSL_listen(listener))
+        goto err;
+
+    /*
+     * Listeners, and other QUIC objects, default to operating in blocking mode,
+     * so the below call is not actually necessary. The configured behaviour is
+     * inherited by child objects.
+     */
+    SSL_set_blocking_mode(listener, 1);
+
+    for (;;) {
+        /* Blocking wait for an incoming connection, similar to accept(2). */
+        conn = SSL_accept_connection(listener, 0);
+        if (conn == NULL) {
+            fprintf(stderr, "error while accepting connection\n");
+            goto err;
+        }
+
+        /*
+         * Optionally, we could disable blocking mode on the accepted connection
+         * here by calling SSL_set_blocking_mode().
+         */
+
+        /*
+         * Service the connection. In a real application this would be done
+         * concurrently. In this demonstration program a single connection is
+         * accepted and serviced at a time.
+         */
+        if (!run_quic_conn(conn)) {
+            SSL_free(conn);
+            goto err;
+        }
+
+        /* Free the connection, then loop again, accepting another connection. */
+        SSL_free(conn);
+    }
+
+    ok = 1;
+err:
+    if (!ok)
+        ERR_print_errors_fp(stderr);
+
+    SSL_free(listener);
+    return ok;
+}
+
+int main(int argc, char **argv)
+{
+    int rc = 1;
+    SSL_CTX *ctx = NULL;
+    int fd = -1;
+    unsigned long port;
+
+    if (argc < 4) {
+        fprintf(stderr, "usage: %s <port> <server.crt> <server.key>\n", argv[0]);
+        goto err;
+    }
+
+    /* Create SSL_CTX. */
+    if ((ctx = create_ctx(argv[2], argv[3])) == NULL)
+        goto err;
+
+    /* Parse port number from command line arguments. */
+    port = strtoul(argv[1], NULL, 0);
+    if (port == 0 || port > UINT16_MAX) {
+        fprintf(stderr, "invalid port: %lu\n", port);
+        goto err;
+    }
+
+    /* Create UDP socket. */
+    if ((fd = create_socket((uint16_t)port)) < 0)
+        goto err;
+
+    /* Enter QUIC server connection acceptance loop. */
+    if (!run_quic_server(ctx, fd))
+        goto err;
+
+    rc = 0;
+err:
+    if (rc != 0)
+        ERR_print_errors_fp(stderr);
+
+    SSL_CTX_free(ctx);
+
+    if (fd != -1)
+        BIO_closesocket(fd);
+
+    return rc;
+}

--- a/demos/quic/server/server.c
+++ b/demos/quic/server/server.c
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 #include <openssl/quic.h>

--- a/demos/quic/server/server.c
+++ b/demos/quic/server/server.c
@@ -76,15 +76,15 @@ err:
 static int create_socket(uint16_t port)
 {
     int fd = -1;
-    struct sockaddr_in6 sa = {0};
+    struct sockaddr_in sa = {0};
 
-    if ((fd = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
+    if ((fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
         fprintf(stderr, "cannot create socket");
         goto err;
     }
 
-    sa.sin6_family  = AF_INET6;
-    sa.sin6_port    = htons(port);
+    sa.sin_family  = AF_INET;
+    sa.sin_port    = htons(port);
 
     if (bind(fd, (const struct sockaddr *)&sa, sizeof(sa)) < 0) {
         fprintf(stderr, "cannot bind to %u\n", port);

--- a/doc/man3/SSL_new_listener.pod
+++ b/doc/man3/SSL_new_listener.pod
@@ -139,6 +139,9 @@ L</CLIENT-ONLY USAGE>). It is expected that the listener interface, which
 provides an abstracted API for connection acceptance, will be expanded to
 support other protocols, such as TLS over TCP, plain TCP or DTLS in future.
 
+SSL_listen() and SSL_accept_connection() are "I/O" functions, meaning that they
+update the value returned by L<SSL_get_error(3)> if they fail.
+
 =head1 CLIENT-ONLY USAGE
 
 It is also possible to use the listener interface without accepting any

--- a/doc/man3/SSL_new_listener.pod
+++ b/doc/man3/SSL_new_listener.pod
@@ -58,6 +58,11 @@ L<SSL_net_write_desired(3)>;
 
 =item
 
+Certain configurable parameters described in L<SSL_get_value(3)> (see
+L<SSL_get_value(3)> for details);
+
+=item
+
 Accepting network connections using the functions documented in this manual
 page, such as SSL_accept_connection().
 
@@ -127,8 +132,10 @@ to SSL_accept_connection(). Note that since this may change between subsequent
 API calls to the listener SSL object, it should be used for informational
 purposes only.
 
-Currently, listener SSL objects are only supported for QUIC usage via
-L<OSSL_QUIC_server_method(3)>. It is expected that the listener interface, which
+Currently, listener SSL objects are only supported for QUIC server usage via
+L<OSSL_QUIC_server_method(3)>, or QUIC client-only usage via
+L<OSSL_QUIC_client_method(3)> or L<OSSL_QUIC_client_thread_method(3)> (see
+L</CLIENT-ONLY USAGE>). It is expected that the listener interface, which
 provides an abstracted API for connection acceptance, will be expanded to
 support other protocols, such as TLS over TCP, plain TCP or DTLS in future.
 

--- a/doc/man3/SSL_new_listener.pod
+++ b/doc/man3/SSL_new_listener.pod
@@ -58,8 +58,8 @@ L<SSL_net_write_desired(3)>;
 
 =item
 
-Certain configurable parameters described in L<SSL_get_value(3)> (see
-L<SSL_get_value(3)> for details);
+Certain configurable parameters described in L<SSL_get_value_uint(3)> (see
+L<SSL_get_value_uint(3)> for details);
 
 =item
 

--- a/include/internal/quic_engine.h
+++ b/include/internal/quic_engine.h
@@ -82,6 +82,14 @@ QUIC_REACTOR *ossl_quic_engine_get0_reactor(QUIC_ENGINE *qeng);
 OSSL_LIB_CTX *ossl_quic_engine_get0_libctx(QUIC_ENGINE *qeng);
 const char *ossl_quic_engine_get0_propq(QUIC_ENGINE *qeng);
 
+/*
+ * Look through all the engine's ports and determine if any of them have had a
+ * BIO changed. If so, update the blocking support detection data in the
+ * QUIC_REACTOR. If force is 1, always do the update even if nothing seems
+ * to have changed.
+ */
+void ossl_quic_engine_update_poll_descriptors(QUIC_ENGINE *qeng, int force);
+
 # endif
 
 #endif

--- a/include/internal/quic_port.h
+++ b/include/internal/quic_port.h
@@ -82,6 +82,9 @@ QUIC_CHANNEL *ossl_quic_port_create_incoming(QUIC_PORT *port, SSL *tls);
  */
 QUIC_CHANNEL *ossl_quic_port_pop_incoming(QUIC_PORT *port);
 
+/* Returns 1 if there is at least one connection incoming. */
+int ossl_quic_port_have_incoming(QUIC_PORT *port);
+
 /*
  * Delete any channels which are pending acceptance.
  */

--- a/include/internal/quic_port.h
+++ b/include/internal/quic_port.h
@@ -99,10 +99,11 @@ int ossl_quic_port_set_net_rbio(QUIC_PORT *port, BIO *net_rbio);
 int ossl_quic_port_set_net_wbio(QUIC_PORT *port, BIO *net_wbio);
 
 /*
- * Re-poll the network BIOs already set to determine if their support
- * for polling has changed.
+ * Re-poll the network BIOs already set to determine if their support for
+ * polling has changed. If force is 0, only check again if the BIOs have been
+ * changed.
  */
-int ossl_quic_port_update_poll_descriptors(QUIC_PORT *port);
+int ossl_quic_port_update_poll_descriptors(QUIC_PORT *port, int force);
 
 /* Gets the engine which this port is a child of. */
 QUIC_ENGINE *ossl_quic_port_get0_engine(QUIC_PORT *port);

--- a/include/internal/quic_stream_map.h
+++ b/include/internal/quic_stream_map.h
@@ -487,6 +487,7 @@ static ossl_inline ossl_unused int ossl_quic_stream_recv_get_final_size(const QU
 {
     switch (s->recv_state) {
     default:
+        assert(0);
     case QUIC_RSTREAM_STATE_NONE:
     case QUIC_RSTREAM_STATE_RECV:
         return 0;
@@ -515,6 +516,7 @@ static ossl_inline ossl_unused int ossl_quic_stream_recv_pending(const QUIC_STRE
 
     switch (s->recv_state) {
     default:
+        assert(0);
     case QUIC_RSTREAM_STATE_NONE:
         return 0;
 

--- a/ssl/quic/quic_engine.c
+++ b/ssl/quic/quic_engine.c
@@ -97,6 +97,24 @@ const char *ossl_quic_engine_get0_propq(QUIC_ENGINE *qeng)
     return qeng->propq;
 }
 
+void ossl_quic_engine_update_poll_descriptors(QUIC_ENGINE *qeng, int force)
+{
+    QUIC_PORT *port;
+
+    /*
+     * TODO(QUIC MULTIPORT): The implementation of
+     * ossl_quic_port_update_poll_descriptors assumes an engine only ever has a
+     * single port for now due to reactor limitations. This limitation will be
+     * removed in future.
+     *
+     * TODO(QUIC MULTIPORT): Consider only iterating the port list when dirty at
+     * the engine level in future when we can have multiple ports. This is not
+     * important currently as the port list has a single entry.
+     */
+    LIST_FOREACH(port, port, &qeng->port_list)
+        ossl_quic_port_update_poll_descriptors(port, force);
+}
+
 /*
  * QUIC Engine: Child Object Lifecycle Management
  * ==============================================

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -327,8 +327,10 @@ static int expect_quic_as(const SSL *s, QCTX *ctx, uint32_t flags)
         }
 
         if ((flags & QCTX_C) == 0
-            && (qc->default_xso == NULL || (flags & QCTX_S) == 0))
-            return wrong_type(s, flags);
+            && (qc->default_xso == NULL || (flags & QCTX_S) == 0)) {
+            wrong_type(s, flags);
+            goto err;
+        }
 
         ctx->xso            = qc->default_xso;
         break;

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -166,7 +166,44 @@ static int quic_raise_non_normal_error(QCTX *ctx,
                                 OPENSSL_FUNC,                   \
                                 (reason),                       \
                                 (msg))
-
+/*
+ * Flags for expect_quic_as:
+ *
+ *   QCTX_C
+ *      The input SSL object may be a QCSO.
+ *
+ *   QCTX_S
+ *      The input SSL object may be a QSSO or a QCSO with a default stream
+ *      attached.
+ *
+ *      (Note this means there is no current way to require an SSL object with a
+ *      QUIC stream which is not a QCSO; a QCSO with a default stream attached
+ *      is always considered to satisfy QCTX_S.)
+ *
+ *   QCTX_AUTO_S
+ *      The input SSL object may be a QSSO or a QCSO with a default stream
+ *      attached. If no default stream is currently attached to a QCSO,
+ *      one may be auto-created if possible.
+ *
+ *      If QCTX_REMOTE_INIT is set, an auto-created default XSO is
+ *      initiated by the remote party (i.e., local party reads first).
+ *
+ *      If it is not set, an auto-created default XSO is
+ *      initiated by the local party (i.e., local party writes first).
+ *
+ *   QCTX_L
+ *      The input SSL object may be a QLSO.
+ *
+ *   QCTX_LOCK
+ *      If and only if the function returns successfully, the ctx
+ *      is guaranteed to be locked.
+ *
+ *   QCTX_IO
+ *      Begin an I/O context. If not set, begins a non-I/O context.
+ *      This determines whether SSL_get_error() is updated; the value it returns
+ *      is modified only by an I/O call.
+ *
+ */
 #define QCTX_C              (1U << 0)
 #define QCTX_S              (1U << 1)
 #define QCTX_L              (1U << 2)
@@ -204,39 +241,7 @@ static int wrong_type(const SSL *s, uint32_t flags)
  * semantics and as such, it invokes QUIC_RAISE_NON_NORMAL_ERROR() on failure.
  *
  * The flags argument controls the preconditions and postconditions of this
- * function:
- *
- *   QCTX_C
- *      The input SSL object may be a QCSO.
- *
- *   QCTX_S
- *      The input SSL object may be a QSSO or a QCSO with a default stream
- *      attached.
- *
- *      (Note this means there is no current way to require an SSL object with a
- *      QUIC stream which is not a QCSO; a QCSO with a default stream attached
- *      is always considered to satisfy QCTX_S.)
- *
- *   QCTX_AUTO_S
- *      The input SSL object may be a QSSO or a QCSO with a default stream
- *      attached. If no default stream is currently attached to a QCSO,
- *      one may be auto-created if possible.
- *
- *      If QCTX_REMOTE_INIT is set, an auto-created default XSO is
- *      initiated by the remote party (i.e., local party reads first).
- *
- *      If it is not set, an auto-created default XSO is
- *      initiated by the local party (i.e., local party writes first).
- *
- *   QCTX_L
- *      The input SSL object may be a QLSO.
- *
- *   QCTX_LOCK
- *      If and only if the function returns successfully, the ctx
- *      is guaranteed to be locked.
- *
- *   QCTX_IO
- *      Begin an I/O context. If not set, begins a non-I/O context.
+ * function. See above for the different flags.
  *
  * The fields of a QCTX are initialised as follows depending on the identity of
  * the SSL object, and assuming the preconditions demanded by the flags field as

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -364,7 +364,6 @@ err:
     return ok;
 }
 
-
 static int expect_quic_cs(const SSL *s, QCTX *ctx)
 {
     return expect_quic_as(s, ctx, QCTX_C | QCTX_S);

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -3514,10 +3514,8 @@ static int qctx_should_autotick(QCTX *ctx)
     int event_handling_mode;
     QUIC_OBJ *obj = ctx->obj;
 
-    for (; (event_handling_mode = obj->event_handling_mode)
-            == SSL_VALUE_EVENT_HANDLING_MODE_INHERIT
-            && obj->parent_obj != NULL;
-         obj = obj->parent_obj);
+    for (; (event_handling_mode = obj->event_handling_mode) == SSL_VALUE_EVENT_HANDLING_MODE_INHERIT
+           && obj->parent_obj != NULL; obj = obj->parent_obj);
 
     return event_handling_mode != SSL_VALUE_EVENT_HANDLING_MODE_EXPLICIT;
 }

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -41,8 +41,6 @@ static void qc_set_default_xso_keep_ref(QUIC_CONNECTION *qc, QUIC_XSO *xso,
 static SSL *quic_conn_stream_new(QCTX *ctx, uint64_t flags, int need_lock);
 static int quic_validate_for_write(QUIC_XSO *xso, int *err);
 static int quic_mutation_allowed(QUIC_CONNECTION *qc, int req_active);
-static int qc_blocking_mode(const QUIC_CONNECTION *qc);
-static int xso_blocking_mode(const QUIC_XSO *xso);
 static void qctx_maybe_autotick(QCTX *ctx);
 static int qctx_should_autotick(QCTX *ctx);
 
@@ -480,6 +478,16 @@ static int quic_mutation_allowed(QUIC_CONNECTION *qc, int req_active)
     return 1;
 }
 
+static int qctx_is_top_level(QCTX *ctx)
+{
+    return ctx->obj->parent_obj == NULL;
+}
+
+static int qctx_blocking(QCTX *ctx)
+{
+    return ossl_quic_obj_blocking(ctx->obj);
+}
+
 /*
  * Block until a predicate is met.
  *
@@ -585,11 +593,8 @@ SSL *ossl_quic_new(SSL_CTX *ctx)
     qc->default_stream_mode     = SSL_DEFAULT_STREAM_MODE_AUTO_BIDI;
     qc->default_ssl_mode        = qc->obj.ssl.ctx->mode;
     qc->default_ssl_options     = qc->obj.ssl.ctx->options & OSSL_QUIC_PERMITTED_OPTIONS;
-    qc->desires_blocking        = 1;
-    qc->blocking                = 0;
     qc->incoming_stream_policy  = SSL_INCOMING_STREAM_POLICY_AUTO;
     qc->last_error              = SSL_ERROR_NONE;
-    qc->last_net_bio_epoch      = UINT64_MAX;
 
     qc_update_reject_policy(qc);
 
@@ -1051,24 +1056,6 @@ static int csm_analyse_init_peer_addr(BIO *net_wbio, BIO_ADDR *peer)
     return 1;
 }
 
-static int qc_can_support_blocking_cached(QUIC_CONNECTION *qc)
-{
-    QUIC_REACTOR *rtor = ossl_quic_channel_get_reactor(qc->ch);
-
-    return ossl_quic_reactor_can_poll_r(rtor)
-        && ossl_quic_reactor_can_poll_w(rtor);
-}
-
-static void qc_update_can_support_blocking(QUIC_CONNECTION *qc)
-{
-    ossl_quic_port_update_poll_descriptors(qc->port); /* best effort */
-}
-
-static void qc_update_blocking_mode(QUIC_CONNECTION *qc)
-{
-    qc->blocking = qc->desires_blocking && qc_can_support_blocking_cached(qc);
-}
-
 static int
 quic_set0_net_rbio(QUIC_OBJ *obj, BIO *net_rbio)
 {
@@ -1165,22 +1152,20 @@ int ossl_quic_conn_get_blocking_mode(const SSL *s)
 {
     QCTX ctx;
 
-    if (!expect_quic_cs(s, &ctx))
+    if (!expect_quic_csl(s, &ctx))
         return 0;
 
-    if (ctx.is_stream)
-        return xso_blocking_mode(ctx.xso);
-
-    return qc_blocking_mode(ctx.qc);
+    return qctx_blocking(&ctx);
 }
 
 QUIC_TAKES_LOCK
 int ossl_quic_conn_set_blocking_mode(SSL *s, int blocking)
 {
     int ret = 0;
+    unsigned int mode;
     QCTX ctx;
 
-    if (!expect_quic_cs(s, &ctx))
+    if (!expect_quic_csl(s, &ctx))
         return 0;
 
     qctx_lock(&ctx);
@@ -1188,38 +1173,27 @@ int ossl_quic_conn_set_blocking_mode(SSL *s, int blocking)
     /* Sanity check - can we support the request given the current network BIO? */
     if (blocking) {
         /*
-         * If called directly on a QCSO, update our information on network BIO
-         * capabilities.
+         * If called directly on a top-level object (QCSO or QLSO), update our
+         * information on network BIO capabilities.
          */
-        if (!ctx.is_stream)
-            qc_update_can_support_blocking(ctx.qc);
+        if (qctx_is_top_level(&ctx))
+            ossl_quic_engine_update_poll_descriptors(ctx.obj->engine, /*force=*/1);
 
         /* Cannot enable blocking mode if we do not have pollable FDs. */
-        if (!qc_can_support_blocking_cached(ctx.qc)) {
+        if (!ossl_quic_obj_can_support_blocking(ctx.obj)) {
             ret = QUIC_RAISE_NON_NORMAL_ERROR(&ctx, ERR_R_UNSUPPORTED, NULL);
             goto out;
         }
     }
 
-    if (!ctx.is_stream)
-        /*
-         * If called directly on a QCSO, update default and connection-level
-         * blocking modes.
-         */
-        ctx.qc->desires_blocking = (blocking != 0);
+    mode = (blocking != 0)
+        ? QUIC_BLOCKING_MODE_BLOCKING
+        : QUIC_BLOCKING_MODE_NONBLOCKING;
 
-    if (ctx.xso != NULL) {
-        /*
-         * If called on a QSSO or a QCSO with a default XSO, update the blocking
-         * mode.
-         */
-        ctx.xso->desires_blocking       = (blocking != 0);
-        ctx.xso->desires_blocking_set   = 1;
-    }
+    ossl_quic_obj_set_blocking_mode(ctx.obj, mode);
 
     ret = 1;
 out:
-    qc_update_blocking_mode(ctx.qc);
     qctx_unlock(&ctx);
     return ret;
 }
@@ -1254,34 +1228,6 @@ int ossl_quic_conn_set_initial_peer_addr(SSL *s,
  *   (BIO/)SSL_get_poll_fd          => ossl_quic_get_poll_fd
  *
  */
-static void qc_try_update_blocking(QUIC_CONNECTION *qc)
-{
-    uint64_t cur_epoch;
-
-    cur_epoch = ossl_quic_port_get_net_bio_epoch(qc->port);
-    if (qc->last_net_bio_epoch == cur_epoch)
-        return;
-
-    qc_update_can_support_blocking(qc);
-    qc_update_blocking_mode(qc);
-    qc->last_net_bio_epoch = cur_epoch;
-}
-
-/* Returns 1 if the connection is being used in blocking mode. */
-static int qc_blocking_mode(const QUIC_CONNECTION *qc)
-{
-    qc_try_update_blocking((QUIC_CONNECTION *)qc);
-    return qc->blocking;
-}
-
-static int xso_blocking_mode(const QUIC_XSO *xso)
-{
-    if (xso->desires_blocking_set)
-        return xso->desires_blocking && qc_can_support_blocking_cached(xso->conn);
-    else
-        /* Only ever set if we can support blocking. */
-        return xso->conn->blocking;
-}
 
 /* SSL_handle_events; performs QUIC I/O and timeout processing. */
 QUIC_TAKES_LOCK
@@ -1501,7 +1447,7 @@ int ossl_quic_conn_shutdown(SSL *s, uint64_t flags,
         qc_shutdown_flush_init(ctx.qc);
 
         if (!qc_shutdown_flush_finished(ctx.qc)) {
-            if (!no_block && qc_blocking_mode(ctx.qc)) {
+            if (!no_block && qctx_blocking(&ctx)) {
                 ret = block_until_pred(&ctx, quic_shutdown_flush_wait, ctx.qc, 0);
                 if (ret < 1) {
                     ret = 0;
@@ -1520,7 +1466,7 @@ int ossl_quic_conn_shutdown(SSL *s, uint64_t flags,
 
     /* Phase 2: Connection Closure */
     if (wait_peer && !ossl_quic_channel_is_term_any(ctx.qc->ch)) {
-        if (!no_block && qc_blocking_mode(ctx.qc)) {
+        if (!no_block && qctx_blocking(&ctx)) {
             ret = block_until_pred(&ctx, quic_shutdown_peer_wait, ctx.qc, 0);
             if (ret < 1) {
                 ret = 0;
@@ -1560,7 +1506,7 @@ int ossl_quic_conn_shutdown(SSL *s, uint64_t flags,
     }
 
     /* Phase 3: Terminating Wait Time */
-    if (!no_block && qc_blocking_mode(ctx.qc)
+    if (!no_block && qctx_blocking(&ctx)
         && (flags & SSL_SHUTDOWN_FLAG_RAPID) == 0) {
         ret = block_until_pred(&ctx, quic_shutdown_wait, ctx.qc, 0);
         if (ret < 1) {
@@ -1889,7 +1835,7 @@ static int quic_do_handshake(QCTX *ctx)
         /* The handshake is now done. */
         return 1;
 
-    if (!qc_blocking_mode(qc)) {
+    if (!qctx_blocking(ctx)) {
         /* Try to advance the reactor. */
         qctx_maybe_autotick(ctx);
 
@@ -1900,7 +1846,7 @@ static int quic_do_handshake(QCTX *ctx)
         if (ossl_quic_channel_is_term_any(qc->ch)) {
             QUIC_RAISE_NON_NORMAL_ERROR(ctx, SSL_R_PROTOCOL_IS_SHUTDOWN, NULL);
             return 0;
-        } else if (qc->desires_blocking) {
+        } else if (ossl_quic_obj_desires_blocking(&qc->obj)) {
             /*
              * As a special case when doing a handshake when blocking mode is
              * desired yet not available, see if the network BIOs have become
@@ -1908,16 +1854,14 @@ static int quic_do_handshake(QCTX *ctx)
              * which do late creation of socket FDs and therefore cannot expose
              * a poll descriptor until after a network BIO is set on the QCSO.
              */
-            assert(!qc->blocking);
-            qc_update_can_support_blocking(qc);
-            qc_update_blocking_mode(qc);
+            ossl_quic_engine_update_poll_descriptors(qc->obj.engine, /*force=*/1);
         }
     }
 
     /*
      * We are either in blocking mode or just entered it due to the code above.
      */
-    if (qc_blocking_mode(qc)) {
+    if (qctx_blocking(ctx)) {
         /* In blocking mode, wait for the handshake to complete. */
         struct quic_handshake_wait_args args;
 
@@ -2107,7 +2051,7 @@ static int qc_wait_for_default_xso_for_read(QCTX *ctx, int peek)
         if (peek)
             return 0;
 
-        if (!qc_blocking_mode(qc))
+        if (!qctx_blocking(ctx))
             /* Non-blocking mode, so just bail immediately. */
             return QUIC_RAISE_NORMAL_ERROR(ctx, SSL_ERROR_WANT_READ);
 
@@ -2231,7 +2175,7 @@ static SSL *quic_conn_stream_new(QCTX *ctx, uint64_t flags, int need_lock)
          * Stream count flow control currently doesn't permit this stream to be
          * opened.
          */
-        if (no_blocking || !qc_blocking_mode(qc)) {
+        if (no_blocking || !qctx_blocking(ctx)) {
             QUIC_RAISE_NON_NORMAL_ERROR(ctx, SSL_R_STREAM_COUNT_LIMITED, NULL);
             goto err;
         }
@@ -2791,7 +2735,7 @@ int ossl_quic_write_flags(SSL *s, const void *buf, size_t len,
         goto out;
     }
 
-    if (xso_blocking_mode(ctx.xso))
+    if (qctx_blocking(&ctx))
         ret = quic_write_blocking(&ctx, buf, len, flags, written);
     else if (partial_write)
         ret = quic_write_nonblocking_epw(&ctx, buf, len, flags, written);
@@ -3001,7 +2945,7 @@ static int quic_read(SSL *s, void *buf, size_t len, size_t *bytes_read, int peek
          */
         qctx_maybe_autotick(&ctx);
         ret = 1;
-    } else if (xso_blocking_mode(ctx.xso)) {
+    } else if (qctx_blocking(&ctx)) {
         /*
          * We were not able to read anything immediately, so our stream
          * buffer is empty. This means we need to block until we get
@@ -3801,7 +3745,7 @@ SSL *ossl_quic_accept_stream(SSL *s, uint64_t flags)
 
     qs = ossl_quic_stream_map_peek_accept_queue(qsm);
     if (qs == NULL) {
-        if (qc_blocking_mode(ctx.qc)
+        if (qctx_blocking(&ctx)
             && (flags & SSL_ACCEPT_STREAM_NO_BLOCK) == 0) {
             struct wait_for_incoming_stream_args args;
 
@@ -4332,11 +4276,9 @@ static QUIC_CONNECTION *create_qc_from_incoming_conn(QUIC_LISTENER *ql, QUIC_CHA
     qc->mutex                   = ql->mutex;
 #endif
     qc->tls                     = ossl_quic_channel_get0_tls(ch);
-    qc->last_net_bio_epoch      = UINT64_MAX;
     qc->started                 = 1;
     qc->as_server               = 1;
     qc->as_server_state         = 1;
-    qc->desires_blocking        = 1;
     qc->default_stream_mode     = SSL_DEFAULT_STREAM_MODE_AUTO_BIDI;
     qc->default_ssl_options     = ql->obj.ssl.ctx->options & OSSL_QUIC_PERMITTED_OPTIONS;
     qc->incoming_stream_policy  = SSL_INCOMING_STREAM_POLICY_AUTO;

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -367,12 +367,12 @@ err:
 }
 
 
-static int expect_quic(const SSL *s, QCTX *ctx)
+static int expect_quic_cs(const SSL *s, QCTX *ctx)
 {
     return expect_quic_as(s, ctx, QCTX_C | QCTX_S);
 }
 
-static int expect_quic_any(const SSL *s, QCTX *ctx)
+static int expect_quic_csl(const SSL *s, QCTX *ctx)
 {
     return expect_quic_as(s, ctx, QCTX_C | QCTX_S | QCTX_L);
 }
@@ -383,7 +383,7 @@ static int expect_quic_listener(const SSL *s, QCTX *ctx)
 }
 
 /*
- * Like expect_quic(), but requires a QUIC_XSO be contextually available. In
+ * Like expect_quic_cs(), but requires a QUIC_XSO be contextually available. In
  * other words, requires that the passed QSO be a QSSO or a QCSO with a default
  * stream.
  *
@@ -411,7 +411,7 @@ static int ossl_unused expect_quic_with_stream_lock(const SSL *s, int remote_ini
 }
 
 /*
- * Like expect_quic(), but fails if called on a QUIC_XSO. ctx->xso may still
+ * Like expect_quic_cs(), but fails if called on a QUIC_XSO. ctx->xso may still
  * be non-NULL if the QCSO has a default stream.
  */
 static int ossl_unused expect_quic_conn_only(const SSL *s, QCTX *ctx)
@@ -671,7 +671,7 @@ void ossl_quic_free(SSL *s)
     int is_default;
 
     /* We should never be called on anything but a QSO. */
-    if (!expect_quic_any(s, &ctx))
+    if (!expect_quic_csl(s, &ctx))
         return;
 
     if (ctx.is_listener) {
@@ -779,7 +779,7 @@ int ossl_quic_reset(SSL *s)
 {
     QCTX ctx;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return 0;
 
     ERR_raise(ERR_LIB_SSL, ERR_R_UNSUPPORTED);
@@ -791,7 +791,7 @@ int ossl_quic_clear(SSL *s)
 {
     QCTX ctx;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return 0;
 
     ERR_raise(ERR_LIB_SSL, ERR_R_UNSUPPORTED);
@@ -804,7 +804,7 @@ int ossl_quic_conn_set_override_now_cb(SSL *s,
 {
     QCTX ctx;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return 0;
 
     qctx_lock(&ctx);
@@ -820,7 +820,7 @@ void ossl_quic_conn_force_assist_thread_wake(SSL *s)
 {
     QCTX ctx;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return;
 
 #if !defined(OPENSSL_NO_QUIC_THREAD_ASSIST)
@@ -927,7 +927,7 @@ static uint64_t quic_mask_or_options(SSL *ssl, uint64_t mask_value, uint64_t or_
     QCTX ctx;
     uint64_t hs_mask_value, hs_or_value, ret;
 
-    if (!expect_quic(ssl, &ctx))
+    if (!expect_quic_cs(ssl, &ctx))
         return 0;
 
     qctx_lock(&ctx);
@@ -1113,7 +1113,7 @@ void ossl_quic_conn_set0_net_rbio(SSL *s, BIO *net_rbio)
 {
     QCTX ctx;
 
-    if (!expect_quic_any(s, &ctx))
+    if (!expect_quic_csl(s, &ctx))
         return;
 
     /* Returns 0 if no change. */
@@ -1125,7 +1125,7 @@ void ossl_quic_conn_set0_net_wbio(SSL *s, BIO *net_wbio)
 {
     QCTX ctx;
 
-    if (!expect_quic_any(s, &ctx))
+    if (!expect_quic_csl(s, &ctx))
         return;
 
     /* Returns 0 if no change. */
@@ -1138,7 +1138,7 @@ BIO *ossl_quic_conn_get_net_rbio(const SSL *s)
     QCTX ctx;
     QUIC_PORT *port;
 
-    if (!expect_quic_any(s, &ctx))
+    if (!expect_quic_csl(s, &ctx))
         return NULL;
 
     port = ossl_quic_obj_get0_port(ctx.obj);
@@ -1151,7 +1151,7 @@ BIO *ossl_quic_conn_get_net_wbio(const SSL *s)
     QCTX ctx;
     QUIC_PORT *port;
 
-    if (!expect_quic_any(s, &ctx))
+    if (!expect_quic_csl(s, &ctx))
         return NULL;
 
     port = ossl_quic_obj_get0_port(ctx.obj);
@@ -1163,7 +1163,7 @@ int ossl_quic_conn_get_blocking_mode(const SSL *s)
 {
     QCTX ctx;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return 0;
 
     if (ctx.is_stream)
@@ -1178,7 +1178,7 @@ int ossl_quic_conn_set_blocking_mode(SSL *s, int blocking)
     int ret = 0;
     QCTX ctx;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return 0;
 
     qctx_lock(&ctx);
@@ -1227,7 +1227,7 @@ int ossl_quic_conn_set_initial_peer_addr(SSL *s,
 {
     QCTX ctx;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return 0;
 
     if (ctx.qc->started)
@@ -1287,7 +1287,7 @@ int ossl_quic_handle_events(SSL *s)
 {
     QCTX ctx;
 
-    if (!expect_quic_any(s, &ctx))
+    if (!expect_quic_csl(s, &ctx))
         return 0;
 
     qctx_lock(&ctx);
@@ -1309,7 +1309,7 @@ int ossl_quic_get_event_timeout(SSL *s, struct timeval *tv, int *is_infinite)
     QCTX ctx;
     OSSL_TIME deadline = ossl_time_infinite();
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return 0;
 
     qctx_lock(&ctx);
@@ -1344,7 +1344,7 @@ int ossl_quic_get_rpoll_descriptor(SSL *s, BIO_POLL_DESCRIPTOR *desc)
     QUIC_PORT *port = NULL;
     BIO *net_rbio;
 
-    if (!expect_quic_any(s, &ctx))
+    if (!expect_quic_csl(s, &ctx))
         return 0;
 
     port = ossl_quic_obj_get0_port(ctx.obj);
@@ -1363,7 +1363,7 @@ int ossl_quic_get_wpoll_descriptor(SSL *s, BIO_POLL_DESCRIPTOR *desc)
     QUIC_PORT *port = NULL;
     BIO *net_wbio;
 
-    if (!expect_quic_any(s, &ctx))
+    if (!expect_quic_csl(s, &ctx))
         return 0;
 
     port = ossl_quic_obj_get0_port(ctx.obj);
@@ -1382,7 +1382,7 @@ int ossl_quic_get_net_read_desired(SSL *s)
     QCTX ctx;
     int ret;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return 0;
 
     qctx_lock(&ctx);
@@ -1398,7 +1398,7 @@ int ossl_quic_get_net_write_desired(SSL *s)
     int ret;
     QCTX ctx;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return 0;
 
     qctx_lock(&ctx);
@@ -1479,7 +1479,7 @@ int ossl_quic_conn_shutdown(SSL *s, uint64_t flags,
     int no_block = ((flags & SSL_SHUTDOWN_FLAG_NO_BLOCK) != 0);
     int wait_peer = ((flags & SSL_SHUTDOWN_FLAG_WAIT_PEER) != 0);
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return -1;
 
     if (ctx.is_stream) {
@@ -1580,7 +1580,7 @@ long ossl_quic_ctrl(SSL *s, int cmd, long larg, void *parg)
 {
     QCTX ctx;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return 0;
 
     switch (cmd) {
@@ -1658,7 +1658,7 @@ void ossl_quic_set_connect_state(SSL *s)
 {
     QCTX ctx;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return;
 
     /* Cannot be changed after handshake started */
@@ -1673,7 +1673,7 @@ void ossl_quic_set_accept_state(SSL *s)
 {
     QCTX ctx;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return;
 
     /* Cannot be changed after handshake started */
@@ -1946,7 +1946,7 @@ int ossl_quic_do_handshake(SSL *s)
     int ret;
     QCTX ctx;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return 0;
 
     qctx_lock_for_io(&ctx);
@@ -2299,7 +2299,7 @@ int ossl_quic_get_error(const SSL *s, int i)
     QCTX ctx;
     int net_error, last_error;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return 0;
 
     qctx_lock(&ctx);
@@ -2346,7 +2346,7 @@ int ossl_quic_want(const SSL *s)
     QCTX ctx;
     int w;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return SSL_NOTHING;
 
     qctx_lock(&ctx);
@@ -2944,7 +2944,7 @@ static int quic_read(SSL *s, void *buf, size_t len, size_t *bytes_read, int peek
 
     *bytes_read = 0;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return 0;
 
     qctx_lock_for_io(&ctx);
@@ -3055,7 +3055,7 @@ static size_t ossl_quic_pending_int(const SSL *s, int check_channel)
     QCTX ctx;
     size_t avail = 0;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return 0;
 
     qctx_lock(&ctx);
@@ -3151,7 +3151,7 @@ int SSL_inject_net_dgram(SSL *s, const unsigned char *buf,
     QCTX ctx;
     QUIC_DEMUX *demux;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return 0;
 
     qctx_lock(&ctx);
@@ -3171,7 +3171,7 @@ SSL *ossl_quic_get0_connection(SSL *s)
 {
     QCTX ctx;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return NULL;
 
     return &ctx.qc->obj.ssl;
@@ -3185,7 +3185,7 @@ SSL *ossl_quic_get0_listener(SSL *s)
 {
     QCTX ctx;
 
-    if (!expect_quic_any(s, &ctx))
+    if (!expect_quic_csl(s, &ctx))
         return NULL;
 
     return ctx.ql != NULL ? &ctx.ql->obj.ssl : NULL;
@@ -3199,7 +3199,7 @@ int ossl_quic_get_stream_type(SSL *s)
 {
     QCTX ctx;
 
-    if (!expect_quic(s, &ctx))
+    if (!expect_quic_cs(s, &ctx))
         return SSL_STREAM_TYPE_BIDI;
 
     if (ctx.xso == NULL) {
@@ -3648,7 +3648,7 @@ static int expect_quic_for_value(SSL *s, QCTX *ctx, uint32_t id)
     case SSL_VALUE_STREAM_WRITE_BUF_SIZE:
     case SSL_VALUE_STREAM_WRITE_BUF_USED:
     case SSL_VALUE_STREAM_WRITE_BUF_AVAIL:
-        return expect_quic(s, ctx);
+        return expect_quic_cs(s, ctx);
     default:
         return expect_quic_conn_only(s, ctx);
     }
@@ -4524,7 +4524,7 @@ int ossl_quic_conn_poll_events(SSL *ssl, uint64_t events, int do_tick,
     QCTX ctx;
     uint64_t revents = 0;
 
-    if (!expect_quic(ssl, &ctx))
+    if (!expect_quic_cs(ssl, &ctx))
         return 0;
 
     qctx_lock(&ctx);

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -313,7 +313,7 @@ static int expect_quic_as(const SSL *s, QCTX *ctx, uint32_t flags)
                 goto err;
 
             if ((flags & QCTX_REMOTE_INIT) != 0) {
-                if (!qc_wait_for_default_xso_for_read(ctx))
+                if (!qc_wait_for_default_xso_for_read(ctx, /*peek=*/0))
                     goto err;
             } else {
                 if (!qc_try_create_default_xso_for_write(ctx))
@@ -2688,7 +2688,7 @@ int ossl_quic_write_flags(SSL *s, const void *buf, size_t len,
 
     if (len == 0) {
         /* Do not autocreate default XSO for zero-length writes. */
-        if (!expect_quic(s, &ctx))
+        if (!expect_quic_cs(s, &ctx))
             return 0;
 
         qctx_lock_for_io(&ctx);

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -377,6 +377,8 @@ static int expect_quic_csl(const SSL *s, QCTX *ctx)
     return expect_quic_as(s, ctx, QCTX_C | QCTX_S | QCTX_L);
 }
 
+#define expect_quic_any expect_quic_csl
+
 static int expect_quic_listener(const SSL *s, QCTX *ctx)
 {
     return expect_quic_as(s, ctx, QCTX_L);
@@ -671,7 +673,7 @@ void ossl_quic_free(SSL *s)
     int is_default;
 
     /* We should never be called on anything but a QSO. */
-    if (!expect_quic_csl(s, &ctx))
+    if (!expect_quic_any(s, &ctx))
         return;
 
     if (ctx.is_listener) {
@@ -779,7 +781,7 @@ int ossl_quic_reset(SSL *s)
 {
     QCTX ctx;
 
-    if (!expect_quic_cs(s, &ctx))
+    if (!expect_quic_any(s, &ctx))
         return 0;
 
     ERR_raise(ERR_LIB_SSL, ERR_R_UNSUPPORTED);
@@ -791,7 +793,7 @@ int ossl_quic_clear(SSL *s)
 {
     QCTX ctx;
 
-    if (!expect_quic_cs(s, &ctx))
+    if (!expect_quic_any(s, &ctx))
         return 0;
 
     ERR_raise(ERR_LIB_SSL, ERR_R_UNSUPPORTED);
@@ -804,7 +806,7 @@ int ossl_quic_conn_set_override_now_cb(SSL *s,
 {
     QCTX ctx;
 
-    if (!expect_quic_cs(s, &ctx))
+    if (!expect_quic_conn_only(s, &ctx))
         return 0;
 
     qctx_lock(&ctx);
@@ -820,7 +822,7 @@ void ossl_quic_conn_force_assist_thread_wake(SSL *s)
 {
     QCTX ctx;
 
-    if (!expect_quic_cs(s, &ctx))
+    if (!expect_quic_conn_only(s, &ctx))
         return;
 
 #if !defined(OPENSSL_NO_QUIC_THREAD_ASSIST)
@@ -1287,7 +1289,7 @@ int ossl_quic_handle_events(SSL *s)
 {
     QCTX ctx;
 
-    if (!expect_quic_csl(s, &ctx))
+    if (!expect_quic_any(s, &ctx))
         return 0;
 
     qctx_lock(&ctx);
@@ -1309,7 +1311,7 @@ int ossl_quic_get_event_timeout(SSL *s, struct timeval *tv, int *is_infinite)
     QCTX ctx;
     OSSL_TIME deadline = ossl_time_infinite();
 
-    if (!expect_quic_cs(s, &ctx))
+    if (!expect_quic_any(s, &ctx))
         return 0;
 
     qctx_lock(&ctx);
@@ -1382,7 +1384,7 @@ int ossl_quic_get_net_read_desired(SSL *s)
     QCTX ctx;
     int ret;
 
-    if (!expect_quic_cs(s, &ctx))
+    if (!expect_quic_csl(s, &ctx))
         return 0;
 
     qctx_lock(&ctx);
@@ -1398,7 +1400,7 @@ int ossl_quic_get_net_write_desired(SSL *s)
     int ret;
     QCTX ctx;
 
-    if (!expect_quic_cs(s, &ctx))
+    if (!expect_quic_csl(s, &ctx))
         return 0;
 
     qctx_lock(&ctx);
@@ -1580,11 +1582,14 @@ long ossl_quic_ctrl(SSL *s, int cmd, long larg, void *parg)
 {
     QCTX ctx;
 
-    if (!expect_quic_cs(s, &ctx))
+    if (!expect_quic_csl(s, &ctx))
         return 0;
 
     switch (cmd) {
     case SSL_CTRL_MODE:
+        if (ctx.is_listener)
+            return QUIC_RAISE_NON_NORMAL_ERROR(&ctx, ERR_R_UNSUPPORTED, NULL);
+
         /* If called on a QCSO, update the default mode. */
         if (!ctx.is_stream)
             ctx.qc->default_ssl_mode |= (uint32_t)larg;
@@ -1604,6 +1609,9 @@ long ossl_quic_ctrl(SSL *s, int cmd, long larg, void *parg)
 
         return ctx.qc->default_ssl_mode;
     case SSL_CTRL_CLEAR_MODE:
+        if (ctx.is_listener)
+            return QUIC_RAISE_NON_NORMAL_ERROR(&ctx, ERR_R_UNSUPPORTED, NULL);
+
         if (!ctx.is_stream)
             ctx.qc->default_ssl_mode &= ~(uint32_t)larg;
 
@@ -1615,6 +1623,9 @@ long ossl_quic_ctrl(SSL *s, int cmd, long larg, void *parg)
         return ctx.qc->default_ssl_mode;
 
     case SSL_CTRL_SET_MSG_CALLBACK_ARG:
+        if (ctx.is_listener)
+            return QUIC_RAISE_NON_NORMAL_ERROR(&ctx, ERR_R_UNSUPPORTED, NULL);
+
         ossl_quic_channel_set_msg_callback_arg(ctx.qc->ch, parg);
         /* This ctrl also needs to be passed to the internal SSL object */
         return SSL_ctrl(ctx.qc->tls, cmd, larg, parg);
@@ -1649,6 +1660,9 @@ long ossl_quic_ctrl(SSL *s, int cmd, long larg, void *parg)
          * supported by anything, the handshake layer's ctrl method will finally
          * return 0.
          */
+        if (ctx.is_listener)
+            return QUIC_RAISE_NON_NORMAL_ERROR(&ctx, ERR_R_UNSUPPORTED, NULL);
+
         return ossl_ctrl_internal(&ctx.qc->obj.ssl, cmd, larg, parg, /*no_quic=*/1);
     }
 }
@@ -3147,7 +3161,7 @@ int SSL_inject_net_dgram(SSL *s, const unsigned char *buf,
                          const BIO_ADDR *peer,
                          const BIO_ADDR *local)
 {
-    int ret;
+    int ret = 0;
     QCTX ctx;
     QUIC_DEMUX *demux;
 
@@ -3156,9 +3170,16 @@ int SSL_inject_net_dgram(SSL *s, const unsigned char *buf,
 
     qctx_lock(&ctx);
 
-    demux = ossl_quic_channel_get0_demux(ctx.qc->ch);
+    if (ctx.obj->port == NULL) {
+        QUIC_RAISE_NON_NORMAL_ERROR(&ctx, ERR_R_UNSUPPORTED, NULL);
+        goto err;
+    }
+
+    demux = ossl_quic_port_get0_demux(ctx.obj->port);
     ret = ossl_quic_demux_inject(demux, buf, buf_len, peer, local);
 
+    ret = 1;
+err:
     qctx_unlock(&ctx);
     return ret;
 }
@@ -4524,6 +4545,7 @@ int ossl_quic_conn_poll_events(SSL *ssl, uint64_t events, int do_tick,
     QCTX ctx;
     uint64_t revents = 0;
 
+    /* TODO(QUIC SERVER): Support listeners */
     if (!expect_quic_cs(ssl, &ctx))
         return 0;
 

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -2050,9 +2050,12 @@ static int qc_wait_for_default_xso_for_read(QCTX *ctx, int peek)
         if (peek)
             return 0;
 
-        if (!qctx_blocking(ctx))
+        if (ossl_quic_channel_is_term_any(qc->ch)) {
+            return QUIC_RAISE_NON_NORMAL_ERROR(ctx, SSL_R_PROTOCOL_IS_SHUTDOWN, NULL);
+        } else if (!qctx_blocking(ctx)) {
             /* Non-blocking mode, so just bail immediately. */
             return QUIC_RAISE_NORMAL_ERROR(ctx, SSL_ERROR_WANT_READ);
+        }
 
         /* Block until we have a stream. */
         wargs.qc        = qc;

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4199,12 +4199,27 @@ int ossl_quic_listen(SSL *ssl)
  * SSL_accept_connection
  * ---------------------
  */
+static int quic_accept_connection_wait(void *arg)
+{
+    QUIC_PORT *port = arg;
+
+    if (!ossl_quic_port_is_running(port))
+        return -1;
+
+    if (ossl_quic_port_have_incoming(port))
+        return 1;
+
+    return 0;
+}
+
 QUIC_TAKES_LOCK
 SSL *ossl_quic_accept_connection(SSL *ssl, uint64_t flags)
 {
+    int ret;
     QCTX ctx;
     QUIC_CONNECTION *qc = NULL;
     QUIC_CHANNEL *new_ch = NULL;
+    int no_block = ((flags & SSL_ACCEPT_CONNECTION_NO_BLOCK) != 0);
 
     if (!expect_quic_listener(ssl, &ctx))
         return NULL;
@@ -4214,11 +4229,25 @@ SSL *ossl_quic_accept_connection(SSL *ssl, uint64_t flags)
     if (!ql_listen(ctx.ql))
         goto out;
 
-    /* TODO(QUIC SERVER): Autotick */
-    /* TODO(QUIC SERVER): Implement blocking and SSL_ACCEPT_CONNECTION_NO_BLOCK */
-
+    /* Wait for an incoming connection if needed. */
     new_ch = ossl_quic_port_pop_incoming(ctx.ql->port);
-    if (new_ch == NULL) {
+    if (new_ch == NULL && ossl_quic_port_is_running(ctx.ql->port)) {
+        if (!no_block && qctx_blocking(&ctx)) {
+            ret = block_until_pred(&ctx, quic_accept_connection_wait,
+                                   ctx.ql->port, 0);
+            if (ret < 1)
+                goto out;
+        } else {
+            qctx_maybe_autotick(&ctx);
+        }
+
+        if (!ossl_quic_port_is_running(ctx.ql->port))
+            goto out;
+
+        new_ch = ossl_quic_port_pop_incoming(ctx.ql->port);
+    }
+
+    if (new_ch == NULL && ossl_quic_port_is_running(ctx.ql->port)) {
         /* No connections already queued. */
         ossl_quic_reactor_tick(ossl_quic_engine_get0_reactor(ctx.ql->engine), 0);
 

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -3501,14 +3501,13 @@ QUIC_NEEDS_LOCK
 static int qctx_should_autotick(QCTX *ctx)
 {
     int event_handling_mode;
+    QUIC_OBJ *obj = ctx->obj;
 
-    if (ctx->is_stream) {
-        event_handling_mode = ctx->xso->event_handling_mode;
-        if (event_handling_mode != SSL_VALUE_EVENT_HANDLING_MODE_INHERIT)
-            return event_handling_mode != SSL_VALUE_EVENT_HANDLING_MODE_EXPLICIT;
-    }
+    for (; (event_handling_mode = obj->event_handling_mode)
+            == SSL_VALUE_EVENT_HANDLING_MODE_INHERIT
+            && obj->parent_obj != NULL;
+         obj = obj->parent_obj);
 
-    event_handling_mode = ctx->qc->event_handling_mode;
     return event_handling_mode != SSL_VALUE_EVENT_HANDLING_MODE_EXPLICIT;
 }
 
@@ -3518,7 +3517,7 @@ static void qctx_maybe_autotick(QCTX *ctx)
     if (!qctx_should_autotick(ctx))
         return;
 
-    ossl_quic_reactor_tick(ossl_quic_channel_get_reactor(ctx->qc->ch), 0);
+    ossl_quic_reactor_tick(ossl_quic_obj_get0_reactor(ctx->obj), 0);
 }
 
 QUIC_TAKES_LOCK
@@ -3550,14 +3549,9 @@ static int qc_getset_event_handling(QCTX *ctx, uint32_t class_,
         }
 
         value_out = *p_value_in;
-        if (ctx->is_stream)
-            ctx->xso->event_handling_mode = (int)value_out;
-        else
-            ctx->qc->event_handling_mode = (int)value_out;
+        ctx->obj->event_handling_mode = (int)value_out;
     } else {
-        value_out = ctx->is_stream
-            ? ctx->xso->event_handling_mode
-            : ctx->qc->event_handling_mode;
+        value_out = ctx->obj->event_handling_mode;
     }
 
     ret = 1;

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4191,7 +4191,7 @@ int ossl_quic_listen(SSL *ssl)
     if (!expect_quic_listener(ssl, &ctx))
         return 0;
 
-    qctx_lock(&ctx);
+    qctx_lock_for_io(&ctx);
 
     ret = ql_listen(ctx.ql);
 
@@ -4228,7 +4228,7 @@ SSL *ossl_quic_accept_connection(SSL *ssl, uint64_t flags)
     if (!expect_quic_listener(ssl, &ctx))
         return NULL;
 
-    qctx_lock(&ctx);
+    qctx_lock_for_io(&ctx);
 
     if (!ql_listen(ctx.ql))
         goto out;

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -2906,11 +2906,6 @@ static int quic_read(SSL *s, void *buf, size_t len, size_t *bytes_read, int peek
 
     qctx_lock_for_io(&ctx);
 
-    if (!quic_mutation_allowed(ctx.qc, /*req_active=*/0)) {
-        ret = QUIC_RAISE_NON_NORMAL_ERROR(&ctx, SSL_R_PROTOCOL_IS_SHUTDOWN, NULL);
-        goto out;
-    }
-
     /* If we haven't finished the handshake, try to advance it. */
     if (quic_do_handshake(&ctx) < 1) {
         ret = 0; /* ossl_quic_do_handshake raised error here */
@@ -2942,8 +2937,13 @@ static int quic_read(SSL *s, void *buf, size_t len, size_t *bytes_read, int peek
          * Even though we succeeded, tick the reactor here to ensure we are
          * handling other aspects of the QUIC connection.
          */
-        qctx_maybe_autotick(&ctx);
+        if (quic_mutation_allowed(ctx.qc, /*req_active=*/0))
+            qctx_maybe_autotick(&ctx);
+
         ret = 1;
+    } else if (!quic_mutation_allowed(ctx.qc, /*req_active=*/0)) {
+        ret = QUIC_RAISE_NON_NORMAL_ERROR(&ctx, SSL_R_PROTOCOL_IS_SHUTDOWN, NULL);
+        goto out;
     } else if (qctx_blocking(&ctx)) {
         /*
          * We were not able to read anything immediately, so our stream

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -3110,18 +3110,20 @@ int SSL_inject_net_dgram(SSL *s, const unsigned char *buf,
     int ret = 0;
     QCTX ctx;
     QUIC_DEMUX *demux;
+    QUIC_PORT *port;
 
-    if (!expect_quic_cs(s, &ctx))
+    if (!expect_quic_csl(s, &ctx))
         return 0;
 
     qctx_lock(&ctx);
 
-    if (ctx.obj->port == NULL) {
+    port = ossl_quic_obj_get0_port(ctx.obj);
+    if (port == NULL) {
         QUIC_RAISE_NON_NORMAL_ERROR(&ctx, ERR_R_UNSUPPORTED, NULL);
         goto err;
     }
 
-    demux = ossl_quic_port_get0_demux(ctx.obj->port);
+    demux = ossl_quic_port_get0_demux(port);
     ret = ossl_quic_demux_inject(demux, buf, buf_len, peer, local);
 
     ret = 1;

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -72,9 +72,6 @@ struct quic_xso_st {
     /* Is an AON write in progress? */
     unsigned int                    aon_write_in_progress   : 1;
 
-    /* Event handling mode. One of SSL_QUIC_VALUE_EVENT_HANDLING. */
-    unsigned int                    event_handling_mode     : 2;
-
     /*
      * The base buffer pointer the caller passed us for the initial AON write
      * call. We use this for validation purposes unless
@@ -208,9 +205,6 @@ struct quic_conn_st {
     /* Are we using addressed mode (BIO_sendmmsg with non-NULL peer)? */
     unsigned int                    addressed_mode_w        : 1;
     unsigned int                    addressed_mode_r        : 1;
-
-    /* Event handling mode. One of SSL_QUIC_VALUE_EVENT_HANDLING. */
-    unsigned int                    event_handling_mode     : 2;
 
     /* Default stream type. Defaults to SSL_DEFAULT_STREAM_MODE_AUTO_BIDI. */
     uint32_t                        default_stream_mode;

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -42,19 +42,6 @@ struct quic_xso_st {
     /* The stream object. Always non-NULL for as long as the XSO exists. */
     QUIC_STREAM                     *stream;
 
-    /*
-     * Has this stream been logically configured into blocking mode? Only
-     * meaningful if desires_blocking_set is 1. Ignored if blocking is not
-     * currently possible given QUIC_CONNECTION configuration.
-     */
-    unsigned int                    desires_blocking        : 1;
-
-    /*
-     * Has SSL_set_blocking_mode been called on this stream? If not set, we
-     * inherit from the QUIC_CONNECTION blocking state.
-     */
-    unsigned int                    desires_blocking_set    : 1;
-
     /* The application has retired a FIN (i.e. SSL_ERROR_ZERO_RETURN). */
     unsigned int                    retired_fin             : 1;
 
@@ -205,12 +192,6 @@ struct quic_conn_st {
     /* Are we using thread assisted mode? Never changes after init. */
     unsigned int                    is_thread_assisted      : 1;
 
-    /* Do connection-level operations (e.g. handshakes) run in blocking mode? */
-    unsigned int                    blocking                : 1;
-
-    /* Does the application want blocking mode? */
-    unsigned int                    desires_blocking        : 1;
-
     /* Have we created a default XSO yet? */
     unsigned int                    default_xso_created     : 1;
 
@@ -243,11 +224,6 @@ struct quic_conn_st {
     /* SSL_set_incoming_stream_policy. */
     int                             incoming_stream_policy;
     uint64_t                        incoming_stream_aec;
-
-    /*
-     * Last network BIO epoch at which blocking mode compatibility was checked.
-     */
-    uint64_t                        last_net_bio_epoch;
 
     /*
      * Last 'normal' error during an app-level I/O operation, used by

--- a/ssl/quic/quic_obj.c
+++ b/ssl/quic/quic_obj.c
@@ -81,9 +81,9 @@ static int obj_update_cache(QUIC_OBJ *obj)
 
 SSL_CONNECTION *ossl_quic_obj_get0_handshake_layer(QUIC_OBJ *obj)
 {
-    assert(obj->init_done);
+    assert(obj != NULL && obj->init_done);
 
-    if (obj == NULL || obj->ssl.type != SSL_TYPE_QUIC_CONNECTION)
+    if (obj->ssl.type != SSL_TYPE_QUIC_CONNECTION)
         return NULL;
 
     return SSL_CONNECTION_FROM_SSL_ONLY(((QUIC_CONNECTION *)obj)->tls);
@@ -92,7 +92,10 @@ SSL_CONNECTION *ossl_quic_obj_get0_handshake_layer(QUIC_OBJ *obj)
 /* (Returns a cached result.) */
 int ossl_quic_obj_can_support_blocking(const QUIC_OBJ *obj)
 {
-    QUIC_REACTOR *rtor = ossl_quic_obj_get0_reactor(obj);
+    QUIC_REACTOR *rtor;
+
+    assert(obj != NULL);
+    rtor = ossl_quic_obj_get0_reactor(obj);
 
     return ossl_quic_reactor_can_poll_r(rtor)
         || ossl_quic_reactor_can_poll_w(rtor);
@@ -102,6 +105,7 @@ int ossl_quic_obj_desires_blocking(const QUIC_OBJ *obj)
 {
     unsigned int req_blocking_mode;
 
+    assert(obj != NULL);
     for (; (req_blocking_mode = obj->req_blocking_mode)
             == QUIC_BLOCKING_MODE_INHERIT && obj->parent_obj != NULL;
          obj = obj->parent_obj);
@@ -111,6 +115,8 @@ int ossl_quic_obj_desires_blocking(const QUIC_OBJ *obj)
 
 int ossl_quic_obj_blocking(const QUIC_OBJ *obj)
 {
+    assert(obj != NULL);
+
     if (!ossl_quic_obj_desires_blocking(obj))
         return 0;
 
@@ -121,5 +127,7 @@ int ossl_quic_obj_blocking(const QUIC_OBJ *obj)
 
 void ossl_quic_obj_set_blocking_mode(QUIC_OBJ *obj, unsigned int mode)
 {
+    assert(obj != NULL);
+
     obj->req_blocking_mode = mode;
 }

--- a/ssl/quic/quic_obj.c
+++ b/ssl/quic/quic_obj.c
@@ -106,9 +106,8 @@ int ossl_quic_obj_desires_blocking(const QUIC_OBJ *obj)
     unsigned int req_blocking_mode;
 
     assert(obj != NULL);
-    for (; (req_blocking_mode = obj->req_blocking_mode)
-            == QUIC_BLOCKING_MODE_INHERIT && obj->parent_obj != NULL;
-         obj = obj->parent_obj);
+    for (; (req_blocking_mode = obj->req_blocking_mode) == QUIC_BLOCKING_MODE_INHERIT
+           && obj->parent_obj != NULL; obj = obj->parent_obj);
 
     return req_blocking_mode != QUIC_BLOCKING_MODE_NONBLOCKING;
 }

--- a/ssl/quic/quic_obj_local.h
+++ b/ssl/quic/quic_obj_local.h
@@ -109,6 +109,9 @@ struct quic_obj_st {
      * by default inherits from the parent SSL object.
      */
     unsigned int            req_blocking_mode       : 2; /* QUIC_BLOCKING_MODE */
+
+    /* Event handling mode. One of SSL_QUIC_VALUE_EVENT_HANDLING. */
+    unsigned int            event_handling_mode     : 2;
 };
 
 enum {

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -475,7 +475,7 @@ void ossl_quic_port_subtick(QUIC_PORT *port, QUIC_TICK_RESULT *res,
 {
     QUIC_CHANNEL *ch;
 
-    res->net_read_desired   = 0;
+    res->net_read_desired   = ossl_quic_port_is_running(port);
     res->net_write_desired  = 0;
     res->tick_deadline      = ossl_time_infinite();
 

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -435,6 +435,11 @@ QUIC_CHANNEL *ossl_quic_port_pop_incoming(QUIC_PORT *port)
     return ch;
 }
 
+int ossl_quic_port_have_incoming(QUIC_PORT *port)
+{
+    return ossl_list_incoming_ch_head(&port->incoming_channel_list) != NULL;
+}
+
 void ossl_quic_port_drop_incoming(QUIC_PORT *port)
 {
     QUIC_CHANNEL *ch;

--- a/ssl/quic/quic_port_local.h
+++ b/ssl/quic/quic_port_local.h
@@ -81,9 +81,6 @@ struct quic_port_st {
     /* Port-level permanent errors (causing failure state) are stored here. */
     ERR_STATE                       *err_state;
 
-    /* Network BIO epoch. Increments whenever network BIO config changes. */
-    uint64_t                        net_bio_epoch;
-
     /* DCID length used for incoming short header packets. */
     unsigned char                   rx_short_dcid_len;
     /* For clients, CID length used for outgoing Initial packets. */
@@ -107,6 +104,9 @@ struct quic_port_st {
     /* Are we using addressed mode (BIO_sendmmsg with non-NULL peer)? */
     unsigned int                    addressed_mode_w                : 1;
     unsigned int                    addressed_mode_r                : 1;
+
+    /* Has the BIO been changed since we last updated reactor pollability? */
+    unsigned int                    bio_changed                     : 1;
 };
 
 # endif

--- a/test/radix/quic_ops.c
+++ b/test/radix/quic_ops.c
@@ -266,7 +266,7 @@ DEF_FUNC(hf_accept_conn_none)
 
     REQUIRE_SSL(listener);
 
-    conn = SSL_accept_connection(listener, 0);
+    conn = SSL_accept_connection(listener, SSL_ACCEPT_CONNECTION_NO_BLOCK);
     if (!TEST_ptr_null(conn)) {
         SSL_free(conn);
         goto err;


### PR DESCRIPTION
This PR, which incorporates all the changes in https://github.com/openssl/openssl/pull/23995, makes further refinements and refactoring sufficient to support a minimal server API usage demo in blocking mode.

A demo is included and works with `s_client`.

Fixes https://github.com/openssl/project/issues/523