### PR TITLE
Fix nasm installation step

### DIFF
--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -132,7 +132,10 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - uses: ilammy/msvc-dev-cmd@v1
-    - uses: ilammy/setup-nasm@v1
+    - name: install nasm
+      run: |
+        choco install nasm
+        "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: prepare the build directory
       run: mkdir _build
     - name: config

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,9 +35,10 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@v1
       with:
         arch: ${{ matrix.platform.arch }}
-    - uses: ilammy/setup-nasm@v1
-      with:
-        platform: ${{ matrix.platform.arch }}
+    - name: install nasm
+      run: |
+        choco install nasm ${{ matrix.platform.arch == 'win32' && '--x86' || '' }}
+        "C:\Program Files${{ matrix.platform.arch == 'win32' && ' (x86)' || '' }}\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: prepare the build directory
       run: mkdir _build
     - name: config
@@ -57,8 +58,8 @@ jobs:
       working-directory: _build
       run: |
         apps/openssl.exe version -v
-        apps/openssl.exe version -v | %{($_ -split '\s+')[1]} 
-        apps/openssl.exe version -v | %{($_ -split '\s+')[1] -replace '([0-9]+\.[0-9]+)(\..*)','$1'} 
+        apps/openssl.exe version -v | %{($_ -split '\s+')[1]}
+        apps/openssl.exe version -v | %{($_ -split '\s+')[1] -replace '([0-9]+\.[0-9]+)(\..*)','$1'}
         echo "OSSL_VERSION=$(apps/openssl.exe version -v | %{($_ -split '\s+')[1] -replace '([0-9]+\.[0-9]+)(\..*)','$1'})" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
     - name: Set registry keys
       working-directory: _build

--- a/.github/workflows/windows_comp.yml
+++ b/.github/workflows/windows_comp.yml
@@ -27,7 +27,10 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - uses: ilammy/msvc-dev-cmd@v1
-    - uses: ilammy/setup-nasm@v1
+    - name: install nasm
+      run: |
+        choco install nasm
+        "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: prepare the build directory
       run: mkdir _build
     - name: Get zstd
@@ -86,7 +89,10 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - uses: ilammy/msvc-dev-cmd@v1
-    - uses: ilammy/setup-nasm@v1
+    - name: install nasm
+      run: |
+        choco install nasm
+        "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: prepare the build directory
       run: mkdir _build
     - name: Get brotli


### PR DESCRIPTION
This PR replaces `ilammy/setup-nasm@v1` GitHub Actions with command to install `nasm` from [Chocolatey](https://chocolatey.org/) software repository for Windows.