### PR TITLE
Fixes for potential deadlock

### DIFF
--- a/crypto/engine/eng_list.c
+++ b/crypto/engine/eng_list.c
@@ -243,6 +243,7 @@ ENGINE *ENGINE_get_first(void)
         int ref;
 
         if (!CRYPTO_UP_REF(&ret->struct_ref, &ref)) {
+            CRYPTO_THREAD_unlock(global_engine_lock);
             ERR_raise(ERR_LIB_ENGINE, ERR_R_CRYPTO_LIB);
             return NULL;
         }
@@ -269,6 +270,7 @@ ENGINE *ENGINE_get_last(void)
         int ref;
 
         if (!CRYPTO_UP_REF(&ret->struct_ref, &ref)) {
+            CRYPTO_THREAD_unlock(global_engine_lock);
             ERR_raise(ERR_LIB_ENGINE, ERR_R_CRYPTO_LIB);
             return NULL;
         }
@@ -294,6 +296,7 @@ ENGINE *ENGINE_get_next(ENGINE *e)
 
         /* Return a valid structural reference to the next ENGINE */
         if (!CRYPTO_UP_REF(&ret->struct_ref, &ref)) {
+            CRYPTO_THREAD_unlock(global_engine_lock);
             ERR_raise(ERR_LIB_ENGINE, ERR_R_CRYPTO_LIB);
             return NULL;
         }
@@ -320,6 +323,7 @@ ENGINE *ENGINE_get_prev(ENGINE *e)
 
         /* Return a valid structural reference to the next ENGINE */
         if (!CRYPTO_UP_REF(&ret->struct_ref, &ref)) {
+            CRYPTO_THREAD_unlock(global_engine_lock);
             ERR_raise(ERR_LIB_ENGINE, ERR_R_CRYPTO_LIB);
             return NULL;
         }


### PR DESCRIPTION
Fixes #24517

(3/3) Addresses the potential deadlock if an error occurs from up_ref in functions ENGINE_get_first, ENGINE_get_last, ENGINE_get_next, and ENGINE_get_prev in file crypto/engine/eng_list.c by unlocking the set lock.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
