### PR TITLE
CMS_get1_crls(): Remove redundant check for NULL crls

### DIFF
--- a/crypto/cms/cms_lib.c
+++ b/crypto/cms/cms_lib.c
@@ -665,10 +665,6 @@ STACK_OF(X509_CRL) *CMS_get1_crls(CMS_ContentInfo *cms)
     for (i = 0; i < n; i++) {
         rch = sk_CMS_RevocationInfoChoice_value(*pcrls, i);
         if (rch->type == 0) {
-            if (crls == NULL) {
-                if ((crls = sk_X509_CRL_new_null()) == NULL)
-                    return NULL;
-            }
             if (!sk_X509_CRL_push(crls, rch->d.crl)
                     || !X509_CRL_up_ref(rch->d.crl)) {
                 sk_X509_CRL_pop_free(crls, X509_CRL_free);


### PR DESCRIPTION
Fixes Coverity 1610380
