### PR TITLE
EVP_PKEY_encapsulate/decapsulate documentation error

### DIFF
--- a/doc/man3/EVP_PKEY_decapsulate.pod
+++ b/doc/man3/EVP_PKEY_decapsulate.pod
@@ -64,7 +64,7 @@ Decapsulate data using RSA:
  unsigned char *secret = NULL;;
 
  ctx = EVP_PKEY_CTX_new_from_pkey(libctx, rsa_priv_key, NULL);
- if (ctx = NULL)
+ if (ctx == NULL)
      /* Error */
  if (EVP_PKEY_decapsulate_init(ctx, NULL) <= 0)
      /* Error */

--- a/doc/man3/EVP_PKEY_encapsulate.pod
+++ b/doc/man3/EVP_PKEY_encapsulate.pod
@@ -70,7 +70,7 @@ Encapsulate an RSASVE key (for RSA keys).
  unsigned char *out = NULL, *secret = NULL;
 
  ctx = EVP_PKEY_CTX_new_from_pkey(libctx, rsa_pub_key, NULL);
- if (ctx = NULL)
+ if (ctx == NULL)
      /* Error */
  if (EVP_PKEY_encapsulate_init(ctx, NULL) <= 0)
      /* Error */


### PR DESCRIPTION
This fixes the documentation for EVP_PKEY_encapsulate/decapsulate.

Closes #25448

- [X] documentation is added or updated