### PR TITLE
pkcs12: increase macsaltlen from 8 to 16 as per NIST SP 800-132

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -80,6 +80,12 @@ OpenSSL 3.6
 
    *Tim Perry*
 
+ * Increase PKCS12 default macsaltlen from 8 to 16, as per NIST SP
+   800-132 this improves interoperability for newly generated PKCS12
+   stores between FIPS and non-FIPS implementations.
+
+   *Dimitri John Ledkov*
+
 OpenSSL 3.5
 -----------
 

--- a/doc/man1/openssl-pkcs12.pod.in
+++ b/doc/man1/openssl-pkcs12.pod.in
@@ -385,9 +385,9 @@ to be needed to use MAC iterations counts but they are now used by default.
 
 =item B<-macsaltlen>
 
-This option specifies the salt length in bytes for the MAC. The salt length 
-should be at least 16 bytes as per NIST SP 800-132. The default value 
-is 8 bytes for backwards compatibility.
+This option specifies the salt length in bytes for the MAC. The salt
+length should be at least 16 bytes as per NIST SP 800-132, which is
+the default value.
 
 =item B<-nomac>
 
@@ -487,6 +487,7 @@ L<ossl_store-file(7)>
 
 The B<-engine> option was deprecated in OpenSSL 3.0.
 The B<-nodes> option was deprecated in OpenSSL 3.0, too; use B<-noenc> instead.
+The B<-macsaltlen> option default changed from 8 to 16 bytes in OpenSSL 3.6.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/pkcs12.h.in
+++ b/include/openssl/pkcs12.h.in
@@ -45,8 +45,14 @@ extern "C" {
 
 # define PKCS12_MAC_KEY_LENGTH 20
 
-/* The macro is expected to be used only internally. Kept for backwards compatibility. */
-# define PKCS12_SALT_LEN 8
+/*
+ * The macro is expected to be used only internally. Kept for
+ * backwards compatibility. NIST requires 16, previous value was
+ * 8. Allow to override this at compile time.
+ */
+# ifndef PKCS12_SALT_LEN
+#  define PKCS12_SALT_LEN 16
+# endif
 
 /* It's not clear if these are actually needed... */
 # define PKCS12_key_gen PKCS12_key_gen_utf8


### PR DESCRIPTION
With this change, newly created PKCS12 PBMAC1 PBKDF2 keystores use mac
salt length of 16 bytes by default. This increases interoperability
with FIPS implementations which require at least 16 bytes of salt
length. Otherwise FIPS implementations fail to to open keystore with
invalid salt length errors (unapproved):

    Mac verify error: invalid password?
    80EBD061AD7F0000:error:1C800070:Provider routines:kdf_pbkdf2_set_ctx_params:invalid salt length:providers/implementations/kdfs/pbkdf2.c:293:
    80EBD061AD7F0000:error:118C0103:PKCS12 routines:PBMAC1_PBKDF2_HMAC:internal error:crypto/pkcs12/p12_mutl.c:143:
    80EBD061AD7F0000:error:1180006D:PKCS12 routines:PKCS12_verify_mac:mac generation error:crypto/pkcs12/p12_mutl.c:324:
    80EBD061AD7F0000:error:1C800070:Provider routines:kdf_pbkdf2_set_ctx_params:invalid salt length:providers/implementations/kdfs/pbkdf2.c:293:
    80EBD061AD7F0000:error:118C0103:PKCS12 routines:PBMAC1_PBKDF2_HMAC:internal error:crypto/pkcs12/p12_mutl.c:143:
    80EBD061AD7F0000:error:1180006D:PKCS12 routines:PKCS12_verify_mac:mac generation error:crypto/pkcs12/p12_mutl.c:324:

The compile time constant is made possible to override with a build
time define, such that one can revert back to 8 if so is needed for
backwards compatibility.
