### PR TITLE
apps/lib/log.c: Add check for BIO_new()

### DIFF
--- a/apps/lib/log.c
+++ b/apps/lib/log.c
@@ -46,6 +46,9 @@ static void log_with_prefix(const char *prog, const char *fmt, va_list ap)
     char prefix[80];
     BIO *bio, *pre = BIO_new(BIO_f_prefix());
 
+    if (pre == NULL)
+        return;
+
     (void)BIO_snprintf(prefix, sizeof(prefix), "%s: ", prog);
     (void)BIO_set_prefix(pre, prefix);
     bio = BIO_push(pre, bio_err);


### PR DESCRIPTION
Add check for the return value of BIO_new() to avoid potential NULL pointer dereference.

Fixes: 8a2ec00d7f ("apps/lib/http_server.{c,h}: clean up logging and move it to log.{c,h}")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
