### PR TITLE
New speed tests fail on OpenBSD

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1259,6 +1259,15 @@ my %targets = (
         perlasm_scheme   => "elf",
     },
 
+    "BSD-openbsd-x86_64" => {
+        inherit_from     => [ "BSD-nodef-generic64" ],
+        lib_cppflags     => add("-DL_ENDIAN"),
+        bn_ops           => "SIXTY_FOUR_BIT_LONG",
+        asm_arch         => 'x86_64',
+        perlasm_scheme   => "elf",
+        disable          => add("async"),
+    },
+
 #### SCO/Caldera targets.
 #
 # Originally we had like unixware-*, unixware-*-pentium, unixware-*-p6, etc.

--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -807,7 +807,7 @@ EOF
       [ 'ia64-.*-openbsd.*',      { target => "BSD-nodef-ia64" } ],
       [ 'ia64-.*-.*bsd.*',        { target => "BSD-ia64" } ],
       [ 'x86_64-.*-dragonfly.*',  { target => "BSD-x86_64" } ],
-      [ 'amd64-.*-openbsd.*',     { target => "BSD-nodef-x86_64" } ],
+      [ 'amd64-.*-openbsd.*',     { target => "BSD-openbsd-x86_64" } ],
       [ 'amd64-.*-.*bsd.*',       { target => "BSD-x86_64" } ],
       [ 'arm64-.*-.*bsd.*',       { target => "BSD-aarch64" } ],
       [ 'armv6-.*-.*bsd.*',       { target => "BSD-armv4" } ],


### PR DESCRIPTION
this is caused by '-async_jobs' used by newly added openssl speed test. The speed asyn_jobs option depends on getcontext() function found in libc. OpenBSD seems to be minority which lacks this function.

If I build OpenSSL on OpenBSD with no specific options test test_speed fails. To workarond it I must pass `no-async` option to `./Configure` command when preparing my build. This is kind of unfortunate.

The proposed change fixes ./Configure for openbsd-amd64. It's a proof-of-concept to check if I'm heading in right direction.

There might be other OSes which are not able to run async speed test because they lack getcontext() function.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
