### PR TITLE
Revert "Return NULL from ossl_lib_ctx_get_concrete()"

### DIFF
--- a/crypto/context.c
+++ b/crypto/context.c
@@ -47,23 +47,17 @@ struct ossl_lib_ctx_st {
 
 int ossl_lib_ctx_write_lock(OSSL_LIB_CTX *ctx)
 {
-    if ((ctx = ossl_lib_ctx_get_concrete(ctx)) == NULL)
-        return 0;
-    return CRYPTO_THREAD_write_lock(ctx->lock);
+    return CRYPTO_THREAD_write_lock(ossl_lib_ctx_get_concrete(ctx)->lock);
 }
 
 int ossl_lib_ctx_read_lock(OSSL_LIB_CTX *ctx)
 {
-    if ((ctx = ossl_lib_ctx_get_concrete(ctx)) == NULL)
-        return 0;
-    return CRYPTO_THREAD_read_lock(ctx->lock);
+    return CRYPTO_THREAD_read_lock(ossl_lib_ctx_get_concrete(ctx)->lock);
 }
 
 int ossl_lib_ctx_unlock(OSSL_LIB_CTX *ctx)
 {
-    if ((ctx = ossl_lib_ctx_get_concrete(ctx)) == NULL)
-        return 0;
-    return CRYPTO_THREAD_unlock(ctx->lock);
+    return CRYPTO_THREAD_unlock(ossl_lib_ctx_get_concrete(ctx)->lock);
 }
 
 int ossl_lib_ctx_is_child(OSSL_LIB_CTX *ctx)
@@ -179,7 +173,7 @@ static OSSL_LIB_CTX *get_default_context(void)
 {
     OSSL_LIB_CTX *current_defctx = get_thread_default_context();
 
-    if (current_defctx == NULL && default_context_inited)
+    if (current_defctx == NULL)
         current_defctx = &default_context_int;
     return current_defctx;
 }

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -686,9 +686,6 @@ EVP_RAND_CTX *RAND_get0_public(OSSL_LIB_CTX *ctx)
             return NULL;
 
         ctx = ossl_lib_ctx_get_concrete(ctx);
-
-        if (ctx == NULL)
-            return NULL;
         /*
          * If the private is also NULL then this is the first time we've
          * used this thread.
@@ -722,9 +719,6 @@ EVP_RAND_CTX *RAND_get0_private(OSSL_LIB_CTX *ctx)
             return NULL;
 
         ctx = ossl_lib_ctx_get_concrete(ctx);
-
-        if (ctx == NULL)
-            return NULL;
         /*
          * If the public is also NULL then this is the first time we've
          * used this thread.


### PR DESCRIPTION
We do not have default_context_inited in 3.0 branch.

This reverts commit ed7651c93336049c2744327478f4d60bf9c21886.

This is urgent as 3.0 CI is broken.
