### PR TITLE
Update pkeyutl documentation for PQC algorithms (Fixes #27415)

### DIFF
--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -439,7 +439,7 @@ no additional options.
 
 =head2 SLH-DSA ALGORITHMS
 
-The SLH-DSA algorithm is a post-quantum signature algorithm. When using SLH-DSA with pkeyutl, the following options are available:
+The SLH-DSA algorithms (SLH-DSA-SHA2-128s, SLH-DSA-SHA2-128f, SLH-DSA-SHA2-192s, SLH-DSA-SHA2-192f, SLH-DSA-SHA2-256s, SLH-DSA-SHA2-256f) are post-quantum signature algorithms. When using SLH-DSA with pkeyutl, the following options are available:
 
 =over 4
 
@@ -641,31 +641,31 @@ Decrypt some data using a private key with OAEP padding using SHA256:
 
 Create an ML-DSA key pair and sign data with a specific context string:
 
- openssl genpkey -algorithm mldsa65 -out mldsa65.pem
- openssl pkeyutl -sign -in file -inkey mldsa65.pem -out sig -pkeyopt context-string:example
+  $ openssl genpkey -algorithm ML-DSA-65 -out mldsa65.pem
+  $ openssl pkeyutl -sign -in file.txt -inkey mldsa65.pem -out sig -pkeyopt context-string:example
 
 Verify a signature using ML-DSA with the same context string:
 
- openssl pkeyutl -verify -in file -inkey mldsa65.pem -sigfile sig -pkeyopt context-string:example
+  $ openssl pkeyutl -verify -in file.txt -inkey mldsa65.pem -sigfile sig -pkeyopt context-string:example
 
 Generate an ML-KEM key pair and use it for encapsulation:
 
- openssl genpkey -algorithm mlkem768 -out mlkem768.pem
- openssl pkey -in mlkem768.pem -pubout -out mlkem768_pub.pem
- openssl pkeyutl -encap -inkey mlkem768_pub.pem -pubin -out ciphertext -secret shared_secret.bin
+  $ openssl genpkey -algorithm ML-KEM-768 -out mlkem768.pem
+  $ openssl pkey -in mlkem768.pem -pubout -out mlkem768_pub.pem
+  $ openssl pkeyutl -encap -inkey mlkem768_pub.pem -pubin -out ciphertext -secret shared_secret.bin
 
 Decapsulate a shared secret using an ML-KEM private key:
 
- openssl pkeyutl -decap -inkey mlkem768.pem -in ciphertext -secret decapsulated_secret.bin
+  $ openssl pkeyutl -decap -inkey mlkem768.pem -in ciphertext -secret decapsulated_secret.bin
 
 Create an SLH-DSA key pair and sign data:
 
- openssl genpkey -algorithm slh-dsa-sha2-128s -out slh-dsa.pem
- openssl pkeyutl -sign -in file -inkey slh-dsa.pem -out sig
+  $ openssl genpkey -algorithm SLH-DSA-SHA2-128s -out slh-dsa.pem
+  $ openssl pkeyutl -sign -in file.txt -inkey slh-dsa.pem -out sig
 
 Verify a signature using SLH-DSA:
 
- openssl pkeyutl -verify -in file -inkey slh-dsa.pem -sigfile sig
+  $ openssl pkeyutl -verify -in file.txt -inkey slh-dsa.pem -sigfile sig
 
 =head1 SEE ALSO
 

--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -450,6 +450,10 @@ A deterministic result can also be obtained by specifying an explicit
 entropy value via the B<hextest-entropy>:I<value> parameter.
 Deterministic B<ML-DSA> signing should only be used in tests.
 
+The B<context-string>:I<string> option can be used to specify a context string
+for both signing and verification operations. The context string must be the
+same for verification to succeed.
+
 See L<EVP_SIGNATURE-ML-DSA(7)> for additional options and detail.
 
 =head1 ML-KEM-512, ML-KEM-768 AND ML-KEM-1024 ALGORITHMS
@@ -548,6 +552,34 @@ Decrypt some data using a private key with OAEP padding using SHA256:
 
  openssl pkeyutl -decrypt -in file -inkey key.pem -out secret \
     -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:sha256
+
+Create an ML-DSA key pair and sign data with a specific context string:
+
+ openssl genpkey -algorithm mldsa65 -out mldsa65.pem
+ openssl pkeyutl -sign -in file -inkey mldsa65.pem -out sig -pkeyopt context-string:example
+
+Verify a signature using ML-DSA with the same context string:
+
+ openssl pkeyutl -verify -in file -inkey mldsa65.pem -sigfile sig -pkeyopt context-string:example
+
+Generate an ML-KEM key pair and use it for encapsulation:
+
+ openssl genpkey -algorithm mlkem768 -out mlkem768.pem
+ openssl pkey -in mlkem768.pem -pubout -out mlkem768_pub.pem
+ openssl pkeyutl -encap -inkey mlkem768_pub.pem -pubin -out ciphertext -secret shared_secret.bin
+
+Decapsulate a shared secret using an ML-KEM private key:
+
+ openssl pkeyutl -decap -inkey mlkem768.pem -in ciphertext -secret decapsulated_secret.bin
+
+Create an SLH-DSA key pair and sign data:
+
+ openssl genpkey -algorithm slh-dsa-sha2-128s -out slh-dsa.pem
+ openssl pkeyutl -sign -in file -inkey slh-dsa.pem -out sig
+
+Verify a signature using SLH-DSA:
+
+ openssl pkeyutl -verify -in file -inkey slh-dsa.pem -sigfile sig
 
 =head1 SEE ALSO
 

--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -461,7 +461,8 @@ See L<EVP_PKEY-SLH-DSA(7)> and L<EVP_SIGNATURE-SLH-DSA(7)> for additional detail
 
 =head2 ML-DSA ALGORITHMS
 
-The ML-DSA algorithm is a post-quantum signature algorithm. When using ML-DSA with pkeyutl, the following options are available:
+The ML-DSA algorithm is a post-quantum signature algorithm that supports signing and verification of "raw" messages.
+No preliminary hashing is performed. When using ML-DSA with pkeyutl, the following options are available:
 
 =over 4
 
@@ -530,6 +531,14 @@ Specifies a context string in hex format, allowing binary control values. For ex
   $ openssl pkeyutl -sign -in file.txt -inkey mldsa65.pem -out sig -pkeyopt hexcontext-string:6d79636f6e74657874
 
 =back
+
+The signing operation supports a B<deterministic>:I<bool> option,
+with I<bool> set to C<1> if a deterministic signature is to be generated
+with a fixed all zero random input.
+By default, or if the I<bool> is C<0> a random entropy value is used.
+A deterministic result can also be obtained by specifying an explicit
+entropy value via the B<hextest-entropy>:I<value> parameter.
+Deterministic B<ML-DSA> signing should only be used in tests.
 
 See L<EVP_SIGNATURE-ML-DSA(7)> for additional details about the ML-DSA algorithm and its implementation.
 

--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -437,24 +437,101 @@ for the B<-pkeyopt> B<digest> option.
 The X25519 and X448 algorithms support key derivation only. Currently there are
 no additional options.
 
-=head1 ML-DSA-44, ML-DSA-65 AND ML-DSA-87 ALGORITHMS
+=head2 SLH-DSA ALGORITHMS
 
-The B<ML-DSA> algorithms support signing and verification of "raw" messages.
-No preliminary hashing is performed.
+The SLH-DSA algorithm is a post-quantum signature algorithm. When using SLH-DSA with pkeyutl, the following options are available:
 
-The signing operation supports a B<deterministic>:I<bool> option,
-with I<bool> set to C<1> if a deterministic signature is to be generated
-with a fixed all zero random input.
-By default, or if the I<bool> is C<0> a random entropy value is used.
-A deterministic result can also be obtained by specifying an explicit
-entropy value via the B<hextest-entropy>:I<value> parameter.
-Deterministic B<ML-DSA> signing should only be used in tests.
+=over 4
 
-The B<context-string>:I<string> option can be used to specify a context string
-for both signing and verification operations. The context string must be the
-same for verification to succeed.
+=item B<-sign>
 
-See L<EVP_SIGNATURE-ML-DSA(7)> for additional options and detail.
+Sign the input data using an SLH-DSA private key. For example:
+
+  $ openssl pkeyutl -sign -in file.txt -inkey slhdsa.pem -out sig
+
+=item B<-verify>
+
+Verify the signature using an SLH-DSA public key. For example:
+
+  $ openssl pkeyutl -verify -in file.txt -inkey slhdsa.pem -sigfile sig
+
+=back
+
+See L<EVP_PKEY-SLH-DSA(7)> and L<EVP_SIGNATURE-SLH-DSA(7)> for additional details about the SLH-DSA algorithm and its implementation.
+
+=head2 ML-DSA ALGORITHMS
+
+The ML-DSA algorithm is a post-quantum signature algorithm. When using ML-DSA with pkeyutl, the following options are available:
+
+=over 4
+
+=item B<-sign>
+
+Sign the input data using an ML-DSA private key. For example:
+
+  $ openssl pkeyutl -sign -in file.txt -inkey mldsa65.pem -out sig
+
+=item B<-verify>
+
+Verify the signature using an ML-DSA public key. For example:
+
+  $ openssl pkeyutl -verify -in file.txt -inkey mldsa65.pem -sigfile sig
+
+=item B<-pkeyopt> I<opt>:I<value>
+
+Additional options for ML-DSA signing and verification:
+
+=over 4
+
+=item B<message-encoding>:I<value>
+
+Specifies the message encoding mode. For example:
+
+  $ openssl pkeyutl -sign -in file.txt -inkey mldsa65.pem -out sig -pkeyopt message-encoding:1
+
+=item B<test-entropy>:I<value>
+
+Specifies a test entropy value for deterministic signing. For example:
+
+  $ openssl pkeyutl -sign -in file.txt -inkey mldsa65.pem -out sig -pkeyopt test-entropy:abcdefghijklmnopqrstuvwxyz012345
+
+=item B<hextest-entropy>:I<value>
+
+Specifies a test entropy value in hex format. For example:
+
+  $ openssl pkeyutl -sign -in file.txt -inkey mldsa65.pem -out sig -pkeyopt hextest-entropy:000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
+
+=item B<deterministic>:I<value>
+
+Enables deterministic signing. For example:
+
+  $ openssl pkeyutl -sign -in file.txt -inkey mldsa65.pem -out sig -pkeyopt deterministic:1
+
+=item B<mu>:I<value>
+
+Specifies the mu parameter. For example:
+
+  $ echo -n "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" >file.txt
+  $ openssl pkeyutl -sign -in file.txt -inkey mldsa65.pem -out sig -pkeyopt mu:1
+
+=back
+
+=item B<context-string>:I<string>
+
+Specifies a context string for both signing and verification operations. The context string must be the same for verification to succeed. For example:
+
+  $ openssl pkeyutl -sign -in file.txt -inkey mldsa65.pem -out sig -pkeyopt context-string:mycontext
+  $ openssl pkeyutl -verify -in file.txt -inkey mldsa65.pem -sigfile sig -pkeyopt context-string:mycontext
+
+=item B<hexcontext-string>:I<string>
+
+Specifies a context string in hex format, allowing binary control values. For example:
+
+  $ openssl pkeyutl -sign -in file.txt -inkey mldsa65.pem -out sig -pkeyopt hexcontext-string:6d79636f6e74657874
+
+=back
+
+See L<EVP_SIGNATURE-ML-DSA(7)> for additional details about the ML-DSA algorithm and its implementation.
 
 =head1 ML-KEM-512, ML-KEM-768 AND ML-KEM-1024 ALGORITHMS
 

--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -459,9 +459,9 @@ Verify the signature using an SLH-DSA public key. For example:
 
 See L<EVP_PKEY-SLH-DSA(7)> and L<EVP_SIGNATURE-SLH-DSA(7)> for additional details about the SLH-DSA algorithm and its implementation.
 
-=head2 ML-DSA ALGORITHMS
+=head1 ML-DSA-44, ML-DSA-65 AND ML-DSA-87 ALGORITHMS
 
-The ML-DSA algorithm is a post-quantum signature algorithm that supports signing and verification of "raw" messages.
+The ML-DSA algorithms are post-quantum signature algorithms that support signing and verification of "raw" messages.
 No preliminary hashing is performed. When using ML-DSA with pkeyutl, the following options are available:
 
 =over 4
@@ -486,7 +486,7 @@ Additional options for ML-DSA signing and verification:
 
 =item B<message-encoding>:I<value>
 
-Specifies the message encoding mode. For example:
+Specifies the message encoding mode used for signing. This controls how the input message is processed before signing. Valid values are described in L<EVP_SIGNATURE-ML-DSA(7)>. For example:
 
   $ openssl pkeyutl -sign -in file.txt -inkey mldsa65.pem -out sig -pkeyopt message-encoding:1
 
@@ -540,7 +540,7 @@ A deterministic result can also be obtained by specifying an explicit
 entropy value via the B<hextest-entropy>:I<value> parameter.
 Deterministic B<ML-DSA> signing should only be used in tests.
 
-See L<EVP_SIGNATURE-ML-DSA(7)> for additional details about the ML-DSA algorithm and its implementation.
+See L<EVP_SIGNATURE-ML-DSA(7)> for additional details about the ML-DSA algorithms and their implementation.
 
 =head1 ML-KEM-512, ML-KEM-768 AND ML-KEM-1024 ALGORITHMS
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
Issue #27415 reported that the pkeyutl command documentation lacks information on using post-quantum cryptography algorithms (ML-KEM, ML-DSA, SLH-DSA). This lack of documentation led to user confusion, as evidenced by a question in the discussions section about how to provide context strings when using ML-DSA.

## Changes Made
This PR enhances the openssl-pkeyutl.pod.in documentation with:
- Added information about the context-string option for ML-DSA algorithms in the ML-DSA section
- Added practical examples for:
  - Creating ML-DSA keys and signing/verifying with context strings
  - Generating ML-KEM keys and performing encapsulation/decapsulation
  - Creating SLH-DSA keys and signing/verifying

# Why It Matters
These documentation improvements directly benefit users by:
- Providing clear examples of how to use post-quantum algorithms with the pkeyutl command
- Clarifying the usage of context-string with ML-DSA, addressing the confusion reported in the discussions
- Demonstrating the correct workflow for key generation, signing/verification, and encapsulation/decapsulation operations

## Testing
- Validated all examples with OpenSSL 3.6.0-dev to confirm they work correctly
- Verified that the context-string parameter works as documented, with verification failing when context strings don't match
- Confirmed that KEM encapsulation and decapsulation produce matching shared secrets
- Checked that signing and verification work with SLH-DSA as documented

## Note:
This PR doesn't change any code functionality, only documentation.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
