### PR TITLE
CHACHA POLY: fix errant settable_ctx_param list (3.5)

### DIFF
--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.c
@@ -32,7 +32,7 @@ static OSSL_FUNC_cipher_set_ctx_params_fn chacha20_poly1305_set_ctx_params;
 static OSSL_FUNC_cipher_cipher_fn chacha20_poly1305_cipher;
 static OSSL_FUNC_cipher_final_fn chacha20_poly1305_final;
 static OSSL_FUNC_cipher_gettable_ctx_params_fn chacha20_poly1305_gettable_ctx_params;
-#define chacha20_poly1305_settable_ctx_params ossl_cipher_aead_settable_ctx_params
+static OSSL_FUNC_cipher_settable_ctx_params_fn chacha20_poly1305_settable_ctx_params;
 #define chacha20_poly1305_gettable_params ossl_cipher_generic_gettable_params
 #define chacha20_poly1305_update chacha20_poly1305_cipher
 
@@ -158,6 +158,21 @@ static const OSSL_PARAM *chacha20_poly1305_gettable_ctx_params
     return chacha20_poly1305_known_gettable_ctx_params;
 }
 
+static const OSSL_PARAM chacha20_poly1305_known_settable_ctx_params[] = {
+    OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_KEYLEN, NULL),
+    OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_IVLEN, NULL),
+    OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG, NULL, 0),
+    OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TLS1_AAD, NULL, 0),
+    OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TLS1_IV_FIXED, NULL, 0),
+    OSSL_PARAM_END
+};
+static const OSSL_PARAM *chacha20_poly1305_settable_ctx_params(
+        ossl_unused void *cctx, ossl_unused void *provctx
+    )
+{
+    return chacha20_poly1305_known_settable_ctx_params;
+}
+
 static int chacha20_poly1305_set_ctx_params(void *vctx,
                                             const OSSL_PARAM params[])
 {
@@ -238,7 +253,6 @@ static int chacha20_poly1305_set_ctx_params(void *vctx,
             return 0;
         }
     }
-    /* ignore OSSL_CIPHER_PARAM_AEAD_MAC_KEY */
     return 1;
 }
 


### PR DESCRIPTION
The settable list used the generic AEAD cipher list which included an extra parameter and omitted the IV length one.  The set ctx param call was custom so the errant list didn't directly impact operation.

Cherry picking the relevant parts from #27523.

The comment about ignoring `OSSL_CIPHER_PARAM_AEAD_MAC_KEY` is completely bogus.  That parameter isn't accepted either here or by the shared AEAD cipher params.
