### PR TITLE
Use the reactor from ctx.obj for net read/write desired implementations

### DIFF
--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -1387,7 +1387,7 @@ int ossl_quic_get_net_read_desired(SSL *s)
         return 0;
 
     qctx_lock(&ctx);
-    ret = ossl_quic_reactor_net_read_desired(ossl_quic_channel_get_reactor(ctx.qc->ch));
+    ret = ossl_quic_reactor_net_read_desired(ossl_quic_obj_get0_reactor(ctx.obj));
     qctx_unlock(&ctx);
     return ret;
 }
@@ -1403,7 +1403,7 @@ int ossl_quic_get_net_write_desired(SSL *s)
         return 0;
 
     qctx_lock(&ctx);
-    ret = ossl_quic_reactor_net_write_desired(ossl_quic_channel_get_reactor(ctx.qc->ch));
+    ret = ossl_quic_reactor_net_write_desired(ossl_quic_obj_get0_reactor(ctx.obj));
     qctx_unlock(&ctx);
     return ret;
 }


### PR DESCRIPTION
The `ossl_quic_get_net_write_desired()` and `ossl_quic_reactor_net_read_desired()` implementations can be used by listeners. But in that case there is no `ctx.qc` object present. Instead we should use the reactor from `ctx.obj` which will work also for a listener.

This fixes the issue described [here](https://github.com/openssl/openssl/pull/25431#discussion_r1792592063)

It turns out the `SSL_net_read_desired()` and `SSL_net_write_desired()` functions are basically untested for QUIC. We need a test to be written for those functions (marking as tests deferred).
