### PR TITLE
fix: util/check-format-commit.sh - fix ending check

### DIFF
--- a/util/check-format-commit.sh
+++ b/util/check-format-commit.sh
@@ -164,7 +164,7 @@ done
 cat $TEMPDIR/results-filtered.txt
 
 # If any findings were in range, exit with a different error code
-if [ -n "$(cat $TEMPDIR/results-filtered.txt)" ]
+if [ -s $TEMPDIR/results-filtered.txt ]
 then
     exit 2
 fi

--- a/util/check-format-commit.sh
+++ b/util/check-format-commit.sh
@@ -164,7 +164,7 @@ done
 cat $TEMPDIR/results-filtered.txt
 
 # If any findings were in range, exit with a different error code
-if [ -n $TEMPDIR/results-filtered.txt ]
+if [ -n "$(cat $TEMPDIR/results-filtered.txt)" ]
 then
     exit 2
 fi


### PR DESCRIPTION
Look at the end result instead of the file name it's stored in
