### PR TITLE
fips no-des: compile out TDES KAT

### DIFF
--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -39,6 +39,7 @@ jobs:
           no-tls1_2,
           no-tls1_3,
           enable-trace enable-fips,
+          enable-fips no-des no-dsa no-ec2m,
           no-ui,
           no-quic
         ]

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -66,6 +66,7 @@ jobs:
           enable-fips,
           enable-fips enable-acvp-tests,
           enable-fips no-tls1_3,
+          enable-fips no-des no-dsa no-ec2m,
           no-fuzz-afl,
           no-fuzz-libfuzzer,
           no-gost,

--- a/providers/fips/self_test_data.inc
+++ b/providers/fips/self_test_data.inc
@@ -250,6 +250,7 @@ static const unsigned char aes_128_ecb_ct[] = {
     0x4e, 0xaa, 0x6f, 0xb4, 0xdb, 0xf7, 0x84, 0x65
 };
 
+#ifndef OPENSSL_NO_DES
 /*
  * TDES-ECB test data from
  * https://github.com/usnistgov/ACVP-Server/blob/master/gen-val/json-files/ACVP-TDES-ECB-1.0
@@ -266,6 +267,7 @@ static const unsigned char tdes_ct[] = {
 static const unsigned char tdes_pt[] = {
     0x4B, 0xAB, 0x3B, 0xE1, 0x50, 0x2E, 0x3B, 0x36
 };
+#endif
 
 static const ST_KAT_CIPHER st_kat_cipher_tests[] = {
     {
@@ -291,6 +293,7 @@ static const ST_KAT_CIPHER st_kat_cipher_tests[] = {
         CIPHER_MODE_DECRYPT,
         ITM(aes_128_ecb_key)
     },
+#ifndef OPENSSL_NO_DES
     {
         {
             OSSL_SELF_TEST_DESC_CIPHER_TDES,
@@ -301,6 +304,7 @@ static const ST_KAT_CIPHER st_kat_cipher_tests[] = {
         CIPHER_MODE_DECRYPT,
         ITM(tdes_key)
     }
+#endif
 };
 
 static const char hkdf_digest[] = "SHA256";


### PR DESCRIPTION
- **fips no-des: compile out TDES KAT**
  FIPS provider correctly supports no-des build time option and doesn't
  advertise DES related algorithms. However KAT test for DES is still
  attempted to be executed and fails.
  
  This prevents configuring FIPS provider without legacy behaviour as
  defined in SP 800-131Arev2. Also see #25761 internal docs.
  
  Fix `enable-fips no-des` build option, and add a daily checker for
  "legacy-free" (as much as currently feasible) FIPS configuration.
  
- **github: add fips configuration, with legacy transitions turned off**

- **temp: run new proposed run-checker-daily configuration in run-checker-ci**
  