### PR TITLE
Add generated cipher implementation files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,8 @@ providers/common/include/prov/der_digests.h
 providers/common/include/prov/der_wrap.h
 providers/common/include/prov/der_sm2.h
 providers/common/include/prov/der_ml_dsa.h
+providers/implementations/ciphers/ciphercommon.c
+providers/implementations/ciphers/cipher_chacha20_poly1305.c
 
 # error code files
 /crypto/err/openssl.txt.old


### PR DESCRIPTION
A commit was merged recently which changes ciphercommon.c and cipher_chacha20_poly1305.c to be generated files. The corresponding .c files were not added to the gitignore, so this commit adds them to avoid them being erroneously tracked in the future.
