### PR TITLE
Free data if sk_OPENSSL_STRING_push fails.

### DIFF
--- a/crypto/x509/by_store.c
+++ b/crypto/x509/by_store.c
@@ -122,7 +122,7 @@ static int by_store_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argp,
                 uris = sk_OPENSSL_STRING_new_null();
                 X509_LOOKUP_set_method_data(ctx, uris);
             }
-            if (!sk_OPENSSL_STRING_push(uris, data)) {
+            if (sk_OPENSSL_STRING_push(uris, data) <= 0) {
                 OPENSSL_free(data);
                 return 0;
             }

--- a/crypto/x509/by_store.c
+++ b/crypto/x509/by_store.c
@@ -122,7 +122,11 @@ static int by_store_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argp,
                 uris = sk_OPENSSL_STRING_new_null();
                 X509_LOOKUP_set_method_data(ctx, uris);
             }
-            return sk_OPENSSL_STRING_push(uris, data) > 0;
+            if (!sk_OPENSSL_STRING_push(uris, data)) {
+                OPENSSL_free(data);
+                return 0;
+            }
+            return 1;
         }
         /* NOP if no URI is given. */
         return 1;

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -202,7 +202,13 @@ static int ctrladd(STACK_OF(OPENSSL_STRING) *controls, const char *value)
 
     if (data == NULL)
         return -1;
-    return sk_OPENSSL_STRING_push(controls, data) > 0;
+
+    if (!sk_OPENSSL_STRING_push(controls, data)) {
+        OPENSSL_free(data);
+        return -1;
+    }
+
+    return 1;
 }
 
 /* Because OPENSSL_free is a macro, it can't be passed as a function pointer */

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -203,7 +203,7 @@ static int ctrladd(STACK_OF(OPENSSL_STRING) *controls, const char *value)
     if (data == NULL)
         return -1;
 
-    if (!sk_OPENSSL_STRING_push(controls, data)) {
+    if (sk_OPENSSL_STRING_push(controls, data) <= 0) {
         OPENSSL_free(data);
         return -1;
     }


### PR DESCRIPTION
Fixes #26203

Checked additional calls to sk_OPENSSL_STRING_push() and found another case. A reviewer could do the same task and verify that I didn't miss another case.