### PR TITLE
Fix -sigopt option with "nonce-type" in openssl dgst

### DIFF
--- a/crypto/ec/ecdsa_ossl.c
+++ b/crypto/ec/ecdsa_ossl.c
@@ -106,6 +106,10 @@ int ossl_ecdsa_deterministic_sign(const unsigned char *dgst, int dlen,
         ERR_raise(ERR_LIB_EC, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
+    if (digestname == NULL) {
+        ERR_raise(ERR_LIB_EC, EC_R_INVALID_DIGEST);
+        return 0;
+    }
 
     *siglen = 0;
     if (!ecdsa_sign_setup(eckey, NULL, &kinv, &r, dgst, dlen,

--- a/providers/implementations/signature/ecdsa_sig.c
+++ b/providers/implementations/signature/ecdsa_sig.c
@@ -589,18 +589,9 @@ static const OSSL_PARAM settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM settable_ctx_params_no_digest[] = {
-    OSSL_PARAM_uint(OSSL_SIGNATURE_PARAM_KAT, NULL),
-    OSSL_PARAM_END
-};
-
 static const OSSL_PARAM *ecdsa_settable_ctx_params(void *vctx,
                                                    ossl_unused void *provctx)
 {
-    PROV_ECDSA_CTX *ctx = (PROV_ECDSA_CTX *)vctx;
-
-    if (ctx != NULL && !ctx->flag_allow_md)
-        return settable_ctx_params_no_digest;
     return settable_ctx_params;
 }
 

--- a/providers/implementations/signature/ecdsa_sig.c
+++ b/providers/implementations/signature/ecdsa_sig.c
@@ -207,9 +207,13 @@ static int ecdsa_sign(void *vctx, unsigned char *sig, size_t *siglen,
         return 0;
 
     if (ctx->nonce_type != 0) {
+        const char *mdname = NULL;
+
+        if (ctx->mdname[0] != '\0')
+            mdname = ctx->mdname;
         ret = ossl_ecdsa_deterministic_sign(tbs, tbslen, sig, &sltmp,
                                             ctx->ec, ctx->nonce_type,
-                                            ctx->mdname,
+                                            mdname,
                                             ctx->libctx, ctx->propq);
     } else {
         ret = ECDSA_sign_ex(0, tbs, tbslen, sig, &sltmp, ctx->kinv, ctx->r,

--- a/test/recipes/20-test_dgst.t
+++ b/test/recipes/20-test_dgst.t
@@ -17,7 +17,7 @@ use OpenSSL::Test::Utils;
 
 setup("test_dgst");
 
-plan tests => 13;
+plan tests => 14;
 
 sub tsignverify {
     my $testtext = shift;
@@ -231,7 +231,7 @@ subtest "SHAKE digest generation with no xoflen set `dgst` CLI" => sub {
 };
 
 SKIP: {
-    skip "ECDSA is not supported by this OpenSSL build", 1
+    skip "ECDSA is not supported by this OpenSSL build", 2
         if disabled("ec");
 
     subtest "signing with xoflen is not supported `dgst` CLI" => sub {
@@ -243,5 +243,17 @@ SKIP: {
                      '-out', 'test.sig',
                      srctop_file('test', 'data.bin')])),
                      "Generating signature with xoflen should fail");
+    };
+
+    subtest "signing using the nonce-type sigopt" => sub {
+        plan tests => 1;
+        my $data_to_sign = srctop_file('test', 'data.bin');
+
+        ok(run(app(['openssl', 'dgst', '-sha256',
+                     '-sign', srctop_file("test","testec-p256.pem"),
+                     '-out', 'test.sig',
+                     '-sigopt', 'nonce-type:1',
+                     srctop_file('test', 'data.bin')])),
+                     "Sign using the nonce-type sigopt");
     }
 }


### PR DESCRIPTION
We apply two fixes:

1) Don't restrict the ECDSA settable ctx params unnecessarily

We were being a bit overzealous about what settable_ctx_params are reported for ECDSA and weren't always getting it right. Just report all the possible ones. We have checks anyway if you try and set things that aren't appropriate for a given situation.

2) Improve the error reporting if we end up sending an empty digest for deterministic ECDSA

Fixes #25012