### PR TITLE
Fix ci break on building quic with no-siphash

### DIFF
--- a/ssl/build.info
+++ b/ssl/build.info
@@ -22,7 +22,7 @@ SOURCE[../libssl]=\
 # in libssl as well.
 SHARED_SOURCE[../libssl]=\
         ../crypto/packet.c ../crypto/quic_vlint.c ../crypto/time.c \
-        ../crypto/hashtable/hashfunc.c ../crypto/siphash/siphash.c
+        ../crypto/hashtable/hashfunc.c
 
 IF[{- !$disabled{'deprecated-3.0'} -}]
   SOURCE[../libssl]=ssl_rsa_legacy.c
@@ -30,4 +30,9 @@ ENDIF
 
 IF[{- !$disabled{quic} -}]
   SOURCE[../libssl]=priority_queue.c
+  IF[{- $disabled{siphash} -}]
+    SOURCE[../libssl]=../crypto/siphash/siphash.c
+  ELSE
+    SHARED_SOURCE[../libssl]=../crypto/siphash/siphash.c
+  ENDIF
 ENDIF


### PR DESCRIPTION
SHARED_SOURCE doesn't pull in siphash if its disabled in the
configuration leading to undefined symbols, which we need for quic.
    
If siphash is disabled in the build, then pull it in via a SOURCE
addition, otherwise pull it in via SHARED_SOURCE
