### PR TITLE
Coverity-1638715 - remove dead code from scrypt_alg

### DIFF
--- a/providers/implementations/kdfs/scrypt.c
+++ b/providers/implementations/kdfs/scrypt.c
@@ -507,10 +507,6 @@ static int scrypt_alg(const char *pass, size_t passlen,
         return 0;
     }
 
-    /* Check that the maximum memory doesn't exceed a size_t limits */
-    if (maxmem > SIZE_MAX)
-        maxmem = SIZE_MAX;
-
     if (Blen + Vlen > maxmem) {
         ERR_raise(ERR_LIB_EVP, EVP_R_MEMORY_LIMIT_EXCEEDED);
         return 0;


### PR DESCRIPTION
Coverity noticed that we check for maxmem, which is a uint64_t being larger than SIZE_MAX, which is impossible, leading to a dead code warning.

Just remove the check.

Fixes openssl/project#970

