### PR TITLE
Rearrange code examples in docs to keep code block intact wrt deprecation notices

### DIFF
--- a/doc/man3/MD5.pod
+++ b/doc/man3/MD5.pod
@@ -7,11 +7,11 @@ MD4_Final, MD5_Init, MD5_Update, MD5_Final - MD2, MD4, and MD5 hash functions
 
 =head1 SYNOPSIS
 
- #include <openssl/md2.h>
-
 The following functions have been deprecated since OpenSSL 3.0, and can be
 hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
 see L<openssl_user_macros(7)>:
+
+ #include <openssl/md2.h>
 
  unsigned char *MD2(const unsigned char *d, unsigned long n, unsigned char *md);
 
@@ -20,11 +20,11 @@ see L<openssl_user_macros(7)>:
  int MD2_Final(unsigned char *md, MD2_CTX *c);
 
 
- #include <openssl/md4.h>
-
 The following functions have been deprecated since OpenSSL 3.0, and can be
 hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
 see L<openssl_user_macros(7)>:
+
+ #include <openssl/md4.h>
 
  unsigned char *MD4(const unsigned char *d, unsigned long n, unsigned char *md);
 
@@ -32,12 +32,11 @@ see L<openssl_user_macros(7)>:
  int MD4_Update(MD4_CTX *c, const void *data, unsigned long len);
  int MD4_Final(unsigned char *md, MD4_CTX *c);
 
-
- #include <openssl/md5.h>
-
 The following functions have been deprecated since OpenSSL 3.0, and can be
 hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
 see L<openssl_user_macros(7)>:
+
+ #include <openssl/md5.h>
 
  unsigned char *MD5(const unsigned char *d, unsigned long n, unsigned char *md);
 


### PR DESCRIPTION
The introduction of a deprecation notice between the header include line and the function prototypes left the inclusion in the previous block.  Move the `#include` to after the deprecation notice to ensure that the headers is included together with the corresponding `MDX_y*` functions. See screenshot for current arrangement:

<img width="861" alt="Screenshot 2024-07-12 at 12 05 04" src="https://github.com/user-attachments/assets/3a72b37a-38a7-4cb4-bbf3-32e054fed7ab">

- [x] documentation is added or updated

