### PR TITLE
[DOCS] Correct history in doc/man3/OSSL_STORE_LOADER.pod

### DIFF
--- a/doc/man3/OSSL_STORE_LOADER.pod
+++ b/doc/man3/OSSL_STORE_LOADER.pod
@@ -105,7 +105,6 @@ see L<openssl_user_macros(7)>:
  typedef int (*OSSL_STORE_close_fn)(OSSL_STORE_LOADER_CTX *ctx);
  int OSSL_STORE_LOADER_set_close(OSSL_STORE_LOADER *store_loader,
                                  OSSL_STORE_close_fn store_close_function);
- void OSSL_STORE_LOADER_free(OSSL_STORE_LOADER *store_loader);
 
  int OSSL_STORE_register_loader(OSSL_STORE_LOADER *loader);
  OSSL_STORE_LOADER *OSSL_STORE_unregister_loader(const char *scheme);

--- a/doc/man3/OSSL_STORE_LOADER.pod
+++ b/doc/man3/OSSL_STORE_LOADER.pod
@@ -358,21 +358,25 @@ L<provider-storemgmt(7)>
 =head1 HISTORY
 
 OSSL_STORE_LOADER_fetch(), OSSL_STORE_LOADER_up_ref(),
-OSSL_STORE_LOADER_free(), OSSL_STORE_LOADER_get0_provider(),
-OSSL_STORE_LOADER_get0_properties(), OSSL_STORE_LOADER_is_a(),
-OSSL_STORE_LOADER_do_all_provided() and
-OSSL_STORE_LOADER_names_do_all() were added in OpenSSL 3.0.
+OSSL_STORE_LOADER_get0_provider(), OSSL_STORE_LOADER_get0_properties(),
+OSSL_STORE_LOADER_get0_description(), OSSL_STORE_LOADER_is_a(),
+OSSL_STORE_LOADER_do_all_provided() and OSSL_STORE_LOADER_names_do_all()
+were added in OpenSSL 3.0.
 
-OSSL_STORE_open_ex_fn() was added in OpenSSL 3.0.
+B<OSSL_STORE_LOADER> and OSSL_STORE_LOADER_free() were added in OpenSSL
+1.1.1.
 
-B<OSSL_STORE_LOADER>, B<OSSL_STORE_LOADER_CTX>, OSSL_STORE_LOADER_new(),
+OSSL_STORE_LOADER_set_open_ex() and OSSL_STORE_open_ex_fn() were added in
+OpenSSL 3.0, and are deprecated.
+
+B<OSSL_STORE_LOADER_CTX>, OSSL_STORE_LOADER_new(),
 OSSL_STORE_LOADER_set0_scheme(), OSSL_STORE_LOADER_get0_scheme(),
 OSSL_STORE_LOADER_get0_engine(), OSSL_STORE_LOADER_set_expect(),
 OSSL_STORE_LOADER_set_find(), OSSL_STORE_LOADER_set_attach(),
 OSSL_STORE_LOADER_set_open_ex(), OSSL_STORE_LOADER_set_open(),
 OSSL_STORE_LOADER_set_ctrl(),
 OSSL_STORE_LOADER_set_load(), OSSL_STORE_LOADER_set_eof(),
-OSSL_STORE_LOADER_set_close(), OSSL_STORE_LOADER_free(),
+OSSL_STORE_LOADER_set_close(),
 OSSL_STORE_register_loader(), OSSL_STORE_LOADER_set_error(),
 OSSL_STORE_unregister_loader(), OSSL_STORE_open_fn(), OSSL_STORE_ctrl_fn(),
 OSSL_STORE_load_fn(), OSSL_STORE_eof_fn() and OSSL_STORE_close_fn()


### PR DESCRIPTION
Bulk editing had history wrongly specify current functions as deprecated,
among other small errors.

Fixes #24678
