### PR TITLE
Alternate fix for freebsd ci failure

### DIFF
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -297,8 +297,7 @@ sub start
     # Process the output from s_server until we find the ACCEPT line, which
     # tells us what the accepting address and port are.
     while (<$sout>) {
-        print;
-        s/\R$//; # chomp does not work on windows.
+        chomp;
         next unless (/^ACCEPT\s.*:(\d+)$/);
         $self->{server_port} = $1;
         last;

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -216,7 +216,6 @@ sub start
     my ($self) = shift;
     my $pid;
 
-
     # Create the Proxy socket
     my $proxaddr = $self->{proxy_addr};
     $proxaddr =~ s/[\[\]]//g; # Remove [ and ]

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -290,14 +290,8 @@ sub start
     if ($self->debug) {
         print STDERR "Server command: $execcmd\n";
     }
-    my $sin = undef;
-    my $sout = undef;
-    if ("$^O" eq "MSWin32") {
-        $pid = IPC::Open2::open2($sout, $sin, $execcmd) or die "Failed to $execcmd: $!\n";
-    } else {
-        $pid = IPC::Open3::open3($sin, $sout, undef, $execcmd) or die "Failed to $execcmd: $!\n";
-    }
 
+    $pid = IPC::Open2::open2(my $sout, my $sin, $execcmd) or die "Failed to $execcmd: $!\n";
     $self->{serverpid} = $pid;
 
     # Process the output from s_server until we find the ACCEPT line, which

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -7,7 +7,6 @@
 
 use strict;
 use POSIX ":sys_wait_h";
-use IPC::Open2;
 
 package TLSProxy::Proxy;
 
@@ -205,7 +204,7 @@ sub connect_to_server
                              Proto => $self->{isdtls} ? 'udp' : 'tcp');
     if (!defined($sock)) {
         my $err = $!;
-        kill(3, $self->{serverpid});
+        kill(3, $self->{real_serverpid});
         die "unable to connect: $err\n";
     }
 
@@ -216,6 +215,7 @@ sub start
 {
     my ($self) = shift;
     my $pid;
+
 
     # Create the Proxy socket
     my $proxaddr = $self->{proxy_addr};
@@ -291,13 +291,17 @@ sub start
         print STDERR "Server command: $execcmd\n";
     }
 
-    $pid = IPC::Open2::open2(my $sout, my $sin, $execcmd) or die "Failed to $execcmd: $!\n";
-    $self->{serverpid} = $pid;
+    open(my $savedin, "<&STDIN");
+
+    # Temporarily replace STDIN so that sink process can inherit it...
+    $pid = open(STDIN, "$execcmd 2>&1 |") or die "Failed to $execcmd: $!\n";
+    $self->{real_serverpid} = $pid;
 
     # Process the output from s_server until we find the ACCEPT line, which
     # tells us what the accepting address and port are.
-    while (<$sout>) {
-        chomp;
+    while (<>) {
+        print;
+        s/\R$//;                # Better chomp
         next unless (/^ACCEPT\s.*:(\d+)$/);
         $self->{server_port} = $1;
         last;
@@ -309,6 +313,38 @@ sub start
         waitpid($pid, 0);
         die "no ACCEPT detected in '$execcmd' output: $?\n";
     }
+
+    # Just make sure everything else is simply printed [as separate lines].
+    # The sub process simply inherits our STD* and will keep consuming
+    # server's output and printing it as long as there is anything there,
+    # out of our way.
+    my $error;
+    $pid = undef;
+    if (eval { require Win32::Process; 1; }) {
+        if (Win32::Process::Create(my $h, $^X, "perl -ne print", 0, 0, ".")) {
+            $pid = $h->GetProcessID();
+            $self->{proc_handle} = $h;  # hold handle till next round [or exit]
+        } else {
+            $error = Win32::FormatMessage(Win32::GetLastError());
+        }
+    } else {
+        if (defined($pid = fork)) {
+            $pid or exec("$^X -ne print") or exit($!);
+        } else {
+            $error = $!;
+        }
+    }
+
+    # Change back to original stdin
+    open(STDIN, "<&", $savedin);
+    close($savedin);
+
+    if (!defined($pid)) {
+        kill(3, $self->{real_serverpid});
+        die "Failed to capture s_server's output: $error\n";
+    }
+
+    $self->{serverpid} = $pid;
 
     print STDERR "Server responds on ",
                  "$self->{server_addr}:$self->{server_port}\n";
@@ -366,7 +402,7 @@ sub clientstart
         # dead-lock...
         if (!($pid = open(STDOUT, "| $execcmd"))) {
             my $err = $!;
-            kill(3, $self->{serverpid});
+            kill(3, $self->{real_serverpid});
             die "Failed to $execcmd: $err\n";
         }
         $self->{clientpid} = $pid;
@@ -382,7 +418,7 @@ sub clientstart
     # Wait for incoming connection from client
     my $fdset = IO::Select->new($self->{proxy_sock});
     if (!$fdset->can_read(60)) {
-        kill(3, $self->{serverpid});
+        kill(3, $self->{real_serverpid});
         die "s_client didn't try to connect\n";
     }
 
@@ -441,14 +477,14 @@ sub clientstart
                     $server_sock->shutdown(SHUT_WR);
                 }
             } else {
-                kill(3, $self->{serverpid});
+                kill(3, $self->{real_serverpid});
                 die "Unexpected handle";
             }
         }
     }
 
     if ($ctr >= 10) {
-        kill(3, $self->{serverpid});
+        kill(3, $self->{real_serverpid});
         print "No progress made\n";
         $success = 0;
     }
@@ -467,6 +503,15 @@ sub clientstart
     my $pid;
     if (--$self->{serverconnects} == 0) {
         $pid = $self->{serverpid};
+        print "Waiting for 'perl -ne print' process to close: $pid...\n";
+        $pid = waitpid($pid, 0);
+        if ($pid > 0) {
+            die "exit code $? from 'perl -ne print' process\n" if $? != 0;
+        } elsif ($pid == 0) {
+            kill(3, $self->{real_serverpid});
+            die "lost control over $self->{serverpid}?";
+        }
+        $pid = $self->{real_serverpid};
         print "Waiting for s_server process to close: $pid...\n";
         # it's done already, just collect the exit code [and reap]...
         waitpid($pid, 0);

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -294,6 +294,7 @@ sub start
     open(my $savedin, "<&STDIN");
 
     # Temporarily replace STDIN so that sink process can inherit it...
+    open(STDIN, "$^X -e 'sleep(1)' |");
     $pid = open(STDIN, "$execcmd 2>&1 |") or die "Failed to $execcmd: $!\n";
     $self->{real_serverpid} = $pid;
 


### PR DESCRIPTION
This reverts 3d3bb26a13dcc67f99e66de6a44ae9ced117f64b, 3e94e2b11d73ed22c601f818b31b7c4ca281f5d1 and 4439ed16c5742e5ffb0417d45677900e77b299f2.
For DTLS tests a different fix is used.
The advantage is that the output from s_server command is no longer suppressed,
which could reveal interesting details in case of an error.