### PR TITLE
Fix memory overrun bug in EVP_RAND_nonce for 3.0

### DIFF
--- a/crypto/evp/evp_rand.c
+++ b/crypto/evp/evp_rand.c
@@ -634,10 +634,8 @@ static int evp_rand_nonce_locked(EVP_RAND_CTX *ctx, unsigned char *out,
 {
     unsigned int str = evp_rand_strength_locked(ctx);
 
-    if (ctx->meth->nonce == NULL)
-        return 0;
-    if (ctx->meth->nonce(ctx->algctx, out, str, outlen, outlen))
-        return 1;
+    if (ctx->meth->nonce != NULL)
+        return ctx->meth->nonce(ctx->algctx, out, str, outlen, outlen) > 0;
     return evp_rand_generate_locked(ctx, out, outlen, str, 0, NULL, 0);
 }
 

--- a/doc/man3/EVP_RAND.pod
+++ b/doc/man3/EVP_RAND.pod
@@ -151,11 +151,8 @@ operating system.  If I<prediction_resistance> is specified, fresh entropy
 from a live source will be sought.  This call operates as per NIST SP 800-90A
 and SP 800-90C.
 
-EVP_RAND_nonce() creates a nonce in I<out> of maximum length I<outlen>
-bytes from the RAND I<ctx>. The function returns the length of the generated
-nonce. If I<out> is NULL, the length is still returned but no generation
-takes place. This allows a caller to dynamically allocate a buffer of the
-appropriate size.
+EVP_RAND_nonce() creates a nonce in I<out> of length I<outlen>
+bytes from the RAND I<ctx>.
 
 EVP_RAND_enable_locking() enables locking for the RAND I<ctx> and all of
 its parents.  After this I<ctx> will operate in a thread safe manner, albeit
@@ -376,7 +373,7 @@ B<EVP_RAND_CTX> structure or NULL if an error occurred.
 
 EVP_RAND_CTX_free() does not return a value.
 
-EVP_RAND_nonce() returns the length of the nonce.
+EVP_RAND_nonce() returns 1 on success, 0 on error.
 
 EVP_RAND_get_strength() returns the strength of the random number generator
 in bits.

--- a/providers/implementations/rands/test_rng.c
+++ b/providers/implementations/rands/test_rng.c
@@ -125,16 +125,18 @@ static int test_rng_reseed(ossl_unused void *vtest,
 static size_t test_rng_nonce(void *vtest, unsigned char *out,
                              unsigned int strength,
                              ossl_unused size_t min_noncelen,
-                             ossl_unused size_t max_noncelen)
+                             size_t max_noncelen)
 {
     PROV_TEST_RNG *t = (PROV_TEST_RNG *)vtest;
+    size_t i;
 
     if (t->nonce == NULL || strength > t->strength)
         return 0;
 
+    i = t->nonce_len > max_noncelen ? max_noncelen : t->nonce_len;
     if (out != NULL)
-        memcpy(out, t->nonce, t->nonce_len);
-    return t->nonce_len;
+        memcpy(out, t->nonce, i);
+    return i;
 }
 
 static int test_rng_get_ctx_params(void *vtest, OSSL_PARAM params[])

--- a/test/rand_test.c
+++ b/test/rand_test.c
@@ -19,6 +19,7 @@ static int test_rand(void)
     OSSL_PARAM params[2], *p = params;
     unsigned char entropy1[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05 };
     unsigned char entropy2[] = { 0xff, 0xfe, 0xfd };
+    unsigned char nonce[] = { 0x00, 0x01, 0x02, 0x03, 0x04 };
     unsigned char outbuf[3];
 
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_RAND_PARAM_TEST_ENTROPY,
@@ -41,6 +42,14 @@ static int test_rand(void)
             || !TEST_int_gt(RAND_priv_bytes(outbuf, sizeof(outbuf)), 0)
             || !TEST_mem_eq(outbuf, sizeof(outbuf), entropy2, sizeof(outbuf)))
         return 0;
+
+    *params = OSSL_PARAM_construct_octet_string(OSSL_RAND_PARAM_TEST_NONCE,
+                                                nonce, sizeof(nonce));
+    if (!TEST_true(EVP_RAND_CTX_set_params(privctx, params))
+            || !TEST_true(EVP_RAND_nonce(privctx, outbuf, sizeof(outbuf)))
+            || !TEST_mem_eq(outbuf, sizeof(outbuf), nonce, sizeof(outbuf)))
+        return 0;
+
     return 1;
 }
 


### PR DESCRIPTION
This is not a security issue.  The problem only manifests with the test RNG and it isn't used in a way that has issues by OpenSSL or the unit tests.

The EVP_RAND_nonce function in the test RNG could walk memory if asked for something less than the full nonce.  Fix this and add a unit test for the situation.

Additionally, EVP_RAND_nonce is documented as returning the length which it doesn't.  Address this too.  The logic in this function is confused and incorrect so address that too.

- [x] tests are added or updated

Same as #27766 but for 3.0.