### PR TITLE
Set op_num to 0

### DIFF
--- a/test/radix/terp.c
+++ b/test/radix/terp.c
@@ -667,7 +667,7 @@ static int TERP_execute(TERP *terp)
 {
     int ok = 0;
     uint64_t opc;
-    size_t op_num = SIZE_MAX;
+    size_t op_num = 0;
     int in_debug_output = 0;
     size_t spin_count = 0;
     BIO *debug_bio = terp->cfg.debug_bio;


### PR DESCRIPTION
Here, op_num is just used for logging purposes (number of completed operations), so start it at 0. Avoid (guaranteed) integer overflow

Fixes https://scan5.scan.coverity.com/#/project-view/62507/10222?selectedIssue=1643034
