### PR TITLE
fips: in RSA KEM always call rsa key check with protect 1

### DIFF
--- a/providers/implementations/kem/rsa_kem.c
+++ b/providers/implementations/kem/rsa_kem.c
@@ -131,7 +131,6 @@ static int rsakem_init(void *vprsactx, void *vrsa,
                        const char *desc)
 {
     PROV_RSA_CTX *prsactx = (PROV_RSA_CTX *)vprsactx;
-    int protect = 0;
 
     if (!ossl_prov_is_running())
         return 0;
@@ -139,8 +138,6 @@ static int rsakem_init(void *vprsactx, void *vrsa,
     if (prsactx == NULL || vrsa == NULL)
         return 0;
 
-    if (!ossl_rsa_key_op_get_protect(vrsa, operation, &protect))
-        return 0;
     if (!RSA_up_ref(vrsa))
         return 0;
     RSA_free(prsactx->rsa);
@@ -152,7 +149,7 @@ static int rsakem_init(void *vprsactx, void *vrsa,
 #ifdef FIPS_MODULE
     if (!ossl_fips_ind_rsa_key_check(OSSL_FIPS_IND_GET(prsactx),
                                      OSSL_FIPS_IND_SETTABLE0, prsactx->libctx,
-                                     prsactx->rsa, desc, protect))
+                                     prsactx->rsa, desc, 1))
         return 0;
 #endif
     return 1;


### PR DESCRIPTION
This function conforms to [SP800-56Br2](https://doi.org/10.6028/NIST.SP.800-56Br2) Section 7.2.1.2 RSASVE Generate Operation (RSASVE.GENERATE). Section 7.2.1.3 RSASVE Recovery Operation (RSASVE.RECOVER).

The [SP800-131Ar2](https://doi.org/10.6028/NIST.SP.800-131Ar2) Section 6 Key Agreement and Key Transport Using RSA specifies key transition. For both encapsulation and decapsulation sizes less than 2048 bits are disallowed. Thus always call ossl_fips_ind_rsa_key_check with protect set to 1.
