### PR TITLE
[Docs] Default value for verification flags is 'SSL_VERIFY_NONE'

### DIFF
--- a/doc/man3/SSL_CTX_set_verify.pod
+++ b/doc/man3/SSL_CTX_set_verify.pod
@@ -144,6 +144,9 @@ B<Client mode:> ignored (see BUGS)
 
 If the B<mode> is SSL_VERIFY_NONE none of the other flags may be set.
 
+If verification flags are not modified explicitly by C<SSL_CTX_set_verify()>
+or C<SSL_set_verify()>, the default value will be SSL_VERIFY_NONE.
+
 The actual verification procedure is performed either using the built-in
 verification procedure or using another application provided verification
 function set with


### PR DESCRIPTION
- [x] documentation is added or updated
