### PR TITLE
More seed and private key checks for ML-DSA

### DIFF
--- a/crypto/ml_dsa/ml_dsa_encoders.c
+++ b/crypto/ml_dsa/ml_dsa_encoders.c
@@ -8,7 +8,9 @@
  */
 
 #include <openssl/byteorder.h>
+#include <openssl/err.h>
 #include <openssl/evp.h>
+#include <openssl/proverr.h>
 #include "ml_dsa_hash.h"
 #include "ml_dsa_key.h"
 #include "ml_dsa_sign.h"
@@ -811,8 +813,13 @@ int ossl_ml_dsa_sk_decode(ML_DSA_KEY *key, const uint8_t *in, size_t in_len)
      * the |tr| value in the private key, else the key was corrupted.
      */
     if (!ossl_ml_dsa_key_public_from_private(key)
-            || memcmp(input_tr, key->tr, sizeof(input_tr)) != 0)
+            || memcmp(input_tr, key->tr, sizeof(input_tr)) != 0) {
+        ERR_raise_data(ERR_LIB_PROV, PROV_R_INVALID_KEY,
+                       "%s private key does not match its pubkey part",
+                       key->params->alg);
+        ossl_ml_dsa_key_reset(key);
         goto err;
+    }
 
     return 1;
  err:

--- a/include/crypto/ml_dsa.h
+++ b/include/crypto/ml_dsa.h
@@ -106,10 +106,6 @@ __owur int ossl_ml_dsa_key_public_from_private(ML_DSA_KEY *key);
 __owur int ossl_ml_dsa_pk_decode(ML_DSA_KEY *key, const uint8_t *in, size_t in_len);
 __owur int ossl_ml_dsa_sk_decode(ML_DSA_KEY *key, const uint8_t *in, size_t in_len);
 
-__owur int ossl_ml_dsa_key_public_from_private(ML_DSA_KEY *key);
-__owur int ossl_ml_dsa_pk_decode(ML_DSA_KEY *key, const uint8_t *in, size_t in_len);
-__owur int ossl_ml_dsa_sk_decode(ML_DSA_KEY *key, const uint8_t *in, size_t in_len);
-
 __owur int ossl_ml_dsa_sign(const ML_DSA_KEY *priv, int msg_is_mu,
                             const uint8_t *msg, size_t msg_len,
                             const uint8_t *context, size_t context_len,

--- a/test/recipes/15-test_ml_dsa_codecs.t
+++ b/test/recipes/15-test_ml_dsa_codecs.t
@@ -25,13 +25,18 @@ my @formats = qw(seed-priv priv-only seed-only oqskeypair bare-seed bare-priv);
 plan skip_all => "ML-DSA isn't supported in this build"
     if disabled("ml-dsa");
 
-plan tests => @algs * (16 + 10 * @formats);
+plan tests => @algs * (23 + 10 * @formats);
 my $seed = join ("", map {sprintf "%02x", $_} (0..31));
+my $weed = join ("", map {sprintf "%02x", $_} (1..32));
 my $ikme = join ("", map {sprintf "%02x", $_} (0..31));
+my %alg = ("44" => [4, 4, 2560], "65" => [6, 5, 4032], "87" => [8, 7, 4896]);
 
 foreach my $alg (@algs) {
     my $pub = sprintf("pub-%s.pem", $alg);
     my %formats = map { ($_, sprintf("prv-%s-%s.pem", $alg, $_)) } @formats;
+    my ($k, $l, $sk_len) = @{$alg{$alg}};
+    # The number of low-bits |d| in t_0 is 13 across all the variants
+    my $t0_len = $k * 13 * 32;
 
     # (1 + 6 * @formats) tests
     my $i = 0;
@@ -40,11 +45,11 @@ foreach my $alg (@algs) {
     ok(run(app(['openssl', 'pkey', '-pubin', '-in', $in0,
                 '-outform', 'DER', '-out', $der0])));
     foreach my $f (keys %formats) {
-        my $k = $formats{$f};
+        my $kf = $formats{$f};
         my %pruned = %formats;
         delete $pruned{$f};
         my $rest = join(", ", keys %pruned);
-        my $in = data_file($k);
+        my $in = data_file($kf);
         my $der = sprintf("pub-%s.%d.der", $alg, $i);
         #
         # Compare expected DER public key with DER public key of private
@@ -75,8 +80,8 @@ foreach my $alg (@algs) {
     ok(run(app([qw(openssl pkeyutl -verify -rawin -pubin -inkey),
                 $in0, '-in', $der0, '-sigfile', $refsig],
                sprintf("Signature verify with pubkey: %s", $alg))));
-    while (my ($f, $k) = each %formats) {
-        my $sk = data_file($k);
+    while (my ($f, $kf) = each %formats) {
+        my $sk = data_file($kf);
         my $s = sprintf("sig-%s.%d.dat", $alg, $i++);
         ok(run(app([qw(openssl pkeyutl -sign -rawin -inkey), $sk, '-in', $der0,
                     qw(-pkeyopt deterministic:1 -out), $s])));
@@ -143,13 +148,67 @@ foreach my $alg (@algs) {
 
     # (2 * @formats) tests
     # Check text encoding
-    while (my ($f, $k) = each %formats) {
+    while (my ($f, $kf) = each %formats) {
         my $txt =  sprintf("prv-%s-%s.txt", $alg,
                             ($f =~ m{seed}) ? 'seed' : 'priv');
         my $out = sprintf("prv-%s-%s.txt", $alg, $f);
-        ok(run(app(['openssl', 'pkey', '-in', data_file($k),
+        ok(run(app(['openssl', 'pkey', '-in', data_file($kf),
                     '-noout', '-text', '-out', $out])));
         ok(!compare(data_file($txt), $out),
             sprintf("text form private key: %s with %s", $alg, $f));
     }
+
+    # (8 tests): Test import/load seed/priv consistency checks
+    my $real = sprintf('real-%s.der', $alg);
+    my $fake = sprintf('fake-%s.der', $alg);
+    my $mixt = sprintf('mixt-%s.der', $alg);
+    my $mash = sprintf('mash-%s.der', $alg);
+    ok(run(app([qw(openssl genpkey -algorithm), "ml-dsa-$alg",
+                qw(-provparam ml-dsa.output_formats=seed-priv -pkeyopt),
+                "hexseed:$seed", qw(-outform DER -out), $real])),
+        sprintf("create real private key: %s", $alg));
+    ok(run(app([qw(openssl genpkey -algorithm), "ml-dsa-$alg",
+                qw(-provparam ml-dsa.output_formats=seed-priv -pkeyopt),
+                "hexseed:$weed", qw(-outform DER -out), $fake])),
+        sprintf("create fake private key: %s", $alg));
+    my $realfh = IO::File->new($real, "<:raw");
+    my $fakefh = IO::File->new($fake, "<:raw");
+    local $/ = undef;
+    my $realder = <$realfh>;
+    $realfh->close();
+    my $fakeder = <$fakefh>;
+    $fakefh->close();
+    #
+    # - 20 bytes PKCS8 fixed overhead,
+    # - 4 byte private key octet string tag + length
+    # - 4 byte seed + key sequence tag + length
+    #   - 2 byte seed tag + length
+    #     - 32 byte seed
+    #   - 4 byte key tag + length
+    #     - $sk_len private key, ending in t0.
+    #
+    my $p8_len = 28 + (2 + 32) + (4 + $sk_len);
+    ok((length($realder) == $p8_len && length($fakeder) == $p8_len),
+        sprintf("Got expected DER lengths of %s seed-priv key", $alg));
+    my $mixtder = substr($realder, 0, 28 + 34)
+        . substr($fakeder, 28 + 34);
+    my $mixtfh = IO::File->new($mixt, ">:raw");
+    print $mixtfh $mixtder;
+    $mixtfh->close();
+    ok(run(app([qw(openssl pkey -inform DER -noout -in), $real])),
+        sprintf("accept valid keypair: %s", $alg));
+    ok(!run(app([qw(openssl pkey -inform DER -noout -in), $mixt])),
+        sprintf("Using seed reject mismatched private %s", $alg));
+    ok(run(app([qw(openssl pkey -provparam ml-dsa.prefer_seed=no),
+                qw(-inform DER -noout -in), $mixt])),
+        sprintf("Ignoring seed accept mismatched private %s", $alg));
+    # Mutate the t0 vector
+    my $mashder = $realder;
+    substr($mashder, -$t0_len, 1) =~ s{(.)}{chr(ord($1)^1)}es;
+    my $mashfh = IO::File->new($mash, ">:raw");
+    print $mashfh $mashder;
+    $mashfh->close();
+    ok(!run(app([qw(openssl pkey -provparam ml-dsa.prefer_seed=no),
+                 qw(-inform DER -noout -in), $mash])),
+        sprintf("reject real private and mutated public: %s", $alg));
 }


### PR DESCRIPTION
- Check seed/key consistency when generating from a seed and the private key is also given.
- Improve error reporting when the private key does not match an explicit public key.
- Make Perl read/write of DER files uses binary mode also in ML-KEM codec tests.

##### Checklist
- [x] tests are added or updated
