### PR TITLE
Change default EC point formats to 'uncompressed' only

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,10 @@ OpenSSL 3.5
 
 ### Changes between 3.5 and 3.6 [xx XXX xxxx]
 
- * none yet
+ * Change default EC point formats configuration to support only uncompressed
+   format, to align with modern TLS standards and other implementations.
+
+   *Tim Perry*
 
 ### Changes between 3.4 and 3.5 [xx XXX xxxx]
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -194,9 +194,7 @@ static const struct {
 };
 
 static const unsigned char ecformats_default[] = {
-    TLSEXT_ECPOINTFORMAT_uncompressed,
-    TLSEXT_ECPOINTFORMAT_ansiX962_compressed_prime,
-    TLSEXT_ECPOINTFORMAT_ansiX962_compressed_char2
+    TLSEXT_ECPOINTFORMAT_uncompressed
 };
 
 /* Group list string of the built-in pseudo group DEFAULT */

--- a/test/recipes/75-test_quicapi_data/ssltraceref.txt
+++ b/test/recipes/75-test_quicapi_data/ssltraceref.txt
@@ -19,10 +19,8 @@ Header:
           000f - 01 02 04 04 80 0c 00 00-05 04 80 08 00 00 06   ...............
           001e - 04 80 08 00 00 07 04 80-08 00 00 08 02 40 64   .............@d
           002d - 09 02 40 64                                    ..@d
-        extension_type=ec_point_formats(11), length=4
+        extension_type=ec_point_formats(11), length=2
           uncompressed (0)
-          ansiX962_compressed_prime (1)
-          ansiX962_compressed_char2 (2)
         extension_type=supported_groups(10), length=18
           X25519MLKEM768 (4588)
           ecdh_x25519 (29)

--- a/test/ssl-tests/20-cert-select.cnf
+++ b/test/ssl-tests/20-cert-select.cnf
@@ -1,6 +1,6 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 58
+num_tests = 55
 
 test-0 = 0-ECDSA CipherString Selection
 test-1 = 1-ECDSA CipherString Selection
@@ -10,56 +10,53 @@ test-4 = 4-P-256 CipherString and Signature Algorithm Selection
 test-5 = 5-ECDSA CipherString Selection, no ECDSA certificate
 test-6 = 6-ECDSA Signature Algorithm Selection
 test-7 = 7-ECDSA Signature Algorithm Selection SHA384
-test-8 = 8-ECDSA Signature Algorithm Selection compressed point
-test-9 = 9-ECDSA Signature Algorithm Selection, no ECDSA certificate
-test-10 = 10-RSA Signature Algorithm Selection
-test-11 = 11-RSA-PSS Signature Algorithm Selection
-test-12 = 12-RSA key exchange with all RSA certificate types
-test-13 = 13-Suite B P-256 Hash Algorithm Selection
-test-14 = 14-Suite B P-384 Hash Algorithm Selection
-test-15 = 15-Ed25519 CipherString and Signature Algorithm Selection
-test-16 = 16-Ed448 CipherString and Signature Algorithm Selection
-test-17 = 17-TLS 1.2 Ed25519 Client Auth
-test-18 = 18-TLS 1.2 Ed448 Client Auth
-test-19 = 19-ECDSA Signature Algorithm Selection SHA1
-test-20 = 20-ECDSA with brainpool
-test-21 = 21-Ed25519 CipherString and Curves Selection
-test-22 = 22-Ed448 CipherString and Curves Selection
-test-23 = 23-RSA-PSS Certificate CipherString Selection
-test-24 = 24-RSA-PSS Certificate Legacy Signature Algorithm Selection
-test-25 = 25-RSA-PSS Certificate Unified Signature Algorithm Selection
-test-26 = 26-Only RSA-PSS Certificate
-test-27 = 27-Only RSA-PSS Certificate Valid Signature Algorithms
-test-28 = 28-RSA-PSS Certificate, no PSS signature algorithms
-test-29 = 29-Only RSA-PSS Restricted Certificate
-test-30 = 30-RSA-PSS Restricted Certificate Valid Signature Algorithms
-test-31 = 31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm
-test-32 = 32-RSA-PSS Restricted Certificate Invalid Signature Algorithms
-test-33 = 33-RSA key exchange with only RSA-PSS certificate
-test-34 = 34-Only RSA-PSS Certificate, TLS v1.1
-test-35 = 35-TLS 1.3 ECDSA Signature Algorithm Selection
-test-36 = 36-TLS 1.3 ECDSA Signature Algorithm Selection compressed point
-test-37 = 37-TLS 1.3 ECDSA Signature Algorithm Selection SHA1
-test-38 = 38-TLS 1.3 ECDSA Signature Algorithm Selection with PSS
-test-39 = 39-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS
-test-40 = 40-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate
-test-41 = 41-TLS 1.3 RSA Signature Algorithm Selection, no PSS
-test-42 = 42-TLS 1.3 RSA-PSS Signature Algorithm Selection
-test-43 = 43-TLS 1.3 RSA Client Auth Signature Algorithm Selection
-test-44 = 44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names
-test-45 = 45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection
-test-46 = 46-TLS 1.3 Ed25519 Signature Algorithm Selection
-test-47 = 47-TLS 1.3 Ed448 Signature Algorithm Selection
-test-48 = 48-TLS 1.3 Ed25519 CipherString and Groups Selection
-test-49 = 49-TLS 1.3 Ed448 CipherString and Groups Selection
-test-50 = 50-TLS 1.3 Ed25519 Client Auth
-test-51 = 51-TLS 1.3 Ed448 Client Auth
-test-52 = 52-TLS 1.3 ECDSA with brainpool but no suitable groups
-test-53 = 53-TLS 1.3 ECDSA with brainpool
-test-54 = 54-TLS 1.2 DSA Certificate Test
-test-55 = 55-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms
-test-56 = 56-TLS 1.3 DSA Certificate Test
-test-57 = 57-TLS 1.3 ML-DSA Certificate Test
+test-8 = 8-ECDSA Signature Algorithm Selection, no ECDSA certificate
+test-9 = 9-RSA Signature Algorithm Selection
+test-10 = 10-RSA-PSS Signature Algorithm Selection
+test-11 = 11-RSA key exchange with all RSA certificate types
+test-12 = 12-Ed25519 CipherString and Signature Algorithm Selection
+test-13 = 13-Ed448 CipherString and Signature Algorithm Selection
+test-14 = 14-TLS 1.2 Ed25519 Client Auth
+test-15 = 15-TLS 1.2 Ed448 Client Auth
+test-16 = 16-ECDSA Signature Algorithm Selection SHA1
+test-17 = 17-ECDSA with brainpool
+test-18 = 18-Ed25519 CipherString and Curves Selection
+test-19 = 19-Ed448 CipherString and Curves Selection
+test-20 = 20-RSA-PSS Certificate CipherString Selection
+test-21 = 21-RSA-PSS Certificate Legacy Signature Algorithm Selection
+test-22 = 22-RSA-PSS Certificate Unified Signature Algorithm Selection
+test-23 = 23-Only RSA-PSS Certificate
+test-24 = 24-Only RSA-PSS Certificate Valid Signature Algorithms
+test-25 = 25-RSA-PSS Certificate, no PSS signature algorithms
+test-26 = 26-Only RSA-PSS Restricted Certificate
+test-27 = 27-RSA-PSS Restricted Certificate Valid Signature Algorithms
+test-28 = 28-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm
+test-29 = 29-RSA-PSS Restricted Certificate Invalid Signature Algorithms
+test-30 = 30-RSA key exchange with only RSA-PSS certificate
+test-31 = 31-Only RSA-PSS Certificate, TLS v1.1
+test-32 = 32-TLS 1.3 ECDSA Signature Algorithm Selection
+test-33 = 33-TLS 1.3 ECDSA Signature Algorithm Selection compressed point
+test-34 = 34-TLS 1.3 ECDSA Signature Algorithm Selection SHA1
+test-35 = 35-TLS 1.3 ECDSA Signature Algorithm Selection with PSS
+test-36 = 36-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS
+test-37 = 37-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate
+test-38 = 38-TLS 1.3 RSA Signature Algorithm Selection, no PSS
+test-39 = 39-TLS 1.3 RSA-PSS Signature Algorithm Selection
+test-40 = 40-TLS 1.3 RSA Client Auth Signature Algorithm Selection
+test-41 = 41-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names
+test-42 = 42-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection
+test-43 = 43-TLS 1.3 Ed25519 Signature Algorithm Selection
+test-44 = 44-TLS 1.3 Ed448 Signature Algorithm Selection
+test-45 = 45-TLS 1.3 Ed25519 CipherString and Groups Selection
+test-46 = 46-TLS 1.3 Ed448 CipherString and Groups Selection
+test-47 = 47-TLS 1.3 Ed25519 Client Auth
+test-48 = 48-TLS 1.3 Ed448 Client Auth
+test-49 = 49-TLS 1.3 ECDSA with brainpool but no suitable groups
+test-50 = 50-TLS 1.3 ECDSA with brainpool
+test-51 = 51-TLS 1.2 DSA Certificate Test
+test-52 = 52-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms
+test-53 = 53-TLS 1.3 DSA Certificate Test
+test-54 = 54-TLS 1.3 ML-DSA Certificate Test
 # ===========================================================
 
 [0-ECDSA CipherString Selection]
@@ -321,69 +318,39 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[8-ECDSA Signature Algorithm Selection compressed point]
-ssl_conf = 8-ECDSA Signature Algorithm Selection compressed point-ssl
+[8-ECDSA Signature Algorithm Selection, no ECDSA certificate]
+ssl_conf = 8-ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl
 
-[8-ECDSA Signature Algorithm Selection compressed point-ssl]
-server = 8-ECDSA Signature Algorithm Selection compressed point-server
-client = 8-ECDSA Signature Algorithm Selection compressed point-client
+[8-ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl]
+server = 8-ECDSA Signature Algorithm Selection, no ECDSA certificate-server
+client = 8-ECDSA Signature Algorithm Selection, no ECDSA certificate-client
 
-[8-ECDSA Signature Algorithm Selection compressed point-server]
+[8-ECDSA Signature Algorithm Selection, no ECDSA certificate-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-cecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-cecdsa-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[8-ECDSA Signature Algorithm Selection compressed point-client]
+[8-ECDSA Signature Algorithm Selection, no ECDSA certificate-client]
 CipherString = DEFAULT
 SignatureAlgorithms = EcDsA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-8]
-ExpectedResult = Success
-ExpectedServerCertType = P-256
-ExpectedServerSignHash = SHA256
-ExpectedServerSignType = EC
-
-
-# ===========================================================
-
-[9-ECDSA Signature Algorithm Selection, no ECDSA certificate]
-ssl_conf = 9-ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl
-
-[9-ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl]
-server = 9-ECDSA Signature Algorithm Selection, no ECDSA certificate-server
-client = 9-ECDSA Signature Algorithm Selection, no ECDSA certificate-client
-
-[9-ECDSA Signature Algorithm Selection, no ECDSA certificate-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[9-ECDSA Signature Algorithm Selection, no ECDSA certificate-client]
-CipherString = DEFAULT
-SignatureAlgorithms = eCdsA+SHA256
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-9]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[10-RSA Signature Algorithm Selection]
-ssl_conf = 10-RSA Signature Algorithm Selection-ssl
+[9-RSA Signature Algorithm Selection]
+ssl_conf = 9-RSA Signature Algorithm Selection-ssl
 
-[10-RSA Signature Algorithm Selection-ssl]
-server = 10-RSA Signature Algorithm Selection-server
-client = 10-RSA Signature Algorithm Selection-client
+[9-RSA Signature Algorithm Selection-ssl]
+server = 9-RSA Signature Algorithm Selection-server
+client = 9-RSA Signature Algorithm Selection-client
 
-[10-RSA Signature Algorithm Selection-server]
+[9-RSA Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -395,13 +362,13 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[10-RSA Signature Algorithm Selection-client]
+[9-RSA Signature Algorithm Selection-client]
 CipherString = DEFAULT
-SignatureAlgorithms = rsA+SHA256
+SignatureAlgorithms = rSa+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-10]
+[test-9]
 ExpectedResult = Success
 ExpectedServerCertType = RSA
 ExpectedServerSignHash = SHA256
@@ -410,14 +377,14 @@ ExpectedServerSignType = RSA
 
 # ===========================================================
 
-[11-RSA-PSS Signature Algorithm Selection]
-ssl_conf = 11-RSA-PSS Signature Algorithm Selection-ssl
+[10-RSA-PSS Signature Algorithm Selection]
+ssl_conf = 10-RSA-PSS Signature Algorithm Selection-ssl
 
-[11-RSA-PSS Signature Algorithm Selection-ssl]
-server = 11-RSA-PSS Signature Algorithm Selection-server
-client = 11-RSA-PSS Signature Algorithm Selection-client
+[10-RSA-PSS Signature Algorithm Selection-ssl]
+server = 10-RSA-PSS Signature Algorithm Selection-server
+client = 10-RSA-PSS Signature Algorithm Selection-client
 
-[11-RSA-PSS Signature Algorithm Selection-server]
+[10-RSA-PSS Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -429,13 +396,13 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[11-RSA-PSS Signature Algorithm Selection-client]
+[10-RSA-PSS Signature Algorithm Selection-client]
 CipherString = DEFAULT
-SignatureAlgorithms = RSA-pss+SHA256
+SignatureAlgorithms = rSa-pSS+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-11]
+[test-10]
 ExpectedResult = Success
 ExpectedServerCertType = RSA
 ExpectedServerSignHash = SHA256
@@ -444,101 +411,41 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[12-RSA key exchange with all RSA certificate types]
-ssl_conf = 12-RSA key exchange with all RSA certificate types-ssl
+[11-RSA key exchange with all RSA certificate types]
+ssl_conf = 11-RSA key exchange with all RSA certificate types-ssl
 
-[12-RSA key exchange with all RSA certificate types-ssl]
-server = 12-RSA key exchange with all RSA certificate types-server
-client = 12-RSA key exchange with all RSA certificate types-client
+[11-RSA key exchange with all RSA certificate types-ssl]
+server = 11-RSA key exchange with all RSA certificate types-server
+client = 11-RSA key exchange with all RSA certificate types-client
 
-[12-RSA key exchange with all RSA certificate types-server]
+[11-RSA key exchange with all RSA certificate types-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PSS.Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 PSS.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[12-RSA key exchange with all RSA certificate types-client]
+[11-RSA key exchange with all RSA certificate types-client]
 CipherString = kRSA
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-12]
+[test-11]
 ExpectedResult = Success
 ExpectedServerCertType = RSA
 
 
 # ===========================================================
 
-[13-Suite B P-256 Hash Algorithm Selection]
-ssl_conf = 13-Suite B P-256 Hash Algorithm Selection-ssl
+[12-Ed25519 CipherString and Signature Algorithm Selection]
+ssl_conf = 12-Ed25519 CipherString and Signature Algorithm Selection-ssl
 
-[13-Suite B P-256 Hash Algorithm Selection-ssl]
-server = 13-Suite B P-256 Hash Algorithm Selection-server
-client = 13-Suite B P-256 Hash Algorithm Selection-client
+[12-Ed25519 CipherString and Signature Algorithm Selection-ssl]
+server = 12-Ed25519 CipherString and Signature Algorithm Selection-server
+client = 12-Ed25519 CipherString and Signature Algorithm Selection-client
 
-[13-Suite B P-256 Hash Algorithm Selection-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = SUITEB128
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/p256-server-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/p256-server-key.pem
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[13-Suite B P-256 Hash Algorithm Selection-client]
-CipherString = DEFAULT
-SignatureAlgorithms = eCdsA+SHA384:ECdSA+SHA256
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/p384-root.pem
-VerifyMode = Peer
-
-[test-13]
-ExpectedResult = Success
-ExpectedServerCertType = P-256
-ExpectedServerSignHash = SHA256
-ExpectedServerSignType = EC
-
-
-# ===========================================================
-
-[14-Suite B P-384 Hash Algorithm Selection]
-ssl_conf = 14-Suite B P-384 Hash Algorithm Selection-ssl
-
-[14-Suite B P-384 Hash Algorithm Selection-ssl]
-server = 14-Suite B P-384 Hash Algorithm Selection-server
-client = 14-Suite B P-384 Hash Algorithm Selection-client
-
-[14-Suite B P-384 Hash Algorithm Selection-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = SUITEB128
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/p384-server-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/p384-server-key.pem
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[14-Suite B P-384 Hash Algorithm Selection-client]
-CipherString = DEFAULT
-SignatureAlgorithms = EcdSA+SHA256:ECDSA+SHA384
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/p384-root.pem
-VerifyMode = Peer
-
-[test-14]
-ExpectedResult = Success
-ExpectedServerCertType = P-384
-ExpectedServerSignHash = SHA384
-ExpectedServerSignType = EC
-
-
-# ===========================================================
-
-[15-Ed25519 CipherString and Signature Algorithm Selection]
-ssl_conf = 15-Ed25519 CipherString and Signature Algorithm Selection-ssl
-
-[15-Ed25519 CipherString and Signature Algorithm Selection-ssl]
-server = 15-Ed25519 CipherString and Signature Algorithm Selection-server
-client = 15-Ed25519 CipherString and Signature Algorithm Selection-client
-
-[15-Ed25519 CipherString and Signature Algorithm Selection-server]
+[12-Ed25519 CipherString and Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -550,15 +457,15 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[15-Ed25519 CipherString and Signature Algorithm Selection-client]
+[12-Ed25519 CipherString and Signature Algorithm Selection-client]
 CipherString = aECDSA
 MaxProtocol = TLSv1.2
 RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-SignatureAlgorithms = eD25519:eCdsa+SHA256
+SignatureAlgorithms = ed25519:ecdsA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-15]
+[test-12]
 ExpectedResult = Success
 ExpectedServerCANames = empty
 ExpectedServerCertType = Ed25519
@@ -567,14 +474,14 @@ ExpectedServerSignType = Ed25519
 
 # ===========================================================
 
-[16-Ed448 CipherString and Signature Algorithm Selection]
-ssl_conf = 16-Ed448 CipherString and Signature Algorithm Selection-ssl
+[13-Ed448 CipherString and Signature Algorithm Selection]
+ssl_conf = 13-Ed448 CipherString and Signature Algorithm Selection-ssl
 
-[16-Ed448 CipherString and Signature Algorithm Selection-ssl]
-server = 16-Ed448 CipherString and Signature Algorithm Selection-server
-client = 16-Ed448 CipherString and Signature Algorithm Selection-client
+[13-Ed448 CipherString and Signature Algorithm Selection-ssl]
+server = 13-Ed448 CipherString and Signature Algorithm Selection-server
+client = 13-Ed448 CipherString and Signature Algorithm Selection-client
 
-[16-Ed448 CipherString and Signature Algorithm Selection-server]
+[13-Ed448 CipherString and Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -586,15 +493,15 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[16-Ed448 CipherString and Signature Algorithm Selection-client]
+[13-Ed448 CipherString and Signature Algorithm Selection-client]
 CipherString = aECDSA
 MaxProtocol = TLSv1.2
 RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-ed448-cert.pem
-SignatureAlgorithms = Ed448:ECdSa+SHA256
+SignatureAlgorithms = ED448:ECDsA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-ed448-cert.pem
 VerifyMode = Peer
 
-[test-16]
+[test-13]
 ExpectedResult = Success
 ExpectedServerCANames = empty
 ExpectedServerCertType = Ed448
@@ -603,21 +510,21 @@ ExpectedServerSignType = Ed448
 
 # ===========================================================
 
-[17-TLS 1.2 Ed25519 Client Auth]
-ssl_conf = 17-TLS 1.2 Ed25519 Client Auth-ssl
+[14-TLS 1.2 Ed25519 Client Auth]
+ssl_conf = 14-TLS 1.2 Ed25519 Client Auth-ssl
 
-[17-TLS 1.2 Ed25519 Client Auth-ssl]
-server = 17-TLS 1.2 Ed25519 Client Auth-server
-client = 17-TLS 1.2 Ed25519 Client Auth-client
+[14-TLS 1.2 Ed25519 Client Auth-ssl]
+server = 14-TLS 1.2 Ed25519 Client Auth-server
+client = 14-TLS 1.2 Ed25519 Client Auth-client
 
-[17-TLS 1.2 Ed25519 Client Auth-server]
+[14-TLS 1.2 Ed25519 Client Auth-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[17-TLS 1.2 Ed25519 Client Auth-client]
+[14-TLS 1.2 Ed25519 Client Auth-client]
 CipherString = DEFAULT
 Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/client-ed25519-cert.pem
 Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/client-ed25519-key.pem
@@ -626,7 +533,7 @@ MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-17]
+[test-14]
 ExpectedClientCertType = Ed25519
 ExpectedClientSignType = Ed25519
 ExpectedResult = Success
@@ -634,21 +541,21 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[18-TLS 1.2 Ed448 Client Auth]
-ssl_conf = 18-TLS 1.2 Ed448 Client Auth-ssl
+[15-TLS 1.2 Ed448 Client Auth]
+ssl_conf = 15-TLS 1.2 Ed448 Client Auth-ssl
 
-[18-TLS 1.2 Ed448 Client Auth-ssl]
-server = 18-TLS 1.2 Ed448 Client Auth-server
-client = 18-TLS 1.2 Ed448 Client Auth-client
+[15-TLS 1.2 Ed448 Client Auth-ssl]
+server = 15-TLS 1.2 Ed448 Client Auth-server
+client = 15-TLS 1.2 Ed448 Client Auth-client
 
-[18-TLS 1.2 Ed448 Client Auth-server]
+[15-TLS 1.2 Ed448 Client Auth-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[18-TLS 1.2 Ed448 Client Auth-client]
+[15-TLS 1.2 Ed448 Client Auth-client]
 CipherString = DEFAULT
 Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/client-ed448-cert.pem
 Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/client-ed448-key.pem
@@ -657,7 +564,7 @@ MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-18]
+[test-15]
 ExpectedClientCertType = Ed448
 ExpectedClientSignType = Ed448
 ExpectedResult = Success
@@ -665,14 +572,14 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[19-ECDSA Signature Algorithm Selection SHA1]
-ssl_conf = 19-ECDSA Signature Algorithm Selection SHA1-ssl
+[16-ECDSA Signature Algorithm Selection SHA1]
+ssl_conf = 16-ECDSA Signature Algorithm Selection SHA1-ssl
 
-[19-ECDSA Signature Algorithm Selection SHA1-ssl]
-server = 19-ECDSA Signature Algorithm Selection SHA1-server
-client = 19-ECDSA Signature Algorithm Selection SHA1-client
+[16-ECDSA Signature Algorithm Selection SHA1-ssl]
+server = 16-ECDSA Signature Algorithm Selection SHA1-server
+client = 16-ECDSA Signature Algorithm Selection SHA1-client
 
-[19-ECDSA Signature Algorithm Selection SHA1-server]
+[16-ECDSA Signature Algorithm Selection SHA1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT:@SECLEVEL=0
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -684,13 +591,13 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[19-ECDSA Signature Algorithm Selection SHA1-client]
+[16-ECDSA Signature Algorithm Selection SHA1-client]
 CipherString = DEFAULT:@SECLEVEL=0
-SignatureAlgorithms = ECdSa+SHA1
+SignatureAlgorithms = ECdsA+SHA1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-19]
+[test-16]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignHash = SHA1
@@ -699,20 +606,20 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[20-ECDSA with brainpool]
-ssl_conf = 20-ECDSA with brainpool-ssl
+[17-ECDSA with brainpool]
+ssl_conf = 17-ECDSA with brainpool-ssl
 
-[20-ECDSA with brainpool-ssl]
-server = 20-ECDSA with brainpool-server
-client = 20-ECDSA with brainpool-client
+[17-ECDSA with brainpool-ssl]
+server = 17-ECDSA with brainpool-server
+client = 17-ECDSA with brainpool-client
 
-[20-ECDSA with brainpool-server]
+[17-ECDSA with brainpool-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-cert.pem
 CipherString = DEFAULT
 Groups = brainpoolP256r1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-key.pem
 
-[20-ECDSA with brainpool-client]
+[17-ECDSA with brainpool-client]
 CipherString = aECDSA
 Groups = brainpoolP256r1
 MaxProtocol = TLSv1.2
@@ -720,7 +627,7 @@ RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-20]
+[test-17]
 ExpectedResult = Success
 ExpectedServerCANames = empty
 ExpectedServerCertType = brainpoolP256r1
@@ -729,14 +636,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[21-Ed25519 CipherString and Curves Selection]
-ssl_conf = 21-Ed25519 CipherString and Curves Selection-ssl
+[18-Ed25519 CipherString and Curves Selection]
+ssl_conf = 18-Ed25519 CipherString and Curves Selection-ssl
 
-[21-Ed25519 CipherString and Curves Selection-ssl]
-server = 21-Ed25519 CipherString and Curves Selection-server
-client = 21-Ed25519 CipherString and Curves Selection-client
+[18-Ed25519 CipherString and Curves Selection-ssl]
+server = 18-Ed25519 CipherString and Curves Selection-server
+client = 18-Ed25519 CipherString and Curves Selection-client
 
-[21-Ed25519 CipherString and Curves Selection-server]
+[18-Ed25519 CipherString and Curves Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -748,15 +655,15 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[21-Ed25519 CipherString and Curves Selection-client]
+[18-Ed25519 CipherString and Curves Selection-client]
 CipherString = aECDSA
 Curves = X25519
 MaxProtocol = TLSv1.2
-SignatureAlgorithms = ecDSA+SHA256:Ed25519
+SignatureAlgorithms = ECDSA+SHA256:ed25519
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-21]
+[test-18]
 ExpectedResult = Success
 ExpectedServerCertType = Ed25519
 ExpectedServerSignType = Ed25519
@@ -764,14 +671,14 @@ ExpectedServerSignType = Ed25519
 
 # ===========================================================
 
-[22-Ed448 CipherString and Curves Selection]
-ssl_conf = 22-Ed448 CipherString and Curves Selection-ssl
+[19-Ed448 CipherString and Curves Selection]
+ssl_conf = 19-Ed448 CipherString and Curves Selection-ssl
 
-[22-Ed448 CipherString and Curves Selection-ssl]
-server = 22-Ed448 CipherString and Curves Selection-server
-client = 22-Ed448 CipherString and Curves Selection-client
+[19-Ed448 CipherString and Curves Selection-ssl]
+server = 19-Ed448 CipherString and Curves Selection-server
+client = 19-Ed448 CipherString and Curves Selection-client
 
-[22-Ed448 CipherString and Curves Selection-server]
+[19-Ed448 CipherString and Curves Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -783,15 +690,15 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[22-Ed448 CipherString and Curves Selection-client]
+[19-Ed448 CipherString and Curves Selection-client]
 CipherString = aECDSA
 Curves = X448
 MaxProtocol = TLSv1.2
-SignatureAlgorithms = ECDSa+SHA256:ED448
+SignatureAlgorithms = ecDsa+SHA256:ED448
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-ed448-cert.pem
 VerifyMode = Peer
 
-[test-22]
+[test-19]
 ExpectedResult = Success
 ExpectedServerCertType = Ed448
 ExpectedServerSignType = Ed448
@@ -799,14 +706,14 @@ ExpectedServerSignType = Ed448
 
 # ===========================================================
 
-[23-RSA-PSS Certificate CipherString Selection]
-ssl_conf = 23-RSA-PSS Certificate CipherString Selection-ssl
+[20-RSA-PSS Certificate CipherString Selection]
+ssl_conf = 20-RSA-PSS Certificate CipherString Selection-ssl
 
-[23-RSA-PSS Certificate CipherString Selection-ssl]
-server = 23-RSA-PSS Certificate CipherString Selection-server
-client = 23-RSA-PSS Certificate CipherString Selection-client
+[20-RSA-PSS Certificate CipherString Selection-ssl]
+server = 20-RSA-PSS Certificate CipherString Selection-server
+client = 20-RSA-PSS Certificate CipherString Selection-client
 
-[23-RSA-PSS Certificate CipherString Selection-server]
+[20-RSA-PSS Certificate CipherString Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -820,13 +727,13 @@ PSS.Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 PSS.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[23-RSA-PSS Certificate CipherString Selection-client]
+[20-RSA-PSS Certificate CipherString Selection-client]
 CipherString = aRSA
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-23]
+[test-20]
 ExpectedResult = Success
 ExpectedServerCertType = RSA-PSS
 ExpectedServerSignType = RSA-PSS
@@ -834,14 +741,14 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[24-RSA-PSS Certificate Legacy Signature Algorithm Selection]
-ssl_conf = 24-RSA-PSS Certificate Legacy Signature Algorithm Selection-ssl
+[21-RSA-PSS Certificate Legacy Signature Algorithm Selection]
+ssl_conf = 21-RSA-PSS Certificate Legacy Signature Algorithm Selection-ssl
 
-[24-RSA-PSS Certificate Legacy Signature Algorithm Selection-ssl]
-server = 24-RSA-PSS Certificate Legacy Signature Algorithm Selection-server
-client = 24-RSA-PSS Certificate Legacy Signature Algorithm Selection-client
+[21-RSA-PSS Certificate Legacy Signature Algorithm Selection-ssl]
+server = 21-RSA-PSS Certificate Legacy Signature Algorithm Selection-server
+client = 21-RSA-PSS Certificate Legacy Signature Algorithm Selection-client
 
-[24-RSA-PSS Certificate Legacy Signature Algorithm Selection-server]
+[21-RSA-PSS Certificate Legacy Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -855,13 +762,13 @@ PSS.Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 PSS.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[24-RSA-PSS Certificate Legacy Signature Algorithm Selection-client]
+[21-RSA-PSS Certificate Legacy Signature Algorithm Selection-client]
 CipherString = DEFAULT
-SignatureAlgorithms = rSA-pSS+SHA256
+SignatureAlgorithms = RSA-pSs+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-24]
+[test-21]
 ExpectedResult = Success
 ExpectedServerCertType = RSA
 ExpectedServerSignHash = SHA256
@@ -870,14 +777,14 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[25-RSA-PSS Certificate Unified Signature Algorithm Selection]
-ssl_conf = 25-RSA-PSS Certificate Unified Signature Algorithm Selection-ssl
+[22-RSA-PSS Certificate Unified Signature Algorithm Selection]
+ssl_conf = 22-RSA-PSS Certificate Unified Signature Algorithm Selection-ssl
 
-[25-RSA-PSS Certificate Unified Signature Algorithm Selection-ssl]
-server = 25-RSA-PSS Certificate Unified Signature Algorithm Selection-server
-client = 25-RSA-PSS Certificate Unified Signature Algorithm Selection-client
+[22-RSA-PSS Certificate Unified Signature Algorithm Selection-ssl]
+server = 22-RSA-PSS Certificate Unified Signature Algorithm Selection-server
+client = 22-RSA-PSS Certificate Unified Signature Algorithm Selection-client
 
-[25-RSA-PSS Certificate Unified Signature Algorithm Selection-server]
+[22-RSA-PSS Certificate Unified Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -891,13 +798,13 @@ PSS.Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 PSS.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[25-RSA-PSS Certificate Unified Signature Algorithm Selection-client]
+[22-RSA-PSS Certificate Unified Signature Algorithm Selection-client]
 CipherString = DEFAULT
-SignatureAlgorithms = rsA_PsS_PsS_sHa256
+SignatureAlgorithms = rsA_pSS_Pss_sHa256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-25]
+[test-22]
 ExpectedResult = Success
 ExpectedServerCertType = RSA-PSS
 ExpectedServerSignHash = SHA256
@@ -906,19 +813,96 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[26-Only RSA-PSS Certificate]
-ssl_conf = 26-Only RSA-PSS Certificate-ssl
+[23-Only RSA-PSS Certificate]
+ssl_conf = 23-Only RSA-PSS Certificate-ssl
 
-[26-Only RSA-PSS Certificate-ssl]
-server = 26-Only RSA-PSS Certificate-server
-client = 26-Only RSA-PSS Certificate-client
+[23-Only RSA-PSS Certificate-ssl]
+server = 23-Only RSA-PSS Certificate-server
+client = 23-Only RSA-PSS Certificate-client
 
-[26-Only RSA-PSS Certificate-server]
+[23-Only RSA-PSS Certificate-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 
-[26-Only RSA-PSS Certificate-client]
+[23-Only RSA-PSS Certificate-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-23]
+ExpectedResult = Success
+ExpectedServerCertType = RSA-PSS
+ExpectedServerSignHash = SHA256
+ExpectedServerSignType = RSA-PSS
+
+
+# ===========================================================
+
+[24-Only RSA-PSS Certificate Valid Signature Algorithms]
+ssl_conf = 24-Only RSA-PSS Certificate Valid Signature Algorithms-ssl
+
+[24-Only RSA-PSS Certificate Valid Signature Algorithms-ssl]
+server = 24-Only RSA-PSS Certificate Valid Signature Algorithms-server
+client = 24-Only RSA-PSS Certificate Valid Signature Algorithms-client
+
+[24-Only RSA-PSS Certificate Valid Signature Algorithms-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
+
+[24-Only RSA-PSS Certificate Valid Signature Algorithms-client]
+CipherString = DEFAULT
+SignatureAlgorithms = rsa_pSS_PSs_sHa512
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-24]
+ExpectedResult = Success
+ExpectedServerCertType = RSA-PSS
+ExpectedServerSignHash = SHA512
+ExpectedServerSignType = RSA-PSS
+
+
+# ===========================================================
+
+[25-RSA-PSS Certificate, no PSS signature algorithms]
+ssl_conf = 25-RSA-PSS Certificate, no PSS signature algorithms-ssl
+
+[25-RSA-PSS Certificate, no PSS signature algorithms-ssl]
+server = 25-RSA-PSS Certificate, no PSS signature algorithms-server
+client = 25-RSA-PSS Certificate, no PSS signature algorithms-client
+
+[25-RSA-PSS Certificate, no PSS signature algorithms-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
+
+[25-RSA-PSS Certificate, no PSS signature algorithms-client]
+CipherString = DEFAULT
+SignatureAlgorithms = RSA+SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-25]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[26-Only RSA-PSS Restricted Certificate]
+ssl_conf = 26-Only RSA-PSS Restricted Certificate-ssl
+
+[26-Only RSA-PSS Restricted Certificate-ssl]
+server = 26-Only RSA-PSS Restricted Certificate-server
+client = 26-Only RSA-PSS Restricted Certificate-client
+
+[26-Only RSA-PSS Restricted Certificate-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
+
+[26-Only RSA-PSS Restricted Certificate-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -932,200 +916,223 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[27-Only RSA-PSS Certificate Valid Signature Algorithms]
-ssl_conf = 27-Only RSA-PSS Certificate Valid Signature Algorithms-ssl
+[27-RSA-PSS Restricted Certificate Valid Signature Algorithms]
+ssl_conf = 27-RSA-PSS Restricted Certificate Valid Signature Algorithms-ssl
 
-[27-Only RSA-PSS Certificate Valid Signature Algorithms-ssl]
-server = 27-Only RSA-PSS Certificate Valid Signature Algorithms-server
-client = 27-Only RSA-PSS Certificate Valid Signature Algorithms-client
+[27-RSA-PSS Restricted Certificate Valid Signature Algorithms-ssl]
+server = 27-RSA-PSS Restricted Certificate Valid Signature Algorithms-server
+client = 27-RSA-PSS Restricted Certificate Valid Signature Algorithms-client
 
-[27-Only RSA-PSS Certificate Valid Signature Algorithms-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
+[27-RSA-PSS Restricted Certificate Valid Signature Algorithms-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
 CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
 
-[27-Only RSA-PSS Certificate Valid Signature Algorithms-client]
+[27-RSA-PSS Restricted Certificate Valid Signature Algorithms-client]
 CipherString = DEFAULT
-SignatureAlgorithms = rsa_psS_psS_sHa512
+SignatureAlgorithms = RSa_PSs_PsS_sha256:rsa_Pss_PsS_sHA512
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-27]
 ExpectedResult = Success
 ExpectedServerCertType = RSA-PSS
-ExpectedServerSignHash = SHA512
+ExpectedServerSignHash = SHA256
 ExpectedServerSignType = RSA-PSS
 
 
 # ===========================================================
 
-[28-RSA-PSS Certificate, no PSS signature algorithms]
-ssl_conf = 28-RSA-PSS Certificate, no PSS signature algorithms-ssl
+[28-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm]
+ssl_conf = 28-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-ssl
 
-[28-RSA-PSS Certificate, no PSS signature algorithms-ssl]
-server = 28-RSA-PSS Certificate, no PSS signature algorithms-server
-client = 28-RSA-PSS Certificate, no PSS signature algorithms-client
+[28-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-ssl]
+server = 28-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-server
+client = 28-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-client
 
-[28-RSA-PSS Certificate, no PSS signature algorithms-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
+[28-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
 CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
 
-[28-RSA-PSS Certificate, no PSS signature algorithms-client]
+[28-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-client]
 CipherString = DEFAULT
-SignatureAlgorithms = rsa+SHA256
+SignatureAlgorithms = RSA_psS_PsS_shA512:Rsa_pSs_PSS_shA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-28]
-ExpectedResult = ServerFail
+ExpectedResult = Success
+ExpectedServerCertType = RSA-PSS
+ExpectedServerSignHash = SHA256
+ExpectedServerSignType = RSA-PSS
 
 
 # ===========================================================
 
-[29-Only RSA-PSS Restricted Certificate]
-ssl_conf = 29-Only RSA-PSS Restricted Certificate-ssl
+[29-RSA-PSS Restricted Certificate Invalid Signature Algorithms]
+ssl_conf = 29-RSA-PSS Restricted Certificate Invalid Signature Algorithms-ssl
 
-[29-Only RSA-PSS Restricted Certificate-ssl]
-server = 29-Only RSA-PSS Restricted Certificate-server
-client = 29-Only RSA-PSS Restricted Certificate-client
+[29-RSA-PSS Restricted Certificate Invalid Signature Algorithms-ssl]
+server = 29-RSA-PSS Restricted Certificate Invalid Signature Algorithms-server
+client = 29-RSA-PSS Restricted Certificate Invalid Signature Algorithms-client
 
-[29-Only RSA-PSS Restricted Certificate-server]
+[29-RSA-PSS Restricted Certificate Invalid Signature Algorithms-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
 
-[29-Only RSA-PSS Restricted Certificate-client]
+[29-RSA-PSS Restricted Certificate Invalid Signature Algorithms-client]
 CipherString = DEFAULT
+SignatureAlgorithms = Rsa_Pss_pss_Sha512
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-29]
-ExpectedResult = Success
-ExpectedServerCertType = RSA-PSS
-ExpectedServerSignHash = SHA256
-ExpectedServerSignType = RSA-PSS
-
-
-# ===========================================================
-
-[30-RSA-PSS Restricted Certificate Valid Signature Algorithms]
-ssl_conf = 30-RSA-PSS Restricted Certificate Valid Signature Algorithms-ssl
-
-[30-RSA-PSS Restricted Certificate Valid Signature Algorithms-ssl]
-server = 30-RSA-PSS Restricted Certificate Valid Signature Algorithms-server
-client = 30-RSA-PSS Restricted Certificate Valid Signature Algorithms-client
-
-[30-RSA-PSS Restricted Certificate Valid Signature Algorithms-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
-
-[30-RSA-PSS Restricted Certificate Valid Signature Algorithms-client]
-CipherString = DEFAULT
-SignatureAlgorithms = RSa_pSS_pSs_sHA256:rsa_PsS_PSs_sHA512
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-30]
-ExpectedResult = Success
-ExpectedServerCertType = RSA-PSS
-ExpectedServerSignHash = SHA256
-ExpectedServerSignType = RSA-PSS
-
-
-# ===========================================================
-
-[31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm]
-ssl_conf = 31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-ssl
-
-[31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-ssl]
-server = 31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-server
-client = 31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-client
-
-[31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
-
-[31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-client]
-CipherString = DEFAULT
-SignatureAlgorithms = rsA_pss_psS_sha512:rsA_pSS_PSs_ShA256
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-31]
-ExpectedResult = Success
-ExpectedServerCertType = RSA-PSS
-ExpectedServerSignHash = SHA256
-ExpectedServerSignType = RSA-PSS
-
-
-# ===========================================================
-
-[32-RSA-PSS Restricted Certificate Invalid Signature Algorithms]
-ssl_conf = 32-RSA-PSS Restricted Certificate Invalid Signature Algorithms-ssl
-
-[32-RSA-PSS Restricted Certificate Invalid Signature Algorithms-ssl]
-server = 32-RSA-PSS Restricted Certificate Invalid Signature Algorithms-server
-client = 32-RSA-PSS Restricted Certificate Invalid Signature Algorithms-client
-
-[32-RSA-PSS Restricted Certificate Invalid Signature Algorithms-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
-
-[32-RSA-PSS Restricted Certificate Invalid Signature Algorithms-client]
-CipherString = DEFAULT
-SignatureAlgorithms = rSa_PSS_pSS_sHa512
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-32]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[33-RSA key exchange with only RSA-PSS certificate]
-ssl_conf = 33-RSA key exchange with only RSA-PSS certificate-ssl
+[30-RSA key exchange with only RSA-PSS certificate]
+ssl_conf = 30-RSA key exchange with only RSA-PSS certificate-ssl
 
-[33-RSA key exchange with only RSA-PSS certificate-ssl]
-server = 33-RSA key exchange with only RSA-PSS certificate-server
-client = 33-RSA key exchange with only RSA-PSS certificate-client
+[30-RSA key exchange with only RSA-PSS certificate-ssl]
+server = 30-RSA key exchange with only RSA-PSS certificate-server
+client = 30-RSA key exchange with only RSA-PSS certificate-client
 
-[33-RSA key exchange with only RSA-PSS certificate-server]
+[30-RSA key exchange with only RSA-PSS certificate-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 
-[33-RSA key exchange with only RSA-PSS certificate-client]
+[30-RSA key exchange with only RSA-PSS certificate-client]
 CipherString = kRSA
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-33]
+[test-30]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[34-Only RSA-PSS Certificate, TLS v1.1]
-ssl_conf = 34-Only RSA-PSS Certificate, TLS v1.1-ssl
+[31-Only RSA-PSS Certificate, TLS v1.1]
+ssl_conf = 31-Only RSA-PSS Certificate, TLS v1.1-ssl
 
-[34-Only RSA-PSS Certificate, TLS v1.1-ssl]
-server = 34-Only RSA-PSS Certificate, TLS v1.1-server
-client = 34-Only RSA-PSS Certificate, TLS v1.1-client
+[31-Only RSA-PSS Certificate, TLS v1.1-ssl]
+server = 31-Only RSA-PSS Certificate, TLS v1.1-server
+client = 31-Only RSA-PSS Certificate, TLS v1.1-client
 
-[34-Only RSA-PSS Certificate, TLS v1.1-server]
+[31-Only RSA-PSS Certificate, TLS v1.1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 
-[34-Only RSA-PSS Certificate, TLS v1.1-client]
+[31-Only RSA-PSS Certificate, TLS v1.1-client]
 CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-31]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[32-TLS 1.3 ECDSA Signature Algorithm Selection]
+ssl_conf = 32-TLS 1.3 ECDSA Signature Algorithm Selection-ssl
+
+[32-TLS 1.3 ECDSA Signature Algorithm Selection-ssl]
+server = 32-TLS 1.3 ECDSA Signature Algorithm Selection-server
+client = 32-TLS 1.3 ECDSA Signature Algorithm Selection-client
+
+[32-TLS 1.3 ECDSA Signature Algorithm Selection-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[32-TLS 1.3 ECDSA Signature Algorithm Selection-client]
+CipherString = DEFAULT
+SignatureAlgorithms = ECDsA+SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-32]
+ExpectedResult = Success
+ExpectedServerCANames = empty
+ExpectedServerCertType = P-256
+ExpectedServerSignHash = SHA256
+ExpectedServerSignType = EC
+
+
+# ===========================================================
+
+[33-TLS 1.3 ECDSA Signature Algorithm Selection compressed point]
+ssl_conf = 33-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-ssl
+
+[33-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-ssl]
+server = 33-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-server
+client = 33-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-client
+
+[33-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-cecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-cecdsa-key.pem
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[33-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-client]
+CipherString = DEFAULT
+SignatureAlgorithms = ecdsA+SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-33]
+ExpectedResult = Success
+ExpectedServerCANames = empty
+ExpectedServerCertType = P-256
+ExpectedServerSignHash = SHA256
+ExpectedServerSignType = EC
+
+
+# ===========================================================
+
+[34-TLS 1.3 ECDSA Signature Algorithm Selection SHA1]
+ssl_conf = 34-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-ssl
+
+[34-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-ssl]
+server = 34-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-server
+client = 34-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-client
+
+[34-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT:@SECLEVEL=0
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[34-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-client]
+CipherString = DEFAULT:@SECLEVEL=0
+SignatureAlgorithms = eCdSa+SHA1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1135,14 +1142,14 @@ ExpectedResult = ServerFail
 
 # ===========================================================
 
-[35-TLS 1.3 ECDSA Signature Algorithm Selection]
-ssl_conf = 35-TLS 1.3 ECDSA Signature Algorithm Selection-ssl
+[35-TLS 1.3 ECDSA Signature Algorithm Selection with PSS]
+ssl_conf = 35-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-ssl
 
-[35-TLS 1.3 ECDSA Signature Algorithm Selection-ssl]
-server = 35-TLS 1.3 ECDSA Signature Algorithm Selection-server
-client = 35-TLS 1.3 ECDSA Signature Algorithm Selection-client
+[35-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-ssl]
+server = 35-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-server
+client = 35-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-client
 
-[35-TLS 1.3 ECDSA Signature Algorithm Selection-server]
+[35-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1155,114 +1162,14 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[35-TLS 1.3 ECDSA Signature Algorithm Selection-client]
+[35-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-client]
 CipherString = DEFAULT
-SignatureAlgorithms = ECDsa+SHA256
+RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+SignatureAlgorithms = EcdsA+SHA256:rsA-pSS+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-35]
-ExpectedResult = Success
-ExpectedServerCANames = empty
-ExpectedServerCertType = P-256
-ExpectedServerSignHash = SHA256
-ExpectedServerSignType = EC
-
-
-# ===========================================================
-
-[36-TLS 1.3 ECDSA Signature Algorithm Selection compressed point]
-ssl_conf = 36-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-ssl
-
-[36-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-ssl]
-server = 36-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-server
-client = 36-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-client
-
-[36-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-cecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-cecdsa-key.pem
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[36-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-client]
-CipherString = DEFAULT
-SignatureAlgorithms = ecDSA+SHA256
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-36]
-ExpectedResult = Success
-ExpectedServerCANames = empty
-ExpectedServerCertType = P-256
-ExpectedServerSignHash = SHA256
-ExpectedServerSignType = EC
-
-
-# ===========================================================
-
-[37-TLS 1.3 ECDSA Signature Algorithm Selection SHA1]
-ssl_conf = 37-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-ssl
-
-[37-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-ssl]
-server = 37-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-server
-client = 37-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-client
-
-[37-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT:@SECLEVEL=0
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
-Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
-Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
-Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
-Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[37-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-client]
-CipherString = DEFAULT:@SECLEVEL=0
-SignatureAlgorithms = eCDSa+SHA1
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-37]
-ExpectedResult = ServerFail
-
-
-# ===========================================================
-
-[38-TLS 1.3 ECDSA Signature Algorithm Selection with PSS]
-ssl_conf = 38-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-ssl
-
-[38-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-ssl]
-server = 38-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-server
-client = 38-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-client
-
-[38-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
-Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
-Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
-Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
-Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[38-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-client]
-CipherString = DEFAULT
-RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-SignatureAlgorithms = eCdsA+SHA256:rsA-pSs+SHA256
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-38]
 ExpectedResult = Success
 ExpectedServerCANames = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 ExpectedServerCertType = P-256
@@ -1272,14 +1179,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[39-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS]
-ssl_conf = 39-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-ssl
+[36-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS]
+ssl_conf = 36-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-ssl
 
-[39-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-ssl]
-server = 39-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-server
-client = 39-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-client
+[36-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-ssl]
+server = 36-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-server
+client = 36-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-client
 
-[39-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-server]
+[36-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1292,13 +1199,13 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[39-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-client]
+[36-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-client]
 CipherString = DEFAULT
-SignatureAlgorithms = ECdsA+SHA384:RSa-psS+SHA384
+SignatureAlgorithms = ECdsa+SHA384:rSA-PsS+SHA384
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-39]
+[test-36]
 ExpectedResult = Success
 ExpectedServerCertType = RSA
 ExpectedServerSignHash = SHA384
@@ -1307,40 +1214,40 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[40-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate]
-ssl_conf = 40-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl
+[37-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate]
+ssl_conf = 37-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl
 
-[40-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl]
-server = 40-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-server
-client = 40-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-client
+[37-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl]
+server = 37-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-server
+client = 37-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-client
 
-[40-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-server]
+[37-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[40-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-client]
+[37-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-client]
 CipherString = DEFAULT
-SignatureAlgorithms = eCDSA+SHA256
+SignatureAlgorithms = ECdsA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-40]
+[test-37]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[41-TLS 1.3 RSA Signature Algorithm Selection, no PSS]
-ssl_conf = 41-TLS 1.3 RSA Signature Algorithm Selection, no PSS-ssl
+[38-TLS 1.3 RSA Signature Algorithm Selection, no PSS]
+ssl_conf = 38-TLS 1.3 RSA Signature Algorithm Selection, no PSS-ssl
 
-[41-TLS 1.3 RSA Signature Algorithm Selection, no PSS-ssl]
-server = 41-TLS 1.3 RSA Signature Algorithm Selection, no PSS-server
-client = 41-TLS 1.3 RSA Signature Algorithm Selection, no PSS-client
+[38-TLS 1.3 RSA Signature Algorithm Selection, no PSS-ssl]
+server = 38-TLS 1.3 RSA Signature Algorithm Selection, no PSS-server
+client = 38-TLS 1.3 RSA Signature Algorithm Selection, no PSS-client
 
-[41-TLS 1.3 RSA Signature Algorithm Selection, no PSS-server]
+[38-TLS 1.3 RSA Signature Algorithm Selection, no PSS-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1353,26 +1260,26 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[41-TLS 1.3 RSA Signature Algorithm Selection, no PSS-client]
+[38-TLS 1.3 RSA Signature Algorithm Selection, no PSS-client]
 CipherString = DEFAULT
-SignatureAlgorithms = RSA+SHA256
+SignatureAlgorithms = rsA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-41]
+[test-38]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[42-TLS 1.3 RSA-PSS Signature Algorithm Selection]
-ssl_conf = 42-TLS 1.3 RSA-PSS Signature Algorithm Selection-ssl
+[39-TLS 1.3 RSA-PSS Signature Algorithm Selection]
+ssl_conf = 39-TLS 1.3 RSA-PSS Signature Algorithm Selection-ssl
 
-[42-TLS 1.3 RSA-PSS Signature Algorithm Selection-ssl]
-server = 42-TLS 1.3 RSA-PSS Signature Algorithm Selection-server
-client = 42-TLS 1.3 RSA-PSS Signature Algorithm Selection-client
+[39-TLS 1.3 RSA-PSS Signature Algorithm Selection-ssl]
+server = 39-TLS 1.3 RSA-PSS Signature Algorithm Selection-server
+client = 39-TLS 1.3 RSA-PSS Signature Algorithm Selection-client
 
-[42-TLS 1.3 RSA-PSS Signature Algorithm Selection-server]
+[39-TLS 1.3 RSA-PSS Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1385,13 +1292,13 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[42-TLS 1.3 RSA-PSS Signature Algorithm Selection-client]
+[39-TLS 1.3 RSA-PSS Signature Algorithm Selection-client]
 CipherString = DEFAULT
-SignatureAlgorithms = Rsa-PSS+SHA256
+SignatureAlgorithms = rsA-pSs+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-42]
+[test-39]
 ExpectedResult = Success
 ExpectedServerCertType = RSA
 ExpectedServerSignHash = SHA256
@@ -1400,22 +1307,22 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[43-TLS 1.3 RSA Client Auth Signature Algorithm Selection]
-ssl_conf = 43-TLS 1.3 RSA Client Auth Signature Algorithm Selection-ssl
+[40-TLS 1.3 RSA Client Auth Signature Algorithm Selection]
+ssl_conf = 40-TLS 1.3 RSA Client Auth Signature Algorithm Selection-ssl
 
-[43-TLS 1.3 RSA Client Auth Signature Algorithm Selection-ssl]
-server = 43-TLS 1.3 RSA Client Auth Signature Algorithm Selection-server
-client = 43-TLS 1.3 RSA Client Auth Signature Algorithm Selection-client
+[40-TLS 1.3 RSA Client Auth Signature Algorithm Selection-ssl]
+server = 40-TLS 1.3 RSA Client Auth Signature Algorithm Selection-server
+client = 40-TLS 1.3 RSA Client Auth Signature Algorithm Selection-client
 
-[43-TLS 1.3 RSA Client Auth Signature Algorithm Selection-server]
+[40-TLS 1.3 RSA Client Auth Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-ClientSignatureAlgorithms = PSS+SHA256
+ClientSignatureAlgorithms = PSs+SHA256
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[43-TLS 1.3 RSA Client Auth Signature Algorithm Selection-client]
+[40-TLS 1.3 RSA Client Auth Signature Algorithm Selection-client]
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-client-chain.pem
 ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-key.pem
@@ -1426,7 +1333,7 @@ RSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-43]
+[test-40]
 ExpectedClientCANames = empty
 ExpectedClientCertType = RSA
 ExpectedClientSignHash = SHA256
@@ -1436,23 +1343,23 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names]
-ssl_conf = 44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-ssl
+[41-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names]
+ssl_conf = 41-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-ssl
 
-[44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-ssl]
-server = 44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-server
-client = 44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-client
+[41-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-ssl]
+server = 41-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-server
+client = 41-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-client
 
-[44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-server]
+[41-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-ClientSignatureAlgorithms = Pss+SHA256
+ClientSignatureAlgorithms = pSS+SHA256
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-client]
+[41-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-client]
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-client-chain.pem
 ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-key.pem
@@ -1463,7 +1370,7 @@ RSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-44]
+[test-41]
 ExpectedClientCANames = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 ExpectedClientCertType = RSA
 ExpectedClientSignHash = SHA256
@@ -1473,22 +1380,22 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection]
-ssl_conf = 45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-ssl
+[42-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection]
+ssl_conf = 42-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-ssl
 
-[45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-ssl]
-server = 45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-server
-client = 45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-client
+[42-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-ssl]
+server = 42-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-server
+client = 42-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-client
 
-[45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-server]
+[42-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-ClientSignatureAlgorithms = ECDsA+SHA256
+ClientSignatureAlgorithms = EcdsA+SHA256
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-client]
+[42-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-client]
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-client-chain.pem
 ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-key.pem
@@ -1499,7 +1406,7 @@ RSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-45]
+[test-42]
 ExpectedClientCertType = P-256
 ExpectedClientSignHash = SHA256
 ExpectedClientSignType = EC
@@ -1508,14 +1415,14 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[46-TLS 1.3 Ed25519 Signature Algorithm Selection]
-ssl_conf = 46-TLS 1.3 Ed25519 Signature Algorithm Selection-ssl
+[43-TLS 1.3 Ed25519 Signature Algorithm Selection]
+ssl_conf = 43-TLS 1.3 Ed25519 Signature Algorithm Selection-ssl
 
-[46-TLS 1.3 Ed25519 Signature Algorithm Selection-ssl]
-server = 46-TLS 1.3 Ed25519 Signature Algorithm Selection-server
-client = 46-TLS 1.3 Ed25519 Signature Algorithm Selection-client
+[43-TLS 1.3 Ed25519 Signature Algorithm Selection-ssl]
+server = 43-TLS 1.3 Ed25519 Signature Algorithm Selection-server
+client = 43-TLS 1.3 Ed25519 Signature Algorithm Selection-client
 
-[46-TLS 1.3 Ed25519 Signature Algorithm Selection-server]
+[43-TLS 1.3 Ed25519 Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1528,13 +1435,13 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[46-TLS 1.3 Ed25519 Signature Algorithm Selection-client]
+[43-TLS 1.3 Ed25519 Signature Algorithm Selection-client]
 CipherString = DEFAULT
-SignatureAlgorithms = eD25519
+SignatureAlgorithms = Ed25519
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-46]
+[test-43]
 ExpectedResult = Success
 ExpectedServerCertType = Ed25519
 ExpectedServerSignType = Ed25519
@@ -1542,14 +1449,14 @@ ExpectedServerSignType = Ed25519
 
 # ===========================================================
 
-[47-TLS 1.3 Ed448 Signature Algorithm Selection]
-ssl_conf = 47-TLS 1.3 Ed448 Signature Algorithm Selection-ssl
+[44-TLS 1.3 Ed448 Signature Algorithm Selection]
+ssl_conf = 44-TLS 1.3 Ed448 Signature Algorithm Selection-ssl
 
-[47-TLS 1.3 Ed448 Signature Algorithm Selection-ssl]
-server = 47-TLS 1.3 Ed448 Signature Algorithm Selection-server
-client = 47-TLS 1.3 Ed448 Signature Algorithm Selection-client
+[44-TLS 1.3 Ed448 Signature Algorithm Selection-ssl]
+server = 44-TLS 1.3 Ed448 Signature Algorithm Selection-server
+client = 44-TLS 1.3 Ed448 Signature Algorithm Selection-client
 
-[47-TLS 1.3 Ed448 Signature Algorithm Selection-server]
+[44-TLS 1.3 Ed448 Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1562,13 +1469,13 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[47-TLS 1.3 Ed448 Signature Algorithm Selection-client]
+[44-TLS 1.3 Ed448 Signature Algorithm Selection-client]
 CipherString = DEFAULT
-SignatureAlgorithms = eD448
+SignatureAlgorithms = ed448
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-ed448-cert.pem
 VerifyMode = Peer
 
-[test-47]
+[test-44]
 ExpectedResult = Success
 ExpectedServerCertType = Ed448
 ExpectedServerSignType = Ed448
@@ -1576,14 +1483,14 @@ ExpectedServerSignType = Ed448
 
 # ===========================================================
 
-[48-TLS 1.3 Ed25519 CipherString and Groups Selection]
-ssl_conf = 48-TLS 1.3 Ed25519 CipherString and Groups Selection-ssl
+[45-TLS 1.3 Ed25519 CipherString and Groups Selection]
+ssl_conf = 45-TLS 1.3 Ed25519 CipherString and Groups Selection-ssl
 
-[48-TLS 1.3 Ed25519 CipherString and Groups Selection-ssl]
-server = 48-TLS 1.3 Ed25519 CipherString and Groups Selection-server
-client = 48-TLS 1.3 Ed25519 CipherString and Groups Selection-client
+[45-TLS 1.3 Ed25519 CipherString and Groups Selection-ssl]
+server = 45-TLS 1.3 Ed25519 CipherString and Groups Selection-server
+client = 45-TLS 1.3 Ed25519 CipherString and Groups Selection-client
 
-[48-TLS 1.3 Ed25519 CipherString and Groups Selection-server]
+[45-TLS 1.3 Ed25519 CipherString and Groups Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1596,14 +1503,14 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[48-TLS 1.3 Ed25519 CipherString and Groups Selection-client]
+[45-TLS 1.3 Ed25519 CipherString and Groups Selection-client]
 CipherString = DEFAULT
 Groups = X25519
-SignatureAlgorithms = EcdSA+SHA256:eD25519
+SignatureAlgorithms = ECDSA+SHA256:ED25519
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-48]
+[test-45]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignType = EC
@@ -1611,14 +1518,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[49-TLS 1.3 Ed448 CipherString and Groups Selection]
-ssl_conf = 49-TLS 1.3 Ed448 CipherString and Groups Selection-ssl
+[46-TLS 1.3 Ed448 CipherString and Groups Selection]
+ssl_conf = 46-TLS 1.3 Ed448 CipherString and Groups Selection-ssl
 
-[49-TLS 1.3 Ed448 CipherString and Groups Selection-ssl]
-server = 49-TLS 1.3 Ed448 CipherString and Groups Selection-server
-client = 49-TLS 1.3 Ed448 CipherString and Groups Selection-client
+[46-TLS 1.3 Ed448 CipherString and Groups Selection-ssl]
+server = 46-TLS 1.3 Ed448 CipherString and Groups Selection-server
+client = 46-TLS 1.3 Ed448 CipherString and Groups Selection-client
 
-[49-TLS 1.3 Ed448 CipherString and Groups Selection-server]
+[46-TLS 1.3 Ed448 CipherString and Groups Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1631,14 +1538,14 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[49-TLS 1.3 Ed448 CipherString and Groups Selection-client]
+[46-TLS 1.3 Ed448 CipherString and Groups Selection-client]
 CipherString = DEFAULT
 Groups = X448
-SignatureAlgorithms = eCDSa+SHA256:ED448
+SignatureAlgorithms = ECDSA+SHA256:ed448
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-49]
+[test-46]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignType = EC
@@ -1646,21 +1553,21 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[50-TLS 1.3 Ed25519 Client Auth]
-ssl_conf = 50-TLS 1.3 Ed25519 Client Auth-ssl
+[47-TLS 1.3 Ed25519 Client Auth]
+ssl_conf = 47-TLS 1.3 Ed25519 Client Auth-ssl
 
-[50-TLS 1.3 Ed25519 Client Auth-ssl]
-server = 50-TLS 1.3 Ed25519 Client Auth-server
-client = 50-TLS 1.3 Ed25519 Client Auth-client
+[47-TLS 1.3 Ed25519 Client Auth-ssl]
+server = 47-TLS 1.3 Ed25519 Client Auth-server
+client = 47-TLS 1.3 Ed25519 Client Auth-client
 
-[50-TLS 1.3 Ed25519 Client Auth-server]
+[47-TLS 1.3 Ed25519 Client Auth-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[50-TLS 1.3 Ed25519 Client Auth-client]
+[47-TLS 1.3 Ed25519 Client Auth-client]
 CipherString = DEFAULT
 EdDSA.Certificate = ${ENV::TEST_CERTS_DIR}/client-ed25519-cert.pem
 EdDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/client-ed25519-key.pem
@@ -1669,7 +1576,7 @@ MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-50]
+[test-47]
 ExpectedClientCertType = Ed25519
 ExpectedClientSignType = Ed25519
 ExpectedResult = Success
@@ -1677,21 +1584,21 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[51-TLS 1.3 Ed448 Client Auth]
-ssl_conf = 51-TLS 1.3 Ed448 Client Auth-ssl
+[48-TLS 1.3 Ed448 Client Auth]
+ssl_conf = 48-TLS 1.3 Ed448 Client Auth-ssl
 
-[51-TLS 1.3 Ed448 Client Auth-ssl]
-server = 51-TLS 1.3 Ed448 Client Auth-server
-client = 51-TLS 1.3 Ed448 Client Auth-client
+[48-TLS 1.3 Ed448 Client Auth-ssl]
+server = 48-TLS 1.3 Ed448 Client Auth-server
+client = 48-TLS 1.3 Ed448 Client Auth-client
 
-[51-TLS 1.3 Ed448 Client Auth-server]
+[48-TLS 1.3 Ed448 Client Auth-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[51-TLS 1.3 Ed448 Client Auth-client]
+[48-TLS 1.3 Ed448 Client Auth-client]
 CipherString = DEFAULT
 EdDSA.Certificate = ${ENV::TEST_CERTS_DIR}/client-ed448-cert.pem
 EdDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/client-ed448-key.pem
@@ -1700,7 +1607,7 @@ MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-51]
+[test-48]
 ExpectedClientCertType = Ed448
 ExpectedClientSignType = Ed448
 ExpectedResult = Success
@@ -1708,45 +1615,45 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[52-TLS 1.3 ECDSA with brainpool but no suitable groups]
-ssl_conf = 52-TLS 1.3 ECDSA with brainpool but no suitable groups-ssl
+[49-TLS 1.3 ECDSA with brainpool but no suitable groups]
+ssl_conf = 49-TLS 1.3 ECDSA with brainpool but no suitable groups-ssl
 
-[52-TLS 1.3 ECDSA with brainpool but no suitable groups-ssl]
-server = 52-TLS 1.3 ECDSA with brainpool but no suitable groups-server
-client = 52-TLS 1.3 ECDSA with brainpool but no suitable groups-client
+[49-TLS 1.3 ECDSA with brainpool but no suitable groups-ssl]
+server = 49-TLS 1.3 ECDSA with brainpool but no suitable groups-server
+client = 49-TLS 1.3 ECDSA with brainpool but no suitable groups-client
 
-[52-TLS 1.3 ECDSA with brainpool but no suitable groups-server]
+[49-TLS 1.3 ECDSA with brainpool but no suitable groups-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-cert.pem
 CipherString = DEFAULT
 Groups = brainpoolP256r1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-key.pem
 
-[52-TLS 1.3 ECDSA with brainpool but no suitable groups-client]
+[49-TLS 1.3 ECDSA with brainpool but no suitable groups-client]
 CipherString = aECDSA
 Groups = brainpoolP256r1
 RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-52]
+[test-49]
 ExpectedResult = ClientFail
 
 
 # ===========================================================
 
-[53-TLS 1.3 ECDSA with brainpool]
-ssl_conf = 53-TLS 1.3 ECDSA with brainpool-ssl
+[50-TLS 1.3 ECDSA with brainpool]
+ssl_conf = 50-TLS 1.3 ECDSA with brainpool-ssl
 
-[53-TLS 1.3 ECDSA with brainpool-ssl]
-server = 53-TLS 1.3 ECDSA with brainpool-server
-client = 53-TLS 1.3 ECDSA with brainpool-client
+[50-TLS 1.3 ECDSA with brainpool-ssl]
+server = 50-TLS 1.3 ECDSA with brainpool-server
+client = 50-TLS 1.3 ECDSA with brainpool-client
 
-[53-TLS 1.3 ECDSA with brainpool-server]
+[50-TLS 1.3 ECDSA with brainpool-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-cert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-key.pem
 
-[53-TLS 1.3 ECDSA with brainpool-client]
+[50-TLS 1.3 ECDSA with brainpool-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
@@ -1754,20 +1661,20 @@ RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-53]
+[test-50]
 ExpectedResult = Success
 
 
 # ===========================================================
 
-[54-TLS 1.2 DSA Certificate Test]
-ssl_conf = 54-TLS 1.2 DSA Certificate Test-ssl
+[51-TLS 1.2 DSA Certificate Test]
+ssl_conf = 51-TLS 1.2 DSA Certificate Test-ssl
 
-[54-TLS 1.2 DSA Certificate Test-ssl]
-server = 54-TLS 1.2 DSA Certificate Test-server
-client = 54-TLS 1.2 DSA Certificate Test-client
+[51-TLS 1.2 DSA Certificate Test-ssl]
+server = 51-TLS 1.2 DSA Certificate Test-server
+client = 51-TLS 1.2 DSA Certificate Test-client
 
-[54-TLS 1.2 DSA Certificate Test-server]
+[51-TLS 1.2 DSA Certificate Test-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = ALL
 DHParameters = ${ENV::TEST_CERTS_DIR}/dhp2048.pem
@@ -1777,52 +1684,52 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[54-TLS 1.2 DSA Certificate Test-client]
+[51-TLS 1.2 DSA Certificate Test-client]
 CipherString = ALL
-SignatureAlgorithms = DSA+SHA256:DSa+SHA1
+SignatureAlgorithms = dsA+SHA256:DSa+SHA1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-54]
+[test-51]
 ExpectedResult = Success
 
 
 # ===========================================================
 
-[55-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms]
-ssl_conf = 55-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-ssl
+[52-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms]
+ssl_conf = 52-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-ssl
 
-[55-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-ssl]
-server = 55-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-server
-client = 55-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-client
+[52-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-ssl]
+server = 52-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-server
+client = 52-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-client
 
-[55-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-server]
+[52-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-ClientSignatureAlgorithms = ecDSA+SHA1:DsA+SHA256:rsA+SHA256
+ClientSignatureAlgorithms = ECdSa+SHA1:Dsa+SHA256:RSA+SHA256
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Request
 
-[55-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-client]
+[52-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-55]
+[test-52]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[56-TLS 1.3 DSA Certificate Test]
-ssl_conf = 56-TLS 1.3 DSA Certificate Test-ssl
+[53-TLS 1.3 DSA Certificate Test]
+ssl_conf = 53-TLS 1.3 DSA Certificate Test-ssl
 
-[56-TLS 1.3 DSA Certificate Test-ssl]
-server = 56-TLS 1.3 DSA Certificate Test-server
-client = 56-TLS 1.3 DSA Certificate Test-client
+[53-TLS 1.3 DSA Certificate Test-ssl]
+server = 53-TLS 1.3 DSA Certificate Test-server
+client = 53-TLS 1.3 DSA Certificate Test-client
 
-[56-TLS 1.3 DSA Certificate Test-server]
+[53-TLS 1.3 DSA Certificate Test-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = ALL
 DSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-dsa-cert.pem
@@ -1831,42 +1738,42 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[56-TLS 1.3 DSA Certificate Test-client]
+[53-TLS 1.3 DSA Certificate Test-client]
 CipherString = ALL
-SignatureAlgorithms = dSA+SHA1:DSA+SHA256:ecDsa+SHA256
+SignatureAlgorithms = dsA+SHA1:DSa+SHA256:ecDSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-56]
+[test-53]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[57-TLS 1.3 ML-DSA Certificate Test]
-ssl_conf = 57-TLS 1.3 ML-DSA Certificate Test-ssl
+[54-TLS 1.3 ML-DSA Certificate Test]
+ssl_conf = 54-TLS 1.3 ML-DSA Certificate Test-ssl
 
-[57-TLS 1.3 ML-DSA Certificate Test-ssl]
-server = 57-TLS 1.3 ML-DSA Certificate Test-server
-client = 57-TLS 1.3 ML-DSA Certificate Test-client
+[54-TLS 1.3 ML-DSA Certificate Test-ssl]
+server = 54-TLS 1.3 ML-DSA Certificate Test-server
+client = 54-TLS 1.3 ML-DSA Certificate Test-client
 
-[57-TLS 1.3 ML-DSA Certificate Test-server]
+[54-TLS 1.3 ML-DSA Certificate Test-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-ml-dsa-44-cert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ml-dsa-44-key.pem
-SignatureAlgorithms = mlDsA44
+SignatureAlgorithms = mlDSA44
 
-[57-TLS 1.3 ML-DSA Certificate Test-client]
+[54-TLS 1.3 ML-DSA Certificate Test-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
-SignatureAlgorithms = mlDSa44
+SignatureAlgorithms = mldsA44
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-ml-dsa-44-cert.pem
 VerifyMode = Peer
 
-[test-57]
+[test-54]
 ExpectedResult = Success
 
 

--- a/test/ssl-tests/20-cert-select.cnf.in
+++ b/test/ssl-tests/20-cert-select.cnf.in
@@ -203,23 +203,6 @@ our @tests = (
         },
     },
     {
-        name => "ECDSA Signature Algorithm Selection compressed point",
-        server => {
-            "ECDSA.Certificate" => test_pem("server-cecdsa-cert.pem"),
-            "ECDSA.PrivateKey" => test_pem("server-cecdsa-key.pem"),
-            "MaxProtocol" => "TLSv1.2"
-        },
-        client => {
-            "SignatureAlgorithms" => randcase("ECDSA+SHA256"),
-        },
-        test   => {
-            "ExpectedServerCertType" => "P-256",
-            "ExpectedServerSignHash" => "SHA256",
-            "ExpectedServerSignType" => "EC",
-            "ExpectedResult" => "Success"
-        },
-    },
-    {
         name => "ECDSA Signature Algorithm Selection, no ECDSA certificate",
         server => {
              "MaxProtocol" => "TLSv1.2"
@@ -267,44 +250,6 @@ our @tests = (
         test   => {
             "ExpectedServerCertType" =>, "RSA",
             "ExpectedResult" => $fips_3_4 ? "ClientFail" : "Success"
-        },
-    },
-    {
-        name => "Suite B P-256 Hash Algorithm Selection",
-        server =>  {
-            "ECDSA.Certificate" => test_pem("p256-server-cert.pem"),
-            "ECDSA.PrivateKey" => test_pem("p256-server-key.pem"),
-            "MaxProtocol" => "TLSv1.2",
-            "CipherString" => "SUITEB128"
-        },
-        client => {
-            "VerifyCAFile" => test_pem("p384-root.pem"),
-            "SignatureAlgorithms" => randcase("ECDSA+SHA384:ECDSA+SHA256")
-        },
-        test   => {
-            "ExpectedServerCertType" => "P-256",
-            "ExpectedServerSignHash" => "SHA256",
-            "ExpectedServerSignType" => "EC",
-            "ExpectedResult" => "Success"
-        },
-    },
-    {
-        name => "Suite B P-384 Hash Algorithm Selection",
-        server =>  {
-            "ECDSA.Certificate" => test_pem("p384-server-cert.pem"),
-            "ECDSA.PrivateKey" => test_pem("p384-server-key.pem"),
-            "MaxProtocol" => "TLSv1.2",
-            "CipherString" => "SUITEB128"
-        },
-        client => {
-            "VerifyCAFile" => test_pem("p384-root.pem"),
-            "SignatureAlgorithms" => randcase("ECDSA+SHA256:ECDSA+SHA384")
-        },
-        test   => {
-            "ExpectedServerCertType" => "P-384",
-            "ExpectedServerSignHash" => "SHA384",
-            "ExpectedServerSignType" => "EC",
-            "ExpectedResult" => "Success"
         },
     },
     {


### PR DESCRIPTION
This PR is an alternative to #26990.

Rather than making EC points configurable, since compressed formats are deprecated nowadays, we could instead change the OpenSSL default entirely to just send uncompressed by default as suggested by @davidben.

This would align OpenSSL with various other TLS implementations, such as BoringSSL, who already do this by default.

It may cause disruption downstream, since it changes a parameter of all TLS handshakes, and there is no configurability here, so it means effectively dropping support for compressed EC points with no workarounds for any affected users. I'm not aware of any good reason anybody would depend on that previous behaviour, particularly since it's deprecated and rarely used elsewhere, but changing this default does notably break 3 of the `20-cert-select` integration tests here.

**I've just deleted those tests to make CI pass, on the assumption that they're handshakes that are no longer supported with this change, so the tests aren't relevant, but I don't know the full context of these test configurations! Somebody who does should evaluate this.** Each of these tests fails consistently with this change, but I don't have a good enough understanding of the configurations in question to confirm why exactly that happens.

I also haven't removed the pre-existing present-but-unused configuration logic for this field (`ctx->ext.ecpointformats`). If you want to commit to fully dropping support for all other EC point formats, that field and all related code can probably be removed, along with any other code that actually supports the two dropped compression formats.

This PR is intended as a rough draft to start discussion on changing this default, and see if that's a route people would prefer in reality over making it configurable (#26990). I'll leave this PR as a draft until the various consequences (especially deleting the failing tests) been discussed.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
