### PR TITLE
FIPS self test signature update

### DIFF
--- a/crypto/evp/build.info
+++ b/crypto/evp/build.info
@@ -1,7 +1,7 @@
 LIBS=../../libcrypto
 $COMMON=digest.c evp_enc.c evp_lib.c evp_fetch.c evp_utils.c \
         mac_lib.c mac_meth.c keymgmt_meth.c keymgmt_lib.c kdf_lib.c kdf_meth.c \
-        m_sigver.c pmeth_lib.c signature.c p_lib.c pmeth_gn.c exchange.c \
+        pmeth_lib.c signature.c p_lib.c pmeth_gn.c exchange.c \
         evp_rand.c asymcipher.c kem.c dh_support.c ec_support.c pmeth_check.c
 
 SOURCE[../../libcrypto]=$COMMON\
@@ -16,7 +16,7 @@ SOURCE[../../libcrypto]=$COMMON\
         e_aes_cbc_hmac_sha1.c e_aes_cbc_hmac_sha256.c e_rc4_hmac_md5.c \
         e_chacha20_poly1305.c \
         legacy_sha.c ctrl_params_translate.c \
-        cmeth_lib.c
+        cmeth_lib.c m_sigver.c
 
 # Diverse type specific ctrl functions.  They are kinda sorta legacy, kinda
 # sorta not.

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -395,6 +395,7 @@ int EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *data, size_t count)
     if (ctx->pctx != NULL
             && EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx->pctx)
             && ctx->pctx->op.sig.algctx != NULL) {
+#ifndef FIPS_MODULE
         /*
          * Prior to OpenSSL 3.0 EVP_DigestSignUpdate() and
          * EVP_DigestVerifyUpdate() were just macros for EVP_DigestUpdate().
@@ -407,6 +408,7 @@ int EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *data, size_t count)
             return EVP_DigestSignUpdate(ctx, data, count);
         if (ctx->pctx->operation == EVP_PKEY_OP_VERIFYCTX)
             return EVP_DigestVerifyUpdate(ctx, data, count);
+#endif
         ERR_raise(ERR_LIB_EVP, EVP_R_UPDATE_ERROR);
         return 0;
     }

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -16,13 +16,11 @@
 #include "internal/numbers.h"   /* includes SIZE_MAX */
 #include "evp_local.h"
 
-#ifndef FIPS_MODULE
 static int update(EVP_MD_CTX *ctx, const void *data, size_t datalen)
 {
     ERR_raise(ERR_LIB_EVP, EVP_R_ONLY_ONESHOT_SUPPORTED);
     return 0;
 }
-#endif
 
 /*
  * If we get the "NULL" md then the name comes back as "UNDEF". We want to use
@@ -58,10 +56,8 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
         reinit = 0;
         if (e == NULL)
             ctx->pctx = EVP_PKEY_CTX_new_from_pkey(libctx, pkey, props);
-#ifndef FIPS_MODULE
         else
             ctx->pctx = EVP_PKEY_CTX_new(pkey, e);
-#endif
     }
     if (ctx->pctx == NULL)
         return 0;
@@ -243,11 +239,6 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
             if (ctx->fetched_digest != NULL) {
                 ctx->digest = ctx->reqdigest = ctx->fetched_digest;
             } else {
-#ifdef FIPS_MODULE
-                (void)ERR_clear_last_mark();
-                ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
-                goto err;
-#else
                 /* legacy engine support : remove the mark when this is deleted */
                 ctx->reqdigest = ctx->digest = EVP_get_digestbyname(mdname);
                 if (ctx->digest == NULL) {
@@ -255,7 +246,6 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                     ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
                     goto err;
                 }
-#endif
             }
             (void)ERR_pop_to_mark();
         }
@@ -301,9 +291,6 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
     EVP_KEYMGMT_free(tmp_keymgmt);
     tmp_keymgmt = NULL;
 
-#ifdef FIPS_MODULE
-    return 0;
-#else
     if (type == NULL && mdname != NULL)
         type = evp_get_digestbyname_ex(locpctx->libctx, mdname);
 
@@ -366,12 +353,9 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
         ctx->pctx->flag_call_digest_custom = 1;
 
     ret = 1;
-#endif
  end:
-#ifndef FIPS_MODULE
     if (ret > 0)
         ret = evp_pkey_ctx_use_cached_data(locpctx);
-#endif
 
     EVP_KEYMGMT_free(tmp_keymgmt);
     return ret > 0 ? 1 : 0;
@@ -386,14 +370,12 @@ int EVP_DigestSignInit_ex(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                           params);
 }
 
-#ifndef FIPS_MODULE
 int EVP_DigestSignInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                        const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey)
 {
     return do_sigver_init(ctx, pctx, type, NULL, NULL, NULL, e, pkey, 0,
                           NULL);
 }
-#endif
 
 int EVP_DigestVerifyInit_ex(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                             const char *mdname, OSSL_LIB_CTX *libctx,
@@ -404,14 +386,12 @@ int EVP_DigestVerifyInit_ex(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                           params);
 }
 
-#ifndef FIPS_MODULE
 int EVP_DigestVerifyInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                          const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey)
 {
     return do_sigver_init(ctx, pctx, type, NULL, NULL, NULL, e, pkey, 1,
                           NULL);
 }
-#endif /* FIPS_MODULE */
 
 int EVP_DigestSignUpdate(EVP_MD_CTX *ctx, const void *data, size_t dsize)
 {
@@ -437,10 +417,6 @@ int EVP_DigestSignUpdate(EVP_MD_CTX *ctx, const void *data, size_t dsize)
                                                       data, dsize);
 
  legacy:
-#ifdef FIPS_MODULE
-    ERR_raise(ERR_LIB_EVP, EVP_R_UPDATE_ERROR);
-    return 0;
-#else
     if (pctx != NULL) {
         /* do_sigver_init() checked that |digest_custom| is non-NULL */
         if (pctx->flag_call_digest_custom
@@ -450,7 +426,6 @@ int EVP_DigestSignUpdate(EVP_MD_CTX *ctx, const void *data, size_t dsize)
     }
 
     return EVP_DigestUpdate(ctx, data, dsize);
-#endif
 }
 
 int EVP_DigestVerifyUpdate(EVP_MD_CTX *ctx, const void *data, size_t dsize)
@@ -477,10 +452,6 @@ int EVP_DigestVerifyUpdate(EVP_MD_CTX *ctx, const void *data, size_t dsize)
                                                         data, dsize);
 
  legacy:
-#ifdef FIPS_MODULE
-    ERR_raise(ERR_LIB_EVP, EVP_R_UPDATE_ERROR);
-    return 0;
-#else
     if (pctx != NULL) {
         /* do_sigver_init() checked that |digest_custom| is non-NULL */
         if (pctx->flag_call_digest_custom
@@ -490,15 +461,12 @@ int EVP_DigestVerifyUpdate(EVP_MD_CTX *ctx, const void *data, size_t dsize)
     }
 
     return EVP_DigestUpdate(ctx, data, dsize);
-#endif
 }
 
 int EVP_DigestSignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
                         size_t *siglen)
 {
-#ifndef FIPS_MODULE
     int sctx = 0;
-#endif
     int r = 0;
     EVP_PKEY_CTX *dctx = NULL, *pctx = ctx->pctx;
 
@@ -513,14 +481,12 @@ int EVP_DigestSignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
             || pctx->op.sig.signature == NULL)
         goto legacy;
 
-#ifndef FIPS_MODULE
     if (sigret != NULL && (ctx->flags & EVP_MD_CTX_FLAG_FINALISE) == 0) {
         /* try dup */
         dctx = EVP_PKEY_CTX_dup(pctx);
         if (dctx != NULL)
             pctx = dctx;
     }
-#endif
     r = pctx->op.sig.signature->digest_sign_final(pctx->op.sig.algctx,
                                                   sigret, siglen,
                                                   sigret == NULL ? 0 : *siglen);
@@ -531,10 +497,6 @@ int EVP_DigestSignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
     return r;
 
  legacy:
-#ifdef FIPS_MODULE
-    ERR_raise(ERR_LIB_EVP, EVP_R_UPDATE_ERROR);
-    return 0;
-#else
     if (pctx == NULL || pctx->pmeth == NULL) {
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         return 0;
@@ -606,7 +568,6 @@ int EVP_DigestSignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
         }
     }
     return 1;
-#endif
 }
 
 int EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sigret, size_t *siglen,
@@ -631,11 +592,6 @@ int EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sigret, size_t *siglen,
                                                        sigret == NULL ? 0 : *siglen,
                                                        tbs, tbslen);
         }
-#ifdef FIPS_MODULE
-    }
-    ERR_raise(ERR_LIB_EVP, EVP_R_FINAL_ERROR);
-    return 0;
-#else
     } else {
         /* legacy */
         if (ctx->pctx->pmeth != NULL && ctx->pctx->pmeth->digestsign != NULL)
@@ -645,17 +601,14 @@ int EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sigret, size_t *siglen,
     if (sigret != NULL && EVP_DigestSignUpdate(ctx, tbs, tbslen) <= 0)
         return 0;
     return EVP_DigestSignFinal(ctx, sigret, siglen);
-#endif
 }
 
 int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig,
                           size_t siglen)
 {
-#ifndef FIPS_MODULE
     int vctx = 0;
     unsigned int mdlen = 0;
     unsigned char md[EVP_MAX_MD_SIZE];
-#endif
     int r = 0;
     EVP_PKEY_CTX *dctx = NULL, *pctx = ctx->pctx;
 
@@ -670,14 +623,12 @@ int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig,
             || pctx->op.sig.signature == NULL)
         goto legacy;
 
-#ifndef FIPS_MODULE
     if ((ctx->flags & EVP_MD_CTX_FLAG_FINALISE) == 0) {
         /* try dup */
         dctx = EVP_PKEY_CTX_dup(pctx);
         if (dctx != NULL)
             pctx = dctx;
     }
-#endif
     r = pctx->op.sig.signature->digest_verify_final(pctx->op.sig.algctx,
                                                     sig, siglen);
     if (dctx == NULL)
@@ -687,10 +638,6 @@ int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig,
     return r;
 
  legacy:
-#ifdef FIPS_MODULE
-    ERR_raise(ERR_LIB_EVP, EVP_R_UPDATE_ERROR);
-    return 0;
-#else
     if (pctx == NULL || pctx->pmeth == NULL) {
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         return 0;
@@ -730,7 +677,6 @@ int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig,
     if (vctx || !r)
         return r;
     return EVP_PKEY_verify(pctx, sig, siglen, md, mdlen);
-#endif
 }
 
 int EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sigret,
@@ -753,11 +699,6 @@ int EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sigret,
                                                          sigret, siglen,
                                                          tbs, tbslen);
         }
-#ifdef FIPS_MODULE
-    }
-    ERR_raise(ERR_LIB_EVP, EVP_R_FINAL_ERROR);
-    return 0;
-#else
     } else {
         /* legacy */
         if (ctx->pctx->pmeth != NULL && ctx->pctx->pmeth->digestverify != NULL)
@@ -766,5 +707,4 @@ int EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sigret,
     if (EVP_DigestVerifyUpdate(ctx, tbs, tbslen) <= 0)
         return -1;
     return EVP_DigestVerifyFinal(ctx, sigret, siglen);
-#endif
 }

--- a/providers/fips/self_test_data.inc
+++ b/providers/fips/self_test_data.inc
@@ -56,7 +56,7 @@ typedef struct st_kat_st {
 /* FIPS 140-3 only allows DSA verification for legacy purposes */
 #define SIGNATURE_MODE_VERIFY_ONLY 1
 #define SIGNATURE_MODE_SIGN_ONLY   2
-#define SIGNATURE_MODE_ONESHOT     4
+#define SIGNATURE_MODE_DIGESTED    4
 
 typedef ST_KAT ST_KAT_DIGEST;
 typedef struct st_kat_cipher_st {
@@ -117,8 +117,8 @@ typedef struct st_kat_kas_st {
 
 typedef struct st_kat_sign_st {
     const char *desc;
-    const char *algorithm;
-    const char *mdalgorithm;
+    const char *keytype;
+    const char *sigalgorithm;
     int mode;
     const ST_KAT_PARAM *key;
     const unsigned char *msg;
@@ -1651,7 +1651,7 @@ static const unsigned char sig_kat_persstr[] = {
 static const ST_KAT_SIGN st_kat_sign_tests[] = {
     {
         OSSL_SELF_TEST_DESC_SIGN_RSA,
-        "RSA", "SHA-256", 0,
+        "RSA", "RSA-SHA256", 0,
         rsa_crt_key,
         ITM_STR(rsa_sig_msg),
         ITM(sig_kat_entropyin),
@@ -1662,7 +1662,7 @@ static const ST_KAT_SIGN st_kat_sign_tests[] = {
 #ifndef OPENSSL_NO_EC
     {
         OSSL_SELF_TEST_DESC_SIGN_ECDSA,
-        "EC", "SHA-256", 0,
+        "EC", "ECDSA-SHA256", 0,
         ecdsa_prime_key,
         ITM_STR(rsa_sig_msg),
         ITM(sig_kat_entropyin),
@@ -1673,7 +1673,7 @@ static const ST_KAT_SIGN st_kat_sign_tests[] = {
 # ifndef OPENSSL_NO_EC2M
     {
         OSSL_SELF_TEST_DESC_SIGN_ECDSA,
-        "EC", "SHA-256", 0,
+        "EC", "ECDSA-SHA256", 0,
         ecdsa_bin_key,
         ITM_STR(rsa_sig_msg),
         ITM(sig_kat_entropyin),
@@ -1685,7 +1685,7 @@ static const ST_KAT_SIGN st_kat_sign_tests[] = {
 # ifndef OPENSSL_NO_ECX
     {
         OSSL_SELF_TEST_DESC_SIGN_EDDSA,
-        "ED448", NULL, SIGNATURE_MODE_ONESHOT,
+        "ED448", "ED448", 0,
         ed448_key,
         ITM(ecx_sig_msg),
         NULL, 0, NULL, 0, NULL, 0,
@@ -1693,7 +1693,7 @@ static const ST_KAT_SIGN st_kat_sign_tests[] = {
     },
     {
         OSSL_SELF_TEST_DESC_SIGN_EDDSA,
-        "ED25519", NULL, SIGNATURE_MODE_ONESHOT,
+        "ED25519", "ED25519", 0,
         ed25519_key,
         ITM(ecx_sig_msg),
         NULL, 0, NULL, 0, NULL, 0,
@@ -1704,7 +1704,7 @@ static const ST_KAT_SIGN st_kat_sign_tests[] = {
 #ifndef OPENSSL_NO_DSA
     {
         OSSL_SELF_TEST_DESC_SIGN_DSA,
-        "DSA", "SHA-256", SIGNATURE_MODE_VERIFY_ONLY,
+        "DSA", "DSA-SHA256", SIGNATURE_MODE_VERIFY_ONLY,
         dsa_key,
         ITM_STR(rsa_sig_msg),
         ITM(sig_kat_entropyin),

--- a/providers/fips/self_test_kats.c
+++ b/providers/fips/self_test_kats.c
@@ -514,14 +514,14 @@ static int self_test_digest_sign(const ST_KAT_SIGN *t,
         siglen = t->sig_expected_len;
     } else {
         if (digested) {
-             if (EVP_PKEY_sign_init_ex2(ctx, sigalg, paramsinit) <= 0)
-                 goto err;
-         } else {
-             if (EVP_PKEY_sign_message_init(ctx, sigalg, paramsinit) <= 0)
-                 goto err;
-         }
-         if (EVP_PKEY_sign(ctx, sig, &siglen, t->msg, t->msg_len) <= 0)
-             goto err;
+            if (EVP_PKEY_sign_init_ex2(ctx, sigalg, paramsinit) <= 0)
+                goto err;
+        } else {
+            if (EVP_PKEY_sign_message_init(ctx, sigalg, paramsinit) <= 0)
+                goto err;
+        }
+        if (EVP_PKEY_sign(ctx, sig, &siglen, t->msg, t->msg_len) <= 0)
+            goto err;
 
         if (t->sig_expected != NULL
                 && (siglen != t->sig_expected_len

--- a/providers/implementations/signature/rsa_sig.c
+++ b/providers/implementations/signature/rsa_sig.c
@@ -2003,11 +2003,8 @@ static int rsa_sigalg_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
                                              0, &prsactx->siglen))
                 return 0;
         }
-        return 1;
     }
-
-    /* Wrong operation */
-    return 0;
+    return 1;
 }
 
 #define IMPL_RSA_SIGALG(md, MD)                                         \


### PR DESCRIPTION
Change FIPS self tests to use EVP_PKEY_sign/verify API
Self tests no longer use the EVP_DigestSign/Verify API's.

Note second commit is cherry picked from PR https://github.com/openssl/openssl/pull/25499

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
