### PR TITLE
Remove similar functionality code

### DIFF
--- a/fuzz/test-corpus.c
+++ b/fuzz/test-corpus.c
@@ -40,14 +40,12 @@ static void testfile(const char *pathname)
     FILE *f;
     unsigned char *buf;
     size_t s;
-
-    if (stat(pathname, &st) < 0 || !S_ISREG(st.st_mode))
-        return;
-    printf("# %s\n", pathname);
-    fflush(stdout);
+    
     f = fopen(pathname, "rb");
     if (f == NULL)
         return;
+    printf("# %s\n", pathname);
+    fflush(stdout);
     buf = malloc(st.st_size);
     if (buf != NULL) {
         s = fread(buf, 1, st.st_size, f);


### PR DESCRIPTION
fopen() automatically checks whether the specified file exists, and handles errors, so there is no need to perform an additional check using stat().

[CLA: trivial]

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
