### PR TITLE
openssl-dgst: required shake xoflen

### DIFF
--- a/doc/man1/openssl-dgst.pod.in
+++ b/doc/man1/openssl-dgst.pod.in
@@ -89,17 +89,19 @@ Output the digest or signature in binary form.
 Set the output length for XOF algorithms, such as B<shake128> and B<shake256>.
 This option is not supported for signing operations.
 
-For OpenSSL providers it is recommended to set this value for shake algorithms,
-since the default values are set to only supply half of the maximum security
-strength.
+For OpenSSL providers it is required to set this value for shake algorithms,
+since the previous default values were only set to supply half of the maximum
+security strength.
 
-For backwards compatibility reasons the default xoflen length for B<shake128> is
-16 (bytes) which results in a security strength of only 64 bits. To ensure the
-maximum security strength of 128 bits, the xoflen should be set to at least 32.
+To ensure the maximum security strength of 128 bits, the xoflen for B<shake128>
+should be set to at least 32 (bytes). For compatibility with previous versions
+of OpenSSL, it may be set to 16, resulting in a security strength of only 64
+bits.
 
-For backwards compatibility reasons the default xoflen length for B<shake256> is
-32 (bytes) which results in a security strength of only 128 bits. To ensure the
-maximum security strength of 256 bits, the xoflen should be set to at least 64.
+To ensure the maximum security strength of 256 bits, the xoflen for B<shake256>
+should be set to at least 64 (bytes). For compatibility with previous versions
+of OpenSSL, it may be set to 32, resulting in a security strength of only 128
+bits.
 
 =item B<-r>
 


### PR DESCRIPTION
With b911fef216d1386210ec24e201d54d709528abb4, there is no longer a default xoflen for shake algorithms. Update the manual to reflect this.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

