### PR TITLE
Fix magic + 20 in PEM_ASN1_write_bio

### DIFF
--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -356,9 +356,8 @@ PEM_ASN1_write_bio_internal(
         dsize = 0;
         goto err;
     }
-    /* dsize + 8 bytes are needed */
-    /* actually it needs the cipher block size extra... */
-    data = OPENSSL_malloc((unsigned int)dsize + 20);
+    /* Allocate enough space for one extra cipher block */
+    data = OPENSSL_malloc((unsigned int)dsize + EVP_MAX_BLOCK_LENGTH);
     if (data == NULL)
         goto err;
     p = data;


### PR DESCRIPTION
Fixes #26476

In the file crypto/pem/pem_lib.c the function had a +20 to account for padding in the data size, however this was recognized to not be up to standard quality. Instead it has now been updated to use the static maximum block size and uses that for the calculation as opposed to a +20.

CLA: trivial

@bbbrumley 
