### PR TITLE
Fix no_cache provider behavior

### DIFF
--- a/crypto/core_fetch.c
+++ b/crypto/core_fetch.c
@@ -120,7 +120,7 @@ static void ossl_method_construct_this(OSSL_PROVIDER *provider,
      * It is *expected* that the put function increments the refcnt
      * of the passed method.
      */
-    data->mcm->put(data->store, method, provider, algo->algorithm_names,
+    data->mcm->put(no_store ? data->store : NULL, method, provider, algo->algorithm_names,
                    algo->property_definition, data->mcm_data);
 
     /* refcnt-- because we're dropping the reference */

--- a/test/nocache-and-default.cnf
+++ b/test/nocache-and-default.cnf
@@ -1,0 +1,18 @@
+openssl_conf = openssl_init
+
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+test    = test_sect
+default = default_sect
+
+[test_sect]
+module = ../test/p_test.so
+activate = true
+
+[default_sect]
+activate = true

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -230,12 +230,21 @@ static const OSSL_ITEM *p_get_reason_strings(void *_)
     return reason_strings;
 }
 
+static const OSSL_ALGORITHM *p_query(OSSL_PROVIDER *prov,
+                                     int operation_id,
+                                     int *no_cache)
+{
+    *no_cache = 1;
+    return NULL;
+}
+
 static const OSSL_DISPATCH p_test_table[] = {
     { OSSL_FUNC_PROVIDER_GETTABLE_PARAMS, (void (*)(void))p_gettable_params },
     { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))p_get_params },
     { OSSL_FUNC_PROVIDER_GET_REASON_STRINGS,
         (void (*)(void))p_get_reason_strings},
     { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))p_teardown },
+    { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))p_query },
     OSSL_DISPATCH_END
 };
 

--- a/test/recipes/20-test_nocache.t
+++ b/test/recipes/20-test_nocache.t
@@ -1,0 +1,34 @@
+#! /usr/bin/env perl
+# Copyright 2016-2024 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use OpenSSL::Test qw/:DEFAULT bldtop_file srctop_file bldtop_dir with/;
+use OpenSSL::Test::Utils;
+
+setup("test_nocache");
+
+plan tests => 4;
+
+ok(run(app(["openssl", "list", "-mac-algorithms"],
+        stdout => "listout.txt")),
+"List mac algorithms - default configuration");
+open DATA, "listout.txt";
+my @match = grep /MAC/, <DATA>;
+close DATA;
+ok(scalar @match > 1 ? 1 : 0, "Several algorithms are listed - default configuration");
+
+$ENV{OPENSSL_CONF} = bldtop_file("test", "nocache-and-default.cnf");
+ok(run(app(["openssl", "list", "-mac-algorithms"],
+        stdout => "listout.txt")),
+"List mac algorithms");
+open DATA, "listout.txt";
+my @match = grep /MAC/, <DATA>;
+close DATA;
+ok(scalar @match > 1 ? 1 : 0, "Several algorithms are listed - nocache-and-default");


### PR DESCRIPTION
As we agreed today, this is a follow-up OpenSSL-only test to #26038 
Update: also the fix

Fixes: #26038

This tests modifies a NULL provider so it returns *no_cache equal to 1.
Surprisingly no other tests seem to fail.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

@levitte if you have any clues what could go wrong it would be great

CC @simo5 