### PR TITLE
fuzz/decoder.c: Limit the EVP_PKEY_param_check on DHX keys as well

### DIFF
--- a/fuzz/decoder.c
+++ b/fuzz/decoder.c
@@ -68,7 +68,8 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
          * Param check will take too long time on large DH parameters.
          * Skip it.
          */
-        if (!EVP_PKEY_is_a(pkey, "DH") || EVP_PKEY_get_bits(pkey) <= 8192)
+        if ((!EVP_PKEY_is_a(pkey, "DH") && !EVP_PKEY_is_a(pkey, "DHX"))
+            || EVP_PKEY_get_bits(pkey) <= 8192)
             EVP_PKEY_param_check(ctx);
 
         EVP_PKEY_public_check(ctx);


### PR DESCRIPTION
The safe-prime check is done regardless of the decoded key type.
Refer #24049