### PR TITLE
SLH-DSA - restrict keygen seed length to exact value of 3*n

### DIFF
--- a/crypto/slh_dsa/slh_dsa_key.c
+++ b/crypto/slh_dsa/slh_dsa_key.c
@@ -357,7 +357,7 @@ int ossl_slh_dsa_generate_key(SLH_DSA_HASH_CTX *ctx, SLH_DSA_KEY *out,
     uint8_t *pub = SLH_DSA_PUB(out);
 
     if (entropy != NULL && entropy_len != 0) {
-        if (entropy_len < entropy_len_expected)
+        if (entropy_len != entropy_len_expected)
             goto err;
         memcpy(priv, entropy, entropy_len_expected);
     } else {

--- a/include/crypto/slh_dsa.h
+++ b/include/crypto/slh_dsa.h
@@ -18,6 +18,7 @@
 # include "crypto/types.h"
 
 # define SLH_DSA_MAX_CONTEXT_STRING_LEN 255
+# define SLH_DSA_MAX_N                  32
 
 typedef struct slh_dsa_hash_ctx_st SLH_DSA_HASH_CTX;
 typedef struct slh_dsa_key_st SLH_DSA_KEY;

--- a/providers/implementations/keymgmt/slh_dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/slh_dsa_kmgmt.c
@@ -41,7 +41,7 @@ struct slh_dsa_gen_ctx {
     SLH_DSA_HASH_CTX *ctx;
     OSSL_LIB_CTX *libctx;
     char *propq;
-    uint8_t entropy[32 * 3];
+    uint8_t entropy[SLH_DSA_MAX_N * 3];
     size_t entropy_len;
 };
 

--- a/providers/implementations/signature/slh_dsa_sig.c
+++ b/providers/implementations/signature/slh_dsa_sig.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -7,9 +7,6 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "internal/deprecated.h"
-
-#include <assert.h>
 #include <openssl/core_names.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
@@ -284,7 +281,6 @@ static int slh_dsa_set_ctx_params(void *vctx, const OSSL_PARAM params[])
         void *vp = pctx->add_random;
         size_t n = ossl_slh_dsa_key_get_n(pctx->key);
 
-        assert(n <= sizeof(pctx->add_random));
         if (!OSSL_PARAM_get_octet_string(p, &vp, n, &(pctx->add_random_len))
                 || pctx->add_random_len != n) {
             pctx->add_random_len = 0;


### PR DESCRIPTION
Only the last commit is relevant to this PR.

Rebase will happen after dependencies are merged to master.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
