### PR TITLE
Fix potential memory leak in PKCS12_add_key_ex()

### DIFF
--- a/crypto/pkcs12/p12_crt.c
+++ b/crypto/pkcs12/p12_crt.c
@@ -246,8 +246,10 @@ PKCS12_SAFEBAG *PKCS12_add_key_ex(STACK_OF(PKCS12_SAFEBAG) **pbags,
     /* Make a PKCS#8 structure */
     if ((p8 = EVP_PKEY2PKCS8(key)) == NULL)
         goto err;
-    if (key_usage && !PKCS8_add_keyusage(p8, key_usage))
+    if (key_usage && !PKCS8_add_keyusage(p8, key_usage)) {
+        PKCS8_PRIV_KEY_INFO_free(p8);
         goto err;
+    }
     if (nid_key != -1) {
         /* This call does not take ownership of p8 */
         bag = PKCS12_SAFEBAG_create_pkcs8_encrypt_ex(nid_key, pass, -1, NULL, 0,


### PR DESCRIPTION
p8 is allocated using EVP_PKEY2PKCS8(), but when PKCS8_add_keyusage() fails this memory is not freed. Fix this by adding a call to PKCS8_PRIV_KEY_INFO_free().

Note: this was detected using an experimental static analyser I'm working on. I could be wrong because my results are based on static analysis, even though I manually read the code as well.