### PR TITLE
let OpenSSL to use windows API to deal with utf-16 to utf-8 conversion.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1595,7 +1595,8 @@ my %targets = (
         ex_libs          => add(sub {
             my @ex_libs = ();
             push @ex_libs, 'ws2_32.lib' unless $disabled{sock};
-            push @ex_libs, 'gdi32.lib advapi32.lib crypt32.lib user32.lib Shell32.lib';
+            push @ex_libs, 'gdi32.lib advapi32.lib crypt32.lib user32.lib';
+            push @ex_libs, 'Kernel32.lib Shell32.lib';
             return join(" ", @ex_libs);
         }),
     },

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1595,7 +1595,7 @@ my %targets = (
         ex_libs          => add(sub {
             my @ex_libs = ();
             push @ex_libs, 'ws2_32.lib' unless $disabled{sock};
-            push @ex_libs, 'gdi32.lib advapi32.lib crypt32.lib user32.lib';
+            push @ex_libs, 'gdi32.lib advapi32.lib crypt32.lib user32.lib Shell32.lib';
             return join(" ", @ex_libs);
         }),
     },

--- a/apps/lib/win32_init.c
+++ b/apps/lib/win32_init.c
@@ -15,6 +15,8 @@
 #include <string.h>
 #include <malloc.h>
 
+#include <openssl/crypto.h>
+
 #if defined(CP_UTF8)
 
 static UINT saved_cp;
@@ -141,7 +143,7 @@ static int process_glob(WCHAR *wstr, int wlen)
     return 1;
 }
 
-static void win32_cleanup_argv(int argc, char **argv))
+static void win32_cleanup_argv(int argc, char **argv)
 {
     int i;
 
@@ -161,7 +163,7 @@ static void win32_cleanup_argv_atexit(void)
 void win32_utf8argv(int *argc_out, char ***argv_out)
 {
     LPWSTR  cmd_line_args;
-    LPWSTR *cmd_args
+    LPWSTR *cmd_args;
     int     argc, argc_used, i, sz;
     char  **argv;
 

--- a/apps/lib/win32_init.c
+++ b/apps/lib/win32_init.c
@@ -71,7 +71,7 @@ void win32_utf8argv(int *argc_out, char ***argv_out)
         return;
 
     argc_used = 0;
-    if (i = 0; i < argc; i++) {
+    for (i = 0; i < argc; i++) {
         sz = WideCharToMultiByte(CP_UTF8, 0, cmd_args[i], -1, NULL,
                                  0, NULL, NULL);
         if (sz > 0) {
@@ -89,9 +89,9 @@ void win32_utf8argv(int *argc_out, char ***argv_out)
             NULL, NULL);
     }
 
-    OPENSSL_atexit(win32_cleanup_argv);
+    OPENSSL_atexit(win32_cleanup_argv_atexit);
     LocalFree(cmd_args);
-    win32_cleanup_argv();
+    win32_cleanup_argv_atexit();
     newargv = argv;
     newargc = argc_used;
 

--- a/apps/lib/win32_init.c
+++ b/apps/lib/win32_init.c
@@ -54,7 +54,7 @@ void win32_utf8argv(int *argc_out, char ***argv_out)
         return;
 
     cmd_line_args = GetCommandLineW();
-    if (cmd_args == NULL)
+    if (cmd_line_args == NULL)
         return;
 
     cmd_args = CommandLineToArgvW(cmd_line_args, &argc);


### PR DESCRIPTION
This is a draft PR which replaces current implementation of `win32_utf8argv()` which is using a home-brewed code
with code that uses Windows API.