### PR TITLE
chore: adjust naming authority formatting when printing out admission extension

### DIFF
--- a/crypto/x509/v3_admis.c
+++ b/crypto/x509/v3_admis.c
@@ -81,14 +81,14 @@ static int i2r_NAMING_AUTHORITY(const struct v3_ext_method *method, void *in,
         && namingAuthority->namingAuthorityUrl == NULL)
         return 0;
 
-    if (BIO_printf(bp, "%*snamingAuthority: ", ind, "") <= 0)
+    if (BIO_printf(bp, "%*snamingAuthority:\n", ind, "") <= 0)
         goto err;
 
     if (namingAuthority->namingAuthorityId != NULL) {
         char objbuf[128];
         const char *ln = OBJ_nid2ln(OBJ_obj2nid(namingAuthority->namingAuthorityId));
 
-        if (BIO_printf(bp, "%*s  admissionAuthorityId: ", ind, "") <= 0)
+        if (BIO_printf(bp, "%*s  namingAuthorityId: ", ind, "") <= 0)
             goto err;
 
         OBJ_obj2txt(objbuf, sizeof(objbuf), namingAuthority->namingAuthorityId, 1);

--- a/crypto/x509/v3_admis.c
+++ b/crypto/x509/v3_admis.c
@@ -143,7 +143,7 @@ static int i2r_ADMISSION_SYNTAX(const struct v3_ext_method *method, void *in,
         }
 
         if (entry->namingAuthority != NULL) {
-            if (i2r_NAMING_AUTHORITY(method, entry->namingAuthority, bp, ind) <= 0)
+            if (i2r_NAMING_AUTHORITY(method, entry->namingAuthority, bp, ind + 2) <= 0)
                 goto err;
         }
 
@@ -161,7 +161,7 @@ static int i2r_ADMISSION_SYNTAX(const struct v3_ext_method *method, void *in,
             }
 
             if (pinfo->namingAuthority != NULL) {
-                if (i2r_NAMING_AUTHORITY(method, pinfo->namingAuthority, bp, ind + 2) <= 0)
+                if (i2r_NAMING_AUTHORITY(method, pinfo->namingAuthority, bp, ind + 4) <= 0)
                     goto err;
             }
 

--- a/crypto/x509/v3_admis.c
+++ b/crypto/x509/v3_admis.c
@@ -80,14 +80,14 @@ static int i2r_NAMING_AUTHORITY(const struct v3_ext_method *method, void *in,
         && namingAuthority->namingAuthorityUrl == NULL)
         return 0;
 
-    if (BIO_printf(bp, "%*s  namingAuthority:\n", ind, "") <= 0)
+    if (BIO_printf(bp, "%*snamingAuthority:\n", ind, "") <= 0)
         goto err;
 
     if (namingAuthority->namingAuthorityId != NULL) {
         char objbuf[128];
         const char *ln = OBJ_nid2ln(OBJ_obj2nid(namingAuthority->namingAuthorityId));
 
-        if (BIO_printf(bp, "%*s    namingAuthorityId: ", ind, "") <= 0)
+        if (BIO_printf(bp, "%*s  namingAuthorityId: ", ind, "") <= 0)
             goto err;
 
         OBJ_obj2txt(objbuf, sizeof(objbuf), namingAuthority->namingAuthorityId, 1);
@@ -97,13 +97,13 @@ static int i2r_NAMING_AUTHORITY(const struct v3_ext_method *method, void *in,
             goto err;
     }
     if (namingAuthority->namingAuthorityText != NULL) {
-        if (BIO_printf(bp, "%*s    namingAuthorityText: ", ind, "") <= 0
+        if (BIO_printf(bp, "%*s  namingAuthorityText: ", ind, "") <= 0
             || ASN1_STRING_print(bp, namingAuthority->namingAuthorityText) <= 0
             || BIO_printf(bp, "\n") <= 0)
             goto err;
     }
     if (namingAuthority->namingAuthorityUrl != NULL) {
-        if (BIO_printf(bp, "%*s    namingAuthorityUrl: ", ind, "") <= 0
+        if (BIO_printf(bp, "%*s  namingAuthorityUrl: ", ind, "") <= 0
             || ASN1_STRING_print(bp, namingAuthority->namingAuthorityUrl) <= 0
             || BIO_printf(bp, "\n") <= 0)
             goto err;

--- a/crypto/x509/v3_admis.c
+++ b/crypto/x509/v3_admis.c
@@ -80,14 +80,14 @@ static int i2r_NAMING_AUTHORITY(const struct v3_ext_method *method, void *in,
         && namingAuthority->namingAuthorityUrl == NULL)
         return 0;
 
-    if (BIO_printf(bp, "%*snamingAuthority:\n", ind, "") <= 0)
+    if (BIO_printf(bp, "%*s  namingAuthority:\n", ind, "") <= 0)
         goto err;
 
     if (namingAuthority->namingAuthorityId != NULL) {
         char objbuf[128];
         const char *ln = OBJ_nid2ln(OBJ_obj2nid(namingAuthority->namingAuthorityId));
 
-        if (BIO_printf(bp, "%*s  namingAuthorityId: ", ind, "") <= 0)
+        if (BIO_printf(bp, "%*s    namingAuthorityId: ", ind, "") <= 0)
             goto err;
 
         OBJ_obj2txt(objbuf, sizeof(objbuf), namingAuthority->namingAuthorityId, 1);
@@ -97,13 +97,13 @@ static int i2r_NAMING_AUTHORITY(const struct v3_ext_method *method, void *in,
             goto err;
     }
     if (namingAuthority->namingAuthorityText != NULL) {
-        if (BIO_printf(bp, "%*s  namingAuthorityText: ", ind, "") <= 0
+        if (BIO_printf(bp, "%*s    namingAuthorityText: ", ind, "") <= 0
             || ASN1_STRING_print(bp, namingAuthority->namingAuthorityText) <= 0
             || BIO_printf(bp, "\n") <= 0)
             goto err;
     }
     if (namingAuthority->namingAuthorityUrl != NULL) {
-        if (BIO_printf(bp, "%*s  namingAuthorityUrl: ", ind, "") <= 0
+        if (BIO_printf(bp, "%*s    namingAuthorityUrl: ", ind, "") <= 0
             || ASN1_STRING_print(bp, namingAuthority->namingAuthorityUrl) <= 0
             || BIO_printf(bp, "\n") <= 0)
             goto err;

--- a/crypto/x509/v3_admis.c
+++ b/crypto/x509/v3_admis.c
@@ -67,11 +67,10 @@ const X509V3_EXT_METHOD ossl_v3_ext_admission = {
     NULL                    /* extension-specific data */
 };
 
-
 static int i2r_NAMING_AUTHORITY(const struct v3_ext_method *method, void *in,
                                 BIO *bp, int ind)
 {
-    NAMING_AUTHORITY *namingAuthority = (NAMING_AUTHORITY*) in;
+    NAMING_AUTHORITY *namingAuthority = (NAMING_AUTHORITY *) in;
 
     if (namingAuthority == NULL)
         return 0;
@@ -130,9 +129,10 @@ static int i2r_ADMISSION_SYNTAX(const struct v3_ext_method *method, void *in,
     }
 
     for (i = 0; i < sk_ADMISSIONS_num(admission->contentsOfAdmissions); i++) {
-        ADMISSIONS* entry = sk_ADMISSIONS_value(admission->contentsOfAdmissions, i);
+        ADMISSIONS *entry = sk_ADMISSIONS_value(admission->contentsOfAdmissions, i);
 
-        if (BIO_printf(bp, "%*sEntry %0d:\n", ind, "", 1 + i) <= 0) goto err;
+        if (BIO_printf(bp, "%*sEntry %0d:\n", ind, "", 1 + i) <= 0)
+            goto err;
 
         if (entry->admissionAuthority != NULL) {
             if (BIO_printf(bp, "%*s  admissionAuthority:\n", ind, "") <= 0
@@ -148,7 +148,7 @@ static int i2r_ADMISSION_SYNTAX(const struct v3_ext_method *method, void *in,
         }
 
         for (j = 0; j < sk_PROFESSION_INFO_num(entry->professionInfos); j++) {
-            PROFESSION_INFO* pinfo = sk_PROFESSION_INFO_value(entry->professionInfos, j);
+            PROFESSION_INFO *pinfo = sk_PROFESSION_INFO_value(entry->professionInfos, j);
 
             if (BIO_printf(bp, "%*s  Profession Info Entry %0d:\n", ind, "", 1 + j) <= 0)
                 goto err;
@@ -170,7 +170,7 @@ static int i2r_ADMISSION_SYNTAX(const struct v3_ext_method *method, void *in,
                 if (BIO_printf(bp, "%*s    Info Entries:\n", ind, "") <= 0)
                     goto err;
                 for (k = 0; k < sk_ASN1_STRING_num(pinfo->professionItems); k++) {
-                    ASN1_STRING* val = sk_ASN1_STRING_value(pinfo->professionItems, k);
+                    ASN1_STRING *val = sk_ASN1_STRING_value(pinfo->professionItems, k);
 
                     if (BIO_printf(bp, "%*s      ", ind, "") <= 0
                         || ASN1_STRING_print(bp, val) <= 0
@@ -183,7 +183,7 @@ static int i2r_ADMISSION_SYNTAX(const struct v3_ext_method *method, void *in,
                 if (BIO_printf(bp, "%*s    Profession OIDs:\n", ind, "") <= 0)
                     goto err;
                 for (k = 0; k < sk_ASN1_OBJECT_num(pinfo->professionOIDs); k++) {
-                    ASN1_OBJECT* obj = sk_ASN1_OBJECT_value(pinfo->professionOIDs, k);
+                    ASN1_OBJECT *obj = sk_ASN1_OBJECT_value(pinfo->professionOIDs, k);
                     const char *ln = OBJ_nid2ln(OBJ_obj2nid(obj));
                     char objbuf[128];
 
@@ -207,31 +207,29 @@ const ASN1_OBJECT *NAMING_AUTHORITY_get0_authorityId(const NAMING_AUTHORITY *n)
     return n->namingAuthorityId;
 }
 
-void NAMING_AUTHORITY_set0_authorityId(NAMING_AUTHORITY *n, ASN1_OBJECT* id)
+void NAMING_AUTHORITY_set0_authorityId(NAMING_AUTHORITY *n, ASN1_OBJECT *id)
 {
     ASN1_OBJECT_free(n->namingAuthorityId);
     n->namingAuthorityId = id;
 }
 
-const ASN1_IA5STRING *NAMING_AUTHORITY_get0_authorityURL(
-    const NAMING_AUTHORITY *n)
+const ASN1_IA5STRING *NAMING_AUTHORITY_get0_authorityURL(const NAMING_AUTHORITY *n)
 {
     return n->namingAuthorityUrl;
 }
 
-void NAMING_AUTHORITY_set0_authorityURL(NAMING_AUTHORITY *n, ASN1_IA5STRING* u)
+void NAMING_AUTHORITY_set0_authorityURL(NAMING_AUTHORITY *n, ASN1_IA5STRING *u)
 {
     ASN1_IA5STRING_free(n->namingAuthorityUrl);
     n->namingAuthorityUrl = u;
 }
 
-const ASN1_STRING *NAMING_AUTHORITY_get0_authorityText(
-    const NAMING_AUTHORITY *n)
+const ASN1_STRING *NAMING_AUTHORITY_get0_authorityText(const NAMING_AUTHORITY *n)
 {
     return n->namingAuthorityText;
 }
 
-void NAMING_AUTHORITY_set0_authorityText(NAMING_AUTHORITY *n, ASN1_STRING* t)
+void NAMING_AUTHORITY_set0_authorityText(NAMING_AUTHORITY *n, ASN1_STRING *t)
 {
     ASN1_IA5STRING_free(n->namingAuthorityText);
     n->namingAuthorityText = t;


### PR DESCRIPTION
This PR is pure cosmetics and fixes the formatting of the `namingAuthority` field when printing out the admission extension.
 
With the current master, it looks like this:
```
            Professional Information or basis for Admission: 
                admissionAuthority:
                  DirName:C = DE, O = Elektronisches Gesundheitsberuferegister
                Entry 1:
                namingAuthority:                   admissionAuthorityId: undefined (1.2.276.0.76.4.225)
                  namingAuthorityText: Betriebsst....tte Deutscher Apothekerverband
                  namingAuthorityUrl: http://example.com
                  Profession Info Entry 1:
                    ...
```
The `namingAuthorityId` field is named `admissionAuthorityId` (probably due to copy & paste of the initial impl) and is printed in the same line as the start of `namingAuthority` section.

With the proposed patch applied the formatting is adjusted to:

```
            Professional Information or basis for Admission: 
                admissionAuthority:
                  DirName:C = DE, O = Elektronisches Gesundheitsberuferegister
                Entry 1:
                namingAuthority:
                  namingAuthorityId: undefined (1.2.276.0.76.4.225)
                  namingAuthorityText: Betriebsst....tte Deutscher Apothekerverband
                  namingAuthorityUrl: http://example.com
                  Profession Info Entry 1:
                    ...
```

##### Checklist

TBH I think this change is too insignificant to add docs, tests or changelog entry, but will gladly add them the reviewers decide it is necessary.