### PR TITLE
docs: fix SSL_CTX_set_tlsext_ticket_key_cb typos

### DIFF
--- a/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
@@ -126,9 +126,9 @@ The I<hctx> key material can be set using L<HMAC_Init_ex(3)>.
 
 =head1 NOTES
 
-Session resumption shortcuts the TLS so that the client certificate
-negotiation don't occur. It makes up for this by storing client certificate
-an all other negotiated state information encrypted within the ticket. In a
+Session resumption shortcuts the TLS handshake so that the client certificate
+negotiation doesn't occur. It makes up for this by storing the client certificate
+and all other negotiated state information encrypted within the ticket. In a
 resumed session the applications will have all this state information available
 exactly as if a full negotiation had occurred.
 


### PR DESCRIPTION
The existing man page text for `SSL_CTX_set_tlsext_ticket_key_cb`/`SSL_CTX_set_tlsext_ticket_key_evp_cb` had a "NOTES" section that could use some minor editorial tweaks:

* "shortcuts the TLS" -> "shortcuts the TLS handshake"
* "don't occur" -> "doesn't occur"
* "storing client certificate" -> "storing the client certificate"
* "an all other" -> "and all other"

CLA: trivial

##### Checklist
- [x] documentation is added or updated
