### PR TITLE
Ensure the tests pass even if the default seclevel has been changed

### DIFF
--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -138,7 +138,8 @@ jobs:
           -DOPENSSL_PEDANTIC_ZEROIZATION,
           -DOPENSSL_PEDANTIC_ZEROIZATION enable-fips,
           -DOPENSSL_NO_BUILTIN_OVERFLOW_CHECKING,
-          -DSSL3_ALIGN_PAYLOAD=4
+          -DSSL3_ALIGN_PAYLOAD=4,
+          -DOPENSSL_TLS_SECURITY_LEVEL=0
         ]
     runs-on: ubuntu-latest
     steps:

--- a/test/recipes/70-test_renegotiation.t
+++ b/test/recipes/70-test_renegotiation.t
@@ -60,6 +60,7 @@ SKIP: {
     #Test 3: TLS 1.2 client does not send the Reneg extension. Reneg should fail
 
     $proxy->clear();
+    $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
     $proxy->filter(\&reneg_ext_filter);
     $proxy->clientflags("-no_tls1_3");
     $proxy->serverflags("-client_renegotiation");

--- a/test/recipes/70-test_sslmessages.t
+++ b/test/recipes/70-test_sslmessages.t
@@ -172,6 +172,7 @@ my $proxy = TLSProxy::Proxy->new(
 #Test 1: Check we get all the right messages for a default handshake
 (undef, my $session) = tempfile();
 $proxy->serverconnects(2);
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_tls1_3 -sess_out ".$session);
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
 plan tests => 21;
@@ -181,6 +182,7 @@ checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
 
 #Test 2: Resumption handshake
 $proxy->clearClient();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_tls1_3 -sess_in ".$session);
 $proxy->clientstart();
 checkhandshake($proxy, checkhandshake::RESUME_HANDSHAKE,
@@ -195,6 +197,7 @@ SKIP: {
 
     #Test 3: A status_request handshake (client request only)
     $proxy->clear();
+    $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
     $proxy->clientflags("-no_tls1_3 -status");
     $proxy->start();
     checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
@@ -204,6 +207,7 @@ SKIP: {
 
     #Test 4: A status_request handshake (server support only)
     $proxy->clear();
+    $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
     $proxy->clientflags("-no_tls1_3");
     $proxy->serverflags("-status_file "
                         .srctop_file("test", "recipes", "ocsp-response.der"));
@@ -214,6 +218,7 @@ SKIP: {
 
     #Test 5: A status_request handshake (client and server)
     $proxy->clear();
+    $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
     $proxy->clientflags("-no_tls1_3 -status");
     $proxy->serverflags("-status_file "
                         .srctop_file("test", "recipes", "ocsp-response.der"));
@@ -227,6 +232,7 @@ SKIP: {
 
 #Test 6: A client auth handshake
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_tls1_3 -cert ".srctop_file("apps", "server.pem"));
 $proxy->serverflags("-Verify 5");
 $proxy->start();
@@ -236,6 +242,7 @@ checkhandshake($proxy, checkhandshake::CLIENT_AUTH_HANDSHAKE,
 
 #Test 7: A handshake with a renegotiation
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_tls1_3");
 $proxy->serverflags("-client_renegotiation");
 $proxy->reneg(1);
@@ -246,6 +253,7 @@ checkhandshake($proxy, checkhandshake::RENEG_HANDSHAKE,
 
 #Test 8: Server name handshake (no client request)
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_tls1_3 -noservername");
 $proxy->start();
 checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
@@ -255,6 +263,7 @@ checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
 
 #Test 9: Server name handshake (server support only)
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_tls1_3 -noservername");
 $proxy->serverflags("-servername testhost");
 $proxy->start();
@@ -265,6 +274,7 @@ checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
 
 #Test 10: Server name handshake (client and server)
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_tls1_3 -servername testhost");
 $proxy->serverflags("-servername testhost");
 $proxy->start();
@@ -275,6 +285,7 @@ checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
 
 #Test 11: ALPN handshake (client request only)
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_tls1_3 -alpn test");
 $proxy->start();
 checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
@@ -284,6 +295,7 @@ checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
 
 #Test 12: ALPN handshake (server support only)
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_tls1_3");
 $proxy->serverflags("-alpn test");
 $proxy->start();
@@ -293,6 +305,7 @@ checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
 
 #Test 13: ALPN handshake (client and server)
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_tls1_3 -alpn test");
 $proxy->serverflags("-alpn test");
 $proxy->start();
@@ -308,6 +321,7 @@ SKIP: {
 
     #Test 14: SCT handshake (client request only)
     $proxy->clear();
+    $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
     #Note: -ct also sends status_request
     $proxy->clientflags("-no_tls1_3 -ct");
     $proxy->serverflags("-status_file "
@@ -327,6 +341,7 @@ SKIP: {
 
     #Test 15: SCT handshake (server support only)
     $proxy->clear();
+    $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
     #Note: -ct also sends status_request
     $proxy->clientflags("-no_tls1_3");
     $proxy->serverflags("-status_file "
@@ -345,6 +360,7 @@ SKIP: {
     #There is no built-in server side support for this so we are actually also
     #testing custom extensions here
     $proxy->clear();
+    $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
     #Note: -ct also sends status_request
     $proxy->clientflags("-no_tls1_3 -ct");
     $proxy->serverflags("-status_file "
@@ -367,6 +383,7 @@ SKIP: {
 
     #Test 17: NPN handshake (client request only)
     $proxy->clear();
+    $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
     $proxy->clientflags("-no_tls1_3 -nextprotoneg test");
     $proxy->start();
     checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
@@ -376,6 +393,7 @@ SKIP: {
 
     #Test 18: NPN handshake (server support only)
     $proxy->clear();
+    $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
     $proxy->clientflags("-no_tls1_3");
     $proxy->serverflags("-nextprotoneg test");
     $proxy->start();
@@ -385,6 +403,7 @@ SKIP: {
 
     #Test 19: NPN handshake (client and server)
     $proxy->clear();
+    $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
     $proxy->clientflags("-no_tls1_3 -nextprotoneg test");
     $proxy->serverflags("-nextprotoneg test");
     $proxy->start();
@@ -405,6 +424,7 @@ SKIP: {
     #SRP extension gets added on the client side. There is no SRP extension
     #generated on the server side anyway.
     $proxy->clear();
+    $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
     $proxy->clientflags("-no_tls1_3 -srpuser user -srppass pass:pass");
     $proxy->start();
     checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
@@ -417,6 +437,7 @@ SKIP: {
 SKIP: {
     skip "No EC support in this OpenSSL build", 1 if disabled("ec");
     $proxy->clear();
+    $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
     $proxy->clientflags("-no_tls1_3");
     $proxy->serverflags("-no_tls1_3");
     $proxy->ciphers("ECDHE-RSA-AES128-SHA");

--- a/test/recipes/70-test_tls13kexmodes.t
+++ b/test/recipes/70-test_tls13kexmodes.t
@@ -193,6 +193,7 @@ my $proxy = TLSProxy::Proxy->new(
 
 #Test 1: First get a session
 (undef, my $session) = tempfile();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -sess_out ".$session);
 $proxy->serverflags("-no_rx_cert_comp -servername localhost");
 $proxy->sessionfile($session);
@@ -203,6 +204,7 @@ ok(TLSProxy::Message->success(), "Initial connection");
 #Test 2: Attempt a resume with no kex modes extension. Should fail (server
 #        MUST abort handshake with pre_shared key and no psk_kex_modes)
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -sess_in ".$session);
 my $testtype = DELETE_EXTENSION;
 $proxy->filter(\&modify_kex_modes_filter);
@@ -212,6 +214,7 @@ ok(TLSProxy::Message->fail(), "Resume with no kex modes");
 #Test 3: Attempt a resume with empty kex modes extension. Should fail (empty
 #        extension is invalid)
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -sess_in ".$session);
 $testtype = EMPTY_EXTENSION;
 $proxy->start();
@@ -220,6 +223,7 @@ ok(TLSProxy::Message->fail(), "Resume with empty kex modes");
 #Test 4: Attempt a resume with non-dhe kex mode only. Should resume without a
 #        key_share
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -allow_no_dhe_kex -sess_in ".$session);
 $proxy->serverflags("-no_rx_cert_comp -allow_no_dhe_kex");
 $testtype = NON_DHE_KEX_MODE_ONLY;
@@ -233,6 +237,7 @@ checkhandshake($proxy, checkhandshake::RESUME_HANDSHAKE,
 
 #Test 5: Attempt a resume with dhe kex mode only. Should resume with a key_share
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -sess_in ".$session);
 $testtype = DHE_KEX_MODE_ONLY;
 $proxy->start();
@@ -247,6 +252,7 @@ checkhandshake($proxy, checkhandshake::RESUME_HANDSHAKE,
 #Test 6: Attempt a resume with only unrecognised kex modes. Should not resume
 #        but rather fall back to full handshake
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -sess_in ".$session);
 $testtype = UNKNOWN_KEX_MODES;
 $proxy->start();
@@ -260,6 +266,7 @@ checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
 #Test 7: Attempt a resume with both, non-dhe and dhe kex mode. Should resume with
 #        a key_share, even though non-dhe is allowed, but not explicitly preferred.
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -allow_no_dhe_kex -sess_in ".$session);
 $proxy->serverflags("-allow_no_dhe_kex");
 $testtype = BOTH_KEX_MODES;
@@ -275,6 +282,7 @@ checkhandshake($proxy, checkhandshake::RESUME_HANDSHAKE,
 #Test 8: Attempt a resume with both, non-dhe and dhe kex mode, but with server-side
 #        preference for non-dhe. Should resume without a key_share.
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -allow_no_dhe_kex -sess_in ".$session);
 $proxy->serverflags("-allow_no_dhe_kex -prefer_no_dhe_kex");
 $testtype = BOTH_KEX_MODES;
@@ -289,6 +297,7 @@ checkhandshake($proxy, checkhandshake::RESUME_HANDSHAKE,
 #Test 9: Attempt a resume with both, non-dhe and dhe kex mode, with server-side
 #        preference for non-dhe, but non-dhe not allowed. Should resume with a key_share.
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -allow_no_dhe_kex -sess_in ".$session);
 $proxy->serverflags("-prefer_no_dhe_kex");
 $testtype = BOTH_KEX_MODES;
@@ -304,6 +313,7 @@ checkhandshake($proxy, checkhandshake::RESUME_HANDSHAKE,
 #Test 10: Attempt a resume with both non-dhe and dhe kex mode, but unacceptable
 #        initial key_share. Should resume with a key_share following an HRR
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -sess_in ".$session);
 $proxy->serverflags("-no_rx_cert_comp -curves P-384");
 $testtype = BOTH_KEX_MODES;
@@ -320,6 +330,7 @@ checkhandshake($proxy, checkhandshake::HRR_RESUME_HANDSHAKE,
 #Test 11: Attempt a resume with dhe kex mode only and an unacceptable initial
 #        key_share. Should resume with a key_share following an HRR
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -sess_in ".$session);
 $proxy->serverflags("-no_rx_cert_comp -curves P-384");
 $testtype = DHE_KEX_MODE_ONLY;
@@ -337,6 +348,7 @@ checkhandshake($proxy, checkhandshake::HRR_RESUME_HANDSHAKE,
 #         initial key_share and no overlapping groups. Should resume without a
 #         key_share
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -allow_no_dhe_kex -curves P-384 -sess_in ".$session);
 $proxy->serverflags("-no_rx_cert_comp -allow_no_dhe_kex -curves P-256");
 $testtype = BOTH_KEX_MODES;
@@ -351,6 +363,7 @@ checkhandshake($proxy, checkhandshake::RESUME_HANDSHAKE,
 #Test 13: Attempt a resume with dhe kex mode only, unacceptable
 #         initial key_share and no overlapping groups. Should fail
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -curves P-384 -sess_in ".$session);
 $proxy->serverflags("-no_rx_cert_comp -curves P-256");
 $testtype = DHE_KEX_MODE_ONLY;

--- a/test/recipes/70-test_tls13messages.t
+++ b/test/recipes/70-test_tls13messages.t
@@ -209,6 +209,7 @@ my $proxy = TLSProxy::Proxy->new(
 #Test 1: Check we get all the right messages for a default handshake
 (undef, my $session) = tempfile();
 $proxy->serverconnects(2);
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -sess_out ".$session);
 $proxy->sessionfile($session);
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
@@ -219,6 +220,7 @@ checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
 
 #Test 2: Resumption handshake
 $proxy->clearClient();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -sess_in ".$session);
 $proxy->clientstart();
 checkhandshake($proxy, checkhandshake::RESUME_HANDSHAKE,
@@ -232,6 +234,7 @@ SKIP: {
         if disabled("ct") || disabled("ec") || disabled("ocsp");
     #Test 3: A status_request handshake (client request only)
     $proxy->clear();
+    $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
     $proxy->clientflags("-no_rx_cert_comp -status");
     $proxy->start();
     checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
@@ -241,6 +244,7 @@ SKIP: {
 
     #Test 4: A status_request handshake (server support only)
     $proxy->clear();
+    $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
     $proxy->clientflags("-no_rx_cert_comp");
     $proxy->serverflags("-no_rx_cert_comp -status_file "
                         .srctop_file("test", "recipes", "ocsp-response.der"));
@@ -251,6 +255,7 @@ SKIP: {
 
     #Test 5: A status_request handshake (client and server)
     $proxy->clear();
+    $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
     $proxy->clientflags("-no_rx_cert_comp -status");
     $proxy->serverflags("-no_rx_cert_comp -status_file "
                         .srctop_file("test", "recipes", "ocsp-response.der"));
@@ -263,6 +268,7 @@ SKIP: {
 
     #Test 6: A status_request handshake (client and server) with client auth
     $proxy->clear();
+    $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
     $proxy->clientflags("-no_rx_cert_comp -status -enable_pha -cert "
                         .srctop_file("apps", "server.pem"));
     $proxy->serverflags("-no_rx_cert_comp -Verify 5 -status_file "
@@ -278,6 +284,7 @@ SKIP: {
 
 #Test 7: A client auth handshake
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -enable_pha -cert ".srctop_file("apps", "server.pem"));
 $proxy->serverflags("-no_rx_cert_comp -Verify 5");
 $proxy->start();
@@ -288,6 +295,7 @@ checkhandshake($proxy, checkhandshake::CLIENT_AUTH_HANDSHAKE,
 
 #Test 8: Server name handshake (no client request)
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -noservername");
 $proxy->start();
 checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
@@ -297,6 +305,7 @@ checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
 
 #Test 9: Server name handshake (server support only)
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -noservername");
 $proxy->serverflags("-no_rx_cert_comp -servername testhost");
 $proxy->start();
@@ -307,6 +316,7 @@ checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
 
 #Test 10: Server name handshake (client and server)
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -servername testhost");
 $proxy->serverflags("-no_rx_cert_comp -servername testhost");
 $proxy->start();
@@ -317,6 +327,7 @@ checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
 
 #Test 11: ALPN handshake (client request only)
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -alpn test");
 $proxy->start();
 checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
@@ -326,6 +337,7 @@ checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
 
 #Test 12: ALPN handshake (server support only)
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp");
 $proxy->serverflags("-no_rx_cert_comp -alpn test");
 $proxy->start();
@@ -335,6 +347,7 @@ checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,
 
 #Test 13: ALPN handshake (client and server)
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -alpn test");
 $proxy->serverflags("-no_rx_cert_comp -alpn test");
 $proxy->start();
@@ -350,6 +363,7 @@ SKIP: {
 
     #Test 14: SCT handshake (client request only)
     $proxy->clear();
+    $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
     #Note: -ct also sends status_request
     $proxy->clientflags("-no_rx_cert_comp -ct");
     $proxy->serverflags("-no_rx_cert_comp -status_file "
@@ -367,6 +381,7 @@ SKIP: {
 
 #Test 15: HRR Handshake
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp");
 $proxy->serverflags("-no_rx_cert_comp -curves P-384");
 $proxy->start();
@@ -377,6 +392,7 @@ checkhandshake($proxy, checkhandshake::HRR_HANDSHAKE,
 
 #Test 16: Resumption handshake with HRR
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -sess_in ".$session);
 $proxy->serverflags("-no_rx_cert_comp -curves P-384");
 $proxy->start();
@@ -389,6 +405,7 @@ checkhandshake($proxy, checkhandshake::HRR_RESUME_HANDSHAKE,
 
 #Test 17: Acceptable but non preferred key_share
 $proxy->clear();
+$proxy->cipherc("DEFAULT:\@SECLEVEL=2");
 $proxy->clientflags("-no_rx_cert_comp -curves P-384");
 $proxy->start();
 checkhandshake($proxy, checkhandshake::DEFAULT_HANDSHAKE,

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -763,7 +763,8 @@ static int test_client_hello_cb(void)
 
     /* The gimpy cipher list we configure can't do TLS 1.3. */
     SSL_CTX_set_max_proto_version(cctx, TLS1_2_VERSION);
-
+    /* Avoid problems where the default seclevel has been changed */
+    SSL_CTX_set_security_level(cctx, 2);
     if (!TEST_true(SSL_CTX_set_cipher_list(cctx,
                         "AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384"))
             || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl,


### PR DESCRIPTION
The compile time default TLS security level can be changed if the user
sets `-DOPENSSL_TLS_SECURITY_LEVEL=x` at configure time (where "x" is some
number, typically 0 or 1).

Since OpenSSL 3.4 tests are failing if the default security level is 0. We
fix the tests for this case.

Fixes https://github.com/openssl/openssl/issues/26255
