### PR TITLE
core_namemap.c: Use OPENSSL_STRING instead of defining STRING type

### DIFF
--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -24,10 +24,8 @@ HT_END_KEY_DEFN(NAMENUM_KEY)
  * ==================
  */
 
-typedef char STRING;
-typedef STACK_OF(STRING) NAMES;
+typedef STACK_OF(OPENSSL_STRING) NAMES;
 
-DEFINE_STACK_OF(STRING)
 DEFINE_STACK_OF(NAMES)
 
 struct ossl_namemap_st {
@@ -49,7 +47,7 @@ static void name_string_free(char *name)
 
 static void names_free(NAMES *n)
 {
-    sk_STRING_pop_free(n, name_string_free);
+    sk_OPENSSL_STRING_pop_free(n, name_string_free);
 }
 
 /* OSSL_LIB_CTX_METHOD functions for a namemap stored in a library context */
@@ -125,17 +123,17 @@ int ossl_namemap_doall_names(const OSSL_NAMEMAP *namemap, int number,
 
     names = sk_NAMES_value(namemap->numnames, number - 1);
     if (names != NULL)
-        names = sk_STRING_dup(names);
+        names = sk_OPENSSL_STRING_dup(names);
 
     CRYPTO_THREAD_unlock(namemap->lock);
 
     if (names == NULL)
         return 0;
 
-    for (i = 0; i < sk_STRING_num(names); i++)
-        fn(sk_STRING_value(names, i), data);
+    for (i = 0; i < sk_OPENSSL_STRING_num(names); i++)
+        fn(sk_OPENSSL_STRING_value(names, i), data);
 
-    sk_STRING_free(names);
+    sk_OPENSSL_STRING_free(names);
     return i > 0;
 }
 
@@ -194,7 +192,7 @@ const char *ossl_namemap_num2name(const OSSL_NAMEMAP *namemap, int number,
 
     names = sk_NAMES_value(namemap->numnames, number - 1);
     if (names != NULL)
-        ret = sk_STRING_value(names, idx);
+        ret = sk_OPENSSL_STRING_value(names, idx);
 
     CRYPTO_THREAD_unlock(namemap->lock);
 
@@ -216,7 +214,7 @@ static int numname_insert(OSSL_NAMEMAP *namemap, int number,
         }
     } else {
         /* a completely new entry */
-        names = sk_STRING_new_null();
+        names = sk_OPENSSL_STRING_new_null();
         if (names == NULL)
             return 0;
     }
@@ -224,8 +222,9 @@ static int numname_insert(OSSL_NAMEMAP *namemap, int number,
     if ((tmpname = OPENSSL_strdup(name)) == NULL)
         goto err;
 
-    if (!sk_STRING_push(names, tmpname))
+    if (!sk_OPENSSL_STRING_push(names, tmpname))
         goto err;
+    tmpname = NULL;
 
     if (number <= 0) {
         if (!sk_NAMES_push(namemap->numnames, names))
@@ -236,7 +235,7 @@ static int numname_insert(OSSL_NAMEMAP *namemap, int number,
 
  err:
     if (number <= 0)
-        sk_STRING_free(names);
+        sk_OPENSSL_STRING_pop_free(names, name_string_free);
     OPENSSL_free(tmpname);
     return 0;
 }


### PR DESCRIPTION
Also avoid leak if stack push fails.
