### PR TITLE
Don't free peer key on error within EVP_PKEY_derive_set_peer_ex

### DIFF
--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -494,18 +494,14 @@ int EVP_PKEY_derive_set_peer_ex(EVP_PKEY_CTX *ctx, EVP_PKEY *peer,
         return -1;
     }
 
+    ret = ctx->pmeth->ctrl(ctx, EVP_PKEY_CTRL_PEER_KEY, 1, peer);
+    if (ret <= 0)
+        return ret;
     if (!EVP_PKEY_up_ref(peer))
         return -1;
 
     EVP_PKEY_free(ctx->peerkey);
     ctx->peerkey = peer;
-
-    ret = ctx->pmeth->ctrl(ctx, EVP_PKEY_CTRL_PEER_KEY, 1, peer);
-
-    if (ret <= 0) {
-        ctx->peerkey = NULL;
-        return ret;
-    }
 
     return 1;
 #endif

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -503,7 +503,6 @@ int EVP_PKEY_derive_set_peer_ex(EVP_PKEY_CTX *ctx, EVP_PKEY *peer,
     ret = ctx->pmeth->ctrl(ctx, EVP_PKEY_CTRL_PEER_KEY, 1, peer);
 
     if (ret <= 0) {
-        EVP_PKEY_free(ctx->peerkey);
         ctx->peerkey = NULL;
         return ret;
     }


### PR DESCRIPTION
In EVP_PKEY_derive_set_peer_ex, don't free peer key on error. Revert to existing functionality.

Bug was introduced with https://github.com/openssl/openssl/pull/26294
Fixes https://scan5.scan.coverity.com/#/project-view/62507/10222?selectedIssue=1643099
Fixes https://scan5.scan.coverity.com/#/project-view/62507/10222?selectedIssue=1643098
Fixes https://scan5.scan.coverity.com/#/project-view/62507/10222?selectedIssue=1643088
Fixes https://scan5.scan.coverity.com/#/project-view/62507/10222?selectedIssue=1643090
Fixes https://scan5.scan.coverity.com/#/project-view/62507/10222?selectedIssue=1643096