### PR TITLE
Fixes #[14771]. Improved error message

### DIFF
--- a/crypto/x509/x509_txt.c
+++ b/crypto/x509/x509_txt.c
@@ -40,7 +40,7 @@ const char *X509_verify_cert_error_string(long n)
     case X509_V_ERR_CRL_SIGNATURE_FAILURE:
         return "CRL signature failure";
     case X509_V_ERR_CERT_NOT_YET_VALID:
-        return "certificate is not yet valid";
+        return "certificate is not yet valid or the system clock is incorrect";
     case X509_V_ERR_CERT_HAS_EXPIRED:
         return "certificate has expired";
     case X509_V_ERR_CRL_NOT_YET_VALID:


### PR DESCRIPTION
In addition to an invalid certificate, it is not unlikely that this exact error (case X509_V_ERR_CERT_NOT_YET_VALID) is caused by an incorrect system clock. This cannot be trivially fixed, so for now, we simply improve the quality of the error message.
