### PR TITLE
Create new investigation template

### DIFF
--- a/.github/ISSUE_TEMPLATE/investigation.md
+++ b/.github/ISSUE_TEMPLATE/investigation.md
@@ -1,15 +1,15 @@
 ---
 name: Investigation 
 labels: 'investigation'
-about: Discuss a broad topic or concern in openssl 
+about: Discuss a broad topic or concern in OpenSSL
 
 ---
 
 <!--
-Thank you for your report.  
+Thank you for your report.
 
-Investigation reports are meant to codify larger issues in openssl for which
-thre is no immediate corrective action known or recognized.  Instead, these
+Investigation reports are meant to codify larger issues in OpenSSL for which
+there is no immediate corrective action known or recognized.  Instead, these
 issues are meant to allow a space for developers to discuss problems in the
 project that may span a wide range of topics, which may result in future
 specific actions to be taken.  If such actions are identified, new bug report

--- a/.github/ISSUE_TEMPLATE/investigation.md
+++ b/.github/ISSUE_TEMPLATE/investigation.md
@@ -1,8 +1,7 @@
 ---
 name: Investigation 
-labels: 'investigation'
-about: Discuss a broad topic or concern in OpenSSL
-
+labels: 'investigation needed'
+about: Raise a broad topic or concern in OpenSSL requiring investigation
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/investigation.md
+++ b/.github/ISSUE_TEMPLATE/investigation.md
@@ -1,0 +1,19 @@
+---
+name: Investigation 
+labels: 'investigation'
+about: Discuss a broad topic or concern in openssl 
+
+---
+
+<!--
+Thank you for your report.  
+
+Investigation reports are meant to codify larger issues in openssl for which
+thre is no immediate corrective action known or recognized.  Instead, these
+issues are meant to allow a space for developers to discuss problems in the
+project that may span a wide range of topics, which may result in future
+specific actions to be taken.  If such actions are identified, new bug report
+issues should be created with specific problems and corrective tasks identified,
+which should then be linked here.  Investigation issues will themselves not be
+scheduled to be addressed.
+-->


### PR DESCRIPTION
In sifting through our bug backlog, one theme I've identified is that, often we have issues created with address a very broad category of problem (for instance 'performance').  The root cause of these issues are discussed and debated, and may result in changes being made to the code base, but the issues themselves, having no clear direction or goal, are difficult or impossible to refine, making their resolution and closing a subject of much debate.  For development purposes, they are invaluable, but for planning purposes, they are useless, so it seems critical to be able to draw a distinction between the two.

As such, I'm proposing the following:
1) The creation of an 'Investigation' label in github (done), which
   identifies an issue as being open ended, for which no actionable
   output is expected.  Any actions identified during that discussion
   should be the subject of a new issue, with a specific problem
   statement and corrective action listed
2) The creation of a new template, so that developers can (hopefully)
   easily create such investegatory issues for discussion that are
   clearly marked as such, and can be ignored for planning purposes

This PR creates that template to automatically assign the aforementioned label, to make this process a little more automated.


