### PR TITLE
older versions of darwin (10.8 and earlier) don't understand .previous.

### DIFF
--- a/crypto/perlasm/x86_64-xlate.pl
+++ b/crypto/perlasm/x86_64-xlate.pl
@@ -957,7 +957,9 @@ my %globals;
                         $current_segment = ".text";
                         push(@segment_stack, $current_segment);
                     }
-		    $self->{value} = $current_segment if ($flavour eq "mingw64");
+                    if ($flavour eq "mingw64" || $flavour eq "macosx") {
+		        $self->{value} = $current_segment;
+                    }
 		}
 		$$line = "";
 		return $self;


### PR DESCRIPTION
this tweak emits the previous section directive which preceeds the rodata (for example .text) instead of using .previous. We use the same for mingw

Fixes #26447

