### PR TITLE
evp_test (ML_KEM): IKME instead of entropy name, bug fixes & a small refactor

### DIFF
--- a/providers/implementations/kem/ml_kem.c
+++ b/providers/implementations/kem/ml_kem.c
@@ -126,8 +126,8 @@ static int mlkem_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     if (params == NULL)
         return 1;
 
-    if ((p = OSSL_PARAM_locate_const(params, OSSL_KEM_PARAM_MLKEM_ENC_ENTROPY)) != NULL
-        && (p->data_size != MLKEM_ENCAP_ENTROPY
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_KEM_PARAM_IKME)) != NULL
+        && (p->data_size < MLKEM_ENCAP_ENTROPY
             || (ctx->entropy = OPENSSL_memdup(p->data, MLKEM_ENCAP_ENTROPY)) == NULL))
         return 0;
 
@@ -136,7 +136,7 @@ static int mlkem_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 }
 
 static const OSSL_PARAM known_settable_mlkem_ctx_params[] = {
-    OSSL_PARAM_octet_string(OSSL_KEM_PARAM_MLKEM_ENC_ENTROPY, NULL, 0),
+    OSSL_PARAM_octet_string(OSSL_KEM_PARAM_IKME, NULL, 0),
     OSSL_PARAM_END
 };
 

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -2210,33 +2210,25 @@ static int encapsulate(EVP_TEST *t, EVP_PKEY_CTX *ctx, const char *op,
                        unsigned char **outwrapped, size_t *outwrappedlen,
                        unsigned char **outsecret, size_t *outsecretlen)
 {
-    int ret = 1;
+    int ret = 0;
     KEM_DATA *kdata = t->data;
     unsigned char *wrapped = NULL, *secret = NULL;
     size_t wrappedlen = 0, secretlen = 0;
-    OSSL_PARAM *params = NULL;
-    OSSL_PARAM_BLD *bld = NULL;
-    size_t params_n = 0, params_n_allocated = 0;
+    OSSL_PARAM params[10] = { OSSL_PARAM_END };
+    size_t params_n = 0;
 
-    if (sk_OPENSSL_STRING_num(kdata->init_ctrls) > 0) {
-        if (!TEST_ptr(params = OPENSSL_malloc(sizeof(OSSL_PARAM) * 2)))
+    if (sk_OPENSSL_STRING_num(kdata->init_ctrls) > 0)
+        if (ctrl2params(t, kdata->init_ctrls, NULL, params,
+                        OSSL_NELEM(params) - 1, &params_n))
             goto err;
-        params[0] = OSSL_PARAM_construct_end();
-        params[1] = OSSL_PARAM_construct_end();
-        if (ctrl2params(t, kdata->init_ctrls, NULL, params, 2, &params_n))
-            goto err;
-    }
 
-    if (kdata->entropy != NULL
-        && (!TEST_ptr(bld = OSSL_PARAM_BLD_new())
-            || !TEST_int_eq(OSSL_PARAM_BLD_push_octet_string(bld,
-                                                             OSSL_KEM_PARAM_MLKEM_ENC_ENTROPY,
-                                                             kdata->entropy,
-                                                             kdata->entropylen),
-                            1)
-            || !TEST_ptr(params = OSSL_PARAM_BLD_to_param(bld)))) {
-        ret = 0;
-        goto err;
+    if (kdata->entropy != NULL) {
+        /* Input key material a.k.a entropy */
+        params[params_n] =
+            OSSL_PARAM_construct_octet_string(OSSL_KEM_PARAM_IKME,
+                                              kdata->entropy,
+                                              kdata->entropylen);
+        params[params_n + 1] = OSSL_PARAM_construct_end();
     }
 
     if (EVP_PKEY_encapsulate_init(ctx, params) <= 0) {
@@ -2291,9 +2283,7 @@ err:
     OPENSSL_free(secret);
 end:
     if (sk_OPENSSL_STRING_num(kdata->init_ctrls) > 0)
-        ctrl2params_free(params, params_n, params_n_allocated);
-    OSSL_PARAM_free(params);
-    OSSL_PARAM_BLD_free(bld);
+        ctrl2params_free(params, params_n, 0);
     return ret;
 }
 
@@ -2301,7 +2291,7 @@ static int decapsulate(EVP_TEST *t, EVP_PKEY_CTX *ctx, const char *op,
                        const unsigned char *in, size_t inlen,
                        const unsigned char *expected, size_t expectedlen)
 {
-    int ret = 1;
+    int ret = 0;
     KEM_DATA *kdata = t->data;
     size_t outlen = 0;
     unsigned char *out = NULL;

--- a/util/perl/OpenSSL/paramnames.pm
+++ b/util/perl/OpenSSL/paramnames.pm
@@ -415,7 +415,6 @@ my %params = (
 
 # MLKEM parameters
     'PKEY_PARAM_MLKEM_SEED' => "seed",
-    'KEM_PARAM_MLKEM_ENC_ENTROPY' => "entropy",
 
 # Key generation parameters
     'PKEY_PARAM_FFC_TYPE' =>         "type",


### PR DESCRIPTION
Use the existing IKME param instead of a new one for the key generation input.
Avoid using param builder.
Fix some mistakes in the return code.

- [ ] documentation is added or updated
- [x] tests are added or updated
