### PR TITLE
coveralls.yml: Avoid excluding subdirectories of already excluded dirs

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -80,8 +80,6 @@ jobs:
     - name: generate coverage info
       run: lcov -d . -c
              --exclude "${PWD}/test/*"
-             --exclude "${PWD}/test/helpers/*"
-             --exclude "${PWD}/test/testutil/*"
              --exclude "${PWD}/fuzz/*"
              --exclude "/usr/include/*"
              --ignore-errors mismatch


### PR DESCRIPTION
This is again urgent due to Coverage CI failure.