### PR TITLE
Rename arguments of SSL_select_next_proto to match documentation.

### DIFF
--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -801,7 +801,7 @@ void SSL_get0_next_proto_negotiated(const SSL *s, const unsigned char **data,
 # endif
 
 __owur int SSL_select_next_proto(unsigned char **out, unsigned char *outlen,
-                                 const unsigned char *in, unsigned int inlen,
+                                 const unsigned char *server, unsigned int server_len,
                                  const unsigned char *client,
                                  unsigned int client_len);
 


### PR DESCRIPTION
`server` and `server_len` are more descriptive than `in` and `in_len`.

Fixes #27822

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
