### PR TITLE
Implement riscv_vlen_asm for riscv32

### DIFF
--- a/crypto/riscv32cpuid.pl
+++ b/crypto/riscv32cpuid.pl
@@ -84,5 +84,22 @@ OPENSSL_cleanse:
 ___
 }
 
+{
+my ($ret) = ('a0');
+$code .= <<___;
+################################################################################
+# size_t riscv_vlen_asm(void)
+# Return VLEN (i.e. the length of a vector register in bits).
+.p2align 3
+.globl riscv_vlen_asm
+.type riscv_vlen_asm,\@function
+riscv_vlen_asm:
+    csrr $ret, vlenb
+    slli $ret, $ret, 3
+    ret
+.size riscv_vlen_asm,.-riscv_vlen_asm
+___
+}
+
 print $code;
 close STDOUT or die "error closing STDOUT: $!";


### PR DESCRIPTION
Now for the linux32-riscv32 target, we would get the error when linking

```
riscvcap.c:(.text.startup+0x104): undefined reference to `riscv_vlen_asm'
```

#20149 added `riscv_vlen_asm` in `riscv64cpuid.pl` but not in `riscv32cpuid.pl`, and this function is needed in `riscvcap.c`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
