### PR TITLE
potential NULL pointer dereference due to glitch ossl_quic_stream_has…

### DIFF
--- a/include/internal/quic_stream_map.h
+++ b/include/internal/quic_stream_map.h
@@ -349,8 +349,26 @@ static ossl_inline ossl_unused int ossl_quic_stream_is_local_init(const QUIC_STR
     return ossl_quic_stream_is_server_init(s) == s->as_server;
 }
 
+static ossl_inline ossl_unused const char *ossl_quic_get_sstream_state_str(
+    QUIC_STREAM *s)
+{
+    static const char *state_names[] = {
+        "QUIC_SSTREAM_STATE_NONE",
+        "QUIC_SSTREAM_STATE_READY",
+        "QUIC_SSTREAM_STATE_SEND",
+        "QUIC_SSTREAM_STATE_DATA_SENT",
+        "QUIC_SSTREAM_STATE_DATA_RECVD",
+        "QUIC_SSTREAM_STATE_RESET_SENT",
+        "QUIC_SSTREAM_STATE_RESET_RECVD",
+        "???"
+    };
+    int state = (s->send_state > QUIC_SSTREAM_STATE_RESET_RECVD) ?
+                 QUIC_SSTREAM_STATE_DATA_RECVD + 1 : s->send_state;
+    return state_names[state];
+}
+
 /*
- * Returns 1 if the QUIC_STREAM has a sending part, based on its stream type.
+ * Returns 1 if the QUIC_STREAM has a sending part, based on its stream state.
  *
  * Do NOT use (s->sstream != NULL) to test this; use this function. Note that
  * even if this function returns 1, s->sstream might be NULL if the QUIC_SSTREAM
@@ -358,11 +376,45 @@ static ossl_inline ossl_unused int ossl_quic_stream_is_local_init(const QUIC_STR
  */
 static ossl_inline ossl_unused int ossl_quic_stream_has_send(const QUIC_STREAM *s)
 {
-    return s->send_state != QUIC_SSTREAM_STATE_NONE;
+    int rv = 0;
+
+    switch (s->send_state) {
+    case QUIC_SSTREAM_STATE_NONE:
+    case QUIC_SSTREAM_STATE_RESET_SENT:
+    case QUIC_SSTREAM_STATE_RESET_RECVD:
+        rv = 0;
+        break;
+    case QUIC_SSTREAM_STATE_READY:
+    case QUIC_SSTREAM_STATE_SEND:
+    case QUIC_SSTREAM_STATE_DATA_SENT:
+    case QUIC_SSTREAM_STATE_DATA_RECVD:
+        rv = 1;
+        break;
+    default:
+        assert(0);
+    }
+    return rv;
+}
+
+static ossl_inline ossl_unused const char *ossl_quic_get_rstream_state_str(
+     QUIC_STREAM *s)
+{
+    static const char *state_names[] = {
+        "QUIC_RSTREAM_STATE_NONE",
+        "QUIC_RSTREAM_STATE_RECV",
+        "QUIC_RSTREAM_STATE_SIZE_KNOWN",
+        "QUIC_RSTREAM_STATE_DATA_RECVD",
+        "QUIC_RSTREAM_STATE_DATA_READ",
+        "QUIC_RSTREAM_STATE_RESET_RECVD",
+        "QUIC_RSTREAM_STATE_RESET_READ"
+    };
+    int state = (s->recv_state > QUIC_RSTREAM_STATE_RESET_READ) ?
+                 QUIC_RSTREAM_STATE_RESET_READ + 1 : s->recv_state;
+    return state_names[state];
 }
 
 /*
- * Returns 1 if the QUIC_STREAM has a receiving part, based on its stream type.
+ * Returns 1 if the QUIC_STREAM has a receiving part, based on its stream state.
  *
  * Do NOT use (s->rstream != NULL) to test this; use this function. Note that
  * even if this function returns 1, s->rstream might be NULL if the QUIC_RSTREAM
@@ -371,7 +423,25 @@ static ossl_inline ossl_unused int ossl_quic_stream_has_send(const QUIC_STREAM *
  */
 static ossl_inline ossl_unused int ossl_quic_stream_has_recv(const QUIC_STREAM *s)
 {
-    return s->recv_state != QUIC_RSTREAM_STATE_NONE;
+    int rv = 0;
+
+    switch (s->recv_state) {
+    case QUIC_RSTREAM_STATE_NONE:
+    case QUIC_RSTREAM_STATE_RESET_RECVD:
+    case QUIC_RSTREAM_STATE_RESET_READ:
+        rv = 0;
+        break;
+    case QUIC_RSTREAM_STATE_RECV:
+    case QUIC_RSTREAM_STATE_SIZE_KNOWN:
+    case QUIC_RSTREAM_STATE_DATA_RECVD:
+    case QUIC_RSTREAM_STATE_DATA_READ:
+        rv = 1;
+        break;
+    default:
+        assert(0);
+    }
+
+    return rv;
 }
 
 /*

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -5093,8 +5093,7 @@ static int test_poll_event_r(QUIC_XSO *xso)
 QUIC_NEEDS_LOCK
 static int test_poll_event_er(QUIC_XSO *xso)
 {
-    return ossl_quic_stream_has_recv(xso->stream)
-        && ossl_quic_stream_recv_is_reset(xso->stream)
+    return ossl_quic_stream_recv_is_reset(xso->stream)
         && !xso->retired_fin;
 }
 
@@ -5115,8 +5114,7 @@ static int test_poll_event_w(QUIC_XSO *xso)
 QUIC_NEEDS_LOCK
 static int test_poll_event_ew(QUIC_XSO *xso)
 {
-    return ossl_quic_stream_has_send(xso->stream)
-        && xso->stream->peer_stop_sending
+    return xso->stream->peer_stop_sending
         && !xso->requested_reset
         && !xso->conn->shutting_down;
 }

--- a/ssl/quic/quic_rx_depack.c
+++ b/ssl/quic/quic_rx_depack.c
@@ -237,7 +237,7 @@ static int depack_do_frame_stop_sending(PACKET *pkt,
     if (stream == NULL)
         return 1; /* old deleted stream, not a protocol violation, ignore */
 
-    if (!ossl_quic_stream_has_send(stream)) {
+    if (stream->send_state == QUIC_SSTREAM_STATE_NONE) {
         ossl_quic_channel_raise_protocol_error(ch,
                                                OSSL_QUIC_ERR_STREAM_STATE_ERROR,
                                                OSSL_QUIC_FRAME_TYPE_STOP_SENDING,


### PR DESCRIPTION
…_{send,recv}()

Whenever stream state reaches RESET_SENT state the underlying stream object (QUIC_SSTREAM/QUIC_RSTREAM) is gone. The current code is just lucky enough, not to hit this issue.

The change also adds ossl_quic_get_{sstream,rstream}_state_str() functions for convenience.

the changes to ossl_quic_stream_has_{send,recv}() functions require some finishing touches to keep tests happy.

depack_do_frame_stop_sending() needs to test _STATE_NONE explicitly to signal caller it is attempting to conclude receivng stream. The function send stream is present only when we receive the first stream RESET notifiation from remote peer. If there is a retransmission, then we may fail unexpectadly. Testing _STATE_NONE explicitly makes code happy.

similarly tets to test_poll_event_e{w,r}() the adjustments here make quicsslapitest happy.

I've found glitches in ossl_quic_stream_has_{send,recv}() while experimenting with SSL_poll().

