### PR TITLE
Add NonStop KLT Configuration for new platform kernel threading model

### DIFF
--- a/Configurations/50-nonstop.conf
+++ b/Configurations/50-nonstop.conf
@@ -174,6 +174,15 @@
     },
 
     ######################################################################
+    # Build models
+    'nonstop-model-klt' => {
+        template         => 1,
+        defines          => ['_KLT_MODEL_',
+                             '_REENTRANT', '_THREAD_SUPPORT_FUNCTIONS'],
+        ex_libs          => '-lklt',
+    },
+
+    ######################################################################
     # Now for the entries themselves, let's combine things!
     'nonstop-nsx' => {
         inherit_from     => [ 'nonstop-common',
@@ -210,6 +219,28 @@
         multilib         => '64-put',
         multibin         => '64-put',
         disable          => ['atexit'],
+    },
+    'nonstop-nsx_64_klt' => {
+        inherit_from     => [ 'nonstop-common',
+                              'nonstop-archenv-x86_64-oss',
+                              'nonstop-lp64-x86_64',
+                              'nonstop-efloat-x86_64',
+                              'nonstop-model-klt' ],
+        multilib         => '64-klt',
+        multibin         => '64-klt',
+        disable          => ['atexit'],
+    },
+    'nonstop-nsx_g' => {
+        inherit_from     => [ 'nonstop-common',
+                              'nonstop-archenv-x86_64-guardian',
+                              'nonstop-ilp32', 'nonstop-nfloat-x86_64' ],
+        disable          => ['threads','atexit'],
+    },
+    'nonstop-nsx_g_tandem' => {
+        inherit_from     => [ 'nonstop-common',
+                              'nonstop-archenv-x86_64-guardian',
+                              'nonstop-ilp32', 'nonstop-tfloat-x86_64' ],
+        disable          => ['threads','atexit'],
     },
     'nonstop-nsv' => {
         inherit_from     => [ 'nonstop-nsx' ],

--- a/NOTES-NONSTOP.md
+++ b/NOTES-NONSTOP.md
@@ -30,8 +30,15 @@ for each on the TNS/X (L-Series) platform:
 
  * `nonstop-nsx` or default will select an unthreaded 32-bit build.
  * `nonstop-nsx_64` selects an unthreaded 64-bit memory and file length build.
+ * `nonstop-nsx_64_klt` selects the 64-bit memory and file length KLT build.
  * `nonstop-nsx_put` selects the PUT build.
  * `nonstop-nsx_64_put` selects the 64-bit memory and file length PUT build.
+
+The KLT threading model is a newly released model on NonStop. It implements
+kernel-level threading. KLT provides much closer threading to what OpenSSL
+uses for Linux-like threading models. KLT continues to use the pthread library
+API. There is no supported 32-bit or Guardian builds for KLT. Note: KLT is
+not currently available but is planned for post-2024.
 
 The SPT threading model is no longer supported as of OpenSSL 3.2.
 


### PR DESCRIPTION
This fix supports the new NonStop KLT threading model, including configurations and documentation for using this model.

Fixes: fix-24175
##### Checklist
- [X] documentation is added or updated
