### PR TITLE
Add amplification limit test to interop quic testing

### DIFF
--- a/.github/workflows/run_quic_interop_server.yml
+++ b/.github/workflows/run_quic_interop_server.yml
@@ -10,7 +10,7 @@ jobs:
   run_quic_interop:
     strategy:
       matrix:
-        tests: [http3, transfer, handshake, retry, chacha20, resumption]
+        tests: [http3, transfer, handshake, retry, chacha20, resumption, amplificationlimit]
         servers: [quic-go, ngtcp2, mvfst, quiche, nginx, msquic, haproxy]
         clients: [quic-go, ngtcp2, mvfst, quiche, msquic, openssl]
       fail-fast: false


### PR DESCRIPTION
Because this ci job only runs from the master branch, we need to add the test here to validate that our server respects amplification limits in our ci runs.


##### Checklist
- [x] tests are added or updated
