### PR TITLE
Fix memory leak in x509_req_test

### DIFF
--- a/test/x509_req_test.c
+++ b/test/x509_req_test.c
@@ -13,7 +13,6 @@
 #include "testutil.h"
 
 static char *certsDir = NULL;
-static char *certFilePath = NULL;
 
 /*
  * Test for the missing X509 version check discussed in issue #5738 and
@@ -24,6 +23,7 @@ static char *certFilePath = NULL;
  */
 static int test_x509_req_detect_invalid_version(void)
 {
+    char *certFilePath;
     BIO *bio = NULL;
     EVP_PKEY *pkey = NULL;
     X509_REQ *req = NULL;
@@ -49,6 +49,7 @@ err:
     EVP_PKEY_free(pkey);
     X509_REQ_free(req);
     BIO_free(bio);
+    OPENSSL_free(certFilePath);
     return ret;
 }
 


### PR DESCRIPTION
Running the x509_req_test with address sanitizer shows a memory leak:

```
==186455==ERROR: LeakSanitizer: detected memory leaks Direct leak of 53 byte(s) in 1 object(s) allocated from:
    #0 0x3ffad5f47af in malloc (/lib64/libasan.so.8+0xf47af) (BuildId: 93b3d2536d76f772a95880d76c746c150daabbee)
    #1 0x3ffac4214fb in CRYPTO_malloc crypto/mem.c:202
    #2 0x3ffac421759 in CRYPTO_zalloc crypto/mem.c:222
    #3 0x100e58f in test_mk_file_path test/testutil/driver.c:450
    #4 0x1004671 in test_x509_req_detect_invalid_version test/x509_req_test.c:32
    #5 0x100d247 in run_tests test/testutil/driver.c:342
    #6 0x10042e3 in main test/testutil/main.c:31
    #7 0x3ffaad34a5b in __libc_start_call_main (/lib64/libc.so.6+0x34a5b) (BuildId: 461b58df774538594b6173825bed67a9247a014d)
    #8 0x3ffaad34b5d in __libc_start_main@GLIBC_2.2 (/lib64/libc.so.6+0x34b5d) (BuildId: 461b58df774538594b6173825bed67a9247a014d)
    #9 0x1004569  (/root/openssl/test/x509_req_test+0x1004569) (BuildId: ab6bce0e531df1e3626a8f506d07f6ad7c7c6d57)
SUMMARY: AddressSanitizer: 53 byte(s) leaked in 1 allocation(s).
```

The certFilePath that is obtained via `test_mk_file_path()` must be freed when no longer used.

While at it, make the `certFilePath` variable a local variable, there is no need to have this a global static variable.

Fixes: https://github.com/openssl/openssl/commit/7d2c0a4b1feb152ee1190dfedc65dfd1c928f9e5

