### PR TITLE
Avoid potential double close of client_skt in sslecho

### DIFF
--- a/demos/sslecho/main.c
+++ b/demos/sslecho/main.c
@@ -264,6 +264,11 @@ int main(int argc, char **argv)
                 SSL_shutdown(ssl);
                 SSL_free(ssl);
                 close(client_skt);
+                /*
+                 * Set client_skt to -1 to avoid double close when
+                 * server_running become false before next accept
+                 */
+                client_skt = -1;
             }
         }
         printf("Server exiting...\n");


### PR DESCRIPTION
The server_running variable is declared as volatile and some comments in the code are mentioning about implementing CTRL+C handler in the future.

In the client handling loop, the client_skt is closed at the end of the loop if server_running is true. If (future) CTRL+C handler changes server_running to false at this time. The next accept will not happen and the exit clean up code will close client_skt for the second time.

This patch fixes this potential double close by setting client_skt back to -1 after closing it.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->


