### PR TITLE
Allow for retries if we've reached our max stream limit

### DIFF
--- a/demos/guide/quic-hq-interop.c
+++ b/demos/guide/quic-hq-interop.c
@@ -529,6 +529,8 @@ static size_t build_request_set(SSL *ssl)
     char req_string[REQ_STRING_SZ];
     SSL *new_stream;
     size_t written;
+    unsigned long error;
+    size_t retry_count;
 
     /*
      * Free any previous poll list
@@ -607,11 +609,32 @@ static size_t build_request_set(SSL *ssl)
 
         /*
          * We don't strictly have to do this check, but our quic client limits
-         * our max data streams to 100, so we're just batching in groups of 100
+         * our max data streams to 25, so we're just batching in groups of 100
          * for now
+         * NOTE: WE are doing groups of 25 because thats 1/4 of the initial max
+         * stream count that most servers advertise.  This gives the server an
+         * opportunity to send us updated MAX_STREAM frames to extend our stream
+         * allotment, which many servers defer doing.
          */
-        if (poll_count <= 99)
-            new_stream = SSL_new_stream(ssl, 0);
+        if (poll_count <= 25) {
+            for (retry_count = 0; retry_count < 10; retry_count++) {
+                ERR_clear_error();
+                new_stream = SSL_new_stream(ssl, 0);
+                if (new_stream == NULL && (error = ERR_get_error()) != 0) {
+                    if (ERR_GET_REASON(error) == SSL_R_STREAM_COUNT_LIMITED) {
+                        /*
+                         * Kick the SSL state machine in the hopes that
+                         * the server has a MAX_STREAM frame for us to process
+                         */
+                        fprintf(stderr, "Stream limit reached, retrying\n");
+                        SSL_handle_events(ssl);
+                        continue;
+                    }
+                    break;
+                }
+                break;
+            }
+        }
 
         if (new_stream == NULL) {
             /*


### PR DESCRIPTION
Several servers defer the sending of max stream frames.  

For instance quic-go uses a go-routine to do the sending after sufficient existing streams have finished, while mvfst seems to wait for a number of outstanding streams to be closed before issuing a new batch. 

This result in the client, if all streams are in use, getting a transient NULL return from SSL_new_stream().    The error is fairly random, but appears to be consistent on our server branch in the CI environment. 

Because our hq-interop client, which is used for interop testing, batches stream requests at the rate of 100 per batch (which happens to be the hard coded maximum number of streams allowed prior to the recept of a MAX_STREAM frame from the server, allowing for additional streams to be created), we occasionally get the NULL return from SSL_new_stream() above.  So we need to handle that event.

Fix it by doing two things:

1) Reduce our batch number to 25 (i.e. about 1/4 of our typical initial max bidi stream count).  This gives us the potential opportunity to trigger a new MAX_STREAM frame from the server before we reach our limit.  It would be nice if we had an API that exposed what our current max stream number is, but until that time, we're left with hard coding this.

2) In the event that we get a NULL return from SSL_new_stream(), introduce a limited retry operation, in which we check the error stack for the SSL_R_STREAM_COUNT_LIMITED error.  If found, kick the quic reactor to process any inbound frames (in the hope that we've been sent a new MAX_STREAM frame) via a call to SSL_handle_events(), and then retry the operation up to 10 times, before giving up.

Making these adjustments lets us pass the multiplexing interop test consistently with all servers.


##### Checklist
- [x] tests are added or updated
