### PR TITLE
Remove appveyor badge and replace it with os zoo badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to the OpenSSL Project
 [![openssl logo]][www.openssl.org]
 
 [![github actions ci badge]][github actions ci]
-[![appveyor badge]][appveyor jobs]
+![Nightly OS Zoo ci badge](https://github.com/openssl/openssl/actions/workflows/os-zoo.yml/badge.svg)
 
 OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit
 for the TLS (formerly SSL), DTLS and QUIC (currently client side only)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Welcome to the OpenSSL Project
 
 [![github actions ci badge]][github actions ci]
 ![Nightly OS Zoo ci badge](https://github.com/openssl/openssl/actions/workflows/os-zoo.yml/badge.svg)
+![Provider Compatibility]( https://github.com/openssl/openssl/actions/workflows/provider-compatibility.yml/badge.svg)
+![Daily checks](https://github.com/openssl/openssl/actions/workflows/run-checker-daily.yml/badge.svg)
 
 OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit
 for the TLS (formerly SSL), DTLS and QUIC (currently client side only)


### PR DESCRIPTION
We don't use appveyor anymore. Replace it with the os zoo badge, so we can more persistently see when its breaking

