### PR TITLE
docs: add HISTORY section to openssl-fipsinstall

### DIFF
--- a/doc/man1/openssl-fipsinstall.pod.in
+++ b/doc/man1/openssl-fipsinstall.pod.in
@@ -439,6 +439,10 @@ L<fips_config(5)>,
 L<OSSL_PROVIDER-FIPS(7)>,
 L<EVP_MAC(3)>
 
+=head1 HISTORY
+
+The B<openssl-fipsinstall> application was added in OpenSSL 3.0.
+
 =head1 COPYRIGHT
 
 Copyright 2019-2024 The OpenSSL Project Authors. All Rights Reserved.

--- a/doc/man1/openssl-fipsinstall.pod.in
+++ b/doc/man1/openssl-fipsinstall.pod.in
@@ -453,6 +453,34 @@ The following options were added in OpenSSL 3.2:
 B<-pedantic>,
 B<-no_drbg_truncated_digests>
 
+The following options were added in OpenSSL 3.4:
+
+B<-hmac_key_check>,
+B<-kmac_key_check>,
+B<-signature_digest_check>,
+B<-hkdf_digest_check>,
+B<-tls13_kdf_digest_check>,
+B<-tls1_prf_digest_check>,
+B<-sshkdf_digest_check>,
+B<-sskdf_digest_check>,
+B<-x963kdf_digest_check>,
+B<-dsa_sign_disabled>,
+B<-no_pbkdf2_lower_bound_check>,
+B<-no_short_mac>,
+B<-tdes_encrypt_disabled>,
+B<-rsa_pkcs15_padding_disabled>,
+B<-rsa_pss_saltlen_check>,
+B<-rsa_sign_x931_disabled>,
+B<-hkdf_key_check>,
+B<-kbkdf_key_check>,
+B<-tls13_kdf_key_check>,
+B<-tls1_prf_key_check>,
+B<-sshkdf_key_check>,
+B<-sskdf_key_check>,
+B<-x963kdf_key_check>,
+B<-x942kdf_key_check>,
+B<-ecdh_cofactor_check>
+
 =head1 COPYRIGHT
 
 Copyright 2019-2024 The OpenSSL Project Authors. All Rights Reserved.

--- a/doc/man1/openssl-fipsinstall.pod.in
+++ b/doc/man1/openssl-fipsinstall.pod.in
@@ -443,6 +443,11 @@ L<EVP_MAC(3)>
 
 The B<openssl-fipsinstall> application was added in OpenSSL 3.0.
 
+The following options were added in OpenSSL 3.1:
+
+B<-ems_check>,
+B<-self_test_oninstall>
+
 =head1 COPYRIGHT
 
 Copyright 2019-2024 The OpenSSL Project Authors. All Rights Reserved.

--- a/doc/man1/openssl-fipsinstall.pod.in
+++ b/doc/man1/openssl-fipsinstall.pod.in
@@ -448,6 +448,11 @@ The following options were added in OpenSSL 3.1:
 B<-ems_check>,
 B<-self_test_oninstall>
 
+The following options were added in OpenSSL 3.2:
+
+B<-pedantic>,
+B<-no_drbg_truncated_digests>
+
 =head1 COPYRIGHT
 
 Copyright 2019-2024 The OpenSSL Project Authors. All Rights Reserved.


### PR DESCRIPTION
Documents when the command was added (3.0.0?) and when various options
were added after that.

Note sure about formatting, looks ok as a manpage.
