### PR TITLE
EC_get_buildin_curves does not return an error

### DIFF
--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -67,13 +67,11 @@ const OPTIONS ecparam_options[] = {
 
 static int list_builtin_curves(BIO *out)
 {
-    int ret = 0;
     EC_builtin_curve *curves = NULL;
     size_t n, crv_len = EC_get_builtin_curves(NULL, 0);
 
     curves = app_malloc((int)sizeof(*curves) * crv_len, "list curves");
-    if (!EC_get_builtin_curves(curves, crv_len))
-        goto end;
+    EC_get_builtin_curves(curves, crv_len);
 
     for (n = 0; n < crv_len; n++) {
         const char *comment = curves[n].comment;
@@ -87,10 +85,8 @@ static int list_builtin_curves(BIO *out)
         BIO_printf(out, "  %-10s: ", sname);
         BIO_printf(out, "%s\n", comment);
     }
-    ret = 1;
-end:
     OPENSSL_free(curves);
-    return ret;
+    return 1;
 }
 
 int ecparam_main(int argc, char **argv)


### PR DESCRIPTION
EC_get_buildin_curves does not return an error, this check is unnecessary.

Found by Linux Verification Center (linuxtesting.org) with SVACE.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
