### PR TITLE
`atoi` should be allowed

### DIFF
--- a/util/platform_symbols/unix-symbols.txt
+++ b/util/platform_symbols/unix-symbols.txt
@@ -1,6 +1,7 @@
 abort
 accept
 aligned_alloc
+atoi
 bcmp
 bind
 calloc


### PR DESCRIPTION
When we compile with -O0 for Linux, the command
`./util/checkplatformsyms.pl ./util/platform_symbols/unix-symbols.txt ./libcrypto.so ./libssl.so` complains to the lack of `atoi`

Related: #26407