### PR TITLE
Don't enable lms on branches that don't support it

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -62,7 +62,7 @@ jobs:
               "extra_config": "no-afalgeng enable-fips"
             }, {
               "branch": "master",
-              "extra_config": "no-afalgeng enable-fips enable-tfo"
+              "extra_config": "no-afalgeng enable-fips enable-tfo enable-lms"
           }]
           EOF
           )
@@ -99,7 +99,7 @@ jobs:
     - name: setup hostname workaround
       run: sudo hostname localhost
     - name: config
-      run: CC=gcc ./config --debug --coverage ${{ matrix.branches.extra_config }} no-asm enable-lms enable-rc5 enable-md2 enable-ssl3 enable-nextprotoneg enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 enable-buildtest-c++ enable-ssl-trace enable-trace
+      run: CC=gcc ./config --debug --coverage ${{ matrix.branches.extra_config }} no-asm enable-rc5 enable-md2 enable-ssl3 enable-nextprotoneg enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 enable-buildtest-c++ enable-ssl-trace enable-trace
     - name: config dump
       run: ./configdata.pm --dump
     - name: make


### PR DESCRIPTION
commit 2bcfff8 enabled lms on all branches, but its supported on only the master branch currently, leading to config failures when the configure step is run on matrix elements that target branches other than master when running the coveralls ci job.  Fix it up to only enable lms on the master branch

Corrects failing job https://github.com/openssl/openssl/actions/runs/16256829424/job/45894488757

