### PR TITLE
Fix typing on call to interlockedExchange for windows

### DIFF
--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -365,7 +365,7 @@ static struct rcu_qp *update_qp(CRYPTO_RCU_LOCK *lock)
 
     /* update the reader index to be the prior qp */
     tmp = lock->current_alloc_idx;
-    InterlockedExchange(&lock->reader_idx, tmp);
+    InterlockedExchange((LONG volatile *)&lock->reader_idx, tmp);
 
     /* wake up any waiters */
     ossl_crypto_condvar_broadcast(lock->alloc_signal);


### PR DESCRIPTION
mingw is complaining on builds about the use of InterlockedExchange on a uint32_t type, as the input parameter here is expected to be LONG (defined as signed 32 bit on all versions of windows).

the input value (reader_idx) will never grow larger than the group size of the lock (nominally 2, but always a reasonably small value), so it should be safe to just cast it to a signed int here.
