### PR TITLE
Fix TODO(QUIC_SERVER) relating to short connection id lengths

### DIFF
--- a/include/internal/quic_channel.h
+++ b/include/internal/quic_channel.h
@@ -306,6 +306,9 @@ OSSL_STATM *ossl_quic_channel_get_statm(QUIC_CHANNEL *ch);
 /* Gets the TLS handshake layer used with the channel. */
 SSL *ossl_quic_channel_get0_tls(QUIC_CHANNEL *ch);
 
+/* get the channels short header connection id length */
+size_t ossl_quic_channel_get_short_header_conn_id_len(QUIC_CHANNEL *ch);
+
 /*
  * Gets/sets the current peer address. Generally this should be used before
  * starting a channel in client mode.

--- a/include/internal/quic_record_rx.h
+++ b/include/internal/quic_record_rx.h
@@ -68,6 +68,11 @@ void ossl_qrx_set_msg_callback_arg(OSSL_QRX *qrx,
                                    void *msg_callback_arg);
 
 /*
+ * Get the short header connection id len from this qrx
+ */
+size_t ossl_qrx_get_short_hdr_conn_id_len(OSSL_QRX *qrx);
+
+/*
  * Secret Management
  * =================
  *

--- a/include/internal/quic_tserver.h
+++ b/include/internal/quic_tserver.h
@@ -81,6 +81,9 @@ ossl_quic_tserver_get_terminate_cause(const QUIC_TSERVER *srv);
 /* Returns 1 if the server is in a terminated state */
 int ossl_quic_tserver_is_terminated(const QUIC_TSERVER *srv);
 
+/* Get out short header conn id length */
+size_t ossl_quic_tserver_get_short_header_conn_id_len(const QUIC_TSERVER *srv);
+
 /*
  * Attempts to read from stream 0. Writes the number of bytes read to
  * *bytes_read and returns 1 on success. If no bytes are available, 0 is written

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -516,6 +516,11 @@ SSL *ossl_quic_channel_get0_tls(QUIC_CHANNEL *ch)
     return ch->tls;
 }
 
+size_t ossl_quic_channel_get_short_header_conn_id_len(QUIC_CHANNEL *ch)
+{
+    return ossl_qrx_get_short_hdr_conn_id_len(ch->qrx);
+}
+
 QUIC_STREAM *ossl_quic_channel_get_stream_by_id(QUIC_CHANNEL *ch,
                                                 uint64_t stream_id)
 {

--- a/ssl/quic/quic_record_rx.c
+++ b/ssl/quic/quic_record_rx.c
@@ -1356,3 +1356,8 @@ void ossl_qrx_set_msg_callback_arg(OSSL_QRX *qrx, void *msg_callback_arg)
 {
     qrx->msg_callback_arg = msg_callback_arg;
 }
+
+size_t ossl_qrx_get_short_hdr_conn_id_len(OSSL_QRX *qrx)
+{
+    return qrx->short_conn_id_len;
+}

--- a/ssl/quic/quic_tserver.c
+++ b/ssl/quic/quic_tserver.c
@@ -239,6 +239,11 @@ int ossl_quic_tserver_is_terminated(const QUIC_TSERVER *srv)
     return ossl_quic_channel_is_terminated(srv->ch);
 }
 
+size_t ossl_quic_tserver_get_short_header_conn_id_len(const QUIC_TSERVER *srv)
+{
+    return ossl_quic_channel_get_short_header_conn_id_len(srv->ch);
+}
+
 int ossl_quic_tserver_is_handshake_confirmed(const QUIC_TSERVER *srv)
 {
     return ossl_quic_channel_is_handshake_confirmed(srv->ch);

--- a/test/helpers/pktsplitbio.c
+++ b/test/helpers/pktsplitbio.c
@@ -53,6 +53,7 @@ static int pkt_split_dgram_recvmmsg(BIO *bio, BIO_MSG *msg, size_t stride,
     BIO *next = BIO_next(bio);
     size_t i, j, data_len = 0, msg_cnt = 0;
     BIO_MSG *thismsg;
+    QTEST_DATA *bdata = BIO_get_data(bio);
 
     if (!TEST_ptr(next))
         return 0;
@@ -88,11 +89,8 @@ static int pkt_split_dgram_recvmmsg(BIO *bio, BIO_MSG *msg, size_t stride,
             return 0;
 
         /* Decode the packet header */
-        /*
-         * TODO(QUIC SERVER): We need to query the short connection id len
-         * here, e.g. via some API SSL_get_short_conn_id_len()
-         */
-        if (ossl_quic_wire_decode_pkt_hdr(&pkt, 0, 0, 0, &hdr, NULL, NULL) != 1)
+        if (ossl_quic_wire_decode_pkt_hdr(&pkt, bdata->short_conn_id_len,
+                                          0, 0, &hdr, NULL, NULL) != 1)
             return 0;
         remain = PACKET_remaining(&pkt);
         if (remain > 0) {

--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -134,6 +134,11 @@ int qtest_create_quic_objects(OSSL_LIB_CTX *libctx, SSL_CTX *clientctx,
     BIO_ADDR *peeraddr = NULL;
     struct in_addr ina = {0};
     BIO *tmpbio = NULL;
+    QTEST_DATA *bdata = NULL;
+
+    bdata = OPENSSL_zalloc(sizeof(QTEST_DATA));
+    if (bdata == NULL)
+        return 0;
 
     *qtserv = NULL;
     if (*cssl == NULL) {
@@ -146,6 +151,7 @@ int qtest_create_quic_objects(OSSL_LIB_CTX *libctx, SSL_CTX *clientctx,
         *fault = OPENSSL_zalloc(sizeof(**fault));
         if (*fault == NULL)
             goto err;
+        bdata->fault = *fault;
     }
 
 #ifndef OPENSSL_NO_SSL_TRACE
@@ -226,11 +232,13 @@ int qtest_create_quic_objects(OSSL_LIB_CTX *libctx, SSL_CTX *clientctx,
         if (!TEST_ptr(pktsplitbio))
             goto err;
         cbio = BIO_push(pktsplitbio, cbio);
+        BIO_set_data(pktsplitbio, bdata);
 
         pktsplitbio = BIO_new(bio_f_pkt_split_dgram_filter());
         if (!TEST_ptr(pktsplitbio))
             goto err;
         sbio = BIO_push(pktsplitbio, sbio);
+        BIO_set_data(pktsplitbio, bdata);
     }
 
     if ((flags & QTEST_FLAG_NOISE) != 0) {
@@ -295,7 +303,7 @@ int qtest_create_quic_objects(OSSL_LIB_CTX *libctx, SSL_CTX *clientctx,
     if (!TEST_ptr(fisbio))
         goto err;
 
-    BIO_set_data(fisbio, fault == NULL ? NULL : *fault);
+    BIO_set_data(fisbio, bdata);
 
     if (!BIO_up_ref(sbio))
         goto err;
@@ -329,6 +337,7 @@ int qtest_create_quic_objects(OSSL_LIB_CTX *libctx, SSL_CTX *clientctx,
                                                   keyfile)))
         goto err;
 
+    bdata->short_conn_id_len = ossl_quic_tserver_get_short_header_conn_id_len(*qtserv);
     /* Ownership of fisbio and sbio is now held by *qtserv */
     sbio = NULL;
     fisbio = NULL;
@@ -354,6 +363,7 @@ int qtest_create_quic_objects(OSSL_LIB_CTX *libctx, SSL_CTX *clientctx,
     ossl_quic_tserver_free(*qtserv);
     if (fault != NULL)
         OPENSSL_free(*fault);
+    OPENSSL_free(bdata);
     BIO_free(tmpbio);
     if (tracebio != NULL)
         *tracebio = NULL;
@@ -1086,20 +1096,20 @@ static int pcipher_sendmmsg(BIO *b, BIO_MSG *msg, size_t stride,
                             size_t num_msg, uint64_t flags,
                             size_t *num_processed)
 {
-    QTEST_FAULT *fault;
     BIO *next = BIO_next(b);
     ossl_ssize_t ret = 0;
     size_t i = 0, tmpnump;
     QUIC_PKT_HDR hdr;
     PACKET pkt;
     unsigned char *tmpdata;
+    QTEST_DATA *bdata = NULL;
 
     if (next == NULL)
         return 0;
 
-    fault = BIO_get_data(b);
-    if (fault == NULL
-            || (fault->pciphercb == NULL && fault->datagramcb == NULL))
+    bdata = BIO_get_data(b);
+    if (bdata == NULL || bdata->fault == NULL
+            || (bdata->fault->pciphercb == NULL && bdata->fault->datagramcb == NULL))
         return BIO_sendmmsg(next, msg, stride, num_msg, flags, num_processed);
 
     if (num_msg == 0) {
@@ -1108,38 +1118,33 @@ static int pcipher_sendmmsg(BIO *b, BIO_MSG *msg, size_t stride,
     }
 
     for (i = 0; i < num_msg; ++i) {
-        fault->msg = BIO_MSG_N(msg, stride, i);
+        bdata->fault->msg = BIO_MSG_N(msg, stride, i);
 
         /* Take a copy of the data so that callbacks can modify it */
-        tmpdata = OPENSSL_malloc(fault->msg.data_len + GROWTH_ALLOWANCE);
+        tmpdata = OPENSSL_malloc(bdata->fault->msg.data_len + GROWTH_ALLOWANCE);
         if (tmpdata == NULL)
             return 0;
-        memcpy(tmpdata, fault->msg.data, fault->msg.data_len);
-        fault->msg.data = tmpdata;
-        fault->msgalloc = fault->msg.data_len + GROWTH_ALLOWANCE;
+        memcpy(tmpdata, bdata->fault->msg.data, bdata->fault->msg.data_len);
+        bdata->fault->msg.data = tmpdata;
+        bdata->fault->msgalloc = bdata->fault->msg.data_len + GROWTH_ALLOWANCE;
 
-        if (fault->pciphercb != NULL) {
-            if (!PACKET_buf_init(&pkt, fault->msg.data, fault->msg.data_len))
+        if (bdata->fault->pciphercb != NULL) {
+            if (!PACKET_buf_init(&pkt, bdata->fault->msg.data, bdata->fault->msg.data_len))
                 return 0;
 
             do {
                 if (!ossl_quic_wire_decode_pkt_hdr(&pkt,
-                        /*
-                         * TODO(QUIC SERVER):
-                         * Needs to be set to the actual short header CID length
-                         * when testing the server implementation.
-                         */
-                        0,
-                        1,
-                        0, &hdr, NULL, NULL))
+                                                   bdata->short_conn_id_len,
+                                                   1, 0, &hdr, NULL, NULL))
                     goto out;
 
                 /*
                  * hdr.data is const - but its our buffer so casting away the
                  * const is safe
                  */
-                if (!fault->pciphercb(fault, &hdr, (unsigned char *)hdr.data,
-                                    hdr.len, fault->pciphercbarg))
+                if (!bdata->fault->pciphercb(bdata->fault, &hdr,
+                                             (unsigned char *)hdr.data, hdr.len,
+                                             bdata->fault->pciphercbarg))
                     goto out;
 
                 /*
@@ -1152,26 +1157,26 @@ static int pcipher_sendmmsg(BIO *b, BIO_MSG *msg, size_t stride,
             } while (PACKET_remaining(&pkt) > 0);
         }
 
-        if (fault->datagramcb != NULL
-                && !fault->datagramcb(fault, &fault->msg, stride,
-                                      fault->datagramcbarg))
+        if (bdata->fault->datagramcb != NULL
+                && !bdata->fault->datagramcb(bdata->fault, &bdata->fault->msg, stride,
+                                             bdata->fault->datagramcbarg))
             goto out;
 
-        if (!BIO_sendmmsg(next, &fault->msg, stride, 1, flags, &tmpnump)) {
+        if (!BIO_sendmmsg(next, &bdata->fault->msg, stride, 1, flags, &tmpnump)) {
             *num_processed = i;
             goto out;
         }
 
-        OPENSSL_free(fault->msg.data);
-        fault->msg.data = NULL;
-        fault->msgalloc = 0;
+        OPENSSL_free(bdata->fault->msg.data);
+        bdata->fault->msg.data = NULL;
+        bdata->fault->msgalloc = 0;
     }
 
     *num_processed = i;
 out:
     ret = i > 0;
-    OPENSSL_free(fault->msg.data);
-    fault->msg.data = NULL;
+    OPENSSL_free(bdata->fault->msg.data);
+    bdata->fault->msg.data = NULL;
     return ret;
 }
 
@@ -1183,6 +1188,12 @@ static long pcipher_ctrl(BIO *b, int cmd, long larg, void *parg)
         return -1;
 
     return BIO_ctrl(next, cmd, larg, parg);
+}
+
+static int pcipher_destroy(BIO *b)
+{
+    OPENSSL_free(BIO_get_data(b));
+    return 1;
 }
 
 BIO_METHOD *qtest_get_bio_method(void)
@@ -1198,7 +1209,8 @@ BIO_METHOD *qtest_get_bio_method(void)
         return NULL;
 
     if (!TEST_true(BIO_meth_set_sendmmsg(tmp, pcipher_sendmmsg))
-            || !TEST_true(BIO_meth_set_ctrl(tmp, pcipher_ctrl)))
+            || !TEST_true(BIO_meth_set_ctrl(tmp, pcipher_ctrl))
+            || !TEST_true(BIO_meth_set_destroy(tmp, pcipher_destroy)))
         goto err;
 
     pcipherbiometh = tmp;

--- a/test/helpers/quictestlib.h
+++ b/test/helpers/quictestlib.h
@@ -13,6 +13,11 @@
 /* Type to represent the Fault Injector */
 typedef struct qtest_fault QTEST_FAULT;
 
+typedef struct bio_qtest_data {
+    size_t short_conn_id_len;
+    struct qtest_fault *fault;
+} QTEST_DATA;
+
 /*
  * Structure representing a parsed EncryptedExtension message. Listeners can
  * make changes to the contents of structure objects as required and the fault

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -681,6 +681,7 @@ static int helper_init(struct helper *h, const char *script_name,
     QUIC_TSERVER_ARGS s_args = {0};
     union BIO_sock_info_u info;
     char title[128];
+    QTEST_DATA *bdata = NULL;
 
     memset(h, 0, sizeof(*h));
     h->c_fd = -1;
@@ -689,6 +690,10 @@ static int helper_init(struct helper *h, const char *script_name,
     h->blocking = blocking;
     h->need_injector = need_injector;
     h->time_slip = ossl_time_zero();
+
+    bdata = OPENSSL_zalloc(sizeof(QTEST_DATA));
+    if (bdata == NULL)
+        goto err;
 
     if (!TEST_ptr(h->time_lock = CRYPTO_THREAD_lock_new()))
         goto err;
@@ -763,8 +768,8 @@ static int helper_init(struct helper *h, const char *script_name,
         h->qtf = qtest_create_injector(h->s_priv);
         if (!TEST_ptr(h->qtf))
             goto err;
-
-        BIO_set_data(h->s_qtf_wbio, h->qtf);
+        bdata->fault = h->qtf;
+        BIO_set_data(h->s_qtf_wbio, bdata);
     }
 
     h->s_net_bio_own = NULL;


### PR DESCRIPTION
We have several tests that need to decode quic short headers.  These headers have a variable length connection id in the middle of the header, and to parse them properly we need to know that length (as per RFC).  Add apis to fetch the short header connection id length from the established connection so they can be parsed properly

##### Checklist
- [x] tests are added or updated


