### PR TITLE
Fix buggy stringop-overflow error on s390

### DIFF
--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -42,11 +42,13 @@ static void le_copy(unsigned char *out, size_t outlen,
     if (IS_LITTLE_ENDIAN) {
         memcpy(out, in, outlen);
     } else {
-        if (outlen < inlen)
+        if (outlen < inlen) {
             in = (const char *)in + inlen - outlen;
+            inlen = outlen;
+        }
         if (!ossl_assert(outlen <= inlen))
             return;
-        swap_copy(out, in, outlen);
+        swap_copy(out, in, inlen);
     }
 }
 


### PR DESCRIPTION
Despite some recent changes to our s390 builds, we're still seeing errors due to some stringop-overflow warnings:
https://github.com/openssl/openssl/actions/runs/15748518222/job/44389197443

It appears to be caused because the static analysis that gcc preforms in gcc 12 (the version of the compiler on our s390 runner), fails to infer the proper sizes of the buffer on which we do the reverse memcpy in swap_copy(), resulting in warnings, which on --strict-warnings builds, breaks us.

Fix it by using inlen rather than outlen to limit the copy length, adjusting it if need be to match the size of the output buffer in le_copy().  This allows the compiler to properly infer the array length constraints and suppress the warnings.

##### Checklist
- [x] tests are added or updated
