### PR TITLE
signature: add signature query functions

### DIFF
--- a/providers/implementations/signature/ml_dsa_sig.c
+++ b/providers/implementations/signature/ml_dsa_sig.c
@@ -330,9 +330,18 @@ static int ml_dsa_get_ctx_params(void *vctx, OSSL_PARAM *params)
 
 #define MAKE_SIGNATURE_FUNCTIONS(alg)                                          \
     static OSSL_FUNC_signature_newctx_fn ml_dsa_##alg##_newctx;                \
+    static OSSL_FUNC_signature_query_key_types_fn ml_dsa_##alg##_sigalg_query_key_types; \
     static void *ml_dsa_##alg##_newctx(void *provctx, const char *propq)       \
     {                                                                          \
         return ml_dsa_newctx(provctx, EVP_PKEY_ML_DSA_##alg, propq);           \
+    }                                                                          \
+    static const char **ml_dsa_##alg##_sigalg_query_key_types(void)            \
+    {                                                                          \
+        static const char *ml_dsa_##alg##_keytypes[] = {                       \
+            "ML-DSA-" # alg, NULL                                              \
+         };                                                                    \
+                                                                               \
+        return ml_dsa_##alg##_keytypes;                                        \
     }                                                                          \
     const OSSL_DISPATCH ossl_ml_dsa_##alg##_signature_functions[] = {          \
         { OSSL_FUNC_SIGNATURE_NEWCTX, (void (*)(void))ml_dsa_##alg##_newctx }, \
@@ -360,6 +369,8 @@ static int ml_dsa_get_ctx_params(void *vctx, OSSL_PARAM *params)
         { OSSL_FUNC_SIGNATURE_GETTABLE_CTX_PARAMS,                             \
           (void (*)(void))ml_dsa_gettable_ctx_params },                        \
         { OSSL_FUNC_SIGNATURE_DUPCTX, (void (*)(void))ml_dsa_dupctx },         \
+        { OSSL_FUNC_SIGNATURE_QUERY_KEY_TYPES,                                 \
+          (void (*)(void))ml_dsa_##alg##_sigalg_query_key_types },             \
         OSSL_DISPATCH_END                                                      \
     }
 

--- a/providers/implementations/signature/ml_dsa_sig.c
+++ b/providers/implementations/signature/ml_dsa_sig.c
@@ -339,7 +339,7 @@ static int ml_dsa_get_ctx_params(void *vctx, OSSL_PARAM *params)
     {                                                                          \
         static const char *ml_dsa_##alg##_keytypes[] = {                       \
             "ML-DSA-" # alg, NULL                                              \
-         };                                                                    \
+        };                                                                     \
                                                                                \
         return ml_dsa_##alg##_keytypes;                                        \
     }                                                                          \

--- a/providers/implementations/signature/slh_dsa_sig.c
+++ b/providers/implementations/signature/slh_dsa_sig.c
@@ -342,9 +342,16 @@ static int slh_dsa_get_ctx_params(void *vctx, OSSL_PARAM *params)
 
 #define MAKE_SIGNATURE_FUNCTIONS(alg, fn)                                      \
     static OSSL_FUNC_signature_newctx_fn slh_dsa_##fn##_newctx;                \
+    static OSSL_FUNC_signature_query_key_types_fn slh_dsa_##fn##_sigalg_query_key_types; \
     static void *slh_dsa_##fn##_newctx(void *provctx, const char *propq)       \
     {                                                                          \
         return slh_dsa_newctx(provctx, alg, propq);                            \
+    }                                                                          \
+    static const char **slh_dsa_##fn##_sigalg_query_key_types(void)            \
+    {                                                                          \
+        static const char *slh_dsa_##fn##_keytypes[] = { alg, NULL };          \
+                                                                               \
+        return slh_dsa_##fn##_keytypes;                                        \
     }                                                                          \
     const OSSL_DISPATCH ossl_slh_dsa_##fn##_signature_functions[] = {          \
         { OSSL_FUNC_SIGNATURE_NEWCTX, (void (*)(void))slh_dsa_##fn##_newctx }, \
@@ -371,6 +378,8 @@ static int slh_dsa_get_ctx_params(void *vctx, OSSL_PARAM *params)
           (void (*)(void))slh_dsa_get_ctx_params },                            \
         { OSSL_FUNC_SIGNATURE_GETTABLE_CTX_PARAMS,                             \
           (void (*)(void))slh_dsa_gettable_ctx_params },                       \
+        { OSSL_FUNC_SIGNATURE_QUERY_KEY_TYPES,                                 \
+          (void (*)(void))slh_dsa_##fn##_sigalg_query_key_types },             \
         OSSL_DISPATCH_END                                                      \
     }
 

--- a/providers/implementations/signature/sm2_sig.c
+++ b/providers/implementations/signature/sm2_sig.c
@@ -54,6 +54,7 @@ static OSSL_FUNC_signature_get_ctx_md_params_fn sm2sig_get_ctx_md_params;
 static OSSL_FUNC_signature_gettable_ctx_md_params_fn sm2sig_gettable_ctx_md_params;
 static OSSL_FUNC_signature_set_ctx_md_params_fn sm2sig_set_ctx_md_params;
 static OSSL_FUNC_signature_settable_ctx_md_params_fn sm2sig_settable_ctx_md_params;
+static OSSL_FUNC_signature_query_key_types_fn sm2_sigalg_query_key_types;
 
 /*
  * What's passed as an actual key is defined by the KEYMGMT interface.
@@ -547,6 +548,13 @@ static const OSSL_PARAM *sm2sig_settable_ctx_md_params(void *vpsm2ctx)
     return EVP_MD_settable_ctx_params(psm2ctx->md);
 }
 
+static const char **sm2_sigalg_query_key_types(void)
+{
+    static const char *sm2_keytypes[] = { "SM2", NULL };
+
+    return sm2_keytypes;
+}
+
 const OSSL_DISPATCH ossl_sm2_signature_functions[] = {
     { OSSL_FUNC_SIGNATURE_NEWCTX, (void (*)(void))sm2sig_newctx },
     { OSSL_FUNC_SIGNATURE_SIGN_INIT, (void (*)(void))sm2sig_signature_init },
@@ -581,5 +589,7 @@ const OSSL_DISPATCH ossl_sm2_signature_functions[] = {
       (void (*)(void))sm2sig_set_ctx_md_params },
     { OSSL_FUNC_SIGNATURE_SETTABLE_CTX_MD_PARAMS,
       (void (*)(void))sm2sig_settable_ctx_md_params },
+    { OSSL_FUNC_SIGNATURE_QUERY_KEY_TYPES,
+      (void (*)(void))sm2_sigalg_query_key_types },
     OSSL_DISPATCH_END
 };


### PR DESCRIPTION
This is instead of relying on the fall back code path.

