### PR TITLE
fix potential memory leak in PKCS12_add_key_ex()

### DIFF
--- a/crypto/pkcs12/p12_crt.c
+++ b/crypto/pkcs12/p12_crt.c
@@ -249,16 +249,19 @@ PKCS12_SAFEBAG *PKCS12_add_key_ex(STACK_OF(PKCS12_SAFEBAG) **pbags,
     if (key_usage && !PKCS8_add_keyusage(p8, key_usage))
         goto err;
     if (nid_key != -1) {
+        /* This call does not take ownership of p8 */
         bag = PKCS12_SAFEBAG_create_pkcs8_encrypt_ex(nid_key, pass, -1, NULL, 0,
                                                      iter, p8, ctx, propq);
-        PKCS8_PRIV_KEY_INFO_free(p8);
-    } else
+    } else {
         bag = PKCS12_SAFEBAG_create0_p8inf(p8);
+        if (bag != NULL)
+           p8 = NULL; /* bag takes ownership of p8 */
+    }
+    /* This does not need to be in the error path */
+    if (p8 != NULL)
+        PKCS8_PRIV_KEY_INFO_free(p8);
 
-    if (!bag)
-        goto err;
-
-    if (!pkcs12_add_bag(pbags, bag))
+    if (bag == NULL || !pkcs12_add_bag(pbags, bag))
         goto err;
 
     return bag;


### PR DESCRIPTION
function must make sure memorry allocated for `p8` gets freed in error path. Issue reported by LuMingYinDetect

Fixes #24453

