### PR TITLE
Free hashtable prior to freeing atomic worker_lock

### DIFF
--- a/test/lhash_test.c
+++ b/test/lhash_test.c
@@ -710,9 +710,9 @@ shutdown:
 
 end_free:
     shutting_down = 1;
+    ossl_ht_free(m_ht);
     CRYPTO_THREAD_lock_free(worker_lock);
     CRYPTO_THREAD_lock_free(testrand_lock);
-    ossl_ht_free(m_ht);
 end:
     return ret;
 }


### PR DESCRIPTION
lhash_test uses a hashtable that may not be empty at the end of the test

Given that the free function frees the elements in the list and uses the atomic worker_lock to do so, we need to free the hash table prior to freeing the working lock to avoid the use of unallocated memory.

Fixes #26798
