### PR TITLE
DH private key size was one bit too large

### DIFF
--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -267,7 +267,7 @@ static int generate_key(DH *dh)
     int ok = 0;
     int generate_new_key = 0;
 #ifndef FIPS_MODULE
-    unsigned l;
+    int l;
 #endif
     BN_CTX *ctx = NULL;
     BIGNUM *pub_key = NULL, *priv_key = NULL;
@@ -327,11 +327,13 @@ static int generate_key(DH *dh)
                 goto err;
 #else
             if (dh->params.q == NULL) {
-                /* secret exponent length, must satisfy 2^(l-1) <= p */
-                if (dh->length != 0
-                    && dh->length >= BN_num_bits(dh->params.p))
+                /* secret exponent length, must satisfy 2^l < (p-1)/2 */
+                l = BN_num_bits(dh->params.p);
+                if (dh->length >= l)
                     goto err;
-                l = dh->length ? dh->length : BN_num_bits(dh->params.p) - 1;
+                l -= 2;
+                if (dh->length != 0 && dh->length < l)
+                    l = dh->length;
                 if (!BN_priv_rand_ex(priv_key, l, BN_RAND_TOP_ONE,
                                      BN_RAND_BOTTOM_ANY, 0, ctx))
                     goto err;


### PR DESCRIPTION
In the case when no q parameter was given,
the function generate_key in dh_key.c did create
one bit too much, so the priv_key value was exeeding the DH group size q = (p-1)/2.
This affects also the ffdhe groups, where e.g. the length for ffdhe3072 is given as 275 by RFC 7919,
but the wording in the RFC makes it clear that we
did also use one bit too much, see section 5.2:
"for an ffdhe3072 handshake, each peer can choose
 to do $`2\times 2\times 275`$ multiplications by choosing their
 secret exponent from the range $`[2^{274}, 2^{275}]`$"
Therefore $`2^{274}`$ must be the highest bit in the
secret exponent, not $`2^{275}`$ as we did previously.
