### PR TITLE
Typo in TLS introduction

### DIFF
--- a/doc/man7/ossl-guide-tls-introduction.pod
+++ b/doc/man7/ossl-guide-tls-introduction.pod
@@ -74,7 +74,7 @@ TLSv1.2 is chosen.
 =head1 CERTIFICATES
 
 In order for a client to establish a connection to a server it must authenticate
-the identify of that server, i.e. it needs to confirm that the server is really
+the identity of that server, i.e. it needs to confirm that the server is really
 the server that it claims to be and not some imposter. In order to do this the
 server will send to the client a digital certificate (also commonly referred to
 as an X.509 certificate). The certificate contains various information about the


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

While reading a found a small typo in the TLS introduction. It uses "identify" but in that instance it doesn't make sense to me. I'm not an English native, but to my knowledge this is a typo. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
- [ ] tests are added or updated
