### PR TITLE
openindiana complains on duplicate symbol OPENSSL_ia32cap_P

### DIFF
--- a/crypto/cpuid.c
+++ b/crypto/cpuid.c
@@ -14,7 +14,7 @@
         defined(__x86_64) || defined(__x86_64__) || \
         defined(_M_AMD64) || defined(_M_X64)
 
-extern unsigned int OPENSSL_ia32cap_P[4];
+unsigned int OPENSSL_ia32cap_P[4];
 
 # if defined(OPENSSL_CPUID_OBJ)
 
@@ -155,8 +155,6 @@ void OPENSSL_cpuid_setup(void)
     OPENSSL_ia32cap_P[0] = (unsigned int)vec | (1 << 10);
     OPENSSL_ia32cap_P[1] = (unsigned int)(vec >> 32);
 }
-# else
-unsigned int OPENSSL_ia32cap_P[4];
 # endif
 #endif
 

--- a/crypto/perlasm/x86gas.pl
+++ b/crypto/perlasm/x86gas.pl
@@ -167,8 +167,8 @@ sub ::file_end
 	}
     }
     if (grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out) {
-	my $tmp=".bss\n";
 	my $tmp=".comm\t${nmdecor}OPENSSL_ia32cap_P,16";
+	push (@out,".bss\n");
 	if ($::elf)	{ push (@out,"$tmp,4\n"); }
 	else		{ push (@out,"$tmp\n"); }
     }

--- a/crypto/perlasm/x86gas.pl
+++ b/crypto/perlasm/x86gas.pl
@@ -166,12 +166,6 @@ sub ::file_end
 	    {	push(@out,"$non_lazy_ptr{$i}:\n.indirect_symbol\t$i\n.long\t0\n");   }
 	}
     }
-    if (grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out) {
-	my $tmp=".comm\t${nmdecor}OPENSSL_ia32cap_P,16";
-	push (@out,".bss\n");
-	if ($::elf)	{ push (@out,"$tmp,4\n"); }
-	else		{ push (@out,"$tmp\n"); }
-    }
     push(@out,$initseg) if ($initseg);
     if ($::elf) {
 	push(@out,"

--- a/crypto/perlasm/x86gas.pl
+++ b/crypto/perlasm/x86gas.pl
@@ -166,6 +166,12 @@ sub ::file_end
 	    {	push(@out,"$non_lazy_ptr{$i}:\n.indirect_symbol\t$i\n.long\t0\n");   }
 	}
     }
+    if (grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out) {
+	my $tmp=".bss\n";
+	my $tmp=".comm\t${nmdecor}OPENSSL_ia32cap_P,16";
+	if ($::elf)	{ push (@out,"$tmp,4\n"); }
+	else		{ push (@out,"$tmp\n"); }
+    }
     push(@out,$initseg) if ($initseg);
     if ($::elf) {
 	push(@out,"

--- a/crypto/perlasm/x86gas.pl
+++ b/crypto/perlasm/x86gas.pl
@@ -166,12 +166,6 @@ sub ::file_end
 	    {	push(@out,"$non_lazy_ptr{$i}:\n.indirect_symbol\t$i\n.long\t0\n");   }
 	}
     }
-    if (grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out) {
-	my $tmp=".comm\t${nmdecor}OPENSSL_ia32cap_P,16";
-	if ($::macosx)	{ push (@out,"$tmp,2\n"); }
-	elsif ($::elf)	{ push (@out,"$tmp,4\n"); }
-	else		{ push (@out,"$tmp\n"); }
-    }
     push(@out,$initseg) if ($initseg);
     if ($::elf) {
 	push(@out,"

--- a/crypto/perlasm/x86masm.pl
+++ b/crypto/perlasm/x86masm.pl
@@ -140,9 +140,7 @@ ___
 
     if (grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out)
     {	my $comm=<<___;
-.bss	SEGMENT 'BSS'
-COMM	${nmdecor}OPENSSL_ia32cap_P:DWORD:4
-.bss	ENDS
+EXTERN	OPENSSL_ia32cap_P:DWORD:4
 ___
 	# comment out OPENSSL_ia32cap_P declarations
 	grep {s/(^EXTERN\s+${nmdecor}OPENSSL_ia32cap_P)/\;$1/} @out;

--- a/crypto/perlasm/x86masm.pl
+++ b/crypto/perlasm/x86masm.pl
@@ -138,6 +138,12 @@ ___
 
     push(@out,"$segment	ENDS\n");
 
+    if (grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out)
+    {	my $comm=<<___;
+EXTERN ${nmdecor}OPENSSL_ia32cap_P)
+___
+	push (@out,$comm);
+    }
     push (@out,$initseg) if ($initseg);
     push (@out,"END\n");
 }

--- a/crypto/perlasm/x86masm.pl
+++ b/crypto/perlasm/x86masm.pl
@@ -140,7 +140,7 @@ ___
 
     if (grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out)
     {	my $comm=<<___;
-EXTERN	OPENSSL_ia32cap_P:DWORD:4
+EXTERN	${nmdecor}OPENSSL_ia32cap_P:DWORD:4
 ___
 	# comment out OPENSSL_ia32cap_P declarations
 	grep {s/(^EXTERN\s+${nmdecor}OPENSSL_ia32cap_P)/\;$1/} @out;

--- a/crypto/perlasm/x86masm.pl
+++ b/crypto/perlasm/x86masm.pl
@@ -140,7 +140,7 @@ ___
 
     if (grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out)
     {	my $comm=<<___;
-EXTERN ${nmdecor}OPENSSL_ia32cap_P)
+EXTERN ${nmdecor}OPENSSL_ia32cap_P
 ___
 	push (@out,$comm);
     }

--- a/crypto/perlasm/x86masm.pl
+++ b/crypto/perlasm/x86masm.pl
@@ -138,16 +138,6 @@ ___
 
     push(@out,"$segment	ENDS\n");
 
-    if (grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out)
-    {	my $comm=<<___;
-.bss	SEGMENT 'BSS'
-COMM	${nmdecor}OPENSSL_ia32cap_P:DWORD:4
-.bss	ENDS
-___
-	# comment out OPENSSL_ia32cap_P declarations
-	grep {s/(^EXTERN\s+${nmdecor}OPENSSL_ia32cap_P)/\;$1/} @out;
-	push (@out,$comm);
-    }
     push (@out,$initseg) if ($initseg);
     push (@out,"END\n");
 }

--- a/crypto/perlasm/x86masm.pl
+++ b/crypto/perlasm/x86masm.pl
@@ -140,7 +140,9 @@ ___
 
     if (grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out)
     {	my $comm=<<___;
-EXTERN	${nmdecor}OPENSSL_ia32cap_P:DWORD:4
+.bss	SEGMENT 'BSS'
+COMM	${nmdecor}OPENSSL_ia32cap_P:DWORD:4
+.bss	ENDS
 ___
 	# comment out OPENSSL_ia32cap_P declarations
 	grep {s/(^EXTERN\s+${nmdecor}OPENSSL_ia32cap_P)/\;$1/} @out;

--- a/crypto/perlasm/x86nasm.pl
+++ b/crypto/perlasm/x86nasm.pl
@@ -125,7 +125,7 @@ sub ::function_end_B
 sub ::file_end
 {   if (grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out)
     {	my $comm=<<___;
-${drdecor}extern	${nmdecor}OPENSSL_ia32cap_P 16
+${drdecor}extern	${nmdecor}OPENSSL_ia32cap_P
 ___
 	push (@out,$comm)
     }

--- a/crypto/perlasm/x86nasm.pl
+++ b/crypto/perlasm/x86nasm.pl
@@ -123,16 +123,7 @@ sub ::function_end_B
 }
 
 sub ::file_end
-{   if (grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out)
-    {	my $comm=<<___;
-${drdecor}segment	.bss
-${drdecor}common	${nmdecor}OPENSSL_ia32cap_P 16
-___
-	# comment out OPENSSL_ia32cap_P declarations
-	grep {s/(^extern\s+${nmdecor}OPENSSL_ia32cap_P)/\;$1/} @out;
-	push (@out,$comm)
-    }
-    push (@out,$initseg) if ($initseg);
+{  push (@out,$initseg) if ($initseg);
 }
 
 sub ::comment {   foreach (@_) { push(@out,"\t; $_\n"); }   }

--- a/crypto/perlasm/x86nasm.pl
+++ b/crypto/perlasm/x86nasm.pl
@@ -125,8 +125,7 @@ sub ::function_end_B
 sub ::file_end
 {   if (grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out)
     {	my $comm=<<___;
-${drdecor}segment	.bss
-${drdecor}common	${nmdecor}OPENSSL_ia32cap_P 16
+extern	OPENSSL_ia32cap_P
 ___
 	# comment out OPENSSL_ia32cap_P declarations
 	grep {s/(^extern\s+${nmdecor}OPENSSL_ia32cap_P)/\;$1/} @out;

--- a/crypto/perlasm/x86nasm.pl
+++ b/crypto/perlasm/x86nasm.pl
@@ -123,7 +123,13 @@ sub ::function_end_B
 }
 
 sub ::file_end
-{  push (@out,$initseg) if ($initseg);
+{   if (grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out)
+    {	my $comm=<<___;
+${drdecor}extern	${nmdecor}OPENSSL_ia32cap_P 16
+___
+	push (@out,$comm)
+    }
+    push (@out,$initseg) if ($initseg);
 }
 
 sub ::comment {   foreach (@_) { push(@out,"\t; $_\n"); }   }

--- a/crypto/perlasm/x86nasm.pl
+++ b/crypto/perlasm/x86nasm.pl
@@ -125,7 +125,7 @@ sub ::function_end_B
 sub ::file_end
 {   if (grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out)
     {	my $comm=<<___;
-extern	OPENSSL_ia32cap_P
+extern	${nmdecor}OPENSSL_ia32cap_P
 ___
 	# comment out OPENSSL_ia32cap_P declarations
 	grep {s/(^extern\s+${nmdecor}OPENSSL_ia32cap_P)/\;$1/} @out;

--- a/crypto/perlasm/x86nasm.pl
+++ b/crypto/perlasm/x86nasm.pl
@@ -125,7 +125,8 @@ sub ::function_end_B
 sub ::file_end
 {   if (grep {/\b${nmdecor}OPENSSL_ia32cap_P\b/i} @out)
     {	my $comm=<<___;
-extern	${nmdecor}OPENSSL_ia32cap_P
+${drdecor}segment	.bss
+${drdecor}common	${nmdecor}OPENSSL_ia32cap_P 16
 ___
 	# comment out OPENSSL_ia32cap_P declarations
 	grep {s/(^extern\s+${nmdecor}OPENSSL_ia32cap_P)/\;$1/} @out;


### PR DESCRIPTION
It's actually 01-test_symbol_presence.t testcase where report on duplicate symbol comes from.

The OPENSSL-ia32cap_P is global symbol which holds features for particular CPU. The variaous perlsasm files declars that symbol as .comm .comm [1]. The description is kind of vague:
```
When linking, a common symbol in one object file may be merged with
a defined or common symbol of the same name in another object file.
```

This PR makes sure the `OPENSSL_ia32cap_P` global variable will be defined in `crypto/cpuid.c`. All other modules will use `extern OPENSSL_ia32cap_P`. The .comm directive is currently emmitted by:
  - `crypto/perlasm/x86gas.pl` (proposed change emits nothing, the `extern` is optional in gnu assembler. it may make also life easier for darwin

  - `crypto/perlasm/x86masm.pl` (proposed change emits EXTERN ...)

  - `crypto/perlasm/x86nasm.pl` (prposed change emits extern ...)

Fixes #23528

[1] https://sourceware.org/binutils/docs/as/Comm.html

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
