### PR TITLE
dtls_meth.c: Silently drop records with invalid MAC

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,12 @@ OpenSSL 3.4
 
 ### Changes between 3.4 and 3.5 [xx XXX xxxx]
 
+ * Changed DTLS handling of invalid records.
+   Records with invalid MAC or invalid length used to generate fatal alert,
+   and are now silently dropped.
+
+   *Omer Kattan*
+
  * Enhanced PKCS#7 inner contents verification.
    In the PKCS7_verify() function, the BIO *indata parameter refers to the
    signed data if the content is detached from p7. Otherwise, indata should be
@@ -55,12 +61,6 @@ OpenSSL 3.4
 -----------
 
 ### Changes between 3.3 and 3.4 [xx XXX xxxx]
-
- * Changed DTLS handling of record with invalid MAC.
-   Records with invalid MAC used to generate fatal alert, and are now
-   silently dropped.
-
-   *Omer Kattan*
 
  * For the FIPS provider only, replaced the primary DRBG with a continuous
    health check module.  This also removes the now forbidden DRBG chaining.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,12 @@ OpenSSL 3.4
 
 ### Changes between 3.3 and 3.4 [xx XXX xxxx]
 
+ * Changed DTLS handling of record with invalid MAC.
+   Records with invalid MAC used to generate fatal alert, and are now
+   silently dropped.
+
+   *Omer Kattan*
+
  * For the FIPS provider only, replaced the primary DRBG with a continuous
    health check module.  This also removes the now forbidden DRBG chaining.
 

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -170,8 +170,7 @@ static int dtls_process_record(OSSL_RECORD_LAYER *rl, DTLS_BITMAP *bitmap)
         mac = rr->data + rr->length;
         i = rl->funcs->mac(rl, rr, md, 0 /* not send */);
         if (i == 0 || CRYPTO_memcmp(md, mac, (size_t)mac_size) != 0) {
-            RLAYERfatal(rl, SSL_AD_BAD_RECORD_MAC,
-                        SSL_R_DECRYPTION_FAILED_OR_BAD_RECORD_MAC);
+            /* Silently drop the packet in case of invalid MAC. */
             return 0;
         }
         /*

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -138,7 +138,8 @@ static int dtls_process_record(OSSL_RECORD_LAYER *rl, DTLS_BITMAP *bitmap)
 
     /*
      * check is not needed I believe
-     * As per RFC 6347 4.1.2.7 and RFC 9147 4.5.2: Silently drop the packet in case of invalid length.
+     * As per RFC 6347 4.1.2.7 and RFC 9147 4.5.2: Silently drop the packet in case of invalid
+     * length.
      */
     if (rr->length > SSL3_RT_MAX_ENCRYPTED_LENGTH)
         return 0;
@@ -164,8 +165,8 @@ static int dtls_process_record(OSSL_RECORD_LAYER *rl, DTLS_BITMAP *bitmap)
         unsigned char *mac;
 
         /*
-         * As per RFC 6347 4.1.2.7 and RFC 9147 4.5.2: Silently drop the packet in case of invalid length.
-         * In this case the record length is too small to contain a mac.
+         * As per RFC 6347 4.1.2.7 and RFC 9147 4.5.2: Silently drop the packet in case of invalid
+         * length. In this case the record length is too small to contain a mac.
          */
         if (rr->orig_len < mac_size)
             return 0;
@@ -174,10 +175,13 @@ static int dtls_process_record(OSSL_RECORD_LAYER *rl, DTLS_BITMAP *bitmap)
         mac = rr->data + rr->length;
         i = rl->funcs->mac(rl, rr, md, 0 /* not send */);
 
-        /* As per RFC 6347 4.1.2.7 and RFC 9147 4.5.2: Silently drop the packet in case of invalid MAC. */
+        /*
+         * As per RFC 6347 4.1.2.7 and RFC 9147 4.5.2: Silently drop the packet in case of invalid
+         * MAC.
+         */
         if (i == 0 || CRYPTO_memcmp(md, mac, (size_t)mac_size) != 0)
             return 0;
-        
+
         /*
          * We've handled the mac now - there is no MAC inside the encrypted
          * record
@@ -240,7 +244,10 @@ static int dtls_process_record(OSSL_RECORD_LAYER *rl, DTLS_BITMAP *bitmap)
     /* r->length is now just compressed */
     if (rl->compctx != NULL) {
         if (rr->length > SSL3_RT_MAX_COMPRESSED_LENGTH) {
-            /* As per RFC 6347 4.1.2.7 and RFC 9147 4.5.2: Silently drop the packet in case of invalid length. */
+            /*
+             * As per RFC 6347 4.1.2.7 and RFC 9147 4.5.2: Silently drop the packet in case of
+             * invalid length.
+             */
             rr->length = 0;
             rl->packet_length = 0;
             goto end;

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -170,7 +170,7 @@ static int dtls_process_record(OSSL_RECORD_LAYER *rl, DTLS_BITMAP *bitmap)
         mac = rr->data + rr->length;
         i = rl->funcs->mac(rl, rr, md, 0 /* not send */);
         if (i == 0 || CRYPTO_memcmp(md, mac, (size_t)mac_size) != 0) {
-            /* Silently drop the packet in case of invalid MAC. */
+            /* As per RFC 9147 4.5.2: Silently drop the packet in case of invalid MAC. */
             return 0;
         }
         /*

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -136,11 +136,12 @@ static int dtls_process_record(OSSL_RECORD_LAYER *rl, DTLS_BITMAP *bitmap)
      * bytes of encrypted compressed stuff.
      */
 
-    /* check is not needed I believe */
-    if (rr->length > SSL3_RT_MAX_ENCRYPTED_LENGTH) {
-        /* As per RFC 9147 4.5.2: Silently drop the packet in case of invalid length. */
+    /*
+     * check is not needed I believe
+     * As per RFC 6347 4.1.2.7 and RFC 9147 4.5.2: Silently drop the packet in case of invalid length.
+     */
+    if (rr->length > SSL3_RT_MAX_ENCRYPTED_LENGTH)
         return 0;
-    }
 
     /* decrypt in place in 'rr->input' */
     rr->data = rr->input;
@@ -162,20 +163,21 @@ static int dtls_process_record(OSSL_RECORD_LAYER *rl, DTLS_BITMAP *bitmap)
     if (rl->use_etm && rl->md_ctx != NULL) {
         unsigned char *mac;
 
-        if (rr->orig_len < mac_size) {
-            /*
-             * As per RFC 9147 4.5.2: Silently drop the packet in case of invalid length.
-             * In this case the record length is too small to contain a mac.
-             */
+        /*
+         * As per RFC 6347 4.1.2.7 and RFC 9147 4.5.2: Silently drop the packet in case of invalid length.
+         * In this case the record length is too small to contain a mac.
+         */
+        if (rr->orig_len < mac_size)
             return 0;
-        }
+
         rr->length -= mac_size;
         mac = rr->data + rr->length;
         i = rl->funcs->mac(rl, rr, md, 0 /* not send */);
-        if (i == 0 || CRYPTO_memcmp(md, mac, (size_t)mac_size) != 0) {
-            /* As per RFC 9147 4.5.2: Silently drop the packet in case of invalid MAC. */
+
+        /* As per RFC 6347 4.1.2.7 and RFC 9147 4.5.2: Silently drop the packet in case of invalid MAC. */
+        if (i == 0 || CRYPTO_memcmp(md, mac, (size_t)mac_size) != 0)
             return 0;
-        }
+        
         /*
          * We've handled the mac now - there is no MAC inside the encrypted
          * record
@@ -238,7 +240,7 @@ static int dtls_process_record(OSSL_RECORD_LAYER *rl, DTLS_BITMAP *bitmap)
     /* r->length is now just compressed */
     if (rl->compctx != NULL) {
         if (rr->length > SSL3_RT_MAX_COMPRESSED_LENGTH) {
-            /* As per RFC 9147 4.5.2: Silently drop the packet in case of invalid length. */
+            /* As per RFC 6347 4.1.2.7 and RFC 9147 4.5.2: Silently drop the packet in case of invalid length. */
             rr->length = 0;
             rl->packet_length = 0;
             goto end;
@@ -254,9 +256,8 @@ static int dtls_process_record(OSSL_RECORD_LAYER *rl, DTLS_BITMAP *bitmap)
      * Length setting.
      */
     if (rr->length > rl->max_frag_len) {
-        /* As per RFC 9147 4.5.2: Silently drop the packet in case of invalid length. */
-        rr->length = 0;
-        rl->packet_length = 0;
+        /* As per RFC 6066 section 4, exceeding maximum fragment length should generate an alert */
+        RLAYERfatal(rl, SSL_AD_RECORD_OVERFLOW, SSL_R_DATA_LENGTH_TOO_LONG);
         goto end;
     }
 


### PR DESCRIPTION
Silently drop DTLS records with invalid MAC instead of generating fatal alert, fixes https://github.com/openssl/openssl/issues/24972

This solves a case where Application Data messages from a previous session are buffered before the handshake, and are handled as part of the new session.

Checklist
 documentation is added or updated