### PR TITLE
Improve quic interop testing

### DIFF
--- a/.github/workflows/run_quic_interop.yml
+++ b/.github/workflows/run_quic_interop.yml
@@ -10,7 +10,7 @@ jobs:
   run_quic_interop:
     strategy:
       matrix:
-        tests: [http3, transfer, handshake, retry, chacha20]
+        tests: [http3, transfer, handshake, retry, chacha20, resumption, multiplexing]
         servers: [quic-go, ngtcp2, mvfst, quiche, nginx, msquic, haproxy]
       fail-fast: false
     runs-on: ubuntu-latest 
@@ -27,7 +27,6 @@ jobs:
           sudo apt-get install -y tshark
       - name: Patch implementations file
         run: |
-          head -n -2 implementations.json > ./implementations.tmp
           jq '.openssl = { image: "quay.io/openssl-ci/openssl-quic-interop"
                          , url: "https://github.com/openssl/openssl"
                          , role: "client"

--- a/demos/guide/README.md
+++ b/demos/guide/README.md
@@ -71,6 +71,28 @@ to run the quic-client-block demo:
 
 SSL_CERT_FILE=rootcert.pem LD_LIBRARY_PATH=../.. ./quic-client-block localhost 4443
 
+Notes on the quic-hq-interop demo
+---------------------------------
+
+The quic-hq-interop demo is effectively the same as the quic-client-nonblock
+demo, but is specifically constructed to use the hq-interop alpn for the
+purposes of interacting with other demonstration containers found in the 
+QUIC working group [interop runner](https://github.com/quic-interop/quic-interop-runner)
+It is run as follows:
+
+SSL_CERT_FILE=ca.pem LD_LIBRARY_PATH=../../ ./quic-hq-interop host port file
+
+The demo will then do the following:
+
+1. Connect to the server at host/port
+2. Negotiates the hq-interop alpn
+3. Issues an HTTP 1.0 GET request of the form "GET /$FILE"
+3. Reads any response from the server and write it verbatim to stdout
+
+This demo can be used for any hq-interop negotiating server, but its use can
+most easily be seen in action in our quic interop container, buildable from
+./test/quic_interop_openssl in this source tree.
+
 <!-- Links  -->
 
 [guide]: https://www.openssl.org/docs/manmaster/man7/ossl-guide-introduction.html

--- a/demos/guide/README.md
+++ b/demos/guide/README.md
@@ -76,7 +76,7 @@ Notes on the quic-hq-interop demo
 
 The quic-hq-interop demo is effectively the same as the quic-client-nonblock
 demo, but is specifically constructed to use the hq-interop alpn for the
-purposes of interacting with other demonstration containers found in the 
+purposes of interacting with other demonstration containers found in the
 QUIC working group [interop runner](https://github.com/quic-interop/quic-interop-runner)
 It is run as follows:
 

--- a/demos/guide/build.info
+++ b/demos/guide/build.info
@@ -8,7 +8,8 @@ PROGRAMS{noinst} = tls-client-block \
                    quic-client-block \
                    quic-multi-stream \
                    tls-client-non-block \
-                   quic-client-non-block
+                   quic-client-non-block \
+                   quic-hq-interop
 
 INCLUDE[tls-client-block]=../../include
 SOURCE[tls-client-block]=tls-client-block.c
@@ -29,3 +30,7 @@ DEPEND[tls-client-non-block]=../../libcrypto ../../libssl
 INCLUDE[quic-client-non-block]=../../include
 SOURCE[quic-client-non-block]=quic-client-non-block.c
 DEPEND[quic-client-non-block]=../../libcrypto ../../libssl
+
+INCLUDE[quic-hq-interop]=../../include
+SOURCE[quic-hq-interop]=quic-hq-interop.c
+DEPEND[quic-hq-interop]=../../libcrypto ../../libssl

--- a/demos/guide/quic-hq-interop.c
+++ b/demos/guide/quic-hq-interop.c
@@ -484,11 +484,7 @@ static int setup_session_cache(SSL *ssl, SSL_CTX *ctx, const char *filename)
     int new_cache = 0;
 
     /* make sure caching is enabled */
-    if (!SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_BOTH))
-        return rc;
-
-    /* Don't use stateless session tickets */
-    if (!SSL_CTX_set_options(ctx, SSL_OP_NO_TICKET))
+    if (!SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_SERVER))
         return rc;
 
     /* open our cache file */
@@ -668,11 +664,11 @@ static size_t build_request_set(SSL *ssl)
         outnames[poll_idx] = req;
 
         /* Format the http request */
-        sprintf(req_string, "GET /%s\r\n", req);
+        BIO_snprintf(req_string, 1024, "GET /%s\r\n", req);
 
         /* build the outfile request path */
         memset(outfilename, 0, 1024);
-        sprintf(outfilename, "/downloads/%s", req);
+        BIO_snprintf(outfilename, 1024, "/downloads/%s", req);
 
         /* open a bio to write the file */
         outbiolist[poll_idx] = BIO_new_file(outfilename, "w+");

--- a/demos/guide/quic-hq-interop.c
+++ b/demos/guide/quic-hq-interop.c
@@ -873,12 +873,12 @@ static int setup_connection(char *hostname, char *port, int ipv6,
         goto end; /* Cannot retry: error */
     }
 
-    return 0;
+    return 1;
 end:
     SSL_CTX_free(*ctx);
     SSL_free(*ssl);
     BIO_ADDR_free(peer_addr);
-    return 1;
+    return 0;
 }
 
 /**
@@ -926,7 +926,7 @@ int main(int argc, char *argv[])
     size_t result_count = 0;
     struct timeval poll_timeout;
     size_t this_poll_count = 0;
-    char *req, *saveptr = NULL;
+    char *req = NULL;
     char *hostname, *port;
     int ipv6 = 0;
 
@@ -976,13 +976,13 @@ int main(int argc, char *argv[])
         goto end;
     }
 
-    req = strtok_r(reqnames, " ", &saveptr);
+    req = strtok(reqnames, " ");
 
     while (req != NULL) {
         total_requests++;
         req_array = OPENSSL_realloc(req_array, sizeof(char *) * total_requests);
         req_array[total_requests - 1] = req;
-        req = strtok_r(NULL, " ", &saveptr);
+        req = strtok(NULL, " ");
     }
 
     /* get a list of requests to poll */

--- a/demos/guide/quic-hq-interop.c
+++ b/demos/guide/quic-hq-interop.c
@@ -1,0 +1,546 @@
+/*
+ *  Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License").  You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://www.openssl.org/source/license.html
+ */
+
+#include <string.h>
+
+/* Include the appropriate header file for SOCK_DGRAM */
+#ifdef _WIN32 /* Windows */
+# include <winsock2.h>
+#else /* Linux/Unix */
+# include <sys/socket.h>
+# include <sys/select.h>
+#endif
+
+#include <openssl/bio.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
+/* Helper function to create a BIO connected to the server */
+static BIO *create_socket_bio(const char *hostname, const char *port,
+                              int family, BIO_ADDR **peer_addr)
+{
+    int sock = -1;
+    BIO_ADDRINFO *res;
+    const BIO_ADDRINFO *ai = NULL;
+    BIO *bio;
+
+    /*
+     * Lookup IP address info for the server.
+     */
+    if (!BIO_lookup_ex(hostname, port, BIO_LOOKUP_CLIENT, family, SOCK_DGRAM, 0,
+                       &res))
+        return NULL;
+
+    /*
+     * Loop through all the possible addresses for the server and find one
+     * we can connect to.
+     */
+    for (ai = res; ai != NULL; ai = BIO_ADDRINFO_next(ai)) {
+        /*
+         * Create a UDP socket. We could equally use non-OpenSSL calls such
+         * as "socket" here for this and the subsequent connect and close
+         * functions. But for portability reasons and also so that we get
+         * errors on the OpenSSL stack in the event of a failure we use
+         * OpenSSL's versions of these functions.
+         */
+        sock = BIO_socket(BIO_ADDRINFO_family(ai), SOCK_DGRAM, 0, 0);
+        if (sock == -1)
+            continue;
+
+        /* Connect the socket to the server's address */
+        if (!BIO_connect(sock, BIO_ADDRINFO_address(ai), 0)) {
+            BIO_closesocket(sock);
+            sock = -1;
+            continue;
+        }
+
+        /* Set to nonblocking mode */
+        if (!BIO_socket_nbio(sock, 1)) {
+            BIO_closesocket(sock);
+            sock = -1;
+            continue;
+        }
+
+        break;
+    }
+
+    if (sock != -1) {
+        *peer_addr = BIO_ADDR_dup(BIO_ADDRINFO_address(ai));
+        if (*peer_addr == NULL) {
+            BIO_closesocket(sock);
+            return NULL;
+        }
+    }
+
+    /* Free the address information resources we allocated earlier */
+    BIO_ADDRINFO_free(res);
+
+    /* If sock is -1 then we've been unable to connect to the server */
+    if (sock == -1)
+        return NULL;
+
+    /* Create a BIO to wrap the socket */
+    bio = BIO_new(BIO_s_datagram());
+    if (bio == NULL) {
+        BIO_closesocket(sock);
+        return NULL;
+    }
+
+    /*
+     * Associate the newly created BIO with the underlying socket. By
+     * passing BIO_CLOSE here the socket will be automatically closed when
+     * the BIO is freed. Alternatively you can use BIO_NOCLOSE, in which
+     * case you must close the socket explicitly when it is no longer
+     * needed.
+     */
+    BIO_set_fd(bio, sock, BIO_CLOSE);
+
+    return bio;
+}
+
+static void wait_for_activity(SSL *ssl)
+{
+    fd_set wfds, rfds;
+    int width, sock, isinfinite;
+    struct timeval tv;
+    struct timeval *tvp = NULL;
+
+    /* Get hold of the underlying file descriptor for the socket */
+    sock = SSL_get_fd(ssl);
+
+    FD_ZERO(&wfds);
+    FD_ZERO(&rfds);
+
+    /*
+     * Find out if we would like to write to the socket, or read from it (or
+     * both)
+     */
+    if (SSL_net_write_desired(ssl))
+        FD_SET(sock, &wfds);
+    if (SSL_net_read_desired(ssl))
+        FD_SET(sock, &rfds);
+    width = sock + 1;
+
+    /*
+     * Find out when OpenSSL would next like to be called, regardless of
+     * whether the state of the underlying socket has changed or not.
+     */
+    if (SSL_get_event_timeout(ssl, &tv, &isinfinite) && !isinfinite)
+        tvp = &tv;
+
+    /*
+     * Wait until the socket is writeable or readable. We use select here
+     * for the sake of simplicity and portability, but you could equally use
+     * poll/epoll or similar functions
+     *
+     * NOTE: For the purposes of this demonstration code this effectively
+     * makes this demo block until it has something more useful to do. In a
+     * real application you probably want to go and do other work here (e.g.
+     * update a GUI, or service other connections).
+     *
+     * Let's say for example that you want to update the progress counter on
+     * a GUI every 100ms. One way to do that would be to use the timeout in
+     * the last parameter to "select" below. If the tvp value is greater
+     * than 100ms then use 100ms instead. Then, when select returns, you
+     * check if it did so because of activity on the file descriptors or
+     * because of the timeout. If the 100ms GUI timeout has expired but the
+     * tvp timeout has not then go and update the GUI and then restart the
+     * "select" (with updated timeouts).
+     */
+
+    select(width, &rfds, &wfds, NULL, tvp);
+}
+
+static int handle_io_failure(SSL *ssl, int res)
+{
+    switch (SSL_get_error(ssl, res)) {
+    case SSL_ERROR_WANT_READ:
+    case SSL_ERROR_WANT_WRITE:
+        /* Temporary failure. Wait until we can read/write and try again */
+        wait_for_activity(ssl);
+        return 1;
+
+    case SSL_ERROR_ZERO_RETURN:
+        /* EOF */
+        return 0;
+
+    case SSL_ERROR_SYSCALL:
+        return -1;
+
+    case SSL_ERROR_SSL:
+        /*
+         * Some stream fatal error occurred. This could be because of a
+         * stream reset - or some failure occurred on the underlying
+         * connection.
+         */
+        switch (SSL_get_stream_read_state(ssl)) {
+        case SSL_STREAM_STATE_RESET_REMOTE:
+            fprintf(stderr, "Stream reset occurred\n");
+            /*
+             * The stream has been reset but the connection is still
+             * healthy.
+             */
+            break;
+
+        case SSL_STREAM_STATE_CONN_CLOSED:
+            fprintf(stderr, "Connection closed\n");
+            /* Connection is already closed. */
+            break;
+
+        default:
+            fprintf(stderr, "Unknown stream failure\n");
+            break;
+        }
+        /*
+         * If the failure is due to a verification error we can get more
+         * information about it from SSL_get_verify_result().
+         */
+        if (SSL_get_verify_result(ssl) != X509_V_OK)
+            fprintf(stderr, "Verify error: %s\n",
+                X509_verify_cert_error_string(SSL_get_verify_result(ssl)));
+        return -1;
+
+    default:
+        return -1;
+    }
+}
+
+static BIO *bio_keylog = NULL;
+
+static void keylog_callback(const SSL *ssl, const char *line)
+{
+    if (bio_keylog == NULL) {
+        fprintf(stderr, "Keylog callback is invoked without valid file!\n");
+        return;
+    }
+
+    /*
+     * There might be concurrent writers to the keylog file, so we must ensure
+     * that the given line is written at once.
+     */
+    BIO_printf(bio_keylog, "%s\n", line);
+    (void)BIO_flush(bio_keylog);
+}
+
+int set_keylog_file(SSL_CTX *ctx, const char *keylog_file)
+{
+    /* Close any open files */
+    BIO_free_all(bio_keylog);
+    bio_keylog = NULL;
+
+    if (ctx == NULL || keylog_file == NULL) {
+        /* Keylogging is disabled, OK. */
+        return 0;
+    }
+
+    /*
+     * Append rather than write in order to allow concurrent modification.
+     * Furthermore, this preserves existing keylog files which is useful when
+     * the tool is run multiple times.
+     */
+    bio_keylog = BIO_new_file(keylog_file, "a");
+    if (bio_keylog == NULL) {
+        printf("Error writing keylog file %s\n", keylog_file);
+        return 1;
+    }
+
+    /* Write a header for seekable, empty files (this excludes pipes). */
+    if (BIO_tell(bio_keylog) == 0) {
+        BIO_puts(bio_keylog,
+                 "# SSL/TLS secrets log file, generated by OpenSSL\n");
+        (void)BIO_flush(bio_keylog);
+    }
+    SSL_CTX_set_keylog_callback(ctx, keylog_callback);
+    return 0;
+}
+
+/*
+ * Simple application to send a basic HTTP/1.0 request to a server and
+ * print the response on the screen. Note that HTTP/1.0 over QUIC is
+ * non-standard and will not typically be supported by real world servers. This
+ * is for demonstration purposes only.
+ */
+int main(int argc, char *argv[])
+{
+    SSL_CTX *ctx = NULL;
+    SSL *ssl = NULL;
+    BIO *bio = NULL;
+    int res = EXIT_FAILURE;
+    int ret;
+    unsigned char alpn[] = { 10, 'h','q','-','i','n','t','e','r','o','p'};
+    char req_string[1024];
+    size_t written, readbytes = 0;
+    char buf[160];
+    BIO_ADDR *peer_addr = NULL;
+    int eof = 0;
+    char *hostname, *port;
+    int ipv6 = 0;
+    int argnext = 1;
+    char *reqfile = NULL;
+    char *sslkeylogfile = NULL;
+    BIO *req_bio = NULL;
+    char *reqnames = OPENSSL_zalloc(1025);
+    size_t read_offset = 0;
+    size_t bytes_read = 0;
+    char *req = NULL, *saveptr = NULL;
+    char outfilename[1024];
+    SSL *stream_bio = NULL;
+
+    if (argc < 4) {
+        fprintf(stderr, "Usage: quic-client-non-block [-6] hostname port file\n");
+        goto end;
+    }
+
+    if (!strcmp(argv[argnext], "-6")) {
+        if (argc < 5) {
+            fprintf(stderr, "Usage: quic-client-non-block [-6] hostname port\n");
+            goto end;
+        }
+        ipv6 = 1;
+        argnext++;
+    }
+    hostname = argv[argnext++];
+    port = argv[argnext++];
+    reqfile = argv[argnext];
+
+    memset(req_string, 0, 1024);
+#if 0
+    sprintf(req_string, "GET /%s\r\n",
+            reqfile);
+#endif
+    req_bio = BIO_new_file(reqfile, "r");
+    if (req_bio == NULL) {
+        fprintf(stderr, "Failed to open request file %s\n", reqfile);
+        goto end;
+    }
+
+    /* Get the list of requests */
+    while (!BIO_eof(req_bio)) {
+        if (!BIO_read_ex(req_bio, &reqnames[read_offset], 1024, &bytes_read)) {
+            fprintf(stderr, "Failed to read some data from request file\n");
+            goto end;
+        }
+        read_offset += bytes_read;
+        reqnames = OPENSSL_realloc(reqnames, read_offset+1024);
+        if (reqnames == NULL) {
+            fprintf(stderr, "Realloc failure\n");
+            goto end;
+        }
+    }
+    BIO_free(req_bio);
+    req_bio = NULL;
+    reqnames[read_offset+1] = '\0';
+    
+    /*
+     * Create an SSL_CTX which we can use to create SSL objects from. We
+     * want an SSL_CTX for creating clients so we use
+     * OSSL_QUIC_client_method() here.
+     */
+    ctx = SSL_CTX_new(OSSL_QUIC_client_method());
+    if (ctx == NULL) {
+        fprintf(stderr, "Failed to create the SSL_CTX\n");
+        goto end;
+    }
+
+    /*
+     * Configure the client to abort the handshake if certificate
+     * verification fails. Virtually all clients should do this unless you
+     * really know what you are doing.
+     */
+    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+
+    /* Use the default trusted certificate store */
+    if (!SSL_CTX_set_default_verify_paths(ctx)) {
+        fprintf(stderr, "Failed to set the default trusted certificate store\n");
+        goto end;
+    }
+
+    sslkeylogfile = getenv("SSLKEYLOGFILE");
+    if (sslkeylogfile != NULL)
+        if (set_keylog_file(ctx, sslkeylogfile))
+            goto end;
+
+    /* Create an SSL object to represent the TLS connection */
+    ssl = SSL_new(ctx);
+    if (ssl == NULL) {
+        fprintf(stderr, "Failed to create the SSL object\n");
+        goto end;
+    }
+
+    /*
+     * Create the underlying transport socket/BIO and associate it with the
+     * connection.
+     */
+    bio = create_socket_bio(hostname, port, ipv6 ? AF_INET6 : AF_INET,
+                            &peer_addr);
+    if (bio == NULL) {
+        fprintf(stderr, "Failed to crete the BIO\n");
+        goto end;
+    }
+    SSL_set_bio(ssl, bio, bio);
+
+    /*
+     * Tell the server during the handshake which hostname we are attempting
+     * to connect to in case the server supports multiple hosts.
+     */
+    if (!SSL_set_tlsext_host_name(ssl, hostname)) {
+        fprintf(stderr, "Failed to set the SNI hostname\n");
+        goto end;
+    }
+
+    /*
+     * Ensure we check during certificate verification that the server has
+     * supplied a certificate for the hostname that we were expecting.
+     * Virtually all clients should do this unless you really know what you
+     * are doing.
+     */
+    if (!SSL_set1_host(ssl, hostname)) {
+        fprintf(stderr, "Failed to set the certificate verification hostname");
+        goto end;
+    }
+
+    /* SSL_set_alpn_protos returns 0 for success! */
+    if (SSL_set_alpn_protos(ssl, alpn, sizeof(alpn)) != 0) {
+        fprintf(stderr, "Failed to set the ALPN for the connection\n");
+        goto end;
+    }
+
+    /* Set the IP address of the remote peer */
+    if (!SSL_set1_initial_peer_addr(ssl, peer_addr)) {
+        fprintf(stderr, "Failed to set the initial peer address\n");
+        goto end;
+    }
+
+    /*
+     * The underlying socket is always nonblocking with QUIC, but the default
+     * behaviour of the SSL object is still to block. We set it for nonblocking
+     * mode in this demo.
+     {*/
+    if (!SSL_set_blocking_mode(ssl, 0)) {
+        fprintf(stderr, "Failed to turn off blocking mode\n");
+        goto end;
+    }
+
+    /* Do the handshake with the server */
+    while ((ret = SSL_connect(ssl)) != 1) {
+        if (handle_io_failure(ssl, ret) == 1)
+            continue; /* Retry */
+        fprintf(stderr, "Failed to connect to server\n");
+        goto end; /* Cannot retry: error */
+    }
+
+
+    /* Send an http1.0 request for each item in reqnames */
+    req = strtok_r(reqnames, " ", &saveptr);
+    while (req != NULL) {
+
+        eof = 0;
+
+        /* Format the http request */
+        sprintf(req_string, "GET /%s\r\n", req);
+
+        /* build the outfile request path */
+        memset(outfilename, 0, 1024);
+        sprintf(outfilename, "/downloads/%s", req);
+
+        /* open a bio to write the file */
+        req_bio = BIO_new_file(outfilename, "w+");
+        if (req_bio == NULL) {
+            fprintf(stderr, "Failed to open outfile %s\n", outfilename);
+            goto end;
+        }
+
+        /* create a request stream */
+        stream_bio = SSL_new_stream(ssl, 0);
+        if (stream_bio == NULL) {
+            fprintf(stderr, "Failed to create stream request bio\n");
+            goto end;
+        }
+
+        /* Write an HTTP GET request to the peer */
+        while (!SSL_write_ex2(stream_bio, req_string, strlen(req_string),
+                              SSL_WRITE_FLAG_CONCLUDE, &written)) {
+            fprintf(stderr, "Write failed\n");
+            if (handle_io_failure(stream_bio, 0) == 1)
+                continue; /* Retry */
+            fprintf(stderr, "Failed to write start of HTTP request\n");
+            goto end; /* Cannot retry: error */
+        }
+
+        do {
+            /*
+             * Get up to sizeof(buf) bytes of the response. We keep reading until
+             * the server closes the connection.
+             */
+            while (!eof && !SSL_read_ex(stream_bio, buf, sizeof(buf), &readbytes)) {
+                switch (handle_io_failure(stream_bio, 0)) {
+                case 1:
+                    continue; /* Retry */
+                case 0:
+                    eof = 1;
+                    continue;
+                case -1:
+                default:
+                    fprintf(stderr, "Failed reading remaining data\n");
+                    goto end; /* Cannot retry: error */
+                }
+            }
+            /*
+             * OpenSSL does not guarantee that the returned data is a string or
+             * that it is NUL terminated so we use fwrite() to write the exact
+             * number of bytes that we read. The data could be non-printable or
+             * have NUL characters in the middle of it. For this simple example
+             * we're going to print it to stdout anyway.
+             */
+            if (!eof)
+                BIO_write(req_bio, buf, readbytes);
+            else
+                fprintf(stderr, "Wrote %s\n", outfilename);
+        } while (!eof);
+        /* In case the response didn't finish with a newline we add one now */
+        BIO_free(req_bio);
+        req_bio = NULL;
+        req = strtok_r(NULL, " ", &saveptr);
+        SSL_free(stream_bio);
+        stream_bio = NULL;
+    }
+
+    /*
+     * Repeatedly call SSL_shutdown() until the connection is fully
+     * closed.
+     */
+    while ((ret = SSL_shutdown(ssl)) != 1) {
+        if (ret < 0 && handle_io_failure(ssl, ret) == 1)
+            continue; /* Retry */
+    }
+
+    /* Success! */
+    res = EXIT_SUCCESS;
+ end:
+    /*
+     * If something bad happened then we will dump the contents of the
+     * OpenSSL error stack to stderr. There might be some useful diagnostic
+     * information there.
+     */
+    if (res == EXIT_FAILURE)
+        ERR_print_errors_fp(stderr);
+
+    /*
+     * Free the resources we allocated. We do not free the BIO object here
+     * because ownership of it was immediately transferred to the SSL object
+     * via SSL_set_bio(). The BIO will be freed when we free the SSL object.
+     */
+    SSL_free(stream_bio);
+    SSL_free(ssl);
+    SSL_CTX_free(ctx);
+    BIO_ADDR_free(peer_addr);
+    OPENSSL_free(reqnames);
+    BIO_free(req_bio);
+    return res;
+}

--- a/demos/guide/quic-hq-interop.c
+++ b/demos/guide/quic-hq-interop.c
@@ -54,6 +54,7 @@
 #include <openssl/err.h>
 
 static int handle_io_failure(SSL *ssl, int res);
+static int set_keylog_file(SSL_CTX *ctx, const char *keylog_file);
 
 /**
  * @brief A static pointer to a BIO object representing the session's BIO.
@@ -383,7 +384,7 @@ static void keylog_callback(const SSL *ssl, const char *line)
  * seekable. It also ensures that any previously opened keylog files are
  * closed before opening a new one.
  */
-int set_keylog_file(SSL_CTX *ctx, const char *keylog_file)
+static int set_keylog_file(SSL_CTX *ctx, const char *keylog_file)
 {
     /* Close any open files */
     BIO_free_all(bio_keylog);

--- a/demos/guide/quic-hq-interop.c
+++ b/demos/guide/quic-hq-interop.c
@@ -1,4 +1,3 @@
-
 /*
  *  Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
  *
@@ -81,7 +80,6 @@ static BIO *session_bio = NULL;
  * file in which it is declared.
  */
 static BIO *bio_keylog = NULL;
-
 
 /**
  * @brief Creates a BIO object for a UDP socket connection to a server.
@@ -331,7 +329,7 @@ static int handle_io_failure(SSL *ssl, int res)
          */
         if (SSL_get_verify_result(ssl) != X509_V_OK)
             fprintf(stderr, "Verify error: %s\n",
-                X509_verify_cert_error_string(SSL_get_verify_result(ssl)));
+                    X509_verify_cert_error_string(SSL_get_verify_result(ssl)));
         return -1;
 
     default:
@@ -480,7 +478,6 @@ static int cache_new_session(struct ssl_st *ssl, SSL_SESSION *sess)
  */
 static int setup_session_cache(SSL *ssl, SSL_CTX *ctx, const char *filename)
 {
-
     SSL_SESSION *sess = NULL;
     int rc = 0;
     int new_cache = 0;
@@ -638,7 +635,7 @@ static size_t build_request_set(SSL *ssl)
      * multiple calls to build_request_list are made
      */
     while (req_idx < total_requests) {
-	req = req_array[req_idx];
+        req = req_array[req_idx];
         /* Up our poll count and set our poll_list index */
         poll_count++;
         poll_idx = poll_count - 1;
@@ -739,6 +736,151 @@ err:
 }
 
 /**
+ * @brief Static pointer to a BIO_ADDR structure representing the peer's address.
+ *
+ * This variable is used to store the address of a peer for network communication.
+ * It is statically allocated and should be initialized appropriately.
+ */
+static BIO_ADDR *peer_addr = NULL;
+
+/**
+ * @brief Set up a TLS/QUIC connection to the specified hostname and port.
+ *
+ * This function creates and configures an SSL context for a client connection
+ * using the QUIC client method. It sets up the necessary certificates,
+ * performs host verification, configures ALPN, and establishes a non-blocking
+ * connection.
+ *
+ * @param hostname Hostname to connect to.
+ * @param port Port to connect to.
+ * @param ipv6 Whether to use IPv6 (non-zero for IPv6, zero for IPv4).
+ * @param ctx Pointer to an SSL_CTX object, which will be created.
+ * @param ssl Pointer to an SSL object, which will be created.
+ *
+ * @return Returns 0 on success, 1 on error.
+ */
+static int setup_connection(char *hostname, char *port, int ipv6,
+                            SSL_CTX **ctx, SSL **ssl)
+{
+    unsigned char alpn[] = {10, 'h', 'q', '-', 'i', 'n', 't', 'e', 'r', 'o', 'p'};
+    int ret = 0;
+    char *sslkeylogfile = NULL;
+    BIO *bio = NULL;
+
+    /*
+     * Create an SSL_CTX which we can use to create SSL objects from. We
+     * want an SSL_CTX for creating clients so we use
+     * OSSL_QUIC_client_method() here.
+     */
+    *ctx = SSL_CTX_new(OSSL_QUIC_client_method());
+    if (*ctx == NULL) {
+        fprintf(stderr, "Failed to create the SSL_CTX\n");
+        goto end;
+    }
+
+    /*
+     * Configure the client to abort the handshake if certificate
+     * verification fails. Virtually all clients should do this unless you
+     * really know what you are doing.
+     */
+    SSL_CTX_set_verify(*ctx, SSL_VERIFY_PEER, NULL);
+
+    /* Use the default trusted certificate store */
+    if (!SSL_CTX_set_default_verify_paths(*ctx)) {
+        fprintf(stderr, "Failed to set the default trusted certificate store\n");
+        goto end;
+    }
+
+    sslkeylogfile = getenv("SSLKEYLOGFILE");
+    if (sslkeylogfile != NULL)
+        if (set_keylog_file(*ctx, sslkeylogfile))
+            goto end;
+
+    /* Create an SSL object to represent the TLS connection */
+    *ssl = SSL_new(*ctx);
+    if (*ssl == NULL) {
+        fprintf(stderr, "Failed to create the SSL object\n");
+        goto end;
+    }
+
+    if (getenv("SSL_SESSION_FILE") != NULL) {
+        if (!setup_session_cache(*ssl, *ctx, getenv("SSL_SESSION_FILE"))) {
+            fprintf(stderr, "Unable to setup session cache\n");
+            goto end;
+        }
+    }
+
+    /*
+     * Create the underlying transport socket/BIO and associate it with the
+     * connection.
+     */
+    bio = create_socket_bio(hostname, port, ipv6 ? AF_INET6 : AF_INET,
+                            &peer_addr);
+    if (bio == NULL) {
+        fprintf(stderr, "Failed to crete the BIO\n");
+        goto end;
+    }
+    SSL_set_bio(*ssl, bio, bio);
+
+    /*
+     * Tell the server during the handshake which hostname we are attempting
+     * to connect to in case the server supports multiple hosts.
+     */
+    if (!SSL_set_tlsext_host_name(*ssl, hostname)) {
+        fprintf(stderr, "Failed to set the SNI hostname\n");
+        goto end;
+    }
+
+    /*
+     * Ensure we check during certificate verification that the server has
+     * supplied a certificate for the hostname that we were expecting.
+     * Virtually all clients should do this unless you really know what you
+     * are doing.
+     */
+    if (!SSL_set1_host(*ssl, hostname)) {
+        fprintf(stderr, "Failed to set the certificate verification hostname");
+        goto end;
+    }
+
+    /* SSL_set_alpn_protos returns 0 for success! */
+    if (SSL_set_alpn_protos(*ssl, alpn, sizeof(alpn)) != 0) {
+        fprintf(stderr, "Failed to set the ALPN for the connection\n");
+        goto end;
+    }
+
+    /* Set the IP address of the remote peer */
+    if (!SSL_set1_initial_peer_addr(*ssl, peer_addr)) {
+        fprintf(stderr, "Failed to set the initial peer address\n");
+        goto end;
+    }
+
+    /*
+     * The underlying socket is always nonblocking with QUIC, but the default
+     * behaviour of the SSL object is still to block. We set it for nonblocking
+     * mode in this demo.
+     */
+    if (!SSL_set_blocking_mode(*ssl, 0)) {
+        fprintf(stderr, "Failed to turn off blocking mode\n");
+        goto end;
+    }
+
+    /* Do the handshake with the server */
+    while ((ret = SSL_connect(*ssl)) != 1) {
+        if (handle_io_failure(*ssl, ret) == 1)
+            continue; /* Retry */
+        fprintf(stderr, "Failed to connect to server\n");
+        goto end; /* Cannot retry: error */
+    }
+
+    return 0;
+end:
+    SSL_CTX_free(*ctx);
+    SSL_free(*ssl);
+    BIO_ADDR_free(peer_addr);
+    return 1;
+}
+
+/**
  * @brief Entry point for the QUIC hq-interop client demo application.
  *
  * This function sets up an SSL/TLS connection using QUIC, sends HTTP GET
@@ -766,7 +908,6 @@ int main(int argc, char *argv[])
 {
     SSL_CTX *ctx = NULL;
     SSL *ssl = NULL;
-    BIO *bio = NULL;
     BIO *req_bio = NULL;
     int res = EXIT_FAILURE;
     int ret;
@@ -776,7 +917,6 @@ int main(int argc, char *argv[])
     int eof = 0;
     int argnext = 1;
     char *reqfile = NULL;
-    char *sslkeylogfile = NULL;
     char *reqnames = OPENSSL_zalloc(1025);
     size_t read_offset = 0;
     size_t bytes_read = 0;
@@ -788,8 +928,6 @@ int main(int argc, char *argv[])
     char *req, *saveptr = NULL;
     char *hostname, *port;
     int ipv6 = 0;
-    unsigned char alpn[] = { 10, 'h','q','-','i','n','t','e','r','o','p'};
-    BIO_ADDR *peer_addr = NULL;
 
     if (argc < 4) {
         fprintf(stderr, "Usage: quic-hq-interop [-6] hostname port file\n");
@@ -822,7 +960,7 @@ int main(int argc, char *argv[])
             goto end;
         }
         read_offset += bytes_read;
-        reqnames = OPENSSL_realloc(reqnames, read_offset+1024);
+        reqnames = OPENSSL_realloc(reqnames, read_offset + 1024);
         if (reqnames == NULL) {
             fprintf(stderr, "Realloc failure\n");
             goto end;
@@ -830,124 +968,25 @@ int main(int argc, char *argv[])
     }
     BIO_free(req_bio);
     req_bio = NULL;
-    reqnames[read_offset+1] = '\0';
-    
-    /*
-     * Create an SSL_CTX which we can use to create SSL objects from. We
-     * want an SSL_CTX for creating clients so we use
-     * OSSL_QUIC_client_method() here.
-     */
-    ctx = SSL_CTX_new(OSSL_QUIC_client_method());
-    if (ctx == NULL) {
-        fprintf(stderr, "Failed to create the SSL_CTX\n");
+    reqnames[read_offset + 1] = '\0';
+
+    if (!setup_connection(hostname, port, ipv6, &ctx, &ssl)) {
+        fprintf(stderr, "Unable to establish connection\n");
         goto end;
-    }
-
-    /*
-     * Configure the client to abort the handshake if certificate
-     * verification fails. Virtually all clients should do this unless you
-     * really know what you are doing.
-     */
-    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
-
-    /* Use the default trusted certificate store */
-    if (!SSL_CTX_set_default_verify_paths(ctx)) {
-        fprintf(stderr, "Failed to set the default trusted certificate store\n");
-        goto end;
-    }
-
-    sslkeylogfile = getenv("SSLKEYLOGFILE");
-    if (sslkeylogfile != NULL)
-        if (set_keylog_file(ctx, sslkeylogfile))
-            goto end;
-
-    /* Create an SSL object to represent the TLS connection */
-    ssl = SSL_new(ctx);
-    if (ssl == NULL) {
-        fprintf(stderr, "Failed to create the SSL object\n");
-        goto end;
-    }
-
-    if (getenv("SSL_SESSION_FILE") != NULL) {
-        if (!setup_session_cache(ssl, ctx, getenv("SSL_SESSION_FILE"))) {
-            fprintf(stderr, "Unable to setup session cache\n");
-            goto end;
-        }
-    }
-
-    /*
-     * Create the underlying transport socket/BIO and associate it with the
-     * connection.
-     */
-    bio = create_socket_bio(hostname, port, ipv6 ? AF_INET6 : AF_INET,
-                            &peer_addr);
-    if (bio == NULL) {
-        fprintf(stderr, "Failed to crete the BIO\n");
-        goto end;
-    }
-    SSL_set_bio(ssl, bio, bio);
-
-    /*
-     * Tell the server during the handshake which hostname we are attempting
-     * to connect to in case the server supports multiple hosts.
-     */
-    if (!SSL_set_tlsext_host_name(ssl, hostname)) {
-        fprintf(stderr, "Failed to set the SNI hostname\n");
-        goto end;
-    }
-
-    /*
-     * Ensure we check during certificate verification that the server has
-     * supplied a certificate for the hostname that we were expecting.
-     * Virtually all clients should do this unless you really know what you
-     * are doing.
-     */
-    if (!SSL_set1_host(ssl, hostname)) {
-        fprintf(stderr, "Failed to set the certificate verification hostname");
-        goto end;
-    }
-
-    /* SSL_set_alpn_protos returns 0 for success! */
-    if (SSL_set_alpn_protos(ssl, alpn, sizeof(alpn)) != 0) {
-        fprintf(stderr, "Failed to set the ALPN for the connection\n");
-        goto end;
-    }
-
-    /* Set the IP address of the remote peer */
-    if (!SSL_set1_initial_peer_addr(ssl, peer_addr)) {
-        fprintf(stderr, "Failed to set the initial peer address\n");
-        goto end;
-    }
-
-    /*
-     * The underlying socket is always nonblocking with QUIC, but the default
-     * behaviour of the SSL object is still to block. We set it for nonblocking
-     * mode in this demo.
-     */
-    if (!SSL_set_blocking_mode(ssl, 0)) {
-        fprintf(stderr, "Failed to turn off blocking mode\n");
-        goto end;
-    }
-
-    /* Do the handshake with the server */
-    while ((ret = SSL_connect(ssl)) != 1) {
-        if (handle_io_failure(ssl, ret) == 1)
-            continue; /* Retry */
-        fprintf(stderr, "Failed to connect to server\n");
-        goto end; /* Cannot retry: error */
     }
 
     req = strtok_r(reqnames, " ", &saveptr);
 
     while (req != NULL) {
-	total_requests++;
-	req_array = OPENSSL_realloc(req_array, sizeof(char *) * total_requests); 
-	req_array[total_requests-1] = req;
-    	req = strtok_r(NULL, " ", &saveptr);
+        total_requests++;
+        req_array = OPENSSL_realloc(req_array, sizeof(char *) * total_requests);
+        req_array[total_requests - 1] = req;
+        req = strtok_r(NULL, " ", &saveptr);
     }
 
     /* get a list of requests to poll */
     this_poll_count = build_request_set(ssl);
+
     /*
      * Now poll all our descriptors for events
      */
@@ -956,7 +995,7 @@ int main(int argc, char *argv[])
         poll_timeout.tv_sec = 0;
         poll_timeout.tv_usec = 0;
         if (!SSL_poll(poll_list, this_poll_count, sizeof(SSL_POLL_ITEM),
-                     &poll_timeout, 0, &result_count)) {
+                      &poll_timeout, 0, &result_count)) {
             fprintf(stderr, "Failed to poll\n");
             goto end;
         }
@@ -1005,8 +1044,8 @@ int main(int argc, char *argv[])
 
                 /*
                  * If error handling indicated that this SSL is in an EOF state
-                 * we mark the SSL as not needing any more polling, and up our 
-                 * poll_done count.  Otherwise, just write to the outbio 
+                 * we mark the SSL as not needing any more polling, and up our
+                 * poll_done count.  Otherwise, just write to the outbio
                  */
                 if (!eof) {
                     BIO_write(outbiolist[poll_idx], buf, readbytes);
@@ -1024,7 +1063,7 @@ int main(int argc, char *argv[])
          */
         if (poll_done == this_poll_count) {
             this_poll_count = build_request_set(ssl);
-	    poll_done=0;
+            poll_done = 0;
         }
     }
 

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4023,6 +4023,16 @@ static int test_poll_event_r(QUIC_XSO *xso)
     int fin = 0;
     size_t avail = 0;
 
+    /*
+     * If the recv state is QUIC_RSTREAM_STATE_DATA_READ
+     * then we must have received a fin bit in the last packet
+     * return 1 here to indicate a read event so the next SSL_read
+     * produces an error and SSL_ZERO_RETURN cause
+     */
+    if (xso->stream->recv_state == QUIC_RSTREAM_STATE_DATA_READ)
+        return 1;
+
+
     return ossl_quic_stream_has_recv_buffer(xso->stream)
         && ossl_quic_rstream_available(xso->stream->rstream, &avail, &fin)
         && (avail > 0 || (fin && !xso->retired_fin));

--- a/test/quic-openssl-docker/Dockerfile
+++ b/test/quic-openssl-docker/Dockerfile
@@ -25,8 +25,8 @@ RUN git clone https://github.com/ngtcp2/nghttp3.git && \
 # download and build openssl 
 RUN git clone https://github.com/openssl/openssl.git && \
     cd openssl && \
-    ./Configure enable-fips no-docs --prefix=/usr --openssldir=/etc/pki/tls && \
-    make -j 4 && make install && \
+    ./Configure enable-fips enable-demos no-docs --prefix=/usr --openssldir=/etc/pki/tls && \
+    make -j 4 && make install && cp demos/guide/quic-hq-interop /usr/local/bin && \
     rm -rf /openssl
 
 # Build curl

--- a/test/quic-openssl-docker/Dockerfile
+++ b/test/quic-openssl-docker/Dockerfile
@@ -4,6 +4,9 @@ FROM martenseemann/quic-network-simulator-endpoint:latest
 ENV PKG_CONFIG_LIBDIR=/usr/lib64/pkgconfig:/usr/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig/:$PKG_CONFIG_LIBDIR
 # Set the environment variable LD_LIBRARY_PATH to ensure we get the right libraries
 ENV LD_LIBRARY_PATH=/usr/lib64:/usr/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+# The branch of openssl to clone
+ARG OPENSSL_URL=https://github.com/openssl/openssl.git
+ARG OPENSSL_BRANCH=master
 
 # Install needed tools
 RUN apt-get update && apt-get install -y \
@@ -13,7 +16,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /
 
 # build nghttp3
-RUN git clone https://github.com/ngtcp2/nghttp3.git && \
+RUN git clone --depth 1 https://github.com/ngtcp2/nghttp3.git && \
     cd nghttp3 && \
     git submodule update --init && \
     autoreconf -i && \
@@ -23,14 +26,14 @@ RUN git clone https://github.com/ngtcp2/nghttp3.git && \
     rm -rf /nghttp3
 
 # download and build openssl 
-RUN git clone https://github.com/openssl/openssl.git && \
+RUN git clone --depth 1 -b $OPENSSL_BRANCH $OPENSSL_URL && \
     cd openssl && \
-    ./Configure enable-fips enable-demos no-docs --prefix=/usr --openssldir=/etc/pki/tls && \
+    ./Configure enable-fips enable-demos disable-docs --prefix=/usr --openssldir=/etc/pki/tls && \
     make -j 4 && make install && cp demos/guide/quic-hq-interop /usr/local/bin && \
     rm -rf /openssl
 
 # Build curl
-RUN git clone https://github.com/curl/curl.git && \
+RUN git clone --depth 1 https://github.com/curl/curl.git && \
     cd curl && \
     autoreconf -fi && ./configure --with-openssl-quic --with-openssl --with-nghttp3 --prefix=/usr && \
     make -j 4 && \

--- a/test/quic-openssl-docker/run_endpoint.sh
+++ b/test/quic-openssl-docker/run_endpoint.sh
@@ -39,11 +39,7 @@ if [ "$ROLE" == "client" ]; then
         echo -e "--verbose\n--parallel" >> $CURLRC
         generate_outputs_http3
         dump_curlrc
-        SSL_CERT_FILE=/certs/ca.pem curl --config $CURLRC 
-        if [ $? -ne 0 ]
-        then
-            exit 1
-        fi
+        SSL_CERT_FILE=/certs/ca.pem curl --config $CURLRC || exit 1
         exit 0
         ;;
     "handshake"|"transfer"|"retry")
@@ -58,11 +54,7 @@ if [ "$ROLE" == "client" ]; then
            fi
            echo -n "$OUTFILE " >> ./reqfile.txt
        done
-       SSLKEYLOGFILE=/logs/keys.log SSL_CERT_FILE=/certs/ca.pem SSL_CERT_DIR=/certs quic-hq-interop $HOSTNAME $HOSTPORT ./reqfile.txt 
-       if [ $? -ne 0 ]
-       then
-           exit 1
-       fi
+       SSLKEYLOGFILE=/logs/keys.log SSL_CERT_FILE=/certs/ca.pem SSL_CERT_DIR=/certs quic-hq-interop $HOSTNAME $HOSTPORT ./reqfile.txt || exit 1
        exit 0
        ;; 
     "resumption")
@@ -72,11 +64,7 @@ if [ "$ROLE" == "client" ]; then
            echo -n "$OUTFILE " > ./reqfile.txt
            HOSTNAME=$(printf "%s\n" "$req" | sed -ne 's,^https://\([^/:]*\).*,\1,p')
            HOSTPORT=$(printf "%s\n" "$req" | sed -ne 's,^https://[^:/]*:\([^/]*\).*,\1,p')
-           SSL_SESSION_FILE=./session.db SSLKEYLOGFILE=/logs/keys.log SSL_CERT_FILE=/certs/ca.pem SSL_CERT_DIR=/certs quic-hq-interop $HOSTNAME $HOSTPORT ./reqfile.txt
-           if [ $? -ne 0 ]
-           then
-                exit 1
-           fi
+           SSL_SESSION_FILE=./session.db SSLKEYLOGFILE=/logs/keys.log SSL_CERT_FILE=/certs/ca.pem SSL_CERT_DIR=/certs quic-hq-interop $HOSTNAME $HOSTPORT ./reqfile.txt || exit 1
        done
        exit 0
        ;;

--- a/test/quic-openssl-docker/run_endpoint.sh
+++ b/test/quic-openssl-docker/run_endpoint.sh
@@ -53,8 +53,8 @@ if [ "$ROLE" == "client" ]; then
            OUTFILE=$(basename $req)
            if [ "$HOSTNAME" == "none" ]
            then
-               HOSTNAME=$(echo $req | sed -e"s/\(^https:\/\/\)\(.*\)\(:.*$\)/\2/")
-               HOSTPORT=$(echo $req | sed -e"s/\(^https:\/\/\)\(.*:\)\(.*\)\(\/.*$\)/\3/")
+               HOSTNAME=$(printf "%s\n" "$req" | sed -ne 's,^https://\([^/:]*\).*,\1,p')
+               HOSTPORT=$(printf "%s\n" "$req" | sed -ne 's,^https://[^:/]*:\([^/]*\).*,\1,p')
            fi
            echo -n "$OUTFILE " >> ./reqfile.txt
        done
@@ -70,8 +70,8 @@ if [ "$ROLE" == "client" ]; then
        do
            OUTFILE=$(basename $req)
            echo -n "$OUTFILE " > ./reqfile.txt
-           HOSTNAME=$(echo $req | sed -e"s/\(^https:\/\/\)\(.*\)\(:.*$\)/\2/")
-           HOSTPORT=$(echo $req | sed -e"s/\(^https:\/\/\)\(.*:\)\(.*\)\(\/.*$\)/\3/")
+           HOSTNAME=$(printf "%s\n" "$req" | sed -ne 's,^https://\([^/:]*\).*,\1,p')
+           HOSTPORT=$(printf "%s\n" "$req" | sed -ne 's,^https://[^:/]*:\([^/]*\).*,\1,p')
            SSL_SESSION_FILE=./session.db SSLKEYLOGFILE=/logs/keys.log SSL_CERT_FILE=/certs/ca.pem SSL_CERT_DIR=/certs quic-hq-interop $HOSTNAME $HOSTPORT ./reqfile.txt
            if [ $? -ne 0 ]
            then

--- a/test/quic-openssl-docker/run_endpoint.sh
+++ b/test/quic-openssl-docker/run_endpoint.sh
@@ -65,6 +65,21 @@ if [ "$ROLE" == "client" ]; then
        fi
        exit 0
        ;; 
+    "resumption")
+       for req in $REQUESTS
+       do
+           OUTFILE=$(basename $req)
+           echo -n "$OUTFILE " > ./reqfile.txt
+           HOSTNAME=$(echo $req | sed -e"s/\(^https:\/\/\)\(.*\)\(:.*$\)/\2/")
+           HOSTPORT=$(echo $req | sed -e"s/\(^https:\/\/\)\(.*:\)\(.*\)\(\/.*$\)/\3/")
+           SSL_SESSION_FILE=./session.db SSLKEYLOGFILE=/logs/keys.log SSL_CERT_FILE=/certs/ca.pem SSL_CERT_DIR=/certs quic-hq-interop $HOSTNAME $HOSTPORT ./reqfile.txt
+           if [ $? -ne 0 ]
+           then
+                exit 1
+           fi
+       done
+       exit 0
+       ;;
     "chacha20")
        OUTFILE=$(basename $REQUESTS)
        SSL_CERT_FILE=/certs/ca.pem curl --verbose --tlsv1.3 --tls13-ciphers TLS_CHACHA20_POLY1305_SHA256 --http3 -o /downloads/$OUTFILE $REQUESTS || exit 1

--- a/test/quic-openssl-docker/run_endpoint.sh
+++ b/test/quic-openssl-docker/run_endpoint.sh
@@ -36,9 +36,9 @@ if [ "$ROLE" == "client" ]; then
 
     case "$TESTCASE" in
     "http3")
-    echo -e "--verbose\n--parallel" >> $CURLRC
-    generate_outputs_http3
-    dump_curlrc
+        echo -e "--verbose\n--parallel" >> $CURLRC
+        generate_outputs_http3
+        dump_curlrc
         SSL_CERT_FILE=/certs/ca.pem curl --config $CURLRC 
         if [ $? -ne 0 ]
         then

--- a/test/quic-openssl-docker/run_endpoint.sh
+++ b/test/quic-openssl-docker/run_endpoint.sh
@@ -46,7 +46,7 @@ if [ "$ROLE" == "client" ]; then
         fi
         exit 0
         ;;
-    "handshake"|"transfer")
+    "handshake"|"transfer"|"retry")
        HOSTNAME=none
        for req in $REQUESTS
        do
@@ -63,11 +63,6 @@ if [ "$ROLE" == "client" ]; then
        then
            exit 1
        fi
-       exit 0
-       ;; 
-    "retry")
-       OUTFILE=$(basename $REQUESTS)
-       SSL_CERT_FILE=/certs/ca.pem curl --verbose --http3 -o /downloads/$OUTFILE $REQUESTS || exit 1
        exit 0
        ;; 
     "chacha20")


### PR DESCRIPTION
This gives us some improvements in quic interop testing by creating a quic-hq-interop client

Some tests in the quic interop suite use http3 to communicate, for which we use a version of curl built with our latest openssl library and nghttp3.  However many expect to negotiate an hq-interop alpn (which is a testing alpn that represents http/1.0 over QUIC.  The use of http1.0 simplifies the communication needed between the client and server to do file transfers, and most tests will fail if an h3 alpn is offered rather than hq-interop, which curl cannot currently do.

So this PR creates demos/guide/quic-hq-interop, which offers the following features
1) peer validation using the openssl built in SSL_CERT_FILE environment variable
2) SSL keylogging (this is temporary until https://github.com/openssl/openssl/pull/25297 is merged)
3) Session resumption across application runs using the SSL_SESSION_FILE environment variable
4) Parallel stream download/batching using multiple SSL stream objects

While its listed in the demos directory (as it seems it may be useful as a guide for other users), it is built nighly as part of the CI job that rebuilds our interop container (build_quic_interop_container.yml) and used to run the interop tests.


##### Checklist
- [x] tests are added or updated
