### PR TITLE
Fixed the formatting in the error string in argon2 to correctly report number of requested/available threads

### DIFF
--- a/providers/implementations/kdfs/argon2.c
+++ b/providers/implementations/kdfs/argon2.c
@@ -1071,8 +1071,8 @@ static int kdf_argon2_derive(void *vctx, unsigned char *out, size_t outlen,
 # else
         if (ctx->threads > ossl_get_avail_threads(ctx->libctx)) {
             ERR_raise_data(ERR_LIB_PROV, PROV_R_INVALID_THREAD_POOL_SIZE,
-                           "requested %u threads, available: 1",
-                           ossl_get_avail_threads(ctx->libctx));
+                           "requested %u threads, available: %u",
+                           ctx->threads, ossl_get_avail_threads(ctx->libctx));
             return 0;
         }
 # endif


### PR DESCRIPTION
Previously, the error string was hardcoded to 1 instead of the number of available threads. 

Fixes: #25344

##### Checklist
- [x] documentation is added or updated
