### PR TITLE
Fixes #23386 Update test_strn_eq and test_strn_ne

### DIFF
--- a/test/testutil/tests.c
+++ b/test/testutil/tests.c
@@ -306,8 +306,11 @@ int test_strn_eq(const char *file, int line, const char *st1, const char *st2,
                  const char *s1, size_t n1, const char *s2, size_t n2)
 {
     if (s1 == NULL && s2 == NULL)
-      return 1;
-    if (n1 != n2 || s1 == NULL || s2 == NULL || strncmp(s1, s2, n1) != 0) {
+        return 1;
+    if (s1 == NULL || s2 == NULL ||
+        (n1 != n2 && OPENSSL_strnlen(s1, n1) != OPENSSL_strnlen(s2, n2)) ||
+        strncmp(s1, s2, n1) != 0)
+    {
         test_fail_string_message(NULL, file, line, "string", st1, st2, "==",
                                  s1, s1 == NULL ? 0 : OPENSSL_strnlen(s1, n1),
                                  s2, s2 == NULL ? 0 : OPENSSL_strnlen(s2, n2));
@@ -321,7 +324,10 @@ int test_strn_ne(const char *file, int line, const char *st1, const char *st2,
 {
     if ((s1 == NULL) ^ (s2 == NULL))
       return 1;
-    if (n1 != n2 || s1 == NULL || strncmp(s1, s2, n1) == 0) {
+    if (n1 != n2 && OPENSSL_strnlen(s1, n1) != OPENSSL_strnlen(s2, n2)) {
+        return 1;
+    }
+    if (s1 == NULL || strncmp(s1, s2, n1) == 0) {
         test_fail_string_message(NULL, file, line, "string", st1, st2, "!=",
                                  s1, s1 == NULL ? 0 : OPENSSL_strnlen(s1, n1),
                                  s2, s2 == NULL ? 0 : OPENSSL_strnlen(s2, n2));


### PR DESCRIPTION
Fixes #23386 to handle string tests of different lengths

CLA: trivial

@bbbrumley 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

