### PR TITLE
create SSL_listen_ex api

### DIFF
--- a/include/internal/quic_channel.h
+++ b/include/internal/quic_channel.h
@@ -319,6 +319,9 @@ OSSL_STATM *ossl_quic_channel_get_statm(QUIC_CHANNEL *ch);
 /* Gets the TLS handshake layer used with the channel. */
 SSL *ossl_quic_channel_get0_tls(QUIC_CHANNEL *ch);
 
+/* Sets the TLS handshake layer used for the channel */
+void ossl_quic_channel_set0_tls(QUIC_CHANNEL *ch, SSL *ssl);
+
 /* Gets the channels short header connection id length */
 size_t ossl_quic_channel_get_short_header_conn_id_len(QUIC_CHANNEL *ch);
 

--- a/include/internal/quic_port.h
+++ b/include/internal/quic_port.h
@@ -159,6 +159,11 @@ size_t ossl_quic_port_get_num_incoming_channels(const QUIC_PORT *port);
 /* Sets if incoming connections should currently be allowed. */
 void ossl_quic_port_set_allow_incoming(QUIC_PORT *port, int allow_incoming);
 
+/* Sets flag to indicate we are using SSL_listen_ex to get connections */
+void ossl_quic_port_set_using_peeloff(QUIC_PORT *port, int using_peeloff);
+
+int ossl_quic_port_get_using_peeloff(QUIC_PORT *port);
+
 /* Returns 1 if we are using addressed mode on the read side. */
 int ossl_quic_port_is_addressed_r(const QUIC_PORT *port);
 

--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -120,6 +120,7 @@ __owur int ossl_quic_set_value_uint(SSL *s, uint32_t class_, uint32_t id,
 __owur SSL *ossl_quic_accept_connection(SSL *ssl, uint64_t flags);
 __owur size_t ossl_quic_get_accept_connection_queue_len(SSL *ssl);
 __owur int ossl_quic_listen(SSL *ssl);
+__owur int ossl_quic_peeloff_conn(SSL *listener, SSL *new_conn);
 
 __owur int ossl_quic_stream_reset(SSL *ssl,
                                   const SSL_STREAM_RESET_ARGS *args,

--- a/include/internal/ssl_unwrap.h
+++ b/include/internal/ssl_unwrap.h
@@ -51,7 +51,8 @@ struct ssl_connection_st *ossl_quic_obj_get0_handshake_layer(QUIC_OBJ *obj);
 #  define IS_QUIC_METHOD(m) \
     ((m) == OSSL_QUIC_client_method() || \
      (m) == OSSL_QUIC_client_thread_method() || \
-     (m) == OSSL_QUIC_server_method())
+     (m) == OSSL_QUIC_server_method() || \
+     (m) == OSSL_QUIC_method())
 
 #  define IS_QUIC_CTX(ctx)          IS_QUIC_METHOD((ctx)->method)
 

--- a/include/openssl/quic.h
+++ b/include/openssl/quic.h
@@ -67,6 +67,11 @@ __owur const SSL_METHOD *OSSL_QUIC_client_thread_method(void);
  */
 __owur const SSL_METHOD *OSSL_QUIC_server_method(void);
 
+/*
+ * Method used for QUIC client/server connection
+ */
+__owur const SSL_METHOD *OSSL_QUIC_method(void);
+
 #  ifdef __cplusplus
 }
 #  endif

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2571,6 +2571,9 @@ void SSL_trace(int write_p, int version, int content_type,
 int DTLSv1_listen(SSL *s, BIO_ADDR *client);
 # endif
 
+
+__owur int SSL_listen_ex(SSL *listener, SSL *new_conn);
+
 # ifndef OPENSSL_NO_CT
 
 /*

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -556,6 +556,12 @@ SSL *ossl_quic_channel_get0_tls(QUIC_CHANNEL *ch)
     return ch->tls;
 }
 
+void ossl_quic_channel_set0_tls(QUIC_CHANNEL *ch, SSL *ssl)
+{
+    SSL_free(ch->tls);
+    ch->tls = ssl;
+}
+
 static void free_buf_mem(unsigned char *buf, size_t buf_len, void *arg)
 {
     BUF_MEM_free((BUF_MEM *)arg);

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4529,6 +4529,31 @@ int ossl_quic_listen(SSL *ssl)
     return ret;
 }
 
+QUIC_TAKES_LOCK
+int ossl_quic_peeloff_conn(SSL *listener, SSL *new_conn)
+{
+    QCTX lctx;
+    QCTX cctx;
+    QUIC_CHANNEL *new_ch;
+    int ret = 0;
+
+    if (!expect_quic_listener(listener, &lctx))
+        return 0;
+
+    if (!expect_quic_cs(new_conn, &cctx))
+        return 0;
+
+    qctx_lock_for_io(&lctx);
+    new_ch = ossl_quic_port_pop_incoming(lctx.ql->port);
+    if (new_ch != NULL) {
+        /*
+         * Do our cloning work here
+         */
+    }
+    qctx_unlock(&lctx);
+    return ret;
+}
+
 /*
  * SSL_accept_connection
  * ---------------------

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4544,12 +4544,21 @@ int ossl_quic_peeloff_conn(SSL *listener, SSL *new_conn)
         return 0;
 
     qctx_lock_for_io(&lctx);
+    if (ossl_quic_port_get_using_peeloff(lctx.ql->port) == -1) {
+        QUIC_RAISE_NON_NORMAL_ERROR(NULL, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED,
+                                    "This listener is using SSL_accept_connection");
+        ret = -1;
+        goto out;
+    }
+
+    ossl_quic_port_set_using_peeloff(lctx.ql->port, 1);
     new_ch = ossl_quic_port_pop_incoming(lctx.ql->port);
     if (new_ch != NULL) {
         /*
          * Do our cloning work here
          */
     }
+out:
     qctx_unlock(&lctx);
     return ret;
 }
@@ -4589,6 +4598,14 @@ SSL *ossl_quic_accept_connection(SSL *ssl, uint64_t flags)
 
     if (!ql_listen(ctx.ql))
         goto out;
+
+    if (ossl_quic_get_using_peeloff(ctx.ql->port) == 1) {
+        QUIC_RAISE_NON_NORMAL_ERROR(NULL, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED,
+                                    "This listener is using SSL_accept_ex");
+        goto out; 
+    }
+    
+    ossl_quic_set_using_peeloff(ctx.ql->port, -1);
 
     /* Wait for an incoming connection if needed. */
     new_ch = ossl_quic_port_pop_incoming(ctx.ql->port);

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4599,13 +4599,13 @@ SSL *ossl_quic_accept_connection(SSL *ssl, uint64_t flags)
     if (!ql_listen(ctx.ql))
         goto out;
 
-    if (ossl_quic_get_using_peeloff(ctx.ql->port) == 1) {
+    if (ossl_quic_port_get_using_peeloff(ctx.ql->port) == 1) {
         QUIC_RAISE_NON_NORMAL_ERROR(NULL, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED,
                                     "This listener is using SSL_accept_ex");
         goto out; 
     }
     
-    ossl_quic_set_using_peeloff(ctx.ql->port, -1);
+    ossl_quic_port_set_using_peeloff(ctx.ql->port, -1);
 
     /* Wait for an incoming connection if needed. */
     new_ch = ossl_quic_port_pop_incoming(ctx.ql->port);

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4535,6 +4535,9 @@ int ossl_quic_peeloff_conn(SSL *listener, SSL *new_conn)
     QCTX lctx;
     QCTX cctx;
     QUIC_CHANNEL *new_ch;
+    QUIC_CONNECTION *qc = NULL;
+    QUIC_LISTENER *ql = NULL;
+    SSL *tls = NULL;
     int ret = 0;
 
     if (!expect_quic_listener(listener, &lctx))
@@ -4554,9 +4557,37 @@ int ossl_quic_peeloff_conn(SSL *listener, SSL *new_conn)
     ossl_quic_port_set_using_peeloff(lctx.ql->port, 1);
     new_ch = ossl_quic_port_pop_incoming(lctx.ql->port);
     if (new_ch != NULL) {
-        /*
-         * Do our cloning work here
-         */
+        qc = cctx.qc;
+        ql = lctx.ql;
+        ossl_quic_channel_free(qc->ch);
+        ossl_quic_port_free(qc->port);
+        ossl_quic_engine_free(qc->engine);
+        qc->obj.engine              = ql->engine;
+        qc->engine                  = ql->engine;
+        qc->port                    = ql->port;
+        qc->pending                 = 1;
+#if defined(OPENSSL_THREADS)
+        ossl_crypto_mutex_free(&qc->mutex);
+        qc->mutex                   = ql->mutex;
+#endif
+        qc->ch                      = new_ch;
+        tls = ossl_ssl_connection_new_int(ossl_quic_port_get_channel_ctx(lctx.ql->port),
+                                          new_conn, TLS_method());
+        if (tls == NULL)
+            goto out;
+        SSL_free(qc->tls);
+        ossl_quic_channel_set0_tls(new_ch, tls);
+        qc->tls = tls;
+        ossl_quic_channel_get_peer_addr(new_ch, &qc->init_peer_addr); /* best effort */
+        qc->started                 = 1;
+        qc->as_server               = 1;
+        qc->as_server_state         = 1;
+        qc->default_stream_mode     = SSL_DEFAULT_STREAM_MODE_AUTO_BIDI;
+        qc->default_ssl_options     = ql->obj.ssl.ctx->options & OSSL_QUIC_PERMITTED_OPTIONS;
+        qc->incoming_stream_policy  = SSL_INCOMING_STREAM_POLICY_AUTO;
+        qc->last_error              = SSL_ERROR_NONE;
+        qc_update_reject_policy(qc);
+        ret = 1;
     }
 out:
     qctx_unlock(&lctx);

--- a/ssl/quic/quic_method.c
+++ b/ssl/quic/quic_method.c
@@ -11,6 +11,16 @@
 #include <openssl/objects.h>
 #include "quic_local.h"
 
+/*
+ * NOTE: An endpoint method can be used to create a quic connection
+ * for use as a client or server, based on a subsequent call to 
+ * SSL_set_[accept|connect]_state
+ */
+IMPLEMENT_quic_meth_func(OSSL_QUIC_ANY_VERSION,
+                         OSSL_QUIC_method,
+                         ssl_undefined_function,
+                         ossl_quic_connect, ssl3_undef_enc_method)
+
 IMPLEMENT_quic_meth_func(OSSL_QUIC_ANY_VERSION,
                          OSSL_QUIC_client_method,
                          ssl_undefined_function,

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -529,23 +529,34 @@ static QUIC_CHANNEL *port_make_channel(QUIC_PORT *port, SSL *tls, OSSL_QRX *qrx,
     if (ch == NULL)
         return NULL;
 
-    /*
-     * Fixup the channel tls connection here before we init the channel
-     */
-    ch->tls = (tls != NULL) ? tls : port_new_handshake_layer(port, ch);
-
+    if (tls != NULL) {
+        ch->tls = tls;
+    } else {
+        if (ossl_quic_port_get_using_peeloff(port) <= 0) {
+            ossl_quic_port_set_using_peeloff(port, -1);
+            /*
+             * We're using the normal SSL_accept_connection_path
+             */
+            ch->tls = port_new_handshake_layer(port, ch);
 #ifndef OPENSSL_NO_QLOG
-    /*
-     * If we're using qlog, make sure the tls get further configured properly
-     */
-    ch->use_qlog = 1;
-    if (ch->tls->ctx->qlog_title != NULL) {
-        if ((ch->qlog_title = OPENSSL_strdup(ch->tls->ctx->qlog_title)) == NULL) {
-            OPENSSL_free(ch);
-            return NULL;
+            /*
+             * If we're using qlog, make sure the tls get further configured properly
+             */
+            ch->use_qlog = 1;
+            if (ch->tls->ctx->qlog_title != NULL) {
+                if ((ch->qlog_title = OPENSSL_strdup(ch->tls->ctx->qlog_title)) == NULL) {
+                    OPENSSL_free(ch);
+                    return NULL;
+                }
+            }
+#endif
+        } else {
+            /*
+             * We're deferring user ssl creation until SSL_accept_ex is called
+             */
+            ch->tls = NULL;
         }
     }
-#endif
 
     /*
      * And finally init the channel struct

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -640,6 +640,16 @@ void ossl_quic_port_set_allow_incoming(QUIC_PORT *port, int allow_incoming)
     port->allow_incoming = allow_incoming;
 }
 
+void ossl_quic_port_set_using_peeloff(QUIC_PORT *port, int using_peeloff)
+{
+    port->using_peeloff = using_peeloff;
+}
+
+int ossl_quic_port_get_using_peeloff(QUIC_PORT *port)
+{
+    return port->using_peeloff;
+}
+
 /*
  * QUIC Port: Ticker-Mutator
  * =========================

--- a/ssl/quic/quic_port_local.h
+++ b/ssl/quic/quic_port_local.h
@@ -114,6 +114,9 @@ struct quic_port_st {
     /* Has the BIO been changed since we last updated reactor pollability? */
     unsigned int                    bio_changed                     : 1;
 
+    /* Are we using SSL_listen_ex to peeloff connections */
+    unsigned int                    using_peeloff;
+
     /* AES-256 GCM context for token encryption */
     EVP_CIPHER_CTX *token_ctx;
 };

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -8042,8 +8042,9 @@ size_t SSL_get_accept_connection_queue_len(SSL *ssl)
 int SSL_listen_ex(SSL *listener, SSL *new_conn)
 {
 #ifndef OPENSSL_NO_QUIC
-    if (!IS_QUIC(listener) || !IS_QUIC(new_conn))
+    if (IS_QUIC(listener) && IS_QUIC(new_conn))
         return ossl_quic_peeloff_conn(listener, new_conn);
+    return 0;
 #else
     return 0;
 #endif

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -8039,6 +8039,16 @@ size_t SSL_get_accept_connection_queue_len(SSL *ssl)
 #endif
 }
 
+int SSL_listen_ex(SSL *listener, SSL *new_conn)
+{
+#ifndef OPENSSL_NO_QUIC
+    if (!IS_QUIC(listener) || !IS_QUIC(new_conn))
+        return ossl_quic_peeloff_conn(listener, new_conn);
+#else
+    return 0;
+#endif
+}
+
 int SSL_listen(SSL *ssl)
 {
 #ifndef OPENSSL_NO_QUIC

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -33,6 +33,12 @@ static char *datadir = NULL;
 
 static int is_fips = 0;
 
+static BIO_ADDR *create_addr(struct in_addr *ina, short int port);
+static int bio_addr_bind(BIO *bio, BIO_ADDR *addr);
+static SSL *ql_create(SSL_CTX *ssl_ctx, BIO *bio);
+static SSL_CTX *create_server_ctx(void);
+static int qc_init(SSL *qconn, BIO_ADDR *dst_addr);
+
 /* The ssltrace test assumes some options are switched on/off */
 #if !defined(OPENSSL_NO_SSL_TRACE) \
     && defined(OPENSSL_NO_BROTLI) && defined(OPENSSL_NO_ZSTD) \
@@ -966,6 +972,105 @@ err:
     SSL_CTX_free(ctx);
     if (fd >= 0)
         BIO_closesocket(fd);
+    return testresult;
+}
+
+static int test_ssl_listen_ex(void)
+{
+
+    SSL_CTX *lctx = NULL, *sctx = NULL;
+    SSL_CTX *sconnctx = SSL_CTX_new_ex(libctx, NULL, OSSL_QUIC_method());
+    SSL *qlistener = NULL, *qserver = NULL, *qconn = NULL;
+    SSL *sconn = NULL;
+    int testresult = 0;
+    int chk;
+    BIO *lbio = NULL, *sbio = NULL;
+    BIO_ADDR *addr = NULL;
+    struct in_addr ina;
+    int count = 0;
+
+    if (!TEST_ptr(sconnctx))
+        goto err;
+
+    ina.s_addr = htonl(0x1f000001);
+    if (!TEST_ptr(lctx = create_server_ctx())
+        || !TEST_ptr(sctx = create_server_ctx())
+        || !TEST_true(BIO_new_bio_dgram_pair(&lbio, 0, &sbio, 0)))
+        goto err;
+
+    if (!TEST_ptr(addr = create_addr(&ina, 8040)))
+        goto err;
+
+    if (!TEST_true(bio_addr_bind(lbio, addr)))
+        goto err;
+    addr = NULL;
+
+    if (!TEST_ptr(addr = create_addr(&ina, 4080)))
+        goto err;
+
+    if (!TEST_true(bio_addr_bind(sbio, addr)))
+        goto err;
+    addr = NULL;
+
+    qlistener = ql_create(lctx, lbio);
+    lbio = NULL;
+    if (!TEST_ptr(qlistener))
+        goto err;
+
+    qserver = ql_create(sctx, sbio);
+    sbio = NULL;
+    if (!TEST_ptr(qserver))
+        goto err;
+
+    if (!TEST_ptr(qconn = SSL_new_from_listener(qlistener, 0)))
+        goto err;
+
+    if (!TEST_ptr(addr = create_addr(&ina, 4080)))
+        goto err;
+
+    chk = qc_init(qconn, addr);
+    if (!TEST_true(chk))
+        goto err;
+
+    sconn = SSL_new(sconnctx);
+    if (!TEST_ptr(sconn))
+        goto err;
+
+    SSL_listen_ex(qserver, sconn);
+
+
+    for (count = 0; count < 10; count++) {
+        chk = SSL_do_handshake(qconn);
+        if (chk == -1) {
+            SSL_handle_events(qserver);
+            SSL_handle_events(qlistener);
+        }
+        chk = SSL_listen_ex(qserver, sconn);
+        if (chk > 0) {
+            TEST_info("Listener event received\n");
+            break;
+        }
+    }
+
+    
+    if (!TEST_int_gt(chk, 0)) {
+        TEST_info("SSL_do_handshake() failed\n");
+        goto err;
+    }
+
+    testresult = 1;
+ err:
+    SSL_free(sconn);
+    SSL_free(qconn);
+    SSL_free(qlistener);
+    SSL_free(qserver);
+    BIO_free(lbio);
+    BIO_free(sbio);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(lctx);
+    SSL_CTX_free(sconnctx);
+    BIO_ADDR_free(addr);
+
     return testresult;
 }
 
@@ -2768,6 +2873,7 @@ int setup_tests(void)
     ADD_TEST(test_quic_forbidden_options);
     ADD_ALL_TESTS(test_quic_set_fd, 3);
     ADD_TEST(test_bio_ssl);
+    ADD_TEST(test_ssl_listen_ex);
     ADD_TEST(test_back_pressure);
     ADD_TEST(test_multiple_dgrams);
     ADD_ALL_TESTS(test_non_io_retry, 2);


### PR DESCRIPTION
Rough draft of SSL_listen_ex api

Allows for the creation of a 'blank' SSL object using OSSL_QUIC_method(), which can be passed to SSL_listen_ex to allow for quic to poll for inbound connections in a fashion simmilar to DTLS.

Very rough draft, still needs documentation, but it has a rudimentary test in place, which seems to work

##### Checklist
- [ ] documentation is added or updated
- [x] tests are added or updated
