### PR TITLE
re-enable gost-engine external tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -644,8 +644,8 @@ jobs:
       run: |
         cat /proc/cpuinfo
         ./util/opensslwrap.sh version -c
-#    - name: test external gost-engine
-#      run: make test TESTS="test_external_gost_engine"
+    - name: test external gost-engine
+      run: make test TESTS="test_external_gost_engine"
     - name: test external krb5
       run: make test TESTS="test_external_krb5"
     - name: test external tlsfuzzer


### PR DESCRIPTION
Now that  the freeze is lifted, re-enablement of gost-engine tests can procede to release branches

