### PR TITLE
dh_cms_set_peerkey() -- allow only absent parameters

### DIFF
--- a/crypto/cms/cms_dh.c
+++ b/crypto/cms/cms_dh.c
@@ -35,7 +35,7 @@ static int dh_cms_set_peerkey(EVP_PKEY_CTX *pctx,
     if (OBJ_obj2nid(aoid) != NID_dhpublicnumber)
         goto err;
     /* Only absent parameters allowed in RFC XXXX */
-    if (atype != V_ASN1_UNDEF && atype == V_ASN1_NULL)
+    if (atype != V_ASN1_UNDEF && atype != V_ASN1_NULL)
         goto err;
 
     pk = EVP_PKEY_CTX_get0_pkey(pctx);


### PR DESCRIPTION
dh_cms_set_peerkey() -- Fix the incorrect condition -- Only absent parameters allowed in RFC XXXX

Fixes #25824

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
