### PR TITLE
BIO_dump_indent_cb(): Check for negative return from BIO_snprintf()

### DIFF
--- a/crypto/bio/bio_dump.c
+++ b/crypto/bio/bio_dump.c
@@ -47,6 +47,8 @@ int BIO_dump_indent_cb(int (*cb) (const void *data, size_t len, void *u),
     for (i = 0; i < rows; i++) {
         n = BIO_snprintf(buf, sizeof(buf), "%*s%04x - ", indent, "",
                          i * dump_width);
+        if (n < 0)
+            return -1;
         for (j = 0; j < dump_width; j++) {
             if (SPACE(buf, n, 3)) {
                 if (((i * dump_width) + j) >= len) {


### PR DESCRIPTION
In practice this cannot happen but Coverity complains.

Fixes Coverity 1646683
