### PR TITLE
Documentation Edit provider-compatibility.yml CLA: Trivial

### DIFF
--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -31,7 +31,7 @@ jobs:
           # Formally released versions should be added here.
           #     `dir' it the directory inside the tarball.
           #     `tgz' is the name of the tarball.
-          #     `utl' is the download URL.
+          #     `url' is the download URL.
           {
             dir: openssl-3.0.0,
             tgz: openssl-3.0.0.tar.gz,


### PR DESCRIPTION
Documentation Change: Line 34

Changed 'utl' to 'url' to correctly reflect the variables used in the releases in this file.

CLA: trivial

@bbbrumley 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
