### PR TITLE
25-test_pkcs8.t: Remove unused use import

### DIFF
--- a/test/recipes/25-test_pkcs8.t
+++ b/test/recipes/25-test_pkcs8.t
@@ -11,7 +11,7 @@ use warnings;
 
 use OpenSSL::Test::Utils;
 use File::Copy;
-use File::Compare qw(compare_text compare);
+use File::Compare qw(compare_text);
 use OpenSSL::Test qw/:DEFAULT srctop_file ok_nofips is_nofips/;
 
 setup("test_pkcs8");


### PR DESCRIPTION
For these identical file tests, even the in and out filenames are the same, output file format would change to be DOS format on Windows and that failed the tests.

CLA: trivial
