### PR TITLE
Fix potential memory leak on failure of dsa_gen_init()

### DIFF
--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -430,7 +430,7 @@ static void *dsa_gen_init(void *provctx, int selection,
         OSSL_FIPS_IND_INIT(gctx)
     }
     if (!dsa_gen_set_params(gctx, params)) {
-        OPENSSL_free(gctx);
+        dsa_gen_cleanup(gctx);
         gctx = NULL;
     }
     return gctx;


### PR DESCRIPTION
When dsa_gen_set_params()  returns 0, it could have duplicated the memory for the parameter OSSL_PKEY_PARAM_FFC_DIGEST already in gctx->mdname, leading to a memory leak.

Allocated here: https://github.com/openssl/openssl/blob/47a80fd2034cd4314d3b4958539dcd3106087109/providers/implementations/keymgmt/dsa_kmgmt.c#L524
Can return 0 here: https://github.com/openssl/openssl/blob/47a80fd2034cd4314d3b4958539dcd3106087109/providers/implementations/keymgmt/dsa_kmgmt.c#L529-L536

Note: this was detected using an experimental static analyser I'm working on. I could be wrong because my results are based on static analysis, even though I manually read the code as well.

Very similar to https://github.com/openssl/openssl/pull/26015