### PR TITLE
CMP: fix reporting error when no root CA cert update available

### DIFF
--- a/crypto/cmp/cmp_asn.c
+++ b/crypto/cmp/cmp_asn.c
@@ -287,23 +287,31 @@ OSSL_CMP_ITAV *OSSL_CMP_ITAV_new_rootCaKeyUpdate(const X509 *newWithNew,
                                                  const X509 *oldWithNew)
 {
     OSSL_CMP_ITAV *itav;
-    OSSL_CMP_ROOTCAKEYUPDATE *upd = OSSL_CMP_ROOTCAKEYUPDATE_new();
+    OSSL_CMP_ROOTCAKEYUPDATE *upd = NULL;
 
+    if (newWithNew == NULL)
+        goto null_value;
+
+    upd = OSSL_CMP_ROOTCAKEYUPDATE_new();
     if (upd == NULL)
         return NULL;
-    if (newWithNew != NULL && (upd->newWithNew = X509_dup(newWithNew)) == NULL)
+
+    if ((upd->newWithNew = X509_dup(newWithNew)) == NULL)
         goto err;
     if (newWithOld != NULL && (upd->newWithOld = X509_dup(newWithOld)) == NULL)
         goto err;
     if (oldWithNew != NULL && (upd->oldWithNew = X509_dup(oldWithNew)) == NULL)
         goto err;
+
+ null_value:
     if ((itav = OSSL_CMP_ITAV_new()) == NULL)
         goto err;
+
     itav->infoType = OBJ_nid2obj(NID_id_it_rootCaKeyUpdate);
     itav->infoValue.rootCaKeyUpdate = upd;
     return itav;
 
-    err:
+ err:
     OSSL_CMP_ROOTCAKEYUPDATE_free(upd);
     return NULL;
 }
@@ -324,11 +332,11 @@ int OSSL_CMP_ITAV_get0_rootCaKeyUpdate(const OSSL_CMP_ITAV *itav,
         return 0;
     }
     upd = itav->infoValue.rootCaKeyUpdate;
-    *newWithNew = upd->newWithNew;
+    *newWithNew = upd != NULL ? upd->newWithNew : NULL;
     if (newWithOld != NULL)
-        *newWithOld = upd->newWithOld;
+        *newWithOld = upd != NULL ? upd->newWithOld : NULL;
     if (oldWithNew != NULL)
-        *oldWithNew = upd->oldWithNew;
+        *oldWithNew = upd != NULL ? upd->oldWithNew : NULL;
     return 1;
 }
 

--- a/crypto/cmp/cmp_asn.c
+++ b/crypto/cmp/cmp_asn.c
@@ -289,24 +289,23 @@ OSSL_CMP_ITAV *OSSL_CMP_ITAV_new_rootCaKeyUpdate(const X509 *newWithNew,
     OSSL_CMP_ITAV *itav;
     OSSL_CMP_ROOTCAKEYUPDATE *upd = NULL;
 
-    if (newWithNew == NULL)
-        goto null_value;
+    if (newWithNew != NULL) {
+        upd = OSSL_CMP_ROOTCAKEYUPDATE_new();
+        if (upd == NULL)
+            return NULL;
 
-    upd = OSSL_CMP_ROOTCAKEYUPDATE_new();
-    if (upd == NULL)
-        return NULL;
+        if ((upd->newWithNew = X509_dup(newWithNew)) == NULL)
+            goto err;
+        if (newWithOld != NULL
+            && (upd->newWithOld = X509_dup(newWithOld)) == NULL)
+            goto err;
+        if (oldWithNew != NULL
+            && (upd->oldWithNew = X509_dup(oldWithNew)) == NULL)
+            goto err;
+    }
 
-    if ((upd->newWithNew = X509_dup(newWithNew)) == NULL)
-        goto err;
-    if (newWithOld != NULL && (upd->newWithOld = X509_dup(newWithOld)) == NULL)
-        goto err;
-    if (oldWithNew != NULL && (upd->oldWithNew = X509_dup(oldWithNew)) == NULL)
-        goto err;
-
- null_value:
     if ((itav = OSSL_CMP_ITAV_new()) == NULL)
         goto err;
-
     itav->infoType = OBJ_nid2obj(NID_id_it_rootCaKeyUpdate);
     itav->infoValue.rootCaKeyUpdate = upd;
     return itav;

--- a/crypto/cmp/cmp_genm.c
+++ b/crypto/cmp/cmp_genm.c
@@ -307,9 +307,11 @@ int OSSL_CMP_get1_rootCaKeyUpdate(OSSL_CMP_CTX *ctx,
     if (!OSSL_CMP_ITAV_get0_rootCaKeyUpdate(itav, newWithNew,
                                             &my_newWithOld, &my_oldWithNew))
         goto end;
-
-    if (*newWithNew == NULL) /* no root CA cert update available */
+    /* no root CA cert update available */
+    if (*newWithNew == NULL) {
+        res = 1;
         goto end;
+    }
     if ((oldWithOld_copy = X509_dup(oldWithOld)) == NULL && oldWithOld != NULL)
         goto end;
     if (!verify_ss_cert_trans(ctx, oldWithOld_copy, my_newWithOld,

--- a/doc/man3/OSSL_CMP_ITAV_new_caCerts.pod
+++ b/doc/man3/OSSL_CMP_ITAV_new_caCerts.pod
@@ -59,7 +59,8 @@ If I<newWithOld> is not NULL, it assigns to I<*newWithOld> the internal pointer
 to the certificate contained in the newWithOld infoValue sub-field of I<itav>.
 If I<oldWithNew> is not NULL, it assigns to I<*oldWithNew> the internal pointer
 to the certificate contained in the oldWithNew infoValue sub-field of I<itav>.
-Each of these pointers will be NULL if the respective sub-field is not set.
+Each of these pointers will be set to NULL if update of root CA certificate is
+not included.
 
 =head1 NOTES
 

--- a/doc/man3/OSSL_CMP_ITAV_new_caCerts.pod
+++ b/doc/man3/OSSL_CMP_ITAV_new_caCerts.pod
@@ -49,7 +49,8 @@ the internal pointer to the certificate contained in the infoValue field.
 OSSL_CMP_ITAV_new_rootCaKeyUpdate() creates a new B<OSSL_CMP_ITAV> structure
 of type B<rootCaKeyUpdate> that includes an RootCaKeyUpdateContent structure
 with the optional I<newWithNew>, I<newWithOld>, and I<oldWithNew> certificates.
-An RootCaKeyUpdateContent structure is included only if newWithNew is not NULL.
+An RootCaKeyUpdateContent structure is included only if I<newWithNew>
+is not NULL.
 
 OSSL_CMP_ITAV_get0_rootCaKeyUpdate() requires that I<itav> has infoType
 B<rootCaKeyUpdate>.

--- a/doc/man3/OSSL_CMP_ITAV_new_caCerts.pod
+++ b/doc/man3/OSSL_CMP_ITAV_new_caCerts.pod
@@ -49,6 +49,7 @@ the internal pointer to the certificate contained in the infoValue field.
 OSSL_CMP_ITAV_new_rootCaKeyUpdate() creates a new B<OSSL_CMP_ITAV> structure
 of type B<rootCaKeyUpdate> that includes an RootCaKeyUpdateContent structure
 with the optional I<newWithNew>, I<newWithOld>, and I<oldWithNew> certificates.
+An RootCaKeyUpdateContent structure is included only if newWithNew is not NULL.
 
 OSSL_CMP_ITAV_get0_rootCaKeyUpdate() requires that I<itav> has infoType
 B<rootCaKeyUpdate>.
@@ -59,8 +60,8 @@ If I<newWithOld> is not NULL, it assigns to I<*newWithOld> the internal pointer
 to the certificate contained in the newWithOld infoValue sub-field of I<itav>.
 If I<oldWithNew> is not NULL, it assigns to I<*oldWithNew> the internal pointer
 to the certificate contained in the oldWithNew infoValue sub-field of I<itav>.
-Each of these pointers will be set to NULL if update of root CA certificate is
-not included.
+Each of these pointers will be set to NULL if no root CA certificate update 
+is present or the respective sub-field is not included.
 
 =head1 NOTES
 

--- a/test/recipes/80-test_cmp_http_data/test_commands.csv
+++ b/test/recipes/80-test_cmp_http_data/test_commands.csv
@@ -77,7 +77,7 @@ expected,description, -section,val, -cmd,val,val2, -cacertsout,val,val2, -infoty
 0,genm rootCaCert oldwithold empty file  , -section,, -cmd,genm,, BLANK,,, -infotype,rootCaCert,, -oldwithold, empty.txt     , -newwithnew, _RESULT_DIR/test.newwithnew.pem
 0,genm rootCaCert oldwithold random file , -section,, -cmd,genm,, BLANK,,, -infotype,rootCaCert,, -oldwithold, random.bin    , -newwithnew, _RESULT_DIR/test.newwithnew.pem
 0,genm rootCaCert oldwithold nonexistent , -section,, -cmd,genm,, BLANK,,, -infotype,rootCaCert,, -oldwithold, idontexist    , -newwithnew, _RESULT_DIR/test.newwithnew.pem
-0,genm rootCaCert oldwithold wrong       , -section,, -cmd,genm,, BLANK,,, -infotype,rootCaCert,, -oldwithold, signer.crt    , -newwithnew, _RESULT_DIR/test.newwithnew.pem
+1,genm rootCaCert oldwithold wrong       , -section,, -cmd,genm,, BLANK,,, -infotype,rootCaCert,, -oldwithold, signer.crt    , -newwithnew, _RESULT_DIR/test.newwithnew.pem
 0,genm rootCaCert missing newwithnew     , -section,, -cmd,genm,, BLANK,,, -infotype,rootCaCert,, -oldwithold, oldWithOld.pem, BLANK      ,,
 0,genm rootCaCert newwithnew missing arg , -section,, -cmd,genm,, BLANK,,, -infotype,rootCaCert,, -oldwithold, oldWithOld.pem, -newwithnew,,
 1,genm rootCaCert with oldwithnew        , -section,, -cmd,genm,, BLANK,,, -infotype,rootCaCert,, -oldwithold, oldWithOld.pem, -newwithnew, _RESULT_DIR/test.newwithnew1.pem, -oldwithnew, _RESULT_DIR/test.oldwithnew1.pem

--- a/test/recipes/80-test_cmp_http_data/test_commands.csv
+++ b/test/recipes/80-test_cmp_http_data/test_commands.csv
@@ -77,7 +77,7 @@ expected,description, -section,val, -cmd,val,val2, -cacertsout,val,val2, -infoty
 0,genm rootCaCert oldwithold empty file  , -section,, -cmd,genm,, BLANK,,, -infotype,rootCaCert,, -oldwithold, empty.txt     , -newwithnew, _RESULT_DIR/test.newwithnew.pem
 0,genm rootCaCert oldwithold random file , -section,, -cmd,genm,, BLANK,,, -infotype,rootCaCert,, -oldwithold, random.bin    , -newwithnew, _RESULT_DIR/test.newwithnew.pem
 0,genm rootCaCert oldwithold nonexistent , -section,, -cmd,genm,, BLANK,,, -infotype,rootCaCert,, -oldwithold, idontexist    , -newwithnew, _RESULT_DIR/test.newwithnew.pem
-1,genm rootCaCert oldwithold wrong       , -section,, -cmd,genm,, BLANK,,, -infotype,rootCaCert,, -oldwithold, signer.crt    , -newwithnew, _RESULT_DIR/test.newwithnew.pem
+1,genm rootCaCert oldwithold different   , -section,, -cmd,genm,, BLANK,,, -infotype,rootCaCert,, -oldwithold, signer.crt    , -newwithnew, _RESULT_DIR/test.newwithnew.pem
 0,genm rootCaCert missing newwithnew     , -section,, -cmd,genm,, BLANK,,, -infotype,rootCaCert,, -oldwithold, oldWithOld.pem, BLANK      ,,
 0,genm rootCaCert newwithnew missing arg , -section,, -cmd,genm,, BLANK,,, -infotype,rootCaCert,, -oldwithold, oldWithOld.pem, -newwithnew,,
 1,genm rootCaCert with oldwithnew        , -section,, -cmd,genm,, BLANK,,, -infotype,rootCaCert,, -oldwithold, oldWithOld.pem, -newwithnew, _RESULT_DIR/test.newwithnew1.pem, -oldwithnew, _RESULT_DIR/test.oldwithnew1.pem


### PR DESCRIPTION
This pull request addresses the issue where an error occurs when the root CA certificate update is not available. In this case, the client should not classify it as an error.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
