### PR TITLE
VMS: Redefine _XOPEN_SOURCE_EXTENDED with the value 1 in apps/ocsp.c

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -11,7 +11,7 @@
 
 #ifdef OPENSSL_SYS_VMS
   /* So fd_set and friends get properly defined on OpenVMS */
-# define _XOPEN_SOURCE_EXTENDED
+# define _XOPEN_SOURCE_EXTENDED 1
 #endif
 
 #include <stdio.h>


### PR DESCRIPTION
Fixes #24466 on release older than 3.3.
