### PR TITLE
Append check for funcrion ossl_quic_rxfc_on_retire()

### DIFF
--- a/ssl/quic/quic_stream_map.c
+++ b/ssl/quic/quic_stream_map.c
@@ -757,7 +757,8 @@ void ossl_quic_stream_map_remove_from_accept_queue(QUIC_STREAM_MAP *qsm,
     --qsm->num_accept;
 
     if ((max_streams_rxfc = qsm_get_max_streams_rxfc(qsm, s)) != NULL)
-        ossl_quic_rxfc_on_retire(max_streams_rxfc, 1, rtt);
+        if (!ossl_quic_rxfc_on_retire(max_streams_rxfc, 1, rtt)
+          return;
 }
 
 size_t ossl_quic_stream_map_get_accept_queue_len(QUIC_STREAM_MAP *qsm)


### PR DESCRIPTION
Return value of function 'ossl_quic_rxfc_on_retire', called at quic_stream_map.c:760, is not checked, but it is usually checked for this function.

CLA: trivial