### PR TITLE
Wrap use of poll.h to prevent including on NonStop.

### DIFF
--- a/include/internal/sockets.h
+++ b/include/internal/sockets.h
@@ -97,7 +97,9 @@ typedef size_t socklen_t;        /* Currently appears to be missing on VMS */
 #   include <in.h>
 #   include <inet.h>
 #  else
-#   include <poll.h>
+#   if !defined(OPENSSL_SYS_TANDEM)
+#    include <poll.h>
+#   endif
 #   include <sys/socket.h>
 #   if !defined(NO_SYS_UN_H) && defined(AF_UNIX) && !defined(OPENSSL_NO_UNIX_SOCK)
 #    include <sys/un.h>


### PR DESCRIPTION
This inclusion modifies a change done at 38e8392ba0c8dcd975de47a3119d0051cf5e44a1 that always includes poll.h when building threaded models. This is not portable.

This fix may apply to other branches.

Fixes: #26724