### PR TITLE
output negotiated TLS1.3 group

### DIFF
--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -1306,12 +1306,15 @@ void print_ssl_summary(SSL *s)
     ssl_print_point_formats(bio_err, s);
     if (SSL_is_server(s))
         ssl_print_groups(bio_err, s, 1);
-    else
-        ssl_print_tmp_key(bio_err, s);
-#else
-    if (!SSL_is_server(s))
-        ssl_print_tmp_key(bio_err, s);
 #endif
+    if (!SSL_is_server(s)) {
+        if (SSL_version(s) == TLS1_3_VERSION) {
+            int nid = SSL_get_negotiated_group(s);
+
+            BIO_printf(bio_err, "Negotiated TLS1.3 group: %s\n", SSL_group_to_name(s, nid));
+        }
+        ssl_print_tmp_key(bio_err, s);
+    }
 }
 
 int config_ctx(SSL_CONF_CTX *cctx, STACK_OF(OPENSSL_STRING) *str,

--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -1308,11 +1308,9 @@ void print_ssl_summary(SSL *s)
         ssl_print_groups(bio_err, s, 1);
 #endif
     if (!SSL_is_server(s)) {
-        if (SSL_version(s) == TLS1_3_VERSION) {
-            int nid = SSL_get_negotiated_group(s);
-
-            BIO_printf(bio_err, "Negotiated TLS1.3 group: %s\n", SSL_group_to_name(s, nid));
-        }
+        if (SSL_version(s) == TLS1_3_VERSION)
+            BIO_printf(bio_err, "Negotiated TLS1.3 group: %s\n",
+                       SSL_group_to_name(s, SSL_get_negotiated_group(s)));
         ssl_print_tmp_key(bio_err, s);
     }
 }


### PR DESCRIPTION
This adds client-side output for TLS1.3 showing which group has actually been negotiated.