### PR TITLE
doc/man3/OSSL_PARAM.pod: Correct the type of data_type

### DIFF
--- a/doc/man3/OSSL_PARAM.pod
+++ b/doc/man3/OSSL_PARAM.pod
@@ -11,7 +11,7 @@ OSSL_PARAM - a structure to pass or request object parameters
  typedef struct ossl_param_st OSSL_PARAM;
  struct ossl_param_st {
      const char *key;             /* the name of the parameter */
-     unsigned char data_type;     /* declare what kind of content is in data */
+     unsigned int data_type;      /* declare what kind of content is in data */
      void *data;                  /* value being passed in or out */
      size_t data_size;            /* data size */
      size_t return_size;          /* returned size */


### PR DESCRIPTION
This updates the definition of the `ossl_param_st` struct given in the `OSSL_PARAM` man3 page to match the [definition of the struct in `core.h`](https://github.com/openssl/openssl/blob/a57c6f84920bff522bca5fede73f1a3f132d7cff/include/openssl/core.h#L87).

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated