### PR TITLE
LoongArch: Add SHA-2 assembly implementation for better performance

### DIFF
--- a/crypto/sha/asm/sha256-loongarch64.pl
+++ b/crypto/sha/asm/sha256-loongarch64.pl
@@ -1,0 +1,360 @@
+#! /usr/bin/env perl
+# This file is dual-licensed, meaning that you can use it under your
+# choice of either of the following two licenses:
+#
+# Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License"). You can obtain
+# a copy in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+#
+# or
+#
+# Copyright (c) 2025, Julian Zhu <jz531210@gmail.com>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+use warnings;
+
+# $output is the last argument if it looks like a file (it has an extension)
+# $flavour is the first argument if it doesn't look like a file
+my $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
+my $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
+
+$output and open STDOUT,">$output";
+
+my $code=<<___;
+.text
+___
+
+my $K256 = "K256";
+
+# Function arguments
+my ($zero,$ra,$tp,$sp,$fp)=map("\$r$_",(0..3,22));
+my ($a0,$a1,$a2,$a3,$a4,$a5,$a6,$a7)=map("\$r$_",(4..11));
+my ($t0,$t1,$t2,$t3,$t4,$t5,$t6,$t7,$t8,$x)=map("\$r$_",(12..21));
+my ($s0,$s1,$s2,$s3,$s4,$s5,$s6,$s7,$s8)=map("\$r$_",(23..31));
+
+my ($INP, $LEN, $ADDR) = ($a1, $a2, $sp);
+my ($KT, $T1, $T2, $T3, $T4, $T5, $T6) = ($t0, $t1, $t2, $t3, $t4, $t5, $t6);
+my ($A, $B, $C, $D ,$E ,$F ,$G ,$H) = ($s0, $s1, $s2, $s3, $s4, $s5, $s6, $s7);
+
+sub MSGSCHEDULE0 {
+    my ($index) = @_;
+    my $code=<<___;
+    ld.w $T1, $INP, 4*$index
+    revb.2w $T1, $T1
+    st.w $T1, $ADDR, 4*$index
+___
+    return $code;
+}
+
+sub MSGSCHEDULE1 {
+    my ($index) = @_;
+    my $code=<<___;
+    ld.w $T1, $ADDR, (($index-2)&0x0f)*4
+    ld.w $T2, $ADDR, (($index-15)&0x0f)*4
+    ld.w $T3, $ADDR, (($index-7)&0x0f)*4
+    ld.w $T4, $ADDR, ($index&0x0f)*4
+    rotri.w $T5, $T1, 17
+    rotri.w $T6, $T1, 19
+    srli.w $T1, $T1, 10
+    xor $T1, $T1, $T5
+    xor $T1, $T1, $T6
+    add.w $T1, $T1, $T3
+    rotri.w $T5, $T2, 7
+    rotri.w $T6, $T2, 18
+    srli.w $T2, $T2, 3
+    xor $T2, $T2, $T5
+    xor $T2, $T2, $T6
+    add.w $T1, $T1, $T2
+    add.w $T1, $T1, $T4
+    st.w $T1, $ADDR, ($index&0x0f)*4
+___
+    return $code;
+}
+
+sub sha256_T1 {
+    my ($index, $e, $f, $g, $h) = @_;
+    my $code=<<___;
+    ld.w $T4, $KT, 4*$index
+    add.w $h, $h, $T1
+    add.w $h, $h, $T4
+    rotri.w $T2, $e, 6
+    rotri.w $T3, $e, 11
+    rotri.w $T4, $e, 25
+    xor $T2, $T2, $T3
+    xor $T1, $f, $g
+    xor $T2, $T2, $T4
+    and $T1, $T1, $e
+    add.w $h, $h, $T2
+    xor $T1, $T1, $g
+    add.w $T1, $T1, $h
+___
+    return $code;
+}
+
+sub sha256_T2 {
+    my ($a, $b, $c) = @_;
+    my $code=<<___;
+    rotri.w $T2, $a, 2
+    rotri.w $T3, $a, 13
+    rotri.w $T4, $a, 22
+    xor $T2, $T2, $T3
+    xor $T2, $T2, $T4
+    xor $T4, $b, $c
+    and $T3, $b, $c
+    and $T4, $T4, $a
+    xor $T4, $T4, $T3
+    add.w $T2, $T2, $T4
+___
+    return $code;
+}
+
+sub SHA256ROUND {
+    my ($index, $a, $b, $c, $d, $e, $f, $g, $h) = @_;
+    my $code=<<___;
+    @{[sha256_T1 $index, $e, $f, $g, $h]}
+    @{[sha256_T2 $a, $b, $c]}
+    add.w $d, $d, $T1
+    add.w $h, $T2, $T1
+___
+    return $code;
+}
+
+sub SHA256ROUND0 {
+    my ($index, $a, $b, $c, $d, $e, $f, $g, $h) = @_;
+    my $code=<<___;
+    @{[MSGSCHEDULE0 $index]}
+    @{[SHA256ROUND $index, $a, $b, $c, $d, $e, $f, $g, $h]}
+___
+    return $code;
+}
+
+sub SHA256ROUND1 {
+    my ($index, $a, $b, $c, $d, $e, $f, $g, $h) = @_;
+    my $code=<<___;
+    @{[MSGSCHEDULE1 $index]}
+    @{[SHA256ROUND $index, $a, $b, $c, $d, $e, $f, $g, $h]}
+___
+    return $code;
+}
+
+################################################################################
+# void sha256_block_data_order(void *c, const void *p, size_t len)
+$code .= <<___;
+.p2align 3
+.globl sha256_block_data_order
+.type   sha256_block_data_order,\@function
+sha256_block_data_order:
+
+    addi.d $sp, $sp, -80
+
+    st.d $s0, $sp, 0
+    st.d $s1, $sp, 8
+    st.d $s2, $sp, 16
+    st.d $s3, $sp, 24
+    st.d $s4, $sp, 32
+    st.d $s5, $sp, 40
+    st.d $s6, $sp, 48
+    st.d $s7, $sp, 56
+    st.d $s8, $sp, 64
+    st.d $fp, $sp, 72
+
+    addi.d $sp, $sp, -64
+
+    la $KT, $K256
+
+    # load ctx
+    ld.w $A, $a0, 0
+    ld.w $B, $a0, 4
+    ld.w $C, $a0, 8
+    ld.w $D, $a0, 12
+    ld.w $E, $a0, 16
+    ld.w $F, $a0, 20
+    ld.w $G, $a0, 24
+    ld.w $H, $a0, 28
+
+L_round_loop:
+    # Decrement length by 1
+    addi.d $LEN, $LEN, -1
+
+    @{[SHA256ROUND0 0, $A, $B, $C, $D, $E, $F, $G, $H]}
+    @{[SHA256ROUND0 1, $H, $A, $B, $C, $D, $E, $F, $G]}
+    @{[SHA256ROUND0 2, $G, $H, $A, $B, $C, $D, $E, $F]}
+    @{[SHA256ROUND0 3, $F, $G, $H, $A, $B, $C, $D, $E]}
+
+    @{[SHA256ROUND0 4, $E, $F, $G, $H, $A, $B, $C, $D]}
+    @{[SHA256ROUND0 5, $D, $E, $F, $G, $H, $A, $B, $C]}
+    @{[SHA256ROUND0 6, $C, $D, $E, $F, $G, $H, $A, $B]}
+    @{[SHA256ROUND0 7, $B, $C, $D, $E, $F, $G, $H, $A]}
+
+    @{[SHA256ROUND0 8, $A, $B, $C, $D, $E, $F, $G, $H]}
+    @{[SHA256ROUND0 9, $H, $A, $B, $C, $D, $E, $F, $G]}
+    @{[SHA256ROUND0 10, $G, $H, $A, $B, $C, $D, $E, $F]}
+    @{[SHA256ROUND0 11, $F, $G, $H, $A, $B, $C, $D, $E]}
+
+    @{[SHA256ROUND0 12, $E, $F, $G, $H, $A, $B, $C, $D]}
+    @{[SHA256ROUND0 13, $D, $E, $F, $G, $H, $A, $B, $C]}
+    @{[SHA256ROUND0 14, $C, $D, $E, $F, $G, $H, $A, $B]}
+    @{[SHA256ROUND0 15, $B, $C, $D, $E, $F, $G, $H, $A]}
+
+    @{[SHA256ROUND1 16, $A, $B, $C, $D, $E, $F, $G, $H]}
+    @{[SHA256ROUND1 17, $H, $A, $B, $C, $D, $E, $F, $G]}
+    @{[SHA256ROUND1 18, $G, $H, $A, $B, $C, $D, $E, $F]}
+    @{[SHA256ROUND1 19, $F, $G, $H, $A, $B, $C, $D, $E]}
+
+    @{[SHA256ROUND1 20, $E, $F, $G, $H, $A, $B, $C, $D]}
+    @{[SHA256ROUND1 21, $D, $E, $F, $G, $H, $A, $B, $C]}
+    @{[SHA256ROUND1 22, $C, $D, $E, $F, $G, $H, $A, $B]}
+    @{[SHA256ROUND1 23, $B, $C, $D, $E, $F, $G, $H, $A]}
+
+    @{[SHA256ROUND1 24, $A, $B, $C, $D, $E, $F, $G, $H]}
+    @{[SHA256ROUND1 25, $H, $A, $B, $C, $D, $E, $F, $G]}
+    @{[SHA256ROUND1 26, $G, $H, $A, $B, $C, $D, $E, $F]}
+    @{[SHA256ROUND1 27, $F, $G, $H, $A, $B, $C, $D, $E]}
+
+    @{[SHA256ROUND1 28, $E, $F, $G, $H, $A, $B, $C, $D]}
+    @{[SHA256ROUND1 29, $D, $E, $F, $G, $H, $A, $B, $C]}
+    @{[SHA256ROUND1 30, $C, $D, $E, $F, $G, $H, $A, $B]}
+    @{[SHA256ROUND1 31, $B, $C, $D, $E, $F, $G, $H, $A]}
+
+    @{[SHA256ROUND1 32, $A, $B, $C, $D, $E, $F, $G, $H]}
+    @{[SHA256ROUND1 33, $H, $A, $B, $C, $D, $E, $F, $G]}
+    @{[SHA256ROUND1 34, $G, $H, $A, $B, $C, $D, $E, $F]}
+    @{[SHA256ROUND1 35, $F, $G, $H, $A, $B, $C, $D, $E]}
+
+    @{[SHA256ROUND1 36, $E, $F, $G, $H, $A, $B, $C, $D]}
+    @{[SHA256ROUND1 37, $D, $E, $F, $G, $H, $A, $B, $C]}
+    @{[SHA256ROUND1 38, $C, $D, $E, $F, $G, $H, $A, $B]}
+    @{[SHA256ROUND1 39, $B, $C, $D, $E, $F, $G, $H, $A]}
+
+    @{[SHA256ROUND1 40, $A, $B, $C, $D, $E, $F, $G, $H]}
+    @{[SHA256ROUND1 41, $H, $A, $B, $C, $D, $E, $F, $G]}
+    @{[SHA256ROUND1 42, $G, $H, $A, $B, $C, $D, $E, $F]}
+    @{[SHA256ROUND1 43, $F, $G, $H, $A, $B, $C, $D, $E]}
+
+    @{[SHA256ROUND1 44, $E, $F, $G, $H, $A, $B, $C, $D]}
+    @{[SHA256ROUND1 45, $D, $E, $F, $G, $H, $A, $B, $C]}
+    @{[SHA256ROUND1 46, $C, $D, $E, $F, $G, $H, $A, $B]}
+    @{[SHA256ROUND1 47, $B, $C, $D, $E, $F, $G, $H, $A]}
+
+    @{[SHA256ROUND1 48, $A, $B, $C, $D, $E, $F, $G, $H]}
+    @{[SHA256ROUND1 49, $H, $A, $B, $C, $D, $E, $F, $G]}
+    @{[SHA256ROUND1 50, $G, $H, $A, $B, $C, $D, $E, $F]}
+    @{[SHA256ROUND1 51, $F, $G, $H, $A, $B, $C, $D, $E]}
+
+    @{[SHA256ROUND1 52, $E, $F, $G, $H, $A, $B, $C, $D]}
+    @{[SHA256ROUND1 53, $D, $E, $F, $G, $H, $A, $B, $C]}
+    @{[SHA256ROUND1 54, $C, $D, $E, $F, $G, $H, $A, $B]}
+    @{[SHA256ROUND1 55, $B, $C, $D, $E, $F, $G, $H, $A]}
+
+    @{[SHA256ROUND1 56, $A, $B, $C, $D, $E, $F, $G, $H]}
+    @{[SHA256ROUND1 57, $H, $A, $B, $C, $D, $E, $F, $G]}
+    @{[SHA256ROUND1 58, $G, $H, $A, $B, $C, $D, $E, $F]}
+    @{[SHA256ROUND1 59, $F, $G, $H, $A, $B, $C, $D, $E]}
+
+    @{[SHA256ROUND1 60, $E, $F, $G, $H, $A, $B, $C, $D]}
+    @{[SHA256ROUND1 61, $D, $E, $F, $G, $H, $A, $B, $C]}
+    @{[SHA256ROUND1 62, $C, $D, $E, $F, $G, $H, $A, $B]}
+    @{[SHA256ROUND1 63, $B, $C, $D, $E, $F, $G, $H, $A]}
+
+    ld.w $T1, $a0, 0
+    ld.w $T2, $a0, 4
+    ld.w $T3, $a0, 8
+    ld.w $T4, $a0, 12
+
+    add.w $A, $A, $T1
+    add.w $B, $B, $T2
+    add.w $C, $C, $T3
+    add.w $D, $D, $T4
+
+    st.w $A, $a0, 0
+    st.w $B, $a0, 4
+    st.w $C, $a0, 8
+    st.w $D, $a0, 12
+
+    ld.w $T1, $a0, 16
+    ld.w $T2, $a0, 20
+    ld.w $T3, $a0, 24
+    ld.w $T4, $a0, 28
+
+    add.w $E, $E, $T1
+    add.w $F, $F, $T2
+    add.w $G, $G, $T3
+    add.w $H, $H, $T4
+
+    st.w $E, $a0, 16
+    st.w $F, $a0, 20
+    st.w $G, $a0, 24
+    st.w $H, $a0, 28
+
+    addi.d $INP, $INP, 64
+
+    bnez $LEN, L_round_loop
+
+    addi.d $sp, $sp, 64
+
+    ld.d $s0, $sp, 0
+    ld.d $s1, $sp, 8
+    ld.d $s2, $sp, 16
+    ld.d $s3, $sp, 24
+    ld.d $s4, $sp, 32
+    ld.d $s5, $sp, 40
+    ld.d $s6, $sp, 48
+    ld.d $s7, $sp, 56
+    ld.d $s8, $sp, 64
+    ld.d $fp, $sp, 72
+
+    addi.d $sp, $sp, 80
+
+    ret
+.size sha256_block_data_order,.-sha256_block_data_order
+
+.section .rodata
+.p2align 3
+.type $K256,\@object
+$K256:
+    .word 0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5
+    .word 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5
+    .word 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3
+    .word 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174
+    .word 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc
+    .word 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da
+    .word 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7
+    .word 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967
+    .word 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13
+    .word 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85
+    .word 0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3
+    .word 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070
+    .word 0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5
+    .word 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3
+    .word 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208
+    .word 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+.size $K256,.-$K256
+___
+
+print $code;
+
+close STDOUT or die "error closing STDOUT: $!";

--- a/crypto/sha/asm/sha512-loongarch64.pl
+++ b/crypto/sha/asm/sha512-loongarch64.pl
@@ -1,0 +1,405 @@
+#! /usr/bin/env perl
+# This file is dual-licensed, meaning that you can use it under your
+# choice of either of the following two licenses:
+#
+# Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License"). You can obtain
+# a copy in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+#
+# or
+#
+# Copyright (c) 2025, Julian Zhu <jz531210@gmail.com>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+use warnings;
+
+# $output is the last argument if it looks like a file (it has an extension)
+# $flavour is the first argument if it doesn't look like a file
+my $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
+my $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
+
+$output and open STDOUT,">$output";
+
+my $code=<<___;
+.text
+___
+
+my $K512 = "K512";
+
+# Function arguments
+
+my ($zero,$ra,$tp,$sp,$fp)=map("\$r$_",(0..3,22));
+my ($a0,$a1,$a2,$a3,$a4,$a5,$a6,$a7)=map("\$r$_",(4..11));
+my ($t0,$t1,$t2,$t3,$t4,$t5,$t6,$t7,$t8,$x)=map("\$r$_",(12..21));
+my ($s0,$s1,$s2,$s3,$s4,$s5,$s6,$s7,$s8)=map("\$r$_",(23..31));
+
+my ($INP, $LEN, $ADDR) = ($a1, $a2, $sp);
+my ($KT, $T1, $T2, $T3, $T4, $T5, $T6) = ($t0, $t1, $t2, $t3, $t4, $t5, $t6);
+my ($A, $B, $C, $D ,$E ,$F ,$G ,$H) = ($s0, $s1, $s2, $s3, $s4, $s5, $s6, $s7);
+
+sub MSGSCHEDULE0 {
+    my ($index) = @_;
+    my $code=<<___;
+    ld.d $T1, $INP, 8*$index
+    revb.d $T1, $T1
+    st.d $T1, $ADDR, 8*$index
+___
+    return $code;
+}
+
+sub MSGSCHEDULE1 {
+    my ($index) = @_;
+    my $code=<<___;
+    ld.d $T1, $ADDR, (($index-2)&0x0f)*8
+    ld.d $T2, $ADDR, (($index-15)&0x0f)*8
+    ld.d $T3, $ADDR, (($index-7)&0x0f)*8
+    ld.d $T4, $ADDR, ($index&0x0f)*8
+    rotri.d $T5, $T1, 19
+    rotri.d $T6, $T1, 61
+    srli.d $T1, $T1, 6
+    xor $T1, $T1, $T5
+    xor $T1, $T1, $T6
+    add.d $T1, $T1, $T3
+    rotri.d $T5, $T2, 1
+    rotri.d $T6, $T2, 8
+    srli.d $T2, $T2, 7
+    xor $T2, $T2, $T5
+    xor $T2, $T2, $T6
+    add.d $T1, $T1, $T2
+    add.d $T1, $T1, $T4
+    st.d $T1, $ADDR, 8*($index&0x0f)
+___
+    return $code;
+}
+
+sub sha512_T1 {
+    my ($index, $e, $f, $g, $h) = @_;
+    my $code=<<___;
+    ld.d $T4, $KT, 8*$index
+    add.d $h, $h, $T1
+    add.d $h, $h, $T4
+    rotri.d $T2, $e, 14
+    rotri.d $T3, $e, 18
+    rotri.d $T4, $e, 41
+    xor $T2, $T2, $T3
+    xor $T1, $f, $g
+    xor $T2, $T2, $T4
+    and $T1, $T1, $e
+    add.d $h, $h, $T2
+    xor $T1, $T1, $g
+    add.d $T1, $T1, $h
+___
+    return $code;
+}
+
+sub sha512_T2 {
+    my ($a, $b, $c) = @_;
+    my $code=<<___;
+    rotri.d $T2, $a, 28
+    rotri.d $T3, $a, 34
+    rotri.d $T4, $a, 39
+    xor $T2, $T2, $T3
+    xor $T5, $b, $c
+    and $T3, $b, $c
+    and $T5, $T5, $a
+    xor $T2, $T2, $T4
+    xor $T3, $T3, $T5
+    add.d $T2, $T2, $T3
+___
+    return $code;
+}
+
+sub SHA512ROUND {
+    my ($index, $a, $b, $c, $d, $e, $f, $g, $h) = @_;
+    my $code=<<___;
+    @{[sha512_T1 $index, $e, $f, $g, $h]}
+    @{[sha512_T2 $a, $b, $c]}
+    add.d $d, $d, $T1
+    add.d $h, $T2, $T1
+___
+    return $code;
+}
+
+sub SHA512ROUND0 {
+    my ($index, $a, $b, $c, $d, $e, $f, $g, $h) = @_;
+    my $code=<<___;
+    @{[MSGSCHEDULE0 $index]}
+    @{[SHA512ROUND $index, $a, $b, $c, $d, $e, $f, $g, $h]}
+___
+    return $code;
+}
+
+sub SHA512ROUND1 {
+    my ($index, $a, $b, $c, $d, $e, $f, $g, $h) = @_;
+    my $code=<<___;
+    @{[MSGSCHEDULE1 $index]}
+    @{[SHA512ROUND $index, $a, $b, $c, $d, $e, $f, $g, $h]}
+___
+    return $code;
+}
+
+################################################################################
+# void sha512_block_data_order(void *c, const void *p, size_t len)
+$code .= <<___;
+.p2align 3
+.globl sha512_block_data_order
+.type   sha512_block_data_order,\@function
+sha512_block_data_order:
+
+    addi.d $sp, $sp, -80
+
+    st.d $s0, $sp, 0
+    st.d $s1, $sp, 8
+    st.d $s2, $sp, 16
+    st.d $s3, $sp, 24
+    st.d $s4, $sp, 32
+    st.d $s5, $sp, 40
+    st.d $s6, $sp, 48
+    st.d $s7, $sp, 56
+    st.d $s8, $sp, 64
+    st.d $fp, $sp, 72
+
+    addi.d $sp, $sp, -128
+
+    la $KT, $K512
+
+    # load ctx
+    ld.d $A, $a0, 0
+    ld.d $B, $a0, 8
+    ld.d $C, $a0, 16
+    ld.d $D, $a0, 24
+    ld.d $E, $a0, 32
+    ld.d $F, $a0, 40
+    ld.d $G, $a0, 48
+    ld.d $H, $a0, 56
+
+L_round_loop:
+    # Decrement length by 1
+    addi.d $LEN, $LEN, -1
+
+    @{[SHA512ROUND0 0, $A, $B, $C, $D, $E, $F, $G, $H]}
+    @{[SHA512ROUND0 1, $H, $A, $B, $C, $D, $E, $F, $G]}
+    @{[SHA512ROUND0 2, $G, $H, $A, $B, $C, $D, $E, $F]}
+    @{[SHA512ROUND0 3, $F, $G, $H, $A, $B, $C, $D, $E]}
+
+    @{[SHA512ROUND0 4, $E, $F, $G, $H, $A, $B, $C, $D]}
+    @{[SHA512ROUND0 5, $D, $E, $F, $G, $H, $A, $B, $C]}
+    @{[SHA512ROUND0 6, $C, $D, $E, $F, $G, $H, $A, $B]}
+    @{[SHA512ROUND0 7, $B, $C, $D, $E, $F, $G, $H, $A]}
+
+    @{[SHA512ROUND0 8, $A, $B, $C, $D, $E, $F, $G, $H]}
+    @{[SHA512ROUND0 9, $H, $A, $B, $C, $D, $E, $F, $G]}
+    @{[SHA512ROUND0 10, $G, $H, $A, $B, $C, $D, $E, $F]}
+    @{[SHA512ROUND0 11, $F, $G, $H, $A, $B, $C, $D, $E]}
+
+    @{[SHA512ROUND0 12, $E, $F, $G, $H, $A, $B, $C, $D]}
+    @{[SHA512ROUND0 13, $D, $E, $F, $G, $H, $A, $B, $C]}
+    @{[SHA512ROUND0 14, $C, $D, $E, $F, $G, $H, $A, $B]}
+    @{[SHA512ROUND0 15, $B, $C, $D, $E, $F, $G, $H, $A]}
+
+    @{[SHA512ROUND1 16, $A, $B, $C, $D, $E, $F, $G, $H]}
+    @{[SHA512ROUND1 17, $H, $A, $B, $C, $D, $E, $F, $G]}
+    @{[SHA512ROUND1 18, $G, $H, $A, $B, $C, $D, $E, $F]}
+    @{[SHA512ROUND1 19, $F, $G, $H, $A, $B, $C, $D, $E]}
+
+    @{[SHA512ROUND1 20, $E, $F, $G, $H, $A, $B, $C, $D]}
+    @{[SHA512ROUND1 21, $D, $E, $F, $G, $H, $A, $B, $C]}
+    @{[SHA512ROUND1 22, $C, $D, $E, $F, $G, $H, $A, $B]}
+    @{[SHA512ROUND1 23, $B, $C, $D, $E, $F, $G, $H, $A]}
+
+    @{[SHA512ROUND1 24, $A, $B, $C, $D, $E, $F, $G, $H]}
+    @{[SHA512ROUND1 25, $H, $A, $B, $C, $D, $E, $F, $G]}
+    @{[SHA512ROUND1 26, $G, $H, $A, $B, $C, $D, $E, $F]}
+    @{[SHA512ROUND1 27, $F, $G, $H, $A, $B, $C, $D, $E]}
+
+    @{[SHA512ROUND1 28, $E, $F, $G, $H, $A, $B, $C, $D]}
+    @{[SHA512ROUND1 29, $D, $E, $F, $G, $H, $A, $B, $C]}
+    @{[SHA512ROUND1 30, $C, $D, $E, $F, $G, $H, $A, $B]}
+    @{[SHA512ROUND1 31, $B, $C, $D, $E, $F, $G, $H, $A]}
+
+    @{[SHA512ROUND1 32, $A, $B, $C, $D, $E, $F, $G, $H]}
+    @{[SHA512ROUND1 33, $H, $A, $B, $C, $D, $E, $F, $G]}
+    @{[SHA512ROUND1 34, $G, $H, $A, $B, $C, $D, $E, $F]}
+    @{[SHA512ROUND1 35, $F, $G, $H, $A, $B, $C, $D, $E]}
+
+    @{[SHA512ROUND1 36, $E, $F, $G, $H, $A, $B, $C, $D]}
+    @{[SHA512ROUND1 37, $D, $E, $F, $G, $H, $A, $B, $C]}
+    @{[SHA512ROUND1 38, $C, $D, $E, $F, $G, $H, $A, $B]}
+    @{[SHA512ROUND1 39, $B, $C, $D, $E, $F, $G, $H, $A]}
+
+    @{[SHA512ROUND1 40, $A, $B, $C, $D, $E, $F, $G, $H]}
+    @{[SHA512ROUND1 41, $H, $A, $B, $C, $D, $E, $F, $G]}
+    @{[SHA512ROUND1 42, $G, $H, $A, $B, $C, $D, $E, $F]}
+    @{[SHA512ROUND1 43, $F, $G, $H, $A, $B, $C, $D, $E]}
+
+    @{[SHA512ROUND1 44, $E, $F, $G, $H, $A, $B, $C, $D]}
+    @{[SHA512ROUND1 45, $D, $E, $F, $G, $H, $A, $B, $C]}
+    @{[SHA512ROUND1 46, $C, $D, $E, $F, $G, $H, $A, $B]}
+    @{[SHA512ROUND1 47, $B, $C, $D, $E, $F, $G, $H, $A]}
+
+    @{[SHA512ROUND1 48, $A, $B, $C, $D, $E, $F, $G, $H]}
+    @{[SHA512ROUND1 49, $H, $A, $B, $C, $D, $E, $F, $G]}
+    @{[SHA512ROUND1 50, $G, $H, $A, $B, $C, $D, $E, $F]}
+    @{[SHA512ROUND1 51, $F, $G, $H, $A, $B, $C, $D, $E]}
+
+    @{[SHA512ROUND1 52, $E, $F, $G, $H, $A, $B, $C, $D]}
+    @{[SHA512ROUND1 53, $D, $E, $F, $G, $H, $A, $B, $C]}
+    @{[SHA512ROUND1 54, $C, $D, $E, $F, $G, $H, $A, $B]}
+    @{[SHA512ROUND1 55, $B, $C, $D, $E, $F, $G, $H, $A]}
+
+    @{[SHA512ROUND1 56, $A, $B, $C, $D, $E, $F, $G, $H]}
+    @{[SHA512ROUND1 57, $H, $A, $B, $C, $D, $E, $F, $G]}
+    @{[SHA512ROUND1 58, $G, $H, $A, $B, $C, $D, $E, $F]}
+    @{[SHA512ROUND1 59, $F, $G, $H, $A, $B, $C, $D, $E]}
+
+    @{[SHA512ROUND1 60, $E, $F, $G, $H, $A, $B, $C, $D]}
+    @{[SHA512ROUND1 61, $D, $E, $F, $G, $H, $A, $B, $C]}
+    @{[SHA512ROUND1 62, $C, $D, $E, $F, $G, $H, $A, $B]}
+    @{[SHA512ROUND1 63, $B, $C, $D, $E, $F, $G, $H, $A]}
+
+    @{[SHA512ROUND1 64, $A, $B, $C, $D, $E, $F, $G, $H]}
+    @{[SHA512ROUND1 65, $H, $A, $B, $C, $D, $E, $F, $G]}
+    @{[SHA512ROUND1 66, $G, $H, $A, $B, $C, $D, $E, $F]}
+    @{[SHA512ROUND1 67, $F, $G, $H, $A, $B, $C, $D, $E]}
+
+    @{[SHA512ROUND1 68, $E, $F, $G, $H, $A, $B, $C, $D]}
+    @{[SHA512ROUND1 69, $D, $E, $F, $G, $H, $A, $B, $C]}
+    @{[SHA512ROUND1 70, $C, $D, $E, $F, $G, $H, $A, $B]}
+    @{[SHA512ROUND1 71, $B, $C, $D, $E, $F, $G, $H, $A]}
+
+    @{[SHA512ROUND1 72, $A, $B, $C, $D, $E, $F, $G, $H]}
+    @{[SHA512ROUND1 73, $H, $A, $B, $C, $D, $E, $F, $G]}
+    @{[SHA512ROUND1 74, $G, $H, $A, $B, $C, $D, $E, $F]}
+    @{[SHA512ROUND1 75, $F, $G, $H, $A, $B, $C, $D, $E]}
+
+    @{[SHA512ROUND1 76, $E, $F, $G, $H, $A, $B, $C, $D]}
+    @{[SHA512ROUND1 77, $D, $E, $F, $G, $H, $A, $B, $C]}
+    @{[SHA512ROUND1 78, $C, $D, $E, $F, $G, $H, $A, $B]}
+    @{[SHA512ROUND1 79, $B, $C, $D, $E, $F, $G, $H, $A]}
+
+    ld.d $T1, $a0, 0
+    ld.d $T2, $a0, 8
+    ld.d $T3, $a0, 16
+    ld.d $T4, $a0, 24
+
+    add.d $A, $A, $T1
+    add.d $B, $B, $T2
+    add.d $C, $C, $T3
+    add.d $D, $D, $T4
+
+    st.d $A, $a0, 0
+    st.d $B, $a0, 8
+    st.d $C, $a0, 16
+    st.d $D, $a0, 24
+
+    ld.d $T1, $a0, 32
+    ld.d $T2, $a0, 40
+    ld.d $T3, $a0, 48
+    ld.d $T4, $a0, 56
+
+    add.d $E, $E, $T1
+    add.d $F, $F, $T2
+    add.d $G, $G, $T3
+    add.d $H, $H, $T4
+
+    st.d $E, $a0, 32
+    st.d $F, $a0, 40
+    st.d $G, $a0, 48
+    st.d $H, $a0, 56
+
+    addi.d $INP, $INP, 128
+
+    bnez $LEN, L_round_loop
+
+    addi.d $sp, $sp, 128
+
+    ld.d $s0, $sp, 0
+    ld.d $s1, $sp, 8
+    ld.d $s2, $sp, 16
+    ld.d $s3, $sp, 24
+    ld.d $s4, $sp, 32
+    ld.d $s5, $sp, 40
+    ld.d $s6, $sp, 48
+    ld.d $s7, $sp, 56
+    ld.d $s8, $sp, 64
+    ld.d $fp, $sp, 72
+
+    addi.d $sp, $sp, 80
+
+    ret
+.size sha512_block_data_order,.-sha512_block_data_order
+
+.section .rodata
+.p2align 3
+.type $K512,\@object
+$K512:
+    .dword 0x428a2f98d728ae22, 0x7137449123ef65cd
+    .dword 0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc
+    .dword 0x3956c25bf348b538, 0x59f111f1b605d019
+    .dword 0x923f82a4af194f9b, 0xab1c5ed5da6d8118
+    .dword 0xd807aa98a3030242, 0x12835b0145706fbe
+    .dword 0x243185be4ee4b28c, 0x550c7dc3d5ffb4e2
+    .dword 0x72be5d74f27b896f, 0x80deb1fe3b1696b1
+    .dword 0x9bdc06a725c71235, 0xc19bf174cf692694
+    .dword 0xe49b69c19ef14ad2, 0xefbe4786384f25e3
+    .dword 0x0fc19dc68b8cd5b5, 0x240ca1cc77ac9c65
+    .dword 0x2de92c6f592b0275, 0x4a7484aa6ea6e483
+    .dword 0x5cb0a9dcbd41fbd4, 0x76f988da831153b5
+    .dword 0x983e5152ee66dfab, 0xa831c66d2db43210
+    .dword 0xb00327c898fb213f, 0xbf597fc7beef0ee4
+    .dword 0xc6e00bf33da88fc2, 0xd5a79147930aa725
+    .dword 0x06ca6351e003826f, 0x142929670a0e6e70
+    .dword 0x27b70a8546d22ffc, 0x2e1b21385c26c926
+    .dword 0x4d2c6dfc5ac42aed, 0x53380d139d95b3df
+    .dword 0x650a73548baf63de, 0x766a0abb3c77b2a8
+    .dword 0x81c2c92e47edaee6, 0x92722c851482353b
+    .dword 0xa2bfe8a14cf10364, 0xa81a664bbc423001
+    .dword 0xc24b8b70d0f89791, 0xc76c51a30654be30
+    .dword 0xd192e819d6ef5218, 0xd69906245565a910
+    .dword 0xf40e35855771202a, 0x106aa07032bbd1b8
+    .dword 0x19a4c116b8d2d0c8, 0x1e376c085141ab53
+    .dword 0x2748774cdf8eeb99, 0x34b0bcb5e19b48a8
+    .dword 0x391c0cb3c5c95a63, 0x4ed8aa4ae3418acb
+    .dword 0x5b9cca4f7763e373, 0x682e6ff3d6b2b8a3
+    .dword 0x748f82ee5defb2fc, 0x78a5636f43172f60
+    .dword 0x84c87814a1f0ab72, 0x8cc702081a6439ec
+    .dword 0x90befffa23631e28, 0xa4506cebde82bde9
+    .dword 0xbef9a3f7b2c67915, 0xc67178f2e372532b
+    .dword 0xca273eceea26619c, 0xd186b8c721c0c207
+    .dword 0xeada7dd6cde0eb1e, 0xf57d4f7fee6ed178
+    .dword 0x06f067aa72176fba, 0x0a637dc5a2c898a6
+    .dword 0x113f9804bef90dae, 0x1b710b35131c471b
+    .dword 0x28db77f523047d84, 0x32caab7b40c72493
+    .dword 0x3c9ebe0a15c9bebc, 0x431d67c49c100d4c
+    .dword 0x4cc5d4becb3e42b6, 0x597f299cfc657e2a
+    .dword 0x5fcb6fab3ad6faec, 0x6c44198c4a475817
+.size $K512,.-$K512
+___
+
+print $code;
+
+close STDOUT or die "error closing STDOUT: $!";

--- a/crypto/sha/build.info
+++ b/crypto/sha/build.info
@@ -18,8 +18,8 @@ IF[{- !$disabled{asm} -}]
   $SHA1ASM_alpha=sha1-alpha.S
   $SHA1DEF_alpha=SHA1_ASM
 
-  $SHA1ASM_loongarch64=sha256-loongarch64.S
-  $SHA1DEF_loongarch64=SHA256_ASM
+  $SHA1ASM_loongarch64=sha256-loongarch64.S sha512-loongarch64.S
+  $SHA1DEF_loongarch64=SHA256_ASM SHA512_ASM
 
   $SHA1ASM_mips32=sha1-mips.S sha256-mips.S
   $SHA1DEF_mips32=SHA1_ASM SHA256_ASM
@@ -138,6 +138,8 @@ GENERATE[sha512-parisc.s]=asm/sha512-parisc.pl
 
 GENERATE[sha256-loongarch64.S]=asm/sha256-loongarch64.pl
 INCLUDE[sha256-loongarch64.o]=..
+GENERATE[sha512-loongarch64.S]=asm/sha512-loongarch64.pl
+INCLUDE[sha512-loongarch64.o]=..
 
 GENERATE[sha1-mips.S]=asm/sha1-mips.pl
 INCLUDE[sha1-mips.o]=..

--- a/crypto/sha/build.info
+++ b/crypto/sha/build.info
@@ -18,6 +18,9 @@ IF[{- !$disabled{asm} -}]
   $SHA1ASM_alpha=sha1-alpha.S
   $SHA1DEF_alpha=SHA1_ASM
 
+  $SHA1ASM_loongarch64=sha256-loongarch64.S
+  $SHA1DEF_loongarch64=SHA256_ASM
+
   $SHA1ASM_mips32=sha1-mips.S sha256-mips.S
   $SHA1DEF_mips32=SHA1_ASM SHA256_ASM
   $SHA1ASM_mips64=$SHA1ASM_mips32 sha512-mips.S
@@ -132,6 +135,9 @@ GENERATE[keccak1600-ppc64.s]=asm/keccak1600-ppc64.pl
 GENERATE[sha1-parisc.s]=asm/sha1-parisc.pl
 GENERATE[sha256-parisc.s]=asm/sha512-parisc.pl
 GENERATE[sha512-parisc.s]=asm/sha512-parisc.pl
+
+GENERATE[sha256-loongarch64.S]=asm/sha256-loongarch64.pl
+INCLUDE[sha256-loongarch64.o]=..
 
 GENERATE[sha1-mips.S]=asm/sha1-mips.pl
 INCLUDE[sha1-mips.o]=..


### PR DESCRIPTION
This PR adds SHA-2 assembly implementation for loongarch platforms. 
For SHA-256, assembly implementation gets about 20%~ better performance than compiler-generated code.
For SHA-512, assembly implementation also gets a better performance on small-size data, and inot worse on large-size data. 
Please see benchmark results below for more details.

**Special thanks to [@loongson-community/1024](http://github.com/loongson-community/1024) for providing the testing 3A6000 machine.**

Benchmark result: 

For SHA-256:
| Implementation | 16 bytes | 64 bytes | 256 bytes | 1024 bytes | 8192 bytes | 16384 bytes |
|--------|-------|-------|-------|--------|--------|---------|
|C Compiled |33057.89|83904.60|156370.43|199317.66|216331.61|217732.44|
|Assembly |40331.31|101350.10|193465.11|248759.30|271461.03|274240.85|
|C Compiled |100%|100%|100%|100%|100%|100%|
|Assembly |122.00%|120.79%|123.72%|124.81%|125.48%|125.95%|


For SHA-512:
| Implementation | 16 bytes | 64 bytes | 256 bytes | 1024 bytes | 8192 bytes | 16384 bytes |
|--------|-------|-------|-------|--------|--------|---------|
|C Compiled |32301.50|127619.16|236190.38|354342.57|412707.50|417704.62|
|Assembly |33834.43|135554.35|239562.67|357283.50|417139.37|421915.31|
|C Compiled |100%|100%|100%|100%|100%|100%|
|Assembly |104.75%|106.22%|101.43%|100.83%|101.07%|101.01%|
