### PR TITLE
Fix duplicate mutex allocation in threads_win.c

### DIFF
--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -158,7 +158,6 @@ CRYPTO_RCU_LOCK *ossl_rcu_lock_new(int num_writers)
     new->prior_signal = ossl_crypto_condvar_new();
     new->alloc_lock = ossl_crypto_mutex_new();
     new->prior_lock = ossl_crypto_mutex_new();
-    new->write_lock = ossl_crypto_mutex_new();
     new->qp_group = allocate_new_qp_group(new, num_writers + 1);
     if (new->qp_group == NULL
         || new->alloc_signal == NULL


### PR DESCRIPTION
Creating an rcu lock does a double allocation of the underlying mutex. Not sure how asan didn't catch this, but we clearly have a duplicate line here

Fixes #24085 