### PR TITLE
Fix quic_multistream_test: correct more frame types

### DIFF
--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2842,6 +2842,7 @@ static int script_21_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
 
     switch (h->inject_word1) {
     case OSSL_QUIC_FRAME_TYPE_PATH_CHALLENGE:
+    case OSSL_QUIC_FRAME_TYPE_PATH_RESPONSE:
         if (!TEST_true(WPACKET_put_bytes_u64(&wpkt, (uint64_t)0)))
             goto err;
         break;

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2845,6 +2845,8 @@ static int script_21_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
         if (!TEST_true(WPACKET_put_bytes_u64(&wpkt, (uint64_t)0)))
             goto err;
         break;
+    case OSSL_QUIC_FRAME_TYPE_STOP_SENDING:
+    case OSSL_QUIC_FRAME_TYPE_MAX_STREAM_DATA:
     case OSSL_QUIC_FRAME_TYPE_STREAM_DATA_BLOCKED:
         if (!TEST_true(WPACKET_quic_write_vlint(&wpkt, (uint64_t)0)))
             goto err;


### PR DESCRIPTION
There are a few more critical frame injections that previously created an out-of-diskspace problem
and now only a CI test failure.  The pattern
in the qlog files is always similar to this:

{"frame_type":"stop_sending","stream_id":6,"error_code":1152,"length":4}, {"frame_type":"path_challenge","length":9},...{}

Note: The stream_id 6 is a OSSL_QUIC_FRAME_TYPE_CRYPTO.
