### PR TITLE
enable AES-XTS optimization for AIX

### DIFF
--- a/crypto/aes/build.info
+++ b/crypto/aes/build.info
@@ -38,7 +38,7 @@ IF[{- !$disabled{asm} -}]
   $AESASM_parisc20_64=$AESASM_parisc11
   $AESDEF_parisc20_64=$AESDEF_parisc11
 
-  IF[{- $target{sys_id} ne "AIX" && $target{sys_id} ne "MACOSX" -}]
+  IF[{- $target{sys_id} ne "MACOSX" -}]
     $AESASM_ppc32=aes_core.c aes_cbc.c aes-ppc.s vpaes-ppc.s aesp8-ppc.s
   ELSE
     $AESASM_ppc32=aes_core.c aes_cbc.c aes-ppc.s vpaes-ppc.s

--- a/include/crypto/aes_platform.h
+++ b/include/crypto/aes_platform.h
@@ -65,7 +65,7 @@ void AES_xts_decrypt(const unsigned char *inp, unsigned char *out, size_t len,
 #   ifdef VPAES_ASM
 #    define VPAES_CAPABLE (OPENSSL_ppccap_P & PPC_ALTIVEC)
 #   endif
-#   if !defined(OPENSSL_SYS_AIX) && !defined(OPENSSL_SYS_MACOSX)
+#   if !defined(OPENSSL_SYS_MACOSX)
 #    define HWAES_CAPABLE  (OPENSSL_ppccap_P & PPC_CRYPTO207)
 #    define HWAES_set_encrypt_key aes_p8_set_encrypt_key
 #    define HWAES_set_decrypt_key aes_p8_set_decrypt_key
@@ -75,6 +75,8 @@ void AES_xts_decrypt(const unsigned char *inp, unsigned char *out, size_t len,
 #    define HWAES_ctr32_encrypt_blocks aes_p8_ctr32_encrypt_blocks
 #    define HWAES_xts_encrypt aes_p8_xts_encrypt
 #    define HWAES_xts_decrypt aes_p8_xts_decrypt
+#   endif /* OPENSSL_SYS_MACOSX */
+#   if !defined(OPENSSL_SYS_AIX) && !defined(OPENSSL_SYS_MACOSX)
 #    define PPC_AES_GCM_CAPABLE (OPENSSL_ppccap_P & PPC_MADD300)
 #    define AES_GCM_ENC_BYTES 128
 #    define AES_GCM_DEC_BYTES 128


### PR DESCRIPTION
Hello

As part of https://github.com/openssl/openssl/pull/22860 PR, AIX platform is also disabled.
Since the build issue is not seen in AIX, we need to enable AES-XTS optimization for AIX.

Please find below build status on AIX 7.2 with xlc 16.1 on Power7, Power8 : 

Configure aix-cc

CC="cc" perl crypto/aes/asm/aesp8-ppc.pl "aix32" -I. -Iinclude -Iproviders/common/include -Iproviders/implementations/include -qpic -q32 -qmaxmem=16384 -qro -qroconst -D__HIDE_SVR4_POLLFD_NAMES -qthreaded -O -DB_ENDIAN -DOPENSSL_PIC -DOPENSSLDIR="\"sandbox/ssl\"" -DENGINESDIR="\"sandbox/lib/engines-3\"" -DMODULESDIR="\"sandbox/lib/ossl-
modules\"" -D_THREAD_SAFE -DOPENSSL_BUILDING_OPENSSL -DNDEBUG  -DAES_ASM -DOPENSSL_BN_ASM_MONT -DOPENSSL_CPUID_OBJ -DPOLY1305_ASM -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DVPAES_ASM  crypto/aes/aesp8-ppc.s
cc -qpic -q32 -qmaxmem=16384 -qro -qroconst -D__HIDE_SVR4_POLLFD_NAMES -qthreaded -O -DB_ENDIAN -DOPENSSL_PIC -DOPENSSLDIR="\"sandbox/ssl\"" -DENGINESDIR="\"sandbox/lib/engines-3\"" -DMODULESDIR="\"sandbox/lib/ossl-modules\"" -D_THREAD_SAFE -DOPENSSL_BUILDING_OPENSSL -DNDEBUG  -c -o crypto/aes/libcrypto-lib-aesp8-ppc.o crypto/aes/aesp8-
ppc.s
CC="cc" perl crypto/aes/asm/vpaes-ppc.pl "aix32" -I. -Iinclude -Iproviders/common/include -Iproviders/implementations/include -qpic -q32 .....

Configure aix64-cc

CC="cc" perl crypto/aes/asm/aesp8-ppc.pl "aix64" -I. -Iinclude -Iproviders/common/include -Iproviders/implementations/include -qpic -q64 -qmaxmem=16384 -qro -qroconst -qthreaded -O -DB_ENDIAN -DOPENSSL_PIC -DOPENSSLDIR="\"sandbox/ssl\"" -DENGINESDIR="\"sandbox/lib/engines-3\"" -DMODULESDIR="\"sandbox/lib/ossl-modules\"" -D_THREAD_SAFE -DOPENSSL_BUILDING_OPENSSL -DNDEBUG  -DAES_ASM -DECP_NISTZ256_ASM -DKECCAK1600_ASM -OPENSSL_BN_ASM_MONT -DOPENSSL_CPUID_OBJ -DPOLY1305_ASM -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DVPAES_ASM -DX25519_ASM  crypto/aes/aesp8-ppc.s
cc -qpic -q64 -qmaxmem=16384 -qro -qroconst -qthreaded -O -DB_ENDIAN -DOPENSSL_PIC -DOPENSSLDIR="\"sandbox/ssl\"" -DENGINESDIR="\"sandbox/lib/engines-3\"" -DMODULESDIR="\"sandbox/lib/ossl-modules\"" -D_THREAD_SAFE -DOPENSSL_BUILDING_OPENSSL -DNDEBUG  -c -o crypto/aes/libcrypto-lib-aesp8-ppc.o crypto/aes/aesp8-ppc.s
CC="cc" perl crypto/aes/asm/vpaes-ppc.pl "aix64" -
....
