### PR TITLE
crypto/pkcs7/pk7_smime.c: Add BIO_free() to avoid memory leak

### DIFF
--- a/crypto/pkcs7/pk7_smime.c
+++ b/crypto/pkcs7/pk7_smime.c
@@ -320,8 +320,12 @@ int PKCS7_verify(PKCS7 *p7, STACK_OF(X509) *certs, X509_STORE *store,
         tmpout = out;
 
     /* We now have to 'read' from p7bio to calculate digests etc. */
-    if ((buf = OPENSSL_malloc(BUFFERSIZE)) == NULL)
+    if ((buf = OPENSSL_malloc(BUFFERSIZE)) == NULL) {
+        if (flags & PKCS7_TEXT)
+            BIO_free(tmpout);
         goto err;
+    }
+
     for (;;) {
         i = BIO_read(p7bio, buf, BUFFERSIZE);
         if (i <= 0)


### PR DESCRIPTION
Add BIO_free() to free tmpout if OPENSSL_malloc() fails to avoid memory leak.

Fixes: 8e704858f2 ("RT3955: Reduce some stack usage")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
