### PR TITLE
demos: In FIPS mode, pbkdf2 key derivation does not appear to use consistent indicators

### DIFF
--- a/demos/kdf/pbkdf2.c
+++ b/demos/kdf/pbkdf2.c
@@ -8,6 +8,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 #include <openssl/core_names.h>
 #include <openssl/crypto.h>
 #include <openssl/kdf.h>
@@ -71,7 +72,7 @@ int main(int argc, char **argv)
     EVP_KDF *kdf = NULL;
     EVP_KDF_CTX *kctx = NULL;
     unsigned char out[64];
-    OSSL_PARAM params[5], *p = params;
+    OSSL_PARAM params[6], *p = params;
 
     /* Check if we are in FIPS mode */
     if (EVP_default_properties_is_fips_enabled(NULL)) {
@@ -109,6 +110,12 @@ int main(int argc, char **argv)
     /* Set the underlying hash function used to derive the key */
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
                                             "SHA256", 0);
+
+    int pkcs5 = 0;
+    if (argc>1 && strcmp(argv[1],"1")==0)
+        pkcs5 = 1;
+    printf("Testing with pkcs5 set to %i\n", pkcs5);
+    *p++ = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_PKCS5, &pkcs5);
     *p = OSSL_PARAM_construct_end();
 
     /* Derive the key */
@@ -122,7 +129,7 @@ int main(int argc, char **argv)
     if (CRYPTO_memcmp(expected_output, out, sizeof(expected_output)) != 0) {
         fprintf(stderr, "Generated key does not match expected value as expected\n");
     } else {
-        fprintf(stderr, "Generated key matches.... but should have failed to generate\n");
+        fprintf(stderr, "Generated key matches.... but should have failed to generate, unless unapproved\n");
     }
     
     /* Get FIPS indicator */

--- a/test/fips-and-base.cnf
+++ b/test/fips-and-base.cnf
@@ -9,7 +9,7 @@ config_diagnostics = 1
 providers = provider_sect
 # You MUST uncomment the following line to operate in a FIPS approved manner,
 # It is commented out here purely for testing purposes.
-#alg_section = evp_properties
+alg_section = evp_properties
 
 [evp_properties]
 default_properties = "fips=yes"


### PR DESCRIPTION
Coding as per documentation at https://docs.openssl.org/master/man7/EVP_KDF-PBKDF2/#supported-parameters

Setting very low value for interations count.
Unapproved indicator does not fire; and fips-approved remains at 1.

It appears as if in fips mode nothing is enforced w.r.t. pbkdf2.

Are there bugs in the documentation, or my code implementing it, or in the fips provider?

```
./Configure enable-fips
make -j`nproc`
make -C demos/kdf/
sed 's/#alg_section/alg_section/' -i test/fips-and-base.cnf

$ ./util/wrap.pl -fips ./demos/kdf/pbkdf2 0
FIPS is on
Testing with pkcs5 set to 0
EVP_KDF_derive() failed, as expected
Generated key does not match expected value as expected
Service indicator for OSSL_KDF_PARAM_FIPS_APPROVED_INDICATOR is: 1

$ ./util/wrap.pl -fips ./demos/kdf/pbkdf2 1
FIPS is on
Testing with pkcs5 set to 1
FIPS INDICATOR: PBKDF2 : Salt size is not approved
EVP_KDF_derive() failed, as expected
Generated key does not match expected value as expected
Service indicator for OSSL_KDF_PARAM_FIPS_APPROVED_INDICATOR is: 0
```