### PR TITLE
Add riscv64 runner

### DIFF
--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -213,7 +213,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: config
-      run: ./config enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-trace
+      run: ./config enable-fips enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-trace
     - name: config dump
       run: ./configdata.pm --dump
     - name: make

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -213,14 +213,16 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: config
-      run: ./config enable-fips enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-trace
+      run: ./config enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-trace
     - name: config dump
       run: ./configdata.pm --dump
     - name: make
-      run: make -j4
+      run: make -j8
     - name: get cpu info
       run: ./util/opensslwrap.sh version -c
     - name: make test
+      env:
+        OPENSSL_riscvcap: ZBA_ZBB_ZBC_ZBS_ZKT
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   freebsd-x86_64:

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -208,6 +208,21 @@ jobs:
     - name: make test
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
+  linux-riscv64:
+    runs-on: linux-riscv64
+    steps:
+    - uses: actions/checkout@v4
+    - name: config
+      run: ./config enable-fips enable-ec_nistp_64_gcc_128 enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-trace
+    - name: config dump
+      run: ./configdata.pm --dump
+    - name: make
+      run: make -j4
+    - name: get cpu info
+      run: ./util/opensslwrap.sh version -c
+    - name: make test
+      run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
+
   freebsd-x86_64:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
ISCAS (Institute of Software Chinese Academy of Sciences) provided riscv64 machines to run openssl tests against this architecture. This PR adds a new job to "OS Zoo" scheduled workflow.

~~Please backport it to all active branches.~~

[Test run](https://github.com/quarckster/openssl-fork/actions/runs/14216340315/job/39833851393)