### PR TITLE
crypto/x509/v3_lib.c: Free tmpext if X509V3_EXT_add() fails to avoid …

### DIFF
--- a/crypto/x509/v3_lib.c
+++ b/crypto/x509/v3_lib.c
@@ -100,7 +100,11 @@ int X509V3_EXT_add_alias(int nid_to, int nid_from)
     *tmpext = *ext;
     tmpext->ext_nid = nid_to;
     tmpext->ext_flags |= X509V3_EXT_DYNAMIC;
-    return X509V3_EXT_add(tmpext);
+    if (!X509V3_EXT_add(tmpext)) {
+        OPENSSL_free(tmpext);
+        return 0;
+    }
+    return 1;
 }
 
 void X509V3_EXT_cleanup(void)


### PR DESCRIPTION
…memory leak

Add OPENSSL_free to free tmpext if X509V3_EXT_add() fails to avoid memory leak.

Fixes: 878dc8dd95 ("Join the x509 and x509v3 directories")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
