### PR TITLE
doc : Corrected the return value documentation for SSL_SESSION_set_time()

### DIFF
--- a/doc/man3/SSL_SESSION_get_time.pod
+++ b/doc/man3/SSL_SESSION_get_time.pod
@@ -60,7 +60,9 @@ of the session.
 SSL_SESSION_get_time() and SSL_SESSION_get_timeout() return the currently
 valid values.
 
-SSL_SESSION_set_time() and SSL_SESSION_set_timeout() return 1 on success.
+SSL_SESSION_set_time() sets the time for the SSL session and returns the new time on success or 0 on error.
+
+SSL_SESSION_set_timeout() sets the timeout value for the SSL session and returns 1 on success or 0 on error.
 
 If any of the function is passed the NULL pointer for the session B<s>,
 0 is returned.


### PR DESCRIPTION
Fixes #24322

This pull request updates the documentation of the return value for SSL_SESSION_set_time() and SSL_SESSION_set_timeout()

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [+] documentation is added or updated

