### PR TITLE
Fix documentation of OSSL_ASYM_CIPHER_PARAM_IMPLICIT_REJECTION

### DIFF
--- a/doc/man3/EVP_PKEY_decrypt.pod
+++ b/doc/man3/EVP_PKEY_decrypt.pod
@@ -61,7 +61,7 @@ used private key. They had to be processed in a side-channel free way.
 Since version 3.2.0, the EVP_PKEY_decrypt() method when used with PKCS#1
 v1.5 padding as implemented in the B<default> provider implements
 the implicit rejection mechanism (see
-B<OSSL_PKEY_PARAM_IMPLICIT_REJECTION> in L<provider-asym_cipher(7)>).
+B<OSSL_ASYM_CIPHER_PARAM_IMPLICIT_REJECTION> in L<provider-asym_cipher(7)>).
 That means it doesn't return an error when it detects an error in padding,
 instead it returns a pseudo-randomly generated message, removing the need
 of side-channel secure code from applications using OpenSSL.

--- a/doc/man7/provider-asym_cipher.pod
+++ b/doc/man7/provider-asym_cipher.pod
@@ -234,14 +234,14 @@ The TLS protocol version first requested by the client.
 
 The negotiated TLS protocol version.
 
-=item "implicit-rejection" (B<OSSL_PKEY_PARAM_IMPLICIT_REJECTION>) <unsigned integer>
+=item "implicit-rejection" (B<OSSL_ASYM_CIPHER_PARAM_IMPLICIT_REJECTION>) <unsigned integer>
 
-Gets of sets the use of the implicit rejection mechanism for RSA PKCS#1 v1.5
+Gets or sets the use of the implicit rejection mechanism for RSA PKCS#1 v1.5
 decryption. When set (non zero value), the decryption API will return
 a deterministically random value if the PKCS#1 v1.5 padding check fails.
 This makes exploitation of the Bleichenbacher significantly harder, even
 if the code using the RSA decryption API is not implemented in side-channel
-free manner. Set by default. Requires provider support.
+free manner. Set by default in OpenSSL providers.
 
 =back
 

--- a/util/perl/OpenSSL/paramnames.pm
+++ b/util/perl/OpenSSL/paramnames.pm
@@ -303,6 +303,9 @@ my %params = (
     'PKEY_PARAM_DIST_ID' =>             "distid",
     'PKEY_PARAM_PUB_KEY' =>             "pub",
     'PKEY_PARAM_PRIV_KEY' =>            "priv",
+    # PKEY_PARAM_IMPLICIT_REJECTION isn't actually used, or meaningful.  We keep
+    # it for API stability, but please use ASYM_CIPHER_PARAM_IMPLICIT_REJECTION
+    # instead.
     'PKEY_PARAM_IMPLICIT_REJECTION' =>  "implicit-rejection",
     'PKEY_PARAM_FIPS_DIGEST_CHECK' =>   "digest-check",
     'PKEY_PARAM_FIPS_KEY_CHECK' =>      "key-check",


### PR DESCRIPTION
This drops `OSSL_PKEY_PARAM_IMPLICIT_REJECTION` - which is a meaningless
name - everywhere apart from still existing (for API stability, in
case someone uses that macro).
