### PR TITLE
apps/lib/apps.c: Add a check for OPENSSL_strdup()

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1758,6 +1758,9 @@ CA_DB *load_index(const char *dbfile, DB_ATTR *db_attr)
     }
 
     retdb->dbfname = OPENSSL_strdup(dbfile);
+    if (retdb->dbfname == NULL)
+        goto err;
+
 #ifndef OPENSSL_NO_POSIX_IO
     retdb->dbst = dbst;
 #endif


### PR DESCRIPTION
Add a check for the return value of OPENSSL_strdup() to guarantee the success of allocation, similar to the other call sites.

Fixes: c7d5ea2670 ("Prepare to detect index changes in OCSP responder.")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
