### PR TITLE
Make group names case-insensitive

### DIFF
--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -164,7 +164,7 @@ registry.
 For some groups, OpenSSL supports additional aliases.
 Such an alias could be a B<NIST> name (e.g. B<P-256>), an OpenSSL OID name
 (e.g. B<prime256v1>), or some other commonly used name.
-Group names are case sensitive.
+Group names are case-insensitive in OpenSSL 3.5 and later.
 The list should be in order of preference with the most preferred group first.
 
 The first group listed will also be used for the B<key_share> sent by a client
@@ -200,8 +200,17 @@ This is a synonym for the B<-groups> command.
 
 =item B<-named_curve> I<curve>
 
-This sets the temporary curve used for ephemeral ECDH modes. Only used
-by servers.
+This sets the temporary curve used for ephemeral ECDH modes.
+This is only applicable in TLS 1.0 and 1.1, and should not be used with later
+protocol versions.
+
+The I<curve> argument is a curve name or the special value B<auto> which
+picks an appropriate curve based on client and server preferences. The
+curve can be either the B<NIST> name (e.g. B<P-256>) or an OpenSSL OID name
+(e.g. B<prime256v1>).
+Even with TLS 1.0 and 1.1, the default value of C<auto> is strongly recommended
+over choosing a specific curve.
+Curve names are case-insensitive in OpenSSL 3.5 and later.
 
 =item B<-tx_cert_comp>
 
@@ -220,11 +229,6 @@ Enables support for receiving TLSv1.3 compressed certificates.
 Disables support for receiving TLSv1.3 compressed certificates.
 
 =item B<-comp>
-
-The B<groups> argument is a curve name or the special value B<auto> which
-picks an appropriate curve based on client and server preferences. The
-curve can be either the B<NIST> name (e.g. B<P-256>) or an OpenSSL OID name
-(e.g. B<prime256v1>). Curve names are case sensitive.
 
 =item B<-cipher> I<ciphers>
 
@@ -461,7 +465,7 @@ registry.
 For some groups, OpenSSL supports additional aliases.
 Such an alias could be a B<NIST> name (e.g. B<P-256>), an OpenSSL OID name
 (e.g. B<prime256v1>), or some other commonly used name.
-Group names are case sensitive.
+Group names are case-insensitive in OpenSSL 3.5 and later.
 The list should be in order of preference with the most preferred group first.
 
 The commands below list the available groups for TLS 1.2 and TLS 1.3,
@@ -860,8 +864,8 @@ B<MLKEM512>, B<MLKEM768> and B<MLKEM1024> TLS groups.
 These are based on the underlying B<ML-KEM-512>, B<ML-KEM-768> and
 B<ML-KEM-1024> algorithms from FIPS 203.
 
-OpenSSL 3.5 also introduces support for three I<hybrid> ECDH PQ key exchange
-TLS I<groups>: B<X25519MLKEM768>, B<SecP256r1MLKEM768> and
+OpenSSL 3.5 also introduces support for three B<hybrid> ECDH PQ key exchange
+TLS groups: B<X25519MLKEM768>, B<SecP256r1MLKEM768> and
 B<SecP384r1MLKEM1024>.
 They offer CPU performance comparable to the associated ECDH group, though at
 the cost of significantly larger key exchange messages.
@@ -870,6 +874,8 @@ largely as a result of the high CPU cost of ECDH for the underlying B<P-384>
 group.
 Also its key exchange messages at close to 1700 bytes are larger than the
 roughly 1200 bytes for the first two groups.
+
+As of OpenSSL 3.5 key exchange group names are case-insensitive.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set1_curves.pod
+++ b/doc/man3/SSL_CTX_set1_curves.pod
@@ -96,8 +96,10 @@ respectively:
 
 Each group can be either the B<NIST> name (e.g. B<P-256>), some other commonly
 used name where applicable (e.g. B<X25519>, B<ffdhe2048>) or an OpenSSL OID name
-(e.g. B<prime256v1>). Group names are case sensitive. The preferred group names
-are those defined by IANA for TLS parameters.
+(e.g. B<prime256v1>).
+Group names are case-insensitive in OpenSSL 3.5 and later.
+The preferred group names are those defined by
+L<IANA|https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8>.
 
 The I<list> can be used to define several group tuples of comparable security
 levels, and can specify which key shares should be sent by a client.
@@ -324,6 +326,19 @@ Support for ignoring unknown groups in SSL_CTX_set1_groups_list() and
 SSL_set1_groups_list() was added in OpenSSL 3.3.
 
 Support for B<ML-KEM> was added in OpenSSL 3.5.
+
+OpenSSL 3.5 also introduces support for three I<hybrid> ECDH PQ key exchange
+TLS groups: B<X25519MLKEM768>, B<SecP256r1MLKEM768> and
+B<SecP384r1MLKEM1024>.
+They offer CPU performance comparable to the associated ECDH group, though at
+the cost of significantly larger key exchange messages.
+The third group, B<SecP384r1MLKEM1024> is substantially more CPU-intensive,
+largely as a result of the high CPU cost of ECDH for the underlying B<P-384>
+group.
+Also its key exchange messages at close to 1700 bytes are larger than the
+roughly 1200 bytes for the first two groups.
+
+As of OpenSSL 3.5 key exchange group names are case-insensitive.
 
 B<SSL_CTX_get0_implemented_groups> was first implemented in OpenSSL 3.5.
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -686,8 +686,8 @@ static uint16_t tls1_group_name2id(SSL_CTX *ctx, const char *name)
     size_t i;
 
     for (i = 0; i < ctx->group_list_len; i++) {
-        if (strcmp(ctx->group_list[i].tlsname, name) == 0
-                || strcmp(ctx->group_list[i].realname, name) == 0)
+        if (OPENSSL_strcasecmp(ctx->group_list[i].tlsname, name) == 0
+                || OPENSSL_strcasecmp(ctx->group_list[i].realname, name) == 0)
             return ctx->group_list[i].group_id;
     }
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1401,7 +1401,7 @@ static int gid_cb(const char *elem, int len, void *arg)
     if (gid == 0) {
         /* Is it one of the GOST groups ? */
         for (i = 0; i < OSSL_NELEM(name2id_arr); i++) {
-            if (strcmp(etmp, name2id_arr[i].group_name) == 0) {
+            if (OPENSSL_strcasecmp(etmp, name2id_arr[i].group_name) == 0) {
                 gid = name2id_arr[i].groupID;
                 break;
             }


### PR DESCRIPTION
Group names should not be case-sensitive.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
