### PR TITLE
Add quic-server branch to coveralls

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -26,6 +26,9 @@ jobs:
       matrix:
         branches: [
           {
+            branch: feature/quic-server,
+            extra_config: no-afalgeng enable-fips enable-tfo
+          }, {
             branch: openssl-3.4,
             extra_config: no-afalgeng enable-fips enable-tfo
           }, {


### PR DESCRIPTION
We don't need this for long, but given the impending merge of the quic-server branch, it would be good to get some predictive coverage numbers on the branch so we're not caught unaware when the merge occurs.

Running lcov locally works, but lcov produces numbers that differ from what coveralls reports on existing branches (for instance coveralls coverage for master is currently at 67.7% but lcov run locally reports coverage for the same branch at 66.3%).  Given that lcov is somewhat sensitive to gcc and lcov versions it would be good to run quic-server through the ci/coveralls process so we have an apples to apples comparison.
