### PR TITLE
crash in EVP_DigestVerify

### DIFF
--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -701,8 +701,10 @@ int EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sigret,
         }
     } else {
         /* legacy */
-        if (ctx->pctx->pmeth != NULL && ctx->pctx->pmeth->digestverify != NULL)
-            return ctx->pctx->pmeth->digestverify(ctx, sigret, siglen, tbs, tbslen);
+        if (pctx == NULL)
+            return -1;
+        if (pctx->pmeth != NULL && pctx->pmeth->digestverify != NULL)
+            return pctx->pmeth->digestverify(ctx, sigret, siglen, tbs, tbslen);
     }
     if (EVP_DigestVerifyUpdate(ctx, tbs, tbslen) <= 0)
         return -1;


### PR DESCRIPTION
Correction of a possible crash in EVP_DigestVerify
if ctx->pctx == NULL, then check ctx->pctx->pmeth != NULL will cause a crash

Found by Linux Verification Center (linuxtesting.org) with SVACE.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
