### PR TITLE
Fix ordering on windows_comp.yml ci

### DIFF
--- a/.github/workflows/windows_comp.yml
+++ b/.github/workflows/windows_comp.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     paths:
       - 'crypto/comp/*.c'
+      - '.github/workflows/windows_comp.yml'
   push:
     paths:
       - '**.c'
@@ -33,9 +34,18 @@ jobs:
       working-directory: _build
       run: |
         vcpkg install zstd:x64-windows
+    - name: config
+      working-directory: _build
+      run: |
+        perl ..\Configure enable-comp enable-zstd --with-zstd-include=C:\vcpkg\packages\zstd_x64-windows\include --with-zstd-lib=C:\vcpkg\packages\zstd_x64-windows\lib\zstd.lib no-makedepend -DOSSL_WINCTX=openssl VC-WIN64A
+        perl configdata.pm --dump
+    - name: build
+      working-directory: _build
+      run: nmake
     - name: Gather openssl version info
       working-directory: _build
       run: |
+        $env:Path+=";C:\vcpkg\packages\zstd_x64-windows\bin"
         apps/openssl.exe version -v
         apps/openssl.exe version -v | %{($_ -split '\s+')[1]}
         apps/openssl.exe version -v | %{($_ -split '\s+')[1] -replace '([0-9]+\.[0-9]+)(\..*)','$1'} 
@@ -48,14 +58,6 @@ jobs:
         reg.exe add HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v ENGINESDIR /t REG_EXPAND_SZ /d TESTOPENSSLDIR /reg:32
         reg.exe add HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v MODULESDIR /t REG_EXPAND_SZ /d TESTOPENSSLDIR /reg:32
         reg.exe query HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v OPENSSLDIR /reg:32
-    - name: config
-      working-directory: _build
-      run: |
-        perl ..\Configure enable-comp enable-zstd --with-zstd-include=C:\vcpkg\packages\zstd_x64-windows\include --with-zstd-lib=C:\vcpkg\packages\zstd_x64-windows\lib\zstd.lib no-makedepend -DOSSL_WINCTX=openssl VC-WIN64A
-        perl configdata.pm --dump
-    - name: build
-      working-directory: _build
-      run: nmake
     - name: download coreinfo
       uses: suisei-cn/actions-download-file@v1.6.0
       with:
@@ -90,21 +92,6 @@ jobs:
       working-directory: _build
       run: |
         vcpkg install brotli:x64-windows
-    - name: Gather openssl version info
-      working-directory: _build
-      run: |
-        apps/openssl.exe version -v
-        apps/openssl.exe version -v | awk '{print $2}'
-        apps/openssl.exe version -v | awk '{print $2}' | sed -e's/-.*$//'
-        echo "OSSL_VERSION=$(apps/openssl.exe version -v | awk '{print $2}' | sed -e's/-.*$//')" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-    - name: Set registry keys
-      working-directory: _build
-      run: |
-        echo ${Env:OSSL_VERSION}
-        reg.exe add HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v OPENSSLDIR /t REG_EXPAND_SZ /d TESTOPENSSLDIR /reg:32
-        reg.exe add HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v ENGINESDIR /t REG_EXPAND_SZ /d TESTOPENSSLDIR /reg:32
-        reg.exe add HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v MODULESDIR /t REG_EXPAND_SZ /d TESTOPENSSLDIR /reg:32
-        reg.exe query HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v OPENSSLDIR /reg:32
     - name: config
       working-directory: _build
       run: |
@@ -125,6 +112,22 @@ jobs:
         7z.exe x coreinfo/Coreinfo.zip
         ./Coreinfo64.exe -accepteula -f
         ./apps/openssl.exe version -c
+    - name: Gather openssl version info
+      working-directory: _build
+      run: |
+        $env:Path+=";C:\vcpkg\packages\brotli_x64-windows\bin"
+        apps/openssl.exe version -v
+        apps/openssl.exe version -v | awk '{print $2}'
+        apps/openssl.exe version -v | awk '{print $2}' | sed -e's/-.*$//'
+        echo "OSSL_VERSION=$(apps/openssl.exe version -v | awk '{print $2}' | sed -e's/-.*$//')" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+    - name: Set registry keys
+      working-directory: _build
+      run: |
+        echo ${Env:OSSL_VERSION}
+        reg.exe add HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v OPENSSLDIR /t REG_EXPAND_SZ /d TESTOPENSSLDIR /reg:32
+        reg.exe add HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v ENGINESDIR /t REG_EXPAND_SZ /d TESTOPENSSLDIR /reg:32
+        reg.exe add HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v MODULESDIR /t REG_EXPAND_SZ /d TESTOPENSSLDIR /reg:32
+        reg.exe query HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v OPENSSLDIR /reg:32
     - name: test
       working-directory: _build
       run: |


### PR DESCRIPTION
Because the windows_comp.ci test doesn't run on pull requests unless something in the crypto/comp directory changes, we missed the fact that we were trying to run openssl.exe before it was built

Fix the ordering of the steps for the brotli and zstd builds, and run this job any time the ci file changes
