### PR TITLE
Fix default_md in multiple configuration file templates

### DIFF
--- a/test/CAtsa.cnf
+++ b/test/CAtsa.cnf
@@ -51,7 +51,7 @@ emailAddress		= optional
 
 #----------------------------------------------------------------------
 [ req ]
-default_md		= sha1
+default_md		= sha256
 distinguished_name	= $ENV::TSDNSECT
 encrypt_rsa_key		= no
 prompt 			= no

--- a/test/ca-and-certs.cnf
+++ b/test/ca-and-certs.cnf
@@ -8,7 +8,7 @@ CN2 = Brother 2
 [ req ]
 distinguished_name	= req_distinguished_name
 encrypt_rsa_key		= no
-default_md		= sha1
+default_md		= sha256
 
 [ req_distinguished_name ]
 countryName			= Country Name (2 letter code)
@@ -70,7 +70,7 @@ name_opt 	= ca_default
 cert_opt 	= ca_default
 default_days	= 365
 default_crl_days= 30
-default_md	= sha1
+default_md	= sha256
 preserve	= no
 policy		= policy_anything
 

--- a/test/recipes/90-test_includes_data/conf-includes/includes1.cnf
+++ b/test/recipes/90-test_includes_data/conf-includes/includes1.cnf
@@ -24,7 +24,7 @@ private_key	= $dir/private/CAkey.pem# The private key
 
 default_days	= 365			# how long to certify for
 default_crl_days= 30			# how long before next CRL
-default_md	= md5			# which md to use.
+default_md	= sha256			# which md to use.
 
 # A few difference way of specifying how similar the request should look
 # For type CA, the listed attributes must be the same, and the optional

--- a/test/test.cnf
+++ b/test/test.cnf
@@ -19,7 +19,7 @@ private_key	= $dir/private/CAkey.pem# The private key
 
 default_days	= 365			# how long to certify for
 default_crl_days= 30			# how long before next CRL
-default_md	= md5			# which md to use.
+default_md	= sha256			# which md to use.
 
 # A few difference way of specifying how similar the request should look
 # For type CA, the listed attributes must be the same, and the optional


### PR DESCRIPTION
In reference to issue [#25856](https://github.com/openssl/openssl/pull/25856) I reported previously, since the **default_md** option for **ca** and **req** can utilize any digest supported by the **openssl-dgst** command, it is recommended for security reasons to set default_md in the configuration file templates to **sha256**, aligning with the default digest of the openssl-dgst command. This can avoid security risks for users who directly use configuration file templates.
