### PR TITLE
Add static analysis workflow for on-premise Coverity Connect

### DIFF
--- a/.github/workflows/static-analysis-on-prem.yml
+++ b/.github/workflows/static-analysis-on-prem.yml
@@ -1,0 +1,39 @@
+# Copyright 2021-2024 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+name: Static Analysis On Prem
+
+on:
+  schedule:
+    - cron:  '20 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  coverity-analysis:
+    runs-on: ubuntu-latest
+    container: quay.io/openssl-ci/coverity-analysis:2024.3.1
+    steps:
+    - name: Put license
+      run: echo ${{ secrets.COVERITY_LICENSE }} | base64 -d > /opt/coverity-analysis/bin/license.dat
+    - name: Put auth key file
+      run: |
+        echo ${{ secrets.COVERITY_AUTH_KEY }} | base64 -d > /auth_key_file.txt
+        chmod 0600 /auth_key_file.txt
+    - uses: actions/checkout@v4
+    - name: Config
+      run: CC=gcc ./config --banner=Configured --debug enable-fips enable-rc5 enable-md2 enable-ssl3 enable-nextprotoneg enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 no-shared enable-buildtest-c++ enable-external-tests -DPEDANTIC
+    - name: Config dump
+      run: ./configdata.pm --dump
+    - name: Make
+      run: cov-build --dir cov-int make -s -j4
+    - name: Analyze
+      run: cov-analyze --dir cov-int --strip-path $(pwd)
+    - name: Commit defects
+      run: cov-commit-defects --url https://coverity.openssl.org:443 --stream OpenSSL --dir cov-int --auth-key-file /auth_key_file.txt


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

We use a self-hosted Coverity Connect instance to prevent unexpected changes in static analysis when Coverity Cloud is updated.

Here is a successful job run https://github.com/quarckster/openssl/actions/runs/9304315460/job/25611006591.
