### PR TITLE
Fix potential memory leak in BIO_get_accept_socket()

### DIFF
--- a/crypto/bio/bio_addr.c
+++ b/crypto/bio/bio_addr.c
@@ -571,8 +571,13 @@ int BIO_parse_hostserv(const char *hostserv, char **host, char **service,
             *service = NULL;
         } else {
             *service = OPENSSL_strndup(p, pl);
-            if (*service == NULL)
+            if (*service == NULL) {
+                if (h != NULL && host != NULL) {
+                    OPENSSL_free(*host);
+                    *host = NULL;
+                }
                 return 0;
+            }
         }
     }
 

--- a/crypto/bio/bio_sock.c
+++ b/crypto/bio/bio_sock.c
@@ -256,7 +256,7 @@ int BIO_get_accept_socket(char *host, int bind_mode)
     BIO_ADDRINFO *res = NULL;
 
     if (!BIO_parse_hostserv(host, &h, &p, BIO_PARSE_PRIO_SERV))
-        goto err;
+        return INVALID_SOCKET;
 
     if (BIO_sock_init() != 1)
         goto err;

--- a/crypto/bio/bio_sock.c
+++ b/crypto/bio/bio_sock.c
@@ -256,10 +256,10 @@ int BIO_get_accept_socket(char *host, int bind_mode)
     BIO_ADDRINFO *res = NULL;
 
     if (!BIO_parse_hostserv(host, &h, &p, BIO_PARSE_PRIO_SERV))
-        return INVALID_SOCKET;
+        goto err;
 
     if (BIO_sock_init() != 1)
-        return INVALID_SOCKET;
+        goto err;
 
     if (BIO_lookup(h, p, BIO_LOOKUP_SERVER, AF_UNSPEC, SOCK_STREAM, &res) != 0)
         goto err;


### PR DESCRIPTION
When BIO_parse_hostserv() fails it may still have allocated memory, yet this memory is not freed. Fix it by jumping to the err label.

Note: this was detected using an experimental static analyser I'm working on.  I could be wrong because my results are based on static analysis, even though I manually read the code as well.