### PR TITLE
fips: zeroize temporary self-check out MD variable

### DIFF
--- a/providers/fips/self_test.c
+++ b/providers/fips/self_test.c
@@ -289,6 +289,7 @@ err:
     OSSL_SELF_TEST_onend(ev, ret);
     EVP_MAC_CTX_free(ctx);
     EVP_MAC_free(mac);
+    OPENSSL_cleanse(out, sizeof(out));
     return ret;
 }
 #endif /* OPENSSL_NO_FIPS_POST */


### PR DESCRIPTION
At least this is done on module startup only.

To satisfy ISO/IEC 19790:2012/Cor.1:2015(E) Section 7.5 [05.10] requirement