### PR TITLE
Clarify elliptic curve docs for s_client/s_server

### DIFF
--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -656,7 +656,11 @@ For example strings, see L<SSL_CTX_set1_sigalgs(3)>
 =item B<-curves> I<curvelist>
 
 Specifies the list of supported curves to be sent by the client. The curve is
-ultimately selected by the server. For a list of all curves, use:
+ultimately selected by the server.
+
+The list of all supported groups includes named EC parameters as well as X25519
+and X448 or FFDHE groups, and may also include groups implemented in 3rd-party
+providers. For a list of named EC parameters, use:
 
     $ openssl ecparam -list_curves
 

--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -671,7 +671,10 @@ Signature algorithms to support for client certificate authentication
 =item B<-named_curve> I<val>
 
 Specifies the elliptic curve to use. NOTE: this is single curve, not a list.
-For a list of all possible curves, use:
+
+The list of all supported groups includes named EC parameters as well as X25519
+and X448 or FFDHE groups, and may also include groups implemented in 3rd-party
+providers. For a list of named EC parameters, use:
 
     $ openssl ecparam -list_curves
 


### PR DESCRIPTION
Clarify in the `s_client`/`s_server` documentation that supported elliptic curves include EC curves with parameters, as well as X25519 and X448, which do not use EC parameters.

See https://github.com/openssl/openssl/issues/5232#issuecomment-371543251
> `ecparam` is a tool for manipulating EC parameter files. Curve25519 and Curve448 are _special_ and do not use EC parameter files (they do not work with standard ECDH(E) or ECSDA - instead they use X25519/X448 and Ed25519/Ed448). `-list_curves` only gives you the standard built-in curves that use EC parameter files.

It is not reasonable to implement a command that only displays the two X25519 and X448 elliptic curves.

Fixes #7920

##### Checklist
- [X] documentation is added or updated
