### PR TITLE
Add threading support to the FIPS provider.

### DIFF
--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -24,6 +24,14 @@ provider-base
                        OSSL_thread_stop_handler_fn handfn,
                        void *arg);
 
+ typedef uint32_t (*OSSL_thread_start_handler_fn)(void *);
+ uint64_t core_get_avail_threads(const OSSL_CORE_HANDLE *handle);
+ void *core_crypto_thread_start(const OSSL_CORE_HANDLE *prov,
+                                OSSL_thread_start_handler_fn start,
+                                void *data);
+ int core_crypto_thread_join(void *vhandle, uint32_t *ret);
+ int core_crypto_thread_clean(void *vhandle);
+
  OPENSSL_CORE_CTX *core_get_libctx(const OSSL_CORE_HANDLE *handle);
  void core_new_error(const OSSL_CORE_HANDLE *handle);
  void core_set_error_debug(const OSSL_CORE_HANDLE *handle,
@@ -150,6 +158,10 @@ provider):
  core_gettable_params           OSSL_FUNC_CORE_GETTABLE_PARAMS
  core_get_params                OSSL_FUNC_CORE_GET_PARAMS
  core_thread_start              OSSL_FUNC_CORE_THREAD_START
+ core_get_avail_threads         OSSL_FUNC_CORE_GET_AVAIL_THREADS
+ core_crypto_thread_start       OSSL_FUNC_CORE_CRYPTO_THREAD_START
+ core_crypto_thread_join        OSSL_FUNC_CORE_CRYPTO_THREAD_JOIN
+ core_crypto_thread_clean       OSSL_FUNC_CORE_CRYPTO_THREAD_CLEAN
  core_get_libctx                OSSL_FUNC_CORE_GET_LIBCTX
  core_new_error                 OSSL_FUNC_CORE_NEW_ERROR
  core_set_error_debug           OSSL_FUNC_CORE_SET_ERROR_DEBUG
@@ -225,6 +237,25 @@ callback will subsequently be called, with the supplied argument I<arg>, from
 the thread that is stopping and gets passed the provider context as an
 argument. This may be useful to perform thread specific clean up such as
 freeing thread local variables.
+
+The functions core_crypto_thread_start(), core_crypto_thread_join(),
+core_crypto_thread_clean() and core_get_avail_threads() are used to
+supply threading related functions to providers that do not implement threading.
+core_crypto_thread_start() and core_get_avail_threads() must be passed the
+I<handle> for this provider.
+
+The function core_crypto_thread_start() returns a handle to a created thread,
+which will run the function I<start> that is passed the parameter I<data>.
+
+core_crypto_thread_join() and core_crypto_thread_clean() must use the handle
+returned from core_crypto_thread_start() as their I<vhandle>.
+
+The function core_crypto_thread_join() may be called to wait until the thread
+is finished. The |ret| value returns the exit status if it is not NULL.
+
+The function core_crypto_thread_clean() should be used to clean up the thread.
+
+The function core_get_avail_threads() returns the number of available threads.
 
 core_get_libctx() retrieves the core context in which the library
 object for the current provider is stored, accessible through the I<handle>.

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -15,6 +15,9 @@
 # include <openssl/core.h>
 # include <openssl/indicator.h>
 
+/* Note that this matches CRYPTO_THREAD_ROUTINE */
+typedef uint32_t (*OSSL_thread_start_handler_fn)(void *);
+
 # ifdef __cplusplus
 extern "C" {
 # endif
@@ -92,6 +95,19 @@ OSSL_CORE_MAKE_FUNC(int, core_clear_last_error_mark,
 # define OSSL_FUNC_CORE_POP_ERROR_TO_MARK     10
 OSSL_CORE_MAKE_FUNC(int, core_pop_error_to_mark, (const OSSL_CORE_HANDLE *prov))
 
+# define OSSL_FUNC_CORE_GET_AVAIL_THREADS     15
+OSSL_CORE_MAKE_FUNC(uint64_t, core_get_avail_threads,
+                    (const OSSL_CORE_HANDLE *prov))
+
+# define OSSL_FUNC_CORE_CRYPTO_THREAD_START   16
+OSSL_CORE_MAKE_FUNC(void *, core_crypto_thread_start,
+                    (const OSSL_CORE_HANDLE *prov,
+                     OSSL_thread_start_handler_fn start,
+                     void *data))
+# define OSSL_FUNC_CORE_CRYPTO_THREAD_JOIN    17
+OSSL_CORE_MAKE_FUNC(int, core_crypto_thread_join, (void *task, uint32_t *ret))
+# define OSSL_FUNC_CORE_CRYPTO_THREAD_CLEAN   18
+OSSL_CORE_MAKE_FUNC(int, core_crypto_thread_clean, (void *vhandle))
 
 /* Functions to access the OBJ database */
 

--- a/providers/build.info
+++ b/providers/build.info
@@ -176,3 +176,7 @@ ENDIF
 # include all the object files that are needed.
 $NULLGOAL=../libcrypto
 SOURCE[$NULLGOAL]=nullprov.c prov_running.c
+
+IF[{- !$disabled{'thread-pool'} -}]
+  SOURCE[$NULLGOAL]=prov_threads.c
+ENDIF

--- a/providers/common/include/prov/providercommon.h
+++ b/providers/common/include/prov/providercommon.h
@@ -22,3 +22,12 @@ void ossl_set_error_state(const char *type);
 
 /* Return true if the module is in a usable condition */
 int ossl_prov_is_running(void);
+
+#if !defined(OPENSSL_NO_DEFAULT_THREAD_POOL)
+uint64_t ossl_prov_get_avail_threads(OSSL_LIB_CTX *libctx);
+void *ossl_prov_thread_start(OSSL_LIB_CTX *ctx,
+                             OSSL_thread_start_handler_fn start,
+                             void *data);
+int ossl_prov_thread_join(void *task, uint32_t *ret);
+int ossl_prov_thread_clean(void *vhandle);
+#endif /* OPENSSL_NO_DEFAULT_THREAD_POOL */

--- a/providers/prov_threads.c
+++ b/providers/prov_threads.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/**
+ * @brief A simple wrapper around the thread calls for the default provider.
+ *
+ * Algorithms that need to use functions such as ossl_get_avail_threads() and
+ * ossl_crypto_thread_start() should use these wrappers if the algorithm needs
+ * to be included in the OpenSSL FIPS provider. (e.g. If Argon2 becomes a FIPS
+ * algorithm).
+ * The FIPS provider has its own copy of the functions listed below since
+ * functions such as ossl_get_avail_threads(), and ossl_crypto_thread_start()
+ * are not directly available.
+ */
+
+#include <openssl/e_os2.h>
+#include "prov/providercommon.h"
+#include "internal/thread.h"
+
+#if !defined(OPENSSL_NO_DEFAULT_THREAD_POOL)
+uint64_t ossl_prov_get_avail_threads(OSSL_LIB_CTX *ctx)
+{
+    return ossl_get_avail_threads(ctx);
+}
+
+void *ossl_prov_thread_start(OSSL_LIB_CTX *ctx, CRYPTO_THREAD_ROUTINE start,
+                             void *data)
+{
+    return ossl_crypto_thread_start(ctx, start, data);
+}
+
+int ossl_prov_thread_join(void *task, uint32_t *ret)
+{
+    return ossl_crypto_thread_join(task, ret);
+}
+
+int ossl_prov_thread_clean(void *vhandle)
+{
+    return ossl_crypto_thread_clean(vhandle);
+}
+#endif /* OPENSSL_NO_DEFAULT_THREAD_POOL */


### PR DESCRIPTION
The FIPS provider does not include threading code directly. The core passes thread related methods to the providers so that the FIPS provider has access to threading.
This allows complex algorithms such as ARGON or HSS to use threads once they are implemented in the FIPS provider.

An existing PR for HSS will use and test this code.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
