### PR TITLE
ssl/ssl_lib.c: Avoid crash when SSL_CONNECTION is NULL

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4945,6 +4945,9 @@ int SSL_do_handshake(SSL *s)
         return ossl_quic_do_handshake(s);
 #endif
 
+    if (sc == NULL)
+        return -1;
+
     if (sc->handshake_func == NULL) {
         ERR_raise(ERR_LIB_SSL, SSL_R_CONNECTION_TYPE_NOT_SET);
         return -1;


### PR DESCRIPTION
Detection for sc == NULL is performed after sc is used. Add the check to the correct place.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
