### PR TITLE
Fix !fips v3.0.0 check

### DIFF
--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -1341,9 +1341,7 @@ int setup_tests(void)
     }
 
     /* FIPS(3.0.0): provider imports explicit params but they won't work #17998 */
-    is_fips_3_0_0 = fips_provider_version_eq(testctx, 3, 0, 0);
-    if (is_fips_3_0_0 < 0)
-        return 0;
+    is_fips_3_0_0 = is_fips && fips_provider_version_eq(testctx, 3, 0, 0);
 
 #ifdef STATIC_LEGACY
     /*


### PR DESCRIPTION
The fips_provider_version_* functions return true if the FIPS provider isn't loaded.  This is somewhat counterintuitive and the fix in #25327 neglected this nuance resulting in not running the SM2 tests when the FIPS provider wasn't being loaded.

- [ ] documentation is added or updated
- [x] tests are added or updated
