### PR TITLE
quic-interop-ci: Fix failing CI

### DIFF
--- a/.github/workflows/run_quic_interop.yml
+++ b/.github/workflows/run_quic_interop.yml
@@ -41,6 +41,20 @@ jobs:
                          , role: "both"
                          }' ./implementations.json > ./implementations.tmp
           mv ./implementations.tmp implementations.json
+      - name: "Update to docker-compose 2.36"
+        run: |
+          curl -SL https://github.com/docker/compose/releases/download/v2.36.0/docker-compose-linux-x86_64 -o ./docker-compose
+          echo "$PWD" >> $GITHUB_PATH
+          chmod 755 ./docker-compose
+      - name: Check docker compose version
+        run: |
+          docker-compose --version
+      - name: Patch Docker compose file
+        run: |
+          yq -i '.services.sim.networks.leftnet += {"interface_name" : "eth0"}
+                 | .services.sim.networks.rightnet += {"interface_name" : "eth1"}
+                 | .services.server.networks.rightnet += {"interface_name" : "eth0"}
+                 | .services.client.networks.leftnet += {"interface_name" : "eth0"}' docker-compose.yml
       - name: "run interop with openssl client"
         run: |
           python3 ./run.py -c openssl -t ${{ matrix.tests }} -s ${{ matrix.servers }} --log-dir ./logs-client -d
@@ -78,6 +92,20 @@ jobs:
                          , role: "both"
                          }' ./implementations.json > ./implementations.tmp
           mv ./implementations.tmp implementations.json
+      - name: "Update to docker-compose 2.36"
+        run: |
+          curl -SL https://github.com/docker/compose/releases/download/v2.36.0/docker-compose-linux-x86_64 -o ./docker-compose
+          echo "$PWD" >> $GITHUB_PATH
+          chmod 755 ./docker-compose
+      - name: Check docker-compose version
+        run: |
+          docker-compose --version
+      - name: Patch Docker compose file
+        run: |
+          yq -i '.services.sim.networks.leftnet += {"interface_name" : "eth0"}
+                 | .services.sim.networks.rightnet += {"interface_name" : "eth1"}
+                 | .services.server.networks.rightnet += {"interface_name" : "eth0"}
+                 | .services.client.networks.leftnet += {"interface_name" : "eth0"}' docker-compose.yml
       - name: "run interop with openssl server"
         run: |
           python3 ./run.py -s openssl -t ${{ matrix.tests }} -c ${{ matrix.clients }} --log-dir ./logs-server -d


### PR DESCRIPTION
The issue was a flaky "impossible to reach server" in the CI.

The issue was caused by introduction of indeterminism to docker networking (docker engine v28.0) and docker compose is affected by that since v2.33.1.

Using constant network interface names solves the issue. The "interface_name" was introduced in docker compose v2.36.0.

Resolves: https://github.com/openssl/project/issues/1182

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
