### PR TITLE
exporters for pkg-config: align with the changes for CMake

### DIFF
--- a/exporters/pkg-config/libcrypto.pc.in
+++ b/exporters/pkg-config/libcrypto.pc.in
@@ -1,8 +1,13 @@
 prefix={- $OpenSSL::safe::installdata::PREFIX[0] -}
 exec_prefix=${prefix}
-libdir={- $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]
-          ? '${exec_prefix}/' . $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]
-          : $OpenSSL::safe::installdata::libdir[0] -}
+libdir={- if (defined $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]) {
+              my $x = '';
+              $x = '/' . $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]
+                  if $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0];
+              '${exec_prefix}' . $x;
+          } else {
+              $OpenSSL::safe::installdata::libdir[0];
+          } -}
 includedir={- $OUT = '';
               $OUT .= '${prefix}/' . $_ . ' '
                   foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX); -}

--- a/exporters/pkg-config/libssl.pc.in
+++ b/exporters/pkg-config/libssl.pc.in
@@ -1,8 +1,13 @@
-prefix={- $OpenSSL::safe::installdata::PREFIX -}
+prefix={- $OpenSSL::safe::installdata::PREFIX[0] -}
 exec_prefix=${prefix}
-libdir={- $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX
-          ? '${exec_prefix}/' . $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX
-          : $OpenSSL::safe::installdata::libdir -}
+libdir={- if (defined $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]) {
+              my $x = '';
+              $x = '/' . $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]
+                  if $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0];
+              '${exec_prefix}' . $x;
+          } else {
+              $OpenSSL::safe::installdata::libdir[0];
+          } -}
 includedir={- $OUT = '';
               $OUT .= '${prefix}/' . $_ . ' '
                   foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX); -}

--- a/exporters/pkg-config/openssl.pc.in
+++ b/exporters/pkg-config/openssl.pc.in
@@ -1,9 +1,16 @@
-prefix={- $OpenSSL::safe::installdata::PREFIX -}
+prefix={- $OpenSSL::safe::installdata::PREFIX[0] -}
 exec_prefix=${prefix}
-libdir={- $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX
-          ? '${exec_prefix}/' . $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX
-          : $OpenSSL::safe::installdata::libdir -}
-includedir=${prefix}/{- $OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX -}
+libdir={- if (defined $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]) {
+              my $x = '';
+              $x = '/' . $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]
+                  if $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0];
+              '${exec_prefix}' . $x;
+          } else {
+              $OpenSSL::safe::installdata::libdir[0];
+          } -}
+includedir={- $OUT = '';
+              $OUT .= '${prefix}/' . $_ . ' '
+                  foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX); -}
 
 Name: OpenSSL
 Description: Secure Sockets Layer and cryptography libraries and tools


### PR DESCRIPTION
The latest CMake exporter changes reworked the the variables in builddata.pm
and installdata.pm.  Unfortunately, the pkg-config exporter templates were
forgotten in that effort.

Fixes #25299
