### PR TITLE
require GNU assembler 2.30 or higher to build aesni-xtx-avx512.pl

### DIFF
--- a/crypto/aes/asm/aesni-xts-avx512.pl
+++ b/crypto/aes/asm/aesni-xts-avx512.pl
@@ -36,7 +36,7 @@ die "can't locate x86_64-xlate.pl";
 
 if (`$ENV{CC} -Wa,-v -c -o /dev/null -x assembler /dev/null 2>&1`
         =~ /GNU assembler version ([2-9]\.[0-9]+)/) {
-    $avx512vaes = ($1>=2.26);
+    $avx512vaes = ($1>=2.30);
 }
 
 if (!$avx512vaes && $win64 && ($flavour =~ /nasm/ || $ENV{ASM} =~ /nasm/) &&


### PR DESCRIPTION
The peralsm in aesni-xts-avx512 currently checks for GNU assembler 2.26 or higher. According to reporters it looks like we need 2.30.

This PR just attempts fix version check so people with older tool chains can  build OpenSSL.

Fixes #27049
