### PR TITLE
Fix fragile explicit cert date tests.

### DIFF
--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -609,7 +609,7 @@ ok(run(app(["openssl", "x509", "-in", "testreq-cert.pem",
             "-noout", "-text"])), "cert verification");
 
 # Generate cert with explicit start and end dates
-my $today = strftime("%Y-%m-%d", localtime);
+my %today = (strftime("%Y-%m-%d", gmtime) => 1);
 my $cert = "self-signed_explicit_date.pem";
 ok(run(app(["openssl", "req", "-x509", "-new", "-text",
             "-config", srctop_file('test', 'test.cnf'),
@@ -617,5 +617,6 @@ ok(run(app(["openssl", "req", "-x509", "-new", "-text",
             "-not_before", "today",
             "-not_after", "today",
             "-out", $cert]))
-&& get_not_before_date($cert) eq $today
-&& get_not_after_date($cert) eq $today, "explicit start and end dates");
+&& ++$today{strftime("%Y-%m-%d", gmtime)}
+&& (grep { defined $today{$_} } get_not_before_date($cert))
+&& (grep { defined $today{$_} } get_not_after_date($cert)), "explicit start and end dates");

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -255,16 +255,16 @@ ok(run(app(["openssl", "x509", "-req", "-text", "-CAcreateserial",
 ok(-e $ca_serial_dot_in_dir);
 
 # Tests for explict start and end dates of certificates
-my $today;
+my %today = (strftime("%Y-%m-%d", gmtime) => 1);
 my $enddate;
-$today = strftime("%Y-%m-%d", localtime);
 ok(run(app(["openssl", "x509", "-req", "-text",
 	    "-key", $b_key,
 	    "-not_before", "20231031000000Z",
 	    "-not_after", "today",
             "-in", $b_csr, "-out", $b_cert]))
 && get_not_before($b_cert) =~ /Oct 31 00:00:00 2023 GMT/
-&& get_not_after_date($b_cert) eq $today);
+&& ++$today{strftime("%Y-%m-%d", gmtime)}
+&& (grep { defined $today{$_} } get_not_after_date($b_cert)));
 # explicit start and end dates
 ok(run(app(["openssl", "x509", "-req", "-text",
 	    "-key", $b_key,
@@ -275,14 +275,15 @@ ok(run(app(["openssl", "x509", "-req", "-text",
 && get_not_before($b_cert) =~ /Oct 31 00:00:00 2023 GMT/
 && get_not_after($b_cert) =~ /Dec 31 00:00:00 2023 GMT/);
 # start date today and days
-$today = strftime("%Y-%m-%d", localtime);
-$enddate = strftime("%Y-%m-%d", localtime(time + 99 * 24 * 60 * 60));
+%today = (strftime("%Y-%m-%d", gmtime) => 1);
+$enddate = strftime("%Y-%m-%d", gmtime(time + 99 * 24 * 60 * 60));
 ok(run(app(["openssl", "x509", "-req", "-text",
 	    "-key", $b_key,
 	    "-not_before", "today",
 	    "-days", "99",
             "-in", $b_csr, "-out", $b_cert]))
-&& get_not_before_date($b_cert) eq $today
+&& ++$today{strftime("%Y-%m-%d", gmtime)}
+&& (grep { defined $today{$_} } get_not_before_date($b_cert))
 && get_not_after_date($b_cert) eq $enddate);
 # end date before start date
 ok(!run(app(["openssl", "x509", "-req", "-text",
@@ -291,12 +292,13 @@ ok(!run(app(["openssl", "x509", "-req", "-text",
 	      "-not_after", "20231031000000Z",
               "-in", $b_csr, "-out", $b_cert])));
 # default days option
-$today = strftime("%Y-%m-%d", localtime);
-$enddate = strftime("%Y-%m-%d", localtime(time + 30 * 24 * 60 * 60));
+%today = (strftime("%Y-%m-%d", gmtime) => 1);
+$enddate = strftime("%Y-%m-%d", gmtime(time + 30 * 24 * 60 * 60));
 ok(run(app(["openssl", "x509", "-req", "-text",
 	    "-key", $b_key,
             "-in", $b_csr, "-out", $b_cert]))
-&& get_not_before_date($b_cert) eq $today
+&& ++$today{strftime("%Y-%m-%d", gmtime)}
+&& (grep { defined $today{$_} } get_not_before_date($b_cert))
 && get_not_after_date($b_cert) eq $enddate);
 
 SKIP: {


### PR DESCRIPTION
The tests used `localtime` to format "today's" date, but then extracted a GMT date from the cert.  The comparison breaks when run late in the evening west of UTC, or early in the AM hours east of UTC.

Also took care of case when test runs at stroke of midnight, by accepting either the "today" before the cert creation, or the "today" after, should they be different.

Fixes fragile tests in #21716