### PR TITLE
Fixes #27703 DTLS msg callback data corruption

### DIFF
--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -216,12 +216,14 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
             }
             dtls1_fix_message_header(s, frag_off, len - DTLS1_HM_HEADER_LENGTH);
 
-            /* Save the data that will be overwritten by
+            /*
+             * Save the data that will be overwritten by
              * dtls1_write_messsage_header so no corruption occurs when using
-             * a msg callback. */
+             * a msg callback.
+             */
             if (s->msg_callback && s->init_off != 0)
                 memcpy(saved_payload, &s->init_buf->data[s->init_off],
-                    sizeof(saved_payload));
+                       sizeof(saved_payload));
 
             dtls1_write_message_header(s,
                                        (unsigned char *)&s->init_buf->
@@ -233,7 +235,7 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
 
         if (type == SSL3_RT_HANDSHAKE && s->msg_callback && s->init_off != 0)
             memcpy(&s->init_buf->data[s->init_off], saved_payload,
-                sizeof(saved_payload));
+                   sizeof(saved_payload));
 
         if (ret <= 0) {
             /*


### PR DESCRIPTION
New pull request with requested changes asked in [#27725](https://github.com/openssl/openssl/pull/27725).
