### PR TITLE
 Do not falsely start the QUIC connection through some SSL functions [3.2]

### DIFF
--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -2812,6 +2812,9 @@ static size_t ossl_quic_pending_int(const SSL *s, int check_channel)
 
     quic_lock(ctx.qc);
 
+    if (!ctx.qc->started)
+        goto out;
+
     if (ctx.xso == NULL) {
         /* No XSO yet, but there might be a default XSO eligible to be created. */
         if (qc_wait_for_default_xso_for_read(&ctx, /*peek=*/1)) {

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -1059,7 +1059,8 @@ int ossl_quic_handle_events(SSL *s)
         return 0;
 
     quic_lock(ctx.qc);
-    ossl_quic_reactor_tick(ossl_quic_channel_get_reactor(ctx.qc->ch), 0);
+    if (ctx.qc->started)
+        ossl_quic_reactor_tick(ossl_quic_channel_get_reactor(ctx.qc->ch), 0);
     quic_unlock(ctx.qc);
     return 1;
 }

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -1082,8 +1082,9 @@ int ossl_quic_get_event_timeout(SSL *s, struct timeval *tv, int *is_infinite)
 
     quic_lock(ctx.qc);
 
-    deadline
-        = ossl_quic_reactor_get_tick_deadline(ossl_quic_channel_get_reactor(ctx.qc->ch));
+    if (ctx.qc->started)
+        deadline
+            = ossl_quic_reactor_get_tick_deadline(ossl_quic_channel_get_reactor(ctx.qc->ch));
 
     if (ossl_time_is_infinite(deadline)) {
         *is_infinite = 1;


### PR DESCRIPTION
Backport of #25069 to 3.2 branch.