### PR TITLE
Ensure cmd from fuzz buffer is always valid

### DIFF
--- a/fuzz/quic-srtm.c
+++ b/fuzz/quic-srtm.c
@@ -36,7 +36,8 @@ enum {
     CMD_ADD,
     CMD_REMOVE,
     CMD_CULL,
-    CMD_LOOKUP
+    CMD_LOOKUP,
+    CMD_MAX
 };
 
 int FuzzerTestOneInput(const uint8_t *buf, size_t len)
@@ -60,7 +61,7 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
         if (!PACKET_get_1(&pkt, &cmd))
             goto err;
 
-        switch (cmd) {
+        switch (cmd % CMD_MAX) {
         case CMD_ADD:
             if (!PACKET_get_net_8(&pkt, &arg_opaque)
                 || !PACKET_get_net_8(&pkt, &arg_seq_num)


### PR DESCRIPTION
The quic-srtm fuzzer uses a loop in which an integer command is extracted from the fuzzer buffer input to determine the action to take, switching on the values between 0 and 3, and ignoring all other commands.  Howver in the failing fuzzer test case here: https://oss-fuzz.com/testcase-detail/5618331942977536

The buffer provided shows a large number of 0 values (indicating an SRTM add command), and almost no 1, 2, or 3 values.  As such, the fuzzer only truly exercises the srtm add path, which has the side effect of growing the SRTM hash table unboundedly, leading to a timeout when 10 entries need to be iterated over when the hashtable doall command is executed.

Fix this by ensuring that the command is always valid, and reasonably distributed among all the operations with some modulo math.

Introducing this change bounds the hash table size in the reproducer test case to less than half of the initially observed size, and avoids the timeout.

Fixes openssl/project#679
