### PR TITLE
apps/lib/apps.c: Add check for BIO_new()

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -3057,7 +3057,7 @@ BIO *dup_bio_out(int format)
     if (FMT_istext(format)) {
         btmp = BIO_new(BIO_f_linebuffer());
         if (btmp == NULL) {
-            BIO_free_all(b);
+            BIO_free(b);
             return NULL;
         }
         b = BIO_push(btmp, b);
@@ -3088,7 +3088,7 @@ BIO *dup_bio_err(int format)
         BIO *btmp = BIO_new(BIO_f_linebuffer());
 
         if (btmp == NULL) {
-            BIO_free_all(b);
+            BIO_free(b);
             return NULL;
         }
         b = BIO_push(btmp, b);


### PR DESCRIPTION
Add checks for the return value of BIO_new() to guarantee successful allocation, consistent with other usages.

Fixes: a412b89198 ("dup_bio_* and bio_open_* are utility functions and belong in apps.c")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
