### PR TITLE
move BIO_err_is_non_fatal() to bio_lib.c

### DIFF
--- a/crypto/bio/bio_err.c
+++ b/crypto/bio/bio_err.c
@@ -97,18 +97,3 @@ int ossl_err_load_BIO_strings(void)
 #endif
     return 1;
 }
-
-#ifndef OPENSSL_NO_SOCK
-
-int BIO_err_is_non_fatal(unsigned int errcode)
-{
-    if (ERR_SYSTEM_ERROR(errcode))
-        return BIO_sock_non_fatal_error(ERR_GET_REASON(errcode));
-    else if (ERR_GET_LIB(errcode) == ERR_LIB_BIO
-             && ERR_GET_REASON(errcode) == BIO_R_NON_FATAL)
-        return 1;
-    else
-        return 0;
-}
-
-#endif

--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -1080,3 +1080,18 @@ int BIO_do_connect_retry(BIO *bio, int timeout, int nap_milliseconds)
 
     return rv;
 }
+
+#ifndef OPENSSL_NO_SOCK
+
+int BIO_err_is_non_fatal(unsigned int errcode)
+{
+    if (ERR_SYSTEM_ERROR(errcode))
+        return BIO_sock_non_fatal_error(ERR_GET_REASON(errcode));
+    else if (ERR_GET_LIB(errcode) == ERR_LIB_BIO
+             && ERR_GET_REASON(errcode) == BIO_R_NON_FATAL)
+        return 1;
+    else
+        return 0;
+}
+
+#endif


### PR DESCRIPTION
<del>because `mkerr.pl` doesn't generate it anymore in `bio_err.c`</del>
Doing this without running `mkerr.pl` otherwise this is what `mkerr.pl` would do:
* remove `BIO_err_is_non_fatal` from `bio_err.c`
* remove duplicate `BIO_R_PORT_MISMATCH`
* reorder/sort 3 things
* update copyright year from `2022` to `2025`

see previous PR attempt: https://github.com/openssl/openssl/pull/27185
see issue #27183

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

