### PR TITLE
Make tracing for EndOfEarlyData message more accurate (s_server)

### DIFF
--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -1697,6 +1697,10 @@ static int ssl_print_handshake(BIO *bio, const SSL_CONNECTION *sc, int server,
             return 0;
         break;
 
+    case SSL3_MT_END_OF_EARLY_DATA:
+        BIO_indent(bio, indent, 80);
+        break;
+
     default:
         BIO_indent(bio, indent + 2, 80);
         BIO_puts(bio, "Unsupported, hex dump follows:\n");

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -1698,7 +1698,8 @@ static int ssl_print_handshake(BIO *bio, const SSL_CONNECTION *sc, int server,
         break;
 
     case SSL3_MT_END_OF_EARLY_DATA:
-        BIO_indent(bio, indent, 80);
+        if (msglen != 0)
+            ssl_print_hex(bio, indent + 2, "unexpected value", msg, msglen);
         break;
 
     default:

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -1671,6 +1671,7 @@ static int ssl_print_handshake(BIO *bio, const SSL_CONNECTION *sc, int server,
         ssl_print_hex(bio, indent + 2, "verify_data", msg, msglen);
         break;
 
+    case SSL3_MT_END_OF_EARLY_DATA:
     case SSL3_MT_SERVER_DONE:
         if (msglen != 0)
             ssl_print_hex(bio, indent + 2, "unexpected value", msg, msglen);
@@ -1695,11 +1696,6 @@ static int ssl_print_handshake(BIO *bio, const SSL_CONNECTION *sc, int server,
         if (!ssl_trace_list(bio, indent + 2, msg, msglen, 1,
                             ssl_key_update_tbl))
             return 0;
-        break;
-
-    case SSL3_MT_END_OF_EARLY_DATA:
-        if (msglen != 0)
-            ssl_print_hex(bio, indent + 2, "unexpected value", msg, msglen);
         break;
 
     default:


### PR DESCRIPTION
When using s_server together with early data, the message EndOfEarlyData is not correctly logged but it says "Unsupported, hex dump follows".


The PR adds the case SSL3_MT_END_OF_EARLY_DATA in
`static int ssl_print_handshake(BIO *bio, 
const SSL_CONNECTION *sc,
int server,
const unsigned char *msg, size_t msglen,
int indent) {}`

This results in improved logging:
``` shell
# log snip start
Received TLS Record
Header:
  Version = TLS 1.2 (0x303)
  Content Type = ApplicationData (23)
  Length = 21
  Inner Content Type = Handshake (22)
    EndOfEarlyData, Length=0
# log snip end
```

---
**How to reproduce current log behavior:**
1. Start s_server: `openssl s_server -cert ./server_cert.pem -key ./server_key.pem -tls1_3 -early_data -no_anti_replay -trace`
    - hint: -anit_replay is only active because the client won't close the connection with close_notify and I want to prevent that s_server is throwing away the session information
3. Start s_client: `openssl s_client -connect localhost:4433 -verifyCAfile ./root_ca_cert.pem -tls1_3 -sess_out session.pem`
4. Stop s_client
5. Start s_client: `openssl s_client -connect localhost:4433 -verifyCAfile ./root_ca_cert.pem -tls1_3 -sess_in session.pem -early_data earlyData.txt`

The current logs show:
``` shell
# log snip start
Received TLS Record
Header:
  Version = TLS 1.2 (0x303)
  Content Type = ApplicationData (23)
  Length = 21
  Inner Content Type = Handshake (22)
    EndOfEarlyData, Length=0
      Unsupported, hex dump follows:
# log snip end
```




    