### PR TITLE
DOC: update references to obsolete RFC 2459 

### DIFF
--- a/crypto/asn1/a_sign.c
+++ b/crypto/asn1/a_sign.c
@@ -47,7 +47,7 @@ int ASN1_sign(i2d_of_void *i2d, X509_ALGOR *algor1, X509_ALGOR *algor2,
             continue;
         if (type->pkey_type == NID_dsaWithSHA1) {
             /*
-             * special case: RFC 2459 tells us to omit 'parameters' with
+             * special case: RFC 3370 tells us to omit 'parameters' with
              * id-dsa-with-sha1
              */
             ASN1_TYPE_free(a->parameter);

--- a/crypto/asn1/a_strnid.c
+++ b/crypto/asn1/a_strnid.c
@@ -41,7 +41,7 @@ unsigned long ASN1_STRING_get_default_mask(void)
  * MASK:XXXX : a numerical mask value.
  * default   : use Printable, IA5, T61, BMP, and UTF8 string types
  * nombstr   : any string type except variable-sized BMPStrings or UTF8Strings
- * pkix      : PKIX recommendation in RFC2459
+ * pkix      : PKIX recommendation in RFC 5280
  * utf8only  : this is the default, use UTF8Strings
  */
 

--- a/doc/man1/openssl-ca.pod.in
+++ b/doc/man1/openssl-ca.pod.in
@@ -427,7 +427,7 @@ in delta CRLs which are not currently implemented.
 
 This sets the CRL revocation reason code to B<certificateHold> and the hold
 instruction to I<instruction> which must be an OID. Although any OID can be
-used only B<holdInstructionNone> (the use of which is discouraged by RFC2459)
+used, only B<holdInstructionNone> (the use of which is deprecated in RFC 5280),
 B<holdInstructionCallIssuer> or B<holdInstructionReject> will normally be used.
 
 =item B<-crl_compromise> I<time>

--- a/doc/man1/openssl-dsaparam.pod.in
+++ b/doc/man1/openssl-dsaparam.pod.in
@@ -49,7 +49,7 @@ The DSA parameters output format; the default is B<PEM>.
 See L<openssl-format-options(1)> for details.
 
 Parameters are a sequence of B<ASN.1 INTEGER>s: B<p>, B<q>, and B<g>.
-This is compatible with RFC 2459 B<DSS-Parms> structure.
+This is compatible with RFC 3370 B<DSS-Parms> structure.
 
 =item B<-in> I<filename>
 

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -554,7 +554,7 @@ several values:
 
 =back
 
-Note that B<utf8only> is the PKIX recommendation in RFC2459 after 2003, and the
+Note that B<utf8only> is the PKIX recommendation in RFC 5280, and the
 default B<string_mask>; B<default> is not the default option. The B<nombstr>
 value is a workaround for some software that has problems with variable-sized
 BMPStrings and UTF8Strings.

--- a/doc/man3/PEM_read_bio_PrivateKey.pod
+++ b/doc/man3/PEM_read_bio_PrivateKey.pod
@@ -280,13 +280,13 @@ key is not DSA.
 
 The B<Parameters> functions read or write key parameters in PEM format using
 an EVP_PKEY structure.  The encoding depends on the type of key; for DSA key
-parameters, it will be a Dss-Parms structure as defined in RFC2459, and for DH
+parameters, it will be a Dss-Parms structure as defined in RFC 3370, and for DH
 key parameters, it will be a PKCS#3 DHparameter structure.  I<These functions
 only exist for the B<BIO> type>.
 
 The B<DSAparams> functions process DSA parameters using a DSA
 structure. The parameters are encoded using a Dss-Parms structure
-as defined in RFC2459.
+as defined in RFC 3370.
 
 The B<DHparams> functions process DH parameters using a DH
 structure. The parameters are encoded using a PKCS#3 DHparameter

--- a/doc/man3/X509_NAME_get_index_by_NID.pod
+++ b/doc/man3/X509_NAME_get_index_by_NID.pod
@@ -26,7 +26,7 @@ X509_NAME lookup and enumeration functions
 
 These functions allow an B<X509_NAME> structure to be examined. The
 B<X509_NAME> structure is the same as the B<Name> type defined in
-RFC2459 (and elsewhere) and used for example in certificate subject
+RFC 5280 (and elsewhere) and used for example in certificate subject
 and issuer names.
 
 X509_NAME_get_index_by_NID() and X509_NAME_get_index_by_OBJ() retrieve

--- a/include/openssl/asn1.h.in
+++ b/include/openssl/asn1.h.in
@@ -212,7 +212,7 @@ struct asn1_string_table_st {
     generate_stack_macros("ASN1_STRING_TABLE");
 -}
 
-/* size limits: this stuff is taken straight from RFC2459 */
+/* size limits: this stuff is taken straight from RFC 5280 */
 
 # define ub_name                         32768
 # define ub_common_name                  64


### PR DESCRIPTION
That RFC was updated by RFC 3280 and then in 2008 by RFC 5280, while the DSA parts were taken over by RFC 3370, published in 2002.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
