### PR TITLE
Fix coverity-1604666

### DIFF
--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -208,7 +208,7 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
 
     mdlen = EVP_MD_get_size(md);
 
-    if (tlen <= 0 || flen <= 0 || mdlen < 0)
+    if (tlen <= 0 || flen <= 0 || mdlen <= 0)
         return -1;
     /*
      * |num| is the length of the modulus; |flen| is the length of the

--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -208,7 +208,7 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
 
     mdlen = EVP_MD_get_size(md);
 
-    if (tlen <= 0 || flen <= 0)
+    if (tlen <= 0 || flen <= 0 || mdlen < 0)
         return -1;
     /*
      * |num| is the length of the modulus; |flen| is the length of the


### PR DESCRIPTION
Coverity recently flaged an error in which the return value for EVP_MD_get_size wasn't checked for negative values prior to use, which can cause underflow later in the function.

Just add the check and error out if get_size returns an error.

Fixes openssl/private#566
