### PR TITLE
o_fopen: fix coding style and build error with VS2010

### DIFF
--- a/crypto/o_fopen.c
+++ b/crypto/o_fopen.c
@@ -38,12 +38,15 @@
 FILE *openssl_fopen(const char *filename, const char *mode)
 {
     FILE *file = NULL;
+# if defined(_WIN32) && defined(CP_UTF8)
+    int sz, len_0;
+    DWORD flags;
+# endif
 
     if (filename == NULL)
         return NULL;
 # if defined(_WIN32) && defined(CP_UTF8)
-    int sz, len_0 = (int)strlen(filename) + 1;
-    DWORD flags;
+    len_0 = (int)strlen(filename) + 1;
 
     /*
      * Basically there are three cases to cover: a) filename is


### PR DESCRIPTION
Follow the coding style to place variable definitions before code

Fixes a build error on Windows 2003 with VS2010 introduced in [1]
``` C
crypto\o_fopen.c(45) : error C2143: syntax error : missing ';' before 'type' crypto\o_fopen.c(46) : error C2275: 'DWORD' : illegal use of this type as an expression
        E:\Program Files (x86)\Microsoft SDKs\Windows\v7.0A\include\windef.h(152) : see declaration of 'DWORD'
crypto\o_fopen.c(46) : error C2146: syntax error : missing ';' before identifier 'flags' crypto\o_fopen.c(46) : error C2065: 'flags' : undeclared identifier
```
[1] https://github.com/openssl/openssl/commit/917f37195ac95252a4c90e86d7d7414c5569aed8

##### Checklist
- [ ] documentation is added or updated
- [ ] tests are added or updated

@nhorman @t8m @tom-cosgrove-arm @paulidale @shahsb @levitte @mattcaswell @hlandau @viruscamp @yjh-styx