### PR TITLE
Fix test_fuzz_hashtable failure in complier ZOO CI

### DIFF
--- a/crypto/hashtable/hashtable.c
+++ b/crypto/hashtable/hashtable.c
@@ -658,7 +658,7 @@ int ossl_ht_insert(HT *h, HT_KEY *key, HT_VALUE *data, HT_VALUE **olddata)
 
     for (i = 0;
          (rc = ossl_ht_insert_locked(h, hash, newval, olddata)) == -1
-         && i < 2;
+         && i < 4;
          ++i)
         if (!grow_hashtable(h, h->wpd.neighborhood_len)) {
             rc = -1;

--- a/fuzz/hashtable.c
+++ b/fuzz/hashtable.c
@@ -188,6 +188,10 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
             rc = ossl_ht_fz_FUZZER_VALUE_insert(fuzzer_table, TO_HT_KEY(&key),
                                                 valptr, NULL);
 
+        if (rc == -1)
+            /* failed to grow the hash table due to too many collisions */
+            break;
+
         /*
          * mark the entry as being allocated
          */


### PR DESCRIPTION
We allow for more iterations of grow_hashtable() and actually make rc == -1 OK on insert when fuzzing as that is an expectable error.

