### PR TITLE
Add functions to set default DRBG parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -125,6 +125,10 @@ OpenSSL Releases
    no interest in session tickets and session resumption.
 
    *Daniel Kubec*
+ * API calls `RAND_set_default_parameters`, and
+    `RAND_set_default_primary_parameters` have been added to libcrypto.
+
+   *Christian Vögl*
 
  * Added test framework for testing function memory allocation failures.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,9 @@ OpenSSL 4.1
 
 ### Major changes between OpenSSL 4.0 and OpenSSL 4.1 [under development]
 
+  * API calls `RAND_set_default_parameters`, and
+    `RAND_set_default_primary_parameters` have been added
+
   * API calls `CRYPTO_atomic_load_ptr`, `CRYPTO_atomic_store_ptr`, and
     `CRYPTO_atomic_cmp_exch_ptr` have been added.
   * Initial support for the Elbrus2000 (e2k) architecture

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -10,6 +10,8 @@
 /* We need to use some RAND deprecated APIs */
 #define OPENSSL_SUPPRESS_DEPRECATED
 
+#include <stdbool.h>
+
 #include <openssl/err.h>
 #include <openssl/opensslconf.h>
 #include <openssl/core_names.h>
@@ -68,6 +70,10 @@ typedef struct rand_global_st {
     /* Allow the randomness source to be changed */
     char *seed_name;
     char *seed_propq;
+
+    /* Parameters to use when DRGBs are created via rand_get_0 functions. */
+    OSSL_PARAM *default_params;
+    OSSL_PARAM *default_primary_params;
 } RAND_GLOBAL;
 
 static EVP_RAND_CTX *rand_get0_primary(OSSL_LIB_CTX *ctx, RAND_GLOBAL *dgbl);
@@ -499,6 +505,8 @@ void ossl_rand_ctx_free(void *vdgbl)
     OPENSSL_free(dgbl->rng_propq);
     OPENSSL_free(dgbl->seed_name);
     OPENSSL_free(dgbl->seed_propq);
+    OSSL_PARAM_free(dgbl->default_primary_params);
+    OSSL_PARAM_free(dgbl->default_params);
 
     OPENSSL_free(dgbl);
 }
@@ -624,8 +632,7 @@ EVP_RAND_CTX *ossl_rand_get0_seed_noncreating(OSSL_LIB_CTX *ctx)
 #endif /* !FIPS_MODULE */
 
 static EVP_RAND_CTX *rand_new_drbg(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent,
-    unsigned int reseed_interval,
-    time_t reseed_time_interval)
+    bool primary)
 {
     EVP_RAND *rand;
     RAND_GLOBAL *dgbl = rand_get_global(libctx);
@@ -635,9 +642,22 @@ static EVP_RAND_CTX *rand_new_drbg(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent,
     const char *prov_name;
     char *name, *cipher;
     int use_df = 1;
+    time_t reseed_time_interval;
+    unsigned int reseed_interval;
+    const OSSL_PARAM *default_params;
+    OSSL_PARAM *merged_params;
 
     if (dgbl == NULL)
         return NULL;
+    if (primary) {
+        default_params = dgbl->default_primary_params;
+        reseed_time_interval = PRIMARY_RESEED_TIME_INTERVAL;
+        reseed_interval = PRIMARY_RESEED_INTERVAL;
+    } else {
+        default_params = dgbl->default_params;
+        reseed_time_interval = SECONDARY_RESEED_TIME_INTERVAL;
+        reseed_interval = SECONDARY_RESEED_INTERVAL;
+    }
     name = dgbl->rng_name != NULL ? dgbl->rng_name : "CTR-DRBG";
     rand = EVP_RAND_fetch(libctx, name, dgbl->rng_propq);
     if (rand == NULL) {
@@ -677,11 +697,18 @@ static EVP_RAND_CTX *rand_new_drbg(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent,
     *p++ = OSSL_PARAM_construct_time_t(OSSL_DRBG_PARAM_RESEED_TIME_INTERVAL,
         &reseed_time_interval);
     *p = OSSL_PARAM_construct_end();
-    if (!EVP_RAND_instantiate(ctx, 0, 0, NULL, 0, params)) {
-        ERR_raise(ERR_LIB_RAND, RAND_R_ERROR_INSTANTIATING_DRBG);
+    if ((merged_params = OSSL_PARAM_merge(params, default_params)) == NULL) {
+        ERR_raise(ERR_LIB_RAND, ERR_R_INTERNAL_ERROR);
         EVP_RAND_CTX_free(ctx);
         return NULL;
     }
+
+    if (!EVP_RAND_instantiate(ctx, 0, 0, NULL, 0, merged_params)) {
+        ERR_raise(ERR_LIB_RAND, RAND_R_ERROR_INSTANTIATING_DRBG);
+        EVP_RAND_CTX_free(ctx);
+        ctx = NULL;
+    }
+    OSSL_PARAM_free(merged_params);
     return ctx;
 }
 
@@ -748,8 +775,7 @@ static EVP_RAND_CTX *rand_get0_primary(OSSL_LIB_CTX *ctx, RAND_GLOBAL *dgbl)
     /* The FIPS provider has entropy health tests instead of the primary */
     ret = rand_new_crngt(ctx, seed);
 #else /* FIPS_MODULE */
-    ret = rand_new_drbg(ctx, seed, PRIMARY_RESEED_INTERVAL,
-        PRIMARY_RESEED_TIME_INTERVAL);
+    ret = rand_new_drbg(ctx, seed, true);
 #endif /* FIPS_MODULE */
 
     if (ret == NULL)
@@ -820,8 +846,7 @@ static EVP_RAND_CTX *rand_get0_public(OSSL_LIB_CTX *ctx, RAND_GLOBAL *dgbl)
         if (CRYPTO_THREAD_get_local_ex(CRYPTO_THREAD_LOCAL_DRBG_PRIV_KEY, ctx) == NULL
             && !ossl_init_thread_start(NULL, ctx, rand_delete_thread_state))
             return NULL;
-        rand = rand_new_drbg(ctx, primary, SECONDARY_RESEED_INTERVAL,
-            SECONDARY_RESEED_TIME_INTERVAL);
+        rand = rand_new_drbg(ctx, primary, false);
         if (!CRYPTO_THREAD_set_local_ex(CRYPTO_THREAD_LOCAL_DRBG_PUB_KEY, ctx, rand)) {
             EVP_RAND_CTX_free(rand);
             rand = NULL;
@@ -863,8 +888,7 @@ static EVP_RAND_CTX *rand_get0_private(OSSL_LIB_CTX *ctx, RAND_GLOBAL *dgbl)
         if (CRYPTO_THREAD_get_local_ex(CRYPTO_THREAD_LOCAL_DRBG_PUB_KEY, ctx) == NULL
             && !ossl_init_thread_start(NULL, ctx, rand_delete_thread_state))
             return NULL;
-        rand = rand_new_drbg(ctx, primary, SECONDARY_RESEED_INTERVAL,
-            SECONDARY_RESEED_TIME_INTERVAL);
+        rand = rand_new_drbg(ctx, primary, false);
         if (!CRYPTO_THREAD_set_local_ex(CRYPTO_THREAD_LOCAL_DRBG_PRIV_KEY, ctx, rand)) {
             EVP_RAND_CTX_free(rand);
             rand = NULL;
@@ -1044,6 +1068,53 @@ int RAND_set_DRBG_type(OSSL_LIB_CTX *ctx, const char *drbg, const char *propq,
         && random_set_string(&dgbl->rng_propq, propq)
         && random_set_string(&dgbl->rng_cipher, cipher)
         && random_set_string(&dgbl->rng_digest, digest);
+}
+
+int(RAND_set_default_primary_parameters)(OSSL_LIB_CTX *ctx,
+    const OSSL_PARAM *parameters)
+{
+    RAND_GLOBAL *dgbl = rand_get_global(ctx);
+
+    if (dgbl == NULL)
+        return 0;
+    if (dgbl->primary != NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, RAND_R_ALREADY_INSTANTIATED);
+        return 0;
+    }
+    OSSL_PARAM_free(dgbl->default_primary_params);
+    if (parameters == NULL) {
+        dgbl->default_primary_params = NULL;
+        return 1;
+    }
+    dgbl->default_primary_params = OSSL_PARAM_dup(parameters);
+    if (dgbl->default_primary_params == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+    return 1;
+}
+
+int RAND_set_default_parameters(OSSL_LIB_CTX *ctx, const OSSL_PARAM *parameters)
+{
+    RAND_GLOBAL *dgbl = rand_get_global(ctx);
+
+    if (dgbl == NULL)
+        return 0;
+    if (dgbl->primary != NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, RAND_R_ALREADY_INSTANTIATED);
+        return 0;
+    }
+    OSSL_PARAM_free(dgbl->default_params);
+    if (parameters == NULL) {
+        dgbl->default_params = NULL;
+        return 1;
+    }
+    dgbl->default_params = OSSL_PARAM_dup(parameters);
+    if (dgbl->default_params == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+    return 1;
 }
 
 int RAND_set_seed_source_type(OSSL_LIB_CTX *ctx, const char *seed,

--- a/doc/man3/RAND_set_DRBG_type.pod
+++ b/doc/man3/RAND_set_DRBG_type.pod
@@ -3,8 +3,10 @@
 =head1 NAME
 
 RAND_set_DRBG_type,
-RAND_set_seed_source_type
-- specify the global random number generator types
+RAND_set_seed_source_type,
+RAND_set_default_parameters,
+RAND_set_default_primary_parameters
+- specify the global random number generator types and default parameters
 
 =head1 SYNOPSIS
 
@@ -14,6 +16,11 @@ RAND_set_seed_source_type
                         const char *cipher, const char *digest);
  int RAND_set_seed_source_type(OSSL_LIB_CTX *ctx, const char *seed,
                                const char *propq);
+ int RAND_set_default_primary_parameters(OSSL_LIB_CTX *ctx,
+                                         const OSSL_PARAM *parameters);
+ int RAND_set_default_parameters(OSSL_LIB_CTX *ctx,
+                                 const OSSL_PARAM *parameters);
+
 
 =head1 DESCRIPTION
 
@@ -28,6 +35,16 @@ RAND_set_seed_source_type() specifies the seed source that will be used
 within the library context I<ctx>.  The seed source of name I<seed>
 with properties I<propq> will be fetched and used to seed the primary
 random bit generator.
+
+RAND_set_default_primary_parameters() specifies parameters that will be used to
+instantiate the primary DRBG in the library context I<ctx>. If this function
+is called multiple times with the same I<ctx> the last value of I<parameters>
+will be used.
+If I<parameters> is NULL, previously set parameters will be deleted.
+
+RAND_set_default_parameters() is like RAND_set_default_primary_parameters(),
+except the parameters will be used to construct the public and private
+threadlocal DRBGs
 
 =head1 RETURN VALUES
 

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -88,6 +88,8 @@ int RAND_set_DRBG_type(OSSL_LIB_CTX *ctx, const char *drbg, const char *propq,
     const char *cipher, const char *digest);
 int RAND_set_seed_source_type(OSSL_LIB_CTX *ctx, const char *seed,
     const char *propq);
+int RAND_set_default_parameters(OSSL_LIB_CTX *ctx, const OSSL_PARAM *p);
+int RAND_set_default_primary_parameters(OSSL_LIB_CTX *ctx, const OSSL_PARAM *p);
 
 void RAND_seed(const void *buf, int num);
 void RAND_keep_random_devices_open(int keep);

--- a/test/rand_test.c
+++ b/test/rand_test.c
@@ -455,6 +455,65 @@ end:
     return rc;
 }
 
+static int test_rand_set_default_parameters(void)
+{
+    OSSL_PARAM prim_par[3];
+    OSSL_PARAM sec_par[3];
+    OSSL_PARAM test_par[3];
+    unsigned reseed_request_prim = 314;
+    unsigned reseed_request_sec = 42;
+    int reseed_time_interval_prim = 1024;
+    int reseed_time_interval_sec = 2048;
+    unsigned reseed_request_test = 0;
+    int reseed_time_interval_test = 0;
+    OSSL_LIB_CTX *ctx = OSSL_LIB_CTX_new();
+    EVP_RAND_CTX *rctx;
+    int res = 0;
+
+    prim_par[0] = OSSL_PARAM_construct_uint(OSSL_DRBG_PARAM_RESEED_REQUESTS,
+        &reseed_request_prim);
+    prim_par[1] = OSSL_PARAM_construct_int(OSSL_DRBG_PARAM_RESEED_TIME_INTERVAL,
+        &reseed_time_interval_prim);
+    prim_par[2] = OSSL_PARAM_construct_end();
+    sec_par[0] = OSSL_PARAM_construct_uint(OSSL_DRBG_PARAM_RESEED_REQUESTS,
+        &reseed_request_sec);
+    sec_par[1] = OSSL_PARAM_construct_int(OSSL_DRBG_PARAM_RESEED_TIME_INTERVAL,
+        &reseed_time_interval_sec);
+    sec_par[2] = OSSL_PARAM_construct_end();
+    test_par[0] = OSSL_PARAM_construct_uint(OSSL_DRBG_PARAM_RESEED_REQUESTS,
+        &reseed_request_test);
+    test_par[1] = OSSL_PARAM_construct_int(OSSL_DRBG_PARAM_RESEED_TIME_INTERVAL,
+        &reseed_time_interval_test);
+    test_par[2] = OSSL_PARAM_construct_end();
+    if (!TEST_ptr(ctx))
+        return 0;
+    if (!TEST_true(RAND_set_default_primary_parameters(ctx, prim_par))
+        || !TEST_true(RAND_set_default_parameters(ctx, sec_par))
+        || !TEST_ptr(rctx = RAND_get0_primary(ctx))
+        || !TEST_int_eq(EVP_RAND_CTX_get_params(rctx, test_par), 1)
+        || !TEST_uint_eq(reseed_request_prim, reseed_request_test)
+        || !TEST_int_eq(reseed_time_interval_prim,
+            reseed_time_interval_test)
+        || !TEST_ptr(rctx = RAND_get0_private(ctx))
+        || !TEST_int_eq(EVP_RAND_CTX_get_params(rctx, test_par), 1)
+        || !TEST_uint_eq(reseed_request_sec, reseed_request_test)
+        || !TEST_int_eq(reseed_time_interval_sec,
+            reseed_time_interval_test))
+        goto err;
+    reseed_time_interval_test = 0;
+    reseed_request_test = 0;
+    if (!TEST_ptr(rctx = RAND_get0_public(ctx))
+        || !TEST_int_eq(EVP_RAND_CTX_get_params(rctx, test_par), 1)
+        || !TEST_uint_eq(reseed_request_sec, reseed_request_test)
+        || !TEST_int_eq(reseed_time_interval_sec,
+            reseed_time_interval_test))
+        goto err;
+
+    res = 1;
+err:
+    OSSL_LIB_CTX_free(ctx);
+    return res;
+}
 int setup_tests(void)
 {
     if (!test_skip_common_options()) {
@@ -486,5 +545,6 @@ int setup_tests(void)
     ADD_MFAIL_ALL_TESTS(test_rand_bytes_mfail, 2);
     ADD_MFAIL_TEST(test_rand_seed_src_mfail);
     ADD_MFAIL_TEST(test_rand_drbg_mfail);
+    ADD_TEST(test_rand_set_default_parameters);
     return 1;
 }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5728,3 +5728,5 @@ ASN1_STRING_set_data                    ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_set_string                  ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_length_ex                   ?	4_1_0	EXIST::FUNCTION:
 CMS_add_standard_smimecap_ex            ?	4_1_0	EXIST::FUNCTION:CMS
+RAND_set_default_parameters             ?	4_1_0	EXIST::FUNCTION:
+RAND_set_default_primary_parameters     ?	4_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
RAND_set_default_parameters and RAND_set_default_primary_parameters can be used to set parameters used to instantiate the primary, private and public DRBGs.
 
I'm still really unsure about names here. `RAND_set_default_primary_parameters` seems logical, but also overly long.
It also seems useful to be able to set different defaults for the primary and the secondary generators, I'm not sure if I should also add different defaults for primary and secondary.

- [x] documentation is added or updated
- [x] tests are added or updated
