### PR TITLE
Fix test failures on big endian ARMv9 target

### DIFF
--- a/crypto/chacha/asm/chacha-armv8-sve.pl
+++ b/crypto/chacha/asm/chacha-armv8-sve.pl
@@ -248,9 +248,6 @@ sub load_regs() {
 	my $next_offset = $offset + 1;
 $code.=<<___;
 	ld1w	{$reg.s},p0/z,[$inp,#$offset,MUL VL]
-#ifdef  __AARCH64EB__
-	revb    $reg.s,p0/m,$reg.s
-#endif
 ___
 	if (@_) {
 		&load_regs($next_offset, @_);
@@ -272,9 +269,6 @@ sub store_regs() {
 	my $reg = shift;
 	my $next_offset = $offset + 1;
 $code.=<<___;
-#ifdef  __AARCH64EB__
-	revb	$reg.s,p0/m,$reg.s
-#endif
 	st1w	{$reg.s},p0,[$outp,#$offset,MUL VL]
 ___
 	if (@_) {
@@ -480,13 +474,29 @@ sub SVE_TRANSFORMS() {
 $code.=<<___;
 #ifdef	__AARCH64EB__
 	rev	@sxx[0],@sxx[0]
+	revb	@mx[0].s,p0/m,@mx[0].s
+	revb	@mx[1].s,p0/m,@mx[1].s
 	rev	@sxx[2],@sxx[2]
+	revb	@mx[2].s,p0/m,@mx[2].s
+	revb	@mx[3].s,p0/m,@mx[3].s
 	rev	@sxx[4],@sxx[4]
+	revb	@mx[4].s,p0/m,@mx[4].s
+	revb	@mx[5].s,p0/m,@mx[5].s
 	rev	@sxx[6],@sxx[6]
+	revb	@mx[6].s,p0/m,@mx[6].s
+	revb	@mx[7].s,p0/m,@mx[7].s
 	rev	@sxx[8],@sxx[8]
+	revb	@mx[8].s,p0/m,@mx[8].s
+	revb	@mx[9].s,p0/m,@mx[9].s
 	rev	@sxx[10],@sxx[10]
+	revb	@mx[10].s,p0/m,@mx[10].s
+	revb	@mx[11].s,p0/m,@mx[11].s
 	rev	@sxx[12],@sxx[12]
+	revb	@mx[12].s,p0/m,@mx[12].s
+	revb	@mx[13].s,p0/m,@mx[13].s
 	rev	@sxx[14],@sxx[14]
+	revb	@mx[14].s,p0/m,@mx[14].s
+	revb	@mx[15].s,p0/m,@mx[15].s
 #endif
 	.if mixin == 1
 		add	@K[6],@K[6],#1

--- a/crypto/sm3/asm/sm3-armv8.pl
+++ b/crypto/sm3/asm/sm3-armv8.pl
@@ -153,13 +153,13 @@ $code.=<<___;
 
 .Loop:
 	// load input
-	ld1     {$s0.16b-$s3.16b}, [$pdata], #64
+	ld1     {$s0.4s-$s3.4s}, [$pdata], #64
 	sub     $num, $num, #1
 
 	mov     $bkstate1.16b, $state1.16b
 	mov     $bkstate2.16b, $state2.16b
 
-#ifndef __ARMEB__
+#ifndef __AARCH64EB__
 	rev32   $s0.16b, $s0.16b
 	rev32   $s1.16b, $s1.16b
 	rev32   $s2.16b, $s2.16b

--- a/crypto/sm4/asm/sm4-armv8.pl
+++ b/crypto/sm4/asm/sm4-armv8.pl
@@ -32,7 +32,7 @@ sub rev32() {
 my $dst = shift;
 my $src = shift;
 $code.=<<___;
-#ifndef __ARMEB__
+#ifndef __AARCH64EB__
 	rev32	$dst.16b,$src.16b
 #endif
 ___
@@ -404,7 +404,7 @@ ___
 	&enc_blk($ivec);
 	&rev32($ivec,$ivec);
 $code.=<<___;
-	st1	{$ivec.16b},[$out],#16
+	st1	{$ivec.4s},[$out],#16
 	b.ne	1b
 	b	3f
 .Ldec:
@@ -485,11 +485,11 @@ ___
 $code.=<<___;
 	eor	@dat[0].16b,@dat[0].16b,$ivec.16b
 	mov	$ivec.16b,@in[0].16b
-	st1	{@dat[0].16b},[$out],#16
+	st1	{@dat[0].4s},[$out],#16
 	b.ne	1b
 3:
 	// save back IV
-	st1	{$ivec.16b},[$ivp]
+	st1	{$ivec.4s},[$ivp]
 	ldp	d8,d9,[sp],#16
 	ret
 .size	${prefix}_cbc_encrypt,.-${prefix}_cbc_encrypt


### PR DESCRIPTION
This fixes a couple of big-endian issues in the
assembler code of chacha, SM3 and SM4.

Fixes #27197
Tested-by: @zeldin
