### PR TITLE
Avoid NULL dereference with PKCS7_OP_SET_DETACHED_SIGNATURE

### DIFF
--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -28,6 +28,11 @@ long PKCS7_ctrl(PKCS7 *p7, int cmd, long larg, char *parg)
     /* NOTE(emilia): does not support detached digested data. */
     case PKCS7_OP_SET_DETACHED_SIGNATURE:
         if (nid == NID_pkcs7_signed) {
+            if (p7->d.sign == NULL) {
+                ERR_raise(ERR_LIB_PKCS7, PKCS7_R_NO_CONTENT);
+                ret = 0;
+                break;
+            }
             ret = p7->detached = (int)larg;
             if (ret && PKCS7_type_is_data(p7->d.sign->contents)) {
                 ASN1_OCTET_STRING *os;


### PR DESCRIPTION
We would dereference p7->d.sign pointer which can be NULL.

Reported by Han Zheng.

This is not a security issue as this CTRL is called by the application creating a PKCS7 content.
