### PR TITLE
Fix test/recipes/25-test_verify.t [3.5]

### DIFF
--- a/test/recipes/25-test_verify.t
+++ b/test/recipes/25-test_verify.t
@@ -30,7 +30,7 @@ sub verify {
     run(app([@args]));
 }
 
-plan tests => 205;
+plan tests => 203;
 
 # Canonical success
 ok(verify("ee-cert", "sslserver", ["root-cert"], ["ca-cert"]),
@@ -608,12 +608,10 @@ SKIP: {
     my $foo_file = "foo:cert.pem";
     copy($rootcert, $foo_file);
     ok(vfy_root("-CAstore", $foo_file), "CAstore foo:file");
-    ok(vfy_root("-CAstore", "file:".$foo_file), "CAstore file:foo:file");
 }
 my $foo_file = "cert.pem";
 copy($rootcert, $foo_file);
 ok(vfy_root("-CAstore", $foo_file), "CAstore foo:file");
-ok(vfy_root("-CAstore", "file:".$foo_file), "CAstore file:foo:file");
 my $abs_cert = abs_path($rootcert);
 # Windows file: URIs should have a path part starting with a slash, i.e.
 # file://authority/C:/what/ever/foo.pem and file:///C:/what/ever/foo.pem


### PR DESCRIPTION
This removes a couple of tests that check a relaxation of the
'file:' scheme implementation that isn't present in OpenSSL 3.5

Fixes cherry-pick of #27529 to openssl-3.5
