### PR TITLE
Aead qrx fix

### DIFF
--- a/include/internal/quic_channel.h
+++ b/include/internal/quic_channel.h
@@ -116,12 +116,15 @@ typedef struct quic_channel_args_st {
     QUIC_LCIDM      *lcidm;
     /* SRTM to register SRTs with. */
     QUIC_SRTM       *srtm;
+    OSSL_QRX        *qrx;
 
     int             is_server;
     SSL             *tls;
 
     /* Whether to use qlog. */
     int             use_qlog;
+
+    int             is_tserver_ch;
 
     /* Title to use for the qlog session, or NULL. */
     const char      *qlog_title;
@@ -177,6 +180,7 @@ typedef struct quic_terminate_cause_st {
  */
 QUIC_CHANNEL *ossl_quic_channel_alloc(const QUIC_CHANNEL_ARGS *args);
 int ossl_quic_channel_init(QUIC_CHANNEL *ch);
+void ossl_quic_channel_bind_qrx(QUIC_CHANNEL *tserver_ch, OSSL_QRX *qrx);
 
 
 /* No-op if ch is NULL. */

--- a/include/internal/quic_channel.h
+++ b/include/internal/quic_channel.h
@@ -300,6 +300,8 @@ void ossl_quic_channel_on_stateless_reset(QUIC_CHANNEL *ch);
 
 void ossl_quic_channel_inject(QUIC_CHANNEL *ch, QUIC_URXE *e);
 
+void ossl_quic_channel_inject_pkt(QUIC_CHANNEL *ch, OSSL_QRX_PKT *qpkt);
+
 /*
  * Queries and Accessors
  * =====================

--- a/include/internal/quic_predef.h
+++ b/include/internal/quic_predef.h
@@ -31,6 +31,7 @@ typedef struct quic_reactor_st QUIC_REACTOR;
 typedef struct quic_reactor_wait_ctx_st QUIC_REACTOR_WAIT_CTX;
 typedef struct ossl_statm_st OSSL_STATM;
 typedef struct quic_demux_st QUIC_DEMUX;
+typedef struct ossl_qrx_st OSSL_QRX;
 typedef struct ossl_qrx_pkt_st OSSL_QRX_PKT;
 typedef struct ossl_qtx_pkt_st OSSL_QTX_PKT;
 typedef struct quic_tick_result_st QUIC_TICK_RESULT;

--- a/include/internal/quic_record_rx.h
+++ b/include/internal/quic_record_rx.h
@@ -23,7 +23,6 @@
  * QUIC Record Layer - RX
  * ======================
  */
-typedef struct ossl_qrx_st OSSL_QRX;
 
 typedef struct ossl_qrx_args_st {
     OSSL_LIB_CTX   *libctx;
@@ -321,6 +320,8 @@ int ossl_qrx_set_late_validation_cb(OSSL_QRX *qrx,
  * establish a new connection.
  */
 void ossl_qrx_inject_urxe(OSSL_QRX *qrx, QUIC_URXE *e);
+int ossl_qrx_validate_initial_packet(OSSL_QRX *qrx, QUIC_URXE *urxe,
+                                     const QUIC_CONN_ID *dcid);
 
 /*
  * Decryption of 1-RTT packets must be explicitly enabled by calling this

--- a/include/internal/quic_record_rx.h
+++ b/include/internal/quic_record_rx.h
@@ -320,6 +320,7 @@ int ossl_qrx_set_late_validation_cb(OSSL_QRX *qrx,
  * establish a new connection.
  */
 void ossl_qrx_inject_urxe(OSSL_QRX *qrx, QUIC_URXE *e);
+void ossl_qrx_inject_pkt(OSSL_QRX *qrx, OSSL_QRX_PKT *pkt);
 int ossl_qrx_validate_initial_packet(OSSL_QRX *qrx, QUIC_URXE *urxe,
                                      const QUIC_CONN_ID *dcid);
 

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -295,23 +295,44 @@ static int ch_init(QUIC_CHANNEL *ch)
 
     ossl_quic_tx_packetiser_set_ack_tx_cb(ch->txp, ch_on_txp_ack_tx, ch);
 
-    qrx_args.libctx             = ch->port->engine->libctx;
-    qrx_args.demux              = ch->port->demux;
-    qrx_args.short_conn_id_len  = rx_short_dcid_len;
-    qrx_args.max_deferred       = 32;
+    /*
+     * qrx does not exist yet, then we must be dealing with client channel
+     * (QUIC connection initiator).
+     * If qrx exists already, then we are dealing with server channel which
+     * qrx gets created by port_default_packet_handler() before
+     * port_default_packet_handler() accepts connection and creates channel
+     * for it.
+     * The exception here is tserver which always creates channel,
+     * before the first packet is ever seen.
+     */
+    if (ch->qrx == NULL && ch->is_tserver_ch == 0) {
+        /* we are regular client, create channel */
+        qrx_args.libctx             = ch->port->engine->libctx;
+        qrx_args.demux              = ch->port->demux;
+        qrx_args.short_conn_id_len  = rx_short_dcid_len;
+        qrx_args.max_deferred       = 32;
 
-    if ((ch->qrx = ossl_qrx_new(&qrx_args)) == NULL)
-        goto err;
+        if ((ch->qrx = ossl_qrx_new(&qrx_args)) == NULL)
+            goto err;
+    }
 
-    if (!ossl_qrx_set_late_validation_cb(ch->qrx,
-                                         rx_late_validate,
-                                         ch))
-        goto err;
+    if (ch->qrx != NULL) {
+        /*
+         * callbacks for channels associated with tserver's port
+         * are set up later when we call ossl_quic_channel_bind_qrx()
+         * in port_default_packet_handler()
+         */
+        if (!ossl_qrx_set_late_validation_cb(ch->qrx,
+                                             rx_late_validate,
+                                             ch))
+            goto err;
 
-    if (!ossl_qrx_set_key_update_cb(ch->qrx,
-                                    rxku_detected,
-                                    ch))
-        goto err;
+        if (!ossl_qrx_set_key_update_cb(ch->qrx,
+                                        rxku_detected,
+                                        ch))
+            goto err;
+    }
+
 
     for (pn_space = QUIC_PN_SPACE_INITIAL; pn_space < QUIC_PN_SPACE_NUM; ++pn_space) {
         ch->crypto_recv[pn_space] = ossl_quic_rstream_new(NULL, NULL, 0);
@@ -426,6 +447,17 @@ int ossl_quic_channel_init(QUIC_CHANNEL *ch)
     return ch_init(ch);
 }
 
+void ossl_quic_channel_bind_qrx(QUIC_CHANNEL *tserver_ch, OSSL_QRX *qrx)
+{
+    if (tserver_ch->qrx == NULL && tserver_ch->is_tserver_ch == 1) {
+        tserver_ch->qrx = qrx;
+        ossl_qrx_set_late_validation_cb(tserver_ch->qrx, rx_late_validate,
+                                        tserver_ch);
+        ossl_qrx_set_key_update_cb(tserver_ch->qrx, rxku_detected,
+                                   tserver_ch);
+    }
+}
+
 QUIC_CHANNEL *ossl_quic_channel_alloc(const QUIC_CHANNEL_ARGS *args)
 {
     QUIC_CHANNEL *ch = NULL;
@@ -433,11 +465,13 @@ QUIC_CHANNEL *ossl_quic_channel_alloc(const QUIC_CHANNEL_ARGS *args)
     if ((ch = OPENSSL_zalloc(sizeof(*ch))) == NULL)
         return NULL;
 
-    ch->port        = args->port;
-    ch->is_server   = args->is_server;
-    ch->tls         = args->tls;
-    ch->lcidm       = args->lcidm;
-    ch->srtm        = args->srtm;
+    ch->port           = args->port;
+    ch->is_server      = args->is_server;
+    ch->tls            = args->tls;
+    ch->lcidm          = args->lcidm;
+    ch->srtm           = args->srtm;
+    ch->qrx            = args->qrx;
+    ch->is_tserver_ch  = args->is_tserver_ch;
 #ifndef OPENSSL_NO_QLOG
     ch->use_qlog    = args->use_qlog;
 
@@ -570,7 +604,7 @@ err:
 
 size_t ossl_quic_channel_get_short_header_conn_id_len(QUIC_CHANNEL *ch)
 {
-    return ossl_qrx_get_short_hdr_conn_id_len(ch->qrx);
+    return ossl_quic_port_get_rx_short_dcid_len(ch->port);
 }
 
 QUIC_STREAM *ossl_quic_channel_get_stream_by_id(QUIC_CHANNEL *ch,
@@ -3655,12 +3689,15 @@ static int ch_on_new_conn_common(QUIC_CHANNEL *ch, const BIO_ADDR *peer,
     ossl_qtx_set_qlog_cb(ch->qtx, ch_get_qlog_cb, ch);
     ossl_quic_tx_packetiser_set_qlog_cb(ch->txp, ch_get_qlog_cb, ch);
 
-    /* Plug in secrets for the Initial EL. */
+    /*
+     * Plug in secrets for the Initial EL. secrets for QRX were created in
+     * port_default_packet_handler() already.
+     */
     if (!ossl_quic_provide_initial_secret(ch->port->engine->libctx,
                                           ch->port->engine->propq,
                                           &ch->init_dcid,
                                           /*is_server=*/1,
-                                          ch->qrx, ch->qtx))
+                                          NULL, ch->qtx))
         return 0;
 
     /* Register the peer ODCID in the LCIDM. */
@@ -3976,7 +4013,12 @@ void ossl_quic_channel_set_msg_callback(QUIC_CHANNEL *ch,
     ossl_qtx_set_msg_callback(ch->qtx, msg_callback, msg_callback_ssl);
     ossl_quic_tx_packetiser_set_msg_callback(ch->txp, msg_callback,
                                              msg_callback_ssl);
-    ossl_qrx_set_msg_callback(ch->qrx, msg_callback, msg_callback_ssl);
+    /*
+     * postpone msg callback setting for tserver until port calls
+     * port_bind_channel().
+     */
+    if (ch->is_tserver_ch == 0)
+        ossl_qrx_set_msg_callback(ch->qrx, msg_callback, msg_callback_ssl);
 }
 
 void ossl_quic_channel_set_msg_callback_arg(QUIC_CHANNEL *ch,
@@ -3985,7 +4027,13 @@ void ossl_quic_channel_set_msg_callback_arg(QUIC_CHANNEL *ch,
     ch->msg_callback_arg = msg_callback_arg;
     ossl_qtx_set_msg_callback_arg(ch->qtx, msg_callback_arg);
     ossl_quic_tx_packetiser_set_msg_callback_arg(ch->txp, msg_callback_arg);
-    ossl_qrx_set_msg_callback_arg(ch->qrx, msg_callback_arg);
+
+    /*
+     * postpone msg callback setting for tserver until port calls
+     * port_bind_channel().
+     */
+    if (ch->is_tserver_ch == 0)
+        ossl_qrx_set_msg_callback_arg(ch->qrx, msg_callback_arg);
 }
 
 void ossl_quic_channel_set_txku_threshold_override(QUIC_CHANNEL *ch,

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -3443,6 +3443,11 @@ void ossl_quic_channel_inject(QUIC_CHANNEL *ch, QUIC_URXE *e)
     ossl_qrx_inject_urxe(ch->qrx, e);
 }
 
+void ossl_quic_channel_inject_pkt(QUIC_CHANNEL *ch, OSSL_QRX_PKT *qpkt)
+{
+    ossl_qrx_inject_pkt(ch->qrx, qpkt);
+}
+
 void ossl_quic_channel_on_stateless_reset(QUIC_CHANNEL *ch)
 {
     QUIC_TERMINATE_CAUSE tcause = {0};

--- a/ssl/quic/quic_channel_local.h
+++ b/ssl/quic/quic_channel_local.h
@@ -452,6 +452,9 @@ struct quic_channel_st {
     /* Has qlog been requested? */
     unsigned int                    use_qlog                            : 1;
 
+    /* Has qlog been requested? */
+    unsigned int                    is_tserver_ch                       : 1;
+
     /* Saved error stack in case permanent error was encountered */
     ERR_STATE                       *err_state;
 

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -1648,7 +1648,6 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
          */
         qrx = NULL;
     } else {
-        ossl_assert(qrx_src != NULL);
         /*
 	 * We still need to salvage packets from almost forgotten qrx
          * and pass them to channel.

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -1649,7 +1649,7 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
         qrx = NULL;
     } else {
         /*
-	 * We still need to salvage packets from almost forgotten qrx
+	     * We still need to salvage packets from almost forgotten qrx
          * and pass them to channel.
          */
         while (ossl_qrx_read_pkt(qrx_src, &qrx_pkt) == 1)

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -1567,12 +1567,12 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
 
     if (port->validate_addr == 0) {
         /*
-	 * Forget qrx, because it becomes (almost) useless here. We must let
-	 * channel to create a new QRX for connection ID server chooses. The
-	 * validation keys for new DCID will be derived by
-	 * ossl_quic_channel_on_new_conn() when we will be creating channel.
-	 * See RFC 9000 section 7.2 negotiating connection id to better
-	 * understand what's going on here.
+         * Forget qrx, because it becomes (almost) useless here. We must let
+         * channel to create a new QRX for connection ID server chooses. The
+         * validation keys for new DCID will be derived by
+         * ossl_quic_channel_on_new_conn() when we will be creating channel.
+         * See RFC 9000 section 7.2 negotiating connection id to better
+         * understand what's going on here.
          *
          * Did we say qrx is almost useless? Why? Because qrx remembers packets
          * we just validated. Those packets must be injected to channel we are

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -1453,8 +1453,10 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
     QUIC_CONN_ID odcid, scid;
     uint8_t gen_new_token = 0;
     OSSL_QRX *qrx = NULL;
+    OSSL_QRX *qrx_src = NULL;
     OSSL_QRX_ARGS qrx_args = {0};
     uint64_t cause_flags = 0;
+    OSSL_QRX_PKT *qrx_pkt = NULL;
 
     /* Don't handle anything if we are no longer running. */
     if (!ossl_quic_port_is_running(port))
@@ -1563,6 +1565,23 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
     if (ossl_qrx_validate_initial_packet(qrx, e, (const QUIC_CONN_ID *)dcid) == 0)
         goto undesirable;
 
+    if (port->validate_addr == 0) {
+        /*
+	 * Forget qrx, because it becomes (almost) useless here. We must let
+	 * channel to create a new QRX for connection ID server chooses. The
+	 * validation keys for new DCID will be derived by
+	 * ossl_quic_channel_on_new_conn() when we will be creating channel.
+	 * See RFC 9000 section 7.2 negotiating connection id to better
+	 * understand what's going on here.
+         *
+         * Did we say qrx is almost useless? Why? Because qrx remembers packets
+         * we just validated. Those packets must be injected to channel we are
+         * going to create. We use qrx_src alias so we can read packets from
+         * qrx and inject them to channel.
+         */
+         qrx_src = qrx;
+         qrx = NULL;
+    }
     /*
      * TODO(QUIC FUTURE): there should be some logic similar to accounting half-open
      * states in TCP. If we reach certain threshold, then we want to
@@ -1570,13 +1589,6 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
      */
     if (port->validate_addr == 1 && hdr.token == NULL) {
         port_send_retry(port, &e->peer, &hdr);
-        /*
-         * This is a kind of bummer because we forget secrets for initial
-         * level encryption. The secrets costs us CPU to compute. What we can
-         * do here is to store them within retry token. Then we can retrieve them
-         * from initial packet which will carry our retry token to validate
-         * client's address.
-         */
         goto undesirable;
     }
 
@@ -1585,6 +1597,9 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
      * server address validation, we may still get a token if we sent
      * a NEW_TOKEN frame during a prior connection, which we should still
      * validate here
+     *
+     * TODO: is it OK to keep qrx in this case? Are not we running into
+     * similar problem like we did in case when validate_addr == 0?
      */
     if (hdr.token != NULL
         && port_validate_token(&hdr, port, &e->peer,
@@ -1627,10 +1642,20 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
     if (gen_new_token == 1)
         generate_new_token(new_ch, &e->peer);
 
-    /*
-     * The qrx belongs to channel now, so don't free it.
-     */
-    qrx = NULL;
+    if (qrx != NULL) {
+        /*
+         * The qrx belongs to channel now, so don't free it.
+         */
+        qrx = NULL;
+    } else {
+        ossl_assert(qrx_src != NULL);
+        /*
+	 * We still need to salvage packets from almost forgotten qrx
+         * and pass them to channel.
+         */
+        while (ossl_qrx_read_pkt(qrx_src, &qrx_pkt) == 1)
+            ossl_quic_channel_inject_pkt(new_ch, qrx_pkt);
+    }
 
     /*
      * If function reaches this place, then packet got validated in
@@ -1647,6 +1672,7 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
 
 undesirable:
     ossl_qrx_free(qrx);
+    ossl_qrx_free(qrx_src);
     ossl_quic_demux_release_urxe(port->demux, e);
 }
 

--- a/ssl/quic/quic_record_rx.c
+++ b/ssl/quic/quic_record_rx.c
@@ -371,7 +371,7 @@ static int qrx_validate_initial_pkt(OSSL_QRX *qrx, QUIC_URXE *urxe,
     pkt_mark(&urxe->hpr_removed, 0);
 
     /* Decode the now unprotected header. */
-    if (!ossl_quic_wire_decode_pkt_hdr(&pkt, 0,
+    if (ossl_quic_wire_decode_pkt_hdr(&pkt, 0,
                                       0, 0, &rxe->hdr, NULL, NULL) != 1)
         goto malformed;
 

--- a/ssl/quic/quic_record_rx.c
+++ b/ssl/quic/quic_record_rx.c
@@ -374,7 +374,7 @@ static int qrx_validate_initial_pkt(OSSL_QRX *qrx, QUIC_URXE *urxe,
     pkt_mark(&urxe->hpr_removed, 0);
 
     /* Decode the now unprotected header. */
-    if (ossl_quic_wire_decode_pkt_hdr(&pkt, 0,
+    if (!ossl_quic_wire_decode_pkt_hdr(&pkt, 0,
                                       0, 0, &rxe->hdr, NULL, NULL) != 1)
         goto malformed;
 

--- a/ssl/quic/quic_record_rx.c
+++ b/ssl/quic/quic_record_rx.c
@@ -280,8 +280,7 @@ void ossl_qrx_inject_pkt(OSSL_QRX *qrx, OSSL_QRX_PKT *pkt)
      * to get pkt. Such packet has refcount 1.
      */
     ossl_qrx_pkt_release(pkt);
-    assert(rxe->refcount == 0);
-    if (rxe->refcount == 0)
+    if (ossl_assert(rxe->refcount == 0))
         ossl_list_rxe_insert_tail(&qrx->rx_pending, rxe);
 }
 

--- a/ssl/quic/quic_record_rx.c
+++ b/ssl/quic/quic_record_rx.c
@@ -271,6 +271,23 @@ void ossl_qrx_inject_urxe(OSSL_QRX *qrx, QUIC_URXE *urxe)
                           qrx->msg_callback_arg);
 }
 
+void ossl_qrx_inject_pkt(OSSL_QRX *qrx, OSSL_QRX_PKT *pkt)
+{
+    RXE *rxe = (RXE *)pkt;
+
+    /*
+     * port_default_packet_handler() uses ossl_qrx_read_pkt()
+     * to get pkt. Such packet has refcount 1.
+     */
+    assert(rxe->refcount == 1);
+    if (rxe->refcount != 1) {
+        ossl_qrx_pkt_release(pkt);
+    } else {
+        rxe->refcount = 0;
+        ossl_list_rxe_insert_tail(&qrx->rx_pending, rxe);
+    }
+}
+
 /*
  * qrx_validate_initial_pkt() is derived from qrx_process_pkt(). Unlike
  * qrx_process_pkt() the qrx_validate_initial_pkt() function can process

--- a/ssl/quic/quic_record_rx.c
+++ b/ssl/quic/quic_record_rx.c
@@ -279,13 +279,10 @@ void ossl_qrx_inject_pkt(OSSL_QRX *qrx, OSSL_QRX_PKT *pkt)
      * port_default_packet_handler() uses ossl_qrx_read_pkt()
      * to get pkt. Such packet has refcount 1.
      */
-    assert(rxe->refcount == 1);
-    if (rxe->refcount != 1) {
-        ossl_qrx_pkt_release(pkt);
-    } else {
-        rxe->refcount = 0;
+    ossl_qrx_pkt_release(pkt);
+    assert(rxe->refcount == 0);
+    if (rxe->refcount == 0)
         ossl_list_rxe_insert_tail(&qrx->rx_pending, rxe);
-    }
 }
 
 /*


### PR DESCRIPTION
fixes [#1104](https://github.com/openssl/project/issues/1104)

`Perform initial AEAD validation....` changeset puts the stuff, we reverted from feature branch, back this is identical to change delivered in [#26610](https://github.com/openssl/openssl/pull/26610)

`FIX AEAD validation of initial packets in port...` changeset is fix built on top of stuff as found in #26610 