### PR TITLE
Do not confuse TAP::Parser by mixing up stderr with stdout.

### DIFF
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -243,12 +243,15 @@ sub start
     if ($self->debug) {
         print STDERR "Server command: $execcmd\n";
     }
+    my $sin = undef;
+    my $sout = undef;
+    if ("$^O" eq "MSWin32") {
+        $pid = IPC::Open2::open2($sout, $sin, $execcmd) or die "Failed to $execcmd: $!\n";
+    } else {
+        $pid = IPC::Open3::open3($sin, $sout, undef, $execcmd) or die "Failed to $execcmd: $!\n";
+    }
 
-    open(my $savedin, "<&STDIN");
-
-    # Temporarily replace STDIN so that sink process can inherit it...
-    $pid = open(STDIN, "$execcmd 2>&1 |") or die "Failed to $execcmd: $!\n";
-    $self->{real_serverpid} = $pid;
+    $self->{serverpid} = $pid;
 
     # Process the output from s_server until we find the ACCEPT line, which
     # tells us what the accepting address and port are.

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -251,7 +251,7 @@ sub start
         $pid = IPC::Open3::open3($sin, $sout, undef, $execcmd) or die "Failed to $execcmd: $!\n";
     }
 
-    $self->{serverpid} = $pid;
+    $self->{real_serverpid} = $pid;
 
     # Process the output from s_server until we find the ACCEPT line, which
     # tells us what the accepting address and port are.

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -7,6 +7,7 @@
 
 use strict;
 use POSIX ":sys_wait_h";
+use IPC::Open2;
 
 package TLSProxy::Proxy;
 

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -292,10 +292,6 @@ sub start
         }
     }
 
-    # Change back to original stdin
-    open(STDIN, "<&", $savedin);
-    close($savedin);
-
     if (!defined($pid)) {
         kill(3, $self->{real_serverpid});
         die "Failed to capture s_server's output: $error\n";

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -256,7 +256,7 @@ sub start
 
     # Process the output from s_server until we find the ACCEPT line, which
     # tells us what the accepting address and port are.
-    while (<>) {
+    while (<$sout>) {
         print;
         s/\R$//;                # Better chomp
         next unless (/^ACCEPT\s.*:(\d+)$/);


### PR DESCRIPTION
This avoids false psotivie failures on FreeBSD-CI which suffers most from this issue.

There was conflict when merging
https://github.com/openssl/openssl/pull/25613 from master to openssl-3.2 and earlier.

The openssl-3.2 branch (and earlier branches) are
missing 4439ed16 which introduces `open2()` to create s_server process.

Fixes #23992

