### PR TITLE
Fix EVP_PKEY_print_private() so that it works with non default providers

### DIFF
--- a/crypto/encode_decode/encoder_pkey.c
+++ b/crypto/encode_decode/encoder_pkey.c
@@ -189,9 +189,13 @@ encoder_construct_pkey(OSSL_ENCODER_INSTANCE *encoder_inst, void *arg)
         const OSSL_PROVIDER *e_prov = OSSL_ENCODER_get0_provider(encoder);
 
         if (k_prov != e_prov) {
+            int selection = data->selection;
+
+            if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)
+                selection |= OSSL_KEYMGMT_SELECT_PUBLIC_KEY;
             data->encoder_inst = encoder_inst;
 
-            if (!evp_keymgmt_export(pk->keymgmt, pk->keydata, data->selection,
+            if (!evp_keymgmt_export(pk->keymgmt, pk->keydata, selection,
                                     &encoder_import_cb, data))
                 return NULL;
             data->obj = data->constructed_obj;

--- a/test/recipes/04-test_encoder_decoder.t
+++ b/test/recipes/04-test_encoder_decoder.t
@@ -25,9 +25,26 @@ my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 my $rsa_key = srctop_file("test", "certs", "ee-key.pem");
 my $pss_key = srctop_file("test", "certs", "ca-pss-key.pem");
 
-plan tests => ($no_fips ? 0 : 3) + 2;     # FIPS install test + test
+plan tests => ($no_fips ? 0 : 5) + 2;     # FIPS install test + test
 
 my $conf = srctop_file("test", "default.cnf");
+
+# Check if the specified pattern occurs in the given file
+# Returns 1 if the pattern is found and 0 if not
+sub find_line_file {
+    my ($key, $file) = @_;
+
+    open(my $in, $file) or return -1;
+    while (my $line = <$in>) {
+        if ($line =~ /$key/) {
+            close($in);
+            return 1;
+        }
+    }
+    close($in);
+    return 0;
+}
+
 ok(run(test(["endecode_test", "-rsa", $rsa_key,
                               "-pss", $pss_key,
                               "-config", $conf,
@@ -47,7 +64,15 @@ unless ($no_fips) {
                                   "-pss", $pss_key,
                                   "-config", $conf,
                                   "-provider", "fips"])));
-
+SKIP: {
+    skip "EC disabled", 2 if disabled("ec");
+    ok(run(app([ 'openssl', 'genpkey', '-algorithm', 'EC',
+                 '-pkeyopt', 'group:P-256', '-text',
+                 '-config', $conf, '-provider', 'fips', '-out', 'ec.txt' ])),
+       'Print a FIPS provider EC private key');
+    ok(find_line_file('NIST CURVE: P-256', 'ec.txt') == 1,
+       'Printing an FIPS provider EC private key');
+}
     my $no_des = disabled("des");
 SKIP: {
     skip "MD5 disabled", 2 if disabled("md5");


### PR DESCRIPTION
At some point in time it was decided that the EC keymanagers ec_export() function would only allow the selection to be both the public + private parts. If just the private element is selected it returns an error. Many openssl commandline apps use EVP_PKEY_print_private() which passes EVP_PKEY_PRIVATE_KEY to the encoder. This selection propagates to encoder_construct_pkey(). For external providers (such as the fips provider this will call the keymanagers export() with the selection set to just the private part.

So we either need to
1) change the selection in EVP_PKEY_print_private() or
2) modify the selection used in the export used in
   encoder_construct_pkey
3) Change the ec_export to allow this.

I have chosen 2) but I am not sure if this is the correct thing to do or whether it should conditionally do this when the output_type == 'text'.

Issue was reported by Ilia Okomin (Oracle).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
