### PR TITLE
Run interop tests on feature/quic-server branch

### DIFF
--- a/.github/workflows/build_quic_interop_container_server.yml
+++ b/.github/workflows/build_quic_interop_container_server.yml
@@ -1,0 +1,26 @@
+name: "Build openssl interop container from quic-server"
+
+on:
+  schedule:
+    - cron:  '40 02 * * *'
+  workflow_dispatch:
+
+jobs:
+  update_quay_container:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+         fetch-depth: 0
+         ref: feature/quic-server
+      - name: "log in to quay.io"
+        run: |
+          docker login -u openssl-ci+machine -p ${{ secrets.QUAY_IO_PASSWORD }} quay.io
+      - name: "Build container"
+        run: |
+          cd test/quic-openssl-docker/
+          docker build -t quay.io/openssl-ci/openssl-quic-interop-server:latest --build-arg OPENSSL_URL=https://github.com/openssl/openssl --build-arg OPENSSL_BRANCH=feature/quic-server .
+      - name: "Push to quay"
+        run: |
+          docker push quay.io/openssl-ci/openssl-quic-interop-server:latest
+

--- a/.github/workflows/run_quic_interop_server.yml
+++ b/.github/workflows/run_quic_interop_server.yml
@@ -1,0 +1,41 @@
+name: "Run openssl quic interop testing"
+
+on:
+  workflow_run:
+    workflows: ["Build openssl interop container from quic-server"]
+    types: [completed]
+  workflow_dispatch:
+
+jobs:
+  run_quic_interop:
+    strategy:
+      matrix:
+        tests: [http3, transfer, handshake, retry, chacha20, resumption]
+        servers: [quic-go, ngtcp2, mvfst, quiche, nginx, msquic, haproxy]
+      fail-fast: false
+    runs-on: ubuntu-latest 
+    steps:
+      - uses: actions/checkout@v4
+        with:
+         repository: 'quic-interop/quic-interop-runner'
+         fetch-depth: 0
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          sudo add-apt-repository ppa:wireshark-dev/stable
+          sudo apt-get update
+          sudo apt-get install -y tshark
+      - name: Patch implementations file
+        run: |
+          jq '.openssl = { image: "quay.io/openssl-ci/openssl-quic-interop-server"
+                         , url: "https://github.com/openssl/openssl"
+                         , role: "both"
+                         }' ./implementations.json > ./implementations.tmp
+          mv ./implementations.tmp implementations.json
+      - name: "run interop with openssl client"
+        run: |
+          python3 ./run.py -c openssl -t ${{ matrix.tests }} -s ${{ matrix.servers }} --log-dir ./logs-client -d
+      - name: "run interop with openssl server"
+        run: |
+          python3 ./run.py -s openssl -t ${{ matrix.tests }} -c ${{ matrix.servers }} --log-dir ./logs-server -d
+


### PR DESCRIPTION
We currently run interop tests as a client only from the master branch. While we are developing quic-server it would be beneficial to also get interop test results from the quic-server branch run as both a client and a server, until such time as the feature branch is merged.  Add building and running of a container in the test harness to our CI set

