### PR TITLE
CI: Remove -Wno-stringop-overflow for s390x builds

### DIFF
--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -113,7 +113,7 @@ jobs:
           }, {
             arch: s390x-linux-gnu,
             libs: libc6-dev-s390x-cross,
-            target: linux64-s390x -Wno-stringop-overflow,
+            target: linux64-s390x,
             fips: no
           }, {
             arch: sh4-linux-gnu,

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -199,7 +199,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: config
-      run: ./config --strict-warnings -Wno-stringop-overflow enable-fips enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-trace
+      run: ./config --strict-warnings enable-fips enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-trace
     - name: config dump
       run: ./configdata.pm --dump
     - name: make


### PR DESCRIPTION
Since https://github.com/openssl/openssl/commit/9a788281d91f698d6a229d588b9cb36987549669 it should now build warning-free on s390x, so remove the '-Wno-stringop-overflow' build option for s390x builds.

If newly added code causes -Wstringop-overflow warnings again, it should be noted in the CI runs and the newly added code should be fixed accordingly.

References: https://github.com/openssl/openssl/pull/27710#issuecomment-2915463503
