### PR TITLE
riscv: add dl_hwcap for capability detection

### DIFF
--- a/crypto/riscvcap.c
+++ b/crypto/riscvcap.c
@@ -21,6 +21,7 @@
 # include <unistd.h>
 # include <sys/syscall.h>
 # include <asm/hwprobe.h>
+# include <sys/auxv.h>
 #endif
 
 extern size_t riscv_vlen_asm(void);
@@ -29,6 +30,10 @@ static void parse_env(const char *envstr);
 static void strtoupper(char *str);
 
 static size_t vlen = 0;
+
+#ifdef OSSL_RISCV_HWPROBE
+unsigned int OPENSSL_riscv_hwcap_P = 0;
+#endif
 
 uint32_t OPENSSL_rdtsc(void)
 {
@@ -100,9 +105,10 @@ static void hwprobe_to_cap(void)
                 if (pairs[j].key == RISCV_capabilities[i].hwprobe_key
                         && (pairs[j].value & RISCV_capabilities[i].hwprobe_value)
                            != 0)
-                    /* Match, set relevant bit in OPENSSL_riscvcap_P[] */
-                    OPENSSL_riscvcap_P[RISCV_capabilities[i].index] |=
-                        (1 << RISCV_capabilities[i].bit_offset);
+                    if (!IS_IN_DEPEND_VECTOR(RISCV_capabilities[i].bit_offset) || VECTOR_CAPABLE)
+                        /* Match, set relevant bit in OPENSSL_riscvcap_P[] */
+                        OPENSSL_riscvcap_P[RISCV_capabilities[i].index] |=
+                            (1 << RISCV_capabilities[i].bit_offset);
             }
         }
     }
@@ -131,6 +137,7 @@ void OPENSSL_cpuid_setup(void)
     }
 #ifdef OSSL_RISCV_HWPROBE
     else {
+        OPENSSL_riscv_hwcap_P = getauxval(AT_HWCAP);
         hwprobe_to_cap();
     }
 #endif

--- a/include/crypto/riscv_arch.h
+++ b/include/crypto/riscv_arch.h
@@ -22,6 +22,12 @@
      */
 #   ifdef __NR_riscv_hwprobe
 #    define OSSL_RISCV_HWPROBE
+#    include <asm/hwcap.h>
+extern unsigned int OPENSSL_riscv_hwcap_P;
+#    define VECTOR_CAPABLE (OPENSSL_riscv_hwcap_P & COMPAT_HWCAP_ISA_V)
+#    define ZVX_MIN 15
+#    define ZVX_MAX 23
+#    define IS_IN_DEPEND_VECTOR(offset) ((ZVX_MIN >= offset) && (offset <= ZVX_MAX))
 #   endif
 #  endif
 # endif


### PR DESCRIPTION
Availability of ZVK* should be determined with dl_hwcap.

Because some zv* extensions rely on vector registers, kernel vector support is required to save the state of context switching.
OpenSSL requires hwprobe for hardware capability detection, and cooperates with dl_hwcap to detect whether the kernel supports vector.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
