### PR TITLE
test/tls-provider.c: Remove redundant return statement

### DIFF
--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -783,7 +783,6 @@ static void *xor_dup(const void *vfromkey, int selection)
         xor_freekey(tokey);
         tokey = NULL;
     }
-    return tokey;
 }
 
 static ossl_inline int xor_get_params(void *vkey, OSSL_PARAM params[])


### PR DESCRIPTION
Remove redundant return statement since the type of xor_dup is void.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
