### PR TITLE
Add debuginfo build target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,7 +567,7 @@ jobs:
     - name: package installs
       run: |
         sudo apt-get update
-        sudo apt-get -yq install bison gettext keyutils ldap-utils libldap2-dev libkeyutils-dev python3 python3-paste python3-pyrad slapd tcsh python3-virtualenv virtualenv python3-kdcproxy
+        sudo apt-get -yq install bison gettext keyutils ldap-utils libldap2-dev libkeyutils-dev python3 python3-paste python3-pyrad slapd tcsh python3-virtualenv virtualenv python3-kdcproxy gdb
     - name: install cpanm and Test2::V0 for gost_engine testing
       uses: perl-actions/install-with-cpanm@stable
       with:
@@ -590,6 +590,11 @@ jobs:
       run: make test TESTS="test_external_tlsfuzzer"
     - name: test external oqs-provider
       run: make test TESTS="test_external_oqsprovider"
+    - name: test ability to produce debuginfo files
+      run: |
+        make debuginfo
+        gdb < <(echo -e "file ./libcrypto.so.3\nquit") > ./results
+        grep -q "Reading symbols from.*libcrypto\.so\.3\.debug" results
 
   external-test-pyca:
     runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,11 @@ OpenSSL 3.4
 
 ### Changes between 3.3 and 3.4 [xx XXX xxxx]
 
+ * Add debuginfo makefile target for unix platofms to produce
+   a separated DWARF info file from the corresponding shared libs
+
+   *Neil Horman*
+
  * Add feature to retrieve configured TLS signature algorithms,
    e.g., via the openssl list command.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,8 +29,8 @@ OpenSSL 3.4
 
 ### Changes between 3.3 and 3.4 [xx XXX xxxx]
 
- * Add debuginfo makefile target for unix platofms to produce
-   a separated DWARF info file from the corresponding shared libs
+ * Add debuginfo Makefile target for unix platforms to produce
+   a separate DWARF info file from the corresponding shared libs.
 
    *Neil Horman*
 

--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -78,6 +78,7 @@ my %targets=(
         AR              => "ar",
         ARFLAGS         => "qc",
         CC              => "cc",
+        OBJCOPY         => "objcopy",
         bin_cflags      =>
             sub {
                 my @flags = ();

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -373,6 +373,7 @@ CFLAGS={- join(' ', @{$config{CFLAGS}}) -}
 CXXFLAGS={- join(' ', @{$config{CXXFLAGS}}) -}
 LDFLAGS= {- join(' ', @{$config{LDFLAGS}}) -}
 EX_LIBS= {- join(' ', @{$config{LDLIBS}}) -}
+OBJCOPY={- $config{OBJCOPY} -}
 
 MAKEDEPEND={- $config{makedepcmd} -}
 
@@ -533,6 +534,11 @@ LANG=C
 {- dependmagic('build_programs', 'Build the openssl executables and scripts'); -}: build_programs_nodep
 
 all: build_sw {- "build_docs" if !$disabled{docs}; -} ## Build software and documentation
+debuginfo: $(SHLIBS)
+	@set -e; for i in $(SHLIBS); do \
+		$(OBJCOPY) --only-keep-debug $$i $$i.debug; \
+		$(OBJCOPY) --strip-debug --add-gnu-debuglink=$$i.debug $$i; \
+	done;
 
 ##@ Documentation
 build_generated_pods: $(GENERATED_PODS)

--- a/Configure
+++ b/Configure
@@ -758,6 +758,7 @@ my %user = (
     RANLIB      => env('RANLIB'),
     RC          => env('RC') || env('WINDRES'),
     RCFLAGS     => [ env('RCFLAGS') || () ],
+    OBJCOPY     => undef,
     RM          => undef,
    );
 # Info about what "make variables" may be prefixed with the cross compiler

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1676,6 +1676,12 @@ described here.  Examine the Makefiles themselves for the full list.
     build_docs
                    Build all documentation components.
 
+    debuginfo
+                    On unix platforms, this target can be used to create .debug
+                    libraries, which separate the DWARF information in the
+                    shared library ELF files into a separate file for use
+                    in post-mortem (core dump) debugging
+
     clean
                    Remove all build artefacts and return the directory to a "clean"
                    state.


### PR DESCRIPTION
In the webinar we are currently producing on debugging openssl applications, we talk about ways to allow debugable binaries without having to ship all the debug DWARF information to production systems.

Add an optional target to do that DWARF separation to aid users


##### Checklist
- [x] documentation is added or updated

