### PR TITLE
Move to error state if ML-DSA / SLH-DSA PCT fails

### DIFF
--- a/providers/implementations/keymgmt/ml_dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/ml_dsa_kmgmt.c
@@ -474,8 +474,10 @@ static void *ml_dsa_gen(void *genctx, int evp_type)
         goto err;
     }
 #ifdef FIPS_MODULE
-    if (!ml_dsa_pairwise_test(key))
+    if (!ml_dsa_pairwise_test(key)) {
+        ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT);
         goto err;
+    }
 #endif
     return key;
  err:

--- a/providers/implementations/keymgmt/ml_dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/ml_dsa_kmgmt.c
@@ -84,6 +84,8 @@ static int ml_dsa_pairwise_test(const ML_DSA_KEY *key)
                          sig, &sig_len, sizeof(sig)) <= 0)
         goto err;
 
+    OSSL_SELF_TEST_oncorrupt_byte(st, sig);
+
     if (ossl_ml_dsa_verify(key, 0, msg, sizeof(msg), NULL, 0, 0,
                            sig, sig_len) <= 0)
         goto err;

--- a/providers/implementations/keymgmt/slh_dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/slh_dsa_kmgmt.c
@@ -346,8 +346,10 @@ static void *slh_dsa_gen(void *genctx, const char *alg)
                                    gctx->entropy, gctx->entropy_len))
         goto err;
 #ifdef FIPS_MODULE
-    if (!slh_dsa_fips140_pairwise_test(ctx, key, gctx->libctx))
+    if (!slh_dsa_fips140_pairwise_test(ctx, key, gctx->libctx)) {
+        ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT);
         goto err;
+    }
 #endif /* FIPS_MODULE */
     ossl_slh_dsa_hash_ctx_free(ctx);
     return key;

--- a/test/pairwise_fail_test.c
+++ b/test/pairwise_fail_test.c
@@ -133,6 +133,39 @@ static int test_keygen_pairwise_failure(void)
             goto err;
         if (!TEST_ptr_null(pkey))
             goto err;
+    } else if (strncmp(pairwise_name, "ml-dsa", 6) == 0) {
+        if (!TEST_true(setup_selftest_pairwise_failure(type)))
+            goto err;
+        if (!TEST_ptr(ctx = EVP_PKEY_CTX_new_from_name(libctx, "ML-DSA-87", NULL)))
+            goto err;
+        if (!TEST_int_eq(EVP_PKEY_keygen_init(ctx), 1))
+            goto err;
+        if (!TEST_int_le(EVP_PKEY_keygen(ctx, &pkey), 0))
+            goto err;
+        if (!TEST_ptr_null(pkey))
+            goto err;
+    } else if (strncmp(pairwise_name, "slh-dsa", 7) == 0) {
+        if (!TEST_true(setup_selftest_pairwise_failure(type)))
+            goto err;
+        if (!TEST_ptr(ctx = EVP_PKEY_CTX_new_from_name(libctx, "SLH-DSA-SHA2-256f", NULL)))
+            goto err;
+        if (!TEST_int_eq(EVP_PKEY_keygen_init(ctx), 1))
+            goto err;
+        if (!TEST_int_le(EVP_PKEY_keygen(ctx, &pkey), 0))
+            goto err;
+        if (!TEST_ptr_null(pkey))
+            goto err;
+    } else if (strncmp(pairwise_name, "ml-kem", 6) == 0) {
+        if (!TEST_true(setup_selftest_pairwise_failure(type)))
+            goto err;
+        if (!TEST_ptr(ctx = EVP_PKEY_CTX_new_from_name(libctx, "ML-KEM-1024", NULL)))
+            goto err;
+        if (!TEST_int_eq(EVP_PKEY_keygen_init(ctx), 1))
+            goto err;
+        if (!TEST_int_le(EVP_PKEY_keygen(ctx, &pkey), 0))
+            goto err;
+        if (!TEST_ptr_null(pkey))
+            goto err;
     }
     ret = 1;
 err:

--- a/test/recipes/30-test_pairwise_fail.t
+++ b/test/recipes/30-test_pairwise_fail.t
@@ -22,7 +22,7 @@ use lib bldtop_dir('.');
 plan skip_all => "These tests are unsupported in a non fips build"
     if disabled("fips");
 
-plan tests => 6;
+plan tests => 9;
 my $provconf = srctop_file("test", "fips-and-base.cnf");
 
 run(test(["fips_version_test", "-config", $provconf, ">=3.1.0"]),
@@ -76,4 +76,46 @@ SKIP: {
     ok(run(test(["pairwise_fail_test", "-config", $provconf,
                  "-pairwise", "eddsa"])),
        "fips provider eddsa keygen pairwise failure test");
+}
+
+SKIP: {
+    skip "Skip ML-DSA test because of no ml-dsa in this build", 1
+        if disabled("ml-dsa");
+
+    run(test(["fips_version_test", "-config", $provconf, ">=3.5.0"]),
+             capture => 1, statusvar => \my $exit);
+    skip "FIPS provider version is too old", 1
+        if !$exit;
+
+    ok(run(test(["pairwise_fail_test", "-config", $provconf,
+                 "-pairwise", "ml-dsa"])),
+       "fips provider ml-dsa keygen pairwise failure test");
+}
+
+SKIP: {
+    skip "Skip SLH-DSA test because of no slh-dsa in this build", 1
+        if disabled("slh-dsa");
+
+    run(test(["fips_version_test", "-config", $provconf, ">=3.5.0"]),
+             capture => 1, statusvar => \my $exit);
+    skip "FIPS provider version is too old", 1
+        if !$exit;
+
+    ok(run(test(["pairwise_fail_test", "-config", $provconf,
+                 "-pairwise", "slh-dsa"])),
+       "fips provider slh-dsa keygen pairwise failure test");
+}
+
+SKIP: {
+    skip "Skip ML-KEM test because of no ml-kem in this build", 1
+        if disabled("ml-kem");
+
+    run(test(["fips_version_test", "-config", $provconf, ">=3.5.0"]),
+             capture => 1, statusvar => \my $exit);
+    skip "FIPS provider version is too old", 1
+        if !$exit;
+
+    ok(run(test(["pairwise_fail_test", "-config", $provconf,
+                 "-pairwise", "ml-kem"])),
+       "fips provider ml-kem keygen pairwise failure test");
 }


### PR DESCRIPTION
Is there a particular reason why this was not implemented as part of 3.5.0? As far as I can tell, this is required for FIPS.

Also updates `test/pairwise_fail_test.c` and `30-test_pairwise_fail.t` to make sure everything works correctly. The parameter sets for the test were chosen arbitrarily.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
