### PR TITLE
Ensure the msg_callback is called on CCS receipt in TLSv1.3

### DIFF
--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -750,8 +750,11 @@ int tls_get_more_records(OSSL_RECORD_LAYER *rl)
         }
         /*
          * CCS messages are ignored in TLSv1.3. We treat it like an empty
-         * handshake record
+         * handshake record - but we still call the msg_callback
          */
+        if (rl->msg_callback != NULL)
+            rl->msg_callback(0, TLS1_3_VERSION, SSL3_RT_CHANGE_CIPHER_SPEC,
+                             thisrr->data, 1, rl->cbarg);
         thisrr->type = SSL3_RT_HANDSHAKE;
         if (++(rl->empty_record_count) > MAX_EMPTY_RECORDS) {
             RLAYERfatal(rl, SSL_AD_UNEXPECTED_MESSAGE,


### PR DESCRIPTION
CCS records are ignore in TLSv1.3. But we should still call the msg_callback anyway.

Fixes #25166
