### PR TITLE
fips: add missing ossl_prov_is_running checks

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
@@ -338,6 +338,9 @@ static void *aes_cbc_hmac_sha1_dupctx(void *provctx)
 {
     PROV_AES_HMAC_SHA1_CTX *ctx = provctx;
 
+    if (!ossl_prov_is_running())
+        return NULL;
+
     if (ctx == NULL)
         return NULL;
 
@@ -374,6 +377,9 @@ static void *aes_cbc_hmac_sha256_newctx(void *provctx, size_t kbits,
 static void *aes_cbc_hmac_sha256_dupctx(void *provctx)
 {
     PROV_AES_HMAC_SHA256_CTX *ctx = provctx;
+
+    if (!ossl_prov_is_running())
+        return NULL;
 
     return OPENSSL_memdup(ctx, sizeof(*ctx));
 }

--- a/providers/implementations/ciphers/cipher_aes_ccm.c
+++ b/providers/implementations/ciphers/cipher_aes_ccm.c
@@ -38,6 +38,9 @@ static void *aes_ccm_dupctx(void *provctx)
     PROV_AES_CCM_CTX *ctx = provctx;
     PROV_AES_CCM_CTX *dupctx = NULL;
 
+    if (!ossl_prov_is_running())
+        return NULL;
+
     if (ctx == NULL)
         return NULL;
     dupctx = OPENSSL_memdup(provctx, sizeof(*ctx));

--- a/providers/implementations/ciphers/cipher_aes_gcm.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm.c
@@ -39,6 +39,9 @@ static void *aes_gcm_dupctx(void *provctx)
     PROV_AES_GCM_CTX *ctx = provctx;
     PROV_AES_GCM_CTX *dctx = NULL;
 
+    if (!ossl_prov_is_running())
+        return NULL;
+
     if (ctx == NULL)
         return NULL;
 

--- a/providers/implementations/ciphers/cipher_aes_wrp.c
+++ b/providers/implementations/ciphers/cipher_aes_wrp.c
@@ -71,6 +71,9 @@ static void *aes_wrap_dupctx(void *wctx)
     PROV_AES_WRAP_CTX *ctx = wctx;
     PROV_AES_WRAP_CTX *dctx = wctx;
 
+    if (!ossl_prov_is_running())
+        return NULL;
+
     if (ctx == NULL)
         return NULL;
     dctx = OPENSSL_memdup(ctx, sizeof(*ctx));

--- a/providers/implementations/ciphers/cipher_aes_xts.c
+++ b/providers/implementations/ciphers/cipher_aes_xts.c
@@ -123,8 +123,12 @@ static int aes_xts_dinit(void *vctx, const unsigned char *key, size_t keylen,
 static void *aes_xts_newctx(void *provctx, unsigned int mode, uint64_t flags,
                             size_t kbits, size_t blkbits, size_t ivbits)
 {
-    PROV_AES_XTS_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
+    PROV_AES_XTS_CTX *ctx;
 
+    if (!ossl_prov_is_running())
+        return NULL;
+
+    ctx = OPENSSL_zalloc(sizeof(*ctx));
     if (ctx != NULL) {
         ossl_cipher_generic_initkey(&ctx->base, kbits, blkbits, ivbits, mode,
                                     flags, ossl_prov_cipher_hw_aes_xts(kbits),

--- a/providers/implementations/kem/rsa_kem.c
+++ b/providers/implementations/kem/rsa_kem.c
@@ -23,6 +23,7 @@
 #include <openssl/proverr.h>
 #include "crypto/rsa.h"
 #include "prov/provider_ctx.h"
+#include "prov/providercommon.h"
 #include "prov/implementations.h"
 #include "prov/securitycheck.h"
 
@@ -82,8 +83,12 @@ static int rsakem_opname2id(const char *name)
 
 static void *rsakem_newctx(void *provctx)
 {
-    PROV_RSA_CTX *prsactx =  OPENSSL_zalloc(sizeof(PROV_RSA_CTX));
+    PROV_RSA_CTX *prsactx;
 
+    if (!ossl_prov_is_running())
+        return NULL;
+
+    prsactx =  OPENSSL_zalloc(sizeof(PROV_RSA_CTX));
     if (prsactx == NULL)
         return NULL;
     prsactx->libctx = PROV_LIBCTX_OF(provctx);
@@ -106,6 +111,9 @@ static void *rsakem_dupctx(void *vprsactx)
     PROV_RSA_CTX *srcctx = (PROV_RSA_CTX *)vprsactx;
     PROV_RSA_CTX *dstctx;
 
+    if (!ossl_prov_is_running())
+        return NULL;
+
     dstctx = OPENSSL_zalloc(sizeof(*srcctx));
     if (dstctx == NULL)
         return NULL;
@@ -124,6 +132,9 @@ static int rsakem_init(void *vprsactx, void *vrsa,
 {
     PROV_RSA_CTX *prsactx = (PROV_RSA_CTX *)vprsactx;
     int protect = 0;
+
+    if (!ossl_prov_is_running())
+        return 0;
 
     if (prsactx == NULL || vrsa == NULL)
         return 0;
@@ -343,6 +354,9 @@ static int rsakem_generate(void *vprsactx, unsigned char *out, size_t *outlen,
 {
     PROV_RSA_CTX *prsactx = (PROV_RSA_CTX *)vprsactx;
 
+    if (!ossl_prov_is_running())
+        return 0;
+
     switch (prsactx->op) {
         case KEM_OP_RSASVE:
             return rsasve_generate(prsactx, out, outlen, secret, secretlen);
@@ -355,6 +369,9 @@ static int rsakem_recover(void *vprsactx, unsigned char *out, size_t *outlen,
                           const unsigned char *in, size_t inlen)
 {
     PROV_RSA_CTX *prsactx = (PROV_RSA_CTX *)vprsactx;
+
+    if (!ossl_prov_is_running())
+        return 0;
 
     switch (prsactx->op) {
         case KEM_OP_RSASVE:


### PR DESCRIPTION
After rudimentary analysis, it appears the below functions can
potentially produce output, whilst the provider is in error state.

These functions were detected using this method:

```
CFLAGS='-save-temps' ./Configure enable-fips --debug
make -j10
find . -name '*.i' | xargs git add -f
git grep --cached -p ossl_prov_is_running | grep libfips-lib > ossl_prov_is_running.txt
git grep --cached -p 'return' | grep  libfips-lib > return.txt
grep '\.i=' return.txt > func-with_return.txt
grep '\.i=' ossl_prov_is_running.txt > func-with-ossl_prov_is_running.txt
grep --fixed-strings --line-regexp --file=func-with-ossl_prov_is_running.txt return.txt > func-without-ossl_prov_is_running.txt
grep -e newctx -e initctx -e dupctx func-without-ossl_prov_is_running.txt  | grep -v ossl_prov_is_running
```

And from there doing manual inspection, as the list was short at that
point.

As in compile with keeping pre-processed source code; and use `git
grep --cached -p` to find these preprocessed files, and scan for calls
to return or opssl_prov_is_running, with function name printed. And
then exclude one from the other, to hopefully get a list of all the
functions that do not check for ossl_prov_is_running.

As number of functions without "func-without-ossl_prov_is_running"
check is large, I do wonder which other functions are "interesting" to
check for. I think I'm not scanning for _update functions
correctly. Any tips on improving above analysis will help with
maintaining such checks going forward.