### PR TITLE
send tls alert when receiving http request in first record

### DIFF
--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -341,8 +341,13 @@ int ssl3_get_record(SSL *s)
                         if (strncmp((char *)p, "GET ", 4) == 0 ||
                             strncmp((char *)p, "POST ", 5) == 0 ||
                             strncmp((char *)p, "HEAD ", 5) == 0 ||
+                            strncmp((char *)p, "PATCH", 5) == 0 ||
+                            strncmp((char *)p, "OPTIO", 5) == 0 ||
+                            strncmp((char *)p, "DELET", 5) == 0 ||
+                            strncmp((char *)p, "TRACE", 5) == 0 ||
                             strncmp((char *)p, "PUT ", 4) == 0) {
-                            SSLfatal(s, SSL_AD_NO_ALERT, SSL_R_HTTP_REQUEST);
+                            SSLfatal(s, SSL_AD_UNEXCPECTED_MESSAGE,
+                                     SSL_R_HTTP_REQUEST);
                             return -1;
                         } else if (strncmp((char *)p, "CONNE", 5) == 0) {
                             SSLfatal(s, SSL_AD_NO_ALERT,

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -346,7 +346,7 @@ int ssl3_get_record(SSL *s)
                             strncmp((char *)p, "DELET", 5) == 0 ||
                             strncmp((char *)p, "TRACE", 5) == 0 ||
                             strncmp((char *)p, "PUT ", 4) == 0) {
-                            SSLfatal(s, SSL_AD_UNEXCPECTED_MESSAGE,
+                            SSLfatal(s, SSL_AD_UNEXPECTED_MESSAGE,
                                      SSL_R_HTTP_REQUEST);
                             return -1;
                         } else if (strncmp((char *)p, "CONNE", 5) == 0) {


### PR DESCRIPTION
According to the TLS RFC, such behavior should result in a TLS alert. From Section 5 of RFC 8446 (https://www.rfc-editor.org/rfc/rfc8446#section-5): "If a TLS implementation receives an unexpected record type, it MUST terminate the connection with an 'unexpected_message' alert."

Additionally the change checks for all HTTP methods, not only GET, POST, PUT and HEAD

CLA: trivial

