### PR TITLE
fix: Have util/mkerr.pl comply better with our coding style

### DIFF
--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -567,12 +567,11 @@ EOF
                 $rn =~ tr/_[A-Z]/ [a-z]/;
                 $strings{$i} = $rn;
             }
-            my $short = "    {ERR_PACK($pack_lib, 0, $i), \"$rn\"},";
-            if ( length($short) <= 80 ) {
-                print OUT "$short\n";
-            } else {
-                print OUT "    {ERR_PACK($pack_lib, 0, $i),\n    \"$rn\"},\n";
-            }
+            my $lines;
+            $lines = "    {ERR_PACK($pack_lib, 0, $i), \"$rn\"},";
+            $lines = "    {ERR_PACK($pack_lib, 0, $i),\n     \"$rn\"},"
+                if length($lines) > 80;
+            print OUT "$lines\n";
         }
         print OUT <<"EOF";
     {0, NULL}


### PR DESCRIPTION
util/mkerr.pl produced lines like these:

    {ERR_PACK(ERR_LIB_EVP, 0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE),
    "operation not supported for this keytype"},

According to our coding style, they should look like this:

    {ERR_PACK(ERR_LIB_EVP, 0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE),
     "operation not supported for this keytype"},

This nit was correctly picked up by util/check-format.pl
