### PR TITLE
apps.c: Check potential NULL returned by OPENSSL_strdup

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1718,6 +1718,10 @@ CA_DB *load_index(const char *dbfile, DB_ATTR *db_attr)
     }
 
     retdb->dbfname = OPENSSL_strdup(dbfile);
+    if (retdb->dbfname == NULL){
+        ERR_raise_data(ERR_LIB_SYS, errno, "Out of memory while copying filename: %s", dbfile);
+        goto err;
+    }
 #ifndef OPENSSL_NO_POSIX_IO
     retdb->dbst = dbst;
 #endif

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1718,7 +1718,11 @@ CA_DB *load_index(const char *dbfile, DB_ATTR *db_attr)
     }
 
     retdb->dbfname = OPENSSL_strdup(dbfile);
-    if (retdb->dbfname == NULL){
+    if (retdb->dbfname == NULL) {
+        TXT_DB_free(retdb->db);        
+        retdb->db = NULL;
+        OPENSSL_free(retdb);
+        retdb = NULL;
         ERR_raise_data(ERR_LIB_SYS, errno, "Out of memory while copying filename: %s", dbfile);
         goto err;
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

I add a null pointer check for `retdb->dbfname = OPENSSL_strdup(dbfile);`.

I think the null pointer check is necessary for the following usage:
I searched the codebase, and found only one location that uses the field `dbfname`,
it's `apps/ocsp.c:index_changed`:
```c
static int index_changed(CA_DB *rdb)
{
    struct stat sb;

    if (rdb != NULL && stat(rdb->dbfname, &sb) != -1) {
        if (rdb->dbst.st_mtime != sb.st_mtime
            || rdb->dbst.st_ctime != sb.st_ctime
            || rdb->dbst.st_ino != sb.st_ino
            || rdb->dbst.st_dev != sb.st_dev) {
            syslog(LOG_INFO, "index file changed, reloading");
            return 1;
        }
    }
    return 0;
}
```
If the dbfname is a null pointer, `stat(rdb->dbfname, &sb)` will always fail, and the function will always return `0` regardless of the status of the index file.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
