### PR TITLE
Fix regression of EVP_PKEY_CTX_add1_hkdf_info() with older providers

### DIFF
--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -1008,6 +1008,7 @@ static int evp_pkey_ctx_add1_octet_string(EVP_PKEY_CTX *ctx, int fallback,
                                           int datalen)
 {
     OSSL_PARAM os_params[2];
+    const OSSL_PARAM *gettables;
     unsigned char *info = NULL;
     size_t info_len = 0;
     size_t info_alloc = 0;
@@ -1031,6 +1032,12 @@ static int evp_pkey_ctx_add1_octet_string(EVP_PKEY_CTX *ctx, int fallback,
         return 1;
     }
 
+    /* Check for older provider that doesn't support getting this parameter */
+    gettables = EVP_PKEY_CTX_gettable_params(ctx);
+    if (gettables == NULL || OSSL_PARAM_locate_const(gettables, param) == NULL)
+        return evp_pkey_ctx_set1_octet_string(ctx, fallback, param, op, ctrl,
+                                              data, datalen);
+
     /* Get the original value length */
     os_params[0] = OSSL_PARAM_construct_octet_string(param, NULL, 0);
     os_params[1] = OSSL_PARAM_construct_end();
@@ -1038,9 +1045,9 @@ static int evp_pkey_ctx_add1_octet_string(EVP_PKEY_CTX *ctx, int fallback,
     if (!EVP_PKEY_CTX_get_params(ctx, os_params))
         return 0;
 
-    /* Older provider that doesn't support getting this parameter */
+    /* This should not happen but check to be sure. */
     if (os_params[0].return_size == OSSL_PARAM_UNMODIFIED)
-        return evp_pkey_ctx_set1_octet_string(ctx, fallback, param, op, ctrl, data, datalen);
+        return 0;
 
     info_alloc = os_params[0].return_size + datalen;
     if (info_alloc == 0)


### PR DESCRIPTION
If there is no get_ctx_params() implemented in the key exchange provider implementation the fallback will not work. Instead check the gettable_ctx_params() to see if the fallback should be performed.

Fixes #24611
