### PR TITLE
In scrypt remove the check that N < 2^(128 * r / 8)

### DIFF
--- a/providers/implementations/kdfs/scrypt.c
+++ b/providers/implementations/kdfs/scrypt.c
@@ -461,18 +461,6 @@ static int scrypt_alg(const char *pass, size_t passlen,
         return 0;
     }
 
-    /*
-     * Need to check N: if 2^(128 * r / 8) overflows limit this is
-     * automatically satisfied since N <= UINT64_MAX.
-     */
-
-    if (16 * r <= LOG2_UINT64_MAX) {
-        if (N >= (((uint64_t)1) << (16 * r))) {
-            ERR_raise(ERR_LIB_EVP, EVP_R_MEMORY_LIMIT_EXCEEDED);
-            return 0;
-        }
-    }
-
     /* Memory checks: check total allocated buffer size fits in uint64_t */
 
     /*

--- a/test/recipes/30-test_evp_data/evpkdf_scrypt.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_scrypt.txt
@@ -53,6 +53,14 @@ Ctrl.r = r:8
 Ctrl.p = p:1
 Output = 7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887
 
+KDF = id-scrypt
+Ctrl.pass = pass:pass
+Ctrl.salt = salt:salt
+Ctrl.N = n:262144
+Ctrl.r = r:1
+Ctrl.p = p:1
+Output = 60d559ba9609b74d574019cc50835e3f294d56b1ea6eda3edccc7279324e4037173d34a813030f15068e3835230a99dfc91d487ce258a43be5044c4e04c8697b
+
 # Out of memory
 KDF = id-scrypt
 Ctrl.pass = pass:pleaseletmein

--- a/test/recipes/30-test_evp_data/evppkey_kdf_scrypt.txt
+++ b/test/recipes/30-test_evp_data/evppkey_kdf_scrypt.txt
@@ -53,6 +53,14 @@ Ctrl.r = r:8
 Ctrl.p = p:1
 Output = 7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887
 
+PKEYKDF = scrypt
+Ctrl.pass = pass:pass
+Ctrl.salt = salt:salt
+Ctrl.N = N:262144
+Ctrl.r = r:1
+Ctrl.p = p:1
+Output = 60d559ba9609b74d574019cc50835e3f294d56b1ea6eda3edccc7279324e4037173d34a813030f15068e3835230a99dfc91d487ce258a43be5044c4e04c8697b
+
 # Out of memory
 PKEYKDF = scrypt
 Ctrl.pass = pass:pleaseletmein


### PR DESCRIPTION
This bound is given in RFC 7914, and would imply that scrypt could not make use of more than 16 MB of memory. This bound is contradicted by the RFC itself, which includes tests which use up to 1 GB.

An errata was filed for the RFC in 2020 regarding this issue, but never acted upon by the authors.

See #24650 for background
