### PR TITLE
Fix potential memory leak in OSSL_HPKE_CTX_new()

### DIFF
--- a/crypto/hpke/hpke.c
+++ b/crypto/hpke/hpke.c
@@ -841,6 +841,7 @@ OSSL_HPKE_CTX *OSSL_HPKE_CTX_new(int mode, OSSL_HPKE_SUITE suite, int role,
 
  err:
     EVP_CIPHER_free(ctx->aead_ciph);
+    OPENSSL_free(ctx->propq);
     OPENSSL_free(ctx);
     return NULL;
 }


### PR DESCRIPTION
ctx->propq is a duplicated string, but the error code does not free the duplicated string's memory. If e.g. EVP_CIPHER_fetch() fails then we can leak the string's memory.

Note: this was detected using an experimental static analyser I'm working on. I understand this is quite an unlikely bug.
I could also be wrong because my results are based on static analysis even though I manually read the code as well.