### PR TITLE
Bug:Fix duplicate cipher definition for 0xC102 in ssl/t1_trce.c #27303

### DIFF
--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -452,7 +452,6 @@ static const ssl_trace_tbl ssl_ciphers_tbl[] = {
     {0xC0B5, "TLS_SHA384_SHA384"},
     {0xC100, "GOST2012-KUZNYECHIK-KUZNYECHIKOMAC"},
     {0xC101, "GOST2012-MAGMA-MAGMAOMAC"},
-    {0xC102, "GOST2012-GOST8912-IANA"},
 };
 
 /* Compression methods */


### PR DESCRIPTION
Fix duplicate cipher definition in ssl/t1_trce.c. This commit removes the duplicate definition of cipher 0xC102 in ssl/t1_trce.c, as reported in issue #27303. The first definition (IANA-GOST2012-GOST8912-GOST8912) is kept as the canonical one.

Fixes  #27303