### PR TITLE
Fix fips provider compatibility regression

### DIFF
--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -5172,7 +5172,7 @@ static int test_evp_updated_iv(int idx)
         errmsg = "CIPHER_CTX_GET_UPDATED_IV";
         goto err;
     } else {
-        if (!TEST_false(ERR_peek_error())) {
+        if (fips_provider_version_ge(testctx, 3, 6, 0) && !TEST_false(ERR_peek_error())) {
             errmsg = "CIPHER_CTX_GET_UPDATED_IV_SILENT_ERROR";
             goto err;
         }

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -1092,6 +1092,7 @@ static int cipher_test_enc(EVP_TEST *t, int enc, size_t out_misalign,
     EVP_CIPHER_CTX *ctx_base = NULL;
     EVP_CIPHER_CTX *ctx = NULL, *duped;
     int fips_dupctx_supported = fips_provider_version_ge(libctx, 3, 2, 0);
+    int fips_no_silent_error = fips_provider_version_ge(libctx, 3, 6, 0);
 
     t->err = "TEST_FAILURE";
     if (!TEST_ptr(ctx_base = EVP_CIPHER_CTX_new()))
@@ -1219,7 +1220,7 @@ static int cipher_test_enc(EVP_TEST *t, int enc, size_t out_misalign,
             t->err = "INVALID_IV";
             goto err;
         } else {
-            if (!TEST_false(ERR_peek_error())) {
+            if (fips_no_silent_error && !TEST_false(ERR_peek_error())) {
                 t->err = "GET_UPDATED_IV_SILENT_ERROR";
                 goto err;
             }
@@ -1515,7 +1516,7 @@ static int cipher_test_enc(EVP_TEST *t, int enc, size_t out_misalign,
             t->err = "INVALID_NEXT_IV";
             goto err;
         } else {
-            if (!TEST_false(ERR_peek_error())) {
+            if (fips_no_silent_error && !TEST_false(ERR_peek_error())) {
                 t->err = "GET_UPDATED_IV_SILENT_ERROR";
                 goto err;
             }


### PR DESCRIPTION
Fixes CI regression from 418609e115.

Older versions place an error code to the error queue when retrieving updated IV.
