### PR TITLE
When doing AEAD validation in quic, create a unique qrx for each validation, and remove it when done

### DIFF
--- a/include/internal/quic_channel.h
+++ b/include/internal/quic_channel.h
@@ -116,15 +116,12 @@ typedef struct quic_channel_args_st {
     QUIC_LCIDM      *lcidm;
     /* SRTM to register SRTs with. */
     QUIC_SRTM       *srtm;
-    OSSL_QRX        *qrx;
 
     int             is_server;
     SSL             *tls;
 
     /* Whether to use qlog. */
     int             use_qlog;
-
-    int             is_tserver_ch;
 
     /* Title to use for the qlog session, or NULL. */
     const char      *qlog_title;
@@ -180,7 +177,6 @@ typedef struct quic_terminate_cause_st {
  */
 QUIC_CHANNEL *ossl_quic_channel_alloc(const QUIC_CHANNEL_ARGS *args);
 int ossl_quic_channel_init(QUIC_CHANNEL *ch);
-void ossl_quic_channel_bind_qrx(QUIC_CHANNEL *tserver_ch, OSSL_QRX *qrx);
 
 
 /* No-op if ch is NULL. */

--- a/include/internal/quic_predef.h
+++ b/include/internal/quic_predef.h
@@ -32,7 +32,6 @@ typedef struct quic_reactor_st QUIC_REACTOR;
 typedef struct quic_reactor_wait_ctx_st QUIC_REACTOR_WAIT_CTX;
 typedef struct ossl_statm_st OSSL_STATM;
 typedef struct quic_demux_st QUIC_DEMUX;
-typedef struct ossl_qrx_st OSSL_QRX;
 typedef struct ossl_qrx_pkt_st OSSL_QRX_PKT;
 typedef struct ossl_qtx_pkt_st OSSL_QTX_PKT;
 typedef struct quic_tick_result_st QUIC_TICK_RESULT;

--- a/include/internal/quic_record_rx.h
+++ b/include/internal/quic_record_rx.h
@@ -23,6 +23,7 @@
  * QUIC Record Layer - RX
  * ======================
  */
+typedef struct ossl_qrx_st OSSL_QRX;
 
 typedef struct ossl_qrx_args_st {
     OSSL_LIB_CTX   *libctx;
@@ -320,6 +321,7 @@ int ossl_qrx_set_late_validation_cb(OSSL_QRX *qrx,
  * establish a new connection.
  */
 void ossl_qrx_inject_urxe(OSSL_QRX *qrx, QUIC_URXE *e);
+
 int ossl_qrx_validate_initial_packet(OSSL_QRX *qrx, QUIC_URXE *urxe,
                                      const QUIC_CONN_ID *dcid);
 

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -295,44 +295,23 @@ static int ch_init(QUIC_CHANNEL *ch)
 
     ossl_quic_tx_packetiser_set_ack_tx_cb(ch->txp, ch_on_txp_ack_tx, ch);
 
-    /*
-     * qrx does not exist yet, then we must be dealing with client channel
-     * (QUIC connection initiator).
-     * If qrx exists already, then we are dealing with server channel which
-     * qrx gets created by port_default_packet_handler() before
-     * port_default_packet_handler() accepts connection and creates channel
-     * for it.
-     * The exception here is tserver which always creates channel,
-     * before the first packet is ever seen.
-     */
-    if (ch->qrx == NULL && ch->is_tserver_ch == 0) {
-        /* we are regular client, create channel */
-        qrx_args.libctx             = ch->port->engine->libctx;
-        qrx_args.demux              = ch->port->demux;
-        qrx_args.short_conn_id_len  = rx_short_dcid_len;
-        qrx_args.max_deferred       = 32;
+    qrx_args.libctx             = ch->port->engine->libctx;
+    qrx_args.demux              = ch->port->demux;
+    qrx_args.short_conn_id_len  = rx_short_dcid_len;
+    qrx_args.max_deferred       = 32;
 
-        if ((ch->qrx = ossl_qrx_new(&qrx_args)) == NULL)
-            goto err;
-    }
+    if ((ch->qrx = ossl_qrx_new(&qrx_args)) == NULL)
+        goto err;
 
-    if (ch->qrx != NULL) {
-        /*
-         * callbacks for channels associated with tserver's port
-         * are set up later when we call ossl_quic_channel_bind_qrx()
-         * in port_default_packet_handler()
-         */
-        if (!ossl_qrx_set_late_validation_cb(ch->qrx,
-                                             rx_late_validate,
-                                             ch))
-            goto err;
+    if (!ossl_qrx_set_late_validation_cb(ch->qrx,
+                                         rx_late_validate,
+                                         ch))
+        goto err;
 
-        if (!ossl_qrx_set_key_update_cb(ch->qrx,
-                                        rxku_detected,
-                                        ch))
-            goto err;
-    }
-
+    if (!ossl_qrx_set_key_update_cb(ch->qrx,
+                                    rxku_detected,
+                                    ch))
+        goto err;
 
     for (pn_space = QUIC_PN_SPACE_INITIAL; pn_space < QUIC_PN_SPACE_NUM; ++pn_space) {
         ch->crypto_recv[pn_space] = ossl_quic_rstream_new(NULL, NULL, 0);
@@ -446,17 +425,6 @@ int ossl_quic_channel_init(QUIC_CHANNEL *ch)
     return ch_init(ch);
 }
 
-void ossl_quic_channel_bind_qrx(QUIC_CHANNEL *tserver_ch, OSSL_QRX *qrx)
-{
-    if (tserver_ch->qrx == NULL && tserver_ch->is_tserver_ch == 1) {
-        tserver_ch->qrx = qrx;
-        ossl_qrx_set_late_validation_cb(tserver_ch->qrx, rx_late_validate,
-                                        tserver_ch);
-        ossl_qrx_set_key_update_cb(tserver_ch->qrx, rxku_detected,
-                                   tserver_ch);
-    }
-}
-
 QUIC_CHANNEL *ossl_quic_channel_alloc(const QUIC_CHANNEL_ARGS *args)
 {
     QUIC_CHANNEL *ch = NULL;
@@ -464,13 +432,11 @@ QUIC_CHANNEL *ossl_quic_channel_alloc(const QUIC_CHANNEL_ARGS *args)
     if ((ch = OPENSSL_zalloc(sizeof(*ch))) == NULL)
         return NULL;
 
-    ch->port           = args->port;
-    ch->is_server      = args->is_server;
-    ch->tls            = args->tls;
-    ch->lcidm          = args->lcidm;
-    ch->srtm           = args->srtm;
-    ch->qrx            = args->qrx;
-    ch->is_tserver_ch  = args->is_tserver_ch;
+    ch->port        = args->port;
+    ch->is_server   = args->is_server;
+    ch->tls         = args->tls;
+    ch->lcidm       = args->lcidm;
+    ch->srtm        = args->srtm;
 #ifndef OPENSSL_NO_QLOG
     ch->use_qlog    = args->use_qlog;
 
@@ -603,7 +569,7 @@ err:
 
 size_t ossl_quic_channel_get_short_header_conn_id_len(QUIC_CHANNEL *ch)
 {
-    return ossl_quic_port_get_rx_short_dcid_len(ch->port);
+    return ossl_qrx_get_short_hdr_conn_id_len(ch->qrx);
 }
 
 QUIC_STREAM *ossl_quic_channel_get_stream_by_id(QUIC_CHANNEL *ch,
@@ -3669,15 +3635,12 @@ static int ch_on_new_conn_common(QUIC_CHANNEL *ch, const BIO_ADDR *peer,
     ossl_qtx_set_qlog_cb(ch->qtx, ch_get_qlog_cb, ch);
     ossl_quic_tx_packetiser_set_qlog_cb(ch->txp, ch_get_qlog_cb, ch);
 
-    /*
-     * Plug in secrets for the Initial EL. secrets for QRX were created in
-     * port_default_packet_handler() already.
-     */
+    /* Plug in secrets for the Initial EL. */
     if (!ossl_quic_provide_initial_secret(ch->port->engine->libctx,
                                           ch->port->engine->propq,
                                           &ch->init_dcid,
                                           /*is_server=*/1,
-                                          NULL, ch->qtx))
+                                          ch->qrx, ch->qtx))
         return 0;
 
     /* Register the peer ODCID in the LCIDM. */
@@ -3993,12 +3956,7 @@ void ossl_quic_channel_set_msg_callback(QUIC_CHANNEL *ch,
     ossl_qtx_set_msg_callback(ch->qtx, msg_callback, msg_callback_ssl);
     ossl_quic_tx_packetiser_set_msg_callback(ch->txp, msg_callback,
                                              msg_callback_ssl);
-    /*
-     * postpone msg callback setting for tserver until port calls
-     * port_bind_channel().
-     */
-    if (ch->is_tserver_ch == 0)
-        ossl_qrx_set_msg_callback(ch->qrx, msg_callback, msg_callback_ssl);
+    ossl_qrx_set_msg_callback(ch->qrx, msg_callback, msg_callback_ssl);
 }
 
 void ossl_quic_channel_set_msg_callback_arg(QUIC_CHANNEL *ch,
@@ -4007,13 +3965,7 @@ void ossl_quic_channel_set_msg_callback_arg(QUIC_CHANNEL *ch,
     ch->msg_callback_arg = msg_callback_arg;
     ossl_qtx_set_msg_callback_arg(ch->qtx, msg_callback_arg);
     ossl_quic_tx_packetiser_set_msg_callback_arg(ch->txp, msg_callback_arg);
-
-    /*
-     * postpone msg callback setting for tserver until port calls
-     * port_bind_channel().
-     */
-    if (ch->is_tserver_ch == 0)
-        ossl_qrx_set_msg_callback_arg(ch->qrx, msg_callback_arg);
+    ossl_qrx_set_msg_callback_arg(ch->qrx, msg_callback_arg);
 }
 
 void ossl_quic_channel_set_txku_threshold_override(QUIC_CHANNEL *ch,

--- a/ssl/quic/quic_channel_local.h
+++ b/ssl/quic/quic_channel_local.h
@@ -451,9 +451,6 @@ struct quic_channel_st {
     /* Has qlog been requested? */
     unsigned int                    use_qlog                            : 1;
 
-    /* Has qlog been requested? */
-    unsigned int                    is_tserver_ch                       : 1;
-
     /* Saved error stack in case permanent error was encountered */
     ERR_STATE                       *err_state;
 

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -498,18 +498,15 @@ static SSL *port_new_handshake_layer(QUIC_PORT *port, QUIC_CHANNEL *ch)
     return tls;
 }
 
-static QUIC_CHANNEL *port_make_channel(QUIC_PORT *port, SSL *tls, OSSL_QRX *qrx,
-                                       int is_server, int is_tserver)
+static QUIC_CHANNEL *port_make_channel(QUIC_PORT *port, SSL *tls, int is_server)
 {
     QUIC_CHANNEL_ARGS args = {0};
     QUIC_CHANNEL *ch;
 
-    args.port          = port;
-    args.is_server     = is_server;
-    args.lcidm         = port->lcidm;
-    args.srtm          = port->srtm;
-    args.qrx           = qrx;
-    args.is_tserver_ch = is_tserver;
+    args.port       = port;
+    args.is_server  = is_server;
+    args.lcidm      = port->lcidm;
+    args.srtm       = port->srtm;
 
     /*
      * Creating a a new channel is made a bit tricky here as there is a
@@ -559,8 +556,7 @@ static QUIC_CHANNEL *port_make_channel(QUIC_PORT *port, SSL *tls, OSSL_QRX *qrx,
 
 QUIC_CHANNEL *ossl_quic_port_create_outgoing(QUIC_PORT *port, SSL *tls)
 {
-    return port_make_channel(port, tls, NULL, /* is_server= */ 0,
-                             /* is_tserver= */ 0);
+    return port_make_channel(port, tls, /* is_server= */ 0);
 }
 
 QUIC_CHANNEL *ossl_quic_port_create_incoming(QUIC_PORT *port, SSL *tls)
@@ -569,12 +565,7 @@ QUIC_CHANNEL *ossl_quic_port_create_incoming(QUIC_PORT *port, SSL *tls)
 
     assert(port->tserver_ch == NULL);
 
-    /*
-     * pass -1 for qrx to indicate port will create qrx
-     * later in port_default_packet_handler() when calling port_bind_channel().
-     */
-    ch = port_make_channel(port, tls, NULL, /* is_server= */ 1,
-                           /* is_tserver_ch */ 1);
+    ch = port_make_channel(port, tls, /* is_server= */ 1);
     port->tserver_ch = ch;
     port->allow_incoming = 1;
     return ch;
@@ -712,8 +703,7 @@ static void port_rx_pre(QUIC_PORT *port)
  */
 static void port_bind_channel(QUIC_PORT *port, const BIO_ADDR *peer,
                               const QUIC_CONN_ID *scid, const QUIC_CONN_ID *dcid,
-                              const QUIC_CONN_ID *odcid, OSSL_QRX *qrx,
-                              QUIC_CHANNEL **new_ch)
+                              const QUIC_CONN_ID *odcid, QUIC_CHANNEL **new_ch)
 {
     QUIC_CHANNEL *ch;
 
@@ -724,13 +714,8 @@ static void port_bind_channel(QUIC_PORT *port, const BIO_ADDR *peer,
     if (port->tserver_ch != NULL) {
         ch = port->tserver_ch;
         port->tserver_ch = NULL;
-        ossl_quic_channel_bind_qrx(ch, qrx);
-        ossl_qrx_set_msg_callback(ch->qrx, ch->msg_callback,
-                                  ch->msg_callback_ssl);
-        ossl_qrx_set_msg_callback_arg(ch->qrx, ch->msg_callback_arg);
     } else {
-        ch = port_make_channel(port, NULL, qrx, /* is_server= */ 1,
-                               /* is_tserver */ 0);
+        ch = port_make_channel(port, NULL, /* is_server= */ 1);
     }
 
     if (ch == NULL)
@@ -1452,9 +1437,9 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
     QUIC_CHANNEL *ch = NULL, *new_ch = NULL;
     QUIC_CONN_ID odcid, scid;
     uint8_t gen_new_token = 0;
+    uint64_t cause_flags = 0;
     OSSL_QRX *qrx = NULL;
     OSSL_QRX_ARGS qrx_args = {0};
-    uint64_t cause_flags = 0;
 
     /* Don't handle anything if we are no longer running. */
     if (!ossl_quic_port_is_running(port))
@@ -1557,11 +1542,16 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
                                           port->engine->propq,
                                           &hdr.dst_conn_id,
                                           /* is_server */ 1,
-                                          qrx, NULL))
+                                          qrx, NULL)) {
+        ossl_qrx_free(qrx);
         goto undesirable;
+    }
 
-    if (ossl_qrx_validate_initial_packet(qrx, e, (const QUIC_CONN_ID *)dcid) == 0)
+    if (ossl_qrx_validate_initial_packet(qrx, e, (const QUIC_CONN_ID *)dcid) == 0) {
+        ossl_qrx_free(qrx);
         goto undesirable;
+    }
+    ossl_qrx_free(qrx);
 
     /*
      * TODO(QUIC FUTURE): there should be some logic similar to accounting half-open
@@ -1570,13 +1560,6 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
      */
     if (port->validate_addr == 1 && hdr.token == NULL) {
         port_send_retry(port, &e->peer, &hdr);
-        /*
-         * This is a kind of bummer because we forget secrets for initial
-         * level encryption. The secrets costs us CPU to compute. What we can
-         * do here is to store them within retry token. Then we can retrieve them
-         * from initial packet which will carry our retry token to validate
-         * client's address.
-         */
         goto undesirable;
     }
 
@@ -1602,24 +1585,13 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
          * the request is valid
          */
         if (port->validate_addr == 1) {
-            /*
-             * Again: we should consider saving initial encryption level
-             * secrets to token here to save some CPU cycles.
-             */
             port_send_retry(port, &e->peer, &hdr);
             goto undesirable;
         }
     }
 
     port_bind_channel(port, &e->peer, &scid, &hdr.dst_conn_id,
-                      &odcid, qrx, &new_ch);
-
-    /*
-     * if packet validates it gets moved to channel, we've just bound
-     * to port.
-     */
-    if (new_ch == NULL)
-        goto undesirable;
+                      &odcid, &new_ch);
 
     /*
      * Generate a token for sending in a later NEW_TOKEN frame
@@ -1628,25 +1600,16 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
         generate_new_token(new_ch, &e->peer);
 
     /*
-     * The qrx belongs to channel now, so don't free it.
+     * The channel will do all the LCID registration needed, but as an
+     * optimization inject this packet directly into the channel's QRX for
+     * processing without going through the DEMUX again.
      */
-    qrx = NULL;
-
-    /*
-     * If function reaches this place, then packet got validated in
-     * ossl_qrx_validate_initial_packet(). Keep in mind the function
-     * ossl_qrx_validate_initial_packet() decrypts the packet to validate it.
-     * If packet validation was successful (and it was because we are here),
-     * then the function puts the packet to qrx->rx_pending. We must not call
-     * ossl_qrx_inject_urxe() here now, because we don't want to insert
-     * the packet to qrx->urx_pending which keeps packet waiting for decryption.
-     *
-     * We are going to call ossl_quic_demux_release_urxe() to dispose buffer
-     * which still holds encrypted data.
-     */
+    if (new_ch != NULL) {
+        ossl_qrx_inject_urxe(new_ch->qrx, e);
+        return;
+    }
 
 undesirable:
-    ossl_qrx_free(qrx);
     ossl_quic_demux_release_urxe(port->demux, e);
 }
 


### PR DESCRIPTION

   Recently found that some clients don't work with AEAD validation of
    initial packets with our server (specifically quiche, quic-go and
    ngtcp2).  Root cause isn't determined yet, but it appears to stem from
    the observation that checking for validation again once the initial
    frame is injected to the channel fails with the secrets provided in
    port_default_packet_handler.
    
 Given the nearness of our feature branch merge, I'm proposing the
    following temporary fix.  Instead of creating a qrx and binding it to a
    channel after the default packet handler creates the channel, instead
    just allocate a temporary qrx solely for the purposes of validation and
    free it when validation fails/passes.  This requires an extra
    allocation of a qrx at the channel level (as we nominally do), and
    shouldn't be too impactful to performance, as we only validate the
    initial packet once.

Given that we plan to merge the feature branch as soon as tomorrow, and that this is breaking CI, I'm marking it as urgent