### PR TITLE
Disable s390x HMAC hardware acceleration if an engine is used for the hash

### DIFF
--- a/crypto/hmac/hmac_s390x.c
+++ b/crypto/hmac/hmac_s390x.c
@@ -7,10 +7,16 @@
  * https://www.openssl.org/source/license.html
  */
 
+/* We need to use some engine deprecated APIs */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 #include "crypto/s390x_arch.h"
 #include "hmac_local.h"
 #include "openssl/obj_mac.h"
 #include "openssl/evp.h"
+#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODULE)
+# include <openssl/engine.h>
+#endif
 
 #ifdef OPENSSL_HMAC_S390X
 
@@ -69,6 +75,31 @@ static void s390x_call_kmac(HMAC_CTX *ctx, const unsigned char *in, size_t len)
     ctx->plat.s390x.ikp = 1;
 }
 
+static int s390x_check_engine_used(const EVP_MD *md, ENGINE *impl)
+{
+# if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODULE)
+    const EVP_MD *d;
+
+    if (impl != NULL) {
+        if (!ENGINE_init(impl))
+            return 0;
+    } else {
+        impl = ENGINE_get_digest_engine(EVP_MD_get_type(md));
+    }
+
+    if (impl == NULL)
+        return 0;
+
+    d = ENGINE_get_digest(impl, EVP_MD_get_type(md));
+    ENGINE_finish(impl);
+
+    if (d != NULL)
+        return 1;
+# endif
+
+    return 0;
+}
+
 int s390x_HMAC_init(HMAC_CTX *ctx, const void *key, int key_len, ENGINE *impl)
 {
     unsigned char *key_param;
@@ -77,6 +108,11 @@ int s390x_HMAC_init(HMAC_CTX *ctx, const void *key, int key_len, ENGINE *impl)
     ctx->plat.s390x.fc = s390x_fc_from_md(ctx->md);
     if (ctx->plat.s390x.fc == 0)
         return -1; /* Not supported by kmac instruction */
+
+    if (s390x_check_engine_used(ctx->md, impl)) {
+        ctx->plat.s390x.fc = 0;
+        return -1; /* An engine handles the digest, disable acceleration */
+    }
 
     ctx->plat.s390x.blk_size = EVP_MD_get_block_size(ctx->md);
     if (ctx->plat.s390x.blk_size < 0)


### PR DESCRIPTION
After adding support for hardware accelerated HMAC on the s390x platform with commit https://github.com/openssl/openssl/commit/0499de5adda26b1ef09660f70c12b4710b5f7c8a, some tests fail in our internal CI:

- test_key_share
- test_sslextension
- test_sslrecords
- test_sslvertol
- test_tlsextms

It turned out that these tests use the `TLSProxy` which in turn uses a special engine called `ossltest` which produces _known_ output for certain algorithms, including HMAC. 

However, when running on a s390x system that supports hardware acceleration of HMAC, that engine is not used for calculating HMACs, but the s390x specific HMAC implementation is used, which does produce _correct_ output, but not the expected _known_ output that the engine would produce. This causes some tests to fail.

I don't know if this is the best approach, but when I disable HMAC hardware acceleration on s390 via unconditionally setting environment variable `OPENSSL_s390xcap`  inside `Proxy.pm` then these tests do work, because the engine is then used. 

I do not want to entirely disable HMAC hardware acceleration in our CI, since I do want to use and test the HMAC hardware acceleration as much as possible. So I would say we should only disable it where the special `ossltest` engine is used. I found that disabling HMAC hardware acceleration inside `Proxy.pm` is a good place. 

Any objections? Any other/better ideas how to deal with this? 
