### PR TITLE
fips: zeroization of ECX public keys

### DIFF
--- a/crypto/ec/ecx_key.c
+++ b/crypto/ec/ecx_key.c
@@ -75,6 +75,9 @@ void ossl_ecx_key_free(ECX_KEY *key)
     REF_ASSERT_ISNT(i < 0);
 
     OPENSSL_free(key->propq);
+#ifdef OPENSSL_PEDANTIC_ZEROIZATION
+    OPENSSL_cleanse(&key->pubkey, sizeof(key->pubkey));
+#endif
     OPENSSL_secure_clear_free(key->privkey, key->keylen);
     CRYPTO_FREE_REF(&key->references);
     OPENSSL_free(key);


### PR DESCRIPTION
Commit fa338aa7cd added zeroization of public security parameters as required by ISO 19790:2012/Cor.1:2015 7.9. However, that commit overlooked ECX keys, which are used for EdDSA and X25519/X448.