### PR TITLE
Better ANSI C check and support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: config
-      run: CPPFLAGS='-ansi -D_XOPEN_SOURCE=1 -D_POSIX_C_SOURCE=200809L' ./config --banner=Configured no-asm no-makedepend enable-buildtest-c++ enable-fips --strict-warnings && perl configdata.pm --dump
+      run: CPPFLAGS='-ansi -D_XOPEN_SOURCE=1 -D_POSIX_C_SOURCE=200809L' ./config --banner=Configured no-asm no-secure-memory no-makedepend enable-buildtest-c++ enable-fips --strict-warnings && perl configdata.pm --dump
     - name: make
       run: make -s -j4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: config
-      run: CPPFLAGS=-ansi ./config --banner=Configured no-asm no-makedepend enable-buildtest-c++ enable-fips --strict-warnings -D_DEFAULT_SOURCE && perl configdata.pm --dump
+      run: CPPFLAGS='-ansi -D_XOPEN_SOURCE=1 -D_POSIX_C_SOURCE=200809L' ./config --banner=Configured no-asm no-makedepend enable-buildtest-c++ enable-fips --strict-warnings && perl configdata.pm --dump
     - name: make
       run: make -s -j4
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -52,6 +52,8 @@ To install OpenSSL, you will need:
  * Perl 5 with core modules (please read [NOTES-PERL.md](NOTES-PERL.md))
  * The Perl module `Text::Template` (please read [NOTES-PERL.md](NOTES-PERL.md))
  * an ANSI C compiler
+ * POSIX C library (at least POSIX.1-2008), or compatible types and
+   functionality.
  * a development environment in the form of development libraries and C
    header files
  * a supported operating system
@@ -65,6 +67,7 @@ issues and other details, please read one of these:
  * [Notes for the DOS platform with DJGPP](NOTES-DJGPP.md)
  * [Notes for the OpenVMS platform](NOTES-VMS.md)
  * [Notes for the HPE NonStop platform](NOTES-NONSTOP.md)
+ * [Notes on POSIX](NOTES-POSIX.md)
  * [Notes on Perl](NOTES-PERL.md)
  * [Notes on Valgrind](NOTES-VALGRIND.md)
 

--- a/NOTES-ANSI.md
+++ b/NOTES-ANSI.md
@@ -6,7 +6,7 @@ the following configuration settings:
 
 -   `no-asm`
 
-    There are cases if `asm()` calls in our C source, which isn't supported
+    There are cases of `asm()` calls in our C source, which isn't supported
     in pure ANSI C.
 
 -   `no-secure-memory`
@@ -29,5 +29,5 @@ the following configuration settings:
     -   `strdup()`
 
 It's arguable that with gcc and clang, all of these issues are removed when
-defining the macro `_DEFAULT_SOURCE`.  However. that effectively sets the C
+defining the macro `_DEFAULT_SOURCE`.  However, that effectively sets the C
 language level to C99, which isn't ANSI C.

--- a/NOTES-ANSI.md
+++ b/NOTES-ANSI.md
@@ -1,0 +1,33 @@
+Notes on ANSI C
+===============
+
+When building for pure ANSI C (C89/C90), you must configure with at least
+the following configuration settings:
+
+-   `no-asm`
+
+    There are cases if `asm()` calls in our C source, which isn't supported
+    in pure ANSI C.
+
+-   `no-secure-memory`
+
+    The secure memory calls aren't supported with ANSI C.
+
+-   `-D_XOPEN_SOURCE=1`
+
+    This macro enables the use of the following types, functions and global
+    variables:
+
+    -   `timezone`
+
+-   `-D_POSIX_C_SOURCE=200809L`
+
+    This macro enables the use of the following types, functions and global
+    variables:
+
+    -   `ssize_t`
+    -   `strdup()`
+
+It's arguable that with gcc and clang, all of these issues are removed when
+defining the macro `_DEFAULT_SOURCE`.  However. that effectively sets the C
+language level to C99, which isn't ANSI C.

--- a/NOTES-POSIX.md
+++ b/NOTES-POSIX.md
@@ -1,0 +1,21 @@
+Notes on POSIX
+==============
+
+There are few instances where OpenSSL requires a POSIX C library, at least
+version 1-2008, or compatible enough functionality.
+
+There are exceptions, though, for platforms that do not have a POSIX
+library, or where there are quirks that need working around.  A notable
+platform is Windows, where POSIX functionality may be available, but where
+the function names are prefixed with an underscore, and where some POSIX
+types are not present (such as `ssize_t`).
+
+Platforms that do have a POSIX library may still not have them accessible
+unless the following macros are defined:
+
+    _POSIX_C_SOURCE=200809L
+    _XOPEN_SOURCE=1
+
+This is, for example, the case when building with gcc or clang and using the
+flag `-ansi`.
+

--- a/NOTES-POSIX.md
+++ b/NOTES-POSIX.md
@@ -18,4 +18,3 @@ unless the following macros are defined:
 
 This is, for example, the case when building with gcc or clang and using the
 flag `-ansi`.
-

--- a/crypto/sleep.c
+++ b/crypto/sleep.c
@@ -20,7 +20,7 @@ void OSSL_sleep(uint64_t millis)
     /* HPNS does not support usleep for non threaded apps */
     PROCESS_DELAY_(millis * 1000);
 }
-# elif defined(__DJGPP__)
+# elif defined(__DJGPP__) || defined(__TANDEM)
 #  include <unistd.h>
 void OSSL_sleep(uint64_t millis)
 {

--- a/crypto/sleep.c
+++ b/crypto/sleep.c
@@ -15,7 +15,7 @@
 
 # if defined(OPENSSL_USE_USLEEP)                        \
     || defined(__DJGPP__)                               \
-    || (defined(__TANDEM) && defined(_REENTRANT)
+    || (defined(__TANDEM) && defined(_REENTRANT))
 
 /*
  * usleep() was made obsolete by POSIX.1-2008, and nanosleep()

--- a/crypto/sleep.c
+++ b/crypto/sleep.c
@@ -33,6 +33,12 @@ void OSSL_sleep(uint64_t millis)
 
     if (s > 0)
         sleep(s);
+    /*
+     * On NonStop with the PUT thread model, thread context switch is
+     * cooperative, with usleep() being a "natural" context switch point.
+     * We avoid checking us > 0 here, to allow that context switch to
+     * happen.
+     */
     usleep(us);
 }
 

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -200,6 +200,7 @@ extern "C" {
 # endif
 
 # ifndef ossl_ssize_t
+#  include <sys/types.h>
 #  define ossl_ssize_t ssize_t
 #  if defined(SSIZE_MAX)
 #   define OSSL_SSIZE_MAX SSIZE_MAX

--- a/util/platform_symbols/unix-symbols.txt
+++ b/util/platform_symbols/unix-symbols.txt
@@ -76,6 +76,7 @@ mlock
 mmap
 mprotect
 munmap
+nanosleep
 opendir
 openlog
 poll


### PR DESCRIPTION
Our check of ANSI C compatibility defines `_DEFAULT_SOURCE`, which effectively turns gcc and clang into a C99 compiler...  perhaps not with regard to pure language features, but it enables a few too many types and functions that aren't defined in ANSI C library, or in some cases, in any C language level library.

This changeset drops `_DEFAULT_SOURCE` and deals with the consequences.  This includes explicitly enabling the use of POSIX and X/OPEN features throught the macro definitions `_XOPEN_SOURCE=1` and `_POSIX_SOURCE=200809L`, which enables the use of `timezone`, `ssize_t`, `strdup()` and `nanosleep()`.

INSTALL.md is amended, and NOTES for ANSI and POSIX are added.
