### PR TITLE
Fix provider encoder dispatch validation

### DIFF
--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -281,15 +281,15 @@ static void *encoder_from_algorithm(int id, const OSSL_ALGORITHM *algodef,
         }
     }
     /*
-     * Try to check that the method is sensible.
-     * If you have a constructor, you must have a destructor and vice versa.
-     * You must have the encoding driver functions.
+     * In order to be a consistent set of functions we must have at least
+     * a set of context functions (newctx and freectx) as well as a pair of
+     * "object" functions: (import_object, free_object). encode and 
+     * does_selection are required as well.
      */
-    if (!((encoder->newctx == NULL && encoder->freectx == NULL)
-          || (encoder->newctx != NULL && encoder->freectx != NULL)
-          || (encoder->import_object != NULL && encoder->free_object != NULL)
-          || (encoder->import_object == NULL && encoder->free_object == NULL))
-        || encoder->encode == NULL) {
+    if ((encoder->import_object != NULL && encoder->free_object == NULL)
+        || (encoder->import_object == NULL && encoder->free_object != NULL)
+        || encoder->encode == NULL || encoder->does_selection == NULL
+        || encoder->newctx == NULL || encoder->freectx == NULL) {
         OSSL_ENCODER_free(encoder);
         ERR_raise(ERR_LIB_OSSL_ENCODER, ERR_R_INVALID_PROVIDER_FUNCTIONS);
         return NULL;


### PR DESCRIPTION
This change ensures the `OSSL_ENCODER` dispatch table contains the minimum required entries prior to use. Prior to this change, sigfaults were encountered due to missing entries in the table when running openssl from the command line. 

Specifically, a provider could register an `OSSL_DISPATCH` table without `newctx` or `freectx` or `does_selection` function pointers populated and encounter the failure.

- [ ] documentation is added or updated
- [ ] tests are added or updated
