### PR TITLE
Remove _strlen31

### DIFF
--- a/include/internal/e_os.h
+++ b/include/internal/e_os.h
@@ -106,17 +106,6 @@
 #    define EACCES   13
 #   endif
 #   include <string.h>
-#   ifdef _WIN64
-#    define strlen(s) _strlen31(s)
-/* cut strings to 2GB */
-static __inline unsigned int _strlen31(const char *str)
-{
-    unsigned int len = 0;
-    while (*str && len < 0x80000000U)
-        str++, len++;
-    return len & 0x7FFFFFFF;
-}
-#   endif   /* def(_WIN64) */
 #   include <malloc.h>
 #   if defined(_MSC_VER) && !defined(_WIN32_WCE) && !defined(_DLL) && defined(stdin)
 #    if _MSC_VER>=1300 && _MSC_VER<1600


### PR DESCRIPTION
This function is old and fairly broken.  Code archeology in our git tree hasn't revealed why it was creted (though it may have possibly been to support older win32 systems that couldn't do 64 bit integers properly, like windows 95/98).

There seems to be no good reason to keep it around, and given that it has potentially serious side effects, lets just remove it.

Fixes #27761

