### PR TITLE
Expose the provider `c_get_params` function via PROV_CTX.

### DIFF
--- a/providers/baseprov.c
+++ b/providers/baseprov.c
@@ -181,6 +181,7 @@ int ossl_base_provider_init(const OSSL_CORE_HANDLE *handle,
                                        (OSSL_LIB_CTX *)c_get_libctx(handle));
     ossl_prov_ctx_set0_handle(*provctx, handle);
     ossl_prov_ctx_set0_core_bio_method(*provctx, corebiometh);
+    ossl_prov_ctx_set0_core_get_params(*provctx, c_get_params);
 
     *out = base_dispatch_table;
 

--- a/providers/common/include/prov/provider_ctx.h
+++ b/providers/common/include/prov/provider_ctx.h
@@ -14,11 +14,13 @@
 # include <openssl/crypto.h>
 # include <openssl/bio.h>
 # include <openssl/core.h>
+# include <openssl/core_dispatch.h>
 
 typedef struct prov_ctx_st {
     const OSSL_CORE_HANDLE *handle;
     OSSL_LIB_CTX *libctx;         /* For all provider modules */
     BIO_METHOD *corebiometh;
+    OSSL_FUNC_core_get_params_fn *core_get_params;
 } PROV_CTX;
 
 /*
@@ -33,8 +35,13 @@ void ossl_prov_ctx_free(PROV_CTX *ctx);
 void ossl_prov_ctx_set0_libctx(PROV_CTX *ctx, OSSL_LIB_CTX *libctx);
 void ossl_prov_ctx_set0_handle(PROV_CTX *ctx, const OSSL_CORE_HANDLE *handle);
 void ossl_prov_ctx_set0_core_bio_method(PROV_CTX *ctx, BIO_METHOD *corebiometh);
+void
+ossl_prov_ctx_set0_core_get_params(PROV_CTX *ctx,
+                                   OSSL_FUNC_core_get_params_fn *c_get_params);
 OSSL_LIB_CTX *ossl_prov_ctx_get0_libctx(PROV_CTX *ctx);
 const OSSL_CORE_HANDLE *ossl_prov_ctx_get0_handle(PROV_CTX *ctx);
 BIO_METHOD *ossl_prov_ctx_get0_core_bio_method(PROV_CTX *ctx);
+OSSL_FUNC_core_get_params_fn *ossl_prov_ctx_get0_core_get_params(PROV_CTX *ctx);
+int ossl_prov_ctx_get_bool_param(PROV_CTX *ctx, const char *name, int defval);
 
 #endif

--- a/providers/common/provider_ctx.c
+++ b/providers/common/provider_ctx.c
@@ -8,6 +8,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 #include "prov/provider_ctx.h"
 #include "prov/bio.h"
 
@@ -39,6 +40,14 @@ void ossl_prov_ctx_set0_core_bio_method(PROV_CTX *ctx, BIO_METHOD *corebiometh)
         ctx->corebiometh = corebiometh;
 }
 
+void
+ossl_prov_ctx_set0_core_get_params(PROV_CTX *ctx,
+                                   OSSL_FUNC_core_get_params_fn *c_get_params)
+{
+    if (ctx != NULL)
+        ctx->core_get_params = c_get_params;
+}
+
 OSSL_LIB_CTX *ossl_prov_ctx_get0_libctx(PROV_CTX *ctx)
 {
     if (ctx == NULL)
@@ -58,4 +67,45 @@ BIO_METHOD *ossl_prov_ctx_get0_core_bio_method(PROV_CTX *ctx)
     if (ctx == NULL)
         return NULL;
     return ctx->corebiometh;
+}
+
+OSSL_FUNC_core_get_params_fn *ossl_prov_ctx_get0_core_get_params(PROV_CTX *ctx)
+{
+    if (ctx == NULL)
+        return NULL;
+    return ctx->core_get_params;
+}
+
+int ossl_prov_ctx_get_bool_param(PROV_CTX *ctx, const char *name, int defval)
+{
+    char *val = NULL;
+    OSSL_PARAM param[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
+
+    if (ctx == NULL
+        || ctx->handle == NULL
+        || ctx->core_get_params == NULL)
+        return defval;
+
+    param[0].key = (char *)name;
+    param[0].data_type = OSSL_PARAM_UTF8_PTR;
+    param[0].data = (void *) &val;
+    param[0].data_size = sizeof(val);
+    param[0].return_size = OSSL_PARAM_UNMODIFIED;
+
+    /* Errors are ignored, returning the default value */
+    if (ctx->core_get_params(ctx->handle, param)
+        && OSSL_PARAM_modified(param)
+        && val != NULL) {
+        if ((strcmp(val, "1") == 0)
+            || (OPENSSL_strcasecmp(val, "yes") == 0)
+            || (OPENSSL_strcasecmp(val, "true") == 0)
+            || (OPENSSL_strcasecmp(val, "on") == 0))
+            return 1;
+        else if ((strcmp(val, "0") == 0)
+                 || (OPENSSL_strcasecmp(val, "no") == 0)
+                 || (OPENSSL_strcasecmp(val, "false") == 0)
+                 || (OPENSSL_strcasecmp(val, "off") == 0))
+            return 0;
+    }
+    return defval;
 }

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -661,6 +661,7 @@ int ossl_default_provider_init(const OSSL_CORE_HANDLE *handle,
                                        (OSSL_LIB_CTX *)c_get_libctx(handle));
     ossl_prov_ctx_set0_handle(*provctx, handle);
     ossl_prov_ctx_set0_core_bio_method(*provctx, corebiometh);
+    ossl_prov_ctx_set0_core_get_params(*provctx, c_get_params);
 
     *out = deflt_dispatch_table;
     ossl_prov_cache_exported_algorithms(deflt_ciphers, exported_ciphers);

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -816,6 +816,7 @@ int OSSL_provider_init_int(const OSSL_CORE_HANDLE *handle,
     }
 
     ossl_prov_ctx_set0_libctx(*provctx, libctx);
+    ossl_prov_ctx_set0_core_get_params(*provctx, c_get_params);
     ossl_prov_ctx_set0_handle(*provctx, handle);
 
     *out = fips_dispatch_table;


### PR DESCRIPTION
The various "mumbleprov.c" files squirrel-away a private `c_get_params` callback function into the core, that can be used for parameter lookup, but this is not available in the dispatch functions of keymanagement, decoder, ... modules.

This function is (optionally) added to the PROV_CTX by the "base", "default" and "tips" providers, making it available to dispatch functions that have access to a `provctx`.