### PR TITLE
Fix memory leaks after failure of PKCS7_add_signed_attribute()

### DIFF
--- a/crypto/ts/ts_rsp_sign.c
+++ b/crypto/ts/ts_rsp_sign.c
@@ -649,7 +649,7 @@ static int ossl_ess_add1_signing_cert(PKCS7_SIGNER_INFO *si,
 
     OPENSSL_free(pp);
     if (!PKCS7_add_signed_attribute(si, NID_id_smime_aa_signingCertificate,
-                                      V_ASN1_SEQUENCE, seq)) {
+                                    V_ASN1_SEQUENCE, seq)) {
         ASN1_STRING_free(seq);
         return 0;
     }
@@ -676,7 +676,7 @@ static int ossl_ess_add1_signing_cert_v2(PKCS7_SIGNER_INFO *si,
 
     OPENSSL_free(pp);
     if (!PKCS7_add_signed_attribute(si, NID_id_smime_aa_signingCertificateV2,
-                                      V_ASN1_SEQUENCE, seq)) {
+                                    V_ASN1_SEQUENCE, seq)) {
         ASN1_STRING_free(seq);
         return 0;
     }

--- a/crypto/ts/ts_rsp_sign.c
+++ b/crypto/ts/ts_rsp_sign.c
@@ -648,8 +648,12 @@ static int ossl_ess_add1_signing_cert(PKCS7_SIGNER_INFO *si,
     }
 
     OPENSSL_free(pp);
-    return PKCS7_add_signed_attribute(si, NID_id_smime_aa_signingCertificate,
-                                      V_ASN1_SEQUENCE, seq);
+    if (!PKCS7_add_signed_attribute(si, NID_id_smime_aa_signingCertificate,
+                                      V_ASN1_SEQUENCE, seq)) {
+        ASN1_STRING_free(seq);
+        return 0;
+    }
+    return 1;
 }
 
 static int ossl_ess_add1_signing_cert_v2(PKCS7_SIGNER_INFO *si,
@@ -671,8 +675,12 @@ static int ossl_ess_add1_signing_cert_v2(PKCS7_SIGNER_INFO *si,
     }
 
     OPENSSL_free(pp);
-    return PKCS7_add_signed_attribute(si, NID_id_smime_aa_signingCertificateV2,
-                                      V_ASN1_SEQUENCE, seq);
+    if (!PKCS7_add_signed_attribute(si, NID_id_smime_aa_signingCertificateV2,
+                                      V_ASN1_SEQUENCE, seq)) {
+        ASN1_STRING_free(seq);
+        return 0;
+    }
+    return 1;
 }
 
 static int ts_RESP_sign(TS_RESP_CTX *ctx)


### PR DESCRIPTION
If PKCS7_add_signed_attribute fails,
seq never escapes out of the callee and will
therefore result in a memory leak.
This is similar to ed3d277127.

CLA: trivial

Found with an experimental static analysis tool that I am developing.