### PR TITLE
Fix more quic_multistream test formatting

### DIFF
--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2827,7 +2827,7 @@ static int script_21_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
 {
     int ok = 0;
     WPACKET wpkt;
-    unsigned char frame_buf[28];
+    unsigned char frame_buf[21];
     size_t written;
 
     if (h->inject_word0 == 0 || hdr->type != h->inject_word0)
@@ -2913,19 +2913,16 @@ static int script_21_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
         if (!TEST_true(WPACKET_quic_write_vlint(&wpkt, (uint64_t)0)))
             goto err;
 
-        /* Connection id length, arbitrary at 8 bytes */
-        if (!TEST_true(WPACKET_put_bytes_u8(&wpkt, (uint8_t)8)))
+        /* Connection id length, arbitrary at 1 bytes */
+        if (!TEST_true(WPACKET_put_bytes_u8(&wpkt, (uint8_t)1)))
             goto err;
 
         /* The connection id, to match the above length */
-        if (!TEST_true(WPACKET_put_bytes_u64(&wpkt, (uint64_t)0)))
+        if (!TEST_true(WPACKET_put_bytes_u8(&wpkt, (uint8_t)0)))
             goto err;
 
-        /* two uint64_t's (16 bytes total) for the SRT */
-        if (!TEST_true(WPACKET_put_bytes_u64(&wpkt, (uint64_t)0)))
-            goto err;
-
-        if (!TEST_true(WPACKET_put_bytes_u64(&wpkt, (uint64_t)0)))
+        /* 16 bytes total for the SRT */
+        if (!TEST_true(WPACKET_memset(&wpkt, 0, 16)))
             goto err;
 
         break;

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2827,7 +2827,7 @@ static int script_21_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
 {
     int ok = 0;
     WPACKET wpkt;
-    unsigned char frame_buf[128];
+    unsigned char frame_buf[28];
     size_t written;
 
     if (h->inject_word0 == 0 || hdr->type != h->inject_word0)
@@ -2892,11 +2892,11 @@ static int script_21_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
          */
 
         /* New token length, cannot be zero */
-        if (!TEST_true(WPACKET_quic_write_vlint(&wpkt, (uint64_t)8)))
+        if (!TEST_true(WPACKET_quic_write_vlint(&wpkt, (uint64_t)1)))
             goto err;
 
-        /* 8 bytes of token data, to match the above length */
-        if (!TEST_true(WPACKET_put_bytes_u64(&wpkt, (uint64_t)0)))
+        /* 1 bytes of token data, to match the above length */
+        if (!TEST_true(WPACKET_put_bytes_u8(&wpkt, (uint8_t)0)))
             goto err;
         break;
     case OSSL_QUIC_FRAME_TYPE_NEW_CONN_ID:
@@ -2920,8 +2920,15 @@ static int script_21_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
         /* The connection id, to match the above length */
         if (!TEST_true(WPACKET_put_bytes_u64(&wpkt, (uint64_t)0)))
             goto err;
-        break;
 
+        /* two uint64_t's (16 bytes total) for the SRT */
+        if (!TEST_true(WPACKET_put_bytes_u64(&wpkt, (uint64_t)0)))
+            goto err;
+
+        if (!TEST_true(WPACKET_put_bytes_u64(&wpkt, (uint64_t)0)))
+            goto err;
+
+        break;
     }
 
     if (!TEST_true(WPACKET_get_total_written(&wpkt, &written)))

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2827,7 +2827,7 @@ static int script_21_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
 {
     int ok = 0;
     WPACKET wpkt;
-    unsigned char frame_buf[9];
+    unsigned char frame_buf[128];
     size_t written;
 
     if (h->inject_word0 == 0 || hdr->type != h->inject_word0)
@@ -2843,17 +2843,85 @@ static int script_21_inject_plain(struct helper *h, QUIC_PKT_HDR *hdr,
     switch (h->inject_word1) {
     case OSSL_QUIC_FRAME_TYPE_PATH_CHALLENGE:
     case OSSL_QUIC_FRAME_TYPE_PATH_RESPONSE:
+    case OSSL_QUIC_FRAME_TYPE_RETIRE_CONN_ID:
+        /*
+         * These cases to be formatted properly need a single uint64_t
+         */
         if (!TEST_true(WPACKET_put_bytes_u64(&wpkt, (uint64_t)0)))
+            goto err;
+        break;
+    case OSSL_QUIC_FRAME_TYPE_MAX_DATA:
+    case OSSL_QUIC_FRAME_TYPE_STREAMS_BLOCKED_UNI:
+    case OSSL_QUIC_FRAME_TYPE_STREAMS_BLOCKED_BIDI:
+    case OSSL_QUIC_FRAME_TYPE_MAX_STREAMS_BIDI:
+    case OSSL_QUIC_FRAME_TYPE_MAX_STREAMS_UNI:
+    case OSSL_QUIC_FRAME_TYPE_DATA_BLOCKED:
+        /*
+         * These cases require a single vlint
+         */
+        if (!TEST_true(WPACKET_quic_write_vlint(&wpkt, (uint64_t)0)))
             goto err;
         break;
     case OSSL_QUIC_FRAME_TYPE_STOP_SENDING:
     case OSSL_QUIC_FRAME_TYPE_MAX_STREAM_DATA:
     case OSSL_QUIC_FRAME_TYPE_STREAM_DATA_BLOCKED:
+        /*
+         * These cases require 2 variable integers
+         */
         if (!TEST_true(WPACKET_quic_write_vlint(&wpkt, (uint64_t)0)))
             goto err;
         if (!TEST_true(WPACKET_quic_write_vlint(&wpkt, (uint64_t)0)))
             goto err;
         break;
+    case OSSL_QUIC_FRAME_TYPE_STREAM:
+    case OSSL_QUIC_FRAME_TYPE_RESET_STREAM:
+    case OSSL_QUIC_FRAME_TYPE_CONN_CLOSE_APP:
+        /*
+         * These cases require 3 variable integers
+         */
+        if (!TEST_true(WPACKET_quic_write_vlint(&wpkt, (uint64_t)0)))
+            goto err;
+        if (!TEST_true(WPACKET_quic_write_vlint(&wpkt, (uint64_t)0)))
+            goto err;
+        if (!TEST_true(WPACKET_quic_write_vlint(&wpkt, (uint64_t)0)))
+            goto err;
+        break;
+    case OSSL_QUIC_FRAME_TYPE_NEW_TOKEN:
+        /*
+         * Special case for new token
+         */
+
+        /* New token length, cannot be zero */
+        if (!TEST_true(WPACKET_quic_write_vlint(&wpkt, (uint64_t)8)))
+            goto err;
+
+        /* 8 bytes of token data, to match the above length */
+        if (!TEST_true(WPACKET_put_bytes_u64(&wpkt, (uint64_t)0)))
+            goto err;
+        break;
+    case OSSL_QUIC_FRAME_TYPE_NEW_CONN_ID:
+        /*
+         * Special case for New Connection ids, has a combination
+         * of vlints and fixed width values
+         */
+
+        /* seq number */
+        if (!TEST_true(WPACKET_quic_write_vlint(&wpkt, (uint64_t)0)))
+            goto err;
+
+        /* retire prior to */
+        if (!TEST_true(WPACKET_quic_write_vlint(&wpkt, (uint64_t)0)))
+            goto err;
+
+        /* Connection id length, arbitrary at 8 bytes */
+        if (!TEST_true(WPACKET_put_bytes_u8(&wpkt, (uint8_t)8)))
+            goto err;
+
+        /* The connection id, to match the above length */
+        if (!TEST_true(WPACKET_put_bytes_u64(&wpkt, (uint64_t)0)))
+            goto err;
+        break;
+
     }
 
     if (!TEST_true(WPACKET_get_total_written(&wpkt, &written)))


### PR DESCRIPTION
We encountered another failure in the quic_multistream_test: https://github.com/openssl/openssl/actions/runs/14127125173/job/39578660601#step:9:1005

It appears we still occasionally get empty frames in our qlog, with the validate-qlog.py scripts properly bails out on.  In the above case, the offending frame entry looked like this:
```
{
  "name": "transport:packet_received",
  "data": {
    "header": {
      "packet_type": "initial",
      "packet_number": 4,
      "dcid": "",
      "scid": "6217813c336a012a"
    },
    "datagram_id": 6,
    "frames": [
      {
        "frame_type": "new_token",
        "token": {
          "raw": {
            "data": "44801add5794"
          }
        },
        "length": 8
      },
      {
        "frame_type": "stream",
        "stream_id": 15897,
        "offset": 625652585,
        "payload_length": 11,
        "explicit_length": true,
        "fin": true,
        "length": 8
      },
      {}    <= NOTE EMPTY FRAME HERE
    ]
  },
  "time": 0
}
```

I think we're still missing some frame formatting cases in script_21_inject_plain(), which can format potentially any of the frames listed in the forbidden_frame_types array when running the test_dyn_frame_types test.

I think we need to enumerate all of those frame types in the case statement we have there.  Fortunately we generally don't have to provide sane values, and most of the cases fall into 4 categories (those that need a 64 bit data value, and those that require 1, 2 or 3 variable integers).  There are two special cases, NEW_TOKEN, and NEW_CONNECTION, but those just need a mix of fixed and variable width data.

So lets fully enumerate those and hopefully put this to bed.


##### Checklist
- [x] tests are added or updated
