### PR TITLE
test/timing_load_creds.c: Free contents in error handling to avoid me…

### DIFF
--- a/test/timing_load_creds.c
+++ b/test/timing_load_creds.c
@@ -150,6 +150,7 @@ int main(int ac, char **av)
     }
     fp = fopen(av[0], "r");
     if ((long)fread(contents, 1, sb.st_size, fp) != sb.st_size) {
+        OPENSSL_free(contents);
         perror("fread");
         exit(EXIT_FAILURE);
     }
@@ -171,10 +172,12 @@ int main(int ac, char **av)
     }
 
     if (gettimeofday(&e_start, NULL) < 0) {
+        OPENSSL_free(contents);
         perror("elapsed start");
         exit(EXIT_FAILURE);
     }
     if (getrusage(RUSAGE_SELF, &start) < 0) {
+        OPENSSL_free(contents);
         perror("start");
         exit(EXIT_FAILURE);
     }
@@ -189,10 +192,12 @@ int main(int ac, char **av)
         }
     }
     if (getrusage(RUSAGE_SELF, &end) < 0) {
+        OPENSSL_free(contents);
         perror("getrusage");
         exit(EXIT_FAILURE);
     }
     if (gettimeofday(&e_end, NULL) < 0) {
+        OPENSSL_free(contents);
         perror("gettimeofday");
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
…mory leak

Add a call to OPENSSL_free() in the error handling path to ensure contents is properly freed and prevent a memory leak.

Fixes: 45479dcee1 ("test/timing_load_creds.c: fix coding style and other (mostly minor) issues")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
