### PR TITLE
avoid dead buffer dereference in test_poll_event_r()

### DIFF
--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -5128,7 +5128,8 @@ static int test_poll_event_r(QUIC_XSO *xso)
      * is only set if the last stream frame received had the fin bit set, and
      * the client read the data.  This catches our poll/read/poll case
      */
-    if (xso->stream->recv_state == QUIC_RSTREAM_STATE_DATA_READ)
+    if (ossl_quic_stream_has_recv_buffer(xso->stream) &&
+        xso->stream->recv_state == QUIC_RSTREAM_STATE_DATA_READ)
         return 1;
 
     return ossl_quic_stream_has_recv_buffer(xso->stream)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
