### PR TITLE
Free memory when realloc fails in ossl_property_merge() and check realloc result in demo code

### DIFF
--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -541,7 +541,7 @@ OSSL_PROPERTY_LIST *ossl_property_merge(const OSSL_PROPERTY_LIST *a,
     const OSSL_PROPERTY_DEFINITION *const ap = a->properties;
     const OSSL_PROPERTY_DEFINITION *const bp = b->properties;
     const OSSL_PROPERTY_DEFINITION *copy;
-    OSSL_PROPERTY_LIST *r;
+    OSSL_PROPERTY_LIST *r, *rtmp;
     int i, j, n;
     const int t = a->num_properties + b->num_properties;
 
@@ -567,8 +567,12 @@ OSSL_PROPERTY_LIST *ossl_property_merge(const OSSL_PROPERTY_LIST *a,
         r->has_optional |= copy->optional;
     }
     r->num_properties = n;
-    if (n != t)
-        r = OPENSSL_realloc(r, sizeof(*r) + (n - 1) * sizeof(r->properties[0]));
+    if (n != t) {
+        rtmp = OPENSSL_realloc(r, sizeof(*r) + (n - 1) * sizeof(r->properties[0]));
+        if (rtmp == NULL)
+            OPENSSL_free(r);
+        r = rtmp;
+    }
     return r;
 }
 

--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -541,7 +541,7 @@ OSSL_PROPERTY_LIST *ossl_property_merge(const OSSL_PROPERTY_LIST *a,
     const OSSL_PROPERTY_DEFINITION *const ap = a->properties;
     const OSSL_PROPERTY_DEFINITION *const bp = b->properties;
     const OSSL_PROPERTY_DEFINITION *copy;
-    OSSL_PROPERTY_LIST *r, *rtmp;
+    OSSL_PROPERTY_LIST *r;
     int i, j, n;
     const int t = a->num_properties + b->num_properties;
 
@@ -567,12 +567,7 @@ OSSL_PROPERTY_LIST *ossl_property_merge(const OSSL_PROPERTY_LIST *a,
         r->has_optional |= copy->optional;
     }
     r->num_properties = n;
-    if (n != t) {
-        rtmp = OPENSSL_realloc(r, sizeof(*r) + (n - 1) * sizeof(r->properties[0]));
-        if (rtmp == NULL)
-            OPENSSL_free(r);
-        r = rtmp;
-    }
+
     return r;
 }
 

--- a/demos/guide/quic-hq-interop.c
+++ b/demos/guide/quic-hq-interop.c
@@ -911,6 +911,8 @@ int main(int argc, char *argv[])
     while (req != NULL) {
         total_requests++;
         req_array = OPENSSL_realloc(req_array, sizeof(char *) * total_requests);
+        if (req_array == NULL)
+            goto end;
         req_array[total_requests - 1] = req;
         req = strtok(NULL, " ");
     }


### PR DESCRIPTION
I went through the master code for uses of OPENSSL-realloc to spot if there are places where the result is not checked. I found these two cases.