### PR TITLE
Test 3.4 backport unchain

### DIFF
--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -207,7 +207,7 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
-      run: ./config --with-rand-seed=none enable-jitter --with-jitter-include=jitter/ --with-jitter-lib=jitter/ -DOPENSSL_DEFAULT_SEED_SRC=JITTER && perl configdata.pm --dump
+      run: ./config --with-rand-seed=none enable-jitter --with-jitter-include=jitter/ --with-jitter-lib=jitter/ -DOPENSSL_DEFAULT_SEED_SRC=JITTER -DOPENSSL_RAND_CHAIN=0 && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: get cpu info

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -272,8 +272,8 @@ static int provider_conf_activate(OSSL_LIB_CTX *libctx, const char *name,
     return ok;
 }
 
-static int provider_conf_parse_bool_setting(const char *confname,
-                                            const char *confvalue, int *val)
+int provider_conf_parse_bool_setting(const char *confname,
+                                     const char *confvalue, int *val)
 {
 
     if (confvalue == NULL) {

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -35,6 +35,7 @@
 # include "prov/seeding.h"
 # include "internal/e_os.h"
 # include "internal/property.h"
+# include "internal/provider.h"
 
 # ifndef OPENSSL_NO_ENGINE
 /* non-NULL if default_RAND_meth is ENGINE-provided */
@@ -127,7 +128,6 @@ void RAND_keep_random_devices_open(int keep)
 int RAND_poll(void)
 {
     static const char salt[] = "polling";
-
 # ifndef OPENSSL_NO_DEPRECATED_3_0
     const RAND_METHOD *meth = RAND_get_rand_method();
     int ret = meth == RAND_OpenSSL();
@@ -154,7 +154,7 @@ int RAND_poll(void)
             goto err;
 
         ret = 1;
-     err:
+    err:
         ossl_rand_pool_free(pool);
         return ret;
     }
@@ -320,7 +320,7 @@ int RAND_status(void)
         return 0;
     return EVP_RAND_get_state(rand) == EVP_RAND_STATE_READY;
 }
-# else  /* !FIPS_MODULE */
+#else  /* !FIPS_MODULE */
 
 # ifndef OPENSSL_NO_DEPRECATED_3_0
 const RAND_METHOD *RAND_get_rand_method(void)
@@ -448,6 +448,7 @@ typedef struct rand_global_st {
     /* Allow the randomness source to be changed */
     char *seed_name;
     char *seed_propq;
+    int chain;
 } RAND_GLOBAL;
 
 /*
@@ -461,12 +462,14 @@ void *ossl_rand_ctx_new(OSSL_LIB_CTX *libctx)
     if (dgbl == NULL)
         return NULL;
 
+    dgbl->chain = OPENSSL_RAND_CHAIN;
+
 #ifndef FIPS_MODULE
     /*
      * We need to ensure that base libcrypto thread handling has been
      * initialised.
      */
-     OPENSSL_init_crypto(OPENSSL_INIT_BASE_ONLY, NULL);
+    OPENSSL_init_crypto(OPENSSL_INIT_BASE_ONLY, NULL);
 #endif
 
     dgbl->lock = CRYPTO_THREAD_lock_new();
@@ -694,6 +697,11 @@ static EVP_RAND_CTX *rand_new_drbg(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent,
         EVP_RAND_CTX_free(ctx);
         return NULL;
     }
+    if (!EVP_RAND_enable_locking(ctx)) {
+        ERR_raise(ERR_LIB_RAND, RAND_R_ERROR_INSTANTIATING_DRBG);
+        EVP_RAND_CTX_free(ctx);
+        return NULL;
+    }
     return ctx;
 }
 
@@ -808,6 +816,22 @@ EVP_RAND_CTX *RAND_get0_public(OSSL_LIB_CTX *ctx)
         if (CRYPTO_THREAD_get_local(&dgbl->private) == NULL
                 && !ossl_init_thread_start(NULL, ctx, rand_delete_thread_state))
             return NULL;
+
+#ifndef FIPS_MODULE
+        /*
+         * FIPS modules prior to 3.5 use callback
+         * FIPS modules 3.5+ set primary to a crng-tested
+         * seed source, and thus need that as parent
+         */
+        if (!CRYPTO_THREAD_read_lock(dgbl->lock))
+            return NULL;
+
+        if (dgbl->chain == 0)
+            primary = dgbl->seed;
+
+        CRYPTO_THREAD_unlock(dgbl->lock);
+#endif
+
         rand = rand_new_drbg(ctx, primary, SECONDARY_RESEED_INTERVAL,
                              SECONDARY_RESEED_TIME_INTERVAL);
         CRYPTO_THREAD_set_local(&dgbl->public, rand);
@@ -841,6 +865,22 @@ EVP_RAND_CTX *RAND_get0_private(OSSL_LIB_CTX *ctx)
         if (CRYPTO_THREAD_get_local(&dgbl->public) == NULL
                 && !ossl_init_thread_start(NULL, ctx, rand_delete_thread_state))
             return NULL;
+
+#ifndef FIPS_MODULE
+        /*
+         * FIPS modules prior to 3.5 use callback
+         * FIPS modules 3.5+ set primary to a crng-tested
+         * seed source, and thus need that as parent
+         */
+        if (!CRYPTO_THREAD_read_lock(dgbl->lock))
+            return NULL;
+
+        if (dgbl->chain == 0)
+            primary = dgbl->seed;
+
+        CRYPTO_THREAD_unlock(dgbl->lock);
+#endif
+
         rand = rand_new_drbg(ctx, primary, SECONDARY_RESEED_INTERVAL,
                              SECONDARY_RESEED_TIME_INTERVAL);
         CRYPTO_THREAD_set_local(&dgbl->private, rand);
@@ -946,6 +986,11 @@ static int random_conf_init(CONF_IMODULE *md, const CONF *cnf)
         } else if (OPENSSL_strcasecmp(cval->name, "seed_properties") == 0) {
             if (!random_set_string(&dgbl->seed_propq, cval->value))
                 return 0;
+        } else if (OPENSSL_strcasecmp(cval->name, "chain") == 0) {
+            if (!provider_conf_parse_bool_setting(cval->name,
+                                                  cval->value,
+                                                  &dgbl->chain))
+                return 0;
         } else {
             ERR_raise_data(ERR_LIB_CRYPTO,
                            CRYPTO_R_UNKNOWN_NAME_IN_RANDOM_SECTION,
@@ -955,7 +1000,6 @@ static int random_conf_init(CONF_IMODULE *md, const CONF *cnf)
     }
     return r;
 }
-
 
 static void random_conf_deinit(CONF_IMODULE *md)
 {

--- a/crypto/rand/rand_local.h
+++ b/crypto/rand/rand_local.h
@@ -25,6 +25,11 @@
 # define PRIMARY_RESEED_TIME_INTERVAL            (60 * 60) /* 1 hour */
 # define SECONDARY_RESEED_TIME_INTERVAL          (7 * 60)  /* 7 minutes */
 
+/* Whether to chain public/private DRBGs to primary DRBG */
+# ifndef OPENSSL_RAND_CHAIN
+#  define OPENSSL_RAND_CHAIN 1
+# endif
+
 # ifndef FIPS_MODULE
 /* The global RAND method, and the global buffer and DRBG instance. */
 extern RAND_METHOD ossl_rand_meth;

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -478,6 +478,13 @@ to access the same randomness sources from outside the validated boundary.
 
 This sets the property query used when fetching the randomness source.
 
+=item B<chain>
+
+This controls whether or not public/private random instances chain to primary
+for seeding, or not. Default is 1, meaning to chain. Set to 0, for
+public/private random instances to acquire entropy seed directly. See
+L<EVP_RAND(7)> for more details.
+
 =back
 
 =head1 EXAMPLES
@@ -572,6 +579,8 @@ could be used in pathnames, only the double-quote character was recognized,
 and comments began with a semi-colon.
 This function was deprecated in OpenSSL 3.0; applications with
 configuration files using that syntax will have to be modified.
+
+Random Configuration, chain option was added in OpenSSL 3.5.0.
 
 =head1 SEE ALSO
 

--- a/doc/man7/EVP_RAND.pod
+++ b/doc/man7/EVP_RAND.pod
@@ -153,6 +153,36 @@ EVP_RAND_generate(<public>, ...) and
 EVP_RAND_generate(<private>, ...),
 respectively.
 
+When `[random] chain=0` is set in `openssl.cnf`, the public & private
+DRBG are not chained to primary, and instead use seed source
+directly. It is also possibly to configure OpenSSL to default to no
+chaining with -DOPENSSL_RAND_CHAIN=0.
+
+FIPS provider 3.5 and later are always unchained and use the following
+configuration instead:
+
+               +-------------+
+               |             |
+               | Seed Source |
+               |             |
+               +------+------+
+                      |
+                      |
+                      v
+               +-------------+
+               |             |
+               |  CRNG Test  |
+               |             |
+               ++----------+-+
+                |          |
+                |          |
+                v          v
+    +--------------+     +--------------+
+    |              |     |              |
+    | Public DRBG  |     | Private DRBG |
+    |              |     |              |
+    +--------------+     +--------------+
+
 =head1 RESEEDING
 
 A DRBG instance seeds itself automatically, pulling random input from

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -105,6 +105,8 @@ int ossl_provider_test_operation_bit(OSSL_PROVIDER *provider, size_t bitnum,
 
 /* Configuration */
 void ossl_provider_add_conf_module(void);
+int provider_conf_parse_bool_setting(const char *confname,
+                                     const char *confvalue, int *val);
 
 /* Child providers */
 int ossl_provider_init_as_child(OSSL_LIB_CTX *ctx,

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -225,6 +225,7 @@ static int test_drbg_reseed(int expect_success,
      * step 3: check postconditions
      */
 
+#if OPENSSL_RAND_CHAIN == 1
     /* Test whether reseeding succeeded as expected */
     if (!TEST_int_eq(state(primary), expected_state)
         || !TEST_int_eq(state(public), expected_state)
@@ -236,6 +237,12 @@ static int test_drbg_reseed(int expect_success,
         if (!TEST_int_ge(reseed_counter(primary), primary_reseed))
             return 0;
     }
+#else
+    /* Test whether reseeding succeeded as expected */
+    if (!TEST_int_eq(state(public), expected_state)
+        || !TEST_int_eq(state(private), expected_state))
+        return 0;
+#endif
 
     if (expect_public_reseed >= 0) {
         /* Test whether public DRBG was reseeded as expected */
@@ -246,7 +253,7 @@ static int test_drbg_reseed(int expect_success,
     }
 
     if (expect_private_reseed >= 0) {
-        /* Test whether public DRBG was reseeded as expected */
+        /* Test whether private DRBG was reseeded as expected */
         if (!TEST_int_ge(reseed_counter(private), private_reseed)
                 || !TEST_uint_ge(reseed_counter(private),
                                  reseed_counter(primary)))
@@ -254,6 +261,7 @@ static int test_drbg_reseed(int expect_success,
     }
 
     if (expect_success == 1) {
+#if OPENSSL_RAND_CHAIN == 1
         /* Test whether reseed time of primary DRBG is set correctly */
         if (!TEST_time_t_le(before_reseed, reseed_time(primary))
             || !TEST_time_t_le(reseed_time(primary), after_reseed))
@@ -263,6 +271,17 @@ static int test_drbg_reseed(int expect_success,
         if (!TEST_time_t_ge(reseed_time(public), reseed_time(primary))
             || !TEST_time_t_ge(reseed_time(private), reseed_time(primary)))
             return 0;
+#else
+        /* Test whether reseed times of child DRBGs are set correctly */
+        if (!TEST_time_t_le(before_reseed, reseed_time(public))
+            || !TEST_time_t_le(reseed_time(public), after_reseed))
+            return 0;
+
+        if (!TEST_time_t_le(before_reseed, reseed_time(private))
+            || !TEST_time_t_le(reseed_time(private), after_reseed))
+            return 0;
+#endif
+
     } else {
         ERR_clear_error();
     }
@@ -548,9 +567,11 @@ static int test_rand_fork_safety(int i)
 static int test_rand_reseed(void)
 {
     EVP_RAND_CTX *primary, *public, *private;
-    unsigned char rand_add_buf[256];
     int rv = 0;
+#if OPENSSL_RAND_CHAIN == 1
+    unsigned char rand_add_buf[256];
     time_t before_reseed;
+#endif
 
     if (using_fips_rng())
         return TEST_skip("CRNGT cannot be disabled");
@@ -561,12 +582,13 @@ static int test_rand_reseed(void)
         return 0;
 #endif
 
-    /* All three DRBGs should be non-null */
+    /* All three DRBGs and primary seed should be non-null */
     if (!TEST_ptr(primary = RAND_get0_primary(NULL))
         || !TEST_ptr(public = RAND_get0_public(NULL))
         || !TEST_ptr(private = RAND_get0_private(NULL)))
         return 0;
 
+#if OPENSSL_RAND_CHAIN == 1
     /* There should be three distinct DRBGs, two of them chained to primary */
     if (!TEST_ptr_ne(public, private)
         || !TEST_ptr_ne(public, primary)
@@ -574,6 +596,15 @@ static int test_rand_reseed(void)
         || !TEST_ptr_eq(prov_rand(public)->parent, prov_rand(primary))
         || !TEST_ptr_eq(prov_rand(private)->parent, prov_rand(primary)))
         return 0;
+#else
+    /* There should be three distinct DRBGs, all chained to seed */
+    if (!TEST_ptr_ne(public, private)
+        || !TEST_ptr_ne(public, primary)
+        || !TEST_ptr_ne(private, primary)
+        || !TEST_ptr_eq(prov_rand(public)->parent, prov_rand(primary)->parent)
+        || !TEST_ptr_eq(prov_rand(private)->parent, prov_rand(primary)->parent))
+        return 0;
+#endif
 
     /* Disable CRNG testing for the primary DRBG */
     if (!TEST_true(disable_crngt(primary)))
@@ -602,6 +633,7 @@ static int test_rand_reseed(void)
                                     0, 0, 0, 0)))
         goto error;
 
+#if OPENSSL_RAND_CHAIN == 1
     /*
      * Test whether the public and private DRBG are both reseeded when their
      * reseed counters differ from the primary's reseed counter.
@@ -656,6 +688,7 @@ static int test_rand_reseed(void)
                                     1, 1, 1,
                                     before_reseed)))
         goto error;
+#endif
 
     rv = 1;
 


### PR DESCRIPTION
Test backport of https://github.com/openssl/openssl/pull/25615 for the 3.4 branch

Add runtime configuration `[random] chain = <bool>` and build-time
configuration -DOPENSSL_RAND_CHAIN=int to control if public/private
DRBGs are chained to primary, or not. Defaults to chain, current v3+
behaviour.

This is useful for NIST ESV certification, as currently chained and
unchained entropy sources are considered to be distinct. Thus
operating without chaining, may allow reuse of an existing ESV
certificate for Linux kernel, or Jitter Entropy library without need
to re-submit a separate ESV certificate for linux+OpenSSL or
jitter+OpenSSL, as per current guidance.

Also note, future developments in Linux kernel may make un-chained
mode of operation particularly attractive with inclusion of getrandom
in vDSO in upcomming Linux kernel v6.11, potentially being quicker
than chaining with locks to a syscall. Thus there is performance
optimisations to this as well.

Note current chaining behaviour is preserved, and it is considered to
be behave better on low entropy systems.

Note 3.5+ FIPS module self-unchains. Thus this unchaining is for
default provider and to support 3.4 and earlier FIPS modules.

Also see lots of review & design choices in:
- Merged https://github.com/openssl/openssl/pull/25415
- Draft 2 https://github.com/openssl/openssl/pull/25275
- Draft 1 https://github.com/openssl/openssl/pull/25168

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
