### PR TITLE
Enforce RFC5280 extension rules in CRL app and check for duplicate X509v3 extensions

### DIFF
--- a/apps/verify.c
+++ b/apps/verify.c
@@ -365,6 +365,7 @@ static int cb(int ok, X509_STORE_CTX *ctx)
         case X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION:
             /* errors due to strict conformance checking (-x509_strict) */
         case X509_V_ERR_INVALID_PURPOSE:
+        case X509_V_ERR_DUPLICATE_EXTENSION:
         case X509_V_ERR_PATHLEN_INVALID_FOR_NON_CA:
         case X509_V_ERR_PATHLEN_WITHOUT_KU_KEY_CERT_SIGN:
         case X509_V_ERR_CA_BCONS_NOT_CRITICAL:

--- a/crypto/x509/x509_txt.c
+++ b/crypto/x509/x509_txt.c
@@ -194,6 +194,8 @@ const char *X509_verify_cert_error_string(long n)
         return "invalid CA certificate";
     case X509_V_ERR_PATHLEN_INVALID_FOR_NON_CA:
         return "Path length invalid for non-CA cert";
+    case X509_V_ERR_DUPLICATE_EXTENSION:
+        return "duplicate extension found";
     case X509_V_ERR_PATHLEN_WITHOUT_KU_KEY_CERT_SIGN:
         return "Path length given without key usage keyCertSign";
     case X509_V_ERR_KU_KEY_CERT_SIGN_INVALID_FOR_NON_CA:

--- a/doc/man1/openssl-crl.pod.in
+++ b/doc/man1/openssl-crl.pod.in
@@ -31,6 +31,7 @@ B<openssl> B<crl>
 {- $OpenSSL::safe::opt_name_synopsis -}
 {- $OpenSSL::safe::opt_trust_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
+[B<-check-extensions]
 
 =head1 DESCRIPTION
 
@@ -139,6 +140,10 @@ Output the nextUpdate field.
 {- $OpenSSL::safe::opt_trust_item -}
 
 {- $OpenSSL::safe::opt_provider_item -}
+
+=item B<-check-extensions>
+
+Output list of extensions found in the CRL and their OIDs. Also provides a list of errors associated with given extension/s.
 
 =back
 

--- a/doc/man1/openssl-verification-options.pod
+++ b/doc/man1/openssl-verification-options.pod
@@ -192,8 +192,9 @@ Part of these checks are enabled only if the B<-x509_strict> option is given.
 The second step is to check the X.509v3 extensions of every certificate
 for consistency with the intended specific purpose, if any.
 If no purpose is given explicitly then no such checks are done except for
-CMS signature checking, where by default C<smimesign> is checked, and SSL/(D)TLS
-connection setup, where by default C<sslserver> or C<sslclient> are checked.
+CMS signature checking, where by default C<smimesign> is checked, SSL/(D)TLS
+connection setup, where by default C<sslserver> or C<sslclient> are checked,
+and that no duplicate extensions are found.
 The X.509v3 extensions of the target or "leaf" certificate
 must be compatible with the specified purpose.
 All other certificates down the chain are checked to be valid CA certificates,

--- a/doc/man3/X509_verify.pod
+++ b/doc/man3/X509_verify.pod
@@ -25,7 +25,7 @@ verify certificate, certificate request, or CRL signature
 =head1 DESCRIPTION
 
 X509_verify() verifies the signature of certificate I<x> using public key
-I<pkey>. Only the signature is checked: no other checks (such as certificate
+I<pkey>. Only the signature and extensions are checked: no other checks (such as certificate
 chain validity) are performed.
 
 X509_self_signed() checks whether certificate I<cert> is self-signed.

--- a/include/openssl/x509_vfy.h.in
+++ b/include/openssl/x509_vfy.h.in
@@ -320,12 +320,12 @@ X509_LOOKUP_ctrl_ex((x), X509_L_ADD_STORE, (name), 0, NULL,           \
 # define X509_V_ERR_DUPLICATE_EXTENSION                  96
 
 /* additional OCSP status errors */
-# define X509_V_ERR_OCSP_RESP_INVALID                    96
-# define X509_V_ERR_OCSP_SIGNATURE_FAILURE               97
-# define X509_V_ERR_OCSP_NOT_YET_VALID                   98
-# define X509_V_ERR_OCSP_HAS_EXPIRED                     99
-# define X509_V_ERR_OCSP_NO_RESPONSE                    100
-# define X509_V_ERR_CRL_VERIFY_FAILED                   101
+# define X509_V_ERR_OCSP_RESP_INVALID                    97
+# define X509_V_ERR_OCSP_SIGNATURE_FAILURE               98
+# define X509_V_ERR_OCSP_NOT_YET_VALID                   99
+# define X509_V_ERR_OCSP_HAS_EXPIRED                    100
+# define X509_V_ERR_OCSP_NO_RESPONSE                    101
+# define X509_V_ERR_CRL_VERIFY_FAILED                   102
 
 /* Certificate verify flags */
 # ifndef OPENSSL_NO_DEPRECATED_1_1_0

--- a/include/openssl/x509_vfy.h.in
+++ b/include/openssl/x509_vfy.h.in
@@ -317,6 +317,7 @@ X509_LOOKUP_ctrl_ex((x), X509_L_ADD_STORE, (name), 0, NULL,           \
 # define X509_V_ERR_EXTENSIONS_REQUIRE_VERSION_3         93
 # define X509_V_ERR_EC_KEY_EXPLICIT_PARAMS               94
 # define X509_V_ERR_RPK_UNTRUSTED                        95
+# define X509_V_ERR_DUPLICATE_EXTENSION                  96
 
 /* additional OCSP status errors */
 # define X509_V_ERR_OCSP_RESP_INVALID                    96

--- a/test/recipes/25-test_crl.t
+++ b/test/recipes/25-test_crl.t
@@ -15,7 +15,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_crl");
 
-plan tests => 10;
+plan tests => 11;
 
 require_ok(srctop_file('test','recipes','tconversion.pl'));
 
@@ -50,6 +50,130 @@ ok(run(app(["openssl", "crl", "-text", "-in", $pem, "-inform", "PEM",
             "-out", $out, "-nameopt", "utf8"])));
 is(cmp_text($out, srctop_file("test/certs", "cyrillic_crl.utf8")),
    0, 'Comparing utf8 output');
+
+subtest 'CRL RFC5280 extension enforcement failures' => sub {
+    # v1 CRL with extensions => version mismatch
+    my $v1 = srctop_file('test','testcrl_v1_ext.pem');
+    ok(! run(app(["openssl","crl","-in",$v1,"-noout","-check-extensions"])),
+        'v1 CRL with extensions should fail');
+    like(join('', @{run(app(["openssl","crl","-in",$v1,"-noout","-check-extensions"], capture=>1))}),
+        qr/Extensions are only valid in a v2 CRL/,
+        'version mismatch error');
+
+    # Authority Key Identifier (AKI)
+    my @aki_tests = (
+        ['missing AKI' => 'testcrl_missing_aki.pem',
+            qr/Authority Key Identifier .* MUST appear exactly once/],
+        ['AKI marked critical' > 'testcrl_aki_critical.pem',
+            qr/Authority Key Identifier .* MUST NOT be marked critical/],
+        ['empty keyIdentifier' => 'testcrl_aki_empty_keyid.pem',
+            qr/MUST contain a non-empty keyIdentifier/],
+        ['includes certIssuer' => 'testcrl_aki_certissuer.pem',
+            qr/MUST NOT include authorityCertIssuer/],
+        ['includes certSerialNumber' => 'testcrl_aki_certserial.pem',
+            qr/MUST NOT include authorityCertSerialNumber/],
+    );
+    for my $t (@aki_tests) {
+        my ($desc, $file, $pattern) = @$t;
+        my $pemfile = srctop_file('test',$file);
+        ok(! run(app(["openssl","crl","-in",$pemfile,"-noout","-check-extensions"])),
+            "$desc should fail");
+        like(join('', @{run(app(["openssl","crl","-in",$pemfile,"-noout","-check-extensions"], capture=>1))}),
+            $pattern,
+            "$desc error");
+    }
+
+    # CRL Number
+    my $no_crlnum = srctop_file('test','testcrl_missing_crlnum.pem');
+    ok(! run(app(["openssl","crl","-in",$no_crlnum,"-noout","-check-extensions"])),
+        'missing CRL Number should fail');
+    like(join('', @{run(app(["openssl","crl","-in",$no_crlnum,"-noout","-check-extensions"], capture=>1))}),
+        qr/CRL Number .* MUST appear exactly once/,
+        'CRL Number cardinality error');
+    my $crlnum_crit = srctop_file('test','testcrl_crlnum_critical.pem');
+    ok(! run(app(["openssl","crl","-in",$crlnum_crit,"-noout","-check-extensions"])),
+        'CRL Number marked critical should fail');
+    like(join('', @{run(app(["openssl","crl","-in",$crlnum_crit,"-noout","-check-extensions"], capture=>1))}),
+        qr/CRL Number .* MUST NOT be marked critical/,
+        'CRL Number criticality error');
+
+    # Issuer Alternative Name (IAN)
+    my $ian2 = srctop_file('test','testcrl_ian_twice.pem');
+    ok(! run(app(["openssl","crl","-in",$ian2,"-noout","-check-extensions"])),
+        'duplicate Issuer Alternative Name should warn');
+    like(join('', @{run(app(["openssl","crl","-in",$ian2,"-noout","-check-extensions"], capture=>1))}),
+        qr/Issuer Alternative Name .* at most once/,
+        'IAN duplicate count error');
+    like(join('', @{run(app(["openssl","crl","-in",$ian2,"-noout","-check-extensions"], capture=>1))}),
+        qr/Issuer Alternative Name .* SHOULD NOT be critical/,
+        'IAN criticality error');
+
+    # Delta CRL Indicator
+    my $dnc = srctop_file('test','testcrl_delta_noncrit.pem');
+    ok(! run(app(["openssl","crl","-in",$dnc,"-noout","-check-extensions"])),
+        'Delta CRL missing criticality should fail');
+    like(join('', @{run(app(["openssl","crl","-in",$dnc,"-noout","-check-extensions"], capture=>1))}),
+        qr/Delta CRL Indicator MUST be marked critical/,
+        'Delta CRL criticality error');
+    my $d2 = srctop_file('test','testcrl_delta_twice.pem');
+    ok(! run(app(["openssl","crl","-in",$d2,"-noout","-check-extensions"])),
+        'duplicate Delta CRL Indicator should warn');
+    like(join('', @{run(app(["openssl","crl","-in",$d2,"-noout","-check-extensions"], capture=>1))}),
+        qr/MUST appear at most once \(found 2\)/,
+        'Delta CRL duplicate count error');
+
+    # Issuing Distribution Point (IDP)
+    my $idpnc = srctop_file('test','testcrl_idp_noncrit.pem');
+    ok(! run(app(["openssl","crl","-in",$idpnc,"-noout","-check-extensions"])),
+        'IDP missing criticality should fail');
+    like(join('', @{run(app(["openssl","crl","-in",$idpnc,"-noout","-check-extensions"], capture=>1))}),
+        qr/Issuing Distribution Point MUST be marked critical/,
+        'IDP criticality error');
+    my $idp2 = srctop_file('test','testcrl_idp_twice.pem');
+    ok(! run(app(["openssl","crl","-in",$idp2,"-noout","-check-extensions"])),
+        'duplicate IDP should warn');
+    like(join('', @{run(app(["openssl","crl","-in",$idp2,"-noout","-check-extensions"], capture=>1))}),
+        qr/MUST appear at most once \(found 2\)/,
+        'IDP duplicate count error');
+
+    # Freshest CRL
+    my $f_in_delta = srctop_file('test','testcrl_freshest_in_delta.pem');
+    ok(! run(app(["openssl","crl","-in",$f_in_delta,"-noout","-check-extensions"])),
+        'Freshest CRL in delta should fail');
+    like(join('', @{run(app(["openssl","crl","-in",$f_in_delta,"-noout","-check-extensions"], capture=>1))}),
+        qr/Freshest CRL MUST NOT appear in a delta CRL/,
+        'Freshest-in-delta error');
+    my $f2 = srctop_file('test','testcrl_freshest_twice.pem');
+    ok(! run(app(["openssl","crl","-in",$f2,"-noout","-check-extensions"])),
+        'duplicate Freshest CRL should warn');
+    like(join('', @{run(app(["openssl","crl","-in",$f2,"-noout","-check-extensions"], capture=>1))}),
+        qr/MUST appear at most once \(found 2\)/,
+        'Freshest duplicate count error');
+    like(join('', @{run(app(["openssl","crl","-in",$f2,"-noout","-check-extensions"], capture=>1))}),
+        qr/SHOULD NOT be critical/,
+        'Freshest criticality error');
+
+    # Authority Information Access (AIA)
+    my $aia2 = srctop_file('test','testcrl_infoaccess_twice.pem');
+    ok(! run(app(["openssl","crl","-in",$aia2,"-noout","-check-extensions"])),
+        'duplicate Authority Information Access should warn');
+    like(join('', @{run(app(["openssl","crl","-in",$aia2,"-noout","-check-extensions"], capture=>1))}),
+        qr/MUST appear at most once \(found 2\)/,
+        'AIA duplicate count error');
+    like(join('', @{run(app(["openssl","crl","-in",$aia2,"-noout","-check-extensions"], capture=>1))}),
+        qr/SHOULD NOT be critical/,
+        'AIA criticality error');
+
+    # Unknown critical extension
+    my $unk = srctop_file('test','testcrl_unknown_crit.pem');
+    ok(! run(app(["openssl","crl","-in",$unk,"-noout","-check-extensions"])),
+        'unknown critical extension should fail');
+    like(join('', @{run(app(["openssl","crl","-in",$unk,"-noout","-check-extensions"], capture=>1))}),
+        qr/unknown critical CRL extension/,
+        'Unknown critical extension error');
+
+    1;
+};
 
 sub compare1stline {
     my ($cmdarray, $str) = @_;

--- a/test/recipes/25-test_verify.t
+++ b/test/recipes/25-test_verify.t
@@ -519,6 +519,11 @@ ok(verify("ee-self-signed", "", ["ee-self-signed"], [], "-attime", "1593565200")
 ok(verify("ee-ss-with-keyCertSign", "", ["ee-ss-with-keyCertSign"], []),
    "accept trusted self-signed EE cert with key usage keyCertSign also when strict");
 
+# Duplicate‐extension in CRL must be rejected
+ok(!verify("ee-cert", "", [qw(root-cert)], [], "-crl_check", "-CRLfile",
+    srctop_file("test", "crls", "crl-dup-ext.pem")),
+    "reject CRL containing duplicate extensions");
+
 SKIP: {
     skip "Ed25519 is not supported by this OpenSSL build", 6
         if disabled("ecx");


### PR DESCRIPTION
crl_verify: enforce RFC5280 extension rules in do_ver()
- Count and tabulate all CRL extension NIDs present
- Require exactly one instance of Authority Key Identifier and CRL Number
- Allow at most one instance of IssuerAltName, DeltaCRLIndicator,
  IssuingDistributionPoint, FreshestCRL, and AuthorityInfoAccess
- Reject the CRL if any unknown extension is marked critical
- Return errors and abort verification on violations

@bbbrumley @t8m @owen5280

Fixes #26661, #25799

##### Checklist
- [x] documentation is added or updated
- [ ] tests are added or updated
