### PR TITLE
Document EVP_MD_CTX_FLAG_REUSE and other internal flags

### DIFF
--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -550,9 +550,13 @@ can be used the manipulate and test these B<EVP_MD_CTX> flags:
 
 This flag instructs the digest to optimize for one update only, if possible.
 
-=for comment EVP_MD_CTX_FLAG_CLEANED is internal, don't mention it
+=item EVP_MD_CTX_FLAG_CLEANED
 
-=for comment EVP_MD_CTX_FLAG_REUSE is internal, don't mention it
+This flag is for internal use only and I<must not> be used in user code.
+
+=item EVP_MD_CTX_FLAG_REUSE
+
+This flag is for internal use only and I<must not> be used in user code.
 
 =for comment We currently avoid documenting flags that are only bit holder:
 EVP_MD_CTX_FLAG_NON_FIPS_ALLOW, EVP_MD_CTX_FLAGS_PAD_*


### PR DESCRIPTION
Fixes #6343: Addressed a memory leak in the `EVP_MD_CTX_free` function, by adding documentation that the internal flags `EVP_MD_CTX_FLAG_CLEANED` and `EVP_MD_CTX_FLAG_REUSE` must not be used in user code.

Checklist
- [x] documentation is added or updated