### PR TITLE
Fix Strict c issue in aes_gcm for armv8

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_gcm_hw_armv8.inc
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw_armv8.inc
@@ -15,10 +15,8 @@
 size_t armv8_aes_gcm_encrypt(const unsigned char *in, unsigned char *out, size_t len,
                              const void *key, unsigned char ivec[16], u64 *Xi)
 {
-    size_t align_bytes = 0;
-    align_bytes = len - len % 16;
-
     AES_KEY *aes_key = (AES_KEY *)key;
+    size_t align_bytes = len - len % 16;
 
     switch(aes_key->rounds) {
         case 10:
@@ -49,10 +47,8 @@ size_t armv8_aes_gcm_encrypt(const unsigned char *in, unsigned char *out, size_t
 size_t armv8_aes_gcm_decrypt(const unsigned char *in, unsigned char *out, size_t len,
                              const void *key, unsigned char ivec[16], u64 *Xi)
 {
-    size_t align_bytes = 0;
-    align_bytes = len - len % 16;
-
     AES_KEY *aes_key = (AES_KEY *)key;
+    size_t align_bytes = len - len % 16;
 
     switch(aes_key->rounds) {
         case 10:


### PR DESCRIPTION
This appears to be a 6 year old change. So it would apply to all branches,

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
