### PR TITLE
Allow local QUIC transport params to be set more than once

### DIFF
--- a/include/internal/quic_tls.h
+++ b/include/internal/quic_tls.h
@@ -96,6 +96,8 @@ int ossl_quic_tls_configure(QUIC_TLS *qtls);
 /* Advance the state machine */
 int ossl_quic_tls_tick(QUIC_TLS *qtls);
 
+void ossl_quic_tls_clear(QUIC_TLS *qtls);
+
 int ossl_quic_tls_set_transport_params(QUIC_TLS *qtls,
                                        const unsigned char *transport_params,
                                        size_t transport_params_len);

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -865,24 +865,44 @@ void ossl_quic_deinit(SSL *s)
 int ossl_quic_reset(SSL *s)
 {
     QCTX ctx;
+    SSL_CONNECTION *sc;
 
     if (!expect_quic_any(s, &ctx))
         return 0;
 
-    ERR_raise(ERR_LIB_SSL, ERR_R_UNSUPPORTED);
-    return 0;
+    sc = SSL_CONNECTION_FROM_SSL(s);
+    if (sc == NULL)
+        return 0;
+    /* Currently, only QCSOs support SSL_clear */
+    if (sc->qtls == NULL) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_UNSUPPORTED);
+        return 0;
+    }
+
+    ossl_quic_tls_clear(sc->qtls);
+    return 1;
 }
 
 /* ssl_clear method (unused) */
 int ossl_quic_clear(SSL *s)
 {
     QCTX ctx;
+    SSL_CONNECTION *sc;
 
     if (!expect_quic_any(s, &ctx))
         return 0;
 
-    ERR_raise(ERR_LIB_SSL, ERR_R_UNSUPPORTED);
-    return 0;
+    sc = SSL_CONNECTION_FROM_SSL(s);
+    if (sc == NULL)
+        return 0;
+    /* Currently, only QCSOs support SSL_clear */
+    if (sc->qtls == NULL) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_UNSUPPORTED);
+        return 0;
+    }
+
+    ossl_quic_tls_clear(sc->qtls);
+    return 1;
 }
 
 int ossl_quic_set_override_now_cb(SSL *s,

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -865,44 +865,24 @@ void ossl_quic_deinit(SSL *s)
 int ossl_quic_reset(SSL *s)
 {
     QCTX ctx;
-    SSL_CONNECTION *sc;
 
     if (!expect_quic_any(s, &ctx))
         return 0;
 
-    sc = SSL_CONNECTION_FROM_SSL(s);
-    if (sc == NULL)
-        return 0;
-    /* Currently, only QCSOs support SSL_clear */
-    if (sc->qtls == NULL) {
-        ERR_raise(ERR_LIB_SSL, ERR_R_UNSUPPORTED);
-        return 0;
-    }
-
-    ossl_quic_tls_clear(sc->qtls);
-    return 1;
+    ERR_raise(ERR_LIB_SSL, ERR_R_UNSUPPORTED);
+    return 0;
 }
 
 /* ssl_clear method (unused) */
 int ossl_quic_clear(SSL *s)
 {
     QCTX ctx;
-    SSL_CONNECTION *sc;
 
     if (!expect_quic_any(s, &ctx))
         return 0;
 
-    sc = SSL_CONNECTION_FROM_SSL(s);
-    if (sc == NULL)
-        return 0;
-    /* Currently, only QCSOs support SSL_clear */
-    if (sc->qtls == NULL) {
-        ERR_raise(ERR_LIB_SSL, ERR_R_UNSUPPORTED);
-        return 0;
-    }
-
-    ossl_quic_tls_clear(sc->qtls);
-    return 1;
+    ERR_raise(ERR_LIB_SSL, ERR_R_UNSUPPORTED);
+    return 0;
 }
 
 int ossl_quic_set_override_now_cb(SSL *s,

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -858,6 +858,13 @@ int ossl_quic_tls_tick(QUIC_TLS *qtls)
 }
 #endif
 
+void ossl_quic_tls_clear(QUIC_TLS *qtls)
+{
+    if (qtls == NULL)
+        return;
+    qtls->local_transport_params_consumed = 0;
+}
+
 int ossl_quic_tls_set_transport_params(QUIC_TLS *qtls,
                                        const unsigned char *transport_params,
                                        size_t transport_params_len)

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -652,6 +652,8 @@ int ossl_ssl_connection_reset(SSL *s)
             return 0;
     }
 
+    ossl_quic_tls_clear(sc->qtls);
+
     if (!RECORD_LAYER_reset(&sc->rlayer))
         return 0;
 


### PR DESCRIPTION
While working on https://github.com/cloudflare/quiche/pull/2052 to integrate OpenSSL into [Quiche](https://github.com/cloudflare/quiche), I noticed that Quiche sets local QUIC transport parameters more than once, specifically when processing a Retry or VersionNegotiation packet. This is their reasoning for doing it:

```rust
        if hdr.ty == packet::Type::VersionNegotiation {
            ...
            // Encode transport parameters again, as the new version might be
            // using a different format.
            self.encode_transport_params()?;
```

https://github.com/cloudflare/quiche/blob/548509b43616dea9c551cbf51ba661f4d845db83/quiche/src/lib.rs#L2832-L2834

Without this change (or if I skip setting transport params a second time), I am not able to pass the QUIC interop tests with Quiche as a server (as client still passes).