### PR TITLE
Fix compile error when building VC-WIN64-CLANGASM-ARM target with MSVC

### DIFF
--- a/Configurations/50-win-clang-cl.conf
+++ b/Configurations/50-win-clang-cl.conf
@@ -11,7 +11,7 @@ my %targets = (
         multilib        => "-arm64",
         asm_arch        => "aarch64",
         AS        => "clang-cl.exe",
-        ASFLAGS   => "/nologo /Zi",
+        ASFLAGS   => "/nologo /Zi --target=arm64-pc-windows-msvc",
         asflags   => "/c",
         asoutflag => "/Fo",
         perlasm_scheme => "win64",


### PR DESCRIPTION
Fix compile error when building VC-WIN64-CLANGASM-ARM target with MSVC v143,
C++ Clang Compiler for Windows (18.1.8)

Many errors similar to:
```
crypto\aes\libcrypto-lib-aesv8-armx.obj.asm:3795:7: error: unknown token in expression
        ld1     {v2.16b},[x0],#16
```
CLA: trivial

Similar to https://github.com/openssl/openssl/pull/25293

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
