### PR TITLE
sm2_sig_verify(): Do not call BN_CTX_end() without BN_CTX_start()

### DIFF
--- a/crypto/sm2/sm2_sign.c
+++ b/crypto/sm2/sm2_sign.c
@@ -338,17 +338,21 @@ static int sm2_sig_verify(const EC_KEY *key, const ECDSA_SIG *sig,
     OSSL_LIB_CTX *libctx = ossl_ec_key_get_libctx(key);
 
     ctx = BN_CTX_new_ex(libctx);
-    pt = EC_POINT_new(group);
-    if (ctx == NULL || pt == NULL) {
-        ERR_raise(ERR_LIB_SM2, ERR_R_EC_LIB);
+    if (ctx == NULL) {
+        ERR_raise(ERR_LIB_SM2, ERR_R_BN_LIB);
         goto done;
     }
-
     BN_CTX_start(ctx);
     t = BN_CTX_get(ctx);
     x1 = BN_CTX_get(ctx);
     if (x1 == NULL) {
         ERR_raise(ERR_LIB_SM2, ERR_R_BN_LIB);
+        goto done;
+    }
+
+    pt = EC_POINT_new(group);
+    if (pt == NULL) {
+        ERR_raise(ERR_LIB_SM2, ERR_R_EC_LIB);
         goto done;
     }
 


### PR DESCRIPTION
In case of memory allocation failure this could happen.

This was reported to us by kak1

