### PR TITLE
OS X 10.4/10.5 C code compatibility patch

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1849,6 +1849,10 @@ my %targets = (
     # Option "freeze" such as -std=gnu9x can't negatively interfere
     # with future defaults for below two targets, because MacOS X
     # for PPC has no future, it was discontinued by vendor in 2009.
+    "darwin8-ppc-cc" => {
+        inherit_from => [ "darwin-ppc" ],
+        disable => [ "async" ]
+    },
     "darwin-ppc-cc" => { inherit_from => [ "darwin-ppc" ] }, # Historic alias
     "darwin-ppc" => {
         inherit_from     => [ "darwin-common" ],
@@ -1857,6 +1861,10 @@ my %targets = (
         shared_cflag     => add("-fno-common"),
         asm_arch         => 'ppc32',
         perlasm_scheme   => "osx32",
+    },
+    "darwin8-ppc-cc" => {
+        inherit_from => [ "darwin64-ppc" ],
+        disable => [ "async" ]
     },
     "darwin64-ppc-cc" => { inherit_from => [ "darwin64-ppc" ] }, # Historic alias
     "darwin64-ppc" => {

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1862,7 +1862,7 @@ my %targets = (
         asm_arch         => 'ppc32',
         perlasm_scheme   => "osx32",
     },
-    "darwin8-ppc-cc" => {
+    "darwin8-ppc64-cc" => {
         inherit_from => [ "darwin64-ppc" ],
         disable => [ "async" ]
     },

--- a/include/crypto/rand.h
+++ b/include/crypto/rand.h
@@ -23,12 +23,12 @@
 # include "crypto/rand_pool.h"
 
 # if defined(__APPLE__) && !defined(OPENSSL_NO_APPLE_CRYPTO_RANDOM)
-#if (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
-#  include <Availability.h>
-#else
-#  include <TargetConditionals.h>
-#  include <AvailabilityMacros.h>
-#endif
+#  if (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
+#   include <Availability.h>
+#  else
+#   include <TargetConditionals.h>
+#   include <AvailabilityMacros.h>
+#  endif
 #  if (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200) || \
      (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 80000)
 #   define OPENSSL_APPLE_CRYPTO_RANDOM 1

--- a/include/crypto/rand.h
+++ b/include/crypto/rand.h
@@ -23,7 +23,7 @@
 # include "crypto/rand_pool.h"
 
 # if defined(__APPLE__) && !defined(OPENSSL_NO_APPLE_CRYPTO_RANDOM)
-#  if (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
+#  if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
 #   include <Availability.h>
 #  else
 #   include <TargetConditionals.h>

--- a/include/crypto/rand.h
+++ b/include/crypto/rand.h
@@ -23,7 +23,12 @@
 # include "crypto/rand_pool.h"
 
 # if defined(__APPLE__) && !defined(OPENSSL_NO_APPLE_CRYPTO_RANDOM)
+#if (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
 #  include <Availability.h>
+#else
+#  include <TargetConditionals.h>
+#  include <AvailabilityMacros.h>
+#endif
 #  if (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200) || \
      (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 80000)
 #   define OPENSSL_APPLE_CRYPTO_RANDOM 1

--- a/include/internal/numbers.h
+++ b/include/internal/numbers.h
@@ -106,5 +106,13 @@ typedef __uint128_t uint128_t;
 #  define OSSL_UINTMAX_MAX __MAXUINT__(ossl_uintmax_t)
 # endif
 
+// Fix for cross compiling 64-bit PowerPC on OS X 10.4 
+# if defined(__APPLE__) && defined(_ARCH_PPC64) && _ARCH_PPC64
+#  ifdef SIZE_MAX
+#   undef SIZE_MAX
+#  endif
+#  define SIZE_MAX __MAXUINT__(uint64_t)
+# endif
+
 #endif
 

--- a/include/internal/numbers.h
+++ b/include/internal/numbers.h
@@ -107,7 +107,7 @@ typedef __uint128_t uint128_t;
 # endif
 
 /* Fix for cross compiling 64-bit PowerPC on OS X 10.4 */
-# if defined(__APPLE__) && defined(_ARCH_PPC64) && _ARCH_PPC64
+# if defined(__APPLE__) && defined(_ARCH_PPC64)
 #  ifdef SIZE_MAX
 #   undef SIZE_MAX
 #  endif

--- a/include/internal/numbers.h
+++ b/include/internal/numbers.h
@@ -106,7 +106,7 @@ typedef __uint128_t uint128_t;
 #  define OSSL_UINTMAX_MAX __MAXUINT__(ossl_uintmax_t)
 # endif
 
-// Fix for cross compiling 64-bit PowerPC on OS X 10.4 
+/* Fix for cross compiling 64-bit PowerPC on OS X 10.4 */
 # if defined(__APPLE__) && defined(_ARCH_PPC64) && _ARCH_PPC64
 #  ifdef SIZE_MAX
 #   undef SIZE_MAX

--- a/test/testutil/helper.c
+++ b/test/testutil/helper.c
@@ -19,7 +19,7 @@
 # define timezone _timezone
 #endif
 
-#if defined(__FreeBSD__) || defined(__wasi__)
+#if defined(__FreeBSD__) || defined(__wasi__) || (defined(__APPLE__) && !defined(OPENSSL_NO_APPLE_CRYPTO_RANDOM) && !(defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1050))
 # define USE_TIMEGM
 #endif
 

--- a/test/testutil/helper.c
+++ b/test/testutil/helper.c
@@ -19,7 +19,9 @@
 # define timezone _timezone
 #endif
 
-#if defined(__FreeBSD__) || defined(__wasi__) || (defined(__APPLE__) && !defined(OPENSSL_NO_APPLE_CRYPTO_RANDOM) && !(defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1050))
+#if defined(__FreeBSD__) || defined(__wasi__) || \
+  (defined(__APPLE__) && !defined(OPENSSL_NO_APPLE_CRYPTO_RANDOM) && \
+   !(defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1050))
 # define USE_TIMEGM
 #endif
 

--- a/test/testutil/helper.c
+++ b/test/testutil/helper.c
@@ -20,8 +20,8 @@
 #endif
 
 #if defined(__FreeBSD__) || defined(__wasi__) || \
-  (defined(__APPLE__) && !defined(OPENSSL_NO_APPLE_CRYPTO_RANDOM) && \
-   !(defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1050))
+    (defined(__APPLE__) && !defined(OPENSSL_NO_APPLE_CRYPTO_RANDOM) && \
+     !(defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1050))
 # define USE_TIMEGM
 #endif
 

--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -146,6 +146,7 @@ my $guess_patterns = [
     ],
     [ 'Paragon.*?:.*',              'i860-intel-osf1' ],
     [ 'Rhapsody:.*',                'ppc-apple-rhapsody' ],
+    [ 'Darwin:8.*?:.*?:Power.*',    'ppc-apple-darwin8' ],
     [ 'Darwin:.*?:.*?:Power.*',     'ppc-apple-darwin' ],
     [ 'Darwin:.*',                  '${MACHINE}-apple-darwin' ],
     [ 'SunOS:5\..*',                '${MACHINE}-whatever-solaris2' ],
@@ -491,6 +492,22 @@ EOF
         }
       ],
       [ 'ppc-apple-rhapsody',     { target => "rhapsody-ppc" } ],
+      [ 'ppc-apple-darwin8.*', 
+        sub {
+            my $KERNEL_BITS = $ENV{KERNEL_BITS} // '';
+            my $ISA64 = `sysctl -n hw.optional.64bitops 2>/dev/null`;
+            if ( $ISA64 == 1 && $KERNEL_BITS eq '' ) {
+                print <<EOF;
+WARNING! To build 64-bit package, do this:
+         $WHERE/Configure darwin8-ppc64-cc
+EOF
+                maybe_abort();
+            }
+            return { target => "darwin8-ppc64-cc" }
+                if $ISA64 == 1 && $KERNEL_BITS eq '64';
+            return { target => "darwin8-ppc-cc" };
+        }
+      ],
       [ 'ppc-apple-darwin.*',
         sub {
             my $KERNEL_BITS = $ENV{KERNEL_BITS} // '';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
Fixes #19684 

This patch fixes OS X 10.4 Tiger & OS X 10.5 Leopard support for a no-asm no-async build of the OpenSSL master branch, building on @mpsuzuki's work to apply it to the current master branch, specifically for OS X 10.4+.

I didn't yet include making no-async the default on OS X 10.4+, simply because I wanted to get some input on what is the best approach?  My initial thinking is that it would seem best to make no-async the default for all PowerPC Darwin (since only Leopard supports it and will build without it), and then perhaps create special cases for Leopard+ (darwin9-ppc-cc and darwin9-ppc64-cc) in config.pm and/or 10-main.conf to have it enabled by default only on that platform.

The static initialization workarounds for proposed by @mpsuzuki may still be needed for (an) earlier version(s) of OS X, but they were/are not needed for my machine which uses OS X 10.4 Tiger.  So, I didn't include them in my PR, although I'm not opposed to adding them, I just don't have an earlier version of OS X than 10.4 Tiger to test.

The assembler code is being worked out in a separate thread since there is an issue in the asm code pertinent to other PowerPC machine architectures.  So, OpenSSL on PPC OS X should be built with no-asm for the time being, but that may change once issue #27017 gets resolved (see discussion in its associated PR): https://github.com/openssl/openssl/pull/27017

Attached is my build log.  I used the stock Xcode that comes on my OS X 10.4 installation disc with the only modification to my build environment being an updated version of Perl (version 5.40) since OpenSSL requires Perl 5.10+ and OS X 10.4 Tiger comes with 5.8.6:

[openssl-master-noasm+noasync-ppc64.txt](https://github.com/user-attachments/files/20073925/openssl-master-noasm%2Bnoasync-ppc64.txt)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated (see helper.c)