### PR TITLE
test/tls-provider.c: Remove redundant check

### DIFF
--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -716,10 +716,8 @@ static void xor_freekey(void *keydata)
         return;
     assert(refcnt == 0);
 
-    if (key != NULL) {
-        OPENSSL_free(key->tls_name);
-        key->tls_name = NULL;
-    }
+    OPENSSL_free(key->tls_name);
+    key->tls_name = NULL;
     CRYPTO_FREE_REF(&key->references);
     OPENSSL_free(key);
 }


### PR DESCRIPTION
Remove "if (key != NULL)" since there is already a check before.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
