### PR TITLE
update configurable sigalgs documentation for providers

### DIFF
--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -121,7 +121,7 @@ algorithms in order of decreasing preference of the form B<algorithm+hash>
 or B<signature_scheme>. For the default providers shipped with OpenSSL,
 B<algorithm> is one of B<RSA>, B<DSA> or B<ECDSA> and
 B<hash> is a supported algorithm OID short name such as B<SHA1>, B<SHA224>,
-B<SHA256>, B<SHA384> of B<SHA512>.  Note: algorithm and hash names are case
+B<SHA256>, B<SHA384> or B<SHA512>.  Note: algorithm and hash names are case
 sensitive.  B<signature_scheme> is one of the signature schemes defined in
 TLSv1.3, specified using the IETF name, e.g., B<ecdsa_secp256r1_sha256>,
 B<ed25519>, or B<rsa_pss_pss_sha256>. Additional providers may make available
@@ -372,9 +372,10 @@ servers it is used to determine which signature algorithms to support.
 
 The B<value> argument should be a colon separated list of signature algorithms
 in order of decreasing preference of the form B<algorithm+hash> or
-B<signature_scheme>. For the default providers shipped with OpenSSL,B<algorithm>
-is one of B<RSA>, B<DSA> or B<ECDSA> and B<hash> is a supported algorithm
-OID short name such as B<SHA1>, B<SHA224>, B<SHA256>, B<SHA384> of B<SHA512>.
+B<signature_scheme>. For the default providers shipped with OpenSSL,
+B<algorithm> is one of B<RSA>, B<DSA> or B<ECDSA> and B<hash> is a supported
+algorithm OID short name such as B<SHA1>, B<SHA224>, B<SHA256>, B<SHA384>
+or B<SHA512>.
 Note: algorithm and hash names are case sensitive.
 B<signature_scheme> is one of the signature schemes defined in TLSv1.3,
 specified using the IETF name, e.g., B<ecdsa_secp256r1_sha256>, B<ed25519>,

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -372,16 +372,18 @@ servers it is used to determine which signature algorithms to support.
 
 The B<value> argument should be a colon separated list of signature algorithms
 in order of decreasing preference of the form B<algorithm+hash> or
-B<signature_scheme>. B<algorithm>
+B<signature_scheme>. For the default providers shipped with OpenSSL,B<algorithm>
 is one of B<RSA>, B<DSA> or B<ECDSA> and B<hash> is a supported algorithm
 OID short name such as B<SHA1>, B<SHA224>, B<SHA256>, B<SHA384> of B<SHA512>.
 Note: algorithm and hash names are case sensitive.
 B<signature_scheme> is one of the signature schemes defined in TLSv1.3,
 specified using the IETF name, e.g., B<ecdsa_secp256r1_sha256>, B<ed25519>,
 or B<rsa_pss_pss_sha256>.
+Additional providers may make available further algorithms via the TLS_SIGALG
+capability. See L<provider-base(7)/CAPABILITIES>.
 
-If this option is not set then all signature algorithms supported by the
-OpenSSL library are permissible.
+If this option is not set then all signature algorithms supported by all
+activated providers are permissible.
 
 Note: algorithms which specify a PKCS#1 v1.5 signature scheme (either by
 using B<RSA> as the B<algorithm> or by using one of the B<rsa_pkcs1_*>

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -118,15 +118,18 @@ algorithms to support.
 
 The B<algs> argument should be a colon separated list of signature
 algorithms in order of decreasing preference of the form B<algorithm+hash>
-or B<signature_scheme>. B<algorithm> is one of B<RSA>, B<DSA> or B<ECDSA> and
+or B<signature_scheme>. For the default providers shipped with OpenSSL,
+B<algorithm> is one of B<RSA>, B<DSA> or B<ECDSA> and
 B<hash> is a supported algorithm OID short name such as B<SHA1>, B<SHA224>,
 B<SHA256>, B<SHA384> of B<SHA512>.  Note: algorithm and hash names are case
 sensitive.  B<signature_scheme> is one of the signature schemes defined in
 TLSv1.3, specified using the IETF name, e.g., B<ecdsa_secp256r1_sha256>,
-B<ed25519>, or B<rsa_pss_pss_sha256>.
+B<ed25519>, or B<rsa_pss_pss_sha256>. Additional providers may make available
+further algorithms via the TLS_SIGALG capability.
+See L<provider-base(7)/CAPABILITIES>.
 
-If this option is not set then all signature algorithms supported by the
-OpenSSL library are permissible.
+If this option is not set then all signature algorithms supported by all
+activated providers are permissible.
 
 Note: algorithms which specify a PKCS#1 v1.5 signature scheme (either by
 using B<RSA> as the B<algorithm> or by using one of the B<rsa_pkcs1_*>


### PR DESCRIPTION
Since OpenSSL 3.2, providers can change the list of supported TLS signature algorithms. This documentation update makes this explicit providing reference to the mechanism.

This may be made even more clear by referencing the `openssl list -signature-algorithms` command -- but I'm unsure whether this is desirable in this section of the documentation. Glad to update the PR if anyone thinks so.