### PR TITLE
math.h: avoid using <math.h> functions to check for NaN and infinity

### DIFF
--- a/ssl/quic/json_enc.c
+++ b/ssl/quic/json_enc.c
@@ -11,7 +11,6 @@
 #include "internal/nelem.h"
 #include "internal/numbers.h"
 #include <string.h>
-#include <math.h>
 
 /*
  * wbuf
@@ -603,19 +602,16 @@ void ossl_json_f64(OSSL_JSON_ENC *json, double value)
     if (!json_pre_item(json))
         return;
 
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
     {
-        int checks = isnan(value);
-# if !defined(OPENSSL_SYS_VMS)
-        checks |= isinf(value);
-# endif
+        /* Figure out if we've been passed a NaN or infinty */
+        const double x = 0 * value;     /* NaN if value is NaN or infinity */
+        const int is_number = x == x;   /* False if x is a NaN, True otherwise */
 
-        if (checks) {
+        if (!is_number) {
             json_raise_error(json);
             return;
         }
     }
-#endif
 
     BIO_snprintf(buf, sizeof(buf), "%1.17g", value);
     json_write_str(json, buf);


### PR DESCRIPTION
Fixes #23980

- [ ] documentation is added or updated
- [ ] tests are added or updated
