### PR TITLE
Yield Read and write keys on the client at the same time

### DIFF
--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1299,7 +1299,6 @@ struct ssl_connection_st {
     /* where we are */
     OSSL_STATEM statem;
     SSL_EARLY_DATA_STATE early_data_state;
-    uint8_t write_key_yielded;
     BUF_MEM *init_buf;          /* buffer used during init */
     void *init_msg;             /* pointer to handshake message body, set by
                                  * tls_get_message_header() */

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1299,6 +1299,7 @@ struct ssl_connection_st {
     /* where we are */
     OSSL_STATEM statem;
     SSL_EARLY_DATA_STATE early_data_state;
+    uint8_t write_key_yielded;
     BUF_MEM *init_buf;          /* buffer used during init */
     void *init_msg;             /* pointer to handshake message body, set by
                                  * tls_get_message_header() */

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1799,13 +1799,11 @@ MSG_PROCESS_RETURN tls_process_server_hello(SSL_CONNECTION *s, PACKET *pkt)
          * in case the quic stack needs to ACK packets independent of the handshake process
          */
         if (SSL_IS_QUIC_HANDSHAKE(s)) {
-            if (s->early_data_state != SSL_EARLY_DATA_NONE
-                && s->write_key_yielded == 0) {
-                    if (!ssl->method->ssl3_enc->change_cipher_state(s,
-                        SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE))
+            if (s->early_data_state != SSL_EARLY_DATA_NONE) {
+                if (!ssl->method->ssl3_enc->change_cipher_state(s,
+                    SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE))
                         /* SSLfatal() already called */
                         goto err;
-                s->write_key_yielded = 1;
             }
         }
         /*

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1799,6 +1799,9 @@ MSG_PROCESS_RETURN tls_process_server_hello(SSL_CONNECTION *s, PACKET *pkt)
          * in case the quic stack needs to ACK packets independent of the handshake process
          */
         if (SSL_IS_QUIC_HANDSHAKE(s)) {
+            /*
+             * calling tls13_change_cipher_state here to provide a write secret
+             */
             if (s->early_data_state != SSL_EARLY_DATA_NONE) {
                 if (!ssl->method->ssl3_enc->change_cipher_state(s,
                     SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE))

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1800,12 +1800,13 @@ MSG_PROCESS_RETURN tls_process_server_hello(SSL_CONNECTION *s, PACKET *pkt)
          */
         if (SSL_IS_QUIC_HANDSHAKE(s)) {
             if (s->early_data_state != SSL_EARLY_DATA_NONE
-                && s->write_key_yielded == 0
-                && !ssl->method->ssl3_enc->change_cipher_state(s,
-                    SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE))
-                /* SSLfatal() already called */
-                goto err;
-            s->write_key_yielded = 1;
+                && s->write_key_yielded == 0) {
+                    if (!ssl->method->ssl3_enc->change_cipher_state(s,
+                        SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE))
+                        /* SSLfatal() already called */
+                        goto err;
+                s->write_key_yielded = 1;
+            }
         }
         /*
          * If we're not doing early-data and we're not going to send a dummy CCS
@@ -2140,7 +2141,7 @@ WORK_STATE tls_post_process_server_certificate(SSL_CONNECTION *s,
     }
 
     if ((clu = ssl_cert_lookup_by_pkey(pkey, &certidx,
-                       SSL_CONNECTION_GET_CTX(s))) == NULL) {
+                                       SSL_CONNECTION_GET_CTX(s))) == NULL) {
         SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_UNKNOWN_CERTIFICATE_TYPE);
         return WORK_ERROR;
     }
@@ -3824,44 +3825,19 @@ CON_FUNC_RETURN tls_construct_client_certificate(SSL_CONNECTION *s,
         return CON_FUNC_ERROR;
     }
 
-    /*
-     * If we attempted to write early data or we're in middlebox compat mode
-     * then we deferred changing the handshake write keys to the last possible
-     * moment. We need to do it now.
-     * NOTE: We split this into quic and non-quic cases here to suppress the
-     * cipher state change if SSL_EARLY_DATA_NONE is set in the early data state
-     * to create a single update of the keys in conjunction with tls_process_server_hello
-     */
-    if (SSL_IS_QUIC_HANDSHAKE(s)) {
-        if (SSL_CONNECTION_IS_TLS13(s)
+    if (!SSL_IS_QUIC_HANDSHAKE(s)
+            && SSL_CONNECTION_IS_TLS13(s)
             && SSL_IS_FIRST_HANDSHAKE(s)
             && (s->early_data_state != SSL_EARLY_DATA_NONE
                 || (s->options & SSL_OP_ENABLE_MIDDLEBOX_COMPAT) != 0)
-        && s->write_key_yielded == 0
             && (!ssl->method->ssl3_enc->change_cipher_state(s,
-                SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE))) {
-            /*
-             * This is a fatal error, which leaves enc_write_ctx in an inconsistent
-             * state and thus ssl3_send_alert may crash.
-             */
-            SSLfatal(s, SSL_AD_NO_ALERT, SSL_R_CANNOT_CHANGE_CIPHER);
-            return CON_FUNC_ERROR;
-        }
-    s->write_key_yielded = 1;
-    } else {
-        if (SSL_CONNECTION_IS_TLS13(s)
-                && SSL_IS_FIRST_HANDSHAKE(s)
-                && (s->early_data_state != SSL_EARLY_DATA_NONE
-                    || (s->options & SSL_OP_ENABLE_MIDDLEBOX_COMPAT) != 0)
-                && (!ssl->method->ssl3_enc->change_cipher_state(s,
-                        SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE))) {
-            /*
-             * This is a fatal error, which leaves enc_write_ctx in an inconsistent
-             * state and thus ssl3_send_alert may crash.
-             */
-            SSLfatal(s, SSL_AD_NO_ALERT, SSL_R_CANNOT_CHANGE_CIPHER);
-            return CON_FUNC_ERROR;
-        }
+                    SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE))) {
+        /*
+         * This is a fatal error, which leaves enc_write_ctx in an inconsistent
+         * state and thus ssl3_send_alert may crash.
+         */
+        SSLfatal(s, SSL_AD_NO_ALERT, SSL_R_CANNOT_CHANGE_CIPHER);
+        return CON_FUNC_ERROR;
     }
 
     return CON_FUNC_SUCCESS;
@@ -3935,40 +3911,18 @@ CON_FUNC_RETURN tls_construct_client_compressed_certificate(SSL_CONNECTION *sc,
             || !WPACKET_close(pkt))
         goto err;
 
-    /*
-     * If we attempted to write early data or we're in middlebox compat mode
-     * then we deferred changing the handshake write keys to the last possible
-     * moment. We need to do it now.
-     */
-    if (SSL_IS_QUIC_HANDSHAKE(sc)) {
-        if (SSL_CONNECTION_IS_TLS13(sc)
+    if (!SSL_IS_QUIC_HANDSHAKE(sc)
             && SSL_IS_FIRST_HANDSHAKE(sc)
             && (sc->early_data_state != SSL_EARLY_DATA_NONE
                 || (sc->options & SSL_OP_ENABLE_MIDDLEBOX_COMPAT) != 0)
-            && sc->write_key_yielded == 0
             && (!ssl->method->ssl3_enc->change_cipher_state(sc,
-                SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE))) {
-            /*
-             * This is a fatal error, which leaves enc_write_ctx in an inconsistent
-             * state and thus ssl3_send_alert may crash.
-             */
-            SSLfatal(sc, SSL_AD_NO_ALERT, SSL_R_CANNOT_CHANGE_CIPHER);
-            return CON_FUNC_ERROR;
-        }
-        sc->write_key_yielded = 1;
-    } else {
-        if (SSL_IS_FIRST_HANDSHAKE(sc)
-                && (sc->early_data_state != SSL_EARLY_DATA_NONE
-                    || (sc->options & SSL_OP_ENABLE_MIDDLEBOX_COMPAT) != 0)
-                && (!ssl->method->ssl3_enc->change_cipher_state(sc,
-                        SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE))) {
-            /*
-             * This is a fatal error, which leaves sc->enc_write_ctx in an
-             * inconsistent state and thus ssl3_send_alert may crash.
-             */
-            SSLfatal(sc, SSL_AD_NO_ALERT, SSL_R_CANNOT_CHANGE_CIPHER);
-            goto out;
-        }
+                    SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE))) {
+        /*
+         * This is a fatal error, which leaves sc->enc_write_ctx in an
+         * inconsistent state and thus ssl3_send_alert may crash.
+         */
+        SSLfatal(sc, SSL_AD_NO_ALERT, SSL_R_CANNOT_CHANGE_CIPHER);
+        goto out;
     }
     ret = 1;
     goto out;

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -625,18 +625,17 @@ CON_FUNC_RETURN tls_construct_finished(SSL_CONNECTION *s, WPACKET *pkt)
      * then we need to do it now.
      */
     if (SSL_IS_QUIC_HANDSHAKE(s)) {
-        if (SSL_CONNECTION_IS_TLS13(s)
-            && !s->server
-            && (s->early_data_state != SSL_EARLY_DATA_NONE
-                || (s->options & SSL_OP_ENABLE_MIDDLEBOX_COMPAT) != 0)
+        if (!s->server
+            && s->early_data_state != SSL_EARLY_DATA_NONE
             && s->s3.tmp.cert_req == 0
-            && s->write_key_yielded == 0
-            && (!ssl->method->ssl3_enc->change_cipher_state(s,
-                    SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE))) {
-                /* SSLfatal() already called */
-                return CON_FUNC_ERROR;
+            && s->write_key_yielded == 0) {
+                if (!ssl->method->ssl3_enc->change_cipher_state(s,
+                        SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE)) {
+                    /* SSLfatal() already called */
+                    return CON_FUNC_ERROR;
+                }
+                s->write_key_yielded = 1;
         }
-        s->write_key_yielded = 1;
     } else {
         if (SSL_CONNECTION_IS_TLS13(s)
                 && !s->server

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -618,22 +618,7 @@ CON_FUNC_RETURN tls_construct_finished(SSL_CONNECTION *s, WPACKET *pkt)
     if (!s->server && s->post_handshake_auth != SSL_PHA_REQUESTED)
         s->statem.cleanuphand = 1;
 
-    /*
-     * Handle the quic and non-quic cases separately here
-     * For quic, we need to yield the write handshake now, if it has
-     * not already been done in tls_process_server_hello.
-     */
-    if (SSL_IS_QUIC_HANDSHAKE(s)) {
-        if (!s->server
-            && s->early_data_state != SSL_EARLY_DATA_NONE
-            && s->s3.tmp.cert_req == 0) {
-            if (!ssl->method->ssl3_enc->change_cipher_state(s,
-                SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE)) {
-                    /* SSLfatal() already called */
-                    return CON_FUNC_ERROR;
-            }
-        }
-    } else if (SSL_CONNECTION_IS_TLS13(s)) {
+    if (!SSL_IS_QUIC_HANDSHAKE(s) && SSL_CONNECTION_IS_TLS13(s)) {
         /*
          * If we attempted to write early data or we're in middlebox compat mode
          * then we deferred changing the handshake write keys to the last possible

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -621,20 +621,17 @@ CON_FUNC_RETURN tls_construct_finished(SSL_CONNECTION *s, WPACKET *pkt)
     /*
      * Handle the quic and non-quic cases separately here
      * For quic, we need to yield the write handshake now, if it has
-     * not already been done in tls_process_server_hello, as tracked
-     * by the write_key_yielded variable
+     * not already been done in tls_process_server_hello.
      */
     if (SSL_IS_QUIC_HANDSHAKE(s)) {
         if (!s->server
             && s->early_data_state != SSL_EARLY_DATA_NONE
-            && s->s3.tmp.cert_req == 0
-            && s->write_key_yielded == 0) {
-                if (!ssl->method->ssl3_enc->change_cipher_state(s,
-                        SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE)) {
+            && s->s3.tmp.cert_req == 0) {
+            if (!ssl->method->ssl3_enc->change_cipher_state(s,
+                SSL3_CC_HANDSHAKE | SSL3_CHANGE_CIPHER_CLIENT_WRITE)) {
                     /* SSLfatal() already called */
                     return CON_FUNC_ERROR;
-                }
-                s->write_key_yielded = 1;
+            }
         }
     } else if (SSL_CONNECTION_IS_TLS13(s)) {
         /*

--- a/test/helpers/ssltestlib.h
+++ b/test/helpers/ssltestlib.h
@@ -28,11 +28,15 @@ int create_ssl_objects(SSL_CTX *serverctx, SSL_CTX *clientctx, SSL **sssl,
                        SSL **cssl, BIO *s_to_c_fbio, BIO *c_to_s_fbio);
 int create_bare_ssl_connection(SSL *serverssl, SSL *clientssl, int want,
                                int read, int listen);
+int create_bare_ssl_connection_ex(SSL *serverssl, SSL *clientssl, int want,
+                                  int read, int listen, int *cm_count, int *sm_count);
 int create_ssl_objects2(SSL_CTX *serverctx, SSL_CTX *clientctx, SSL **sssl,
                        SSL **cssl, int sfd, int cfd);
 int wait_until_sock_readable(int sock);
 int create_test_sockets(int *cfdp, int *sfdp, int socktype, BIO_ADDR *saddr);
 int create_ssl_connection(SSL *serverssl, SSL *clientssl, int want);
+int create_ssl_connection_ex(SSL *serverssl, SSL *clientssl, int want,
+                             int *cm_count, int *sm_count);
 void shutdown_ssl_connection(SSL *serverssl, SSL *clientssl);
 
 /* Note: Not thread safe! */

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -12738,7 +12738,7 @@ static int secret_history_idx = 0;
 typedef enum {
     LAST_DIR_READ = 0,
     LAST_DIR_WRITE = 1,
-    LAST_DIR_UNSET = 2,
+    LAST_DIR_UNSET = 2
 } last_dir_history_state;
 
 static int yield_secret_cb(SSL *s, uint32_t prot_level, int direction,

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -12726,7 +12726,7 @@ static int crypto_release_rcd_cb(SSL *s, size_t bytes_read, void *arg)
 
 struct secret_yield_entry {
     uint8_t recorded;
-    uint32_t prot_level;
+    int prot_level;
     int direction;
     int sm_generation;
     SSL *ssl;
@@ -12749,7 +12749,7 @@ static int check_secret_history(SSL *s)
     int i;
     int ret = 0;
     last_dir_history_state last_state = LAST_DIR_UNSET;
-    uint32_t last_prot_level = 0;
+    int last_prot_level = 0;
     int last_generation = 0;
 
     TEST_info("Checking history for %p\n", (void *)s);
@@ -12847,7 +12847,7 @@ static int yield_secret_cb(SSL *s, uint32_t prot_level, int direction,
     }
 
     secret_history[secret_history_idx].direction = direction;
-    secret_history[secret_history_idx].prot_level = prot_level;
+    secret_history[secret_history_idx].prot_level = (int)prot_level;
     secret_history[secret_history_idx].recorded = 1;
     secret_history[secret_history_idx].ssl = s;
     secret_history[secret_history_idx].sm_generation = data->sm_count;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -12858,7 +12858,6 @@ static int test_quic_tls(int idx)
     secret_history_idx = 0;
     memset(&sdata, 0, sizeof(sdata));
     memset(&cdata, 0, sizeof(cdata));
-    secret_history_idx = 0;
     sdata.peer = &cdata;
     cdata.peer = &sdata;
     if (idx == 1)
@@ -12932,7 +12931,7 @@ static int test_quic_tls(int idx)
         case LAST_DIR_WRITE:
             if (last_prot_level == secret_history[i].prot_level
                 && secret_history[i].direction == LAST_DIR_READ) {
-                TEST_info("Got read key before write key");
+                TEST_error("Got read key before write key");
                 goto end;
             }
             /* FALLTHROUGH */
@@ -12941,7 +12940,7 @@ static int test_quic_tls(int idx)
             last_state = secret_history[i].direction;
             break;
         default:
-            TEST_info("Unknown secret history state");
+            TEST_error("Unknown secret history state");
             goto end;
         }
     }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -12752,7 +12752,7 @@ static int check_secret_history(SSL *s)
     uint32_t last_prot_level = 0;
     int last_generation = 0;
 
-    TEST_info("Checking history for %p\n", s);
+    TEST_info("Checking history for %p\n", (void *)s);
     for (i = 0; secret_history[i].recorded == 1; i++) {
         if (secret_history[i].ssl != s)
             continue;


### PR DESCRIPTION
Test patch to yield write secrets and read secrets in parallel on a client for openssl when using quic.

To provide detail, In attempting to address the issue discussed on msquic integration starting [here](https://github.com/microsoft/msquic/pull/4959#issuecomment-2885309381), I've become convinced that openssl needs to yield write secrets within the same TLS processing cycle as the corresponding read secret (if not before, as @davidben notes below).  While not strictly required by any functionality, it creates a situation in which not doing so impacts performance of the quic stack (or doing so may simply not be supported by the quic stack).  To mitigate this, modify the openssl TLS stack to ensure that when the read secret is yielded, the write secret yield will also be triggered in reponse to the same TLS message for quic cases.
