### PR TITLE
Add missing FIPS source(e_aes.c) to libfips.a build target

### DIFF
--- a/crypto/evp/build.info
+++ b/crypto/evp/build.info
@@ -2,12 +2,13 @@ LIBS=../../libcrypto
 $COMMON=digest.c evp_enc.c evp_lib.c evp_fetch.c evp_utils.c \
         mac_lib.c mac_meth.c keymgmt_meth.c keymgmt_lib.c kdf_lib.c kdf_meth.c \
         m_sigver.c pmeth_lib.c signature.c p_lib.c pmeth_gn.c exchange.c \
-        evp_rand.c asymcipher.c kem.c dh_support.c ec_support.c pmeth_check.c
+        evp_rand.c asymcipher.c kem.c dh_support.c ec_support.c pmeth_check.c \
+        e_aes.c
 
 SOURCE[../../libcrypto]=$COMMON\
         encode.c evp_key.c evp_cnf.c \
         e_des.c e_bf.c e_idea.c e_des3.c \
-        e_rc4.c e_aes.c names.c e_aria.c e_sm4.c \
+        e_rc4.c names.c e_aria.c e_sm4.c \
         e_xcbc_d.c e_rc2.c e_cast.c e_rc5.c m_null.c \
         p_seal.c p_sign.c p_verify.c p_legacy.c \
         bio_md.c bio_b64.c bio_enc.c evp_err.c e_null.c \

--- a/providers/fips.module.sources
+++ b/providers/fips.module.sources
@@ -201,6 +201,7 @@ crypto/ec/ecx_key.c
 crypto/evp/asymcipher.c
 crypto/evp/dh_support.c
 crypto/evp/digest.c
+crypto/evp/e_aes.c
 crypto/evp/ec_support.c
 crypto/evp/evp_enc.c
 crypto/evp/evp_fetch.c


### PR DESCRIPTION
`crypto/evp/e_aes.c` is leveraging `FIPS_MODULE` macro to fulfil FIPS requirements, but the file doesn't belong to the FIPS module sources which results in stripping FIPS-required code when building the FIPS provider.
This change fixes that oversight.