### PR TITLE
Updated the change log to include SSLv3 being disabled by default.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6472,6 +6472,12 @@ OpenSSL 1.1.0
 
    *Rob Percival <robpercival@google.com>*
 
+ * Disable SSLv3 default build, default negotiation and weak ciphers. SSLv3
+   is by default disabled at build-time. Builds that are not configured with
+   "enable-ssl3" will not support SSLv3.
+
+   *Kurt Roeckx*
+
 OpenSSL 1.0.2
 -------------
 


### PR DESCRIPTION
Fixes #8969

This change was implemented into version 1.1.0 and onward. The last version that had SSLv3 enabled was version 1.0.2h, which is why the addition was made where it is.

CLA: trivial

##### Checklist
- [x] documentation is added or updated
