### PR TITLE
Revert API change of OPENSSL_version()

### DIFF
--- a/apps/version.c
+++ b/apps/version.c
@@ -147,7 +147,7 @@ opthelp:
         printf("%s\n", OpenSSL_version(OPENSSL_CPU_INFO));
 #if defined(_WIN32)
     if (windows)
-        printf("OSSL_WINCTX: %s\n", OpenSSL_version(OPENSSL_WINCTX));
+        printf("%s\n", OpenSSL_version(OPENSSL_WINCTX));
 #endif
     ret = 0;
  end:

--- a/apps/version.c
+++ b/apps/version.c
@@ -56,7 +56,6 @@ int version_main(int argc, char **argv)
 #endif
     char *prog;
     OPTION_CHOICE o;
-    const char *tmp;
 
     prog = opt_init(argc, argv, version_options);
     while ((o = opt_next()) != OPT_EOF) {
@@ -134,18 +133,12 @@ opthelp:
     }
     if (cflags)
         printf("%s\n", OpenSSL_version(OPENSSL_CFLAGS));
-    if (dir) {
-        tmp = OpenSSL_version(OPENSSL_DIR);
-        printf("OPENSSLDIR: %s\n", tmp == NULL ? "Undefined" : tmp);
-    }
-    if (engdir) {
-        tmp = OpenSSL_version(OPENSSL_ENGINES_DIR);
-        printf("ENGINESDIR: %s\n", tmp == NULL ? "Undefined" : tmp);
-    }
-    if (moddir) {
-        tmp = OpenSSL_version(OPENSSL_MODULES_DIR);
-        printf("MODULESDIR: %s\n", tmp == NULL ? "Undefined" : tmp);
-    }
+    if (dir)
+        printf("%s\n", OpenSSL_version(OPENSSL_DIR));
+    if (engdir)
+        printf("%s\n", OpenSSL_version(OPENSSL_ENGINES_DIR));
+    if (moddir)
+        printf("%s\n", OpenSSL_version(OPENSSL_MODULES_DIR));
     if (seed) {
         const char *src = OPENSSL_info(OPENSSL_INFO_SEED_SOURCE);
         printf("Seeding source: %s\n", src ? src : "N/A");

--- a/crypto/cversion.c
+++ b/crypto/cversion.c
@@ -125,7 +125,11 @@ const char *OpenSSL_version(int t)
         else
             return "CPUINFO: N/A";
     case OPENSSL_WINCTX:
-        return ossl_get_wininstallcontext();
+#if defined(_WIN32) && defined(OSSL_WINCTX)
+        return "OSSL_WINCTX: \"" MAKESTR(OSSL_WINCTX) "\"";
+#else
+        return "OSSL_WINCTX: Undefined";
+#endif
     }
     return "not available";
 }

--- a/crypto/cversion.c
+++ b/crypto/cversion.c
@@ -70,6 +70,10 @@ DEFINE_RUN_ONCE_STATIC(version_strings_setup)
                  ossl_get_modulesdir());
     return 1;
 }
+
+# define TOSTR(x) #x
+# define OSSL_WINCTX_VERSION_STRING "OSSL_WINCTX: \"" ## TOSTR(OSSL_WINCTX) ## "\""
+
 #endif
 
 const char *OpenSSL_version(int t)
@@ -126,7 +130,7 @@ const char *OpenSSL_version(int t)
             return "CPUINFO: N/A";
     case OPENSSL_WINCTX:
 #if defined(_WIN32) && defined(OSSL_WINCTX)
-        return "OSSL_WINCTX: \"" MAKESTR(OSSL_WINCTX) "\"";
+        return OSSL_WINCTX_VERSION_STRING;
 #else
         return "OSSL_WINCTX: Undefined";
 #endif

--- a/crypto/cversion.c
+++ b/crypto/cversion.c
@@ -72,7 +72,7 @@ DEFINE_RUN_ONCE_STATIC(version_strings_setup)
 }
 
 # define TOSTR(x) #x
-# define OSSL_WINCTX_VERSION_STRING "OSSL_WINCTX: \"" ## TOSTR(OSSL_WINCTX) ## "\""
+# define OSSL_WINCTX_STRING "OSSL_WINCTX: \"" ## TOSTR(OSSL_WINCTX) ## "\""
 
 #endif
 
@@ -130,7 +130,7 @@ const char *OpenSSL_version(int t)
             return "CPUINFO: N/A";
     case OPENSSL_WINCTX:
 #if defined(_WIN32) && defined(OSSL_WINCTX)
-        return OSSL_WINCTX_VERSION_STRING;
+        return OSSL_WINCTX_STRING;
 #else
         return "OSSL_WINCTX: Undefined";
 #endif


### PR DESCRIPTION
There was an API change done as part of PR #24450. This patch reverts it.
