### PR TITLE
Issue.26672.test

### DIFF
--- a/test/build.info
+++ b/test/build.info
@@ -720,7 +720,8 @@ IF[{- !$disabled{tests} -}]
     INCLUDE[moduleloadtest]=../include ../apps/include
 
     MODULES{noinst}=mod_shlibtest
-    SOURCE[mod_shlibtest]=mod_shlibtest.c
+    SOURCE[mod_shlibtest]=mod_shlibtest.c mod_shlibtest.ld
+    GENERATE[mod_shlibtest.ld]=mod_shlibtest.num
     INCLUDE[mod_shlibtest]=../include ..
     DEPEND[mod_shlibtest]=../libcrypto ../libssl
 

--- a/test/build.info
+++ b/test/build.info
@@ -720,8 +720,11 @@ IF[{- !$disabled{tests} -}]
     INCLUDE[moduleloadtest]=../include ../apps/include
 
     MODULES{noinst}=mod_shlibtest
-    SOURCE[mod_shlibtest]=mod_shlibtest.c mod_shlibtest.ld
-    GENERATE[mod_shlibtest.ld]=mod_shlibtest.num
+    SOURCE[mod_shlibtest]=mod_shlibtest.c
+    IF[{- defined $target{shared_defflag} -}]
+       SOURCE[mod_shlibtest]=mod_shlibtest.ld
+       GENERATE[mod_shlibtest.ld]=mod_shlibtest.num
+    ENDIF
     INCLUDE[mod_shlibtest]=../include ..
     DEPEND[mod_shlibtest]=../libcrypto ../libssl
 

--- a/test/build.info
+++ b/test/build.info
@@ -718,6 +718,12 @@ IF[{- !$disabled{tests} -}]
     PROGRAMS{noinst}=moduleloadtest
     SOURCE[moduleloadtest]=moduleloadtest.c simpledynamic.c
     INCLUDE[moduleloadtest]=../include ../apps/include
+
+    MODULES{noinst}=mod_shlibtest
+    SOURCE[mod_shlibtest]=mod_shlibtest.c
+    INCLUDE[mod_shlibtest]=../include ..
+    DEPEND[mod_shlibtest]=../libcrypto ../libssl
+
   ENDIF
 
   # cipher_overhead_test uses internal symbols, so it must be linked with

--- a/test/mod_shlibtest.c
+++ b/test/mod_shlibtest.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ *
+ */
+
+#include <openssl/ssl.h>
+
+int do_test_just_init(void)
+{
+    return OPENSSL_init_ssl(OPENSSL_INIT_ENGINE_ALL_BUILTIN, NULL);
+}
+
+int do_test_create_ssl_ctx(void)
+{
+    SSL_CTX *ctx = NULL;
+
+    if (do_test_just_init() == 1) {
+        ctx = SSL_CTX_new(TLS_method());
+        if (ctx != NULL)
+            SSL_CTX_free(ctx);
+    }
+
+    return ctx != NULL;
+}

--- a/test/mod_shlibtest.num
+++ b/test/mod_shlibtest.num
@@ -1,2 +1,2 @@
-do_test_just_init	1	*	EXISTS::FUNCTION:
-do_test_create_ssl_ctx	1	*	EXISTS::FUNCTION:
+do_test_just_init                     1	*	EXIST::FUNCTION:
+do_test_create_ssl_ctx                     1	*	EXIST::FUNCTION:

--- a/test/mod_shlibtest.num
+++ b/test/mod_shlibtest.num
@@ -1,0 +1,2 @@
+do_test_just_init	1	*	EXISTS::FUNCTION:
+do_test_create_ssl_ctx	1	*	EXISTS::FUNCTION:

--- a/test/recipes/90-test_shlibload.t
+++ b/test/recipes/90-test_shlibload.t
@@ -61,6 +61,7 @@ ok(run(test(["shlibloadtest", "-no_atexit", $libcrypto, $libssl, $atexit_outfile
    "running shlibloadtest -no_atexit $atexit_outfile");
 ok(!check_atexit($atexit_outfile));
 
+$ENV{"MODULES_PATH"} = bldtop_dir("test");
 ok(run(test(["shlibloadtest", "-apache_like", $libcrypto, $libssl, $atexit_outfile])),
     "running shlibloadtest -apache_like $atexit_outfile");
 ok(!check_atexit($atexit_outfile));

--- a/test/recipes/90-test_shlibload.t
+++ b/test/recipes/90-test_shlibload.t
@@ -25,7 +25,7 @@ plan skip_all => "Test only supported in a dso build" if disabled("dso");
 plan skip_all => "Test is disabled in an address sanitizer build" unless disabled("asan");
 plan skip_all => "Test is disabled in no-atexit build" if disabled("atexit");
 
-plan tests => 10;
+plan tests => 12;
 
 my $libcrypto = platform->sharedlib('libcrypto');
 my $libssl = platform->sharedlib('libssl');
@@ -59,6 +59,10 @@ $atexit_outfile = 'atexit-noatexit.txt';
 1 while unlink $atexit_outfile;
 ok(run(test(["shlibloadtest", "-no_atexit", $libcrypto, $libssl, $atexit_outfile])),
    "running shlibloadtest -no_atexit $atexit_outfile");
+ok(!check_atexit($atexit_outfile));
+
+ok(run(test(["shlibloadtest", "-apache_like", $libcrypto, $libssl, $atexit_outfile])),
+    "running shlibloadtest -apache_like $atexit_outfile");
 ok(!check_atexit($atexit_outfile));
 
 sub check_atexit {

--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -97,7 +97,7 @@ static int test_apache_like(void)
         mySSL_CTX_free = (SSL_CTX_free_t)symbols[2].func;
         myOPENSSL_init_ssl = (OPENSSL_init_ssl_t)symbols[3].func;
 
-        myOPENSSL_init_ssl(OPENSSL_INIT_ENGINE_ALL_BUILTIN, NULL);
+        myOPENSSL_init_ssl(OPENSSL_INIT_ENGINE_ALL_BUILTIN | OPENSSL_INIT_LOAD_SSL_STRINGS, NULL);
         ctx = mySSL_CTX_new(myTLS_method());
         if (ctx == NULL) {
             fprintf(stderr, "Failed to create SSL_CTX after %s\n", action[i]);

--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -97,7 +97,7 @@ static int test_apache_like(void)
         mySSL_CTX_free = (SSL_CTX_free_t)symbols[2].func;
         myOPENSSL_init_ssl = (OPENSSL_init_ssl_t)symbols[3].func;
 
-        myOPENSSL_init_ssl(0, NULL);
+        myOPENSSL_init_ssl(OPENSSL_INIT_ENGINE_ALL_BUILTIN, NULL);
         ctx = mySSL_CTX_new(myTLS_method());
         if (ctx == NULL) {
             fprintf(stderr, "Failed to create SSL_CTX after %s\n", action[i]);

--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -87,16 +87,16 @@ static int test_apache_like(void)
         goto end;
     }
 
-#if _WIN32
-    asprintf(&mod_path, "%s\\%s", mod_dir, MODULE_NAME);
-#else
-    asprintf(&mod_path, "%s/%s", mod_dir, MODULE_NAME);
-#endif
+    mod_path = malloc(strlen(mod_dir) + 1 + sizeof(MODULE_NAME));
     if (mod_path == NULL) {
         fprintf(stderr, "no memery\n");
         goto end;
     }
-
+#if _WIN32
+    sprintf(mod_path, "%s\\%s", mod_dir, MODULE_NAME);
+#else
+    sprintf(mod_path, "%s/%s", mod_dir, MODULE_NAME);
+#endif
     if (!sd_load(mod_path, &testlib, SD_SHLIB)) {
         fprintf(stderr, "Failed to load %s\n", mod_path);
         goto end;


### PR DESCRIPTION
This is a proposed unit test case which hopes to trigger the same issue like we are seeing in apache server with mod_ssl which uses OpenSSL 3.4 (details are [here)](https://github.com/openssl/openssl/issues/26672).

The test is supposed to crash on windows but no crash is seen. I'm sure I must be missing something here. If I understand the issue the testcase as follows should be sufficient to reproduce it:
```
int
main(int argc, const char *argv[])
{
    shlib = Load("mod_shlibtest.dll");
    do_test_just_init = resolve(shlib, "do_test_just_init");
    do_test_just_init();
    Free(shlib);

     shlib = Load("mod_shlibtest.dll");
     do_test_create_ssl_ctx = resolve(shlib, "do_test_create_ssl_ctx");
     do_test_create_ssl_ctx(); /* this should crash but it works */
     Free(shlib);
}
```

The unit test uses `sd_load()`, `sd_close()` and `sd_sym()` which in case of windows are implemented by `LoadLibraryA()`, `FreeLibrary()` and `GetProcAddress()`.