### PR TITLE
Handle "wrong" downgrade signals and repair downgrade tests (3.0)

### DIFF
--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1967,23 +1967,24 @@ int ssl_choose_client_version(SSL *s, int version, RAW_EXTENSION *extensions)
         real_max = ver_max;
 
     /* Check for downgrades */
-    if (s->version == TLS1_2_VERSION && real_max > s->version) {
-        if (memcmp(tls12downgrade,
+    if (!SSL_IS_DTLS(s) && real_max > s->version) {
+        /* Signal applies to all versions */
+        if (memcmp(tls11downgrade,
                    s->s3.server_random + SSL3_RANDOM_SIZE
-                                        - sizeof(tls12downgrade),
-                   sizeof(tls12downgrade)) == 0) {
+                   - sizeof(tls11downgrade),
+                   sizeof(tls11downgrade)) == 0) {
             s->version = origv;
             SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER,
                      SSL_R_INAPPROPRIATE_FALLBACK);
             return 0;
         }
-    } else if (!SSL_IS_DTLS(s)
-               && s->version < TLS1_2_VERSION
-               && real_max > s->version) {
-        if (memcmp(tls11downgrade,
-                   s->s3.server_random + SSL3_RANDOM_SIZE
-                                        - sizeof(tls11downgrade),
-                   sizeof(tls11downgrade)) == 0) {
+        /* Only when accepting TLS1.3 */
+        if (real_max == TLS1_3_VERSION
+            && memcmp(tls12downgrade,
+                      s->s3.server_random + SSL3_RANDOM_SIZE
+                      - sizeof(tls12downgrade),
+                      sizeof(tls12downgrade)) == 0) {
+
             s->version = origv;
             SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER,
                      SSL_R_INAPPROPRIATE_FALLBACK);

--- a/test/recipes/70-test_tls13downgrade.t
+++ b/test/recipes/70-test_tls13downgrade.t
@@ -24,9 +24,8 @@ plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");
 
 plan skip_all => "$test_name needs TLS1.3 and TLS1.2 enabled"
-    if disabled("tls1_3")
-       || (disabled("ec") && disabled("dh"))
-       || disabled("tls1_2");
+    if disabled("tls1_3") || disabled("tls1_2")
+        || (disabled("ec") && disabled("dh"));
 
 $ENV{OPENSSL_ia32cap} = '~0x200000200000000';
 
@@ -48,49 +47,70 @@ $proxy->filter(\&downgrade_filter);
 my $testtype = DOWNGRADE_TO_TLS_1_2;
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
 plan tests => 6;
-ok(TLSProxy::Message->fail(), "Downgrade TLSv1.3 to TLSv1.2");
+ok(is_illegal_parameter_client_alert(), "Downgrade TLSv1.3 to TLSv1.2");
 
-#Test 2: Downgrade from TLSv1.3 to TLSv1.1
-$proxy->clear();
-$testtype = DOWNGRADE_TO_TLS_1_1;
-$proxy->start();
-ok(TLSProxy::Message->fail(), "Downgrade TLSv1.3 to TLSv1.1");
-
-#Test 3: Downgrade from TLSv1.2 to TLSv1.1
-$proxy->clear();
-$proxy->clientflags("-no_tls1_3");
-$proxy->serverflags("-no_tls1_3");
-$proxy->start();
-ok(TLSProxy::Message->fail(), "Downgrade TLSv1.2 to TLSv1.1");
-
-#Test 4: Client falls back from TLSv1.3 (server does not support the fallback
+#Test 2: Client falls back from TLSv1.3 (server does not support the fallback
 #        SCSV)
 $proxy->clear();
 $testtype = FALLBACK_FROM_TLS_1_3;
 $proxy->clientflags("-fallback_scsv -no_tls1_3");
 $proxy->start();
-my $alert = TLSProxy::Message->alert();
-ok(TLSProxy::Message->fail()
-   && !$alert->server()
-   && $alert->description() == TLSProxy::Message::AL_DESC_ILLEGAL_PARAMETER,
-   "Fallback from TLSv1.3");
+ok(is_illegal_parameter_client_alert(), "Fallback from TLSv1.3");
 
 SKIP: {
-    skip "TLSv1.1 disabled", 2 if disabled("tls1_1");
+    skip "TLSv1.1 disabled", 4 if disabled("tls1_1");
+
+    my $client_flags = "-min_protocol TLSv1.1 -cipher DEFAULT:\@SECLEVEL=0";
+    my $server_flags = "-min_protocol TLSv1.1";
+    my $ciphers = "AES128-SHA:\@SECLEVEL=0";
+
+    #Test 3: Downgrade from TLSv1.3 to TLSv1.1
+    $proxy->clear();
+    $testtype = DOWNGRADE_TO_TLS_1_1;
+    $proxy->clientflags($client_flags);
+    $proxy->serverflags($server_flags);
+    $proxy->ciphers($ciphers);
+    $proxy->start();
+    ok(is_illegal_parameter_client_alert(), "Downgrade TLSv1.3 to TLSv1.1");
+
+    #Test 4: Downgrade from TLSv1.2 to TLSv1.1
+    $proxy->clear();
+    $testtype = DOWNGRADE_TO_TLS_1_1;
+    $proxy->clientflags($client_flags." -max_protocol TLSv1.2");
+    $proxy->serverflags($server_flags." -max_protocol TLSv1.2");
+    $proxy->ciphers($ciphers);
+    $proxy->start();
+    ok(is_illegal_parameter_client_alert(), "Downgrade TLSv1.2 to TLSv1.1");
+
     #Test 5: A client side protocol "hole" should not be detected as a downgrade
     $proxy->clear();
     $proxy->filter(undef);
-    $proxy->clientflags("-no_tls1_2");
-    $proxy->ciphers("AES128-SHA:\@SECLEVEL=0");
+    $proxy->clientflags($client_flags." -no_tls1_2");
+    $proxy->serverflags($server_flags);
+    $proxy->ciphers($ciphers);
     $proxy->start();
     ok(TLSProxy::Message->success(), "TLSv1.2 client-side protocol hole");
 
     #Test 6: A server side protocol "hole" should not be detected as a downgrade
     $proxy->clear();
     $proxy->filter(undef);
-    $proxy->serverflags("-no_tls1_2");
+    $proxy->clientflags($client_flags);
+    $proxy->serverflags($server_flags." -no_tls1_2");
+    $proxy->ciphers($ciphers);
     $proxy->start();
     ok(TLSProxy::Message->success(), "TLSv1.2 server-side protocol hole");
+}
+
+# Validate that the exchange fails with an illegal parameter alert from
+#  the client
+sub is_illegal_parameter_client_alert
+{
+    return 0 unless TLSProxy::Message->fail();
+    my $alert = TLSProxy::Message->alert();
+    return 1 if !$alert->server()
+                && $alert->description()
+                   == TLSProxy::Message::AL_DESC_ILLEGAL_PARAMETER;
+    return 0;
 }
 
 sub downgrade_filter


### PR DESCRIPTION
This accounts for cases that can only occur when een non-compliant server sends the wrong downgrade signal. (TLS1.1 signal when negotiating TLS1.2 or TLS1.2 signal when negotiating TLS1.0/TLS1.1). According to the TLS1.3 RFC these
cases should be rejected:

> [RFC8446, section 4.1.3](https://datatracker.ietf.org/doc/html/rfc8446#autoid-22): TLS 1.3 clients receiving a ServerHello indicating
> TLS 1.2 or below MUST check that the last 8 bytes are not equal to either of
> these values. TLS 1.2 clients SHOULD also check that the last 8 bytes are
> not equal to the second value if the ServerHello indicates TLS 1.1 or below.

A number of the downgrade tests were passing for the wrong reasons. The intention is to verify that the client sends an illegal parameter alert when an unexpected downgrade signal is received. Instead, a number of tests passed because TLS1.1 was not available (passing the test because failure was expected). The tests are adapted to explicitly check for an illegal parameter alert from the client. Client and server flags are updated to enable TLS1.1 where required and a few tests requiring TLS1.1 were moved to be disabled when TLS1.1 is not available.

This is a backport of #27518 to 3.0.

I've left out the DTLS1.3 TODO since it's not relevant here and won't merge cleanly anyway.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
