### PR TITLE
crypto: des: Fix potential integer overflow in DES_quad_cksum() in qud_cksm.c

### DIFF
--- a/crypto/des/qud_cksm.c
+++ b/crypto/des/qud_cksm.c
@@ -19,6 +19,9 @@
  * use.
  */
 #include "internal/deprecated.h"
+#include <stdint.h>  
+
+typedef uint32_t DES_LONG;
 
 #include "des_local.h"
 
@@ -65,10 +68,9 @@ DES_LONG DES_quad_cksum(const unsigned char *input, DES_cblock output[],
             t0 &= 0xffffffffL;
             t1 = z1;
             /* square, well sort of square */
-            z0 = ((((t0 * t0) & 0xffffffffL) + ((t1 * t1) & 0xffffffffL))
-                  & 0xffffffffL) % 0x7fffffffL;
-            z1 = ((t0 * ((t1 + NOISE) & 0xffffffffL)) & 0xffffffffL) %
-                0x7fffffffL;
+            z0 = ((((uint64_t)t0 * t0) & 0xffffffffL) +  
+                  (((uint64_t)t1 * t1) & 0xffffffffL)) % 0x7fffffffL;
+            z1 = (((uint64_t)t0 * ((t1 + NOISE) & 0xffffffffL)) & 0xffffffffL) %
         }
         if (lp != NULL) {
             /*


### PR DESCRIPTION
Report of the static analyzer:
The value of an arithmetic expression 't1 * t1' is subject to overflow because its operands are not cast to a larger data type before performing arithmetic.

Corrections explained:
1. Changed DES_LONG from unsigned int to uint32_t to ensure a fixed 32-bit width across platforms.
2. Explicitly cast t0 and t1 to uint64_t before multiplication to prevent potential integer overflow.
3. Ensured the correctness of modular arithmetic by maintaining 2^32 constraints.

This improves the portability and correctness of the function, preventing unexpected behavior on architectures where unsigned int may be 16-bit.

Triggers found by static analyzer Svace.

Signed-off-by: Anton Moryakov <[ant.v.moryakov@gmail.com](mailto:ant.v.moryakov@gmail.com)>

CLA: trivial