### PR TITLE
Fix potential double free through SRP_user_pwd_set1_ids()

### DIFF
--- a/crypto/srp/srp_vfy.c
+++ b/crypto/srp/srp_vfy.c
@@ -214,6 +214,8 @@ int SRP_user_pwd_set1_ids(SRP_user_pwd *vinfo, const char *id,
 {
     OPENSSL_free(vinfo->id);
     OPENSSL_free(vinfo->info);
+    vinfo->id = NULL;
+    vinfo->info = NULL;
     if (id != NULL && NULL == (vinfo->id = OPENSSL_strdup(id)))
         return 0;
     return (info == NULL || NULL != (vinfo->info = OPENSSL_strdup(info)));


### PR DESCRIPTION
If SRP_user_pwd_set1_ids() fails during one of the duplications, or id is NULL, then the old pointer values are still stored but they are now dangling. Later when SRP_user_pwd_free() is called on failure these are freed again, leading to a double free.
Although there are no such uses in OpenSSL as far as I found (all calls are on new objects), it's still a public API.

CLA: trivial

(Side note: I will be able to get a proper CLA soon)