### PR TITLE
Remove ternary from "runs-on", security repo is hosted on github.com

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   check_update:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - name: install unifdef
       run: |
@@ -45,7 +45,7 @@ jobs:
       run: git diff --exit-code
 
   check_docs:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: config
@@ -65,7 +65,7 @@ jobs:
   # We are not as strict with libraries, but rather adapt to what's
   # expected to be available in a certain version of each platform.
   check-ansi:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: config
@@ -74,7 +74,7 @@ jobs:
       run: make -s -j4
 
   basic_gcc:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
@@ -105,7 +105,7 @@ jobs:
         path: artifacts.tar.gz
 
   basic_clang:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
@@ -152,7 +152,7 @@ jobs:
         path: artifacts.tar.gz
 
   minimal:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
@@ -174,7 +174,7 @@ jobs:
         path: artifacts.tar.gz
 
   no-deprecated:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
@@ -196,7 +196,7 @@ jobs:
         path: artifacts.tar.gz
 
   no-shared-ubuntu:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
@@ -222,7 +222,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-13, macos-14]
-    if: github.server_url == 'https://github.com'
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -245,7 +244,7 @@ jobs:
         path: artifacts.tar.gz
 
   non-caching:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
@@ -271,7 +270,7 @@ jobs:
         path: artifacts.tar.gz
 
   address_ub_sanitizer:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
@@ -297,7 +296,7 @@ jobs:
         path: artifacts.tar.gz
 
   fuzz_tests:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
@@ -324,7 +323,7 @@ jobs:
         if-no-files-found: ignore
 
   memory_sanitizer:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
@@ -351,7 +350,7 @@ jobs:
         path: artifacts.tar.gz
 
   threads_sanitizer:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
@@ -377,7 +376,7 @@ jobs:
         path: artifacts.tar.gz
 
   enable_non-default_options:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
@@ -401,7 +400,7 @@ jobs:
         path: artifacts.tar.gz
 
   full_featured:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
@@ -431,7 +430,7 @@ jobs:
         path: artifacts.tar.gz
 
   no-legacy:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
@@ -453,7 +452,7 @@ jobs:
         path: artifacts.tar.gz
 
   legacy:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
@@ -480,7 +479,7 @@ jobs:
   # - That building, testing and installing works with a read-only source
   #   tree
   out-of-readonly-source-and-install-ubuntu:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
@@ -525,7 +524,6 @@ jobs:
       matrix:
         os: [macos-13, macos-14]
     runs-on: ${{ matrix.os }}
-    if: github.server_url == 'https://github.com'
     steps:
     - uses: actions/checkout@v4
       with:
@@ -565,7 +563,7 @@ jobs:
       working-directory: ./build
 
   external-tests-misc:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
@@ -604,7 +602,7 @@ jobs:
         grep -q "Reading symbols from.*libcrypto\.so\.3\.debug" results
 
   external-tests-providers:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
@@ -627,7 +625,7 @@ jobs:
       run: make test TESTS="test_external_pkcs11_provider" VERBOSE=1
 
   external-tests-pyca:
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         RUST:

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -150,7 +150,7 @@ jobs:
             tests: none
           }
         ]
-    runs-on: ${{ github.server_url == 'https://github.com' && 'ubuntu-latest' || 'ubuntu-22.04-self-hosted' }}
+    runs-on: ubuntu-latest
     steps:
     - name: install package repository
       if: matrix.platform.ppa != ''

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,7 +27,7 @@ jobs:
           - arch: win32
             os: windows-2022
             config: --strict-warnings no-fips
-    runs-on: ${{ github.server_url == 'https://github.com' && matrix.platform.os || format('{0}-self-hosted', matrix.platform.os) }}
+    runs-on: ${{ matrix.platform.os }}
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
@@ -94,7 +94,7 @@ jobs:
         os:
 # Reducing CI footprint  - windows-2019
           - windows-2022
-    runs-on: ${{ github.server_url == 'https://github.com' && matrix.os || format('{0}-self-hosted', matrix.os) }}
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
@@ -131,7 +131,7 @@ jobs:
         os:
           - windows-2019
 # Reducing CI footprint  - windows-2022
-    runs-on: ${{ github.server_url == 'https://github.com' && matrix.os || format('{0}-self-hosted', matrix.os) }}
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
@@ -176,7 +176,7 @@ jobs:
 # are we really learning sth new from win32? So let's save some CO2 for now disabling this
 #          - arch: win32
 #            config: -DCMAKE_C_COMPILER=gcc --strict-warnings no-fips
-    runs-on: ${{ github.server_url == 'https://github.com' && matrix.os || format('{0}-self-hosted', matrix.os) }}
+    runs-on: ${{ matrix.os }}
     env:
       CYGWIN_NOWINPATH: 1
       SHELLOPTS: igncr


### PR DESCRIPTION
Private openssl/security repository is migrated to GitHub and there is no need in these hacks anymore.

https://github.com/openssl/tools/pull/219