### PR TITLE
fix small footprint builds on arm

### DIFF
--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -485,7 +485,11 @@ static void gcm_get_funcs(struct gcm_funcs_st *ctx)
 #elif defined(GHASH_ASM_ARM)
     /* ARM defaults */
     ctx->gmult = gcm_gmult_4bit;
+# if !defined(OPENSSL_SMALL_FOOTPRINT)
     ctx->ghash = gcm_ghash_4bit;
+# else
+    ctx->ghash = NULL;
+# endif
 # ifdef PMULL_CAPABLE
     if (PMULL_CAPABLE) {
         ctx->ginit = (gcm_init_fn)gcm_init_v8;


### PR DESCRIPTION
Building with '-D OPENSSL_SMALL_FOOTPRINT' for aarch64 fails due to 'gcm_ghash_4bit' being undeclared.  Fix that by not setting the function pointer when building with OPENSSL_SMALL_FOOTPRINT, matching openssl behavior on x86.
