### PR TITLE
crypto/slh_dsa/slh_hash.c: Add check for EVP_MD_get_size()

### DIFF
--- a/crypto/slh_dsa/slh_hash.c
+++ b/crypto/slh_dsa/slh_hash.c
@@ -158,6 +158,9 @@ slh_hmsg_sha2(SLH_DSA_HASH_CTX *hctx, const uint8_t *r, const uint8_t *pk_seed,
     int sz = EVP_MD_get_size(hctx->key->md_big);
     size_t seed_len = (size_t)sz + 2 * n;
 
+    if (sz <= 0)
+        return 0;
+
     memcpy(seed, r, n);
     memcpy(seed + n, pk_seed, n);
     return digest_4(hctx->md_big_ctx, r, n, pk_seed, n, pk_root, n, msg, msg_len,


### PR DESCRIPTION
Add the check for the return value of EVP_MD_get_size() to avoid invalid size.

Fixes: 2f9e152d86 ("Add SLH_DSA signature verification.")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
