### PR TITLE
Documentation enhancement warning about duplicate algorithm registrations

### DIFF
--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -775,7 +775,6 @@ complete algorithm is ignored.
 The core_obj_create() and core_obj_add_sigid() functions were not thread safe
 in OpenSSL 3.0.
 
-
 =head1 EXAMPLES
 
 This is an example of a simple provider made available as a

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -581,6 +581,11 @@ The name of the group as known by the provider. This could be the same as the
 
 The TLS group id value as given in the IANA TLS Supported Groups registry.
 
+It is possible to register the same group id from within different
+providers. Users should note that if no property query is specified, or
+more than one implementation matches the property query then it is
+undefined which implementation for a particular group id will be used.
+
 =item "tls-group-alg" (B<OSSL_CAPABILITY_TLS_GROUP_ALG>) <UTF8 string>
 
 The name of a Key Management algorithm that the provider offers and that should
@@ -666,6 +671,11 @@ This value must be supplied.
 
 The TLS algorithm ID value as given in the IANA TLS SignatureScheme registry.
 This value must be supplied.
+
+It is possible to register the same code point from within different
+providers. Users should note that if no property query is specified, or
+more than one implementation matches the property query then it is
+undefined which implementation for a particular code point will be used.
 
 =item "sigalg-name" (B<OSSL_CAPABILITY_TLS_SIGALG_NAME>) <UTF8 string>
 
@@ -764,6 +774,7 @@ complete algorithm is ignored.
 
 The core_obj_create() and core_obj_add_sigid() functions were not thread safe
 in OpenSSL 3.0.
+
 
 =head1 EXAMPLES
 

--- a/doc/man7/provider.pod
+++ b/doc/man7/provider.pod
@@ -239,6 +239,15 @@ e.g., when no provider implementing the required functionality has been
 activated. In particular, provider initialization should not depend on other
 providers already having been initialized.
 
+=head3 Note on naming clashes
+
+It is possible to register the same algorithm name from within different
+providers. Users should note that if no property query is specified, or
+more than one implementation matches the property query then it is
+undefined which implementation of a particular algorithm will be returned.
+Such naming clashes may also occur if algorithms only differ in
+capitalization as L</Algorithm naming> is case insensitive.
+
 =head1 OPENSSL PROVIDERS
 
 OpenSSL provides a number of its own providers. These are the default, base,


### PR DESCRIPTION
Enhances documentation as discussed in https://github.com/openssl/openssl/discussions/25612
