### PR TITLE
Intentionally break EVP_DigestFinal for SHAKE128 and SHAKE256

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,16 @@ OpenSSL 3.4
 
    *Tomáš Mráz*
 
+ * SHAKE-128 and SHAKE-256 implementations have no default digest length
+   anymore. That means these algorithms cannot be used with
+   EVP_DigestFinal/_ex() unless the `xoflen` param is set before.
+
+   This change was necessary because the preexisting default lengths were
+   half the size necessary for full collision resistance supported by these
+   algorithms.
+
+   *Tomáš Mráz*
+
  * Setting `config_diagnostics=1` in the config file will cause errors to
    be returned from SSL_CTX_new() and SSL_CTX_new_ex() if there is an error
    in the ssl module configuration.

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -454,6 +454,8 @@ int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *isize)
     if (ctx->digest->prov == NULL)
         goto legacy;
 
+    if (sz == 0) /* Assuming a xoflen must have been set. */
+        mdsize = SIZE_MAX;
     if (ctx->digest->gettable_ctx_params != NULL) {
         OSSL_PARAM params[] = { OSSL_PARAM_END, OSSL_PARAM_END };
 

--- a/crypto/sha/sha3.c
+++ b/crypto/sha/sha3.c
@@ -34,12 +34,12 @@ int ossl_sha3_init(KECCAK1600_CTX *ctx, unsigned char pad, size_t bitlen)
     return 0;
 }
 
-int ossl_keccak_kmac_init(KECCAK1600_CTX *ctx, unsigned char pad, size_t bitlen)
+int ossl_keccak_init(KECCAK1600_CTX *ctx, unsigned char pad, size_t bitlen, size_t mdlen)
 {
     int ret = ossl_sha3_init(ctx, pad, bitlen);
 
     if (ret)
-        ctx->md_size *= 2;
+        ctx->md_size = mdlen / 8;
     return ret;
 }
 

--- a/doc/man7/EVP_MD-SHAKE.pod
+++ b/doc/man7/EVP_MD-SHAKE.pod
@@ -62,15 +62,10 @@ settable for an B<EVP_MD_CTX> with L<EVP_MD_CTX_set_params(3)>:
 Sets the digest length for extendable output functions.
 The length of the "xoflen" parameter should not exceed that of a B<size_t>.
 
-For backwards compatibility reasons the default xoflen length for SHAKE-128 is
-16 (bytes) which results in a security strength of only 64 bits. To ensure the
-maximum security strength of 128 bits, the xoflen should be set to at least 32.
+The SHAKE-128 and SHAKE-256 implementations do not have any default digest
+length.
 
-For backwards compatibility reasons the default xoflen length for SHAKE-256 is
-32 (bytes) which results in a security strength of only 128 bits. To ensure the
-maximum security strength of 256 bits, the xoflen should be set to at least 64.
-
-This parameter may be used when calling either EVP_DigestFinal_ex() or
+This parameter must be set before calling either EVP_DigestFinal_ex() or
 EVP_DigestFinal(), since these functions were not designed to handle variable
 length output. It is recommended to either use EVP_DigestSqueeze() or
 EVP_DigestFinalXOF() instead.
@@ -88,6 +83,11 @@ length passed to EVP_DigestFinalXOF() should be at least 64.
 =head1 SEE ALSO
 
 L<EVP_MD_CTX_set_params(3)>, L<provider-digest(7)>, L<OSSL_PROVIDER-default(7)>
+
+=head1 HISTORY
+
+Since OpenSSL 3.4 the SHAKE-128 and SHAKE-256 implementations have no default
+digest length.
 
 =head1 COPYRIGHT
 

--- a/include/internal/sha3.h
+++ b/include/internal/sha3.h
@@ -51,8 +51,8 @@ struct keccak_st {
 
 void ossl_sha3_reset(KECCAK1600_CTX *ctx);
 int ossl_sha3_init(KECCAK1600_CTX *ctx, unsigned char pad, size_t bitlen);
-int ossl_keccak_kmac_init(KECCAK1600_CTX *ctx, unsigned char pad,
-                          size_t bitlen);
+int ossl_keccak_init(KECCAK1600_CTX *ctx, unsigned char pad,
+                     size_t typelen, size_t mdlen);
 int ossl_sha3_update(KECCAK1600_CTX *ctx, const void *_inp, size_t len);
 int ossl_sha3_final(KECCAK1600_CTX *ctx, unsigned char *out, size_t outlen);
 int ossl_sha3_squeeze(KECCAK1600_CTX *ctx, unsigned char *out, size_t outlen);

--- a/test/recipes/20-test_dgst.t
+++ b/test/recipes/20-test_dgst.t
@@ -223,13 +223,11 @@ subtest "Custom length XOF digest generation with `dgst` CLI" => sub {
 };
 
 subtest "SHAKE digest generation with no xoflen set `dgst` CLI" => sub {
-    plan tests => 1;
+    plan tests => 2;
 
     my $testdata = srctop_file('test', 'data.bin');
-    my @xofdata = run(app(['openssl', 'dgst', '-shake128', $testdata], stderr => "outerr.txt"), capture => 1);
-    chomp(@xofdata);
-    my $expected = qr/SHAKE-128\(\Q$testdata\E\)= bb565dac72640109e1c926ef441d3fa6/;
-    ok($xofdata[0] =~ $expected, "Check short digest is output");
+    ok(!run(app(['openssl', 'dgst', '-shake128', $testdata])), "SHAKE128 must fail without xoflen");
+    ok(!run(app(['openssl', 'dgst', '-shake256', $testdata])), "SHAKE256 must fail without xoflen");
 };
 
 SKIP: {


### PR DESCRIPTION
It will work only if OSSL_DIGEST_PARAM_XOFLEN is set.

Also add new SHAKE-128/128, SHAKE-256/256, SHAKE-128/256 and SHAKE-256/512 algorithms which have explicit default XOFLEN set.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
