### PR TITLE
Added new API to enable 0-RTT for 3rd party QUIC stacks.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,10 @@ OpenSSL 3.5
 
 ### Changes between 3.4 and 3.5 [xx XXX xxxx]
 
+* Added new API to enable 0-RTT for 3rd party QUIC stacks.
+
+  *Cheng Zhang*
+
 * Added support for a new callback registration SSL_CTX_set_new_pending_conn_cb,
   which allows for application notification of new connection SSL object
   creation, which occurs independently of calls to SSL_accept_connection().

--- a/doc/man3/SSL_set_quic_tls_cbs.pod
+++ b/doc/man3/SSL_set_quic_tls_cbs.pod
@@ -9,7 +9,8 @@ OSSL_FUNC_SSL_QUIC_TLS_yield_secret_fn,
 OSSL_FUNC_SSL_QUIC_TLS_got_transport_params_fn,
 OSSL_FUNC_SSL_QUIC_TLS_alert_fn,
 SSL_set_quic_tls_cbs,
-SSL_set_quic_tls_transport_params
+SSL_set_quic_tls_transport_params,
+SSL_set_quic_tls_early_data_enabled
 - Use the OpenSSL TLS implementation for a third party QUIC implementation
 
 =head1 SYNOPSIS
@@ -59,6 +60,7 @@ SSL_set_quic_tls_transport_params
  int SSL_set_quic_tls_transport_params(SSL *s,
                                        const unsigned char *params,
                                        size_t params_len);
+ int SSL_set_quic_tls_early_data_enabled(SSL *s, int enabled);
 
 =head1 DESCRIPTION
 
@@ -132,6 +134,9 @@ parameters should remain valid until after the parameters have been sent. This
 function must have been called by the time the transport parameters need to be
 sent. For a client this will be before the connection has been initiated. For a
 server this might typically occur during the got_transport_params_cb.
+
+The SSL_set_quic_tls_early_data_enabled() function is used to enable the 0-RTT
+feature for a third party QUIC implementation.
 
 =head1 RETURN VALUES
 

--- a/include/internal/quic_tls.h
+++ b/include/internal/quic_tls.h
@@ -108,4 +108,5 @@ int ossl_quic_tls_get_error(QUIC_TLS *qtls,
 int ossl_quic_tls_is_cert_request(QUIC_TLS *qtls);
 int ossl_quic_tls_has_bad_max_early_data(QUIC_TLS *qtls);
 
+int ossl_quic_tls_set_early_data_enabled(QUIC_TLS *qtls, int enabled);
 #endif

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2878,6 +2878,8 @@ int SSL_set_quic_tls_transport_params(SSL *s,
                                       const unsigned char *params,
                                       size_t params_len);
 
+int SSL_set_quic_tls_early_data_enabled(SSL *s, int enabled);
+
 # ifdef  __cplusplus
 }
 # endif

--- a/ssl/quic/quic_tls_api.c
+++ b/ssl/quic/quic_tls_api.c
@@ -186,3 +186,20 @@ int SSL_set_quic_tls_transport_params(SSL *s,
 
     return ossl_quic_tls_set_transport_params(sc->qtls, params, params_len);
 }
+
+int SSL_set_quic_tls_early_data_enabled(SSL *s, int enabled)
+{
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    if (!SSL_is_tls(s)) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
+        return 0;
+    }
+
+    if (sc->qtls == NULL) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
+        return 0;
+    }
+
+    return ossl_quic_tls_set_early_data_enabled(sc->qtls, enabled);
+}

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4946,6 +4946,13 @@ int SSL_do_handshake(SSL *s)
             ret = sc->handshake_func(s);
         }
     }
+
+    if (ret == 1 && SSL_IS_QUIC_HANDSHAKE(sc) && !SSL_is_init_finished(s)) {
+        sc->rwstate = SSL_READING;
+        BIO_clear_retry_flags(SSL_get_rbio(s));
+        BIO_set_retry_read(SSL_get_rbio(s));
+        ret = 0;
+    }
     return ret;
 }
 

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -589,6 +589,7 @@ SSL_set_block_padding_ex                589	3_4_0	EXIST::FUNCTION:
 SSL_get1_builtin_sigalgs                590	3_4_0	EXIST::FUNCTION:
 SSL_set_quic_tls_cbs                    ?	3_5_0	EXIST::FUNCTION:
 SSL_set_quic_tls_transport_params       ?	3_5_0	EXIST::FUNCTION:
+SSL_set_quic_tls_early_data_enabled     ?	3_5_0	EXIST::FUNCTION:
 OSSL_QUIC_server_method                 ?	3_5_0	EXIST::FUNCTION:QUIC
 SSL_is_listener                         ?	3_5_0	EXIST::FUNCTION:
 SSL_get0_listener                       ?	3_5_0	EXIST::FUNCTION:


### PR DESCRIPTION
Added new API to enable 0-RTT for 3rd party QUIC stacks.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
