### PR TITLE
github: fix quoting in github workflow for jitter tests

### DIFF
--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -207,7 +207,7 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
-      run: ./config --with-rand-seed=none enable-jitter --with-jitter-include=jitter/ --with-jitter-lib=jitter/ -DOPENSSL_DEFAULT_SEED_SRC='"JITTER"' && perl configdata.pm --dump
+      run: ./config --with-rand-seed=none enable-jitter --with-jitter-include=jitter/ --with-jitter-lib=jitter/ -DOPENSSL_DEFAULT_SEED_SRC=JITTER && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: get cpu info

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -21,7 +21,7 @@
 #include "crypto/context.h"
 
 #ifndef OPENSSL_DEFAULT_SEED_SRC
-# define OPENSSL_DEFAULT_SEED_SRC "SEED-SRC"
+# define OPENSSL_DEFAULT_SEED_SRC SEED-SRC
 #endif
 
 #ifndef FIPS_MODULE
@@ -597,7 +597,7 @@ static EVP_RAND_CTX *rand_new_seed(OSSL_LIB_CTX *libctx)
                 propq = props;
             }
         }
-        name = OPENSSL_DEFAULT_SEED_SRC;
+        name = OPENSSL_MSTR(OPENSSL_DEFAULT_SEED_SRC);
     }
 
     rand = EVP_RAND_fetch(libctx, name, propq);

--- a/doc/man3/RAND_set_DRBG_type.pod
+++ b/doc/man3/RAND_set_DRBG_type.pod
@@ -42,7 +42,7 @@ is made too late.
 The default DRBG is "CTR-DRBG" using the "AES-256-CTR" cipher.
 
 The default seed source can be configured when OpenSSL is compiled by
-setting B<-DOPENSSL_DEFAULT_SEED_SRC='\"SEED-SRC\"'>. If not set then
+setting B<-DOPENSSL_DEFAULT_SEED_SRC=SEED-SRC>. If not set then
 "SEED-SRC" is used.
 
 =head1 EXAMPLES

--- a/doc/man7/EVP_RAND.pod
+++ b/doc/man7/EVP_RAND.pod
@@ -226,9 +226,9 @@ but also for every generate request.
 In most cases OpenSSL will automatically choose a suitable seed source
 for automatically seeding and reseeding its <primary> DRBG. The
 default seed source can be configured when OpenSSL is compiled by
-setting B<-DOPENSSL_DEFAULT_SEED_SRC='\"SEED-SRC\"'>. If not set then
+setting B<-DOPENSSL_DEFAULT_SEED_SRC=SEED-SRC>. If not set then
 "SEED-SRC" is used. One can specify a third-party provider seed-source,
-or B<-DOPENSSL_DEFAULT_SEED_SRC='\"JITTER\"'> if available.
+or B<-DOPENSSL_DEFAULT_SEED_SRC=JITTER> if available.
 
 In some cases however, it will be necessary to explicitly specify a
 seed source used by "SEED-SRC" during configuration, using the


### PR DESCRIPTION
Nested quoting got ignore previously. And this way one can specify
string name directly.

Successfully run with Jitter at
https://github.com/xnox/openssl/actions/runs/10223149419/job/28289017013