### PR TITLE
Explicitly include e_os.h for close()

### DIFF
--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -16,6 +16,7 @@
 # include <sys/stat.h>
 #endif
 
+#include "internal/e_os.h"
 #include "internal/cryptlib.h"
 
 #include <errno.h>


### PR DESCRIPTION
This is an urgent CI fix for 3.1 and 3.0 branches but should be merged to all the active branches.
