### PR TITLE
X509_add_cert crash

### DIFF
--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -192,7 +192,7 @@ int ossl_x509_add_cert_new(STACK_OF(X509) **p_sk, X509 *cert, int flags)
 
 int X509_add_cert(STACK_OF(X509) *sk, X509 *cert, int flags)
 {
-    if (sk == NULL) {
+    if (sk == NULL || cert == NULL) {
         ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -196,6 +196,9 @@ int X509_add_cert(STACK_OF(X509) *sk, X509 *cert, int flags)
         ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
+    if (cert == NULL)
+        return 1;
+        
     if ((flags & X509_ADD_FLAG_NO_DUP) != 0) {
         /*
          * not using sk_X509_set_cmp_func() and sk_X509_find()
@@ -219,7 +222,7 @@ int X509_add_cert(STACK_OF(X509) *sk, X509 *cert, int flags)
         ERR_raise(ERR_LIB_X509, ERR_R_CRYPTO_LIB);
         return 0;
     }
-    if ((flags & X509_ADD_FLAG_UP_REF) != 0 && cert != NULL)
+    if ((flags & X509_ADD_FLAG_UP_REF) != 0)
         (void)X509_up_ref(cert);
     return 1;
 }

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -192,7 +192,7 @@ int ossl_x509_add_cert_new(STACK_OF(X509) **p_sk, X509 *cert, int flags)
 
 int X509_add_cert(STACK_OF(X509) *sk, X509 *cert, int flags)
 {
-    if (sk == NULL || cert == NULL) {
+    if (sk == NULL) {
         ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
@@ -219,7 +219,7 @@ int X509_add_cert(STACK_OF(X509) *sk, X509 *cert, int flags)
         ERR_raise(ERR_LIB_X509, ERR_R_CRYPTO_LIB);
         return 0;
     }
-    if ((flags & X509_ADD_FLAG_UP_REF) != 0)
+    if ((flags & X509_ADD_FLAG_UP_REF) != 0 && cert != NULL)
         (void)X509_up_ref(cert);
     return 1;
 }

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -197,7 +197,7 @@ int X509_add_cert(STACK_OF(X509) *sk, X509 *cert, int flags)
         return 0;
     }
     if (cert == NULL)
-        return 1;
+        return 0;
     if ((flags & X509_ADD_FLAG_NO_DUP) != 0) {
         /*
          * not using sk_X509_set_cmp_func() and sk_X509_find()

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -198,7 +198,6 @@ int X509_add_cert(STACK_OF(X509) *sk, X509 *cert, int flags)
     }
     if (cert == NULL)
         return 1;
-        
     if ((flags & X509_ADD_FLAG_NO_DUP) != 0) {
         /*
          * not using sk_X509_set_cmp_func() and sk_X509_find()

--- a/doc/man3/X509_add_cert.pod
+++ b/doc/man3/X509_add_cert.pod
@@ -16,7 +16,7 @@ X509 certificate list addition functions
 =head1 DESCRIPTION
 
 X509_add_cert() adds a certificate I<cert> to the given list I<sk>.
-The I<cert> argument may be NULL, which implies no effect.
+It is an error for the I<cert> argument to be NULL.
 
 X509_add_certs() adds a list of certificate I<certs> to the given list I<sk>.
 The I<certs> argument may be NULL, which implies no effect.

--- a/doc/man3/X509_add_cert.pod
+++ b/doc/man3/X509_add_cert.pod
@@ -16,6 +16,7 @@ X509 certificate list addition functions
 =head1 DESCRIPTION
 
 X509_add_cert() adds a certificate I<cert> to the given list I<sk>.
+The I<cert> argument may be NULL, which implies no effect.
 
 X509_add_certs() adds a list of certificate I<certs> to the given list I<sk>.
 The I<certs> argument may be NULL, which implies no effect.


### PR DESCRIPTION
If you call X509_add_cert with cert = NULL and the X509_ADD_FLAG_UP_REF flag, it will сrash to X509_up_ref.

Found by Linux Verification Center (linuxtesting.org) with SVACE.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
