### PR TITLE
test/timing_load_creds.c: Add fclose() if error occurs

### DIFF
--- a/test/timing_load_creds.c
+++ b/test/timing_load_creds.c
@@ -150,6 +150,7 @@ int main(int ac, char **av)
     }
     fp = fopen(av[0], "r");
     if ((long)fread(contents, 1, sb.st_size, fp) != sb.st_size) {
+        fclose(fp);
         OPENSSL_free(contents);
         perror("fread");
         exit(EXIT_FAILURE);


### PR DESCRIPTION
Add fclose() if error occurs to release fp.

Fixes: 6212fc6814 ("Add a stand-alone "timing" program")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
