### PR TITLE
Ensure we pass the user SSL object for the SSL_set_verify callback (3.4/3.3/3.2 backport)

### DIFF
--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -467,9 +467,9 @@ static int ssl_verify_internal(SSL_CONNECTION *s, STACK_OF(X509) *sk, EVP_PKEY *
     /* Set suite B flags if needed */
     X509_STORE_CTX_set_flags(ctx, tls1_suiteb(s));
     if (!X509_STORE_CTX_set_ex_data(ctx,
-            SSL_get_ex_data_X509_STORE_CTX_idx(), s)) {
+            SSL_get_ex_data_X509_STORE_CTX_idx(),
+            SSL_CONNECTION_GET_USER_SSL(s)))
         goto end;
-    }
 
     /* Verify via DANE if enabled */
     if (DANETLS_ENABLED(&s->dane))


### PR DESCRIPTION
This is a backport of #27838 for the 3.4, 3.3 and 3.2 branches. It's basically the same except the test is dropped. The test requires quic server capabilities which don't exist in these branches. Theoretically the test could perhaps be rewritten to use tserver instead for these branches - but I'm not sure its worth it for this small fix.

When calling the verify callback we need to ensure we supply the user SSL object, and not any internal SSL object.

Fixes #27830

