### PR TITLE
gitignore: add .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,9 @@ providers/common/include/prov/der_sm2.h
 /apps/progs.c
 /apps/progs.h
 
+# macOS
+.DS_Store
+
 # Windows (legacy)
 /tmp32
 /tmp32.dbg


### PR DESCRIPTION
macOS creates `.DS_Store` files all over the place while browsing directories. Let's add it to the list of ignored files.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated

@nhorman @t8m @mattcaswell @tom-cosgrove-arm @levitte @paulidale @tmshort @bernd-edlinger
