### PR TITLE
clang/gcc: add clang 18 and gcc 14

### DIFF
--- a/.github/workflows/compiler-zoo.yml
+++ b/.github/workflows/compiler-zoo.yml
@@ -41,6 +41,9 @@ jobs:
             distro: ubuntu-22.04,
             gcc-ppa-name: ubuntu-toolchain-r/test
           }, {
+            cc: gcc-14,
+            distro: ubuntu-24.04,
+          },{
             cc: clang-6.0,
             distro: ubuntu-20.04
           }, {
@@ -77,6 +80,10 @@ jobs:
             llvm-ppa-name: jammy
           }, {
             cc: clang-17,
+            distro: ubuntu-22.04,
+            llvm-ppa-name: jammy
+          }, {
+            cc: clang-18,
             distro: ubuntu-22.04,
             llvm-ppa-name: jammy
           }


### PR DESCRIPTION
new clang18 and gcc 14 was run successfully in the ci here https://github.com/ajayk/openssl/actions/runs/11923783605/job/33232831964
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->


<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

