### PR TITLE
Configurable import-time PCT for ML-KEM

### DIFF
--- a/crypto/ml_dsa/ml_dsa_key.h
+++ b/crypto/ml_dsa/ml_dsa_key.h
@@ -34,8 +34,7 @@ struct ml_dsa_key_st {
     uint8_t *pub_encoding;
     uint8_t *priv_encoding;
     uint8_t *seed;
-    int retain_seed;
-    int prefer_seed;
+    int prov_flags;
 
     /*
      * t1 is the Polynomial encoding of the 10 MSB of each coefficient of the

--- a/crypto/ml_kem/ml_kem.c
+++ b/crypto/ml_kem/ml_kem.c
@@ -1394,7 +1394,7 @@ int genkey(const uint8_t seed[ML_KEM_SEED_BYTES],
 
     /* Optionally save the |d| portion of the seed */
     key->d = key->z + ML_KEM_RANDOM_BYTES;
-    if (key->retain_seed) {
+    if (key->prov_flags & ML_KEM_KEY_RETAIN_SEED) {
         memcpy(key->d, seed, ML_KEM_RANDOM_BYTES);
     } else {
         OPENSSL_cleanse(key->d, ML_KEM_RANDOM_BYTES);
@@ -1576,10 +1576,6 @@ const ML_KEM_VINFO *ossl_ml_kem_get_vinfo(int evp_type)
     return NULL;
 }
 
-/*
- * The |retain_seed| parameter indicates whether the seed should be retained
- * once the key is generated.
- */
 ML_KEM_KEY *ossl_ml_kem_key_new(OSSL_LIB_CTX *libctx, const char *properties,
                                 int evp_type)
 {
@@ -1594,8 +1590,7 @@ ML_KEM_KEY *ossl_ml_kem_key_new(OSSL_LIB_CTX *libctx, const char *properties,
 
     key->vinfo = vinfo;
     key->libctx = libctx;
-    key->prefer_seed = 1;
-    key->retain_seed = 1;
+    key->prov_flags = ML_KEM_KEY_PROV_FLAGS_DEFAULT;
     key->shake128_md = EVP_MD_fetch(libctx, "SHAKE128", properties);
     key->shake256_md = EVP_MD_fetch(libctx, "SHAKE256", properties);
     key->sha3_256_md = EVP_MD_fetch(libctx, "SHA3-256", properties);

--- a/doc/man7/EVP_PKEY-ML-KEM.pod
+++ b/doc/man7/EVP_PKEY-ML-KEM.pod
@@ -108,6 +108,17 @@ configuration options programmatically.
 
 =over 4
 
+=item C<ml-kem.import_pct_type> (B<OSSL_PKEY_PARAM_ML_KEM_IMPORT_PCT_TYPE>) <UTF8 string>
+
+When an B<ML-KEM> key is imported as an explict FIPS 203 B<dk> decapsulation
+key, rather than a seed, a pairwise consistency test (PCT) is optionally
+performed.
+By default, or when this parameter is set explicitly to C<random>, the PCT
+is performed with a random entropy value for the encapsulation step.
+Setting the parameter to C<fixed>, still runs the test, but the encapsulation
+entropy is a fixed 32 byte value.
+Specifying any other value of the parameter, e.g. C<none>, skips the test.
+
 =item C<ml-kem.retain_seed> (B<OSSL_PKEY_PARAM_ML_KEM_RETAIN_SEED>) <UTF8 string>
 
 When set to a string representing a false boolean value (see

--- a/include/crypto/ml_dsa.h
+++ b/include/crypto/ml_dsa.h
@@ -42,6 +42,12 @@
 # define MAX_ML_DSA_PUB_LEN ML_DSA_87_PUB_LEN
 # define MAX_ML_DSA_SIG_LEN ML_DSA_87_SIG_LEN
 
+# define ML_DSA_KEY_PREFER_SEED (1 << 0)
+# define ML_DSA_KEY_RETAIN_SEED (1 << 1)
+/* Default provider flags */
+# define ML_DSA_KEY_PROV_FLAGS_DEFAULT \
+    (ML_DSA_KEY_PREFER_SEED | ML_DSA_KEY_RETAIN_SEED)
+
 /*
  * Refer to FIPS 204 Section 4 Parameter sets.
  * Fields that are shared between all algorithms (such as q & d) have been omitted.
@@ -86,9 +92,8 @@ __owur size_t ossl_ml_dsa_key_get_pub_len(const ML_DSA_KEY *key);
 __owur const uint8_t *ossl_ml_dsa_key_get_priv(const ML_DSA_KEY *key);
 __owur size_t ossl_ml_dsa_key_get_priv_len(const ML_DSA_KEY *key);
 __owur const uint8_t *ossl_ml_dsa_key_get_seed(const ML_DSA_KEY *key);
-__owur int ossl_ml_dsa_key_prefer_seed(const ML_DSA_KEY *key);
-__owur int ossl_ml_dsa_key_retain_seed(const ML_DSA_KEY *key);
-int ossl_ml_dsa_set_prekey(ML_DSA_KEY *key, int prefer_seed, int retain_seed,
+__owur int ossl_ml_dsa_key_get_prov_flags(const ML_DSA_KEY *key);
+int ossl_ml_dsa_set_prekey(ML_DSA_KEY *key, int flags_set, int flags_clr,
                            const uint8_t *seed, size_t seed_len,
                            const uint8_t *sk, size_t sk_len);
 __owur size_t ossl_ml_dsa_key_get_collision_strength_bits(const ML_DSA_KEY *key);

--- a/include/crypto/ml_kem.h
+++ b/include/crypto/ml_kem.h
@@ -117,6 +117,17 @@
 # define ML_KEM_1024_DV         5
 # define ML_KEM_1024_SECBITS    256
 
+# define ML_KEM_KEY_RANDOM_PCT  (1 << 0)
+# define ML_KEM_KEY_FIXED_PCT   (1 << 1)
+# define ML_KEM_KEY_PREFER_SEED (1 << 2)
+# define ML_KEM_KEY_RETAIN_SEED (1 << 3)
+/* Mask to check whether PCT on import is enabled */
+# define ML_KEM_KEY_PCT_TYPE \
+    (ML_KEM_KEY_RANDOM_PCT | ML_KEM_KEY_FIXED_PCT)
+/* Default provider flags */
+# define ML_KEM_KEY_PROV_FLAGS_DEFAULT \
+    (ML_KEM_KEY_RANDOM_PCT | ML_KEM_KEY_PREFER_SEED | ML_KEM_KEY_RETAIN_SEED)
+
 /*
  * External variant-specific API
  * -----------------------------
@@ -171,8 +182,7 @@ typedef struct ossl_ml_kem_key_st {
     struct ossl_ml_kem_scalar_st *s;        /* Private key secret vector */
     uint8_t *z;                             /* Private key FO failure secret */
     uint8_t *d;                             /* Private key seed */
-    int prefer_seed;                        /* Given seed and key use seed? */
-    int retain_seed;                        /* Retain the seed after keygen? */
+    int prov_flags;                         /* prefer/retain seed and PCT flags */
 
     /*
      * Fixed-size built-in buffer, which holds the |rho| and the public key

--- a/providers/implementations/encode_decode/ml_kem_codecs.c
+++ b/providers/implementations/encode_decode/ml_kem_codecs.c
@@ -13,6 +13,7 @@
 #include <openssl/x509.h>
 #include <openssl/core_names.h>
 #include "internal/encoder.h"
+#include "prov/ml_kem.h"
 #include "ml_kem_codecs.h"
 
 /* Tables describing supported ASN.1 input/output formats. */
@@ -138,7 +139,6 @@ ossl_ml_kem_d2i_PKCS8(const uint8_t *prvenc, int prvlen,
                       int evp_type, PROV_CTX *provctx,
                       const char *propq)
 {
-    OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(provctx);
     const ML_KEM_VINFO *v;
     const ML_COMMON_CODEC *codec;
     ML_COMMON_PKCS8_FMT_PREF *fmt_slots = NULL, *slot;
@@ -241,12 +241,9 @@ ossl_ml_kem_d2i_PKCS8(const uint8_t *prvenc, int prvlen,
      * Collect the seed and/or key into a "decoded" private key object,
      * to be turned into a real key on provider "load" or "import".
      */
-    if ((key = ossl_ml_kem_key_new(libctx, propq, evp_type)) == NULL)
+    if ((key = ossl_prov_ml_kem_new(provctx, propq, evp_type)) == NULL)
         goto end;
-    key->retain_seed = ossl_prov_ctx_get_bool_param(
-        provctx, OSSL_PKEY_PARAM_ML_KEM_RETAIN_SEED, 1);
-    key->prefer_seed = ossl_prov_ctx_get_bool_param(
-        provctx, OSSL_PKEY_PARAM_ML_KEM_PREFER_SEED, 1);
+
     if (p8fmt->seed_length > 0) {
         if (!ossl_ml_kem_set_seed(buf + p8fmt->seed_offset,
                                   ML_KEM_SEED_BYTES, key)) {

--- a/providers/implementations/include/prov/ml_dsa.h
+++ b/providers/implementations/include/prov/ml_dsa.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "crypto/ml_dsa.h"
+#include "prov/provider_ctx.h"
+
+ML_DSA_KEY *
+ossl_prov_ml_dsa_new(PROV_CTX *provctx, const char *propq, int evp_type);

--- a/providers/implementations/include/prov/ml_kem.h
+++ b/providers/implementations/include/prov/ml_kem.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "crypto/ml_kem.h"
+#include "prov/provider_ctx.h"
+
+ML_KEM_KEY *
+ossl_prov_ml_kem_new(PROV_CTX *provctx, const char *propq, int evp_type);

--- a/test/recipes/15-test_ml_kem_codecs.t
+++ b/test/recipes/15-test_ml_kem_codecs.t
@@ -25,7 +25,7 @@ my @formats = qw(seed-priv priv-only seed-only oqskeypair bare-seed bare-priv);
 plan skip_all => "ML-KEM isn't supported in this build"
     if disabled("ml-kem");
 
-plan tests => @algs * (24 + 10 * @formats);
+plan tests => @algs * (25 + 10 * @formats);
 my $seed = join ("", map {sprintf "%02x", $_} (0..63));
 my $weed = join ("", map {sprintf "%02x", $_} (1..64));
 my $ikme = join ("", map {sprintf "%02x", $_} (0..31));
@@ -160,7 +160,7 @@ foreach my $alg (@algs) {
             sprintf("text form private key: %s with %s", $alg, $f));
     }
 
-    # (5 tests): Test import/load PCT failure
+    # (6 tests): Test import/load PCT failure
     my $real = sprintf('real-%s.der', $alg);
     my $fake = sprintf('fake-%s.der', $alg);
     my $mixt = sprintf('mixt-%s.der', $alg);
@@ -171,17 +171,28 @@ foreach my $alg (@algs) {
     ok(run(app([qw(openssl genpkey -algorithm), "ml-kem-$alg",
                 qw(-provparam ml-kem.output_formats=seed-priv -pkeyopt),
                 "hexseed:$seed", qw(-outform DER -out), $real])),
-                sprintf("create real private key: %s", $alg));
+        sprintf("create real private key: %s", $alg));
     ok(run(app([qw(openssl genpkey -algorithm), "ml-kem-$alg",
                 qw(-provparam ml-kem.output_formats=seed-priv -pkeyopt),
                 "hexseed:$weed", qw(-outform DER -out), $fake])),
-                sprintf("create fake private key: %s", $alg));
+        sprintf("create fake private key: %s", $alg));
     my $realfh = IO::File->new($real, "r");
     my $fakefh = IO::File->new($fake, "r");
     local $/ = undef;
     my $realder = <$realfh>;
     my $fakeder = <$fakefh>;
-    ok (length($realder) == 28 + (2 + 64) + (4 + $slen + $plen + $zlen)
+    #
+    # - 20 bytes PKCS8 fixed overhead,
+    # - 4 byte private key octet string tag + length
+    # - 4 byte seed + key sequence tag + length
+    #   - 2 byte seed tag + length
+    #     - 64 byte seed
+    #   - 4 byte key tag + length
+    #     - |dk| 's' vector
+    #     - |ek| public key ('t' vector || 'rho')
+    #     - implicit rejection 'z' seed component
+    #
+    ok(length($realder) == 28 + (2 + 64) + (4 + $slen + $plen + $zlen)
         && length($fakeder) == 28 + (2 + 64) + (4 + $slen + $plen + $zlen));
     my $mixtder = substr($realder, 0, 28 + 66 + 4 + $slen)
         . substr($fakeder, 28 + 66 + 4 + $slen, $plen)
@@ -189,11 +200,15 @@ foreach my $alg (@algs) {
     my $mixtfh = IO::File->new($mixt, "w");
     print $mixtfh $mixtder;
     $mixtfh->close();
-    ok(run(app([qw(openssl pkey -inform DER -noout -in), $real],
-               sprintf("accept valid keypair: %s", $alg))));
+    ok(run(app([qw(openssl pkey -inform DER -noout -in), $real])),
+        sprintf("accept valid keypair: %s", $alg));
     ok(!run(app([qw(openssl pkey -provparam ml-kem.prefer_seed=no),
                  qw(-inform DER -noout -in), $mixt])),
-                sprintf("reject real private and fake public: %s", $alg));
+        sprintf("reject real private and fake public: %s", $alg));
+    ok(run(app([qw(openssl pkey -provparam ml-kem.prefer_seed=no),
+                 qw(-provparam ml-kem.import_pct_type=none),
+                 qw(-inform DER -noout -in), $mixt])),
+        sprintf("Absent PCT accept fake public: %s", $alg));
     # Mutate the public key hash
     my $mashder = $realder;
     substr($mashder, -64, 1) =~ s{(.)}{chr(ord($1)^1)}es;
@@ -201,5 +216,5 @@ foreach my $alg (@algs) {
     print $mashfh $mashder;
     $mashfh->close();
     ok(!run(app([qw(openssl pkey -inform DER -noout -in), $mash])),
-                sprintf("reject real private and mutated public: %s", $alg));
+        sprintf("reject real private and mutated public: %s", $alg));
 }

--- a/test/recipes/15-test_ml_kem_codecs.t
+++ b/test/recipes/15-test_ml_kem_codecs.t
@@ -197,7 +197,7 @@ foreach my $alg (@algs) {
     my $mixtder = substr($realder, 0, 28 + 66 + 4 + $slen)
         . substr($fakeder, 28 + 66 + 4 + $slen, $plen)
         . substr($realder, 28 + 66 + 4 + $slen + $plen, $zlen);
-    my $mixtfh = IO::File->new($mixt, "w");
+    my $mixtfh = IO::File->new($mixt, ">:raw");
     print $mixtfh $mixtder;
     $mixtfh->close();
     ok(run(app([qw(openssl pkey -inform DER -noout -in), $real])),
@@ -212,7 +212,7 @@ foreach my $alg (@algs) {
     # Mutate the public key hash
     my $mashder = $realder;
     substr($mashder, -64, 1) =~ s{(.)}{chr(ord($1)^1)}es;
-    my $mashfh = IO::File->new($mash, "w");
+    my $mashfh = IO::File->new($mash, ">:raw");
     print $mashfh $mashder;
     $mashfh->close();
     ok(!run(app([qw(openssl pkey -inform DER -noout -in), $mash])),

--- a/test/recipes/15-test_ml_kem_codecs.t
+++ b/test/recipes/15-test_ml_kem_codecs.t
@@ -191,7 +191,8 @@ foreach my $alg (@algs) {
     $mixtfh->close();
     ok(run(app([qw(openssl pkey -inform DER -noout -in), $real],
                sprintf("accept valid keypair: %s", $alg))));
-    ok(!run(app([qw(openssl pkey -inform DER -noout -in), $mixt])),
+    ok(!run(app([qw(openssl pkey -provparam ml-kem.prefer_seed=no),
+                 qw(-inform DER -noout -in), $mixt])),
                 sprintf("reject real private and fake public: %s", $alg));
     # Mutate the public key hash
     my $mashder = $realder;

--- a/test/recipes/15-test_ml_kem_codecs.t
+++ b/test/recipes/15-test_ml_kem_codecs.t
@@ -25,7 +25,7 @@ my @formats = qw(seed-priv priv-only seed-only oqskeypair bare-seed bare-priv);
 plan skip_all => "ML-KEM isn't supported in this build"
     if disabled("ml-kem");
 
-plan tests => @algs * (23 + 10 * @formats);
+plan tests => @algs * (24 + 10 * @formats);
 my $seed = join ("", map {sprintf "%02x", $_} (0..63));
 my $weed = join ("", map {sprintf "%02x", $_} (1..64));
 my $ikme = join ("", map {sprintf "%02x", $_} (0..31));
@@ -164,31 +164,41 @@ foreach my $alg (@algs) {
     my $real = sprintf('real-%s.der', $alg);
     my $fake = sprintf('fake-%s.der', $alg);
     my $mixt = sprintf('mixt-%s.der', $alg);
+    my $mash = sprintf('mash-%s.der', $alg);
     my $slen = $alg * 3 / 2; # Secret vector |s|
     my $plen = $slen + 64;   # Public |t|, |rho| and hash
     my $zlen = 32;           # FO implicit reject seed
     ok(run(app([qw(openssl genpkey -algorithm), "ml-kem-$alg",
-                qw(-provparam ml-kem.output_formats=bare-priv -pkeyopt),
-                "hexseed:$seed", qw(-outform DER -out), $real],
-                sprintf("create real private key: %s", $alg))));
+                qw(-provparam ml-kem.output_formats=seed-priv -pkeyopt),
+                "hexseed:$seed", qw(-outform DER -out), $real])),
+                sprintf("create real private key: %s", $alg));
     ok(run(app([qw(openssl genpkey -algorithm), "ml-kem-$alg",
-                qw(-provparam ml-kem.output_formats=bare-priv -pkeyopt),
-                "hexseed:$weed", qw(-outform DER -out), $fake],
-                sprintf("create fake private key: %s", $alg))));
+                qw(-provparam ml-kem.output_formats=seed-priv -pkeyopt),
+                "hexseed:$weed", qw(-outform DER -out), $fake])),
+                sprintf("create fake private key: %s", $alg));
     my $realfh = IO::File->new($real, "r");
     my $fakefh = IO::File->new($fake, "r");
     local $/ = undef;
     my $realder = <$realfh>;
     my $fakeder = <$fakefh>;
-    ok (length($realder) == 24 + $slen + $plen + $zlen
-        && length($fakeder) == 24 + $slen + $plen + $zlen);
-    my $mixtder = substr($realder, 0, 24 + $slen)
-        . substr($fakeder, 24 + $slen, $plen)
-        . substr($realder, 24 + $slen + $plen, $zlen);
+    ok (length($realder) == 28 + (2 + 64) + (4 + $slen + $plen + $zlen)
+        && length($fakeder) == 28 + (2 + 64) + (4 + $slen + $plen + $zlen));
+    my $mixtder = substr($realder, 0, 28 + 66 + 4 + $slen)
+        . substr($fakeder, 28 + 66 + 4 + $slen, $plen)
+        . substr($realder, 28 + 66 + 4 + $slen + $plen, $zlen);
     my $mixtfh = IO::File->new($mixt, "w");
     print $mixtfh $mixtder;
+    $mixtfh->close();
     ok(run(app([qw(openssl pkey -inform DER -noout -in), $real],
                sprintf("accept valid keypair: %s", $alg))));
-    ok(!run(app([qw(openssl pkey -inform DER -noout -in), $mixt],
-                sprintf("reject real private and fake public: %s", $alg))));
+    ok(!run(app([qw(openssl pkey -inform DER -noout -in), $mixt])),
+                sprintf("reject real private and fake public: %s", $alg));
+    # Mutate the public key hash
+    my $mashder = $realder;
+    substr($mashder, -64, 1) =~ s{(.)}{chr(ord($1)^1)}es;
+    my $mashfh = IO::File->new($mash, "w");
+    print $mashfh $mashder;
+    $mashfh->close();
+    ok(!run(app([qw(openssl pkey -inform DER -noout -in), $mash])),
+                sprintf("reject real private and mutated public: %s", $alg));
 }

--- a/util/perl/OpenSSL/paramnames.pm
+++ b/util/perl/OpenSSL/paramnames.pm
@@ -423,6 +423,7 @@ my %params = (
     'PKEY_PARAM_ML_KEM_RETAIN_SEED' => "ml-kem.retain_seed",
     'PKEY_PARAM_ML_KEM_INPUT_FORMATS' => "ml-kem.input_formats",
     'PKEY_PARAM_ML_KEM_OUTPUT_FORMATS' => "ml-kem.output_formats",
+    'PKEY_PARAM_ML_KEM_IMPORT_PCT_TYPE' => "ml-kem.import_pct_type",
 
 # Key generation parameters
     'PKEY_PARAM_FFC_TYPE' =>         "type",


### PR DESCRIPTION
And related cleanup.

Rebased on #26812 which will be merged first. So this shows those commits as well.

With a small change in ML-DSA to switch from two separate key booleans to key flags, just like in ML-KEM.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
