### PR TITLE
Update quic_tserver.c

### DIFF
--- a/ssl/quic/quic_tserver.c
+++ b/ssl/quic/quic_tserver.c
@@ -58,12 +58,12 @@ static int alpn_select_cb(SSL *ssl, const unsigned char **out,
     static const unsigned char alpndeflt[] = {
         8, 'o', 's', 's', 'l', 't', 'e', 's', 't'
     };
-    const unsigned char *alpn;
-    size_t alpnlen;
+    static unsigned char *alpn;
+    static size_t alpnlen;
 
     if (srv->args.alpn == NULL) {
         alpn = alpndeflt;
-        alpnlen = sizeof(alpndeflt);
+        alpnlen = sizeof(alpn);
     } else {
         alpn = srv->args.alpn;
         alpnlen = srv->args.alpnlen;


### PR DESCRIPTION
Improves followon fix [a88b56b](https://github.com/openssl/openssl/commit/a88b56b)

make static *alpn and alpnlen, remove const for non-constants

CLA: trivial
