### PR TITLE
fix vs2019 warning

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1886,7 +1886,7 @@ static MSG_PROCESS_RETURN tls_process_as_hello_retry_request(SSL_CONNECTION *s,
 
 MSG_PROCESS_RETURN tls_process_server_rpk(SSL_CONNECTION *sc, PACKET *pkt)
 {
-    EVP_PKEY *peer_rpk;
+    EVP_PKEY *peer_rpk = NULL;
 
     if (!tls_process_rpk(sc, pkt, &peer_rpk)) {
         /* SSLfatal() already called */


### PR DESCRIPTION
windows vs2019 throws warnings when compiling openssl for edk2:

ERROR - Compiler #2220 from [2024-07-15 13:43:34] [build-stdout] d:\a\edk2\edk2\CryptoPkg\Library\OpensslLib\openssl\ssl\statem\statem_clnt.c(1895) : the following warning is treated as an error
WARNING - Compiler #4701 from [2024-07-15 13:43:34] [build-stdout] d:\a\edk2\edk2\CryptoPkg\Library\OpensslLib\openssl\ssl\statem\statem_clnt.c(1895) : potentially uninitialized local variable 'peer_rpk' used
WARNING - Compiler #4703 from [2024-07-15 13:43:34] [build-stdout] d:\a\edk2\edk2\CryptoPkg\Library\OpensslLib\openssl\ssl\statem\statem_clnt.c(1895) : potentially uninitialized local pointer variable 'peer_rpk' used

Explicitly initialize the peer_rpk variable to make the compiler happy.

Yes, it's a false positive, but you have to check the tls_process_rpk() body in another source file to see that, which apparently is beyond the compiler's capabilities.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
