### PR TITLE
qlog_event_helpers.c: Fix inverted condition

### DIFF
--- a/ssl/quic/qlog_event_helpers.c
+++ b/ssl/quic/qlog_event_helpers.c
@@ -542,7 +542,7 @@ static int log_frames(QLOG *qlog_instance,
             if (need_skip > 0) {
                 size_t adv = need_skip;
 
-                if (adv < PACKET_remaining(&pkt))
+                if (adv > PACKET_remaining(&pkt))
                     adv = PACKET_remaining(&pkt);
 
                 if (!PACKET_forward(&pkt, adv))


### PR DESCRIPTION
We want to skip up to PACKET_remaining() and not "at least" PACKET_remaining() bytes.
