### PR TITLE
Fix windows test failures caused by binary compare of text

### DIFF
--- a/test/recipes/15-test_dsaparam.t
+++ b/test/recipes/15-test_dsaparam.t
@@ -11,7 +11,7 @@ use warnings;
 
 use File::Spec;
 use File::Copy;
-use File::Compare qw/compare/;
+use File::Compare qw/compare_text/;
 use OpenSSL::Glob;
 use OpenSSL::Test qw/:DEFAULT data_file/;
 use OpenSSL::Test::Utils;
@@ -84,4 +84,4 @@ my $inout = "inout.pem";
 copy($input, $inout);
 ok(run(app(['openssl', 'dsaparam', '-in', $inout, '-out', $inout])),
     "identical infile and outfile");
-ok(!compare($input, $inout), "converted file $inout did not change");
+ok(!compare_text($input, $inout), "converted file $inout did not change");

--- a/test/recipes/15-test_ml_dsa_codecs.t
+++ b/test/recipes/15-test_ml_dsa_codecs.t
@@ -63,7 +63,7 @@ foreach my $alg (@algs) {
         ok(run(app(['openssl', 'genpkey', '-out', $pem,
                     '-pkeyopt', "hexseed:$seed", '-algorithm', "ml-dsa-$alg",
                     '-provparam', "ml-dsa.output_formats=$f"])));
-        ok(!compare($in, $pem),
+        ok(!compare_text($in, $pem),
             sprintf("prvkey PEM match: %s, %s", $alg, $f));
 
         ok(run(app(['openssl', 'pkey', '-in', $in, '-noout',
@@ -95,7 +95,7 @@ foreach my $alg (@algs) {
     ok(run(app([qw(openssl genpkey -provparam ml-dsa.retain_seed=no),
                 '-algorithm', "ml-dsa-$alg", '-pkeyopt', "hexseed:$seed",
                 '-out', $seedless])));
-    ok(!compare(data_file($formats{'priv-only'}), $seedless),
+    ok(!compare_text(data_file($formats{'priv-only'}), $seedless),
         sprintf("seedless via cli key match: %s", $alg));
     {
         local $ENV{'OPENSSL_CONF'} = data_file("ml-dsa.cnf");
@@ -104,14 +104,14 @@ foreach my $alg (@algs) {
         ok(run(app(['openssl', 'genpkey',
                     '-algorithm', "ml-dsa-$alg", '-pkeyopt', "hexseed:$seed",
                     '-out', $seedless])));
-        ok(!compare(data_file($formats{'priv-only'}), $seedless),
+        ok(!compare_text(data_file($formats{'priv-only'}), $seedless),
             sprintf("seedless via config match: %s", $alg));
 
         my $seedfull = sprintf("seedfull-%s.gen.conf+cli.pem", $alg);
         ok(run(app(['openssl', 'genpkey', '-provparam', 'ml-dsa.retain_seed=yes',
                     '-algorithm', "ml-dsa-$alg", '-pkeyopt', "hexseed:$seed",
                     '-out', $seedfull])));
-        ok(!compare(data_file($formats{'seed-priv'}), $seedfull),
+        ok(!compare_text(data_file($formats{'seed-priv'}), $seedfull),
             sprintf("seedfull via cli vs. conf key match: %s", $alg));
     }
 
@@ -120,7 +120,7 @@ foreach my $alg (@algs) {
     $seedless = sprintf("seedless-%s.dec.cli.pem", $alg);
     ok(run(app(['openssl', 'pkey', '-provparam', 'ml-dsa.retain_seed=no',
                 '-in', data_file($formats{'seed-only'}), '-out', $seedless])));
-    ok(!compare(data_file($formats{'priv-only'}), $seedless),
+    ok(!compare_text(data_file($formats{'priv-only'}), $seedless),
         sprintf("seedless via provparam key match: %s", $alg));
     {
         local $ENV{'OPENSSL_CONF'} = data_file("ml-dsa.cnf");
@@ -128,13 +128,13 @@ foreach my $alg (@algs) {
         $seedless = sprintf("seedless-%s.dec.cnf.pem", $alg);
         ok(run(app(['openssl', 'pkey',
                     '-in', data_file($formats{'seed-only'}), '-out', $seedless])));
-        ok(!compare(data_file($formats{'priv-only'}), $seedless),
+        ok(!compare_text(data_file($formats{'priv-only'}), $seedless),
             sprintf("seedless via config match: %s", $alg));
 
         my $seedfull = sprintf("seedfull-%s.dec.conf+cli.pem", $alg);
         ok(run(app(['openssl', 'pkey', '-provparam', 'ml-dsa.retain_seed=yes',
                     '-in', data_file($formats{'seed-only'}), '-out', $seedfull])));
-        ok(!compare(data_file($formats{'seed-priv'}), $seedfull),
+        ok(!compare_text(data_file($formats{'seed-priv'}), $seedfull),
             sprintf("seedfull via cli vs. conf key match: %s", $alg));
     }
 
@@ -143,7 +143,7 @@ foreach my $alg (@algs) {
     my $privpref = sprintf("privpref-%s.dec.cli.pem", $alg);
     ok(run(app(['openssl', 'pkey', '-provparam', 'ml-dsa.prefer_seed=no',
                 '-in', data_file($formats{'seed-priv'}), '-out', $privpref])));
-    ok(!compare(data_file($formats{'priv-only'}), $privpref),
+    ok(!compare_text(data_file($formats{'priv-only'}), $privpref),
         sprintf("seed non-preference via provparam key match: %s", $alg));
 
     # (2 * @formats) tests
@@ -154,7 +154,7 @@ foreach my $alg (@algs) {
         my $out = sprintf("prv-%s-%s.txt", $alg, $f);
         ok(run(app(['openssl', 'pkey', '-in', data_file($kf),
                     '-noout', '-text', '-out', $out])));
-        ok(!compare(data_file($txt), $out),
+        ok(!compare_text(data_file($txt), $out),
             sprintf("text form private key: %s with %s", $alg, $f));
     }
 

--- a/test/recipes/15-test_ml_kem_codecs.t
+++ b/test/recipes/15-test_ml_kem_codecs.t
@@ -59,7 +59,7 @@ foreach my $alg (@algs) {
         ok(run(app(['openssl', 'genpkey', '-out', $pem,
                     '-pkeyopt', "hexseed:$seed", '-algorithm', "ml-kem-$alg",
                     '-provparam', "ml-kem.output_formats=$f"])));
-        ok(!compare($in, $pem),
+        ok(!compare_text($in, $pem),
             sprintf("prvkey PEM match: %s, %s", $alg, $f));
 
         ok(run(app(['openssl', 'pkey', '-in', $in, '-noout',
@@ -97,7 +97,7 @@ foreach my $alg (@algs) {
     ok(run(app(['openssl', 'genpkey', '-provparam', 'ml-kem.retain_seed=no',
                 '-algorithm', "ml-kem-$alg", '-pkeyopt', "hexseed:$seed",
                 '-out', $seedless])));
-    ok(!compare(data_file($formats{'priv-only'}), $seedless),
+    ok(!compare_text(data_file($formats{'priv-only'}), $seedless),
         sprintf("seedless via cli key match: %s", $alg));
     {
         local $ENV{'OPENSSL_CONF'} = data_file("ml-kem.cnf");
@@ -106,14 +106,14 @@ foreach my $alg (@algs) {
         ok(run(app(['openssl', 'genpkey',
                     '-algorithm', "ml-kem-$alg", '-pkeyopt', "hexseed:$seed",
                     '-out', $seedless])));
-        ok(!compare(data_file($formats{'priv-only'}), $seedless),
+        ok(!compare_text(data_file($formats{'priv-only'}), $seedless),
             sprintf("seedless via config match: %s", $alg));
 
         my $seedfull = sprintf("seedfull-%s.gen.conf+cli.pem", $alg);
         ok(run(app(['openssl', 'genpkey', '-provparam', 'ml-kem.retain_seed=yes',
                     '-algorithm', "ml-kem-$alg", '-pkeyopt', "hexseed:$seed",
                     '-out', $seedfull])));
-        ok(!compare(data_file($formats{'seed-priv'}), $seedfull),
+        ok(!compare_text(data_file($formats{'seed-priv'}), $seedfull),
             sprintf("seedfull via cli vs. conf key match: %s", $alg));
     }
 
@@ -122,7 +122,7 @@ foreach my $alg (@algs) {
     $seedless = sprintf("seedless-%s.dec.cli.pem", $alg);
     ok(run(app(['openssl', 'pkey', '-provparam', 'ml-kem.retain_seed=no',
                 '-in', data_file($formats{'seed-only'}), '-out', $seedless])));
-    ok(!compare(data_file($formats{'priv-only'}), $seedless),
+    ok(!compare_text(data_file($formats{'priv-only'}), $seedless),
         sprintf("seedless via provparam key match: %s", $alg));
     {
         local $ENV{'OPENSSL_CONF'} = data_file("ml-kem.cnf");
@@ -130,13 +130,13 @@ foreach my $alg (@algs) {
         $seedless = sprintf("seedless-%s.dec.cnf.pem", $alg);
         ok(run(app(['openssl', 'pkey',
                     '-in', data_file($formats{'seed-only'}), '-out', $seedless])));
-        ok(!compare(data_file($formats{'priv-only'}), $seedless),
+        ok(!compare_text(data_file($formats{'priv-only'}), $seedless),
             sprintf("seedless via config match: %s", $alg));
 
         my $seedfull = sprintf("seedfull-%s.dec.conf+cli.pem", $alg);
         ok(run(app(['openssl', 'pkey', '-provparam', 'ml-kem.retain_seed=yes',
                     '-in', data_file($formats{'seed-only'}), '-out', $seedfull])));
-        ok(!compare(data_file($formats{'seed-priv'}), $seedfull),
+        ok(!compare_text(data_file($formats{'seed-priv'}), $seedfull),
             sprintf("seedfull via cli vs. conf key match: %s", $alg));
     }
 
@@ -145,7 +145,7 @@ foreach my $alg (@algs) {
     my $privpref = sprintf("privpref-%s.dec.cli.pem", $alg);
     ok(run(app(['openssl', 'pkey', '-provparam', 'ml-kem.prefer_seed=no',
                 '-in', data_file($formats{'seed-priv'}), '-out', $privpref])));
-    ok(!compare(data_file($formats{'priv-only'}), $privpref),
+    ok(!compare_text(data_file($formats{'priv-only'}), $privpref),
         sprintf("seed non-preference via provparam key match: %s", $alg));
 
     # (2 * @formats) tests
@@ -156,7 +156,7 @@ foreach my $alg (@algs) {
         my $out = sprintf("prv-%s-%s.txt", $alg, $f);
         ok(run(app(['openssl', 'pkey', '-in', data_file($k),
                     '-noout', '-text', '-out', $out])));
-        ok(!compare(data_file($txt), $out),
+        ok(!compare_text(data_file($txt), $out),
             sprintf("text form private key: %s with %s", $alg, $f));
     }
 

--- a/test/recipes/15-test_pkey.t
+++ b/test/recipes/15-test_pkey.t
@@ -11,7 +11,7 @@ use warnings;
 
 use OpenSSL::Test::Utils;
 use File::Copy;
-use File::Compare qw(compare);
+use File::Compare qw(compare_text);
 use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_pkey");
@@ -40,7 +40,7 @@ subtest "=== pkey typical en-/decryption (using AES256-CBC) ===" => sub {
     ok(run(app([@app, '-in', $encrypted_key, '-out', $decrypted_key,
                 '-passin', $pass])),
        "decrypt key");
-    is(compare($in_key, $decrypted_key), 0,
+    is(compare_text($in_key, $decrypted_key), 0,
        "Same file contents after encrypting and decrypting in separate files");
 };
 
@@ -61,7 +61,7 @@ subtest "=== pkey handling of identical input and output files (using 3DES) and 
 
     ok(run(app([@app, '-in', $inout, '-out', $inout, '-passin', $pass])),
        "decrypt using identical infile and outfile");
-    is(compare($in_key, $inout), 0,
+    is(compare_text($in_key, $inout), 0,
        "Same file contents after encrypting and decrypting using same file");
 };
 
@@ -75,19 +75,19 @@ subtest "=== pkey handling of public keys (Ed25519) ===" => sub {
     my $pub_out1 = 'pub1.pem';
     ok(run(app([@app, '-in', $in_ed_key, '-pubout', '-out', $pub_out1])),
        "extract public key");
-    is(compare($in_pubkey, $pub_out1), 0,
+    is(compare_text($in_pubkey, $pub_out1), 0,
        "extracted public key is same as original public key");
 
     my $pub_out2 = 'pub2.pem';
     ok(run(app([@app, '-in', $in_pubkey, '-pubin', '-pubout', '-out', $pub_out2])),
        "read public key from pubfile");
-    is(compare($in_pubkey, $pub_out2), 0,
+    is(compare_text($in_pubkey, $pub_out2), 0,
        "public key read using pubfile is same as original public key");
 
     my $pub_out3 = 'pub3.pem';
     ok(run(app([@app, '-in', $in_ed_key, '-pubin', '-pubout', '-out', $pub_out3])),
        "extract public key from pkey file with -pubin");
-    is(compare($in_pubkey, $pub_out3), 0,
+    is(compare_text($in_pubkey, $pub_out3), 0,
        "public key extraced from pkey file with -pubin is same as original");
 };
 
@@ -108,7 +108,7 @@ subtest "=== pkey handling of DER encoding ===" => sub {
     ok(run(app([@app, '-in', $der_out, '-inform', 'DER',
                  '-out', $pem_out])),
        "read DER-encoded key");
-    is(compare($in_key, $pem_out), 0,
+    is(compare_text($in_key, $pem_out), 0,
        "Same file contents after converting to DER and back");
 };
 

--- a/test/recipes/20-test_dhparam.t
+++ b/test/recipes/20-test_dhparam.t
@@ -11,7 +11,7 @@ use strict;
 use warnings;
 
 use File::Copy;
-use File::Compare qw/compare/;
+use File::Compare qw/compare_text/;
 use OpenSSL::Test qw(:DEFAULT data_file srctop_file);
 use OpenSSL::Test::Utils;
 
@@ -221,4 +221,4 @@ my $inout = "inout.pem";
 copy($input, $inout);
 ok(run(app(['openssl', 'dhparam', '-in', $inout, '-out', $inout])),
     "identical infile and outfile");
-ok(!compare($input, $inout), "converted file $inout did not change");
+ok(!compare_text($input, $inout), "converted file $inout did not change");

--- a/test/recipes/25-test_pkcs8.t
+++ b/test/recipes/25-test_pkcs8.t
@@ -28,7 +28,7 @@ ok(run(app(['openssl', 'pkcs8', '-topk8', '-in', $inout,
 ok(run(app(['openssl', 'pkcs8', '-in', $inout,
             '-out', $inout, '-passin', 'pass:password'])),
    "identical infile and outfile, from PKCS#8");
-is(compare($pc5_key, $inout), 0,
+is(compare_text($pc5_key, $inout), 0,
    "Same file contents after converting forth and back");
 
 ok(run(app(([ 'openssl', 'pkcs8', '-topk8',


### PR DESCRIPTION
Fixes #27047

Swapped out the compare() calls for compare_text() for PEM and txt files.

Tests pass OK on HEAD with a windows dll build.