### PR TITLE
Remove two unused union members from struct x509_object_st.

### DIFF
--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -331,7 +331,7 @@ static int ossl_x509_store_ctx_get_by_subject(const X509_STORE_CTX *ctx,
         return 0;
 
     stmp.type = X509_LU_NONE;
-    stmp.data.ptr = NULL;
+    stmp.data.x509 = NULL;
 
     if (!x509_store_read_lock(store))
         return 0;
@@ -371,7 +371,7 @@ static int ossl_x509_store_ctx_get_by_subject(const X509_STORE_CTX *ctx,
         return -1;
 
     ret->type = tmp->type;
-    ret->data.ptr = tmp->data.ptr;
+    ret->data = tmp->data;
     return 1;
 }
 

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -303,10 +303,8 @@ struct x509_object_st {
     /* one of the above types */
     X509_LOOKUP_TYPE type;
     union {
-        char *ptr;
         X509 *x509;
         X509_CRL *crl;
-        EVP_PKEY *pkey;
     } data;
 };
 


### PR DESCRIPTION
Running the `bugprone-tagged-union-member-count` check of the clang-tidy static analyzer on the project, a warning has been issued for the tagged-union struct called `x509_object_st` in the file `include/crypto/x509.h`, as it has 3 possible enum values and 4 union data members. This could be a bug based on the pigeonhole principle, as 3 enum values cannot identify 4 distinct union data members.

The enum values:

```c
typedef enum {
    X509_LU_NONE = 0,
    X509_LU_X509, X509_LU_CRL
} X509_LOOKUP_TYPE;
```

The tagged union:

```c
struct x509_object_st {
    /* one of the above types */
    X509_LOOKUP_TYPE type;
    union {
        char *ptr;
        X509 *x509;
        X509_CRL *crl;
        EVP_PKEY *pkey;
    } data;
};
```

Based on the naming of the enum constants it seems that `EVP_PKEY *pkey` and `char *ptr` do not have a corresponding enum constant. After removing these two union data members and fixing the two total usages of `char *ptr` (`EVP_PKEY *pkey` is not used anywhere), the code compiles and every test case passes.

CLA: trivial