### PR TITLE
Fix missing NULL check in prov_config_test

### DIFF
--- a/test/prov_config_test.c
+++ b/test/prov_config_test.c
@@ -83,6 +83,9 @@ static int test_path_config(void)
     char *full_path = NULL;
     int rc;
 
+    if (!TEST_ptr(module_path))
+        return 0;
+
     full_path = OPENSSL_zalloc(strlen(module_path) + strlen(P_TEST_PATH) + 1);
     if (!TEST_ptr(full_path))
         return 0;


### PR DESCRIPTION
coverity-1596500 caught a missing null check.  We should never hit it as the test harness always sets the environment variable, but lets add the check for safety

