### PR TITLE
Disable Power10 optimized chacha20 on all big-endian platforms

### DIFF
--- a/crypto/chacha/chacha_ppc.c
+++ b/crypto/chacha/chacha_ppc.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include <openssl/opensslconf.h>
+#include "internal/endian.h"
 #include "crypto/chacha.h"
 #include "crypto/ppc_arch.h"
 
@@ -30,7 +31,7 @@ void ChaCha20_ctr32(unsigned char *out, const unsigned char *inp,
                     size_t len, const unsigned int key[8],
                     const unsigned int counter[4])
 {
-#if !defined(OPENSSL_SYS_AIX) && !defined(OPENSSL_SYS_MACOSX)
+#if defined(L_ENDIAN)
     OPENSSL_ppccap_P & PPC_BRD31
         ? ChaCha20_ctr32_vsx_p10(out, inp, len, key, counter) :
 #endif


### PR DESCRIPTION
It fails most tests on a linux-ppc64-power10 host. I suspect this was never tested on a Power10 BE host, thus it has been disabled on AIX and darwin. However, the macro guards do not cover ppc64 linux (or openbsd if used there).

Update the guard to explicitly enable this only for little-endian hosts. This passes all tests on a linux-ppc64-power10 host running debian unstable.

Fixes #25451

CLA: trivial
