### PR TITLE
ecdh_cofactor_derive_test(): Skip the test if the curve is not supported

### DIFF
--- a/.github/workflows/run-checker-merge.yml
+++ b/.github/workflows/run-checker-merge.yml
@@ -22,7 +22,7 @@ jobs:
           no-ct,
           no-dso,
           no-dynamic-engine,
-          no-ec2m,
+          no-ec2m enable-fips,
           no-engine no-shared,
           no-err,
           no-filenames,

--- a/test/acvp_test.c
+++ b/test/acvp_test.c
@@ -363,8 +363,10 @@ static int ecdh_cofactor_derive_test(int tstid)
     if (!ec_cofactors)
         return TEST_skip("not supported by FIPS provider version");
 
-    if (!TEST_ptr(peer1 = EVP_PKEY_Q_keygen(libctx, NULL, "EC", curve))
-            || !TEST_ptr(peer2 = EVP_PKEY_Q_keygen(libctx, NULL, "EC", curve)))
+    if (!TEST_ptr(peer1 = EVP_PKEY_Q_keygen(libctx, NULL, "EC", curve)))
+        return TEST_skip("Curve %s not supported by the FIPS provider", curve);
+
+    if (!TEST_ptr(peer2 = EVP_PKEY_Q_keygen(libctx, NULL, "EC", curve)))
         goto err;
 
     params[1] = OSSL_PARAM_construct_end();


### PR DESCRIPTION
It will not be supported if the fips provider was built with no-ec2m.
    
Fixes #25729

Also adjust run-checker-merge.yml to detect this issue.