### PR TITLE
s390x: Don't probe crypto cards for ME/CRT offloading during initialization

### DIFF
--- a/crypto/s390x_arch.h
+++ b/crypto/s390x_arch.h
@@ -74,17 +74,21 @@ struct OPENSSL_s390xcap_st {
     unsigned long long kdsa[2];
 };
 
-#if defined(__GNUC__) && defined(__linux)
-__attribute__ ((visibility("hidden")))
-#endif
+#  if defined(__GNUC__) && defined(__linux)
+__attribute__((visibility("hidden")))
+#  endif
 extern struct OPENSSL_s390xcap_st OPENSSL_s390xcap_P;
 
-#ifdef S390X_MOD_EXP
-# if defined(__GNUC__) && defined(__linux)
-__attribute__ ((visibility("hidden")))
-# endif
+#  ifdef S390X_MOD_EXP
+#   if defined(__GNUC__) && defined(__linux)
+__attribute__((visibility("hidden")))
+#   endif
 extern int OPENSSL_s390xcex;
-#endif
+#   if defined(__GNUC__) && defined(__linux)
+__attribute__((visibility("hidden")))
+#   endif
+extern int OPENSSL_s390xcex_nodev;
+#  endif
 
 /* Max number of 64-bit words currently returned by STFLE */
 #  define S390X_STFLE_MAX       3


### PR DESCRIPTION
Probing for crypto cards during initialization by issuing an ioctl to the zcrypt device driver can cause a lot of traffic and overhead, because it runs for each and every application that uses OpenSSL, regardless if that application will later perform ME or CRT operations or not.

Fixes: https://github.com/openssl/openssl/commit/79040cf29e011c21789563d74da626b7465a0540

Because the commit https://github.com/openssl/openssl/commit/79040cf29e011c21789563d74da626b7465a0540 that this PR fixes went into 3.2 and later, this change should also go into the 3.2, 3.3, 3.4 and master branches. Are you cherry picking this, or do yo want me to open PR for each branch separately?