### PR TITLE
Fix typo in SHA256 RISC-V64 Zbb comments: Sigma0 -> Sum0

### DIFF
--- a/crypto/sha/asm/sha256-riscv64-zbb.pl
+++ b/crypto/sha/asm/sha256-riscv64-zbb.pl
@@ -134,7 +134,7 @@ sub sha256_T2 {
         $a, $b, $c,
     ) = @_;
     my $code=<<___;
-    # Sigma0
+    # Sum0
     @{[roriw $T2, $a, 2]}  # roriw $T2, $a, 2
     @{[roriw $T3, $a, 13]}  # roriw $T3, $a, 13
     @{[roriw $T4, $a, 22]}  # roriw $T4, $a, 22


### PR DESCRIPTION
This corrects a misleading comment in sha256-riscv64-zbb.pl. The rotation operation corresponds to the Sum0 function as defined in the FIPS 180-4 standard, not Sigma0.

CLA: trivial


Fixes #27463

