### PR TITLE
Updates to openssl-env(7) and friends to consistently document environment variable usage

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1180,7 +1180,7 @@ generate_buildinfo: generate_doc_buildinfo
 
 .PHONY: doc-nits md-nits
 doc-nits: build_generated_pods ## Evaluate OpenSSL documentation
-	$(PERL) $(SRCDIR)/util/find-doc-nits -c -n -l -e -i
+	$(PERL) $(SRCDIR)/util/find-doc-nits -c -n -l -e -i -a
 
 # This uses "mdl", the markdownlint application, which is written in ruby.
 # The source is at https://github.com/markdownlint/markdownlint

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -3047,15 +3047,11 @@ BIO *dup_bio_out(int format)
 {
     BIO *b = BIO_new_fp(stdout,
                         BIO_NOCLOSE | (FMT_istext(format) ? BIO_FP_TEXT : 0));
-    void *prefix = NULL;
-    BIO *btmp;
-
-    if (b == NULL)
-        return NULL;
 
 #ifdef OPENSSL_SYS_VMS
-    if (FMT_istext(format)) {
-        btmp = BIO_new(BIO_f_linebuffer());
+    if (b != NULL && FMT_istext(format)) {
+        BIO *btmp = BIO_new(BIO_f_linebuffer());
+
         if (btmp == NULL) {
             BIO_free(b);
             return NULL;
@@ -3063,17 +3059,6 @@ BIO *dup_bio_out(int format)
         b = BIO_push(btmp, b);
     }
 #endif
-
-    if (FMT_istext(format)
-        && (prefix = getenv("HARNESS_OSSL_PREFIX")) != NULL) {
-        btmp = BIO_new(BIO_f_prefix());
-        if (btmp == NULL) {
-            BIO_free_all(b);
-            return NULL;
-        }
-        b = BIO_push(btmp, b);
-        BIO_set_prefix(b, prefix);
-    }
 
     return b;
 }

--- a/doc/man1/openssl-rehash.pod.in
+++ b/doc/man1/openssl-rehash.pod.in
@@ -133,6 +133,13 @@ By default, this command only lists each directory as it is processed.
 The path to an executable to use to generate hashes and
 fingerprints (see above).
 
+=item B<PATH>
+
+List of paths, separated by colons (or semicolons, on Windows platforms),
+where the B<openssl> executable is searched in case the path to the hash
+generating executable is not provided in the B<OPENSSL> environment variable
+or it is not usable (that is, does not exist or is not executable).
+
 =item B<SSL_CERT_DIR>
 
 Colon separated list of directories to operate on.

--- a/doc/man1/openssl-s_time.pod.in
+++ b/doc/man1/openssl-s_time.pod.in
@@ -134,6 +134,18 @@ See L<openssl(1)/TLS Version Options>.
 
 =back
 
+=head1 ENVIRONMENT
+
+=over 4
+
+=item B<SSL_CIPHER>
+
+If the B<-cipher> option is not specified, the contents of this environment
+variable are used to modify the TLSv1.2 and below cipher list sent
+by the client the same way the aforementioned option does.
+
+=back
+
 =head1 NOTES
 
 This command can be used to measure the performance of an SSL connection.

--- a/doc/man3/OPENSSL_malloc.pod
+++ b/doc/man3/OPENSSL_malloc.pod
@@ -18,7 +18,8 @@ CRYPTO_get_alloc_counts,
 CRYPTO_set_mem_debug, CRYPTO_mem_ctrl,
 CRYPTO_mem_leaks, CRYPTO_mem_leaks_fp, CRYPTO_mem_leaks_cb,
 OPENSSL_MALLOC_FAILURES,
-OPENSSL_MALLOC_FD
+OPENSSL_MALLOC_FD,
+OPENSSL_MALLOC_SEED
 - Memory allocation functions
 
 =head1 SYNOPSIS
@@ -69,6 +70,7 @@ OPENSSL_MALLOC_FD
 
  env OPENSSL_MALLOC_FAILURES=... <application>
  env OPENSSL_MALLOC_FD=... <application>
+ env OPENSSL_MALLOC_SEED=... <application>
 
 The following functions have been deprecated since OpenSSL 3.0, and can be
 hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
@@ -155,9 +157,9 @@ with CRYPTO_set_mem_functions(), it's recommended to swap them all out
 at once.
 
 If the library is built with the C<crypto-mdebug> option, then one
-function, CRYPTO_get_alloc_counts(), and two additional environment
-variables, B<OPENSSL_MALLOC_FAILURES> and B<OPENSSL_MALLOC_FD>,
-are available.
+function, CRYPTO_get_alloc_counts(), and three additional environment
+variables, B<OPENSSL_MALLOC_FAILURES>, B<OPENSSL_MALLOC_FD>,
+and B<OPENSSL_MALLOC_SEED>, are available.
 
 The function CRYPTO_get_alloc_counts() fills in the number of times
 each of CRYPTO_malloc(), CRYPTO_realloc(), and CRYPTO_free() have been
@@ -172,8 +174,9 @@ as a floating point number that is rounded up to two decimal digits
 of precision, defaulting to 100).  If the count is zero, then it lasts forever.
 For example, C<100;@0.258> or C<100@0;0@0.258> means the first 100 allocations
 pass, then all other allocations (until the program exits or crashes) have
-a 0.26% chance of failing. The length of the value of B<OPENSSL_MALLOC_FAILURES>
-must be 256 or fewer characters.
+a 0.26% chance of failing, with random(3) used as a source of randomness.
+The length of the value of B<OPENSSL_MALLOC_FAILURES> must be 256 or fewer
+characters.
 
 If the variable B<OPENSSL_MALLOC_FD> is parsed as a positive integer, then
 it is taken as an open file descriptor. This is used in conjunction with
@@ -188,6 +191,10 @@ work on all platforms):
   OPENSSL_MALLOC_FD=3
   export OPENSSL_MALLOC_FD
   ...app invocation... 3>/tmp/log$$
+
+If the environment variable B<OPENSSL_MALLOC_SEED> is set, its value
+is interpreted as an integer using atoi(3) and supplied to the srandom(3)
+call for the random number generator initialisation.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/OPENSSL_malloc.pod
+++ b/doc/man3/OPENSSL_malloc.pod
@@ -167,12 +167,13 @@ respectively.  If a pointer is NULL, then the corresponding count is not stored.
 The variable
 B<OPENSSL_MALLOC_FAILURES> controls how often allocations should fail.
 It is a set of fields separated by semicolons, which each field is a count
-(defaulting to zero) and an optional atsign and percentage (defaulting
-to 100).  If the count is zero, then it lasts forever.  For example,
-C<100;@25> or C<100@0;0@25> means the first 100 allocations pass, then all
-other allocations (until the program exits or crashes) have a 25% chance of
-failing. The length of the value of B<OPENSSL_MALLOC_FAILURES> must be 256 or
-fewer characters.
+(defaulting to zero) and an optional atsign and percentage (interpreted
+as a floating point number that is rounded up to two decimal digits
+of precision, defaulting to 100).  If the count is zero, then it lasts forever.
+For example, C<100;@0.258> or C<100@0;0@0.258> means the first 100 allocations
+pass, then all other allocations (until the program exits or crashes) have
+a 0.26% chance of failing. The length of the value of B<OPENSSL_MALLOC_FAILURES>
+must be 256 or fewer characters.
 
 If the variable B<OPENSSL_MALLOC_FD> is parsed as a positive integer, then
 it is taken as an open file descriptor. This is used in conjunction with

--- a/doc/man3/PKCS12_gen_mac.pod
+++ b/doc/man3/PKCS12_gen_mac.pod
@@ -67,6 +67,28 @@ given passphrase. See L<passphrase-encoding(7)> for more information.
 
 All functions returning an integer return 1 on success and 0 if an error occurred.
 
+=head1 ENVIRONMENT
+
+=over 4
+
+=item B<LEGACY_GOST_PKCS12>
+
+=for comment
+https://tc26.ru/standarts/metodicheskie-rekomendatsii/transportnyy-klyuchevoy-konteyner.html section 5.1
+https://tc26.ru/standard/rs/%D0%A0%2050.1.112-2016.pdf section 5
+https://meganorm.ru/mega_doc/norm/prikaz/25/r_1323565_1_041-2022_rekomendatsii_po_standartizatsii.html section 7.1
+
+If this environment variable is set, MAC generation that utilises
+GOST R 34.11-94 or GOST 34.11-2012 hashing algorithms is performed the usual
+way and not in accordance with the specification provided in the methodical
+recommendation MP 26.2.002-2012 (or in its later versions, standartisation
+recommendation P 50.1.112-2016 or P 1323565.1.041-2022)
+of Technical Committee 26, that specifies that the key used for MAC
+generation should be the last 32 bytes of the 96-byte sequence generated
+by L<PKCS5_PBKDF2_HMAC(3)> and not the whole sequence.
+
+=back
+
 =head1 CONFORMING TO
 
 IETF RFC 7292 (L<https://tools.ietf.org/html/rfc7292>)

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -6,8 +6,8 @@ openssl-env - OpenSSL environment variables
 
 =head1 DESCRIPTION
 
-The OpenSSL libraries use environment variables to override the
-compiled-in default paths for various data.
+The OpenSSL libraries and commands use environment variables to override
+compiled-in defaults for various aspects of their behaviour.
 To avoid security risks, the environment is not consulted
 for security-sensitive environment variables when the executable
 is set-user-ID or set-group-ID.

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -107,6 +107,14 @@ Default is 0. For more info see L<CRYPTO_secure_malloc_init(3)>.
 
 This variable is not considered security-sensitive.
 
+=item B<OPENSSL_TEST_LIBCTX>
+
+This test-only environment variable, that is recognised by the L<openssl(1)>
+command, when is set to "1", leads to creation of a nondefault library context
+by the command, for which the B<-config> option then takes effect.
+
+This variable is not considered security-sensitive.
+
 =item B<OPENSSL_TRACE>
 
 By default the OpenSSL trace feature is disabled statically.

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -46,6 +46,13 @@ Specifies a configuration option and filename for the B<req> and B<ca>
 commands invoked by the B<CA.pl> script.
 See L<CA.pl(1)>.
 
+=item B<OPENSSL_DEBUG_DECC_INIT>
+
+On VMS only:  if this variable is set, enables verbose output of parsing
+of C<DECC$*> logical names, that contain C RTL features, during library
+initialisation (C<LIB$INITIALIZE>).  If the value of the variable is more
+than 1, outputs information about every processed feature.
+
 =item B<OPENSSL_ENGINES>
 
 Specifies the directory from which dynamic engines are loaded.

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -21,6 +21,15 @@ See L<CTLOG_STORE_new(3)>.
 
 This variable is considered a security-sensitive environment variable.
 
+=item B<HOME>, B<SYSTEMROOT>, B<USERPROFILE>
+
+Path which L<RAND_file_name(3)> uses as a directory for the random seed file
+name when the B<RANDFILE> environment variable is not set.
+B<HOME> is the only variable that is considered on Unix-like systems;
+B<USERPROFILE> and B<SYSTEMROOT> are used as fallbacks on Windows platforms.
+
+B<HOME> variable is considered a security-sensitive environment variable.
+
 =item B<HTTPS_PROXY>, B<HTTP_PROXY>, B<NO_PROXY>, B<https_proxy>, B<http_proxy>, B<no_proxy>
 
 Specify a proxy hostname.

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -46,7 +46,7 @@ See L<CA.pl(1)>.
 Specifies the directory from which dynamic engines are loaded.
 See L<openssl-engine(1)>.
 
-=item B<OPENSSL_MALLOC_FD>, B<OPENSSL_MALLOC_FAILURES>
+=item B<OPENSSL_MALLOC_FAILURES>, B<OPENSSL_MALLOC_FD>, B<OPENSSL_MALLOC_SEED>
 
 If built with debugging, this allows memory allocation to fail.
 See L<OPENSSL_malloc(3)>.

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -181,13 +181,13 @@ See L<SSL_CTX_load_verify_locations(3)>.
 
 Additional arguments for the L<tsget(1)> command.
 
-=item B<OPENSSL_ia32cap>, B<OPENSSL_sparcv9cap>, B<OPENSSL_ppccap>, B<OPENSSL_armcap>, B<OPENSSL_s390xcap>, B<OPENSSL_riscvcap>
+=item B<OPENSSL_armcap>, B<OPENSSL_ia32cap>, B<OPENSSL_ppccap>, B<OPENSSL_riscvcap>, B<OPENSSL_s390xcap>, B<OPENSSL_sparcv9cap>
 
 OpenSSL supports a number of different algorithm implementations for
 various machines and, by default, it determines which to use based on the
 processor capabilities and run time feature enquiry.  These environment
 variables can be used to exert more control over this selection process.
-See L<OPENSSL_ia32cap(3)>, L<OPENSSL_s390xcap(3)> and L<OPENSSL_riscvcap(3)>.
+See L<OPENSSL_ia32cap(3)>, L<OPENSSL_riscvcap(3)>, and L<OPENSSL_s390xcap(3)>.
 
 =item B<NO_PROXY>, B<HTTPS_PROXY>, B<HTTP_PROXY>
 

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -23,6 +23,11 @@ See L<CTLOG_STORE_new(3)>.
 Specify a proxy hostname.
 See L<OSSL_HTTP_parse_url(3)>.
 
+=item B<LEGACY_GOST_PKCS12>
+
+Affects the way MAC is generated in PKCS#12 containers for GOST algorithms.
+See L<PKCS12_gen_mac(3)>.
+
 =item B<OPENSSL>
 
 Specifies the path to the B<openssl> executable. Used by

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -18,6 +18,11 @@ the executable is set-user-ID or set-group-ID.
 Specifies the path to a certificate transparency log list.
 See L<CTLOG_STORE_new(3)>.
 
+=item B<NO_PROXY>, B<HTTPS_PROXY>, B<HTTP_PROXY>
+
+Specify a proxy hostname.
+See L<OSSL_HTTP_parse_url(3)>.
+
 =item B<OPENSSL>
 
 Specifies the path to the B<openssl> executable. Used by
@@ -166,21 +171,6 @@ the L<openssl(1)> program also transcodes the command-line parameters
 from the current code page to UTF-8.
 This environment variable is only checked on Microsoft Windows platforms.
 
-=item B<RANDFILE>
-
-The state file for the random number generator.
-This should not be needed in normal use.
-See L<RAND_load_file(3)>.
-
-=item B<SSL_CERT_DIR>, B<SSL_CERT_FILE>
-
-Specify the default directory or file containing CA certificates.
-See L<SSL_CTX_load_verify_locations(3)>.
-
-=item B<TSGET>
-
-Additional arguments for the L<tsget(1)> command.
-
 =item B<OPENSSL_armcap>, B<OPENSSL_ia32cap>, B<OPENSSL_ppccap>, B<OPENSSL_riscvcap>, B<OPENSSL_s390xcap>, B<OPENSSL_sparcv9cap>
 
 OpenSSL supports a number of different algorithm implementations for
@@ -189,18 +179,19 @@ processor capabilities and run time feature enquiry.  These environment
 variables can be used to exert more control over this selection process.
 See L<OPENSSL_ia32cap(3)>, L<OPENSSL_riscvcap(3)>, and L<OPENSSL_s390xcap(3)>.
 
-=item B<NO_PROXY>, B<HTTPS_PROXY>, B<HTTP_PROXY>
+=item B<OSSL_QFILTER>
 
-Specify a proxy hostname.
-See L<OSSL_HTTP_parse_url(3)>.
+Used to set a QUIC qlog filter specification. See L<openssl-qlog(7)>.
 
 =item B<QLOGDIR>
 
 Specifies a QUIC qlog output directory. See L<openssl-qlog(7)>.
 
-=item B<OSSL_QFILTER>
+=item B<RANDFILE>
 
-Used to set a QUIC qlog filter specification. See L<openssl-qlog(7)>.
+The state file for the random number generator.
+This should not be needed in normal use.
+See L<RAND_load_file(3)>.
 
 =item B<SSLKEYLOGFILE>
 
@@ -213,6 +204,15 @@ Note: the use of B<SSLKEYLOGFILE> poses an explicit security risk.  By recording
 the exchanged keys during an SSL session, it allows any available party with
 read access to the file to decrypt application traffic sent over that session.
 Use of this feature should be restricted to test and debug environments only.
+
+=item B<SSL_CERT_DIR>, B<SSL_CERT_FILE>
+
+Specify the default directory or file containing CA certificates.
+See L<SSL_CTX_load_verify_locations(3)>.
+
+=item B<TSGET>
+
+Additional arguments for the L<tsget(1)> command.
 
 =back
 

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -222,6 +222,24 @@ Additional arguments for the L<tsget(1)> command.
 
 =back
 
+=head1 HISTORY
+
+This section contains environment variables that are no longer considered
+by the OpenSSL libraries and commands.
+
+=over 4
+
+=item B<HARNESS_OSSL_PREFIX>
+
+This environment variable, existed in OpenSSL versions from 1.1.1 up to 3.5,
+allowed specification of a prefix prepended to each line sent to the I<stdout>
+by L<openssl(1)>, used by the test harness to avoid commingling the command
+under test output with the output for the TAP consumer.
+
+This variable was not considered security-sensitive.
+
+=back
+
 =head1 COPYRIGHT
 
 Copyright 2019-2024 The OpenSSL Project Authors. All Rights Reserved.

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -192,7 +192,10 @@ Traces encoder operations.
 
 =item B<REF_COUNT>
 
-Traces decrementing certain ASN.1 structure references.
+Traces reference count changes in various structures,
+including C<BIO>, C<DH>, C<DSA>, C<EC_KEY>, C<ECX_KEY>,
+C<EVP_PKEY>, C<EVP_SKEY>, C<RSA>, C<SSL>, C<SSL_CTX>, C<SSL_SESSION>,
+C<X509_CRL>, C<X509_STORE>, C<X509>, and some others.
 
 =item B<HTTP>
 

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -122,53 +122,9 @@ with the following available:
 
 =over 4
 
-=item B<TRACE>
+=item B<ALL>
 
-Traces the OpenSSL trace API itself.
-
-=item B<INIT>
-
-Traces OpenSSL library initialization and cleanup.
-
-=item B<TLS>
-
-Traces the TLS/SSL protocol.
-
-=item B<TLS_CIPHER>
-
-Traces the ciphers used by the TLS/SSL protocol.
-
-=item B<CONF>
-
-Show details about provider and engine configuration.
-
-=item B<ENGINE_TABLE>
-
-The function that is used by RSA, DSA (etc) code to select registered
-ENGINEs, cache defaults and functional references (etc), will generate
-debugging summaries.
-
-=item B<ENGINE_REF_COUNT>
-
-Reference counts in the ENGINE structure will be monitored with a line
-of generated for each change.
-
-=item B<PKCS5V2>
-
-Traces PKCS#5 v2 key generation.
-
-=item B<PKCS12_KEYGEN>
-
-Traces PKCS#12 key generation.
-
-=item B<PKCS12_DECRYPT>
-
-Traces PKCS#12 decryption.
-
-=item B<X509V3_POLICY>
-
-Generates the complete policy tree at various points during X.509 v3
-policy evaluation.
+Traces everything.
 
 =item B<BN_CTX>
 
@@ -178,9 +134,9 @@ Traces BIGNUM context operations.
 
 Traces CMP client and server activity.
 
-=item B<STORE>
+=item B<CONF>
 
-Traces STORE operations.
+Show details about provider and engine configuration.
 
 =item B<DECODER>
 
@@ -190,16 +146,36 @@ Traces decoder operations.
 
 Traces encoder operations.
 
-=item B<REF_COUNT>
+=item B<ENGINE_REF_COUNT>
 
-Traces reference count changes in various structures,
-including C<BIO>, C<DH>, C<DSA>, C<EC_KEY>, C<ECX_KEY>,
-C<EVP_PKEY>, C<EVP_SKEY>, C<RSA>, C<SSL>, C<SSL_CTX>, C<SSL_SESSION>,
-C<X509_CRL>, C<X509_STORE>, C<X509>, and some others.
+Reference counts in the ENGINE structure will be monitored with a line
+of generated for each change.
+
+=item B<ENGINE_TABLE>
+
+The function that is used by RSA, DSA (etc) code to select registered
+ENGINEs, cache defaults and functional references (etc), will generate
+debugging summaries.
 
 =item B<HTTP>
 
 Traces the HTTP client and server, such as messages being sent and received.
+
+=item B<INIT>
+
+Traces OpenSSL library initialization and cleanup.
+
+=item B<PKCS12_DECRYPT>
+
+Traces PKCS#12 decryption.
+
+=item B<PKCS12_KEYGEN>
+
+Traces PKCS#12 key generation.
+
+=item B<PKCS5V2>
+
+Traces PKCS#5 v2 key generation.
 
 =item B<PROVIDER>
 
@@ -212,6 +188,34 @@ parameter and capability retrieval, self-test, and so on.
 Traces operation related to addition, removal, and fetching of methods
 in the so-called method store, that holds pointers to functions provided
 by various providers.
+
+=item B<REF_COUNT>
+
+Traces reference count changes in various structures,
+including C<BIO>, C<DH>, C<DSA>, C<EC_KEY>, C<ECX_KEY>,
+C<EVP_PKEY>, C<EVP_SKEY>, C<RSA>, C<SSL>, C<SSL_CTX>, C<SSL_SESSION>,
+C<X509_CRL>, C<X509_STORE>, C<X509>, and some others.
+
+=item B<STORE>
+
+Traces STORE operations.
+
+=item B<TLS>
+
+Traces the TLS/SSL protocol.
+
+=item B<TLS_CIPHER>
+
+Traces the ciphers used by the TLS/SSL protocol.
+
+=item B<TRACE>
+
+Traces the OpenSSL trace API itself.
+
+=item B<X509V3_POLICY>
+
+Generates the complete policy tree at various points during X.509 v3
+policy evaluation.
 
 =back
 

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -8,8 +8,9 @@ openssl-env - OpenSSL environment variables
 
 The OpenSSL libraries use environment variables to override the
 compiled-in default paths for various data.
-To avoid security risks, the environment is usually not consulted when
-the executable is set-user-ID or set-group-ID.
+To avoid security risks, the environment is not consulted
+for security-sensitive environment variables when the executable
+is set-user-ID or set-group-ID.
 
 =over 4
 
@@ -18,15 +19,21 @@ the executable is set-user-ID or set-group-ID.
 Specifies the path to a certificate transparency log list.
 See L<CTLOG_STORE_new(3)>.
 
+This variable is considered a security-sensitive environment variable.
+
 =item B<HTTPS_PROXY>, B<HTTP_PROXY>, B<NO_PROXY>, B<https_proxy>, B<http_proxy>, B<no_proxy>
 
 Specify a proxy hostname.
 See L<OSSL_HTTP_parse_url(3)>.
 
+These variables are considered security-sensitive environment variables.
+
 =item B<LEGACY_GOST_PKCS12>
 
 Affects the way MAC is generated in PKCS#12 containers for GOST algorithms.
 See L<PKCS12_gen_mac(3)>.
+
+This variable is considered a security-sensitive environment variable.
 
 =item B<OPENSSL>
 
@@ -34,17 +41,23 @@ Specifies the path to the B<openssl> executable. Used by
 the B<rehash> script (see L<openssl-rehash(1)/Script Configuration>)
 and by the B<CA.pl> script (see L<CA.pl(1)/NOTES>
 
+This variable is not considered security-sensitive.
+
 =item B<OPENSSL_CONF>, B<OPENSSL_CONF_INCLUDE>
 
 Specifies the path to a configuration file and the directory for
 included files.
 See L<config(5)>.
 
+These variables are considered security-sensitive environment variables.
+
 =item B<OPENSSL_CONFIG>
 
 Specifies a configuration option and filename for the B<req> and B<ca>
 commands invoked by the B<CA.pl> script.
 See L<CA.pl(1)>.
+
+This variable is not considered security-sensitive.
 
 =item B<OPENSSL_DEBUG_DECC_INIT>
 
@@ -53,20 +66,28 @@ of C<DECC$*> logical names, that contain C RTL features, during library
 initialisation (C<LIB$INITIALIZE>).  If the value of the variable is more
 than 1, outputs information about every processed feature.
 
+This variable is not considered security-sensitive.
+
 =item B<OPENSSL_ENGINES>
 
 Specifies the directory from which dynamic engines are loaded.
 See L<openssl-engine(1)>.
+
+This variable is considered a security-sensitive environment variable.
 
 =item B<OPENSSL_MALLOC_FAILURES>, B<OPENSSL_MALLOC_FD>, B<OPENSSL_MALLOC_SEED>
 
 If built with debugging, this allows memory allocation to fail.
 See L<OPENSSL_malloc(3)>.
 
+These variables are not considered security-sensitive.
+
 =item B<OPENSSL_MODULES>
 
 Specifies the directory from which cryptographic providers are loaded.
 Equivalently, the generic B<-provider-path> command-line option may be used.
+
+This variable is considered a security-sensitive environment variable.
 
 =item B<OPENSSL_SEC_MEM>
 
@@ -76,11 +97,15 @@ indicates the B<size> parameter in bytes. The value can be expressed in
 binary, octal, decimal and hexadecimal. For formatting see B<strtol(3)>.
 For further restrictions see L<CRYPTO_secure_malloc_init(3)>.
 
+This variable is not considered security-sensitive.
+
 =item B<OPENSSL_SEC_MEM_MINSIZE>
 
 An optional variable used with B<OPENSSL_SEC_MEM>. The value indicates
 B<minsize> parameter in bytes. The same formatting applies as above.
 Default is 0. For more info see L<CRYPTO_secure_malloc_init(3)>.
+
+This variable is not considered security-sensitive.
 
 =item B<OPENSSL_TRACE>
 
@@ -175,6 +200,8 @@ Traces the HTTP client and server, such as messages being sent and received.
 
 =back
 
+This variable is not considered security-sensitive.
+
 =item B<OPENSSL_WIN32_UTF8>
 
 If set, then L<UI_OpenSSL(3)> returns UTF-8 encoded strings, rather than
@@ -191,19 +218,27 @@ processor capabilities and run time feature enquiry.  These environment
 variables can be used to exert more control over this selection process.
 See L<OPENSSL_ia32cap(3)>, L<OPENSSL_riscvcap(3)>, and L<OPENSSL_s390xcap(3)>.
 
+These variables are not considered security-sensitive.
+
 =item B<OSSL_QFILTER>
 
 Used to set a QUIC qlog filter specification. See L<openssl-qlog(7)>.
 
+This variable is considered a security-sensitive environment variable.
+
 =item B<QLOGDIR>
 
 Specifies a QUIC qlog output directory. See L<openssl-qlog(7)>.
+
+This variable is considered a security-sensitive environment variable.
 
 =item B<RANDFILE>
 
 The state file for the random number generator.
 This should not be needed in normal use.
 See L<RAND_load_file(3)>.
+
+This variable is considered a security-sensitive environment variable.
 
 =item B<SSLKEYLOGFILE>
 
@@ -217,10 +252,16 @@ the exchanged keys during an SSL session, it allows any available party with
 read access to the file to decrypt application traffic sent over that session.
 Use of this feature should be restricted to test and debug environments only.
 
+This variable is considered a security-sensitive environment variable.
+
 =item B<SSL_CERT_DIR>, B<SSL_CERT_FILE>
 
 Specify the default directory or file containing CA certificates.
 See L<SSL_CTX_load_verify_locations(3)>.
+
+These variables are considered security-sensitive environment variables,
+except in L<openssl-rehash(1)>, where B<SSL_CERT_DIR> is not considered
+security-sensitive.
 
 =item B<SSL_CIPHER>
 
@@ -228,9 +269,13 @@ Used by L<openssl-s_time(1)> in case B<-cipher> option (that allows modifying
 TLSv1.2 and below cipher list sent by the client) is not provided,
 for specification of the aforementioned ciphers.
 
+This variable is not considered security-sensitive.
+
 =item B<TSGET>
 
 Additional arguments for the L<tsget(1)> command.
+
+This variable is not considered security-sensitive.
 
 =back
 

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -204,6 +204,12 @@ Traces various operations that are performed on OpenSSL providers during their
 handling by the library (see L<provider(7)>), such as initialisation, tear down,
 parameter and capability retrieval, self-test, and so on.
 
+=item B<QUERY>
+
+Traces operation related to addition, removal, and fetching of methods
+in the so-called method store, that holds pointers to functions provided
+by various providers.
+
 =back
 
 This variable is not considered security-sensitive.

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -18,7 +18,7 @@ the executable is set-user-ID or set-group-ID.
 Specifies the path to a certificate transparency log list.
 See L<CTLOG_STORE_new(3)>.
 
-=item B<NO_PROXY>, B<HTTPS_PROXY>, B<HTTP_PROXY>
+=item B<HTTPS_PROXY>, B<HTTP_PROXY>, B<NO_PROXY>, B<https_proxy>, B<http_proxy>, B<no_proxy>
 
 Specify a proxy hostname.
 See L<OSSL_HTTP_parse_url(3)>.

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -210,6 +210,12 @@ Use of this feature should be restricted to test and debug environments only.
 Specify the default directory or file containing CA certificates.
 See L<SSL_CTX_load_verify_locations(3)>.
 
+=item B<SSL_CIPHER>
+
+Used by L<openssl-s_time(1)> in case B<-cipher> option (that allows modifying
+TLSv1.2 and below cipher list sent by the client) is not provided,
+for specification of the aforementioned ciphers.
+
 =item B<TSGET>
 
 Additional arguments for the L<tsget(1)> command.

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -198,6 +198,12 @@ Traces decrementing certain ASN.1 structure references.
 
 Traces the HTTP client and server, such as messages being sent and received.
 
+=item B<PROVIDER>
+
+Traces various operations that are performed on OpenSSL providers during their
+handling by the library (see L<provider(7)>), such as initialisation, tear down,
+parameter and capability retrieval, self-test, and so on.
+
 =back
 
 This variable is not considered security-sensitive.

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -117,7 +117,7 @@ Unless OpenSSL tracing support is generally disabled,
 enable trace output of specific parts of OpenSSL libraries, by name.
 This output usually makes sense only if you know OpenSSL internals well.
 
-The value of this environment varialble is a comma-separated list of names,
+The value of this environment variable is a comma-separated list of names,
 with the following available:
 
 =over 4

--- a/test/recipes/95-test_external_gost_engine_data/gost_engine.sh
+++ b/test/recipes/95-test_external_gost_engine_data/gost_engine.sh
@@ -48,7 +48,6 @@ echo "------------------------------------------------------------------"
 cmake $SRCTOP/gost-engine -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT_DIR" -DOPENSSL_ENGINES_DIR="$OPENSSL_ROOT_DIR/engines"
 make
 export CTEST_OUTPUT_ON_FAILURE=1
-export HARNESS_OSSL_PREFIX=''
 export OPENSSL_ENGINES="$PWD/bin"
 export OPENSSL_APP="$O_EXE/openssl"
 make test

--- a/test/recipes/95-test_external_oqsprovider_data/oqsprovider.sh
+++ b/test/recipes/95-test_external_oqsprovider_data/oqsprovider.sh
@@ -65,7 +65,6 @@ fi
 echo "   CWD:                $PWD"
 liboqs_DIR=$SRCTOP/oqs-provider/.local cmake $SRCTOP/oqs-provider -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT_DIR" -B _build && cmake --build _build
 export CTEST_OUTPUT_ON_FAILURE=1
-export HARNESS_OSSL_PREFIX=''
 export OPENSSL_APP="$O_EXE/openssl"
 export OPENSSL_MODULES=$PWD/_build/lib
 export OQS_PROVIDER_TESTSCRIPTS=$SRCTOP/oqs-provider/scripts

--- a/test/recipes/95-test_external_pkcs11_provider_data/pkcs11-provider.sh
+++ b/test/recipes/95-test_external_pkcs11_provider_data/pkcs11-provider.sh
@@ -63,9 +63,8 @@ echo "------------------------------------------------------------------"
 echo "Running tests"
 echo "------------------------------------------------------------------"
 
-# The OpenSSL app uses ${HARNESS_OSSL_PREFIX} as a prefix for its standard output
 # For maintenance reasons and simplicity we only run test with kryoptic token
-HARNESS_OSSL_PREFIX= meson test -C $PKCS11_PROVIDER_BUILDDIR --suite=kryoptic
+meson test -C $PKCS11_PROVIDER_BUILDDIR --suite=kryoptic
 
 if [ $? -ne 0 ]; then
     cat $PKCS11_PROVIDER_BUILDDIR/meson-logs/testlog.txt

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -42,11 +42,13 @@ our($opt_u);
 our($opt_v);
 our($opt_c);
 our($opt_i);
+our($opt_a);
 
 # Print usage message and exit.
 sub help {
     print <<EOF;
 Find small errors (nits) in documentation.  Options:
+    -a List undocumented env vars
     -c List undocumented commands, undocumented options and unimplemented options.
     -d Detailed list of undocumented (implies -u)
     -e Detailed list of new undocumented (implies -v)
@@ -62,7 +64,7 @@ EOF
     exit;
 }
 
-getopts('cdehlm:noiuv');
+getopts('acdehlm:noiuv');
 
 help() if $opt_h;
 $opt_u = 1 if $opt_d;
@@ -74,8 +76,8 @@ die "Cannot use both -d and -e"
 
 # We only need to check c, l, n, u and v.
 # Options d, e, o imply one of the above.
-die "Need one of -[cdehlnouv] flags.\n"
-    unless $opt_c or $opt_l or $opt_n or $opt_u or $opt_v;
+die "Need one of -[acdehlnouv] flags.\n"
+    unless $opt_a or $opt_c or $opt_l or $opt_n or $opt_u or $opt_v;
 
 
 my $temp = '/tmp/docnits.txt';
@@ -1275,6 +1277,104 @@ sub checkflags {
     }
 }
 
+sub check_env_vars {
+    # initialized with the list of "untracable" variables
+    my %env_list = ("SSL_CERT_FILE" => 1);
+    my @env_files;
+    my @except_env_files = (
+        "$config{sourcedir}/providers/implementations/keymgmt/template_kmgmt.c",
+        "$config{sourcedir}/providers/implementations/kem/template_kem.c",
+        "$config{sourcedir}/Makefile.in",
+    );
+    my @env_headers;
+    my @env_macro;
+
+    # look for source files
+    find(sub { push @env_files, $File::Find::name if /\.c$|\.in$/; },
+         $config{sourcedir});
+
+    foreach my $filename (@env_files) {
+        next if $filename =~ /test\/|demos\//
+                || grep { $_ eq $filename } @except_env_files;
+
+        open my $fh, '<', $filename or die "Can't open $filename: $!";
+        while (my $line = <$fh>) {
+            # for windows
+            # for .in files
+            $env_list{$1} = 1 if ($line =~ /GetEnvironmentVariableW\([\s\S]*"([^"]+)",/
+                || $line =~ /\$ENV\{([^}"']+)\}/);
+            # this also handles ossl_safe_getenv
+            if ($line =~ /getenv\(([^()\s]+)\)/) {
+                my $env1 = $1;
+                if ($env1 =~ /"([^"]+)"/) {
+                    $env_list{$1} = 1;
+                } elsif ($env1 =~ /([A-Z0-9_])/) {
+                    push(@env_macro, $env1);
+                }
+            }
+            # match ternary operators; $1 - true, $2 - false
+            if ($line =~ /env\(\s*[^?]+\?\s*([^:( ]+)\s*:\s*([^(]+)\s*\)/) {
+                my ($env1, $env2) = ($1, $2);
+                # if it's a string just add to the list
+                # otherwise look for the constant value later
+                if ($env1 =~ /"([^"]+)"/) {
+                    $env_list{$1} = 1;
+                } else {
+                    push(@env_macro, $env1);
+                }
+                if ($env2 =~ /"([^"]+)"/) {
+                    $env_list{$1} = 1;
+                } else {
+                    push(@env_macro, $env2);
+                }
+            }
+        }
+        close $fh;
+    }
+
+    # look for constants in header files
+    find(sub { push @env_headers, $File::Find::name if /\.h$/; },
+         $config{sourcedir});
+
+     foreach my $filename (@env_headers) {
+        open my $fh, '<', $filename or die "Can't open $filename: $!";
+        while (my $line = <$fh>) {
+            foreach my $em (@env_macro) {
+                $env_list{$1} = 1 if ($line =~ /define\s+\Q$em\E\s+"(\S+)"/);
+            }
+        }
+     }
+
+    # need to save the value before starting to delete from the hash
+    my $number_of_env = scalar keys %env_list;
+
+    # check for env vars in pod files
+    foreach ( files(TAGS => [ 'manual' ]) ) {
+        my %podinfo = extract_pod_info($_, { debug => $debug });
+        my $contents = $podinfo{contents};
+
+        # openssl-env.pod does not have ENVIRONMENT section, but the whole file
+        # is about environment variables
+        if ( $contents =~ /=head1 ENVIRONMENT(.*)=head1/ms ) {
+            $contents = $1;
+        } elsif ( $_ !~ /openssl-env.pod/ ) {
+            next;
+        }
+
+        for my $env_name (keys %env_list) {
+            delete($env_list{$env_name}) if $contents =~ $env_name;
+        }
+    }
+
+    print "Number of env vars found:".$number_of_env."\n" if $debug;
+    $number_of_env = scalar keys %env_list;
+    if ($number_of_env != 0) {
+        print "Undocumented environment variables:\n";
+        print join("\n", sort keys %env_list)."\n";
+        err("Total:".$number_of_env."\n");
+    }
+}
+
 ##
 ##  MAIN()
 ##  Do the work requested by the various getopt flags.
@@ -1371,6 +1471,10 @@ if ( $opt_n ) {
             err("$_ doesn't start with openssl-") unless /openssl-/;
         }
     }
+}
+
+if ( $opt_a ) {
+    check_env_vars();
 }
 
 checkstate();

--- a/util/other.syms
+++ b/util/other.syms
@@ -2,9 +2,12 @@
 # that don't appear in lib*.num -- because they are define's, in
 # assembly language, etc.
 #
+OPENSSL_armcap                          environment
 OPENSSL_ia32cap                         environment
-OPENSSL_s390xcap                        environment
+OPENSSL_ppccap                          environment
 OPENSSL_riscvcap                        environment
+OPENSSL_s390xcap                        environment
+OPENSSL_sparcv9cap                      environment
 OPENSSL_MALLOC_FD                       environment
 OPENSSL_MALLOC_FAILURES                 environment
 OPENSSL_instrument_bus                  assembler

--- a/util/other.syms
+++ b/util/other.syms
@@ -10,6 +10,7 @@ OPENSSL_s390xcap                        environment
 OPENSSL_sparcv9cap                      environment
 OPENSSL_MALLOC_FD                       environment
 OPENSSL_MALLOC_FAILURES                 environment
+OPENSSL_MALLOC_SEED                     environment
 OPENSSL_instrument_bus                  assembler
 OPENSSL_instrument_bus2                 assembler
 #


### PR DESCRIPTION
This patch set aims to consistently document environment variables used by the OpenSSL library and commands.  This includes:
 * sorting the variables in lexicographical order;
 * mentioning already documented `http_proxy`, `https_proxy`, and `no_proxy` environment variables;
 * removing `HARNESS_OSSL_PREFIX` environment usage and documenting it in the HISTORY section;
 * adding documentation for `HOME`, `LEGACY_GOST_PKCS12`, `OPENSSL_DEBUG_DECC_INIT`, `OPENSSL_MALLOC_SEED`, `OPENSSL_TEST_LIBCTX`, `PATH` (in `doc/man1/openssl-rehash.pod.in`), and `SSL_CIPHER` variables;
 * consistently documenting which environment variables are considered security-sensitive and not consulted when the execution is performed in an elevated context.
 * adding documentation for `PROVIDER` and `QUERY` `OPENSSL_TRACE` categories;
 * rewording `REF_COUNT` `OPENSSL_TRACE` category description, and sorting the categories lexicographically;
 * adding a check to `util/find-doc-nits` from #28070 for controlling whether all the used environment variables are covered by documentation, to ensure that the patch set delivers on its promise.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated