### PR TITLE
Amplification limit

### DIFF
--- a/.github/workflows/run_quic_interop.yml
+++ b/.github/workflows/run_quic_interop.yml
@@ -10,7 +10,7 @@ jobs:
   run_quic_interop:
     strategy:
       matrix:
-        tests: [http3, transfer, handshake, retry, chacha20, resumption]
+        tests: [http3, transfer, handshake, retry, chacha20, resumption, amplificationlimit]
         servers: [quic-go, ngtcp2, mvfst, quiche, nginx, msquic, haproxy]
       fail-fast: false
     runs-on: ubuntu-latest 

--- a/demos/guide/quic-hq-interop-server.c
+++ b/demos/guide/quic-hq-interop-server.c
@@ -570,6 +570,7 @@ static int run_quic_server(SSL_CTX *ctx, BIO *sock)
                  * Filter on the shutdown error, and only print an error
                  * message if the cause is not SHUTDOWN
                  */
+                ERR_print_errors_fp(stderr);
                 errcode = ERR_get_error();
                 if (ERR_GET_REASON(errcode) != SSL_R_PROTOCOL_IS_SHUTDOWN)
                     fprintf(stderr, "Failure in accept stream, error %s\n",

--- a/include/internal/quic_txp.h
+++ b/include/internal/quic_txp.h
@@ -66,6 +66,13 @@ typedef struct ossl_quic_tx_packetiser_args_st {
 
 OSSL_QUIC_TX_PACKETISER *ossl_quic_tx_packetiser_new(const OSSL_QUIC_TX_PACKETISER_ARGS *args);
 
+void ossl_quic_tx_packetiser_set_validated(OSSL_QUIC_TX_PACKETISER *txp);
+void ossl_quic_tx_packetiser_add_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp,
+                                                    size_t credit);
+void ossl_quic_tx_packetiser_consume_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp,
+                                                        size_t credit);
+size_t ossl_quic_tx_packetiser_get_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp);
+
 typedef void (ossl_quic_initial_token_free_fn)(const unsigned char *buf,
                                                size_t buf_len, void *arg);
 

--- a/include/internal/quic_txp.h
+++ b/include/internal/quic_txp.h
@@ -71,7 +71,8 @@ void ossl_quic_tx_packetiser_add_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp
                                                     size_t credit);
 void ossl_quic_tx_packetiser_consume_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp,
                                                         size_t credit);
-int ossl_quic_tx_packetiser_check_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp, size_t req_credit);
+int ossl_quic_tx_packetiser_check_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp,
+                                                     size_t req_credit);
 
 typedef void (ossl_quic_initial_token_free_fn)(const unsigned char *buf,
                                                size_t buf_len, void *arg);

--- a/include/internal/quic_txp.h
+++ b/include/internal/quic_txp.h
@@ -71,7 +71,7 @@ void ossl_quic_tx_packetiser_add_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp
                                                     size_t credit);
 void ossl_quic_tx_packetiser_consume_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp,
                                                         size_t credit);
-size_t ossl_quic_tx_packetiser_get_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp);
+int ossl_quic_tx_packetiser_check_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp, size_t req_credit);
 
 typedef void (ossl_quic_initial_token_free_fn)(const unsigned char *buf,
                                                size_t buf_len, void *arg);

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -1037,7 +1037,7 @@ static int ch_on_handshake_complete(void *arg)
         return 0;
 
     /*
-     * When handshake is complete, we no longer need to abide by the 
+     * When handshake is complete, we no longer need to abide by the
      * 3x amplification limit, though we should be validated as soon
      * as we see a handshake key encrypted packet (see ossl_quic_handle_packet)
      */

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -298,6 +298,10 @@ static int ch_init(QUIC_CHANNEL *ch)
     if (ch->txp == NULL)
         goto err;
 
+    /* clients have no amplification limit, so are considered always valid */
+    if (!ch->is_server)
+        ossl_quic_tx_packetiser_set_validated(ch->txp);
+
     ossl_quic_tx_packetiser_set_ack_tx_cb(ch->txp, ch_on_txp_ack_tx, ch);
 
     qrx_args.libctx             = ch->port->engine->libctx;
@@ -1031,6 +1035,13 @@ static int ch_on_handshake_complete(void *arg)
 
     if (!ossl_assert(ch->tx_enc_level == QUIC_ENC_LEVEL_1RTT))
         return 0;
+
+    /*
+     * When handshake is complete, we no longer need to abide by the 
+     * 3x amplification limit, though we should be validated as soon
+     * as we see a handshake key encrypted packet (see ossl_quic_handle_packet)
+     */
+    ossl_quic_tx_packetiser_set_validated(ch->txp);
 
     if (!ch->got_remote_transport_params) {
         /*

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4436,8 +4436,6 @@ SSL *ossl_quic_accept_connection(SSL *ssl, uint64_t flags)
 
 out:
     qctx_unlock(&ctx);
-    if (qc != NULL)
-        ossl_quic_do_handshake(&qc->obj.ssl);
     return qc != NULL ? &qc->obj.ssl : NULL;
 }
 

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4436,6 +4436,8 @@ SSL *ossl_quic_accept_connection(SSL *ssl, uint64_t flags)
 
 out:
     qctx_unlock(&ctx);
+    if (qc != NULL)
+        ossl_quic_do_handshake(&qc->obj.ssl);
     return qc != NULL ? &qc->obj.ssl : NULL;
 }
 

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -608,7 +608,7 @@ static void port_bind_channel(QUIC_PORT *port, const BIO_ADDR *peer,
 
     if (odcid->id_len != 0) {
         /*
-         * If we have an odcid, then we wen't through server address validation
+         * If we have an odcid, then we went through server address validation
          * and as such, this channel need not conform to the 3x validation cap
          * See RFC 9000 s. 8.1
          */

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -1116,7 +1116,6 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
     QUIC_CONN_ID odcid, scid;
     uint64_t cause_flags = 0;
 
-
     /* Don't handle anything if we are no longer running. */
     if (!ossl_quic_port_is_running(port))
         goto undesirable;

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -11,6 +11,7 @@
 #include "internal/quic_channel.h"
 #include "internal/quic_lcidm.h"
 #include "internal/quic_srtm.h"
+#include "internal/quic_txp.h"
 #include "internal/ssl_unwrap.h"
 #include "quic_port_local.h"
 #include "quic_channel_local.h"
@@ -606,6 +607,12 @@ static void port_bind_channel(QUIC_PORT *port, const BIO_ADDR *peer,
         return;
 
     if (odcid->id_len != 0) {
+        /*
+         * If we have an odcid, then we wen't through server address validation
+         * and as such, this channel need not conform to the 3x validation cap
+         * See RFC 9000 s. 8.1
+         */
+        ossl_quic_tx_packetiser_set_validated(ch->txp);
         if (!ossl_quic_bind_channel(ch, peer, scid, dcid, odcid)) {
             ossl_quic_channel_free(ch);
             return;
@@ -1109,6 +1116,7 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
     QUIC_CONN_ID odcid, scid;
     uint64_t cause_flags = 0;
 
+
     /* Don't handle anything if we are no longer running. */
     if (!ossl_quic_port_is_running(port))
         goto undesirable;
@@ -1170,7 +1178,6 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
          * RFC 9000 s. 6 and 14.1, we only do so however, if the UDP datagram
          * is a minimum of 1200 bytes in size
          */
-
         if (e->data_len < 1200)
             goto undesirable;
 

--- a/ssl/quic/quic_rx_depack.c
+++ b/ssl/quic/quic_rx_depack.c
@@ -1411,6 +1411,7 @@ int ossl_quic_handle_frames(QUIC_CHANNEL *ch, OSSL_QRX_PKT *qpacket)
     PACKET pkt;
     OSSL_ACKM_RX_PKT ackm_data;
     uint32_t enc_level;
+    size_t dgram_len = qpacket->datagram_len;
 
     /*
      * ok has three states:
@@ -1443,6 +1444,18 @@ int ossl_quic_handle_frames(QUIC_CHANNEL *ch, OSSL_QRX_PKT *qpacket)
 
     ok = 0; /* Still assume the worst */
     ackm_data.pkt_space = ossl_quic_enc_level_to_pn_space(enc_level);
+
+    /*
+     * RFC 9000 s. 8.1
+     * If we recieve a packet from a client protected with handshake keys
+     * We can consider the connection validated, and the amplification limit
+     * no longer applies.  Otherwise
+     * Add this packet length to the unvalidated credit we have
+     */
+    if (enc_level == QUIC_ENC_LEVEL_HANDSHAKE)
+        ossl_quic_tx_packetiser_set_validated(ch->txp);
+    else
+        ossl_quic_tx_packetiser_add_unvalidated_credit(ch->txp, dgram_len);
 
     /* Now that special cases are out of the way, parse frames */
     if (!PACKET_buf_init(&pkt, qpacket->hdr->data, qpacket->hdr->len)

--- a/ssl/quic/quic_rx_depack.c
+++ b/ssl/quic/quic_rx_depack.c
@@ -1447,10 +1447,11 @@ int ossl_quic_handle_frames(QUIC_CHANNEL *ch, OSSL_QRX_PKT *qpacket)
 
     /*
      * RFC 9000 s. 8.1
-     * If we recieve a packet from a client protected with handshake keys
-     * We can consider the connection validated, and the amplification limit
-     * no longer applies.  Otherwise
-     * Add this packet length to the unvalidated credit we have
+     * We can consider the connection to be validated, if we receive a packet
+     * from the client protected via handshake keys, meaning that the
+     * amplification limit no longer applies (i.e. we can set it as validated.
+     * Otherwise, add the size of this packet to the unvalidated credit for
+     * the connection.
      */
     if (enc_level == QUIC_ENC_LEVEL_HANDSHAKE)
         ossl_quic_tx_packetiser_set_validated(ch->txp);

--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -67,6 +67,8 @@ struct ossl_quic_tx_packetiser_st {
     uint64_t        next_pn[QUIC_PN_SPACE_NUM]; /* Next PN to use in given PN space. */
     OSSL_TIME       last_tx_time;               /* Last time a packet was generated, or 0. */
 
+    size_t          unvalidated_credit;         /* Limit of data we can send until validated */
+
     /* Internal state - frame (re)generation flags. */
     unsigned int    want_handshake_done     : 1;
     unsigned int    want_max_data           : 1;
@@ -450,6 +452,83 @@ static int txp_pkt_commit(OSSL_QUIC_TX_PACKETISER *txp, struct txp_pkt *pkt,
                           uint32_t archetype, int *txpim_pkt_reffed);
 static uint32_t txp_determine_archetype(OSSL_QUIC_TX_PACKETISER *txp,
                                         uint64_t cc_limit);
+
+/**
+ * Sets the validated state of a QUIC TX packetiser.
+ *
+ * This function marks the provided QUIC TX packetiser as having its credit
+ * fully validated by setting its `unvalidated_credit` field to `SIZE_MAX`.
+ *
+ * @param txp A pointer to the OSSL_QUIC_TX_PACKETISER structure to update.
+ */
+void ossl_quic_tx_packetiser_set_validated(OSSL_QUIC_TX_PACKETISER *txp)
+{
+    txp->unvalidated_credit = SIZE_MAX;
+    return;
+}
+
+/**
+ * Adds unvalidated credit to a QUIC TX packetiser.
+ *
+ * This function increases the unvalidated credit of the provided QUIC TX
+ * packetiser. If the current unvalidated credit is not `SIZE_MAX`, the
+ * function adds three times the specified `credit` value, ensuring it does
+ * not exceed the maximum allowable value (`SIZE_MAX - 1`). If the addition
+ * would cause an overflow, the unvalidated credit is capped at
+ * `SIZE_MAX - 1`. If the current unvalidated credit is already `SIZE_MAX`,
+ * the function does nothing.
+ *
+ * @param txp    A pointer to the OSSL_QUIC_TX_PACKETISER structure to update.
+ * @param credit The amount of credit to add, multiplied by 3.
+ */
+void ossl_quic_tx_packetiser_add_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp,
+                                                    size_t credit)
+{
+    if (txp->unvalidated_credit != SIZE_MAX) {
+        if (SIZE_MAX - txp->unvalidated_credit < credit * 3)
+            txp->unvalidated_credit += credit * 3;
+        else
+            txp->unvalidated_credit = SIZE_MAX - 1;
+    }
+    return;
+}
+
+/**
+ * Consumes unvalidated credit from a QUIC TX packetiser.
+ *
+ * This function decreases the unvalidated credit of the specified
+ * QUIC TX packetiser by the given `credit` value. If the unvalidated credit
+ * is set to `SIZE_MAX`, the function does nothing, as `SIZE_MAX` represents
+ * an unlimited credit state.
+ *
+ * @param txp    A pointer to the OSSL_QUIC_TX_PACKETISER structure to update.
+ * @param credit The amount of credit to consume.
+ */
+void ossl_quic_tx_packetiser_consume_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp,
+                                                        size_t credit)
+{
+    if (txp->unvalidated_credit != SIZE_MAX)
+        txp->unvalidated_credit -= credit;
+
+}
+
+/**
+ * Checks if the QUIC TX packetiser has sufficient unvalidated credit.
+ *
+ * This function determines whether the unvalidated credit of the specified
+ * QUIC TX packetiser exceeds the required credit value (`req_credit`).
+ * If the unvalidated credit is greater than `req_credit`, the function
+ * returns 1 (true); otherwise, it returns 0 (false).
+ *
+ * @param txp        A pointer to the OSSL_QUIC_TX_PACKETISER structure to check.
+ * @param req_credit The required credit value to compare against.
+ *
+ * @return 1 if the unvalidated credit exceeds `req_credit`, 0 otherwise.
+ */
+int ossl_quic_tx_packetiser_check_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp, size_t req_credit)
+{
+    return txp->unvalidated_credit;
+}
 
 OSSL_QUIC_TX_PACKETISER *ossl_quic_tx_packetiser_new(const OSSL_QUIC_TX_PACKETISER_ARGS *args)
 {

--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -532,7 +532,7 @@ void ossl_quic_tx_packetiser_consume_unvalidated_credit(OSSL_QUIC_TX_PACKETISER 
 int ossl_quic_tx_packetiser_check_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp,
                                                      size_t req_credit)
 {
-    return (txp->unvalidated_credit > req_credit) ? 1 : 0;
+    return (txp->unvalidated_credit > req_credit);
 }
 
 OSSL_QUIC_TX_PACKETISER *ossl_quic_tx_packetiser_new(const OSSL_QUIC_TX_PACKETISER_ARGS *args)

--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -485,11 +485,12 @@ void ossl_quic_tx_packetiser_add_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp
                                                     size_t credit)
 {
     if (txp->unvalidated_credit != SIZE_MAX) {
-        if (SIZE_MAX - txp->unvalidated_credit < credit * 3)
+        if ((SIZE_MAX - txp->unvalidated_credit) > (credit * 3))
             txp->unvalidated_credit += credit * 3;
         else
             txp->unvalidated_credit = SIZE_MAX - 1;
-    }
+    } else
+
     return;
 }
 
@@ -507,9 +508,12 @@ void ossl_quic_tx_packetiser_add_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp
 void ossl_quic_tx_packetiser_consume_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp,
                                                         size_t credit)
 {
-    if (txp->unvalidated_credit != SIZE_MAX)
-        txp->unvalidated_credit -= credit;
-
+    if (txp->unvalidated_credit != SIZE_MAX) {
+        if (txp->unvalidated_credit < credit)
+            txp->unvalidated_credit = 0;
+        else
+            txp->unvalidated_credit -= credit;
+    }
 }
 
 /**
@@ -527,7 +531,7 @@ void ossl_quic_tx_packetiser_consume_unvalidated_credit(OSSL_QUIC_TX_PACKETISER 
  */
 int ossl_quic_tx_packetiser_check_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp, size_t req_credit)
 {
-    return txp->unvalidated_credit;
+    return (txp->unvalidated_credit > req_credit) ? 1 : 0;
 }
 
 OSSL_QUIC_TX_PACKETISER *ossl_quic_tx_packetiser_new(const OSSL_QUIC_TX_PACKETISER_ARGS *args)
@@ -859,12 +863,13 @@ int ossl_quic_tx_packetiser_generate(OSSL_QUIC_TX_PACKETISER *txp,
     uint64_t cc_limit = txp->args.cc_method->get_tx_allowance(txp->args.cc_data);
     int need_padding = 0, txpim_pkt_reffed;
 
+    memset(status, 0, sizeof(*status));
+
     for (enc_level = QUIC_ENC_LEVEL_INITIAL;
          enc_level < QUIC_ENC_LEVEL_NUM;
          ++enc_level)
         pkt[enc_level].h_valid = 0;
 
-    memset(status, 0, sizeof(*status));
 
     /*
      * Should not be needed, but a sanity check in case anyone else has been
@@ -986,6 +991,12 @@ int ossl_quic_tx_packetiser_generate(OSSL_QUIC_TX_PACKETISER *txp,
             /* Nothing was generated for this EL, so skip. */
             continue;
 
+        if (!ossl_quic_tx_packetiser_check_unvalidated_credit(txp, pkt[enc_level].h.bytes_appended)) {
+            res = TXP_ERR_SPACE;
+            goto out;
+        }
+        ossl_quic_tx_packetiser_consume_unvalidated_credit(txp, pkt[enc_level].h.bytes_appended);
+
         rc = txp_pkt_commit(txp, &pkt[enc_level], archetype,
                             &txpim_pkt_reffed);
         if (rc) {
@@ -1006,6 +1017,7 @@ int ossl_quic_tx_packetiser_generate(OSSL_QUIC_TX_PACKETISER *txp,
             goto out;
 
         ++pkts_done;
+
     }
 
     /* Flush & Cleanup */

--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -489,7 +489,7 @@ void ossl_quic_tx_packetiser_add_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp
             txp->unvalidated_credit += credit * 3;
         else
             txp->unvalidated_credit = SIZE_MAX - 1;
-    } else
+    }
 
     return;
 }
@@ -529,7 +529,8 @@ void ossl_quic_tx_packetiser_consume_unvalidated_credit(OSSL_QUIC_TX_PACKETISER 
  *
  * @return 1 if the unvalidated credit exceeds `req_credit`, 0 otherwise.
  */
-int ossl_quic_tx_packetiser_check_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp, size_t req_credit)
+int ossl_quic_tx_packetiser_check_unvalidated_credit(OSSL_QUIC_TX_PACKETISER *txp,
+                                                     size_t req_credit)
 {
     return (txp->unvalidated_credit > req_credit) ? 1 : 0;
 }
@@ -991,7 +992,8 @@ int ossl_quic_tx_packetiser_generate(OSSL_QUIC_TX_PACKETISER *txp,
             /* Nothing was generated for this EL, so skip. */
             continue;
 
-        if (!ossl_quic_tx_packetiser_check_unvalidated_credit(txp, pkt[enc_level].h.bytes_appended)) {
+        if (!ossl_quic_tx_packetiser_check_unvalidated_credit(txp,
+                                                              pkt[enc_level].h.bytes_appended)) {
             res = TXP_ERR_SPACE;
             goto out;
         }

--- a/test/quic-openssl-docker/run_endpoint.sh
+++ b/test/quic-openssl-docker/run_endpoint.sh
@@ -91,7 +91,10 @@ elif [ "$ROLE" == "server" ]; then
     "handshake")
         NO_ADDR_VALIDATE=yes SSLKEYLOGFILE=/logs/keys.log FILEPREFIX=/www quic-hq-interop-server 443 /certs/cert.pem /certs/priv.key
         ;;
-    "transfer"|"retry"|"resumption")
+    "transfer")
+        NO_ADDR_VALIDATE=yes SSLKEYLOGFILE=/logs/keys.log FILEPREFIX=/www quic-hq-interop-server 443 /certs/cert.pem /certs/priv.key
+        ;;
+    "retry"|"resumption")
      	SSLKEYLOGFILE=/logs/keys.log FILEPREFIX=/www quic-hq-interop-server 443 /certs/cert.pem /certs/priv.key
         ;;
     "chacha20")

--- a/test/quic_txp_test.c
+++ b/test/quic_txp_test.c
@@ -212,6 +212,12 @@ static int helper_init(struct helper *h)
     if (!TEST_ptr(h->txp = ossl_quic_tx_packetiser_new(&h->args)))
         goto err;
 
+    /*
+     * Our helper should always skip validation
+     * as the tests are not written to expect delayed connections
+     */
+    ossl_quic_tx_packetiser_set_validated(h->txp);
+
     if (!TEST_ptr(h->demux = ossl_quic_demux_new(h->bio2, 8,
                                                  fake_now, NULL)))
         goto err;


### PR DESCRIPTION
Testing with the interop harness indicated we were violating the amplification limit prior to an address being validated, validation consisting of the following conditions:
1) A retry packet is sent and properly responded to (we conform here)
2) A handshake key encrypted packet is received from the client (RFC 9002 S 8.1) (we do not conform here)

So add a credit monitor such that we bound our sending data until such time as condition 1 or two is met
