### PR TITLE
test: skip tlsfuzzer tests pkcs11-provider test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -678,9 +678,8 @@ jobs:
         ./util/opensslwrap.sh version -c
     - name: test external oqs-provider
       run: make test TESTS="test_external_oqsprovider"
-    # Disabled temporarily: https://github.com/latchset/pkcs11-provider/pull/525#discussion_r1982805969
-    # - name: test external pkcs11-provider
-    #   run: make test TESTS="test_external_pkcs11_provider" VERBOSE=1
+    - name: test external pkcs11-provider
+      run: make test TESTS="test_external_pkcs11_provider" VERBOSE=1
 
   external-tests-pyca:
     runs-on: ubuntu-latest

--- a/test/recipes/95-test_external_pkcs11_provider_data/pkcs11-provider.sh
+++ b/test/recipes/95-test_external_pkcs11_provider_data/pkcs11-provider.sh
@@ -44,6 +44,7 @@ echo "   OPENSSL_ROOT_DIR:   $OPENSSL_ROOT_DIR"
 echo "   OpenSSL version:    $OPENSSL_VERSION"
 echo "------------------------------------------------------------------"
 
+PKCS11_PROVIDER_SRCDIR=$OPENSSL_ROOT_DIR/pkcs11-provider/
 PKCS11_PROVIDER_BUILDDIR=$OPENSSL_ROOT_DIR/pkcs11-provider/builddir
 
 echo "------------------------------------------------------------------"
@@ -52,6 +53,11 @@ echo "------------------------------------------------------------------"
 
 PKG_CONFIG_PATH="$BLDTOP" meson setup $PKCS11_PROVIDER_BUILDDIR $OPENSSL_ROOT_DIR/pkcs11-provider/ || exit 1
 meson compile -C $PKCS11_PROVIDER_BUILDDIR pkcs11 || exit 1
+
+# Remove pkcs11-provider tlsfuzzer submodule tlsfuzzer directory to skip tlsfuzzer tests
+if [ -d "${PKCS11_PROVIDER_SRCDIR}/tlsfuzzer/tlsfuzzer" ]; then
+    rm -rf "${PKCS11_PROVIDER_SRCDIR}/tlsfuzzer/tlsfuzzer"
+fi
 
 echo "------------------------------------------------------------------"
 echo "Running tests"


### PR DESCRIPTION
Tlsfuzzer tests in pkcs11-provider external test currently uses hard-coded lists of TLS 1.3 signature algorithms expected from openssl. However, openssl neither promises a fixed default set of the signature algorithms nor promises a fixed default ordering ofthese algorithms and hence test might fail eventually even though there is nothing wrong anywhere.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist

N/A