### PR TITLE
Clarify SSL_CERT_DIR list separator on Windows

### DIFF
--- a/doc/man1/openssl-rehash.pod.in
+++ b/doc/man1/openssl-rehash.pod.in
@@ -135,7 +135,9 @@ fingerprints (see above).
 
 =item B<SSL_CERT_DIR>
 
-Colon separated list of directories to operate on.
+List of directories to operate on.
+On Unix-like systems the list entries are separated by a colon.
+On Windows they are separated by a semicolon.
 Ignored if directories are listed on the command line.
 
 =back


### PR DESCRIPTION
Fixes #27698
OpenSSL uses `;` as the path delimiter on Windows. 
Update the manpage to state this explicitly instead of implying `:` everywhere.

CLA: trivial


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
