### PR TITLE
Attempt to fix #27869: enable verify_callback and proper error exit f…

### DIFF
--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -118,6 +118,7 @@ int s_time_main(int argc, char **argv)
     SSL *scon = NULL;
     SSL_CTX *ctx = NULL;
     const SSL_METHOD *meth = NULL;
+    int verify = SSL_VERIFY_PEER;
     char *CApath = NULL, *CAfile = NULL, *CAstore = NULL;
     char *cipher = NULL, *ciphersuites = NULL;
     char *www_path = NULL;
@@ -157,6 +158,7 @@ int s_time_main(int argc, char **argv)
             verify_args.depth = opt_int_arg();
             BIO_printf(bio_err, "%s: verify depth is %d\n",
                        prog, verify_args.depth);
+            verify_args.return_error = 1;
             break;
         case OPT_CERT:
             certfile = opt_arg();
@@ -240,9 +242,10 @@ int s_time_main(int argc, char **argv)
     if (cipher == NULL)
         cipher = getenv("SSL_CIPHER");
 
-    if ((ctx = SSL_CTX_new(meth)) == NULL)
+    if ((ctx = SSL_CTX_new(meth)) == NULL) {
         goto end;
-
+    }
+    SSL_CTX_set_verify(ctx, verify, verify_callback);
     SSL_CTX_set_quiet_shutdown(ctx, 1);
     if (SSL_CTX_set_min_proto_version(ctx, min_version) == 0)
         goto end;


### PR DESCRIPTION

This PR is an initial attempt to resolve two problems reported in issue #27869:

1. **Callback never called**   Adds `SSL_CTX_set_verify(ctx, verify, verify_callback);` immediately after `SSL_CTX_new()` in `apps/s_time.c` so that the `verify_callback` is actually invoked.

2. **-verify doesn’t abort on failure**   Sets `verify_args.return_error = 1` in the `case OPT_VERIFY` block, ensuring that `s_time -verify` exits with a non-zero code when certificate validation fails.

> **Note:** this is a first attempt—any feedback or adjustments are welcome!

Closes #27869

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
