### PR TITLE
sm2: sm2_sign.c: check EC_KEY_get0_private_key() for NULL in sm2_sig_gen()

### DIFF
--- a/crypto/sm2/sm2_sign.c
+++ b/crypto/sm2/sm2_sign.c
@@ -220,6 +220,10 @@ static ECDSA_SIG *sm2_sig_gen(const EC_KEY *key, const BIGNUM *e)
     BIGNUM *tmp = NULL;
     OSSL_LIB_CTX *libctx = ossl_ec_key_get_libctx(key);
 
+    if (dA == NULL) {
+        ERR_raise(ERR_LIB_SM2, ERR_R_PASSED_NULL_PARAMETER);
+        goto done;
+    }
     kG = EC_POINT_new(group);
     if (kG == NULL) {
         ERR_raise(ERR_LIB_SM2, ERR_R_EC_LIB);


### PR DESCRIPTION

Static analysis revealed that sm2_sig_gen() dereferences the return value of EC_KEY_get0_private_key() without checking for NULL. This could lead to a crash if the private key is unset.

This patch adds a NULL check and raises ERR_R_PASSED_NULL_PARAMETER if the key is missing.

Issue found by static analyzer:
> Return value of EC_KEY_get0_private_key() is dereferenced without checking for NULL (11/12 checked)

CLA: trivial

Signed-off-by: Anton Moryakov [ant.v.moryakov@gmail.com](mailto:ant.v.moryakov@gmail.com)
