### PR TITLE
Remove unnecessary sk_GENERAL_NAME_free() calls on NULL

### DIFF
--- a/crypto/x509/v3_san.c
+++ b/crypto/x509/v3_san.c
@@ -308,7 +308,6 @@ static GENERAL_NAMES *v2i_issuer_alt(X509V3_EXT_METHOD *method,
 
     if (gens == NULL) {
         ERR_raise(ERR_LIB_X509V3, ERR_R_CRYPTO_LIB);
-        sk_GENERAL_NAME_free(gens);
         return NULL;
     }
     for (i = 0; i < num; i++) {
@@ -387,7 +386,6 @@ static GENERAL_NAMES *v2i_subject_alt(X509V3_EXT_METHOD *method,
     gens = sk_GENERAL_NAME_new_reserve(NULL, num);
     if (gens == NULL) {
         ERR_raise(ERR_LIB_X509V3, ERR_R_CRYPTO_LIB);
-        sk_GENERAL_NAME_free(gens);
         return NULL;
     }
 
@@ -483,7 +481,6 @@ GENERAL_NAMES *v2i_GENERAL_NAMES(const X509V3_EXT_METHOD *method,
     gens = sk_GENERAL_NAME_new_reserve(NULL, num);
     if (gens == NULL) {
         ERR_raise(ERR_LIB_X509V3, ERR_R_CRYPTO_LIB);
-        sk_GENERAL_NAME_free(gens);
         return NULL;
     }
 


### PR DESCRIPTION
There are several calls to sk_GENERAL_NAME_free() where the argument is actually NULL, there are not necessary.
