### PR TITLE
Fix a copy & paste error in the EVP_RAND docs

### DIFF
--- a/doc/man3/EVP_RAND.pod
+++ b/doc/man3/EVP_RAND.pod
@@ -285,7 +285,7 @@ associated RAND ctx.
 Reads or set the number of elapsed seconds before reseeding the
 associated RAND ctx.
 
-=item "max_request" (B<OSSL_DRBG_PARAM_RESEED_REQUESTS>) <unsigned integer>
+=item "max_request" (B<OSSL_RAND_PARAM_MAX_REQUEST>) <unsigned integer>
 
 Specifies the maximum number of bytes that can be generated in a single
 call to OSSL_FUNC_rand_generate.


### PR DESCRIPTION
The "max_request" string is defined via the OSSL_RAND_PARAM_MAX_REQUEST macro.