### PR TITLE
doc: Fix type of OSSL_KEM_PARAM_IKME for ML-KEM

### DIFF
--- a/doc/man7/EVP_KEM-ML-KEM.pod
+++ b/doc/man7/EVP_KEM-ML-KEM.pod
@@ -15,7 +15,7 @@ about basic KEM operations.
 
 =over 4
 
-=item "ikme" (B<OSSL_KEM_PARAM_IKME>)<UTF8 string>
+=item "ikme" (B<OSSL_KEM_PARAM_IKME>) <octet string>
 
 The OpenSSL ML-KEM encapsulation mechanism can only be modified by
 setting randomness during encapsulation, this enables testing, as per


### PR DESCRIPTION
Fixes #26945

Just a doc fix. The implementation is correct.