### PR TITLE
Fix: Unsafe Text Processing Function Could Corrupt Data in apps/rehash.c

### DIFF
--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -568,7 +568,8 @@ int rehash_main(int argc, char **argv)
             errs = 1;
             goto end;
         }
-        for (e = strtok(m, lsc); e != NULL; e = strtok(NULL, lsc))
+    char *saveptr = NULL;
+        for (e = strtok_r(\1,\2,strtok(m, lsc)saveptr); e != NULL; e = strtok_r(\1,\2,strtok(NULL, lsc)saveptr))
             errs += do_dir(e, h);
         OPENSSL_free(m);
     } else {


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** Avoid using 'strtok()'. This function directly modifies the first argument buffer, permanently erasing the delimiter character. Use 'strtok_r()' instead.
- **Rule ID:** c.lang.security.insecure-use-strtok-fn.insecure-use-strtok-fn-apps-rehash.c
- **Severity:** HIGH
- **File:** apps/rehash.c
- **Lines Affected:** 571 - 571

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `apps/rehash.c` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.