### PR TITLE
Fix Coverity 1616307

### DIFF
--- a/apps/list.c
+++ b/apps/list.c
@@ -779,10 +779,12 @@ static void list_tls_signatures(void)
     int tls_sigalg_listed = 0;
     char *builtin_sigalgs = SSL_get1_builtin_sigalgs(app_get0_libctx());
 
-    if (builtin_sigalgs != NULL && builtin_sigalgs[0] != 0) {
-        BIO_printf(bio_out, "%s", builtin_sigalgs);
+    if (builtin_sigalgs != NULL) {
+        if (builtin_sigalgs[0] != 0) {
+            BIO_printf(bio_out, "%s", builtin_sigalgs);
+            tls_sigalg_listed = 1;
+        }
         OPENSSL_free(builtin_sigalgs);
-        tls_sigalg_listed = 1;
     }
 
     /* As built-in providers don't have this capability, never error */


### PR DESCRIPTION
The value returned by `SSL_get1_builtin_sigalgs` will always be a [malloc'd `char*`](https://github.com/openssl/openssl/blob/d550d2aae531c6fa2e10b1a30d2acdf373663889/ssl/t1_lib.c#L1604), except when the function returns NULL. Therefore, we must always free it.

Fixes https://github.com/openssl/project/issues/810