### PR TITLE
fix: add check for NULL zalloc in tls-provider.c

### DIFF
--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -930,10 +930,10 @@ static void *xor_gen_init(void *provctx, int selection,
                       | OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS)) == 0)
         return NULL;
 
-    if ((gctx = OPENSSL_zalloc(sizeof(*gctx))) != NULL)
+    if ((gctx = OPENSSL_zalloc(sizeof(*gctx))) != NULL) {
         gctx->selection = selection;
-
-    gctx->libctx = PROV_XOR_LIBCTX_OF(provctx);
+        gctx->libctx = PROV_XOR_LIBCTX_OF(provctx);
+    }
 
     if (!xor_gen_set_params(gctx, params)) {
         OPENSSL_free(gctx);

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -930,10 +930,11 @@ static void *xor_gen_init(void *provctx, int selection,
                       | OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS)) == 0)
         return NULL;
 
-    if ((gctx = OPENSSL_zalloc(sizeof(*gctx))) != NULL) {
-        gctx->selection = selection;
-        gctx->libctx = PROV_XOR_LIBCTX_OF(provctx);
-    }
+    if ((gctx = OPENSSL_zalloc(sizeof(*gctx))) == NULL)
+        return NULL;
+
+    gctx->selection = selection;
+    gctx->libctx = PROV_XOR_LIBCTX_OF(provctx);
 
     if (!xor_gen_set_params(gctx, params)) {
         OPENSSL_free(gctx);


### PR DESCRIPTION
OOM can lead CWE-476. With my fix it will be avoided

P.S. Idk it's test update or not

##### Checklist
- [x] tests are added or updated
