### PR TITLE
apps: lib: Prevent potential NULL dereference in init_client() in s_socket.c

### DIFF
--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -173,7 +173,7 @@ int init_client(int *sock, const char *host, const char *port,
         }
 
         /* Save the address */
-        if (tfo || !doconn)
+        if ((tfo || !doconn) && (ba_ret != NULL))
             *ba_ret = BIO_ADDR_dup(BIO_ADDRINFO_address(ai));
 
         /* Success, don't try any more addresses */


### PR DESCRIPTION
The previous check for ba_ret != NULL before setting *ba_ret was removed,
which introduced a potential NULL pointer dereference in cases where ba_ret
is not initialized by the caller.

This commit restores the NULL check before assigning *ba_ret to ensure
safety and prevent crashes.

Before fix:
    `if (tfo || !doconn)
        *ba_ret = BIO_ADDR_dup(BIO_ADDRINFO_address(ai));`

After fix:
    `if ((tfo || !doconn) && (ba_ret != NULL))
        *ba_ret = BIO_ADDR_dup(BIO_ADDRINFO_address(ai));`

This ensures that ba_ret is only dereferenced if it is not NULL.

Signed-off-by: <Anton Moryakov> <[ant.v.moryakov@gmail.com](mailto:ant.v.moryakov@gmail.com)>