### PR TITLE
Add FIPS indicator for TEST-RAND RNG

### DIFF
--- a/doc/man3/EVP_RAND.pod
+++ b/doc/man3/EVP_RAND.pod
@@ -267,6 +267,12 @@ Returns the state of the random number generator.
 
 Returns the bit strength of the random number generator.
 
+=item "fips-indicator" (B<OSSL_RAND_PARAM_FIPS_APPROVED_INDICATOR>) <integer>
+
+A getter that returns 1 if the operation is FIPS approved, or 0 otherwise.
+This option is used by the OpenSSL FIPS provider and is not supported
+by all EVP_RAND sources.
+
 =back
 
 For rands that are also deterministic random bit generators (DRBGs), these

--- a/doc/man7/EVP_RAND-TEST-RAND.pod
+++ b/doc/man7/EVP_RAND-TEST-RAND.pod
@@ -1,4 +1,3 @@
-
 =pod
 
 =head1 NAME

--- a/doc/man7/EVP_RAND-TEST-RAND.pod
+++ b/doc/man7/EVP_RAND-TEST-RAND.pod
@@ -46,6 +46,8 @@ These parameter works as described in L<EVP_RAND(3)/PARAMETERS>.
 
 =item "reseed_counter" (B<OSSL_DRBG_PARAM_RESEED_COUNTER>) <unsigned integer>
 
+=item "fips-indicator" (B<OSSL_EXCHANGE_PARAM_FIPS_APPROVED_INDICATOR>) <int>
+
 These parameters work as described in L<EVP_RAND(3)/PARAMETERS>, except that
 they can all be set as well as read.
 

--- a/doc/man7/EVP_RAND-TEST-RAND.pod
+++ b/doc/man7/EVP_RAND-TEST-RAND.pod
@@ -22,6 +22,8 @@ The supported parameters are:
 
 =item "state" (B<OSSL_RAND_PARAM_STATE>) <integer>
 
+=item "fips-indicator" (B<OSSL_RAND_PARAM_FIPS_APPROVED_INDICATOR>) <int>
+
 These parameter works as described in L<EVP_RAND(3)/PARAMETERS>.
 
 =item "strength" (B<OSSL_RAND_PARAM_STRENGTH>) <unsigned integer>
@@ -45,8 +47,6 @@ These parameter works as described in L<EVP_RAND(3)/PARAMETERS>.
 =item "max_adinlen" (B<OSSL_DRBG_PARAM_MAX_ADINLEN>) <unsigned integer>
 
 =item "reseed_counter" (B<OSSL_DRBG_PARAM_RESEED_COUNTER>) <unsigned integer>
-
-=item "fips-indicator" (B<OSSL_EXCHANGE_PARAM_FIPS_APPROVED_INDICATOR>) <int>
 
 These parameters work as described in L<EVP_RAND(3)/PARAMETERS>, except that
 they can all be set as well as read.

--- a/doc/man7/EVP_RAND-TEST-RAND.pod
+++ b/doc/man7/EVP_RAND-TEST-RAND.pod
@@ -1,3 +1,4 @@
+
 =pod
 
 =head1 NAME
@@ -22,7 +23,7 @@ The supported parameters are:
 
 =item "state" (B<OSSL_RAND_PARAM_STATE>) <integer>
 
-=item "fips-indicator" (B<OSSL_RAND_PARAM_FIPS_APPROVED_INDICATOR>) <int>
+=item "fips-indicator" (B<OSSL_RAND_PARAM_FIPS_APPROVED_INDICATOR>) <integer>
 
 These parameter works as described in L<EVP_RAND(3)/PARAMETERS>.
 

--- a/doc/man7/provider-rand.pod
+++ b/doc/man7/provider-rand.pod
@@ -191,6 +191,12 @@ Returns the state of the random number generator.
 
 Returns the bit strength of the random number generator.
 
+=item "fips-indicator" (B<OSSL_RAND_PARAM_FIPS_APPROVED_INDICATOR>) <integer>
+
+A getter that returns 1 if the operation is FIPS approved, or 0 otherwise.
+This option is used by the OpenSSL FIPS provider and is not supported
+by all EVP_RAND sources.
+
 =back
 
 For rands that are also deterministic random bit generators (DRBGs), these

--- a/providers/implementations/rands/test_rng.c
+++ b/providers/implementations/rands/test_rng.c
@@ -201,7 +201,7 @@ static int test_rng_get_ctx_params(void *vtest, OSSL_PARAM params[])
         return 0;
 
 #ifdef FIPS_MODULE
-    p = OSSL_PARAM_locate(params, OSSL_DRBG_PARAM_FIPS_APPROVED_INDICATOR);
+    p = OSSL_PARAM_locate(params, OSSL_RAND_PARAM_FIPS_APPROVED_INDICATOR);
     if (p != NULL && !OSSL_PARAM_set_int(p, 0))
         return 0;
 #endif  /* FIPS_MODULE */

--- a/providers/implementations/rands/test_rng.c
+++ b/providers/implementations/rands/test_rng.c
@@ -20,6 +20,7 @@
 #include "prov/provider_ctx.h"
 #include "prov/provider_util.h"
 #include "prov/implementations.h"
+#include "prov/fipsindicator.h"
 
 static OSSL_FUNC_rand_newctx_fn test_rng_new;
 static OSSL_FUNC_rand_freectx_fn test_rng_free;
@@ -196,8 +197,14 @@ static int test_rng_get_ctx_params(void *vtest, OSSL_PARAM params[])
         return 0;
 
     p = OSSL_PARAM_locate(params, OSSL_RAND_PARAM_GENERATE);
-    if (p != NULL && OSSL_PARAM_set_uint(p, t->generate))
+    if (p != NULL && !OSSL_PARAM_set_uint(p, t->generate))
         return 0;
+
+#ifdef FIPS_MODULE
+    p = OSSL_PARAM_locate(params, OSSL_DRBG_PARAM_FIPS_APPROVED_INDICATOR);
+    if (p != NULL && !OSSL_PARAM_set_int(p, 0))
+        return 0;
+#endif  /* FIPS_MODULE */
     return 1;
 }
 
@@ -209,6 +216,7 @@ static const OSSL_PARAM *test_rng_gettable_ctx_params(ossl_unused void *vtest,
         OSSL_PARAM_uint(OSSL_RAND_PARAM_STRENGTH, NULL),
         OSSL_PARAM_size_t(OSSL_RAND_PARAM_MAX_REQUEST, NULL),
         OSSL_PARAM_uint(OSSL_RAND_PARAM_GENERATE, NULL),
+        OSSL_FIPS_IND_GETTABLE_CTX_PARAM()
         OSSL_PARAM_END
     };
     return known_gettable_ctx_params;

--- a/test/rand_test.c
+++ b/test/rand_test.c
@@ -49,7 +49,7 @@ static int test_rand(void)
     prov = EVP_RAND_get0_provider(EVP_RAND_CTX_get0_rand(privctx));
     if (prov != NULL
             && strcmp(OSSL_PROVIDER_get0_name(prov), "fips") == 0) {
-        params[0] = OSSL_PARAM_construct_int(OSSL_DRBG_PARAM_FIPS_APPROVED_INDICATOR,
+        params[0] = OSSL_PARAM_construct_int(OSSL_RAND_PARAM_FIPS_APPROVED_INDICATOR,
                                              &indicator);
         if (!TEST_true(EVP_RAND_CTX_get_params(privctx, params))
                 || !TEST_int_eq(indicator, 0))

--- a/test/rand_test.c
+++ b/test/rand_test.c
@@ -17,6 +17,8 @@
 static int test_rand(void)
 {
     EVP_RAND_CTX *privctx;
+    const OSSL_PROVIDER *prov;
+    int indicator = 1;
     OSSL_PARAM params[2], *p = params;
     unsigned char entropy1[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05 };
     unsigned char entropy2[] = { 0xff, 0xfe, 0xfd };
@@ -42,6 +44,17 @@ static int test_rand(void)
             || !TEST_int_gt(RAND_priv_bytes(outbuf, sizeof(outbuf)), 0)
             || !TEST_mem_eq(outbuf, sizeof(outbuf), entropy2, sizeof(outbuf)))
         return 0;
+
+    /* Verify that the FIPS indicator can be read and is false */
+    prov = EVP_RAND_get0_provider(EVP_RAND_CTX_get0_rand(privctx));
+    if (prov != NULL
+            && strcmp(OSSL_PROVIDER_get0_name(prov), "fips") == 0) {
+        params[0] = OSSL_PARAM_construct_int(OSSL_DRBG_PARAM_FIPS_APPROVED_INDICATOR,
+                                             &indicator);
+        if (!TEST_true(EVP_RAND_CTX_get_params(privctx, params))
+                || !TEST_int_eq(indicator, 0))
+            return 0;
+    }
     return 1;
 }
 
@@ -78,8 +91,14 @@ static int test_rand_uniform(void)
 
 int setup_tests(void)
 {
-    if (!TEST_true(RAND_set_DRBG_type(NULL, "TEST-RAND", NULL, NULL, NULL)))
+    char *configfile;
+
+    if (!TEST_ptr(configfile = test_get_argument(0))
+            || !TEST_true(RAND_set_DRBG_type(NULL, "TEST-RAND", "fips=no",
+                                             NULL, NULL))
+            || !TEST_true(OSSL_LIB_CTX_load_config(NULL, configfile)))
         return 0;
+
     ADD_TEST(test_rand);
     ADD_TEST(test_rand_uniform);
     return 1;

--- a/test/recipes/05-test_rand.t
+++ b/test/recipes/05-test_rand.t
@@ -10,11 +10,19 @@ use strict;
 use warnings;
 use OpenSSL::Test;
 use OpenSSL::Test::Utils;
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
-plan tests => 5;
+plan tests => 6;
 setup("test_rand");
 
-ok(run(test(["rand_test"])));
+ok(run(test(["rand_test", srctop_file("test", "default.cnf")])));
+
+SKIP: {
+    skip "Skipping FIPS test in this build", 1 if disabled('fips');
+
+    ok(run(test(["rand_test", srctop_file("test", "fips.cnf")])));
+}
+
 ok(run(test(["drbgtest"])));
 ok(run(test(["rand_status_test"])));
 

--- a/util/perl/OpenSSL/paramnames.pm
+++ b/util/perl/OpenSSL/paramnames.pm
@@ -202,6 +202,7 @@ my %params = (
     'RAND_PARAM_TEST_ENTROPY' =>            "test_entropy",
     'RAND_PARAM_TEST_NONCE' =>              "test_nonce",
     'RAND_PARAM_GENERATE' =>                "generate",
+    'RAND_PARAM_FIPS_APPROVED_INDICATOR' => '*ALG_PARAM_FIPS_APPROVED_INDICATOR',
 
 # RAND/DRBG names
     'DRBG_PARAM_RESEED_REQUESTS' =>         "reseed_requests",


### PR DESCRIPTION
This RNG is not and never will be approved and is guarded by a `fips="no"` property but it still should have an indicator saying _not FIPS_.

- [ ] documentation is added or updated
- [x] tests are added or updated
