### PR TITLE
check gctx for NULL before cleanup.

### DIFF
--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -510,15 +510,15 @@ static void *ecx_gen_init(void *provctx, int selection,
         if (algdesc != NULL
                 && !ossl_FIPS_IND_callback(libctx, algdesc, "KeyGen Init")) {
             OPENSSL_free(gctx);
-            return 0;
+            return NULL;
         }
 #endif
+    } else {
+        return NULL;
     }
     if (!ecx_gen_set_params(gctx, params)) {
-        if (gctx != NULL) {
-            ecx_gen_cleanup(gctx);
-            gctx = NULL;
-        }
+        ecx_gen_cleanup(gctx);
+        gctx = NULL;
     }
     return gctx;
 }


### PR DESCRIPTION
Checking for gctx to be not NULL before cleanup (NULL dereference). 

Found by Linux Verification Center (linuxtesting.org) with SVACE.
