### PR TITLE
test/provider_fallback_test.c: Add OSSL_PROVIDER_unload() to avoid me…

### DIFF
--- a/test/provider_fallback_test.c
+++ b/test/provider_fallback_test.c
@@ -47,7 +47,6 @@ static int test_explicit_provider(void)
             ok = TEST_true(OSSL_PROVIDER_unload(prov));
         else
             OSSL_PROVIDER_unload(prov);
-            OSSL_PROVIDER_unload(prov);
     }
 
     OSSL_LIB_CTX_free(ctx);

--- a/test/provider_fallback_test.c
+++ b/test/provider_fallback_test.c
@@ -43,12 +43,11 @@ static int test_explicit_provider(void)
 
     if (ok) {
         ok = test_provider(ctx);
-        if (ok) {
+        if (ok)
             ok = TEST_true(OSSL_PROVIDER_unload(prov));
-        }
-        else {
+        else
             OSSL_PROVIDER_unload(prov);
-        }
+            OSSL_PROVIDER_unload(prov);
     }
 
     OSSL_LIB_CTX_free(ctx);

--- a/test/provider_fallback_test.c
+++ b/test/provider_fallback_test.c
@@ -39,9 +39,17 @@ static int test_explicit_provider(void)
     int ok;
 
     ok = TEST_ptr(ctx = OSSL_LIB_CTX_new())
-        && TEST_ptr(prov = OSSL_PROVIDER_load(ctx, "default"))
-        && test_provider(ctx)
-        && TEST_true(OSSL_PROVIDER_unload(prov));
+        && TEST_ptr(prov = OSSL_PROVIDER_load(ctx, "default"));
+
+    if (ok) {
+        ok = test_provider(ctx);
+        if (ok) {
+            ok = TEST_true(OSSL_PROVIDER_unload(prov));
+        }
+        else {
+            OSSL_PROVIDER_unload(prov);
+        }
+    }
 
     OSSL_LIB_CTX_free(ctx);
     return ok;


### PR DESCRIPTION
…mory leak

Add OSSL_PROVIDER_unload() when test_provider() fails to avoid memory leak.

Fixes: f995e5bdcd ("TEST: Add provider_fallback_test, to test aspects of fallback providers")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
