### PR TITLE
Re-enable RCU torture test on MACOSX

### DIFF
--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -295,7 +295,6 @@ static int torture_rw_high(void)
 }
 
 
-# ifndef OPENSSL_SYS_MACOSX 
 static CRYPTO_RCU_LOCK *rcu_lock = NULL;
 
 static int writer1_done = 0;
@@ -492,7 +491,6 @@ static int torture_rcu_high(void)
     contention = 1;
     return _torture_rcu();
 }
-# endif
 #endif
 
 static CRYPTO_ONCE once_run = CRYPTO_ONCE_STATIC_INIT;
@@ -1329,10 +1327,8 @@ int setup_tests(void)
 #if defined(OPENSSL_THREADS)
     ADD_TEST(torture_rw_low);
     ADD_TEST(torture_rw_high);
-# ifndef OPENSSL_SYS_MACOSX
     ADD_TEST(torture_rcu_low);
     ADD_TEST(torture_rcu_high);
-# endif
 #endif
     ADD_TEST(test_once);
     ADD_TEST(test_thread_local);


### PR DESCRIPTION
This test was disabled due to "Stochastic failures in the RCU test on MACOSX" by #23967, which sounds like an issue that is probably fixed now.
