### PR TITLE
Simplify the QUIC time override handling

### DIFF
--- a/fuzz/quic-client.c
+++ b/fuzz/quic-client.c
@@ -78,7 +78,7 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
         goto end;
 
     fake_now = ossl_ms2time(1);
-    if (!ossl_quic_conn_set_override_now_cb(client, fake_now_cb, NULL))
+    if (!ossl_quic_set_override_now_cb(client, fake_now_cb, NULL))
         goto end;
 
     peer_addr = BIO_ADDR_new();

--- a/include/internal/quic_engine.h
+++ b/include/internal/quic_engine.h
@@ -80,7 +80,7 @@ OSSL_TIME ossl_quic_engine_get_time(QUIC_ENGINE *qeng);
  */
 OSSL_TIME ossl_quic_engine_make_real_time(QUIC_ENGINE *qeng, OSSL_TIME tm);
 
-/* Override the callback for getting the current time*/
+/* Override the callback for getting the current time */
 void ossl_quic_engine_set_time_cb(QUIC_ENGINE *qeng,
                                   OSSL_TIME (*now_cb)(void *arg),
                                   void *now_cb_arg);

--- a/include/internal/quic_engine.h
+++ b/include/internal/quic_engine.h
@@ -53,9 +53,6 @@ typedef struct quic_engine_args_st {
      */
     CRYPTO_MUTEX    *mutex;
 
-    OSSL_TIME       (*now_cb)(void *arg);
-    void            *now_cb_arg;
-
     /* Flags to pass when initialising the reactor. */
     uint64_t        reactor_flags;
 } QUIC_ENGINE_ARGS;
@@ -75,6 +72,18 @@ CRYPTO_MUTEX *ossl_quic_engine_get0_mutex(QUIC_ENGINE *qeng);
 
 /* Gets the current time. */
 OSSL_TIME ossl_quic_engine_get_time(QUIC_ENGINE *qeng);
+
+/*
+ * Some use cases really need actual time rather than "fake" time. Convert a
+ * fake time into a real time. If tm is before the current fake time then the
+ * current time is returned.
+ */
+OSSL_TIME ossl_quic_engine_make_real_time(QUIC_ENGINE *qeng, OSSL_TIME tm);
+
+/* Override the callback for getting the current time*/
+void ossl_quic_engine_set_time_cb(QUIC_ENGINE *qeng,
+                                  OSSL_TIME (*now_cb)(void *arg),
+                                  void *now_cb_arg);
 
 /* For testing use. While enabled, ticking is not performed. */
 void ossl_quic_engine_set_inhibit_tick(QUIC_ENGINE *qeng, int inhibit);

--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -124,9 +124,9 @@ __owur int ossl_quic_set_write_buffer_size(SSL *s, size_t size);
  * overridden at any time, expect strange results if you change it after
  * connecting.
  */
-int ossl_quic_conn_set_override_now_cb(SSL *s,
-                                       OSSL_TIME (*now_cb)(void *arg),
-                                       void *now_cb_arg);
+int ossl_quic_set_override_now_cb(SSL *s,
+                                  OSSL_TIME (*now_cb)(void *arg),
+                                  void *now_cb_arg);
 
 /*
  * Condvar waiting in the assist thread doesn't support time faking as it relies

--- a/include/internal/quic_thread_assist.h
+++ b/include/internal/quic_thread_assist.h
@@ -47,8 +47,6 @@ typedef struct quic_thread_assist_st {
     CRYPTO_CONDVAR *cv;
     CRYPTO_THREAD *t;
     int teardown, joined;
-    OSSL_TIME (*now_cb)(void *arg);
-    void *now_cb_arg;
 } QUIC_THREAD_ASSIST;
 
 /*
@@ -58,9 +56,7 @@ typedef struct quic_thread_assist_st {
  * not affect the state of the mutex.
  */
 int ossl_quic_thread_assist_init_start(QUIC_THREAD_ASSIST *qta,
-                                       QUIC_CHANNEL *ch,
-                                       OSSL_TIME (*now_cb)(void *arg),
-                                       void *now_cb_arg);
+                                       QUIC_CHANNEL *ch);
 
 /*
  * Request the thread assist helper to begin stopping the assist thread. This

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -1313,11 +1313,6 @@ int ossl_quic_get_event_timeout(SSL *s, struct timeval *tv, int *is_infinite)
     qctx_lock(&ctx);
 
     reactor = ossl_quic_obj_get0_reactor(ctx.obj);
-    /*
-     * TODO(QUIC SERVER): There's no longer a way to indicate infinite timeout,
-     * should this now be the responsibility of
-     * ossl_quic_reactor_get_tick_deadline()?
-     */
     deadline = ossl_quic_reactor_get_tick_deadline(reactor);
 
     if (ossl_time_is_infinite(deadline)) {

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -45,26 +45,6 @@ static void qctx_maybe_autotick(QCTX *ctx);
 static int qctx_should_autotick(QCTX *ctx);
 
 /*
- * QUIC Front-End I/O API: Common Utilities
- * ========================================
- */
-
-static OSSL_TIME get_time(QUIC_CONNECTION *qc)
-{
-    if (qc->override_now_cb != NULL)
-        return qc->override_now_cb(qc->override_now_cb_arg);
-    else
-        return ossl_time_now();
-}
-
-static OSSL_TIME get_time_cb(void *arg)
-{
-    QUIC_CONNECTION *qc = arg;
-
-    return get_time(qc);
-}
-
-/*
  * QCTX is a utility structure which provides information we commonly wish to
  * unwrap upon an API call being dispatched to us, namely:
  *
@@ -867,19 +847,18 @@ int ossl_quic_clear(SSL *s)
     return 0;
 }
 
-int ossl_quic_conn_set_override_now_cb(SSL *s,
-                                       OSSL_TIME (*now_cb)(void *arg),
-                                       void *now_cb_arg)
+int ossl_quic_set_override_now_cb(SSL *s,
+                                  OSSL_TIME (*now_cb)(void *arg),
+                                  void *now_cb_arg)
 {
     QCTX ctx;
 
-    if (!expect_quic_conn_only(s, &ctx))
+    if (!expect_quic_any(s, &ctx))
         return 0;
 
     qctx_lock(&ctx);
 
-    ctx.qc->override_now_cb     = now_cb;
-    ctx.qc->override_now_cb_arg = now_cb_arg;
+    ossl_quic_engine_set_time_cb(ctx.obj->engine, now_cb, now_cb_arg);
 
     qctx_unlock(&ctx);
     return 1;
@@ -1354,15 +1333,7 @@ int ossl_quic_get_event_timeout(SSL *s, struct timeval *tv, int *is_infinite)
         return 1;
     }
 
-    /*
-     * TODO(QUIC SERVER): The clock override callback belongs at the engine
-     * (DOMAIN) not the QC layer, which would make `basetime` independent of
-     * the object type.
-     */
-    if (ctx.qc)
-        basetime = get_time(ctx.qc);
-    else
-        basetime = ossl_time_now();
+    basetime = ossl_quic_engine_get_time(ctx.obj->engine);
 
     qctx_unlock(&ctx);
 
@@ -1791,8 +1762,7 @@ static int create_channel(QUIC_CONNECTION *qc, SSL_CTX *ctx)
 #if defined(OPENSSL_THREADS)
     engine_args.mutex         = qc->mutex;
 #endif
-    engine_args.now_cb        = get_time_cb;
-    engine_args.now_cb_arg    = qc;
+
     if (need_notifier_for_domain_flags(ctx->domain_flags))
         engine_args.reactor_flags |= QUIC_REACTOR_FLAG_USE_NOTIFIER;
 
@@ -1846,9 +1816,7 @@ static int ensure_channel_started(QCTX *ctx)
 
 #if !defined(OPENSSL_NO_QUIC_THREAD_ASSIST)
         if (qc->is_thread_assisted)
-            if (!ossl_quic_thread_assist_init_start(&qc->thread_assist, qc->ch,
-                                                    qc->override_now_cb,
-                                                    qc->override_now_cb_arg)) {
+            if (!ossl_quic_thread_assist_init_start(&qc->thread_assist, qc->ch)) {
                 QUIC_RAISE_NON_NORMAL_ERROR(ctx, ERR_R_INTERNAL_ERROR,
                                             "failed to start assist thread");
                 return 0;
@@ -4253,6 +4221,7 @@ SSL *ossl_quic_new_listener(SSL_CTX *ctx, uint64_t flags)
 #if defined(OPENSSL_THREADS)
     engine_args.mutex   = ql->mutex;
 #endif
+
     if (need_notifier_for_domain_flags(ctx->domain_flags))
         engine_args.reactor_flags |= QUIC_REACTOR_FLAG_USE_NOTIFIER;
 
@@ -4576,6 +4545,7 @@ SSL *ossl_quic_new_domain(SSL_CTX *ctx, uint64_t flags)
 #if defined(OPENSSL_THREADS)
     engine_args.mutex   = qd->mutex;
 #endif
+
     if (need_notifier_for_domain_flags(domain_flags))
         engine_args.reactor_flags |= QUIC_REACTOR_FLAG_USE_NOTIFIER;
 

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -167,10 +167,6 @@ struct quic_conn_st {
     QUIC_THREAD_ASSIST              thread_assist;
 #  endif
 
-    /* If non-NULL, used instead of ossl_time_now(). Used for testing. */
-    OSSL_TIME                       (*override_now_cb)(void *arg);
-    void                            *override_now_cb_arg;
-
     /* Number of XSOs allocated. Includes the default XSO, if any. */
     size_t                          num_xso;
 

--- a/ssl/quic/quic_tserver.c
+++ b/ssl/quic/quic_tserver.c
@@ -122,11 +122,12 @@ QUIC_TSERVER *ossl_quic_tserver_new(const QUIC_TSERVER_ARGS *args,
     engine_args.libctx          = srv->args.libctx;
     engine_args.propq           = srv->args.propq;
     engine_args.mutex           = srv->mutex;
-    engine_args.now_cb          = srv->args.now_cb;
-    engine_args.now_cb_arg      = srv->args.now_cb_arg;
 
     if ((srv->engine = ossl_quic_engine_new(&engine_args)) == NULL)
         goto err;
+
+    ossl_quic_engine_set_time_cb(srv->engine, srv->args.now_cb,
+                                 srv->args.now_cb_arg);
 
     port_args.channel_ctx       = srv->ctx;
     port_args.is_multi_conn     = 1;

--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -306,7 +306,7 @@ int qtest_create_quic_objects(OSSL_LIB_CTX *libctx, SSL_CTX *clientctx,
         using_fake_time = 1;
         qtest_reset_time();
         tserver_args.now_cb = fake_now_cb;
-        (void)ossl_quic_conn_set_override_now_cb(*cssl, fake_now_cb, NULL);
+        (void)ossl_quic_set_override_now_cb(*cssl, fake_now_cb, NULL);
     } else {
         using_fake_time = 0;
     }

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -792,7 +792,7 @@ static int helper_init(struct helper *h, const char *script_name,
         goto err;
 
     /* Use custom time function for virtual time skip. */
-    if (!TEST_true(ossl_quic_conn_set_override_now_cb(h->c_conn, get_time, h)))
+    if (!TEST_true(ossl_quic_set_override_now_cb(h->c_conn, get_time, h)))
         goto err;
 
     /* Takes ownership of our reference to the BIO. */

--- a/test/quic_tserver_test.c
+++ b/test/quic_tserver_test.c
@@ -166,7 +166,7 @@ static int do_test(int use_thread_assist, int use_fake_time, int use_inject)
         goto err;
 
     if (use_fake_time)
-        if (!TEST_true(ossl_quic_conn_set_override_now_cb(c_ssl, fake_now, NULL)))
+        if (!TEST_true(ossl_quic_set_override_now_cb(c_ssl, fake_now, NULL)))
             goto err;
 
     /* 0 is a success for SSL_set_alpn_protos() */


### PR DESCRIPTION
Centralise the storage of the override in the QUIC_ENGINE rather than in
the QUIC_CONNECTION. We can now set the override on any type of QUIC SSL
object as needed.
