### PR TITLE
increase rsa min bits to 1024

### DIFF
--- a/demos/pkey/EVP_PKEY_RSA_keygen.c
+++ b/demos/pkey/EVP_PKEY_RSA_keygen.c
@@ -254,7 +254,7 @@ int main(int argc, char **argv)
 
     if (argc > 1) {
         bits_i = atoi(argv[1]);
-        if (bits < 512) {
+        if (bits < OPENSSL_RSA_MIN_MODULUS_BITS) {
             fprintf(stderr, "Invalid RSA key size\n");
             return EXIT_FAILURE;
         }

--- a/doc/man1/openssl-genrsa.pod.in
+++ b/doc/man1/openssl-genrsa.pod.in
@@ -97,7 +97,7 @@ Write the key using the traditional PKCS#1 format instead of the PKCS#8 format.
 =item B<numbits>
 
 The size of the private key to generate in bits. This must be the last option
-specified. The default is 2048 and values less than 512 are not allowed.
+specified. The default is 2048 and values less than 1024 are not allowed.
 
 =back
 

--- a/include/crypto/rsa.h
+++ b/include/crypto/rsa.h
@@ -15,7 +15,7 @@
 # include <openssl/rsa.h>
 # include "crypto/types.h"
 
-#define RSA_MIN_MODULUS_BITS    512
+# define RSA_MIN_MODULUS_BITS OPENSSL_RSA_MIN_MODULUS_BITS
 
 typedef struct rsa_pss_params_30_st {
     int hash_algorithm_nid;

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -35,6 +35,10 @@
 extern "C" {
 # endif
 
+# ifndef OPENSSL_RSA_MIN_MODULUS_BITS
+#  define OPENSSL_RSA_MIN_MODULUS_BITS 1024
+# endif
+
 # ifndef OPENSSL_RSA_MAX_MODULUS_BITS
 #  define OPENSSL_RSA_MAX_MODULUS_BITS   16384
 # endif

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -3879,7 +3879,7 @@ static int test_EVP_rsa_pss_with_keygen_bits(void)
     ret = TEST_ptr(md)
         && TEST_ptr((ctx = EVP_PKEY_CTX_new_from_name(testctx, "RSA-PSS", testpropq)))
         && TEST_int_gt(EVP_PKEY_keygen_init(ctx), 0)
-        && TEST_int_gt(EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, 512), 0)
+        && TEST_int_gt(EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, OPENSSL_RSA_MIN_MODULUS_BITS), 0)
         && TEST_int_gt(EVP_PKEY_CTX_set_rsa_pss_keygen_md(ctx, md), 0)
         && TEST_true(EVP_PKEY_keygen(ctx, &pkey));
 

--- a/test/recipes/15-test_genrsa.t
+++ b/test/recipes/15-test_genrsa.t
@@ -136,15 +136,15 @@ unless ($no_fips) {
                 '-out', 'genrsatest3072.pem'])),
        "Generating RSA key with 3072 bits");
 
-   ok(!run(app(['openssl', 'genrsa', @prov, '512'])),
-       "Generating RSA key with 512 bits should fail in FIPS provider");
+   ok(!run(app(['openssl', 'genrsa', @prov, '1024'])),
+       "Generating RSA key with 1024 bits should fail in FIPS provider");
 
    ok(!run(app(['openssl', 'genrsa',
                 @prov,
                 '-provider', 'default',
                 '-propquery', '?fips!=yes',
-                '512'])),
-       "Generating RSA key with 512 bits should succeed with FIPS provider as".
+                '1024'])),
+       "Generating RSA key with 1024 bits should succeed with FIPS provider as".
        " default with a non-FIPS property query");
 
     # We want to know that an absurdly large number of bits fails the RNG check

--- a/test/recipes/20-test_cli_fips.t
+++ b/test/recipes/20-test_cli_fips.t
@@ -250,7 +250,7 @@ SKIP: {
         $testtext = $testtext_prefix.': '.
             'Generate a key with a non-FIPS algorithm with the default provider';
         ok(run(app(['openssl', 'genpkey', '-algorithm', 'RSA',
-                    '-pkeyopt', 'rsa_keygen_bits:512',
+                    '-pkeyopt', 'rsa_keygen_bits:1024',
                     '-out', $nonfips_key])),
            $testtext);
 
@@ -271,7 +271,7 @@ SKIP: {
             'Generate a key with a non-FIPS algorithm'.
             ' (should fail)';
         ok(!run(app(['openssl', 'genpkey', '-algorithm', 'RSA',
-                    '-pkeyopt', 'rsa_keygen_bits:512',
+                    '-pkeyopt', 'rsa_keygen_bits:1024',
                      '-out', $testtext_prefix.'.fail.priv.pem'])),
            $testtext);
 

--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -860,10 +860,10 @@ static void thread_general_worker(void)
 
     /*
      * We want the test to run quickly - not securely.
-     * Therefore we use an insecure bit length where we can (512).
+     * Therefore we use an insecure bit length where we can (1024).
      * In the FIPS module though we must use a longer length.
      */
-    pkey = EVP_PKEY_Q_keygen(multi_libctx, NULL, "RSA", isfips ? 2048 : 512);
+    pkey = EVP_PKEY_Q_keygen(multi_libctx, NULL, "RSA", isfips ? 2048 : OPENSSL_RSA_MIN_MODULUS_BITS);
     if (!TEST_ptr(pkey))
         goto err;
 


### PR DESCRIPTION
Per #25092, prevents generation of RSA keys smaller than 1024, though still allows existing keys to be used.

Please let me know if a CLA is needed - this seems like a trivial change to me, but... 🤷 

##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated
