### PR TITLE
Refactor EVP_SKEY initialization

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -559,8 +559,7 @@ static int evp_cipher_init_skey_internal(EVP_CIPHER_CTX *ctx,
         }
     }
 
-    if (skey != NULL && skey->skeymgmt != NULL
-        && ctx->cipher->prov != skey->skeymgmt->prov) {
+    if (skey != NULL && ctx->cipher->prov != skey->skeymgmt->prov) {
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         return 0;
     }

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -414,5 +414,3 @@ int evp_names_do_all(OSSL_PROVIDER *prov, int number,
                      void (*fn)(const char *name, void *data),
                      void *data);
 int evp_cipher_cache_constants(EVP_CIPHER *cipher);
-
-EVP_SKEY *evp_skey_alloc(void);


### PR DESCRIPTION
Enforce that skeymgmt cannot ever be NULL in EVP_SKEY.

Also add missing allocation checks.

Fixes multiple issues found by Coverity.
