### PR TITLE
Fix potential memory leak on failure of ecx_gen_init()

### DIFF
--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -510,7 +510,7 @@ static void *ecx_gen_init(void *provctx, int selection,
 #endif
     }
     if (!ecx_gen_set_params(gctx, params)) {
-        OPENSSL_free(gctx);
+        ecx_gen_cleanup(gctx);
         gctx = NULL;
     }
     return gctx;


### PR DESCRIPTION
When ecx_gen_set_params() returns 0, it could have duplicated the memory for the parameter OSSL_KDF_PARAM_PROPERTIES already in gctx->propq, leading to a memory leak.

Allocated here:
https://github.com/openssl/openssl/blob/47a80fd2034cd4314d3b4958539dcd3106087109/providers/implementations/keymgmt/ecx_kmgmt.c#L583-L585

Leaks when returning 0 here:
https://github.com/openssl/openssl/blob/47a80fd2034cd4314d3b4958539dcd3106087109/providers/implementations/keymgmt/ecx_kmgmt.c#L592-L594

Note: this was detected using an experimental static analyser I'm working on. I could be wrong because my results are based on static analysis, even though I manually read the code as well.