### PR TITLE
DTLS 1.3: Run test_server_mtu_larger_than_max_fragment_length()

### DIFF
--- a/test/dtls_mtu_test.c
+++ b/test/dtls_mtu_test.c
@@ -217,13 +217,6 @@ static int test_server_mtu_larger_than_max_fragment_length(void)
                                       NULL, NULL)))
         goto end;
 
-    /**
-     * TODO(DTLSv1.3): Test fails with
-     * SSL routines:tls_parse_ctos_maxfragmentlen:ssl3 ext invalid max fragment length:
-     *      ssl/statem/extensions_srvr.c:202:
-     */
-    OPENSSL_assert(SSL_set_max_proto_version(clnt_ssl, DTLS1_2_VERSION) == 1);
-
     SSL_set_options(srvr_ssl, SSL_OP_NO_QUERY_MTU);
     if (!TEST_true(DTLS_set_link_mtu(srvr_ssl, 1500)))
         goto end;


### PR DESCRIPTION
Previously it was forced to run on DTLS 1.2>. But the underlying issue was fixed on master and it works now that the feature branch has been rebased on top of a more recent master.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
