### PR TITLE
  Disable DSA signing in the FIPS provider

### DIFF
--- a/doc/man1/openssl-fipsinstall.pod.in
+++ b/doc/man1/openssl-fipsinstall.pod.in
@@ -30,6 +30,7 @@ B<openssl fipsinstall>
 [B<-sshkdf_digest_check>]
 [B<-sskdf_digest_check>]
 [B<-x963kdf_digest_check>]
+[B<-dsa_sign_disabled>]
 [B<-self_test_onload>]
 [B<-self_test_oninstall>]
 [B<-corrupt_desc> I<selftest_description>]
@@ -231,6 +232,11 @@ See NIST SP 800-56Cr2 for details.
 Configure the module to enable a run-time digest check when deriving a key by
 X963KDF.
 See NIST SP 800-131Ar2 for details.
+
+=item B<-dsa_sign_disabled>
+
+Configure the module to not allow DSA signing (DSA signature verification is
+still allowed). See FIPS 140-3 IG C.K for details.
 
 =item B<-self_test_onload>
 

--- a/doc/man7/EVP_SIGNATURE-DSA.pod
+++ b/doc/man7/EVP_SIGNATURE-DSA.pod
@@ -29,6 +29,8 @@ using EVP_PKEY_sign_init_ex() or EVP_PKEY_verify_init_ex().
 
 =item "digest-check" (B<OSSL_SIGNATURE_PARAM_FIPS_DIGEST_CHECK>) <integer>
 
+=item "sign-check"  (B<OSSL_SIGNATURE_PARAM_FIPS_SIGN_CHECK>) <int>
+
 The settable parameters are described in L<provider-signature(7)>.
 
 =back

--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -392,7 +392,7 @@ supply known values that either pass or fail.
 
 A getter that returns 1 if the operation is FIPS approved, or 0 otherwise.
 This may be used after calling either the sign or verify final functions. It may
-return 0 if either the "digest-check" or the "key-check" are set to 0.
+return 0 if either the "digest-check", "key-check", or "sign-check" are set to 0.
 This option is used by the OpenSSL FIPS provider.
 
 =item "key-check" (B<OSSL_SIGNATURE_PARAM_FIPS_KEY_CHECK>) <integer>
@@ -411,6 +411,15 @@ If required this parameter should be set before the signature digest is set.
 The default value of 1 causes an error when the digest is set if the digest is
 not FIPS approved (e.g. SHA1 is used for signing). Setting this to 0 will ignore
 the error and set the approved "fips-indicator" to 0.
+This option is used by the OpenSSL FIPS provider, and breaks FIPS compliance if
+set to 0.
+
+=item "sign-check" (B<OSSL_SIGNATURE_PARAM_FIPS_SIGN_CHECK>) <int>
+
+If required this parameter should be set early via an init function.
+The default value of 1 causes an error when a signing algorithm is used. (This
+is triggered by deprecated signing algorithms).
+Setting this to 0 will ignore the error and set the approved "fips-indicator" to 0.
 This option is used by the OpenSSL FIPS provider, and breaks FIPS compliance if
 set to 0.
 

--- a/include/openssl/fips_names.h
+++ b/include/openssl/fips_names.h
@@ -118,6 +118,13 @@ extern "C" {
  */
 # define OSSL_PROV_FIPS_PARAM_X963KDF_DIGEST_CHECK "x963kdf-digest-check"
 
+/*
+ * A boolean that determines if DSA signing operations are allowed.
+ * This is disabled by default.
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+# define OSSL_PROV_FIPS_PARAM_DSA_SIGN_DISABLED "dsa-sign-disabled"
+
 # ifdef __cplusplus
 }
 # endif

--- a/providers/common/include/prov/fipscommon.h
+++ b/providers/common/include/prov/fipscommon.h
@@ -19,5 +19,6 @@ int FIPS_tls1_prf_digest_check(OSSL_LIB_CTX *libctx);
 int FIPS_sshkdf_digest_check(OSSL_LIB_CTX *libctx);
 int FIPS_sskdf_digest_check(OSSL_LIB_CTX *libctx);
 int FIPS_x963kdf_digest_check(OSSL_LIB_CTX *libctx);
+int FIPS_dsa_sign_check(OSSL_LIB_CTX *libctx);
 
 #endif

--- a/providers/common/include/prov/securitycheck.h
+++ b/providers/common/include/prov/securitycheck.h
@@ -10,6 +10,10 @@
 #include "crypto/types.h"
 #include <openssl/ec.h>
 
+#ifdef FIPS_MODULE
+# include "fipscommon.h"
+#endif
+
 /* Functions that are common */
 int ossl_rsa_key_op_get_protect(const RSA *rsa, int operation, int *outprotect);
 int ossl_rsa_check_key_size(const RSA *rsa, int protect);

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -97,6 +97,7 @@ typedef struct fips_global_st {
     FIPS_OPTION fips_sshkdf_digest_check;
     FIPS_OPTION fips_sskdf_digest_check;
     FIPS_OPTION fips_x963kdf_digest_check;
+    FIPS_OPTION fips_dsa_sign_disallowed;
 } FIPS_GLOBAL;
 
 static void init_fips_option(FIPS_OPTION *opt, int enabled)
@@ -120,6 +121,7 @@ void *ossl_fips_prov_ossl_ctx_new(OSSL_LIB_CTX *libctx)
     init_fips_option(&fgbl->fips_sshkdf_digest_check, 0);
     init_fips_option(&fgbl->fips_sskdf_digest_check, 0);
     init_fips_option(&fgbl->fips_x963kdf_digest_check, 0);
+    init_fips_option(&fgbl->fips_dsa_sign_disallowed, 0);
     return fgbl;
 }
 
@@ -149,6 +151,8 @@ static const OSSL_PARAM fips_param_types[] = {
                     NULL, 0),
     OSSL_PARAM_DEFN(OSSL_PROV_PARAM_X963KDF_DIGEST_CHECK, OSSL_PARAM_INTEGER,
                     NULL, 0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_DSA_SIGN_DISABLED,
+                    OSSL_PARAM_INTEGER, NULL, 0),
     OSSL_PARAM_END
 };
 
@@ -162,7 +166,7 @@ static int fips_get_params_from_core(FIPS_GLOBAL *fgbl)
     * OSSL_PROV_FIPS_PARAM_SECURITY_CHECKS and
     * OSSL_PROV_FIPS_PARAM_TLS1_PRF_EMS_CHECK are not self test parameters.
     */
-    OSSL_PARAM core_params[16], *p = core_params;
+    OSSL_PARAM core_params[17], *p = core_params;
 
     *p++ = OSSL_PARAM_construct_utf8_ptr(
             OSSL_PROV_PARAM_CORE_MODULE_FILENAME,
@@ -213,6 +217,8 @@ static int fips_get_params_from_core(FIPS_GLOBAL *fgbl)
                         fips_sskdf_digest_check);
     FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_X963KDF_DIGEST_CHECK,
                         fips_x963kdf_digest_check);
+    FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_DSA_SIGN_DISABLED,
+                        fips_dsa_sign_disallowed);
 #undef FIPS_FEATURE_OPTION
 
     *p = OSSL_PARAM_construct_end();
@@ -272,6 +278,8 @@ static int fips_get_params(void *provctx, OSSL_PARAM params[])
                      fips_sskdf_digest_check);
     FIPS_FEATURE_GET(fgbl, OSSL_PROV_PARAM_X963KDF_DIGEST_CHECK,
                      fips_x963kdf_digest_check);
+    FIPS_FEATURE_GET(fgbl, OSSL_PROV_PARAM_DSA_SIGN_DISABLED,
+                     fips_dsa_sign_disallowed);
 #undef FIPS_FEATURE_GET
     return 1;
 }
@@ -812,6 +820,7 @@ int OSSL_provider_init_int(const OSSL_CORE_HANDLE *handle,
     FIPS_SET_OPTION(fgbl, fips_sshkdf_digest_check);
     FIPS_SET_OPTION(fgbl, fips_sskdf_digest_check);
     FIPS_SET_OPTION(fgbl, fips_x963kdf_digest_check);
+    FIPS_SET_OPTION(fgbl, fips_dsa_sign_disallowed);
 #undef FIPS_SET_OPTION
 
     ossl_prov_cache_exported_algorithms(fips_ciphers, exported_fips_ciphers);
@@ -1019,6 +1028,7 @@ FIPS_FEATURE_CHECK(FIPS_tls1_prf_digest_check, fips_tls1_prf_digest_check)
 FIPS_FEATURE_CHECK(FIPS_sshkdf_digest_check, fips_sshkdf_digest_check)
 FIPS_FEATURE_CHECK(FIPS_sskdf_digest_check, fips_sskdf_digest_check)
 FIPS_FEATURE_CHECK(FIPS_x963kdf_digest_check, fips_x963kdf_digest_check)
+FIPS_FEATURE_CHECK(FIPS_dsa_sign_check, fips_dsa_sign_disallowed)
 
 #undef FIPS_FEATURE_CHECK
 

--- a/providers/fips/self_test_data.inc
+++ b/providers/fips/self_test_data.inc
@@ -44,6 +44,9 @@ typedef struct st_kat_st {
 #define CIPHER_MODE_DECRYPT 2
 #define CIPHER_MODE_ALL     (CIPHER_MODE_ENCRYPT | CIPHER_MODE_DECRYPT)
 
+/* FIPS 140-3 only allows DSA verification for legacy purposes */
+#define ST_PARAM_VERIFY_ONLY "verify_only"
+
 typedef ST_KAT ST_KAT_DIGEST;
 typedef struct st_kat_cipher_st {
     ST_KAT base;
@@ -1632,12 +1635,14 @@ static const unsigned char dsa_expected_sig[] = {
     0x34, 0x8d, 0x9e, 0x88, 0x08, 0x06
 };
 
+static int verify_only = 1;
 static const ST_KAT_PARAM dsa_key[] = {
     ST_KAT_PARAM_BIGNUM(OSSL_PKEY_PARAM_FFC_P, dsa_p),
     ST_KAT_PARAM_BIGNUM(OSSL_PKEY_PARAM_FFC_Q, dsa_q),
     ST_KAT_PARAM_BIGNUM(OSSL_PKEY_PARAM_FFC_G, dsa_g),
     ST_KAT_PARAM_BIGNUM(OSSL_PKEY_PARAM_PUB_KEY, dsa_pub),
     ST_KAT_PARAM_BIGNUM(OSSL_PKEY_PARAM_PRIV_KEY, dsa_priv),
+    ST_KAT_PARAM_INT(ST_PARAM_VERIFY_ONLY, verify_only),
     ST_KAT_PARAM_END()
 };
 #endif /* OPENSSL_NO_DSA */

--- a/providers/fips/self_test_kats.c
+++ b/providers/fips/self_test_kats.c
@@ -488,8 +488,7 @@ static int self_test_sign(const ST_KAT_SIGN *t,
 
     /* Create a EVP_PKEY_CTX to use for the signing operation */
     sctx = EVP_PKEY_CTX_new_from_pkey(libctx, pkey, NULL);
-    if (sctx == NULL
-        || EVP_PKEY_sign_init(sctx) <= 0)
+    if (sctx == NULL)
         goto err;
 
     /* set signature parameters */
@@ -498,11 +497,20 @@ static int self_test_sign(const ST_KAT_SIGN *t,
                                          strlen(t->mdalgorithm) + 1))
         goto err;
     params_sig = OSSL_PARAM_BLD_to_param(bld);
-    if (EVP_PKEY_CTX_set_params(sctx, params_sig) <= 0)
-        goto err;
 
-    if (EVP_PKEY_sign(sctx, sig, &siglen, dgst, sizeof(dgst)) <= 0
-        || EVP_PKEY_verify_init(sctx) <= 0
+    /* Skip the sign for legacy algorithms that only support the verify operation */
+    if (OSSL_PARAM_locate(params, ST_PARAM_VERIFY_ONLY) == NULL) {
+        if (EVP_PKEY_sign_init(sctx) <= 0)
+            goto err;
+        if (EVP_PKEY_CTX_set_params(sctx, params_sig) <= 0)
+            goto err;
+        if (EVP_PKEY_sign(sctx, sig, &siglen, dgst, sizeof(dgst)) <= 0)
+            goto err;
+    } else {
+        memcpy(sig, t->sig_expected, t->sig_expected_len);
+        siglen = t->sig_expected_len;
+    }
+    if (EVP_PKEY_verify_init(sctx) <= 0
         || EVP_PKEY_CTX_set_params(sctx, params_sig) <= 0)
         goto err;
 

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -189,6 +189,7 @@ static const OSSL_PARAM settable_ctx_params[] = {
     OSSL_PARAM_int("key-check", NULL),
     OSSL_PARAM_int("digest-check", NULL),
     OSSL_PARAM_int("ems_check", NULL),
+    OSSL_PARAM_int("sign-check", NULL),
     OSSL_PARAM_END
 };
 
@@ -4072,7 +4073,7 @@ static int check_deterministic_noncetype(EVP_TEST *t,
 static int signverify_init(EVP_TEST *t, DIGESTSIGN_DATA *data)
 {
     const char *name = data->md == NULL ? NULL : EVP_MD_get0_name(data->md);
-    OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
+    OSSL_PARAM params[5];
     OSSL_PARAM *p = NULL;
     int i, ret = 0;
     size_t params_n = 0, params_allocated_n = 0;

--- a/test/recipes/20-test_cli_fips.t
+++ b/test/recipes/20-test_cli_fips.t
@@ -36,6 +36,9 @@ my $bogus_data = $fipsconf;
 
 $ENV{OPENSSL_CONF} = $fipsconf;
 
+run(test(["fips_version_test", "-config", $fipsconf, "<3.4.0"]),
+          capture => 1, statusvar => \my $dsasignpass);
+
 ok(run(app(['openssl', 'list', '-public-key-methods', '-verbose'])),
    "provider listing of public key methods");
 ok(run(app(['openssl', 'list', '-public-key-algorithms', '-verbose'])),
@@ -279,7 +282,7 @@ SKIP: {
 
 SKIP : {
     skip "FIPS DSA tests because of no dsa in this build", 1
-        if disabled("dsa");
+        if disabled("dsa") || $dsasignpass == '0';
 
     subtest DSA => sub {
         my $testtext_prefix = 'DSA';

--- a/test/recipes/30-test_evp_data/evppkey_dsa.txt
+++ b/test/recipes/30-test_evp_data/evppkey_dsa.txt
@@ -277,6 +277,7 @@ Output = 00
 Result = DIGESTSIGNINIT_ERROR
 
 # Test sign with a 2048 bit key with N == 224 is allowed in fips mode
+FIPSversion = <3.4.0
 DigestSign = SHA256
 Key = DSA-2048-224
 Input = "Hello"
@@ -284,18 +285,21 @@ Output = 00
 Result = SIGNATURE_MISMATCH
 
 # Test sign with a 2048 bit key with N == 256 is allowed in fips mode
+FIPSversion = <3.4.0
 DigestSign = SHA256
 Key = DSA-2048-256
 Input = "Hello"
 Result = SIGNATURE_MISMATCH
 
 # Test sign with a 3072 bit key with N == 256 is allowed in fips mode
+FIPSversion = <3.4.0
 DigestSign = SHA256
 Key = DSA-3072-256
 Input = "Hello"
 Result = SIGNATURE_MISMATCH
 
 # Test sign with a 2048 bit SHA3 is allowed in fips mode
+FIPSversion = <3.4.0
 DigestSign = SHA3-224
 Key = DSA-2048-256
 Input = "Hello"
@@ -354,45 +358,82 @@ Key = DSA-4096-256
 Input = "Hello"
 Result = DIGESTSIGNINIT_ERROR
 
+# Test sign is not allowed in fips mode
+FIPSversion = >=3.4.0
+DigestSign = SHA256
+Securitycheck = 1
+Key = DSA-2048-256
+Input = "Hello"
+Result = DIGESTSIGNINIT_ERROR
+
 Title = Fips Indicator Tests
 # Check that the indicator callback is triggered
 
-# Test sign with a 1024 bit key in fips mode
+# Test sign with a 1024 bit key is unapproved in fips mode if the sign and key
+# checks are ignored.
 FIPSversion = >=3.4.0
 DigestSign = SHA256
 Securitycheck = 1
 Unapproved = 1
+CtrlInit = sign-check:0
 CtrlInit = key-check:0
 Key = DSA-1024-FIPS186-2
 Input = "Hello"
 Result = SIGNATURE_MISMATCH
 
-# Test sign with a 3072 bit key with N == 224 is not allowed in fips mode
+# Test sign with a 1024 bit key is unapproved and fails the key check in
+# fips mode if the sign check is ignored
 FIPSversion = >=3.4.0
 DigestSign = SHA256
 Securitycheck = 1
 Unapproved = 1
+CtrlInit = sign-check:0
+Key = DSA-1024-FIPS186-2
+Input = "Hello"
+Result = DIGESTSIGNINIT_ERROR
+
+# Test sign with a 3072 bit key with N == 224 is unapproved in fips mode if the
+# sign and key checks are ignored
+FIPSversion = >=3.4.0
+DigestSign = SHA256
+Securitycheck = 1
+Unapproved = 1
+CtrlInit = sign-check:0
 CtrlInit = key-check:0
 Key = DSA-3072-224
 Input = "Hello"
 Result = SIGNATURE_MISMATCH
 
-# Test sign with a 4096 bit key is not allowed in fips mode
+# Test sign with a 4096 bit key is unapproved in fips mode if the sign and key
+# checks are ignored
 FIPSversion = >=3.4.0
 DigestSign = SHA256
 Securitycheck = 1
 Unapproved = 1
+CtrlInit = sign-check:0
 CtrlInit = key-check:0
 Key = DSA-4096-256
 Input = "Hello"
 Result = SIGNATURE_MISMATCH
 
-# Test sign with SHA1 is not allowed in fips mode
+# Test DSA sign with SHA1 is unapproved in fips mode if the sign and digest checks
+# are ignored
 FIPSversion = >=3.4.0
 DigestSign = SHA1
 Securitycheck = 1
 Unapproved = 1
+CtrlInit = sign-check:0
 CtrlInit = digest-check:0
 Key = DSA-2048-256
 Input = "Hello"
 Result = SIGNATURE_MISMATCH
+
+# Test sign with SHA1 is unapproved in fips mode if DSA sign check is ignored
+FIPSversion = >=3.4.0
+DigestSign = SHA1
+Securitycheck = 1
+Unapproved = 1
+CtrlInit = sign-check:0
+Key = DSA-2048-256
+Input = "Hello"
+Result = DIGESTSIGNINIT_ERROR

--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -40,6 +40,7 @@ my @defaultprov = ("-provider-path", $provpath,
 
 my @config = ( );
 my $provname = 'default';
+my $dsaallow = '1';
 
 my $datadir = srctop_dir("test", "recipes", "80-test_cms_data");
 my $smdir    = srctop_dir("test", "smime-certs");
@@ -55,8 +56,13 @@ plan tests => 25;
 ok(run(test(["pkcs7_test"])), "test pkcs7");
 
 unless ($no_fips) {
-    @config = ( "-config", srctop_file("test", "fips-and-base.cnf") );
+    my $provconf = srctop_file("test", "fips-and-base.cnf");
+    @config = ( "-config", $provconf );
     $provname = 'fips';
+
+    run(test(["fips_version_test", "-config", $provconf, "<3.4.0"]),
+    capture => 1, statusvar => \$dsaallow);
+    $no_dsa = 1 if $dsaallow == '0';
 }
 
 $ENV{OPENSSL_TEST_LIBCTX} = "1";

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -28,6 +28,7 @@ use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
+my $dsaallow = '1';
 
 $ENV{TEST_CERTS_DIR} = srctop_dir("test", "certs");
 
@@ -47,6 +48,12 @@ if (defined $ENV{SSL_TESTS}) {
 map { s/;.*// } @conf_srcs if $^O eq "VMS";
 my @conf_files = map { basename($_, ".in") } @conf_srcs;
 map { s/\^// } @conf_files if $^O eq "VMS";
+
+unless ($no_fips) {
+    my $provconf = srctop_file("test", "fips-and-base.cnf");
+    run(test(["fips_version_test", "-config", $provconf, "<3.4.0"]),
+              capture => 1, statusvar => \$dsaallow);
+}
 
 # Some test results depend on the configuration of enabled protocols. We only
 # verify generated sources in the default configuration.
@@ -177,6 +184,7 @@ sub test_conf {
       # Test 3. Run the test.
       skip "No tests available; skipping tests", 1 if $skip;
       skip "Stale sources; skipping tests", 1 if !$run_test;
+      skip "Dsa not allowed in FIPS 140-3 provider", 1 if ($provider eq "fips") && ($dsaallow eq '0');
 
       my $msg = "running CTLOG_FILE=test/ct/log_list.cnf". # $ENV{CTLOG_FILE}.
           " TEST_CERTS_DIR=test/certs". # $ENV{TEST_CERTS_DIR}.

--- a/util/mk-fipsmodule-cnf.pl
+++ b/util/mk-fipsmodule-cnf.pl
@@ -15,8 +15,10 @@ my $security_checks = 1;
 my $ems_check = 1;
 my $drgb_no_trunc_dgst = 1;
 my $kdf_digest_check = 1;
+my $dsa_sign_disabled = 1;
 
 my $activate = 1;
+my $version = 1;
 my $mac_key;
 my $module_name;
 my $section_name = "fips_sect";
@@ -44,10 +46,12 @@ my $module_mac = join(':', @module_mac);
 print <<_____;
 [$section_name]
 activate = $activate
+install-version = $version
 conditional-errors = $conditional_errors
 security-checks = $security_checks
 tls1-prf-ems-check = $ems_check
 drbg-no-trunc-md = $drgb_no_trunc_dgst
+dsa-sign-disabled = $dsa_sign_disabled
 module-mac = $module_mac
 hkdf-digest-check = $kdf_digest_check
 tls13-kdf-digest-check = $kdf_digest_check

--- a/util/perl/OpenSSL/paramnames.pm
+++ b/util/perl/OpenSSL/paramnames.pm
@@ -39,6 +39,7 @@ my %params = (
     'PROV_PARAM_SSHKDF_DIGEST_CHECK' =>    "sshkdf-digest-check",    # uint
     'PROV_PARAM_SSKDF_DIGEST_CHECK' =>     "sskdf-digest-check",     # uint
     'PROV_PARAM_X963KDF_DIGEST_CHECK' =>   "x963kdf-digest-check",   # uint
+    'PROV_PARAM_DSA_SIGN_DISABLED' =>      "dsa-sign-disabled",      # uint
 
 # Self test callback parameters
     'PROV_PARAM_SELF_TEST_PHASE' =>  "st-phase",# utf8_string
@@ -407,6 +408,7 @@ my %params = (
     'SIGNATURE_PARAM_CONTEXT_STRING' =>     "context-string",
     'SIGNATURE_PARAM_FIPS_DIGEST_CHECK' =>  '*PKEY_PARAM_FIPS_DIGEST_CHECK',
     'SIGNATURE_PARAM_FIPS_KEY_CHECK' =>     '*PKEY_PARAM_FIPS_KEY_CHECK',
+    'SIGNATURE_PARAM_FIPS_SIGN_CHECK' =>    "sign-check",
     'SIGNATURE_PARAM_FIPS_APPROVED_INDICATOR' => '*ALG_PARAM_FIPS_APPROVED_INDICATOR',
 
 # Asym cipher parameters


### PR DESCRIPTION
 This is a FIPS 140-3 requirement.
 This uses a FIPS indicator if either the FIPS configurable "dsa_sign_check" is set to 0,
 OR OSSL_SIGNATURE_PARAM_FIPS_SIGN_CHECK is set to 0 in the dsa signing context.


<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
