### PR TITLE
Silence -Wstringop-overflow warnings with gcc 14 on s390x

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -917,7 +917,7 @@ my %targets = (
 
     "linux64-s390x" => {
         inherit_from     => [ "linux-generic64" ],
-        cflags           => add("-m64"),
+        cflags           => add("-m64 -Wno-stringop-overflow"),
         cxxflags         => add("-m64"),
         lib_cppflags     => add("-DB_ENDIAN"),
         asm_arch         => 's390x',
@@ -942,7 +942,7 @@ my %targets = (
         # sysdeps/s390/dl-procinfo.c affecting ldconfig and ld.so.1...
         #
         inherit_from     => [ "linux-generic32" ],
-        cflags           => add("-m31 -Wa,-mzarch"),
+        cflags           => add("-m31 -Wa,-mzarch -Wno-stringop-overflow"),
         cxxflags         => add("-m31 -Wa,-mzarch"),
         lib_cppflags     => add("-DB_ENDIAN"),
         asm_arch         => 's390x',


### PR DESCRIPTION
Compiling OpenSSL on s390x with gcc 14 (i.e. in Fedora 41) shows several -Wstringop-overflow warnings in providers/implementations/rands/drbg_ctr.c and test/params_api_test.c. Those are false positives and are not a bug in OpenSSL code, see https://github.com/openssl/openssl/issues/27525#issuecomment-2894754548

