### PR TITLE
Correctly mark the release as prerelease

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -38,4 +38,5 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       run: |
         VERSION=$(echo ${{ github.ref_name }} | cut -d "-" -f 2-)
-        gh release create ${{ github.ref_name }} -t "OpenSSL $VERSION" -d --notes " " -R ${{ github.repository }} ${{ github.ref_name }}/assets/*
+        PRE_RELEASE=$([[ ${{ github.ref_name }} =~ alpha|beta ]] && echo "-p" || echo "")
+        gh release create ${{ github.ref_name }} $PRE_RELEASE -t "OpenSSL $VERSION" -d --notes " " -R ${{ github.repository }} ${{ github.ref_name }}/assets/*


### PR DESCRIPTION
Release must be marked as prerelease if "alpha" or "beta" is in tag name.

Please backport it to `openssl-3.5` as well.