### PR TITLE
riscv: Provide a vector only implementation of CHACHA20 cipher

### DIFF
--- a/crypto/chacha/build.info
+++ b/crypto/chacha/build.info
@@ -22,7 +22,7 @@ IF[{- !$disabled{asm} -}]
 
   $CHACHAASM_c64xplus=chacha-c64xplus.s
 
-  $CHACHAASM_riscv64=chacha_riscv.c chacha_enc.c chacha-riscv64-zbb-zvkb.s
+  $CHACHAASM_riscv64=chacha_riscv.c chacha_enc.c chacha-riscv64-v-zbb.s chacha-riscv64-v-zbb-zvkb.s
   $CHACHADEF_riscv64=INCLUDE_C_CHACHA20
 
   # Now that we have defined all the arch specific variables, use the
@@ -53,4 +53,5 @@ GENERATE[chacha-s390x.S]=asm/chacha-s390x.pl
 GENERATE[chacha-ia64.S]=asm/chacha-ia64.pl
 GENERATE[chacha-ia64.s]=chacha-ia64.S
 GENERATE[chacha-loongarch64.S]=asm/chacha-loongarch64.pl
-GENERATE[chacha-riscv64-zbb-zvkb.s]=asm/chacha-riscv64-zbb-zvkb.pl
+GENERATE[chacha-riscv64-v-zbb.s]=asm/chacha-riscv64-v-zbb.pl
+GENERATE[chacha-riscv64-v-zbb-zvkb.s]=asm/chacha-riscv64-v-zbb.pl zvkb

--- a/crypto/chacha/chacha_riscv.c
+++ b/crypto/chacha/chacha_riscv.c
@@ -40,16 +40,23 @@
 #include "crypto/chacha.h"
 #include "crypto/riscv_arch.h"
 
-void ChaCha20_ctr32_zbb_zvkb(unsigned char *out, const unsigned char *inp,
-                             size_t len, const unsigned int key[8],
-                             const unsigned int counter[4]);
+void ChaCha20_ctr32_v_zbb_zvkb(unsigned char *out, const unsigned char *inp,
+                               size_t len, const unsigned int key[8],
+                               const unsigned int counter[4]);
+
+void ChaCha20_ctr32_v_zbb(unsigned char *out, const unsigned char *inp,
+                          size_t len, const unsigned int key[8],
+                          const unsigned int counter[4]);
 
 void ChaCha20_ctr32(unsigned char *out, const unsigned char *inp, size_t len,
                     const unsigned int key[8], const unsigned int counter[4])
 {
-    if (len > CHACHA_BLK_SIZE && RISCV_HAS_ZVKB() && RISCV_HAS_ZBB() &&
-        riscv_vlen() >= 128) {
-        ChaCha20_ctr32_zbb_zvkb(out, inp, len, key, counter);
+    if (len > CHACHA_BLK_SIZE && RISCV_HAS_ZBB() && riscv_vlen() >= 128) {
+        if (RISCV_HAS_ZVKB()) {
+            ChaCha20_ctr32_v_zbb_zvkb(out, inp, len, key, counter);
+        } else {
+            ChaCha20_ctr32_v_zbb(out, inp, len, key, counter);
+        }
     } else {
         ChaCha20_ctr32_c(out, inp, len, key, counter);
     }

--- a/crypto/perlasm/riscv.pm
+++ b/crypto/perlasm/riscv.pm
@@ -598,6 +598,15 @@ sub vmv_v_v {
     return ".word ".($template | ($vs1 << 15) | ($vd << 7));
 }
 
+sub vor_vv {
+    # vor.vv vd, vs2, vs1
+    my $template = 0b0010101_00000_00000_000_00000_1010111;
+    my $vd = read_vreg shift;
+    my $vs2 = read_vreg shift;
+    my $vs1 = read_vreg shift;
+    return ".word ".($template | ($vs2 << 20) | ($vs1 << 15) | ($vd << 7));
+}
+
 sub vor_vv_v0t {
     # vor.vv vd, vs2, vs1, v0.t
     my $template = 0b0010100_00000_00000_000_00000_1010111;
@@ -741,6 +750,15 @@ sub vslideup_vi {
 sub vsll_vi {
     # vsll.vi vd, vs2, uimm, vm
     my $template = 0b1001011_00000_00000_011_00000_1010111;
+    my $vd = read_vreg shift;
+    my $vs2 = read_vreg shift;
+    my $uimm = shift;
+    return ".word ".($template | ($vs2 << 20) | ($uimm << 15) | ($vd << 7));
+}
+
+sub vsrl_vi {
+    # vsrl.vi vd, vs2, uimm, vm
+    my $template = 0b1010001_00000_00000_011_00000_1010111;
     my $vd = read_vreg shift;
     my $vs2 = read_vreg shift;
     my $uimm = shift;


### PR DESCRIPTION
Although we have a Zvkb version of Chacha20, the Zvkb from the RISC-V Vector Cryptography Bit-manipulation extension was ratified in late 2023 and does not come to the RVA23 Profile. Many CPUs in 2024 currently do not support Zvkb but may have Vector and Scalar Bit-manipulation, which are already in the RVA22 Profile. This commit provides a vector-only implementation that replaced the vror with vsll+vsrl+vor and can provide enough speed for Chacha20 for new CPUs this year.

##### Performance Evaluation

Platform: Canaan Kendryte K230
CPU: T-Head C908 @1.6GHz
Compiler: gcc version 13.2.1 20230801 (GCC)

```console
[cyy@archlinux ssl]$ neofetch
                   -`                    cyy@archlinux
                  .o+`                   -------------
                 `ooo/                   OS: Arch Linux riscv64
                `+oooo:                  Host: Canaan Kendryte K230
               `+oooooo:                 Kernel: 6.8.0+
               -+oooooo+:                Uptime: 4 days, 17 hours, 27 mins
             `/:-:++oooo+:               Packages: 156 (pacman)
            `/++++/+++++++:              Shell: bash 5.2.26
           `/++++++++++++++:             Terminal: /dev/pts/0
          `/+++ooooooooooooo/`           CPU: (1)
         ./ooosssso++osssssso+`          Memory: 72MiB / 477MiB
        .oossssso-````/ossssss+`
       -osssssso.      :ssssssso.
      :osssssss/        osssso+++.
     /ossssssss/        +ssssooo/-
   `/ossssso+/:-        -:/+osssso+-
  `+sso+:-`                 `.-/+oso:
 `++:.                           `-/+/
 .`                                 `/

[cyy@archlinux ssl]$ cat /proc/cpuinfo
processor	: 0
hart		: 0
isa		: rv64imafdcv_zicbom_zicntr_zicsr_zifencei_zihpm_zba_zbb_zbc_zbs_svpbmt
mmu		: sv39
mvendorid	: 0x5b7
marchid		: 0x8000000009140d00
mimpid		: 0x50000
hart isa	: rv64imafdcv_zicbom_zicntr_zicsr_zifencei_zihpm_zba_zbb_zbc_zbs_svpbmt

[cyy@archlinux ssl]$ unset OPENSSL_riscvcap
[cyy@archlinux ssl]$ ./bin/openssl speed -evp chacha20
Doing ChaCha20 ops for 3s on 16 size blocks: 9190817 ChaCha20 ops in 2.90s
Doing ChaCha20 ops for 3s on 64 size blocks: 3541082 ChaCha20 ops in 2.98s
Doing ChaCha20 ops for 3s on 256 size blocks: 998612 ChaCha20 ops in 2.98s
Doing ChaCha20 ops for 3s on 1024 size blocks: 258575 ChaCha20 ops in 2.99s
Doing ChaCha20 ops for 3s on 8192 size blocks: 32655 ChaCha20 ops in 2.98s
Doing ChaCha20 ops for 3s on 16384 size blocks: 16335 ChaCha20 ops in 2.99s
version: 3.4.0-dev
built on: Fri Apr 19 06:03:02 2024 UTC
options: bn(64,64)
compiler: gcc -fPIC -pthread -Wa,--noexecstack -Wall -O3 -DOPENSSL_USE_NODELETE -DOPENSSL_PIC -DOPENSSL_BUILDING_OPENSSL -DNDEBUG
CPUINFO: N/A
The 'numbers' are in 1000s of bytes per second processed.
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
ChaCha20         50707.96k    76050.08k    85786.80k    88555.45k    89768.38k    89509.24k
[cyy@archlinux ssl]$ export OPENSSL_riscvcap=rv64gc_v_zba_zbb
[cyy@archlinux ssl]$ ./bin/openssl speed -evp chacha20
Doing ChaCha20 ops for 3s on 16 size blocks: 9400208 ChaCha20 ops in 2.97s
Doing ChaCha20 ops for 3s on 64 size blocks: 3561831 ChaCha20 ops in 2.99s
Doing ChaCha20 ops for 3s on 256 size blocks: 1417570 ChaCha20 ops in 2.98s
Doing ChaCha20 ops for 3s on 1024 size blocks: 370833 ChaCha20 ops in 2.98s
Doing ChaCha20 ops for 3s on 8192 size blocks: 57722 ChaCha20 ops in 2.99s
Doing ChaCha20 ops for 3s on 16384 size blocks: 28833 ChaCha20 ops in 2.98s
version: 3.4.0-dev
built on: Fri Apr 19 06:03:02 2024 UTC
options: bn(64,64)
compiler: gcc -fPIC -pthread -Wa,--noexecstack -Wall -O3 -DOPENSSL_USE_NODELETE -DOPENSSL_PIC -DOPENSSL_BUILDING_OPENSSL -DNDEBUG
CPUINFO: N/A
The 'numbers' are in 1000s of bytes per second processed.
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
ChaCha20         50640.85k    76239.86k   121777.83k   127427.18k   158146.70k   158523.45k
[cyy@archlinux ssl]$ unset OPENSSL_riscvcap
[cyy@archlinux ssl]$ ./bin/openssl speed -evp chacha20
Doing ChaCha20 ops for 3s on 16 size blocks: 10710666 ChaCha20 ops in 2.99s
Doing ChaCha20 ops for 3s on 64 size blocks: 4656347 ChaCha20 ops in 3.00s
Doing ChaCha20 ops for 3s on 256 size blocks: 1390592 ChaCha20 ops in 3.00s
Doing ChaCha20 ops for 3s on 1024 size blocks: 366078 ChaCha20 ops in 3.01s
Doing ChaCha20 ops for 3s on 8192 size blocks: 46493 ChaCha20 ops in 3.00s
Doing ChaCha20 ops for 3s on 16384 size blocks: 23223 ChaCha20 ops in 3.00s
version: 3.4.0-dev
built on: Fri Apr 19 06:13:13 2024 UTC
options: bn(64,64)
compiler: gcc -fPIC -pthread -Wa,--noexecstack -Wall -O3 -march=rv64gcv_zba_zbb -DOPENSSL_USE_NODELETE -DOPENSSL_PIC -DOPENSSL_BUILDING_OPENSSL -DNDEBUG
CPUINFO: N/A
The 'numbers' are in 1000s of bytes per second processed.
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
ChaCha20         57314.60k    99335.40k   118663.85k   124539.49k   126956.89k   126828.54k
[cyy@archlinux ssl]$ export OPENSSL_riscvcap=rv64gc_v_zba_zbb
[cyy@archlinux ssl]$ ./bin/openssl speed -evp chacha20
Doing ChaCha20 ops for 3s on 16 size blocks: 11064374 ChaCha20 ops in 2.96s
Doing ChaCha20 ops for 3s on 64 size blocks: 4723040 ChaCha20 ops in 3.00s
Doing ChaCha20 ops for 3s on 256 size blocks: 1426926 ChaCha20 ops in 3.01s
Doing ChaCha20 ops for 3s on 1024 size blocks: 373266 ChaCha20 ops in 3.00s
Doing ChaCha20 ops for 3s on 8192 size blocks: 58149 ChaCha20 ops in 2.99s
Doing ChaCha20 ops for 3s on 16384 size blocks: 29032 ChaCha20 ops in 2.97s
version: 3.4.0-dev
built on: Fri Apr 19 06:13:13 2024 UTC
options: bn(64,64)
compiler: gcc -fPIC -pthread -Wa,--noexecstack -Wall -O3 -march=rv64gcv_zba_zbb -DOPENSSL_USE_NODELETE -DOPENSSL_PIC -DOPENSSL_BUILDING_OPENSSL -DNDEBUG
CPUINFO: N/A
The 'numbers' are in 1000s of bytes per second processed.
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
ChaCha20         59807.43k   100758.19k   121359.82k   127408.13k   159316.59k   160154.98k
[cyy@archlinux ssl]$
```

Summary of the result:

Chacha20 Implementation | GCC -march | 16 bytes | 64 bytes | 256 bytes | 1024 bytes | 8192 bytes | 16384 bytes
-- | -- | -- | -- | -- | -- | -- | --
C | 64gc | 50707.96k | 76050.08k | 85786.80k | 88555.45k | 89768.38k | 89509.24k
C | 64gcv_zba_zbb | 57314.60k | 99335.40k | 118663.85k | 124539.49k | 126956.89k | 126828.54k
ASM-RVV | 64gc | 50640.85k | 76239.86k | 121777.83k | 127427.18k | 158146.70k | 158523.45k
ASM-RVV | 64gcv_zba_zbb | 59807.43k | 100758.19k | 121359.82k | 127408.13k | 159316.59k | 160154.98k

According to the result, we get chacha20 speed up to 160154.98k on 16384 bytes blocks, which is 26.3% faster compared to C implementation with rv64gcv_zba_zbb optimized by GCC and 78.9% faster compared to C implementation with rv64gc which is the default -march for riscv in GCC.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated

I also `diff` the generated ASM for Zvkb since I updated the Perl script for ASM generation. There are no changes except for indentation. 