### PR TITLE
Fix evp_test HKDF failure in crosstest 3.1.2 FIPS provider with master

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -151,6 +151,10 @@ static int pkey_check_fips_approved(EVP_PKEY_CTX *ctx, EVP_TEST *t)
      */
     int approved = 1;
 
+    /* Older providers dont have a gettable */
+    if (EVP_PKEY_CTX_gettable_params(ctx) == NULL)
+        return 1;
+
     params[0] = OSSL_PARAM_construct_int(OSSL_ALG_PARAM_FIPS_APPROVED_INDICATOR,
                                          &approved);
     if (!EVP_PKEY_CTX_get_params(ctx, params))

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -135,6 +135,9 @@ static int mac_check_fips_approved(EVP_MAC_CTX *ctx, EVP_TEST *t)
      */
     int approved = 1;
 
+    if (EVP_MAC_CTX_gettable_params(ctx) == NULL)
+        return 1;
+
     params[0] = OSSL_PARAM_construct_int(OSSL_MAC_PARAM_FIPS_APPROVED_INDICATOR,
                                          &approved);
     if (!EVP_MAC_CTX_get_params(ctx, params))
@@ -170,6 +173,9 @@ static int rand_check_fips_approved(EVP_RAND_CTX *ctx, EVP_TEST *t)
      * value of approved.
      */
     int approved = 1;
+
+    if (EVP_RAND_CTX_gettable_params(ctx) == NULL)
+        return 1;
 
     params[0] = OSSL_PARAM_construct_int(OSSL_DRBG_PARAM_FIPS_APPROVED_INDICATOR,
                                          &approved);


### PR DESCRIPTION
Fixes https://github.com/openssl/openssl/issues/25089

The test to check if the FIPS indicator was correct failed in 3.1.2
since EVP_PKEY_CTX_get_params() returns 0 if there is no
gettable/getter.

The code has been modified to return 1 if there is no gettable.
Manually reproduced and tested by copying the 3.1.2 FIPS provider to master.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
