### PR TITLE
Update fips-label.yml to make 'Cleanup artifact' conditional

### DIFF
--- a/.github/workflows/fips-label.yml
+++ b/.github/workflows/fips-label.yml
@@ -80,6 +80,7 @@ jobs:
               }
             }
       - name: 'Cleanup artifact'
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         run: rm artifact.zip pr_num
 
       - name: 'Download abidiff artifact'


### PR DESCRIPTION
If it's not conditional in the same manner as the other steps, it fails
because the artifacts aren't present => job failure.
