### PR TITLE
Add a target config for MINGW on ARM64

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1746,6 +1746,18 @@ my %targets = (
         multilib         => "64",
     },
 
+    "mingwarm64" => {
+        inherit_from     => [ "mingw-common" ],
+        cflags           => "",
+        sys_id           => "MINGWARM64",
+        bn_ops           => add("SIXTY_FOUR_BIT"),
+        asm_arch         => 'aarch64',
+        uplink_arch      => 'armv8',
+        perlasm_scheme   => "win64",
+        shared_rcflag    => "",
+        multilib         => "-arm64",
+    },
+
 #### UEFI
     "UEFI" => {
         inherit_from     => [ "BASE_unix" ],


### PR DESCRIPTION
This is necessary to build OpenSSL native on Windows on Arm64 with gcc or clang. It also works when cross compiling on Linux for aarch64-w64-windows-gnu.

This patch is used since years on MSYS2:
  https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-openssl/001-support-aarch64.patch

It is also used in ruby-pg: https://github.com/ged/ruby-pg/pull/626

Fixes #10533
Related to #12363


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
  - Couldn't find any docs about supported platforms in the repo
- [ ] tests are added or updated
  - Not in this project, but in the linked projects above

I submitted my CLA.