### PR TITLE
let underlying stream object know connection is being closed

### DIFF
--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -179,6 +179,7 @@ int ossl_quic_conn_poll_events(SSL *ssl, uint64_t events, int do_tick,
 int ossl_quic_get_notifier_fd(SSL *ssl);
 void ossl_quic_enter_blocking_section(SSL *ssl, QUIC_REACTOR_WAIT_CTX *wctx);
 void ossl_quic_leave_blocking_section(SSL *ssl, QUIC_REACTOR_WAIT_CTX *wctx);
+void ossl_quic_conn_notify_close(SSL *qc_ssl);
 
 # endif
 

--- a/include/internal/quic_stream_map.h
+++ b/include/internal/quic_stream_map.h
@@ -314,6 +314,10 @@ struct quic_stream_st {
     unsigned int    ready_for_gc            : 1;
     /* Set to 1 if this is currently counted in the shutdown flush stream count. */
     unsigned int    shutdown_flush          : 1;
+    /* set when underlying connection signals EC, the connection is being closed
+     * by removte peer, while there are still streams hanging around
+     */
+    unsigned int    conn_tearing_down       : 1;
 };
 
 #define QUIC_STREAM_INITIATOR_CLIENT        0

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -378,6 +378,11 @@ err:
     return ok;
 }
 
+static int expect_quic_c(const SSL *s, QCTX *ctx)
+{
+    return expect_quic_as(s, ctx, QCTX_C);
+}
+
 static int expect_quic_cs(const SSL *s, QCTX *ctx)
 {
     return expect_quic_as(s, ctx, QCTX_C | QCTX_S);
@@ -5093,9 +5098,9 @@ static int test_poll_event_r(QUIC_XSO *xso)
 QUIC_NEEDS_LOCK
 static int test_poll_event_er(QUIC_XSO *xso)
 {
-    return ossl_quic_stream_has_recv(xso->stream)
+    return (ossl_quic_stream_has_recv(xso->stream)
         && ossl_quic_stream_recv_is_reset(xso->stream)
-        && !xso->retired_fin;
+        && !xso->retired_fin) || xso->stream->conn_tearing_down;
 }
 
 /* Do we have the W (write) condition? */
@@ -5115,10 +5120,10 @@ static int test_poll_event_w(QUIC_XSO *xso)
 QUIC_NEEDS_LOCK
 static int test_poll_event_ew(QUIC_XSO *xso)
 {
-    return ossl_quic_stream_has_send(xso->stream)
+    return (ossl_quic_stream_has_send(xso->stream)
         && xso->stream->peer_stop_sending
         && !xso->requested_reset
-        && !xso->conn->shutting_down;
+        && !xso->conn->shutting_down) || xso->stream->conn_tearing_down;
 }
 
 /* Do we have the EC (exception: connection) condition? */
@@ -5164,6 +5169,21 @@ QUIC_NEEDS_LOCK
 static int test_poll_event_ic(QUIC_LISTENER *ql)
 {
     return ossl_quic_port_get_num_incoming_channels(ql->port) > 0;
+}
+
+QUIC_TAKES_LOCK
+void ossl_quic_conn_notify_close(SSL *qc_ssl)
+{
+    QCTX ctx;
+    QUIC_STREAM_MAP *qsm;
+
+    if (!expect_quic_c(qc_ssl, &ctx))
+        return;
+
+    qctx_lock(&ctx);
+    qsm = ossl_quic_channel_get_qsm(ctx.qc->ch);
+    ossl_quic_stream_map_notify_close(qsm);
+    qctx_unlock(&ctx);
 }
 
 QUIC_TAKES_LOCK


### PR DESCRIPTION
the proposed change attempts to fix following edge-case.

local QUIC connection end-point receives connection close notification from remote peer while QUIC streams still exists. In my opinion QUIC stack should signal error condition to all existing streams as soon as there connection is going to be closed.

Change in this PR makes that working for non-blocking I/O which uses SSL_poll(). Whenever the SSL_poll() triggers _EC event on QUIC connection it will also make sure the error will be triggered on all stream objects which belong to connection.

There two events which notify application about QUIC connection termination:
  - SSL_POLL_EVENT_EC - comes first and tells connection is about to terminate
  - SSL_POLL_EVENT_ECD - comes second after this the connection is gone

The errors on streams are signaled with SSL_POLL_EVENT_EC. The application is told the error on stream objects is permanent. Application should just free stream objects.

