### PR TITLE
Restricted include of poll.h to UNIX but not NonStop (not supported).

### DIFF
--- a/include/internal/sockets.h
+++ b/include/internal/sockets.h
@@ -97,7 +97,12 @@ typedef size_t socklen_t;        /* Currently appears to be missing on VMS */
 #   include <in.h>
 #   include <inet.h>
 #  else
-#   include <poll.h>
+#   ifdef OPENSSL_SYS_UNIX
+#     ifndef OPENSSL_SYS_TANDEM
+#      include <poll.h>
+#     endif
+#     include <errno.h>
+#   endif
 #   include <sys/socket.h>
 #   if !defined(NO_SYS_UN_H) && defined(AF_UNIX) && !defined(OPENSSL_NO_UNIX_SOCK)
 #    include <sys/un.h>


### PR DESCRIPTION
Fixes: #25902

Signed-off-by: Randall S. Becker <randall.becker@nexbridge.ca>