### PR TITLE
Correct documentated KEM ids for OSSL_HPKE_str2suite

### DIFF
--- a/doc/man3/OSSL_HPKE_CTX_new.pod
+++ b/doc/man3/OSSL_HPKE_CTX_new.pod
@@ -454,9 +454,9 @@ The input I<str> should be a comma-separated string with a KEM,
 KDF and AEAD name in that order, for example "x25519,hkdf-sha256,aes128gcm".
 This can be used by command line tools that accept string form names for HPKE
 codepoints. Valid (case-insensitive) names are:
-"p256", "p384", "p521", "x25519" and "x448" for KEM,
-"hkdf-SHA256", "hkdf-SHA384" and "hkdf-SHA512" for KDF, and
-"aes-gcm-128", "aes-gcm-256" and "chacha20-poly1305" for AEAD.
+"p-256", "p-384", "p-521", "x25519" and "x448" for KEM,
+"hkdf-sha256", "hkdf-sha384" and "hkdf-sha512" for KDF, and
+"aes-gcm-128", "aes-gcm-256", "chacha20-poly1305" and "exporter" for AEAD.
 String variants of the numbers listed in L</OSSL_HPKE_SUITE Identifiers>
 can also be used.
 


### PR DESCRIPTION
I tried to use "p256" per the documentation and it didn't work, so I've updated the values to match the values in https://github.com/openssl/openssl/blob/8ad98cce41aa8a6278f7ade6ad2f70b80b194b72/include/openssl/hpke.h#L56.

I also made the values consistently lowercase, and added the "exporter" AEAD value.
