### PR TITLE
(DTLS-1.3) Sanity checks of arguments to ssl_version_cmp()

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4294,8 +4294,8 @@ const SSL_CIPHER *ssl3_choose_cipher(SSL_CONNECTION *s, STACK_OF(SSL_CIPHER) *cl
         maxversion = SSL_CONNECTION_IS_DTLS(s) ? c->max_dtls : c->max_tls;
 
         /* Skip ciphers not supported by the protocol version */
-        if (ssl_version_cmp(s, s->version, minversion) < 0
-            || ssl_version_cmp(s, s->version, maxversion) > 0)
+        if ((minversion > 0 && ssl_version_cmp(s, s->version, minversion) < 0)
+                || (maxversion > 0 && ssl_version_cmp(s, s->version, maxversion) > 0))
             continue;
 
         /*

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -4123,8 +4123,8 @@ int ssl_cipher_list_to_bytes(SSL_CONNECTION *s, STACK_OF(SSL_CIPHER) *sk,
             int minproto = SSL_CONNECTION_IS_DTLS(s) ? c->min_dtls : c->min_tls;
             int maxproto = SSL_CONNECTION_IS_DTLS(s) ? c->max_dtls : c->max_tls;
 
-            if (ssl_version_cmp(s, maxproto, s->s3.tmp.max_ver) >= 0
-                    && ssl_version_cmp(s, minproto, s->s3.tmp.max_ver) <= 0)
+            if ((maxproto == 0 || ssl_version_cmp(s, maxproto, s->s3.tmp.max_ver) >= 0)
+                    && (minproto == 0 || ssl_version_cmp(s, minproto, s->s3.tmp.max_ver) <= 0))
                 maxverok = 1;
         }
 

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -2193,10 +2193,10 @@ int ssl_choose_server_version(SSL_CONNECTION *s, CLIENTHELLO_MSG *hello,
         return SSL_R_UNSUPPORTED_PROTOCOL;
 
     if (suppversions->present) {
-        unsigned int candidate_vers = 0;
-        const unsigned int best_vers_init = SSL_CONNECTION_IS_DTLS(s) ? UINT_MAX
-                                                                      : 0;
-        unsigned int best_vers = best_vers_init;
+        int candidate_vers = 0;
+        const int best_vers_init = SSL_CONNECTION_IS_DTLS(s) ? INT_MAX
+                                                             : 0;
+        int best_vers = best_vers_init;
         const SSL_METHOD *best_method = NULL;
         PACKET versionslist;
 
@@ -2219,9 +2219,9 @@ int ssl_choose_server_version(SSL_CONNECTION *s, CLIENTHELLO_MSG *hello,
         if (client_version <= SSL3_VERSION)
             return SSL_R_BAD_LEGACY_VERSION;
 
-        while (PACKET_get_net_2(&versionslist, &candidate_vers)) {
+        while (PACKET_get_net_2(&versionslist, (unsigned int*)&candidate_vers)) {
             if (candidate_vers <= 0
-                    || (best_vers != 0
+                    || (best_vers != best_vers_init
                         && ssl_version_cmp(s, candidate_vers, best_vers) <= 0))
                 continue;
             if (ssl_version_supported(s, candidate_vers, &best_method))

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -156,12 +156,13 @@ int tls_setup_handshake(SSL_CONNECTION *s)
 
     /* Sanity check that we have MD5-SHA1 if we need it */
     if (sctx->ssl_digest_methods[SSL_MD_MD5_SHA1_IDX] == NULL) {
-        int negotiated_minversion;
-        int md5sha1_needed_maxversion = SSL_CONNECTION_IS_DTLS(s)
-                                        ? DTLS1_VERSION : TLS1_1_VERSION;
+        const int version1_2 = SSL_CONNECTION_IS_DTLS(s) ? DTLS1_2_VERSION
+                                                         : TLS1_2_VERSION;
+        const int version1_1 = SSL_CONNECTION_IS_DTLS(s) ? DTLS1_VERSION
+                                                         : TLS1_1_VERSION;
 
         /* We don't have MD5-SHA1 - do we need it? */
-        if (ssl_version_cmp(s, ver_max, md5sha1_needed_maxversion) <= 0) {
+        if (ssl_version_cmp(s, ver_max, version1_1) <= 0) {
             SSLfatal_data(s, SSL_AD_HANDSHAKE_FAILURE,
                           SSL_R_NO_SUITABLE_DIGEST_ALGORITHM,
                           "The max supported SSL/TLS version needs the"
@@ -174,10 +175,8 @@ int tls_setup_handshake(SSL_CONNECTION *s)
         ok = 1;
 
         /* Don't allow TLSv1.1 or below to be negotiated */
-        negotiated_minversion = SSL_CONNECTION_IS_DTLS(s) ?
-                                DTLS1_2_VERSION : TLS1_2_VERSION;
-        if (ssl_version_cmp(s, ver_min, negotiated_minversion) < 0)
-                ok = SSL_set_min_proto_version(ssl, negotiated_minversion);
+        if (ssl_version_cmp(s, ver_min, version1_2) < 0)
+                ok = SSL_set_min_proto_version(ssl, version1_2);
         if (!ok) {
             /* Shouldn't happen */
             SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE, ERR_R_INTERNAL_ERROR);
@@ -202,8 +201,10 @@ int tls_setup_handshake(SSL_CONNECTION *s)
             int cipher_maxprotover = SSL_CONNECTION_IS_DTLS(s)
                                      ? c->max_dtls : c->max_tls;
 
-            if (ssl_version_cmp(s, ver_max, cipher_minprotover) >= 0
-                    && ssl_version_cmp(s, ver_max, cipher_maxprotover) <= 0) {
+            if ((cipher_minprotover == 0
+                 || ssl_version_cmp(s, ver_max, cipher_minprotover) >= 0)
+                && (cipher_maxprotover == 0
+                    || ssl_version_cmp(s, ver_max, cipher_maxprotover) <= 0)) {
                 ok = 1;
                 break;
             }
@@ -1791,6 +1792,9 @@ int ssl_version_cmp(const SSL_CONNECTION *s, int versiona, int versionb)
 {
     int dtls = SSL_CONNECTION_IS_DTLS(s);
 
+    if (!ossl_assert(versiona > 0) || !ossl_assert(versionb > 0))
+        return 0;
+
     if (versiona == versionb)
         return 0;
     if (!dtls)
@@ -2216,7 +2220,9 @@ int ssl_choose_server_version(SSL_CONNECTION *s, CLIENTHELLO_MSG *hello,
             return SSL_R_BAD_LEGACY_VERSION;
 
         while (PACKET_get_net_2(&versionslist, &candidate_vers)) {
-            if (ssl_version_cmp(s, candidate_vers, best_vers) <= 0)
+            if (candidate_vers <= 0
+                    || (best_vers != 0
+                        && ssl_version_cmp(s, candidate_vers, best_vers) <= 0))
                 continue;
             if (ssl_version_supported(s, candidate_vers, &best_method))
                 best_vers = candidate_vers;

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2504,7 +2504,8 @@ static int tls12_sigalg_allowed(const SSL_CONNECTION *s, int op,
 {
     unsigned char sigalgstr[2];
     int secbits;
-    int dsa_version_limit;
+    const int version1_3 = SSL_CONNECTION_IS_DTLS(s) ? DTLS1_3_VERSION
+                                                     : TLS1_3_VERSION;
 
     if (lu == NULL || !lu->enabled)
         return 0;
@@ -2515,8 +2516,8 @@ static int tls12_sigalg_allowed(const SSL_CONNECTION *s, int op,
      * At some point we should fully axe DSA/etc. in ClientHello as per (D)TLSv1.3
      * spec
      */
-    dsa_version_limit = SSL_CONNECTION_IS_DTLS(s) ? DTLS1_3_VERSION : TLS1_3_VERSION;
-    if (!s->server && ssl_version_cmp(s, s->s3.tmp.min_ver, dsa_version_limit) >= 0
+    if (!s->server && s->s3.tmp.min_ver > 0
+        && ssl_version_cmp(s, s->s3.tmp.min_ver, version1_3) >= 0
         && (lu->sig == EVP_PKEY_DSA || lu->hash_idx == SSL_MD_SHA1_IDX
             || lu->hash_idx == SSL_MD_MD5_IDX
             || lu->hash_idx == SSL_MD_SHA224_IDX))
@@ -2530,14 +2531,14 @@ static int tls12_sigalg_allowed(const SSL_CONNECTION *s, int op,
             || lu->sig == NID_id_GostR3410_2012_512
             || lu->sig == NID_id_GostR3410_2001) {
         int any_version = SSL_CONNECTION_IS_DTLS(s) ? DTLS_ANY_VERSION : TLS_ANY_VERSION;
-        int gost_version_limit = SSL_CONNECTION_IS_DTLS(s) ? DTLS1_3_VERSION : TLS1_3_VERSION;
 
         /* We never allow GOST sig algs on the server with (D)TLSv1.3 */
         if (s->server && SSL_CONNECTION_IS_VERSION13(s))
             return 0;
         if (!s->server
                 && SSL_CONNECTION_GET_SSL(s)->method->version == any_version
-                && ssl_version_cmp(s, s->s3.tmp.max_ver, gost_version_limit) >= 0) {
+                && s->s3.tmp.max_ver > 0
+                && ssl_version_cmp(s, s->s3.tmp.max_ver, version1_3) >= 0) {
             int i, num;
             STACK_OF(SSL_CIPHER) *sk;
 
@@ -2547,7 +2548,8 @@ static int tls12_sigalg_allowed(const SSL_CONNECTION *s, int op,
              * ciphersuites enabled.
              */
 
-            if (ssl_version_cmp(s, s->s3.tmp.min_ver, gost_version_limit) >= 0)
+            if (s->s3.tmp.min_ver > 0
+                && ssl_version_cmp(s, s->s3.tmp.min_ver, version1_3) >= 0)
                 return 0;
 
             sk = SSL_get_ciphers(SSL_CONNECTION_GET_SSL(s));

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2100,8 +2100,9 @@ int ssl_cipher_disabled(const SSL_CONNECTION *s, const SSL_CIPHER *c,
             && (c->algorithm_mkey & (SSL_kECDHE | SSL_kECDHEPSK)) != 0)
         minversion = SSL3_VERSION;
 
-    if (ssl_version_cmp(s, minversion, s->s3.tmp.max_ver) > 0
-        || ssl_version_cmp(s, maxversion, s->s3.tmp.min_ver) < 0)
+    if ((minversion > 0 && ssl_version_cmp(s, minversion, s->s3.tmp.max_ver) > 0)
+        || (maxversion > 0
+            && ssl_version_cmp(s, maxversion, s->s3.tmp.min_ver) < 0))
         return 1;
 
     return !ssl_security(s, op, c->strength_bits, 0, (void *)c);


### PR DESCRIPTION
I cherry-picked the change from https://github.com/openssl/openssl/pull/24292 and fixed a couple of additional cases of misuse.