### PR TITLE
Clarify how s_client -ign_eof and -quiet impact command processing

### DIFF
--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -507,7 +507,7 @@ by some servers.
 =item B<-ign_eof>
 
 Inhibit shutting down the connection when end of file is reached in the
-input. This implicitly turn on B<-nocommands> as well.
+input. This implicitly turns on B<-nocommands> as well.
 
 =item B<-quiet>
 

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -507,12 +507,12 @@ by some servers.
 =item B<-ign_eof>
 
 Inhibit shutting down the connection when end of file is reached in the
-input.
+input. This implicitly turn on B<-nocommands> as well.
 
 =item B<-quiet>
 
 Inhibit printing of session and certificate information.  This implicitly
-turns on B<-ign_eof> as well.
+turns on B<-ign_eof> and B<-nocommands> as well.
 
 =item B<-no_ign_eof>
 


### PR DESCRIPTION
If -ign_eof -or -quiet are passed to s_client this implicitly turns off command processing (i.e. equivalent to -nocommands). This was stated on the man page in the "CONNECTED COMMANDS" section, but not in the documentation for "-ign_eof" or "-quiet" directly. We state it here as well to make it clearer.

Fixes #27443