### PR TITLE
Fix intermittent test failure in 80-test_cmp_http.t

### DIFF
--- a/test/recipes/80-test_cmp_http.t
+++ b/test/recipes/80-test_cmp_http.t
@@ -293,7 +293,7 @@ sub start_server {
                           $args ? $args : ()]), display => 1);
     print "Current directory is ".getcwd()."\n";
     print "Launching $server_name server: $cmd\n";
-    my $pid = open($server_fh, "$cmd 2>error.txt |");
+    my $pid = open($server_fh, "$cmd 2>".result_dir()."/error.txt |");
     unless ($pid) {
         print "Error launching $cmd, cannot obtain $server_name server PID";
         return 0;

--- a/test/recipes/80-test_cmp_http.t
+++ b/test/recipes/80-test_cmp_http.t
@@ -293,7 +293,7 @@ sub start_server {
                           $args ? $args : ()]), display => 1);
     print "Current directory is ".getcwd()."\n";
     print "Launching $server_name server: $cmd\n";
-    my $pid = open($server_fh, "$cmd|");
+    my $pid = open($server_fh, "$cmd 2>error.txt |");
     unless ($pid) {
         print "Error launching $cmd, cannot obtain $server_name server PID";
         return 0;


### PR DESCRIPTION
output to stderr is unbuffered bypassing the normal output, which does not happen at line boundaries and is therefore confusing the TAP parser. This is known to cause random test failures like this one:

80-test_cmp_http.t                    (Wstat: 0 Tests: 5 Failed: 0)
  Parse errors: Tests out of sequence.  Found (6) but expected (5)
                Bad plan.  You planned 6 tests but ran 5.

