### PR TITLE
Fix build failure with nonstandard compiler configuration

### DIFF
--- a/crypto/asn1/tasn_enc.c
+++ b/crypto/asn1/tasn_enc.c
@@ -383,7 +383,13 @@ typedef struct {
     const ASN1_VALUE *field;
 } DER_ENC;
 
-static int __cdecl der_cmp(const void *a, const void *b)
+static int
+#ifdef __GNUC__
+  __attribute__((cdecl))
+#elif _MSC_VER
+  __cdecl
+#endif
+  der_cmp(const void *a, const void *b)
 {
     const DER_ENC *d1 = a, *d2 = b;
     int cmplen, i;

--- a/crypto/asn1/tasn_enc.c
+++ b/crypto/asn1/tasn_enc.c
@@ -383,7 +383,7 @@ typedef struct {
     const ASN1_VALUE *field;
 } DER_ENC;
 
-static int der_cmp(const void *a, const void *b)
+static int __cdecl der_cmp(const void *a, const void *b)
 {
     const DER_ENC *d1 = a, *d2 = b;
     int cmplen, i;


### PR DESCRIPTION
OpenSSL currently fails to build when the compiler is set to anything other than cdecl by default due to a calling convention mismatch.

CLA: trivial