### PR TITLE
Remove windows-2019 runner images

### DIFF
--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -125,7 +125,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022, windows-2025]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,13 +19,13 @@ jobs:
       matrix:
         platform:
           - arch: win64
-            os: windows-2019
+            os: windows-2022
             config: enable-fips
           - arch: win64
-            os: windows-2022
+            os: windows-2025
             config: enable-fips no-thread-pool no-quic
           - arch: win32
-            os: windows-2022
+            os: windows-2025
             config: --strict-warnings no-fips
     runs-on: ${{ matrix.platform.os }}
     steps:
@@ -93,7 +93,6 @@ jobs:
     strategy:
       matrix:
         os:
-# Reducing CI footprint  - windows-2019
           - windows-2022
     runs-on: ${{ matrix.os }}
     steps:
@@ -130,8 +129,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
-# Reducing CI footprint  - windows-2022
+          - windows-2022
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -168,9 +166,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
-# really worth while running, too? cygwin should mask this
-#          - windows-2022
+          - windows-2022
         platform:
           - arch: win64
             config: -DCMAKE_C_COMPILER=gcc --strict-warnings enable-demos no-fips


### PR DESCRIPTION
According to https://github.com/actions/runner-images/issues/12045 The Windows 2019 Actions runner image will begin deprecation on 2025-06-01 and will be fully unsupported by 2025-06-30. Jobs using the windows-2019 YAML workflow label should be updated to windows-2022, windows-2025 or windows-latest.