### PR TITLE
crypto/rand: implement Jitter Entropy based random seed source

### DIFF
--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -191,6 +191,32 @@ jobs:
       if: steps.sctp_auth.outcome == 'success' && steps.sctp_auth.conclusion == 'success'
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
+  rand_seed_jitter:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout openssl
+      uses: actions/checkout@v4
+    - name: checkout jitter
+      uses: actions/checkout@v4
+      with:
+        repository: smuellerDD/jitterentropy-library
+        ref: v3.5.0
+        path: jitter
+    - name: build jitter
+      run: make -C jitter/
+    - name: checkout fuzz/corpora submodule
+      run: git submodule update --init --depth 1 fuzz/corpora
+    - name: config
+      run: ./config --with-rand-seed=jitter --with-jitter-include=jitter/ --with-jitter-lib=jitter/ && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: get cpu info
+      run: |
+        cat /proc/cpuinfo
+        ./util/opensslwrap.sh version -c
+    - name: make test
+      run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
+
   enable_brotli_dynamic:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -155,6 +155,11 @@ OpenSSL 3.3
 
 ### Changes between 3.2 and 3.3.0 [9 Apr 2024]
 
+ * Add a new random seed source `jitter` using a statically linked
+   jitterentropy library.
+
+   *Dimitri John Ledkov*
+
  * The `-verify` option to the `openssl crl` and `openssl req` will make
    the program exit with 1 on failure.
 

--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -59,6 +59,8 @@ my %targets=(
         includes        =>
             sub {
                 my @incs = ();
+                push @incs, $withargs{jitter_include}
+                    if !$disabled{jitter} && $withargs{jitter_include};
                 push @incs, $withargs{brotli_include}
                     if !$disabled{brotli} && $withargs{brotli_include};
                 push @incs, $withargs{zlib_include}
@@ -95,6 +97,7 @@ my %targets=(
         lflags          =>
             sub {
                 my @libs = ();
+                push(@libs, "-L".$withargs{jitter_lib}) if $withargs{jitter_lib};
                 push(@libs, "-L".$withargs{zlib_lib}) if $withargs{zlib_lib};
                 push(@libs, "-L".$withargs{brotli_lib}) if $withargs{brotli_lib};
                 push(@libs, "-L".$withargs{zstd_lib}) if $withargs{zstd_lib};
@@ -103,6 +106,7 @@ my %targets=(
         ex_libs         =>
             sub {
                 my @libs = ();
+                push(@libs, "-l:libjitterentropy.a") if !defined($disabled{jitter});
                 push(@libs, "-lz") if !defined($disabled{zlib}) && defined($disabled{"zlib-dynamic"});
                 if (!defined($disabled{brotli}) && defined($disabled{"brotli-dynamic"})) {
                     push(@libs, "-lbrotlienc");

--- a/Configure
+++ b/Configure
@@ -477,6 +477,7 @@ my @disablables = (
     "gost",
     "http",
     "idea",
+    "jitter",
     "ktls",
     "legacy",
     "loadereng",
@@ -587,6 +588,7 @@ our %disabled = ( # "what"         => "comment"
                   "fuzz-afl"            => "default",
                   "fuzz-libfuzzer"      => "default",
                   "pie"                 => "default",
+                  "jitter"              => "default",
                   "ktls"                => "default",
                   "md2"                 => "default",
                   "msan"                => "default",
@@ -816,7 +818,7 @@ my %cmdvars = ();               # Stores FOO='blah' type arguments
 my %unsupported_options = ();
 my %deprecated_options = ();
 # If you change this, update apps/version.c
-my @known_seed_sources = qw(getrandom devrandom os egd none rdcpu);
+my @known_seed_sources = qw(getrandom devrandom os egd none rdcpu jitter);
 my @seed_sources = ();
 while (@argvcopy)
         {
@@ -1019,6 +1021,14 @@ while (@argvcopy)
                 elsif (/^--openssldir=(.*)$/)
                         {
                         $config{openssldir}=$1;
+                        }
+                elsif (/^--with-jitter-include=(.*)$/)
+                        {
+                        $withargs{jitter_include}=$1;
+                        }
+                elsif (/^--with-jitter-lib=(.*)$/)
+                        {
+                        $withargs{jitter_lib}=$1;
                         }
                 elsif (/^--with-zlib-lib=(.*)$/)
                         {
@@ -1305,6 +1315,9 @@ if (scalar(@seed_sources) == 0) {
 }
 if (scalar(grep { $_ eq 'egd' } @seed_sources) > 0) {
     delete $disabled{'egd'};
+}
+if (scalar(grep { $_ eq 'jitter' } @seed_sources) > 0) {
+    delete $disabled{'jitter'};
 }
 if (scalar(grep { $_ eq 'none' } @seed_sources) > 0) {
     die "Cannot seed with none and anything else" if scalar(@seed_sources) > 1;

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -510,6 +510,23 @@ This source is ignored by the FIPS provider.
 Use the `RDSEED` or `RDRAND` command on x86 or `RNDRRS` command on aarch64
 if provided by the CPU.
 
+### jitter
+
+Use
+[jitterentropy-library](https://github.com/smuellerDD/jitterentropy-library) statically linked only.
+
+Additional configuration flags available:
+
+    --with-jitter-include=DIR
+
+The directory for the location of the jitterentropy.h include file, if
+it is outside the system include path.
+
+    --with-jitter-lib=DIR
+
+This is the directory containing the static libjitterentropy.a
+library, if it is outside the system library path.
+
 ### none
 
 Disable automatic seeding.  This is the default on some operating systems where

--- a/crypto/info.c
+++ b/crypto/info.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2019-2024 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -14,6 +14,11 @@
 #include "internal/cryptlib.h"
 #include "internal/e_os.h"
 #include "buildinf.h"
+
+#ifdef OPENSSL_RAND_SEED_JITTER
+# include <stdio.h>
+# include <jitterentropy.h>
+#endif
 
 #if defined(__arm__) || defined(__arm) || defined(__aarch64__)
 # include "arm_arch.h"
@@ -170,6 +175,11 @@ DEFINE_RUN_ONCE_STATIC(init_info_strings)
 # else
         add_seeds_string("rdrand ( rdseed rdrand )");
 # endif
+#endif
+#ifdef OPENSSL_RAND_SEED_JITTER
+        char jent_version_string[32];
+        sprintf(jent_version_string, "jitterentropy (%d)", jent_version());
+        add_seeds_string(jent_version_string);
 #endif
 #ifdef OPENSSL_RAND_SEED_GETRANDOM
         add_seeds_string("getrandom-syscall");

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2023 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2024 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -19,6 +19,10 @@
 #include "crypto/cryptlib.h"
 #include "rand_local.h"
 #include "crypto/context.h"
+
+#ifdef OPENSSL_RAND_SEED_JITTER
+#include <jitterentropy.h>
+#endif
 
 #ifndef FIPS_MODULE
 # include <stdio.h>
@@ -61,6 +65,11 @@ DEFINE_RUN_ONCE_STATIC(do_rand_init)
 
     if (!ossl_rand_pool_init())
         goto err;
+
+# ifdef OPENSSL_RAND_SEED_JITTER
+    if (jent_entropy_init_ex(0, JENT_FORCE_FIPS))
+        goto err;
+# endif
 
     rand_inited = 1;
     return 1;

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -664,7 +664,17 @@ static EVP_RAND_CTX *rand_new_drbg(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent,
         ERR_raise(ERR_LIB_RAND, RAND_R_UNABLE_TO_FETCH_DRBG);
         return NULL;
     }
+#if defined(OPENSSL_RAND_SEED_JITTER)
+    /*
+     * Explicitely use SEED_JITTER, directly, without chaining to
+     * allow reuse of pre-certified static jitterentropy.a without
+     * need for a separate ESV certificate. Potentially this should be
+     * default for all FIPS_MODULE builds, not just jitterentropy.
+     */
+    ctx = EVP_RAND_CTX_new(rand, NULL);
+#else
     ctx = EVP_RAND_CTX_new(rand, parent);
+#endif
     EVP_RAND_free(rand);
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_RAND, RAND_R_UNABLE_TO_CREATE_DRBG);

--- a/providers/implementations/include/prov/seeding.h
+++ b/providers/implementations/include/prov/seeding.h
@@ -13,6 +13,7 @@
 /* Hardware-based seeding functions. */
 size_t ossl_prov_acquire_entropy_from_tsc(RAND_POOL *pool);
 size_t ossl_prov_acquire_entropy_from_cpu(RAND_POOL *pool);
+size_t ossl_prov_acquire_entropy_from_jitter(RAND_POOL *pool);
 
 /*
  * External seeding functions from the core dispatch table.

--- a/providers/implementations/rands/seeding/build.info
+++ b/providers/implementations/rands/seeding/build.info
@@ -1,4 +1,4 @@
-$COMMON=rand_unix.c rand_win.c rand_tsc.c
+$COMMON=rand_unix.c rand_win.c rand_tsc.c rand_jitter.c
 IF[{- $config{target} =~ /vxworks/i -}]
   $COMMON=$COMMON rand_vxworks.c
 ENDIF

--- a/providers/implementations/rands/seeding/rand_jitter.c
+++ b/providers/implementations/rands/seeding/rand_jitter.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "internal/cryptlib.h"
+#include <openssl/opensslconf.h>
+#include "crypto/rand_pool.h"
+#include "prov/seeding.h"
+
+#ifdef OPENSSL_RAND_SEED_JITTER
+#include <jitterentropy.h>
+
+#define JITTER_MAX_NUM_TRIES 3
+
+static size_t get_jitter_random_value(unsigned char *buf, size_t len);
+
+/*
+ * Acquire entropy from jitterentropy library
+ *
+ * Returns the total entropy count, if it exceeds the requested
+ * entropy count. Otherwise, returns an entropy count of 0.
+ */
+size_t ossl_prov_acquire_entropy_from_jitter(RAND_POOL *pool)
+{
+    size_t bytes_needed;
+    unsigned char *buffer;
+
+    bytes_needed = ossl_rand_pool_bytes_needed(pool, 1 /*entropy_factor*/);
+    if (bytes_needed > 0) {
+        buffer = ossl_rand_pool_add_begin(pool, bytes_needed);
+
+        if (buffer != NULL) {
+            if (get_jitter_random_value(buffer, bytes_needed) == bytes_needed) {
+                ossl_rand_pool_add_end(pool, bytes_needed, 8 * bytes_needed);
+            } else {
+                ossl_rand_pool_add_end(pool, 0, 0);
+            }
+        }
+    }
+
+    return ossl_rand_pool_entropy_available(pool);
+}
+
+/* Obtain random bytes from the jitter library */
+static size_t get_jitter_random_value(unsigned char *buf, size_t len)
+{
+    struct rand_data *jitter_ec = NULL;
+    ssize_t result = 0;
+    size_t num_tries;
+
+    jitter_ec = jent_entropy_collector_alloc(0, JENT_FORCE_FIPS);
+    if (jitter_ec == NULL) {
+        return 0;
+    }
+
+    for (num_tries = 0; num_tries < JITTER_MAX_NUM_TRIES; num_tries++) {
+      // Do not use _safe API variant with built-in retries, until
+      // failure because it reseeds the entropy source which is not
+      // certifyable
+      result = jent_read_entropy(jitter_ec, (char *) buf, len);
+
+      // Success
+      if (result == len) {
+          jent_entropy_collector_free(jitter_ec);
+          return len;
+      }
+    }
+
+    jent_entropy_collector_free(jitter_ec);
+
+    // Catastrophic failure, maybe should abort here
+    return 0;
+}
+
+#else
+NON_EMPTY_TRANSLATION_UNIT
+#endif

--- a/providers/implementations/rands/seeding/rand_unix.c
+++ b/providers/implementations/rands/seeding/rand_unix.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2023 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2024 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -95,6 +95,7 @@ static uint64_t get_time_stamp(void);
 /* none means none. this simplifies the following logic */
 # undef OPENSSL_RAND_SEED_OS
 # undef OPENSSL_RAND_SEED_GETRANDOM
+# undef OPENSSL_RAND_SEED_JITTER
 # undef OPENSSL_RAND_SEED_DEVRANDOM
 # undef OPENSSL_RAND_SEED_RDTSC
 # undef OPENSSL_RAND_SEED_RDCPU
@@ -702,6 +703,12 @@ size_t ossl_pool_acquire_entropy(RAND_POOL *pool)
 
 #   if defined(OPENSSL_RAND_SEED_RDCPU)
     entropy_available = ossl_prov_acquire_entropy_from_cpu(pool);
+    if (entropy_available > 0)
+        return entropy_available;
+#   endif
+
+#   if defined(OPENSSL_RAND_SEED_JITTER)
+    entropy_available = ossl_prov_acquire_entropy_from_jitter(pool);
     if (entropy_available > 0)
         return entropy_available;
 #   endif


### PR DESCRIPTION
Implement Jitter Entropy based random seed source using statically linked jitterentropy-library. This is desirable for those that don't control the OS provided entropy, and cannot assert if OS provides SP800-90B compliant getrandom().

Tested on Linux only, but in theory should be possible to port this to Windows and MacOS as well.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
- [X] tests are added or updated
