### PR TITLE
Fixes #27831: Decreased NAMEMAP_HT_BUCKETS to 512.

### DIFF
--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -13,7 +13,7 @@
 #include "internal/sizes.h"
 #include "crypto/context.h"
 
-#define NAMEMAP_HT_BUCKETS 2048
+#define NAMEMAP_HT_BUCKETS 512
 
 HT_START_KEY_DEFN(namenum_key)
 HT_DEF_KEY_FIELD_CHAR_ARRAY(name, 64)


### PR DESCRIPTION
Decreased the NAMEMAP_HT_BUCKETS value to 512, to avoid memory allocation failure issues.

CLA: Trivial

Signed-off-by: Kanagavel S <kanagavels@ami.com>
