### PR TITLE
Fix return value of the i2d_ASN1_bio_stream() call

### DIFF
--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -96,7 +96,7 @@ int i2d_ASN1_bio_stream(BIO *out, ASN1_VALUE *val, BIO *in, int flags,
      * internally
      */
     else
-        ASN1_item_i2d_bio(it, out, val);
+        rv = ASN1_item_i2d_bio(it, out, val);
     return rv;
 }
 


### PR DESCRIPTION
If the `flags` argument does not contain the `SMIME_STREAM` bit,  the `i2d_ASN1_bio_stream()` function always returns `1`, ignoring the result of the `ASN1_item_i2d_bio()` call.
Fix the return value to the result of the `ASN1_item_i2d_bio()` call for this case.
