### PR TITLE
Replace self-hosted runners with GitHub hosted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
       with:
         name: "ci@linux-arm64"
         path: artifacts.tar.gz
-  
+
   freebsd-x86_64:
     runs-on: ubuntu-latest
     steps:
@@ -155,9 +155,9 @@ jobs:
     - uses: cross-platform-actions/action@v0.26.0
       with:
         operating_system: freebsd
-        image_url: https://github.com/openssl/freebsd-builder/releases/download/25-01-02-2/freebsd-13.4-x86-64.qcow2
         version: "13.4"
         run: |
+          sudo pkg install -y gcc perl5
           ./config enable-demos enable-fips enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-trace
           ./configdata.pm --dump
           make -j4
@@ -428,7 +428,7 @@ jobs:
     - name: Enable sctp
       run: sudo modprobe sctp
     - name: Enable auth in sctp
-      run: sudo sysctl -w net.sctp.auth_enable=1 
+      run: sudo sysctl -w net.sctp.auth_enable=1
     - name: install extra config support
       run: sudo apt-get -y install libsctp-dev abigail-tools libzstd-dev zstd
     - name: config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,14 +148,14 @@ jobs:
         name: "ci@linux-arm64"
         path: artifacts.tar.gz
   
-  BSD-x86_64:
+  freebsd-x86_64:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: cross-platform-actions/action@v0.26.0
       with:
         operating_system: freebsd
-        image_url: https://github.com/quarckster/freebsd-builder/releases/download/25-01-02-2/freebsd-13.4-x86-64.qcow2
+        image_url: https://github.com/openssl/freebsd-builder/releases/download/25-01-02-2/freebsd-13.4-x86-64.qcow2
         version: "13.4"
         run: |
           ./config enable-demos enable-fips enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-trace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,15 +152,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: cross-platform-actions/action@v0.26.0
+    - name: config
+      uses: cross-platform-actions/action@v0.26.0
+      with:
+        operating_system: freebsd
+        version: "13.4"
+        shutdown_vm: false
+        run: |
+          sudo pkg install -y gcc perl5
+          ./config enable-fips enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-trace
+    - name: config dump
+      uses: cross-platform-actions/action@v0.26.0
+      with:
+        operating_system: freebsd
+        version: "13.4"
+        shutdown_vm: false
+        run: ./configdata.pm --dump
+    - name: make
+      uses: cross-platform-actions/action@v0.26.0
+      with:
+        operating_system: freebsd
+        version: "13.4"
+        shutdown_vm: false
+        run: make -j4
+    - name: make test
+      uses: cross-platform-actions/action@v0.26.0
       with:
         operating_system: freebsd
         version: "13.4"
         run: |
-          sudo pkg install -y gcc perl5
-          ./config enable-demos enable-fips enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-trace
-          ./configdata.pm --dump
-          make -j4
           ./util/opensslwrap.sh version -c
           .github/workflows/make-test
     - name: save artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,13 +126,8 @@ jobs:
         name: "ci@basic-clang"
         path: artifacts.tar.gz
 
-  self-hosted:
-    if: github.repository == 'openssl/openssl'
-    strategy:
-      matrix:
-        os: [freebsd-13.2, ubuntu-arm64-22.04]
-    runs-on: ${{ matrix.os }}-self-hosted
-    continue-on-error: true
+  linux-arm64:
+    runs-on: linux-arm64
     steps:
     - uses: actions/checkout@v4
     - name: config
@@ -142,13 +137,36 @@ jobs:
     - name: make
       run: make -j4
     - name: get cpu info
-      run: ./util/opensslwrap.sh version -c
+      run: |
+        cat /proc/cpuinfo
+        ./util/opensslwrap.sh version -c
     - name: make test
       run: .github/workflows/make-test
     - name: save artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: "ci@self-hosted-${{ matrix.os }}"
+        name: "ci@linux-arm64"
+        path: artifacts.tar.gz
+  
+  BSD-x86_64:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cross-platform-actions/action@v0.26.0
+      with:
+        operating_system: freebsd
+        image_url: https://github.com/quarckster/freebsd-builder/releases/download/25-01-02-2/freebsd-13.4-x86-64.qcow2
+        version: "13.4"
+        run: |
+          ./config enable-demos enable-fips enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-trace
+          ./configdata.pm --dump
+          make -j4
+          ./util/opensslwrap.sh version -c
+          .github/workflows/make-test
+    - name: save artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: "ci@BSD-x86_64"
         path: artifacts.tar.gz
 
   minimal:

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -159,12 +159,8 @@ jobs:
       working-directory: _build
       run: nmake test VERBOSE_FAILURE=yes HARNESS_JOBS=4
 
-  self-hosted:
-    strategy:
-      matrix:
-        os: [freebsd-13.2, ubuntu-arm64-22.04]
-    runs-on: ${{ matrix.os }}-self-hosted
-    continue-on-error: true
+  linux-arm64:
+    runs-on: linux-arm64
     steps:
     - uses: actions/checkout@v4
     - name: config
@@ -194,3 +190,19 @@ jobs:
         ./util/opensslwrap.sh version -c
     - name: make test
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
+
+  BSD-x86_64:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cross-platform-actions/action@v0.26.0
+      with:
+        operating_system: freebsd
+        image_url: https://github.com/quarckster/freebsd-builder/releases/download/25-01-02-2/freebsd-13.4-x86-64.qcow2
+        version: "13.4"
+        run: |
+          ./config enable-fips enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-trace
+          ./configdata.pm --dump
+          make -j4
+          ./util/opensslwrap.sh version -c
+          make test HARNESS_JOBS=${HARNESS_JOBS:-4}

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -191,14 +191,14 @@ jobs:
     - name: make test
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
-  BSD-x86_64:
+  freebsd-x86_64:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: cross-platform-actions/action@v0.26.0
       with:
         operating_system: freebsd
-        image_url: https://github.com/quarckster/freebsd-builder/releases/download/25-01-02-2/freebsd-13.4-x86-64.qcow2
+        image_url: https://github.com/openssl/freebsd-builder/releases/download/25-01-02-2/freebsd-13.4-x86-64.qcow2
         version: "13.4"
         run: |
           ./config enable-fips enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-trace

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -198,9 +198,9 @@ jobs:
     - uses: cross-platform-actions/action@v0.26.0
       with:
         operating_system: freebsd
-        image_url: https://github.com/openssl/freebsd-builder/releases/download/25-01-02-2/freebsd-13.4-x86-64.qcow2
         version: "13.4"
         run: |
+          sudo pkg install -y gcc perl5
           ./config enable-fips enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-trace
           ./configdata.pm --dump
           make -j4

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -195,14 +195,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: cross-platform-actions/action@v0.26.0
+    - name: config
+      uses: cross-platform-actions/action@v0.26.0
+      with:
+        operating_system: freebsd
+        version: "13.4"
+        shutdown_vm: false
+        run: |
+          sudo pkg install -y gcc perl5
+          ./config enable-fips enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-trace
+    - name: config dump
+      uses: cross-platform-actions/action@v0.26.0
+      with:
+        operating_system: freebsd
+        version: "13.4"
+        shutdown_vm: false
+        run: ./configdata.pm --dump
+    - name: make
+      uses: cross-platform-actions/action@v0.26.0
+      with:
+        operating_system: freebsd
+        version: "13.4"
+        shutdown_vm: false
+        run: make -j4
+    - name: make test
+      uses: cross-platform-actions/action@v0.26.0
       with:
         operating_system: freebsd
         version: "13.4"
         run: |
-          sudo pkg install -y gcc perl5
-          ./config enable-fips enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-trace
-          ./configdata.pm --dump
-          make -j4
           ./util/opensslwrap.sh version -c
-          make test HARNESS_JOBS=${HARNESS_JOBS:-4}
+          .github/workflows/make-test


### PR DESCRIPTION
GitHub recently announced Ubuntu arm64 runners availability. This PR replaces self-hosted runners with GitHub hosted ones.
