### PR TITLE
s390x: Add new machine generation z17

### DIFF
--- a/crypto/s390xcap.c
+++ b/crypto/s390xcap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2023 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2010-2025 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -718,6 +718,111 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex)
      * Implements MSA and MSA1-9 (same as z15, no need to repeat).
      */
 
+    /*-
+     * z17 (2025) - z/Architecture POP
+     * Implements MSA and MSA1-12.
+     */
+    static const struct OPENSSL_s390xcap_st z17 = {
+        /*.stfle  = */{S390X_CAPBIT(S390X_MSA)
+                       | S390X_CAPBIT(S390X_STCKF)
+                       | S390X_CAPBIT(S390X_MSA5),
+                       S390X_CAPBIT(S390X_MSA3)
+                       | S390X_CAPBIT(S390X_MSA4)
+                       | S390X_CAPBIT(S390X_MSA12),
+                       S390X_CAPBIT(S390X_VX)
+                       | S390X_CAPBIT(S390X_VXD)
+                       | S390X_CAPBIT(S390X_VXE)
+                       | S390X_CAPBIT(S390X_MSA8)
+                       | S390X_CAPBIT(S390X_MSA9),
+                       0ULL},
+        /*.kimd   = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_SHA_1)
+                       | S390X_CAPBIT(S390X_SHA_256)
+                       | S390X_CAPBIT(S390X_SHA_512)
+                       | S390X_CAPBIT(S390X_SHA3_224)
+                       | S390X_CAPBIT(S390X_SHA3_256)
+                       | S390X_CAPBIT(S390X_SHA3_384)
+                       | S390X_CAPBIT(S390X_SHA3_512)
+                       | S390X_CAPBIT(S390X_SHAKE_128)
+                       | S390X_CAPBIT(S390X_SHAKE_256),
+                       S390X_CAPBIT(S390X_GHASH)},
+        /*.klmd   = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_SHA_1)
+                       | S390X_CAPBIT(S390X_SHA_256)
+                       | S390X_CAPBIT(S390X_SHA_512)
+                       | S390X_CAPBIT(S390X_SHA3_224)
+                       | S390X_CAPBIT(S390X_SHA3_256)
+                       | S390X_CAPBIT(S390X_SHA3_384)
+                       | S390X_CAPBIT(S390X_SHA3_512)
+                       | S390X_CAPBIT(S390X_SHAKE_128)
+                       | S390X_CAPBIT(S390X_SHAKE_256),
+                       0ULL},
+        /*.km     = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_AES_128)
+                       | S390X_CAPBIT(S390X_AES_192)
+                       | S390X_CAPBIT(S390X_AES_256)
+                       | S390X_CAPBIT(S390X_XTS_AES_128)
+                       | S390X_CAPBIT(S390X_XTS_AES_256),
+                       S390X_CAPBIT(S390X_XTS_AES_128_MSA10)
+                       | S390X_CAPBIT(S390X_XTS_AES_256_MSA10)},
+        /*.kmc    = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_AES_128)
+                       | S390X_CAPBIT(S390X_AES_192)
+                       | S390X_CAPBIT(S390X_AES_256),
+                       0ULL},
+        /*.kmac   = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_AES_128)
+                       | S390X_CAPBIT(S390X_AES_192)
+                       | S390X_CAPBIT(S390X_AES_256),
+                       S390X_CAPBIT(S390X_HMAC_SHA_224)
+                       | S390X_CAPBIT(S390X_HMAC_SHA_256)
+                       | S390X_CAPBIT(S390X_HMAC_SHA_384)
+                       | S390X_CAPBIT(S390X_HMAC_SHA_512)},
+        /*.kmctr  = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_AES_128)
+                       | S390X_CAPBIT(S390X_AES_192)
+                       | S390X_CAPBIT(S390X_AES_256),
+                       0ULL},
+        /*.kmo    = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_AES_128)
+                       | S390X_CAPBIT(S390X_AES_192)
+                       | S390X_CAPBIT(S390X_AES_256),
+                       0ULL},
+        /*.kmf    = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_AES_128)
+                       | S390X_CAPBIT(S390X_AES_192)
+                       | S390X_CAPBIT(S390X_AES_256),
+                       0ULL},
+        /*.prno   = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_SHA_512_DRNG),
+                       S390X_CAPBIT(S390X_TRNG)},
+        /*.kma    = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_AES_128)
+                       | S390X_CAPBIT(S390X_AES_192)
+                       | S390X_CAPBIT(S390X_AES_256),
+                       0ULL},
+        /*.pcc    = */{S390X_CAPBIT(S390X_QUERY),
+                       S390X_CAPBIT(S390X_SCALAR_MULTIPLY_P256)
+                       | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_P384)
+                       | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_P521)
+                       | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_ED25519)
+                       | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_ED448)
+                       | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_X25519)
+                       | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_X448)},
+        /*.kdsa   = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_ECDSA_VERIFY_P256)
+                       | S390X_CAPBIT(S390X_ECDSA_VERIFY_P384)
+                       | S390X_CAPBIT(S390X_ECDSA_VERIFY_P521)
+                       | S390X_CAPBIT(S390X_ECDSA_SIGN_P256)
+                       | S390X_CAPBIT(S390X_ECDSA_SIGN_P384)
+                       | S390X_CAPBIT(S390X_ECDSA_SIGN_P521)
+                       | S390X_CAPBIT(S390X_EDDSA_VERIFY_ED25519)
+                       | S390X_CAPBIT(S390X_EDDSA_VERIFY_ED448)
+                       | S390X_CAPBIT(S390X_EDDSA_SIGN_ED25519)
+                       | S390X_CAPBIT(S390X_EDDSA_SIGN_ED448),
+                       0ULL},
+    };
+
     char *tok_begin, *tok_end, *buff, tok[S390X_STFLE_MAX][LEN + 1];
     int rc, off, i, n;
 
@@ -773,6 +878,7 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex)
         else if TOK_CPU(z14)
         else if TOK_CPU(z15)
         else if TOK_CPU_ALIAS(z16, z15)
+        else if TOK_CPU(z17)
 
         /* nocex to deactivate cex support */
         else if (sscanf(tok_begin, " %" STR(LEN) "s %" STR(LEN) "s ",

--- a/doc/man3/OPENSSL_s390xcap.pod
+++ b/doc/man3/OPENSSL_s390xcap.pod
@@ -35,7 +35,7 @@ The name of a processor generation. A bit in the environment variable's
 mask is set to one if and only if the specified processor generation
 implements the corresponding instruction set extension. Possible values
 are B<z900>, B<z990>, B<z9>, B<z10>, B<z196>, B<zEC12>, B<z13>, B<z14>,
-B<z15>, and B<z16>.
+B<z15>, B<z16>, and B<z17>.
 
 =item <string>:<mask>:<mask>
 


### PR DESCRIPTION
Allow to specify "z17" as machine generation in environment variable OPENSSL_s390xcap.
