### PR TITLE
Fixed multiline output bug in crl command

### DIFF
--- a/crypto/x509/t_crl.c
+++ b/crypto/x509/t_crl.c
@@ -50,24 +50,24 @@ int X509_CRL_print_ex(BIO *out, X509_CRL *x, unsigned long nmflag)
     
     if((nmflag & XN_FLAG_SEP_MASK) == XN_FLAG_SEP_MULTILINE) {
     	mlch = '\n';
-    	nmindent = 12;
+    	nmindent = 8;
     }
 
     BIO_printf(out, "Certificate Revocation List (CRL):\n");
     l = X509_CRL_get_version(x);
     if (l >= X509_CRL_VERSION_1 && l <= X509_CRL_VERSION_2)
-        BIO_printf(out, "%8sVersion %ld (0x%lx)\n", "", l + 1, (unsigned long)l);
+        BIO_printf(out, "%4sVersion %ld (0x%lx)\n", "", l + 1, (unsigned long)l);
     else
-        BIO_printf(out, "%8sVersion unknown (%ld)\n", "", l);
+        BIO_printf(out, "%4sVersion unknown (%ld)\n", "", l);
     X509_CRL_get0_signature(x, &sig, &sig_alg);
     BIO_puts(out, "    ");
     X509_signature_print(out, sig_alg, NULL);
-    BIO_printf(out, "%8sIssuer:%c", "", mlch);
+    BIO_printf(out, "%4sIssuer:%c", "", mlch);
     X509_NAME_print_ex(out, X509_CRL_get_issuer(x), nmindent, nmflag);
     BIO_puts(out, "\n");
-    BIO_printf(out, "%8sLast Update: ", "");
+    BIO_printf(out, "%4sLast Update: ", "");
     ASN1_TIME_print(out, X509_CRL_get0_lastUpdate(x));
-    BIO_printf(out, "\n%8sNext Update: ", "");
+    BIO_printf(out, "\n%4sNext Update: ", "");
     if (X509_CRL_get0_nextUpdate(x))
         ASN1_TIME_print(out, X509_CRL_get0_nextUpdate(x));
     else
@@ -75,7 +75,7 @@ int X509_CRL_print_ex(BIO *out, X509_CRL *x, unsigned long nmflag)
     BIO_printf(out, "\n");
 
     X509V3_extensions_print(out, "CRL extensions",
-                            X509_CRL_get0_extensions(x), 0, 8);
+                            X509_CRL_get0_extensions(x), 0, 4);
 
     rev = X509_CRL_get_REVOKED(x);
 

--- a/crypto/x509/t_crl.c
+++ b/crypto/x509/t_crl.c
@@ -45,6 +45,13 @@ int X509_CRL_print_ex(BIO *out, X509_CRL *x, unsigned long nmflag)
     const ASN1_BIT_STRING *sig;
     long l;
     int i;
+    char mlch = ' ';
+    int nmindent = 0;
+    
+    if((nmflag & XN_FLAG_SEP_MASK) == XN_FLAG_SEP_MULTILINE) {
+    	mlch = '\n';
+    	nmindent = 12;
+    }
 
     BIO_printf(out, "Certificate Revocation List (CRL):\n");
     l = X509_CRL_get_version(x);
@@ -55,8 +62,8 @@ int X509_CRL_print_ex(BIO *out, X509_CRL *x, unsigned long nmflag)
     X509_CRL_get0_signature(x, &sig, &sig_alg);
     BIO_puts(out, "    ");
     X509_signature_print(out, sig_alg, NULL);
-    BIO_printf(out, "%8sIssuer: ", "");
-    X509_NAME_print_ex(out, X509_CRL_get_issuer(x), 0, nmflag);
+    BIO_printf(out, "%8sIssuer:%c", "", mlch);
+    X509_NAME_print_ex(out, X509_CRL_get_issuer(x), nmindent, nmflag);
     BIO_puts(out, "\n");
     BIO_printf(out, "%8sLast Update: ", "");
     ASN1_TIME_print(out, X509_CRL_get0_lastUpdate(x));

--- a/crypto/x509/t_crl.c
+++ b/crypto/x509/t_crl.c
@@ -47,10 +47,10 @@ int X509_CRL_print_ex(BIO *out, X509_CRL *x, unsigned long nmflag)
     int i;
     char mlch = ' ';
     int nmindent = 0;
-    
+
     if((nmflag & XN_FLAG_SEP_MASK) == XN_FLAG_SEP_MULTILINE) {
-    	mlch = '\n';
-    	nmindent = 8;
+        mlch = '\n';
+        nmindent = 8;
     }
 
     BIO_printf(out, "Certificate Revocation List (CRL):\n");

--- a/crypto/x509/t_crl.c
+++ b/crypto/x509/t_crl.c
@@ -60,7 +60,6 @@ int X509_CRL_print_ex(BIO *out, X509_CRL *x, unsigned long nmflag)
     else
         BIO_printf(out, "%4sVersion unknown (%ld)\n", "", l);
     X509_CRL_get0_signature(x, &sig, &sig_alg);
-    BIO_puts(out, "    ");
     X509_signature_print(out, sig_alg, NULL);
     BIO_printf(out, "%4sIssuer:%c", "", mlch);
     X509_NAME_print_ex(out, X509_CRL_get_issuer(x), nmindent, nmflag);

--- a/crypto/x509/t_crl.c
+++ b/crypto/x509/t_crl.c
@@ -48,7 +48,7 @@ int X509_CRL_print_ex(BIO *out, X509_CRL *x, unsigned long nmflag)
     char mlch = ' ';
     int nmindent = 0;
 
-    if((nmflag & XN_FLAG_SEP_MASK) == XN_FLAG_SEP_MULTILINE) {
+    if ((nmflag & XN_FLAG_SEP_MASK) == XN_FLAG_SEP_MULTILINE) {
         mlch = '\n';
         nmindent = 8;
     }

--- a/test/certs/cyrillic_crl.utf8
+++ b/test/certs/cyrillic_crl.utf8
@@ -1,12 +1,12 @@
 Certificate Revocation List (CRL):
-        Version 2 (0x1)
-        Signature Algorithm: sha256WithRSAEncryption
-        Issuer: C=RU, ST=Москва, O=Я, OU=Я, CN=Дмитрий Белявский, emailAddress=beldmit@example.com
-        Last Update: Apr 24 13:25:31 2017 GMT
-        Next Update: May 24 13:25:31 2017 GMT
-        CRL extensions:
-            X509v3 CRL Number: 
-                1
+    Version 2 (0x1)
+    Signature Algorithm: sha256WithRSAEncryption
+    Issuer: C=RU, ST=Москва, O=Я, OU=Я, CN=Дмитрий Белявский, emailAddress=beldmit@example.com
+    Last Update: Apr 24 13:25:31 2017 GMT
+    Next Update: May 24 13:25:31 2017 GMT
+    CRL extensions:
+        X509v3 CRL Number: 
+            1
 No Revoked Certificates.
     Signature Algorithm: sha256WithRSAEncryption
     Signature Value:


### PR DESCRIPTION
Fixed output, added check for multiline, changing to newline character/spacing amount. 

Initial issue: openssl#25880
Initial pull: openssl#26860
(I apologize for the separate pull request, I messed up git on my end, and it was easier to discard commits and repush)

Also following up on a comment on the previous pull, I have since signed a CLA.

@zriback
@bbbrumley