### PR TITLE
zeroize rsa->p,rsa->q on error

### DIFF
--- a/crypto/rsa/rsa_sp800_56b_gen.c
+++ b/crypto/rsa/rsa_sp800_56b_gen.c
@@ -147,11 +147,15 @@ int ossl_rsa_fips186_4_gen_prob_primes(RSA *rsa, RSA_ACVP_TEST *test,
     ret = 1;
 err:
     /* Zeroize any internally generated values that are not returned */
-    if (Xpo != NULL)
-        BN_clear(Xpo);
-    if (Xqo != NULL)
-        BN_clear(Xqo);
+    BN_clear(Xpo);
+    BN_clear(Xqo);
     BN_clear(tmp);
+    if (ret != 1) {
+        BN_clear_free(rsa->p);
+        rsa->p = NULL;
+        BN_clear_free(rsa->q);
+        rsa->q = NULL;
+    }
 
     BN_CTX_end(ctx);
     return ret;


### PR DESCRIPTION
this is rquired by fips-186-5 section A.1.6, step 7:
	Zeroize the internally generated values that are not returned

In OpenSSL code we need to zero p, q members of rsa structure. The rsa structure is provided by ossl_rsa_fips186_4_gen_prob_primes() caller.

The remaining values (variables) mentioned by standard are zeroed already in functions we call from ossl_rsa_fips186_4_gen_prob_primes().

