### PR TITLE
Reduce the scope of pkcs11-provider external test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -658,16 +658,12 @@ jobs:
         gdb < <(echo -e "file ./libcrypto.so.3\nquit") > ./results
         grep -q "Reading symbols from.*libcrypto\.so\.3\.debug" results
 
-  external-tests-providers:
+  external-tests-oqs-provider:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
-    - name: package installs
-      run: |
-        sudo apt-get update
-        sudo apt-get -yq install meson pkg-config gnutls-bin libnss3-tools libnss3-dev libsofthsm2 opensc expect
     - name: config
       run: ./config --strict-warnings --banner=Configured --debug enable-external-tests && perl configdata.pm --dump
     - name: make
@@ -678,6 +674,21 @@ jobs:
         ./util/opensslwrap.sh version -c
     - name: test external oqs-provider
       run: make test TESTS="test_external_oqsprovider"
+
+  external-tests-pkcs11-provider:
+    runs-on: ubuntu-latest
+    container: fedora:rawhide
+    steps:
+    - name: package installs
+      run: |
+        dnf install -y kryoptic perl git meson opensc expect
+    - uses: actions/checkout@v4
+      with:
+        submodules: true  
+    - name: config
+      run: ./config --strict-warnings --banner=Configured --debug enable-external-tests && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
     - name: test external pkcs11-provider
       run: make test TESTS="test_external_pkcs11_provider" VERBOSE=1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -678,9 +678,8 @@ jobs:
         ./util/opensslwrap.sh version -c
     - name: test external oqs-provider
       run: make test TESTS="test_external_oqsprovider"
-    # Disabled temporarily: https://github.com/latchset/pkcs11-provider/pull/525#discussion_r1982805969
-    # - name: test external pkcs11-provider
-    #   run: make test TESTS="test_external_pkcs11_provider" VERBOSE=1
+    - name: test external pkcs11-provider
+      run: make test TESTS="test_external_pkcs11_provider" VERBOSE=1
 
   external-tests-pyca:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -677,20 +677,32 @@ jobs:
 
   external-tests-pkcs11-provider:
     runs-on: ubuntu-latest
-    container: fedora:rawhide
+    container: fedora:latest
     steps:
     - name: package installs
       run: |
-        dnf install -y kryoptic perl git meson opensc expect
+        dnf install -y perl-FindBin perl-IPC-Cmd perl-File-Compare perl-File-Copy perl-Test-Simple perl-Test-Harness python3 make g++ perl git meson opensc expect kryoptic
     - uses: actions/checkout@v4
-      with:
-        submodules: true  
+    - name: checkout fuzz/corpora and pkcs11-provider submodule
+      run: |
+        git config --global --add safe.directory /__w/openssl/openssl
+        git submodule update --init --depth 1 fuzz/corpora
+        git submodule update --init --depth 1 pkcs11-provider
     - name: config
-      run: ./config --strict-warnings --banner=Configured --debug enable-external-tests && perl configdata.pm --dump
+      run: ./config --strict-warnings --banner=Configured --debug enable-external-tests no-fips && perl configdata.pm --dump
     - name: make
       run: make -s -j4
+    # Run all tests except external tests to make sure they work fine on Fedora because
+    # this is the only job running on Fedora, only then execute pkcs11-provider external
+    # test.
+    - name: test (except external tests)
+      run: make test TESTS="-test_external_*"
     - name: test external pkcs11-provider
       run: make test TESTS="test_external_pkcs11_provider" VERBOSE=1
+    - name: get cpu info
+      run: |
+        cat /proc/cpuinfo
+        ./util/opensslwrap.sh version -c
 
   external-tests-pyca:
     runs-on: ubuntu-latest

--- a/test/README-external.md
+++ b/test/README-external.md
@@ -132,8 +132,7 @@ Then configure/build OpenSSL enabling external tests:
     $ make
 
 pkcs11-provider requires meson for the build process. Moreover, it requires
-softhsm and nss softokn tokens and certtool, certutil, pkcs11-tool and expect
-to run the tests.
+kryoptic, opensc and expect to run the tests.
 
 Tests will then be run as part of the rest of the suite, or can be
 explicitly run (with more debugging):

--- a/test/recipes/95-test_external_pkcs11_provider_data/pkcs11-provider.sh
+++ b/test/recipes/95-test_external_pkcs11_provider_data/pkcs11-provider.sh
@@ -44,6 +44,7 @@ echo "   OPENSSL_ROOT_DIR:   $OPENSSL_ROOT_DIR"
 echo "   OpenSSL version:    $OPENSSL_VERSION"
 echo "------------------------------------------------------------------"
 
+PKCS11_PROVIDER_SRCDIR=$OPENSSL_ROOT_DIR/pkcs11-provider/
 PKCS11_PROVIDER_BUILDDIR=$OPENSSL_ROOT_DIR/pkcs11-provider/builddir
 
 echo "------------------------------------------------------------------"
@@ -52,6 +53,11 @@ echo "------------------------------------------------------------------"
 
 PKG_CONFIG_PATH="$BLDTOP" meson setup $PKCS11_PROVIDER_BUILDDIR $OPENSSL_ROOT_DIR/pkcs11-provider/ || exit 1
 meson compile -C $PKCS11_PROVIDER_BUILDDIR pkcs11 || exit 1
+
+# Remove pkcs11-provider tlsfuzzer submodule tlsfuzzer directory to skip tlsfuzzer tests
+if [ -d "${PKCS11_PROVIDER_SRCDIR}/tlsfuzzer/tlsfuzzer" ]; then
+    rm -rf "${PKCS11_PROVIDER_SRCDIR}/tlsfuzzer/tlsfuzzer"
+fi
 
 echo "------------------------------------------------------------------"
 echo "Running tests"

--- a/test/recipes/95-test_external_pkcs11_provider_data/pkcs11-provider.sh
+++ b/test/recipes/95-test_external_pkcs11_provider_data/pkcs11-provider.sh
@@ -64,7 +64,8 @@ echo "Running tests"
 echo "------------------------------------------------------------------"
 
 # The OpenSSL app uses ${HARNESS_OSSL_PREFIX} as a prefix for its standard output
-HARNESS_OSSL_PREFIX= meson test -C $PKCS11_PROVIDER_BUILDDIR
+# For maintenance reasons and simplicity we only run test with kryoptic token
+HARNESS_OSSL_PREFIX= meson test -C $PKCS11_PROVIDER_BUILDDIR --suite=kryoptic
 
 if [ $? -ne 0 ]; then
     cat $PKCS11_PROVIDER_BUILDDIR/meson-logs/testlog.txt


### PR DESCRIPTION
To ease maintenance and improve reliability of pkcs11-provider external test we reduce its execution to a single (and most reliable) token - kryoptic (this also reduces dependencies of the test). To be able to do so we need to run the test on Fedora (container) instead of ubuntu because kryoptic is not available there and hence we need to split the original external-tests-providers into external-tests-oqs-provider and external-tests-pkcs11-provider. 

Since we have not a CI job running on fedora:latest container it makes sense to run other non-external tests there too to make sure everything works fine.

Moreover, we intentionally disable tlsfuzzer tests available in pkcs11-provider testsuite since this external tests is not really a good place to run them. 

Finally, we update the pkcs11-provider submodule to the latest upstream version.