### PR TITLE
openssl-info.pod.in: Add windowscontext option to synopsis in doc

### DIFF
--- a/doc/man1/openssl-info.pod.in
+++ b/doc/man1/openssl-info.pod.in
@@ -17,6 +17,7 @@ B<openssl info>
 [B<-listsep>]
 [B<-seeds>]
 [B<-cpusettings>]
+[B<-windowscontext>]
 
 =head1 DESCRIPTION
 
@@ -82,6 +83,8 @@ Outputs the Windows install context.
 =head1 HISTORY
 
 This command was added in OpenSSL 3.0.
+
+The B<-windowscontext> option was added in OpenSSL 3.4.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
This is urgent to fix doc-nits CI regression.