### PR TITLE
provide support for openxl compiler in AIX

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1414,6 +1414,25 @@ my %targets = (
         AR               => add("-X32"),
         RANLIB           => add("-X32"),
     },
+    # To enable openxl compiler for aix
+    # If 17.1 openxl runtime is available, -latomic can be used 
+    # instead of -DBROKEN_CLANG_ATOMICS
+    "aix-clang" => {
+        inherit_from     => [ "aix-common" ],
+        CC               => "ibm-clang",
+        CFLAGS           => picker(debug   => "-O0 -g",
+                                   release => "-O"),
+        cflags           => combine("-Wno-implicit-function-declaration -mcmodel=large -DBROKEN_CLANG_ATOMICS",
+                            threads("-pthread")),
+        ex_libs          => add(threads("-pthread")),
+        bn_ops           => "BN_LLONG RC4_CHAR",
+        asm_arch         => 'ppc32',
+        perlasm_scheme   => "aix32",
+        shared_cflag     => "-fpic",
+        shared_ldflag    => add("-shared"),
+        AR               => add("-X32"),
+        RANLIB           => add("-X32"),
+    },
     # shared_target of "aix-solib" builds shared libraries packaged
     # without archives.  This improves the behavior of inter-library
     # references (libssl depending on libcrypto) when building with
@@ -1441,6 +1460,23 @@ my %targets = (
         perlasm_scheme   => "aix64",
         dso_scheme       => "dlfcn",
         shared_cflag     => "-qpic",
+        shared_extension => "64.so.\$(SHLIB_VERSION_NUMBER)",
+        AR               => add("-X64"),
+        RANLIB           => add("-X64"),
+    },
+    "aix64-clang" => {
+        inherit_from     => [ "aix-common" ],
+        CC               => "ibm-clang",
+        CFLAGS           => picker(debug   => "-O0 -g",
+                                   release => "-O"),
+        cflags           => combine("-maix64 -Wno-implicit-function-declaration -mcmodel=large",
+                            threads("-pthread")),
+        ex_libs          => add(threads("-pthread")),
+        bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
+        asm_arch         => 'ppc64',
+        perlasm_scheme   => "aix64",
+        shared_cflag     => "-fpic",
+        shared_ldflag    => add("-shared"),
         shared_extension => "64.so.\$(SHLIB_VERSION_NUMBER)",
         AR               => add("-X64"),
         RANLIB           => add("-X64"),

--- a/Configure
+++ b/Configure
@@ -1673,7 +1673,7 @@ if (!$disabled{makedepend}) {
     disable('unavailable', 'makedepend') unless $config{makedep_scheme};
 }
 
-if (!$disabled{asm} && !$predefined_C{__MACH__} && $^O ne 'VMS') {
+if (!$disabled{asm} && !$predefined_C{__MACH__} && $^O ne 'VMS' && !$predefined_C{_AIX}) {
     # probe for -Wa,--noexecstack option...
     if ($predefined_C{__clang__}) {
         # clang has builtin assembler, which doesn't recognize --help,


### PR DESCRIPTION
Hello

This PR provides configuration to build 32-bit and 64-bit openssl with openxl compiler on AIX OS

With xlc 16.1 nearing end of support shortly, it is required to provide a configuration that supports the next compiler (openxl) on AIX. 

This configuration has been tested on different AIX levels (7.2, 7.3) and on different Power platforms.
Thanks