### PR TITLE
Allow our *_gen_cleanup functions to tolerate a NULL ctx

### DIFF
--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -848,6 +848,9 @@ static void ecx_gen_cleanup(void *genctx)
 {
     struct ecx_gen_ctx *gctx = genctx;
 
+    if (gctx == NULL)
+        return;
+
     OPENSSL_clear_free(gctx->dhkem_ikm, gctx->dhkem_ikmlen);
     OPENSSL_free(gctx->propq);
     OPENSSL_free(gctx);

--- a/providers/implementations/keymgmt/mac_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/mac_legacy_kmgmt.c
@@ -519,6 +519,9 @@ static void mac_gen_cleanup(void *genctx)
 {
     struct mac_gen_ctx *gctx = genctx;
 
+    if (gctx == NULL)
+        return;
+
     OPENSSL_secure_clear_free(gctx->priv_key, gctx->priv_key_len);
     ossl_prov_cipher_reset(&gctx->cipher);
     OPENSSL_free(gctx);

--- a/providers/implementations/keymgmt/ml_dsa_kmgmt.c.in
+++ b/providers/implementations/keymgmt/ml_dsa_kmgmt.c.in
@@ -573,6 +573,9 @@ static void ml_dsa_gen_cleanup(void *genctx)
 {
     struct ml_dsa_gen_ctx *gctx = genctx;
 
+    if (gctx == NULL)
+        return;
+
     OPENSSL_cleanse(gctx->entropy, gctx->entropy_len);
     OPENSSL_free(gctx->propq);
     OPENSSL_free(gctx);

--- a/providers/implementations/keymgmt/ml_kem_kmgmt.c.in
+++ b/providers/implementations/keymgmt/ml_kem_kmgmt.c.in
@@ -816,6 +816,9 @@ static void ml_kem_gen_cleanup(void *vgctx)
 {
     PROV_ML_KEM_GEN_CTX *gctx = vgctx;
 
+    if (gctx == NULL)
+        return;
+
     if (gctx->seed != NULL)
         OPENSSL_cleanse(gctx->seed, ML_KEM_RANDOM_BYTES);
     OPENSSL_free(gctx->propq);

--- a/providers/implementations/keymgmt/slh_dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/slh_dsa_kmgmt.c
@@ -410,6 +410,9 @@ static void slh_dsa_gen_cleanup(void *genctx)
 {
     struct slh_dsa_gen_ctx *gctx = genctx;
 
+    if (gctx == NULL)
+        return;
+
     OPENSSL_cleanse(gctx->entropy, gctx->entropy_len);
     OPENSSL_free(gctx->propq);
     OPENSSL_free(gctx);

--- a/providers/implementations/keymgmt/template_kmgmt.c
+++ b/providers/implementations/keymgmt/template_kmgmt.c
@@ -387,6 +387,9 @@ static void template_gen_cleanup(void *genctx)
 {
     struct template_gen_ctx *gctx = genctx;
 
+    if (gctx == NULL)
+        return;
+
     debug_print("gen cleanup for %p\n", gctx);
     OPENSSL_free(gctx);
 }


### PR DESCRIPTION
Our *_gen_cleanup functions are essentially "free" functions. Our free functions tolerate NULL being passed. We are being inconsistent with our *_gen_cleanup functions. Some of them tolerate NULL and others do not.

We should consistently tolerate NULL.

See also #27795

