### PR TITLE
Optimization of ossl_ec_key_public_check()

### DIFF
--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -563,9 +563,15 @@ int ossl_ec_key_public_check(const EC_KEY *eckey, BN_CTX *ctx)
     int ret = 0;
     EC_POINT *point = NULL;
     const BIGNUM *order = NULL;
+    const BIGNUM *cofactor = EC_GROUP_get0_cofactor(eckey->group);
 
     if (!ossl_ec_key_public_check_quick(eckey, ctx))
         return 0;
+
+    if (cofactor != NULL && BN_is_one(cofactor)) {
+        /* Skip the unnecessary expensive computation for curves with cofactor of 1. */
+        return 1;
+    }
 
     point = EC_POINT_new(eckey->group);
     if (point == NULL)


### PR DESCRIPTION
We can do just the quick check if `cofactor == 1` as the fact that the point is on the curve already implies that `order * point = infinity`.

Fixes #21833
