### PR TITLE
apps/cmp.c: Free bio on error to avoid memory leak

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2506,6 +2506,7 @@ static int save_template(const char *file, const OSSL_CRMF_CERTTEMPLATE *tmpl)
                          bio, tmpl)) {
         CMP_err1("error saving certTemplate from genp: cannot write file %s",
                  file);
+        BIO_free(bio);
         return 0;
     } else {
         CMP_info1("stored certTemplate from genp to file '%s'", file);
@@ -2525,6 +2526,7 @@ static int save_keyspec(const char *file, const OSSL_CMP_ATAVS *keyspec)
 
     if (!ASN1_i2d_bio_of(OSSL_CMP_ATAVS, i2d_OSSL_CMP_ATAVS, bio, keyspec)) {
         CMP_err1("error saving keySpec from genp: cannot write file %s", file);
+        BIO_free(bio);
         return 0;
     } else {
         CMP_info1("stored keySpec from genp to file '%s'", file);


### PR DESCRIPTION
Call BIO_free() to release bio if ASN1_i2d_bio_of() fails, preventing a memory leak.

Fixes: 6a3579e190 ("CMP: add support for requesting cert template using genm/genp")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
