### PR TITLE
Change cipher suite alert for 0 length cipher_suites

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -6989,7 +6989,7 @@ int ssl_cache_cipherlist(SSL_CONNECTION *s, PACKET *cipher_suites, int sslv2form
     n = sslv2format ? SSLV2_CIPHER_LEN : TLS_CIPHER_LEN;
 
     if (PACKET_remaining(cipher_suites) == 0) {
-        SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_NO_CIPHERS_SPECIFIED);
+        SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_NO_CIPHERS_SPECIFIED);
         return 0;
     }
 

--- a/test/recipes/95-test_external_tlsfuzzer_data/cert.json.in
+++ b/test/recipes/95-test_external_tlsfuzzer_data/cert.json.in
@@ -48,20 +48,11 @@
         "arguments" : ["-p", "@PORT@"]},
        {"name" : "test-conversation.py",
         "arguments" : ["-p", "@PORT@",
-                       "-d"]}
-     ]
-    },
-    {"server_command": ["@SERVER@", "s_server", "-www",
-                 "-key", "tests/serverX509Key.pem",
-                 "-cert", "tests/serverX509Cert.pem"],
-     "environment": {"PYTHONPATH" : "."},
-     "server_hostname": "localhost",
-     "server_port": @PORT@,
-     "tests" : [
-        {"name" : "test-invalid-client-hello-w-record-overflow.py",
-         "arguments" : ["-n", "0", "-C",
-                        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "-d",
-                        "--ems", "session ID len fuzz to 5 w/ext"]}
+                       "-d"]},
+       {"name" : "test-invalid-client-hello-w-record-overflow.py",
+        "arguments" : ["-n", "0", "-C",
+                       "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "-d",
+                       "--ems", "session ID len fuzz to 5 w/ext"]}
      ]
     }
 ]

--- a/test/recipes/95-test_external_tlsfuzzer_data/cert.json.in
+++ b/test/recipes/95-test_external_tlsfuzzer_data/cert.json.in
@@ -50,5 +50,18 @@
         "arguments" : ["-p", "@PORT@",
                        "-d"]}
      ]
+    },
+    {"server_command": ["@SERVER@", "s_server", "-www",
+                 "-key", "tests/serverX509Key.pem",
+                 "-cert", "tests/serverX509Cert.pem"],
+     "environment": {"PYTHONPATH" : "."},
+     "server_hostname": "localhost",
+     "server_port": @PORT@,
+     "tests" : [
+        {"name" : "test-invalid-client-hello-w-record-overflow.py",
+         "arguments" : ["-n", "0", "-C",
+                        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "-d",
+                        "--ems", "session ID len fuzz to 5 w/ext"]}
+     ]
     }
 ]


### PR DESCRIPTION
From RFC 8446:

Note: TLS defines two generic alerts (see Section 6) to use upon
   failure to parse a message.  Peers which receive a message which
   cannot be parsed according to the syntax (e.g., have a length
   extending beyond the message boundary or contain an out-of-range
   length) MUST terminate the connection with a "decode_error" alert.
   Peers which receive a message which is syntactically correct but
   semantically invalid (e.g., a DHE share of p - 1, or an invalid enum)
   MUST terminate the connection with an "illegal_parameter" alert.

A zero length cipher suite list I think is considered out of range, and so we should return "decode_error" rather than "illegal_parameter"

Fixes #25309

