### PR TITLE
Fix doc of `ASN1_item_sign*()` and `OSSL_SIGNATURE_PARAM_ALGORITHM_ID`

### DIFF
--- a/doc/man3/ASN1_item_sign.pod
+++ b/doc/man3/ASN1_item_sign.pod
@@ -49,14 +49,18 @@ I<ASN1_ITEM_rptr(X509_REQ_INFO)>, and I<ASN1_ITEM_rptr(X509_CRL_INFO)>.
 I<signature>, <algor1>, and I<algor2> are essentially output parameters.
 The generated signature is set into I<signature>,
 which must have been allocated beforehand, e.g., using I<ASN1_BIT_STRING_new()>.
-The <algor1> and I<algor2> parameters are optional and support outputting up to two
-B<X509_ALGOR> values representing the signature algorithm (including any digest
-algorithm and/or further parameters), which is useful for structures like X.509
-that must contain the same signature algorithm information in two places.
+This may happen indirectly, for instance by having an ASN.1 structure like
+B<X509> that includes a non-optional signature field of type B<ASN1_BIT_STRING>.
+The <algor1> and I<algor2> parameters are optional and support outputting
+up to two B<X509_ALGOR> values representing the signature algorithm
+(typically including a digest algorithm, and/or possibly other parameters),
+which is useful for structures like B<X509> that must contain the same signature
+algorithm information in two places: I<sig_alg> and I<cert_info.signature>.
 Each of the <algor1> and I<algor2> pointers may be NULL, otherwise
-the caller must have allocated it beforehand (e.g., using I<X509_ALGOR_new()>),
-and the ASN1_item_sign_ex() function sets into it the signature algorithm.
-This is done before generating the signature value and setting it into I<signature>.
+they must must have been allocated beforehand (e.g., using I<X509_ALGOR_new()>,
+or indirectly like for the B<X509>fields I<sig_alg> and I<cert_info.signature>),
+and the ASN1_item_sign_ex() function sets into it the signature algorithm. This
+is done before generating the signature value and setting it into I<signature>.
 
 The B<OSSL_LIB_CTX> specified in I<libctx> and the property query string
 specified in I<props> are used when searching for algorithms in providers.

--- a/doc/man3/ASN1_item_sign.pod
+++ b/doc/man3/ASN1_item_sign.pod
@@ -57,7 +57,7 @@ up to two B<X509_ALGOR> values representing the signature algorithm
 which is useful for structures like B<X509> that must contain the same signature
 algorithm information in two places: I<sig_alg> and I<cert_info.signature>.
 Each of the <algor1> and I<algor2> pointers may be NULL, otherwise
-they must must have been allocated beforehand (e.g., using I<X509_ALGOR_new()>,
+they must have been allocated beforehand (e.g., using I<X509_ALGOR_new()>,
 or indirectly like for the B<X509>fields I<sig_alg> and I<cert_info.signature>),
 and the ASN1_item_sign_ex() function sets into it the signature algorithm. This
 is done before generating the signature value and setting it into I<signature>.

--- a/doc/man3/ASN1_item_sign.pod
+++ b/doc/man3/ASN1_item_sign.pod
@@ -40,24 +40,28 @@ ASN1 sign and verify
 =head1 DESCRIPTION
 
 ASN1_item_sign_ex() is used to sign arbitrary ASN1 data using a data object
-I<data>, the ASN.1 structure I<it>, private key I<pkey> and message digest I<md>.
-The data that is signed is formed by taking the data object in I<data> and
-converting it to der format using the ASN.1 structure I<it>.
-The I<data> that will be signed, and a structure containing the signature may
-both have a copy of the B<X509_ALGOR>. The ASN1_item_sign_ex() function will
-write the correct B<X509_ALGOR> to the structs based on the algorithms and
-parameters that have been set up. If one of I<algor1> or I<algor2> points to the
-B<X509_ALGOR> of the I<data> to be signed, then that B<X509_ALGOR> will first be
-written before the signature is generated.
-Examples of valid values that can be used by the ASN.1 structure I<it> are
-ASN1_ITEM_rptr(X509_CINF), ASN1_ITEM_rptr(X509_REQ_INFO) and
-ASN1_ITEM_rptr(X509_CRL_INFO).
+I<data>, the ASN.1 structure I<it>, private key I<pkey>, and message digest I<md>.
+The data to be signed is formed by taking the data object in I<data>
+and converting it to DER format using the ASN.1 type structure I<it>.
+Examples of values that can be used for I<it> are I<ASN1_ITEM_rptr(X509_CINF)>,
+I<ASN1_ITEM_rptr(X509_REQ_INFO)>, and I<ASN1_ITEM_rptr(X509_CRL_INFO)>.
+
+I<signature>, <algor1>, and I<algor2> are essentially output parameters.
+The generated signature is set into I<signature>,
+which must have been allocated beforehand, e.g., using I<ASN1_BIT_STRING_new()>.
+The <algor1> and I<algor2> parameters are optional and support outputting up to two
+B<X509_ALGOR> values representing the signature algorithm (including any digest
+algorithm and/or further parameters), which is useful for structures like X.509
+that must contain the same signature algorithm information in two places.
+Each of the <algor1> and I<algor2> pointers may be NULL, otherwise
+the caller must have allocated it beforehand (e.g., using I<X509_ALGOR_new()>),
+and the ASN1_item_sign_ex() function sets into it the signature algorithm.
+This is done before generating the signature value and setting it into I<signature>.
+
 The B<OSSL_LIB_CTX> specified in I<libctx> and the property query string
 specified in I<props> are used when searching for algorithms in providers.
-The generated signature is set into I<signature>.
 The optional parameter I<id> can be NULL, but can be set for special key types.
-See EVP_PKEY_CTX_set1_id() for further info. The output parameters <algor1> and
-I<algor2> are ignored if they are NULL.
+See EVP_PKEY_CTX_set1_id() for further info.
 
 ASN1_item_sign() is similar to ASN1_item_sign_ex() but uses default values of
 NULL for the I<id>, I<libctx> and I<propq>.

--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -470,8 +470,13 @@ The length of the "digest-size" parameter should not exceed that of a B<size_t>.
 
 =item "algorithm-id" (B<OSSL_SIGNATURE_PARAM_ALGORITHM_ID>) <octet string>
 
-Gets the DER encoded AlgorithmIdentifier that corresponds to the combination of
-signature algorithm and digest algorithm for the signature operation.
+Gets the DER-encoded AlgorithmIdentifier for the signature operation.
+This typically corresponds to the combination of a digest algorithm
+with a purely asymmetric signature algorithm, such as SHA256WithECDSA.
+
+The L<ASN1_item_sign_ctx(3)> relies on this operation and is used by
+many other functions signing ASN.1 structures such as X.509 certificates,
+certificate requests, and CRLs, as well as OCSP, CMP, and CMS messages.
 
 =item "nonce-type" (B<OSSL_SIGNATURE_PARAM_NONCE_TYPE>) <unsigned integer>
 
@@ -603,7 +608,8 @@ All other functions should return 1 for success or 0 on error.
 
 =head1 SEE ALSO
 
-L<provider(7)>
+L<provider(7)>,
+L<ASN1_item_sign_ctx(3)>
 
 =head1 HISTORY
 

--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -378,7 +378,7 @@ should be written to I<*siglen>. If I<sig> is NULL then the maximum length of
 the signature should be written to I<*siglen>.
 
 OSSL_FUNC_signature_digest_sign() implements a "one shot" digest sign operation
-previously started through OSSL_FUNC_signature_digeset_sign_init(). A previously
+previously started through OSSL_FUNC_signature_digest_sign_init(). A previously
 initialised signature context is passed in the I<ctx> parameter. The data to be
 signed is in I<tbs> which should be I<tbslen> bytes long. Unless I<sig> is NULL,
 the signature should be written to the location pointed to by the I<sig>
@@ -388,7 +388,7 @@ length of the signature should be written to I<*siglen>.
 
 =head2 Digest Verify Functions
 
-OSSL_FUNC_signature_digeset_verify_init() initialises a context for verifying given a
+OSSL_FUNC_signature_digest_verify_init() initialises a context for verifying given a
 provider side verification context in the I<ctx> parameter, and a pointer to a
 provider key object in the I<provkey> parameter.
 The I<params>, if not NULL, should be set on the context in a manner similar to
@@ -412,7 +412,7 @@ verification context is passed in the I<ctx> parameter. The signature to be
 verified is in I<sig> which is I<siglen> bytes long.
 
 OSSL_FUNC_signature_digest_verify() implements a "one shot" digest verify operation
-previously started through OSSL_FUNC_signature_digeset_verify_init(). A previously
+previously started through OSSL_FUNC_signature_digest_verify_init(). A previously
 initialised verification context is passed in the I<ctx> parameter. The data to be
 verified is in I<tbs> which should be I<tbslen> bytes long. The signature to be
 verified is in I<sig> which is I<siglen> bytes long.


### PR DESCRIPTION
This provides a fix for the documentation part of #22932:
* `provider-signature.pod`: fix doc of `OSSL_SIGNATURE_PARAM_ALGORITHM_ID`, now describing its importance
* `ASN1_item_sign.pod`: fix description of the `algor1`, `algor2`, and `signature` in/out-parameters, which so far was very hard to understand correctly

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
