### PR TITLE
test/quic_multistream_test.c: Add OPENSSL_free() to avoid memory leak

### DIFF
--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -853,6 +853,7 @@ static int helper_init(struct helper *h, const char *script_name,
 
     h->start_time   = ossl_time_now();
     h->init         = 1;
+    OPENSSL_free(bdata);
     return 1;
 
 err:


### PR DESCRIPTION
Add OPENSSL_free() in the success path to avoid memory leak if not need_injector.

Fixes: c7b82a7250 ("Fixup tests to properly check version negotiation")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
