### PR TITLE
Limit key checks in the decoder fuzzer

### DIFF
--- a/doc/man3/EVP_PKEY_check.pod
+++ b/doc/man3/EVP_PKEY_check.pod
@@ -61,6 +61,11 @@ It is not necessary to call these functions after locally calling an approved ke
 generation method, but may be required for assurance purposes when receiving
 keys from a third party.
 
+The EVP_PKEY_pairwise_check() and EVP_PKEY_private_check() might not be bounded
+by any key size limits as private keys are not expected to be supplied by
+attackers. For that reason they might take an unbounded time if run on
+arbitrarily large keys.
+
 =head1 RETURN VALUES
 
 All functions return 1 for success or others for failure.

--- a/fuzz/decoder.c
+++ b/fuzz/decoder.c
@@ -64,10 +64,19 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
         EVP_PKEY_free(pkey2);
 
         ctx = EVP_PKEY_CTX_new(pkey, NULL);
-        EVP_PKEY_param_check(ctx);
+        /*
+         * Param check will take too long time on large DH parameters.
+         * Skip it.
+         */
+        if (!EVP_PKEY_is_a(pkey, "DH") || EVP_PKEY_get_bits(pkey) <= 8192)
+            EVP_PKEY_param_check(ctx);
+
         EVP_PKEY_public_check(ctx);
-        EVP_PKEY_private_check(ctx);
-        EVP_PKEY_pairwise_check(ctx);
+        /* Private and pairwise checks are unbounded, skip for large keys. */
+        if (EVP_PKEY_get_bits(pkey) <= 16384) {
+            EVP_PKEY_private_check(ctx);
+            EVP_PKEY_pairwise_check(ctx);
+        }
         OPENSSL_assert(ctx != NULL);
         EVP_PKEY_CTX_free(ctx);
         EVP_PKEY_free(pkey);


### PR DESCRIPTION
In particular the DH safe prime check will be limited to 8192 bits and the private and pairwise checks are limited to 16384 bits on any key types.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
