### PR TITLE
ASN1_item_i2d: check both returned length and allocated pointer

### DIFF
--- a/crypto/asn1/a_dup.c
+++ b/crypto/asn1/a_dup.c
@@ -75,7 +75,7 @@ void *ASN1_item_dup(const ASN1_ITEM *it, const void *x)
     }
 
     i = ASN1_item_i2d(x, &b, it);
-    if (b == NULL) {
+    if (i < 0 || b == NULL) {
         ERR_raise(ERR_LIB_ASN1, ERR_R_ASN1_LIB);
         return NULL;
     }

--- a/crypto/asn1/a_i2d_fp.c
+++ b/crypto/asn1/a_i2d_fp.c
@@ -88,7 +88,7 @@ int ASN1_item_i2d_bio(const ASN1_ITEM *it, BIO *out, const void *x)
     int i, j = 0, n, ret = 1;
 
     n = ASN1_item_i2d(x, &b, it);
-    if (b == NULL) {
+    if (n < 0 || b == NULL) {
         ERR_raise(ERR_LIB_ASN1, ERR_R_ASN1_LIB);
         return 0;
     }

--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -862,7 +862,7 @@ int CMS_SignerInfo_sign(CMS_SignerInfo *si)
 
     alen = ASN1_item_i2d((ASN1_VALUE *)si->signedAttrs, &abuf,
                          ASN1_ITEM_rptr(CMS_Attributes_Sign));
-    if (!abuf)
+    if (alen < 0 || abuf == NULL)
         goto err;
     if (EVP_DigestSignUpdate(mctx, abuf, alen) <= 0)
         goto err;

--- a/crypto/pkcs7/pk7_attr.c
+++ b/crypto/pkcs7/pk7_attr.c
@@ -28,6 +28,10 @@ int PKCS7_add_attrib_smimecap(PKCS7_SIGNER_INFO *si,
     }
     seq->length = ASN1_item_i2d((ASN1_VALUE *)cap, &seq->data,
                                 ASN1_ITEM_rptr(X509_ALGORS));
+    if (seq->length <= 0 || seq->data == NULL) {
+        ASN1_STRING_free(seq);
+        return 1;
+    }
     if (!PKCS7_add_signed_attribute(si, NID_SMIMECapabilities,
                                     V_ASN1_SEQUENCE, seq)) {
         ASN1_STRING_free(seq);

--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -920,7 +920,7 @@ int PKCS7_SIGNER_INFO_sign(PKCS7_SIGNER_INFO *si)
 
     alen = ASN1_item_i2d((ASN1_VALUE *)si->auth_attr, &abuf,
                          ASN1_ITEM_rptr(PKCS7_ATTR_SIGN));
-    if (!abuf)
+    if (alen < 0 || abuf == NULL)
         goto err;
     if (EVP_DigestSignUpdate(mctx, abuf, alen) <= 0)
         goto err;
@@ -1102,7 +1102,7 @@ int PKCS7_signatureVerify(BIO *bio, PKCS7 *p7, PKCS7_SIGNER_INFO *si,
 
         alen = ASN1_item_i2d((ASN1_VALUE *)sk, &abuf,
                              ASN1_ITEM_rptr(PKCS7_ATTR_VERIFY));
-        if (alen <= 0) {
+        if (alen <= 0 || abuf == NULL) {
             ERR_raise(ERR_LIB_PKCS7, ERR_R_ASN1_LIB);
             ret = -1;
             goto err;

--- a/crypto/x509/v3_conf.c
+++ b/crypto/x509/v3_conf.c
@@ -148,7 +148,7 @@ static X509_EXTENSION *do_ext_i2d(const X509V3_EXT_METHOD *method,
         ext_der = NULL;
         ext_len =
             ASN1_item_i2d(ext_struc, &ext_der, ASN1_ITEM_ptr(method->it));
-        if (ext_len < 0) {
+        if (ext_len < 0 || ext_der == NULL) {
             ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
             goto err;
         }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

I added checks for both the returned length and the allocated pointer for the API `ASN1_item_i2d`.

According to the usage at `crypto/asn1/a_digest.c:ossl_asn1_item_digest_ex` (and several other places):

```c
    i = ASN1_item_i2d(asn, &str, it);
    if (i < 0 || str == NULL)
        return 0;
```

Both the returned length (`i` in the above case) and the allocated pointer (`str` in the above case) should be checked.

Therefore, I added checks for this API in the usage sites which did not check both values.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
