### PR TITLE
Added NULL pointer checks

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -1011,7 +1011,7 @@ int cms_main(int argc, char **argv)
                 goto end;
 
             pctx = CMS_RecipientInfo_get0_pkey_ctx(ri);
-            if (kparam != NULL) {
+            if (pctx != NULL && kparam != NULL) {
                 if (!cms_set_pkey_param(pctx, kparam->param))
                     goto end;
             }

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -1049,6 +1049,10 @@ static void make_ocsp_response(BIO *err, OCSP_RESPONSE **resp, OCSP_REQUEST *req
     }
 
     bs = OCSP_BASICRESP_new();
+    if (bs == NULL) {
+        *resp = OCSP_response_create(OCSP_RESPONSE_STATUS_INTERNALERROR, bs);
+        goto end;
+    }
     thisupd = X509_gmtime_adj(NULL, 0);
     if (ndays != -1)
         nextupd = X509_time_adj_ex(NULL, ndays, nmin * 60, NULL);


### PR DESCRIPTION
Fixes #26941

Added NULL pointer checks in cms_main() and make_ocsp_response() functions. Without these checks, potential null pointer dereference could occur in subsequent function calls.