### PR TITLE
free'ing appname if it was set after initializing crypto.

### DIFF
--- a/crypto/conf/conf_sap.c
+++ b/crypto/conf/conf_sap.c
@@ -38,6 +38,8 @@ void OPENSSL_config(const char *appname)
         settings.appname = strdup(appname);
     settings.flags = DEFAULT_CONF_MFLAGS;
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, &settings);
+
+    free(settings.appname);
 }
 #endif
 


### PR DESCRIPTION
Fixes: #24729

As proposed in #24729, we need to free appname after crypto finished initializing, iff it was set. We are checking `appname != NULL` rather than `settings.appname` -- these two are equivalent at the moment but possibly could change later, so to avoid possible double-free it's better to be explicit and only free what we know we allocated.

CLA: trivial


##### Checklist
N/A