### PR TITLE
ssl_sess.c: deprecate SSL_SESSION_get_time/SSL_SESSION_set_time

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -89,6 +89,12 @@ OpenSSL 3.4
 
    *Craig Lorentzen*
 
+ * SSL_SESSION_get_time()/SSL_SESSION_set_time()/SSL_CTX_flush_sessions() have
+   been deprecated in favour of their respective ..._ex() replacement functions
+   which are Y2038-safe.
+
+   *Alexander Kanavin*
+
 OpenSSL 3.3
 -----------
 

--- a/doc/man3/SSL_CTX_flush_sessions.pod
+++ b/doc/man3/SSL_CTX_flush_sessions.pod
@@ -2,18 +2,27 @@
 
 =head1 NAME
 
-SSL_CTX_flush_sessions - remove expired sessions
+SSL_CTX_flush_sessions_ex, SSL_CTX_flush_sessions - remove expired sessions
 
 =head1 SYNOPSIS
 
  #include <openssl/ssl.h>
 
+ void SSL_CTX_flush_sessions_ex(SSL_CTX *ctx, time_t tm);
+
+The following functions have been deprecated since OpenSSL 3.4, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
+
  void SSL_CTX_flush_sessions(SSL_CTX *ctx, long tm);
 
 =head1 DESCRIPTION
 
-SSL_CTX_flush_sessions() causes a run through the session cache of
+SSL_CTX_flush_sessions_ex() causes a run through the session cache of
 B<ctx> to remove sessions expired at time B<tm>.
+
+SSL_CTX_flush_sessions() is an older variant of the function that is not
+Y2038 safe due to usage of long datatype instead of time_t.
 
 =head1 NOTES
 
@@ -23,20 +32,20 @@ As sessions will not be reused ones they are expired, they should be
 removed from the cache to save resources. This can either be done
 automatically whenever 255 new sessions were established (see
 L<SSL_CTX_set_session_cache_mode(3)>)
-or manually by calling SSL_CTX_flush_sessions().
+or manually by calling SSL_CTX_flush_sessions_ex().
 
 The parameter B<tm> specifies the time which should be used for the
 expiration test, in most cases the actual time given by time(0)
 will be used.
 
-SSL_CTX_flush_sessions() will only check sessions stored in the internal
+SSL_CTX_flush_sessions_ex() will only check sessions stored in the internal
 cache. When a session is found and removed, the remove_session_cb is however
 called to synchronize with the external cache (see
 L<SSL_CTX_sess_set_get_cb(3)>).
 
 =head1 RETURN VALUES
 
-SSL_CTX_flush_sessions() does not return a value.
+SSL_CTX_flush_sessions_ex() does not return a value.
 
 =head1 SEE ALSO
 

--- a/doc/man3/SSL_CTX_set_ct_validation_callback.pod
+++ b/doc/man3/SSL_CTX_set_ct_validation_callback.pod
@@ -101,7 +101,7 @@ otherwise.
 When SCT processing is enabled, OCSP stapling will be enabled. This is because
 one possible source of SCTs is the OCSP response from a server.
 
-The time returned by SSL_SESSION_get_time() will be used to evaluate whether any
+The time returned by SSL_SESSION_get_time_ex() will be used to evaluate whether any
 presented SCTs have timestamps that are in the future (and therefore invalid).
 
 =head1 RESTRICTIONS

--- a/doc/man3/SSL_SESSION_get_time.pod
+++ b/doc/man3/SSL_SESSION_get_time.pod
@@ -11,26 +11,31 @@ SSL_get_time, SSL_set_time, SSL_get_timeout, SSL_set_timeout
 
  #include <openssl/ssl.h>
 
- long SSL_SESSION_get_time(const SSL_SESSION *s);
- long SSL_SESSION_set_time(SSL_SESSION *s, long tm);
  long SSL_SESSION_get_timeout(const SSL_SESSION *s);
  long SSL_SESSION_set_timeout(SSL_SESSION *s, long tm);
 
- long SSL_get_time(const SSL_SESSION *s);
- long SSL_set_time(SSL_SESSION *s, long tm);
  long SSL_get_timeout(const SSL_SESSION *s);
  long SSL_set_timeout(SSL_SESSION *s, long tm);
 
  time_t SSL_SESSION_get_time_ex(const SSL_SESSION *s);
  time_t SSL_SESSION_set_time_ex(SSL_SESSION *s, time_t tm);
 
+The following functions have been deprecated since OpenSSL 3.4, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
+
+ long SSL_SESSION_get_time(const SSL_SESSION *s);
+ long SSL_SESSION_set_time(SSL_SESSION *s, long tm);
+ long SSL_get_time(const SSL_SESSION *s);
+ long SSL_set_time(SSL_SESSION *s, long tm);
+
 =head1 DESCRIPTION
 
-SSL_SESSION_get_time() returns the time at which the session B<s> was
+SSL_SESSION_get_time_ex() returns the time at which the session B<s> was
 established. The time is given in seconds since the Epoch and therefore
 compatible to the time delivered by the time() call.
 
-SSL_SESSION_set_time() replaces the creation time of the session B<s> with
+SSL_SESSION_set_time_ex() replaces the creation time of the session B<s> with
 the chosen value B<tm>.
 
 SSL_SESSION_get_timeout() returns the timeout value set for session B<s>
@@ -39,9 +44,10 @@ in seconds.
 SSL_SESSION_set_timeout() sets the timeout value for session B<s> in seconds
 to B<tm>.
 
-SSL_SESSION_get_time_ex() and SSL_SESSION_set_time_ex() extended functions use
-the time_t datatype instead of long to fix the Y2038 problem on systems with
-64 bit time_t type.
+SSL_SESSION_get_time() and SSL_SESSION_set_time() functions use
+the long datatype instead of time_t and are therefore deprecated due to not
+being Y2038-safe on 32 bit systems. Note that such systems still need
+to be configured to use 64 bit time_t to be able to avoid overflow in system time.
 
 The SSL_get_time(), SSL_set_time(), SSL_get_timeout(), and SSL_set_timeout()
 functions are synonyms for the SSL_SESSION_*() counterparts.
@@ -57,10 +63,10 @@ of the session.
 
 =head1 RETURN VALUES
 
-SSL_SESSION_get_time() and SSL_SESSION_get_timeout() return the currently
+SSL_SESSION_get_time_ex() and SSL_SESSION_get_timeout() return the currently
 valid values.
 
-SSL_SESSION_set_time() and SSL_SESSION_set_timeout() return 1 on success.
+SSL_SESSION_set_time_ex() and SSL_SESSION_set_timeout() return 1 on success.
 
 If any of the function is passed the NULL pointer for the session B<s>,
 0 is returned.

--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -169,6 +169,7 @@
  * 'no-deprecated'.
  */
 
+# undef OPENSSL_NO_DEPRECATED_3_4
 # undef OPENSSL_NO_DEPRECATED_3_1
 # undef OPENSSL_NO_DEPRECATED_3_0
 # undef OPENSSL_NO_DEPRECATED_1_1_1
@@ -178,6 +179,17 @@
 # undef OPENSSL_NO_DEPRECATED_1_0_0
 # undef OPENSSL_NO_DEPRECATED_0_9_8
 
+# if OPENSSL_API_LEVEL >= 30400
+#  ifndef OPENSSL_NO_DEPRECATED
+#   define OSSL_DEPRECATEDIN_3_4                OSSL_DEPRECATED(3.4)
+#   define OSSL_DEPRECATEDIN_3_4_FOR(msg)       OSSL_DEPRECATED_FOR(3.4, msg)
+#  else
+#   define OPENSSL_NO_DEPRECATED_3_4
+#  endif
+# else
+#  define OSSL_DEPRECATEDIN_3_4
+#  define OSSL_DEPRECATEDIN_3_4_FOR(msg)
+# endif
 # if OPENSSL_API_LEVEL >= 30100
 #  ifndef OPENSSL_NO_DEPRECATED
 #   define OSSL_DEPRECATEDIN_3_1                OSSL_DEPRECATED(3.1)

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -1572,7 +1572,11 @@ void SSL_CTX_set1_cert_store(SSL_CTX *, X509_STORE *);
 __owur int SSL_want(const SSL *s);
 __owur int SSL_clear(SSL *s);
 
+#ifndef OPENSSL_NO_DEPRECATED_3_4
+OSSL_DEPRECATEDIN_3_4_FOR("not Y2038-safe, replace with SSL_CTX_flush_sessions_ex()")
 void SSL_CTX_flush_sessions(SSL_CTX *ctx, long tm);
+#endif
+void SSL_CTX_flush_sessions_ex(SSL_CTX *ctx, time_t tm);
 
 __owur const SSL_CIPHER *SSL_get_current_cipher(const SSL *s);
 __owur const SSL_CIPHER *SSL_get_pending_cipher(const SSL *s);

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -1688,8 +1688,13 @@ __owur const char *SSL_state_string(const SSL *s);
 __owur const char *SSL_rstate_string(const SSL *s);
 __owur const char *SSL_state_string_long(const SSL *s);
 __owur const char *SSL_rstate_string_long(const SSL *s);
+
+#ifndef OPENSSL_NO_DEPRECATED_3_4
+OSSL_DEPRECATEDIN_3_4_FOR("not Y2038-safe, replace with SSL_SESSION_get_time_ex()")
 __owur long SSL_SESSION_get_time(const SSL_SESSION *s);
+OSSL_DEPRECATEDIN_3_4_FOR("not Y2038-safe, replace with SSL_SESSION_set_time_ex()")
 __owur long SSL_SESSION_set_time(SSL_SESSION *s, long t);
+#endif
 __owur long SSL_SESSION_get_timeout(const SSL_SESSION *s);
 __owur long SSL_SESSION_set_timeout(SSL_SESSION *s, long t);
 __owur int SSL_SESSION_get_protocol_version(const SSL_SESSION *s);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4151,7 +4151,7 @@ void SSL_CTX_free(SSL_CTX *a)
      * (See ticket [openssl.org #212].)
      */
     if (a->sessions != NULL)
-        SSL_CTX_flush_sessions(a, 0);
+        SSL_CTX_flush_sessions_ex(a, 0);
 
     CRYPTO_free_ex_data(CRYPTO_EX_INDEX_SSL_CTX, a, &a->ex_data);
     lh_SSL_SESSION_free(a->sessions);
@@ -4544,7 +4544,7 @@ void ssl_update_cache(SSL_CONNECTION *s, int mode)
         else
             stat = &s->session_ctx->stats.sess_accept_good;
         if ((ssl_tsan_load(s->session_ctx, stat) & 0xff) == 0xff)
-            SSL_CTX_flush_sessions(s->session_ctx, (unsigned long)time(NULL));
+            SSL_CTX_flush_sessions_ex(s->session_ctx, time(NULL));
     }
 }
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -6363,7 +6363,7 @@ int ssl_validate_ct(SSL_CONNECTION *s)
     CT_POLICY_EVAL_CTX_set_shared_CTLOG_STORE(ctx,
             SSL_CONNECTION_GET_CTX(s)->ctlog_store);
     CT_POLICY_EVAL_CTX_set_time(
-            ctx, (uint64_t)SSL_SESSION_get_time(s->session) * 1000);
+            ctx, (uint64_t)SSL_SESSION_get_time_ex(s->session) * 1000);
 
     scts = SSL_get0_peer_scts(SSL_CONNECTION_GET_SSL(s));
 

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -941,10 +941,12 @@ long SSL_SESSION_get_timeout(const SSL_SESSION *s)
     return (long)ossl_time_to_time_t(s->timeout);
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_4
 long SSL_SESSION_get_time(const SSL_SESSION *s)
 {
     return (long) SSL_SESSION_get_time_ex(s);
 }
+#endif
 
 time_t SSL_SESSION_get_time_ex(const SSL_SESSION *s)
 {
@@ -973,10 +975,12 @@ time_t SSL_SESSION_set_time_ex(SSL_SESSION *s, time_t t)
     return t;
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_4
 long SSL_SESSION_set_time(SSL_SESSION *s, long t)
 {
     return (long) SSL_SESSION_set_time_ex(s, (time_t) t);
 }
+#endif
 
 int SSL_SESSION_get_protocol_version(const SSL_SESSION *s)
 {

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -1183,7 +1183,14 @@ int SSL_set_session_ticket_ext(SSL *s, void *ext_data, int ext_len)
     return 0;
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_4
 void SSL_CTX_flush_sessions(SSL_CTX *s, long t)
+{
+    SSL_CTX_flush_sessions_ex(s, (time_t) t);
+}
+#endif
+
+void SSL_CTX_flush_sessions_ex(SSL_CTX *s, time_t t)
 {
     STACK_OF(SSL_SESSION) *sk;
     SSL_SESSION *current;

--- a/test/clienthellotest.c
+++ b/test/clienthellotest.c
@@ -164,7 +164,7 @@ static int test_client_hello(int currtest)
          * We reset the creation time so that we don't discard the session as
          * too old.
          */
-        if (!TEST_true(SSL_SESSION_set_time(sess, (long)time(NULL)))
+        if (!TEST_true(SSL_SESSION_set_time_ex(sess, time(NULL)))
                 || !TEST_true(SSL_set_session(con, sess)))
             goto end;
     }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -9377,21 +9377,21 @@ static int test_session_timeout(int test)
         goto end;
 
     /* This should remove "early" */
-    SSL_CTX_flush_sessions(ctx, now + TIMEOUT - 1);
+    SSL_CTX_flush_sessions_ex(ctx, now + TIMEOUT - 1);
     if (!TEST_ptr_null(early->prev)
         || !TEST_ptr(middle->prev)
         || !TEST_ptr(late->prev))
         goto end;
 
     /* This should remove "middle" */
-    SSL_CTX_flush_sessions(ctx, now + TIMEOUT + 1);
+    SSL_CTX_flush_sessions_ex(ctx, now + TIMEOUT + 1);
     if (!TEST_ptr_null(early->prev)
         || !TEST_ptr_null(middle->prev)
         || !TEST_ptr(late->prev))
         goto end;
 
     /* This should remove "late" */
-    SSL_CTX_flush_sessions(ctx, now + TIMEOUT + 11);
+    SSL_CTX_flush_sessions_ex(ctx, now + TIMEOUT + 11);
     if (!TEST_ptr_null(early->prev)
         || !TEST_ptr_null(middle->prev)
         || !TEST_ptr_null(late->prev))
@@ -9410,7 +9410,7 @@ static int test_session_timeout(int test)
         goto end;
 
     /* This should remove all of them */
-    SSL_CTX_flush_sessions(ctx, 0);
+    SSL_CTX_flush_sessions_ex(ctx, 0);
     if (!TEST_ptr_null(early->prev)
         || !TEST_ptr_null(middle->prev)
         || !TEST_ptr_null(late->prev))

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -2330,9 +2330,9 @@ static int execute_test_session(int maxprot, int use_int_cache,
      */
 
     /* Make sess1 expire before sess2 */
-    if (!TEST_long_gt(SSL_SESSION_set_time(sess1, 1000), 0)
+    if (!TEST_time_t_gt(SSL_SESSION_set_time_ex(sess1, 1000), 0)
             || !TEST_long_gt(SSL_SESSION_set_timeout(sess1, 1000), 0)
-            || !TEST_long_gt(SSL_SESSION_set_time(sess2, 2000), 0)
+            || !TEST_time_t_gt(SSL_SESSION_set_time_ex(sess2, 2000), 0)
             || !TEST_long_gt(SSL_SESSION_set_timeout(sess2, 2000), 0))
         goto end;
 
@@ -3991,7 +3991,7 @@ static int early_data_skip_helper(int testtype, int cipher, int idx)
          * time. It could be any value as long as it is not within tolerance.
          * This should mean the ticket is rejected.
          */
-        if (!TEST_true(SSL_SESSION_set_time(sess, (long)(time(NULL) - 20))))
+        if (!TEST_true(SSL_SESSION_set_time_ex(sess, time(NULL) - 20)))
             goto end;
     }
 
@@ -9325,7 +9325,7 @@ static int test_session_timeout(int test)
     SSL_SESSION *late = NULL;
     SSL_CTX *ctx;
     int testresult = 0;
-    long now = (long)time(NULL);
+    time_t now = time(NULL);
 #define TIMEOUT 10
 
     if (!TEST_ptr(ctx = SSL_CTX_new_ex(libctx, NULL, TLS_method()))
@@ -9353,9 +9353,9 @@ static int test_session_timeout(int test)
         || !TEST_ptr(late->prev))
         goto end;
 
-    if (!TEST_int_ne(SSL_SESSION_set_time(early, now - 10), 0)
-        || !TEST_int_ne(SSL_SESSION_set_time(middle, now), 0)
-        || !TEST_int_ne(SSL_SESSION_set_time(late, now + 10), 0))
+    if (!TEST_time_t_ne(SSL_SESSION_set_time_ex(early, now - 10), 0)
+        || !TEST_time_t_ne(SSL_SESSION_set_time_ex(middle, now), 0)
+        || !TEST_time_t_ne(SSL_SESSION_set_time_ex(late, now + 10), 0))
         goto end;
 
     if (!TEST_int_ne(SSL_SESSION_set_timeout(early, TIMEOUT), 0)
@@ -9421,9 +9421,9 @@ static int test_session_timeout(int test)
 
     /* make sure |now| is NOT  equal to the current time */
     now -= 10;
-    if (!TEST_int_ne(SSL_SESSION_set_time(early, now), 0)
+    if (!TEST_time_t_ne(SSL_SESSION_set_time_ex(early, now), 0)
         || !TEST_int_eq(SSL_CTX_add_session(ctx, early), 1)
-        || !TEST_long_ne(SSL_SESSION_get_time(early), now))
+        || !TEST_time_t_ne(SSL_SESSION_get_time_ex(early), now))
         goto end;
 
     testresult = 1;

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -186,7 +186,7 @@ TLSv1_2_client_method                   186	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_1
 SSL_add_client_CA                       187	3_0_0	EXIST::FUNCTION:
 SSL_CTX_get0_security_ex_data           188	3_0_0	EXIST::FUNCTION:
 SSL_get_ex_data                         189	3_0_0	EXIST::FUNCTION:
-SSL_CTX_flush_sessions                  190	3_0_0	EXIST::FUNCTION:
+SSL_CTX_flush_sessions                  190	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_4
 SSL_use_PrivateKey                      191	3_0_0	EXIST::FUNCTION:
 DTLSv1_client_method                    192	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_1_1_0,DTLS1_METHOD
 SSL_CTX_dane_mtype_set                  193	3_0_0	EXIST::FUNCTION:
@@ -583,3 +583,4 @@ SSL_set_value_uint                      583	3_3_0	EXIST::FUNCTION:
 SSL_poll                                584	3_3_0	EXIST::FUNCTION:
 SSL_SESSION_get_time_ex                 585	3_3_0	EXIST::FUNCTION:
 SSL_SESSION_set_time_ex                 586	3_3_0	EXIST::FUNCTION:
+SSL_CTX_flush_sessions_ex               587	3_4_0	EXIST::FUNCTION:

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -147,7 +147,7 @@ SSL_set_security_callback               147	3_0_0	EXIST::FUNCTION:
 SSL_SRP_CTX_init                        148	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
 ERR_load_SSL_strings                    149	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 SSL_CTX_SRP_CTX_init                    150	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
-SSL_SESSION_set_time                    151	3_0_0	EXIST::FUNCTION:
+SSL_SESSION_set_time                    151	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_4
 i2d_SSL_SESSION                         152	3_0_0	EXIST::FUNCTION:
 SSL_SESSION_get_master_key              153	3_0_0	EXIST::FUNCTION:
 SSL_COMP_get_compression_methods        154	3_0_0	EXIST::FUNCTION:
@@ -246,7 +246,7 @@ SSL_get_verify_mode                     246	3_0_0	EXIST::FUNCTION:
 SSL_CIPHER_get_id                       247	3_0_0	EXIST::FUNCTION:
 SSL_SESSION_print_keylog                248	3_0_0	EXIST::FUNCTION:
 SSL_CTX_set_psk_client_callback         249	3_0_0	EXIST::FUNCTION:PSK
-SSL_SESSION_get_time                    250	3_0_0	EXIST::FUNCTION:
+SSL_SESSION_get_time                    250	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_4
 SSL_set_debug                           251	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_1_1_0
 SSL_get_security_level                  252	3_0_0	EXIST::FUNCTION:
 SSL_CIPHER_description                  253	3_0_0	EXIST::FUNCTION:

--- a/util/perl/OpenSSL/ParseC.pm
+++ b/util/perl/OpenSSL/ParseC.pm
@@ -266,7 +266,13 @@ my @opensslchandlers = (
     { regexp   => qr/OSSL_DEPRECATEDIN_\d+_\d+(?:_\d+)?\s+(.*)/,
       massager => sub { return $1; },
     },
+    { regexp   => qr/OSSL_DEPRECATEDIN_\d+_\d+(?:_\d+)?_FOR<<<.*>>>(.*)/,
+      massager => sub { return $1; },
+    },
     { regexp   => qr/(.*?)\s+OSSL_DEPRECATEDIN_\d+_\d+(?:_\d+)?\s+(.*)/,
+      massager => sub { return "$1 $2"; },
+    },
+    { regexp   => qr/(.*?)\s+OSSL_DEPRECATEDIN_\d+_\d+(?:_\d+)?_FOR<<<.*>>>(.*)/,
       massager => sub { return "$1 $2"; },
     },
 


### PR DESCRIPTION
Fixes: #23648