### PR TITLE
ssl: statem: Fix potential NULL dereference in set_client_ciphersuite in statem_clnt.c

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1432,7 +1432,7 @@ static int set_client_ciphersuite(SSL_CONNECTION *s,
              * In TLSv1.3 it is valid for the server to select a different
              * ciphersuite as long as the hash is the same.
              */
-            if (md == NULL
+            if (s->session->cipher == NULL || md == NULL
                     || md != ssl_md(sctx, s->session->cipher->algorithm2)) {
                 SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER,
                          SSL_R_CIPHERSUITE_DIGEST_HAS_CHANGED);


### PR DESCRIPTION
Added a NULL check for `s->session->cipher` before dereferencing it
in the TLS 1.3 ciphersuite validation logic. This prevents a crash
if `s->session->cipher` is NULL when accessing `algorithm2`.

Also added a check for `md == NULL` to ensure the hash algorithm
is valid before comparison.

Signed-off-by: <[ant.v.moryakov@gmail.com](mailto:ant.v.moryakov@gmail.com)>