### PR TITLE
rehash.c: handle possible null pointer returned by OPENSSL_strdup

### DIFF
--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -562,6 +562,11 @@ int rehash_main(int argc, char **argv)
     } else if ((env = getenv(X509_get_default_cert_dir_env())) != NULL) {
         char lsc[2] = { LIST_SEPARATOR_CHAR, '\0' };
         m = OPENSSL_strdup(env);
+        if (m == NULL) {
+            BIO_puts(bio_err, "out of memory\n");
+            errs = -1;
+            goto end;
+        }
         for (e = strtok(m, lsc); e != NULL; e = strtok(NULL, lsc))
             errs += do_dir(e, h);
         OPENSSL_free(m);

--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -564,7 +564,7 @@ int rehash_main(int argc, char **argv)
         m = OPENSSL_strdup(env);
         if (m == NULL) {
             BIO_puts(bio_err, "out of memory\n");
-            errs = -1;
+            errs = 1;
             goto end;
         }
         for (e = strtok(m, lsc); e != NULL; e = strtok(NULL, lsc))


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

In the following code snippet, the pointer `m` returned by `OPENSSL_strdup` should be checked (marked with "+").
The library function `strtok` can take `NULL` as its first argument. In that case, it assumes the string to process is the same as the previous call. Therefore, if `m` is a null pointer without being checked, it will cause unexpected behavior after passing to `strtok` in the for-loop.

```c
        m = OPENSSL_strdup(env);
        + if (m == NULL) {
        +   BIO_puts(bio_err, "out of memory\n");
        +   errs = 1;
        +   goto end;
        + }
        for (e = strtok(m, lsc); e != NULL; e = strtok(NULL, lsc))
            errs += do_dir(e, h);
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
