### PR TITLE
Reject empty SKID when signing

### DIFF
--- a/crypto/x509/v3_skid.c
+++ b/crypto/x509/v3_skid.c
@@ -116,7 +116,5 @@ static ASN1_OCTET_STRING *s2i_skey_id(X509V3_EXT_METHOD *method,
         return NULL;  // Prevent signing if SKID is empty
     }
 
-    return ossl_x509_pubkey_hash(ctx->subject_cert != NULL ?
-                                 ctx->subject_cert->cert_info.key :
-                                 ctx->subject_req->req_info.pubkey);
+    return skid;
 }

--- a/crypto/x509/v3_skid.c
+++ b/crypto/x509/v3_skid.c
@@ -104,6 +104,11 @@ static ASN1_OCTET_STRING *s2i_skey_id(X509V3_EXT_METHOD *method,
         ERR_raise(ERR_LIB_X509V3, X509V3_R_NO_SUBJECT_DETAILS);
         return NULL;
     }
+   if (skid == NULL || skid->length == 0) {
+        ERR_raise(ERR_LIB_X509V3, X509V3_R_INVALID_KEY_IDENTIFIER);
+        ASN1_OCTET_STRING_free(skid);
+        return NULL;  // Prevent signing if SKID is empty
+    }
 
     return ossl_x509_pubkey_hash(ctx->subject_cert != NULL ?
                                  ctx->subject_cert->cert_info.key :

--- a/crypto/x509/v3_skid.c
+++ b/crypto/x509/v3_skid.c
@@ -91,6 +91,7 @@ ASN1_OCTET_STRING *ossl_x509_pubkey_hash(X509_PUBKEY *pubkey)
 static ASN1_OCTET_STRING *s2i_skey_id(X509V3_EXT_METHOD *method,
                                       X509V3_CTX *ctx, char *str)
 {
+    ASN1_OCTET_STRING *skid = NULL;
     if (strcmp(str, "none") == 0)
         return ASN1_OCTET_STRING_new(); /* dummy */
 
@@ -104,6 +105,11 @@ static ASN1_OCTET_STRING *s2i_skey_id(X509V3_EXT_METHOD *method,
         ERR_raise(ERR_LIB_X509V3, X509V3_R_NO_SUBJECT_DETAILS);
         return NULL;
     }
+
+   skid = ossl_x509_pubkey_hash(ctx->subject_cert != NULL ?
+                                 ctx->subject_cert->cert_info.key :
+                                 ctx->subject_req->req_info.pubkey);
+
    if (skid == NULL || skid->length == 0) {
         ERR_raise(ERR_LIB_X509V3, X509V3_R_INVALID_KEY_IDENTIFIER);
         ASN1_OCTET_STRING_free(skid);


### PR DESCRIPTION
This PR implements the recommendation (validating the SKID extension when signing certificates ) in the discussion of the previous PR #27023 .
It ensures that SKID is not empty when signing certificates, as suggested in the discussion.
Please let me know if any further refinements are needed. Looking forward to your review. 
