### PR TITLE
Unchecked function result in ossl_quic_rxfc_on_retire()

### DIFF
--- a/ssl/quic/quic_stream_map.c
+++ b/ssl/quic/quic_stream_map.c
@@ -764,7 +764,7 @@ void ossl_quic_stream_map_remove_from_accept_queue(QUIC_STREAM_MAP *qsm,
         --qsm->num_accept_uni;
 
     if ((max_streams_rxfc = qsm_get_max_streams_rxfc(qsm, s)) != NULL)
-        ossl_quic_rxfc_on_retire(max_streams_rxfc, 1, rtt);
+        (void)ossl_quic_rxfc_on_retire(max_streams_rxfc, 1, rtt);
 }
 
 size_t ossl_quic_stream_map_get_accept_queue_len(QUIC_STREAM_MAP *qsm, int is_uni)


### PR DESCRIPTION
Return value of function 'ossl_quic_rxfc_on_retire', called at quic_stream_map.c:767, is not checked, but it is usually checked for this function.
Found by Linux Verification Center (linuxtesting.org) with SVACE.

CLA: trivial