### PR TITLE
Exclude retry test with msquic server from interop

### DIFF
--- a/.github/workflows/run_quic_interop.yml
+++ b/.github/workflows/run_quic_interop.yml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         tests: [http3, transfer, handshake, retry, chacha20, resumption, multiplexing, ipv6]
         servers: [quic-go, ngtcp2, mvfst, quiche, nginx, msquic, haproxy]
+        exclude:
+          - clients: msquic
+            tests: retry
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -39,7 +42,7 @@ jobs:
     strategy:
       matrix:
         tests: [http3, transfer, handshake, retry, chacha20, resumption, amplificationlimit, ipv6]
-        clients: [quic-go, ngtcp2, mvfst, quiche, msquic, openssl]
+        clients: [quic-go, ngtcp2, mvfst, quiche, msquic, openssl, chrome]
         exclude:
           - clients: mvfst
             tests: amplificationlimit


### PR DESCRIPTION
With the addition of larger ml-kem keys in our tls handshake, we've uncovered a interop failure, as described here:
https://github.com/microsoft/msquic/issues/4905

In short, when we send a client hello that spans multiple datagrams, the servers sends an ACK frame in a datagram prior to sending its server hello.  msquic however, recomputes a new SCID always when sending its server hello, which is fine nominally, but because in this test the server sends a retry frame to update the SCID, followed by an ACK using that SCID (which is an initial packet), msquic violates the RFC in section 7.2 which states:

Once a client has received a valid Initial packet from the server, it MUST discard any subsequent packet it receives on that connection with a different Source Connection ID

Because msquic sent an initial packet with that ACK frame, we are required to discard subsequent frames on the connection containing a different SCID.

Until msquic fixes that in their implementation we are going to fail the retry interop test with msquic as a server, so for now, lets exclude the test.

Also, while we're at it, re-add chrome into the client list for our server tests, as that seems to have been lost during the merge.

Fixes openssl/project#1132



##### Checklist
- [x] tests are added or updated
