### PR TITLE
Fix the default_md example in the ca docs

### DIFF
--- a/doc/man1/openssl-ca.pod.in
+++ b/doc/man1/openssl-ca.pod.in
@@ -723,7 +723,7 @@ A sample configuration file with the relevant sections for this command:
 
  default_days   = 365                   # how long to certify for
  default_crl_days= 30                   # how long before next CRL
- default_md     = md5                   # md to use
+ default_md     = sha256                # md to use
 
  policy         = policy_any            # default policy
  email_in_dn    = no                    # Don't add the email into cert DN


### PR DESCRIPTION
We should not have an example showing the default_md as md5.
