### PR TITLE
Fix second error from Coverity-161057

### DIFF
--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -681,6 +681,10 @@ static int cmd_RecordPadding(SSL_CONF_CTX *cctx, const char *value)
         hs_padding = block_padding;
     OPENSSL_free(copy);
 
+    /*
+     * All we care about are non-negative values,
+     * the setters check the range
+     */
     if (cctx->ctx)
         rv = SSL_CTX_set_block_padding_ex(cctx->ctx, (size_t)block_padding,
                                           (size_t)hs_padding);

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -680,18 +680,13 @@ static int cmd_RecordPadding(SSL_CONF_CTX *cctx, const char *value)
     if (commap == NULL)
         hs_padding = block_padding;
     OPENSSL_free(copy);
-    /*
-     * All we care about are non-negative values,
-     * the setters check the range
-     */
-    if (block_padding >= 0 || hs_padding >= 0) {
-        if (cctx->ctx)
-            rv = SSL_CTX_set_block_padding_ex(cctx->ctx, (size_t)block_padding,
-                                              (size_t)hs_padding);
-        if (cctx->ssl)
-            rv = SSL_set_block_padding_ex(cctx->ssl, (size_t)block_padding,
+
+    if (cctx->ctx)
+        rv = SSL_CTX_set_block_padding_ex(cctx->ctx, (size_t)block_padding,
                                           (size_t)hs_padding);
-    }
+    if (cctx->ssl)
+        rv = SSL_set_block_padding_ex(cctx->ssl, (size_t)block_padding,
+                                      (size_t)hs_padding);
     return rv;
 }
 


### PR DESCRIPTION
Coverity flagged a second error in this code

we're comparing block_padding and hs_padding for >= 0, which is always true

With the change to the use of strtoul, inputs that are preceded with a - (i.e. negative values), are caught already, so the check is redundant

just remove the check entirely
