### PR TITLE
Readability change - srp_verifier.txt

### DIFF
--- a/apps/demoSRP/srp_verifier.txt
+++ b/apps/demoSRP/srp_verifier.txt
@@ -1,6 +1,6 @@
 # This is a file that will be filled by the openssl srp routine.
 # You can initialize the file with additional groups, these are
-# records starting with an I followed by the g and N values and the id.
+# records starting with an 'I' followed by the 'g' and 'N' values and the ID.
 # The exact values ... you have to dig this out from the source of srp.c
 # or srp_vfy.c
-# The last value of an I is used as the default group for new users.
+# The last value of an 'I' is used as the default group for new users.


### PR DESCRIPTION
I enclosed each of the values (I, g, and N) in single quotes to increase readability and lessen any confusion for the readers.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
