### PR TITLE
man ECDSA_sign(3): fix wrong variable names

### DIFF
--- a/doc/man3/ECDSA_sign.pod
+++ b/doc/man3/ECDSA_sign.pod
@@ -52,7 +52,7 @@ size use L<EVP_PKEY_sign(3)> with a NULL I<sig> parameter.
 
 ECDSA_sign() computes a digital signature of the I<dgstlen> bytes hash value
 I<dgst> using the private EC key I<eckey>. The DER encoded signatures is
-stored in I<sig> and its length is returned in I<sig_len>. Note: I<sig> must
+stored in I<sig> and its length is returned in I<siglen>. Note: I<sig> must
 point to ECDSA_size(eckey) bytes of memory. The parameter I<type> is currently
 ignored. ECDSA_sign() is wrapper function for ECDSA_sign_ex() with I<kinv>
 and I<rp> set to NULL.
@@ -82,7 +82,7 @@ used in a later call to ECDSA_sign_ex() or ECDSA_do_sign_ex().
 ECDSA_sign_ex() computes a digital signature of the I<dgstlen> bytes hash value
 I<dgst> using the private EC key I<eckey> and the optional pre-computed values
 I<kinv> and I<rp>. The DER encoded signature is stored in I<sig> and its
-length is returned in I<sig_len>. Note: I<sig> must point to ECDSA_size(eckey)
+length is returned in I<siglen>. Note: I<sig> must point to ECDSA_size(eckey)
 bytes of memory. The parameter I<type> is ignored.
 
 ECDSA_do_sign_ex() is similar to ECDSA_sign_ex() except the signature is


### PR DESCRIPTION
the parameters in the function definitions use `siglen` not `sig_len`, this fixes the doc text.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
