### PR TITLE
test/bio_comp_test.c: Initialize pointer before free to avoid undefined behavior

### DIFF
--- a/test/bio_comp_test.c
+++ b/test/bio_comp_test.c
@@ -83,8 +83,10 @@ static int do_bio_comp(const BIO_METHOD *meth, int n)
     int size = sizes[n % 4];
     int type = n / 4;
 
-    if (!TEST_ptr(original = OPENSSL_malloc(BUFFER_SIZE))
-        || !TEST_ptr(result = OPENSSL_malloc(BUFFER_SIZE)))
+    original = OPENSSL_malloc(BUFFER_SIZE);
+    result = OPENSSL_malloc(BUFFER_SIZE);
+
+    if (!TEST_ptr(original) || !TEST_ptr(result))
         goto err;
 
     switch (type) {


### PR DESCRIPTION
If the allocation for "original" fails, "result" may be freed without being properly initialized. Since result could hold a random value due to its assignment in do_bio_comp_test(), freeing it without initialization is unsafe and may lead to undefined behavior.

Fixes: 12e96a2360 ("Add brotli compression support (RFC7924)")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
