### PR TITLE
add simple memory profiler openssl.

### DIFF
--- a/Configure
+++ b/Configure
@@ -496,6 +496,7 @@ my @disablables = (
     "ml-dsa",
     "ml-kem",
     "module",
+    "mprofile",
     "msan",
     "multiblock",
     "nextprotoneg",
@@ -554,7 +555,7 @@ my @disablables = (
     "zlib",
     "zlib-dynamic",
     "zstd",
-    "zstd-dynamic",
+    "zstd-dynamic"
     );
 foreach my $proto ((@tls, @dtls))
         {
@@ -605,6 +606,7 @@ our %disabled = ( # "what"         => "comment"
                   "jitter"              => "default",
                   "ktls"                => "default",
                   "md2"                 => "default",
+                  "mprofile"            => "default",
                   "msan"                => "default",
                   "rc5"                 => "default",
                   "sctp"                => "default",
@@ -1948,6 +1950,10 @@ if ($disabled{"dynamic-engine"}) {
     push @{$config{openssl_feature_defines}}, "OPENSSL_NO_DYNAMIC_ENGINE";
 } else {
     push @{$config{openssl_feature_defines}}, "OPENSSL_NO_STATIC_ENGINE";
+}
+
+if (!$disabled{"mprofile"}) {
+    push @{$config{openssl_feature_defines}}, "OPENSSL_DO_MPROFILE";
 }
 
 # If we use the unified build, collect information from build.info files

--- a/Configure
+++ b/Configure
@@ -555,7 +555,7 @@ my @disablables = (
     "zlib",
     "zlib-dynamic",
     "zstd",
-    "zstd-dynamic"
+    "zstd-dynamic",
     );
 foreach my $proto ((@tls, @dtls))
         {

--- a/test/build.info
+++ b/test/build.info
@@ -26,13 +26,25 @@ $LIBAPPSSRC=../apps/lib/opt.c $AUXLIBAPPSSRC
 
 IF[{- !$disabled{tests} -}]
   LIBS{noinst,has_main}=libtestutil.a
-  SOURCE[libtestutil.a]=testutil/basic_output.c testutil/output.c \
-          testutil/driver.c testutil/tests.c testutil/cb.c testutil/stanza.c \
-          testutil/format_output.c testutil/load.c testutil/fake_random.c \
-          testutil/test_cleanup.c testutil/main.c testutil/testutil_init.c \
-          testutil/options.c testutil/test_options.c testutil/provider.c \
-          testutil/apps_shims.c testutil/random.c testutil/helper.c $LIBAPPSSRC
-  INCLUDE[libtestutil.a]=../include ../apps/include ..
+  IF[{- $disabled{mprofile} -}]
+    SOURCE[libtestutil.a]=testutil/basic_output.c testutil/output.c \
+            testutil/driver.c testutil/tests.c testutil/cb.c testutil/stanza.c \
+            testutil/format_output.c testutil/load.c testutil/fake_random.c \
+            testutil/test_cleanup.c testutil/main.c testutil/testutil_init.c \
+            testutil/options.c testutil/test_options.c testutil/provider.c \
+            testutil/apps_shims.c testutil/random.c testutil/helper.c $LIBAPPSSRC
+    INCLUDE[libtestutil.a]=../include ../apps/include ..
+  ENDIF
+  IF[{- !$disabled{mprofile} -}]
+    SOURCE[libtestutil.a]=testutil/basic_output.c testutil/output.c \
+            testutil/driver.c testutil/tests.c testutil/cb.c testutil/stanza.c \
+            testutil/format_output.c testutil/load.c testutil/fake_random.c \
+            testutil/test_cleanup.c testutil/main.c testutil/testutil_init.c \
+            testutil/options.c testutil/test_options.c testutil/provider.c \
+            testutil/apps_shims.c testutil/random.c testutil/helper.c $LIBAPPSSRC \
+            ../mprofile/init.c ../mprofile/record.c ../mprofile/stack.c
+    INCLUDE[libtestutil.a]=../include ../apps/include ../mprofile ..
+  ENDIF
   DEPEND[libtestutil.a]=../libcrypto
 
   PROGRAMS{noinst}= \

--- a/test/testutil/main.c
+++ b/test/testutil/main.c
@@ -12,6 +12,12 @@
 #include "tu_local.h"
 
 #ifdef OPENSSL_DO_MPROFILE
+#include <stdio.h>
+#include <stdlib.h>
+#include <libgen.h>
+#include <string.h>
+
+#define	FNAME_BUF_SZ	512
 extern void mprofile_start(void);
 #endif
 
@@ -19,9 +25,50 @@ int main(int argc, char *argv[])
 {
     int ret = EXIT_FAILURE;
     int setup_res;
-
 #ifdef OPENSSL_DO_MPROFILE
-    mprofile_start();
+    char file_name_buf[2][FNAME_BUF_SZ];
+    char *do_mprofile = getenv("DO_MPROFILE");
+    char *results_dir = getenv("MPROFILE_RESULTS");
+    int i, sn;
+
+    if (do_mprofile != NULL && results_dir != NULL) {
+        /*
+         * Tests may execute single binary with different arguments.  The
+         * memory profiler (libmprofile) expects test to set MPROFILE_OUTF
+         * environment variable to specify file where to store the result.
+         * Such approach requires to update all test recopies. This can be done
+         * later, step-by-step. To allow this step-by-step approach we derive
+         * output file from arguments.
+         *
+         * Another option is to use strlcat(3) to concatenate all arguments
+         * into single string. My preference is to for snprintf() and flip
+         * two buffers as loop goes.
+         */
+         file_name_buf[0][0] = '\0';
+         file_name_buf[1][0] = '\0';
+         for (i = 0; i < argc && sn < FNAME_BUF_SZ; i++) {
+             if (i == 0)
+                 sn = snprintf(file_name_buf[i], FNAME_BUF_SZ, "%s",
+                     basename(argv[i]));
+             else
+                 sn = snprintf(file_name_buf[i % 2], FNAME_BUF_SZ, "%s__%s",
+                 file_name_buf[(i - 1) % 2], basename(argv[i]));
+         }
+
+         if (i == argc && results_dir != NULL) {
+             sn = snprintf(file_name_buf[i % 2], FNAME_BUF_SZ, "%s/%s.json",
+                 results_dir, file_name_buf[(i - 1) % 2]);
+             if (sn < FNAME_BUF_SZ) {
+                 setenv("MPROFILE_OUTF", file_name_buf[i % 2], 1);
+                 /*
+                  * we are all set to run mprofile. mprofile is best effort,
+                  * os if anything fails just give up. Perhaps we should
+                  * report such failure.
+                  */
+                  mprofile_start();
+             }
+         }
+    }
 #endif
 
     test_open_streams();

--- a/test/testutil/main.c
+++ b/test/testutil/main.c
@@ -11,11 +11,18 @@
 #include "output.h"
 #include "tu_local.h"
 
+#ifdef OPENSSL_DO_MPROFILE
+extern void mprofile_start(void);
+#endif
 
 int main(int argc, char *argv[])
 {
     int ret = EXIT_FAILURE;
     int setup_res;
+
+#ifdef OPENSSL_DO_MPROFILE
+    mprofile_start();
+#endif
 
     test_open_streams();
 

--- a/test/testutil/main.c
+++ b/test/testutil/main.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
         /*
          * Almost every test gets two instances of libmprofile:
          *     - libmprofile.so instance we get via LD_PRELOAD
-         *         - libmprofile we get via static libtestutil library
+         *     - libmprofile we get via static libtestutil library
          * Both instances are controlled via the identical env. variables
          * including MPROFILE_OUTF. To resolve conflict between dynamic and
          * static version of libmprofile we prepend a static_ prefix to

--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -13,6 +13,8 @@ use warnings;
 use Carp;
 use Test::More 0.96;
 
+use File::Spec::Functions 'catfile';
+
 use Exporter;
 use vars qw($VERSION @ISA @EXPORT @EXPORT_OK %EXPORT_TAGS);
 $VERSION = "1.0";
@@ -1296,10 +1298,11 @@ sub __decorate_cmd {
 
     if ($ENV{DO_MPROFILE}) {
         my $libmprofile = $ENV{LIBMPROFILE};
+
 	if ($^O ne 'WIN32') {
-            $ENV{LD_PRELOAD}="$libmprofile";
-	    $ENV{MPROFILE_MODE}="1";
-	    $ENV{MPROFILE_OUTF}="";
+            $ENV{LD_PRELOAD} = "$libmprofile";
+            $ENV{MPROFILE_MODE} = "1";
+            $ENV{MPROFILE_OUTF} = catfile(result_dir(), "$test_name".".json");
         }
     }
     $cmdstr .= "$stdin$stdout$stderr";

--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -1297,10 +1297,8 @@ sub __decorate_cmd {
     }
 
     if ($ENV{DO_MPROFILE}) {
-        my $libmprofile = $ENV{LIBMPROFILE};
 
 	if ($^O ne 'WIN32') {
-            $ENV{LD_PRELOAD} = "$libmprofile";
             $ENV{MPROFILE_MODE} = "1";
             $ENV{MPROFILE_OUTF} = catfile(result_dir(), "$test_name".".json");
         }

--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -1298,10 +1298,17 @@ sub __decorate_cmd {
 
     if ($ENV{DO_MPROFILE}) {
 
-	if ($^O ne 'WIN32') {
-            $ENV{MPROFILE_MODE} = "1";
-            $ENV{MPROFILE_OUTF} = catfile(result_dir(), "$test_name".".json");
-        }
+        $ENV{MPROFILE_MODE} = "1";
+        #
+	# Note the tests which are linked with libtestutil directory will
+        # override MPROFILE_OUTF
+        #
+        $ENV{MPROFILE_OUTF} = catfile(result_dir(), "$test_name".".json");
+        #
+        # MPROFILE_RESULTS is used by libtestutil where to write
+        # the profile data.
+        #
+        $ENV{MPROFILE_RESULTS} = result_dir();
     }
     $cmdstr .= "$stdin$stdout$stderr";
 

--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -13,6 +13,7 @@ use warnings;
 use Carp;
 use Test::More 0.96;
 
+use File::Basename;
 use File::Spec::Functions 'catfile';
 
 use Exporter;
@@ -1297,18 +1298,34 @@ sub __decorate_cmd {
     }
 
     if ($ENV{DO_MPROFILE}) {
+        my $file_name;
+        my $index = 0;
+        my $glob_pattern = catfile(result_dir(), "$test_name"."*.json");
 
-        $ENV{MPROFILE_MODE} = "1";
+        #
+        # some tests execute more than one command, we need to capture
+        # data for each command invocation. The output names for memory
+        # profile record read as follow: sometest_1.json, sometest_2.json, ...
+        #
+        # loop here finds the next index to continue.
+        #
+        foreach $file_name ( glob($glob_pattern) ) {
+            $file_name = basename($file_name);
+            if ($file_name =~ m/.*_(\d+).json/) {
+                if ($index < $1) {
+                    $index = $1;
+                }
+            }
+        }
+        $index = $index + 1;
+        $file_name = "$test_name"."_"."$index".".json";
+
+        $ENV{MPROFILE_ANNOTATION} = "$cmdstr";
         #
 	# Note the tests which are linked with libtestutil directory will
         # override MPROFILE_OUTF
         #
-        $ENV{MPROFILE_OUTF} = catfile(result_dir(), "$test_name".".json");
-        #
-        # MPROFILE_RESULTS is used by libtestutil where to write
-        # the profile data.
-        #
-        $ENV{MPROFILE_RESULTS} = result_dir();
+        $ENV{MPROFILE_OUTF} = catfile(result_dir(), $file_name);
     }
     $cmdstr .= "$stdin$stdout$stderr";
 

--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -1294,6 +1294,14 @@ sub __decorate_cmd {
             unless $stderr || !$ENV{HARNESS_ACTIVE} || $ENV{HARNESS_VERBOSE};
     }
 
+    if ($ENV{DO_MPROFILE}) {
+        my $libmprofile = $ENV{LIBMPROFILE};
+	if ($^O ne 'WIN32') {
+            $ENV{LD_PRELOAD}="$libmprofile";
+	    $ENV{MPROFILE_MODE}="1";
+	    $ENV{MPROFILE_OUTF}="";
+        }
+    }
     $cmdstr .= "$stdin$stdout$stderr";
 
     if ($debug) {

--- a/util/shlib_wrap.sh.in
+++ b/util/shlib_wrap.sh.in
@@ -105,7 +105,7 @@ NONSTOP_KERNEL)
 	if [ "$OSTYPE" != msdosdjgpp ]; then
 		PATH="${THERE}:$PATH"; export PATH
 	fi
-	if [ "${DO_MPROFILE}" == "1" ] ; then
+	if [ "${DO_MPROFILE}" -eq 1 ] ; then
 		#
 		# if binary we are about to load is linked with shared
 		# libcrypto.so then make sure to preload libmprofile.so
@@ -113,8 +113,6 @@ NONSTOP_KERNEL)
 		ldd "$1" |grep "$LIBCRYPTOSO" > /dev/null
 		if [ $? -eq 0 ] ; then
 			export LD_PRELOAD="${LIBMPROFILE}"
-		else
-			unset LD_PRELOAD;
 		fi
 
 	fi

--- a/util/shlib_wrap.sh.in
+++ b/util/shlib_wrap.sh.in
@@ -105,6 +105,19 @@ NONSTOP_KERNEL)
 	if [ "$OSTYPE" != msdosdjgpp ]; then
 		PATH="${THERE}:$PATH"; export PATH
 	fi
+	if [ "${DO_MPROFILE}" == "1" ] ; then
+		#
+		# if binary we are about to load is linked with shared
+		# libcrypto.so then make sure to preload libmprofile.so
+		#
+		ldd "$1" |grep "$LIBCRYPTOSO" > /dev/null
+		if [ $? -eq 0 ] ; then
+			export LD_PRELOAD="${LIBMPROFILE}"
+		else
+			unset LD_PRELOAD;
+		fi
+
+	fi
 	;;
 esac
 
@@ -117,8 +130,8 @@ if [ -f "$LIBCRYPTOSO" -a -z "$preload_var" ]; then
 	# it into a script makes it possible to do so on multi-ABI
 	# platforms.
 	case "$SYSNAME" in
-	*BSD)	LD_PRELOAD="$LIBCRYPTOSO:$LIBSSLSO" ;;	# *BSD
-	*)	LD_PRELOAD="$LIBCRYPTOSO $LIBSSLSO" ;;	# SunOS, Linux, ELF HP-UX
+	*BSD)	LD_PRELOAD="$LD_PRELOAD:$LIBCRYPTOSO:$LIBSSLSO" ;;	# *BSD
+	*)	LD_PRELOAD="$LD_PRELOAD $LIBCRYPTOSO $LIBSSLSO" ;;	# SunOS, Linux, ELF HP-UX
 	esac
 	_RLD_LIST="$LIBCRYPTOSO:$LIBSSLSO:DEFAULT"	# Tru64, o32 IRIX
 	DYLD_INSERT_LIBRARIES="$LIBCRYPTOSO:$LIBSSLSO"	# MacOS X


### PR DESCRIPTION
This is the first take on adding a memory profiler to openssl. The original idea was to preload shared library to gather memory profile data while running `make test`. This approach works as long as tests are using shared libcrypto. Unfortunately it's not always the case. Lot of tests are using static version of libcrypto. To enable profiling for those tests too we need add a static version of memory profiler at compile time. The chosen approach presented here suggest to add memory profiler to `libtestutil`. The `libtestutil` is static library used by all test binaries. This way we can obtain memory profile from test applications which link static version of libcrypto.

To collect memory profiling data one must set up shell environment properly before running `make test`:
```
export DO_MPROFILE=1     # tell tests to run in memory profile mode
export LIBMPROFILE=/path/to/libmprofile.so # see https://github.com/sashan/mprofile
make test # expect to find data in test-run/test_name/*.json
```
I don't expect this PR to be merged as-is. This is just draft so people can see where I'm at with this. What I'd like to figure out is to solve everything with `LD_PRELOAD=` only, so changes to libtestutil can be avoided. 
