### PR TITLE
fips: Edwards curves are approved for signatures only

### DIFF
--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -410,8 +410,8 @@ static const OSSL_ALGORITHM fips_keyexch[] = {
 #ifndef OPENSSL_NO_EC
     { PROV_NAMES_ECDH, FIPS_DEFAULT_PROPERTIES, ossl_ecdh_keyexch_functions },
 # ifndef OPENSSL_NO_ECX
-    { PROV_NAMES_X25519, FIPS_DEFAULT_PROPERTIES, ossl_x25519_keyexch_functions },
-    { PROV_NAMES_X448, FIPS_DEFAULT_PROPERTIES, ossl_x448_keyexch_functions },
+    { PROV_NAMES_X25519, FIPS_UNAPPROVED_PROPERTIES, ossl_x25519_keyexch_functions },
+    { PROV_NAMES_X448, FIPS_UNAPPROVED_PROPERTIES, ossl_x448_keyexch_functions },
 # endif
 #endif
     { PROV_NAMES_TLS1_PRF, FIPS_DEFAULT_PROPERTIES,
@@ -427,9 +427,9 @@ static const OSSL_ALGORITHM fips_signature[] = {
     { PROV_NAMES_RSA, FIPS_DEFAULT_PROPERTIES, ossl_rsa_signature_functions },
 #ifndef OPENSSL_NO_EC
 # ifndef OPENSSL_NO_ECX
-    { PROV_NAMES_ED25519, FIPS_UNAPPROVED_PROPERTIES,
+    { PROV_NAMES_ED25519, FIPS_DEFAULT_PROPERTIES,
       ossl_ed25519_signature_functions },
-    { PROV_NAMES_ED448, FIPS_UNAPPROVED_PROPERTIES, ossl_ed448_signature_functions },
+    { PROV_NAMES_ED448, FIPS_DEFAULT_PROPERTIES, ossl_ed448_signature_functions },
 # endif
     { PROV_NAMES_ECDSA, FIPS_DEFAULT_PROPERTIES, ossl_ecdsa_signature_functions },
 #endif
@@ -471,13 +471,13 @@ static const OSSL_ALGORITHM fips_keymgmt[] = {
     { PROV_NAMES_EC, FIPS_DEFAULT_PROPERTIES, ossl_ec_keymgmt_functions,
       PROV_DESCS_EC },
 # ifndef OPENSSL_NO_ECX
-    { PROV_NAMES_X25519, FIPS_DEFAULT_PROPERTIES, ossl_x25519_keymgmt_functions,
+    { PROV_NAMES_X25519, FIPS_UNAPPROVED_PROPERTIES, ossl_x25519_keymgmt_functions,
       PROV_DESCS_X25519 },
-    { PROV_NAMES_X448, FIPS_DEFAULT_PROPERTIES, ossl_x448_keymgmt_functions,
+    { PROV_NAMES_X448, FIPS_UNAPPROVED_PROPERTIES, ossl_x448_keymgmt_functions,
       PROV_DESCS_X448 },
-    { PROV_NAMES_ED25519, FIPS_UNAPPROVED_PROPERTIES, ossl_ed25519_keymgmt_functions,
+    { PROV_NAMES_ED25519, FIPS_DEFAULT_PROPERTIES, ossl_ed25519_keymgmt_functions,
       PROV_DESCS_ED25519 },
-    { PROV_NAMES_ED448, FIPS_UNAPPROVED_PROPERTIES, ossl_ed448_keymgmt_functions,
+    { PROV_NAMES_ED448, FIPS_DEFAULT_PROPERTIES, ossl_ed448_keymgmt_functions,
       PROV_DESCS_ED448 },
 # endif
 #endif


### PR DESCRIPTION
Edwards curves 25519 and 448 can be used in many contexts. NIST approved their usage for digital signatures only. And not (yet) for key aggrement.

Specifically see [NIST CMVP Implementation Guidance](https://csrc.nist.gov/csrc/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS%20140-3%20IG.pdf) C.K Transition from FIPS 186-4 to FIPS 186-5 and and SP 800-186 (pages 114-116)

Resolution:

> 5. The publication of SP 800-186 does not impact the curves
> permitted under SP 800-56Arev3. Curves that are included in SP
> 800-186 but not included in SP 800-56Arev3 are not approved for key
> agreement.  E.g., the ECDH X25519 and X448 key agreement schemes
> (defined in RFC 7748) that use Curve25519 and Curve448,
> respectively, are not compliant to SP 800-56Arev3. The corresponding
> Montgomery curves Curve25519 and Curve448 are included in SP 800-186
> only for use within digital signatures as alternative
> representations of the Edwards25519 and Edwards448 curves, as shown
> in Table 2 of SP 800- 186.

Additional Comments:

> 7. FIPS 186-5 uses Ed25519 and Ed448 to mean the signature schemes
> and not the curves themselves, while SP 800-186 uses Edwards25519
> and Edwards448 to mean the curves themselves.

> 9. SP 800-186 Table 2 says that the following curves are not to be
> used for ECDSA or EdDSA directly: Curve25519, W-25519, Curve448,
> E448, W-448. SP 800-186 B.1 explains: “Implementations may take
> advantage of these mappings to carry out elliptic curve group
> operations that were originally defined for a twisted Edwards curve
> on the corresponding Montgomery curve, or vice-versa, and
> translating the result back to the original curve to potentially
> allow code reuse”. This is permitted in the approved mode, as long
> as “procedures […] include all cryptographic checks included with
> the specifications in this document. This is important because the
> checks are essential for the prevention of subtle attacks”.  For
> example, an implementation may start on one of the permitted curves
> given in Table 2 of SP 800-186, then map to a different curve,
> perform some operation(s), and map back to the original permitted
> curve.  This should not impact the CAVP testing which will test the
> final signature on the original curve.

> 10. FIPS 186-5 uses Ed25519 and Ed448 to mean the signature schemes
> and not the curves themselves, while SP 800-186 uses Edwards25519
> and Edwards448 to mean the curves themselves.

This reverts 759ab5984eb981f2dd165979a7abb950ddad81ae - Marking Signatures unapproved. @paulidale

This reverts 8948b5749410084ed1dfabf17a90df65efcf0f82 - Marking Key change approved. @paulidale

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
