### PR TITLE
Update IMPL_*_SIGALG to not have to stringify parameter

### DIFF
--- a/providers/implementations/signature/dsa_sig.c
+++ b/providers/implementations/signature/dsa_sig.c
@@ -990,11 +990,11 @@ static int dsa_sigalg_set_ctx_params(void *vpdsactx, const OSSL_PARAM params[])
     dsa_##md##_sign_init(void *vpdsactx, void *vdsa,                    \
                          const OSSL_PARAM params[])                     \
     {                                                                   \
-        static const char desc[] = "DSA-" #MD " Sign Init";             \
+        static const char desc[] = "DSA-" MD " Sign Init";             \
                                                                         \
         return dsa_sigalg_signverify_init(vpdsactx, vdsa,               \
                                           dsa_sigalg_set_ctx_params,    \
-                                          params, #MD,                  \
+                                          params, MD,                  \
                                           EVP_PKEY_OP_SIGN,             \
                                           desc);                        \
     }                                                                   \
@@ -1003,11 +1003,11 @@ static int dsa_sigalg_set_ctx_params(void *vpdsactx, const OSSL_PARAM params[])
     dsa_##md##_sign_message_init(void *vpdsactx, void *vdsa,            \
                                  const OSSL_PARAM params[])             \
     {                                                                   \
-        static const char desc[] = "DSA-" #MD " Sign Message Init";     \
+        static const char desc[] = "DSA-" MD " Sign Message Init";     \
                                                                         \
         return dsa_sigalg_signverify_init(vpdsactx, vdsa,               \
                                           dsa_sigalg_set_ctx_params,    \
-                                          params, #MD,                  \
+                                          params, MD,                  \
                                           EVP_PKEY_OP_SIGNMSG,          \
                                           desc);                        \
     }                                                                   \
@@ -1016,11 +1016,11 @@ static int dsa_sigalg_set_ctx_params(void *vpdsactx, const OSSL_PARAM params[])
     dsa_##md##_verify_init(void *vpdsactx, void *vdsa,                  \
                            const OSSL_PARAM params[])                   \
     {                                                                   \
-        static const char desc[] = "DSA-" #MD " Verify Init";           \
+        static const char desc[] = "DSA-" MD " Verify Init";           \
                                                                         \
         return dsa_sigalg_signverify_init(vpdsactx, vdsa,               \
                                           dsa_sigalg_set_ctx_params,    \
-                                          params, #MD,                  \
+                                          params, MD,                  \
                                           EVP_PKEY_OP_VERIFY,           \
                                           desc);                        \
     }                                                                   \
@@ -1029,11 +1029,11 @@ static int dsa_sigalg_set_ctx_params(void *vpdsactx, const OSSL_PARAM params[])
     dsa_##md##_verify_message_init(void *vpdsactx, void *vdsa,          \
                                    const OSSL_PARAM params[])           \
     {                                                                   \
-        static const char desc[] = "DSA-" #MD " Verify Message Init";   \
+        static const char desc[] = "DSA-" MD " Verify Message Init";   \
                                                                         \
         return dsa_sigalg_signverify_init(vpdsactx, vdsa,               \
                                           dsa_sigalg_set_ctx_params,    \
-                                          params, #MD,                  \
+                                          params, MD,                  \
                                           EVP_PKEY_OP_VERIFYMSG,        \
                                           desc);                        \
     }                                                                   \
@@ -1074,12 +1074,12 @@ static int dsa_sigalg_set_ctx_params(void *vpdsactx, const OSSL_PARAM params[])
         OSSL_DISPATCH_END                                               \
     }
 
-IMPL_DSA_SIGALG(sha1, SHA1);
-IMPL_DSA_SIGALG(sha224, SHA2-224);
-IMPL_DSA_SIGALG(sha256, SHA2-256);
-IMPL_DSA_SIGALG(sha384, SHA2-384);
-IMPL_DSA_SIGALG(sha512, SHA2-512);
-IMPL_DSA_SIGALG(sha3_224, SHA3-224);
-IMPL_DSA_SIGALG(sha3_256, SHA3-256);
-IMPL_DSA_SIGALG(sha3_384, SHA3-384);
-IMPL_DSA_SIGALG(sha3_512, SHA3-512);
+IMPL_DSA_SIGALG(sha1, "SHA1");
+IMPL_DSA_SIGALG(sha224, "SHA2-224");
+IMPL_DSA_SIGALG(sha256, "SHA2-256");
+IMPL_DSA_SIGALG(sha384, "SHA2-384");
+IMPL_DSA_SIGALG(sha512, "SHA2-512");
+IMPL_DSA_SIGALG(sha3_224, "SHA3-224");
+IMPL_DSA_SIGALG(sha3_256, "SHA3-256");
+IMPL_DSA_SIGALG(sha3_384, "SHA3-384");
+IMPL_DSA_SIGALG(sha3_512, "SHA3-512");

--- a/providers/implementations/signature/ecdsa_sig.c
+++ b/providers/implementations/signature/ecdsa_sig.c
@@ -1013,11 +1013,11 @@ static int ecdsa_sigalg_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     ecdsa_##md##_sign_init(void *vctx, void *vec,                       \
                          const OSSL_PARAM params[])                     \
     {                                                                   \
-        static const char desc[] = "ECDSA-" #MD " Sign Init";           \
+        static const char desc[] = "ECDSA-" MD " Sign Init";           \
                                                                         \
         return ecdsa_sigalg_signverify_init(vctx, vec,                  \
                                             ecdsa_sigalg_set_ctx_params, \
-                                            params, #MD,                \
+                                            params, MD,                \
                                             EVP_PKEY_OP_SIGN,           \
                                             desc);                      \
     }                                                                   \
@@ -1026,11 +1026,11 @@ static int ecdsa_sigalg_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     ecdsa_##md##_sign_message_init(void *vctx, void *vec,               \
                                    const OSSL_PARAM params[])           \
     {                                                                   \
-        static const char desc[] = "ECDSA-" #MD " Sign Message Init";   \
+        static const char desc[] = "ECDSA-" MD " Sign Message Init";   \
                                                                         \
         return ecdsa_sigalg_signverify_init(vctx, vec,                  \
                                             ecdsa_sigalg_set_ctx_params, \
-                                            params, #MD,                \
+                                            params, MD,                \
                                             EVP_PKEY_OP_SIGNMSG,        \
                                             desc);                      \
     }                                                                   \
@@ -1039,11 +1039,11 @@ static int ecdsa_sigalg_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     ecdsa_##md##_verify_init(void *vctx, void *vec,                     \
                            const OSSL_PARAM params[])                   \
     {                                                                   \
-        static const char desc[] = "ECDSA-" #MD " Verify Init";         \
+        static const char desc[] = "ECDSA-" MD " Verify Init";         \
                                                                         \
         return ecdsa_sigalg_signverify_init(vctx, vec,                  \
                                             ecdsa_sigalg_set_ctx_params, \
-                                            params, #MD,                \
+                                            params, MD,                \
                                             EVP_PKEY_OP_VERIFY,         \
                                             desc);                      \
     }                                                                   \
@@ -1052,11 +1052,11 @@ static int ecdsa_sigalg_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     ecdsa_##md##_verify_message_init(void *vctx, void *vec,             \
                                      const OSSL_PARAM params[])         \
     {                                                                   \
-        static const char desc[] = "ECDSA-" #MD " Verify Message Init"; \
+        static const char desc[] = "ECDSA-" MD " Verify Message Init"; \
                                                                         \
         return ecdsa_sigalg_signverify_init(vctx, vec,                  \
                                             ecdsa_sigalg_set_ctx_params, \
-                                            params, #MD,                \
+                                            params, MD,                \
                                             EVP_PKEY_OP_VERIFYMSG,      \
                                             desc);                      \
     }                                                                   \
@@ -1097,12 +1097,12 @@ static int ecdsa_sigalg_set_ctx_params(void *vctx, const OSSL_PARAM params[])
         OSSL_DISPATCH_END                                               \
     }
 
-IMPL_ECDSA_SIGALG(sha1, SHA1);
-IMPL_ECDSA_SIGALG(sha224, SHA2-224);
-IMPL_ECDSA_SIGALG(sha256, SHA2-256);
-IMPL_ECDSA_SIGALG(sha384, SHA2-384);
-IMPL_ECDSA_SIGALG(sha512, SHA2-512);
-IMPL_ECDSA_SIGALG(sha3_224, SHA3-224);
-IMPL_ECDSA_SIGALG(sha3_256, SHA3-256);
-IMPL_ECDSA_SIGALG(sha3_384, SHA3-384);
-IMPL_ECDSA_SIGALG(sha3_512, SHA3-512);
+IMPL_ECDSA_SIGALG(sha1, "SHA1");
+IMPL_ECDSA_SIGALG(sha224, "SHA2-224");
+IMPL_ECDSA_SIGALG(sha256, "SHA2-256");
+IMPL_ECDSA_SIGALG(sha384, "SHA2-384");
+IMPL_ECDSA_SIGALG(sha512, "SHA2-512");
+IMPL_ECDSA_SIGALG(sha3_224, "SHA3-224");
+IMPL_ECDSA_SIGALG(sha3_256, "SHA3-256");
+IMPL_ECDSA_SIGALG(sha3_384, "SHA3-384");
+IMPL_ECDSA_SIGALG(sha3_512, "SHA3-512");

--- a/providers/implementations/signature/rsa_sig.c
+++ b/providers/implementations/signature/rsa_sig.c
@@ -2023,7 +2023,7 @@ static int rsa_sigalg_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
                                                                         \
         return rsa_sigalg_signverify_init(vprsactx, vrsa,               \
                                           rsa_sigalg_set_ctx_params,    \
-                                          params, #MD,                  \
+                                          params, MD,                  \
                                           EVP_PKEY_OP_SIGN,             \
                                           RSA_PKCS1_PADDING,            \
                                           desc);                        \
@@ -2037,7 +2037,7 @@ static int rsa_sigalg_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
                                                                         \
         return rsa_sigalg_signverify_init(vprsactx, vrsa,               \
                                           rsa_sigalg_set_ctx_params,    \
-                                          params, #MD,                  \
+                                          params, MD,                  \
                                           EVP_PKEY_OP_SIGNMSG,          \
                                           RSA_PKCS1_PADDING,            \
                                           desc);                        \
@@ -2051,7 +2051,7 @@ static int rsa_sigalg_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
                                                                         \
         return rsa_sigalg_signverify_init(vprsactx, vrsa,               \
                                           rsa_sigalg_set_ctx_params,    \
-                                          params, #MD,                  \
+                                          params, MD,                  \
                                           EVP_PKEY_OP_VERIFY,           \
                                           RSA_PKCS1_PADDING,            \
                                           desc);                        \
@@ -2065,7 +2065,7 @@ static int rsa_sigalg_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
                                                                         \
         return rsa_sigalg_signverify_init(vprsactx, vrsa,               \
                                           rsa_sigalg_set_ctx_params,    \
-                                          params, #MD,                  \
+                                          params, MD,                  \
                                           EVP_PKEY_OP_VERIFYRECOVER,    \
                                           RSA_PKCS1_PADDING,            \
                                           desc);                        \
@@ -2079,7 +2079,7 @@ static int rsa_sigalg_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
                                                                         \
         return rsa_sigalg_signverify_init(vprsactx, vrsa,               \
                                           rsa_sigalg_set_ctx_params,    \
-                                          params, #MD,                  \
+                                          params, MD,                  \
                                           EVP_PKEY_OP_VERIFYMSG,        \
                                           RSA_PKCS1_PADDING,            \
                                           desc);                        \
@@ -2126,19 +2126,19 @@ static int rsa_sigalg_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
     }
 
 #if !defined(OPENSSL_NO_RMD160) && !defined(FIPS_MODULE)
-IMPL_RSA_SIGALG(ripemd160, RIPEMD160);
+IMPL_RSA_SIGALG(ripemd160, "RIPEMD160");
 #endif
-IMPL_RSA_SIGALG(sha1, SHA1);
-IMPL_RSA_SIGALG(sha224, SHA2-224);
-IMPL_RSA_SIGALG(sha256, SHA2-256);
-IMPL_RSA_SIGALG(sha384, SHA2-384);
-IMPL_RSA_SIGALG(sha512, SHA2-512);
-IMPL_RSA_SIGALG(sha512_224, SHA2-512/224);
-IMPL_RSA_SIGALG(sha512_256, SHA2-512/256);
-IMPL_RSA_SIGALG(sha3_224, SHA3-224);
-IMPL_RSA_SIGALG(sha3_256, SHA3-256);
-IMPL_RSA_SIGALG(sha3_384, SHA3-384);
-IMPL_RSA_SIGALG(sha3_512, SHA3-512);
+IMPL_RSA_SIGALG(sha1, "SHA1");
+IMPL_RSA_SIGALG(sha224, "SHA2-224");
+IMPL_RSA_SIGALG(sha256, "SHA2-256");
+IMPL_RSA_SIGALG(sha384, "SHA2-384");
+IMPL_RSA_SIGALG(sha512, "SHA2-512");
+IMPL_RSA_SIGALG(sha512_224, "SHA2-512/224");
+IMPL_RSA_SIGALG(sha512_256, "SHA2-512/256");
+IMPL_RSA_SIGALG(sha3_224, "SHA3-224");
+IMPL_RSA_SIGALG(sha3_256, "SHA3-256");
+IMPL_RSA_SIGALG(sha3_384, "SHA3-384");
+IMPL_RSA_SIGALG(sha3_512, "SHA3-512");
 #if !defined(OPENSSL_NO_SM3) && !defined(FIPS_MODULE)
-IMPL_RSA_SIGALG(sm3, SM3);
+IMPL_RSA_SIGALG(sm3, "SM3");
 #endif


### PR DESCRIPTION
Noted while playing with some c-style tools that these macros got mis-handled when doing style changes.  Specifically, the last parameter, as it passed externally as a token, but stringified internal to the associated macro, got handled as an arithmetic expression rather than a string.

Given that the only thing this parameter is used for is as a string, cut out the middle man and just pass it as a string in the first place


