### PR TITLE
prevent libssl from unloading.

### DIFF
--- a/ssl/ssl_init.c
+++ b/ssl/ssl_init.c
@@ -70,7 +70,7 @@ static void pin_library(void)
 {
 #if !defined(OPENSSL_USE_NODELETE) \
     && !defined(OPENSSL_NO_PINSHARED)
-# if defined(DSO_WIN32) && !defined(_WIN32_WCE)
+# if defined(WIN32) && !defined(_WIN32_WCE)
     {
         HMODULE handle = NULL;
 

--- a/ssl/ssl_init.c
+++ b/ssl/ssl_init.c
@@ -13,6 +13,7 @@
 #include <openssl/crypto.h>
 #include <openssl/evp.h>
 #include <openssl/trace.h>
+#include <openssl/err.h>
 #include "ssl_local.h"
 #include "sslerr.h"
 #include "internal/thread_once.h"
@@ -41,6 +42,12 @@ static void pin_library(void)
      * to remain loaded until the atexit() handler is run at process exit.
      */
     (void) DSO_dsobyaddr(&stopped, DSO_FLAG_NO_UNLOAD_ON_FREE);
+    /*
+     * clear errors eventually left behind runtime linker.
+     * those errors are meant to be ignored anyway. Library
+     * pinning is just best effort.
+     */
+    ERR_clear_error();
 # endif
 #endif
 }

--- a/ssl/ssl_init.c
+++ b/ssl/ssl_init.c
@@ -20,7 +20,10 @@
 #include "internal/dso.h"
 
 static int stopped;
+#if !defined(OPENSSL_USE_NODELETE) \
+    && !defined(OPENSSL_NO_PINSHARED)
 static int ssl_pinned = 0;
+#endif
 
 static CRYPTO_ONCE ssl_base = CRYPTO_ONCE_STATIC_INIT;
 static int ssl_base_inited = 0;


### PR DESCRIPTION
this issue has been discovered by mod_ssl in Apache server. It's a regression introduced in 3.4 by da9342ed5edabfbbd658e35f6bad1831682cc7e7. Among other things the change removes at-exit handler set by libssl at its initialization. Armed exit handler is sufficient to prevent library from unloading when handle gets closed.

The change here is more explicit we dlopen (load) ssl library and deliberately leak a reference at library initialzation.

Fixes #26672

