### PR TITLE
fips: do not perform cryptographic update operations in error state

### DIFF
--- a/providers/implementations/ciphers/ciphercommon.c
+++ b/providers/implementations/ciphers/ciphercommon.c
@@ -254,6 +254,9 @@ int ossl_cipher_generic_block_update(void *vctx, unsigned char *out,
     size_t blksz = ctx->blocksize;
     size_t nextblocks;
 
+    if (!ossl_prov_is_running())
+        return 0;
+
     if (!ctx->key_set) {
         ERR_raise(ERR_LIB_PROV, PROV_R_NO_KEY_SET);
         return 0;

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -76,6 +76,9 @@ static int keccak_update(void *vctx, const unsigned char *inp, size_t len)
     const size_t bsz = ctx->block_size;
     size_t num, rem;
 
+    if (!ossl_prov_is_running())
+        return 0;
+
     if (len == 0)
         return 1;
 

--- a/providers/implementations/macs/hmac_prov.c
+++ b/providers/implementations/macs/hmac_prov.c
@@ -215,6 +215,9 @@ static int hmac_update(void *vmacctx, const unsigned char *data,
 {
     struct hmac_data_st *macctx = vmacctx;
 
+    if (!ossl_prov_is_running())
+        return 0;
+
     if (macctx->tls_data_size > 0) {
         /* We're doing a TLS HMAC */
         if (!macctx->tls_header_set) {

--- a/providers/implementations/signature/ecdsa_sig.c
+++ b/providers/implementations/signature/ecdsa_sig.c
@@ -265,8 +265,7 @@ ecdsa_signverify_init(PROV_ECDSA_CTX *ctx, void *ec,
                       const OSSL_PARAM params[], int operation,
                       const char *desc)
 {
-    if (!ossl_prov_is_running()
-            || ctx == NULL)
+    if (!ossl_prov_is_running() || ctx == NULL)
         return 0;
 
     if (ec == NULL && ctx->ec == NULL) {
@@ -547,7 +546,7 @@ static int ecdsa_digest_signverify_update(void *vctx, const unsigned char *data,
 {
     PROV_ECDSA_CTX *ctx = (PROV_ECDSA_CTX *)vctx;
 
-    if (ctx == NULL || ctx->mdctx == NULL)
+    if (!ossl_prov_is_running() || ctx == NULL || ctx->mdctx == NULL)
         return 0;
     /* Sigalg implementations shouldn't do digest_sign */
     if (ctx->flag_sigalg)

--- a/providers/implementations/signature/rsa_sig.c
+++ b/providers/implementations/signature/rsa_sig.c
@@ -1239,7 +1239,7 @@ static int rsa_digest_sign_update(void *vprsactx, const unsigned char *data,
 {
     PROV_RSA_CTX *prsactx = (PROV_RSA_CTX *)vprsactx;
 
-    if (prsactx == NULL)
+    if (!ossl_prov_is_running() || prsactx == NULL)
         return 0;
     /* Sigalg implementations shouldn't do digest_sign */
     if (prsactx->flag_sigalg)
@@ -1283,7 +1283,7 @@ static int rsa_digest_verify_update(void *vprsactx, const unsigned char *data,
 {
     PROV_RSA_CTX *prsactx = (PROV_RSA_CTX *)vprsactx;
 
-    if (prsactx == NULL)
+    if (!ossl_prov_is_running() || prsactx == NULL)
         return 0;
     /* Sigalg implementations shouldn't do digest_sign */
     if (prsactx->flag_sigalg)


### PR DESCRIPTION
Do not perform cryptographic update operations when fips provider is in error state.

This is to satisfy ISO/IEC 19790:2012/Cor.1:2015(E) Section 7.10.1 "shall not [10.09]" requirement.

Alternative implementations use abort() which is not nice.