### PR TITLE
check whether addr == NULL.

### DIFF
--- a/crypto/x509/v3_addr.c
+++ b/crypto/x509/v3_addr.c
@@ -910,9 +910,8 @@ static int IPAddressOrRanges_canonize(IPAddressOrRanges *aors,
  */
 int X509v3_addr_canonize(IPAddrBlocks *addr)
 {
-    if (addr == NULL) {
+    if (addr == NULL)
         return 0;
-    }
 
     int i;
 

--- a/crypto/x509/v3_addr.c
+++ b/crypto/x509/v3_addr.c
@@ -910,6 +910,11 @@ static int IPAddressOrRanges_canonize(IPAddressOrRanges *aors,
  */
 int X509v3_addr_canonize(IPAddrBlocks *addr)
 {
+    if (addr == NULL)
+    {
+        return 0;
+    }
+
     int i;
 
     for (i = 0; i < sk_IPAddressFamily_num(addr); i++) {

--- a/crypto/x509/v3_addr.c
+++ b/crypto/x509/v3_addr.c
@@ -910,8 +910,7 @@ static int IPAddressOrRanges_canonize(IPAddressOrRanges *aors,
  */
 int X509v3_addr_canonize(IPAddrBlocks *addr)
 {
-    if (addr == NULL)
-    {
+    if (addr == NULL) {
         return 0;
     }
 

--- a/crypto/x509/v3_addr.c
+++ b/crypto/x509/v3_addr.c
@@ -910,10 +910,10 @@ static int IPAddressOrRanges_canonize(IPAddressOrRanges *aors,
  */
 int X509v3_addr_canonize(IPAddrBlocks *addr)
 {
+    int i;
+
     if (addr == NULL)
         return 0;
-
-    int i;
 
     for (i = 0; i < sk_IPAddressFamily_num(addr); i++) {
         IPAddressFamily *f = sk_IPAddressFamily_value(addr, i);

--- a/crypto/x509/v3_addr.c
+++ b/crypto/x509/v3_addr.c
@@ -912,8 +912,10 @@ int X509v3_addr_canonize(IPAddrBlocks *addr)
 {
     int i;
 
-    if (addr == NULL)
+    if (addr == NULL) {
+        ERR_raise(ERR_LIB_X509V3, X509V3_R_INVALID_NULL_ARGUMENT);
         return 0;
+    }
 
     for (i = 0; i < sk_IPAddressFamily_num(addr); i++) {
         IPAddressFamily *f = sk_IPAddressFamily_value(addr, i);


### PR DESCRIPTION
Checking whether `IPAddrBlocks == NULL` because it's invalid to call `*_set_cmp_func` on a NULL object. 

However I'm not sure what to return, because empty extension is canonicall, but doc says: 

> X509v3_addr_canonize attempts to bring the **non-NULL** addrblocks into canonical form.

Found by Linux Verification Center (linuxtesting.org) with SVACE.