### PR TITLE
Fix memory leak in tls_parse_ctos_psk()

### DIFF
--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -1121,7 +1121,7 @@ int tls_parse_ctos_psk(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
 
             if (sesstmp == NULL) {
                 SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-                return 0;
+                goto err;
             }
             SSL_SESSION_free(sess);
             sess = sesstmp;


### PR DESCRIPTION
`sess` is not NULL at this point, and is freed on the success path, but not on the error path. Fix this by going to the `err` label such that `SSL_SESSION_free(sess)` is called.

CLA: trivial


Disclaimer: this bug was found by an experimental static analyzer I'm working on. As such, I could be wrong because even though I manually read the code as well.