### PR TITLE
Allow our *_gen_cleanup functions to tolerate a NULL ctx (3.4/3.3/3.2/3.0)

### DIFF
--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -843,6 +843,9 @@ static void ecx_gen_cleanup(void *genctx)
 {
     struct ecx_gen_ctx *gctx = genctx;
 
+    if (gctx == NULL)
+        return;
+
     OPENSSL_clear_free(gctx->dhkem_ikm, gctx->dhkem_ikmlen);
     OPENSSL_free(gctx->propq);
     OPENSSL_free(gctx);

--- a/providers/implementations/keymgmt/mac_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/mac_legacy_kmgmt.c
@@ -519,6 +519,9 @@ static void mac_gen_cleanup(void *genctx)
 {
     struct mac_gen_ctx *gctx = genctx;
 
+    if (gctx == NULL)
+        return;
+
     OPENSSL_secure_clear_free(gctx->priv_key, gctx->priv_key_len);
     ossl_prov_cipher_reset(&gctx->cipher);
     OPENSSL_free(gctx);


### PR DESCRIPTION
This is a backport of #27807 to the 3.4/3.3/3.2 and 3.0 branches. The only difference is that some files are not affected because they do not exist in these older branches. There is a trivial conflict when cherry-picking this to the 3.0 branch which I think can simply be resolved when merging.

Our *_gen_cleanup functions are essentially "free" functions. Our free functions tolerate NULL being passed. We are being inconsistent with our *_gen_cleanup functions. Some of them tolerate NULL and others do not.

We should consistently tolerate NULL.

See also #27795