### PR TITLE
crypto: x509: Fix potential NULL dereference in crl_akid_check in x509_vfy.c

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1400,6 +1400,9 @@ static void crl_akid_check(X509_STORE_CTX *ctx, X509_CRL *crl,
 
     crl_issuer = sk_X509_value(ctx->chain, cidx);
 
+    if (crl_issuer == NULL) 
+        return -1;
+
     if (X509_check_akid(crl_issuer, crl->akid) == X509_V_OK) {
         if (*pcrl_score & CRL_SCORE_ISSUER_NAME) {
             *pcrl_score |= CRL_SCORE_AKID | CRL_SCORE_ISSUER_CERT;


### PR DESCRIPTION
Fix potential NULL dereference in crl_akid_check

This commit addresses a potential NULL dereference in the `crl_akid_check`
function. The pointer `crl_issuer`, returned by `sk_X509_value`, could be
NULL if `cidx` is out of bounds or if the chain is corrupted. This would
lead to a crash when passing `crl_issuer` to `X509_check_akid`.

Changes:
1. Added a NULL check for `crl_issuer` before calling `X509_check_akid`.
2. Changed the return type of `crl_akid_check` to `int` to allow error handling.
3. Return `-1` if `crl_issuer` is NULL to indicate an error condition.

This fix prevents undefined behavior and improves the robustness of the code.

Triggers found by static analyzer Svace.

Signed-off-by: <[ant.v.moryakov@gmail.com](mailto:ant.v.moryakov@gmail.com)>