### PR TITLE
fips: remove P-192

### DIFF
--- a/crypto/ec/ec_curve.c
+++ b/crypto/ec/ec_curve.c
@@ -29,6 +29,7 @@ typedef struct {
     unsigned int cofactor;      /* promoted to BN_ULONG */
 } EC_CURVE_DATA;
 
+#ifndef FIPS_MODULE
 /* the nist prime curves */
 static const struct {
     EC_CURVE_DATA h;
@@ -61,6 +62,7 @@ static const struct {
         0x99, 0xDE, 0xF8, 0x36, 0x14, 0x6B, 0xC9, 0xB1, 0xB4, 0xD2, 0x28, 0x31
     }
 };
+#endif /* FIPS_MODULE */
 
 static const struct {
     EC_CURVE_DATA h;
@@ -2856,8 +2858,6 @@ static const ec_list_element curve_list[] = {
      "NIST/SECG curve over a 521 bit prime field"},
 
     /* X9.62 curves */
-    {NID_X9_62_prime192v1, &_EC_NIST_PRIME_192.h, 0,
-     "NIST/X9.62/SECG curve over a 192 bit prime field"},
     {NID_X9_62_prime256v1, &_EC_X9_62_PRIME_256V1.h,
 # if defined(ECP_NISTZ256_ASM)
      EC_GFp_nistz256_method,

--- a/providers/common/capabilities.c
+++ b/providers/common/capabilities.c
@@ -168,10 +168,8 @@ static const OSSL_PARAM param_group_list[][10] = {
     TLS_GROUP_ENTRY("secp160r1", "secp160r1", "EC", 15),
     TLS_GROUP_ENTRY("secp160r2", "secp160r2", "EC", 16),
     TLS_GROUP_ENTRY("secp192k1", "secp192k1", "EC", 17),
-#  endif
     TLS_GROUP_ENTRY("secp192r1", "prime192v1", "EC", 18),
     TLS_GROUP_ENTRY("P-192", "prime192v1", "EC", 18), /* Alias of above */
-#  ifndef FIPS_MODULE
     TLS_GROUP_ENTRY("secp224k1", "secp224k1", "EC", 19),
 #  endif
     TLS_GROUP_ENTRY("secp224r1", "secp224r1", "EC", 20),

--- a/test/acvp_test.inc
+++ b/test/acvp_test.inc
@@ -212,15 +212,6 @@ static const unsigned char ecdsa_sigver_s1[] = {
 };
 static const struct ecdsa_sigver_st ecdsa_sigver_data[] = {
     {
-        "SHA-1",
-        "P-192",
-        ITM(ecdsa_sigver_msg0),
-        ITM(ecdsa_sigver_pub0),
-        ITM(ecdsa_sigver_r0),
-        ITM(ecdsa_sigver_s0),
-        PASS,
-    },
-    {
         "SHA2-512",
         "P-521",
         ITM(ecdsa_sigver_msg1),

--- a/test/recipes/65-test_cmp_protect.t
+++ b/test/recipes/65-test_cmp_protect.t
@@ -27,6 +27,9 @@ plan skip_all => "This test is not supported in a no-cmp build"
 plan skip_all => "This test is not supported in a shared library build on Windows"
     if $^O eq 'MSWin32' && !disabled("shared");
 
+plan skip_all => "Intermediate_CA.crt uses legacy P-192"
+    unless $no_fips;
+
 plan tests => 2 + ($no_fips ? 0 : 1); #fips test
 
 my @basic_cmd = ("cmp_protect_test",

--- a/test/recipes/65-test_cmp_vfy.t
+++ b/test/recipes/65-test_cmp_vfy.t
@@ -27,6 +27,9 @@ plan skip_all => "This test is not supported in a no-cmp build"
 plan skip_all => "This test is not supported in a no-ec build"
     if disabled("ec");
 
+plan skip_all => "Intermediate_CA.crt uses legacy P-192"
+    unless $no_fips;
+
 plan tests => 2 + ($no_fips ? 0 : 1); #fips test
 
 my @basic_cmd = ("cmp_vfy_test",


### PR DESCRIPTION
In recent NIST standards P-192 now has legacy status for verification only, remove it from FIPS module.

Note, I don't believe it ever was popular. Thus I'm not sure it is needed to support "verification-only" mode of P-192 in the FIPS module.

Related: 24193

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
