### PR TITLE
Resolve issue #27207.

### DIFF
--- a/crypto/x509/v3_san.c
+++ b/crypto/x509/v3_san.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2024 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1999-2025 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -183,7 +183,7 @@ STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(X509V3_EXT_METHOD *method,
         break;
 
     case GEN_DIRNAME:
-        if (X509_NAME_oneline(gen->d.dirn, oline, sizeof(oline)) == NULL
+        if (X509_NAME_oneline_for_locale(gen->d.dirn, oline, sizeof(oline)) == NULL
                 || !X509V3_add_value("DirName", oline, &ret))
             return NULL;
         break;

--- a/crypto/x509/v3_san.c
+++ b/crypto/x509/v3_san.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1999-2024 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -183,7 +183,7 @@ STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(X509V3_EXT_METHOD *method,
         break;
 
     case GEN_DIRNAME:
-        if (X509_NAME_oneline_for_locale(gen->d.dirn, oline, sizeof(oline)) == NULL
+        if (X509_NAME_oneline(gen->d.dirn, oline, sizeof(oline)) == NULL
                 || !X509V3_add_value("DirName", oline, &ret))
             return NULL;
         break;

--- a/crypto/x509/x509_obj.c
+++ b/crypto/x509/x509_obj.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2024 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2025 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -15,6 +15,24 @@
 #include "crypto/x509.h"
 #include "crypto/ctype.h"
 
+#if !defined(TRUE) && !defined(FALSE)
+# define TRUE  1
+# define FALSE (!TRUE)
+#endif
+#ifdef UNINITIALIZED
+# undef UNINITIALIZED
+#endif
+#define UNINITIALIZED (-1)
+
+#ifdef DEL
+# undef DEL
+#endif
+#ifndef CHARSET_EBCDIC
+# define DEL 127
+#else
+# define DEL 7
+#endif
+
 /*
  * Limit to ensure we don't overflow: much greater than
  * anything encountered in practice.
@@ -22,7 +40,20 @@
 
 #define NAME_ONELINE_MAX    (1024 * 1024)
 
-char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
+/*
+ * X509_NAME_online_with_bool() is the foundation of both X509_NAME_oneline()
+ * and X509_NAME_oneline_for_locale(). It prints a version of "a" to "buf".
+ * If "is_hex_escaping_non_ASCII" is TRUE, then non-ASCII UTF-8 characters
+ * will be hex-escaped, and "buf" will be ASCII; if it's FALSE, then
+ * such characters will remain UTF-8 if the X.509 NAME entry value type
+ * is UTF8String. If "buf" is NULL, then a buffer is dynamically allocated
+ * and returned, and "len" is ignored. Otherwise, at most "len" bytes will
+ * be written, including the ending '\0', and "buf" is returned.
+ */
+
+static char *X509_NAME_oneline_with_bool(const X509_NAME *a, char *buf,
+                                         int len,
+                                         int is_hex_escaping_non_ASCII)
 {
     const X509_NAME_ENTRY *ne;
     int i;
@@ -58,9 +89,15 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
         return buf;
     }
 
+    if (is_hex_escaping_non_ASCII != TRUE &&
+        is_hex_escaping_non_ASCII != FALSE)
+        is_hex_escaping_non_ASCII = TRUE;
+
     len--;                      /* space for '\0' */
     l = 0;
     for (i = 0; i < sk_X509_NAME_ENTRY_num(a->entries); i++) {
+        int is_hex_escaping = is_hex_escaping_non_ASCII;
+
         ne = sk_X509_NAME_ENTRY_value(a->entries, i);
         n = OBJ_obj2nid(ne->object);
         if ((n == NID_undef) || ((s = OBJ_nid2sn(n)) == NULL)) {
@@ -70,6 +107,10 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
         l1 = strlen(s);
 
         type = ne->value->type;
+
+        if (!is_hex_escaping && type != V_ASN1_UTF8STRING)
+            is_hex_escaping = TRUE;
+
         num = ne->value->length;
         if (num > NAME_ONELINE_MAX) {
             ERR_raise(ERR_LIB_X509, X509_R_NAME_TOO_LONG);
@@ -110,8 +151,10 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
             l2++;
             if (q[j] == '/' || q[j] == '+')
                 l2++; /* char needs to be escaped */
-            else if ((ossl_toascii(q[j]) < ossl_toascii(' ')) ||
-                     (ossl_toascii(q[j]) > ossl_toascii('~')))
+            else if (ossl_toascii(q[j]) < ossl_toascii(' ') ||
+                     ossl_toascii(q[j]) == ossl_toascii(DEL) ||
+                     (is_hex_escaping &&
+                      ossl_toascii(q[j]) > ossl_toascii('~')))
                 l2 += 3;
         }
 
@@ -129,8 +172,8 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
             break;
         } else
             p = &(buf[lold]);
-        *(p++) = prev_set == ne->set ? '+' : '/';
-        memcpy(p, s, (unsigned int)l1);
+        *(p++) = (prev_set == ne->set) ? '+' : '/';
+        memcpy(p, s, (size_t)l1);
         p += l1;
         *(p++) = '=';
 
@@ -143,18 +186,19 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
                 continue;
 #ifndef CHARSET_EBCDIC
             n = q[j];
-            if ((n < ' ') || (n > '~')) {
+            if (n < ' ' || n == DEL || (is_hex_escaping && n > '~')) {
                 *(p++) = '\\';
                 *(p++) = 'x';
                 p += ossl_to_hex(p, n);
             } else {
                 if (n == '/' || n == '+')
                     *(p++) = '\\';
-                *(p++) = n;
+                *(p++) = (char)((unsigned char)n);
             }
 #else
             n = os_toascii[q[j]];
-            if ((n < os_toascii[' ']) || (n > os_toascii['~'])) {
+            if (n < os_toascii[' '] || n == os_toascii[DEL]
+                || (is_hex_escaping && n > os_toascii['~'])) {
                 *(p++) = '\\';
                 *(p++) = 'x';
                 p += ossl_to_hex(p, n);
@@ -181,4 +225,62 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
  end:
     BUF_MEM_free(b);
     return NULL;
+}
+
+char *X509_NAME_oneline(const X509_NAME *a, char *buf, int size)
+{
+    return X509_NAME_oneline_with_bool(a, buf, size, TRUE);
+}
+
+/*
+ * If the locale of the process specifies the UTF-8 codeset,
+ * then don't hex-escape non-ASCII UTF-8-encoded characters
+ * via X509_NAME_oneline_for_locale().
+ *
+ * However, if the X.509 NAME entry value type is not UTF8String,
+ * then non-ASCII UTF-8-encoded characters will always be
+ * hex-escaped in X509_NAME_oneline_with_bool(), even if
+ * the provided is_hex_escaping_non_ASCII value is FALSE.
+ */
+
+char *X509_NAME_oneline_for_locale(const X509_NAME *a, char *buf, int size)
+{
+    static int is_hex_escaping_non_ASCII = UNINITIALIZED;
+
+    if (is_hex_escaping_non_ASCII == UNINITIALIZED) {
+        static const char *environment_variable[] = {
+            "LC_ALL", "LC_CTYPE", "LANG", NULL
+        };
+        static const char utf_8[] = ".UTF-8";
+        static const size_t utf_8_len =
+            sizeof utf_8 / sizeof *utf_8 - sizeof *utf_8;
+        const char **this_environment_variable;
+
+        /*
+         * Check LC_ALL, LC_CTYPE, and LANG, in this order.
+         * Only process the first non-NULL value found.
+         */
+        for (this_environment_variable = environment_variable;
+             *this_environment_variable != NULL;
+             ++this_environment_variable) {
+            char *this_environment_value = getenv(*this_environment_variable);
+
+            if (this_environment_value != NULL) {
+                size_t length = strlen(this_environment_value);
+
+                is_hex_escaping_non_ASCII =
+                    (length <= utf_8_len
+                     || strncmp(this_environment_value + length - utf_8_len,
+                                utf_8, utf_8_len) != 0)
+                    ? TRUE : FALSE;
+                break;
+            }
+        }
+
+        if (is_hex_escaping_non_ASCII == UNINITIALIZED)
+            is_hex_escaping_non_ASCII = TRUE;
+    }
+
+    return X509_NAME_oneline_with_bool(a, buf, size,
+                                       is_hex_escaping_non_ASCII);
 }

--- a/crypto/x509/x509_obj.c
+++ b/crypto/x509/x509_obj.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2024 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -15,15 +15,6 @@
 #include "crypto/x509.h"
 #include "crypto/ctype.h"
 
-#if !defined(TRUE) && !defined(FALSE)
-#define TRUE    1
-#define FALSE   (!TRUE)
-#endif
-#ifdef UNINITIALIZED
-#undef UNINITIALIZED
-#endif
-#define UNINITIALIZED   (-1)
-
 /*
  * Limit to ensure we don't overflow: much greater than
  * anything encountered in practice.
@@ -31,8 +22,7 @@
 
 #define NAME_ONELINE_MAX    (1024 * 1024)
 
-static char *X509_NAME_oneline_with_bool(const X509_NAME *a, char *buf,
-    int len, int is_hex_escaping_above_ASCII_tilde)
+char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
 {
     const X509_NAME_ENTRY *ne;
     int i;
@@ -68,20 +58,9 @@ static char *X509_NAME_oneline_with_bool(const X509_NAME *a, char *buf,
         return buf;
     }
 
-    /*
-     * If is_hex_escaping_above_ASCII_tilde has an invalid value
-     * (e.g. UNINITIALIZED), set it to TRUE.
-     */
-    if (is_hex_escaping_above_ASCII_tilde != TRUE &&
-        is_hex_escaping_above_ASCII_tilde != FALSE) {
-        is_hex_escaping_above_ASCII_tilde = TRUE;
-    }
-
     len--;                      /* space for '\0' */
     l = 0;
     for (i = 0; i < sk_X509_NAME_ENTRY_num(a->entries); i++) {
-        int is_hex_escaping = is_hex_escaping_above_ASCII_tilde;
-
         ne = sk_X509_NAME_ENTRY_value(a->entries, i);
         n = OBJ_obj2nid(ne->object);
         if ((n == NID_undef) || ((s = OBJ_nid2sn(n)) == NULL)) {
@@ -91,15 +70,6 @@ static char *X509_NAME_oneline_with_bool(const X509_NAME *a, char *buf,
         l1 = strlen(s);
 
         type = ne->value->type;
-
-        /*
-         * If the name entry value type is not UTF8String,
-         * then force hex-escaping for characters above ASCII '~'.
-         */
-        if (!is_hex_escaping && type != V_ASN1_UTF8STRING) {
-            is_hex_escaping = TRUE;
-        }
-
         num = ne->value->length;
         if (num > NAME_ONELINE_MAX) {
             ERR_raise(ERR_LIB_X509, X509_R_NAME_TOO_LONG);
@@ -140,9 +110,8 @@ static char *X509_NAME_oneline_with_bool(const X509_NAME *a, char *buf,
             l2++;
             if (q[j] == '/' || q[j] == '+')
                 l2++; /* char needs to be escaped */
-            else if (ossl_toascii(q[j]) < ossl_toascii(' ') ||
-                     (is_hex_escaping &&
-                      ossl_toascii(q[j]) > ossl_toascii('~')))
+            else if ((ossl_toascii(q[j]) < ossl_toascii(' ')) ||
+                     (ossl_toascii(q[j]) > ossl_toascii('~')))
                 l2 += 3;
         }
 
@@ -160,8 +129,8 @@ static char *X509_NAME_oneline_with_bool(const X509_NAME *a, char *buf,
             break;
         } else
             p = &(buf[lold]);
-        *(p++) = (prev_set == ne->set) ? '+' : '/';
-        memcpy(p, s, (size_t) l1);
+        *(p++) = prev_set == ne->set ? '+' : '/';
+        memcpy(p, s, (unsigned int)l1);
         p += l1;
         *(p++) = '=';
 
@@ -174,19 +143,18 @@ static char *X509_NAME_oneline_with_bool(const X509_NAME *a, char *buf,
                 continue;
 #ifndef CHARSET_EBCDIC
             n = q[j];
-            if (n < ' ' || (is_hex_escaping && n > '~')) {
+            if ((n < ' ') || (n > '~')) {
                 *(p++) = '\\';
                 *(p++) = 'x';
                 p += ossl_to_hex(p, n);
             } else {
                 if (n == '/' || n == '+')
                     *(p++) = '\\';
-                *(p++) = (char) ((unsigned char) n);
+                *(p++) = n;
             }
 #else
             n = os_toascii[q[j]];
-            if (n < os_toascii[' ']
-                || (is_hex_escaping && n > os_toascii['~'])) {
+            if ((n < os_toascii[' ']) || (n > os_toascii['~'])) {
                 *(p++) = '\\';
                 *(p++) = 'x';
                 p += ossl_to_hex(p, n);
@@ -213,61 +181,4 @@ static char *X509_NAME_oneline_with_bool(const X509_NAME *a, char *buf,
  end:
     BUF_MEM_free(b);
     return NULL;
-}
-
-char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
-{
-    return X509_NAME_oneline_with_bool(a, buf, len, TRUE);
-}
-
-/*
- * If the locale of the process specifies the UTF-8 codeset,
- * then don’t hex-escape UTF-8-encoded characters above '~'
- * via X509_NAME_oneline_for_locale().
- *
- * However, if the X.509 NAME entry value type is not UTF8String,
- * then UTF-8-encoded characters above '~' will always be
- * hex-escaped in X509_NAME_oneline_with_bool(), even if
- * the provided is_hex_escaping_above_ASCII_tilde value is FALSE.
- */
-
-char *X509_NAME_oneline_for_locale(const X509_NAME *a, char *buf, int len)
-{
-    static int is_hex_escaping_above_ASCII_tilde = UNINITIALIZED;
-
-    if (UNINITIALIZED == is_hex_escaping_above_ASCII_tilde)
-    {
-        static const char *environment_variable[] = {
-            "LC_ALL", "LC_CTYPE", "LANG", NULL
-        };
-        static const char utf_8[] = ".UTF-8";
-        static const size_t utf_8_len =
-            sizeof utf_8/sizeof *utf_8 - sizeof *utf_8;
-        const char **this_environment_variable;
-
-        /*
-         * Check LC_ALL, LC_CTYPE, and LANG, in this order.
-         * Break after processing the first non-NULL value found.
-         */
-        for (this_environment_variable = environment_variable;
-         NULL != *this_environment_variable; ++this_environment_variable) {
-            char *this_environment_value = getenv(*this_environment_variable);
-
-            if (NULL != this_environment_value) {
-                size_t length = strlen(this_environment_value);
-
-                is_hex_escaping_above_ASCII_tilde = (length <= utf_8_len
-                 || 0 != OPENSSL_strncasecmp(this_environment_value
-                 + length - utf_8_len, utf_8, utf_8_len)) ? TRUE : FALSE;
-                break;
-            }
-        }
-
-        if (UNINITIALIZED == is_hex_escaping_above_ASCII_tilde) {
-            is_hex_escaping_above_ASCII_tilde = TRUE;
-        }
-    }
-
-    return X509_NAME_oneline_with_bool(a, buf, len,
-     is_hex_escaping_above_ASCII_tilde);
 }

--- a/doc/man1/openssl-crl.pod.in
+++ b/doc/man1/openssl-crl.pod.in
@@ -142,6 +142,24 @@ Output the nextUpdate field.
 
 =back
 
+=head1 ENVIRONMENT
+
+=over 4
+
+=item B<LANG>, B<LC_CTYPE>, B<LC_ALL>
+
+If any of these is defined with a codeset of C<.UTF-8>,
+and the CRL is printed out in text form,
+and the CRL's X.509 NAME value type is C<UTF8String>,
+then don't hex-escape non-ASCII UTF-8-encoded characters
+in the C<DirName> field.
+
+When more than one of these are defined,
+B<LC_CTYPE> overrides B<LANG>, and
+B<LC_ALL> overrides both B<LC_CTYPE> and B<LANG>.
+
+=back
+
 =head1 EXAMPLES
 
 Convert a CRL file from PEM to DER:
@@ -151,6 +169,12 @@ Convert a CRL file from PEM to DER:
 Output the text form of a DER encoded certificate:
 
  openssl crl -in crl.der -text -noout
+
+Output the text form of a DER encoded certificate,
+displaying non-ASCII UTF-8 characters in the C<DirName> field
+without hex-escaping them:
+
+ LC_ALL=C.UTF-8 openssl crl -in crl.der -text -noout
 
 =head1 BUGS
 
@@ -171,7 +195,7 @@ Since OpenSSL 3.3, the B<-verify> option will exit with 1 on failure.
 
 =head1 COPYRIGHT
 
-Copyright 2000-2024 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2025 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/X509_NAME_print_ex.pod
+++ b/doc/man3/X509_NAME_print_ex.pod
@@ -3,7 +3,7 @@
 =head1 NAME
 
 X509_NAME_print_ex, X509_NAME_print_ex_fp, X509_NAME_print,
-X509_NAME_oneline - X509_NAME printing routines
+X509_NAME_oneline, X509_NAME_oneline_for_locale - X509_NAME printing routines
 
 =head1 SYNOPSIS
 
@@ -14,6 +14,7 @@ X509_NAME_oneline - X509_NAME printing routines
  int X509_NAME_print_ex_fp(FILE *fp, const X509_NAME *nm,
                            int indent, unsigned long flags);
  char *X509_NAME_oneline(const X509_NAME *a, char *buf, int size);
+ char *X509_NAME_oneline_for_locale(const X509_NAME *a, char *buf, int size);
  int X509_NAME_print(BIO *bp, const X509_NAME *name, int obase);
 
 =head1 DESCRIPTION
@@ -32,19 +33,25 @@ I<size> is ignored.
 Otherwise, at most I<size> bytes will be written, including the ending '\0',
 and I<buf> is returned.
 
+X509_NAME_oneline_for_locale() prints a UTF-8 version of I<a> to I<buf>
+if I<a> has non-ASCII UTF-8 characters, the locale has a codeset of
+C<.UTF-8>, and the X.509 NAME value type is C<UTF8String>. It otherwise
+has the same behaviour as X509_NAME_oneline().
+
 X509_NAME_print() prints out I<name> to I<bp> indenting each line by I<obase>
 characters. Multiple lines are used if the output (including indent) exceeds
 80 characters.
 
 =head1 NOTES
 
-The functions X509_NAME_oneline() and X509_NAME_print()
+The functions X509_NAME_oneline(), X509_NAME_oneline_for_locale(),
+and X509_NAME_print()
 produce a non standard output form, they don't handle multi-character fields and
 have various quirks and inconsistencies.
 Their use is strongly discouraged in new applications and they could
 be deprecated in a future release.
 
-Although there are a large number of possible flags for most purposes
+Although there is a large number of possible flags, for most purposes
 B<XN_FLAG_ONELINE>, B<XN_FLAG_MULTILINE> or B<XN_FLAG_RFC2253> will suffice.
 As noted on the L<ASN1_STRING_print_ex(3)> manual page
 for UTF8 terminals the B<ASN1_STRFLGS_ESC_MSB> should be unset: so for example
@@ -52,19 +59,19 @@ B<XN_FLAG_ONELINE & ~ASN1_STRFLGS_ESC_MSB> would be used.
 
 The complete set of the flags supported by X509_NAME_print_ex() is listed below.
 
-Several options can be ored together.
+Several options can be C<or>ed together.
 
 The options B<XN_FLAG_SEP_COMMA_PLUS>, B<XN_FLAG_SEP_CPLUS_SPC>,
 B<XN_FLAG_SEP_SPLUS_SPC> and B<XN_FLAG_SEP_MULTILINE>
 determine the field separators to use.
 Two distinct separators are used between distinct RelativeDistinguishedName
 components and separate values in the same RDN for a multi-valued RDN.
-Multi-valued RDNs are currently very rare
+Multi-valued RDNs are currently very rare,
 so the second separator will hardly ever be used.
 
 B<XN_FLAG_SEP_COMMA_PLUS> uses comma and plus as separators.
-B<XN_FLAG_SEP_CPLUS_SPC> uses comma and plus with spaces:
-this is more readable that plain comma and plus.
+B<XN_FLAG_SEP_CPLUS_SPC> uses comma and plus with spaces;
+this is more readable than plain comma and plus.
 B<XN_FLAG_SEP_SPLUS_SPC> uses spaced semicolon and plus.
 B<XN_FLAG_SEP_MULTILINE> uses spaced newline and plus respectively.
 
@@ -72,9 +79,9 @@ If B<XN_FLAG_DN_REV> is set the whole DN is printed in reversed order.
 
 The fields B<XN_FLAG_FN_SN>, B<XN_FLAG_FN_LN>, B<XN_FLAG_FN_OID>,
 B<XN_FLAG_FN_NONE> determine how a field name is displayed. It will
-use the short name (e.g. CN) the long name (e.g. commonName) always
-use OID numerical form (normally OIDs are only used if the field name is not
-recognised) and no field name respectively.
+use the short name (e.g. CN), the long name (e.g. commonName), always
+use the OID numerical form (normally OIDs are only used if the field name
+is not recognised), and no field name respectively.
 
 If B<XN_FLAG_SPC_EQ> is set then spaces will be placed around the '=' character
 separating field names and values.
@@ -82,13 +89,13 @@ separating field names and values.
 If B<XN_FLAG_DUMP_UNKNOWN_FIELDS> is set then the encoding of unknown fields is
 printed instead of the values.
 
-If B<XN_FLAG_FN_ALIGN> is set then field names are padded to 20 characters: this
+If B<XN_FLAG_FN_ALIGN> is set then field names are padded to 20 characters; this
 is only of use for multiline format.
 
 Additionally all the options supported by ASN1_STRING_print_ex() can be used to
 control how each field value is displayed.
 
-In addition a number options can be set for commonly used formats.
+In addition a number of options can be set for commonly used formats.
 
 B<XN_FLAG_RFC2253> sets options which produce an output compatible with RFC2253.
 It is equivalent to:
@@ -103,12 +110,13 @@ B<XN_FLAG_MULTILINE> is a multiline format which is the same as:
  C<ASN1_STRFLGS_ESC_CTRL | ASN1_STRFLGS_ESC_MSB | XN_FLAG_SEP_MULTILINE
    | XN_FLAG_SPC_EQ | XN_FLAG_FN_LN | XN_FLAG_FN_ALIGN>
 
-B<XN_FLAG_COMPAT> uses a format identical to X509_NAME_print():
+B<XN_FLAG_COMPAT> uses a format identical to X509_NAME_print();
 in fact it calls X509_NAME_print() internally.
 
 =head1 RETURN VALUES
 
-X509_NAME_oneline() returns a valid string on success or NULL on error.
+X509_NAME_oneline() and X509_NAME_oneline_for_locale()
+return a valid string on success or NULL on error.
 
 X509_NAME_print() returns 1 on success or 0 on error.
 
@@ -120,9 +128,16 @@ Otherwise, it returns -1 on error or other values on success.
 
 L<ASN1_STRING_print_ex(3)>
 
+=head1 HISTORY
+
+The functions X509_NAME_print_ex(), X509_NAME_print_ex_fp(),
+X509_NAME_print(), and X509_NAME_oneline() were added in OpenSSL 3.0.0.
+
+The function X509_NAME_oneline_for_locale() was added in OpenSSL 3.6.0.
+
 =head1 COPYRIGHT
 
-Copyright 2002-2020 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2002-2025 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -1,7 +1,7 @@
 /*
  * {- join("\n * ", @autowarntext) -}
  *
- * Copyright 1995-2024 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2025 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
@@ -622,7 +622,8 @@ DECLARE_ASN1_FUNCTIONS(NETSCAPE_CERT_SEQUENCE)
 
 X509_INFO *X509_INFO_new(void);
 void X509_INFO_free(X509_INFO *a);
-char *X509_NAME_oneline(const X509_NAME *a, char *buf, int size);
+char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len);
+char *X509_NAME_oneline_for_locale(const X509_NAME *a, char *buf, int len);
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
 OSSL_DEPRECATEDIN_3_0

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -1,7 +1,7 @@
 /*
  * {- join("\n * ", @autowarntext) -}
  *
- * Copyright 1995-2024 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2025 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
@@ -623,6 +623,7 @@ DECLARE_ASN1_FUNCTIONS(NETSCAPE_CERT_SEQUENCE)
 X509_INFO *X509_INFO_new(void);
 void X509_INFO_free(X509_INFO *a);
 char *X509_NAME_oneline(const X509_NAME *a, char *buf, int size);
+char *X509_NAME_oneline_for_locale(const X509_NAME *a, char *buf, int size);
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
 OSSL_DEPRECATEDIN_3_0

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -1,7 +1,7 @@
 /*
  * {- join("\n * ", @autowarntext) -}
  *
- * Copyright 1995-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2024 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
@@ -622,8 +622,7 @@ DECLARE_ASN1_FUNCTIONS(NETSCAPE_CERT_SEQUENCE)
 
 X509_INFO *X509_INFO_new(void);
 void X509_INFO_free(X509_INFO *a);
-char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len);
-char *X509_NAME_oneline_for_locale(const X509_NAME *a, char *buf, int len);
+char *X509_NAME_oneline(const X509_NAME *a, char *buf, int size);
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
 OSSL_DEPRECATEDIN_3_0

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5928,3 +5928,4 @@ OPENSSL_sk_set_thunks                   ?	3_6_0	EXIST::FUNCTION:
 i2d_PKCS8PrivateKey                     ?	3_6_0	EXIST::FUNCTION:
 OSSL_PARAM_set_octet_string_or_ptr      ?	3_6_0	EXIST::FUNCTION:
 OSSL_STORE_LOADER_settable_ctx_params   ?	3_6_0	EXIST::FUNCTION:
+X509_NAME_oneline_for_locale            ?	3_6_0	EXIST::FUNCTION:


### PR DESCRIPTION
Fixes #27207.

The example CRL provided by @onepeople158 shows that with the `-text` option of `openssl crl`, the `DirName` field of the `X509v3 Authority Key Identifier` is displayed using hex-escape sequences of UTF-8-encoded characters, e.g. displaying “Ö” as “\xC3\x96”, and “ü” as “\xC3\xBC”. This proposed fix allows such characters in the `DirName` field to be displayed as themselves, without any hex-escaping, if and only if all of the following prerequisites are met:

1. Such characters have code points outside of the ASCII codespace;
2. The field’s X.509 NAME entry value type is “UTF8String”;
3. The `openssl` process is run in an environment with an appropriate environment variable set that has a value with a “.UTF-8” codeset.

The example CRL’s `DirName` field will continue to show hex-escaped non-ASCII UTF-8-encoded characters if the `openssl` process lacks `LC_ALL`, `LC_CTYPE`, and `LANG` environment variables, or if the first available environment variable in the order above either does not specify a codeset, or has a codeset that is not “.UTF-8”.

For example, having `LANG=en_US.ISO8859-1` in the environment of `openssl` would preserve the non-ASCII hex-escaping of `DirName`; having `LC_CTYPE=de_AT.UTF-8` would prevent the non-ASCII hex-escaping (overriding `LANG`); and having `LC_ALL=C` would preserve the non-ASCII hex-escaping (overriding both `LC_CTYPE` and `LANG`). But if the X.509 NAME entry value type of the CRL were not “UTF8String”, the non-ASCII hex-escaping would be preserved, overriding environment variable values that would otherwise prevent the hex-escaping.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated