### PR TITLE
Support converting ed25519 key to x25519 key.

### DIFF
--- a/include/crypto/ecx.h
+++ b/include/crypto/ecx.h
@@ -131,6 +131,13 @@ void
 ossl_x448_public_from_private(uint8_t out_public_value[56],
                               const uint8_t private_key[56]);
 
+void
+ossl_x25519_private_from_ed25519(uint8_t out_private_key[32],
+                                 const uint8_t private_key[32]);
+void
+ossl_x25519_public_from_ed25519(uint8_t out_public_value[32],
+                                const uint8_t public_value[32]);
+
 
 /* Backend support */
 typedef enum {


### PR DESCRIPTION
In many applications we need to convert x25519 key from ed25519 key for DH exchange.

CLA: trivial

Respond to @nhorman 's requet.
https://github.com/openssl/openssl/issues/13630#issuecomment-2161599890

propose this patch to pr.
https://github.com/openssl/openssl/discussions/23905