### PR TITLE
Remove workaround for an old ppc64le compiler bug

### DIFF
--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -103,10 +103,7 @@ jobs:
           }, {
             arch: powerpc64le-linux-gnu,
             libs: libc6-dev-ppc64el-cross,
-            # The default compiler for this platform on Ubuntu 20.04 seems
-            # buggy and causes test failures. Dropping the optimisation level
-            # resolves it.
-            target: -O2 linux-ppc64le,
+            target: linux-ppc64le,
             fips: no
           }, {
             arch: riscv64-linux-gnu,


### PR DESCRIPTION
Lowering the optimization level is no longer needed, since the old compiler bug from ubuntu-20.04 has been fixed meanwhile.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
