### PR TITLE
Avoid calling ssl_load_sigalgs in tls1_set_sigalgs_list

### DIFF
--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -1323,7 +1323,7 @@ const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk, size_t *pidx,
         }
     }
     /* check provider-loaded pk types */
-    for (i = 0; ctx->sigalg_list_len; i++) {
+    for (i = 0; i < ctx->sigalg_list_len; i++) {
         SSL_CERT_LOOKUP *tmp_lu = &(ctx->ssl_cert_info[i]);
 
         if (EVP_PKEY_is_a(pk, OBJ_nid2sn(tmp_lu->nid))

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -3121,9 +3121,8 @@ int tls1_set_sigalgs_list(SSL_CTX *ctx, CERT *c, const char *str, int client)
     sig_cb_st sig;
     sig.sigalgcnt = 0;
 
-    if (ctx != NULL && ssl_load_sigalgs(ctx)) {
+    if (ctx != NULL)
         sig.ctx = ctx;
-    }
     if (!CONF_parse_list(str, ':', 1, sig_cb, &sig))
         return 0;
     if (sig.sigalgcnt == 0) {


### PR DESCRIPTION
- The signature algorithms are already loaded in SSL_CTX_new()

- Calling ssl_load_sigalgs() again is non-productive, and does not look thread safe.

- And of course avoiding the call is cheaper.