### PR TITLE
Fixes #27822 : difference between parameter name between doc and header file.

### DIFF
--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -801,7 +801,7 @@ void SSL_get0_next_proto_negotiated(const SSL *s, const unsigned char **data,
 # endif
 
 __owur int SSL_select_next_proto(unsigned char **out, unsigned char *outlen,
-                                 const unsigned char *in, unsigned int inlen,
+                                 const unsigned char *server, unsigned int server_len,
                                  const unsigned char *client,
                                  unsigned int client_len);
 


### PR DESCRIPTION

See issue [here](https://github.com/openssl/openssl/issues/27822).