### PR TITLE
Properly skip SM2 evp tests.

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -4274,6 +4274,10 @@ static int is_pkey_disabled(const char *name)
     if (HAS_CASE_PREFIX(name, "DSA"))
         return 1;
 #endif
+#ifdef OPENSSL_NO_SM2
+    if (HAS_CASE_PREFIX(name, "SM2"))
+        return 1;
+#endif
     return 0;
 }
 


### PR DESCRIPTION
In 3.3, with `-no-sm2` configured, `evp_test` fails for `evppkey_sm2.txt`:

```
# ./evp_test -provider default recipes/30-test_evp_data/evppkey_sm2.txt
1..1
    # Subtest: run_file_tests
    1..1
    # INFO:  @ test/testutil/stanza.c:21
    # Reading recipes/30-test_evp_data/evppkey_sm2.txt
    # INFO:  @ test/testutil/stanza.c:122
    # Starting "SM2 tests" tests at line 19
    # INFO:  @ test/evp_test.c:1824
    # skipping, key 'SM2_key1' is disabled
    # INFO:  @ test/evp_test.c:1824
    # skipping, key 'SM2_key1' is disabled
    # INFO:  @ test/evp_test.c:1824
    # skipping, key 'SM2_key1' is disabled
    # INFO:  @ test/evp_test.c:1824
    # skipping, key 'SM2_key1' is disabled
    # INFO:  @ test/evp_test.c:1824
    # skipping, key 'SM2_key1' is disabled
    # INFO:  @ test/evp_test.c:1824
    # skipping, key 'SM2_key1' is disabled
    # INFO:  @ test/evp_test.c:1824
    # skipping, key 'SM2_key1' is disabled
    # INFO:  @ test/evp_test.c:1824
    # skipping, key 'SM2_key1' is disabled
    # INFO:  @ test/testutil/stanza.c:122
    # Starting "SM2 key generation tests" tests at line 78
    # ERROR: (ptr) 'genctx = EVP_PKEY_CTX_new_from_name(libctx, alg, propquery) != NULL' failed @ test/evp_test.c:3263
    # 0x0
    # ERROR:  @ test/evp_test.c:4052
    # unknown KeyGen: SM2
    # 
    # 
    # INFO:  @ test/testutil/stanza.c:32
    # Completed 0 tests with 1 errors and 8 skipped
    # OPENSSL_TEST_RAND_SEED=1744749984
    not ok 1 - iteration 1
# OPENSSL_TEST_RAND_SEED=1744749984
not ok 1 - run_file_tests
```

For 3.4+, this was fixed with https://github.com/openssl/openssl/commit/2a53830958b1e90231742e1d8ae0523d463560e3, but the patch overall does not apply cleanly to 3.3, which is what we use in [AzureLinux](https://github.com/microsoft/azurelinux/blob/5e37eeb85857cb482bb555f9abee78a77184de71/SPECS/openssl/openssl.spec#L11).

I've taken just the snippet from that commit that disables `SM2` tests depending on `OPENSSL_NO_SM2`.

What do people think of this as a way to get those tests skipped properly without needing to backport that entire change?

