### PR TITLE
Fix make-release workflow event trigger

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -10,7 +10,7 @@ name: "Make release"
 on:
   push:
     tags:
-      - "openssl-*"
+      - "openssl-**"
 
 jobs:
   release:


### PR DESCRIPTION
Otherwise this workflow won't be triggered. Moreover, this workflow must be backported to all openssl-3.x branches. Should I create separate PRs?
