### PR TITLE
Comment Syntax Fixes

### DIFF
--- a/util/checkplatformsyms.pl
+++ b/util/checkplatformsyms.pl
@@ -1,11 +1,13 @@
-#! /usr/bin/env perl
-# Copyright 2006-2023 The OpenSSL Project Authors. All Rights Reserved.
-#
-# Licensed under the Apache License 2.0 (the "License").  You may not use
-# this file except in compliance with the License.  You can obtain a copy
-# in the file LICENSE in the source distribution or at
-# https://www.openssl.org/source/license.html
-
+/*
+ *! /usr/bin/env perl
+ * Copyright 2006-2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+ 
 use warnings;
 use strict;
 use Config;

--- a/util/ck_errf.pl
+++ b/util/ck_errf.pl
@@ -1,17 +1,19 @@
-#! /usr/bin/env perl
-# Copyright 1995-2018 The OpenSSL Project Authors. All Rights Reserved.
-#
-# Licensed under the Apache License 2.0 (the "License").  You may not use
-# this file except in compliance with the License.  You can obtain a copy
-# in the file LICENSE in the source distribution or at
-# https://www.openssl.org/source/license.html
+/*
+ *! /usr/bin/env perl
+ * Copyright 1995-2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
 
-# This is just a quick script to scan for cases where the 'error'
-# function name in a XXXerr() macro is wrong.
-#
-# Run in the top level by going
-# perl util/ck_errf.pl */*.c */*/*.c
-#
+/* This is just a quick script to scan for cases where the 'error'
+ * function name in a XXXerr() macro is wrong.
+ *
+ * Run in the top level by going
+ * perl util/ck_errf.pl */*.c */*/*.c
+ */
 
 use strict;
 use warnings;
@@ -80,11 +82,11 @@ if ( $internal ) {
     @source = @ARGV;
 }
 
-# To detect if there is any error generation for a libcrypto/libssl libs
-# we don't know, we need to find out what libs we do know.  That list is
-# readily available in crypto/err/openssl.ec, in form of lines starting
-# with "L ".  Note that we always rely on the modules SYS and ERR to be
-# generally available.
+/* To detect if there is any error generation for a libcrypto/libssl libs
+ * we don't know, we need to find out what libs we do know.  That list is
+ * readily available in crypto/err/openssl.ec, in form of lines starting
+ * with "L ".  Note that we always rely on the modules SYS and ERR to be
+ * generally available. */
 my %libs       = ( SYS => 1, ERR => 1 );
 open my $cfh, $config or die "Trying to read $config: $!\n";
 while (<$cfh>) {

--- a/util/copy.pl
+++ b/util/copy.pl
@@ -1,10 +1,12 @@
-#! /usr/bin/env perl
-# Copyright 2005-2018 The OpenSSL Project Authors. All Rights Reserved.
-#
-# Licensed under the Apache License 2.0 (the "License").  You may not use
-# this file except in compliance with the License.  You can obtain a copy
-# in the file LICENSE in the source distribution or at
-# https://www.openssl.org/source/license.html
+/*
+ *! /usr/bin/env perl
+ * Copyright 2005-2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
 
 
 use Fcntl;
@@ -12,8 +14,8 @@ use Fcntl;
 
 # copy.pl
 
-# Perl script 'copy' comment. On Windows the built in "copy" command also
-# copies timestamps: this messes up Makefile dependencies.
+/* Perl script 'copy' comment. On Windows the built in "copy" command also
+ * copies timestamps: this messes up Makefile dependencies. */
 
 my $stripcr = 0;
 

--- a/util/dofile.pl
+++ b/util/dofile.pl
@@ -21,7 +21,7 @@ use Getopt::Std;
 use OpenSSL::Template;
 
 # We expect to get a lot of information from configdata, so check that
-# it was part of our commandline.
+# it was part of our command line.
 die "You must run this script with -Mconfigdata\n"
     if !exists($config{target});
 
@@ -90,9 +90,9 @@ foreach (@template_settings) {
                                  autowarntext => \@autowarntext },
                        BROKEN => \&errorcallback,
                        PREPEND => $prepend,
-                       # To ensure that global variables and functions
-                       # defined in one template stick around for the
-                       # next, making them combinable
+                       /* To ensure that global variables and functions
+                        * defined in one template stick around for the
+                        * next, making them combinable */
                        PACKAGE => 'OpenSSL::safe');
     exit 1 if $failed;
 

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -121,46 +121,48 @@ my %collected_tags = ();
 # We cache results based on tags
 my %collected_results = ();
 
-# files OPTIONS
-#
-# Example:
-#
-#       files(TAGS => 'manual');
-#       files(TAGS => [ 'manual', 'man1' ]);
-#
-# This function returns an array of files corresponding to a set of tags
-# given with the options "TAGS".  The value of this option can be a single
-# word, or an array of several words, which work as inclusive or exclusive
-# selectors.  Inclusive selectors are used to add one more set of files to
-# the returned array, while exclusive selectors limit the set of files added
-# to the array.  The recognised tag values are:
-#
-# 'public_manual'       - inclusive selector, adds public manuals to the
-#                         returned array of files.
-# 'internal_manual'     - inclusive selector, adds internal manuals to the
-#                         returned array of files.
-# 'manual'              - inclusive selector, adds any manual to the returned
-#                         array of files.  This is really a shorthand for
-#                         'public_manual' and 'internal_manual' combined.
-# 'public_header'       - inclusive selector, adds public headers to the
-#                         returned array of files.
-# 'header'              - inclusive selector, adds any header file to the
-#                         returned array of files.  Since we currently only
-#                         care about public headers, this is exactly
-#                         equivalent to 'public_header', but is present for
-#                         consistency.
-#
-# 'man1', 'man3', 'man5', 'man7'
-#                       - exclusive selectors, only applicable together with
-#                         any of the manual selectors.  If any of these are
-#                         present, only the manuals from the given sections
-#                         will be included.  If none of these are present,
-#                         the manuals from all sections will be returned.
-#
-# All returned manual files come from configdata.pm.
-# All returned header files come from looking inside
-# "$config{sourcedir}/include/openssl"
-#
+/*-
+ * files OPTIONS
+ *
+ * Example:
+ *
+ *       files(TAGS => 'manual');
+ *       files(TAGS => [ 'manual', 'man1' ]);
+ *
+ * This function returns an array of files corresponding to a set of tags
+ * given with the options "TAGS".  The value of this option can be a single
+ * word, or an array of several words, which work as inclusive or exclusive
+ * selectors.  Inclusive selectors are used to add one more set of files to
+ * the returned array, while exclusive selectors limit the set of files added
+ * to the array.  The recognised tag values are:
+ *
+ * 'public_manual'       - inclusive selector, adds public manuals to the
+ *                         returned array of files.
+ * 'internal_manual'     - inclusive selector, adds internal manuals to the
+ *                         returned array of files.
+ * 'manual'              - inclusive selector, adds any manual to the returned
+ *                         array of files.  This is really a shorthand for
+ *                         'public_manual' and 'internal_manual' combined.
+ * 'public_header'       - inclusive selector, adds public headers to the
+ *                         returned array of files.
+ * 'header'              - inclusive selector, adds any header file to the
+ *                         returned array of files.  Since we currently only
+ *                         care about public headers, this is exactly
+ *                         equivalent to 'public_header', but is present for
+ *                         consistency.
+ *
+ * 'man1', 'man3', 'man5', 'man7'
+ *                       - exclusive selectors, only applicable together with
+ *                         any of the manual selectors.  If any of these are
+ *                         present, only the manuals from the given sections
+ *                         will be included.  If none of these are present,
+ *                         the manuals from all sections will be returned.
+ *
+ * All returned manual files come from configdata.pm.
+ * All returned header files come from looking inside
+ * "$config{sourcedir}/include/openssl"
+ *
+ */
 sub files {
     my %opts = ( @_ );          # Make a copy of the arguments
 
@@ -194,11 +196,11 @@ sub files {
         print STDERR "DEBUG[files]: collecting public manuals\n"
             if $debug;
 
-        # The structure in configdata.pm is that $unified_info{mandocs}
-        # contains lists of man files, and in turn, $unified_info{depends}
-        # contains hash tables showing which POD file each of those man
-        # files depend on.  We use that information to find the POD files,
-        # and to attach the man section they belong to as tags
+        /* The structure in configdata.pm is that $unified_info{mandocs}
+         * contains lists of man files, and in turn, $unified_info{depends}
+         * contains hash tables showing which POD file each of those man
+         * files depend on. We use that information to find the POD files,
+         * and to attach the man section they belong to as tags */
         foreach my $mansect ( @sections ) {
             foreach ( map { @{$unified_info{depends}->{$_}} }
                       @{$unified_info{mandocs}->{$mansect}} ) {
@@ -212,8 +214,8 @@ sub files {
         print STDERR "DEBUG[files]: collecting internal manuals\n"
             if $debug;
 
-        # We don't have the internal docs in configdata.pm.  However, they
-        # are all in the source tree, so they're easy to find.
+        /* We don't have the internal docs in configdata.pm.  However, they
+         * are all in the source tree, so they're easy to find. */
         foreach my $mansect ( @sections ) {
             foreach ( glob(catfile($config{sourcedir},
                                    'doc', 'internal', $mansect, '*.pod')) ) {
@@ -240,8 +242,8 @@ sub files {
         foreach my $type ( ( 'public_manual', 'internal_manual' ) ) {
             next unless $tags{$type};
 
-            # If caller asked for specific sections, we care about sections.
-            # Otherwise, we give back all of them.
+            /* If caller asked for specific sections, we care about sections.
+             * Otherwise, we give back all of them. */
             my @selected_sections =
                 grep { $tags{$_} } @sections;
             @selected_sections = @sections unless @selected_sections;
@@ -276,7 +278,7 @@ sub err {
     $status = 1
 }
 
-# Cross-check functions in the NAME and SYNOPSIS section.
+# Cross-check functions in the NAME and SYNOPSIS sections.
 sub name_synopsis {
     my $id = shift;
     my $filename = shift;
@@ -328,10 +330,10 @@ sub name_synopsis {
     # Remove all comments
     $syn =~ s/\/\*.*?\*\///msg;
     while ( $syn ) {
-        # "env" lines end at a newline.
-        # Preprocessor lines start with a # and end at a newline.
-        # Other lines end with a semicolon, and may cover more than
-        # one physical line.
+        /* "env" lines end at a newline.
+         * Preprocessor lines start with a # and end at a newline.
+         * Other lines end with a semicolon, and may cover more than
+         * one physical line. */
         if ( $syn !~ /^ \s*(env .*?|#.*?|.*?;)\s*$/ms ) {
             err($id, "Can't parse rest of synopsis:\n$syn\n(declarations not ending with a semicolon (;)?)");
             last;
@@ -464,13 +466,13 @@ sub check_head_style {
     }
 }
 
-# Because we have options and symbols with extra markup, we need
-# to take that into account, so we need a regexp that extracts
-# markup chunks, including recursive markup.
+/* Because we have options and symbols with extra markup, we need
+ * to take that into account, so we need a regexp that extracts
+ * markup chunks, including recursive markup. */
 # please read up on /(?R)/ in perlre(1)
-# (note: order is important, (?R) needs to come before .)
-# (note: non-greedy is important, or something like 'B<foo> and B<bar>'
-# will be captured as one item)
+/* (note: order is important, (?R) needs to come before .)
+ * (note: non-greedy is important, or something like 'B<foo> and B<bar>'
+ * will be captured as one item) */
 my $markup_re =
     qr/(                        # Capture group
            [BIL]<               # The start of what we recurse on
@@ -481,10 +483,10 @@ my $markup_re =
            >                    # The end of what we recurse on
        )/x;                     # (the x allows this sort of split up regexp)
 
-# Options must start with a dash, followed by a letter, possibly
-# followed by letters, digits, dashes and underscores, and the last
-# character must be a letter or a digit.
-# We do also accept the single -? or -n, where n is a digit
+/* Options must start with a dash, followed by a letter, possibly
+ * followed by letters, digits, dashes and underscores, and the last
+ * character must be a letter or a digit.
+ * We do also accept the single -? or -n, where n is a digit */
 my $option_re =
     qr/(?:
             \?                  # Single question mark
@@ -496,11 +498,11 @@ my $option_re =
             [[:alpha:]](?:[-_[:alnum:]]*?[[:alnum:]])?
        )/x;
 
-# Helper function to check if a given $thing is properly marked up
-# option.  It returns one of these values:
-#     undef         if it's not an option
-#     ""            if it's a malformed option
-#     $unwrapped    the option with the outermost B<> wrapping removed.
+/* Helper function to check if a given $thing is properly marked up
+ * option.  It returns one of these values:
+ *     undef         if it's not an option
+ *     ""            if it's a malformed option
+ *     $unwrapped    the option with the outermost B<> wrapping removed. */
 sub normalise_option {
     my $id = shift;
     my $filename = shift;
@@ -525,9 +527,9 @@ sub normalise_option {
     return undef;               # Something else
 }
 
-# Checks of command option (man1) formatting.  The man1 checks are
-# restricted to the SYNOPSIS and OPTIONS sections, the rest is too
-# free form, we simply cannot be too strict there.
+/* Checks of command option (man1) formatting.  The man1 checks are
+ * restricted to the SYNOPSIS and OPTIONS sections, the rest is too
+ * free form, we simply cannot be too strict there. */
 
 sub option_check {
     my $id = shift;
@@ -594,9 +596,9 @@ sub option_check {
 # Normal symbol form
 my $symbol_re = qr/[[:alpha:]_][_[:alnum:]]*?/;
 
-# Checks of function name (man3) formatting.  The man3 checks are
-# easier than the man1 checks, we only check the names followed by (),
-# and only the names that have POD markup.
+/* Checks of function name (man3) formatting.  The man3 checks are
+ * easier than the man1 checks, we only check the names followed by (),
+ * and only the names that have POD markup. */
 sub functionname_check {
     my $id = shift;
     my $filename = shift;
@@ -614,10 +616,10 @@ sub functionname_check {
             unless $symbol =~ /^B<.*?>$/ && $unmarked =~ /^${symbol_re}$/
     }
 
-    # We can't do the kind of collecting coolness that option_check()
-    # does, because there are too many things that can't be found in
-    # name repositories like the NAME sections, such as symbol names
-    # with a variable part (typically marked up as B<foo_I<TYPE>_bar>
+    /* We can't do the kind of collecting coolness that option_check()
+     * does, because there are too many things that can't be found in
+     * name repositories like the NAME sections, such as symbol names
+     * with a variable part (typically marked up as B<foo_I<TYPE>_bar> */
 }
 
 # This is from http://man7.org/linux/man-pages/man7/man-pages.7.html
@@ -719,9 +721,9 @@ sub check {
     while ( $contents =~ /$markup_re/msg ) {
         my $target = $1;
         next unless $target =~ /^L<(.*)>$/;     # Skip if not L<...>
-        $target = $1;                           # Peal away L< and >
-        $target =~ s/\/[^\/]*$//;               # Peal away possible anchor
-        $target =~ s/.*\|//g;                   # Peal away possible link text
+        $target = $1;                           # Peel away L< and >
+        $target =~ s/\/[^\/]*$//;               # Peel away possible anchor
+        $target =~ s/.*\|//g;                   # Peel away possible link text
         next if $target eq '';                  # Skip if links within page, or
         next if $target =~ /::/;                #   links to a Perl module, or
         next if $target =~ /^https?:/;          #   is a URL link, or
@@ -826,27 +828,27 @@ sub check {
 
 # Map of links in each POD file; filename => [ "foo(1)", "bar(3)", ... ]
 my %link_map = ();
-# Map of names in each POD file or from "missing" files; possible values are:
-# If found in a POD files, "name(s)" => filename
-# If found in a "missing" file or external, "name(s)" => ''
+/* Map of names in each POD file or from "missing" files; possible values are:
+ * If found in a POD files, "name(s)" => filename
+ * If found in a "missing" file or external, "name(s)" => '' */
 my %name_map = ();
 
-# State of man-page names.
-# %state is affected by loading util/*.num and util/*.syms
-# Values may be one of:
-# 'crypto' : belongs in libcrypto (loaded from libcrypto.num)
-# 'ssl' : belongs in libssl (loaded from libssl.num)
-# 'other' : belongs in libcrypto or libssl (loaded from other.syms)
-# 'internal' : Internal
-# 'public' : Public (generic name or external documentation)
-# Any of these values except 'public' may be prefixed with 'missing_'
-# to indicate that they are known to be missing.
+/* State of man-page names.
+ * %state is affected by loading util/*.num and util/*.syms
+ * Values may be one of:
+ * 'crypto' : belongs in libcrypto (loaded from libcrypto.num)
+ * 'ssl' : belongs in libssl (loaded from libssl.num)
+ * 'other' : belongs in libcrypto or libssl (loaded from other.syms)
+ * 'internal' : Internal
+ * 'public' : Public (generic name or external documentation)
+ * Any of these values except 'public' may be prefixed with 'missing_'
+ * to indicate that they are known to be missing. */
 my %state;
-# %missing is affected by loading util/missing*.txt.  Values may be one of:
-# 'crypto' : belongs in libcrypto (loaded from libcrypto.num)
-# 'ssl' : belongs in libssl (loaded from libssl.num)
-# 'other' : belongs in libcrypto or libssl (loaded from other.syms)
-# 'internal' : Internal
+/* %missing is affected by loading util/missing*.txt.  Values may be one of:
+ * 'crypto' : belongs in libcrypto (loaded from libcrypto.num)
+ * 'ssl' : belongs in libssl (loaded from libssl.num)
+ * 'other' : belongs in libcrypto or libssl (loaded from other.syms)
+ * 'internal' : Internal */
 my %missing;
 
 # Parse libcrypto.num, etc., and return sorted list of what's there.
@@ -894,13 +896,13 @@ sub checkstate () {
     foreach ( grep { $_ =~ /\(3\)$/ } sort keys %names ) {
         next if ( $name_map{$_} // '') eq '' || $_ =~ /$ignored/;
 
-        # If a man-page isn't recorded public or if it's recorded missing
-        # and internal, it's declared to be internal.
+        /* If a man-page isn't recorded public or if it's recorded missing
+         * and internal, it's declared to be internal. */
         my $declared_internal =
             ($state{$_} // 'internal') eq 'internal'
             || ($missing{$_} // '') eq 'internal';
-        # If a man-page isn't recorded internal or if it's recorded missing
-        # and not internal, it's declared to be public
+        /* If a man-page isn't recorded internally or if it's recorded missing
+         * and not internal, it's declared to be public */
         my $declared_public =
             ($state{$_} // 'internal') ne 'internal'
             || ($missing{$_} // 'internal') ne 'internal';
@@ -912,8 +914,8 @@ sub checkstate () {
     }
 }
 
-# Check for undocumented macros; ignore those in the "missing" file
-# and do simple check for #define in our header files.
+/* Check for undocumented macros; ignore those in the "missing" file
+ * and do simple check for #define in our header files. */
 sub checkmacros {
     my $count = 0;
     my %seen;
@@ -945,8 +947,8 @@ sub checkmacros {
         if $count > 0;
 }
 
-# Find out what is undocumented (filtering out the known missing ones)
-# and display them.
+/* Find out what is undocumented (filtering out the known missing ones)
+ * and display them. */
 sub printem ($) {
     my $type = shift;
     my $count = 0;
@@ -1004,10 +1006,10 @@ sub collectnames {
     }
 
     my @links = ();
-    # Don't use this regexp directly on $podinfo{contents}, as it causes
-    # a regexp recursion, which fails on really big PODs.  Instead, use
-    # $markup_re to pick up general markup, and use this regexp to check
-    # that the markup that was found is indeed a link.
+    /* Don't use this regexp directly on $podinfo{contents}, as it causes
+     * a regexp recursion, which fails on really big PODs.  Instead, use
+     * $markup_re to pick up general markup, and use this regexp to check
+     * that the markup that was found is indeed a link. */
     my $linkre = qr/L<
                     # if the link is of the form L<something|name(s)>,
                     # then remove 'something'.  Note that 'something'
@@ -1131,12 +1133,12 @@ sub checkflags {
     }
 }
 
-##
-##  MAIN()
-##  Do the work requested by the various getopt flags.
-##  The flags are parsed in alphabetical order, just because we have
-##  to have *some way* of listing them.
-##
+/*
+ *  MAIN()
+ *  Do the work requested by the various getopt flags.
+ *  The flags are parsed in alphabetical order, just because we have
+ *  to have *some way* of listing them.
+ */
 
 if ( $opt_c ) {
     my @commands = ();

--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -246,15 +246,18 @@ if ( ! $reindex && $statefile ) {
     }
 }
 
-# Scan each C source file and look for reason codes.  This is done by
-# looking for strings that "look like" reason codes: basically anything
-# consisting of all uppercase and numerics which _R_ in it and which has
-# the name of an error library at the start.  Should there be anything else,
-# such as a type name, we add exceptions here.
-# If a code doesn't exist in list compiled from headers then mark it
-# with the value "X" as a place holder to give it a value later.
-# Store all reason codes found in and %usedreasons so all those unreferenced
-# can be printed out.
+/* 
+ * Scan each C source file and look for reason codes.  This is done by
+ * looking for strings that "look like" reason codes: basically anything
+ * consisting of all uppercase and numerics with _R_ in it and which has
+ * the name of an error library at the start.  Should there be anything else,
+ * such as a type name, we add exceptions here.
+ * If a code doesn't exist in list compiled from headers then mark it
+ * with the value "X" as a placeholder to give it a value later.
+ * Store all reason codes found in and %usedreasons so all those unreferenced
+ * can be printed out.
+ */
+
 &phase("Scanning source");
 my %usedreasons;
 foreach my $file ( @source ) {
@@ -296,8 +299,10 @@ foreach my $lib ( keys %errorfile ) {
     print STDERR "$lib: $rnew{$lib} new reasons\n" if $rnew{$lib};
     $newstate = 1;
 
-    # If we get here then we have some new error codes so we
-    # need to rebuild the header file and C file.
+    /*
+     * If we get here then we have some new error codes so we
+     * need to rebuild the header file and C file.
+     */
 
     # Make a sorted list of error and reason codes for later use.
     my @reasons  = sort grep( /^${lib}_/, keys %rcodes );
@@ -305,10 +310,12 @@ foreach my $lib ( keys %errorfile ) {
     # indent level for innermost preprocessor lines
     my $indent = " ";
 
-    # Flag if the sub-library is disablable
-    # There are a few exceptions, where disabling the sub-library
-    # doesn't actually remove the whole sub-library, but rather implements
-    # it with a NULL backend.
+    /*
+     * Flag if the sub-library is disablable
+     * There are a few exceptions, where disabling the sub-library
+     * doesn't actually remove the whole sub-library, but rather implements
+     * it with a NULL backend.
+     */
     my $disablable =
         ($lib ne "SSL" && $lib ne "ASYNC" && $lib ne "DSO"
          && (grep { $lib eq uc $_ } @disablables, @disablables_int));

--- a/util/mkinstallvars.pl
+++ b/util/mkinstallvars.pl
@@ -33,13 +33,14 @@ foreach my $k (sort keys %keys) {
 }
 foreach my $k (sort keys %keys) {
     my $v = $ENV{$k} || '.';
-
-    # Absolute paths for the subdir variables are computed.  This provides
-    # the usual form of values for names that have become norm, known as GNU
-    # installation paths.
-    # For the benefit of those that need it, the subdirectories are preserved
-    # as they are, using the same variable names, suffixed with '_REL', if they
-    # are indeed subdirectories.
+    /*
+     * Absolute paths for the subdir variables are computed.  This provides
+     * the usual form of values for names that have become norm, known as GNU
+     * installation paths.
+     * For the benefit of those that need it, the subdirectories are preserved
+     * as they are, using the same variable names, suffixed with '_REL', if they
+     * are indeed subdirectories.
+     */
     if (grep { $k eq $_ } @subdirs) {
         if (File::Spec->file_name_is_absolute($v)) {
             $ENV{"${k}_REL"} = File::Spec->abs2rel($v, $ENV{PREFIX});

--- a/util/shlib_wrap.sh.in
+++ b/util/shlib_wrap.sh.in
@@ -5,10 +5,12 @@
     use lib catdir($config{sourcedir}, 'Configurations');
     use platform;
 -}
+
 # To test this OpenSSL version's applications against another version's
 # shared libraries, simply set
 #
 #     OPENSSL_REGRESSION=/path/to/other/OpenSSL/build/tree
+
 if [ -n "$OPENSSL_REGRESSION" ]; then
     shlibwrap="$OPENSSL_REGRESSION/util/shlib_wrap.sh"
     if [ -x "$shlibwrap" ]; then
@@ -56,9 +58,9 @@ SunOS|IRIX*)
 		;;
 	# Why are newly built .so's preloaded anyway? Because run-time
 	# .so lookup path embedded into application takes precedence
-	# over LD_LIBRARY_PATH and as result application ends up linking
-	# to previously installed .so's. On IRIX instead of preloading
-	# newly built .so's we trick run-time linker to fail to find
+	# over LD_LIBRARY_PATH and as a result, the application ends up
+	# linking to previously installed .so's. On IRIX instead of preloading
+	# newly built .so's we trick run-time linker into failing to find
 	# the installed .so by setting _RLD_ROOT variable.
 	*ELF\ 32*MIPS*)
 		#_RLD_LIST="$LIBCRYPTOSO:$LIBSSLSO:DEFAULT"; export _RLD_LIST
@@ -85,11 +87,13 @@ SunOS|IRIX*)
 	unset rld_var
 	;;
 NONSTOP_KERNEL)
+	
 	# HPE NonStop has a proprietary mechanism for specifying
 	# the location of DLLs. It does not use PATH or variables
 	# commonly used on other platforms. The platform has a limited
-	# environment space keeping extraneous variables to a minimum
+	# environment space. Keeping extraneous variables to a minimum
 	# is recommended.
+
 	_RLD_LIB_PATH="${THERE}:$LD_LIBRARY_PATH"
 	export _RLD_LIB_PATH
 	;;
@@ -98,8 +102,8 @@ NONSTOP_KERNEL)
 	SHLIB_PATH="${THERE}:$SHLIB_PATH"		# legacy HP-UX
 	LIBPATH="${THERE}:$LIBPATH"			# AIX, OS/2
 	export LD_LIBRARY_PATH DYLD_LIBRARY_PATH SHLIB_PATH LIBPATH
-	# Even though $PATH is adjusted [for Windows sake], it doesn't
-	# necessarily does the trick. Trouble is that with introduction
+	# Even though $PATH is adjusted [for Windows's sake], it doesn't
+	# necessarily do the trick. Trouble is that with the introduction
 	# of SafeDllSearchMode in XP/2003 it's more appropriate to copy
 	# .DLLs in vicinity of executable, which is done elsewhere...
 	if [ "$OSTYPE" != msdosdjgpp ]; then


### PR DESCRIPTION
Fixed Comment Syntax to align with OpenSSL standards

- Changed various large comment blocks to using "/* */" format.
- A few small misc typo fixes along the way.

CLA: trivial
