### PR TITLE
keymgmt: refactor fips indicator check

### DIFF
--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -1306,14 +1306,10 @@ static void *ec_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
         }
     }
 #ifdef FIPS_MODULE
-    if (!ossl_ec_check_security_strength(gctx->gen_group, 1)) {
-        if (!OSSL_FIPS_IND_ON_UNAPPROVED(gctx, OSSL_FIPS_IND_SETTABLE0,
-                                         gctx->libctx, "EC KeyGen", "key size",
-                                         ossl_fips_config_securitycheck_enabled)) {
-            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
-            goto err;
-        }
-    }
+    if (!ossl_fips_ind_ec_key_check(OSSL_FIPS_IND_GET(gctx),
+                                    OSSL_FIPS_IND_SETTABLE0, gctx->libctx,
+                                    gctx->gen_group, "EC KeyGen", 1))
+        goto err;
 #endif
 
     /* We must always assign a group, no matter what */


### PR DESCRIPTION
Currently direct call to ossl_ec_check_security_strength is used,
instead of ossl_fips_ind_ec_key_check() like in all other places.

Make keymgmt do the same check as ecdh_exch and ecdsa_sig do.
