### PR TITLE
fix: in test/evp_test.c, don't conflated 'FIPSversion' with avail. FIPS prov

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -4667,11 +4667,6 @@ start:
                     t->skip = 1;
                     return 0;
             }
-        } else {
-            TEST_info("skipping, FIPS provider not active: %s:%d",
-                      t->s.test_file, t->s.start);
-            t->skip = 1;
-            return 0;
         }
         skipped++;
         pp++;


### PR DESCRIPTION
`FIPSversion = >= 3.2.0` should mean that if the FIPS provider is available,
it must be version 3.2.0 or higher, without implying `Availablein = fips`.
In other words, that same stanza should be useful with the default provider
too, without having to duplicate it.

If you do want a stanza to be exclusively for the FIPS provider, you can
still, and should use an explicit `Availablein = fips`.
