### PR TITLE
Remove dead code from CMS_get1_crls

### DIFF
--- a/crypto/cms/cms_lib.c
+++ b/crypto/cms/cms_lib.c
@@ -665,10 +665,6 @@ STACK_OF(X509_CRL) *CMS_get1_crls(CMS_ContentInfo *cms)
     for (i = 0; i < n; i++) {
         rch = sk_CMS_RevocationInfoChoice_value(*pcrls, i);
         if (rch->type == 0) {
-            if (crls == NULL) {
-                if ((crls = sk_X509_CRL_new_null()) == NULL)
-                    return NULL;
-            }
             if (!sk_X509_CRL_push(crls, rch->d.crl)
                     || !X509_CRL_up_ref(rch->d.crl)) {
                 sk_X509_CRL_pop_free(crls, X509_CRL_free);


### PR DESCRIPTION
Commit cc31db1eb6ccdfa3028b21a4a6236d721e0ca36b changed how the stack of crls was allocated, leading to some dead code inside the for loop, which coverity flagged.

Remove the dead code
