### PR TITLE
Update openssl-smime.pod.in

### DIFF
--- a/doc/man1/openssl-smime.pod.in
+++ b/doc/man1/openssl-smime.pod.in
@@ -197,14 +197,14 @@ Don't try to verify the signatures on the message.
 
 =item B<-nocerts>
 
-When signing a message the signer's certificate is normally included
-with this option it is excluded. This will reduce the size of the
-signed message but the verifier must have a copy of the signers certificate
+When signing a message, the signer's certificate is normally included.
+With this option it is excluded. This will reduce the size of the
+signed message, but the verifier must have a copy of the signers certificate
 available locally (passed using the B<-certfile> option for example).
 
 =item B<-noattr>
 
-Normally when a message is signed a set of attributes are included which
+Normally, when a message is signed, a set of attributes are included which
 include the signing time and supported symmetric algorithms. With this
 option they are not included.
 

--- a/doc/man1/openssl-smime.pod.in
+++ b/doc/man1/openssl-smime.pod.in
@@ -245,14 +245,6 @@ used multiple times if more than one signer is required. If a message is being
 verified then the signers certificates will be written to this file if the
 verification was successful.
 
-=item B<-nocerts>
-
-Don't include signers certificate when signing.
-
-=item B<-noattr>
-
-Don't include any signed attributes when signing.
-
 =item B<-recip> I<file>
 
 The recipients certificate when decrypting a message. This certificate


### PR DESCRIPTION
remove duplicate entries for -nocerts and -noattr

The manpage for _openssl-smime_ shows two entries for -nocerts and -noattr, respectively. One set of them (l. 198 ff) is quite exhaustive, the second one merely mentions the existence, and thus is redundant.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
- [ ] tests are added or updated

CLA: trivial