### PR TITLE
Properly zeroize ML-KEM z and d values

### DIFF
--- a/crypto/ml_kem/ml_kem.c
+++ b/crypto/ml_kem/ml_kem.c
@@ -1550,7 +1550,7 @@ ossl_ml_kem_key_reset(ML_KEM_KEY *key)
      */
     if (ossl_ml_kem_have_prvkey(key))
         OPENSSL_cleanse(key->s,
-                        key->vinfo->vector_bytes + 2 * ML_KEM_RANDOM_BYTES);
+                        key->vinfo->rank * sizeof(scalar) + 2 * ML_KEM_RANDOM_BYTES);
     OPENSSL_free(key->t);
     key->d = key->z = (uint8_t *)(key->s = key->m = key->t = NULL);
 }


### PR DESCRIPTION
Ensure z and d are actually zeroized by cleansing the full size of s, rather than just vector_bytes.

Based on my testing in GDB:
- For ML-KEM-512: s is 1024 bytes but vector_bytes is 768
- For ML-KEM-768: s is 1536 bytes but vector_bytes is 1152
- For ML-KEM-1024: s is 2048 bytes but vector_bytes is 1536

In all cases, z and d do not get properly zeroized.

In my personal opinion, it would be cleaner to just `OPENSSL_cleanse` z and d individually, rather than relying on the memory layout of s, z, and d. Is there actually a significant performance gain by combining it?

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
