### PR TITLE
demos/cms/cms_ddec.c: Replace "in" with "dcont" to correctly check th…

### DIFF
--- a/demos/cms/cms_ddec.c
+++ b/demos/cms/cms_ddec.c
@@ -58,7 +58,7 @@ int main(int argc, char **argv)
     /* Open file containing detached content */
     dcont = BIO_new_file("smencr.out", "rb");
 
-    if (!in)
+    if (dcont == NULL)
         goto err;
 
     out = BIO_new_file("encrout.txt", "w");


### PR DESCRIPTION
…e success of BIO_new_file()

Replace "in" with "dcont" to properly check the return value of BIO_new_file().

Fixes: 1728756255 ("Detached encrypt/decrypt example, fix decrypt sample.")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
