### PR TITLE
checking pctx != NULL for legacy part of EVP_DigestSign

### DIFF
--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -594,8 +594,8 @@ int EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sigret, size_t *siglen,
         }
     } else {
         /* legacy */
-        if (pctx != NULL 
-                && pctx->pmeth != NULL 
+        if (pctx != NULL
+                && pctx->pmeth != NULL
                 && pctx->pmeth->digestsign != NULL)
             return pctx->pmeth->digestsign(ctx, sigret, siglen, tbs, tbslen);
     }

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -577,7 +577,7 @@ int EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sigret, size_t *siglen,
 
     if (pctx == NULL) {
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
-        return -1;
+        return 0;
     }
 
     if ((ctx->flags & EVP_MD_CTX_FLAG_FINALISED) != 0) {

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -575,13 +575,17 @@ int EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sigret, size_t *siglen,
 {
     EVP_PKEY_CTX *pctx = ctx->pctx;
 
+    if (pctx == NULL) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
+        return -1;
+    }
+
     if ((ctx->flags & EVP_MD_CTX_FLAG_FINALISED) != 0) {
         ERR_raise(ERR_LIB_EVP, EVP_R_FINAL_ERROR);
         return 0;
     }
 
-    if (pctx != NULL
-            && pctx->operation == EVP_PKEY_OP_SIGNCTX
+    if (pctx->operation == EVP_PKEY_OP_SIGNCTX
             && pctx->op.sig.algctx != NULL
             && pctx->op.sig.signature != NULL) {
         if (pctx->op.sig.signature->digest_sign != NULL) {
@@ -594,9 +598,7 @@ int EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sigret, size_t *siglen,
         }
     } else {
         /* legacy */
-        if (pctx != NULL
-                && pctx->pmeth != NULL
-                && pctx->pmeth->digestsign != NULL)
+        if (pctx->pmeth != NULL && pctx->pmeth->digestsign != NULL)
             return pctx->pmeth->digestsign(ctx, sigret, siglen, tbs, tbslen);
     }
 

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -594,8 +594,10 @@ int EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sigret, size_t *siglen,
         }
     } else {
         /* legacy */
-        if (ctx->pctx->pmeth != NULL && ctx->pctx->pmeth->digestsign != NULL)
-            return ctx->pctx->pmeth->digestsign(ctx, sigret, siglen, tbs, tbslen);
+        if (pctx != NULL 
+                && pctx->pmeth != NULL 
+                && pctx->pmeth->digestsign != NULL)
+            return pctx->pmeth->digestsign(ctx, sigret, siglen, tbs, tbslen);
     }
 
     if (sigret != NULL && EVP_DigestSignUpdate(ctx, tbs, tbslen) <= 0)


### PR DESCRIPTION
Firstly, use `pctx` variable as it equals `ctx->pctx`.
Secondly, add `NULL` check because else branch may be triggered if `pctx == NULL`.

Also, why don't we check the first parameter (`EVP_MD_CTX`) for `NULL` as those functions are public and they can be called with first `NULL`? 

Found by Linux Verification Center (linuxtesting.org) with SVACE.

