### PR TITLE
Fix strtoul test on alpine/musl

### DIFF
--- a/test/strtoultest.c
+++ b/test/strtoultest.c
@@ -36,16 +36,17 @@ static struct strtoul_test_entry strtoul_tests[] = {
     {
         "0x12345", 10, 0, 1, 1
     },
-#if defined(__WORDSIZE) && __WORDSIZE == 64
+#if ULONG_MAX == 4294967295
     /* pass on ULONG_MAX translation */
-    {
-        "18446744073709551615", 0, ULONG_MAX, 1, 20
-    },
-#else
     {
         "4294967295", 0, ULONG_MAX, 1, 10
     },
+#else
+    {
+        "18446744073709551615", 0, ULONG_MAX, 1, 20
+    },
 #endif
+
     /* fail on negative input */
     {
         "-1", 0, 0, 0, 0


### PR DESCRIPTION
The strtoul tests that were recently added had a compile time check for __WORDSIZE to properly determine the string to use for an maximal unsigned long.  Unfortunately musl libc doesn't define __WORDSIZE so we were in a position where on that platform we fall to the 32 bit unsigned long variant, which breaks on x86 platforms.

Fix it by checking if __WORDSIZE is defined, and, if not, falling back to reliance on __x86_64__ being defined
