### PR TITLE
Avoid leaking *ba_ret on reconnections

### DIFF
--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -84,10 +84,9 @@ int init_client(int *sock, const char *host, const char *port,
     int ret;
     int options = 0;
 
-    if (*ba_ret != NULL) {
-        BIO_ADDR_free(*ba_ret);
-        *ba_ret = NULL;
-    }
+    /* There might be a BIO_ADDR from previous calls, release it. */
+    BIO_ADDR_free(*ba_ret);
+    *ba_ret = NULL;
 
     if (BIO_sock_init() != 1)
         return 0;

--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -84,10 +84,6 @@ int init_client(int *sock, const char *host, const char *port,
     int ret;
     int options = 0;
 
-    /* There might be a BIO_ADDR from previous calls, release it. */
-    BIO_ADDR_free(*ba_ret);
-    *ba_ret = NULL;
-
     if (BIO_sock_init() != 1)
         return 0;
 

--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -84,8 +84,10 @@ int init_client(int *sock, const char *host, const char *port,
     int ret;
     int options = 0;
 
-    if (tfo && ba_ret != NULL)
+    if (*ba_ret != NULL) {
+        BIO_ADDR_free(*ba_ret);
         *ba_ret = NULL;
+    }
 
     if (BIO_sock_init() != 1)
         return 0;

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2167,6 +2167,9 @@ int s_client_main(int argc, char **argv)
     if (tfo)
         BIO_printf(bio_c_out, "Connecting via TFO\n");
  re_start:
+    /* peer_addr might be set from previous connections */
+    BIO_ADDR_free(peer_addr);
+    peer_addr = NULL;
     if (init_client(&sock, host, port, bindhost, bindport, socket_family,
                     socket_type, protocol, tfo, !isquic, &peer_addr) == 0) {
         BIO_printf(bio_err, "connect:errno=%d\n", get_last_socket_error());


### PR DESCRIPTION
Also fixes Coverity 1604639
There is no point in checking ba_ret as it can never be NULL.
