### PR TITLE
Add the ablity to set a local address for BIO_dgram_pair

### DIFF
--- a/doc/man3/BIO_s_dgram_pair.pod
+++ b/doc/man3/BIO_s_dgram_pair.pod
@@ -4,7 +4,8 @@
 
 BIO_s_dgram_pair, BIO_new_bio_dgram_pair, BIO_dgram_set_no_trunc,
 BIO_dgram_get_no_trunc, BIO_dgram_get_effective_caps, BIO_dgram_get_caps,
-BIO_dgram_set_caps, BIO_dgram_set_mtu, BIO_dgram_get_mtu - datagram pair BIO
+BIO_dgram_set_caps, BIO_dgram_set_mtu, BIO_dgram_get_mtu,
+BIO_dgram_set0_local_addr - datagram pair BIO
 
 =head1 SYNOPSIS
 
@@ -21,6 +22,7 @@ BIO_dgram_set_caps, BIO_dgram_set_mtu, BIO_dgram_get_mtu - datagram pair BIO
  int BIO_dgram_set_caps(BIO *bio, uint32_t caps);
  int BIO_dgram_set_mtu(BIO *bio, unsigned int mtu);
  unsigned int BIO_dgram_get_mtu(BIO *bio);
+ int BIO_dgram_set0_local_addr(BIO *bio, BIO_ADDR *addr);
 
 =head1 DESCRIPTION
 
@@ -101,6 +103,14 @@ halves of the pair. The value does not affect the operation of the BIO datagram
 pair (except for BIO_get_write_guarantee(); see above) but may be used by other
 code to determine a requested MTU. When a BIO datagram pair BIO is created, the
 MTU is set to an unspecified but valid value.
+
+BIO_dgram_set0_local_addr() can be used to set the local BIO_ADDR to be used
+when sending a datagram via a BIO datagram pair. This becomes the peer address
+when receiving on the other half of the pair. If the BIO is used in a call to
+L<BIO_sendmmsg(3)> and a local address is explicitly specified, then the
+explicitly specified local address takes precedence. The reference to the
+BIO_ADDR is passed to the BIO by this call and will be freed automatically when
+the BIO is freed.
 
 L<BIO_flush(3)> is a no-op.
 
@@ -205,6 +215,8 @@ capabilities are supported.
 
 BIO_dgram_get_mtu() returns the MTU value configured on the BIO, or zero if the
 operation is not supported.
+
+BIO_dgram_set0_local_addr() returns 1 on success and <= 0 otherwise.
 
 =head1 SEE ALSO
 

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -194,6 +194,7 @@ extern "C" {
 # define BIO_CTRL_GET_RPOLL_DESCRIPTOR          91
 # define BIO_CTRL_GET_WPOLL_DESCRIPTOR          92
 # define BIO_CTRL_DGRAM_DETECT_PEER_ADDR        93
+# define BIO_CTRL_DGRAM_SET0_LOCAL_ADDR         94
 
 # define BIO_DGRAM_CAP_NONE                 0U
 # define BIO_DGRAM_CAP_HANDLES_SRC_ADDR     (1U << 0)
@@ -670,6 +671,8 @@ int BIO_ctrl_reset_read_request(BIO *b);
          (unsigned int)BIO_ctrl((b), BIO_CTRL_DGRAM_GET_MTU, 0, NULL)
 # define BIO_dgram_set_mtu(b, mtu) \
          (int)BIO_ctrl((b), BIO_CTRL_DGRAM_SET_MTU, (mtu), NULL)
+# define BIO_dgram_set0_local_addr(b, addr) \
+         (int)BIO_ctrl((b), BIO_CTRL_DGRAM_SET0_LOCAL_ADDR, 0, (addr))
 
 /* ctrl macros for BIO_f_prefix */
 # define BIO_set_prefix(b,p) BIO_ctrl((b), BIO_CTRL_SET_PREFIX, 0, (void *)(p))

--- a/util/other.syms
+++ b/util/other.syms
@@ -175,6 +175,7 @@ BIO_ctrl_set_connected                  define
 BIO_dgram_get_mtu_overhead              define
 BIO_dgram_get_peer                      define
 BIO_dgram_set_peer                      define
+BIO_dgram_set0_local_addr               define
 BIO_dgram_recv_timedout                 define
 BIO_dgram_send_timedout                 define
 BIO_dgram_detect_peer_addr              define


### PR DESCRIPTION
BIOs created from a BIO_dgram_pair don't normally have a local BIO_ADDR
associated with them. This allows us to set one.

Fixes https://github.com/openssl/project/issues/933
