### PR TITLE
Raise an error if PBKDF2 iteration count set to zero on check disabled in default provider

### DIFF
--- a/providers/implementations/kdfs/pbkdf2.c
+++ b/providers/implementations/kdfs/pbkdf2.c
@@ -242,6 +242,9 @@ static int lower_bound_check_passed(KDF_PBKDF2 *ctx, int saltlen, uint64_t iter,
             ERR_raise(ERR_LIB_PROV, error);
             return 0;
         }
+    } else if (iter < 1) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_ITERATION_COUNT);
+        return 0;
     }
 #endif
 

--- a/test/recipes/30-test_evp_data/evpkdf_pbkdf2.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_pbkdf2.txt
@@ -275,3 +275,12 @@ Ctrl.iter = iter:10
 Ctrl.digest = digest:sha1
 Result = KDF_CTRL_ERROR
 Reason = invalid iteration count
+
+Availablein = default
+KDF = PBKDF2
+Ctrl.pass = pass:password
+Ctrl.salt = salt:salt
+Ctrl.iter = iter:0
+Ctrl.digest = digest:sha1
+Result = KDF_CTRL_ERROR
+Reason = invalid iteration count


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

Before [#27001](https://github.com/openssl/openssl/pull/27001/files#diff-286fa75634773cc184851e33db5715da5fb5eca6e9488cc11fdd1350aeb89d22L303) , if we set iteration count to zero, an error is raised.

However, we missed this case on refactoring. Therefore, we add related check again and the corresponding test here.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
