### PR TITLE
docs(provider-base): Add HISTORY note for OSSL_CAPABILITY_TLS_SIGALG_MIN_DTLS (and MAX)

### DIFF
--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -977,6 +977,12 @@ L<provider(7)>
 The concept of providers and everything surrounding them was
 introduced in OpenSSL 3.0.
 
+Definitions for
+B<OSSL_CAPABILITY_TLS_SIGALG_MIN_DTLS>
+and
+B<OSSL_CAPABILITY_TLS_SIGALG_MAX_DTLS>
+were added in OpenSSL 3.5.
+
 =head1 COPYRIGHT
 
 Copyright 2019-2025 The OpenSSL Project Authors. All Rights Reserved.


### PR DESCRIPTION
This commit adds a small note about definitions for `OSSL_CAPABILITY_TLS_SIGALG_MIN_DTLS` and `OSSL_CAPABILITY_TLS_SIGALG_MAX_DTLS` being first added in OpenSSL 3.5.

PR #26975 added these definitions for OpenSSL 3.5, but the documentation update omitted a history note for the addition.

CLA: trivial

This PR is against `master`, but should likely be backported to the 3.5 branch before release.