### PR TITLE
`app/s_client.c`: clean up and broaden use of `ERR_print_errors()`

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3254,7 +3254,8 @@ int s_client_main(int argc, char **argv)
     }
 
  shut:
-    ERR_print_errors(bio_err); /* show any errors accumulated so far */
+    if (ret > 0)
+        ERR_print_errors(bio_err); /* show any errors accumulated so far */
     if (in_init)
         print_stuff(bio_c_out, con, full_log);
     do_ssl_shutdown(con);
@@ -3285,7 +3286,8 @@ int s_client_main(int argc, char **argv)
 
     BIO_closesocket(SSL_get_fd(con));
  end:
-    ERR_print_errors(bio_err); /* show any new or remaining errors */
+    if (ret > 0)
+        ERR_print_errors(bio_err); /* show any new or remaining errors */
     if (con != NULL) {
         if (prexit != 0)
             print_stuff(bio_c_out, con, 1);

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -446,11 +446,13 @@ static int tlsa_import_rr(SSL *con, const char *rrdata)
     OPENSSL_free(data);
 
     if (ret == 0) {
+        ERR_print_errors(bio_err);
         BIO_printf(bio_err, "%s: warning: unusable TLSA rrdata: %s\n",
                    prog, rrdata);
         return 0;
     }
     if (ret < 0) {
+        ERR_print_errors(bio_err);
         BIO_printf(bio_err, "%s: warning: error loading TLSA rrdata: %s\n",
                    prog, rrdata);
         return 0;

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -446,13 +446,11 @@ static int tlsa_import_rr(SSL *con, const char *rrdata)
     OPENSSL_free(data);
 
     if (ret == 0) {
-        ERR_print_errors(bio_err);
         BIO_printf(bio_err, "%s: warning: unusable TLSA rrdata: %s\n",
                    prog, rrdata);
         return 0;
     }
     if (ret < 0) {
-        ERR_print_errors(bio_err);
         BIO_printf(bio_err, "%s: warning: error loading TLSA rrdata: %s\n",
                    prog, rrdata);
         return 0;
@@ -1772,7 +1770,6 @@ int s_client_main(int argc, char **argv)
         crls = sk_X509_CRL_new_null();
         if (crls == NULL || !sk_X509_CRL_push(crls, crl)) {
             BIO_puts(bio_err, "Error adding CRL\n");
-            ERR_print_errors(bio_err);
             X509_CRL_free(crl);
             goto end;
         }
@@ -1808,10 +1805,8 @@ int s_client_main(int argc, char **argv)
 #endif
 
     ctx = SSL_CTX_new_ex(app_get0_libctx(), app_get0_propq(), meth);
-    if (ctx == NULL) {
-        ERR_print_errors(bio_err);
+    if (ctx == NULL)
         goto end;
-    }
 
     SSL_CTX_clear_mode(ctx, SSL_MODE_AUTO_RETRY);
 
@@ -1825,7 +1820,6 @@ int s_client_main(int argc, char **argv)
         if (SSL_CTX_config(ctx, ssl_config) == 0) {
             BIO_printf(bio_err, "Error using configuration \"%s\"\n",
                        ssl_config);
-            ERR_print_errors(bio_err);
             goto end;
         }
     }
@@ -1851,7 +1845,6 @@ int s_client_main(int argc, char **argv)
 
     if (vpmtouched && !SSL_CTX_set1_param(ctx, vpm)) {
         BIO_printf(bio_err, "Error setting verify params\n");
-        ERR_print_errors(bio_err);
         goto end;
     }
 
@@ -1897,7 +1890,6 @@ int s_client_main(int argc, char **argv)
                          chCApath, chCAfile, chCAstore,
                          crls, crl_download)) {
         BIO_printf(bio_err, "Error loading store locations\n");
-        ERR_print_errors(bio_err);
         goto end;
     }
     if (ReqCAfile != NULL) {
@@ -1906,7 +1898,6 @@ int s_client_main(int argc, char **argv)
         if (nm == NULL || !SSL_add_file_cert_subjects_to_stack(nm, ReqCAfile)) {
             sk_X509_NAME_pop_free(nm, X509_NAME_free);
             BIO_printf(bio_err, "Error loading CA names\n");
-            ERR_print_errors(bio_err);
             goto end;
         }
         SSL_CTX_set0_CA_list(ctx, nm);
@@ -1915,7 +1906,6 @@ int s_client_main(int argc, char **argv)
     if (ssl_client_engine) {
         if (!SSL_CTX_set_client_cert_engine(ctx, ssl_client_engine)) {
             BIO_puts(bio_err, "Error setting client auth engine\n");
-            ERR_print_errors(bio_err);
             release_engine(ssl_client_engine);
             goto end;
         }
@@ -1935,14 +1925,12 @@ int s_client_main(int argc, char **argv)
 
         if (stmp == NULL) {
             BIO_printf(bio_err, "Can't open PSK session file %s\n", psksessf);
-            ERR_print_errors(bio_err);
             goto end;
         }
         psksess = PEM_read_bio_SSL_SESSION(stmp, NULL, 0, NULL);
         BIO_free(stmp);
         if (psksess == NULL) {
             BIO_printf(bio_err, "Can't read PSK session file %s\n", psksessf);
-            ERR_print_errors(bio_err);
             goto end;
         }
     }
@@ -1954,7 +1942,6 @@ int s_client_main(int argc, char **argv)
         /* Returns 0 on success! */
         if (SSL_CTX_set_tlsext_use_srtp(ctx, srtp_profiles) != 0) {
             BIO_printf(bio_err, "Error setting SRTP profile\n");
-            ERR_print_errors(bio_err);
             goto end;
         }
     }
@@ -2001,15 +1988,12 @@ int s_client_main(int argc, char **argv)
     /* Enable SCT processing, without early connection termination */
     if (ct_validation &&
         !SSL_CTX_enable_ct(ctx, SSL_CT_VALIDATION_PERMISSIVE)) {
-        ERR_print_errors(bio_err);
         goto end;
     }
 
     if (!ctx_set_ctlog_list_file(ctx, ctlog_file)) {
-        if (ct_validation) {
-            ERR_print_errors(bio_err);
+        if (ct_validation)
             goto end;
-        }
 
         /*
          * If CT validation is not enabled, the log list isn't needed so don't
@@ -2024,10 +2008,8 @@ int s_client_main(int argc, char **argv)
     SSL_CTX_set_verify(ctx, verify, verify_callback);
 
     if (!ctx_set_verify_locations(ctx, CAfile, noCAfile, CApath, noCApath,
-                                  CAstore, noCAstore)) {
-        ERR_print_errors(bio_err);
+                                  CAstore, noCAstore))
         goto end;
-    }
 
     ssl_ctx_add_crls(ctx, crls, crl_download);
 
@@ -2050,7 +2032,6 @@ int s_client_main(int argc, char **argv)
             BIO_printf(bio_err,
                        "%s: Error enabling DANE TLSA authentication.\n",
                        prog);
-            ERR_print_errors(bio_err);
             goto end;
         }
     }
@@ -2091,19 +2072,16 @@ int s_client_main(int argc, char **argv)
         BIO *stmp = BIO_new_file(sess_in, "r");
         if (stmp == NULL) {
             BIO_printf(bio_err, "Can't open session file %s\n", sess_in);
-            ERR_print_errors(bio_err);
             goto end;
         }
         sess = PEM_read_bio_SSL_SESSION(stmp, NULL, 0, NULL);
         BIO_free(stmp);
         if (sess == NULL) {
             BIO_printf(bio_err, "Can't open session file %s\n", sess_in);
-            ERR_print_errors(bio_err);
             goto end;
         }
         if (!SSL_set_session(con, sess)) {
             BIO_printf(bio_err, "Can't set session\n");
-            ERR_print_errors(bio_err);
             goto end;
         }
 
@@ -2120,7 +2098,6 @@ int s_client_main(int argc, char **argv)
         }
         if (servername != NULL && !SSL_set_tlsext_host_name(con, servername)) {
             BIO_printf(bio_err, "Unable to set TLS servername extension.\n");
-            ERR_print_errors(bio_err);
             goto end;
         }
     }
@@ -2129,7 +2106,6 @@ int s_client_main(int argc, char **argv)
         if (SSL_dane_enable(con, dane_tlsa_domain) <= 0) {
             BIO_printf(bio_err, "%s: Error enabling DANE TLSA "
                        "authentication.\n", prog);
-            ERR_print_errors(bio_err);
             goto end;
         }
         if (dane_tlsa_rrset == NULL) {
@@ -2185,10 +2161,8 @@ int s_client_main(int argc, char **argv)
      * non-blocking mode at the SSL level
      */
     if (c_nbio || isquic) {
-        if (!BIO_socket_nbio(sock, 1)) {
-            ERR_print_errors(bio_err);
+        if (!BIO_socket_nbio(sock, 1))
             goto end;
-        }
         if (c_nbio) {
             if (isquic && !SSL_set_blocking_mode(con, 0))
                 goto end;
@@ -2267,7 +2241,6 @@ int s_client_main(int argc, char **argv)
 
     if (sbio == NULL) {
         BIO_printf(bio_err, "Unable to create BIO\n");
-        ERR_print_errors(bio_err);
         BIO_closesocket(sock);
         goto end;
     }
@@ -2584,7 +2557,6 @@ int s_client_main(int argc, char **argv)
                 }
                 if (numeric == 691) {
                     BIO_printf(bio_err, "STARTTLS negotiation failed: ");
-                    ERR_print_errors(bio_err);
                     break;
                 }
             } while (numeric != 670);
@@ -2894,7 +2866,6 @@ int s_client_main(int argc, char **argv)
                 default:
                     BIO_printf(bio_err, "Error writing early data\n");
                     BIO_free(edfile);
-                    ERR_print_errors(bio_err);
                     goto shut;
                 }
             }
@@ -3138,7 +3109,6 @@ int s_client_main(int argc, char **argv)
             case SSL_ERROR_WANT_ASYNC_JOB:
                 /* This shouldn't ever happen in s_client - treat as an error */
             case SSL_ERROR_SSL:
-                ERR_print_errors(bio_err);
                 goto shut;
             }
         }
@@ -3226,7 +3196,6 @@ int s_client_main(int argc, char **argv)
             case SSL_ERROR_WANT_ASYNC_JOB:
                 /* This shouldn't ever happen in s_client. Treat as an error */
             case SSL_ERROR_SSL:
-                ERR_print_errors(bio_err);
                 goto shut;
             }
         }
@@ -3285,6 +3254,7 @@ int s_client_main(int argc, char **argv)
     }
 
  shut:
+    ERR_print_errors(bio_err); /* show any errors accumulated so far */
     if (in_init)
         print_stuff(bio_c_out, con, full_log);
     do_ssl_shutdown(con);
@@ -3315,6 +3285,7 @@ int s_client_main(int argc, char **argv)
 
     BIO_closesocket(SSL_get_fd(con));
  end:
+    ERR_print_errors(bio_err); /* show any new or remaining errors */
     if (con != NULL) {
         if (prexit != 0)
             print_stuff(bio_c_out, con, 1);
@@ -3921,8 +3892,6 @@ static int user_data_execute(struct user_data_st *user_data, int cmd, char *arg)
     }
 
     BIO_printf(bio_err, "ERROR\n");
-    ERR_print_errors(bio_err);
-
     return USER_DATA_PROCESS_SHUT;
 }
 


### PR DESCRIPTION
During discussion at https://github.com/openssl/openssl/issues/27461#issuecomment-2827572573 came up that in `s_client.c`, 
on the one hand, `ERR_print_errors(bio_err)` are scattered in many places,
but on the other hand, are missing in other error situations.
This is fixed here.
