### PR TITLE
Disable unterminated-string-initialization in strict-warnings

### DIFF
--- a/Configure
+++ b/Configure
@@ -171,6 +171,7 @@ my @gcc_devteam_warn = qw(
     -Wextra
     -Wno-unused-parameter
     -Wno-missing-field-initializers
+    -Wno-unterminated-string-initialization
     -Wswitch
     -Wsign-compare
     -Wshadow


### PR DESCRIPTION
Recently updated to fedora 42, which includes an updated gcc, which triggers a new warning:

test/afalgtest.c:44:9: error: initializer-string for array of 'unsigned char' truncates NUL terminator but destination lacks 'nonstring' attribute (18 chars into 17 available) [-Werror=unterminated-string-initialization]
   44 |         "\x53\x69\x6e\x67\x6c\x65\x20\x62\x6c\x6f\x63\x6b\x20\x6d\x73\x67"

The warning occurs because in some locations we create char buffers of length X, and fill it with X bytes of data, truncating the NULL terminator.

We could fix it by adding the nonstring attribute, but given that: 
1) Adding attributes might impact other platforms that don't understand the
   attribute.

2) We often create char buffers that don't expect a NULL terminator.

3) Converting the unsigned char arrays to uint8_t, or other types that
   could be interpreted as non-strings has no impact, only applying the
   nonstring attribute silences the warning.

It seems more sensible to just disable the warning entirely


