### PR TITLE
test/quicapitest.c: Fix build with no-ssl-trace

### DIFF
--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -31,7 +31,7 @@ jobs:
           no-http,
           no-legacy,
           no-sock,
-          enable-ssl-trace,
+          no-ssl-trace,
           no-stdio,
           no-threads,
           no-thread-pool,

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -115,7 +115,6 @@ jobs:
           no-ssl,
           no-ssl3,
           no-ssl3-method,
-          no-ssl-trace,
           no-static-engine no-shared,
           no-tests,
           enable-tfo,

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -554,6 +554,7 @@ static int test_ssl_trace(void)
 }
 #endif
 
+#ifndef OPENSSL_NO_SSL_TRACE
 enum {
     INITIAL = 0,
     GATHER_TOKEN = 1,
@@ -687,6 +688,7 @@ static int test_new_token(void)
 
     return testresult;
 }
+#endif
 
 static int ensure_valid_ciphers(const STACK_OF(SSL_CIPHER) *ciphers)
 {
@@ -2740,7 +2742,9 @@ int setup_tests(void)
     ADD_TEST(test_domain_flags);
     ADD_TEST(test_early_ticks);
     ADD_TEST(test_ssl_new_from_listener);
+#ifndef OPENSSL_NO_SSL_TRACE
     ADD_TEST(test_new_token);
+#endif
     return 1;
  err:
     cleanup_tests();


### PR DESCRIPTION
Fixes daily CI build. Urgent as this is a CI fix and it is obvious.
