### PR TITLE
fips: improve PCT for DH

### DIFF
--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -19,6 +19,10 @@
 #include "crypto/bn.h"
 #include "crypto/dh.h"
 #include "crypto/security_bits.h"
+#ifdef FIPS_MODULE
+#include <openssl/self_test.h>
+#include "prov/providercommon.h"
+#endif
 
 #ifdef FIPS_MODULE
 # define MIN_STRENGTH 112
@@ -393,6 +397,7 @@ static int generate_key(DH *dh)
     dh->priv_key = priv_key;
 #ifdef FIPS_MODULE
     if (ossl_dh_check_pairwise(dh) <= 0) {
+        ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT);
         ERR_raise(ERR_LIB_PROV, DH_R_CHECK_PUBKEY_INVALID);
         goto err;
     }


### PR DESCRIPTION
In generate_key() ensure public key is checked, and pairwise check is
performed.

Based on https://gitlab.com/redhat/centos-stream/rpms/openssl/-/blob/c9s/0044-FIPS-140-3-keychecks.patch by @beldmit

Forward port to current codebase, use return errors rather than aborting the library.

IG 10.3.A additional comment 1 on page 87 (10/23/2024 edition of FIPS 140-3 IG) states the following:

> Though not a CAST, a pairwise consistency test (PCT) shall be conducted for every generated public and private key pair for the applicable approved algorithm (per ISO/IEC 19790:2012 Section 7.10.3.3). At minimum, the PCT that is required by the underlying algorithm standard (e.g., SP 800-56Arev3 Section 5.6.2.1.4 option ‘b’ or SP 800-56Brev2 Section 6.4.1.1 option ‘2.’) shall be performed, which will satisfy the PCT requirement in either TE10.35.01 for key transport, TE10.35.02 for signatures, or TE10.35.03 for key agreement.

The SP 800-56Arev3 Section 5.6.2.1.4(b) is to validate public parameters & recompute and compare the public key a second time. This is now implemented with calls to `DH_check_pub_key()` and ossl_dh_check_pairwise().

Co-authored-by: Dmitry Belyavskiy <dbelyavs@redhat.com>

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>