### PR TITLE
Point to new docs location

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2069,7 +2069,7 @@ OpenSSL 0.9.x
 [CVE-2006-2940]: https://www.openssl.org/news/vulnerabilities.html#CVE-2006-2940
 [CVE-2006-2937]: https://www.openssl.org/news/vulnerabilities.html#CVE-2006-2937
 [CVE-2005-2969]: https://www.openssl.org/news/vulnerabilities.html#CVE-2005-2969
-[OpenSSL Guide]: https://www.openssl.org/docs/manmaster/man7/ossl-guide-introduction.html
+[OpenSSL Guide]: https://docs.openssl.org/master/man7/ossl-guide-introduction
 [CHANGES.md]: ./CHANGES.md
 [README-QUIC.md]: ./README-QUIC.md
 [issue tracker]: https://github.com/openssl/openssl/issues

--- a/README-FIPS.md
+++ b/README-FIPS.md
@@ -168,7 +168,7 @@ Using the FIPS Module in applications
 Documentation about using the FIPS module is available on the [fips_module(7)]
 manual page.
 
- [fips_module(7)]: https://www.openssl.org/docs/manmaster/man7/fips_module.html
+ [fips_module(7)]: https://docs.openssl.org/master/man7/fips_module
 
 Entropy Source
 ==============

--- a/README-PROVIDERS.md
+++ b/README-PROVIDERS.md
@@ -20,7 +20,7 @@ distribute their own providers which can be added to OpenSSL dynamically.
 Documentation about writing providers is available on the [provider(7)]
 manual page.
 
- [provider(7)]: https://www.openssl.org/docs/manmaster/man7/provider.html
+ [provider(7)]: https://docs.openssl.org/master/man7/provider
 
 The Default Provider
 --------------------
@@ -88,7 +88,7 @@ Providers to be loaded can be specified in the OpenSSL config file.
 See the [config(5)] manual page for information about how to configure
 providers via the config file, and how to automatically activate them.
 
- [config(5)]: https://www.openssl.org/docs/manmaster/man5/config.html
+ [config(5)]: https://docs.openssl.org/master/man5/config
 
 The following is a minimal config file example to load and activate both
 the legacy and the default provider in the default library context.

--- a/README-QUIC.md
+++ b/README-QUIC.md
@@ -98,11 +98,11 @@ use this dedicated server example instead.
 For more information about implementing QUIC servers with OpenSSL, refer to the
 [OpenSSL Guide] and the [openssl-quic(7) manual page].
 
-[openssl-quic(7) manual page]: https://www.openssl.org/docs/manmaster/man7/openssl-quic.html
-[OpenSSL Guide]: https://www.openssl.org/docs/manmaster/man7/ossl-guide-introduction.html
+[openssl-quic(7) manual page]: https://docs.openssl.org/master/man7/openssl-quic
+[OpenSSL Guide]: https://docs.openssl.org/master/man7/ossl-guide-introduction
 [DDD]: https://github.com/openssl/openssl/tree/master/doc/designs/ddd
 [found in the source tree under `doc/designs/ddd`]: ./doc/designs/ddd/
 [demo found in `demos/http3`]: ./demos/http3/
-[QUIC Introduction]: https://www.openssl.org/docs/manmaster/man7/ossl-guide-quic-introduction.html
+[QUIC Introduction]: https://docs.openssl.org/master/man7/ossl-guide-quic-introduction
 [RFC 9114]: https://tools.ietf.org/html/rfc9114
 [ALPN ids]: https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids

--- a/README.md
+++ b/README.md
@@ -149,10 +149,11 @@ Manual Pages
 The manual pages for the master branch and all current stable releases are
 available online.
 
-- [OpenSSL master](https://www.openssl.org/docs/manmaster)
-- [OpenSSL 3.0](https://www.openssl.org/docs/man3.0)
-- [OpenSSL 3.1](https://www.openssl.org/docs/man3.1)
-- [OpenSSL 3.2](https://www.openssl.org/docs/man3.2)
+- [OpenSSL master](https://docs.openssl.org/master/)
+- [OpenSSL 3.5](https://docs.openssl.org/3.5/)
+- [OpenSSL 3.4](https://docs.openssl.org/3.4/)
+- [OpenSSL 3.3](https://docs.openssl.org/3.3/)
+- [OpenSSL 3.2](https://docs.openssl.org/3.2/)
 
 Demos
 -----
@@ -217,7 +218,7 @@ All rights reserved.
     "OpenSSL Wiki"
 
 [ossl-guide-migration(7ossl)]:
-    <https://www.openssl.org/docs/manmaster/man7/ossl-guide-migration.html>
+    <https://docs.openssl.org/master/man7/ossl-guide-migration>
     "OpenSSL Migration Guide"
 
 [RFC 8446]:
@@ -234,7 +235,7 @@ All rights reserved.
     "List of third party OpenSSL binaries"
 
 [OpenSSL Guide]:
-    <https://www.openssl.org/docs/manmaster/man7/ossl-guide-introduction.html>
+    <https://docs.openssl.org/master/man7/ossl-guide-introduction>
     "An introduction to OpenSSL"
 
 <!-- Logos and Badges -->

--- a/demos/guide/README.md
+++ b/demos/guide/README.md
@@ -86,5 +86,5 @@ most easily be seen in action in our quic interop container, buildable from
 
 <!-- Links  -->
 
-[guide]: https://www.openssl.org/docs/manmaster/man7/ossl-guide-introduction.html
-[TLS Introduction]: https://www.openssl.org/docs/manmaster/man7/ossl-guide-tls-introduction.html
+[guide]: https://docs.openssl.org/master/man7/ossl-guide-introduction
+[TLS Introduction]: https://docs.openssl.org/master/man7/ossl-guide-tls-introduction

--- a/demos/sslecho/A-SSL-Docs.txt
+++ b/demos/sslecho/A-SSL-Docs.txt
@@ -1,12 +1,12 @@
 Useful Links:
 
-OpenSSL API Documentation: https://www.openssl.org/docs
+OpenSSL API Documentation: https://docs.openssl.org/master
 
 Github: https://github.com/openssl/openssl
 
-OpenSSL Wiki: https://github.com/openssl/openssl/wiki
+OpenSSL Wiki: https://wiki.openssl.org/index.php/Main_Page
 
-Original Simple Server: https://github.com/openssl/openssl/wiki/Simple_TLS_Server
+Original Simple Server: https://wiki.openssl.org/index.php/Simple_TLS_Server
 
 ---------------------------------------------------------------
 

--- a/dev/release-aux/openssl-announce-pre-release.tmpl
+++ b/dev/release-aux/openssl-announce-pre-release.tmpl
@@ -15,7 +15,7 @@
    Specific notes on upgrading to OpenSSL $series from previous versions are
    available in the OpenSSL Migration Guide, here:
 
-        https://www.openssl.org/docs/manmaster/man7/ossl-guide-migration.html
+        https://docs.openssl.org/master/man7/ossl-guide-migration
 
    The $label release is available for download via HTTPS and FTP from the
    following master locations (you can find the various FTP mirrors under

--- a/dev/release-aux/openssl-announce-release.tmpl
+++ b/dev/release-aux/openssl-announce-release.tmpl
@@ -14,7 +14,7 @@
    Specific notes on upgrading to OpenSSL $series from previous versions are
    available in the OpenSSL Migration Guide, here:
 
-        https://www.openssl.org/docs/man$series/man7/ossl-guide-migration.html
+        https://docs.openssl.org/$series/man7/ossl-guide-migration.html
 
    OpenSSL $release is available for download via HTTPS and FTP from the
    following master locations (you can find the various FTP mirrors under

--- a/doc/HOWTO/certificates.txt
+++ b/doc/HOWTO/certificates.txt
@@ -11,12 +11,12 @@ Your role can be one or several of:
   - Certificate authority
 
 This file is for users who wish to get a certificate of their own.
-Certificate authorities should read https://www.openssl.org/docs/apps/ca.html.
+Certificate authorities should read https://docs.openssl.org/master/man1/openssl-ca.
 
 In all the cases shown below, the standard configuration file, as
 compiled into openssl, will be used.  You may find it in /etc/,
 /usr/local/ssl/ or somewhere else.  By default the file is named
-openssl.cnf and is described at https://www.openssl.org/docs/apps/config.html.
+openssl.cnf and is described at https://docs.openssl.org/master/man5/config.
 You can specify a different configuration file using the
 '-config {file}' argument with the commands shown below.
 
@@ -35,7 +35,7 @@ you want an RSA private key, or if you want a DSA private key:
 
 The private keys created by these commands are not passphrase protected;
 it might or might not be the desirable thing.  Further information on how to
-create private keys can be found at https://www.openssl.org/docs/HOWTO/keys.txt.
+create private keys can be found at https://github.com/openssl/openssl/blob/master/doc/HOWTO/keys.txt.
 The rest of this text assumes you have a private key in the file privkey.pem.
 
 
@@ -77,7 +77,7 @@ with a certificate authority, or if you just want to create a test
 certificate for yourself.  This is similar to creating a certificate
 request, but creates a certificate instead of a certificate request.
 This is NOT the recommended way to create a CA certificate, see
-https://www.openssl.org/docs/apps/ca.html.
+https://docs.openssl.org/master/man1/openssl-ca.
 
   openssl req -new -x509 -key privkey.pem -out cacert.pem -days 1095
 

--- a/doc/designs/evp-cipher-pipeline.md
+++ b/doc/designs/evp-cipher-pipeline.md
@@ -15,7 +15,7 @@ chunks of data in one cipher update call, thereby allowing the provided
 implementation to take advantage of parallel computing. This is very beneficial
 for hardware accelerators as pipeline amortizes the latency over multiple
 chunks. Our libssl makes use of pipeline as discussed in
-[here](https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_max_pipelines.html).
+[here](https://docs.openssl.org/master/man3/SSL_CTX_set_max_pipelines).
 
 Pipelining with ENGINE
 -----------------------

--- a/doc/designs/quic-design/quic-api.md
+++ b/doc/designs/quic-design/quic-api.md
@@ -1214,7 +1214,7 @@ Options:
 #### MTU Signalling
 
 **See also:**
-[BIO_s_dgram_pair(3)](https://www.openssl.org/docs/manmaster/man3/BIO_s_dgram_pair.html)
+[BIO_s_dgram_pair(3)](https://docs.openssl.org/master/man3/BIO_s_dgram_pair)
 
 `BIO_dgram_get_mtu` (`BIO_CTRL_DGRAM_GET_MTU`) and `BIO_dgram_set_mtu`
 (`BIO_CTRL_DGRAM_SET_MTU`) already exist for `BIO_s_dgram` and are implemented
@@ -1229,7 +1229,7 @@ from the OS using `BIO_CTRL_DGRAM_QUERY_MTU`.
 #### `BIO_sendmmsg` and `BIO_recvmmsg`
 
 **See also:**
-[BIO_sendmmsg(3)](https://www.openssl.org/docs/manmaster/man3/BIO_sendmmsg.html)
+[BIO_sendmmsg(3)](https://docs.openssl.org/master/man3/BIO_sendmmsg)
 
 The BIO interface features a new high-performance API for the execution of
 multiple read or write operations in a single system call, on supported OSes. On
@@ -1265,7 +1265,7 @@ corresponding `BIO_meth` getter/setter functions.
 #### Truncation Mode
 
 **See also:**
-[BIO_s_dgram_pair(3)](https://www.openssl.org/docs/manmaster/man3/BIO_s_dgram_pair.html)
+[BIO_s_dgram_pair(3)](https://docs.openssl.org/master/man3/BIO_s_dgram_pair)
 
 The controls `BIO_dgram_set_no_trunc` (`BIO_CTRL_DGRAM_SET_NO_TRUNC`) and
 `BIO_dgram_get_no_trunc` (`BIO_CTRL_DGRAM_GET_NO_TRUNC`) are introduced. This is
@@ -1278,7 +1278,7 @@ For compatibility, the default behaviour is off.
 #### Capability Negotiation
 
 **See also:**
-[BIO_s_dgram_pair(3)](https://www.openssl.org/docs/manmaster/man3/BIO_s_dgram_pair.html)
+[BIO_s_dgram_pair(3)](https://docs.openssl.org/master/man3/BIO_s_dgram_pair)
 
 Where a `BIO_s_dgram_pair` is used, there is the potential for such a memory BIO
 to be used by existing application code which is being adapted for use with
@@ -1314,7 +1314,7 @@ The usage is as follows:
 #### Local Address Support
 
 **See also:**
-[BIO_s_dgram_pair(3)](https://www.openssl.org/docs/manmaster/man3/BIO_s_dgram_pair.html)
+[BIO_s_dgram_pair(3)](https://docs.openssl.org/master/man3/BIO_s_dgram_pair)
 
 Support for local addressing (the reception of destination addresses for
 incoming packets, and the specification of source addresses for outgoing
@@ -1349,7 +1349,7 @@ enabled).
 #### `BIO_s_dgram_pair`
 
 **See also:**
-[BIO_s_dgram_pair(3)](https://www.openssl.org/docs/manmaster/man3/BIO_s_dgram_pair.html)
+[BIO_s_dgram_pair(3)](https://docs.openssl.org/master/man3/BIO_s_dgram_pair)
 
 A new BIO implementation, `BIO_s_dgram_pair`, is provided. This is similar to
 the existing BIO pair but provides datagram semantics. It provides full support
@@ -1403,7 +1403,7 @@ local addressing.
 
 A new predicate function `BIO_err_is_non_fatal` is defined which determines if
 an error code represents a non-fatal or transient error. For details, see
-[BIO_sendmmsg(3)](https://www.openssl.org/docs/manmaster/man3/BIO_sendmmsg.html).
+[BIO_sendmmsg(3)](https://docs.openssl.org/master/man3/BIO_sendmmsg).
 
 Q & A
 -----


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

The OpenSSL documentation URLs have changed. Some old URLs automatically redirect, but others don't. 

Also, I removed 3.0 and 3.1 documentation links from the README and added 3.3, 3.4 and 3.5.  (Not sure how useful the non-master links are since it's easy enough to switch on the docs page.)

I made liberal use of this Perl one-liner:

```
perl -pi.bak -e 's|https://www.openssl.org/docs/manmaster/([^ ]+).html|https://docs.openssl.org/master/\1|g'
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated