### PR TITLE
rand: make public/private chaining to primary configurable

### DIFF
--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -272,8 +272,8 @@ static int provider_conf_activate(OSSL_LIB_CTX *libctx, const char *name,
     return ok;
 }
 
-static int provider_conf_parse_bool_setting(const char *confname,
-                                            const char *confvalue, int *val)
+int provider_conf_parse_bool_setting(const char *confname,
+                                     const char *confvalue, int *val)
 {
 
     if (confvalue == NULL) {

--- a/crypto/rand/rand_local.h
+++ b/crypto/rand/rand_local.h
@@ -25,6 +25,11 @@
 # define PRIMARY_RESEED_TIME_INTERVAL            (60 * 60) /* 1 hour */
 # define SECONDARY_RESEED_TIME_INTERVAL          (7 * 60)  /* 7 minutes */
 
+/* Whether to chain public/private DRBGs to primary DRBG */
+# ifndef OPENSSL_RAND_CHAIN
+#  define OPENSSL_RAND_CHAIN 1
+# endif
+
 # ifndef FIPS_MODULE
 /* The global RAND method, and the global buffer and DRBG instance. */
 extern RAND_METHOD ossl_rand_meth;

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -478,6 +478,13 @@ to access the same randomness sources from outside the validated boundary.
 
 This sets the property query used when fetching the randomness source.
 
+=item B<chain>
+
+This controls whether or not public/private random instances chain to primary
+for seeding, or not. Default is 1, meaning to chain. Set to 0, for
+public/private random instances to acquire entropy seed directly. See
+L<EVP_RAND(7)> for more details.
+
 =back
 
 =head1 EXAMPLES

--- a/doc/man7/EVP_RAND.pod
+++ b/doc/man7/EVP_RAND.pod
@@ -153,6 +153,11 @@ EVP_RAND_generate(<public>, ...) and
 EVP_RAND_generate(<private>, ...),
 respectively.
 
+When `[random] chain=0` is set in `openssl.cnf`, the public & private
+DRBG are not chained to primary, and instead use seed source
+directly. It is also possibly to configure OpenSSL to default to no
+chaining with -DOPENSSL_RAND_CHAIN=0.
+
 =head1 RESEEDING
 
 A DRBG instance seeds itself automatically, pulling random input from

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -105,6 +105,8 @@ int ossl_provider_test_operation_bit(OSSL_PROVIDER *provider, size_t bitnum,
 
 /* Configuration */
 void ossl_provider_add_conf_module(void);
+int provider_conf_parse_bool_setting(const char *confname,
+                                     const char *confvalue, int *val);
 
 /* Child providers */
 int ossl_provider_init_as_child(OSSL_LIB_CTX *ctx,

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -225,6 +225,7 @@ static int test_drbg_reseed(int expect_success,
      * step 3: check postconditions
      */
 
+#if OPENSSL_RAND_CHAIN == 1
     /* Test whether reseeding succeeded as expected */
     if (!TEST_int_eq(state(primary), expected_state)
         || !TEST_int_eq(state(public), expected_state)
@@ -236,6 +237,12 @@ static int test_drbg_reseed(int expect_success,
         if (!TEST_int_ge(reseed_counter(primary), primary_reseed))
             return 0;
     }
+#else
+    /* Test whether reseeding succeeded as expected */
+    if (!TEST_int_eq(state(public), expected_state)
+        || !TEST_int_eq(state(private), expected_state))
+        return 0;
+#endif
 
     if (expect_public_reseed >= 0) {
         /* Test whether public DRBG was reseeded as expected */
@@ -246,7 +253,7 @@ static int test_drbg_reseed(int expect_success,
     }
 
     if (expect_private_reseed >= 0) {
-        /* Test whether public DRBG was reseeded as expected */
+        /* Test whether private DRBG was reseeded as expected */
         if (!TEST_int_ge(reseed_counter(private), private_reseed)
                 || !TEST_uint_ge(reseed_counter(private),
                                  reseed_counter(primary)))
@@ -254,6 +261,7 @@ static int test_drbg_reseed(int expect_success,
     }
 
     if (expect_success == 1) {
+#if OPENSSL_RAND_CHAIN == 1
         /* Test whether reseed time of primary DRBG is set correctly */
         if (!TEST_time_t_le(before_reseed, reseed_time(primary))
             || !TEST_time_t_le(reseed_time(primary), after_reseed))
@@ -263,6 +271,17 @@ static int test_drbg_reseed(int expect_success,
         if (!TEST_time_t_ge(reseed_time(public), reseed_time(primary))
             || !TEST_time_t_ge(reseed_time(private), reseed_time(primary)))
             return 0;
+#else
+        /* Test whether reseed times of child DRBGs are set correctly */
+        if (!TEST_time_t_le(before_reseed, reseed_time(public))
+            || !TEST_time_t_le(reseed_time(public), after_reseed))
+            return 0;
+
+        if (!TEST_time_t_le(before_reseed, reseed_time(private))
+            || !TEST_time_t_le(reseed_time(private), after_reseed))
+            return 0;
+#endif
+
     } else {
         ERR_clear_error();
     }
@@ -548,9 +567,11 @@ static int test_rand_fork_safety(int i)
 static int test_rand_reseed(void)
 {
     EVP_RAND_CTX *primary, *public, *private;
-    unsigned char rand_add_buf[256];
     int rv = 0;
+#if OPENSSL_RAND_CHAIN == 1
+    unsigned char rand_add_buf[256];
     time_t before_reseed;
+#endif
 
     if (using_fips_rng())
         return TEST_skip("CRNGT cannot be disabled");
@@ -561,12 +582,13 @@ static int test_rand_reseed(void)
         return 0;
 #endif
 
-    /* All three DRBGs should be non-null */
+    /* All three DRBGs and primary seed should be non-null */
     if (!TEST_ptr(primary = RAND_get0_primary(NULL))
         || !TEST_ptr(public = RAND_get0_public(NULL))
         || !TEST_ptr(private = RAND_get0_private(NULL)))
         return 0;
 
+#if OPENSSL_RAND_CHAIN == 1
     /* There should be three distinct DRBGs, two of them chained to primary */
     if (!TEST_ptr_ne(public, private)
         || !TEST_ptr_ne(public, primary)
@@ -574,6 +596,15 @@ static int test_rand_reseed(void)
         || !TEST_ptr_eq(prov_rand(public)->parent, prov_rand(primary))
         || !TEST_ptr_eq(prov_rand(private)->parent, prov_rand(primary)))
         return 0;
+#else
+    /* There should be three distinct DRBGs, all chained to seed */
+    if (!TEST_ptr_ne(public, private)
+        || !TEST_ptr_ne(public, primary)
+        || !TEST_ptr_ne(private, primary)
+        || !TEST_ptr_eq(prov_rand(public)->parent, prov_rand(primary)->parent)
+        || !TEST_ptr_eq(prov_rand(private)->parent, prov_rand(primary)->parent))
+        return 0;
+#endif
 
     /* Disable CRNG testing for the primary DRBG */
     if (!TEST_true(disable_crngt(primary)))
@@ -602,6 +633,7 @@ static int test_rand_reseed(void)
                                     0, 0, 0, 0)))
         goto error;
 
+#if OPENSSL_RAND_CHAIN == 1
     /*
      * Test whether the public and private DRBG are both reseeded when their
      * reseed counters differ from the primary's reseed counter.
@@ -656,6 +688,7 @@ static int test_rand_reseed(void)
                                     1, 1, 1,
                                     before_reseed)))
         goto error;
+#endif
 
     rv = 1;
 


### PR DESCRIPTION
Add runtime configuration `[random] chain = <bool>` and build-time
configuration -DOPENSSL_RAND_CHAIN=int to control if public/private
DRBGs are chained to primary, or not. Defaults to chain, current v3+
behaviour.

This is useful for NIST ESV certification, as currently chained and
unchained entropy sources are considered to be distinct. Thus
operating without chaining, may allow reuse of an existing ESV
certificate for Linux kernel, or Jitter Entropy library without need
to re-submit a separate ESV certificate for linux+OpenSSL or
jitter+OpenSSL, as per current guidance.

Also note, future developments in Linux kernel may make un-chained
mode of operation particularly attractive with inclusion of getrandom
in vDSO in upcomming Linux kernel v6.11, potentially being quicker
than chaining with locks to a syscall. Thus there is performance
optimisations to this as well.

Note current chaining behaviour is preserved, and it is considered to
be behave better on low entropy systems.
