### PR TITLE
Workflow to automate creating of GitHub releases

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -1,0 +1,30 @@
+# Copyright 2021-2024 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+name: "Make release"
+
+on:
+  push:
+    tags:
+      - "openssl-*"
+
+jobs:
+  release:
+    runs-on: "releaser"
+    steps:
+    - name: "Prepare assets"
+      run: |
+        curl -L -O -H "Authorization: Bearer ${{ secrets.GHE_TOKEN }}" https://github.openssl.org/openssl/openssl/archive/refs/tags/${{ github.ref_name }}.tar.gz
+        openssl sha1 < ${{ github.ref_name }}.tar.gz | cut -d " " -f 2 > ${{ github.ref_name }}.tar.gz.sha1
+        openssl sha256 < ${{ github.ref_name }}.tar.gz | cut -d " " -f 2 > ${{ github.ref_name }}.tar.gz.sha256
+        gpg -u ${{ vars.signing_key_uid }} -sba ${{ github.ref_name }}.tar.gz
+    - name: "Create release"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      run: |
+        VERSION=$(echo ${{ github.ref_name }} | cut -d "-" -f 2-)
+        gh release create ${{ github.ref_name }} -t "OpenSSL $VERSION" -d --notes " " -R ${{ github.repository }} ${{ github.ref_name }}.tar.gz*

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -11,7 +11,6 @@ on:
   push:
     tags:
       - "openssl-*"
-  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -11,6 +11,7 @@ on:
   push:
     tags:
       - "openssl-*"
+  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -16,15 +16,26 @@ jobs:
   release:
     runs-on: "releaser"
     steps:
+    - name: "Checkout"
+      uses: "actions/checkout@v4"
+      with:
+        fetch-depth: 1
+        ref: ${{ github.ref_name }}
+        github-server-url: "https://github.openssl.org/"
+        repository: "openssl/openssl"
+        token: ${{ secrets.GHE_TOKEN }}
+        path: ${{ github.ref_name }}
     - name: "Prepare assets"
       run: |
-        curl -L -O -H "Authorization: Bearer ${{ secrets.GHE_TOKEN }}" https://github.openssl.org/openssl/openssl/archive/refs/tags/${{ github.ref_name }}.tar.gz
+        cd ${{ github.ref_name }}
+        ./util/mktar.sh
+        mkdir assets && mv ${{ github.ref_name }}.tar.gz assets/ && cd assets
         openssl sha1 < ${{ github.ref_name }}.tar.gz | cut -d " " -f 2 > ${{ github.ref_name }}.tar.gz.sha1
         openssl sha256 < ${{ github.ref_name }}.tar.gz | cut -d " " -f 2 > ${{ github.ref_name }}.tar.gz.sha256
-        gpg -u ${{ vars.signing_key_uid }} -sba ${{ github.ref_name }}.tar.gz
+        gpg -u ${{ vars.signing_key_uid }} -o ${{ github.ref_name }}.tar.gz.asc -sba ${{ github.ref_name }}.tar.gz
     - name: "Create release"
       env:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       run: |
         VERSION=$(echo ${{ github.ref_name }} | cut -d "-" -f 2-)
-        gh release create ${{ github.ref_name }} -t "OpenSSL $VERSION" -d --notes " " -R ${{ github.repository }} ${{ github.ref_name }}.tar.gz*
+        gh release create ${{ github.ref_name }} -t "OpenSSL $VERSION" -d --notes " " -R ${{ github.repository }} ${{ github.ref_name }}/assets/*


### PR DESCRIPTION
This workflow creates a draft GitHub release when a tag with pattern `openssl-*` is pushed to the repo. Also this workflow can be triggered manually. The workflow is executed on a self-hosted runner in the environment which OpenSSL team owns. 

[Test job run](https://github.com/quarckster/openssl-fork/actions/runs/11328721778/job/31502594961)
[Test release](https://github.com/quarckster/openssl-fork/releases/tag/openssl-3.3.2)
