### PR TITLE
Remove the dead store in EVP_DecryptFinal_ex

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1034,8 +1034,7 @@ int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
         for (i = 0; i < n; i++)
             out[i] = ctx->final[i];
         *outl = n;
-    } else
-        *outl = 0;
+    }
     return 1;
 }
 


### PR DESCRIPTION
`*outl` is known to be zero in this context. We don't need to store zero to it again.
This patch removes the dead store.