### PR TITLE
Let QPORT to generate RX secrets for initial level encryption.

### DIFF
--- a/include/internal/quic_channel.h
+++ b/include/internal/quic_channel.h
@@ -125,6 +125,8 @@ typedef struct quic_channel_args_st {
 
     /* Title to use for the qlog session, or NULL. */
     const char      *qlog_title;
+
+    QUIC_PORT_SECRETS *qps;
 } QUIC_CHANNEL_ARGS;
 
 /* Represents the cause for a connection's termination. */

--- a/include/internal/quic_port.h
+++ b/include/internal/quic_port.h
@@ -186,6 +186,12 @@ uint64_t ossl_quic_port_get_net_bio_epoch(const QUIC_PORT *port);
 void ossl_quic_port_raise_net_error(QUIC_PORT *port,
                                     QUIC_CHANNEL *triggering_ch);
 
+OSSL_LIB_CTX *ossl_quic_port_get_libctx(QUIC_PORT *port);
+const char *ossl_quic_port_get_propq(QUIC_PORT *port);
+EVP_MD *ossl_quic_port_get_digest_alg(QUIC_PORT *port); /* SHA 256 */
+EVP_CIPHER *ossl_quic_port_get_hpr_cipher(QUIC_PORT *port); /* AES-128-ECB */
+EVP_CIPHER *ossl_quic_port_get_pkt_cipher(QUIC_PORT *port); /* AES-128-GCM */
+
 # endif
 
 #endif

--- a/include/internal/quic_record_rx.h
+++ b/include/internal/quic_record_rx.h
@@ -46,6 +46,7 @@ typedef struct ossl_qrx_args_st {
 
     /* Initial key phase. For debugging use only; always 0 in real use. */
     unsigned char   init_key_phase_bit;
+    QUIC_PORT_SECRETS *qps;
 } OSSL_QRX_ARGS;
 
 /* Instantiates a new QRX. */

--- a/include/internal/quic_record_util.h
+++ b/include/internal/quic_record_util.h
@@ -12,6 +12,7 @@
 
 # include <openssl/ssl.h>
 # include "internal/quic_types.h"
+# include "internal/quic_predef.h"
 
 # ifndef OPENSSL_NO_QUIC
 
@@ -65,6 +66,30 @@ int ossl_quic_provide_initial_secret(OSSL_LIB_CTX *libctx,
                                      struct ossl_qrx_st *qrx,
                                      struct ossl_qtx_st *qtx);
 
+/*
+ * sizes come from suite_aes128cgm. which is used by QRX for
+ * protection of initial packets (initial level envryption)
+ */
+#define QPS_RX_SECRET_SZ	32
+#define QPS_RX_CIPHER_KEY_SZ	16
+#define QPS_RX_CIPHER_IV_SZ	12
+#define	QPS_RX_CIPHER_TAG_SZ	16
+#define QPS_RX_HPR_KEY_SZ	16
+/*
+ * we might add evp contxts here and initialize them,
+ * the ownership of context would be transfered to
+ * channel/qrx.
+ */
+typedef struct quic_port_secrets_st {
+    unsigned char qps_rx_secret[32];
+    unsigned char qps_rx_cipher_iv[EVP_MAX_IV_LENGTH];
+    EVP_CIPHER_CTX *qps_hpr_ctx;
+    EVP_CIPHER_CTX *qps_pkt_ctx;
+} QUIC_PORT_SECRETS;
+
+QUIC_PORT_SECRETS *ossl_quic_provide_initial_rx_secret_for_dcid(QUIC_PORT *port,
+                                                 const QUIC_CONN_ID *dst_conn_id);
+void ossl_quic_destroy_port_secrets(QUIC_PORT_SECRETS *qps);
 /*
  * QUIC Record Layer Ciphersuite Info
  * ==================================

--- a/include/internal/quic_wire_pkt.h
+++ b/include/internal/quic_wire_pkt.h
@@ -13,6 +13,7 @@
 # include <openssl/ssl.h>
 # include "internal/packet_quic.h"
 # include "internal/quic_types.h"
+# include "internal/quic_record_util.h"
 
 # ifndef OPENSSL_NO_QUIC
 
@@ -192,6 +193,11 @@ int ossl_quic_hdr_protector_init(QUIC_HDR_PROTECTOR *hpr,
                                  const unsigned char *quic_hp_key,
                                  size_t quic_hp_key_len);
 
+int ossl_quic_hdr_protector_init_from_qps(QUIC_HDR_PROTECTOR *hpr,
+                                          OSSL_LIB_CTX *libctx,
+                                          const char *propq,
+                                          uint32_t cipher_id,
+                                          QUIC_PORT_SECRETS *qps);
 /*
  * Destroys a header protector. This is also safe to call on a zero-initialized
  * OSSL_QUIC_HDR_PROTECTOR structure which has not been initialized, or which

--- a/ssl/quic/quic_channel_local.h
+++ b/ssl/quic/quic_channel_local.h
@@ -454,6 +454,7 @@ struct quic_channel_st {
 
     /* Title for qlog purposes. We own this copy. */
     char                            *qlog_title;
+    QUIC_PORT_SECRETS               *qps;
 };
 
 # endif

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -1398,6 +1398,7 @@ static int port_chk_derive_nonce(QUIC_PORT_SECRETS *qps, QUIC_PN pn,
                                  unsigned char *nonce, int nonce_sz)
 {
     int nonce_len, i;
+    size_t i;
 
     nonce_len = EVP_CIPHER_CTX_get_iv_length(qps->qps_pkt_ctx);
     if (nonce_len > nonce_sz)

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -1397,7 +1397,7 @@ static int port_chk_remove_hdr_protection(QUIC_PORT_SECRETS *qps,
 static int port_chk_derive_nonce(QUIC_PORT_SECRETS *qps, QUIC_PN pn,
                                  unsigned char *nonce, int nonce_sz)
 {
-    int nonce_len, i;
+    int nonce_len;
     size_t i;
 
     nonce_len = EVP_CIPHER_CTX_get_iv_length(qps->qps_pkt_ctx);

--- a/ssl/quic/quic_port_local.h
+++ b/ssl/quic/quic_port_local.h
@@ -116,6 +116,10 @@ struct quic_port_st {
 
     /* AES-256 GCM context for token encryption */
     EVP_CIPHER_CTX *token_ctx;
+
+    EVP_CIPHER *evp_aes128gcm;
+    EVP_CIPHER *evp_aes128ecb;
+    EVP_MD *evp_sha256;
 };
 
 # endif

--- a/ssl/quic/quic_record_shared.h
+++ b/ssl/quic/quic_record_shared.h
@@ -115,7 +115,8 @@ int ossl_qrl_enc_level_set_provide_secret(OSSL_QRL_ENC_LEVEL_SET *els,
                                           const unsigned char *secret,
                                           size_t secret_len,
                                           unsigned char init_key_phase_bit,
-                                          int is_tx);
+                                          int is_tx,
+                                          QUIC_PORT_SECRETS *qps);
 
 /*
  * Returns 1 if the given keyslot index is currently valid for a given EL and EL

--- a/ssl/quic/quic_record_tx.c
+++ b/ssl/quic/quic_record_tx.c
@@ -196,7 +196,8 @@ int ossl_qtx_provide_secret(OSSL_QTX              *qtx,
                                                  secret,
                                                  secret_len,
                                                  0,
-                                                 /*is_tx=*/1);
+                                                 /*is_tx=*/1,
+                                                 /* port secrets */NULL);
 }
 
 int ossl_qtx_discard_enc_level(OSSL_QTX *qtx, uint32_t enc_level)

--- a/ssl/quic/quic_record_util.c
+++ b/ssl/quic/quic_record_util.c
@@ -91,7 +91,6 @@ int ossl_quic_provide_initial_secret(OSSL_LIB_CTX *libctx,
     unsigned char client_initial_secret[32], server_initial_secret[32];
     unsigned char *rx_secret, *tx_secret;
     EVP_MD *sha256;
-    int i;
 
     if (qrx == NULL && qtx == NULL)
         return 1;
@@ -178,14 +177,6 @@ int ossl_quic_provide_initial_secret(OSSL_LIB_CTX *libctx,
 err:
     EVP_MD_free(sha256);
     return 0;
-}
-
-void ossl_print_array(FILE *f, const unsigned char *array, size_t array_sz)
-{
-    int i;
-
-    for (i = 0; i < array_sz; i++)
-        fprintf(f, "%x", array[i]);
 }
 
 void ossl_quic_destroy_port_secrets(QUIC_PORT_SECRETS *qps)

--- a/ssl/quic/quic_wire_pkt.c
+++ b/ssl/quic/quic_wire_pkt.c
@@ -90,7 +90,6 @@ int ossl_quic_hdr_protector_init_from_qps(QUIC_HDR_PROTECTOR *hpr,
 
 
 
-extern void ossl_print_array(FILE *, const unsigned char *, size_t);
 static int hdr_generate_mask(QUIC_HDR_PROTECTOR *hpr,
                              const unsigned char *sample, size_t sample_len,
                              unsigned char *mask)
@@ -152,7 +151,6 @@ int ossl_quic_hdr_protector_decrypt(QUIC_HDR_PROTECTOR *hpr,
                                                   ptrs->raw_pn);
 }
 
-extern void ossl_print_array(FILE *, const unsigned char *, size_t);
 int ossl_quic_hdr_protector_decrypt_fields(QUIC_HDR_PROTECTOR *hpr,
                                            const unsigned char *sample,
                                            size_t sample_len,

--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -271,7 +271,9 @@ int qtest_create_quic_objects(OSSL_LIB_CTX *libctx, SSL_CTX *clientctx,
          *    client. This needs to be removed once we have proper server side
          *    handling.
          */
+#if 0
         (void)BIO_ctrl(sbio, BIO_CTRL_NOISE_BACK_OFF, 0, NULL);
+#endif
 
         (*fault)->noiseargs.cbio = cbio;
         (*fault)->noiseargs.sbio = sbio;


### PR DESCRIPTION
This will allow port to check integrity of received INITIAL packet. Also allow channel constructor to use those initial secrets when QRX object is being created.

