### PR TITLE
Fix Coverity-1604641

### DIFF
--- a/crypto/asn1/a_object.c
+++ b/crypto/asn1/a_object.c
@@ -198,7 +198,8 @@ int i2a_ASN1_OBJECT(BIO *bp, const ASN1_OBJECT *a)
     }
     if (i <= 0) {
         i = BIO_write(bp, "<INVALID>", 9);
-        i += BIO_dump(bp, (const char *)a->data, a->length);
+        if (i > 0)
+            i += BIO_dump(bp, (const char *)a->data, a->length);
         return i;
     }
     BIO_write(bp, p, i);


### PR DESCRIPTION
Coverity flagged an overflow warning here that can occur if BIO_write returns an error.

The overflow itself is a bit of a non-issue, but if BIO_write returns < 0, then the return from i2a_ASN1_OBJECT will be some odd value representing whatever the offset from the error code to the number of bytes the dump may or may not have written (or some larger negative error code if both fail.

So lets fix it.  Only do the dump if the BIO_write call returned 0 or greaater.
