### PR TITLE
Fixes #4545 with an additional init check.

### DIFF
--- a/ssl/bio_ssl.c
+++ b/ssl/bio_ssl.c
@@ -79,7 +79,7 @@ static int ssl_free(BIO *a)
         return 0;
     bs = BIO_get_data(a);
     if (BIO_get_shutdown(a)) {
-        if (bs->ssl != NULL)
+        if (bs->ssl != NULL && !SSL_in_init(bs->ssl))
             SSL_shutdown(bs->ssl);
         if (BIO_get_init(a))
             SSL_free(bs->ssl);


### PR DESCRIPTION
If free is called for an SSL BIO that is in initialization phase, the `SSL_shutdown` call is omitted.