### PR TITLE
Generated OSSL_PARAM name parsers can now return an error

### DIFF
--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.c.in
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.c.in
@@ -113,7 +113,8 @@ static int chacha20_poly1305_get_ctx_params(void *vctx, OSSL_PARAM params[])
     PROV_CHACHA20_POLY1305_CTX *ctx = (PROV_CHACHA20_POLY1305_CTX *)vctx;
     struct chacha20_poly1305_get_ctx_params_st p;
 
-    p = chacha20_poly1305_get_ctx_params_decoder(params);
+    if (ctx == NULL || !chacha20_poly1305_get_ctx_params_decoder(params, &p))
+        return 0;
 
     if (p.ivlen != NULL
             && !OSSL_PARAM_set_size_t(p.ivlen, CHACHA20_POLY1305_IVLEN)) {
@@ -187,10 +188,8 @@ static int chacha20_poly1305_set_ctx_params(void *vctx,
         (PROV_CIPHER_HW_CHACHA20_POLY1305 *)ctx->base.hw;
     struct chacha20_poly1305_set_ctx_params_st p;
 
-    if (ossl_param_is_empty(params))
-        return 1;
-
-    p = chacha20_poly1305_set_ctx_params_decoder(params);
+    if (ctx == NULL || !chacha20_poly1305_set_ctx_params_decoder(params, &p))
+        return 0;
 
 
     if (p.keylen != NULL) {

--- a/providers/implementations/ciphers/ciphercommon.c.in
+++ b/providers/implementations/ciphers/ciphercommon.c.in
@@ -52,7 +52,8 @@ int ossl_cipher_generic_get_params(OSSL_PARAM params[], unsigned int md,
 {
     struct ossl_cipher_generic_get_params_st p;
 
-    p = ossl_cipher_generic_get_params_decoder(params);
+    if (!ossl_cipher_generic_get_params_decoder(params, &p))
+        return 0;
 
     if (p.mode != NULL && !OSSL_PARAM_set_uint(p.mode, md)) {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
@@ -162,11 +163,9 @@ int ossl_cipher_var_keylen_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     PROV_CIPHER_CTX *ctx = (PROV_CIPHER_CTX *)vctx;
     struct ossl_cipher_set_ctx_param_list_st p;
 
-    if (ossl_param_is_empty(params))
-        return 1;
-
-    p = cipher_var_keylen_set_ctx_params_decoder(params);
-    if (!ossl_cipher_common_set_ctx_params(ctx, &p))
+    if (ctx == NULL
+            || !cipher_var_keylen_set_ctx_params_decoder(params, &p)
+            || !ossl_cipher_common_set_ctx_params(ctx, &p))
         return 0;
 
     if (p.keylen != NULL) {
@@ -649,7 +648,8 @@ int ossl_cipher_generic_get_ctx_params(void *vctx, OSSL_PARAM params[])
     PROV_CIPHER_CTX *ctx = (PROV_CIPHER_CTX *)vctx;
     struct ossl_cipher_get_ctx_param_list_st p;
 
-    p = cipher_generic_get_ctx_params_decoder(params);
+    if (ctx == NULL || !cipher_generic_get_ctx_params_decoder(params, &p))
+        return 0;
     return ossl_cipher_common_get_ctx_params(ctx, &p);
 }
 
@@ -710,7 +710,8 @@ int ossl_cipher_generic_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     if (ossl_param_is_empty(params))
         return 1;
 
-    p = cipher_generic_set_ctx_params_decoder(params);
+    if (ctx == NULL || !cipher_generic_set_ctx_params_decoder(params, &p))
+        return 0;
     return ossl_cipher_common_set_ctx_params(ctx, &p);
 }
 

--- a/providers/implementations/ciphers/ciphercommon_ccm.c.in
+++ b/providers/implementations/ciphers/ciphercommon_ccm.c.in
@@ -89,10 +89,8 @@ int ossl_ccm_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     size_t sz, ivlen;
     struct ossl_cipher_ccm_set_ctx_params_st p;
 
-    if (ossl_param_is_empty(params))
-        return 1;
-
-    p = ossl_cipher_ccm_set_ctx_params_decoder(params);
+    if (ctx == NULL || !ossl_cipher_ccm_set_ctx_params_decoder(params, &p))
+        return 0;
 
     if (p.tag != NULL) {
         if (p.tag->data_type != OSSL_PARAM_OCTET_STRING) {
@@ -179,7 +177,8 @@ int ossl_ccm_get_ctx_params(void *vctx, OSSL_PARAM params[])
     PROV_CCM_CTX *ctx = (PROV_CCM_CTX *)vctx;
     struct ossl_cipher_ccm_get_ctx_params_st p;
 
-    p = ossl_cipher_ccm_get_ctx_params_decoder(params);
+    if (ctx == NULL || !ossl_cipher_ccm_get_ctx_params_decoder(params, &p))
+        return 0;
 
     if (p.ivlen != NULL && !OSSL_PARAM_set_size_t(p.ivlen, ccm_get_ivlen(ctx))) {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);

--- a/providers/implementations/ciphers/ciphercommon_gcm.c.in
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c.in
@@ -168,7 +168,8 @@ int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
     size_t sz;
     struct ossl_cipher_gcm_get_ctx_params_st p;
 
-    p = ossl_cipher_gcm_get_ctx_params_decoder(params);
+    if (ctx == NULL || !ossl_cipher_gcm_get_ctx_params_decoder(params, &p))
+        return 0;
 
     if (p.ivlen != NULL && !OSSL_PARAM_set_size_t(p.ivlen, ctx->ivlen)) {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
@@ -271,10 +272,8 @@ int ossl_gcm_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     void *vp;
     struct ossl_cipher_gcm_set_ctx_params_st p;
 
-    if (ossl_param_is_empty(params))
-        return 1;
-
-    p = ossl_cipher_gcm_set_ctx_params_decoder(params);
+    if (ctx == NULL || !ossl_cipher_gcm_set_ctx_params_decoder(params, &p))
+        return 0;
 
     if (p.tag != NULL) {
         vp = ctx->buf;

--- a/providers/implementations/digests/digestcommon.c.in
+++ b/providers/implementations/digests/digestcommon.c.in
@@ -28,7 +28,8 @@ int ossl_digest_default_get_params(OSSL_PARAM params[], size_t blksz,
 {
     struct digest_default_get_params_st p;
 
-    p = digest_default_get_params_decoder(params);
+    if (!digest_default_get_params_decoder(params, &p))
+        return 0;
 
     if (p.bsize != NULL && !OSSL_PARAM_set_size_t(p.bsize, blksz)) {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);

--- a/providers/implementations/keymgmt/ml_dsa_kmgmt.c.in
+++ b/providers/implementations/keymgmt/ml_dsa_kmgmt.c.in
@@ -203,7 +203,10 @@ static int ml_dsa_key_fromdata(ML_DSA_KEY *key, const OSSL_PARAM params[],
     const ML_DSA_PARAMS *key_params = ossl_ml_dsa_key_params(key);
     const uint8_t *pk = NULL, *sk = NULL, *seed = NULL;
     size_t pk_len = 0, sk_len = 0, seed_len = 0;
-    struct ml_dsa_key_type_params_st p = ml_dsa_key_type_params_decoder(params);
+    struct ml_dsa_key_type_params_st p;
+
+    if (key == NULL || !ml_dsa_key_type_params_decoder(params, &p))
+        return 0;
 
     if (p.pubkey != NULL) {
         if (!OSSL_PARAM_get_octet_string_ptr(p.pubkey, (const void **)&pk, &pk_len))
@@ -317,7 +320,10 @@ static int ml_dsa_get_params(void *keydata, OSSL_PARAM params[])
     ML_DSA_KEY *key = keydata;
     const uint8_t *d;
     size_t len;
-    struct ml_dsa_get_params_st p = ml_dsa_get_params_decoder(params);
+    struct ml_dsa_get_params_st p;
+
+    if (key == NULL || !ml_dsa_get_params_decoder(params, &p))
+        return 0;
 
     if (p.bits != NULL
             && !OSSL_PARAM_set_int(p.bits, 8 * ossl_ml_dsa_key_get_pub_len(key)))
@@ -512,12 +518,8 @@ static int ml_dsa_gen_set_params(void *genctx, const OSSL_PARAM params[])
     struct ml_dsa_gen_ctx *gctx = genctx;
     struct ml_dsa_gen_set_params_st p;
 
-    if (gctx == NULL)
+    if (gctx == NULL || !ml_dsa_gen_set_params_decoder(params, &p))
         return 0;
-    if (ossl_param_is_empty(params))
-        return 1;
-
-    p = ml_dsa_gen_set_params_decoder(params);
 
     if (p.seed != NULL) {
         void *vp = gctx->entropy;

--- a/providers/implementations/keymgmt/ml_kem_kmgmt.c.in
+++ b/providers/implementations/keymgmt/ml_kem_kmgmt.c.in
@@ -386,10 +386,11 @@ static int ml_kem_key_fromdata(ML_KEM_KEY *key,
     struct ml_kem_key_type_params_st p;
 
     /* Invalid attempt to mutate a key, what is the right error to report? */
-    if (key == NULL || ossl_ml_kem_have_pubkey(key))
+    if (key == NULL
+            || ossl_ml_kem_have_pubkey(key)
+            || !ml_kem_key_type_params_decoder(params, &p))
         return 0;
     v = ossl_ml_kem_key_vinfo(key);
-    p = ml_kem_key_type_params_decoder(params);
 
     /*
      * When a private key is provided, without a seed, any public key also
@@ -570,7 +571,10 @@ static int ml_kem_get_params(void *vkey, OSSL_PARAM params[])
 {
     ML_KEM_KEY *key = vkey;
     const ML_KEM_VINFO *v = ossl_ml_kem_key_vinfo(key);
-    struct ml_kem_get_params_st p = ml_kem_get_params_decoder(params);
+    struct ml_kem_get_params_st p;
+
+    if (key == NULL || !ml_kem_get_params_decoder(params, &p))
+        return 0;
 
     if (p.bits != NULL && !OSSL_PARAM_set_int(p.bits, v->bits))
         return 0;
@@ -630,10 +634,8 @@ static int ml_kem_set_params(void *vkey, const OSSL_PARAM params[])
     size_t publen = 0;
     struct ml_kem_set_params_st p;
 
-    if (ossl_param_is_empty(params))
-        return 1;
-
-    p = ml_kem_set_params_decoder(params);
+    if (key == NULL || !ml_kem_set_params_decoder(params, &p))
+        return 0;
 
     /* Used in TLS via EVP_PKEY_set1_encoded_public_key(). */
     if (p.pub != NULL
@@ -667,12 +669,8 @@ static int ml_kem_gen_set_params(void *vgctx, const OSSL_PARAM params[])
     PROV_ML_KEM_GEN_CTX *gctx = vgctx;
     struct ml_kem_gen_set_params_st p;
 
-    if (gctx == NULL)
+    if (gctx == NULL || !ml_kem_gen_set_params_decoder(params, &p))
         return 0;
-    if (ossl_param_is_empty(params))
-        return 1;
-
-    p = ml_kem_gen_set_params_decoder(params);
 
     if (p.propq != NULL) {
         if (p.propq->data_type != OSSL_PARAM_UTF8_STRING)

--- a/providers/implementations/keymgmt/mlx_kmgmt.c.in
+++ b/providers/implementations/keymgmt/mlx_kmgmt.c.in
@@ -171,14 +171,14 @@ static int export_sub_cb(const OSSL_PARAM *params, void *varg)
     struct ml_kem_import_export_st p;
     size_t len;
 
+    if (!ml_kem_import_export_decoder(params, &p))
+        return 0;
+
     /*
      * The caller will decide whether anything essential is missing, but, if
      * some key material was returned, it should have the right (parameter)
      * data type and length.
      */
-    if (ossl_param_is_empty(params))
-        return 1;
-    p = ml_kem_import_export_decoder(params);
     if (sub_arg->pubenc != NULL && p.pubkey != NULL) {
         void *pub = sub_arg->pubenc + sub_arg->puboff;
 
@@ -423,7 +423,8 @@ static int mlx_kem_key_fromdata(MLX_KEY *key,
     pubkey_bytes = key->minfo->pubkey_bytes + key->xinfo->pubkey_bytes;
     prvkey_bytes = key->minfo->prvkey_bytes + key->xinfo->prvkey_bytes;
 
-    p = ml_kem_import_export_decoder(params);
+    if (!ml_kem_import_export_decoder(params, &p))
+        return 0;
 
     /* What does the caller want to set? */
     if (p.pubkey != NULL &&
@@ -499,7 +500,8 @@ static int mlx_kem_get_params(void *vkey, OSSL_PARAM params[])
     size_t publen = key->minfo->pubkey_bytes + key->xinfo->pubkey_bytes;
     size_t prvlen = key->minfo->prvkey_bytes + key->xinfo->prvkey_bytes;
 
-    p = mlx_get_params_decoder(params);
+    if (key == NULL || !mlx_get_params_decoder(params, &p))
+        return 0;
 
     /* The reported "bit" count is those of the ML-KEM key */
     if (p.bits != NULL)
@@ -595,10 +597,8 @@ static int mlx_kem_set_params(void *vkey, const OSSL_PARAM params[])
     const void *pubenc = NULL;
     size_t publen = 0;
 
-    if (ossl_param_is_empty(params))
-        return 1;
-
-    p = mlx_set_params_decoder(params);
+    if (key == NULL || !mlx_set_params_decoder(params, &p))
+        return 0;
 
     if (p.propq != NULL) {
         OPENSSL_free(key->propq);
@@ -638,12 +638,8 @@ static int mlx_kem_gen_set_params(void *vgctx, const OSSL_PARAM params[])
     PROV_ML_KEM_GEN_CTX *gctx = vgctx;
     struct mlx_gen_set_params_st p;
 
-    if (gctx == NULL)
+    if (gctx == NULL || !mlx_gen_set_params_decoder(params, &p))
         return 0;
-    if (ossl_param_is_empty(params))
-        return 1;
-
-    p = mlx_gen_set_params_decoder(params);
 
     if (p.propq != NULL) {
         if (p.propq->data_type != OSSL_PARAM_UTF8_STRING)

--- a/providers/implementations/signature/eddsa_sig.c.in
+++ b/providers/implementations/signature/eddsa_sig.c.in
@@ -801,10 +801,8 @@ static int eddsa_get_ctx_params(void *vpeddsactx, OSSL_PARAM *params)
     PROV_EDDSA_CTX *peddsactx = (PROV_EDDSA_CTX *)vpeddsactx;
     struct eddsa_get_ctx_params_st p;
 
-    if (peddsactx == NULL)
+    if (peddsactx == NULL || !eddsa_get_ctx_params_decoder(params, &p))
         return 0;
-
-    p = eddsa_get_ctx_params_decoder(params);
 
     if (p.id != NULL
         && !OSSL_PARAM_set_octet_string(p.id,
@@ -899,12 +897,8 @@ static int eddsa_set_ctx_params(void *vpeddsactx, const OSSL_PARAM params[])
     PROV_EDDSA_CTX *peddsactx = (PROV_EDDSA_CTX *)vpeddsactx;
     struct eddsa_set_ctx_params_st p;
 
-    if (peddsactx == NULL)
+    if (peddsactx == NULL || !eddsa_set_ctx_params_decoder(params, &p))
         return 0;
-    if (ossl_param_is_empty(params))
-        return 1;
-
-    p = eddsa_set_ctx_params_decoder(params);
     return eddsa_set_ctx_params_internal(peddsactx, &p);
 }
 
@@ -926,12 +920,8 @@ static int eddsa_set_variant_ctx_params(void *vpeddsactx,
     PROV_EDDSA_CTX *peddsactx = (PROV_EDDSA_CTX *)vpeddsactx;
     struct eddsa_set_ctx_params_st p;
 
-    if (peddsactx == NULL)
+    if (peddsactx == NULL || !eddsa_set_variant_ctx_params_decoder(params, &p))
         return 0;
-    if (ossl_param_is_empty(params))
-        return 1;
-
-    p = eddsa_set_variant_ctx_params_decoder(params);
     return eddsa_set_ctx_params_internal(peddsactx, &p);
 }
 

--- a/providers/implementations/signature/ml_dsa_sig.c.in
+++ b/providers/implementations/signature/ml_dsa_sig.c.in
@@ -390,12 +390,8 @@ static int ml_dsa_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     PROV_ML_DSA_CTX *pctx = (PROV_ML_DSA_CTX *)vctx;
     struct ml_dsa_verifymsg_set_ctx_params_st p;
 
-    if (pctx == NULL)
+    if (pctx == NULL || !ml_dsa_verifymsg_set_ctx_params_decoder(params, &p))
         return 0;
-    if (ossl_param_is_empty(params))
-        return 1;
-
-    p = ml_dsa_verifymsg_set_ctx_params_decoder(params);
 
     if (p.ctx != NULL) {
         void *vp = pctx->context_string;
@@ -468,10 +464,8 @@ static int ml_dsa_get_ctx_params(void *vctx, OSSL_PARAM *params)
     PROV_ML_DSA_CTX *ctx = (PROV_ML_DSA_CTX *)vctx;
     struct ml_dsa_get_ctx_params_st p;
 
-    if (ctx == NULL)
+    if (ctx == NULL || !ml_dsa_get_ctx_params_decoder(params, &p))
         return 0;
-
-    p = ml_dsa_get_ctx_params_decoder(params);
 
     if (p.id != NULL
         && !OSSL_PARAM_set_octet_string(p.id,


### PR DESCRIPTION

As noted in #27859, better argument checking when processing parameters was desirable.
This adds checking to the generated param parsing code.

The case where a populated but empty OSSL_PARAM array is passed is handled correctly, although there is no short-circuit return anymore.  Rather, the structure is returned without any parameter pointers being set.
