### PR TITLE
Fix typo in openssl-verification-options documentation

### DIFF
--- a/doc/man1/openssl-verification-options.pod
+++ b/doc/man1/openssl-verification-options.pod
@@ -430,7 +430,7 @@ This option may be used multiple times.
 =item B<-policy> I<arg>
 
 Enable policy processing and add I<arg> to the user-initial-policy-set (see
-RFC5280). The policy I<arg> can be an object name an OID in numeric form.
+RFC5280). The policy I<arg> can be an object name or an OID in numeric form.
 This argument can appear more than once.
 
 =item B<-explicit_policy>


### PR DESCRIPTION
"or" word is missing.

- [ x ] documentation is added or updated
- [ ] tests are added or updated
