### PR TITLE
crypto/bn/bn_gcd.c: Remove BN_CTX_free() to avoid dangling pointer

### DIFF
--- a/crypto/bn/bn_gcd.c
+++ b/crypto/bn/bn_gcd.c
@@ -531,7 +531,7 @@ BIGNUM *BN_mod_inverse(BIGNUM *in,
     rv = int_bn_mod_inverse(in, a, n, ctx, &noinv);
     if (noinv)
         ERR_raise(ERR_LIB_BN, BN_R_NO_INVERSE);
-    BN_CTX_free(new_ctx);
+
     return rv;
 }
 


### PR DESCRIPTION
The pointers ctx and new_ctx are alias pointers when assigned by BN_CTX_new_ex().
Consequently, ctx becomes a dangling pointer after new_ctx is freed. Since ctx will be freed outside of the function, the BN_CTX_free() call within the function is unnecessary and dangerous.

Fixes: 5d8b3a3ef2 ("Refactor BN_R_NO_INVERSE logic in internal functions")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
