### PR TITLE
Memory leak fix ktls_meth.c

### DIFF
--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -431,7 +431,7 @@ ktls_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
                                             taglen, mactype, md, comp);
 
     if (ret != OSSL_RECORD_RETURN_SUCCESS) {
-        OPENSSL_free(*retrl);
+        tls_free(*retrl);
         *retrl = NULL;
     } else {
         /*


### PR DESCRIPTION
The OSSL_RECORD_LAYER needs to be properly freed when return code isnt success. Memory leak fix
Fixes #27028 

