### PR TITLE
OSSL_STORE: Improve diagnostics of `file_set_ctx_params()` and `cache_objects()` in `crypto/x509/by_store.c`

### DIFF
--- a/crypto/x509/by_store.c
+++ b/crypto/x509/by_store.c
@@ -43,8 +43,11 @@ static int cache_objects(X509_LOOKUP *lctx, const char *uri,
      * but it's a nice optimization when it can be applied (such as on an
      * actual directory with a thousand CA certs).
      */
-    if (criterion != NULL)
+    if (criterion != NULL) {
+        ERR_set_mark();
         OSSL_STORE_find(ctx, criterion);
+        ERR_pop_to_mark();
+    }
 
     for (;;) {
         OSSL_STORE_INFO *info = OSSL_STORE_load(ctx);

--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -350,22 +350,26 @@ static int file_set_ctx_params(void *loaderctx, const OSSL_PARAM params[])
         size_t der_len = 0;
         X509_NAME *x509_name;
         unsigned long hash;
-        int ok;
-
-        if (ctx->type != IS_DIR) {
-            ERR_raise(ERR_LIB_PROV,
-                      PROV_R_SEARCH_ONLY_SUPPORTED_FOR_DIRECTORIES);
-            return 0;
-        }
+        int ok = 0;
 
         if (!OSSL_PARAM_get_octet_string_ptr(p, (const void **)&der, &der_len)
             || (x509_name = d2i_X509_NAME(NULL, &der, der_len)) == NULL)
             return 0;
+        if (ctx->type != IS_DIR) {
+            char *str = X509_NAME_oneline(x509_name, NULL, 0);
+
+            ERR_raise_data(ERR_LIB_PROV, PROV_R_SEARCH_ONLY_SUPPORTED_FOR_DIRECTORIES,
+                           "uri=%s:subject=%s", ctx->uri, str);
+            OPENSSL_free(str);
+            goto end;
+        }
+
         hash = X509_NAME_hash_ex(x509_name,
                                  ossl_prov_ctx_get0_libctx(ctx->provctx), NULL,
                                  &ok);
         BIO_snprintf(ctx->_.dir.search_name, sizeof(ctx->_.dir.search_name),
                      "%08lx", hash);
+    end:
         X509_NAME_free(x509_name);
         if (ok == 0)
             return 0;


### PR DESCRIPTION
This is another spin-off from #27461 following up https://github.com/openssl/openssl/issues/27461#issuecomment-2829480670.
