### PR TITLE
Remove empty buffer check in script_84 of quic_multistream_test

### DIFF
--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -5542,7 +5542,6 @@ static const struct script_op script_84[] = {
     OP_S_READ_EXPECT        (a, "apple", 5)
     OP_S_WRITE              (a, "orange", 6)
     OP_C_READ_EXPECT        (a, "orange", 6)
-    OP_CHECK2               (check_write_buf_stat, 0, 0)
 
     OP_END
 };


### PR DESCRIPTION
The quic_multistream_test occasionally fails script_84, specifically failing on:

OP_CHECK2(check_write_buf_stat, 0, 0)

which fails due to the send stream buffer not reading zero after data is sent on the stream

However, the send stream is culled of pending data, not after the stream is sent, but rather only after the peer sends an ack confirming that the data has been received.  There is no guarantee that ACK will be sent immediately, so occasionally timing discrepancies result in the test not getting that ack by the time we check the send stream buffer.

We could modify the script to wait longer, or repeatedly tick the quic stack to wait for that ack to be collected, but since its perfectly valid for that data to live in the ring buffer for a period, and that any true erroneous keeping of that data beyond its ack point would manifest as any number of other duplicate transmissions, it seems more sane to just remove the check.

Fixes openssl/project#1117


##### Checklist
- [x] tests are added or updated
