### PR TITLE
fix: let util/mkbuildinf.pl use SOURCE_DATE_EPOCH, even if it's zero

### DIFF
--- a/util/mkbuildinf.pl
+++ b/util/mkbuildinf.pl
@@ -12,7 +12,9 @@ use warnings;
 my ($cflags, $platform) = @ARGV;
 $cflags = "compiler: $cflags";
 
-my $date = gmtime($ENV{'SOURCE_DATE_EPOCH'} || time()) . " UTC";
+# Use the value of the envvar SOURCE_DATE_EPOCH, even if it's
+# zero or the empty string.
+my $date = gmtime($ENV{'SOURCE_DATE_EPOCH'} // time()) . " UTC";
 
 print <<"END_OUTPUT";
 /*


### PR DESCRIPTION
Doing this allows reproducible builds, for those who want this.

Fixes #25475
