### PR TITLE
Fix 3.0 branch to skip tests if using 3.4

### DIFF
--- a/test/recipes/03-test_fipsinstall.t
+++ b/test/recipes/03-test_fipsinstall.t
@@ -30,6 +30,9 @@ my $infile = bldtop_file('providers', platform->dso('fips'));
 my $fipskey = $ENV{FIPSKEY} // config('FIPSKEY') // '00';
 my $provconf = srctop_file("test", "fips-and-base.cnf");
 
+run(test(["fips_version_test", "-config", $provconf, "<3.4.0"]),
+          capture => 1, statusvar => \my $indicatorpost);
+
 # Read in a text $infile and replace the regular expression in $srch with the
 # value in $repl and output to a new file $outfile.
 sub replace_line_file_internal {
@@ -269,24 +272,27 @@ ok(replace_parent_line_file('fips_no_module_mac.cnf',
                 '-config', 'fips_parent_no_module_mac.cnf'])),
    "verify load config fail no module mac");
 
-ok(replace_parent_line_file('fips_no_install_mac.cnf',
-                            'fips_parent_no_install_mac.cnf')
-   && !run(app(['openssl', 'fipsinstall',
-                '-config', 'fips_parent_no_install_mac.cnf'])),
-   "verify load config fail no install mac");
 
-ok(replace_parent_line_file('fips_bad_indicator.cnf',
-                            'fips_parent_bad_indicator.cnf')
-   && !run(app(['openssl', 'fipsinstall',
-                '-config', 'fips_parent_bad_indicator.cnf'])),
-   "verify load config fail bad indicator");
+SKIP: {
+    skip "Newer FIPS provider version does not support this feature", 3
+        if !$indicatorpost;
 
-
-ok(replace_parent_line_file('fips_bad_install_mac.cnf',
-                            'fips_parent_bad_install_mac.cnf')
-   && !run(app(['openssl', 'fipsinstall',
-                '-config', 'fips_parent_bad_install_mac.cnf'])),
-   "verify load config fail bad install mac");
+    ok(replace_parent_line_file('fips_no_install_mac.cnf',
+                                'fips_parent_no_install_mac.cnf')
+       && !run(app(['openssl', 'fipsinstall',
+                    '-config', 'fips_parent_no_install_mac.cnf'])),
+       "verify load config fail no install mac");
+    ok(replace_parent_line_file('fips_bad_indicator.cnf',
+                                'fips_parent_bad_indicator.cnf')
+       && !run(app(['openssl', 'fipsinstall',
+                    '-config', 'fips_parent_bad_indicator.cnf'])),
+       "verify load config fail bad indicator");
+    ok(replace_parent_line_file('fips_bad_install_mac.cnf',
+                                'fips_parent_bad_install_mac.cnf')
+       && !run(app(['openssl', 'fipsinstall',
+                    '-config', 'fips_parent_bad_install_mac.cnf'])),
+       "verify load config fail bad install mac");
+}
 
 ok(replace_parent_line_file('fips_bad_module_mac.cnf',
                             'fips_parent_bad_module_mac.cnf')


### PR DESCRIPTION
PR #25147 removes the POST being allowed to be skipped. This causes issue when testing 3.0 with the 3.4 provider.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
