### PR TITLE
DTLS 1.3: Place start of ClientHello correctly when calculating binder

### DIFF
--- a/crypto/packet.c
+++ b/crypto/packet.c
@@ -365,6 +365,12 @@ int WPACKET_finish(WPACKET *pkt)
 
 int WPACKET_start_sub_packet_len__(WPACKET *pkt, size_t lenbytes)
 {
+    return WPACKET_start_sub_packet_at_offset_len__(pkt, lenbytes, 0);
+}
+
+int WPACKET_start_sub_packet_at_offset_len__(WPACKET *pkt, size_t lenbytes,
+                                             size_t offset)
+{
     WPACKET_SUB *sub;
     unsigned char *lenchars;
 
@@ -381,7 +387,7 @@ int WPACKET_start_sub_packet_len__(WPACKET *pkt, size_t lenbytes)
 
     sub->parent = pkt->subs;
     pkt->subs = sub;
-    sub->pwritten = pkt->written + lenbytes;
+    sub->pwritten = pkt->written + lenbytes + offset;
     sub->lenbytes = lenbytes;
 
     if (lenbytes == 0) {
@@ -391,7 +397,8 @@ int WPACKET_start_sub_packet_len__(WPACKET *pkt, size_t lenbytes)
 
     sub->packet_len = pkt->written;
 
-    if (!WPACKET_allocate_bytes(pkt, lenbytes, &lenchars))
+    if (!WPACKET_allocate_bytes(pkt, lenbytes, &lenchars)
+            || (offset > 0 && !WPACKET_allocate_bytes(pkt, offset, &lenchars)))
         return 0;
 
     return 1;

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -184,6 +184,10 @@ __owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
                            (c)[1]=(unsigned char)(((l)>> 8)&0xff), \
                            (c)[2]=(unsigned char)(((l)    )&0xff)),(c)+=3)
 
+#define l3n2(c,l)       (l =((uint64_t)(*((c)++)))<<16, \
+                         l|=((uint64_t)(*((c)++)))<< 8, \
+                         l|=((uint64_t)(*((c)++))))
+
 static ossl_inline int ossl_ends_with_dirsep(const char *path)
 {
     if (*path != '\0')

--- a/include/internal/packet.h
+++ b/include/internal/packet.h
@@ -766,6 +766,18 @@ int WPACKET_fill_lengths(WPACKET *pkt);
 
 /*
  * Initialise a new sub-packet. Additionally |lenbytes| of data is preallocated
+ * at the current position in |pkt| to store the sub-packets length once we know
+ * it. The sub-packet start is set at |offset| from current position in |pkt|
+ * Don't call this directly. Use the convenience macros below instead.
+ */
+int WPACKET_start_sub_packet_at_offset_len__(WPACKET *pkt, size_t lenbytes,
+                                             size_t offset);
+
+#define WPACKET_start_sub_packet_u24_at_offset(pkt, offset) \
+    WPACKET_start_sub_packet_at_offset_len__((pkt), 3, (offset))
+
+/*
+ * Initialise a new sub-packet. Additionally |lenbytes| of data is preallocated
  * at the start of the sub-packet to store its length once we know it. Don't
  * call this directly. Use the convenience macros below instead.
  */

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1535,8 +1535,8 @@ int tls_psk_do_binder(SSL_CONNECTION *s, const EVP_MD *md,
     static const unsigned char resumption_label[] = "\x72\x65\x73\x20\x62\x69\x6E\x64\x65\x72";
     /* ASCII: "ext binder", in hex for EBCDIC compatibility */
     static const unsigned char external_label[] = "\x65\x78\x74\x20\x62\x69\x6E\x64\x65\x72";
-    const unsigned char *label;
-    size_t bindersize, labelsize, hashsize;
+    const unsigned char *label, *msgbodystart;
+    size_t bindersize, labelsize, hashsize, msgbodylen;
     int hashsizei = EVP_MD_get_size(md);
     int ret = -1;
     int usepskfored = 0;
@@ -1654,7 +1654,23 @@ int tls_psk_do_binder(SSL_CONNECTION *s, const EVP_MD *md,
         }
     }
 
-    if (EVP_DigestUpdate(mctx, msgstart, binderoffset) <= 0
+    if (SSL_CONNECTION_IS_DTLS(s)) {
+        msgbodystart = msgstart + DTLS1_HM_HEADER_LENGTH;
+        msgbodylen = binderoffset - DTLS1_HM_HEADER_LENGTH;
+    } else {
+        msgbodystart = msgstart + SSL3_HM_HEADER_LENGTH;
+        msgbodylen = binderoffset - SSL3_HM_HEADER_LENGTH;
+    }
+
+    /*
+     * RFC9147 (DTLSv1.3)
+     * The transcript consists of complete TLS Handshake messages
+     * (reassembled as necessary). Note that this requires removing the
+     * message_seq, fragment_offset, and fragment_length fields to create
+     * the Handshake structure.
+     */
+    if (EVP_DigestUpdate(mctx, msgstart, SSL3_HM_HEADER_LENGTH) <= 0
+            || EVP_DigestUpdate(mctx, msgbodystart, msgbodylen) <= 0
             || EVP_DigestFinal_ex(mctx, hash, NULL) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -1206,6 +1206,14 @@ EXT_RETURN tls_construct_ctos_psk(SSL_CONNECTION *s, WPACKET *pkt,
 
     msgstart = WPACKET_get_curr(pkt) - msglen;
 
+    /*
+     * difference in dtls1_set_handshake_header() vs ssl3_set_handshake_header()?
+     */
+    if (SSL_CONNECTION_IS_DTLS(s)) {
+        msgstart += DTLS1_HM_HEADER_LENGTH;
+        binderoffset -= DTLS1_HM_HEADER_LENGTH;
+    }
+
     if (dores
             && tls_psk_do_binder(s, mdres, msgstart, binderoffset, NULL,
                                  resbinder, s->session, 1, 0) != 1) {

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -1206,17 +1206,8 @@ EXT_RETURN tls_construct_ctos_psk(SSL_CONNECTION *s, WPACKET *pkt,
 
     msgstart = WPACKET_get_curr(pkt) - msglen;
 
-    /*
-     * difference in dtls1_set_handshake_header() vs ssl3_set_handshake_header()?
-     */
-    if (SSL_CONNECTION_IS_DTLS(s)) {
-        msgstart += DTLS1_HM_HEADER_LENGTH;
-        binderoffset -= DTLS1_HM_HEADER_LENGTH;
-    }
-
-    if (dores
-            && tls_psk_do_binder(s, mdres, msgstart, binderoffset, NULL,
-                                 resbinder, s->session, 1, 0) != 1) {
+    if (dores && tls_psk_do_binder(s, mdres, msgstart, binderoffset, NULL,
+                                   resbinder, s->session, 1, 0) != 1) {
         /* SSLfatal() already called */
         return EXT_RETURN_FAIL;
     }

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -1248,17 +1248,8 @@ int tls_parse_ctos_psk(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
 
     msgstart = (unsigned char *)s->init_buf->data;
 
-    /*
-     * difference in dtls1_set_handshake_header() vs ssl3_set_handshake_header()?
-     */
-    if (SSL_CONNECTION_IS_DTLS(s)) {
-        msgstart += DTLS1_HM_HEADER_LENGTH;
-        binderoffset -= DTLS1_HM_HEADER_LENGTH;
-    }
-
-    if (tls_psk_do_binder(s, md, msgstart,
-                          binderoffset, PACKET_data(&binder), NULL, sess, 0,
-                          ext) != 1) {
+    if (tls_psk_do_binder(s, md, msgstart, binderoffset, PACKET_data(&binder),
+                          NULL, sess, 0, ext) != 1) {
         /* SSLfatal() already called */
         goto err;
     }

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -1030,7 +1030,6 @@ int tls_parse_ctos_psk(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
     const EVP_MD *md = NULL;
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
     SSL *ssl = SSL_CONNECTION_GET_SSL(s);
-    unsigned char *msgstart = NULL;
 
     /*
      * If we have no PSK kex mode that we recognise then we can't resume so
@@ -1245,11 +1244,9 @@ int tls_parse_ctos_psk(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
         SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_BAD_EXTENSION);
         goto err;
     }
-
-    msgstart = (unsigned char *)s->init_buf->data;
-
-    if (tls_psk_do_binder(s, md, msgstart, binderoffset, PACKET_data(&binder),
-                          NULL, sess, 0, ext) != 1) {
+    if (tls_psk_do_binder(s, md, (const unsigned char *)s->init_buf->data,
+                          binderoffset, PACKET_data(&binder), NULL, sess, 0,
+                          ext) != 1) {
         /* SSLfatal() already called */
         goto err;
     }

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -152,9 +152,10 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
     } else if (ossl_assert(type == SSL3_RT_CHANGE_CIPHER_SPEC)) {
         msg_type = SSL3_MT_CCS;
         msg_len = 0; /* SSL3_RT_CHANGE_CIPHER_SPEC */
-    } else
+    } else {
         /* Other record types are not supported */
         return -1;
+    }
 
     if (!dtls1_query_mtu(s))
         return -1;

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -140,11 +140,11 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
     size_t written;
     size_t curr_mtu;
     int retry = 1;
-    size_t len, overhead, used_len, msg_len = 0;
+    size_t len, overhead, used_len, msg_len;
     SSL *ssl = SSL_CONNECTION_GET_SSL(s);
     unsigned char *data = (unsigned char *)s->init_buf->data;
     unsigned short msg_seq = s->d1->w_msg_hdr.seq;
-    unsigned char msg_type = 0;
+    unsigned char msg_type;
 
     if (type == SSL3_RT_HANDSHAKE) {
         msg_type = *data++;
@@ -152,7 +152,9 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
     } else if (ossl_assert(type == SSL3_RT_CHANGE_CIPHER_SPEC)) {
         msg_type = SSL3_MT_CCS;
         msg_len = 0; /* SSL3_RT_CHANGE_CIPHER_SPEC */
-    }
+    } else
+        /* Other record types are not supported */
+        return -1;
 
     if (!dtls1_query_mtu(s))
         return -1;

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -223,6 +223,8 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
          * XDTLS: this function is too long.  split out the CCS part
          */
         if (type == SSL3_RT_HANDSHAKE) {
+            unsigned char *p = (unsigned char *)&s->init_buf->data[s->init_off];
+
             if (len < DTLS1_HM_HEADER_LENGTH) {
                 /*
                  * len is so small that we really can't do anything sensible
@@ -230,7 +232,6 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
                  */
                 return -1;
             }
-            unsigned char *p = (unsigned char *)&s->init_buf->data[s->init_off];
 
             *p++ = msg_type;
             l2n3(msg_len, p);

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -96,6 +96,29 @@ void dtls1_hm_fragment_free(hm_fragment *frag)
     OPENSSL_free(frag);
 }
 
+static int dtls1_write_hm_header(unsigned char *msgheaderstart,
+                                 unsigned char msg_type, size_t msg_len,
+                                 unsigned short msg_seq, size_t fragoff,
+                                 size_t fraglen)
+{
+    WPACKET msgheader;
+    size_t msgheaderlen;
+
+    if (!WPACKET_init_static_len(&msgheader, msgheaderstart,
+                                 DTLS1_HM_HEADER_LENGTH, 0)
+        || !WPACKET_put_bytes_u8(&msgheader, msg_type)
+        || !WPACKET_put_bytes_u24(&msgheader, msg_len)
+        || !WPACKET_put_bytes_u16(&msgheader, msg_seq)
+        || !WPACKET_put_bytes_u24(&msgheader, fragoff)
+        || !WPACKET_put_bytes_u24(&msgheader, fraglen)
+        || !WPACKET_get_total_written(&msgheader, &msgheaderlen)
+        || msgheaderlen != DTLS1_HM_HEADER_LENGTH
+        || !WPACKET_finish(&msgheader))
+        return 0;
+
+    return 1;
+}
+
 /*
  * send s->init_buf in records of type 'type' (SSL3_RT_HANDSHAKE or
  * SSL3_RT_CHANGE_CIPHER_SPEC)
@@ -149,6 +172,8 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
 
     /* s->init_num shouldn't ever be < 0...but just in case */
     while (s->init_num > 0) {
+        unsigned char *msgstart;
+
         if (type == SSL3_RT_HANDSHAKE && s->init_off > 0) {
             /*
              * We must be writing a fragment other than the first one
@@ -204,29 +229,25 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
         if (len > ssl_get_max_send_fragment(s))
             len = ssl_get_max_send_fragment(s);
 
-        /*
-         * XDTLS: this function is too long.  split out the CCS part
-         */
-        if (type == SSL3_RT_HANDSHAKE) {
-            unsigned char *p = (unsigned char *)&s->init_buf->data[s->init_off];
+        msgstart = (unsigned char *)&s->init_buf->data[s->init_off];
 
-            if (len < DTLS1_HM_HEADER_LENGTH) {
+        if (type == SSL3_RT_HANDSHAKE) {
+            const size_t fragoff = s->init_off;
+            const size_t fraglen = len - DTLS1_HM_HEADER_LENGTH;
+
+            if (len < DTLS1_HM_HEADER_LENGTH
+                    || !dtls1_write_hm_header(msgstart, msg_type, msg_len,
+                                              msg_seq, fragoff, fraglen))
                 /*
                  * len is so small that we really can't do anything sensible
                  * so fail
                  */
                 return -1;
-            }
-
-            *p++ = msg_type;
-            l2n3(msg_len, p);
-            s2n(msg_seq, p);
-            l2n3(s->init_off, p);
-            l2n3(len - DTLS1_HM_HEADER_LENGTH, p);
         }
-        unsigned char *msgstart = (unsigned char *)&s->init_buf->data[s->init_off];
 
-        if (dtls1_write_bytes(s, type, msgstart, len, &written) <= 0) {
+        ret = dtls1_write_bytes(s, type, msgstart, len, &written);
+
+        if (ret <= 0) {
             /*
              * might need to update MTU here, but we don't know which
              * previous packet caused the failure -- so can't really
@@ -272,12 +293,10 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
                      * reconstruct message header is if it is being sent in
                      * single fragment
                      */
-                    *msgstart++ = msg_type;
-                    l2n3(msg_len, msgstart);
-                    s2n(msg_seq, msgstart);
-                    l2n3(0, msgstart);
-                    l2n3(msg_len, msgstart);
-                    msgstart -= DTLS1_HM_HEADER_LENGTH;
+                    if (!dtls1_write_hm_header(msgstart, msg_type, msg_len,
+                                               msg_seq, s->init_off, msg_len))
+                        return -1;
+
                     xlen = written;
                 } else {
                     msgstart += DTLS1_HM_HEADER_LENGTH;

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -140,11 +140,11 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
     size_t written;
     size_t curr_mtu;
     int retry = 1;
-    size_t len, overhead, used_len, msg_len;
+    size_t len, overhead, used_len, msg_len = 0;
     SSL *ssl = SSL_CONNECTION_GET_SSL(s);
     unsigned char *data = (unsigned char *)s->init_buf->data;
     unsigned short msg_seq = s->d1->w_msg_hdr.seq;
-    unsigned char msg_type;
+    unsigned char msg_type = 0;
 
     if (type == SSL3_RT_HANDSHAKE) {
         msg_type = *data++;

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -129,7 +129,7 @@ int tls_close_construct_packet(SSL_CONNECTION *s, WPACKET *pkt, int htype)
             || !WPACKET_get_length(pkt, &msglen)
             || msglen > INT_MAX)
         return 0;
-    s->init_num = (int)msglen;
+    s->init_num = msglen;
     s->init_off = 0;
 
     return 1;

--- a/test/dtls_mtu_test.c
+++ b/test/dtls_mtu_test.c
@@ -66,6 +66,18 @@ static int mtu_test(SSL_CTX *ctx, const char *cs, int no_etm)
     if (no_etm)
         SSL_set_options(srvr_ssl, SSL_OP_NO_ENCRYPT_THEN_MAC);
 
+#ifndef OPENSSL_NO_SCTP
+    /**
+     * TODO(DTLSv1.3): Fix SCTP support
+     * This test is failing on exporting the sctp auth key on server and client
+     * because ossl_statem_export_allowed() fails.
+     * ossl_statem_server_post_work:internal error:ssl/statem/statem_srvr.c:937:
+     * and
+     * tls_process_server_hello:internal error:ssl/statem/statem_clnt.c:1763:
+     */
+    OPENSSL_assert(SSL_set_max_proto_version(clnt_ssl, DTLS1_2_VERSION) == 1);
+#endif
+
     if (!TEST_true(SSL_set_cipher_list(srvr_ssl, cs))
             || !TEST_true(SSL_set_cipher_list(clnt_ssl, cs))
             || !TEST_ptr(sc_bio = SSL_get_rbio(srvr_ssl))

--- a/test/ssl-tests/29-dtls-sctp-label-bug.cnf.in
+++ b/test/ssl-tests/29-dtls-sctp-label-bug.cnf.in
@@ -42,6 +42,7 @@ our @tests = (
     },
     {
         name => "SCTPLabelBug-bad1",
+        # TODO(DTLSv1.3): Fix SCTP support
         server => {
             MaxProtocol => "DTLSv1.2"
         },
@@ -56,6 +57,7 @@ our @tests = (
     },
     {
         name => "SCTPLabelBug-bad2",
+        # TODO(DTLSv1.3): Fix SCTP support
         server => {
             MaxProtocol => "DTLSv1.2"
         },


### PR DESCRIPTION
I found out that the msgstart and the binderoffset are calculated incorrectly for DTLS 1.3. I'm not sure exactly why, but it seems like it is off with the size of the handshake message header. Maybe you have a suggestion to a better fix than my original commit? It also appears that the maxfragmentlen is parsed wrongly.