### PR TITLE
fips: prohibit SHA1 in DH & ECDH exchange

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -83,7 +83,7 @@ OpenSSL 3.4
 
    [fips_module(7)]: https://docs.openssl.org/master/man7/fips_module/#FIPS indicators
 
-   *Shane Lontis, Paul Dale and Po-Hsing Wu*
+   *Shane Lontis, Paul Dale, Po-Hsing Wu and Dimitri John Ledkov*
 
  * Added support for hardware acceleration for HMAC on S390x architecture.
 

--- a/providers/common/securitycheck_fips.c
+++ b/providers/common/securitycheck_fips.c
@@ -78,9 +78,9 @@ int ossl_fips_ind_ec_key_check(OSSL_FIPS_IND *ind, int id,
 }
 #endif
 
-int ossl_fips_ind_digest_check(OSSL_FIPS_IND *ind, int id,
-                               OSSL_LIB_CTX *libctx,
-                               const EVP_MD *md, const char *desc)
+int ossl_fips_ind_digest_exch_check(OSSL_FIPS_IND *ind, int id,
+                                    OSSL_LIB_CTX *libctx,
+                                    const EVP_MD *md, const char *desc)
 {
     int nid = ossl_digest_get_approved_nid(md);
     int approved = (nid != NID_undef && nid != NID_sha1);

--- a/providers/common/securitycheck_fips.c
+++ b/providers/common/securitycheck_fips.c
@@ -82,7 +82,8 @@ int ossl_fips_ind_digest_check(OSSL_FIPS_IND *ind, int id,
                                OSSL_LIB_CTX *libctx,
                                const EVP_MD *md, const char *desc)
 {
-    int approved = (ossl_digest_get_approved_nid(md) != NID_undef);
+    int nid = ossl_digest_get_approved_nid(md);
+    int approved = (nid != NID_undef && nid != NID_sha1);
 
     if (!approved) {
         if (!ossl_FIPS_IND_on_unapproved(ind, id, libctx, desc, "Digest",

--- a/providers/fips/include/fips/fipsindicator.h
+++ b/providers/fips/include/fips/fipsindicator.h
@@ -129,8 +129,8 @@ int ossl_fips_ind_ec_key_check(OSSL_FIPS_IND *ind, int id, OSSL_LIB_CTX *libctx,
                                const EC_GROUP *group, const char *desc,
                                int protect);
 # endif
-int ossl_fips_ind_digest_check(OSSL_FIPS_IND *ind, int id, OSSL_LIB_CTX *libctx,
-                               const EVP_MD *md, const char *desc);
+int ossl_fips_ind_digest_exch_check(OSSL_FIPS_IND *ind, int id, OSSL_LIB_CTX *libctx,
+                                    const EVP_MD *md, const char *desc);
 int ossl_fips_ind_digest_sign_check(OSSL_FIPS_IND *ind, int id,
                                     OSSL_LIB_CTX *libctx,
                                     int nid, int sha1_allowed,

--- a/providers/implementations/exchange/dh_exch.c
+++ b/providers/implementations/exchange/dh_exch.c
@@ -113,9 +113,9 @@ static int dh_check_key(PROV_DH_CTX *ctx)
 
 static int digest_check(PROV_DH_CTX *ctx, const EVP_MD *md)
 {
-    return ossl_fips_ind_digest_check(OSSL_FIPS_IND_GET(ctx),
-                                      OSSL_FIPS_IND_SETTABLE1, ctx->libctx,
-                                      md, "DH Set Ctx");
+    return ossl_fips_ind_digest_exch_check(OSSL_FIPS_IND_GET(ctx),
+                                           OSSL_FIPS_IND_SETTABLE1, ctx->libctx,
+                                           md, "DH Set Ctx");
 }
 #endif
 

--- a/providers/implementations/exchange/ecdh_exch.c
+++ b/providers/implementations/exchange/ecdh_exch.c
@@ -320,9 +320,9 @@ int ecdh_set_ctx_params(void *vpecdhctx, const OSSL_PARAM params[])
             return 0;
         }
 #ifdef FIPS_MODULE
-        if (!ossl_fips_ind_digest_check(OSSL_FIPS_IND_GET(pectx),
-                                        OSSL_FIPS_IND_SETTABLE1, pectx->libctx,
-                                        pectx->kdf_md, "ECDH Set Ctx")) {
+        if (!ossl_fips_ind_digest_exch_check(OSSL_FIPS_IND_GET(pectx),
+                                             OSSL_FIPS_IND_SETTABLE1, pectx->libctx,
+                                             pectx->kdf_md, "ECDH Set Ctx")) {
             EVP_MD_free(pectx->kdf_md);
             pectx->kdf_md = NULL;
             return 0;

--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -647,17 +647,23 @@ my @smime_cms_param_tests = (
       [ "{cmd2}", @defaultprov, "-decrypt", "-recip", catfile($smdir, "smec2.pem"),
         "-in", "{output}.cms", "-out", "{output}.txt" ],
       \&final_compare
-    ],
-
-    [ "enveloped content test streaming S/MIME format, X9.42 DH",
-      [ "{cmd1}", @prov, "-encrypt", "-in", $smcont,
-        "-stream", "-out", "{output}.cms",
-        "-recip", catfile($smdir, "smdh.pem"), "-aes128" ],
-      [ "{cmd2}", @prov, "-decrypt", "-recip", catfile($smdir, "smdh.pem"),
-        "-in", "{output}.cms", "-out", "{output}.txt" ],
-      \&final_compare
     ]
 );
+
+if ($no_fips || $old_fips) {
+    # Only SHA1 supported in dh_cms_encrypt()
+    push(@smime_cms_param_tests,
+
+	 [ "enveloped content test streaming S/MIME format, X9.42 DH",
+	   [ "{cmd1}", @prov, "-encrypt", "-in", $smcont,
+	     "-stream", "-out", "{output}.cms",
+	     "-recip", catfile($smdir, "smdh.pem"), "-aes128" ],
+	   [ "{cmd2}", @prov, "-decrypt", "-recip", catfile($smdir, "smdh.pem"),
+	     "-in", "{output}.cms", "-out", "{output}.txt" ],
+	   \&final_compare
+	 ]
+    );
+}
 
 my @smime_cms_param_tests_autodigestmax = (
     [ "signed content test streaming PEM format, RSA keys, PSS signature, saltlen=auto-digestmax, digestsize < maximum salt length",


### PR DESCRIPTION
See Section 5 Key Agreement Using Diffie-Hellman and MQV of [NIST SP 800-131Ar2](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf).

Strengths less than 112bits is disallowed, thus eliminating SHA1.

Skip cms test case that requires use of SHA1 with X9.42 DH.

Note ACVP testing of DH/ECDH with SHA-1 is not possible at all.