### PR TITLE
Simplify ALPN support with first match algorithm #27335

### DIFF
--- a/doc/man3/SSL_CTX_set_alpn_select_cb.pod
+++ b/doc/man3/SSL_CTX_set_alpn_select_cb.pod
@@ -49,16 +49,24 @@ SSL_select_next_proto, SSL_get0_alpn_selected, SSL_get0_next_proto_negotiated
 
 =head1 DESCRIPTION
 
-SSL_CTX_set_alpn_protos() and SSL_set_alpn_protos() are used by the client to
-set the list of protocols available to be negotiated. The B<protos> must be in
-protocol-list format, described below. The length of B<protos> is specified in
-B<protos_len>. Setting B<protos_len> to 0 clears any existing list of ALPN
-protocols and no ALPN extension will be sent to the server.
+SSL_CTX_set_alpn_protos() and SSL_set_alpn_protos() can be used by both
+clients and servers. For clients, they set the list of protocols available
+to be negotiated. For servers, if no callback is registered via
+SSL_CTX_set_alpn_select_cb(), they define the list of supported protocols.
+During the TLS handshake, the server will automatically select the first
+protocol from the client's list that matches any entry in its own list.
+
+The B<protos> must be in protocol-list format, described below, and its
+length is specified by B<protos_len>. Setting B<protos_len> to 0 clears any
+existing ALPN protocol list. For clients, if no protocols are set, no ALPN
+extension will be sent to the server.
 
 SSL_CTX_set_alpn_select_cb() sets the application callback B<cb> used by a
-server to select which protocol to use for the incoming connection. When B<cb>
-is NULL, ALPN is not used. The B<arg> value is a pointer which is passed to
-the application callback.
+server to select the protocol to use for an incoming connection. When B<cb>
+is NULL, the server will use the protocol list set via
+SSL_CTX_set_alpn_protos() (if any). If neither the callback nor a protocol
+list is set, ALPN will not be used. The B<arg> value is a pointer passed to
+the callback during selection.
 
 B<cb> is the application defined callback. The B<in>, B<inlen> parameters are a
 vector in protocol-list format. The value of the B<out>, B<outlen> vector

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3729,7 +3729,12 @@ static int alpn_value_ok(const unsigned char *protos, unsigned int protos_len)
 /*
  * SSL_CTX_set_alpn_protos sets the ALPN protocol list on |ctx| to |protos|.
  * |protos| must be in wire-format (i.e. a series of non-empty, 8-bit
- * length-prefixed strings). Returns 0 on success.
+ * length-prefixed strings). 
+ * This function can be used by both clients and servers:
+ * - For clients, it sets the protocols to be sent in the ClientHello
+ * - For servers, it sets the protocols to be used for selection when no
+ *   alpn_select_cb is set (using a "first match" algorithm)
+ * Returns 0 on success.
  */
 int SSL_CTX_set_alpn_protos(SSL_CTX *ctx, const unsigned char *protos,
                             unsigned int protos_len)
@@ -3759,7 +3764,12 @@ int SSL_CTX_set_alpn_protos(SSL_CTX *ctx, const unsigned char *protos,
 /*
  * SSL_set_alpn_protos sets the ALPN protocol list on |ssl| to |protos|.
  * |protos| must be in wire-format (i.e. a series of non-empty, 8-bit
- * length-prefixed strings). Returns 0 on success.
+ * length-prefixed strings).
+ * This function can be used by both clients and servers:
+ * - For clients, it sets the protocols to be sent in the ClientHello
+ * - For servers, it sets the protocols to be used for selection when no
+ *   alpn_select_cb is set (using a "first match" algorithm)
+ * Returns 0 on success.
  */
 int SSL_set_alpn_protos(SSL *ssl, const unsigned char *protos,
                         unsigned int protos_len)

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1683,6 +1683,8 @@ struct ssl_connection_st {
         /*
          * For a client, this contains the list of supported protocols in wire
          * format.
+         * For a server, this contains the list of supported protocols in wire
+         * format.
          */
         unsigned char *alpn;
         size_t alpn_len;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated


Simplified the ALPN selection process when no cb is provided.
Current implementation uses first match algorithm to determine the alpn proto.
Server has to use SSL_CTX_set_alpn_protos and not set a cb in order to use this functionality