### PR TITLE
ktls: move ktls_enable() within ktls_start()

### DIFF
--- a/crypto/bio/bio_sock2.c
+++ b/crypto/bio/bio_sock2.c
@@ -181,15 +181,6 @@ int BIO_connect(int sock, const BIO_ADDR *addr, int options)
         }
         return 0;
     }
-# ifndef OPENSSL_NO_KTLS
-    /*
-     * The new socket is created successfully regardless of ktls_enable.
-     * ktls_enable doesn't change any functionality of the socket, except
-     * changing the setsockopt to enable the processing of ktls_start.
-     * Thus, it is not a problem to call it for non-TLS sockets.
-     */
-    ktls_enable(sock);
-# endif
     return 1;
 }
 

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -252,15 +252,6 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
                 if (!conn_create_dgram_bio(b, c))
                     break;
                 c->state = BIO_CONN_S_OK;
-# ifndef OPENSSL_NO_KTLS
-                /*
-                 * The new socket is created successfully regardless of ktls_enable.
-                 * ktls_enable doesn't change any functionality of the socket, except
-                 * changing the setsockopt to enable the processing of ktls_start.
-                 * Thus, it is not a problem to call it for non-TLS sockets.
-                 */
-                ktls_enable(b->num);
-# endif
             }
             break;
 

--- a/crypto/bio/bss_sock.c
+++ b/crypto/bio/bss_sock.c
@@ -72,17 +72,6 @@ BIO *BIO_new_socket(int fd, int close_flag)
     if (ret == NULL)
         return NULL;
     BIO_set_fd(ret, fd, close_flag);
-# ifndef OPENSSL_NO_KTLS
-    {
-        /*
-         * The new socket is created successfully regardless of ktls_enable.
-         * ktls_enable doesn't change any functionality of the socket, except
-         * changing the setsockopt to enable the processing of ktls_start.
-         * Thus, it is not a problem to call it for non-TLS sockets.
-         */
-        ktls_enable(fd);
-    }
-# endif
     return ret;
 }
 

--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -302,6 +302,12 @@ static ossl_inline int ktls_enable(int fd)
 static ossl_inline int ktls_start(int fd, ktls_crypto_info_t *crypto_info,
                                   int is_tx)
 {
+    /*
+     * Socket must be in TCP established state to enable KTLS.
+     * Further calls to enable ktls will return EEXIST
+     */
+    ktls_enable(fd);
+
     return setsockopt(fd, SOL_TLS, is_tx ? TLS_TX : TLS_RX,
                       crypto_info, crypto_info->tls_crypto_info_len) ? 0 : 1;
 }

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1728,15 +1728,6 @@ int SSL_set_fd(SSL *s, int fd)
     }
     BIO_set_fd(bio, fd, BIO_NOCLOSE);
     SSL_set_bio(s, bio, bio);
-#ifndef OPENSSL_NO_KTLS
-    /*
-     * The new socket is created successfully regardless of ktls_enable.
-     * ktls_enable doesn't change any functionality of the socket, except
-     * changing the setsockopt to enable the processing of ktls_start.
-     * Thus, it is not a problem to call it for non-TLS sockets.
-     */
-    ktls_enable(fd);
-#endif /* OPENSSL_NO_KTLS */
     ret = 1;
  err:
     return ret;
@@ -1762,15 +1753,6 @@ int SSL_set_wfd(SSL *s, int fd)
         }
         BIO_set_fd(bio, fd, BIO_NOCLOSE);
         SSL_set0_wbio(s, bio);
-#ifndef OPENSSL_NO_KTLS
-        /*
-         * The new socket is created successfully regardless of ktls_enable.
-         * ktls_enable doesn't change any functionality of the socket, except
-         * changing the setsockopt to enable the processing of ktls_start.
-         * Thus, it is not a problem to call it for non-TLS sockets.
-         */
-        ktls_enable(fd);
-#endif /* OPENSSL_NO_KTLS */
     } else {
         if (!BIO_up_ref(rbio))
             return 0;


### PR DESCRIPTION
On linux ktls can only be enabled on established TCP sockets. When SSL_set_fd() is called before the connection is established ktls_enable() fails and ktls is not setup.

This moves ktls_enable() call within then ktls_start() function. Multiple calls to ktls_start() will trigger additional ktls_enable() calls which fail with EEXIST, but do not affect the ktls socket.

Fixes #19676 
