### PR TITLE
CMS: add missing output error checks and CLI failure messages; fix micalg output for SHAKE and GostR3411

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -1280,6 +1280,7 @@ int cms_main(int argc, char **argv)
             goto end;
         }
         if (ret <= 0) {
+            BIO_printf(bio_err, "Error writing CMS output\n");
             ret = 6;
             goto end;
         }

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -1244,6 +1244,7 @@ int cms_main(int argc, char **argv)
             goto end;
         }
     } else {
+        /* within this block, ret > 0 means 'ok' */
         if (noout) {
             if (print) {
                 ASN1_PCTX *pctx = NULL;
@@ -1258,6 +1259,7 @@ int cms_main(int argc, char **argv)
                 CMS_ContentInfo_print_ctx(out, cms, 0, pctx);
                 ASN1_PCTX_free(pctx);
             }
+            ret = 1;
         } else if (outformat == FORMAT_SMIME) {
             if (to)
                 BIO_printf(out, "To: %s%s", to, mime_eol);
@@ -1285,7 +1287,7 @@ int cms_main(int argc, char **argv)
     }
     ret = 0;
  end:
-    if (ret)
+    if (ret != 0)
         ERR_print_errors(bio_err);
     OSSL_STACK_OF_X509_free(encerts);
     OSSL_STACK_OF_X509_free(other);

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -1261,12 +1261,12 @@ int cms_main(int argc, char **argv)
             }
             ret = 1;
         } else if (outformat == FORMAT_SMIME) {
-            if (to)
-                BIO_printf(out, "To: %s%s", to, mime_eol);
-            if (from)
-                BIO_printf(out, "From: %s%s", from, mime_eol);
-            if (subject)
-                BIO_printf(out, "Subject: %s%s", subject, mime_eol);
+            if (to != NULL && BIO_printf(out, "To: %s%s", to, mime_eol) < 0)
+                goto end;
+            if (from != NULL && BIO_printf(out, "From: %s%s", from, mime_eol) < 0)
+                goto end;
+            if (subject != NULL && BIO_printf(out, "Subject: %s%s", subject, mime_eol) < 0)
+                goto end;
             if (operation == SMIME_RESIGN)
                 ret = SMIME_write_CMS(out, cms, indata, flags);
             else

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -854,36 +854,24 @@ int cms_main(int argc, char **argv)
         }
     }
 
-    if (certfile != NULL) {
-        if (!load_certs(certfile, 0, &other, NULL, "certificate file")) {
-            ERR_print_errors(bio_err);
-            goto end;
-        }
-    }
+    if (certfile != NULL
+            && !load_certs(certfile, 0, &other, NULL, "certificate file"))
+        goto end;
 
-    if (recipfile != NULL && (operation == SMIME_DECRYPT)) {
-        if ((recip = load_cert(recipfile, FORMAT_UNDEF,
-                               "recipient certificate file")) == NULL) {
-            ERR_print_errors(bio_err);
-            goto end;
-        }
-    }
+    if (recipfile != NULL && (operation == SMIME_DECRYPT)
+        && (recip = load_cert(recipfile, FORMAT_UNDEF,
+                              "recipient certificate file")) == NULL)
+        goto end;
 
-    if (originatorfile != NULL) {
-        if ((originator = load_cert(originatorfile, FORMAT_UNDEF,
-                                    "originator certificate file")) == NULL) {
-            ERR_print_errors(bio_err);
-            goto end;
-        }
-    }
+    if (originatorfile != NULL
+        && (originator = load_cert(originatorfile, FORMAT_UNDEF,
+                                   "originator certificate file")) == NULL)
+        goto end;
 
-    if (operation == SMIME_SIGN_RECEIPT) {
-        if ((signer = load_cert(signerfile, FORMAT_UNDEF,
-                                "receipt signer certificate file")) == NULL) {
-            ERR_print_errors(bio_err);
-            goto end;
-        }
-    }
+    if (operation == SMIME_SIGN_RECEIPT
+        && (signer = load_cert(signerfile, FORMAT_UNDEF,
+                               "receipt signer certificate file")) == NULL)
+        goto end;
 
     if ((operation == SMIME_DECRYPT) || (operation == SMIME_ENCRYPT)) {
         if (keyfile == NULL)
@@ -1511,8 +1499,7 @@ static int cms_set_pkey_param(EVP_PKEY_CTX *pctx,
     for (i = 0; i < sk_OPENSSL_STRING_num(param); i++) {
         keyopt = sk_OPENSSL_STRING_value(param, i);
         if (pkey_ctrl_string(pctx, keyopt) <= 0) {
-            BIO_printf(bio_err, "parameter error \"%s\"\n", keyopt);
-            ERR_print_errors(bio_err);
+            BIO_printf(bio_err, "Error setting CMS key parameter \"%s\"\n", keyopt);
             return 0;
         }
     }

--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -692,14 +692,17 @@ static int multi_split(BIO *bio, int flags, const char *bound, STACK_OF(BIO) **r
 #else
                     1
 #endif
-                        || (flags & SMIME_CRLFEOL) != 0)
-                    BIO_write(bpart, "\r\n", 2);
-                else
-                    BIO_write(bpart, "\n", 1);
+                        || (flags & SMIME_CRLFEOL) != 0) {
+                    if (BIO_puts(bpart, "\r\n") < 0)
+                        return 0;
+                } else {
+                    if (BIO_puts(bpart, "\n") < 0)
+                        return 0;
+                }
             }
             eol = next_eol;
-            if (len > 0)
-                BIO_write(bpart, linebuf, len);
+            if (len > 0 && BIO_write(bpart, linebuf, len) != len)
+                return 0;
         }
     }
     BIO_free(bpart);

--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -633,10 +633,9 @@ int SMIME_text(BIO *in, BIO *out)
     }
     sk_MIME_HEADER_pop_free(headers, mime_hdr_free);
     while ((len = BIO_read(in, iobuf, sizeof(iobuf))) > 0)
-        BIO_write(out, iobuf, len);
-    if (len < 0)
-        return 0;
-    return 1;
+        if (BIO_write(out, iobuf, len) != len && out != NULL)
+            return 0;
+    return len >= 0;
 }
 
 /*

--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -128,11 +128,9 @@ static int B64_write_ASN1(BIO *out, ASN1_VALUE *val, BIO *in, int flags,
 int PEM_write_bio_ASN1_stream(BIO *out, ASN1_VALUE *val, BIO *in, int flags,
                               const char *hdr, const ASN1_ITEM *it)
 {
-    int r;
-    BIO_printf(out, "-----BEGIN %s-----\n", hdr);
-    r = B64_write_ASN1(out, val, in, flags, it);
-    BIO_printf(out, "-----END %s-----\n", hdr);
-    return r;
+    return BIO_printf(out, "-----BEGIN %s-----\n", hdr) >= 0
+        && B64_write_ASN1(out, val, in, flags, it)
+        && BIO_printf(out, "-----END %s-----\n", hdr) >= 0;
 }
 
 static ASN1_VALUE *b64_read_asn1(BIO *bio, const ASN1_ITEM *it, ASN1_VALUE **x,

--- a/doc/man3/d2i_X509.pod
+++ b/doc/man3/d2i_X509.pod
@@ -588,8 +588,9 @@ freed in the event of error and I<*a> is set to NULL.
 B<i2d_I<TYPE>>() returns the number of bytes successfully encoded or a negative
 value if an error occurs.
 
-B<i2d_I<TYPE>_bio>() and B<i2d_I<TYPE>_fp>() return 1 for success and 0 if an
-error occurs.
+B<i2d_I<TYPE>_bio>() and B<i2d_I<TYPE>_fp>(),
+as well as i2d_ASN1_bio_stream(),
+return 1 for success and 0 if an error occurs.
 
 =head1 EXAMPLES
 


### PR DESCRIPTION
For many error cases the CMS app so far does not provide any user-level error message.
And in case something goes wrong when outputting the CMS structure (e.g., due to I/O failure)
or when signing a CMS structure for instance due to a provider failure,
typically no error is reported at all and an incomplete output is generated, such as:
```
MIME-Version: 1.0
Content-Type: multipart/signed; protocol="application/pkcs7-signature"; micalg="sha-256"; boundary="----06E11A8E98630D2D320E8F2EAFD28032"

This is an S/MIME signed message

------06E11A8E98630D2D320E8F2EAFD28032
12345
```

This PR fixes the above mentioned issues by adding error messages in `apps/cms.c` and adding 
error checking for calls to `BIO_printf()`, `BIO_puts()`, and `asn1_write_micalg()` in `SMIME_write_ASN1_ex()`. 
It also removes several needless extra `ERR_print_errors()` calls and 
clarifies the treatment of the `ret` variable in `cms_main()` in `apps/cms.c`.
