### PR TITLE
Fix use after free bugs for public_keys and private_keys in evp_test.

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -5426,7 +5426,9 @@ static int run_file_tests(int i)
     clear_test(t);
 
     free_key_list(public_keys);
+    public_keys = NULL;
     free_key_list(private_keys);
+    private_keys = NULL;
     BIO_free(t->s.key);
     c = t->s.errors;
     OPENSSL_free(t);


### PR DESCRIPTION
When running `evp_test` on multiple `pkey` tests, there is a seg fault due to a use after free issue with both `public_keys` and `private_keys`.

Example command:
```
LD_LIBRARY_PATH=/workspace/code/upstream/openssl-tobiasb-ms/:$LD_LIBRARY_PATH  ./evp_test -provider default recipes/30-test_evp_data/evppkey_brainpool.txt recipes/30-test_evp_data/evppkey_dh.txt
```

Call stack from `gdb`:
```
#0  0x000055555556c1f2 in find_key (ppk=0x0, name=0x55555565e810 "ALICE_dh2048", lst=0x70) at test/evp_test.c:5052
#1  0x000055555556cb6e in parse (t=0x5555555be570) at test/evp_test.c:5295
#2  0x000055555556d261 in run_file_tests (i=1) at test/evp_test.c:5404
#3  0x0000555555570d4c in run_tests (test_prog_name=0x7fffffffd9b7 "/workspace/code/upstream/openssl-tobiasb-ms/test/evp_test") at test/testutil/driver.c:377
#4  0x000055555557120d in main (argc=3, argv=0x7fffffffd528) at test/testutil/main.c:31
```

[run_file_tests](https://github.com/openssl/openssl/blob/6f26301c83bf7796240a484249510d625f968028/test/evp_test.c#L5400) calls [parse](https://github.com/openssl/openssl/blob/6f26301c83bf7796240a484249510d625f968028/test/evp_test.c#L5181) to parse the test recipe file.
Depending on the type of keys found in the file, `parse` will use either of the globals [private_keys](https://github.com/openssl/openssl/blob/6f26301c83bf7796240a484249510d625f968028/test/evp_test.c#L5211) or [public_keys](https://github.com/openssl/openssl/blob/6f26301c83bf7796240a484249510d625f968028/test/evp_test.c#L5220) to allocate these keys, including calling [find_key](https://github.com/openssl/openssl/blob/6f26301c83bf7796240a484249510d625f968028/test/evp_test.c#L5306) on it to avoid duplicates. Then, back in `run_file_tests`, it [frees both of these globals](https://github.com/tobiasb-ms/openssl/blob/6f26301c83bf7796240a484249510d625f968028/test/evp_test.c#L5428-L5429) to clean up resources after the test.

When `run_file_tests` is called on the next file, all this happens again, but `public_keys` and `private_keys` are dangling pointers at this point, so when `find_key` is called, it looks at random memory for the keys. I see a consistent seg fault, but in theory it could have different (unintended) behavior.

NULLing out these pointers when we free them fixes this issue.

