### PR TITLE
test/evp_extra_test.c: Add check for BIO_new()

### DIFF
--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1071,6 +1071,9 @@ static int test_selection(EVP_PKEY *pkey, int selection)
     int ret;
     BIO *bio = BIO_new(BIO_s_mem());
 
+    if (!TEST_ptr(bio))
+        goto err;
+
     ret = PEM_write_bio_PUBKEY(bio, pkey);
     if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0) {
         if (!TEST_true(ret))


### PR DESCRIPTION
Add check for the return value of BIO_new() to avoid NULL pointer dereference.

Fixes: fd19fc4c27 ("Test that a key is usable after an EVP_PKEY_fromdata call")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
