### PR TITLE
Use scalar ALU and vector ALU together for chacha20 stream cipher.

### DIFF
--- a/crypto/chacha/build.info
+++ b/crypto/chacha/build.info
@@ -22,7 +22,7 @@ IF[{- !$disabled{asm} -}]
 
   $CHACHAASM_c64xplus=chacha-c64xplus.s
 
-  $CHACHAASM_riscv64=chacha_riscv.c chacha_enc.c chacha-riscv64-zvkb.s
+  $CHACHAASM_riscv64=chacha_riscv.c chacha_enc.c chacha-riscv64-zbb-zvkb.s
   $CHACHADEF_riscv64=INCLUDE_C_CHACHA20
 
   # Now that we have defined all the arch specific variables, use the
@@ -53,4 +53,4 @@ GENERATE[chacha-s390x.S]=asm/chacha-s390x.pl
 GENERATE[chacha-ia64.S]=asm/chacha-ia64.pl
 GENERATE[chacha-ia64.s]=chacha-ia64.S
 GENERATE[chacha-loongarch64.S]=asm/chacha-loongarch64.pl
-GENERATE[chacha-riscv64-zvkb.s]=asm/chacha-riscv64-zvkb.pl
+GENERATE[chacha-riscv64-zbb-zvkb.s]=asm/chacha-riscv64-zbb-zvkb.pl

--- a/crypto/chacha/chacha_riscv.c
+++ b/crypto/chacha/chacha_riscv.c
@@ -40,15 +40,16 @@
 #include "crypto/chacha.h"
 #include "crypto/riscv_arch.h"
 
-void ChaCha20_ctr32_zvkb(unsigned char *out, const unsigned char *inp,
-                         size_t len, const unsigned int key[8],
-                         const unsigned int counter[4]);
+void ChaCha20_ctr32_zbb_zvkb(unsigned char *out, const unsigned char *inp,
+                             size_t len, const unsigned int key[8],
+                             const unsigned int counter[4]);
 
 void ChaCha20_ctr32(unsigned char *out, const unsigned char *inp, size_t len,
                     const unsigned int key[8], const unsigned int counter[4])
 {
-    if (RISCV_HAS_ZVKB() && riscv_vlen() >= 128) {
-        ChaCha20_ctr32_zvkb(out, inp, len, key, counter);
+    if (len > CHACHA_BLK_SIZE && RISCV_HAS_ZVKB() && RISCV_HAS_ZBB() &&
+        riscv_vlen() >= 128) {
+        ChaCha20_ctr32_zbb_zvkb(out, inp, len, key, counter);
     } else {
         ChaCha20_ctr32_c(out, inp, len, key, counter);
     }

--- a/crypto/perlasm/riscv.pm
+++ b/crypto/perlasm/riscv.pm
@@ -384,6 +384,36 @@ sub rev8 {
     return ".word ".($template | ($rs << 15) | ($rd << 7));
 }
 
+sub roriw {
+    # Encoding for roriw rd, rs1, shamt instruction on RV64
+    #               XXXXXXX_ shamt _ rs1 _XXX_ rd  _XXXXXXX
+    my $template = 0b0110000_00000_00000_101_00000_0011011;
+    my $rd = read_reg shift;
+    my $rs1 = read_reg shift;
+    my $shamt = shift;
+    return ".word ".($template | ($shamt << 20) | ($rs1 << 15) | ($rd << 7));
+}
+
+sub maxu {
+    # Encoding for maxu rd, rs1, rs2 instruction on RV64
+    #               XXXXXXX_ rs2 _ rs1 _XXX_ rd  _XXXXXXX
+    my $template = 0b0000101_00000_00000_111_00000_0110011;
+    my $rd = read_reg shift;
+    my $rs1 = read_reg shift;
+    my $rs2 = read_reg shift;
+    return ".word ".($template | ($rs2 << 20) | ($rs1 << 15) | ($rd << 7));
+}
+
+sub minu {
+    # Encoding for minu rd, rs1, rs2 instruction on RV64
+    #               XXXXXXX_ rs2 _ rs1 _XXX_ rd  _XXXXXXX
+    my $template = 0b0000101_00000_00000_101_00000_0110011;
+    my $rd = read_reg shift;
+    my $rs1 = read_reg shift;
+    my $rs2 = read_reg shift;
+    return ".word ".($template | ($rs2 << 20) | ($rs1 << 15) | ($rd << 7));
+}
+
 # Vector instructions
 
 sub vadd_vv {


### PR DESCRIPTION
Fixes #24070

Use scalar ALU for 1 chacha block with rvv ALU simultaneously. The tail elements(non-multiple of block length) will be handled by the scalar logic.

Use rvv path if the input length > chacha_block_size.

And we have about 1.2x improvement comparing with the original code.
