### PR TITLE
Give DTLS tests more time to complete

### DIFF
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -293,7 +293,7 @@ sub start
     open(my $savedin, "<&STDIN");
 
     # Temporarily replace STDIN so that sink process can inherit it...
-    open(STDIN, "$^X -e 'sleep(1)' |");
+    open(STDIN, "$^X -e 'sleep(10)' |") if $self->{isdtls};
     $pid = open(STDIN, "$execcmd 2>&1 |") or die "Failed to $execcmd: $!\n";
     $self->{real_serverpid} = $pid;
 


### PR DESCRIPTION
Increase the timeout for DTLS tests to 10 seconds. But do that only for DTLS as this would waste time for other tests, most of the TLS tests do not need this at all.

Fixes #26491
