### PR TITLE
ci: add 3.4 to the provider compatibility test

### DIFF
--- a/.github/workflows/prov-compat-label.yml
+++ b/.github/workflows/prov-compat-label.yml
@@ -126,6 +126,10 @@ jobs:
             dir: branch-3.3,
             tgz: branch-3.3.tar.gz,
           }, {
+            name: openssl-3.4,
+            dir: branch-3.4,
+            tgz: branch-3.4.tar.gz,
+          }, {
             name: master,
             dir: branch-master,
             tgz: branch-master.tar.gz,
@@ -193,12 +197,14 @@ jobs:
         # Note that releases are not used as a test environment for
         # later providers.  Problems in these situations ought to be
         # caught by cross branch testing before the release.
-        tree_a: [ branch-3.3, branch-3.2, branch-3.1, branch-3.0,
+        tree_a: [ branch-3.4, branch-3.3, branch-3.2, branch-3.1, branch-3.0,
                   openssl-3.0.0, openssl-3.0.8, openssl-3.0.9, openssl-3.1.2 ]
         tree_b: [ PR ]
         include:
           - tree_a: PR
             tree_b: branch-master
+          - tree_a: PR
+            tree_b: branch-3.4
           - tree_a: PR
             tree_b: branch-3.3
           - tree_a: PR

--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -13,9 +13,9 @@ name: Provider compatibility across versions
 # NOTE: if this is being run on pull_request, it will **not** use the pull
 #       request's branch.  It is hardcoded to use the master branch.
 #
-on: #[pull_request]
-  schedule:
-    - cron: '0 15 * * *'
+on: [pull_request]
+#  schedule:
+#    - cron: '0 15 * * *'
 
 permissions:
   contents: read

--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -125,6 +125,10 @@ jobs:
             dir: branch-3.3,
             tgz: branch-3.3.tar.gz,
           }, {
+            name: openssl-3.4,
+            dir: branch-3.4,
+            tgz: branch-3.4.tar.gz,
+          }, {
             name: master,
             dir: branch-master,
             tgz: branch-master.tar.gz,
@@ -195,10 +199,11 @@ jobs:
         # Note that releases are not used as a test environment for
         # later providers.  Problems in these situations ought to be
         # caught by cross branch testing before the release.
-        tree_a: [ branch-master, branch-3.3, branch-3.2, branch-3.1, branch-3.0,
+        tree_a: [ branch-master, branch-3.4, branch-3.3,
+                  branch-3.2, branch-3.1, branch-3.0,
                   openssl-3.0.0, openssl-3.0.8, openssl-3.0.9, openssl-3.1.2 ]
-        tree_b: [ branch-master, branch-3.3, branch-3.2, branch-3.1,
-                  branch-3.0  ]
+        tree_b: [ branch-master, branch-3.4, branch-3.3,
+                  branch-3.2, branch-3.1, branch-3.0  ]
     steps:
       - name: early exit checks
         id: early_exit


### PR DESCRIPTION
This really should have been done with the 3.4 branch was first created.  I'd consider this urgent because of this.

Extended tests label included to see what's currently broken.

- [ ] documentation is added or updated
- [x] tests are added or updated
