### PR TITLE
riscv: use hwprobe syscall for capability detection

### DIFF
--- a/crypto/info.c
+++ b/crypto/info.c
@@ -21,6 +21,9 @@
 #elif defined(__s390__) || defined(__s390x__)
 # include "s390x_arch.h"
 # define CPU_INFO_STR_LEN 2048
+#elif defined(__riscv)
+# include "crypto/riscv_arch.h"
+# define CPU_INFO_STR_LEN 2048
 #else
 # define CPU_INFO_STR_LEN 128
 #endif
@@ -95,6 +98,33 @@ DEFINE_RUN_ONCE_STATIC(init_info_strings)
                  OPENSSL_s390xcap_P.pcc[0], OPENSSL_s390xcap_P.pcc[1],
                  OPENSSL_s390xcap_P.kdsa[0], OPENSSL_s390xcap_P.kdsa[1]);
     if ((env = getenv("OPENSSL_s390xcap")) != NULL)
+        BIO_snprintf(ossl_cpu_info_str + strlen(ossl_cpu_info_str),
+                     sizeof(ossl_cpu_info_str) - strlen(ossl_cpu_info_str),
+                     " env:%s", env);
+# elif defined(__riscv)
+    const char *env;
+    char sep = '=';
+
+    BIO_snprintf(ossl_cpu_info_str, sizeof(ossl_cpu_info_str),
+                 CPUINFO_PREFIX "OPENSSL_riscvcap");
+    for (size_t i = 0; i < kRISCVNumCaps; ++i) {
+        if (OPENSSL_riscvcap_P[RISCV_capabilities[i].index]
+                & (1 << RISCV_capabilities[i].bit_offset)) {
+            /* Match, display the name */
+            BIO_snprintf(ossl_cpu_info_str + strlen(ossl_cpu_info_str),
+                         sizeof(ossl_cpu_info_str) - strlen(ossl_cpu_info_str),
+                         "%c%s", sep, RISCV_capabilities[i].name);
+            /* Only the first sep is '=' */
+            sep = '_';
+        }
+    }
+    /* If no capability is found, add back the = */
+    if (sep == '=') {
+        BIO_snprintf(ossl_cpu_info_str + strlen(ossl_cpu_info_str),
+                     sizeof(ossl_cpu_info_str) - strlen(ossl_cpu_info_str),
+                     "%c", sep);
+    }
+    if ((env = getenv("OPENSSL_riscvcap")) != NULL)
         BIO_snprintf(ossl_cpu_info_str + strlen(ossl_cpu_info_str),
                      sizeof(ossl_cpu_info_str) - strlen(ossl_cpu_info_str),
                      " env:%s", env);

--- a/doc/build.info
+++ b/doc/build.info
@@ -1575,6 +1575,10 @@ DEPEND[html/man3/OPENSSL_malloc.html]=man3/OPENSSL_malloc.pod
 GENERATE[html/man3/OPENSSL_malloc.html]=man3/OPENSSL_malloc.pod
 DEPEND[man/man3/OPENSSL_malloc.3]=man3/OPENSSL_malloc.pod
 GENERATE[man/man3/OPENSSL_malloc.3]=man3/OPENSSL_malloc.pod
+DEPEND[html/man3/OPENSSL_riscvcap.html]=man3/OPENSSL_riscvcap.pod
+GENERATE[html/man3/OPENSSL_riscvcap.html]=man3/OPENSSL_riscvcap.pod
+DEPEND[man/man3/OPENSSL_riscvcap.3]=man3/OPENSSL_riscvcap.pod
+GENERATE[man/man3/OPENSSL_riscvcap.3]=man3/OPENSSL_riscvcap.pod
 DEPEND[html/man3/OPENSSL_s390xcap.html]=man3/OPENSSL_s390xcap.pod
 GENERATE[html/man3/OPENSSL_s390xcap.html]=man3/OPENSSL_s390xcap.pod
 DEPEND[man/man3/OPENSSL_s390xcap.3]=man3/OPENSSL_s390xcap.pod
@@ -3361,6 +3365,7 @@ html/man3/OPENSSL_init_ssl.html \
 html/man3/OPENSSL_instrument_bus.html \
 html/man3/OPENSSL_load_builtin_modules.html \
 html/man3/OPENSSL_malloc.html \
+html/man3/OPENSSL_riscvcap.html \
 html/man3/OPENSSL_s390xcap.html \
 html/man3/OPENSSL_secure_malloc.html \
 html/man3/OPENSSL_strcasecmp.html \
@@ -4015,6 +4020,7 @@ man/man3/OPENSSL_init_ssl.3 \
 man/man3/OPENSSL_instrument_bus.3 \
 man/man3/OPENSSL_load_builtin_modules.3 \
 man/man3/OPENSSL_malloc.3 \
+man/man3/OPENSSL_riscvcap.3 \
 man/man3/OPENSSL_s390xcap.3 \
 man/man3/OPENSSL_secure_malloc.3 \
 man/man3/OPENSSL_strcasecmp.3 \

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -700,7 +700,7 @@ For information about the use of environment variables in configuration,
 see L<config(5)/ENVIRONMENT>.
 
 For information about querying or specifying CPU architecture flags, see
-L<OPENSSL_ia32cap(3)>, and L<OPENSSL_s390xcap(3)>.
+L<OPENSSL_ia32cap(3)>, L<OPENSSL_s390xcap(3)> and L<OPENSSL_riscvcap(3)>.
 
 For information about all environment variables used by the OpenSSL libraries,
 see L<openssl-env(7)>.

--- a/doc/man3/OPENSSL_riscvcap.pod
+++ b/doc/man3/OPENSSL_riscvcap.pod
@@ -1,0 +1,211 @@
+=pod
+
+=head1 NAME
+
+OPENSSL_riscvcap - the RISC-V processor capabilities vector
+
+=head1 SYNOPSIS
+
+ env OPENSSL_riscvcap=... <application>
+
+=head1 DESCRIPTION
+
+libcrypto supports RISC-V instruction set extensions. These
+extensions are denoted by individual extension names in the capabilities
+vector. For Linux platform, when libcrypto is initialized, the results
+returned by the RISC-V Hardware Probing syscall (hwprobe) are stored
+in the vector. Otherwise all capabilities are disabled.
+
+To override the set of instructions available to an application, you can
+set the B<OPENSSL_riscvcap> environment variable before you start the
+application.
+
+The environment variable is similar to the RISC-V ISA string defined in the
+RISC-V Instruction Set Manual. It is case insensitive. Though due to the limit
+of the environment variable parser inside libcrypto, an extension must be
+prefixed with an underscore to make it recognizable. This also applies to the
+Vector extension.
+
+ OPENSSL_riscvcap="rv64gc_v_zba_zbb_zbs..."
+
+Note that extension implication is currently not implemented.
+For example, when "rv64gc_b" is provided as the environment variable,
+zba/zbb/zbs would not be implied in the capability vector.
+
+Currently only these extensions are recognized:
+
+=over 4
+
+=item ZBA
+
+Address Generation
+
+Could be detected using hwprobe for Linux kernel >= 6.5
+
+=item ZBB
+
+Basic bit-manipulation
+
+Could be detected using hwprobe for Linux kernel >= 6.5
+
+=item ZBC
+
+Carry-less multiplication
+
+Could be detected using hwprobe for Linux kernel >= 6.8
+
+=item ZBS
+
+Single-bit instructions
+
+Could be detected using hwprobe for Linux kernel >= 6.5
+
+=item ZBKB
+
+Bit-manipulation for Cryptography
+
+Could be detected using hwprobe for Linux kernel >= 6.8
+
+=item ZBKC
+
+Carry-less multiplication for Cryptography
+
+Could be detected using hwprobe for Linux kernel >= 6.8
+
+=item ZBKX
+
+Crossbar permutations
+
+Could be detected using hwprobe for Linux kernel >= 6.8
+
+=item ZKND
+
+NIST Suite: AES Decryption
+
+Could be detected using hwprobe for Linux kernel >= 6.8
+
+=item ZKNE
+
+NIST Suite: AES Encryption
+
+Could be detected using hwprobe for Linux kernel >= 6.8
+
+=item ZKNH
+
+NIST Suite: Hash Function Instructions
+
+Could be detected using hwprobe for Linux kernel >= 6.8
+
+=item ZKSED
+
+ShangMi Suite: SM4 Block Cipher Instructions
+
+Could be detected using hwprobe for Linux kernel >= 6.8
+
+=item ZKSH
+
+ShangMi Suite: SM3 Hash Function Instructions
+
+Could be detected using hwprobe for Linux kernel >= 6.8
+
+=item ZKR
+
+Entropy Source Extension
+
+=item ZKT
+
+Data Independent Execution Latency
+
+Could be detected using hwprobe for Linux kernel >= 6.8
+
+=item V
+
+Vector Extention for Application Processors
+
+Could be detected using hwprobe for Linux kernel >= 6.5
+
+=item ZVBB
+
+Vector Basic Bit-manipulation
+
+Could be detected using hwprobe for Linux kernel >= 6.8
+
+=item ZVBC
+
+Vector Carryless Multiplication
+
+Could be detected using hwprobe for Linux kernel >= 6.8
+
+=item ZVKB
+
+Vector Cryptography Bit-manipulation
+
+Could be detected using hwprobe for Linux kernel >= 6.8
+
+=item ZVKG
+
+Vector GCM/GMAC
+
+Could be detected using hwprobe for Linux kernel >= 6.8
+
+=item ZVKNED
+
+NIST Suite: Vector AES Block Cipher
+
+Could be detected using hwprobe for Linux kernel >= 6.8
+
+=item ZVKNHA
+
+NIST Suite: Vector SHA-2 Secure Hash
+
+Could be detected using hwprobe for Linux kernel >= 6.8
+
+=item ZVKNHB
+
+NIST Suite: Vector SHA-2 Secure Hash
+
+Could be detected using hwprobe for Linux kernel >= 6.8
+
+=item ZVKSED
+
+ShangMi Suite: SM4 Block Cipher
+
+Could be detected using hwprobe for Linux kernel >= 6.8
+
+=item ZVKSH
+
+ShangMi Suite: SM3 Secure Hash
+
+Could be detected using hwprobe for Linux kernel >= 6.8
+
+=back
+
+=head1 RETURN VALUES
+
+Not available.
+
+=head1 EXAMPLES
+
+Check currently detected capabilities
+
+ $ openssl info -cpusettings
+ OPENSSL_riscvcap=ZBA_ZBB_ZBC_ZBS_V
+
+Disables all instruction set extensions:
+
+ OPENSSL_riscvcap="rv64gc"
+
+Only enable the vector extension:
+
+ OPENSSL_riscvcap="rv64gc_v"
+
+=head1 COPYRIGHT
+
+Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -80,7 +80,7 @@ OpenSSL supports a number of different algorithm implementations for
 various machines and, by default, it determines which to use based on the
 processor capabilities and run time feature enquiry.  These environment
 variables can be used to exert more control over this selection process.
-See L<OPENSSL_ia32cap(3)>, L<OPENSSL_s390xcap(3)>.
+See L<OPENSSL_ia32cap(3)>, L<OPENSSL_s390xcap(3)> and L<OPENSSL_riscvcap(3)>.
 
 =item B<NO_PROXY>, B<HTTPS_PROXY>, B<HTTP_PROXY>
 

--- a/include/crypto/riscv_arch.def
+++ b/include/crypto/riscv_arch.def
@@ -16,37 +16,45 @@
  * second argument as the index in the array where the capability will be stored
  * and third argument as the index of the bit to be used to encode the
  * capability.
- * RISCV_DEFINE_CAP(EXTENSION NAME, array index, bit index) */
+ *
+ * The fourth and the fifth arguments are copied from linux header asm/hwprobe.h.
+ * Directly coping values instead of macro names comes from the fact
+ * that an old version may lack definition of some macro.
+ * When there is no hwprobe key/value pair for a capability, the key is set to -1
+ * and the value is set to 0, as when the hwprobe syscall returns a key of -1,
+ * the value is set to 0 and the corresponding capability would not be enabled.
+ *
+ * RISCV_DEFINE_CAP(EXTENSION NAME, array index, bit index, hwprobe key, hwprobe value) */
 
-RISCV_DEFINE_CAP(ZBA, 0, 0)
-RISCV_DEFINE_CAP(ZBB, 0, 1)
-RISCV_DEFINE_CAP(ZBC, 0, 2)
-RISCV_DEFINE_CAP(ZBS, 0, 3)
-RISCV_DEFINE_CAP(ZBKB, 0, 4)
-RISCV_DEFINE_CAP(ZBKC, 0, 5)
-RISCV_DEFINE_CAP(ZBKX, 0, 6)
-RISCV_DEFINE_CAP(ZKND, 0, 7)
-RISCV_DEFINE_CAP(ZKNE, 0, 8)
-RISCV_DEFINE_CAP(ZKNH, 0, 9)
-RISCV_DEFINE_CAP(ZKSED, 0, 10)
-RISCV_DEFINE_CAP(ZKSH, 0, 11)
-RISCV_DEFINE_CAP(ZKR, 0, 12)
-RISCV_DEFINE_CAP(ZKT, 0, 13)
-RISCV_DEFINE_CAP(V, 0, 14)
-RISCV_DEFINE_CAP(ZVBB, 0, 15)
-RISCV_DEFINE_CAP(ZVBC, 0, 16)
-RISCV_DEFINE_CAP(ZVKB, 0, 17)
-RISCV_DEFINE_CAP(ZVKG, 0, 18)
-RISCV_DEFINE_CAP(ZVKNED, 0, 19)
-RISCV_DEFINE_CAP(ZVKNHA, 0, 20)
-RISCV_DEFINE_CAP(ZVKNHB, 0, 21)
-RISCV_DEFINE_CAP(ZVKSED, 0, 22)
-RISCV_DEFINE_CAP(ZVKSH, 0, 23)
+RISCV_DEFINE_CAP(ZBA, 0, 0, 4, (1 << 3))
+RISCV_DEFINE_CAP(ZBB, 0, 1, 4, (1 << 4))
+RISCV_DEFINE_CAP(ZBC, 0, 2, 4, (1 << 7))
+RISCV_DEFINE_CAP(ZBS, 0, 3, 4, (1 << 5))
+RISCV_DEFINE_CAP(ZBKB, 0, 4, 4, (1 << 8))
+RISCV_DEFINE_CAP(ZBKC, 0, 5, 4, (1 << 9))
+RISCV_DEFINE_CAP(ZBKX, 0, 6, 4, (1 << 10))
+RISCV_DEFINE_CAP(ZKND, 0, 7, 4, (1 << 11))
+RISCV_DEFINE_CAP(ZKNE, 0, 8, 4, (1 << 12))
+RISCV_DEFINE_CAP(ZKNH, 0, 9, 4, (1 << 13))
+RISCV_DEFINE_CAP(ZKSED, 0, 10, 4, (1 << 14))
+RISCV_DEFINE_CAP(ZKSH, 0, 11, 4, (1 << 15))
+RISCV_DEFINE_CAP(ZKR, 0, 12, -1, 0)
+RISCV_DEFINE_CAP(ZKT, 0, 13, 4, (1 << 16))
+RISCV_DEFINE_CAP(V, 0, 14, 4, (1 << 2))
+RISCV_DEFINE_CAP(ZVBB, 0, 15, 4, (1 << 17))
+RISCV_DEFINE_CAP(ZVBC, 0, 16, 4, (1 << 18))
+RISCV_DEFINE_CAP(ZVKB, 0, 17, 4, (1 << 19))
+RISCV_DEFINE_CAP(ZVKG, 0, 18, 4, (1 << 20))
+RISCV_DEFINE_CAP(ZVKNED, 0, 19, 4, (1 << 21))
+RISCV_DEFINE_CAP(ZVKNHA, 0, 20, 4, (1 << 22))
+RISCV_DEFINE_CAP(ZVKNHB, 0, 21, 4, (1 << 23))
+RISCV_DEFINE_CAP(ZVKSED, 0, 22, 4, (1 << 24))
+RISCV_DEFINE_CAP(ZVKSH, 0, 23, 4, (1 << 25))
 
 /*
  * In the future ...
- * RISCV_DEFINE_CAP(ZFOO, 0, 31)
- * RISCV_DEFINE_CAP(ZBAR, 1, 0)
+ * RISCV_DEFINE_CAP(ZFOO, 0, 31, ..., ...)
+ * RISCV_DEFINE_CAP(ZBAR, 1, 0, ..., ...)
  * ... and so on.
  */
 

--- a/util/other.syms
+++ b/util/other.syms
@@ -4,6 +4,7 @@
 #
 OPENSSL_ia32cap                         environment
 OPENSSL_s390xcap                        environment
+OPENSSL_riscvcap                        environment
 OPENSSL_MALLOC_FD                       environment
 OPENSSL_MALLOC_FAILURES                 environment
 OPENSSL_instrument_bus                  assembler


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

This originates from https://github.com/openssl/openssl/pull/24069#issuecomment-2044632179

[hwprobe](https://docs.kernel.org/arch/riscv/hwprobe.html) is a linux syscall specific to riscv architecture where key/value pairs can be queried to detect whether an extension exists. This corresponds to the capability defined in openssl.

hwprobe syscall is added in Linux 6.4 and `<asm/hwprobe.h>` is still updating (check [lkml](https://lore.kernel.org/linux-riscv/?q=hwprobe)). To workaround the compile time/runtime linux version problem, examples are
  * compile/run in system where kernel<6.4
  * compile/run in system where kernel>=6.4 but `<asm/hwprobe.h>` is does not corresponds to the hwprobe.h openssl required
  * compile in a new system and run in an old system

As for non-existing syscall, `__has_include(<asm/hwprobe.h>)` can be used at compile time and `-ENOSYS` can be used at runtime

As for unknown key/value query, the syscall would clear it, see

>  If a key is unknown to the kernel, its key field will be cleared to -1, and its value set to 0.
> https://docs.kernel.org/arch/riscv/hwprobe.html

The only problem is the possible unknown macros from `<asm/hwprobe.h>` (undefined macro when compiling in old system) so directly coping value is the workaround.

As the original thread discussed, `OPENSSL_riscvcap`, when provided, should override hwprobe interface.

Documentation for `OPENSSL_riscvcap` together with hwprobe would be added in another PR.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
