### PR TITLE
RISC-V: Define vlenb symbol for assembler

### DIFF
--- a/crypto/riscv32cpuid.pl
+++ b/crypto/riscv32cpuid.pl
@@ -94,8 +94,24 @@ $code .= <<___;
 .globl riscv_vlen_asm
 .type riscv_vlen_asm,\@function
 riscv_vlen_asm:
-    csrr $ret, vlenb
-    slli $ret, $ret, 3
+    # Check for vector extension support.
+    csrrs   $t0,misa,x0
+    andi    $t0,$t0,(1<<20)
+    beqz    $t0,no_vector_extension
+
+    # vlenb is defined by RISC-V "V" Vector Extension
+    # version 1.0.
+    # See: https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc
+    .equ    vlenb,0xC22
+
+    # Read vlenb.
+    csrr    $ret,vlenb
+    slli    $ret,$ret,3
+    ret
+
+no_vector_extension:
+    # Return 0 if no vector extension.
+    li      $ret,0
     ret
 .size riscv_vlen_asm,.-riscv_vlen_asm
 ___

--- a/crypto/riscv64cpuid.pl
+++ b/crypto/riscv64cpuid.pl
@@ -94,8 +94,24 @@ $code .= <<___;
 .globl riscv_vlen_asm
 .type riscv_vlen_asm,\@function
 riscv_vlen_asm:
-    csrr $ret, vlenb
-    slli $ret, $ret, 3
+    # Check for vector extension support.
+    csrrs   $t0,misa,x0
+    andi    $t0,$t0,(1<<20)
+    beqz    $t0,no_vector_extension
+
+    # vlenb is defined by RISC-V "V" Vector Extension
+    # version 1.0.
+    # See: https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc
+    .equ    vlenb,0xC22
+
+    # Read vlenb.
+    csrr    $ret,vlenb
+    slli    $ret,$ret,3
+    ret
+
+no_vector_extension:
+    # Return 0 if no vector extension.
+    li      $ret,0
     ret
 .size riscv_vlen_asm,.-riscv_vlen_asm
 ___


### PR DESCRIPTION
## RISC-V: Define vlenb symbol for assembler

The assembler was unable to recognize the 'vlenb' symbol when building for RISC-V. This led to build failures as reported in #23011.

This commit explicitly defines the 'vlenb' symbol using the '.equ' directive, associating it with the address 0xC22 as defined in the RISC-V "V" Vector Extension specification (Section 3, Table 1) and this addresses the build issue.

This solution is based on the approach suggested by @xicilion in #23011, who provided a working modification using `csrr a0, 0xC22`.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->