### PR TITLE
Add workflow dispatch inputs into coveralls workflow

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -1,4 +1,4 @@
-# Copyright 2021-2024 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2021-2025 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -7,44 +7,74 @@
 
 name: Coverage
 
-# Run once a day
 on:
   schedule:
-    - cron:  '15 02 * * *'
+    - cron: '15 02 * * *'
   workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to measure coverage
+        required: true
+        default: master
+      extra_config:
+        description: Extra options for configuration script
+        default: ""
 
 permissions:
   contents: read
 
 jobs:
+  define-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.branches.outputs.branches }}
+    steps:
+      - name: Define branches
+        id: branches
+        run: |
+          if [ "${{ github.event_name}}" = "workflow_dispatch" ]; then
+          MATRIX=$(cat << EOF
+          [{
+            "branch": "${{ github.event.inputs.branch }}",
+            "extra_config": "${{ github.event.inputs.extra_config }}"
+          }]
+          EOF
+          )
+          else
+          MATRIX=$(cat << EOF
+          [{
+              "branch": "openssl-3.4",
+              "extra_config": "no-afalgeng enable-fips enable-tfo"
+            }, {
+              "branch": "openssl-3.3",
+              "extra_config": "no-afalgeng enable-fips enable-tfo"
+            }, {
+              "branch": "openssl-3.2",
+              "extra_config": "no-afalgeng enable-fips enable-tfo"
+            }, {
+              "branch": "openssl-3.1",
+              "extra_config": "no-afalgeng enable-fips"
+            }, {
+              "branch": "openssl-3.0",
+              "extra_config": "no-afalgeng enable-fips"
+            }, {
+              "branch": "master",
+              "extra_config": "no-afalgeng enable-fips enable-tfo"
+          }]
+          EOF
+          )
+          fi
+          echo "branches<<EOF"$'\n'"$MATRIX"$'\n'EOF >> "$GITHUB_OUTPUT"
+
   coverage:
+    needs: define-matrix
     permissions:
       checks: write     # for coverallsapp/github-action to create new checks
       contents: read    # for actions/checkout to fetch code
     strategy:
       fail-fast: false
       matrix:
-        branches: [
-          {
-            branch: openssl-3.4,
-            extra_config: no-afalgeng enable-fips enable-tfo
-          }, {
-            branch: openssl-3.3,
-            extra_config: no-afalgeng enable-fips enable-tfo
-          }, {
-            branch: openssl-3.2,
-            extra_config: no-afalgeng enable-fips enable-tfo
-          }, {
-            branch: openssl-3.1,
-            extra_config: no-afalgeng enable-fips
-          }, {
-            branch: openssl-3.0,
-            extra_config: no-afalgeng enable-fips
-          }, {
-            branch: master,
-            extra_config: no-afalgeng enable-fips enable-tfo
-          }
-        ]
+        branches: ${{ fromJSON(needs.define-matrix.outputs.branches) }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds ability to run `.github/workflows/coveralls.yml` workflow manually and specify a target branch and extra options for the configuration script. Here are runs from my fork:

* [Manually triggered run](https://github.com/quarckster/openssl-fork/actions/runs/13155207659/)
* [Scheduled run](https://github.com/quarckster/openssl-fork/actions/runs/13155178179)