### PR TITLE
FIPS: Change fips tests to use SHA2 for corruption test.

### DIFF
--- a/test/recipes/03-test_fipsinstall.t
+++ b/test/recipes/03-test_fipsinstall.t
@@ -246,7 +246,7 @@ SKIP: {
                  '-module', $infile,
                  '-provider_name', 'fips', '-mac_name', 'HMAC',
                  '-macopt', 'digest:SHA256', '-macopt', "hexkey:$fipskey",
-                 '-section_name', 'fips_sect', '-corrupt_desc', 'SHA1'])),
+                 '-section_name', 'fips_sect', '-corrupt_desc', 'SHA2'])),
        "fipsinstall fails when the digest result is corrupted");
 
     # corrupt another digest


### PR DESCRIPTION
Fixes cross testing with OpenSSL 3.4 which removed SHA1 from the self tests.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
