### PR TITLE
unit test to test timeout in 3.1 and 3.0 branches

### DIFF
--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2883,4 +2883,6 @@ static ossl_unused ossl_inline void ssl_tsan_counter(const SSL_CTX *ctx,
     }
 }
 
+void ssl_session_get_calc_timeout(SSL_SESSION *, time_t *, int *);
+void ssl_session_set_times(SSL_SESSION *, time_t, time_t);
 #endif

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -91,6 +91,19 @@ void ssl_session_calculate_timeout(SSL_SESSION *ss)
      */
 }
 
+void ssl_session_get_calc_timeout(SSL_SESSION *ss, time_t *calc_time, int *ovf)
+{
+    *calc_time = ss->calc_timeout;
+    *ovf = ss->timeout_ovf;
+}
+
+void ssl_session_set_times(SSL_SESSION *ss, time_t time, time_t timeout)
+{
+    ss->time = time;
+    ss->timeout = timeout;
+    ss->timeout_ovf = 0;
+}
+
 /*
  * SSL_get_session() and SSL_get1_session() are problematic in TLS1.3 because,
  * unlike in earlier protocol versions, the session ticket may not have been

--- a/test/build.info
+++ b/test/build.info
@@ -616,7 +616,7 @@ IF[{- !$disabled{tests} -}]
                      rsa_sp800_56b_test bn_internal_test ecdsatest rsa_test \
                      rc2test rc4test rc5test hmactest ffc_internal_test \
                      asn1_dsa_internal_test dsatest dsa_no_digest_size_test \
-                     dhtest ssl_old_test
+                     dhtest ssl_old_test ssl_timeout_test
 
     IF[{- !$disabled{poly1305} -}]
       PROGRAMS{noinst}=poly1305_internal_test
@@ -800,6 +800,10 @@ IF[{- !$disabled{tests} -}]
     SOURCE[ssl_old_test]=ssl_old_test.c helpers/predefined_dhparams.c
     INCLUDE[ssl_old_test]=.. ../include ../apps/include
     DEPEND[ssl_old_test]=../libcrypto.a ../libssl.a libtestutil.a
+
+    SOURCE[ssl_timeout_test]=ssl_timeout_test.c
+    INCLUDE[ssl_timeout_test]=.. ../include ../apps/include
+    DEPEND[ssl_timeout_test]=../libcrypto.a ../libssl.a libtestutil.a
 
     PROGRAMS{noinst}=ext_internal_test
     SOURCE[ext_internal_test]=ext_internal_test.c

--- a/test/recipes/90-test_ssl_timeout.t
+++ b/test/recipes/90-test_ssl_timeout.t
@@ -1,0 +1,17 @@
+#! /usr/bin/env perl
+# Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use OpenSSL::Test::Utils;
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+
+my $test_name = "test_ssl_timeout";
+setup($test_name);
+
+plan tests => 1;
+
+ok(run(test(["ssl_timeout_test"])), "running ssl_timeout_test");

--- a/test/ssl_timeout_test.c
+++ b/test/ssl_timeout_test.c
@@ -1,0 +1,344 @@
+/*
+ * Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/crypto.h>
+#include <openssl/ssl.h>
+#include <ssl/ssl_local.h>
+
+#include "testutil.h"
+#include "testutil/output.h"
+
+#ifndef B_TRUE
+# define B_TRUE (1 == 1)
+#endif
+
+#ifndef B_FALSE
+# define B_FALSE (1 != 1)
+#endif
+
+struct sample {
+    time_t time;
+    time_t timeout;
+    time_t expected;
+    int expected_ovf;
+};
+
+struct sample_64 {
+    uint64_t time;
+    uint64_t timeout;
+    uint64_t expected;
+    int expected_ovf;
+};
+
+static struct sample_64 test_sample_64[] = {
+    {
+        0xfffffffffffff3ff,
+        0x100,
+        0xfffffffffffff4ff,
+        B_FALSE
+    },
+    {
+        0x100,
+        0xfffffffffffff3ff,
+        0x100,
+        B_FALSE
+    },
+    {
+        0x8000000000000000,
+        0x7fffffffffffffff,
+        0xffffffffffffffff,
+        B_FALSE
+    },
+    {
+        0x7fffffffffffffff,
+        0x8000000000000000,
+        0x7fffffffffffffff,
+        B_FALSE
+    },
+    {
+        0xffffffffffff3fff,
+	0x100,
+        0xffffffffffff40ff,
+	B_FALSE
+    },
+    {
+	0x100,
+        0xffffffffffff3fff,
+        0x100,
+	B_FALSE
+    },
+    {
+        0xffffffffffffffff,
+        0x0,
+        0xffffffffffffffff,
+        B_FALSE
+    },
+    {
+        0x0,
+        0xffffffffffffffff,
+        0x0,
+        B_FALSE
+    },
+    {
+        0xffffffffffffffff,
+        0x100,
+        0xff,
+        B_FALSE
+    },
+    {
+        0x100,
+        0xffffffffffffffff,
+        0x100,
+        B_FALSE
+    },
+    {
+        0x7fffffffffffffff,
+        0x7fffffffffffffff,
+        0xfffffffffffffffe,
+        B_TRUE
+    },
+    {
+        0x20,
+        0x7fffffffffffffff,
+        0x800000000000001f,
+        B_TRUE
+    },
+    {
+        0x7fffffffffffffff,
+        0x20,
+        0x800000000000001f,
+        B_TRUE
+    },
+    {
+        0x130,
+        0x66f3cafa,
+        0x66f3cc2a,
+        B_FALSE
+    },
+    {
+        0x66f3cafa,
+        0x130,
+        0x66f3cc2a,
+        B_FALSE
+    },
+    {
+        0x66f3caf8,
+        0x130,
+        0x66f3cc28,
+        B_FALSE
+    },
+    {
+        0x130,
+        0x66f3caf8,
+        0x66f3cc28,
+        B_FALSE
+    },
+    {
+        0x2020202020202020,
+        0xffffffffffffffff,
+        0x2020202020202020,
+        B_FALSE
+    },
+    {
+        0xffffffffffffffff,
+        0x2020202020202020,
+        0x202020202020201f,
+        B_FALSE
+    },
+    { 0 }
+};
+
+static struct sample test_sample_32[] = {
+    {
+        0xfffff3ff,
+        0x100,
+        0xfffff4ff,
+        B_FALSE
+    },
+    {
+        0x100,
+        0xfffff3ff,
+        0x100,
+        B_FALSE
+    },
+    {
+        0x80000000,
+        0x7fffffff,
+        0xffffffff,
+        B_FALSE
+    },
+    {
+        0x7fffffff,
+        0x80000000,
+        0x7fffffff,
+        B_FALSE
+    },
+    {
+        0xffff3fff,
+	0x100,
+        0xffff40ff,
+	B_FALSE
+    },
+    {
+	0x100,
+        0xffff3fff,
+        0x100,
+	B_FALSE
+    },
+    {
+        0xffffffff,
+        0x0,
+        0xffffffff,
+        B_FALSE
+    },
+    {
+        0x0,
+        0xffffffff,
+        0x0,
+        B_FALSE
+    },
+    {
+        0xffffffff,
+        0x100,
+        0xff,
+        B_FALSE
+    },
+    {
+        0x100,
+        0xffffffff,
+        0x100,
+        B_FALSE
+    },
+    {
+        0x7fffffff,
+        0x7fffffff,
+        0xfffffffe,
+        B_TRUE
+    },
+    {
+        0x20,
+        0x7fffffff,
+        0x8000001f,
+        B_TRUE
+    },
+    {
+        0x7fffffff,
+        0x20,
+        0x8000001f,
+        B_TRUE
+    },
+    {
+        0x130,
+        0x66f3cafa,
+        0x66f3cc2a,
+        B_FALSE
+    },
+    {
+        0x66f3cafa,
+        0x130,
+        0x66f3cc2a,
+        B_FALSE
+    },
+    {
+        0x66f3caf8,
+        0x130,
+        0x66f3cc28,
+        B_FALSE
+    },
+    {
+        0x130,
+        0x66f3caf8,
+        0x66f3cc28,
+        B_FALSE
+    },
+    {
+        0x20202020,
+        0xffffffff,
+        0x20202020,
+        B_FALSE
+    },
+    {
+        0xffffffff,
+        0x20202020,
+        0x2020201f,
+        B_FALSE
+    },
+    { 0 }
+};
+
+static int test_ssl_timeout(void)
+{
+    int i = 0;
+    SSL_SESSION *s;
+    SSL_CTX *ctx;
+    OSSL_LIB_CTX *libctx;
+    time_t result;
+    int overflow;
+    int testresult = 1;
+    struct sample *test_sample;
+
+    libctx = OSSL_LIB_CTX_new();
+    if (!TEST_ptr(libctx))
+        return 0;
+
+    ctx = SSL_CTX_new_ex(libctx, NULL, TLS_method());
+    if (!TEST_ptr(ctx)) {
+        OSSL_LIB_CTX_free(libctx);
+        return 0;
+    }
+
+    s = SSL_SESSION_new();
+    if (!TEST_ptr(ctx)) {
+        SSL_CTX_free(ctx);
+        OSSL_LIB_CTX_free(libctx);
+        return 0;
+    }
+
+    if (sizeof(time_t) == 8)
+        test_sample = (struct sample *)test_sample_64;
+    else
+        test_sample = test_sample_32;
+
+    while (!((test_sample[i].time == 0) && (test_sample[i].timeout == 0))) {
+        ssl_session_set_times(s, test_sample[i].time, test_sample[i].timeout);
+        ssl_session_calculate_timeout(s);
+        ssl_session_get_calc_timeout(s, &result, &overflow);
+        if (!TEST_time_t_eq(result, test_sample[i].expected)) {
+            testresult = 0;
+            TEST_info("test_ssl_timeout (%d) fails for %p + %p = %p, got %p\n",
+                i, (void *)test_sample[i].time, (void *)test_sample[i].timeout,
+                (void *)test_sample[i].expected, (void *)result);
+        }
+        if (!TEST_int_eq(overflow, test_sample[i].expected_ovf)) {
+            TEST_info("test_ssl_timeout (%d) failed to detect overflow for "
+                      "%p + %p = %p (%s), got %p (%s)\n",
+                i, (void *)test_sample[i].time, (void *)test_sample[i].timeout,
+                (void *)test_sample[i].expected,
+                (test_sample[i].expected_ovf ? "with overflow" : "no overflow"),
+                (void *)result,
+                (overflow ? "with overflow" : "no overflow"));
+            testresult = 0;
+        }
+        i++;
+    }
+
+    SSL_SESSION_free(s);
+    SSL_CTX_free(ctx);
+    OSSL_LIB_CTX_free(libctx);
+
+    return testresult;
+}
+
+
+int setup_tests(void)
+{
+    ADD_TEST(test_ssl_timeout);
+
+    return 1;
+}


### PR DESCRIPTION
Earlier fix to address undefined behavior reported by oss-fuzz [1] is incomplete because fuzzer found yet another issue [2]. The new report made me to
look at ssl_calc_timeout() more closely.

The function is covered by sslapitest unit test,
however it's not easy to extend sslapitest by
all edgecases found by asn1 fuzzer.

The code in this PR implements simple unit test
which excercises ssl_calc_timeout() for various
inputs (time and timeout). The expected values
were calculated by original version of ssl_calc_timeout() (before a85eb03 [3] got integrated).

The test here helped me to come up with better
method to safely calculate timeout without altering behavior of original function.

I don't intend to integrate those changes unless people here will deem tests are
worth enough to keep them in repository for 3.1 and 3.0 branches.

Also failures reported by `90-test_ssl_timeout.t` are expected. To fix those
failures one need to bring changes from #25564 

[1] https://issues.oss-fuzz.com/issues/42537990
[2] https://issues.oss-fuzz.com/issues/42538363
[3] https://github.com/openssl/openssl/commit/a85eb03a5ccaccd7b18f979d4dfb5cc76bb61cea
