### PR TITLE
doc: Document properties param for Argon2 KDF

### DIFF
--- a/doc/man7/EVP_KDF-ARGON2.pod
+++ b/doc/man7/EVP_KDF-ARGON2.pod
@@ -44,6 +44,8 @@ The supported parameters are:
 
 =item "size" (B<OSSL_KDF_PARAM_SIZE>) <unsigned integer>
 
+=item "properties" (B<OSSL_KDF_PARAM_PROPERTIES>) <UTF8 string>
+
 These parameters work as described in L<EVP_KDF(3)/PARAMETERS>.
 
 Note that RFC 9106 recommends 128 bits salt for most applications, or 64 bits


### PR DESCRIPTION
The Argon2 KDF uses `OSSL_KDF_PARAM_PROPERTIES` to fetch implementations of blake2bmac and blake2b512 if `ctx->mac` and `ctx->md` are NULL. This isn't documented in the manpage, so users that might, for example, want to fetch an instance of Argon2 with the "-fips" property query to obtain a working Argon2 KDF even though the default property query requires "fips=yes" are left wondering why this fails.

Fortunately, `EVP_KDF(3)/PARAMETERS` already explains what the properties are used for, so we really just need to add a single line.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated