### PR TITLE
Fixes for issue #24121: invoking tear_down when exiting the function …

### DIFF
--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -450,13 +450,18 @@ static int test_encode_tls_sct(void)
 
     fixture->sct_list = sk_SCT_new_null();
     if (fixture->sct_list == NULL)
-	    return 0;
+    {
+        tear_down(fixture);
+        return 0;
+    }
 
     if (!TEST_ptr(sct = SCT_new_from_base64(SCT_VERSION_V1, log_id,
                                             CT_LOG_ENTRY_TYPE_X509, timestamp,
                                             extensions, signature)))
-
+    {
+        tear_down(fixture);
         return 0;
+    }
 
     sk_SCT_push(fixture->sct_list, sct);
     fixture->sct_dir = ct_dir;


### PR DESCRIPTION
Fixed by invoking *`tear_down(fixture);`* for cases when the function returns for error cases from the `if` conditions.

**Before**
```c
    SETUP_CT_TEST_FIXTURE();

    fixture->sct_list = sk_SCT_new_null();
    if (fixture->sct_list == NULL)
        return 0;

    if (!TEST_ptr(sct = SCT_new_from_base64(SCT_VERSION_V1, log_id,
                                            CT_LOG_ENTRY_TYPE_X509, timestamp,
                                            extensions, signature)))
        return 0;
```

**After**
```c
    SETUP_CT_TEST_FIXTURE();

    fixture->sct_list = sk_SCT_new_null();
    if (fixture->sct_list == NULL)
    {
        tear_down(fixture); // added this line
	return 0;
    }

    if (!TEST_ptr(sct = SCT_new_from_base64(SCT_VERSION_V1, log_id,
                                            CT_LOG_ENTRY_TYPE_X509, timestamp,
                                            extensions, signature)))
    {
        tear_down(fixture); // added this line
        return 0;
    }
```


<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [] documentation is added or updated
- [] tests are added or updated
