### PR TITLE
test/bio_pw_callback_test.c: Add BIO_free() to avoid memory leak

### DIFF
--- a/test/bio_pw_callback_test.c
+++ b/test/bio_pw_callback_test.c
@@ -372,8 +372,10 @@ int setup_tests(void)
     if (!TEST_ptr(bio = BIO_new_file(key_file, "r")))
         return 0;
     if (!TEST_ptr(PEM_read_bio_PrivateKey(bio, &original_pkey,
-                                          callback_original_pw, NULL)))
+                                          callback_original_pw, NULL))) {
+        BIO_free(bio);
         return 0;
+    }
     BIO_free(bio);
 
     /* add all tests */


### PR DESCRIPTION
Add BIO_free() if PEM_read_bio_PrivateKey fails to avoid memory leak.

Fixes: fa6ae88a47 ("Add test for BIO password callback functionality")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
