### PR TITLE
Fix passing struct by value rather than by reference to syscall

### DIFF
--- a/engines/e_afalg.c
+++ b/engines/e_afalg.c
@@ -164,7 +164,7 @@ static ossl_inline int io_getevents(aio_context_t ctx, long min, long max,
             ts32.tv_sec = (__kernel_long_t) timeout->tv_sec;
             ts32.tv_nsec = (__kernel_long_t) timeout->tv_nsec;
 
-            return syscall(__NR_io_getevents, ctx, min, max, events, ts32);
+            return syscall(__NR_io_getevents, ctx, min, max, events, &ts32);
         } else {
             return syscall(__NR_io_getevents, ctx, min, max, events, NULL);
         }


### PR DESCRIPTION
[engines/e_afalg.c:168](https://github.com/openssl/openssl/blob/e5499a3cac1e823c3e0697e8667e952317b70cc8/engines/e_afalg.c#L168) passes a `struct __timespec32` to `syscall(__NR_io_getevents, ...)`, which expects a `struct timespec *`. This is most likely undefined behaviour. I believe the line should be `return syscall(__NR_io_getevents, ctx, min, max, events, &ts32);` (instead of passing `ts32` by value).

I suspect this hasn't been caught previously since this function is only ever called with an all-zero `timeout`, so the struct is reinterpreted as NULL.

Fixes #26521
