### PR TITLE
Add params precondition in ASN1_STRING_TABLE_add, ASN1_STRING_TABLE_get

### DIFF
--- a/crypto/asn1/a_strnid.c
+++ b/crypto/asn1/a_strnid.c
@@ -129,6 +129,11 @@ ASN1_STRING_TABLE *ASN1_STRING_TABLE_get(int nid)
     int idx;
     ASN1_STRING_TABLE fnd;
 
+    if (nid <= 0) {
+        ERR_raise(ERR_LIB_ASN1, ERR_R_PASSED_INVALID_ARGUMENT);
+        return NULL;
+    }
+
 #ifndef OPENSSL_NO_AUTOLOAD_CONFIG
     /* "stable" can be impacted by config, so load the config file first */
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
@@ -189,6 +194,11 @@ int ASN1_STRING_TABLE_add(int nid,
                           unsigned long flags)
 {
     ASN1_STRING_TABLE *tmp;
+
+    if (nid <= 0 || (minsize >= 0 && maxsize >= 0 && minsize > maxsize)) {
+        ERR_raise(ERR_LIB_ASN1, ERR_R_PASSED_INVALID_ARGUMENT);
+        return 0;
+    }
 
     tmp = stable_get(nid);
     if (tmp == NULL) {


### PR DESCRIPTION
There is a potential type overflow [here]( https://github.com/openssl/openssl/blob/e0ae801728776b53e2be0972846072ce32bea304/crypto/asn1/a_strnid.c#L115) and [here]( https://github.com/openssl/openssl/blob/e0ae801728776b53e2be0972846072ce32bea304/crypto/asn1/a_strnid.c#L122) if `(*a)->nid < 0` и `(*a)->nid + (*b)->nid > INT_MAX`.
Bonus: minsize, maxsize values sanity check.

CLA: trivial