### PR TITLE
Extend `X509_REQ_add_extensions_nid()` and thus APPS/req to support augmenting/overriding existing extensions

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -481,7 +481,7 @@ int req_main(int argc, char **argv)
             }
             i = duplicated(addexts, p);
             if (i == 1)
-                goto opthelp;
+                goto end;
             if (i == -1)
                 BIO_printf(bio_err, "Internal error handling -addext %s\n", p);
             if (i < 0 || BIO_printf(addext_bio, "%s\n", p) < 0)

--- a/crypto/x509/x509_att.c
+++ b/crypto/x509/x509_att.c
@@ -123,7 +123,8 @@ STACK_OF(X509_ATTRIBUTE) *X509at_add1_attr(STACK_OF(X509_ATTRIBUTE) **x,
         return NULL;
     }
     if (*x != NULL && X509at_get_attr_by_OBJ(*x, attr->object, -1) != -1) {
-        ERR_raise(ERR_LIB_X509, X509_R_DUPLICATE_ATTRIBUTE);
+        ERR_raise_data(ERR_LIB_X509, X509_R_DUPLICATE_ATTRIBUTE,
+                       "name=%s", OBJ_nid2sn(OBJ_obj2nid(attr->object)));
         return NULL;
     }
 
@@ -158,7 +159,8 @@ STACK_OF(X509_ATTRIBUTE) *X509at_add1_attr_by_OBJ(STACK_OF(X509_ATTRIBUTE)
         return NULL;
     }
     if (*x != NULL && X509at_get_attr_by_OBJ(*x, obj, -1) != -1) {
-        ERR_raise(ERR_LIB_X509, X509_R_DUPLICATE_ATTRIBUTE);
+        ERR_raise_data(ERR_LIB_X509, X509_R_DUPLICATE_ATTRIBUTE,
+                       "name=%s", OBJ_nid2sn(OBJ_obj2nid(obj)));
         return NULL;
     }
 
@@ -191,7 +193,8 @@ STACK_OF(X509_ATTRIBUTE) *X509at_add1_attr_by_NID(STACK_OF(X509_ATTRIBUTE)
         return NULL;
     }
     if (*x != NULL && X509at_get_attr_by_NID(*x, nid, -1) != -1) {
-        ERR_raise(ERR_LIB_X509, X509_R_DUPLICATE_ATTRIBUTE);
+        ERR_raise_data(ERR_LIB_X509, X509_R_DUPLICATE_ATTRIBUTE,
+                       "name=%s", OBJ_nid2sn(nid));
         return NULL;
     }
 

--- a/crypto/x509/x509_att.c
+++ b/crypto/x509/x509_att.c
@@ -80,7 +80,7 @@ X509_ATTRIBUTE *X509at_delete_attr(STACK_OF(X509_ATTRIBUTE) *x, int loc)
 }
 
 STACK_OF(X509_ATTRIBUTE) *ossl_x509at_add1_attr(STACK_OF(X509_ATTRIBUTE) **x,
-                                                X509_ATTRIBUTE *attr)
+                                                const X509_ATTRIBUTE *attr)
 {
     X509_ATTRIBUTE *new_attr = NULL;
     STACK_OF(X509_ATTRIBUTE) *sk = NULL;

--- a/crypto/x509/x509_req.c
+++ b/crypto/x509/x509_req.c
@@ -139,7 +139,7 @@ static STACK_OF(X509_EXTENSION) *get_extensions_by_nid(const X509_REQ *req,
                       ASN1_ITEM_rptr(X509_EXTENSIONS));
 }
 
-STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(const X509_REQ *req)
+STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(OSSL_CONST_FUTURE X509_REQ *req)
 {
     STACK_OF(X509_EXTENSION) *exts = NULL;
     int *pnid;

--- a/crypto/x509/x509_req.c
+++ b/crypto/x509/x509_req.c
@@ -117,26 +117,19 @@ void X509_REQ_set_extension_nids(int *nids)
     ext_nids = nids;
 }
 
-STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(X509_REQ *req)
+static STACK_OF(X509_EXTENSION) *get_extensions_by_nid(const X509_REQ *req,
+                                                       int nid)
 {
     X509_ATTRIBUTE *attr;
     ASN1_TYPE *ext = NULL;
-    int idx, *pnid;
     const unsigned char *p;
+    int idx = X509_REQ_get_attr_by_NID(req, nid, -1);
 
-    if (req == NULL || !ext_nids)
-        return NULL;
-    for (pnid = ext_nids; *pnid != NID_undef; pnid++) {
-        idx = X509_REQ_get_attr_by_NID(req, *pnid, -1);
-        if (idx < 0)
-            continue;
-        attr = X509_REQ_get_attr(req, idx);
-        ext = X509_ATTRIBUTE_get0_type(attr, 0);
-        break;
-    }
-    if (ext == NULL) /* no extensions is not an error */
+    if (idx < 0) /* no extensions is not an error */
         return sk_X509_EXTENSION_new_null();
-    if (ext->type != V_ASN1_SEQUENCE) {
+    attr = X509_REQ_get_attr(req, idx);
+    ext = X509_ATTRIBUTE_get0_type(attr, 0);
+    if (ext == NULL || ext->type != V_ASN1_SEQUENCE) {
         ERR_raise(ERR_LIB_X509, X509_R_WRONG_TYPE);
         return NULL;
     }
@@ -144,6 +137,25 @@ STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(X509_REQ *req)
     return (STACK_OF(X509_EXTENSION) *)
         ASN1_item_d2i(NULL, &p, ext->value.sequence->length,
                       ASN1_ITEM_rptr(X509_EXTENSIONS));
+}
+
+STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(const X509_REQ *req)
+{
+    STACK_OF(X509_EXTENSION) *exts = NULL;
+    int *pnid;
+
+    if (req == NULL || ext_nids == NULL)
+        return NULL;
+    for (pnid = ext_nids; *pnid != NID_undef; pnid++) {
+        exts = get_extensions_by_nid(req, *pnid);
+        if (exts == NULL)
+            return NULL;
+        if (sk_X509_EXTENSION_num(exts) > 0)
+            return exts;
+        sk_X509_EXTENSION_free(exts);
+    }
+    /* no extensions is not an error */
+    return sk_X509_EXTENSION_new_null();
 }
 
 /*

--- a/crypto/x509/x509_req.c
+++ b/crypto/x509/x509_req.c
@@ -139,7 +139,7 @@ static STACK_OF(X509_EXTENSION) *get_extensions_by_nid(const X509_REQ *req,
                       ASN1_ITEM_rptr(X509_EXTENSIONS));
 }
 
-STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(OSSL_CONST_FUTURE X509_REQ *req)
+STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(OSSL_FUTURE_CONST X509_REQ *req)
 {
     STACK_OF(X509_EXTENSION) *exts = NULL;
     int *pnid;

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -392,7 +392,11 @@ Add a specific extension to the certificate (if B<-x509> is in use)
 or certificate request.  The argument must have the form of
 a C<key=value> pair as it would appear in a config file.
 
+If an extension is added using this option that has the same OID as one
+defined in the extension section of the config file, it overrides that one.
+
 This option can be given multiple times.
+Doing so, the same key most not be given more than once.
 
 =item B<-precert>
 
@@ -552,7 +556,7 @@ BMPStrings and UTF8Strings.
 
 This specifies the configuration file section containing a list of
 extensions to add to the certificate request. It can be overridden
-by the B<-reqexts> command line switch. See the
+by the B<-reqexts> (or B<-extensions>) command line switch. See the
 L<x509v3_config(5)> manual page for details of the
 extension section format.
 

--- a/doc/man3/X509_REQ_get_extensions.pod
+++ b/doc/man3/X509_REQ_get_extensions.pod
@@ -10,7 +10,7 @@ X509_REQ_add_extensions, X509_REQ_add_extensions_nid
 
  #include <openssl/x509.h>
 
- STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(X509_REQ *req);
+ STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(const X509_REQ *req);
  int X509_REQ_add_extensions(X509_REQ *req, const STACK_OF(X509_EXTENSION) *exts);
  int X509_REQ_add_extensions_nid(X509_REQ *req,
                                  const STACK_OF(X509_EXTENSION) *exts, int nid);

--- a/doc/man3/X509_REQ_get_extensions.pod
+++ b/doc/man3/X509_REQ_get_extensions.pod
@@ -22,13 +22,15 @@ found in the attributes of I<req>.
 The returned list is empty if there are no such extensions in I<req>.
 The caller is responsible for freeing the list obtained.
 
-X509_REQ_add_extensions() adds to I<req> a list of X.509 extensions I<exts>,
-which must not be NULL, using the default B<NID_ext_req>.
-This function must not be called more than once on the same I<req>.
+X509_REQ_add_extensions_nid() adds to I<req> a list of X.509 extensions I<exts>,
+using I<nid> to identify the extensions attribute.
+I<req> is unchanged if I<exts> is NULL or an empty list.
+This function may be called more than once on the same I<req> and I<nid>.
+In such case any previous extensions are augmented, where an extension to be
+added that has the same OID as a pre-existing one replaces this earlier one.
 
-X509_REQ_add_extensions_nid() is like X509_REQ_add_extensions()
-except that I<nid> is used to identify the extensions attribute.
-This function must not be called more than once with the same I<req> and I<nid>.
+X509_REQ_add_extensions() is like X509_REQ_add_extensions_nid()
+except that the default B<NID_ext_req> is used.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/X509v3_get_ext_by_NID.pod
+++ b/doc/man3/X509v3_get_ext_by_NID.pod
@@ -4,7 +4,7 @@
 
 X509v3_get_ext_count, X509v3_get_ext, X509v3_get_ext_by_NID,
 X509v3_get_ext_by_OBJ, X509v3_get_ext_by_critical, X509v3_delete_ext,
-X509v3_add_ext, X509_get_ext_count, X509_get_ext,
+X509v3_add_ext, X509v3_add_extensions, X509_get_ext_count, X509_get_ext,
 X509_get_ext_by_NID, X509_get_ext_by_OBJ, X509_get_ext_by_critical,
 X509_delete_ext, X509_add_ext, X509_CRL_get_ext_count, X509_CRL_get_ext,
 X509_CRL_get_ext_by_NID, X509_CRL_get_ext_by_OBJ, X509_CRL_get_ext_by_critical,
@@ -29,6 +29,9 @@ X509_REVOKED_add_ext - extension stack utility functions
  X509_EXTENSION *X509v3_delete_ext(STACK_OF(X509_EXTENSION) *x, int loc);
  STACK_OF(X509_EXTENSION) *X509v3_add_ext(STACK_OF(X509_EXTENSION) **x,
                                           X509_EXTENSION *ex, int loc);
+ STACK_OF(X509_EXTENSION)
+      *X509v3_add_extensions(STACK_OF(X509_EXTENSION) **target,
+                             const STACK_OF(X509_EXTENSION) *exts);
 
  int X509_get_ext_count(const X509 *x);
  X509_EXTENSION *X509_get_ext(const X509 *x, int loc);
@@ -79,10 +82,16 @@ X509v3_delete_ext() deletes the extension with index I<loc> from I<x>.
 The deleted extension is returned and must be freed by the caller.
 If I<loc> is an invalid index value, NULL is returned.
 
-X509v3_add_ext() adds extension I<ex> to STACK I<*x> at position I<loc>. If
-I<loc> is -1, the new extension is added to the end. If I<*x> is NULL,
-a new STACK will be allocated. The passed extension I<ex> is duplicated
-internally so it must be freed after use.
+X509v3_add_ext() inserts extension I<ex> to STACK I<*x> at position I<loc>.
+If I<loc> is -1, the new extension is added to the end.
+A new STACK is allocated if I<*x> is NULL.
+The passed extension I<ex> is duplicated so it must be freed after use.
+
+X509v3_add_extensions() adds the list of extensions I<exts> to STACK I<*target>.
+The STACK I<*target> is returned unchanged if I<exts> is NULL or an empty list.
+Otherwise a new stack is allocated if I<*target> is NULL.
+An extension to be added
+that has the same OID as a pre-existing one replaces this earlier one.
 
 X509_get_ext_count(), X509_get_ext(), X509_get_ext_by_NID(),
 X509_get_ext_by_OBJ(), X509_get_ext_by_critical(), X509_delete_ext()
@@ -132,13 +141,18 @@ the extension index or -1 if an error occurs.
 X509v3_get_ext_by_NID() returns the extension index or negative values if an
 error occurs.
 
-X509v3_add_ext() returns a STACK of extensions or NULL on error.
+X509v3_add_ext() and X509v3_add_extensions()
+return a STACK of extensions or NULL on error.
 
 X509_add_ext() returns 1 on success and 0 on error.
 
 =head1 SEE ALSO
 
 L<X509V3_get_d2i(3)>
+
+=head1 HISTORY
+
+X509v3_add_extensions() was added in OpenSSL 3.4.
 
 =head1 COPYRIGHT
 

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -373,7 +373,7 @@ int x509v3_add_len_value_uchar(const char *name, const unsigned char *value,
                                size_t vallen, STACK_OF(CONF_VALUE) **extlist);
 /* Attribute addition functions not checking for duplicate attributes */
 STACK_OF(X509_ATTRIBUTE) *ossl_x509at_add1_attr(STACK_OF(X509_ATTRIBUTE) **x,
-                                                X509_ATTRIBUTE *attr);
+                                                const X509_ATTRIBUTE *attr);
 STACK_OF(X509_ATTRIBUTE) *ossl_x509at_add1_attr_by_OBJ(STACK_OF(X509_ATTRIBUTE) **x,
                                                        const ASN1_OBJECT *obj,
                                                        int type,

--- a/include/openssl/types.h
+++ b/include/openssl/types.h
@@ -34,9 +34,9 @@ extern "C" {
 # include <openssl/macros.h>
 
 # if OPENSSL_VERSION_MAJOR >= 4
-#  define OSSL_CONST_FUTURE const
+#  define OSSL_FUTURE_CONST const
 # else
-#  define OSSL_CONST_FUTURE
+#  define OSSL_FUTURE_CONST
 # endif
 
 typedef struct ossl_provider_st OSSL_PROVIDER; /* Provider Object */

--- a/include/openssl/types.h
+++ b/include/openssl/types.h
@@ -33,6 +33,12 @@ extern "C" {
 # include <openssl/safestack.h>
 # include <openssl/macros.h>
 
+# if OPENSSL_VERSION_MAJOR >= 4
+#  define OSSL_CONST_FUTURE const
+# else
+#  define OSSL_CONST_FUTURE
+# endif
+
 typedef struct ossl_provider_st OSSL_PROVIDER; /* Provider Object */
 
 # ifdef NO_ASN1_TYPEDEFS

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -710,7 +710,7 @@ X509_PUBKEY *X509_REQ_get_X509_PUBKEY(X509_REQ *req);
 int X509_REQ_extension_nid(int nid);
 int *X509_REQ_get_extension_nids(void);
 void X509_REQ_set_extension_nids(int *nids);
-STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(X509_REQ *req);
+STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(const X509_REQ *req);
 int X509_REQ_add_extensions_nid(X509_REQ *req,
                                 const STACK_OF(X509_EXTENSION) *exts, int nid);
 int X509_REQ_add_extensions(X509_REQ *req, const STACK_OF(X509_EXTENSION) *ext);

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -899,6 +899,9 @@ X509_EXTENSION *X509v3_get_ext(const STACK_OF(X509_EXTENSION) *x, int loc);
 X509_EXTENSION *X509v3_delete_ext(STACK_OF(X509_EXTENSION) *x, int loc);
 STACK_OF(X509_EXTENSION) *X509v3_add_ext(STACK_OF(X509_EXTENSION) **x,
                                          X509_EXTENSION *ex, int loc);
+STACK_OF(X509_EXTENSION)
+    *X509v3_add_extensions(STACK_OF(X509_EXTENSION) **target,
+                           const STACK_OF(X509_EXTENSION) *exts);
 
 int X509_get_ext_count(const X509 *x);
 int X509_get_ext_by_NID(const X509 *x, int nid, int lastpos);

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -710,7 +710,7 @@ X509_PUBKEY *X509_REQ_get_X509_PUBKEY(X509_REQ *req);
 int X509_REQ_extension_nid(int nid);
 int *X509_REQ_get_extension_nids(void);
 void X509_REQ_set_extension_nids(int *nids);
-STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(const X509_REQ *req);
+STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(OSSL_CONST_FUTURE X509_REQ *req);
 int X509_REQ_add_extensions_nid(X509_REQ *req,
                                 const STACK_OF(X509_EXTENSION) *exts, int nid);
 int X509_REQ_add_extensions(X509_REQ *req, const STACK_OF(X509_EXTENSION) *ext);

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -710,7 +710,7 @@ X509_PUBKEY *X509_REQ_get_X509_PUBKEY(X509_REQ *req);
 int X509_REQ_extension_nid(int nid);
 int *X509_REQ_get_extension_nids(void);
 void X509_REQ_set_extension_nids(int *nids);
-STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(OSSL_CONST_FUTURE X509_REQ *req);
+STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(OSSL_FUTURE_CONST X509_REQ *req);
 int X509_REQ_add_extensions_nid(X509_REQ *req,
                                 const STACK_OF(X509_EXTENSION) *exts, int nid);
 int X509_REQ_add_extensions(X509_REQ *req, const STACK_OF(X509_EXTENSION) *ext);

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -15,7 +15,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_req");
 
-plan tests => 109;
+plan tests => 110;
 
 require_ok(srctop_file('test', 'recipes', 'tconversion.pl'));
 
@@ -36,7 +36,7 @@ if (disabled("rsa")) {
 $ENV{MSYS2_ARG_CONV_EXCL} = "/CN=";
 
 # Check for duplicate -addext parameters, and one "working" case.
-my @addext_args = ( "openssl", "req", "-new", "-out", "testreq.pem",
+my @addext_args = ( "openssl", "req", "-new", "-out", "testreq-addexts.pem",
                     "-key",  srctop_file(@certs, "ee-key.pem"),
     "-config", srctop_file("test", "test.cnf"), @req_new );
 my $val = "subjectAltName=DNS:example.com";
@@ -54,6 +54,9 @@ ok(!run(app([@addext_args, "-addext", $val, "-addext", $val3])));
 ok(!run(app([@addext_args, "-addext", $val2, "-addext", $val3])));
 ok(run(app([@addext_args, "-addext", "SXNetID=1:one, 2:two, 3:three"])));
 ok(run(app([@addext_args, "-addext", "subjectAltName=dirName:dirname_sec"])));
+
+ok(run(app([@addext_args, "-addext", "keyUsage=digitalSignature",
+           "-reqexts", "reqexts"]))); # referring to section in test.cnf
 
 # If a CSR is provided with neither of -key or -CA/-CAkey, this should fail.
 ok(!run(app(["openssl", "req", "-x509",

--- a/test/test.cnf
+++ b/test/test.cnf
@@ -78,3 +78,6 @@ C  = UK
 O  = My Organization
 OU = My Unit
 CN = My Name
+
+[ reqexts ]
+keyUsage = critical,digitalSignature,keyEncipherment

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5629,6 +5629,7 @@ X509_ACERT_verify                       ?	3_4_0	EXIST::FUNCTION:
 X509_ACERT_get_ext_d2i                  ?	3_4_0	EXIST::FUNCTION:
 X509_ACERT_add1_ext_i2d                 ?	3_4_0	EXIST::FUNCTION:
 X509_ACERT_get0_extensions              ?	3_4_0	EXIST::FUNCTION:
+X509v3_add_extensions                   ?	3_4_0	EXIST::FUNCTION:
 OSSL_IETF_ATTR_SYNTAX_VALUE_it          ?	3_4_0	EXIST::FUNCTION:
 OSSL_IETF_ATTR_SYNTAX_VALUE_free        ?	3_4_0	EXIST::FUNCTION:
 OSSL_IETF_ATTR_SYNTAX_VALUE_new         ?	3_4_0	EXIST::FUNCTION:


### PR DESCRIPTION
This fixes what recently has been reported as a follow-up problem in #11169,
namely that the `req` app option `-addext` cannot be combined at all with other of X.509v3 REQ (PKCS#10) extensions defined in a section of a config file.

Note that part of the original issue reported in #11169 had been fixed earlier,
and this FR fixes the remaining problem.
Still I see this PR more as a feature extension rather than a bug fix,
but we could also backport (most of) it to earlier branches.

Doing this, 
* made `X509_REQ_add_extensions*()` more flexible in this regard,
* added `X509v3_add_extensions()` (used also for CMP) as a public API function,
* constified `X509_REQ_get_extensions()` and `ossl_x509at_add1_attr()`,
* extended error entry on duplicate attribute by `X509at_add1_attr*()`, 
* added a test case demonstrating the fix, and
* improved and extended related documentation.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
