### PR TITLE
fix ecdh and ffdh dangling pointer use in speed

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -546,6 +546,7 @@ typedef struct loopargs_st {
     EVP_PKEY_CTX *ecdsa_sign_ctx[ECDSA_NUM];
     EVP_PKEY_CTX *ecdsa_verify_ctx[ECDSA_NUM];
     EVP_PKEY_CTX *ecdh_ctx[EC_NUM];
+    EVP_PKEY *ecdh_keys[EC_NUM*2];
 #ifndef OPENSSL_NO_ECX
     EVP_MD_CTX *eddsa_ctx[EdDSA_NUM];
     EVP_MD_CTX *eddsa_ctx2[EdDSA_NUM];
@@ -3589,10 +3590,10 @@ int speed_main(int argc, char **argv)
             }
 
             loopargs[i].ecdh_ctx[testnum] = ctx;
+            loopargs[i].ecdh_keys[testnum*2] = key_A;
+            loopargs[i].ecdh_keys[testnum*2+1] = key_B;
             loopargs[i].outlen[testnum] = outlen;
 
-            EVP_PKEY_free(key_A);
-            EVP_PKEY_free(key_B);
             EVP_PKEY_CTX_free(test_ctx);
             test_ctx = NULL;
         }
@@ -4682,8 +4683,11 @@ int speed_main(int argc, char **argv)
             EVP_PKEY_CTX_free(loopargs[i].ecdsa_sign_ctx[k]);
             EVP_PKEY_CTX_free(loopargs[i].ecdsa_verify_ctx[k]);
         }
-        for (k = 0; k < EC_NUM; k++)
+        for (k = 0; k < EC_NUM; k++) {
             EVP_PKEY_CTX_free(loopargs[i].ecdh_ctx[k]);
+            EVP_PKEY_free(loopargs[i].ecdh_keys[k*2]);
+            EVP_PKEY_free(loopargs[i].ecdh_keys[k*2+1]);
+        }
 #ifndef OPENSSL_NO_ECX
         for (k = 0; k < EdDSA_NUM; k++) {
             EVP_MD_CTX_free(loopargs[i].eddsa_ctx[k]);

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -561,6 +561,7 @@ typedef struct loopargs_st {
     size_t outlen[EC_NUM];
 #ifndef OPENSSL_NO_DH
     EVP_PKEY_CTX *ffdh_ctx[FFDH_NUM];
+    EVP_PKEY *ffdh_keys[FFDH_NUM*2];
     unsigned char *secret_ff_a;
     unsigned char *secret_ff_b;
 #endif
@@ -4020,10 +4021,10 @@ int speed_main(int argc, char **argv)
             }
 
             loopargs[i].ffdh_ctx[testnum] = ffdh_ctx;
+            loopargs[i].ffdh_keys[testnum] = pkey_A;
+            loopargs[i].ffdh_keys[testnum + 1] = pkey_B;
 
-            EVP_PKEY_free(pkey_A);
             pkey_A = NULL;
-            EVP_PKEY_free(pkey_B);
             pkey_B = NULL;
             EVP_PKEY_CTX_free(test_ctx);
             test_ctx = NULL;
@@ -4670,8 +4671,12 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_DH
         OPENSSL_free(loopargs[i].secret_ff_a);
         OPENSSL_free(loopargs[i].secret_ff_b);
-        for (k = 0; k < FFDH_NUM; k++)
+        for (k = 0; k < FFDH_NUM; k++) {
             EVP_PKEY_CTX_free(loopargs[i].ffdh_ctx[k]);
+            EVP_PKEY_free(loopargs[i].ffdh_keys[k*2]);
+            EVP_PKEY_free(loopargs[i].ffdh_keys[k*2+1]);
+        }
+
 #endif
 #ifndef OPENSSL_NO_DSA
         for (k = 0; k < DSA_NUM; k++) {


### PR DESCRIPTION
In `speed`, for both `echd` and `ffdh` tests, we create two keys and a context and then frees the keys before running the benchmark. This works for the default openssl provider, but for a provider that does no refcounting or anything, this means that during the benchmark, the context uses keys that have been freed, causing a use after free (usually a seg fault). We have reproed this on Azure Linux 3 with the SymCrypt provider.

I've fixed this by freeing them at the same time as we free the contexts.