### PR TITLE
SSL_poll() should re-issue SSL_shutdown() when object is

### DIFF
--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -134,6 +134,7 @@ __owur int ossl_quic_get_stream_write_error_code(SSL *ssl,
 __owur int ossl_quic_get_conn_close_info(SSL *ssl,
                                          SSL_CONN_CLOSE_INFO *info,
                                          size_t info_len);
+__owur int ossl_quic_conn_in_shutdown(SSL *ssl);
 
 uint64_t ossl_quic_set_options(SSL *s, uint64_t opts);
 uint64_t ossl_quic_clear_options(SSL *s, uint64_t opts);

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -1557,7 +1557,6 @@ int ossl_quic_conn_shutdown(SSL *s, uint64_t flags,
 
         if (!qc_shutdown_flush_finished(ctx.qc)) {
             qctx_unlock(&ctx);
-            fprintf(stderr, "%s flush not finished\n", __func__);
             return 0; /* ongoing */
         }
     }
@@ -1598,7 +1597,6 @@ int ossl_quic_conn_shutdown(SSL *s, uint64_t flags,
 
     SSL_set_shutdown(ctx.qc->tls, SSL_SENT_SHUTDOWN);
 
-    fprintf(stderr, "%s closing the channel\n", __func__);
     if (ossl_quic_channel_is_terminated(ctx.qc->ch)) {
         qctx_unlock(&ctx);
         return 1;

--- a/ssl/rio/poll_immediate.c
+++ b/ssl/rio/poll_immediate.c
@@ -232,6 +232,7 @@ static int poll_translate(SSL_POLL_ITEM *items,
                  */
                 if (ossl_quic_conn_in_shutdown(ssl))
                     SSL_shutdown(ssl);
+                /* FALLTHRU */
 
             case SSL_TYPE_QUIC_LISTENER:
             case SSL_TYPE_QUIC_XSO:

--- a/ssl/rio/poll_immediate.c
+++ b/ssl/rio/poll_immediate.c
@@ -225,8 +225,15 @@ static int poll_translate(SSL_POLL_ITEM *items,
 
             switch (ssl->type) {
 # ifndef OPENSSL_NO_QUIC
-            case SSL_TYPE_QUIC_LISTENER:
             case SSL_TYPE_QUIC_CONNECTION:
+                /*
+                 * Re-issue shutdown as condition prveinting shutdown to complete
+                 * could have changed.
+                 */
+                if (ossl_quic_conn_in_shutdown(ssl))
+                    SSL_shutdown(ssl);
+
+            case SSL_TYPE_QUIC_LISTENER:
             case SSL_TYPE_QUIC_XSO:
                 if (!poll_translate_ssl_quic(ssl, wctx, rpb, item->events,
                                              abort_blocking))


### PR DESCRIPTION
in shutting_down state.

This is the scenario which requires proposed twek.

The client application uses event loop. The event loop invokes callbacks to serve the events reported by SSL_poll().

The recv() callback receives all data on its last stream.

The recv() callback invokes SSL_shutdown() on connection object which owns the stream. The regular shutdown can not progress here because there is stream still attached.

The recv() callback returns and hints event loop the stream object can be destroyed now. event loop then does SSL_free() on stream object.

Once stream object is freed the event loop calls SSL_poll() again. Here we should call SSL_shutdown() on connection which used to own stream. The connection shuuld be able to proceed to ossl_quic_channel_local_close() which schedules CONNECTION_CLOSE notification. This makes the connection unstuck.

Fixes openssl/project#1232

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
