### PR TITLE
correct example of ossl_store

### DIFF
--- a/doc/man7/ossl_store.pod
+++ b/doc/man7/ossl_store.pod
@@ -44,7 +44,11 @@ other encoding is undefined.
 
 =head2 A generic call
 
- OSSL_STORE_CTX *ctx = OSSL_STORE_open("file:/foo/bar/data.pem");
+ #include <openssl/ui.h> /* for UI_get_default_method */
+ #include <openssl/store.h>
+
+ OSSL_STORE_CTX *ctx = OSSL_STORE_open("file:/foo/bar/data.pem",
+                        UI_get_default_method(), NULL, NULL, NULL);
 
  /*
   * OSSL_STORE_eof() simulates file semantics for any repository to signal
@@ -65,6 +69,7 @@ other encoding is undefined.
          PEM_write_X509(stdout, OSSL_STORE_INFO_get0_CERT(info));
          break;
      }
+     OSSL_STORE_INFO_free(info);
  }
 
  OSSL_STORE_close(ctx);


### PR DESCRIPTION
I digged in git history didn't find a time where this proto of `OSSL_STORE_open` was valid. I also saw this snippet https://github.com/openssl/openssl/blob/0d2a5f600c7b6bef6fa6cf720204876560a6194b/crypto/x509/by_store.c#L53-L55 this seems to workaround [this bug](https://github.com/openssl/openssl/issues/20472). If the bug is fixed we could use the `OSSL_STORE_eof` like the example to better dogfooding.

I also added [`OSSL_STORE_INFO_free`](https://github.com/openssl/openssl/blob/0d2a5f600c7b6bef6fa6cf720204876560a6194b/apps/storeutl.c#L486C9-L486C29) like the storeutl.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

One force push is to add `CLA: trivial` and the other is to add a GPG signature even if GitHub say they are identical.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is updated (yes because it is only a documentation change)
