### PR TITLE
test: add a default greeting to avoid printing a null pointer.

### DIFF
--- a/test/provider_internal_test.c
+++ b/test/provider_internal_test.c
@@ -22,7 +22,7 @@ static OSSL_PARAM greeting_request[] = {
 
 static int test_provider(OSSL_PROVIDER *prov, const char *expected_greeting)
 {
-    const char *greeting = NULL;
+    const char *greeting = "no greeting received";
     int ret = 0;
 
     ret =


### PR DESCRIPTION
urgent: unit test breaking fix

- [ ] documentation is added or updated
- [x] tests are added or updated
