### PR TITLE
Begin incorporating <stdbool.h> usage in json encoding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,12 @@ OpenSSL 3.6
 
 ### Changes between 3.5 and 3.6 [xx XXX xxxx]
 
+ * Introduces use of `<stdbool.h>` when handling JSON encoding in
+   the OpenSSL codebase, replacing the previous use of `int` for
+   these boolean values.
+
+   *Alexis Goodfellow*
+
  * An ANSI-C toolchain is no longer sufficient for building OpenSSL. The code
    should build on compilers supporting C-99 features.
 

--- a/include/internal/json_enc.h
+++ b/include/internal/json_enc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2023-2025 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,6 +10,7 @@
 #ifndef OSSL_JSON_ENC_H
 # define OSSL_JSON_ENC_H
 
+# include <stdbool.h>
 # include <openssl/bio.h>
 
 /*
@@ -194,7 +195,7 @@ void ossl_json_key(OSSL_JSON_ENC *json, const char *key);
 void ossl_json_null(OSSL_JSON_ENC *json);
 
 /* Encode a JSON boolean value. */
-void ossl_json_bool(OSSL_JSON_ENC *json, int value);
+void ossl_json_bool(OSSL_JSON_ENC *json, bool value);
 
 /* Encode a JSON integer from a uint64_t. */
 void ossl_json_u64(OSSL_JSON_ENC *json, uint64_t value);

--- a/include/internal/qlog.h
+++ b/include/internal/qlog.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2023-2025 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -11,6 +11,7 @@
 # define OSSL_QLOG_H
 
 # include <openssl/ssl.h>
+# include <stdbool.h>
 # include "internal/quic_types.h"
 # include "internal/time.h"
 
@@ -110,7 +111,7 @@ void ossl_qlog_str_len(QLOG *qlog, const char *name,
                        const char *value, size_t value_len);
 void ossl_qlog_u64(QLOG *qlog, const char *name, uint64_t value);
 void ossl_qlog_i64(QLOG *qlog, const char *name, int64_t value);
-void ossl_qlog_bool(QLOG *qlog, const char *name, int value);
+void ossl_qlog_bool(QLOG *qlog, const char *name, bool value);
 void ossl_qlog_bin(QLOG *qlog, const char *name,
                    const void *value, size_t value_len);
 

--- a/ssl/quic/json_enc.c
+++ b/ssl/quic/json_enc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2023-2025 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -11,6 +11,7 @@
 #include "internal/nelem.h"
 #include "internal/numbers.h"
 #include <string.h>
+#include <stdbool.h>
 
 /*
  * wbuf
@@ -521,12 +522,12 @@ void ossl_json_null(OSSL_JSON_ENC *json)
     json_post_item(json);
 }
 
-void ossl_json_bool(OSSL_JSON_ENC *json, int v)
+void ossl_json_bool(OSSL_JSON_ENC *json, bool v)
 {
     if (!json_pre_item(json))
         return;
 
-    json_write_str(json, v > 0 ? "true" : "false");
+    json_write_str(json, v ? "true" : "false");
     json_post_item(json);
 }
 

--- a/ssl/quic/qlog.c
+++ b/ssl/quic/qlog.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2023-2025 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <stdbool.h>
 #include "internal/qlog.h"
 #include "internal/json_enc.h"
 #include "internal/common.h"
@@ -492,7 +493,7 @@ void ossl_qlog_i64(QLOG *qlog, const char *name, int64_t value)
     ossl_json_i64(&qlog->json, value);
 }
 
-void ossl_qlog_bool(QLOG *qlog, const char *name, int value)
+void ossl_qlog_bool(QLOG *qlog, const char *name, bool value)
 {
     if (name != NULL)
         ossl_json_key(&qlog->json, name);

--- a/test/json_test.c
+++ b/test/json_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2022-2025 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,6 +8,7 @@
  */
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <string.h>
 
 #include "testutil.h"
@@ -172,11 +173,11 @@ BEGIN_SCRIPT(array_empty, "serialize an empty array", 0)
 END_SCRIPT_EXPECTING_Q([])
 
 BEGIN_SCRIPT(bool_false, "serialize false", 0)
-    OPJ_BOOL(0)
+    OPJ_BOOL(false)
 END_SCRIPT_EXPECTING_Q(false)
 
 BEGIN_SCRIPT(bool_true, "serialize true", 0)
-    OPJ_BOOL(1)
+    OPJ_BOOL(true)
 END_SCRIPT_EXPECTING_Q(true)
 
 BEGIN_SCRIPT(u64_0, "serialize u64(0)", 0)


### PR DESCRIPTION
I'm not sure if this is truly _trivial_, but now that openssl has decided to move onto [only supporting C99 and later](https://github.com/openssl/openssl/commit/53e5071f3402ef0ae52f583154574ddd5aa8d3d7), the project can start using the `bool`, `true`, and `false` convenience macros from `<stdbool.h>` where it is appropriate to do so for readability's sake. 

At a cursory glance, it looks like some "boolean" values also handle sentinel values (like `-1`) - I've opted not to touch these yet until I grok them a bit better. Nonetheless, I think there are some worthwhile applications and "low-hanging fruit" - this one seemed like an appropriate place to start, especially since it's (relatively) self-contained as far as I can tell. 

I ran `make test` after these updates and they worked as expected on my machine, so I think they're okay - but it's been a long time since I've worked in a C codebase and I'm admittedly a little rusty. 

I'll make sure to handle CLA stuff before this gets merged in (if maintainers find it warranted, of course)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
