### PR TITLE
Allow overlength strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: config
-      run: CPPFLAGS='-ansi -D_XOPEN_SOURCE=1 -D_POSIX_C_SOURCE=200809L' ./config --banner=Configured enable-sslkeylog no-asm no-secure-memory no-makedepend enable-buildtest-c++ enable-fips --strict-warnings && perl configdata.pm --dump
+      run: CPPFLAGS='-ansi -D_XOPEN_SOURCE=1 -D_POSIX_C_SOURCE=200809L' ./config --banner=Configured enable-sslkeylog no-asm no-secure-memory no-makedepend enable-buildtest-c++ enable-fips --strict-warnings -Wno-overlength-strings && perl configdata.pm --dump
     - name: make
       run: make -s -j4
 


### PR DESCRIPTION
As we now allow these on master branch it is problematic for backports
to stable branches and this particular issue is unlikely to break
builds on old compilers.

This fixes CI failure: https://github.com/openssl/openssl/actions/runs/16006213381/job/45153399608

This is for a discussion. An alternative would be to rewrite the code to not use such a long string literal.