### PR TITLE
Fix RCU TODOs

### DIFF
--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -217,12 +217,11 @@ struct rcu_lock_st {
     /* The context we are being created against */
     OSSL_LIB_CTX *ctx;
 
-    /* rcu generation counter for in-order retirement */
-    uint32_t id_ctr;
-
-    /* TODO: can be moved before id_ctr for better alignment */
     /* Array of quiescent points for synchronization */
     struct rcu_qp *qp_group;
+
+    /* rcu generation counter for in-order retirement */
+    uint32_t id_ctr;
 
     /* Number of elements in qp_group array */
     uint32_t group_count;
@@ -422,10 +421,8 @@ static void retire_qp(CRYPTO_RCU_LOCK *lock, struct rcu_qp *qp)
     pthread_mutex_unlock(&lock->alloc_lock);
 }
 
-/* TODO: count should be unsigned, e.g uint32_t */
-/* a negative value could result in unexpected behaviour */
 static struct rcu_qp *allocate_new_qp_group(CRYPTO_RCU_LOCK *lock,
-                                            int count)
+                                            uint32_t count)
 {
     struct rcu_qp *new =
         OPENSSL_zalloc(sizeof(*new) * count);

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -83,12 +83,11 @@ struct rcu_lock_st {
     /* The context we are being created against */
     OSSL_LIB_CTX *ctx;
 
-    /* rcu generation counter for in-order retirement */
-    uint32_t id_ctr;
-
-    /* TODO: can be moved before id_ctr for better alignment */
     /* Array of quiescent points for synchronization */
     struct rcu_qp *qp_group;
+
+    /* rcu generation counter for in-order retirement */
+    uint32_t id_ctr;
 
     /* Number of elements in qp_group array */
     uint32_t group_count;
@@ -124,10 +123,8 @@ struct rcu_lock_st {
     CRYPTO_RWLOCK *rw_lock;
 };
 
-/* TODO: count should be unsigned, e.g uint32_t */
-/* a negative value could result in unexpected behaviour */
 static struct rcu_qp *allocate_new_qp_group(struct rcu_lock_st *lock,
-                                            int count)
+                                            uint32_t count)
 {
     struct rcu_qp *new =
         OPENSSL_zalloc(sizeof(*new) * count);


### PR DESCRIPTION
Fix RCU TODO's in master

- Ensure that any calls to `allocate_new_qp_group` check input before casting to uint32_t. Currently just `ossl_rcu_lock_new`
  - Documentation shouldn't need to be updated because not only does the API not change, but it also states that "The num_writers param... value must be at least 1": https://github.com/openssl/openssl/blob/master/doc/internal/man3/ossl_rcu_lock_new.pod#description
  - However, we can also consider updating `ossl_rcu_lock_new` to only take an unsigned int because it's an internal API
- Move id_ctr in rcu_lock_st for better stack alignment