### PR TITLE
Add OpenSSL version checking capability to evp_test

### DIFF
--- a/test/build.info
+++ b/test/build.info
@@ -26,7 +26,8 @@ IF[{- !$disabled{tests} -}]
           testutil/format_output.c testutil/load.c testutil/fake_random.c \
           testutil/test_cleanup.c testutil/main.c testutil/testutil_init.c \
           testutil/options.c testutil/test_options.c testutil/provider.c \
-          testutil/apps_shims.c testutil/random.c testutil/helper.c $LIBAPPSSRC
+          testutil/apps_shims.c testutil/random.c testutil/helper.c \
+          testutil/version_check.c $LIBAPPSSRC
   INCLUDE[libtestutil.a]=../include ../apps/include ..
   DEPEND[libtestutil.a]=../libcrypto
 
@@ -60,7 +61,7 @@ IF[{- !$disabled{tests} -}]
           context_internal_test aesgcmtest params_test evp_pkey_dparams_test \
           keymgmt_internal_test hexstr_test provider_status_test defltfips_test \
           bio_readbuffer_test user_property_test pkcs7_test upcallstest \
-          provfetchtest prov_config_test rand_test \
+          provfetchtest prov_config_test rand_test version_test \
           ca_internals_test bio_tfo_test membio_test bio_dgram_test list_test \
           fips_version_test x509_test hpke_test pairwise_fail_test \
           nodefltctxtest evp_xof_test x509_load_cert_file_test bio_meth_test \
@@ -549,6 +550,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[fips_version_test]=fips_version_test.c
   INCLUDE[fips_version_test]=../include  ../apps/include
   DEPEND[fips_version_test]=../libcrypto libtestutil.a
+
+  SOURCE[version_test]=version_test.c
+  INCLUDE[version_test]=../include  ../apps/include
+  DEPEND[version_test]=../libcrypto libtestutil.a
 
   SOURCE[ocspapitest]=ocspapitest.c
   INCLUDE[ocspapitest]=../include ../apps/include

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -4655,6 +4655,20 @@ start:
         skipped++;
         pp++;
         goto start;
+    } else if (strcmp(pp->key, "Version") == 0) {
+        j = version_match(pp->value);
+        if (j < 0) {
+            TEST_info("Line %d: error matching OpenSSL versions\n", t->s.curr);
+            return 0;
+        } else if (j == 0) {
+            TEST_info("skipping, OpenSSL incompatible version: %s:%d",
+                      t->s.test_file, t->s.start);
+            t->skip = 1;
+            return 0;
+        }
+        skipped++;
+        pp++;
+        goto start;
     } else if (strcmp(pp->key, "FIPSversion") == 0) {
         if (prov_available("fips")) {
             j = fips_provider_version_match(libctx, pp->value);

--- a/test/recipes/03-test_version.t
+++ b/test/recipes/03-test_version.t
@@ -1,0 +1,16 @@
+#! /usr/bin/env perl
+# Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use OpenSSL::Test;              # get 'plan'
+use OpenSSL::Test::Simple;
+use OpenSSL::Test::Utils;
+
+setup("test_version");
+
+simple_test("test_version", "version_test");

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -238,6 +238,16 @@ int setup_tests(void);
 void cleanup_tests(void);
 
 /*
+ * This function matches the OpenSSL version with (potentially multiple)
+ * <operator>maj.min.patch version strings in versions.
+ * The operator can be one of = ! <= or > comparison symbols.
+ * If the OpenSSL version matches all the version comparisons the function
+ * returns 1.  If the OpenSSL version does not match the version comparisons,
+ * it returns 0.  On error the function returns -1.
+ */
+int version_match(const char *versions);
+
+/*
  * Helper functions to detect specific versions of the FIPS provider being in use.
  * Because of FIPS rules, code changes after a module has been validated are
  * difficult and because we provide a hard guarantee of ABI and behavioural

--- a/test/testutil/version_check.c
+++ b/test/testutil/version_check.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright 20243 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "../testutil.h"
+#include <ctype.h>
+#include <openssl/opensslv.h>
+
+int version_match(const char *versions)
+{
+    const char *p;
+    int major, minor, patch, r;
+    enum {
+        MODE_EQ, MODE_NE, MODE_LE, MODE_LT, MODE_GT, MODE_GE
+    } mode;
+
+    while (*versions != '\0') {
+        for (; isspace((unsigned char)(*versions)); versions++)
+            continue;
+        if (*versions == '\0')
+            break;
+        for (p = versions; *versions != '\0' && !isspace((unsigned char)(*versions)); versions++)
+            continue;
+        if (*p == '!') {
+            mode = MODE_NE;
+            p++;
+        } else if (*p == '=') {
+            mode = MODE_EQ;
+            p++;
+        } else if (*p == '<' && p[1] == '=') {
+            mode = MODE_LE;
+            p += 2;
+        } else if (*p == '>' && p[1] == '=') {
+            mode = MODE_GE;
+            p += 2;
+        } else if (*p == '<') {
+            mode = MODE_LT;
+            p++;
+        } else if (*p == '>') {
+            mode = MODE_GT;
+            p++;
+        } else if (isdigit((unsigned char)*p)) {
+            mode = MODE_EQ;
+        } else {
+            TEST_info("Error matching OpenSSL version: mode %s\n", p);
+            return -1;
+        }
+        if (sscanf(p, "%d.%d.%d", &major, &minor, &patch) != 3) {
+            TEST_info("Error matching OpenSSL version: version %s\n", p);
+            return -1;
+        }
+        switch (mode) {
+        case MODE_EQ:
+            r = OPENSSL_VERSION_MAJOR == major
+                && OPENSSL_VERSION_MINOR == minor
+                && OPENSSL_VERSION_PATCH == patch;
+            break;
+        case MODE_NE:
+            r = OPENSSL_VERSION_MAJOR != major
+                || OPENSSL_VERSION_MINOR != minor
+                || OPENSSL_VERSION_PATCH != patch;
+            break;
+        case MODE_LE:
+            r = OPENSSL_VERSION_MAJOR < major
+                || (OPENSSL_VERSION_MAJOR == major
+                    && (OPENSSL_VERSION_MINOR < minor
+                        || (OPENSSL_VERSION_MINOR == minor
+                            && OPENSSL_VERSION_PATCH <= patch)));
+            break;
+        case MODE_LT:
+            r = OPENSSL_VERSION_MAJOR < major
+                || (OPENSSL_VERSION_MAJOR == major
+                    && (OPENSSL_VERSION_MINOR < minor
+                        || (OPENSSL_VERSION_MINOR == minor
+                            && OPENSSL_VERSION_PATCH < patch)));
+            break;
+        case MODE_GT:
+            r = OPENSSL_VERSION_MAJOR > major
+                || (OPENSSL_VERSION_MAJOR == major
+                    && (OPENSSL_VERSION_MINOR > minor
+                        || (OPENSSL_VERSION_MINOR == minor
+                            && OPENSSL_VERSION_PATCH > patch)));
+            break;
+        case MODE_GE:
+            r = OPENSSL_VERSION_MAJOR > major
+                || (OPENSSL_VERSION_MAJOR == major
+                    && (OPENSSL_VERSION_MINOR > minor
+                        || (OPENSSL_VERSION_MINOR == minor
+                            && OPENSSL_VERSION_PATCH >= patch)));
+            break;
+        }
+        if (r == 0)
+            return 0;
+    }
+    return 1;
+}

--- a/test/version_test.c
+++ b/test/version_test.c
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/opensslv.h>
+#include "testutil.h"
+
+static int test(const char *op, int major, int minor, int patch)
+{
+    char buf[1000];
+
+    snprintf(buf, sizeof(buf), "%s%d.%d.%d", op, major, minor, patch);
+    return version_match(buf);
+}
+
+static int test_basic_version(void)
+{
+    return TEST_true(test("=", OPENSSL_VERSION_MAJOR,
+                          OPENSSL_VERSION_MINOR,
+                          OPENSSL_VERSION_PATCH))
+            && TEST_true(test(">=", OPENSSL_VERSION_MAJOR,
+                              OPENSSL_VERSION_MINOR,
+                              OPENSSL_VERSION_PATCH))
+            && TEST_true(test("<=", OPENSSL_VERSION_MAJOR,
+                              OPENSSL_VERSION_MINOR,
+                              OPENSSL_VERSION_PATCH))
+
+            && TEST_false(test("!", OPENSSL_VERSION_MAJOR,
+                               OPENSSL_VERSION_MINOR,
+                               OPENSSL_VERSION_PATCH))
+            && TEST_false(test(">", OPENSSL_VERSION_MAJOR,
+                               OPENSSL_VERSION_MINOR,
+                               OPENSSL_VERSION_PATCH))
+            && TEST_false(test("<", OPENSSL_VERSION_MAJOR,
+                               OPENSSL_VERSION_MINOR,
+                               OPENSSL_VERSION_PATCH))
+
+            && TEST_true(test("<=", OPENSSL_VERSION_MAJOR + 1,
+                              OPENSSL_VERSION_MINOR,
+                              OPENSSL_VERSION_PATCH))
+            && TEST_true(test("<=", OPENSSL_VERSION_MAJOR,
+                              OPENSSL_VERSION_MINOR + 1,
+                              OPENSSL_VERSION_PATCH))
+            && TEST_true(test("<=", OPENSSL_VERSION_MAJOR,
+                              OPENSSL_VERSION_MINOR,
+                              OPENSSL_VERSION_PATCH + 1))
+
+            && TEST_true(test("<", OPENSSL_VERSION_MAJOR + 1,
+                              OPENSSL_VERSION_MINOR,
+                              OPENSSL_VERSION_PATCH))
+            && TEST_true(test("<", OPENSSL_VERSION_MAJOR,
+                              OPENSSL_VERSION_MINOR + 1,
+                              OPENSSL_VERSION_PATCH))
+            && TEST_true(test("<", OPENSSL_VERSION_MAJOR,
+                              OPENSSL_VERSION_MINOR,
+                              OPENSSL_VERSION_PATCH + 1))
+
+            && TEST_false(test(">=", OPENSSL_VERSION_MAJOR + 1,
+                               OPENSSL_VERSION_MINOR,
+                               OPENSSL_VERSION_PATCH))
+            && TEST_false(test(">=", OPENSSL_VERSION_MAJOR,
+                               OPENSSL_VERSION_MINOR + 1,
+                               OPENSSL_VERSION_PATCH))
+            && TEST_false(test(">=", OPENSSL_VERSION_MAJOR,
+                               OPENSSL_VERSION_MINOR,
+                               OPENSSL_VERSION_PATCH + 1))
+
+            && TEST_false(test(">", OPENSSL_VERSION_MAJOR + 1,
+                               OPENSSL_VERSION_MINOR,
+                               OPENSSL_VERSION_PATCH))
+            && TEST_false(test(">", OPENSSL_VERSION_MAJOR,
+                               OPENSSL_VERSION_MINOR + 1,
+                               OPENSSL_VERSION_PATCH))
+            && TEST_false(test(">", OPENSSL_VERSION_MAJOR,
+                               OPENSSL_VERSION_MINOR,
+                               OPENSSL_VERSION_PATCH + 1))
+
+            && TEST_false(test("=", OPENSSL_VERSION_MAJOR + 1,
+                               OPENSSL_VERSION_MINOR,
+                               OPENSSL_VERSION_PATCH))
+            && TEST_false(test("=", OPENSSL_VERSION_MAJOR,
+                               OPENSSL_VERSION_MINOR + 1,
+                               OPENSSL_VERSION_PATCH))
+            && TEST_false(test("=", OPENSSL_VERSION_MAJOR,
+                               OPENSSL_VERSION_MINOR,
+                               OPENSSL_VERSION_PATCH + 1))
+
+            && TEST_true(test("!", OPENSSL_VERSION_MAJOR + 1,
+                              OPENSSL_VERSION_MINOR,
+                              OPENSSL_VERSION_PATCH))
+            && TEST_true(test("!", OPENSSL_VERSION_MAJOR,
+                              OPENSSL_VERSION_MINOR + 1,
+                              OPENSSL_VERSION_PATCH))
+            && TEST_true(test("!", OPENSSL_VERSION_MAJOR,
+                              OPENSSL_VERSION_MINOR,
+                              OPENSSL_VERSION_PATCH + 1))
+
+            && TEST_false(test("<=", OPENSSL_VERSION_MAJOR - 1,
+                               OPENSSL_VERSION_MINOR,
+                               OPENSSL_VERSION_PATCH))
+            && TEST_false(test("<=", OPENSSL_VERSION_MAJOR,
+                               OPENSSL_VERSION_MINOR - 1,
+                               OPENSSL_VERSION_PATCH))
+            && TEST_false(test("<=", OPENSSL_VERSION_MAJOR,
+                               OPENSSL_VERSION_MINOR,
+                               OPENSSL_VERSION_PATCH - 1))
+
+            && TEST_false(test("<", OPENSSL_VERSION_MAJOR - 1,
+                               OPENSSL_VERSION_MINOR,
+                               OPENSSL_VERSION_PATCH))
+            && TEST_false(test("<", OPENSSL_VERSION_MAJOR,
+                               OPENSSL_VERSION_MINOR - 1,
+                               OPENSSL_VERSION_PATCH))
+            && TEST_false(test("<", OPENSSL_VERSION_MAJOR,
+                               OPENSSL_VERSION_MINOR,
+                               OPENSSL_VERSION_PATCH - 1))
+
+            && TEST_true(test(">=", OPENSSL_VERSION_MAJOR - 1,
+                              OPENSSL_VERSION_MINOR,
+                              OPENSSL_VERSION_PATCH))
+            && TEST_true(test(">=", OPENSSL_VERSION_MAJOR,
+                              OPENSSL_VERSION_MINOR - 1,
+                              OPENSSL_VERSION_PATCH))
+            && TEST_true(test(">=", OPENSSL_VERSION_MAJOR,
+                              OPENSSL_VERSION_MINOR,
+                              OPENSSL_VERSION_PATCH - 1))
+
+            && TEST_true(test(">", OPENSSL_VERSION_MAJOR - 1,
+                              OPENSSL_VERSION_MINOR,
+                              OPENSSL_VERSION_PATCH))
+            && TEST_true(test(">", OPENSSL_VERSION_MAJOR,
+                              OPENSSL_VERSION_MINOR - 1,
+                              OPENSSL_VERSION_PATCH))
+            && TEST_true(test(">", OPENSSL_VERSION_MAJOR,
+                              OPENSSL_VERSION_MINOR,
+                              OPENSSL_VERSION_PATCH - 1))
+
+            && TEST_false(test("=", OPENSSL_VERSION_MAJOR - 1,
+                               OPENSSL_VERSION_MINOR,
+                               OPENSSL_VERSION_PATCH))
+            && TEST_false(test("=", OPENSSL_VERSION_MAJOR,
+                               OPENSSL_VERSION_MINOR - 1,
+                               OPENSSL_VERSION_PATCH))
+            && TEST_false(test("=", OPENSSL_VERSION_MAJOR,
+                               OPENSSL_VERSION_MINOR,
+                               OPENSSL_VERSION_PATCH - 1))
+
+            && TEST_true(test("!", OPENSSL_VERSION_MAJOR - 1,
+                              OPENSSL_VERSION_MINOR,
+                              OPENSSL_VERSION_PATCH))
+            && TEST_true(test("!", OPENSSL_VERSION_MAJOR,
+                              OPENSSL_VERSION_MINOR - 1,
+                              OPENSSL_VERSION_PATCH))
+            && TEST_true(test("!", OPENSSL_VERSION_MAJOR,
+                              OPENSSL_VERSION_MINOR,
+                              OPENSSL_VERSION_PATCH - 1));
+}
+
+static int test_compound_version(void)
+{
+    return TEST_false(version_match("<3.0.0 >=3.0.0"))
+            && TEST_true(version_match(">=3.0.0 <9999.1.1"));
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(&test_basic_version);
+    ADD_TEST(&test_compound_version);
+    return 1;
+}


### PR DESCRIPTION
This adds an option that is similar in nature to the `FIPSversion` capability.
The option allows `evp_test` stanzas to be run conditionally based on the version of OpenSSL that is running the tests.

This becomes useful once we have cross version compatibility checks.  Without we cannot e.g. change an error return without breaking old builds.

- [ ] documentation is added or updated
- [x] tests are added or updated
