### PR TITLE
apps: allow ca and req apps to be used without a default openssl.cnf

### DIFF
--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -687,6 +687,7 @@ char *CONF_get1_default_config_file(void)
     const char *t;
     char *file, *sep = "";
     size_t size;
+    BIO *biofile;
 
     if ((file = ossl_safe_getenv("OPENSSL_CONF")) != NULL)
         return OPENSSL_strdup(file);
@@ -713,6 +714,17 @@ char *CONF_get1_default_config_file(void)
     if (file == NULL)
         return NULL;
     BIO_snprintf(file, size, "%s%s%s", t, sep, OPENSSL_CONF);
+
+    ERR_set_mark();
+    biofile = BIO_new_file(file, "r");
+    if (biofile == NULL) {
+        ERR_pop_to_mark();
+        OPENSSL_free(file);
+        return OPENSSL_strdup("");
+    } else {
+        ERR_clear_last_mark();
+        BIO_free(biofile);
+    }
 
     return file;
 }


### PR DESCRIPTION
Most libcrypto and libssl APIs just work fine, if the default
openssl.cnf is not shipped. Default provider will be loaded without
one, and the boilerplate settings of [ca] in the default config file
are not strictly needed.

However currently ca and req apps require openssl.cnf to be present,
and fail to run even if all configuration and options were passed in
on the command line. As the apps currently do not make any destinction
if a default config file is being used, or if it was passed in on the
command-line, or the environment variable. Thus today, if for whatever
reason no openssl.cnf exists one has to either create an empty file it
its place, or set OPENSSL_CONF= variable to an empty value.

Update the logic slightly, to make fallback default config file
optional, whilst continue to enforce that config file set via
commandline argument or the environment variable is present. This is
achieved by testing the presense of fallback openssl.cnf, prior to
returning and setting it as the default config.

It is common for a small and diverse set of distributions to split
openssl.cnf into a separate package, or not ship it all if they are
"configuration-less", container-like, atomic root filesystem
(empty-etc) operating systems. This change makes boilerplate
openssl.cnf completely optional to ship, and gains ability to still
run ca & req apps on such systems.
