### PR TITLE
APPS/pkeyutl doc and error reporting fixups

### DIFF
--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -81,7 +81,7 @@ const OPTIONS pkeyutl_options[] = {
     {"verify", OPT_VERIFY, '-', "Verify with public key"},
     {"encrypt", OPT_ENCRYPT, '-', "Encrypt input data with public key"},
     {"decrypt", OPT_DECRYPT, '-', "Decrypt input data with private key"},
-    {"derive", OPT_DERIVE, '-', "Derive shared secret"},
+    {"derive", OPT_DERIVE, '-', "Derive shared secret from own and peer (EC)DH keys"},
     {"decap", OPT_DECAP, '-', "Decapsulate shared secret"},
     {"encap", OPT_ENCAP, '-', "Encapsulate shared secret"},
     OPT_CONFIG_OPTION,
@@ -310,7 +310,11 @@ int pkeyutl_main(int argc, char **argv)
         goto opthelp;
     } else if (peerkey != NULL && pkey_op != EVP_PKEY_OP_DERIVE) {
         BIO_printf(bio_err,
-                   "%s: no peer key given (-peerkey parameter).\n", prog);
+                   "%s: -peerkey option needlessly given (when not performing -derive).\n", prog);
+        goto opthelp;
+    } else if (peerkey == NULL && pkey_op == EVP_PKEY_OP_DERIVE) {
+        BIO_printf(bio_err,
+                   "%s: missing -peerkey option for -derive operation.\n", prog);
         goto opthelp;
     }
 
@@ -748,9 +752,10 @@ static EVP_PKEY_CTX *init_ctx(const char *kdfalg, int *pkeysize,
 static int setup_peer(EVP_PKEY_CTX *ctx, int peerform, const char *file,
                       ENGINE *e)
 {
+    EVP_PKEY *pkey = EVP_PKEY_CTX_get0_pkey(ctx);
     EVP_PKEY *peer = NULL;
     ENGINE *engine = NULL;
-    int ret;
+    int ret = 1;
 
     if (peerform == FORMAT_ENGINE)
         engine = e;
@@ -759,8 +764,14 @@ static int setup_peer(EVP_PKEY_CTX *ctx, int peerform, const char *file,
         BIO_printf(bio_err, "Error reading peer key %s\n", file);
         return 0;
     }
-
-    ret = EVP_PKEY_derive_set_peer(ctx, peer) > 0;
+    if (strcmp(EVP_PKEY_get0_type_name(peer), EVP_PKEY_get0_type_name(pkey)) != 0) {
+        BIO_printf(bio_err,
+                   "Type of peer public key: %s does not match type of private key: %s\n",
+                   EVP_PKEY_get0_type_name(peer), EVP_PKEY_get0_type_name(pkey));
+        ret = 0;
+    } else {
+        ret = EVP_PKEY_derive_set_peer(ctx, peer) > 0;
+    }
 
     EVP_PKEY_free(peer);
     return ret;

--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -3,7 +3,7 @@
 
 =head1 NAME
 
-openssl-pkeyutl - public key algorithm command
+openssl-pkeyutl - asymmetric key command
 
 =head1 SYNOPSIS
 
@@ -45,8 +45,8 @@ B<openssl> B<pkeyutl>
 
 =head1 DESCRIPTION
 
-This command can be used to perform low-level public key
-operations using any supported algorithm.
+This command can be used to perform low-level operations
+on asymmetric (public or private) keys using any supported algorithm.
 
 By default the signing operation (see B<-sign> option) is assumed.
 
@@ -95,8 +95,7 @@ so the B<-digest> option cannot be used with EdDSA.
 
 =item B<-out> I<filename>
 
-Specifies the output filename to write to or standard output by
-default.
+Specifies the output filename to write to or standard output by default.
 
 =item B<-secret> I<filename>
 
@@ -104,7 +103,7 @@ Specifies the output filename to write the secret to on I<-encap>.
 
 =item B<-sigfile> I<file>
 
-Signature file, required and allowed for B<-verify> operations only
+Signature file, required and allowed for B<-verify> operations only.
 
 =item B<-inkey> I<filename>|I<uri>
 
@@ -249,8 +248,9 @@ hex dump the output data.
 =item B<-asn1parse>
 
 Parse the ASN.1 output data to check its DER encoding and print any errors.
-When combined with the B<-verifyrecover> option, this may be useful only in case
-an ASN.1 DER-encoded structure had been signed directly (without hashing it).
+When combined with the B<-verifyrecover> option, this may be useful in case
+an ASN.1 DER-encoded structure had been signed directly (without hashing it)
+and when checking a signature in PKCS#1 v1.5 format, which has a DER encoding.
 
 {- $OpenSSL::safe::opt_engine_item -}
 
@@ -274,13 +274,14 @@ engine I<id> for crypto operations.
 The operations and options supported vary according to the key algorithm
 and its implementation. The OpenSSL operations and options are indicated below.
 
-Unless otherwise mentioned, all algorithms support the B<digest:>I<alg> option,
+Unless otherwise mentioned, the B<-pkeyopt> option supports
+for all public-key types the I<digest>:I<alg> argument,
 which specifies the digest in use for the signing and verification operations.
 The value I<alg> should represent a digest name as used in the
 EVP_get_digestbyname() function for example B<sha1>. This value is not used to
 hash the input data. It is used (by some algorithms) for sanity-checking the
 lengths of data passed in and for creating the structures that make up the
-signature (e.g. B<DigestInfo> in RSASSA PKCS#1 v1.5 signatures).
+signature (e.g., B<DigestInfo> in RSASSA PKCS#1 v1.5 signatures).
 
 This command does not hash the input data (except where -rawin is used) but
 rather it will use the data directly as input to the signature algorithm.
@@ -406,8 +407,7 @@ no additional options.
 
 These algorithms only support signing and verifying. OpenSSL only implements the
 "pure" variants of these algorithms so raw data can be passed directly to them
-without hashing them first. The option B<-rawin> must be used with these
-algorithms with no B<-digest> specified. Additionally OpenSSL only supports
+without hashing them first. OpenSSL only supports
 "oneshot" operation with these algorithms. This means that the entire file to
 be signed/verified must be read into memory before processing it. Signing or
 Verifying very large files should be avoided. Additionally the size of the file

--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -18,8 +18,6 @@ B<openssl> B<pkeyutl>
 [B<-inkey> I<filename>|I<uri>]
 [B<-keyform> B<DER>|B<PEM>|B<P12>|B<ENGINE>]
 [B<-passin> I<arg>]
-[B<-peerkey> I<file>]
-[B<-peerform> B<DER>|B<PEM>|B<P12>|B<ENGINE>]
 [B<-pubin>]
 [B<-certin>]
 [B<-rev>]
@@ -29,6 +27,8 @@ B<openssl> B<pkeyutl>
 [B<-encrypt>]
 [B<-decrypt>]
 [B<-derive>]
+[B<-peerkey> I<file>]
+[B<-peerform> B<DER>|B<PEM>|B<P12>|B<ENGINE>]
 [B<-encap>]
 [B<-decap>]
 [B<-kdf> I<algorithm>]
@@ -120,15 +120,6 @@ See L<openssl-format-options(1)> for details.
 The input key password source. For more information about the format of I<arg>
 see L<openssl-passphrase-options(1)>.
 
-=item B<-peerkey> I<file>
-
-The peer key file, used by key derivation (agreement) operations.
-
-=item B<-peerform> B<DER>|B<PEM>|B<P12>|B<ENGINE>
-
-The peer key format; unspecified by default.
-See L<openssl-format-options(1)> for details.
-
 =item B<-pubin>
 
 By default a private key is read from the key input.
@@ -189,7 +180,18 @@ Decrypt the input data using a private key.
 
 =item B<-derive>
 
-Derive a shared secret using the peer key.
+Derive a shared secret using own private (EC)DH key and peer key.
+
+=item B<-peerkey> I<file>
+
+File containing the peer public or private (EC)DH key
+to use with the key derivation (agreement) operation.
+Its type must match the type of the own private key given with B<-inkey>.
+
+=item B<-peerform> B<DER>|B<PEM>|B<P12>|B<ENGINE>
+
+The peer key format; unspecified by default.
+See L<openssl-format-options(1)> for details.
 
 =item B<-encap>
 

--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -70,7 +70,7 @@ which is not hashed by any message digest algorithm.
 Except with EdDSA,
 the user can specify a digest algorithm by using the B<-digest> option.
 For signature algorithms like RSA, DSA and ECDSA,
-the default digest algorithm is SHA-256. For SM2, it is SM3.
+the default digest algorithm is SHA256. For SM2, it is SM3.
 
 This option can only be used with B<-sign> and B<-verify>.
 For EdDSA (the Ed25519 and Ed448 algorithms) this option
@@ -275,25 +275,27 @@ The operations and options supported vary according to the key algorithm
 and its implementation. The OpenSSL operations and options are indicated below.
 
 Unless otherwise mentioned, the B<-pkeyopt> option supports
-for all public-key types the I<digest>:I<alg> argument,
+for all public-key types the C<digest:>I<alg> argument,
 which specifies the digest in use for the signing and verification operations.
 The value I<alg> should represent a digest name as used in the
-EVP_get_digestbyname() function for example B<sha1>. This value is not used to
+EVP_get_digestbyname() function for example B<sha256>. This value is not used to
 hash the input data. It is used (by some algorithms) for sanity-checking the
 lengths of data passed in and for creating the structures that make up the
 signature (e.g., B<DigestInfo> in RSASSA PKCS#1 v1.5 signatures).
 
-This command does not hash the input data (except where -rawin is used) but
-rather it will use the data directly as input to the signature algorithm.
+For instance,
+if the value of the B<-pkeyopt> option C<digest> argument is B<sha256>,
+the signature or verification input should be the 32 bytes long binary value
+of the SHA256 hash function output.
+
+Unless B<-rawin> is used or implied, this command does not hash the input data
+but rather it will use the data directly as input to the signature algorithm.
 Depending on the key type, signature type, and mode of padding, the maximum
-acceptable lengths of input data differ. The signed data can't be longer than
-the key modulus with RSA. In case of ECDSA and DSA the data shouldn't be longer
+sensible lengths of input data differ. With RSA the signed data cannot be longer
+than the key modulus. In case of ECDSA and DSA the data should not be longer
 than the field size, otherwise it will be silently truncated to the field size.
 In any event the input size must not be larger than the largest supported digest
-size.
-
-In other words, if the value of digest is B<sha1> the input should be the 20
-bytes long binary encoding of the SHA-1 hash function output.
+output size B<EVP_MAX_MD_SIZE>, which currently is 64 bytes.
 
 =head1 RSA ALGORITHM
 
@@ -345,7 +347,7 @@ explicitly set in PSS mode then the signing digest is used.
 =item B<rsa_oaep_md:>I<digest>
 
 Sets the digest used for the OAEP hash function. If not explicitly set then
-SHA1 is used.
+SHA256 is used.
 
 =item B<rsa_pkcs1_implicit_rejection:>I<flag>
 
@@ -384,7 +386,7 @@ value less than the minimum restriction.
 =head1 DSA ALGORITHM
 
 The DSA algorithm supports signing and verification operations only. Currently
-there are no additional B<-pkeyopt> options other than B<digest>. The SHA1
+there are no additional B<-pkeyopt> options other than B<digest>. The SHA256
 digest is assumed by default.
 
 =head1 DH ALGORITHM
@@ -395,8 +397,8 @@ B<-pkeyopt> options.
 =head1 EC ALGORITHM
 
 The EC algorithm supports sign, verify and derive operations. The sign and
-verify operations use ECDSA and derive uses ECDH. SHA1 is assumed by default for
-the B<-pkeyopt> B<digest> option.
+verify operations use ECDSA and derive uses ECDH. SHA256 is assumed by default
+for the B<-pkeyopt> B<digest> option.
 
 =head1 X25519 AND X448 ALGORITHMS
 


### PR DESCRIPTION
This handles part of the loose ends regarding documentation mentioned in PRs #25831 and #25913 and in  issue #25892.

On this occasion, also add some missing app-level checks,
which so far lead to just low-level lib errors or even assertion failures.
For instance,
```
apps/openssl pkeyutl -derive -inkey test/certs/ec_privkey_with_chain.pem -peerkey test/certs/dhk2048.pem
```
depending on the OpenSSL version leads to
```
crypto/evp/keymgmt_lib.c:149: OpenSSL internal error: Assertion failed: match_type(pk->keymgmt, keymgmt)
Abort trap: 6
```
or
```
Could not read peer key from test/certs/dhk2048.pem
408F940602000000:error:1608010C:STORE routines:ossl_store_handle_load_result:unsupported:crypto/store/store_result.c:151:
Error reading peer key test/certs/dhk2048.pem
```
With the proposed fix, it will output
```
Type of peer public key: DH does not match type of private key: EC
pkeyutl: Error setting up peer key
```