### PR TITLE
Remove configuration targets and related documentation for Guardian

### DIFF
--- a/Configurations/50-nonstop.conf
+++ b/Configurations/50-nonstop.conf
@@ -211,18 +211,6 @@
         multibin         => '64-put',
         disable          => ['atexit'],
     },
-    'nonstop-nsx_g' => {
-        inherit_from     => [ 'nonstop-common',
-                              'nonstop-archenv-x86_64-guardian',
-                              'nonstop-ilp32', 'nonstop-nfloat-x86_64' ],
-        disable          => ['threads','atexit'],
-    },
-    'nonstop-nsx_g_tandem' => {
-        inherit_from     => [ 'nonstop-common',
-                              'nonstop-archenv-x86_64-guardian',
-                              'nonstop-ilp32', 'nonstop-tfloat-x86_64' ],
-        disable          => ['threads','atexit'],
-    },
     'nonstop-nsv' => {
         inherit_from     => [ 'nonstop-nsx' ],
     },
@@ -261,17 +249,4 @@
         multilib         => '64-put',
         multibin         => '64-put',
         disable          => ['atexit'],
-    },
-    'nonstop-nse_g' => {
-        inherit_from     => [ 'nonstop-common',
-                              'nonstop-archenv-itanium-guardian',
-                              'nonstop-ilp32', 'nonstop-nfloat-itanium' ],
-        disable          => ['threads','atexit'],
-    },
-
-    'nonstop-nse_g_tandem' => {
-        inherit_from     => [ 'nonstop-common',
-                              'nonstop-archenv-itanium-guardian',
-                              'nonstop-ilp32', 'nonstop-tfloat-itanium' ],
-        disable          => ['threads','atexit'],
     },

--- a/NOTES-NONSTOP.md
+++ b/NOTES-NONSTOP.md
@@ -217,13 +217,10 @@ Example Configure Targets
 -------------------------
 
 For OSS targets, the main DLL names will be `libssl.so` and `libcrypto.so`.
-For GUARDIAN targets, DLL names will be `ssl` and `crypto`. The following
-assumes that your PWD is set according to your installation standards.
+The following assumes that your PWD is set according to your installation
+standards.
 
     ./Configure nonstop-nsx           --prefix=${PWD} \
-        --openssldir=${PWD}/ssl no-threads \
-        --with-rand-seed=rdcpu ${CIPHENABLES} ${DBGFLAG} ${SYSTEMLIBS}
-    ./Configure nonstop-nsx_g         --prefix=${PWD} \
         --openssldir=${PWD}/ssl no-threads \
         --with-rand-seed=rdcpu ${CIPHENABLES} ${DBGFLAG} ${SYSTEMLIBS}
     ./Configure nonstop-nsx_put       --prefix=${PWD} \
@@ -234,9 +231,6 @@ assumes that your PWD is set according to your installation standards.
         --with-rand-seed=rdcpu ${CIPHENABLES} ${DBGFLAG} ${SYSTEMLIBS}
     ./Configure nonstop-nsx_64_put    --prefix=${PWD} \
         --openssldir=${PWD}/ssl threads "-D_REENTRANT" \
-        --with-rand-seed=rdcpu ${CIPHENABLES} ${DBGFLAG} ${SYSTEMLIBS}
-    ./Configure nonstop-nsx_g_tandem  --prefix=${PWD} \
-        --openssldir=${PWD}/ssl no-threads \
         --with-rand-seed=rdcpu ${CIPHENABLES} ${DBGFLAG} ${SYSTEMLIBS}
 
     ./Configure nonstop-nse           --prefix=${PWD} \
@@ -253,7 +247,4 @@ assumes that your PWD is set according to your installation standards.
         --with-rand-seed=egd ${CIPHENABLES} ${DBGFLAG} ${SYSTEMLIBS}
     ./Configure nonstop-nse_64_put    --prefix=${PWD} \
         --openssldir=${PWD}/ssl threads "-D_REENTRANT"
-        --with-rand-seed=egd ${CIPHENABLES} ${DBGFLAG} ${SYSTEMLIBS}
-    ./Configure nonstop-nse_g_tandem  --prefix=${PWD} \
-        --openssldir=${PWD}/ssl no-threads \
         --with-rand-seed=egd ${CIPHENABLES} ${DBGFLAG} ${SYSTEMLIBS}


### PR DESCRIPTION
NonStop Guardian builds are not longer supported by the community maintainer(s) so the configuration targets
are removed.

The intermediate configuration items to support Guardian builds are left in place as a convenience for users who want to set up configurations for Guardian on their own.

Fixes: #22175

##### Checklist
- [X] documentation is added or updated
