### PR TITLE
apps: Change default cipher to aes-256-cbc for req, cms and smime apps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,13 @@ OpenSSL 3.4
 
 ### Changes between 3.4 and 3.5 [xx XXX xxxx]
 
+ * Updated the default encryption cipher for the `req`, `cms`, and `smime` applications
+   from `des-ede3-cbc` to `aes-256-cbc`.
+
+   AES-256 provides a stronger 256-bit key encryption than legacy 3DES.
+
+   *Aditya*
+
  * Enhanced PKCS#7 inner contents verification.
    In the PKCS7_verify() function, the BIO *indata parameter refers to the
    signed data if the content is detached from p7. Otherwise, indata should be

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,7 +33,8 @@ This release is in development.
 This release incorporates the following potentially significant or incompatible
 changes:
 
-  * none yet
+  * Default encryption cipher for the `req`, `cms`, and `smime` applications
+    changed from `des-ede3-cbc` to `aes-256-cbc`.
 
 This release adds the following new features:
 

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -823,12 +823,7 @@ int cms_main(int argc, char **argv)
 
     if (operation == SMIME_ENCRYPT) {
         if (!cipher) {
-#ifndef OPENSSL_NO_DES
             cipher = (EVP_CIPHER *)EVP_aes_256_cbc();
-#else
-            BIO_printf(bio_err, "No cipher selected\n");
-            goto end;
-#endif
         }
 
         if (secret_key && !secret_keyid) {

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -822,10 +822,8 @@ int cms_main(int argc, char **argv)
     }
 
     if (operation == SMIME_ENCRYPT) {
-        if (!cipher) {
+        if (!cipher)
             cipher = (EVP_CIPHER *)EVP_aes_256_cbc();
-        }
-
         if (secret_key && !secret_keyid) {
             BIO_printf(bio_err, "No secret key id\n");
             goto end;

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -824,7 +824,7 @@ int cms_main(int argc, char **argv)
     if (operation == SMIME_ENCRYPT) {
         if (!cipher) {
 #ifndef OPENSSL_NO_DES
-            cipher = (EVP_CIPHER *)EVP_des_ede3_cbc();
+            cipher = (EVP_CIPHER *)EVP_aes_256_cbc();
 #else
             BIO_printf(bio_err, "No cipher selected\n");
             goto end;

--- a/apps/req.c
+++ b/apps/req.c
@@ -275,9 +275,7 @@ int req_main(int argc, char **argv)
     long newkey_len = -1;
     unsigned long chtype = MBSTRING_ASC, reqflag = 0;
 
-#ifndef OPENSSL_NO_DES
     cipher = (EVP_CIPHER *)EVP_aes_256_cbc();
-#endif
 
     opt_set_unknown_name("digest");
     prog = opt_init(argc, argv, req_options);

--- a/apps/req.c
+++ b/apps/req.c
@@ -276,7 +276,7 @@ int req_main(int argc, char **argv)
     unsigned long chtype = MBSTRING_ASC, reqflag = 0;
 
 #ifndef OPENSSL_NO_DES
-    cipher = (EVP_CIPHER *)EVP_des_ede3_cbc();
+    cipher = (EVP_CIPHER *)EVP_aes_256_cbc();
 #endif
 
     opt_set_unknown_name("digest");

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -473,7 +473,7 @@ int smime_main(int argc, char **argv)
     if (operation == SMIME_ENCRYPT) {
         if (cipher == NULL) {
 #ifndef OPENSSL_NO_DES
-            cipher = (EVP_CIPHER *)EVP_des_ede3_cbc();
+            cipher = (EVP_CIPHER *)EVP_aes_256_cbc();
 #else
             BIO_printf(bio_err, "No cipher selected\n");
             goto end;

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -472,12 +472,7 @@ int smime_main(int argc, char **argv)
 
     if (operation == SMIME_ENCRYPT) {
         if (cipher == NULL) {
-#ifndef OPENSSL_NO_DES
             cipher = (EVP_CIPHER *)EVP_aes_256_cbc();
-#else
-            BIO_printf(bio_err, "No cipher selected\n");
-            goto end;
-#endif
         }
         encerts = sk_X509_new_null();
         if (encerts == NULL)

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -471,9 +471,8 @@ int smime_main(int argc, char **argv)
     }
 
     if (operation == SMIME_ENCRYPT) {
-        if (cipher == NULL) {
+        if (cipher == NULL)
             cipher = (EVP_CIPHER *)EVP_aes_256_cbc();
-        }
         encerts = sk_X509_new_null();
         if (encerts == NULL)
             goto end;

--- a/doc/man1/openssl-cms.pod.in
+++ b/doc/man1/openssl-cms.pod.in
@@ -896,7 +896,7 @@ L<ossl_store-file(7)>
 
 =head1 HISTORY
 
-The dedault encryption cipher was changed from 3DES to AES-256 in OpenSSL 3.5.
+The default encryption cipher was changed from 3DES to AES-256 in OpenSSL 3.5.
 
 The use of multiple B<-signer> options and the B<-resign> command were first
 added in OpenSSL 1.0.0.

--- a/doc/man1/openssl-cms.pod.in
+++ b/doc/man1/openssl-cms.pod.in
@@ -406,16 +406,16 @@ One or more certificate filenames may be given.
 
 =item B<-I<cipher>>
 
-The encryption algorithm to use. For example triple DES (168 bits) - B<-des3>
-or 256 bit AES - B<-aes256>. Any standard algorithm name (as used by the
+The encryption algorithm to use. For example, AES (256 bits) - B<-aes256>
+or triple DES (168 bits) - B<-des3>. Any standard algorithm name (as used by the
 EVP_get_cipherbyname() function) can also be used preceded by a dash, for
 example B<-aes-128-cbc>. See L<openssl-enc(1)> for a list of ciphers
 supported by your version of OpenSSL.
 
-Currently the AES variants with GCM mode are the only supported AEAD
+Currently, the AES variants with GCM mode are the only supported AEAD
 algorithms.
 
-If not specified triple DES is used. Only used with B<-encrypt> and
+If not specified, AES-256-CBC is used as the default. Only used with B<-encrypt> and
 B<-EncryptedData_create> commands.
 
 =item B<-wrap> I<cipher>
@@ -895,6 +895,8 @@ No revocation checking is done on the signer's certificate.
 L<ossl_store-file(7)>
 
 =head1 HISTORY
+
+The dedault encryption cipher was changed from 3DES to AES-256 in OpenSSL 3.5.
 
 The use of multiple B<-signer> options and the B<-resign> command were first
 added in OpenSSL 1.0.0.

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -90,8 +90,8 @@ The data is a PKCS#10 object.
 =item B<-cipher> I<name>
 
 Specify the cipher to be used for encrypting the private key.
-The default cipher is 3DES (DES-EDE3-CBC).
-If no cipher is specified, 3DES will be used by default.
+The default cipher is AES-256-CBC.
+If no cipher is specified, AES-256-CBC will be used by default.
 You can override this by providing any valid OpenSSL cipher name.
 
 =item B<-in> I<filename>

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -90,7 +90,6 @@ The data is a PKCS#10 object.
 =item B<-cipher> I<name>
 
 Specify the cipher to be used for encrypting the private key.
-The default cipher is AES-256-CBC.
 If no cipher is specified, AES-256-CBC will be used by default.
 You can override this by providing any valid OpenSSL cipher name.
 

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -835,6 +835,8 @@ L<x509v3_config(5)>
 
 =head1 HISTORY
 
+The default encryption cipher was changed from 3DES to AES-256 in OpenSSL 3.5.
+
 The B<-section> option was added in OpenSSL 3.0.0.
 
 The B<-multivalue-rdn> option has become obsolete in OpenSSL 3.0.0 and

--- a/doc/man1/openssl-smime.pod.in
+++ b/doc/man1/openssl-smime.pod.in
@@ -167,13 +167,13 @@ default digest algorithm for the signing key will be used (usually SHA1).
 
 =item B<-I<cipher>>
 
-The encryption algorithm to use. For example DES  (56 bits) - B<-des>,
-triple DES (168 bits) - B<-des3>,
-EVP_get_cipherbyname() function) can also be used preceded by a dash, for
-example B<-aes-128-cbc>. See L<openssl-enc(1)> for list of ciphers
-supported by your version of OpenSSL.
+The encryption algorithm to use. For example, DES (56 bits) - B<-des>,
+triple DES (168 bits) - B<-des3>, or AES (256 bits) - B<-aes256>.
+Any standard algorithm name (as used by the EVP_get_cipherbyname() function)
+can also be used, preceded by a dash, for example B<-aes-128-cbc>.
+See L<openssl-enc(1)> for a list of ciphers supported by your version of OpenSSL.
 
-If not specified triple DES is used. Only used with B<-encrypt>.
+If not specified, AES-256-CBC is used as the default. Only used with B<-encrypt>.
 
 =item B<-nointern>
 
@@ -467,6 +467,8 @@ structures may cause parsing errors.
 L<ossl_store-file(7)>
 
 =head1 HISTORY
+
+The default encryption cipher was changed from 3DES to AES-256 in OpenSSL 3.5.
 
 The use of multiple B<-signer> options and the B<-resign> command were first
 added in OpenSSL 1.0.0


### PR DESCRIPTION
Following PR #25776 which implemented the -cipher option for the req command, this PR changes the default cipher from `des-ede3-cbc` to `aes-256-cbc` for the req, cms, and smime applications.

As suggested in [this issue](https://github.com/openssl/project/issues/909), this change updates the default encryption cipher to use a more secure algorithm instead of the legacy 3DES encryption.


##### Checklist
- [x] documentation is added or updated

I didn’t find any updates needed for the existing test cases, but please lmk if you recommend any changes.