### PR TITLE
fips: correctly initialise FIPS indicator settables

### DIFF
--- a/providers/common/include/prov/fipsindicator.h
+++ b/providers/common/include/prov/fipsindicator.h
@@ -52,8 +52,8 @@
  * settable.
  */
 typedef struct ossl_fips_ind_st {
-    unsigned int approved;
-    int settable[OSSL_FIPS_IND_SETTABLE_MAX]; /* See OSSL_FIPS_IND_STATE */
+    unsigned char approved;
+    signed char settable[OSSL_FIPS_IND_SETTABLE_MAX]; /* See OSSL_FIPS_IND_STATE */
 } OSSL_FIPS_IND;
 
 typedef int (OSSL_FIPS_IND_CHECK_CB)(OSSL_LIB_CTX *libctx);

--- a/providers/fips/fipsindicator.c
+++ b/providers/fips/fipsindicator.c
@@ -15,8 +15,11 @@
 
 void ossl_FIPS_IND_init(OSSL_FIPS_IND *ind)
 {
+    int i;
+
     ossl_FIPS_IND_set_approved(ind); /* Assume we are approved by default */
-    memset(ind->settable, OSSL_FIPS_IND_STATE_UNKNOWN, sizeof(ind->settable));
+    for (i = 0; i < OSSL_FIPS_IND_SETTABLE_MAX; i++)
+        ind->settable[i] = OSSL_FIPS_IND_STATE_UNKNOWN;
 }
 
 void ossl_FIPS_IND_set_approved(OSSL_FIPS_IND *ind)


### PR DESCRIPTION
The `memset(3)` just happened to work because 2s complement. This is more robust.

Also reduced the size of the indicator structure.
