### PR TITLE
New FIPS kemop (3.3)

### DIFF
--- a/test/evp_libctx_test.c
+++ b/test/evp_libctx_test.c
@@ -38,6 +38,8 @@ static OSSL_LIB_CTX *libctx = NULL;
 static OSSL_PROVIDER *nullprov = NULL;
 static OSSL_PROVIDER *libprov = NULL;
 static STACK_OF(OPENSSL_STRING) *cipher_names = NULL;
+static int is_fips = 0;
+static int is_fips_lt_3_5 = 0;
 
 typedef enum OPTION_choice {
     OPT_ERR = -1,
@@ -668,9 +670,10 @@ static int kem_rsa_params(void)
         && TEST_int_eq(EVP_PKEY_decapsulate(pubctx, secret, &secretlen, ct,
                                             sizeof(ct)), 0)
         && TEST_uchar_eq(secret[0], 0)
-        /* Test encapsulate fails if the mode is not set */
+        /* Unless newer FIPS, test encapsulate fails when the mode is not set. */
         && TEST_int_eq(EVP_PKEY_encapsulate_init(pubctx, NULL), 1)
-        && TEST_int_eq(EVP_PKEY_encapsulate(pubctx, ct, &ctlen, secret, &secretlen), -2)
+        && (!is_fips_lt_3_5 ||
+            TEST_int_eq(EVP_PKEY_encapsulate(pubctx, ct, &ctlen, secret, &secretlen), -2))
         /* Test setting a bad kem ops fail */
         && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(pubctx, "RSA"), 0)
         && TEST_int_eq(EVP_PKEY_CTX_set_kem_op(pubctx, NULL), 0)
@@ -782,8 +785,14 @@ int setup_tests(void)
 
     ADD_TEST(test_evp_cipher_api_safety);
 
+    if (strcmp(prov_name, "fips") == 0)
+        is_fips = 1;
+
+    is_fips_lt_3_5 = is_fips && fips_provider_version_lt(libctx, 3, 5, 0);
+
 #if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DH)
-    ADD_ALL_TESTS(test_dsa_param_keygen, 3 * 3 * 3);
+    if (!is_fips || fips_provider_version_lt(libctx, 3, 4, 0))
+        ADD_ALL_TESTS(test_dsa_param_keygen, 3 * 3 * 3);
 #endif
 #ifndef OPENSSL_NO_DH
     ADD_ALL_TESTS(test_dh_safeprime_param_keygen, 3 * 3 * 3);


### PR DESCRIPTION
Tolerate 3.5+ FIPS providers in kem_rsa_params test

##### Checklist
- [x] tests are added or updated
