### PR TITLE
Extend `flags` and `mask` of `ssl_method_st` to 64-bit

### DIFF
--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -419,7 +419,7 @@ struct ssl_cipher_st {
 struct ssl_method_st {
     int version;
     unsigned flags;
-    unsigned long mask;
+    uint64_t mask;
     SSL *(*ssl_new) (SSL_CTX *ctx);
     void (*ssl_free) (SSL *s);
     int (*ssl_reset) (SSL *s);


### PR DESCRIPTION
Fixes #23260: The bit count for `SSL_OP_*` flags has exceeded 32 bits, making it impossible to handle newer flags and protocol extensions with the existing 32-bit variables. This commit extends the `flags` and `mask` fields in the `ssl_method_st` structure to 64-bit, aligning them with the previously extended 64-bit `options` field.
