### PR TITLE
APPS/pkeyutl: fix checks for `-verifyrecover` option

### DIFF
--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -490,8 +490,7 @@ int pkeyutl_main(int argc, char **argv)
 
     /* Sanity check the input if the input is not raw */
     if (!rawin
-        && (pkey_op == EVP_PKEY_OP_SIGN || pkey_op == EVP_PKEY_OP_VERIFY
-            || pkey_op == EVP_PKEY_OP_VERIFYRECOVER)) {
+        && (pkey_op == EVP_PKEY_OP_SIGN || pkey_op == EVP_PKEY_OP_VERIFY)) {
         if (buf_inlen > EVP_MAX_MD_SIZE) {
             BIO_printf(bio_err,
                        "Error: The non-raw input data length %d is too long - max supported hashed size is %d\n",

--- a/test/recipes/20-test_pkeyutl.t
+++ b/test/recipes/20-test_pkeyutl.t
@@ -17,7 +17,7 @@ use File::Compare qw/compare_text compare/;
 
 setup("test_pkeyutl");
 
-plan tests => 24;
+plan tests => 25;
 
 # For the tests below we use the cert itself as the TBS file
 
@@ -54,7 +54,7 @@ SKIP: {
 }
 
 SKIP: {
-    skip "Skipping tests that require ECX", 6
+    skip "Skipping tests that require ECX", 7
         if disabled("ecx");
 
     # Ed25519
@@ -68,6 +68,9 @@ SKIP: {
                   '-inkey', srctop_file('test', 'certs', 'server-ed25519-cert.pem'),
                   '-sigfile', 'Ed25519.sig']))),
                   "Verify an Ed25519 signature against a piece of data");
+    ok(!run(app(([ 'openssl', 'pkeyutl', '-verifyrecover', '-in', 'Ed25519.sig',
+                   '-inkey', srctop_file('test', 'certs', 'server-ed25519-key.pem')]))),
+       "Cannot use -verifyrecover with EdDSA");
 
     # Ed448
     ok(run(app(([ 'openssl', 'pkeyutl', '-sign', '-in',


### PR DESCRIPTION
This fixes #25898 (remove wrong check for `-verifyrecover` regarding too long sign/verify input).

On this occasion, also add missing high-level check for `-verifyrecover` not being compatible with EdDSA.
When using `-verifyrecover` with EdDSA, so far there was just a low-level error:
```
pkeyutl: Error initializing context
408F940602000000:error:03000096:digital envelope routines:evp_pkey_signature_init:operation not supported for this keytype:crypto/evp/signature.c:743:
```
Now this high-level error shown is:
```
pkeyutl: -verifyrecover cannot be used with EdDSA
```
**Update:**
```
pkeyutl: -verifyrecover can be used only with RSA
```

