### PR TITLE
Deploy docs.openssl.org on doc changes

### DIFF
--- a/.github/workflows/deploy-docs-openssl-org.yml
+++ b/.github/workflows/deploy-docs-openssl-org.yml
@@ -1,0 +1,23 @@
+name: "Trigger docs.openssl.org deployment"
+
+on:
+  push:
+    branches:
+      - "openssl-3.[0-9]+"
+      - "master"
+    paths:
+      - "doc/man*/**"
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Trigger deployment workflow"
+        run: |
+          gh workflow run -f branch=${{ github.ref_name }} deploy-site.yaml
+          sleep 3
+          RUN_ID=$(gh run list -w deploy-site.yaml -L 1 --json databaseId -q ".[0].databaseId")
+          gh run watch ${RUN_ID} --exit-status
+        env:
+          GH_REPO: "openssl/openssl-docs"
+          GH_TOKEN: ${{ secrets.OPENSSL_MACHINE_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to trigger `docs.openssl.org` [building and deployment](https://github.com/openssl/openssl-docs/actions/workflows/deploy-site.yaml) on changes in `doc/man*` directories.
