### PR TITLE
disable gost-engine tests in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -644,8 +644,8 @@ jobs:
       run: |
         cat /proc/cpuinfo
         ./util/opensslwrap.sh version -c
-    - name: test external gost-engine
-      run: make test TESTS="test_external_gost_engine"
+#    - name: test external gost-engine
+#      run: make test TESTS="test_external_gost_engine"
     - name: test external krb5
       run: make test TESTS="test_external_krb5"
     - name: test external tlsfuzzer


### PR DESCRIPTION
We need to temporarily disable this as we have a build break in CI: https://github.com/openssl/openssl/actions/runs/14192630435

Its occuring because gost-engine depends on libprov, which requires a minimum version cmake-3.0.  The update of github runners to cmake-4.0 causes a bail out as cmake 4.0 no longers supports cmake 3.0 syntax.

Libprov is fixed now, but gost-engine needs to update its libprov submodule, and then we need to update the gost-engine submodule.  Until thats done (which may take days), we should disable the gost-engine external tests

