### PR TITLE
Fix interop ci yaml

### DIFF
--- a/.github/workflows/run_quic_interop.yml
+++ b/.github/workflows/run_quic_interop.yml
@@ -13,7 +13,7 @@ jobs:
         tests: [http3, transfer, handshake, retry, chacha20, resumption, multiplexing, ipv6]
         servers: [quic-go, ngtcp2, mvfst, quiche, nginx, msquic, haproxy]
         exclude:
-          - clients: msquic
+          - servers: msquic
             tests: retry
       fail-fast: false
     runs-on: ubuntu-latest


### PR DESCRIPTION
Somehow I mistakenly listed clients in the exlude list, when it should have been servers, resulting in an invalid yml file


##### Checklist
- [x] tests are added or updated
