### PR TITLE
convert hashtable to using ossl_rcu_deref on lookup

### DIFF
--- a/crypto/hashtable/hashtable.c
+++ b/crypto/hashtable/hashtable.c
@@ -639,8 +639,7 @@ HT_VALUE *ossl_ht_get(HT *h, HT_KEY *key)
         CRYPTO_atomic_load(&md->neighborhoods[neigh_idx].entries[j].hash,
                            &ehash, h->atomic_lock);
         if (compare_hash(hash, ehash)) {
-            CRYPTO_atomic_load((uint64_t *)&md->neighborhoods[neigh_idx].entries[j].value,
-                               (uint64_t *)&vidx, h->atomic_lock);
+            vidx = ossl_rcu_deref(&md->neighborhoods[neigh_idx].entries[j].value);
             ret = (HT_VALUE *)vidx;
             break;
         }


### PR DESCRIPTION
The new hashtable has an issue on non-64 bit builds.  We use CRYPTO_atomic_load to load a pointer value when doing lookups, but that API relies on the expectation that pointers are 64 bits wide.  On 32 bit systems, we try to load 64 bits using CRYPTO_atomic_load into a 32 bit pointer, which overruns our stack

Fix this by no longer using CRYPTO_atomic_load for value fetches from the hashtable.  Instead use ossl_rcu_deref, whcih operates on void pointers and is safe on all arches

