### PR TITLE
test/threadstest.c: Add checks for CRYPTO_THREAD_lock_new()

### DIFF
--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -90,6 +90,9 @@ static int test_lock(void)
     CRYPTO_RWLOCK *lock = CRYPTO_THREAD_lock_new();
     int res;
 
+    if (!TEST_ptr(lock))
+        return 0;
+
     res = TEST_true(CRYPTO_THREAD_read_lock(lock))
           && TEST_true(CRYPTO_THREAD_unlock(lock))
           && TEST_true(CRYPTO_THREAD_write_lock(lock))
@@ -225,6 +228,9 @@ static int _torture_rw(void)
 
     rwtorturelock = CRYPTO_THREAD_lock_new();
     atomiclock = CRYPTO_THREAD_lock_new();
+    if (!TEST_ptr(rwtorturelock) || !TEST_ptr(atomiclock))
+        goto out;
+
     rwwriter1_iterations = 0;
     rwwriter2_iterations = 0;
     rwreader1_iterations = 0;
@@ -413,6 +419,9 @@ static int _torture_rcu(void)
     int rc = 0;
 
     atomiclock = CRYPTO_THREAD_lock_new();
+    if (!TEST_ptr(atomiclock))
+        goto out;
+
     memset(&writer1, 0, sizeof(thread_t));
     memset(&writer2, 0, sizeof(thread_t));
     memset(&reader1, 0, sizeof(thread_t));
@@ -427,6 +436,8 @@ static int _torture_rcu(void)
     rcu_torture_result = 1;
 
     rcu_lock = ossl_rcu_lock_new(1, NULL);
+    if (!rcu_lock)
+        goto out;
 
     TEST_info("Staring rcu torture");
     t1 = ossl_time_now();


### PR DESCRIPTION
Add checks for the return value of CRYPTO_THREAD_lock_new() in order to avoid Null pointer dereference.

Fixes: 5f8b812931 ("Add locking to atomic operations in rw/rcu tests")
Fixes: d0e1a0ae70 ("RCU lock implementation")
Fixes: 71a04cfca0 ("Implement new multi-threading API")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
