### PR TITLE
SSL_inject_net_dgram() should return result of  ossl_quic_demux_inject()

### DIFF
--- a/doc/designs/quic-design/glossary.md
+++ b/doc/designs/quic-design/glossary.md
@@ -179,6 +179,21 @@ listener (QLSO) in the APL.
 QLSO. This is the QUIC core object corresponding to the APL's `QUIC_LISTENER`
 object (a QLSO). Owns zero more `QUIC_CHANNEL` instances.
 
+**QL:** See `QUIC_LISTENER`.
+
+**QLSO:** QUIC Listener SSL Object. An object created to represent a socket
+which can accept one or more incoming QUIC connections and/or make multiple
+outgoing QUIC connections. Parent of zero or more QCSOs.
+
+**QUIC_LISTENER:** QUIC listener. This is the APL object representing a QUIC
+listener (QLSO) in the APL.
+
+**QP:** See `QUIC_PORT`.
+
+**QUIC_PORT:** Internal object owning the network socket BIO which services a
+QLSO. This is the QUIC core object corresponding to the APL's `QUIC_LISTENER`
+object (a QLSO). Owns zero more `QUIC_CHANNEL` instances.
+
 **QRL:** QUIC record layer. Refers collectively to the QRX and QTX.
 
 **QRX:** QUIC Record Layer RX. Receives incoming datagrams and decrypts the

--- a/doc/designs/quic-design/glossary.md
+++ b/doc/designs/quic-design/glossary.md
@@ -179,21 +179,6 @@ listener (QLSO) in the APL.
 QLSO. This is the QUIC core object corresponding to the APL's `QUIC_LISTENER`
 object (a QLSO). Owns zero more `QUIC_CHANNEL` instances.
 
-**QL:** See `QUIC_LISTENER`.
-
-**QLSO:** QUIC Listener SSL Object. An object created to represent a socket
-which can accept one or more incoming QUIC connections and/or make multiple
-outgoing QUIC connections. Parent of zero or more QCSOs.
-
-**QUIC_LISTENER:** QUIC listener. This is the APL object representing a QUIC
-listener (QLSO) in the APL.
-
-**QP:** See `QUIC_PORT`.
-
-**QUIC_PORT:** Internal object owning the network socket BIO which services a
-QLSO. This is the QUIC core object corresponding to the APL's `QUIC_LISTENER`
-object (a QLSO). Owns zero more `QUIC_CHANNEL` instances.
-
 **QRL:** QUIC record layer. Refers collectively to the QRX and QTX.
 
 **QRX:** QUIC Record Layer RX. Receives incoming datagrams and decrypts the

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -2109,7 +2109,6 @@ static int qc_wait_for_default_xso_for_read(QCTX *ctx, int peek)
             return QUIC_RAISE_NON_NORMAL_ERROR(ctx, SSL_R_PROTOCOL_IS_SHUTDOWN, NULL);
         } else if (!qctx_blocking(ctx)) {
             /* Non-blocking mode, so just bail immediately. */
-            /* Non-blocking mode, so just bail immediately. */
             return QUIC_RAISE_NORMAL_ERROR(ctx, SSL_ERROR_WANT_READ);
         }
 

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -2109,6 +2109,7 @@ static int qc_wait_for_default_xso_for_read(QCTX *ctx, int peek)
             return QUIC_RAISE_NON_NORMAL_ERROR(ctx, SSL_R_PROTOCOL_IS_SHUTDOWN, NULL);
         } else if (!qctx_blocking(ctx)) {
             /* Non-blocking mode, so just bail immediately. */
+            /* Non-blocking mode, so just bail immediately. */
             return QUIC_RAISE_NORMAL_ERROR(ctx, SSL_ERROR_WANT_READ);
         }
 

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -3199,7 +3199,6 @@ int SSL_inject_net_dgram(SSL *s, const unsigned char *buf,
     demux = ossl_quic_port_get0_demux(port);
     ret = ossl_quic_demux_inject(demux, buf, buf_len, peer, local);
 
-    ret = 1;
 err:
     qctx_unlock(&ctx);
     return ret;


### PR DESCRIPTION
This got introduced by 595288251bb (QUIC APL: Ensure APL functions use correct prologue)

