### PR TITLE
demos/bio/sconnect.c: Free ssl_bio on error to avoid memory leak

### DIFF
--- a/demos/bio/sconnect.c
+++ b/demos/bio/sconnect.c
@@ -74,8 +74,10 @@ int main(int argc, char *argv[])
 
     /* The BIO has parsed the host:port and even IPv6 literals in [] */
     hostname = BIO_get_conn_hostname(out);
-    if (!hostname || SSL_set1_host(ssl, hostname) <= 0)
+    if (!hostname || SSL_set1_host(ssl, hostname) <= 0) {
+        BIO_free(ssl_bio);
         goto err;
+    }
 
     BIO_set_nbio(out, 1);
     out = BIO_push(ssl_bio, out);


### PR DESCRIPTION
Call BIO_free() to release ssl_bio if an error occurs before BIO_push(), preventing a memory leak.

Fixes: 396e720965 ("Fix certificate validation for IPv6 literals in sconnect demo")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
