### PR TITLE
ec: FIPS zero-ization for all

### DIFF
--- a/crypto/ec/ec2_smpl.c
+++ b/crypto/ec/ec2_smpl.c
@@ -917,7 +917,7 @@ int ec_GF2m_simple_points_mul(const EC_GROUP *group, EC_POINT *r,
     ret = 1;
 
  err:
-    EC_POINT_free(t);
+    EC_POINT_clear_free(t);
     return ret;
 }
 

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -836,7 +836,7 @@ EC_GROUP *EC_GROUP_new_from_ecparameters(const ECPARAMETERS *params)
     BN_free(p);
     BN_free(a);
     BN_free(b);
-    EC_POINT_free(point);
+    EC_POINT_clear_free(point);
 
     BN_CTX_free(ctx);
 

--- a/crypto/ec/ec_backend.c
+++ b/crypto/ec/ec_backend.c
@@ -493,7 +493,7 @@ int ossl_ec_key_fromdata(EC_KEY *ec, const OSSL_PARAM params[], int include_priv
     BN_CTX_free(ctx);
     BN_clear_free(priv_key);
     OPENSSL_free(pub_key);
-    EC_POINT_free(pub_point);
+    EC_POINT_clear_free(pub_point);
     return ok;
 }
 

--- a/crypto/ec/ec_check.c
+++ b/crypto/ec/ec_check.c
@@ -112,7 +112,7 @@ int EC_GROUP_check(const EC_GROUP *group, BN_CTX *ctx)
 
  err:
     BN_CTX_free(new_ctx);
-    EC_POINT_free(point);
+    EC_POINT_clear_free(point);
     return ret;
 #endif /* FIPS_MODULE */
 }

--- a/crypto/ec/ec_curve.c
+++ b/crypto/ec/ec_curve.c
@@ -3275,7 +3275,7 @@ static EC_GROUP *ec_group_new_from_data(OSSL_LIB_CTX *libctx,
         EC_GROUP_free(group);
         group = NULL;
     }
-    EC_POINT_free(P);
+    EC_POINT_clear_free(P);
     BN_CTX_free(ctx);
     BN_free(p);
     BN_free(a);

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -96,7 +96,7 @@ void EC_KEY_free(EC_KEY *r)
 #endif
     CRYPTO_FREE_REF(&r->references);
     EC_GROUP_free(r->group);
-    EC_POINT_free(r->pub_key);
+    EC_POINT_clear_free(r->pub_key);
     BN_clear_free(r->priv_key);
     OPENSSL_free(r->propq);
 
@@ -134,7 +134,7 @@ EC_KEY *EC_KEY_copy(EC_KEY *dest, const EC_KEY *src)
 
         /*  copy the public key */
         if (src->pub_key != NULL) {
-            EC_POINT_free(dest->pub_key);
+            EC_POINT_clear_free(dest->pub_key);
             dest->pub_key = EC_POINT_new(src->group);
             if (dest->pub_key == NULL)
                 return NULL;
@@ -283,7 +283,7 @@ static int ecdsa_keygen_knownanswer_test(EC_KEY *eckey, BN_CTX *ctx,
 err:
     OSSL_SELF_TEST_onend(st, ret);
     OSSL_SELF_TEST_free(st);
-    EC_POINT_free(pub_key2);
+    EC_POINT_clear_free(pub_key2);
     return ret;
 }
 
@@ -395,7 +395,7 @@ err:
             EC_POINT_set_to_infinity(group, eckey->pub_key);
     }
 
-    EC_POINT_free(pub_key);
+    EC_POINT_clear_free(pub_key);
     BN_clear_free(priv_key);
     BN_CTX_free(ctx);
     BN_free(order);
@@ -587,7 +587,7 @@ int ossl_ec_key_public_check(const EC_KEY *eckey, BN_CTX *ctx)
     }
     ret = 1;
 err:
-    EC_POINT_free(point);
+    EC_POINT_clear_free(point);
     return ret;
 }
 
@@ -643,7 +643,7 @@ int ossl_ec_key_pairwise_check(const EC_KEY *eckey, BN_CTX *ctx)
     }
     ret = 1;
 err:
-    EC_POINT_free(point);
+    EC_POINT_clear_free(point);
     return ret;
 }
 
@@ -737,7 +737,7 @@ int EC_KEY_set_public_key_affine_coordinates(EC_KEY *key, BIGNUM *x,
  err:
     BN_CTX_end(ctx);
     BN_CTX_free(ctx);
-    EC_POINT_free(point);
+    EC_POINT_clear_free(point);
     return ok;
 
 }
@@ -886,7 +886,7 @@ int EC_KEY_set_public_key(EC_KEY *key, const EC_POINT *pub_key)
     if (key->meth->set_public != NULL
         && key->meth->set_public(key, pub_key) == 0)
         return 0;
-    EC_POINT_free(key->pub_key);
+    EC_POINT_clear_free(key->pub_key);
     key->pub_key = EC_POINT_dup(pub_key, key->group);
     key->dirty_cnt++;
     return (key->pub_key == NULL) ? 0 : 1;

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -129,7 +129,7 @@ void EC_GROUP_free(EC_GROUP *group)
 
     EC_pre_comp_free(group);
     BN_MONT_CTX_free(group->mont_data);
-    EC_POINT_free(group->generator);
+    EC_POINT_clear_free(group->generator);
     BN_free(group->order);
     BN_free(group->cofactor);
     OPENSSL_free(group->seed);
@@ -743,12 +743,7 @@ EC_POINT *EC_POINT_new(const EC_GROUP *group)
 
 void EC_POINT_free(EC_POINT *point)
 {
-    if (point == NULL)
-        return;
-
-    if (point->meth->point_finish != 0)
-        point->meth->point_finish(point);
-    OPENSSL_free(point);
+    EC_POINT_clear_free(point);
 }
 
 void EC_POINT_clear_free(EC_POINT *point)
@@ -794,7 +789,7 @@ EC_POINT *EC_POINT_dup(const EC_POINT *a, const EC_GROUP *group)
         return NULL;
     r = EC_POINT_copy(t, a);
     if (!r) {
-        EC_POINT_free(t);
+        EC_POINT_clear_free(t);
         return NULL;
     }
     return t;
@@ -1750,7 +1745,7 @@ EC_GROUP *EC_GROUP_new_from_params(const OSSL_PARAM params[],
         EC_GROUP_free(group);
         group = NULL;
     }
-    EC_POINT_free(point);
+    EC_POINT_clear_free(point);
     BN_CTX_end(bnctx);
     BN_CTX_free(bnctx);
 

--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -94,7 +94,7 @@ void EC_ec_pre_comp_free(EC_PRE_COMP *pre)
         EC_POINT **pts;
 
         for (pts = pre->points; *pts != NULL; pts++)
-            EC_POINT_free(*pts);
+            EC_POINT_clear_free(*pts);
         OPENSSL_free(pre->points);
     }
     CRYPTO_FREE_REF(&pre->references);
@@ -371,7 +371,7 @@ int ossl_ec_scalar_mul_ladder(const EC_GROUP *group, EC_POINT *r,
     ret = 1;
 
  err:
-    EC_POINT_free(p);
+    EC_POINT_clear_free(p);
     EC_POINT_clear_free(s);
     BN_CTX_end(ctx);
 
@@ -775,7 +775,7 @@ int ossl_ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
     ret = 1;
 
  err:
-    EC_POINT_free(tmp);
+    EC_POINT_clear_free(tmp);
     OPENSSL_free(wsize);
     OPENSSL_free(wNAF_len);
     if (wNAF != NULL) {
@@ -967,11 +967,11 @@ int ossl_ec_wNAF_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
         EC_POINT **p;
 
         for (p = points; *p != NULL; p++)
-            EC_POINT_free(*p);
+            EC_POINT_clear_free(*p);
         OPENSSL_free(points);
     }
-    EC_POINT_free(tmp_point);
-    EC_POINT_free(base);
+    EC_POINT_clear_free(tmp_point);
+    EC_POINT_clear_free(base);
     return ret;
 }
 

--- a/crypto/ec/ecdsa_ossl.c
+++ b/crypto/ec/ecdsa_ossl.c
@@ -247,7 +247,7 @@ static int ecdsa_sign_setup(EC_KEY *eckey, BN_CTX *ctx_in,
     }
     if (ctx != ctx_in)
         BN_CTX_free(ctx);
-    EC_POINT_free(tmp_point);
+    EC_POINT_clear_free(tmp_point);
     BN_clear_free(X);
     return ret;
 }
@@ -535,6 +535,6 @@ int ossl_ecdsa_simple_verify_sig(const unsigned char *dgst, int dgst_len,
  err:
     BN_CTX_end(ctx);
     BN_CTX_free(ctx);
-    EC_POINT_free(point);
+    EC_POINT_clear_free(point);
     return ret;
 }

--- a/crypto/ec/ecp_nistp224.c
+++ b/crypto/ec/ecp_nistp224.c
@@ -1591,7 +1591,7 @@ int ossl_ec_GFp_nistp224_points_mul(const EC_GROUP *group, EC_POINT *r,
 
  err:
     BN_CTX_end(ctx);
-    EC_POINT_free(generator);
+    EC_POINT_clear_free(generator);
     OPENSSL_free(secrets);
     OPENSSL_free(pre_comp);
     OPENSSL_free(tmp_felems);
@@ -1726,7 +1726,7 @@ int ossl_ec_GFp_nistp224_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
     ret = 1;
  err:
     BN_CTX_end(ctx);
-    EC_POINT_free(generator);
+    EC_POINT_clear_free(generator);
 #ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif

--- a/crypto/ec/ecp_nistp256.c
+++ b/crypto/ec/ecp_nistp256.c
@@ -2209,7 +2209,7 @@ int ossl_ec_GFp_nistp256_points_mul(const EC_GROUP *group, EC_POINT *r,
 
  err:
     BN_CTX_end(ctx);
-    EC_POINT_free(generator);
+    EC_POINT_clear_free(generator);
     OPENSSL_free(secrets);
     OPENSSL_free(pre_comp);
     OPENSSL_free(tmp_smallfelems);
@@ -2355,7 +2355,7 @@ int ossl_ec_GFp_nistp256_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
 
  err:
     BN_CTX_end(ctx);
-    EC_POINT_free(generator);
+    EC_POINT_clear_free(generator);
 #ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif

--- a/crypto/ec/ecp_nistp384.c
+++ b/crypto/ec/ecp_nistp384.c
@@ -1884,7 +1884,7 @@ int ossl_ec_GFp_nistp384_points_mul(const EC_GROUP *group, EC_POINT *r,
 
  err:
     BN_CTX_end(ctx);
-    EC_POINT_free(generator);
+    EC_POINT_clear_free(generator);
     OPENSSL_free(secrets);
     OPENSSL_free(pre_comp);
     OPENSSL_free(tmp_felems);
@@ -1983,7 +1983,7 @@ int ossl_ec_GFp_nistp384_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
     pre = NULL;
  err:
     BN_CTX_end(ctx);
-    EC_POINT_free(generator);
+    EC_POINT_clear_free(generator);
 #ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif

--- a/crypto/ec/ecp_nistp521.c
+++ b/crypto/ec/ecp_nistp521.c
@@ -2098,7 +2098,7 @@ int ossl_ec_GFp_nistp521_points_mul(const EC_GROUP *group, EC_POINT *r,
 
  err:
     BN_CTX_end(ctx);
-    EC_POINT_free(generator);
+    EC_POINT_clear_free(generator);
     OPENSSL_free(secrets);
     OPENSSL_free(pre_comp);
     OPENSSL_free(tmp_felems);
@@ -2213,7 +2213,7 @@ int ossl_ec_GFp_nistp521_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
     pre = NULL;
  err:
     BN_CTX_end(ctx);
-    EC_POINT_free(generator);
+    EC_POINT_clear_free(generator);
 #ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif

--- a/crypto/ec/ecp_nistz256.c
+++ b/crypto/ec/ecp_nistz256.c
@@ -916,8 +916,8 @@ __owur static int ecp_nistz256_mult_precompute(EC_GROUP *group, BN_CTX *ctx)
 
     EC_nistz256_pre_comp_free(pre_comp);
     OPENSSL_free(precomp_storage);
-    EC_POINT_free(P);
-    EC_POINT_free(T);
+    EC_POINT_clear_free(P);
+    EC_POINT_clear_free(T);
     return ret;
 }
 
@@ -990,14 +990,14 @@ __owur static int ecp_nistz256_points_mul(const EC_GROUP *group,
             ecp_nistz256_gather_w7(&p.a, pre_comp->precomp[0], 1);
             if (!ecp_nistz256_set_from_affine(pre_comp_generator,
                                               group, &p.a, ctx)) {
-                EC_POINT_free(pre_comp_generator);
+                EC_POINT_clear_free(pre_comp_generator);
                 goto err;
             }
 
             if (0 == EC_POINT_cmp(group, generator, pre_comp_generator, ctx))
                 preComputedTable = (const PRECOMP256_ROW *)pre_comp->precomp;
 
-            EC_POINT_free(pre_comp_generator);
+            EC_POINT_clear_free(pre_comp_generator);
         }
 
         if (preComputedTable == NULL && ecp_nistz256_is_affine_G(generator)) {

--- a/crypto/sm2/sm2_crypt.c
+++ b/crypto/sm2/sm2_crypt.c
@@ -249,8 +249,8 @@ int ossl_sm2_encrypt(const EC_KEY *key,
     OPENSSL_free(C3);
     EVP_MD_CTX_free(hash);
     BN_CTX_free(ctx);
-    EC_POINT_free(kG);
-    EC_POINT_free(kP);
+    EC_POINT_clear_free(kG);
+    EC_POINT_clear_free(kP);
     return rc;
 }
 
@@ -382,7 +382,7 @@ int ossl_sm2_decrypt(const EC_KEY *key,
     OPENSSL_free(msg_mask);
     OPENSSL_free(x2y2);
     OPENSSL_free(computed_C3);
-    EC_POINT_free(C1);
+    EC_POINT_clear_free(C1);
     BN_CTX_free(ctx);
     SM2_Ciphertext_free(sm2_ctext);
     EVP_MD_CTX_free(hash);

--- a/crypto/sm2/sm2_sign.c
+++ b/crypto/sm2/sm2_sign.c
@@ -319,7 +319,7 @@ static ECDSA_SIG *sm2_sig_gen(const EC_KEY *key, const BIGNUM *e)
     }
 
     BN_CTX_free(ctx);
-    EC_POINT_free(kG);
+    EC_POINT_clear_free(kG);
     return sig;
 }
 
@@ -398,7 +398,7 @@ static int sm2_sig_verify(const EC_KEY *key, const ECDSA_SIG *sig,
 
  done:
     BN_CTX_end(ctx);
-    EC_POINT_free(pt);
+    EC_POINT_clear_free(pt);
     BN_CTX_free(ctx);
     return ret;
 }

--- a/doc/man3/EC_POINT_new.pod
+++ b/doc/man3/EC_POINT_new.pod
@@ -105,11 +105,10 @@ An B<EC_POINT> structure represents a point on a curve. A new point is
 constructed by calling the function EC_POINT_new() and providing the
 B<group> object that the point relates to.
 
-EC_POINT_free() frees the memory associated with the B<EC_POINT>.
-if B<point> is NULL nothing is done.
-
-EC_POINT_clear_free() destroys any sensitive data held within the EC_POINT and
-then frees its memory. If B<point> is NULL nothing is done.
+EC_POINT_free() and EC_POINT_clear_free() destroys any sensitive data
+held within the EC_POINT and then frees its memory. If B<point> is
+NULL nothing is done. Prior to v3.4 EC_POINT_free() did not destroy
+sensitive data held within the EC_POINT.
 
 EC_POINT_copy() copies the point B<src> into B<dst>. Both B<src> and B<dst>
 must use the same B<EC_METHOD>.

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -562,8 +562,8 @@ int EC_GROUP_check_named_curve(const EC_GROUP *group, int nist_only,
  */
 EC_POINT *EC_POINT_new(const EC_GROUP *group);
 
-/** Frees a EC_POINT object
- *  \param  point  EC_POINT object to be freed
+/** Clears and frees a EC_POINT object
+ *  \param  point  EC_POINT object to be cleared and freed
  */
 void EC_POINT_free(EC_POINT *point);
 

--- a/test/ec_internal_test.c
+++ b/test/ec_internal_test.c
@@ -249,9 +249,9 @@ static int underflow_test(void)
 
  err:
     BN_CTX_end(ctx);
-    EC_POINT_free(P);
-    EC_POINT_free(Q);
-    EC_POINT_free(R);
+    EC_POINT_clear_free(P);
+    EC_POINT_clear_free(Q);
+    EC_POINT_clear_free(R);
     EC_GROUP_free(grp);
     BN_CTX_free(ctx);
 

--- a/test/ecstresstest.c
+++ b/test/ecstresstest.c
@@ -95,7 +95,7 @@ static int test_curve(void)
 
 err:
     EC_GROUP_free(group);
-    EC_POINT_free(point);
+    EC_POINT_clear_free(point);
     BN_free(result);
     BN_free(expected_result);
     return ret;

--- a/test/ectest.c
+++ b/test/ectest.c
@@ -145,10 +145,10 @@ err:
     if (r == 0 && i != 0)
         TEST_info(i == 1 ? "allowing precomputation" :
                            "without precomputation");
-    EC_POINT_free(P);
-    EC_POINT_free(Q);
-    EC_POINT_free(R);
-    EC_POINT_free(S);
+    EC_POINT_clear_free(P);
+    EC_POINT_clear_free(Q);
+    EC_POINT_clear_free(R);
+    EC_POINT_clear_free(S);
     BN_free(n1);
     BN_free(n2);
     BN_free(order);
@@ -593,9 +593,9 @@ err:
     BN_free(a);
     BN_free(b);
     EC_GROUP_free(group);
-    EC_POINT_free(P);
-    EC_POINT_free(Q);
-    EC_POINT_free(R);
+    EC_POINT_clear_free(P);
+    EC_POINT_clear_free(Q);
+    EC_POINT_clear_free(R);
     BN_free(x);
     BN_free(y);
     BN_free(z);
@@ -924,9 +924,9 @@ err:
     BN_free(z);
     BN_free(yplusone);
     BN_free(cof);
-    EC_POINT_free(P);
-    EC_POINT_free(Q);
-    EC_POINT_free(R);
+    EC_POINT_clear_free(P);
+    EC_POINT_clear_free(Q);
+    EC_POINT_clear_free(R);
     EC_GROUP_free(group);
     return r;
 }
@@ -1073,9 +1073,9 @@ err:
     BN_free(a);
     BN_free(b);
     EC_GROUP_free(group);
-    EC_POINT_free(P);
-    EC_POINT_free(Q);
-    EC_POINT_free(R);
+    EC_POINT_clear_free(P);
+    EC_POINT_clear_free(Q);
+    EC_POINT_clear_free(R);
     BN_free(x);
     BN_free(y);
     BN_free(z);
@@ -1128,7 +1128,7 @@ err:
     BN_free(x);
     BN_free(y);
     EC_GROUP_free(group);
-    EC_POINT_free(point);
+    EC_POINT_clear_free(point);
     OPENSSL_free(buf);
     return r;
 }
@@ -1428,10 +1428,10 @@ static int nistp_single_test(int idx)
     r = 1;
 err:
     EC_GROUP_free(NISTP);
-    EC_POINT_free(G);
-    EC_POINT_free(P);
-    EC_POINT_free(Q);
-    EC_POINT_free(Q_CHECK);
+    EC_POINT_clear_free(G);
+    EC_POINT_clear_free(P);
+    EC_POINT_clear_free(Q);
+    EC_POINT_clear_free(Q_CHECK);
     BN_free(n);
     BN_free(m);
     BN_free(p);
@@ -1677,7 +1677,7 @@ err:
     BN_free(group_cofactor);
     BN_free(other_cofactor);
     BN_free(other_order);
-    EC_POINT_free(other_gen);
+    EC_POINT_clear_free(other_gen);
     EC_GROUP_free(gtest);
     EC_GROUP_free(group);
     BN_CTX_free(bn_ctx);
@@ -1868,7 +1868,7 @@ static int check_named_curve_from_ecparameters(int id)
         || !TEST_true(BN_add_word(other_cofactor, 1)))
         goto err;
 
-    EC_POINT_free(other_gen);
+    EC_POINT_clear_free(other_gen);
     other_gen = NULL;
 
     if (!TEST_ptr(other_gen = EC_POINT_new(tmpg))
@@ -2002,7 +2002,7 @@ err:
     for (p_next = &p_ary[0]; p_next < p_ary + OSSL_NELEM(g_ary); p_next++)
         ECPARAMETERS_free(*p_next);
     ECPARAMETERS_free(params);
-    EC_POINT_free(other_gen);
+    EC_POINT_clear_free(other_gen);
     EC_GROUP_free(tmpg);
     EC_GROUP_free(group);
     BN_CTX_end(bn_ctx);
@@ -2337,7 +2337,7 @@ static int cardinality_test(int n)
         goto err;
     ret = 1;
  err:
-    EC_POINT_free(g2_gen);
+    EC_POINT_clear_free(g2_gen);
     EC_GROUP_free(g1);
     EC_GROUP_free(g2);
     BN_CTX_end(ctx);
@@ -2441,9 +2441,9 @@ int ec_point_hex2point_test_helper(const EC_GROUP *group, const EC_POINT *P,
     ret = 1;
 
  err:
-    EC_POINT_free(Pinf);
+    EC_POINT_clear_free(Pinf);
     OPENSSL_free(hex);
-    EC_POINT_free(Q);
+    EC_POINT_clear_free(Q);
 
     return ret;
 }
@@ -2490,7 +2490,7 @@ static int ec_point_hex2point_test(int id)
     ret = 1;
 
  err:
-    EC_POINT_free(P);
+    EC_POINT_clear_free(P);
     EC_GROUP_free(group);
     BN_CTX_free(bnctx);
 
@@ -2789,9 +2789,9 @@ static int custom_generator_test(int id)
     ret = 1;
 
  err:
-    EC_POINT_free(Q1);
-    EC_POINT_free(Q2);
-    EC_POINT_free(G2);
+    EC_POINT_clear_free(Q1);
+    EC_POINT_clear_free(Q2);
+    EC_POINT_clear_free(G2);
     EC_GROUP_free(group);
     BN_CTX_end(ctx);
     BN_CTX_free(ctx);
@@ -2890,7 +2890,7 @@ static int custom_params_test(int id)
 #endif
 
     /* set 2*G as the generator of altgroup */
-    EC_POINT_free(G2); /* discard G2 as it refers to the original group */
+    EC_POINT_clear_free(G2); /* discard G2 as it refers to the original group */
     if (!TEST_ptr(G2 = EC_POINT_new(altgroup))
             || !TEST_true(EC_POINT_oct2point(altgroup, G2, buf1, bsize, ctx))
             || !TEST_int_eq(EC_POINT_is_on_curve(altgroup, G2, ctx), 1)
@@ -3059,9 +3059,9 @@ static int custom_params_test(int id)
     OSSL_PARAM_BLD_free(param_bld);
     OSSL_PARAM_free(params1);
     OSSL_PARAM_free(params2);
-    EC_POINT_free(Q1);
-    EC_POINT_free(Q2);
-    EC_POINT_free(G2);
+    EC_POINT_clear_free(Q1);
+    EC_POINT_clear_free(Q2);
+    EC_POINT_clear_free(G2);
     EC_GROUP_free(group);
     EC_GROUP_free(altgroup);
     OPENSSL_free(buf1);

--- a/test/sm2_internal_test.c
+++ b/test/sm2_internal_test.c
@@ -120,7 +120,7 @@ done:
     BN_free(b);
     BN_free(g_x);
     BN_free(g_y);
-    EC_POINT_free(generator);
+    EC_POINT_clear_free(generator);
     BN_free(order);
     BN_free(cof);
     if (!ok) {
@@ -198,7 +198,7 @@ static int test_sm2_crypt(const EC_GROUP *group,
     rc = 1;
  done:
     BN_free(priv);
-    EC_POINT_free(pt);
+    EC_POINT_clear_free(pt);
     OPENSSL_free(ctext);
     OPENSSL_free(recovered);
     OPENSSL_free(expected);
@@ -361,7 +361,7 @@ static int test_sm2_sign(const EC_GROUP *group,
 
  done:
     ECDSA_SIG_free(sig);
-    EC_POINT_free(pt);
+    EC_POINT_clear_free(pt);
     EC_KEY_free(key);
     BN_free(priv);
     BN_free(r);


### PR DESCRIPTION
FIPS requires key material zeroization within the cryptographic module. Many FIPS implementations redefine EC_POINT_free() as EC_POINT_clear_free(). But that means only FIPS module itself benefits from this, rather than stock library, public users and non-fips curves.

Also many functions currently leave behind freed'ed but not zeroed-out memory with temporary EC_POINTS from various operations. Whilst not security sensitive, it is privacy sensative to leak even the public points.

This is despite the small cost of re-zeroing out memory, in the error-path of first allocation only in a couple of places.

Ideally, EC_POINT_free() should remain supported - as it is nice code to write. But it should hopefully only become a library symbol alias for EC_POINT_clear_free() if at all possible. Such that any newly linked code only uses EC_POINT_clear_free().

Ensure OpenSSL codebase only uses EC_POINT_clear_free(), ensure EC_POINT_free is a wrapper around EC_POINT_clear_free() without declaring it deprecated.

Explicit is better than implicit.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
