### PR TITLE
Document SSL_CTX_set_min_proto_version defaults

### DIFF
--- a/doc/man3/SSL_CTX_set_min_proto_version.pod
+++ b/doc/man3/SSL_CTX_set_min_proto_version.pod
@@ -31,9 +31,10 @@ L<SSL_CTX_set_options(3)> that also make it possible to disable
 specific protocol versions.
 Use these functions instead of disabling specific protocol versions.
 
-Setting the minimum or maximum version to 0, will enable protocol
+Setting the minimum or maximum version to 0 (default), will enable protocol
 versions down to the lowest version, or up to the highest version
-supported by the library, respectively.
+supported by the library, respectively. The supported versions might be
+controlled by system configuration.
 
 Getters return 0 in case B<ctx> or B<ssl> have been configured to
 automatically use the lowest or highest version supported by the library.


### PR DESCRIPTION
Update documentation to give a clearer description.
If the function is not called the settings default to 0.

Fixes #10584

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
~- [ ] tests are added or updated~
