### PR TITLE
We can't check policy if we got an empty stack of certs

### DIFF
--- a/crypto/x509/pcy_tree.c
+++ b/crypto/x509/pcy_tree.c
@@ -110,6 +110,8 @@ static int tree_init(X509_POLICY_TREE **ptree, STACK_OF(X509) *certs,
 
     *ptree = NULL;
 
+    if (n < 0)
+        return X509_PCY_TREE_INTERNAL;
     /* Can't do anything with just a trust anchor */
     if (n == 0)
         return X509_PCY_TREE_EMPTY;


### PR DESCRIPTION
Some extra hardening.

`tree_init` gets a stack of certs as an external argument from the `X509_policy_check` and doesn't do any checks.

I believe we can leave without tests here

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
