### PR TITLE
VMS: Redefine _XOPEN_SOURCE_EXTENDED with the value 1

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -2061,7 +2061,8 @@ my %targets = (
                               ? "/WARNINGS=DISABLE=(".join(",",@warnings).")" : (); }),
         cflag_incfirst   => '/FIRST_INCLUDE=',
         lib_defines      =>
-            add("OPENSSL_USE_NODELETE", "_XOPEN_SOURCE", "_XOPEN_SOURCE_EXTENDED",
+            add("OPENSSL_USE_NODELETE",
+                "_XOPEN_SOURCE", "_XOPEN_SOURCE_EXTENDED=1",
                 sub {
                     return vms_info()->{def_zlib}
                         ? "LIBZ=\"\"\"".vms_info()->{def_zlib}."\"\"\"" : ();


### PR DESCRIPTION
Some versions if the VMS C system header files seem to require this.

Fixes #24466
