### PR TITLE
Apply the FIPS_eddsa_no_verify_digested indicator on prehash EdDSA only

### DIFF
--- a/providers/implementations/signature/eddsa_sig.c
+++ b/providers/implementations/signature/eddsa_sig.c
@@ -383,9 +383,10 @@ static int ed448_digest_sign(void *vpeddsactx, unsigned char *sigret,
 static int fips_check_verify(PROV_EDDSA_CTX *ctx)
 {
 #ifdef FIPS_MODULE
-    if (!OSSL_FIPS_IND_ON_UNAPPROVED(ctx, OSSL_FIPS_IND_SETTABLE0,
-                                     ctx->libctx, "Verify", "EdDSA",
-                                     FIPS_eddsa_no_verify_digested))
+    if (ctx->prehash_flag
+        && !OSSL_FIPS_IND_ON_UNAPPROVED(ctx, OSSL_FIPS_IND_SETTABLE0,
+                                        ctx->libctx, "Verify", "EdDSA",
+                                        FIPS_eddsa_no_verify_digested))
         return 0;
 #endif  /* FIPS_MODULE */
     return 1;


### PR DESCRIPTION
This is urgent fix for the CI breakage on the master branch.

I am not even sure the FIPS_eddsa_no_verify_digested makes much sense but if anything it should be applied to the prehash variant only as the non-prehash does the digest internally.

Alternatively, we should revert #25032