### PR TITLE
Add printing of multiple x509 certs found in input

### DIFF
--- a/apps/x509.c
+++ b/apps/x509.c
@@ -55,7 +55,7 @@ typedef enum OPTION_choice {
     OPT_SUBJECT_HASH_OLD, OPT_ISSUER_HASH_OLD, OPT_COPY_EXTENSIONS,
     OPT_BADSIG, OPT_MD, OPT_ENGINE, OPT_NOCERT, OPT_PRESERVE_DATES,
     OPT_NOT_BEFORE, OPT_NOT_AFTER,
-    OPT_R_ENUM, OPT_PROV_ENUM, OPT_EXT, OPT_BUNDLE
+    OPT_R_ENUM, OPT_PROV_ENUM, OPT_EXT, OPT_MULTI
 } OPTION_CHOICE;
 
 const OPTIONS x509_options[] = {
@@ -122,7 +122,7 @@ const OPTIONS x509_options[] = {
     {"purpose", OPT_PURPOSE, '-', "Print out certificate purposes"},
     {"pubkey", OPT_PUBKEY, '-', "Print the public key in PEM format"},
     {"modulus", OPT_MODULUS, '-', "Print the RSA key modulus"},
-    {"bundle", OPT_BUNDLE, '-', "Process multiple certificates"},
+    {"multi", OPT_MULTI, '-', "Process multiple certificates"},
 
     OPT_SECTION("Certificate checking"),
     {"checkend", OPT_CHECKEND, 'M',
@@ -294,7 +294,7 @@ int x509_main(int argc, char **argv)
     int fingerprint = 0, reqfile = 0, checkend = 0;
     int informat = FORMAT_UNDEF, outformat = FORMAT_PEM, keyformat = FORMAT_UNDEF;
     int next_serial = 0, subject_hash = 0, issuer_hash = 0, ocspid = 0;
-    int noout = 0, CA_createserial = 0, email = 0, bundle = 0;
+    int noout = 0, CA_createserial = 0, email = 0, multi = 0;
     int ocsp_uri = 0, trustout = 0, clrtrust = 0, clrreject = 0, aliasout = 0;
     int ret = 1, i, j, k = 0, num = 0, badsig = 0, clrext = 0, nocert = 0;
     int text = 0, serial = 0, subject = 0, issuer = 0, startdate = 0, ext = 0;
@@ -607,8 +607,8 @@ int x509_main(int argc, char **argv)
         case OPT_CHECKIP:
             checkip = opt_arg();
             break;
-        case OPT_BUNDLE:
-            bundle = 1;
+        case OPT_MULTI:
+            multi = 1;
             break;
         case OPT_PRESERVE_DATES:
             preserve_dates = 1;
@@ -737,8 +737,8 @@ int x509_main(int argc, char **argv)
         }
     }
 
-    if (bundle && (reqfile || newcert)) {
-        BIO_printf(bio_err, "Error: -bundle cannot be used with -req or -new\n");
+    if (multi && (reqfile || newcert)) {
+        BIO_printf(bio_err, "Error: -multi cannot be used with -req or -new\n");
         goto err;
     }
 
@@ -799,7 +799,7 @@ int x509_main(int argc, char **argv)
         if (infile == NULL && isatty(fileno_stdin()))
             BIO_printf(bio_err,
                        "Warning: Reading certificate(s) from stdin since no -in or -new option is given\n");
-        if (bundle) {
+        if (multi) {
             certs = sk_X509_new_null();
             if (!load_certs(infile, 1, &certs, passin, NULL))
                 goto end;
@@ -817,7 +817,7 @@ int x509_main(int argc, char **argv)
         goto end;
 
  cert_loop:
-    if (bundle)
+    if (multi)
         x = sk_X509_value(certs, k);
 
     if ((fsubj != NULL || req != NULL)
@@ -1129,7 +1129,7 @@ int x509_main(int argc, char **argv)
     }
 
  end_cert_loop:
-    if (bundle && ++k < sk_X509_num(certs))
+    if (multi && ++k < sk_X509_num(certs))
         goto cert_loop;
 
     ret = 0;
@@ -1139,7 +1139,7 @@ int x509_main(int argc, char **argv)
     ERR_print_errors(bio_err);
 
  end:
-    if (bundle) {
+    if (multi) {
         sk_X509_pop_free(certs, X509_free);
         x = NULL;
     }

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -1102,6 +1102,7 @@ int x509_main(int argc, char **argv)
             BIO_printf(out, "Certificate will expire\n");
         else
             BIO_printf(out, "Certificate will not expire\n");
+        goto end_cert_loop;
     }
 
     if (!check_cert_attributes(out, x, checkhost, checkemail, checkip, 1))

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -47,7 +47,7 @@ typedef enum OPTION_choice {
     OPT_CASERIAL, OPT_SET_SERIAL, OPT_NEW, OPT_FORCE_PUBKEY, OPT_ISSU, OPT_SUBJ,
     OPT_ADDTRUST, OPT_ADDREJECT, OPT_SETALIAS, OPT_CERTOPT, OPT_DATEOPT, OPT_NAMEOPT,
     OPT_EMAIL, OPT_OCSP_URI, OPT_SERIAL, OPT_NEXT_SERIAL,
-    OPT_MODULUS, OPT_PUBKEY, OPT_X509TOREQ, OPT_TEXT, OPT_HASH,
+    OPT_MODULUS, OPT_MULTI, OPT_PUBKEY, OPT_X509TOREQ, OPT_TEXT, OPT_HASH,
     OPT_ISSUER_HASH, OPT_SUBJECT, OPT_ISSUER, OPT_FINGERPRINT, OPT_DATES,
     OPT_PURPOSE, OPT_STARTDATE, OPT_ENDDATE, OPT_CHECKEND, OPT_CHECKHOST,
     OPT_CHECKEMAIL, OPT_CHECKIP, OPT_NOOUT, OPT_TRUSTOUT, OPT_CLRTRUST,
@@ -55,7 +55,7 @@ typedef enum OPTION_choice {
     OPT_SUBJECT_HASH_OLD, OPT_ISSUER_HASH_OLD, OPT_COPY_EXTENSIONS,
     OPT_BADSIG, OPT_MD, OPT_ENGINE, OPT_NOCERT, OPT_PRESERVE_DATES,
     OPT_NOT_BEFORE, OPT_NOT_AFTER,
-    OPT_R_ENUM, OPT_PROV_ENUM, OPT_EXT, OPT_MULTI
+    OPT_R_ENUM, OPT_PROV_ENUM, OPT_EXT
 } OPTION_CHOICE;
 
 const OPTIONS x509_options[] = {
@@ -288,13 +288,13 @@ int x509_main(int argc, char **argv)
     char *infile = NULL, *outfile = NULL, *privkeyfile = NULL, *CAfile = NULL;
     char *prog, *not_before = NULL, *not_after = NULL;
     int days = UNSET_DAYS; /* not explicitly set */
-    int x509toreq = 0, modulus = 0, print_pubkey = 0, pprint = 0;
+    int x509toreq = 0, modulus = 0, multi = 0, print_pubkey = 0, pprint = 0;
     int CAformat = FORMAT_UNDEF, CAkeyformat = FORMAT_UNDEF;
     unsigned long dateopt = ASN1_DTFLGS_RFC822;
     int fingerprint = 0, reqfile = 0, checkend = 0;
     int informat = FORMAT_UNDEF, outformat = FORMAT_PEM, keyformat = FORMAT_UNDEF;
     int next_serial = 0, subject_hash = 0, issuer_hash = 0, ocspid = 0;
-    int noout = 0, CA_createserial = 0, email = 0, multi = 0;
+    int noout = 0, CA_createserial = 0, email = 0;
     int ocsp_uri = 0, trustout = 0, clrtrust = 0, clrreject = 0, aliasout = 0;
     int ret = 1, i, j, k = 0, num = 0, badsig = 0, clrext = 0, nocert = 0;
     int text = 0, serial = 0, subject = 0, issuer = 0, startdate = 0, ext = 0;
@@ -501,6 +501,9 @@ int x509_main(int argc, char **argv)
         case OPT_MODULUS:
             modulus = ++num;
             break;
+        case OPT_MULTI:
+            multi = 1;
+            break;
         case OPT_PUBKEY:
             print_pubkey = ++num;
             break;
@@ -606,9 +609,6 @@ int x509_main(int argc, char **argv)
             break;
         case OPT_CHECKIP:
             checkip = opt_arg();
-            break;
-        case OPT_MULTI:
-            multi = 1;
             break;
         case OPT_PRESERVE_DATES:
             preserve_dates = 1;
@@ -801,6 +801,8 @@ int x509_main(int argc, char **argv)
                        "Warning: Reading certificate(s) from stdin since no -in or -new option is given\n");
         if (multi) {
             certs = sk_X509_new_null();
+            if (certs == NULL)
+                goto end;
             if (!load_certs(infile, 1, &certs, passin, NULL))
                 goto end;
             if (sk_X509_num(certs) <= 0)

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -48,6 +48,7 @@ B<openssl> B<x509>
 [B<-purpose>]
 [B<-pubkey>]
 [B<-modulus>]
+[B<-bundle>]
 [B<-checkend> I<num>]
 [B<-checkhost> I<host>]
 [B<-checkemail> I<host>]
@@ -337,6 +338,11 @@ Prints the certificate's SubjectPublicKeyInfo block in PEM format.
 
 This option prints out the value of the modulus of the public key
 contained in the certificate.
+
+=item B<-bundle>
+
+This option prints selected information about all certificates
+contained in the input.
 
 =back
 

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -48,7 +48,7 @@ B<openssl> B<x509>
 [B<-purpose>]
 [B<-pubkey>]
 [B<-modulus>]
-[B<-bundle>]
+[B<-multi>]
 [B<-checkend> I<num>]
 [B<-checkhost> I<host>]
 [B<-checkemail> I<host>]
@@ -339,7 +339,7 @@ Prints the certificate's SubjectPublicKeyInfo block in PEM format.
 This option prints out the value of the modulus of the public key
 contained in the certificate.
 
-=item B<-bundle>
+=item B<-multi>
 
 This option prints selected information about all certificates
 contained in the input.

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -16,7 +16,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_x509");
 
-plan tests => 134;
+plan tests => 140;
 
 # Prevent MSys2 filename munging for arguments that look like file paths but
 # aren't
@@ -484,6 +484,28 @@ ok(run(app(["openssl", "x509", "-noout", "-dates", "-dateopt", "iso_8601",
 ok(!run(app(["openssl", "x509", "-noout", "-dates", "-dateopt", "invalid_format",
 	     "-in", srctop_file("test/certs", "ca-cert.pem")])),
    "Run with invalid -dateopt format");
+
+# same tests w/ -bundle (single cert)
+ok(run(app(["openssl", "x509", "-noout", "-bundle", "-dates", "-dateopt", "rfc_822",
+	     "-in", srctop_file("test/certs", "ca-cert.pem")])),
+   "Run with rfc_8222 -dateopt format and -bundle (single cert)");
+ok(run(app(["openssl", "x509", "-noout", "-bundle", "-dates", "-dateopt", "iso_8601",
+	     "-in", srctop_file("test/certs", "ca-cert.pem")])),
+   "Run with iso_8601 -dateopt format and -bundle (single cert)");
+ok(!run(app(["openssl", "x509", "-noout", "-bundle", "-dates", "-dateopt", "invalid_format",
+	     "-in", srctop_file("test/certs", "ca-cert.pem")])),
+   "Run with invalid -dateopt format and -bundle (single cert)");
+
+# same tests w/ -bundle (multi cert)
+ok(run(app(["openssl", "x509", "-noout", "-bundle", "-dates", "-dateopt", "rfc_822",
+	     "-in", srctop_file("test/certs", "goodcn2-chain.pem")])),
+   "Run with rfc_8222 -dateopt format and -bundle (multi cert)");
+ok(run(app(["openssl", "x509", "-noout", "-bundle", "-dates", "-dateopt", "iso_8601",
+	     "-in", srctop_file("test/certs", "goodcn2-chain.pem")])),
+   "Run with iso_8601 -dateopt format and -bundle (multi cert)");
+ok(!run(app(["openssl", "x509", "-noout", "-bundle", "-dates", "-dateopt", "invalid_format",
+	     "-in", srctop_file("test/certs", "goodcn2-chain.pem")])),
+   "Run with invalid -dateopt format and -bundle (multi cert)");
 
 # Tests for signing certs (broken in 1.1.1o)
 my $a_key = "a-key.pem";

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -485,27 +485,27 @@ ok(!run(app(["openssl", "x509", "-noout", "-dates", "-dateopt", "invalid_format"
 	     "-in", srctop_file("test/certs", "ca-cert.pem")])),
    "Run with invalid -dateopt format");
 
-# same tests w/ -bundle (single cert)
-ok(run(app(["openssl", "x509", "-noout", "-bundle", "-dates", "-dateopt", "rfc_822",
+# same tests w/ -multi (single cert)
+ok(run(app(["openssl", "x509", "-noout", "-multi", "-dates", "-dateopt", "rfc_822",
 	     "-in", srctop_file("test/certs", "ca-cert.pem")])),
-   "Run with rfc_8222 -dateopt format and -bundle (single cert)");
-ok(run(app(["openssl", "x509", "-noout", "-bundle", "-dates", "-dateopt", "iso_8601",
+   "Run with rfc_8222 -dateopt format and -multi (single cert)");
+ok(run(app(["openssl", "x509", "-noout", "-multi", "-dates", "-dateopt", "iso_8601",
 	     "-in", srctop_file("test/certs", "ca-cert.pem")])),
-   "Run with iso_8601 -dateopt format and -bundle (single cert)");
-ok(!run(app(["openssl", "x509", "-noout", "-bundle", "-dates", "-dateopt", "invalid_format",
+   "Run with iso_8601 -dateopt format and -multi (single cert)");
+ok(!run(app(["openssl", "x509", "-noout", "-multi", "-dates", "-dateopt", "invalid_format",
 	     "-in", srctop_file("test/certs", "ca-cert.pem")])),
-   "Run with invalid -dateopt format and -bundle (single cert)");
+   "Run with invalid -dateopt format and -multi (single cert)");
 
-# same tests w/ -bundle (multi cert)
-ok(run(app(["openssl", "x509", "-noout", "-bundle", "-dates", "-dateopt", "rfc_822",
+# same tests w/ -multi (multi cert)
+ok(run(app(["openssl", "x509", "-noout", "-multi", "-dates", "-dateopt", "rfc_822",
 	     "-in", srctop_file("test/certs", "goodcn2-chain.pem")])),
-   "Run with rfc_8222 -dateopt format and -bundle (multi cert)");
-ok(run(app(["openssl", "x509", "-noout", "-bundle", "-dates", "-dateopt", "iso_8601",
+   "Run with rfc_8222 -dateopt format and -multi (multi cert)");
+ok(run(app(["openssl", "x509", "-noout", "-multi", "-dates", "-dateopt", "iso_8601",
 	     "-in", srctop_file("test/certs", "goodcn2-chain.pem")])),
-   "Run with iso_8601 -dateopt format and -bundle (multi cert)");
-ok(!run(app(["openssl", "x509", "-noout", "-bundle", "-dates", "-dateopt", "invalid_format",
+   "Run with iso_8601 -dateopt format and -multi (multi cert)");
+ok(!run(app(["openssl", "x509", "-noout", "-multi", "-dates", "-dateopt", "invalid_format",
 	     "-in", srctop_file("test/certs", "goodcn2-chain.pem")])),
-   "Run with invalid -dateopt format and -bundle (multi cert)");
+   "Run with invalid -dateopt format and -multi (multi cert)");
 
 # Tests for signing certs (broken in 1.1.1o)
 my $a_key = "a-key.pem";

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -12,11 +12,12 @@ use warnings;
 
 use File::Spec;
 use OpenSSL::Test::Utils;
-use OpenSSL::Test qw/:DEFAULT srctop_file/;
+use OpenSSL::Test qw/:DEFAULT srctop_file result_file/;
+use File::Compare qw/compare_text/;
 
 setup("test_x509");
 
-plan tests => 140;
+plan tests => 136;
 
 # Prevent MSys2 filename munging for arguments that look like file paths but
 # aren't
@@ -485,27 +486,18 @@ ok(!run(app(["openssl", "x509", "-noout", "-dates", "-dateopt", "invalid_format"
 	     "-in", srctop_file("test/certs", "ca-cert.pem")])),
    "Run with invalid -dateopt format");
 
-# same tests w/ -multi (single cert)
-ok(run(app(["openssl", "x509", "-noout", "-multi", "-dates", "-dateopt", "rfc_822",
-	     "-in", srctop_file("test/certs", "ca-cert.pem")])),
-   "Run with rfc_8222 -dateopt format and -multi (single cert)");
-ok(run(app(["openssl", "x509", "-noout", "-multi", "-dates", "-dateopt", "iso_8601",
-	     "-in", srctop_file("test/certs", "ca-cert.pem")])),
-   "Run with iso_8601 -dateopt format and -multi (single cert)");
-ok(!run(app(["openssl", "x509", "-noout", "-multi", "-dates", "-dateopt", "invalid_format",
-	     "-in", srctop_file("test/certs", "ca-cert.pem")])),
-   "Run with invalid -dateopt format and -multi (single cert)");
+my $ca_cert = srctop_file(@certs, "ca-cert.pem");
+my $goodcn2_chain = srctop_file(@certs, "goodcn2-chain.pem");
 
-# same tests w/ -multi (multi cert)
-ok(run(app(["openssl", "x509", "-noout", "-multi", "-dates", "-dateopt", "rfc_822",
-	     "-in", srctop_file("test/certs", "goodcn2-chain.pem")])),
-   "Run with rfc_8222 -dateopt format and -multi (multi cert)");
-ok(run(app(["openssl", "x509", "-noout", "-multi", "-dates", "-dateopt", "iso_8601",
-	     "-in", srctop_file("test/certs", "goodcn2-chain.pem")])),
-   "Run with iso_8601 -dateopt format and -multi (multi cert)");
-ok(!run(app(["openssl", "x509", "-noout", "-multi", "-dates", "-dateopt", "invalid_format",
-	     "-in", srctop_file("test/certs", "goodcn2-chain.pem")])),
-   "Run with invalid -dateopt format and -multi (multi cert)");
+# -multi test with single cert
+ok(run(app(["openssl", "x509", "-multi", "-in", $ca_cert])),
+   "Run with -multi (single cert)");
+
+# -multi test with multiple certs
+my $outfile = result_file("multi.out");
+ok(run(app(["openssl", "x509", "-multi", "-in", $goodcn2_chain, "-out", $outfile]))
+   && compare_text($outfile, $goodcn2_chain) == 0,
+   "Run with -multi (multiple certs)");
 
 # Tests for signing certs (broken in 1.1.1o)
 my $a_key = "a-key.pem";


### PR DESCRIPTION
Add printing of multiple x509 certs found in input

Adds a ~~`-bundle`~~ `-multi` option to x509 that loops through any certificates found in the input instead of just the first one.

e.g. 

without ~~`-bundle`~~ `-multi`
```
❯ echo | openssl s_client -connect google.com:443 -showcerts 2>/dev/null | openssl x509 -noout -subject -issuer -dates
subject=CN=*.google.com
issuer=C=US, O=Google Trust Services, CN=WE2
notBefore=Mar 20 11:18:50 2025 GMT
notAfter=Jun 12 11:18:49 2025 GMT
```

with ~~`-bundle`~~ `-multi`
```
❯ echo | openssl s_client -connect google.com:443 -showcerts 2>/dev/null | openssl x509 -noout -subject -issuer -dates -multi
subject=CN=*.google.com
issuer=C=US, O=Google Trust Services, CN=WE2
notBefore=Mar 20 11:18:50 2025 GMT
notAfter=Jun 12 11:18:49 2025 GMT
subject=C=US, O=Google Trust Services, CN=WE2
issuer=C=US, O=Google Trust Services LLC, CN=GTS Root R4
notBefore=Dec 13 09:00:00 2023 GMT
notAfter=Feb 20 14:00:00 2029 GMT
subject=C=US, O=Google Trust Services LLC, CN=GTS Root R4
issuer=C=BE, O=GlobalSign nv-sa, OU=Root CA, CN=GlobalSign Root CA
notBefore=Nov 15 03:43:21 2023 GMT
notAfter=Jan 28 00:00:42 2028 GMT
```

This is a slightly contrived example since `s_client` with `-showcerts` displays the example information (albeit in slightly more verbose form).  However, this also allows one to display all/any certificate information from file-based bundles via stdin or the `-in` flag.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

