### PR TITLE
Fix missing sendmmsg/recvmmsg on AIX

### DIFF
--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -66,7 +66,7 @@
    #undef NO_RECVMSG
    #define NO_RECVMSG
 # endif
-# if defined(__ANDROID_API__) && __ANDROID_API__ < 21
+# if (defined(__ANDROID_API__) && __ANDROID_API__ < 21) || defined(_AIX)
 #  undef NO_RECVMMSG
 #  define NO_RECVMMSG
 # endif


### PR DESCRIPTION
This at least fixes the build failures on AIX

This will not fix the test failures though.
