### PR TITLE
.ctags.d is previous, include it in our tarballs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,10 @@
 # For git archive
 fuzz/corpora/**                         export-ignore
 Configurations/*.norelease.conf         export-ignore
+# We generally avoid anything with a name starting with a period.
+# However, .ctags.d is precious, so we don't ignore that.
 .*                                      export-ignore
+.ctags.d                                !export-ignore
 util/mktar.sh                           export-ignore
 krb5                                    export-ignore
 pyca-cryptography                       export-ignore


### PR DESCRIPTION
This is a simple change of .gitattributes, so our tarballs continue to
be a reproducible output of a util/mktar.sh (i.e. git archive with no
other funny business).

Fixes #24090
