### PR TITLE
Deprecate `SSL_get_peer_certificate()`

### DIFF
--- a/doc/internal/man3/OSSL_DEPRECATED.pod
+++ b/doc/internal/man3/OSSL_DEPRECATED.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-OSSL_DEPRECATED, OSSL_DEPRECATED_FOR - General deprecation macros
+OSSL_DEPRECATED, OSSL_DEPRECATED_FOR, OSSL_DEPRECATED_INSTEAD_USE - General deprecation macros
 
 =head1 SYNOPSIS
 
@@ -10,6 +10,7 @@ OSSL_DEPRECATED, OSSL_DEPRECATED_FOR - General deprecation macros
 
  #define OSSL_DEPRECATED(since)
  #define OSSL_DEPRECATED_FOR(since, msg)
+ #define OSSL_DEPRECATED_INSTEAD_USE(f1, f2)
 
 =head1 DESCRIPTION
 
@@ -23,6 +24,11 @@ OSSL_DEPRECATED_FOR() does the same as OSSL_DEPRECATED(), but also takes a
 second argument I<msg>, which is an additional text messages to be displayed
 with the deprecation warning along with the OpenSSL version number, for
 compilers that support user specified deprecation messages.
+
+OSSL_DEPRECATED_INSTEAD_USE() implements a warning via a compiler specific
+pragma, to be used when e.g. deprecating a macro.
+It takes two arguments, I<f1> the function that is deprecated and I<f2>
+the function that shall be used instead.
 
 These macros are used to define the version specific deprecation macros
 described in L<deprecation(7)>.

--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -28,11 +28,12 @@
 /*
  * Generic deprecation macro
  *
- * If OPENSSL_SUPPRESS_DEPRECATED is defined, then OSSL_DEPRECATED and
- * OSSL_DEPRECATED_FOR become no-ops
+ * If OPENSSL_SUPPRESS_DEPRECATED is defined, then OSSL_DEPRECATED,
+ * OSSL_DEPRECATED_FOR, and OSSL_DEPRECATED_INSTEAD_USE become no-ops
  */
 # ifndef OSSL_DEPRECATED
 #  undef OSSL_DEPRECATED_FOR
+#  undef OSSL_DEPRECATED_INSTEAD_USE
 #  ifndef OPENSSL_SUPPRESS_DEPRECATED
 #   if defined(_MSC_VER)
      /*
@@ -40,10 +41,13 @@
       * and __declspec(deprecated(message)) since MSVC 2005 (14.00)
       */
 #    if _MSC_VER >= 1400
+#     undef OSSL_PRAGMA_MESSAGE
 #     define OSSL_DEPRECATED(since) \
           __declspec(deprecated("Since OpenSSL " # since))
 #     define OSSL_DEPRECATED_FOR(since, message) \
           __declspec(deprecated("Since OpenSSL " # since ";" message))
+#     define OSSL_PRAGMA_MESSAGE(msg) __pragma(message(msg))
+#     define OSSL_DEPRECATED_INSTEAD_USE(f1, f2) OSSL_PRAGMA_MESSAGE(f1 is deprecated use f2 instead) f2
 #    elif _MSC_VER >= 1310
 #     define OSSL_DEPRECATED(since) __declspec(deprecated)
 #     define OSSL_DEPRECATED_FOR(since, message) __declspec(deprecated)
@@ -54,10 +58,15 @@
       * GCC 4.5.0
       */
 #    if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
+#     undef OSSL_PRAGMA_WRAP
+#     undef OSSL_PRAGMA_GCC_WARN
 #     define OSSL_DEPRECATED(since) \
           __attribute__((deprecated("Since OpenSSL " # since)))
 #     define OSSL_DEPRECATED_FOR(since, message) \
           __attribute__((deprecated("Since OpenSSL " # since ";" message)))
+#     define OSSL_PRAGMA_WRAP(s) _Pragma(#s)
+#     define OSSL_PRAGMA_GCC_WARN(message) OSSL_PRAGMA_WRAP(GCC warning # message)
+#     define OSSL_DEPRECATED_INSTEAD_USE(f1, f2) OSSL_PRAGMA_GCC_WARN(f1 is deprecated use f2 instead) f2
 #    elif __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ > 0)
 #     define OSSL_DEPRECATED(since) __attribute__((deprecated))
 #     define OSSL_DEPRECATED_FOR(since, message) __attribute__((deprecated))
@@ -78,6 +87,7 @@
 # ifndef OSSL_DEPRECATED
 #  define OSSL_DEPRECATED(since)                extern
 #  define OSSL_DEPRECATED_FOR(since, message)   extern
+#  define OSSL_DEPRECATED_INSTEAD_USE(f1, f2)	f2
 # endif
 
 /*

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -1760,7 +1760,7 @@ __owur X509 *SSL_get0_peer_certificate(const SSL *s);
 __owur X509 *SSL_get1_peer_certificate(const SSL *s);
 /* Deprecated in 3.0.0 */
 #  ifndef OPENSSL_NO_DEPRECATED_3_0
-#   define SSL_get_peer_certificate SSL_get1_peer_certificate
+#   define SSL_get_peer_certificate(s) OSSL_DEPRECATED_INSTEAD_USE(SSL_get_peer_certificate, SSL_get1_peer_certificate)(s)
 #  endif
 # endif
 


### PR DESCRIPTION
While triaging https://github.com/strophe/libstrophe/discussions/244 I discovered that this project could handle the deprecation of macros a bit better.

This adds a new macro `OSSL_DEPRECATED_INSTEAD_USE()` in order to be able to mark deprecated macros as such and make the compiler spit a message in case such a macro is used.

As a first example the `SSL_get_peer_certificate()` macro is marked as deprecated.

This PR fixes #22972 