### PR TITLE
Reject invalid FFDHE and ECDHE key shares with SSL_AD_ILLEGAL_PARAMETER alert (RFC 8446)

### DIFF
--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3087,7 +3087,7 @@ static int tls_process_cke_dhe(SSL_CONNECTION *s, PACKET *pkt)
     }
 
     if (EVP_PKEY_set1_encoded_public_key(ckey, data, i) <= 0) {
-        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_BAD_KEY_SHARE);
         goto err;
     }
 
@@ -3141,7 +3141,7 @@ static int tls_process_cke_ecdhe(SSL_CONNECTION *s, PACKET *pkt)
         }
 
         if (EVP_PKEY_set1_encoded_public_key(ckey, data, i) <= 0) {
-            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EC_LIB);
+            SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_BAD_KEY_SHARE);
             goto err;
         }
     }


### PR DESCRIPTION
Fixes: #25402 

The test results after modification are as follows:

<details>
<summary>dhe</summary>

```sh
$ PYTHONPATH=. python scripts/test-dhe-rsa-key-exchange-with-bad-messages.py
sanity ...
OK

invalid dh_Yc value - 1 ...
OK

padded Client Key Exchange ...
OK

invalid dh_Yc value - 8192b ...
OK

invalid dh_Yc value - p ...
OK

invalid dh_Yc value - p-1 ...
OK

truncated dh_Yc value ...
OK

invalid dh_Yc value - 0 ...
OK

invalid dh_Yc value - missing ...
OK

sanity ...
OK

Check if server properly verifies received Client Key Exchange
message. That the extra data (pad) at the end is noticed, that
too short message is rejected and a message with "obviously"
wrong client key share is rejected
Test end
====================
version: 6
====================
TOTAL: 10
SKIP: 0
PASS: 10
XFAIL: 0
FAIL: 0
XPASS: 0
====================
```

</details>

<details>
<summary>ecdhe</summary>

```sh
$ PYTHONPATH=. python scripts/test-ecdhe-rsa-key-exchange-with-bad-messages.py
sanity ...
OK

invalid point (self-inconsistent, y all zero) ...
OK

invalid point (0, 0) ...
OK

invalid point (self-inconsistent) ...
OK

truncated ecdh_Yc value ...
OK

padded Client Key Exchange ...
OK

invalid point (0, 1) ...
OK

sanity ...
OK

Test end
====================
version: 5
====================
TOTAL: 8
SKIP: 0
PASS: 8
XFAIL: 0
FAIL: 0
XPASS: 0
====================
```

</details>