### PR TITLE
docs: update OSSL_PARAM documentation

### DIFF
--- a/doc/man3/OSSL_PARAM.pod
+++ b/doc/man3/OSSL_PARAM.pod
@@ -354,6 +354,45 @@ could fill in the parameters like this:
         /* Ignore stuff we don't know */
     }
 
+=head3 Example 3
+
+This example shows a special case where I<-Wincompatible-pointer-types-discards-qualifiers> may be set during compilation, where the above examples may cause compilation warnings or errors. Specifically, the value for I<data> cannot be a I<const char*>. 
+
+For example, this code:
+
+    OSSL_PARAM params[2]
+    EVP_MAC *mac;
+
+    EVP_MAC *mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
+    *ctx = EVP_MAC_CTX_new(mac);
+    if (*ctx == NULL)
+        return -1;
+    EVP_MAC_free(mac);
+    params[0] = OSSL_PARAM_construct_utf8_string("digest", "SHA1", 0);
+    params[1] = OSSL_PARAM_construct_end();
+
+    EVP_MAC_init(*ctx, key, key_len, params);
+
+    /* More code followed */
+
+Can be made compatible with the following version:
+
+    EVP_MAC *mac;
+
+    char sha1[] = "SHA1";
+    OSSL_PARAM params[] = {
+        OSSL_PARAM_utf8_string("digest", sha1, sizeof(sha1) - 1),
+        OSSL_PARAM_END
+    };
+
+    mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
+    *ctx = EVP_MAC_CTX_new(mac);
+    EVP_MAC_free(mac);
+    if (*ctx == NULL)
+        return -1;
+
+    /* More code followed */
+
 =head1 SEE ALSO
 
 L<openssl-core.h(7)>, L<OSSL_PARAM_get_int(3)>, L<OSSL_PARAM_dup(3)>


### PR DESCRIPTION
Fixes 20956 in openssl. Also going to revise this in the coming days before going upstream with it

Will need to sign a CLA most likely for this

@bbbrumley 
@Fir3grip