### PR TITLE
Add default: label to all switch statements that omitted them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       run: sudo locale-gen tr_TR.UTF-8
     - name: config
       # enable-quic is on by default, but we leave it here to check we're testing the explicit enable somewhere
-      run: CC=gcc ./config --banner=Configured enable-demos enable-h3demo enable-fips enable-quic --strict-warnings && perl configdata.pm --dump
+      run: CC=gcc ./config --banner=Configured enable-demos enable-h3demo enable-fips enable-quic --strict-warnings -Wall -Werror -Wswitch-default && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: get cpu info

--- a/apps/asn1parse.c
+++ b/apps/asn1parse.c
@@ -155,6 +155,8 @@ int asn1parse_main(int argc, char **argv)
                 goto end;
             }
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -501,6 +501,8 @@ opthelp:
         case OPT_ENGINE:
             e = setup_engine(opt_arg(), 0);
             break;
+        default:
+            break;
         }
     }
 
@@ -2393,6 +2395,8 @@ static char *make_revocation_str(REVINFO_TYPE rev_type, const char *rev_arg)
         else
             reason = "CAkeyTime";
 
+        break;
+    default:
         break;
     }
 

--- a/apps/ciphers.c
+++ b/apps/ciphers.c
@@ -169,6 +169,8 @@ int ciphers_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -3142,6 +3142,8 @@ static int get_opts(int argc, char **argv)
         case OPT_ACCEPT_RAVERIFIED:
             opt_accept_raverified = 1;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -697,6 +697,8 @@ int cms_main(int argc, char **argv)
         case OPT_3DES_WRAP:
             wrapname = opt_flag() + 1;
             break;
+        default:
+            break;
         }
     }
     if (!app_RAND_load())

--- a/apps/crl.c
+++ b/apps/crl.c
@@ -206,6 +206,8 @@ int crl_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/crl2pkcs7.c
+++ b/apps/crl2pkcs7.c
@@ -100,6 +100,8 @@ int crl2pkcs7_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -219,6 +219,8 @@ int dgst_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -155,6 +155,8 @@ int dhparam_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/dsa.c
+++ b/apps/dsa.c
@@ -158,6 +158,8 @@ int dsa_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -126,6 +126,8 @@ int dsaparam_main(int argc, char **argv)
         case OPT_QUIET:
             verbose = 0;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/ec.c
+++ b/apps/ec.c
@@ -154,6 +154,8 @@ int ec_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -182,6 +182,8 @@ int ecparam_main(int argc, char **argv)
         case OPT_ENGINE:
             e = setup_engine(opt_arg(), 0);
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -318,6 +318,8 @@ int enc_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/engine.c
+++ b/apps/engine.c
@@ -357,6 +357,8 @@ int engine_main(int argc, char **argv)
         case OPT_POST:
             sk_OPENSSL_STRING_push(post_cmds, opt_arg());
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/errstr.c
+++ b/apps/errstr.c
@@ -49,6 +49,8 @@ int errstr_main(int argc, char **argv)
             opt_help(errstr_options);
             ret = 0;
             goto end;
+        default:
+            break;
         }
     }
 

--- a/apps/fipsinstall.c
+++ b/apps/fipsinstall.c
@@ -461,6 +461,8 @@ opthelp:
                 goto end;
             fips_opts.self_test_onload = 0;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -102,6 +102,8 @@ int gendsa_main(int argc, char **argv)
         case OPT_QUIET:
             verbose = 0;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -193,6 +193,8 @@ int genpkey_main(int argc, char **argv)
             if (!opt_rand(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -145,6 +145,8 @@ opthelp:
         case OPT_TRADITIONAL:
             traditional = 1;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/lib/app_provider.c
+++ b/apps/lib/app_provider.c
@@ -80,6 +80,8 @@ int opt_provider(int opt)
         return opt_provider_path(opt_arg());
     case OPT_PROV_PROPQUERY:
         return app_set_propq(opt_arg());
+    default:
+        break;
     }
     /* Should never get here but if we do, undo what we did earlier */
     provider_option_given = given;

--- a/apps/lib/app_rand.c
+++ b/apps/lib/app_rand.c
@@ -117,6 +117,8 @@ int opt_rand(int opt)
         if (save_rand_file == NULL)
             return 0;
         break;
+    default:
+        break;
     }
     return 1;
 }

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -895,6 +895,8 @@ static const char *format2string(int format)
         return "PEM";
     case FORMAT_ASN1:
         return "DER";
+    default:
+        break;
     }
     return NULL;
 }
@@ -1897,6 +1899,8 @@ int parse_yesno(const char *str, int def)
         case 'Y':              /* YES */
         case '1':              /* 1 */
             return 1;
+        default:
+            break;
         }
     }
     return def;
@@ -3059,6 +3063,8 @@ static const char *modestr(char mode, int format)
         return FMT_istext(format) ? "r" : "rb";
     case 'w':
         return FMT_istext(format) ? "w" : "wb";
+    default:
+        break;
     }
     /* The assert above should make sure we never reach this point */
     return NULL;
@@ -3073,6 +3079,8 @@ static const char *modeverb(char mode)
         return "reading";
     case 'w':
         return "writing";
+    default:
+        break;
     }
     return "(doing something)";
 }

--- a/apps/lib/apps_ui.c
+++ b/apps/lib/apps_ui.c
@@ -48,6 +48,8 @@ static int ui_read(UI *ui, UI_STRING *uis)
         case UIT_INFO:
         case UIT_ERROR:
             break;
+        default:
+            break;
         }
     }
 
@@ -80,6 +82,8 @@ static int ui_write(UI *ui, UI_STRING *uis)
         case UIT_BOOLEAN:
         case UIT_INFO:
         case UIT_ERROR:
+            break;
+        default:
             break;
         }
     }

--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -859,6 +859,8 @@ int opt_verify(int opt, X509_VERIFY_PARAM *vpm)
     case OPT_V_ALLOW_PROXY_CERTS:
         X509_VERIFY_PARAM_set_flags(vpm, X509_V_FLAG_ALLOW_PROXY_CERTS);
         break;
+    default:
+        break;
     }
     return 1;
 
@@ -1124,6 +1126,8 @@ static const char *valtype2param(const OPTIONS *o)
         return "nonneg";
     case 'U':
         return "uintmax";
+    default:
+        break;
     }
     return "parm";
 }

--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -106,6 +106,8 @@ int verify_callback(int ok, X509_STORE_CTX *ctx)
         if (!verify_args.quiet)
             policies_print(ctx);
         break;
+    default:
+        break;
     }
     if (err == X509_V_OK && ok == 2 && !verify_args.quiet)
         policies_print(ctx);
@@ -1154,6 +1156,8 @@ int args_excert(int opt, SSL_EXCERT **pexc)
         if (!opt_format(opt_arg(), OPT_FMT_ANY, &exc->keyform))
             return 0;
         break;
+    default:
+        break;
     }
     return 1;
 
@@ -1479,6 +1483,8 @@ static int security_callback_debug(const SSL *s, const SSL_CTX *ctx,
     case SSL_SECOP_SIGALG_MASK:
         show_nm = 0;
         break;
+    default:
+        break;
     }
     if (show_nm)
         BIO_printf(sdb->out, "%s=", nm);
@@ -1550,6 +1556,8 @@ static int security_callback_debug(const SSL *s, const SSL_CTX *ctx,
             }
         }
 
+    default:
+        break;
     }
 
     if (show_bits)

--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -653,6 +653,8 @@ void msg_cb(int write_p, int version, int content_type, const void *buf,
                 case 2:
                     str_details1 = ", fatal";
                     break;
+                default:
+                    break;
                 }
                 str_details2 = lookup((int)bp[1], alert_types, " ???");
             }

--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -479,6 +479,8 @@ void do_ssl_shutdown(SSL *ssl)
             case SSL_ERROR_WANT_ASYNC_JOB:
                 /* We just do busy waiting. Nothing clever */
                 continue;
+            default:
+                break;
             }
             ret = 0;
         }

--- a/apps/list.c
+++ b/apps/list.c
@@ -1672,6 +1672,8 @@ opthelp:
             if (!opt_provider(o))
                 return 1;
             break;
+        default:
+            break;
         }
         done = 1;
     }

--- a/apps/nseq.c
+++ b/apps/nseq.c
@@ -69,6 +69,8 @@ int nseq_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -530,6 +530,8 @@ int ocsp_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -143,6 +143,8 @@ static size_t internal_trace_cb(const char *buf, size_t cnt,
         BIO_set_prefix(trace_data->bio, NULL);
 
         break;
+    default:
+        break;
     }
 
     return ret < 0 ? 0 : ret;
@@ -355,6 +357,8 @@ int help_main(int argc, char **argv)
         case OPT_hHELP:
             opt_help(help_options);
             return 0;
+        default:
+            break;
         }
     }
 

--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -182,6 +182,8 @@ int passwd_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -367,6 +367,8 @@ int pkcs12_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/pkcs7.c
+++ b/apps/pkcs7.c
@@ -112,6 +112,8 @@ int pkcs7_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/pkcs8.c
+++ b/apps/pkcs8.c
@@ -199,6 +199,8 @@ int pkcs8_main(int argc, char **argv)
             if (!opt_int(opt_arg(), &saltlen))
                 goto opthelp;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -168,6 +168,8 @@ int pkey_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/pkeyparam.c
+++ b/apps/pkeyparam.c
@@ -87,6 +87,8 @@ int pkeyparam_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -249,6 +249,8 @@ int pkeyutl_main(int argc, char **argv)
         case OPT_DIGEST:
             digestname = opt_arg();
             break;
+        default:
+            break;
         }
     }
 
@@ -563,6 +565,8 @@ static EVP_PKEY_CTX *init_ctx(const char *kdfalg, int *pkeysize,
     case KEY_NONE:
         break;
 
+    default:
+        break;
     }
 
 #ifndef OPENSSL_NO_ENGINE
@@ -615,6 +619,8 @@ static EVP_PKEY_CTX *init_ctx(const char *kdfalg, int *pkeysize,
             rv = EVP_DigestVerifyInit_ex(mctx, NULL, digestname, libctx, propq,
                                          pkey, NULL);
             break;
+        default:
+            break;
         }
 
     } else {
@@ -641,6 +647,8 @@ static EVP_PKEY_CTX *init_ctx(const char *kdfalg, int *pkeysize,
 
         case EVP_PKEY_OP_DERIVE:
             rv = EVP_PKEY_derive_init(ctx);
+            break;
+        default:
             break;
         }
     }
@@ -703,6 +711,8 @@ static int do_keyop(EVP_PKEY_CTX *ctx, int pkey_op,
         rv = EVP_PKEY_derive(ctx, out, poutlen);
         break;
 
+    default:
+        break;
     }
     return rv;
 }
@@ -749,6 +759,8 @@ static int do_raw_keyop(int pkey_op, EVP_MD_CTX *mctx,
                 rv = EVP_DigestSign(mctx, *out, poutlen, mbuf, buf_len);
             }
             break;
+        default:
+            break;
         }
         goto end;
     }
@@ -791,6 +803,8 @@ static int do_raw_keyop(int pkey_op, EVP_MD_CTX *mctx,
             *out = app_malloc(*poutlen, "buffer output");
             rv = EVP_DigestSignFinal(mctx, *out, poutlen);
         }
+        break;
+    default:
         break;
     }
 

--- a/apps/prime.c
+++ b/apps/prime.c
@@ -96,6 +96,8 @@ opthelp:
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/rand.c
+++ b/apps/rand.c
@@ -90,6 +90,8 @@ int rand_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -543,6 +543,8 @@ int rehash_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/req.c
+++ b/apps/req.c
@@ -493,6 +493,8 @@ int req_main(int argc, char **argv)
         case OPT_MD:
             digest = opt_unknown();
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -214,6 +214,8 @@ int rsa_main(int argc, char **argv)
         case OPT_TRADITIONAL:
             traditional = 1;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/rsautl.c
+++ b/apps/rsautl.c
@@ -165,6 +165,8 @@ int rsautl_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 
@@ -200,6 +202,8 @@ int rsautl_main(int argc, char **argv)
             pkey = X509_get_pubkey(x);
             X509_free(x);
         }
+        break;
+    default:
         break;
     }
 
@@ -261,6 +265,8 @@ int rsautl_main(int argc, char **argv)
         rv = EVP_PKEY_decrypt_init(ctx) > 0
             && EVP_PKEY_CTX_set_rsa_padding(ctx, pad) > 0
             && EVP_PKEY_decrypt(ctx, rsa_out, &rsa_outlen, rsa_in, rsa_inlen) > 0;
+        break;
+    default:
         break;
     }
 

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2859,6 +2859,8 @@ int s_client_main(int argc, char **argv)
             mbuf_len = 0;
         }
         break;
+    default:
+        break;
     }
 
     if (early_data_file != NULL
@@ -3135,6 +3137,8 @@ int s_client_main(int argc, char **argv)
             case SSL_ERROR_SSL:
                 ERR_print_errors(bio_err);
                 goto shut;
+            default:
+                break;
             }
         }
 #if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_MSDOS) || defined(OPENSSL_SYS_VMS)
@@ -3223,6 +3227,8 @@ int s_client_main(int argc, char **argv)
             case SSL_ERROR_SSL:
                 ERR_print_errors(bio_err);
                 goto shut;
+            default:
+                break;
             }
         }
 
@@ -3569,6 +3575,8 @@ static void print_stuff(BIO *bio, SSL *s, int full)
             BIO_printf(bio, "Early data was accepted\n");
             break;
 
+        default:
+            break;
         }
 
         /*

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1571,6 +1571,8 @@ int s_client_main(int argc, char **argv)
         case OPT_ENABLE_CLIENT_RPK:
             enable_client_rpk = 1;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1704,6 +1704,8 @@ int s_server_main(int argc, char *argv[])
         case OPT_ENABLE_CLIENT_RPK:
             enable_client_rpk = 1;
             break;
+        default:
+            break;
         }
     }
 
@@ -2815,6 +2817,8 @@ static int sv_body(int s, int stype, int prot, unsigned char *context)
                     (void)BIO_flush(bio_s_out);
                     ret = 1;
                     goto err;
+                default:
+                    break;
                 }
                 if (k > 0) {
                     l += k;
@@ -2906,6 +2910,8 @@ static int sv_body(int s, int stype, int prot, unsigned char *context)
                     (void)BIO_flush(bio_s_out);
                     ret = 1;
                     goto err;
+                default:
+                    break;
                 }
             }
         }
@@ -3433,6 +3439,8 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
                     break;
                 case 3:
                     dot = (e[0] == '/' || e[0] == '\\') ? -1 : 0;
+                    break;
+                default:
                     break;
                 }
                 if (dot == 0)

--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -230,6 +230,8 @@ int s_time_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/sess_id.c
+++ b/apps/sess_id.c
@@ -94,6 +94,8 @@ int sess_id_main(int argc, char **argv)
         case OPT_CONTEXT:
             context = opt_arg();
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -385,6 +385,8 @@ int smime_main(int argc, char **argv)
                 goto opthelp;
             vpmtouched++;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1466,6 +1466,8 @@ static int run_benchmark(int async_jobs,
             ERR_print_errors(bio_err);
             error = 1;
             break;
+        default:
+            break;
         }
     }
 
@@ -1571,6 +1573,8 @@ static int run_benchmark(int async_jobs,
                 BIO_printf(bio_err, "Failure in the job\n");
                 ERR_print_errors(bio_err);
                 error = 1;
+                break;
+            default:
                 break;
             }
         }
@@ -2069,6 +2073,8 @@ int speed_main(int argc, char **argv)
                        prog);
             goto end;
 #endif
+            break;
+        default:
             break;
         }
     }

--- a/apps/spkac.c
+++ b/apps/spkac.c
@@ -129,6 +129,8 @@ int spkac_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/srp.c
+++ b/apps/srp.c
@@ -302,6 +302,8 @@ int srp_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/storeutl.c
+++ b/apps/storeutl.c
@@ -254,6 +254,8 @@ int storeutl_main(int argc, char *argv[])
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 
@@ -300,6 +302,8 @@ int storeutl_main(int argc, char *argv[])
                 ERR_print_errors(bio_err);
                 goto end;
             }
+            break;
+        default:
             break;
         }
     }

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -287,6 +287,8 @@ int ts_main(int argc, char **argv)
                 goto end;
             vpmtouched++;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -191,6 +191,8 @@ int verify_main(int argc, char **argv)
             if (!opt_provider(o))
                 goto end;
             break;
+        default:
+            break;
         }
     }
 
@@ -381,6 +383,8 @@ static int cb(int ok, X509_STORE_CTX *ctx)
         case X509_V_ERR_MISSING_SUBJECT_KEY_IDENTIFIER:
         case X509_V_ERR_EXTENSIONS_REQUIRE_VERSION_3:
             ok = 1;
+        default:
+            break;
         }
         return ok;
 

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -383,6 +383,7 @@ static int cb(int ok, X509_STORE_CTX *ctx)
         case X509_V_ERR_MISSING_SUBJECT_KEY_IDENTIFIER:
         case X509_V_ERR_EXTENSIONS_REQUIRE_VERSION_3:
             ok = 1;
+            break;
         default:
             break;
         }

--- a/apps/version.c
+++ b/apps/version.c
@@ -95,6 +95,8 @@ opthelp:
                 = dir = engdir = moddir = cpuinfo
                 = 1;
             break;
+        default:
+            break;
         }
     }
 

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -609,6 +609,8 @@ int x509_main(int argc, char **argv)
         case OPT_MD:
             digest = opt_unknown();
             break;
+        default:
+            break;
         }
     }
     /* No extra arguments. */

--- a/crypto/asn1/a_mbstr.c
+++ b/crypto/asn1/a_mbstr.c
@@ -185,6 +185,8 @@ int ASN1_mbstring_ncopy(ASN1_STRING **out, const unsigned char *in, int len,
         traverse_string(in, len, inform, out_utf8, &outlen);
         cpyfunc = cpy_utf8;
         break;
+    default:
+        break;
     }
     if ((p = OPENSSL_malloc(outlen + 1)) == NULL) {
         if (free_out) {

--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -182,6 +182,8 @@ int ossl_asn1_time_to_tm(struct tm *tm, const ASN1_TIME *d)
         case 6:
             tmp.tm_sec = n;
             break;
+        default:
+            break;
         }
     }
 

--- a/crypto/asn1/asn1_gen.c
+++ b/crypto/asn1/asn1_gen.c
@@ -339,6 +339,8 @@ static int asn1_cb(const char *elem, int len, void *bitstr)
         }
         break;
 
+    default:
+        break;
     }
 
     return 1;

--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -773,6 +773,8 @@ static STACK_OF(MIME_HEADER) *mime_parse_hdr(BIO *bio)
                     state = MIME_VALUE;
                 }
                 break;
+            default:
+                break;
             }
         }
 

--- a/crypto/asn1/bio_asn1.c
+++ b/crypto/asn1/bio_asn1.c
@@ -239,6 +239,8 @@ static int asn1_bio_write(BIO *b, const char *in, int inl)
             BIO_clear_retry_flags(b);
             return 0;
 
+        default:
+            break;
         }
 
     }

--- a/crypto/asn1/tasn_fre.c
+++ b/crypto/asn1/tasn_fre.c
@@ -116,6 +116,8 @@ void ossl_asn1_item_embed_free(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed
             *pval = NULL;
         }
         break;
+    default:
+        break;
     }
 }
 

--- a/crypto/asn1/tasn_new.c
+++ b/crypto/asn1/tasn_new.c
@@ -154,6 +154,8 @@ int asn1_item_embed_new(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed,
         if (asn1_cb && !asn1_cb(ASN1_OP_NEW_POST, pval, it, NULL))
             goto auxerr2;
         break;
+    default:
+        break;
     }
     return 1;
 
@@ -200,6 +202,8 @@ static void asn1_item_clear(ASN1_VALUE **pval, const ASN1_ITEM *it)
     case ASN1_ITYPE_SEQUENCE:
     case ASN1_ITYPE_NDEF_SEQUENCE:
         *pval = NULL;
+        break;
+    default:
         break;
     }
 }

--- a/crypto/asn1/tasn_utl.c
+++ b/crypto/asn1/tasn_utl.c
@@ -108,6 +108,8 @@ int ossl_asn1_do_lock(ASN1_VALUE **pval, int op, const ASN1_ITEM *it)
             CRYPTO_FREE_REF(refcnt);
         }
         break;
+    default:
+        break;
     }
 
     return ret;

--- a/crypto/asn1/x_long.c
+++ b/crypto/asn1/x_long.c
@@ -149,6 +149,8 @@ static int long_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
             len--;
             sign = 0;
             break;
+        default:
+            break;
         }
     }
     if (len > (int)sizeof(long)) {

--- a/crypto/bf/bf_local.h
+++ b/crypto/bf/bf_local.h
@@ -31,6 +31,7 @@
                         case 2: l1|=((unsigned long)(*(--(c))))<<16; \
                         /* fall through */                              \
                         case 1: l1|=((unsigned long)(*(--(c))))<<24; \
+                        /* fall through */                               \
                         default: \
                             break; \
                                 } \
@@ -55,6 +56,7 @@
                         case 2: *(--(c))=(unsigned char)(((l1)>>16)&0xff); \
                         /* fall through */                                    \
                         case 1: *(--(c))=(unsigned char)(((l1)>>24)&0xff); \
+                        /* fall through */                               \
                         default: \
                             break; \
                                 } \

--- a/crypto/bf/bf_local.h
+++ b/crypto/bf/bf_local.h
@@ -31,6 +31,8 @@
                         case 2: l1|=((unsigned long)(*(--(c))))<<16; \
                         /* fall through */                              \
                         case 1: l1|=((unsigned long)(*(--(c))))<<24; \
+                        default: \
+                            break; \
                                 } \
                         }
 
@@ -53,6 +55,8 @@
                         case 2: *(--(c))=(unsigned char)(((l1)>>16)&0xff); \
                         /* fall through */                                    \
                         case 1: *(--(c))=(unsigned char)(((l1)>>24)&0xff); \
+                        default: \
+                            break; \
                                 } \
                         }
 

--- a/crypto/bio/bf_prefix.c
+++ b/crypto/bio/bf_prefix.c
@@ -183,6 +183,8 @@ static long prefix_ctrl(BIO *b, int cmd, long num, void *ptr)
         case BIO_CTRL_RESET:
             ctx->linestart = 1;
             break;
+        default:
+            break;
         }
         if (BIO_next(b) != NULL)
             ret = BIO_ctrl(BIO_next(b), cmd, num, ptr);

--- a/crypto/bio/bio_addr.c
+++ b/crypto/bio/bio_addr.c
@@ -885,6 +885,8 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
             case SOCK_DGRAM:
                 proto = "udp";
                 break;
+            default:
+                break;
             }
 
             if (endp != service && *endp == '\0'

--- a/crypto/bio/bss_core.c
+++ b/crypto/bio/bss_core.c
@@ -181,6 +181,8 @@ int ossl_bio_init_core(OSSL_LIB_CTX *libctx, const OSSL_DISPATCH *fns)
             if (bcgbl->c_bio_free == NULL)
                 bcgbl->c_bio_free = OSSL_FUNC_BIO_free(fns);
             break;
+        default:
+            break;
         }
     }
 

--- a/crypto/bio/bss_log.c
+++ b/crypto/bio/bss_log.c
@@ -356,6 +356,8 @@ static void xsyslog(BIO *bp, int priority, const char *string)
     case LOG_DEBUG:
         priority_tag = "DEBUG";
         break;
+    default:
+        break;
     }
 
     buf_dsc.dsc$b_dtype = DSC$K_DTYPE_T;

--- a/crypto/bn/bn_mul.c
+++ b/crypto/bn/bn_mul.c
@@ -125,6 +125,8 @@ BN_ULONG bn_sub_part_words(BN_ULONG *r,
                     r[3] = a[3];
                     if (--dl <= 0)
                         break;
+                default:
+                    break;
                 }
                 a += 4;
                 r += 4;
@@ -237,6 +239,8 @@ void bn_mul_recursive(BN_ULONG *r, BN_ULONG *a, BN_ULONG *b, int n2,
     case 4:
         bn_sub_part_words(t, a, &(a[n]), tna, n - tna);
         bn_sub_part_words(&(t[n]), &(b[n]), b, tnb, tnb - n);
+        break;
+    default:
         break;
     }
 
@@ -358,6 +362,8 @@ void bn_mul_part_recursive(BN_ULONG *r, BN_ULONG *a, BN_ULONG *b, int n,
     case 4:
         bn_sub_part_words(t, a, &(a[n]), tna, n - tna);
         bn_sub_part_words(&(t[n]), &(b[n]), b, tnb, tnb - n);
+        break;
+    default:
         break;
     }
     /*

--- a/crypto/bn/bn_mul.c
+++ b/crypto/bn/bn_mul.c
@@ -125,6 +125,7 @@ BN_ULONG bn_sub_part_words(BN_ULONG *r,
                     r[3] = a[3];
                     if (--dl <= 0)
                         break;
+                    break;
                 default:
                     break;
                 }

--- a/crypto/cast/cast_local.h
+++ b/crypto/cast/cast_local.h
@@ -31,6 +31,7 @@
                         case 2: l1|=((unsigned long)(*(--(c))))<<16; \
                         /* fall through */                              \
                         case 1: l1|=((unsigned long)(*(--(c))))<<24; \
+                        /* fall through */                               \
                         default: \
                             break; \
                                 } \
@@ -55,6 +56,7 @@
                         case 2: *(--(c))=(unsigned char)(((l1)>>16)&0xff); \
                         /* fall through */                                    \
                         case 1: *(--(c))=(unsigned char)(((l1)>>24)&0xff); \
+                        /* fall through */                               \
                         default: \
                             break; \
                                 } \

--- a/crypto/cast/cast_local.h
+++ b/crypto/cast/cast_local.h
@@ -31,6 +31,8 @@
                         case 2: l1|=((unsigned long)(*(--(c))))<<16; \
                         /* fall through */                              \
                         case 1: l1|=((unsigned long)(*(--(c))))<<24; \
+                        default: \
+                            break; \
                                 } \
                         }
 
@@ -53,6 +55,8 @@
                         case 2: *(--(c))=(unsigned char)(((l1)>>16)&0xff); \
                         /* fall through */                                    \
                         case 1: *(--(c))=(unsigned char)(((l1)>>24)&0xff); \
+                        default: \
+                            break; \
                                 } \
                         }
 

--- a/crypto/cms/cms_asn1.c
+++ b/crypto/cms/cms_asn1.c
@@ -333,6 +333,8 @@ static int cms_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
         OPENSSL_free(cms->ctx.propq);
         break;
 
+    default:
+        break;
     }
     return 1;
 }

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -180,6 +180,8 @@ void OPENSSL_showfatal(const char *fmta, ...)
                         case L'C':
                             fmtw[i + 1] = L'c';
                             break;
+                        default:
+                            break;
                         }
                     } while (keepgoing);
             }

--- a/crypto/ct/ct_prn.c
+++ b/crypto/ct/ct_prn.c
@@ -63,6 +63,8 @@ const char *SCT_validation_status_string(const SCT *sct)
         return "invalid";
     case SCT_VALIDATION_STATUS_VALID:
         return "valid";
+    default:
+        break;
     }
     return "unknown status";
 }

--- a/crypto/ct/ct_sct.c
+++ b/crypto/ct/ct_sct.c
@@ -70,6 +70,8 @@ int SCT_set_log_entry_type(SCT *sct, ct_log_entry_type_t entry_type)
         return 1;
     case CT_LOG_ENTRY_TYPE_NOT_SET:
         break;
+    default:
+        break;
     }
     ERR_raise(ERR_LIB_CT, CT_R_UNSUPPORTED_ENTRY_TYPE);
     return 0;
@@ -268,6 +270,8 @@ int SCT_set_source(SCT *sct, sct_source_t source)
     case SCT_SOURCE_X509V3_EXTENSION:
         return SCT_set_log_entry_type(sct, CT_LOG_ENTRY_TYPE_PRECERT);
     case SCT_SOURCE_UNKNOWN:
+        break;
+    default:
         break;
     }
     /* if we aren't sure, leave the log entry type alone */

--- a/crypto/cversion.c
+++ b/crypto/cversion.c
@@ -81,6 +81,8 @@ const char *OpenSSL_version(int t)
             return ossl_cpu_info_str;
         else
             return "CPUINFO: N/A";
+    default:
+        break;
     }
     return "not available";
 }

--- a/crypto/des/des_local.h
+++ b/crypto/des/des_local.h
@@ -51,6 +51,7 @@
                         case 2: l1|=((DES_LONG)(*(--(c))))<< 8L; \
                         /* fall through */                          \
                         case 1: l1|=((DES_LONG)(*(--(c))));      \
+                        /* fall through */                               \
                         default: \
                             break; \
                                 } \
@@ -80,6 +81,7 @@
                         case 2: *(--(c))=(unsigned char)(((l1)>> 8L)&0xff); \
                         /* fall through */                                     \
                         case 1: *(--(c))=(unsigned char)(((l1)     )&0xff); \
+                        /* fall through */                               \
                         default: \
                             break; \
                                 } \

--- a/crypto/des/des_local.h
+++ b/crypto/des/des_local.h
@@ -51,6 +51,8 @@
                         case 2: l1|=((DES_LONG)(*(--(c))))<< 8L; \
                         /* fall through */                          \
                         case 1: l1|=((DES_LONG)(*(--(c))));      \
+                        default: \
+                            break; \
                                 } \
                         }
 
@@ -78,6 +80,8 @@
                         case 2: *(--(c))=(unsigned char)(((l1)>> 8L)&0xff); \
                         /* fall through */                                     \
                         case 1: *(--(c))=(unsigned char)(((l1)     )&0xff); \
+                        default: \
+                            break; \
                                 } \
                         }
 

--- a/crypto/dllmain.c
+++ b/crypto/dllmain.c
@@ -39,6 +39,8 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
         break;
     case DLL_PROCESS_DETACH:
         break;
+    default:
+        break;
     }
     return TRUE;
 }

--- a/crypto/ec/ec_backend.c
+++ b/crypto/ec/ec_backend.c
@@ -122,6 +122,8 @@ static int ec_set_check_group_type_from_param(EC_KEY *ec, const OSSL_PARAM *p)
     case OSSL_PARAM_UTF8_PTR:
         status = OSSL_PARAM_get_utf8_ptr(p, &name);
         break;
+    default:
+        break;
     }
     if (status)
         return ossl_ec_set_check_group_type_from_name(ec, name);
@@ -696,6 +698,8 @@ int ossl_ec_encoding_param2id(const OSSL_PARAM *p, int *id)
     case OSSL_PARAM_UTF8_PTR:
         status = OSSL_PARAM_get_utf8_ptr(p, &name);
         break;
+    default:
+        break;
     }
     if (status) {
         int i = ossl_ec_encoding_name2id(name);
@@ -721,6 +725,8 @@ int ossl_ec_pt_format_param2id(const OSSL_PARAM *p, int *id)
         break;
     case OSSL_PARAM_UTF8_PTR:
         status = OSSL_PARAM_get_utf8_ptr(p, &name);
+        break;
+    default:
         break;
     }
     if (status) {

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -115,6 +115,8 @@ void EC_pre_comp_free(EC_GROUP *group)
     case PCT_ec:
         EC_ec_pre_comp_free(group->pre_comp.ec);
         break;
+    default:
+        break;
     }
     group->pre_comp.ec = NULL;
 }
@@ -207,6 +209,8 @@ int EC_GROUP_copy(EC_GROUP *dest, const EC_GROUP *src)
 #endif
     case PCT_ec:
         dest->pre_comp.ec = EC_ec_pre_comp_dup(src->pre_comp.ec);
+        break;
+    default:
         break;
     }
 
@@ -1486,6 +1490,8 @@ static EC_GROUP *group_new_from_name(const OSSL_PARAM *p,
         break;
     case OSSL_PARAM_UTF8_PTR:
         ok = OSSL_PARAM_get_utf8_ptr(p, &curve_name);
+        break;
+    default:
         break;
     }
 

--- a/crypto/ec/ecx_backend.c
+++ b/crypto/ec/ecx_backend.c
@@ -48,6 +48,8 @@ int ossl_ecx_public_from_private(ECX_KEY *key)
             return 0;
         }
         break;
+    default:
+        break;
     }
     return 1;
 }

--- a/crypto/ec/ecx_key.c
+++ b/crypto/ec/ecx_key.c
@@ -40,6 +40,8 @@ ECX_KEY *ossl_ecx_key_new(OSSL_LIB_CTX *libctx, ECX_KEY_TYPE type, int haspubkey
     case ECX_KEY_TYPE_ED448:
         ret->keylen = ED448_KEYLEN;
         break;
+    default:
+        break;
     }
     ret->type = type;
 

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -907,6 +907,8 @@ static int pkey_ecd_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
 
     case EVP_PKEY_CTRL_DIGESTINIT:
         return 1;
+    default:
+        break;
     }
     return -2;
 }

--- a/crypto/encode_decode/decoder_lib.c
+++ b/crypto/encode_decode/decoder_lib.c
@@ -470,6 +470,8 @@ static void collect_extra_decoder(OSSL_DECODER *decoder, void *arg)
                 return;
             }
             break;
+        default:
+            break;
         }
 
         /*

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -260,6 +260,8 @@ void *ossl_decoder_from_algorithm(int id, const OSSL_ALGORITHM *algodef,
             if (decoder->export_object == NULL)
                 decoder->export_object = OSSL_FUNC_decoder_export_object(fns);
             break;
+        default:
+            break;
         }
     }
     /*

--- a/crypto/encode_decode/encoder_lib.c
+++ b/crypto/encode_decode/encoder_lib.c
@@ -613,6 +613,8 @@ static int encoder_process(struct encoder_process_data_st *data)
                 current_abstract = abstract;
             }
             break;
+        default:
+            break;
         }
 
         /* Calling the encoder implementation */

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -268,6 +268,8 @@ static void *encoder_from_algorithm(int id, const OSSL_ALGORITHM *algodef,
                 encoder->free_object =
                     OSSL_FUNC_encoder_free_object(fns);
             break;
+        default:
+            break;
         }
     }
     /*

--- a/crypto/engine/eng_ctrl.c
+++ b/crypto/engine/eng_ctrl.c
@@ -119,6 +119,8 @@ static int int_ctrl_helper(ENGINE *e, int cmd, long i, void *p,
                                                       : cdp->cmd_desc));
     case ENGINE_CTRL_GET_CMD_FLAGS:
         return cdp->cmd_flags;
+    default:
+        break;
     }
     /* Shouldn't really be here ... */
     ERR_raise(ERR_LIB_ENGINE, ENGINE_R_INTERNAL_LIST_ERROR);

--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -108,6 +108,8 @@ static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation,
             if (cipher == NULL)
                 goto legacy;
             break;
+        default:
+            break;
         }
         if (cipher == NULL)
             continue;
@@ -423,6 +425,8 @@ static void *evp_asym_cipher_from_algorithm(int name_id,
             cipher->settable_ctx_params
                 = OSSL_FUNC_asym_cipher_settable_ctx_params(fns);
             sparamfncnt++;
+            break;
+        default:
             break;
         }
     }

--- a/crypto/evp/ctrl_params_translate.c
+++ b/crypto/evp/ctrl_params_translate.c
@@ -1771,6 +1771,8 @@ static int get_dh_dsa_payload_q(enum state state,
         bn = DSA_get0_q(EVP_PKEY_get0_DSA(ctx->p2));
         break;
 #endif
+    default:
+        break;
     }
 
     return get_payload_bn(state, translation, ctx, bn);
@@ -1793,6 +1795,8 @@ static int get_dh_dsa_payload_g(enum state state,
         bn = DSA_get0_g(EVP_PKEY_get0_DSA(ctx->p2));
         break;
 #endif
+    default:
+        break;
     }
 
     return get_payload_bn(state, translation, ctx, bn);

--- a/crypto/evp/ctrl_params_translate.c
+++ b/crypto/evp/ctrl_params_translate.c
@@ -508,6 +508,8 @@ static int default_fixup_args(enum state state,
                 OSSL_PARAM_construct_octet_ptr(translation->param_key,
                                                ctx->p2, (size_t)ctx->p1);
             break;
+        default:
+            break;
         }
         break;
     case POST_CTRL_TO_PARAMS:
@@ -523,6 +525,8 @@ static int default_fixup_args(enum state state,
             case OSSL_PARAM_OCTET_STRING:
             case OSSL_PARAM_OCTET_PTR:
                 ctx->p1 = (int)ctx->params[0].return_size;
+                break;
+            default:
                 break;
             }
         }

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -1108,6 +1108,8 @@ static void *evp_md_from_algorithm(int name_id,
                 md->gettable_ctx_params =
                     OSSL_FUNC_digest_gettable_ctx_params(fns);
             break;
+        default:
+            break;
         }
     }
     if ((fncnt != 0 && fncnt != 5 && fncnt != 6)

--- a/crypto/evp/ec_ctrl.c
+++ b/crypto/evp/ec_ctrl.c
@@ -234,6 +234,8 @@ int EVP_PKEY_CTX_set0_ecdh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char *ukm, int le
     case 1:
         OPENSSL_free(ukm);
         break;
+    default:
+        break;
     }
 
     return ret;

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1671,6 +1671,8 @@ static void *evp_cipher_from_algorithm(const int name_id,
             cipher->settable_ctx_params =
                 OSSL_FUNC_cipher_settable_ctx_params(fns);
             break;
+        default:
+            break;
         }
     }
     if ((fnciphcnt != 0 && fnciphcnt != 3 && fnciphcnt != 4)

--- a/crypto/evp/evp_rand.c
+++ b/crypto/evp/evp_rand.c
@@ -248,6 +248,8 @@ static void *evp_rand_from_algorithm(int name_id,
                 break;
             rand->clear_seed = OSSL_FUNC_rand_clear_seed(fns);
             break;
+        default:
+            break;
         }
     }
     /*

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -115,6 +115,8 @@ static void *evp_keyexch_from_algorithm(int name_id,
                 = OSSL_FUNC_keyexch_settable_ctx_params(fns);
             sparamfncnt++;
             break;
+        default:
+            break;
         }
     }
     if (fncnt != 4
@@ -293,6 +295,8 @@ int EVP_PKEY_derive_init_ex(EVP_PKEY_CTX *ctx, const OSSL_PARAM params[])
                                               supported_exch, ctx->propquery);
             if (exchange == NULL)
                 goto legacy;
+            break;
+        default:
             break;
         }
         if (exchange == NULL)

--- a/crypto/evp/kdf_meth.c
+++ b/crypto/evp/kdf_meth.c
@@ -137,6 +137,8 @@ static void *evp_kdf_from_algorithm(int name_id,
                 break;
             kdf->set_ctx_params = OSSL_FUNC_kdf_set_ctx_params(fns);
             break;
+        default:
+            break;
         }
     }
     if (fnkdfcnt != 1 || fnctxcnt != 2) {

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -106,6 +106,8 @@ static int evp_kem_init(EVP_PKEY_CTX *ctx, int operation,
                 ret = -2;
                 goto err;
             }
+        default:
+            break;
         }
         if (kem == NULL)
             continue;
@@ -388,6 +390,8 @@ static void *evp_kem_from_algorithm(int name_id, const OSSL_ALGORITHM *algodef,
             kem->settable_ctx_params
                 = OSSL_FUNC_kem_settable_ctx_params(fns);
             sparamfncnt++;
+            break;
+        default:
             break;
         }
     }

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -207,6 +207,8 @@ static void *keymgmt_from_algorithm(int name_id,
                 keymgmt->export_types_ex = OSSL_FUNC_keymgmt_export_types_ex(fns);
             }
             break;
+        default:
+            break;
         }
     }
     /*

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -158,6 +158,8 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
             if (signature == NULL)
                 goto legacy;
             break;
+        default:
+            break;
         }
         if (signature == NULL)
             continue;

--- a/crypto/evp/mac_meth.c
+++ b/crypto/evp/mac_meth.c
@@ -143,6 +143,8 @@ static void *evp_mac_from_algorithm(int name_id,
                 break;
             mac->set_ctx_params = OSSL_FUNC_mac_set_ctx_params(fns);
             break;
+        default:
+            break;
         }
     }
     if (fnmaccnt != 3

--- a/crypto/evp/pmeth_gn.c
+++ b/crypto/evp/pmeth_gn.c
@@ -46,6 +46,8 @@ static int gen_init(EVP_PKEY_CTX *ctx, int operation)
             evp_keymgmt_gen_init(ctx->keymgmt, OSSL_KEYMGMT_SELECT_KEYPAIR,
                                  NULL);
         break;
+    default:
+        break;
     }
 
     if (ctx->op.keymgmt.genctx == NULL)
@@ -74,6 +76,8 @@ static int gen_init(EVP_PKEY_CTX *ctx, int operation)
     case EVP_PKEY_OP_KEYGEN:
         if (ctx->pmeth->keygen_init != NULL)
             ret = ctx->pmeth->keygen_init(ctx);
+        break;
+    default:
         break;
     }
 #endif

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -700,6 +700,8 @@ int EVP_PKEY_CTX_set_params(EVP_PKEY_CTX *ctx, const OSSL_PARAM *params)
     case EVP_PKEY_STATE_LEGACY:
         return evp_pkey_ctx_set_params_to_ctrl(ctx, params);
 #endif
+    default:
+        break;
     }
     return 0;
 }
@@ -738,6 +740,8 @@ int EVP_PKEY_CTX_get_params(EVP_PKEY_CTX *ctx, OSSL_PARAM *params)
     case EVP_PKEY_STATE_LEGACY:
         return evp_pkey_ctx_get_params_to_ctrl(ctx, params);
 #endif
+    default:
+        break;
     }
     return 0;
 }
@@ -1314,6 +1318,8 @@ static int evp_pkey_ctx_ctrl_int(EVP_PKEY_CTX *ctx, int keytype, int optype,
         if (ret == -2)
             ERR_raise(ERR_LIB_EVP, EVP_R_COMMAND_NOT_SUPPORTED);
         break;
+    default:
+        break;
     }
     return ret;
 }
@@ -1378,6 +1384,8 @@ static int evp_pkey_ctx_ctrl_str_int(EVP_PKEY_CTX *ctx,
                                   EVP_PKEY_CTRL_MD, value);
         else
             ret = ctx->pmeth->ctrl_str(ctx, name, value);
+        break;
+    default:
         break;
     }
 
@@ -1467,6 +1475,8 @@ static int evp_pkey_ctx_store_cached_data(EVP_PKEY_CTX *ctx,
                 return -1;
             }
             break;
+        default:
+            break;
         }
     }
     if (optype != -1 && (ctx->operation & optype) == 0) {
@@ -1490,6 +1500,8 @@ static int evp_pkey_ctx_store_cached_data(EVP_PKEY_CTX *ctx,
         ctx->cached_parameters.dist_id_set = 1;
         ctx->cached_parameters.dist_id_len = data_len;
         break;
+    default:
+        break;
     }
     return 1;
 }
@@ -1504,6 +1516,8 @@ static void evp_pkey_ctx_free_cached_data(EVP_PKEY_CTX *ctx,
         OPENSSL_free(ctx->cached_parameters.dist_id_name);
         ctx->cached_parameters.dist_id = NULL;
         ctx->cached_parameters.dist_id_name = NULL;
+        break;
+    default:
         break;
     }
 }

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -221,6 +221,8 @@ static void *evp_signature_from_algorithm(int name_id,
                 = OSSL_FUNC_signature_settable_ctx_md_params(fns);
             smdparamfncnt++;
             break;
+        default:
+            break;
         }
     }
     if (ctxfncnt != 2
@@ -476,6 +478,8 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation,
                                               supported_sig, ctx->propquery);
             if (signature == NULL)
                 goto legacy;
+            break;
+        default:
             break;
         }
         if (signature == NULL)

--- a/crypto/idea/idea_local.h
+++ b/crypto/idea/idea_local.h
@@ -37,6 +37,8 @@ else \
                         case 2: l1|=((unsigned long)(*(--(c))))<<16; \
                         /* fall through */                              \
                         case 1: l1|=((unsigned long)(*(--(c))))<<24; \
+                        default: \
+                            break; \
                                 } \
                         }
 
@@ -59,6 +61,8 @@ else \
                         case 2: *(--(c))=(unsigned char)(((l1)>>16)&0xff); \
                         /* fall through */                                    \
                         case 1: *(--(c))=(unsigned char)(((l1)>>24)&0xff); \
+                        default: \
+                            break; \
                                 } \
                         }
 

--- a/crypto/idea/idea_local.h
+++ b/crypto/idea/idea_local.h
@@ -37,6 +37,7 @@ else \
                         case 2: l1|=((unsigned long)(*(--(c))))<<16; \
                         /* fall through */                              \
                         case 1: l1|=((unsigned long)(*(--(c))))<<24; \
+                        /* fall through */                               \
                         default: \
                             break; \
                                 } \
@@ -61,6 +62,7 @@ else \
                         case 2: *(--(c))=(unsigned char)(((l1)>>16)&0xff); \
                         /* fall through */                                    \
                         case 1: *(--(c))=(unsigned char)(((l1)>>24)&0xff); \
+                        /* fall through */                               \
                         default: \
                             break; \
                                 } \

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -129,6 +129,8 @@ int OPENSSL_hexchar2int(unsigned char c)
           return 0x0E;
     case 'f': case 'F':
           return 0x0F;
+    default:
+        break;
     }
     return -1;
 }

--- a/crypto/ocsp/ocsp_prn.c
+++ b/crypto/ocsp/ocsp_prn.c
@@ -178,6 +178,8 @@ int OCSP_RESPONSE_print(BIO *bp, OCSP_RESPONSE *o, unsigned long flags)
     case V_OCSP_RESPID_KEY:
         i2a_ASN1_STRING(bp, rid->value.byKey, 0);
         break;
+    default:
+        break;
     }
 
     if (BIO_printf(bp, "\n    Produced At: ") <= 0)

--- a/crypto/params.c
+++ b/crypto/params.c
@@ -269,6 +269,8 @@ int OSSL_PARAM_get_int(const OSSL_PARAM *p, int *val)
         return OSSL_PARAM_get_int32(p, (int32_t *)val);
     case sizeof(int64_t):
         return OSSL_PARAM_get_int64(p, (int64_t *)val);
+    default:
+        break;
     }
 #endif
     return general_get_int(p, val, sizeof(*val));
@@ -282,6 +284,8 @@ int OSSL_PARAM_set_int(OSSL_PARAM *p, int val)
         return OSSL_PARAM_set_int32(p, (int32_t)val);
     case sizeof(int64_t):
         return OSSL_PARAM_set_int64(p, (int64_t)val);
+    default:
+        break;
     }
 #endif
     return general_set_int(p, &val, sizeof(val));
@@ -300,6 +304,8 @@ int OSSL_PARAM_get_uint(const OSSL_PARAM *p, unsigned int *val)
         return OSSL_PARAM_get_uint32(p, (uint32_t *)val);
     case sizeof(uint64_t):
         return OSSL_PARAM_get_uint64(p, (uint64_t *)val);
+    default:
+        break;
     }
 #endif
     return general_get_uint(p, val, sizeof(*val));
@@ -313,6 +319,8 @@ int OSSL_PARAM_set_uint(OSSL_PARAM *p, unsigned int val)
         return OSSL_PARAM_set_uint32(p, (uint32_t)val);
     case sizeof(uint64_t):
         return OSSL_PARAM_set_uint64(p, (uint64_t)val);
+    default:
+        break;
     }
 #endif
     return general_set_uint(p, &val, sizeof(val));
@@ -332,6 +340,8 @@ int OSSL_PARAM_get_long(const OSSL_PARAM *p, long int *val)
         return OSSL_PARAM_get_int32(p, (int32_t *)val);
     case sizeof(int64_t):
         return OSSL_PARAM_get_int64(p, (int64_t *)val);
+    default:
+        break;
     }
 #endif
     return general_get_int(p, val, sizeof(*val));
@@ -345,6 +355,8 @@ int OSSL_PARAM_set_long(OSSL_PARAM *p, long int val)
         return OSSL_PARAM_set_int32(p, (int32_t)val);
     case sizeof(int64_t):
         return OSSL_PARAM_set_int64(p, (int64_t)val);
+    default:
+        break;
     }
 #endif
     return general_set_int(p, &val, sizeof(val));
@@ -363,6 +375,8 @@ int OSSL_PARAM_get_ulong(const OSSL_PARAM *p, unsigned long int *val)
         return OSSL_PARAM_get_uint32(p, (uint32_t *)val);
     case sizeof(uint64_t):
         return OSSL_PARAM_get_uint64(p, (uint64_t *)val);
+    default:
+        break;
     }
 #endif
     return general_get_uint(p, val, sizeof(*val));
@@ -376,6 +390,8 @@ int OSSL_PARAM_set_ulong(OSSL_PARAM *p, unsigned long int val)
         return OSSL_PARAM_set_uint32(p, (uint32_t)val);
     case sizeof(uint64_t):
         return OSSL_PARAM_set_uint64(p, (uint64_t)val);
+    default:
+        break;
     }
 #endif
     return general_set_uint(p, &val, sizeof(val));
@@ -415,6 +431,8 @@ int OSSL_PARAM_get_int32(const OSSL_PARAM *p, int32_t *val)
             }
             err_out_of_range;
             return 0;
+        default:
+            break;
         }
 #endif
         return general_get_int(p, val, sizeof(*val));
@@ -441,6 +459,8 @@ int OSSL_PARAM_get_int32(const OSSL_PARAM *p, int32_t *val)
             }
             err_out_of_range;
             return 0;
+        default:
+            break;
         }
 #endif
         return general_get_int(p, val, sizeof(*val));
@@ -458,6 +478,8 @@ int OSSL_PARAM_get_int32(const OSSL_PARAM *p, int32_t *val)
             }
             err_out_of_range;
             return 0;
+        default:
+            break;
         }
         err_unsupported_real;
         return 0;
@@ -487,6 +509,8 @@ int OSSL_PARAM_set_int32(OSSL_PARAM *p, int32_t val)
             p->return_size = sizeof(int64_t);
             *(int64_t *)p->data = (int64_t)val;
             return 1;
+        default:
+            break;
         }
 #endif
         return general_set_int(p, &val, sizeof(val));
@@ -503,6 +527,8 @@ int OSSL_PARAM_set_int32(OSSL_PARAM *p, int32_t val)
             p->return_size = sizeof(uint64_t);
             *(uint64_t *)p->data = (uint64_t)val;
             return 1;
+        default:
+            break;
         }
 #endif
         return general_set_int(p, &val, sizeof(val));
@@ -526,6 +552,8 @@ int OSSL_PARAM_set_int32(OSSL_PARAM *p, int32_t val)
             }
             *(double *)p->data = (double)val;
             return 1;
+        default:
+            break;
         }
         err_unsupported_real;
         return 0;
@@ -569,6 +597,8 @@ int OSSL_PARAM_get_uint32(const OSSL_PARAM *p, uint32_t *val)
             }
             err_out_of_range;
             return 0;
+        default:
+            break;
         }
 #endif
         return general_get_uint(p, val, sizeof(*val));
@@ -597,6 +627,8 @@ int OSSL_PARAM_get_uint32(const OSSL_PARAM *p, uint32_t *val)
             else
                 err_out_of_range;
             return 0;
+        default:
+            break;
         }
 #endif
         return general_get_uint(p, val, sizeof(*val));
@@ -613,6 +645,8 @@ int OSSL_PARAM_get_uint32(const OSSL_PARAM *p, uint32_t *val)
             }
             err_inexact;
             return 0;
+        default:
+            break;
         }
         err_unsupported_real;
         return 0;
@@ -643,6 +677,8 @@ int OSSL_PARAM_set_uint32(OSSL_PARAM *p, uint32_t val)
             p->return_size = sizeof(uint64_t);
             *(uint64_t *)p->data = val;
             return 1;
+        default:
+            break;
         }
 #endif
         return general_set_uint(p, &val, sizeof(val));
@@ -663,6 +699,8 @@ int OSSL_PARAM_set_uint32(OSSL_PARAM *p, uint32_t val)
             p->return_size = sizeof(int64_t);
             *(int64_t *)p->data = (int64_t)val;
             return 1;
+        default:
+            break;
         }
 #endif
         return general_set_uint(p, &val, sizeof(val));
@@ -682,6 +720,8 @@ int OSSL_PARAM_set_uint32(OSSL_PARAM *p, uint32_t val)
             }
             *(double *)p->data = (double)val;
             return 1;
+        default:
+            break;
         }
         err_unsupported_real;
         return 0;
@@ -718,6 +758,8 @@ int OSSL_PARAM_get_int64(const OSSL_PARAM *p, int64_t *val)
         case sizeof(int64_t):
             *val = *(const int64_t *)p->data;
             return 1;
+        default:
+            break;
         }
 #endif
         return general_get_int(p, val, sizeof(*val));
@@ -737,6 +779,8 @@ int OSSL_PARAM_get_int64(const OSSL_PARAM *p, int64_t *val)
             }
             err_out_of_range;
             return 0;
+        default:
+            break;
         }
 #endif
         return general_get_int(p, val, sizeof(*val));
@@ -760,6 +804,8 @@ int OSSL_PARAM_get_int64(const OSSL_PARAM *p, int64_t *val)
             }
             err_inexact;
             return 0;
+        default:
+            break;
         }
         err_unsupported_real;
         return 0;
@@ -793,6 +839,8 @@ int OSSL_PARAM_set_int64(OSSL_PARAM *p, int64_t val)
         case sizeof(int64_t):
             *(int64_t *)p->data = val;
             return 1;
+        default:
+            break;
         }
 #endif
         return general_set_int(p, &val, sizeof(val));
@@ -813,6 +861,8 @@ int OSSL_PARAM_set_int64(OSSL_PARAM *p, int64_t val)
         case sizeof(uint64_t):
             *(uint64_t *)p->data = (uint64_t)val;
             return 1;
+        default:
+            break;
         }
 #endif
         return general_set_int(p, &val, sizeof(val));
@@ -832,6 +882,8 @@ int OSSL_PARAM_set_int64(OSSL_PARAM *p, int64_t val)
             }
             err_inexact;
             return 0;
+        default:
+            break;
         }
         err_unsupported_real;
         return 0;
@@ -867,6 +919,8 @@ int OSSL_PARAM_get_uint64(const OSSL_PARAM *p, uint64_t *val)
         case sizeof(uint64_t):
             *val = *(const uint64_t *)p->data;
             return 1;
+        default:
+            break;
         }
 #endif
         return general_get_uint(p, val, sizeof(*val));
@@ -892,6 +946,8 @@ int OSSL_PARAM_get_uint64(const OSSL_PARAM *p, uint64_t *val)
             }
             err_unsigned_negative;
             return 0;
+        default:
+            break;
         }
 #endif
         return general_get_uint(p, val, sizeof(*val));
@@ -915,6 +971,8 @@ int OSSL_PARAM_get_uint64(const OSSL_PARAM *p, uint64_t *val)
             }
             err_inexact;
             return 0;
+        default:
+            break;
         }
         err_unsupported_real;
         return 0;
@@ -949,6 +1007,8 @@ int OSSL_PARAM_set_uint64(OSSL_PARAM *p, uint64_t val)
         case sizeof(uint64_t):
             *(uint64_t *)p->data = val;
             return 1;
+        default:
+            break;
         }
 #endif
         return general_set_uint(p, &val, sizeof(val));
@@ -973,6 +1033,8 @@ int OSSL_PARAM_set_uint64(OSSL_PARAM *p, uint64_t val)
             }
             err_out_of_range;
             return 0;
+        default:
+            break;
         }
 #endif
         return general_set_uint(p, &val, sizeof(val));
@@ -987,6 +1049,8 @@ int OSSL_PARAM_set_uint64(OSSL_PARAM *p, uint64_t val)
             }
             err_inexact;
             return 0;
+        default:
+            break;
         }
         err_unsupported_real;
         return 0;
@@ -1010,6 +1074,8 @@ int OSSL_PARAM_get_size_t(const OSSL_PARAM *p, size_t *val)
         return OSSL_PARAM_get_uint32(p, (uint32_t *)val);
     case sizeof(uint64_t):
         return OSSL_PARAM_get_uint64(p, (uint64_t *)val);
+    default:
+        break;
     }
 #endif
     return general_get_uint(p, val, sizeof(*val));
@@ -1023,6 +1089,8 @@ int OSSL_PARAM_set_size_t(OSSL_PARAM *p, size_t val)
         return OSSL_PARAM_set_uint32(p, (uint32_t)val);
     case sizeof(uint64_t):
         return OSSL_PARAM_set_uint64(p, (uint64_t)val);
+    default:
+        break;
     }
 #endif
     return general_set_uint(p, &val, sizeof(val));
@@ -1042,6 +1110,8 @@ int OSSL_PARAM_get_time_t(const OSSL_PARAM *p, time_t *val)
         return OSSL_PARAM_get_int32(p, (int32_t *)val);
     case sizeof(int64_t):
         return OSSL_PARAM_get_int64(p, (int64_t *)val);
+    default:
+        break;
     }
 #endif
     return general_get_int(p, val, sizeof(*val));
@@ -1055,6 +1125,8 @@ int OSSL_PARAM_set_time_t(OSSL_PARAM *p, time_t val)
         return OSSL_PARAM_set_int32(p, (int32_t)val);
     case sizeof(int64_t):
         return OSSL_PARAM_set_int64(p, (int64_t)val);
+    default:
+        break;
     }
 #endif
     return general_set_int(p, &val, sizeof(val));
@@ -1171,6 +1243,8 @@ int OSSL_PARAM_get_double(const OSSL_PARAM *p, double *val)
         case sizeof(double):
             *val = *(const double *)p->data;
             return 1;
+        default:
+            break;
         }
         err_unsupported_real;
         return 0;
@@ -1187,6 +1261,8 @@ int OSSL_PARAM_get_double(const OSSL_PARAM *p, double *val)
             }
             err_inexact;
             return 0;
+        default:
+            break;
         }
     } else if (p->data_type == OSSL_PARAM_INTEGER) {
         switch (p->data_size) {
@@ -1202,6 +1278,8 @@ int OSSL_PARAM_get_double(const OSSL_PARAM *p, double *val)
             }
             err_inexact;
             return 0;
+        default:
+            break;
         }
     }
     err_bad_type;
@@ -1224,6 +1302,8 @@ int OSSL_PARAM_set_double(OSSL_PARAM *p, double val)
         case sizeof(double):
             *(double *)p->data = val;
             return 1;
+        default:
+            break;
         }
         err_unsupported_real;
         return 0;
@@ -1258,6 +1338,8 @@ int OSSL_PARAM_set_double(OSSL_PARAM *p, double val)
             }
             err_out_of_range;
             return 0;
+        default:
+            break;
         }
     } else if (p->data_type == OSSL_PARAM_INTEGER) {
         p->return_size = sizeof(double);
@@ -1290,6 +1372,8 @@ int OSSL_PARAM_set_double(OSSL_PARAM *p, double val)
             }
             err_out_of_range;
             return 0;
+        default:
+            break;
         }
     }
     err_bad_type;

--- a/crypto/params_from_text.c
+++ b/crypto/params_from_text.c
@@ -126,6 +126,8 @@ static int prepare_from_text(const OSSL_PARAM *paramdefs, const char *key,
             *buf_n = value_n;
         }
         break;
+    default:
+        break;
     }
 
     return 1;
@@ -185,6 +187,8 @@ static int construct_from_text(OSSL_PARAM *to, const OSSL_PARAM *paramdef,
             } else {
                 memcpy(buf, value, buf_n);
             }
+            break;
+        default:
             break;
         }
     }

--- a/crypto/pem/pvkfmt.c
+++ b/crypto/pem/pvkfmt.c
@@ -103,6 +103,8 @@ static EVP_PKEY *evp_pkey_new0_key(void *key, int evp_type)
             pkey = NULL;
             break;
 #endif
+        default:
+            break;
         }
     } else {
         ERR_raise(ERR_LIB_PEM, ERR_R_EVP_LIB);
@@ -117,6 +119,8 @@ static EVP_PKEY *evp_pkey_new0_key(void *key, int evp_type)
         DSA_free(key);
         break;
 #endif
+    default:
+        break;
     }
 
     return pkey;

--- a/crypto/pkcs7/pk7_asn1.c
+++ b/crypto/pkcs7/pk7_asn1.c
@@ -54,6 +54,8 @@ static int pk7_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
             return 0;
         break;
 
+    default:
+        break;
     }
     return 1;
 }

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1012,6 +1012,8 @@ static int provider_init(OSSL_PROVIDER *prov)
                 break;
 # endif
 #endif
+            default:
+                break;
             }
         }
     }

--- a/crypto/rc2/rc2_local.h
+++ b/crypto/rc2/rc2_local.h
@@ -34,6 +34,8 @@
                         case 2: l1|=((unsigned long)(*(--(c))))<< 8L; \
                         /* fall through */                               \
                         case 1: l1|=((unsigned long)(*(--(c))));      \
+                        default: \
+                            break; \
                                 } \
                         }
 
@@ -63,6 +65,8 @@
                         case 2: *(--(c))=(unsigned char)(((l1)>> 8L)&0xff); \
                         /* fall through */                                     \
                         case 1: *(--(c))=(unsigned char)(((l1)     )&0xff); \
+                        default: \
+                            break; \
                                 } \
                         }
 

--- a/crypto/rc2/rc2_local.h
+++ b/crypto/rc2/rc2_local.h
@@ -34,6 +34,7 @@
                         case 2: l1|=((unsigned long)(*(--(c))))<< 8L; \
                         /* fall through */                               \
                         case 1: l1|=((unsigned long)(*(--(c))));      \
+                        /* fall through */                               \
                         default: \
                             break; \
                                 } \
@@ -65,6 +66,7 @@
                         case 2: *(--(c))=(unsigned char)(((l1)>> 8L)&0xff); \
                         /* fall through */                                     \
                         case 1: *(--(c))=(unsigned char)(((l1)     )&0xff); \
+                        /* fall through */                               \
                         default: \
                             break; \
                                 } \

--- a/crypto/rc5/rc5_local.h
+++ b/crypto/rc5/rc5_local.h
@@ -36,6 +36,7 @@
                         case 2: l1|=((unsigned long)(*(--(c))))<< 8L; \
                         /* fall through */                               \
                         case 1: l1|=((unsigned long)(*(--(c))));      \
+                        /* fall through */                               \
                         default: \
                             break; \
                                 } \
@@ -67,6 +68,7 @@
                         case 2: *(--(c))=(unsigned char)(((l1)>> 8L)&0xff); \
                         /* fall through */                                     \
                         case 1: *(--(c))=(unsigned char)(((l1)     )&0xff); \
+                        /* fall through */                               \
                         default: \
                             break; \
                                 } \

--- a/crypto/rc5/rc5_local.h
+++ b/crypto/rc5/rc5_local.h
@@ -36,6 +36,8 @@
                         case 2: l1|=((unsigned long)(*(--(c))))<< 8L; \
                         /* fall through */                               \
                         case 1: l1|=((unsigned long)(*(--(c))));      \
+                        default: \
+                            break; \
                                 } \
                         }
 
@@ -65,6 +67,8 @@
                         case 2: *(--(c))=(unsigned char)(((l1)>> 8L)&0xff); \
                         /* fall through */                                     \
                         case 1: *(--(c))=(unsigned char)(((l1)     )&0xff); \
+                        default: \
+                            break; \
                                 } \
                         }
 

--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -910,6 +910,8 @@ static int rsa_int_import_from(const OSSL_PARAM params[], void *vpctx,
     case RSA_FLAG_TYPE_RSASSAPSS:
         ok = EVP_PKEY_assign(pkey, EVP_PKEY_RSA_PSS, rsa);
         break;
+    default:
+        break;
     }
 
  err:

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -345,6 +345,8 @@ uint16_t ossl_ifc_ffc_compute_security_bits(int n)
         return 200;
     case 15360:     /* FIPS 140-2 IG 7.5 */
         return 256;
+    default:
+        break;
     }
 
     /*

--- a/crypto/rsa/rsa_x931.c
+++ b/crypto/rsa/rsa_x931.c
@@ -118,6 +118,8 @@ int RSA_X931_hash_id(int nid)
     case NID_sha512:
         return 0x35;
 
+    default:
+        break;
     }
     return -1;
 }

--- a/crypto/siphash/siphash.c
+++ b/crypto/siphash/siphash.c
@@ -230,6 +230,8 @@ int SipHash_Final(SIPHASH *ctx, unsigned char *out, size_t outlen)
         b |= ((uint64_t)ctx->leavings[0]);
     case 0:
         break;
+    default:
+        break;
     }
 
     v3 ^= b;

--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -392,6 +392,8 @@ int OSSL_STORE_find(OSSL_STORE_CTX *ctx, const OSSL_STORE_SEARCH *search)
                                                 search->stringlength))
                 ret = 1;
             break;
+        default:
+            break;
         }
         if (ret) {
             params = OSSL_PARAM_BLD_to_param(bld);
@@ -843,6 +845,8 @@ void OSSL_STORE_INFO_free(OSSL_STORE_INFO *info)
         case OSSL_STORE_INFO_CRL:
             X509_CRL_free(info->_.crl);
             break;
+        default:
+            break;
         }
         OPENSSL_free(info);
     }
@@ -885,6 +889,8 @@ int OSSL_STORE_supports_search(OSSL_STORE_CTX *ctx, int search_type)
             break;
         case OSSL_STORE_SEARCH_BY_ALIAS:
             ret = (p_alias != NULL);
+            break;
+        default:
             break;
         }
     }

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -227,6 +227,8 @@ static void *loader_from_algorithm(int scheme_id, const OSSL_ALGORITHM *algodef,
             if (loader->p_open_ex == NULL)
                 loader->p_open_ex = OSSL_FUNC_store_open_ex(fns);
             break;
+        default:
+            break;
         }
     }
 

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -496,6 +496,8 @@ BIO *OSSL_trace_begin(int category)
             (void)BIO_ctrl(channel, OSSL_TRACE_CTRL_BEGIN,
                            prefix == NULL ? 0 : strlen(prefix), prefix);
             break;
+        default:
+            break;
         }
     }
 #endif
@@ -524,6 +526,8 @@ void OSSL_trace_end(int category, BIO *channel)
         case CALLBACK_CHANNEL:
             (void)BIO_ctrl(channel, OSSL_TRACE_CTRL_END,
                            suffix == NULL ? 0 : strlen(suffix), suffix);
+            break;
+        default:
             break;
         }
         current_channel = NULL;

--- a/crypto/ui/ui_lib.c
+++ b/crypto/ui/ui_lib.c
@@ -63,6 +63,8 @@ static void free_string(UI_STRING *uis)
         case UIT_ERROR:
         case UIT_INFO:
             break;
+        default:
+            break;
         }
     }
     OPENSSL_free(uis);
@@ -779,6 +781,8 @@ const char *UI_get0_action_string(UI_STRING *uis)
     case UIT_INFO:
     case UIT_ERROR:
         break;
+    default:
+        break;
     }
     return NULL;
 }
@@ -793,6 +797,8 @@ const char *UI_get0_result_string(UI_STRING *uis)
     case UIT_BOOLEAN:
     case UIT_INFO:
     case UIT_ERROR:
+        break;
+    default:
         break;
     }
     return NULL;
@@ -809,6 +815,8 @@ int UI_get_result_string_length(UI_STRING *uis)
     case UIT_INFO:
     case UIT_ERROR:
         break;
+    default:
+        break;
     }
     return -1;
 }
@@ -823,6 +831,8 @@ const char *UI_get0_test_string(UI_STRING *uis)
     case UIT_INFO:
     case UIT_ERROR:
     case UIT_PROMPT:
+        break;
+    default:
         break;
     }
     return NULL;
@@ -839,6 +849,8 @@ int UI_get_result_minsize(UI_STRING *uis)
     case UIT_ERROR:
     case UIT_BOOLEAN:
         break;
+    default:
+        break;
     }
     return -1;
 }
@@ -853,6 +865,8 @@ int UI_get_result_maxsize(UI_STRING *uis)
     case UIT_INFO:
     case UIT_ERROR:
     case UIT_BOOLEAN:
+        break;
+    default:
         break;
     }
     return -1;
@@ -921,6 +935,8 @@ int UI_set_result_ex(UI *ui, UI_STRING *uis, const char *result, int len)
     case UIT_NONE:
     case UIT_INFO:
     case UIT_ERROR:
+        break;
+    default:
         break;
     }
     return 0;

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -213,6 +213,8 @@ static int write_string(UI *ui, UI_STRING *uis)
     case UIT_VERIFY:
     case UIT_BOOLEAN:
         break;
+    default:
+        break;
     }
     return 1;
 }
@@ -251,6 +253,8 @@ static int read_string(UI *ui, UI_STRING *uis)
     case UIT_NONE:
     case UIT_INFO:
     case UIT_ERROR:
+        break;
+    default:
         break;
     }
     return 1;

--- a/crypto/ui/ui_util.c
+++ b/crypto/ui/ui_util.c
@@ -127,6 +127,8 @@ static int ui_read(UI *ui, UI_STRING *uis)
     case UIT_INFO:
     case UIT_ERROR:
         break;
+    default:
+        break;
     }
     return 1;
 }

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -101,6 +101,8 @@ static int dir_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp, long argl,
         } else
             ret = add_cert_dir(ld, argp, (int)argl);
         break;
+    default:
+        break;
     }
     return ret;
 }

--- a/crypto/x509/by_file.c
+++ b/crypto/x509/by_file.c
@@ -74,6 +74,8 @@ static int by_file_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argp,
                                              propq) != 0);
         }
         break;
+    default:
+        break;
     }
     return ok;
 }

--- a/crypto/x509/by_store.c
+++ b/crypto/x509/by_store.c
@@ -80,6 +80,8 @@ static int cache_objects(X509_LOOKUP *lctx, const char *uri,
                 ok = X509_STORE_add_crl(xstore,
                                         OSSL_STORE_INFO_get0_CRL(info));
                 break;
+            default:
+                break;
             }
         }
 
@@ -207,6 +209,8 @@ static int by_store_subject_ex(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
                 X509_CRL_free(tmp->data.crl);
             break;
         case X509_LU_NONE:
+            break;
+        default:
             break;
         }
     }

--- a/crypto/x509/v3_ac_tgt.c
+++ b/crypto/x509/v3_ac_tgt.c
@@ -122,6 +122,8 @@ static int i2r_OBJECT_DIGEST_INFO(X509V3_EXT_METHOD *method,
     case OSSL_ODI_TYPE_OTHER:
         BIO_printf(out, "%*sDigest Type: Other\n", indent, "");
         break;
+    default:
+        break;
     }
     if (odi->otherObjectTypeID != NULL) {
         BIO_printf(out, "%*sDigest Type Identifier: ", indent, "");
@@ -192,6 +194,8 @@ static int i2r_TARGET(X509V3_EXT_METHOD *method,
     case OSSL_TGT_TARGET_CERT:
         BIO_printf(out, "%*sTarget Cert:\n", indent, "");
         i2r_TARGET_CERT(method, target->choice.targetCert, out, indent + 2);
+        break;
+    default:
         break;
     }
     return 1;

--- a/crypto/x509/v3_addr.c
+++ b/crypto/x509/v3_addr.c
@@ -194,6 +194,8 @@ static int i2r_IPAddressOrRanges(BIO *out,
                 return 0;
             BIO_puts(out, "\n");
             continue;
+        default:
+            break;
         }
     }
     return 1;
@@ -266,6 +268,8 @@ static int i2r_IPAddrBlocks(const X509V3_EXT_METHOD *method,
                                        f->ipAddressChoice->
                                        u.addressesOrRanges, afi))
                 return 0;
+            break;
+        default:
             break;
         }
     }
@@ -594,6 +598,8 @@ static IPAddressOrRanges *make_prefix_or_range(IPAddrBlocks *addr,
     case IANA_AFI_IPV6:
         (void)sk_IPAddressOrRange_set_cmp_func(aors, v6IPAddressOrRange_cmp);
         break;
+    default:
+        break;
     }
     f->ipAddressChoice->type = IPAddressChoice_addressesOrRanges;
     f->ipAddressChoice->u.addressesOrRanges = aors;
@@ -657,6 +663,8 @@ static int extract_min_max(IPAddressOrRange *aor,
     case IPAddressOrRange_addressRange:
         return (addr_expand(min, aor->u.addressRange->min, length, 0x00) &&
                 addr_expand(max, aor->u.addressRange->max, length, 0xFF));
+    default:
+        break;
     }
     return 0;
 }
@@ -978,6 +986,8 @@ static void *v2i_IPAddrBlocks(const struct v3_ext_method *method,
             break;
         case IANA_AFI_IPV6:
             addr_chars = v6addr_chars;
+            break;
+        default:
             break;
         }
 

--- a/crypto/x509/v3_asid.c
+++ b/crypto/x509/v3_asid.c
@@ -255,6 +255,8 @@ static int extract_min_max(ASIdOrRange *aor,
         *min = aor->u.range->min;
         *max = aor->u.range->max;
         return 1;
+    default:
+        break;
     }
 
     return 0;
@@ -460,6 +462,8 @@ static int ASIdentifierChoice_canonize(ASIdentifierChoice *choice)
                 ASN1_INTEGER_free(a->u.range->max);
                 a->u.range->max = b_max;
                 break;
+            default:
+                break;
             }
             switch (b->type) {
             case ASIdOrRange_id:
@@ -467,6 +471,8 @@ static int ASIdentifierChoice_canonize(ASIdentifierChoice *choice)
                 break;
             case ASIdOrRange_range:
                 b->u.range->max = NULL;
+                break;
+            default:
                 break;
             }
             ASIdOrRange_free(b);
@@ -784,6 +790,8 @@ static int asid_validate_path_internal(X509_STORE_CTX *ctx,
         case ASIdentifierChoice_asIdsOrRanges:
             child_as = ext->asnum->u.asIdsOrRanges;
             break;
+        default:
+            break;
         }
     }
     if (ext->rdi != NULL) {
@@ -793,6 +801,8 @@ static int asid_validate_path_internal(X509_STORE_CTX *ctx,
             break;
         case ASIdentifierChoice_asIdsOrRanges:
             child_rdi = ext->rdi->u.asIdsOrRanges;
+            break;
+        default:
             break;
         }
     }

--- a/crypto/x509/v3_crld.c
+++ b/crypto/x509/v3_crld.c
@@ -315,6 +315,8 @@ static int dpn_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
     case ASN1_OP_FREE_POST:
         X509_NAME_free(dpn->dpname);
         break;
+    default:
+        break;
     }
     return 1;
 }

--- a/crypto/x509/v3_genn.c
+++ b/crypto/x509/v3_genn.c
@@ -155,6 +155,8 @@ int GENERAL_NAME_cmp(GENERAL_NAME *a, GENERAL_NAME *b)
     case GEN_RID:
         result = OBJ_cmp(a->d.rid, b->d.rid);
         break;
+    default:
+        break;
     }
     return result;
 }
@@ -205,6 +207,8 @@ void GENERAL_NAME_set0_value(GENERAL_NAME *a, int type, void *value)
 
     case GEN_RID:
         a->d.rid = value;
+        break;
+    default:
         break;
     }
     a->type = type;

--- a/crypto/x509/v3_san.c
+++ b/crypto/x509/v3_san.c
@@ -200,6 +200,9 @@ STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(X509V3_EXT_METHOD *method,
         if (!X509V3_add_value("Registered ID", oline, &ret))
             return NULL;
         break;
+
+    default:
+        break;
     }
     return ret;
 }
@@ -293,6 +296,9 @@ int GENERAL_NAME_print(BIO *out, GENERAL_NAME *gen)
     case GEN_RID:
         BIO_printf(out, "Registered ID:");
         i2a_ASN1_OBJECT(out, gen->d.rid);
+        break;
+
+    default:
         break;
     }
     return 1;

--- a/crypto/x509/v3_utl.c
+++ b/crypto/x509/v3_utl.c
@@ -371,6 +371,8 @@ STACK_OF(CONF_VALUE) *X509V3_parse_list(const char *line)
                 q = p + 1;
             }
 
+        default:
+            break;
         }
     }
 

--- a/crypto/x509/v3_utl.c
+++ b/crypto/x509/v3_utl.c
@@ -370,6 +370,7 @@ STACK_OF(CONF_VALUE) *X509V3_parse_list(const char *line)
                 ntmp = NULL;
                 q = p + 1;
             }
+            break;
 
         default:
             break;

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -175,6 +175,8 @@ static int x509_object_cmp(const X509_OBJECT *const *a,
     case X509_LU_NONE:
         /* abort(); */
         return 0;
+    default:
+        break;
     }
     return ret;
 }
@@ -454,6 +456,8 @@ int X509_OBJECT_up_ref_count(X509_OBJECT *a)
         return X509_up_ref(a->data.x509);
     case X509_LU_CRL:
         return X509_CRL_up_ref(a->data.crl);
+    default:
+        break;
     }
     return 1;
 }
@@ -499,6 +503,8 @@ static void x509_object_free_internal(X509_OBJECT *a)
         break;
     case X509_LU_CRL:
         X509_CRL_free(a->data.crl);
+        break;
+    default:
         break;
     }
 }

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -291,6 +291,8 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
     case NID_sha384:
     case NID_sha512:
         siginf->flags |= X509_SIG_INFO_TLS;
+    default:
+        break;
     }
     siginf->flags |= X509_SIG_INFO_VALID;
     return 1;

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -291,6 +291,7 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
     case NID_sha384:
     case NID_sha512:
         siginf->flags |= X509_SIG_INFO_TLS;
+        break;
     default:
         break;
     }

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -59,6 +59,8 @@ static int crl_inf_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
     case ASN1_OP_D2I_POST:
         (void)sk_X509_REVOKED_set_cmp_func(a->revoked, X509_REVOKED_cmp);
         break;
+    default:
+        break;
     }
     return 1;
 }
@@ -279,6 +281,8 @@ static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
             if (!ossl_x509_crl_set0_libctx(crl, old->libctx, old->propq))
                 return 0;
         }
+        break;
+    default:
         break;
     }
     return 1;

--- a/crypto/x509/x_ietfatt.c
+++ b/crypto/x509/x_ietfatt.c
@@ -135,6 +135,8 @@ void *OSSL_IETF_ATTR_SYNTAX_get0_value(const OSSL_IETF_ATTR_SYNTAX *a,
         return val->u.oid;
     case OSSL_IETFAS_STRING:
         return val->u.string;
+    default:
+        break;
     }
 
     return NULL;
@@ -228,6 +230,8 @@ int OSSL_IETF_ATTR_SYNTAX_print(BIO *bp, OSSL_IETF_ATTR_SYNTAX *a, int indent)
         case OSSL_IETFAS_OCTETS:
         case OSSL_IETFAS_STRING:
             ASN1_STRING_print(bp, attr_value);
+            break;
+        default:
             break;
         }
     }

--- a/crypto/x509/x_req.c
+++ b/crypto/x509/x_req.c
@@ -101,6 +101,8 @@ static int req_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
             *propq = ret->propq;
         }
         break;
+    default:
+        break;
     }
 
     return 1;

--- a/engines/e_capi.c
+++ b/engines/e_capi.c
@@ -1609,6 +1609,8 @@ CAPI_KEY *capi_find_key(CAPI_CTX *ctx, const char *id)
                                    ctx->csptype, ctx->keytype);
         }
         break;
+    default:
+        break;
     }
 
     return key;

--- a/fuzz/fuzz_rand.c
+++ b/fuzz/fuzz_rand.c
@@ -130,6 +130,8 @@ static const OSSL_ALGORITHM *fuzz_rand_query(void *provctx,
     switch (operation_id) {
     case OSSL_OP_RAND:
         return fuzz_rand_rand;
+    default:
+        break;
     }
     return NULL;
 }

--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -250,13 +250,13 @@ static void free_params(OSSL_PARAM *param)
 {
     for (; param != NULL && param->key != NULL; param++) {
         switch (param->data_type) {
-            case OSSL_PARAM_INTEGER:
-            case OSSL_PARAM_UNSIGNED_INTEGER:
-            case OSSL_PARAM_REAL:
-                if (param->data != NULL) {
-                    OPENSSL_free(param->data);
-                }
-                break;
+        case OSSL_PARAM_INTEGER:
+        case OSSL_PARAM_UNSIGNED_INTEGER:
+        case OSSL_PARAM_REAL:
+            if (param->data != NULL) {
+                OPENSSL_free(param->data);
+            }
+            break;
         default:
             break;
         }

--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -257,6 +257,8 @@ static void free_params(OSSL_PARAM *param)
                     OPENSSL_free(param->data);
                 }
                 break;
+        default:
+            break;
         }
     }
 }

--- a/fuzz/quic-client.c
+++ b/fuzz/quic-client.c
@@ -211,6 +211,8 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
                     thisstream = 0;
                 stream = allstreams[thisstream];
                 break;
+            default:
+                break;
             }
             assert(stream != NULL);
             assert(thisstream < numstreams);

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -120,6 +120,8 @@ __owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
                         case 3: l1|=((unsigned long)(*(--(c))))<<16; \
                         case 2: l1|=((unsigned long)(*(--(c))))<< 8; \
                         case 1: l1|=((unsigned long)(*(--(c))));     \
+                        default: \
+                            break; \
                                 } \
                         }
 
@@ -168,6 +170,8 @@ __owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
                         case 3: *(--(c))=(unsigned char)(((l1)>>16)&0xff); \
                         case 2: *(--(c))=(unsigned char)(((l1)>> 8)&0xff); \
                         case 1: *(--(c))=(unsigned char)(((l1)    )&0xff); \
+                        default: \
+                            break; \
                                 } \
                         }
 

--- a/providers/baseprov.c
+++ b/providers/baseprov.c
@@ -109,6 +109,8 @@ static const OSSL_ALGORITHM *base_query(void *provctx, int operation_id,
         return base_store;
     case OSSL_OP_RAND:
         return base_rands;
+    default:
+        break;
     }
     return NULL;
 }

--- a/providers/common/bio_prov.c
+++ b/providers/common/bio_prov.c
@@ -67,6 +67,8 @@ int ossl_prov_bio_from_dispatch(const OSSL_DISPATCH *fns)
             if (c_bio_vprintf == NULL)
                 c_bio_vprintf = OSSL_FUNC_BIO_vprintf(fns);
             break;
+        default:
+            break;
         }
     }
 

--- a/providers/common/der/der_rsa_key.c
+++ b/providers/common/der/der_rsa_key.c
@@ -377,6 +377,8 @@ int ossl_DER_w_algorithmIdentifier_RSA_PSS(WPACKET *pkt, int tag,
         RSA_CASE(rsaEncryption, rsa);
     case RSA_FLAG_TYPE_RSASSAPSS:
         RSA_CASE(rsassaPss, rsa);
+    default:
+        break;
     }
 
     if (rsa_oid == NULL)

--- a/providers/common/provider_seeding.c
+++ b/providers/common/provider_seeding.c
@@ -73,6 +73,8 @@ int ossl_prov_seeding_from_dispatch(const OSSL_DISPATCH *fns)
         case OSSL_FUNC_CLEANUP_USER_NONCE:
             set_func(c_cleanup_user_nonce, OSSL_FUNC_cleanup_user_nonce(fns));
             break;
+        default:
+            break;
         }
 #undef set_func
     }

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -547,6 +547,8 @@ static const OSSL_ALGORITHM *deflt_query(void *provctx, int operation_id,
         return deflt_decoder;
     case OSSL_OP_STORE:
         return deflt_store;
+    default:
+        break;
     }
     return NULL;
 }

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -523,6 +523,8 @@ static const OSSL_ALGORITHM *fips_query(void *provctx, int operation_id,
         return fips_asym_cipher;
     case OSSL_OP_KEM:
         return fips_asym_kem;
+    default:
+        break;
     }
     return NULL;
 }

--- a/providers/implementations/ciphers/cipher_aes_gcm_hw_armv8.inc
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw_armv8.inc
@@ -42,6 +42,8 @@ size_t armv8_aes_gcm_encrypt(const unsigned char *in, unsigned char *out, size_t
                 aes_gcm_enc_256_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
             }
             break;
+    default:
+        break;
     }
     return align_bytes;
 }
@@ -76,6 +78,8 @@ size_t armv8_aes_gcm_decrypt(const unsigned char *in, unsigned char *out, size_t
                 aes_gcm_dec_256_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
             }
             break;
+    default:
+        break;
     }
     return align_bytes;
 }

--- a/providers/implementations/ciphers/cipher_aes_gcm_hw_armv8.inc
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw_armv8.inc
@@ -21,27 +21,27 @@ size_t armv8_aes_gcm_encrypt(const unsigned char *in, unsigned char *out, size_t
     AES_KEY *aes_key = (AES_KEY *)key;
 
     switch(aes_key->rounds) {
-        case 10:
-            if (IS_CPU_SUPPORT_UNROLL8_EOR3()) {
-                unroll8_eor3_aes_gcm_enc_128_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
-            } else {
-                aes_gcm_enc_128_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
-            }
-            break;
-        case 12:
-            if (IS_CPU_SUPPORT_UNROLL8_EOR3()) {
-                unroll8_eor3_aes_gcm_enc_192_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
-            } else {
-                aes_gcm_enc_192_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
-            }
-            break;
-        case 14:
-            if (IS_CPU_SUPPORT_UNROLL8_EOR3()) {
-                unroll8_eor3_aes_gcm_enc_256_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
-            } else {
-                aes_gcm_enc_256_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
-            }
-            break;
+    case 10:
+        if (IS_CPU_SUPPORT_UNROLL8_EOR3()) {
+            unroll8_eor3_aes_gcm_enc_128_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
+        } else {
+            aes_gcm_enc_128_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
+        }
+        break;
+    case 12:
+        if (IS_CPU_SUPPORT_UNROLL8_EOR3()) {
+            unroll8_eor3_aes_gcm_enc_192_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
+        } else {
+            aes_gcm_enc_192_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
+        }
+        break;
+    case 14:
+        if (IS_CPU_SUPPORT_UNROLL8_EOR3()) {
+            unroll8_eor3_aes_gcm_enc_256_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
+        } else {
+            aes_gcm_enc_256_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
+        }
+        break;
     default:
         break;
     }
@@ -57,27 +57,27 @@ size_t armv8_aes_gcm_decrypt(const unsigned char *in, unsigned char *out, size_t
     AES_KEY *aes_key = (AES_KEY *)key;
 
     switch(aes_key->rounds) {
-        case 10:
-            if (IS_CPU_SUPPORT_UNROLL8_EOR3()) {
-                unroll8_eor3_aes_gcm_dec_128_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
-            } else {
-                aes_gcm_dec_128_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
-            }
-            break;
-        case 12:
-            if (IS_CPU_SUPPORT_UNROLL8_EOR3()) {
-                unroll8_eor3_aes_gcm_dec_192_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
-            } else {
-                aes_gcm_dec_192_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
-            }
-            break;
-        case 14:
-            if (IS_CPU_SUPPORT_UNROLL8_EOR3()) {
-                unroll8_eor3_aes_gcm_dec_256_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
-            } else {
-                aes_gcm_dec_256_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
-            }
-            break;
+    case 10:
+        if (IS_CPU_SUPPORT_UNROLL8_EOR3()) {
+            unroll8_eor3_aes_gcm_dec_128_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
+        } else {
+            aes_gcm_dec_128_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
+        }
+        break;
+    case 12:
+        if (IS_CPU_SUPPORT_UNROLL8_EOR3()) {
+            unroll8_eor3_aes_gcm_dec_192_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
+        } else {
+            aes_gcm_dec_192_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
+        }
+        break;
+    case 14:
+        if (IS_CPU_SUPPORT_UNROLL8_EOR3()) {
+            unroll8_eor3_aes_gcm_dec_256_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
+        } else {
+            aes_gcm_dec_256_kernel(in, align_bytes * 8, out, (uint64_t *)Xi, ivec, key);
+        }
+        break;
     default:
         break;
     }

--- a/providers/implementations/ciphers/cipher_rc2.c
+++ b/providers/implementations/ciphers/cipher_rc2.c
@@ -66,6 +66,8 @@ static int rc2_keybits_to_magic(int keybits)
         return RC2_64_MAGIC;
     case 40:
         return RC2_40_MAGIC;
+    default:
+        break;
     }
     ERR_raise(ERR_LIB_PROV, PROV_R_UNSUPPORTED_KEY_SIZE);
     return 0;
@@ -80,6 +82,8 @@ static int rc2_magic_to_keybits(int magic)
         return 64;
     case RC2_40_MAGIC:
         return 40;
+    default:
+        break;
     }
     ERR_raise(ERR_LIB_PROV, PROV_R_UNSUPPORTED_KEY_SIZE);
     return 0;

--- a/providers/implementations/encode_decode/decode_der2key.c
+++ b/providers/implementations/encode_decode/decode_der2key.c
@@ -549,6 +549,8 @@ static int rsa_check(void *key, struct der2key_ctx_st *ctx)
         return ctx->desc->evp_type == EVP_PKEY_RSA;
     case RSA_FLAG_TYPE_RSASSAPSS:
         return ctx->desc->evp_type == EVP_PKEY_RSA_PSS;
+    default:
+        break;
     }
 
     /* Currently unsupported RSA key type */

--- a/providers/implementations/encode_decode/encode_key2any.c
+++ b/providers/implementations/encode_decode/encode_key2any.c
@@ -74,6 +74,8 @@ static void free_asn1_data(int type, void *data)
     case V_ASN1_SEQUENCE:
         ASN1_STRING_free(data);
         break;
+    default:
+        break;
     }
 }
 
@@ -898,6 +900,8 @@ static int prepare_rsa_params(const void *rsa, int nid, int save,
             OPENSSL_free(str);
             return 0;
         }
+                default:
+                    break;
     }
 
     /* Currently unsupported RSA key type */
@@ -922,6 +926,8 @@ static int rsa_check_key_type(const void *rsa, int expected_type)
         return expected_type == EVP_PKEY_RSA;
     case RSA_FLAG_TYPE_RSASSAPSS:
         return expected_type == EVP_PKEY_RSA_PSS;
+    default:
+        break;
     }
 
     /* Currently unsupported RSA key type */

--- a/providers/implementations/encode_decode/encode_key2any.c
+++ b/providers/implementations/encode_decode/encode_key2any.c
@@ -903,8 +903,8 @@ static int prepare_rsa_params(const void *rsa, int nid, int save,
             OPENSSL_free(str);
             return 0;
         }
-                default:
-                    break;
+    default:
+        break;
     }
 
     /* Currently unsupported RSA key type */

--- a/providers/implementations/encode_decode/encode_key2any.c
+++ b/providers/implementations/encode_decode/encode_key2any.c
@@ -870,6 +870,9 @@ static int prepare_rsa_params(const void *rsa, int nid, int save,
                         goto err;
                     }
                     break;
+
+                default:
+                    break;
                 }
                 if (!ossl_DER_w_RSASSA_PSS_params(&pkt, -1, pss)
                     || !WPACKET_finish(&pkt)

--- a/providers/implementations/encode_decode/encode_key2text.c
+++ b/providers/implementations/encode_decode/encode_key2text.c
@@ -590,6 +590,8 @@ static int ecx_to_text(BIO *out, const void *key, int selection)
     case ECX_KEY_TYPE_ED448:
         type_label = "ED448";
         break;
+    default:
+        break;
     }
 
     if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
@@ -767,6 +769,8 @@ static int rsa_to_text(BIO *out, const void *key, int selection)
                                (trailerfield == 1 ? " (default)" : "")) <= 0)
                     goto err;
             }
+            break;
+        default:
             break;
         }
     }

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -82,6 +82,8 @@ const char *ec_query_operation_name(int operation_id)
         return "ECDH";
     case OSSL_OP_SIGNATURE:
         return "ECDSA";
+    default:
+        break;
     }
     return NULL;
 }
@@ -94,6 +96,8 @@ const char *sm2_query_operation_name(int operation_id)
     switch (operation_id) {
     case OSSL_OP_SIGNATURE:
         return "SM2";
+    default:
+        break;
     }
     return NULL;
 }

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -715,6 +715,8 @@ static void *ecx_gen(struct ecx_gen_ctx *gctx)
                                             gctx->propq))
             goto err;
         break;
+    default:
+        break;
     }
     key->haspubkey = 1;
     return key;

--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -727,6 +727,8 @@ static int file_eof(void *loaderctx)
          */
         return !BIO_pending(ctx->_.file.file)
             && BIO_eof(ctx->_.file.file);
+    default:
+        break;
     }
 
     /* ctx->type has an unexpected value */
@@ -764,6 +766,8 @@ static int file_close(void *loaderctx)
         return file_close_dir(ctx);
     case IS_FILE:
         return file_close_stream(ctx);
+    default:
+        break;
     }
 
     /* ctx->type has an unexpected value */

--- a/providers/legacyprov.c
+++ b/providers/legacyprov.c
@@ -177,6 +177,8 @@ static const OSSL_ALGORITHM *legacy_query(void *provctx, int operation_id,
         return legacy_ciphers;
     case OSSL_OP_KDF:
         return legacy_kdfs;
+    default:
+        break;
     }
     return NULL;
 }
@@ -233,6 +235,8 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
             break;
         case OSSL_FUNC_CORE_POP_ERROR_TO_MARK:
             set_func(c_pop_error_to_mark, OSSL_FUNC_core_pop_error_to_mark(tmp));
+            break;
+        default:
             break;
         }
     }

--- a/ssl/quic/quic_record_rx.c
+++ b/ssl/quic/quic_record_rx.c
@@ -642,6 +642,8 @@ static size_t qrx_get_cipher_ctx_idx(OSSL_QRX *qrx, OSSL_QRL_ENC_LEVEL *el,
          */
         *rx_key_epoch = el->key_epoch;
         break;
+    default:
+        break;
     }
 
     return idx;

--- a/ssl/quic/quic_wire_pkt.c
+++ b/ssl/quic/quic_wire_pkt.c
@@ -354,6 +354,8 @@ int ossl_quic_wire_decode_pkt_hdr(PACKET *pkt,
             case 3:
                 hdr->type = QUIC_PKT_TYPE_RETRY;
                 break;
+            default:
+                break;
             }
 
             hdr->pn_len     = 0;

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1271,6 +1271,8 @@ static int check_suiteb_cipher_list(const SSL_METHOD *meth, CERT *c,
     case SSL_CERT_FLAG_SUITEB_192_LOS:
         *prule_str = "ECDHE-ECDSA-AES256-GCM-SHA384";
         break;
+    default:
+        break;
     }
     return 1;
 }

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -396,6 +396,8 @@ static int dane_tlsa_add(SSL_DANE *dane,
             else
                 EVP_PKEY_free(pkey);
             break;
+        default:
+            break;
         }
     }
 
@@ -2264,6 +2266,8 @@ static int ssl_io_intern(void *vargs)
         return args->f.func_write(s, buf, num, &sc->asyncrw);
     case OTHERFUNC:
         return args->f.func_other(s);
+    default:
+        break;
     }
     return -1;
 }
@@ -6364,6 +6368,8 @@ int ssl_validate_ct(SSL_CONNECTION *s)
         case DANETLS_USAGE_DANE_TA:
         case DANETLS_USAGE_DANE_EE:
             return 1;
+        default:
+            break;
         }
     }
 

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -625,6 +625,8 @@ int ssl_get_prev_session(SSL_CONNECTION *s, CLIENTHELLO_MSG *hello)
         case SSL_TICKET_SUCCESS:
         case SSL_TICKET_SUCCESS_RENEW:
             break;
+        default:
+            break;
         }
     }
 

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -728,6 +728,9 @@ static SUB_STATE_RETURN read_state_machine(SSL_CONNECTION *s)
                     dtls1_stop_timer(s);
                 }
                 return SUB_STATE_FINISHED;
+
+            default:
+                break;
             }
             break;
 
@@ -852,6 +855,9 @@ static SUB_STATE_RETURN write_state_machine(SSL_CONNECTION *s)
             case WRITE_TRAN_ERROR:
                 check_fatal(s);
                 return SUB_STATE_ERROR;
+
+            default:
+                break;
             }
             break;
 
@@ -871,6 +877,9 @@ static SUB_STATE_RETURN write_state_machine(SSL_CONNECTION *s)
 
             case WORK_FINISHED_STOP:
                 return SUB_STATE_END_HANDSHAKE;
+
+            default:
+                break;
             }
             if (!get_construct_message_f(s, &confunc, &mt)) {
                 /* SSLfatal() already called */
@@ -944,6 +953,9 @@ static SUB_STATE_RETURN write_state_machine(SSL_CONNECTION *s)
 
             case WORK_FINISHED_STOP:
                 return SUB_STATE_END_HANDSHAKE;
+
+            default:
+                break;
             }
             break;
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2492,6 +2492,7 @@ SSL_TICKET_STATUS tls_decrypt_ticket(SSL_CONNECTION *s,
         case SSL_TICKET_SUCCESS_RENEW:
         case SSL_TICKET_EMPTY:
             s->ext.ticket_expected = 1;
+            break;
         default:
             break;
         }

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1767,6 +1767,8 @@ size_t tls12_get_psigalgs(SSL_CONNECTION *s, int sent, const uint16_t **psigs)
     case SSL_CERT_FLAG_SUITEB_192_LOS:
         *psigs = suiteb_sigalgs + 1;
         return 1;
+    default:
+        break;
     }
     /*
      *  We use client_sigalgs (if not NULL) if we're a server
@@ -2490,6 +2492,8 @@ SSL_TICKET_STATUS tls_decrypt_ticket(SSL_CONNECTION *s,
         case SSL_TICKET_SUCCESS_RENEW:
         case SSL_TICKET_EMPTY:
             s->ext.ticket_expected = 1;
+        default:
+            break;
         }
     }
 

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -1788,6 +1788,7 @@ void SSL_trace(int write_p, int version, int content_type,
                        SSL_alert_type_string_long(msg[0] << 8),
                        msg[0], SSL_alert_desc_string_long(msg[1]), msg[1]);
         }
+        break;
 
     default:
         break;

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -1199,6 +1199,8 @@ static int ssl_print_client_keyex(BIO *bio, int indent, const SSL_CONNECTION *sc
                       "GOST-wrapped PreMasterSecret", msg, msglen);
         msglen = 0;
         break;
+    default:
+        break;
     }
 
     return !msglen;
@@ -1265,6 +1267,8 @@ static int ssl_print_server_keyex(BIO *bio, int indent, const SSL_CONNECTION *sc
 
     case SSL_kPSK:
     case SSL_kRSAPSK:
+        break;
+    default:
         break;
     }
     if (!(id & SSL_PSK))
@@ -1785,6 +1789,8 @@ void SSL_trace(int write_p, int version, int content_type,
                        msg[0], SSL_alert_desc_string_long(msg[1]), msg[1]);
         }
 
+    default:
+        break;
     }
 
     BIO_puts(bio, "\n");

--- a/test/bio_enc_test.c
+++ b/test/bio_enc_test.c
@@ -212,6 +212,8 @@ static int do_test_bio_cipher(const EVP_CIPHER* cipher, int idx)
             return do_bio_cipher(cipher, KEY, NULL);
         case 1:
             return do_bio_cipher(cipher, KEY, IV);
+    default:
+        break;
     }
     return 0;
 }

--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -368,6 +368,8 @@ static int test_d2i_CMS_decode(const int idx)
         if (!TEST_ptr(cms = d2i_CMS_ContentInfo(NULL, &tmp, buf_len)))
             goto end;
         break;
+    default:
+        break;
     }
 
     if (!TEST_int_eq(ERR_peek_error(), 0))

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -206,6 +206,8 @@ static int assert_validity(CT_TEST_FIXTURE *fixture, STACK_OF(SCT) *scts,
         case SCT_VALIDATION_STATUS_UNKNOWN_VERSION:
             /* Ignore other validation statuses. */
             break;
+        default:
+            break;
         }
     }
 

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -3381,6 +3381,8 @@ static int test_keygen_with_empty_template(int n)
             || !TEST_ptr(ctx = EVP_PKEY_CTX_new(tkey, NULL)))
             goto err;
         break;
+    default:
+        break;
     }
 
     if (!TEST_int_gt(EVP_PKEY_keygen_init(ctx), 0)
@@ -5269,6 +5271,8 @@ static int test_ecx_not_private_key(int tst)
     case NID_X25519:
     case NID_X448:
         return TEST_skip("signing not supported for X25519/X448");
+    default:
+        break;
     }
 
     /* Check if this algorithm supports public keys */

--- a/test/evp_fetch_prov_test.c
+++ b/test/evp_fetch_prov_test.c
@@ -248,6 +248,8 @@ static int test_explicit_EVP_MD_fetch_by_X509_ALGOR(int idx)
         if (!TEST_int_gt(OBJ_obj2txt(id, sizeof(id), obj, 1), 0))
             goto end;
         break;
+    default:
+        break;
     }
 
     ret = test_explicit_EVP_MD_fetch(id);
@@ -363,6 +365,8 @@ static int test_explicit_EVP_CIPHER_fetch_by_X509_ALGOR(int idx)
     case 1:
         if (!TEST_int_gt(OBJ_obj2txt(id, sizeof(id), obj, 1), 0))
             goto end;
+        break;
+    default:
         break;
     }
 

--- a/test/fake_rsaprov.c
+++ b/test/fake_rsaprov.c
@@ -716,6 +716,8 @@ static const OSSL_ALGORITHM *fake_rsa_query(void *provctx,
 
     case OSSL_OP_STORE:
         return fake_rsa_store_algs;
+    default:
+        break;
     }
     return NULL;
 }

--- a/test/helpers/handshake.c
+++ b/test/helpers/handshake.c
@@ -525,6 +525,8 @@ static int configure_handshake_ctx(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
         break;
     case SSL_TEST_VERIFY_NONE:
         break;
+    default:
+        break;
     }
 
     switch (extra->client.max_fragment_len_mode) {
@@ -535,6 +537,8 @@ static int configure_handshake_ctx(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
     case TLSEXT_max_fragment_length_DISABLED:
         SSL_CTX_set_tlsext_max_fragment_length(
               client_ctx, extra->client.max_fragment_len_mode);
+        break;
+    default:
         break;
     }
 
@@ -562,6 +566,8 @@ static int configure_handshake_ctx(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
         break;
     case SSL_TEST_SERVERNAME_CLIENT_HELLO_NO_V12:
         SSL_CTX_set_client_hello_cb(server_ctx, client_hello_nov12_cb, server2_ctx);
+    default:
+        break;
     }
 
     if (extra->server.cert_status != SSL_TEST_CERT_STATUS_NONE) {
@@ -692,6 +698,8 @@ static int configure_handshake_ctx(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
             goto err;
         break;
     case SSL_TEST_CT_VALIDATION_NONE:
+        break;
+    default:
         break;
     }
 #endif
@@ -1136,6 +1144,8 @@ static connect_phase_t next_phase(const SSL_TEST_CTX *test_ctx,
     case CONNECTION_DONE:
         TEST_error("Trying to progress after connection done");
         break;
+    default:
+        break;
     }
     return -1;
 }
@@ -1164,6 +1174,8 @@ static void do_connect_step(const SSL_TEST_CTX *test_ctx, PEER *peer,
         break;
     case CONNECTION_DONE:
         TEST_error("Action after connection done");
+        break;
+    default:
         break;
     }
 }
@@ -1239,6 +1251,8 @@ static handshake_status_t handshake_status(peer_status_t last_status,
             /* Both peers errored. Return the one that errored first. */
             return client_spoke_last ? SERVER_ERROR : CLIENT_ERROR;
         }
+        default:
+            break;
     }
     /* Control should never reach here. */
     return INTERNAL_ERROR;
@@ -1634,6 +1648,8 @@ static HANDSHAKE_RESULT *do_handshake_internal(
                     client_turn ^= 1;
                 }
             }
+            break;
+        default:
             break;
         }
     }

--- a/test/helpers/handshake.c
+++ b/test/helpers/handshake.c
@@ -1228,6 +1228,9 @@ static handshake_status_t handshake_status(peer_status_t last_status,
              * already errored. This shouldn't happen.
              */
             return INTERNAL_ERROR;
+
+        default:
+            break;
         }
         break;
 
@@ -1250,6 +1253,8 @@ static handshake_status_t handshake_status(peer_status_t last_status,
         case PEER_ERROR:
             /* Both peers errored. Return the one that errored first. */
             return client_spoke_last ? SERVER_ERROR : CLIENT_ERROR;
+        default:
+            break;
         }
         default:
             break;

--- a/test/helpers/handshake.c
+++ b/test/helpers/handshake.c
@@ -566,6 +566,7 @@ static int configure_handshake_ctx(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
         break;
     case SSL_TEST_SERVERNAME_CLIENT_HELLO_NO_V12:
         SSL_CTX_set_client_hello_cb(server_ctx, client_hello_nov12_cb, server2_ctx);
+        break;
     default:
         break;
     }
@@ -1256,8 +1257,8 @@ static handshake_status_t handshake_status(peer_status_t last_status,
         default:
             break;
         }
-        default:
-            break;
+    default:
+        break;
     }
     /* Control should never reach here. */
     return INTERNAL_ERROR;

--- a/test/helpers/ssl_test_ctx.c
+++ b/test/helpers/ssl_test_ctx.c
@@ -544,6 +544,8 @@ __owur static int parse_expected_key_type(int *ptype, const char *value)
     case NID_brainpoolP512r1tls13:
         nid = NID_brainpoolP512r1;
         break;
+    default:
+        break;
     }
     if (nid == NID_undef)
         return 0;

--- a/test/ocspapitest.c
+++ b/test/ocspapitest.c
@@ -177,6 +177,8 @@ static int test_access_description(int testcase)
         if (!TEST_ptr(ad->location))
             goto err;
         break;
+    default:
+        break;
     }
     ACCESS_DESCRIPTION_free(ad);
     ret = 1;

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -104,6 +104,8 @@ static int test_param_type_null(OSSL_PARAM *param)
         /* these are allowed to be null */
         return 1;
         break;
+    default:
+        break;
     }
 
     /*

--- a/test/provfetchtest.c
+++ b/test/provfetchtest.c
@@ -188,6 +188,8 @@ static const OSSL_ALGORITHM *dummy_query(void *provctx, int operation_id,
         return dummy_store;
     case OSSL_OP_RAND:
         return dummy_rand;
+    default:
+        break;
     }
     return NULL;
 }

--- a/test/quic_ackm_test.c
+++ b/test/quic_ackm_test.c
@@ -598,6 +598,8 @@ static int test_tx_ack_time_script(int tidx)
                 }
 
                 break;
+        default:
+            break;
         }
 
     testresult = 1;

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -3450,6 +3450,8 @@ static int script_39_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
         seq_no          = 1;
         retire_prior_to = 1;
         break;
+    default:
+        break;
     }
 
     if (!TEST_true(WPACKET_init_static_len(&wpkt, frame_buf,
@@ -3901,6 +3903,8 @@ static int script_46_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
         ect1            = 50;
         ecnce           = 200;
         break;
+    default:
+        break;
     }
 
     h->inject_word0 = 0;
@@ -4169,6 +4173,8 @@ static int script_53_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
          */
         offset      = 100000;
         data_len    = 1;
+        break;
+    default:
         break;
     }
 

--- a/test/rsa_test.c
+++ b/test/rsa_test.c
@@ -227,6 +227,8 @@ static int rsa_setkey(RSA** key, unsigned char *ctext, int idx)
         case 2:
             clen = key3(*key, ctext);
             break;
+        default:
+            break;
         }
     return clen;
 }

--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -102,6 +102,8 @@ static int test_lib(void)
             goto end;
         }
         break;
+    default:
+        break;
     }
 
     if (test_type == NO_ATEXIT) {

--- a/test/ssl_ctx_test.c
+++ b/test/ssl_ctx_test.c
@@ -94,6 +94,8 @@ static int test_set_min_max_version(int idx_tst)
         meth = OSSL_QUIC_client_method();
         break;
 #endif
+    default:
+        break;
     }
 
     if (meth == NULL)

--- a/test/ssl_handshake_rtt_test.c
+++ b/test/ssl_handshake_rtt_test.c
@@ -111,6 +111,8 @@ static int test_handshake_rtt(int tst)
         st->hand_state = TLS_ST_CR_SRVR_DONE;
         ossl_statem_client_write_transition(s);
         break;
+    default:
+        break;
     }
 
     if (!TEST_int_gt(SSL_get_handshake_rtt(SSL_CONNECTION_GET_SSL(s), &rtt), 0))

--- a/test/ssl_old_test.c
+++ b/test/ssl_old_test.c
@@ -1837,6 +1837,8 @@ int main(int argc, char *argv[])
             ret = EXIT_FAILURE;
             goto end;
 #endif
+        default:
+            break;
         }
         if (ret != EXIT_SUCCESS)
             break;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -5377,20 +5377,20 @@ static int test_tls13_ciphersuite(int idx)
     size_t i;
 
     switch (idx) {
-        case 0:
-            set_at_ctx = 1;
-            break;
-        case 1:
-            set_at_ssl = 1;
-            break;
-        case 2:
-            set_at_ctx = 1;
-            t12_cipher = TLS1_TXT_RSA_WITH_AES_128_SHA256;
-            break;
-        case 3:
-            set_at_ssl = 1;
-            t12_cipher = TLS1_TXT_RSA_WITH_AES_128_SHA256;
-            break;
+    case 0:
+        set_at_ctx = 1;
+        break;
+    case 1:
+        set_at_ssl = 1;
+        break;
+    case 2:
+        set_at_ctx = 1;
+        t12_cipher = TLS1_TXT_RSA_WITH_AES_128_SHA256;
+        break;
+    case 3:
+        set_at_ssl = 1;
+        t12_cipher = TLS1_TXT_RSA_WITH_AES_128_SHA256;
+        break;
     default:
         break;
     }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -2908,6 +2908,8 @@ static void setupbio(BIO **res, BIO *bio1, BIO *bio2, int type)
     case USE_BIO_2:
         *res = bio2;
         break;
+    default:
+        break;
     }
 }
 
@@ -5389,6 +5391,8 @@ static int test_tls13_ciphersuite(int idx)
             set_at_ssl = 1;
             t12_cipher = TLS1_TXT_RSA_WITH_AES_128_SHA256;
             break;
+    default:
+        break;
     }
 
     for (max_ver = TLS1_2_VERSION; max_ver <= TLS1_3_VERSION; max_ver++) {
@@ -6402,6 +6406,8 @@ static int test_serverinfo_custom(const int idx)
         extension_context = TLS13CONTEXT;
         si = serverinfo_custom_tls13;
         si_len = serverinfo_custom_tls13_len;
+        break;
+    default:
         break;
     }
 
@@ -11416,6 +11422,8 @@ static int check_version_string(SSL *s, int version)
         break;
     case DTLS1_2_VERSION:
         verstr = "DTLSv1.2";
+    default:
+        break;
     }
 
     return TEST_str_eq(verstr, SSL_get_version(s));

--- a/test/testutil/fake_random.c
+++ b/test/testutil/fake_random.c
@@ -150,6 +150,8 @@ static const OSSL_ALGORITHM *fake_rand_query(void *provctx,
     switch (operation_id) {
     case OSSL_OP_RAND:
         return fake_rand_rand;
+    default:
+        break;
     }
     return NULL;
 }

--- a/test/testutil/provider.c
+++ b/test/testutil/provider.c
@@ -230,6 +230,8 @@ int fips_provider_version_match(OSSL_LIB_CTX *libctx, const char *versions)
         case MODE_GE:
             r = fips_provider_version_ge(libctx, major, minor, patch);
             break;
+        default:
+            break;
         }
         if (r < 0) {
             TEST_info("Error matching FIPS version: internal error\n");

--- a/test/testutil/testutil_init.c
+++ b/test/testutil/testutil_init.c
@@ -46,6 +46,8 @@ static size_t internal_trace_cb(const char *buf, size_t cnt,
 
         BIO_set_prefix(trace_data->bio, NULL);
         break;
+    default:
+        break;
     }
 
     return ret < 0 ? 0 : ret;

--- a/test/timing_load_creds.c
+++ b/test/timing_load_creds.c
@@ -167,6 +167,8 @@ int main(int ac, char **av)
         case 'p':
             readpkey(contents, (int)sb.st_size);
             break;
+        default:
+            break;
         }
     }
 
@@ -185,6 +187,8 @@ int main(int ac, char **av)
             break;
         case 'p':
             readpkey(contents, (int)sb.st_size);
+            break;
+        default:
             break;
         }
     }

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -1344,6 +1344,8 @@ static void free_asn1_data(int type, void *data)
     case V_ASN1_SEQUENCE:
         ASN1_STRING_free(data);
         break;
+    default:
+        break;
     }
 }
 
@@ -3152,6 +3154,8 @@ static const OSSL_ALGORITHM *tls_prov_query(void *provctx, int operation_id,
         return tls_prov_decoder;
     case OSSL_OP_SIGNATURE:
         return tls_prov_signature;
+    default:
+        break;
     }
     return NULL;
 }

--- a/test/tls13ccstest.c
+++ b/test/tls13ccstest.c
@@ -471,6 +471,8 @@ static int test_tls13ccs(int tst)
                 || !TEST_size_t_gt(chsessidlen, 0))
             goto err;
         break;
+    default:
+        break;
     }
 
     ret = 1;

--- a/test/wpackettest.c
+++ b/test/wpackettest.c
@@ -608,6 +608,8 @@ static int test_WPACKET_quic_vlint_random(void)
             case 3:
                 expected &= OSSL_QUIC_VLINT_8B_MAX;
                 break;
+        default:
+            break;
         }
 
         if (!TEST_true(WPACKET_init(&pkt, buf))


### PR DESCRIPTION
This was done automatically using this script:

```awk
BEGIN {depth=0;inswitch=0;founddefault=0;spaces="";bs=""}
/.*switch.*/ {
                inswitch=1;
                split($0, spc, "s");
                spaces=spc[1];
                bs = substr($0, length($0)) == "\\" ? " \\" : "";
             }
/{/ {if (inswitch==1) { depth=depth+1;}}
/}/ {if (inswitch==1) {
                           depth=depth-1;
                           if (depth==0) {
                               inswitch=0;
                               if (founddefault==0) {
                                   print (spaces "default:" bs);
                                   print (spaces "    break;" bs);
                               }
                               founddefault=0;
                           }
                      }
    }
/default:/ {if (inswitch==1) {founddefault=1}}
{print}
```

The dozenish false corrections were fixed manually by deleting the the two added lines in each case.
The only false positive not caught by a build was in the demos and this was also fixed.

There were also eight false negatives due to nested switch statements.  These were manually addressed.
