### PR TITLE
apps/openssl.c: Add OPENSSL_free() to avoid memory leak

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -190,6 +190,7 @@ static void setup_trace_category(int category)
 
         OSSL_trace_set_callback(category, NULL, NULL);
         BIO_free_all(channel);
+        OPENSSL_free(trace_data);
     }
 }
 


### PR DESCRIPTION
Add OPENSSL_free() to release trace_data if trace_data is not NULL but other errors occur to avoid memory leak.

Fixes: 682b444f8a ("apps/openssl.c: Adapt to enable tracing output")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
