### PR TITLE
get memory profile using libtcmalloc and gperftools

### DIFF
--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -1318,8 +1318,8 @@ sub __decorate_cmd {
         }
         $index = $index + 1;
 	$file_name = "$test_name"."_"."$index".".result";
-	open(MARKER, ">$file_name");
-	close(MARKER);
+	open(RESULT, ">$file_name");
+	close(RESULT);
         # the result is collected in shlib_wrap.sh
 	$ENV{MPROFILE_RESULT}=$file_name;
 

--- a/util/shlib_wrap.sh.in
+++ b/util/shlib_wrap.sh.in
@@ -105,6 +105,9 @@ NONSTOP_KERNEL)
 	if [ "$OSTYPE" != msdosdjgpp ]; then
 		PATH="${THERE}:$PATH"; export PATH
 	fi
+	if [ "${DO_MPROFILE}" -eq 1 ] ; then
+		export LD_PRELOAD="${LIBMPROFILE}"
+	fi
 	;;
 esac
 
@@ -129,7 +132,13 @@ fi
 cmd="$1"; [ -x "$cmd" ] || cmd="$cmd${EXE_EXT}"
 shift
 if [ $# -eq 0 ]; then
+	if [ "${DO_MPROFILE}" -eq 1 ] ; then
+		echo "$cmd" > ${MPROFILE_RESULT}
+	fi
 	exec "$cmd"	# old sh, such as Tru64 4.x, fails to expand empty "$@"
 else
+	if [ "${DO_MPROFILE}" -eq 1 ] ; then
+		echo "$cmd" "$@" > ${MPROFILE_RESULT}
+	fi
 	exec "$cmd" "$@"
 fi

--- a/util/wrap.pl.in
+++ b/util/wrap.pl.in
@@ -92,17 +92,6 @@ if ($^O eq 'VMS') {
 # from the call, so we resort to using system() instead.
 my $waitcode = system @cmd;
 
-if ( $ENV{DO_MPROFILE} ) {
-    my $prof = "$ENV{HEAPPROFILE}".".0001.heap";
-    my $result = "$ENV{MPROFILE_RESULT}";
-    my $pprof_cmd = "pprof-symbolize --text --show_bytes --alloc_space";
-
-    $pprof_cmd = "$pprof_cmd "."$cmd[1]"." $prof"." |grep '^Total' >>";
-    $pprof_cmd = "$pprof_cmd"." $result";
-    system $pprof_cmd;
-    unlink( ( $prof ) );
-}
-
 # According to documentation, -1 means that system() couldn't run the command,
 # otherwise, the value is similar to the Unix wait() status value
 # (exitcode << 8 | signalcode)
@@ -133,4 +122,16 @@ if ($^O eq 'VMS' && $exitcode != 0) {
         + 2                     # Severity: E(rror)
         + 0x10000000;           # bit 28 set => the shell stays silent
 }
+
+if ( $ENV{DO_MPROFILE} ) {
+    my $prof = "$ENV{HEAPPROFILE}".".0001.heap";
+    my $result = "$ENV{MPROFILE_RESULT}";
+    my $pprof_cmd = "pprof-symbolize --text --show_bytes --alloc_space";
+
+    $pprof_cmd = "$pprof_cmd "."$cmd[1]"." $prof"." |grep '^Total' >>";
+    $pprof_cmd = "$pprof_cmd"." $result";
+    system $pprof_cmd;
+    unlink( ( $prof ) );
+}
+
 exit($exitcode);

--- a/util/wrap.pl.in
+++ b/util/wrap.pl.in
@@ -92,6 +92,17 @@ if ($^O eq 'VMS') {
 # from the call, so we resort to using system() instead.
 my $waitcode = system @cmd;
 
+if ( $ENV{DO_MPROFILE} ) {
+    my $prof = "$ENV{HEAPPROFILE}".".0001.heap";
+    my $result = "$ENV{MPROFILE_RESULT}";
+    my $pprof_cmd = "pprof-symbolize --text --show_bytes --alloc_space";
+
+    $pprof_cmd = "$pprof_cmd "."$cmd[1]"." $prof"." |grep '^Total' >>";
+    $pprof_cmd = "$pprof_cmd"." $result";
+    system $pprof_cmd;
+    unlink( ( $prof ) );
+}
+
 # According to documentation, -1 means that system() couldn't run the command,
 # otherwise, the value is similar to the Unix wait() status value
 # (exitcode << 8 | signalcode)


### PR DESCRIPTION
This is alternative approach to what's in PR here https://github.com/openssl/openssl/pull/27139

it currently fails in quic multistream test and CA test. The quic multistream test stalls don't know why it gets stuck. I have not looked at failure in CA test. it could be some trivial oversought in scripting which introduces tcmalloc and gperftoosls.

the change has been tested on ubuntu-24:
```
export DO_MPROFILE=1
export LIBMPROFILE=/path/to/libtcmalloc.so
```
the tcmalloc path on ubuntu 24 is `/usr/lib/x86_64-linux-gnu/libtcmalloc_and_profiler.so`