### PR TITLE
Fixes for s390x: support CPACF sha3/shake performance improvements

### DIFF
--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -198,10 +198,12 @@ static size_t s390x_sha3_absorb(void *vctx, const void *inp, size_t len)
     if (!(ctx->xof_state == XOF_STATE_INIT ||
           ctx->xof_state == XOF_STATE_ABSORB))
         return 0;
-    fc = ctx->pad;
-    fc |= ctx->xof_state == XOF_STATE_INIT ? S390X_KIMD_NIP : 0;
-    ctx->xof_state = XOF_STATE_ABSORB;
-    s390x_kimd(inp, len - rem, fc, ctx->A);
+    if (len - rem > 0) {
+        fc = ctx->pad;
+        fc |= ctx->xof_state == XOF_STATE_INIT ? S390X_KIMD_NIP : 0;
+        ctx->xof_state = XOF_STATE_ABSORB;
+        s390x_kimd(inp, len - rem, fc, ctx->A);
+    }
     return rem;
 }
 

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -245,6 +245,7 @@ static int s390x_shake_final(void *vctx, unsigned char *out, size_t outlen)
 static int s390x_shake_squeeze(void *vctx, unsigned char *out, size_t outlen)
 {
     KECCAK1600_CTX *ctx = vctx;
+    unsigned int fc;
     size_t len;
 
     if (!ossl_prov_is_running())
@@ -255,8 +256,10 @@ static int s390x_shake_squeeze(void *vctx, unsigned char *out, size_t outlen)
      * On the first squeeze call, finish the absorb process (incl. padding).
      */
     if (ctx->xof_state != XOF_STATE_SQUEEZE) {
+        fc = ctx->pad;
+        fc |= ctx->xof_state == XOF_STATE_INIT ? S390X_KLMD_NIP : 0;
         ctx->xof_state = XOF_STATE_SQUEEZE;
-        s390x_klmd(ctx->buf, ctx->bufsz, out, outlen, ctx->pad, ctx->A);
+        s390x_klmd(ctx->buf, ctx->bufsz, out, outlen, fc, ctx->A);
         ctx->bufsz = outlen % ctx->block_size;
         /* reuse ctx->bufsz to count bytes squeezed from current sponge */
         return 1;


### PR DESCRIPTION
Fixes for the support that was added by https://github.com/openssl/openssl/commit/25f5d7b85f6657cd2f9f1ab7ae87f319d9bafe54

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] tests are added or updated

@jschmidb @holger-dengler please review.
