### PR TITLE
fix read out of buffer bounds when dealing with BIO_ADDR

### DIFF
--- a/crypto/bio/bio_addr.c
+++ b/crypto/bio/bio_addr.c
@@ -104,6 +104,7 @@ void BIO_ADDR_clear(BIO_ADDR *ap)
  */
 int BIO_ADDR_make(BIO_ADDR *ap, const struct sockaddr *sa)
 {
+    memset(ap, 0, sizeof(BIO_ADDR));
     if (sa->sa_family == AF_INET) {
         memcpy(&(ap->s_in), sa, sizeof(struct sockaddr_in));
         return 1;

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -474,8 +474,7 @@ int ossl_quic_channel_get_peer_addr(QUIC_CHANNEL *ch, BIO_ADDR *peer_addr)
     if (!ch->addressed_mode)
         return 0;
 
-    *peer_addr = ch->cur_peer_addr;
-    return 1;
+    return BIO_ADDR_copy(peer_addr, &ch->cur_peer_addr);
 }
 
 int ossl_quic_channel_set_peer_addr(QUIC_CHANNEL *ch, const BIO_ADDR *peer_addr)
@@ -489,8 +488,11 @@ int ossl_quic_channel_set_peer_addr(QUIC_CHANNEL *ch, const BIO_ADDR *peer_addr)
         return 1;
     }
 
-    ch->cur_peer_addr   = *peer_addr;
-    ch->addressed_mode  = 1;
+    if (!BIO_ADDR_copy(&ch->cur_peer_addr, peer_addr)) {
+        ch->addressed_mode = 0;
+        return 0;
+    }
+
     return 1;
 }
 
@@ -3344,7 +3346,9 @@ int ossl_quic_channel_on_new_conn(QUIC_CHANNEL *ch, const BIO_ADDR *peer,
         return 0;
 
     /* Note our newly learnt peer address and CIDs. */
-    ch->cur_peer_addr   = *peer;
+    if (!BIO_ADDR_copy(&ch->cur_peer_addr, peer))
+        return 0;
+
     ch->init_dcid       = *peer_dcid;
     ch->cur_remote_dcid = *peer_scid;
 

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -492,6 +492,7 @@ int ossl_quic_channel_set_peer_addr(QUIC_CHANNEL *ch, const BIO_ADDR *peer_addr)
         ch->addressed_mode = 0;
         return 0;
     }
+    ch->addressed_mode = 1;
 
     return 1;
 }

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -1026,8 +1026,7 @@ int ossl_quic_conn_set_initial_peer_addr(SSL *s,
         return 1;
     }
 
-    ctx.qc->init_peer_addr = *peer_addr;
-    return 1;
+    return BIO_ADDR_copy(&ctx.qc->init_peer_addr, peer_addr);
 }
 
 /*

--- a/ssl/quic/quic_record_tx.c
+++ b/ssl/quic/quic_record_tx.c
@@ -842,15 +842,19 @@ int ossl_qtx_write_pkt(OSSL_QTX *qtx, const OSSL_QTX_PKT *pkt)
 
         if (!was_coalescing) {
             /* Set addresses in TXE. */
-            if (pkt->peer != NULL)
-                BIO_ADDR_copy(&txe->peer, pkt->peer);
-            else
+            if (pkt->peer != NULL) {
+                if (!BIO_ADDR_copy(&txe->peer, pkt->peer))
+                    return 0;
+            } else {
                 BIO_ADDR_clear(&txe->peer);
+            }
 
-            if (pkt->local != NULL)
-                BIO_ADDR_copy(&txe->local, pkt->local);
-            else
+            if (pkt->local != NULL) {
+                if (!BIO_ADDR_copy(&txe->local, pkt->local))
+                    return 0;
+            } else {
                 BIO_ADDR_clear(&txe->local);
+            }
         }
 
         ret = qtx_mutate_write(qtx, pkt, txe, enc_level);

--- a/ssl/quic/quic_record_tx.c
+++ b/ssl/quic/quic_record_tx.c
@@ -843,12 +843,12 @@ int ossl_qtx_write_pkt(OSSL_QTX *qtx, const OSSL_QTX_PKT *pkt)
         if (!was_coalescing) {
             /* Set addresses in TXE. */
             if (pkt->peer != NULL)
-                txe->peer = *pkt->peer;
+                BIO_ADDR_copy(&txe->peer, pkt->peer);
             else
                 BIO_ADDR_clear(&txe->peer);
 
             if (pkt->local != NULL)
-                txe->local = *pkt->local;
+                BIO_ADDR_copy(&txe->local, pkt->local);
             else
                 BIO_ADDR_clear(&txe->local);
         }

--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -613,8 +613,7 @@ int ossl_quic_tx_packetiser_set_peer(OSSL_QUIC_TX_PACKETISER *txp,
         return 1;
     }
 
-    txp->args.peer = *peer;
-    return 1;
+    return BIO_ADDR_copy(&txp->args.peer, peer);
 }
 
 void ossl_quic_tx_packetiser_set_ack_tx_cb(OSSL_QUIC_TX_PACKETISER *txp,

--- a/test/recipes/75-test_quicapi_data/ssltraceref.txt
+++ b/test/recipes/75-test_quicapi_data/ssltraceref.txt
@@ -297,6 +297,4 @@ Sent Packet
   Payload length: 60
   Packet Number: 0x00000000
 Sent Datagram
-  Length: 1119
-Sent Datagram
-  Length: 81
+  Length: 1200

--- a/test/recipes/75-test_quicapi_data/ssltraceref.txt
+++ b/test/recipes/75-test_quicapi_data/ssltraceref.txt
@@ -297,4 +297,6 @@ Sent Packet
   Payload length: 60
   Packet Number: 0x00000000
 Sent Datagram
-  Length: 1200
+  Length: 1119
+Sent Datagram
+  Length: 81


### PR DESCRIPTION
This issue was discoevered while I was testing SSL_new_from_listener() using a newly created unit test. It has turned out the QUIC stack at few places contain pattern as follows:
	foo(QUIC_WHATEVER *q, BIO_ADDR *a)
	{
	   q->a = *a;
	}

The problem is that derefencning a that way is risky. If the address `a` comes from BIO_lookup_ex() it may actually be shorter than sizeof(BIO_ADDR). Using BIO_ADDR_copy() is the right thing to do here.

Fixes: #26241
