### PR TITLE
`ec_kem`: `ikmlen` check

### DIFF
--- a/providers/implementations/kem/ec_kem.c
+++ b/providers/implementations/kem/ec_kem.c
@@ -405,10 +405,10 @@ int ossl_ec_dhkem_derive_private(EC_KEY *ec, BIGNUM *priv,
         return 0;
 
     /* ikmlen should have a length of at least Nsk */
-    if (ikmlen < info->Nsecret) {
+    if (ikmlen < info->Nsk) {
         ERR_raise_data(ERR_LIB_PROV, PROV_R_INVALID_INPUT_LENGTH,
                        "ikm length is :%zu, should be at least %zu",
-                       ikmlen, info->Nsecret);
+                       ikmlen, info->Nsk);
         goto err;
     }
 


### PR DESCRIPTION
This makes `ikmlen` have a length of at least `Nsk`.

Fixes #26213