### PR TITLE
More consistent ML-KEM key checks

### DIFF
--- a/test/recipes/15-test_ml_kem_codecs.t
+++ b/test/recipes/15-test_ml_kem_codecs.t
@@ -191,7 +191,8 @@ foreach my $alg (@algs) {
     $mixtfh->close();
     ok(run(app([qw(openssl pkey -inform DER -noout -in), $real],
                sprintf("accept valid keypair: %s", $alg))));
-    ok(!run(app([qw(openssl pkey -inform DER -noout -in), $mixt])),
+    ok(!run(app([qw(openssl pkey -provparam ml-kem.prefer_seed=no),
+                 qw(-inform DER -noout -in), $mixt])),
                 sprintf("reject real private and fake public: %s", $alg));
     # Mutate the public key hash
     my $mashder = $realder;

--- a/test/recipes/15-test_ml_kem_codecs.t
+++ b/test/recipes/15-test_ml_kem_codecs.t
@@ -25,7 +25,7 @@ my @formats = qw(seed-priv priv-only seed-only oqskeypair bare-seed bare-priv);
 plan skip_all => "ML-KEM isn't supported in this build"
     if disabled("ml-kem");
 
-plan tests => @algs * (23 + 10 * @formats);
+plan tests => @algs * (24 + 10 * @formats);
 my $seed = join ("", map {sprintf "%02x", $_} (0..63));
 my $weed = join ("", map {sprintf "%02x", $_} (1..64));
 my $ikme = join ("", map {sprintf "%02x", $_} (0..31));
@@ -164,31 +164,41 @@ foreach my $alg (@algs) {
     my $real = sprintf('real-%s.der', $alg);
     my $fake = sprintf('fake-%s.der', $alg);
     my $mixt = sprintf('mixt-%s.der', $alg);
+    my $mash = sprintf('mash-%s.der', $alg);
     my $slen = $alg * 3 / 2; # Secret vector |s|
     my $plen = $slen + 64;   # Public |t|, |rho| and hash
     my $zlen = 32;           # FO implicit reject seed
     ok(run(app([qw(openssl genpkey -algorithm), "ml-kem-$alg",
-                qw(-provparam ml-kem.output_formats=bare-priv -pkeyopt),
-                "hexseed:$seed", qw(-outform DER -out), $real],
-                sprintf("create real private key: %s", $alg))));
+                qw(-provparam ml-kem.output_formats=seed-priv -pkeyopt),
+                "hexseed:$seed", qw(-outform DER -out), $real])),
+                sprintf("create real private key: %s", $alg));
     ok(run(app([qw(openssl genpkey -algorithm), "ml-kem-$alg",
-                qw(-provparam ml-kem.output_formats=bare-priv -pkeyopt),
-                "hexseed:$weed", qw(-outform DER -out), $fake],
-                sprintf("create fake private key: %s", $alg))));
+                qw(-provparam ml-kem.output_formats=seed-priv -pkeyopt),
+                "hexseed:$weed", qw(-outform DER -out), $fake])),
+                sprintf("create fake private key: %s", $alg));
     my $realfh = IO::File->new($real, "r");
     my $fakefh = IO::File->new($fake, "r");
     local $/ = undef;
     my $realder = <$realfh>;
     my $fakeder = <$fakefh>;
-    ok (length($realder) == 24 + $slen + $plen + $zlen
-        && length($fakeder) == 24 + $slen + $plen + $zlen);
-    my $mixtder = substr($realder, 0, 24 + $slen)
-        . substr($fakeder, 24 + $slen, $plen)
-        . substr($realder, 24 + $slen + $plen, $zlen);
+    ok (length($realder) == 28 + (2 + 64) + (4 + $slen + $plen + $zlen)
+        && length($fakeder) == 28 + (2 + 64) + (4 + $slen + $plen + $zlen));
+    my $mixtder = substr($realder, 0, 28 + 66 + 4 + $slen)
+        . substr($fakeder, 28 + 66 + 4 + $slen, $plen)
+        . substr($realder, 28 + 66 + 4 + $slen + $plen, $zlen);
     my $mixtfh = IO::File->new($mixt, "w");
     print $mixtfh $mixtder;
+    $mixtfh->close();
     ok(run(app([qw(openssl pkey -inform DER -noout -in), $real],
                sprintf("accept valid keypair: %s", $alg))));
-    ok(!run(app([qw(openssl pkey -inform DER -noout -in), $mixt],
-                sprintf("reject real private and fake public: %s", $alg))));
+    ok(!run(app([qw(openssl pkey -inform DER -noout -in), $mixt])),
+                sprintf("reject real private and fake public: %s", $alg));
+    # Mutate the public key hash
+    my $mashder = $realder;
+    substr($mashder, -64, 1) =~ s{(.)}{chr(ord($1)^1)}es;
+    my $mashfh = IO::File->new($mash, "w");
+    print $mashfh $mashder;
+    $mashfh->close();
+    ok(!run(app([qw(openssl pkey -inform DER -noout -in), $mash])),
+                sprintf("reject real private and mutated public: %s", $alg));
 }


### PR DESCRIPTION
- Cross-check seed `z` value on import as well as load.
- On import/load, when re-generating from a seed, check hash of any explicit private key when both provided.
- Avoid leak of expanded key encoding when load fails.
- Added test to ensure public key hash mutation in expanded key is detected during seed import.

##### Checklist
- [x] tests are added or updated
