### PR TITLE
Fix several errors in our os zoo ci jobs

### DIFF
--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -27,7 +27,7 @@ jobs:
       image: docker.io/library/alpine:${{ matrix.tag }}
     env:
       # https://www.openwall.com/lists/musl/2022/02/16/14
-      EXTRA_CFLAGS: ${{ matrix.cc == 'clang' && '-Wno-sign-compare' || '' }}
+      EXTRA_CFLAGS: ${{ matrix.cc == 'clang' && '-Wno-sign-compare -Wno-switch-default' || '' }}
       CC: ${{ matrix.cc }}
     steps:
     - name: install packages

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -37,7 +37,7 @@ jobs:
         ref: ${{ matrix.branch }}
     - name: config
       run: |
-        ./config --banner=Configured no-shared -Wall -Werror enable-fips --strict-warnings -DOPENSSL_USE_IPV6=0 \
+        ./config --banner=Configured no-shared -Wall -Werror enable-fips --strict-warnings \
                  ${EXTRA_CFLAGS}
     - name: config dump
       run: ./configdata.pm --dump

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -105,7 +105,7 @@ jobs:
       fail-fast: false
       matrix:
         branch: [openssl-3.0, openssl-3.1, master]
-        os: [macos-11, macos-12, macos-13, macos-14]
+        os: [macos-12, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Fix several items discovered here 

https://github.com/openssl/openssl/issues/24739

It appears we've recently run into a few os zoo CI errors:
* alpine containers seem to have recently enabled ipv6, which breaks our build that set OPENSSL_USE_IPV6=0
* macos-11 is being deprecated in github soon, for which we hit a brownout
* clang-18 on newer containers is complaining about several switch statements that have no default case.

Address those issues here.  Also add a manual_dispatch trigger for os-zoo so we can run it manually to diagnose problems in the future rather than waiting for the cron job to run it.