### PR TITLE
Fix setup-nasm action

### DIFF
--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -132,7 +132,7 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - uses: ilammy/msvc-dev-cmd@v1
-    - uses: ilammy/setup-nasm@v1
+    - uses: ilammy/setup-nasm@v1.5.2
     - name: prepare the build directory
       run: mkdir _build
     - name: config

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,7 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@v1
       with:
         arch: ${{ matrix.platform.arch }}
-    - uses: ilammy/setup-nasm@v1
+    - uses: ilammy/setup-nasm@v1.5.2
       with:
         platform: ${{ matrix.platform.arch }}
     - name: prepare the build directory

--- a/.github/workflows/windows_comp.yml
+++ b/.github/workflows/windows_comp.yml
@@ -27,7 +27,7 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - uses: ilammy/msvc-dev-cmd@v1
-    - uses: ilammy/setup-nasm@v1
+    - uses: ilammy/setup-nasm@v1.5.2
     - name: prepare the build directory
       run: mkdir _build
     - name: Get zstd


### PR DESCRIPTION
We've been failing our windows builds for a few days because www.nasm.us is down, and have no idea when its comming back.

Update the setup-nasm action to the latest version which supports mirror downloads to insulate us from this sort of thing
