### PR TITLE
Cherry-picked fix for Windows CI build failures on 3.1 branch

### DIFF
--- a/test/build_wincrypt_test.c
+++ b/test/build_wincrypt_test.c
@@ -22,7 +22,11 @@
 # include <wincrypt.h>
 # ifndef X509_NAME
 #  ifndef PEDANTIC
-#   warning "wincrypt.h no longer defining X509_NAME before OpenSSL headers"
+#    ifdef _MSC_VER
+#      pragma message("wincrypt.h no longer defining X509_NAME before OpenSSL headers")
+#    else
+#      warning "wincrypt.h no longer defining X509_NAME before OpenSSL headers"
+#    endif
 #  endif
 # endif
 #endif


### PR DESCRIPTION
Fixes issue https://github.com/openssl/openssl/issues/20805

Reviewed-by: Todd Short <todd.short@me.com>
Reviewed-by: Tomas Mraz <tomas@openssl.org>
(Merged from https://github.com/openssl/openssl/pull/20806)

(cherry picked from commit b5a635dc2113e1bc807ea358a670146c813df989)

This is urgent fix as the CI on 3.1 is broken.