### PR TITLE
Fix heap-buffer-overflow in ossl_i2c_ASN1_BIT_STRING, when data contains only zero values

### DIFF
--- a/crypto/asn1/a_bitstr.c
+++ b/crypto/asn1/a_bitstr.c
@@ -37,9 +37,9 @@ int ossl_i2c_ASN1_BIT_STRING(ASN1_BIT_STRING *a, unsigned char **pp)
                     break;
             }
 
-            if (len == 0)
+            if (len == 0) {
                 bits = 0;
-            else {
+            } else {
                 j = a->data[len - 1];
                 if (j & 0x01)
                     bits = 0;

--- a/crypto/asn1/a_bitstr.c
+++ b/crypto/asn1/a_bitstr.c
@@ -36,6 +36,10 @@ int ossl_i2c_ASN1_BIT_STRING(ASN1_BIT_STRING *a, unsigned char **pp)
                 if (a->data[len - 1])
                     break;
             }
+
+            if (len == 0)
+                return -1;
+
             j = a->data[len - 1];
             if (j & 0x01)
                 bits = 0;

--- a/crypto/asn1/a_bitstr.c
+++ b/crypto/asn1/a_bitstr.c
@@ -38,27 +38,28 @@ int ossl_i2c_ASN1_BIT_STRING(ASN1_BIT_STRING *a, unsigned char **pp)
             }
 
             if (len == 0)
-                return -1;
-
-            j = a->data[len - 1];
-            if (j & 0x01)
                 bits = 0;
-            else if (j & 0x02)
-                bits = 1;
-            else if (j & 0x04)
-                bits = 2;
-            else if (j & 0x08)
-                bits = 3;
-            else if (j & 0x10)
-                bits = 4;
-            else if (j & 0x20)
-                bits = 5;
-            else if (j & 0x40)
-                bits = 6;
-            else if (j & 0x80)
-                bits = 7;
-            else
-                bits = 0;       /* should not happen */
+            else {
+                j = a->data[len - 1];
+                if (j & 0x01)
+                    bits = 0;
+                else if (j & 0x02)
+                    bits = 1;
+                else if (j & 0x04)
+                    bits = 2;
+                else if (j & 0x08)
+                    bits = 3;
+                else if (j & 0x10)
+                    bits = 4;
+                else if (j & 0x20)
+                    bits = 5;
+                else if (j & 0x40)
+                    bits = 6;
+                else if (j & 0x80)
+                    bits = 7;
+                else
+                    bits = 0;       /* should not happen */
+            }
         }
     } else
         bits = 0;


### PR DESCRIPTION
Fix heap-buffer-overflow in ```ossl_i2c_ASN1_BIT_STRING()``` in ```crypto/asn1/a_bitstr.c```
Issue  #26189

CLA: trivial
