### PR TITLE
Avoid compiler warnings on `sprintf()`calls

### DIFF
--- a/apps/lib/vms_term_sock.c
+++ b/apps/lib/vms_term_sock.c
@@ -353,7 +353,7 @@ static int CreateSocketPair (int SocketFamily,
     /*
     ** Get the binary (64-bit) time of the specified timeout value
     */
-    sprintf (AscTimeBuff, "0 0:0:%02d.00", SOCKET_PAIR_TIMEOUT_VALUE);
+    BIO_snprintf(AscTimeBuff, sizeof(AscTimeBuff), "0 0:0:%02d.00", SOCKET_PAIR_TIMEOUT_VALUE);
     AscTimeDesc.dsc$w_length = strlen (AscTimeBuff);
     AscTimeDesc.dsc$a_pointer = AscTimeBuff;
     status = sys$bintim (&AscTimeDesc, BinTimeBuff);
@@ -567,10 +567,10 @@ static void LogMessage (char *msg, ...)
     /*
     ** Format the message buffer
     */
-    sprintf (MsgBuff, "%02d-%s-%04d %02d:%02d:%02d [%08X] %s\n",
-             LocTime->tm_mday, Month[LocTime->tm_mon],
-             (LocTime->tm_year + 1900), LocTime->tm_hour, LocTime->tm_min,
-             LocTime->tm_sec, pid, msg);
+    BIO_snprintf(MsgBuff, sizeof(MsgBuff), "%02d-%s-%04d %02d:%02d:%02d [%08X] %s\n",
+                 LocTime->tm_mday, Month[LocTime->tm_mon],
+                 (LocTime->tm_year + 1900), LocTime->tm_hour, LocTime->tm_min,
+                 LocTime->tm_sec, pid, msg);
 
     /*
     ** Get any variable arguments and add them to the print of the message

--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -589,7 +589,8 @@ static char *shacrypt(const char *passwd, const char *magic, const char *salt)
     OPENSSL_strlcat(out_buf, ascii_dollar, sizeof(out_buf));
     if (rounds_custom) {
         char tmp_buf[80]; /* "rounds=999999999" */
-        sprintf(tmp_buf, "rounds=%u", rounds);
+
+        BIO_snprintf(tmp_buf, sizeof(tmp_buf), "rounds=%u", rounds);
 #ifdef CHARSET_EBCDIC
         /* In case we're really on a ASCII based platform and just pretend */
         if (tmp_buf[0] != 0x72)  /* ASCII 'r' */

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -2624,13 +2624,13 @@ int speed_main(int argc, char **argv)
     if (doit[D_HMAC]) {
         static const char hmac_key[] = "This is a key...";
         int len = strlen(hmac_key);
+        size_t hmac_name_len = sizeof("hmac()") + strlen(evp_mac_mdname);
         OSSL_PARAM params[3];
 
         if (evp_mac_mdname == NULL)
             goto end;
-        evp_hmac_name = app_malloc(sizeof("hmac()") + strlen(evp_mac_mdname),
-                                   "HMAC name");
-        sprintf(evp_hmac_name, "hmac(%s)", evp_mac_mdname);
+        evp_hmac_name = app_malloc(hmac_name_len, "HMAC name");
+        BIO_snprintf(evp_hmac_name, hmac_name_len, "hmac(%s)", evp_mac_mdname);
         names[D_HMAC] = evp_hmac_name;
 
         params[0] =
@@ -2894,6 +2894,7 @@ int speed_main(int argc, char **argv)
     }
 
     if (doit[D_EVP_CMAC]) {
+        size_t len = sizeof("cmac()") + strlen(evp_mac_ciphername);
         OSSL_PARAM params[3];
         EVP_CIPHER *cipher = NULL;
 
@@ -2906,9 +2907,8 @@ int speed_main(int argc, char **argv)
             BIO_printf(bio_err, "\nRequested CMAC cipher with unsupported key length.\n");
             goto end;
         }
-        evp_cmac_name = app_malloc(sizeof("cmac()")
-                                   + strlen(evp_mac_ciphername), "CMAC name");
-        sprintf(evp_cmac_name, "cmac(%s)", evp_mac_ciphername);
+        evp_cmac_name = app_malloc(len, "CMAC name");
+        BIO_snprintf(evp_cmac_name, len, "cmac(%s)", evp_mac_ciphername);
         names[D_EVP_CMAC] = evp_cmac_name;
 
         params[0] = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_CIPHER,

--- a/crypto/bio/bss_log.c
+++ b/crypto/bio/bss_log.c
@@ -281,7 +281,7 @@ static void xsyslog(BIO *bp, int priority, const char *string)
         break;
     }
 
-    sprintf(pidbuf, "[%lu] ", GetCurrentProcessId());
+    BIO_snprintf(pidbuf, sizeof(pidbuf), "[%lu] ", GetCurrentProcessId());
     lpszStrings[0] = pidbuf;
     lpszStrings[1] = string;
 

--- a/crypto/dso/dso_dl.c
+++ b/crypto/dso/dso_dl.c
@@ -229,13 +229,12 @@ static char *dl_name_converter(DSO *dso, const char *filename)
         ERR_raise(ERR_LIB_DSO, DSO_R_NAME_TRANSLATION_FAILED);
         return NULL;
     }
-    if (transform) {
-        if ((DSO_flags(dso) & DSO_FLAG_NAME_TRANSLATION_EXT_ONLY) == 0)
-            sprintf(translated, "lib%s%s", filename, DSO_EXTENSION);
-        else
-            sprintf(translated, "%s%s", filename, DSO_EXTENSION);
-    } else
-        sprintf(translated, "%s", filename);
+    if (transform)
+        BIO_snprintf(translated, rsize,
+                     (DSO_flags(dso) & DSO_FLAG_NAME_TRANSLATION_EXT_ONLY) == 0
+                     ? "lib%s%s" : "%s%s", filename, DSO_EXTENSION);
+    else
+        BIO_snprintf(translated, rsize, "%s", filename);
     return translated;
 }
 

--- a/crypto/dso/dso_dlfcn.c
+++ b/crypto/dso/dso_dlfcn.c
@@ -265,11 +265,12 @@ static char *dlfcn_name_converter(DSO *dso, const char *filename)
     }
     if (transform) {
         if ((DSO_flags(dso) & DSO_FLAG_NAME_TRANSLATION_EXT_ONLY) == 0)
-            sprintf(translated, "lib%s" DSO_EXTENSION, filename);
+            BIO_snprintf(translated, rsize, "lib%s" DSO_EXTENSION, filename);
         else
-            sprintf(translated, "%s" DSO_EXTENSION, filename);
-    } else
-        sprintf(translated, "%s", filename);
+            BIO_snprintf(translated, rsize, "%s" DSO_EXTENSION, filename);
+    } else {
+        BIO_snprintf(translated, rsize, "%s", filename);
+    }
     return translated;
 }
 

--- a/crypto/dso/dso_win32.c
+++ b/crypto/dso/dso_win32.c
@@ -458,10 +458,7 @@ static char *win32_name_converter(DSO *dso, const char *filename)
         ERR_raise(ERR_LIB_DSO, DSO_R_NAME_TRANSLATION_FAILED);
         return NULL;
     }
-    if (transform)
-        sprintf(translated, "%s.dll", filename);
-    else
-        sprintf(translated, "%s", filename);
+    BIO_snprintf(translated, len + 1, transform ? "%s.dll" : "%s", filename);
     return translated;
 }
 

--- a/crypto/dso/dso_win32.c
+++ b/crypto/dso/dso_win32.c
@@ -444,21 +444,20 @@ static char *win32_name_converter(DSO *dso, const char *filename)
     char *translated;
     int len, transform;
 
-    len = strlen(filename);
     transform = ((strstr(filename, "/") == NULL) &&
                  (strstr(filename, "\\") == NULL) &&
                  (strstr(filename, ":") == NULL));
+    /* If transform != 0, then we convert to %s.dll, else just dupe filename */
+
+    len = strlen(filename) + 1;
     if (transform)
-        /* We will convert this to "%s.dll" */
-        translated = OPENSSL_malloc(len + 5);
-    else
-        /* We will simply duplicate filename */
-        translated = OPENSSL_malloc(len + 1);
+        len += strlen(".dll");
+    translated = OPENSSL_malloc(len);
     if (translated == NULL) {
         ERR_raise(ERR_LIB_DSO, DSO_R_NAME_TRANSLATION_FAILED);
         return NULL;
     }
-    BIO_snprintf(translated, len + 1, transform ? "%s.dll" : "%s", filename);
+    BIO_snprintf(translated, len, "%s%s", filename, transform ? ".dll" : "");
     return translated;
 }
 

--- a/crypto/info.c
+++ b/crypto/info.c
@@ -190,10 +190,10 @@ DEFINE_RUN_ONCE_STATIC(init_info_strings)
 #endif
 #ifndef OPENSSL_NO_JITTER
         {
-            char jent_version_string[32];
+            char buf[32];
 
-            sprintf(jent_version_string, "JITTER (%d)", jent_version());
-            add_seeds_string(jent_version_string);
+            BIO_snprintf(buf, sizeof(buf), "JITTER (%d)", jent_version());
+            add_seeds_string(buf);
         }
 #endif
         seed_sources = seeds;

--- a/test/cmactest.c
+++ b/test/cmactest.c
@@ -327,13 +327,15 @@ err:
     return ret;
 }
 
+#define OSSL_HEX_CHARS_PER_BYTE 2
 static char *pt(unsigned char *md, unsigned int len)
 {
     unsigned int i;
-    static char buf[80];
+    static char buf[81];
 
-    for (i = 0; i < len; i++)
-        BIO_snprintf(&(buf[i * 2]), sizeof(buf), "%02x", md[i]);
+    for (i = 0; i < len && (i + 1) * OSSL_HEX_CHARS_PER_BYTE < sizeof(buf); i++)
+        BIO_snprintf(buf + i * OSSL_HEX_CHARS_PER_BYTE,
+                     OSSL_HEX_CHARS_PER_BYTE + 1, "%02x", md[i]);
     return buf;
 }
 

--- a/test/cmactest.c
+++ b/test/cmactest.c
@@ -333,7 +333,7 @@ static char *pt(unsigned char *md, unsigned int len)
     static char buf[80];
 
     for (i = 0; i < len; i++)
-        sprintf(&(buf[i * 2]), "%02x", md[i]);
+        BIO_snprintf(&(buf[i * 2]), sizeof(buf), "%02x", md[i]);
     return buf;
 }
 

--- a/test/conf_include_test.c
+++ b/test/conf_include_test.c
@@ -186,7 +186,7 @@ static int test_check_overflow(void)
     char max[(sizeof(long) * 8) / 3 + 3];
     char *p;
 
-    p = max + sprintf(max, "0%ld", LONG_MAX) - 1;
+    p = max + BIO_snprintf(max, sizeof (max), "0%ld", LONG_MAX) - 1;
     setenv("FNORD", max, 1);
     if (!TEST_true(NCONF_get_number(NULL, "missing", "FNORD", &val))
             || !TEST_long_eq(val, LONG_MAX))

--- a/test/conf_include_test.c
+++ b/test/conf_include_test.c
@@ -186,7 +186,7 @@ static int test_check_overflow(void)
     char max[(sizeof(long) * 8) / 3 + 3];
     char *p;
 
-    p = max + BIO_snprintf(max, sizeof (max), "0%ld", LONG_MAX) - 1;
+    p = max + BIO_snprintf(max, sizeof(max), "0%ld", LONG_MAX) - 1;
     setenv("FNORD", max, 1);
     if (!TEST_true(NCONF_get_number(NULL, "missing", "FNORD", &val))
             || !TEST_long_eq(val, LONG_MAX))

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -417,7 +417,7 @@ static int test_rand_reseed_on_fork(EVP_RAND_CTX *primary,
 
         presult[0].pindex = presult[1].pindex = i;
 
-        sprintf(presult[0].name, "child %d", i);
+        BIO_snprintf(presult[0].name, sizeof(presult[0].name), "child %d", i);
         strcpy(presult[1].name, presult[0].name);
 
         /* collect the random output of the children */

--- a/test/enginetest.c
+++ b/test/enginetest.c
@@ -147,9 +147,9 @@ static int test_engines(void)
 
     TEST_info("About to beef up the engine-type list");
     for (loop = 0; loop < NUMTOADD; loop++) {
-        sprintf(buf, "id%d", loop);
+        BIO_snprintf(buf, sizeof(buf), "id%d", loop);
         eid[loop] = OPENSSL_strdup(buf);
-        sprintf(buf, "Fake engine type %d", loop);
+        BIO_snprintf(buf, sizeof(buf), "Fake engine type %d", loop);
         ename[loop] = OPENSSL_strdup(buf);
         if (!TEST_ptr(block[loop] = ENGINE_new())
                 || !TEST_true(ENGINE_set_id(block[loop], eid[loop]))

--- a/test/hmactest.c
+++ b/test/hmactest.c
@@ -284,7 +284,7 @@ static char *pt(unsigned char *md, unsigned int len)
     if (md == NULL)
         return NULL;
     for (i = 0; i < len; i++)
-        sprintf(&(buf[i * 2]), "%02x", md[i]);
+        BIO_snprintf(&(buf[i * 2]), sizeof(buf), "%02x", md[i]);
     return buf;
 }
 # endif

--- a/test/hmactest.c
+++ b/test/hmactest.c
@@ -275,19 +275,21 @@ static int test_hmac_copy_uninited(void)
     return res;
 }
 
-# ifndef OPENSSL_NO_MD5
+#ifndef OPENSSL_NO_MD5
+# define OSSL_HEX_CHARS_PER_BYTE 2
 static char *pt(unsigned char *md, unsigned int len)
 {
     unsigned int i;
-    static char buf[200];
+    static char buf[201];
 
     if (md == NULL)
         return NULL;
-    for (i = 0; i < len; i++)
-        BIO_snprintf(&(buf[i * 2]), sizeof(buf), "%02x", md[i]);
+    for (i = 0; i < len && (i + 1) * OSSL_HEX_CHARS_PER_BYTE < sizeof(buf); i++)
+        BIO_snprintf(buf + i * OSSL_HEX_CHARS_PER_BYTE,
+                     OSSL_HEX_CHARS_PER_BYTE + 1, "%02x", md[i]);
     return buf;
 }
-# endif
+#endif
 
 static struct test_chunks_st {
     const char *md_name;

--- a/test/pkcs12_format_test.c
+++ b/test/pkcs12_format_test.c
@@ -365,7 +365,8 @@ static int test_single_key(PKCS12_ENC *enc)
     char fname[80];
     PKCS12_BUILDER *pb;
 
-    sprintf(fname, "1key_ciph-%s_iter-%d.p12", OBJ_nid2sn(enc->nid), enc->iter);
+    BIO_snprintf(fname, sizeof(fname), "1key_ciph-%s_iter-%d.p12",
+                 OBJ_nid2sn(enc->nid), enc->iter);
 
     pb = new_pkcs12_builder(fname);
 
@@ -464,7 +465,8 @@ static int test_single_cert_mac(PKCS12_ENC *mac)
     char fname[80];
     PKCS12_BUILDER *pb;
 
-    sprintf(fname, "1cert_mac-%s_iter-%d.p12", OBJ_nid2sn(mac->nid), mac->iter);
+    BIO_snprintf(fname, sizeof(fname), "1cert_mac-%s_iter-%d.p12",
+                 OBJ_nid2sn(mac->nid), mac->iter);
 
     pb = new_pkcs12_builder(fname);
 
@@ -624,7 +626,8 @@ static int test_single_secret(PKCS12_ENC *enc)
     char fname[80];
     PKCS12_BUILDER *pb;
 
-    sprintf(fname, "1secret_ciph-%s_iter-%d.p12", OBJ_nid2sn(enc->nid), enc->iter);
+    BIO_snprintf(fname, sizeof(fname), "1secret_ciph-%s_iter-%d.p12",
+                 OBJ_nid2sn(enc->nid), enc->iter);
     pb = new_pkcs12_builder(fname);
     custom_nid = get_custom_oid();
 

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -190,7 +190,7 @@ static int compare_hex_encoded_buffer(const char *hex_encoded,
         return 1;
 
     for (i = j = 0; i < raw_length && j + 1 < hex_length; i++, j += 2) {
-        sprintf(hexed, "%02x", raw[i]);
+        BIO_snprintf(hexed, sizeof(hexed), "%02x", raw[i]);
         if (!TEST_int_eq(hexed[0], hex_encoded[j])
                 || !TEST_int_eq(hexed[1], hex_encoded[j + 1]))
             return 1;


### PR DESCRIPTION
* replace various calls to `sprintf()` by `snprintf()` to avoid deprecation compiler warnings on MacOS
* ~`internal/list.h`: rename `LIST_FOREACH` to `OSSL_LIST_FOREACH`, which prevents
    clash with `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sys/queue.h`~

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
