### PR TITLE
test: add FIPS provider version checks for 3.4 compatibility

### DIFF
--- a/test/recipes/30-test_evp_data/evppkey_dsa.txt
+++ b/test/recipes/30-test_evp_data/evppkey_dsa.txt
@@ -341,8 +341,8 @@ Input = "Hello"
 Result = DIGESTSIGNINIT_ERROR
 
 # Test sign with a 3072 bit key with N == 224 is not allowed in fips mode
-FIPSversion = <3.4.0
 Availablein = fips
+FIPSversion = <3.4.0
 DigestSign = SHA256
 Securitycheck = 1
 Key = DSA-3072-224

--- a/test/recipes/30-test_evp_data/evppkey_dsa.txt
+++ b/test/recipes/30-test_evp_data/evppkey_dsa.txt
@@ -270,6 +270,7 @@ Title = FIPS Tests (using different key sizes and digests)
 
 # Test sign with a 2048 bit key with N == 160 is not allowed in fips mode
 Availablein = fips
+FIPSversion = <3.4.0
 DigestSign = SHA256
 Key = DSA-2048-160
 Input = "Hello"
@@ -324,6 +325,7 @@ Title = Fips Negative Tests (using different key sizes and digests)
 
 # Test sign with a 1024 bit key is not allowed in fips mode
 Availablein = fips
+FIPSversion = <3.4.0
 DigestSign = SHA256
 Securitycheck = 1
 Key = DSA-1024-FIPS186-2
@@ -339,6 +341,7 @@ Input = "Hello"
 Result = DIGESTSIGNINIT_ERROR
 
 # Test sign with a 3072 bit key with N == 224 is not allowed in fips mode
+FIPSversion = <3.4.0
 Availablein = fips
 DigestSign = SHA256
 Securitycheck = 1
@@ -348,6 +351,7 @@ Result = DIGESTSIGNINIT_ERROR
 
 # Test sign with a 4096 bit key is not allowed in fips mode
 Availablein = fips
+FIPSversion = <3.4.0
 DigestSign = SHA256
 Securitycheck = 1
 Key = DSA-4096-256

--- a/test/recipes/30-test_evp_data/evppkey_ecdsa.txt
+++ b/test/recipes/30-test_evp_data/evppkey_ecdsa.txt
@@ -216,6 +216,7 @@ Result = DIGESTSIGNINIT_ERROR
 
 # Test that SHA1 is not allowed in fips mode for signing
 Availablein = fips
+FIPSversion = <3.4.0
 Sign = P-256
 Securitycheck = 1
 Ctrl = digest:SHA1

--- a/test/recipes/30-test_evp_data/evppkey_rsa_common.txt
+++ b/test/recipes/30-test_evp_data/evppkey_rsa_common.txt
@@ -1831,6 +1831,7 @@ Output = 80382819f51b197c42f9fc02a85198683d918059afc013ae155992442563dd289700829
 
 # Signing with SHA1 is not allowed in fips mode
 Availablein = fips
+FIPSversion = <3.4.0
 DigestSign = SHA1
 Securitycheck = 1
 Key = RSA-2048


### PR DESCRIPTION
Tests that are changed by #25020 mandate updates to older test suite data to pass because the FIPS provider's behaviour changes in 3.4.

This is required for the cross version FIPS provider checks to pass once the changes are merged.


- [ ] documentation is added or updated
- [x] tests are added or updated
