### PR TITLE
The issue has been discovered by libFuzzer running on provider target.

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -425,7 +425,7 @@ int EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *data, size_t count)
 
     /* Code below to be removed when legacy support is dropped. */
  legacy:
-    return ctx->update(ctx, data, count);
+    return ctx->update != NULL ? ctx->update(ctx, data, count) : 0;
 }
 
 /* The caller can assume that this removes any secret data from the context */

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -5624,6 +5624,25 @@ static int test_aes_rc4_keylen_change_cve_2023_5363(void)
 }
 #endif
 
+static int test_invalid_ctx_for_digest(void)
+{
+    int ret;
+    EVP_MD_CTX *mdctx;
+
+    mdctx = EVP_MD_CTX_new();
+    if (mdctx == NULL)
+        return 0;
+
+    if (EVP_DigestUpdate(mdctx, "test", sizeof("test") - 1) == 1)
+        ret = 0;
+    else
+        ret = 1;
+
+    EVP_MD_CTX_free(mdctx);
+
+    return ret;
+}
+
 int setup_tests(void)
 {
     OPTION_CHOICE o;
@@ -5794,6 +5813,8 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_RC4
     ADD_TEST(test_aes_rc4_keylen_change_cve_2023_5363);
 #endif
+
+    ADD_TEST(test_invalid_ctx_for_digest);
 
     return 1;
 }

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -5630,10 +5630,10 @@ static int test_invalid_ctx_for_digest(void)
     EVP_MD_CTX *mdctx;
 
     mdctx = EVP_MD_CTX_new();
-    if (mdctx == NULL)
+    if (!TEST_ptr(mdctx))
         return 0;
 
-    if (EVP_DigestUpdate(mdctx, "test", sizeof("test") - 1) == 1)
+    if (!TEST_int_eq(EVP_DigestUpdate(mdctx, "test", sizeof("test") - 1), 0))
         ret = 0;
     else
         ret = 1;


### PR DESCRIPTION
There are currently three distinct reports which are addressed by code change here.

    https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=69236#c1
    https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=69243#c1
    https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=69261#c1

the issue has been introduced with openssl 3.0.

