### PR TITLE
Fix coverity-1604665

### DIFF
--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -646,7 +646,7 @@ int opt_uintmax(const char *value, ossl_uintmax_t *result)
         opt_number_error(value);
         return 0;
     }
-    *result = (ossl_intmax_t)m;
+    *result = (ossl_uintmax_t)m;
     errno = oerrno;
     return 1;
 }


### PR DESCRIPTION
Coverity issued an error in the opt_uintmax code, detecting a potential overflow on a cast to ossl_intmax_t

Looks like it was just a typo, casting m from uintmax_t to ossl_intmax_t

Fix it by correcting the cast to be ossl_uintmax_t, as would be expected

Theres also some conditionals that seem like they should be removed, but I'll save that for later, as there may be some corner cases in which ossl_uintmax_t isn't equal in size to uintmax_t..maybe.

Fixes openssl/private#567
