### PR TITLE
Encoder : Fix floating pointer when OSSL_ENCODER_to_data() is called twice

### DIFF
--- a/crypto/encode_decode/encoder_pkey.c
+++ b/crypto/encode_decode/encoder_pkey.c
@@ -210,6 +210,7 @@ encoder_construct_pkey(OSSL_ENCODER_INSTANCE *encoder_inst, void *arg)
 static void encoder_destruct_pkey(void *arg)
 {
     struct construct_data_st *data = arg;
+    int match = (data->obj == data->constructed_obj);
 
     if (data->encoder_inst != NULL) {
         OSSL_ENCODER *encoder =
@@ -218,6 +219,8 @@ static void encoder_destruct_pkey(void *arg)
         encoder->free_object(data->constructed_obj);
     }
     data->constructed_obj = NULL;
+    if (match)
+        data->obj = NULL;
 }
 
 /*

--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -1311,13 +1311,12 @@ static int ec_encode_to_data_multi(void)
     EVP_PKEY *key = NULL;
     uint8_t *enc = NULL;
     size_t enc_len = 0;
-    const char* curve_name = "P-256";
 
-    ret = TEST_ptr(key = EVP_PKEY_Q_keygen(testctx, "", "EC", curve_name))
-          && TEST_ptr(ectx = OSSL_ENCODER_CTX_new_for_pkey(key, EVP_PKEY_KEYPAIR,
-                                                           "DER", NULL, NULL))
-          && TEST_int_eq(OSSL_ENCODER_to_data(ectx, NULL, &enc_len), 1)
-          && TEST_int_eq(OSSL_ENCODER_to_data(ectx, &enc, &enc_len), 1);
+    ret = TEST_ptr(key = EVP_PKEY_Q_keygen(testctx, "", "EC", "P-256"))
+        && TEST_ptr(ectx = OSSL_ENCODER_CTX_new_for_pkey(key, EVP_PKEY_KEYPAIR,
+                                                         "DER", NULL, NULL))
+        && TEST_int_eq(OSSL_ENCODER_to_data(ectx, NULL, &enc_len), 1)
+        && TEST_int_eq(OSSL_ENCODER_to_data(ectx, &enc, &enc_len), 1);
     OPENSSL_free(enc);
     EVP_PKEY_free(key);
     OSSL_ENCODER_CTX_free(ectx);

--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -1300,6 +1300,29 @@ static int create_ec_explicit_trinomial_params(OSSL_PARAM_BLD *bld)
     return do_create_ec_explicit_trinomial_params(bld, gen2, sizeof(gen2));
 }
 # endif /* OPENSSL_NO_EC2M */
+
+/*
+ * Test that multiple calls to OSSL_ENCODER_to_data() do not cause side effects
+ */
+static int ec_encode_to_data_multi(void)
+{
+    int ret;
+    OSSL_ENCODER_CTX *ectx = NULL;
+    EVP_PKEY *key = NULL;
+    uint8_t *enc = NULL;
+    size_t enc_len = 0;
+    const char* curve_name = "P-256";
+
+    ret = TEST_ptr(key = EVP_PKEY_Q_keygen(testctx, "", "EC", curve_name))
+          && TEST_ptr(ectx = OSSL_ENCODER_CTX_new_for_pkey(key, EVP_PKEY_KEYPAIR,
+                                                           "DER", NULL, NULL))
+          && TEST_int_eq(OSSL_ENCODER_to_data(ectx, NULL, &enc_len), 1)
+          && TEST_int_eq(OSSL_ENCODER_to_data(ectx, &enc, &enc_len), 1);
+    OPENSSL_free(enc);
+    EVP_PKEY_free(key);
+    OSSL_ENCODER_CTX_free(ectx);
+    return ret;
+}
 #endif /* OPENSSL_NO_EC */
 
 typedef enum OPTION_choice {
@@ -1525,6 +1548,8 @@ int setup_tests(void)
 # endif
 #endif
 #ifndef OPENSSL_NO_EC
+        if (!is_fips_lt_3_5)
+            ADD_TEST(ec_encode_to_data_multi);
         ADD_TEST_SUITE(EC);
         ADD_TEST_SUITE_PARAMS(EC);
         ADD_TEST_SUITE_LEGACY(EC);

--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -1547,8 +1547,7 @@ int setup_tests(void)
 # endif
 #endif
 #ifndef OPENSSL_NO_EC
-        if (!is_fips_lt_3_5)
-            ADD_TEST(ec_encode_to_data_multi);
+        ADD_TEST(ec_encode_to_data_multi);
         ADD_TEST_SUITE(EC);
         ADD_TEST_SUITE_PARAMS(EC);
         ADD_TEST_SUITE_LEGACY(EC);


### PR DESCRIPTION
Fixes #26862

This only happens when using the FIPS provider, since it needs to export the key.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
