### PR TITLE
die() in .tmpl file should not be silently ignored.

### DIFF
--- a/configdata.pm.in
+++ b/configdata.pm.in
@@ -145,7 +145,7 @@ _____
                        # defined in one template stick around for the
                        # next, making them combinable
                        PACKAGE => 'OpenSSL::safe')
-            or die $Text::Template::ERROR;
+            or die $OpenSSL::Template::ERROR;
         close BUILDFILE;
         rename("$buildfile.new", $buildfile)
             or die "Trying to rename $buildfile.new to $buildfile: $!";
@@ -167,7 +167,7 @@ _____
                        # defined in one template stick around for the
                        # next, making them combinable
                        PACKAGE => 'OpenSSL::safe')
-            or die $Text::Template::ERROR;
+            or die $OpenSSL::Template::ERROR;
         close CONFIGURATION_H;
 
         # When using stat() on Windows, we can get it to perform better by

--- a/util/perl/OpenSSL/Template.pm
+++ b/util/perl/OpenSSL/Template.pm
@@ -42,6 +42,14 @@ use Text::Template 1.46;
 
 our @ISA = qw(Text::Template);  # parent
 
+sub tmpl_error {
+    my (%err_dict) = @_;
+
+    $ERROR = $err_dict{"error"};
+  
+    return undef;
+}
+
 sub new {
     my $class = shift;
 
@@ -66,6 +74,7 @@ sub fill_in {
                                     output_on => sub { $self->output_on() },
                                     output_off => sub { $self->output_off() },
                                     %hash },
+                          BROKEN => \&tmpl_error,
                           %opts);
 }
 


### PR DESCRIPTION
call to die() in perl templates is currently ignored. any error printed by die() commad appears in template output.

In order to make sure die() terminates processing we must ensure we emite `undef` value. This is ensured by adding a `BROKEN` callback to `fill_in()` Template method. The callback must return undef to stop processing.

