### PR TITLE
Fixes #27703 DTLS msg callback data corruption

### DIFF
--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -218,6 +218,9 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
             }
             dtls1_fix_message_header(s, frag_off, len - DTLS1_HM_HEADER_LENGTH);
 
+            /* Save the data that will be overwritten by
+             * dtls1_write_messsage_header so no corruption occurs when using
+             * a msg callback. */
             if (s->msg_callback && s->init_off != 0)
                 memcpy(saved_payload, &s->init_buf->data[s->init_off],
                     sizeof(saved_payload));

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -218,9 +218,11 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
             }
             dtls1_fix_message_header(s, frag_off, len - DTLS1_HM_HEADER_LENGTH);
 
-            /* Save the data that will be overwritten by
+            /*
+             * Save the data that will be overwritten by
              * dtls1_write_messsage_header so no corruption occurs when using
-             * a msg callback. */
+             * a msg callback.
+             */
             if (s->msg_callback && s->init_off != 0)
                 memcpy(saved_payload, &s->init_buf->data[s->init_off],
                     sizeof(saved_payload));

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -16,9 +16,8 @@
 #include "internal/cryptlib.h"
 #include "internal/ssl_unwrap.h"
 #include <openssl/buffer.h>
-#include <openssl/objects.h>
-#include <openssl/evp.h>
 #include <openssl/x509.h>
+
 
 #define RSMBLY_BITMASK_SIZE(msg_len) (((msg_len) + 7) / 8)
 
@@ -116,6 +115,7 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
     size_t len, frag_off, overhead, used_len;
     SSL *ssl = SSL_CONNECTION_GET_SSL(s);
     SSL *ussl = SSL_CONNECTION_GET_USER_SSL(s);
+    uint8_t saved_payload[DTLS1_HM_HEADER_LENGTH];
 
     if (!dtls1_query_mtu(s))
         return -1;
@@ -218,6 +218,10 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
             }
             dtls1_fix_message_header(s, frag_off, len - DTLS1_HM_HEADER_LENGTH);
 
+            if (s->msg_callback && s->init_off != 0)
+                memcpy(saved_payload, &s->init_buf->data[s->init_off],
+                    sizeof(saved_payload));
+
             dtls1_write_message_header(s,
                                        (unsigned char *)&s->init_buf->
                                        data[s->init_off]);
@@ -226,15 +230,9 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
         ret = dtls1_write_bytes(s, type, &s->init_buf->data[s->init_off], len,
                                 &written);
 
-        /* Invoke the msg callback when we wrote the first fragment.
-         * This avoids corruption of data that is going to be used in the
-         * callback when a message spans over multiple fragments. */
-        if (s->init_off == 0) {
-            if (s->msg_callback)
-                s->msg_callback(1, s->version, type, s->init_buf->data,
-                                s->init_off + s->init_num, ussl,
-                                s->msg_callback_arg);
-        }
+        if (type == SSL3_RT_HANDSHAKE && s->msg_callback && s->init_off != 0)
+            memcpy(&s->init_buf->data[s->init_off], saved_payload,
+                sizeof(saved_payload));
 
         if (ret <= 0) {
             /*
@@ -306,6 +304,11 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
             }
 
             if (written == s->init_num) {
+                if (s->msg_callback)
+                    s->msg_callback(1, s->version, type, s->init_buf->data,
+                                    s->init_off + s->init_num, ussl,
+                                    s->msg_callback_arg);
+
                 s->init_off = 0; /* done writing this message */
                 s->init_num = 0;
 


### PR DESCRIPTION
Hi,

This merge request is a fix to the issue I described [here](https://github.com/openssl/openssl/issues/27703). The fragmenting loop used in DTLS overwrites part of the original message with DTLS handshake message header.
The message callback is invoked with the modified data, causing corrupted data to show or even making some internal ASN.1 parsing function fail.

This fix is not ideal since it uses `memcpy` and a small tempory buffer to restore the data back if a message callback is used, but I do not want to modify it furthers (especially for a 'debugging' issue) since it is a critical piece of code in the codebase.

You can reproduce this issue using `s_server`  with the `-trace` option in DTLS 1.x with  any certificate.