### PR TITLE
Exclude amplificationlimit test with mvfst client

### DIFF
--- a/.github/workflows/run_quic_interop_server.yml
+++ b/.github/workflows/run_quic_interop_server.yml
@@ -40,6 +40,9 @@ jobs:
       matrix:
         tests: [http3, transfer, handshake, retry, chacha20, resumption, amplificationlimit]
         clients: [quic-go, ngtcp2, mvfst, quiche, msquic, openssl]
+        exclude:
+          - clients: mvfst
+            tests: amplificationlimit
       fail-fast: false
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The amplificationlimit interop test is failing currently with our server.

However, based on the global nightly runs here:
https://github.com/openssl/openssl/actions/runs/12860128783/job/35851614148

it appears to be failing in all test cases.

Some analysis indicates that the client appears to abort operations early during frame loss in this test.

As such just exclude the combination of this test and client.  Re-add it later if it ever becomes functional

Fixes openssl/project#1062


##### Checklist
- [x] tests are added or updated
