### PR TITLE
test/quic-openssl-docker/hq-interop/quic-hq-interop.c: Move BIO_free(…

### DIFF
--- a/test/quic-openssl-docker/hq-interop/quic-hq-interop.c
+++ b/test/quic-openssl-docker/hq-interop/quic-hq-interop.c
@@ -911,8 +911,6 @@ int main(int argc, char *argv[])
             goto end;
         }
     }
-    BIO_free(req_bio);
-    req_bio = NULL;
     reqnames[read_offset + 1] = '\0';
 
     if (!setup_connection(hostname, port, &ctx, &ssl)) {
@@ -1042,6 +1040,7 @@ int main(int argc, char *argv[])
      */
     BIO_ADDR_free(peer_addr);
     OPENSSL_free(reqnames);
+    BIO_free(req_bio);
     BIO_free(session_bio);
     for (poll_idx = 0; poll_idx < poll_count; poll_idx++) {
         BIO_free(outbiolist[poll_idx]);


### PR DESCRIPTION
…) to err label to avoid memory leak

Relocate the BIO_free() call to the 'err' label to ensure the memory is properly freed in case of an error.

Fixes: ec6200bf0f ("Move hq-interop code to test/quic-openssl-docker")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
