### PR TITLE
Fix a memory order issue with weakly ordered systems (yet another alternative)

### DIFF
--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -408,6 +408,13 @@ static struct rcu_qp *update_qp(CRYPTO_RCU_LOCK *lock, uint32_t *curr_id)
     ATOMIC_STORE_N(uint32_t, &lock->reader_idx, lock->current_alloc_idx,
                    __ATOMIC_RELAXED);
 
+    /*
+     * this should make sure that the new value of reader_idx is visible in
+     * get_hold_current_qp, directly after incrementing the users count
+     */
+    ATOMIC_ADD_FETCH(&lock->qp_group[current_idx].users, (uint64_t)0,
+                     __ATOMIC_RELEASE);
+
     /* wake up any waiters */
     pthread_cond_signal(&lock->alloc_signal);
     pthread_mutex_unlock(&lock->alloc_lock);


### PR DESCRIPTION
this adds a dummy atomic release operation to update_qp, which should make sure that the new value of reader_idx is visible in get_hold_current_qp, directly after incrementing the users count.

Fixes: #26875
