### PR TITLE
Fix buildinf.h generation for space and backslash

### DIFF
--- a/util/mkbuildinf.pl
+++ b/util/mkbuildinf.pl
@@ -9,7 +9,9 @@
 use strict;
 use warnings;
 
-my ($cflags, $platform) = @ARGV;
+my $platform = pop @ARGV;
+my $cflags = join(' ', @ARGV);
+$cflags =~ s(\\)(\\\\)g;
 $cflags = "compiler: $cflags";
 
 # Use the value of the envvar SOURCE_DATE_EPOCH, even if it's


### PR DESCRIPTION
Builds may be configured with CC or CFLAGS containing space and double quotes. In particular on Windows, this may lead to passing more than two arguments into mkbuildinf.pl.
In addition, backslashes must be escaped for constructing the C string.

Fixes #26253.

Attention: This change may burn the absolute file path to the compiler into binaries.