### PR TITLE
APPS/pkey etc.: fix case where infile and outfile are the same

### DIFF
--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -179,10 +179,6 @@ int dhparam_main(int argc, char **argv)
         goto end;
     }
 
-    out = bio_open_default(outfile, 'w', outformat);
-    if (out == NULL)
-        goto end;
-
     /* DH parameters */
     if (num && !g)
         g = 2;
@@ -321,6 +317,10 @@ int dhparam_main(int argc, char **argv)
             tmppkey = NULL;
         }
     }
+
+    out = bio_open_default(outfile, 'w', outformat);
+    if (out == NULL)
+        goto end;
 
     if (text)
         EVP_PKEY_print_params(out, pkey, 4, NULL);

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -150,10 +150,6 @@ int dsaparam_main(int argc, char **argv)
     numbits = num;
     private = genkey ? 1 : 0;
 
-    out = bio_open_owner(outfile, outformat, private);
-    if (out == NULL)
-        goto end;
-
     ctx = EVP_PKEY_CTX_new_from_name(app_get0_libctx(), "DSA", app_get0_propq());
     if (ctx == NULL) {
         BIO_printf(bio_err,
@@ -199,6 +195,10 @@ int dsaparam_main(int argc, char **argv)
         /* Error message should already have been displayed */
         goto end;
     }
+
+    out = bio_open_owner(outfile, outformat, private);
+    if (out == NULL)
+        goto end;
 
     if (text) {
         EVP_PKEY_print_params(out, params, 0, NULL);

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -194,16 +194,6 @@ int ecparam_main(int argc, char **argv)
 
     private = genkey ? 1 : 0;
 
-    out = bio_open_owner(outfile, outformat, private);
-    if (out == NULL)
-        goto end;
-
-    if (list_curves) {
-        if (list_builtin_curves(out))
-            ret = 0;
-        goto end;
-    }
-
     if (curve_name != NULL) {
         OSSL_PARAM params[4];
         OSSL_PARAM *p = params;
@@ -273,6 +263,16 @@ int ecparam_main(int argc, char **argv)
         && !EVP_PKEY_set_octet_string_param(params_key, OSSL_PKEY_PARAM_EC_SEED,
                                             NULL, 0)) {
         BIO_printf(bio_err, "unable to clear seed\n");
+        goto end;
+    }
+
+    out = bio_open_owner(outfile, outformat, private);
+    if (out == NULL)
+        goto end;
+
+    if (list_curves) {
+        if (list_builtin_curves(out))
+            ret = 0;
         goto end;
     }
 

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -553,10 +553,6 @@ int ocsp_main(int argc, char **argv)
         && respin == NULL && !(port != NULL && ridx_filename != NULL))
         goto opthelp;
 
-    out = bio_open_default(outfile, 'w', FORMAT_TEXT);
-    if (out == NULL)
-        goto end;
-
     if (req == NULL && (add_nonce != 2))
         add_nonce = 0;
 
@@ -708,6 +704,10 @@ redo_accept:
             goto end;
         }
     }
+
+    out = bio_open_default(outfile, 'w', FORMAT_TEXT);
+    if (out == NULL)
+        goto end;
 
     if (req_text && req != NULL)
         OCSP_REQUEST_print(out, req, 0);

--- a/apps/pkcs8.c
+++ b/apps/pkcs8.c
@@ -227,9 +227,6 @@ int pkcs8_main(int argc, char **argv)
                           informat == FORMAT_UNDEF ? FORMAT_PEM : informat);
     if (in == NULL)
         goto end;
-    out = bio_open_owner(outfile, outformat, private);
-    if (out == NULL)
-        goto end;
 
     if (topk8) {
         pkey = load_key(infile, informat, 1, passin, e, "key");
@@ -240,6 +237,8 @@ int pkcs8_main(int argc, char **argv)
             ERR_print_errors(bio_err);
             goto end;
         }
+        if ((out = bio_open_owner(outfile, outformat, private)) == NULL)
+            goto end;
         if (nocrypt) {
             assert(private);
             if (outformat == FORMAT_PEM) {
@@ -361,6 +360,9 @@ int pkcs8_main(int argc, char **argv)
     }
 
     assert(private);
+    out = bio_open_owner(outfile, outformat, private);
+    if (out == NULL)
+        goto end;
     if (outformat == FORMAT_PEM) {
         if (traditional)
             PEM_write_bio_PrivateKey_traditional(out, pkey, NULL, NULL, 0,

--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -208,15 +208,15 @@ int pkey_main(int argc, char **argv)
         goto end;
     }
 
-    out = bio_open_owner(outfile, outformat, private);
-    if (out == NULL)
-        goto end;
-
     if (pubin)
         pkey = load_pubkey(infile, informat, 1, passin, e, "Public Key");
     else
         pkey = load_key(infile, informat, 1, passin, e, "key");
     if (pkey == NULL)
+        goto end;
+
+    out = bio_open_owner(outfile, outformat, private);
+    if (out == NULL)
         goto end;
 
 #ifndef OPENSSL_NO_EC

--- a/apps/pkeyparam.c
+++ b/apps/pkeyparam.c
@@ -97,9 +97,6 @@ int pkeyparam_main(int argc, char **argv)
     in = bio_open_default(infile, 'r', FORMAT_PEM);
     if (in == NULL)
         goto end;
-    out = bio_open_default(outfile, 'w', FORMAT_PEM);
-    if (out == NULL)
-        goto end;
     pkey = PEM_read_bio_Parameters_ex(in, NULL, app_get0_libctx(),
                                       app_get0_propq());
     if (pkey == NULL) {
@@ -107,6 +104,9 @@ int pkeyparam_main(int argc, char **argv)
         ERR_print_errors(bio_err);
         goto end;
     }
+    out = bio_open_default(outfile, 'w', FORMAT_PEM);
+    if (out == NULL)
+        goto end;
 
     if (check) {
         if (e == NULL)

--- a/doc/man1/openssl-dhparam.pod.in
+++ b/doc/man1/openssl-dhparam.pod.in
@@ -50,14 +50,15 @@ See L<openssl-format-options(1)> for details.
 
 =item B<-in> I<filename>
 
-This specifies the input filename to read parameters from or standard input if
+This specifies the input file to read parameters from or standard input if
 this option is not specified.
 
 =item B<-out> I<filename>
 
-This specifies the output filename parameters to. Standard output is used
-if this option is not present. The output filename should B<not> be the same
-as the input filename.
+This specifies the output file to write parameters to.
+Standard output is used if this option is not present.
+The output filename can be the same as the input filename,
+which leads to replacing the file contents in situ.
 
 =item B<-dsaparam>
 

--- a/doc/man1/openssl-dhparam.pod.in
+++ b/doc/man1/openssl-dhparam.pod.in
@@ -58,7 +58,8 @@ this option is not specified.
 This specifies the output file to write parameters to.
 Standard output is used if this option is not present.
 The output filename can be the same as the input filename,
-which leads to replacing the file contents in situ.
+which leads to replacing the file contents.
+Note that file I/O is not atomic. The output file is truncated and then written.
 
 =item B<-dsaparam>
 

--- a/doc/man1/openssl-dsaparam.pod.in
+++ b/doc/man1/openssl-dsaparam.pod.in
@@ -53,15 +53,16 @@ This is compatible with RFC 2459 B<DSS-Parms> structure.
 
 =item B<-in> I<filename>
 
-This specifies the input filename to read parameters from or standard input if
+This specifies the input file to read parameters from or standard input if
 this option is not specified. If the I<numbits> parameter is included then
 this option will be ignored.
 
 =item B<-out> I<filename>
 
-This specifies the output filename parameters to. Standard output is used
-if this option is not present. The output filename should B<not> be the same
-as the input filename.
+This specifies the output file to write parameters to. Standard output is used
+if this option is not present.
+The output filename can be the same as the input filename,
+which leads to replacing the file contents in situ.
 
 =item B<-noout>
 

--- a/doc/man1/openssl-dsaparam.pod.in
+++ b/doc/man1/openssl-dsaparam.pod.in
@@ -62,7 +62,8 @@ this option will be ignored.
 This specifies the output file to write parameters to. Standard output is used
 if this option is not present.
 The output filename can be the same as the input filename,
-which leads to replacing the file contents in situ.
+which leads to replacing the file contents.
+Note that file I/O is not atomic. The output file is truncated and then written.
 
 =item B<-noout>
 

--- a/doc/man1/openssl-ecparam.pod.in
+++ b/doc/man1/openssl-ecparam.pod.in
@@ -63,7 +63,8 @@ this option is not specified.
 This specifies the output filename parameters to. Standard output is used
 if this option is not present.
 The output filename can be the same as the input filename,
-which leads to replacing the file contents in situ.
+which leads to replacing the file contents.
+Note that file I/O is not atomic. The output file is truncated and then written.
 
 =item B<-noout>
 

--- a/doc/man1/openssl-ecparam.pod.in
+++ b/doc/man1/openssl-ecparam.pod.in
@@ -55,14 +55,15 @@ Parameters are encoded as B<EcpkParameters> as specified in IETF RFC 3279.
 
 =item B<-in> I<filename>
 
-This specifies the input filename to read parameters from or standard input if
+This specifies the input file to read parameters from or standard input if
 this option is not specified.
 
 =item B<-out> I<filename>
 
 This specifies the output filename parameters to. Standard output is used
-if this option is not present. The output filename should B<not> be the same
-as the input filename.
+if this option is not present.
+The output filename can be the same as the input filename,
+which leads to replacing the file contents in situ.
 
 =item B<-noout>
 

--- a/doc/man1/openssl-ocsp.pod.in
+++ b/doc/man1/openssl-ocsp.pod.in
@@ -24,10 +24,10 @@ B<openssl> B<ocsp>
 [B<-req_text>]
 [B<-resp_text>]
 [B<-text>]
-[B<-reqout> I<file>]
-[B<-respout> I<file>]
-[B<-reqin> I<file>]
-[B<-respin> I<file>]
+[B<-reqout> I<filename>]
+[B<-respout> I<filename>]
+[B<-reqin> I<filename>]
+[B<-respin> I<filename>]
 [B<-url> I<URL>]
 [B<-host> I<host>:I<port>]
 [B<-path> I<pathname>]
@@ -155,11 +155,13 @@ a nonce is automatically added specifying B<-no_nonce> overrides this.
 
 Print out the text form of the OCSP request, response or both respectively.
 
-=item B<-reqout> I<file>, B<-respout> I<file>
+=item B<-reqout> I<file>, B<-respout> I<filename>
 
-Write out the DER encoded certificate request or response to I<file>.
+Write out the DER-encoded OCSP request or response to I<filename>.
+The output filename can be the same as the input filename,
+which leads to replacing the file contents in situ.
 
-=item B<-reqin> I<file>, B<-respin> I<file>
+=item B<-reqin> I<file>, B<-respin> I<filename>
 
 Read OCSP request or response file from I<file>. These option are ignored
 if OCSP request or response creation is implied by other options (for example

--- a/doc/man1/openssl-ocsp.pod.in
+++ b/doc/man1/openssl-ocsp.pod.in
@@ -159,7 +159,8 @@ Print out the text form of the OCSP request, response or both respectively.
 
 Write out the DER-encoded OCSP request or response to I<filename>.
 The output filename can be the same as the input filename,
-which leads to replacing the file contents in situ.
+which leads to replacing the file contents.
+Note that file I/O is not atomic. The output file is truncated and then written.
 
 =item B<-reqin> I<file>, B<-respin> I<filename>
 

--- a/doc/man1/openssl-pkcs8.pod.in
+++ b/doc/man1/openssl-pkcs8.pod.in
@@ -93,7 +93,8 @@ see L<openssl-passphrase-options(1)>.
 
 This specifies the output file to write a key to or standard output by default.
 The output filename can be the same as the input filename,
-which leads to replacing the file contents in situ.
+which leads to replacing the file contents.
+Note that file I/O is not atomic. The output file is truncated and then written.
 
 If any encryption options are set and B<-passout> is not given
 then a pass phrase will be prompted for.

--- a/doc/man1/openssl-pkcs8.pod.in
+++ b/doc/man1/openssl-pkcs8.pod.in
@@ -79,9 +79,9 @@ key is written.
 
 =item B<-in> I<filename>
 
-This specifies the input filename to read a key from or standard input if this
+This specifies the input file to read a key from or standard input if this
 option is not specified. If the key is encrypted a pass phrase will be
-prompted for.
+prompted for unless B<-passin> is given.
 
 =item B<-passin> I<arg>, B<-passout> I<arg>
 
@@ -91,10 +91,13 @@ see L<openssl-passphrase-options(1)>.
 
 =item B<-out> I<filename>
 
-This specifies the output filename to write a key to or standard output by
-default. If any encryption options are set then a pass phrase will be
-prompted for. The output filename should B<not> be the same as the input
-filename.
+This specifies the output file to write a key to or standard output by default.
+The output filename can be the same as the input filename,
+which leads to replacing the file contents in situ.
+
+If any encryption options are set and B<-passout> is not given
+then a pass phrase will be prompted for.
+When password input is interrupted, the output file is not touched.
 
 =item B<-iter> I<count>
 

--- a/doc/man1/openssl-pkey.pod.in
+++ b/doc/man1/openssl-pkey.pod.in
@@ -69,8 +69,9 @@ or the public component of a key pair.
 
 =item B<-in> I<filename>|I<uri>
 
-This specifies the input to read a key from
+This specifies the input file to read a key from
 or standard input if this option is not specified.
+
 If the key input is encrypted and B<-passin> is not given
 a pass phrase will be prompted for.
 
@@ -100,11 +101,14 @@ If the input contains no public key but a private key, its public part is used.
 
 =item B<-out> I<filename>
 
-This specifies the output filename to save the encoded and/or text output of key
+This specifies the output file to save the encoded and/or text output of key
 or standard output if this option is not specified.
+The output filename can be the same as the input filename,
+which leads to replacing the file contents in situ.
+
 If any cipher option is set but no B<-passout> is given
 then a pass phrase will be prompted for.
-The output filename should B<not> be the same as the input filename.
+When password input is interrupted, the output file is not touched.
 
 =item B<-outform> B<DER>|B<PEM>
 

--- a/doc/man1/openssl-pkey.pod.in
+++ b/doc/man1/openssl-pkey.pod.in
@@ -104,7 +104,8 @@ If the input contains no public key but a private key, its public part is used.
 This specifies the output file to save the encoded and/or text output of key
 or standard output if this option is not specified.
 The output filename can be the same as the input filename,
-which leads to replacing the file contents in situ.
+which leads to replacing the file contents.
+Note that file I/O is not atomic. The output file is truncated and then written.
 
 If any cipher option is set but no B<-passout> is given
 then a pass phrase will be prompted for.

--- a/doc/man1/openssl-pkeyparam.pod.in
+++ b/doc/man1/openssl-pkeyparam.pod.in
@@ -43,7 +43,8 @@ this option is not specified.
 This specifies the output filename to write parameters to or standard output if
 this option is not specified.
 The output filename can be the same as the input filename,
-which leads to replacing the file contents in situ.
+which leads to replacing the file contents.
+Note that file I/O is not atomic. The output file is truncated and then written.
 
 =item B<-text>
 

--- a/doc/man1/openssl-pkeyparam.pod.in
+++ b/doc/man1/openssl-pkeyparam.pod.in
@@ -35,13 +35,15 @@ Print out a usage message.
 
 =item B<-in> I<filename>
 
-This specifies the input filename to read parameters from or standard input if
+This specifies the input file to read parameters from or standard input if
 this option is not specified.
 
 =item B<-out> I<filename>
 
 This specifies the output filename to write parameters to or standard output if
 this option is not specified.
+The output filename can be the same as the input filename,
+which leads to replacing the file contents in situ.
 
 =item B<-text>
 

--- a/test/recipes/15-test_dsaparam.t
+++ b/test/recipes/15-test_dsaparam.t
@@ -10,6 +10,8 @@ use strict;
 use warnings;
 
 use File::Spec;
+use File::Copy;
+use File::Compare qw/compare/;
 use OpenSSL::Glob;
 use OpenSSL::Test qw/:DEFAULT data_file/;
 use OpenSSL::Test::Utils;
@@ -66,7 +68,7 @@ plan skip_all => "DSA isn't supported in this build"
 my @valid = glob(data_file("valid", "*.pem"));
 my @invalid = glob(data_file("invalid", "*.pem"));
 
-my $num_tests = scalar @valid + scalar @invalid;
+my $num_tests = scalar @valid + scalar @invalid + 2;
 plan tests => $num_tests;
 
 foreach (@valid) {
@@ -76,3 +78,10 @@ foreach (@valid) {
 foreach (@invalid) {
     ok(!run(app([qw{openssl pkeyparam -noout -check -in}, $_])));
 }
+
+my $input = data_file("valid", "p3072_q256_t1864.pem");
+my $inout = "inout.pem";
+copy($input, $inout);
+ok(run(app(['openssl', 'dsaparam', '-in', $inout, '-out', $inout])),
+    "identical infile and outfile");
+ok(!compare($input, $inout), "converted file $inout did not change");

--- a/test/recipes/15-test_ecparam.t
+++ b/test/recipes/15-test_ecparam.t
@@ -11,7 +11,8 @@ use strict;
 use warnings;
 
 use File::Spec;
-use File::Compare qw/compare_text/;
+use File::Copy;
+use File::Compare qw/compare_text compare/;
 use OpenSSL::Glob;
 use OpenSSL::Test qw/:DEFAULT data_file srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
@@ -29,7 +30,7 @@ if (disabled("sm2")) {
     @valid = grep { !/sm2-.*\.pem/} @valid;
 }
 
-plan tests => 12;
+plan tests => 13;
 
 sub checkload {
     my $files = shift; # List of files
@@ -60,6 +61,19 @@ sub checkcompare {
             $in1 =~ s/\r\n/\n/g;
             $in2 =~ s/\r\n/\n/g;
             $in1 ne $in2}), "Original file $_ is the same as new one");
+    }
+}
+
+sub check_identical {
+    my $apps = shift; # List of applications
+
+    foreach (@$apps) {
+        my $inout = "$_.tst";
+        my $backup = "backup.tst";
+
+        copy($inout, $backup);
+        ok(run(app(['openssl', $_, '-in', $inout, '-out', $inout])));
+        ok(!compare($inout, $backup), "converted file $inout did not change");
     }
 }
 
@@ -118,6 +132,12 @@ subtest "Check ecparam does not change the parameter file on output" => sub {
 subtest "Check pkeyparam does not change the parameter file on output" => sub {
     plan tests => 2 * scalar(@valid);
     checkcompare(\@valid, "pkeyparam");
+};
+
+my @apps = ("ecparam", "pkeyparam");
+subtest "Check param apps do not garble infile identical to outfile" => sub {
+    plan tests => 2 * scalar(@apps);
+    check_identical(\@apps);
 };
 
 subtest "Check loading of fips and non-fips params" => sub {

--- a/test/recipes/15-test_pkey.t
+++ b/test/recipes/15-test_pkey.t
@@ -1,0 +1,129 @@
+#! /usr/bin/env perl
+# Copyright 2022-2024 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use OpenSSL::Test::Utils;
+use File::Copy;
+use File::Compare qw(compare);
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+
+setup("test_pkey");
+
+plan tests => 5;
+
+my @app = ('openssl', 'pkey');
+
+my $in_key = srctop_file('test', 'certs', 'root-key.pem');
+my $pass = 'pass:password';
+
+subtest "=== pkey typical en-/decryption (using AES256-CBC) ===" => sub {
+    plan tests => 4;
+
+    my $encrypted_key = 'encrypted_key.pem';
+    my $decrypted_key = 'decrypted_key.pem';
+
+    ok(run(app([@app, '-aes256', '-in', $in_key, '-out', $encrypted_key,
+                '-passout', $pass])),
+       "encrypt key (using aes-256-cbc)");
+
+    ok(run(app(['openssl', 'asn1parse', '-in', $encrypted_key,
+                '-offset', '34', '-length', '18'])), # incl. 2 bytes header
+       "encrypted key has default PBKDF2 PARAM 'salt length' 16");
+
+    ok(run(app([@app, '-in', $encrypted_key, '-out', $decrypted_key,
+                '-passin', $pass])),
+       "decrypt key");
+    is(compare($in_key, $decrypted_key), 0,
+       "Same file contents after encrypting and decrypting in separate files");
+};
+
+subtest "=== pkey handling of identical input and output files (using 3DES) and -traditional ===" => sub {
+    plan skip_all => "DES not supported in this build" if disabled("des");
+    plan tests => 4;
+
+    my $inout = 'inout.pem';
+
+    copy($in_key, $inout);
+    ok(run(app([@app, '-des3', '-traditional', '-in', $inout, '-out', $inout,
+                '-passout', $pass])),
+       "encrypt using identical infile and outfile");
+
+    sub file_line_contains { grep /$_[0]/, ((open F, $_[1]), <F>, close F) }
+    ok(file_line_contains("DEK-Info: DES-EDE3-CBC,", $inout),
+       "traditional encoding contains \"DEK-Info: DES-EDE3-CBC,\"");
+
+    ok(run(app([@app, '-in', $inout, '-out', $inout, '-passin', $pass])),
+       "decrypt using identical infile and outfile");
+    is(compare($in_key, $inout), 0,
+       "Same file contents after encrypting and decrypting using same file");
+};
+
+subtest "=== pkey handling of public keys (Ed25519) ===" => sub {
+    plan skip_all => "ECX not supported inthis build" if disabled("ecx");
+    plan tests => 6;
+
+    my $in_ed_key = srctop_file('test', 'certs', 'root-ed25519.privkey.pem');
+    my $in_pubkey = srctop_file('test', 'certs', 'root-ed25519.pubkey.pem');
+
+    my $pub_out1 = 'pub1.pem';
+    ok(run(app([@app, '-in', $in_ed_key, '-pubout', '-out', $pub_out1])),
+       "extract public key");
+    is(compare($in_pubkey, $pub_out1), 0,
+       "extracted public key is same as original public key");
+
+    my $pub_out2 = 'pub2.pem';
+    ok(run(app([@app, '-in', $in_pubkey, '-pubin', '-pubout', '-out', $pub_out2])),
+       "read public key from pubfile");
+    is(compare($in_pubkey, $pub_out2), 0,
+       "public key read using pubfile is same as original public key");
+
+    my $pub_out3 = 'pub3.pem';
+    ok(run(app([@app, '-in', $in_ed_key, '-pubin', '-pubout', '-out', $pub_out3])),
+       "extract public key from pkey file with -pubin");
+    is(compare($in_pubkey, $pub_out3), 0,
+       "public key extraced from pkey file with -pubin is same as original");
+};
+
+
+subtest "=== pkey handling of DER encoding ===" => sub {
+    plan tests => 4;
+
+    my $der_out = 'key.der';
+    my $pem_out = 'key.pem';
+    ok(run(app([@app, '-in', $in_key, '-outform', 'DER',
+                 '-out', $der_out])),
+       "write DER-encoded pkey");
+
+    ok(run(app(['openssl', 'asn1parse', '-in', $der_out, '-inform', 'DER',
+                 '-offset', '268', '-length', '5'])), # incl. 2 bytes header
+       "see if length of the modulus encoding is included");
+
+    ok(run(app([@app, '-in', $der_out, '-inform', 'DER',
+                 '-out', $pem_out])),
+       "read DER-encoded key");
+    is(compare($in_key, $pem_out), 0,
+       "Same file contents after converting to DER and back");
+};
+
+subtest "=== pkey text output ===" => sub {
+    plan tests => 3;
+
+    ok((grep /BEGIN PRIVATE KEY/,
+        run(app([@app, '-in', $in_key, '-text']), capture => 1)),
+        "pkey text output contains PEM header");
+
+    ok(!(grep /BEGIN PRIVATE KEY/,
+        run(app([@app, '-in', $in_key, '-text', '-noout']), capture => 1)),
+        "pkey text output with -noout does not contain PEM header");
+
+    ok((grep /Private-Key:/,
+        run(app([@app, '-in', $in_key, '-text', '-noout']), capture => 1)),
+        "pkey text output (even with -noout) contains \"Private-Key:\"");
+};

--- a/test/recipes/25-test_pkcs8.t
+++ b/test/recipes/25-test_pkcs8.t
@@ -10,15 +10,29 @@ use strict;
 use warnings;
 
 use OpenSSL::Test::Utils;
-use File::Compare qw(compare_text);
+use File::Copy;
+use File::Compare qw(compare_text compare);
 use OpenSSL::Test qw/:DEFAULT srctop_file ok_nofips is_nofips/;
 
 setup("test_pkcs8");
 
-plan tests => 15;
+plan tests => 18;
+
+my $pc5_key = srctop_file('test', 'certs', 'pc5-key.pem');
+
+my $inout = 'inout.pem';
+copy($pc5_key, $inout);
+ok(run(app(['openssl', 'pkcs8', '-topk8', '-in', $inout,
+            '-out', $inout, '-passout', 'pass:password'])),
+   "identical infile and outfile, to PKCS#8");
+ok(run(app(['openssl', 'pkcs8', '-in', $inout,
+            '-out', $inout, '-passin', 'pass:password'])),
+   "identical infile and outfile, from PKCS#8");
+is(compare($pc5_key, $inout), 0,
+   "Same file contents after converting forth and back");
 
 ok(run(app(([ 'openssl', 'pkcs8', '-topk8',
-              '-in', srctop_file('test', 'certs', 'pc5-key.pem'),
+              '-in', $pc5_key,
               '-out', 'pbkdf2_default_saltlen.pem',
               '-passout', 'pass:password']))),
    "Convert a private key to PKCS5 v2.0 format using PBKDF2 with the default saltlen");
@@ -35,7 +49,7 @@ SKIP: {
         if disabled("scrypt");
 
     ok(run(app(([ 'openssl', 'pkcs8', '-topk8',
-                  '-in', srctop_file('test', 'certs', 'pc5-key.pem'),
+                  '-in', $pc5_key,
                   '-scrypt',
                   '-out', 'scrypt_default_saltlen.pem',
                   '-passout', 'pass:password']))),
@@ -49,7 +63,7 @@ SKIP: {
        "Check the default size of the SCRYPT PARAM 'salt length' = 16");
 
     ok(run(app(([ 'openssl', 'pkcs8', '-topk8',
-                  '-in', srctop_file('test', 'certs', 'pc5-key.pem'),
+                  '-in', $pc5_key,
                   '-scrypt',
                   '-saltlen', '8',
                   '-out', 'scrypt_64bit_saltlen.pem',
@@ -69,7 +83,7 @@ SKIP: {
         if disabled('legacy') || disabled("des");
 
     ok(run(app(([ 'openssl', 'pkcs8', '-topk8',
-                  '-in', srctop_file('test', 'certs', 'pc5-key.pem'),
+                  '-in', $pc5_key,
                   '-v1', "PBE-MD5-DES",
                   '-provider', 'legacy',
                   '-provider', 'default',
@@ -83,7 +97,7 @@ SKIP: {
        "Check the default size of the PBE PARAM 'salt length' = 8");
 
     ok(run(app(([ 'openssl', 'pkcs8', '-topk8',
-                  '-in', srctop_file('test', 'certs', 'pc5-key.pem'),
+                  '-in', $pc5_key,
                   '-v1', "PBE-MD5-DES",
                   '-saltlen', '16',
                   '-provider', 'legacy',
@@ -100,7 +114,7 @@ SKIP: {
 
 
 ok(run(app(([ 'openssl', 'pkcs8', '-topk8',
-              '-in', srctop_file('test', 'certs', 'pc5-key.pem'),
+              '-in', $pc5_key,
               '-saltlen', '8',
               '-out', 'pbkdf2_64bit_saltlen.pem',
               '-passout', 'pass:password']))),


### PR DESCRIPTION
When using e.g. `openssl pkey -in test.priv.pem -aes128 -out test.priv.pem`
the file was reset to zero length before reading its contents.

This was recently [reported](https://marc.info/?l=openssl-users&m=172737274321305&w=2) on the openssl-users mailing list.
