### PR TITLE
Alternative fix for -Wstringop-overflow warnings with gcc 14 on s390x

### DIFF
--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -23,6 +23,7 @@
 #include "crypto/evp.h"
 #include "crypto/evp/evp_local.h"
 #include "internal/provider.h"
+#include "internal/common.h"
 
 static OSSL_FUNC_rand_newctx_fn drbg_ctr_new_wrapper;
 static OSSL_FUNC_rand_freectx_fn drbg_ctr_free;
@@ -85,6 +86,8 @@ static void ctr_XOR(PROV_DRBG_CTR *ctr, const unsigned char *in, size_t inlen)
      * are XORing. So just process however much input we have.
      */
     n = inlen < ctr->keylen ? inlen : ctr->keylen;
+    if (!ossl_assert(n <= sizeof(ctr->K)))
+        return;
     for (i = 0; i < n; i++)
         ctr->K[i] ^= in[i];
     if (inlen <= ctr->keylen)

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -44,6 +44,8 @@ static void le_copy(unsigned char *out, size_t outlen,
     } else {
         if (outlen < inlen)
             in = (const char *)in + inlen - outlen;
+        if (!ossl_assert(outlen <= inlen))
+            return;
         swap_copy(out, in, outlen);
     }
 }


### PR DESCRIPTION
Compiling OpenSSL on s390x with gcc 14 (i.e. in Fedora 41) shows several -Wstringop-overflow warnings in providers/implementations/rands/drbg_ctr.c and test/params_api_test.c.

Add explicit length checks to let the compiler know that it won't overrun the buffer. This also silences the warnings.

This is a more generic fix for https://github.com/openssl/openssl/issues/27525 and an alternative for the architecture specific fix in https://github.com/openssl/openssl/pull/27675