### PR TITLE
Change "a SSL" to "an SSL"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8606,7 +8606,7 @@ OpenSSL 1.0.1
    *Matt Caswell*
 
  * Fix issue where no-ssl3 configuration sets method to NULL. When openssl is
-   built with the no-ssl3 option and a SSL v3 ClientHello is received the ssl
+   built with the no-ssl3 option and an SSL v3 ClientHello is received the ssl
    method would be set to NULL which could later result in a NULL pointer
    dereference. Thanks to Frank Schmirler for reporting this issue.
    ([CVE-2014-3569])
@@ -9671,7 +9671,7 @@ OpenSSL 1.0.0
    *Matt Caswell*
 
  * Fix issue where no-ssl3 configuration sets method to NULL. When openssl is
-   built with the no-ssl3 option and a SSL v3 ClientHello is received the ssl
+   built with the no-ssl3 option and an SSL v3 ClientHello is received the ssl
    method would be set to NULL which could later result in a NULL pointer
    dereference. Thanks to Frank Schmirler for reporting this issue.
    ([CVE-2014-3569])
@@ -15802,7 +15802,7 @@ s-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
    *stefank@valicert.com via Richard Levitte*
 
- * Add a SSL_SESS_CACHE_NO_INTERNAL_STORE flag to take over half
+ * Add an SSL_SESS_CACHE_NO_INTERNAL_STORE flag to take over half
    the job SSL_SESS_CACHE_NO_INTERNAL_LOOKUP was inconsistently
    doing, define a new flag (SSL_SESS_CACHE_NO_INTERNAL) to be
    the bitwise-OR of the two for use by the majority of applications
@@ -16351,7 +16351,7 @@ s-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 ### Changes between 0.9.6a and 0.9.6b  [9 Jul 2001]
 
  * Change ssleay_rand_bytes (crypto/rand/md_rand.c)
-   to avoid a SSLeay/OpenSSL PRNG weakness pointed out by
+   to avoid an SSLeay/OpenSSL PRNG weakness pointed out by
    Markku-Juhani O. Saarinen <markku-juhani.saarinen@nokia.com>:
    PRNG state recovery was possible based on the output of
    one PRNG request appropriately sized to gain knowledge on
@@ -18952,7 +18952,7 @@ s-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 
  * Bugfix: ssl23_get_client_hello did not work properly when called in
    state SSL23_ST_SR_CLNT_HELLO_B, i.e. when the first 7 bytes of
-   a SSLv2-compatible client hello for SSLv3 or TLSv1 could be read,
+   an SSLv2-compatible client hello for SSLv3 or TLSv1 could be read,
    but a retry condition occurred while trying to read the rest.
 
    *Bodo Moeller*

--- a/demos/bio/sconnect.c
+++ b/demos/bio/sconnect.c
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
     if (!SSL_CTX_load_verify_locations(ssl_ctx, CAfile, NULL))
         goto err;
 
-    /* Lets make a SSL structure */
+    /* Let's make an SSL structure */
     ssl = SSL_new(ssl_ctx);
     SSL_set_connect_state(ssl);
 

--- a/demos/http3/ossl-nghttp3.h
+++ b/demos/http3/ossl-nghttp3.h
@@ -57,7 +57,7 @@ OSSL_DEMO_H3_CONN *OSSL_DEMO_H3_CONN_new_for_conn(BIO *qconn_bio,
  * underlying QUIC connection SSL object is owned by the OSSL_DEMO_H3_CONN and
  * can be subsequently retrieved using OSSL_DEMO_H3_CONN_get0_connection.
  *
- * Returns NULL on failure. ctx must be a SSL_CTX using a QUIC client
+ * Returns NULL on failure. ctx must be an SSL_CTX using a QUIC client
  * SSL_METHOD.
  */
 OSSL_DEMO_H3_CONN *OSSL_DEMO_H3_CONN_new_for_addr(SSL_CTX *ctx,

--- a/doc/designs/ddd/REPORT.md
+++ b/doc/designs/ddd/REPORT.md
@@ -122,7 +122,7 @@ The following additional changes needed to be made:
 The following changes were foreseen to be necessary, but turned out to actually
 not be necessary:
 
-- The need to change code which pushes a `BIO_f_buffer()` after a SSL BIO
+- The need to change code which pushes a `BIO_f_buffer()` after an SSL BIO
   was foreseen as use of buffering on the network side is unworkable with
   QUIC. This turned out not to be necessary since we can just reject the
   BIO_push() call. The buffer should still be freed eventually when the

--- a/doc/designs/quic-design/error-handling.md
+++ b/doc/designs/quic-design/error-handling.md
@@ -75,7 +75,7 @@ for errors happening in the internal assistance thread. When a permanent error
 is detected the error stack entries are moved to this error stack in
 QUIC_CHANNEL.
 
-When returning to an application from a SSL_read()/SSL_write() call with
+When returning to an application from an SSL_read()/SSL_write() call with
 a permanent connection error, entries from the QUIC_CHANNEL error stack
 are copied to the thread local error stack. They are always kept on
 the QUIC_CHANNEL error stack as well for possible further calls from

--- a/doc/designs/quic-design/glossary.md
+++ b/doc/designs/quic-design/glossary.md
@@ -151,7 +151,7 @@ Initial packets. It is only used temporarily.
 `SSL_new` using a QUIC method.
 
 **QCTX**: QUIC Context. This is a utility object defined within the QUIC APL
-which helps to unwrap a SSL object pointer (a QCSO or QSSO) into the relevant
+which helps to unwrap an SSL object pointer (a QCSO or QSSO) into the relevant
 structure pointers such as `QUIC_CONNECTION` or `QUIC_XSO`.
 
 **QRL:** QUIC record layer. Refers collectively to the QRX and QTX.

--- a/doc/designs/quic-design/quic-api-ssl-funcs.md
+++ b/doc/designs/quic-design/quic-api-ssl-funcs.md
@@ -929,7 +929,7 @@ TODO: new_session_ticket doesn't need modifying as such, but ticket machinery
 
 ### What should `SSL_pending` and `SSL_has_pending` do?
 
-`SSL_pending` traditionally yields the number of bytes buffered inside a SSL
+`SSL_pending` traditionally yields the number of bytes buffered inside an SSL
 object available for immediate reading. For QUIC, we can just make this report
 the current size of the receive stream buffer.
 

--- a/doc/designs/quic-design/quic-api.md
+++ b/doc/designs/quic-design/quic-api.md
@@ -563,7 +563,7 @@ int SSL_shutdown_ex(SSL *ssl,
 are read only on the first call to `SSL_shutdown_ex` for a given SSL object and
 subsequent calls to `SSL_shutdown_ex` ignore the `args` argument. `args_len`
 should be set to `sizeof(*args)`. This function is idempotent; once the shutdown
-process for a SSL object is complete, further calls are a no-op and return 1.
+process for an SSL object is complete, further calls are a no-op and return 1.
 
 Calling `SSL_shutdown_ex` on a QUIC connection SSL object causes the immediate
 close of the QUIC connection. “Immediate close” is as defined by RFC 9000.
@@ -744,7 +744,7 @@ no-ops. This is considered a success case.
  *
  * For SSL_get_stream_read_state, this means that there is no more data to read,
  * and that any future SSL_read calls will return any residual data waiting to
- * be read followed by a SSL_ERROR_ZERO_RETURN condition.
+ * be read followed by an SSL_ERROR_ZERO_RETURN condition.
  *
  * For SSL_get_stream_write_state, this means that the local application has
  * already indicated the end of the stream by calling SSL_stream_conclude,
@@ -949,7 +949,7 @@ int SSL_is_connection(SSL *ssl);
 
 ```c
 /*
- * If the object represents a stream, returns a SSL_STREAM_TYPE value
+ * If the object represents a stream, returns an SSL_STREAM_TYPE value
  * designating whether the stream can be used for transmission, reception,
  * or both.
  *

--- a/doc/man3/SSL_CTX_set1_verify_cert_store.pod
+++ b/doc/man3/SSL_CTX_set1_verify_cert_store.pod
@@ -59,7 +59,7 @@ affected if the parent SSL_CTX store pointer is set to a new value.
 
 The verification store is used to verify the certificate chain sent by the
 peer: that is an SSL/TLS client will use the verification store to verify
-the server's certificate chain and a SSL/TLS server will use it to verify
+the server's certificate chain and an SSL/TLS server will use it to verify
 any client certificate chain.
 
 The chain store is used to build the certificate chain.

--- a/doc/man3/SSL_CTX_set_cert_verify_callback.pod
+++ b/doc/man3/SSL_CTX_set_cert_verify_callback.pod
@@ -20,7 +20,7 @@ the time when L<SSL_new(3)> is called.
 
 =head1 NOTES
 
-When a peer certificate has been received during a SSL/TLS handshake,
+When a peer certificate has been received during an SSL/TLS handshake,
 a verification function is called regardless of the verification mode.
 If the application does not explicitly specify a verification callback function,
 the built-in verification function is used.

--- a/doc/man3/SSL_CTX_set_max_cert_list.pod
+++ b/doc/man3/SSL_CTX_set_max_cert_list.pod
@@ -55,7 +55,7 @@ than the default, as the buffer is handled dynamically and only uses the
 memory actually required by the data sent by the peer.
 
 If the maximum certificate chain size allowed is exceeded, the handshake will
-fail with a SSL_R_EXCESSIVE_MESSAGE_SIZE error.
+fail with an SSL_R_EXCESSIVE_MESSAGE_SIZE error.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -71,7 +71,7 @@ CSP 3.x.
 
 =item SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS
 
-Disables a countermeasure against a SSL 3.0/TLS 1.0 protocol
+Disables a countermeasure against an SSL 3.0/TLS 1.0 protocol
 vulnerability affecting CBC ciphers, which cannot be handled by some
 broken SSL implementations.  This option has no effect for connections
 using other ciphers.
@@ -357,7 +357,7 @@ Disable version rollback attack detection.
 During the client key exchange, the client must send the same information
 about acceptable SSL/TLS protocol levels as during the first hello. Some
 clients violate this rule by adapting to the server's answer. (Example:
-the client sends a SSLv2 hello and accepts up to SSLv3.1=TLSv1, the server
+the client sends an SSLv2 hello and accepts up to SSLv3.1=TLSv1, the server
 only understands up to SSLv3. In this case the client must still use the
 same SSLv3.1=TLSv1 announcement. Some clients step down to SSLv3 with respect
 to the server's answer and violate the version rollback protection.)

--- a/doc/man3/SSL_CTX_set_quiet_shutdown.pod
+++ b/doc/man3/SSL_CTX_set_quiet_shutdown.pod
@@ -36,7 +36,7 @@ has no effect if called on a QUIC SSL object.
 
 =head1 NOTES
 
-Normally when a SSL connection is finished, the parties must send out
+Normally when an SSL connection is finished, the parties must send out
 close_notify alert messages using L<SSL_shutdown(3)>
 for a clean shutdown.
 

--- a/doc/man3/SSL_SESSION_free.pod
+++ b/doc/man3/SSL_SESSION_free.pod
@@ -41,7 +41,7 @@ the SSL_SESSION objects are internally referenced by the SSL_CTX and
 linked into its session cache. SSL objects may be using the SSL_SESSION object;
 as a session may be reused, several SSL objects may be using one SSL_SESSION
 object at the same time. It is therefore crucial to keep the reference
-count (usage information) correct and not delete a SSL_SESSION object
+count (usage information) correct and not delete an SSL_SESSION object
 that is still used, as this may lead to program failures due to
 dangling pointers. These failures may also appear delayed, e.g.
 when an SSL_SESSION object was completely freed as the reference count

--- a/doc/man3/SSL_accept_stream.pod
+++ b/doc/man3/SSL_accept_stream.pod
@@ -52,11 +52,11 @@ functionality.
 
 SSL_accept_stream() returns a newly allocated QUIC stream SSL object, or NULL if
 no new incoming streams are available, or if the connection has been terminated,
-or if called on a SSL object other than a QUIC connection SSL object.
+or if called on an SSL object other than a QUIC connection SSL object.
 L<SSL_get_error(3)> can be used to obtain further information in this case.
 
 SSL_get_accept_stream_queue_len() returns the number of incoming streams
-currently waiting in the accept queue, or 0 if called on a SSL object other than
+currently waiting in the accept queue, or 0 if called on an SSL object other than
 a QUIC connection SSL object.
 
 =head1 SEE ALSO

--- a/doc/man3/SSL_clear.pod
+++ b/doc/man3/SSL_clear.pod
@@ -28,8 +28,8 @@ set the SSL_SENT_SHUTDOWN state.
 If a session was closed cleanly, the session object will be kept and all
 settings corresponding. This explicitly means, that e.g. the special method
 used during the session will be kept for the next handshake. So if the
-session was a TLSv1 session, a SSL client object will use a TLSv1 client
-method for the next handshake and a SSL server object will use a TLSv1
+session was a TLSv1 session, an SSL client object will use a TLSv1 client
+method for the next handshake and an SSL server object will use a TLSv1
 server method, even if TLS_*_methods were chosen on startup. This
 will might lead to connection failures (see L<SSL_new(3)>)
 for a description of the method's properties.

--- a/doc/man3/SSL_do_handshake.pod
+++ b/doc/man3/SSL_do_handshake.pod
@@ -12,7 +12,7 @@ SSL_do_handshake - perform a TLS/SSL handshake
 
 =head1 DESCRIPTION
 
-SSL_do_handshake() will wait for a SSL/TLS handshake to take place. If the
+SSL_do_handshake() will wait for an SSL/TLS handshake to take place. If the
 connection is in client mode, the handshake will be started. The handshake
 routines may have to be explicitly set in advance using either
 L<SSL_set_connect_state(3)> or

--- a/doc/man3/SSL_get_value_uint.pod
+++ b/doc/man3/SSL_get_value_uint.pod
@@ -24,7 +24,7 @@ SSL_VALUE_STREAM_WRITE_BUF_USED,
 SSL_get_stream_write_buf_used,
 SSL_VALUE_STREAM_WRITE_BUF_AVAIL,
 SSL_get_stream_write_buf_avail -
-manage negotiable features and configuration values for a SSL object
+manage negotiable features and configuration values for an SSL object
 
 =head1 SYNOPSIS
 

--- a/doc/man3/SSL_handle_events.pod
+++ b/doc/man3/SSL_handle_events.pod
@@ -12,7 +12,7 @@ SSL_handle_events - advance asynchronous state machine and perform network I/O
 
 =head1 DESCRIPTION
 
-SSL_handle_events() performs any internal processing which is due on a SSL object. The
+SSL_handle_events() performs any internal processing which is due on an SSL object. The
 exact operations performed by SSL_handle_events() vary depending on what kind of protocol
 is being used with the given SSL object. For example, SSL_handle_events() may handle
 timeout events which have become due, or may attempt, to the extent currently

--- a/doc/man3/SSL_inject_net_dgram.pod
+++ b/doc/man3/SSL_inject_net_dgram.pod
@@ -33,7 +33,7 @@ given addresses.
 =head1 RETURN VALUES
 
 Returns 1 on success or 0 on failure. This function always fails if called
-on a SSL object which is not a QUIC connection SSL object.
+on an SSL object which is not a QUIC connection SSL object.
 
 =head1 SEE ALSO
 

--- a/doc/man3/SSL_poll.pod
+++ b/doc/man3/SSL_poll.pod
@@ -91,7 +91,7 @@ The fields of B<SSL_POLL_ITEM> are as follows:
 
 The resource being polled for readiness, as represented by a
 B<BIO_POLL_DESCRIPTOR>. Currently, this must be a poll descriptor of type
-B<BIO_POLL_DESCRIPTOR_TYPE_SSL>, representing a SSL object pointer, and the SSL
+B<BIO_POLL_DESCRIPTOR_TYPE_SSL>, representing an SSL object pointer, and the SSL
 object must be a QUIC connection SSL object or QUIC stream SSL object.
 
 If a B<SSL_POLL_ITEM> has a poll descriptor type of

--- a/doc/man3/SSL_set_blocking_mode.pod
+++ b/doc/man3/SSL_set_blocking_mode.pod
@@ -47,7 +47,7 @@ which can support blocking mode and explicitly call SSL_set_blocking_mode().
 =head1 RETURN VALUES
 
 SSL_set_blocking_mode() returns 1 on success and 0 on failure. The function
-fails if called on a SSL object which does not represent a QUIC connection,
+fails if called on an SSL object which does not represent a QUIC connection,
 or if blocking mode cannot be used for the given connection.
 
 SSL_get_blocking_mode() returns 1 if blocking is currently enabled. It returns

--- a/doc/man3/SSL_shutdown.pod
+++ b/doc/man3/SSL_shutdown.pod
@@ -69,7 +69,7 @@ shutdown process was first initiated by the local application or by the peer.
 
 =head2 Locally-Initiated Shutdown
 
-Calling SSL_shutdown() on a SSL/TLS or DTLS SSL object initiates the shutdown
+Calling SSL_shutdown() on an SSL/TLS or DTLS SSL object initiates the shutdown
 process and causes OpenSSL to try to send a close_notify shutdown alert to the
 peer. The shutdown process will then be considered completed once the peer
 responds in turn with a close_notify shutdown alert message.
@@ -204,7 +204,7 @@ which indicates unambiguously when all data has been sent.
 
 =head2 Session Ticket Handling
 
-If a client application only writes to a SSL/TLS or DTLS connection and never
+If a client application only writes to an SSL/TLS or DTLS connection and never
 reads, OpenSSL may never process new SSL/TLS session tickets sent by the server.
 This is because OpenSSL ordinarily processes handshake messages received from a
 peer during calls to L<SSL_read(3)> by the application.

--- a/doc/man7/openssl-quic.pod
+++ b/doc/man7/openssl-quic.pod
@@ -598,7 +598,7 @@ Gets the QUIC connection SSL object from a QUIC stream SSL object.
 
 =item L<SSL_is_connection(3)>
 
-Returns 1 if a SSL object is not a QUIC stream SSL object.
+Returns 1 if an SSL object is not a QUIC stream SSL object.
 
 =item L<SSL_get_stream_type(3)>
 

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -386,7 +386,7 @@ typedef int (*SSL_async_callback_fn)(SSL *s, void *arg);
      */
 # define SSL_OP_CIPHER_SERVER_PREFERENCE                 SSL_OP_BIT(22)
     /*
-     * If set, a server will allow a client to issue a SSLv3.0 version
+     * If set, a server will allow a client to issue an SSLv3.0 version
      * number as latest version supported in the premaster secret, even when
      * TLSv1.0 (version 3.1) was announced in the client hello. Normally
      * this is forbidden to prevent version rollback attacks.

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -174,7 +174,7 @@ static void dtls_unbuffer_record(SSL_CONNECTION *s)
  *   -  SSL3_RT_APPLICATION_DATA (when ssl3_read calls us)
  *   -  0 (during a shutdown, no data has to be returned)
  *
- * If we don't have stored data to work from, read a SSL/TLS record first
+ * If we don't have stored data to work from, read an SSL/TLS record first
  * (possibly multiple records if we still don't have anything to return).
  *
  * This function must handle any surprises the peer may have for us, such as

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -590,7 +590,7 @@ int ssl_release_record(SSL_CONNECTION *s, TLS_RECORD *rr, size_t length)
  *   -  SSL3_RT_APPLICATION_DATA (when ssl3_read calls us)
  *   -  0 (during a shutdown, no data has to be returned)
  *
- * If we don't have stored data to work from, read a SSL/TLS record first
+ * If we don't have stored data to work from, read an SSL/TLS record first
  * (possibly multiple records if we still don't have anything to return).
  *
  * This function must handle any surprises the peer may have for us, such as

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -5038,7 +5038,7 @@ SSL *SSL_dup(SSL *s)
 {
     SSL *ret;
     int i;
-    /* TODO(QUIC FUTURE): Add a SSL_METHOD function for duplication */
+    /* TODO(QUIC FUTURE): Add an SSL_METHOD function for duplication */
     SSL_CONNECTION *retsc;
     SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL_ONLY(s);
 

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -820,7 +820,7 @@ struct ssl_ctx_st {
     /*
      * If this callback is not null, it will be called each time a session id
      * is added to the cache.  If this function returns 1, it means that the
-     * callback will do a SSL_SESSION_free() when it has finished using it.
+     * callback will do an SSL_SESSION_free() when it has finished using it.
      * Otherwise, on 0, it means the callback has finished with it. If
      * remove_session_cb is not null, it will be called when a session-id is
      * removed from the cache.  After the call, OpenSSL will

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1532,7 +1532,7 @@ MSG_PROCESS_RETURN tls_process_client_hello(SSL_CONNECTION *s, PACKET *pkt)
             || mt != SSL2_MT_CLIENT_HELLO) {
             /*
              * Should never happen. We should have tested this in the record
-             * layer in order to have determined that this is a SSLv2 record
+             * layer in order to have determined that this is an SSLv2 record
              * in the first place
              */
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);


### PR DESCRIPTION
@mattcaswell 
- "a SSL" -> "an SSL"
- "A SSL" -> "An SSL"

- [x] documentation is added or updated