### PR TITLE
Fix: Reject empty Subject Key Identifier (RFC 5280 Compliance)

### DIFF
--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -590,7 +590,7 @@ int ossl_x509v3_cache_extensions(X509 *x)
         x->ex_flags |= EXFLAG_INVALID;
     if (x->skid == NULL && i != -1)
         x->ex_flags |= EXFLAG_INVALID;
-  
+
     x->akid = X509_get_ext_d2i(x, NID_authority_key_identifier, &i, NULL);
     if (x->akid == NULL && i != -1)
         x->ex_flags |= EXFLAG_INVALID;

--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -585,15 +585,11 @@ int ossl_x509v3_cache_extensions(X509 *x)
     }
 
     /* Handle subject key identifier and issuer/authority key identifier */
-  
-	
-
     x->skid = X509_get_ext_d2i(x, NID_subject_key_identifier, &i, NULL);
-
-    if (x->skid == NULL || ASN1_STRING_length(x->skid) == 0) {
-    	ERR_raise(ERR_LIB_X509V3, X509V3_R_INVALID_EXTENSION_STRING);
-    	x->ex_flags |= EXFLAG_INVALID;
-    }
+    if (ASN1_STRING_length(x->skid) == 0) /* Reject "Subject Key Identifier" extension with an empty value */
+        x->ex_flags |= EXFLAG_INVALID;
+    if (x->skid == NULL && i != -1)
+        x->ex_flags |= EXFLAG_INVALID;
     x->akid = X509_get_ext_d2i(x, NID_authority_key_identifier, &i, NULL);
     if (x->akid == NULL && i != -1)
         x->ex_flags |= EXFLAG_INVALID;
@@ -1107,7 +1103,6 @@ uint32_t X509_get_extended_key_usage(X509 *x)
 const ASN1_OCTET_STRING *X509_get0_subject_key_id(X509 *x)
 {   
     /* Call for side-effect of computing hash and caching extensions */
-   
     if (X509_check_purpose(x, -1, 0) != 1)
         return NULL;
     return x->skid;

--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -585,10 +585,15 @@ int ossl_x509v3_cache_extensions(X509 *x)
     }
 
     /* Handle subject key identifier and issuer/authority key identifier */
-    x->skid = X509_get_ext_d2i(x, NID_subject_key_identifier, &i, NULL);
-    if (x->skid == NULL && i != -1)
-        x->ex_flags |= EXFLAG_INVALID;
+  
+	
 
+    x->skid = X509_get_ext_d2i(x, NID_subject_key_identifier, &i, NULL);
+
+    if (x->skid == NULL || ASN1_STRING_length(x->skid) == 0) {
+    	ERR_raise(ERR_LIB_X509V3, X509V3_R_INVALID_EXTENSION_STRING);
+    	x->ex_flags |= EXFLAG_INVALID;
+    }
     x->akid = X509_get_ext_d2i(x, NID_authority_key_identifier, &i, NULL);
     if (x->akid == NULL && i != -1)
         x->ex_flags |= EXFLAG_INVALID;
@@ -1100,8 +1105,9 @@ uint32_t X509_get_extended_key_usage(X509 *x)
 }
 
 const ASN1_OCTET_STRING *X509_get0_subject_key_id(X509 *x)
-{
+{   
     /* Call for side-effect of computing hash and caching extensions */
+   
     if (X509_check_purpose(x, -1, 0) != 1)
         return NULL;
     return x->skid;

--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -590,6 +590,7 @@ int ossl_x509v3_cache_extensions(X509 *x)
         x->ex_flags |= EXFLAG_INVALID;
     if (x->skid == NULL && i != -1)
         x->ex_flags |= EXFLAG_INVALID;
+  
     x->akid = X509_get_ext_d2i(x, NID_authority_key_identifier, &i, NULL);
     if (x->akid == NULL && i != -1)
         x->ex_flags |= EXFLAG_INVALID;

--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -1101,7 +1101,7 @@ uint32_t X509_get_extended_key_usage(X509 *x)
 }
 
 const ASN1_OCTET_STRING *X509_get0_subject_key_id(X509 *x)
-{   
+{
     /* Call for side-effect of computing hash and caching extensions */
     if (X509_check_purpose(x, -1, 0) != 1)
         return NULL;


### PR DESCRIPTION
Fixes #26088 
Summary

RFC 5280 requires the Subject Key Identifier (SKI) to be non-empty, but OpenSSL was allowing empty SKIs. This PR fixes the issue by rejecting certificates with an empty SKI.
Changes

    Added a check in ossl_x509v3_cache_extensions() to validate SKI.
    If SKI is missing or empty, OpenSSL raises an error and marks the cert as invalid.

Testing & Verification

    Used the same certificate from the issue (Cert1732784126935D1.pem).
    Ran openssl verify Cert1732784126935D1.pem and confirmed OpenSSL now rejects empty SKIs as expected.