### PR TITLE
Use the correct length value for input salt in HKDF

### DIFF
--- a/providers/implementations/kdfs/hkdf.c
+++ b/providers/implementations/kdfs/hkdf.c
@@ -721,7 +721,7 @@ static int prov_tls13_hkdf_generate_secret(OSSL_LIB_CTX *libctx,
         EVP_MD_CTX_free(mctx);
 
         /* Generate the pre-extract secret */
-        if (!prov_tls13_hkdf_expand(md, prevsecret, mdlen,
+        if (!prov_tls13_hkdf_expand(md, prevsecret, prevsecretlen,
                                     prefix, prefixlen, label, labellen,
                                     hash, mdlen, preextractsec, mdlen))
             return 0;

--- a/test/recipes/30-test_evp_data/evpkdf_tls13_kdf.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_tls13_kdf.txt
@@ -5024,3 +5024,14 @@ Ctrl.data = hexdata:7c92f68bd5bf3638ea338a6494722e1b44127e1b7e8aad535f2322a644ff
 Ctrl.prefix = hexprefix:746c73313320
 Ctrl.label = hexlabel:6320652074726166666963
 Output = a8464234c7957b85460bf7abda8e20aa43b9e0944c02d76c1c28672619cf6978
+
+# Test that salt of arbitrary length works
+FIPSversion = >=3.4.0
+KDF = TLS13-KDF
+Ctrl.mode = mode:EXTRACT_ONLY
+Ctrl.digest = digest:SHA2-256
+Ctrl.key = hexkey:f8af6aea2d397baf2948a25b2834200692cff17eee9165e4e27babee9edefd05
+Ctrl.salt = hexsalt:00010203040506070809000102030405060708090001020304050607080900010203040506070809
+Ctrl.prefix = hexprefix:746c73313320
+Ctrl.label = hexlabel:64657269766564
+Output = ef0aa4925ab6f4588759e15dfadcf7602ca7aa39ebb092bd7ab48f6a68c54449


### PR DESCRIPTION
In this function the salt can be either a zero buffer of exactly mdlen length, or an arbitrary salt of prevsecretlen length. Although in practice OpenSSL will always pass in a salt of mdlen size bytes in the current TLS 1.3 code, the openssl kdf command can pass in arbitrary values (I did it for testing), and a future change in the higher layer code could also result in unmatched lengths.

If prevsecretlen is > mdlen this will cause incorrect salt expansion, if prevsecretlen < mdlen this could cause a crash or reading random information. Inboth case the generated output would be incorrect.

Fixes #25557