### PR TITLE
Check rand_meth_lock existence before trying to lock it

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -289,6 +289,9 @@ const RAND_METHOD *RAND_get_rand_method(void)
     if (!RUN_ONCE(&rand_init, do_rand_init))
         return NULL;
 
+    if (rand_meth_lock == NULL)
+        return NULL;
+
     if (!CRYPTO_THREAD_read_lock(rand_meth_lock))
         return NULL;
     tmp_meth = default_RAND_meth;


### PR DESCRIPTION
There are situations during exit clean up where dependent libraries might be using TLS to finalize stuff but that might crash because the rand_meth_lock can get freed and there is still an attempt to get rand bytes. This change makes sure that things fail nicely.

Specifically in my case I use nginx with pkcs11-provider and pkcs11-proxy that uses TLS to proxy pkcs11 calls. What happens during exit is best visible from this backtrace:

```
==1960960==    at 0x51CA6E5: __pthread_rwlock_rdlock_full64 (pthread_rwlock_common.c:298)
==1960960==    by 0x51CA6E5: pthread_rwlock_rdlock@@GLIBC_2.34 (pthread_rwlock_rdlock.c:26)
==1960960==    by 0x4D41850: CRYPTO_THREAD_read_lock (threads_pthread.c:627)
==1960960==    by 0x4E2A389: RAND_get_rand_method (rand_lib.c:197)
==1960960==    by 0x4E2A8C4: RAND_bytes_ex (rand_lib.c:372)
==1960960==    by 0x4A1A2FA: tls1_cipher (tls1_meth.c:215)
==1960960==    by 0x4A21025: tls_write_records_default (tls_common.c:1857)
==1960960==    by 0x4A222D9: tls_write_records_multiblock (tls_multib.c:180)
==1960960==    by 0x4A21356: tls_write_records (tls_common.c:1896)
==1960960==    by 0x4A11086: ssl3_write_bytes (rec_layer_s3.c:466)
==1960960==    by 0x49877A8: ssl3_write (s3_lib.c:4566)
==1960960==    by 0x499C55F: ssl_write_internal (ssl_lib.c:2545)
==1960960==    by 0x499C758: SSL_write (ssl_lib.c:2628)
==1960960==    by 0x57C8291: gck_rpc_tls_write_all (gck-rpc-tls-psk.c:378)
==1960960==    by 0x57B9D14: call_write (gck-rpc-module.c:262)
==1960960==    by 0x57BACBE: call_send_recv (gck-rpc-module.c:621)
==1960960==    by 0x57BB01A: call_run (gck-rpc-module.c:685)
==1960960==    by 0x57BDABF: rpc_C_CloseSession (gck-rpc-module.c:1618)
==1960960==    by 0x575EA48: p11prov_CloseSession (interface.gen.c:316)
==1960960==    by 0x577E7E4: token_session_close (session.c:110)
==1960960==    by 0x577F6C7: session_free (session.c:386)
==1960960==    by 0x577EAD5: p11prov_session_pool_free (session.c:170)
==1960960==    by 0x57890AB: p11prov_free_slots (slot.c:359)
==1960960==    by 0x5775E68: p11prov_ctx_free (provider.c:569)
==1960960==    by 0x577659D: p11prov_teardown (provider.c:668)
==1960960==    by 0x4D3E136: ossl_provider_teardown (provider_core.c:1623)
==1960960==    by 0x4D3C5C3: ossl_provider_free (provider_core.c:721)
==1960960==    by 0x4D3B2AE: provider_deactivate_free (provider_core.c:239)
==1960960==    by 0x4E7E57F: OPENSSL_sk_pop_free (stack.c:439)
==1960960==    by 0x4D3B1E1: sk_OSSL_PROVIDER_pop_free (provider_core.c:199)
==1960960==    by 0x4D3B52A: ossl_provider_store_free (provider_core.c:295)
==1960960==    by 0x4D1EA3E: context_deinit_objs (context.c:282)
==1960960==    by 0x4D1ECAC: context_deinit (context.c:374)
==1960960==    by 0x4D1ED7F: ossl_lib_ctx_default_deinit (context.c:413)
==1960960==    by 0x4D24AC9: OPENSSL_cleanup (init.c:464)
==1960960==    by 0x516FA75: __run_exit_handlers (exit.c:108)
==1960960==    by 0x516FBBD: exit (exit.c:138)
==1960960==    by 0x156621: ngx_master_process_exit (ngx_process_cycle.c:694)
==1960960==    by 0x15845F: ngx_master_process_cycle (ngx_process_cycle.c:178)
==1960960==    by 0x12BA3F: main (nginx.c:384)
```

Basically provider tries to close session which uses TLS but at that time, the `rand_meth_lock` was already freed so it crashes. This simple check fixes the crash. It still leaves the session open but it's not a big problem because proxy daemon (server) closes the session anyway.

The test for this is not easy unless the whole stack is added into it which might be a bit involved. Considering that rand methods are deprecated, it probably does not make much sense.