### PR TITLE
[draft] to check for fallout [issue.27054]

### DIFF
--- a/crypto/aes/asm/aesni-sha1-x86_64.pl
+++ b/crypto/aes/asm/aesni-sha1-x86_64.pl
@@ -125,25 +125,25 @@ $use_tool_asm=0;
 #
 # clang 9 or newer
 #
-$use_tool_asm=1 if (!$use_tool_aesni && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0-9]+\.[0-9]+)/ && $2>=9.0);
+$use_tool_asm=1 if (!$use_tool_asm && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0-9]+\.[0-9]+)/ && $2>=9.0);
 
 #
 # GNU assembler 2.30 or newer
 #
-$use_tool_asm=1 if (!$use_tool_aesni && `$ENV{CC} -Wa,-v -c -o /dev/null -x assembler /dev/null 2>&1`
+$use_tool_asm=1 if (!$use_tool_asm && `$ENV{CC} -Wa,-v -c -o /dev/null -x assembler /dev/null 2>&1`
 		=~ /GNU assembler version ([2-9]\.[0-9]+)/ &&
 	   $1>=2.30);
 #
 # masm version 14 or higher. The version is bundled with Visual Studio 2019
 #
-$use_tool_asm=1 if (!$use_tool_aesni && $win64 && ($flavour =~ /masm/ || $ENV{ASM} =~ /ml64/) &&
+$use_tool_asm=1 if (!$use_tool_asm && $win64 && ($flavour =~ /masm/ || $ENV{ASM} =~ /ml64/) &&
 	   `ml64 2>&1` =~ /Version ([0-9]+)\./ &&
 	   $1>=14);
 
 #
 # netwide assembler 2.15 or newer (2.15 is since 2020)
 #
-$use_tool_asm=1 if (!$use_tool_aesni && $win64 && ($flavour =~ /nasm/ || $ENV{ASM} =~ /nasm/) &&
+$use_tool_asm=1 if (!$use_tool_asm && $win64 && ($flavour =~ /nasm/ || $ENV{ASM} =~ /nasm/) &&
 	   `nasm -v 2>&1` =~ /NASM version ([2-9]\.[0-9]+)/ &&
 	   $1>=2.15);
 

--- a/crypto/aes/asm/aesni-sha1-x86_64.pl
+++ b/crypto/aes/asm/aesni-sha1-x86_64.pl
@@ -2120,30 +2120,11 @@ sub sha1op38 {
     }
 }
 
-sub aesni {
-  my $line=shift;
-  my @opcode=(0x0f,0x38);
-
-    if ($line=~/(aes[a-z]+)\s+%xmm([0-9]+),\s*%xmm([0-9]+)/) {
-	my %opcodelet = (
-		"aesenc" => 0xdc,	"aesenclast" => 0xdd,
-		"aesdec" => 0xde,	"aesdeclast" => 0xdf
-	);
-	return undef if (!defined($opcodelet{$1}));
-	rex(\@opcode,$3,$2);
-	push @opcode,$opcodelet{$1},0xc0|($2&7)|(($3&7)<<3);	# ModR/M
-	unshift @opcode,0x66;
-	return ".byte\t".join(',',@opcode);
-    }
-    return $line;
-}
-
 foreach (split("\n",$code)) {
         s/\`([^\`]*)\`/eval $1/geo;
 
 	s/\b(sha1rnds4)\s+(.*)/sha1rnds4($2)/geo		or
-	s/\b(sha1[^\s]*)\s+(.*)/sha1op38($1,$2)/geo		or
-	s/\b(aes.*%xmm[0-9]+).*$/aesni($1)/geo;
+	s/\b(sha1[^\s]*)\s+(.*)/sha1op38($1,$2)/geo;
 
 	print $_,"\n";
 }

--- a/crypto/ec/asm/ecp_nistz256-x86_64.pl
+++ b/crypto/ec/asm/ecp_nistz256-x86_64.pl
@@ -2627,12 +2627,9 @@ $code.=<<___	if ($avx>1);
 	test	\$`1<<5`, %eax
 	jnz	.Lavx2_gather_w5
 ___
-if ($win64) {
-$code.=<<___;
+$code.=<<___ if ($win64 && $use_tool_asm);
 	lea	-0x88(%rsp), %rax
 .LSEH_begin_ecp_nistz256_gather_w5:
----
-$code.=<<___ if ($use_tool_asm);
 	lea	-0x20(%rax), %rsp
 	movaps	%xmm6, -0x20(%rax)
 	movaps	%xmm7, -0x10(%rax)
@@ -2645,8 +2642,9 @@ $code.=<<___ if ($use_tool_asm);
 	movaps	%xmm14, 0x60(%rax)
 	movaps	%xmm15, 0x70(%rax)
 ___
-$code.=<<___ if (!$use_tool_asm);
-$code.=<<___;
+$code.=<<___ if ($win64 && !$use_tool_asm);
+	lea	-0x88(%rsp), %rax
+.LSEH_begin_ecp_nistz256_gather_w5:
 	.byte	0x48,0x8d,0x60,0xe0		#lea	-0x20(%rax), %rsp
 	.byte	0x0f,0x29,0x70,0xe0		#movaps	%xmm6, -0x20(%rax)
 	.byte	0x0f,0x29,0x78,0xf0		#movaps	%xmm7, -0x10(%rax)
@@ -2659,7 +2657,6 @@ $code.=<<___;
 	.byte	0x44,0x0f,0x29,0x70,0x60	#movaps	%xmm14, 0x60(%rax)
 	.byte	0x44,0x0f,0x29,0x78,0x70	#movaps	%xmm15, 0x70(%rax)
 ___
-}
 
 $code.=<<___;
 	movdqa	.LOne(%rip), $ONE
@@ -2766,12 +2763,9 @@ $code.=<<___	if ($avx>1);
 	test	\$`1<<5`, %eax
 	jnz	.Lavx2_gather_w7
 ___
-if ($win64) {
-$code.=<<___;
+$code.=<<___ if ($win64 && $use_tool_asm) ;
 	lea	-0x88(%rsp), %rax
 .LSEH_begin_ecp_nistz256_gather_w7:
-___
-$code.=<<___ if ($use_tool_asm) ;
 	lea	-0x20(%rax), %rsp
 	movaps	%xmm6, -0x20(%rax)
 	movaps	%xmm7, -0x10(%rax)
@@ -2784,7 +2778,9 @@ $code.=<<___ if ($use_tool_asm) ;
 	movaps	%xmm14, 0x60(%rax)
 	movaps	%xmm15, 0x70(%rax)
 ___
-$code.=<<___ if (!$use_tool_asm) ;
+$code.=<<___ if ($win64 && !$use_tool_asm) ;
+	lea	-0x88(%rsp), %rax
+.LSEH_begin_ecp_nistz256_gather_w7:
 	.byte	0x48,0x8d,0x60,0xe0		#lea	-0x20(%rax), %rsp
 	.byte	0x0f,0x29,0x70,0xe0		#movaps	%xmm6, -0x20(%rax)
 	.byte	0x0f,0x29,0x78,0xf0		#movaps	%xmm7, -0x10(%rax)
@@ -2797,7 +2793,6 @@ $code.=<<___ if (!$use_tool_asm) ;
 	.byte	0x44,0x0f,0x29,0x70,0x60	#movaps	%xmm14, 0x60(%rax)
 	.byte	0x44,0x0f,0x29,0x78,0x70	#movaps	%xmm15, 0x70(%rax)
 ___
-}
 $code.=<<___;
 	movdqa	.LOne(%rip), $M0
 	movd	$index, $INDEX
@@ -2875,13 +2870,10 @@ ecp_nistz256_avx2_gather_w5:
 .Lavx2_gather_w5:
 	vzeroupper
 ___
-if ($win64) {
-$code.=<<___;
+$code.=<<___ if ($win64 && $use_tool_asm);
 	lea	-0x88(%rsp), %rax
 	mov	%rsp,%r11
 .LSEH_begin_ecp_nistz256_avx2_gather_w5:
-___
-$code.=<<___ if ($use_tool_asm);
 	lea	-0x20(%rax), %rsp
 	vmovaps %xmm6, -0x20(%rax)
 	vmovaps %xmm7, -0x10(%rax)
@@ -2894,7 +2886,10 @@ $code.=<<___ if ($use_tool_asm);
 	vmovaps %xmm14, 0x60(%rax)
 	vmovaps %xmm15, 0x70(%rax)
 ___
-$code.=<<___ if (!$use_tool_asm);
+$code.=<<___ if ($win64 && !$use_tool_asm);
+	lea	-0x88(%rsp), %rax
+	mov	%rsp,%r11
+.LSEH_begin_ecp_nistz256_avx2_gather_w5:
 	.byte	0x48,0x8d,0x60,0xe0		# lea	-0x20(%rax), %rsp
 	.byte	0xc5,0xf8,0x29,0x70,0xe0	# vmovaps %xmm6, -0x20(%rax)
 	.byte	0xc5,0xf8,0x29,0x78,0xf0	# vmovaps %xmm7, -0x10(%rax)
@@ -2907,7 +2902,6 @@ $code.=<<___ if (!$use_tool_asm);
 	.byte	0xc5,0x78,0x29,0x70,0x60	# vmovaps %xmm14, 0x60(%rax)
 	.byte	0xc5,0x78,0x29,0x78,0x70	# vmovaps %xmm15, 0x70(%rax)
 ___
-}
 $code.=<<___;
 	vmovdqa	.LTwo(%rip), $TWO
 
@@ -3000,13 +2994,10 @@ ecp_nistz256_avx2_gather_w7:
 .Lavx2_gather_w7:
 	vzeroupper
 ___
-if ($win64) {
-$code.=<<___;
+$code.=<<___ if ($win64 && $use_tool_asm);
 	mov	%rsp,%r11
 	lea	-0x88(%rsp), %rax
 .LSEH_begin_ecp_nistz256_avx2_gather_w7:
----
-$code.=<<___ if ($use_tool_asm);
 	lea	-0x20(%rax), %rsp
 	vmovaps %xmm6, -0x20(%rax)
 	vmovaps %xmm7, -0x10(%rax)
@@ -3019,7 +3010,10 @@ $code.=<<___ if ($use_tool_asm);
 	vmovaps %xmm14, 0x60(%rax)
 	vmovaps %xmm15, 0x70(%rax)
 ___
-$code.=<<___ if (!$use_tool_asm);
+$code.=<<___ if ($win64 && !$use_tool_asm);
+	mov	%rsp,%r11
+	lea	-0x88(%rsp), %rax
+.LSEH_begin_ecp_nistz256_avx2_gather_w7:
 	.byte	0x48,0x8d,0x60,0xe0		# lea	-0x20(%rax), %rsp
 	.byte	0xc5,0xf8,0x29,0x70,0xe0	# vmovaps %xmm6, -0x20(%rax)
 	.byte	0xc5,0xf8,0x29,0x78,0xf0	# vmovaps %xmm7, -0x10(%rax)
@@ -3032,7 +3026,6 @@ $code.=<<___ if (!$use_tool_asm);
 	.byte	0xc5,0x78,0x29,0x70,0x60	# vmovaps %xmm14, 0x60(%rax)
 	.byte	0xc5,0x78,0x29,0x78,0x70	# vmovaps %xmm15, 0x70(%rax)
 ___
-}
 $code.=<<___;
 	vmovdqa	.LThree(%rip), $THREE
 

--- a/crypto/ec/asm/ecp_nistz256-x86_64.pl
+++ b/crypto/ec/asm/ecp_nistz256-x86_64.pl
@@ -84,25 +84,25 @@ $use_tool_asm=0;
 #
 # clang 9 or newer
 #
-$use_tool_asm=1 if (!$use_tool_aesni && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0-9]+\.[0-9]+)/ && $2>=9.0);
+$use_tool_asm=1 if (!$use_tool_asm && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0-9]+\.[0-9]+)/ && $2>=9.0);
 
 #
 # GNU assembler 2.30 or newer
 #
-$use_tool_asm=1 if (!$use_tool_aesni && `$ENV{CC} -Wa,-v -c -o /dev/null -x assembler /dev/null 2>&1`
+$use_tool_asm=1 if (!$use_tool_asm && `$ENV{CC} -Wa,-v -c -o /dev/null -x assembler /dev/null 2>&1`
 		=~ /GNU assembler version ([2-9]\.[0-9]+)/ &&
 	   $1>=2.30);
 #
 # masm version 14 or higher. The version is bundled with Visual Studio 2019
 #
-$use_tool_asm=1 if (!$use_tool_aesni && $win64 && ($flavour =~ /masm/ || $ENV{ASM} =~ /ml64/) &&
+$use_tool_asm=1 if (!$use_tool_asm && $win64 && ($flavour =~ /masm/ || $ENV{ASM} =~ /ml64/) &&
 	   `ml64 2>&1` =~ /Version ([0-9]+)\./ &&
 	   $1>=14);
 
 #
 # netwide assembler 2.15 or newer (2.15 is since 2020)
 #
-$use_tool_asm=1 if (!$use_tool_aesni && $win64 && ($flavour =~ /nasm/ || $ENV{ASM} =~ /nasm/) &&
+$use_tool_asm=1 if (!$use_tool_asm && $win64 && ($flavour =~ /nasm/ || $ENV{ASM} =~ /nasm/) &&
 	   `nasm -v 2>&1` =~ /NASM version ([2-9]\.[0-9]+)/ &&
 	   $1>=2.15);
 

--- a/crypto/modes/asm/ghash-x86_64.pl
+++ b/crypto/modes/asm/ghash-x86_64.pl
@@ -1886,7 +1886,7 @@ $code.=<<___ if ($use_tool_asm) ;
 	movaps 0x20(rsp),xmm8
 	movaps 0x10(rsp),xmm7
 	movaps 0x00(rsp),xmm6
-	sub	rsp,\$xa8
+	sub	rsp,\$168
 ___
 $code.=<<___ if (!$use_tool_asm) ;
 	.byte	0x33,0xf8,0x09,0x00	#movaps 0x90(rsp),xmm15

--- a/crypto/modes/asm/ghash-x86_64.pl
+++ b/crypto/modes/asm/ghash-x86_64.pl
@@ -1886,7 +1886,7 @@ $code.=<<___ if ($use_tool_asm) ;
 	movaps 0x20(rsp),xmm8
 	movaps 0x10(rsp),xmm7
 	movaps 0x00(rsp),xmm6
-	sub	rsp,0xa8
+	sub	rsp,\$xa8
 ___
 $code.=<<___ if (!$use_tool_asm) ;
 	.byte	0x33,0xf8,0x09,0x00	#movaps 0x90(rsp),xmm15

--- a/crypto/modes/asm/ghash-x86_64.pl
+++ b/crypto/modes/asm/ghash-x86_64.pl
@@ -125,25 +125,25 @@ $use_tool_asm=0;
 #
 # clang 9 or newer
 #
-$use_tool_asm=1 if (!$use_tool_aesni && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0-9]+\.[0-9]+)/ && $2>=9.0);
+$use_tool_asm=1 if (!$use_tool_asm && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0-9]+\.[0-9]+)/ && $2>=9.0);
 
 #
 # GNU assembler 2.30 or newer
 #
-$use_tool_asm=1 if (!$use_tool_aesni && `$ENV{CC} -Wa,-v -c -o /dev/null -x assembler /dev/null 2>&1`
+$use_tool_asm=1 if (!$use_tool_asm && `$ENV{CC} -Wa,-v -c -o /dev/null -x assembler /dev/null 2>&1`
 		=~ /GNU assembler version ([2-9]\.[0-9]+)/ &&
 	   $1>=2.30);
 #
 # masm version 14 or higher. The version is bundled with Visual Studio 2019
 #
-$use_tool_asm=1 if (!$use_tool_aesni && $win64 && ($flavour =~ /masm/ || $ENV{ASM} =~ /ml64/) &&
+$use_tool_asm=1 if (!$use_tool_asm && $win64 && ($flavour =~ /masm/ || $ENV{ASM} =~ /ml64/) &&
 	   `ml64 2>&1` =~ /Version ([0-9]+)\./ &&
 	   $1>=14);
 
 #
 # netwide assembler 2.15 or newer (2.15 is since 2020)
 #
-$use_tool_asm=1 if (!$use_tool_aesni && $win64 && ($flavour =~ /nasm/ || $ENV{ASM} =~ /nasm/) &&
+$use_tool_asm=1 if (!$use_tool_asm && $win64 && ($flavour =~ /nasm/ || $ENV{ASM} =~ /nasm/) &&
 	   `nasm -v 2>&1` =~ /NASM version ([2-9]\.[0-9]+)/ &&
 	   $1>=2.15);
 
@@ -1874,7 +1874,7 @@ $code.=<<___;
 	.byte	0x04,0x22,0x00,0x00	#sub	rsp,0x18
 .LSEH_info_gcm_ghash_clmul:
 	.byte	0x01,0x33,0x16,0x00
----
+___
 $code.=<<___ if ($use_tool_asm) ;
 	movaps 0x90(rsp),xmm15
 	movaps 0x80(rsp),xmm14
@@ -1887,7 +1887,7 @@ $code.=<<___ if ($use_tool_asm) ;
 	movaps 0x10(rsp),xmm7
 	movaps 0x00(rsp),xmm6
 	sub	rsp,0xa8
----
+___
 $code.=<<___ if (!$use_tool_asm) ;
 	.byte	0x33,0xf8,0x09,0x00	#movaps 0x90(rsp),xmm15
 	.byte	0x2e,0xe8,0x08,0x00	#movaps 0x80(rsp),xmm14

--- a/crypto/modes/asm/ghash-x86_64.pl
+++ b/crypto/modes/asm/ghash-x86_64.pl
@@ -699,13 +699,11 @@ gcm_ghash_clmul:
 	endbranch
 .L_ghash_clmul:
 ___
-if ($win64) {
-$code.=<<___;
+$code.=<<___ if ($win64);
 	lea	-0x88(%rsp),%rax
 .LSEH_begin_gcm_ghash_clmul:
 ___
-  if ($use_tool_asm) {
-$code.=<<___;
+$code.=<<___ if ($win64 && $use_tool_asm);
 	lea	-0x20(%rax),%rsp
 	movaps	%xmm6,-0x20(%rax)
 	movaps	%xmm7,-0x10(%rax)
@@ -718,8 +716,7 @@ $code.=<<___;
 	movaps	%xmm14,0x60(%rax)
 	movaps	%xmm15,0x70(%rax)
 ___
-  } else {
-$code.=<<___;
+$code.=<<___ if ($win64 && !$use_tool_asm);
 	# I can't trust assembler to use specific encoding:-(
 	.byte	0x48,0x8d,0x60,0xe0		#lea	-0x20(%rax),%rsp
 	.byte	0x0f,0x29,0x70,0xe0		#movaps	%xmm6,-0x20(%rax)
@@ -733,8 +730,6 @@ $code.=<<___;
 	.byte	0x44,0x0f,0x29,0x70,0x60	#movaps	%xmm14,0x60(%rax)
 	.byte	0x44,0x0f,0x29,0x78,0x70	#movaps	%xmm15,0x70(%rax)
 ___
-  }
-}
 $code.=<<___;
 	movdqa		.Lbswap_mask(%rip),$T3
 
@@ -1241,13 +1236,11 @@ my ($Xlo,$Xhi,$Xmi,
     $Zlo,$Zhi,$Zmi,
     $Hkey,$HK,$T1,$T2,
     $Xi,$Xo,$Tred,$bswap,$Ii,$Ij) = map("%xmm$_",(0..15));
-if ($win64) {
-$code.=<<___;
+$code.=<<___ if ($win64) ;
 	lea	-0x88(%rsp),%rax
 .LSEH_begin_gcm_ghash_avx:
 ___
-  if ($use_tool_asm) {
-$code.=<<___;
+$code.=<<___ if ($win64 && $use_tool_asm);
 	lea	-0x20(%rax),%rsp
 	movaps	%xmm6,-0x20(%rax)
 	movaps	%xmm7,-0x10(%rax)
@@ -1260,8 +1253,7 @@ $code.=<<___;
 	movaps	%xmm14,0x60(%rax)
 	movaps	%xmm15,0x70(%rax)
 ___
-  } else {
-$code.=<<___;
+$code.=<<___ if ($win64 && !$use_tool_asm);
 	# I can't trust assembler to use specific encoding:-(
 	.byte	0x48,0x8d,0x60,0xe0		#lea	-0x20(%rax),%rsp
 	.byte	0x0f,0x29,0x70,0xe0		#movaps	%xmm6,-0x20(%rax)
@@ -1275,8 +1267,6 @@ $code.=<<___;
 	.byte	0x44,0x0f,0x29,0x70,0x60	#movaps	%xmm14,0x60(%rax)
 	.byte	0x44,0x0f,0x29,0x78,0x70	#movaps	%xmm15,0x70(%rax)
 ___
-  }
-}
 $code.=<<___;
 	vzeroupper
 
@@ -1885,8 +1875,7 @@ $code.=<<___;
 .LSEH_info_gcm_ghash_clmul:
 	.byte	0x01,0x33,0x16,0x00
 ---
-if ($use_tool_asm) {
-$code.=<<___;
+$code.=<<___ if ($use_tool_asm) ;
 	movaps 0x90(rsp),xmm15
 	movaps 0x80(rsp),xmm14
 	movaps 0x70(rsp),xmm13
@@ -1898,9 +1887,8 @@ $code.=<<___;
 	movaps 0x10(rsp),xmm7
 	movaps 0x00(rsp),xmm6
 	sub	rsp,0xa8
-___
-} else {
-$code.=<<___;
+---
+$code.=<<___ if (!$use_tool_asm) ;
 	.byte	0x33,0xf8,0x09,0x00	#movaps 0x90(rsp),xmm15
 	.byte	0x2e,0xe8,0x08,0x00	#movaps 0x80(rsp),xmm14
 	.byte	0x29,0xd8,0x07,0x00	#movaps 0x70(rsp),xmm13


### PR DESCRIPTION
removing asni() function which encodes opcode directly instead of leaving it up to assembler compier.

clang tool chain is happy, so let's see how other
tools will deal with it.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
