### PR TITLE
SLH-DSA coverity fixes.

### DIFF
--- a/crypto/slh_dsa/slh_dsa.c
+++ b/crypto/slh_dsa/slh_dsa.c
@@ -354,7 +354,7 @@ static int get_tree_ids(PACKET *rpkt, const SLH_DSA_PARAMS *params,
      * i.e. A & (0xFFFF_FFFF_FFFF_FFFF >> (64 - X))
      */
     tree_id_mask = (~(uint64_t)0) >> (64 - (params->h - params->hm));
-    leaf_id_mask = (1 << params->hm) - 1; /* max value is 0x1FF when hm = 9 */
+    leaf_id_mask = ((uint64_t)1 << params->hm) - 1; /* max value is 0x1FF when hm = 9 */
     *tree_id = bytes_to_u64_be(tree_id_bytes, tree_id_len) & tree_id_mask;
     *leaf_id = (uint32_t)(bytes_to_u64_be(leaf_id_bytes, leaf_id_len) & leaf_id_mask);
     return 1;

--- a/crypto/slh_dsa/slh_fors.c
+++ b/crypto/slh_dsa/slh_fors.c
@@ -181,7 +181,8 @@ int ossl_slh_fors_sign(SLH_DSA_HASH_CTX *ctx, const uint8_t *md,
                 return 0;
             node_id >>= 1; /* Get the parent node id */
             tree_offset >>= 1; /* Each layer up has half as many nodes */
-            WPACKET_memcpy(sig_wpkt, out, n);
+            if (!WPACKET_memcpy(sig_wpkt, out, n))
+                return 0;
         }
         tree_id_times_two_power_a += two_power_a;
     }


### PR DESCRIPTION
Fixes 1643092 and 1643093

Neither of these are major issues, but fixed anyway..

i.e. 1<<hm is bounded by the parameter set so this is not an issue Not checking an error from WPACKET_memcpy() would also not cause an issue.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
