### PR TITLE
Replace snprintf with BIO_snprintf

### DIFF
--- a/apps/lib/http_server.c
+++ b/apps/lib/http_server.c
@@ -222,7 +222,7 @@ BIO *http_server_init_bio(const char *prog, const char *port)
     int asock;
     char name[40];
 
-    snprintf(name, sizeof(name), "[::]:%s", port); /* port may be "0" */
+    BIO_snprintf(name, sizeof(name), "[::]:%s", port); /* port may be "0" */
     bufbio = BIO_new(BIO_f_buffer());
     if (bufbio == NULL)
         goto err;


### PR DESCRIPTION
`libapps.lib(libapps-lib-http_server.obj) : error LNK2019: unresolved external symbol _snprintf`
This needs to be cherry-picked to the 3.1 and 3.2 branches as well.
#24008

CLA: trivial