### PR TITLE
speed: Pass IV to EVP_CipherInit_ex for -evp runs with non-AEAD ciphers

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -2999,7 +2999,7 @@ int speed_main(int argc, char **argv)
 
                     if (!ae_mode) {
                         if (!EVP_CipherInit_ex(loopargs[k].ctx, NULL, NULL,
-                                               loopargs[k].key, NULL, -1)) {
+                                               loopargs[k].key, iv, -1)) {
                             BIO_printf(bio_err, "\nFailed to set the key\n");
                             dofail();
                             exit(1);


### PR DESCRIPTION
Commit 607a46d003f472d4bce646f3df6e85725094d68a corrected the use of AEAD ciphers, but removed the IV from being passed to EVP_CipherInit_ex() for non-AEAD ciphers.

Running `openssl speed -evp aes-256-xts -bytes 256` seems to perform measurements but it fails with the following and does not really perform any AES-XTS operations, because every operations fails:

```
# openssl speed -evp aes-256-xts -bytes 256
Doing AES-256-XTS ops for 3s on 256 size blocks: 24052955 AES-256-XTS ops in 2.99s
version: 3.5.0-dev
built on: Wed Jan  8 12:35:09 2025 UTC
options: bn(64,64)
compiler: gcc -fPIC -pthread -m64 -Wa,--noexecstack -Wall -O3 -g -ggdb3 -DOPENSSL_USE_NODELETE -DB_ENDIAN -DOPENSSL_PIC -DOPENSSL_BUILDING_OPENSSL -DZLIB -DZLIB_SHARED -DNDEBUG
CPUINFO: OPENSSL_s390xcap=stfle:0xfbebfffbfeffff7c:0x7fce00000000000:0x77003b9804800000:0x0:kimd:0xf0000000fc000000:0x4000000000000000:klmd:0xf0000000fc000000:0x0:km:0xf070383800002828:0x0:kmc:0xf070383800000000:0x1000000000000000:kmac:0xf070383800000000:0x0:kmctr:0xf070383800000000:0x0:kmo:0xf070383800000000:0x0:kmf:0xf070383800000000:0x0:prno:0x9000000000000000:0xa000:kma:0x8000383800000000:0x0:pcc:0xf070383800002828:0xe0c0c00000000000:kdsa:0xf070700088888800:0x0
The 'numbers' are in 1000s of bytes per second processed.
type            256 bytes
AES-256-XTS    2059383.44k
000003FF99AF2080:error:1C800066:Provider routines:aes_xts_stream_update:cipher operation failed:providers/implementations/ciphers/cipher_aes_xts.c:228:
```

The failure is in `aes_xts_cipher()` where `ctx->base.iv_set` is checked. `aes_xts_cipher()` returns 0 if the IV is not set causing `aes_xts_stream_update()` to set the error `PROV_R_CIPHER_OPERATION_FAILED`.

I might also affect other ciphers that require an IV (like CBC), but it seems those do not check if an IV is set. 

