### PR TITLE
Fix configuring provider certificate algs via config file

### DIFF
--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -88,7 +88,9 @@ struct ssl_conf_ctx_st {
     /* Pointer to SSL or SSL_CTX options field or NULL if none */
     uint64_t *poptions;
     /* Certificate filenames for each type */
-    char *cert_filename[SSL_PKEY_NUM];
+    char **cert_filename;
+    /* Number of elements in the cert_filename array */
+    size_t num_cert_filename;
     /* Pointer to SSL or SSL_CTX cert_flags or NULL if none */
     uint32_t *pcert_flags;
     /* Pointer to SSL or SSL_CTX verify_mode or NULL if none */
@@ -453,12 +455,18 @@ static int cmd_Certificate(SSL_CONF_CTX *cctx, const char *value)
         }
     }
     if (rv > 0 && c != NULL && cctx->flags & SSL_CONF_FLAG_REQUIRE_PRIVATE) {
-        char **pfilename = &cctx->cert_filename[c->key - c->pkeys];
+        size_t fileidx = c->key - c->pkeys;
 
-        OPENSSL_free(*pfilename);
-        *pfilename = OPENSSL_strdup(value);
-        if (*pfilename == NULL)
+        if (fileidx >= cctx->num_cert_filename) {
             rv = 0;
+        } else {
+            char **pfilename = &cctx->cert_filename[c->key - c->pkeys];
+
+            OPENSSL_free(*pfilename);
+            *pfilename = OPENSSL_strdup(value);
+            if (*pfilename == NULL)
+                rv = 0;
+        }
     }
 
     return rv > 0;
@@ -1051,12 +1059,12 @@ int SSL_CONF_CTX_finish(SSL_CONF_CTX *cctx)
             c = sc->cert;
     }
     if (c != NULL && cctx->flags & SSL_CONF_FLAG_REQUIRE_PRIVATE) {
-        for (i = 0; i < SSL_PKEY_NUM; i++) {
+        for (i = 0; i < cctx->num_cert_filename; i++) {
             const char *p = cctx->cert_filename[i];
             /*
              * If missing private key try to load one from certificate file
              */
-            if (p && !c->pkeys[i].privatekey) {
+            if (p != NULL && c->pkeys[i].privatekey == NULL) {
                 if (!cmd_PrivateKey(cctx, p))
                     return 0;
             }
@@ -1074,12 +1082,21 @@ int SSL_CONF_CTX_finish(SSL_CONF_CTX *cctx)
     return 1;
 }
 
+static void free_cert_filename(SSL_CONF_CTX *cctx)
+{
+    size_t i;
+
+    for (i = 0; i < cctx->num_cert_filename; i++)
+        OPENSSL_free(cctx->cert_filename[i]);
+    OPENSSL_free(cctx->cert_filename);
+    cctx->cert_filename = NULL;
+    cctx->num_cert_filename = 0;
+}
+
 void SSL_CONF_CTX_free(SSL_CONF_CTX *cctx)
 {
     if (cctx) {
-        size_t i;
-        for (i = 0; i < SSL_PKEY_NUM; i++)
-            OPENSSL_free(cctx->cert_filename[i]);
+        free_cert_filename(cctx);
         OPENSSL_free(cctx->prefix);
         sk_X509_NAME_pop_free(cctx->canames, X509_NAME_free);
         OPENSSL_free(cctx);
@@ -1129,12 +1146,17 @@ void SSL_CONF_CTX_set_ssl(SSL_CONF_CTX *cctx, SSL *ssl)
         cctx->max_version = &sc->max_proto_version;
         cctx->pcert_flags = &sc->cert->cert_flags;
         cctx->pvfy_flags = &sc->verify_mode;
+        cctx->cert_filename = OPENSSL_zalloc(sc->ssl_pkey_num
+                                             * sizeof(*cctx->cert_filename));
+        if (cctx->cert_filename != NULL)
+            cctx->num_cert_filename = sc->ssl_pkey_num;
     } else {
         cctx->poptions = NULL;
         cctx->min_version = NULL;
         cctx->max_version = NULL;
         cctx->pcert_flags = NULL;
         cctx->pvfy_flags = NULL;
+        free_cert_filename(cctx);
     }
 }
 
@@ -1148,11 +1170,16 @@ void SSL_CONF_CTX_set_ssl_ctx(SSL_CONF_CTX *cctx, SSL_CTX *ctx)
         cctx->max_version = &ctx->max_proto_version;
         cctx->pcert_flags = &ctx->cert->cert_flags;
         cctx->pvfy_flags = &ctx->verify_mode;
+        cctx->cert_filename = OPENSSL_zalloc((SSL_PKEY_NUM + ctx->sigalg_list_len)
+                                             * sizeof(*cctx->cert_filename));
+        if (cctx->cert_filename != NULL)
+            cctx->num_cert_filename = SSL_PKEY_NUM + ctx->sigalg_list_len;
     } else {
         cctx->poptions = NULL;
         cctx->min_version = NULL;
         cctx->max_version = NULL;
         cctx->pcert_flags = NULL;
         cctx->pvfy_flags = NULL;
+        free_cert_filename(cctx);
     }
 }

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -1061,6 +1061,7 @@ int SSL_CONF_CTX_finish(SSL_CONF_CTX *cctx)
     if (c != NULL && cctx->flags & SSL_CONF_FLAG_REQUIRE_PRIVATE) {
         for (i = 0; i < cctx->num_cert_filename; i++) {
             const char *p = cctx->cert_filename[i];
+
             /*
              * If missing private key try to load one from certificate file
              */
@@ -1136,6 +1137,7 @@ void SSL_CONF_CTX_set_ssl(SSL_CONF_CTX *cctx, SSL *ssl)
 {
     cctx->ssl = ssl;
     cctx->ctx = NULL;
+    free_cert_filename(cctx);
     if (ssl != NULL) {
         SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(ssl);
 
@@ -1156,7 +1158,6 @@ void SSL_CONF_CTX_set_ssl(SSL_CONF_CTX *cctx, SSL *ssl)
         cctx->max_version = NULL;
         cctx->pcert_flags = NULL;
         cctx->pvfy_flags = NULL;
-        free_cert_filename(cctx);
     }
 }
 
@@ -1164,6 +1165,7 @@ void SSL_CONF_CTX_set_ssl_ctx(SSL_CONF_CTX *cctx, SSL_CTX *ctx)
 {
     cctx->ctx = ctx;
     cctx->ssl = NULL;
+    free_cert_filename(cctx);
     if (ctx) {
         cctx->poptions = &ctx->options;
         cctx->min_version = &ctx->min_proto_version;
@@ -1180,6 +1182,5 @@ void SSL_CONF_CTX_set_ssl_ctx(SSL_CONF_CTX *cctx, SSL_CTX *ctx)
         cctx->max_version = NULL;
         cctx->pcert_flags = NULL;
         cctx->pvfy_flags = NULL;
-        free_cert_filename(cctx);
     }
 }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -10081,8 +10081,10 @@ static int create_cert_key(int idx, char *certfilename, char *privkeyfilename)
  * correctly establish a TLS (1.3) connection.
  * Test 0: Signature algorithm with built-in hashing functionality: "xorhmacsig"
  * Test 1: Signature algorithm using external SHA2 hashing: "xorhmacsha2sig"
- * Test 2: Test 0 using RPK
- * Test 3: Test 1 using RPK
+ * Test 2: Signature algorithm with built-in hashing configured via SSL_CONF_cmd
+ * Test 3: Test 0 using RPK
+ * Test 4: Test 1 using RPK
+ * Test 5: Test 2 using RPK
  */
 static int test_pluggable_signature(int idx)
 {
@@ -10094,8 +10096,14 @@ static int test_pluggable_signature(int idx)
     OSSL_PROVIDER *defaultprov = OSSL_PROVIDER_load(libctx, "default");
     char *certfilename = "tls-prov-cert.pem";
     char *privkeyfilename = "tls-prov-key.pem";
-    int sigidx = idx % 2;
-    int rpkidx = idx / 2;
+    int sigidx = idx % 3;
+    int rpkidx = idx / 3;
+    int do_conf_cmd = 0;
+
+    if (sigidx == 2) {
+        sigidx = 0;
+        do_conf_cmd = 1;
+    }
 
     /* create key and certificate for the different algorithm types */
     if (!TEST_ptr(tlsprov)
@@ -10106,9 +10114,40 @@ static int test_pluggable_signature(int idx)
                                        TLS_client_method(),
                                        TLS1_3_VERSION,
                                        TLS1_3_VERSION,
-                                       &sctx, &cctx, certfilename, privkeyfilename))
-            || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL)))
+                                       &sctx, &cctx, NULL, NULL)))
+        goto end;
+
+    if (do_conf_cmd) {
+        SSL_CONF_CTX *confctx = SSL_CONF_CTX_new();
+
+        if (!TEST_ptr(confctx))
+            goto end;
+        SSL_CONF_CTX_set_flags(confctx, SSL_CONF_FLAG_FILE
+                                        | SSL_CONF_FLAG_SERVER
+                                        | SSL_CONF_FLAG_CERTIFICATE
+                                        | SSL_CONF_FLAG_REQUIRE_PRIVATE
+                                        | SSL_CONF_FLAG_SHOW_ERRORS);
+        SSL_CONF_CTX_set_ssl_ctx(confctx, sctx);
+        if (!TEST_int_gt(SSL_CONF_cmd(confctx, "Certificate", certfilename), 0)
+                || !TEST_int_gt(SSL_CONF_cmd(confctx, "PrivateKey", privkeyfilename), 0)
+                || !TEST_true(SSL_CONF_CTX_finish(confctx))) {
+            SSL_CONF_CTX_free(confctx);
+            goto end;
+        }
+        SSL_CONF_CTX_free(confctx);
+    } else {
+        if (!TEST_int_eq(SSL_CTX_use_certificate_file(sctx, certfilename,
+                                                      SSL_FILETYPE_PEM), 1)
+                || !TEST_int_eq(SSL_CTX_use_PrivateKey_file(sctx,
+                                                            privkeyfilename,
+                                                            SSL_FILETYPE_PEM), 1))
+            goto end;
+    }
+    if (!TEST_int_eq(SSL_CTX_check_private_key(sctx), 1))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+                                      NULL, NULL)))
         goto end;
 
     /* Enable RPK for server cert */
@@ -12682,7 +12721,7 @@ int setup_tests(void)
 #endif
 #ifndef OPENSSL_NO_TLS1_3
     ADD_ALL_TESTS(test_pluggable_group, 2);
-    ADD_ALL_TESTS(test_pluggable_signature, 4);
+    ADD_ALL_TESTS(test_pluggable_signature, 6);
 #endif
 #ifndef OPENSSL_NO_TLS1_2
     ADD_TEST(test_ssl_dup);


### PR DESCRIPTION
A crash could occur when attempting to configure a certificate via a
config file, where the algorithm for the certificate key was added
dynamically via a provider.