### PR TITLE
fips: remove redundant RSA encrypt/decrypt KAT

### DIFF
--- a/providers/fips/self_test_data.inc
+++ b/providers/fips/self_test_data.inc
@@ -1267,18 +1267,6 @@ static const ST_KAT_PARAM rsa_priv_key[] = {
     ST_KAT_PARAM_END()
 };
 
-/*-
- * Using OSSL_PKEY_RSA_PAD_MODE_NONE directly in the expansion of the
- * ST_KAT_PARAM_UTF8STRING macro below causes a failure on ancient
- * HP/UX PA-RISC compilers.
- */
-static const char pad_mode_none[] = OSSL_PKEY_RSA_PAD_MODE_NONE;
-
-static const ST_KAT_PARAM rsa_enc_params[] = {
-    ST_KAT_PARAM_UTF8STRING(OSSL_ASYM_CIPHER_PARAM_PAD_MODE, pad_mode_none),
-    ST_KAT_PARAM_END()
-};
-
 static const unsigned char rsa_sig_msg[] = "Hello World!";
 
 static const unsigned char rsa_expected_sig[256] = {
@@ -1717,34 +1705,4 @@ static const ST_KAT_SIGN st_kat_sign_tests[] = {
         ITM(dsa_expected_sig)
     },
 #endif /* OPENSSL_NO_DSA */
-};
-
-static const ST_KAT_ASYM_CIPHER st_kat_asym_cipher_tests[] = {
-    {
-        OSSL_SELF_TEST_DESC_ASYM_RSA_ENC,
-        "RSA",
-        1,
-        rsa_pub_key,
-        rsa_enc_params,
-        ITM(rsa_asym_plaintext_encrypt),
-        ITM(rsa_asym_expected_encrypt),
-    },
-    {
-        OSSL_SELF_TEST_DESC_ASYM_RSA_DEC,
-        "RSA",
-        0,
-        rsa_priv_key,
-        rsa_enc_params,
-        ITM(rsa_asym_expected_encrypt),
-        ITM(rsa_asym_plaintext_encrypt),
-    },
-    {
-        OSSL_SELF_TEST_DESC_ASYM_RSA_DEC,
-        "RSA",
-        0,
-        rsa_crt_key,
-        rsa_enc_params,
-        ITM(rsa_asym_expected_encrypt),
-        ITM(rsa_asym_plaintext_encrypt),
-    },
 };

--- a/providers/fips/self_test_kats.c
+++ b/providers/fips/self_test_kats.c
@@ -561,93 +561,6 @@ err:
 }
 
 /*
- * Test an encrypt or decrypt KAT..
- *
- * FIPS 140-2 IG D.9 states that separate KAT tests are needed for encrypt
- * and decrypt..
- */
-static int self_test_asym_cipher(const ST_KAT_ASYM_CIPHER *t, OSSL_SELF_TEST *st,
-                                 OSSL_LIB_CTX *libctx)
-{
-    int ret = 0;
-    OSSL_PARAM *keyparams = NULL, *initparams = NULL;
-    OSSL_PARAM_BLD *keybld = NULL, *initbld = NULL;
-    EVP_PKEY_CTX *encctx = NULL, *keyctx = NULL;
-    EVP_PKEY *key = NULL;
-    BN_CTX *bnctx = NULL;
-    unsigned char out[256];
-    size_t outlen = sizeof(out);
-
-    OSSL_SELF_TEST_onbegin(st, OSSL_SELF_TEST_TYPE_KAT_ASYM_CIPHER, t->desc);
-
-    bnctx = BN_CTX_new_ex(libctx);
-    if (bnctx == NULL)
-        goto err;
-
-    /* Load a public or private key from data */
-    keybld = OSSL_PARAM_BLD_new();
-    if (keybld == NULL
-        || !add_params(keybld, t->key, bnctx))
-        goto err;
-    keyparams = OSSL_PARAM_BLD_to_param(keybld);
-    keyctx = EVP_PKEY_CTX_new_from_name(libctx, t->algorithm, NULL);
-    if (keyctx == NULL || keyparams == NULL)
-        goto err;
-    if (EVP_PKEY_fromdata_init(keyctx) <= 0
-        || EVP_PKEY_fromdata(keyctx, &key, EVP_PKEY_KEYPAIR, keyparams) <= 0)
-        goto err;
-
-    /* Create a EVP_PKEY_CTX to use for the encrypt or decrypt operation */
-    encctx = EVP_PKEY_CTX_new_from_pkey(libctx, key, NULL);
-    if (encctx == NULL
-        || (t->encrypt && EVP_PKEY_encrypt_init(encctx) <= 0)
-        || (!t->encrypt && EVP_PKEY_decrypt_init(encctx) <= 0))
-        goto err;
-
-    /* Add any additional parameters such as padding */
-    if (t->postinit != NULL) {
-        initbld = OSSL_PARAM_BLD_new();
-        if (initbld == NULL)
-            goto err;
-        if (!add_params(initbld, t->postinit, bnctx))
-            goto err;
-        initparams = OSSL_PARAM_BLD_to_param(initbld);
-        if (initparams == NULL)
-            goto err;
-        if (EVP_PKEY_CTX_set_params(encctx, initparams) <= 0)
-            goto err;
-    }
-
-    if (t->encrypt) {
-        if (EVP_PKEY_encrypt(encctx, out, &outlen,
-                             t->in, t->in_len) <= 0)
-            goto err;
-    } else {
-        if (EVP_PKEY_decrypt(encctx, out, &outlen,
-                             t->in, t->in_len) <= 0)
-            goto err;
-    }
-    /* Check the KAT */
-    OSSL_SELF_TEST_oncorrupt_byte(st, out);
-    if (outlen != t->expected_len
-        || memcmp(out, t->expected, t->expected_len) != 0)
-        goto err;
-
-    ret = 1;
-err:
-    BN_CTX_free(bnctx);
-    EVP_PKEY_free(key);
-    EVP_PKEY_CTX_free(encctx);
-    EVP_PKEY_CTX_free(keyctx);
-    OSSL_PARAM_free(keyparams);
-    OSSL_PARAM_BLD_free(keybld);
-    OSSL_PARAM_free(initparams);
-    OSSL_PARAM_BLD_free(initbld);
-    OSSL_SELF_TEST_onend(st, ret);
-    return ret;
-}
-
-/*
  * Test a data driven list of KAT's for digest algorithms.
  * All tests are run regardless of if they fail or not.
  * Return 0 if any test fails.
@@ -669,17 +582,6 @@ static int self_test_ciphers(OSSL_SELF_TEST *st, OSSL_LIB_CTX *libctx)
 
     for (i = 0; i < (int)OSSL_NELEM(st_kat_cipher_tests); ++i) {
         if (!self_test_cipher(&st_kat_cipher_tests[i], st, libctx))
-            ret = 0;
-    }
-    return ret;
-}
-
-static int self_test_asym_ciphers(OSSL_SELF_TEST *st, OSSL_LIB_CTX *libctx)
-{
-    int i, ret = 1;
-
-    for (i = 0; i < (int)OSSL_NELEM(st_kat_asym_cipher_tests); ++i) {
-        if (!self_test_asym_cipher(&st_kat_asym_cipher_tests[i], st, libctx))
             ret = 0;
     }
     return ret;
@@ -904,8 +806,6 @@ int SELF_TEST_kats(OSSL_SELF_TEST *st, OSSL_LIB_CTX *libctx)
     if (!self_test_drbgs(st, libctx))
         ret = 0;
     if (!self_test_kas(st, libctx))
-        ret = 0;
-    if (!self_test_asym_ciphers(st, libctx))
         ret = 0;
 
     RAND_set0_private(libctx, saved_rand);

--- a/test/recipes/03-test_fipsinstall.t
+++ b/test/recipes/03-test_fipsinstall.t
@@ -63,7 +63,7 @@ my @commandline =
         ( 'x942kdf_key_check',              'x942kdf-key-check' )
     );
 
-plan tests => 37 + (scalar @pedantic_okay) + (scalar @pedantic_fail)
+plan tests => 36 + (scalar @pedantic_okay) + (scalar @pedantic_fail)
               + 4 * (scalar @commandline);
 
 my $infile = bldtop_file('providers', platform->dso('fips'));
@@ -347,16 +347,6 @@ SKIP: {
                 '-corrupt_desc', 'DSA',
                 '-corrupt_type', 'PCT_Signature'])),
        "fipsinstall fails when the signature result is corrupted");
-}
-
-# corrupt an Asymmetric cipher test
-SKIP: {
-    skip "Skipping Asymmetric RSA corruption test because of no rsa in this build", 1
-        if disabled("rsa") || disabled("fips-post");
-    ok(!run(app(['openssl', 'fipsinstall', '-out', 'fips.cnf', '-module', $infile,
-                '-corrupt_desc', 'RSA_Encrypt',
-                '-corrupt_type', 'KAT_AsymmetricCipher'])),
-       "fipsinstall fails when the asymmetric cipher result is corrupted");
 }
 
 # 'local' ensures that this change is only done in this file.


### PR DESCRIPTION
FIPS 140-2 IG D.9 has become FIPS 140-3 D.G (see "Mapping FIPS 140-2
IGs to FIPS 140-3" in the FIPS 140-3 IG).

The requirements w.r.t. RSA KATs have now been relaxed, meaning that
existing full-message RSA signature verification (which is performed
separately) is sufficient to meet KAT requirements for all RSA
usecases (KEM/Encrypt/Decrypt/Sign/Verify).

Dropping this KAT is very useful, because it is large/expensive on
module startup, but also because it enables in the future to block RSA
Encrypt/Decrypt operations with paddings other than OAEP, which are
legacy or deprecated by either current or draft algorithm transition
SP.
