### PR TITLE
80-test_cms.t: Add test case for verification of multiple signatures

### DIFF
--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -53,7 +53,7 @@ my ($no_des, $no_dh, $no_dsa, $no_ec, $no_ec2m, $no_rc2, $no_zlib)
 
 $no_rc2 = 1 if disabled("legacy");
 
-plan tests => 30;
+plan tests => 31;
 
 ok(run(test(["pkcs7_test"])), "test pkcs7");
 
@@ -1462,4 +1462,58 @@ subtest "SLH-DSA tests for CMS" => sub {
                     "-CAfile", $smroot, "-content", $smcont])),
            "accept CMS verify with SLH-DSA-SHAKE-256s");
     }
+};
+
+subtest "sign and verify with multiple keys" => sub {
+    plan tests => 7;
+
+    my $smrsa2 = catfile($smdir, "smrsa2.pem");
+    my $sig1 = "sig1.cms";
+    my $out1 = "out1.txt";
+    my $sig2 = "sig2.cms";
+    my $out2 = "out2.txt";
+
+    ok(run(app(['openssl', 'cms',
+		@defaultprov,
+		'-sign', '-in', $smcont,
+                '-nodetach',
+                '-signer', $smrsa1,
+		'-out', $sig1, '-outform', 'DER',
+	       ])),
+       "sign with first key");
+    ok(run(app(['openssl', 'cms',
+		@defaultprov,
+		'-verify', '-in', $sig1, '-inform', 'DER',
+                '-CAfile', $smrsa1, '-partial_chain',
+		'-out', $out1,
+	       ])),
+       "verify single signature");
+    is(compare($smcont, $out1), 0, "compare original message with verified message");
+
+    ok(run(app(['openssl', 'cms',
+		@defaultprov,
+		'-resign', '-in', $sig1, '-inform', 'DER',
+                '-signer', $smrsa2,
+		'-out', $sig2, '-outform', 'DER',
+	       ])),
+       "resign with second key");
+
+    # because the smrsa2 signature cannot be verified, overall verification fails
+    ok(!run(app(['openssl', 'cms',
+		@defaultprov,
+		'-verify', '-in', $sig2, '-inform', 'DER',
+                '-CAfile', $smrsa1, '-partial_chain',
+		'-out', $out2,
+	       ])),
+       "try to verify two signatures with only rsa1");
+
+    # because both signatures can be verified, overall verification succeeds
+    ok(run(app(['openssl', 'cms',
+		@defaultprov,
+		'-verify', '-in', $sig2, '-inform', 'DER',
+                '-CAfile', $smroot,
+		'-out', $out2,
+	       ])),
+       "verify both signature signatures with root");
+    is(compare($smcont, $out2), 0, "compare original message with verified message");
 };


### PR DESCRIPTION
openssl cms -verify requires all signatures to pass verification, so adding a signature with -resign will cause overall verification to fail if the new signature cannot be verified.

As I intend to optionally allow this case (see #26382), this new test case ensures that the current behavior stays the default.

- [x] tests are added or updated
