### PR TITLE
ci: enable lms only on master

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -62,7 +62,7 @@ jobs:
               "extra_config": "no-afalgeng enable-fips"
             }, {
               "branch": "master",
-              "extra_config": "no-afalgeng enable-fips enable-tfo"
+              "extra_config": "no-afalgeng enable-fips enable-tfo enable-lms"
           }]
           EOF
           )
@@ -99,7 +99,7 @@ jobs:
     - name: setup hostname workaround
       run: sudo hostname localhost
     - name: config
-      run: CC=gcc ./config --debug --coverage ${{ matrix.branches.extra_config }} no-asm enable-lms enable-rc5 enable-md2 enable-ssl3 enable-nextprotoneg enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 enable-buildtest-c++ enable-ssl-trace enable-trace
+      run: CC=gcc ./config --debug --coverage ${{ matrix.branches.extra_config }} no-asm enable-rc5 enable-md2 enable-ssl3 enable-nextprotoneg enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 enable-buildtest-c++ enable-ssl-trace enable-trace
     - name: config dump
       run: ./configdata.pm --dump
     - name: make

--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 env:
-  opts: enable-lms enable-rc5 enable-md2 enable-ssl3 enable-weak-ssl-ciphers enable-zlib
+  opts: enable-rc5 enable-md2 enable-ssl3 enable-weak-ssl-ciphers enable-zlib
 
 jobs:
   fips-releases:
@@ -111,30 +111,37 @@ jobs:
           #     `dir' directory that will be used to build and test in.
           #     `tgz' is the name of the tarball use to keep the artifacts of
           #         the build.
+          #     `extra_config` adds extra config build option for the branch.
           {
             name: openssl-3.0,
             dir: branch-3.0,
             tgz: branch-3.0.tar.gz,
+            extra_config: "",
           }, {
             name: openssl-3.2,
             dir: branch-3.2,
             tgz: branch-3.2.tar.gz,
+            extra_config: "",
           }, {
             name: openssl-3.3,
             dir: branch-3.3,
             tgz: branch-3.3.tar.gz,
+            extra_config: "",
           }, {
             name: openssl-3.4,
             dir: branch-3.4,
             tgz: branch-3.4.tar.gz,
+            extra_config: "",
           }, {
             name: openssl-3.5,
             dir: branch-3.5,
             tgz: branch-3.5.tar.gz,
+            extra_config: "",
           }, {
             name: master,
             dir: branch-master,
             tgz: branch-master.tar.gz,
+            extra_config: "enable-lms",
           },
         ]
 
@@ -150,7 +157,7 @@ jobs:
 
       - name: config branch
         run: |
-          ./config --banner=Configured enable-shared enable-fips ${{ env.opts }}
+          ./config --banner=Configured enable-shared enable-fips ${{ env.opts }} ${{ matrix.branch.extra_config }}
         working-directory: ${{ matrix.branch.dir }}
       - name: config dump current
         run: ./configdata.pm --dump


### PR DESCRIPTION
a new config option cannot be enabled globally because the option was not backported to the older versions.