### PR TITLE
When we try to get a group, we need session to be valid

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3734,7 +3734,7 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
             if (SSL_CONNECTION_IS_TLS13(sc) && sc->s3.did_kex)
                 id = sc->s3.group_id;
             else
-                id = sc->session->kex_group;
+                id = (sc->session != NULL) ? sc->session->kex_group : NID_undef;
             ret = tls1_group_id2nid(id, 1);
             break;
         }


### PR DESCRIPTION
`OPENSSL_CONF=/dev/null LD_LIBRARY_PATH=. apps/openssl s_client -connect google.com:443 -tls1` in current master causes a crash with the following stack
```
Program received signal SIGSEGV, Segmentation fault.
ssl3_ctrl (s=0x591b70, cmd=134, larg=0, parg=0x0) at ssl/s3_lib.c:3737
3737	                id = sc->session->kex_group;
(gdb) bt
#0  ssl3_ctrl (s=0x591b70, cmd=134, larg=0, parg=0x0) at ssl/s3_lib.c:3737
#1  0x00007ffff7e9e229 in ossl_ctrl_internal (s=0x591b70, cmd=134, larg=0, parg=0x0, no_quic=0) at ssl/ssl_lib.c:3040
#2  0x00007ffff7e9db32 in SSL_ctrl (s=0x591b70, cmd=134, larg=0, parg=0x0) at ssl/ssl_lib.c:2912
#3  0x00000000004886f3 in ssl_print_tmp_key (out=0x5118c0, s=0x591b70) at apps/lib/s_cb.c:424
#4  0x0000000000452058 in print_stuff (bio=0x5118c0, s=0x591b70, full=1) at apps/s_client.c:3444
#5  0x00000000004516f3 in s_client_main (argc=4, argv=0x7fffffffdb50) at apps/s_client.c:3288
#6  0x0000000000438a47 in do_cmd (prog=0x525360, argc=4, argv=0x7fffffffdb50) at apps/openssl.c:428
#7  0x0000000000438659 in main (argc=4, argv=0x7fffffffdb50) at apps/openssl.c:309
```
It looks like a side-effect of #25959 to me.
Weird but I didn't manage to reproduce it with `util/wrap.pl` and had to set LD_LIBRARY_PATH explicitly.

I believe we can skip tests for this fix

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
