### PR TITLE
speed: Increase MAX_SIG_NUM and fix its usage in loopargs_t fields

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -507,7 +507,7 @@ static size_t kems_algs_len = 0;
 static char *kems_algname[MAX_KEM_NUM] = { NULL };
 static double kems_results[MAX_KEM_NUM][3];  /* keygen, encaps, decaps */
 
-#define MAX_SIG_NUM 111
+#define MAX_SIG_NUM 256
 static size_t sigs_algs_len = 0;
 static char *sigs_algname[MAX_SIG_NUM] = { NULL };
 static double sigs_results[MAX_SIG_NUM][3];  /* keygen, sign, verify */
@@ -573,12 +573,12 @@ typedef struct loopargs_st {
     unsigned char *kem_out[MAX_KEM_NUM];
     unsigned char *kem_send_secret[MAX_KEM_NUM];
     unsigned char *kem_rcv_secret[MAX_KEM_NUM];
-    EVP_PKEY_CTX *sig_gen_ctx[MAX_KEM_NUM];
-    EVP_PKEY_CTX *sig_sign_ctx[MAX_KEM_NUM];
-    EVP_PKEY_CTX *sig_verify_ctx[MAX_KEM_NUM];
-    size_t sig_max_sig_len[MAX_KEM_NUM];
-    size_t sig_act_sig_len[MAX_KEM_NUM];
-    unsigned char *sig_sig[MAX_KEM_NUM];
+    EVP_PKEY_CTX *sig_gen_ctx[MAX_SIG_NUM];
+    EVP_PKEY_CTX *sig_sign_ctx[MAX_SIG_NUM];
+    EVP_PKEY_CTX *sig_verify_ctx[MAX_SIG_NUM];
+    size_t sig_max_sig_len[MAX_SIG_NUM];
+    size_t sig_act_sig_len[MAX_SIG_NUM];
+    unsigned char *sig_sig[MAX_SIG_NUM];
 } loopargs_t;
 static int run_benchmark(int async_jobs, int (*loop_function) (void *),
                          loopargs_t *loopargs);


### PR DESCRIPTION
Increase the maximum number of signature algorithms.

With the introduction of the SignMessage and VerifyMessage API with OpenSSL 3.4 the providers that support combined digest and sign algorithms register quite a lot more signature algorithms, so the current limit of 111 is hit easily.

While at it correct the definitions of the signature fields within the loopargs_t structure to use MAX_SIG_NUM instead of MAX_KEM_NUM.

Closes: https://github.com/openssl/openssl/issues/27873
