### PR TITLE
Configure: Remove -Wswitch-default from strict warnings

### DIFF
--- a/Configure
+++ b/Configure
@@ -167,7 +167,6 @@ my @gcc_devteam_warn = qw(
     -Wshadow
     -Wformat
     -Wno-type-limits
-    -Wno-tautological-constant-out-of-range-compare
     -Wundef
     -Werror
     -Wmissing-prototypes
@@ -184,11 +183,11 @@ my @gcc_devteam_warn = qw(
 #       -Wextended-offsetof -- no, needed in CMS ASN1 code
 my @clang_devteam_warn = qw(
     -Wno-unknown-warning-option
-    -Wswitch-default
     -Wno-parentheses-equality
     -Wno-language-extension-token
     -Wno-extended-offsetof
     -Wno-missing-braces
+    -Wno-tautological-constant-out-of-range-compare
     -Wconditional-uninitialized
     -Wincompatible-pointer-types-discards-qualifiers
     -Wmissing-variable-declarations


### PR DESCRIPTION
Also move -Wno-tautological-constant-out-of-range-compare to clang-specific options as it is not supported by gcc.

We do not have default cases in many switch() statements.

This is alternative to https://github.com/openssl/openssl/pull/24756 - IMO this needs to go at least into the stable branches.
