### PR TITLE
Disable server address validation for resumption test

### DIFF
--- a/test/quic-openssl-docker/run_endpoint.sh
+++ b/test/quic-openssl-docker/run_endpoint.sh
@@ -91,8 +91,11 @@ elif [ "$ROLE" == "server" ]; then
     "handshake"|"transfer"|"ipv6")
         NO_ADDR_VALIDATE=yes SSLKEYLOGFILE=/logs/keys.log FILEPREFIX=/www quic-hq-interop-server 443 /certs/cert.pem /certs/priv.key
         ;;
-    "retry"|"resumption")
-     	SSLKEYLOGFILE=/logs/keys.log FILEPREFIX=/www quic-hq-interop-server 443 /certs/cert.pem /certs/priv.key
+    "retry")
+        SSLKEYLOGFILE=/logs/keys.log FILEPREFIX=/www quic-hq-interop-server 443 /certs/cert.pem /certs/priv.key
+        ;;
+    "resumption")
+        NO_ADDR_VALIDATE=yes SSLKEYLOGFILE=/logs/keys.log FILEPREFIX=/www quic-hq-interop-server 443 /certs/cert.pem /certs/priv.key
         ;;
     "http3")
         FILEPREFIX=/www/ SSLKEYLOGFILE=/logs/keys.log ossl-nghttp3-demo-server 443 /certs/cert.pem /certs/priv.key


### PR DESCRIPTION
The quic-interop runner expects a handshake message and certificate exchange in the first 3 frames in this test.  The addition of server address validation retry frames causes the test to fail.  Strictly speaking this is a shortcoming of the test, but disabling address validation allows the test to pass, and we have the mechanism, so disable the feature.

Fixes openssl/project#1061


##### Checklist
- [x] tests are added or updated
