### PR TITLE
NULL Pointer Dereference in `int ASN1_item_ex_i2d()`, `crypto/asn1/tasn_enc.c`

### DIFF
--- a/crypto/asn1/tasn_enc.c
+++ b/crypto/asn1/tasn_enc.c
@@ -141,10 +141,12 @@ int ASN1_item_ex_i2d(const ASN1_VALUE **pval, unsigned char **out,
     case ASN1_ITYPE_EXTERN:
         /* If new style i2d it does all the work */
         ef = it->funcs;
-        if(ef)
-            return ef->asn1_ex_i2d(pval, out, it, tag, aclass);
-        else
-            return 0;
+        if(!ef)
+        {
+            ERR_raise(ERR_LIB_ASN1, ASN1_R_BAD_TEMPLATE);
+            return -1;
+        }
+        return ef->asn1_ex_i2d(pval, out, it, tag, aclass);
 
     case ASN1_ITYPE_NDEF_SEQUENCE:
         /* Use indefinite length constructed if requested */

--- a/crypto/asn1/tasn_enc.c
+++ b/crypto/asn1/tasn_enc.c
@@ -141,7 +141,10 @@ int ASN1_item_ex_i2d(const ASN1_VALUE **pval, unsigned char **out,
     case ASN1_ITYPE_EXTERN:
         /* If new style i2d it does all the work */
         ef = it->funcs;
-        return ef->asn1_ex_i2d(pval, out, it, tag, aclass);
+        if(ef)
+            return ef->asn1_ex_i2d(pval, out, it, tag, aclass);
+        else
+            return 0;
 
     case ASN1_ITYPE_NDEF_SEQUENCE:
         /* Use indefinite length constructed if requested */


### PR DESCRIPTION
The NULL Dereference vulnerability happens in  ` int ASN1_item_ex_i2d()`, `crypto/asn1/tasn_enc.c`
How the NULL Pointer Dereference happens:
1. When the following conditions are met: `aux == NULL`, The value of aux is obtained from `it->funcs`：`const ASN1_AUX *aux = it->funcs;`
2. `ef` is set to NULL at `ef = it->funcs;`
3. Dereference of NULL variable `ef->asn1_ex_i2d` in `return ef->asn1_ex_i2d(pval, out, it, tag, aclass);`
```
int ASN1_item_ex_i2d(const ASN1_VALUE **pval, unsigned char **out,
                     const ASN1_ITEM *it, int tag, int aclass)
{
    const ASN1_TEMPLATE *tt = NULL;
    int i, seqcontlen, seqlen, ndef = 1;
    const ASN1_EXTERN_FUNCS *ef;
=>  const ASN1_AUX *aux = it->funcs;
    ASN1_aux_const_cb *asn1_cb = NULL;

    if ((it->itype != ASN1_ITYPE_PRIMITIVE) && *pval == NULL)
        return 0;

=>  if (aux != NULL) {
        asn1_cb = ((aux->flags & ASN1_AFLG_CONST_CB) != 0) ? aux->asn1_const_cb
            : (ASN1_aux_const_cb *)aux->asn1_cb; /* backward compatibility */
    }

    switch (it->itype) {

        ......

=>      case ASN1_ITYPE_EXTERN:
            /* If new style i2d it does all the work */
=>          ef = it->funcs;
=>          return ef->asn1_ex_i2d(pval, out, it, tag, aclass);
    
        ......
    }
    ......
    return 0;
}
```

