### PR TITLE
Check returns of sk_X509_CRL_push and handle appropriately.

### DIFF
--- a/apps/crl2pkcs7.c
+++ b/apps/crl2pkcs7.c
@@ -135,10 +135,10 @@ int crl2pkcs7_main(int argc, char **argv)
         goto end;
 
     if (crl != NULL) {
-        if ((crl_stack = sk_X509_CRL_new_null()) == NULL)
+        if ((crl_stack = sk_X509_CRL_new_null()) == NULL
+            || !sk_X509_CRL_push(crl_stack, crl))
             goto end;
         p7s->crl = crl_stack;
-        sk_X509_CRL_push(crl_stack, crl);
         crl = NULL;             /* now part of p7 for OPENSSL_freeing */
     }
 

--- a/apps/crl2pkcs7.c
+++ b/apps/crl2pkcs7.c
@@ -135,10 +135,12 @@ int crl2pkcs7_main(int argc, char **argv)
         goto end;
 
     if (crl != NULL) {
-        if ((crl_stack = sk_X509_CRL_new_null()) == NULL
-            || !sk_X509_CRL_push(crl_stack, crl))
+        if ((crl_stack = sk_X509_CRL_new_null()) == NULL)
             goto end;
         p7s->crl = crl_stack;
+
+        if (!sk_X509_CRL_push(crl_stack, crl))
+            goto end;
         crl = NULL;             /* now part of p7 for OPENSSL_freeing */
     }
 

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2515,18 +2515,23 @@ static STACK_OF(X509_CRL) *crls_http_cb(const X509_STORE_CTX *ctx,
     crldp = X509_get_ext_d2i(x, NID_crl_distribution_points, NULL, NULL);
     crl = load_crl_crldp(crldp);
     sk_DIST_POINT_pop_free(crldp, DIST_POINT_free);
-    if (!crl) {
-        sk_X509_CRL_free(crls);
-        return NULL;
-    }
-    sk_X509_CRL_push(crls, crl);
+
+    if (!crl || !sk_X509_CRL_push(crls, crl))
+        goto error;
+
     /* Try to download delta CRL */
     crldp = X509_get_ext_d2i(x, NID_freshest_crl, NULL, NULL);
     crl = load_crl_crldp(crldp);
     sk_DIST_POINT_pop_free(crldp, DIST_POINT_free);
-    if (crl)
-        sk_X509_CRL_push(crls, crl);
+
+    if (crl && !sk_X509_CRL_push(crls, crl))
+        goto error;
+
     return crls;
+
+error:
+    sk_X509_CRL_free(crls);
+    return NULL;
 }
 
 void store_setup_crl_download(X509_STORE *st)

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2516,7 +2516,7 @@ static STACK_OF(X509_CRL) *crls_http_cb(const X509_STORE_CTX *ctx,
     crl = load_crl_crldp(crldp);
     sk_DIST_POINT_pop_free(crldp, DIST_POINT_free);
 
-    if (!crl || !sk_X509_CRL_push(crls, crl))
+    if (crl == NULL || !sk_X509_CRL_push(crls, crl))
         goto error;
 
     /* Try to download delta CRL */
@@ -2524,12 +2524,13 @@ static STACK_OF(X509_CRL) *crls_http_cb(const X509_STORE_CTX *ctx,
     crl = load_crl_crldp(crldp);
     sk_DIST_POINT_pop_free(crldp, DIST_POINT_free);
 
-    if (crl && !sk_X509_CRL_push(crls, crl))
+    if (crl != NULL && !sk_X509_CRL_push(crls, crl))
         goto error;
 
     return crls;
 
 error:
+    X509_CRL_free(crl);
     sk_X509_CRL_free(crls);
     return NULL;
 }

--- a/crypto/cmp/cmp_asn.c
+++ b/crypto/cmp/cmp_asn.c
@@ -800,6 +800,7 @@ OSSL_CMP_ITAV *OSSL_CMP_ITAV_new_crls(const X509_CRL *crl)
                 || (crl_copy = X509_CRL_dup(crl)) == NULL
                 || !sk_X509_CRL_push(crls, crl_copy))
             goto err;
+        crl_copy = NULL; /* ownership transferred to crls */
     }
 
     itav->infoType = OBJ_nid2obj(NID_id_it_crls);

--- a/crypto/cmp/cmp_asn.c
+++ b/crypto/cmp/cmp_asn.c
@@ -797,9 +797,9 @@ OSSL_CMP_ITAV *OSSL_CMP_ITAV_new_crls(const X509_CRL *crl)
 
     if (crl != NULL) {
         if ((crls = sk_X509_CRL_new_reserve(NULL, 1)) == NULL
-                || (crl_copy = X509_CRL_dup(crl)) == NULL)
+                || (crl_copy = X509_CRL_dup(crl)) == NULL
+                || !sk_X509_CRL_push(crls, crl_copy))
             goto err;
-        (void)sk_X509_CRL_push(crls, crl_copy); /* cannot fail */
     }
 
     itav->infoType = OBJ_nid2obj(NID_id_it_crls);
@@ -807,6 +807,7 @@ OSSL_CMP_ITAV *OSSL_CMP_ITAV_new_crls(const X509_CRL *crl)
     return itav;
 
  err:
+    OPENSSL_free(crl_copy);
     sk_X509_CRL_free(crls);
     OSSL_CMP_ITAV_free(itav);
     return NULL;

--- a/fuzz/x509.c
+++ b/fuzz/x509.c
@@ -98,10 +98,10 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
 
     if (crl != NULL) {
         crls = sk_X509_CRL_new_null();
-        if (crls == NULL)
+        if (crls == NULL
+            || !sk_X509_CRL_push(crls, crl))
             goto err;
 
-        sk_X509_CRL_push(crls, crl);
         X509_STORE_CTX_set0_crls(ctx, crls);
     }
 

--- a/test/crltest.c
+++ b/test/crltest.c
@@ -302,11 +302,12 @@ static STACK_OF(X509_CRL) *make_CRL_stack(X509_CRL *x1, X509_CRL *x2)
 {
     STACK_OF(X509_CRL) *sk = sk_X509_CRL_new_null();
 
-    if (x1 != NULL && sk_X509_CRL_push(sk, x1))
-        X509_CRL_up_ref(x1);
-    if (x2 != NULL && sk_X509_CRL_push(sk, x2))
+    sk_X509_CRL_push(sk, x1);
+    X509_CRL_up_ref(x1);
+    if (x2 != NULL) {
+        sk_X509_CRL_push(sk, x2);
         X509_CRL_up_ref(x2);
-
+    }
     return sk;
 }
 

--- a/test/crltest.c
+++ b/test/crltest.c
@@ -302,12 +302,11 @@ static STACK_OF(X509_CRL) *make_CRL_stack(X509_CRL *x1, X509_CRL *x2)
 {
     STACK_OF(X509_CRL) *sk = sk_X509_CRL_new_null();
 
-    sk_X509_CRL_push(sk, x1);
-    X509_CRL_up_ref(x1);
-    if (x2 != NULL) {
-        sk_X509_CRL_push(sk, x2);
+    if (x1 != NULL && sk_X509_CRL_push(sk, x1))
+        X509_CRL_up_ref(x1);
+    if (x2 != NULL && sk_X509_CRL_push(sk, x2))
         X509_CRL_up_ref(x2);
-    }
+
     return sk;
 }
 


### PR DESCRIPTION
Related to #26227. There are `sk_X509_CRL_push()` return values that aren't checked.