### PR TITLE
Recycle the TLS key that holds thread_event_handler

### DIFF
--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -266,9 +266,8 @@ void *ossl_thread_event_ctx_new(OSSL_LIB_CTX *libctx)
     if (tlocal == NULL)
         return NULL;
 
-    if (!CRYPTO_THREAD_init_local(tlocal, NULL)) {
+    if (!CRYPTO_THREAD_init_local(tlocal, NULL))
         goto deinit;
-    }
 
     hands = OPENSSL_zalloc(sizeof(*hands));
     if (hands == NULL)

--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -267,7 +267,7 @@ void *ossl_thread_event_ctx_new(OSSL_LIB_CTX *libctx)
         return NULL;
 
     if (!CRYPTO_THREAD_init_local(tlocal, NULL)) {
-        goto err;
+        goto deinit;
     }
 
     hands = OPENSSL_zalloc(sizeof(*hands));
@@ -290,12 +290,15 @@ void *ossl_thread_event_ctx_new(OSSL_LIB_CTX *libctx)
     return tlocal;
  err:
     OPENSSL_free(hands);
+    CRYPTO_THREAD_cleanup_local(tlocal);
+ deinit:
     OPENSSL_free(tlocal);
     return NULL;
 }
 
 void ossl_thread_event_ctx_free(void *tlocal)
 {
+    CRYPTO_THREAD_cleanup_local(tlocal);
     OPENSSL_free(tlocal);
 }
 


### PR DESCRIPTION
fixes: #25278 

The change cleans up TLS when handling errors in `ossl_thread_event_ctx_new` as well.