### PR TITLE
Fix `do_server()` socket from remaining open after `naccept` is supposed to reach `0`

### DIFF
--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -411,6 +411,12 @@ int do_server(int *accept_sock, const char *host, const char *port,
                 BIO_closesocket(asock);
                 break;
             }
+
+            if (naccept != -1)
+                naccept--;
+            if (naccept == 0)
+                BIO_closesocket(asock);
+
             BIO_set_tcp_ndelay(sock, 1);
             i = (*cb)(sock, type, protocol, context);
 
@@ -441,11 +447,12 @@ int do_server(int *accept_sock, const char *host, const char *port,
 
             BIO_closesocket(sock);
         } else {
+            if (naccept != -1)
+                naccept--;
+
             i = (*cb)(asock, type, protocol, context);
         }
 
-        if (naccept != -1)
-            naccept--;
         if (i < 0 || naccept == 0) {
             BIO_closesocket(asock);
             ret = i;


### PR DESCRIPTION
When `-naccept` is passed to `s_server`, the listening socket remains open while handling clients, even after `naccept` is supposed to reach `0`.

This is caused to to the decrementation of `naccept` and closing of the socket happening a little too late in the `do_server` function.

This causes a weird behaviour where clients can still connect to the server, but will never be handled (instead of just getting rejected by the OS).

Fixes https://github.com/openssl/openssl/issues/26229.