### PR TITLE
FIPS: add indicator for using EdDSA with a precomputed digest

### DIFF
--- a/apps/fipsinstall.c
+++ b/apps/fipsinstall.c
@@ -38,7 +38,7 @@ typedef enum OPTION_choice {
     OPT_NO_LOG, OPT_CORRUPT_DESC, OPT_CORRUPT_TYPE, OPT_QUIET, OPT_CONFIG,
     OPT_NO_CONDITIONAL_ERRORS,
     OPT_NO_SECURITY_CHECKS,
-    OPT_TLS_PRF_EMS_CHECK, OPT_NO_SHORT_MAC,
+    OPT_TLS_PRF_EMS_CHECK, OPT_EDDSA_NO_VERIFY_DIGESTED, OPT_NO_SHORT_MAC,
     OPT_DISALLOW_SIGNATURE_X931_PADDING,
     OPT_DISALLOW_DRGB_TRUNC_DIGEST,
     OPT_HKDF_DIGEST_CHECK,
@@ -80,6 +80,8 @@ const OPTIONS fipsinstall_options[] = {
      "Forces self tests to run once on module installation"},
     {"ems_check", OPT_TLS_PRF_EMS_CHECK, '-',
      "Enable the run-time FIPS check for EMS during TLS1_PRF"},
+    {"eddsa_no_verify_digested", OPT_EDDSA_NO_VERIFY_DIGESTED, '-',
+     "Disallow Ed25519/Ed448 verification of pre-hashed data"},
     {"no_short_mac", OPT_NO_SHORT_MAC, '-', "Disallow short MAC output"},
     {"no_drbg_truncated_digests", OPT_DISALLOW_DRGB_TRUNC_DIGEST, '-',
      "Disallow truncated digests with Hash and HMAC DRBGs"},
@@ -136,6 +138,7 @@ typedef struct {
     unsigned int conditional_errors : 1;
     unsigned int security_checks : 1;
     unsigned int tls_prf_ems_check : 1;
+    unsigned int eddsa_no_verify_digested : 1;
     unsigned int no_short_mac : 1;
     unsigned int drgb_no_trunc_dgst : 1;
     unsigned int hkdf_digest_check : 1;
@@ -162,6 +165,7 @@ static const FIPS_OPTS pedantic_opts = {
     1,      /* conditional_errors */
     1,      /* security_checks */
     1,      /* tls_prf_ems_check */
+    1,      /* eddsa_no_verify_digested */
     1,      /* no_short_mac */
     1,      /* drgb_no_trunc_dgst */
     1,      /* hkdf_digest_check */
@@ -188,6 +192,7 @@ static FIPS_OPTS fips_opts = {
     1,      /* conditional_errors */
     1,      /* security_checks */
     0,      /* tls_prf_ems_check */
+    0,      /* eddsa_no_verify_digested */
     0,      /* no_short_mac */
     0,      /* drgb_no_trunc_dgst */
     0,      /* hkdf_digest_check */
@@ -327,6 +332,8 @@ static int write_config_fips_section(BIO *out, const char *section,
                       opts->security_checks ? "1" : "0") <= 0
         || BIO_printf(out, "%s = %s\n", OSSL_PROV_FIPS_PARAM_TLS1_PRF_EMS_CHECK,
                       opts->tls_prf_ems_check ? "1" : "0") <= 0
+        || BIO_printf(out, "%s = %s\n", OSSL_PROV_FIPS_PARAM_EDDSA_NO_VERIFY_DIGESTED,
+                      opts->eddsa_no_verify_digested ? "1" : "0") <= 0
         || BIO_printf(out, "%s = %s\n", OSSL_PROV_PARAM_NO_SHORT_MAC,
                       opts->no_short_mac ? "1" : "0") <= 0
         || BIO_printf(out, "%s = %s\n", OSSL_PROV_PARAM_DRBG_TRUNC_DIGEST,
@@ -552,6 +559,9 @@ int fipsinstall_main(int argc, char **argv)
             break;
         case OPT_TLS_PRF_EMS_CHECK:
             fips_opts.tls_prf_ems_check = 1;
+            break;
+        case OPT_EDDSA_NO_VERIFY_DIGESTED:
+            fips_opts.eddsa_no_verify_digested = 1;
             break;
         case OPT_NO_SHORT_MAC:
             fips_opts.no_short_mac = 1;

--- a/doc/man1/openssl-fipsinstall.pod.in
+++ b/doc/man1/openssl-fipsinstall.pod.in
@@ -23,6 +23,7 @@ B<openssl fipsinstall>
 [B<-no_conditional_errors>]
 [B<-no_security_checks>]
 [B<-ems_check>]
+[B<-eddsa_no_verify_digested>]
 [B<-no_drbg_truncated_digests>]
 [B<-hkdf_digest_check>]
 [B<-tls13_kdf_digest_check>]
@@ -201,6 +202,12 @@ turn off the check at compile time.
 Configure the module to enable a run-time Extended Master Secret (EMS) check
 when using the TLS1_PRF KDF algorithm. This check is disabled by default.
 See RFC 7627 for information related to EMS.
+
+=item B<-eddsa_no_verify_digested>
+
+Configure the module to not allow EdDSA to verify from a message digest
+directly.  Instead, EdDSA will digest the message itself.
+This check is disabled by default.
 
 =item B<-no_short_mac>
 

--- a/doc/man7/EVP_SIGNATURE-ED25519.pod
+++ b/doc/man7/EVP_SIGNATURE-ED25519.pod
@@ -38,9 +38,9 @@ instance, a nonempty context-string is not permitted.
 
 =head2 ED25519 and ED448 Signature Parameters
 
-Two parameters can be set during signing or verification: the EdDSA
-B<instance name> and the B<context-string value>.  They can be set by
-passing an OSSL_PARAM array to EVP_DigestSignInit_ex().
+The following parameters can be set during signing or verification by
+passing an OSSL_PARAM array to EVP_DigestSignInit_ex() or
+EVP_PKEY_CTX_set_params():
 
 =over 4
 
@@ -56,9 +56,14 @@ One of the five strings "Ed25519", "Ed25519ctx", "Ed25519ph", "Ed448", "Ed448ph"
 
 A string of octets with length at most 255.
 
+=item * "verify-digested" (B<OSSL_SIGNATURE_PARAM_EDDSA_VERIFY_DIGESTED> <integer>
+
+If set to a nonzero value, EdDSA can be used to verify a hash of a message.
+If zero, EdDSA will digest the message internally.
+
 =back
 
-Both of these parameters are optional.
+All of these parameters are optional.
 
 If the instance name is not specified, then the default "Ed25519" or
 "Ed448" is used.
@@ -81,6 +86,8 @@ EVP_PKEY_CTX_get_params().
 =item * "instance" (B<OSSL_SIGNATURE_PARAM_INSTANCE>) <utf8 string>
 
 =item * "context-string" (B<OSSL_SIGNATURE_PARAM_CONTEXT_STRING>) <octet string>
+
+=item * "fips-indicator" (B<OSSL_SIGNATURE_PARAM_FIPS_APPROVED_INDICATOR>) <integer>
 
 =back
 

--- a/include/openssl/fips_names.h
+++ b/include/openssl/fips_names.h
@@ -62,6 +62,13 @@ extern "C" {
 # define OSSL_PROV_FIPS_PARAM_TLS1_PRF_EMS_CHECK "tls1-prf-ems-check"
 
 /*
+ * A boolean that determines if Ed448 and Ed25519 are forbidden to process
+ * a pre-hashed message or not.
+ * This is disabled by default.
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+# define OSSL_PROV_FIPS_PARAM_EDDSA_NO_VERIFY_DIGESTED "eddsa-no-verify-digested"
+/*
  * A boolean that determines if the runtime FIPS check for undersized MAC output
  * is performed.
  * This is enabled by default.

--- a/providers/common/include/prov/fipscommon.h
+++ b/providers/common/include/prov/fipscommon.h
@@ -12,6 +12,7 @@
 
 int FIPS_security_check_enabled(OSSL_LIB_CTX *libctx);
 int FIPS_tls_prf_ems_check(OSSL_LIB_CTX *libctx);
+int FIPS_eddsa_no_verify_digested(OSSL_LIB_CTX *libctx);
 int FIPS_no_short_mac(OSSL_LIB_CTX *libctx);
 int FIPS_restricted_drbg_digests_enabled(OSSL_LIB_CTX *libctx);
 int FIPS_hkdf_digest_check(OSSL_LIB_CTX *libctx);

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -87,6 +87,7 @@ typedef struct fips_global_st {
     SELF_TEST_POST_PARAMS selftest_params;
     FIPS_OPTION fips_security_checks;
     FIPS_OPTION fips_tls1_prf_ems_check;
+    FIPS_OPTION fips_eddsa_no_verify_digested;
     FIPS_OPTION fips_no_short_mac;
     FIPS_OPTION fips_restricted_drgb_digests;
     FIPS_OPTION fips_hkdf_digest_check;
@@ -121,6 +122,7 @@ void *ossl_fips_prov_ossl_ctx_new(OSSL_LIB_CTX *libctx)
         return NULL;
     init_fips_option(&fgbl->fips_security_checks, 1);
     init_fips_option(&fgbl->fips_tls1_prf_ems_check, 0); /* Disabled by default */
+    init_fips_option(&fgbl->fips_eddsa_no_verify_digested, 0);
     init_fips_option(&fgbl->fips_no_short_mac, 1);
     init_fips_option(&fgbl->fips_restricted_drgb_digests, 0);
     init_fips_option(&fgbl->fips_hkdf_digest_check, 0);
@@ -202,7 +204,7 @@ static int fips_get_params_from_core(FIPS_GLOBAL *fgbl)
     * OSSL_PROV_FIPS_PARAM_SECURITY_CHECKS and
     * OSSL_PROV_FIPS_PARAM_TLS1_PRF_EMS_CHECK are not self test parameters.
     */
-    OSSL_PARAM core_params[27], *p = core_params;
+    OSSL_PARAM core_params[28], *p = core_params;
 
     *p++ = OSSL_PARAM_construct_utf8_ptr(
             OSSL_PROV_PARAM_CORE_MODULE_FILENAME,
@@ -239,6 +241,8 @@ static int fips_get_params_from_core(FIPS_GLOBAL *fgbl)
                         fips_security_checks);
     FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_TLS1_PRF_EMS_CHECK,
                         fips_tls1_prf_ems_check);
+    FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_EDDSA_NO_VERIFY_DIGESTED,
+                        fips_eddsa_no_verify_digested);
     FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_NO_SHORT_MAC,
                         fips_no_short_mac);
     FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_DRBG_TRUNC_DIGEST,
@@ -320,6 +324,8 @@ static int fips_get_params(void *provctx, OSSL_PARAM params[])
                      fips_security_checks);
     FIPS_FEATURE_GET(fgbl, OSSL_PROV_PARAM_TLS1_PRF_EMS_CHECK,
                      fips_tls1_prf_ems_check);
+    FIPS_FEATURE_GET(fgbl, OSSL_PROV_FIPS_PARAM_EDDSA_NO_VERIFY_DIGESTED,
+                     fips_eddsa_no_verify_digested);
     FIPS_FEATURE_GET(fgbl, OSSL_PROV_PARAM_NO_SHORT_MAC,
                      fips_no_short_mac);
     FIPS_FEATURE_GET(fgbl, OSSL_PROV_PARAM_DRBG_TRUNC_DIGEST,
@@ -889,6 +895,7 @@ int OSSL_provider_init_int(const OSSL_CORE_HANDLE *handle,
 
     FIPS_SET_OPTION(fgbl, fips_security_checks);
     FIPS_SET_OPTION(fgbl, fips_tls1_prf_ems_check);
+    FIPS_SET_OPTION(fgbl, fips_eddsa_no_verify_digested);
     FIPS_SET_OPTION(fgbl, fips_no_short_mac);
     FIPS_SET_OPTION(fgbl, fips_restricted_drgb_digests);
     FIPS_SET_OPTION(fgbl, fips_hkdf_digest_check);
@@ -1106,6 +1113,7 @@ int BIO_snprintf(char *buf, size_t n, const char *format, ...)
 
 FIPS_FEATURE_CHECK(FIPS_security_check_enabled, fips_security_checks)
 FIPS_FEATURE_CHECK(FIPS_tls_prf_ems_check, fips_tls1_prf_ems_check)
+FIPS_FEATURE_CHECK(FIPS_eddsa_no_verify_digested, fips_eddsa_no_verify_digested)
 FIPS_FEATURE_CHECK(FIPS_no_short_mac, fips_no_short_mac)
 FIPS_FEATURE_CHECK(FIPS_restricted_drbg_digests_enabled,
                    fips_restricted_drgb_digests)

--- a/test/cmp_protect_test.c
+++ b/test/cmp_protect_test.c
@@ -162,6 +162,14 @@ static int test_cmp_calc_protection_pkey(void)
 static int test_cmp_calc_protection_pkey_Ed(void)
 {
     SETUP_TEST_FIXTURE(CMP_PROTECT_TEST_FIXTURE, set_up);
+
+    /* eddsa_no_verify_digested prevents this test working */
+    if (fips_provider_version_match(libctx, ">=3.4.0")) {
+        tear_down(fixture);
+        fixture = NULL;
+        return TEST_skip("incompatible FIPS provider version");
+    }
+
     fixture->pubkey = prot_Ed_key;
     if (!TEST_true(OSSL_CMP_CTX_set1_pkey(fixture->cmp_ctx, prot_Ed_key))
         || !TEST_ptr(fixture->msg = load_pkimsg(genm_prot_Ed_f, libctx))) {

--- a/test/recipes/30-test_evp_data/evppkey_ecx.txt
+++ b/test/recipes/30-test_evp_data/evppkey_ecx.txt
@@ -255,10 +255,18 @@ Input = ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a
 Output = dc2a4459e7369633a52b1bf277839a00201009a3efbf3ecb69bea2186c26b58909351fc9ac90b3ecfdfbc7c66431e0303dca179c138ac17ad9bef1177331a704
 
 # Verify test
+FIPSversion = <3.4.0
 OneShotDigestVerify = NULL
 Key = ED25519-1-PUBLIC
 Input = ""
 Output = e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b
+
+FIPSversion = >=3.4.0
+Availablein = fips
+OneShotDigestVerify = NULL
+Key = ED25519-1-PUBLIC
+Input = ""
+Result = VERIFY_ERROR
 
 # Corrupted input
 OneShotDigestVerify = NULL
@@ -300,10 +308,18 @@ Key = ED25519-1-Raw
 Input = ""
 Output = e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b
 
+FIPSversion = <3.4.0
 OneShotDigestVerify = NULL
 Key = ED25519-1-PUBLIC-Raw
 Input = ""
 Output = e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b
+
+FIPSversion = >=3.4.0
+Availablein = fips
+OneShotDigestVerify = NULL
+Key = ED25519-1-PUBLIC-Raw
+Input = ""
+Result = VERIFY_ERROR
 
 #Signature maleability test.
 #Same as the verify operation above but with the order added to s
@@ -475,10 +491,18 @@ Input = 6ddf802e1aae4986935f7f981ba3f0351d6273c0a0c22c9c0e8339168e675412a3debfaf
 Output = e301345a41a39a4d72fff8df69c98075a0cc082b802fc9b2b6bc503f926b65bddf7f4c8f1cb49f6396afc8a70abe6d8aef0db478d4c6b2970076c6a0484fe76d76b3a97625d79f1ce240e7c576750d295528286f719b413de9ada3e8eb78ed573603ce30d8bb761785dc30dbc320869e1a00
 
 # Verify test
+FIPSversion = <3.4.0
 OneShotDigestVerify = NULL
 Key = ED448-1-PUBLIC
 Input = ""
 Output = 533a37f6bbe457251f023c0d88f976ae2dfb504a843e34d2074fd823d41a591f2b233f034f628281f2fd7a22ddd47d7828c59bd0a21bfd3980ff0d2028d4b18a9df63e006c5d1c2d345b925d8dc00b4104852db99ac5c7cdda8530a113a0f4dbb61149f05a7363268c71d95808ff2e652600
+
+FIPSversion = >=3.4.0
+Availablein = fips
+OneShotDigestVerify = NULL
+Key = ED448-1-PUBLIC
+Input = ""
+Result = VERIFY_ERROR
 
 # Corrupted input
 OneShotDigestVerify = NULL
@@ -516,10 +540,17 @@ Key = ED448-1-Raw
 Input = ""
 Output = 533a37f6bbe457251f023c0d88f976ae2dfb504a843e34d2074fd823d41a591f2b233f034f628281f2fd7a22ddd47d7828c59bd0a21bfd3980ff0d2028d4b18a9df63e006c5d1c2d345b925d8dc00b4104852db99ac5c7cdda8530a113a0f4dbb61149f05a7363268c71d95808ff2e652600
 
+FIPSversion = <3.4.0
 OneShotDigestVerify = NULL
 Key = ED448-1-PUBLIC-Raw
 Input = ""
 Output = 533a37f6bbe457251f023c0d88f976ae2dfb504a843e34d2074fd823d41a591f2b233f034f628281f2fd7a22ddd47d7828c59bd0a21bfd3980ff0d2028d4b18a9df63e006c5d1c2d345b925d8dc00b4104852db99ac5c7cdda8530a113a0f4dbb61149f05a7363268c71d95808ff2e652600
+
+FIPSversion = >=3.4.0
+OneShotDigestVerify = NULL
+Key = ED448-1-PUBLIC-Raw
+Input = ""
+Result = VERIFY_ERROR
 
 #Signature malelability test.
 #Same as the verify operation above but with the order added to s
@@ -919,3 +950,23 @@ Input = 616263
 Ctrl = instance:Ed448ph
 Ctrl = hexcontext-string:666f6f
 Output = c32299d46ec8ff02b54540982814dce9a05812f81962b649d528095916a2aa481065b1580423ef927ecf0af5888f90da0f6a9a85ad5dc3f280d91224ba9911a3653d00e484e2ce232521481c8658df304bb7745a73514cdb9bf3e15784ab71284f8d0704a608c54a6b62d97beb511d132100
+
+Title = FIPS indicator tests
+
+FIPSversion = >=3.4.0
+Availablein = fips
+OneShotDigestVerify = NULL
+Key = ED25519-1-PUBLIC
+Input = ""
+Unapproved = 1
+Ctrl = verify-digested:0
+Output = e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b
+
+FIPSversion = >=3.4.0
+Availablein = fips
+OneShotDigestVerify = NULL
+Key = ED448-1-PUBLIC
+Input = ""
+Unapproved = 1
+Ctrl = verify-digested:0
+Output = 533a37f6bbe457251f023c0d88f976ae2dfb504a843e34d2074fd823d41a591f2b233f034f628281f2fd7a22ddd47d7828c59bd0a21bfd3980ff0d2028d4b18a9df63e006c5d1c2d345b925d8dc00b4104852db99ac5c7cdda8530a113a0f4dbb61149f05a7363268c71d95808ff2e652600

--- a/util/perl/OpenSSL/paramnames.pm
+++ b/util/perl/OpenSSL/paramnames.pm
@@ -426,6 +426,7 @@ my %params = (
     'SIGNATURE_PARAM_FIPS_SIGN_CHECK' =>    "sign-check",
     'SIGNATURE_PARAM_FIPS_SIGN_X931_PAD_CHECK' => "sign-x931-pad-check",
     'SIGNATURE_PARAM_FIPS_APPROVED_INDICATOR' => '*ALG_PARAM_FIPS_APPROVED_INDICATOR',
+    'SIGNATURE_PARAM_EDDSA_VERIFY_DIGESTED' => 'verify-digested',
 
 # Asym cipher parameters
     'ASYM_CIPHER_PARAM_DIGEST' =>                   '*PKEY_PARAM_DIGEST',


### PR DESCRIPTION
NIST has mandates that a precalculated digest isn't permitted for EdDSA.
Instead the EdDSA operation needs to compute the digest.

- [x] documentation is added or updated
- [x] tests are added or updated
