### PR TITLE
fix undefined behavior on 3.1

### DIFF
--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -59,7 +59,7 @@ __owur static int timeoutcmp(SSL_SESSION *a, SSL_SESSION *b)
  */
 void ssl_session_calculate_timeout(SSL_SESSION *ss)
 {
-    time_t tmax = -1;
+    time_t tmax = (time_t)-1;
 
     if (sizeof(time_t) == 8) {
         uint64_t overflow;
@@ -80,7 +80,7 @@ void ssl_session_calculate_timeout(SSL_SESSION *ss)
 #ifndef __DJGPP__ /* time_t is unsigned on djgp, it's signed anywhere else */
         tmax = (time_t)((uint32_t)tmax >> 1);
 #endif
-        overflow = ((uint32_t)tmax - ss->time);
+        overflow = (uint32_t)((uint32_t)tmax - ss->time);
 
         if (ss->timeout > (time_t)overflow) {
             ss->timeout_ovf |= 1;

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -67,7 +67,7 @@ void ssl_session_calculate_timeout(SSL_SESSION *ss)
 #ifndef __DJGPP__ /* time_t is unsigned on djgpp, it's signed anywhere else */
         tmax = (time_t)((uint64_t)tmax >> 1);
 #endif
-        overflow = (uint64_t)((uint64_t)tmax - ss->time);
+        overflow = ((uint64_t)tmax - ss->time);
         if (ss->timeout > (time_t)overflow) {
             ss->timeout_ovf |= 1;
             ss->calc_timeout = ss->timeout - overflow;
@@ -77,10 +77,10 @@ void ssl_session_calculate_timeout(SSL_SESSION *ss)
     } else {
         uint32_t overflow;
 
-#ifndef __DJGPP__ /* time_t is unsigned on djgp, it's signed anywhere elsep */
+#ifndef __DJGPP__ /* time_t is unsigned on djgp, it's signed anywhere else */
         tmax = (time_t)((uint32_t)tmax >> 1);
 #endif
-        overflow = (uint32_t)((uint32_t)tmax - ss->time);
+        overflow = ((uint32_t)tmax - ss->time);
 
         if (ss->timeout > (time_t)overflow) {
             ss->timeout_ovf |= 1;

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -69,7 +69,7 @@ void ssl_session_calculate_timeout(SSL_SESSION *ss)
 #endif
         overflow = (uint64_t)tmax - (uint64_t)ss->time;
         if (ss->timeout > (time_t)overflow) {
-            ss->timeout_ovf |= 1;
+            ss->timeout_ovf = 1;
             ss->calc_timeout = ss->timeout - (time_t)overflow;
         } else {
             ss->calc_timeout = ss->time + ss->timeout;
@@ -83,7 +83,7 @@ void ssl_session_calculate_timeout(SSL_SESSION *ss)
         overflow = (uint32_t)tmax - (uint32_t)ss->time;
 
         if (ss->timeout > (time_t)overflow) {
-            ss->timeout_ovf |= 1;
+            ss->timeout_ovf = 1;
             ss->calc_timeout = ss->timeout - (time_t)overflow;
         } else {
             ss->calc_timeout = ss->time + ss->timeout;

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -67,6 +67,7 @@ __owur static int timeoutcmp(SSL_SESSION *a, SSL_SESSION *b)
             (_ss_)->timeout_ovf = 1; \
             (_ss_)->calc_timeout = (_ss_)->timeout - (time_t)overflow; \
         } else { \
+            (_ss_)->timeout_ovf = 0; \
             (_ss_)->calc_timeout = (_ss_)->time + (_ss_)->timeout; \
         } \
     } while (0)

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -67,10 +67,10 @@ void ssl_session_calculate_timeout(SSL_SESSION *ss)
 #ifndef __DJGPP__ /* time_t is unsigned on djgpp, it's signed anywhere else */
         tmax = (time_t)((uint64_t)tmax >> 1);
 #endif
-        overflow = ((uint64_t)tmax - ss->time);
+        overflow = (uint64_t)tmax - (uint64_t)ss->time;
         if (ss->timeout > (time_t)overflow) {
             ss->timeout_ovf |= 1;
-            ss->calc_timeout = ss->timeout - overflow;
+            ss->calc_timeout = ss->timeout - (time_t)overflow;
         } else {
             ss->calc_timeout = ss->time + ss->timeout;
         }
@@ -80,11 +80,11 @@ void ssl_session_calculate_timeout(SSL_SESSION *ss)
 #ifndef __DJGPP__ /* time_t is unsigned on djgp, it's signed anywhere else */
         tmax = (time_t)((uint32_t)tmax >> 1);
 #endif
-        overflow = (uint32_t)((uint32_t)tmax - ss->time);
+        overflow = (uint32_t)tmax - (uint32_t)ss->time;
 
         if (ss->timeout > (time_t)overflow) {
             ss->timeout_ovf |= 1;
-            ss->calc_timeout = ss->timeout - overflow;
+            ss->calc_timeout = ss->timeout - (time_t)overflow;
         } else {
             ss->calc_timeout = ss->time + ss->timeout;
         }


### PR DESCRIPTION
(https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=71220)

OpenSSL 3.2 and later are not affected, because they use a `safemath` to do integer arithmetics.

This change is specific to 3.1 and 3.0. It changes just update of timer.

