### PR TITLE
Work around for ARM64 atomics bug

### DIFF
--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -68,6 +68,13 @@ __tsan_mutex_post_lock((x), 0, 0)
 # endif
 
 /*
+ * The AARCH64 atomics seem to be broken
+ */
+# ifdef __aarch64__
+#  define USE_ATOMIC_FALLBACKS
+# endif
+
+/*
  * For all GNU/clang atomic builtins, we also need fallbacks, to cover all
  * other compilers.
 


### PR DESCRIPTION
Avoid that by using ATOMIC_FALLBACKS for now.

Fixes: #26875
