### PR TITLE
Enable AES and SHA3 optimisations on Apple Silicon M4-based macOS systems

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -300,7 +300,8 @@ void OPENSSL_cpuid_setup(void)
             if ((sysctlbyname("machdep.cpu.brand_string", uarch, &len, NULL, 0) == 0) &&
                ((strncmp(uarch, "Apple M1", 8) == 0) ||
                 (strncmp(uarch, "Apple M2", 8) == 0) ||
-                (strncmp(uarch, "Apple M3", 8) == 0))) {
+                (strncmp(uarch, "Apple M3", 8) == 0) ||
+                (strncmp(uarch, "Apple M4", 8) == 0))) {
                 OPENSSL_armcap_P |= ARMV8_UNROLL8_EOR3;
                 OPENSSL_armcap_P |= ARMV8_HAVE_SHA3_AND_WORTH_USING;
             }


### PR DESCRIPTION
AES gets a performance enhancement of 7-33%.

Tested on an M4 Pro, but the CPU cores are the same on M4 and M4 Max.
