### PR TITLE
fips: Align PKCS5_PBKDF2_HMAC defaults with EVP_KDF-PBKDF2

### DIFF
--- a/crypto/evp/p5_crpt2.c
+++ b/crypto/evp/p5_crpt2.c
@@ -25,11 +25,11 @@ int ossl_pkcs5_pbkdf2_hmac_ex(const char *pass, int passlen,
                               OSSL_LIB_CTX *libctx, const char *propq)
 {
     const char *empty = "";
-    int rv = 1, mode = 1;
+    int rv = 1;
     EVP_KDF *kdf;
     EVP_KDF_CTX *kctx;
     const char *mdname = EVP_MD_get0_name(digest);
-    OSSL_PARAM params[6], *p = params;
+    OSSL_PARAM params[5], *p = params;
 
     /* Keep documented behaviour. */
     if (pass == NULL) {
@@ -50,7 +50,6 @@ int ossl_pkcs5_pbkdf2_hmac_ex(const char *pass, int passlen,
         return 0;
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_PASSWORD,
                                              (char *)pass, (size_t)passlen);
-    *p++ = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_PKCS5, &mode);
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
                                              (unsigned char *)salt, saltlen);
     *p++ = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_ITER, &iter);

--- a/doc/man3/PKCS5_PBKDF2_HMAC.pod
+++ b/doc/man3/PKCS5_PBKDF2_HMAC.pod
@@ -36,6 +36,9 @@ equal to 1. RFC 2898 suggests an iteration count of at least 1000. Any
 B<iter> value less than 1 is invalid; such values will result in failure
 and raise the PROV_R_INVALID_ITERATION_COUNT error.
 
+Lower bounds checks are provider dependent and are described in the
+L<EVP_KDF-PBKDF2(7)/Supported parameters> B<OSSL_KDF_PARAM_PKCS5>.
+
 B<digest> is the message digest function used in the derivation.
 PKCS5_PBKDF2_HMAC_SHA1() calls PKCS5_PBKDF2_HMAC() with EVP_sha1().
 


### PR DESCRIPTION
EVP_KDF-PBKDF2 has provider-dependent runtime behaviour w.r.t. lower
bounds checks. The default provider does not enforce them, but can opt
into them. The fips provider does enforce them, but can opt out.

The same is not true for the PKCS5_PBKDF2_HMAC, which always opts out
of the lower bound checks.

This leads to unexpected behaviour without user consent, they may
expect in error that when using FIPS provider the lower bound checks
will be enforced by default.

There are two popular tools for ACVP testing:
- https://github.com/cisco/libacvp/blob/9ee15db6e6c6f123f5fdd72e453eca261482ea94/app/app_kdf.c#L411
- https://github.com/smuellerDD/acvpparser/blob/e1c094ae3a708a9c45cb8b270e96c252365a5376/backends/backend_openssl_common.c#L1836

One of them creates params and then calls the one-shot EVP_KDF_derive
api, whilst the other calls the PKCS5_PBKDF2_HMAC convenience
wrapper. For the same ACVP test vectors the two produce different
results: with and without lower bounds checks.

But it seems like PKCS5_PBKDF2_HMAC is popular, as it outnumbers
EVP_KDF_derive 8x when doing a global code search on github
(anecdotal, as results are skewed by the number of forks). This thus
comes down to the expectations end users have. And it feels like, at
least for this API, the FIPS 140-3 users expectation would be for the
lower bound checks to be enforced.

Modify the PKCS5_PBKDF2_HMAC wrapper around EVP_KDF_derive to not set
PKCS5 parameter, such that the provider implicit default is used
instead. Thus no change for default provider users, and FIPS
enforcement by default in the FIPS case like it always has done when
calling via EVP_KDF_derive.
