### PR TITLE
x509_vfy: fix possible null dereference flagged by static analyzer

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1407,7 +1407,7 @@ static void crl_akid_check(X509_STORE_CTX *ctx, X509_CRL *crl,
 
     crl_issuer = sk_X509_value(ctx->chain, cidx);
 
-    if (X509_check_akid(crl_issuer, crl->akid) == X509_V_OK) {
+    if (crl_issuer != NULL && X509_check_akid(crl_issuer, crl->akid) == X509_V_OK) {
         if (*pcrl_score & CRL_SCORE_ISSUER_NAME) {
             *pcrl_score |= CRL_SCORE_AKID | CRL_SCORE_ISSUER_CERT;
             *pissuer = crl_issuer;
@@ -1417,6 +1417,8 @@ static void crl_akid_check(X509_STORE_CTX *ctx, X509_CRL *crl,
 
     for (cidx++; cidx < sk_X509_num(ctx->chain); cidx++) {
         crl_issuer = sk_X509_value(ctx->chain, cidx);
+        if (crl_issuer == NULL)
+            continue;
         if (X509_NAME_cmp(X509_get_subject_name(crl_issuer), cnm))
             continue;
         if (X509_check_akid(crl_issuer, crl->akid) == X509_V_OK) {


### PR DESCRIPTION
A static analysis tool reported a possible null pointer dereference in `crl_akid_check()` when accessing `crl_issuer`, which is obtained from `sk_X509_value()`.

Although in practice this may not happen due to how `ctx->chain` is constructed, it is safer to add an explicit NULL check before using `crl_issuer` in calls such as `X509_check_akid()`.

This change prevents potential undefined behavior and satisfies static analyzers like SVACE.

CLA: trivial