### PR TITLE
fix potential null pointer dereference in cms_main function in apps/cms.c #26941

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -1299,7 +1299,7 @@ int cms_main(int argc, char **argv)
             if (kparam != NULL) {
                 EVP_PKEY_CTX *pctx = CMS_SignerInfo_get0_pkey_ctx(si);
 
-                if (!cms_set_pkey_param(pctx, kparam->param))
+                if (pctx == NULL || !cms_set_pkey_param(pctx, kparam->param))
                     goto end;
             }
             if (rr != NULL && !CMS_add1_ReceiptRequest(si, rr)) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
How the Null Pointer Derefrence Happens: 
in the cms_main function in the apps/cms.c file
At lines 1013-1015, the following code snippet is present:
pctx = CMS_RecipientInfo_get0_pkey_ctx(ri); if (kparam != NULL) { if (!cms_set_pkey_param(pctx, kparam->param))

The assignment pctx = CMS_RecipientInfo_get0_pkey_ctx(ri); suggests that pctx might be NULL. However, in the subsequent call chain:
(!cms_set_pkey_param(pctx, kparam->param))
-> pkey_ctrl_string(pctx, keyopt)
-> rv = EVP_PKEY_CTX_ctrl_str(ctx, stmp, vtmp)
-> ret = evp_pkey_ctx_store_cached_data(ctx, -1, -1, -1, name, value, strlen(value) + 1)
-> evp_pkey_ctx_state(ctx)

There are dereference operations involving pctx, which may pose a potential risk if pctx is NULL. So I add a null check:
`if (pctx && !cms_set_pkey_param(pctx, kparam->param))
`
