### PR TITLE
fix: util/check-format-commit.sh to handle one-line diff hunks

### DIFF
--- a/util/check-format-commit.sh
+++ b/util/check-format-commit.sh
@@ -130,6 +130,8 @@ do
         RANGE=$k
         RSTART=$(echo $RANGE | awk -F',' '{print $1}')
         RLEN=$(echo $RANGE | awk -F',' '{print $2}')
+        # when the hunk is just one line, its length is implied
+        if [ -z "$RLEN" ]; then RLEN=1; fi
         let REND=$RSTART+$RLEN
         range_start+=($RSTART)
         range_end+=($REND)


### PR DESCRIPTION
For multi-line hunks, 'git diff -U0' outputs a pair of START,COUNT
indicators to show where the hunk starts and ends.  However, if the hunk is
just one line, only START is output, with the COUNT of 1 being implied.
Typically, this happens for copyright change hunks, like this:

    --- a/crypto/evp/evp_err.c
    +++ b/crypto/evp/evp_err.c
    @@ -3 +3 @@
    - * Copyright 1995-2023 The OpenSSL Project Authors. All Rights Reserved.
    + * Copyright 1995-2024 The OpenSSL Project Authors. All Rights Reserved.

This is normal unified diff output, and our script must adapt.
