### PR TITLE
MASM: Need to strip arguments after .pdata or .xdata

### DIFF
--- a/crypto/perlasm/x86_64-xlate.pl
+++ b/crypto/perlasm/x86_64-xlate.pl
@@ -1047,6 +1047,7 @@ my %globals;
 					    push(@segment_stack, ".text\$");
 				        }
 					$v="$current_segment\tENDS\n" if ($current_segment);
+					$$line =~ s/([^,]*).*/$1/;
 					$v.="$$line\tSEGMENT";
 					if ($$line=~/\.([prx])data/) {
 					    $v.=" READONLY";


### PR DESCRIPTION
For MASM,
```
.section .pdata,"r"
```
got translated to:
```
.pdata,"r"    SEGMENT READONLY ALIGN(4)
```
that breaks ml64.

Previous version of x86_64-xlate.pl did strip that `,"r"`.

CLA: trivial
