### PR TITLE
fix coverity issues

### DIFF
--- a/providers/implementations/kem/template_kem.c
+++ b/providers/implementations/kem/template_kem.c
@@ -142,10 +142,8 @@ static int template_encapsulate(void *vctx, unsigned char *out, size_t *outlen,
     if (secretlen != NULL)
         *secretlen = 0; /* replace with real shared secret length */
 
-    if (out == NULL) {
-        debug_print("encaps outlens set to %d and %d\n", *outlen, *secretlen);
+    if (out == NULL)
         return 1;
-    }
 
     /* check key and perform real KEM operation */
 
@@ -156,17 +154,15 @@ static int template_encapsulate(void *vctx, unsigned char *out, size_t *outlen,
 static int template_decapsulate(void *vctx, unsigned char *out, size_t *outlen,
                                 const unsigned char *in, size_t inlen)
 {
-    debug_print("decaps %p to %p inlen at %d\n", vctx, out, inlen);
+    debug_print("decaps %p to %p inlen at %u\n", vctx, out, inlen);
 
     /* add algorithm-specific length checks */
 
     if (outlen != NULL)
         *outlen = 0; /* replace with shared secret length */
 
-    if (out == NULL) {
-        debug_print("decaps outlen set to %d \n", *outlen);
+    if (out == NULL)
         return 1;
-    }
 
     /* check key and perform real decaps operation */
 


### PR DESCRIPTION
this PR fixes coverity issues reported on Oct 21st 2024
  - CID 1633357  Null pointer dereferences  (FORWARD_NULL), line 167
  - CID 1633356  Null pointer dereferences  (FORWARD_NULL), line 146
  - CID 1633355  API usage errors  (PRINTF_ARGS), line 159
  - CID 1633354  API usage errors  (PRINTF_ARGS), line 146
  - CID 1633353  Null pointer dereferences  (FORWARD_NULL). line 146
  - CID 1633352  API usage errors  (PRINTF_ARGS). line 146
  - CID 1633351  API usage errors  (PRINTF_ARGS). line 167

also I'm not sure if those debug_print() should be eventually changed to some OPENSSL_TRACE(), but it's another PR perhaps.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
