### PR TITLE
Buffer file-based BIO reads on Windows

### DIFF
--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -235,15 +235,6 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
                 _setmode(fd, _O_TEXT);
             else
                 _setmode(fd, _O_BINARY);
-            /*
-             * Reports show that ftell() isn't trustable in text mode.
-             * This has been confirmed as a bug in the Universal C RTL, see
-             * https://developercommunity.visualstudio.com/content/problem/425878/fseek-ftell-fail-in-text-mode-for-unix-style-text.html
-             * The suggested work-around from Microsoft engineering is to
-             * turn off buffering until the bug is resolved.
-             */
-            if ((num & BIO_FP_TEXT) != 0)
-                setvbuf((FILE *)ptr, NULL, _IONBF, 0);
 # elif defined(OPENSSL_SYS_MSDOS)
             int fd = fileno((FILE *)ptr);
             /* Set correct text/binary mode */

--- a/crypto/engine/eng_openssl.c
+++ b/crypto/engine/eng_openssl.c
@@ -422,7 +422,11 @@ static EVP_PKEY *openssl_load_privkey(ENGINE *eng, const char *key_id,
     EVP_PKEY *key;
     fprintf(stderr, "(TEST_ENG_OPENSSL_PKEY)Loading Private key %s\n",
             key_id);
+# if defined(OPENSSL_SYS_WINDOWS)
+    in = BIO_new_file(key_id, "rb");
+# else
     in = BIO_new_file(key_id, "r");
+# endif
     if (!in)
         return NULL;
     key = PEM_read_bio_PrivateKey(in, NULL, 0, NULL);

--- a/crypto/ts/ts_conf.c
+++ b/crypto/ts/ts_conf.c
@@ -50,7 +50,11 @@ X509 *TS_CONF_load_cert(const char *file)
     BIO *cert = NULL;
     X509 *x = NULL;
 
+#if defined(OPENSSL_SYS_WINDOWS)
+    if ((cert = BIO_new_file(file, "rb")) == NULL)
+#else
     if ((cert = BIO_new_file(file, "r")) == NULL)
+#endif
         goto end;
     x = PEM_read_bio_X509_AUX(cert, NULL, NULL, NULL);
  end:
@@ -67,7 +71,11 @@ STACK_OF(X509) *TS_CONF_load_certs(const char *file)
     STACK_OF(X509_INFO) *allcerts = NULL;
     int i;
 
+#if defined(OPENSSL_SYS_WINDOWS)
+    if ((certs = BIO_new_file(file, "rb")) == NULL)
+#else
     if ((certs = BIO_new_file(file, "r")) == NULL)
+#endif
         goto end;
     if ((othercerts = sk_X509_new_null()) == NULL)
         goto end;
@@ -98,7 +106,11 @@ EVP_PKEY *TS_CONF_load_key(const char *file, const char *pass)
     BIO *key = NULL;
     EVP_PKEY *pkey = NULL;
 
+#if defined(OPENSSL_SYS_WINDOWS)
+    if ((key = BIO_new_file(file, "rb")) == NULL)
+#else
     if ((key = BIO_new_file(file, "r")) == NULL)
+#endif
         goto end;
     pkey = PEM_read_bio_PrivateKey(key, NULL, NULL, (char *)pass);
  end:

--- a/crypto/x509/by_file.c
+++ b/crypto/x509/by_file.c
@@ -238,7 +238,11 @@ int X509_load_cert_crl_file_ex(X509_LOOKUP *ctx, const char *file, int type,
 
     if (type != X509_FILETYPE_PEM)
         return X509_load_cert_file_ex(ctx, file, type, libctx, propq);
+#if defined(OPENSSL_SYS_WINDOWS)
+    in = BIO_new_file(file, "rb");
+#else
     in = BIO_new_file(file, "r");
+#endif
     if (in == NULL) {
         ERR_raise(ERR_LIB_X509, ERR_R_BIO_LIB);
         return 0;


### PR DESCRIPTION
This is a follow up to my [previous PR and discussion](https://github.com/openssl/openssl/pull/24249#issuecomment-2192025429) to resolve a performance issue due to openssl disabling buffered reads for file-based `BIO`s in text mode on Windows. This PR reverts the commit that disabled buffering and modifies the file-based `BIO` to read PEM files in binary mode, since the PEM parser already handles `CRLF` correctly.

This resolves the immediate issue I was seeing, but I did have some questions for reviewers:

1. Should I be special casing `OPENSSL_SYS_VMS` as is done in https://github.com/openssl/openssl/blob/6bb62ab82682b9e19d594eb8fd52a5a560ba65f3/crypto/conf/conf_def.c#L172-L176
2. Do these other other call sites need to be modified?

```
$ git grep BIO_new_file | grep -E '("r"|"w")' | grep -vE '^demos' | grep -vE '^test' | grep -vE '^apps'
crypto/conf/conf_def.c:    in = BIO_new_file(name, "r");
crypto/conf/conf_def.c:                next = BIO_new_file(include_path, "r");
crypto/conf/conf_def.c:    next = BIO_new_file(include, "r");
crypto/conf/conf_def.c:            bio = BIO_new_file(newpath, "r");
crypto/conf/conf_lib.c:    in = BIO_new_file(file, "r");
crypto/engine/eng_openssl.c:    in = BIO_new_file(key_id, "r");
crypto/ts/ts_conf.c:    if ((cert = BIO_new_file(file, "r")) == NULL)
crypto/ts/ts_conf.c:    if ((certs = BIO_new_file(file, "r")) == NULL)
crypto/ts/ts_conf.c:    if ((key = BIO_new_file(file, "r")) == NULL)
crypto/x509/v3_pci.c:            BIO *b = BIO_new_file(valp, "r");
doc/man3/BIO_s_file.pod: out = BIO_new_file("filename.txt", "w");
engines/e_ossltest.c:    in = BIO_new_file(key_id, "r");
```
3. I wasn't sure whether tests are needed or where best to add it, though I manually verified Windows now reads `cert.pem` using a 4k buffer.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
