### PR TITLE
drbg: provide requested amount of entropy, rather than self-strength

### DIFF
--- a/providers/implementations/rands/drbg.c
+++ b/providers/implementations/rands/drbg.c
@@ -235,7 +235,8 @@ static size_t get_entropy(PROV_DRBG *drbg, unsigned char **pout, int entropy,
      *       a warning in some static code analyzers, but it's
      *       intentional and correct here.
      */
-    bytes = drbg->parent_get_seed(drbg->parent, pout, drbg->strength,
+    bytes = drbg->parent_get_seed(drbg->parent, pout,
+                                  entropy > 0 ? entropy : (int) drbg->strength,
                                   min_len, max_len, prediction_resistance,
                                   (unsigned char *)&drbg, sizeof(drbg));
     ossl_drbg_unlock_parent(drbg);


### PR DESCRIPTION
Parent DRBG can be seed source (os or jitter) and thus able to provide
unlimited entropy.

get_entropy is documented to provide at least the request amount of
entropy. If requested amount of entropy is same as, or less than
drbg->strength, everything is compliant. However, if requested entropy
is more than drbg->strength (unlikely, but possible), the returned
amount of entropy will be insufficient and additional repeated calls
to get_entropy will be required.

Reading history of refactors, it seems to me that this function call
previouslly had assumptions and usecases that couldn't ever request or
require more than strength amount of entropy.

If desired, we can set set drbg->strength as the floor for amount of
requested entropy, to preserve previous behaviour.

Not sure how to test this, as this is a logic bug.
