### PR TITLE
s390x: Add hardware acceleration for HMAC

### DIFF
--- a/crypto/hmac/build.info
+++ b/crypto/hmac/build.info
@@ -2,5 +2,22 @@ LIBS=../../libcrypto
 
 $COMMON=hmac.c
 
-SOURCE[../../libcrypto]=$COMMON
-SOURCE[../../providers/libfips.a]=$COMMON
+IF[{- !$disabled{asm} -}]
+  IF[{- ($target{perlasm_scheme} // '') ne '31' -}]
+    $HMACASM_s390x=hmac_s390x.c
+    $HMACDEF_s390x=OPENSSL_HMAC_S390X
+  ENDIF
+
+  # Now that we have defined all the arch specific variables, use the
+  # appropriate ones, and define the appropriate macros
+  IF[$HMACASM_{- $target{asm_arch} -}]
+    $HMACASM=$HMACASM_{- $target{asm_arch} -}
+    $HMACDEF=$HMACDEF_{- $target{asm_arch} -}
+  ENDIF
+ENDIF
+
+DEFINE[../../libcrypto]=$HMACDEF
+DEFINE[../../providers/libfips.a]=$HMACDEF
+
+SOURCE[../../libcrypto]=$COMMON $HMACASM
+SOURCE[../../providers/libfips.a]=$COMMON $HMACASM

--- a/crypto/hmac/hmac.c
+++ b/crypto/hmac/hmac.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2021 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2024 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -48,6 +48,12 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len,
      */
     if ((EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF) != 0)
         return 0;
+
+#ifdef OPENSSL_HMAC_S390X
+    rv = s390x_HMAC_init(ctx, key, len, impl);
+    if (rv >= 1)
+        return rv;
+#endif
 
     if (key != NULL) {
         reset = 1;
@@ -111,6 +117,12 @@ int HMAC_Update(HMAC_CTX *ctx, const unsigned char *data, size_t len)
 {
     if (!ctx->md)
         return 0;
+
+#ifdef OPENSSL_HMAC_S390X
+    if (ctx->plat.s390x.fc)
+        return s390x_HMAC_update(ctx, data, len);
+#endif
+
     return EVP_DigestUpdate(ctx->md_ctx, data, len);
 }
 
@@ -121,6 +133,11 @@ int HMAC_Final(HMAC_CTX *ctx, unsigned char *md, unsigned int *len)
 
     if (!ctx->md)
         goto err;
+
+#ifdef OPENSSL_HMAC_S390X
+    if (ctx->plat.s390x.fc)
+        return s390x_HMAC_final(ctx, md, len);
+#endif
 
     if (!EVP_DigestFinal_ex(ctx->md_ctx, buf, &i))
         goto err;
@@ -161,6 +178,10 @@ static void hmac_ctx_cleanup(HMAC_CTX *ctx)
     EVP_MD_CTX_reset(ctx->o_ctx);
     EVP_MD_CTX_reset(ctx->md_ctx);
     ctx->md = NULL;
+
+#ifdef OPENSSL_HMAC_S390X
+    s390x_HMAC_CTX_cleanup(ctx);
+#endif
 }
 
 void HMAC_CTX_free(HMAC_CTX *ctx)
@@ -212,6 +233,12 @@ int HMAC_CTX_copy(HMAC_CTX *dctx, HMAC_CTX *sctx)
     if (!EVP_MD_CTX_copy_ex(dctx->md_ctx, sctx->md_ctx))
         goto err;
     dctx->md = sctx->md;
+
+#ifdef OPENSSL_HMAC_S390X
+    if (s390x_HMAC_CTX_copy(dctx, sctx) == 0)
+        goto err;
+#endif
+
     return 1;
  err:
     hmac_ctx_cleanup(dctx);

--- a/crypto/hmac/hmac_local.h
+++ b/crypto/hmac/hmac_local.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2020 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2024 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,6 +10,10 @@
 #ifndef OSSL_CRYPTO_HMAC_LOCAL_H
 # define OSSL_CRYPTO_HMAC_LOCAL_H
 
+# include "internal/common.h"
+# include "internal/numbers.h"
+# include "openssl/sha.h"
+
 /* The current largest case is for SHA3-224 */
 #define HMAC_MAX_MD_CBLOCK_SIZE     144
 
@@ -18,6 +22,45 @@ struct hmac_ctx_st {
     EVP_MD_CTX *md_ctx;
     EVP_MD_CTX *i_ctx;
     EVP_MD_CTX *o_ctx;
+
+    /* Platform specific data */
+    union {
+        int dummy;
+# ifdef OPENSSL_HMAC_S390X
+        struct {
+            unsigned int fc; /* 0 if not supported by kmac instruction */
+            int blk_size;
+            int ikp;
+            int iimp;
+            unsigned char *buf;
+            size_t size; /* must be multiple of digest block size */
+            size_t num;
+            union {
+                OSSL_UNION_ALIGN;
+                struct {
+                    uint32_t h[8];
+                    uint64_t imbl;
+                    unsigned char key[64];
+                } hmac_224_256;
+                struct {
+                    uint64_t h[8];
+                    uint128_t imbl;
+                    unsigned char key[128];
+                } hmac_384_512;
+            } param;
+        } s390x;
+# endif /* OPENSSL_HMAC_S390X */
+    } plat;
 };
+
+# ifdef OPENSSL_HMAC_S390X
+#  define HMAC_S390X_BUF_NUM_BLOCKS 64
+
+int s390x_HMAC_init(HMAC_CTX *ctx, const void *key, int key_len, ENGINE *impl);
+int s390x_HMAC_update(HMAC_CTX *ctx, const unsigned char *data, size_t len);
+int s390x_HMAC_final(HMAC_CTX *ctx, unsigned char *md, unsigned int *len);
+int s390x_HMAC_CTX_copy(HMAC_CTX *dctx, HMAC_CTX *sctx);
+int s390x_HMAC_CTX_cleanup(HMAC_CTX *ctx);
+# endif /* OPENSSL_HMAC_S390X */
 
 #endif

--- a/crypto/hmac/hmac_s390x.c
+++ b/crypto/hmac/hmac_s390x.c
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "crypto/s390x_arch.h"
+#include "hmac_local.h"
+#include "openssl/obj_mac.h"
+#include "openssl/evp.h"
+
+#ifdef OPENSSL_HMAC_S390X
+
+static int s390x_fc_from_md(const EVP_MD *md)
+{
+    int fc;
+
+    switch (EVP_MD_get_type(md)) {
+    case NID_sha224:
+        fc = S390X_HMAC_SHA_224;
+        break;
+    case NID_sha256:
+        fc = S390X_HMAC_SHA_256;
+        break;
+    case NID_sha384:
+        fc = S390X_HMAC_SHA_384;
+        break;
+    case NID_sha512:
+        fc = S390X_HMAC_SHA_512;
+        break;
+    default:
+        return 0;
+    }
+
+    if ((OPENSSL_s390xcap_P.kmac[1] & S390X_CAPBIT(fc)) == 0)
+        return 0;
+
+    return fc;
+}
+
+static void s390x_call_kmac(HMAC_CTX *ctx, const unsigned char *in, size_t len)
+{
+    unsigned int fc = ctx->plat.s390x.fc;
+
+    if (ctx->plat.s390x.ikp)
+        fc |= S390X_KMAC_IKP;
+
+    if (ctx->plat.s390x.iimp)
+        fc |= S390X_KMAC_IIMP;
+
+    switch (ctx->plat.s390x.fc) {
+    case S390X_HMAC_SHA_224:
+    case S390X_HMAC_SHA_256:
+        ctx->plat.s390x.param.hmac_224_256.imbl += ((uint64_t)len * 8);
+        break;
+    case S390X_HMAC_SHA_384:
+    case S390X_HMAC_SHA_512:
+        ctx->plat.s390x.param.hmac_384_512.imbl += ((uint128_t)len * 8);
+        break;
+    default:
+        break;
+    }
+
+    s390x_kmac(in, len, fc, &ctx->plat.s390x.param);
+
+    ctx->plat.s390x.ikp = 1;
+}
+
+int s390x_HMAC_init(HMAC_CTX *ctx, const void *key, int key_len, ENGINE *impl)
+{
+    unsigned char *key_param;
+    unsigned int key_param_len;
+
+    ctx->plat.s390x.fc = s390x_fc_from_md(ctx->md);
+    if (ctx->plat.s390x.fc == 0)
+        return -1; /* Not supported by kmac instruction */
+
+    ctx->plat.s390x.blk_size = EVP_MD_get_block_size(ctx->md);
+    if (ctx->plat.s390x.blk_size < 0)
+        return 0;
+
+    if (ctx->plat.s390x.size !=
+        (size_t)(ctx->plat.s390x.blk_size * HMAC_S390X_BUF_NUM_BLOCKS)) {
+        OPENSSL_clear_free(ctx->plat.s390x.buf, ctx->plat.s390x.size);
+        ctx->plat.s390x.size = 0;
+        ctx->plat.s390x.buf = OPENSSL_zalloc(ctx->plat.s390x.blk_size *
+                                             HMAC_S390X_BUF_NUM_BLOCKS);
+        if (ctx->plat.s390x.buf == NULL)
+            return 0;
+        ctx->plat.s390x.size = ctx->plat.s390x.blk_size *
+            HMAC_S390X_BUF_NUM_BLOCKS;
+    }
+    ctx->plat.s390x.num = 0;
+
+    ctx->plat.s390x.ikp = 0;
+    ctx->plat.s390x.iimp = 1;
+
+    switch (ctx->plat.s390x.fc) {
+    case S390X_HMAC_SHA_224:
+    case S390X_HMAC_SHA_256:
+        ctx->plat.s390x.param.hmac_224_256.imbl = 0;
+        OPENSSL_cleanse(ctx->plat.s390x.param.hmac_224_256.h,
+                        sizeof(ctx->plat.s390x.param.hmac_224_256.h));
+        break;
+    case S390X_HMAC_SHA_384:
+    case S390X_HMAC_SHA_512:
+        ctx->plat.s390x.param.hmac_384_512.imbl = 0;
+        OPENSSL_cleanse(ctx->plat.s390x.param.hmac_384_512.h,
+                        sizeof(ctx->plat.s390x.param.hmac_384_512.h));
+        break;
+    default:
+        return 0;
+    }
+
+    if (key != NULL) {
+        switch (ctx->plat.s390x.fc) {
+        case S390X_HMAC_SHA_224:
+        case S390X_HMAC_SHA_256:
+            OPENSSL_cleanse(&ctx->plat.s390x.param.hmac_224_256.key,
+                            sizeof(ctx->plat.s390x.param.hmac_224_256.key));
+            key_param = ctx->plat.s390x.param.hmac_224_256.key;
+            key_param_len = sizeof(ctx->plat.s390x.param.hmac_224_256.key);
+            break;
+        case S390X_HMAC_SHA_384:
+        case S390X_HMAC_SHA_512:
+            OPENSSL_cleanse(&ctx->plat.s390x.param.hmac_384_512.key,
+                            sizeof(ctx->plat.s390x.param.hmac_384_512.key));
+            key_param = ctx->plat.s390x.param.hmac_384_512.key;
+            key_param_len = sizeof(ctx->plat.s390x.param.hmac_384_512.key);
+            break;
+        default:
+            return 0;
+        }
+
+        if (!ossl_assert(ctx->plat.s390x.blk_size <= (int)key_param_len))
+            return 0;
+
+        if (key_len > ctx->plat.s390x.blk_size) {
+            if (!EVP_DigestInit_ex(ctx->md_ctx, ctx->md, impl)
+                    || !EVP_DigestUpdate(ctx->md_ctx, key, key_len)
+                    || !EVP_DigestFinal_ex(ctx->md_ctx, key_param,
+                                           &key_param_len))
+                return 0;
+        } else {
+            if (key_len < 0 || key_len > (int)key_param_len)
+                return 0;
+            memcpy(key_param, key, key_len);
+            /* remaining key bytes already zeroed out above */
+        }
+    }
+
+    return 1;
+}
+
+int s390x_HMAC_update(HMAC_CTX *ctx, const unsigned char *data, size_t len)
+{
+    size_t remain, num;
+
+    if (len == 0)
+        return 1;
+
+    /* buffer is full, process it now */
+    if (ctx->plat.s390x.num == ctx->plat.s390x.size) {
+        s390x_call_kmac(ctx, ctx->plat.s390x.buf, ctx->plat.s390x.num);
+
+        ctx->plat.s390x.num = 0;
+    }
+
+    remain = ctx->plat.s390x.size - ctx->plat.s390x.num;
+    if (len > remain) {
+        /* data does not fit into buffer */
+        if (ctx->plat.s390x.num > 0) {
+            /* first fill buffer and process it */
+            memcpy(&ctx->plat.s390x.buf[ctx->plat.s390x.num], data, remain);
+            ctx->plat.s390x.num += remain;
+
+            s390x_call_kmac(ctx, ctx->plat.s390x.buf, ctx->plat.s390x.num);
+
+            ctx->plat.s390x.num = 0;
+
+            data += remain;
+            len -= remain;
+        }
+
+        if (!ossl_assert(ctx->plat.s390x.num == 0))
+            return 0;
+
+        if (len > ctx->plat.s390x.size) {
+            /*
+             * remaining data is still larger than buffer, process remaining
+             * full blocks of input directly
+             */
+            remain = len % ctx->plat.s390x.blk_size;
+            num = len - remain;
+
+            s390x_call_kmac(ctx, data, num);
+
+            data += num;
+            len -= num;
+        }
+    }
+
+    /* add remaining input data (which is < buffer size) to buffer */
+    if (!ossl_assert(len <= ctx->plat.s390x.size))
+        return 0;
+
+    if (len > 0) {
+        memcpy(&ctx->plat.s390x.buf[ctx->plat.s390x.num], data, len);
+        ctx->plat.s390x.num += len;
+    }
+
+    return 1;
+}
+
+int s390x_HMAC_final(HMAC_CTX *ctx, unsigned char *md, unsigned int *len)
+{
+    void *result;
+    unsigned int res_len;
+
+    ctx->plat.s390x.iimp = 0; /* last block */
+    s390x_call_kmac(ctx, ctx->plat.s390x.buf, ctx->plat.s390x.num);
+
+    ctx->plat.s390x.num = 0;
+
+    switch (ctx->plat.s390x.fc) {
+    case S390X_HMAC_SHA_224:
+        result = &ctx->plat.s390x.param.hmac_224_256.h[0];
+        res_len = SHA224_DIGEST_LENGTH;
+        break;
+    case S390X_HMAC_SHA_256:
+        result = &ctx->plat.s390x.param.hmac_224_256.h[0];
+        res_len = SHA256_DIGEST_LENGTH;
+        break;
+    case S390X_HMAC_SHA_384:
+        result = &ctx->plat.s390x.param.hmac_384_512.h[0];
+        res_len = SHA384_DIGEST_LENGTH;
+        break;
+    case S390X_HMAC_SHA_512:
+        result = &ctx->plat.s390x.param.hmac_384_512.h[0];
+        res_len = SHA512_DIGEST_LENGTH;
+        break;
+    default:
+        return 0;
+    }
+
+    memcpy(md, result, res_len);
+    if (len != NULL)
+        *len = res_len;
+
+    return 1;
+}
+
+int s390x_HMAC_CTX_copy(HMAC_CTX *dctx, HMAC_CTX *sctx)
+{
+    dctx->plat.s390x.fc = sctx->plat.s390x.fc;
+    dctx->plat.s390x.blk_size = sctx->plat.s390x.blk_size;
+    dctx->plat.s390x.ikp = sctx->plat.s390x.ikp;
+    dctx->plat.s390x.iimp = sctx->plat.s390x.iimp;
+
+    memcpy(&dctx->plat.s390x.param, &sctx->plat.s390x.param,
+           sizeof(dctx->plat.s390x.param));
+
+    dctx->plat.s390x.buf = NULL;
+    if (sctx->plat.s390x.buf != NULL) {
+        dctx->plat.s390x.buf = OPENSSL_memdup(sctx->plat.s390x.buf,
+                                              sctx->plat.s390x.size);
+        if (dctx->plat.s390x.buf == NULL)
+            return 0;
+    }
+
+    dctx->plat.s390x.size = sctx->plat.s390x.size;
+    dctx->plat.s390x.num = sctx->plat.s390x.num;
+
+    return 1;
+}
+
+int s390x_HMAC_CTX_cleanup(HMAC_CTX *ctx)
+{
+    OPENSSL_clear_free(ctx->plat.s390x.buf, ctx->plat.s390x.size);
+    ctx->plat.s390x.buf = NULL;
+    ctx->plat.s390x.size = 0;
+    ctx->plat.s390x.num = 0;
+
+    OPENSSL_cleanse(&ctx->plat.s390x.param, sizeof(ctx->plat.s390x.param));
+
+    ctx->plat.s390x.blk_size = 0;
+    ctx->plat.s390x.ikp = 0;
+    ctx->plat.s390x.iimp = 1;
+
+    ctx->plat.s390x.fc = 0;
+
+    return 1;
+}
+
+#endif

--- a/crypto/s390x_arch.h
+++ b/crypto/s390x_arch.h
@@ -192,5 +192,8 @@ extern int OPENSSL_s390xcex;
 # define S390X_KMA_HS           0x400
 # define S390X_KDSA_D           0x80
 # define S390X_KLMD_PS          0x100
+# define S390X_KMAC_IKP         0x8000
+# define S390X_KMAC_IIMP        0x4000
+# define S390X_KMAC_CCUP        0x2000
 
 #endif

--- a/crypto/s390x_arch.h
+++ b/crypto/s390x_arch.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2017-2024 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -115,6 +115,7 @@ extern int OPENSSL_s390xcex;
 # define S390X_MSA5             57      /* message-security-assist-ext. 5 */
 # define S390X_MSA3             76      /* message-security-assist-ext. 3 */
 # define S390X_MSA4             77      /* message-security-assist-ext. 4 */
+# define S390X_MSA12            86      /* message-security-assist-ext. 12 */
 # define S390X_VX               129     /* vector */
 # define S390X_VXD              134     /* vector packed decimal */
 # define S390X_VXE              135     /* vector enhancements 1 */
@@ -150,6 +151,14 @@ extern int OPENSSL_s390xcex;
 /* km */
 # define S390X_XTS_AES_128      50
 # define S390X_XTS_AES_256      52
+# define S390X_XTS_AES_128_MSA10 82
+# define S390X_XTS_AES_256_MSA10 84
+
+/* kmac */
+# define S390X_HMAC_SHA_224     112
+# define S390X_HMAC_SHA_256     113
+# define S390X_HMAC_SHA_384     114
+# define S390X_HMAC_SHA_512     115
 
 /* prno */
 # define S390X_SHA_512_DRNG     3

--- a/doc/man3/OPENSSL_s390xcap.pod
+++ b/doc/man3/OPENSSL_s390xcap.pod
@@ -74,6 +74,7 @@ the numbering is continuous across 64-bit mask boundaries.
       :
       # 76    1<<51    message-security assist extension 3
       # 77    1<<50    message-security assist extension 4
+      # 86    1<<41    message-security-assist extension 12
       :
       #129    1<<62    vector facility
       #134    1<<57    vector packed decimal facility
@@ -110,6 +111,8 @@ the numbering is continuous across 64-bit mask boundaries.
       # 50    1<<13    KM-XTS-AES-128
       # 52    1<<11    KM-XTS-AES-256
       :
+      # 82    1<<45    KM-XTS-AES-128-MSA10
+      # 84    1<<43    KM-XTS-AES-256-MSA10
 
  kmc  :
       # 18    1<<45    KMC-AES-128
@@ -122,6 +125,10 @@ the numbering is continuous across 64-bit mask boundaries.
       # 19    1<<44    KMAC-AES-192
       # 20    1<<43    KMAC-AES-256
       :
+      # 112   1<<15    KMAC-SHA-224 
+      # 113   1<<14    KMAC-SHA-256 
+      # 114   1<<13    KMAC-SHA-384 
+      # 115   1<<12    KMAC-SHA-512 
 
  kmctr:
       :

--- a/test/hmactest.c
+++ b/test/hmactest.c
@@ -279,7 +279,7 @@ static int test_hmac_copy_uninited(void)
 static char *pt(unsigned char *md, unsigned int len)
 {
     unsigned int i;
-    static char buf[80];
+    static char buf[200];
 
     if (md == NULL)
         return NULL;
@@ -289,6 +289,144 @@ static char *pt(unsigned char *md, unsigned int len)
 }
 # endif
 
+static struct test_chunks_st {
+    const char *md_name;
+    char key[256];
+    int key_len;
+    int chunks;
+    int chunk_size[10];
+    const char *digest;
+} test_chunks[12] = {
+    {
+        "SHA224",
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", 64,
+        4, { 1, 50, 200, 4000 },
+        "40821a39dd54f01443b3f96b9370a15023fbdd819a074ffc4b703c77"
+    },
+    {
+        "SHA224",
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", 192,
+        10, { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 },
+        "55ffa85e53e9a68f41c8d653c60b4ada9566d22aed3811834882661c"
+    },
+    {
+        "SHA224", "0123456789abcdef0123456789abcdef", 32,
+        4, { 100, 4096, 100, 3896 },
+        "0fd18e7d8e974f401b29bf0502a71f6a9b77804e9191380ce9f48377"
+    },
+    {
+        "SHA256",
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", 64,
+        4, { 1, 50, 200, 4000 },
+        "f67a46fa77c66d3ea5b3ffb9a10afb3e501eaadd16b15978fdee9f014a782140"
+    },
+    {
+        "SHA256",
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", 192,
+        10, { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 },
+        "21a6f61ed6dbec30b58557a80988ff610d69b50b2e96d75863ab50f99da58c9d"
+    },
+    {
+        "SHA256", "0123456789abcdef0123456789abcdef", 32,
+        4, { 100, 4096, 100, 3896 },
+        "7bfd45c1bdde9b79244816b0aea0a67ea954a182e74c60410bfbc1fdc4842660"
+    },
+    {
+        "SHA384",
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", 64,
+        4, { 1, 50, 200, 4000 },
+        "e270e3c8ca3f2796a0c29cc7569fcec7584b04db26da64326aca0d17bd7731de"
+        "938694b273f3dafe6e2dc123cde26640"
+    },
+    {
+        "SHA384",
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", 192,
+        10, { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 },
+        "7036fd7d251298975acd18938471243e92fffe67be158f16c910c400576592d2"
+        "618c3c077ef25d703312668bd2d813ff"
+    },
+    {
+        "SHA384", "0123456789abcdef0123456789abcdef", 32,
+        4, { 100, 8192, 100, 8092 },
+        "0af8224145bd0812d2e34ba1f980ed4d218461271a54cce75dc43d36eda01e4e"
+        "ff4299c1ebf533a7ae636fa3e6aff903"
+    },
+    {
+        "SHA512",
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", 64,
+        4, { 1, 50, 200, 4000 },
+        "4016e960e2342553d4b9d34fb57355ab8b7f33af5dc2676fc1189e94b38f2b2c"
+        "a0ec8dc3c8b95fb1109d58480cea1e8f88e02f34ad79b303e4809373c46c1b16"
+    },
+    {
+        "SHA512",
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", 192,
+        10, { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 },
+        "7ceb6a421fc19434bcb7ec9c8a15ea524dbfb896c24f5f517513f06597de99b1"
+        "918eb6b2472e52215ec7d1b5544766f79ff6ac6d1eb456f19a93819fa2d43c29"
+    },
+    {
+        "SHA512", "0123456789abcdef0123456789abcdef", 32,
+        4, { 100, 8192, 100, 8092 },
+        "cebf722ffdff5f0e4cbfbd480cd086101d4627d30d42f1f7cf21c43251018069"
+        "854d8e030b5a54cec1e2245d5b4629ff928806d4eababb427d751ec7c274047f"
+    },
+};
+
+static int test_hmac_chunks(int idx)
+{
+    char *p;
+    HMAC_CTX *ctx = NULL;
+    unsigned char buf[32768];
+    unsigned int len;
+    const EVP_MD *md;
+    int i, ret = 0;
+
+    if (!TEST_ptr(md = EVP_get_digestbyname(test_chunks[idx].md_name)))
+        goto err;
+
+    if (!TEST_ptr(ctx = HMAC_CTX_new()))
+        goto err;
+
+#ifdef CHARSET_EBCDIC
+    ebcdic2ascii(test_chunks[idx].key, test_chunks[idx].key,
+                 test_chunks[idx].key_len);
+#endif
+
+    if (!TEST_true(HMAC_Init_ex(ctx, test_chunks[idx].key,
+                                test_chunks[idx].key_len, md, NULL)))
+        goto err;
+
+    for (i = 0; i < test_chunks[idx].chunks; i++) {
+        if (!TEST_true((test_chunks[idx].chunk_size[i] < (int)sizeof(buf))))
+            goto err;
+        memset(buf, i, test_chunks[idx].chunk_size[i]);
+        if (!TEST_true(HMAC_Update(ctx, buf, test_chunks[idx].chunk_size[i])))
+            goto err;
+    }
+
+    if (!TEST_true(HMAC_Final(ctx, buf, &len)))
+        goto err;
+
+    p = pt(buf, len);
+    if (!TEST_ptr(p) || !TEST_str_eq(p, test_chunks[idx].digest))
+        goto err;
+
+    ret = 1;
+
+err:
+    HMAC_CTX_free(ctx);
+    return ret;
+}
+
 int setup_tests(void)
 {
     ADD_ALL_TESTS(test_hmac_md5, 4);
@@ -297,6 +435,8 @@ int setup_tests(void)
     ADD_TEST(test_hmac_run);
     ADD_TEST(test_hmac_copy);
     ADD_TEST(test_hmac_copy_uninited);
+    ADD_ALL_TESTS(test_hmac_chunks,
+                  sizeof(test_chunks) / sizeof(struct test_chunks_st));
     return 1;
 }
 


### PR DESCRIPTION
The CPACF instruction KMAC provides support for accelerating the HMAC algorithm on newer machines for HMAC with SHA-224, SHA-256, SHA-384, and SHA-512.

Preliminary measurements showed performance improvements of up to a factor of 2, dependent on the message size, whether chunking is used and the size of the chunks.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
- [X] tests are added or updated