### PR TITLE
Configure: make absolutedir() use rel2abs() on Windows too

### DIFF
--- a/Configure
+++ b/Configure
@@ -3522,6 +3522,13 @@ sub absolutedir {
         return rel2abs($dir);
     }
 
+    # realpath() on Windows seems to check if the directory actually exists,
+    # which isn't what is wanted here.  All we want to know is if a directory
+    # spec is absolute, not if it exists.
+    if ($^O eq "MSWin32") {
+        return rel2abs($dir);
+    }
+
     # We use realpath() on Unix, since no other will properly clean out
     # a directory spec.
     use Cwd qw/realpath/;


### PR DESCRIPTION
perl's realpath() seems to be buggy on Windows, so we turn to rel2abs()
there as well.

Fixes #23593
