### PR TITLE
Clarify DRBG seeding.

### DIFF
--- a/providers/implementations/rands/drbg.c
+++ b/providers/implementations/rands/drbg.c
@@ -202,6 +202,11 @@ static size_t get_entropy(PROV_DRBG *drbg, unsigned char **pout, int entropy,
         return ossl_crngt_get_entropy(drbg, pout, entropy, min_len, max_len,
                                       prediction_resistance);
 #else
+        /*
+         * In normal use (i.e. OpenSSL's own uses), this is never called.
+         * Outside of the FIPS provider, OpenSSL set's its DRBGs up so that
+         * they always have a parent.  This remains purely for legacy reasons.
+         */
         return ossl_prov_get_entropy(drbg->provctx, pout, entropy, min_len,
                                      max_len);
 #endif

--- a/providers/implementations/rands/drbg.c
+++ b/providers/implementations/rands/drbg.c
@@ -204,7 +204,7 @@ static size_t get_entropy(PROV_DRBG *drbg, unsigned char **pout, int entropy,
 #else
         /*
          * In normal use (i.e. OpenSSL's own uses), this is never called.
-         * Outside of the FIPS provider, OpenSSL set's its DRBGs up so that
+         * Outside of the FIPS provider, OpenSSL sets its DRBGs up so that
          * they always have a parent.  This remains purely for legacy reasons.
          */
         return ossl_prov_get_entropy(drbg->provctx, pout, entropy, min_len,


### PR DESCRIPTION
There is a legacy code path that OpenSSL won't use anymore but applications could.  Add a comment indicating this to avoid confusion for people not intimately conversant with the nuances in the RNG code.

- [x] documentation is added or updated
- [ ] tests are added or updated
