### PR TITLE
Support DTLS 1.3 unified headers in ssltestlib

### DIFF
--- a/test/dtlstest.c
+++ b/test/dtlstest.c
@@ -77,15 +77,9 @@ static int test_dtls_unprocessed(int testidx)
 
     timer_cb_count = 0;
 
-    /**
-     * TODO(DTLSv1.3): Tests fails with
-     *  # No progress made
-     *  # ERROR: (bool) 'create_bare_ssl_connection(serverssl1, clientssl1,
-     *      SSL_ERROR_NONE, 0, 0) == true' failed @ ../test/dtlstest.c:128
-     */
     if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
                                        DTLS_client_method(),
-                                       DTLS1_VERSION, DTLS1_2_VERSION,
+                                       DTLS1_VERSION, 0,
                                        &sctx, &cctx, cert, privkey)))
         return 0;
 
@@ -121,8 +115,10 @@ static int test_dtls_unprocessed(int testidx)
      */
     c_to_s_mempacket = SSL_get_wbio(clientssl1);
     c_to_s_mempacket = BIO_next(c_to_s_mempacket);
-    mempacket_test_inject(c_to_s_mempacket, (char *)certstatus,
-                          sizeof(certstatus), 1, INJECT_PACKET_IGNORE_REC_SEQ);
+    if (!TEST_int_gt(mempacket_test_inject(c_to_s_mempacket, (char *)certstatus,
+                                           sizeof(certstatus), 1, INJECT_PACKET_IGNORE_REC_SEQ),
+                     0))
+        goto end;
 
     /*
      * Create the connection. We use "create_bare_ssl_connection" here so that
@@ -188,32 +184,153 @@ static int test_dtls_unprocessed(int testidx)
              SRV_TO_CLI_RESUME_EPOCH_0_RECS + SRV_TO_CLI_RESUME_EPOCH_1_RECS)
 
 #define TOTAL_RECORDS (TOTAL_FULL_HAND_RECORDS + TOTAL_RESUME_HAND_RECORDS)
+static int test_dtls_drop_records(int serverwbio, int minversion, int maxversion, int doresumption, int epoch, int idx);
+static int test_dtls_drop_records_dtls1(int idx) {
+    int doresumption;
+    int cli_to_srv_cookie, cli_to_srv_epoch0, cli_to_srv_epoch1;
+    int srv_to_cli_epoch0;
+    int serverwbio;
+    int epoch = 0;
+
+    if (idx >= TOTAL_FULL_HAND_RECORDS) {
+        doresumption = 1;
+        cli_to_srv_epoch0 = CLI_TO_SRV_RESUME_EPOCH_0_RECS;
+        cli_to_srv_epoch1 = CLI_TO_SRV_RESUME_EPOCH_1_RECS;
+        srv_to_cli_epoch0 = SRV_TO_CLI_RESUME_EPOCH_0_RECS;
+        cli_to_srv_cookie = CLI_TO_SRV_RESUME_COOKIE_EXCH;
+        idx -= TOTAL_FULL_HAND_RECORDS;
+    } else {
+        doresumption = 0;
+        cli_to_srv_epoch0 = CLI_TO_SRV_EPOCH_0_RECS;
+        cli_to_srv_epoch1 = CLI_TO_SRV_EPOCH_1_RECS;
+        srv_to_cli_epoch0 = SRV_TO_CLI_EPOCH_0_RECS;
+        cli_to_srv_cookie = CLI_TO_SRV_COOKIE_EXCH;
+    }
+    /* Work out which record to drop based on the test number */
+    if (idx >= cli_to_srv_cookie + cli_to_srv_epoch0 + cli_to_srv_epoch1) {
+        serverwbio = 1;
+        idx -= cli_to_srv_cookie + cli_to_srv_epoch0 + cli_to_srv_epoch1;
+        if (idx >= SRV_TO_CLI_COOKIE_EXCH + srv_to_cli_epoch0) {
+            epoch = 1;
+            idx -= SRV_TO_CLI_COOKIE_EXCH + srv_to_cli_epoch0;
+        }
+    } else {
+        serverwbio = 0;
+        if (idx >= cli_to_srv_cookie + cli_to_srv_epoch0) {
+            epoch = 1;
+            idx -= cli_to_srv_cookie + cli_to_srv_epoch0;
+        }
+    }
+
+    return test_dtls_drop_records(serverwbio, DTLS1_VERSION, DTLS1_2_VERSION, doresumption, epoch, idx);
+}
+
+/* ClientHello */
+#define DTLS13_CLI_TO_SRV_EPOCH_0_RECS_FULL 1
+/* ServerHello */
+#define DTLS13_SRV_TO_CLI_EPOCH_0_RECS_FULL 1
+/* Finish */
+#define DTLS13_CLI_TO_SRV_EPOCH_2_RECS_FULL 1
+/* EncryptedExtensions, Certificate, CertificateVerify, Finish */
+#define DTLS13_SRV_TO_CLI_EPOCH_2_RECS_FULL 4
+
+#define DTLS13_TOTAL_HAND_RECORDS_FULL \
+    (DTLS13_CLI_TO_SRV_EPOCH_0_RECS_FULL + DTLS13_SRV_TO_CLI_EPOCH_0_RECS_FULL \
+     + DTLS13_CLI_TO_SRV_EPOCH_2_RECS_FULL + DTLS13_SRV_TO_CLI_EPOCH_2_RECS_FULL)
+
+/* ClientHello */
+#define DTLS13_CLI_TO_SRV_EPOCH_0_RECS_RESM 1
+/* ServerHello */
+#define DTLS13_SRV_TO_CLI_EPOCH_0_RECS_RESM 1
+/* Finish */
+#define DTLS13_CLI_TO_SRV_EPOCH_2_RECS_RESM 1
+/* EncryptedExtensions, Finish */
+#define DTLS13_SRV_TO_CLI_EPOCH_2_RECS_RESM 2
+
+#define DTLS13_TOTAL_HAND_RECORDS_RESM \
+    (DTLS13_CLI_TO_SRV_EPOCH_0_RECS_RESM + DTLS13_SRV_TO_CLI_EPOCH_0_RECS_RESM \
+     + DTLS13_CLI_TO_SRV_EPOCH_2_RECS_RESM + DTLS13_SRV_TO_CLI_EPOCH_2_RECS_RESM)
+
+#define DTLS13_TOTAL_RECORDS \
+    (DTLS13_TOTAL_HAND_RECORDS_FULL + DTLS13_TOTAL_HAND_RECORDS_RESM)
+
+/**
+ * test_dtls_drop_records_dtls13 tests DTLS 1.3 implementation robustness against
+ * dropped records
+ *
+ * @param idx
+ *
+ * idx:
+ *      0) Tests drop of ClientHello (Client)
+ *      1) Tests drop of Finish (Client)
+ *      2) Tests drop of ServerHello (Server)
+ *      3) Tests drop of EncryptedExtensions (Server)
+ *      4) Tests drop of Certificate (Server)
+ *      5) Tests drop of CertificateVerify (Server)
+ *      6) Tests drop of Finish (Server)
+ *      7) Tests drop of ClientHello (Client) in resumption
+ *      8) Tests drop of Finish (Client) in resumption
+ *      9) Tests drop of ServerHello (Server) in resumption
+ *      10) Tests drop of EncryptedExtensions (Server) in resumption
+ *      11) Tests drop of Finish (Server) in resumption
+ *
+ * @return 1 on success, 0 on failure
+ */
+
+static int test_dtls_drop_records_dtls13(int idx) {
+    int doresumption;
+    int srv_to_cli_epoch0, cli_to_srv_epoch0, cli_to_srv_epoch2;
+    int serverwbio;
+    int epoch = 0;
+
+    if (idx >= DTLS13_TOTAL_HAND_RECORDS_FULL) {
+        doresumption = 1;
+        cli_to_srv_epoch0 = DTLS13_CLI_TO_SRV_EPOCH_0_RECS_RESM;
+        cli_to_srv_epoch2 = DTLS13_CLI_TO_SRV_EPOCH_2_RECS_RESM;
+        srv_to_cli_epoch0 = DTLS13_SRV_TO_CLI_EPOCH_0_RECS_RESM;
+        idx -= DTLS13_TOTAL_HAND_RECORDS_FULL;
+    } else {
+        doresumption = 0;
+        cli_to_srv_epoch0 = DTLS13_CLI_TO_SRV_EPOCH_0_RECS_FULL;
+        cli_to_srv_epoch2 = DTLS13_CLI_TO_SRV_EPOCH_2_RECS_FULL;
+        srv_to_cli_epoch0 = DTLS13_SRV_TO_CLI_EPOCH_0_RECS_FULL;
+    }
+    /* Work out which record to drop based on the test number */
+    if (idx >= cli_to_srv_epoch0 + cli_to_srv_epoch2) {
+        serverwbio = 1;
+        idx -= cli_to_srv_epoch0 + cli_to_srv_epoch2;
+        if (idx >= srv_to_cli_epoch0) {
+            epoch = 2;
+            idx -= srv_to_cli_epoch0;
+        }
+    } else {
+        serverwbio = 0;
+        if (idx >= cli_to_srv_epoch0) {
+            epoch = 2;
+            idx -= cli_to_srv_epoch0;
+        }
+    }
+
+    return test_dtls_drop_records(serverwbio, DTLS1_3_VERSION, 0, doresumption, epoch, idx);
+}
 
 /*
  * We are assuming a ServerKeyExchange message is sent in this test. If we don't
  * have either DH or EC, then it won't be
  */
 #if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC)
-static int test_dtls_drop_records(int idx)
+static int test_dtls_drop_records(int serverwbio, int minversion, int maxversion,
+                                  int doresumption, int epoch, int idx)
 {
     SSL_CTX *sctx = NULL, *cctx = NULL;
     SSL *serverssl = NULL, *clientssl = NULL;
     BIO *c_to_s_fbio, *mempackbio;
     int testresult = 0;
-    int epoch = 0;
     SSL_SESSION *sess = NULL;
-    int cli_to_srv_cookie, cli_to_srv_epoch0, cli_to_srv_epoch1;
-    int srv_to_cli_epoch0;
 
-    /**
-     * TODO(DTLSv1.3): Tests fails with
-     *  dtls1_read_bytes:ssl/tls alert unexpected message:
-     *      ssl/record/rec_layer_d1.c:454:SSL alert number 10
-     * And "no progress made"
-     */
     if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
                                        DTLS_client_method(),
-                                       DTLS1_VERSION, DTLS1_2_VERSION,
+                                       minversion, maxversion,
                                        &sctx, &cctx, cert, privkey)))
         return 0;
 
@@ -232,7 +349,7 @@ static int test_dtls_drop_records(int idx)
     SSL_CTX_set_cookie_generate_cb(sctx, generate_cookie_cb);
     SSL_CTX_set_cookie_verify_cb(sctx, verify_cookie_cb);
 
-    if (idx >= TOTAL_FULL_HAND_RECORDS) {
+    if (doresumption) {
         /* We're going to do a resumption handshake. Get a session first. */
         if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
                                           NULL, NULL))
@@ -246,17 +363,6 @@ static int test_dtls_drop_records(int idx)
         SSL_free(serverssl);
         SSL_free(clientssl);
         serverssl = clientssl = NULL;
-
-        cli_to_srv_epoch0 = CLI_TO_SRV_RESUME_EPOCH_0_RECS;
-        cli_to_srv_epoch1 = CLI_TO_SRV_RESUME_EPOCH_1_RECS;
-        srv_to_cli_epoch0 = SRV_TO_CLI_RESUME_EPOCH_0_RECS;
-        cli_to_srv_cookie = CLI_TO_SRV_RESUME_COOKIE_EXCH;
-        idx -= TOTAL_FULL_HAND_RECORDS;
-    } else {
-        cli_to_srv_epoch0 = CLI_TO_SRV_EPOCH_0_RECS;
-        cli_to_srv_epoch1 = CLI_TO_SRV_EPOCH_1_RECS;
-        srv_to_cli_epoch0 = SRV_TO_CLI_EPOCH_0_RECS;
-        cli_to_srv_cookie = CLI_TO_SRV_COOKIE_EXCH;
     }
 
     c_to_s_fbio = BIO_new(bio_f_tls_dump_filter());
@@ -277,20 +383,11 @@ static int test_dtls_drop_records(int idx)
     DTLS_set_timer_cb(serverssl, timer_cb);
 
     /* Work out which record to drop based on the test number */
-    if (idx >= cli_to_srv_cookie + cli_to_srv_epoch0 + cli_to_srv_epoch1) {
+    if (serverwbio) {
         mempackbio = SSL_get_wbio(serverssl);
-        idx -= cli_to_srv_cookie + cli_to_srv_epoch0 + cli_to_srv_epoch1;
-        if (idx >= SRV_TO_CLI_COOKIE_EXCH + srv_to_cli_epoch0) {
-            epoch = 1;
-            idx -= SRV_TO_CLI_COOKIE_EXCH + srv_to_cli_epoch0;
-        }
     } else {
         mempackbio = SSL_get_wbio(clientssl);
-        if (idx >= cli_to_srv_cookie + cli_to_srv_epoch0) {
-            epoch = 1;
-            idx -= cli_to_srv_cookie + cli_to_srv_epoch0;
-        }
-         mempackbio = BIO_next(mempackbio);
+        mempackbio = BIO_next(mempackbio);
     }
     BIO_ctrl(mempackbio, MEMPACKET_CTRL_SET_DROP_EPOCH, epoch, NULL);
     BIO_ctrl(mempackbio, MEMPACKET_CTRL_SET_DROP_REC, idx, NULL);
@@ -670,7 +767,8 @@ int setup_tests(void)
 
     ADD_ALL_TESTS(test_dtls_unprocessed, NUM_TESTS);
 #if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC)
-    ADD_ALL_TESTS(test_dtls_drop_records, TOTAL_RECORDS);
+    ADD_ALL_TESTS(test_dtls_drop_records_dtls1, TOTAL_RECORDS);
+    ADD_ALL_TESTS(test_dtls_drop_records_dtls13, DTLS13_TOTAL_RECORDS);
 #endif
     ADD_TEST(test_cookie);
     ADD_TEST(test_dtls_duplicate_records);

--- a/test/helpers/ssltestlib.c
+++ b/test/helpers/ssltestlib.c
@@ -121,6 +121,11 @@ static void copy_flags(BIO *bio)
 #define MSG_FRAG_LEN_LO         11
 
 
+#define DTLS13_UNI_HDR_RECORD_SEQ_HI 1
+#define DTLS13_UNI_HDR_RECORD_SEQ_LO 2
+#define DTLS13_UNI_HDR_RECORD_LEN_HI 3
+#define DTLS13_UNI_HDR_RECORD_LEN_LO 4
+
 static void dump_data(const char *data, int len)
 {
     int rem, i, content, reclen, msglen, fragoff, fraglen, epoch;
@@ -132,28 +137,51 @@ static void dump_data(const char *data, int len)
     rec = (unsigned char *)data;
 
     while (rem > 0) {
+        int rechdrlen;
+
+        if (DTLS13_UNI_HDR_FIX_BITS_IS_SET(*rec))
+            rechdrlen = DTLS13_UNI_HDR_FIXED_LENGTH;
+        else
+            rechdrlen = DTLS1_RT_HEADER_LENGTH;
+
         if (rem != len)
             printf("*\n");
         printf("*---- START OF RECORD ----\n");
-        if (rem < DTLS1_RT_HEADER_LENGTH) {
+        if (rem < rechdrlen) {
             printf("*---- RECORD TRUNCATED ----\n");
             break;
         }
-        content = rec[RECORD_CONTENT_TYPE];
-        printf("** Record Content-type: %d\n", content);
-        printf("** Record Version: %02x%02x\n",
-               rec[RECORD_VERSION_HI], rec[RECORD_VERSION_LO]);
-        epoch = (rec[RECORD_EPOCH_HI] << 8) | rec[RECORD_EPOCH_LO];
-        printf("** Record Epoch: %d\n", epoch);
-        printf("** Record Sequence: ");
-        for (i = RECORD_SEQUENCE_START; i <= RECORD_SEQUENCE_END; i++)
-            printf("%02x", rec[i]);
-        reclen = (rec[RECORD_LEN_HI] << 8) | rec[RECORD_LEN_LO];
-        printf("\n** Record Length: %d\n", reclen);
+        if (DTLS13_UNI_HDR_FIX_BITS_IS_SET(*rec)) {
+            content = SSL3_RT_APPLICATION_DATA;
+            printf("** Encrypted DTLS 1.3 Record Content\n");
+            epoch = *rec & DTLS13_UNI_HDR_EPOCH_BITS_MASK;
+
+            if (epoch == 0)
+                epoch = 4;
+
+            printf("** Record Epoch: %d\n", epoch);
+            printf("** Record Sequence: ");
+            for (i = DTLS13_UNI_HDR_RECORD_SEQ_HI; i <= DTLS13_UNI_HDR_RECORD_SEQ_LO; i++)
+                printf("%02x", rec[i]);
+            reclen = (rec[DTLS13_UNI_HDR_RECORD_LEN_HI] << 8) | rec[DTLS13_UNI_HDR_RECORD_LEN_LO];
+            printf("\n** Record Length: %d\n", reclen);
+        } else {
+            content = rec[RECORD_CONTENT_TYPE];
+            printf("** Record Content-type: %d\n", content);
+            printf("** Record Version: %02x%02x\n",
+                   rec[RECORD_VERSION_HI], rec[RECORD_VERSION_LO]);
+            epoch = (rec[RECORD_EPOCH_HI] << 8) | rec[RECORD_EPOCH_LO];
+            printf("** Record Epoch: %d\n", epoch);
+            printf("** Record Sequence: ");
+            for (i = RECORD_SEQUENCE_START; i <= RECORD_SEQUENCE_END; i++)
+                printf("%02x", rec[i]);
+            reclen = (rec[RECORD_LEN_HI] << 8) | rec[RECORD_LEN_LO];
+            printf("\n** Record Length: %d\n", reclen);
+        }
 
         /* Now look at message */
-        rec += DTLS1_RT_HEADER_LENGTH;
-        rem -= DTLS1_RT_HEADER_LENGTH;
+        rec += rechdrlen;
+        rem -= rechdrlen;
         if (content == SSL3_RT_HANDSHAKE) {
             printf("**---- START OF HANDSHAKE MESSAGE FRAGMENT ----\n");
             if (epoch > 0) {
@@ -339,13 +367,6 @@ static int mempacket_test_free(BIO *bio)
     return 1;
 }
 
-/* Record Header values */
-#define EPOCH_HI        3
-#define EPOCH_LO        4
-#define RECORD_SEQUENCE 10
-#define RECORD_LEN_HI   11
-#define RECORD_LEN_LO   12
-
 #define STANDARD_PACKET                 0
 
 static int mempacket_test_read(BIO *bio, char *out, int outl)
@@ -353,8 +374,7 @@ static int mempacket_test_read(BIO *bio, char *out, int outl)
     MEMPACKET_TEST_CTX *ctx = BIO_get_data(bio);
     MEMPACKET *thispkt;
     unsigned char *rec;
-    int rem;
-    unsigned int seq, offset, len, epoch;
+    unsigned int seq, offset, len, epoch, rem;
 
     BIO_clear_retry_flags(bio);
     if ((thispkt = sk_MEMPACKET_value(ctx->pkts, 0)) == NULL
@@ -378,27 +398,51 @@ static int mempacket_test_read(BIO *bio, char *out, int outl)
          * with any packets that have been injected
          */
         for (rem = thispkt->len, rec = thispkt->data; rem > 0; rem -= len) {
-            if (rem < DTLS1_RT_HEADER_LENGTH)
+            unsigned int rechdrlen;
+
+            if (DTLS13_UNI_HDR_FIX_BITS_IS_SET(*rec))
+                rechdrlen = DTLS13_UNI_HDR_FIXED_LENGTH;
+            else
+                rechdrlen = DTLS1_RT_HEADER_LENGTH;
+
+            if (rem < rechdrlen)
                 return -1;
-            epoch = (rec[EPOCH_HI] << 8) | rec[EPOCH_LO];
+
+            if (DTLS13_UNI_HDR_FIX_BITS_IS_SET(*rec))
+                /* We don't expect epochs higher than 3 */
+                epoch = *rec & DTLS13_UNI_HDR_EPOCH_BITS_MASK;
+            else
+                epoch = (rec[RECORD_EPOCH_HI] << 8) | rec[RECORD_EPOCH_LO];
+
             if (epoch != ctx->epoch) {
                 ctx->epoch = epoch;
                 ctx->currrec = 0;
             }
             seq = ctx->currrec;
             offset = 0;
-            do {
-                rec[RECORD_SEQUENCE - offset] = seq & 0xFF;
-                seq >>= 8;
-                offset++;
-            } while (seq > 0);
 
-            len = ((rec[RECORD_LEN_HI] << 8) | rec[RECORD_LEN_LO])
-                  + DTLS1_RT_HEADER_LENGTH;
-            if (rem < (int)len)
+            if (DTLS13_UNI_HDR_FIX_BITS_IS_SET(*rec)) {
+                //rec[DTLS13_UNI_HDR_RECORD_SEQ_HI] = (seq >> 8) & 0xFF;
+                //rec[DTLS13_UNI_HDR_RECORD_SEQ_LO] = seq & 0xFF;
+            } else {
+                do {
+                    rec[RECORD_SEQUENCE_END - offset] = seq & 0xFF;
+                    seq >>= 8;
+                    offset++;
+                } while (seq > 0);
+            }
+
+            if (DTLS13_UNI_HDR_FIX_BITS_IS_SET(*rec))
+                len = (rec[DTLS13_UNI_HDR_RECORD_LEN_HI] << 8) | rec[DTLS13_UNI_HDR_RECORD_LEN_LO];
+            else
+                len = (rec[RECORD_LEN_HI] << 8) | rec[RECORD_LEN_LO];
+
+            len += rechdrlen;
+
+            if (rem < len)
                 return -1;
             if (ctx->droprec == (int)ctx->currrec && ctx->dropepoch == epoch) {
-                if (rem > (int)len)
+                if (rem > len)
                     memmove(rec, rec + len, rem - len);
                 outl -= len;
                 ctx->droprec = -1;
@@ -442,11 +486,27 @@ int mempacket_swap_epoch(BIO *bio)
         return 0;
 
     for (rem = thispkt->len, rec = thispkt->data; rem > 0; rem -= len, rec += len) {
-        if (rem < DTLS1_RT_HEADER_LENGTH)
+        int rechdrlen;
+
+        if (DTLS13_UNI_HDR_FIX_BITS_IS_SET(*rec))
+            rechdrlen = DTLS13_UNI_HDR_FIXED_LENGTH;
+        else
+            rechdrlen = DTLS1_RT_HEADER_LENGTH;
+
+        if (rem < rechdrlen)
             return 0;
-        epoch = (rec[EPOCH_HI] << 8) | rec[EPOCH_LO];
-        len = ((rec[RECORD_LEN_HI] << 8) | rec[RECORD_LEN_LO])
-                + DTLS1_RT_HEADER_LENGTH;
+        if (DTLS13_UNI_HDR_FIX_BITS_IS_SET(*rec)) {
+            epoch = *rec & DTLS13_UNI_HDR_EPOCH_BITS_MASK;
+
+            if (epoch == 0)
+                epoch = 4;
+
+            len = ((rec[DTLS13_UNI_HDR_RECORD_LEN_HI] << 8) | rec[DTLS13_UNI_HDR_RECORD_LEN_LO])
+                  + rechdrlen;
+        } else {
+            epoch = (rec[RECORD_EPOCH_HI] << 8) | rec[RECORD_EPOCH_LO];
+            len = ((rec[RECORD_LEN_HI] << 8) | rec[RECORD_LEN_LO]) + rechdrlen;
+        }
         if (rem < len)
             return 0;
 
@@ -543,8 +603,23 @@ int mempacket_test_inject(BIO *bio, const char *in, int inl, int pktnum,
     MEMPACKET *thispkt = NULL, *looppkt, *nextpkt, *allpkts[3];
     int i, duprec;
     const unsigned char *inu = (const unsigned char *)in;
-    size_t len = ((inu[RECORD_LEN_HI] << 8) | inu[RECORD_LEN_LO])
-                 + DTLS1_RT_HEADER_LENGTH;
+    size_t len;
+
+    if (DTLS13_UNI_HDR_FIX_BITS_IS_SET(*in)
+            /* The following code does not handle connection ids */
+            && ossl_assert(!DTLS13_UNI_HDR_CID_BIT_IS_SET(*in))) {
+        if (DTLS13_UNI_HDR_LEN_BIT_IS_SET(*in)) {
+            len = 3; /* 2 bytes for len field and 1 byte for record type */
+            len += DTLS13_UNI_HDR_SEQ_BIT_IS_SET(*in) ? 2 : 1;
+            len += ((inu[DTLS13_UNI_HDR_RECORD_LEN_HI] << 8) | inu[DTLS13_UNI_HDR_RECORD_LEN_LO]);
+        } else {
+            /* We assert that inl is the correct record length */
+            len = inl;
+        }
+    } else {
+        len = ((inu[RECORD_LEN_HI] << 8) | inu[RECORD_LEN_LO]);
+             len += DTLS1_RT_HEADER_LENGTH;
+    }
 
     if (ctx == NULL)
         return -1;


### PR DESCRIPTION
Adds drop records test for DTLS 1.3 and enable unprocessed record test case from dtlstest.c.

This is dependent on https://github.com/openssl/openssl/pull/25119 and https://github.com/openssl/openssl/pull/25668.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
