### PR TITLE
fips: stronger rsa (future)

### DIFF
--- a/providers/common/securitycheck.c
+++ b/providers/common/securitycheck.c
@@ -63,12 +63,15 @@ int ossl_rsa_key_op_get_protect(const RSA *rsa, int operation, int *outprotect)
  * signing), and for legacy purposes 80 bits (for decryption or verifying).
  * Set protect = 1 for encryption or signing operations, or 0 otherwise. See
  * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf.
+ *
+ * drafts raise these to 3072/2048 for post-2030, or infinity/3072 for
+ * post-2035 PQC.
  */
 int ossl_rsa_check_key_size(const RSA *rsa, int protect)
 {
     int sz = RSA_bits(rsa);
 
-    if (protect ? (sz < 2048) : (sz < 1024))
+    if (protect ? (sz < 2048) : (sz < 2048))
         return 0;
     return 1;
 }

--- a/providers/implementations/asymciphers/rsa_enc.c
+++ b/providers/implementations/asymciphers/rsa_enc.c
@@ -157,6 +157,13 @@ static int rsa_encrypt(void *vprsactx, unsigned char *out, size_t *outlen,
         return 0;
 
 #ifdef FIPS_MODULE
+    if (prsactx->pad_mode != RSA_PKCS1_OAEP_PADDING) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_PADDING_MODE);
+        return 0;
+    }
+#endif
+
+#ifdef FIPS_MODULE
     if ((prsactx->pad_mode == RSA_PKCS1_PADDING
          || prsactx->pad_mode == RSA_PKCS1_WITH_TLS_PADDING)
         && !OSSL_FIPS_IND_ON_UNAPPROVED(prsactx, OSSL_FIPS_IND_SETTABLE1,
@@ -229,6 +236,13 @@ static int rsa_decrypt(void *vprsactx, unsigned char *out, size_t *outlen,
 
     if (!ossl_prov_is_running())
         return 0;
+
+#ifdef FIPS_MODULE
+    if (prsactx->pad_mode != RSA_PKCS1_OAEP_PADDING) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_PADDING_MODE);
+        return 0;
+    }
+#endif
 
     if (prsactx->pad_mode == RSA_PKCS1_WITH_TLS_PADDING) {
         if (out == NULL) {

--- a/providers/implementations/kem/rsa_kem.c
+++ b/providers/implementations/kem/rsa_kem.c
@@ -281,6 +281,11 @@ static int rsasve_generate(PROV_RSA_CTX *prsactx,
     int ret;
     size_t nlen;
 
+    if (!ossl_rsa_check_key_size(prsactx->rsa, 1)) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
+        return 0;
+    }
+
     /* Step (1): nlen = Ceil(len(n)/8) */
     nlen = RSA_size(prsactx->rsa);
 
@@ -356,6 +361,11 @@ static int rsasve_recover(PROV_RSA_CTX *prsactx,
 {
     size_t nlen;
     int ret;
+
+    if (!ossl_rsa_check_key_size(prsactx->rsa, 1)) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
+        return 0;
+    }
 
     /* Step (1): get the byte length of n */
     nlen = RSA_size(prsactx->rsa);


### PR DESCRIPTION
- **rsasve_generate & rsasve_recover: invoke ossl_rsa_check_key_size with protect**
  TODO check what the current min requirements are
  

- **ossl_rsa_check_key_size(): raise protect=0 to no-legacy level**
  TODO make these compile time configurable somehow.

Related https://github.com/openssl/openssl/pull/25761
  