### PR TITLE
Http client minor fixups backport

### DIFF
--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -67,7 +67,7 @@ struct ossl_http_req_ctx_st {
     time_t max_time;            /* Maximum end time of current transfer, or 0 */
     time_t max_total_time;      /* Maximum end time of total transfer, or 0 */
     char *redirection_url;      /* Location obtained from HTTP status 301/302 */
-    size_t max_hdr_lines;       /* Max. number of http hdr lines, or 0 */
+    size_t max_hdr_lines;       /* Max. number of response header lines, or 0 */
 };
 
 /* HTTP states */
@@ -698,7 +698,6 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
         resp_hdr_lines++;
         if (rctx->max_hdr_lines != 0 && rctx->max_hdr_lines < resp_hdr_lines) {
             ERR_raise(ERR_LIB_HTTP, HTTP_R_RESPONSE_TOO_MANY_HDRLINES);
-            OSSL_TRACE(HTTP, "Received too many headers\n");
             rctx->state = OHS_ERROR;
             return 0;
         }
@@ -806,8 +805,6 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
             goto next_line;
         if (OSSL_TRACE_ENABLED(HTTP))
             OSSL_TRACE(HTTP, "]\n");
-
-        resp_hdr_lines = 0;
 
         if (rctx->keep_alive != 0 /* do not let server initiate keep_alive */
                 && !found_keep_alive /* otherwise there is no change */) {

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -620,8 +620,9 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
             }
             if (OSSL_TRACE_ENABLED(HTTP) && rctx->state == OHS_WRITE_HDR1)
                 OSSL_TRACE(HTTP, "Sending request: [\n");
-            OSSL_TRACE_STRING(HTTP, rctx->state != OHS_WRITE_REQ || rctx->text,
-                              rctx->state != OHS_WRITE_REQ, rctx->pos, sz);
+            if (OSSL_TRACE_ENABLED(HTTP))
+                OSSL_TRACE_STRING(HTTP, rctx->state != OHS_WRITE_REQ || rctx->text,
+                                  rctx->state != OHS_WRITE_REQ, rctx->pos, sz);
             if (rctx->state == OHS_WRITE_HDR1)
                 rctx->state = OHS_WRITE_HDR;
             rctx->pos += sz;

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -80,14 +80,15 @@ struct ossl_http_req_ctx_st {
 #define OHS_WRITE_HDR      (4 | OHS_NOREAD) /* Request header being sent */
 #define OHS_WRITE_REQ      (5 | OHS_NOREAD) /* Request content being sent */
 #define OHS_FLUSH          (6 | OHS_NOREAD) /* Request being flushed */
+#define OHS_ASN1_DONE      (7 | OHS_NOREAD) /* ASN1 content read completed */
+#define OHS_STREAM         (8 | OHS_NOREAD) /* HTTP content stream to be read */
 #define OHS_FIRSTLINE       1 /* First line of response being read */
 #define OHS_HEADERS         2 /* MIME headers of response being read */
 #define OHS_HEADERS_ERROR   3 /* MIME headers of resp. being read after error */
 #define OHS_REDIRECT        4 /* MIME headers being read, expecting Location */
 #define OHS_ASN1_HEADER     5 /* ASN1 sequence header (tag+length) being read */
 #define OHS_ASN1_CONTENT    6 /* ASN1 content octets being read */
-#define OHS_ASN1_DONE      (7 | OHS_NOREAD) /* ASN1 content read completed */
-#define OHS_STREAM         (8 | OHS_NOREAD) /* HTTP content stream to be read */
+#define OHS_BODY_ERROR      7 /* response body being read after error */
 
 /* Low-level HTTP API implementation */
 
@@ -577,6 +578,8 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
             }
         }
         if (n <= 0) {
+            if (rctx->state == OHS_BODY_ERROR && OSSL_TRACE_ENABLED(HTTP))
+                OSSL_TRACE(HTTP, "]\n"); /* end of error response body */
             if (BIO_should_retry(rctx->rbio))
                 return -1;
             ERR_raise(ERR_LIB_HTTP, HTTP_R_FAILED_READING_DATA);
@@ -694,6 +697,12 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
                 goto next_io;
             rctx->state = OHS_ERROR;
             return 0;
+        }
+
+        if (rctx->state == OHS_BODY_ERROR) {
+            if (OSSL_TRACE_ENABLED(HTTP)) /* dump response body line */
+                OSSL_TRACE_STRING(HTTP, got_text, 1, (unsigned char *)buf, n);
+            goto next_line;
         }
 
         resp_hdr_lines++;
@@ -818,18 +827,10 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
         }
 
         if (rctx->state == OHS_HEADERS_ERROR) {
+            rctx->state = OHS_BODY_ERROR;
             if (OSSL_TRACE_ENABLED(HTTP)) {
-                int printed_final_nl = 0;
-
                 OSSL_TRACE(HTTP, "Received error response body: [\n");
-                while ((n = BIO_read(rctx->rbio, rctx->buf, rctx->buf_size)) > 0
-                       || (OSSL_sleep(100), BIO_should_retry(rctx->rbio))) {
-                    OSSL_TRACE_STRING(HTTP, got_text, 1, rctx->buf, n);
-                    if (n > 0)
-                        printed_final_nl = rctx->buf[n - 1] == '\n';
-                }
-                OSSL_TRACE1(HTTP, "%s]\n", printed_final_nl ? "" : "\n");
-                (void)printed_final_nl; /* avoid warning unless enable-trace */
+                goto next_line;
             }
             return 0;
         }

--- a/doc/man3/OSSL_HTTP_REQ_CTX.pod
+++ b/doc/man3/OSSL_HTTP_REQ_CTX.pod
@@ -198,9 +198,11 @@ I/O error when trying to send the next request via I<rctx>.
 
 The OSSL_HTTP_REQ_CTX_set_max_response_hdr_lines() function changes the limit
 for the number of HTTP headers which can be received in a response. The default
-value is 256.  If the number of HTTP headers in a response exceeds the limit,
+value is B<OSSL_HTTP_DEFAULT_MAX_RESP_HDR_LINES>, currently 256.
+If the number of HTTP headers in a response exceeds the limit,
 then the HTTP_R_RESPONSE_TOO_MANY_HDRLINES error is indicated. Setting the
 limit to 0 disables the check.
+
 
 =head1 WARNINGS
 
@@ -248,8 +250,8 @@ See also L<OSSL_trace_enabled(3)> and L<openssl-env(7)>.
 OSSL_HTTP_REQ_CTX_new() returns a pointer to a B<OSSL_HTTP_REQ_CTX>, or NULL
 on error.
 
-OSSL_HTTP_REQ_CTX_free() and OSSL_HTTP_REQ_CTX_set_max_response_length()
-do not return values.
+OSSL_HTTP_REQ_CTX_free(), OSSL_HTTP_REQ_CTX_set_max_response_length(), and
+OSSL_HTTP_REQ_CTX_set_max_response_hdr_lines() do not return values.
 
 OSSL_HTTP_REQ_CTX_set_request_line(), OSSL_HTTP_REQ_CTX_add1_header(),
 OSSL_HTTP_REQ_CTX_set1_req(), and OSSL_HTTP_REQ_CTX_set_expected()
@@ -283,7 +285,9 @@ L<OSSL_trace_enabled(3)>, and L<openssl-env(7)>.
 
 =head1 HISTORY
 
-The functions described here were added in OpenSSL 3.0.
+OSSL_HTTP_REQ_CTX_set_max_response_hdr_lines() was added in OpenSSL 3.3.
+
+All other functions described here were added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
As requested, this backports the essential parts of the fixup PR #25541:
* partial HTTP trace output when tracing not enabled for HTTP (since 3.2)
* empty HTTP trace output for body of error response message (since 3.3)
* redundant trace output for an error already placed in the error queue (since 3.3)
* documentation omissions of PR #23781 (since 3.3)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated