### PR TITLE
Arrange the ossl-nghttp3-demo-server.c to run with the client demo.

### DIFF
--- a/demos/http3/ossl-nghttp3-demo-server.c
+++ b/demos/http3/ossl-nghttp3-demo-server.c
@@ -38,7 +38,7 @@ struct h3ssl {
     int done;
     int received_from_two;
     int restart;
-    uint64_t id_bidi; /* the id of the stream use to send reponse */
+    uint64_t id_bidi; /* the id of the stream used to send response */
 };
 
 static void init_ids(struct h3ssl *h3ssl)

--- a/demos/http3/ossl-nghttp3-demo-server.c
+++ b/demos/http3/ossl-nghttp3-demo-server.c
@@ -313,6 +313,16 @@ static int read_from_ssl_ids(nghttp3_conn *h3conn, struct h3ssl *h3ssl)
             item++;
         }
     }
+
+    /*
+     * SSL_POLL_FLAG_NO_HANDLE_EVENTS would require to use:
+     * SSL_get_event_timeout on the connection stream
+     * select/wait using the timeout value (which could be no wait time)
+     * SSL_handle_events
+     * SSL_poll
+     * for the moment we let SSL_poll to performs ticking internally 
+     * on an automatic basis.
+     */
     ret = SSL_poll(items, numitem, sizeof(SSL_POLL_ITEM), &nz_timeout, 0,
                    &result_count);
     if (!ret) {
@@ -379,7 +389,7 @@ static int read_from_ssl_ids(nghttp3_conn *h3conn, struct h3ssl *h3ssl)
     if (item->revents & SSL_POLL_EVENT_OSU) {
         /* at least one uni */
         /* we have 4 streams from the client 2, 6 , 10 and 0 */
-        /* need 2 streams to the client */
+        /* need 3 streams to the client */
         printf("Create uni?\n");
         processed_event = processed_event + SSL_POLL_EVENT_OSU;
         if (!h3ssl->has_uni) {

--- a/demos/http3/ossl-nghttp3-demo-server.c
+++ b/demos/http3/ossl-nghttp3-demo-server.c
@@ -42,7 +42,7 @@ struct h3ssl {
     int done;                 /* connection terminated EVENT_ECD, after EVENT_EC */
     int received_from_two;    /* workaround for -607 on nghttp3_conn_read_stream on stream 2 */
     int restart;              /* new request/reponse cycle started */   
-    uint64_t id_bidi;         /* the id of the stream use to read request and send reponse */
+    uint64_t id_bidi;         /* the id of the stream used to read request and send response */
 };
 
 static void init_ids(struct h3ssl *h3ssl)
@@ -185,7 +185,7 @@ static int quic_server_read(nghttp3_conn *h3conn, SSL *stream, uint64_t id, stru
     uint8_t msg2[16000];
     size_t l = sizeof(msg2);
 
-    if (!SSL_net_read_desired(stream))
+    if (!SSL_has_pending(stream))
         return 0; /* Nothing to read */
 
     ret = SSL_read(stream, msg2, l);
@@ -201,7 +201,7 @@ static int quic_server_read(nghttp3_conn *h3conn, SSL *stream, uint64_t id, stru
     }
 
     /* XXX: work around nghttp3_conn_read_stream returning  -607 on stream 2 */
-    if (!h3ssl->received_from_two && id !=2 ) {
+    if (!h3ssl->received_from_two && id != 2 ) {
        r = nghttp3_conn_read_stream(h3conn, id, msg2, ret, 0);
     } else {
        r = ret; /* ignore it for the moment ... */
@@ -747,7 +747,7 @@ restart:
                 /*
                  * XXX: 25 is TOO BIG.
                  * Probably something wrong when waiting for the close on
-                 * the previous request/reponse
+                 * the previous request/response
                  */
                 if (waitsocket(fd, 1)) {
                     printf("waiting for end_headers_received timeout %d\n", numtimeout);

--- a/demos/http3/ossl-nghttp3-demo-server.c
+++ b/demos/http3/ossl-nghttp3-demo-server.c
@@ -77,6 +77,7 @@ static void add_id(uint64_t id, SSL *ssl, struct h3ssl *h3ssl)
     printf("Oops too many streams to add!!!\n");
     exit(1);
 }
+
 static void set_id_status(uint64_t id, int status, struct h3ssl *h3ssl)
 {
     struct ssl_id *ssl_ids;

--- a/demos/http3/ossl-nghttp3-demo-server.c
+++ b/demos/http3/ossl-nghttp3-demo-server.c
@@ -336,7 +336,7 @@ static int read_from_ssl_ids(nghttp3_conn *h3conn, struct h3ssl *h3ssl)
     }
     /* Well trying... */
     if (numitem <= 1) {
-        return 0; /* Assume nothing for the moment */
+        return hassomething;
     }
 
     /* Process the other stream */

--- a/demos/http3/ossl-nghttp3-demo-server.c
+++ b/demos/http3/ossl-nghttp3-demo-server.c
@@ -91,7 +91,7 @@ static void set_id_status(uint64_t id, int status, struct h3ssl *h3ssl)
         }
     }
     printf("Oops can't set status, can't find stream!!!\n");
-    exit(1);
+    assert(0);
 }
 static int are_all_clientid_closed(struct h3ssl *h3ssl)
 {
@@ -177,7 +177,7 @@ static int quic_server_read(nghttp3_conn *h3conn, SSL *stream, uint64_t id, stru
 {
     int ret, r;
     uint8_t msg2[16000];
-    size_t l = sizeof(msg2) - 1;
+    size_t l = sizeof(msg2);
 
     if (!SSL_net_read_desired(stream))
         return 0; /* Nothing to read */
@@ -201,8 +201,6 @@ static int quic_server_read(nghttp3_conn *h3conn, SSL *stream, uint64_t id, stru
        r = ret; /* ignore it for the moment ... */
     }
 
-    printf("reading something %d on %llu\n", ret,
-           (unsigned long long) id);
     printf("nghttp3_conn_read_stream used %d of %d on %llu\n", r,
            ret, (unsigned long long) id);
     if (r != ret) {

--- a/demos/http3/ossl-nghttp3-demo-server.c
+++ b/demos/http3/ossl-nghttp3-demo-server.c
@@ -94,6 +94,7 @@ static void set_id_status(uint64_t id, int status, struct h3ssl *h3ssl)
     printf("Oops can't set status, can't find stream!!!\n");
     assert(0);
 }
+
 static int are_all_clientid_closed(struct h3ssl *h3ssl)
 {
     struct ssl_id *ssl_ids;


### PR DESCRIPTION
While implementing with the API I have 2 problems:
- Sometime select() return events that are processed internally and nothing is reported by SSL_poll()
- It is no easy to find when to finish a h3connection (nghttp3_conn):
   * sometimes SSL_poll() reports:
      - SSL_POLL_EVENT_ECD and/or SSL_POLL_EVENT_EC
      - SSL_POLL_EVENT_ER on the streams open by the client (not on the bidi)
      - both the above.
    * Is there a way to find that the client is gone? (like with the connection is cut)?
  - Testing with chrome is limited to the number of streams configured (after a few request the server exit