### PR TITLE
`util/check-format.pl`: various fixes preventing false positives

### DIFF
--- a/util/check-format-test-negatives.c
+++ b/util/check-format-test-negatives.c
@@ -296,6 +296,7 @@ const OPTIONS passwd_options[] = {
     {NULL}
 };
 
+typedef bool (*LOG_cb_t)(int lineno, severity level, const char *msg);
 typedef * d(int)
     x;
 typedef (int)

--- a/util/check-format-test-negatives.c
+++ b/util/check-format-test-negatives.c
@@ -236,6 +236,9 @@ int g(void)
                     return 0;
             }
             break;
+        case 1: {
+            ;
+        }
         default:
             /* This should be dead code */
             return 0;

--- a/util/check-format-test-negatives.c
+++ b/util/check-format-test-negatives.c
@@ -161,6 +161,13 @@ int g(void)
         while (1);
     while (2);
 
+    if (pcrl != NULL) {
+        1;
+        2;
+    } else if (pcrls != NULL) {
+        1;
+    }
+
     if (1)
         f(a, b);
     do

--- a/util/check-format-test-negatives.c
+++ b/util/check-format-test-negatives.c
@@ -10,7 +10,7 @@
 
 /*
  * A collection of test cases where check-format.pl should not report issues.
- * There are some known false positives, though, which are marked below.
+ * There are some known false positives, though, which are marked below using /*@
  */
 
 #include <errno.h> /* should not report whitespace nits within <...> */
@@ -264,7 +264,14 @@ int g(void)
             && expr_line3)
         hanging_stmt;
 }
-#define m \
+
+#define m1                           \
+    if (ctx == NULL)                 \
+        return 0;                    \
+    if (ossl_param_is_empty(params)) \
+        return 1;                    \
+
+#define m2                                                               \
     do { /* should not be confused with function header followed by '{' */ \
     } while (0)
 

--- a/util/check-format-test-positives.c
+++ b/util/check-format-test-positives.c
@@ -21,6 +21,8 @@
  * following digit indicating the number of reports expected for this line.
  */
 
+/* this line is between 81 and 100 chars long, to be reported with -strict-len */
+
 /* For each of the following set of lines the tool should complain once */
 /*@ tab character: 	 */
 /*@ intra-line carriage return character:  */
@@ -46,8 +48,7 @@
 */ /*@ multi-line comment end indent off by -1 (relative to comment start) */
 */ /*@ unexpected comment ending delimiter outside comment */
 /*- '-' for formatted comment not allowed in intra-line comment */
-/*@ comment line is 4 columns tooooooooooooooooo wide, reported unless sloppy-len */
-/*@ comment line is 5 columns toooooooooooooooooooooooooooooooooooooooooooooo wide */
+/*@ comment line is toooooooooooo wide by 1 char, or by 21 chars in case strict-len option is used */
 #if ~0              /*@ '#if' with constant condition */
  #endif             /*@ indent of preproc. directive off by 1 (must be 0) */
 #define X (1 +  1)  /*@0 extra space in body, reported unless sloppy-spc */
@@ -100,7 +101,7 @@ int f (int a,       /*@ space after fn before '(', reported unless sloppy-spc */
            b,       /*@ expr indent as on line above, accepted if sloppy-hang */
     b, /*@ expr indent off -8 but @ extra indent accepted if sloppy-hang */
    "again aligned" /*@ expr indent off by -9 (left of stmt indent, */ "right",
-            abc == /*@ .. so reported also with sloppy-hang; this line is too long */ 456
+            abc == /*@ .. so reported also with sloppy-hang; this line is too long by 6 or 26 chars */ 456
 # define MAC(A) (A) /*@ nesting indent of preprocessor directive off by 1 */
              ? 1    /*@ hanging expr indent off by 1 */
               : 2); /*@ hanging expr indent off by 2, or 1 for leading ':' */

--- a/util/check-format-test-positives.c
+++ b/util/check-format-test-positives.c
@@ -15,10 +15,11 @@
  */
 
 /*
- * The '@'s after '*' are used for self-tests: they mark lines containing
- * a single flaw that should be reported. Normally it should be reported
- * while handling the given line, but in case of delayed checks there is a
- * following digit indicating the number of reports expected for this line.
+ * The '@'s after leading '*' in comment lines are used for self-tests:
+ * they mark lines containing a single issue that should be reported.
+ * Normally it should be reported while handling the given line,
+ * but in case of delayed checks there is a following digit
+ * indicating the number of reports expected for this line.
  */
 
 /* this line is between 81 and 100 chars long, to be reported with -strict-len */

--- a/util/check-format.pl
+++ b/util/check-format.pl
@@ -833,7 +833,8 @@ while (<>) { # loop over all lines of all input files
         report("space after function/macro name")
                                       if $intra_line =~ m/(\w+)\s+\(/        # fn/macro name with space before '('
        && !($1 =~ m/^(sizeof|if|else|while|do|for|switch|case|default|break|continue|goto|return|void|char|signed|unsigned|int|short|long|float|double|typedef|enum|struct|union|auto|extern|static|const|volatile|register)$/) # not keyword
-                                    && !(m/^\s*#\s*define\s+\w+\s+\(/); # not a macro without parameters having a body that starts with '('
+                                    && !(m/^\s*#\s*define\s+\w+\s+\(/) # not a macro without parameters having a body that starts with '('
+                                    && !(m/^\s*typedef\W/); # not a typedef
         report("missing space before '{'")   if $intra_line =~ m/[^\s{(\[]\{/;      # '{' without preceding space or {([
         report("missing space after '}'")    if $intra_line =~ m/\}[^\s,;\])}]/;    # '}' without following space or ,;])}
     }

--- a/util/check-format.pl
+++ b/util/check-format.pl
@@ -62,7 +62,8 @@
 #   except within if ... else constructs where some branch contains more than one
 #   statement. Since the exception is hard to recognize when such branches occur
 #   after the current position (such that false positives would be reported)
-#   the tool by checks for this rule by default only for do/while/for bodies.
+#   the tool checks for this rule by default only for do/while/for bodies
+#   and for 'if' without 'else'.
 #   Yet with the --1-stmt option false positives are preferred over negatives.
 #   False negatives occur if the braces are more than two non-blank lines apart.
 #
@@ -168,9 +169,9 @@ my $local_offset;          # current extra indent due to label, switch case/defa
 my $line_body_start;       # number of line where last function body started, or 0
 my $line_function_start;   # number of line where last function definition started, used for $line_body_start
 my $last_function_header;  # header containing name of last function defined, used if $line_body_start != 0
-my $line_opening_brace;    # number of previous line with opening brace after if/do/while/for, optionally for 'else'
+my $line_opening_brace;    # number of previous line with opening brace after if/do/while/for, partly for 'else/else if' - used for detection of { 1 stmt }
 
-my $keyword_opening_brace; # name of previous keyword, used if $line_opening_brace != 0
+my $keyword_opening_brace; # name of keyword (or combination 'else if') just before '{', used if $line_opening_brace != 0
 my $block_indent;          # currently required normal indentation at block/statement level
 my $hanging_offset;        # extra indent, which may be nested, for just one hanging statement or expr or typedef
 my @in_do_hanging_offsets; # stack of hanging offsets for nested 'do' ... 'while'
@@ -981,7 +982,7 @@ while (<>) { # loop over all lines of all input files
         my $next_word = $1;
         if ($line_opening_brace > 0 &&
             ($keyword_opening_brace ne "if" ||
-             $extended_1_stmt || $next_word ne "else") &&
+             $extended_1_stmt || $next_word ne "else") && # --1-stmt or 'if' without 'else'
             ($line_opening_brace == $line_before2 ||
              $line_opening_brace == $line_before)
             && $contents_before =~ m/;/) { # there is at least one terminator ';', so there is some stmt
@@ -1019,8 +1020,9 @@ while (<>) { # loop over all lines of all input files
     }
     if ($paren_expr_start || $return_enum_start || $assignment_start)
     {
-        my ($head, $mid, $tail) = ($1, $3, $4);
+        my ($head, $pre, $mid, $tail) = ($1, $2, $3, $4);
         $keyword_opening_brace = $mid if $mid ne "=";
+        $keyword_opening_brace = "else if" if $pre =~ m/(^|\W)else[\s@]+$/ && $mid eq "if" && !$extended_1_stmt; # prevent reporting "{ 1 stmt }" on "else if" unless --1-stmt
         # to cope with multi-line expressions, do this also if !($tail =~ m/\{/)
         push @in_if_hanging_offsets, $hanging_offset if $mid eq "if";
 
@@ -1138,10 +1140,10 @@ while (<>) { # loop over all lines of all input files
                     report("'{' not at line start") if length($head) != $preproc_offset && $head =~ m/\)\s*/; # at end of function definition header
                     $line_body_start = $contents =~ m/LONG BODY/ ? 0 : $line if $line_function_start != 0;
                 }
-            } else {
-                $line_opening_brace = $line if $keyword_opening_brace =~ m/if|do|while|for|(OSSL_)?LIST_FOREACH(_\w+)?/;
+            } else { # prepare detection of { 1 stmt }
+                $line_opening_brace = $line if $keyword_opening_brace =~ m/^(if|do|while|for|(OSSL_)?LIST_FOREACH(_\w+)?)$/;
                 # using, not assigning, $keyword_opening_brace here because it could be on an earlier line
-                $line_opening_brace = $line if $keyword_opening_brace eq "else" && $extended_1_stmt &&
+                $line_opening_brace = $line if $keyword_opening_brace =~ m/else|else if/ && $extended_1_stmt &&
                 # TODO prevent false positives for if/else where braces around single-statement branches
                 # should be avoided but only if all branches have just single statements
                 # The following helps detecting the exception when handling multiple 'if ... else' branches:


### PR DESCRIPTION
* prevent false positive on typedef with space and '(' after type name
* check-format-test-negatives.c: add 2nd macro indent test and hint on how known false positives are marked
* check-format.pl: prevent reporting "{ 1 stmt }" on "else if" branch unless -1 or --1-stmt option is given
* check-format.pl: allow block for switch case/default
* check-format-test-positives.c slightly improve comment describing the '*@' tags
* adapt check-format-test-positives.c for too long lines after limit was relaxed from 80 to 100
