### PR TITLE
fix potential memory leak OSSL_IETF_ATTR_SYNTAX_add1_value()

### DIFF
--- a/crypto/x509/x_ietfatt.c
+++ b/crypto/x509/x_ietfatt.c
@@ -174,6 +174,7 @@ int OSSL_IETF_ATTR_SYNTAX_add1_value(OSSL_IETF_ATTR_SYNTAX *a, int type,
         val->u.string = data;
         break;
     default:
+        OSSL_IETF_ATTR_SYNTAX_VALUE_free(val);
         ERR_raise(ERR_LIB_X509V3, ERR_R_PASSED_INVALID_ARGUMENT);
         return 0;
     }


### PR DESCRIPTION
The function may leak memory if it deals with an unknown type. issue reported by LuMingYinDetect.

Fixes #24452

