### PR TITLE
add_uris_recursive(): Avoid OSSL_STORE_INFO leak on error

### DIFF
--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -993,16 +993,17 @@ static int add_uris_recursive(STACK_OF(X509_NAME) *stack,
     OSSL_STORE_CTX *ctx = NULL;
     X509 *x = NULL;
     X509_NAME *xn = NULL;
+    OSSL_STORE_INFO *info = NULL;
 
     if ((ctx = OSSL_STORE_open(uri, NULL, NULL, NULL, NULL)) == NULL)
         goto err;
 
     while (!OSSL_STORE_eof(ctx) && !OSSL_STORE_error(ctx)) {
-        OSSL_STORE_INFO *info = OSSL_STORE_load(ctx);
-        int infotype = info == 0 ? 0 : OSSL_STORE_INFO_get_type(info);
+        int infotype;
 
-        if (info == NULL)
+        if ((info = OSSL_STORE_load(ctx)) == NULL)
             continue;
+        infotype = OSSL_STORE_INFO_get_type(info);
 
         if (infotype == OSSL_STORE_INFO_NAME) {
             /*
@@ -1027,6 +1028,7 @@ static int add_uris_recursive(STACK_OF(X509_NAME) *stack,
         }
 
         OSSL_STORE_INFO_free(info);
+        info = NULL;
     }
 
     ERR_clear_error();
@@ -1034,6 +1036,7 @@ static int add_uris_recursive(STACK_OF(X509_NAME) *stack,
 
  err:
     ok = 0;
+    OSSL_STORE_INFO_free(info);
  done:
     OSSL_STORE_close(ctx);
 


### PR DESCRIPTION
Fixes #26480
