### PR TITLE
Fix potential memory leak in save_statusInfo()

### DIFF
--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -106,9 +106,12 @@ static int save_statusInfo(OSSL_CMP_CTX *ctx, OSSL_CMP_PKISI *si)
     ss = si->statusString; /* may be NULL */
     for (i = 0; i < sk_ASN1_UTF8STRING_num(ss); i++) {
         ASN1_UTF8STRING *str = sk_ASN1_UTF8STRING_value(ss, i);
+        ASN1_UTF8STRING *dup = ASN1_STRING_dup(str);
 
-        if (!sk_ASN1_UTF8STRING_push(ctx->statusString, ASN1_STRING_dup(str)))
+        if (dup == NULL || !sk_ASN1_UTF8STRING_push(ctx->statusString, dup)) {
+            ASN1_UTF8STRING_free(dup);
             return 0;
+        }
     }
     return 1;
 }


### PR DESCRIPTION
If sk_ASN1_UTF8STRING_push() fails then the duplicated string will leak memory. Add a ASN1_UTF8STRING_free() to fix this.

CLA: trivial

Note: this was detected using an experimental static analyser I'm working on. I understand this is quite an unlikely bug.
I could also be wrong because my results are based on static analysis even though I manually read the code as well.
