### PR TITLE
ecparam: Only list actually available curves in -list_curves

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,9 @@ OpenSSL 3.4
 
 ### Changes between 3.3 and 3.4 [xx XXX xxxx]
 
+ * The `openssl ecparam -list_curves` now only shows curves that are
+   available for use with the default library context.
+
  * Added options `-not_before` and `-not_after` for explicit setting
    start and end dates of certificates created with the `req` and `x509`
    apps. Added the same options also to `ca` app as alias for

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -76,6 +76,9 @@ static int list_builtin_curves(BIO *out)
         goto end;
 
     for (n = 0; n < crv_len; n++) {
+        if (!EC_GROUP_new_by_curve_name(curves[n].nid)) {
+           continue;
+        }
         const char *comment = curves[n].comment;
         const char *sname = OBJ_nid2sn(curves[n].nid);
 


### PR DESCRIPTION
Currently `openssl list -all-algorithms` doesn't show anything about ec curves.

ecparams app has `-list_curves` option, but it currently shows "all known curves" rather than usable curves in the default library context.

Improve `-list_curves` to only show curves that are getable with a default library context.

However, this might be treated as a breaking API / UX change. Because IMHO `ecparam -list_curves` should show sensible list of curves that one can actually use.

If that's not acceptable, I guess the alternative is a request to add "list all known curves, and actually provided curves" in the `openssl list` applet, as stand alone request and as part of `-all-algorithms`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
