### PR TITLE
Work around for ARM64 atomics bug (alternative)

### DIFF
--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -278,6 +278,11 @@ static struct rcu_qp *get_hold_current_qp(struct rcu_lock_st *lock)
 
         ATOMIC_ADD_FETCH(&lock->qp_group[qp_idx].users, (uint64_t)1,
                          __ATOMIC_ACQUIRE);
+# ifdef __aarch64__
+        /* work around for broken AARCH64 atomics */
+        ATOMIC_LOAD_N(uint64_t, &lock->qp_group[qp_idx].users,
+                      __ATOMIC_ACQUIRE);
+# endif
 
         /* if the idx hasn't changed, we're good, else try again */
         if (qp_idx == ATOMIC_LOAD_N(uint32_t, &lock->reader_idx,


### PR DESCRIPTION
Avoid that by adding a second acquire barrier.

Fixes: #26875
