### PR TITLE
hkdf: when HMAC key is all zeros, still set a valid key length

### DIFF
--- a/providers/implementations/kdfs/hkdf.c
+++ b/providers/implementations/kdfs/hkdf.c
@@ -631,7 +631,7 @@ static int prov_tls13_hkdf_generate_secret(OSSL_LIB_CTX *libctx,
     }
     if (prevsecret == NULL) {
         prevsecret = default_zeros;
-        prevsecretlen = 0;
+        prevsecretlen = mdlen;
     } else {
         EVP_MD_CTX *mctx = EVP_MD_CTX_new();
         unsigned char hash[EVP_MAX_MD_SIZE];


### PR DESCRIPTION
By itself, this is no change in any computation. However, this will unlock enforcing minimum key lengths for NIST and FIPS 140-3 requirements.

Also reading RFC8448 and RFC5869, this seems to be strictly correct too.

Submitting this separately from #24199 because this may seem as potentially critical change.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated

No tests adjusted as the expectations are to remain the same.