### PR TITLE
Fix memory leak in ecdsa_keygen_knownanswer_test

### DIFF
--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -256,14 +256,14 @@ static int ecdsa_keygen_knownanswer_test(EC_KEY *eckey, BN_CTX *ctx,
     int len, ret = 0;
     OSSL_SELF_TEST *st = NULL;
     unsigned char bytes[512] = {0};
-    EC_POINT *pub_key2 = EC_POINT_new(eckey->group);
-
-    if (pub_key2 == NULL)
-        return 0;
+    EC_POINT *pub_key2 = NULL;
 
     st = OSSL_SELF_TEST_new(cb, cbarg);
     if (st == NULL)
-        goto err_point;
+        return 0;
+
+    if ((pub_key2 = EC_POINT_new(eckey->group)) == NULL)
+        return 0;
 
     OSSL_SELF_TEST_onbegin(st, OSSL_SELF_TEST_TYPE_PCT_KAT,
                                OSSL_SELF_TEST_DESC_PCT_ECDSA);
@@ -283,7 +283,6 @@ static int ecdsa_keygen_knownanswer_test(EC_KEY *eckey, BN_CTX *ctx,
 err:
     OSSL_SELF_TEST_onend(st, ret);
     OSSL_SELF_TEST_free(st);
-err_point:
     EC_POINT_free(pub_key2);
     return ret;
 }

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -262,11 +262,11 @@ static int ecdsa_keygen_knownanswer_test(EC_KEY *eckey, BN_CTX *ctx,
     if (st == NULL)
         return 0;
 
-    if ((pub_key2 = EC_POINT_new(eckey->group)) == NULL)
-        return 0;
-
     OSSL_SELF_TEST_onbegin(st, OSSL_SELF_TEST_TYPE_PCT_KAT,
                                OSSL_SELF_TEST_DESC_PCT_ECDSA);
+
+    if ((pub_key2 = EC_POINT_new(eckey->group)) == NULL)
+        goto err;
 
     /* pub_key = priv_key * G (where G is a point on the curve) */
     if (!EC_POINT_mul(eckey->group, pub_key2, eckey->priv_key, NULL, NULL, ctx))

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -263,7 +263,7 @@ static int ecdsa_keygen_knownanswer_test(EC_KEY *eckey, BN_CTX *ctx,
 
     st = OSSL_SELF_TEST_new(cb, cbarg);
     if (st == NULL)
-        return 0;
+        goto err_point;
 
     OSSL_SELF_TEST_onbegin(st, OSSL_SELF_TEST_TYPE_PCT_KAT,
                                OSSL_SELF_TEST_DESC_PCT_ECDSA);
@@ -283,6 +283,7 @@ static int ecdsa_keygen_knownanswer_test(EC_KEY *eckey, BN_CTX *ctx,
 err:
     OSSL_SELF_TEST_onend(st, ret);
     OSSL_SELF_TEST_free(st);
+err_point:
     EC_POINT_free(pub_key2);
     return ret;
 }


### PR DESCRIPTION
We allocate an EC_POINT with EC_POINT_new here, but in failing a subsequent check, we don't free it, correct that.

Fixes #26779


