### PR TITLE
Revert "QUIC CHANNEL: Defer transport parameter generation"

### DIFF
--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -1717,8 +1717,14 @@ static int ch_generate_transport_params(QUIC_CHANNEL *ch)
     int wpkt_valid = 0;
     size_t buf_len = 0;
 
-    if (ch->local_transport_params != NULL || ch->got_local_transport_params)
+    if (ch->state != QUIC_CHANNEL_STATE_IDLE &&
+        (ch->local_transport_params != NULL || ch->got_local_transport_params))
         goto err;
+
+    /* Free prior params */
+    OPENSSL_free(ch->local_transport_params);
+    ch->local_transport_params = NULL;
+    ch->got_local_transport_params = 0;
 
     if ((buf_mem = BUF_MEM_new()) == NULL)
         goto err;

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -352,6 +352,14 @@ static int ch_init(QUIC_CHANNEL *ch)
     ossl_ackm_set_tx_max_ack_delay(ch->ackm, ossl_ms2time(ch->tx_max_ack_delay));
     ossl_ackm_set_rx_max_ack_delay(ch->ackm, ossl_ms2time(ch->rx_max_ack_delay));
 
+    /*
+     * Determine the QUIC Transport Parameters and serialize the transport
+     * parameters block. (For servers, we do this later as we must defer
+     * generation until we have received the client's transport parameters.)
+     */
+    if (!ch->is_server && !ch_generate_transport_params(ch))
+        goto err;
+
     ch_update_idle(ch);
     ossl_list_ch_insert_tail(&ch->port->channel_list, ch);
     ch->on_port_list = 1;
@@ -2595,15 +2603,6 @@ int ossl_quic_channel_start(QUIC_CHANNEL *ch)
                                           &ch->init_dcid,
                                           ch->is_server,
                                           ch->qrx, ch->qtx))
-        return 0;
-
-    /*
-     * Determine the QUIC Transport Parameters and serialize the transport
-     * parameters block. (For servers, we do this later as we must defer
-     * generation until we have received the client's transport parameters.)
-     */
-    if (!ch->is_server && !ch->got_local_transport_params
-        && !ch_generate_transport_params(ch))
         return 0;
 
     /* Change state. */

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -3253,7 +3253,8 @@ static int qc_getset_idle_timeout(QCTX *ctx, uint32_t class_,
                 goto err;
             }
 
-            if (ossl_quic_channel_have_generated_transport_params(ctx->qc->ch)) {
+            if (ossl_quic_channel_is_active(ctx->qc->ch)
+                && ossl_quic_channel_have_generated_transport_params(ctx->qc->ch)) {
                 QUIC_RAISE_NON_NORMAL_ERROR(ctx, SSL_R_FEATURE_NOT_RENEGOTIABLE,
                                             NULL);
                 goto err;


### PR DESCRIPTION
This reverts commit 69616017a613c7442fa51794d51f167b0de2fc9c.

Recently discovered (in #25054 ) that QUIC when used to connect to a quic server via s_client, that the TLS client hello header contains and empty quic_transport_parameters extension, causing the connection to be aborted by the server.

It occurs because in 69616017a613c7442fa51794d51f167b0de2fc9c we deferred the initialization of these parameters until a connection was established. The way s_client handles the TLS handshake, this is too late however, and produces the previously mentioned empty extension

Looking at the code suggests that while its possible to do so in some cases, theres no real reason to defer the establishment of these parameters.  As such revert the change

Fixes #25054 