### PR TITLE
Always tick the QUIC_ENGINE (for the quic-server branch)

### DIFF
--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -1870,12 +1870,12 @@ void ossl_quic_channel_subtick(QUIC_CHANNEL *ch, QUIC_TICK_RESULT *res,
      *   - determine the time at which we should next be ticked.
      */
 
-    /* Nothing to do yet if connection has not been started. */
-    if (ch->state == QUIC_CHANNEL_STATE_IDLE)
-        return;
-
-    /* If we are in the TERMINATED state, there is nothing to do. */
-    if (ossl_quic_channel_is_terminated(ch)) {
+    /*
+     * If the connection has not yet started, or we are in the TERMINATED state,
+     * there is nothing to do.
+     */
+    if (ch->state == QUIC_CHANNEL_STATE_IDLE
+            || ossl_quic_channel_is_terminated(ch)) {
         res->net_read_desired       = 0;
         res->net_write_desired      = 0;
         res->notify_other_threads   = 0;

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -1301,14 +1301,7 @@ int ossl_quic_handle_events(SSL *s)
         return 0;
 
     qctx_lock(&ctx);
-    /*
-     * TODO(QUIC SERVER): We should always tick the engine, whether the current
-     * connection is started or not.  When ticking the engine, we MUST avoid
-     * inadvertently starting connections that haven't started, the guards
-     * don't belong here.
-     */
-    if (ctx.qc == NULL || ctx.qc->started)
-        ossl_quic_reactor_tick(ossl_quic_obj_get0_reactor(ctx.obj), 0);
+    ossl_quic_reactor_tick(ossl_quic_obj_get0_reactor(ctx.obj), 0);
     qctx_unlock(&ctx);
     return 1;
 }
@@ -4782,15 +4775,15 @@ int ossl_quic_conn_poll_events(SSL *ssl, uint64_t events, int do_tick,
 
     qctx_lock(&ctx);
 
+    if (do_tick)
+        ossl_quic_reactor_tick(ossl_quic_channel_get_reactor(ctx.qc->ch), 0);
+
     if (!ctx.qc->started) {
         /* We can only try to write on non-started connection. */
         if ((events & SSL_POLL_EVENT_W) != 0)
             revents |= SSL_POLL_EVENT_W;
         goto end;
     }
-
-    if (do_tick)
-        ossl_quic_reactor_tick(ossl_quic_channel_get_reactor(ctx.qc->ch), 0);
 
     if (ctx.xso != NULL) {
         /* SSL object has a stream component. */

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -2218,6 +2218,56 @@ err:
     return testresult;
 }
 
+/*
+ * Test that calling SSL_handle_events() early behaves as expected
+ */
+static int test_early_ticks(void)
+{
+    SSL_CTX *cctx = SSL_CTX_new_ex(libctx, NULL, OSSL_QUIC_client_method());
+    SSL *clientquic = NULL;
+    QUIC_TSERVER *qtserv = NULL;
+    int testresult = 0;
+    struct timeval tv;
+    int inf = 0;
+
+    if (!TEST_ptr(cctx)
+            || !TEST_true(qtest_create_quic_objects(libctx, cctx, NULL, cert,
+                                                    privkey, QTEST_FLAG_FAKE_TIME,
+                                                    &qtserv,
+                                                    &clientquic, NULL, NULL)))
+        goto err;
+
+    if (!TEST_true(SSL_in_before(clientquic)))
+        goto err;
+
+    if (!TEST_true(SSL_handle_events(clientquic)))
+        goto err;
+
+    if (!TEST_true(SSL_get_event_timeout(clientquic, &tv, &inf))
+            || !TEST_true(inf))
+        goto err;
+
+    if (!TEST_false(SSL_has_pending(clientquic))
+            || !TEST_int_eq(SSL_pending(clientquic), 0))
+        goto err;
+
+    if (!TEST_true(SSL_in_before(clientquic)))
+        goto err;
+
+    if (!TEST_true(qtest_create_quic_connection(qtserv, clientquic)))
+        goto err;
+
+    if (!TEST_false(SSL_in_before(clientquic)))
+        goto err;
+
+    testresult = 1;
+ err:
+    SSL_free(clientquic);
+    SSL_CTX_free(cctx);
+    ossl_quic_tserver_free(qtserv);
+    return testresult;
+}
+
 /***********************************************************************************/
 
 OPT_TEST_DECLARE_USAGE("provider config certsdir datadir\n")
@@ -2311,7 +2361,7 @@ int setup_tests(void)
     ADD_TEST(test_get_shutdown);
     ADD_ALL_TESTS(test_tparam, OSSL_NELEM(tparam_tests));
     ADD_TEST(test_domain_flags);
-
+    ADD_TEST(test_early_ticks);
     return 1;
  err:
     cleanup_tests();


### PR DESCRIPTION
This PR will eventually target the quic-server branch - but is currently built on top of #25432 and is pending the merge of that PR. Only the last 2 commits are relevant.

Just because one connection has not started yet, it does not mean that we should not tick the QUIC_ENGINE. There may be other connections that do need ticking.

We also add a test for the issue described in #25054, which was originally fixed by #25069 to ensure we haven't broken anything by the changes in the other commit in this PR.