### PR TITLE
Fix potential leak in error path in cert_response()

### DIFF
--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -736,8 +736,10 @@ static int cert_response(OSSL_CMP_CTX *ctx, int sleep, int rid,
         ERR_add_error_data(1, "; cannot extract certificate from response");
         return 0;
     }
-    if (!ossl_cmp_ctx_set0_newCert(ctx, cert))
+    if (!ossl_cmp_ctx_set0_newCert(ctx, cert)) {
+        X509_free(cert);
         return 0;
+    }
 
     /*
      * if the CMP server returned certificates in the caPubs field, copy them


### PR DESCRIPTION
get1_cert_status() returns an object that must be freed, but the error path does not do that.
Fix it by adding a call to X509_free() in the error path.

This was found by an experimental static analyser I'm working on.