### PR TITLE
Ensure we pass the user SSL object for the SSL_set_verify callback

### DIFF
--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -478,9 +478,9 @@ static int ssl_verify_internal(SSL_CONNECTION *s, STACK_OF(X509) *sk, EVP_PKEY *
     /* Set suite B flags if needed */
     X509_STORE_CTX_set_flags(ctx, tls1_suiteb(s));
     if (!X509_STORE_CTX_set_ex_data(ctx,
-            SSL_get_ex_data_X509_STORE_CTX_idx(), s)) {
+            SSL_get_ex_data_X509_STORE_CTX_idx(),
+            SSL_CONNECTION_GET_USER_SSL(s)))
         goto end;
-    }
 
     /* Verify via DANE if enabled */
     if (DANETLS_ENABLED(&s->dane))


### PR DESCRIPTION
When calling the verify callback we need to ensure we supply the user SSL
object, and not any internal SSL object.

Fixes https://github.com/openssl/openssl/discussions/27830
