### PR TITLE
Pass functions with correct signatures to the evp_generic_fetch_xxx

### DIFF
--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -24,11 +24,13 @@
  */
 #define NAME_SEPARATOR ':'
 
-static void ossl_decoder_free(void *data) {
+static void ossl_decoder_free(void *data)
+{
     OSSL_DECODER_free((OSSL_DECODER *)data);
 }
 
-static int ossl_decoder_up_ref(void *data) {
+static int ossl_decoder_up_ref(void *data)
+{
     return OSSL_DECODER_up_ref((OSSL_DECODER *)data);
 }
 

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -26,12 +26,12 @@
 
 static void ossl_decoder_free(void *data)
 {
-    OSSL_DECODER_free((OSSL_DECODER *)data);
+    OSSL_DECODER_free(data);
 }
 
 static int ossl_decoder_up_ref(void *data)
 {
-    return OSSL_DECODER_up_ref((OSSL_DECODER *)data);
+    return OSSL_DECODER_up_ref(data);
 }
 
 /* Simple method structure constructor and destructor */

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -24,6 +24,14 @@
  */
 #define NAME_SEPARATOR ':'
 
+static void ossl_decoder_free(void *data) {
+    OSSL_DECODER_free((OSSL_DECODER *)data);
+}
+
+static int ossl_decoder_up_ref(void *data) {
+    return OSSL_DECODER_up_ref((OSSL_DECODER *)data);
+}
+
 /* Simple method structure constructor and destructor */
 static OSSL_DECODER *ossl_decoder_new(void)
 {
@@ -191,8 +199,8 @@ static int put_decoder_in_store(void *store, void *method,
         return 0;
 
     return ossl_method_store_add(store, prov, id, propdef, method,
-                                 (int (*)(void *))OSSL_DECODER_up_ref,
-                                 (void (*)(void *))OSSL_DECODER_free);
+                                 ossl_decoder_up_ref,
+                                 ossl_decoder_free);
 }
 
 /* Create and populate a decoder method */

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -24,11 +24,13 @@
  */
 #define NAME_SEPARATOR ':'
 
-static void ossl_encoder_free(void *data) {
+static void ossl_encoder_free(void *data)
+{
     OSSL_ENCODER_free((OSSL_ENCODER *)data);
 }
 
-static int ossl_encoder_up_ref(void *data) {
+static int ossl_encoder_up_ref(void *data)
+{
     return OSSL_ENCODER_up_ref((OSSL_ENCODER *)data);
 }
 

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -24,6 +24,14 @@
  */
 #define NAME_SEPARATOR ':'
 
+static void ossl_encoder_free(void *data) {
+    OSSL_ENCODER_free((OSSL_ENCODER *)data);
+}
+
+static int ossl_encoder_up_ref(void *data) {
+    return OSSL_ENCODER_up_ref((OSSL_ENCODER *)data);
+}
+
 /* Simple method structure constructor and destructor */
 static OSSL_ENCODER *ossl_encoder_new(void)
 {
@@ -191,8 +199,8 @@ static int put_encoder_in_store(void *store, void *method,
         return 0;
 
     return ossl_method_store_add(store, prov, id, propdef, method,
-                                 (int (*)(void *))OSSL_ENCODER_up_ref,
-                                 (void (*)(void *))OSSL_ENCODER_free);
+                                 ossl_encoder_up_ref,
+                                 ossl_encoder_free);
 }
 
 /* Create and populate a encoder method */

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -26,12 +26,12 @@
 
 static void ossl_encoder_free(void *data)
 {
-    OSSL_ENCODER_free((OSSL_ENCODER *)data);
+    OSSL_ENCODER_free(data);
 }
 
 static int ossl_encoder_up_ref(void *data)
 {
-    return OSSL_ENCODER_up_ref((OSSL_ENCODER *)data);
+    return OSSL_ENCODER_up_ref(data);
 }
 
 /* Simple method structure constructor and destructor */

--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -17,6 +17,16 @@
 #include "crypto/evp.h"
 #include "evp_local.h"
 
+static void evp_asym_cipher_free(void *data)
+{
+    EVP_ASYM_CIPHER_free((EVP_ASYM_CIPHER *)data);
+}
+
+static int evp_asym_cipher_up_ref(void *data)
+{
+    return EVP_ASYM_CIPHER_up_ref((EVP_ASYM_CIPHER *)data);
+}
+
 static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation,
                                      const OSSL_PARAM params[])
 {
@@ -484,8 +494,8 @@ EVP_ASYM_CIPHER *EVP_ASYM_CIPHER_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
 {
     return evp_generic_fetch(ctx, OSSL_OP_ASYM_CIPHER, algorithm, properties,
                              evp_asym_cipher_from_algorithm,
-                             (int (*)(void *))EVP_ASYM_CIPHER_up_ref,
-                             (void (*)(void *))EVP_ASYM_CIPHER_free);
+                             evp_asym_cipher_up_ref,
+                             evp_asym_cipher_free);
 }
 
 EVP_ASYM_CIPHER *evp_asym_cipher_fetch_from_prov(OSSL_PROVIDER *prov,
@@ -495,8 +505,8 @@ EVP_ASYM_CIPHER *evp_asym_cipher_fetch_from_prov(OSSL_PROVIDER *prov,
     return evp_generic_fetch_from_prov(prov, OSSL_OP_ASYM_CIPHER,
                                        algorithm, properties,
                                        evp_asym_cipher_from_algorithm,
-                                       (int (*)(void *))EVP_ASYM_CIPHER_up_ref,
-                                       (void (*)(void *))EVP_ASYM_CIPHER_free);
+                                       evp_asym_cipher_up_ref,
+                                       evp_asym_cipher_free);
 }
 
 int EVP_ASYM_CIPHER_is_a(const EVP_ASYM_CIPHER *cipher, const char *name)
@@ -527,8 +537,8 @@ void EVP_ASYM_CIPHER_do_all_provided(OSSL_LIB_CTX *libctx,
     evp_generic_do_all(libctx, OSSL_OP_ASYM_CIPHER,
                        (void (*)(void *, void *))fn, arg,
                        evp_asym_cipher_from_algorithm,
-                       (int (*)(void *))EVP_ASYM_CIPHER_up_ref,
-                       (void (*)(void *))EVP_ASYM_CIPHER_free);
+                       evp_asym_cipher_up_ref,
+                       evp_asym_cipher_free);
 }
 
 

--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -19,12 +19,12 @@
 
 static void evp_asym_cipher_free(void *data)
 {
-    EVP_ASYM_CIPHER_free((EVP_ASYM_CIPHER *)data);
+    EVP_ASYM_CIPHER_free(data);
 }
 
 static int evp_asym_cipher_up_ref(void *data)
 {
-    return EVP_ASYM_CIPHER_up_ref((EVP_ASYM_CIPHER *)data);
+    return EVP_ASYM_CIPHER_up_ref(data);
 }
 
 static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation,

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -18,6 +18,16 @@
 #include "crypto/evp.h"
 #include "evp_local.h"
 
+static void evp_keyexch_free(void *data)
+{
+    EVP_KEYEXCH_free((EVP_KEYEXCH *)data);
+}
+
+static int evp_keyexch_up_ref(void *data)
+{
+    return EVP_KEYEXCH_up_ref((EVP_KEYEXCH *)data);
+}
+
 static EVP_KEYEXCH *evp_keyexch_new(OSSL_PROVIDER *prov)
 {
     EVP_KEYEXCH *exchange = OPENSSL_zalloc(sizeof(EVP_KEYEXCH));
@@ -172,8 +182,8 @@ EVP_KEYEXCH *EVP_KEYEXCH_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
 {
     return evp_generic_fetch(ctx, OSSL_OP_KEYEXCH, algorithm, properties,
                              evp_keyexch_from_algorithm,
-                             (int (*)(void *))EVP_KEYEXCH_up_ref,
-                             (void (*)(void *))EVP_KEYEXCH_free);
+                             evp_keyexch_up_ref,
+                             evp_keyexch_free);
 }
 
 EVP_KEYEXCH *evp_keyexch_fetch_from_prov(OSSL_PROVIDER *prov,
@@ -183,8 +193,8 @@ EVP_KEYEXCH *evp_keyexch_fetch_from_prov(OSSL_PROVIDER *prov,
     return evp_generic_fetch_from_prov(prov, OSSL_OP_KEYEXCH,
                                        algorithm, properties,
                                        evp_keyexch_from_algorithm,
-                                       (int (*)(void *))EVP_KEYEXCH_up_ref,
-                                       (void (*)(void *))EVP_KEYEXCH_free);
+                                       evp_keyexch_up_ref,
+                                       evp_keyexch_free);
 }
 
 int EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx)
@@ -562,8 +572,8 @@ void EVP_KEYEXCH_do_all_provided(OSSL_LIB_CTX *libctx,
     evp_generic_do_all(libctx, OSSL_OP_KEYEXCH,
                        (void (*)(void *, void *))fn, arg,
                        evp_keyexch_from_algorithm,
-                       (int (*)(void *))EVP_KEYEXCH_up_ref,
-                       (void (*)(void *))EVP_KEYEXCH_free);
+                       evp_keyexch_up_ref,
+                       evp_keyexch_free);
 }
 
 int EVP_KEYEXCH_names_do_all(const EVP_KEYEXCH *keyexch,

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -20,12 +20,12 @@
 
 static void evp_keyexch_free(void *data)
 {
-    EVP_KEYEXCH_free((EVP_KEYEXCH *)data);
+    EVP_KEYEXCH_free(data);
 }
 
 static int evp_keyexch_up_ref(void *data)
 {
-    return EVP_KEYEXCH_up_ref((EVP_KEYEXCH *)data);
+    return EVP_KEYEXCH_up_ref(data);
 }
 
 static EVP_KEYEXCH *evp_keyexch_new(OSSL_PROVIDER *prov)

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -17,6 +17,16 @@
 #include "crypto/evp.h"
 #include "evp_local.h"
 
+static void evp_kem_free(void *data)
+{
+    EVP_KEM_free((EVP_KEM *)data);
+}
+
+static int evp_kem_up_ref(void *data)
+{
+    return EVP_KEM_up_ref((EVP_KEM *)data);
+}
+
 static int evp_kem_init(EVP_PKEY_CTX *ctx, int operation,
                         const OSSL_PARAM params[], EVP_PKEY *authkey)
 {
@@ -452,8 +462,8 @@ EVP_KEM *EVP_KEM_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
 {
     return evp_generic_fetch(ctx, OSSL_OP_KEM, algorithm, properties,
                              evp_kem_from_algorithm,
-                             (int (*)(void *))EVP_KEM_up_ref,
-                             (void (*)(void *))EVP_KEM_free);
+                             evp_kem_up_ref,
+                             evp_kem_free);
 }
 
 EVP_KEM *evp_kem_fetch_from_prov(OSSL_PROVIDER *prov, const char *algorithm,
@@ -461,8 +471,8 @@ EVP_KEM *evp_kem_fetch_from_prov(OSSL_PROVIDER *prov, const char *algorithm,
 {
     return evp_generic_fetch_from_prov(prov, OSSL_OP_KEM, algorithm, properties,
                                        evp_kem_from_algorithm,
-                                       (int (*)(void *))EVP_KEM_up_ref,
-                                       (void (*)(void *))EVP_KEM_free);
+                                       evp_kem_up_ref,
+                                       evp_kem_free);
 }
 
 int EVP_KEM_is_a(const EVP_KEM *kem, const char *name)
@@ -491,8 +501,8 @@ void EVP_KEM_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_KEM, (void (*)(void *, void *))fn, arg,
                        evp_kem_from_algorithm,
-                       (int (*)(void *))EVP_KEM_up_ref,
-                       (void (*)(void *))EVP_KEM_free);
+                       evp_kem_up_ref,
+                       evp_kem_free);
 }
 
 int EVP_KEM_names_do_all(const EVP_KEM *kem,

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -19,12 +19,12 @@
 
 static void evp_kem_free(void *data)
 {
-    EVP_KEM_free((EVP_KEM *)data);
+    EVP_KEM_free(data);
 }
 
 static int evp_kem_up_ref(void *data)
 {
-    return EVP_KEM_up_ref((EVP_KEM *)data);
+    return EVP_KEM_up_ref( data);
 }
 
 static int evp_kem_init(EVP_PKEY_CTX *ctx, int operation,

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -24,7 +24,7 @@ static void evp_kem_free(void *data)
 
 static int evp_kem_up_ref(void *data)
 {
-    return EVP_KEM_up_ref( data);
+    return EVP_KEM_up_ref(data);
 }
 
 static int evp_kem_init(EVP_PKEY_CTX *ctx, int operation,

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -17,6 +17,16 @@
 #include "crypto/evp.h"
 #include "evp_local.h"
 
+static void evp_keymgmt_free(void *data)
+{
+    EVP_KEYMGMT_free(data);
+}
+
+static int evp_keymgmt_up_ref(void *data)
+{
+    return EVP_KEYMGMT_up_ref(data);
+}
+
 static void *keymgmt_new(void)
 {
     EVP_KEYMGMT *keymgmt = NULL;
@@ -259,16 +269,6 @@ static void *keymgmt_from_algorithm(int name_id,
 #endif
 
     return keymgmt;
-}
-
-static void evp_keymgmt_free(void *data)
-{
-    EVP_KEYMGMT_free((EVP_KEYMGMT *)data);
-}
-
-static int evp_keymgmt_up_ref(void *data)
-{
-    return EVP_KEYMGMT_up_ref((EVP_KEYMGMT *)data);
 }
 
 EVP_KEYMGMT *evp_keymgmt_fetch_from_prov(OSSL_PROVIDER *prov,

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -261,6 +261,16 @@ static void *keymgmt_from_algorithm(int name_id,
     return keymgmt;
 }
 
+static void evp_keymgmt_free(void *data)
+{
+    EVP_KEYMGMT_free((EVP_KEYMGMT *)data);
+}
+
+static int evp_keymgmt_up_ref(void *data)
+{
+    return EVP_KEYMGMT_up_ref((EVP_KEYMGMT *)data);
+}
+
 EVP_KEYMGMT *evp_keymgmt_fetch_from_prov(OSSL_PROVIDER *prov,
                                          const char *name,
                                          const char *properties)
@@ -268,8 +278,8 @@ EVP_KEYMGMT *evp_keymgmt_fetch_from_prov(OSSL_PROVIDER *prov,
     return evp_generic_fetch_from_prov(prov, OSSL_OP_KEYMGMT,
                                        name, properties,
                                        keymgmt_from_algorithm,
-                                       (int (*)(void *))EVP_KEYMGMT_up_ref,
-                                       (void (*)(void *))EVP_KEYMGMT_free);
+                                       evp_keymgmt_up_ref,
+                                       evp_keymgmt_free);
 }
 
 EVP_KEYMGMT *EVP_KEYMGMT_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
@@ -277,8 +287,8 @@ EVP_KEYMGMT *EVP_KEYMGMT_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
 {
     return evp_generic_fetch(ctx, OSSL_OP_KEYMGMT, algorithm, properties,
                              keymgmt_from_algorithm,
-                             (int (*)(void *))EVP_KEYMGMT_up_ref,
-                             (void (*)(void *))EVP_KEYMGMT_free);
+                             evp_keymgmt_up_ref,
+                             evp_keymgmt_free);
 }
 
 int EVP_KEYMGMT_up_ref(EVP_KEYMGMT *keymgmt)
@@ -343,8 +353,8 @@ void EVP_KEYMGMT_do_all_provided(OSSL_LIB_CTX *libctx,
     evp_generic_do_all(libctx, OSSL_OP_KEYMGMT,
                        (void (*)(void *, void *))fn, arg,
                        keymgmt_from_algorithm,
-                       (int (*)(void *))EVP_KEYMGMT_up_ref,
-                       (void (*)(void *))EVP_KEYMGMT_free);
+                       evp_keymgmt_up_ref,
+                       evp_keymgmt_free);
 }
 
 int EVP_KEYMGMT_names_do_all(const EVP_KEYMGMT *keymgmt,

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -20,6 +20,16 @@
 #include "crypto/evp.h"
 #include "evp_local.h"
 
+static void evp_signature_free(void *data)
+{
+    EVP_SIGNATURE_free((EVP_SIGNATURE *)data);
+}
+
+static int evp_signature_up_ref(void *data)
+{
+    return EVP_SIGNATURE_up_ref((EVP_SIGNATURE *)data);
+}
+
 static EVP_SIGNATURE *evp_signature_new(OSSL_PROVIDER *prov)
 {
     EVP_SIGNATURE *signature = OPENSSL_zalloc(sizeof(EVP_SIGNATURE));
@@ -404,8 +414,8 @@ EVP_SIGNATURE *EVP_SIGNATURE_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
 {
     return evp_generic_fetch(ctx, OSSL_OP_SIGNATURE, algorithm, properties,
                              evp_signature_from_algorithm,
-                             (int (*)(void *))EVP_SIGNATURE_up_ref,
-                             (void (*)(void *))EVP_SIGNATURE_free);
+                             evp_signature_up_ref,
+                             evp_signature_free);
 }
 
 EVP_SIGNATURE *evp_signature_fetch_from_prov(OSSL_PROVIDER *prov,
@@ -415,8 +425,8 @@ EVP_SIGNATURE *evp_signature_fetch_from_prov(OSSL_PROVIDER *prov,
     return evp_generic_fetch_from_prov(prov, OSSL_OP_SIGNATURE,
                                        algorithm, properties,
                                        evp_signature_from_algorithm,
-                                       (int (*)(void *))EVP_SIGNATURE_up_ref,
-                                       (void (*)(void *))EVP_SIGNATURE_free);
+                                       evp_signature_up_ref,
+                                       evp_signature_free);
 }
 
 int EVP_SIGNATURE_is_a(const EVP_SIGNATURE *signature, const char *name)
@@ -448,8 +458,8 @@ void EVP_SIGNATURE_do_all_provided(OSSL_LIB_CTX *libctx,
     evp_generic_do_all(libctx, OSSL_OP_SIGNATURE,
                        (void (*)(void *, void *))fn, arg,
                        evp_signature_from_algorithm,
-                       (int (*)(void *))EVP_SIGNATURE_up_ref,
-                       (void (*)(void *))EVP_SIGNATURE_free);
+                       evp_signature_up_ref,
+                       evp_signature_free);
 }
 
 

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -22,12 +22,12 @@
 
 static void evp_signature_free(void *data)
 {
-    EVP_SIGNATURE_free((EVP_SIGNATURE *)data);
+    EVP_SIGNATURE_free(data);
 }
 
 static int evp_signature_up_ref(void *data)
 {
-    return EVP_SIGNATURE_up_ref((EVP_SIGNATURE *)data);
+    return EVP_SIGNATURE_up_ref(data);
 }
 
 static EVP_SIGNATURE *evp_signature_new(OSSL_PROVIDER *prov)


### PR DESCRIPTION
Pass functions with correct signatures to the evp_generic_fetch_xxx family of methods. UBSan complains about functions being called with incorrect signatures. Relates to https://github.com/openssl/openssl/issues/22896.