### PR TITLE
Fix memleaks in cmd_RecordPadding()

### DIFF
--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -666,22 +666,19 @@ static int cmd_RecordPadding(SSL_CONF_CTX *cctx, const char *value)
 
     copy = OPENSSL_strdup(value);
     if (copy == NULL)
-        return 0;
+        goto out;
     commap = strstr(copy, ",");
     if (commap != NULL) {
         *commap = '\0';
-        if (*(commap + 1) == '\0') {
-            OPENSSL_free(copy);
-            return 0;
-        }
+        if (*(commap + 1) == '\0')
+            goto out;
         if (!OPENSSL_strtoul(commap + 1, &endptr, 0, &hs_padding))
-            return 0;
+            goto out;
     }
     if (!OPENSSL_strtoul(copy, &endptr, 0, &block_padding))
-        return 0;
+        goto out;
     if (commap == NULL)
         hs_padding = block_padding;
-    OPENSSL_free(copy);
 
     /*
      * All we care about are non-negative values,
@@ -693,6 +690,8 @@ static int cmd_RecordPadding(SSL_CONF_CTX *cctx, const char *value)
     if (cctx->ssl)
         rv = SSL_set_block_padding_ex(cctx->ssl, (size_t)block_padding,
                                       (size_t)hs_padding);
+out:
+    OPENSSL_free(copy);
     return rv;
 }
 


### PR DESCRIPTION
Free the internal copy of parameter `value` on each early exit.

Fixes #25906

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
