### PR TITLE
remove redundant check ascii_salt length.

### DIFF
--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -369,6 +369,8 @@ static char *md5crypt(const char *passwd, const char *magic, const char *salt)
     if (magic_len > 0)
         salt_out += 2 + magic_len;
 
+    assert(salt_len == 8);
+
     md = EVP_MD_CTX_new();
     if (md == NULL
         || !EVP_DigestInit_ex(md, EVP_md5(), NULL)

--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -369,9 +369,6 @@ static char *md5crypt(const char *passwd, const char *magic, const char *salt)
     if (magic_len > 0)
         salt_out += 2 + magic_len;
 
-    if (salt_len > 8)
-        goto err;
-
     md = EVP_MD_CTX_new();
     if (md == NULL
         || !EVP_DigestInit_ex(md, EVP_md5(), NULL)

--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -369,7 +369,7 @@ static char *md5crypt(const char *passwd, const char *magic, const char *salt)
     if (magic_len > 0)
         salt_out += 2 + magic_len;
 
-    assert(salt_len == 8);
+    assert(salt_len <= 8);
 
     md = EVP_MD_CTX_new();
     if (md == NULL


### PR DESCRIPTION
Looks like this check is redundant 'cause `salt_len` is the length of `ascii_salt` that has fixed size of 8 chars plus '/0', thus `salt_len` must always be equal to 8.

Found by Linux Verification Center (linuxtesting.org) with SVACE.