### PR TITLE
Avoid erroneous legacy codepath when provided

### DIFF
--- a/crypto/evp/ctrl_params_translate.c
+++ b/crypto/evp/ctrl_params_translate.c
@@ -2895,11 +2895,15 @@ static int evp_pkey_ctx_setget_params_to_ctrl(EVP_PKEY_CTX *pctx,
 
 int evp_pkey_ctx_set_params_to_ctrl(EVP_PKEY_CTX *ctx, const OSSL_PARAM *params)
 {
+    if (ctx->keymgmt != NULL)
+        return 0;
     return evp_pkey_ctx_setget_params_to_ctrl(ctx, SET, (OSSL_PARAM *)params);
 }
 
 int evp_pkey_ctx_get_params_to_ctrl(EVP_PKEY_CTX *ctx, OSSL_PARAM *params)
 {
+    if (ctx->keymgmt != NULL)
+        return 0;
     return evp_pkey_ctx_setget_params_to_ctrl(ctx, GET, params);
 }
 

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -701,8 +701,9 @@ int EVP_PKEY_CTX_set_params(EVP_PKEY_CTX *ctx, const OSSL_PARAM *params)
                 ctx->op.encap.kem->set_ctx_params(ctx->op.encap.algctx,
                                                   params);
         break;
-#ifndef FIPS_MODULE
     case EVP_PKEY_STATE_UNKNOWN:
+        break;
+#ifndef FIPS_MODULE
     case EVP_PKEY_STATE_LEGACY:
         return evp_pkey_ctx_set_params_to_ctrl(ctx, params);
 #endif
@@ -745,8 +746,9 @@ int EVP_PKEY_CTX_get_params(EVP_PKEY_CTX *ctx, OSSL_PARAM *params)
                 evp_keymgmt_gen_get_params(ctx->keymgmt, ctx->op.keymgmt.genctx,
                                            params);
         break;
-#ifndef FIPS_MODULE
     case EVP_PKEY_STATE_UNKNOWN:
+        break;
+#ifndef FIPS_MODULE
     case EVP_PKEY_STATE_LEGACY:
         return evp_pkey_ctx_get_params_to_ctrl(ctx, params);
 #endif

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -945,7 +945,9 @@ static EVP_PKEY *make_key_fromdata(char *keytype, OSSL_PARAM *params)
 
     if (!TEST_ptr(pctx = EVP_PKEY_CTX_new_from_name(testctx, keytype, testpropq)))
         goto err;
-    if (!TEST_int_gt(EVP_PKEY_fromdata_init(pctx), 0)
+    /* Check that premature EVP_PKEY_CTX_set_params() fails gracefully */
+    if (!TEST_int_eq(EVP_PKEY_CTX_set_params(pctx, params), 0)
+        || !TEST_int_gt(EVP_PKEY_fromdata_init(pctx), 0)
         || !TEST_int_gt(EVP_PKEY_fromdata(pctx, &tmp_pkey, EVP_PKEY_KEYPAIR,
                                           params), 0))
         goto err;


### PR DESCRIPTION
Calling `EVP_PKEY_CTX_set_params(3)` crashed on provided keys if called before setting the "operation", such as `EVP_PKEY_fromdata_init()`, ... Fail, rather than erroneously falling into the legacy codepath.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
