### PR TITLE
apps/x509.c: Fix the -addreject option adding trust instead of rejection

### DIFF
--- a/apps/x509.c
+++ b/apps/x509.c
@@ -467,7 +467,7 @@ int x509_main(int argc, char **argv)
                            prog, opt_arg());
                 goto opthelp;
             }
-            if (!sk_ASN1_OBJECT_push(trust, objtmp))
+            if (!sk_ASN1_OBJECT_push(reject, objtmp))
                 goto end;
             trustout = 1;
             break;


### PR DESCRIPTION
Fixes CVE-2025-4575

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
