### PR TITLE
README: Remove client only restriction for QUIC.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Welcome to the OpenSSL Project
 ![Daily checks](https://github.com/openssl/openssl/actions/workflows/run-checker-daily.yml/badge.svg)
 
 OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit
-for the TLS (formerly SSL), DTLS and QUIC (currently client side only)
-protocols.
+for the TLS (formerly SSL), DTLS and QUIC protocols.
 
 The protocol implementations are based on a full-strength general purpose
 cryptographic library, which can also be used stand-alone. Also included is a
@@ -42,7 +41,7 @@ The OpenSSL toolkit includes:
 - **libssl**
   an implementation of all TLS protocol versions up to TLSv1.3 ([RFC 8446]),
   DTLS protocol versions up to DTLSv1.2 ([RFC 6347]) and
-  the QUIC (currently client side only) version 1 protocol ([RFC 9000]).
+  the QUIC version 1 protocol ([RFC 9000]).
 
 - **libcrypto**
   a full-strength general purpose cryptographic library. It constitutes the


### PR DESCRIPTION
The QUIC protocol is also supported on server side. Update the README file accordingly.