### PR TITLE
Fix timing side-channel in ECDSA signature computation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -119,6 +119,19 @@ OpenSSL 3.4
 
 ### Changes between 3.4.0 and 3.4.1 [xx XXX xxxx]
 
+ * Fixed timing side-channel in ECDSA signature computation.
+
+   There is a timing signal of around 300 nanoseconds when the top word of
+   the inverted ECDSA nonce value is zero. This can happen with significant
+   probability only for some of the supported elliptic curves. In particular
+   the NIST P-521 curve is affected. To be able to measure this leak, the
+   attacker process must either be located in the same physical computer or
+   must have a very fast network connection with low latency.
+
+   ([CVE-2024-13176])
+
+   *Tomáš Mráz*
+
  * Reverted the behavior change of CMS_get1_certs() and CMS_get1_crls()
    that happened in the 3.4.0 release. These functions now return NULL
    again if there are no certs or crls in the CMS object.
@@ -20978,6 +20991,7 @@ ndif
 
 <!-- Links -->
 
+[CVE-2024-13176]: https://www.openssl.org/news/vulnerabilities.html#CVE-2024-13176
 [CVE-2024-9143]: https://www.openssl.org/news/vulnerabilities.html#CVE-2024-9143
 [CVE-2024-6119]: https://www.openssl.org/news/vulnerabilities.html#CVE-2024-6119
 [CVE-2024-5535]: https://www.openssl.org/news/vulnerabilities.html#CVE-2024-5535

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,12 +49,19 @@ This release adds the following new features:
 OpenSSL 3.4
 -----------
 
-### Major changes between OpenSSL 3.3 and OpenSSL 3.4 [under development]
+### Major changes between OpenSSL 3.4.0 and OpenSSL 3.4.1 [under development]
+
+This release is in development.
+
+This release incorporates the following bug fixes and mitigations:
+
+  * Fixed timing side-channel in ECDSA signature computation.
+    ([CVE-2024-13176])
+
+### Major changes between OpenSSL 3.3 and OpenSSL 3.4.0 [22 Oct 2024]
 
 OpenSSL 3.4.0 is a feature release adding significant new functionality to
 OpenSSL.
-
-This release is in development.
 
 This release incorporates the following potentially significant or incompatible
 changes:
@@ -1848,6 +1855,7 @@ OpenSSL 0.9.x
 
 <!-- Links -->
 
+[CVE-2024-13176]: https://www.openssl.org/news/vulnerabilities.html#CVE-2024-13176
 [CVE-2024-9143]: https://www.openssl.org/news/vulnerabilities.html#CVE-2024-9143
 [CVE-2024-6119]: https://www.openssl.org/news/vulnerabilities.html#CVE-2024-6119
 [CVE-2024-5535]: https://www.openssl.org/news/vulnerabilities.html#CVE-2024-5535

--- a/crypto/bn/bn_exp.c
+++ b/crypto/bn/bn_exp.c
@@ -606,7 +606,7 @@ static int MOD_EXP_CTIME_COPY_FROM_PREBUF(BIGNUM *b, int top,
  * out by Colin Percival,
  * http://www.daemonology.net/hyperthreading-considered-harmful/)
  */
-int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
+int bn_mod_exp_mont_fixed_top(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
                               const BIGNUM *m, BN_CTX *ctx,
                               BN_MONT_CTX *in_mont)
 {
@@ -622,10 +622,6 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
 #if defined(SPARC_T4_MONT)
     unsigned int t4 = 0;
 #endif
-
-    bn_check_top(a);
-    bn_check_top(p);
-    bn_check_top(m);
 
     if (!BN_is_odd(m)) {
         ERR_raise(ERR_LIB_BN, BN_R_CALLED_WITH_EVEN_MODULUS);
@@ -1146,7 +1142,7 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
             goto err;
     } else
 #endif
-    if (!BN_from_montgomery(rr, &tmp, mont, ctx))
+    if (!bn_from_mont_fixed_top(rr, &tmp, mont, ctx))
         goto err;
     ret = 1;
  err:
@@ -1158,6 +1154,19 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
     }
     BN_CTX_end(ctx);
     return ret;
+}
+
+int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
+                              const BIGNUM *m, BN_CTX *ctx,
+                              BN_MONT_CTX *in_mont)
+{
+    bn_check_top(a);
+    bn_check_top(p);
+    bn_check_top(m);
+    if (!bn_mod_exp_mont_fixed_top(rr, a, p, m, ctx, in_mont))
+        return 0;
+    bn_correct_top(rr);
+    return 1;
 }
 
 int BN_mod_exp_mont_word(BIGNUM *rr, BN_ULONG a, const BIGNUM *p,

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -21,6 +21,7 @@
 #include <openssl/opensslv.h>
 #include <openssl/param_build.h>
 #include "crypto/ec.h"
+#include "crypto/bn.h"
 #include "internal/nelem.h"
 #include "ec_local.h"
 
@@ -1265,10 +1266,10 @@ static int ec_field_inverse_mod_ord(const EC_GROUP *group, BIGNUM *r,
     if (!BN_sub(e, group->order, e))
         goto err;
     /*-
-     * Exponent e is public.
-     * No need for scatter-gather or BN_FLG_CONSTTIME.
+     * Although the exponent is public we want the result to be
+     * fixed top.
      */
-    if (!BN_mod_exp_mont(r, x, e, group->order, ctx, group->mont_data))
+    if (!bn_mod_exp_mont_fixed_top(r, x, e, group->order, ctx, group->mont_data))
         goto err;
 
     ret = 1;

--- a/include/crypto/bn.h
+++ b/include/crypto/bn.h
@@ -73,6 +73,9 @@ int bn_set_words(BIGNUM *a, const BN_ULONG *words, int num_words);
  */
 int bn_mul_mont_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
                           BN_MONT_CTX *mont, BN_CTX *ctx);
+int bn_mod_exp_mont_fixed_top(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
+                              const BIGNUM *m, BN_CTX *ctx,
+                              BN_MONT_CTX *in_mont);
 int bn_to_mont_fixed_top(BIGNUM *r, const BIGNUM *a, BN_MONT_CTX *mont,
                          BN_CTX *ctx);
 int bn_from_mont_fixed_top(BIGNUM *r, const BIGNUM *a, BN_MONT_CTX *mont,


### PR DESCRIPTION
There is a timing signal of around 300 nanoseconds when the top word of
the inverted ECDSA nonce value is zero. This can happen with significant
probability only for some of the supported elliptic curves. In particular
the NIST P-521 curve is affected. To be able to measure this leak, the
attacker process must either be located in the same physical computer or
must have a very fast network connection with low latency.

Fixes CVE-2024-13176
