### PR TITLE
Disable stringop-overflow warnings on s390

### DIFF
--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -196,7 +196,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: config
-      run: ./config --strict-warnings enable-fips enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-trace
+      run: ./config --strict-warnings -Wno-stringop-overflow enable-fips enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-trace
     - name: config dump
       run: ./configdata.pm --dump
     - name: make


### PR DESCRIPTION
Recently ci on master has been failing:
https://github.com/openssl/openssl/actions/runs/14234051502/job/39919663876

Its occuring because the s390 gcc compiler is complaining about various functions attempting to write past the end of an array.

However, I can find no case in which we actually do so in this case.

The problem resolves when we either:
1) Disable the stringop-overflow warning
or
2) disable all loop unrolling optimizations with fno-loop-nest-optimize

Given that asan doesn't report any out of bounds errors on s390 when built with case (1), and case (2) can be a significant performance hit, coupled with the fact that gcc on any other platform avoids the same issue (s390 is stuck on gcc 12, instead of gcc 16 where the other platforms are), I think the right thing to do is just disable the warning here

