### PR TITLE
Add main languages in use to OSSL guide introduction

### DIFF
--- a/doc/man7/ossl-guide-introduction.pod
+++ b/doc/man7/ossl-guide-introduction.pod
@@ -17,7 +17,7 @@ Finally, it also has a set of providers that supply implementations of a broad
 set of cryptographic algorithms.
 
 OpenSSL is fully open source. Version 3.0 and above are distributed under the
-Apache v2 license.
+Apache v2 license. The codebase is mostly in C, C++, and Perl.
 
 =head1 GETTING AND INSTALLING OPENSSL
 


### PR DESCRIPTION
I appreciate this overview.

I came to the overview from https://openssl-foundation.org/get-involved/ , which said "Read the [OpenSSL Guide](https://docs.openssl.org/3.2/man7/ossl-guide-introduction/) for a technical overview of the OpenSSL library." Given that context, I believe it's reasonable for the guide to mention which languages the codebase is written in.

CLA: trivial