### PR TITLE
dtls1_read_bytes(): Fix backported patch for no renegotiation

### DIFF
--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -615,7 +615,7 @@ int dtls1_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
                  * the future we might have a renegotiation where we don't care
                  * if the peer refused it where we carry on.
                  */
-                SSLfatal(sc, SSL_AD_HANDSHAKE_FAILURE, SSL_R_NO_RENEGOTIATION);
+                SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE, SSL_R_NO_RENEGOTIATION);
                 return -1;
             }
         } else if (alert_level == SSL3_AL_FATAL) {


### PR DESCRIPTION
This is urgent as the build is broken on 3.0.
