### PR TITLE
Add 'openssl info' item for the Windows install context

### DIFF
--- a/apps/info.c
+++ b/apps/info.c
@@ -14,7 +14,7 @@
 typedef enum OPTION_choice {
     OPT_COMMON,
     OPT_CONFIGDIR, OPT_ENGINESDIR, OPT_MODULESDIR, OPT_DSOEXT, OPT_DIRNAMESEP,
-    OPT_LISTSEP, OPT_SEEDS, OPT_CPUSETTINGS
+    OPT_LISTSEP, OPT_SEEDS, OPT_CPUSETTINGS, OPT_WINDOWSCONTEXT
 } OPTION_CHOICE;
 
 const OPTIONS info_options[] = {
@@ -32,6 +32,7 @@ const OPTIONS info_options[] = {
     {"listsep", OPT_LISTSEP, '-', "List separator character"},
     {"seeds", OPT_SEEDS, '-', "Seed sources"},
     {"cpusettings", OPT_CPUSETTINGS, '-', "CPU settings info"},
+    {"windowscontext", OPT_WINDOWSCONTEXT, '-', "Windows install context"},
     {NULL}
 };
 
@@ -83,6 +84,10 @@ opthelp:
             break;
         case OPT_CPUSETTINGS:
             type = OPENSSL_INFO_CPU_SETTINGS;
+            dirty++;
+            break;
+        case OPT_WINDOWSCONTEXT:
+            type = OPENSSL_INFO_WINDOWS_CONTEXT;
             dirty++;
             break;
         }

--- a/crypto/info.c
+++ b/crypto/info.c
@@ -243,6 +243,8 @@ const char *OPENSSL_info(int t)
         if (ossl_cpu_info_str[0] != '\0')
             return ossl_cpu_info_str + strlen(CPUINFO_PREFIX);
         break;
+    case OPENSSL_INFO_WINDOWS_CONTEXT:
+        return ossl_get_wininstallcontext();
     default:
         break;
     }

--- a/doc/man1/openssl-info.pod.in
+++ b/doc/man1/openssl-info.pod.in
@@ -73,6 +73,10 @@ Outputs the randomness seed sources.
 
 Outputs the OpenSSL CPU settings info.
 
+=item B<-windowscontext>
+
+Outputs the Windows install context.
+
 =back
 
 =head1 HISTORY

--- a/doc/man3/OpenSSL_version.pod
+++ b/doc/man3/OpenSSL_version.pod
@@ -211,6 +211,15 @@ automatically configured but may be set via an environment variable.
 The value has the same syntax as the environment variable.
 For x86 the string looks like C<OPENSSL_ia32cap=0x123:0x456>.
 
+=item OPENSSL_INFO_WINDOWS_CONTEXT
+
+The Windows install context.
+The Windows install context is used to compute the OpenSSL registry key name
+on Windows.  The full registry key is
+C<SOFTWARE\WOW6432Node\OpenSSL-{major}.{minor}-{context}>, where C<{major}>,
+C<{minor}> and C<{context}> are OpenSSL's major version number, minor version
+number and the Windows install context, respectively.
+
 =back
 
 For an unknown I<t>, NULL is returned.

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -186,6 +186,7 @@ const char *OPENSSL_info(int type);
 # define OPENSSL_INFO_LIST_SEPARATOR            1006
 # define OPENSSL_INFO_SEED_SOURCE               1007
 # define OPENSSL_INFO_CPU_SETTINGS              1008
+# define OPENSSL_INFO_WINDOWS_CONTEXT           1009
 
 int OPENSSL_issetugid(void);
 


### PR DESCRIPTION
This information is already present as an 'openssl version' item.
