### PR TITLE
Clarify Tag Length Setting in OCB Mode

### DIFF
--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -1435,10 +1435,9 @@ For GCM, this call is only valid when decrypting data.
 For OCB, this call is valid when decrypting data to set the expected tag,
 and when encrypting to set the desired tag length.
 
-In OCB mode, calling this when encrypting with C<tag> set to C<NULL> sets the
-tag length. The tag length can only be set before specifying an IV. If this is
-not called prior to setting the IV during encryption, then a default tag length
-is used.
+In OCB mode, calling this with C<tag> set to C<NULL> sets the tag length.
+The tag length can only be set before specifying an IV. If this is not called
+prior to setting the IV, then a default tag length is used.
 
 For OCB AES, the default tag length is 16 (i.e. 128 bits).  It is also the
 maximum tag length for OCB.


### PR DESCRIPTION
Fixes #8331: Updated the description for setting the tag length in OCB mode to remove the misleading “when encrypting” and "during encryption" phrasing. This change emphasizes that setting a custom tag length requires a call with NULL, applicable to both encryption and decryption contexts.

- [x] documentation is added or updated
