### PR TITLE
quic_multistream_test: fix undefined symbol snprintf with VS2010

### DIFF
--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -784,7 +784,7 @@ static int helper_init(struct helper *h, const char *script_name,
         goto err;
 
     /* Set title for qlog purposes. */
-    snprintf(title, sizeof(title), "quic_multistream_test: %s", script_name);
+    BIO_snprintf(title, sizeof(title), "quic_multistream_test: %s", script_name);
     if (!TEST_true(ossl_quic_set_diag_title(h->c_ctx, title)))
         goto err;
 
@@ -5827,7 +5827,7 @@ static int test_script(int idx)
     }
 #endif
 
-    snprintf(script_name, sizeof(script_name), "script %d", script_idx + 1);
+    BIO_snprintf(script_name, sizeof(script_name), "script %d", script_idx + 1);
 
     TEST_info("Running script %d (order=%d, blocking=%d)", script_idx + 1,
               free_order, blocking);
@@ -5912,8 +5912,8 @@ static ossl_unused int test_dyn_frame_types(int idx)
             s[i].arg2 = forbidden_frame_types[idx].expected_err;
         }
 
-    snprintf(script_name, sizeof(script_name),
-             "dyn script %d", idx);
+    BIO_snprintf(script_name, sizeof(script_name),
+                 "dyn script %d", idx);
 
     return run_script(dyn_frame_types_script, script_name, 0, 0);
 }


### PR DESCRIPTION
As `snprintf` is not available everywhere, use `BIO_snprintf` instead.

Fixes:
```
        IF EXIST test\quic_multistream_test.exe.manifest DEL /F /Q test\quic_multistream_test.exe.manifest
        "link" /nologo /debug setargv.obj /subsystem:console /opt:ref  /nologo /debug @V:\_tmp\nm4.tmp
quic_multistream_test-bin-quic_multistream_test.obj : error LNK2019: unresolved external symbol _snprintf referenced in function _helper_init test\quic_multistream_test.exe : fatal error LNK1120: 1 unresolved externals NMAKE : fatal error U1077: '"E:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\BIN\link.EXE"' : return code '0x460'
```

This PR is part 1/3 of https://github.com/openssl/openssl/pull/24326 which has been split.

Build and run tested:
- Windows 2003 x64, Windows 2003 x86, Visual Studio 2010
- Windows 11 21H2, Visual Studio 2019
- Ubuntu 22.04.4 LTS
- macOS 14.4.1 Intel
- FreeBSD-13.2-p11

@t8m @nhorman @tom-cosgrove-arm @viruscamp @levitte @paulidale @mattcaswell @hlandau

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
