### PR TITLE
Enable RFC 7919 FFDHE groups for TLS 1.2 server

### DIFF
--- a/providers/common/capabilities.c
+++ b/providers/common/capabilities.c
@@ -90,11 +90,11 @@ static const TLS_GROUP_CONSTANTS group_list[] = {
     { OSSL_TLS_GROUP_ID_brainpoolP384r1_tls13, 192, TLS1_3_VERSION, 0, -1, -1 },
     { OSSL_TLS_GROUP_ID_brainpoolP512r1_tls13, 256, TLS1_3_VERSION, 0, -1, -1 },
     /* Security bit values as given by BN_security_bits() */
-    { OSSL_TLS_GROUP_ID_ffdhe2048, 112, TLS1_3_VERSION, 0, -1, -1 },
-    { OSSL_TLS_GROUP_ID_ffdhe3072, 128, TLS1_3_VERSION, 0, -1, -1 },
-    { OSSL_TLS_GROUP_ID_ffdhe4096, 128, TLS1_3_VERSION, 0, -1, -1 },
-    { OSSL_TLS_GROUP_ID_ffdhe6144, 128, TLS1_3_VERSION, 0, -1, -1 },
-    { OSSL_TLS_GROUP_ID_ffdhe8192, 192, TLS1_3_VERSION, 0, -1, -1 },
+    { OSSL_TLS_GROUP_ID_ffdhe2048, 112, TLS1_VERSION, 0, -1, -1 },
+    { OSSL_TLS_GROUP_ID_ffdhe3072, 128, TLS1_VERSION, 0, -1, -1 },
+    { OSSL_TLS_GROUP_ID_ffdhe4096, 128, TLS1_VERSION, 0, -1, -1 },
+    { OSSL_TLS_GROUP_ID_ffdhe6144, 128, TLS1_VERSION, 0, -1, -1 },
+    { OSSL_TLS_GROUP_ID_ffdhe8192, 192, TLS1_VERSION, 0, -1, -1 },
 };
 
 #define TLS_GROUP_ENTRY(tlsname, realname, algorithm, idx) \

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3720,7 +3720,7 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
 
     case SSL_CTRL_GET_SHARED_GROUP:
         {
-            uint16_t id = tls1_shared_group(sc, larg);
+            uint16_t id = tls1_shared_group(sc, larg, 1, 1);
 
             if (larg != -1)
                 return tls1_group_id2nid(id, 1);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4338,7 +4338,8 @@ void ssl_set_masks(SSL_CONNECTION *s)
 
     dh_tmp = (c->dh_tmp != NULL
               || c->dh_tmp_cb != NULL
-              || c->dh_tmp_auto);
+              || c->dh_tmp_auto
+              || tls1_shared_group(s, -2, 0, 1) != 0);
 
     rsa_enc = pvalid[SSL_PKEY_RSA] & CERT_PKEY_VALID;
     rsa_sign = pvalid[SSL_PKEY_RSA] & CERT_PKEY_VALID;

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2763,7 +2763,7 @@ __owur int tls1_group_id2nid(uint16_t group_id, int include_unknown);
 __owur uint16_t tls1_nid2group_id(int nid);
 __owur int tls1_check_group_id(SSL_CONNECTION *s, uint16_t group_id,
                                int check_own_curves);
-__owur uint16_t tls1_shared_group(SSL_CONNECTION *s, int nmatch);
+__owur uint16_t tls1_shared_group(SSL_CONNECTION *s, int nmatch, int ec, int dh);
 __owur int tls1_set_groups(uint16_t **pext, size_t *pextlen,
                            int *curves, size_t ncurves);
 __owur int tls1_set_groups_list(SSL_CTX *ctx, uint16_t **pext, size_t *pextlen,

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -10428,7 +10428,9 @@ static int test_set_tmp_dh(int idx)
 
     if (!TEST_true(SSL_set_min_proto_version(serverssl, TLS1_2_VERSION))
             || !TEST_true(SSL_set_max_proto_version(serverssl, TLS1_2_VERSION))
-            || !TEST_true(SSL_set_cipher_list(serverssl, "DHE-RSA-AES128-SHA")))
+            || !TEST_true(SSL_set_cipher_list(serverssl, "DHE-RSA-AES128-SHA"))
+            /* Make sure RFC 7919 isn't used in this test. */
+            || !TEST_true(SSL_set1_groups_list(serverssl, "P-256")))
         goto end;
 
     /*
@@ -10450,7 +10452,6 @@ static int test_set_tmp_dh(int idx)
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
     EVP_PKEY_free(dhpkey);
-
     return testresult;
 }
 
@@ -10539,6 +10540,8 @@ static int test_dh_auto(int idx)
             || !TEST_true(SSL_set_min_proto_version(serverssl, TLS1_2_VERSION))
             || !TEST_true(SSL_set_max_proto_version(serverssl, TLS1_2_VERSION))
             || !TEST_true(SSL_set_cipher_list(serverssl, ciphersuite))
+            /* Make sure RFC 7919 isn't used in this test. */
+            || !TEST_true(SSL_set1_groups_list(serverssl, "P-256"))
             || !TEST_true(SSL_set_cipher_list(clientssl, ciphersuite)))
         goto end;
 
@@ -10567,9 +10570,7 @@ static int test_dh_auto(int idx)
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
     EVP_PKEY_free(tmpkey);
-
     return testresult;
-
 }
 # endif /* OPENSSL_NO_DH */
 #endif /* OPENSSL_NO_TLS1_2 */


### PR DESCRIPTION
For TLS versions prior to TLS 1.3, the SSL server currently only uses
the supported_groups extension for ECDHE cipher suites. This commit
extends this functionality by also considering the supported_groups for
DHE cipher suites.

Before this commit, the logic for generating a temporary DH key for DHE
cipher suites is the following:
1) If dh_tmp_auto is set (see SSL_set_dh_auto), the SSL server
   automatically generates a set of DH parameters (P and G) appropriate
   for the security level of the cipher suite.
2) Otherwise, if the user provided a pre-generated set of DH parameters
   (SSL_set0_tmp_dh_pkey), those parameters are used.
3) Finally, if neither 1) or 2) are applicable, a callback function can
   be set using SSL_set_tmp_dh_callback, which will be invoked to
   generate the temporary DH parameters. From OpenSSL 3.0, this
   functionality is deprecated.
4) Using the parameters from step 1-3, an ephemeral DH key is
   generated. The parameters and the public key are sent to the client.

This commit adds an additional step, prior to step 1:
0) If tls1_shared_group returns any shared known group between the
   server and the client, the DH parameters associated with this group
   are selected.

This change also has the added benefit that SSL_set1_groups and friends
now behave as expected for FFDHE groups on the server side (and by
extension, `s_server -groups` too). This provides the user with more
control over which DH parameters are used by the server for key
exchange, which is useful for testing purposes.

Note however, that the new behavior is technically not compliant with
RFC 7919 (Section 4):
  If a compatible TLS server receives a Supported Groups extension from
  a client that includes any FFDHE group (i.e., any codepoint between
  256 and 511, inclusive, even if unknown to the server), and if none
  of the client-proposed FFDHE groups are known and acceptable to the
  server, then the server MUST NOT select an FFDHE cipher suite.

Nevertheless, for backwards-compatibility purposes, a slight deviation
from the RFC is acceptable here.

Finally, it doesn't seem like in TLS < 1.3, the selected FFDHE group is
explicitly sent from the server to the client. In other words, the
server knows that it selected an RFC 7919 FFDHE group, but the client
only receives the DH parameters. Of course, the client could go through
the tedious effort of comparing these parameters with the RFC 7919
FFDHE group parameters to determine which group was selected.

Partially fixes #10971.

##### Checklist

- [ ] documentation is added or updated
- [ ] tests are added or updated
