### PR TITLE
stricter parser for ipv4_from_asc

### DIFF
--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -58,22 +58,92 @@ static IP_TESTDATA a2i_ipaddress_tests[] = {
     {"127.0.0.1", "\x7f\x00\x00\x01", 4},
     {"1.2.3.4", "\x01\x02\x03\x04", 4},
     {"1.2.3.255", "\x01\x02\x03\xff", 4},
-    {"1.2.3", NULL, 0},
-    {"1.2.3 .4", NULL, 0},
+    {"255.255.255.255", "\xff\xff\xff\xff", 4},
 
+    {"::", "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 16},
     {"::1", "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01", 16},
+    {"::01", "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01", 16},
+    {"::0001", "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01", 16},
+    {"ffff::", "\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 16},
+    {"ffff::1", "\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01", 16},
+    {"1::2", "\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02", 16},
     {"1:1:1:1:1:1:1:1", "\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01", 16},
     {"2001:db8::ff00:42:8329", "\x20\x01\x0d\xb8\x00\x00\x00\x00\x00\x00\xff\x00\x00\x42\x83\x29", 16},
+    {"::1.2.3.4", "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x03\x04", 16},
+    {"ffff:ffff:ffff:ffff:ffff:ffff:1.2.3.4", "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01\x02\x03\x04", 16},
+
     {"1:1:1:1:1:1:1:1.test", NULL, 0},
     {":::1", NULL, 0},
     {"2001::123g", NULL, 0},
 
-    {"example.test", NULL, 0},
-    {"", NULL, 0},
+    /* Too few IPv4 components. */
+    {"1", NULL, 0 },
+    {"1.", NULL, 0 },
+    {"1.2", NULL, 0 },
+    {"1.2.", NULL, 0 },
+    {"1.2.3", NULL, 0 },
+    {"1.2.3.", NULL, 0 },
 
-    {"1.2.3.4 ", "\x01\x02\x03\x04", 4},
-    {" 1.2.3.4", "\x01\x02\x03\x04", 4},
-    {" 1.2.3.4 ", "\x01\x02\x03\x04", 4},
+    /* Invalid embedded IPv4 address. */
+    {"::1.2.3", NULL, 0 },
+
+    /* IPv4 literals take the place of two IPv6 components. */
+    {"1:2:3:4:5:6:7:1.2.3.4", NULL, 0 },
+
+    /* '::' should have fewer than 16 components or it is redundant. */
+    {"1:2:3:4:5:6:7::8", NULL, 0 },
+
+    /* Embedded IPv4 addresses must be at the end. */
+    {"::1.2.3.4:1", NULL, 0 },
+
+    /* Too many components. */
+    {"1.2.3.4.5", NULL, 0 },
+    {"1:2:3:4:5:6:7:8:9", NULL, 0 },
+    {"1:2:3:4:5::6:7:8:9", NULL, 0 },
+
+    /* Stray whitespace or other invalid characters. */
+    {"1.2.3.4 ", NULL, 0 },
+    {"1.2.3 .4", NULL, 0 },
+    {"1.2.3. 4", NULL, 0 },
+    {" 1.2.3.4", NULL, 0 },
+    {"1.2.3.4.", NULL, 0 },
+    {"1.2.3.+4", NULL, 0 },
+    {"1.2.3.-4", NULL, 0 },
+    {"1.2.3.4.example.test", NULL, 0 },
+    {"::1 ", NULL, 0 },
+    {" ::1", NULL, 0 },
+    {":: 1", NULL, 0 },
+    {": :1", NULL, 0 },
+    {"1.2.3.nope", NULL, 0 },
+    {"::nope", NULL, 0 },
+
+    /* Components too large. */
+    {"1.2.3.256", NULL, 0},  /* Overflows when adding */
+    {"1.2.3.260", NULL, 0},  /* Overflows when multiplying by 10 */
+    {"1.2.3.999999999999999999999999999999999999999999", NULL, 0 },
+    {"::fffff", NULL, 0 },
+
+    /* Although not an overflow, more than four hex digits is an error. */
+    {"::00000", NULL, 0 },
+
+    /* Too many colons. */
+    {":::", NULL, 0 },
+    {"1:::", NULL, 0 },
+    {":::2", NULL, 0 },
+    {"1:::2", NULL, 0 },
+
+    /* Only one group of zeros may be elided. */
+    {"1::2::3", NULL, 0 },
+
+    /* We only support decimal. */
+    {"1.2.3.01", NULL, 0 },
+    {"1.2.3.0x1", NULL, 0 },
+
+    /* Random garbage. */
+    {"example.test", NULL, 0 },
+    {"", NULL, 0},
+    {" 1.2.3.4", NULL, 0},
+    {" 1.2.3.4 ", NULL, 0},
     {"1.2.3.4.example.test", NULL, 0},
 };
 


### PR DESCRIPTION
reject invalid IPv4 addresses in ipv4_from_asc

The old scanf-based parser accepted all kinds of invalid inputs like: "1.2.3.4.5"
"1.2.3.4 "
"1.2.3. 4"
" 1.2.3.4"
"1.2.3.4."
"1.2.3.+4"
"1.2.3.4.example.test"
"1.2.3.01"
"1.2.3.0x1"
Thanks to Amir Mohamadi for pointing this out.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
