### PR TITLE
Workaround for RSA on AArch64 Big Endian

### DIFF
--- a/crypto/bn/asm/armv8-mont.pl
+++ b/crypto/bn/asm/armv8-mont.pl
@@ -85,9 +85,11 @@ bn_mul_mont:
 	cmp	$num,#32
 	b.le	.Lscalar_impl
 #ifndef	__KERNEL__
+#ifndef	__AARCH64EB__
 	adrp	x17,OPENSSL_armv8_rsa_neonized
 	ldr	w17,[x17,#:lo12:OPENSSL_armv8_rsa_neonized]
 	cbnz	w17, bn_mul8x_mont_neon
+#endif
 #endif
 
 .Lscalar_impl:


### PR DESCRIPTION
10646160125 introduced and optimized RSA NEON implementation for AArch64 architecture, namely Cortex-A72 and Neoverse N1. This implementation is broken in Big Endian mode, which is not widely used, therefore not properly verified.
Here we disable this optimized implementation when Big Endian platform is used.

Fixes: #22687

CLA: trivial

