### PR TITLE
fuzz/cmp.c: Correct the usages of BIO_new()

### DIFF
--- a/fuzz/cmp.c
+++ b/fuzz/cmp.c
@@ -176,12 +176,25 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
         return 0;
 
     in = BIO_new(BIO_s_mem());
-    OPENSSL_assert((size_t)BIO_write(in, buf, len) == len);
+    if ((size_t)BIO_write(in, buf, len) != len) {
+        BIO_free(in);
+        return 0;
+    }
+
     msg = d2i_OSSL_CMP_MSG_bio(in, NULL);
     if (msg != NULL) {
         BIO *out = BIO_new(BIO_s_null());
         OSSL_CMP_SRV_CTX *srv_ctx = OSSL_CMP_SRV_CTX_new(NULL, NULL);
         OSSL_CMP_CTX *client_ctx = OSSL_CMP_CTX_new(NULL, NULL);
+
+        if (out == NULL) {
+            OSSL_CMP_CTX_free(client_ctx);
+            OSSL_CMP_SRV_CTX_free(srv_ctx);
+            OSSL_CMP_MSG_free(msg);
+            BIO_free(in);
+            ERR_clear_error();
+            return 0;
+        }
 
         i2d_OSSL_CMP_MSG_bio(out, msg);
         ASN1_item_print(out, (ASN1_VALUE *)msg, 4,


### PR DESCRIPTION
Use BIO_free() to free "in" if error occurs to avoid memory leak. Moreover, add check for "out" to avoid NULL pointer dereference.

Fixes: e599d0aecd ("Add CMP fuzzing to fuzz/cmp.c, including a couple of helpers in crypto/cmp/")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
