### PR TITLE
cmp_vfy_test.c: Avoid NULL pointer dereference

### DIFF
--- a/test/cmp_vfy_test.c
+++ b/test/cmp_vfy_test.c
@@ -336,8 +336,9 @@ static int test_validate_msg_signature_sender_cert_extracert(void)
             || !add_trusted(fixture->cmp_ctx, instaca_cert)) {
         tear_down(fixture);
         fixture = NULL;
+    } else {
+        fixture->cert = sk_X509_value(fixture->msg->extraCerts, 1); /* Insta CA */
     }
-    fixture->cert = sk_X509_value(fixture->msg->extraCerts, 1); /* Insta CA */
     EXECUTE_TEST(execute_validate_msg_test, tear_down);
     return result;
 }


### PR DESCRIPTION
Fixes Coverity 1619463
