### PR TITLE
Fix data race between SSL_SESSION_list_add and ssl_session_dup

### DIFF
--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -540,11 +540,6 @@ struct ssl_session_st {
                                  * load the 'cipher' structure */
     unsigned int kex_group;      /* TLS group from key exchange */
     CRYPTO_EX_DATA ex_data;     /* application specific data */
-    /*
-     * These are used to make removal of session-ids more efficient and to
-     * implement a maximum cache size.
-     */
-    struct ssl_session_st *prev, *next;
 
     struct {
         char *hostname;
@@ -574,6 +569,12 @@ struct ssl_session_st {
     size_t ticket_appdata_len;
     uint32_t flags;
     SSL_CTX *owner;
+
+    /*
+     * These are used to make removal of session-ids more efficient and to
+     * implement a maximum cache size.
+     */
+    struct ssl_session_st *prev, *next;
 };
 
 /* Extended master secret support */

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -530,7 +530,6 @@ struct ssl_session_st {
      * certificate is not ok, we must remember the error for session reuse:
      */
     long verify_result;         /* only for servers */
-    CRYPTO_REF_COUNT references;
     OSSL_TIME timeout;
     OSSL_TIME time;
     OSSL_TIME calc_timeout;
@@ -572,9 +571,10 @@ struct ssl_session_st {
 
     /*
      * These are used to make removal of session-ids more efficient and to
-     * implement a maximum cache size.
+     * implement a maximum cache size. Access requires protection of ctx->lock.
      */
     struct ssl_session_st *prev, *next;
+    CRYPTO_REF_COUNT references;
 };
 
 /* Extended master secret support */

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -140,13 +140,10 @@ static SSL_SESSION *ssl_session_dup_intern(const SSL_SESSION *src, int ticket)
         return NULL;
 
     /*
-     * Copy until prev ptr, because it's a part of sessons cache which can be modified
-     * concurrently. Other fields filled in the code bellow.
+     * src is logically read-only but the prev/next pointers are not, they are
+     * part of the session cache and can be modified concurrently.
      */
     memcpy(dest, src, offsetof(SSL_SESSION, prev));
-    dest->ext = src->ext;
-    dest->ticket_appdata_len = src->ticket_appdata_len;
-    dest->flags = src->flags;
 
     /*
      * Set the various pointers to NULL so that we can call SSL_SESSION_free in

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -138,7 +138,15 @@ static SSL_SESSION *ssl_session_dup_intern(const SSL_SESSION *src, int ticket)
     dest = OPENSSL_malloc(sizeof(*dest));
     if (dest == NULL)
         return NULL;
-    memcpy(dest, src, sizeof(*dest));
+
+    /*
+     * Copy until prev ptr, because it's a part of sessons cache which can be modified
+     * concurrently. Other fields filled in the code bellow.
+     */
+    memcpy(dest, src, offsetof(SSL_SESSION, prev));
+    dest->ext = src->ext;
+    dest->ticket_appdata_len = src->ticket_appdata_len;
+    dest->flags = src->flags;
 
     /*
      * Set the various pointers to NULL so that we can call SSL_SESSION_free in


### PR DESCRIPTION
Fixes #24629

This upstreams a fix for data race #24629 which has been made a while ago (https://github.com/openssl/openssl/issues/24629#issuecomment-2174295424)

It resolved the tsan warning in my local testing, nevertheless kindly double check if everything is kosher
(https://github.com/openssl/openssl/issues/24629#issuecomment-2174309613)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
