### PR TITLE
Fix winstore provider to work with recent decoder changes

### DIFF
--- a/providers/implementations/storemgmt/winstore_store.c
+++ b/providers/implementations/storemgmt/winstore_store.c
@@ -183,6 +183,7 @@ static int setup_decoder(struct winstore_ctx_st *ctx)
 {
     OSSL_LIB_CTX *libctx = ossl_prov_ctx_get0_libctx(ctx->provctx);
     const OSSL_ALGORITHM *to_algo = NULL;
+    const char *input_structure = NULL;
 
     if (ctx->dctx != NULL)
         return 1;
@@ -198,7 +199,8 @@ static int setup_decoder(struct winstore_ctx_st *ctx)
         goto err;
     }
 
-    if (!OSSL_DECODER_CTX_set_input_structure(ctx->dctx, "Certificate")) {
+    input_structure = "Certificate";
+    if (!OSSL_DECODER_CTX_set_input_structure(ctx->dctx, input_structure)) {
         ERR_raise(ERR_LIB_PROV, ERR_R_OSSL_DECODER_LIB);
         goto err;
     }
@@ -217,7 +219,8 @@ static int setup_decoder(struct winstore_ctx_st *ctx)
          */
         to_obj = ossl_decoder_from_algorithm(0, to_algo, NULL);
         if (to_obj != NULL)
-            to_obj_inst = ossl_decoder_instance_new(to_obj, ctx->provctx);
+            to_obj_inst = ossl_decoder_instance_new_forprov(to_obj, ctx->provctx,
+                                                            input_structure);
 
         OSSL_DECODER_free(to_obj);
         if (to_obj_inst == NULL)


### PR DESCRIPTION
Changes made recently in commit 31b5f3f made changes to how a default decoder was created, in which ossl_decoder_instance_new() started returning null.  Other storemgmt providers were updated to start using ossl_decoder_instance_new_forprov, but the winstore manager seems to have got missed.  Fix it up properly

Fixes #27355

