### PR TITLE
hkdf: allow salt to be reset to null

### DIFF
--- a/providers/implementations/kdfs/hkdf.c
+++ b/providers/implementations/kdfs/hkdf.c
@@ -307,13 +307,11 @@ static int hkdf_common_set_ctx_params(KDF_HKDF *ctx, const OSSL_PARAM params[])
     }
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_SALT)) != NULL) {
-        if (p->data_size != 0 && p->data != NULL) {
-            OPENSSL_free(ctx->salt);
-            ctx->salt = NULL;
-            if (!OSSL_PARAM_get_octet_string(p, (void **)&ctx->salt, 0,
-                                             &ctx->salt_len))
-                return 0;
-        }
+        OPENSSL_free(ctx->salt);
+        ctx->salt = NULL;
+        if (!OSSL_PARAM_get_octet_string(p, (void **)&ctx->salt, 0,
+                                         &ctx->salt_len))
+            return 0;
     }
 
     return 1;

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -3524,6 +3524,7 @@ static int test_empty_salt_info_HKDF(void)
     size_t outlen;
     int ret = 0;
     unsigned char salt[] = "";
+    unsigned char fake[] = "0123456789";
     unsigned char key[] = "012345678901234567890123456789";
     unsigned char info[] = "";
     const unsigned char expected[] = {
@@ -3540,6 +3541,8 @@ static int test_empty_salt_info_HKDF(void)
 
     if (!TEST_int_gt(EVP_PKEY_derive_init(pctx), 0)
             || !TEST_int_gt(EVP_PKEY_CTX_set_hkdf_md(pctx, EVP_sha256()), 0)
+            || !TEST_int_gt(EVP_PKEY_CTX_set1_hkdf_salt(pctx, fake,
+                                                        sizeof(fake) - 1), 0)
             || !TEST_int_gt(EVP_PKEY_CTX_set1_hkdf_salt(pctx, salt,
                                                         sizeof(salt) - 1), 0)
             || !TEST_int_gt(EVP_PKEY_CTX_set1_hkdf_key(pctx, key,


### PR DESCRIPTION
The fix in #24141 wasn't quite correct.  The test case just happened to work on a freshly initialised context.

- [ ] documentation is added or updated
- [x] tests are added or updated
