### PR TITLE
apps/prime.c: Remove unused assignment

### DIFF
--- a/apps/prime.c
+++ b/apps/prime.c
@@ -203,7 +203,6 @@ opthelp:
                     BIO_printf(bio_err, "Read error in %s\n", argv[0]);
 
                 BIO_free(in);
-                in = NULL;
             }
         }
     }


### PR DESCRIPTION
The variable is never read after the assignment.

Coverity issue: 1646789

Followup from: https://github.com/openssl/project/issues/1183

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
