### PR TITLE
Correctly fail on invalid pkey in CMS_decrypt

### DIFF
--- a/crypto/cms/cms_enc.c
+++ b/crypto/cms/cms_enc.c
@@ -151,25 +151,19 @@ BIO *ossl_cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec,
             ERR_clear_error();
     }
 
-    if (ec->keylen != tkeylen) {
-        /* If necessary set key length */
-        if (EVP_CIPHER_CTX_set_key_length(ctx, (int)ec->keylen) <= 0) {
-            /*
-             * Only reveal failure if debugging so we don't leak information
-             * which may be useful in MMA.
-             */
-            if (enc || ec->debug) {
-                ERR_raise(ERR_LIB_CMS, CMS_R_INVALID_KEY_LENGTH);
-                goto err;
-            } else {
-                /* Use random key */
-                OPENSSL_clear_free(ec->key, ec->keylen);
-                ec->key = tkey;
-                ec->keylen = tkeylen;
-                tkey = NULL;
-                ERR_clear_error();
-            }
+    if (ec->keylen != tkeylen
+        && EVP_CIPHER_CTX_set_key_length(ctx, (int)ec->keylen) <= 0) {
+        /* Fail only when this cannot act as an MMA oracle or debug enabled */
+        if (enc || ec->debug || ec->harderr) {
+            ERR_raise(ERR_LIB_CMS, CMS_R_INVALID_KEY_LENGTH);
+            goto err;
         }
+        /* Use random key */
+        OPENSSL_clear_free(ec->key, ec->keylen);
+        ec->key = tkey;
+        ec->keylen = tkeylen;
+        tkey = NULL;
+        ERR_clear_error();
     }
 
     if (EVP_CipherInit_ex(ctx, NULL, NULL, ec->key, piv, enc) <= 0) {

--- a/crypto/cms/cms_enc.c
+++ b/crypto/cms/cms_enc.c
@@ -140,25 +140,19 @@ BIO *ossl_cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec,
             ERR_clear_error();
     }
 
-    if (ec->keylen != tkeylen) {
-        /* If necessary set key length */
-        if (EVP_CIPHER_CTX_set_key_length(ctx, (int)ec->keylen) <= 0) {
-            /*
-             * Only reveal failure if debugging so we don't leak information
-             * which may be useful in MMA.
-             */
-            if (enc || ec->debug) {
-                ERR_raise(ERR_LIB_CMS, CMS_R_INVALID_KEY_LENGTH);
-                goto err;
-            } else {
-                /* Use random key */
-                OPENSSL_clear_free(ec->key, ec->keylen);
-                ec->key = tkey;
-                ec->keylen = tkeylen;
-                tkey = NULL;
-                ERR_clear_error();
-            }
+    if (ec->keylen != tkeylen
+        && EVP_CIPHER_CTX_set_key_length(ctx, (int)ec->keylen) <= 0) {
+        /* Fail only when this cannot act as an MMA oracle or debug enabled */
+        if (enc || ec->debug || ec->harderr) {
+            ERR_raise(ERR_LIB_CMS, CMS_R_INVALID_KEY_LENGTH);
+            goto err;
         }
+        /* Use random key */
+        OPENSSL_clear_free(ec->key, ec->keylen);
+        ec->key = tkey;
+        ec->keylen = tkeylen;
+        tkey = NULL;
+        ERR_clear_error();
     }
 
     if (EVP_CipherInit_ex(ctx, NULL, NULL, ec->key, piv, enc) <= 0) {

--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -20,6 +20,8 @@
 #include <openssl/err.h>
 #include <openssl/cms.h>
 #include <openssl/evp.h>
+#include <openssl/rsa.h>
+#include <openssl/params.h>
 #include <openssl/core_names.h>
 #include "internal/sizes.h"
 #include "crypto/asn1.h"
@@ -591,6 +593,35 @@ err:
 
 /* Decrypt content key from KTRI */
 
+/* Check whether reporting a key length mismatch cannot act as an MMA oracle */
+static int cms_ktri_harderr_ok(EVP_PKEY_CTX *pctx, EVP_PKEY *pkey)
+{
+    int pad_mode;
+    unsigned int implicit_rejection = 0;
+    OSSL_PARAM params[2];
+
+    if (!EVP_PKEY_is_a(pkey, "RSA")
+        || EVP_PKEY_CTX_get_rsa_padding(pctx, &pad_mode) <= 0)
+        return 0;
+
+    /* An RSA-OAEP decryption failure is safe to reveal */
+    if (pad_mode == RSA_PKCS1_OAEP_PADDING)
+        return 1;
+    if (pad_mode != RSA_PKCS1_PADDING)
+        return 0;
+
+    /* For PKCS#1 v1.5 it is only safe with implicit rejection in effect */
+    params[0] = OSSL_PARAM_construct_uint(
+        OSSL_ASYM_CIPHER_PARAM_IMPLICIT_REJECTION,
+        &implicit_rejection);
+    params[1] = OSSL_PARAM_construct_end();
+    if (EVP_PKEY_CTX_get_params(pctx, params) <= 0
+        || !OSSL_PARAM_modified(&params[0]))
+        return 0;
+
+    return implicit_rejection != 0;
+}
+
 static int cms_RecipientInfo_ktri_decrypt(CMS_ContentInfo *cms,
     CMS_RecipientInfo *ri)
 {
@@ -648,6 +679,17 @@ static int cms_RecipientInfo_ktri_decrypt(CMS_ContentInfo *cms,
 
     if (!ossl_cms_env_asn1_ctrl(ri, 1))
         goto err;
+
+    /*
+     * Check whether a decryption failure or a key length mismatch can be
+     * reported without MMA risk.  This must be determined before the
+     * decryption is attempted so a failure of the decryption itself (only
+     * possible for a publicly invalid ciphertext when implicit rejection
+     * is in effect, or a padding check failure with RSA-OAEP) is reported
+     * as well.
+     */
+    if (!ec->havenocert && !ec->debug)
+        ec->harderr = cms_ktri_harderr_ok(ktri->pctx, pkey);
 
     if (evp_pkey_decrypt_alloc(ktri->pctx, &ek, &eklen, fixlen,
             ktri->encryptedKey->data,

--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -20,6 +20,8 @@
 #include <openssl/err.h>
 #include <openssl/cms.h>
 #include <openssl/evp.h>
+#include <openssl/rsa.h>
+#include <openssl/params.h>
 #include <openssl/core_names.h>
 #include "internal/sizes.h"
 #include "crypto/asn1.h"
@@ -591,6 +593,35 @@ err:
 
 /* Decrypt content key from KTRI */
 
+/* Check whether reporting a key length mismatch cannot act as an MMA oracle */
+static int cms_ktri_harderr_ok(EVP_PKEY_CTX *pctx, EVP_PKEY *pkey)
+{
+    int pad_mode;
+    unsigned int implicit_rejection = 0;
+    OSSL_PARAM params[2];
+
+    if (!EVP_PKEY_is_a(pkey, "RSA")
+        || EVP_PKEY_CTX_get_rsa_padding(pctx, &pad_mode) <= 0)
+        return 0;
+
+    /* An RSA-OAEP decryption failure is safe to reveal */
+    if (pad_mode == RSA_PKCS1_OAEP_PADDING)
+        return 1;
+    if (pad_mode != RSA_PKCS1_PADDING)
+        return 0;
+
+    /* For PKCS#1 v1.5 it is only safe with implicit rejection in effect */
+    params[0] = OSSL_PARAM_construct_uint(
+        OSSL_ASYM_CIPHER_PARAM_IMPLICIT_REJECTION,
+        &implicit_rejection);
+    params[1] = OSSL_PARAM_construct_end();
+    if (EVP_PKEY_CTX_get_params(pctx, params) <= 0
+        || !OSSL_PARAM_modified(&params[0]))
+        return 0;
+
+    return implicit_rejection != 0;
+}
+
 static int cms_RecipientInfo_ktri_decrypt(CMS_ContentInfo *cms,
     CMS_RecipientInfo *ri)
 {
@@ -654,6 +685,10 @@ static int cms_RecipientInfo_ktri_decrypt(CMS_ContentInfo *cms,
             ktri->encryptedKey->length)
         <= 0)
         goto err;
+
+    /* Check whether a key length mismatch can be reported without MMA risk */
+    if (!ec->havenocert && !ec->debug)
+        ec->harderr = cms_ktri_harderr_ok(ktri->pctx, pkey);
 
     ret = 1;
 

--- a/crypto/cms/cms_local.h
+++ b/crypto/cms/cms_local.h
@@ -140,6 +140,8 @@ struct CMS_EncryptedContentInfo_st {
     int debug;
     /* Set to 1 if we have no cert and need extra safety measures for MMA */
     int havenocert;
+    /* Set to 1 if key length mismatch can be reported without an MMA risk */
+    int harderr;
 };
 
 struct CMS_RecipientInfo_st {

--- a/crypto/cms/cms_local.h
+++ b/crypto/cms/cms_local.h
@@ -145,6 +145,8 @@ struct CMS_EncryptedContentInfo_st {
     int debug;
     /* Set to 1 if we have no cert and need extra safety measures for MMA */
     int havenocert;
+    /* Set to 1 if key length mismatch can be reported without an MMA risk */
+    int harderr;
 };
 
 struct CMS_RecipientInfo_st {

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -792,6 +792,7 @@ int CMS_decrypt_set1_pkey_and_peer(CMS_ContentInfo *cms, EVP_PKEY *pk,
         OPENSSL_clear_free(ec->key, ec->keylen);
         ec->key = NULL;
         ec->keylen = 0;
+        ec->harderr = 0;
     }
 
     if (ris != NULL && ec != NULL)
@@ -835,10 +836,11 @@ int CMS_decrypt_set1_pkey_and_peer(CMS_ContentInfo *cms, EVP_PKEY *pk,
             CMS_RecipientInfo_set0_pkey(ri, NULL);
             if (cert != NULL) {
                 /*
-                 * If not debugging clear any error and return success to
-                 * avoid leaking of information useful to MMA
+                 * If not debugging and a failure cannot be reported safely,
+                 * clear any error and return success to avoid leaking of
+                 * information useful to MMA
                  */
-                if (!debug) {
+                if (!debug && (ec == NULL || !ec->harderr)) {
                     ERR_clear_error();
                     return 1;
                 }
@@ -919,6 +921,7 @@ int CMS_decrypt_set1_password(CMS_ContentInfo *cms,
         OPENSSL_clear_free(ec->key, ec->keylen);
         ec->key = NULL;
         ec->keylen = 0;
+        ec->harderr = 0;
     }
 
     for (i = 0; i < sk_CMS_RecipientInfo_num(ris); i++) {

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -760,6 +760,7 @@ int CMS_decrypt_set1_pkey_and_peer(CMS_ContentInfo *cms, EVP_PKEY *pk,
         OPENSSL_clear_free(ec->key, ec->keylen);
         ec->key = NULL;
         ec->keylen = 0;
+        ec->harderr = 0;
     }
 
     if (ris != NULL && ec != NULL)
@@ -887,6 +888,7 @@ int CMS_decrypt_set1_password(CMS_ContentInfo *cms,
         OPENSSL_clear_free(ec->key, ec->keylen);
         ec->key = NULL;
         ec->keylen = 0;
+        ec->harderr = 0;
     }
 
     for (i = 0; i < sk_CMS_RecipientInfo_num(ris); i++) {

--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -19,6 +19,8 @@
 
 static X509 *cert = NULL;
 static EVP_PKEY *privkey = NULL;
+static X509 *cert2 = NULL;
+static EVP_PKEY *privkey2 = NULL;
 static char *derin = NULL;
 static char *too_long_iv_cms_in = NULL;
 static char *pwri_kek_oob_der_in = NULL;
@@ -273,6 +275,50 @@ static int test_encrypt_decrypt_aes_192_gcm(void)
 static int test_encrypt_decrypt_aes_256_gcm(void)
 {
     return test_encrypt_decrypt(EVP_aes_256_gcm());
+}
+
+static int test_decrypt_with_wrong_key(void)
+{
+    int testresult = 0;
+    STACK_OF(X509) *certstack = sk_X509_new_null();
+    const char *msg = "Hello world";
+    BIO *msgbio = BIO_new_mem_buf(msg, (int)strlen(msg));
+    BIO *outmsgbio;
+    CMS_ContentInfo *content = NULL;
+    BIO *contentbio = NULL;
+    const EVP_CIPHER *cipher = EVP_aes_128_cbc();
+
+    if (!TEST_ptr(certstack) || !TEST_ptr(msgbio))
+        goto end;
+
+    if (!TEST_int_gt(sk_X509_push(certstack, cert), 0))
+        goto end;
+
+    content = CMS_encrypt(certstack, msgbio, cipher, 0);
+    if (!TEST_ptr(content))
+        goto end;
+
+    for (int i = 0; i < 1000; ++i) {
+        outmsgbio = BIO_new(BIO_s_mem());
+        if (!TEST_false(CMS_decrypt(content, privkey2, cert, NULL, outmsgbio,
+                            0)
+                == 1)) {
+            BIO_free(outmsgbio);
+            goto end;
+        }
+        BIO_free(outmsgbio);
+    }
+
+    ERR_clear_error();
+
+    testresult = 1;
+end:
+    BIO_free(contentbio);
+    sk_X509_free(certstack);
+    BIO_free(msgbio);
+    CMS_ContentInfo_free(content);
+
+    return testresult;
 }
 
 static int test_CMS_add1_cert(void)
@@ -739,12 +785,46 @@ end:
     return ret;
 }
 
-OPT_TEST_DECLARE_USAGE("certfile privkeyfile derfile tooLongIVpem pwriKekOobDer\n")
+static int load_certificate(const char *certin, X509 **certout)
+{
+    BIO *certbio = BIO_new_file(certin, "r");
+    if (!TEST_ptr(certbio))
+        return 0;
+    if (!TEST_true(PEM_read_bio_X509(certbio, certout, NULL, NULL))) {
+        BIO_free(certbio);
+        return 0;
+    }
+    BIO_free(certbio);
+
+    return 1;
+}
+
+static int load_private_key(const char *privkeyin, EVP_PKEY **privkeyout)
+{
+    BIO *privkeybio = BIO_new_file(privkeyin, "r");
+    if (!TEST_ptr(privkeybio)) {
+        X509_free(cert);
+        cert = NULL;
+        return 0;
+    }
+    if (!TEST_true(PEM_read_bio_PrivateKey(privkeybio, privkeyout, NULL, NULL))) {
+        BIO_free(privkeybio);
+        X509_free(cert);
+        cert = NULL;
+        return 0;
+    }
+    BIO_free(privkeybio);
+
+    return 1;
+}
+
+OPT_TEST_DECLARE_USAGE("certfile privkeyfile derfile tooLongIVpem pwriKekOobDer"
+                       " certfile2 privkeyfile2\n")
 
 int setup_tests(void)
 {
     char *certin = NULL, *privkeyin = NULL;
-    BIO *certbio = NULL, *privkeybio = NULL;
+    char *certin2 = NULL, *privkeyin2 = NULL;
 
     if (!test_skip_common_options()) {
         TEST_error("Error parsing test options\n");
@@ -755,31 +835,23 @@ int setup_tests(void)
         || !TEST_ptr(privkeyin = test_get_argument(1))
         || !TEST_ptr(derin = test_get_argument(2))
         || !TEST_ptr(too_long_iv_cms_in = test_get_argument(3))
-        || !TEST_ptr(pwri_kek_oob_der_in = test_get_argument(4)))
+        || !TEST_ptr(pwri_kek_oob_der_in = test_get_argument(4))
+        || !TEST_ptr(certin2 = test_get_argument(5))
+        || !TEST_ptr(privkeyin2 = test_get_argument(6)))
         return 0;
 
-    certbio = BIO_new_file(certin, "r");
-    if (!TEST_ptr(certbio))
-        return 0;
-    if (!TEST_true(PEM_read_bio_X509(certbio, &cert, NULL, NULL))) {
-        BIO_free(certbio);
+    if (!load_certificate(certin, &cert)) {
         return 0;
     }
-    BIO_free(certbio);
-
-    privkeybio = BIO_new_file(privkeyin, "r");
-    if (!TEST_ptr(privkeybio)) {
-        X509_free(cert);
-        cert = NULL;
+    if (!load_private_key(privkeyin, &privkey)) {
         return 0;
     }
-    if (!TEST_true(PEM_read_bio_PrivateKey(privkeybio, &privkey, NULL, NULL))) {
-        BIO_free(privkeybio);
-        X509_free(cert);
-        cert = NULL;
+    if (!load_certificate(certin2, &cert2)) {
         return 0;
     }
-    BIO_free(privkeybio);
+    if (!load_private_key(privkeyin2, &privkey2)) {
+        return 0;
+    }
 
     ADD_TEST(test_encrypt_decrypt_aes_cbc);
     ADD_TEST(test_encrypt_decrypt_aes_128_gcm);
@@ -788,6 +860,7 @@ int setup_tests(void)
     ADD_TEST(test_non_aead_on_auth_envelope_enc);
     ADD_TEST(test_non_aead_on_auth_envelope_dec);
     ADD_TEST(test_short_mac_on_auth_envelope_data);
+    ADD_TEST(test_decrypt_with_wrong_key);
     ADD_TEST(test_CMS_add1_cert);
     ADD_TEST(test_d2i_CMS_bio_NULL);
     ADD_TEST(test_CMS_set1_key_mem_leak);
@@ -803,4 +876,6 @@ void cleanup_tests(void)
 {
     X509_free(cert);
     EVP_PKEY_free(privkey);
+    X509_free(cert2);
+    EVP_PKEY_free(privkey2);
 }

--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -21,6 +21,8 @@ static X509 *cert = NULL;
 static EVP_PKEY *privkey = NULL;
 static X509 *ed448_cert = NULL;
 static EVP_PKEY *ed448_privkey = NULL;
+static X509 *cert2 = NULL;
+static EVP_PKEY *privkey2 = NULL;
 static char *derin = NULL;
 static char *too_long_iv_cms_in = NULL;
 static char *pwri_kek_oob_der_in = NULL;
@@ -315,6 +317,50 @@ static int test_CMS_add_standard_smimecap_ex(void)
 end:
     sk_X509_ALGOR_pop_free(smcap, X509_ALGOR_free);
     return ret;
+}
+
+static int test_decrypt_with_wrong_key(void)
+{
+    int testresult = 0;
+    STACK_OF(X509) *certstack = sk_X509_new_null();
+    const char *msg = "Hello world";
+    BIO *msgbio = BIO_new_mem_buf(msg, (int)strlen(msg));
+    BIO *outmsgbio;
+    CMS_ContentInfo *content = NULL;
+    BIO *contentbio = NULL;
+    const EVP_CIPHER *cipher = EVP_aes_128_cbc();
+
+    if (!TEST_ptr(certstack) || !TEST_ptr(msgbio))
+        goto end;
+
+    if (!TEST_int_gt(sk_X509_push(certstack, cert), 0))
+        goto end;
+
+    content = CMS_encrypt(certstack, msgbio, cipher, 0);
+    if (!TEST_ptr(content))
+        goto end;
+
+    for (int i = 0; i < 1000; ++i) {
+        outmsgbio = BIO_new(BIO_s_mem());
+        if (!TEST_false(CMS_decrypt(content, privkey2, cert, NULL, outmsgbio,
+                            0)
+                == 1)) {
+            BIO_free(outmsgbio);
+            goto end;
+        }
+        BIO_free(outmsgbio);
+    }
+
+    ERR_clear_error();
+
+    testresult = 1;
+end:
+    BIO_free(contentbio);
+    sk_X509_free(certstack);
+    BIO_free(msgbio);
+    CMS_ContentInfo_free(content);
+
+    return testresult;
 }
 
 static int test_CMS_add1_cert(void)
@@ -947,12 +993,15 @@ end:
 }
 #endif
 
-OPT_TEST_DECLARE_USAGE("certfile privkeyfile derfile tooLongIVpem pwriKekOobDer pwriKekNoIv ecrecip [ed448certfile ed448privkeyfile]\n")
+OPT_TEST_DECLARE_USAGE("certfile privkeyfile derfile tooLongIVpem pwriKekOobDer"
+                       " pwriKekNoIv ecrecip certfile2 privkeyfile2"
+                       " [ed448certfile ed448privkeyfile]\n")
 
 int setup_tests(void)
 {
     char *certin = NULL, *privkeyin = NULL;
     char *ed448_certin = NULL, *ed448_privkeyin = NULL;
+    char *certin2 = NULL, *privkeyin2 = NULL;
 
     if (!test_skip_common_options()) {
         TEST_error("Error parsing test options\n");
@@ -965,21 +1014,29 @@ int setup_tests(void)
         || !TEST_ptr(too_long_iv_cms_in = test_get_argument(3))
         || !TEST_ptr(pwri_kek_oob_der_in = test_get_argument(4))
         || !TEST_ptr(pwri_kek_no_iv_in = test_get_argument(5))
-        || !TEST_ptr(ec_recip_in = test_get_argument(6)))
+        || !TEST_ptr(ec_recip_in = test_get_argument(6))
+        || !TEST_ptr(certin2 = test_get_argument(7))
+        || !TEST_ptr(privkeyin2 = test_get_argument(8)))
         return 0;
 
     if (!TEST_ptr(cert = load_cert_pem(certin, NULL))
-        || !TEST_ptr(privkey = load_pkey_pem(privkeyin, NULL))) {
+        || !TEST_ptr(privkey = load_pkey_pem(privkeyin, NULL))
+        || !TEST_ptr(cert2 = load_cert_pem(certin2, NULL))
+        || !TEST_ptr(privkey2 = load_pkey_pem(privkeyin2, NULL))) {
         X509_free(cert);
         cert = NULL;
         EVP_PKEY_free(privkey);
         privkey = NULL;
+        X509_free(cert2);
+        cert2 = NULL;
+        EVP_PKEY_free(privkey2);
+        privkey2 = NULL;
         return 0;
     }
 
-    if (test_get_argument_count() >= 9) {
-        ed448_certin = test_get_argument(7);
-        ed448_privkeyin = test_get_argument(8);
+    if (test_get_argument_count() >= 11) {
+        ed448_certin = test_get_argument(9);
+        ed448_privkeyin = test_get_argument(10);
 
         if (!TEST_ptr(ed448_cert = load_cert_pem(ed448_certin, NULL))
             || !TEST_ptr(ed448_privkey = load_pkey_pem(ed448_privkeyin, NULL))) {
@@ -999,6 +1056,7 @@ int setup_tests(void)
     ADD_TEST(test_non_aead_on_auth_envelope_dec);
     ADD_TEST(test_short_mac_on_auth_envelope_data);
     ADD_TEST(test_CMS_add_standard_smimecap_ex);
+    ADD_TEST(test_decrypt_with_wrong_key);
     ADD_TEST(test_CMS_add1_cert);
     ADD_TEST(test_d2i_CMS_bio_NULL);
     ADD_TEST(test_CMS_set1_key_mem_leak);
@@ -1026,4 +1084,6 @@ void cleanup_tests(void)
     EVP_PKEY_free(privkey);
     X509_free(ed448_cert);
     EVP_PKEY_free(ed448_privkey);
+    X509_free(cert2);
+    EVP_PKEY_free(privkey2);
 }

--- a/test/recipes/80-test_cmsapi.t
+++ b/test/recipes/80-test_cmsapi.t
@@ -20,5 +20,7 @@ ok(run(test(["cmsapitest", srctop_file("test", "certs", "servercert.pem"),
              srctop_file("test", "certs", "serverkey.pem"),
              srctop_file("test", "recipes", "80-test_cmsapi_data", "encryptedData.der"),
              srctop_file("test", "recipes", "80-test_cmsapi_data", "encDataWithTooLongIV.pem"),
-             srctop_file("test", "recipes", "80-test_cmsapi_data", "cms_pwri_kek_oob.der")])),
+             srctop_file("test", "recipes", "80-test_cmsapi_data", "cms_pwri_kek_oob.der"),
+             srctop_file("test", "certs", "alt1-cert.pem"),
+             srctop_file("test", "certs", "alt1-key.pem")])),
              "running cmsapitest");

--- a/test/recipes/80-test_cmsapi.t
+++ b/test/recipes/80-test_cmsapi.t
@@ -27,5 +27,7 @@ ok(run(test(["cmsapitest", srctop_file("test", "certs", "servercert.pem"),
              srctop_file("test", "recipes", "80-test_cmsapi_data", "cms_pwri_kek_oob.der"),
              srctop_file("test", "recipes", "80-test_cmsapi_data", "cms_pwri_kek_NoIV.der"),
              srctop_file("test", "smime-certs", "smec1.pem"),
+             srctop_file("test", "certs", "alt1-cert.pem"),
+             srctop_file("test", "certs", "alt1-key.pem"),
              @ed448_args])),
              "running cmsapitest");


### PR DESCRIPTION
This removes random key generation which is already handled by the PKCS#1 v1.5 mitigation introduced in #13817.

- [x] tests are added or updated
