### PR TITLE
doc: add history section to the Jitter RNG source

### DIFF
--- a/doc/man7/EVP_RAND-JITTER.pod
+++ b/doc/man7/EVP_RAND-JITTER.pod
@@ -44,6 +44,8 @@ A context for the seed source can be obtained by calling:
  EVP_RAND *rand = EVP_RAND_fetch(NULL, "JITTER", NULL);
  EVP_RAND_CTX *rctx = EVP_RAND_CTX_new(rand, NULL);
 
+The B<enable-jitter> configuration option was added in OpenSSL 3.4.
+
 =head1 EXAMPLES
 
  EVP_RAND *rand;


### PR DESCRIPTION
This should have been included originally.  I've included the same commit as part of #25498 which modifies the history section and thus will avoid a conflict later.

- [x] documentation is added or updated
- [ ] tests are added or updated
