### PR TITLE
Fix coverity-1604661

### DIFF
--- a/apps/asn1parse.c
+++ b/apps/asn1parse.c
@@ -216,6 +216,9 @@ int asn1parse_main(int argc, char **argv)
                 i = BIO_read(in, &(buf->data[num]), BUFSIZ);
                 if (i <= 0)
                     break;
+                /* make sure num doesn't overflow */
+                if ((num + i) <= 0)
+                    goto end;
                 num += i;
             }
         }

--- a/apps/asn1parse.c
+++ b/apps/asn1parse.c
@@ -217,7 +217,7 @@ int asn1parse_main(int argc, char **argv)
                 if (i <= 0)
                     break;
                 /* make sure num doesn't overflow */
-                if ((num + i) <= 0)
+                if (i > LONG_MAX - num)
                     goto end;
                 num += i;
             }


### PR DESCRIPTION
Coverity called out an error in asn1parse_main, indicating that the for(;;) loop which repeatedly reads from a bio and updates the length value num, may overflow said value prior to exiting the loop.

We could probably call this a false positive, but on very large PEM file, I suppose it could happen, so just add a check to ensure that num doesn't go from a large positive to a large negative value inside the loop

Fixes openssl/private#571
