### PR TITLE
archive artifacts before upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "ci@basic-gcc"
-        path: artifacts/
+        path: artifacts.tar.gz
 
   basic_clang:
     runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
@@ -118,7 +118,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "ci@basic-clang"
-        path: artifacts/
+        path: artifacts.tar.gz
 
   self-hosted:
     if: github.repository == 'openssl/openssl'
@@ -143,7 +143,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "ci@self-hosted-${{ matrix.os }}"
-        path: artifacts/
+        path: artifacts.tar.gz
 
   minimal:
     runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
@@ -165,8 +165,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "ci@minimal"
-        path: artifacts/
-        if-no-files-found: ignore
+        path: artifacts.tar.gz
 
   no-deprecated:
     runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
@@ -188,7 +187,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "ci@no-deprecated"
-        path: artifacts/
+        path: artifacts.tar.gz
 
   no-shared-ubuntu:
     runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
@@ -210,7 +209,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "ci@no-shared-ubuntu"
-        path: artifacts/
+        path: artifacts.tar.gz
 
   no-shared-macos:
     strategy:
@@ -237,7 +236,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "ci@no-shared-${{ matrix.os }}"
-        path: artifacts/
+        path: artifacts.tar.gz
 
   non-caching:
     runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
@@ -263,7 +262,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "ci@non-caching"
-        path: artifacts/
+        path: artifacts.tar.gz
 
   address_ub_sanitizer:
     runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
@@ -289,7 +288,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "ci@address_ub_sanitizer"
-        path: artifacts/
+        path: artifacts.tar.gz
 
   fuzz_tests:
     runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
@@ -315,7 +314,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "ci@fuzz_tests"
-        path: artifacts/
+        path: artifacts.tar.gz
         if-no-files-found: ignore
 
   memory_sanitizer:
@@ -343,7 +342,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "ci@memory_sanitizer"
-        path: artifacts/
+        path: artifacts.tar.gz
 
   threads_sanitizer:
     runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
@@ -369,7 +368,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "ci@threads_sanitizer"
-        path: artifacts/
+        path: artifacts.tar.gz
 
   enable_non-default_options:
     runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
@@ -393,7 +392,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "ci@enable_non-default_options"
-        path: artifacts/
+        path: artifacts.tar.gz
 
   full_featured:
     runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
@@ -423,7 +422,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "ci@full_featured"
-        path: artifacts/
+        path: artifacts.tar.gz
 
   no-legacy:
     runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
@@ -445,7 +444,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "ci@no-legacy"
-        path: artifacts/
+        path: artifacts.tar.gz
 
   legacy:
     runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
@@ -467,7 +466,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "ci@legacy"
-        path: artifacts/
+        path: artifacts.tar.gz
 
   # out-of-source-and-install checks multiple things at the same time:
   # - That building, testing and installing works from an out-of-source
@@ -509,7 +508,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "ci@out-of-readonly-source-and-install-ubuntu"
-        path: build/artifacts/
+        path: build/artifacts.tar.gz
     - name: make install
       run: make install
       working-directory: ./build
@@ -554,7 +553,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "ci@out-of-readonly-source-and-install-${{ matrix.os }}"
-        path: build/artifacts/
+        path: build/artifacts.tar.gz
     - name: make install
       run: make install
       working-directory: ./build

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -220,5 +220,5 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: "cross-compiles@${{ matrix.platform.arch }}"
-        path: artifacts/
+        path: artifacts.tar.gz
         if-no-files-found: ignore

--- a/.github/workflows/make-test
+++ b/.github/workflows/make-test
@@ -37,4 +37,7 @@ echo "Test suite exited with $RESULT, artifacts path is $OSSL_CI_ARTIFACTS_PATH"
 (cd "$OSSL_CI_ARTIFACTS_PATH"; find . -type f | sort)
 echo "::endgroup::"
 
+echo "Archive artifacts"
+tar -czvf artifacts.tar.gz $OSSL_CI_ARTIFACTS_PATH
+
 exit $RESULT


### PR DESCRIPTION
Some CI jobs produce a significant amount of artifacts and it takes a lot of time to upload them into GitHub artifacts storage. It will be much faster to upload only one archive with artifacts.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

