### PR TITLE
This is a workaround to failures we occasionally see on self-hosted

### DIFF
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -291,7 +291,12 @@ sub start
         print STDERR "Server command: $execcmd\n";
     }
 
-    $pid = IPC::Open3::open3(my $sin, my $sout, my $serr, $execcmd) or die "Failed to $execcmd: $!\n";
+    if ("$^O" eq "MSWin32") {
+        $pid = IPC::Open2::open2(my $sout, my $sin, $execcmd) or die "Failed to $execcmd: $!\n";
+    } else {
+        $pid = IPC::Open3::open3(my $sin, my $sout, my $serr, $execcmd) or die "Failed to $execcmd: $!\n";
+    }
+
     $self->{serverpid} = $pid;
 
     # Process the output from s_server until we find the ACCEPT line, which

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -290,7 +290,9 @@ sub start
     if ($self->debug) {
         print STDERR "Server command: $execcmd\n";
     }
-
+    my $sin = undef;
+    my $sout = undef;
+    my $serr = undef;
     if ("$^O" eq "MSWin32") {
         $pid = IPC::Open2::open2(my $sin, my $sout, $execcmd) or die "Failed to $execcmd: $!\n";
     } else {

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -294,9 +294,9 @@ sub start
     my $sout = undef;
     my $serr = undef;
     if ("$^O" eq "MSWin32") {
-        $pid = IPC::Open2::open2(my $sin, my $sout, $execcmd) or die "Failed to $execcmd: $!\n";
+        $pid = IPC::Open2::open2($sin, $sout, $execcmd) or die "Failed to $execcmd: $!\n";
     } else {
-        $pid = IPC::Open3::open3(my $sin, my $sout, my $serr, $execcmd) or die "Failed to $execcmd: $!\n";
+        $pid = IPC::Open3::open3($sin, $sout, $serr, $execcmd) or die "Failed to $execcmd: $!\n";
     }
 
     $self->{serverpid} = $pid;

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -292,7 +292,7 @@ sub start
     }
 
     if ("$^O" eq "MSWin32") {
-        $pid = IPC::Open2::open2(my $sout, my $sin, $execcmd) or die "Failed to $execcmd: $!\n";
+        $pid = IPC::Open2::open2(my $sin, my $sout, $execcmd) or die "Failed to $execcmd: $!\n";
     } else {
         $pid = IPC::Open3::open3(my $sin, my $sout, my $serr, $execcmd) or die "Failed to $execcmd: $!\n";
     }

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -291,7 +291,7 @@ sub start
         print STDERR "Server command: $execcmd\n";
     }
 
-    $pid = IPC::Open2::open2(my $sout, my $sin, $execcmd) or die "Failed to $execcmd: $!\n";
+    $pid = IPC::Open3::open3(my $sin, my $sout, my $serr, $execcmd) or die "Failed to $execcmd: $!\n";
     $self->{serverpid} = $pid;
 
     # Process the output from s_server until we find the ACCEPT line, which

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -292,11 +292,10 @@ sub start
     }
     my $sin = undef;
     my $sout = undef;
-    my $serr = undef;
     if ("$^O" eq "MSWin32") {
-        $pid = IPC::Open2::open2($sin, $sout, $execcmd) or die "Failed to $execcmd: $!\n";
+        $pid = IPC::Open2::open2($sout, $sin, $execcmd) or die "Failed to $execcmd: $!\n";
     } else {
-        $pid = IPC::Open3::open3($sin, $sout, $serr, $execcmd) or die "Failed to $execcmd: $!\n";
+        $pid = IPC::Open3::open3($sin, $sout, undef, $execcmd) or die "Failed to $execcmd: $!\n";
     }
 
     $self->{serverpid} = $pid;


### PR DESCRIPTION
runner when running tests on FreeBSD. These failures are caused by some kind of race condition in perl code which controls test suite run. The typical symptom is:

```
Test Summary Report
-------------------
70-test_tls13messages.t               (Wstat: 0 Tests: 17 Failed: 0)
  Parse errors: No plan found in TAP output
```

The racecondition is time dependant. The slower the machine is the more likely is we trigger it. Our current self hosted runners run on google cloud as E2 instances. If I run simple shell script here:

```

GO=0
COUNT=0

while [ $GO -eq 0 ] ; do
        make test TESTS='test_tls13messages test_tls13hrr' HARNESS_JOBS=2
        GO=$?
        COUNT=$(($COUNT + 1))
done

echo "Failure after $COUNT tries"

```
The script seems to alwasy stop after 13 - 45 iterations due to 'No plan found in TAP output' error. Another possible error I could see was 'tests run out of sequence'. Both errors are occasionally seen.

If I upgrade google instance from E2 to N2 the script above continues to run overnight until I stop it.

Another option is to set number of harness jobs to 1. This also keeps script above running with no issues.

When using 1 job instead of 4 jobs makes test to run 11 minutes instead of 8. So it runs like 40% slower.

