### PR TITLE
Reduce the matrix fanout of interop runner

### DIFF
--- a/.github/workflows/run_quic_interop_server.yml
+++ b/.github/workflows/run_quic_interop_server.yml
@@ -7,12 +7,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  run_quic_interop:
+  run_quic_interop_openssl_client:
     strategy:
       matrix:
         tests: [http3, transfer, handshake, retry, chacha20, resumption, amplificationlimit]
         servers: [quic-go, ngtcp2, mvfst, quiche, nginx, msquic, haproxy]
-        clients: [quic-go, ngtcp2, mvfst, quiche, msquic, openssl]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -36,7 +35,31 @@ jobs:
       - name: "run interop with openssl client"
         run: |
           python3 ./run.py -c openssl -t ${{ matrix.tests }} -s ${{ matrix.servers }} --log-dir ./logs-client -d
+  run_quic_interop_openssl_server:
+    strategy:
+      matrix:
+        tests: [http3, transfer, handshake, retry, chacha20, resumption, amplificationlimit]
+        clients: [quic-go, ngtcp2, mvfst, quiche, msquic, openssl]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+         repository: 'quic-interop/quic-interop-runner'
+         fetch-depth: 0
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          sudo add-apt-repository ppa:wireshark-dev/stable
+          sudo apt-get update
+          sudo apt-get install -y tshark
+      - name: Patch implementations file
+        run: |
+          jq '.openssl = { image: "quay.io/openssl-ci/openssl-quic-interop-server"
+                         , url: "https://github.com/openssl/openssl"
+                         , role: "both"
+                         }' ./implementations.json > ./implementations.tmp
+          mv ./implementations.tmp implementations.json
       - name: "run interop with openssl server"
         run: |
           python3 ./run.py -s openssl -t ${{ matrix.tests }} -c ${{ matrix.clients }} --log-dir ./logs-server -d
-


### PR DESCRIPTION
Recent test additions have increased the number of jobs spawned by the interop runner test which exceeds the maximum allowed.

This occurs because the matrix expands to:
7 server elements
6 client elements
7 tests
2 test steps (client interop and server interop

Because of how github ci does matrix expansion, this results in 2 * 7 * 7 * 6 = 588

But most of those are invalid because each of the 2 steps only considers either the client or server elements, and so get rerun multiple times

Alter the steps to be individual jobs, each with their own reduced matrix to only run each relevant test once, limiting our job count to at most 49 jobs.


##### Checklist
- [x] tests are added or updated
