### PR TITLE
drbg: streamline test for allowed digests

### DIFF
--- a/providers/implementations/rands/drbg.c
+++ b/providers/implementations/rands/drbg.c
@@ -1029,11 +1029,12 @@ int ossl_drbg_verify_digest(PROV_DRBG *drbg, OSSL_LIB_CTX *libctx,
             return 0;
         }
     }
-#endif
+#else   /* FIPS_MODULE */
     /* Outside of FIPS, any digests that are not XOF are allowed */
     if ((EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF) != 0) {
         ERR_raise(ERR_LIB_PROV, PROV_R_XOF_DIGESTS_NOT_ALLOWED);
         return 0;
     }
+#endif  /* FIPS_MODULE */
     return 1;
 }


### PR DESCRIPTION
Under FIPS, we've got a whitelist of algorithms.  There is no need to then also check for XOF digests because they aren't possible.

