### PR TITLE
Avoid multiple wrong_type errors on error stack

### DIFF
--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -73,7 +73,7 @@ int ossl_quic_renegotiate_check(SSL *ssl, int initok);
 
 int ossl_quic_do_handshake(SSL *s);
 void ossl_quic_set_connect_state(SSL *s);
-void ossl_quic_set_accept_state(SSL *s);
+int ossl_quic_set_accept_state(SSL *s);
 
 __owur int ossl_quic_has_pending(const SSL *s);
 __owur int ossl_quic_handle_events(SSL *s);

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -1687,18 +1687,19 @@ void ossl_quic_set_connect_state(SSL *s)
 }
 
 /* SSL_set_accept_state */
-void ossl_quic_set_accept_state(SSL *s)
+int ossl_quic_set_accept_state(SSL *s)
 {
     QCTX ctx;
 
     if (!expect_quic_cs(s, &ctx))
-        return;
+        return 0;
 
     /* Cannot be changed after handshake started */
     if (ctx.qc->started || ctx.is_stream)
-        return;
+        return 0;
 
     ctx.qc->as_server_state = 1;
+    return 1;
 }
 
 /* SSL_do_handshake */
@@ -1993,7 +1994,8 @@ int ossl_quic_connect(SSL *s)
 int ossl_quic_accept(SSL *s)
 {
     /* Ensure we are in accept state (no-op if non-idle). */
-    ossl_quic_set_accept_state(s);
+    if (!ossl_quic_set_accept_state(s))
+        return 0;
 
     /* Begin or continue the handshake */
     return ossl_quic_do_handshake(s);


### PR DESCRIPTION
Quic uses the ossl_quic_set_accept_state function in a few locations, assuming it is always successful.  But in the event that the wrong type of ssl object is passed to it, we get a wrong_type error on the stack.

Because it returns void, users proceded with operations which might result in a second wrong_type error on the stack

To avoid these duplicates, change ossl_quic_set_accept_state to return an int, and return callers early if the call fails, avoiding the duplicated errors on the stack

Fixes #27348

