### PR TITLE
ssl/t1_lib.c: Free gix if sk_TLS_GROUP_IX_push() fails to avoid memor…

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -976,8 +976,10 @@ int tls1_get0_implemented_groups(int min_proto_version, int max_proto_version,
             goto end;
         gix->grp = grps;
         gix->ix = ix;
-        if (sk_TLS_GROUP_IX_push(collect, gix) <= 0)
+        if (sk_TLS_GROUP_IX_push(collect, gix) <= 0) {
+            OPENSSL_free(gix);
             goto end;
+        }
     }
 
     sk_TLS_GROUP_IX_sort(collect);


### PR DESCRIPTION
…y leak

Add OPENSSL_free() to free gix if sk_TLS_GROUP_IX_push() fails to avoid memory leak

Fixes: 4b1c73d2dd ("ML-KEM hybrids for TLS")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
