### PR TITLE
Trivial: Grammar Fixes and Spell Checks in Notes - sha512.c

### DIFF
--- a/crypto/sha/sha512.c
+++ b/crypto/sha/sha512.c
@@ -18,16 +18,16 @@
 /*-
  * IMPLEMENTATION NOTES.
  *
- * As you might have noticed 32-bit hash algorithms:
+ * As you might have noticed, 32-bit hash algorithms:
  *
  * - permit SHA_LONG to be wider than 32-bit
  * - optimized versions implement two transform functions: one operating
- *   on [aligned] data in host byte order and one - on data in input
+ *   on [aligned] data in host byte order, and one - on data in input
  *   stream byte order;
  * - share common byte-order neutral collector and padding function
  *   implementations, crypto/md32_common.h;
  *
- * Neither of the above applies to this SHA-512 implementations. Reasons
+ * Neither of the above applies to this SHA-512 implementation. Reasons
  * [in reverse order] are:
  *
  * - it's the only 64-bit hash algorithm for the moment of this writing,

--- a/crypto/sha/sha512.c
+++ b/crypto/sha/sha512.c
@@ -22,7 +22,7 @@
  *
  * - permit SHA_LONG to be wider than 32-bit
  * - optimized versions implement two transform functions: one operating
- *   on [aligned] data in host byte order, and one - on data in input
+ *   on [aligned] data in host byte order, and one operating on data in input
  *   stream byte order;
  * - share common byte-order neutral collector and padding function
  *   implementations, crypto/md32_common.h;


### PR DESCRIPTION
Added commas for sentence openers in Implementation Notes. Fixed spelling of "reasons" section of the notes. @bbbrumley 

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
