### PR TITLE
Fix for AIX Specific issues for openssl 3.5

### DIFF
--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -23,6 +23,17 @@
 #endif
 #include "internal/numbers.h"  /* UINT64_C */
 
+#if defined(_AIX)
+/*
+ * Some versions of AIX define macros for events and revents for use when
+ * accessing pollfd structures (see Github issue #24236). That interferes
+ * with our use of these names here. We simply undef them.
+ */
+# undef revents
+# undef events
+#endif
+
+
 static const char *certfile, *keyfile;
 
 #if defined(_AIX)

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -22,6 +22,16 @@
  * ============================================================================
  */
 
+#if defined(_AIX)
+/*
+ * Some versions of AIX define macros for events and revents for use when
+ * accessing pollfd structures (see Github issue #24236). That interferes
+ * with our use of these names here. We simply undef them.
+ */
+# undef revents
+# undef events
+#endif
+
 /*
  * Test: simple_conn
  * -----------------


### PR DESCRIPTION
Fix compilation issues seen for AIX using aix-cc configuration option. Error message seen during compilation :
```cc  -Iinclude -Iapps/include  -q32 -qmaxmem=16384 -qro -qroconst -qthreaded -O -D_THREAD_SAFE -DOPENSSL_BUILDING_OPENSSL -DNDEBUG   -c -o test/quic_multistream_test-bin-quic_multistream_test.o test/quic_multistream_test.c
"test/quic_multistream_test.c", line 5655.11: 1506-022 (S) "reqevents" is not a member of "struct ssl_poll_item_st".
"test/quic_multistream_test.c", line 5656.11: 1506-022 (S) "rtnevents" is not a member of "struct ssl_poll_item_st".
"test/quic_multistream_test.c", line 5660.11: 1506-022 (S) "reqevents" is not a member of "struct ssl_poll_item_st".
"test/quic_multistream_test.c", line 5661.11: 1506-022 (S) "rtnevents" is not a member of "struct ssl_poll_item_st".
"test/quic_multistream_test.c", line 5665.11: 1506-022 (S) "reqevents" is not a member of "struct ssl_poll_item_st".
"test/quic_multistream_test.c", line 5666.11: 1506-022 (S) "rtnevents" is not a member of "struct ssl_poll_item_st".
"test/quic_multistream_test.c", line 5670.11: 1506-022 (S) "reqevents" is not a member of "struct ssl_poll_item_st".
"test/quic_multistream_test.c", line 5671.11: 1506-022 (S) "rtnevents" is not a member of "struct ssl_poll_item_st".
"test/quic_multistream_test.c", line 5675.11: 1506-022 (S) "reqevents" is not a member of "struct ssl_poll_item_st".
"test/quic_multistream_test.c", line 5676.11: 1506-022 (S) "rtnevents" is not a member of "struct ssl_poll_item_st".
"test/quic_multistream_test.c", line 5713.40: 1506-022 (S) "rtnevents" is not a member of "struct ssl_poll_item_st".
make: The error code from the last command is 1.

and 

cc  -Iinclude -Iapps/include  -q32 -qmaxmem=16384 -qro -qroconst -qthreaded -O -D_THREAD_SAFE -DOPENSSL_BUILDING_OPENSSL -DNDEBUG   -c -o test/radix/quic_radix_test-bin-quic_radix.o test/radix/quic_radix.c
"test/radix/quic_tests.c", line 87.14: 1506-022 (S) "reqevents" is not a member of "struct ssl_poll_item_st".
"test/radix/quic_tests.c", line 88.14: 1506-022 (S) "rtnevents" is not a member of "struct ssl_poll_item_st".
"test/radix/quic_tests.c", line 92.22: 1506-022 (S) "reqevents" is not a member of "struct ssl_poll_item_st".
"test/radix/quic_tests.c", line 93.22: 1506-022 (S) "rtnevents" is not a member of "struct ssl_poll_item_st".
"test/radix/quic_tests.c", line 105.18: 1506-022 (S) "reqevents" is not a member of "struct ssl_poll_item_st".
"test/radix/quic_tests.c", line 106.27: 1506-022 (S) "rtnevents" is not a member of "struct ssl_poll_item_st".
"test/radix/quic_tests.c", line 108.27: 1506-022 (S) "rtnevents" is not a member of "struct ssl_poll_item_st".
"test/radix/quic_tests.c", line 111.26: 1506-022 (S) "reqevents" is not a member of "struct ssl_poll_item_st".
"test/radix/quic_tests.c", line 112.35: 1506-022 (S) "rtnevents" is not a member of "struct ssl_poll_item_st".
"test/radix/quic_tests.c", line 118.27: 1506-022 (S) "rtnevents" is not a member of "struct ssl_poll_item_st".
"test/radix/quic_tests.c", line 126.18: 1506-022 (S) "reqevents" is not a member of "struct ssl_poll_item_st".
"test/radix/quic_tests.c", line 127.27: 1506-022 (S) "rtnevents" is not a member of "struct ssl_poll_item_st".
"test/radix/quic_tests.c", line 145.40: 1506-022 (S) "rtnevents" is not a member of "struct ssl_poll_item_st".
"test/radix/quic_tests.c", line 145.67: 1506-022 (S) "rtnevents" is not a member of "struct ssl_poll_item_st".
make: The error code from the last command is 1.
```
CLA: Trivial 