### PR TITLE
Fix incorrect openssl-smime doc sample command for encrypt

### DIFF
--- a/doc/man1/openssl-smime.pod.in
+++ b/doc/man1/openssl-smime.pod.in
@@ -397,9 +397,9 @@ Verify a message and extract the signer's certificate if successful:
 
 Send encrypted mail using triple DES:
 
- openssl smime -encrypt -in in.txt -from steve@openssl.org \
+ openssl smime -encrypt -in in.txt -out mail.msg -from steve@openssl.org \
         -to someone@somewhere -subject "Encrypted message" \
-        -des3 user.pem -out mail.msg
+        -des3 user.pem
 
 Sign and encrypt mail:
 


### PR DESCRIPTION
Original documented sample command causes error. PEM recipient cert argument needs to go last.

CLA: trivial

original command causes error like this:
```
Can't open -out for reading, No such file or directory
139744484525376:error:02001002:system library:fopen:No such file or directory:../crypto/bio/bss_file.c:69:fopen('-out','r')
139744484525376:error:2006D080:BIO routines:BIO_new_file:no such file:../crypto/bio/bss_file.c:76:
unable to load certificate
```

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

