### PR TITLE
Fix doc and use of `X509v3_add_extensions()` in corner case

### DIFF
--- a/crypto/cmp/cmp_msg.c
+++ b/crypto/cmp/cmp_msg.c
@@ -330,7 +330,7 @@ OSSL_CRMF_MSG *OSSL_CMP_CTX_setup_CRM(OSSL_CMP_CTX *ctx, int for_KUR, int rid)
         != NULL
             && !add1_extension(&exts, NID_subject_alt_name, crit, default_sans))
         goto err;
-    if (ctx->reqExtensions != NULL /* augment/override existing ones */
+    if (sk_X509_EXTENSION_num(ctx->reqExtensions) > 0 /* augment/override existing ones */
             && X509v3_add_extensions(&exts, ctx->reqExtensions) == NULL)
         goto err;
     if (sk_GENERAL_NAME_num(ctx->subjectAltNames) > 0

--- a/crypto/x509/x509_v3.c
+++ b/crypto/x509/x509_v3.c
@@ -142,9 +142,9 @@ STACK_OF(X509_EXTENSION) *X509v3_add_ext(STACK_OF(X509_EXTENSION) **x,
     return NULL;
 }
 
-STACK_OF(X509_EXTENSION)
-     *X509v3_add_extensions(STACK_OF(X509_EXTENSION) **target,
-                            const STACK_OF(X509_EXTENSION) *exts)
+/* This returns NULL also in non-error case *target == NULL && sk_X509_EXTENSION_num(exts) <= 0 */
+STACK_OF(X509_EXTENSION) *X509v3_add_extensions(STACK_OF(X509_EXTENSION) **target,
+                                                const STACK_OF(X509_EXTENSION) *exts)
 {
     int i;
 

--- a/doc/man3/X509v3_get_ext_by_NID.pod
+++ b/doc/man3/X509v3_get_ext_by_NID.pod
@@ -141,8 +141,10 @@ the extension index or -1 if an error occurs.
 X509v3_get_ext_by_NID() returns the extension index or negative values if an
 error occurs.
 
-X509v3_add_ext() and X509v3_add_extensions()
-return a STACK of extensions or NULL on error.
+X509v3_add_ext() returns a STACK of extensions or NULL on error.
+
+X509v3_add_extensions() returns a STACK of extensions
+or NULL on error or if I<*target> is NULL and I<exts> is NULL or an empty list.
 
 X509_add_ext() returns 1 on success and 0 on error.
 

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -904,9 +904,8 @@ X509_EXTENSION *X509v3_get_ext(const STACK_OF(X509_EXTENSION) *x, int loc);
 X509_EXTENSION *X509v3_delete_ext(STACK_OF(X509_EXTENSION) *x, int loc);
 STACK_OF(X509_EXTENSION) *X509v3_add_ext(STACK_OF(X509_EXTENSION) **x,
                                          X509_EXTENSION *ex, int loc);
-STACK_OF(X509_EXTENSION)
-    *X509v3_add_extensions(STACK_OF(X509_EXTENSION) **target,
-                           const STACK_OF(X509_EXTENSION) *exts);
+STACK_OF(X509_EXTENSION) *X509v3_add_extensions(STACK_OF(X509_EXTENSION) **target,
+                                                const STACK_OF(X509_EXTENSION) *exts);
 
 int X509_get_ext_count(const X509 *x);
 int X509_get_ext_by_NID(const X509 *x, int nid, int lastpos);


### PR DESCRIPTION
In case `*target == NULL && sk_X509_EXTENSION_num(exts) <= 0`,
the recently exported function `X509v3_add_extensions(target, exts)` yields NULL also in this non-error situation.
This is now properly covered by the documentation and its use in `cmp_msg.c`.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
