### PR TITLE
LoongArch: we should access global symbol by la.global instead of la.pcrel

### DIFF
--- a/crypto/chacha/asm/chacha-loongarch64.pl
+++ b/crypto/chacha/asm/chacha-loongarch64.pl
@@ -72,7 +72,7 @@ ChaCha20_ctr32:
 
 	beqz		$len,.Lno_data
 	ori			$t3,$zero,64
-	la.pcrel	$t0,OPENSSL_loongarch_hwcap_P
+	la.global	$t0,OPENSSL_loongarch_hwcap_P
 	ld.w		$t0,$t0,0
 
 	bleu		$len,$t3,.LChaCha20_1x  # goto 1x when len <= 64


### PR DESCRIPTION
openssl will not be built successfully on LoongArch platform with binutils-2.43.50.20241230
which checks if global symbols are accessed by PC-relative in shared library.

CLA: trivial