### PR TITLE
Fix URL scheme parsing and TLS Server Name Indication (SNI) and its use in `apps/`

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -472,13 +472,13 @@ const OPTIONS cmp_options[] = {
         "NOTE: -server, -proxy, and -no_proxy not supported due to no-sock/no-http build" },
 #else
     { "server", OPT_SERVER, 's',
-        "[http[s]://]address[:port][/path] of CMP server. Default port 80 or 443." },
+        "[http[s]://]host[:port][/path] of CMP server to use. Default port 80 or 443." },
     { OPT_MORE_STR, 0, 0,
-        "address may be a DNS name or an IP address; path can be overridden by -path" },
+        "host may be a DNS name or an IP address; path can be overridden by -path" },
     { "proxy", OPT_PROXY, 's',
-        "[http[s]://]address[:port][/path] of HTTP(S) proxy to use; path is ignored" },
+        "[http[s]://]host[:port][/path] of HTTP(S) proxy to use; path is ignored" },
     { "no_proxy", OPT_NO_PROXY, 's',
-        "List of addresses of servers not to use HTTP(S) proxy for" },
+        "List of servers not to use HTTP(S) proxy for" },
     { OPT_MORE_STR, 0, 0,
         "Default from environment variable 'no_proxy', else 'NO_PROXY', else none" },
 #endif
@@ -597,7 +597,7 @@ const OPTIONS cmp_options[] = {
         "Trusted certificates to use for verifying the TLS server certificate;" },
     { OPT_MORE_STR, 0, 0, "this implies hostname validation" },
     { "tls_host", OPT_TLS_HOST, 's',
-        "Address to be checked (rather than -server) during TLS hostname validation" },
+        "Host name/address (rather than -server) to verify in TLS server cert" },
 #endif
 
     OPT_SECTION("Client-side debugging"),
@@ -861,7 +861,11 @@ static X509 *load_cert_pwd(const char *uri, const char *source, const char *desc
     return cert;
 }
 
-/* set expected hostname/IP addr and clears the email addr in the given ts */
+/*
+ * Set expected hostname/IP address and clears any email address in the given ts.
+ * If the host is NULL, host name/address verification is disabled.
+ * It is interpreted as an IP address when possible, otherwise as a domain name.
+ */
 static int truststore_set_host_etc(X509_STORE *ts, const char *host)
 {
     X509_VERIFY_PARAM *ts_vpm = X509_STORE_get0_param(ts);
@@ -871,10 +875,14 @@ static int truststore_set_host_etc(X509_STORE *ts, const char *host)
         || !X509_VERIFY_PARAM_set1_ip(ts_vpm, NULL, 0)
         || !X509_VERIFY_PARAM_set1_email(ts_vpm, NULL, 0))
         return 0;
+    if (host == NULL)
+        return 1;
+
     X509_VERIFY_PARAM_set_hostflags(ts_vpm,
         X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT | X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
-    return (host != NULL && X509_VERIFY_PARAM_set1_ip_asc(ts_vpm, host))
-        || X509_VERIFY_PARAM_set1_host(ts_vpm, host, 0);
+    return host_is_ip_address(host)
+        ? X509_VERIFY_PARAM_set1_ip_asc(ts_vpm, host)
+        : X509_VERIFY_PARAM_set1_host(ts_vpm, host, 0);
 }
 
 /* write OSSL_CMP_MSG DER-encoded to the specified file name item */
@@ -1583,8 +1591,7 @@ static SSL_CTX *setup_ssl_ctx(OSSL_CMP_CTX *ctx, const char *host)
          * If we did this before checking our own TLS cert
          * the expected hostname would mislead the check.
          */
-        if (!truststore_set_host_etc(trust_store,
-                opt_tls_host != NULL ? opt_tls_host : host))
+        if (!truststore_set_host_etc(trust_store, host))
             goto err;
     }
     return ssl_ctx;
@@ -2369,9 +2376,9 @@ set_path:
             goto err;
         APP_HTTP_TLS_INFO_free(OSSL_CMP_CTX_get_http_cb_arg(ctx));
         (void)OSSL_CMP_CTX_set_http_cb_arg(ctx, info);
-        info->ssl_ctx = setup_ssl_ctx(ctx, host);
+        info->ssl_ctx = setup_ssl_ctx(ctx, opt_tls_host != NULL ? opt_tls_host : host);
         info->server = host;
-        host = NULL; /* prevent deallocation */
+        host = NULL; /* ownership has been transferred to info structure */
         if ((info->port = OPENSSL_strdup(server_port)) == NULL)
             goto err;
         /* workaround for callback design flaw, see #17088: */
@@ -3999,11 +4006,7 @@ err:
         /* cannot free info already here, as it may be used indirectly by: */
         OSSL_CMP_CTX_free(cmp_ctx);
 #if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
-        if (info != NULL) {
-            OPENSSL_free((char *)info->server);
-            OPENSSL_free((char *)info->port);
-            APP_HTTP_TLS_INFO_free(info);
-        }
+        APP_HTTP_TLS_INFO_free(info);
 #endif
     }
     X509_VERIFY_PARAM_free(vpm);

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -323,6 +323,8 @@ int check_cert_might_be_valid(BIO *bio, BIO *bio_err, X509 *x,
 
 void store_setup_crl_download(X509_STORE *st);
 
+int host_is_ip_address(const char *host);
+
 typedef struct app_http_tls_info_st {
     const char *server;
     const char *port;

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2964,7 +2964,10 @@ BIO *app_http_tls_cb(BIO *bio, void *arg, int connect, int detail)
             goto err;
 
         SSL_set_connect_state(ssl);
-        BIO_set_ssl(sbio, ssl, BIO_CLOSE);
+        if (BIO_set_ssl(sbio, ssl, BIO_CLOSE) <= 0) {
+            SSL_free(ssl);
+            goto err;
+        }
         if (!host_is_ip_address(info->server)) {
             if (!SSL_set_tlsext_host_name(ssl, info->server)) /* set SNI */
                 goto err;

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2868,6 +2868,34 @@ void store_setup_crl_download(X509_STORE *st)
     X509_STORE_set_lookup_crls_cb(st, crls_http_cb);
 }
 
+int host_is_ip_address(const char *host)
+{
+#ifndef INET6_ADDRSTRLEN /* not defined on OPENSSL_NO_SOCK */
+#define INET6_ADDRSTRLEN 46
+#endif
+    char stripped_host_ipv6[INET6_ADDRSTRLEN + 1];
+    ASN1_OCTET_STRING *str;
+    int ret;
+
+    if (host == NULL)
+        return 0;
+
+    if (host[0] == '[') { /* OSSL_parse_url() returns IPv6 addresses enclosed in [ and ] */
+        size_t len = strlen(++host);
+        if (len == 0 || len > sizeof(stripped_host_ipv6) || host[--len] != ']')
+            return 0;
+        strncpy(stripped_host_ipv6, host, sizeof(stripped_host_ipv6));
+        stripped_host_ipv6[len] = '\0';
+        host = stripped_host_ipv6;
+    }
+    ERR_set_mark();
+    str = a2i_IPADDRESS(host);
+    ret = str != NULL;
+    ERR_pop_to_mark();
+    ASN1_OCTET_STRING_free(str);
+    return ret;
+}
+
 #if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
 static const char *tls_error_hint(void)
 {
@@ -2917,15 +2945,12 @@ BIO *app_http_tls_cb(BIO *bio, void *arg, int connect, int detail)
 {
     APP_HTTP_TLS_INFO *info = (APP_HTTP_TLS_INFO *)arg;
     SSL_CTX *ssl_ctx = info->ssl_ctx;
+    BIO *sbio = NULL;
 
     if (ssl_ctx == NULL) /* not using TLS */
         return bio;
     if (connect) {
         SSL *ssl;
-        BIO *sbio = NULL;
-        X509_STORE *ts = SSL_CTX_get_cert_store(ssl_ctx);
-        X509_VERIFY_PARAM *vpm = X509_STORE_get0_param(ts);
-        char *host = vpm == NULL ? NULL : X509_VERIFY_PARAM_get0_host(vpm, 0 /* first hostname */);
 
         /* adapt after fixing callback design flaw, see #17088 */
         if ((info->use_proxy
@@ -2935,27 +2960,32 @@ BIO *app_http_tls_cb(BIO *bio, void *arg, int connect, int detail)
             || (sbio = BIO_new(BIO_f_ssl())) == NULL) {
             return NULL;
         }
-        if ((ssl = SSL_new(ssl_ctx)) == NULL) {
-            BIO_free(sbio);
-            return NULL;
-        }
-
-        if (vpm != NULL)
-            SSL_set_tlsext_host_name(ssl, host /* may be NULL */);
+        if ((ssl = SSL_new(ssl_ctx)) == NULL)
+            goto err;
 
         SSL_set_connect_state(ssl);
         BIO_set_ssl(sbio, ssl, BIO_CLOSE);
+        if (!host_is_ip_address(info->server)) {
+            if (!SSL_set_tlsext_host_name(ssl, info->server)) /* set SNI */
+                goto err;
+        }
 
         bio = BIO_push(sbio, bio);
     } else { /* disconnect from TLS */
         bio = http_tls_shutdown(bio);
     }
     return bio;
+
+err:
+    BIO_free(sbio);
+    return NULL;
 }
 
 void APP_HTTP_TLS_INFO_free(APP_HTTP_TLS_INFO *info)
 {
     if (info != NULL) {
+        OPENSSL_free((char *)info->server);
+        OPENSSL_free((char *)info->port);
         SSL_CTX_free(info->ssl_ctx);
         OPENSSL_free(info);
     }

--- a/crypto/http/http_lib.c
+++ b/crypto/http/http_lib.c
@@ -110,7 +110,7 @@ int OSSL_parse_url(const char *url, char **pscheme, char **puser, char **phost,
     /* parse hostname/address as far as needed here */
     if (host[0] == '[') {
         /* IPv6 literal, which may include ':' */
-        host_end = strchr(host + 1, ']');
+        host_end = memchr(host + 1, ']', authority_end - host - 1);
         if (host_end == NULL)
             goto parse_err;
         p = ++host_end;

--- a/crypto/http/http_lib.c
+++ b/crypto/http/http_lib.c
@@ -21,6 +21,7 @@
 #define NI_MAXHOST 255
 #endif
 #include "crypto/ctype.h" /* for ossl_isspace() */
+#define OSSL_URL_SCHEME_SUFFIX "://"
 
 static void init_pstring(char **pstr)
 {
@@ -79,16 +80,20 @@ int OSSL_parse_url(const char *url, char **pscheme, char **puser, char **phost,
         return 0;
     }
 
-    /* check for optional prefix "<scheme>://" */
-    scheme = scheme_end = url;
-    p = strstr(url, "://");
-    if (p == NULL) {
-        p = url;
-    } else {
-        scheme_end = p;
-        if (scheme_end == scheme)
-            goto parse_err;
-        p += strlen("://");
+    /* check for optional prefix "<scheme>://" as per RFC 3986 */
+    scheme = scheme_end = p = url;
+    if (ossl_isalpha(*p)) {
+        while (*p != '\0'
+            && (ossl_isalpha(*p)
+                || ossl_isdigit(*p)
+                || strchr("+-.", *p) != NULL))
+            p++;
+        if (HAS_PREFIX(p, OSSL_URL_SCHEME_SUFFIX)) {
+            scheme_end = p;
+            p += sizeof(OSSL_URL_SCHEME_SUFFIX) - 1;
+        } else {
+            p = url;
+        }
     }
 
     /* parse optional "userinfo@" */

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -116,7 +116,7 @@ TLS connection options:
 [B<-tls_keypass> I<arg>]
 [B<-tls_extra> I<filenames>|I<uris>]
 [B<-tls_trusted> I<filenames>|I<uris>]
-[B<-tls_host> I<name>]
+[B<-tls_host> I<host>]
 
 Client-side debugging options:
 
@@ -527,9 +527,14 @@ Reason numbers defined in RFC 5280 are:
 =item B<-server> I<[http[s]://][userinfo@]host[:port][/path][?query][#fragment]>
 
 The I<host> domain name or IP address and optionally I<port>
-of the CMP server to connect to using HTTP(S).
-IP address may be for v4 or v6, such as C<127.0.0.1> or C<[::1]> for localhost.
-If the host string is an IPv6 address, it must be enclosed in C<[> and C<]>.
+of the CMP server to connect to via HTTP(S).
+An IP address may be for v4 or v6, such as C<127.0.0.1> or C<[::1]> for C<localhost>.
+If the I<host> string is an IPv6 address, it must be enclosed in C<[> and C<]>.
+
+For TLS connections, the name verified in server certificates is I<host>
+unless the B<-tls_host> option is used to specify a different name.
+If I<host> is a DNS name, it is also used for
+TLS Server Name Indication (SNI) according to RFC 3546 section 3.1.
 
 This option excludes I<-port> and I<-use_mock_srv>.
 It is ignored if I<-rspin> is given with enough filename arguments.
@@ -1038,11 +1043,10 @@ The certificate verification options
 B<-verify_hostname>, B<-verify_ip>, and B<-verify_email>
 have no effect on the certificate verification enabled via this option.
 
-=item B<-tls_host> I<name>
+=item B<-tls_host> I<host>
 
-Address to be checked during hostname validation.
-This may be a DNS name or an IP address.
-If not given it defaults to the B<-server> address.
+Hostname or IP address to be checked in the TLS server certificate.
+If not given it defaults to the host part of the B<-server> option URL argument.
 
 =back
 

--- a/doc/man3/BIO_f_ssl.pod
+++ b/doc/man3/BIO_f_ssl.pod
@@ -56,6 +56,7 @@ SSL structure is also freed using SSL_free().
 
 BIO_set_ssl() sets the internal SSL pointer of SSL BIO B<b> to B<ssl> using
 the close flag B<c>.
+On success, ownership of B<ssl> is transferred to BIO B<b>.
 
 BIO_get_ssl() retrieves the SSL pointer of SSL BIO B<b>, it can then be
 manipulated using the standard SSL library functions.

--- a/doc/man3/OSSL_HTTP_REQ_CTX.pod
+++ b/doc/man3/OSSL_HTTP_REQ_CTX.pod
@@ -111,10 +111,10 @@ in the header line, followed by a C<;> character and any further text.
 For instance, if the I<expected_content_type> argument specifies C<text/html>,
 this is matched by C<Text/HTML>, C<text/html; charset=UTF-8>, etc.
 
-If the I<expect_asn1> parameter is nonzero a structure in ASN.1 encoding will be
-expected as the response content and input streaming is disabled.  This means
-that an ASN.1 sequence header is required, its length field is checked, and
-OSSL_HTTP_REQ_CTX_get0_mem_bio() should be used to get the buffered response.
+If the I<expect_asn1> parameter is nonzero, a structure in ASN.1 DER/BER encoding
+will be expected as the response content and input streaming is disabled.
+This means that an ASN.1 sequence header is required, its length field is checked,
+and OSSL_HTTP_REQ_CTX_get0_mem_bio() should be used to get the buffered response.
 Otherwise (by default) any input format is allowed,
 with body length checks being performed on error messages only.
 In this case the BIO given as I<rbio> argument to OSSL_HTTP_REQ_CTX_new() should

--- a/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
@@ -26,9 +26,9 @@ the ClientHello callback, which can be set using SSL_CTX_set_client_hello_cb().
 However, even where the ClientHello callback is used, the servername callback is
 still necessary in order to acknowledge the servername requested by the client.
 
-SSL_CTX_set_tlsext_servername_callback() sets the application callback B<cb>
+SSL_CTX_set_tlsext_servername_callback() sets the application callback I<cb>
 used by a server to perform any actions or configuration required based on
-the servername extension received in the incoming connection. When B<cb>
+the B<servername> extension received in the incoming connection. When I<cb>
 is NULL, SNI is not used. Note that this callback occurs late in the processing
 of the ClientHello message. In particular it happens after session resumption
 has occurred, and so typically this callback should not call functions such
@@ -49,14 +49,14 @@ up a different configuration for the selected servername in this case.
 
 In this case the servername requested by the client is not accepted and the
 handshake will be aborted. The value of the alert to be used should be stored in
-the location pointed to by the B<al> parameter to the callback. By default this
+the location pointed to by the I<al> parameter to the callback. By default this
 value is initialised to SSL_AD_UNRECOGNIZED_NAME.
 
 =item SSL_TLSEXT_ERR_ALERT_WARNING
 
 If this value is returned then the servername is not accepted by the server.
 However, the handshake will continue and send a warning alert instead. The value
-of the alert should be stored in the location pointed to by the B<al> parameter
+of the alert should be stored in the location pointed to by the I<al> parameter
 as for SSL_TLSEXT_ERR_ALERT_FATAL above. Note that TLSv1.3 does not support
 warning alerts, so if TLSv1.3 has been negotiated then this return value is
 treated the same way as SSL_TLSEXT_ERR_NOACK.
@@ -69,7 +69,7 @@ No alerts are sent and the server will not acknowledge the requested servername.
 =back
 
 SSL_CTX_set_tlsext_servername_arg() sets a context-specific argument to be
-passed into the callback (via the B<arg> parameter) for this B<SSL_CTX>.
+passed into the callback (via the I<arg> parameter) for this B<SSL_CTX>.
 
 The behaviour of SSL_get_servername() depends on a number of different factors.
 In particular note that in TLSv1.3 the servername is negotiated in every
@@ -127,21 +127,27 @@ client is processed. The servername, certificate and ALPN callbacks occur after
 a servername extension from the client is processed.
 
 SSL_get_servername_type() returns the servername type or -1 if no servername
-is present. Currently the only supported type (defined in RFC3546) is
-B<TLSEXT_NAMETYPE_host_name>.
+is present.
+The only type defined in RFC 3546 and supported here is B<TLSEXT_NAMETYPE_host_name>.
 
-SSL_set_tlsext_host_name() sets the server name indication ClientHello extension
-to contain the value B<name>. The type of server name indication extension is set
-to B<TLSEXT_NAMETYPE_host_name> (defined in RFC3546).
+SSL_set_tlsext_host_name() sets the Server Name Indication (SNI)
+ClientHello extension defined in RFC 3546 section 3.1
+to contain the value I<name> of type B<TLSEXT_NAMETYPE_host_name>.
+If I<name> is NULL, it clears the SNI extension.
+
+Using this function may also be important for correct routing of connection requests.
+TLS clients should call this function alongside L<SSL_set1_dnsname(3)> or
+L<SSL_add1_dnsname(3)> to set the expected server hostname(s) for certificate validation.
+
+The SSL_set_tlsext_host_name() function should only be called on SSL objects
+that will act as clients; otherwise, the configured I<name> will be ignored.
+In the future, calling this function on the server side may result in an error.
 
 =head1 NOTES
 
 Several callbacks are executed during ClientHello processing, including
 the ClientHello, ALPN, and servername callbacks.  The ClientHello callback is
 executed first, then the servername callback, followed by the ALPN callback.
-
-The SSL_set_tlsext_host_name() function should only be called on SSL objects
-that will act as clients; otherwise the configured B<name> will be ignored.
 
 =head1 RETURN VALUES
 
@@ -152,7 +158,9 @@ SSL_set_tlsext_host_name() returns 1 on success, 0 in case of error.
 =head1 SEE ALSO
 
 L<ssl(7)>, L<SSL_CTX_set_alpn_select_cb(3)>,
-L<SSL_get0_alpn_selected(3)>, L<SSL_CTX_set_client_hello_cb(3)>
+L<SSL_get0_alpn_selected(3)>, L<SSL_CTX_set_client_hello_cb(3)>,
+L<SSL_set1_dnsname(3)>, L<SSL_add1_dnsname(3)>,
+L<X509_VERIFY_PARAM_set1_host(3)>, L<X509_VERIFY_PARAM_add1_host(3)>
 
 =head1 HISTORY
 

--- a/ssl/bio_ssl.c
+++ b/ssl/bio_ssl.c
@@ -299,7 +299,6 @@ static long ssl_ctrl(BIO *b, int cmd, long num, void *ptr)
         }
         BIO_set_shutdown(b, num);
         ssl = (SSL *)ptr;
-        bs->ssl = ssl;
         bio = SSL_get_rbio(ssl);
         if (bio != NULL) {
             if (!BIO_up_ref(bio)) {
@@ -311,6 +310,7 @@ static long ssl_ctrl(BIO *b, int cmd, long num, void *ptr)
             BIO_set_next(b, bio);
         }
         BIO_set_init(b, 1);
+        bs->ssl = ssl;
         break;
     case BIO_C_GET_SSL:
         if (ptr != NULL) {

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4025,8 +4025,7 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
          * from the server, but we currently allow it to be used on servers
          * as well, which is a programming error.  Currently we just clear
          * the field in SSL_do_handshake() for server SSLs, but when we can
-         * make ABI-breaking changes, we may want to make use of this API
-         * an error on server SSLs.
+         * make ABI-breaking changes, we may want to return an error in this case.
          */
         if (larg == TLSEXT_NAMETYPE_host_name) {
             size_t len;

--- a/test/http_test.c
+++ b/test/http_test.c
@@ -287,8 +287,8 @@ err:
     return res;
 }
 
-static int test_http_url_ok(const char *url, int exp_ssl, const char *exp_host,
-    const char *exp_port, const char *exp_path)
+static int test_http_url_frag_ok(const char *url, int exp_ssl, const char *exp_host,
+    const char *exp_port, const char *exp_path, const char *exp_frag)
 {
     char *user, *host, *port, *path, *query, *frag;
     int exp_num, num, ssl;
@@ -305,8 +305,8 @@ static int test_http_url_ok(const char *url, int exp_ssl, const char *exp_host,
         && TEST_int_eq(ssl, exp_ssl);
     if (res && *user != '\0')
         res = TEST_str_eq(user, "user:pass");
-    if (res && *frag != '\0')
-        res = TEST_str_eq(frag, "fr");
+    if (res)
+        res = TEST_str_eq(frag, exp_frag);
     if (res && *query != '\0')
         res = TEST_str_eq(query, "q");
     OPENSSL_free(user);
@@ -316,6 +316,12 @@ static int test_http_url_ok(const char *url, int exp_ssl, const char *exp_host,
     OPENSSL_free(query);
     OPENSSL_free(frag);
     return res;
+}
+
+static int test_http_url_ok(const char *url, int exp_ssl, const char *exp_host,
+    const char *exp_port, const char *exp_path)
+{
+    return test_http_url_frag_ok(url, exp_ssl, exp_host, exp_port, exp_path, "");
 }
 
 static int test_http_url_path_query_ok(const char *url, const char *exp_path_qu)
@@ -349,6 +355,11 @@ static int test_http_url_dns(void)
     return test_http_url_ok("host:65535/path", 0, "host", "65535", "/path");
 }
 
+static int test_http_url_ip(void)
+{
+    return test_http_url_ok("1.2.3.4:5678//blahblablah", 0, "1.2.3.4", "5678", "//blahblablah");
+}
+
 static int test_http_url_timestamp(void)
 {
     return test_http_url_ok("host/p/2017-01-03T00:00:00", 0, "host", "80",
@@ -368,7 +379,9 @@ static int test_http_url_path_query(void)
 
 static int test_http_url_userinfo_query_fragment(void)
 {
-    return test_http_url_ok("user:pass@host/p?q#fr", 0, "host", "80", "/p");
+    return test_http_url_frag_ok("user:pass@host/p?q#fr", 0, "host", "80", "/p", "fr")
+        && test_http_url_frag_ok("host.example.org/some/path#://not-a-scheme/not.a.host:404", 0,
+            "host.example.org", "80", "/some/path", "://not-a-scheme/not.a.host:404");
 }
 
 static int test_http_url_at_sign_outside_authority(void)
@@ -652,6 +665,7 @@ int setup_tests(void)
         return 0;
 
     ADD_TEST(test_http_url_dns);
+    ADD_TEST(test_http_url_ip);
     ADD_TEST(test_http_url_timestamp);
     ADD_TEST(test_http_url_path_query);
     ADD_TEST(test_http_url_userinfo_query_fragment);

--- a/test/http_test.c
+++ b/test/http_test.c
@@ -287,6 +287,8 @@ err:
     return res;
 }
 
+static int test_http_url_invalid(const char *url);
+
 static int test_http_url_frag_ok(const char *url, int exp_ssl, const char *exp_host,
     const char *exp_port, const char *exp_path, const char *exp_frag)
 {
@@ -398,7 +400,8 @@ static int test_http_url_ipv4(void)
 
 static int test_http_url_ipv6(void)
 {
-    return test_http_url_ok("http://[FF01::101]:6", 0, "[FF01::101]", "6", "/");
+    return test_http_url_ok("http://[FF01::101]:6", 0, "[FF01::101]", "6", "/")
+        && test_http_url_invalid("http://[FF01::101/path]");
 }
 
 static int test_http_url_invalid(const char *url)


### PR DESCRIPTION
~Add recommendation that TLS clients should use `SSL_set_tlsext_host_name()` for SNI
and that this should be done jointly with using `{SSL,X509_VERIFY_PARAM}_{set1,add1}_host()`.
On this occasion fix nits and omissions in the respective `.pod` files.~ ~Doc changes moved to #29150.~

* ~Fix `OSSL_parse_url()` going too far when scanning for '`@`' to detect the end of the `userinfo` component.,
going astray when an `@` symbol occurs after the `host` component, for instance in the `query` component.~ meanwhile superseded by #30319

* Fix `OSSL_parse_url()` to correctly parse scheme (where only certain chars are allowed)

* Make sure that `app_http_tls_cb()` calls `SSL_set_tlsext_host_name()` for setting the SNI only if a server name (rather than an IP address) is given. 

* Also fix the server name being set in the SNI: it must always be the server actually connecting to, 
while for the CMP CLI app so far this is wrongly tied to the `-tls_host` option.

* Add to `OSSL_HTTP_REQ_CTX_nbio` support for partial content-type string matching

* Extend related doc, e.g., of `SSL_set_tlsext_host_name()` and `OSSL_HTTP_REQ_CTX_set_expected()`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
