### PR TITLE
test/provider_test.c: Add OSSL_PROVIDER_unload() to avoid memory leak

### DIFF
--- a/test/provider_test.c
+++ b/test/provider_test.c
@@ -255,6 +255,7 @@ static int test_builtin_provider_with_child(void)
 
     if (!TEST_true(OSSL_PROVIDER_add_builtin(libctx, name,
                                              PROVIDER_INIT_FUNCTION_NAME))) {
+        OSSL_PROVIDER_unload(legacy);
         OSSL_LIB_CTX_free(libctx);
         return 0;
     }


### PR DESCRIPTION
Add OSSL_PROVIDER_unload() when OSSL_PROVIDER_add_builtin() fails to avoid memory leak.

Fixes: 5442611dff ("Add a test for OSSL_LIB_CTX_new_child()")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
