### PR TITLE
fixed callsite error checking for pkcs7_decrypt_rinfo

### DIFF
--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -215,6 +215,7 @@ static int pkcs7_decrypt_rinfo(unsigned char **pek, int *peklen,
     ret = evp_pkey_decrypt_alloc(pctx, &ek, &eklen, fixlen,
                                  ri->enc_key->data, ri->enc_key->length);
     if (ret <= 0)
+		if (ret == 0) ret = -1;
         goto err;
 
     ret = 1;


### PR DESCRIPTION
Fixes openssl #27693

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
reopening this since I had to close #27745 because it had a `needs CLA` tag