### PR TITLE
Remove DAYS argument

### DIFF
--- a/apps/CA.pl.in
+++ b/apps/CA.pl.in
@@ -143,7 +143,7 @@ if ($WHAT eq '-newcert' ) {
     print "Pre-cert is in $NEWCERT, private key is in $NEWKEY\n" if $RET == 0;
 } elsif ($WHAT =~ /^\-newreq(\-nodes)?$/ ) {
     # create a certificate request
-    $RET = run("$REQ -new $1 -keyout $NEWKEY -out $NEWREQ $DAYS $EXTRA{req}");
+    $RET = run("$REQ -new" . (defined $1 ? " $1" : "") . " -keyout $NEWKEY -out $NEWREQ $EXTRA{req}");
     print "Request is in $NEWREQ, private key is in $NEWKEY\n" if $RET == 0;
 } elsif ($WHAT eq '-newca' ) {
     # create the directory hierarchy


### PR DESCRIPTION
This commit removes DAYS from certificate requests to avoid the warning

'Ignoring -days without -x509; not generating a certificate'

This argument is not needed with the -new argument. Additionally makes sure $1 is handled when -nodes is not given. Preventing an uninitialized value error when the DAYS argument is removed.

Fixes #26595

CLA: trivial

@bog-the-frog
@bbbrumley 
