### PR TITLE
Don't use __ATOMIC_ACQ_REL on older compilers

### DIFF
--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -90,7 +90,6 @@ __tsan_mutex_post_lock((x), 0, 0)
  * fallback function names.
  */
 typedef void *pvoid;
-typedef struct rcu_cb_item *prcu_cb_item;
 
 # if defined(__GNUC__) && defined(__ATOMIC_ACQUIRE) && !defined(BROKEN_CLANG_ATOMICS) \
     && !defined(USE_ATOMIC_FALLBACKS)
@@ -193,7 +192,6 @@ IMPL_fallback_atomic_store(pvoid)
         return ret;                                                     \
     }
 IMPL_fallback_atomic_exchange_n(uint64_t)
-IMPL_fallback_atomic_exchange_n(prcu_cb_item)
 
 #  define ATOMIC_EXCHANGE_N(t, p, v, o) fallback_atomic_exchange_n_##t(p, v)
 
@@ -583,6 +581,10 @@ void ossl_synchronize_rcu(CRYPTO_RCU_LOCK *lock)
     }
 }
 
+/*
+ * Note: This call assumes its made under the protection of
+ * ossl_rcu_write_lock
+ */
 int ossl_rcu_call(CRYPTO_RCU_LOCK *lock, rcu_cb_fn cb, void *data)
 {
     struct rcu_cb_item *new =

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -593,21 +593,9 @@ int ossl_rcu_call(CRYPTO_RCU_LOCK *lock, rcu_cb_fn cb, void *data)
 
     new->data = data;
     new->fn = cb;
-    /*
-     * Use __ATOMIC_ACQ_REL here to indicate that any prior writes to this
-     * list are visible to us prior to reading, and publish the new value
-     * immediately
-     */
-# ifdef __ATOMIC_ACQ_REL
-    new->next = ATOMIC_EXCHANGE_N(prcu_cb_item, &lock->cb_items, new,
-                                  __ATOMIC_ACQ_REL);
-# else
-    pthread_mutex_lock(&lock->write_lock);
+
     new->next = lock->cb_items;
     lock->cb_items = new;
-    pthread_mutex_unlock(&lock->write_lock);
-# endif
-
 
     return 1;
 }

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -598,8 +598,16 @@ int ossl_rcu_call(CRYPTO_RCU_LOCK *lock, rcu_cb_fn cb, void *data)
      * list are visible to us prior to reading, and publish the new value
      * immediately
      */
+# ifdef __ATOMIC_ACQ_REL
     new->next = ATOMIC_EXCHANGE_N(prcu_cb_item, &lock->cb_items, new,
                                   __ATOMIC_ACQ_REL);
+# else
+    pthread_mutex_lock(&lock->write_lock);
+    new->next = lock->cb_items;
+    lock->cb_items = new;
+    pthread_mutex_unlock(&lock->write_lock);
+# endif
+
 
     return 1;
 }


### PR DESCRIPTION
Older compilers don't always support __ATOMIC_ACQ_REL, use a lock where they don't
