### PR TITLE
Fix various issues with hashtable on new nonstop threading model

### DIFF
--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -994,7 +994,7 @@ int CRYPTO_atomic_store(uint64_t *dst, uint64_t val, CRYPTO_RWLOCK *lock)
         return 1;
     }
 # endif
-    if (lock == NULL || !CRYPTO_THREAD_read_lock(lock))
+    if (lock == NULL || !CRYPTO_THREAD_write_lock(lock))
         return 0;
     *dst  = val;
     if (!CRYPTO_THREAD_unlock(lock))

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -59,7 +59,11 @@ __tsan_mutex_post_lock((x), 0, 0)
 
 # include <assert.h>
 
-# ifdef PTHREAD_RWLOCK_INITIALIZER
+/*
+ * The Non-Stop KLT thread model currently seems broken in its rwlock
+ * implementation
+ */
+# if defined(PTHREAD_RWLOCK_INITIALIZER) && !defined(_KLT_MODEL_)
 #  define USE_RWLOCK
 # endif
 


### PR DESCRIPTION
@rsbecker recently reported some failures in the new KLT thread model that HP is developing.  

Mostly what we discovered is that rwlocks on the new api exist, but aren't implemented properly.

Along the way however, we noted a few deficiencies in our hashtable implementation:

1) CRYPTO_atomic_store takes a read lock rather than a write lock when updating an atomic using an rwlock

2) ossl_ht_delete, as a matter of consistency should use read-once semantics as implemented via ossl_rcu_deref

3) hashtable.c assumes that CRYPTO_atomic_load/store assumes that those operations are infallible, but can fail, we should error check those

4) As the title suggests, the new KLT thread model should only use mutexes at the moment, rather than rwlocks, as the rwlocks return errors pretty consistently. 


Fix all of these issues here