### PR TITLE
Fix inaccurate comment about default nonce length in demos/cipher/aesccm.c

### DIFF
--- a/demos/cipher/aesccm.c
+++ b/demos/cipher/aesccm.c
@@ -94,7 +94,7 @@ static int aes_ccm_encrypt(void)
     if ((cipher = EVP_CIPHER_fetch(libctx, "AES-192-CCM", propq)) == NULL)
         goto err;
 
-    /* Set nonce length if default 96 bits is not appropriate */
+    /* Default nonce length for AES-CCM is 7 bytes (56 bits). */
     params[0] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_AEAD_IVLEN,
                                             &ccm_nonce_len);
     /* Set tag length */


### PR DESCRIPTION
### Description

This pull request updates the comment in `demos/cipher/aesccm.c` to correctly reflect the default nonce length for AES-CCM. The previous comment incorrectly stated that the default nonce length is 96 bits. The correct default nonce length for AES-CCM is 7 bytes (56 bits).

### Fixes

This PR addresses the issue described in #25270 by correcting the inaccurate comment.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
