### PR TITLE
crypto/property/property.c: Free impl->method to avoid memory leak

### DIFF
--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -348,7 +348,7 @@ int ossl_method_store_add(OSSL_METHOD_STORE *store, const OSSL_PROVIDER *prov,
 
     /* Insert into the hash table if required */
     if (!ossl_property_write_lock(store)) {
-        OPENSSL_free(impl);
+        impl_free(impl);
         return 0;
     }
 


### PR DESCRIPTION
After ossl_method_up_ref() succeeds, impl_free() should be called to free impl->method.

Fixes: 860ecfd700 ("property: check return values from the property locking calls.")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
