### PR TITLE
Dependabot: no longer set an "approval: otc review pending" label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,5 @@ updates:
       - "dependencies"
       - "cla: trivial"
       - "approval: review pending"
-      - "approval: otc review pending"
     reviewers:
       - "openssl/committers"


### PR DESCRIPTION
The label doesn't exist anymore.
