### PR TITLE
doc: add more documentation around SP 800-131A

### DIFF
--- a/doc/designs/sp800-131A.md
+++ b/doc/designs/sp800-131A.md
@@ -1,0 +1,81 @@
+OpenSSL and NIST SP 800-131A
+============================
+
+NIST periodically publishes and updates [NIST SP
+800-131A](https://csrc.nist.gov/pubs/sp/800/131/a/r2/final)
+"Transitioning the Use of Cryptographic Algorithms and Key
+Lengths". That document is time-dependent implementation requirements
+for submissions or updates to FIPS certified cryptographic modules.
+
+Various configure time, and runtime indicators exist to address issues
+raised by this document. This reference is meant to document various
+options that control OpenSSL FIPS provider behaviour of dissallowed,
+legacy-only, and deprecated algorithms.
+
+This will hopefully be a living document that can explain various
+build options availalble in OpenSSL to compile a future-proof FIPS
+provider without any dissallowed/legacy-only/deprecated behaviour.
+
+
+NIST SP 800-131Ar2
+------------------
+
+## tl;dr
+
+`enable-fips no-des no-dsa no-ec2m disable-fips186-4-ffc enable-fips-pedanticonly`
+
+> [!WARNING]
+> Currently such configuration doesn't work yet / not yet fully merged
+
+### 2 Encryption and Decryption Using Block Cipher Algorithms
+
+TDEA can be disabled with `no-des` configuration option.
+Skipjack not present.
+
+### 3 Digital Signatures
+
+DSA can be disabled using `no-dsa`.
+
+Binary curves can be disabled using `no-ec2m`.
+
+ECDSA & RSA mininum key sizes enforced with fips-indicator. However
+legacy use is allowed.
+
+> [!NOTE]
+> Enforcing fips-indicators as implicit service indicator needs https://github.com/openssl/openssl/pull/25276
+
+> [!WARNING]
+> add compile time options to increase signature verification minimum thresholds
+
+### 4 Random Bit Generation
+
+Only Acceptable RBG present
+
+### 5 Key Agreement Using Diffie-Hellman and MQV
+
+FIPS 186-type domain parameters are acceptable, but can be disabled
+with disable-fips186-4-ffc.
+
+> [!NOTE]
+> Pull request https://github.com/openssl/openssl/pull/25720 not yet merged
+
+### 6 Key Agreement and Key Transport Using RSA
+
+Only acceptable is supported.
+
+### 7 Key Wrapping
+
+TDEA can be disabled with `no-des` configuration option.
+
+### 8 Deriving Additional Keys from a Cryptographic Key
+
+TDEA can be disabled with `no-des` configuration option.
+
+### 9 Hash Functions
+
+> [!WARNING]
+> Need to add compile time options to disable SHA-1
+
+### 10 Message Authentication Codes (MACs)
+
+TDEA can be disabled with `no-des` configuration option.


### PR DESCRIPTION
At times it is desired to compile out dissallowed, deprecated, or
legacy behaviour out of the FIPS provider. This might be done due to
desire to protect information post the future transition dates, or to
achieve full length FIPS certification.

This document is a living document to keep track of the revisions to
SP 800-131A as well as any configuration gaps.

Currently revision 2 is documented together with known compile-time
toggles. The revision 3 draft will be documented once outstanding gaps
are addressed.
