### PR TITLE
Fix unwraplen assignment in EVP_PKEY_decapsulate

### DIFF
--- a/doc/man3/EVP_PKEY_decapsulate.pod
+++ b/doc/man3/EVP_PKEY_decapsulate.pod
@@ -34,7 +34,10 @@ I<wrapped> and I<wrappedlen> parameters.
 If I<unwrapped> is NULL then the maximum size of the output secret buffer
 is written to I<*unwrappedlen>. If I<unwrapped> is not NULL and the
 call is successful then the decapsulated secret data is written to I<unwrapped>
-and the amount of data written to I<*unwrappedlen>.
+and the amount of data written to I<*unwrappedlen>.  Note that, if I<unwrappedlen>
+is not NULL in this call, the value it points to must be set to the length of
+I<unwrapped>, so that the call can validate it is of sufficient size to hold the
+result of the operation.
 
 =head1 NOTES
 

--- a/doc/man3/EVP_PKEY_decapsulate.pod
+++ b/doc/man3/EVP_PKEY_decapsulate.pod
@@ -31,7 +31,7 @@ key that is used during decapsulation.
 The EVP_PKEY_decapsulate() function performs a private key decapsulation
 operation using I<ctx>. The data to be decapsulated is specified using the
 I<wrapped> and I<wrappedlen> parameters.
-If I<unwrapped> is NULL then the maximum size of the output secret buffer
+If I<unwrapped> is NULL then the size of the output secret buffer
 is written to I<*unwrappedlen>. If I<unwrapped> is not NULL and the
 call is successful then the decapsulated secret data is written to I<unwrapped>
 and the amount of data written to I<*unwrappedlen>.  Note that, if I<unwrappedlen>

--- a/doc/man3/EVP_PKEY_decapsulate.pod
+++ b/doc/man3/EVP_PKEY_decapsulate.pod
@@ -35,7 +35,7 @@ If I<unwrapped> is NULL then the size of the output secret buffer
 is written to I<*unwrappedlen>. If I<unwrapped> is not NULL and the
 call is successful then the decapsulated secret data is written to I<unwrapped>
 and the amount of data written to I<*unwrappedlen>.  Note that, if I<unwrappedlen>
-is not NULL in this call, the value it points to must be set to the length of
+is not NULL in this call, the value it points to must be initialised to the length of
 I<unwrapped>, so that the call can validate it is of sufficient size to hold the
 result of the operation.
 

--- a/doc/man3/EVP_PKEY_encapsulate.pod
+++ b/doc/man3/EVP_PKEY_encapsulate.pod
@@ -43,7 +43,7 @@ internally generated key is written to I<genkey> and its size is written to
 I<*genkeylen>. The encapsulated version of the generated key is written to
 I<wrappedkey> and its size is written to I<*wrappedkeylen>.  Note that if
 I<unwrappedlen> is not NULL, then the value it points to must hold the size of
-the  I<unrwapped> buffer so that its size can be validated by the call, ensuring
+the  I<unwrapped> buffer so that its size can be validated by the call, ensuring
 it is large enough to hold the result written to I<wrapped>.
 
 =head1 NOTES

--- a/doc/man3/EVP_PKEY_encapsulate.pod
+++ b/doc/man3/EVP_PKEY_encapsulate.pod
@@ -42,7 +42,7 @@ If I<wrappedkey> is not NULL and the call is successful then the
 internally generated key is written to I<genkey> and its size is written to
 I<*genkeylen>. The encapsulated version of the generated key is written to
 I<wrappedkey> and its size is written to I<*wrappedkeylen>.  Note that if
-I<unwrappedlen> is not NULL, then the value it points to must hold the size of
+I<wrappedlen> is not NULL, then the value it points to must hold the size of
 the  I<unwrapped> buffer so that its size can be validated by the call, ensuring
 it is large enough to hold the result written to I<wrapped>.
 

--- a/doc/man3/EVP_PKEY_encapsulate.pod
+++ b/doc/man3/EVP_PKEY_encapsulate.pod
@@ -41,7 +41,10 @@ unless I<genkeylen> is NULL.
 If I<wrappedkey> is not NULL and the call is successful then the
 internally generated key is written to I<genkey> and its size is written to
 I<*genkeylen>. The encapsulated version of the generated key is written to
-I<wrappedkey> and its size is written to I<*wrappedkeylen>.
+I<wrappedkey> and its size is written to I<*wrappedkeylen>.  Note that if
+I<unwrappedlen> is not NULL, then the value it points to must hold the size of
+the  I<unrwapped> buffer so that its size can be validated by the call, ensuring
+it is large enough to hold the result written to I<wrapped>.
 
 =head1 NOTES
 

--- a/doc/man3/EVP_PKEY_encapsulate.pod
+++ b/doc/man3/EVP_PKEY_encapsulate.pod
@@ -42,7 +42,7 @@ If I<wrappedkey> is not NULL and the call is successful then the
 internally generated key is written to I<genkey> and its size is written to
 I<*genkeylen>. The encapsulated version of the generated key is written to
 I<wrappedkey> and its size is written to I<*wrappedkeylen>.  Note that if
-I<wrappedlen> is not NULL, then the value it points to must hold the size of
+I<wrappedlen> is not NULL, then the value it points to must initially hold the size of
 the  I<unwrapped> buffer so that its size can be validated by the call, ensuring
 it is large enough to hold the result written to I<wrapped>.
 

--- a/providers/implementations/kem/rsa_kem.c
+++ b/providers/implementations/kem/rsa_kem.c
@@ -286,6 +286,12 @@ static int rsasve_generate(PROV_RSA_CTX *prsactx,
             *secretlen = nlen;
         return 1;
     }
+
+    if (outlen != NULL && *outlen < nlen) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_OUTPUT_LENGTH);
+        return 0;
+    }
+
     /*
      * Step (2): Generate a random byte string z of nlen bytes where
      *            1 < z < n - 1
@@ -307,15 +313,33 @@ static int rsasve_generate(PROV_RSA_CTX *prsactx,
     return ret;
 }
 
-/*
- * NIST.SP.800-56Br2
+/**
+ * rsasve_recover - Recovers a secret value from ciphertext using an RSA
+ * private key.  Once, recovered, the secret value is considered to be a
+ * shared secret.  Algorithm is preformed as per
+ * NIST SP 800-56B Rev 2
  * 7.2.1.3 RSASVE Recovery Operation (RSASVE.RECOVER).
+ *
+ * This function performs RSA decryption using the private key from the
+ * provided RSA context (`prsactx`). It takes the input ciphertext, decrypts
+ * it, and writes the decrypted message to the output buffer.
+ *
+ * @prsactx:      The RSA context containing the private key.
+ * @out:          The output buffer to store the decrypted message.
+ * @outlen:       On input, the size of the output buffer. On successful
+ *                completion, the actual length of the decrypted message.
+ * @in:           The input buffer containing the ciphertext to be decrypted.
+ * @inlen:        The length of the input ciphertext in bytes.
+ *
+ * Returns 1 on success, or 0 on error. In case of error, appropriate
+ * error messages are raised using the ERR_raise function.
  */
 static int rsasve_recover(PROV_RSA_CTX *prsactx,
                           unsigned char *out, size_t *outlen,
                           const unsigned char *in, size_t inlen)
 {
     size_t nlen;
+    int ret;
 
     /* Step (1): get the byte length of n */
     nlen = RSA_size(prsactx->rsa);
@@ -329,13 +353,24 @@ static int rsasve_recover(PROV_RSA_CTX *prsactx,
         return 1;
     }
 
-    /* Step (2): check the input ciphertext 'inlen' matches the nlen */
+    /*
+     * Step (2): check the input ciphertext 'inlen' matches the nlen
+     * and that outlen is at least nlen bytes
+     */
     if (inlen != nlen) {
         ERR_raise(ERR_LIB_PROV, PROV_R_BAD_LENGTH);
         return 0;
     }
+    if (outlen != NULL && *outlen < nlen) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_OUTPUT_LENGTH);
+        return 0;
+    }
+
     /* Step (3): out = RSADP((n,d), in) */
-    return (RSA_private_decrypt(inlen, in, out, prsactx->rsa, RSA_NO_PADDING) > 0);
+    ret = RSA_private_decrypt(inlen, in, out, prsactx->rsa, RSA_NO_PADDING);
+    if (ret > 0 && outlen != NULL)
+        *outlen = ret;
+    return ret > 0;
 }
 
 static int rsakem_generate(void *vprsactx, unsigned char *out, size_t *outlen,

--- a/providers/implementations/kem/rsa_kem.c
+++ b/providers/implementations/kem/rsa_kem.c
@@ -287,6 +287,11 @@ static int rsasve_generate(PROV_RSA_CTX *prsactx,
         return 1;
     }
 
+    /*
+     * If outlen is specified, then it must report the length
+     * of the out buffer on input so that we can confirm
+     * its size is sufficent for encapsulation
+     */
     if (outlen != NULL && *outlen < nlen) {
         ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_OUTPUT_LENGTH);
         return 0;
@@ -361,6 +366,12 @@ static int rsasve_recover(PROV_RSA_CTX *prsactx,
         ERR_raise(ERR_LIB_PROV, PROV_R_BAD_LENGTH);
         return 0;
     }
+
+    /*
+     * If outlen is specified, then it must report the length
+     * of the out buffer, so that we can confirm that it is of
+     * sufficient size to hold the output of decapsulation
+     */
     if (outlen != NULL && *outlen < nlen) {
         ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_OUTPUT_LENGTH);
         return 0;

--- a/test/evp_libctx_test.c
+++ b/test/evp_libctx_test.c
@@ -677,6 +677,7 @@ static int kem_rsa_params(void)
           && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(NULL,  NULL), 0)
           /* Test secretlen is optional */
           && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(pubctx, "RSASVE"), 1)
+          && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, NULL, &ctlen, NULL, NULL), 1)
           && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, ct, &ctlen, secret, NULL), 1)
           && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, NULL, &ctlen, NULL, NULL), 1)
           /* Test outlen is optional */

--- a/test/evp_libctx_test.c
+++ b/test/evp_libctx_test.c
@@ -595,7 +595,7 @@ static int kem_rsa_gen_recover(void)
           && TEST_ptr(rctx = EVP_PKEY_CTX_new_from_pkey(libctx, priv, NULL))
           && TEST_int_eq(EVP_PKEY_decapsulate_init(rctx, NULL), 1)
           && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(rctx, "RSASVE"), 1)
-          /* Test that not providing a NULL unwrappedlen fails */
+          /* Test that providing a NULL unwrappedlen fails */
           && TEST_int_eq(EVP_PKEY_decapsulate(rctx, NULL, NULL, ct, ctlen), 0)
           && TEST_int_eq(EVP_PKEY_decapsulate(rctx, NULL, &unwraplen,
                                               ct, ctlen), 1)

--- a/test/evp_libctx_test.c
+++ b/test/evp_libctx_test.c
@@ -584,7 +584,7 @@ static int kem_rsa_gen_recover(void)
           && TEST_int_eq(EVP_PKEY_encapsulate_init(sctx, NULL), 1)
           && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(sctx, "RSASVE"), 1)
           && TEST_ptr(dctx = EVP_PKEY_CTX_dup(sctx))
-          /* Test that not providing a NULL wrappedlen fails */
+          /* Test that providing a NULL wrappedlen fails */
           && TEST_int_eq(EVP_PKEY_encapsulate(dctx, NULL, NULL, NULL, NULL), 0)
           && TEST_int_eq(EVP_PKEY_encapsulate(dctx, NULL, &ctlen, NULL,
                                               &secretlen), 1)

--- a/test/evp_libctx_test.c
+++ b/test/evp_libctx_test.c
@@ -603,9 +603,7 @@ static int kem_rsa_gen_recover(void)
                                               ct, ctlen), 1)
           && TEST_mem_eq(unwrap, unwraplen, secret, secretlen);
 
-    /*
-     * Test that providing a too short unwrapped/ctlen fails
-     */
+    /* Test that providing a too short unwrapped/ctlen fails */
     ctlen = 1;
     if (!TEST_int_eq(EVP_PKEY_encapsulate(dctx, ct, &ctlen, secret,
                                           &secretlen), 0))

--- a/test/evp_libctx_test.c
+++ b/test/evp_libctx_test.c
@@ -649,60 +649,60 @@ static int kem_rsa_params(void)
     size_t ctlen = 0, secretlen = 0;
 
     ret = TEST_true(rsa_keygen(2048, &pub, &priv))
-          && TEST_ptr(pubctx = EVP_PKEY_CTX_new_from_pkey(libctx, pub, NULL))
-          && TEST_ptr(privctx = EVP_PKEY_CTX_new_from_pkey(libctx, priv, NULL))
-          /* Test setting kem op before the init fails */
-          && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(pubctx, "RSASVE"), -2)
-          /* Test NULL ctx passed */
-          && TEST_int_eq(EVP_PKEY_encapsulate_init(NULL, NULL), 0)
-          && TEST_int_eq(EVP_PKEY_encapsulate(NULL, NULL, NULL, NULL, NULL), 0)
-          && TEST_int_eq(EVP_PKEY_decapsulate_init(NULL, NULL), 0)
-          && TEST_int_eq(EVP_PKEY_decapsulate(NULL, NULL, NULL, NULL, 0), 0)
-          /* Test Invalid operation */
-          && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, NULL, NULL, NULL, NULL), -1)
-          && TEST_int_eq(EVP_PKEY_decapsulate(privctx, NULL, NULL, NULL, 0), 0)
-          /* Wrong key component - no secret should be returned on failure */
-          && TEST_int_eq(EVP_PKEY_decapsulate_init(pubctx, NULL), 1)
-          && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(pubctx, "RSASVE"), 1)
-          && TEST_int_eq(EVP_PKEY_decapsulate(pubctx, secret, &secretlen, ct,
-                                              sizeof(ct)), 0)
-          && TEST_uchar_eq(secret[0], 0)
-          /* Test encapsulate fails if the mode is not set */
-          && TEST_int_eq(EVP_PKEY_encapsulate_init(pubctx, NULL), 1)
-          && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, ct, &ctlen, secret, &secretlen), -2)
-          /* Test setting a bad kem ops fail */
-          && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(pubctx, "RSA"), 0)
-          && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(pubctx,  NULL), 0)
-          && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(NULL,  "RSASVE"), 0)
-          && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(NULL,  NULL), 0)
-          /* Test secretlen is optional */
-          && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(pubctx, "RSASVE"), 1)
-          && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, NULL, &ctlen, NULL, NULL), 1)
-          && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, ct, &ctlen, secret, NULL), 1)
-          && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, NULL, &ctlen, NULL, NULL), 1)
-          /* Test outlen is optional */
-          && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, NULL, NULL, NULL, &secretlen), 1)
-          && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, ct, NULL, secret, &secretlen), 1)
-          /* test that either len must be set if out is NULL */
-          && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, NULL, NULL, NULL, NULL), 0)
-          && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, NULL, &ctlen, NULL, NULL), 1)
-          && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, NULL, NULL, NULL, &secretlen), 1)
-          && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, NULL, &ctlen, NULL, &secretlen), 1)
-          /* Secret buffer should be set if there is an output buffer */
-          && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, ct, &ctlen, NULL, NULL), 0)
-          /* Test that lengths are optional if ct is not NULL */
-          && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, ct, NULL, secret, NULL), 1)
-          /* Pass if secret or secret length are not NULL */
-          && TEST_int_eq(EVP_PKEY_decapsulate_init(privctx, NULL), 1)
-          && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(privctx, "RSASVE"), 1)
-          && TEST_int_eq(EVP_PKEY_decapsulate(privctx, secret, NULL, ct, sizeof(ct)), 1)
-          && TEST_int_eq(EVP_PKEY_decapsulate(privctx, NULL, &secretlen, ct, sizeof(ct)), 1)
-          && TEST_int_eq(secretlen, 256)
-          /* Fail if passed NULL arguments */
-          && TEST_int_eq(EVP_PKEY_decapsulate(privctx, NULL, NULL, ct, sizeof(ct)), 0)
-          && TEST_int_eq(EVP_PKEY_decapsulate(privctx, secret, &secretlen, NULL, 0), 0)
-          && TEST_int_eq(EVP_PKEY_decapsulate(privctx, secret, &secretlen, NULL, sizeof(ct)), 0)
-          && TEST_int_eq(EVP_PKEY_decapsulate(privctx, secret, &secretlen, ct, 0), 0);
+        && TEST_ptr(pubctx = EVP_PKEY_CTX_new_from_pkey(libctx, pub, NULL))
+        && TEST_ptr(privctx = EVP_PKEY_CTX_new_from_pkey(libctx, priv, NULL))
+        /* Test setting kem op before the init fails */
+        && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(pubctx, "RSASVE"), -2)
+        /* Test NULL ctx passed */
+        && TEST_int_eq(EVP_PKEY_encapsulate_init(NULL, NULL), 0)
+        && TEST_int_eq(EVP_PKEY_encapsulate(NULL, NULL, NULL, NULL, NULL), 0)
+        && TEST_int_eq(EVP_PKEY_decapsulate_init(NULL, NULL), 0)
+        && TEST_int_eq(EVP_PKEY_decapsulate(NULL, NULL, NULL, NULL, 0), 0)
+        /* Test Invalid operation */
+        && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, NULL, NULL, NULL, NULL), -1)
+        && TEST_int_eq(EVP_PKEY_decapsulate(privctx, NULL, NULL, NULL, 0), 0)
+        /* Wrong key component - no secret should be returned on failure */
+        && TEST_int_eq(EVP_PKEY_decapsulate_init(pubctx, NULL), 1)
+        && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(pubctx, "RSASVE"), 1)
+        && TEST_int_eq(EVP_PKEY_decapsulate(pubctx, secret, &secretlen, ct,
+                                            sizeof(ct)), 0)
+        && TEST_uchar_eq(secret[0], 0)
+        /* Test encapsulate fails if the mode is not set */
+        && TEST_int_eq(EVP_PKEY_encapsulate_init(pubctx, NULL), 1)
+        && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, ct, &ctlen, secret, &secretlen), -2)
+        /* Test setting a bad kem ops fail */
+        && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(pubctx, "RSA"), 0)
+        && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(pubctx, NULL), 0)
+        && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(NULL,  "RSASVE"), 0)
+        && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(NULL,  NULL), 0)
+        /* Test secretlen is optional */
+        && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(pubctx, "RSASVE"), 1)
+        && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, NULL, &ctlen, NULL, NULL), 1)
+        && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, ct, &ctlen, secret, NULL), 1)
+        && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, NULL, &ctlen, NULL, NULL), 1)
+        /* Test outlen is optional */
+        && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, NULL, NULL, NULL, &secretlen), 1)
+        && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, ct, NULL, secret, &secretlen), 1)
+        /* test that either len must be set if out is NULL */
+        && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, NULL, NULL, NULL, NULL), 0)
+        && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, NULL, &ctlen, NULL, NULL), 1)
+        && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, NULL, NULL, NULL, &secretlen), 1)
+        && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, NULL, &ctlen, NULL, &secretlen), 1)
+        /* Secret buffer should be set if there is an output buffer */
+        && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, ct, &ctlen, NULL, NULL), 0)
+        /* Test that lengths are optional if ct is not NULL */
+        && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, ct, NULL, secret, NULL), 1)
+        /* Pass if secret or secret length are not NULL */
+        && TEST_int_eq(EVP_PKEY_decapsulate_init(privctx, NULL), 1)
+        && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(privctx, "RSASVE"), 1)
+        && TEST_int_eq(EVP_PKEY_decapsulate(privctx, secret, NULL, ct, sizeof(ct)), 1)
+        && TEST_int_eq(EVP_PKEY_decapsulate(privctx, NULL, &secretlen, ct, sizeof(ct)), 1)
+        && TEST_int_eq(secretlen, 256)
+        /* Fail if passed NULL arguments */
+        && TEST_int_eq(EVP_PKEY_decapsulate(privctx, NULL, NULL, ct, sizeof(ct)), 0)
+        && TEST_int_eq(EVP_PKEY_decapsulate(privctx, secret, &secretlen, NULL, 0), 0)
+        && TEST_int_eq(EVP_PKEY_decapsulate(privctx, secret, &secretlen, NULL, sizeof(ct)), 0)
+        && TEST_int_eq(EVP_PKEY_decapsulate(privctx, secret, &secretlen, ct, 0), 0);
 
     EVP_PKEY_free(pub);
     EVP_PKEY_free(priv);


### PR DESCRIPTION
@t-j-h noted that EVP_PKEY_decapsulate failed to behave in the way described by the documentation here:

https://docs.openssl.org/master/man3/EVP_PKEY_decapsulate/

Specifically, the docs indicate:
```
The EVP_PKEY_decapsulate() function performs a private key decapsulation operation using ctx.
The data to be decapsulated is specified using the wrapped and wrappedlen parameters.
If unwrapped is NULL then the maximum size of the output secret buffer is written to *unwrappedlen.
If unwrapped is not NULL and the call is successful then the decapsulated secret data is written to
unwrapped and the amount of data written to *unwrappedlen.
```

But the implementation neither checked that *outlen was non-null when a buffer was provided, nor did it write the actual secret length to *outlen after the decryption was complete.

Fix those issues, and augment the tests to ensure that we pass a size_t pointer into the function.  Also add an additional test to ensure that passing a NULL pointer results in an error


