### PR TITLE
coveralls.yml: Do not run tests in parallel

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -72,7 +72,7 @@ jobs:
         cat /proc/cpuinfo
         ./util/opensslwrap.sh version -c
     - name: make test
-      run: make test HARNESS_JOBS=${HARNESS_JOBS:-4} TESTS='-test_external_krb5'
+      run: make test TESTS='-test_external_krb5'
     - name: generate coverage info
       run: lcov -d . -c
              --exclude "${PWD}/test/*"


### PR DESCRIPTION
This hopefully could help somehow derandomize the coverage reports