### PR TITLE
local variable `pfds` used in `ossl_rio_poll_builder_add_fd()` must b…

### DIFF
--- a/ssl/rio/poll_builder.c
+++ b/ssl/rio/poll_builder.c
@@ -115,8 +115,11 @@ int ossl_rio_poll_builder_add_fd(RIO_POLL_BUILDER *rpb, int fd,
     if (i >= rpb->pfd_alloc) {
         if (!rpb_ensure_alloc(rpb, rpb->pfd_alloc * 2))
             return 0;
+        pfds = rpb->pfd_heap;
     }
 
+    assert((rpb->pfd_heap != NULL && rpb->pfd_heap == pfds) ||
+           (rpb->pfd_heap == NULL && rpb->pfds == pfds));
     assert(i <= rpb->pfd_num && rpb->pfd_num <= rpb->pfd_alloc);
     pfds[i].fd      = fd;
     pfds[i].events  = 0;


### PR DESCRIPTION
…e consistent

with `rpb->pfd_heap`. The function maintains array of SSL objects for SSL_poll(3ossl). It works with no issues until we need to reallocate `rbp->pfd_heap` in `rpb_ensure_alloc()`. After `rpb_ensure_alloc()` returns we must update local variable `pfds` with `rpb->pfd_heap` not doing so makes function to write to dead buffer.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
