### PR TITLE
APPS/cmp.c: fix char encoding of subject, issuer, sender, and recipient DN

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -955,7 +955,7 @@ static int set_name(const char *str,
                     OSSL_CMP_CTX *ctx, const char *desc)
 {
     if (str != NULL) {
-        X509_NAME *n = parse_name(str, MBSTRING_ASC, 1, desc);
+        X509_NAME *n = parse_name(str, MBSTRING_UTF8, 1, desc);
 
         if (n == NULL)
             return 0;


### PR DESCRIPTION
It was reported that the helper function `set_name()` was using  `MBSTRING_ASC`
rather than `MBSTRING_UTF8` when calling `parse_name()`,
which lead to wrong encoding of UTF-8 input strings, 
e.g., in the `commonName` of a subject DN, which is of type `UTF8STRING`.

This PR implements the suggested straightforward fix.

Fixes #27572
