### PR TITLE
fips: allow to customize provider vendor name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,9 @@ jobs:
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: localegen
       run: sudo locale-gen tr_TR.UTF-8
+    - name: fipsvendor
+      # Make one fips build use a customized FIPS vendor
+      run: echo "FIPS_VENDOR=CI" >> VERSION.dat
     - name: config
       # enable-quic is on by default, but we leave it here to check we're testing the explicit enable somewhere
       run: CC=gcc ./config --banner=Configured enable-demos enable-h3demo enable-fips enable-quic --strict-warnings && perl configdata.pm --dump
@@ -92,6 +95,9 @@ jobs:
         ./util/opensslwrap.sh version -c
     - name: make test
       run: .github/workflows/make-test
+    - name: check fipsvendor
+      run: |
+        util/wrap.pl -fips apps/openssl list -providers | grep 'name: CI FIPS Provider for OpenSSL$'
     - name: save artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/Configure
+++ b/Configure
@@ -1342,6 +1342,11 @@ push @{$config{openssl_feature_defines}},
      map { (my $x = $_) =~ tr|[\-a-z]|[_A-Z]|; "OPENSSL_RAND_SEED_$x" }
         @seed_sources;
 
+my $provider_string = $disabled{"fips-post"} ? "non-compliant FIPS Provider" : "FIPS Provider";
+
+$config{FIPS_VENDOR} =
+    (defined $version{FIPS_VENDOR} ? "$version{FIPS_VENDOR} $provider_string for OpenSSL" : "OpenSSL $provider_string");
+
 # Backward compatibility?
 if ($target =~ m/^CygWin32(-.*)$/) {
     $target = "Cygwin".$1;

--- a/README-FIPS.md
+++ b/README-FIPS.md
@@ -166,3 +166,17 @@ Documentation about using the FIPS module is available on the [fips_module(7)]
 manual page.
 
  [fips_module(7)]: https://www.openssl.org/docs/manmaster/man7/fips_module.html
+
+3rd-Party Vendor Builds
+=====================================
+
+Some Vendors choose to patch/modify/build their own FIPS provider,
+test it with a Security Laboratory and submit it under their own CMVP
+certificate, instead of using OpenSSL Project submissions. When doing
+so, FIPS provider should uniquely identify its own name and version
+number. The build infrastructure allows to customize FIPS provider
+build information via changes to strings in `VERSION.dat`.
+
+Setting "PRE_RELEASE_TAG" (dashed suffix), "BUILD_METADATA" (plus
+suffix), and "FIPS_VENDOR" allow to control reported FIPS provider
+name and build version as required for CMVP submission.

--- a/include/openssl/fipskey.h.in
+++ b/include/openssl/fipskey.h.in
@@ -28,6 +28,11 @@ extern "C" {
  */
 #define FIPS_KEY_STRING "{- $config{FIPSKEY} -}"
 
+/*
+ * The FIPS provider vendor name, as a string.
+ */
+#define FIPS_VENDOR "{- $config{FIPS_VENDOR} -}"
+
 # ifdef  __cplusplus
 }
 # endif

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -12,6 +12,7 @@
 #include <openssl/core_names.h>
 #include <openssl/params.h>
 #include <openssl/fips_names.h>
+#include <openssl/fipskey.h>
 #include <openssl/rand.h> /* RAND_get0_public() */
 #include <openssl/proverr.h>
 #include <openssl/indicator.h>
@@ -27,12 +28,6 @@
 #include "self_test.h"
 #include "crypto/context.h"
 #include "internal/core.h"
-
-#if defined(OPENSSL_NO_FIPS_POST)
-# define OSSL_FIPS_PROV_NAME "OpenSSL non-compliant FIPS Provider"
-#else
-# define OSSL_FIPS_PROV_NAME "OpenSSL FIPS Provider"
-#endif
 
 static const char FIPS_DEFAULT_PROPERTIES[] = "provider=fips,fips=yes";
 static const char FIPS_UNAPPROVED_PROPERTIES[] = "provider=fips,fips=no";
@@ -321,7 +316,7 @@ static int fips_get_params(void *provctx, OSSL_PARAM params[])
                                               OSSL_LIB_CTX_FIPS_PROV_INDEX);
 
     p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_NAME);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, OSSL_FIPS_PROV_NAME))
+    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, FIPS_VENDOR))
         return 0;
     p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_VERSION);
     if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, OPENSSL_VERSION_STR))

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -142,7 +142,7 @@ static int using_fips_rng(void)
     if (!TEST_ptr(prov))
         return 0;
     name = OSSL_PROVIDER_get0_name(prov);
-    return strcmp(name, "OpenSSL FIPS Provider") == 0;
+    return strstr(name, "FIPS Provider") != NULL;
 }
 
  /*


### PR DESCRIPTION
FIPS providers need to specify identifiable names and versions. Allow to customize the fips provider name prefix, via VERSION.dat which already allows to customize version & buildinfo. With this patch in-place it removes the need of patching code to set customized provider name.

E.g. echo FIPSVENDOR=ACME >> VERSION.dat, results in

```
$ OPENSSL_CONF=fips-and-base.cnf ../util/wrap.pl ../apps/openssl list -providers --verbose
Providers:
  base
    name: OpenSSL Base Provider
    version: 3.4.0
    status: active
    build info: 3.4.0-dev
    gettable provider parameters:
      name: pointer to a UTF8 encoded string (arbitrary size)
      version: pointer to a UTF8 encoded string (arbitrary size)
      buildinfo: pointer to a UTF8 encoded string (arbitrary size)
      status: integer (arbitrary size)
  fips
    name: ACME OpenSSL FIPS Provider
    version: 3.4.0
    status: active
    build info: 3.4.0-dev
    gettable provider parameters:
      name: pointer to a UTF8 encoded string (arbitrary size)
      version: pointer to a UTF8 encoded string (arbitrary size)
      buildinfo: pointer to a UTF8 encoded string (arbitrary size)
      status: integer (arbitrary size)
      security-checks: integer (arbitrary size)
      tls1-prf-ems-check: integer (arbitrary size)
      drbg-no-trunc-md: integer (arbitrary size)
```

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->