### PR TITLE
Add explicit indicator for PBKDF2

### DIFF
--- a/doc/man1/openssl-fipsinstall.pod.in
+++ b/doc/man1/openssl-fipsinstall.pod.in
@@ -31,6 +31,7 @@ B<openssl fipsinstall>
 [B<-sskdf_digest_check>]
 [B<-x963kdf_digest_check>]
 [B<-dsa_sign_disabled>]
+[B<-no_pbkdf2_lower_bound_check>]
 [B<-no_short_mac>]
 [B<-tdes_encrypt_disabled>]
 [B<-rsa_sign_x931_disabled>]
@@ -298,6 +299,11 @@ See NIST SP 800-131Ar2 for details.
 Configure the module to enable a run-time short key-derivation key check when
 deriving a key by X963KDF.
 See NIST SP 800-131Ar2 for details.
+
+=item B<-no_pbkdf2_lower_bound_check>
+
+Configure the module to not perform run-time lower bound check for PBKDF2.
+See NIST SP 800-132 for details.
 
 =item B<-self_test_onload>
 

--- a/doc/man7/EVP_KDF-PBKDF2.pod
+++ b/doc/man7/EVP_KDF-PBKDF2.pod
@@ -59,6 +59,16 @@ The default provider uses a default mode of 1 for backwards compatibility,
 and the FIPS provider uses a default mode of 0.
 
 The value string is expected to be a decimal number 0 or 1.
+Setting this to zero will ignore the error and set the approved "fips-indicator"
+to 0.
+
+=item "fips-indicator" (B<OSSL_KDF_PARAM_FIPS_APPROVED_INDICATOR>) <integer>
+
+A getter that returns 1 if the operation is FIPS approved, or 0 otherwise.
+This may be used after calling EVP_KDF_derive. It returns 0 if the "pkcs5"
+is set to 1 and the derived key length, salt length or iteration count test
+fails.
+This option is used by the OpenSSL FIPS provider.
 
 =back
 

--- a/include/openssl/fips_names.h
+++ b/include/openssl/fips_names.h
@@ -198,6 +198,14 @@ extern "C" {
  */
 # define OSSL_PROV_FIPS_PARAM_X963KDF_KEY_CHECK "x963kdf-key-check"
 
+/*
+ * A boolean that determines if the runtime lower bound check for PBKDF2 is
+ * performed.
+ * This is enabled by default.
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+# define OSSL_PROV_FIPS_PARAM_PBKDF2_LOWER_BOUND_CHECK "pbkdf2-lower-bound-check"
+
 # ifdef __cplusplus
 }
 # endif

--- a/providers/common/include/prov/fipscommon.h
+++ b/providers/common/include/prov/fipscommon.h
@@ -29,5 +29,6 @@ int FIPS_tls1_prf_key_check(OSSL_LIB_CTX *libctx);
 int FIPS_sshkdf_key_check(OSSL_LIB_CTX *libctx);
 int FIPS_sskdf_key_check(OSSL_LIB_CTX *libctx);
 int FIPS_x963kdf_key_check(OSSL_LIB_CTX *libctx);
+int FIPS_pbkdf2_lower_bound_check(OSSL_LIB_CTX *libctx);
 
 #endif

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -104,6 +104,7 @@ typedef struct fips_global_st {
     FIPS_OPTION fips_sshkdf_key_check;
     FIPS_OPTION fips_sskdf_key_check;
     FIPS_OPTION fips_x963kdf_key_check;
+    FIPS_OPTION fips_pbkdf2_lower_bound_check;
 } FIPS_GLOBAL;
 
 static void init_fips_option(FIPS_OPTION *opt, int enabled)
@@ -137,6 +138,7 @@ void *ossl_fips_prov_ossl_ctx_new(OSSL_LIB_CTX *libctx)
     init_fips_option(&fgbl->fips_sshkdf_key_check, 0);
     init_fips_option(&fgbl->fips_sskdf_key_check, 0);
     init_fips_option(&fgbl->fips_x963kdf_key_check, 0);
+    init_fips_option(&fgbl->fips_pbkdf2_lower_bound_check, 1);
     return fgbl;
 }
 
@@ -185,6 +187,8 @@ static const OSSL_PARAM fips_param_types[] = {
                     0),
     OSSL_PARAM_DEFN(OSSL_PROV_PARAM_X963KDF_KEY_CHECK, OSSL_PARAM_INTEGER, NULL,
                     0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_PBKDF2_LOWER_BOUND_CHECK,
+                    OSSL_PARAM_INTEGER, NULL, 0),
     OSSL_PARAM_END
 };
 
@@ -198,7 +202,7 @@ static int fips_get_params_from_core(FIPS_GLOBAL *fgbl)
     * OSSL_PROV_FIPS_PARAM_SECURITY_CHECKS and
     * OSSL_PROV_FIPS_PARAM_TLS1_PRF_EMS_CHECK are not self test parameters.
     */
-    OSSL_PARAM core_params[26], *p = core_params;
+    OSSL_PARAM core_params[27], *p = core_params;
 
     *p++ = OSSL_PARAM_construct_utf8_ptr(
             OSSL_PROV_PARAM_CORE_MODULE_FILENAME,
@@ -269,6 +273,8 @@ static int fips_get_params_from_core(FIPS_GLOBAL *fgbl)
                         fips_sskdf_key_check);
     FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_X963KDF_KEY_CHECK,
                         fips_x963kdf_key_check);
+    FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_PBKDF2_LOWER_BOUND_CHECK,
+                        fips_pbkdf2_lower_bound_check);
 #undef FIPS_FEATURE_OPTION
 
     *p = OSSL_PARAM_construct_end();
@@ -348,6 +354,8 @@ static int fips_get_params(void *provctx, OSSL_PARAM params[])
                      fips_sskdf_key_check);
     FIPS_FEATURE_GET(fgbl, OSSL_PROV_PARAM_X963KDF_KEY_CHECK,
                      fips_x963kdf_key_check);
+    FIPS_FEATURE_GET(fgbl, OSSL_PROV_PARAM_PBKDF2_LOWER_BOUND_CHECK,
+                     fips_pbkdf2_lower_bound_check);
 #undef FIPS_FEATURE_GET
     return 1;
 }
@@ -898,6 +906,7 @@ int OSSL_provider_init_int(const OSSL_CORE_HANDLE *handle,
     FIPS_SET_OPTION(fgbl, fips_sshkdf_key_check);
     FIPS_SET_OPTION(fgbl, fips_sskdf_key_check);
     FIPS_SET_OPTION(fgbl, fips_x963kdf_key_check);
+    FIPS_SET_OPTION(fgbl, fips_pbkdf2_lower_bound_check);
 #undef FIPS_SET_OPTION
 
     ossl_prov_cache_exported_algorithms(fips_ciphers, exported_fips_ciphers);
@@ -1116,6 +1125,7 @@ FIPS_FEATURE_CHECK(FIPS_tls1_prf_key_check, fips_tls1_prf_key_check)
 FIPS_FEATURE_CHECK(FIPS_sshkdf_key_check, fips_sshkdf_key_check)
 FIPS_FEATURE_CHECK(FIPS_sskdf_key_check, fips_sskdf_key_check)
 FIPS_FEATURE_CHECK(FIPS_x963kdf_key_check, fips_x963kdf_key_check)
+FIPS_FEATURE_CHECK(FIPS_pbkdf2_lower_bound_check, fips_pbkdf2_lower_bound_check)
 
 #undef FIPS_FEATURE_CHECK
 

--- a/providers/implementations/kdfs/pbkdf2.c
+++ b/providers/implementations/kdfs/pbkdf2.c
@@ -28,6 +28,7 @@
 #include "prov/providercommon.h"
 #include "prov/implementations.h"
 #include "prov/provider_util.h"
+#include "prov/fipscommon.h"
 #include "prov/fipsindicator.h"
 #include "pbkdf2.h"
 
@@ -205,11 +206,6 @@ static int pbkdf2_lower_bound_check_passed(int saltlen, uint64_t iter,
 }
 
 #ifdef FIPS_MODULE
-static int fips_lower_bound_check_enabled(OSSL_LIB_CTX *libctx)
-{
-    return ossl_kdf_pbkdf2_default_checks; /* Always is 1 */
-}
-
 static int fips_lower_bound_check_passed(KDF_PBKDF2 *ctx, size_t keylen)
 {
     OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(ctx->provctx);
@@ -221,7 +217,7 @@ static int fips_lower_bound_check_passed(KDF_PBKDF2 *ctx, size_t keylen)
     if (!approved) {
         if (!OSSL_FIPS_IND_ON_UNAPPROVED(ctx, OSSL_FIPS_IND_SETTABLE0, libctx,
                                          "PBKDF2", desc,
-                                         fips_lower_bound_check_enabled)) {
+                                         FIPS_pbkdf2_lower_bound_check)) {
             ERR_raise(ERR_LIB_PROV, error);
             return 0;
         }

--- a/test/recipes/03-test_fipsinstall.t
+++ b/test/recipes/03-test_fipsinstall.t
@@ -30,7 +30,8 @@ my @pedantic_okay =
 
 # Incompatible options for pedantic FIPS compliance
 my @pedantic_fail =
-    ( 'no_conditional_errors', 'no_security_checks', 'self_test_oninstall' );
+    ( 'no_conditional_errors', 'no_security_checks', 'self_test_oninstall',
+      'no_pbkdf2_lower_bound_check' );
 
 plan tests => 35 + (scalar @pedantic_okay) + (scalar @pedantic_fail);
 

--- a/test/recipes/30-test_evp_data/evpkdf_pbkdf2.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_pbkdf2.txt
@@ -13,6 +13,7 @@
 
 Title = PBKDF2 tests
 
+Availablein = default
 KDF = PBKDF2
 Ctrl.pkcs5 = pkcs5:1
 Ctrl.pass = pass:password
@@ -21,6 +22,7 @@ Ctrl.iter = iter:1
 Ctrl.digest = digest:sha1
 Output = 0c60c80f961f0e71f3a9b524af6012062fe037a6
 
+Availablein = default
 KDF = PBKDF2
 Ctrl.pkcs5 = pkcs5:1
 Ctrl.pass = pass:password
@@ -29,6 +31,7 @@ Ctrl.iter = iter:1
 Ctrl.digest = digest:sha256
 Output = 120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b
 
+Availablein = default
 KDF = PBKDF2
 Ctrl.pkcs5 = pkcs5:1
 Ctrl.pass = pass:password
@@ -37,6 +40,7 @@ Ctrl.iter = iter:1
 Ctrl.digest = digest:sha512
 Output = 867f70cf1ade02cff3752599a3a53dc4af34c7a669815ae5d513554e1c8cf252c02d470a285a0501bad999bfe943c08f050235d7d68b1da55e63f73b60a57fce
 
+Availablein = default
 KDF = PBKDF2
 Ctrl.pkcs5 = pkcs5:1
 Ctrl.pass = pass:password
@@ -45,6 +49,7 @@ Ctrl.iter = iter:2
 Ctrl.digest = digest:sha1
 Output = ea6c014dc72d6f8ccd1ed92ace1d41f0d8de8957
 
+Availablein = default
 KDF = PBKDF2
 Ctrl.pkcs5 = pkcs5:1
 Ctrl.pass = pass:password
@@ -53,6 +58,7 @@ Ctrl.iter = iter:2
 Ctrl.digest = digest:sha256
 Output = ae4d0c95af6b46d32d0adff928f06dd02a303f8ef3c251dfd6e2d85a95474c43
 
+Availablein = default
 KDF = PBKDF2
 Ctrl.pkcs5 = pkcs5:1
 Ctrl.pass = pass:password
@@ -61,6 +67,7 @@ Ctrl.iter = iter:2
 Ctrl.digest = digest:sha512
 Output = e1d9c16aa681708a45f5c7c4e215ceb66e011a2e9f0040713f18aefdb866d53cf76cab2868a39b9f7840edce4fef5a82be67335c77a6068e04112754f27ccf4e
 
+Availablein = default
 KDF = PBKDF2
 Ctrl.pkcs5 = pkcs5:1
 Ctrl.pass = pass:password
@@ -69,6 +76,7 @@ Ctrl.iter = iter:4096
 Ctrl.digest = digest:sha1
 Output = 4b007901b765489abead49d926f721d065a429c1
 
+Availablein = default
 KDF = PBKDF2
 Ctrl.pkcs5 = pkcs5:1
 Ctrl.pass = pass:password
@@ -77,6 +85,7 @@ Ctrl.iter = iter:4096
 Ctrl.digest = digest:sha256
 Output = c5e478d59288c841aa530db6845c4c8d962893a001ce4e11a4963873aa98134a
 
+Availablein = default
 KDF = PBKDF2
 Ctrl.pkcs5 = pkcs5:1
 Ctrl.pass = pass:password
@@ -106,6 +115,7 @@ Ctrl.iter = iter:4096
 Ctrl.digest = digest:sha512
 Output = 8c0511f4c6e597c6ac6315d8f0362e225f3c501495ba23b868c005174dc4ee71115b59f9e60cd9532fa33e0f75aefe30225c583a186cd82bd4daea9724a3d3b8
 
+Availablein = default
 KDF = PBKDF2
 Ctrl.pkcs5 = pkcs5:1
 Ctrl.hexpass = hexpass:7061737300776f7264
@@ -114,6 +124,7 @@ Ctrl.iter = iter:4096
 Ctrl.digest = digest:sha1
 Output = 56fa6aa75548099dcc37d7f03425e0c3
 
+Availablein = default
 KDF = PBKDF2
 Ctrl.pkcs5 = pkcs5:1
 Ctrl.hexpass = hexpass:7061737300776f7264
@@ -122,6 +133,7 @@ Ctrl.iter = iter:4096
 Ctrl.digest = digest:sha256
 Output = 89b69d0516f829893c696226650a8687
 
+Availablein = default
 KDF = PBKDF2
 Ctrl.pkcs5 = pkcs5:1
 Ctrl.hexpass = hexpass:7061737300776f7264
@@ -130,6 +142,7 @@ Ctrl.iter = iter:4096
 Ctrl.digest = digest:sha512
 Output = 9d9e9c4cd21fe4be24d5b8244c759665
 
+Availablein = default
 KDF = PBKDF2
 Ctrl.pkcs5 = pkcs5:1
 Ctrl.pass = pass:password
@@ -138,6 +151,7 @@ Ctrl.iter = iter:4096
 Ctrl.digest = digest:sha3-224
 Output = 691292bc3683d7d41ea2910f5b3eed23
 
+Availablein = default
 KDF = PBKDF2
 Ctrl.pkcs5 = pkcs5:1
 Ctrl.pass = pass:password
@@ -146,6 +160,7 @@ Ctrl.iter = iter:4096
 Ctrl.digest = digest:sha3-256
 Output = 778b6e237a0f49621549ff70d218d208
 
+Availablein = default
 KDF = PBKDF2
 Ctrl.pkcs5 = pkcs5:1
 Ctrl.pass = pass:password
@@ -154,6 +169,7 @@ Ctrl.iter = iter:4096
 Ctrl.digest = digest:sha3-384
 Output = 9a5f1e45e8b83f1b259ba72d11c59087
 
+Availablein = default
 KDF = PBKDF2
 Ctrl.pkcs5 = pkcs5:1
 Ctrl.pass = pass:password
@@ -164,6 +180,7 @@ Output = 2bfaf2d5ceb6d10f5e262cd902488cfd
 
 Title = PBKDF2 tests for empty inputs
 
+Availablein = default
 KDF = PBKDF2
 Ctrl.pkcs5 = pkcs5:1
 Ctrl.pass = pass:
@@ -172,6 +189,7 @@ Ctrl.iter = iter:1
 Ctrl.digest = digest:sha1
 Output = a33dddc30478185515311f8752895d36ea4363a2
 
+Availablein = default
 KDF = PBKDF2
 Ctrl.pkcs5 = pkcs5:1
 Ctrl.pass = pass:
@@ -180,6 +198,7 @@ Ctrl.iter = iter:1
 Ctrl.digest = digest:sha256
 Output = f135c27993baf98773c5cdb40a5706ce6a345cde
 
+Availablein = default
 KDF = PBKDF2
 Ctrl.pkcs5 = pkcs5:1
 Ctrl.pass = pass:
@@ -205,3 +224,36 @@ Ctrl.salt = salt:salt
 Ctrl.iter = iter:1
 Ctrl.digest = digest:shake-128
 Result = KDF_CTRL_ERROR
+
+Title = FIPS indicator tests
+
+# Test that the operation with unapproved parameters is rejected
+FIPSversion = >=3.4.0
+KDF = PBKDF2
+Ctrl.pass = pass:password
+Ctrl.salt = salt:salt
+Ctrl.iter = iter:4096
+Ctrl.digest = digest:sha1
+Result = KDF_CTRL_ERROR
+
+# Test that the operation with unapproved parameters is reported as unapproved
+FIPSversion = >=3.4.0
+KDF = PBKDF2
+Unapproved = 1
+Ctrl.pkcs5 = pkcs5:1
+Ctrl.pass = pass:password
+Ctrl.salt = salt:salt
+Ctrl.iter = iter:4096
+Ctrl.digest = digest:sha1
+Output = 4b007901b765489abead49d926f721d065a429c1
+
+# Test that the operation with approved parameters and unapproved pkcs5 value is
+# reposted as approved
+FIPSversion = >=3.4.0
+KDF = PBKDF2
+Ctrl.pkcs5 = pkcs5:1
+Ctrl.pass = pass:password
+Ctrl.salt = salt:saltSALTsaltSALTsaltSALTsaltSALTsalt
+Ctrl.iter = iter:4096
+Ctrl.digest = digest:sha1
+Output = 043c508e57c6427036fd2c6cd2a02ec7530a412c

--- a/util/mk-fipsmodule-cnf.pl
+++ b/util/mk-fipsmodule-cnf.pl
@@ -20,6 +20,7 @@ my $dsa_sign_disabled = 1;
 my $tdes_encrypt_disabled = 1;
 my $rsa_sign_x931_pad_disabled = 1;
 my $kdf_key_check = 1;
+my $pbkdf2_lower_bound_check = 1;
 
 my $activate = 1;
 my $version = 1;
@@ -72,4 +73,5 @@ tls1-prf-key-check = $kdf_key_check
 sshkdf-key-check = $kdf_key_check
 sskdf-key-check = $kdf_key_check
 x963kdf-key-check = $kdf_key_check
+pbkdf2-lower-bound-check = $pbkdf2_lower_bound_check
 _____

--- a/util/perl/OpenSSL/paramnames.pm
+++ b/util/perl/OpenSSL/paramnames.pm
@@ -49,6 +49,7 @@ my %params = (
     'PROV_PARAM_SSHKDF_KEY_CHECK' =>       "sshkdf-key-check",       # uint
     'PROV_PARAM_SSKDF_KEY_CHECK' =>        "sskdf-key-check",        # uint
     'PROV_PARAM_X963KDF_KEY_CHECK' =>      "x963kdf-key-check",      # uint
+    'PROV_PARAM_PBKDF2_LOWER_BOUND_CHECK' => "pbkdf2-lower-bound-check", # uint
 
 # Self test callback parameters
     'PROV_PARAM_SELF_TEST_PHASE' =>  "st-phase",# utf8_string


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

Use new indicator framework to provide a indicator for determining whether the operation is FIPS compliant.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
