### PR TITLE
Fix memory leak on failure in copy_issuer()

### DIFF
--- a/crypto/x509/v3_san.c
+++ b/crypto/x509/v3_san.c
@@ -336,7 +336,7 @@ static GENERAL_NAMES *v2i_issuer_alt(X509V3_EXT_METHOD *method,
 
 static int copy_issuer(X509V3_CTX *ctx, GENERAL_NAMES *gens)
 {
-    GENERAL_NAMES *ialt;
+    GENERAL_NAMES *ialt = NULL;
     GENERAL_NAME *gen;
     X509_EXTENSION *ext;
     int i, num;
@@ -371,6 +371,7 @@ static int copy_issuer(X509V3_CTX *ctx, GENERAL_NAMES *gens)
     return 1;
 
  err:
+    sk_GENERAL_NAME_free(ialt);
     return 0;
 
 }


### PR DESCRIPTION
When sk_GENERAL_NAME_reserve() fails, ialt is not freed. Add the freeing operation in the common error path.

Note: this was detected using an experimental static analyser I'm working on. I could be wrong because my results are based on static analysis, even though I manually read the code as well.