### PR TITLE
Reduce optimization in hppa builds

### DIFF
--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -68,7 +68,7 @@ jobs:
           }, {
             arch: hppa-linux-gnu,
             libs: libc6-dev-hppa-cross,
-            target: -static linux-generic32,
+            target: -static -O1 linux-generic32,
             fips: no,
             tests: -test_includes -test_store -test_x509_store
           }, {

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -66,6 +66,8 @@ jobs:
             target: linux-armv4,
             tests: -test_includes -test_store -test_x509_store
           }, {
+            # gcc hppa seems to have some potential compiler issues
+            # with -O2 on this platform, reduce optimization to -01
             arch: hppa-linux-gnu,
             libs: libc6-dev-hppa-cross,
             target: -static -O1 linux-generic32,


### PR DESCRIPTION
We're getting some odd errors in the lhash test on hppa.  Analysis shows that the crash is happening randomly in various places, but always occurs during an indexed load of register r11 or r23.  Root cause hasn't been completely determined, but given that:

1) hppa is an unadopted platform
2) asan/ubsan/threadsan shows no issues with the affected code elsewhere 3) The hppa build does not have threading enabled
4) reducing the optimization level to 01 quashes the problem

The belief is that this is either a bug in gcc optimization, or an issue in the qemu emulator we use to test.

Since this is causing CI failures, I'm proposing that we just lower the optimization level of the build to -01 to avoid the problem, and address it more throughly should an actual platform user encounter an error

Fixes #24272

