### PR TITLE
fix: add OOM handler for x509 fuzz test

### DIFF
--- a/fuzz/x509.c
+++ b/fuzz/x509.c
@@ -78,9 +78,13 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
     resp = d2i_OCSP_RESPONSE(NULL, &p, len);
 
     store = X509_STORE_new();
+    if (store == NULL)
+        goto err;
     X509_STORE_add_cert(store, x509_2);
 
     param = X509_VERIFY_PARAM_new();
+    if (param == NULL)
+        goto err;
     X509_VERIFY_PARAM_set_flags(param, X509_V_FLAG_NO_CHECK_TIME);
     X509_VERIFY_PARAM_set_flags(param, X509_V_FLAG_X509_STRICT);
     X509_VERIFY_PARAM_set_flags(param, X509_V_FLAG_PARTIAL_CHAIN);


### PR DESCRIPTION
Add checks for OOM to avoid null deref