### PR TITLE
Fix file descriptor leak in RAND_write_file

### DIFF
--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -208,8 +208,12 @@ int RAND_write_file(const char *file)
          * should be restrictive from the start
          */
         int fd = open(file, O_WRONLY | O_CREAT | O_BINARY, 0600);
-        if (fd != -1)
+
+        if (fd != -1) {
             out = fdopen(fd, "wb");
+            if (out == NULL)
+                close(fd);
+        }
     }
 #endif
 


### PR DESCRIPTION
Fixes #25064

When the `open()` succeeds, but the `fdopen()` fails, the `fd` from the `open()` is leaked. Explicitly `close()` it before falling through to the old code.

There is no functional change and no documentation changes needed.
