### PR TITLE
Set down_load factor on hash table when culling items in doall

### DIFF
--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -657,10 +657,13 @@ static void impl_cache_flush_one_alg(ossl_uintmax_t idx, ALGORITHM *alg,
                                      void *v)
 {
     IMPL_CACHE_FLUSH *state = (IMPL_CACHE_FLUSH *)v;
+    unsigned long orig_down_load = lh_QUERY_get_down_load(alg->cache);
 
     state->cache = alg->cache;
+    lh_QUERY_set_down_load(alg->cache, 0);
     lh_QUERY_doall_IMPL_CACHE_FLUSH(state->cache, &impl_cache_flush_cache,
                                     state);
+    lh_QUERY_set_down_load(alg->cache, orig_down_load);
 }
 
 static void ossl_method_cache_flush_some(OSSL_METHOD_STORE *store)


### PR DESCRIPTION
oss-fuzz noted this issue:
https://oss-fuzz.com/testcase-detail/5363002606419968

Which reports a heap buffer overflow during ossl_method_cache_flush_some

Its occuring because we delete items from the hash table while inside its doall iterator

The iterator in lhash.c does a reverse traversal of all buckets in the hash table, and at some point a removal during an iteration leads to the hash table shrinking, by calling contract.  When that happens, the bucket index becomes no longer valid, and if the index we are on is large, it exceeds the length of the list, leading to an out of band reference, and the heap buffer overflow report.

Fix it by preventing contractions from happening during the iteration, but setting the down_load factor to 0, and restoring it to its initial value after the iteration is done
