### PR TITLE
We should be using OPENSSL_strdup() because those strings are going

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -127,7 +127,7 @@ static int set_random_provider_name(RAND_GLOBAL *dgbl, const char *name)
         return 1;
 
     OPENSSL_free(dgbl->random_provider_name);
-    dgbl->random_provider_name = strdup(name);
+    dgbl->random_provider_name = OPENSSL_strdup(name);
     return dgbl->random_provider_name != NULL;
 }
 

--- a/test/conf_include_test.c
+++ b/test/conf_include_test.c
@@ -59,7 +59,7 @@ static char *change_path(const char *file)
 
     ret = chdir(s);
     if (ret == 0)
-        new_config_name = strdup(last + DIRSEP_PRESERVE + 1);
+        new_config_name = OPENSSL_strdup(last + DIRSEP_PRESERVE + 1);
  err:
     OPENSSL_free(s);
     return new_config_name;


### PR DESCRIPTION
to be freed by OPENSSL_free(). Things can get messy when application decides to use it's own memory allocation functions using CRYPTO_set_mem_functions(3ossl)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
