### PR TITLE
Add ifndef OPENSSL_NO_TRACE to quicapitest.c

### DIFF
--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -562,6 +562,7 @@ enum {
     FAILED = 4
 };
 
+#ifndef OPENSSL_NO_TRACE
 static int find_new_token_data(BIO *membio)
 {
     char buf[1024];
@@ -619,6 +620,7 @@ static int find_new_token_data(BIO *membio)
     OPENSSL_free(tokenval);
     return (state == SUCCESS);
 }
+#endif
 
 static int test_new_token(void)
 {

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -642,8 +642,10 @@ static int test_new_token(void)
 
         goto err;
 
+#ifndef OPENSSL_NO_TRACE
     SSL_set_msg_callback(clientquic, SSL_trace);
     SSL_set_msg_callback_arg(clientquic, bio);
+#endif
 
     if (!TEST_true(qtest_create_quic_connection(qtserv, clientquic)))
         goto err;
@@ -665,8 +667,10 @@ static int test_new_token(void)
                                              &clientquic2, NULL, NULL)))
         goto err;
 
+#ifndef OPENSSL_NO_TRACE
     SSL_set_msg_callback(clientquic2, SSL_trace);
     SSL_set_msg_callback_arg(clientquic2, bio);
+#endif
 
     /* once we have our new token, create the subsequent connection */
     if (!TEST_true(qtest_create_quic_connection(qtserv2, clientquic2)))

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -677,8 +677,10 @@ static int test_new_token(void)
         goto err;
 
     /* Skip the comparison of the trace when the fips provider is used. */
+#ifndef OPENSSL_NO_TRACE
     if (!TEST_true(find_new_token_data(bio)))
         goto err;
+#endif
 
     testresult = 1;
  err:


### PR DESCRIPTION
Fixes the issue with the daily checker run

e.g. https://github.com/openssl/openssl/actions/runs/13426753269

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are added or updated
