### PR TITLE
Prevent CI jobs with secrets from running in forks

### DIFF
--- a/.github/workflows/build_quic_interop_container.yml
+++ b/.github/workflows/build_quic_interop_container.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   update_quay_container:
+    if: github.repository == 'openssl/openssl'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-docs-openssl-org.yml
+++ b/.github/workflows/deploy-docs-openssl-org.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   trigger:
+    if: github.repository == 'openssl/openssl'
     runs-on: ubuntu-latest
     steps:
       - name: "Trigger deployment workflow"

--- a/.github/workflows/static-analysis-on-prem.yml
+++ b/.github/workflows/static-analysis-on-prem.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   coverity-analysis:
+    if: github.repository == 'openssl/openssl'
     runs-on: ubuntu-latest
     container: quay.io/openssl-ci/coverity-analysis:2024.3.1
     steps:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   coverity:
+    if: github.repository == 'openssl/openssl'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Jobs that use secrets won't be run in forks, so there won't be periodic failures (with potential notifications).

close #27274 
