### PR TITLE
fix snprintf by BIO_snprintf

### DIFF
--- a/test/http_test.c
+++ b/test/http_test.c
@@ -159,7 +159,7 @@ static int test_http_method(int do_get, int do_txt, int suggested_status)
     int res = 0;
     int real_server = do_txt && 0; /* remove "&& 0" for using real server */
 
-    snprintf(path, sizeof(path), "/%d%s", suggested_status,
+    BIO_snprintf(path, sizeof(path), "/%d%s", suggested_status,
              do_get > 1 ? "/will-be-redirected" : RPATH);
     if (do_txt) {
         content_type = "text/plain";

--- a/test/http_test.c
+++ b/test/http_test.c
@@ -160,7 +160,7 @@ static int test_http_method(int do_get, int do_txt, int suggested_status)
     int real_server = do_txt && 0; /* remove "&& 0" for using real server */
 
     BIO_snprintf(path, sizeof(path), "/%d%s", suggested_status,
-             do_get > 1 ? "/will-be-redirected" : RPATH);
+                 do_get > 1 ? "/will-be-redirected" : RPATH);
     if (do_txt) {
         content_type = "text/plain";
         req = BIO_new(BIO_s_mem());


### PR DESCRIPTION
Prevents:
http_test-bin-http_test.obj : error LNK2019: unresolved external symbol snprintf referenced in function test_http_method
test\http_test.exe : fatal error LNK1120: 1 unresolved externals
