### PR TITLE
test/quic-openssl-docker/hq-interop/quic-hq-interop.c: Add check for …

### DIFF
--- a/test/quic-openssl-docker/hq-interop/quic-hq-interop.c
+++ b/test/quic-openssl-docker/hq-interop/quic-hq-interop.c
@@ -883,6 +883,11 @@ int main(int argc, char *argv[])
         goto end;
     }
 
+    if (reqnames == NULL) {
+        fprintf(stderr, "Failed to allocate memory for request names\n");
+        goto end;
+    }
+
     hostname = argv[argnext++];
     port = argv[argnext++];
     reqfile = argv[argnext];


### PR DESCRIPTION
…OPENSSL_zalloc()

Add check for the return value of OPENSSL_zalloc() to avoid potential NULL pointer dereference.

Fixes: 2858149e44 ("Adding an hq-interop alpn client")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
