### PR TITLE
Limit the number of commands that can be used in the quic-lcidm fuzzer

### DIFF
--- a/fuzz/quic-lcidm.c
+++ b/fuzz/quic-lcidm.c
@@ -48,6 +48,8 @@ enum {
     CMD_LOOKUP
 };
 
+#define MAX_CMDS    10000
+
 static int get_cid(PACKET *pkt, QUIC_CONN_ID *cid)
 {
     unsigned int cidl;
@@ -72,6 +74,7 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
     OSSL_QUIC_FRAME_NEW_CONN_ID ncid_frame;
     int did_retire;
     void *opaque_out;
+    size_t limit = 0;
 
     if (!PACKET_buf_init(&pkt, buf, len))
         goto err;
@@ -89,6 +92,9 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
 
     while (PACKET_remaining(&pkt) > 0) {
         if (!PACKET_get_1(&pkt, &cmd))
+            goto err;
+
+        if (++limit > MAX_CMDS)
             goto err;
 
         switch (cmd) {


### PR DESCRIPTION
The fuzzer was reporting a spurious timeout due to excessive numbers of commands in a single file. We limit the number of commands to avoid this.

Found by OSSFuzz
