### PR TITLE
crypto/ui/ui_lib.c: Add OPENSSL_free to avoid memory leaks

### DIFF
--- a/crypto/ui/ui_lib.c
+++ b/crypto/ui/ui_lib.c
@@ -205,6 +205,7 @@ int UI_dup_input_string(UI *ui, const char *prompt, int flags,
                         char *result_buf, int minsize, int maxsize)
 {
     char *prompt_copy = NULL;
+    int ret;
 
     if (prompt != NULL) {
         prompt_copy = OPENSSL_strdup(prompt);
@@ -212,9 +213,13 @@ int UI_dup_input_string(UI *ui, const char *prompt, int flags,
             return 0;
     }
 
-    return general_allocate_string(ui, prompt_copy, 1,
-                                   UIT_PROMPT, flags, result_buf, minsize,
-                                   maxsize, NULL);
+    ret = general_allocate_string(ui, prompt_copy, 1,
+                                  UIT_PROMPT, flags, result_buf, minsize,
+                                  maxsize, NULL);
+    if (ret <= 0)
+        OPENSSL_free(prompt_copy);
+
+    return ret;
 }
 
 int UI_add_verify_string(UI *ui, const char *prompt, int flags,
@@ -231,6 +236,7 @@ int UI_dup_verify_string(UI *ui, const char *prompt, int flags,
                          const char *test_buf)
 {
     char *prompt_copy = NULL;
+    int ret;
 
     if (prompt != NULL) {
         prompt_copy = OPENSSL_strdup(prompt);
@@ -238,9 +244,12 @@ int UI_dup_verify_string(UI *ui, const char *prompt, int flags,
             return -1;
     }
 
-    return general_allocate_string(ui, prompt_copy, 1,
-                                   UIT_VERIFY, flags, result_buf, minsize,
-                                   maxsize, test_buf);
+    ret = general_allocate_string(ui, prompt_copy, 1,
+                                  UIT_VERIFY, flags, result_buf, minsize,
+                                  maxsize, test_buf);
+    if (ret <= 0)
+        OPENSSL_free(prompt_copy);
+    return ret;
 }
 
 int UI_add_input_boolean(UI *ui, const char *prompt, const char *action_desc,
@@ -260,6 +269,7 @@ int UI_dup_input_boolean(UI *ui, const char *prompt, const char *action_desc,
     char *action_desc_copy = NULL;
     char *ok_chars_copy = NULL;
     char *cancel_chars_copy = NULL;
+    int ret;
 
     if (prompt != NULL) {
         prompt_copy = OPENSSL_strdup(prompt);
@@ -285,9 +295,14 @@ int UI_dup_input_boolean(UI *ui, const char *prompt, const char *action_desc,
             goto err;
     }
 
-    return general_allocate_boolean(ui, prompt_copy, action_desc_copy,
-                                    ok_chars_copy, cancel_chars_copy, 1,
-                                    UIT_BOOLEAN, flags, result_buf);
+    ret = general_allocate_boolean(ui, prompt_copy, action_desc_copy,
+                                   ok_chars_copy, cancel_chars_copy, 1,
+                                   UIT_BOOLEAN, flags, result_buf);
+    if (ret <= 0)
+        goto err;
+
+    return ret;
+
  err:
     OPENSSL_free(prompt_copy);
     OPENSSL_free(action_desc_copy);
@@ -305,6 +320,7 @@ int UI_add_info_string(UI *ui, const char *text)
 int UI_dup_info_string(UI *ui, const char *text)
 {
     char *text_copy = NULL;
+    int ret;
 
     if (text != NULL) {
         text_copy = OPENSSL_strdup(text);
@@ -312,8 +328,11 @@ int UI_dup_info_string(UI *ui, const char *text)
             return -1;
     }
 
-    return general_allocate_string(ui, text_copy, 1, UIT_INFO, 0, NULL,
-                                   0, 0, NULL);
+    ret = general_allocate_string(ui, text_copy, 1, UIT_INFO, 0, NULL,
+                                  0, 0, NULL);
+    if (ret <= 0)
+        OPENSSL_free(text_copy);
+    return ret;
 }
 
 int UI_add_error_string(UI *ui, const char *text)
@@ -325,14 +344,19 @@ int UI_add_error_string(UI *ui, const char *text)
 int UI_dup_error_string(UI *ui, const char *text)
 {
     char *text_copy = NULL;
+    int ret;
 
     if (text != NULL) {
         text_copy = OPENSSL_strdup(text);
         if (text_copy == NULL)
             return -1;
     }
-    return general_allocate_string(ui, text_copy, 1, UIT_ERROR, 0, NULL,
-                                   0, 0, NULL);
+
+    ret = general_allocate_string(ui, text_copy, 1, UIT_ERROR, 0, NULL,
+                                  0, 0, NULL);
+    if (ret <= 0)
+        OPENSSL_free(text_copy);
+    return ret;
 }
 
 char *UI_construct_prompt(UI *ui, const char *phrase_desc,


### PR DESCRIPTION
Add OPENSSL_free() if general_allocate_boolean() or general_allocate_string fails to avoid memory leaks.

Fixes: a63d5eaab2 ("Add a general user interface API.  This is designed to replace things like des_read_password and friends (backward compatibility functions using this new API are provided).  The purpose is to remove prompting functions from the DES code section as well as provide for prompting through dialog boxes in a window system and the like.")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
