### PR TITLE
Fix invalid expression syntax

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -66,7 +66,7 @@ jobs:
       run: nmake test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4
     - name: install
       # Run on 64 bit only as 32 bit is slow enough already
-      if: $${{ matrix.platform.arch == 'win64' }}
+      if: ${{ matrix.platform.arch == 'win64' }}
       run: |
         mkdir _dest
         nmake install DESTDIR=_dest


### PR DESCRIPTION
The expression had an extra '$' character which made it always evaluate to true.
    
See https://github.com/boostsecurityio/poutine/blob/main/docs/content/en/rules/if_always_true.md.
    
CLA: trivial

:hammer_and_pick: with :heart: by [Siemens](https://opensource.siemens.com/)