### PR TITLE
req: Add -cipher option to specify private key encryption cipher

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -81,6 +81,7 @@ static int batch = 0;
 
 typedef enum OPTION_choice {
     OPT_COMMON,
+    OPT_CIPHER,
     OPT_INFORM, OPT_OUTFORM, OPT_ENGINE, OPT_KEYGEN_ENGINE, OPT_KEY,
     OPT_PUBKEY, OPT_NEW, OPT_CONFIG, OPT_KEYFORM, OPT_IN, OPT_OUT,
     OPT_KEYOUT, OPT_PASSIN, OPT_PASSOUT, OPT_NEWKEY,
@@ -98,6 +99,7 @@ typedef enum OPTION_choice {
 const OPTIONS req_options[] = {
     OPT_SECTION("General"),
     {"help", OPT_HELP, '-', "Display this summary"},
+    {"cipher", OPT_CIPHER, 's', "Specify the cipher for private key encryption"},
 #ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
     {"keygen_engine", OPT_KEYGEN_ENGINE, 's',
@@ -250,7 +252,7 @@ int req_main(int argc, char **argv)
     LHASH_OF(OPENSSL_STRING) *addexts = NULL;
     X509 *new_x509 = NULL, *CAcert = NULL;
     X509_REQ *req = NULL;
-    EVP_CIPHER *cipher = NULL;
+    const EVP_CIPHER *cipher = NULL;
     int ext_copy = EXT_COPY_UNSET;
     BIO *addext_bio = NULL;
     char *extsect = NULL;
@@ -490,6 +492,13 @@ int req_main(int argc, char **argv)
             break;
         case OPT_PRECERT:
             newreq = precert = 1;
+            break;
+        case OPT_CIPHER:
+            cipher = EVP_get_cipherbyname(opt_arg());
+            if (cipher == NULL) {
+                BIO_printf(bio_err, "Unknown cipher: %s\n", opt_arg());
+                goto opthelp;
+            }
             break;
         case OPT_MD:
             digest = opt_unknown();

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -662,7 +662,7 @@ Examine and verify certificate request:
 
 Specify the cipher to be used for encrypting the private key:
 
- openssl req -new -key privatekey.pem -out request.csr -cipher aes256
+ openssl req -newkey rsa:2048 -keyout privatekey.pem -out request.csr -cipher aes-256-cbc
 
 Create a private key and then generate a certificate request from it:
 

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -9,6 +9,7 @@ openssl-req - PKCS#10 certificate request and certificate generating command
 
 B<openssl> B<req>
 [B<-help>]
+[B<-cipher>]
 [B<-inform> B<DER>|B<PEM>]
 [B<-outform> B<DER>|B<PEM>]
 [B<-in> I<filename>]
@@ -85,6 +86,13 @@ The output format; unspecified by default.
 See L<openssl-format-options(1)> for details.
 
 The data is a PKCS#10 object.
+
+=item B<-cipher> I<name>
+
+Specify the cipher to be used for encrypting the private key. 
+The default cipher is 3DES (DES-EDE3-CBC). 
+If no cipher is specified, 3DES will be used by default. 
+You can override this by providing any valid OpenSSL cipher name.
 
 =item B<-in> I<filename>
 
@@ -651,6 +659,10 @@ will be treated as though they were a DirectoryString.
 Examine and verify certificate request:
 
  openssl req -in req.pem -text -verify -noout
+
+Specify the cipher to be used for encrypting the private key:
+
+ openssl req -new -key privatekey.pem -out request.csr -cipher aes256
 
 Create a private key and then generate a certificate request from it:
 

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -15,7 +15,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_req");
 
-plan tests => 110;
+plan tests => 111;
 
 require_ok(srctop_file('test', 'recipes', 'tconversion.pl'));
 
@@ -352,6 +352,47 @@ subtest "generating SM2 certificate requests" => sub {
                     "-verify", "-in", "testreq-sm2.pem", "-noout",
                     "-vfyopt", "hexdistid:DEADBEEF", "-sm3"])),
            "Verifying signature on SM2 certificate request");
+    }
+};
+
+subtest "generating certificate requests with -cipher flag" => sub {
+    plan tests => 4;
+
+    SKIP: {
+        skip "RSA is not supported by this OpenSSL build", 2
+            if disabled("rsa");
+
+        diag("Testing -cipher flag with aes256...");
+
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
+                    "-new", "-out", "testreq-rsa-cipher.pem", "-utf8",
+                    "-key", srctop_file("test", "testrsa.pem"),
+                    "-cipher", "aes256"])),
+           "Generating request with -cipher flag (AES256)");
+
+        diag("Verifying signature for aes256...");
+
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
+                    "-verify", "-in", "testreq-rsa-cipher.pem", "-noout"])),
+           "Verifying signature on request with -cipher");
+
+        diag("Testing -cipher flag with aes128...");
+
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
+                    "-new", "-out", "testreq-rsa-cipher-aes128.pem", "-utf8",
+                    "-key", srctop_file("test", "testrsa.pem"),
+                    "-cipher", "aes128"])),
+           "Generating request with -cipher flag (AES128)");
+
+        diag("Verifying signature for aes128...");
+
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
+                    "-verify", "-in", "testreq-rsa-cipher-aes128.pem", "-noout"])),
+           "Verifying signature on request with -cipher (AES128)");
     }
 };
 

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -356,43 +356,53 @@ subtest "generating SM2 certificate requests" => sub {
 };
 
 subtest "generating certificate requests with -cipher flag" => sub {
-    plan tests => 4;
+    plan tests => 6;
 
     diag("Testing -cipher flag with aes-256-cbc...");
-
     ok(run(app(["openssl", "req",
                 "-config", srctop_file("test", "test.cnf"),
                 "-newkey", "rsa:2048",
                 "-keyout", "privatekey-aes256.pem",
                 "-out", "testreq-rsa-cipher.pem",
                 "-utf8",
-                "-cipher", "aes-256-cbc"])),
+                "-cipher", "aes-256-cbc",
+                "-passout", "pass:password"])),
        "Generating request with -cipher flag (AES-256-CBC)");
 
     diag("Verifying signature for aes-256-cbc...");
-
     ok(run(app(["openssl", "req",
                 "-config", srctop_file("test", "test.cnf"),
                 "-verify", "-in", "testreq-rsa-cipher.pem", "-noout"])),
-       "Verifying signature on request with -cipher");
+       "Verifying signature on request with -cipher (AES-256-CBC)");
+
+    open my $fh, '<', "privatekey-aes256.pem" or BAIL_OUT("Could not open key file: $!");
+    my $first_line = <$fh>;
+    close $fh;
+    ok($first_line =~ /^-----BEGIN ENCRYPTED PRIVATE KEY-----/,
+       "Check that the key file is encrypted (AES-256-CBC)");
 
     diag("Testing -cipher flag with aes-128-cbc...");
-
     ok(run(app(["openssl", "req",
                 "-config", srctop_file("test", "test.cnf"),
                 "-newkey", "rsa:2048",
                 "-keyout", "privatekey-aes128.pem",
                 "-out", "testreq-rsa-cipher-aes128.pem",
                 "-utf8",
-                "-cipher", "aes-128-cbc"])),
+                "-cipher", "aes-128-cbc",
+                "-passout", "pass:password"])),
        "Generating request with -cipher flag (AES-128-CBC)");
 
     diag("Verifying signature for aes-128-cbc...");
-
     ok(run(app(["openssl", "req",
                 "-config", srctop_file("test", "test.cnf"),
                 "-verify", "-in", "testreq-rsa-cipher-aes128.pem", "-noout"])),
        "Verifying signature on request with -cipher (AES-128-CBC)");
+
+    open my $fh_aes128, '<', "privatekey-aes128.pem" or BAIL_OUT("Could not open key file: $!");
+    my $first_line_aes128 = <$fh_aes128>;
+    close $fh_aes128;
+    ok($first_line_aes128 =~ /^-----BEGIN ENCRYPTED PRIVATE KEY-----/,
+       "Check that the key file is encrypted (AES-128-CBC)");
 };
 
 my @openssl_args = ("req", "-config", srctop_file("apps", "openssl.cnf"));

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -358,42 +358,41 @@ subtest "generating SM2 certificate requests" => sub {
 subtest "generating certificate requests with -cipher flag" => sub {
     plan tests => 4;
 
-    SKIP: {
-        skip "RSA is not supported by this OpenSSL build", 2
-            if disabled("rsa");
+    diag("Testing -cipher flag with aes-256-cbc...");
 
-        diag("Testing -cipher flag with aes256...");
+    ok(run(app(["openssl", "req",
+                "-config", srctop_file("test", "test.cnf"),
+                "-newkey", "rsa:2048",
+                "-keyout", "privatekey-aes256.pem",
+                "-out", "testreq-rsa-cipher.pem",
+                "-utf8",
+                "-cipher", "aes-256-cbc"])),
+       "Generating request with -cipher flag (AES-256-CBC)");
 
-        ok(run(app(["openssl", "req",
-                    "-config", srctop_file("test", "test.cnf"),
-                    "-new", "-out", "testreq-rsa-cipher.pem", "-utf8",
-                    "-key", srctop_file("test", "testrsa.pem"),
-                    "-cipher", "aes256"])),
-           "Generating request with -cipher flag (AES256)");
+    diag("Verifying signature for aes-256-cbc...");
 
-        diag("Verifying signature for aes256...");
+    ok(run(app(["openssl", "req",
+                "-config", srctop_file("test", "test.cnf"),
+                "-verify", "-in", "testreq-rsa-cipher.pem", "-noout"])),
+       "Verifying signature on request with -cipher");
 
-        ok(run(app(["openssl", "req",
-                    "-config", srctop_file("test", "test.cnf"),
-                    "-verify", "-in", "testreq-rsa-cipher.pem", "-noout"])),
-           "Verifying signature on request with -cipher");
+    diag("Testing -cipher flag with aes-128-cbc...");
 
-        diag("Testing -cipher flag with aes128...");
+    ok(run(app(["openssl", "req",
+                "-config", srctop_file("test", "test.cnf"),
+                "-newkey", "rsa:2048",
+                "-keyout", "privatekey-aes128.pem",
+                "-out", "testreq-rsa-cipher-aes128.pem",
+                "-utf8",
+                "-cipher", "aes-128-cbc"])),
+       "Generating request with -cipher flag (AES-128-CBC)");
 
-        ok(run(app(["openssl", "req",
-                    "-config", srctop_file("test", "test.cnf"),
-                    "-new", "-out", "testreq-rsa-cipher-aes128.pem", "-utf8",
-                    "-key", srctop_file("test", "testrsa.pem"),
-                    "-cipher", "aes128"])),
-           "Generating request with -cipher flag (AES128)");
+    diag("Verifying signature for aes-128-cbc...");
 
-        diag("Verifying signature for aes128...");
-
-        ok(run(app(["openssl", "req",
-                    "-config", srctop_file("test", "test.cnf"),
-                    "-verify", "-in", "testreq-rsa-cipher-aes128.pem", "-noout"])),
-           "Verifying signature on request with -cipher (AES128)");
-    }
+    ok(run(app(["openssl", "req",
+                "-config", srctop_file("test", "test.cnf"),
+                "-verify", "-in", "testreq-rsa-cipher-aes128.pem", "-noout"])),
+       "Verifying signature on request with -cipher (AES-128-CBC)");
 };
 
 my @openssl_args = ("req", "-config", srctop_file("apps", "openssl.cnf"));

--- a/test/test.cnf
+++ b/test/test.cnf
@@ -50,7 +50,6 @@ emailAddress		= optional
 ####################################################################
 [ req ]
 distinguished_name	= req_distinguished_name
-encrypt_rsa_key		= no
 
 # Make altreq be identical to req
 [ altreq ]


### PR DESCRIPTION
As suggested in the issue #25776 , I add a new command line option `-cipher` to the `req` command that allows users 
to explicitly specify which cipher should be used for private key encryption. 
Previously, the cipher was hardcoded to use 3DES (DES-EDE3-CBC) by default with 
no way to override it.

Changes made:
- Added new OPT_CIPHER option enum and command line option definition
- Added handler for -cipher option that uses EVP_get_cipherbyname()
- Updated the manual page (openssl-req.pod.in) to document the new option
- Added usage example in the manual showing how to use the new option

The changes allow users to specify any valid OpenSSL cipher when encrypting 
private keys, providing more flexibility and allowing the use of stronger 
encryption algorithms like AES-256.

Example usage:
```bash
openssl req -newkey rsa:2048 -keyout privatekey.pem -out request.csr -cipher aes-256-cbc
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated