### PR TITLE
fix: verification options in s_client and s_time behave unexpectedly

### DIFF
--- a/doc/man1/openssl-s_time.pod.in
+++ b/doc/man1/openssl-s_time.pod.in
@@ -16,6 +16,7 @@ B<openssl> B<s_time>
 [B<-reuse>]
 [B<-new>]
 [B<-verify> I<depth>]
+[B<-verify_return_error>]
 [B<-time> I<seconds>]
 [B<-ssl3>]
 [B<-tls1>]
@@ -73,9 +74,16 @@ be used. The file is in PEM format.
 
 The verify depth to use. This specifies the maximum length of the
 server certificate chain and turns on server certificate verification.
-Currently the verify operation continues after errors so all the problems
+Unless the B<-verify_return_error> option is given,
+the verify operation continues after errors so all the problems
 with a certificate chain can be seen. As a side effect the connection
 will never fail due to a server certificate verify failure.
+
+=item B<-verify_return_error>
+
+Turns on server certificate verification, like with B<-verify>,
+but returns verification errors instead of continuing.
+This will typically abort the handshake with a fatal error.
 
 =item B<-new>
 
@@ -171,9 +179,6 @@ on the command line is no guarantee that the certificate works.
 Because this program does not have all the options of the
 L<openssl-s_client(1)> program to turn protocols on and off, you may not
 be able to measure the performance of all protocols with all servers.
-
-The B<-verify> option should really exit if the server verification
-fails.
 
 =head1 HISTORY
 


### PR DESCRIPTION

Updates `s_client` and `s_time` so that the certificate validation options work as described in the docs:

-if `SSL_VERIFY_NONE` is set, then verify the whole chain, displaying an error if it’s too long, don't stop the handshake
-if `SSL_VERIFY_PEER` is set, then verify the chain up to the specified depth and exit the handshake with an error if the root wasn’t reached

Fixes #27869 
Fixes #27877

- [x] documentation is added or updated