### PR TITLE
crypto/pkcs12/p12_mutl.c: Add check and EVP_MD_free() for EVP_MD_fetch()

### DIFF
--- a/crypto/pkcs12/p12_mutl.c
+++ b/crypto/pkcs12/p12_mutl.c
@@ -236,6 +236,8 @@ static int pkcs12_gen_mac(PKCS12 *p12, const char *pass, int passlen,
             if (OBJ_obj2txt(hmac_md_name, sizeof(hmac_md_name), OBJ_nid2obj(pbmac1_kdf_nid), 0) < 0)
                 goto err;
             hmac_md = EVP_MD_fetch(NULL, hmac_md_name, NULL);
+            if (hmac_md == NULL)
+                goto err;
             fetched = 1;
         }
         if (pkcs12_key_gen != NULL) {
@@ -249,6 +251,8 @@ static int pkcs12_gen_mac(PKCS12 *p12, const char *pass, int passlen,
                 goto err;
             }
         } else {
+            if (fetched)
+                EVP_MD_free(hmac_md);
             /* Default to UTF-8 password */
             if (!PKCS12_key_gen_utf8_ex(pass, passlen, salt, saltlen, PKCS12_MAC_ID,
                                         iter, keylen, key, md,


### PR DESCRIPTION
Add check and EVP_MD_free() for EVP_MD_fetch() to avoid NULL pointer dereference and memory leak, like "md_fetch".

Fixes: fe79159be0 ("Implementation of the RFC 9579, PBMAC1 in PKCS#12")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
