### PR TITLE
Make the lock in CRYPTO_secure_actual_size a read lock

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -278,7 +278,7 @@ size_t CRYPTO_secure_actual_size(void *ptr)
 #ifndef OPENSSL_NO_SECURE_MEMORY
     size_t actual_size;
 
-    if (!CRYPTO_THREAD_write_lock(sec_malloc_lock))
+    if (!CRYPTO_THREAD_read_lock(sec_malloc_lock))
         return 0;
     actual_size = sh_actual_size(ptr);
     CRYPTO_THREAD_unlock(sec_malloc_lock);


### PR DESCRIPTION
there is no operations within critical section that would require write lock.
