### PR TITLE
Revert "use-of-uninitialized-value in quic_tserver_test"

### DIFF
--- a/ssl/quic/quic_demux.c
+++ b/ssl/quic/quic_demux.c
@@ -646,7 +646,6 @@ int ossl_quic_demux_inject(QUIC_DEMUX *demux,
 
     /* Move from free list to pending list. */
     ossl_list_urxe_remove(&demux->urx_free, urxe);
-    urxe->datagram_id = demux->next_datagram_id++;
     ossl_list_urxe_insert_tail(&demux->urx_pending, urxe);
     urxe->demux_state = URXE_DEMUX_STATE_PENDING;
 


### PR DESCRIPTION
This reverts commit c2979a6f5026854481f1adf29efa04b9ac042c78.

This struct member is not present in the 3.2 branch code.

This is urgent as the CI on 3.2 branch is currently broken.