### PR TITLE
Add http3 test quic interop test

### DIFF
--- a/demos/http3/ossl-nghttp3-demo-server.c
+++ b/demos/http3/ossl-nghttp3-demo-server.c
@@ -289,15 +289,15 @@ static int on_recv_header(nghttp3_conn *conn, int64_t stream_id, int32_t token,
     if (token == NGHTTP3_QPACK_TOKEN__PATH) {
         int len = (((vvalue.len) < (MAXURL)) ? (vvalue.len) : (MAXURL));
 
-        memcpy(h3ssl->url, vvalue.base, len);
-        if (h3ssl->url[0] == '/') {
-            if (h3ssl->url[1] == '\0') {
+        memset(h3ssl->url, 0, sizeof(h3ssl->url));
+        if (vvalue.base[0] == '/') {
+            if (vvalue.base[1] == '\0') {
                 strncpy(h3ssl->url, "index.html", MAXURL);
-                h3ssl->url[MAXURL - 1] = '\0';
             } else {
-                memcpy(h3ssl->url, h3ssl->url + 1, len - 1);
-                h3ssl->url[len - 1] = '\0';
+                memcpy(h3ssl->url, &vvalue.base[1], len - 1);
             }
+        } else {
+            memcpy(h3ssl->url, vvalue.base, len);
         }
     }
 

--- a/demos/http3/ossl-nghttp3-demo-server.c
+++ b/demos/http3/ossl-nghttp3-demo-server.c
@@ -84,6 +84,7 @@ static void init_ids(struct h3ssl *h3ssl)
 {
     struct ssl_id *ssl_ids;
     int i;
+    char *prior_fileprefix = h3ssl->fileprefix;
 
     memset (h3ssl, 0, sizeof (struct h3ssl));
 
@@ -92,6 +93,9 @@ static void init_ids(struct h3ssl *h3ssl)
         ssl_ids[i].id = UINT64_MAX;
     }
     h3ssl->id_bidi = UINT64_MAX;
+
+    /* restore the fileprefix */
+    h3ssl->fileprefix = prior_fileprefix;
 }
 
 static void reuse_h3ssl(struct h3ssl *h3ssl)

--- a/demos/http3/ossl-nghttp3-demo-server.c
+++ b/demos/http3/ossl-nghttp3-demo-server.c
@@ -348,9 +348,16 @@ static int quic_server_read(nghttp3_conn *h3conn, SSL *stream, uint64_t id, stru
         fprintf(stderr, "SSL_read %d on %llu failed\n",
                 SSL_get_error(stream, ret),
                 (unsigned long long) id);
-        if (SSL_get_error(stream, ret) == SSL_ERROR_WANT_READ)
-            return 0; /* retry we need more data */
-        ERR_print_errors_fp(stderr);
+        switch(SSL_get_error(stream, ret)) {
+        case SSL_ERROR_WANT_READ:
+        case SSL_ERROR_ZERO_RETURN:
+            return 0;
+            break;
+        default:
+            ERR_print_errors_fp(stderr);
+            return -1;
+            break;
+        }
         return -1;
     }
 

--- a/demos/http3/ossl-nghttp3-demo-server.c
+++ b/demos/http3/ossl-nghttp3-demo-server.c
@@ -86,6 +86,9 @@ static void init_ids(struct h3ssl *h3ssl)
     int i;
     char *prior_fileprefix = h3ssl->fileprefix;
 
+    if (h3ssl->ptr_data != NULL && h3ssl->ptr_data != nulldata)
+        free(h3ssl->ptr_data);
+
     memset(h3ssl, 0, sizeof(struct h3ssl));
 
     ssl_ids = h3ssl->ssl_ids;
@@ -350,8 +353,10 @@ static int quic_server_read(nghttp3_conn *h3conn, SSL *stream, uint64_t id, stru
                 (unsigned long long) id);
         switch (SSL_get_error(stream, ret)) {
         case SSL_ERROR_WANT_READ:
-        case SSL_ERROR_ZERO_RETURN:
             return 0;
+            break;
+        case SSL_ERROR_ZERO_RETURN:
+            return 1;
             break;
         default:
             ERR_print_errors_fp(stderr);

--- a/demos/http3/ossl-nghttp3-demo-server.c
+++ b/demos/http3/ossl-nghttp3-demo-server.c
@@ -86,7 +86,7 @@ static void init_ids(struct h3ssl *h3ssl)
     int i;
     char *prior_fileprefix = h3ssl->fileprefix;
 
-    memset (h3ssl, 0, sizeof (struct h3ssl));
+    memset(h3ssl, 0, sizeof(struct h3ssl));
 
     ssl_ids = h3ssl->ssl_ids;
     for (i = 0; i < MAXSSL_IDS; i++) {
@@ -348,7 +348,7 @@ static int quic_server_read(nghttp3_conn *h3conn, SSL *stream, uint64_t id, stru
         fprintf(stderr, "SSL_read %d on %llu failed\n",
                 SSL_get_error(stream, ret),
                 (unsigned long long) id);
-        switch(SSL_get_error(stream, ret)) {
+        switch (SSL_get_error(stream, ret)) {
         case SSL_ERROR_WANT_READ:
         case SSL_ERROR_ZERO_RETURN:
             return 0;

--- a/demos/http3/ossl-nghttp3-demo-server.c
+++ b/demos/http3/ossl-nghttp3-demo-server.c
@@ -354,14 +354,11 @@ static int quic_server_read(nghttp3_conn *h3conn, SSL *stream, uint64_t id, stru
         switch (SSL_get_error(stream, ret)) {
         case SSL_ERROR_WANT_READ:
             return 0;
-            break;
         case SSL_ERROR_ZERO_RETURN:
             return 1;
-            break;
         default:
             ERR_print_errors_fp(stderr);
             return -1;
-            break;
         }
         return -1;
     }

--- a/test/quic-openssl-docker/Dockerfile
+++ b/test/quic-openssl-docker/Dockerfile
@@ -28,9 +28,10 @@ RUN git clone --depth 1 https://github.com/ngtcp2/nghttp3.git && \
 # download and build openssl 
 RUN git clone --depth 1 -b $OPENSSL_BRANCH $OPENSSL_URL && \
     cd openssl && \
-    ./Configure enable-sslkeylog enable-fips enable-demos disable-docs --prefix=/usr --openssldir=/etc/pki/tls && \
+    ./Configure enable-sslkeylog enable-fips enable-demos enable-h3demo disable-docs --prefix=/usr --openssldir=/etc/pki/tls && \
     make -j 4 && make install && cp demos/guide/quic-hq-interop /usr/local/bin && \
     cp demos/guide/quic-hq-interop-server /usr/local/bin && \
+    cp demos/http3/ossl-nghttp3-demo-server /usr/local/bin && \
     rm -rf /openssl
 
 # Build curl

--- a/test/quic-openssl-docker/run_endpoint.sh
+++ b/test/quic-openssl-docker/run_endpoint.sh
@@ -92,7 +92,7 @@ elif [ "$ROLE" == "server" ]; then
      	SSLKEYLOGFILE=/logs/keys.log FILEPREFIX=/www quic-hq-interop-server 443 /certs/cert.pem /certs/priv.key
         ;;
     "http3")
-        SSLKEYLOGFILE=/logs/keys.log ossl-nghttp3-demo-server 443 /certs/cert.pem /certs/priv.key
+        FILEPREFIX=/www/ SSLKEYLOGFILE=/logs/keys.log ossl-nghttp3-demo-server 443 /certs/cert.pem /certs/priv.key
         ;;
     "chacha20")
         SSL_CIPHER_SUITES=TLS_CHACHA20_POLY1305_SHA256 SSLKEYLOGFILE=/logs/keys.log FILEPREFIX=/www quic-hq-interop-server 443 /certs/cert.pem /certs/priv.key

--- a/test/quic-openssl-docker/run_endpoint.sh
+++ b/test/quic-openssl-docker/run_endpoint.sh
@@ -91,6 +91,9 @@ elif [ "$ROLE" == "server" ]; then
     "handshake"|"transfer"|"retry"|"resumption")
      	SSLKEYLOGFILE=/logs/keys.log FILEPREFIX=/www quic-hq-interop-server 443 /certs/cert.pem /certs/priv.key
         ;;
+    "http3")
+        SSLKEYLOGFILE=/logs/keys.log ossl-nghttp3-demo-server 443 /certs/cert.pem /certs/priv.key
+        ;;
     "chacha20")
         SSL_CIPHER_SUITES=TLS_CHACHA20_POLY1305_SHA256 SSLKEYLOGFILE=/logs/keys.log FILEPREFIX=/www quic-hq-interop-server 443 /certs/cert.pem /certs/priv.key
         ;;


### PR DESCRIPTION
Now that we have an http3 demo server, lets add support for this test into our interop container

The addition of this test incorporates our newly added ossl-nghttp3-demo-server.c code to run as a server instance against all the clients we test against.

- [x] tests are added or updated
