### PR TITLE
HTTP client and `80-test_cmp_http.t`: various fixes for IPv6 host addresses and `no_proxy`

### DIFF
--- a/apps/include/http_server.h
+++ b/apps/include/http_server.h
@@ -38,7 +38,7 @@
 
 # ifndef OPENSSL_NO_SOCK
 /*-
- * Initialize an HTTP server, setting up its listening BIO
+ * Initialize an HTTP server, setting up its listening BIO, using IPv4 or IPv6
  * prog: the name of the current app
  * port: the port to listen on
  * verbosity: the level of verbosity to use, or -1 for default: LOG_INFO

--- a/apps/include/http_server.h
+++ b/apps/include/http_server.h
@@ -38,7 +38,7 @@
 
 # ifndef OPENSSL_NO_SOCK
 /*-
- * Initialize an HTTP server, setting up its listening BIO, using IPv4 or IPv6
+ * Initialize an HTTP server, setting up its listening BIO
  * prog: the name of the current app
  * port: the port to listen on
  * verbosity: the level of verbosity to use, or -1 for default: LOG_INFO

--- a/apps/lib/http_server.c
+++ b/apps/lib/http_server.c
@@ -202,8 +202,8 @@ BIO *http_server_init(const char *prog, const char *port, int verb)
         goto err;
     acbio = BIO_new(BIO_s_accept());
     if (acbio == NULL
-        || BIO_set_bind_mode(acbio, BIO_BIND_REUSEADDR) < 0
-        || BIO_set_accept_name(acbio, name) < 0) {
+        || BIO_set_bind_mode(acbio, BIO_BIND_REUSEADDR) <= 0
+        || BIO_set_accept_name(acbio, name) <= 0) {
         log_HTTP(prog, LOG_ERR, "error setting up accept BIO");
         goto err;
     }

--- a/apps/lib/http_server.c
+++ b/apps/lib/http_server.c
@@ -202,6 +202,7 @@ BIO *http_server_init(const char *prog, const char *port, int verb)
         goto err;
     acbio = BIO_new(BIO_s_accept());
     if (acbio == NULL
+        || BIO_set_accept_ip_family(acbio, BIO_FAMILY_IPANY) <= 0 /* IPv4/6 */
         || BIO_set_bind_mode(acbio, BIO_BIND_REUSEADDR) <= 0
         || BIO_set_accept_name(acbio, name) <= 0) {
         log_HTTP(prog, LOG_ERR, "error setting up accept BIO");

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -928,10 +928,10 @@ int OSSL_HTTP_REQ_CTX_nbio_d2i(OSSL_HTTP_REQ_CTX *rctx,
 
 #ifndef OPENSSL_NO_SOCK
 
-static const char *complete_port(const char *host, const char *port, int use_ssl)
+static const char *extract_port(const char *host, const char *port, int use_ssl)
 {
     if (port == NULL) {
-        if (host[0] == '[') { /* IPv6 address enclosed with '[' and ']' */
+        if (host[0] == '[') { /* IPv6 address enclosed in '[' and ']' */
             host = strchr(host + 1, ']');
             if (host == NULL) {
                 ERR_raise(ERR_LIB_HTTP, ERR_R_PASSED_INVALID_ARGUMENT);
@@ -964,7 +964,7 @@ static BIO *http_new_bio(const char *server /* optionally includes ":port" */,
         port = proxy_port;
     }
 
-    if ((port = complete_port(host, port, use_ssl)) == NULL)
+    if ((port = extract_port(host, port, use_ssl)) == NULL)
         return NULL;
 
     cbio = BIO_new_connect(host /* optionally includes ":port" */);
@@ -1052,7 +1052,7 @@ OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
         }
         if (port != NULL && *port == '\0')
             port = NULL;
-        if ((port = complete_port(server, port, use_ssl)) == NULL)
+        if ((port = extract_port(server, port, use_ssl)) == NULL)
             return NULL;
         proxy = OSSL_HTTP_adapt_proxy(proxy, no_proxy, server, use_ssl);
         if (proxy != NULL

--- a/crypto/http/http_lib.c
+++ b/crypto/http/http_lib.c
@@ -14,7 +14,12 @@
 #include <openssl/bio.h> /* for BIO_snprintf() */
 #include <openssl/err.h>
 #include "internal/cryptlib.h" /* for ossl_assert() */
-#include "internal/bio_addr.h" /* for NI_MAXHOST */
+#ifndef OPENSSL_NO_SOCK
+# include "internal/bio_addr.h" /* for NI_MAXHOST */
+#endif
+#ifndef NI_MAXHOST
+# define NI_MAXHOST 255
+#endif
 #include "crypto/ctype.h" /* for ossl_isspace() */
 
 static void init_pstring(char **pstr)

--- a/crypto/http/http_lib.c
+++ b/crypto/http/http_lib.c
@@ -14,6 +14,7 @@
 #include <openssl/bio.h> /* for BIO_snprintf() */
 #include <openssl/err.h>
 #include "internal/cryptlib.h" /* for ossl_assert() */
+#include "crypto/ctype.h" /* for ossl_isspace() */
 
 static void init_pstring(char **pstr)
 {
@@ -251,10 +252,17 @@ static int use_proxy(const char *no_proxy, const char *server)
 {
     size_t sl;
     const char *found = NULL;
+    char host[300];
 
     if (!ossl_assert(server != NULL))
         return 0;
     sl = strlen(server);
+    if (sl >= 2 && sl < sizeof(host) + 2 && server[0] == '[' && server[sl - 1] == ']') {
+        /* strip leading '[' and trailing ']' from escaped IPv6 address */
+        sl -= 2;
+        strncpy(host, server + 1, sl);
+        server = host;
+    }
 
     /*
      * using environment variable names, both lowercase and uppercase variants,
@@ -268,8 +276,8 @@ static int use_proxy(const char *no_proxy, const char *server)
     if (no_proxy != NULL)
         found = strstr(no_proxy, server);
     while (found != NULL
-           && ((found != no_proxy && found[-1] != ' ' && found[-1] != ',')
-               || (found[sl] != '\0' && found[sl] != ' ' && found[sl] != ',')))
+           && ((found != no_proxy && !ossl_isspace(found[-1]) && found[-1] != ',')
+               || (found[sl] != '\0' && !ossl_isspace(found[sl]) && found[sl] != ',')))
         found = strstr(found + 1, server);
     return found == NULL;
 }

--- a/crypto/http/http_lib.c
+++ b/crypto/http/http_lib.c
@@ -252,7 +252,7 @@ static int use_proxy(const char *no_proxy, const char *server)
 {
     size_t sl;
     const char *found = NULL;
-    char host[300];
+    char host[NI_MAXHOST];
 
     if (!ossl_assert(server != NULL))
         return 0;

--- a/crypto/http/http_lib.c
+++ b/crypto/http/http_lib.c
@@ -14,6 +14,7 @@
 #include <openssl/bio.h> /* for BIO_snprintf() */
 #include <openssl/err.h>
 #include "internal/cryptlib.h" /* for ossl_assert() */
+#include "internal/bio_addr.h" /* for NI_MAXHOST */
 #include "crypto/ctype.h" /* for ossl_isspace() */
 
 static void init_pstring(char **pstr)

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -513,7 +513,7 @@ Reason numbers defined in RFC 5280 are:
 The I<host> domain name or IP address and optionally I<port>
 of the CMP server to connect to using HTTP(S).
 IP address may be for v4 or v6, such as C<127.0.0.1> or C<[::1]> for localhost.
-If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
+If the host string is an IPv6 address, it must be enclosed in C<[> and C<]>.
 
 This option excludes I<-port> and I<-use_mock_srv>.
 It is ignored if I<-rspin> is given with enough filename arguments.
@@ -528,7 +528,7 @@ If a path is included it provides the default value for the B<-path> option.
 
 The HTTP(S) proxy server to use for reaching the CMP server unless B<-no_proxy>
 applies, see below.
-If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
+If the host string is an IPv6 address, it must be enclosed in C<[> and C<]>.
 The proxy port defaults to 80 or 443 if the scheme is C<https>; apart from that
 the optional C<http://> or C<https://> prefix is ignored (note that using TLS
 may be required by B<-tls_used> or B<-server> with the prefix C<https>),

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -513,6 +513,7 @@ Reason numbers defined in RFC 5280 are:
 The I<host> domain name or IP address and optionally I<port>
 of the CMP server to connect to using HTTP(S).
 IP address may be for v4 or v6, such as C<127.0.0.1> or C<[::1]> for localhost.
+If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
 
 This option excludes I<-port> and I<-use_mock_srv>.
 It is ignored if I<-rspin> is given with enough filename arguments.
@@ -527,6 +528,7 @@ If a path is included it provides the default value for the B<-path> option.
 
 The HTTP(S) proxy server to use for reaching the CMP server unless B<-no_proxy>
 applies, see below.
+If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
 The proxy port defaults to 80 or 443 if the scheme is C<https>; apart from that
 the optional C<http://> or C<https://> prefix is ignored (note that using TLS
 may be required by B<-tls_used> or B<-server> with the prefix C<https>),

--- a/doc/man1/openssl-ocsp.pod.in
+++ b/doc/man1/openssl-ocsp.pod.in
@@ -29,7 +29,7 @@ B<openssl> B<ocsp>
 [B<-reqin> I<file>]
 [B<-respin> I<file>]
 [B<-url> I<URL>]
-[B<-host> I<host:port>]
+[B<-host> I<host>:I<port>]
 [B<-path> I<pathname>]
 [B<-proxy> I<[http[s]://][userinfo@]host[:port][/path][?query][#fragment]>]
 [B<-no_proxy> I<addresses>]
@@ -173,7 +173,7 @@ The optional userinfo and fragment components are ignored.
 Any given query component is handled as part of the path component.
 For details, see the B<-host> and B<-path> options described next.
 
-=item B<-host> I<host:port>, B<-path> I<pathname>
+=item B<-host> I<host>:I<port>, B<-path> I<pathname>
 
 If the B<-host> option is present then the OCSP request is sent to the host
 I<host> on port I<port>.

--- a/doc/man1/openssl-ocsp.pod.in
+++ b/doc/man1/openssl-ocsp.pod.in
@@ -179,7 +179,7 @@ If the B<-host> option is present then the OCSP request is sent to the host
 I<host> on port I<port>.
 The I<host> may be a domain name or an IP (v4 or v6) address,
 such as C<127.0.0.1> or C<[::1]> for localhost.
-If it is IPv6 address, it must be enclosed in C<[> and C<]>.
+If it is an IPv6 address, it must be enclosed in C<[> and C<]>.
 
 The B<-path> option specifies the HTTP pathname to use or "/" by default.
 This is equivalent to specifying B<-url> with scheme

--- a/doc/man1/openssl-ocsp.pod.in
+++ b/doc/man1/openssl-ocsp.pod.in
@@ -179,7 +179,7 @@ If the B<-host> option is present then the OCSP request is sent to the host
 I<host> on port I<port>.
 The I<host> may be a domain name or an IP (v4 or v6) address,
 such as C<127.0.0.1> or C<[::1]> for localhost.
-If it is IPv6 address, it must be enclosed with C<[> and C<]>.
+If it is IPv6 address, it must be enclosed in C<[> and C<]>.
 
 The B<-path> option specifies the HTTP pathname to use or "/" by default.
 This is equivalent to specifying B<-url> with scheme
@@ -189,7 +189,7 @@ http:// and the given I<host>, I<port>, and optional I<pathname>.
 
 The HTTP(S) proxy server to use for reaching the OCSP server unless B<-no_proxy>
 applies, see below.
-If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
+If the host string is an IPv6 address, it must be enclosed in C<[> and C<]>.
 The proxy port defaults to 80 or 443 if the scheme is C<https>; apart from that
 the optional C<http://> or C<https://> prefix is ignored,
 as well as any userinfo, path, query, and fragment components.

--- a/doc/man1/openssl-ocsp.pod.in
+++ b/doc/man1/openssl-ocsp.pod.in
@@ -29,9 +29,9 @@ B<openssl> B<ocsp>
 [B<-reqin> I<file>]
 [B<-respin> I<file>]
 [B<-url> I<URL>]
-[B<-host> I<host>:I<port>]
+[B<-host> I<host:port>]
 [B<-path> I<pathname>]
-[B<-proxy> I<[http[s]://][userinfo@]host[:port][/path]>]
+[B<-proxy> I<[http[s]://][userinfo@]host[:port][/path][?query][#fragment]>]
 [B<-no_proxy> I<addresses>]
 [B<-header>]
 [B<-timeout> I<seconds>]
@@ -168,28 +168,31 @@ with B<-serial>, B<-cert> and B<-host> options).
 =item B<-url> I<responder_url>
 
 Specify the responder host and optionally port and path via a URL.
- Both HTTP and HTTPS (SSL/TLS) URLs can be specified.
+Both HTTP and HTTPS (SSL/TLS) URLs can be specified.
 The optional userinfo and fragment components are ignored.
 Any given query component is handled as part of the path component.
 For details, see the B<-host> and B<-path> options described next.
 
-=item B<-host> I<host>:I<port>, B<-path> I<pathname>
+=item B<-host> I<host:port>, B<-path> I<pathname>
 
 If the B<-host> option is present then the OCSP request is sent to the host
 I<host> on port I<port>.
 The I<host> may be a domain name or an IP (v4 or v6) address,
 such as C<127.0.0.1> or C<[::1]> for localhost.
+If it is IPv6 address, it must be enclosed with C<[> and C<]>.
+
 The B<-path> option specifies the HTTP pathname to use or "/" by default.
 This is equivalent to specifying B<-url> with scheme
 http:// and the given I<host>, I<port>, and optional I<pathname>.
 
-=item B<-proxy> I<[http[s]://][userinfo@]host[:port][/path]>
+=item B<-proxy> I<[http[s]://][userinfo@]host[:port][/path][?query][#fragment]>
 
 The HTTP(S) proxy server to use for reaching the OCSP server unless B<-no_proxy>
 applies, see below.
+If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
 The proxy port defaults to 80 or 443 if the scheme is C<https>; apart from that
 the optional C<http://> or C<https://> prefix is ignored,
-as well as any userinfo and path components.
+as well as any userinfo, path, query, and fragment components.
 Defaults to the environment variable C<http_proxy> if set, else C<HTTP_PROXY>
 in case no TLS is used, otherwise C<https_proxy> if set, else C<HTTPS_PROXY>.
 

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -10,11 +10,11 @@ openssl-s_client - SSL/TLS client program
 B<openssl> B<s_client>
 [B<-help>]
 [B<-ssl_config> I<section>]
-[B<-connect> I<host:port>]
+[B<-connect> I<host>:I<port>]
 [B<-host> I<hostname>]
 [B<-port> I<port>]
-[B<-bind> I<host:port>]
-[B<-proxy> I<host:port>]
+[B<-bind> I<host>:I<port>]
+[B<-proxy> I<host>:I<port>]
 [B<-proxy_user> I<userid>]
 [B<-proxy_pass> I<arg>]
 [B<-unix> I<path>]
@@ -137,7 +137,7 @@ B<openssl> B<s_client>
 {- $OpenSSL::safe::opt_v_synopsis -}
 [B<-enable_server_rpk>]
 [B<-enable_client_rpk>]
-[I<host:port>]
+[I<host>:I<port>]
 
 =head1 DESCRIPTION
 
@@ -162,7 +162,7 @@ Print out a usage message.
 
 Use the specified section of the configuration file to configure the B<SSL_CTX> object.
 
-=item B<-connect> I<host:port>
+=item B<-connect> I<host>:I<port>
 
 This specifies the host and optional port to connect to. It is possible to
 select the host and port using the optional target positional argument instead.
@@ -178,14 +178,14 @@ Host to connect to; use B<-connect> instead.
 
 Connect to the specified port; use B<-connect> instead.
 
-=item B<-bind> I<host:port>
+=item B<-bind> I<host>:I<port>
 
 This specifies the host address and or port to bind as the source for the
 connection.  For Unix-domain sockets the port is ignored and the host is
 used as the source socket address.
 If the host string is an IPv6 address, it must be enclosed in C<[> and C<]>.
 
-=item B<-proxy> I<host:port>
+=item B<-proxy> I<host>:I<port>
 
 When used with the B<-connect> flag, the program uses the host and port
 specified with this flag and issues an HTTP CONNECT command to connect
@@ -866,7 +866,7 @@ provided a suitable key and public certificate pair is configured.
 Some servers may nevertheless not request any client credentials,
 or may request a certificate.
 
-=item I<host:port>
+=item I<host>:I<port>
 
 Rather than providing B<-connect>, the target host and optional port may
 be provided as a single positional argument after all options. If neither this

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -168,7 +168,7 @@ This specifies the host and optional port to connect to. It is possible to
 select the host and port using the optional target positional argument instead.
 If neither this nor the target positional argument are specified then an attempt
 is made to connect to the local host on port 4433.
-If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
+If the host string is an IPv6 address, it must be enclosed in C<[> and C<]>.
 
 =item B<-host> I<hostname>
 
@@ -183,14 +183,14 @@ Connect to the specified port; use B<-connect> instead.
 This specifies the host address and or port to bind as the source for the
 connection.  For Unix-domain sockets the port is ignored and the host is
 used as the source socket address.
-If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
+If the host string is an IPv6 address, it must be enclosed in C<[> and C<]>.
 
 =item B<-proxy> I<host:port>
 
 When used with the B<-connect> flag, the program uses the host and port
 specified with this flag and issues an HTTP CONNECT command to connect
 to the desired server.
-If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
+If the host string is an IPv6 address, it must be enclosed in C<[> and C<]>.
 
 =item B<-proxy_user> I<userid>
 
@@ -872,7 +872,7 @@ Rather than providing B<-connect>, the target host and optional port may
 be provided as a single positional argument after all options. If neither this
 nor B<-connect> are provided, falls back to attempting to connect to
 I<localhost> on port I<4433>.
-If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
+If the host string is an IPv6 address, it must be enclosed in C<[> and C<]>.
 
 =back
 

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -137,7 +137,7 @@ B<openssl> B<s_client>
 {- $OpenSSL::safe::opt_v_synopsis -}
 [B<-enable_server_rpk>]
 [B<-enable_client_rpk>]
-[I<host>:I<port>]
+[I<host:port>]
 
 =head1 DESCRIPTION
 
@@ -162,12 +162,13 @@ Print out a usage message.
 
 Use the specified section of the configuration file to configure the B<SSL_CTX> object.
 
-=item B<-connect> I<host>:I<port>
+=item B<-connect> I<host:port>
 
 This specifies the host and optional port to connect to. It is possible to
 select the host and port using the optional target positional argument instead.
 If neither this nor the target positional argument are specified then an attempt
 is made to connect to the local host on port 4433.
+If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
 
 =item B<-host> I<hostname>
 
@@ -182,12 +183,14 @@ Connect to the specified port; use B<-connect> instead.
 This specifies the host address and or port to bind as the source for the
 connection.  For Unix-domain sockets the port is ignored and the host is
 used as the source socket address.
+If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
 
 =item B<-proxy> I<host:port>
 
 When used with the B<-connect> flag, the program uses the host and port
 specified with this flag and issues an HTTP CONNECT command to connect
 to the desired server.
+If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
 
 =item B<-proxy_user> I<userid>
 
@@ -863,12 +866,13 @@ provided a suitable key and public certificate pair is configured.
 Some servers may nevertheless not request any client credentials,
 or may request a certificate.
 
-=item I<host>:I<port>
+=item I<host:port>
 
-Rather than providing B<-connect>, the target hostname and optional port may
+Rather than providing B<-connect>, the target host and optional port may
 be provided as a single positional argument after all options. If neither this
 nor B<-connect> are provided, falls back to attempting to connect to
 I<localhost> on port I<4433>.
+If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
 
 =back
 

--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -75,7 +75,7 @@ B<openssl> B<s_server>
 [B<-status>]
 [B<-status_verbose>]
 [B<-status_timeout> I<int>]
-[B<-proxy> I<[http[s]://][userinfo@]host[:port][/path]>]
+[B<-proxy> I<[http[s]://][userinfo@]host[:port][/path][?query][#fragment]>]
 [B<-no_proxy> I<addresses>]
 [B<-status_url> I<val>]
 [B<-status_file> I<infile>]
@@ -522,13 +522,14 @@ certificate signer that is required for certificate status requests.
 
 Sets the timeout for OCSP response to I<int> seconds.
 
-=item B<-proxy> I<[http[s]://][userinfo@]host[:port][/path]>
+=item B<-proxy> I<[http[s]://][userinfo@]host[:port][/path][?query][#fragment]>
 
 The HTTP(S) proxy server to use for reaching the OCSP server unless B<-no_proxy>
 applies, see below.
+If the host string is an IPv6 address, it must be enclosed in C<[> and C<]>.
 The proxy port defaults to 80 or 443 if the scheme is C<https>; apart from that
 the optional C<http://> or C<https://> prefix is ignored,
-as well as any userinfo and path components.
+as well as any userinfo, path, query, and fragment components.
 Defaults to the environment variable C<http_proxy> if set, else C<HTTP_PROXY>
 in case no TLS is used, otherwise C<https_proxy> if set, else C<HTTPS_PROXY>.
 

--- a/doc/man1/openssl-s_time.pod.in
+++ b/doc/man1/openssl-s_time.pod.in
@@ -9,7 +9,7 @@ openssl-s_time - SSL/TLS performance timing program
 
 B<openssl> B<s_time>
 [B<-help>]
-[B<-connect> I<host:port>]
+[B<-connect> I<host>:I<port>]
 [B<-www> I<page>]
 [B<-cert> I<filename>]
 [B<-key> I<filename>]
@@ -47,7 +47,7 @@ connection.
 
 Print out a usage message.
 
-=item B<-connect> I<host:port>
+=item B<-connect> I<host>:I<port>
 
 This specifies the host and optional port to connect to.
 If the host string is an IPv6 address, it must be enclosed in C<[> and C<]>.

--- a/doc/man1/openssl-s_time.pod.in
+++ b/doc/man1/openssl-s_time.pod.in
@@ -9,7 +9,7 @@ openssl-s_time - SSL/TLS performance timing program
 
 B<openssl> B<s_time>
 [B<-help>]
-[B<-connect> I<host>:I<port>]
+[B<-connect> I<host:port>]
 [B<-www> I<page>]
 [B<-cert> I<filename>]
 [B<-key> I<filename>]
@@ -47,9 +47,10 @@ connection.
 
 Print out a usage message.
 
-=item B<-connect> I<host>:I<port>
+=item B<-connect> I<host:port>
 
 This specifies the host and optional port to connect to.
+If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
 
 =item B<-www> I<page>
 

--- a/doc/man1/openssl-s_time.pod.in
+++ b/doc/man1/openssl-s_time.pod.in
@@ -50,7 +50,7 @@ Print out a usage message.
 =item B<-connect> I<host:port>
 
 This specifies the host and optional port to connect to.
-If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
+If the host string is an IPv6 address, it must be enclosed in C<[> and C<]>.
 
 =item B<-www> I<page>
 

--- a/doc/man3/BIO_s_accept.pod
+++ b/doc/man3/BIO_s_accept.pod
@@ -177,16 +177,16 @@ BIO_set_bind_mode(), BIO_get_bind_mode() and BIO_do_accept() are macros.
 BIO_do_accept(),
 BIO_set_accept_name(), BIO_set_accept_port(), BIO_set_nbio_accept(),
 BIO_set_accept_bios(), BIO_set_accept_ip_family(), and BIO_set_bind_mode()
-return 1 for success and <=0 for failure.
+return 1 for success and <= 0 for failure.
 
 BIO_get_accept_name() returns the accept name or NULL on error.
 BIO_get_peer_name() returns the peer name or NULL on error.
 
 BIO_get_accept_port() returns the accept port as a string or NULL on error.
 BIO_get_peer_port() returns the peer port as a string or NULL on error.
-BIO_get_accept_ip_family() returns the IP family or <=0 on error.
+BIO_get_accept_ip_family() returns the IP family or <= 0 on error.
 
-BIO_get_bind_mode() returns the set of B<BIO_BIND> flags, or <=0 on failure.
+BIO_get_bind_mode() returns the set of B<BIO_BIND> flags, or <= 0 on failure.
 
 BIO_new_accept() returns a BIO or NULL on error.
 

--- a/doc/man3/BIO_s_connect.pod
+++ b/doc/man3/BIO_s_connect.pod
@@ -64,7 +64,7 @@ a single call: that is it creates a new connect BIO with hostname B<name>.
 
 BIO_set_conn_hostname() uses the string B<name> to set the hostname.
 The hostname can be an IP address; if the address is an IPv6 one, it
-must be enclosed with brackets C<[> and C<]>.
+must be enclosed in brackets C<[> and C<]>.
 The hostname can also include the port in the form hostname:port;
 see L<BIO_parse_hostserv(3)> and BIO_set_conn_port() for details.
 

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -391,8 +391,10 @@ If TLS is not used this defaults to the value of
 the environment variable C<http_proxy> if set, else C<HTTP_PROXY>.
 Otherwise defaults to the value of C<https_proxy> if set, else C<HTTPS_PROXY>.
 An empty proxy string specifies not to use a proxy.
-Else the format is C<[http[s]://]address[:port][/path]>,
-where any path given is ignored.
+Otherwise the format is
+C<[http[s]://][userinfo@]host[:port][/path][?query][#fragment]>,
+where any given userinfo, path, query, and fragment is ignored.
+If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
 The default port number is 80, or 443 in case C<https:> is given.
 
 OSSL_CMP_CTX_set1_no_proxy() sets the list of server hostnames not to use

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -394,7 +394,7 @@ An empty proxy string specifies not to use a proxy.
 Otherwise the format is
 C<[http[s]://][userinfo@]host[:port][/path][?query][#fragment]>,
 where any given userinfo, path, query, and fragment is ignored.
-If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
+If the host string is an IPv6 address, it must be enclosed in C<[> and C<]>.
 The default port number is 80, or 443 in case C<https:> is given.
 
 OSSL_CMP_CTX_set1_no_proxy() sets the list of server hostnames not to use

--- a/doc/man3/OSSL_HTTP_parse_url.pod
+++ b/doc/man3/OSSL_HTTP_parse_url.pod
@@ -42,8 +42,12 @@ take any further default value from the C<HTTP_PROXY>
 environment variable, or from C<HTTPS_PROXY> if I<use_ssl> is nonzero.
 If I<no_proxy> is NULL, take any default exclusion value from the C<no_proxy>
 environment variable, or else from C<NO_PROXY>.
-Return the determined proxy hostname unless the exclusion contains I<server>.
+Return the determined proxy host unless the exclusion value,
+which is a list of proxy hosts separated by C<,> and/or whitespace,
+contains I<server>.
 Otherwise return NULL.
+In case I<server> is a string enclosed with C<[> and C<]>, it is assumed to be
+an escaped IPv6 address and so the C<[> and C<]> are ignored for the comparison.
 
 OSSL_parse_url() parses its input string I<url> as a URL of the form
 C<[scheme://][userinfo@]host[:port][/path][?query][#fragment]> and splits it up

--- a/doc/man3/OSSL_HTTP_parse_url.pod
+++ b/doc/man3/OSSL_HTTP_parse_url.pod
@@ -53,13 +53,14 @@ OSSL_parse_url() parses its input string I<url> as a URL of the form
 C<[scheme://][userinfo@]host[:port][/path][?query][#fragment]> and splits it up
 into scheme, userinfo, host, port, path, query, and fragment components.
 The host (or server) component may be a DNS name or an IP address
-where IPv6 addresses should be enclosed in square brackets C<[> and C<]>.
+where IPv6 addresses must be enclosed with square brackets C<[> and C<]>.
 The port component is optional and defaults to C<0>.
 If given, it must be in decimal form.  If the I<pport_num> argument is not NULL
 the integer value of the port number is assigned to I<*pport_num> on success.
 The path component is also optional and defaults to C</>.
 Each non-NULL result pointer argument I<pscheme>, I<puser>, I<phost>, I<pport>,
 I<ppath>, I<pquery>, and I<pfrag>, is assigned the respective url component.
+Any IPv6 address in I<*phost> is enclosed with C<[> and C<]>.
 On success, they are guaranteed to contain non-NULL string pointers, else NULL.
 It is the responsibility of the caller to free them using L<OPENSSL_free(3)>.
 If I<pquery> is NULL, any given query component is handled as part of the path.
@@ -74,7 +75,7 @@ and the scheme is C<https>, else 0.
 The port component is optional and defaults to C<443> if the scheme is C<https>,
 else C<80>.
 Note that relative paths must be given with a leading C</>,
-otherwise the first path element is interpreted as the hostname.
+otherwise the first path element is interpreted as the host.
 
 Calling the deprecated function OCSP_parse_url(url, host, port, path, ssl)
 is equivalent to

--- a/doc/man3/OSSL_HTTP_parse_url.pod
+++ b/doc/man3/OSSL_HTTP_parse_url.pod
@@ -46,21 +46,21 @@ Return the determined proxy host unless the exclusion value,
 which is a list of proxy hosts separated by C<,> and/or whitespace,
 contains I<server>.
 Otherwise return NULL.
-In case I<server> is a string enclosed with C<[> and C<]>, it is assumed to be
-an escaped IPv6 address and so the C<[> and C<]> are ignored for the comparison.
+When I<server> is a string delimited by C<[> and C<]>, which are used for IPv6
+addresses, the enclosing C<[> and C<]> are stripped prior to comparison.
 
 OSSL_parse_url() parses its input string I<url> as a URL of the form
 C<[scheme://][userinfo@]host[:port][/path][?query][#fragment]> and splits it up
 into scheme, userinfo, host, port, path, query, and fragment components.
 The host (or server) component may be a DNS name or an IP address
-where IPv6 addresses must be enclosed with square brackets C<[> and C<]>.
+where IPv6 addresses must be enclosed in square brackets C<[> and C<]>.
 The port component is optional and defaults to C<0>.
 If given, it must be in decimal form.  If the I<pport_num> argument is not NULL
 the integer value of the port number is assigned to I<*pport_num> on success.
 The path component is also optional and defaults to C</>.
 Each non-NULL result pointer argument I<pscheme>, I<puser>, I<phost>, I<pport>,
 I<ppath>, I<pquery>, and I<pfrag>, is assigned the respective url component.
-Any IPv6 address in I<*phost> is enclosed with C<[> and C<]>.
+Any IPv6 address in I<*phost> is enclosed in C<[> and C<]>.
 On success, they are guaranteed to contain non-NULL string pointers, else NULL.
 It is the responsibility of the caller to free them using L<OPENSSL_free(3)>.
 If I<pquery> is NULL, any given query component is handled as part of the path.

--- a/doc/man3/OSSL_HTTP_transfer.pod
+++ b/doc/man3/OSSL_HTTP_transfer.pod
@@ -77,12 +77,14 @@ If TLS is not used this defaults to the environment variable C<http_proxy>
 if set, else C<HTTP_PROXY>.
 If I<use_ssl> != 0 it defaults to C<https_proxy> if set, else C<HTTPS_PROXY>.
 An empty proxy string C<""> forbids using a proxy.
-Else the format is
+Otherwise the format is
 C<[http[s]://][userinfo@]host[:port][/path][?query][#fragment]>,
 where any userinfo, path, query, and fragment given is ignored.
+If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
 The default proxy port number is 80, or 443 in case "https:" is given.
 The HTTP client functions connect via the given proxy unless the I<server>
-is found in the optional list I<no_proxy> of proxy hostnames (if not NULL;
+is found in the optional list I<no_proxy> of proxy hostnames or IP addresses
+separated by C<,> and/or whitespace (if not NULL;
 default is the environment variable C<no_proxy> if set, else C<NO_PROXY>).
 Proxying plain HTTP is supported directly,
 while using a proxy for HTTPS connections requires a suitable callback function

--- a/doc/man3/OSSL_HTTP_transfer.pod
+++ b/doc/man3/OSSL_HTTP_transfer.pod
@@ -77,10 +77,10 @@ If TLS is not used this defaults to the environment variable C<http_proxy>
 if set, else C<HTTP_PROXY>.
 If I<use_ssl> != 0 it defaults to C<https_proxy> if set, else C<HTTPS_PROXY>.
 An empty proxy string C<""> forbids using a proxy.
-Otherwise the format is
+Otherwise, the format is
 C<[http[s]://][userinfo@]host[:port][/path][?query][#fragment]>,
 where any userinfo, path, query, and fragment given is ignored.
-If the host string is an IPv6 address, it must be enclosed with C<[> and C<]>.
+If the host string is an IPv6 address, it must be enclosed in C<[> and C<]>.
 The default proxy port number is 80, or 443 in case "https:" is given.
 The HTTP client functions connect via the given proxy unless the I<server>
 is found in the optional list I<no_proxy> of proxy hostnames or IP addresses

--- a/test/recipes/80-test_cmp_http_data/Mock/test.cnf
+++ b/test/recipes/80-test_cmp_http_data/Mock/test.cnf
@@ -17,11 +17,11 @@ policies = certificatePolicies
 
 [Mock] # the built-in OpenSSL CMP mock server
 # no_check_time = 1
-server_host = 127.0.0.1 # localhost
+server_host = * # to be determined by server: 127.0.0.1 or ::1 (localhost)
 server_port = 0 # 0 means that the port is determined by the server
 server_tls = $server_port
 server_cert = server.crt
-server = $server_host:$server_port
+# server = $server_host:$server_port
 server_path = pkix/
 path = $server_path
 ca_dn = /CN=Root CA

--- a/test/recipes/80-test_cmp_http_data/test_connection.csv
+++ b/test/recipes/80-test_cmp_http_data/test_connection.csv
@@ -2,7 +2,7 @@ expected,description, -section,val, -server,val, -proxy,val, -no_proxy,val, -tls
 ,Message transfer options:,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,
 1,default config, -section,,,,,,,,BLANK,,,,BLANK,,BLANK,,BLANK,
-disabled as not supported by some host IP configurations,server domain name, -section,, -server,localhost:_SERVER_PORT,,,,,,,,,,,,,,
+disabled as not supported by some host IP configurations,server domain name, -section,, -server,_SERVER_HOST:_SERVER_PORT,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,
 0,wrong server, -section,, -server,xn--rksmrgs-5wao1o.example.com:_SERVER_PORT,,,,,BLANK,,,, -msg_timeout,1,BLANK,,BLANK,
 0,wrong server port, -section,, -server,_SERVER_HOST:99,,,,,BLANK,,,, -msg_timeout,1,BLANK,,BLANK,


### PR DESCRIPTION
This is going to fix at least one of the issue(s) reported in #22467,
namely that the tests fail in case the mock server happens to use IPv6 rather than IPv4,
by correcting the handling of IPv6 server host (localhost `::1`) in the test driver `80-test_cmp_http.t`
and improving `OSSL_HTTP_adapt_proxy()` (handling of escaped IPv6 host addresses and of whitespace in `no_proxy`).

On this occasion, in separate commits, also
fix completion with default port for IPv6 host addresses in `OSSL_HTTP_open()`,
fix two wrong checks for error return codes in `http_server_init()`
and related whitespace nits (: '<=0' -> '<= 0') in `BIO_s_accept.pod`,
point out that  `http_server_init()` many lead to IPv4 or IPv6 use,
fix doc details on IPv6 host addresses and of whitespace in `no_proxy`


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
