### PR TITLE
80-test_cms.t: Fix incorrect plan from bad merge

### DIFF
--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -52,7 +52,7 @@ my ($no_des, $no_dh, $no_dsa, $no_ec, $no_ec2m, $no_rc2, $no_zlib)
 
 $no_rc2 = 1 if disabled("legacy");
 
-plan tests => 26;
+plan tests => 27;
 
 ok(run(test(["pkcs7_test"])), "test pkcs7");
 


### PR DESCRIPTION
When merging update to a plan and the existing code already has the updated number of tests this is silently merged without a conflict but the test plan is broken.

Urgent fix.
