### PR TITLE
test: fix 20-test_dgst.t to use hexkey

### DIFF
--- a/test/recipes/20-test_dgst.t
+++ b/test/recipes/20-test_dgst.t
@@ -198,11 +198,11 @@ subtest "HMAC generation with `dgst` CLI, key via option" => sub {
 
     my $testdata = srctop_file('test', 'data.bin');
     #HMAC the data twice to check consistency
-    my @hmacdata = run(app(['openssl', 'dgst', '-sha256', '-hmac',
+    my @hmacdata = run(app(['openssl', 'dgst', '-sha256', '-mac', 'HMAC',
                             '-macopt', 'hexkey:FFFF',
                             $testdata, $testdata]), capture => 1);
     chomp(@hmacdata);
-    my $expected = qr/HMAC-SHA2-256\(\Q$testdata\E\)= b6727b7bb251dfa65846e0a8223bdd57d244aa6d7e312cb906d8e21f2dee3a57/;
+    my $expected = qr/HMAC-SHA2-256\(\Q$testdata\E\)= 7c02d4a17d2560a5bb6763edbf33f3a34f415398f8f2e07f04b83ffd7c087dae/;
     ok($hmacdata[0] =~ $expected, "HMAC: Check HMAC value is as expected ($hmacdata[0]) vs ($expected)");
     ok($hmacdata[1] =~ $expected,
        "HMAC: Check second HMAC value is consistent with the first ($hmacdata[1]) vs ($expected)");


### PR DESCRIPTION
test: fix 20-test_dgst.t to use hexkey

Currently 20-test_dgst.t calls a quite bogus command:

    $ openssl dgst -sha256 -hmac -macopt hexkey:FFFF test/data.bin test/data.bin
    hexkey:FFFF: No such file or directory
    HMAC-SHA2-256(test/data.bin)= b6727b7bb251dfa65846e0a8223bdd57d244aa6d7e312cb906d8e21f2dee3a57
    HMAC-SHA2-256(test/data.bin)= b6727b7bb251dfa65846e0a8223bdd57d244aa6d7e312cb906d8e21f2dee3a57
    805B632D4A730000:error:80000002:system library:file_ctrl:No such file or directory:crypto/bio/bss_file.c:297:calling fopen(hexkey:FFF, r)
    805B632D4A730000:error:10080002:BIO routines:file_ctrl:system lib:crypto/bio/bss_file.c:300:

Does not check status code, discards stderr, and verifies the checksums as per above. Note that the checksum is for the HMAC key "-macopt", and `hexkey:FFFF` is attempted to be opened as a file.

See HMAC values for key `-macopt` and `hexkey:FFFF` using `openssl-mac`:

    $ openssl mac -digest SHA256 -macopt hexkey:$(printf '%s' '-macopt' | xxd -p -u) -in ./test/data.bin HMAC
    B6727B7BB251DFA65846E0A8223BDD57D244AA6D7E312CB906D8E21F2DEE3A57

    $ openssl mac -digest SHA256 -macopt hexkey:FFFF -in ./test/data.bin HMAC
    7C02D4A17D2560A5BB6763EDBF33F3A34F415398F8F2E07F04B83FFD7C087DAE

Fix this test case to actually use HMAC with hexkey:FFFF as intended.