### PR TITLE
IPv6 support for HQ QUIC interop runner

### DIFF
--- a/.github/workflows/run_quic_interop.yml
+++ b/.github/workflows/run_quic_interop.yml
@@ -10,7 +10,7 @@ jobs:
   run_quic_interop:
     strategy:
       matrix:
-        tests: [http3, transfer, handshake, retry, chacha20, resumption, amplificationlimit]
+        tests: [http3, transfer, handshake, retry, chacha20, resumption, amplificationlimit, ipv6]
         servers: [quic-go, ngtcp2, mvfst, quiche, nginx, msquic, haproxy]
       fail-fast: false
     runs-on: ubuntu-latest 

--- a/demos/guide/quic-hq-interop-server.c
+++ b/demos/guide/quic-hq-interop-server.c
@@ -284,11 +284,17 @@ static BIO *create_socket(uint16_t port)
         goto err;
     }
 
-    /* Disable IPV6_V6ONLY to accept both IPv4 and IPv6 */
+    /*
+     * IPv6_V6ONLY is only available on some platforms. If it is defined,
+     * disable it to accept both IPv4 and IPv6 connections. Otherwise, the
+     * server will only accept IPv6 connections.
+     */
+#ifdef IPV6_V6ONLY
     if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &opt, sizeof(opt)) < 0) {
         fprintf(stderr, "setsockopt IPV6_V6ONLY failed");
         goto err;
     }
+#endif
 
     /*
      * Create a new BIO_ADDR

--- a/demos/guide/quic-hq-interop-server.c
+++ b/demos/guide/quic-hq-interop-server.c
@@ -271,9 +271,14 @@ static BIO *create_socket(uint16_t port)
     BIO *sock = NULL;
     BIO_ADDR *addr = NULL;
     int opt = 0;
+#ifdef _WIN32
+    struct in6_addr in6addr_any;
+
+    memset(&in6addr_any, 0, sizeof(in6addr_any));
+#endif
 
     /* Retrieve the file descriptor for a new UDP socket */
-    if ((fd = BIO_socket(AF_INET6, SOCK_DGRAM, 0, 0)) < 0) {
+    if ((fd = BIO_socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP, 0)) < 0) {
         fprintf(stderr, "cannot create socket");
         goto err;
     }

--- a/demos/guide/quic-hq-interop-server.c
+++ b/demos/guide/quic-hq-interop-server.c
@@ -43,6 +43,7 @@
 #ifdef _WIN32
 # include <stdarg.h>
 # include <winsock2.h>
+# include <ws2tcpip.h>
 #else
 # include <sys/socket.h>
 # include <netinet/in.h>

--- a/test/quic-openssl-docker/run_endpoint.sh
+++ b/test/quic-openssl-docker/run_endpoint.sh
@@ -42,43 +42,43 @@ if [ "$ROLE" == "client" ]; then
         SSL_CERT_FILE=/certs/ca.pem curl --config $CURLRC || exit 1
         exit 0
         ;;
-    "handshake"|"transfer"|"retry")
-       HOSTNAME=none
-       for req in $REQUESTS
-       do
-           OUTFILE=$(basename $req)
-           if [ "$HOSTNAME" == "none" ]
-           then
-               HOSTNAME=$(printf "%s\n" "$req" | sed -ne 's,^https://\([^/:]*\).*,\1,p')
-               HOSTPORT=$(printf "%s\n" "$req" | sed -ne 's,^https://[^:/]*:\([^/]*\).*,\1,p')
-           fi
-           echo -n "$OUTFILE " >> ./reqfile.txt
-       done
-       SSLKEYLOGFILE=/logs/keys.log SSL_CERT_FILE=/certs/ca.pem SSL_CERT_DIR=/certs quic-hq-interop $HOSTNAME $HOSTPORT ./reqfile.txt || exit 1
-       exit 0
-       ;; 
+    "handshake"|"transfer"|"retry"|"ipv6")
+        HOSTNAME=none
+        for req in $REQUESTS
+        do
+            OUTFILE=$(basename $req)
+            if [ "$HOSTNAME" == "none" ]
+            then
+                HOSTNAME=$(printf "%s\n" "$req" | sed -ne 's,^https://\([^/:]*\).*,\1,p')
+                HOSTPORT=$(printf "%s\n" "$req" | sed -ne 's,^https://[^:/]*:\([^/]*\).*,\1,p')
+            fi
+            echo -n "$OUTFILE " >> ./reqfile.txt
+        done
+        SSLKEYLOGFILE=/logs/keys.log SSL_CERT_FILE=/certs/ca.pem SSL_CERT_DIR=/certs quic-hq-interop $HOSTNAME $HOSTPORT ./reqfile.txt || exit 1
+        exit 0
+        ;; 
     "resumption")
-       for req in $REQUESTS
-       do
-           OUTFILE=$(basename $req)
-           echo -n "$OUTFILE " > ./reqfile.txt
-           HOSTNAME=$(printf "%s\n" "$req" | sed -ne 's,^https://\([^/:]*\).*,\1,p')
-           HOSTPORT=$(printf "%s\n" "$req" | sed -ne 's,^https://[^:/]*:\([^/]*\).*,\1,p')
-           SSL_SESSION_FILE=./session.db SSLKEYLOGFILE=/logs/keys.log SSL_CERT_FILE=/certs/ca.pem SSL_CERT_DIR=/certs quic-hq-interop $HOSTNAME $HOSTPORT ./reqfile.txt || exit 1
-       done
-       exit 0
-       ;;
+        for req in $REQUESTS
+        do
+            OUTFILE=$(basename $req)
+            echo -n "$OUTFILE " > ./reqfile.txt
+            HOSTNAME=$(printf "%s\n" "$req" | sed -ne 's,^https://\([^/:]*\).*,\1,p')
+            HOSTPORT=$(printf "%s\n" "$req" | sed -ne 's,^https://[^:/]*:\([^/]*\).*,\1,p')
+            SSL_SESSION_FILE=./session.db SSLKEYLOGFILE=/logs/keys.log SSL_CERT_FILE=/certs/ca.pem SSL_CERT_DIR=/certs quic-hq-interop $HOSTNAME $HOSTPORT ./reqfile.txt || exit 1
+        done
+        exit 0
+        ;;
     "chacha20")
-       for req in $REQUESTS
-       do
-           OUTFILE=$(basename $req)
-           printf "%s " "$OUTFILE" >> ./reqfile.txt
-           HOSTNAME=$(printf "%s\n" "$req" | sed -ne 's,^https://\([^/:]*\).*,\1,p')
-           HOSTPORT=$(printf "%s\n" "$req" | sed -ne 's,^https://[^:/]*:\([^/]*\).*,\1,p')
-       done
-       SSL_CIPHER_SUITES=TLS_CHACHA20_POLY1305_SHA256 SSL_SESSION_FILE=./session.db SSLKEYLOGFILE=/logs/keys.log SSL_CERT_FILE=/certs/ca.pem SSL_CERT_DIR=/certs quic-hq-interop $HOSTNAME $HOSTPORT ./reqfile.txt || exit 1
-       exit 0
-       ;; 
+        for req in $REQUESTS
+        do
+            OUTFILE=$(basename $req)
+            printf "%s " "$OUTFILE" >> ./reqfile.txt
+            HOSTNAME=$(printf "%s\n" "$req" | sed -ne 's,^https://\([^/:]*\).*,\1,p')
+            HOSTPORT=$(printf "%s\n" "$req" | sed -ne 's,^https://[^:/]*:\([^/]*\).*,\1,p')
+        done
+        SSL_CIPHER_SUITES=TLS_CHACHA20_POLY1305_SHA256 SSL_SESSION_FILE=./session.db SSLKEYLOGFILE=/logs/keys.log SSL_CERT_FILE=/certs/ca.pem SSL_CERT_DIR=/certs quic-hq-interop $HOSTNAME $HOSTPORT ./reqfile.txt || exit 1
+        exit 0
+        ;; 
     *)
         echo "UNSUPPORTED TESTCASE $TESTCASE"
         exit 127
@@ -88,7 +88,7 @@ elif [ "$ROLE" == "server" ]; then
     echo "TESTCASE is $TESTCASE"
     rm -f $CURLRC 
     case "$TESTCASE" in
-    "handshake"|"transfer")
+    "handshake"|"transfer"|"ipv6")
         NO_ADDR_VALIDATE=yes SSLKEYLOGFILE=/logs/keys.log FILEPREFIX=/www quic-hq-interop-server 443 /certs/cert.pem /certs/priv.key
         ;;
     "retry"|"resumption")


### PR DESCRIPTION
Modify the QUIC HQ interop server and client to support both IPv4 and IPv6.

- The server can accept both IPv4 and IPv6 connections on the same socket. 
- The client no longer requires `-6` and will attempt connecting to the server with `AF_UNSPEC` (i.e. either IPv4 or IPv6).

##### Checklist

- [x] tests are added or updated
