### PR TITLE
check CRYPTO_atomic_add return value.

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1111,7 +1111,9 @@ static int provider_deactivate(OSSL_PROVIDER *prov, int upcalls,
         return -1;
     }
 
-    CRYPTO_atomic_add(&prov->activatecnt, -1, &count, prov->activatecnt_lock);
+    if (!CRYPTO_atomic_add(&prov->activatecnt, -1, &count, prov->activatecnt_lock))
+        return -1;
+
 #ifndef FIPS_MODULE
     if (count >= 1 && prov->ischild && upcalls) {
         /*


### PR DESCRIPTION
Checking` CRYPTO_atomic_add` return value, because it can fail on `CRYPTO_THREAD_unlock`. Althgough not quite sure if there are other things that need to be done if `CRYPTO_atomic_add` fails other than just `return -1`.


Found by Linux Verification Center (linuxtesting.org) with SVACE.