### PR TITLE
Change wiki links to point to the GitHub wiki

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5761,7 +5761,7 @@ OpenSSL 1.1.0
 
  * The GOST engine was out of date and therefore it has been removed. An up
    to date GOST engine is now being maintained in an external repository.
-   See: <https://wiki.openssl.org/index.php/Binaries>. Libssl still retains
+   See: <https://github.com/openssl/openssl/wiki/Binaries>. Libssl still retains
    support for GOST ciphersuites (these are only activated if a GOST engine
    is present).
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4473,7 +4473,7 @@ OpenSSL 1.1.1
  * Support for TLSv1.3 added. Note that users upgrading from an earlier
    version of OpenSSL should review their configuration settings to ensure
    that they are still appropriate for TLSv1.3. For further information see:
-   <https://wiki.openssl.org/index.php/TLS1.3>
+   <https://github.com/openssl/openssl/wiki/TLS1.3>
 
    *Matt Caswell*
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -700,7 +700,7 @@ OpenSSL 1.1.1
     * Rewrite of the packet construction code for "safer" packet handling
     * Rewrite of the extension handling code
     For further important information, see the [TLS1.3 page](
-    https://wiki.openssl.org/index.php/TLS1.3) in the OpenSSL Wiki.
+    https://github.com/openssl/openssl/wiki/TLS1.3) in the OpenSSL Wiki.
 
   * Complete rewrite of the OpenSSL random number generator to introduce the
     following capabilities

--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ There are numerous source code demos for using various OpenSSL capabilities in t
 Wiki
 ----
 
-There is a Wiki at [wiki.openssl.org] which is currently not very active.
-It contains a lot of useful information, not all of which is up-to-date.
+There is a Wiki at [wiki] which is
+currently not very active.
 
 License
 =======
@@ -214,8 +214,8 @@ All rights reserved.
     <https://github.com/openssl/openssl>
     "OpenSSL GitHub Mirror"
 
-[wiki.openssl.org]:
-    <https://wiki.openssl.org>
+[wiki]:
+    <https://github.com/openssl/openssl/wiki>
     "OpenSSL Wiki"
 
 [ossl-guide-migration(7ossl)]:
@@ -232,7 +232,7 @@ All rights reserved.
      <https://tools.ietf.org/html/rfc9000>
 
 [Binaries]:
-    <https://wiki.openssl.org/index.php/Binaries>
+    <https://github.com/openssl/openssl/wiki/Binaries>
     "List of third party OpenSSL binaries"
 
 [OpenSSL Guide]:

--- a/README.md
+++ b/README.md
@@ -164,8 +164,7 @@ There are numerous source code demos for using various OpenSSL capabilities in t
 Wiki
 ----
 
-There is a Wiki at [wiki] which is
-currently not very active.
+There is a [GitHub Wiki] which is currently not very active.
 
 License
 =======
@@ -214,7 +213,7 @@ All rights reserved.
     <https://github.com/openssl/openssl>
     "OpenSSL GitHub Mirror"
 
-[wiki]:
+[GitHub Wiki]:
     <https://github.com/openssl/openssl/wiki>
     "OpenSSL Wiki"
 

--- a/demos/sslecho/A-SSL-Docs.txt
+++ b/demos/sslecho/A-SSL-Docs.txt
@@ -4,9 +4,9 @@ OpenSSL API Documentation: https://www.openssl.org/docs
 
 Github: https://github.com/openssl/openssl
 
-OpenSSL Wiki: https://wiki.openssl.org/index.php/Main_Page
+OpenSSL Wiki: https://github.com/openssl/openssl/wiki
 
-Original Simple Server: https://wiki.openssl.org/index.php/Simple_TLS_Server
+Original Simple Server: https://github.com/openssl/openssl/wiki/Simple_TLS_Server
 
 ---------------------------------------------------------------
 

--- a/doc/man7/ossl-guide-introduction.pod
+++ b/doc/man7/ossl-guide-introduction.pod
@@ -32,7 +32,7 @@ attempting to build OpenSSL from the source code.
 
 Some third parties also supply OpenSSL binaries (e.g. for Windows and some other
 platforms). The OpenSSL project maintains a list of these third parties at
-L<https://wiki.openssl.org/index.php/Binaries>.
+L<https://github.com/openssl/openssl/wiki/Binaries>.
 
 If you build and install OpenSSL from the source code then you should download
 the appropriate files for the version that you want to use from the link given

--- a/doc/man7/ossl-guide-migration.pod
+++ b/doc/man7/ossl-guide-migration.pod
@@ -617,13 +617,13 @@ The code needs to be amended to look like this:
 Support for TLSv1.3 has been added.
 
 This has a number of implications for SSL/TLS applications. See the
-L<TLS1.3 page|https://wiki.openssl.org/index.php/TLS1.3> for further details.
+L<TLS1.3 page|https://github.com/openssl/openssl/wiki/TLS1.3> for further details.
 
 =back
 
 More details about the breaking changes between OpenSSL versions 1.0.2 and 1.1.0
 can be found on the
-L<OpenSSL 1.1.0 Changes page|https://wiki.openssl.org/index.php/OpenSSL_1.1.0_Changes>.
+L<OpenSSL 1.1.0 Changes page|https://github.com/openssl/openssl/wiki/OpenSSL_1.1.0_Changes>.
 
 =head3 Upgrading from the OpenSSL 2.0 FIPS Object Module
 


### PR DESCRIPTION
I've move content from [wiki.openssl.org](https://wiki.openssl.org/index.php/Main_Page) to the [GitHub wiki](https://github.com/openssl/openssl/wiki). All the pages linked to from the OpenSSL documentation have been copied and this PR changes the links. There are 4 pages total:

* https://github.com/openssl/openssl/wiki/Binaries
* https://github.com/openssl/openssl/wiki/OpenSSL_1.1.0_Changes
* https://github.com/openssl/openssl/wiki/Simple_TLS_Server
* https://github.com/openssl/openssl/wiki/TLS1.3

The next step for the wiki is to redirect the links to these pages from the old wiki to the GitHub wiki and update other pages to indicate they are for historical reasons only. (In the future, we might shut down the old wiki altogether.) I will also announce this change on the library blog and GitHub Discussions.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

