### PR TITLE
ssl/quic/quic_port.c: Add SSL_free() and OPENSSL_free() to avoid memo…

### DIFF
--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -541,6 +541,7 @@ static QUIC_CHANNEL *port_make_channel(QUIC_PORT *port, SSL *tls, OSSL_QRX *qrx,
     ch->use_qlog = 1;
     if (ch->tls->ctx->qlog_title != NULL) {
         if ((ch->qlog_title = OPENSSL_strdup(ch->tls->ctx->qlog_title)) == NULL) {
+            SSL_free(ch->tls);
             OPENSSL_free(ch);
             return NULL;
         }
@@ -551,6 +552,7 @@ static QUIC_CHANNEL *port_make_channel(QUIC_PORT *port, SSL *tls, OSSL_QRX *qrx,
      * And finally init the channel struct
      */
     if (!ossl_quic_channel_init(ch)) {
+        OPENSSL_free(ch->qlog_title);
         SSL_free(ch->tls);
         OPENSSL_free(ch);
         return NULL;


### PR DESCRIPTION
…ry leak

Add SSL_free() and OPENSSL_free() in the error handling paths to avoid memory leak.

Fixes: f193e0e9fb ("use internal callback to generate user ssl")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
