### PR TITLE
Fix use after free in BN_POOL_finish

### DIFF
--- a/crypto/bn/bn_ctx.c
+++ b/crypto/bn/bn_ctx.c
@@ -295,13 +295,16 @@ static void BN_POOL_init(BN_POOL *p)
 
 static void BN_POOL_finish(BN_POOL *p)
 {
-    unsigned int loop;
+    int loop;
     BIGNUM *bn;
 
     while (p->head) {
-        for (loop = 0, bn = p->head->vals; loop++ < BN_CTX_POOL_SIZE; bn++)
+        for (loop = (BN_CTX_POOL_SIZE - 1); loop >= 0; loop--) {
+            bn = p->head->vals[loop];
             if (bn->d)
                 BN_clear_free(bn);
+        }
+
         p->current = p->head->next;
         OPENSSL_free(p->head);
         p->head = p->current;


### PR DESCRIPTION
In the current implementation of BN_POOL_finish,
there is reported an issue from static code analyses: use after free
There is an assignment to bn variable, which can be freed: BN_clear_free(bn);
and in a loop after this call there is a command: bn++ This causes using bn after free.
This fix proposes going through a loop in the opposite direction.
