### PR TITLE
fixed callsite error checking for `pkcs7_decrypt_rinfo`

### DIFF
--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -621,14 +621,14 @@ BIO *PKCS7_dataDecode(PKCS7 *p7, EVP_PKEY *pkey, BIO *in_bio, X509 *pcert)
                 ri = sk_PKCS7_RECIP_INFO_value(rsk, i);
                 ri->ctx = p7_ctx;
                 if (pkcs7_decrypt_rinfo(&ek, &eklen, ri, pkey,
-                        EVP_CIPHER_get_key_length(cipher)) < 0)
+                        EVP_CIPHER_get_key_length(cipher)) <= 0)
                     goto err;
                 ERR_clear_error();
             }
         } else {
             ri->ctx = p7_ctx;
             /* Only exit on fatal errors, not decrypt failure */
-            if (pkcs7_decrypt_rinfo(&ek, &eklen, ri, pkey, 0) < 0)
+            if (pkcs7_decrypt_rinfo(&ek, &eklen, ri, pkey, 0) <= 0)
                 goto err;
             ERR_clear_error();
         }

--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -215,6 +215,7 @@ static int pkcs7_decrypt_rinfo(unsigned char **pek, int *peklen,
     ret = evp_pkey_decrypt_alloc(pctx, &ek, &eklen, fixlen,
                                  ri->enc_key->data, ri->enc_key->length);
     if (ret <= 0)
+		ret = -1;
         goto err;
 
     ret = 1;
@@ -621,14 +622,14 @@ BIO *PKCS7_dataDecode(PKCS7 *p7, EVP_PKEY *pkey, BIO *in_bio, X509 *pcert)
                 ri = sk_PKCS7_RECIP_INFO_value(rsk, i);
                 ri->ctx = p7_ctx;
                 if (pkcs7_decrypt_rinfo(&ek, &eklen, ri, pkey,
-                        EVP_CIPHER_get_key_length(cipher)) <= 0)
+                        EVP_CIPHER_get_key_length(cipher)) < 0)
                     goto err;
                 ERR_clear_error();
             }
         } else {
             ri->ctx = p7_ctx;
             /* Only exit on fatal errors, not decrypt failure */
-            if (pkcs7_decrypt_rinfo(&ek, &eklen, ri, pkey, 0) <= 0)
+            if (pkcs7_decrypt_rinfo(&ek, &eklen, ri, pkey, 0) < 0)
                 goto err;
             ERR_clear_error();
         }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

This fixes #27693, including the value 0 as error at callsites