### PR TITLE
test: Add external test for pkcs11-provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,7 +564,7 @@ jobs:
       run: make install
       working-directory: ./build
 
-  external-tests:
+  external-tests-misc:
     runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
     steps:
     - uses: actions/checkout@v4
@@ -584,6 +584,7 @@ jobs:
       run: ./config --banner=Configured --strict-warnings --debug no-afalgeng enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 enable-external-tests no-fips && perl configdata.pm --dump
     - name: make
       run: make -s -j4
+    - uses: dtolnay/rust-toolchain@stable
     - name: get cpu info
       run: |
         cat /proc/cpuinfo
@@ -592,17 +593,17 @@ jobs:
       run: make test TESTS="test_external_gost_engine"
     - name: test external krb5
       run: make test TESTS="test_external_krb5"
-    - name: test external_tlsfuzzer
+    - name: test external tlsfuzzer
       run: make test TESTS="test_external_tlsfuzzer"
-    - name: test external oqs-provider
-      run: make test TESTS="test_external_oqsprovider"
+    - name: test external Cloudflare quiche
+      run: make test TESTS="test_external_cf_quiche" VERBOSE=1
     - name: test ability to produce debuginfo files
       run: |
         make debuginfo
         gdb < <(echo -e "file ./libcrypto.so.3\nquit") > ./results
         grep -q "Reading symbols from.*libcrypto\.so\.3\.debug" results
 
-  external-test-pkcs11-provider:
+  external-tests-providers:
     runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
     steps:
     - uses: actions/checkout@v4
@@ -620,10 +621,12 @@ jobs:
       run: |
         cat /proc/cpuinfo
         ./util/opensslwrap.sh version -c
+    - name: test external oqs-provider
+      run: make test TESTS="test_external_oqsprovider"
     - name: test external pkcs11-provider
       run: make test TESTS="test_external_pkcs11_provider" VERBOSE=1
 
-  external-test-pyca:
+  external-tests-pyca:
     runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
     strategy:
       matrix:
@@ -652,21 +655,3 @@ jobs:
         ./util/opensslwrap.sh version -c
     - name: test external pyca
       run: make test TESTS="test_external_pyca" VERBOSE=1
-
-  external-test-cf-quiche:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    - name: Configure OpenSSL
-      run: ./config --banner=Configured --strict-warnings enable-external-tests && perl configdata.pm --dump
-    - name: make
-      run: make -s -j4
-    - uses: dtolnay/rust-toolchain@stable
-    - name: get cpu info
-      run: |
-        cat /proc/cpuinfo
-        ./util/opensslwrap.sh version -c
-    - name: test external Cloudflare quiche
-      run: make test TESTS="test_external_cf_quiche" VERBOSE=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -602,6 +602,27 @@ jobs:
         gdb < <(echo -e "file ./libcrypto.so.3\nquit") > ./results
         grep -q "Reading symbols from.*libcrypto\.so\.3\.debug" results
 
+  external-test-pkcs11-provider:
+    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - name: package installs
+      run: |
+        sudo apt-get update
+        sudo apt-get -yq install meson pkg-config gnutls-bin libnss3-tools libnss3-dev libsofthsm2 opensc expect
+    - name: config
+      run: ./config --banner=Configured --strict-warnings --debug enable-external-tests && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: get cpu info
+      run: |
+        cat /proc/cpuinfo
+        ./util/opensslwrap.sh version -c
+    - name: test external pkcs11-provider
+      run: make test TESTS="test_external_pkcs11_provider" VERBOSE=1
+
   external-test-pyca:
     runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
     strategy:

--- a/.gitmodules
+++ b/.gitmodules
@@ -32,3 +32,6 @@
 	path = fuzz/corpora
 	url = https://github.com/openssl/fuzz-corpora
 	branch = main
+[submodule "pkcs11-provider"]
+	path = pkcs11-provider
+	url = https://github.com/latchset/pkcs11-provider.git

--- a/test/README-external.md
+++ b/test/README-external.md
@@ -118,6 +118,35 @@ algorithms to be skipped, e.g. as follows:
 The names of all supported quantum-safe algorithms are available at
 <https://github.com/open-quantum-safe/oqs-provider#algorithms>
 
+pkcs11-provider test suite
+======================
+
+This builds and runs pkcs11-provider tests agains the local OpenSSL build.
+
+You will need a git checkout of pkcs11-provider at the top level:
+
+    $ git submodule update --init
+
+Then configure/build OpenSSL enabling external tests:
+
+    $ ./config shared enable-external-tests
+    $ make
+
+pkcs11-provider requires meson for the build process. Moreover, it requires
+softhsm and nss softokn tokens and certtool, certutil, pkcs11-tool and expect
+to run the tests.
+
+Tests will then be run as part of the rest of the suite, or can be
+explicitly run (with more debugging):
+
+    $ make test VERBOSE=1 TESTS=test_external_pkcs11_provider
+
+Test failures and suppressions
+------------------------------
+
+There are tests for different software tokens - softhsm, nss-softokn and kryoptic.
+Kryoptic tests will not run at this point. Currently no test fails.
+
 Updating test suites
 ====================
 

--- a/test/README-external.md
+++ b/test/README-external.md
@@ -17,7 +17,7 @@ First checkout the `PYCA/Cryptography` module into `./pyca-cryptography` using:
 
 Then configure/build OpenSSL compatible with the python module:
 
-    $ ./config shared enable-external-tests
+    $ ./config enable-external-tests
     $ make
 
 The tests will run in a python virtual environment which requires virtualenv
@@ -66,7 +66,7 @@ of your system.  Certain tests may require more installed packages to run.  No
 tests are expected to fail.
 
 GOST engine test suite
-===============
+======================
 
 Much like the PYCA/Cryptography test suite, this builds and runs the GOST engine
 tests against the local OpenSSL build.
@@ -77,7 +77,7 @@ You will need a git checkout of gost-engine at the top level:
 
 Then configure/build OpenSSL enabling external tests:
 
-    $ ./config shared enable-external-tests
+    $ ./config enable-external-tests
     $ make
 
 GOST engine requires CMake for the build process.
@@ -100,7 +100,7 @@ You will need a git checkout of oqsprovider at the top level:
 
 Then configure/build OpenSSL enabling external tests:
 
-    $ ./config shared enable-external-tests
+    $ ./config enable-external-tests
     $ make
 
 oqsprovider requires CMake for the build process.
@@ -119,9 +119,9 @@ The names of all supported quantum-safe algorithms are available at
 <https://github.com/open-quantum-safe/oqs-provider#algorithms>
 
 pkcs11-provider test suite
-======================
+==========================
 
-This builds and runs pkcs11-provider tests agains the local OpenSSL build.
+This builds and runs pkcs11-provider tests against the local OpenSSL build.
 
 You will need a git checkout of pkcs11-provider at the top level:
 
@@ -129,7 +129,7 @@ You will need a git checkout of pkcs11-provider at the top level:
 
 Then configure/build OpenSSL enabling external tests:
 
-    $ ./config shared enable-external-tests
+    $ ./config enable-external-tests
     $ make
 
 pkcs11-provider requires meson for the build process. Moreover, it requires

--- a/test/recipes/95-test_external_pkcs11_provider.t
+++ b/test/recipes/95-test_external_pkcs11_provider.t
@@ -1,0 +1,28 @@
+#! /usr/bin/env perl
+# Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test;
+use OpenSSL::Test::Utils;
+use OpenSSL::Test qw/:DEFAULT data_file bldtop_dir srctop_dir cmdstr/;
+
+setup("test_external_pkcs11_provider");
+
+plan skip_all => "No external tests in this configuration"
+    if disabled("external-tests");
+plan skip_all => "pkcs11-provider tests not available on Windows or VMS"
+    if $^O =~ /^(VMS|MSWin32)$/;
+plan skip_all => "pkcs11-provider tests only available in a shared build"
+    if disabled("shared");
+plan skip_all => "pkcs11-provider tests not supported in out of tree builds"
+    if bldtop_dir() ne srctop_dir();
+
+plan tests => 1;
+
+ok(run(cmd(["sh", data_file("pkcs11-provider.sh")])),
+   "running pkcs11-provider tests");

--- a/test/recipes/95-test_external_pkcs11_provider_data/pkcs11-provider.sh
+++ b/test/recipes/95-test_external_pkcs11_provider_data/pkcs11-provider.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+#
+# Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+#
+# OpenSSL external testing using the pkcs11-provider
+#
+
+PWD="$(pwd)"
+
+SRCTOP="$(cd $SRCTOP; pwd)"
+BLDTOP="$(cd $BLDTOP; pwd)"
+
+if [ "$SRCTOP" != "$BLDTOP" ] ; then
+    echo "Out of tree builds not supported with pkcsa11-provider test!"
+    exit 1
+fi
+
+O_EXE="$BLDTOP/apps"
+O_BINC="$BLDTOP/include"
+O_SINC="$SRCTOP/include"
+O_LIB="$BLDTOP"
+
+unset OPENSSL_CONF
+
+export PATH="$O_EXE:$PATH"
+export LD_LIBRARY_PATH="$O_LIB:$LD_LIBRARY_PATH"
+export OPENSSL_ROOT_DIR="$O_LIB"
+
+# Check/Set openssl version
+OPENSSL_VERSION=`openssl version | cut -f 2 -d ' '`
+
+echo "------------------------------------------------------------------"
+echo "Testing OpenSSL using pkcs11-provider:"
+echo "   CWD:                $PWD"
+echo "   SRCTOP:             $SRCTOP"
+echo "   BLDTOP:             $BLDTOP"
+echo "   OPENSSL_ROOT_DIR:   $OPENSSL_ROOT_DIR"
+echo "   OpenSSL version:    $OPENSSL_VERSION"
+echo "------------------------------------------------------------------"
+
+PKCS11_PROVIDER_BUILDDIR=$OPENSSL_ROOT_DIR/pkcs11-provider/builddir
+
+echo "------------------------------------------------------------------"
+echo "Building pkcs11-provider"
+echo "------------------------------------------------------------------"
+
+PKG_CONFIG_PATH="$BLDTOP" meson setup $PKCS11_PROVIDER_BUILDDIR $OPENSSL_ROOT_DIR/pkcs11-provider/ || exit 1
+meson compile -C $PKCS11_PROVIDER_BUILDDIR pkcs11 || exit 1
+
+echo "------------------------------------------------------------------"
+echo "Running tests"
+echo "------------------------------------------------------------------"
+
+# The OpenSSL app uses ${HARNESS_OSSL_PREFIX} as a prefix for its standard output
+HARNESS_OSSL_PREFIX= meson test -C $PKCS11_PROVIDER_BUILDDIR
+
+if [ $? -ne 0 ]; then
+    cat $PKCS11_PROVIDER_BUILDDIR/meson-logs/testlog.txt
+    exit 1
+fi
+
+rm -rf $PKCS11_PROVIDER_BUILDDIR
+
+exit 0


### PR DESCRIPTION
This PR adds an external test for pkcs11-provider (https://github.com/latchset/pkcs11-provider). It runs the self-test of the provider.

##### Checklist
- [x] tests are added or updated
