### PR TITLE
Rename list macros

### DIFF
--- a/include/internal/list.h
+++ b/include/internal/list.h
@@ -24,7 +24,7 @@
     for ((p) = (init);                                                      \
          (p) != NULL;                                                       \
          (p) = ossl_list_##name##_next(p))
-# define OSSL_LIST_FOREACH(p, name, l)                                       \
+# define OSSL_LIST_FOREACH(p, name, l)                                      \
     OSSL_LIST_FOREACH_FROM(p, name, ossl_list_##name##_head(l))
 
 # define OSSL_LIST_FOREACH_REV_FROM(p, name, init)                          \

--- a/include/internal/list.h
+++ b/include/internal/list.h
@@ -20,33 +20,33 @@
 #  define OSSL_LIST_DBG(x) x;
 # endif
 
-# define LIST_FOREACH_FROM(p, name, init)                                   \
+# define OSSL_LIST_FOREACH_FROM(p, name, init)                              \
     for ((p) = (init);                                                      \
          (p) != NULL;                                                       \
          (p) = ossl_list_##name##_next(p))
-# define LIST_FOREACH(p, name, l)                                           \
-    LIST_FOREACH_FROM(p, name, ossl_list_##name##_head(l))
+# define OSSL_LIST_FOREACH(p, name, l)                                       \
+    OSSL_LIST_FOREACH_FROM(p, name, ossl_list_##name##_head(l))
 
-# define LIST_FOREACH_REV_FROM(p, name, init)                               \
+# define OSSL_LIST_FOREACH_REV_FROM(p, name, init)                          \
     for ((p) = (init);                                                      \
          (p) != NULL;                                                       \
          (p) = ossl_list_##name##_prev(p))
-# define LIST_FOREACH_REV(p, name, l)                                       \
-    LIST_FOREACH_FROM(p, name, ossl_list_##name##_tail(l))
+# define OSSL_LIST_FOREACH_REV(p, name, l)                                  \
+    OSSL_LIST_FOREACH_FROM(p, name, ossl_list_##name##_tail(l))
 
-# define LIST_FOREACH_DELSAFE_FROM(p, pn, name, init)                       \
+# define OSSL_LIST_FOREACH_DELSAFE_FROM(p, pn, name, init)                  \
     for ((p) = (init);                                                      \
          (p) != NULL && (((pn) = ossl_list_##name##_next(p)), 1);           \
          (p) = (pn))
-#define LIST_FOREACH_DELSAFE(p, pn, name, l)                                \
-    LIST_FOREACH_DELSAFE_FROM(p, pn, name, ossl_list_##name##_head(l))
+#define OSSL_LIST_FOREACH_DELSAFE(p, pn, name, l)                           \
+    OSSL_LIST_FOREACH_DELSAFE_FROM(p, pn, name, ossl_list_##name##_head(l))
 
-# define LIST_FOREACH_REV_DELSAFE_FROM(p, pn, name, init)                   \
+# define OSSL_LIST_FOREACH_REV_DELSAFE_FROM(p, pn, name, init)              \
     for ((p) = (init);                                                      \
          (p) != NULL && (((pn) = ossl_list_##name##_prev(p)), 1);           \
          (p) = (pn))
-# define LIST_FOREACH_REV_DELSAFE(p, pn, name, l)                           \
-    LIST_FOREACH_REV_DELSAFE_FROM(p, pn, name, ossl_list_##name##_tail(l))
+# define OSSL_LIST_FOREACH_REV_DELSAFE(p, pn, name, l)                      \
+    OSSL_LIST_FOREACH_REV_DELSAFE_FROM(p, pn, name, ossl_list_##name##_tail(l))
 
 /* Define a list structure */
 # define OSSL_LIST(name) OSSL_LIST_ ## name

--- a/ssl/quic/quic_engine.c
+++ b/ssl/quic/quic_engine.c
@@ -131,7 +131,7 @@ static void qeng_tick(QUIC_TICK_RESULT *res, void *arg, uint32_t flags)
         return;
 
     /* Iterate through all ports and service them. */
-    LIST_FOREACH(port, port, &qeng->port_list) {
+    OSSL_LIST_FOREACH(port, port, &qeng->port_list) {
         QUIC_TICK_RESULT subr = {0};
 
         ossl_quic_port_subtick(port, &subr, flags);

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -273,7 +273,7 @@ int ossl_quic_port_set_net_wbio(QUIC_PORT *port, BIO *net_wbio)
     if (!port_update_poll_desc(port, net_wbio, /*for_write=*/1))
         return 0;
 
-    LIST_FOREACH(ch, ch, &port->channel_list)
+    OSSL_LIST_FOREACH(ch, ch, &port->channel_list)
         ossl_qtx_set_bio(ch->qtx, net_wbio);
 
     port->net_wbio = net_wbio;
@@ -373,7 +373,7 @@ void ossl_quic_port_subtick(QUIC_PORT *port, QUIC_TICK_RESULT *res,
             port_rx_pre(port);
 
         /* Iterate through all channels and service them. */
-        LIST_FOREACH(ch, ch, &port->channel_list) {
+        OSSL_LIST_FOREACH(ch, ch, &port->channel_list) {
             QUIC_TICK_RESULT subr = {0};
 
             ossl_quic_channel_subtick(ch, &subr, flags);
@@ -603,7 +603,7 @@ void ossl_quic_port_raise_net_error(QUIC_PORT *port,
     if (triggering_ch != NULL)
         ossl_quic_channel_raise_net_error(triggering_ch);
 
-    LIST_FOREACH(ch, ch, &port->channel_list)
+    OSSL_LIST_FOREACH(ch, ch, &port->channel_list)
         if (ch != triggering_ch)
             ossl_quic_channel_raise_net_error(ch);
 }

--- a/ssl/quic/quic_rcidm.c
+++ b/ssl/quic/quic_rcidm.c
@@ -310,7 +310,7 @@ void ossl_quic_rcidm_free(QUIC_RCIDM *rcidm)
     while ((rcid = ossl_pqueue_RCID_pop(rcidm->rcids)) != NULL)
         OPENSSL_free(rcid);
 
-    LIST_FOREACH_DELSAFE(rcid, rnext, retiring, &rcidm->retiring_list)
+    OSSL_LIST_FOREACH_DELSAFE(rcid, rnext, retiring, &rcidm->retiring_list)
         OPENSSL_free(rcid);
 
     ossl_pqueue_RCID_free(rcidm->rcids);


### PR DESCRIPTION
The quic implementation defined a set of LIST_* macros for list manipulation, which conflicts with the generally support BSD api found in the queue.h system header.  While this isn't normally a problem, A report arrived indicating that MacOSX appears to implicitly include queue.h from another system header which causes definition conflicts.

As the openssl macros are internal only, it seems the most sensible thing to do is place them in a well known namespace for our library to avoid the conflict, so add an OSSL_ prefix to all our macros

Fixes #25516

