### PR TITLE
Update do_gen_key to return NULL on error

### DIFF
--- a/test/ml_dsa_test.c
+++ b/test/ml_dsa_test.c
@@ -42,9 +42,11 @@ static EVP_PKEY *do_gen_key(const char *alg,
     if (!TEST_ptr(ctx = EVP_PKEY_CTX_new_from_name(lib_ctx, alg, NULL))
             || !TEST_int_eq(EVP_PKEY_keygen_init(ctx), 1)
             || !TEST_int_eq(EVP_PKEY_CTX_set_params(ctx, params), 1)
-            || !TEST_int_eq(EVP_PKEY_generate(ctx, &pkey), 1))
+            || !TEST_int_eq(EVP_PKEY_generate(ctx, &pkey), 1)) {
         pkey = NULL;
-
+        goto err;
+    }
+err:
     EVP_PKEY_CTX_free(ctx);
     return pkey;
 }


### PR DESCRIPTION
If do_gen_key encounters an error of any sort, return NULL so the caller can handle it.

Fixes https://scan5.scan.coverity.com/#/project-view/62507/10222?selectedIssue=1642943

##### Checklist

- [x] tests are added or updated
