### PR TITLE
Fix a compilation failure in AIX

### DIFF
--- a/ssl/rio/poll_immediate.c
+++ b/ssl/rio/poll_immediate.c
@@ -21,12 +21,8 @@
  * accessing pollfd structures (see Github issue #24236). That interferes
  * with our use of these names here. We simply undef them.
  */
-# ifdef revents
-#  undef revents
-# endif
-# ifdef events
-#  undef events
-# endif
+# undef revents
+# undef events
 #endif
 
 #define ITEM_N(items, stride, n) \

--- a/ssl/rio/poll_immediate.c
+++ b/ssl/rio/poll_immediate.c
@@ -15,6 +15,20 @@
 #include "../ssl_local.h"
 #include "poll_builder.h"
 
+#if defined(_AIX)
+/*
+ * Some versions of AIX define macros for events and revents for use when
+ * accessing pollfd structures (see Github issue #24236). That interferes
+ * with our use of these names here. We simply undef them.
+ */
+# ifdef revents
+#  undef revents
+# endif
+# ifdef events
+#  undef events
+# endif
+#endif
+
 #define ITEM_N(items, stride, n) \
     (*(SSL_POLL_ITEM *)((char *)(items) + (n)*(stride)))
 


### PR DESCRIPTION
AIX (at least for 7.1)  defines some macros for "events" and "revents" which interferes with our own use of these names.

Fixes #24236
