### PR TITLE
Fix potential NULL dereference and use-after-free in ossl_qtx_write_pkt

### DIFF
--- a/ssl/quic/quic_record_tx.c
+++ b/ssl/quic/quic_record_tx.c
@@ -837,7 +837,9 @@ int ossl_qtx_write_pkt(OSSL_QTX *qtx, const OSSL_QTX_PKT *pkt)
          * Ensure TXE has at least MDPL bytes allocated. This should only be
          * possible if the MDPL has increased.
          */
-        if (!qtx_reserve_txe(qtx, NULL, txe, qtx->mdpl))
+        TXE_LIST *txl = &qtx->free;
+        txe = qtx_reserve_txe(qtx, txl, txe, qtx->mdpl);
+        if (txe == NULL)
             return 0;
 
         if (!was_coalescing) {


### PR DESCRIPTION
In the function ossl_qtx_write_pkt, qtx_reserve_txe was being called with a NULL pointer as the TXE_LIST argument. This could lead to a NULL pointer dereference inside qtx_resize_txe when manipulating the list.

Additionally, the result of qtx_reserve_txe was not assigned back to 'txe', which meant that if qtx_resize_txe returned a new pointer, the old one was used instead — leading to use-after-free errors.

Changes:
- Pass &qtx->free as a valid TXE_LIST pointer to qtx_reserve_txe.
- Assign the result of qtx_reserve_txe back to 'txe' to ensure we use the updated pointer after possible reallocation.
- Use BIO_ADDR_copy() for peer/local address assignment to avoid direct struct copies.

These changes fix DEREFOF_NULL and USE_AFTER_FREE issues reported by static analyzers.

CLA: trivial

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>