### PR TITLE
gitignore: ignore newly generated header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@
 /include/openssl/ui.h
 /include/openssl/x509.h
 /include/openssl/x509v3.h
+/include/openssl/x509_acert.h
 /include/openssl/x509_vfy.h
 /include/openssl/core_names.h
 /include/internal/param_names.h


### PR DESCRIPTION
Ignore generated include/openssl/x509_acert.h introduced in https://github.com/openssl/openssl/pull/15857