### PR TITLE
Don't restrict what EVP_PKEY_Q_keygen can be used for

### DIFF
--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -1236,17 +1236,10 @@ EVP_PKEY *EVP_PKEY_Q_keygen(OSSL_LIB_CTX *libctx, const char *propq,
         name = va_arg(args, char *);
         params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME,
                                                      name, 0);
-    } else if (OPENSSL_strcasecmp(type, "ED25519") != 0
-               && OPENSSL_strcasecmp(type, "X25519") != 0
-               && OPENSSL_strcasecmp(type, "ED448") != 0
-               && OPENSSL_strcasecmp(type, "X448") != 0
-               && OPENSSL_strcasecmp(type, "SM2") != 0) {
-        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_INVALID_ARGUMENT);
-        goto end;
     }
+
     ret = evp_pkey_keygen(libctx, type, propq, params);
 
- end:
     va_end(args);
     return ret;
 }

--- a/doc/man3/EVP_PKEY_keygen.pod
+++ b/doc/man3/EVP_PKEY_keygen.pod
@@ -102,7 +102,7 @@ If I<type> is C<EC>,
 a string parameter must be given to specify the name of the EC curve.
 If I<type> is C<X25519>, C<X448>, C<ED25519>, C<ED448>, or C<SM2>
 no further parameter is needed. Other key types may be possible if they are
-supplied by the loaded providers. EVP_PKEY_Q_keygen() may be useable with such
+supplied by the loaded providers. EVP_PKEY_Q_keygen() may be usable with such
 key types as long as they do not require further parameters.
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_PKEY_keygen.pod
+++ b/doc/man3/EVP_PKEY_keygen.pod
@@ -101,7 +101,9 @@ a B<size_t> parameter must be given to specify the size of the RSA key.
 If I<type> is C<EC>,
 a string parameter must be given to specify the name of the EC curve.
 If I<type> is C<X25519>, C<X448>, C<ED25519>, C<ED448>, or C<SM2>
-no further parameter is needed.
+no further parameter is needed. Other key types may be possible if they are
+supplied by the loaded providers. EVP_PKEY_Q_keygen() may be useable with such
+key types as long as they do not require further parameters.
 
 =head1 RETURN VALUES
 


### PR DESCRIPTION
The EVP_PKEY_Q_keygen function contains a list of algorithm type names and fails if the requested name is not in the list. This prevents the use of this function for externally supplied key type names.

We should just assume that any unrecognised key type name does not require a parameter.
