### PR TITLE
Avoid duplicate dir search

### DIFF
--- a/crypto/x509/by_store.c
+++ b/crypto/x509/by_store.c
@@ -111,14 +111,7 @@ static int by_store_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argp,
 {
     switch (cmd) {
     case X509_L_ADD_STORE:
-        /* If no URI is given, use the default cert dir as default URI */
-        if (argp == NULL)
-            argp = ossl_safe_getenv(X509_get_default_cert_dir_env());
-
-        if (argp == NULL)
-            argp = X509_get_default_cert_dir();
-
-        {
+        if (argp != NULL) {
             STACK_OF(OPENSSL_STRING) *uris = X509_LOOKUP_get_method_data(ctx);
             char *data = OPENSSL_strdup(argp);
 
@@ -131,12 +124,15 @@ static int by_store_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argp,
             }
             return sk_OPENSSL_STRING_push(uris, data) > 0;
         }
+        /* NOP if no URI is given. */
+        return 1;
     case X509_L_LOAD_STORE:
         /* This is a shortcut for quick loading of specific containers */
         return cache_objects(ctx, argp, NULL, 0, libctx, propq);
+    default:
+        /* Unsupported command */
+        return 0;
     }
-
-    return 0;
 }
 
 static int by_store_ctrl(X509_LOOKUP *ctx, int cmd,

--- a/crypto/x509/x509_d2.c
+++ b/crypto/x509/x509_d2.c
@@ -30,6 +30,11 @@ int X509_STORE_set_default_paths_ex(X509_STORE *ctx, OSSL_LIB_CTX *libctx,
     lookup = X509_STORE_add_lookup(ctx, X509_LOOKUP_store());
     if (lookup == NULL)
         return 0;
+    /*
+     * The NULL URI argument will activate any default URIs (presently none),
+     * DO NOT pass the default CApath or CAfile, they're already handled above,
+     * likely much more efficiently.
+     */
     X509_LOOKUP_add_store_ex(lookup, NULL, libctx, propq);
 
     /* clear any errors */


### PR DESCRIPTION
This avoids adding the default CApath to the list of sources for "store" lookups, it is already on the legacy directory search list.

Is including the default search directory (or else the `SSL_CERT_DIR` environment variable value) in the store lookup list required in some situations???

Note, this is based on PR #24139 that fixes tests that failed (depending on time of day), while testing this PR.