### PR TITLE
Implement i2d_PKCS8PrivateKey

### DIFF
--- a/doc/man3/d2i_PKCS8PrivateKey_bio.pod
+++ b/doc/man3/d2i_PKCS8PrivateKey_bio.pod
@@ -41,9 +41,12 @@ corresponding B<PEM> function as described in L<PEM_read_PrivateKey(3)>.
 
 These functions are currently the only way to store encrypted private keys using DER format.
 
-Currently all the functions use BIOs or FILE pointers, there are no functions which
-work directly on memory: this can be readily worked around by converting the buffers
-to memory BIOs, see L<BIO_s_mem(3)> for details.
+Currently all the functions use BIOs or FILE pointers, there are no functions
+which support password-protection and work directly on memory: this can be
+readily worked around by converting the buffers to memory BIOs, see
+L<BIO_s_mem(3)> for details.
+If password-protection is not required, the L<i2d_PKCS8PrivateKey(3)> function
+encodes a private key to an unencrypted DER B<PKCS#8> form.
 
 These functions make no assumption regarding the pass phrase received from the
 password callback.
@@ -59,8 +62,13 @@ and i2d_PKCS8PrivateKey_nid_fp() return 1 on success or 0 on error.
 
 =head1 SEE ALSO
 
+L<i2d_PKCS8PrivateKey(3)>,
 L<PEM_read_PrivateKey(3)>,
 L<passphrase-encoding(7)>
+
+=head1 HISTORY
+
+L<i2d_PKCS8PrivateKey(3)> was added in OpenSSL 3.6.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/d2i_PrivateKey.pod
+++ b/doc/man3/d2i_PrivateKey.pod
@@ -3,10 +3,10 @@
 =head1 NAME
 
 d2i_PrivateKey_ex, d2i_PrivateKey, d2i_PublicKey, d2i_KeyParams,
-d2i_AutoPrivateKey_ex,  d2i_AutoPrivateKey, i2d_PrivateKey, i2d_PublicKey,
-i2d_KeyParams, i2d_KeyParams_bio, d2i_PrivateKey_ex_bio, d2i_PrivateKey_bio,
-d2i_PrivateKey_ex_fp, d2i_PrivateKey_fp, d2i_KeyParams_bio, i2d_PrivateKey_bio,
-i2d_PrivateKey_fp
+d2i_AutoPrivateKey_ex,  d2i_AutoPrivateKey, i2d_PrivateKey,
+i2d_PKCS8PrivateKey, i2d_PublicKey, i2d_KeyParams, i2d_KeyParams_bio,
+d2i_PrivateKey_ex_bio, d2i_PrivateKey_bio, d2i_PrivateKey_ex_fp,
+d2i_PrivateKey_fp, d2i_KeyParams_bio, i2d_PrivateKey_bio, i2d_PrivateKey_fp
 - decode and encode functions for reading and saving EVP_PKEY structures
 
 =head1 SYNOPSIS
@@ -29,6 +29,7 @@ i2d_PrivateKey_fp
                               long length);
 
  int i2d_PrivateKey(const EVP_PKEY *a, unsigned char **pp);
+ int i2d_PKCS8PrivateKey(const EVP_PKEY *a, unsigned char **pp);
  int i2d_PublicKey(const EVP_PKEY *a, unsigned char **pp);
  int i2d_KeyParams(const EVP_PKEY *a, unsigned char **pp);
  int i2d_KeyParams_bio(BIO *bp, const EVP_PKEY *pkey);
@@ -77,6 +78,8 @@ to automatically detect the private key format.
 
 i2d_PrivateKey() encodes I<a>. It uses a key specific format or, if none is
 defined for that key type, PKCS#8 unencrypted PrivateKeyInfo format.
+i2d_PKCS8PrivateKey() does the same using only the PKCS#8 unencrypted
+PrivateKeyInfo format.
 i2d_PublicKey() does the same for public keys.
 i2d_KeyParams() does the same for key parameters.
 These functions are similar to the d2i_X509() functions; see L<d2i_X509(3)>.
@@ -106,9 +109,9 @@ d2i_PrivateKey_ex_fp(), d2i_PrivateKey_fp(), d2i_PublicKey(), d2i_KeyParams()
 and d2i_KeyParams_bio() functions return a valid B<EVP_PKEY> structure or NULL if
 an error occurs. The error code can be obtained by calling L<ERR_get_error(3)>.
 
-i2d_PrivateKey(), i2d_PublicKey() and i2d_KeyParams() return the number of
-bytes successfully encoded or a negative value if an error occurs. The error
-code can be obtained by calling L<ERR_get_error(3)>.
+i2d_PrivateKey(), i2d_PKCS8PrivateKey(), i2d_PublicKey() and i2d_KeyParams()
+return the number of bytes successfully encoded or a negative value if an error
+occurs. The error code can be obtained by calling L<ERR_get_error(3)>.
 
 i2d_PrivateKey_bio(), i2d_PrivateKey_fp() and i2d_KeyParams_bio() return 1 if
 successfully encoded or zero if an error occurs.
@@ -122,6 +125,8 @@ L<d2i_PKCS8PrivateKey_bio(3)>
 
 d2i_PrivateKey_ex(), d2i_PrivateKey_ex_bio(), d2i_PrivateKey_ex_fp(), and
 d2i_AutoPrivateKey_ex() were added in OpenSSL 3.0.
+
+i2d_PKCS8PrivateKey() was added in OpenSSL 3.6.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1457,6 +1457,7 @@ EVP_PKEY *d2i_AutoPrivateKey_ex(EVP_PKEY **a, const unsigned char **pp,
 EVP_PKEY *d2i_AutoPrivateKey(EVP_PKEY **a, const unsigned char **pp,
                              long length);
 int i2d_PrivateKey(const EVP_PKEY *a, unsigned char **pp);
+int i2d_PKCS8PrivateKey(const EVP_PKEY *a, unsigned char **pp);
 
 int i2d_KeyParams(const EVP_PKEY *a, unsigned char **pp);
 EVP_PKEY *d2i_KeyParams(int type, EVP_PKEY **a, const unsigned char **pp,

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5925,3 +5925,4 @@ OSSL_AA_DIST_POINT_new                  ?	3_5_0	EXIST::FUNCTION:
 OSSL_AA_DIST_POINT_it                   ?	3_5_0	EXIST::FUNCTION:
 PEM_ASN1_write_bio_ctx                  ?	3_5_0	EXIST::FUNCTION:
 OPENSSL_sk_set_thunks                   ?	3_6_0	EXIST::FUNCTION:
+i2d_PKCS8PrivateKey                     ?	3_6_0	EXIST::FUNCTION:


### PR DESCRIPTION
Added `i2d_PKCS8PrivateKey(3)` API to complement `i2d_PrivateKey(3)`, the former always outputs PKCS#8.

Extended endecoder_test.c to check that `i2d_PKCS8PrivateKey()` produces the expected PKCS#8 output.

- [x] documentation is added or updated
- [x] tests are added or updated
