### PR TITLE
Fix typos found by codespell in openssl-3.0 doc

### DIFF
--- a/doc/man3/OSSL_DECODER_CTX_new_for_pkey.pod
+++ b/doc/man3/OSSL_DECODER_CTX_new_for_pkey.pod
@@ -82,7 +82,7 @@ choice of preferred pass phrase callback form.  These are called indirectly,
 through an internal L<OSSL_PASSPHRASE_CALLBACK(3)> function.
 
 The internal L<OSSL_PASSPHRASE_CALLBACK(3)> function caches the pass phrase, to
-be re-used in all decodings that are performed in the same decoding run (for
+be reused in all decodings that are performed in the same decoding run (for
 example, within one L<OSSL_DECODER_from_bio(3)> call).
 
 =head2 Input Types

--- a/doc/man3/SSL_CTX_set_alpn_select_cb.pod
+++ b/doc/man3/SSL_CTX_set_alpn_select_cb.pod
@@ -80,7 +80,7 @@ least one valid (nonempty) protocol entry in the list.
 The SSL_select_next_proto() helper function can be useful from either the ALPN
 callback or the NPN callback (described below). If no match is found, the first
 item in B<client>, B<client_len> is returned in B<out>, B<outlen> and
-B<OPENSSL_NPN_NO_OVERLAP> is returned. This can be useful when implementating
+B<OPENSSL_NPN_NO_OVERLAP> is returned. This can be useful when implementing
 the NPN callback. In the ALPN case, the value returned in B<out> and B<outlen>
 must be ignored if B<OPENSSL_NPN_NO_OVERLAP> has been returned from
 SSL_select_next_proto().


### PR DESCRIPTION
##### Checklist
- [x] documentation is added or updated