### PR TITLE
CI: Update upload-artifact action to be compatible

### DIFF
--- a/.github/workflows/prov-compat-label.yml
+++ b/.github/workflows/prov-compat-label.yml
@@ -89,7 +89,7 @@ jobs:
                                                  -providers
         working-directory: ${{ matrix.release.dir }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.release.tgz }}
           path: ${{ matrix.release.tgz }}
@@ -174,7 +174,7 @@ jobs:
           ./util/opensslwrap.sh version -c
         working-directory: ${{ matrix.branch.dir }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.branch.tgz }}
           path: ${{ matrix.branch.tgz }}

--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -93,7 +93,7 @@ jobs:
                                                  -providers
         working-directory: ${{ matrix.release.dir }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.release.tgz }}
           path: ${{ matrix.release.tgz }}
@@ -177,7 +177,7 @@ jobs:
         run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
         working-directory: ${{ matrix.branch.dir }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.branch.tgz }}
           path: ${{ matrix.branch.tgz }}


### PR DESCRIPTION
The download-artifact action was updated to 4.x
and the upload-artifact must be kept in sync.
