### PR TITLE
Fixup non-optional use of IO::Socket::IP

### DIFF
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -97,7 +97,23 @@ sub new_dtls {
 
 sub init
 {
-    require IO::Socket::IP;
+    my $useSockInet = 0;
+    eval {
+        require IO::Socket::IP;
+        my $s = IO::Socket::IP->new(
+                LocalAddr => "::1",
+                LocalPort => 0,
+                Listen=>1,
+                );
+            $s or die "\n";
+            $s->close();
+    };
+    if ($@ eq "") {
+        require IO::Socket::IP;
+    } else {
+        $useSockInet = 1;
+    }
+
     my $class = shift;
     my ($filter,
         $execute,
@@ -118,8 +134,13 @@ sub init
         $test_client_port = 49152 + int(rand(65535 - 49152));
         my $test_sock;
         if ($useINET6 == 0) {
-            $test_sock = IO::Socket::IP->new(LocalPort => $test_client_port,
-                                             LocalAddr => $test_client_addr);
+            if ($useSockInet == 0) {
+                $test_sock = IO::Socket::IP->new(LocalPort => $test_client_port,
+                                                 LocalAddr => $test_client_addr);
+            } else {
+                $test_sock = IO::Socket::INET->new(LocalAddr => $test_client_addr,
+                                                   LocalPort => $test_client_port);
+            }
         } else {
             $test_sock = IO::Socket::INET6->new(LocalAddr => $test_client_addr,
                                                 LocalPort => $test_client_port,


### PR DESCRIPTION
IO::Socket::IP is an optionally used package in our perl scripts, and a recent change of mine used it unilaterally, causing breakage on older perl installations.  Fix it up to use it optionally again, falling back to IO::Socket::INET when needed.

Fixes #27940

