### PR TITLE
Allow hybrid MLKEM in FIPS mode

### DIFF
--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -535,8 +535,8 @@ static const OSSL_ALGORITHM deflt_asym_kem[] = {
     { "X448MLKEM1024", "provider=default", ossl_mlx_kem_asym_kem_functions },
 # endif
 # if !defined(OPENSSL_NO_EC)
-    { "SecP256r1MLKEM768", "provider=default", ossl_mlx_kem_asym_kem_functions },
-    { "SecP384r1MLKEM1024", "provider=default", ossl_mlx_kem_asym_kem_functions },
+    { "SecP256r1MLKEM768", "provider=default,fips=yes", ossl_mlx_kem_asym_kem_functions },
+    { "SecP384r1MLKEM1024", "provider=default,fips=yes", ossl_mlx_kem_asym_kem_functions },
 # endif
 #endif
     { NULL, NULL, NULL }
@@ -615,9 +615,9 @@ static const OSSL_ALGORITHM deflt_keymgmt[] = {
       PROV_DESCS_X448MLKEM1024 },
 # endif
 # if !defined(OPENSSL_NO_EC)
-    { PROV_NAMES_SecP256r1MLKEM768, "provider=default", ossl_mlx_p256_kem_kmgmt_functions,
+    { PROV_NAMES_SecP256r1MLKEM768, "provider=default,fips=yes", ossl_mlx_p256_kem_kmgmt_functions,
       PROV_DESCS_SecP256r1MLKEM768 },
-    { PROV_NAMES_SecP384r1MLKEM1024, "provider=default", ossl_mlx_p384_kem_kmgmt_functions,
+    { PROV_NAMES_SecP384r1MLKEM1024, "provider=default,fips=yes", ossl_mlx_p384_kem_kmgmt_functions,
       PROV_DESCS_SecP384r1MLKEM1024 },
 # endif
 #endif

--- a/providers/implementations/include/prov/mlx_kem.h
+++ b/providers/implementations/include/prov/mlx_kem.h
@@ -44,4 +44,5 @@ typedef struct mlx_key_st {
 #define mlx_kem_have_pubkey(key) ((key)->state > 0)
 #define mlx_kem_have_prvkey(key) ((key)->state > 1)
 
+char *get_adjusted_propq(const char *propq);
 #endif

--- a/providers/implementations/keymgmt/mlx_kmgmt.c
+++ b/providers/implementations/keymgmt/mlx_kmgmt.c
@@ -156,6 +156,52 @@ typedef struct export_cb_arg_st {
     size_t   prvlen;
 } EXPORT_CB_ARG;
 
+#ifndef FIPS_MODULE
+# include <openssl/bn.h>
+# include <openssl/ec.h>
+static size_t decompress_pub_key(void *pub, size_t compressed_len, size_t decompressed_len)
+{
+    EC_GROUP *group = NULL;
+    EC_POINT *point = NULL;
+    BN_CTX *ctx = NULL;
+    size_t len = compressed_len;
+    int group_nid = NID_undef;
+
+    switch (len) {
+    case 33:
+         group_nid = NID_X9_62_prime256v1;
+       break;
+    case 49:
+         group_nid = NID_secp384r1;
+       break;
+    default:
+       return len;
+       break;
+    }
+
+    ctx = BN_CTX_new();
+    group = EC_GROUP_new_by_curve_name(group_nid);
+    if (ctx == NULL || group == NULL)
+        goto err;
+
+    point = EC_POINT_new(group);
+    if (point == NULL)
+        goto err;
+
+    if (!EC_POINT_oct2point(group, point, pub, len, ctx))
+        goto err;
+
+    len = EC_POINT_point2oct(group, point, POINT_CONVERSION_UNCOMPRESSED, pub, decompressed_len, ctx);
+
+err:
+    EC_POINT_free(point);
+    EC_GROUP_free(group);
+    BN_CTX_free(ctx);
+
+    return len;
+}
+#endif
+
 /* Copy any exported key material into its storage slot */
 static int export_sub_cb(const OSSL_PARAM *params, void *varg)
 {
@@ -176,6 +222,10 @@ static int export_sub_cb(const OSSL_PARAM *params, void *varg)
 
         if (OSSL_PARAM_get_octet_string(p, &pub, sub_arg->publen, &len) != 1)
             return 0;
+#ifndef FIPS_MODULE
+        if (len < sub_arg->publen)
+            len = decompress_pub_key(pub, len, sub_arg->publen);
+#endif
         if (len != sub_arg->publen) {
             ERR_raise_data(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR,
                            "Unexpected %s public key length %lu != %lu",
@@ -695,6 +745,9 @@ static void *mlx_kem_gen(void *vgctx, OSSL_CALLBACK *osslcb, void *cbarg)
     PROV_ML_KEM_GEN_CTX *gctx = vgctx;
     MLX_KEY *key;
     char *propq;
+    char *adjusted_propq = NULL;
+    EVP_PKEY_CTX *mctx = NULL;
+    OSSL_PARAM mparams[] = { OSSL_PARAM_END, OSSL_PARAM_END };
 
     if (gctx == NULL
         || (gctx->selection & OSSL_KEYMGMT_SELECT_KEYPAIR) ==
@@ -704,15 +757,27 @@ static void *mlx_kem_gen(void *vgctx, OSSL_CALLBACK *osslcb, void *cbarg)
     /* Lose ownership of propq */
     propq = gctx->propq;
     gctx->propq = NULL;
+    adjusted_propq = get_adjusted_propq(propq);
     if ((key = mlx_kem_key_new(gctx->evp_type, gctx->libctx, propq)) == NULL)
         return NULL;
 
     if ((gctx->selection & OSSL_KEYMGMT_SELECT_KEYPAIR) == 0)
         return key;
 
-    /* For now, using the same "propq" for all components */
-    key->mkey = EVP_PKEY_Q_keygen(key->libctx, key->propq,
-                                  key->minfo->algorithm_name);
+    /* For RHEL build, we need adjust "propq" for all PQ part and pass it downwards */
+/*    key->mkey = EVP_PKEY_Q_keygen(key->libctx, adjusted_propq ? adjusted_propq : key->propq,
+                                  key->minfo->algorithm_name); */
+    mctx = EVP_PKEY_CTX_new_from_name(key->libctx, key->minfo->algorithm_name,
+                                      adjusted_propq ? adjusted_propq : key->propq);
+    mparams[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_PROPERTIES,
+                                                  adjusted_propq ? adjusted_propq : key->propq, 0);
+    if (mctx != NULL
+            && EVP_PKEY_keygen_init(mctx) > 0
+            && EVP_PKEY_CTX_set_params(mctx, mparams))
+        (void)EVP_PKEY_generate(mctx, &(key->mkey));
+    EVP_PKEY_CTX_free(mctx);
+    OPENSSL_free(adjusted_propq);
+
     key->xkey = EVP_PKEY_Q_keygen(key->libctx, key->propq,
                                   key->xinfo->algorithm_name,
                                   key->xinfo->group_name);


### PR DESCRIPTION
These are the changes that allow working hybrid PQ algorithms in hybrid mode with old (pre-3.5) FIPS providers.

Changes I had to introduce, and some reasoning:
* fips=yes for hybrid KEM/KEYMGMT so hybrids would work in FIPS mode
* strip "fips" from MLKEM fetching properties, we want to be able to use the non-fips-certified MLKEM+certified FIPS part
* pass propq down when generating MLKEM keys, so SHAKE would be fetched from default provider. Otherwise FIPS 3.0 provider doesn't have squeeze method
* Expand EC pubkey when old (< 3.0.8) FIPS provider returns compressed one. We have 3.0.7 

We can do it as according to a set of NIST documents (800-56Ar3) we can treat MLKEM as auxiliary data for EC key exchange.

```
Different orderings of the component data fields of FixedInfo may be used, and one or more of
the data fields may be combined (or omitted under certain circumstances). See Section 5 in SP
800-56C, and Sections 5, 7.4, 7.5 and 7.6 in SP 800-108 for details
```
Currently it is WIP and I wonder if it is of any interest for upstream.
