### PR TITLE
apps/pkeyutl.c: Add OPENSSL_free() to avoid a memory leak

### DIFF
--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -426,6 +426,7 @@ int pkeyutl_main(int argc, char **argv)
             if (EVP_PKEY_CTX_ctrl_str(ctx, opt, passwd) <= 0) {
                 BIO_printf(bio_err, "%s: Can't set parameter \"%s\":\n",
                            prog, opt);
+                OPENSSL_free(passwd);
                 goto end;
             }
             OPENSSL_free(passwd);


### PR DESCRIPTION
If EVP_PKEY_CTX_ctrl_str() fails, the code jumps to 'end' label without freeing passwd, causing a memory leak.

Fixes: 9d1bf5f7de ("Add option to read pkeyopts interactively")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
