### PR TITLE
Fix up remaining QUIC TODO's

### DIFF
--- a/doc/man3/SSL_new_listener.pod
+++ b/doc/man3/SSL_new_listener.pod
@@ -5,7 +5,7 @@
 SSL_new_listener, SSL_new_listener_from, SSL_is_listener, SSL_get0_listener,
 SSL_listen,
 SSL_accept_connection, SSL_get_accept_connection_queue_len,
-SSL_new_from_listener, SSL_LISTENER_FLAG_NO_ACCEPT,
+SSL_new_from_listener,
 SSL_ACCEPT_CONNECTION_NO_BLOCK - SSL object interface for abstracted connection
 acceptance
 
@@ -13,7 +13,6 @@ acceptance
 
  #include <openssl/ssl.h>
 
- #define SSL_LISTENER_FLAG_NO_ACCEPT
  SSL *SSL_new_listener(SSL_CTX *ctx, uint64_t flags);
  SSL *SSL_new_listener_from(SSL *ssl, uint64_t flags);
 
@@ -158,13 +157,6 @@ circumstances where it is desirable for multiple connections to share the same
 underlying network resources. For example, multiple outgoing QUIC client
 connections could be made to use the same underlying UDP socket.
 
-To use client-only mode, pass the flag B<SSL_LISTENER_FLAG_NO_ACCEPT> when
-calling SSL_new_listener(). In this mode, SSL_listen() still begins the process
-of handling network resources, but incoming connections are never accepted.
-Calling SSL_accept_connection() is an error and will return NULL. One or more
-outgoing connections under a listener can then be created using the call
-SSL_new_from_listener().
-
 To disable client address validation on a listener SSL object, the flag
 B<SSL_LISTENER_FLAG_NO_VALIDATE> may be passed in the flags field of both
 SSL_new_listener() and SSL_new_listener_from().  Note that this flag only
@@ -177,20 +169,12 @@ numbers of connections and never transact data on them (roughly equivalent to
 a TCP syn flood attack), which address validation mitigates.
 
 The SSL_new_from_listener() creates a client connection under a given listener
-SSL object. For QUIC, it is also possible to use SSL_new_from_listener() in
-conjunction with a listener which does accept incoming connections (i.e., which
-was not created using B<SSL_LISTENER_FLAG_NO_ACCEPT>), leading to a UDP network
-endpoint which has both incoming and outgoing connections.
+SSL object. For QUIC, it is also possible to use SSL_new_from_listener(),
+leading to a UDP network endpoint which has both incoming and outgoing'
+connections.
 
 The I<flags> argument of SSL_new_from_listener() is reserved and must be set to
 0.
-
-Creating a listener using a B<SSL_CTX> which uses a client-oriented
-B<SSL_METHOD> such as L<OSSL_QUIC_client_method(3)> or
-L<OSSL_QUIC_client_thread_method(3)> automatically implies the
-B<SSL_LISTENER_FLAG_NO_ACCEPT> flag. The B<SSL_LISTENER_FLAG_NO_ACCEPT> flag may
-optionally also be specified in this case but is ignored. This is an alternative
-way of using the listener functionality in client-only mode.
 
 =head1 RETURN VALUES
 

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2299,7 +2299,6 @@ __owur int SSL_is_connection(SSL *s);
 
 __owur int SSL_is_listener(SSL *ssl);
 __owur SSL *SSL_get0_listener(SSL *s);
-/* #define SSL_LISTENER_FLAG_NO_ACCEPT     (1UL << 0) */
 #define SSL_LISTENER_FLAG_NO_VALIDATE   (1UL << 1)
 __owur SSL *SSL_new_listener(SSL_CTX *ctx, uint64_t flags);
 __owur SSL *SSL_new_listener_from(SSL *ssl, uint64_t flags);

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2299,7 +2299,7 @@ __owur int SSL_is_connection(SSL *s);
 
 __owur int SSL_is_listener(SSL *ssl);
 __owur SSL *SSL_get0_listener(SSL *s);
-#define SSL_LISTENER_FLAG_NO_ACCEPT     (1UL << 0)
+/* #define SSL_LISTENER_FLAG_NO_ACCEPT     (1UL << 0) */
 #define SSL_LISTENER_FLAG_NO_VALIDATE   (1UL << 1)
 __owur SSL *SSL_new_listener(SSL_CTX *ctx, uint64_t flags);
 __owur SSL *SSL_new_listener_from(SSL *ssl, uint64_t flags);

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4268,7 +4268,7 @@ SSL *ossl_quic_new_listener(SSL_CTX *ctx, uint64_t flags)
         goto err;
     }
 
-    /* TODO(QUIC SERVER): Implement SSL_LISTENER_FLAG_NO_ACCEPT */
+    /* TODO(QUIC FUTURE): Implement SSL_LISTENER_FLAG_NO_ACCEPT */
 
     ossl_quic_port_set_allow_incoming(ql->port, 1);
 
@@ -4331,7 +4331,7 @@ SSL *ossl_quic_new_listener_from(SSL *ssl, uint64_t flags)
     ql->mutex   = ctx.qd->mutex;
 #endif
 
-    /* TODO(QUIC SERVER): Implement SSL_LISTENER_FLAG_NO_ACCEPT */
+    /* TODO(QUIC FUTURE): Implement SSL_LISTENER_FLAG_NO_ACCEPT */
 
     ossl_quic_port_set_allow_incoming(ql->port, 1);
 

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4331,7 +4331,14 @@ SSL *ossl_quic_new_listener_from(SSL *ssl, uint64_t flags)
     ql->mutex   = ctx.qd->mutex;
 #endif
 
-    /* TODO(QUIC FUTURE): Implement SSL_LISTENER_FLAG_NO_ACCEPT */
+    /*
+     * TODO(QUIC FUTURE): Implement SSL_LISTENER_FLAG_NO_ACCEPT
+     * Given that we have apis to create client SSL objects from
+     * server SSL objects (see SSL_new_from_listener), we have aspirations
+     * to enable a flag that allows for the creation of the latter, but not
+     * be used to do accept any connections.  This is a placeholder for the
+     * implementation of that flag
+     */
 
     ossl_quic_port_set_allow_incoming(ql->port, 1);
 

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -1133,7 +1133,7 @@ static void port_send_retry(QUIC_PORT *port,
         goto err;
 
     /*
-     * TODO(QUIC SERVER) need to retry this in the event it return EAGAIN
+     * TODO(QUIC FUTURE) need to retry this in the event it return EAGAIN
      * on a non-blocking BIO
      */
     if (!BIO_sendmmsg(port->net_wbio, msg, sizeof(BIO_MSG), 1, 0, &written))
@@ -1225,7 +1225,7 @@ static void port_send_version_negotiation(QUIC_PORT *port, BIO_ADDR *peer,
 
     /*
      * Send it back to the client attempting to connect
-     * TODO(QUIC SERVER): Need to handle the EAGAIN case here, if the
+     * TODO(QUIC FUTURE): Need to handle the EAGAIN case here, if the
      * BIO_sendmmsg call falls in a retryable manner
      */
     if (!BIO_sendmmsg(port->net_wbio, msg, sizeof(BIO_MSG), 1, 0, &written))
@@ -1417,7 +1417,7 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
         /*
          * If we don't get a supported version, respond with a ver
          * negotiation packet, and discard
-         * TODO(QUIC SERVER): Rate limit the reception of these
+         * TODO(QUIC FUTURE): Rate limit the reception of these
          */
         port_send_version_negotiation(port, &e->peer, &hdr);
         goto undesirable;
@@ -1433,7 +1433,7 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
     odcid.id_len = 0;
 
     /*
-     * TODO(QUIC SERVER): there should be some logic similar to accounting half-open
+     * TODO(QUIC FUTURE): there should be some logic similar to accounting half-open
      * states in TCP. If we reach certain threshold, then we want to
      * validate clients.
      */

--- a/ssl/quic/quic_rx_depack.c
+++ b/ssl/quic/quic_rx_depack.c
@@ -914,7 +914,7 @@ static int depack_do_frame_retire_conn_id(PACKET *pkt,
      * currently non-conformant and for internal testing use; simply handle it
      * as a no-op in this case.
      *
-     * TODO(QUIC SERVER): Revise and implement correctly for server support.
+     * TODO(QUIC FUTURE): Revise and implement correctly for server support.
      */
     if (!ch->is_server) {
         ossl_quic_channel_raise_protocol_error(ch,

--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -1469,7 +1469,8 @@ static int txp_should_try_staging(OSSL_QUIC_TX_PACKETISER *txp,
      * This is not a major concern for clients, since if a client has a 1-RTT EL
      * provisioned the server is guaranteed to also have a 1-RTT EL provisioned.
      *
-     * TODO(QUIC FUTURE): Revisit this when server support is added.
+     * TODO(QUIC FUTURE): Revisit this when when have reached a decision on how
+     * best to implement this
      */
     if (*conn_close_enc_level > enc_level
         && *conn_close_enc_level != QUIC_ENC_LEVEL_1RTT)

--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -1469,7 +1469,7 @@ static int txp_should_try_staging(OSSL_QUIC_TX_PACKETISER *txp,
      * This is not a major concern for clients, since if a client has a 1-RTT EL
      * provisioned the server is guaranteed to also have a 1-RTT EL provisioned.
      *
-     * TODO(QUIC SERVER): Revisit this when server support is added.
+     * TODO(QUIC FUTURE): Revisit this when server support is added.
      */
     if (*conn_close_enc_level > enc_level
         && *conn_close_enc_level != QUIC_ENC_LEVEL_1RTT)

--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -265,7 +265,7 @@ int qtest_create_quic_objects(OSSL_LIB_CTX *libctx, SSL_CTX *clientctx,
                 goto err;
         }
         /*
-         * TODO(QUIC SERVER):
+         * TODO(QUIC FUTURE):
          *    Currently the simplistic handler of the quic tserver cannot cope
          *    with noise introduced in the first packet received from the
          *    client. This needs to be removed once we have proper server side

--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -264,13 +264,7 @@ int qtest_create_quic_objects(OSSL_LIB_CTX *libctx, SSL_CTX *clientctx,
                                       0, &now_cb), 1))
                 goto err;
         }
-        /*
-         * TODO(QUIC FUTURE):
-         *    Currently the simplistic handler of the quic tserver cannot cope
-         *    with noise introduced in the first packet received from the
-         *    client. This needs to be removed once we have proper server side
-         *    handling.
-         */
+
         (void)BIO_ctrl(sbio, BIO_CTRL_NOISE_BACK_OFF, 0, NULL);
 
         (*fault)->noiseargs.cbio = cbio;


### PR DESCRIPTION
Several QUIC TODO items need to be moved to QUIC FUTURE as they're not critical for MVP and we don't likely have time to sort them out prior to release.  Move them to QUIC FUTURE accordingly
