### PR TITLE
Handle 0 return values from ossl_dh_compute_key(), DH_compute_key_padded() and DH_compute_key() as errors.

### DIFF
--- a/crypto/dh/dh_pmeth.c
+++ b/crypto/dh/dh_pmeth.c
@@ -422,7 +422,7 @@ static int pkey_dh_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
             ret = DH_compute_key_padded(key, dhpubbn, dh);
         else
             ret = DH_compute_key(key, dhpubbn, dh);
-        if (ret < 0)
+        if (ret <= 0)
             return ret;
         *keylen = ret;
         return 1;

--- a/test/dhtest.c
+++ b/test/dhtest.c
@@ -208,17 +208,17 @@ static int dh_test(void)
 
     alen = DH_size(a);
     if (!TEST_ptr(abuf = OPENSSL_malloc(alen))
-            || !TEST_true((aout = DH_compute_key(abuf, bpub_key, a)) != -1))
+            || !TEST_true((aout = DH_compute_key(abuf, bpub_key, a)) <= 0))
         goto err3;
 
     blen = DH_size(b);
     if (!TEST_ptr(bbuf = OPENSSL_malloc(blen))
-            || !TEST_true((bout = DH_compute_key(bbuf, apub_key, b)) != -1))
+            || !TEST_true((bout = DH_compute_key(bbuf, apub_key, b)) <= 0))
         goto err3;
 
     clen = DH_size(c);
     if (!TEST_ptr(cbuf = OPENSSL_malloc(clen))
-            || !TEST_true((cout = DH_compute_key(cbuf, apub_key, c)) != -1))
+            || !TEST_true((cout = DH_compute_key(cbuf, apub_key, c)) <= 0))
         goto err3;
 
     if (!TEST_true(aout >= 20)
@@ -694,12 +694,12 @@ static int rfc7919_test(void)
 
     alen = DH_size(a);
     if (!TEST_int_gt(alen, 0) || !TEST_ptr(abuf = OPENSSL_malloc(alen))
-            || !TEST_true((aout = DH_compute_key(abuf, bpub_key, a)) != -1))
+            || !TEST_true((aout = DH_compute_key(abuf, bpub_key, a)) <= 0))
         goto err;
 
     blen = DH_size(b);
     if (!TEST_int_gt(blen, 0) || !TEST_ptr(bbuf = OPENSSL_malloc(blen))
-            || !TEST_true((bout = DH_compute_key(bbuf, apub_key, b)) != -1))
+            || !TEST_true((bout = DH_compute_key(bbuf, apub_key, b)) <= 0))
         goto err;
 
     if (!TEST_true(aout >= 20)


### PR DESCRIPTION
Fixes #27652

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
