### PR TITLE
fix: add NULL check for s->session in tls_construct_ctos_session_ticket

### DIFF
--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -314,7 +314,8 @@ EXT_RETURN tls_construct_ctos_session_ticket(SSL_CONNECTION *s, WPACKET *pkt,
         return EXT_RETURN_NOT_SENT;
 
     if (!WPACKET_put_bytes_u16(pkt, TLSEXT_TYPE_session_ticket)
-            || !WPACKET_sub_memcpy_u16(pkt, s->session->ext.tick, ticklen)) {
+            || (s->session != NULL 
+            && !WPACKET_sub_memcpy_u16(pkt, s->session->ext.tick, ticklen))) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return EXT_RETURN_FAIL;
     }


### PR DESCRIPTION
Should also check s->session for NULL
