### PR TITLE
Re enable external gost tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -644,8 +644,8 @@ jobs:
       run: |
         cat /proc/cpuinfo
         ./util/opensslwrap.sh version -c
-#    - name: test external gost-engine
-#      run: make test TESTS="test_external_gost_engine"
+    - name: test external gost-engine
+      run: make test TESTS="test_external_gost_engine"
     - name: test external krb5
       run: make test TESTS="test_external_krb5"
     - name: test external tlsfuzzer


### PR DESCRIPTION
Now that libprov has the cmake fix we need for gh runners with cmake 4.0  (https://github.com/provider-corner/libprov/pull/6)

And the gost-engine sources have updated to the latest version of libprov (https://github.com/gost-engine/engine/pull/470)

This PR can now update our gost-engine submodule, and we can re-enable the gost-engine tests.


Plan is to commit this to master, and then backfit to release branches once the freeze is lifted