### PR TITLE
Fix some bugs in the QUIC TLS API

### DIFF
--- a/include/internal/ssl.h
+++ b/include/internal/ssl.h
@@ -20,5 +20,7 @@ int ossl_ssl_get_error(const SSL *s, int i, int check_err);
 
 /* Set if this is the QUIC handshake layer */
 # define TLS1_FLAGS_QUIC                         0x2000
+/* Set if this is our QUIC handshake layer */
+# define TLS1_FLAGS_QUIC_INTERNAL                0x4000
 
 #endif

--- a/include/openssl/ssl3.h
+++ b/include/openssl/ssl3.h
@@ -308,6 +308,7 @@ extern "C" {
 # define TLS1_FLAGS_REQUIRED_EXTMS               0x1000
 
 /* 0x2000 is reserved for TLS1_FLAGS_QUIC (internal) */
+/* 0x4000 is reserved for TLS1_FLAGS_QUIC_INTERNAL (internal) */
 
 # define SSL3_MT_HELLO_REQUEST                   0
 # define SSL3_MT_CLIENT_HELLO                    1

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -583,7 +583,7 @@ SSL *ossl_quic_new(SSL_CTX *ctx)
     }
 
     /* override the user_ssl of the inner connection */
-    sc->s3.flags |= TLS1_FLAGS_QUIC;
+    sc->s3.flags |= TLS1_FLAGS_QUIC | TLS1_FLAGS_QUIC_INTERNAL;
 
     /* Restrict options derived from the SSL_CTX. */
     sc->options &= OSSL_QUIC_PERMITTED_OPTIONS_CONN;
@@ -4436,7 +4436,7 @@ SSL *ossl_quic_new_from_listener(SSL *ssl, uint64_t flags)
         QUIC_RAISE_NON_NORMAL_ERROR(NULL, ERR_R_INTERNAL_ERROR, NULL);
         goto err;
     }
-    sc->s3.flags |= TLS1_FLAGS_QUIC;
+    sc->s3.flags |= TLS1_FLAGS_QUIC | TLS1_FLAGS_QUIC_INTERNAL;
 
     qc->default_ssl_options = OSSL_QUIC_PERMITTED_OPTIONS;
     qc->last_error = SSL_ERROR_NONE;

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -490,7 +490,7 @@ static SSL *port_new_handshake_layer(QUIC_PORT *port, QUIC_CHANNEL *ch)
         }
 
     /* Override the user_ssl of the inner connection. */
-    tls_conn->s3.flags      |= TLS1_FLAGS_QUIC;
+    tls_conn->s3.flags      |= TLS1_FLAGS_QUIC | TLS1_FLAGS_QUIC_INTERNAL;
 
     /* Restrict options derived from the SSL_CTX. */
     tls_conn->options       &= OSSL_QUIC_PERMITTED_OPTIONS_CONN;

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -802,6 +802,8 @@ int ossl_quic_tls_tick(QUIC_TLS *qtls)
         if (!ossl_quic_tls_configure(qtls))
             return RAISE_INTERNAL_ERROR(qtls);
 
+        sc->s3.flags |= TLS1_FLAGS_QUIC_INTERNAL;
+
         if (qtls->args.is_server)
             SSL_set_accept_state(qtls->args.s);
         else

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -425,7 +425,7 @@ static int quic_release_record(OSSL_RECORD_LAYER *rl, void *rechandle,
 
     if (rl->recunreleased == length) {
         if (!rl->qtls->args.crypto_release_rcd_cb(rl->recread,
-                                                rl->qtls->args.crypto_release_rcd_cb_arg)) {
+                                                  rl->qtls->args.crypto_release_rcd_cb_arg)) {
             QUIC_TLS_FATAL(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
             return OSSL_RECORD_RETURN_FATAL;
         }

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -708,9 +708,20 @@ static int raise_error(QUIC_TLS *qtls, uint64_t error_code,
 int ossl_quic_tls_configure(QUIC_TLS *qtls)
 {
     SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(qtls->args.s);
+    BIO *nullbio;
 
     if (sc == NULL || !SSL_set_min_proto_version(qtls->args.s, TLS1_3_VERSION))
         return RAISE_INTERNAL_ERROR(qtls);
+
+    nullbio = BIO_new(BIO_s_null());
+    if (nullbio == NULL)
+        return RAISE_INTERNAL_ERROR(qtls);
+
+    /*
+     * Our custom record layer doesn't use the BIO - but libssl generally
+     * expects one to be present.
+     */
+    SSL_set_bio(qtls->args.s, nullbio, nullbio);
 
     SSL_clear_options(qtls->args.s, SSL_OP_ENABLE_MIDDLEBOX_COMPAT);
     ossl_ssl_set_custom_record_layer(sc, &quic_tls_record_method, qtls);
@@ -768,7 +779,6 @@ int ossl_quic_tls_tick(QUIC_TLS *qtls)
     if (!qtls->configured) {
         SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(qtls->args.s);
         SSL_CTX *sctx;
-        BIO *nullbio;
 
         if (sc == NULL)
             return RAISE_INTERNAL_ERROR(qtls);
@@ -791,16 +801,6 @@ int ossl_quic_tls_tick(QUIC_TLS *qtls)
 
         if (!ossl_quic_tls_configure(qtls))
             return RAISE_INTERNAL_ERROR(qtls);
-
-        nullbio = BIO_new(BIO_s_null());
-        if (nullbio == NULL)
-            return RAISE_INTERNAL_ERROR(qtls);
-
-        /*
-         * Our custom record layer doesn't use the BIO - but libssl generally
-         * expects one to be present.
-         */
-        SSL_set_bio(qtls->args.s, nullbio, nullbio);
 
         if (qtls->args.is_server)
             SSL_set_accept_state(qtls->args.s);

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -423,18 +423,15 @@ static int quic_release_record(OSSL_RECORD_LAYER *rl, void *rechandle,
         return OSSL_RECORD_RETURN_FATAL;
     }
 
-    rl->recunreleased -= length;
-
-    if (rl->recunreleased > 0)
-        return OSSL_RECORD_RETURN_SUCCESS;
-
-    if (!rl->qtls->args.crypto_release_rcd_cb(rl->recread,
-                                              rl->qtls->args.crypto_release_rcd_cb_arg)) {
-        QUIC_TLS_FATAL(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-        return OSSL_RECORD_RETURN_FATAL;
+    if (rl->recunreleased == length) {
+        if (!rl->qtls->args.crypto_release_rcd_cb(rl->recread,
+                                                rl->qtls->args.crypto_release_rcd_cb_arg)) {
+            QUIC_TLS_FATAL(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+            return OSSL_RECORD_RETURN_FATAL;
+        }
+        rl->recread = 0;
     }
-
-    rl->recread = 0;
+    rl->recunreleased -= length;
     return OSSL_RECORD_RETURN_SUCCESS;
 }
 

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3498,7 +3498,7 @@ int ssl3_clear(SSL *s)
      * NULL/zero-out everything in the s3 struct, but remember if we are doing
      * QUIC.
      */
-    flags = sc->s3.flags & TLS1_FLAGS_QUIC;
+    flags = sc->s3.flags & (TLS1_FLAGS_QUIC | TLS1_FLAGS_QUIC_INTERNAL);
     memset(&sc->s3, 0, sizeof(sc->s3));
     sc->s3.flags |= flags;
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1428,11 +1428,10 @@ void SSL_free(SSL *s)
         return;
     REF_ASSERT_ISNT(i < 0);
 
-    CRYPTO_free_ex_data(CRYPTO_EX_INDEX_SSL, s, &s->ex_data);
-
     if (s->method != NULL)
         s->method->ssl_free(s);
 
+    CRYPTO_free_ex_data(CRYPTO_EX_INDEX_SSL, s, &s->ex_data);
     SSL_CTX_free(s->ctx);
     CRYPTO_THREAD_lock_free(s->lock);
     CRYPTO_FREE_REF(&s->references);
@@ -1448,14 +1447,16 @@ void ossl_ssl_connection_free(SSL *ssl)
     if (s == NULL)
         return;
 
+    /*
+     * Ignore return values. This could result in user callbacks being called
+     * e.g. for the QUIC TLS record layer. So we do this early before we have
+     * freed other things.
+     */
+    ssl_free_wbio_buffer(s);
+    RECORD_LAYER_clear(&s->rlayer);
+
     X509_VERIFY_PARAM_free(s->param);
     dane_final(&s->dane);
-
-    /* Ignore return value */
-    ssl_free_wbio_buffer(s);
-
-    /* Ignore return value */
-    RECORD_LAYER_clear(&s->rlayer);
 
     BUF_MEM_free(s->init_buf);
 

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -315,6 +315,7 @@
 # define SSL_WRITE_ETM(s) (s->s3.flags & TLS1_FLAGS_ENCRYPT_THEN_MAC_WRITE)
 
 # define SSL_IS_QUIC_HANDSHAKE(s) (((s)->s3.flags & TLS1_FLAGS_QUIC) != 0)
+# define SSL_IS_QUIC_INT_HANDSHAKE(s) (((s)->s3.flags & TLS1_FLAGS_QUIC_INTERNAL) != 0)
 
 /* no end of early data */
 # define SSL_NO_EOED(s) SSL_IS_QUIC_HANDSHAKE(s)

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2874,7 +2874,7 @@ int ssl_cipher_disabled(const SSL_CONNECTION *s, const SSL_CIPHER *c,
     if (s->s3.tmp.max_ver == 0)
         return 1;
 
-    if (SSL_IS_QUIC_HANDSHAKE(s))
+    if (SSL_IS_QUIC_INT_HANDSHAKE(s))
         /* For QUIC, only allow these ciphersuites. */
         switch (SSL_CIPHER_get_id(c)) {
         case TLS1_3_CK_AES_128_GCM_SHA256:

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -12755,6 +12755,7 @@ static int alert_cb(SSL *s, unsigned char alert_code, void *arg)
  * Test the QUIC TLS API
  * Test 0: Normal run
  * Test 1: Force a failure
+ * Test 3: Use a CCM based ciphersuite
  */
 static int test_quic_tls(int idx)
 {
@@ -12803,6 +12804,12 @@ static int test_quic_tls(int idx)
     SSL_set_bio(serverssl, NULL, NULL);
     SSL_set_bio(clientssl, NULL, NULL);
 
+    if (idx == 2) {
+        if (!TEST_true(SSL_set_ciphersuites(serverssl, "TLS_AES_128_CCM_SHA256"))
+                || !TEST_true(SSL_set_ciphersuites(clientssl, "TLS_AES_128_CCM_SHA256")))
+            goto end;
+    }
+
     if (!TEST_true(SSL_set_app_data(clientssl, &clientquicdata))
             || !TEST_true(SSL_set_app_data(serverssl, &serverquicdata)))
         goto end;
@@ -12815,7 +12822,7 @@ static int test_quic_tls(int idx)
                                                             sizeof(sparams))))
         goto end;
 
-    if (idx == 0) {
+    if (idx != 1) {
         if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
             goto end;
     } else {
@@ -13352,7 +13359,7 @@ int setup_tests(void)
 #endif
     ADD_ALL_TESTS(test_alpn, 4);
 #if !defined(OSSL_NO_USABLE_TLS1_3)
-    ADD_ALL_TESTS(test_quic_tls, 2);
+    ADD_ALL_TESTS(test_quic_tls, 3);
     ADD_TEST(test_quic_tls_early_data);
 #endif
     return 1;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -12799,6 +12799,10 @@ static int test_quic_tls(int idx)
                                       NULL)))
         goto end;
 
+    /* Reset the BIOs we set in create_ssl_objects. We should not need them */
+    SSL_set_bio(serverssl, NULL, NULL);
+    SSL_set_bio(clientssl, NULL, NULL);
+
     if (!TEST_true(SSL_set_app_data(clientssl, &clientquicdata))
             || !TEST_true(SSL_set_app_data(serverssl, &serverquicdata)))
         goto end;
@@ -12935,6 +12939,10 @@ static int test_quic_tls_early_data(void)
                                       &clientssl, NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl, sess)))
         goto end;
+
+    /* Reset the BIOs we set in create_ssl_objects. We should not need them */
+    SSL_set_bio(serverssl, NULL, NULL);
+    SSL_set_bio(clientssl, NULL, NULL);
 
     if (!TEST_true(SSL_set_app_data(clientssl, &clientquicdata))
         || !TEST_true(SSL_set_app_data(serverssl, &serverquicdata)))

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -12615,7 +12615,7 @@ static int crypto_send_cb(SSL *s, const unsigned char *buf, size_t buf_len,
     size_t max_len = sizeof(peer->rcd_data[data->wenc_level])
                      - peer->rcd_data_len[data->wenc_level];
 
-    if (!check_app_data(s)){
+    if (!check_app_data(s)) {
         data->err = 1;
         return 0;
     }
@@ -12640,7 +12640,7 @@ static int crypto_recv_rcd_cb(SSL *s, const unsigned char **buf,
 {
     struct quic_tls_test_data *data = (struct quic_tls_test_data *)arg;
 
-    if (!check_app_data(s)){
+    if (!check_app_data(s)) {
         data->err = 1;
         return 0;
     }
@@ -12654,7 +12654,7 @@ static int crypto_release_rcd_cb(SSL *s, size_t bytes_read, void *arg)
 {
     struct quic_tls_test_data *data = (struct quic_tls_test_data *)arg;
 
-    if (!check_app_data(s)){
+    if (!check_app_data(s)) {
         data->err = 1;
         return 0;
     }
@@ -12722,7 +12722,7 @@ static int got_transport_params_cb(SSL *s, const unsigned char *params,
 {
     struct quic_tls_test_data *data = (struct quic_tls_test_data *)arg;
 
-    if (!check_app_data(s)){
+    if (!check_app_data(s)) {
         data->err = 1;
         return 0;
     }
@@ -12742,7 +12742,7 @@ static int alert_cb(SSL *s, unsigned char alert_code, void *arg)
 {
     struct quic_tls_test_data *data = (struct quic_tls_test_data *)arg;
 
-    if (!check_app_data(s)){
+    if (!check_app_data(s)) {
         data->err = 1;
         return 0;
     }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -12871,7 +12871,7 @@ static int test_quic_tls(int idx)
     SSL_CTX_free(cctx);
 
     /* Check that we didn't suddenly hit an unexpected failure during cleanup */
-    if(!TEST_false(sdata.err) || !TEST_false(cdata.err))
+    if (!TEST_false(sdata.err) || !TEST_false(cdata.err))
         testresult = 0;
 
     return testresult;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -12590,6 +12590,22 @@ struct quic_tls_test_data {
     int err;
 };
 
+static int clientquicdata = 0xff, serverquicdata = 0xfe;
+
+static int check_app_data(SSL *s)
+{
+    int *data, *comparedata;
+
+    /* Check app data works */
+    data = (int *)SSL_get_app_data(s);
+    comparedata = SSL_is_server(s) ? &serverquicdata : &clientquicdata;
+
+    if (comparedata != data)
+        return 0;
+
+    return 1;
+}
+
 static int crypto_send_cb(SSL *s, const unsigned char *buf, size_t buf_len,
                           size_t *consumed, void *arg)
 {
@@ -12597,6 +12613,11 @@ static int crypto_send_cb(SSL *s, const unsigned char *buf, size_t buf_len,
     struct quic_tls_test_data *peer = data->peer;
     size_t max_len = sizeof(peer->rcd_data[data->wenc_level])
                      - peer->rcd_data_len[data->wenc_level];
+
+    if (!check_app_data(s)){
+        data->err = 1;
+        return 0;
+    }
 
     if (buf_len > max_len)
         buf_len = max_len;
@@ -12618,6 +12639,11 @@ static int crypto_recv_rcd_cb(SSL *s, const unsigned char **buf,
 {
     struct quic_tls_test_data *data = (struct quic_tls_test_data *)arg;
 
+    if (!check_app_data(s)){
+        data->err = 1;
+        return 0;
+    }
+
     *bytes_read = data->rcd_data_len[data->renc_level];
     *buf = data->rcd_data[data->renc_level];
     return 1;
@@ -12626,6 +12652,11 @@ static int crypto_recv_rcd_cb(SSL *s, const unsigned char **buf,
 static int crypto_release_rcd_cb(SSL *s, size_t bytes_read, void *arg)
 {
     struct quic_tls_test_data *data = (struct quic_tls_test_data *)arg;
+
+    if (!check_app_data(s)){
+        data->err = 1;
+        return 0;
+    }
 
     if (!TEST_size_t_eq(bytes_read, data->rcd_data_len[data->renc_level])
             || !TEST_size_t_gt(bytes_read, 0)) {
@@ -12642,6 +12673,9 @@ static int yield_secret_cb(SSL *s, uint32_t prot_level, int direction,
                            void *arg)
 {
     struct quic_tls_test_data *data = (struct quic_tls_test_data *)arg;
+
+    if (!check_app_data(s))
+        goto err;
 
     if (prot_level < OSSL_RECORD_PROTECTION_LEVEL_EARLY
             || prot_level > OSSL_RECORD_PROTECTION_LEVEL_APPLICATION)
@@ -12680,6 +12714,11 @@ static int got_transport_params_cb(SSL *s, const unsigned char *params,
 {
     struct quic_tls_test_data *data = (struct quic_tls_test_data *)arg;
 
+    if (!check_app_data(s)){
+        data->err = 1;
+        return 0;
+    }
+
     if (!TEST_size_t_le(params_len, sizeof(data->params))) {
         data->err = 1;
         return 0;
@@ -12694,6 +12733,11 @@ static int got_transport_params_cb(SSL *s, const unsigned char *params,
 static int alert_cb(SSL *s, unsigned char alert_code, void *arg)
 {
     struct quic_tls_test_data *data = (struct quic_tls_test_data *)arg;
+
+    if (!check_app_data(s)){
+        data->err = 1;
+        return 0;
+    }
 
     data->alert = 1;
     return 1;
@@ -12741,6 +12785,10 @@ static int test_quic_tls(void)
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL,
                                       NULL)))
+        goto end;
+
+    if (!TEST_true(SSL_set_app_data(clientssl, &clientquicdata))
+            || !TEST_true(SSL_set_app_data(serverssl, &serverquicdata)))
         goto end;
 
     if (!TEST_true(SSL_set_quic_tls_cbs(clientssl, qtdis, &cdata))
@@ -12861,7 +12909,11 @@ static int test_quic_tls_early_data(void)
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
                                       &clientssl, NULL, NULL))
             || !TEST_true(SSL_set_session(clientssl, sess)))
-        return 0;
+        goto end;
+
+    if (!TEST_true(SSL_set_app_data(clientssl, &clientquicdata))
+        || !TEST_true(SSL_set_app_data(serverssl, &serverquicdata)))
+        goto end;
 
     if (!TEST_true(SSL_set_quic_tls_cbs(clientssl, qtdis, &cdata))
             || !TEST_true(SSL_set_quic_tls_cbs(serverssl, qtdis, &sdata))


### PR DESCRIPTION
This fixes some issues in the QUIC TLS API reported [here](https://github.com/ngtcp2/ngtcp2/pull/1582) and [here](https://github.com/ngtcp2/ngtcp2/pull/1583)

Specifically:

- It is no longer necessary to set a NULL BIO on the SSL object when using the QUIC TLS APIs
- Fixes use of the TLS_AES_128_CCM_SHA256 cipher
- Ensures SSL_get_app_data() still works from within crypto_release_rcd_cb if called from SSL_free()

While trying to set up a test for the app_data issue I ran into another unrelated issue where the counter for the amount of unreleased data can get confused under certain circumstances. So I fixed that too.