### PR TITLE
Updated the change log to include SSLv3 being disabled by default.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6618,6 +6618,11 @@ OpenSSL 1.1.0
 
    *Rob Percival <robpercival@google.com>*
 
+ * SSLv3 is by default disabled at build-time. Builds that are not 
+   configured with "enable-ssl3" will not support SSLv3.
+
+   *Kurt Roeckx*
+
 OpenSSL 1.0.2
 -------------
 


### PR DESCRIPTION
This change was implemented into version 1.1.0 and onward. The last version that had SSLv3 enabled was version 1.0.2h, which is why the addition was made where it is.

Fixes #8969 

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
