### PR TITLE
Fix ambiguous output of Signature Algorithms

### DIFF
--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -243,10 +243,10 @@ static const char *get_sigtype(int nid)
         return "ECDSA";
 
     case NID_ED25519:
-        return "Ed25519";
+        return "ed25519";
 
     case NID_ED448:
-        return "Ed448";
+        return "ed448";
 
     case NID_id_GostR3410_2001:
         return "gost2001";
@@ -292,6 +292,26 @@ static int do_print_sigalgs(BIO *out, SSL *s, int shared)
             SSL_get_sigalgs(s, i, &sign_nid, &hash_nid, NULL, &rsign, &rhash);
         if (i)
             BIO_puts(out, ":");
+        switch (rsign | rhash << 8) {
+        case 0x0809:
+            BIO_puts(out, "rsa_pss_pss_sha256");
+            continue;
+        case 0x080a:
+            BIO_puts(out, "rsa_pss_pss_sha384");
+            continue;
+        case 0x080b:
+            BIO_puts(out, "rsa_pss_pss_sha512");
+            continue;
+        case 0x081a:
+            BIO_puts(out, "ecdsa_brainpoolP256r1_sha256");
+            continue;
+        case 0x081b:
+            BIO_puts(out, "ecdsa_brainpoolP384r1_sha384");
+            continue;
+        case 0x081c:
+            BIO_puts(out, "ecdsa_brainpoolP512r1_sha512");
+            continue;
+        }
         sstr = get_sigtype(sign_nid);
         if (sstr)
             BIO_printf(out, "%s", sstr);


### PR DESCRIPTION
Signature Algorithms are printed in an SIG+HASH format, in some cases this is ambiguous like brainpool and RSA-PSS. And the name of ed25519 and ed448 must be spelled in lower case, so that the output can be used as a -sigalgs parameter value.
