### PR TITLE
CMS: add missing CLI failure message; fix micalg output for SHAKE and GostR3411 - backport

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -1280,6 +1280,7 @@ int cms_main(int argc, char **argv)
             goto end;
         }
         if (ret <= 0) {
+            BIO_printf(bio_err, "Error writing CMS output\n");
             ret = 6;
             goto end;
         }

--- a/doc/man3/d2i_X509.pod
+++ b/doc/man3/d2i_X509.pod
@@ -588,8 +588,9 @@ freed in the event of error and I<*a> is set to NULL.
 B<i2d_I<TYPE>>() returns the number of bytes successfully encoded or a negative
 value if an error occurs.
 
-B<i2d_I<TYPE>_bio>() and B<i2d_I<TYPE>_fp>() return 1 for success and 0 if an
-error occurs.
+B<i2d_I<TYPE>_bio>() and B<i2d_I<TYPE>_fp>(),
+as well as i2d_ASN1_bio_stream(),
+return 1 for success and 0 if an error occurs.
 
 =head1 EXAMPLES
 


### PR DESCRIPTION
This backports the most important code fixes and the doc fix of #27368:
On error signing and outputting a CMS structure, the CMS app so far does not show any error report,
and the micalg output goes wrong for SHAKE cases,
and an incomplete output is generated, such as:
```
MIME-Version: 1.0
Content-Type: multipart/signed; protocol="application/pkcs7-signature"; micalg="sha-256"; boundary="----06E11A8E98630D2D320E8F2EAFD28032"

This is an S/MIME signed message

------06E11A8E98630D2D320E8F2EAFD28032
12345
```

This PR fixes the above mentioned issues by adding error messages in `apps/cms.c` and adding 
error checking for calls to `BIO_printf()`, `BIO_puts()`, and `asn1_write_micalg()` in `SMIME_write_ASN1_ex()`. 
It also removes several needless extra `ERR_print_errors()` calls and 
clarifies the treatment of the `ret` variable in `cms_main()` in `apps/cms.c`.
