### PR TITLE
limit bignums to 128 bytes in fuzzer

### DIFF
--- a/fuzz/bignum.c
+++ b/fuzz/bignum.c
@@ -52,12 +52,12 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
      */
     if (len > 2) {
         len -= 3;
-        /* limit l1, l2, and l3 to be no more than 128 bytes */
-        l1 = ((buf[0] * len) / 255) % 128;
+        /* limit l1, l2, and l3 to be no more than 512 bytes */
+        l1 = ((buf[0] * len) / 255) % 512;
         ++buf;
-        l2 = ((buf[0] * (len - l1)) / 255) % 128;
+        l2 = ((buf[0] * (len - l1)) / 255) % 512;
         ++buf;
-        l3 = (len - l1 - l2) % 128;
+        l3 = (len - l1 - l2) % 512;
 
         s1 = buf[0] & 1;
         s3 = buf[0] & 4;

--- a/fuzz/bignum.c
+++ b/fuzz/bignum.c
@@ -52,11 +52,12 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
      */
     if (len > 2) {
         len -= 3;
-        l1 = (buf[0] * len) / 255;
+        /* limit l1, l2, and l3 to be no more than 128 bytes */
+        l1 = ((buf[0] * len) / 255) % 128;
         ++buf;
-        l2 = (buf[0] * (len - l1)) / 255;
+        l2 = ((buf[0] * (len - l1)) / 255) % 128;
         ++buf;
-        l3 = len - l1 - l2;
+        l3 = (len - l1 - l2) % 128;
 
         s1 = buf[0] & 1;
         s3 = buf[0] & 4;


### PR DESCRIPTION
@toralf discovered that running the bignum fuzzer was spending large amounts of time doing computations for large bignums under the AFL fuzzer, leading to reported hangs/delays.  Like we do for several other fuzzers, limit the input size for a bignum to no more than 512 bytes to prevent those warnings
