### PR TITLE
LoongArch: Fix output file name detection for Perl scripts

### DIFF
--- a/crypto/aes/asm/vpaes-loongarch64.pl
+++ b/crypto/aes/asm/vpaes-loongarch64.pl
@@ -29,9 +29,9 @@
 ($vr0,$vr1,$vr2,$vr3,$vr4,$vr5,$vr6,$vr7,$vr8,$vr9,$vr10,$vr11,$vr12,$vr13,$vr14,$vr15,$vr16,$vr17,$vr18,$vr19)=map("\$vr$_",(0..19));
 ($fp)=map("\$r$_",(22));
 
-for (@ARGV) {   $output=$_ if (/\w[\w\-]*\.\w+$/);      }
-open STDOUT,">$output";
-while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {}
+# $output is the last argument if it looks like a file (it has an extension)
+my $output;
+$output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 open STDOUT,">$output";
 
 $PREFIX="vpaes";

--- a/crypto/chacha/asm/chacha-loongarch64.pl
+++ b/crypto/chacha/asm/chacha-loongarch64.pl
@@ -37,8 +37,9 @@ my ($xr0,$xr1,$xr2,$xr3,$xr4,$xr5,$xr6,$xr7,$xr8,$xr9,$xr10,
     $xr20,$xr21,$xr22,$xr23,$xr24,$xr25,$xr26,$xr27,$xr28,
     $xr29,$xr30,$xr31)=map("\$xr$_",(0..31));
 
+# $output is the last argument if it looks like a file (it has an extension)
 my $output;
-for (@ARGV) {	$output=$_ if (/\w[\w\-]*\.\w+$/);	}
+$output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 open STDOUT,">$output";
 
 # Input parameter block

--- a/crypto/loongarch64cpuid.pl
+++ b/crypto/loongarch64cpuid.pl
@@ -16,10 +16,9 @@
 ($vr0,$vr1,$vr2,$vr3,$vr4,$vr5,$vr6,$vr7,$vr8,$vr9,$vr10,$vr11,$vr12,$vr13,$vr14,$vr15,$vr16,$vr17,$vr18,$vr19)=map("\$vr$_",(0..19));
 ($fp)=map("\$r$_",(22));
 
-
-for (@ARGV) {   $output=$_ if (/\w[\w\-]*\.\w+$/);      }
-open STDOUT,">$output";
-while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {}
+# $output is the last argument if it looks like a file (it has an extension)
+my $output;
+$output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 open STDOUT,">$output";
 
 {

--- a/crypto/md5/asm/md5-loongarch64.pl
+++ b/crypto/md5/asm/md5-loongarch64.pl
@@ -18,8 +18,9 @@ my ($zero,$ra,$tp,$sp,$fp)=map("\$r$_",(0..3,22));
 my ($a0,$a1,$a2,$a3,$a4,$a5,$a6,$a7)=map("\$r$_",(4..11));
 my ($t0,$t1,$t2,$t3,$t4,$t5,$t6,$t7,$t8,$x)=map("\$r$_",(12..21));
 
+# $output is the last argument if it looks like a file (it has an extension)
 my $output;
-for (@ARGV) {	$output=$_ if (/\w[\w\-]*\.\w+$/);	}
+$output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 open STDOUT,">$output";
 
 # round1_step() does:


### PR DESCRIPTION
We were using the first (or second) argument containing a '.' as the output name file, but it may be incorrect as -march=la64v1.0 may be in the command line.  If the builder specifies -march=la64v1.0 in the CFLAGS, the script will write to a file named "-march=la64v1.0" and cause a build error with cryptic message:

    ld: crypto/pem/loader_attic-dso-pvkfmt.o: in function `i2b_PVK':
    .../openssl-3.4.1/crypto/pem/pvkfmt.c:1070:(.text+0x11a8): undefined reference to `OPENSSL_cleanse'

Adapt the approach of ARM and RISC-V (they have similar flags like -march=v8.1-a or -misa-spec=2.2) to fix the issue.
