### PR TITLE
Move rodata to .rodata section for armv8

### DIFF
--- a/crypto/sm4/asm/sm4-armv8.pl
+++ b/crypto/sm4/asm/sm4-armv8.pl
@@ -118,7 +118,10 @@ ___
 
 {{{
 $code.=<<___;
+.rodata
 .align	6
+.type _${prefix}_consts,%object
+_${prefix}_consts:
 .Lck:
 	.long 0x00070E15, 0x1C232A31, 0x383F464D, 0x545B6269
 	.long 0x70777E85, 0x8C939AA1, 0xA8AFB6BD, 0xC4CBD2D9
@@ -130,6 +133,9 @@ $code.=<<___;
 	.long 0x10171E25, 0x2C333A41, 0x484F565D, 0x646B7279
 .Lfk:
 	.long 0xa3b1bac6, 0x56aa3350, 0x677d9197, 0xb27022dc
+.size _${prefix}_consts,.-_${prefix}_consts
+
+.previous
 ___
 }}}
 
@@ -146,9 +152,11 @@ $code.=<<___;
 ${prefix}_set_encrypt_key:
 	AARCH64_VALID_CALL_TARGET
 	ld1	{$key0.4s},[$key]
-	adr	$tmp,.Lfk
+	adrp	$tmp, _${prefix}_consts
+	add	$tmp,$tmp,#:lo12:.Lfk
 	ld1	{$fkconst.4s},[$tmp]
-	adr	$tmp,.Lck
+	adrp	$tmp, _${prefix}_consts
+	add	$tmp,$tmp,#:lo12:.Lck
 	ld1	{$const0.4s,$const1.4s,$const2.4s,$const3.4s},[$tmp],64
 ___
 	&rev32($key0, $key0);
@@ -183,9 +191,11 @@ $code.=<<___;
 ${prefix}_set_decrypt_key:
 	AARCH64_VALID_CALL_TARGET
 	ld1	{$key0.4s},[$key]
-	adr	$tmp,.Lfk
+	adrp	$tmp, _${prefix}_consts
+	add	$tmp,$tmp,#:lo12:.Lfk
 	ld1	{$fkconst.4s},[$tmp]
-	adr	$tmp, .Lck
+	adrp	$tmp, _${prefix}_consts
+	add	$tmp,$tmp,#:lo12:.Lck
 	ld1	{$const0.4s,$const1.4s,$const2.4s,$const3.4s},[$tmp],64
 ___
 	&rev32($key0, $key0);

--- a/crypto/sm4/asm/vpsm4-armv8.pl
+++ b/crypto/sm4/asm/vpsm4-armv8.pl
@@ -474,7 +474,8 @@ sub load_sbox () {
 	my $data = shift;
 
 $code.=<<___;
-	adr	$ptr,.Lsbox
+	adrp	$ptr, _${prefix}_consts
+	add	$ptr,$ptr,#:lo12:.Lsbox
 	ld1	{@sbox[0].16b,@sbox[1].16b,@sbox[2].16b,@sbox[3].16b},[$ptr],#64
 	ld1	{@sbox[4].16b,@sbox[5].16b,@sbox[6].16b,@sbox[7].16b},[$ptr],#64
 	ld1	{@sbox[8].16b,@sbox[9].16b,@sbox[10].16b,@sbox[11].16b},[$ptr],#64
@@ -524,7 +525,8 @@ sub compute_tweak_vec() {
 	my $std = shift;
 	&rbit(@vtmp[2],$src,$std);
 $code.=<<___;
-	ldr  @qtmp[0], .Lxts_magic
+	adrp $xtmp2, _${prefix}_consts
+	ldr  @qtmp[0], [$xtmp2,#:lo12:.Lxts_magic]
 	shl  $des.16b, @vtmp[2].16b, #1
 	ext  @vtmp[1].16b, @vtmp[2].16b, @vtmp[2].16b,#15
 	ushr @vtmp[1].16b, @vtmp[1].16b, #7
@@ -539,9 +541,10 @@ $code=<<___;
 .arch	armv8-a
 .text
 
-.type	_vpsm4_consts,%object
+.rodata
+.type	_${prefix}_consts,%object
 .align	7
-_vpsm4_consts:
+_${prefix}_consts:
 .Lsbox:
 	.byte 0xD6,0x90,0xE9,0xFE,0xCC,0xE1,0x3D,0xB7,0x16,0xB6,0x14,0xC2,0x28,0xFB,0x2C,0x05
 	.byte 0x2B,0x67,0x9A,0x76,0x2A,0xBE,0x04,0xC3,0xAA,0x44,0x13,0x26,0x49,0x86,0x06,0x99
@@ -575,7 +578,8 @@ _vpsm4_consts:
 .Lxts_magic:
 	.quad 0x0101010101010187,0x0101010101010101
 
-.size	_vpsm4_consts,.-_vpsm4_consts
+.size	_${prefix}_consts,.-_${prefix}_consts
+.previous
 ___
 
 {{{
@@ -592,13 +596,16 @@ ___
 	&load_sbox();
 	&rev32($vkey,$vkey);
 $code.=<<___;
-	adr	$pointer,.Lshuffles
+	adrp	$pointer, _${prefix}_consts
+	add	$pointer,$pointer,#:lo12:.Lshuffles
 	ld1	{$vmap.2d},[$pointer]
-	adr	$pointer,.Lfk
+	adrp	$pointer, _${prefix}_consts
+	add	$pointer,$pointer,#:lo12:.Lfk
 	ld1	{$vfk.2d},[$pointer]
 	eor	$vkey.16b,$vkey.16b,$vfk.16b
 	mov	$schedules,#32
-	adr	$pointer,.Lck
+	adrp	$pointer, _${prefix}_consts
+	add	$pointer,$pointer,#:lo12:.Lck
 	movi	@vtmp[0].16b,#64
 	cbnz	$enc,1f
 	add	$keys,$keys,124


### PR DESCRIPTION
Adds missing files where asm code is generated by
perl scripts and read only constant is used

PR #24137

closes #23312

