### PR TITLE
Fix goto label indents to match style

### DIFF
--- a/apps/lib/app_provider.c
+++ b/apps/lib/app_provider.c
@@ -133,7 +133,7 @@ static int opt_provider_param(const char *arg)
         ret = 0;
     }
 
-  end:
+ end:
     OPENSSL_free(copy);
     return ret;
 }

--- a/apps/list.c
+++ b/apps/list.c
@@ -871,7 +871,7 @@ static void list_tls_groups(int version, int all)
         BIO_printf(bio_out, "%s%c", sk_OPENSSL_CSTRING_value(groups, i),
                    (i < num - 1) ? ':' : '\n');
     }
-  err:
+ err:
     SSL_CTX_free(ctx);
     sk_OPENSSL_CSTRING_free(groups);
     return;

--- a/crypto/bio/bss_acpt.c
+++ b/crypto/bio/bss_acpt.c
@@ -356,7 +356,7 @@ static int acpt_state(BIO *b, BIO_ACCEPT *c)
         BIO_free(bio);
     else if (s >= 0)
         BIO_closesocket(s);
-  end:
+ end:
     return ret;
 }
 

--- a/crypto/ec/ecp_mont.c
+++ b/crypto/ec/ecp_mont.c
@@ -258,7 +258,7 @@ int ossl_ec_GFp_mont_field_inv(const EC_GROUP *group, BIGNUM *r, const BIGNUM *a
 
     ret = 1;
 
-  err:
+ err:
     BN_CTX_end(ctx);
     BN_CTX_free(new_ctx);
     return ret;

--- a/crypto/ml_dsa/ml_dsa_key.c
+++ b/crypto/ml_dsa/ml_dsa_key.c
@@ -58,7 +58,7 @@ int ossl_ml_dsa_set_prekey(ML_DSA_KEY *key, int flags_set, int flags_clr,
     key->prov_flags &= ~flags_clr;
     ret = 1;
 
-  end:
+ end:
     if (!ret) {
         OPENSSL_free(key->priv_encoding);
         OPENSSL_free(key->seed);

--- a/crypto/ml_kem/ml_kem.c
+++ b/crypto/ml_kem/ml_kem.c
@@ -1402,7 +1402,7 @@ int genkey(const uint8_t seed[ML_KEM_SEED_BYTES],
     }
 
     ret = 1;
-  end:
+ end:
     OPENSSL_cleanse((void *)augmented_seed, ML_KEM_RANDOM_BYTES);
     OPENSSL_cleanse((void *)sigma, ML_KEM_RANDOM_BYTES);
     return ret;
@@ -1618,7 +1618,7 @@ ML_KEM_KEY *ossl_ml_kem_key_dup(const ML_KEM_KEY *key, int selection)
      * duplicated.
      */
     if (ossl_ml_kem_decoded_key(key))
-        return 0;
+        return NULL;
 
     if (key == NULL
         || (ret = OPENSSL_memdup(key, sizeof(*key))) == NULL)

--- a/providers/implementations/encode_decode/ml_dsa_codecs.c
+++ b/providers/implementations/encode_decode/ml_dsa_codecs.c
@@ -256,7 +256,7 @@ ossl_ml_dsa_d2i_PKCS8(const uint8_t *prvenc, int prvlen,
                                seed, ML_DSA_SEED_BYTES, priv, v->sk_len))
         ret = key;
 
-  end:
+ end:
     OPENSSL_free(fmt_slots);
     PKCS8_PRIV_KEY_INFO_free(p8inf);
     if (ret == NULL)
@@ -396,7 +396,7 @@ int ossl_ml_dsa_i2d_prvkey(const ML_DSA_KEY *key, uint8_t **out,
         ret = len;
     }
 
-  end:
+ end:
     OPENSSL_free(fmt_slots);
     if (ret == 0)
         OPENSSL_free(buf);

--- a/providers/implementations/encode_decode/ml_kem_codecs.c
+++ b/providers/implementations/encode_decode/ml_kem_codecs.c
@@ -265,7 +265,7 @@ ossl_ml_kem_d2i_PKCS8(const uint8_t *prvenc, int prvlen,
     /* Any OQS public key content is ignored */
     ret = key;
 
-  end:
+ end:
     OPENSSL_free(fmt_slots);
     PKCS8_PRIV_KEY_INFO_free(p8inf);
     if (ret == NULL)
@@ -417,7 +417,7 @@ int ossl_ml_kem_i2d_prvkey(const ML_KEM_KEY *key, uint8_t **out,
         ret = len;
     }
 
-  end:
+ end:
     OPENSSL_free(fmt_slots);
     if (ret == 0)
         OPENSSL_free(buf);
@@ -481,7 +481,7 @@ int ossl_ml_kem_key_to_text(BIO *out, const ML_KEM_KEY *key, int selection)
                        "no %s key material available",
                        type_label);
 
-  end:
+ end:
     OPENSSL_free(pubenc);
     OPENSSL_free(prvenc);
     return ret;

--- a/providers/implementations/kem/ml_kem_kem.c
+++ b/providers/implementations/kem/ml_kem_kem.c
@@ -206,7 +206,7 @@ static int ml_kem_encapsulate(void *vctx, unsigned char *ctext, size_t *clen,
     else
         ret = ossl_ml_kem_encap_rand(ctext, encap_clen, shsec, encap_slen, key);
 
-  end:
+ end:
     /*
      * One shot entropy, each encapsulate call must either provide a new
      * "ikmE", or else will use a random value.  If a caller sets an explicit

--- a/providers/implementations/kem/mlx_kem.c
+++ b/providers/implementations/kem/mlx_kem.c
@@ -234,7 +234,7 @@ static int mlx_kem_encapsulate(void *vctx, unsigned char *ctext, size_t *clen,
     }
 
     ret = 1;
-  end:
+ end:
     EVP_PKEY_free(xkey);
     EVP_PKEY_CTX_free(ctx);
     return ret;
@@ -322,7 +322,7 @@ static int mlx_kem_decapsulate(void *vctx, uint8_t *shsec, size_t *slen,
     }
 
     ret = 1;
-  end:
+ end:
     EVP_PKEY_CTX_free(ctx);
     EVP_PKEY_free(xkey);
     return ret;

--- a/providers/implementations/keymgmt/ml_kem_kmgmt.c
+++ b/providers/implementations/keymgmt/ml_kem_kmgmt.c
@@ -543,7 +543,7 @@ void *ml_kem_load(const void *reference, size_t reference_sz)
         return key;
     }
 
-  err:
+ err:
     OPENSSL_free(encoded_dk);
     ossl_ml_kem_key_free(key);
     return NULL;

--- a/providers/implementations/keymgmt/mlx_kmgmt.c
+++ b/providers/implementations/keymgmt/mlx_kmgmt.c
@@ -92,7 +92,7 @@ mlx_kem_key_new(unsigned int v, OSSL_LIB_CTX *libctx, char *propq)
     key->propq = propq;
     return key;
 
-  err:
+ err:
     OPENSSL_free(propq);
     return NULL;
 }
@@ -310,7 +310,7 @@ static int mlx_kem_export(void *vkey, int selection, OSSL_CALLBACK *param_cb,
     ret = param_cb(params, cbarg);
     OSSL_PARAM_free(params);
 
-err:
+ err:
     OSSL_PARAM_BLD_free(tmpl);
     OPENSSL_secure_clear_free(sub_arg.prvenc, prvlen);
     OPENSSL_free(sub_arg.pubenc);
@@ -369,7 +369,7 @@ load_slot(OSSL_LIB_CTX *libctx, const char *propq, const char *pname,
     if (EVP_PKEY_fromdata(ctx, ppkey, selection, parr) > 0)
         ret = 1;
 
-  err:
+ err:
     EVP_PKEY_CTX_free(ctx);
     return ret;
 }
@@ -399,7 +399,7 @@ load_keys(MLX_KEY *key,
     key->state = prvlen ? MLX_HAVE_PRVKEY : MLX_HAVE_PUBKEY;
     return 1;
 
-  err:
+ err:
     EVP_PKEY_free(key->mkey);
     EVP_PKEY_free(key->xkey);
     key->xkey = key->mkey = NULL;

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -988,7 +988,7 @@ int tls1_get0_implemented_groups(int min_proto_version, int max_proto_version,
     }
     ret = 1;
 
-  end:
+ end:
     sk_TLS_GROUP_IX_pop_free(collect, free_wrapper);
     return ret;
 }

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -3158,7 +3158,7 @@ ml_kem_seed_to_priv(const char *alg, const unsigned char *seed, int seedlen,
         goto done;
     ok = 1;
 
-  done:
+ done:
     EVP_PKEY_free(pkey);
     OSSL_PARAM_free(params);
     EVP_PKEY_CTX_free(ctx);

--- a/test/ssl_ctx_test.c
+++ b/test/ssl_ctx_test.c
@@ -127,7 +127,7 @@ static int test_set_min_max_version(int idx_tst)
 
     testresult = 1;
 
-  end:
+ end:
     SSL_free(ssl);
     SSL_CTX_free(ctx);
     return testresult;

--- a/test/v3ext.c
+++ b/test/v3ext.c
@@ -311,7 +311,7 @@ static int test_addr_fam_len(void)
         goto end;
 
     testresult = 1;
-  end:
+ end:
     /* Free stack and any memory owned by detached element */
     IPAddressFamily_free(f1);
     sk_IPAddressFamily_pop_free(addr, IPAddressFamily_free);


### PR DESCRIPTION
Applicable to master and perhaps 3.5.

This results in 1927 labels with one space, and 1104 with no spaces, I am assuming the single space majority are the preferred style.