### PR TITLE
Apply fixup to feature/dtls-1.3 branch in order to rebase

### DIFF
--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -118,15 +118,18 @@ algorithms to support.
 
 The B<algs> argument should be a colon separated list of signature
 algorithms in order of decreasing preference of the form B<algorithm+hash>
-or B<signature_scheme>. B<algorithm> is one of B<RSA>, B<DSA> or B<ECDSA> and
+or B<signature_scheme>. For the default providers shipped with OpenSSL,
+B<algorithm> is one of B<RSA>, B<DSA> or B<ECDSA> and
 B<hash> is a supported algorithm OID short name such as B<SHA1>, B<SHA224>,
-B<SHA256>, B<SHA384> of B<SHA512>.  Note: algorithm and hash names are case
+B<SHA256>, B<SHA384> or B<SHA512>.  Note: algorithm and hash names are case
 sensitive.  B<signature_scheme> is one of the signature schemes defined in
 (D)TLSv1.3, specified using the IETF name, e.g., B<ecdsa_secp256r1_sha256>,
-B<ed25519>, or B<rsa_pss_pss_sha256>.
+B<ed25519>, or B<rsa_pss_pss_sha256>. Additional providers may make available
+further algorithms via the TLS_SIGALG capability.
+See L<provider-base(7)/CAPABILITIES>.
 
-If this option is not set then all signature algorithms supported by the
-OpenSSL library are permissible.
+If this option is not set then all signature algorithms supported by all
+activated providers are permissible.
 
 Note: algorithms which specify a PKCS#1 v1.5 signature scheme (either by
 using B<RSA> as the B<algorithm> or by using one of the B<rsa_pkcs1_*>
@@ -371,16 +374,19 @@ servers it is used to determine which signature algorithms to support.
 
 The B<value> argument should be a colon separated list of signature algorithms
 in order of decreasing preference of the form B<algorithm+hash> or
-B<signature_scheme>. B<algorithm>
-is one of B<RSA>, B<DSA> or B<ECDSA> and B<hash> is a supported algorithm
-OID short name such as B<SHA1>, B<SHA224>, B<SHA256>, B<SHA384> of B<SHA512>.
+B<signature_scheme>. For the default providers shipped with OpenSSL,
+B<algorithm> is one of B<RSA>, B<DSA> or B<ECDSA> and B<hash> is a supported
+algorithm OID short name such as B<SHA1>, B<SHA224>, B<SHA256>, B<SHA384>
+or B<SHA512>.
 Note: algorithm and hash names are case sensitive.
 B<signature_scheme> is one of the signature schemes defined in (D)TLSv1.3,
 specified using the IETF name, e.g., B<ecdsa_secp256r1_sha256>, B<ed25519>,
 or B<rsa_pss_pss_sha256>.
+Additional providers may make available further algorithms via the TLS_SIGALG
+capability. See L<provider-base(7)/CAPABILITIES>.
 
-If this option is not set then all signature algorithms supported by the
-OpenSSL library are permissible.
+If this option is not set then all signature algorithms supported by all
+activated providers are permissible.
 
 Note: algorithms which specify a PKCS#1 v1.5 signature scheme (either by
 using B<RSA> as the B<algorithm> or by using one of the B<rsa_pkcs1_*>


### PR DESCRIPTION
There is a conflict when trying to rebase the feature/dtls-1.3 branch on top of the latest master. By applying this fixup commit to the feature branch first the conflict mostly goes away.

There is one other conflict that occurs at this point but it seems to be mostly a git ghost. I can't figure out why the remaining conflict occurs since as far as I can tell there should be no conflict. Merely accepting the incoming change resolves the issue.

Once this fixup is approved I plan to apply it to the feature/dtls-1.3 branch and then immediately rebase it against master (resolving the trivial conflict noted above).
