### PR TITLE
rsa: set verify_message to 1 in rsa_sign only when message was digested

### DIFF
--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -518,8 +518,12 @@ A getter that returns 1 if a signature verification operation acted on
 a raw message, or 0 if it verified a predigested message.  A value of 0
 indicates likely non-approved usage of the FIPS provider.  This flag is
 set when any signature verification initialisation function is called.
-It is also set to 1 when any signing operation is performed to signify
-compliance.  See FIPS 140-3 IG 2.4.B for further information.
+For RSA signing operations it is also set to 1 when acting on a raw
+message, or 0 if acting on a predigested message. Approved usage can
+depend on the padding uses, which may be unknown, thus this indicator
+can be used to check if message was digested.
+It is also set to 1 when any non-RSA signing operation is performed to signify
+compliance. See FIPS 140-3 IG 2.4.B for further information.
 
 =item "key-check" (B<OSSL_SIGNATURE_PARAM_FIPS_KEY_CHECK>) <integer>
 

--- a/providers/implementations/signature/rsa_sig.c
+++ b/providers/implementations/signature/rsa_sig.c
@@ -145,8 +145,8 @@ typedef struct {
 #ifdef FIPS_MODULE
     /*
      * FIPS 140-3 IG 2.4.B mandates that verification based on a digest of a
-     * message is not permitted.  However, signing based on a digest is still
-     * permitted.
+     * message is not permitted.  However, signing based on a digest might be
+     * permitted, depending on vendor choices and padding.
      */
     int verify_message;
 #endif
@@ -661,7 +661,7 @@ static int rsa_sign_init(void *vprsactx, void *vrsa, const OSSL_PARAM params[])
 
 #ifdef FIPS_MODULE
     if (prsactx != NULL)
-        prsactx->verify_message = 1;
+        prsactx->verify_message = 0;
 #endif
 
     return rsa_signverify_init(prsactx, vrsa, rsa_set_ctx_params, params,
@@ -873,6 +873,9 @@ static int rsa_sign_message_final(void *vprsactx, unsigned char *sig,
         if (!EVP_DigestFinal_ex(prsactx->mdctx, digest, &dlen))
             return 0;
 
+#ifdef FIPS_MODULE
+        prsactx->verify_message = 1;
+#endif
         prsactx->flag_allow_update = 0;
         prsactx->flag_allow_oneshot = 0;
         prsactx->flag_allow_final = 0;


### PR DESCRIPTION
In rsa_sign_init choose to set verify_message indicator to 0, and only
raise it to 1, once a message has been digested by
rsa_sign_message_final and no further updates of message digest are
allowed.

This should correctly mirrror/raise verify-message indicator for
signing just like for RSA verification.

The motivation for this is that the only kind of RSA signature
generation without hashing that is approved is the one without any
padding. The same function in OpenSSL can do the operation and the
padding for both the no hashing case and also after hashing, making it
difficult to block a certain padding scheme in that function, as it
would also affect the hashing case. Effectively - unknown. This is why
it is better to have an accurate status for verify-message indicator,
for RSA signatures. Subsequently individual vendor can specify if that
is allowed or unallowed, and testing laboraties have easier APIs to
automate such testing and validation.

Note similar nuance does not exist for other signing algorithms.

This change has been implemented in a submitted module for FIPS 140-3
certification based of 3.4.0 codebase, upon request from a
certification laboratory.

W.r.t. testing - current behaviour of verify-message returning 1 upon
any signing is not tested. Testing this likely needs to be implemented
as a new test case in test/acvp_test.c. It will have to be carefully
version guarded, depending on if this change is accepted at all, and
if accepted into which major versions (3.5 or 3.6), as different fips
provider version combinations will start to have different behaviour.
