### PR TITLE
fips: omit PCT on key import

### DIFF
--- a/providers/implementations/keymgmt/ml_dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/ml_dsa_kmgmt.c
@@ -242,7 +242,6 @@ static int ml_dsa_import(void *keydata, int selection, const OSSL_PARAM params[]
 {
     ML_DSA_KEY *key = keydata;
     int include_priv;
-    int res;
 
     if (!ossl_prov_is_running() || key == NULL)
         return 0;
@@ -251,17 +250,7 @@ static int ml_dsa_import(void *keydata, int selection, const OSSL_PARAM params[]
         return 0;
 
     include_priv = ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0);
-    res = ml_dsa_key_fromdata(key, params, include_priv);
-#ifdef FIPS_MODULE
-    if (res > 0) {
-        res = ml_dsa_pairwise_test(key);
-        if (res <= 0) {
-            ossl_ml_dsa_key_reset(key);
-            ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT);
-        }
-    }
-#endif
-    return res;
+    return ml_dsa_key_fromdata(key, params, include_priv);
 }
 
 #define ML_DSA_IMEXPORTABLE_PARAMETERS \


### PR DESCRIPTION
Our lab thinks the IG 10.3.A additional comment 1 is a mistake and that a PCT on import is not required.

Same as #26696 but based from master.

- [ ] documentation is added or updated
- [ ] tests are added or updated
