### PR TITLE
Expose another prov param accessor

### DIFF
--- a/providers/common/include/prov/provider_ctx.h
+++ b/providers/common/include/prov/provider_ctx.h
@@ -42,6 +42,8 @@ OSSL_LIB_CTX *ossl_prov_ctx_get0_libctx(PROV_CTX *ctx);
 const OSSL_CORE_HANDLE *ossl_prov_ctx_get0_handle(PROV_CTX *ctx);
 BIO_METHOD *ossl_prov_ctx_get0_core_bio_method(PROV_CTX *ctx);
 OSSL_FUNC_core_get_params_fn *ossl_prov_ctx_get0_core_get_params(PROV_CTX *ctx);
+const char *
+ossl_prov_ctx_get_param(PROV_CTX *ctx, const char *name, const char *defval);
 int ossl_prov_ctx_get_bool_param(PROV_CTX *ctx, const char *name, int defval);
 
 #endif

--- a/providers/common/provider_ctx.c
+++ b/providers/common/provider_ctx.c
@@ -76,7 +76,8 @@ OSSL_FUNC_core_get_params_fn *ossl_prov_ctx_get0_core_get_params(PROV_CTX *ctx)
     return ctx->core_get_params;
 }
 
-int ossl_prov_ctx_get_bool_param(PROV_CTX *ctx, const char *name, int defval)
+const char *
+ossl_prov_ctx_get_param(PROV_CTX *ctx, const char *name, const char *defval)
 {
     char *val = NULL;
     OSSL_PARAM param[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
@@ -86,7 +87,7 @@ int ossl_prov_ctx_get_bool_param(PROV_CTX *ctx, const char *name, int defval)
         || ctx->core_get_params == NULL)
         return defval;
 
-    param[0].key = (char *)name;
+    param[0].key = (char *) name;
     param[0].data_type = OSSL_PARAM_UTF8_PTR;
     param[0].data = (void *) &val;
     param[0].data_size = sizeof(val);
@@ -95,7 +96,16 @@ int ossl_prov_ctx_get_bool_param(PROV_CTX *ctx, const char *name, int defval)
     /* Errors are ignored, returning the default value */
     if (ctx->core_get_params(ctx->handle, param)
         && OSSL_PARAM_modified(param)
-        && val != NULL) {
+        && val != NULL)
+        return val;
+    return defval;
+}
+
+int ossl_prov_ctx_get_bool_param(PROV_CTX *ctx, const char *name, int defval)
+{
+    const char *val = ossl_prov_ctx_get_param(ctx, name, NULL);
+
+    if (val != NULL) {
         if ((strcmp(val, "1") == 0)
             || (OPENSSL_strcasecmp(val, "yes") == 0)
             || (OPENSSL_strcasecmp(val, "true") == 0)


### PR DESCRIPTION
With the previous `c_get_params` PR https://github.com/openssl/openssl/pull/26530 approved (and shortly to be merged) this is just one more refinement to add a helpful getter for a given string parameter, now a helper method for the boolean getter.

Two commits, the first is https://github.com/openssl/openssl/pull/26530, so only one new in this PR.