### PR TITLE
Fixes SSL_accept_connection return non-NULL ocassionlly when QUIC handshake hasn't …

### DIFF
--- a/include/internal/quic_port.h
+++ b/include/internal/quic_port.h
@@ -95,6 +95,12 @@ QUIC_CHANNEL *ossl_quic_port_create_incoming(QUIC_PORT *port, SSL *tls);
  */
 QUIC_CHANNEL *ossl_quic_port_pop_incoming(QUIC_PORT *port);
 
+/*
+ * Push an incoming channel back to the incoming channel queue if QUIC handshake
+ * haven't finished yet
+ */
+void ossl_quic_port_push_incoming(QUIC_PORT *port, QUIC_CHANNEL *ch);
+
 /* Returns 1 if there is at least one connection incoming. */
 int ossl_quic_port_have_incoming(QUIC_PORT *port);
 

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4591,6 +4591,12 @@ SSL *ossl_quic_accept_connection(SSL *ssl, uint64_t flags)
         || (conn = SSL_CONNECTION_FROM_SSL(conn_ssl)) == NULL
         || (conn_ssl = SSL_CONNECTION_GET_USER_SSL(conn)) == NULL)
         goto out;
+
+    if (!ossl_quic_channel_is_handshake_complete(new_ch)) {
+        ossl_quic_port_push_incoming(ctx.ql->port, new_ch);
+        conn_ssl = NULL;
+        goto out;
+    }
     qc = (QUIC_CONNECTION *)conn_ssl;
     qc->listener = ctx.ql;
     qc->pending = 0;

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -595,6 +595,12 @@ QUIC_CHANNEL *ossl_quic_port_pop_incoming(QUIC_PORT *port)
     return ch;
 }
 
+void ossl_quic_port_push_incoming(QUIC_PORT *port, QUIC_CHANNEL *ch)
+{
+    ossl_list_incoming_ch_insert_head(&port->incoming_channel_list, ch);
+    return;
+}
+
 int ossl_quic_port_have_incoming(QUIC_PORT *port)
 {
     return ossl_list_incoming_ch_head(&port->incoming_channel_list) != NULL;


### PR DESCRIPTION
SSL_accept_connection sometimes return a quic ssl object although quic handshake is not yet complete.
