### PR TITLE
Fix openssl-cms man page references to -EncryptedData_encrypt option

### DIFF
--- a/doc/man1/openssl-cms.pod.in
+++ b/doc/man1/openssl-cms.pod.in
@@ -425,7 +425,7 @@ Currently, the AES variants with GCM mode are the only supported AEAD
 algorithms.
 
 If not specified, AES-256-CBC is used as the default. Only used with B<-encrypt> and
-B<-EncryptedData_create> commands.
+B<-EncryptedData_encrypt> commands.
 
 =item B<-kekcipher> I<cipher>
 
@@ -792,7 +792,7 @@ The use of PSS with B<-sign>.
 
 The use of OAEP or non-RSA keys with B<-encrypt>.
 
-Additionally the B<-EncryptedData_create> and B<-data_create> type cannot
+Additionally the B<-EncryptedData_encrypt> and B<-data_create> type cannot
 be processed by the older L<openssl-smime(1)> command.
 
 =head1 EXAMPLES


### PR DESCRIPTION
CLA: trivial