### PR TITLE
SKEYMGMT: Expose settable params

### DIFF
--- a/providers/implementations/skeymgmt/aes_skmgmt.c
+++ b/providers/implementations/skeymgmt/aes_skmgmt.c
@@ -48,5 +48,7 @@ const OSSL_DISPATCH ossl_aes_skeymgmt_functions[] = {
     { OSSL_FUNC_SKEYMGMT_FREE, (void (*)(void))generic_free },
     { OSSL_FUNC_SKEYMGMT_IMPORT, (void (*)(void))aes_import },
     { OSSL_FUNC_SKEYMGMT_EXPORT, (void (*)(void))aes_export },
+    { OSSL_FUNC_SKEYMGMT_IMP_SETTABLE_PARAMS,
+      (void (*)(void))generic_imp_settable_params },
     OSSL_DISPATCH_END
 };

--- a/providers/implementations/skeymgmt/generic.c
+++ b/providers/implementations/skeymgmt/generic.c
@@ -65,6 +65,16 @@ end:
     return generic;
 }
 
+static const OSSL_PARAM generic_import_params[] = {
+    OSSL_PARAM_octet_string(OSSL_SKEY_PARAM_RAW_BYTES, NULL, 0),
+    OSSL_PARAM_END
+};
+
+const OSSL_PARAM *generic_imp_settable_params(void *provctx)
+{
+    return generic_import_params;
+}
+
 int generic_export(void *keydata, int selection,
                    OSSL_CALLBACK *param_callback, void *cbarg)
 {
@@ -89,5 +99,7 @@ const OSSL_DISPATCH ossl_generic_skeymgmt_functions[] = {
     { OSSL_FUNC_SKEYMGMT_FREE, (void (*)(void))generic_free },
     { OSSL_FUNC_SKEYMGMT_IMPORT, (void (*)(void))generic_import },
     { OSSL_FUNC_SKEYMGMT_EXPORT, (void (*)(void))generic_export },
+    { OSSL_FUNC_SKEYMGMT_IMP_SETTABLE_PARAMS,
+      (void (*)(void))generic_imp_settable_params },
     OSSL_DISPATCH_END
 };

--- a/providers/implementations/skeymgmt/skeymgmt_lcl.h
+++ b/providers/implementations/skeymgmt/skeymgmt_lcl.h
@@ -15,5 +15,6 @@
 OSSL_FUNC_skeymgmt_import_fn generic_import;
 OSSL_FUNC_skeymgmt_export_fn generic_export;
 OSSL_FUNC_skeymgmt_free_fn generic_free;
+OSSL_FUNC_skeymgmt_imp_settable_params_fn generic_imp_settable_params;
 
 #endif


### PR DESCRIPTION
This is needed for tools that do things like passing
    -skeyopt hexraw-bytes:0102030405060708090a0b0c0d0e0f10
to tools.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
