### PR TITLE
apps/srp.c: Add OPENSSL_free to avoid the Memory Leak

### DIFF
--- a/apps/srp.c
+++ b/apps/srp.c
@@ -556,8 +556,11 @@ int srp_main(int argc, char **argv)
                         || row[DB_srpsalt] == NULL
                         || (userinfo
                             && ((row[DB_srpinfo] = OPENSSL_strdup(userinfo))
-                                == NULL)))
+                                == NULL))) {
+                        OPENSSL_free(row[DB_srpgN]);
+                        OPENSSL_free(row[DB_srpinfo]);
                         goto end;
+                    }
 
                     doupdatedb = 1;
                 }


### PR DESCRIPTION
Add OPENSSL_free() in the error handling to free the memory allocated by OPENSSL_strdup().

Fixes: 6e81b27012 ("apps/srp.c: make it indent-friendly.")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
