### PR TITLE
Proposed Windows installer

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -1,0 +1,78 @@
+# Copyright 2021-2024 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+name: Build Windows Installer
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        description: The tag to build
+
+permissions:
+  contents: read
+
+jobs:
+  build_installer:
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.inputs.tag }}
+    - name: Setup directories 
+      run: |
+        mkdir _installer
+        mkdir _build64
+        mkdir _build32
+    - name: download NSIS installer
+      uses: suisei-cn/actions-download-file@v1.6.0
+      with:
+        url: "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.08/nsis-3.08-setup.exe"
+        target: _installer/
+    - name: Install NSIS 3.0.8
+      working-directory: _installer
+      run:  .\nsis-3.08-setup.exe /s
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: win64
+    - uses: ilammy/setup-nasm@v1
+      with:
+        platform: win64
+    - name: config x64
+      working-directory: _build64
+      run: |
+        perl ..\Configure --banner=Configured no-makedepend enable-fips VC-WIN64A
+        perl configdata.pm --dump
+    - name: build x64 binaries
+      working-directory: _build64
+      run: nmake /S
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: win32
+    - uses: ilammy/setup-nasm@v1
+      with:
+        platform: win32
+    - name: config x32
+      working-directory: _build32
+      run: |
+        perl ..\Configure --banner=Configured no-makedepend enable-fips VC-WIN32
+        perl configdata.pm --dump
+    - name: build x32 binaries
+      working-directory: _build32
+      run: nmake /S
+    - name: build installer
+      working-directory: windows-installer
+      run: makensis.exe /DVERSION=${{ github.event.inputs.tag }} /DBUILD32=_build32 /DBUILD64=_build64 .\openssl.nsi
+    - name: Upload installer as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: openssl-installer
+        path: windows-installer/openssl*.exe
+
+
+

--- a/windows-installer/Makefile
+++ b/windows-installer/Makefile
@@ -1,0 +1,12 @@
+
+openssl-installer: openssl.nsi
+	makensis.exe /DVERSION=testversion /DBUILD32=_build32 /DBUILD64=_build64 .\openssl.nsi
+
+signed-openssl-installer: openssl.nsi
+	makecert.exe /n "CN=TestCompany" /r /h 0 /eku "1.3.6.1.5.5.7.3.3,1.3.6.1.4.1.311.10.3.13" /sv testcert.pvk testcert.cer
+	pvk2pfx.exe /pvk testcert.pvk /pi testpass /spc testcert.cer /pfx testcert.pfx /po testpass
+	makensis.exe /DVERSION=testversion /DBUILD32=_build32 /DBUILD64=_build64 /DSIGN=testcert.pfx /DSIGNPASS=testpass .\openssl.nsi
+
+clean:
+	del .\*.exe .\test*.*
+

--- a/windows-installer/README.md
+++ b/windows-installer/README.md
@@ -1,0 +1,54 @@
+# Windows installer script
+
+## Overview
+
+The windows installer script found in this directory is capable of building a
+windows installer executable capable of installing both 32 and 64 bit openssl
+binaries, along with their corresponding development headers
+
+## Requirements
+
+* [NSIS](https://nsis.sourceforge.io/Main_Page) version 3.0.8 or later
+* Windows 2022 or later
+* The Windows SDK
+  - The makecert.exe utility (to demonstrate installer signing)
+  - The Pvk2Pfx.exe utility (to demonstrate installer signing)
+  - The SignTool.exe utility (to demonstrate installer signing)
+
+## Notes on Signing
+
+Installer signing is demonstrated here using self signed certificates. Do not
+use this signed code in a deployment as the generated certificate should not be
+trusted.  However, if you wish to observe this signed installer in operation,
+the generated certificate may be imported to the local trust store following the
+instructions
+[here](https://learn.microsoft.com/en-us/windows/win32/appxpkg/how-to-create-a-package-signing-certificate).
+at your own risk.
+
+## Installer Build Prerequisites
+
+1) Build Openssl from the parent of this directory:
+    a) cd /path/to/openssl/source/root
+    b) mkdir \_build64
+    c) cd \_build64
+    d) perl ..\Configure [options] VC-WIN64A
+    e) nmake
+    f) repeat steps a-e substituting \_build32 for \_build64 to build VC-WIN32
+
+## Building the installer
+
+From the windows-installer directory, the included makefile can build 2 targets
+1) openssl-installer
+2) signed-openssl-installer
+
+If option 1 is selected, the openssl-testversion-installer.exe file will be
+generated, pulling needed binaries from the ../\_build32 and ../\_build64
+directories.
+
+If option 2 is selected, A self signed certificate will be generated and used to
+create the same installer, and digitally sign it.  Note that the Signtool
+utility requires a password for the generated private key be passed on the
+command line, while the MakeCert utility requires that it be entered via a gui
+popup window.  As such the Makefile is hard coded to use the password
+'testpass', which must be entered when prompted during certificate generation, or
+the signing process will fail.

--- a/windows-installer/README.md
+++ b/windows-installer/README.md
@@ -1,12 +1,15 @@
-# Windows installer script
+Windows installer script
+========================
 
-## Overview
+Overview
+--------
 
 The windows installer script found in this directory is capable of building a
 windows installer executable capable of installing both 32 and 64 bit openssl
 binaries, along with their corresponding development headers
 
-## Requirements
+Requirements
+------------
 
 * [NSIS](https://nsis.sourceforge.io/Main_Page) version 3.0.8 or later
 * Windows 2022 or later
@@ -15,7 +18,8 @@ binaries, along with their corresponding development headers
   - The Pvk2Pfx.exe utility (to demonstrate installer signing)
   - The SignTool.exe utility (to demonstrate installer signing)
 
-## Notes on Signing
+Notes on Signing
+----------------
 
 Installer signing is demonstrated here using self signed certificates. Do not
 use this signed code in a deployment as the generated certificate should not be
@@ -25,7 +29,8 @@ instructions
 [here](https://learn.microsoft.com/en-us/windows/win32/appxpkg/how-to-create-a-package-signing-certificate).
 at your own risk.
 
-## Installer Build Prerequisites
+Installer Build Prerequisites
+-----------------------------
 
 1) Build Openssl from the parent of this directory:
     a) cd /path/to/openssl/source/root
@@ -35,7 +40,8 @@ at your own risk.
     e) nmake
     f) repeat steps a-e substituting \_build32 for \_build64 to build VC-WIN32
 
-## Building the installer
+Building the installer
+----------------------
 
 From the windows-installer directory, the included makefile can build 2 targets
 1) openssl-installer

--- a/windows-installer/openssl.nsi
+++ b/windows-installer/openssl.nsi
@@ -1,0 +1,141 @@
+
+######################################################
+# NSIS windows installer script file
+# Requirements: NSIS 3.0 must be installed with the MUI plugin
+# Usage notes:
+# This script expects to be executed from the directory it is
+# currently stored in.  It expects a 32 bit and 64 bit windows openssl
+# build to be present in the ..\${BUILD32} and ..\${BUILD64} directories
+# respectively
+# ####################################################
+
+!include "MUI.nsh"
+
+!define PRODUCT_NAME "OpenSSL"
+
+# The name of the output file we create when building this
+# NOTE version is passed with the /D option on the command line
+OutFile "openssl-${VERSION}-installer.exe"
+
+# The name that will appear in the installer title bar
+NAME "${PRODUCT_NAME} ${VERSION}"
+
+ShowInstDetails show
+
+Function .onInit
+	StrCpy $INSTDIR "C:\Program Files\openssl-${VERSION}"
+FunctionEnd
+
+# This section is run if installation of 32 bit binaries are selected
+!ifdef BUILD32
+Section "32 Bit Binaries"
+	SetOutPath $INSTDIR\x32
+	File ..\${BUILD32}\libcrypto-3.dll
+	File ..\${BUILD32}\libssl-3.dll
+	File ..\${BUILD32}\apps\openssl.exe
+	SetOutPath $INSTDIR\x32\providers
+	File ..\${BUILD32}\providers\fips.dll
+	File ..\${BUILD32}\providers\legacy.dll
+SectionEnd
+!endif
+
+!ifdef BUILD64
+# This section is run if installation of the 64 bit binaries are selectd
+Section "64 Bit Binaries"
+	SetOutPath $INSTDIR\x64
+	File ..\${BUILD64}\libcrypto-3-x64.dll
+	File ..\${BUILD64}\libssl-3-x64.dll
+	File ..\${BUILD64}\apps\\openssl.exe
+	SetOutPath $INSTDIR\x64\providers
+	File ..\${BUILD64}\providers\fips.dll
+	File ..\${BUILD64}\providers\legacy.dll
+SectionEnd
+!endif
+
+# Optionally install x64 development headers
+!ifdef BUILD64
+Section "x64 Development Headers"
+	SetOutPath $INSTDIR\x64\include\openssl
+	!tempfile headerlist
+	!system 'FOR /R "..\${BUILD64}\include\openssl" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
+	!include "${headerlist}"
+	!delfile "${headerlist}"
+	!undef headerlist
+
+	SetOutPath $INSTDIR\x64\include\crypto
+	!tempfile headerlist
+	!system 'FOR /R "..\${BUILD64}\include\crypto" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
+	!include "${headerlist}"
+	!delfile "${headerlist}"
+	!undef headerlist
+
+	SetOutPath $INSTDIR\x64\include\internal
+	!tempfile headerlist
+	!system 'FOR /R "..\${BUILD64}\include\internal" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
+	!include "${headerlist}"
+	!delfile "${headerlist}"
+	!undef headerlist
+SectionEnd
+!endif
+
+# Optionally install x64 development headers
+!ifdef BUILD32
+Section "x32 Development Headers"
+	SetOutPath $INSTDIR\x32\include\openssl
+	!tempfile headerlist
+	!system 'FOR /R "..\${BUILD32}\include\openssl" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
+	!include "${headerlist}"
+	!delfile "${headerlist}"
+	!undef headerlist
+
+	SetOutPath $INSTDIR\x32\include\crypto
+	!tempfile headerlist
+	!system 'FOR /R "..\${BUILD32}\include\crypto" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
+	!include "${headerlist}"
+	!delfile "${headerlist}"
+	!undef headerlist
+
+	SetOutPath $INSTDIR\x32\include\internal
+	!tempfile headerlist
+	!system 'FOR /R "..\${BUILD32}\include\internal" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
+	!include "${headerlist}"
+	!delfile "${headerlist}"
+	!undef headerlist
+SectionEnd
+!endif
+
+# Always install the uninstaller
+Section 
+	WriteUninstaller $INSTDIR\uninstall.exe
+SectionEnd
+
+# This is run on uninstall
+Section "Uninstall"
+	RMDIR /r $INSTDIR
+SectionEnd
+
+!insertmacro MUI_PAGE_WELCOME
+
+!insertmacro MUI_PAGE_LICENSE ../LICENSE.TXT
+
+!insertmacro MUI_PAGE_COMPONENTS
+
+!define MUI_DIRECTORYPAGE_TEXT_DESTINATION "Installation Directory"
+!insertmacro MUI_PAGE_DIRECTORY
+
+!insertmacro MUI_PAGE_INSTFILES
+
+!insertmacro MUI_UNPAGE_WELCOME
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+!insertmacro MUI_UNPAGE_FINISH
+
+!insertmacro MUI_LANGUAGE "English"
+
+!ifdef SIGN
+!define OutFileSignSHA1 "SignTool.exe sign /f ${SIGN} /p ${SIGNPASS} /fd sha1 /t http://timestamp.comodoca.com /v"
+!define OutFileSignSHA256 "SignTool.exe sign /f ${SIGN} /p ${SIGNPASS} /fd sha256 /tr http://timestamp.comodoca.com?td=sha256 /td sha256 /v"
+
+!finalize "${OutFileSignSHA1} .\openssl-${VERSION}-installer.exe"
+!finalize "${OutFileSignSHA256} .\openssl-${VERSION}-installer.exe"
+!endif

--- a/windows-installer/openssl.nsi
+++ b/windows-installer/openssl.nsi
@@ -28,80 +28,80 @@ FunctionEnd
 
 # This section is run if installation of 32 bit binaries are selected
 !ifdef BUILD32
-Section "32 Bit Binaries"
-	SetOutPath $INSTDIR\x32
-	File ..\${BUILD32}\libcrypto-3.dll
-	File ..\${BUILD32}\libssl-3.dll
-	File ..\${BUILD32}\apps\openssl.exe
-	SetOutPath $INSTDIR\x32\providers
-	File ..\${BUILD32}\providers\fips.dll
-	File ..\${BUILD32}\providers\legacy.dll
-SectionEnd
+SectionGroup "32 Bit Installation"
+	Section "32 Bit Binaries"
+		SetOutPath $INSTDIR\x32
+		File /NONFATAL ..\${BUILD32}\libcrypto-3.dll
+		File /NONFATAL ..\${BUILD32}\libssl-3.dll
+		File ..\${BUILD32}\libcrypto.lib
+		File ..\${BUILD32}\libssl.lib
+		File ..\${BUILD32}\apps\openssl.exe
+		SetOutPath $INSTDIR\x32\providers
+		File /NONFATAL ..\${BUILD32}\providers\fips.dll
+		File ..\${BUILD32}\providers\legacy.dll
+	SectionEnd
+	Section "x32 Development Headers"
+		SetOutPath $INSTDIR\x32\include\openssl
+		!tempfile headerlist
+		!system 'FOR /R "..\${BUILD32}\include\openssl" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
+		!include "${headerlist}"
+		!delfile "${headerlist}"
+		!undef headerlist
+
+		SetOutPath $INSTDIR\x32\include\crypto
+		!tempfile headerlist
+		!system 'FOR /R "..\${BUILD32}\include\crypto" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
+		!include "${headerlist}"
+		!delfile "${headerlist}"
+		!undef headerlist
+
+		SetOutPath $INSTDIR\x32\include\internal
+		!tempfile headerlist
+		!system 'FOR /R "..\${BUILD32}\include\internal" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
+		!include "${headerlist}"
+		!delfile "${headerlist}"
+		!undef headerlist
+	SectionEnd
+SectionGroupEnd
 !endif
 
 !ifdef BUILD64
 # This section is run if installation of the 64 bit binaries are selectd
-Section "64 Bit Binaries"
-	SetOutPath $INSTDIR\x64
-	File ..\${BUILD64}\libcrypto-3-x64.dll
-	File ..\${BUILD64}\libssl-3-x64.dll
-	File ..\${BUILD64}\apps\\openssl.exe
-	SetOutPath $INSTDIR\x64\providers
-	File ..\${BUILD64}\providers\fips.dll
-	File ..\${BUILD64}\providers\legacy.dll
-SectionEnd
-!endif
+SectionGroup "64 Bit Installation"
+	Section "64 Bit Binaries"
+		SetOutPath $INSTDIR\x64
+		File /NONFATAL ..\${BUILD64}\libcrypto-3-x64.dll
+		File /NONFATAL ..\${BUILD64}\libssl-3-x64.dll
+		File ..\${BUILD64}\libcrypto.lib
+		File ..\${BUILD64}\libssl.lib
+		File ..\${BUILD64}\apps\\openssl.exe
+		SetOutPath $INSTDIR\x64\providers
+		File /NONFATAL ..\${BUILD64}\providers\fips.dll
+		File ..\${BUILD64}\providers\legacy.dll
+	SectionEnd
+	Section "x64 Development Headers"
+		SetOutPath $INSTDIR\x64\include\openssl
+		!tempfile headerlist
+		!system 'FOR /R "..\${BUILD64}\include\openssl" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
+		!include "${headerlist}"
+		!delfile "${headerlist}"
+		!undef headerlist
 
-# Optionally install x64 development headers
-!ifdef BUILD64
-Section "x64 Development Headers"
-	SetOutPath $INSTDIR\x64\include\openssl
-	!tempfile headerlist
-	!system 'FOR /R "..\${BUILD64}\include\openssl" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
-	!include "${headerlist}"
-	!delfile "${headerlist}"
-	!undef headerlist
+		SetOutPath $INSTDIR\x64\include\crypto
+		!tempfile headerlist
+		!system 'FOR /R "..\${BUILD64}\include\crypto" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
+		!include "${headerlist}"
+		!delfile "${headerlist}"
+		!undef headerlist
 
-	SetOutPath $INSTDIR\x64\include\crypto
-	!tempfile headerlist
-	!system 'FOR /R "..\${BUILD64}\include\crypto" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
-	!include "${headerlist}"
-	!delfile "${headerlist}"
-	!undef headerlist
-
-	SetOutPath $INSTDIR\x64\include\internal
-	!tempfile headerlist
-	!system 'FOR /R "..\${BUILD64}\include\internal" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
-	!include "${headerlist}"
-	!delfile "${headerlist}"
-	!undef headerlist
-SectionEnd
-!endif
-
-# Optionally install x64 development headers
-!ifdef BUILD32
-Section "x32 Development Headers"
-	SetOutPath $INSTDIR\x32\include\openssl
-	!tempfile headerlist
-	!system 'FOR /R "..\${BUILD32}\include\openssl" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
-	!include "${headerlist}"
-	!delfile "${headerlist}"
-	!undef headerlist
-
-	SetOutPath $INSTDIR\x32\include\crypto
-	!tempfile headerlist
-	!system 'FOR /R "..\${BUILD32}\include\crypto" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
-	!include "${headerlist}"
-	!delfile "${headerlist}"
-	!undef headerlist
-
-	SetOutPath $INSTDIR\x32\include\internal
-	!tempfile headerlist
-	!system 'FOR /R "..\${BUILD32}\include\internal" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
-	!include "${headerlist}"
-	!delfile "${headerlist}"
-	!undef headerlist
-SectionEnd
+		SetOutPath $INSTDIR\x64\include\internal
+		!tempfile headerlist
+		!system 'FOR /R "..\${BUILD64}\include\internal" %A IN (*.h) DO @( >> "${headerlist}" echo.File "%~A" )'
+		!include "${headerlist}"
+		!delfile "${headerlist}"
+		!undef headerlist
+	SectionEnd
+SectionGroupEnd
 !endif
 
 # Always install the uninstaller


### PR DESCRIPTION
As part of https://github.com/openssl/project/issues/20 I've created this draft PR to propose a windows installer framework.  The installer currently:

* Allows for the installation of 32 bit  and 64 bit x86 binaries and supporting libraries, including the fips and legacy proiders (selectable at installer-run-time)
* Allows for the installation of development headers (selectable at installer-run-time)
* Creates an uninstaller
* Allows for the side-by-side installation of multiple openssl versions (target install directory selectable at installer-run-time, defaulting to c:\Program Files\openssl-<version>)
* Demonstrates installer signing using Microsofts code signing utilities with a generated self-signed certificate
* Includes a manually triggered github workflow to build the installer on demand, and could be enhanced to do a nightly build
* Includes a nmake makefile to demonstrate local building

This PR expressly omits any offical building of the installer, as we need to determine how we would want to manage code signing certificates, as well as how we want to incorporate the building and releasing of the installer as part of our release process, but I think the installer itself is in pretty good shape.   My proposal would be to incorporate this PR in 3.4 and target 3.5 for integrating a signed installer release into the 3.5 development cycle

##### Checklist
- [x] tests are added or updated
