### PR TITLE
threads_win: fix build error with VS2010

### DIFF
--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -168,7 +168,7 @@ void ossl_rcu_lock_free(CRYPTO_RCU_LOCK *lock)
     OPENSSL_free(lock);
 }
 
-static inline struct rcu_qp *get_hold_current_qp(CRYPTO_RCU_LOCK *lock)
+static ossl_inline struct rcu_qp *get_hold_current_qp(CRYPTO_RCU_LOCK *lock)
 {
     uint32_t qp_idx;
 


### PR DESCRIPTION
VC 2010 or earlier compilers do not support `static inline`. To work around this problem, we can use the `ossl_inline` macro.

Fixes:
```
crypto\threads_win.c(171) : error C2054: expected '(' to follow 'inline' crypto\threads_win.c(172) : error C2085: 'get_hold_current_qp' : not in formal parameter list crypto\threads_win.c(172) : error C2143: syntax error : missing ';' before '{' crypto\threads_win.c(228) : warning C4013: 'get_hold_current_qp' undefined; assuming extern returning int crypto\threads_win.c(228) : warning C4047: '=' : 'rcu_qp *' differs in levels of indirection from 'int'
```

This PR is part 2/3 of https://github.com/openssl/openssl/pull/24326 which has been split.

Build and run tested:
- Windows 2003 x64, Windows 2003 x86, Visual Studio 2010
- Windows 11 21H2, Visual Studio 2019
- Ubuntu 22.04.4 LTS
- macOS 14.4.1 Intel
- FreeBSD-13.2-p11
@t8m @nhorman @tom-cosgrove-arm @viruscamp @levitte @paulidale @mattcaswell @hlandau 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
