### PR TITLE
Only free the read buffers if we're not using them

### DIFF
--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -283,6 +283,8 @@ static int tls_release_read_buffer(OSSL_RECORD_LAYER *rl)
         OPENSSL_cleanse(b->buf, b->len);
     OPENSSL_free(b->buf);
     b->buf = NULL;
+    rl->packet = NULL;
+    rl->packet_length = 0;
     return 1;
 }
 
@@ -323,6 +325,12 @@ int tls_default_read_n(OSSL_RECORD_LAYER *rl, size_t n, size_t max, int extend,
         rl->packet = rb->buf + rb->offset;
         rl->packet_length = 0;
         /* ... now we can act as if 'extend' was set */
+    }
+
+    if (!ossl_assert(rl->packet != NULL)) {
+        /* does not happen */
+        RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return OSSL_RECORD_RETURN_FATAL;
     }
 
     len = rl->packet_length;

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -2129,7 +2129,10 @@ int tls_free_buffers(OSSL_RECORD_LAYER *rl)
     /* Read direction */
 
     /* If we have pending data to be read then fail */
-    if (rl->curr_rec < rl->num_recs || TLS_BUFFER_get_left(&rl->rbuf) != 0)
+    if (rl->curr_rec < rl->num_recs
+            || rl->curr_rec != rl->num_released
+            || TLS_BUFFER_get_left(&rl->rbuf) != 0
+            || rl->rstate == SSL_ST_READ_BODY)
         return 0;
 
     return tls_release_read_buffer(rl);

--- a/test/helpers/ssltestlib.h
+++ b/test/helpers/ssltestlib.h
@@ -83,4 +83,6 @@ SSL_SESSION *create_a_psk(SSL *ssl, size_t mdsize);
 int ssl_ctx_add_large_cert_chain(OSSL_LIB_CTX *libctx, SSL_CTX *sctx,
                                  const char *cert_file);
 
+ENGINE *load_dasync(void);
+
 #endif /* OSSL_TEST_SSLTESTLIB_H */

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -11186,27 +11186,6 @@ end:
 #endif /* OSSL_NO_USABLE_TLS1_3 */
 
 #if !defined(OPENSSL_NO_TLS1_2) && !defined(OPENSSL_NO_DYNAMIC_ENGINE)
-
-static ENGINE *load_dasync(void)
-{
-    ENGINE *e;
-
-    if (!TEST_ptr(e = ENGINE_by_id("dasync")))
-        return NULL;
-
-    if (!TEST_true(ENGINE_init(e))) {
-        ENGINE_free(e);
-        return NULL;
-    }
-
-    if (!TEST_true(ENGINE_register_ciphers(e))) {
-        ENGINE_free(e);
-        return NULL;
-    }
-
-    return e;
-}
-
 /*
  * Test TLSv1.2 with a pipeline capable cipher. TLSv1.3 and DTLS do not
  * support this yet. The only pipeline capable cipher that we have is in the

--- a/test/sslbuffertest.c
+++ b/test/sslbuffertest.c
@@ -8,10 +8,19 @@
  * or in the file LICENSE in the source distribution.
  */
 
+/*
+ * We need access to the deprecated low level Engine APIs for legacy purposes
+ * when the deprecated calls are not hidden
+ */
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+# define OPENSSL_SUPPRESS_DEPRECATED
+#endif
+
 #include <string.h>
 #include <openssl/ssl.h>
 #include <openssl/bio.h>
 #include <openssl/err.h>
+#include <openssl/engine.h>
 
 /* We include internal headers so we can check if the buffers are allocated */
 #include "../ssl/ssl_local.h"
@@ -325,7 +334,13 @@ static int test_free_buffers(int test)
  end:
     SSL_free(clientssl);
     SSL_free(serverssl);
-
+#ifndef OPENSSL_NO_DYNAMIC_ENGINE
+    if (e != NULL) {
+        ENGINE_unregister_ciphers(e);
+        ENGINE_finish(e);
+        ENGINE_free(e);
+    }
+#endif
     return result;
 }
 

--- a/test/sslbuffertest.c
+++ b/test/sslbuffertest.c
@@ -195,7 +195,7 @@ static int test_free_buffers(int test)
     const char testdata[] = "Test data";
     char buf[120];
     size_t written, readbytes;
-    int pipeline = test > 3;
+    int i, pipeline = test > 3;
     ENGINE *e = NULL;
 
     if (pipeline) {
@@ -225,7 +225,7 @@ static int test_free_buffers(int test)
      * For the non-pipeline case we write one record. For pipelining we write
      * two records.
      */
-    for (int i = 0; i <= pipeline; i++) {
+    for (i = 0; i <= pipeline; i++) {
         if (!TEST_true(SSL_write_ex(clientssl, testdata, strlen(testdata),
                                     &written)))
             goto end;

--- a/test/sslbuffertest.c
+++ b/test/sslbuffertest.c
@@ -185,34 +185,65 @@ static int test_func(int test)
  * Test 2: Attempt to free buffers after a full record header but no record body
  * Test 3: Attempt to free buffers after a full record hedaer and partial record
  *         body
+ * Test 4-7: We repeat tests 0-3 but including data from a second pipelined
+ *           record
  */
 static int test_free_buffers(int test)
 {
     int result = 0;
     SSL *serverssl = NULL, *clientssl = NULL;
     const char testdata[] = "Test data";
-    char buf[40];
+    char buf[120];
     size_t written, readbytes;
+    int pipeline = test > 3;
+    ENGINE *e = NULL;
+
+    if (pipeline) {
+        e = load_dasync();
+        if (e == NULL)
+            goto end;
+        test -= 4;
+    }
 
     if (!TEST_true(create_ssl_objects(serverctx, clientctx, &serverssl,
                                       &clientssl, NULL, NULL)))
         goto end;
 
+    if (pipeline) {
+        if (!TEST_true(SSL_set_cipher_list(serverssl, "AES128-SHA"))
+                || !TEST_true(SSL_set_max_proto_version(serverssl,
+                                                        TLS1_2_VERSION))
+                || !TEST_true(SSL_set_max_pipelines(serverssl, 2)))
+            goto end;
+    }
+
     if (!TEST_true(create_ssl_connection(serverssl, clientssl,
                                          SSL_ERROR_NONE)))
         goto end;
 
-
-    if (!TEST_true(SSL_write_ex(clientssl, testdata, sizeof(testdata),
-                                &written)))
-        goto end;
+    /*
+     * For the non-pipeline case we write one record. For pipelining we write
+     * two records.
+     */
+    for (int i = 0; i <= pipeline; i++) {
+        if (!TEST_true(SSL_write_ex(clientssl, testdata, strlen(testdata),
+                                    &written)))
+            goto end;
+    }
 
     if (test == 0) {
+        size_t readlen = 1;
+
         /*
-        * Deliberately only read the first byte - so the remaining bytes are
-        * still buffered
-        */
-        if (!TEST_true(SSL_read_ex(serverssl, buf, 1, &readbytes)))
+         * Deliberately only read the first byte - so the remaining bytes are
+         * still buffered. In the pipelining case we read as far as the first
+         * byte from the second record.
+         */
+        if (pipeline)
+            readlen += strlen(testdata);
+
+        if (!TEST_true(SSL_read_ex(serverssl, buf, readlen, &readbytes))
+                || !TEST_size_t_eq(readlen, readbytes))
             goto end;
     } else {
         BIO *tmp;
@@ -240,16 +271,47 @@ static int test_free_buffers(int test)
             goto end;
         }
 
-        /* Put back just the partial record */
+        if (pipeline) {
+            /* We happen to know the first record is 57 bytes long */
+            const size_t first_rec_len = 57;
+
+            if (test != 3)
+                partial_len += first_rec_len;
+
+            /*
+             * Sanity check. If we got the record len right then this should
+             * never fail.
+             */
+            if (!TEST_int_eq(buf[first_rec_len], SSL3_RT_APPLICATION_DATA))
+                goto end;
+        }
+
+        /*
+         * Put back just the partial record (plus the whole initial record in
+         * the pipelining case)
+         */
         if (!TEST_true(BIO_write_ex(tmp, buf, partial_len, &written)))
             goto end;
 
-        /*
-         * Attempt a read. This should fail because only a partial record is
-         * available.
-         */
-        if (!TEST_false(SSL_read_ex(serverssl, buf, 1, &readbytes)))
-            goto end;
+        if (pipeline) {
+            /*
+             * Attempt a read. This should pass but only return data from the
+             * first record. Only a partial record is available for the second
+             * record.
+             */
+            if (!TEST_true(SSL_read_ex(serverssl, buf, sizeof(buf),
+                                        &readbytes))
+                    || !TEST_size_t_eq(readbytes, strlen(testdata)))
+                goto end;
+        } else {
+            /*
+            * Attempt a read. This should fail because only a partial record is
+            * available.
+            */
+            if (!TEST_false(SSL_read_ex(serverssl, buf, sizeof(buf),
+                                        &readbytes)))
+                goto end;
+        }
     }
 
     /*
@@ -290,7 +352,11 @@ int setup_tests(void)
     }
 
     ADD_ALL_TESTS(test_func, 9);
+#if !defined(OPENSSL_NO_TLS1_2) && !defined(OPENSSL_NO_DYNAMIC_ENGINE)
+    ADD_ALL_TESTS(test_free_buffers, 8);
+#else
     ADD_ALL_TESTS(test_free_buffers, 4);
+#endif
     return 1;
 }
 

--- a/test/sslbuffertest.c
+++ b/test/sslbuffertest.c
@@ -175,6 +175,98 @@ static int test_func(int test)
     return result;
 }
 
+/*
+ * Test that attempting to free the buffers at points where they cannot be freed
+ * works as expected
+ * Test 0: Attempt to free buffers after a full record has been processed, but
+ *         the application has only performed a partial read
+ * Test 1: Attempt to free buffers after only a partial record header has been
+ *         received
+ * Test 2: Attempt to free buffers after a full record header but no record body
+ * Test 3: Attempt to free buffers after a full record hedaer and partial record
+ *         body
+ */
+static int test_free_buffers(int test)
+{
+    int result = 0;
+    SSL *serverssl = NULL, *clientssl = NULL;
+    const char testdata[] = "Test data";
+    char buf[40];
+    size_t written, readbytes;
+
+    if (!TEST_true(create_ssl_objects(serverctx, clientctx, &serverssl,
+                                      &clientssl, NULL, NULL)))
+        goto end;
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl,
+                                         SSL_ERROR_NONE)))
+        goto end;
+
+
+    if (!TEST_true(SSL_write_ex(clientssl, testdata, sizeof(testdata),
+                                &written)))
+        goto end;
+
+    if (test == 0) {
+        /*
+        * Deliberately only read the first byte - so the remaining bytes are
+        * still buffered
+        */
+        if (!TEST_true(SSL_read_ex(serverssl, buf, 1, &readbytes)))
+            goto end;
+    } else {
+        BIO *tmp;
+        size_t partial_len;
+
+        /* Remove all the data that is pending for read by the server */
+        tmp = SSL_get_rbio(serverssl);
+        if (!TEST_true(BIO_read_ex(tmp, buf, sizeof(buf), &readbytes))
+                || !TEST_size_t_lt(readbytes, sizeof(buf))
+                || !TEST_size_t_gt(readbytes, SSL3_RT_HEADER_LENGTH))
+            goto end;
+
+        switch(test) {
+        case 1:
+            partial_len = SSL3_RT_HEADER_LENGTH - 1;
+            break;
+        case 2:
+            partial_len = SSL3_RT_HEADER_LENGTH;
+            break;
+        case 3:
+            partial_len = readbytes - 1;
+            break;
+        default:
+            TEST_error("Invalid test index");
+            goto end;
+        }
+
+        /* Put back just the partial record */
+        if (!TEST_true(BIO_write_ex(tmp, buf, partial_len, &written)))
+            goto end;
+
+        /*
+         * Attempt a read. This should fail because only a partial record is
+         * available.
+         */
+        if (!TEST_false(SSL_read_ex(serverssl, buf, 1, &readbytes)))
+            goto end;
+    }
+
+    /*
+     * Attempting to free the buffers at this point should fail because they are
+     * still in use
+     */
+    if (!TEST_false(SSL_free_buffers(serverssl)))
+        goto end;
+
+    result = 1;
+ end:
+    SSL_free(clientssl);
+    SSL_free(serverssl);
+
+    return result;
+}
+
 OPT_TEST_DECLARE_USAGE("certfile privkeyfile\n")
 
 int setup_tests(void)
@@ -198,6 +290,7 @@ int setup_tests(void)
     }
 
     ADD_ALL_TESTS(test_func, 9);
+    ADD_ALL_TESTS(test_free_buffers, 4);
     return 1;
 }
 


### PR DESCRIPTION
If we're part way through processing a record, or the application has
not released all the records then we should not free our buffer because
they are still needed.

CVE-2024-4741
