### PR TITLE
remove-UNUSED_VALUE_cms_pwri.c

### DIFF
--- a/crypto/cms/cms_pwri.c
+++ b/crypto/cms/cms_pwri.c
@@ -63,9 +63,6 @@ CMS_RecipientInfo *CMS_add0_recipient_password(CMS_ContentInfo *cms,
     if (wrap_nid <= 0)
         wrap_nid = NID_id_alg_PWRI_KEK;
 
-    if (pbe_nid <= 0)
-        pbe_nid = NID_id_pbkdf2;
-
     /* Get from enveloped data */
     if (kekciph == NULL)
         kekciph = ec->cipher;


### PR DESCRIPTION
Found by Linux Verification Center (linuxtesting.org) with SVACE.

In the cms_pwri.c file, in line 66, when entering the if (pbe_nid <= 0) branch, in line 67, the pbe_nid variable is assigned a new value NID_id_pbkdf2. However, the value NID_id_pbkdf2 is not used anywhere further. In this regard, this branch is proposed for deletion.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
