### PR TITLE
Document the output length behaviour of AES-WRAP-PAD

### DIFF
--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -388,7 +388,8 @@ of data. The amount of data written depends on the block alignment of the
 encrypted data.
 For most ciphers and modes, the amount of data written can be anything
 from zero bytes to (inl + cipher_block_size - 1) bytes.
-
+For wrap cipher modes, the amount of data written can be anything
+from zero bytes to (inl + cipher_block_size) bytes.
 For stream ciphers, the amount of data written can be anything from zero
 bytes to inl bytes.
 Thus, the buffer pointed to by I<out> must contain sufficient room for the

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -389,15 +389,11 @@ encrypted data.
 For most ciphers and modes, the amount of data written can be anything
 from zero bytes to (inl + cipher_block_size - 1) bytes.
 
-When used for wrapping algorithms such as "AES-128-WRAP" and "AES-192-WRAP-PAD"
-the encrypted data buffer I<out> should have sufficent room for
-8 + (I<inl> padded to an 8 byte boundary) bytes.
-
 For stream ciphers, the amount of data written can be anything from zero
 bytes to inl bytes.
 Thus, the buffer pointed to by I<out> must contain sufficient room for the
 operation being performed.
-The actual number of bytes written is placed in I<outl>.
+The actual length of the plaintext is placed in I<outl>.
 
 If padding is enabled (the default) then EVP_EncryptFinal_ex() encrypts
 the "final" data, that is any data that remains in a partial block.
@@ -422,10 +418,6 @@ identical to the encryption operations except that if padding is enabled the
 decrypted data buffer I<out> passed to EVP_DecryptUpdate() should have
 sufficient room for (I<inl> + cipher_block_size) bytes unless the cipher block
 size is 1 in which case I<inl> bytes is sufficient.
-
-When used for wrapping algorithms such as "AES-128-WRAP" and "AES-192-WRAP-PAD"
-the decrypted data buffer I<out> should have sufficent room for
-(I<inl> - 8) bytes.
 
 =item EVP_CipherInit_ex2(), EVP_CipherInit_ex(), EVP_CipherUpdate() and
 EVP_CipherFinal_ex()

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -388,8 +388,11 @@ of data. The amount of data written depends on the block alignment of the
 encrypted data.
 For most ciphers and modes, the amount of data written can be anything
 from zero bytes to (inl + cipher_block_size - 1) bytes.
-For wrap cipher modes, the amount of data written can be anything
-from zero bytes to (inl + cipher_block_size) bytes.
+
+When used for wrapping algorithms such as "AES-128-WRAP" and "AES-192-WRAP-PAD"
+the encrypted data buffer I<out> should have sufficent room for
+8 + (I<inl> padded to an 8 byte boundary) bytes.
+
 For stream ciphers, the amount of data written can be anything from zero
 bytes to inl bytes.
 Thus, the buffer pointed to by I<out> must contain sufficient room for the
@@ -419,6 +422,10 @@ identical to the encryption operations except that if padding is enabled the
 decrypted data buffer I<out> passed to EVP_DecryptUpdate() should have
 sufficient room for (I<inl> + cipher_block_size) bytes unless the cipher block
 size is 1 in which case I<inl> bytes is sufficient.
+
+When used for wrapping algorithms such as "AES-128-WRAP" and "AES-192-WRAP-PAD"
+the decrypted data buffer I<out> should have sufficent room for
+(I<inl> - 8) bytes.
 
 =item EVP_CipherInit_ex2(), EVP_CipherInit_ex(), EVP_CipherUpdate() and
 EVP_CipherFinal_ex()

--- a/doc/man7/EVP_CIPHER-AES.pod
+++ b/doc/man7/EVP_CIPHER-AES.pod
@@ -43,11 +43,11 @@ default provider:
 AES wrapping and unwrapping is performed via the encryption API using functions
 such as EVP_EncryptInit_ex2() and EVP_DecryptInit_ex2().
 
-Any input that need to be wrapped that is not a multiple of 8, or that is less
-than 16 bytes needs to use the padding variant of the algorithm
+When wrapping input that is not a multiple of 8, or that is less
+than 16 bytes the padding variant of the algorithm is required
 (e.g "AES-128-WRAP-PAD").
 
-Note that when unwrapping, that the unwrapped size returned in I<outl> from
+When unwrapping, note that the unwrapped size returned in I<outl> from
 EVP_DecryptUpdate() is smaller than the actual buffer size required for
 the unwrap operation. The unwrap buffer size must be at least the
 wrapped length I<inl> - 8 bytes.

--- a/doc/man7/EVP_CIPHER-AES.pod
+++ b/doc/man7/EVP_CIPHER-AES.pod
@@ -84,8 +84,6 @@ L<EVP_EncryptInit(3)/PARAMETERS>.
 The AES-SIV and AES-WRAP mode implementations do not support streaming. That
 means to obtain correct results there can be only one L<EVP_EncryptUpdate(3)>
 or L<EVP_DecryptUpdate(3)> call after the initialization of the context.
-For output size restrictions see L<EVP_EncryptUpdate(3)> and
-L<EVP_DecryptUpdate(3)>.
 
 The AES-XTS implementations allow streaming to be performed, but each
 L<EVP_EncryptUpdate(3)> or L<EVP_DecryptUpdate(3)> call requires each input

--- a/doc/man7/EVP_CIPHER-AES.pod
+++ b/doc/man7/EVP_CIPHER-AES.pod
@@ -40,6 +40,22 @@ default provider:
 "AES-128-WRAP-INV", "AES-192-WRAP-INV", "AES-256-WRAP-INV",
 "AES-128-WRAP-PAD-INV", "AES-192-WRAP-PAD-INV" and "AES-256-WRAP-PAD-INV"
 
+AES wrapping and unwrapping is performed via the encryption API using functions
+such as EVP_EncryptInit_ex2() and EVP_DecryptInit_ex2().
+
+Any input that need to be wrapped that is not a multiple of 8, or that is less
+than 16 bytes needs to use the padding variant of the algorithm
+(e.g "AES-128-WRAP-PAD").
+
+Note that when unwrapping, that the unwrapped size returned in I<outl> from
+EVP_DecryptUpdate() is smaller than the actual buffer size required for
+the unwrap operation. The unwrap buffer size must be at least the
+wrapped length I<inl> - 8 bytes.
+
+The "inverse cipher" algorithms such as "AES-128-WRAP-INV" reverse the
+AES encryption and decryption block functions used when wrapping and unwrapping.
+See SP 800-38F : Section 5.1 for further information.
+
 =item "AES-128-CBC-HMAC-SHA1", "AES-256-CBC-HMAC-SHA1",
 "AES-128-CBC-HMAC-SHA256" and "AES-256-CBC-HMAC-SHA256"
 
@@ -68,7 +84,7 @@ L<EVP_EncryptInit(3)/PARAMETERS>.
 The AES-SIV and AES-WRAP mode implementations do not support streaming. That
 means to obtain correct results there can be only one L<EVP_EncryptUpdate(3)>
 or L<EVP_DecryptUpdate(3)> call after the initialization of the context.
-For output size restrictions see L<EVP_EncryptUpdate(3)) and
+For output size restrictions see L<EVP_EncryptUpdate(3)> and
 L<EVP_DecryptUpdate(3)>.
 
 The AES-XTS implementations allow streaming to be performed, but each

--- a/doc/man7/EVP_CIPHER-AES.pod
+++ b/doc/man7/EVP_CIPHER-AES.pod
@@ -43,7 +43,7 @@ default provider:
 AES wrapping and unwrapping is performed via the encryption API using functions
 such as EVP_EncryptInit_ex2() and EVP_DecryptInit_ex2().
 
-When wrapping input that is not a multiple of 8, or that is less
+When wrapping input that is not a multiple of 8 bytes, or that is less
 than 16 bytes the padding variant of the algorithm is required
 (e.g "AES-128-WRAP-PAD").
 

--- a/doc/man7/EVP_CIPHER-AES.pod
+++ b/doc/man7/EVP_CIPHER-AES.pod
@@ -68,6 +68,8 @@ L<EVP_EncryptInit(3)/PARAMETERS>.
 The AES-SIV and AES-WRAP mode implementations do not support streaming. That
 means to obtain correct results there can be only one L<EVP_EncryptUpdate(3)>
 or L<EVP_DecryptUpdate(3)> call after the initialization of the context.
+For output size restrictions see L<EVP_EncryptUpdate(3)) and
+L<EVP_DecryptUpdate(3)>.
 
 The AES-XTS implementations allow streaming to be performed, but each
 L<EVP_EncryptUpdate(3)> or L<EVP_DecryptUpdate(3)> call requires each input


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
