### PR TITLE
ML-DSA gettable seed and pk hash validation

### DIFF
--- a/crypto/ml_dsa/ml_dsa_key.c
+++ b/crypto/ml_dsa/ml_dsa_key.c
@@ -132,7 +132,7 @@ int ossl_ml_dsa_key_priv_alloc(ML_DSA_KEY *key)
 }
 
 /**
- * @brief Destroy a ML_DSA_KEY object
+ * @brief Destroy an ML_DSA_KEY object
  */
 void ossl_ml_dsa_key_free(ML_DSA_KEY *key)
 {
@@ -141,6 +141,15 @@ void ossl_ml_dsa_key_free(ML_DSA_KEY *key)
 
     EVP_MD_free(key->shake128_md);
     EVP_MD_free(key->shake256_md);
+    ossl_ml_dsa_key_reset(key);
+    OPENSSL_free(key);
+}
+
+/**
+ * @brief Factory reset an ML_DSA_KEY object
+ */
+void ossl_ml_dsa_key_reset(ML_DSA_KEY *key)
+{
     vector_zero(&key->s2);
     vector_zero(&key->s1);
     vector_zero(&key->t0);
@@ -148,11 +157,13 @@ void ossl_ml_dsa_key_free(ML_DSA_KEY *key)
     vector_free(&key->t1);
     OPENSSL_cleanse(key->K, sizeof(key->K));
     OPENSSL_free(key->pub_encoding);
+    key->pub_encoding = NULL;
     if (key->priv_encoding != NULL)
         OPENSSL_clear_free(key->priv_encoding, key->params->sk_len);
+    key->priv_encoding = NULL;
     if (key->seed != NULL)
         OPENSSL_clear_free(key->seed, ML_DSA_SEED_BYTES);
-    OPENSSL_free(key);
+    key->seed = NULL;
 }
 
 /**

--- a/doc/man7/EVP_PKEY-ML-DSA.pod
+++ b/doc/man7/EVP_PKEY-ML-DSA.pod
@@ -127,11 +127,11 @@ B<ξ> seed and the secret key B<sk> are present in the private key as part of
 the DER encoding of the ASN.1 sequence:
 
     ML-DSA-PrivateKey ::= CHOICE {
-      seed [0] IMPLICIT OCTET STRING SIZE (32),
-      expandedKey OCTET STRING SIZE (2560 | 4032 | 4896)
+      seed [0] IMPLICIT OCTET STRING (SIZE (32)),
+      expandedKey OCTET STRING (SIZE (2560 | 4032 | 4896)),
       both SEQUENCE {
-        seed OCTET STRING SIZE (32),
-        expandedKey OCTET STRING SIZE (2560 | 4032 | 4896) } }
+        seed OCTET STRING (SIZE (32)),
+        expandedKey OCTET STRING (SIZE (2560 | 4032 | 4896)) } }
 
 If the C<seed-priv> format is not included in the list, this format will not be
 recognised on input.

--- a/include/crypto/ml_dsa.h
+++ b/include/crypto/ml_dsa.h
@@ -70,6 +70,8 @@ const ML_DSA_PARAMS *ossl_ml_dsa_params_get(int evp_type);
 const ML_DSA_PARAMS *ossl_ml_dsa_key_params(const ML_DSA_KEY *key);
 __owur ML_DSA_KEY *ossl_ml_dsa_key_new(OSSL_LIB_CTX *libctx, const char *propq,
                                        int evp_type);
+/* Factory reset for keys that fail initialisation */
+void ossl_ml_dsa_key_reset(ML_DSA_KEY *key);
 __owur int ossl_ml_dsa_key_pub_alloc(ML_DSA_KEY *key);
 __owur int ossl_ml_dsa_key_priv_alloc(ML_DSA_KEY *key);
 void ossl_ml_dsa_key_free(ML_DSA_KEY *key);

--- a/providers/implementations/encode_decode/ml_dsa_codecs.c
+++ b/providers/implementations/encode_decode/ml_dsa_codecs.c
@@ -22,11 +22,11 @@
  * corresponding to the "either or both" variants of:
  *
  *  ML-DSA-PrivateKey ::= CHOICE {
- *    seed [0] IMPLICIT OCTET STRING SIZE (32),
- *    expandedKey OCTET STRING SIZE (2560 | 4032 | 4896)
+ *    seed [0] IMPLICIT OCTET STRING (SIZE (32)),
+ *    expandedKey OCTET STRING (SIZE (2560 | 4032 | 4896)),
  *    both SEQUENCE {
- *      seed OCTET STRING SIZE (32),
- *      expandedKey OCTET STRING SIZE (2560 | 4032 | 4896) } }
+ *      seed OCTET STRING (SIZE (32)),
+ *      expandedKey OCTET STRING (SIZE (2560 | 4032 | 4896)) } }
  *
  * one more for a historical OQS encoding:
  *

--- a/providers/implementations/encode_decode/ml_dsa_codecs.h
+++ b/providers/implementations/encode_decode/ml_dsa_codecs.h
@@ -36,11 +36,11 @@ typedef struct {
  * corresponding to the "either or both" variants of:
  *
  *  ML-DSA-PrivateKey ::= CHOICE {
- *    seed [0] IMPLICIT OCTET STRING SIZE (32),
- *    expandedKey OCTET STRING SIZE (2560 | 4032 | 4896)
+ *    seed [0] IMPLICIT OCTET STRING (SIZE (32)),
+ *    expandedKey OCTET STRING (SIZE (2560 | 4032 | 4896)),
  *    both SEQUENCE {
- *      seed OCTET STRING SIZE (32),
- *      expandedKey OCTET STRING SIZE (2560 | 4032 | 4896) } }
+ *      seed OCTET STRING (SIZE (32)),
+ *      expandedKey OCTET STRING (SIZE (2560 | 4032 | 4896)) } }
  *
  * one more for a historical OQS encoding:
  *

--- a/providers/implementations/keymgmt/ml_dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/ml_dsa_kmgmt.c
@@ -255,8 +255,10 @@ static int ml_dsa_import(void *keydata, int selection, const OSSL_PARAM params[]
 #ifdef FIPS_MODULE
     if (res > 0) {
         res = ml_dsa_pairwise_test(key);
-        if (res <= 0)
+        if (res <= 0) {
+            ossl_ml_dsa_key_reset(key);
             ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT);
+        }
     }
 #endif
     return res;

--- a/test/ml_dsa_test.c
+++ b/test/ml_dsa_test.c
@@ -87,16 +87,19 @@ static int ml_dsa_keygen_test(int tst_id)
     int ret = 0;
     const ML_DSA_KEYGEN_TEST_DATA *tst = &ml_dsa_keygen_testdata[tst_id];
     EVP_PKEY *pkey = NULL;
-    uint8_t priv[5 * 1024], pub[3 * 1024];
-    size_t priv_len, pub_len;
+    uint8_t priv[5 * 1024], pub[3 * 1024], seed[ML_DSA_SEED_BYTES];
+    size_t priv_len, pub_len, seed_len;
 
     if (!TEST_ptr(pkey = do_gen_key(tst->name, tst->seed, tst->seed_len))
+            || !TEST_true(EVP_PKEY_get_octet_string_param(pkey, OSSL_PKEY_PARAM_ML_DSA_SEED,
+                                                          seed, sizeof(seed), &seed_len))
             || !TEST_true(EVP_PKEY_get_octet_string_param(pkey, OSSL_PKEY_PARAM_PRIV_KEY,
                                                           priv, sizeof(priv), &priv_len))
             || !TEST_true(EVP_PKEY_get_octet_string_param(pkey, OSSL_PKEY_PARAM_PUB_KEY,
                                                           pub, sizeof(pub), &pub_len))
             || !TEST_mem_eq(pub, pub_len, tst->pub, tst->pub_len)
-            || !TEST_mem_eq(priv, priv_len, tst->priv, tst->priv_len))
+            || !TEST_mem_eq(priv, priv_len, tst->priv, tst->priv_len)
+            || !TEST_mem_eq(seed, seed_len, tst->seed, tst->seed_len))
         goto err;
     ret = 1;
 err:


### PR DESCRIPTION
Make the ML-DSA seed gettable as documented
    
- Also fix the get_params keymgmt function to always return what's
  available.  Requested, but unavailable, parameters are simply left
  unmodified.  It is not an error to request more than is present.
- Reject private keys with an incorrect pk hash

##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated
