### PR TITLE
Add a test recipe for testing the speed command

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3266,6 +3266,7 @@ int speed_main(int argc, char **argv)
             /* if longer than 10s, don't do any more */
             stop_it(ecdsa_doit, testnum);
         }
+        EVP_PKEY_free(ecdsa_key);
     }
 
     for (testnum = 0; testnum < EC_NUM; testnum++) {

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -4682,7 +4682,7 @@ static int do_multi(int multi, int size_num)
                     d = atof(sstrsep(&p, sep));
                     rsa_results[k][3] += d;
                 }
-#ifndef OPENSSL_NO_DSA
+# ifndef OPENSSL_NO_DSA
             } else if (CHECK_AND_SKIP_PREFIX(p, "+F3:")) {
                 tk = sstrsep(&p, sep);
                 if (strtoint(tk, 0, OSSL_NELEM(dsa_results), &k)) {
@@ -4694,7 +4694,7 @@ static int do_multi(int multi, int size_num)
                     d = atof(sstrsep(&p, sep));
                     dsa_results[k][1] += d;
                 }
-#endif /* OPENSSL_NO_DSA */
+# endif /* OPENSSL_NO_DSA */
             } else if (CHECK_AND_SKIP_PREFIX(p, "+F4:")) {
                 tk = sstrsep(&p, sep);
                 if (strtoint(tk, 0, OSSL_NELEM(ecdsa_results), &k)) {

--- a/doc/man1/openssl-speed.pod.in
+++ b/doc/man1/openssl-speed.pod.in
@@ -27,6 +27,7 @@ B<openssl speed>
 [B<-bytes> I<num>]
 [B<-mr>]
 [B<-mlock>]
+[B<-testmode>]
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<algorithm> ...]
@@ -130,6 +131,12 @@ Produce the summary in a mechanical, machine-readable, format.
 
 Lock memory into RAM for more deterministic measurements.
 
+=item B<-testmode>
+
+Runs the speed command in testmode. Runs only 1 iteration of each algorithm test
+regardless of any B<-seconds> value. In the event that any operation fails then
+the speed command will return with a failure result.
+
 {- $OpenSSL::safe::opt_r_item -}
 
 {- $OpenSSL::safe::opt_engine_item -}
@@ -157,6 +164,8 @@ supported by third party providers with the C<openssl speed> command.
 The B<-engine> option was deprecated in OpenSSL 3.0.
 
 DSA512 was removed in OpenSSL 3.2.
+
+The B<-testmode> option was added in OpenSSL 3.4.
 
 =head1 COPYRIGHT
 

--- a/test/recipes/20-test_speed.t
+++ b/test/recipes/20-test_speed.t
@@ -40,11 +40,16 @@ ok(run(app(['openssl', 'speed', '-testmode', '-misalign', 1])),
 
 SKIP: {
     skip "Multiblock is not supported by this OpenSSL build", 1
-        if disabled("multiblock");
+        if disabled("multiblock")
+           # The AES-128-CBC-HMAC-SHA1 cipher isn't available on all platforms
+           # We test its availability without the "-mb" option. We only do the
+           # multiblock test via "-mb" if the cipher seems to exist.
+           || !run(app(['openssl', 'speed', '-testmode', '-evp',
+                       'AES-128-CBC-HMAC-SHA1']));
 
     ok(run(app(['openssl', 'speed', '-testmode', '-mb', '-evp',
                 'AES-128-CBC-HMAC-SHA1'])),
-        "Test the EVP, bytes and mb options");
+        "Test the EVP and mb options");
 }
 
 ok(run(app(['openssl', 'speed', '-testmode', '-kem-algorithms'])),

--- a/test/recipes/20-test_speed.t
+++ b/test/recipes/20-test_speed.t
@@ -1,0 +1,119 @@
+#! /usr/bin/env perl
+# Copyright 2017-2023 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use strict;
+use warnings;
+
+use File::Spec;
+use File::Basename;
+use OpenSSL::Test qw/:DEFAULT with srctop_file bldtop_dir/;
+use OpenSSL::Test::Utils;
+
+setup("test_speed");
+
+plan tests => 24;
+
+ok(run(app(['openssl', 'speed', '-testmode'])),
+       "Simple test of all speed algorithms");
+
+#Test various options to speed. In all cases we use the -testmode option to
+#ensure we don't spend too long in this test. That option also causes the speed
+#app to return an error code if anything unexpectedly goes wrong.
+
+ok(run(app(['openssl', 'speed', '-testmode', '-multi', 2])),
+       "Test the multi option");
+
+ok(run(app(['openssl', 'speed', '-testmode', '-misalign', 1])),
+       "Test the misalign option");
+
+SKIP: {
+    skip "Multiblock is not supported by this OpenSSL build", 1
+        if disabled("multiblock");
+
+    ok(run(app(['openssl', 'speed', '-testmode', '-mb', '-evp',
+                'AES-128-CBC-HMAC-SHA1'])),
+        "Test the EVP, bytes and mb options");
+}
+
+ok(run(app(['openssl', 'speed', '-testmode', '-kem-algorithms'])),
+       "Test the kem-algorithms option");
+
+ok(run(app(['openssl', 'speed', '-testmode', '-signature-algorithms'])),
+       "Test the signature-algorithms option");
+
+ok(run(app(['openssl', 'speed', '-testmode', '-primes', 3, 'rsa1024'])),
+       "Test the primes option");
+
+ok(run(app(['openssl', 'speed', '-testmode', '-mr'])),
+       "Test the mr option");
+
+ok(run(app(['openssl', 'speed', '-testmode', '-decrypt', '-evp', 'aes-128-cbc'])),
+       "Test the decrypt and evp options");
+
+ok(run(app(['openssl', 'speed', '-testmode', '-evp', 'sha256'])),
+       "Test the evp option with a digest");
+
+ok(run(app(['openssl', 'speed', '-testmode', '-hmac', 'sha256'])),
+       "Test the hmac option");
+
+ok(run(app(['openssl', 'speed', '-testmode', '-cmac', 'aes-128-cbc'])),
+       "Test the cmac option");
+
+ok(run(app(['openssl', 'speed', '-testmode', '-aead', '-evp', 'aes-128-gcm'])),
+       "Test the aead and evp options");
+
+SKIP: {
+    skip "ASYNC is not supported by this OpenSSL build", 1
+        if disabled("async");
+
+    ok(run(app(['openssl', 'speed', '-testmode', '-async_jobs', '1'])),
+        "Test the async_jobs option");
+}
+
+ok(run(app(['openssl', 'speed', '-testmode', '-mlock'])),
+       "Test the mlock option");
+
+#We don't expect these options to have an effect in testmode but we at least
+#test that the option parsing works ok
+ok(run(app(['openssl', 'speed', '-testmode', '-seconds', 1, '-bytes', 1,
+            '-elapsed'])),
+       "Test the seconds, bytes and elapsed options");
+
+#No need to -testmode for testing -help. All we're doing is testing the option
+#parsing. We don't sanity check the output
+ok(run(app(['openssl', 'speed', '-help'])),
+       "Test the help option");
+
+#Now test some invalid options. The speed app should fail
+ok(!run(app(['openssl', 'speed', 'blah'])),
+        "Test an unknwon algorithm");
+
+ok(!run(app(['openssl', 'speed', '-evp', 'blah'])),
+        "Test a unknown evp algorithm");
+
+ok(!run(app(['openssl', 'speed', '-hmac', 'blah'])),
+        "Test a unknown hmac algorithm");
+
+ok(!run(app(['openssl', 'speed', '-cmac', 'blah'])),
+        "Test a unknown cmac algorithm");
+
+ok(!run(app(['openssl', 'speed', '-async_jobs', 100000])),
+        "Test an invalid number of async_jobs");
+
+ok(!run(app(['openssl', 'speed', '-misalign', 65])),
+        "Test an invalid misalign number");
+
+SKIP: {
+    skip "Multiblock is not supported by this OpenSSL build", 1
+        if disabled("multiblock");
+
+    ok(!run(app(['openssl', 'speed', '-testmode', '-mb', '-evp',
+                'AES-128-CBC'])),
+            "Test a non multiblock cipher with -mb");
+}

--- a/test/recipes/20-test_speed.t
+++ b/test/recipes/20-test_speed.t
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 2017-2023 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -26,8 +26,14 @@ ok(run(app(['openssl', 'speed', '-testmode'])),
 #ensure we don't spend too long in this test. That option also causes the speed
 #app to return an error code if anything unexpectedly goes wrong.
 
-ok(run(app(['openssl', 'speed', '-testmode', '-multi', 2])),
-       "Test the multi option");
+
+SKIP: {
+    skip "Multi option is not supported by this OpenSSL build", 1
+       if $^O =~ /^(VMS|MSWin32)$/;
+
+    ok(run(app(['openssl', 'speed', '-testmode', '-multi', 2])),
+           "Test the multi option");
+}
 
 ok(run(app(['openssl', 'speed', '-testmode', '-misalign', 1])),
        "Test the misalign option");
@@ -62,22 +68,32 @@ ok(run(app(['openssl', 'speed', '-testmode', '-evp', 'sha256'])),
 ok(run(app(['openssl', 'speed', '-testmode', '-hmac', 'sha256'])),
        "Test the hmac option");
 
-ok(run(app(['openssl', 'speed', '-testmode', '-cmac', 'aes-128-cbc'])),
-       "Test the cmac option");
+SKIP: {
+    skip "CMAC is not supported by this OpenSSL build", 1
+        if disabled("cmac");
+
+    ok(run(app(['openssl', 'speed', '-testmode', '-cmac', 'aes-128-cbc'])),
+           "Test the cmac option");
+}
 
 ok(run(app(['openssl', 'speed', '-testmode', '-aead', '-evp', 'aes-128-gcm'])),
        "Test the aead and evp options");
 
 SKIP: {
-    skip "ASYNC is not supported by this OpenSSL build", 1
-        if disabled("async");
+    skip "ASYNC/threads not supported by this OpenSSL build", 1
+        if disabled("async") || disabled("threads");
 
     ok(run(app(['openssl', 'speed', '-testmode', '-async_jobs', '1'])),
         "Test the async_jobs option");
 }
 
-ok(run(app(['openssl', 'speed', '-testmode', '-mlock'])),
-       "Test the mlock option");
+SKIP: {
+    skip "Mlock option is not supported by this OpenSSL build", 1
+       if $^O !~ /^(linux|MSWin32)$/;
+
+       ok(run(app(['openssl', 'speed', '-testmode', '-mlock'])),
+              "Test the mlock option");
+}
 
 #We don't expect these options to have an effect in testmode but we at least
 #test that the option parsing works ok


### PR DESCRIPTION
Previously there was no test for the speed command. We just do some simple
testing, running the command with various options to confirm that it doesn't
crash or report errors. We use the new -testmode option to ensure that this
happens quickly and doesn't really run full speed tests.
