### PR TITLE
EVP_CIPHER_CTX_get_algor_params() may attempt to access params array at position -1

### DIFF
--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -1273,6 +1273,8 @@ int EVP_CIPHER_CTX_get_algor_params(EVP_CIPHER_CTX *ctx, X509_ALGOR *alg)
         i = 0;
     if (OSSL_PARAM_modified(&params[1]) && params[1].return_size != 0)
         i = 1;
+    if (i < 0)
+        goto err;
 
     /*
      * If alg->parameter is non-NULL, it will be changed by d2i_ASN1_TYPE()
@@ -1282,9 +1284,6 @@ int EVP_CIPHER_CTX_get_algor_params(EVP_CIPHER_CTX *ctx, X509_ALGOR *alg)
      * will be ok.
      */
     type = alg->parameter;
-
-    if (i < 0)
-        goto err;
 
     derk = params[i].key;
     derl = params[i].return_size;

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -1246,12 +1246,10 @@ int EVP_CIPHER_CTX_get_algor_params(EVP_CIPHER_CTX *ctx, X509_ALGOR *alg)
 {
     int ret = -1;                /* Assume the worst */
     unsigned char *der = NULL;
-    size_t derl;
     ASN1_TYPE *type = NULL;
     int i = -1;
     const char *k_old = OSSL_CIPHER_PARAM_ALGORITHM_ID_PARAMS_OLD;
     const char *k_new = OSSL_CIPHER_PARAM_ALGORITHM_ID_PARAMS;
-    const char *derk;
     OSSL_PARAM params[3];
 
     /*
@@ -1283,9 +1281,9 @@ int EVP_CIPHER_CTX_get_algor_params(EVP_CIPHER_CTX *ctx, X509_ALGOR *alg)
      */
     type = alg->parameter;
 
-    derk = params[i].key;
-    derl = params[i].return_size;
-    if (i >= 0 && (der = OPENSSL_malloc(derl)) != NULL) {
+    if (i >= 0 && (der = OPENSSL_malloc(params[i].return_size)) != NULL) {
+        size_t derl = params[i].return_size;
+        const char *derk = params[i].key;
         unsigned char *derp = der;
 
         params[i] = OSSL_PARAM_construct_octet_string(derk, der, derl);

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -1246,10 +1246,12 @@ int EVP_CIPHER_CTX_get_algor_params(EVP_CIPHER_CTX *ctx, X509_ALGOR *alg)
 {
     int ret = -1;                /* Assume the worst */
     unsigned char *der = NULL;
+    size_t derl;
     ASN1_TYPE *type = NULL;
     int i = -1;
     const char *k_old = OSSL_CIPHER_PARAM_ALGORITHM_ID_PARAMS_OLD;
     const char *k_new = OSSL_CIPHER_PARAM_ALGORITHM_ID_PARAMS;
+    const char *derk;
     OSSL_PARAM params[3];
 
     /*
@@ -1281,9 +1283,12 @@ int EVP_CIPHER_CTX_get_algor_params(EVP_CIPHER_CTX *ctx, X509_ALGOR *alg)
      */
     type = alg->parameter;
 
-    if (i >= 0 && (der = OPENSSL_malloc(params[i].return_size)) != NULL) {
-        size_t derl = params[i].return_size;
-        const char *derk = params[i].key;
+    if (i < -1)
+        goto err;
+
+    derk = params[i].key;
+    derl = params[i].return_size;
+    if ((der = OPENSSL_malloc(params[i].return_size)) != NULL) {
         unsigned char *derp = der;
 
         params[i] = OSSL_PARAM_construct_octet_string(derk, der, derl);

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -1283,12 +1283,12 @@ int EVP_CIPHER_CTX_get_algor_params(EVP_CIPHER_CTX *ctx, X509_ALGOR *alg)
      */
     type = alg->parameter;
 
-    if (i < -1)
+    if (i < 0)
         goto err;
 
     derk = params[i].key;
     derl = params[i].return_size;
-    if ((der = OPENSSL_malloc(params[i].return_size)) != NULL) {
+    if ((der = OPENSSL_malloc(derl)) != NULL) {
         unsigned char *derp = der;
 
         params[i] = OSSL_PARAM_construct_octet_string(derk, der, derl);


### PR DESCRIPTION
(prams[=1]).

The issue has been reported by coverity check.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
