### PR TITLE
Fix pretty-printing empty serial number in ossl_serial_number_print()

### DIFF
--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -515,6 +515,12 @@ int ossl_serial_number_print(BIO *out, const ASN1_INTEGER *bs, int indent)
     unsigned long ul;
     const char *neg;
 
+    if (bs->length == 0) {
+        if (BIO_puts(out, " (Empty)") <= 0)
+            return -1;
+        return 0;
+    }
+
     if (bs->length <= (int)sizeof(long)) {
         ERR_set_mark();
         l = ASN1_INTEGER_get(bs);


### PR DESCRIPTION
This is a follow-up to the recent refactoring made in PR #25428.

Fix a crash when the ASN1_INTEGER has empty content. While it is illegal, this is the initial state of the serialNumber field when an X509 object is allocated by X509_new(). X509_print*() should be able to process an incomplete X509 object too.

The second patch in this PR is an additional cleanup of the function.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
