### PR TITLE
update HISTORY sections of libssl functions > 3.0.0

### DIFF
--- a/doc/man3/BN_bn2bin.pod
+++ b/doc/man3/BN_bn2bin.pod
@@ -132,9 +132,15 @@ L<ERR_get_error(3)>, L<BN_zero(3)>,
 L<ASN1_INTEGER_to_BN(3)>,
 L<BN_num_bytes(3)>
 
+=head1 HISTORY
+
+The functions BN_signed_bin2bn(), BN_signed_bn2bin(), BN_signed_lebin2bn(),
+BN_signed_bn2lebin(), BN_signed_native2bn(), BN_signed_bn2native()
+were added in OpenSSL 3.2.
+
 =head1 COPYRIGHT
 
-Copyright 2000-2022 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2024 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/OPENSSL_strcasecmp.pod
+++ b/doc/man3/OPENSSL_strcasecmp.pod
@@ -35,9 +35,13 @@ unpredictably suffer when they use localization (e.g. Turkish locale is
 well-known with a specific I/i cases). These functions use C locale for string
 comparison.
 
+=head1 HISTORY
+
+These functions were added in OpenSSL 3.0.3.
+
 =head1 COPYRIGHT
 
-Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2022-2024 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/SSL_CTX_flush_sessions.pod
+++ b/doc/man3/SSL_CTX_flush_sessions.pod
@@ -54,6 +54,10 @@ L<SSL_CTX_set_session_cache_mode(3)>,
 L<SSL_CTX_set_timeout(3)>,
 L<SSL_CTX_sess_set_get_cb(3)>
 
+=head1 HISTORY
+
+SSL_CTX_flush_sessions_ex() was added in OpenSSL 3.4.
+
 =head1 COPYRIGHT
 
 Copyright 2001-2024 The OpenSSL Project Authors. All Rights Reserved.

--- a/doc/man3/SSL_CTX_set_record_padding_callback.pod
+++ b/doc/man3/SSL_CTX_set_record_padding_callback.pod
@@ -104,6 +104,9 @@ The record padding API was added for TLS 1.3 support in OpenSSL 1.1.1.
 The return type of SSL_CTX_set_record_padding_callback() function was
 changed to int in OpenSSL 3.0.
 
+The functions SSL_set_block_padding_ex() and SSL_CTX_set_block_padding_ex()
+were added in OpenSSL 3.4.
+
 =head1 COPYRIGHT
 
 Copyright 2017-2024 The OpenSSL Project Authors. All Rights Reserved.

--- a/doc/man3/SSL_SESSION_get_time.pod
+++ b/doc/man3/SSL_SESSION_get_time.pod
@@ -85,6 +85,11 @@ L<ssl(7)>,
 L<SSL_CTX_set_timeout(3)>,
 L<SSL_get_default_timeout(3)>
 
+=head1 HISTORY
+
+The functions SSL_SESSION_get_time_ex() and SSL_SESSION_set_time_ex() were
+added in OpenSSL 3.3.
+
 =head1 COPYRIGHT
 
 Copyright 2001-2024 The OpenSSL Project Authors. All Rights Reserved.

--- a/doc/man3/SSL_get0_group_name.pod
+++ b/doc/man3/SSL_get0_group_name.pod
@@ -16,7 +16,6 @@ agreement of the current TLS session establishment
 SSL_get0_group_name() returns the name of the group that was used for
 the key agreement of the current TLS session establishment.
 
-
 =head1 RETURN VALUES
 
 If non-NULL, SSL_get0_group_name() returns the name of the group that was used for
@@ -31,9 +30,13 @@ SSL object I<ssl>.
 
 L<ssl(7)>
 
+=head1 HISTORY
+
+This function was added in OpenSSL 3.2.
+
 =head1 COPYRIGHT
 
-Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2023-2024 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/SSL_get1_builtin_sigalgs.pod
+++ b/doc/man3/SSL_get1_builtin_sigalgs.pod
@@ -26,6 +26,10 @@ algorithms can be activated, e.g., if suitable providers are missing.
 NULL may be returned if no memory could be allocated. Otherwise, a
 newly allocated string is always returned but it may have strlen == 0.
 
+=head1 HISTORY
+
+This call was added in OpenSSL 3.4.
+
 =head1 COPYRIGHT
 
 Copyright 2000-2024 The OpenSSL Project Authors. All Rights Reserved.

--- a/doc/man3/SSL_get_handshake_rtt.pod
+++ b/doc/man3/SSL_get_handshake_rtt.pod
@@ -45,9 +45,13 @@ Returns 1 if the TLS handshake RTT is successfully retrieved.
 Returns 0 if the TLS handshake RTT cannot be determined yet.
 Returns -1 if, while retrieving the TLS handshake RTT, an error occurs.
 
+=head1 HISTORY
+
+This function was added in OpenSSL 3.2.
+
 =head1 COPYRIGHT
 
-Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2023-2024 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/SSL_write.pod
+++ b/doc/man3/SSL_write.pod
@@ -195,6 +195,7 @@ L<ssl(7)>, L<bio(7)>
 
 The SSL_write_ex() function was added in OpenSSL 1.1.1.
 The SSL_sendfile() function was added in OpenSSL 3.0.
+The SSL_write_ex2() function was added in OpenSSL 3.3.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/d2i_SSL_SESSION.pod
+++ b/doc/man3/d2i_SSL_SESSION.pod
@@ -42,9 +42,13 @@ L<ssl(7)>, L<SSL_SESSION_free(3)>,
 L<SSL_CTX_sess_set_get_cb(3)>,
 L<d2i_X509(3)>
 
+=head1 HISTORY
+
+The function d2i_SSL_SESSION_ex() was added in OpenSSL 3.2.
+
 =head1 COPYRIGHT
 
-Copyright 2001-2023 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2001-2024 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy


### PR DESCRIPTION
One of these functions I forgot to properly document myself when adding it; the other fixups are a bonus. May do the same for the remaining `libcrypto` functions in a separate PR sometime later if this one is deemed OK & helpful.