### PR TITLE
s/the are/there are/

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ available online.
 Demos
 -----
 
-The are numerous source code demos for using various OpenSSL capabilities in the
+There are numerous source code demos for using various OpenSSL capabilities in the
 [demos subfolder](./demos).
 
 Wiki


### PR DESCRIPTION
This PR corrects a minor typo in the documentation:  
In the line mentioning "The are numerous source code demos," the word "The" is replaced with "There" for grammatical correctness.  

No other changes were made.  
##### Checklist
- [x] documentation is added or updated
- [ ] tests are added or updated
