### PR TITLE
Document EVP_CIPHER failure for missing provider function

### DIFF
--- a/doc/man7/provider-cipher.pod
+++ b/doc/man7/provider-cipher.pod
@@ -134,8 +134,8 @@ In order to be a consistent set of functions there must at least be a complete
 set of "encrypt" functions, or a complete set of "decrypt" functions, or a
 single "cipher" function. Similarly, there can be a complete set of pipeline
 "encrypt" functions, and/or a complete set of pipeline "decrypt" functions.
-In all cases both the OSSL_FUNC_cipher_newctx and OSSL_FUNC_cipher_freectx functions must be
-present.
+In all cases the OSSL_FUNC_cipher_get_params and both OSSL_FUNC_cipher_newctx
+and OSSL_FUNC_cipher_freectx functions must be present.
 All other functions are optional.
 
 =head2 Context Management Functions


### PR DESCRIPTION
When writing a new CIPHER implementation the OSSL_FUNC_cipher_get_params
must be present, otherwise the fetch fails. This behaviour is seen in
function evp_cipher_cache_constants@crypto/evp/evp_lib.c.

Resolves: #25801

Signed-off-by: Norbert Pocs <norbertp@openssl.org>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
