### PR TITLE
coveralls.yml: Add --ignore-errors mismatch

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -84,6 +84,7 @@ jobs:
              --exclude "${PWD}/test/testutil/*"
              --exclude "${PWD}/fuzz/*"
              --exclude "/usr/include/*"
+             --ignore-errors mismatch
               -o ./lcov.info
     - name: Coveralls upload
       uses: coverallsapp/github-action@v2.3.2


### PR DESCRIPTION
Once lcov is updated to 2.2 version or later, it could be dropped.

This is urgent as coveralls CI is failing after the update to newest ubuntu.
