### PR TITLE
Fix coverity-993406

### DIFF
--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -332,6 +332,9 @@ static unsigned char *read_all(BIO *bio, long *p_len)
         if (ret < 0)
             break;
 
+        if (LONG_MAX - ret < *p_len)
+            break;
+
         *p_len += ret;
 
         if (ret < step)


### PR DESCRIPTION
Coverity flagged an overflow warning in the cmsapitest.

Its pretty insignificant, but if a huge file is passed in via BIO, its possible for the length variable returned to overflow.

Just check it as we read to silence coverity on it.

