### PR TITLE
04-test_encoder_decoder.t: Add } omitted in a backport

### DIFF
--- a/test/recipes/04-test_encoder_decoder.t
+++ b/test/recipes/04-test_encoder_decoder.t
@@ -73,4 +73,4 @@ SKIP: {
     ok(find_line_file('NIST CURVE: P-256', 'ec.txt') == 1,
        'Printing an FIPS provider EC private key');
 }
-
+}


### PR DESCRIPTION
This adds missing } that I've mistakenly omitted in a backport to 3.1 and 3.0.

This is urgent as it fixes broken CI on these branches.