### PR TITLE
Only free the read buffers if we're not using them (3.1/3.0)

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -81,6 +81,15 @@ int RECORD_LAYER_read_pending(const RECORD_LAYER *rl)
     return SSL3_BUFFER_get_left(&rl->rbuf) != 0;
 }
 
+int RECORD_LAYER_data_present(const RECORD_LAYER *rl)
+{
+    if (rl->rstate == SSL_ST_READ_BODY)
+        return 1;
+    if (RECORD_LAYER_processed_read_pending(rl))
+        return 1;
+    return 0;
+}
+
 /* Checks if we have decrypted unread record data pending */
 int RECORD_LAYER_processed_read_pending(const RECORD_LAYER *rl)
 {

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -230,6 +230,12 @@ int ssl3_read_n(SSL *s, size_t n, size_t max, int extend, int clearold,
         /* ... now we can act as if 'extend' was set */
     }
 
+    if (!ossl_assert(s->rlayer.packet != NULL)) {
+        /* does not happen */
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return -1;
+    }
+
     len = s->rlayer.packet_length;
     pkt = rb->buf + align;
     /*

--- a/ssl/record/record.h
+++ b/ssl/record/record.h
@@ -205,6 +205,7 @@ void RECORD_LAYER_release(RECORD_LAYER *rl);
 int RECORD_LAYER_read_pending(const RECORD_LAYER *rl);
 int RECORD_LAYER_processed_read_pending(const RECORD_LAYER *rl);
 int RECORD_LAYER_write_pending(const RECORD_LAYER *rl);
+int RECORD_LAYER_data_present(const RECORD_LAYER *rl);
 void RECORD_LAYER_reset_read_sequence(RECORD_LAYER *rl);
 void RECORD_LAYER_reset_write_sequence(RECORD_LAYER *rl);
 int RECORD_LAYER_is_sslv2_record(RECORD_LAYER *rl);

--- a/ssl/record/ssl3_buffer.c
+++ b/ssl/record/ssl3_buffer.c
@@ -191,5 +191,7 @@ int ssl3_release_read_buffer(SSL *s)
         OPENSSL_cleanse(b->buf, b->len);
     OPENSSL_free(b->buf);
     b->buf = NULL;
+    s->rlayer.packet = NULL;
+    s->rlayer.packet_length = 0;
     return 1;
 }

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -5493,6 +5493,9 @@ int SSL_free_buffers(SSL *ssl)
     if (RECORD_LAYER_read_pending(rl) || RECORD_LAYER_write_pending(rl))
         return 0;
 
+    if (RECORD_LAYER_data_present(rl))
+        return 0;
+
     RECORD_LAYER_release(rl);
     return 1;
 }

--- a/test/helpers/ssltestlib.c
+++ b/test/helpers/ssltestlib.c
@@ -7,8 +7,17 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * We need access to the deprecated low level ENGINE APIs for legacy purposes
+ * when the deprecated calls are not hidden
+ */
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+# define OPENSSL_SUPPRESS_DEPRECATED
+#endif
+
 #include <string.h>
 
+#include <openssl/engine.h>
 #include "internal/nelem.h"
 #include "ssltestlib.h"
 #include "../testutil.h"
@@ -1181,4 +1190,28 @@ void shutdown_ssl_connection(SSL *serverssl, SSL *clientssl)
     SSL_shutdown(serverssl);
     SSL_free(serverssl);
     SSL_free(clientssl);
+}
+
+ENGINE *load_dasync(void)
+{
+#if !defined(OPENSSL_NO_TLS1_2) && !defined(OPENSSL_NO_DYNAMIC_ENGINE)
+    ENGINE *e;
+
+    if (!TEST_ptr(e = ENGINE_by_id("dasync")))
+        return NULL;
+
+    if (!TEST_true(ENGINE_init(e))) {
+        ENGINE_free(e);
+        return NULL;
+    }
+
+    if (!TEST_true(ENGINE_register_ciphers(e))) {
+        ENGINE_free(e);
+        return NULL;
+    }
+
+    return e;
+#else
+    return NULL;
+#endif
 }

--- a/test/helpers/ssltestlib.h
+++ b/test/helpers/ssltestlib.h
@@ -59,4 +59,5 @@ typedef struct mempacket_st MEMPACKET;
 
 DEFINE_STACK_OF(MEMPACKET)
 
+ENGINE *load_dasync(void);
 #endif /* OSSL_TEST_SSLTESTLIB_H */

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -10486,27 +10486,6 @@ end:
 #endif /* OSSL_NO_USABLE_TLS1_3 */
 
 #if !defined(OPENSSL_NO_TLS1_2) && !defined(OPENSSL_NO_DYNAMIC_ENGINE)
-
-static ENGINE *load_dasync(void)
-{
-    ENGINE *e;
-
-    if (!TEST_ptr(e = ENGINE_by_id("dasync")))
-        return NULL;
-
-    if (!TEST_true(ENGINE_init(e))) {
-        ENGINE_free(e);
-        return NULL;
-    }
-
-    if (!TEST_true(ENGINE_register_ciphers(e))) {
-        ENGINE_free(e);
-        return NULL;
-    }
-
-    return e;
-}
-
 /*
  * Test TLSv1.2 with a pipeline capable cipher. TLSv1.3 and DTLS do not
  * support this yet. The only pipeline capable cipher that we have is in the

--- a/test/sslbuffertest.c
+++ b/test/sslbuffertest.c
@@ -170,7 +170,7 @@ static int test_free_buffers(int test)
     const char testdata[] = "Test data";
     char buf[120];
     size_t written, readbytes;
-    int pipeline = test > 3;
+    int i, pipeline = test > 3;
     ENGINE *e = NULL;
 
     if (pipeline) {
@@ -200,7 +200,7 @@ static int test_free_buffers(int test)
      * For the non-pipeline case we write one record. For pipelining we write
      * two records.
      */
-    for (int i = 0; i <= pipeline; i++) {
+    for (i = 0; i <= pipeline; i++) {
         if (!TEST_true(SSL_write_ex(clientssl, testdata, strlen(testdata),
                                     &written)))
             goto end;

--- a/test/sslbuffertest.c
+++ b/test/sslbuffertest.c
@@ -8,10 +8,19 @@
  * or in the file LICENSE in the source distribution.
  */
 
+/*
+ * We need access to the deprecated low level Engine APIs for legacy purposes
+ * when the deprecated calls are not hidden
+ */
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+# define OPENSSL_SUPPRESS_DEPRECATED
+#endif
+
 #include <string.h>
 #include <openssl/ssl.h>
 #include <openssl/bio.h>
 #include <openssl/err.h>
+#include <openssl/engine.h>
 
 #include "internal/packet.h"
 
@@ -300,7 +309,13 @@ static int test_free_buffers(int test)
  end:
     SSL_free(clientssl);
     SSL_free(serverssl);
-
+#ifndef OPENSSL_NO_DYNAMIC_ENGINE
+    if (e != NULL) {
+        ENGINE_unregister_ciphers(e);
+        ENGINE_finish(e);
+        ENGINE_free(e);
+    }
+#endif
     return result;
 }
 


### PR DESCRIPTION
If we're part way through processing a record, or the application has
not released all the records then we should not free our buffer because
they are still needed.

CVE-2024-4741
