### PR TITLE
Fix memory leak in x509_pubkey_ex_d2i_ex()

### DIFF
--- a/crypto/asn1/tasn_dec.c
+++ b/crypto/asn1/tasn_dec.c
@@ -14,6 +14,7 @@
 #include <openssl/objects.h>
 #include <openssl/buffer.h>
 #include <openssl/err.h>
+#include "crypto/asn1.h"
 #include "internal/numbers.h"
 #include "asn1_local.h"
 
@@ -24,12 +25,6 @@
  * recursive invocations of asn1_item_embed_d2i().
  */
 #define ASN1_MAX_CONSTRUCTED_NEST 30
-
-static int asn1_item_embed_d2i(ASN1_VALUE **pval, const unsigned char **in,
-                               long len, const ASN1_ITEM *it,
-                               int tag, int aclass, char opt, ASN1_TLC *ctx,
-                               int depth, OSSL_LIB_CTX *libctx,
-                               const char *propq);
 
 static int asn1_check_eoc(const unsigned char **in, long len);
 static int asn1_find_end(const unsigned char **in, long len, char inf);
@@ -159,11 +154,11 @@ ASN1_VALUE *ASN1_item_d2i(ASN1_VALUE **pval,
  * tag mismatch return -1 to handle OPTIONAL
  */
 
-static int asn1_item_embed_d2i(ASN1_VALUE **pval, const unsigned char **in,
-                               long len, const ASN1_ITEM *it,
-                               int tag, int aclass, char opt, ASN1_TLC *ctx,
-                               int depth, OSSL_LIB_CTX *libctx,
-                               const char *propq)
+int asn1_item_embed_d2i(ASN1_VALUE **pval, const unsigned char **in,
+                        long len, const ASN1_ITEM *it,
+                        int tag, int aclass, char opt, ASN1_TLC *ctx,
+                        int depth, OSSL_LIB_CTX *libctx,
+                        const char *propq)
 {
     const ASN1_TEMPLATE *tt, *errtt = NULL;
     const ASN1_EXTERN_FUNCS *ef;

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -148,10 +148,13 @@ static int x509_pubkey_ex_d2i_ex(ASN1_VALUE **pval,
     }
 
     /* This ensures that |*in| advances properly no matter what */
-    if ((ret = ASN1_item_ex_d2i(pval, in, len,
-                                ASN1_ITEM_rptr(X509_PUBKEY_INTERNAL),
-                                tag, aclass, opt, ctx)) <= 0)
+    if ((ret = asn1_item_embed_d2i(pval, in, len,
+                                   ASN1_ITEM_rptr(X509_PUBKEY_INTERNAL),
+                                   tag, aclass, opt, ctx, 0,
+                                   NULL, NULL)) <= 0) {
+        x509_pubkey_ex_free(pval, it);
         return ret;
+    }
 
     publen = *in - in_saved;
     if (!ossl_assert(publen > 0)) {

--- a/include/crypto/asn1.h
+++ b/include/crypto/asn1.h
@@ -149,4 +149,9 @@ X509_ALGOR *ossl_X509_ALGOR_from_nid(int nid, int ptype, void *pval);
 
 void ossl_asn1_string_set_bits_left(ASN1_STRING *str, unsigned int num);
 
+int asn1_item_embed_d2i(ASN1_VALUE **pval, const unsigned char **in,
+                        long len, const ASN1_ITEM *it, int tag, int aclass,
+                        char opt, ASN1_TLC *ctx, int depth,
+                        OSSL_LIB_CTX *libctx, const char *propq);
+
 #endif /* ndef OSSL_CRYPTO_ASN1_H */


### PR DESCRIPTION
Memory leak was detected at:
```
=================================================================
==2122093==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 13 byte(s) in 1 object(s) allocated from:
    #0 0x4fce8d in malloc (/workspaces/openssl_fuzzing/build/tests+0x4fce8d)
    #1 0x545f2e in CRYPTO_malloc /workspaces/openssl-master/crypto/mem.c:211:11
    #2 0x548148 in CRYPTO_strdup /workspaces/openssl-master/crypto/o_str.c:28:11
    #3 0x56efdf in x509_pubkey_set0_libctx /workspaces/openssl-master/crypto/x509/x_pubkey.c:55:24
    #4 0x5711b1 in x509_pubkey_ex_new_ex /workspaces/openssl-master/crypto/x509/x_pubkey.c:119:13
    #5 0x5324ee in asn1_item_embed_new /workspaces/openssl-master/crypto/asn1/tasn_new.c:80:22
    #6 0x532b12 in asn1_template_new /workspaces/openssl-master/crypto/asn1/tasn_new.c:242:11
    #7 0x532850 in asn1_item_embed_new /workspaces/openssl-master/crypto/asn1/tasn_new.c:151:18
    #8 0x532b12 in asn1_template_new /workspaces/openssl-master/crypto/asn1/tasn_new.c:242:11
    #9 0x532850 in asn1_item_embed_new /workspaces/openssl-master/crypto/asn1/tasn_new.c:151:18
    #10 0x5329c0 in ossl_asn1_item_ex_new_intern /workspaces/openssl-master/crypto/asn1/tasn_new.c:52:12
    #11 0x52f3b6 in asn1_item_embed_d2i /workspaces/openssl-master/crypto/asn1/tasn_dec.c:366:21
    #12 0x530bf2 in asn1_template_noexp_d2i /workspaces/openssl-master/crypto/asn1/tasn_dec.c:651:17
    #13 0x52fd64 in asn1_template_ex_d2i /workspaces/openssl-master/crypto/asn1/tasn_dec.c:558:16
    #14 0x52f6ae in asn1_item_embed_d2i /workspaces/openssl-master/crypto/asn1/tasn_dec.c:422:19
    #15 0x530f40 in asn1_template_noexp_d2i /workspaces/openssl-master/crypto/asn1/tasn_dec.c:682:15
    #16 0x52fc13 in asn1_template_ex_d2i /workspaces/openssl-master/crypto/asn1/tasn_dec.c:534:15
    #17 0x52f6ae in asn1_item_embed_d2i /workspaces/openssl-master/crypto/asn1/tasn_dec.c:422:19
    #18 0x52e7a8 in asn1_item_ex_d2i_intern /workspaces/openssl-master/crypto/asn1/tasn_dec.c:118:10
    #19 0x52e871 in ASN1_item_d2i_ex /workspaces/openssl-master/crypto/asn1/tasn_dec.c:144:9
    #20 0x52d2ce in ASN1_item_d2i_bio_ex /workspaces/openssl-master/crypto/asn1/a_d2i_fp.c:73:11
```

If the call to `ASN1_item_ex_d2i()` from `x509_pubkey_ex_d2i_ex()` fails
`*pval` is freed by `asn1_item_ex_d2i_intern()->ASN1_item_ex_free()->ossl_asn1_item_embed_free()`
inside the `ASN1_item_ex_d2i()` function without freeing the string buffer `X509_PUBKEY::propq`
that was previously allocated in `x509_pubkey_ex_new_ex()` and we lose the pointer to this buffer.

To prevent memory leaks in case of an error, save this pointer in a temporary variable and free it if `ASN1_item_ex_d2i()` fails.

Reproducer for this issue:
```cpp
#include <openssl/asn1t.h>
#include <openssl/x509.h>
#include <openssl/err.h>

const char *invalid_data = 
"MIIDmQYJKoZIhvcNAQcCoIIDijCCA4YCAQExCTAHBgUrDgMCGjAtBgkqhj7f9w0BBwGgIAQeDQpU\n" \
"aGlzIGlzIHNvbWUgc2FtcGxlIGNvbnRlbnQuoIIC4DCCAtwwggKboAMCAQICAgDIMAkGByqGSM44\n" \
"BAMwEjEQMA4GA1UEAxMHQ2FybERTUzAeFw05OTA4MTcwMTEwNDlaFw0zOTEyMzEyMzU5NTlaMBMx\n" \
"ETAPBgNVBAMTCEFsaWNlRFNTMIIBtjCCASsGByqGSM44BAEwggEeAoGBAIGNze2D6gqeOT7CSCij\n" \
"5EeT3Q7XqA7sU8WrhAhP/5Thc0h+DNbzREjR/p+vpKGJL+HZMMg23j+bv7dM3F9piuR10DcMk8WrhAhP/5Thc0h+DNbzREjR/p+vpKGJL+HZMMg23j+bv7dM3F9piuR10DcMkQiV\n" \
"m96nXvn89J8v3UOoi1TxP7AHCEdNXYjDw7Wz41UIddU5dhDEeL3/nbCElzfy5FEbteQJllzzflvb\n" \
"AhUA4kemGkVmuBPG2o+4NyErYov3k80CgYAmONAUiTKqOfs+bdlLWWQiV\n" \
"m96nXvn89J8v3UOoi1TxP7AHCEdNXYjDw7Wz41UIddU5dhDEeL3/nbCElzfy5FEbteQJllzzflvb\n" \
"AhUA4kemGkVmuBPG2o+4NyErYov3k80CgYAmONAUiTKqOfs+bdlLWWpMdiM5BAI1XPLLGjDDHlBd\n" \
"3ZtZ4s2qBT1YwHuiNrhuB699ikIlp/R1z0oIXks+kPht6pzJIYo7dhTpzi5aowfNI4W4LzABfG1J\n" \
"iRGJNkS9+MiVSlNWteL5c+waYTYfEX/Cve3RUP+YdMLRgUpgObo2OQOBhAACgYBc47ladRSWC6l6\n" \
"3eM/qeysXty9txMRNKYWiSgRI9k0hmd1dRMSPUNbb+VRv/qJ8qIbPiR9PQeNW2PIu0WloErjhdbO\n" \
"BoA/6CN+GvIkq1MauCcNHu8Iv2YUgFxirGX6FYvxuATU0pY39mFHssQyhPB+QUD9RqdjTjPypeL0\n" \
"8oPluKOBgTB/MAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgbAMB8GA1UdIwQYMBaAFHBEPoIu\n" \
"b4feStN14z0gvEMrk/EfMB0GA1UdDgQWBBS+bKGz48H37UNwpM4TAeL945f+zTAfBgNVHREEGDAW\n" \
"gRRBbGljZURTU0BleGFtcGxlLmNvbTAJBgcqhkjOOAQDAzAAMC0CFFUMpBkfQiuJcSIzjYNqtT1n\n" \
"a79FAhUAn2FTUlQLXLLd2ud2HYIQUltDXr0xYzBhAgEBMBgwEjEQMA4GA1UEAxMHQ2FybERTUwIC\n" \
"AMgwBwYFKw4DAhowCQYHKozAZEjgIwQuMCwCFD1cSW6LIUFzeXle3YI5SKSBer/sAhQmCq7s/CTF\n" \
"HOEjgASeUjbMpx5g6A==";

int main(void) {
    BIO *bio, *tmp;
    const ASN1_ITEM *it;
    ASN1_VALUE **x = NULL;
    OSSL_LIB_CTX *libctx = NULL;
    const char *propq = "query string";
    
    BIO *b64;
    ASN1_VALUE *val;

    bio = BIO_new_mem_buf((void*)invalid_data, strlen(invalid_data));

    b64 = BIO_new(BIO_f_base64());
    tmp = BIO_push(b64, bio);
    val = ASN1_item_d2i_bio_ex(ASN1_ITEM_rptr(PKCS7), tmp, x, libctx, propq);
    if (!val)
        ERR_raise(ERR_LIB_ASN1, ASN1_R_DECODE_ERROR);

    (void)BIO_flush(tmp);
    BIO_pop(tmp);

    BIO_free(b64);
    BIO_free(bio);
    PKCS7_free((PKCS7 *)val);
    return 0;
}
```