### PR TITLE
Fix conflict in ssl_cipher_list_to_bytes

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -4067,11 +4067,9 @@ int ssl_cipher_list_to_bytes(SSL_CONNECTION *s, STACK_OF(SSL_CIPHER) *sk,
 {
     int i;
     size_t totlen = 0, len, maxlen, maxverok = 0;
-    int min_proto_version_limit = SSL_CONNECTION_IS_DTLS(s)
-                                  ? DTLS1_3_VERSION : TLS1_3_VERSION;
     int empty_reneg_info_scsv = !s->renegotiate
-                                && (ssl_version_cmp(s, s->min_proto_version, min_proto_version_limit) < 0
-                                    || s->min_proto_version == 0);
+                                && (SSL_CONNECTION_IS_DTLS(s)
+                                    || s->min_proto_version < TLS1_3_VERSION);
     SSL *ssl = SSL_CONNECTION_GET_SSL(s);
 
     /* Set disabled masks for this session */


### PR DESCRIPTION
This is a squash commit to be merged to the feature/dtls-1.3 branch to enable that branch to be rebased on top of master once #24161 is merged there. IMO we should retain the orginal commit message and reviewed-by headers for the modified commit, and add this new commit description and reviewed-by headers from this PR onto the end of the commit description.

Once 24161 is merged to master, and this PR is merged to feature/dtls-1.3 we should immediately rebase feature/dtls-1.3 on the latest master.


Updated the logic in ssl_cipher_list_to_bytes to take account of the changes from PR#24161
