### PR TITLE
Fix a visual glitch in test_cms.t

### DIFF
--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -1378,7 +1378,7 @@ subtest "encrypt to three recipients with RSA-OAEP, key only decrypt" => sub {
     is(compare($pt, $ptpt), 0, "compare original message with decrypted ciphertext");
 };
 
-subtest "EdDSA tests for CMS \n" => sub {
+subtest "EdDSA tests for CMS" => sub {
     plan tests => 2;
 
     SKIP: {
@@ -1399,7 +1399,7 @@ subtest "EdDSA tests for CMS \n" => sub {
     }
 };
 
-subtest "ML-DSA tests for CMS \n" => sub {
+subtest "ML-DSA tests for CMS" => sub {
     plan tests => 2;
 
     SKIP: {
@@ -1420,7 +1420,7 @@ subtest "ML-DSA tests for CMS \n" => sub {
     }
 };
 
-subtest "SLH-DSA tests for CMS \n" => sub {
+subtest "SLH-DSA tests for CMS" => sub {
     plan tests => 6;
 
     SKIP: {


### PR DESCRIPTION
the newline in the newly added subtest names somehow creates another small visual glitch in the test output, that looks like:
80-test_cms.t .. 30/?
80-test_cms.t .. ok
