### PR TITLE
After openssl is upgraded facing __GNUC__ safe_math.h not found issue

### DIFF
--- a/include/internal/safe_math.h
+++ b/include/internal/safe_math.h
@@ -16,8 +16,10 @@
 # ifndef OPENSSL_NO_BUILTIN_OVERFLOW_CHECKING
 #  ifdef __has_builtin
 #   define has(func) __has_builtin(func)
-#  elif __GNUC__ > 5
-#   define has(func) 1
+#  elif defined(__GNUC__)
+#   if __GNUC__ > 5
+#    define has(func) 1
+#   endif
 #  endif
 # endif /* OPENSSL_NO_BUILTIN_OVERFLOW_CHECKING */
 


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=4880

Facing the below issue after openssl is upgraded

Edk2\CryptoPkg\Library\OpensslLib\openssl\include\internal/safe_math.h(19): warning C4668: '__GNUC__' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'

CLA: trivial

Reviewed-by: Gerd Hoffmann <kraxel@redhat.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
