### PR TITLE
Report `s_client` chain cert pkey alg correctly

### DIFF
--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -328,6 +328,7 @@ static int do_print_sigalgs(BIO *out, SSL *s, int shared)
 
 int ssl_print_sigalgs(BIO *out, SSL *s)
 {
+    const char *name;
     int nid;
 
     if (!SSL_is_server(s))
@@ -336,7 +337,9 @@ int ssl_print_sigalgs(BIO *out, SSL *s)
     do_print_sigalgs(out, s, 1);
     if (SSL_get_peer_signature_nid(s, &nid) && nid != NID_undef)
         BIO_printf(out, "Peer signing digest: %s\n", OBJ_nid2sn(nid));
-    if (SSL_get_peer_signature_type_nid(s, &nid))
+    if (SSL_get0_peer_signature_name(s, &name))
+        BIO_printf(out, "Peer signature type: %s\n", name);
+    else if (SSL_get_peer_signature_type_nid(s, &nid))
         BIO_printf(out, "Peer signature type: %s\n", get_sigtype(nid));
     return 1;
 }

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3386,27 +3386,29 @@ static void print_stuff(BIO *bio, SSL *s, int full)
 
             BIO_printf(bio, "---\nCertificate chain\n");
             for (i = 0; i < sk_X509_num(sk); i++) {
+                X509 *chain_cert = sk_X509_value(sk, i);
+
                 BIO_printf(bio, "%2d s:", i);
-                X509_NAME_print_ex(bio, X509_get_subject_name(sk_X509_value(sk, i)), 0, get_nameopt());
+                X509_NAME_print_ex(bio, X509_get_subject_name(chain_cert), 0, get_nameopt());
                 BIO_puts(bio, "\n");
                 BIO_printf(bio, "   i:");
-                X509_NAME_print_ex(bio, X509_get_issuer_name(sk_X509_value(sk, i)), 0, get_nameopt());
+                X509_NAME_print_ex(bio, X509_get_issuer_name(chain_cert), 0, get_nameopt());
                 BIO_puts(bio, "\n");
                 public_key = X509_get_pubkey(sk_X509_value(sk, i));
                 if (public_key != NULL) {
                     BIO_printf(bio, "   a:PKEY: %s, %d (bit); sigalg: %s\n",
-                               OBJ_nid2sn(EVP_PKEY_get_base_id(public_key)),
+                               OBJ_nid2ln(EVP_PKEY_get_base_id(public_key)),
                                EVP_PKEY_get_bits(public_key),
-                               OBJ_nid2sn(X509_get_signature_nid(sk_X509_value(sk, i))));
+                               OBJ_nid2ln(X509_get_signature_nid(chain_cert)));
                     EVP_PKEY_free(public_key);
                 }
                 BIO_printf(bio, "   v:NotBefore: ");
-                ASN1_TIME_print(bio, X509_get0_notBefore(sk_X509_value(sk, i)));
+                ASN1_TIME_print(bio, X509_get0_notBefore(chain_cert));
                 BIO_printf(bio, "; NotAfter: ");
-                ASN1_TIME_print(bio, X509_get0_notAfter(sk_X509_value(sk, i)));
+                ASN1_TIME_print(bio, X509_get0_notAfter(chain_cert));
                 BIO_puts(bio, "\n");
                 if (c_showcerts)
-                    PEM_write_bio_X509(bio, sk_X509_value(sk, i));
+                    PEM_write_bio_X509(bio, chain_cert);
             }
         }
 

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3361,7 +3361,6 @@ int s_client_main(int argc, char **argv)
     return ret;
 }
 
-#ifndef OPENSSL_NO_EC
 static char *ec_curve_name(EVP_PKEY *pkey)
 {
     char *curve = 0;
@@ -3376,7 +3375,6 @@ static char *ec_curve_name(EVP_PKEY *pkey)
     }
     return (curve);
 }
-#endif
 
 static void print_cert_key_info(BIO *bio, X509 *cert)
 {
@@ -3389,10 +3387,8 @@ static void print_cert_key_info(BIO *bio, X509 *cert)
     keyalg = EVP_PKEY_get0_type_name(pkey);
     if (keyalg == NULL)
         keyalg = OBJ_nid2ln(EVP_PKEY_get_base_id(pkey));
-#ifndef OPENSSL_NO_EC
     if (EVP_PKEY_id(pkey) == EVP_PKEY_EC)
         curve = ec_curve_name(pkey);
-#endif
     if (curve != NULL)
         BIO_printf(bio, "   a:PKEY: %s, (%s); sigalg: %s\n",
                    keyalg, curve,

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3361,12 +3361,54 @@ int s_client_main(int argc, char **argv)
     return ret;
 }
 
+#ifndef OPENSSL_NO_EC
+static char *ec_curve_name(EVP_PKEY *pkey)
+{
+    char *curve = 0;
+    size_t namelen;
+
+    if (EVP_PKEY_get_group_name(pkey, NULL, 0, &namelen)) {
+        curve = OPENSSL_malloc(++namelen);
+        if (!EVP_PKEY_get_group_name(pkey, curve, namelen, 0)) {
+            OPENSSL_free(curve);
+            curve = NULL;
+        }
+    }
+    return (curve);
+}
+#endif
+
+static void print_cert_key_info(BIO *bio, X509 *cert)
+{
+    EVP_PKEY *pkey = X509_get0_pubkey(cert);
+    char *curve = NULL;
+    const char *keyalg;
+
+    if (pkey == NULL)
+        return;
+    keyalg = EVP_PKEY_get0_type_name(pkey);
+    if (keyalg == NULL)
+        keyalg = OBJ_nid2ln(EVP_PKEY_get_base_id(pkey));
+#ifndef OPENSSL_NO_EC
+    if (EVP_PKEY_id(pkey) == EVP_PKEY_EC)
+        curve = ec_curve_name(pkey);
+#endif
+    if (curve != NULL)
+        BIO_printf(bio, "   a:PKEY: %s, (%s); sigalg: %s\n",
+                   keyalg, curve,
+                   OBJ_nid2ln(X509_get_signature_nid(cert)));
+    else
+        BIO_printf(bio, "   a:PKEY: %s, %d (bit); sigalg: %s\n",
+                   keyalg, EVP_PKEY_get_bits(pkey),
+                   OBJ_nid2ln(X509_get_signature_nid(cert)));
+    OPENSSL_free(curve);
+}
+
 static void print_stuff(BIO *bio, SSL *s, int full)
 {
     X509 *peer = NULL;
     STACK_OF(X509) *sk;
     const SSL_CIPHER *c;
-    EVP_PKEY *public_key;
     int i, istls13 = (SSL_version(s) == TLS1_3_VERSION);
     long verify_result;
 #ifndef OPENSSL_NO_COMP
@@ -3394,14 +3436,7 @@ static void print_stuff(BIO *bio, SSL *s, int full)
                 BIO_printf(bio, "   i:");
                 X509_NAME_print_ex(bio, X509_get_issuer_name(chain_cert), 0, get_nameopt());
                 BIO_puts(bio, "\n");
-                public_key = X509_get_pubkey(sk_X509_value(sk, i));
-                if (public_key != NULL) {
-                    BIO_printf(bio, "   a:PKEY: %s, %d (bit); sigalg: %s\n",
-                               OBJ_nid2ln(EVP_PKEY_get_base_id(public_key)),
-                               EVP_PKEY_get_bits(public_key),
-                               OBJ_nid2ln(X509_get_signature_nid(chain_cert)));
-                    EVP_PKEY_free(public_key);
-                }
+                print_cert_key_info(bio, chain_cert);
                 BIO_printf(bio, "   v:NotBefore: ");
                 ASN1_TIME_print(bio, X509_get0_notBefore(chain_cert));
                 BIO_printf(bio, "; NotAfter: ");


### PR DESCRIPTION
In particular provided keys are also supported, and for EC keys we report the group rather than the bit count.

[ Perhaps the bit count should only be reported for RSA? For pretty much all other algorithms, the name alone, or name + group are sufficient. ]

The merge base is #27130, only the last commit is new.