### PR TITLE
Fix URL parsing to handle missing ports and ISO 8601 timestamps in paths

### DIFF
--- a/crypto/http/http_lib.c
+++ b/crypto/http/http_lib.c
@@ -59,7 +59,7 @@ int OSSL_parse_url(const char *url, char **pscheme, char **puser, char **phost,
     const char *user, *user_end;
     const char *host, *host_end;
     const char *port, *port_end;
-    unsigned int portnum;
+    unsigned int portnum = 0;
     const char *path, *path_end;
     const char *query, *query_end;
     const char *frag, *frag_end;
@@ -107,13 +107,7 @@ int OSSL_parse_url(const char *url, char **pscheme, char **puser, char **phost,
         p = ++host_end;
     } else {
         /* look for start of optional port, path, query, or fragment */
-        host_end = strchr(host, ':');
-        if (host_end == NULL)
-            host_end = strchr(host, '/');
-        if (host_end == NULL)
-            host_end = strchr(host, '?');
-        if (host_end == NULL)
-            host_end = strchr(host, '#');
+        host_end = strpbrk(host, ":/?#");
         if (host_end == NULL) /* the remaining string is just the hostname */
             host_end = host + strlen(host);
         p = host_end;

--- a/test/http_test.c
+++ b/test/http_test.c
@@ -299,6 +299,16 @@ static int test_http_url_dns(void)
     return test_http_url_ok("host:65535/path", 0, "host", "65535", "/path");
 }
 
+static int test_http_url_timestamp(void)
+{
+    return test_http_url_ok("host/p/2017-01-03T00:00:00", 0, "host", "80",
+                            "/p/2017-01-03T00:00:00")
+        && test_http_url_ok("http://host/p/2017-01-03T00:00:00", 0, "host",
+                            "80", "/p/2017-01-03T00:00:00")
+        && test_http_url_ok("https://host/p/2017-01-03T00:00:00", 1, "host",
+                            "443", "/p/2017-01-03T00:00:00");
+}
+
 static int test_http_url_path_query(void)
 {
     return test_http_url_path_query_ok("http://usr@host:1/p?q=x#frag", "/p?q=x")
@@ -496,6 +506,7 @@ int setup_tests(void)
         return 0;
 
     ADD_TEST(test_http_url_dns);
+    ADD_TEST(test_http_url_timestamp);
     ADD_TEST(test_http_url_path_query);
     ADD_TEST(test_http_url_userinfo_query_fragment);
     ADD_TEST(test_http_url_ipv4);

--- a/util/platform_symbols/unix-symbols.txt
+++ b/util/platform_symbols/unix-symbols.txt
@@ -142,6 +142,7 @@ strdup
 strlen
 strncmp
 strncpy
+strpbrk
 strrchr
 strspn
 strstr

--- a/util/platform_symbols/windows-symbols.txt
+++ b/util/platform_symbols/windows-symbols.txt
@@ -125,6 +125,7 @@ tolower
 strspn
 strcspn
 strncpy
+strpbrk
 strncmp
 strcmp
 strcat_s


### PR DESCRIPTION
This PR enhances the OSSL_parse_url() function to address issues with parsing URLs that lack an explicit port or include timestamps in the ISO 8601 format within the path.

Examples of previously problematic URLs:
```
http://localhost/TS-SHA1/2017-01-03T00:00:00
https://localhost/TS-SHA1/2017-01-03T00:00:00
localhost/TS-SHA1/2017-01-03T00:00:00
```

This update replaces multiple strchr() calls with a single strpbrk() call, improving efficiency by locating the first occurrence of any delimiter (":/?#") in the URL and ensuring better compatibility with various URL formats.

[x] tests are added or updated

