### PR TITLE
FIPS: Remove ability to bypass the FIPS self tests

### DIFF
--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -217,7 +217,7 @@ static int fips_get_params_from_core(FIPS_GLOBAL *fgbl)
     * OSSL_PROV_FIPS_PARAM_SECURITY_CHECKS and
     * OSSL_PROV_FIPS_PARAM_TLS1_PRF_EMS_CHECK are not self test parameters.
     */
-    OSSL_PARAM core_params[33], *p = core_params;
+    OSSL_PARAM core_params[30], *p = core_params;
 
     *p++ = OSSL_PARAM_construct_utf8_ptr(
             OSSL_PROV_PARAM_CORE_MODULE_FILENAME,
@@ -227,18 +227,6 @@ static int fips_get_params_from_core(FIPS_GLOBAL *fgbl)
             OSSL_PROV_FIPS_PARAM_MODULE_MAC,
             (char **)&fgbl->selftest_params.module_checksum_data,
             sizeof(fgbl->selftest_params.module_checksum_data));
-    *p++ = OSSL_PARAM_construct_utf8_ptr(
-            OSSL_PROV_FIPS_PARAM_INSTALL_MAC,
-            (char **)&fgbl->selftest_params.indicator_checksum_data,
-            sizeof(fgbl->selftest_params.indicator_checksum_data));
-    *p++ = OSSL_PARAM_construct_utf8_ptr(
-            OSSL_PROV_FIPS_PARAM_INSTALL_STATUS,
-            (char **)&fgbl->selftest_params.indicator_data,
-            sizeof(fgbl->selftest_params.indicator_data));
-    *p++ = OSSL_PARAM_construct_utf8_ptr(
-            OSSL_PROV_FIPS_PARAM_INSTALL_VERSION,
-            (char **)&fgbl->selftest_params.indicator_version,
-            sizeof(fgbl->selftest_params.indicator_version));
     *p++ = OSSL_PARAM_construct_utf8_ptr(
             OSSL_PROV_FIPS_PARAM_CONDITIONAL_ERRORS,
             (char **)&fgbl->selftest_params.conditional_error_check,

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -219,18 +219,19 @@ static int fips_get_params_from_core(FIPS_GLOBAL *fgbl)
     */
     OSSL_PARAM core_params[30], *p = core_params;
 
-    *p++ = OSSL_PARAM_construct_utf8_ptr(
-            OSSL_PROV_PARAM_CORE_MODULE_FILENAME,
-            (char **)&fgbl->selftest_params.module_filename,
-            sizeof(fgbl->selftest_params.module_filename));
-    *p++ = OSSL_PARAM_construct_utf8_ptr(
-            OSSL_PROV_FIPS_PARAM_MODULE_MAC,
-            (char **)&fgbl->selftest_params.module_checksum_data,
-            sizeof(fgbl->selftest_params.module_checksum_data));
-    *p++ = OSSL_PARAM_construct_utf8_ptr(
-            OSSL_PROV_FIPS_PARAM_CONDITIONAL_ERRORS,
-            (char **)&fgbl->selftest_params.conditional_error_check,
-            sizeof(fgbl->selftest_params.conditional_error_check));
+/* FIPS self test params */
+#define FIPS_FEATURE_SELF_TEST(fgbl, pname, field)                             \
+    *p++ = OSSL_PARAM_construct_utf8_ptr(pname,                                \
+                                         (char **)&fgbl->selftest_params.field,\
+                                         sizeof(fgbl->selftest_params.field))
+
+    FIPS_FEATURE_SELF_TEST(fgbl, OSSL_PROV_PARAM_CORE_MODULE_FILENAME,
+                           module_filename);
+    FIPS_FEATURE_SELF_TEST(fgbl, OSSL_PROV_FIPS_PARAM_MODULE_MAC,
+                           module_checksum_data);
+    FIPS_FEATURE_SELF_TEST(fgbl, OSSL_PROV_FIPS_PARAM_CONDITIONAL_ERRORS,
+                           conditional_error_check);
+#undef FIPS_FEATURE_SELF_TEST
 
 /* FIPS features can be enabled or disabled independently */
 #define FIPS_FEATURE_OPTION(fgbl, pname, field)                         \

--- a/providers/fips/self_test.c
+++ b/providers/fips/self_test.c
@@ -304,13 +304,9 @@ int SELF_TEST_post(SELF_TEST_POST_PARAMS *st, int on_demand_test)
     int loclstate;
 #if !defined(OPENSSL_NO_FIPS_POST)
     int ok = 0;
-# if defined(OSSL_POST_140_2_INDICATOR)
-    int kats_already_passed = 0;
-# endif
     long checksum_len;
-    OSSL_CORE_BIO *bio_module = NULL, *bio_indicator = NULL;
+    OSSL_CORE_BIO *bio_module = NULL;
     unsigned char *module_checksum = NULL;
-    unsigned char *indicator_checksum = NULL;
     OSSL_SELF_TEST *ev = NULL;
     EVP_RAND *testrand = NULL;
     EVP_RAND_CTX *rng;
@@ -373,50 +369,10 @@ int SELF_TEST_post(SELF_TEST_POST_PARAMS *st, int on_demand_test)
         goto end;
     }
 
-# if defined(OSSL_POST_140_2_INDICATOR)
-    /* This will be NULL during installation - so the self test KATS will run */
-    if (st->indicator_data != NULL) {
-        /*
-         * If the kats have already passed indicator is set - then check the
-         * integrity of the indicator.
-         */
-        if (st->indicator_checksum_data == NULL) {
-            ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_CONFIG_DATA);
-            goto end;
-        }
-        indicator_checksum = OPENSSL_hexstr2buf(st->indicator_checksum_data,
-                                                &checksum_len);
-        if (indicator_checksum == NULL) {
-            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_CONFIG_DATA);
-            goto end;
-        }
-
-        bio_indicator =
-            (*st->bio_new_buffer_cb)(st->indicator_data,
-                                     strlen(st->indicator_data));
-        if (bio_indicator == NULL
-                || !verify_integrity(bio_indicator, st->bio_read_ex_cb,
-                                     indicator_checksum, checksum_len,
-                                     st->libctx, ev,
-                                     OSSL_SELF_TEST_TYPE_INSTALL_INTEGRITY)) {
-            ERR_raise(ERR_LIB_PROV, PROV_R_INDICATOR_INTEGRITY_FAILURE);
-            goto end;
-        } else {
-            kats_already_passed = 1;
-        }
+    if (!SELF_TEST_kats(ev, st->libctx)) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_SELF_TEST_KAT_FAILURE);
+        goto end;
     }
-
-    /*
-     * Only runs the KAT's during installation OR on_demand().
-     * NOTE: If the installation option 'self_test_onload' is chosen then this
-     * path will always be run, since kats_already_passed will always be 0.
-     */
-    if (on_demand_test || kats_already_passed == 0)
-# endif /* OSSL_POST_140_2_INDICATOR */
-        if (!SELF_TEST_kats(ev, st->libctx)) {
-            ERR_raise(ERR_LIB_PROV, PROV_R_SELF_TEST_KAT_FAILURE);
-            goto end;
-        }
 
     /* Verify that the RNG has been restored properly */
     rng = ossl_rand_get0_private_noncreating(st->libctx);
@@ -433,12 +389,10 @@ end:
     EVP_RAND_free(testrand);
     OSSL_SELF_TEST_free(ev);
     OPENSSL_free(module_checksum);
-    OPENSSL_free(indicator_checksum);
 
-    if (st != NULL) {
-        (*st->bio_free_cb)(bio_indicator);
+    if (st != NULL)
         (*st->bio_free_cb)(bio_module);
-    }
+
     if (ok)
         set_fips_state(FIPS_STATE_RUNNING);
     else

--- a/providers/fips/self_test.c
+++ b/providers/fips/self_test.c
@@ -304,7 +304,9 @@ int SELF_TEST_post(SELF_TEST_POST_PARAMS *st, int on_demand_test)
     int loclstate;
 #if !defined(OPENSSL_NO_FIPS_POST)
     int ok = 0;
+# if defined(OSSL_POST_140_2_INDICATOR)
     int kats_already_passed = 0;
+# endif
     long checksum_len;
     OSSL_CORE_BIO *bio_module = NULL, *bio_indicator = NULL;
     unsigned char *module_checksum = NULL;
@@ -371,6 +373,7 @@ int SELF_TEST_post(SELF_TEST_POST_PARAMS *st, int on_demand_test)
         goto end;
     }
 
+# if defined(OSSL_POST_140_2_INDICATOR)
     /* This will be NULL during installation - so the self test KATS will run */
     if (st->indicator_data != NULL) {
         /*
@@ -408,12 +411,12 @@ int SELF_TEST_post(SELF_TEST_POST_PARAMS *st, int on_demand_test)
      * NOTE: If the installation option 'self_test_onload' is chosen then this
      * path will always be run, since kats_already_passed will always be 0.
      */
-    if (on_demand_test || kats_already_passed == 0) {
+    if (on_demand_test || kats_already_passed == 0)
+# endif /* OSSL_POST_140_2_INDICATOR */
         if (!SELF_TEST_kats(ev, st->libctx)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_SELF_TEST_KAT_FAILURE);
             goto end;
         }
-    }
 
     /* Verify that the RNG has been restored properly */
     rng = ossl_rand_get0_private_noncreating(st->libctx);

--- a/providers/fips/self_test.h
+++ b/providers/fips/self_test.h
@@ -16,11 +16,6 @@ typedef struct self_test_post_params_st {
     const char *module_filename;            /* Module file to perform MAC on */
     const char *module_checksum_data;       /* Expected module MAC integrity */
 
-    /* Used for KAT install indicator integrity check */
-    const char *indicator_version;          /* version - for future proofing */
-    const char *indicator_data;             /* data to perform MAC on */
-    const char *indicator_checksum_data;    /* Expected MAC integrity value */
-
     /* Used for continuous tests */
     const char *conditional_error_check;
 


### PR DESCRIPTION
This is a FIPS 140-3 requirement.
It should not be done as a FIPS indicator.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
