### PR TITLE
Fix typo: Change 'the are' to 'there are'  CLA: trivial

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ available online.
 Demos
 -----
 
-The are numerous source code demos for using various OpenSSL capabilities in the
+There are numerous source code demos for using various OpenSSL capabilities in the
 [demos subfolder](./demos).
 
 Wiki


### PR DESCRIPTION
This pull request fixes a typo in the documentation.  
The phrase "the are" has been corrected to "there are".

Since this is a minor change, it qualifies as `CLA: trivial`.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
- [x] documentation is added or updated
- [ ] tests are added or updated
