### PR TITLE
dtls_meth.c: Silently drop DTLS records with invalid MAC

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,12 @@ OpenSSL 3.4
 
 ### Changes between 3.3 and 3.4 [xx XXX xxxx]
 
+ * Changed DTLS handling of record with invalid MAC.
+   Records with invalid MAC used to generate fatal alert, and are now
+   silently dropped.
+
+   *Omer Kattan*
+
  * Redesigned Windows use of OPENSSLDIR/ENGINESDIR/MODULESDIR such that
    what were formerly build time locations can now be defined at run time
    with registry keys. See NOTES-WINDOWS.md

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -170,8 +170,7 @@ static int dtls_process_record(OSSL_RECORD_LAYER *rl, DTLS_BITMAP *bitmap)
         mac = rr->data + rr->length;
         i = rl->funcs->mac(rl, rr, md, 0 /* not send */);
         if (i == 0 || CRYPTO_memcmp(md, mac, (size_t)mac_size) != 0) {
-            RLAYERfatal(rl, SSL_AD_BAD_RECORD_MAC,
-                        SSL_R_DECRYPTION_FAILED_OR_BAD_RECORD_MAC);
+            /* Silently drop the packet in case of invalid MAC. */
             return 0;
         }
         /*


### PR DESCRIPTION
Silently drop DTLS records with invalid MAC instead of generating fatal alert, fixes #24972 

This solves a case where Application Data messages from a previous session are buffered before the handshake, and are handled as part of the new session.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
