### PR TITLE
Fix data race in asn1_str2tag() on tntmp which was accidentally made static

### DIFF
--- a/crypto/asn1/asn1_gen.c
+++ b/crypto/asn1/asn1_gen.c
@@ -499,7 +499,8 @@ static int append_exp(tag_exp_arg *arg, int exp_tag, int exp_class,
 static int asn1_str2tag(const char *tagstr, int len)
 {
     unsigned int i;
-    static const struct tag_name_st *tntmp, tnst[] = {
+    const struct tag_name_st *tntmp;
+    static const struct tag_name_st tnst[] = {
         ASN1_GEN_STR("BOOL", V_ASN1_BOOLEAN),
         ASN1_GEN_STR("BOOLEAN", V_ASN1_BOOLEAN),
         ASN1_GEN_STR("NULL", V_ASN1_NULL),


### PR DESCRIPTION
Variables `tntmp` and `tnst` are declared in the same declaration and thus share storage class specifiers (`static`). This is unfortunate as `tntmp` is used during iteration through `tnst` array and shouldn't be static. In particular this leads to two problems that may arise when multiple threads are executing `asn1_str2tag()` concurrently:
1. `asn1_str2tag()` might return value that doesn't correspond to `tagstr` parameter. This can happen if other thread modifies `tntmp` to point to a different `tnst` element right after a successful name check in the if statement.
2. `asn1_str2tag()` might perform an out-of-bounds read of `tnst` array. This can happen when multiple threads all first execute `tntmp = tnst;` line and then start executing the loop. If that case those threads can end up incrementing `tntmp` past the end of `tnst` array.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->