### PR TITLE
Allow for short reads in quic hq-interop server

### DIFF
--- a/demos/guide/quic-hq-interop-server.c
+++ b/demos/guide/quic-hq-interop-server.c
@@ -333,19 +333,19 @@ err:
 }
 
 /**
- * @brief Handles I/O failures on an SSL connection based on the result code.
+ * @brief Handles I/O failures on an SSL stream based on the result code.
  *
  * This function processes the result of an SSL I/O operation and handles
  * different types of errors that may occur during the operation. It takes
  * appropriate actions such as retrying the operation, reporting errors, or
  * returning specific status codes based on the error type.
  *
- * @param ssl A pointer to the SSL object representing the connection.
+ * @param ssl A pointer to the SSL object representing the stream.
  * @param res The result code from the SSL I/O operation.
  * @return An integer indicating the outcome:
  *         - 1: Temporary failure, the operation should be retried.
- *         - 0: EOF, indicating the connection has been closed.
- *         - -1: A fatal error occurred or the connection has been reset.
+ *         - 0: EOF, indicating the stream has been closed.
+ *         - -1: A fatal error occurred or the stream has been reset.
  *
  *
  * @note If the failure is due to an SSL verification error, additional

--- a/demos/guide/quic-hq-interop-server.c
+++ b/demos/guide/quic-hq-interop-server.c
@@ -394,7 +394,7 @@ static int handle_io_failure(SSL *ssl, int res)
          * information about it from SSL_get_verify_result().
          */
         if (SSL_get_verify_result(ssl) != X509_V_OK)
-        fprintf(stderr, "Verify error: %s\n",
+            fprintf(stderr, "Verify error: %s\n",
                     X509_verify_cert_error_string(SSL_get_verify_result(ssl)));
         return -1;
 
@@ -466,7 +466,7 @@ static void process_new_stream(SSL *stream)
                 break;
             } else {
                 /* permanent failure, abort */
-                fprintf(stderr, "Failure on stream %lu\n", SSL_get_stream_id(stream));
+                fprintf(stderr, "Failure on stream\n");
                 return;
             }
         }

--- a/demos/guide/quic-hq-interop-server.c
+++ b/demos/guide/quic-hq-interop-server.c
@@ -333,6 +333,77 @@ err:
 }
 
 /**
+ * @brief Handles I/O failures on an SSL connection based on the result code.
+ *
+ * This function processes the result of an SSL I/O operation and handles
+ * different types of errors that may occur during the operation. It takes
+ * appropriate actions such as retrying the operation, reporting errors, or
+ * returning specific status codes based on the error type.
+ *
+ * @param ssl A pointer to the SSL object representing the connection.
+ * @param res The result code from the SSL I/O operation.
+ * @return An integer indicating the outcome:
+ *         - 1: Temporary failure, the operation should be retried.
+ *         - 0: EOF, indicating the connection has been closed.
+ *         - -1: A fatal error occurred or the connection has been reset.
+ *
+ *
+ * @note If the failure is due to an SSL verification error, additional
+ * information will be logged to stderr.
+ */
+static int handle_io_failure(SSL *ssl, int res)
+{
+    switch (SSL_get_error(ssl, res)) {
+    case SSL_ERROR_WANT_READ:
+    case SSL_ERROR_WANT_WRITE:
+        return 1;
+
+    case SSL_ERROR_ZERO_RETURN:
+        /* EOF */
+        return 0;
+
+    case SSL_ERROR_SYSCALL:
+        return -1;
+
+    case SSL_ERROR_SSL:
+        /*
+         * Some stream fatal error occurred. This could be because of a
+         * stream reset - or some failure occurred on the underlying
+         * connection.
+         */
+        switch (SSL_get_stream_read_state(ssl)) {
+        case SSL_STREAM_STATE_RESET_REMOTE:
+            fprintf(stderr, "Stream reset occurred\n");
+            /*
+             * The stream has been reset but the connection is still
+             * healthy.
+             */
+            break;
+
+        case SSL_STREAM_STATE_CONN_CLOSED:
+            fprintf(stderr, "Connection closed\n");
+            /* Connection is already closed. */
+            break;
+
+        default:
+            fprintf(stderr, "Unknown stream failure\n");
+            break;
+        }
+        /*
+         * If the failure is due to a verification error we can get more
+         * information about it from SSL_get_verify_result().
+         */
+        if (SSL_get_verify_result(ssl) != X509_V_OK)
+        fprintf(stderr, "Verify error: %s\n",
+                    X509_verify_cert_error_string(SSL_get_verify_result(ssl)));
+        return -1;
+
+    default:
+        return -1;
+    }
+}
+
+/**
  * @brief Processes a new incoming QUIC stream for an HTTP/0.9 GET request.
  *
  * This function reads an HTTP/0.9 GET request from the provided QUIC stream,
@@ -375,10 +446,31 @@ static void process_new_stream(SSL *stream)
     size_t bytes_written = 0;
     size_t offset = 0;
     int rc;
+    int ret;
+    size_t total_read = 0;
 
     memset(buf, 0, BUF_SIZE);
-    if (SSL_read_ex(stream, buf, sizeof(buf) - 1, &nread) <= 0)
-        return;
+    for (;;) {
+        nread = 0;
+        ret = SSL_read_ex(stream, &buf[total_read],
+                          sizeof(buf) - total_read - 1, &nread);
+        total_read += nread;
+        if (ret <= 0) {
+            ret = handle_io_failure(stream, ret);
+            if (ret >= 1) {
+                /* Transient failure, retry */
+                fprintf(stderr, "Transient read failure, retrying\n");
+                continue;
+            } else if (ret == 0) {
+                /* EOF condition, fin bit set, we got the whole request */
+                break;
+            } else {
+                /* permanent failure, abort */
+                fprintf(stderr, "Failure on stream %lu\n", SSL_get_stream_id(stream));
+                return;
+            }
+        }
+    }
 
     /* We should have a valid http 0.9 GET request here */
     fprintf(stderr, "Request is %s\n", req);

--- a/demos/guide/quic-hq-interop-server.c
+++ b/demos/guide/quic-hq-interop-server.c
@@ -354,10 +354,6 @@ err:
 static int handle_io_failure(SSL *ssl, int res)
 {
     switch (SSL_get_error(ssl, res)) {
-    case SSL_ERROR_WANT_READ:
-    case SSL_ERROR_WANT_WRITE:
-        return 1;
-
     case SSL_ERROR_ZERO_RETURN:
         /* EOF */
         return 0;
@@ -459,7 +455,6 @@ static void process_new_stream(SSL *stream)
             ret = handle_io_failure(stream, ret);
             if (ret >= 1) {
                 /* Transient failure, retry */
-                fprintf(stderr, "Transient read failure, retrying\n");
                 continue;
             } else if (ret == 0) {
                 /* EOF condition, fin bit set, we got the whole request */

--- a/demos/guide/quic-hq-interop-server.c
+++ b/demos/guide/quic-hq-interop-server.c
@@ -343,7 +343,6 @@ err:
  * @param ssl A pointer to the SSL object representing the stream.
  * @param res The result code from the SSL I/O operation.
  * @return An integer indicating the outcome:
- *         - 1: Temporary failure, the operation should be retried.
  *         - 0: EOF, indicating the stream has been closed.
  *         - -1: A fatal error occurred or the stream has been reset.
  *
@@ -453,10 +452,7 @@ static void process_new_stream(SSL *stream)
         total_read += nread;
         if (ret <= 0) {
             ret = handle_io_failure(stream, ret);
-            if (ret >= 1) {
-                /* Transient failure, retry */
-                continue;
-            } else if (ret == 0) {
+            if (ret == 0) {
                 /* EOF condition, fin bit set, we got the whole request */
                 break;
             } else {

--- a/test/quic-openssl-docker/run_endpoint.sh
+++ b/test/quic-openssl-docker/run_endpoint.sh
@@ -88,10 +88,7 @@ elif [ "$ROLE" == "server" ]; then
     echo "TESTCASE is $TESTCASE"
     rm -f $CURLRC 
     case "$TESTCASE" in
-    "handshake")
-        NO_ADDR_VALIDATE=yes SSLKEYLOGFILE=/logs/keys.log FILEPREFIX=/www quic-hq-interop-server 443 /certs/cert.pem /certs/priv.key
-        ;;
-    "transfer")
+    "handshake"|"transfer")
         NO_ADDR_VALIDATE=yes SSLKEYLOGFILE=/logs/keys.log FILEPREFIX=/www quic-hq-interop-server 443 /certs/cert.pem /certs/priv.key
         ;;
     "retry"|"resumption")


### PR DESCRIPTION
The multiplexing test with quic-hq-interop server is failing due to its inability to handle short reads.  augment the server code to allow for the possibility of getting a short read on an http request when a quic stream packet is split between two datagrams

##### Checklist
- [x] tests are added or updated
