### PR TITLE
Add Missing Error Messages for AES-OCB Tag Length Validation

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -367,12 +367,20 @@ static int aes_ocb_set_ctx_params(void *vctx, const OSSL_PARAM params[])
         }
         if (p->data == NULL) {
             /* Tag len must be 0 to 16 */
-            if (p->data_size > OCB_MAX_TAG_LEN)
+            if (p->data_size > OCB_MAX_TAG_LEN) {
+                ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG_LENGTH);
                 return 0;
+            }
             ctx->taglen = p->data_size;
         } else {
-            if (p->data_size != ctx->taglen || ctx->base.enc)
+            if (p->data_size != ctx->taglen) {
+                ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG_LENGTH);
                 return 0;
+            }
+            if (ctx->base.enc) {
+                ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+                return 0;
+            }
             memcpy(ctx->tag, p->data, p->data_size);
         }
      }

--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -373,12 +373,12 @@ static int aes_ocb_set_ctx_params(void *vctx, const OSSL_PARAM params[])
             }
             ctx->taglen = p->data_size;
         } else {
-            if (p->data_size != ctx->taglen) {
-                ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG_LENGTH);
+            if (ctx->base.enc) {
+                ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_INVALID_ARGUMENT);
                 return 0;
             }
-            if (ctx->base.enc) {
-                ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            if (p->data_size != ctx->taglen) {
+                ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG_LENGTH);
                 return 0;
             }
             memcpy(ctx->tag, p->data, p->data_size);


### PR DESCRIPTION
Related to #8331: Addressing found issues by adding specific error messages to improve feedback when tag length checks fail for the `EVP_CTRL_AEAD_SET_TAG` parameter in the AES-OCB algorithm.

- Added `PROV_R_INVALID_TAG_LENGTH` error to indicate when the current tag length exceeds the maximum tag length of the algorithm.
- Added `PROV_R_INVALID_TAG_LENGTH` error to indicate when the current tag length in the context does not match a custom tag length provided as a parameter.
- Added `ERR_R_PASSED_INVALID_ARGUMENT` error to handle cases where a pointer is passed in encryption mode.