### PR TITLE
Fix nullpointer dereference in OSSL_PARAM_merge

### DIFF
--- a/crypto/params_dup.c
+++ b/crypto/params_dup.c
@@ -190,18 +190,18 @@ OSSL_PARAM *OSSL_PARAM_merge(const OSSL_PARAM *p1, const OSSL_PARAM *p2)
     while (1) {
         /* If list1 is finished just tack list2 onto the end */
         if (*p1cur == NULL) {
-            do {
+            while (*p2cur != NULL) {
                 *dst++ = **p2cur;
                 p2cur++;
-            } while (*p2cur != NULL);
+            }
             break;
         }
         /* If list2 is finished just tack list1 onto the end */
         if (*p2cur == NULL) {
-            do {
+            while (*p1cur != NULL) {
                 *dst++ = **p1cur;
                 p1cur++;
-            } while (*p1cur != NULL);
+            }
             break;
         }
         /* consume the list element with the smaller key */

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -856,6 +856,33 @@ static int test_param_copy_null(void)
     OSSL_PARAM_free(cp1);
     return ret;
 }
+static int test_param_merge(void)
+{
+    int val, ret;
+    int values[] = {1, 2, 3, 4};
+    OSSL_PARAM *p = NULL, *cp = NULL;
+    OSSL_PARAM param[3], param1[3];
+
+    param[0] = OSSL_PARAM_construct_int("diff1", &values[0]);
+    param[1] = OSSL_PARAM_construct_int("same", &values[1]);
+    param[2] = OSSL_PARAM_construct_end();
+    param1[0] = OSSL_PARAM_construct_int("diff2", &values[2]);
+    param1[1] = OSSL_PARAM_construct_int("same", &values[3]);
+    param1[2] = OSSL_PARAM_construct_end();
+
+    ret = TEST_ptr(p = OSSL_PARAM_merge(param, param1))
+        && TEST_ptr(cp = OSSL_PARAM_locate(p, "diff1"))
+        && TEST_true(OSSL_PARAM_get_int(p, &val))
+        && TEST_int_eq(val, values[0])
+        && TEST_ptr(cp = OSSL_PARAM_locate(p, "diff2"))
+        && TEST_true(OSSL_PARAM_get_int(cp, &val))
+        && TEST_int_eq(val, values[2])
+        && TEST_ptr(cp = OSSL_PARAM_locate(p, "same"))
+        && TEST_true(OSSL_PARAM_get_int(cp, &val))
+        && TEST_int_eq(val, values[3]);
+    OSSL_PARAM_free(p);
+    return ret;
+}
 
 int setup_tests(void)
 {
@@ -875,5 +902,6 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_param_construct, 4);
     ADD_TEST(test_param_modified);
     ADD_TEST(test_param_copy_null);
+    ADD_TEST(test_param_merge);
     return 1;
 }


### PR DESCRIPTION
OSSL_PARAM_merge contained an error, where a nullpointer was dereferenced when both parameter arrays ended with the same key

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are added or updated
