### PR TITLE
Fix memleak in rsa_cms_sign error path

### DIFF
--- a/crypto/cms/cms_rsa.c
+++ b/crypto/cms/cms_rsa.c
@@ -222,7 +222,10 @@ static int rsa_cms_sign(CMS_SignerInfo *si)
         os = ossl_rsa_ctx_to_pss_string(pkctx);
         if (os == NULL)
             return 0;
-        return X509_ALGOR_set0(alg, OBJ_nid2obj(EVP_PKEY_RSA_PSS), V_ASN1_SEQUENCE, os);
+        if (X509_ALGOR_set0(alg, OBJ_nid2obj(EVP_PKEY_RSA_PSS), V_ASN1_SEQUENCE, os))
+            return 1;
+        ASN1_STRING_free(os);
+        return 0;
     }
 
     params[0] = OSSL_PARAM_construct_octet_string(


### PR DESCRIPTION
If the call to X509_ALGOR_set0 fails then the allocated ASN1_STRING variable passed as parameter leaks.  Fix by explicitly freeing like how all other codepaths with X509_ALGOR_set0 do.

Fixes #22680