### PR TITLE
Enhance util/check-format-commit.sh and use the enhancement

### DIFF
--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -33,18 +33,15 @@ jobs:
         REFSTART=$(git rev-parse $GITHUB_BASE_REF)
         REFEND=$(git rev-parse HEAD)
         echo "Checking from $REFSTART to $REFEND"
-        for i in $(git log --no-merges --format=%H $REFSTART..$REFEND)
-        do
-          echo "::group::Style report for commit $i"
-          set +e
-          ./util/check-format-commit.sh $i
-          if [ $? -ne 0 ]
-          then
-            ERRORS_FOUND=1
-          fi
-          set -e
-          echo "::endgroup::"
-        done
+        echo "::group::Style report for commits $REFSTART..$REFEND"
+        set +e
+        ./util/check-format-commit.sh $REFSTART..$REFEND
+        if [ $? -ne 0 ]
+        then
+          ERRORS_FOUND=1
+        fi
+        set -e
+        echo "::endgroup::"
         SKIP_TEST=$(gh pr view $PR_NUMBER --json labels --jq '.labels[] | select(.name == "style: waived") | .name')
         if [ -z "$SKIP_TEST" ]
         then

--- a/util/check-format-commit.sh
+++ b/util/check-format-commit.sh
@@ -51,6 +51,14 @@ trap cleanup EXIT
 COMMIT_RANGE="$@"
 COMMIT_LAST=$(git rev-parse $COMMIT_RANGE)
 
+# Fail gracefully if git rev-parse doesn't produce a valid
+# commit
+if [ $? -ne 0 ]
+then
+    echo "$1 is not a valid revision"
+    exit 1
+fi
+
 # If the commit range was just one single revision, git rev-parse
 # will output jut commit id of that one alone.  In that case, we
 # must manipulate a little to get a desirable result, 'cause git
@@ -63,15 +71,7 @@ else
     COMMIT_RANGE=$COMMIT_RANGE^..$COMMIT_RANGE
 fi
 
-# Fail gracefully if git rev-parse doesn't produce a valid
-# commit
-if [ $? -ne 0 ]
-then
-    echo "$1 is not a valid revision"
-    exit 1
-fi
-
-# Create a iteratable list of files to check formatting on,
+# Create an iteratable list of files to check formatting on,
 # including the line ranges that are changed by the commits
 # It produces output of this format:
 # <file name> <change start line>, <change line count>

--- a/util/check-format-commit.sh
+++ b/util/check-format-commit.sh
@@ -6,10 +6,10 @@
 # You can obtain a copy in the file LICENSE in the source distribution
 # or at https://www.openssl.org/source/license.html
 #
-# This script is a wrapper around check-format.pl.  It accepts a commit sha
-# value as input, and uses it to identify the files and ranges that were
-# changed in that commit, filtering check-format.pl output only to lines that
-# fall into the commits change ranges.
+# This script is a wrapper around check-format.pl.  It accepts the same commit
+# revision range as 'git diff' as arguments, and uses it to identify the files
+# and ranges that were changed in that range, filtering check-format.pl output
+# only to lines that fall into the change ranges of the changed files.
 #
 
 
@@ -45,10 +45,23 @@ cleanup() {
 
 trap cleanup EXIT
 
-# Get the canonical sha256 sum for the commit we are checking
+# Get the canonical sha256 sum for the commits we are checking
 # This lets us pass in symbolic ref names like master/etc and 
 # resolve them to sha256 sums easily
-COMMIT=$(git rev-parse $1)
+COMMIT_RANGE="$@"
+COMMIT_LAST=$(git rev-parse $COMMIT_RANGE)
+
+# If the commit range was just one single revision, git rev-parse
+# will output jut commit id of that one alone.  In that case, we
+# must manipulate a little to get a desirable result, 'cause git
+# diff has a slightly different interpretation of a single commit
+# id, and takes that to mean all commits up to HEAD.
+if [ $(echo "$COMMIT_LAST" | wc -l) -gt 1 ]; then
+    COMMIT_LAST=$(echo "$COMMIT_LAST" | head -1)
+else
+    # $COMMIT_RANGE is just one commit, make it an actual range
+    COMMIT_RANGE=$COMMIT_RANGE^..$COMMIT_RANGE
+fi
 
 # Fail gracefully if git rev-parse doesn't produce a valid
 # commit
@@ -58,11 +71,12 @@ then
     exit 1
 fi
 
-# Create a iteratable list of files to check for a
-# given commit. It produces output of the format
-# <commit id> <file name> <change start line>, <change line count>
+# Create a iteratable list of files to check formatting on,
+# including the line ranges that are changed by the commits
+# It produces output of this format:
+# <file name> <change start line>, <change line count>
 touch $TEMPDIR/ranges.txt
-git show $COMMIT | awk -v mycmt=$COMMIT '
+git diff $COMMIT_RANGE | awk '
     BEGIN {myfile=""} 
     /+{3}/ {
         gsub(/b\//,"",$2);
@@ -70,7 +84,7 @@ git show $COMMIT | awk -v mycmt=$COMMIT '
     }
     /@@/ {
         gsub(/+/,"",$3);
-        printf mycmt " " myfile " " $3 "\n"
+        printf myfile " " $3 "\n"
     }' >> $TEMPDIR/ranges.txt || true
 
 # filter out anything that matches on a filter regex
@@ -93,20 +107,15 @@ done
 # to $TEMPDIR/check-format.  This give us the full file to run
 # check-format.pl on with line numbers matching the ranges in the
 # $TEMPDIR/ranges.txt file
-for j in $(grep $COMMIT $TEMPDIR/ranges.txt | awk '{print $2}')
+for j in $(cat $TEMPDIR/ranges.txt | awk '{print $1}' | sort | uniq)
 do
     FDIR=$(dirname $j)
     mkdir -p $TEMPDIR/check-format/$FDIR
-    git show $COMMIT:$j > $TEMPDIR/check-format/$j
+    git show $COMMIT_LAST:$j > $TEMPDIR/check-format/$j
 done
 
-# Now for each file in $TEMPDIR/check-format run check-format.pl
-# Note that we use the %P formatter in the find utilty.  This strips
-# off the $TEMPDIR/check-format path prefix, leaving $j with the
-# path to the file relative to the root of the source dir, so that 
-# output from check-format.pl looks correct, relative to the root
-# of the git tree.
-for j in $(find $TEMPDIR/check-format -type f -printf "%P\n")
+# Now for each file in $TEMPDIR/ranges.txt, run check-format.pl
+for j in $(cat $TEMPDIR/ranges.txt | awk '{print $1}' | sort | uniq)
 do
     range_start=()
     range_end=()
@@ -116,7 +125,7 @@ do
     # contains the corresponding end line (note, since diff output gives us
     # a line count for a change, the range_end[k] entry is actually
     # range_start[k]+line count
-    for k in $(grep $COMMIT $TEMPDIR/ranges.txt | grep $j | awk '{print $3}')
+    for k in $(grep ^$j $TEMPDIR/ranges.txt | awk '{print $2}')
     do
         RANGE=$k
         RSTART=$(echo $RANGE | awk -F',' '{print $1}')

--- a/util/check-format-commit.sh
+++ b/util/check-format-commit.sh
@@ -76,7 +76,7 @@ fi
 # It produces output of this format:
 # <file name> <change start line>, <change line count>
 touch $TEMPDIR/ranges.txt
-git diff $COMMIT_RANGE | awk '
+git diff -U0 $COMMIT_RANGE | awk '
     BEGIN {myfile=""} 
     /+{3}/ {
         gsub(/b\//,"",$2);


### PR DESCRIPTION
`util/check-format-commit.sh` is enhanced to be able to handle a
commit range, thus allowing separate code style fixup commits.

`.github/workflows/style-checks.yml` is modified to take advantage of
that.
