### PR TITLE
threads_win: fix improper cast to long * instead of LONG *

### DIFF
--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -558,7 +558,8 @@ int CRYPTO_THREAD_compare_id(CRYPTO_THREAD_ID a, CRYPTO_THREAD_ID b)
 
 int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
 {
-    *ret = (int)InterlockedExchangeAdd((long volatile *)val, (long)amount) + amount;
+    *ret = (int)InterlockedExchangeAdd((LONG volatile *)val, (LONG)amount)
+        + amount;
     return 1;
 }
 


### PR DESCRIPTION
`InterlockedExchangeAdd` expects arguments of type `LONG *`, `LONG` but the `int` arguments were improperly cast to `long *`, `long`

Note:
- `LONG` is always 32 bit
- `long` is 32 bit on Win32 VC x86/x64 and MingW-W64
- `long` is 64 bit on cygwin64

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated

@t8m @paulidale @tom-cosgrove-arm @nhorman @mattcaswell
@shahsb @levitte @hlandau @viruscamp @yjh-styx