### PR TITLE
ctr-drbg: always use the DF for OpenSSL's DRBGs

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -642,7 +642,7 @@ EVP_RAND_CTX *ossl_rand_get0_seed_noncreating(OSSL_LIB_CTX *ctx)
 
 static EVP_RAND_CTX *rand_new_drbg(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent,
                                    unsigned int reseed_interval,
-                                   time_t reseed_time_interval, int use_df)
+                                   time_t reseed_time_interval)
 {
     EVP_RAND *rand;
     RAND_GLOBAL *dgbl = rand_get_global(libctx);
@@ -650,6 +650,7 @@ static EVP_RAND_CTX *rand_new_drbg(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent,
     OSSL_PARAM params[8], *p = params;
     const OSSL_PARAM *settables;
     char *name, *cipher;
+    int use_df = 1;
 
     if (dgbl == NULL)
         return NULL;
@@ -737,7 +738,7 @@ EVP_RAND_CTX *RAND_get0_primary(OSSL_LIB_CTX *ctx)
 
     ret = dgbl->primary = rand_new_drbg(ctx, dgbl->seed,
                                         PRIMARY_RESEED_INTERVAL,
-                                        PRIMARY_RESEED_TIME_INTERVAL, 1);
+                                        PRIMARY_RESEED_TIME_INTERVAL);
     /*
     * The primary DRBG may be shared between multiple threads so we must
     * enable locking.
@@ -779,7 +780,7 @@ EVP_RAND_CTX *RAND_get0_public(OSSL_LIB_CTX *ctx)
                 && !ossl_init_thread_start(NULL, ctx, rand_delete_thread_state))
             return NULL;
         rand = rand_new_drbg(ctx, primary, SECONDARY_RESEED_INTERVAL,
-                             SECONDARY_RESEED_TIME_INTERVAL, 0);
+                             SECONDARY_RESEED_TIME_INTERVAL);
         CRYPTO_THREAD_set_local(&dgbl->public, rand);
     }
     return rand;
@@ -812,7 +813,7 @@ EVP_RAND_CTX *RAND_get0_private(OSSL_LIB_CTX *ctx)
                 && !ossl_init_thread_start(NULL, ctx, rand_delete_thread_state))
             return NULL;
         rand = rand_new_drbg(ctx, primary, SECONDARY_RESEED_INTERVAL,
-                             SECONDARY_RESEED_TIME_INTERVAL, 0);
+                             SECONDARY_RESEED_TIME_INTERVAL);
         CRYPTO_THREAD_set_local(&dgbl->private, rand);
     }
     return rand;


### PR DESCRIPTION
Force the use of the derivation function when creating OpenSSL's internal DRBGs.

FIPS mandates the use of a derivation function, so 3.4 cannot be validated as it stands which run counter to the indicator work that was included.

Not intended for back porting to earlier stable releases.  The issue was [introduced in 3.2](https://github.com/openssl/openssl/pull/16156).  3.2 and 3.3 are unlikely to be FIPS validated with 3.4 so close.