### PR TITLE
Clarify docs of EVP_CIPHER*_get_block_size

### DIFF
--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -371,7 +371,7 @@ int EVP_CIPHER_get_block_size(const EVP_CIPHER *cipher)
 
 int EVP_CIPHER_CTX_get_block_size(const EVP_CIPHER_CTX *ctx)
 {
-    return EVP_CIPHER_get_block_size(ctx->cipher);
+    return (ctx == NULL) ? 0 : EVP_CIPHER_get_block_size(ctx->cipher);
 }
 
 int EVP_CIPHER_impl_ctx_size(const EVP_CIPHER *e)

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -613,8 +613,11 @@ the tag length has not been set.
 
 Return the block size of a cipher when passed an B<EVP_CIPHER> or
 B<EVP_CIPHER_CTX> structure. The constant B<EVP_MAX_BLOCK_LENGTH> is also the
-maximum block length for all ciphers. A value of 0 is returned if the cipher
-has not been properly initialized with a call to B<EVP_CipherInit>.
+maximum block length for all ciphers.
+A value of 0 is returned if, with B<EVP_CIPHER_get_block_size()>, the cipher
+I<e> is NULL, or, with B<EVP_CIPHER_CTX_get_block_size()>, the context
+I<ctx> is NULL or has not been properly initialized with a call to
+B<EVP_CipherInit>.
 
 =item EVP_CIPHER_get_type() and EVP_CIPHER_CTX_get_type()
 
@@ -1360,12 +1363,12 @@ flags.
 =head1 RETURN VALUES
 
 EVP_CIPHER_fetch() returns a pointer to a B<EVP_CIPHER> for success
-and B<NULL> for failure.
+and NULL for failure.
 
 EVP_CIPHER_up_ref() returns 1 for success or 0 otherwise.
 
 EVP_CIPHER_CTX_new() returns a pointer to a newly created
-B<EVP_CIPHER_CTX> for success and B<NULL> for failure.
+B<EVP_CIPHER_CTX> for success and NULL for failure.
 
 EVP_CIPHER_CTX_dup() returns a new EVP_CIPHER_CTX if successful or NULL on failure.
 
@@ -1467,7 +1470,7 @@ depending on the mode specified.
 
 To specify additional authenticated data (AAD), a call to EVP_CipherUpdate(),
 EVP_EncryptUpdate() or EVP_DecryptUpdate() should be made with the output
-parameter I<out> set to B<NULL>. In this case, on success, the parameter
+parameter I<out> set to NULL. In this case, on success, the parameter
 I<outl> is set to the number of bytes authenticated.
 
 When decrypting, the return value of EVP_DecryptFinal() or EVP_CipherFinal()
@@ -1535,7 +1538,7 @@ few additional requirements and different I<ctrl> values.
 
 For CCM mode, the total plaintext or ciphertext length B<MUST> be passed to
 EVP_CipherUpdate(), EVP_EncryptUpdate() or EVP_DecryptUpdate() with the output
-and input parameters (I<in> and I<out>) set to B<NULL> and the length passed in
+and input parameters (I<in> and I<out>) set to NULL and the length passed in
 the I<inl> parameter.
 
 The following I<ctrl>s are supported in CCM mode.
@@ -1572,7 +1575,7 @@ altered and several additional ctrl operations are supported.
 
 To specify any additional authenticated data (AAD) and/or a Nonce, a call to
 EVP_CipherUpdate(), EVP_EncryptUpdate() or EVP_DecryptUpdate() should be made
-with the output parameter I<out> set to B<NULL>.
+with the output parameter I<out> set to NULL.
 
 RFC5297 states that the Nonce is the last piece of AAD before the actual
 encrypt/decrypt takes place. The API does not differentiate the Nonce from
@@ -1615,7 +1618,7 @@ calls). For SIV mode the taglen must be 16.
 
 SIV mode makes two passes over the input data, thus, only one call to
 EVP_CipherUpdate(), EVP_EncryptUpdate() or EVP_DecryptUpdate() should be made
-with I<out> set to a non-B<NULL> value. A call to EVP_DecryptFinal() or
+with I<out> set to a non-NULL value. A call to EVP_DecryptFinal() or
 EVP_CipherFinal() is not required, but will indicate if the update
 operation succeeded.
 
@@ -1938,6 +1941,10 @@ non-deprecated alias macro.
 The EVP_CIPHER_CTX_flags() macro was deprecated in OpenSSL 1.1.0.
 
 EVP_CIPHER_CTX_dup() was added in OpenSSL 3.2.
+
+Prior to OpenSSL 3.5, passing a NULL I<ctx> to
+B<EVP_CIPHER_CTX_get_block_size()> would result in a NULL pointer dereference,
+rather than a 0 return value indicating an error.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
Also, tolerate NULL input ctx, just like NULL cipher.

##### Checklist
- [x] documentation is added or updated

