### PR TITLE
this is a just temporal work around to get llvm-mingw working on aarch64

### DIFF
--- a/crypto/perlasm/arm-xlate.pl
+++ b/crypto/perlasm/arm-xlate.pl
@@ -33,6 +33,15 @@ my $rodata = sub {
     SWITCH: for ($flavour) {
 	/linux/		&& return ".section\t.rodata";
 	/ios/		&& return ".section\t__TEXT,__const";
+	/win64/		&& return ".section\t.rodata";
+	last;
+    }
+};
+my $previous = sub {
+    SWITCH: for ($flavour) {
+	/linux/		&& return ".previous";
+	/ios/		&& return ".previous";
+	/win64/		&& return ".text";
 	last;
     }
 };


### PR DESCRIPTION
We can use this workaround as long as there will be no proper support for masm (microsoft assembler) on Windows ARM. The llvm-mingw should be using ming* assembler flavor instead of win64 which is used now.

However proper fix requires more work and hands-on access to Windows ARM.

Fixes #26415

