### PR TITLE
fips-label.yml: Fix ABI change label removal

### DIFF
--- a/.github/workflows/fips-label.yml
+++ b/.github/workflows/fips-label.yml
@@ -134,7 +134,7 @@ jobs:
                     issue_number: pr_num,
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    name: 'severity: fips change'
+                    name: 'severity: ABI change'
                   });
                 }
               }


### PR DESCRIPTION
We need to remove the ABI change label instead of the fips change label if there are no ABI changes.