### PR TITLE
Add a configuration option to disable the set_keylog_callback api

### DIFF
--- a/Configure
+++ b/Configure
@@ -527,6 +527,7 @@ my @disablables = (
     "static-engine",
     "stdio",
     "sslkeylog",
+    "sslkeylog-cb",
     "tests",
     "tfo",
     "thread-pool",

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -6859,7 +6859,12 @@ int SSL_alloc_buffers(SSL *ssl)
 
 void SSL_CTX_set_keylog_callback(SSL_CTX *ctx, SSL_CTX_keylog_cb_func cb)
 {
+#ifndef OPENSSL_NO_SSLKEYLOG_CB
     ctx->keylog_callback = cb;
+#else
+    ERR_raise_data(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR,
+                   "Keylogging not supported"); 
+#endif
 }
 
 SSL_CTX_keylog_cb_func SSL_CTX_get_keylog_callback(const SSL_CTX *ctx)


### PR DESCRIPTION
Based on conversation in #26283.  Seems like it would be a good security feature to allow disabling this.  Leave it default on for now, consider default-disabled for 4.0

I think the related conversation is here #26282 