### PR TITLE
Fixed the crash issue when a pointer is null.

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -188,6 +188,8 @@ static int err_string_data_cmp(const ERR_STRING_DATA *a,
 static ERR_STRING_DATA *int_err_get_item(const ERR_STRING_DATA *d)
 {
     ERR_STRING_DATA *p = NULL;
+    if(err_string_lock == NULL)
+	return NULL;
 
     if (!CRYPTO_THREAD_read_lock(err_string_lock))
         return NULL;


### PR DESCRIPTION
When using libcurl, at the time the process is about to exit, openssl will invoke the err_cleanup function, setting err_string_lock to NULL. If other threads are still calling libcurl at this moment, it will cause a crash in the int_err_get_item function.

当我使用libcrul，在进程要退出的时候，openssl会调用err_cleanup将err_string_lock赋值为NULL,此时其他线程还在调用libcurl，在int_err_get_item函数中会产生崩溃
