### PR TITLE
test/quic_multistream_test.c: Add OPENSSL_free() to avoid memory leak

### DIFF
--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -780,6 +780,7 @@ static int helper_init(struct helper *h, const char *script_name,
             goto err;
         bdata->fault = h->qtf;
         BIO_set_data(h->s_qtf_wbio, bdata);
+        bdata = NULL;
     }
 
     h->s_net_bio_own = NULL;
@@ -855,6 +856,7 @@ static int helper_init(struct helper *h, const char *script_name,
     return 1;
 
 err:
+    OPENSSL_free(bdata);
     helper_cleanup(h);
     return 0;
 }


### PR DESCRIPTION
Add OPENSSL_free() to free bdata if an error occurs to avoid memory leak.

Fixes: a55b689499 ("Use reported short conn id len in qtestlib")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
