### PR TITLE
Fix dereference of null in ossl_rsa_fromdata() 

### DIFF
--- a/crypto/rsa/rsa_backend.c
+++ b/crypto/rsa/rsa_backend.c
@@ -172,6 +172,8 @@ int ossl_rsa_fromdata(RSA *rsa, const OSSL_PARAM params[], int include_private)
                  * since we set our key and 2 factors above we can skip
                  * the call to ossl_rsa_set0_all_params
                  */
+                if (ctx == NULL)
+                    goto err;
                 if (!ossl_rsa_sp800_56b_derive_params_from_pq(rsa,
                                                               RSA_bits(rsa),
                                                               NULL, ctx)) {


### PR DESCRIPTION
After having been assigned to a NULL value at rsa_backend.c:73, pointer 'ctx' is passed as 4th parameter in call to function 'ossl_rsa_sp800_56b_derive_params_from_pq' at rsa_backend.c:175, where it is dereferenced at rsa_sp800_56b_gen.c:238.
Found by Linux Verification Center (linuxtesting.org) with SVACE.

CLA:trivial