### PR TITLE
Fix Compilation Regression in OpenSSL 3.5.0 on Windows Due to Assembly Translator and Toolchain Compatibility Issues  

### DIFF
--- a/crypto/bn/asm/rsaz-2k-avxifma.pl
+++ b/crypto/bn/asm/rsaz-2k-avxifma.pl
@@ -296,34 +296,34 @@ $code.=<<___;
     and \$0xf, %r14
     vpsubq  .Lmask52x4(%rip), $_R0,  $T0
     shl \$5, %r14
-    vmovapd (%rdx, %r14), $T1
+    vmovapd (%rdx,%r14), $T1
     vblendvpd $T1, $T0, $_R0, $_R0
 
     shr \$4, %r13b
     and \$0xf, %r13
     vpsubq  .Lmask52x4(%rip), $_R0h,  $T0
     shl \$5, %r13
-    vmovapd (%rdx, %r13), $T1
+    vmovapd (%rdx,%r13), $T1
     vblendvpd $T1, $T0, $_R0h, $_R0h
 
     mov %r12b, %r11b
     and \$0xf, %r12
     vpsubq  .Lmask52x4(%rip), $_R1,  $T0
     shl \$5, %r12
-    vmovapd (%rdx, %r12), $T1
+    vmovapd (%rdx,%r12), $T1
     vblendvpd $T1, $T0, $_R1, $_R1
 
     shr \$4, %r11b
     and \$0xf, %r11
     vpsubq  .Lmask52x4(%rip), $_R1h,  $T0
     shl \$5, %r11
-    vmovapd (%rdx, %r11), $T1
+    vmovapd (%rdx,%r11), $T1
     vblendvpd $T1, $T0, $_R1h, $_R1h
 
     and \$0xf, %r10
     vpsubq  .Lmask52x4(%rip), $_R2,  $T0
     shl \$5, %r10
-    vmovapd (%rdx, %r10), $T1
+    vmovapd (%rdx,%r10), $T1
     vblendvpd $T1, $T0, $_R2, $_R2
 
     # Add carries according to the obtained mask

--- a/crypto/bn/asm/rsaz-2k-avxifma.pl
+++ b/crypto/bn/asm/rsaz-2k-avxifma.pl
@@ -27,7 +27,6 @@ $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}../../perlasm/x86_64-xlate.pl" and -f $xlate) or
 die "can't locate x86_64-xlate.pl";
 
-# TODO: Find out the version of NASM that supports VEX-encoded AVX-IFMA instructions
 if (`$ENV{CC} -Wa,-v -c -o /dev/null -x assembler /dev/null 2>&1`
         =~ /GNU assembler version ([2-9]\.[0-9]+)/) {
     $avxifma = ($1>=2.40);
@@ -37,6 +36,11 @@ if (!$avxifma && `$ENV{CC} -v 2>&1`
     =~ /\s*((?:clang|LLVM) version|.*based on LLVM) ([0-9]+)\.([0-9]+)\.([0-9]+)?/) {
     my $ver = $2 + $3/100.0 + $4/10000.0; # 3.1.0->3.01, 3.10.1->3.1001
     $avxifma = ($ver>=16.0);
+}
+
+if ($win64 && ($flavour =~ /nasm/ || $ENV{ASM} =~ /nasm/) &&
+       `nasm -v 2>&1` =~ /NASM version ([2-9]\.[0-9]+)(?:\.([0-9]+))?(rc[0-9]+)?/) {
+    $avxifma = ($1>2.16) + ($1==2.16 && ((!defined($2) && !defined($3)) || (defined($2))));
 }
 
 open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\""

--- a/crypto/bn/asm/rsaz-3k-avxifma.pl
+++ b/crypto/bn/asm/rsaz-3k-avxifma.pl
@@ -355,56 +355,56 @@ $code.=<<___;
     and \$0xf, %r14
     vpsubq  .Lmask52x4(%rip), $_R0,  $T0
     shl \$5, %r14
-    vmovapd (%rdx, %r14), $T1
+    vmovapd (%rdx,%r14), $T1
     vblendvpd $T1, $T0, $_R0, $_R0
 
     shr \$4, %r10b
     and \$0xf, %r10
     vpsubq  .Lmask52x4(%rip), $_R0h,  $T0
     shl \$5, %r10
-    vmovapd (%rdx, %r10), $T1
+    vmovapd (%rdx,%r10), $T1
     vblendvpd $T1, $T0, $_R0h, $_R0h
 
     mov %r13b, %r10b
     and \$0xf, %r13
     vpsubq  .Lmask52x4(%rip), $_R1,  $T0
     shl \$5, %r13
-    vmovapd (%rdx, %r13), $T1
+    vmovapd (%rdx,%r13), $T1
     vblendvpd $T1, $T0, $_R1, $_R1
 
     shr \$4, %r10b
     and \$0xf, %r10
     vpsubq  .Lmask52x4(%rip), $_R1h,  $T0
     shl \$5, %r10
-    vmovapd (%rdx, %r10), $T1
+    vmovapd (%rdx,%r10), $T1
     vblendvpd $T1, $T0, $_R1h, $_R1h
 
     mov %r12b, %r10b
     and \$0xf, %r12
     vpsubq  .Lmask52x4(%rip), $_R2,  $T0
     shl \$5, %r12
-    vmovapd (%rdx, %r12), $T1
+    vmovapd (%rdx,%r12), $T1
     vblendvpd $T1, $T0, $_R2, $_R2
 
     shr \$4, %r10b
     and \$0xf, %r10
     vpsubq  .Lmask52x4(%rip), $_R2h,  $T0
     shl \$5, %r10
-    vmovapd (%rdx, %r10), $T1
+    vmovapd (%rdx,%r10), $T1
     vblendvpd $T1, $T0, $_R2h, $_R2h
 
     mov %r11b, %r10b
     and \$0xf, %r11
     vpsubq  .Lmask52x4(%rip), $_R3,  $T0
     shl \$5, %r11
-    vmovapd (%rdx, %r11), $T1
+    vmovapd (%rdx,%r11), $T1
     vblendvpd $T1, $T0, $_R3, $_R3
 
     shr \$4, %r10b
     and \$0xf, %r10
     vpsubq  .Lmask52x4(%rip), $_R3h,  $T0
     shl \$5, %r10
-    vmovapd (%rdx, %r10), $T1
+    vmovapd (%rdx,%r10), $T1
     vblendvpd $T1, $T0, $_R3h, $_R3h
 
     vpand  .Lmask52x4(%rip), $_R0,  $_R0

--- a/crypto/bn/asm/rsaz-3k-avxifma.pl
+++ b/crypto/bn/asm/rsaz-3k-avxifma.pl
@@ -27,7 +27,6 @@ $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}../../perlasm/x86_64-xlate.pl" and -f $xlate) or
 die "can't locate x86_64-xlate.pl";
 
-# TODO: Find out the version of NASM that supports VEX-encoded AVX-IFMA instructions
 if (`$ENV{CC} -Wa,-v -c -o /dev/null -x assembler /dev/null 2>&1`
         =~ /GNU assembler version ([2-9]\.[0-9]+)/) {
     $avxifma = ($1>=2.40);
@@ -37,6 +36,11 @@ if (!$avxifma && `$ENV{CC} -v 2>&1`
     =~ /\s*((?:clang|LLVM) version|.*based on LLVM) ([0-9]+)\.([0-9]+)\.([0-9]+)?/) {
     my $ver = $2 + $3/100.0 + $4/10000.0; # 3.1.0->3.01, 3.10.1->3.1001
     $avxifma = ($ver>=16.0);
+}
+
+if ($win64 && ($flavour =~ /nasm/ || $ENV{ASM} =~ /nasm/) &&
+       `nasm -v 2>&1` =~ /NASM version ([2-9]\.[0-9]+)(?:\.([0-9]+))?(rc[0-9]+)?/) {
+    $avxifma = ($1>2.16) + ($1==2.16 && ((!defined($2) && !defined($3)) || (defined($2))));
 }
 
 open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\""

--- a/crypto/bn/asm/rsaz-4k-avxifma.pl
+++ b/crypto/bn/asm/rsaz-4k-avxifma.pl
@@ -424,70 +424,70 @@ $code.=<<___;
     and \$0xf, %r14
     vpsubq  .Lmask52x4(%rip), $_R0,  $tmp
     shl \$5, %r14
-    vmovapd (%r8, %r14), $tmp2
+    vmovapd (%r8,%r14), $tmp2
     vblendvpd $tmp2, $tmp, $_R0, $_R0
 
     shr \$4, %r9b
     and \$0xf, %r9
     vpsubq  .Lmask52x4(%rip), $_R0h,  $tmp
     shl \$5, %r9
-    vmovapd (%r8, %r9), $tmp2
+    vmovapd (%r8,%r9), $tmp2
     vblendvpd $tmp2, $tmp, $_R0h, $_R0h
 
     movb    %r13b,%r9b
     and \$0xf, %r13
     vpsubq  .Lmask52x4(%rip), $_R1,  $tmp
     shl \$5, %r13
-    vmovapd (%r8, %r13), $tmp2
+    vmovapd (%r8,%r13), $tmp2
     vblendvpd $tmp2, $tmp, $_R1, $_R1
 
     shr \$4, %r9b
     and \$0xf, %r9
     vpsubq  .Lmask52x4(%rip), $_R1h,  $tmp
     shl \$5, %r9
-    vmovapd (%r8, %r9), $tmp2
+    vmovapd (%r8,%r9), $tmp2
     vblendvpd $tmp2, $tmp, $_R1h, $_R1h
 
     movb    %r12b,%r9b
     and \$0xf, %r12
     vpsubq  .Lmask52x4(%rip), $_R2,  $tmp
     shl \$5, %r12
-    vmovapd (%r8, %r12), $tmp2
+    vmovapd (%r8,%r12), $tmp2
     vblendvpd $tmp2, $tmp, $_R2, $_R2
 
     shr \$4, %r9b
     and \$0xf, %r9
     vpsubq  .Lmask52x4(%rip), $_R2h,  $tmp
     shl \$5, %r9
-    vmovapd (%r8, %r9), $tmp2
+    vmovapd (%r8,%r9), $tmp2
     vblendvpd $tmp2, $tmp, $_R2h, $_R2h
 
     movb    %r11b,%r9b
     and \$0xf, %r11
     vpsubq  .Lmask52x4(%rip), $_R3,  $tmp
     shl \$5, %r11
-    vmovapd (%r8, %r11), $tmp2
+    vmovapd (%r8,%r11), $tmp2
     vblendvpd $tmp2, $tmp, $_R3, $_R3
 
     shr \$4, %r9b
     and \$0xf, %r9
     vpsubq  .Lmask52x4(%rip), $_R3h,  $tmp
     shl \$5, %r9
-    vmovapd (%r8, %r9), $tmp2
+    vmovapd (%r8,%r9), $tmp2
     vblendvpd $tmp2, $tmp, $_R3h, $_R3h
 
     movb    %r10b,%r9b
     and \$0xf, %r10
     vpsubq  .Lmask52x4(%rip), $_R4,  $tmp
     shl \$5, %r10
-    vmovapd (%r8, %r10), $tmp2
+    vmovapd (%r8,%r10), $tmp2
     vblendvpd $tmp2, $tmp, $_R4, $_R4
 
     shr \$4, %r9b
     and \$0xf, %r9
     vpsubq  .Lmask52x4(%rip), $_R4h,  $tmp
     shl \$5, %r9
-    vmovapd (%r8, %r9), $tmp2
+    vmovapd (%r8,%r9), $tmp2
     vblendvpd $tmp2, $tmp, $_R4h, $_R4h
 
     pop %r8

--- a/crypto/bn/asm/rsaz-4k-avxifma.pl
+++ b/crypto/bn/asm/rsaz-4k-avxifma.pl
@@ -27,7 +27,6 @@ $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}../../perlasm/x86_64-xlate.pl" and -f $xlate) or
 die "can't locate x86_64-xlate.pl";
 
-# TODO: Find out the version of NASM that supports VEX-encoded AVX-IFMA instructions
 if (`$ENV{CC} -Wa,-v -c -o /dev/null -x assembler /dev/null 2>&1`
         =~ /GNU assembler version ([2-9]\.[0-9]+)/) {
     $avxifma = ($1>=2.40);
@@ -37,6 +36,11 @@ if (!$avxifma && `$ENV{CC} -v 2>&1`
     =~ /\s*((?:clang|LLVM) version|.*based on LLVM) ([0-9]+)\.([0-9]+)\.([0-9]+)?/) {
     my $ver = $2 + $3/100.0 + $4/10000.0; # 3.1.0->3.01, 3.10.1->3.1001
     $avxifma = ($ver>=16.0);
+}
+
+if ($win64 && ($flavour =~ /nasm/ || $ENV{ASM} =~ /nasm/) &&
+       `nasm -v 2>&1` =~ /NASM version ([2-9]\.[0-9]+)(?:\.([0-9]+))?(rc[0-9]+)?/) {
+    $avxifma = ($1>2.16) + ($1==2.16 && ((!defined($2) && !defined($3)) || (defined($2))));
 }
 
 open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\""


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

Fixes #27582 

## Description  
This PR resolves a compilation regression introduced in OpenSSL 3.5.0 caused by three interrelated issues in the assembly code translation and toolchain checks:  

### 1. Unrecognized `{vex}` Prefix in Assembly Translator  
   - The `x86_64-xlate.pl` script failed to recognize the `{vex}` prefix, resulting in AVX-IFMA instructions being emitted without proper format translation.  
   - **Fix:** Added a `vex_prefix` package to explicitly handle the `{vex}` prefix during instruction translation.  

### 2. Redundant Space in `vmovapd` Effective Address  
   - A misplaced space in the effective address of `vmovapd` instructions caused mismatches in the assembly translator’s regular expressions.  
   - **Fix:** Removed the redundant space to ensure correct pattern matching during translation.  

### 3. Insufficient NASM Version Checks for AVX-IFMA  
   - AVX-IFMA eligibility was not strictly validated against the minimum required NASM version, risking compatibility issues.  
   - **Fix:** Enhanced the toolchain compatibility checks to enforce NASM version requirements for AVX-IFMA support. According to the [Release Note](https://nasm.us/doc/nasmdocc.html) of NASM, the first stable version supporting `{vex}` prefix encoding is 2.16. 

## Impact  
These changes restore reliable compilation by ensuring proper assembly translation of AVX-IFMA instructions and stricter validation of the toolchain environment. This avoids miscompilation or build failures on systems with outdated NASM versions.  

## Testing  
Validated against multiple versions of NASM (2.15.05, 2.16rc4, 2.16rc9, 2.16, 2.16.03) to confirm correct assembly output and compatibility checks.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated