### PR TITLE
Remove atexit() and replace by using a library destructor if it is available

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,6 +95,15 @@ OpenSSL 3.4
 
    *Alexander Kanavin*
 
+ * OpenSSL libraries no longer use atexit(3) to perform cleanup by
+   OPENSSL_cleanup().  The cleanup now runs automatically via a library
+   destructor, unless no-atexit build time option is used. libcrypto
+   built with no-atexit option will not call OPENSSL_cleanup() from
+   library destructor including at-exit handlers set by application
+   by call to OPENSSL_atexit().
+
+   *Alexandr Nedvedicky*
+
 OpenSSL 3.3
 -----------
 

--- a/crypto/dllmain.c
+++ b/crypto/dllmain.c
@@ -25,6 +25,8 @@
  * detaches
  */
 
+extern int ossl_no_cleanup;
+
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved);
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
@@ -38,6 +40,8 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
         OPENSSL_thread_stop();
         break;
     case DLL_PROCESS_DETACH:
+        if (ossl_no_cleanup == 0)
+            OPENSSL_cleanup();
         break;
     }
     return TRUE;

--- a/crypto/engine/eng_lib.c
+++ b/crypto/engine/eng_lib.c
@@ -168,7 +168,6 @@ int engine_cleanup_add_last(ENGINE_CLEANUP_CB *cb)
 /* The API function that performs all cleanup */
 static void engine_cleanup_cb_free(ENGINE_CLEANUP_ITEM *item)
 {
-    (*(item->cb)) ();
     OPENSSL_free(item);
 }
 

--- a/crypto/engine/eng_lib.c
+++ b/crypto/engine/eng_lib.c
@@ -168,6 +168,7 @@ int engine_cleanup_add_last(ENGINE_CLEANUP_CB *cb)
 /* The API function that performs all cleanup */
 static void engine_cleanup_cb_free(ENGINE_CLEANUP_ITEM *item)
 {
+    (*(item->cb)) ();
     OPENSSL_free(item);
 }
 

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -310,7 +310,7 @@ int ERR_unload_strings(int lib, ERR_STRING_DATA *str)
     if (!RUN_ONCE(&err_string_init, do_err_strings_init))
         return 0;
 
-    if (!CRYPTO_THREAD_write_lock(err_string_lock))
+    if (err_string_lock == NULL || !CRYPTO_THREAD_write_lock(err_string_lock))
         return 0;
     /*
      * We don't need to ERR_PACK the lib, since that was done (to

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -310,7 +310,8 @@ int ERR_unload_strings(int lib, ERR_STRING_DATA *str)
     if (!RUN_ONCE(&err_string_init, do_err_strings_init))
         return 0;
 
-    if (err_string_lock == NULL || !CRYPTO_THREAD_write_lock(err_string_lock))
+    /*if (err_string_lock == NULL || !CRYPTO_THREAD_write_lock(err_string_lock)) */
+    if (!CRYPTO_THREAD_write_lock(err_string_lock))
         return 0;
     /*
      * We don't need to ERR_PACK the lib, since that was done (to

--- a/doc/man3/OPENSSL_init_crypto.pod
+++ b/doc/man3/OPENSSL_init_crypto.pod
@@ -175,10 +175,10 @@ See OPENSSL_fork_prepare(3) for details.
 
 =item OPENSSL_INIT_NO_ATEXIT
 
-By default OpenSSL will attempt to clean itself up when the process exits via an
-"atexit" handler. Using this option suppresses that behaviour. This means that
-the application will have to clean up OpenSSL explicitly using
-OPENSSL_cleanup().
+Disables automatic execution of OPENSSL_cleanup() via a library destructor.
+Starting from version 3.4 OpenSSL no longer uses an atexit(3) handler to call
+OPENSSL_cleanup() automatically.  Instead of using atexit(3) OpenSSL relies on
+the run time linker to call OPENSSL_cleanup() via a library destructor.
 
 =back
 
@@ -190,15 +190,19 @@ OPENSSL_init_crypto(). For example:
 
 The OPENSSL_cleanup() function deinitialises OpenSSL (both libcrypto
 and libssl). All resources allocated by OpenSSL are freed. Typically there
-should be no need to call this function directly as it is initiated
-automatically on application exit. This is done via the standard C library
-atexit() function. In the event that the application will close in a manner
-that will not call the registered atexit() handlers then the application should
-call OPENSSL_cleanup() directly. Developers of libraries using OpenSSL
-are discouraged from calling this function and should instead, typically, rely
-on auto-deinitialisation. This is to avoid error conditions where both an
-application and a library it depends on both use OpenSSL, and the library
-deinitialises it before the application has finished using it.
+should be no need to call this function directly as it is done
+automatically on application exit. This is arranged by the linker which ensures
+a library destructor gets invoked on library unload (or process exit).  On some
+platforms there is no support for library destructors. On these platforms the
+OS will still automatically dispose of all resources on process exit. However
+memory leak detection tools such as valgrind or asan may report spurious memory
+leaks. The application may call OPENSSL_cleanup() explicitly to dispose of all
+resources allocated by libcrypto/libssl to avoid this.  Developers of libraries
+using OpenSSL are discouraged from calling the OPENSSL_cleanup() function and
+should instead, rely on the linker to invoke OPENSSL_cleanup() via the library
+destructor.  Explicit calls to OPENSSL_cleanup() from 3rd party libraries may
+disable libcrypto/libssl for the application prematurely as calls to those
+libraries typically fail after OPENSSL_cleanup() is done.
 
 Once OPENSSL_cleanup() has been called the library cannot be reinitialised.
 Attempts to call OPENSSL_init_crypto() will fail and an ERR_R_INIT_FAIL error

--- a/doc/man3/OSSL_trace_set_channel.pod
+++ b/doc/man3/OSSL_trace_set_channel.pod
@@ -128,12 +128,11 @@ trace hook is set.
 
 Traces OpenSSL library initialization and cleanup.
 
-This needs special care, as OpenSSL will do automatic cleanup after
-exit from C<main()>, and any tracing output done during this cleanup
-will be lost if the tracing channel or callback were cleaned away
-prematurely.
-A suggestion is to make such cleanup part of a function that's
-registered very early with L<atexit(3)>.
+Keep in mind that the OpenSSL cleanup function (OPENSSL_cleanup()) is
+invoked by a library destructor. This is typically arranged by the linker.
+So if your function is tracing the OSSL_TRACE_CATEGORY_INIT category,
+then file descriptors to log files (log facilities) must be left
+open after C<main()> exits.
 
 =item B<OSSL_TRACE_CATEGORY_TLS>
 

--- a/test/build.info
+++ b/test/build.info
@@ -38,8 +38,8 @@ IF[{- !$disabled{tests} -}]
           ecstresstest gmdifftest pbelutest \
           destest mdc2test sha_test \
           exptest pbetest localetest evp_pkey_ctx_new_from_name \
-          evp_pkey_provided_test evp_test evp_extra_test evp_extra_test2 \
-          evp_fetch_prov_test evp_libctx_test ossl_store_test \
+          evp_pkey_provided_test evp_test evp_engine_test evp_extra_test \
+          evp_extra_test2 evp_fetch_prov_test evp_libctx_test ossl_store_test \
           v3nametest v3ext punycode_test \
           crltest danetest bad_dtls_test lhash_test sparse_array_test \
           conf_include_test params_api_test params_conversion_test \
@@ -192,6 +192,10 @@ IF[{- !$disabled{tests} -}]
   IF[{- $disabled{legacy} || !$target{dso_scheme} -}]
     DEFINE[evp_test]=NO_LEGACY_MODULE
   ENDIF
+
+  SOURCE[evp_engine_test]=evp_engine_test.c
+  INCLUDE[evp_engine_test]=../include ../apps/include
+  DEPEND[evp_engine_test]=../libcrypto libtestutil.a
 
   SOURCE[evp_extra_test]=evp_extra_test.c fake_rsaprov.c
   INCLUDE[evp_extra_test]=../include ../apps/include

--- a/test/evp_engine_test.c
+++ b/test/evp_engine_test.c
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/* We need to use some deprecated APIs */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <openssl/aes.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/provider.h>
+#include <openssl/params.h>
+#include <openssl/engine.h>
+#include <openssl/proverr.h>
+
+#include "testutil.h"
+#include "internal/nelem.h"
+#include "internal/sizes.h"
+
+/* Test we can create a signature keys with an associated ENGINE */
+static int test_signatures_with_engine(int tst)
+{
+    ENGINE *e;
+    const char *engine_id = "dasync";
+    EVP_PKEY *pkey = NULL;
+    const unsigned char badcmackey[] = { 0x00, 0x01 };
+    const unsigned char cmackey[] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+        0x0c, 0x0d, 0x0e, 0x0f
+    };
+    const unsigned char ed25519key[] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+        0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+        0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f
+    };
+    const unsigned char msg[] = { 0x00, 0x01, 0x02, 0x03 };
+    int testresult = 0;
+    EVP_MD_CTX *ctx = NULL;
+    unsigned char *mac = NULL;
+    size_t maclen = 0;
+    int ret;
+
+#  ifdef OPENSSL_NO_CMAC
+    /* Skip CMAC tests in a no-cmac build */
+    if (tst <= 1)
+        return 1;
+#  endif
+#  ifdef OPENSSL_NO_ECX
+    /* Skip ECX tests in a no-ecx build */
+    if (tst == 2)
+        return 1;
+#  endif
+
+    if (!TEST_ptr(e = ENGINE_by_id(engine_id)))
+        return 0;
+
+    if (!TEST_true(ENGINE_init(e))) {
+        ENGINE_free(e);
+        return 0;
+    }
+
+    switch (tst) {
+    case 0:
+        pkey = EVP_PKEY_new_CMAC_key(e, cmackey, sizeof(cmackey),
+                                     EVP_aes_128_cbc());
+        break;
+    case 1:
+        pkey = EVP_PKEY_new_CMAC_key(e, badcmackey, sizeof(badcmackey),
+                                     EVP_aes_128_cbc());
+        break;
+    case 2:
+        pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_ED25519, e, ed25519key,
+                                            sizeof(ed25519key));
+        break;
+    default:
+        TEST_error("Invalid test case");
+        goto err;
+    }
+    if (!TEST_ptr(pkey))
+        goto err;
+
+    if (!TEST_ptr(ctx = EVP_MD_CTX_new()))
+        goto err;
+
+    ret = EVP_DigestSignInit(ctx, NULL, tst == 2 ? NULL : EVP_sha256(), NULL,
+                             pkey);
+    if (tst == 0) {
+        if (!TEST_true(ret))
+            goto err;
+
+        if (!TEST_true(EVP_DigestSignUpdate(ctx, msg, sizeof(msg)))
+                || !TEST_true(EVP_DigestSignFinal(ctx, NULL, &maclen)))
+            goto err;
+
+        if (!TEST_ptr(mac = OPENSSL_malloc(maclen)))
+            goto err;
+
+        if (!TEST_true(EVP_DigestSignFinal(ctx, mac, &maclen)))
+            goto err;
+    } else {
+        /* We used a bad key. We expect a failure here */
+        if (!TEST_false(ret))
+            goto err;
+    }
+
+    testresult = 1;
+ err:
+    EVP_MD_CTX_free(ctx);
+    OPENSSL_free(mac);
+    EVP_PKEY_free(pkey);
+    ENGINE_finish(e);
+    ENGINE_free(e);
+
+    return testresult;
+}
+
+static int test_cipher_with_engine(void)
+{
+    ENGINE *e;
+    const char *engine_id = "dasync";
+    const unsigned char keyiv[] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+        0x0c, 0x0d, 0x0e, 0x0f
+    };
+    const unsigned char msg[] = { 0x00, 0x01, 0x02, 0x03 };
+    int testresult = 0;
+    EVP_CIPHER_CTX *ctx = NULL, *ctx2 = NULL;
+    unsigned char buf[AES_BLOCK_SIZE];
+    int len = 0;
+
+    if (!TEST_ptr(e = ENGINE_by_id(engine_id)))
+        return 0;
+
+    if (!TEST_true(ENGINE_init(e))) {
+        ENGINE_free(e);
+        return 0;
+    }
+
+    if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new())
+            || !TEST_ptr(ctx2 = EVP_CIPHER_CTX_new()))
+        goto err;
+
+    if (!TEST_true(EVP_EncryptInit_ex(ctx, EVP_aes_128_cbc(), e, keyiv, keyiv)))
+        goto err;
+
+    /* Copy the ctx, and complete the operation with the new ctx */
+    if (!TEST_true(EVP_CIPHER_CTX_copy(ctx2, ctx)))
+        goto err;
+
+    if (!TEST_true(EVP_EncryptUpdate(ctx2, buf, &len, msg, sizeof(msg)))
+            || !TEST_true(EVP_EncryptFinal_ex(ctx2, buf + len, &len)))
+        goto err;
+
+    testresult = 1;
+ err:
+    EVP_CIPHER_CTX_free(ctx);
+    EVP_CIPHER_CTX_free(ctx2);
+    ENGINE_finish(e);
+    ENGINE_free(e);
+
+    return testresult;
+}
+
+int setup_tests(void)
+{
+    /* Tests only support the default libctx */
+#ifndef OPENSSL_NO_EC
+    ADD_ALL_TESTS(test_signatures_with_engine, 3);
+#else
+    ADD_ALL_TESTS(test_signatures_with_engine, 2);
+#endif
+    ADD_TEST(test_cipher_with_engine);
+
+    return 1;
+}

--- a/test/evp_engine_test.c
+++ b/test/evp_engine_test.c
@@ -171,13 +171,15 @@ static int test_cipher_with_engine(void)
 
 int setup_tests(void)
 {
+#ifndef OPENSSL_NO_DYNAMIC_ENGINE
     /* Tests only support the default libctx */
-#ifndef OPENSSL_NO_EC
+# ifndef OPENSSL_NO_EC
     ADD_ALL_TESTS(test_signatures_with_engine, 3);
-#else
+# else
     ADD_ALL_TESTS(test_signatures_with_engine, 2);
-#endif
+# endif
     ADD_TEST(test_cipher_with_engine);
+#endif
 
     return 1;
 }

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -30,7 +30,6 @@
 #include <openssl/aes.h>
 #include <openssl/decoder.h>
 #include <openssl/rsa.h>
-#include <openssl/engine.h>
 #include <openssl/proverr.h>
 #include "testutil.h"
 #include "internal/nelem.h"
@@ -5061,151 +5060,6 @@ static int test_custom_ciph_meth(void)
     return testresult;
 }
 
-# ifndef OPENSSL_NO_DYNAMIC_ENGINE
-/* Test we can create a signature keys with an associated ENGINE */
-static int test_signatures_with_engine(int tst)
-{
-    ENGINE *e;
-    const char *engine_id = "dasync";
-    EVP_PKEY *pkey = NULL;
-    const unsigned char badcmackey[] = { 0x00, 0x01 };
-    const unsigned char cmackey[] = {
-        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
-        0x0c, 0x0d, 0x0e, 0x0f
-    };
-    const unsigned char ed25519key[] = {
-        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
-        0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
-        0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f
-    };
-    const unsigned char msg[] = { 0x00, 0x01, 0x02, 0x03 };
-    int testresult = 0;
-    EVP_MD_CTX *ctx = NULL;
-    unsigned char *mac = NULL;
-    size_t maclen = 0;
-    int ret;
-
-#  ifdef OPENSSL_NO_CMAC
-    /* Skip CMAC tests in a no-cmac build */
-    if (tst <= 1)
-        return 1;
-#  endif
-#  ifdef OPENSSL_NO_ECX
-    /* Skip ECX tests in a no-ecx build */
-    if (tst == 2)
-        return 1;
-#  endif
-
-    if (!TEST_ptr(e = ENGINE_by_id(engine_id)))
-        return 0;
-
-    if (!TEST_true(ENGINE_init(e))) {
-        ENGINE_free(e);
-        return 0;
-    }
-
-    switch (tst) {
-    case 0:
-        pkey = EVP_PKEY_new_CMAC_key(e, cmackey, sizeof(cmackey),
-                                     EVP_aes_128_cbc());
-        break;
-    case 1:
-        pkey = EVP_PKEY_new_CMAC_key(e, badcmackey, sizeof(badcmackey),
-                                     EVP_aes_128_cbc());
-        break;
-    case 2:
-        pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_ED25519, e, ed25519key,
-                                            sizeof(ed25519key));
-        break;
-    default:
-        TEST_error("Invalid test case");
-        goto err;
-    }
-    if (!TEST_ptr(pkey))
-        goto err;
-
-    if (!TEST_ptr(ctx = EVP_MD_CTX_new()))
-        goto err;
-
-    ret = EVP_DigestSignInit(ctx, NULL, tst == 2 ? NULL : EVP_sha256(), NULL,
-                             pkey);
-    if (tst == 0) {
-        if (!TEST_true(ret))
-            goto err;
-
-        if (!TEST_true(EVP_DigestSignUpdate(ctx, msg, sizeof(msg)))
-                || !TEST_true(EVP_DigestSignFinal(ctx, NULL, &maclen)))
-            goto err;
-
-        if (!TEST_ptr(mac = OPENSSL_malloc(maclen)))
-            goto err;
-
-        if (!TEST_true(EVP_DigestSignFinal(ctx, mac, &maclen)))
-            goto err;
-    } else {
-        /* We used a bad key. We expect a failure here */
-        if (!TEST_false(ret))
-            goto err;
-    }
-
-    testresult = 1;
- err:
-    EVP_MD_CTX_free(ctx);
-    OPENSSL_free(mac);
-    EVP_PKEY_free(pkey);
-    ENGINE_finish(e);
-    ENGINE_free(e);
-
-    return testresult;
-}
-
-static int test_cipher_with_engine(void)
-{
-    ENGINE *e;
-    const char *engine_id = "dasync";
-    const unsigned char keyiv[] = {
-        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
-        0x0c, 0x0d, 0x0e, 0x0f
-    };
-    const unsigned char msg[] = { 0x00, 0x01, 0x02, 0x03 };
-    int testresult = 0;
-    EVP_CIPHER_CTX *ctx = NULL, *ctx2 = NULL;
-    unsigned char buf[AES_BLOCK_SIZE];
-    int len = 0;
-
-    if (!TEST_ptr(e = ENGINE_by_id(engine_id)))
-        return 0;
-
-    if (!TEST_true(ENGINE_init(e))) {
-        ENGINE_free(e);
-        return 0;
-    }
-
-    if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new())
-            || !TEST_ptr(ctx2 = EVP_CIPHER_CTX_new()))
-        goto err;
-
-    if (!TEST_true(EVP_EncryptInit_ex(ctx, EVP_aes_128_cbc(), e, keyiv, keyiv)))
-        goto err;
-
-    /* Copy the ctx, and complete the operation with the new ctx */
-    if (!TEST_true(EVP_CIPHER_CTX_copy(ctx2, ctx)))
-        goto err;
-
-    if (!TEST_true(EVP_EncryptUpdate(ctx2, buf, &len, msg, sizeof(msg)))
-            || !TEST_true(EVP_EncryptFinal_ex(ctx2, buf + len, &len)))
-        goto err;
-
-    testresult = 1;
- err:
-    EVP_CIPHER_CTX_free(ctx);
-    EVP_CIPHER_CTX_free(ctx2);
-    ENGINE_finish(e);
-    ENGINE_free(e);
-
-    return testresult;
-}
-# endif /* OPENSSL_NO_DYNAMIC_ENGINE */
 #endif /* OPENSSL_NO_DEPRECATED_3_0 */
 
 #ifndef OPENSSL_NO_ECX
@@ -5769,17 +5623,6 @@ int setup_tests(void)
     ADD_TEST(test_custom_md_meth);
     ADD_TEST(test_custom_ciph_meth);
 
-# ifndef OPENSSL_NO_DYNAMIC_ENGINE
-    /* Tests only support the default libctx */
-    if (testctx == NULL) {
-#  ifndef OPENSSL_NO_EC
-        ADD_ALL_TESTS(test_signatures_with_engine, 3);
-#  else
-        ADD_ALL_TESTS(test_signatures_with_engine, 2);
-#  endif
-        ADD_TEST(test_cipher_with_engine);
-    }
-# endif
 #endif
 
 #ifndef OPENSSL_NO_ECX

--- a/test/recipes/30-test_evp_engine.t
+++ b/test/recipes/30-test_evp_engine.t
@@ -14,6 +14,6 @@ use OpenSSL::Test qw/:DEFAULT bldtop_dir/;
 
 setup("test_evp_extra");
 
-plan tests => 3;
+plan tests => 1;
 
 ok(run(test(["evp_engine_test"])), "running evp_engine_test");

--- a/test/recipes/30-test_evp_engine.t
+++ b/test/recipes/30-test_evp_engine.t
@@ -1,0 +1,19 @@
+#! /usr/bin/env perl
+# Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use strict;
+use warnings;
+
+use OpenSSL::Test qw/:DEFAULT bldtop_dir/;
+
+setup("test_evp_extra");
+
+plan tests => 3;
+
+ok(run(test(["evp_engine_test"])), "running evp_engine_test");

--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -164,7 +164,7 @@ static int test_lib(void)
     }
 
     myOPENSSL_atexit = (OPENSSL_atexit_t)symbols[4].func;
-    if (!myOPENSSL_atexit(atexit_handler)) {
+    if (test_type != NO_ATEXIT && !myOPENSSL_atexit(atexit_handler)) {
         fprintf(stderr, "Failed to register atexit handler\n");
         goto end;
     }


### PR DESCRIPTION
This is the first iteration just to check if I'm heading in right direction. It removes call to atexit(3) done on behalf of library. The call to OPENSSL_cleanup() got moved to library destructors in a same fashion like we do it for FIPS. On platforms/compilers where destructor is not available nothing happens. Application then should call OPENSSL_cleanup() explicitly. Documentation is not updated yet.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
