### PR TITLE
fix coverity issues found in new hashtable

### DIFF
--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -368,7 +368,6 @@ static CONF_MODULE *module_add(DSO *dso, const char *name,
 
  err:
     ossl_rcu_write_unlock(module_list_lock);
-    sk_CONF_MODULE_free(new_modules);
     if (tmod != NULL) {
         OPENSSL_free(tmod->name);
         OPENSSL_free(tmod);

--- a/crypto/hashtable/hashtable.c
+++ b/crypto/hashtable/hashtable.c
@@ -230,7 +230,8 @@ HT *ossl_ht_new(HT_CONFIG *conf)
 err:
     CRYPTO_THREAD_lock_free(new->atomic_lock);
     ossl_rcu_lock_free(new->lock);
-    OPENSSL_free(new->md->neighborhood_ptr_to_free);
+    if (new->md != NULL)
+        OPENSSL_free(new->md->neighborhood_ptr_to_free);
     OPENSSL_free(new->md);
     OPENSSL_free(new);
     return NULL;


### PR DESCRIPTION
Fix 2 issues found in the new hash table:
coverity-1596616 - Missing null check in error path can lead to derefrencing of a null pointer
coverity-1596617 Double free of new_modules list

