### PR TITLE
Address Coverity issues 1655235 and 1655233

### DIFF
--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -283,9 +283,7 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
         off = (ossl_ssize_t)num;
         /* FALLTHRU */
     case BIO_C_FILE_TELL:
-        ret = (long)off;
-        if (off > LONG_MAX)
-            ret = -1;
+        ret = off;
         break;
     case BIO_CTRL_EOF:
         ret = (long)(bm->length == 0);

--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -283,7 +283,7 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
         off = (ossl_ssize_t)num;
         /* FALLTHRU */
     case BIO_C_FILE_TELL:
-        ret = off;
+        ret = (long)off;
         break;
     case BIO_CTRL_EOF:
         ret = (long)(bm->length == 0);


### PR DESCRIPTION
The result for `off` will either be 0 or a number within the size of `char *` (`SIZE_MAX`) as a result of line 257. And because `SIZE_MAX` will always be smaller than `LONG_MAX`, we don't have to keep the `if` check

Fixes https://github.com/openssl/project/issues/1264