### PR TITLE
Add verbose output to 'openssl list -store-loaders'

### DIFF
--- a/apps/list.c
+++ b/apps/list.c
@@ -1336,20 +1336,29 @@ static void list_store_loaders(void)
                                       stores);
     sk_OSSL_STORE_LOADER_sort(stores);
     for (i = 0; i < sk_OSSL_STORE_LOADER_num(stores); i++) {
-        const OSSL_STORE_LOADER *m = sk_OSSL_STORE_LOADER_value(stores, i);
+        const OSSL_STORE_LOADER *l = sk_OSSL_STORE_LOADER_value(stores, i);
         STACK_OF(OPENSSL_CSTRING) *names = NULL;
 
-        if (select_name != NULL && !OSSL_STORE_LOADER_is_a(m, select_name))
+        if (select_name != NULL && !OSSL_STORE_LOADER_is_a(l, select_name))
             continue;
 
         names = sk_OPENSSL_CSTRING_new(name_cmp);
-        if (names != NULL && OSSL_STORE_LOADER_names_do_all(m, collect_names,
+        if (names != NULL && OSSL_STORE_LOADER_names_do_all(l, collect_names,
                                                             names)) {
             BIO_printf(bio_out, "  ");
             print_names(bio_out, names);
 
             BIO_printf(bio_out, " @ %s\n",
-                       OSSL_PROVIDER_get0_name(OSSL_STORE_LOADER_get0_provider(m)));
+                       OSSL_PROVIDER_get0_name(OSSL_STORE_LOADER_get0_provider(l)));
+
+            if (verbose) {
+                const char *desc = OSSL_STORE_LOADER_get0_description(l);
+
+                if (desc != NULL)
+                    BIO_printf(bio_out, "    description: %s\n", desc);
+                print_param_types("settable operation parameters",
+                                  OSSL_STORE_LOADER_settable_ctx_params(l), 4);
+            }
         }
         sk_OPENSSL_CSTRING_free(names);
     }

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -502,3 +502,11 @@ int OSSL_STORE_LOADER_names_do_all(const OSSL_STORE_LOADER *loader,
 
     return 1;
 }
+
+const OSSL_PARAM *
+OSSL_STORE_LOADER_settable_ctx_params(const OSSL_STORE_LOADER *loader)
+{
+    if (loader != NULL && loader->p_settable_ctx_params != NULL)
+        return loader->p_settable_ctx_params(NULL);
+    return NULL;
+}

--- a/doc/man3/OSSL_STORE_LOADER.pod
+++ b/doc/man3/OSSL_STORE_LOADER.pod
@@ -19,6 +19,7 @@ OSSL_STORE_LOADER_set_attach, OSSL_STORE_LOADER_set_ctrl,
 OSSL_STORE_LOADER_set_expect, OSSL_STORE_LOADER_set_find,
 OSSL_STORE_LOADER_set_load, OSSL_STORE_LOADER_set_eof,
 OSSL_STORE_LOADER_set_error, OSSL_STORE_LOADER_set_close,
+OSSL_STORE_LOADER_settable_ctx_params,
 OSSL_STORE_register_loader, OSSL_STORE_unregister_loader,
 OSSL_STORE_open_fn, OSSL_STORE_open_ex_fn,
 OSSL_STORE_attach_fn, OSSL_STORE_ctrl_fn,
@@ -51,6 +52,8 @@ unregister STORE loaders for different URI schemes
  int OSSL_STORE_LOADER_names_do_all(const OSSL_STORE_LOADER *loader,
                                     void (*fn)(const char *name, void *data),
                                     void *data);
+ const OSSL_PARAM *
+ OSSL_STORE_LOADER_settable_ctx_params(const OSSL_STORE_LOADER *loader);
 
 The following functions have been deprecated since OpenSSL 3.0, and can be
 hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
@@ -147,6 +150,11 @@ I<user_arg> as arguments.
 
 OSSL_STORE_LOADER_names_do_all() traverses all names for the given
 I<loader>, and calls I<fn> with each name and I<data>.
+
+OSSL_STORE_LOADER_settable_ctx_params() return a constant L<OSSL_PARAM(3)> array
+that describes the names and types of key parameters that can be passed to
+L<OSSL_STORE_open_ex(3)>.
+
 
 =head2 Legacy Types and Functions (deprecated)
 
@@ -382,6 +390,8 @@ OSSL_STORE_register_loader(), OSSL_STORE_LOADER_set_error(),
 OSSL_STORE_unregister_loader(), OSSL_STORE_open_fn(), OSSL_STORE_ctrl_fn(),
 OSSL_STORE_load_fn(), OSSL_STORE_eof_fn() and OSSL_STORE_close_fn()
 were added in OpenSSL 1.1.1, and became deprecated in OpenSSL 3.0.
+
+OSSL_STORE_LOADER_settable_ctx_params() was added in OpenSSL 3.6.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/store.h
+++ b/include/openssl/store.h
@@ -279,6 +279,8 @@ void OSSL_STORE_LOADER_do_all_provided(OSSL_LIB_CTX *libctx,
 int OSSL_STORE_LOADER_names_do_all(const OSSL_STORE_LOADER *loader,
                                    void (*fn)(const char *name, void *data),
                                    void *data);
+const OSSL_PARAM *
+OSSL_STORE_LOADER_settable_ctx_params(const OSSL_STORE_LOADER *loader);
 
 /*-
  *  Function to register a loader for the given URI scheme.

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5927,3 +5927,4 @@ PEM_ASN1_write_bio_ctx                  ?	3_5_0	EXIST::FUNCTION:
 OPENSSL_sk_set_thunks                   ?	3_6_0	EXIST::FUNCTION:
 i2d_PKCS8PrivateKey                     ?	3_6_0	EXIST::FUNCTION:
 OSSL_PARAM_set_octet_string_or_ptr      ?	3_6_0	EXIST::FUNCTION:
+OSSL_STORE_LOADER_settable_ctx_params   ?	3_6_0	EXIST::FUNCTION:


### PR DESCRIPTION
The provider based STORE loaders do have settable parameters, so they should
be displayed when `-verbose` is given, just like for any other list.

Out of necessity, this also introduces `OSSL_STORE_LOADER_settable_ctx_params()`