### PR TITLE
os-zoo CI: Replace macos-12 run with macos-15

### DIFF
--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -7,9 +7,9 @@
 
 name: OS Zoo CI
 
-on:
-  schedule:
-    - cron: '0 5 * * *'
+on: [pull_request]
+#  schedule:
+#    - cron: '0 5 * * *'
 
 permissions:
   contents: read

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -108,7 +108,7 @@ jobs:
       fail-fast: false
       matrix:
         branch: [openssl-3.0, openssl-3.1, master]
-        os: [macos-12, macos-13, macos-14]
+        os: [macos-13, macos-14, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
macos-12 runners will be removed in December.
