### PR TITLE
Random byte generation provider API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,13 @@ OpenSSL 3.5
 
 ### Changes between 3.4 and 3.5 [xx XXX xxxx]
 
+* A new random generation API has been introduced which modifies all
+  of the L<RAND_bytes(3)> family of calls so they are routed through a
+  specific named provider instead of being resolved via the normal DRBG
+  chaining.  In a future OpenSSL release, this will obsolete RAND_METHOD.
+
+  *Dr Paul Dale*
+
 * New inline functions were added to support loads and stores of unsigned
   16-bit, 32-bit and 64-bit integers in either little-endian or big-endian
   form, regardless of the host byte-order.  See the `OPENSSL_load_u16_le(3)`

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -175,6 +175,7 @@ struct ossl_provider_st {
     OSSL_FUNC_provider_get_params_fn *get_params;
     OSSL_FUNC_provider_get_capabilities_fn *get_capabilities;
     OSSL_FUNC_provider_self_test_fn *self_test;
+    OSSL_FUNC_provider_random_fn *random;
     OSSL_FUNC_provider_query_operation_fn *query_operation;
     OSSL_FUNC_provider_unquery_operation_fn *unquery_operation;
 
@@ -1067,6 +1068,9 @@ static int provider_init(OSSL_PROVIDER *prov)
                 prov->self_test =
                     OSSL_FUNC_provider_self_test(provider_dispatch);
                 break;
+            case OSSL_FUNC_PROVIDER_RANDOM:
+                prov->random = OSSL_FUNC_provider_random(provider_dispatch);
+                break;
             case OSSL_FUNC_PROVIDER_GET_CAPABILITIES:
                 prov->get_capabilities =
                     OSSL_FUNC_provider_get_capabilities(provider_dispatch);
@@ -1860,6 +1864,13 @@ int ossl_provider_self_test(const OSSL_PROVIDER *prov)
  * If tracing is enabled, a message is printed indicating the requested
  * capabilities.
  */
+int ossl_provider_random(const OSSL_PROVIDER *prov, int which, void *buf, size_t n,
+                         unsigned int strength)
+{
+    return prov->random == NULL ? 0 : prov->random(prov->provctx, which, buf, n,
+                                                   strength);
+}
+
 int ossl_provider_get_capabilities(const OSSL_PROVIDER *prov,
                                    const char *capability,
                                    OSSL_CALLBACK *cb,

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -122,7 +122,7 @@ static const char random_provider_fips_name[] = "fips";
 static int set_random_provider_name(RAND_GLOBAL *dgbl, const char *name)
 {
     if (dgbl->random_provider_name != NULL
-            && strcmp(dgbl->random_provider_name, name) == 0)
+            && OPENSSL_strcasecmp(dgbl->random_provider_name, name) == 0)
         return 1;
 
     OPENSSL_free(dgbl->random_provider_name);

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -17,6 +17,7 @@ ossl_provider_libctx,
 ossl_provider_teardown, ossl_provider_gettable_params,
 ossl_provider_get_params,
 ossl_provider_query_operation, ossl_provider_unquery_operation,
+ossl_provider_random_bytes,
 ossl_provider_set_operation_bit, ossl_provider_test_operation_bit,
 ossl_provider_get_capabilities
 - internal provider routines
@@ -86,6 +87,8 @@ ossl_provider_get_capabilities
  void ossl_provider_unquery_operation(const OSSL_PROVIDER *prov,
                                       int operation_id,
                                       const OSSL_ALGORITHM *algs);
+ int ossl_provider_random_bytes(const OSSL_PROVIDER *prov, int which,
+                                void *buf, size_t n, unsigned int strength);
 
  int ossl_provider_set_operation_bit(OSSL_PROVIDER *provider, size_t bitnum);
  int ossl_provider_test_operation_bit(OSSL_PROVIDER *provider, size_t bitnum,
@@ -276,6 +279,26 @@ ossl_provider_unquery_operation() informs the provider that the result of
 ossl_provider_query_operation() is no longer going to be directly accessed and
 that all relevant information has been copied.
 
+ossl_provider_random_bytes() queries the provider, I<prov>, randomness
+source for I<n> bytes of entropy which are returned in the buffer
+I<buf>, the returned entropy will have a number of bits of I<strength>.
+The entropy is drawn from the source, I<which>, which can be:
+
+=over 4
+
+=item *
+
+OSSL_PROV_RANDOM_PUBLIC for a source equivalent to L<RAND_bytes(3)> or
+
+=item *
+
+.OSSL_PROV_RANDOM_PRIVATE for a source equivalent to L<RAND_priv_bytes(3)>.
+
+=back
+
+Specifying other values for I<which> will result in an unspecified source but will
+not result in an error.
+
 ossl_provider_set_operation_bit() registers a 1 for operation I<bitnum>
 in a bitstring that's internal to I<provider>.
 
@@ -363,6 +386,9 @@ return 1 on success, or 0 on error.
 ossl_provider_get_capabilities() returns 1 on success, or 0 on error.
 If this function isn't available in the provider or the provider does not
 support the requested capability then 0 is returned.
+
+ossl_provider_random_bytes() returns 1 on success or 0 or -1 on error as per
+L<RAND_bytes(3)>.
 
 =head1 SEE ALSO
 

--- a/doc/man3/RAND_bytes.pod
+++ b/doc/man3/RAND_bytes.pod
@@ -3,7 +3,7 @@
 =head1 NAME
 
 RAND_bytes, RAND_priv_bytes, RAND_bytes_ex, RAND_priv_bytes_ex,
-RAND_pseudo_bytes - generate random data
+RAND_pseudo_bytes, RAND_set1_random_provider - generate random data
 
 =head1 SYNOPSIS
 
@@ -16,6 +16,8 @@ RAND_pseudo_bytes - generate random data
                    unsigned int strength);
  int RAND_priv_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, size_t num,
                         unsigned int strength);
+
+ int RAND_set1_random_provider(OSSL_LIB_CTX *ctx, OSSL_PROVIDER *p);
 
 The following function has been deprecated since OpenSSL 1.1.0, and can be
 hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
@@ -46,6 +48,12 @@ If the default RAND_METHOD has been changed then for compatibility reasons the
 RAND_METHOD will be used in preference and the DRBG of the library context
 ignored.
 
+RAND_set1_random_provider() specifies a provider, I<prov>, which will be used
+by the library context I<ctx> for all of the generate calls above instead
+of the built-in in DRBGs and entropy source.  Pass NULL for the provider
+to disable the random provider functionality.  In this case, the built-in DRBGs
+and entropy source will be used.  This call should not be considered thread safe.
+
 =head1 NOTES
 
 By default, the OpenSSL CSPRNG supports a security level of 256 bits, provided it
@@ -72,6 +80,8 @@ return 1 on success, -1 if not supported by the current
 RAND method, or 0 on other failure. The error code can be
 obtained by L<ERR_get_error(3)>.
 
+RAND_set1_random_provider() returns 1 on success and 0 on failure.
+
 =head1 SEE ALSO
 
 L<RAND_add(3)>,
@@ -96,6 +106,10 @@ The RAND_priv_bytes() function was added in OpenSSL 1.1.1.
 =item *
 
 The RAND_bytes_ex() and RAND_priv_bytes_ex() functions were added in OpenSSL 3.0
+
+=item *
+
+The RAND_set1_random_provider() function was added in OpenSSL 3.5
 
 =back
 

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -478,6 +478,12 @@ to access the same randomness sources from outside the validated boundary.
 
 This sets the property query used when fetching the randomness source.
 
+=item B<random_provider>
+
+This sets the provider to use for the L<RAND_bytes(3)> calls instead of the built-in
+entropy sources.  It defaults to "fips".  If the named provider is not loaded, the
+built-in entropy sources will be used.
+
 =back
 
 =head1 EXAMPLES
@@ -581,6 +587,7 @@ L<ASN1_generate_nconf(3)>,
 L<EVP_set_default_properties(3)>,
 L<CONF_modules_load(3)>,
 L<CONF_modules_load_file(3)>,
+L<RAND_bytes(3)>,
 L<fips_config(5)>, and
 L<x509v3_config(5)>.
 

--- a/doc/man7/RAND.pod
+++ b/doc/man7/RAND.pod
@@ -54,6 +54,13 @@ only in exceptional cases and is not recommended, unless you have a profound
 knowledge of cryptographic principles and understand the implications of your
 changes.
 
+Finally, it is possible for a provider to bypass the default RAND setup for
+L<RAND_bytes(3)> and associated functions.  A provider can be specified as the
+single randomness source via the L<RAND_set1_random_provider(3)> function or via
+configuration using the B<random_provider> option in L<config(5)>.  Once specified,
+the nominated provider will be used directly when calling the L<RAND_bytes(3)>
+family of functions.
+
 =head1 DEFAULT SETUP
 
 The default OpenSSL RAND method is based on the EVP_RAND deterministic random
@@ -68,7 +75,9 @@ L<RAND_bytes(3)>,
 L<RAND_priv_bytes(3)>,
 L<EVP_RAND(3)>,
 L<RAND_get0_primary(3)>,
-L<EVP_RAND(7)>
+L<config(5)>,
+L<EVP_RAND(7)>,
+L<RAND_set1_random_provider(3)>.
 
 =head1 COPYRIGHT
 

--- a/include/crypto/rand.h
+++ b/include/crypto/rand.h
@@ -151,4 +151,15 @@ uint32_t ossl_rand_uniform_uint32(OSSL_LIB_CTX *ctx, uint32_t upper, int *err);
 uint32_t ossl_rand_range_uint32(OSSL_LIB_CTX *ctx, uint32_t lower, uint32_t upper,
                                 int *err);
 
+/*
+ * Check if the named provider is the nominated entropy/random provider.
+ * If it is, use it.
+ */
+# ifndef FIPS_MODULE
+int ossl_rand_check_random_provider_on_load(OSSL_LIB_CTX *ctx,
+                                            OSSL_PROVIDER *prov);
+int ossl_rand_check_random_provider_on_unload(OSSL_LIB_CTX *ctx,
+                                              OSSL_PROVIDER *prov);
+# endif     /* FIPS_MODULE */
+
 #endif

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -84,8 +84,8 @@ int ossl_provider_get_capabilities(const OSSL_PROVIDER *prov,
                                    OSSL_CALLBACK *cb,
                                    void *arg);
 int ossl_provider_self_test(const OSSL_PROVIDER *prov);
-int ossl_provider_random(const OSSL_PROVIDER *prov, int which, void *buf, size_t n,
-                         unsigned int strength);
+int ossl_provider_random_bytes(const OSSL_PROVIDER *prov, int which,
+                               void *buf, size_t n, unsigned int strength);
 const OSSL_ALGORITHM *ossl_provider_query_operation(const OSSL_PROVIDER *prov,
                                                     int operation_id,
                                                     int *no_cache);

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -84,6 +84,8 @@ int ossl_provider_get_capabilities(const OSSL_PROVIDER *prov,
                                    OSSL_CALLBACK *cb,
                                    void *arg);
 int ossl_provider_self_test(const OSSL_PROVIDER *prov);
+int ossl_provider_random(const OSSL_PROVIDER *prov, int which, void *buf, size_t n,
+                         unsigned int strength);
 const OSSL_ALGORITHM *ossl_provider_query_operation(const OSSL_PROVIDER *prov,
                                                     int operation_id,
                                                     int *no_cache);

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -269,10 +269,10 @@ OSSL_CORE_MAKE_FUNC(int, provider_get_capabilities, (void *provctx,
                     const char *capability, OSSL_CALLBACK *cb, void *arg))
 # define OSSL_FUNC_PROVIDER_SELF_TEST          1031
 OSSL_CORE_MAKE_FUNC(int, provider_self_test, (void *provctx))
-# define OSSL_FUNC_PROVIDER_RANDOM             1032
-OSSL_CORE_MAKE_FUNC(int, provider_random, (void *provctx, int which,
-                                           void *buf, size_t n,
-                                           unsigned int strength))
+# define OSSL_FUNC_PROVIDER_RANDOM_BYTES       1032
+OSSL_CORE_MAKE_FUNC(int, provider_random_bytes, (void *provctx, int which,
+                                                 void *buf, size_t n,
+                                                 unsigned int strength))
 
 /* Operations */
 

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -248,13 +248,13 @@ OSSL_CORE_MAKE_FUNC(int, provider_free,
 
 /* Functions provided by the provider to the Core, reserved numbers 1024-1535 */
 # define OSSL_FUNC_PROVIDER_TEARDOWN           1024
-OSSL_CORE_MAKE_FUNC(void,provider_teardown,(void *provctx))
+OSSL_CORE_MAKE_FUNC(void, provider_teardown, (void *provctx))
 # define OSSL_FUNC_PROVIDER_GETTABLE_PARAMS    1025
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,
                     provider_gettable_params,(void *provctx))
 # define OSSL_FUNC_PROVIDER_GET_PARAMS         1026
-OSSL_CORE_MAKE_FUNC(int,provider_get_params,(void *provctx,
-                                             OSSL_PARAM params[]))
+OSSL_CORE_MAKE_FUNC(int, provider_get_params, (void *provctx,
+                                               OSSL_PARAM params[]))
 # define OSSL_FUNC_PROVIDER_QUERY_OPERATION    1027
 OSSL_CORE_MAKE_FUNC(const OSSL_ALGORITHM *,provider_query_operation,
                     (void *provctx, int operation_id, int *no_store))
@@ -269,6 +269,10 @@ OSSL_CORE_MAKE_FUNC(int, provider_get_capabilities, (void *provctx,
                     const char *capability, OSSL_CALLBACK *cb, void *arg))
 # define OSSL_FUNC_PROVIDER_SELF_TEST          1031
 OSSL_CORE_MAKE_FUNC(int, provider_self_test, (void *provctx))
+# define OSSL_FUNC_PROVIDER_RANDOM             1032
+OSSL_CORE_MAKE_FUNC(int, provider_random, (void *provctx, int which,
+                                           void *buf, size_t n,
+                                           unsigned int strength))
 
 /* Operations */
 

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -118,6 +118,9 @@ OSSL_DEPRECATEDIN_1_1_0 int RAND_event(UINT, WPARAM, LPARAM);
 #  endif
 # endif
 
+#define OSSL_PROV_RANDOM_PUBLIC     0
+#define OSSL_PROV_RANDOM_PRIVATE    1
+
 #ifdef  __cplusplus
 }
 #endif

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -118,6 +118,9 @@ OSSL_DEPRECATEDIN_1_1_0 int RAND_event(UINT, WPARAM, LPARAM);
 #  endif
 # endif
 
+int RAND_set1_random_provider(OSSL_LIB_CTX *ctx, OSSL_PROVIDER *p);
+
+/* Which parameter to provider_random call */
 #define OSSL_PROV_RANDOM_PUBLIC     0
 #define OSSL_PROV_RANDOM_PRIVATE    1
 

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -22,9 +22,9 @@
 # include <openssl/randerr.h>
 # include <openssl/evp.h>
 
-#ifdef  __cplusplus
+# ifdef  __cplusplus
 extern "C" {
-#endif
+# endif
 
 /*
  * Default security strength (in the sense of [NIST SP 800-90Ar1])
@@ -121,11 +121,11 @@ OSSL_DEPRECATEDIN_1_1_0 int RAND_event(UINT, WPARAM, LPARAM);
 int RAND_set1_random_provider(OSSL_LIB_CTX *ctx, OSSL_PROVIDER *p);
 
 /* Which parameter to provider_random call */
-#define OSSL_PROV_RANDOM_PUBLIC     0
-#define OSSL_PROV_RANDOM_PRIVATE    1
+# define OSSL_PROV_RANDOM_PUBLIC     0
+# define OSSL_PROV_RANDOM_PRIVATE    1
 
-#ifdef  __cplusplus
+# ifdef  __cplusplus
 }
-#endif
+# endif
 
 #endif

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -41,7 +41,7 @@ static OSSL_FUNC_provider_gettable_params_fn fips_gettable_params;
 static OSSL_FUNC_provider_get_params_fn fips_get_params;
 static OSSL_FUNC_provider_query_operation_fn fips_query;
 static OSSL_FUNC_provider_query_operation_fn fips_query_internal;
-static OSSL_FUNC_provider_random_fn fips_random;
+static OSSL_FUNC_provider_random_bytes_fn fips_random_bytes;
 
 #define ALGC(NAMES, FUNC, CHECK)                \
     { { NAMES, FIPS_DEFAULT_PROPERTIES, FUNC }, CHECK }
@@ -122,8 +122,8 @@ void ossl_fips_prov_ossl_ctx_free(void *fgbl)
     OPENSSL_free(fgbl);
 }
 
-static int fips_random(ossl_unused void *vprov, int which, void *buf, size_t n,
-                       unsigned int strength)
+static int fips_random_bytes(ossl_unused void *vprov, int which,
+                             void *buf, size_t n, unsigned int strength)
 {
     OSSL_LIB_CTX *libctx;
     PROV_CTX *prov = (PROV_CTX *)vprov;
@@ -619,7 +619,7 @@ static const OSSL_DISPATCH fips_dispatch_table[] = {
     { OSSL_FUNC_PROVIDER_GET_CAPABILITIES,
       (void (*)(void))ossl_prov_get_capabilities },
     { OSSL_FUNC_PROVIDER_SELF_TEST, (void (*)(void))fips_self_test },
-    { OSSL_FUNC_PROVIDER_RANDOM, (void (*)(void))fips_random },
+    { OSSL_FUNC_PROVIDER_RANDOM_BYTES, (void (*)(void))fips_random_bytes },
     OSSL_DISPATCH_END
 };
 

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -41,6 +41,7 @@ static OSSL_FUNC_provider_gettable_params_fn fips_gettable_params;
 static OSSL_FUNC_provider_get_params_fn fips_get_params;
 static OSSL_FUNC_provider_query_operation_fn fips_query;
 static OSSL_FUNC_provider_query_operation_fn fips_query_internal;
+static OSSL_FUNC_provider_random_fn fips_random;
 
 #define ALGC(NAMES, FUNC, CHECK)                \
     { { NAMES, FIPS_DEFAULT_PROPERTIES, FUNC }, CHECK }
@@ -119,6 +120,20 @@ void *ossl_fips_prov_ossl_ctx_new(OSSL_LIB_CTX *libctx)
 void ossl_fips_prov_ossl_ctx_free(void *fgbl)
 {
     OPENSSL_free(fgbl);
+}
+
+static int fips_random(ossl_unused void *vprov, int which, void *buf, size_t n,
+                       unsigned int strength)
+{
+    OSSL_LIB_CTX *libctx;
+    PROV_CTX *prov = (PROV_CTX *)vprov;
+
+    if (prov == NULL)
+        return 0;
+    libctx = ossl_prov_ctx_get0_libctx(prov);
+    if (which == OSSL_PROV_RANDOM_PRIVATE)
+        return RAND_priv_bytes_ex(libctx, buf, n, strength);
+    return RAND_bytes_ex(libctx, buf, n, strength);
 }
 
 /*
@@ -604,6 +619,7 @@ static const OSSL_DISPATCH fips_dispatch_table[] = {
     { OSSL_FUNC_PROVIDER_GET_CAPABILITIES,
       (void (*)(void))ossl_prov_get_capabilities },
     { OSSL_FUNC_PROVIDER_SELF_TEST, (void (*)(void))fips_self_test },
+    { OSSL_FUNC_PROVIDER_RANDOM, (void (*)(void))fips_random },
     OSSL_DISPATCH_END
 };
 

--- a/test/rand_test.c
+++ b/test/rand_test.c
@@ -225,7 +225,7 @@ static int test_rand_random_provider(void)
             || !TEST_mem_eq(privbuf, sizeof(privbuf), data, sizeof(data)))
         goto err;
 
-    /* Test we can revert to not using the provided randomness */
+    /* Test we can revert to not using the provider based randomness */
     if (!TEST_true(RAND_set1_random_provider(ctx, NULL))
             || !RAND_bytes_ex(ctx, buf, sizeof(buf), 256)
             || !TEST_mem_ne(buf, sizeof(buf), data, sizeof(data)))

--- a/test/rand_test.c
+++ b/test/rand_test.c
@@ -162,6 +162,88 @@ static int fips_health_tests(void)
     return 1;
 }
 
+typedef struct r_test_ctx {
+    const OSSL_CORE_HANDLE *handle;
+} R_TEST_CTX;
+
+static void r_teardown(void *provctx)
+{
+    R_TEST_CTX *ctx = (R_TEST_CTX *)provctx;
+
+    free(ctx);
+}
+
+static int r_random_bytes(ossl_unused void *vprov, ossl_unused int which,
+                          void *buf, size_t n, ossl_unused unsigned int strength)
+{
+    while (n-- > 0)
+        ((unsigned char *)buf)[n] = 0xff & n;
+    return 1;
+}
+
+static const OSSL_DISPATCH r_test_table[] = {
+    { OSSL_FUNC_PROVIDER_RANDOM_BYTES, (void (*)(void))r_random_bytes },
+    { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))r_teardown },
+    OSSL_DISPATCH_END
+};
+
+static int r_init(const OSSL_CORE_HANDLE *handle,
+                  ossl_unused const OSSL_DISPATCH *oin,
+                  const OSSL_DISPATCH **out,
+                  void **provctx)
+{
+    R_TEST_CTX *ctx;
+
+    ctx = malloc(sizeof(*ctx));
+    if (ctx == NULL)
+        return 0;
+    ctx->handle = handle;
+
+    *provctx = (void *)ctx;
+    *out = r_test_table;
+    return 1;
+}
+
+static int test_rand_random_provider(void)
+{
+    OSSL_LIB_CTX *ctx = NULL;
+    OSSL_PROVIDER *prov = NULL;
+    int res = 0;
+    static const unsigned char data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+    unsigned char buf[sizeof(data)], privbuf[sizeof(data)];
+
+    memset(buf, 255, sizeof(buf));
+    memset(privbuf, 255, sizeof(privbuf));
+
+    if (!test_get_libctx(&ctx, NULL, NULL, NULL, NULL)
+            || !TEST_true(OSSL_PROVIDER_add_builtin(ctx, "r_prov", &r_init))
+            || !TEST_ptr(prov = OSSL_PROVIDER_try_load(ctx, "r_prov", 1))
+            || !TEST_true(RAND_set1_random_provider(ctx, prov))
+            || !RAND_bytes_ex(ctx, buf, sizeof(buf), 256)
+            || !TEST_mem_eq(buf, sizeof(buf), data, sizeof(data))
+            || !RAND_priv_bytes_ex(ctx, privbuf, sizeof(privbuf), 256)
+            || !TEST_mem_eq(privbuf, sizeof(privbuf), data, sizeof(data)))
+        goto err;
+
+    /* Test we can revert to not using the provided randomness */
+    if (!TEST_true(RAND_set1_random_provider(ctx, NULL))
+            || !RAND_bytes_ex(ctx, buf, sizeof(buf), 256)
+            || !TEST_mem_ne(buf, sizeof(buf), data, sizeof(data)))
+        goto err;
+
+    /* And back to the provided randomness */
+    if (!TEST_true(RAND_set1_random_provider(ctx, prov))
+            || !RAND_bytes_ex(ctx, buf, sizeof(buf), 256)
+            || !TEST_mem_eq(buf, sizeof(buf), data, sizeof(data)))
+        goto err;
+
+    res = 1;
+ err:
+    OSSL_PROVIDER_unload(prov);
+    OSSL_LIB_CTX_free(ctx);
+    return res;
+}
+
 int setup_tests(void)
 {
     char *configfile;
@@ -180,5 +262,6 @@ int setup_tests(void)
             && fips_provider_version_ge(NULL, 3, 4, 0))
         ADD_TEST(fips_health_tests);
 
+    ADD_TEST(test_rand_random_provider);
     return 1;
 }

--- a/test/wpackettest.c
+++ b/test/wpackettest.c
@@ -590,7 +590,7 @@ static int test_WPACKET_quic_vlint_random(void)
         if (!TEST_int_gt(RAND_bytes(rand_data, sizeof(rand_data)), 0))
             return cleanup(&pkt);
 
-        memcpy(&expected, rand_data, sizeof(uint64_t));
+        memcpy(&expected, rand_data, sizeof(expected));
 
         /*
          * Ensure that all size classes get tested with equal probability.

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5747,6 +5747,7 @@ OSSL_CRMF_MSG_centralkeygen_requested   ?	3_5_0	EXIST::FUNCTION:CRMF
 CMS_EnvelopedData_dup                   ?	3_5_0	EXIST::FUNCTION:CMS
 OSSL_CRMF_ENCRYPTEDKEY_init_envdata     ?	3_5_0	EXIST::FUNCTION:CMS,CRMF
 EVP_get1_default_properties             ?	3_5_0	EXIST::FUNCTION:
+RAND_set1_random_provider               ?	3_5_0	EXIST::FUNCTION:
 X509_PURPOSE_get_unused_id              ?	3_5_0	EXIST::FUNCTION:
 d2i_OSSL_AUTHORITY_ATTRIBUTE_ID_SYNTAX  ?	3_5_0	EXIST::FUNCTION:
 i2d_OSSL_AUTHORITY_ATTRIBUTE_ID_SYNTAX  ?	3_5_0	EXIST::FUNCTION:


### PR DESCRIPTION
Add a new provider API to allow a provider to be set as the default entropy source for `RAND_bytes()` et al..
The provider that will be used as the entropy source can be set both programatically and via configuration on a per library context basis.  This permits libcrypto to use the FIPS providers _internal_ DRBGs directly which means that the CRNG tests of the entropy source are used.  It also provides an easier way for third party entropy source providers to be linked into libcrypto.

Fixes #24094

- [x] documentation is added or updated
- [x] tests are added or updated
