### PR TITLE
Rename fnv1a_hash() to ossl_fnv1a_hash()

### DIFF
--- a/crypto/hashtable/hashfunc.c
+++ b/crypto/hashtable/hashfunc.c
@@ -10,7 +10,7 @@
 
 #include "internal/hashfunc.h"
 
-ossl_unused uint64_t fnv1a_hash(uint8_t *key, size_t len)
+ossl_unused uint64_t ossl_fnv1a_hash(uint8_t *key, size_t len)
 {
     uint64_t hash = 0xcbf29ce484222325ULL;
     size_t i;

--- a/crypto/hashtable/hashtable.c
+++ b/crypto/hashtable/hashtable.c
@@ -218,7 +218,7 @@ HT *ossl_ht_new(const HT_CONFIG *conf)
         goto err;
 
     if (new->config.ht_hash_fn == NULL)
-        new->config.ht_hash_fn = fnv1a_hash;
+        new->config.ht_hash_fn = ossl_fnv1a_hash;
 
     return new;
 

--- a/include/internal/hashfunc.h
+++ b/include/internal/hashfunc.h
@@ -14,6 +14,6 @@
 /**
  * Generalized fnv1a 64 bit hash function
  */
-ossl_unused uint64_t fnv1a_hash(uint8_t *key, size_t len);
+ossl_unused uint64_t ossl_fnv1a_hash(uint8_t *key, size_t len);
 
 #endif

--- a/ssl/build.info
+++ b/ssl/build.info
@@ -21,8 +21,7 @@ SOURCE[../libssl]=\
 # For shared builds we need to include the libcrypto packet.c and quic_vlint.c
 # in libssl as well.
 SHARED_SOURCE[../libssl]=\
-        ../crypto/packet.c ../crypto/quic_vlint.c ../crypto/time.c \
-        ../crypto/hashtable/hashfunc.c
+        ../crypto/packet.c ../crypto/quic_vlint.c ../crypto/time.c
 
 IF[{- !$disabled{'deprecated-3.0'} -}]
   SOURCE[../libssl]=ssl_rsa_legacy.c
@@ -30,6 +29,7 @@ ENDIF
 
 IF[{- !$disabled{quic} -}]
   SOURCE[../libssl]=priority_queue.c
+  SHARED_SOURCE[../libssl] = ../crypto/hashtable/hashfunc.c
   IF[{- $disabled{siphash} -}]
     SOURCE[../libssl]=../crypto/siphash/siphash.c
   ELSE

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4657,7 +4657,7 @@ struct ssl_token_store_st {
 
 static unsigned long quic_token_hash(const QUIC_TOKEN *item)
 {
-    return (unsigned long)fnv1a_hash(item->hashkey, item->hashkey_len);
+    return (unsigned long)ossl_fnv1a_hash(item->hashkey, item->hashkey_len);
 }
 
 static int quic_token_cmp(const QUIC_TOKEN *a, const QUIC_TOKEN *b)


### PR DESCRIPTION
It is no longer static.

Also add it to libssl only with quic enabled.