### PR TITLE
fix: drop DSA <=> dsaWithSHA1 aliasing

### DIFF
--- a/crypto/asn1/standard_methods.h
+++ b/crypto/asn1/standard_methods.h
@@ -23,7 +23,6 @@ static const EVP_PKEY_ASN1_METHOD *standard_methods[] = {
     &ossl_dsa_asn1_meths[1],
     &ossl_dsa_asn1_meths[2],
     &ossl_dsa_asn1_meths[3],
-    &ossl_dsa_asn1_meths[4],
 #endif
 #ifndef OPENSSL_NO_EC
     &ossl_eckey_asn1_meth,

--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -516,26 +516,24 @@ static int dsa_pkey_copy(EVP_PKEY *to, EVP_PKEY *from)
 
 /* NB these are sorted in pkey_id order, lowest first */
 
-const EVP_PKEY_ASN1_METHOD ossl_dsa_asn1_meths[5] = {
+const EVP_PKEY_ASN1_METHOD ossl_dsa_asn1_meths[4] = {
 
-    {
-     EVP_PKEY_DSA2,
-     EVP_PKEY_DSA,
-     ASN1_PKEY_ALIAS},
-
+    /* This aliases NID_dsa with NID_dsa_2 */
     {
      EVP_PKEY_DSA1,
      EVP_PKEY_DSA,
      ASN1_PKEY_ALIAS},
 
+    /* This aliases NID_dsaWithSHA with NID_dsaWithSHA_2 */
     {
      EVP_PKEY_DSA4,
-     EVP_PKEY_DSA,
+     EVP_PKEY_DSA2,
      ASN1_PKEY_ALIAS},
 
+    /* This aliases NID_dsaWithSHA with NID_dsaWithSHA1 */
     {
      EVP_PKEY_DSA3,
-     EVP_PKEY_DSA,
+     EVP_PKEY_DSA2,
      ASN1_PKEY_ALIAS},
 
     {

--- a/include/crypto/asn1.h
+++ b/include/crypto/asn1.h
@@ -92,7 +92,7 @@ DEFINE_STACK_OF_CONST(EVP_PKEY_ASN1_METHOD)
 
 extern const EVP_PKEY_ASN1_METHOD ossl_dh_asn1_meth;
 extern const EVP_PKEY_ASN1_METHOD ossl_dhx_asn1_meth;
-extern const EVP_PKEY_ASN1_METHOD ossl_dsa_asn1_meths[5];
+extern const EVP_PKEY_ASN1_METHOD ossl_dsa_asn1_meths[4];
 extern const EVP_PKEY_ASN1_METHOD ossl_eckey_asn1_meth;
 extern const EVP_PKEY_ASN1_METHOD ossl_ecx25519_asn1_meth;
 extern const EVP_PKEY_ASN1_METHOD ossl_ecx448_asn1_meth;


### PR DESCRIPTION
For some reason, DSA has been aliased with dsaWithSHA1 for an eternity.
They are not the same, though, and should never have been aliased in the
first place.

This was first discovered with 'openssl list':

    $ openssl list -signature-algorithms
    ...
    { 1.2.840.10040.4.1, 1.2.840.10040.4.3, 1.3.14.3.2.12, 1.3.14.3.2.13, 1.3.14.3.2.27, DSA, DSA-old, DSA-SHA, DSA-SHA1, DSA-SHA1-old, dsaEncryption, dsaEncryption-old, dsaWithSHA, dsaWithSHA1, dsaWithSHA1-old } @ default

This isn't good at all, as it confuses the key algorithms signature
function with a signature scheme that involves SHA1, and it makes it
look like OpenSSL's providers offer a DSA-SHA1 implementation (which
they currently do not do).

Breaking this aliasing apart (i.e. aliasing DSA, DSA-old, dsaEncryption
and dsaEncryption-old separately from the names that involve SHA) appears
harmless as far as OpenSSL's test suite goes.
