### PR TITLE
Update QUIC man7 pages for server functionality

### DIFF
--- a/doc/man7/openssl-quic-concurrency.pod
+++ b/doc/man7/openssl-quic-concurrency.pod
@@ -324,8 +324,7 @@ blocking mode can be changed explicitly using L<SSL_set_blocking_mode(3)>.
 =head1 SEE ALSO
 
 L<openssl-quic(7)>, L<SSL_handle_events(3)>, L<SSL_get_event_timeout(3)>,
-L<OSSL_QUIC_client_thread_method(3)>,
-L<SSL_CTX_set_domain_flags(3)>,
+L<OSSL_QUIC_client_thread_method(3)>, L<SSL_CTX_set_domain_flags(3)>,
 L<SSL_new_domain(3)>
 
 =head1 COPYRIGHT

--- a/doc/man7/openssl-quic.pod
+++ b/doc/man7/openssl-quic.pod
@@ -7,31 +7,17 @@ openssl-quic - OpenSSL QUIC
 =head1 DESCRIPTION
 
 OpenSSL 3.2 and later features support for the QUIC transport protocol.
-Initially, only client connectivity was supported. Now, server connectivity is
-also supported. This man page describes the usage of QUIC functionality for both
-existing and new applications.
+You can use OpenSSL's QUIC capabilities for both client and server applications.
+This man page describes how to let applications use QUIC protocol using the
+libssl API.
 
-QUIC functionality uses the standard SSL API. A QUIC connection is represented
+QUIC protocol maps to the standard SSL API. A QUIC connection is represented
 by an SSL object in the same way that a TLS connection is. Only minimal changes
-are needed to existing applications making use of the libssl APIs to make use of
-QUIC functionality. To make use of QUIC for clients, use the SSL method
-L<OSSL_QUIC_client_method(3)> or L<OSSL_QUIC_client_thread_method(3)> with
-L<SSL_CTX_new(3)>. For servers, use the SSL method L<OSSL_QUIC_server_method(3)>
-with L<SSL_CTX_new(3)>.
-
-When a QUIC connection is created, by default, it operates in default stream
-mode, which is intended to provide compatibility with existing non-QUIC
-application usage patterns. In this mode, the connection has a single
-stream associated with it. Calls to L<SSL_read(3)> and
-L<SSL_write(3)> on the QUIC connection SSL object read and write from that
-stream. Whether the stream is client-initiated or server-initiated from a QUIC
-perspective depends on whether L<SSL_read(3)> or L<SSL_write(3)> is called
-first. See the MODES OF OPERATION section for more information.
-
-The default stream mode is intended for compatibility with existing
-applications. New applications using QUIC are recommended to disable default
-stream mode and use the multi-stream API; see the MODES OF OPERATION section and
-the RECOMMENDATIONS FOR NEW APPLICATIONS section for more information.
+are needed to existing applications which use libssl API to bring QUIC protocol
+in. QUIC clients can use L<OSSL_QUIC_client_method(3)> or
+L<OSSL_QUIC_client_thread_method(3)> with L<SSL_CTX_new(3)>. See below for more
+details about the difference between the two. For servers, there is only one
+option: SSL method L<OSSL_QUIC_server_method(3)> with L<SSL_CTX_new(3)>.
 
 The remainder of this man page discusses, in order:
 
@@ -39,12 +25,12 @@ The remainder of this man page discusses, in order:
 
 =item
 
-Default stream mode versus multi-stream mode;
+Default stream mode versus multi-stream mode for clients;
 
 =item
 
-The changes to existing libssl APIs which are driven by QUIC-related implementation
-requirements, which existing applications should bear in mind;
+The changes to existing libssl APIs which are driven by QUIC-related
+implementation requirements, which existing applications should bear in mind;
 
 =item
 
@@ -61,7 +47,20 @@ New, QUIC-specific APIs.
 
 =back
 
-=head1 MODES OF OPERATION
+=head1 CLIENT MODES OF OPERATION
+
+When a client creates a QUIC connection, by default, it operates in default
+stream mode, which is intended to provide compatibility with existing non-QUIC
+application usage patterns. In this mode, the connection has a single stream
+associated with it. Calls to L<SSL_read(3)> and L<SSL_write(3)> on the QUIC
+connection SSL object read and write from that stream. Whether the stream is
+client-initiated or server-initiated from a QUIC perspective depends on whether
+L<SSL_read(3)> or L<SSL_write(3)> is called first.
+
+Default stream mode is primarily for compatibility with existing applications.
+For new applications utilizing QUIC, it's recommended to disable this mode and
+instead adopt the multi-stream API. See the RECOMMENDATIONS FOR NEW APPLICATIONS
+section for more details.
 
 =head2 Default Stream Mode
 
@@ -326,13 +325,15 @@ determine what changes they will need to make:
 
 =item
 
-An client application wishing to use QUIC must use L<OSSL_QUIC_client_method(3)>
+A client application wishing to use QUIC must use L<OSSL_QUIC_client_method(3)>
 or L<OSSL_QUIC_client_thread_method(3)> as its SSL method. For more information
-on the differences between these two methods, see B<THREAD ASSISTED MODE>.
+on the differences between these two methods, see
+B<THREAD ASSISTED MODE>.
 
 =item
 
 A server application wishing to use QUIC must use L<OSSL_QUIC_server_method(3)>. 
+The server can then accept new connections with L<SSL_accept_connection(3)>.
 
 =item
 
@@ -409,12 +410,12 @@ it must add a call to L<SSL_set_blocking_mode(3)> to disable blocking mode.
 
 =item
 
-If your application does not choose to use thread assisted mode, it must ensure
-that it calls an I/O function on the SSL object (for example, L<SSL_read(3)> or
-L<SSL_write(3)>), or the new function L<SSL_handle_events(3)>, regularly. If the
-SSL object is used in blocking mode, an ongoing blocking call to an I/O function
-satisfies this requirement. This is required to ensure that timer events
-required by QUIC are handled in a timely fashion.
+If your client application does not choose to use thread assisted mode, it must
+ensure that it calls an I/O function on the SSL object (for example,
+L<SSL_read(3)> or L<SSL_write(3)>), or the new function L<SSL_handle_events(3)>,
+regularly. If the SSL object is used in blocking mode, an ongoing blocking call
+to an I/O function satisfies this requirement. This is required to ensure that
+timer events required by QUIC are handled in a timely fashion.
 
 Most applications will service the SSL object by calling L<SSL_read(3)> or
 L<SSL_write(3)> regularly. If an application does not do this, it should ensure
@@ -429,7 +430,7 @@ L<SSL_get_rpoll_descriptor(3)>, L<SSL_get_wpoll_descriptor(3)> to obtain
 resources which can be used to determine when L<SSL_handle_events(3)> should be
 called due to network I/O.
 
-Applications which use thread assisted mode do not need to be concerned
+Client applications which use thread assisted mode do not need to be concerned
 with this requirement, as the QUIC implementation ensures timeout events
 are handled in a timely manner. See B<THREAD ASSISTED MODE> for details.
 
@@ -504,15 +505,43 @@ The following SSL APIs are new but relevant to both QUIC and DTLS:
 
 =over 4
 
+=item L<SSL_get_event_timeout(3)>
+
+Determines when the QUIC implementation should next be woken up via a call to
+L<SSL_handle_events(3)> (or another I/O function such as L<SSL_read(3)> or
+L<SSL_write(3)>), if ever.
+
+This can also be used with DTLS and supersedes L<DTLSv1_get_timeout(3)> for new
+usage.
+
+=item L<SSL_handle_events(3)>
+
+This is a non-specific I/O operation which makes a best effort attempt to
+perform any pending I/O or timeout processing. It can be used to advance the
+QUIC state machine by processing incoming network traffic, generating outgoing
+network traffic and handling any expired timeout events. Most other I/O
+functions on an SSL object, such as L<SSL_read(3)> and L<SSL_write(3)>,
+implicitly perform event handling on the SSL object, so calling this function is
+only needed if no other I/O function is to be called.
+
+This can also be used with DTLS and supersedes L<DTLSv1_handle_timeout(3)> for
+new usage.
+
+=back
+
+The following SSL APIs are specific to QUIC:
+
+=over 4
+
 =item L<SSL_new_listener(3)>
 
-Creates a listener SSL object. A listener SSL object differs from an ordinary
-SSL object in that it is used to provide an abstraction for the acceptance of
-network connections in a protocol-agnostic manner.
+Creates a listener SSL object, which differs from an ordinary SSL object in that
+it is used to provide an abstraction for the acceptance of network connections
+in a protocol-agnostic manner.
 
 Currently, listener SSL objects are only supported for QUIC server usage or
-client-only usage. It is expected that the listener interface will be expanded
-to support other protocols.
+client-only usage. The listener interface may expand to support additional
+protocols in the future.
 
 =item L<SSL_new_listener_from(3)>
 
@@ -522,7 +551,7 @@ on QUIC domain SSL objects.
 
 =item L<SSL_is_listener(3)>
 
-Returns 1 if and only if a SSL object is a listener SSL object.
+Returns 1 if and only if an SSL object is a listener SSL object.
 
 =item L<SSL_get0_listener(3)>
 
@@ -555,33 +584,20 @@ which does accept incoming connections (i.e., which was not created using
 B<SSL_LISTENER_FLAG_NO_ACCEPT>), leading to a UDP network endpoint which has
 both incoming and outgoing connections.
 
-=item L<SSL_get_event_timeout(3)>
+=item L<SSL_new_domain(3)>
 
-Determines when the QUIC implementation should next be woken up via a call to
-L<SSL_handle_events(3)> (or another I/O function such as L<SSL_read(3)> or
-L<SSL_write(3)>), if ever.
+Creates a new QUIC event domain, represented as an SSL object. This is known as
+a QUIC domain SSL object. The concept of a QUIC event domain is discussed in
+detail in L<openssl-quic-concurrency(7)>.
 
-This can also be used with DTLS and supersedes L<DTLSv1_get_timeout(3)> for new
-usage.
+=item L<SSL_is_domain(3)>
 
-=item L<SSL_handle_events(3)>
+Returns 1 if a SSL object is a QUIC domain SSL object.
 
-This is a non-specific I/O operation which makes a best effort attempt to
-perform any pending I/O or timeout processing. It can be used to advance the
-QUIC state machine by processing incoming network traffic, generating outgoing
-network traffic and handling any expired timeout events. Most other I/O
-functions on an SSL object, such as L<SSL_read(3)> and L<SSL_write(3)>
-implicitly perform event handling on the SSL object, so calling this function is
-only needed if no other I/O function is to be called.
+=item L<SSL_get0_domain(3)>
 
-This can also be used with DTLS and supersedes L<DTLSv1_handle_timeout(3)> for
-new usage.
-
-=back
-
-The following SSL APIs are specific to QUIC:
-
-=over 4
+SSL_get0_domain() obtains a pointer to the QUIC domain SSL object in a SSL
+object hierarchy (if any).
 
 =item L<SSL_set_blocking_mode(3)>, L<SSL_get_blocking_mode(3)>
 
@@ -599,8 +615,9 @@ can be used to synchronise on network readability events which should result in
 a call to L<SSL_handle_events(3)>. L<SSL_get_wpoll_descriptor(3)> works in an
 analogous fashion for the underlying network write BIO.
 
-The poll descriptors provided by these functions need only be used when
-L<SSL_net_read_desired(3)> and L<SSL_net_write_desired(3)> return 1, respectively.
+The poll descriptors provided by these functions should be used only when
+L<SSL_net_read_desired(3)> and L<SSL_net_write_desired(3)> return 1,
+respectively.
 
 =item L<SSL_net_read_desired(3)>, L<SSL_net_write_desired(3)>
 
@@ -751,7 +768,7 @@ L<BIO_recvmmsg(3)> is ephemeral in nature, such as "would block" errors.
 
 =head1 THREAD ASSISTED MODE
 
-The optional thread assisted mode can be used with
+The optional thread assisted mode for clients can be used with
 L<OSSL_QUIC_client_thread_method(3)>. In this mode, a background thread is
 created automatically. The OpenSSL QUIC implementation then takes responsibility
 for ensuring that timeout events are handled on a timely basis even if no SSL
@@ -892,7 +909,8 @@ L<SSL_new_stream(3)>, L<SSL_accept_stream(3)>,
 L<SSL_set_incoming_stream_policy(3)>, L<SSL_set_default_stream_mode(3)>,
 L<SSL_new_listener(3)>, L<SSL_new_listener_from(3)>, L<SSL_is_listener(3)>,
 L<SSL_get0_listener(3)>, L<SSL_listen(3)>, L<SSL_accept_connection(3)>,
-L<SSL_get_accept_connection_queue_len(3)>
+L<SSL_get_accept_connection_queue_len(3)>, L<SSL_new_domain(3)>,
+L<SSL_is_domain(3)>, L<SSL_get0_domain(3)>
 
 Copyright 2022-2024 The OpenSSL Project Authors. All Rights Reserved.
 

--- a/doc/man7/openssl-quic.pod
+++ b/doc/man7/openssl-quic.pod
@@ -8,13 +8,13 @@ openssl-quic - OpenSSL QUIC
 
 OpenSSL 3.2 and later features support for the QUIC transport protocol.
 You can use OpenSSL's QUIC capabilities for both client and server applications.
-This man page describes how to let applications use QUIC protocol using the
+This man page describes how to let applications use the QUIC protocol using the
 libssl API.
 
-QUIC protocol maps to the standard SSL API. A QUIC connection is represented
+The QUIC protocol maps to the standard SSL API. A QUIC connection is represented
 by an SSL object in the same way that a TLS connection is. Only minimal changes
 are needed to existing applications which use libssl API to bring QUIC protocol
-in. QUIC clients can use L<OSSL_QUIC_client_method(3)> or
+support in. QUIC clients can use L<OSSL_QUIC_client_method(3)> or
 L<OSSL_QUIC_client_thread_method(3)> with L<SSL_CTX_new(3)>. See below for more
 details about the difference between the two. For servers, there is only one
 option: SSL method L<OSSL_QUIC_server_method(3)> with L<SSL_CTX_new(3)>.
@@ -592,11 +592,11 @@ detail in L<openssl-quic-concurrency(7)>.
 
 =item L<SSL_is_domain(3)>
 
-Returns 1 if a SSL object is a QUIC domain SSL object.
+Returns 1 if an SSL object is a QUIC domain SSL object.
 
 =item L<SSL_get0_domain(3)>
 
-SSL_get0_domain() obtains a pointer to the QUIC domain SSL object in a SSL
+SSL_get0_domain() obtains a pointer to the QUIC domain SSL object in an SSL
 object hierarchy (if any).
 
 =item L<SSL_set_blocking_mode(3)>, L<SSL_get_blocking_mode(3)>
@@ -672,7 +672,7 @@ Gets the QUIC connection SSL object from a QUIC stream SSL object.
 
 =item L<SSL_is_connection(3)>
 
-Returns 1 if a SSL object is not a QUIC stream SSL object.
+Returns 1 if an SSL object is not a QUIC stream SSL object.
 
 =item L<SSL_get_stream_type(3)>
 

--- a/doc/man7/openssl-quic.pod
+++ b/doc/man7/openssl-quic.pod
@@ -7,15 +7,17 @@ openssl-quic - OpenSSL QUIC
 =head1 DESCRIPTION
 
 OpenSSL 3.2 and later features support for the QUIC transport protocol.
-Currently, only client connectivity is supported. This man page describes the
-usage of QUIC client functionality for both existing and new applications.
+Initially, only client connectivity was supported. Now, server connectivity is
+also supported. This man page describes the usage of QUIC functionality for both
+existing and new applications.
 
 QUIC functionality uses the standard SSL API. A QUIC connection is represented
 by an SSL object in the same way that a TLS connection is. Only minimal changes
 are needed to existing applications making use of the libssl APIs to make use of
-QUIC client functionality. To make use of QUIC, use the SSL method
+QUIC functionality. To make use of QUIC for clients, use the SSL method
 L<OSSL_QUIC_client_method(3)> or L<OSSL_QUIC_client_thread_method(3)> with
-L<SSL_CTX_new(3)>.
+L<SSL_CTX_new(3)>. For servers, use the SSL method L<OSSL_QUIC_server_method(3)>
+with L<SSL_CTX_new(3)>.
 
 When a QUIC connection is created, by default, it operates in default stream
 mode, which is intended to provide compatibility with existing non-QUIC
@@ -238,7 +240,7 @@ B<SSL_METHOD> used, rather than by calls to L<SSL_set_connect_state(3)> or
 L<SSL_set_accept_state(3)>. It is not necessary to call either of
 L<SSL_set_connect_state(3)> or L<SSL_set_accept_state(3)> before connecting, but
 if either of these are called, the function called must be congruent with the
-B<SSL_METHOD> being used. Currently, only client mode is supported.
+B<SSL_METHOD> being used.
 
 =item
 
@@ -324,9 +326,13 @@ determine what changes they will need to make:
 
 =item
 
-An application wishing to use QUIC must use L<OSSL_QUIC_client_method(3)> or
-L<OSSL_QUIC_client_thread_method(3)> as its SSL method. For more information
+An client application wishing to use QUIC must use L<OSSL_QUIC_client_method(3)>
+or L<OSSL_QUIC_client_thread_method(3)> as its SSL method. For more information
 on the differences between these two methods, see B<THREAD ASSISTED MODE>.
+
+=item
+
+A server application wishing to use QUIC must use L<OSSL_QUIC_server_method(3)>. 
 
 =item
 
@@ -396,7 +402,7 @@ in blocking mode or not. Traditionally, an SSL object has automatically operated
 in blocking or nonblocking mode based on whether the underlying network BIO
 operates in blocking or nonblocking mode. QUIC requires the use of a
 nonblocking network BIO, therefore the blocking mode at the application level
-must be explicitly configured by the application using the new
+can be explicitly configured by the application using the new
 L<SSL_set_blocking_mode(3)> API. The default mode is blocking. If an application
 wishes to use the SSL object APIs at application level in a nonblocking manner,
 it must add a call to L<SSL_set_blocking_mode(3)> to disable blocking mode.
@@ -498,6 +504,57 @@ The following SSL APIs are new but relevant to both QUIC and DTLS:
 
 =over 4
 
+=item L<SSL_new_listener(3)>
+
+Creates a listener SSL object. A listener SSL object differs from an ordinary
+SSL object in that it is used to provide an abstraction for the acceptance of
+network connections in a protocol-agnostic manner.
+
+Currently, listener SSL objects are only supported for QUIC server usage or
+client-only usage. It is expected that the listener interface will be expanded
+to support other protocols.
+
+=item L<SSL_new_listener_from(3)>
+
+Creates a listener SSL object which is subordinate to a QUIC domain SSL object
+I<ssl>. See L<SSL_new_domain(3)> and L<openssl-quic-concurrency(7)> for details
+on QUIC domain SSL objects.
+
+=item L<SSL_is_listener(3)>
+
+Returns 1 if and only if a SSL object is a listener SSL object.
+
+=item L<SSL_get0_listener(3)>
+
+Returns an SSL object pointer (potentially to the same object on which it is
+called) or NULL.
+
+=item L<SSL_listen(3)>
+
+Begin listening after a listener has been created. It is ordinarily not needed
+to call this because it will be called automatically on the first call to
+L<SSL_accept_connection(3)>. 
+
+=item L<SSL_accept_connection(3)>
+
+Accepts a new incoming connection for a listner SSL object. A new SSL object
+representing the accepted connection is created and returned on success. If no
+incoming connection is available and the listener SSL object is configured in
+nonblocking mode, NULL is returned.
+
+=item L<SSL_get_accept_connection_queue_len(3)>
+
+Returns an informational value listing the number of connections waiting to be
+popped from the queue via calls to SSL_accept_connection().
+
+=item L<SSL_new_from_listener(3)>
+
+Creates a client connection under a given listener SSL object. For QUIC, it is
+also possible to use SSL_new_from_listener() in conjunction with a listener
+which does accept incoming connections (i.e., which was not created using
+B<SSL_LISTENER_FLAG_NO_ACCEPT>), leading to a UDP network endpoint which has
+both incoming and outgoing connections.
+
 =item L<SSL_get_event_timeout(3)>
 
 Determines when the QUIC implementation should next be woken up via a call to
@@ -562,8 +619,8 @@ autodetected in some cases. See L<SSL_set1_initial_peer_addr(3)> for details.
 =item L<SSL_shutdown_ex(3)>
 
 This augments L<SSL_shutdown(3)> by allowing an application error code to be
-specified. It also allows a client to decide how quickly it wants a shutdown to
-be performed, potentially by trading off strict RFC compliance.
+specified. It also allows an application to decide how quickly it wants a
+shutdown to be performed, potentially by trading off strict RFC compliance.
 
 =item L<SSL_stream_conclude(3)>
 
@@ -832,11 +889,12 @@ L<SSL_stream_reset(3)>, L<SSL_get_stream_read_state(3)>,
 L<SSL_get_stream_read_error_code(3)>, L<SSL_get_conn_close_info(3)>,
 L<SSL_get0_connection(3)>, L<SSL_get_stream_type(3)>, L<SSL_get_stream_id(3)>,
 L<SSL_new_stream(3)>, L<SSL_accept_stream(3)>,
-L<SSL_set_incoming_stream_policy(3)>, L<SSL_set_default_stream_mode(3)>
+L<SSL_set_incoming_stream_policy(3)>, L<SSL_set_default_stream_mode(3)>,
+L<SSL_new_listener(3)>, L<SSL_new_listener_from(3)>, L<SSL_is_listener(3)>,
+L<SSL_get0_listener(3)>, L<SSL_listen(3)>, L<SSL_accept_connection(3)>,
+L<SSL_get_accept_connection_queue_len(3)>
 
-=head1 COPYRIGHT
-
-Copyright 2022-2023 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2022-2024 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man7/openssl-quic.pod
+++ b/doc/man7/openssl-quic.pod
@@ -912,6 +912,8 @@ L<SSL_get0_listener(3)>, L<SSL_listen(3)>, L<SSL_accept_connection(3)>,
 L<SSL_get_accept_connection_queue_len(3)>, L<SSL_new_domain(3)>,
 L<SSL_is_domain(3)>, L<SSL_get0_domain(3)>
 
+=head1 COPYRIGHT
+
 Copyright 2022-2024 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use

--- a/doc/man7/ossl-guide-quic-introduction.pod
+++ b/doc/man7/ossl-guide-quic-introduction.pod
@@ -171,15 +171,21 @@ L<SSL_set_blocking_mode(3)>.
 See L<ossl-guide-quic-client-block(7)> to see an example of applying these
 concepts in order to write a simple blocking QUIC client.
 
+See L<ossl-guide-quic-server-block(7)> to see an example of applying these
+concepts in order to write a simple blocking QUIC server.
+
 =head1 SEE ALSO
 
 L<ossl-guide-introduction(7)>, L<ossl-guide-libraries-introduction(7)>,
 L<ossl-guide-libssl-introduction(7)>, L<ossl-guide-tls-introduction(7)>,
-L<ossl-guide-tls-client-block(7)>, L<ossl-guide-quic-client-block(7)>, L<bio(7)>
+L<ossl-guide-tls-client-block(7)>, L<ossl-guide-quic-client-block(7)>,
+L<ossl-guide-quic-client-non-block(7)>, L<ossl-guide-quic-multi-stream(7)>,
+L<ossl-guide-quic-server-block(7)>, L<ossl-guide-quic-server-non-block(7)>,
+L<bio(7)>,
 
 =head1 COPYRIGHT
 
-Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2023-2024 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man7/ossl-guide-quic-server-block.pod
+++ b/doc/man7/ossl-guide-quic-server-block.pod
@@ -122,7 +122,6 @@ the default handling.
      */
     SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
 
-
 QUIC also dictates using Application-Layer Protocol Negotiation (ALPN) to select
 an application protocol.  We use L<SSL_CTX_set_alpn_select_cb(3)> for this
 purpose.  We can pass a callback which will be called for each connection to


### PR DESCRIPTION
Primarily added functions related to QUIC server functionality to the man7 pages about quic.

Fixes [openssl/projects#871](https://github.com/openssl/project/issues/871)

##### Checklist

- [x] documentation is added or updated