### PR TITLE
Fix exit code for s_time when -new command line switch specified

### DIFF
--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -323,8 +323,10 @@ int s_time_main(int argc, char **argv)
      */
 
  next:
-    if (!(perform & 2))
+    if (!(perform & 2)) {
+        ret = 0;
         goto end;
+    }
     printf("\n\nNow timing with session id reuse.\n");
 
     /* Get an SSL object so we can reuse the session id */


### PR DESCRIPTION
When operating with the -new switch in apps/openssl s_time, we neglect to set the exit code properly, and so the app exits with a code of 1 rather than 0 as expected

Fixes #27856
