### PR TITLE
DTLS 1.3: Disable SCTP auth key extraction

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1739,7 +1739,12 @@ MSG_PROCESS_RETURN tls_process_server_hello(SSL_CONNECTION *s, PACKET *pkt)
     }
 
 #ifndef OPENSSL_NO_SCTP
-    if (SSL_CONNECTION_IS_DTLS(s) && s->hit) {
+    /*
+     * Before exporting the SCTP auth key we check if DTLSv1.3 has been negotiated
+     * which is not supported.
+     * Refer to draft-tuexen-tsvwg-rfc6083-bis-04 for more info.
+     */
+    if (SSL_CONNECTION_IS_DTLS(s) && !SSL_CONNECTION_IS_DTLS13(s) && s->hit) {
         unsigned char sctpauthkey[64];
         char labelbuffer[sizeof(DTLS1_SCTP_AUTH_LABEL)];
         size_t labellen;
@@ -3600,7 +3605,12 @@ int tls_client_key_exchange_post_work(SSL_CONNECTION *s)
     pmslen = 0;
 
 #ifndef OPENSSL_NO_SCTP
-    if (SSL_CONNECTION_IS_DTLS(s)) {
+    /*
+     * Before exporting the SCTP auth key we check if DTLSv1.3 has been negotiated
+     * which is not supported.
+     * Refer to draft-tuexen-tsvwg-rfc6083-bis-04 for more info.
+     */
+    if (SSL_CONNECTION_IS_DTLS(s) && !SSL_CONNECTION_IS_DTLS13(s)) {
         unsigned char sctpauthkey[64];
         char labelbuffer[sizeof(DTLS1_SCTP_AUTH_LABEL)];
         size_t labellen;

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -913,7 +913,12 @@ WORK_STATE ossl_statem_server_post_work(SSL_CONNECTION *s, WORK_STATE wst)
             break;
         }
 #ifndef OPENSSL_NO_SCTP
-        if (SSL_CONNECTION_IS_DTLS(s) && s->hit) {
+        /*
+        * Before exporting the SCTP auth key we check if DTLSv1.3 has been negotiated
+        * which is not supported.
+        * Refer to draft-tuexen-tsvwg-rfc6083-bis-04 for more info.
+        */
+        if (SSL_CONNECTION_IS_DTLS(s) && !SSL_CONNECTION_IS_DTLS13(s) && s->hit) {
             unsigned char sctpauthkey[64];
             char labelbuffer[sizeof(DTLS1_SCTP_AUTH_LABEL)];
             size_t labellen;
@@ -3461,7 +3466,12 @@ WORK_STATE tls_post_process_client_key_exchange(SSL_CONNECTION *s,
 {
 #ifndef OPENSSL_NO_SCTP
     if (wst == WORK_MORE_A) {
-        if (SSL_CONNECTION_IS_DTLS(s)) {
+        /*
+         * Before exporting the SCTP auth key we check if DTLSv1.3 has been
+         * negotiated which is not supported.
+         * Refer to draft-tuexen-tsvwg-rfc6083-bis-04 for more info.
+         */
+        if (SSL_CONNECTION_IS_DTLS(s) && !SSL_CONNECTION_IS_DTLS13(s)) {
             unsigned char sctpauthkey[64];
             char labelbuffer[sizeof(DTLS1_SCTP_AUTH_LABEL)];
             size_t labellen;

--- a/test/dtls_mtu_test.c
+++ b/test/dtls_mtu_test.c
@@ -66,18 +66,6 @@ static int mtu_test(SSL_CTX *ctx, const char *cs, int no_etm)
     if (no_etm)
         SSL_set_options(srvr_ssl, SSL_OP_NO_ENCRYPT_THEN_MAC);
 
-#ifndef OPENSSL_NO_SCTP
-    /**
-     * TODO(DTLSv1.3): Fix SCTP support
-     * This test is failing on exporting the sctp auth key on server and client
-     * because ossl_statem_export_allowed() fails.
-     * ossl_statem_server_post_work:internal error:ssl/statem/statem_srvr.c:937:
-     * and
-     * tls_process_server_hello:internal error:ssl/statem/statem_clnt.c:1763:
-     */
-    OPENSSL_assert(SSL_set_max_proto_version(clnt_ssl, DTLS1_2_VERSION) == 1);
-#endif
-
     if (!TEST_true(SSL_set_cipher_list(srvr_ssl, cs))
             || !TEST_true(SSL_set_cipher_list(clnt_ssl, cs))
             || !TEST_ptr(sc_bio = SSL_get_rbio(srvr_ssl))


### PR DESCRIPTION
SCTP for DTLSv1.3 is yet to be standardised:
draft-tuexen-tsvwg-rfc6083-bis-04

For now we should disable it for DTLSv1.3 connections.