### PR TITLE
Clean up ASN1_STRING comment and improve example in docs

### DIFF
--- a/crypto/asn1/a_strnid.c
+++ b/crypto/asn1/a_strnid.c
@@ -39,10 +39,10 @@ unsigned long ASN1_STRING_get_default_mask(void)
  * This function sets the default to various "flavours" of configuration.
  * based on an ASCII string. Currently this is:
  * MASK:XXXX : a numerical mask value.
- * nobmp : Don't use BMPStrings (just Printable, T61).
- * pkix : PKIX recommendation in RFC2459.
- * utf8only : only use UTF8Strings (RFC2459 recommendation for 2004).
- * default:   the default value, Printable, T61, BMP.
+ * default   : use Printable, IA5, T61, BMP, and UTF8 string types
+ * nombstr   : any string type except variable-sized BMPStrings or UTF8Strings
+ * pkix      : PKIX recommendation in RFC2459
+ * utf8only  : this is the default, use UTF8Strings
  */
 
 int ASN1_STRING_set_default_mask_asc(const char *p)

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -705,7 +705,7 @@ Sample configuration file prompting for field values:
  attributes             = req_attributes
  req_extensions         = v3_ca
 
- dirstring_type = nobmp
+ dirstring_type = nombstr
 
  [ req_distinguished_name ]
  countryName                    = Country Name (2 letter code)


### PR DESCRIPTION
Long ago `nobmp` was replaced with `nombstr` ("no multibyte string"), thus update `ASN1_STRING_set_default_mask_asc()`'s comment section accordingly and update an example in the documentation.

CLA: trivial

##### Checklist
- [x] documentation is added or updated
