### PR TITLE
TRACE: automatically respect disabled categories

### DIFF
--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -475,7 +475,7 @@ BIO *OSSL_trace_begin(int category)
     char *prefix = NULL;
 
     category = ossl_trace_get_category(category);
-    if (category < 0)
+    if (category < 0 || !OSSL_trace_enabled(category))
         return NULL;
 
     channel = trace_channels[category].bio;

--- a/doc/man3/OSSL_trace_enabled.pod
+++ b/doc/man3/OSSL_trace_enabled.pod
@@ -97,9 +97,10 @@ I<category> is enabled, i.e., if the tracing facility has been statically
 enabled (see L</Configure Tracing> below) and a trace channel has been
 registered using L<OSSL_trace_set_channel(3)> or L<OSSL_trace_set_callback(3)>.
 
-OSSL_trace_begin() is used to starts a tracing section, and get the
-channel for the given I<category> in form of a BIO.
+OSSL_trace_begin() is used to start a tracing section,
+and get the channel for the given I<category> in form of a BIO.
 This BIO can only be used for output.
+The pointer returned is NULL if the category is invalid or not enabled.
 
 OSSL_trace_end() is used to end a tracing section.
 
@@ -210,6 +211,9 @@ expands to
  }
 
 =head1 NOTES
+
+It is not needed to guard trace output function calls like
+I<OSSL_TRACE(category, ...)> by I<OSSL_TRACE_ENABLED(category)>.
 
 If producing the trace output requires carrying out auxiliary calculations,
 this auxiliary code should be placed inside a conditional block which is


### PR DESCRIPTION
by `OSSL_trace_begin()` returning NULL when the category in question is not enabled.

I have already been wondering for a while why `OSSL_TRACE_STRING()`, `OSSL_TRACEV()`, and friends still produce output when the respective category is not enabled.

It is very tedious and easily forgotten to guard calls to, e.g., `OSSL_TRACE(category, ...)` by `OSSL_TRACE_ENABLED(category)`.
As a current example see #25647 and https://github.com/openssl/openssl/pull/25541#issuecomment-2398793239.

To me this is not just counter-intuitive, but a bug.
This appears surprisingly simple to fix.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
