### PR TITLE
apps/enc: call set nopad handling before calling the cipher init stack

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -664,6 +664,9 @@ int enc_main(int argc, char **argv)
         if (wrap == 1)
             EVP_CIPHER_CTX_set_flags(ctx, EVP_CIPHER_CTX_FLAG_WRAP_ALLOW);
 
+        if (nopad)
+            EVP_CIPHER_CTX_set_padding(ctx, 0);
+
         if (rawkey_set) {
             if (!EVP_CipherInit_ex(ctx, cipher, e, key,
                                    (hiv == NULL && wrap == 1 ? NULL : iv), enc)) {
@@ -705,9 +708,6 @@ int enc_main(int argc, char **argv)
                 goto end;
             }
         }
-
-        if (nopad)
-            EVP_CIPHER_CTX_set_padding(ctx, 0);
 
         if (debug) {
             BIO_set_callback_ex(benc, BIO_debug_callback_ex);


### PR DESCRIPTION
Setting the padding property in the context needs to be done before initializing the cipher. Some cipher providers do an fallback to the nopad variant e.g. from AES_128_CBC if the property is unset. Therefor setting it after the init is useless.

