### PR TITLE
[providers/implementations/ciphers] make aes-gcm-siv work with zero-l…

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_gcm_siv.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm_siv.c
@@ -144,13 +144,6 @@ static int ossl_aes_gcm_siv_cipher(void *vctx, unsigned char *out, size_t *outl,
     if (!ossl_prov_is_running())
         return 0;
 
-    /* The RFC has a test case for this, but we don't try to do anything */
-    if (inl == 0) {
-        if (outl != NULL)
-            *outl = 0;
-        return 1;
-    }
-
     if (outsize < inl) {
         ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
         return 0;

--- a/providers/implementations/ciphers/cipher_aes_gcm_siv_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm_siv_hw.c
@@ -162,7 +162,7 @@ static int aes_gcm_siv_encrypt(PROV_AES_GCM_SIV_CTX *ctx, const unsigned char *i
     if (!ctx->speed && ctx->used_enc)
         return 0;
     /* need to check the size of the input! */
-    if (len64 > ((int64_t)1 << 36) || len == 0)
+    if (len64 > ((int64_t)1 << 36))
         return 0;
 
     if (IS_LITTLE_ENDIAN) {
@@ -223,7 +223,7 @@ static int aes_gcm_siv_decrypt(PROV_AES_GCM_SIV_CTX *ctx, const unsigned char *i
     if (!ctx->speed && ctx->used_dec)
         return 0;
     /* need to check the size of the input! */
-    if (len64 > ((int64_t)1 << 36) || len == 0)
+    if (len64 > ((int64_t)1 << 36))
         return 0;
 
     memcpy(counter_block, ctx->user_tag, sizeof(counter_block));

--- a/test/recipes/30-test_evp_data/evpciph_aes_gcm_siv.txt
+++ b/test/recipes/30-test_evp_data/evpciph_aes_gcm_siv.txt
@@ -17,6 +17,24 @@ FIPSversion = >=3.2.0
 Cipher = aes-128-gcm-siv
 Key = 01000000000000000000000000000000
 IV = 030000000000000000000000
+Tag = dc20e2d83f25705bb49e439eca56de25
+Plaintext = 
+Ciphertext = 
+
+
+FIPSversion = >=3.2.0
+Cipher = aes-128-gcm-siv
+Key = e66021d5eb8e4f4066d4adb9c33560e4
+IV = f46e44bb3da0015c94f70887
+Tag = a4194b79071b01a87d65f706e3949578
+Plaintext = 
+Ciphertext = 
+
+
+FIPSversion = >=3.2.0
+Cipher = aes-128-gcm-siv
+Key = 01000000000000000000000000000000
+IV = 030000000000000000000000
 Tag = 578782fff6013b815b287c22493a364c
 Plaintext = 0100000000000000
 Ciphertext = b5d839330ac7b786
@@ -227,6 +245,24 @@ Ciphertext = 391cc328d484a4f46406181bcd62efd9b3ee197d05
 
 
 # AES_256_GCM_SIV
+
+
+FIPSversion = >=3.2.0
+Cipher = aes-256-gcm-siv
+Key = 0100000000000000000000000000000000000000000000000000000000000000
+IV = 030000000000000000000000
+Tag = 07f5f4169bbf55a8400cd47ea6fd400f
+Plaintext = 
+Ciphertext = 
+
+
+FIPSversion = >=3.2.0
+Cipher = aes-256-gcm-siv
+Key = e66021d5eb8e4f4066d4adb9c33560e4f46e44bb3da0015c94f7088736864200
+IV = e0eaf5284d884a0e77d31646
+Tag = 169fbb2fbf389a995f6390af22228a62
+Plaintext = 
+Ciphertext = 
 
 
 FIPSversion = >=3.2.0


### PR DESCRIPTION
…ength messages

test cases lifted from RFC 8452

fixes #26431

tagging @romen 

##### Checklist
- [x] tests are added or updated