### PR TITLE
Enhance s_client Output

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3481,8 +3481,8 @@ static void print_stuff(BIO *bio, SSL *s, int full)
     print_verify_detail(s, bio);
     BIO_printf(bio, (SSL_session_reused(s) ? "---\nReused, " : "---\nNew, "));
     c = SSL_get_current_cipher(s);
-    BIO_printf(bio, "Cipher is %s (%s)\n",
-               SSL_CIPHER_get_name(c), SSL_CIPHER_get_version(c));
+    BIO_printf(bio, "%s, Cipher is %s\n",
+               SSL_CIPHER_get_version(c), SSL_CIPHER_get_name(c));
     BIO_printf(bio, "Protocol: %s\n", SSL_get_version(s));
     if (peer != NULL) {
         EVP_PKEY *pktmp;

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3481,8 +3481,9 @@ static void print_stuff(BIO *bio, SSL *s, int full)
     print_verify_detail(s, bio);
     BIO_printf(bio, (SSL_session_reused(s) ? "---\nReused, " : "---\nNew, "));
     c = SSL_get_current_cipher(s);
-    BIO_printf(bio, "%s, Cipher is %s\n",
-               SSL_CIPHER_get_version(c), SSL_CIPHER_get_name(c));
+    BIO_printf(bio, "Cipher is %s (%s)\n",
+               SSL_CIPHER_get_name(c), SSL_CIPHER_get_version(c));
+    BIO_printf(bio, "Protocol: %s\n", SSL_get_version(s));
     if (peer != NULL) {
         EVP_PKEY *pktmp;
 


### PR DESCRIPTION
Fixes #8123: Clarify cipher and protocol version display
- Moved the cipher version output into brackets after the cipher to clearly associate it with the cipher.
- Added a new line “Protocol:” to display the protocol version separately after the cipher line.
