### PR TITLE
Can we let OPENSSL_NO_PINSHARED compile time guard go?

### DIFF
--- a/crypto/init.c
+++ b/crypto/init.c
@@ -131,8 +131,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_load_crypto_nodelete)
 {
     OSSL_TRACE(INIT, "ossl_init_load_crypto_nodelete()\n");
 
-#if !defined(OPENSSL_USE_NODELETE) \
-    && !defined(OPENSSL_NO_PINSHARED)
+#if !defined(OPENSSL_USE_NODELETE)
 # if defined(DSO_WIN32) && !defined(_WIN32_WCE)
     {
         HMODULE handle = NULL;
@@ -669,8 +668,7 @@ int OPENSSL_atexit(void (*handler)(void))
 {
     OPENSSL_INIT_STOP *newhand;
 
-#if !defined(OPENSSL_USE_NODELETE)\
-    && !defined(OPENSSL_NO_PINSHARED)
+#if !defined(OPENSSL_USE_NODELETE)
     {
 # if defined(DSO_WIN32) && !defined(_WIN32_WCE)
         HMODULE handle = NULL;

--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -218,8 +218,7 @@ static int test_lib(void)
         ssllib = SD_INIT;
     }
 
-# if defined(OPENSSL_NO_PINSHARED) \
-    && defined(__GLIBC__) \
+# if defined(__GLIBC__) \
     && defined(__GLIBC_PREREQ) \
     && defined(OPENSSL_SYS_LINUX)
 #  if __GLIBC_PREREQ(2, 3)


### PR DESCRIPTION
while looking at code in `OPENSSL_atexit()` I've noticed the `OPENSSL_NO_PINSHARED` guard could be removed. Because I could not find any control knob in build configuration which provides definition of `OPENSS_NO_PINSHARED` macro. I did use grep `find ./ -type f |xargs grep OPENSSL_NO_PINSHARED`

