### PR TITLE
lib: fix NULL pointer dereference in init_client function

### DIFF
--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -173,7 +173,7 @@ int init_client(int *sock, const char *host, const char *port,
         }
 
         /* Save the address */
-        if (tfo || !doconn)
+        if ((tfo || !doconn) && ba_ret != NULL) {
             *ba_ret = BIO_ADDR_dup(BIO_ADDRINFO_address(ai));
 
         /* Success, don't try any more addresses */


### PR DESCRIPTION
Report of the static analyzer: 
DEREF_AFTER_NULL.EX at  *ba_ret = BIO_ADDR_dup(BIO_ADDRINFO_address(ai));


Corrections explained: 
- Added a check `ba_ret != NULL` before dereferencing `ba_ret` to avoid potential crashes when `ba_ret` is NULL.
- Removed redundant initialization of `*ba_ret = NULL` as it was unsafe without a prior NULL check.

Triggers found by static analyzer Svace.
я
CLA: trivial
