### PR TITLE
Implement disabling of server address validation for quic

### DIFF
--- a/demos/guide/quic-hq-interop-server.c
+++ b/demos/guide/quic-hq-interop-server.c
@@ -33,6 +33,7 @@
  *   Defaults to "./downloads" if not set.
  * - SSLKEYLOGFILE: specifies that keylogging should be preformed on the server
  *   should be set to a file name to record keylog data to
+ * - NO_ADDR_VALIDATE: Disables server address validation of clients
  *
  */
 
@@ -491,13 +492,21 @@ static int run_quic_server(SSL_CTX *ctx, BIO *sock)
     int ok = 0;
     SSL *listener, *conn, *stream;
     unsigned long errcode;
+    uint64_t flags = 0;
+
+    /*
+     * If NO_ADDR_VALIDATE exists in our environment
+     * then disable address validation on our listener
+     */
+    if (getenv("NO_ADDR_VALIDATE") != NULL)
+        flags |= SSL_LISTENER_FLAG_NO_VALIDATE;
 
     /*
      * Create a new QUIC listener. Listeners, and other QUIC objects, default
      * to operating in blocking mode. The configured behaviour is inherited by
      * child objects.
      */
-    if ((listener = SSL_new_listener(ctx, 0)) == NULL)
+    if ((listener = SSL_new_listener(ctx, flags)) == NULL)
         goto err;
 
     /* Provide the listener with our UDP socket. */

--- a/doc/man3/SSL_new_listener.pod
+++ b/doc/man3/SSL_new_listener.pod
@@ -163,6 +163,10 @@ Calling SSL_accept_connection() is an error and will return NULL. One or more
 outgoing connections under a listener can then be created using the call
 SSL_new_from_listener().
 
+To disable client address validation on a listener SSL object, the flag
+B<SSL_LISTENER_FLAG_NO_VALIDATE> may be passed in the flags field of both
+SSL_new_listener() and SSL_new_listener_from(). 
+
 The SSL_new_from_listener() creates a client connection under a given listener
 SSL object. For QUIC, it is also possible to use SSL_new_from_listener() in
 conjunction with a listener which does accept incoming connections (i.e., which

--- a/doc/man3/SSL_new_listener.pod
+++ b/doc/man3/SSL_new_listener.pod
@@ -168,11 +168,11 @@ B<SSL_LISTENER_FLAG_NO_VALIDATE> may be passed in the flags field of both
 SSL_new_listener() and SSL_new_listener_from().  Note that this flag only
 impacts the sending of retry frames for server address validation.  Tokens may
 still be communicated from the server via NEW_TOKEN frames, which will still
-be validated on receipt in furute connections.  Note that this setting is not
-recommended and may be dangerous in untrusted environments.  Not preforming
+be validated on receipt in future connections.  Note that this setting is not
+recommended and may be dangerous in untrusted environments.  Not performing 
 address validation exposes the server to malicious clients that may open large
 numbers of connections and never transact data on them (roughly equivalent to
-a TCP syn flood attack), whcih address validation mitigates.
+a TCP syn flood attack), which address validation mitigates.
 
 The SSL_new_from_listener() creates a client connection under a given listener
 SSL object. For QUIC, it is also possible to use SSL_new_from_listener() in
@@ -206,7 +206,7 @@ SSL_listen() returns 1 on success or 0 on failure.
 SSL_accept_connection() returns a pointer to a new SSL object on success or NULL
 on failure. On success, the caller assumes ownership of the reference.
 
-SSL_get_accept_connection_queue_len() returns a nonnegative value, or 0 if
+SSL_get_accept_connection_queue_len() returns a non-negative value, or 0 if
 called on an unsupported SSL object type.
 
 SSL_new_from_listener() returns a pointer to a new SSL object on success or NULL

--- a/doc/man3/SSL_new_listener.pod
+++ b/doc/man3/SSL_new_listener.pod
@@ -206,7 +206,7 @@ SSL_listen() returns 1 on success or 0 on failure.
 SSL_accept_connection() returns a pointer to a new SSL object on success or NULL
 on failure. On success, the caller assumes ownership of the reference.
 
-SSL_get_accept_connection_queue_len() returns a non-negative value, or 0 if
+SSL_get_accept_connection_queue_len() returns a nonnegative value, or 0 if
 called on an unsupported SSL object type.
 
 SSL_new_from_listener() returns a pointer to a new SSL object on success or NULL

--- a/doc/man3/SSL_new_listener.pod
+++ b/doc/man3/SSL_new_listener.pod
@@ -168,7 +168,11 @@ B<SSL_LISTENER_FLAG_NO_VALIDATE> may be passed in the flags field of both
 SSL_new_listener() and SSL_new_listener_from().  Note that this flag only
 impacts the sending of retry frames for server address validation.  Tokens may
 still be communicated from the server via NEW_TOKEN frames, which will still
-be validated on receipt in future connections.
+be validated on receipt in furute connections.  Note that this setting is not
+recommended and may be dangerous in untrusted environments.  Not preforming
+address validation exposes the server to malicious clients that may open large
+numbers of connections and never transact data on them (roughly equivalent to
+a TCP syn flood attack), whcih address validation mitigates.
 
 The SSL_new_from_listener() creates a client connection under a given listener
 SSL object. For QUIC, it is also possible to use SSL_new_from_listener() in

--- a/doc/man3/SSL_new_listener.pod
+++ b/doc/man3/SSL_new_listener.pod
@@ -168,7 +168,7 @@ B<SSL_LISTENER_FLAG_NO_VALIDATE> may be passed in the flags field of both
 SSL_new_listener() and SSL_new_listener_from().  Note that this flag only
 impacts the sending of retry frames for server address validation.  Tokens may
 still be communicated from the server via NEW_TOKEN frames, which will still
-be validated on receipt in furute connections.
+be validated on receipt in future connections.
 
 The SSL_new_from_listener() creates a client connection under a given listener
 SSL object. For QUIC, it is also possible to use SSL_new_from_listener() in

--- a/doc/man3/SSL_new_listener.pod
+++ b/doc/man3/SSL_new_listener.pod
@@ -165,7 +165,10 @@ SSL_new_from_listener().
 
 To disable client address validation on a listener SSL object, the flag
 B<SSL_LISTENER_FLAG_NO_VALIDATE> may be passed in the flags field of both
-SSL_new_listener() and SSL_new_listener_from(). 
+SSL_new_listener() and SSL_new_listener_from().  Note that this flag only
+impacts the sending of retry frames for server address validation.  Tokens may
+still be communicated from the server via NEW_TOKEN frames, which will still
+be validated on receipt in furute connections.
 
 The SSL_new_from_listener() creates a client connection under a given listener
 SSL object. For QUIC, it is also possible to use SSL_new_from_listener() in

--- a/include/internal/quic_port.h
+++ b/include/internal/quic_port.h
@@ -54,6 +54,11 @@ typedef struct quic_port_args_st {
      * for a single connection, so a zero-length local CID can be used.
      */
     int             is_multi_conn;
+
+    /*
+     * if 1, this port should do server address validation
+     */
+    int             do_addr_validation;
 } QUIC_PORT_ARGS;
 
 /* Only QUIC_ENGINE should use this function. */

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2295,6 +2295,7 @@ __owur int SSL_is_connection(SSL *s);
 __owur int SSL_is_listener(SSL *ssl);
 __owur SSL *SSL_get0_listener(SSL *s);
 #define SSL_LISTENER_FLAG_NO_ACCEPT     (1UL << 0)
+#define SSL_LISTENER_FLAG_NO_VALIDATE   (1UL << 1)
 __owur SSL *SSL_new_listener(SSL_CTX *ctx, uint64_t flags);
 __owur SSL *SSL_new_listener_from(SSL *ssl, uint64_t flags);
 __owur SSL *SSL_new_from_listener(SSL *ssl, uint64_t flags);

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4233,6 +4233,8 @@ SSL *ossl_quic_new_listener(SSL_CTX *ctx, uint64_t flags)
 
     port_args.channel_ctx       = ctx;
     port_args.is_multi_conn     = 1;
+    if (!(flags & SSL_LISTENER_FLAG_NO_VALIDATE))
+        port_args.do_addr_validation = 1;
     ql->port = ossl_quic_engine_create_port(ql->engine, &port_args);
     if (ql->port == NULL) {
         QUIC_RAISE_NON_NORMAL_ERROR(NULL, ERR_R_INTERNAL_ERROR, NULL);
@@ -4286,6 +4288,8 @@ SSL *ossl_quic_new_listener_from(SSL *ssl, uint64_t flags)
 
     port_args.channel_ctx       = ssl->ctx;
     port_args.is_multi_conn     = 1;
+    if (!(flags & SSL_LISTENER_FLAG_NO_VALIDATE))
+        port_args.do_addr_validation = 1;
     ql->port = ossl_quic_engine_create_port(ctx.qd->engine, &port_args);
     if (ql->port == NULL) {
         QUIC_RAISE_NON_NORMAL_ERROR(NULL, ERR_R_INTERNAL_ERROR, NULL);

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4288,7 +4288,7 @@ SSL *ossl_quic_new_listener_from(SSL *ssl, uint64_t flags)
 
     port_args.channel_ctx       = ssl->ctx;
     port_args.is_multi_conn     = 1;
-    if (!(flags & SSL_LISTENER_FLAG_NO_VALIDATE))
+    if ((flags & SSL_LISTENER_FLAG_NO_VALIDATE) == 0)
         port_args.do_addr_validation = 1;
     ql->port = ossl_quic_engine_create_port(ctx.qd->engine, &port_args);
     if (ql->port == NULL) {

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4233,7 +4233,7 @@ SSL *ossl_quic_new_listener(SSL_CTX *ctx, uint64_t flags)
 
     port_args.channel_ctx       = ctx;
     port_args.is_multi_conn     = 1;
-    if (!(flags & SSL_LISTENER_FLAG_NO_VALIDATE))
+    if ((flags & SSL_LISTENER_FLAG_NO_VALIDATE) == 0)
         port_args.do_addr_validation = 1;
     ql->port = ossl_quic_engine_create_port(ql->engine, &port_args);
     if (ql->port == NULL) {

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -84,6 +84,7 @@ QUIC_PORT *ossl_quic_port_new(const QUIC_PORT_ARGS *args)
     port->engine        = args->engine;
     port->channel_ctx   = args->channel_ctx;
     port->is_multi_conn = args->is_multi_conn;
+    port->validate_addr = args->do_addr_validation;
 
     if (!port_init(port)) {
         OPENSSL_free(port);
@@ -1196,11 +1197,14 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
      * states in TCP. If we reach certain threshold, then we want to
      * validate clients.
      */
-    if (hdr.token == NULL) {
-        port_send_retry(port, &e->peer, &hdr);
-        goto undesirable;
-    } else if (port_validate_token(&hdr, port, &e->peer, &odcid, &scid) != 1) {
-        goto undesirable;
+    if (port->validate_addr == 1) {
+        if (hdr.token == NULL) {
+            port_send_retry(port, &e->peer, &hdr);
+            goto undesirable;
+        } else if (port_validate_token(&hdr, port, &e->peer,
+                                       &odcid, &scid) == 0) {
+            goto undesirable;
+        }
     }
 
     port_bind_channel(port, &e->peer, &scid, &hdr.dst_conn_id,

--- a/ssl/quic/quic_port_local.h
+++ b/ssl/quic/quic_port_local.h
@@ -92,6 +92,9 @@ struct quic_port_st {
     /* Is this port created to support multiple connections? */
     unsigned int                    is_multi_conn                   : 1;
 
+    /* Is this port doing server address validation */
+    unsigned int                    validate_addr                   : 1;
+
     /* Has this port sent any packet of any kind yet? */
     unsigned int                    have_sent_any_pkt               : 1;
 

--- a/ssl/quic/quic_tserver.c
+++ b/ssl/quic/quic_tserver.c
@@ -128,7 +128,7 @@ QUIC_TSERVER *ossl_quic_tserver_new(const QUIC_TSERVER_ARGS *args,
 
     port_args.channel_ctx       = srv->ctx;
     port_args.is_multi_conn     = 1;
-
+    port_args.do_addr_validation = 1;
     if ((srv->port = ossl_quic_engine_create_port(srv->engine, &port_args)) == NULL)
         goto err;
 

--- a/test/quic-openssl-docker/run_endpoint.sh
+++ b/test/quic-openssl-docker/run_endpoint.sh
@@ -88,7 +88,10 @@ elif [ "$ROLE" == "server" ]; then
     echo "TESTCASE is $TESTCASE"
     rm -f $CURLRC 
     case "$TESTCASE" in
-    "handshake"|"transfer"|"retry"|"resumption")
+    "handshake")
+        NO_ADDR_VALIDATE=yes SSLKEYLOGFILE=/logs/keys.log FILEPREFIX=/www quic-hq-interop-server 443 /certs/cert.pem /certs/priv.key
+        ;;
+    "transfer"|"retry"|"resumption")
      	SSLKEYLOGFILE=/logs/keys.log FILEPREFIX=/www quic-hq-interop-server 443 /certs/cert.pem /certs/priv.key
         ;;
     "chacha20")


### PR DESCRIPTION
Currently server address validation via retry frames is enabled our quic-server.  However it is always enabled, and the quic-interop-runner contains a test which requires retry frames to not be sent.  The test is somewhat questionable given that the RFC grants discretion to the server in the sending of these frames, but we have discussed needed a mechanism to allow users to disable the feature, so it seems reasonable to do so.

This series adds a set of changes which does the following:
* adds a feature flag to quic_port_st to indicate address validation should (or should not be done)
* Changes the control flow of port_default_packet_handler in response to this flag
* Adds a flag bit to the flags parameter of the SSL_new_listener and SSL_new_listener_from calls to allow users to disable server address validation (default is enabled)
* Modifies our interop container and associated programs to set or clear this flag for appropriate tests


##### Checklist
- [x] documentation is added or updated

Note: This PR is currently based on https://github.com/openssl/openssl/pull/26000 , and will be rebased once its parent PR is merged