### PR TITLE
blank line required to display code in `openssl-ts.pod.in`

### DIFF
--- a/doc/man1/openssl-ts.pod.in
+++ b/doc/man1/openssl-ts.pod.in
@@ -584,10 +584,12 @@ To verify a timestamp reply that includes the certificate chain:
         -CAfile cacert.pem
 
 To verify a timestamp token against the original data file:
+
   openssl ts -verify -data design2.txt -in design2.tsr \
         -CAfile cacert.pem
 
 To verify a timestamp token against a message imprint:
+
   openssl ts -verify -digest b7e5d3f93198b38379852f2c04e78d73abdd0f4b \
          -in design2.tsr -CAfile cacert.pem
 


### PR DESCRIPTION
Blank line is required to display code (command invocation in this case).

CLA: trivial
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated