### PR TITLE
Build: Fix circular object deps with old GCC

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1746,7 +1746,7 @@ EOF
       } elsif ($makedep_scheme eq 'gcc' && !grep /\.rc$/, @srcs) {
           $recipe .= <<"EOF";
 $obj: $deps
-	$cmd $incs $defs $cmdflags -MMD -MF $dep.tmp -MT \$\@ -c -o \$\@ $srcs
+	$cmd $incs $defs $cmdflags -MMD -MF $dep.tmp -c -o \$\@ $srcs
 	\@touch $dep.tmp
 	\@if cmp $dep.tmp $dep > /dev/null 2> /dev/null; then \\
 		rm -f $dep.tmp; \\

--- a/NOTES-NONSTOP.md
+++ b/NOTES-NONSTOP.md
@@ -131,12 +131,9 @@ correctly, you also need the `COMP_ROOT` set, as in:
 
 `COMP_ROOT` needs to be in Windows form.
 
-`Configure` must specify the `no-makedepend` option otherwise errors will
-result when running the build because the c99 cross-compiler does not support
-the `gcc -MT` option. An example of a `Configure` command to be run from the
-OpenSSL directory is:
+An example of a `Configure` command to be run from the OpenSSL directory is:
 
-    ./Configure nonstop-nsx_64 no-makedepend --with-rand-seed=rdcpu
+    ./Configure nonstop-nsx_64 --with-rand-seed=rdcpu
 
 Do not forget to include any OpenSSL cross-compiling prefix and certificate
 options when creating your libraries.


### PR DESCRIPTION
When both `-o` and `-MT` are used, GCC 4.1 (please don't judge 😉) prints the object file twice in the dependency file. e.g.:

```
foo.o foo.o: foo.c
```

If the file name is long, then the second occurrence moves to the next line. e.g.:

ssl/statem/libssl-shlib-statem_dtls.o \
  ssl/statem/libssl-shlib-statem_dtls.o: ../ssl/statem/statem_dtls.c \

add-depends script scans one line at a time, so when the first line is processed, the object file becomes a dependency itself.

Fix by removing `-MT` altogether.

This also fixes makedepend for nonstop platform.
