### PR TITLE
ci: remove windows-2019 runner images

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
           - windows-2022
+          - windows-2025
         platform:
           - arch: win64
             config: enable-fips
@@ -60,8 +60,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
           - windows-2022
+          - windows-2025
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -84,8 +84,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
           - windows-2022
+          - windows-2025
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
According to https://github.com/actions/runner-images/issues/12045 The Windows 2019 Actions runner image will begin deprecation on 2025-06-01 and will be fully unsupported by 2025-06-30. Jobs using the windows-2019 YAML workflow label should be updated to windows-2022, windows-2025 or windows-latest.