### PR TITLE
Implement partial verification for CMS with multiple signatures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -214,6 +214,21 @@ OpenSSL Releases
 
    *Marcel Cornu and Tomasz Kantecki*
 
+ * Add `CMS_VERIFY_PARTIAL` flag to `CMS_verify()` and `-verify_partial` option
+   to `openssl cms -verify`.
+
+   If this flag is set, the call is successful also if not all, but at least
+   one of the individual signatures can be verified (perhaps due to CAs missing
+   from the local store, expired certificates, or unsupported algorithms). The
+   application would then call `CMS_get0_signers()` and check if the set of
+   valid signatures satisfies its policy.
+
+   To access detailed verification results, the new functions
+   `CMS_SignerInfo_get_verification_result()` and
+   `CMS_SignerInfo_get0_signer_cert()` can be used.
+
+   *Jan Lübbe*
+
  * Changed the output of the -disabled option for the list command.
    Displaying disabled features, protocols, and algorithms, in relevant sections.
    Disabled features are now generated at configuration time.

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -1397,6 +1397,35 @@ int cms_main(int argc, char **argv)
                 ret = verify_err + 32;
             goto end;
         }
+        if ((flags & CMS_VERIFY_PARTIAL) != 0) {
+            int i;
+            STACK_OF(CMS_SignerInfo) *sinfos = CMS_get0_SignerInfos(cms);
+
+            for (i = 0; i < sk_CMS_SignerInfo_num(sinfos); i++) {
+                CMS_SignerInfo *si = sk_CMS_SignerInfo_value(sinfos, i);
+                X509 *si_signer = CMS_SignerInfo_get0_signer_cert(si);
+                const X509_NAME *si_subject = NULL;
+
+                if (si_signer == NULL) {
+                    BIO_printf(bio_err, "Signer %d: no certificate\n", i);
+                    continue;
+                }
+
+                si_subject = X509_get_subject_name(si_signer);
+                if (si_subject == NULL) {
+                    BIO_printf(bio_err, "Signer %d: no subject name\n", i);
+                    continue;
+                }
+
+                BIO_printf(bio_err, "Signer %d: ", i);
+                X509_NAME_print_ex(bio_err, si_subject, 0, XN_FLAG_ONELINE);
+                BIO_printf(bio_err, "\n  Verification %s (cert: %s, attrs: %s, content: %s)\n",
+                    CMS_SignerInfo_get_verification_result(si, CMS_VERIFY_RESULT) ? "successful" : "failed",
+                    CMS_SignerInfo_get_verification_result(si, CMS_VERIFY_CERT) ? "success" : "failure or not verified",
+                    CMS_SignerInfo_get_verification_result(si, CMS_VERIFY_ATTR) ? "success" : "failure or not verified",
+                    CMS_SignerInfo_get_verification_result(si, CMS_VERIFY_CONTENT) ? "success" : "failure or not verified");
+            }
+        }
         if (signerfile != NULL) {
             STACK_OF(X509) *signers = CMS_get0_signers(cms);
 

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -81,6 +81,7 @@ typedef enum OPTION_choice {
     OPT_SIGN_RECEIPT,
     OPT_RESIGN,
     OPT_VERIFY,
+    OPT_VERIFY_PARTIAL,
     OPT_VERIFY_RETCODE,
     OPT_VERIFY_RECEIPT,
     OPT_CMSOUT,
@@ -282,8 +283,10 @@ const OPTIONS cms_options[] = {
     { "nointern", OPT_NOINTERN, '-',
         "Don't search certificates in message for signer" },
     { "cades", OPT_DUP, '-', "Check signingCertificate (CAdES-BES)" },
+    { "verify_partial", OPT_VERIFY_PARTIAL, '-',
+        "Return success if at least one signature can be verified" },
     { "verify_retcode", OPT_VERIFY_RETCODE, '-',
-        "Exit non-zero on verification failure" },
+        "Exit non-zero on verification failure (depends on -verify_partial etc.)" },
     { "CAfile", OPT_CAFILE, '<', "File in PEM format with trusted CA certs" },
     { "CApath", OPT_CAPATH, '/', "Dir with trusted CA cert files in PEM format" },
     { "CAstore", OPT_CASTORE, ':', "URI of store with trusted CA certs" },
@@ -456,6 +459,9 @@ int cms_main(int argc, char **argv)
         case OPT_VERIFY_RECEIPT:
             operation = SMIME_VERIFY_RECEIPT;
             rctfile = opt_arg();
+            break;
+        case OPT_VERIFY_PARTIAL:
+            flags |= CMS_VERIFY_PARTIAL;
             break;
         case OPT_VERIFY_RETCODE:
             verify_retcode = 1;

--- a/crypto/cms/cms_local.h
+++ b/crypto/cms/cms_local.h
@@ -103,6 +103,11 @@ struct CMS_SignerInfo_st {
     const CMS_CTX *cms_ctx;
     /* Set to 1 if signing time attribute is to be omitted */
     int omit_signing_time;
+    /* Remember which aspects have been verified */
+    int verify_result; /* for this SignerInfo, all attempted verification aspects succeeded */
+    int cert_verified; /* the certificate was verified successfully */
+    int attr_verified; /* any given signed attributes were verified successfully */
+    int content_verified; /* the signature over the content was verified successfully */
 };
 
 struct CMS_SignerIdentifier_st {

--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -871,6 +871,11 @@ void CMS_SignerInfo_set1_signer_cert(CMS_SignerInfo *si, X509 *signer)
     si->signer = signer;
 }
 
+X509 *CMS_SignerInfo_get0_signer_cert(const CMS_SignerInfo *si)
+{
+    return si->signer;
+}
+
 int CMS_SignerInfo_get0_signer_id(CMS_SignerInfo *si,
     ASN1_OCTET_STRING **keyid,
     X509_NAME **issuer, ASN1_INTEGER **sno)
@@ -1051,6 +1056,27 @@ static int cms_EVP_PKEY_verify(EVP_PKEY_CTX *pctx, BIO *in, unsigned char *sig,
         ret = EVP_PKEY_verify_message_final(pctx);
     }
     return ret;
+}
+
+int CMS_SignerInfo_get_verification_result(const CMS_SignerInfo *si, int type)
+{
+    switch (type) {
+    case CMS_VERIFY_RESULT:
+        return si->verify_result;
+
+    case CMS_VERIFY_CERT:
+        return si->cert_verified;
+
+    case CMS_VERIFY_ATTR:
+        return si->attr_verified;
+
+    case CMS_VERIFY_CONTENT:
+        return si->content_verified;
+
+    default:
+        ERR_raise(ERR_LIB_CMS, CMS_R_UNKNOWN_ID);
+        return 0;
+    }
 }
 
 static int cms_SignerInfo_content_sign(CMS_ContentInfo *cms,

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -350,7 +350,7 @@ int CMS_verify(CMS_ContentInfo *cms, const STACK_OF(X509) *certs,
     STACK_OF(X509_CRL) *crls = NULL;
     STACK_OF(X509) **si_chains = NULL;
     X509 *signer;
-    int i, scount = 0, ret = 0;
+    int i, n = 0, scount = 0, ret = 0;
     BIO *cmsbio = NULL, *tmpin = NULL, *tmpout = NULL;
     int cadesVerify = (flags & CMS_CADES) != 0;
     const CMS_CTX *ctx = ossl_cms_get0_cmsctx(cms);
@@ -378,6 +378,11 @@ int CMS_verify(CMS_ContentInfo *cms, const STACK_OF(X509) *certs,
         CMS_SignerInfo_get0_algs(si, NULL, &signer, NULL, NULL);
         if (signer != NULL)
             scount++;
+        /* Reset verification results */
+        si->verify_result = 1; /* so far, fine */
+        si->cert_verified = 0;
+        si->attr_verified = 0;
+        si->content_verified = 0;
     }
 
     if (scount != sk_CMS_SignerInfo_num(sinfos))
@@ -413,8 +418,11 @@ int CMS_verify(CMS_ContentInfo *cms, const STACK_OF(X509) *certs,
 
             if (!cms_signerinfo_verify_cert(si, store, untrusted, crls,
                     si_chains ? &si_chains[i] : NULL,
-                    ctx))
-                goto err;
+                    ctx)) {
+                si->verify_result = 0;
+                continue;
+            }
+            si->cert_verified = 1;
         }
     }
 
@@ -423,16 +431,25 @@ int CMS_verify(CMS_ContentInfo *cms, const STACK_OF(X509) *certs,
     if ((flags & CMS_NO_ATTR_VERIFY) == 0 || cadesVerify) {
         for (i = 0; i < scount; i++) {
             si = sk_CMS_SignerInfo_value(sinfos, i);
-            if (CMS_signed_get_attr_count(si) < 0)
+            if (!si->verify_result)
                 continue;
-            if (CMS_SignerInfo_verify(si) <= 0)
-                goto err;
+            if (CMS_signed_get_attr_count(si) < 0) {
+                si->attr_verified = 1;
+                continue;
+            }
+            if (CMS_SignerInfo_verify(si) <= 0) {
+                si->verify_result = 0;
+                continue;
+            }
             if (cadesVerify) {
                 STACK_OF(X509) *si_chain = si_chains ? si_chains[i] : NULL;
 
-                if (ossl_cms_check_signing_certs(si, si_chain) <= 0)
-                    goto err;
+                if (ossl_cms_check_signing_certs(si, si_chain) <= 0) {
+                    si->verify_result = 0;
+                    continue;
+                }
             }
+            si->attr_verified = 1;
         }
     }
 
@@ -497,15 +514,30 @@ int CMS_verify(CMS_ContentInfo *cms, const STACK_OF(X509) *certs,
     if (!(flags & CMS_NO_CONTENT_VERIFY)) {
         for (i = 0; i < sk_CMS_SignerInfo_num(sinfos); i++) {
             si = sk_CMS_SignerInfo_value(sinfos, i);
+            if (!si->verify_result)
+                continue;
             if (CMS_SignerInfo_verify_ex(si, cmsbio, tmpin) <= 0) {
                 ERR_raise(ERR_LIB_CMS, CMS_R_CONTENT_VERIFY_ERROR);
-                goto err;
+                si->verify_result = 0;
+                continue;
             }
+            si->content_verified = 1;
         }
     }
 
-    ret = 1;
+    /* Determine overall result */
+    for (i = 0; i < scount; i++) {
+        if (sk_CMS_SignerInfo_value(sinfos, i)->verify_result)
+            n++;
+    }
+    if ((flags & CMS_VERIFY_PARTIAL) != 0)
+        ret = n > 0; /* One success is enough */
+    else
+        ret = n == scount; /* All must be successful */
 err:
+    if (!ret)
+        for (i = 0; i < scount; i++)
+            sk_CMS_SignerInfo_value(sinfos, i)->verify_result = 0;
     if (!(flags & SMIME_BINARY) && dcont) {
         do_free_upto(cmsbio, tmpout);
         if (tmpin != dcont)

--- a/doc/man1/openssl-cms.pod.in
+++ b/doc/man1/openssl-cms.pod.in
@@ -104,6 +104,7 @@ Verification options:
 [B<-noverify>]
 [B<-nointern>]
 [B<-cades>]
+[B<-verify_partial>]
 [B<-verify_retcode>]
 {- $OpenSSL::safe::opt_trust_synopsis -}
 
@@ -593,6 +594,12 @@ The supplied certificates can still be used as untrusted CAs however.
 When used with B<-verify>, require and check signer certificate digest.
 See the NOTES section for more details.
 
+=item B<-verify_partial>
+
+Succeed if at least one signature can be verified.
+Print info which signature verifications succeeded or failed in which
+aspect(s).
+
 =item B<-verify_retcode>
 
 Exit nonzero on verification failure.
@@ -961,6 +968,8 @@ The B<-digest> option was added in OpenSSL 3.2.
 The B<-recip_kdf> and B<-recip_ukm> options were added in OpenSSL 3.6.
 
 The B<-engine> option was removed in OpenSSL 4.0.
+
+The B<-verify_partial> option was added in OpenSSL 4.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/CMS_get0_SignerInfos.pod
+++ b/doc/man3/CMS_get0_SignerInfos.pod
@@ -3,8 +3,10 @@
 =head1 NAME
 
 CMS_SignerInfo_set1_signer_cert,
+CMS_SignerInfo_get0_signer_cert,
 CMS_get0_SignerInfos, CMS_SignerInfo_get0_signer_id,
-CMS_SignerInfo_get0_signature, CMS_SignerInfo_cert_cmp
+CMS_SignerInfo_get0_signature, CMS_SignerInfo_cert_cmp,
+CMS_SignerInfo_get_verification_result
 - CMS signedData signer functions
 
 =head1 SYNOPSIS
@@ -18,6 +20,8 @@ CMS_SignerInfo_get0_signature, CMS_SignerInfo_cert_cmp
  ASN1_OCTET_STRING *CMS_SignerInfo_get0_signature(CMS_SignerInfo *si);
  int CMS_SignerInfo_cert_cmp(CMS_SignerInfo *si, X509 *cert);
  void CMS_SignerInfo_set1_signer_cert(CMS_SignerInfo *si, X509 *signer);
+ X509 *CMS_SignerInfo_get0_signer_cert(CMS_SignerInfo *si);
+ int CMS_SignerInfo_get_verification_result(CMS_SignerInfo *si, int type);
 
 =head1 DESCRIPTION
 
@@ -40,6 +44,16 @@ if not.
 
 CMS_SignerInfo_set1_signer_cert() sets the signer's certificate of B<si> to
 B<signer>.
+
+CMS_SignerInfo_get0_signer_cert() returns the signer's certificate associated
+with I<si>. This pointer should not be freed by the caller.
+
+CMS_SignerInfo_get_verification_result() returns whether a specific aspect of
+the signature verification was successful after calling L<CMS_verify(3)> with
+the flag B<CMS_VERIFY_PARTIAL>. Pass B<CMS_VERIFY_RESULT> as I<type> to get
+the overall result, B<CMS_VERIFY_CERT> for certificate verification,
+B<CMS_VERIFY_ATTR> for attribute verification and B<CMS_VERIFY_CONTENT> for
+content verification.
 
 =head1 NOTES
 
@@ -77,6 +91,11 @@ Any error can be obtained from L<ERR_get_error(3)>
 =head1 SEE ALSO
 
 L<ERR_get_error(3)>, L<CMS_verify(3)>
+
+=head1 HISTORY
+
+B<CMS_SignerInfo_get0_signer_cert> and
+B<CMS_SignerInfo_get_verification_result> were added in OpenSSL 4.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/CMS_verify.pod
+++ b/doc/man3/CMS_verify.pod
@@ -86,9 +86,10 @@ the content is detached I<detached_data> cannot be NULL.
 An attempt is made to locate all the signing certificate(s), first looking in
 the I<certs> parameter (if it is not NULL) and then looking in any
 certificates contained in the I<cms> structure unless B<CMS_NOINTERN> is set.
-If any signing certificate cannot be located the operation fails.
+If any signing certificate cannot be located the operation fails unless
+B<CMS_VERIFY_PARTIAL> is set, where one signing certificate can be sufficient.
 
-Each signing certificate is chain verified
+Each found signing certificate is chain verified
 using the trusted certificate store I<store> if supplied.
 The purpose required in this verification is I<smimesign>
 unless a different one (or B<X509_PURPOSE_DEFAULT_ANY>)
@@ -98,12 +99,16 @@ L<CMS_add1_cert(3)>, are used as untrusted CAs.
 If CRL checking is enabled in I<store> and B<CMS_NOCRL> is not set,
 any internal CRLs, which may have been added using L<CMS_add1_crl(3)>,
 are used in addition to attempting to look them up in I<store>.
-If I<store> is not NULL and any chain verify fails an error code is returned.
+If I<store> is not NULL and any chain verify fails an error code is returned
+unless B<CMS_VERIFY_PARTIAL> is set, where one successful verify can be sufficient.
 
 Finally the signed content is read (and written to I<out> unless it is NULL)
-and the signature is checked.
+and each signature (for which the certificate was successfully verified) is checked.
 
-If all signatures verify correctly then the function is successful.
+The overall result of the function depends on whether B<CMS_VERIFY_PARTIAL> is
+set. When set, a single successfully verified signature is enough and
+L<CMS_get0_SignerInfos(3)> can be used to inspect each signature.
+Otherwise, the function is only successful if all signatures verify successfully.
 
 Any of the following flags (ored together) can be passed in the I<flags>
 parameter to change the default verify behaviour.
@@ -186,6 +191,8 @@ L<ERR_get_error(3)>, L<CMS_sign(3)>
 =head1 HISTORY
 
 CMS_SignedData_verify() was added in OpenSSL 3.2.
+
+The B<CMS_VERIFY_PARTIAL> flag was added in OpenSSL 4.1.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/cms.h.in
+++ b/include/openssl/cms.h.in
@@ -104,6 +104,7 @@ CMS_ContentInfo *CMS_ContentInfo_new_ex(OSSL_LIB_CTX *libctx, const char *propq)
 #define CMS_CADES 0x100000
 #define CMS_USE_ORIGINATOR_KEYID 0x200000
 #define CMS_NO_SIGNING_TIME 0x400000
+#define CMS_VERIFY_PARTIAL 0x800000
 
 const ASN1_OBJECT *CMS_get0_type(const CMS_ContentInfo *cms);
 

--- a/include/openssl/cms.h.in
+++ b/include/openssl/cms.h.in
@@ -76,6 +76,11 @@ CMS_ContentInfo *CMS_ContentInfo_new_ex(OSSL_LIB_CTX *libctx, const char *propq)
 #define CMS_RECIPINFO_OTHER 4
 #define CMS_RECIPINFO_KEM 5
 
+#define CMS_VERIFY_RESULT 0
+#define CMS_VERIFY_CERT 1
+#define CMS_VERIFY_ATTR 2
+#define CMS_VERIFY_CONTENT 3
+
 /* S/MIME related flags */
 
 #define CMS_TEXT 0x1
@@ -290,6 +295,7 @@ EVP_MD_CTX *CMS_SignerInfo_get0_md_ctx(CMS_SignerInfo *si);
 STACK_OF(CMS_SignerInfo) *CMS_get0_SignerInfos(CMS_ContentInfo *cms);
 
 void CMS_SignerInfo_set1_signer_cert(CMS_SignerInfo *si, X509 *signer);
+X509 *CMS_SignerInfo_get0_signer_cert(const CMS_SignerInfo *si);
 int CMS_SignerInfo_get0_signer_id(CMS_SignerInfo *si,
     ASN1_OCTET_STRING **keyid,
     X509_NAME **issuer, ASN1_INTEGER **sno);
@@ -300,6 +306,7 @@ void CMS_SignerInfo_get0_algs(CMS_SignerInfo *si, EVP_PKEY **pk,
     X509 **signer, X509_ALGOR **pdig,
     X509_ALGOR **psig);
 ASN1_OCTET_STRING *CMS_SignerInfo_get0_signature(CMS_SignerInfo *si);
+int CMS_SignerInfo_get_verification_result(const CMS_SignerInfo *si, int type);
 int CMS_SignerInfo_sign(CMS_SignerInfo *si);
 int CMS_SignerInfo_verify(CMS_SignerInfo *si);
 int CMS_SignerInfo_verify_content(CMS_SignerInfo *si, BIO *chain);

--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -56,7 +56,7 @@ my ($no_des, $no_dh, $no_dsa, $no_ec, $no_ec2m, $no_rc2, $no_zlib)
 
 $no_rc2 = 1 if disabled("legacy");
 
-plan tests => 41;
+plan tests => 42;
 
 ok(run(test(["pkcs7_test", srctop_file("test", "certs", "servercert.pem"),
              srctop_file("test", "certs", "serverkey.pem")])), "test pkcs7");
@@ -1811,3 +1811,79 @@ subtest "PWRI missing keyDerivationAlgorithm regression" => sub {
     });
 };
 
+subtest "sign and verify with multiple keys and -verify_partial" => sub {
+    plan tests => 9;
+
+    my $smrsa2 = catfile($smdir, "smrsa2.pem");
+    my $sig1 = "sig1.cms";
+    my $out1 = "out1.txt";
+    my $sig2 = "sig2.cms";
+    my $out2 = "out2.txt";
+
+    ok(run(app(['openssl', 'cms',
+                @defaultprov,
+                '-sign', '-in', $smcont,
+                '-nodetach',
+                '-signer', $smrsa1,
+                '-out', $sig1, '-outform', 'DER',
+               ])),
+       "sign with first key");
+    ok(run(app(['openssl', 'cms',
+                @defaultprov,
+                '-verify', '-in', $sig1, '-inform', 'DER',
+                '-CAfile', $smrsa1, '-partial_chain',
+                '-verify_partial',
+                '-out', $out1,
+               ])),
+       "verify single signature");
+    is(compare($smcont, $out1), 0, "compare original message with verified message");
+
+    # because the smrsa2 signature cannot be verified, overall verification fails
+    ok(!run(app(['openssl', 'cms',
+                 @defaultprov,
+                 '-verify', '-in', $sig1, '-inform', 'DER',
+                 '-CAfile', $smrsa2, '-partial_chain',
+                 '-verify_partial',
+                 '-out', $out2,
+                ])),
+       "try to verify rsa1 signature with only rsa2");
+
+    ok(run(app(['openssl', 'cms',
+                @defaultprov,
+                '-resign', '-in', $sig1, '-inform', 'DER',
+                '-signer', $smrsa2,
+                '-out', $sig2, '-outform', 'DER',
+               ])),
+       "resign with second key");
+
+    # because the smrsa1 signature can be verified, overall verification succeeds
+    ok(run(app(['openssl', 'cms',
+                @defaultprov,
+                '-verify', '-in', $sig2, '-inform', 'DER',
+                '-CAfile', $smrsa1, '-partial_chain',
+                '-verify_partial',
+                '-out', $out2,
+               ])),
+       "verify two signatures with only rsa1");
+
+    # because the smrsa2 signature can be verified, overall verification succeeds
+    ok(run(app(['openssl', 'cms',
+                @defaultprov,
+                '-verify', '-in', $sig2, '-inform', 'DER',
+                '-CAfile', $smrsa2, '-partial_chain',
+                '-verify_partial',
+                '-out', $out2,
+               ])),
+       "verify two signatures with only rsa2");
+
+    # because both signatures can be verified, overall verification succeeds
+    ok(run(app(['openssl', 'cms',
+                 @defaultprov,
+                 '-verify', '-in', $sig2, '-inform', 'DER',
+                 '-CAfile', $smroot,
+                 '-verify_partial',
+                 '-out', $out2,
+                ])),
+       "verify both signature signatures with root");
+    is(compare($smcont, $out2), 0, "compare original message with verified message");
+};

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5715,6 +5715,8 @@ OPENSSL_sk_set_cmp_thunks               5712	4_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_set1                    5713	4_0_0	EXIST::FUNCTION:
 OSSL_ESS_check_signing_certs_ex         5714	4_0_0	EXIST::FUNCTION:
 X509v3_delete_extension                 5715	4_0_0	EXIST::FUNCTION:
+CMS_SignerInfo_get0_signer_cert         ?	4_1_0	EXIST::FUNCTION:CMS
+CMS_SignerInfo_get_verification_result  ?	4_1_0	EXIST::FUNCTION:CMS
 CTLOG_STORE_add0_log                    ?	4_1_0	EXIST::FUNCTION:CT
 CRYPTO_atomic_load_ptr                  ?	4_1_0	EXIST::FUNCTION:
 CRYPTO_atomic_store_ptr                 ?	4_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
Currently, OpenSSL supports creating CMS SignedData structures with
multiple signers using `CMS_sign()` with the `CMS_PARTIAL` flag combined
with `CMS_add1_signer()`. This can be done for a new SignedData or by
adding signers to an existing structure. In addition to the C API, this
is supported via `openssl cms -sign` (using multiple `-signer` options) and
`openssl cms -resign`.

The corresponding `CMS_verify()` function and `openssl cms -verify` command
check the signatures sequentially and abort with an error on the first
problem. They support some flags (`CMS_NO_SIGNER_CERT_VERIFY`,
`CMS_NO_ATTR_VERIFY`, `CMS_NO_CONTENT_VERIFY`), which disable some aspects
of the verification, but do not allow continuing after a failed
signature verification.

The main use cases for multiple signatures on one message are:

* Simplify CA certificate roll-over by signing messages with keys in
  both the old and new hierarchies during a transition period.
  Recipients would have either the old or new CA installed (or
  temporarily even both). In all cases, we'd like to accept any message
  which has at least one signature that can be verified.

* Support user-implemented verification policies which require
  signatures from multiple specific signers.

* Support user-implemented verification policies which require a minimum
  number of signatures from different signers under under a trusted CA.

This is made possible by adding a `CMS_VERIFY_PARTIAL` flag to `CMS_verify()`
and exposing it through a new `-verify_partial` option to `openssl cms
-verify`.

If this flag is set, the call is successful even if some of the
individual signatures cannot be verified (perhaps due to CAs missing
from the local store or expired certificates). The application would
then call `CMS_get0_signers()` and check if the set of valid signatures
satisfies its policy.

When verifying CMS messages with multiple signatures using
`CMS_VERIFY_PARTIAL` to implement additional custom requirements
regarding signatures from which certificates are required and/or
acceptable, information on which signature was considered invalid and
why by `CMS_verify` is useful for reporting or debugging.

Implement this by adding `CMS_SignerInfo`-based access to certificates
(`CMS_SignerInfo_get0_signer_cert`) and verification results
(`CMS_SignerInfo_get_verification_result`). Also use these new functions
to show more details when using `openssl cms -verify` with
`-verify_partial`.

Fixes #3028
Fixes #26382

##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated