### PR TITLE
apps/rehash.c: Add the check for the EVP_MD_get_size()

### DIFF
--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -553,7 +553,7 @@ int rehash_main(int argc, char **argv)
     evpmd = EVP_sha1();
     evpmdsize = EVP_MD_get_size(evpmd);
 
-    if (evpmdsize <= 0)
+    if (evpmdsize <= 0 || evpmdsize > EVP_MAX_MD_SIZE)
         goto end;
 
     if (*argv != NULL) {

--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -140,7 +140,7 @@ static int add_entry(enum Type type, unsigned int hash, const char *filename,
     }
 
     for (ep = bp->first_entry; ep; ep = ep->next) {
-        if (digest && memcmp(digest, ep->digest, evpmdsize) == 0) {
+        if (digest && memcmp(digest, ep->digest, (size_t)evpmdsize) == 0) {
             BIO_printf(bio_err,
                        "%s: warning: skipping duplicate %s in %s\n",
                        opt_getprog(),
@@ -183,7 +183,7 @@ static int add_entry(enum Type type, unsigned int hash, const char *filename,
     if (need_symlink && !ep->need_symlink) {
         ep->need_symlink = 1;
         bp->num_needed++;
-        memcpy(ep->digest, digest, evpmdsize);
+        memcpy(ep->digest, digest, (size_t)evpmdsize);
     }
     return 0;
 }
@@ -552,6 +552,9 @@ int rehash_main(int argc, char **argv)
 
     evpmd = EVP_sha1();
     evpmdsize = EVP_MD_get_size(evpmd);
+
+    if (evpmdsize <= 0)
+        goto end;
 
     if (*argv != NULL) {
         while (*argv != NULL)


### PR DESCRIPTION
Add the check for the return value of EVP_MD_get_size() to avoid invalid negative numbers and then explicitly cast from int to size_t.

Fixes: 8f6f1441a3 ("Add rehash command to openssl")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
