### PR TITLE
crypto: x509: Fix potential NULL pointer dereference in check_crl() in x509_vfy.c

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1670,6 +1670,8 @@ static int check_crl(X509_STORE_CTX *ctx, X509_CRL *crl)
         issuer = sk_X509_value(ctx->chain, cnum + 1);
     } else {
         issuer = sk_X509_value(ctx->chain, chnum);
+        if(issuer == NULL)
+            return 0;
         if (!ossl_assert(issuer != NULL))
             return 0;
         /* If not self-issued, can't check signature */


### PR DESCRIPTION
Report of the static analyzer:
Pointer 'issuer', returned from function 'OPENSSL_sk_value' at x509_vfy.c:1608, 
may be NULL and is dereferenced at x509_vfy.c:409 by passing it as the 2nd 
parameter to function 'check_issued'.

Corrections explained:
1. Added an explicit if (issuer == NULL) check before using issuer 
   to prevent potential NULL pointer dereference.
2. Retained ossl_assert(issuer != NULL) as a debugging mechanism, 
   but it is no longer relied upon for runtime safety.
3. Ensured that issuer is always valid before passing it to 
   ctx->check_issued() and verify_cb_crl().

This fix eliminates the risk of a segmentation fault and ensures 
correct handling when issuer is NULL.

Triggers found by static analyzer Svace.

Signed-off-by: Anton Moryakov <[ant.v.moryakov@gmail.com](mailto:ant.v.moryakov@gmail.com)>

CLA: trivial