### PR TITLE
Prevent crash in SSL_stream_reset for streams which have received all expected data

### DIFF
--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -2509,13 +2509,15 @@ static int quic_validate_for_write(QUIC_XSO *xso, int *err)
         /* FALLTHROUGH */
     case QUIC_SSTREAM_STATE_SEND:
     case QUIC_SSTREAM_STATE_DATA_SENT:
-    case QUIC_SSTREAM_STATE_DATA_RECVD:
         if (ossl_quic_sstream_get_final_size(xso->stream->sstream, NULL)) {
             *err = SSL_R_STREAM_FINISHED;
             return 0;
         }
-
         return 1;
+
+    case QUIC_SSTREAM_STATE_DATA_RECVD:
+        *err = SSL_R_STREAM_FINISHED;
+        return 0;
 
     case QUIC_SSTREAM_STATE_RESET_SENT:
     case QUIC_SSTREAM_STATE_RESET_RECVD:

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -5716,6 +5716,32 @@ static const struct script_op script_86[] = {
     OP_END
 };
 
+
+/* 87. Test stream reset functionality */
+static const struct script_op script_87[] = {
+    OP_C_SET_ALPN           ("ossltest")
+    OP_C_CONNECT_WAIT       ()
+
+    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_NONE)
+    OP_C_NEW_STREAM_BIDI    (a, C_BIDI_ID(0))
+    OP_C_NEW_STREAM_BIDI    (b, C_BIDI_ID(1))
+
+    OP_C_WRITE              (a, "apple", 5)
+
+    OP_C_WRITE              (b, "strawberry", 10)
+
+    OP_S_BIND_STREAM_ID     (a, C_BIDI_ID(0))
+    OP_S_BIND_STREAM_ID     (b, C_BIDI_ID(1))
+    OP_S_READ_EXPECT        (b, "strawberry", 10)
+    /* Reset streams, which have all data received */
+    OP_C_STREAM_RESET       (b, 42)
+    OP_C_STREAM_RESET       (a, 42)
+    OP_CHECK                (check_stream_reset, C_BIDI_ID(0))
+    OP_CHECK                (check_stream_reset, C_BIDI_ID(1))
+
+    OP_END
+};
+
 static const struct script_op *const scripts[] = {
     script_1,
     script_2,
@@ -5802,7 +5828,8 @@ static const struct script_op *const scripts[] = {
     script_83,
     script_84,
     script_85,
-    script_86
+    script_86,
+    script_87
 };
 
 static int test_script(int idx)

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -187,6 +187,7 @@ struct script_op {
 #define OPK_POP_ERR                                 51
 #define OPK_C_WRITE_EX2                             52
 #define OPK_SKIP_IF_BLOCKING                        53
+#define OPK_C_STREAM_RESET_FAIL                     54
 
 #define EXPECT_CONN_CLOSE_APP       (1U << 0)
 #define EXPECT_CONN_CLOSE_REMOTE    (1U << 1)
@@ -285,6 +286,8 @@ struct script_op {
     {OPK_S_READ_FAIL, NULL, (allow_zero_len), NULL, #stream_name},
 #define OP_C_STREAM_RESET(stream_name, aec)  \
     {OPK_C_STREAM_RESET, NULL, 0, NULL, #stream_name, (aec)},
+#define OP_C_STREAM_RESET_FAIL(stream_name, aec)  \
+    {OPK_C_STREAM_RESET_FAIL, NULL, 0, NULL, #stream_name, (aec)},
 #define OP_S_ACCEPT_STREAM_WAIT(stream_name)  \
     {OPK_S_ACCEPT_STREAM_WAIT, NULL, 0, NULL, #stream_name},
 #define OP_NEW_THREAD(num_threads, script) \
@@ -1830,6 +1833,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
             break;
 
         case OPK_C_STREAM_RESET:
+        case OPK_C_STREAM_RESET_FAIL:
             {
                 SSL_STREAM_RESET_ARGS args = {0};
 
@@ -1837,9 +1841,13 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                     goto out;
 
                 args.quic_error_code = op->arg2;
-
-                if (!TEST_true(SSL_stream_reset(c_tgt, &args, sizeof(args))))
-                    goto out;
+                if (op->op == OPK_C_STREAM_RESET) {
+                    if (!TEST_true(SSL_stream_reset(c_tgt, &args, sizeof(args))))
+                        goto out;
+                } else {
+                    if (!TEST_false(SSL_stream_reset(c_tgt, &args, sizeof(args))))
+                        goto out;
+                }
             }
             break;
 
@@ -5721,24 +5729,18 @@ static const struct script_op script_86[] = {
 static const struct script_op script_87[] = {
     OP_C_SET_ALPN           ("ossltest")
     OP_C_CONNECT_WAIT       ()
-
-    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_NONE)
     OP_C_NEW_STREAM_BIDI    (a, C_BIDI_ID(0))
-    OP_C_NEW_STREAM_BIDI    (b, C_BIDI_ID(1))
-
     OP_C_WRITE              (a, "apple", 5)
-
-    OP_C_WRITE              (b, "strawberry", 10)
-
+    OP_C_CONCLUDE           (a)
     OP_S_BIND_STREAM_ID     (a, C_BIDI_ID(0))
-    OP_S_BIND_STREAM_ID     (b, C_BIDI_ID(1))
-    OP_S_READ_EXPECT        (b, "strawberry", 10)
-    /* Reset streams, which have all data received */
-    OP_C_STREAM_RESET       (b, 42)
-    OP_C_STREAM_RESET       (a, 42)
-    OP_CHECK                (check_stream_reset, C_BIDI_ID(0))
-    OP_CHECK                (check_stream_reset, C_BIDI_ID(1))
-
+    OP_S_READ_EXPECT        (a, "apple", 5)
+    OP_S_EXPECT_FIN         (a)
+    OP_S_WRITE              (a, "orange", 6)
+    OP_C_READ_EXPECT        (a, "orange", 6)
+    OP_S_CONCLUDE           (a)
+    OP_C_EXPECT_FIN         (a)
+    OP_SLEEP                (1000)
+    OP_C_STREAM_RESET_FAIL  (a, 42)
     OP_END
 };
 


### PR DESCRIPTION
When calling SSL_stream_reset on a QUIC stream object that has received
    all data that is expected to be sent (i.e. when the sender has sent a
    STREAM frame with the FIN bit set), we encounter the following segfault:
``` 
    Program received signal SIGSEGV, Segmentation fault.
    0x00007ffff7f0bd28 in ossl_quic_sstream_get_final_size (qss=0x0, final_size=0x0) at ssl/quic/quic_sstream.c:273
    273         if (!qss->have_final_size)
    (gdb) bt
    0)  0x00007ffff7f0bd28 in ossl_quic_sstream_get_final_size (qss=0x0, final_size=0x0) at ssl/quic/quic_sstream.c:273
    1)  0x00007ffff7ef65bf in quic_validate_for_write (xso=0x5555555efcb0, err=0x7fffffffd5e0) at ssl/quic/quic_impl.c:2513
    2)  0x00007ffff7ef8ae3 in ossl_quic_stream_reset (ssl=0x5555555efcb0, args=0x0, args_len=0) at ssl/quic/quic_impl.c:3657
    3)  0x00007ffff7ebdaa6 in SSL_stream_reset (s=0x5555555efcb0, args=0x0, args_len=0) at ssl/ssl_lib.c:7635
    4)  0x0000555555557527 in build_request_set (
        req_list=0x55555555ebd0 "neil1.txt neil2.txt neil3.txt neil4.txt neil5.txt neil6.txt neil7.txt neil8.txt neil9.txt neil10.txt neil11.txt neil12.txt neil13.txt neil14.txt neil15.txt neil16.txt neil17.txt neil18.txt neil19.txt "..., ssl=0x5555555b6f80)
        at demos/guide/quic-hq-interop.c:545
    5)  0x00005555555587b2 in main (argc=4, argv=0x7fffffffe568) at demos/guide/quic-hq-interop.c:941
``` 
This occurs because:
    1) When the stream FIN bit is set, the quic stack frees the underlying
       stream structures immediately within the QUIC stack
    and
    2) when SSL_stream_reset is called, the call stack indicates we call
       quic_validate_for_write, which attempts to access the
       xso->stream->sstream QUIC_SSTREAM object, which was already freed in
       (1)
    
The fix I think is pretty straightforward.  On receipt of a STREAM frame
    with a FIN bit set, the QUIC stack sets the QUIC_STREAM object state to
    QUIC_SSTREAM_STATE_DATA_RECVD, which means we can use that state to
    simply assert that the stream is valid for write, which allows it to be
    reset properly.


##### Checklist
- [x] tests are added or updated
