### PR TITLE
fips: explicitly setup cpuid when initialize

### DIFF
--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -695,6 +695,8 @@ int OSSL_provider_init_int(const OSSL_CORE_HANDLE *handle,
         }
     }
 
+    OPENSSL_cpuid_setup();
+
     /*  Create a context. */
     if ((*provctx = ossl_prov_ctx_new()) == NULL
             || (libctx = OSSL_LIB_CTX_new()) == NULL)


### PR DESCRIPTION
Fixes: #23979

Previously fips module relies on OPENSSL_cpuid_setup being used as constructor by the linker to correctly setup the capability vector, either via .section .init (for x86_64) or via `__attribute__((constructor))`.

This would make ld.so call OPENSSL_cpuid_setup before the init function for fips module. However, this early constructing behavior has several disadvantages:

1. Not all platform/toolchain supports such behavior

2. Initialisation sequence is not well defined, and some function might not be initialized when cpuid_setup is called

3. Implicit path is hard to maintain and debug

##### Test

I have tested this branch merged with #24403, and the riscvcap_P inside libcrypto/fips.so are both initialized. 

##### Uncertainties

1. Now cpuid_setup is put after function_id init, and before context/thread/self-test. Putting it before thread init comes from the below snippet, but I do not know whether to put it before context creation or not.

https://github.com/openssl/openssl/blob/a6afe2b29a7b77956ef888653849f8cc38e39106/crypto/init.c#L68-L74

2. This behavior should be documented somewhere, where should I put them.

3. Test and coverage for this also needs massive effort. The coverage is also a problem when we gradually remove the constructor behavior of all cpuid_setup (https://github.com/openssl/openssl/pull/24399#issuecomment-2114245767) 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
