### PR TITLE
test/enginetest.c: Free eid and ename to avoid memory leak if error o…

### DIFF
--- a/test/enginetest.c
+++ b/test/enginetest.c
@@ -61,6 +61,8 @@ static int test_engines(void)
     ENGINE *new_h4 = NULL;
 
     memset(block, 0, sizeof(block));
+    memset(eid, 0, sizeof(eid));
+    memset(ename, 0, sizeof(ename));
     if (!TEST_ptr(new_h1 = ENGINE_new())
             || !TEST_true(ENGINE_set_id(new_h1, "test_id0"))
             || !TEST_true(ENGINE_set_name(new_h1, "First test item"))
@@ -171,10 +173,6 @@ static int test_engines(void)
             goto end;
         ENGINE_free(ptr);
     }
-    for (loop = 0; loop < NUMTOADD; loop++) {
-        OPENSSL_free(eid[loop]);
-        OPENSSL_free(ename[loop]);
-    }
     to_return = 1;
 
  end:
@@ -182,8 +180,11 @@ static int test_engines(void)
     ENGINE_free(new_h2);
     ENGINE_free(new_h3);
     ENGINE_free(new_h4);
-    for (loop = 0; loop < NUMTOADD; loop++)
+    for (loop = 0; loop < NUMTOADD; loop++) {
+        OPENSSL_free(eid[loop]);
+        OPENSSL_free(ename[loop]);
         ENGINE_free(block[loop]);
+    }
     return to_return;
 }
 


### PR DESCRIPTION
…ccurs

Move 'OPENSSL_free(eid[loop])' and 'OPENSSL_free(ename[loop])' from cleanup_loop to end to avoid memory leak. Moreover, initialize them to avoid undefined behavior.

Fixes: 1057c2c39f ("Cleaner disposal of ephemeral engine ids and names")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
