### PR TITLE
VMS: Move defining _XOPEN_SOURCE and  _XOPEN_SOURCE_EXTENDED to config target

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -2054,7 +2054,7 @@ my %targets = (
                               ? "/WARNINGS=DISABLE=(".join(",",@warnings).")" : (); }),
         cflag_incfirst   => '/FIRST_INCLUDE=',
         lib_defines      =>
-            add("OPENSSL_USE_NODELETE",
+            add("OPENSSL_USE_NODELETE", "_XOPEN_SOURCE", "_XOPEN_SOURCE_EXTENDED",
                 sub {
                     return vms_info()->{def_zlib}
                         ? "LIBZ=\"\"\"".vms_info()->{def_zlib}."\"\"\"" : ();

--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -14,8 +14,6 @@
  *      generalTime    GeneralizedTime }
  */
 
-#define _XOPEN_SOURCE            /* To get a definition of timezone */
-
 #include <stdio.h>
 #include <time.h>
 #include "crypto/asn1.h"

--- a/crypto/conf/conf_lib.c
+++ b/crypto/conf/conf_lib.c
@@ -7,8 +7,6 @@
  * https://www.openssl.org/source/license.html
  */
 
-#define _XOPEN_SOURCE_EXTENDED   /* To get a definition of strdup() */
-
 #include "internal/e_os.h"
 #include <stdio.h>
 #include <string.h>

--- a/crypto/conf/conf_sap.c
+++ b/crypto/conf/conf_sap.c
@@ -7,8 +7,6 @@
  * https://www.openssl.org/source/license.html
  */
 
-#define _XOPEN_SOURCE_EXTENDED   /* To get a definition of strdup() */
-
 #include <stdio.h>
 #include <openssl/crypto.h>
 #include "internal/cryptlib.h"


### PR DESCRIPTION
For all other platforms that need these macros defined, that's how it's
done, so we have VMS follow suit.  That avoids a crash between in source
definitions and command line definitions on some other platforms.

Fixes #24075
