### PR TITLE
dllmain: remove cpuid_setup call

### DIFF
--- a/crypto/dllmain.c
+++ b/crypto/dllmain.c
@@ -30,7 +30,6 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     switch (fdwReason) {
     case DLL_PROCESS_ATTACH:
-        OPENSSL_cpuid_setup();
         break;
     case DLL_THREAD_ATTACH:
         break;


### PR DESCRIPTION
`OPENSSL_cpuid_setup` has been explicitly called from libcrypto init function (introduced in 2016 in b184e3ef732), so the call from DllMain could be redundant.

This line dates back to the initial introduction of cpuid in 14e21f863a3 in 2004.

See also discussion in https://github.com/openssl/openssl/pull/27466#issuecomment-2821137574
