### PR TITLE
Return SSL_AD_DECRYPT_ERROR alert on PSK binder validation failure (RFC 8446)

### DIFF
--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1697,7 +1697,7 @@ int tls_psk_do_binder(SSL_CONNECTION *s, const EVP_MD *md,
         /* HMAC keys can't do EVP_DigestVerify* - use CRYPTO_memcmp instead */
         ret = (CRYPTO_memcmp(binderin, binderout, hashsize) == 0);
         if (!ret)
-            SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_BINDER_DOES_NOT_VERIFY);
+            SSLfatal(s, SSL_AD_DECRYPT_ERROR, SSL_R_BINDER_DOES_NOT_VERIFY);
     }
 
  err:


### PR DESCRIPTION
Fixes: #25106
CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
