### PR TITLE
Remove references to git.openssl.org from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For Production Use
 ------------------
 
 Source code tarballs of the official releases can be downloaded from
-[www.openssl.org/source](https://www.openssl.org/source).
+[openssl-library.org/source/](https://openssl-library.org/source/).
 The OpenSSL project does not distribute the toolkit in binary form.
 
 However, for a large variety of operating systems precompiled versions
@@ -87,22 +87,18 @@ the source tarballs, having a local copy of the git repository with
 the entire project history gives you much more insight into the
 code base.
 
-The official OpenSSL Git Repository is located at [git.openssl.org].
-There is a GitHub mirror of the repository at [github.com/openssl/openssl],
+The main OpenSSL Git repository is private.
+There is a public GitHub mirror of it at [github.com/openssl/openssl],
 which is updated automatically from the former on every commit.
 
-A local copy of the Git Repository can be obtained by cloning it from
-the original OpenSSL repository using
-
-    git clone git://git.openssl.org/openssl.git
-
-or from the GitHub mirror using
+A local copy of the Git repository can be obtained by cloning it from
+the GitHub mirror using
 
     git clone https://github.com/openssl/openssl.git
 
 If you intend to contribute to OpenSSL, either to fix bugs or contribute
-new features, you need to fork the OpenSSL repository openssl/openssl on
-GitHub and clone your public fork instead.
+new features, you need to fork the GitHub mirror and clone your public fork
+instead.
 
     git clone https://github.com/yourname/openssl.git
 
@@ -213,14 +209,6 @@ All rights reserved.
 [www.openssl.org]:
     <https://www.openssl.org>
     "OpenSSL Homepage"
-
-[git.openssl.org]:
-    <https://git.openssl.org>
-    "OpenSSL Git Repository"
-
-[git.openssl.org]:
-    <https://git.openssl.org>
-    "OpenSSL Git Repository"
 
 [github.com/openssl/openssl]:
     <https://github.com/openssl/openssl>


### PR DESCRIPTION
Fixes #25191

Since #25198 timed out for changes requested, I did this from scratch.

The manual page links aren't right, but that should be a separate update.