### PR TITLE
Don't complain with "no cipher match" for QUIC objects

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3343,9 +3343,9 @@ int SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str)
      * error as far as ssl_create_cipher_list is concerned, and hence
      * ctx->cipher_list and ctx->cipher_list_by_id has been updated.
      */
-    if (sk == NULL)
+    if (sk == NULL) {
         return 0;
-    else if (ctx->method->num_ciphers() > 0 && cipher_list_tls12_num(sk) == 0) {
+    } else if (ctx->method->num_ciphers() > 0 && cipher_list_tls12_num(sk) == 0) {
         ERR_raise(ERR_LIB_SSL, SSL_R_NO_CIPHER_MATCH);
         return 0;
     }
@@ -3367,9 +3367,9 @@ int SSL_set_cipher_list(SSL *s, const char *str)
                                 &sc->cipher_list, &sc->cipher_list_by_id, str,
                                 sc->cert);
     /* see comment in SSL_CTX_set_cipher_list */
-    if (sk == NULL)
+    if (sk == NULL) {
         return 0;
-    else if (ctx->method->num_ciphers() > 0 && cipher_list_tls12_num(sk) == 0) {
+    } else if (ctx->method->num_ciphers() > 0 && cipher_list_tls12_num(sk) == 0) {
         ERR_raise(ERR_LIB_SSL, SSL_R_NO_CIPHER_MATCH);
         return 0;
     }

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3345,7 +3345,7 @@ int SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str)
      */
     if (sk == NULL)
         return 0;
-    else if (cipher_list_tls12_num(sk) == 0) {
+    else if (ctx->method->num_ciphers() > 0 && cipher_list_tls12_num(sk) == 0) {
         ERR_raise(ERR_LIB_SSL, SSL_R_NO_CIPHER_MATCH);
         return 0;
     }
@@ -3357,17 +3357,19 @@ int SSL_set_cipher_list(SSL *s, const char *str)
 {
     STACK_OF(SSL_CIPHER) *sk;
     SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+    SSL_CTX *ctx;
 
     if (sc == NULL)
         return 0;
 
-    sk = ssl_create_cipher_list(s->ctx, sc->tls13_ciphersuites,
+    ctx = s->ctx;
+    sk = ssl_create_cipher_list(ctx, sc->tls13_ciphersuites,
                                 &sc->cipher_list, &sc->cipher_list_by_id, str,
                                 sc->cert);
     /* see comment in SSL_CTX_set_cipher_list */
     if (sk == NULL)
         return 0;
-    else if (cipher_list_tls12_num(sk) == 0) {
+    else if (ctx->method->num_ciphers() > 0 && cipher_list_tls12_num(sk) == 0) {
         ERR_raise(ERR_LIB_SSL, SSL_R_NO_CIPHER_MATCH);
         return 0;
     }

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3343,9 +3343,9 @@ int SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str)
      * error as far as ssl_create_cipher_list is concerned, and hence
      * ctx->cipher_list and ctx->cipher_list_by_id has been updated.
      */
-    if (sk == NULL) {
+    if (sk == NULL)
         return 0;
-    } else if (ctx->method->num_ciphers() > 0 && cipher_list_tls12_num(sk) == 0) {
+    if (ctx->method->num_ciphers() > 0 && cipher_list_tls12_num(sk) == 0) {
         ERR_raise(ERR_LIB_SSL, SSL_R_NO_CIPHER_MATCH);
         return 0;
     }
@@ -3367,9 +3367,9 @@ int SSL_set_cipher_list(SSL *s, const char *str)
                                 &sc->cipher_list, &sc->cipher_list_by_id, str,
                                 sc->cert);
     /* see comment in SSL_CTX_set_cipher_list */
-    if (sk == NULL) {
+    if (sk == NULL)
         return 0;
-    } else if (ctx->method->num_ciphers() > 0 && cipher_list_tls12_num(sk) == 0) {
+    if (ctx->method->num_ciphers() > 0 && cipher_list_tls12_num(sk) == 0) {
         ERR_raise(ERR_LIB_SSL, SSL_R_NO_CIPHER_MATCH);
         return 0;
     }

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -285,7 +285,7 @@ static int test_fin_only_blocking(void)
 static int test_ciphersuites(void)
 {
     SSL_CTX *ctx = SSL_CTX_new_ex(libctx, NULL, OSSL_QUIC_client_method());
-    SSL *ssl;
+    SSL *ssl = NULL;
     int testresult = 0;
     const STACK_OF(SSL_CIPHER) *ciphers = NULL;
     const SSL_CIPHER *cipher;

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -302,8 +302,18 @@ static int test_ciphersuites(void)
     if (!TEST_ptr(ctx))
         return 0;
 
+    /*
+     * Attempting to set TLSv1.2 ciphersuites should succeed, even though they
+     * aren't used in QUIC.
+     */
+    if (!TEST_true(SSL_CTX_set_cipher_list(ctx, "DEFAULT")))
+        goto err;
+
     ssl = SSL_new(ctx);
     if (!TEST_ptr(ssl))
+        goto err;
+
+    if (!TEST_true(SSL_set_cipher_list(ssl, "DEFAULT")))
         goto err;
 
     ciphers = SSL_get_ciphers(ssl);


### PR DESCRIPTION
Calling the functions SSL_CTX_set_cipher_list() or SSL_set_cipher_list() will
return the error "no cipher match" if no TLSv1.2 (or below) ciphers are enabled
after calling them. However this is normal behaviour for QUIC objects which do
not support TLSv1.2 ciphers. Therefore we should suppress that error in this
case.

Fixes https://github.com/openssl/openssl/issues/25878
