### PR TITLE
Added an explicit yield (OP_SLEEP) to QUIC testing for cooperative threads

### DIFF
--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2376,6 +2376,7 @@ static const struct script_op script_10[] = {
 static const struct script_op script_11_child[] = {
     OP_C_ACCEPT_STREAM_WAIT (a)
     OP_C_READ_EXPECT        (a, "foo", 3)
+    OP_SLEEP                (10)
     OP_C_EXPECT_FIN         (a)
 
     OP_END


### PR DESCRIPTION
This is required for PUT models as a yield is required to catch the finalization (FIN) packet. Otherwise the test_quic_multistream test fails because the FIN is sometimes too slow to be read.

Fixes: #24442

Signed-off-by: Randall S. Becker <randall.becker@nexbridge.ca>