### PR TITLE
`80-test_cmp_http_data/Mock/test.cnf`: further relax `total_timeout`

### DIFF
--- a/test/recipes/80-test_cmp_http_data/Mock/test.cnf
+++ b/test/recipes/80-test_cmp_http_data/Mock/test.cnf
@@ -1,7 +1,7 @@
 [default]
 batch = 1 # do not use stdin
-total_timeout = 20  # is used to prevent, e.g., infinite polling due to error;
-# should hopefully be enough to cover delays caused by the underlying system
+total_timeout = 120 # is used to prevent, e.g., infinite polling due to error;
+# should now really be enough to cover delays caused by the underlying system
 trusted = trusted.crt
 newkey = new.key
 newkeypass =


### PR DESCRIPTION
as a workaround for heavily loaded test systems, such as reported in #26577.

Should fix #26577.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
