### PR TITLE
avoid use-after-free from disparate qrx'es in port_default_packet_handler

### DIFF
--- a/include/internal/quic_record_rx.h
+++ b/include/internal/quic_record_rx.h
@@ -259,6 +259,12 @@ int ossl_qrx_read_pkt(OSSL_QRX *qrx, OSSL_QRX_PKT **pkt);
  */
 void ossl_qrx_pkt_release(OSSL_QRX_PKT *pkt);
 
+/*
+ * Like ossl_qrx_pkt_release, but just ensures that the refcount is dropped
+ * on this qrx_pkt, and ensure its not on any list
+ */
+void ossl_qrx_pkt_orphan(OSSL_QRX_PKT *pkt);
+
 /* Increments the reference count for the given packet. */
 void ossl_qrx_pkt_up_ref(OSSL_QRX_PKT *pkt);
 

--- a/test/quic-openssl-docker/hq-interop/quic-hq-interop.c
+++ b/test/quic-openssl-docker/hq-interop/quic-hq-interop.c
@@ -825,6 +825,9 @@ end:
     SSL_CTX_free(*ctx);
     SSL_free(*ssl);
     BIO_ADDR_free(peer_addr);
+    *ctx = NULL;
+    *ssl = NULL;
+    peer_addr = NULL;
     return 0;
 }
 


### PR DESCRIPTION
It may occur that the qrx we allocate in port_default_packet handler to
    do AEAD validation isn't the one the channel ultimately uses (like if we
    turn off address validation).  In that event, we need to ensure that
    anything we have on that qrx isn't returned to its free list to avoid
    early freeing when we free the qrx at the end of
    port_default_packet_handler, while those frames are still pending on the
    channel qrx


