### PR TITLE
crypto/riscvcap: fix function declaration for hwprobe_to_cap

### DIFF
--- a/crypto/riscvcap.c
+++ b/crypto/riscvcap.c
@@ -85,7 +85,7 @@ static long riscv_hwprobe(struct riscv_hwprobe *pairs, size_t pair_count,
     return syscall(__NR_riscv_hwprobe, pairs, pair_count, cpu_count, cpus, flags);
 }
 
-static void hwprobe_to_cap()
+static void hwprobe_to_cap(void)
 {
     long ret;
     struct riscv_hwprobe pairs[OSSL_RISCV_HWPROBE_PAIR_COUNT] = {


### PR DESCRIPTION
When compiling with gcc from ubuntu 24.04 with `--strict-warnings`, it would complain

```
crypto/riscvcap.c:88:13: error: function declaration isn't a prototype [-Werror=strict-prototypes]
   88 | static void hwprobe_to_cap()
      |             ^~~~~~~~~~~~~~
```

This was found during an attempt to migrate riscv64 cross-compile CI for openssl to ubuntu 24.04. In 24.04, the header `<asm/hwprobe.h>` exists so the `#ifdef` for this function was enabled, whereas it is not the case for 22.04.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
