### PR TITLE
Accessors for the IANA signature scheme name

### DIFF
--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -1306,6 +1306,7 @@ void print_verify_detail(SSL *s, BIO *bio)
 
 void print_ssl_summary(SSL *s)
 {
+    const char *sigalg;
     const SSL_CIPHER *c;
     X509 *peer = SSL_get0_peer_certificate(s);
     EVP_PKEY *peer_rpk = SSL_get0_peer_rpk(s);
@@ -1323,13 +1324,13 @@ void print_ssl_summary(SSL *s)
         BIO_puts(bio_err, "\n");
         if (SSL_get_peer_signature_nid(s, &nid))
             BIO_printf(bio_err, "Hash used: %s\n", OBJ_nid2sn(nid));
-        if (SSL_get_peer_signature_type_nid(s, &nid))
-            BIO_printf(bio_err, "Signature type: %s\n", get_sigtype(nid));
+        if (SSL_get0_peer_signature_name(s, &sigalg))
+            BIO_printf(bio_err, "Signature type: %s\n", sigalg);
         print_verify_detail(s, bio_err);
     } else if (peer_rpk != NULL) {
         BIO_printf(bio_err, "Peer used raw public key\n");
-        if (SSL_get_peer_signature_type_nid(s, &nid))
-            BIO_printf(bio_err, "Signature type: %s\n", get_sigtype(nid));
+        if (SSL_get0_peer_signature_name(s, &sigalg))
+            BIO_printf(bio_err, "Signature type: %s\n", sigalg);
         print_verify_detail(s, bio_err);
     } else {
         BIO_puts(bio_err, "No peer certificate or raw public key\n");

--- a/doc/man3/SSL_get_peer_signature_nid.pod
+++ b/doc/man3/SSL_get_peer_signature_nid.pod
@@ -54,9 +54,14 @@ message.
 
 L<ssl(7)>, L<SSL_get_peer_certificate(3)>,
 
+=head1 HISTORY
+
+The SSL_get0_peer_signature_name() and SSL_get0_signature_name() functions were
+added in OpenSSL 3.5.
+
 =head1 COPYRIGHT
 
-Copyright 2017-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2017-2025 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/SSL_get_peer_signature_nid.pod
+++ b/doc/man3/SSL_get_peer_signature_nid.pod
@@ -2,20 +2,30 @@
 
 =head1 NAME
 
-SSL_get_peer_signature_nid, SSL_get_peer_signature_type_nid,
-SSL_get_signature_nid, SSL_get_signature_type_nid - get TLS message signing
-types
+SSL_get0_peer_signature_name, SSL_get_peer_signature_nid,
+SSL_get_peer_signature_type_nid, SSL_get0_signature_name,
+SSL_get_signature_nid, SSL_get_signature_type_nid -
+get TLS message signing types
 
 =head1 SYNOPSIS
 
  #include <openssl/ssl.h>
 
+ int SSL_get0_peer_signature_name(const SSL *ssl, const char **sigalg);
  int SSL_get_peer_signature_nid(SSL *ssl, int *psig_nid);
  int SSL_get_peer_signature_type_nid(const SSL *ssl, int *psigtype_nid);
+ int SSL_get0_signature_name(SSL *ssl, const char **sigalg);
  int SSL_get_signature_nid(SSL *ssl, int *psig_nid);
  int SSL_get_signature_type_nid(const SSL *ssl, int *psigtype_nid);
 
 =head1 DESCRIPTION
+
+SSL_get0_peer_signature_name() sets I<*sigalg> to the IANA name of the
+L<signature scheme|https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-signaturescheme>
+used by the peer to sign the TLS handshake.
+The caller must not free the returned pointer.
+The returned string should be copied if it is to be retained beyond the
+lifetime of the SSL connection.
 
 SSL_get_peer_signature_nid() sets B<*psig_nid> to the NID of the digest used
 by the peer to sign TLS messages. It is implemented as a macro.
@@ -27,15 +37,18 @@ where it is B<EVP_PKEY_RSA_PSS>. To differentiate between
 B<rsa_pss_rsae_*> and B<rsa_pss_pss_*> signatures, it's necessary to check
 the type of public key in the peer's certificate.
 
-SSL_get_signature_nid() and SSL_get_signature_type_nid() return the equivalent
-information for the local end of the connection.
+SSL_get0_signature_name(), SSL_get_signature_nid() and
+SSL_get_signature_type_nid() return the equivalent information for the local
+end of the connection.
 
 =head1 RETURN VALUES
 
 These functions return 1 for success and 0 for failure. There are several
-possible reasons for failure: the cipher suite has no signature (e.g. it
-uses RSA key exchange or is anonymous), the TLS version is below 1.2 or
-the functions were called too early, e.g. before the peer signed a message.
+possible reasons for failure: the peer or local end is a client and did not
+sign the handshake (did not use a client certificate), the cipher suite has no
+signature (e.g. it uses RSA key exchange or is anonymous), the TLS version is
+below 1.2 or the functions were called too early, e.g. before the peer signed a
+message.
 
 =head1 SEE ALSO
 

--- a/doc/man7/EVP_KEM-ML-KEM.pod
+++ b/doc/man7/EVP_KEM-ML-KEM.pod
@@ -54,7 +54,7 @@ This functionality was added in OpenSSL 3.5.
 
 =head1 COPYRIGHT
 
-Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man7/EVP_PKEY-ML-KEM.pod
+++ b/doc/man7/EVP_PKEY-ML-KEM.pod
@@ -304,7 +304,7 @@ This functionality was added in OpenSSL 3.5.
 
 =head1 COPYRIGHT
 
-Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -1337,6 +1337,8 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 # define SSL_CTRL_GET_VERIFY_CERT_STORE          137
 # define SSL_CTRL_GET_CHAIN_CERT_STORE           138
 # define SSL_CTRL_GET0_IMPLEMENTED_GROUPS        139
+# define SSL_CTRL_GET_SIGNATURE_NAME             140
+# define SSL_CTRL_GET_PEER_SIGNATURE_NAME        141
 # define SSL_CERT_SET_FIRST                      1
 # define SSL_CERT_SET_NEXT                       2
 # define SSL_CERT_SET_SERVER                     3
@@ -1479,8 +1481,12 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
                      (char *)(clist))
 # define SSL_set1_client_certificate_types(s, clist, clistlen) \
         SSL_ctrl(s,SSL_CTRL_SET_CLIENT_CERT_TYPES,clistlen,(char *)(clist))
+# define SSL_get0_signature_name(s, str) \
+        SSL_ctrl(s,SSL_CTRL_GET_SIGNATURE_NAME,0,(1?(str):(const char **)NULL))
 # define SSL_get_signature_nid(s, pn) \
         SSL_ctrl(s,SSL_CTRL_GET_SIGNATURE_NID,0,pn)
+# define SSL_get0_peer_signature_name(s, str) \
+        SSL_ctrl(s,SSL_CTRL_GET_PEER_SIGNATURE_NAME,0,(1?(str):(const char **)NULL))
 # define SSL_get_peer_signature_nid(s, pn) \
         SSL_ctrl(s,SSL_CTRL_GET_PEER_SIGNATURE_NID,0,pn)
 # define SSL_get_peer_tmp_key(s, pk) \

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3826,7 +3826,7 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         return ssl_cert_get_cert_store(sc->cert, parg, 1);
 
     case SSL_CTRL_GET_PEER_SIGNATURE_NAME:
-        if (sc->s3.tmp.peer_sigalg == NULL)
+        if (parg == NULL && sc->s3.tmp.peer_sigalg == NULL)
             return 0;
         *(const char **)parg = sc->s3.tmp.peer_sigalg->name;
         return 1;
@@ -3838,7 +3838,7 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         return 1;
 
     case SSL_CTRL_GET_SIGNATURE_NAME:
-        if (sc->s3.tmp.sigalg == NULL)
+        if (parg == NULL || sc->s3.tmp.sigalg == NULL)
             return 0;
         *(const char **)parg = sc->s3.tmp.sigalg->name;
         return 1;

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3825,10 +3825,22 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
     case SSL_CTRL_GET_CHAIN_CERT_STORE:
         return ssl_cert_get_cert_store(sc->cert, parg, 1);
 
+    case SSL_CTRL_GET_PEER_SIGNATURE_NAME:
+        if (sc->s3.tmp.peer_sigalg == NULL)
+            return 0;
+        *(const char **)parg = sc->s3.tmp.peer_sigalg->name;
+        return 1;
+
     case SSL_CTRL_GET_PEER_SIGNATURE_NID:
         if (sc->s3.tmp.peer_sigalg == NULL)
             return 0;
         *(int *)parg = sc->s3.tmp.peer_sigalg->hash;
+        return 1;
+
+    case SSL_CTRL_GET_SIGNATURE_NAME:
+        if (sc->s3.tmp.sigalg == NULL)
+            return 0;
+        *(const char **)parg = sc->s3.tmp.sigalg->name;
         return 1;
 
     case SSL_CTRL_GET_SIGNATURE_NID:

--- a/util/other.syms
+++ b/util/other.syms
@@ -631,6 +631,7 @@ SSL_get_max_proto_version               define
 SSL_get_min_proto_version               define
 SSL_get_mode                            define
 SSL_get_peer_certificate                define deprecated 3.0.0
+SSL_get0_peer_signature_name            define
 SSL_get_peer_signature_nid              define
 SSL_get_peer_tmp_key                    define
 SSL_get_secure_renegotiation_support    define
@@ -638,6 +639,7 @@ SSL_get_server_tmp_key                  define
 SSL_get_shared_curve                    define
 SSL_get_shared_group                    define
 SSL_get_negotiated_group                define
+SSL_get0_signature_name                 define
 SSL_get_signature_nid                   define
 SSL_get_time                            define
 SSL_get_timeout                         define


### PR DESCRIPTION
This is the official name of the signature algorithm(s) used by the peer and/or local end of the connection, and should be available, e.g. for logging. (As mentioned in https://github.com/openssl/project/issues/1076#issuecomment-2656703701)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests added or updated