### PR TITLE
Swich the logic to skip ARGON2 EVP tests to PREFIX rather than SUFFIX.

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -5601,7 +5601,7 @@ static int is_kdf_disabled(const char *name)
         return 1;
 #endif
 #ifdef OPENSSL_NO_ARGON2
-    if (HAS_CASE_SUFFIX(name, "ARGON2"))
+    if (HAS_CASE_PREFIX(name, "ARGON2"))
         return 1;
 #endif
     return 0;


### PR DESCRIPTION
With `-no-argon2` configured, `evp_test` fails for `evpkdf_argon2.txt`:

```
$ LD_LIBRARY_PATH=/workspace/code/upstream/openssl-tobiasb-ms/:$LD_LIBRARY_PATH ./evp_test recipes/30-test_evp_data/evpkdf_argon2.txt
1..1
    # Subtest: run_file_tests
    1..1
    # INFO:  @ test/testutil/stanza.c:21
    # Reading recipes/30-test_evp_data/evpkdf_argon2.txt
    # INFO:  @ test/testutil/stanza.c:123
    # Starting "Argon2 tests (from rfc 9106 and others)" tests at line 1
    # ERROR:  @ test/evp_test.c:5316
    # unknown KDF: ARGON2D
    #
    #
    # INFO:  @ test/testutil/stanza.c:32
    # Completed 0 tests with 1 errors and 0 skipped
    # OPENSSL_TEST_RAND_SEED=1744753462
    not ok 1 - iteration 1
# OPENSSL_TEST_RAND_SEED=1744753462
not ok 1 - run_file_tests
```

The issues appears to be in [is_kdf_disabled](https://github.com/openssl/openssl/blob/24bc185439a950dc4427be10ec60231a923840ad/test/evp_test.c#L5603C1-L5606C7), which uses `HAS_CASE_SUFFIX` to test whether we should skip a test. However, the algorithms passed in are `ARGON2D`, `ARGON2I`, and `ARGON2ID`, so `HAS_CASE_PREFIX` seems more appropriate. Making that change skips these tests properly. I also made sure that the tests still run correctly if `argon2` is enabled.
