### PR TITLE
crl_verify: enforce RFC5280 extension rules in CRL App do_ver

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -135,7 +135,7 @@ GENERATED_PODS={- # common0.tmpl provides @generated
                        fill_lines(" ", $COLUMNS - 15,
                                   map { my $x = $_;
                                         (
-                                          grep {
+                                          grep { 
                                                  $unified_info{attributes}->{depends}
                                                  ->{$x}->{$_}->{pod} // 0
                                                }
@@ -813,12 +813,12 @@ install_dev: install_runtime_libs
 		cp $$e "$(DESTDIR)$(PKGCONFIGDIR)/$$fn"; \
 		chmod 644 "$(DESTDIR)$(PKGCONFIGDIR)/$$fn"; \
 	done
-	@$(PERL) $(SRCDIR)/util/mkdir-p.pl "$(DESTDIR)$(CMAKECONFIGDIR)"
+	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(CMAKECONFIGDIR)
 	@for e in $(INSTALL_EXPORTERS_CMAKE); do \
 		fn=`basename $$e`; \
 		$(ECHO) "install $$e -> $(DESTDIR)$(CMAKECONFIGDIR)/$$fn"; \
-		cp $$e "$(DESTDIR)$(CMAKECONFIGDIR)/$$fn"; \
-		chmod 644 "$(DESTDIR)$(CMAKECONFIGDIR)/$$fn"; \
+		cp $$e $(DESTDIR)$(CMAKECONFIGDIR)/$$fn; \
+		chmod 644 $(DESTDIR)$(CMAKECONFIGDIR)/$$fn; \
 	done
 
 uninstall_dev: uninstall_runtime_libs

--- a/apps/list.c
+++ b/apps/list.c
@@ -1336,29 +1336,20 @@ static void list_store_loaders(void)
                                       stores);
     sk_OSSL_STORE_LOADER_sort(stores);
     for (i = 0; i < sk_OSSL_STORE_LOADER_num(stores); i++) {
-        const OSSL_STORE_LOADER *l = sk_OSSL_STORE_LOADER_value(stores, i);
+        const OSSL_STORE_LOADER *m = sk_OSSL_STORE_LOADER_value(stores, i);
         STACK_OF(OPENSSL_CSTRING) *names = NULL;
 
-        if (select_name != NULL && !OSSL_STORE_LOADER_is_a(l, select_name))
+        if (select_name != NULL && !OSSL_STORE_LOADER_is_a(m, select_name))
             continue;
 
         names = sk_OPENSSL_CSTRING_new(name_cmp);
-        if (names != NULL && OSSL_STORE_LOADER_names_do_all(l, collect_names,
+        if (names != NULL && OSSL_STORE_LOADER_names_do_all(m, collect_names,
                                                             names)) {
             BIO_printf(bio_out, "  ");
             print_names(bio_out, names);
 
             BIO_printf(bio_out, " @ %s\n",
-                       OSSL_PROVIDER_get0_name(OSSL_STORE_LOADER_get0_provider(l)));
-
-            if (verbose) {
-                const char *desc = OSSL_STORE_LOADER_get0_description(l);
-
-                if (desc != NULL)
-                    BIO_printf(bio_out, "    description: %s\n", desc);
-                print_param_types("settable operation parameters",
-                                  OSSL_STORE_LOADER_settable_ctx_params(l), 4);
-            }
+                       OSSL_PROVIDER_get0_name(OSSL_STORE_LOADER_get0_provider(m)));
         }
         sk_OPENSSL_CSTRING_free(names);
     }

--- a/crypto/bio/bio_dump.c
+++ b/crypto/bio/bio_dump.c
@@ -47,8 +47,6 @@ int BIO_dump_indent_cb(int (*cb) (const void *data, size_t len, void *u),
     for (i = 0; i < rows; i++) {
         n = BIO_snprintf(buf, sizeof(buf), "%*s%04x - ", indent, "",
                          i * dump_width);
-        if (n < 0)
-            return -1;
         for (j = 0; j < dump_width; j++) {
             if (SPACE(buf, n, 3)) {
                 if (((i * dump_width) + j) >= len) {

--- a/crypto/bio/bio_print.c
+++ b/crypto/bio/bio_print.c
@@ -535,10 +535,6 @@ static LDOUBLE abs_val(LDOUBLE value)
     LDOUBLE result = value;
     if (value < 0)
         result = -value;
-    if (result > 0 && result / 2 == result) /* INF */
-        result = 0;
-    else if (result != result) /* NAN */
-        result = 0;
     return result;
 }
 
@@ -595,8 +591,6 @@ fmtfp(char **sbuffer,
     else if (flags & DP_F_SPACE)
         signvalue = ' ';
     ufvalue = abs_val(fvalue);
-    if (ufvalue == 0 && fvalue != 0) /* INF or NAN? */
-        signvalue = '?';
 
     /*
      * G_FORMAT sometimes prints like E_FORMAT and sometimes like F_FORMAT

--- a/crypto/sha/asm/sha256-riscv64-zbb.pl
+++ b/crypto/sha/asm/sha256-riscv64-zbb.pl
@@ -134,7 +134,7 @@ sub sha256_T2 {
         $a, $b, $c,
     ) = @_;
     my $code=<<___;
-    # Sum0
+    # Sigma0
     @{[roriw $T2, $a, 2]}  # roriw $T2, $a, 2
     @{[roriw $T3, $a, 13]}  # roriw $T3, $a, 13
     @{[roriw $T4, $a, 22]}  # roriw $T4, $a, 22

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -502,11 +502,3 @@ int OSSL_STORE_LOADER_names_do_all(const OSSL_STORE_LOADER *loader,
 
     return 1;
 }
-
-const OSSL_PARAM *
-OSSL_STORE_LOADER_settable_ctx_params(const OSSL_STORE_LOADER *loader)
-{
-    if (loader != NULL && loader->p_settable_ctx_params != NULL)
-        return loader->p_settable_ctx_params(NULL);
-    return NULL;
-}

--- a/crypto/x509/by_store.c
+++ b/crypto/x509/by_store.c
@@ -43,11 +43,8 @@ static int cache_objects(X509_LOOKUP *lctx, const char *uri,
      * but it's a nice optimization when it can be applied (such as on an
      * actual directory with a thousand CA certs).
      */
-    if (criterion != NULL) {
-        ERR_set_mark();
+    if (criterion != NULL)
         OSSL_STORE_find(ctx, criterion);
-        ERR_pop_to_mark();
-    }
 
     for (;;) {
         OSSL_STORE_INFO *info = OSSL_STORE_load(ctx);

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -106,7 +106,7 @@ OSSL_CMP_CTX_set1_senderNonce
  /* server authentication: */
  int OSSL_CMP_CTX_set1_srvCert(OSSL_CMP_CTX *ctx, X509 *cert);
  int OSSL_CMP_CTX_set1_expected_sender(OSSL_CMP_CTX *ctx,
-                                       const X509_NAME *name);
+                                      const X509_NAME *name);
  #define OSSL_CMP_CTX_set0_trusted OSSL_CMP_CTX_set0_trustedStore
  int OSSL_CMP_CTX_set0_trustedStore(OSSL_CMP_CTX *ctx, X509_STORE *store);
  #define OSSL_CMP_CTX_get0_trusted OSSL_CMP_CTX_get0_trustedStore
@@ -214,147 +214,147 @@ The following options can be set:
 
 =item B<OSSL_CMP_OPT_LOG_VERBOSITY>
 
-The level of severity needed for actually outputting log messages
-due to errors, warnings, general info, debugging, etc.
-Default is OSSL_CMP_LOG_INFO. See also L<OSSL_CMP_log_open(3)>.
+        The level of severity needed for actually outputting log messages
+        due to errors, warnings, general info, debugging, etc.
+        Default is OSSL_CMP_LOG_INFO. See also L<OSSL_CMP_log_open(3)>.
 
 =item B<OSSL_CMP_OPT_KEEP_ALIVE>
 
-If the given value is 0 then HTTP connections are not kept open
-after receiving a response, which is the default behavior for HTTP 1.0.
-If the value is 1 or 2 then persistent connections are requested.
-If the value is 2 then persistent connections are required,
-i.e., in case the server does not grant them an error occurs.
-The default value is 1: prefer to keep the connection open.
+        If the given value is 0 then HTTP connections are not kept open
+        after receiving a response, which is the default behavior for HTTP 1.0.
+        If the value is 1 or 2 then persistent connections are requested.
+        If the value is 2 then persistent connections are required,
+        i.e., in case the server does not grant them an error occurs.
+        The default value is 1: prefer to keep the connection open.
 
 =item B<OSSL_CMP_OPT_MSG_TIMEOUT>
 
-Number of seconds a CMP request-response message round trip
-is allowed to take before a timeout error is returned.
-A value <= 0 means no limitation (waiting indefinitely).
-Default is to use the B<OSSL_CMP_OPT_TOTAL_TIMEOUT> setting.
+        Number of seconds a CMP request-response message round trip
+        is allowed to take before a timeout error is returned.
+        A value <= 0 means no limitation (waiting indefinitely).
+        Default is to use the B<OSSL_CMP_OPT_TOTAL_TIMEOUT> setting.
 
 =item B<OSSL_CMP_OPT_TOTAL_TIMEOUT>
 
-Maximum total number of seconds a transaction may take,
-including polling etc.
-A value <= 0 means no limitation (waiting indefinitely).
-Default is 0.
+        Maximum total number of seconds a transaction may take,
+        including polling etc.
+        A value <= 0 means no limitation (waiting indefinitely).
+        Default is 0.
 
 =item B<OSSL_CMP_OPT_USE_TLS>
 
-Use this option to indicate to the HTTP implementation
-whether TLS is going to be used for the connection (resulting in HTTPS).
-The value 1 indicates that TLS is used for client-side HTTP connections,
-which needs to be implemented via a callback function set by
-OSSL_CMP_CTX_set_http_cb().
-The value 0 indicates that TLS is not used.
-Default is -1 for backward compatibility: TLS is used by the client side
-if and only if OSSL_CMP_CTX_set_http_cb_arg() sets a non-NULL I<arg>.
+        Use this option to indicate to the HTTP implementation
+        whether TLS is going to be used for the connection (resulting in HTTPS).
+        The value 1 indicates that TLS is used for client-side HTTP connections,
+        which needs to be implemented via a callback function set by
+        OSSL_CMP_CTX_set_http_cb().
+        The value 0 indicates that TLS is not used.
+        Default is -1 for backward compatibility: TLS is used by the client side
+        if and only if OSSL_CMP_CTX_set_http_cb_arg() sets a non-NULL I<arg>.
 
 =item B<OSSL_CMP_OPT_VALIDITY_DAYS>
 
-Number of days new certificates are asked to be valid for.
+        Number of days new certificates are asked to be valid for.
 
 =item B<OSSL_CMP_OPT_SUBJECTALTNAME_NODEFAULT>
 
-Do not take default Subject Alternative Names
-from the reference certificate.
+        Do not take default Subject Alternative Names
+        from the reference certificate.
 
 =item B<OSSL_CMP_OPT_SUBJECTALTNAME_CRITICAL>
 
-Demand that the given Subject Alternative Names are flagged as critical.
+        Demand that the given Subject Alternative Names are flagged as critical.
 
 =item B<OSSL_CMP_OPT_POLICIES_CRITICAL>
 
-Demand that the given policies are flagged as critical.
+        Demand that the given policies are flagged as critical.
 
 =item B<OSSL_CMP_OPT_POPO_METHOD>
 
-Select the proof of possession method to use. Possible values are:
+        Select the proof of possession method to use. Possible values are:
 
-    OSSL_CRMF_POPO_NONE       - ProofOfPossession field omitted,
-                                which implies central key generation
-    OSSL_CRMF_POPO_RAVERIFIED - assert that the RA has already
-                                verified the PoPo
-    OSSL_CRMF_POPO_SIGNATURE  - sign a value with private key,
-                                which is the default.
-    OSSL_CRMF_POPO_KEYENC     - decrypt the encrypted certificate
-                                ("indirect method")
+            OSSL_CRMF_POPO_NONE       - ProofOfPossession field omitted,
+                                        which implies central key generation
+            OSSL_CRMF_POPO_RAVERIFIED - assert that the RA has already
+                                        verified the PoPo
+            OSSL_CRMF_POPO_SIGNATURE  - sign a value with private key,
+                                        which is the default.
+            OSSL_CRMF_POPO_KEYENC     - decrypt the encrypted certificate
+                                        ("indirect method")
 
-Note that a signature-based POPO can only be produced if a private key
-is provided as the newPkey or client's pkey component of the CMP context.
+        Note that a signature-based POPO can only be produced if a private key
+        is provided as the newPkey or client's pkey component of the CMP context.
 
 =item B<OSSL_CMP_OPT_DIGEST_ALGNID>
 
-The NID of the digest algorithm to be used in RFC 4210's MSG_SIG_ALG
-for signature-based message protection and Proof-of-Possession (POPO).
-Default is SHA256.
+        The NID of the digest algorithm to be used in RFC 4210's MSG_SIG_ALG
+        for signature-based message protection and Proof-of-Possession (POPO).
+        Default is SHA256.
 
 =item B<OSSL_CMP_OPT_OWF_ALGNID>
-The NID of the digest algorithm to be used as one-way function (OWF)
-for MAC-based message protection with password-based MAC (PBM).
-See RFC 4210 section 5.1.3.1 for details.
-Default is SHA256.
+        The NID of the digest algorithm to be used as one-way function (OWF)
+        for MAC-based message protection with password-based MAC (PBM).
+        See RFC 4210 section 5.1.3.1 for details.
+        Default is SHA256.
 
 =item B<OSSL_CMP_OPT_MAC_ALGNID>
-The NID of the MAC algorithm to be used for message protection with PBM.
-Default is HMAC-SHA1 as per RFC 4210.
+        The NID of the MAC algorithm to be used for message protection with PBM.
+        Default is HMAC-SHA1 as per RFC 4210.
 
 =item B<OSSL_CMP_OPT_REVOCATION_REASON>
 
-The reason code to be included in a Revocation Request (RR);
-values: 0..10 (RFC 5210, 5.3.1) or -1 for none, which is the default.
+        The reason code to be included in a Revocation Request (RR);
+        values: 0..10 (RFC 5210, 5.3.1) or -1 for none, which is the default.
 
 =item B<OSSL_CMP_OPT_IMPLICIT_CONFIRM>
 
-Request server to enable implicit confirm mode, where the client
-does not need to send confirmation upon receiving the
-certificate. If the server does not enable implicit confirmation
-in the return message, then confirmation is sent anyway.
+        Request server to enable implicit confirm mode, where the client
+        does not need to send confirmation upon receiving the
+        certificate. If the server does not enable implicit confirmation
+        in the return message, then confirmation is sent anyway.
 
 =item B<OSSL_CMP_OPT_DISABLE_CONFIRM>
 
-Do not confirm enrolled certificates, to cope with broken servers
-not supporting implicit confirmation correctly.
+        Do not confirm enrolled certificates, to cope with broken servers
+        not supporting implicit confirmation correctly.
 B<WARNING:> This setting leads to unspecified behavior and it is meant
 exclusively to allow interoperability with server implementations violating
 RFC 4210.
 
 =item B<OSSL_CMP_OPT_UNPROTECTED_SEND>
 
-Send request or response messages without CMP-level protection.
+        Send request or response messages without CMP-level protection.
 
 =item B<OSSL_CMP_OPT_UNPROTECTED_ERRORS>
 
-Accept unprotected error responses which are either explicitly
-unprotected or where protection verification failed. Applies to regular
-error messages as well as certificate responses (IP/CP/KUP) and
-revocation responses (RP) with rejection.
+        Accept unprotected error responses which are either explicitly
+        unprotected or where protection verification failed. Applies to regular
+        error messages as well as certificate responses (IP/CP/KUP) and
+        revocation responses (RP) with rejection.
 B<WARNING:> This setting leads to unspecified behavior and it is meant
 exclusively to allow interoperability with server implementations violating
 RFC 4210.
 
 =item B<OSSL_CMP_OPT_IGNORE_KEYUSAGE>
 
-Ignore key usage restrictions in the signer's certificate when
-validating signature-based protection in received CMP messages.
-Else, 'digitalSignature' must be allowed by CMP signer certificates.
+        Ignore key usage restrictions in the signer's certificate when
+        validating signature-based protection in received CMP messages.
+        Else, 'digitalSignature' must be allowed by CMP signer certificates.
 
 =item B<OSSL_CMP_OPT_PERMIT_TA_IN_EXTRACERTS_FOR_IR>
 
-Allow retrieving a trust anchor from extraCerts and using that
-to validate the certificate chain of an IP message.
-This is a quirk option added to support 3GPP TS 33.310.
+        Allow retrieving a trust anchor from extraCerts and using that
+        to validate the certificate chain of an IP message.
+        This is a quirk option added to support 3GPP TS 33.310.
 
-Note that using this option is dangerous as the certificate obtained
-this way has not been authenticated (at least not at CMP level).
-Taking it over as a trust anchor implements trust-on-first-use (TOFU).
+        Note that using this option is dangerous as the certificate obtained
+        this way has not been authenticated (at least not at CMP level).
+        Taking it over as a trust anchor implements trust-on-first-use (TOFU).
 
 =item B<OSSL_CMP_OPT_NO_CACHE_EXTRACERTS>
 
-Do not cache certificates received in the extraCerts CMP message field.
-Otherwise they are stored to potentially help validate further messages.
+        Do not cache certificates received in the extraCerts CMP message field.
+        Otherwise they are stored to potentially help validate further messages.
 
 =back
 

--- a/doc/man3/OSSL_STORE_LOADER.pod
+++ b/doc/man3/OSSL_STORE_LOADER.pod
@@ -19,7 +19,6 @@ OSSL_STORE_LOADER_set_attach, OSSL_STORE_LOADER_set_ctrl,
 OSSL_STORE_LOADER_set_expect, OSSL_STORE_LOADER_set_find,
 OSSL_STORE_LOADER_set_load, OSSL_STORE_LOADER_set_eof,
 OSSL_STORE_LOADER_set_error, OSSL_STORE_LOADER_set_close,
-OSSL_STORE_LOADER_settable_ctx_params,
 OSSL_STORE_register_loader, OSSL_STORE_unregister_loader,
 OSSL_STORE_open_fn, OSSL_STORE_open_ex_fn,
 OSSL_STORE_attach_fn, OSSL_STORE_ctrl_fn,
@@ -52,8 +51,6 @@ unregister STORE loaders for different URI schemes
  int OSSL_STORE_LOADER_names_do_all(const OSSL_STORE_LOADER *loader,
                                     void (*fn)(const char *name, void *data),
                                     void *data);
- const OSSL_PARAM *
- OSSL_STORE_LOADER_settable_ctx_params(const OSSL_STORE_LOADER *loader);
 
 The following functions have been deprecated since OpenSSL 3.0, and can be
 hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
@@ -150,11 +147,6 @@ I<user_arg> as arguments.
 
 OSSL_STORE_LOADER_names_do_all() traverses all names for the given
 I<loader>, and calls I<fn> with each name and I<data>.
-
-OSSL_STORE_LOADER_settable_ctx_params() return a constant L<OSSL_PARAM(3)> array
-that describes the names and types of key parameters that can be passed to
-L<OSSL_STORE_open_ex(3)>.
-
 
 =head2 Legacy Types and Functions (deprecated)
 
@@ -390,8 +382,6 @@ OSSL_STORE_register_loader(), OSSL_STORE_LOADER_set_error(),
 OSSL_STORE_unregister_loader(), OSSL_STORE_open_fn(), OSSL_STORE_ctrl_fn(),
 OSSL_STORE_load_fn(), OSSL_STORE_eof_fn() and OSSL_STORE_close_fn()
 were added in OpenSSL 1.1.1, and became deprecated in OpenSSL 3.0.
-
-OSSL_STORE_LOADER_settable_ctx_params() was added in OpenSSL 3.6.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/store.h
+++ b/include/openssl/store.h
@@ -279,8 +279,6 @@ void OSSL_STORE_LOADER_do_all_provided(OSSL_LIB_CTX *libctx,
 int OSSL_STORE_LOADER_names_do_all(const OSSL_STORE_LOADER *loader,
                                    void (*fn)(const char *name, void *data),
                                    void *data);
-const OSSL_PARAM *
-OSSL_STORE_LOADER_settable_ctx_params(const OSSL_STORE_LOADER *loader);
 
 /*-
  *  Function to register a loader for the given URI scheme.

--- a/providers/implementations/keymgmt/ml_dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/ml_dsa_kmgmt.c
@@ -84,8 +84,6 @@ static int ml_dsa_pairwise_test(const ML_DSA_KEY *key)
                          sig, &sig_len, sizeof(sig)) <= 0)
         goto err;
 
-    OSSL_SELF_TEST_oncorrupt_byte(st, sig);
-
     if (ossl_ml_dsa_verify(key, 0, msg, sizeof(msg), NULL, 0, 0,
                            sig, sig_len) <= 0)
         goto err;
@@ -474,10 +472,8 @@ static void *ml_dsa_gen(void *genctx, int evp_type)
         goto err;
     }
 #ifdef FIPS_MODULE
-    if (!ml_dsa_pairwise_test(key)) {
-        ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT);
+    if (!ml_dsa_pairwise_test(key))
         goto err;
-    }
 #endif
     return key;
  err:

--- a/providers/implementations/keymgmt/slh_dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/slh_dsa_kmgmt.c
@@ -346,10 +346,8 @@ static void *slh_dsa_gen(void *genctx, const char *alg)
                                    gctx->entropy, gctx->entropy_len))
         goto err;
 #ifdef FIPS_MODULE
-    if (!slh_dsa_fips140_pairwise_test(ctx, key, gctx->libctx)) {
-        ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT);
+    if (!slh_dsa_fips140_pairwise_test(ctx, key, gctx->libctx))
         goto err;
-    }
 #endif /* FIPS_MODULE */
     ossl_slh_dsa_hash_ctx_free(ctx);
     return key;

--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -336,26 +336,22 @@ static int file_set_ctx_params(void *loaderctx, const OSSL_PARAM params[])
         size_t der_len = 0;
         X509_NAME *x509_name;
         unsigned long hash;
-        int ok = 0;
+        int ok;
+
+        if (ctx->type != IS_DIR) {
+            ERR_raise(ERR_LIB_PROV,
+                      PROV_R_SEARCH_ONLY_SUPPORTED_FOR_DIRECTORIES);
+            return 0;
+        }
 
         if (!OSSL_PARAM_get_octet_string_ptr(p, (const void **)&der, &der_len)
             || (x509_name = d2i_X509_NAME(NULL, &der, der_len)) == NULL)
             return 0;
-        if (ctx->type != IS_DIR) {
-            char *str = X509_NAME_oneline(x509_name, NULL, 0);
-
-            ERR_raise_data(ERR_LIB_PROV, PROV_R_SEARCH_ONLY_SUPPORTED_FOR_DIRECTORIES,
-                           "uri=%s:subject=%s", ctx->uri, str);
-            OPENSSL_free(str);
-            goto end;
-        }
-
         hash = X509_NAME_hash_ex(x509_name,
                                  ossl_prov_ctx_get0_libctx(ctx->provctx), NULL,
                                  &ok);
         BIO_snprintf(ctx->_.dir.search_name, sizeof(ctx->_.dir.search_name),
                      "%08lx", hash);
-    end:
         X509_NAME_free(x509_name);
         if (ok == 0)
             return 0;

--- a/ssl/rio/poll_builder.h
+++ b/ssl/rio/poll_builder.h
@@ -24,7 +24,7 @@
  */
 typedef struct rio_poll_builder_st {
 # if RIO_POLL_METHOD == RIO_POLL_METHOD_NONE
-    int             unused_dummy; /* make microsoft compiler happy */
+    /* nothing */;
 # elif RIO_POLL_METHOD == RIO_POLL_METHOD_SELECT
     fd_set          rfd, wfd, efd;
     int             hwm_fd;

--- a/test/pairwise_fail_test.c
+++ b/test/pairwise_fail_test.c
@@ -133,39 +133,6 @@ static int test_keygen_pairwise_failure(void)
             goto err;
         if (!TEST_ptr_null(pkey))
             goto err;
-    } else if (strncmp(pairwise_name, "ml-dsa", 6) == 0) {
-        if (!TEST_true(setup_selftest_pairwise_failure(type)))
-            goto err;
-        if (!TEST_ptr(ctx = EVP_PKEY_CTX_new_from_name(libctx, "ML-DSA-87", NULL)))
-            goto err;
-        if (!TEST_int_eq(EVP_PKEY_keygen_init(ctx), 1))
-            goto err;
-        if (!TEST_int_le(EVP_PKEY_keygen(ctx, &pkey), 0))
-            goto err;
-        if (!TEST_ptr_null(pkey))
-            goto err;
-    } else if (strncmp(pairwise_name, "slh-dsa", 7) == 0) {
-        if (!TEST_true(setup_selftest_pairwise_failure(type)))
-            goto err;
-        if (!TEST_ptr(ctx = EVP_PKEY_CTX_new_from_name(libctx, "SLH-DSA-SHA2-256f", NULL)))
-            goto err;
-        if (!TEST_int_eq(EVP_PKEY_keygen_init(ctx), 1))
-            goto err;
-        if (!TEST_int_le(EVP_PKEY_keygen(ctx, &pkey), 0))
-            goto err;
-        if (!TEST_ptr_null(pkey))
-            goto err;
-    } else if (strncmp(pairwise_name, "ml-kem", 6) == 0) {
-        if (!TEST_true(setup_selftest_pairwise_failure(type)))
-            goto err;
-        if (!TEST_ptr(ctx = EVP_PKEY_CTX_new_from_name(libctx, "ML-KEM-1024", NULL)))
-            goto err;
-        if (!TEST_int_eq(EVP_PKEY_keygen_init(ctx), 1))
-            goto err;
-        if (!TEST_int_le(EVP_PKEY_keygen(ctx, &pkey), 0))
-            goto err;
-        if (!TEST_ptr_null(pkey))
-            goto err;
     }
     ret = 1;
 err:

--- a/test/recipes/30-test_pairwise_fail.t
+++ b/test/recipes/30-test_pairwise_fail.t
@@ -22,7 +22,7 @@ use lib bldtop_dir('.');
 plan skip_all => "These tests are unsupported in a non fips build"
     if disabled("fips");
 
-plan tests => 9;
+plan tests => 6;
 my $provconf = srctop_file("test", "fips-and-base.cnf");
 
 run(test(["fips_version_test", "-config", $provconf, ">=3.1.0"]),
@@ -76,46 +76,4 @@ SKIP: {
     ok(run(test(["pairwise_fail_test", "-config", $provconf,
                  "-pairwise", "eddsa"])),
        "fips provider eddsa keygen pairwise failure test");
-}
-
-SKIP: {
-    skip "Skip ML-DSA test because of no ml-dsa in this build", 1
-        if disabled("ml-dsa");
-
-    run(test(["fips_version_test", "-config", $provconf, ">=3.5.0"]),
-             capture => 1, statusvar => \my $exit);
-    skip "FIPS provider version is too old", 1
-        if !$exit;
-
-    ok(run(test(["pairwise_fail_test", "-config", $provconf,
-                 "-pairwise", "ml-dsa"])),
-       "fips provider ml-dsa keygen pairwise failure test");
-}
-
-SKIP: {
-    skip "Skip SLH-DSA test because of no slh-dsa in this build", 1
-        if disabled("slh-dsa");
-
-    run(test(["fips_version_test", "-config", $provconf, ">=3.5.0"]),
-             capture => 1, statusvar => \my $exit);
-    skip "FIPS provider version is too old", 1
-        if !$exit;
-
-    ok(run(test(["pairwise_fail_test", "-config", $provconf,
-                 "-pairwise", "slh-dsa"])),
-       "fips provider slh-dsa keygen pairwise failure test");
-}
-
-SKIP: {
-    skip "Skip ML-KEM test because of no ml-kem in this build", 1
-        if disabled("ml-kem");
-
-    run(test(["fips_version_test", "-config", $provconf, ">=3.5.0"]),
-             capture => 1, statusvar => \my $exit);
-    skip "FIPS provider version is too old", 1
-        if !$exit;
-
-    ok(run(test(["pairwise_fail_test", "-config", $provconf,
-                 "-pairwise", "ml-kem"])),
-       "fips provider ml-kem keygen pairwise failure test");
 }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5927,4 +5927,3 @@ PEM_ASN1_write_bio_ctx                  ?	3_5_0	EXIST::FUNCTION:
 OPENSSL_sk_set_thunks                   ?	3_6_0	EXIST::FUNCTION:
 i2d_PKCS8PrivateKey                     ?	3_6_0	EXIST::FUNCTION:
 OSSL_PARAM_set_octet_string_or_ptr      ?	3_6_0	EXIST::FUNCTION:
-OSSL_STORE_LOADER_settable_ctx_params   ?	3_6_0	EXIST::FUNCTION:


### PR DESCRIPTION
- Count and tabulate all CRL extension NIDs present
- Require exactly one instance of Authority Key Identifier and CRL Number
- Allow at most one instance of IssuerAltName, DeltaCRLIndicator, IssuingDistributionPoint, FreshestCRL, and AuthorityInfoAccess
- Reject the CRL if any unknown extension is marked critical
- Return errors and abort verification on violations

@bbbrumley @owen5280

Fixes #26661

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
