### PR TITLE
Suppress a spurious error from the sysdefault test

### DIFF
--- a/test/recipes/90-test_sysdefault.t
+++ b/test/recipes/90-test_sysdefault.t
@@ -24,7 +24,7 @@ ok(run(test(["sysdefaulttest"])), "sysdefaulttest");
 
 $ENV{OPENSSL_CONF} = data_file("sysdefault-bad.cnf");
 
-ok(!run(test(["sysdefaulttest"])), "sysdefaulttest");
+ok(run(test(["sysdefaulttest", "-f"])), "sysdefaulttest");
 
 $ENV{OPENSSL_CONF} = data_file("sysdefault-ignore.cnf");
 


### PR DESCRIPTION
Running the sysdefault test results in spurious error output - even though the test has actually passed

Fixes #24383

