### PR TITLE
read lock store on ossl_method_store_do_all

### DIFF
--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -467,7 +467,7 @@ static void alg_copy(ossl_uintmax_t idx, ALGORITHM *alg, void *arg)
 {
     STACK_OF(ALGORITHM) *newalg = arg;
 
-    sk_ALGORITHM_push(newalg, alg);
+    (void)sk_ALGORITHM_push(newalg, alg);
 }
 
 void ossl_method_store_do_all(OSSL_METHOD_STORE *store,

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -480,12 +480,17 @@ void ossl_method_store_do_all(OSSL_METHOD_STORE *store,
     ALGORITHM *alg;
 
     if (store != NULL) {
-        tmpalgs = sk_ALGORITHM_new_reserve(NULL,
-                                           ossl_sa_ALGORITHM_num(store->algs));
-        if (tmpalgs == NULL)
-            return;
+
         if (!ossl_property_read_lock(store))
             return;
+       
+        tmpalgs = sk_ALGORITHM_new_reserve(NULL,
+                                           ossl_sa_ALGORITHM_num(store->algs));
+        if (tmpalgs == NULL) {
+            ossl_property_unlock(store);
+            return;
+        }
+
         ossl_sa_ALGORITHM_doall_arg(store->algs, alg_copy, tmpalgs);
         ossl_property_unlock(store);
         numalgs = sk_ALGORITHM_num(tmpalgs);

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -476,13 +476,14 @@ void ossl_method_store_do_all(OSSL_METHOD_STORE *store,
 {
     int i, j;
     int numalgs, numimps;
-    STACK_OF(ALGORITHM) *tmpalgs = sk_ALGORITHM_new_null();
+    STACK_OF(ALGORITHM) *tmpalgs;
     ALGORITHM *alg;
 
-    if (tmpalgs == NULL)
-        return;
-
     if (store != NULL) {
+        tmpalgs = sk_ALGORITHM_new_reserve(NULL,
+                                           ossl_sa_ALGORITHM_num(store->algs));
+        if (tmpalgs == NULL)
+            return;
         if (!ossl_property_read_lock(store))
             return;
         ossl_sa_ALGORITHM_doall_arg(store->algs, alg_copy, tmpalgs);


### PR DESCRIPTION
Theres a data race between ossl_method_store_insert and ossl_method_store_do_all, as the latter doesn't take the property lock before iterating.

However, we can't lock in do_all, as the call stack in several cases later attempts to take the write lock.

The choices to fix it are I think:
1) add an argument to indicate to ossl_method_store_do_all weather to
   take the read or write lock when doing iterations, and add an
   is_locked api to the ossl_property_[read|write] lock family so that
   subsequent callers can determine if they need to take a lock or not

2) Clone the algs sparse array in ossl_method_store_do_all and use the
   clone to iterate with no lock held, ensuring that updates to the
   parent copy of the sparse array are left untoucheTheres a data race
   between ossl_method_store_insert and ossl_method_store_do_all, as the
   latter doesn't take the property lock before iterating.

I think method (2), while being a bit more expensive, is probably the far less invasive way to go here

Fixes #24672
