### PR TITLE
Fix solaris build in CRYPTO_atomic_store api

### DIFF
--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -994,7 +994,7 @@ int CRYPTO_atomic_store(uint64_t *dst, uint64_t val, CRYPTO_RWLOCK *lock)
     }
 # elif defined(__sun) && (defined(__SunOS_5_10) || defined(__SunOS_5_11))
     /* This will work for all future Solaris versions. */
-    if (ret != NULL) {
+    if (dst != NULL) {
         atomic_swap_64(dst, val);
         return 1;
     }


### PR DESCRIPTION
Misnamed variable, just correct it to dst
