### PR TITLE
IANA has assigned numbers for new TLS Supported Groups in ML-KEM

### DIFF
--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -547,6 +547,8 @@ static const ssl_trace_tbl ssl_groups_tbl[] = {
     {258, "ffdhe4096"},
     {259, "ffdhe6144"},
     {260, "ffdhe8192"},
+    {4587, "SecP256r1MLKEM768"},
+    {4588, "X25519MLKEM768"},
     {25497, "X25519Kyber768Draft00"},
     {25498, "SecP256r1Kyber768Draft00"},
     {0xFF01, "arbitrary_explicit_prime_curves"},


### PR DESCRIPTION
IANA has assigned numbers for new TLS Supported Groups in ML-KEM

https://www.ietf.org/archive/id/draft-kwiatkowski-tls-ecdhe-mlkem-01.html#name-iana-considerations
