### PR TITLE
[msvc] Fix compiler error C2371

### DIFF
--- a/include/openssl/byteorder.h
+++ b/include/openssl/byteorder.h
@@ -21,6 +21,7 @@
  */
 
 # if defined(_MSC_VER) && _MSC_VER>=1300
+#  include <stdlib.h>
 #  pragma intrinsic(_byteswap_ushort)
 #  pragma intrinsic(_byteswap_ulong)
 #  pragma intrinsic(_byteswap_uint64)


### PR DESCRIPTION
Compiling byteorder_test.c with VS2022 produces the following warnings and errors:

E:\build\kiyolee\openssl\include\openssl\byteorder.h(24,21): warning C4164: '_byteswap_ushort': intrinsic function not declared
(compiling source file '../../../test/byteorder_test.c')
E:\build\kiyolee\openssl\include\openssl\byteorder.h(25,21): warning C4164: '_byteswap_ulong': intrinsic function not declared
(compiling source file '../../../test/byteorder_test.c')
E:\build\kiyolee\openssl\include\openssl\byteorder.h(26,21): warning C4164: '_byteswap_uint64': intrinsic function not declared
(compiling source file '../../../test/byteorder_test.c')
E:\build\kiyolee\openssl\include\openssl\byteorder.h(112,18): warning C4013: '_byteswap_ushort' undefined; assuming extern returning int
(compiling source file '../../../test/byteorder_test.c')
E:\build\kiyolee\openssl\include\openssl\byteorder.h(144,18): warning C4013: '_byteswap_ulong' undefined; assuming extern returning int
(compiling source file '../../../test/byteorder_test.c')
E:\build\kiyolee\openssl\include\openssl\byteorder.h(182,18): warning C4013: '_byteswap_uint64' undefined; assuming extern returning int
(compiling source file '../../../test/byteorder_test.c')
C:\Program Files (x86)\Windows
Kits\10\Include\10.0.22621.0\ucrt\stdlib.h(298,41): error C2371: '_byteswap_ushort': redefinition; different basic types
(compiling source file '../../../test/byteorder_test.c')
C:\Program Files (x86)\Windows
Kits\10\Include\10.0.22621.0\ucrt\stdlib.h(299,41): warning C4142: '_byteswap_ulong': benign redefinition of type
(compiling source file '../../../test/byteorder_test.c')
C:\Program Files (x86)\Windows
Kits\10\Include\10.0.22621.0\ucrt\stdlib.h(300,41): error C2371: '_byteswap_uint64': redefinition; different basic types
(compiling source file '../../../test/byteorder_test.c')

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
