### PR TITLE
QUIC server post-rebase nits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,10 @@ OpenSSL 3.5
 
 ### Changes between 3.4 and 3.5 [xx XXX xxxx]
 
+* Added server side support for QUIC
+
+   *Matt Caswell, Tomáš Mráz, Neil Horman, Sasha Nedvedicky, Andrew Dinh*
+
  * Added a `no-tls-deprecated-ec` configuration option.
 
    The `no-tls-deprecated-ec` option disables support for TLS elliptic curve

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,7 @@ OpenSSL 3.5
 
 * Added server side support for QUIC
 
-   *Matt Caswell, Tomáš Mráz, Neil Horman, Sasha Nedvedicky, Andrew Dinh*
+   *Hugo Landau, Matt Caswell, Tomáš Mráz, Neil Horman, Sasha Nedvedicky, Andrew Dinh*
 
  * Added a `no-tls-deprecated-ec` configuration option.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,8 @@ changes:
   * Default encryption cipher for the `req`, `cms`, and `smime` applications
     changed from `des-ede3-cbc` to `aes-256-cbc`.
 
+  * Support for server side QUIC (RFC 9000)
+
 This release adds the following new features:
 
   * Allow the FIPS provider to optionally use the `JITTER` seed source.

--- a/doc/man3/OSSL_QUIC_client_method.pod
+++ b/doc/man3/OSSL_QUIC_client_method.pod
@@ -27,7 +27,7 @@ nonblocking mode of operation and the application periodically calling SSL
 functions.
 
 The OSSL_QUIC_server_method() provides server-side QUIC protocol support and
-must be used using the L<SSL_new_listener(3)> API. Attempting to use
+must be used with the L<SSL_new_listener(3)> API. Attempting to use
 OSSL_QUIC_server_method() with L<SSL_new(3)> will result in an error.
 
 =head1 RETURN VALUES
@@ -43,11 +43,11 @@ L<SSL_CTX_new_ex(3)>, L<SSL_new_listener(3)>
 OSSL_QUIC_client_method() and OSSL_QUIC_client_thread_method() were added in
 OpenSSL 3.2.
 
-OSSL_QUIC_server_method() was added in OpenSSL @VERSION_QUIC_SERVER@.
+OSSL_QUIC_server_method() was added in OpenSSL 3.5.
 
 =head1 COPYRIGHT
 
-Copyright 2022-2024 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2022-2025 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/SSL_new_domain.pod
+++ b/doc/man3/SSL_new_domain.pod
@@ -22,7 +22,7 @@ The SSL_new_domain() function creates a new QUIC event domain, represented as an
 SSL object. This is known as a QUIC domain SSL object (QDSO). The concept of a
 QUIC event domain is discussed in detail in L<openssl-quic-concurrency(7)>.
 
-The I<flags> argument to SSL_new_domain() accepts a set of domain flags. If the
+The I<flags> argument to SSL_new_domain() specifies a set of domain flags. If the
 I<flags> argument to SSL_new_domain() does not specify one of the flags
 B<SSL_DOMAIN_FLAG_SINGLE_THREAD>, B<SSL_DOMAIN_FLAG_MULTI_THREAD> or
 B<SSL_DOMAIN_FLAG_THREAD_ASSISTED>, the domain flags configured on the
@@ -105,7 +105,7 @@ L<SSL_CTX_set_domain_flags(3)>, L<openssl-quic-concurrency(7)>
 
 =head1 HISTORY
 
-These functions were added in OpenSSL @VERSION_QUIC_SERVER@.
+These functions were added in OpenSSL 3.5.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_new_listener.pod
+++ b/doc/man3/SSL_new_listener.pod
@@ -30,11 +30,10 @@ acceptance
 
 =head1 DESCRIPTION
 
-The SSL_new_listener() function creates a listener SSL object. A listener SSL
-object differs from an ordinary SSL object in that it is used to provide an
-abstraction for the acceptance of network connections in a protocol-agnostic
-manner. It cannot be used, for example, for sending or receiving data using
-L<SSL_write_ex(3)> or L<SSL_read_ex(3)>. In general, only those functions
+The SSL_new_listener() function creates a listener SSL object.  Listener SSL
+objects are specialised to only accept network connections in a protocol-
+agnostic manner. They cannot be used, for example, for sending or receiving data
+using L<SSL_write_ex(3)> or L<SSL_read_ex(3)>. In general, only those functions
 expressly documented as being supported on a listener SSL object are available.
 
 The SSL_new_listener_from() function creates a listener SSL object which is
@@ -103,25 +102,27 @@ listener SSL object.
 
 The SSL_get0_listener() function returns a listener object which is related to
 the given SSL object, if there is one. For a listener object, this is the same
-object (the function returns itself). For a connection object which was created
-by a listener object, that listener object is returned. An SSL object which is
-not a listener object and which is not descended from a listener object (e.g. a
-connection obtained using SSL_accept_connection()) or indirectly from a listener
-object (e.g. a QUIC stream SSL object obtained using SSL_accept_stream() called
-on a connection obtained using SSL_accept_connection()) returns NULL.  Also note
-that pending SSL connections on a QUIC listeners accept queue have some caveats,
-see NOTES below.
+object (the function returns its argument). For a connection object which was
+created by a listener object, that listener object is returned. If the I<ssl>
+argument is an SSL object which is not a listener object and which is not
+descended from a listener object (e.g. a connection obtained using
+SSL_accept_connection()) or indirectly from a listener object (e.g. a QUIC
+stream SSL object obtained using SSL_accept_stream() called on a connection
+obtained using SSL_accept_connection()) the return value is NULL. See NOTES
+below for caveats related to pending SSL connections on a QUIC listener's accept
+queue.
 
-The SSL_listen() function begins listening after a listener has been created.
-Appropriate BIOs must have been configured before calling SSL_listen(), along
-with any other needed configuration for the listener SSL object. It is
-ordinarily not needed to call SSL_listen() because it will be called
-automatically on the first call to SSL_accept_connection(). However,
+The SSL_listen() function begins monitoring the listener I<ssl> for incoming
+connections. Appropriate BIOs must have been configured before calling
+SSL_listen(), along with any other needed configuration for the listener SSL
+object. It is typically not necessary to call SSL_listen() because it will be
+called automatically on the first call to SSL_accept_connection(). However,
 SSL_listen() may be called explicitly if it is desired to control precisely when
 the listening process begins, or to ensure that no errors occur when starting to
 listen for connections. After a call to SSL_listen() (or
-SSL_accept_connection()) succeeds, subsequent calls to SSL_listen() are
-idempotent no-ops. This call is supported only on a listener SSL object.
+SSL_accept_connection()) succeeds. The SSL_listen() function is idempotent,
+subsequent calls on the same I<ssl> object are no-ops. This call is supported
+only on listener SSL objects.
 
 The SSL_accept_connection() call is supported only on a listener SSL object and
 accepts a new incoming connection. A new SSL object representing the accepted
@@ -133,11 +134,11 @@ The B<SSL_ACCEPT_CONNECTION_NO_BLOCK> flag may be specified to
 SSL_accept_connection(). If specified, the call does not block even if the
 listener SSL object is configured in blocking mode.
 
-The SSL_get_accept_connection_queue_len() call returns an informational value
-listing the number of connections waiting to be popped from the queue via calls
-to SSL_accept_connection(). Note that since this may change between subsequent
-API calls to the listener SSL object, it should be used for informational
-purposes only.
+The SSL_get_accept_connection_queue_len() call returns the number of pending
+connections on the I<ssl> listener's queue. SSL_accept_connection() returns the
+next pending connection, removing it from the queue. The returned connection
+count is a point-in-time value, the actual number of connections that will
+ultimately be returned may be different.
 
 Currently, listener SSL objects are only supported for QUIC server usage via
 L<OSSL_QUIC_server_method(3)>, or QUIC client-only usage via
@@ -168,10 +169,10 @@ address validation exposes the server to malicious clients that may open large
 numbers of connections and never transact data on them (roughly equivalent to
 a TCP syn flood attack), which address validation mitigates.
 
-The SSL_new_from_listener() creates a client connection under a given listener
-SSL object. For QUIC, it is also possible to use SSL_new_from_listener(),
-leading to a UDP network endpoint which has both incoming and outgoing'
-connections.
+The SSL_new_from_listener() function creates a client connection under a given
+listener SSL object. For QUIC, it is also possible to use
+SSL_new_from_listener(), leading to a UDP network endpoint which has both
+incoming and outgoing connections.
 
 The I<flags> argument of SSL_new_from_listener() is reserved and must be set to
 0.
@@ -181,8 +182,8 @@ The I<flags> argument of SSL_new_from_listener() is reserved and must be set to
 SSL_new_listener() and SSL_new_listener_from() return a new listener SSL object
 or NULL on failure.
 
-SSL_is_listener() returns 0 or 1 depending on the type of the SSL object on
-which it is called.
+SSL_is_listener() returns 1 if its I<ssl> argument is a listener object, 0
+otherwise.
 
 SSL_get0_listener() returns an SSL object pointer (potentially to the same
 object on which it is called) or NULL.
@@ -192,8 +193,8 @@ SSL_listen() returns 1 on success or 0 on failure.
 SSL_accept_connection() returns a pointer to a new SSL object on success or NULL
 on failure. On success, the caller assumes ownership of the reference.
 
-SSL_get_accept_connection_queue_len() returns a nonnegative value, or 0 if
-called on an unsupported SSL object type.
+SSL_get_accept_connection_queue_len() returns a nonnegative value, or 0 if the
+queue is empty, or called on an unsupported SSL object type.
 
 SSL_new_from_listener() returns a pointer to a new SSL object on success or NULL
 on failure. On success, the caller assumes ownership of the reference.
@@ -217,7 +218,7 @@ L<SSL_set_blocking_mode(3)>
 
 =head1 HISTORY
 
-These functions were added in OpenSSL @VERSION_QUIC_SERVER@.
+These functions were added in OpenSSL 3.5.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_new_stream.pod
+++ b/doc/man3/SSL_new_stream.pod
@@ -69,16 +69,15 @@ SSL_new_stream() returns a new stream object, or NULL on error.
 This function fails if called on a QUIC stream SSL object or on a non-QUIC SSL
 object.
 
-SSL_new_stream() may also fail if the connection that the stream is being
-allocated in relation to has reached the maximum number of streams allowed by
-the connection (as dictated by the B<max_streams_bidi> or B<max_streams_uni>
-transport parameter values negotiated by the connection with the server).  In
-this event the NULL return will be accompanied by an error on the error stack
-(obtainable via ERR_get_error()), which will contain a reason code of
+SSL_new_stream() may also fail if the underlying connection has reached the
+maximum stream count, based on the B<max_streams_bidi> or B<max_streams_uni>
+transport parameter values negotiated with the peer.  In this event the NULL
+return will be accompanied by an error on the error stack (obtainable via
+ERR_get_error()), which will contain a reason code of
 B<SSL_R_STREAM_COUNT_LIMITED>.  When this error is encountered, the operation
 may be retried.  It is recommended that, prior to retry, the error stack be
 cleared via a call to ERR_clear_error(), and that the TLS state machine be
-triggered via a call to SSL_handle_events() to process any potential updates
+activated via a call to SSL_handle_events() to process any potential updates
 from the server allowing additional streams to be created.
 
 =head1 SEE ALSO

--- a/doc/man3/SSL_poll.pod
+++ b/doc/man3/SSL_poll.pod
@@ -408,16 +408,16 @@ L<SSL_get_rpoll_descriptor(3)>, L<SSL_get_wpoll_descriptor(3)>
 
 SSL_poll() was added in OpenSSL 3.3.
 
-Before @VERSION_QUIC_SERVER@, SSL_poll() did not support blocking operation and
+Before 3.5, SSL_poll() did not support blocking operation and
 would fail if called with a NULL I<timeout> parameter or a I<timeout> parameter
 pointing to a B<struct timeval> which was not zero.
 
-Before @VERSION_QUIC_SERVER@, the B<SSL_POLL_EVENT_EL> and B<SSL_POLL_EVENT_IC>
+Before 3.5, the B<SSL_POLL_EVENT_EL> and B<SSL_POLL_EVENT_IC>
 event types were not present.
 
 =head1 COPYRIGHT
 
-Copyright 2024 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/test/radix/quic_ops.c
+++ b/test/radix/quic_ops.c
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
 #include "internal/sockets.h"
 
 static const unsigned char alpn_ossltest[] = {


### PR DESCRIPTION
- Apply doc nits suggested by Viktor from https://github.com/openssl/openssl/pull/26762
- Update CHANGES.md & NEWS.md saying there is now support for QUIC server
- Added copyright header in: test/radix/quic_ops.c

Fixes https://github.com/openssl/project/issues/1102

##### Checklist

- [x] documentation is added or updated