### PR TITLE
Remove redundant OPENSSL_assert(i <= n) checks in b64_write()

### DIFF
--- a/crypto/evp/bio_b64.c
+++ b/crypto/evp/bio_b64.c
@@ -343,12 +343,12 @@ static int b64_write(BIO *b, const char *in, int inl)
         EVP_EncodeInit(ctx->base64);
     }
     if (!ossl_assert(ctx->buf_off < (int)sizeof(ctx->buf))) {
-	ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
-	return -1;
+        ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+        return -1;
     }
     if (!ossl_assert(ctx->buf_len <= (int)sizeof(ctx->buf))) {
-	ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
-	return -1;
+        ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+        return -1;
     }
     if (!ossl_assert(ctx->buf_len >= ctx->buf_off)) {
         ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);

--- a/crypto/evp/bio_b64.c
+++ b/crypto/evp/bio_b64.c
@@ -138,11 +138,17 @@ static int b64_read(BIO *b, char *out, int outl)
 
     /* First check if there are buffered bytes already decoded */
     if (ctx->buf_len > 0) {
-        OPENSSL_assert(ctx->buf_len >= ctx->buf_off);
+        if (!ossl_assert(ctx->buf_len >= ctx->buf_off)) {
+            ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+            return 0;
+        }
         i = ctx->buf_len - ctx->buf_off;
         if (i > outl)
             i = outl;
-        OPENSSL_assert(ctx->buf_off + i < (int)sizeof(ctx->buf));
+        if (!ossl_assert(ctx->buf_off + i < (int)sizeof(ctx->buf))) {
+            ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+            return 0;
+        }
         memcpy(out, &(ctx->buf[ctx->buf_off]), i);
         ret = i;
         out += i;
@@ -336,10 +342,18 @@ static int b64_write(BIO *b, const char *in, int inl)
         ctx->tmp_len = 0;
         EVP_EncodeInit(ctx->base64);
     }
-
-    OPENSSL_assert(ctx->buf_off < (int)sizeof(ctx->buf));
-    OPENSSL_assert(ctx->buf_len <= (int)sizeof(ctx->buf));
-    OPENSSL_assert(ctx->buf_len >= ctx->buf_off);
+    if (!ossl_assert(ctx->buf_off < (int)sizeof(ctx->buf))) {
+	ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+	return 0;
+    }
+    if (!ossl_assert(ctx->buf_len <= (int)sizeof(ctx->buf))) {
+	ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+	return 0;
+    }
+    if (!ossl_assert(ctx->buf_len >= ctx->buf_off)) {
+        ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
     n = ctx->buf_len - ctx->buf_off;
     while (n > 0) {
         i = BIO_write(next, &(ctx->buf[ctx->buf_off]), n);
@@ -348,8 +362,14 @@ static int b64_write(BIO *b, const char *in, int inl)
             return i;
         }
         ctx->buf_off += i;
-        OPENSSL_assert(ctx->buf_off <= (int)sizeof(ctx->buf));
-        OPENSSL_assert(ctx->buf_len >= ctx->buf_off);
+        if (!ossl_assert(ctx->buf_off <= (int)sizeof(ctx->buf))) {
+            ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+            return ret == 0 ? -1 : ret;
+        }
+        if (!ossl_assert(ctx->buf_len >= ctx->buf_off)) {
+            ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+            return ret == 0 ? -1 : ret;
+        }
         n -= i;
     }
     /* at this point all pending data has been written */
@@ -364,7 +384,10 @@ static int b64_write(BIO *b, const char *in, int inl)
 
         if ((BIO_get_flags(b) & BIO_FLAGS_BASE64_NO_NL) != 0) {
             if (ctx->tmp_len > 0) {
-                OPENSSL_assert(ctx->tmp_len <= 3);
+                if (!ossl_assert(ctx->tmp_len <= 3)) {
+                    ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+                    return ret == 0 ? -1 : ret;
+                }
                 n = 3 - ctx->tmp_len;
                 /*
                  * There's a theoretical possibility for this
@@ -378,8 +401,14 @@ static int b64_write(BIO *b, const char *in, int inl)
                     break;
                 ctx->buf_len =
                     EVP_EncodeBlock(ctx->buf, ctx->tmp, ctx->tmp_len);
-                OPENSSL_assert(ctx->buf_len <= (int)sizeof(ctx->buf));
-                OPENSSL_assert(ctx->buf_len >= ctx->buf_off);
+                if (!ossl_assert(ctx->buf_len <= (int)sizeof(ctx->buf))) {
+                    ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+                    return ret == 0 ? -1 : ret;
+                }
+                if (!ossl_assert(ctx->buf_len >= ctx->buf_off)) {
+                    ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+                    return ret == 0 ? -1 : ret;
+                }
                 /*
                  * Since we're now done using the temporary buffer, the
                  * length should be 0'd
@@ -395,16 +424,28 @@ static int b64_write(BIO *b, const char *in, int inl)
                 n -= n % 3;
                 ctx->buf_len =
                     EVP_EncodeBlock(ctx->buf, (unsigned char *)in, n);
-                OPENSSL_assert(ctx->buf_len <= (int)sizeof(ctx->buf));
-                OPENSSL_assert(ctx->buf_len >= ctx->buf_off);
+                if (!ossl_assert(ctx->buf_len <= (int)sizeof(ctx->buf))) {
+                    ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+                    return ret == 0 ? -1 : ret;
+                }
+                if (!ossl_assert(ctx->buf_len >= ctx->buf_off)) {
+                    ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+                    return ret == 0 ? -1 : ret;
+                }
                 ret += n;
             }
         } else {
             if (!EVP_EncodeUpdate(ctx->base64, ctx->buf, &ctx->buf_len,
                                   (unsigned char *)in, n))
                 return ret == 0 ? -1 : ret;
-            OPENSSL_assert(ctx->buf_len <= (int)sizeof(ctx->buf));
-            OPENSSL_assert(ctx->buf_len >= ctx->buf_off);
+            if (!ossl_assert(ctx->buf_len <= (int)sizeof(ctx->buf))) {
+                ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+                return ret == 0 ? -1 : ret;
+            }
+            if (!ossl_assert(ctx->buf_len >= ctx->buf_off)) {
+                ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+                return ret == 0 ? -1 : ret;
+            }
             ret += n;
         }
         inl -= n;
@@ -420,8 +461,14 @@ static int b64_write(BIO *b, const char *in, int inl)
             }
             n -= i;
             ctx->buf_off += i;
-            OPENSSL_assert(ctx->buf_off <= (int)sizeof(ctx->buf));
-            OPENSSL_assert(ctx->buf_len >= ctx->buf_off);
+            if (!ossl_assert(ctx->buf_off <= (int)sizeof(ctx->buf))) {
+                ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+                return ret == 0 ? -1 : ret;
+            }
+            if (!ossl_assert(ctx->buf_len >= ctx->buf_off)) {
+                ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+                return ret == 0 ? -1 : ret;
+            }
         }
         ctx->buf_len = 0;
         ctx->buf_off = 0;
@@ -455,7 +502,10 @@ static long b64_ctrl(BIO *b, int cmd, long num, void *ptr)
             ret = BIO_ctrl(next, cmd, num, ptr);
         break;
     case BIO_CTRL_WPENDING:    /* More to write in buffer */
-        OPENSSL_assert(ctx->buf_len >= ctx->buf_off);
+        if (!ossl_assert(ctx->buf_len >= ctx->buf_off)) {
+            ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+            return 0;
+        }
         ret = ctx->buf_len - ctx->buf_off;
         if (ret == 0 && ctx->encode != B64_NONE
             && EVP_ENCODE_CTX_num(ctx->base64) != 0)
@@ -464,7 +514,10 @@ static long b64_ctrl(BIO *b, int cmd, long num, void *ptr)
             ret = BIO_ctrl(next, cmd, num, ptr);
         break;
     case BIO_CTRL_PENDING:     /* More to read in buffer */
-        OPENSSL_assert(ctx->buf_len >= ctx->buf_off);
+        if (!ossl_assert(ctx->buf_len >= ctx->buf_off)) {
+            ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
+            return 0;
+        }
         ret = ctx->buf_len - ctx->buf_off;
         if (ret <= 0)
             ret = BIO_ctrl(next, cmd, num, ptr);

--- a/crypto/evp/bio_b64.c
+++ b/crypto/evp/bio_b64.c
@@ -140,14 +140,14 @@ static int b64_read(BIO *b, char *out, int outl)
     if (ctx->buf_len > 0) {
         if (!ossl_assert(ctx->buf_len >= ctx->buf_off)) {
             ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
-            return 0;
+            return -1;
         }
         i = ctx->buf_len - ctx->buf_off;
         if (i > outl)
             i = outl;
         if (!ossl_assert(ctx->buf_off + i < (int)sizeof(ctx->buf))) {
             ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
-            return 0;
+            return -1;
         }
         memcpy(out, &(ctx->buf[ctx->buf_off]), i);
         ret = i;
@@ -344,15 +344,15 @@ static int b64_write(BIO *b, const char *in, int inl)
     }
     if (!ossl_assert(ctx->buf_off < (int)sizeof(ctx->buf))) {
 	ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
-	return 0;
+	return -1;
     }
     if (!ossl_assert(ctx->buf_len <= (int)sizeof(ctx->buf))) {
 	ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
-	return 0;
+	return -1;
     }
     if (!ossl_assert(ctx->buf_len >= ctx->buf_off)) {
         ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
-        return 0;
+        return -1;
     }
     n = ctx->buf_len - ctx->buf_off;
     while (n > 0) {
@@ -364,11 +364,11 @@ static int b64_write(BIO *b, const char *in, int inl)
         ctx->buf_off += i;
         if (!ossl_assert(ctx->buf_off <= (int)sizeof(ctx->buf))) {
             ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
-            return ret == 0 ? -1 : ret;
+            return -1;
         }
         if (!ossl_assert(ctx->buf_len >= ctx->buf_off)) {
             ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
-            return ret == 0 ? -1 : ret;
+            return -1;
         }
         n -= i;
     }
@@ -504,7 +504,7 @@ static long b64_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_WPENDING:    /* More to write in buffer */
         if (!ossl_assert(ctx->buf_len >= ctx->buf_off)) {
             ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
-            return 0;
+            return -1;
         }
         ret = ctx->buf_len - ctx->buf_off;
         if (ret == 0 && ctx->encode != B64_NONE
@@ -516,7 +516,7 @@ static long b64_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_PENDING:     /* More to read in buffer */
         if (!ossl_assert(ctx->buf_len >= ctx->buf_off)) {
             ERR_raise(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR);
-            return 0;
+            return -1;
         }
         ret = ctx->buf_len - ctx->buf_off;
         if (ret <= 0)

--- a/crypto/evp/bio_b64.c
+++ b/crypto/evp/bio_b64.c
@@ -347,7 +347,6 @@ static int b64_write(BIO *b, const char *in, int inl)
             BIO_copy_next_retry(b);
             return i;
         }
-        OPENSSL_assert(i <= n);
         ctx->buf_off += i;
         OPENSSL_assert(ctx->buf_off <= (int)sizeof(ctx->buf));
         OPENSSL_assert(ctx->buf_len >= ctx->buf_off);
@@ -419,7 +418,6 @@ static int b64_write(BIO *b, const char *in, int inl)
                 BIO_copy_next_retry(b);
                 return ret == 0 ? i : ret;
             }
-            OPENSSL_assert(i <= n);
             n -= i;
             ctx->buf_off += i;
             OPENSSL_assert(ctx->buf_off <= (int)sizeof(ctx->buf));


### PR DESCRIPTION
Currently, the code asserts that the return value of BIO_write() does not exceed n bytes. However, other calls to BIO_write() do not perform such a check.

Since there is no special handling in b64_write()
that would require this assertion, it is safe to remove it.

##### Checklist

- [ ] documentation is added or updated
- [ ] tests are added or updated

P.S. I noticed this assertion while reading the code. Although it has not caused any issues, it led me to check whether there are any cases where BIO_write() might return `i > n`.