### PR TITLE
Allow the jitter entropy source to be used by the FIPS provider as an internal source

### DIFF
--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -207,7 +207,7 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
-      run: ./config --with-rand-seed=none enable-jitter --with-jitter-include=jitter/ --with-jitter-lib=jitter/ -DOPENSSL_DEFAULT_SEED_SRC=JITTER && perl configdata.pm --dump
+      run: ./config --with-rand-seed=none enable-jitter enable-fips-jitter --with-jitter-include=jitter/ --with-jitter-lib=jitter/ -DOPENSSL_DEFAULT_SEED_SRC=JITTER && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: get cpu info

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -8,9 +8,9 @@
 name: Run-checker daily
 # Jobs run daily
 
-on:
-  schedule:
-    - cron: '0 6 * * *'
+on: [pull_request, push]
+#  schedule:
+#    - cron: '0 6 * * *'
 permissions:
   contents: read
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,13 @@ OpenSSL 3.4
 
 ### Changes between 3.4 and 3.5 [xx XXX xxxx]
 
- * none yet
+ * Optionally allow the FIPS provider to use the `JITTER` entropy source.
+   Note that using this option will require the resulting FIPS provider
+   to undergo entropy source validation [ESV] by the [CMVP], without this
+   the FIPS provider will not be FIPS compliant.  Enable this using the
+   configuration option `enable-fips-jitter`.
+
+   *Paul Dale*
 
 OpenSSL 3.4
 -----------
@@ -21062,3 +21068,5 @@ ndif
 [CVE-2002-0657]: https://www.openssl.org/news/vulnerabilities.html#CVE-2002-0657
 [CVE-2002-0656]: https://www.openssl.org/news/vulnerabilities.html#CVE-2002-0656
 [CVE-2002-0655]: https://www.openssl.org/news/vulnerabilities.html#CVE-2002-0655
+[CMVP]: https://csrc.nist.gov/projects/cryptographic-module-validation-program
+[ESV]: https://csrc.nist.gov/Projects/cryptographic-module-validation-program/entropy-validations

--- a/Configure
+++ b/Configure
@@ -472,6 +472,7 @@ my @disablables = (
     "fips",
     "fips-securitychecks",
     "fips-post",
+    "fips-jitter",
     "fuzz-afl",
     "fuzz-libfuzzer",
     "gost",
@@ -573,6 +574,7 @@ my %deprecated_disablables = (
 
 our %disabled = ( # "what"         => "comment"
                   "fips"                => "default",
+                  "fips-jitter"         => "default",
                   "asan"                => "default",
                   "brotli"              => "default",
                   "brotli-dynamic"      => "default",
@@ -689,7 +691,8 @@ my @disable_cascades = (
 
     "cmp"               => [ "crmf" ],
 
-    "fips"              => [ "fips-securitychecks", "fips-post", "acvp-tests" ],
+    "fips"              => [ "fips-securitychecks", "fips-post", "acvp-tests",
+                             "fips-jitter" ],
 
     "threads"           => [ "thread-pool" ],
     "thread-pool"       => [ "default-thread-pool" ],
@@ -956,6 +959,11 @@ while (@argvcopy)
                 elsif ($1 eq "zstd-dynamic")
                         {
                         delete $disabled{"zstd"};
+                        }
+                elsif ($1 eq "fips-jitter")
+                        {
+                        delete $disabled{"fips"};
+                        delete $disabled{"jitter"};
                         }
                 my $algo = $1;
                 delete $disabled{$algo};

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -536,7 +536,7 @@ shown below:
     [random]
     seed=JITTER
 
-It uses a statically linked [jitterentropy-library](https://github.com/smuellerDD/jitterentropy-library) as the seed source.
+It uses a statically linked [jitterentropy-library] as the seed source.
 
 Additional configuration flags available:
 
@@ -840,6 +840,19 @@ Don't perform FIPS module Power On Self Tests.
 
 This option MUST be used for debugging only as it makes the FIPS provider
 non-compliant. It is useful when setting breakpoints in FIPS algorithms.
+
+### enable-fips-jitter
+
+Use the CPU Jitter library as a FIPS validated entropy source.
+
+This option will only produce a compliant FIPS provider if you have:
+
+1. independently performed the required [SP 800-90B] entropy assessments;
+2. meet the minimum required entropy as specified by [jitterentropy-library];
+3. obtain an [ESV] certificate for the [jitterentropy-library] and
+4. have had the resulting FIPS provider certified by the [CMVP].
+
+Failure to do all of these will produce a non-compliant FIPS provider.
 
 ### enable-fuzz-libfuzzer, enable-fuzz-afl
 
@@ -2006,3 +2019,15 @@ is used, as it is the version of the GNU assembler that will be checked.
 
 [10-main.conf]:
     Configurations/10-main.conf
+
+[CMVP]:
+    <https://csrc.nist.gov/projects/cryptographic-module-validation-program>
+
+[ESV]:
+    <https://csrc.nist.gov/Projects/cryptographic-module-validation-program/entropy-validations>
+
+[SP 800-90B]:
+    <https://csrc.nist.gov/pubs/sp/800/90/b/final>
+
+[jitterentropy-library]:
+    <https://github.com/smuellerDD/jitterentropy-library>

--- a/NEWS.md
+++ b/NEWS.md
@@ -37,7 +37,13 @@ changes:
 
 This release adds the following new features:
 
-  * none yet
+  * Allow the FIPS provider to optionally use the `JITTER` seed source.
+    Because this seed source is not part of the OpenSSL FIPS validations,
+    it should only be enabled after the [jitterentropy-library] has been
+    assessed for entropy quality.  Moreover, the FIPS provider including
+    this entropy source will need to obtain an [ESV] from the [CMVP] before
+    FIPS compliance can be claimed.  Enable this using the configuration
+    option `enable-fips-jitter`.
 
 OpenSSL 3.4
 -----------
@@ -2007,3 +2013,6 @@ OpenSSL 0.9.x
 [CHANGES.md]: ./CHANGES.md
 [README-QUIC.md]: ./README-QUIC.md
 [issue tracker]: https://github.com/openssl/openssl/issues
+[CMVP]: https://csrc.nist.gov/projects/cryptographic-module-validation-program
+[ESV]: https://csrc.nist.gov/Projects/cryptographic-module-validation-program/entropy-validations
+[jitterentropy-library]: https://github.com/smuellerDD/jitterentropy-library

--- a/README-FIPS.md
+++ b/README-FIPS.md
@@ -167,6 +167,22 @@ manual page.
 
  [fips_module(7)]: https://www.openssl.org/docs/manmaster/man7/fips_module.html
 
+Entropy Source
+==============
+
+The FIPS provider typically relies on an external entropy source,
+specified during OpenSSL build configuration (default: `os`).  However, by
+enabling the `enable-fips-jitter` option during configuration, an internal
+jitter entropy source will be used instead.  Note that this will cause
+the FIPS provider to operate in a non-compliant mode unless an entropy
+assessment [ESV] and validation through the [CMVP] are additionally conducted.
+
+Note that the `enable-fips-jitter` option is only available in OpenSSL
+versions 3.5 and later.
+
+ [CMVP]: https://csrc.nist.gov/projects/cryptographic-module-validation-program
+ [ESV]: https://csrc.nist.gov/Projects/cryptographic-module-validation-program/entropy-validations
+
 3rd-Party Vendor Builds
 =====================================
 

--- a/crypto/rand/build.info
+++ b/crypto/rand/build.info
@@ -1,14 +1,19 @@
 LIBS=../../libcrypto
 
 $COMMON=rand_lib.c
-$CRYPTO=randfile.c rand_err.c rand_deprecated.c prov_seed.c rand_pool.c \
-        rand_uniform.c
+$CRYPTO=randfile.c rand_err.c rand_deprecated.c prov_seed.c rand_uniform.c
 
 IF[{- !$disabled{'egd'} -}]
   $CRYPTO=$CRYPTO rand_egd.c
 ENDIF
 IF[{- !$disabled{'deprecated-3.0'} -}]
   $CRYPTO=$CRYPTO rand_meth.c
+ENDIF
+
+IF[{- !$disabled{'fips-jitter'} -}]
+  $COMMON=$COMMON rand_pool.c
+ELSE
+  $CRYPTO=$CRYPTO rand_pool.c
 ENDIF
 
 SOURCE[../../libcrypto]=$COMMON $CRYPTO

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -534,14 +534,16 @@ static void rand_delete_thread_state(void *arg)
     EVP_RAND_CTX_free(rand);
 }
 
-#ifndef FIPS_MODULE
+#if !defined(FIPS_MODULE) || !defined(OPENSSL_NO_FIPS_JITTER)
 static EVP_RAND_CTX *rand_new_seed(OSSL_LIB_CTX *libctx)
 {
     EVP_RAND *rand;
-    RAND_GLOBAL *dgbl = rand_get_global(libctx);
-    EVP_RAND_CTX *ctx = NULL;
     const char *propq;
-    char *name, *props = NULL;
+    char *name;
+    EVP_RAND_CTX *ctx = NULL;
+# ifdef OPENSSL_NO_FIPS_JITTER
+    RAND_GLOBAL *dgbl = rand_get_global(libctx);
+    char *props = NULL;
     size_t props_len;
     OSSL_PROPERTY_LIST *pl1, *pl2, *pl3 = NULL;
 
@@ -599,6 +601,10 @@ static EVP_RAND_CTX *rand_new_seed(OSSL_LIB_CTX *libctx)
         }
         name = OPENSSL_MSTR(OPENSSL_DEFAULT_SEED_SRC);
     }
+# else /* !OPENSSL_NO_FIPS_JITTER */
+    name = "JITTER";
+    propq = "-fips";  /* precautionary: shouldn't matter since it's internal */
+# endif /* OPENSSL_NO_FIPS_JITTER */
 
     rand = EVP_RAND_fetch(libctx, name, propq);
     if (rand == NULL) {
@@ -615,15 +621,21 @@ static EVP_RAND_CTX *rand_new_seed(OSSL_LIB_CTX *libctx)
         ERR_raise(ERR_LIB_RAND, RAND_R_ERROR_INSTANTIATING_DRBG);
         goto err;
     }
+# ifdef OPENSSL_NO_FIPS_JITTER
     OPENSSL_free(props);
+# endif /* OPENSSL_NO_FIPS_JITTER */
     return ctx;
  err:
     EVP_RAND_CTX_free(ctx);
+# ifdef OPENSSL_NO_FIPS_JITTER
     ossl_property_free(pl3);
     OPENSSL_free(props);
+# endif /* OPENSSL_NO_FIPS_JITTER */
     return NULL;
 }
+#endif  /* !FIPS_MODULE || !OPENSSL_NO_FIPS_JITTER */
 
+#ifndef FIPS_MODULE
 EVP_RAND_CTX *ossl_rand_get0_seed_noncreating(OSSL_LIB_CTX *ctx)
 {
     RAND_GLOBAL *dgbl = rand_get_global(ctx);
@@ -638,7 +650,7 @@ EVP_RAND_CTX *ossl_rand_get0_seed_noncreating(OSSL_LIB_CTX *ctx)
     CRYPTO_THREAD_unlock(dgbl->lock);
     return ret;
 }
-#endif
+#endif  /* !FIPS_MODULE */
 
 static EVP_RAND_CTX *rand_new_drbg(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent,
                                    unsigned int reseed_interval,
@@ -697,13 +709,13 @@ static EVP_RAND_CTX *rand_new_drbg(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent,
     return ctx;
 }
 
-#ifdef FIPS_MODULE
+#if defined(FIPS_MODULE)
 static EVP_RAND_CTX *rand_new_crngt(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent)
 {
     EVP_RAND *rand;
     EVP_RAND_CTX *ctx;
 
-    rand = EVP_RAND_fetch(libctx, "CRNG-TEST", "fips=no");
+    rand = EVP_RAND_fetch(libctx, "CRNG-TEST", "-fips");
     if (rand == NULL) {
         ERR_raise(ERR_LIB_RAND, RAND_R_UNABLE_TO_FETCH_DRBG);
         return NULL;
@@ -722,7 +734,7 @@ static EVP_RAND_CTX *rand_new_crngt(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent)
     }
     return ctx;
 }
-#endif
+#endif  /* FIPS_MODULE */
 
 /*
  * Get the primary random generator.
@@ -755,17 +767,22 @@ EVP_RAND_CTX *RAND_get0_primary(OSSL_LIB_CTX *ctx)
         return ret;
     }
 
-#ifdef FIPS_MODULE
-    ret = rand_new_crngt(ctx, dgbl->seed);
-#else
+#if !defined(FIPS_MODULE) || !defined(OPENSSL_NO_FIPS_JITTER)
+    /* Create a seed source for libcrypto or jitter enabled FIPS provider */
     if (dgbl->seed == NULL) {
         ERR_set_mark();
         dgbl->seed = rand_new_seed(ctx);
         ERR_pop_to_mark();
     }
+#endif  /* !FIPS_MODULE || !OPENSSL_NO_FIPS_JITTER */
+
+#if defined(FIPS_MODULE)
+    /* The FIPS provider has entropy health tests instead of the primary */
+    ret = rand_new_crngt(ctx, dgbl->seed);
+#else   /* FIPS_MODULE */
     ret = rand_new_drbg(ctx, dgbl->seed, PRIMARY_RESEED_INTERVAL,
                         PRIMARY_RESEED_TIME_INTERVAL);
-#endif
+#endif  /* FIPS_MODULE */
 
     /*
      * The primary DRBG may be shared between multiple threads so we must

--- a/doc/man7/EVP_RAND-JITTER.pod
+++ b/doc/man7/EVP_RAND-JITTER.pod
@@ -46,6 +46,15 @@ A context for the seed source can be obtained by calling:
 
 The B<enable-jitter> option was added in OpenSSL 3.4.
 
+By specifying the B<enable-fips-jitter> configuration option, the FIPS
+provider will use an internal jitter source for its entropy.  Enabling
+this option will cause the FIPS provider to operate in a non-compliant
+mode unless an entropy assessment
+L<ESV|https://csrc.nist.gov/Projects/cryptographic-module-validation-program/entropy-validations>
+and validation through the
+L<CMVP|https://csrc.nist.gov/projects/cryptographic-module-validation-program>
+are additionally conducted.  This option was added in OpenSSL 3.5.
+
 =head1 EXAMPLES
 
  EVP_RAND *rand;

--- a/doc/man7/EVP_RAND-JITTER.pod
+++ b/doc/man7/EVP_RAND-JITTER.pod
@@ -44,6 +44,8 @@ A context for the seed source can be obtained by calling:
  EVP_RAND *rand = EVP_RAND_fetch(NULL, "JITTER", NULL);
  EVP_RAND_CTX *rctx = EVP_RAND_CTX_new(rand, NULL);
 
+The B<enable-jitter> option was added in OpenSSL 3.4.
+
 =head1 EXAMPLES
 
  EVP_RAND *rand;

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -390,6 +390,9 @@ static const OSSL_ALGORITHM fips_rands[] = {
     { PROV_NAMES_CTR_DRBG, FIPS_DEFAULT_PROPERTIES, ossl_drbg_ctr_functions },
     { PROV_NAMES_HASH_DRBG, FIPS_DEFAULT_PROPERTIES, ossl_drbg_hash_functions },
     { PROV_NAMES_HMAC_DRBG, FIPS_DEFAULT_PROPERTIES, ossl_drbg_ossl_hmac_functions },
+#ifndef OPENSSL_NO_FIPS_JITTER
+    { PROV_NAMES_JITTER, FIPS_DEFAULT_PROPERTIES, ossl_jitter_functions },
+#endif
     { PROV_NAMES_TEST_RAND, FIPS_UNAPPROVED_PROPERTIES, ossl_test_rng_functions },
     { NULL, NULL, NULL }
 };

--- a/providers/implementations/rands/build.info
+++ b/providers/implementations/rands/build.info
@@ -5,3 +5,7 @@ $RANDS_GOAL=../../libdefault.a ../../libfips.a
 SOURCE[$RANDS_GOAL]=drbg.c test_rng.c drbg_ctr.c drbg_hash.c drbg_hmac.c
 SOURCE[../../libdefault.a]=seed_src.c seed_src_jitter.c
 SOURCE[../../libfips.a]=fips_crng_test.c
+
+IF[{- !$disabled{'fips-jitter'} -}]
+  SOURCE[../../libfips.a]=seed_src_jitter.c
+ENDIF

--- a/providers/implementations/rands/seed_src_jitter.c
+++ b/providers/implementations/rands/seed_src_jitter.c
@@ -104,7 +104,7 @@ static size_t get_jitter_random_value(PROV_JITTER *s,
             break;
 
         /* Success */
-        if (result == len)
+        if (result >= 0 && (size_t)result == len)
             return len;
     }
 


### PR DESCRIPTION
Doing so makes the FIPS provider non-compliant unless an entropy assessment and revalidation are also undertaken.

- [x] documentation is added or updated
- [x] tests are added or updated
