### PR TITLE
RISC-V: Provide generic optimized SHA-256 implementation for rv64gc

### DIFF
--- a/crypto/perlasm/riscv.pm
+++ b/crypto/perlasm/riscv.pm
@@ -2,7 +2,7 @@
 # This file is dual-licensed, meaning that you can use it under your
 # choice of either of the following two licenses:
 #
-# Copyright 2023-2024 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2023-2025 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License"). You can obtain
 # a copy in the file LICENSE in the source distribution or at
@@ -13,6 +13,7 @@
 # Copyright (c) 2023, Christoph Müllner <christoph.muellner@vrull.eu>
 # Copyright (c) 2023, Jerry Shih <jerry.shih@sifive.com>
 # Copyright (c) 2023, Phoebe Chen <phoebe.chen@sifive.com>
+# Copyright (c) 2025, Julian Zhu <julian.oerv@isrc.iscas.ac.cn>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -274,6 +275,18 @@ sub sd_rev8_rv64i {
         sb      $tmp, $off0($addr)
 ___
     return $seq;
+}
+
+sub roriw_rv64i {
+    my (
+        $rd, $rs, $tmp1, $tmp2, $imm,
+    ) = @_;
+    my $code=<<___;
+    srliw $tmp1, $rs, $imm
+    slliw $tmp2, $rs, (32-$imm)
+    or $rd, $tmp1, $tmp2
+___
+    return $code;
 }
 
 # Scalar crypto instructions

--- a/crypto/sha/build.info
+++ b/crypto/sha/build.info
@@ -46,7 +46,7 @@ IF[{- !$disabled{asm} -}]
   $SHA1ASM_c64xplus=sha1-c64xplus.s sha256-c64xplus.s sha512-c64xplus.s
   $SHA1DEF_c64xplus=SHA1_ASM SHA256_ASM SHA512_ASM
 
-  $SHA1ASM_riscv64=sha_riscv.c sha256-riscv64-zbb.S sha256-riscv64-zvkb-zvknha_or_zvknhb.S sha512-riscv64-zbb.S sha512-riscv64-zvkb-zvknhb.S
+  $SHA1ASM_riscv64=sha_riscv.c sha256-riscv64.S sha256-riscv64-zbb.S sha256-riscv64-zvkb-zvknha_or_zvknhb.S sha512-riscv64-zbb.S sha512-riscv64-zvkb-zvknhb.S
   $SHA1DEF_riscv64=SHA256_ASM INCLUDE_C_SHA256 SHA512_ASM INCLUDE_C_SHA512
 
   # Now that we have defined all the arch specific variables, use the
@@ -170,7 +170,8 @@ GENERATE[sha1-c64xplus.S]=asm/sha1-c64xplus.pl
 GENERATE[sha256-c64xplus.S]=asm/sha256-c64xplus.pl
 GENERATE[sha512-c64xplus.S]=asm/sha512-c64xplus.pl
 
-GENERATE[sha256-riscv64-zbb.S]=asm/sha256-riscv64-zbb.pl
+GENERATE[sha256-riscv64.S]=asm/sha256-riscv64-zbb.pl
+GENERATE[sha256-riscv64-zbb.S]=asm/sha256-riscv64-zbb.pl zbb
 GENERATE[sha256-riscv64-zvkb-zvknha_or_zvknhb.S]=asm/sha256-riscv64-zvkb-zvknha_or_zvknhb.pl
 GENERATE[sha512-riscv64-zbb.S]=asm/sha512-riscv64-zbb.pl
 GENERATE[sha512-riscv64-zvkb-zvknhb.S]=asm/sha512-riscv64-zvkb-zvknhb.pl

--- a/crypto/sha/sha_riscv.c
+++ b/crypto/sha/sha_riscv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2023-2025 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -17,7 +17,7 @@
 void sha256_block_data_order_zvkb_zvknha_or_zvknhb(void *ctx, const void *in,
                                                    size_t num);
 void sha256_block_data_order_zbb(void *ctx, const void *in, size_t num);
-void sha256_block_data_order_c(void *ctx, const void *in, size_t num);
+void sha256_block_data_order_riscv64(void *ctx, const void *in, size_t num);
 void sha256_block_data_order(SHA256_CTX *ctx, const void *in, size_t num);
 
 void sha256_block_data_order(SHA256_CTX *ctx, const void *in, size_t num)
@@ -28,7 +28,7 @@ void sha256_block_data_order(SHA256_CTX *ctx, const void *in, size_t num)
     } else if (RISCV_HAS_ZBB()) {
         sha256_block_data_order_zbb(ctx, in, num);
     } else {
-        sha256_block_data_order_c(ctx, in, num);
+        sha256_block_data_order_riscv64(ctx, in, num);
     }
 }
 


### PR DESCRIPTION
This PR provides a hand-written assembly SHA-256 for rv64gc.


Testing environment:
CPU: eic770x (SiFive P550)
Linux boot 6.6.18-2.oe2403.riscv64 #1 SMP Thu Nov  7 08:15:29 UTC 2024 riscv64 GNU/Linux
gcc version 14.2.0 (Debian 14.2.0-19)

Benchmark result:

| Implementation | 16 bytes | 64 bytes | 256 bytes | 1024 bytes | 8192 bytes | 16384 bytes |
|---------------|----------|----------|-----------|------------|------------|-------------|
| C + 64gc     | 7799.76  | 21089.98  | 41185.79   | 54075.73   | 59542.19   | 59976.36    |
| ASM       | 9480.27  | 24957.08  | 48294.14   | 63056.90   | 69219.67   | 69713.92    |

Performance relative to Compiler version (Baseline):

| Implementation | 16 bytes | 64 bytes | 256 bytes | 1024 bytes | 8192 bytes | 16384 bytes |
|---------------|----------|----------|-----------|------------|------------|-------------|
| C + 64gc     | 100%     | 100%     | 100%      | 100%       | 100%       | 100%        |
| ASM       | 121.55%  | 118.33%  | 117.27%   | 116.58%    | 116.26%    | 116.21%     |
