### PR TITLE
randfile.c: Fix the e_os.h include path

### DIFF
--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -16,7 +16,7 @@
 # include <sys/stat.h>
 #endif
 
-#include "internal/e_os.h"
+#include "e_os.h"
 #include "internal/cryptlib.h"
 
 #include <errno.h>


### PR DESCRIPTION
e_os.h was moved to the internal subdirectory only in 3.1

Urgent CI fix for 3.0 branch only.
