### PR TITLE
fix slh-dsa incorrect prediction of result code

### DIFF
--- a/fuzz/slh-dsa.c
+++ b/fuzz/slh-dsa.c
@@ -341,7 +341,7 @@ static void slh_dsa_sign_verify(uint8_t **buf, size_t *len, void *key1,
     msg_len = *len;
 
     /* if msg_len > 255, sign_message_init will fail */
-    if (msg_len > 255 && (selector & 0x1))
+    if (msg_len > 255 && (selector & 0x1) != 0)
         expect_init_rc = 0;
 
     *len = 0;

--- a/fuzz/slh-dsa.c
+++ b/fuzz/slh-dsa.c
@@ -341,7 +341,7 @@ static void slh_dsa_sign_verify(uint8_t **buf, size_t *len, void *key1,
     msg_len = *len;
 
     /* if msg_len > 255, sign_message_init will fail */
-    if (msg_len > 255)
+    if (msg_len > 255 && (selector & 0x1))
         expect_init_rc = 0;
 
     *len = 0;


### PR DESCRIPTION
The slh_dsa fuzzer predicts failure in EVP_message_sign_init in the event we pass a context_string param of more than 255 bytes.  That makes for an accurate prediction, but only if we actually create  the param.

augment the setting of exepct_rc_init to be determined not only by our allocation of a > 255 byte message, but also on selector bit 1, which determines if we create the parameter at all.

Fixes https://oss-fuzz.com/testcase-detail/4807793999937536

