### PR TITLE
Remove redundant check in apps/storeutl.c

### DIFF
--- a/apps/storeutl.c
+++ b/apps/storeutl.c
@@ -201,9 +201,7 @@ int storeutl_main(int argc, char *argv[])
             }
             break;
         case OPT_CRITERION_FINGERPRINT:
-            if (criterion != 0
-                || (criterion == OSSL_STORE_SEARCH_BY_KEY_FINGERPRINT
-                    && fingerprint != NULL)) {
+            if (criterion != 0) {
                 BIO_printf(bio_err, "%s: criterion already given.\n",
                            prog);
                 goto end;


### PR DESCRIPTION
If criterion == OSSL_STORE_SEARCH_BY_KEY_FINGERPRINT, the criterion !=0 condition will be triggered.

Found by Linux Verification Center (linuxtesting.org) with SVACE.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
