### PR TITLE
Clear leak of (copy of) OPENSSL_MALLOC_FAILURES env var string

### DIFF
--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -170,7 +170,7 @@ void ossl_malloc_setup_failures(void)
     if (cp != NULL) {
         /* if the value is too long we'll just ignore it */
         cplen = strlen(cp);
-        if (cplen <= sizeof(md_failbuf) - 1) {
+        if (cplen <= CRYPTO_MEM_CHECK_MAX_FS) {
             strncpy(md_failbuf, cp, CRYPTO_MEM_CHECK_MAX_FS);
             md_failstring = md_failbuf;
             parseit();

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -38,7 +38,8 @@ static TSAN_QUALIFIER int free_count;
 #  define LOAD(x)      tsan_load(&x)
 # endif /* TSAN_REQUIRES_LOCKING */
 
-static char *md_failstring;
+static char md_failbuf[CRYPTO_MEM_CHECK_MAX_FS+1];
+static char *md_failstring = md_failbuf;
 static long md_count;
 static int md_fail_percent = 0;
 static int md_tracefd = -1;
@@ -164,9 +165,17 @@ static int shouldfail(void)
 void ossl_malloc_setup_failures(void)
 {
     const char *cp = getenv("OPENSSL_MALLOC_FAILURES");
+    size_t cplen = 0;
 
-    if (cp != NULL && (md_failstring = strdup(cp)) != NULL)
-        parseit();
+    if (cp != NULL) {
+        /* if the value is too long we'll just ignore it */
+        cplen = strlen(cp);
+        if (cplen <= CRYPTO_MEM_CHECK_MAX_FS) {
+            strncpy(md_failbuf, cp, CRYPTO_MEM_CHECK_MAX_FS);
+            md_failstring = md_failbuf;
+            parseit();
+        }
+    }
     if ((cp = getenv("OPENSSL_MALLOC_FD")) != NULL)
         md_tracefd = atoi(cp);
     if ((cp = getenv("OPENSSL_MALLOC_SEED")) != NULL)

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -39,7 +39,7 @@ static TSAN_QUALIFIER int free_count;
 # endif /* TSAN_REQUIRES_LOCKING */
 
 static char md_failbuf[CRYPTO_MEM_CHECK_MAX_FS + 1];
-static char *md_failstring = md_failbuf;
+static char *md_failstring = NULL;
 static long md_count;
 static int md_fail_percent = 0;
 static int md_tracefd = -1;
@@ -170,7 +170,7 @@ void ossl_malloc_setup_failures(void)
     if (cp != NULL) {
         /* if the value is too long we'll just ignore it */
         cplen = strlen(cp);
-        if (cplen <= CRYPTO_MEM_CHECK_MAX_FS) {
+        if (cplen <= sizeof(md_failbuf) - 1) {
             strncpy(md_failbuf, cp, CRYPTO_MEM_CHECK_MAX_FS);
             md_failstring = md_failbuf;
             parseit();

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -38,7 +38,7 @@ static TSAN_QUALIFIER int free_count;
 #  define LOAD(x)      tsan_load(&x)
 # endif /* TSAN_REQUIRES_LOCKING */
 
-static char md_failbuf[CRYPTO_MEM_CHECK_MAX_FS+1];
+static char md_failbuf[CRYPTO_MEM_CHECK_MAX_FS + 1];
 static char *md_failstring = md_failbuf;
 static long md_count;
 static int md_fail_percent = 0;

--- a/doc/man3/OPENSSL_malloc.pod
+++ b/doc/man3/OPENSSL_malloc.pod
@@ -171,7 +171,8 @@ It is a set of fields separated by semicolons, which each field is a count
 to 100).  If the count is zero, then it lasts forever.  For example,
 C<100;@25> or C<100@0;0@25> means the first 100 allocations pass, then all
 other allocations (until the program exits or crashes) have a 25% chance of
-failing.
+failing. The length of the value of B<OPENSSL_MALLOC_FAILURES> must be 256 or
+fewer characters.
 
 If the variable B<OPENSSL_MALLOC_FD> is parsed as a positive integer, then
 it is taken as an open file descriptor. This is used in conjunction with

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -367,6 +367,9 @@ void OPENSSL_cleanse(void *ptr, size_t len);
 # define CRYPTO_MEM_CHECK_ENABLE  0x2   /* Control and mode bit */
 # define CRYPTO_MEM_CHECK_DISABLE 0x3   /* Control only */
 
+/* max allowed length for value of OPENSSL_MALLOC_FAILURES env var. */
+# define CRYPTO_MEM_CHECK_MAX_FS  256
+
 void CRYPTO_get_alloc_counts(int *mcount, int *rcount, int *fcount);
 #  ifndef OPENSSL_NO_DEPRECATED_3_0
 #    define OPENSSL_mem_debug_push(info) \

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -368,7 +368,7 @@ void OPENSSL_cleanse(void *ptr, size_t len);
 # define CRYPTO_MEM_CHECK_DISABLE 0x3   /* Control only */
 
 /* max allowed length for value of OPENSSL_MALLOC_FAILURES env var. */
-# define CRYPTO_MEM_CHECK_MAX_FS  256
+#  define CRYPTO_MEM_CHECK_MAX_FS 256
 
 void CRYPTO_get_alloc_counts(int *mcount, int *rcount, int *fcount);
 #  ifndef OPENSSL_NO_DEPRECATED_3_0


### PR DESCRIPTION

I was playing with using the `OPENSSL_MALLOC_FAILURES` environment variable and noticed that the value of that string is leaked if it's set. This PR just provides a way to clear that and adds a call to do so to `s_client.c` which is what I was using for that test. That leak was a bit annoying as it meant all tests had a leak, whereas with this fix, any leaks resulting from memory allocation failures are more interesting, so valgrind output is more useful.

It's likely there's some better way trigger freeing that variable, so this is probably not quite the right thing to merge but if there's a good generic way to free stuff on exit then this might turn into a useful thing.

If (as is more likely) there's a better way to handle this, it's fine to just close this and fix that other way.