### PR TITLE
Fixes issue-25440: openssl genpkey leaves empty file if encryption passphrase does not match

### DIFF
--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -240,11 +240,13 @@ int genpkey_main(int argc, char **argv)
     mem_out = BIO_new(BIO_s_mem());
     if (mem_out == NULL)
         goto end;
+    BIO_set_mem_eof_return(mem_out, 0);
 
     if (outpubkeyfile != NULL) {
         mem_outpubkey = BIO_new(BIO_s_mem());
         if (mem_outpubkey == NULL)
             goto end;
+        BIO_set_mem_eof_return(mem_outpubkey, 0);
     }
 
     if (verbose)
@@ -300,12 +302,12 @@ int genpkey_main(int argc, char **argv)
         if (mem_outpubkey != NULL) {
             rv = mem_bio_to_file(mem_outpubkey, outpubkeyfile, outformat, private);
             if (!rv)
-                BIO_puts(bio_err, "Error writing to outpubkey\n");
+                BIO_printf(bio_err, "Error writing to outpubkey: '%s'. Error: %s\n", outpubkeyfile, strerror(errno));
         }
         if (mem_out != NULL) {
             rv = mem_bio_to_file(mem_out, outfile, outformat, private);
             if (!rv)
-                BIO_puts(bio_err, "Error writing to outfile\n");
+                BIO_printf(bio_err, "Error writing to outfile: '%s'. Error: %s\n", outpubkeyfile, strerror(errno));
         }
     }
     EVP_PKEY_free(pkey);

--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -2226,6 +2226,7 @@ static int txp_generate_stream_frames(OSSL_QUIC_TX_PACKETISER *txp,
             rc = 1;
             goto err;
         }
+        chunks[i].shdr.stream_id = id;
     }
 
     for (i = 0;; ++i) {
@@ -2339,7 +2340,6 @@ static int txp_generate_stream_frames(OSSL_QUIC_TX_PACKETISER *txp,
         if (wpkt == NULL)
             goto err; /* alloc error */
 
-        shdr->stream_id = id;
         if (!ossl_assert(ossl_quic_wire_encode_frame_stream_hdr(wpkt, shdr))) {
             /* (Should not be possible.) */
             tx_helper_rollback(h);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

