### PR TITLE
Add array memory allocation routines

### DIFF
--- a/.ctags.d/langmap.ctags
+++ b/.ctags.d/langmap.ctags
@@ -1,0 +1,11 @@
+#
+# Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+#
+
+--langmap=C:+.h
+--langmap=C:+.inc

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1422,7 +1422,7 @@ test_ordinals:
 tags TAGS: FORCE build_generated
 	rm -f TAGS tags
 	-( cd $(SRCDIR); util/ctags.sh )
-	-etags `find . -name '*.[ch]' -o -name '*.pm'`
+	-etags `find . -name '*.[ch]' -o -name '*.pm' -o -name '*.inc'`
 
 providers/fips.checksum.new: providers/fips.module.sources.new
 	@which unifdef > /dev/null || \

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -106,7 +106,8 @@ int chopup_args(ARGS *arg, char *buf)
             char **tmp;
 
             arg->size += 20;
-            tmp = OPENSSL_realloc(arg->argv, sizeof(*arg->argv) * arg->size);
+            tmp = OPENSSL_realloc_array(arg->argv,
+                                        arg->size, sizeof(*arg->argv));
             if (tmp == NULL)
                 return 0;
             arg->argv = tmp;
@@ -3461,7 +3462,7 @@ OSSL_PARAM *app_params_new_from_opts(STACK_OF(OPENSSL_STRING) *opts,
     if (opts == NULL)
         return NULL;
 
-    params = OPENSSL_zalloc(sizeof(OSSL_PARAM) * (sz + 1));
+    params = OPENSSL_calloc(sz + 1, sizeof(OSSL_PARAM));
     if (params == NULL)
         return NULL;
 

--- a/apps/lib/vms_decc_argv.c
+++ b/apps/lib/vms_decc_argv.c
@@ -56,7 +56,7 @@ char **copy_argv(int *argc, char *argv[])
      * get them when linking with all of libapps.a.
      * See comment in test/build.info.
      */
-    newargv = OPENSSL_malloc(sizeof(*newargv) * (count + 1));
+    newargv = OPENSSL_malloc_array(count + 1, sizeof(*newargv));
     if (newargv == NULL)
         return NULL;
 

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -1303,7 +1303,7 @@ static int print_x509v3_exts(BIO *bio, X509 *x, const char *ext_names)
         BIO_printf(bio, "Invalid extension names: %s\n", ext_names);
         goto end;
     }
-    if ((names = OPENSSL_malloc(sizeof(char *) * nn)) == NULL)
+    if ((names = OPENSSL_malloc_array(nn, sizeof(char *))) == NULL)
         goto end;
     parse_ext_names(tmp_ext_names, names);
 

--- a/crypto/array_alloc.c
+++ b/crypto/array_alloc.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * This file provides implementation of various array allocation routines that
+ * perform integer overflow checking for size calculation.
+ */
+
+#include "internal/mem_alloc_utils.h"
+#include <openssl/crypto.h>
+
+void *CRYPTO_malloc_array(size_t num, size_t size, const char *file, int line)
+{
+    size_t bytes;
+
+    if (ossl_unlikely(!ossl_size_mul(num, size, &bytes, file, line)))
+        return NULL;
+
+    return CRYPTO_malloc(bytes, file, line);
+}
+
+void *CRYPTO_calloc(size_t num, size_t size, const char *file, int line)
+{
+    size_t bytes;
+
+    if (ossl_unlikely(!ossl_size_mul(num, size, &bytes, file, line)))
+        return NULL;
+
+    return CRYPTO_zalloc(bytes, file, line);
+}
+
+void *CRYPTO_aligned_alloc_array(size_t num, size_t size, size_t align,
+                                 void **freeptr, const char *file, int line)
+{
+    size_t bytes;
+
+    if (ossl_unlikely(!ossl_size_mul(num, size, &bytes, file, line))) {
+        *freeptr = NULL;
+
+        return NULL;
+    }
+
+    return CRYPTO_aligned_alloc(bytes, align, freeptr, file, line);
+}
+
+void *CRYPTO_realloc_array(void *addr, size_t num, size_t size,
+                           const char *file, int line)
+{
+    size_t bytes;
+
+    if (ossl_unlikely(!ossl_size_mul(num, size, &bytes, file, line)))
+        return NULL;
+
+    return CRYPTO_realloc(addr, bytes, file, line);
+}
+
+void *CRYPTO_clear_realloc_array(void *addr, size_t old_num, size_t num,
+                                 size_t size, const char *file, int line)
+{
+    size_t old_bytes, bytes = 0;
+
+    if (ossl_unlikely(!ossl_size_mul(old_num, size, &old_bytes, file, line)
+                      || !ossl_size_mul(num, size, &bytes, file, line)))
+        return NULL;
+
+    return CRYPTO_clear_realloc(addr, old_bytes, bytes, file, line);
+}
+
+void *CRYPTO_secure_malloc_array(size_t num, size_t size,
+                                 const char *file, int line)
+{
+    size_t bytes;
+
+    if (ossl_unlikely(!ossl_size_mul(num, size, &bytes, file, line)))
+        return NULL;
+
+    return CRYPTO_secure_malloc(bytes, file, line);
+}
+
+void *CRYPTO_secure_calloc(size_t num, size_t size, const char *file, int line)
+{
+    size_t bytes;
+
+    if (ossl_unlikely(!ossl_size_mul(num, size, &bytes, file, line)))
+        return NULL;
+
+    return CRYPTO_secure_zalloc(bytes, file, line);
+}

--- a/crypto/bn/bn_conv.c
+++ b/crypto/bn/bn_conv.c
@@ -63,7 +63,7 @@ char *BN_bn2dec(const BIGNUM *a)
     num = (i / 10 + i / 1000 + 1) + 1;
     tbytes = num + 3;   /* negative and terminator and one spare? */
     bn_data_num = num / BN_DEC_NUM + 1;
-    bn_data = OPENSSL_malloc(bn_data_num * sizeof(BN_ULONG));
+    bn_data = OPENSSL_malloc_array(bn_data_num, sizeof(BN_ULONG));
     buf = OPENSSL_malloc(tbytes);
     if (buf == NULL || bn_data == NULL)
         goto err;

--- a/crypto/bn/bn_ctx.c
+++ b/crypto/bn/bn_ctx.c
@@ -266,7 +266,7 @@ static int BN_STACK_push(BN_STACK *st, unsigned int idx)
             st->size ? (st->size * 3 / 2) : BN_CTX_START_FRAMES;
         unsigned int *newitems;
 
-        if ((newitems = OPENSSL_malloc(sizeof(*newitems) * newsize)) == NULL)
+        if ((newitems = OPENSSL_malloc_array(newsize, sizeof(*newitems))) == NULL)
             return 0;
         if (st->depth)
             memcpy(newitems, st->indexes, sizeof(*newitems) * st->depth);

--- a/crypto/bn/bn_gf2m.c
+++ b/crypto/bn/bn_gf2m.c
@@ -474,7 +474,7 @@ int BN_GF2m_mod_mul(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
     bn_check_top(b);
     bn_check_top(p);
 
-    arr = OPENSSL_malloc(sizeof(*arr) * max);
+    arr = OPENSSL_malloc_array(max, sizeof(*arr));
     if (arr == NULL)
         return 0;
     ret = BN_GF2m_poly2arr(p, arr, max);
@@ -534,7 +534,7 @@ int BN_GF2m_mod_sqr(BIGNUM *r, const BIGNUM *a, const BIGNUM *p, BN_CTX *ctx)
     bn_check_top(a);
     bn_check_top(p);
 
-    arr = OPENSSL_malloc(sizeof(*arr) * max);
+    arr = OPENSSL_malloc_array(max, sizeof(*arr));
     if (arr == NULL)
         return 0;
     ret = BN_GF2m_poly2arr(p, arr, max);
@@ -917,7 +917,7 @@ int BN_GF2m_mod_exp(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
     bn_check_top(b);
     bn_check_top(p);
 
-    arr = OPENSSL_malloc(sizeof(*arr) * max);
+    arr = OPENSSL_malloc_array(max, sizeof(*arr));
     if (arr == NULL)
         return 0;
     ret = BN_GF2m_poly2arr(p, arr, max);
@@ -979,7 +979,7 @@ int BN_GF2m_mod_sqrt(BIGNUM *r, const BIGNUM *a, const BIGNUM *p, BN_CTX *ctx)
     bn_check_top(a);
     bn_check_top(p);
 
-    arr = OPENSSL_malloc(sizeof(*arr) * max);
+    arr = OPENSSL_malloc_array(max, sizeof(*arr));
     if (arr == NULL)
         return 0;
     ret = BN_GF2m_poly2arr(p, arr, max);
@@ -1113,7 +1113,7 @@ int BN_GF2m_mod_solve_quad(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
     bn_check_top(a);
     bn_check_top(p);
 
-    arr = OPENSSL_malloc(sizeof(*arr) * max);
+    arr = OPENSSL_malloc_array(max, sizeof(*arr));
     if (arr == NULL)
         goto err;
     ret = BN_GF2m_poly2arr(p, arr, max);

--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -276,9 +276,9 @@ static BN_ULONG *bn_expand_internal(const BIGNUM *b, int words)
         return NULL;
     }
     if (BN_get_flags(b, BN_FLG_SECURE))
-        a = OPENSSL_secure_zalloc(words * sizeof(*a));
+        a = OPENSSL_secure_calloc(words, sizeof(*a));
     else
-        a = OPENSSL_zalloc(words * sizeof(*a));
+        a = OPENSSL_calloc(words, sizeof(*a));
     if (ossl_unlikely(a == NULL))
         return NULL;
 

--- a/crypto/bn/bn_mod.c
+++ b/crypto/bn/bn_mod.c
@@ -63,7 +63,7 @@ int bn_mod_add_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
         return 0;
 
     if (mtop > OSSL_NELEM(storage)) {
-        tp = OPENSSL_malloc(mtop * sizeof(BN_ULONG));
+        tp = OPENSSL_malloc_array(mtop, sizeof(BN_ULONG));
         if (tp == NULL)
             return 0;
     }

--- a/crypto/bn/bn_prime.c
+++ b/crypto/bn/bn_prime.c
@@ -144,7 +144,7 @@ int BN_generate_prime_ex2(BIGNUM *ret, int bits, int safe,
         return 0;
     }
 
-    mods = OPENSSL_zalloc(sizeof(*mods) * NUMPRIMES);
+    mods = OPENSSL_calloc(NUMPRIMES, sizeof(*mods));
     if (mods == NULL)
         return 0;
 

--- a/crypto/bn/bn_s390x.c
+++ b/crypto/bn/bn_s390x.c
@@ -31,7 +31,7 @@ static int s390x_mod_exp_hw(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
     if (OPENSSL_s390xcex == -1 || OPENSSL_s390xcex_nodev)
         return 0;
     size = BN_num_bytes(m);
-    buffer = OPENSSL_zalloc(4 * size);
+    buffer = OPENSSL_calloc(size, 4);
     if (buffer == NULL)
         return 0;
     me.inputdata = buffer;

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -100,7 +100,7 @@ $UTIL_COMMON=\
         threads_pthread.c threads_win.c threads_none.c threads_common.c \
         initthread.c context.c sparse_array.c asn1_dsa.c packet.c \
         param_build.c param_build_set.c der_writer.c threads_lib.c \
-        params_dup.c time.c
+        params_dup.c time.c array_alloc.c
 
 SOURCE[../libcrypto]=$UTIL_COMMON \
         mem.c mem_sec.c \

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -357,7 +357,7 @@ int CMS_verify(CMS_ContentInfo *cms, STACK_OF(X509) *certs,
     if ((flags & CMS_NO_SIGNER_CERT_VERIFY) == 0 || cadesVerify) {
         if (cadesVerify) {
             /* Certificate trust chain is required to check CAdES signature */
-            si_chains = OPENSSL_zalloc(scount * sizeof(si_chains[0]));
+            si_chains = OPENSSL_calloc(scount, sizeof(si_chains[0]));
             if (si_chains == NULL)
                 goto err;
         }

--- a/crypto/comp/c_zlib.c
+++ b/crypto/comp/c_zlib.c
@@ -40,7 +40,7 @@ static void *zlib_zalloc(void *opaque, unsigned int no, unsigned int size)
 {
     void *p;
 
-    p = OPENSSL_zalloc(no * size);
+    p = OPENSSL_calloc(no, size);
     return p;
 }
 

--- a/crypto/conf/conf_ssl.c
+++ b/crypto/conf/conf_ssl.c
@@ -78,7 +78,7 @@ static int ssl_module_init(CONF_IMODULE *md, const CONF *cnf)
     }
     cnt = sk_CONF_VALUE_num(cmd_lists);
     ssl_module_free(md);
-    ssl_names = OPENSSL_zalloc(sizeof(*ssl_names) * cnt);
+    ssl_names = OPENSSL_calloc(cnt, sizeof(*ssl_names));
     if (ssl_names == NULL)
         goto err;
     ssl_names_count = cnt;
@@ -101,7 +101,7 @@ static int ssl_module_init(CONF_IMODULE *md, const CONF *cnf)
         if (ssl_name->name == NULL)
             goto err;
         cnt = sk_CONF_VALUE_num(cmds);
-        ssl_name->cmds = OPENSSL_zalloc(cnt * sizeof(struct ssl_conf_cmd_st));
+        ssl_name->cmds = OPENSSL_calloc(cnt, sizeof(struct ssl_conf_cmd_st));
         if (ssl_name->cmds == NULL)
             goto err;
         ssl_name->cmd_count = cnt;

--- a/crypto/ec/ec_curve.c
+++ b/crypto/ec/ec_curve.c
@@ -3406,7 +3406,7 @@ int ossl_ec_curve_nid_from_params(const EC_GROUP *group, BN_CTX *ctx)
         param_len = len;
 
     /* Allocate space to store the padded data for (p, a, b, x, y, order)  */
-    param_bytes = OPENSSL_malloc(param_len * NUM_BN_FIELDS);
+    param_bytes = OPENSSL_malloc_array(NUM_BN_FIELDS, param_len);
     if (param_bytes == NULL)
         goto end;
 

--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -504,11 +504,11 @@ int ossl_ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
 
     totalnum = num + numblocks;
 
-    wsize = OPENSSL_malloc(totalnum * sizeof(wsize[0]));
-    wNAF_len = OPENSSL_malloc(totalnum * sizeof(wNAF_len[0]));
+    wsize = OPENSSL_malloc_array(totalnum, sizeof(wsize[0]));
+    wNAF_len = OPENSSL_malloc_array(totalnum, sizeof(wNAF_len[0]));
     /* include space for pivot */
-    wNAF = OPENSSL_malloc((totalnum + 1) * sizeof(wNAF[0]));
-    val_sub = OPENSSL_malloc(totalnum * sizeof(val_sub[0]));
+    wNAF = OPENSSL_malloc_array(totalnum + 1, sizeof(wNAF[0]));
+    val_sub = OPENSSL_malloc_array(totalnum, sizeof(val_sub[0]));
 
     /* Ensure wNAF is initialised in case we end up going to err */
     if (wNAF != NULL)
@@ -651,7 +651,7 @@ int ossl_ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
      * 'val_sub[i]' is a pointer to the subarray for the i-th point, or to a
      * subarray of 'pre_comp->points' if we already have precomputation.
      */
-    val = OPENSSL_malloc((num_val + 1) * sizeof(val[0]));
+    val = OPENSSL_malloc_array(num_val + 1, sizeof(val[0]));
     if (val == NULL)
         goto err;
     val[num_val] = NULL;        /* pivot element */
@@ -883,7 +883,7 @@ int ossl_ec_wNAF_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
     num = pre_points_per_block * numblocks; /* number of points to compute
                                              * and store */
 
-    points = OPENSSL_malloc(sizeof(*points) * (num + 1));
+    points = OPENSSL_malloc_array(num + 1, sizeof(*points));
     if (points == NULL)
         goto err;
 

--- a/crypto/ec/ecp_nistp224.c
+++ b/crypto/ec/ecp_nistp224.c
@@ -1475,11 +1475,11 @@ int ossl_ec_GFp_nistp224_points_mul(const EC_GROUP *group, EC_POINT *r,
              */
             mixed = 1;
         }
-        secrets = OPENSSL_zalloc(sizeof(*secrets) * num_points);
-        pre_comp = OPENSSL_zalloc(sizeof(*pre_comp) * num_points);
+        secrets = OPENSSL_calloc(num_points, sizeof(*secrets));
+        pre_comp = OPENSSL_calloc(num_points, sizeof(*pre_comp));
         if (mixed)
             tmp_felems =
-                OPENSSL_malloc(sizeof(felem) * (num_points * 17 + 1));
+                OPENSSL_malloc_array(num_points * 17 + 1, sizeof(felem));
         if ((secrets == NULL) || (pre_comp == NULL)
             || (mixed && (tmp_felems == NULL)))
             goto err;

--- a/crypto/ec/ecp_nistp256.c
+++ b/crypto/ec/ecp_nistp256.c
@@ -2088,8 +2088,8 @@ int ossl_ec_GFp_nistp256_points_mul(const EC_GROUP *group, EC_POINT *r,
              */
             mixed = 1;
         }
-        secrets = OPENSSL_malloc(sizeof(*secrets) * num_points);
-        pre_comp = OPENSSL_malloc(sizeof(*pre_comp) * num_points);
+        secrets = OPENSSL_zalloc(sizeof(*secrets) * num_points);
+        pre_comp = OPENSSL_zalloc(sizeof(*pre_comp) * num_points);
         if (mixed)
             tmp_smallfelems =
               OPENSSL_malloc(sizeof(*tmp_smallfelems) * (num_points * 17 + 1));
@@ -2101,8 +2101,6 @@ int ossl_ec_GFp_nistp256_points_mul(const EC_GROUP *group, EC_POINT *r,
          * we treat NULL scalars as 0, and NULL points as points at infinity,
          * i.e., they contribute nothing to the linear combination
          */
-        memset(secrets, 0, sizeof(*secrets) * num_points);
-        memset(pre_comp, 0, sizeof(*pre_comp) * num_points);
         for (i = 0; i < num_points; ++i) {
             if (i == num) {
                 /*

--- a/crypto/ec/ecp_nistp256.c
+++ b/crypto/ec/ecp_nistp256.c
@@ -2088,11 +2088,11 @@ int ossl_ec_GFp_nistp256_points_mul(const EC_GROUP *group, EC_POINT *r,
              */
             mixed = 1;
         }
-        secrets = OPENSSL_zalloc(sizeof(*secrets) * num_points);
-        pre_comp = OPENSSL_zalloc(sizeof(*pre_comp) * num_points);
+        secrets = OPENSSL_calloc(num_points, sizeof(*secrets));
+        pre_comp = OPENSSL_calloc(num_points, sizeof(*pre_comp));
         if (mixed)
-            tmp_smallfelems =
-              OPENSSL_malloc(sizeof(*tmp_smallfelems) * (num_points * 17 + 1));
+            tmp_smallfelems = OPENSSL_malloc_array(num_points * 17 + 1,
+                                                   sizeof(*tmp_smallfelems));
         if ((secrets == NULL) || (pre_comp == NULL)
             || (mixed && (tmp_smallfelems == NULL)))
             goto err;

--- a/crypto/ec/ecp_nistp384.c
+++ b/crypto/ec/ecp_nistp384.c
@@ -1805,11 +1805,11 @@ int ossl_ec_GFp_nistp384_points_mul(const EC_GROUP *group, EC_POINT *r,
              */
             mixed = 1;
         }
-        secrets = OPENSSL_zalloc(sizeof(*secrets) * num_points);
-        pre_comp = OPENSSL_zalloc(sizeof(*pre_comp) * num_points);
+        secrets = OPENSSL_calloc(num_points, sizeof(*secrets));
+        pre_comp = OPENSSL_calloc(num_points, sizeof(*pre_comp));
         if (mixed)
             tmp_felems =
-                OPENSSL_malloc(sizeof(*tmp_felems) * (num_points * 17 + 1));
+                OPENSSL_malloc_array(num_points * 17 + 1, sizeof(*tmp_felems));
         if ((secrets == NULL) || (pre_comp == NULL)
             || (mixed && (tmp_felems == NULL)))
             goto err;

--- a/crypto/ec/ecp_nistp521.c
+++ b/crypto/ec/ecp_nistp521.c
@@ -1978,11 +1978,11 @@ int ossl_ec_GFp_nistp521_points_mul(const EC_GROUP *group, EC_POINT *r,
              */
             mixed = 1;
         }
-        secrets = OPENSSL_zalloc(sizeof(*secrets) * num_points);
-        pre_comp = OPENSSL_zalloc(sizeof(*pre_comp) * num_points);
+        secrets = OPENSSL_calloc(num_points, sizeof(*secrets));
+        pre_comp = OPENSSL_calloc(num_points, sizeof(*pre_comp));
         if (mixed)
             tmp_felems =
-                OPENSSL_malloc(sizeof(*tmp_felems) * (num_points * 17 + 1));
+                OPENSSL_malloc_array(num_points * 17 + 1, sizeof(*tmp_felems));
         if ((secrets == NULL) || (pre_comp == NULL)
             || (mixed && (tmp_felems == NULL)))
             goto err;

--- a/crypto/ec/ecp_nistz256.c
+++ b/crypto/ec/ecp_nistz256.c
@@ -625,9 +625,8 @@ __owur static int ecp_nistz256_windowed_mul(const EC_GROUP *group,
     if ((num * 16 + 6) > OPENSSL_MALLOC_MAX_NELEMS(P256_POINT)
         || (table_storage =
             OPENSSL_malloc((num * 16 + 5) * sizeof(P256_POINT) + 64)) == NULL
-        || (p_str =
-            OPENSSL_malloc(num * 33 * sizeof(unsigned char))) == NULL
-        || (scalars = OPENSSL_malloc(num * sizeof(BIGNUM *))) == NULL)
+        || (p_str = OPENSSL_malloc_array(num, 33)) == NULL
+        || (scalars = OPENSSL_malloc_array(num, sizeof(BIGNUM *))) == NULL)
         goto err;
 
     table = (void *)ALIGNPTR(table_storage, 64);
@@ -1109,11 +1108,11 @@ __owur static int ecp_nistz256_points_mul(const EC_GROUP *group,
          * Without a precomputed table for the generator, it has to be
          * handled like a normal point.
          */
-        new_scalars = OPENSSL_malloc((num + 1) * sizeof(BIGNUM *));
+        new_scalars = OPENSSL_malloc_array(num + 1, sizeof(BIGNUM *));
         if (new_scalars == NULL)
             goto err;
 
-        new_points = OPENSSL_malloc((num + 1) * sizeof(EC_POINT *));
+        new_points = OPENSSL_malloc_array(num + 1, sizeof(EC_POINT *));
         if (new_points == NULL)
             goto err;
 

--- a/crypto/ec/ecp_sm2p256.c
+++ b/crypto/ec/ecp_sm2p256.c
@@ -518,7 +518,7 @@ static int ecp_sm2p256_windowed_mul(const EC_GROUP *group,
     } t, p;
 
     if (num > OPENSSL_MALLOC_MAX_NELEMS(P256_POINT)
-        || (scalars = OPENSSL_malloc(num * sizeof(BIGNUM *))) == NULL) {
+        || (scalars = OPENSSL_malloc_array(num, sizeof(BIGNUM *))) == NULL) {
         ECerr(ERR_LIB_EC, ERR_R_MALLOC_FAILURE);
         goto err;
     }

--- a/crypto/ec/ecp_smpl.c
+++ b/crypto/ec/ecp_smpl.c
@@ -1227,7 +1227,7 @@ int ossl_ec_GFp_simple_points_make_affine(const EC_GROUP *group, size_t num,
     if (tmp_Z == NULL)
         goto err;
 
-    prod_Z = OPENSSL_malloc(num * sizeof(prod_Z[0]));
+    prod_Z = OPENSSL_malloc_array(num, sizeof(prod_Z[0]));
     if (prod_Z == NULL)
         goto err;
     for (i = 0; i < num; i++) {

--- a/crypto/encode_decode/encoder_pkey.c
+++ b/crypto/encode_decode/encoder_pkey.c
@@ -290,7 +290,7 @@ static int ossl_encoder_ctx_setup_for_pkey(OSSL_ENCODER_CTX *ctx,
         namemap = ossl_namemap_stored(libctx);
         end = sk_OPENSSL_CSTRING_num(encoder_data.names);
         if (end > 0) {
-            encoder_data.id_names = OPENSSL_malloc(end * sizeof(int));
+            encoder_data.id_names = OPENSSL_malloc_array(end, sizeof(int));
             if (encoder_data.id_names == NULL) {
                 sk_OPENSSL_CSTRING_free(keymgmt_data.names);
                 goto err;

--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -240,7 +240,7 @@ int ossl_crypto_new_ex_data_ex(OSSL_LIB_CTX *ctx, int class_index, void *obj,
         if (mx < (int)OSSL_NELEM(stack))
             storage = stack;
         else
-            storage = OPENSSL_malloc(sizeof(*storage) * mx);
+            storage = OPENSSL_malloc_array(mx, sizeof(*storage));
         if (storage != NULL)
             for (i = 0; i < mx; i++)
                 storage[i] = sk_EX_CALLBACK_value(ip->meth, i);
@@ -302,7 +302,7 @@ int CRYPTO_dup_ex_data(int class_index, CRYPTO_EX_DATA *to,
         if (mx < (int)OSSL_NELEM(stack))
             storage = stack;
         else
-            storage = OPENSSL_malloc(sizeof(*storage) * mx);
+            storage = OPENSSL_malloc_array(mx, sizeof(*storage));
         if (storage != NULL)
             for (i = 0; i < mx; i++)
                 storage[i] = sk_EX_CALLBACK_value(ip->meth, i);
@@ -386,7 +386,7 @@ void CRYPTO_free_ex_data(int class_index, void *obj, CRYPTO_EX_DATA *ad)
         if (mx < (int)OSSL_NELEM(stack))
             storage = stack;
         else
-            storage = OPENSSL_malloc(sizeof(*storage) * mx);
+            storage = OPENSSL_malloc_array(mx, sizeof(*storage));
         if (storage != NULL)
             for (i = 0; i < mx; i++) {
                 storage[i].excb = sk_EX_CALLBACK_value(ip->meth, i);

--- a/crypto/hashtable/hashtable.c
+++ b/crypto/hashtable/hashtable.c
@@ -154,12 +154,13 @@ static struct ht_neighborhood_st *alloc_new_neighborhood_list(size_t len,
 {
     struct ht_neighborhood_st *ret;
 
-    ret = OPENSSL_aligned_alloc(sizeof(struct ht_neighborhood_st) * len,
-                                CACHE_LINE_BYTES, freeptr);
+    ret = OPENSSL_aligned_alloc_array(len, sizeof(struct ht_neighborhood_st),
+                                      CACHE_LINE_BYTES, freeptr);
 
     /* fall back to regular malloc */
     if (ret == NULL) {
-        ret = *freeptr = OPENSSL_malloc(sizeof(struct ht_neighborhood_st) * len);
+        ret = *freeptr =
+            OPENSSL_malloc_array(len, sizeof(struct ht_neighborhood_st));
         if (ret == NULL)
             return NULL;
     }

--- a/crypto/hmac/hmac_s390x.c
+++ b/crypto/hmac/hmac_s390x.c
@@ -117,8 +117,8 @@ int s390x_HMAC_init(HMAC_CTX *ctx, const void *key, int key_len, ENGINE *impl)
         (size_t)(ctx->plat.s390x.blk_size * HMAC_S390X_BUF_NUM_BLOCKS)) {
         OPENSSL_clear_free(ctx->plat.s390x.buf, ctx->plat.s390x.size);
         ctx->plat.s390x.size = 0;
-        ctx->plat.s390x.buf = OPENSSL_zalloc(ctx->plat.s390x.blk_size *
-                                             HMAC_S390X_BUF_NUM_BLOCKS);
+        ctx->plat.s390x.buf = OPENSSL_calloc(HMAC_S390X_BUF_NUM_BLOCKS,
+                                             ctx->plat.s390x.blk_size);
         if (ctx->plat.s390x.buf == NULL)
             return 0;
         ctx->plat.s390x.size = ctx->plat.s390x.blk_size *

--- a/crypto/lhash/lhash.c
+++ b/crypto/lhash/lhash.c
@@ -66,7 +66,7 @@ OPENSSL_LHASH *OPENSSL_LH_new(OPENSSL_LH_HASHFUNC h, OPENSSL_LH_COMPFUNC c)
 
     if ((ret = OPENSSL_zalloc(sizeof(*ret))) == NULL)
         return NULL;
-    if ((ret->b = OPENSSL_zalloc(sizeof(*ret->b) * MIN_NODES)) == NULL)
+    if ((ret->b = OPENSSL_calloc(MIN_NODES, sizeof(*ret->b))) == NULL)
         goto err;
     ret->comp = ((c == NULL) ? (OPENSSL_LH_COMPFUNC)strcmp : c);
     ret->hash = ((h == NULL) ? (OPENSSL_LH_HASHFUNC)OPENSSL_LH_strhash : h);
@@ -251,7 +251,7 @@ static int expand(OPENSSL_LHASH *lh)
     pmax = lh->pmax;
     if (p + 1 >= pmax) {
         j = nni * 2;
-        n = OPENSSL_realloc(lh->b, sizeof(OPENSSL_LH_NODE *) * j);
+        n = OPENSSL_realloc_array(lh->b, j, sizeof(OPENSSL_LH_NODE *));
         if (n == NULL) {
             lh->error++;
             return 0;
@@ -291,8 +291,7 @@ static void contract(OPENSSL_LHASH *lh)
     np = lh->b[lh->p + lh->pmax - 1];
     lh->b[lh->p + lh->pmax - 1] = NULL; /* 24/07-92 - eay - weird but :-( */
     if (lh->p == 0) {
-        n = OPENSSL_realloc(lh->b,
-                            (unsigned int)(sizeof(OPENSSL_LH_NODE *) * lh->pmax));
+        n = OPENSSL_realloc_array(lh->b, lh->pmax, sizeof(OPENSSL_LH_NODE *));
         if (n == NULL) {
             /* fputs("realloc error in lhash", stderr); */
             lh->error++;

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -250,6 +250,10 @@ void *CRYPTO_aligned_alloc(size_t num, size_t alignment, void **freeptr,
 #if defined(_BSD_SOURCE) || (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L)
         int memalign_ret;
 
+        /* posix_memalign() requires alignment to be at least sizeof(void *) */
+        if (alignment < sizeof(void *))
+            alignment = sizeof(void *);
+
         if ((memalign_ret = posix_memalign(&ret, alignment, num))) {
             ret = NULL;
             switch (memalign_ret) {

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -292,6 +292,8 @@ void *CRYPTO_aligned_alloc(size_t num, size_t alignment, void **freeptr,
 
 void *CRYPTO_realloc(void *str, size_t num, const char *file, int line)
 {
+    void *ret;
+
     INCREMENT(realloc_count);
     if (realloc_impl != CRYPTO_realloc)
         return realloc_impl(str, num, file, line);
@@ -305,7 +307,12 @@ void *CRYPTO_realloc(void *str, size_t num, const char *file, int line)
     }
 
     FAILTEST();
-    return realloc(str, num);
+    ret = realloc(str, num);
+
+    if (num != 0 && ret == NULL)
+        ossl_report_alloc_err(file, line);
+
+    return ret;
 }
 
 void *CRYPTO_clear_realloc(void *str, size_t old_len, size_t num,

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -236,7 +236,7 @@ void *CRYPTO_aligned_alloc(size_t num, size_t alignment, void **freeptr,
     *freeptr = NULL;
 
 #if defined(OPENSSL_SMALL_FOOTPRINT)
-    ret = freeptr = NULL;
+    ret = *freeptr = NULL;
     return ret;
 #endif
 

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -231,6 +231,7 @@ void *CRYPTO_zalloc(size_t num, const char *file, int line)
 void *CRYPTO_aligned_alloc(size_t num, size_t alignment, void **freeptr,
                            const char *file, int line)
 {
+    size_t alloc_bytes;
     void *ret;
 
     *freeptr = NULL;
@@ -280,11 +281,14 @@ void *CRYPTO_aligned_alloc(size_t num, size_t alignment, void **freeptr,
      * via _aligned_malloc, just avoid its use entirely
      */
 
+    if (ossl_unlikely(!ossl_size_add(num, alignment, &alloc_bytes, file, line)))
+        return NULL;
+
     /*
      * Step 1: Allocate an amount of memory that is <alignment>
      * bytes bigger than requested
      */
-    *freeptr = CRYPTO_malloc(num + alignment, file, line);
+    *freeptr = CRYPTO_malloc(alloc_bytes, file, line);
     if (*freeptr == NULL)
         return NULL;
 

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -295,8 +295,14 @@ void *CRYPTO_realloc(void *str, size_t num, const char *file, int line)
     void *ret;
 
     INCREMENT(realloc_count);
-    if (realloc_impl != CRYPTO_realloc)
-        return realloc_impl(str, num, file, line);
+    if (realloc_impl != CRYPTO_realloc) {
+        ret = realloc_impl(str, num, file, line);
+
+        if (num == 0 || ret != NULL)
+            return ret;
+
+        goto err;
+    }
 
     if (str == NULL)
         return CRYPTO_malloc(num, file, line);
@@ -309,6 +315,7 @@ void *CRYPTO_realloc(void *str, size_t num, const char *file, int line)
     FAILTEST();
     ret = realloc(str, num);
 
+err:
     if (num != 0 && ret == NULL)
         ossl_report_alloc_err(file, line);
 

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -246,9 +246,6 @@ void *CRYPTO_aligned_alloc(size_t num, size_t alignment, void **freeptr,
             return NULL;
         *freeptr = ret;
         return ret;
-#elif defined(_ISOC11_SOURCE)
-        ret = *freeptr = aligned_alloc(alignment, num);
-        return ret;
 #endif
     }
 

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -236,8 +236,7 @@ void *CRYPTO_aligned_alloc(size_t num, size_t alignment, void **freeptr,
     *freeptr = NULL;
 
 #if defined(OPENSSL_SMALL_FOOTPRINT)
-    ret = *freeptr = NULL;
-    return ret;
+    return NULL;
 #endif
 
     /* Allow non-malloc() allocations as long as no malloc_impl is provided. */

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -239,6 +239,12 @@ void *CRYPTO_aligned_alloc(size_t num, size_t alignment, void **freeptr,
     return NULL;
 #endif
 
+    /* Ensure that alignment is a power of two */
+    if (alignment == 0 || (alignment & (alignment - 1)) != 0) {
+        ossl_report_alloc_err_inv(file, line);
+        return NULL;
+    }
+
     /* Allow non-malloc() allocations as long as no malloc_impl is provided. */
     if (malloc_impl == CRYPTO_malloc) {
 #if defined(_BSD_SOURCE) || (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L)

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -9,6 +9,7 @@
 
 #include "internal/e_os.h"
 #include "internal/cryptlib.h"
+#include "internal/mem_alloc_utils.h"
 #include "crypto/cryptlib.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -212,15 +213,7 @@ void *CRYPTO_malloc(size_t num, const char *file, int line)
     if (ossl_likely(ptr != NULL))
         return ptr;
  err:
-    /*
-     * ossl_err_get_state_int() in err.c uses CRYPTO_zalloc(num, NULL, 0) for
-     * ERR_STATE allocation. Prevent mem alloc error loop while reporting error.
-     */
-    if (file != NULL || line != 0) {
-        ERR_new();
-        ERR_set_debug(file, line, NULL);
-        ERR_set_error(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE, NULL);
-    }
+    ossl_report_alloc_err(file, line);
     return NULL;
 }
 

--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -480,7 +480,7 @@ static int sh_init(size_t size, size_t minsize)
     for (i = sh.bittable_size; i; i >>= 1)
         sh.freelist_size++;
 
-    sh.freelist = OPENSSL_zalloc(sh.freelist_size * sizeof(char *));
+    sh.freelist = OPENSSL_calloc(sh.freelist_size, sizeof(char *));
     OPENSSL_assert(sh.freelist != NULL);
     if (sh.freelist == NULL)
         goto err;

--- a/crypto/ml_dsa/ml_dsa_key.c
+++ b/crypto/ml_dsa/ml_dsa_key.c
@@ -326,7 +326,7 @@ static int public_from_private(const ML_DSA_KEY *key, EVP_MD_CTX *md_ctx,
     VECTOR s1_ntt;
     VECTOR t;
 
-    polys = OPENSSL_malloc(sizeof(*polys) * (k + l + k * l));
+    polys = OPENSSL_malloc_array(k + l + k * l, sizeof(*polys));
     if (polys == NULL)
         return 0;
 
@@ -388,7 +388,7 @@ int ossl_ml_dsa_key_pairwise_check(const ML_DSA_KEY *key)
     if (key->pub_encoding == NULL || key->priv_encoding == 0)
         return 0;
 
-    polys = OPENSSL_malloc(sizeof(*polys) * (2 * k));
+    polys = OPENSSL_malloc_array(2 * k, sizeof(*polys));
     if (polys == NULL)
         return 0;
     md_ctx = EVP_MD_CTX_new();

--- a/crypto/ml_dsa/ml_dsa_vector.h
+++ b/crypto/ml_dsa/ml_dsa_vector.h
@@ -33,7 +33,7 @@ void vector_init(VECTOR *v, POLY *polys, size_t num_polys)
 static ossl_inline ossl_unused
 int vector_alloc(VECTOR *v, size_t num_polys)
 {
-    v->poly = OPENSSL_malloc(num_polys * sizeof(POLY));
+    v->poly = OPENSSL_malloc_array(num_polys, sizeof(POLY));
     if (v->poly == NULL)
         return 0;
     v->num_poly = num_polys;
@@ -43,7 +43,7 @@ int vector_alloc(VECTOR *v, size_t num_polys)
 static ossl_inline ossl_unused
 int vector_secure_alloc(VECTOR *v, size_t num_polys)
 {
-    v->poly = OPENSSL_secure_malloc(num_polys * sizeof(POLY));
+    v->poly = OPENSSL_secure_malloc_array(num_polys, sizeof(POLY));
     if (v->poly == NULL)
         return 0;
     v->num_poly = num_polys;

--- a/crypto/modes/ocb128.c
+++ b/crypto/modes/ocb128.c
@@ -110,7 +110,7 @@ static OCB_BLOCK *ocb_lookup_l(OCB128_CONTEXT *ctx, size_t idx)
          * the index.
          */
         ctx->max_l_index += (idx - ctx->max_l_index + 4) & ~3;
-        tmp_ptr = OPENSSL_realloc(ctx->l, ctx->max_l_index * sizeof(OCB_BLOCK));
+        tmp_ptr = OPENSSL_realloc_array(ctx->l, ctx->max_l_index, sizeof(OCB_BLOCK));
         if (tmp_ptr == NULL) /* prevent ctx->l from being clobbered */
             return NULL;
         ctx->l = tmp_ptr;
@@ -155,7 +155,7 @@ int CRYPTO_ocb128_init(OCB128_CONTEXT *ctx, void *keyenc, void *keydec,
     memset(ctx, 0, sizeof(*ctx));
     ctx->l_index = 0;
     ctx->max_l_index = 5;
-    if ((ctx->l = OPENSSL_malloc(ctx->max_l_index * 16)) == NULL)
+    if ((ctx->l = OPENSSL_malloc_array(ctx->max_l_index, 16)) == NULL)
         return 0;
 
     /*
@@ -200,7 +200,7 @@ int CRYPTO_ocb128_copy_ctx(OCB128_CONTEXT *dest, OCB128_CONTEXT *src,
     if (keydec)
         dest->keydec = keydec;
     if (src->l) {
-        if ((dest->l = OPENSSL_malloc(src->max_l_index * 16)) == NULL)
+        if ((dest->l = OPENSSL_malloc_array(src->max_l_index, 16)) == NULL)
             return 0;
         memcpy(dest->l, src->l, (src->l_index + 1) * 16);
     }

--- a/crypto/objects/o_names.c
+++ b/crypto/objects/o_names.c
@@ -333,7 +333,7 @@ void OBJ_NAME_do_all_sorted(int type,
 
     d.type = type;
     d.names =
-        OPENSSL_malloc(sizeof(*d.names) * lh_OBJ_NAME_num_items(names_lh));
+        OPENSSL_malloc_array(lh_OBJ_NAME_num_items(names_lh), sizeof(*d.names));
     /* Really should return an error if !d.names...but its a void function! */
     if (d.names != NULL) {
         d.n = 0;

--- a/crypto/params_dup.c
+++ b/crypto/params_dup.c
@@ -188,7 +188,7 @@ OSSL_PARAM *OSSL_PARAM_merge(const OSSL_PARAM *p1, const OSSL_PARAM *p2)
     qsort(list2, list2_sz, sizeof(OSSL_PARAM *), compare_params);
 
    /* Allocate enough space to store the merged parameters */
-    params = OPENSSL_zalloc((list1_sz + list2_sz + 1) * sizeof(*p1));
+    params = OPENSSL_calloc(list1_sz + list2_sz + 1, sizeof(*p1));
     if (params == NULL)
         return NULL;
     dst = params;

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -665,7 +665,7 @@ int PEM_write_bio(BIO *bp, const char *name, const char *header,
         }
     }
 
-    buf = OPENSSL_malloc(PEM_BUFSIZE * 8);
+    buf = OPENSSL_malloc_array(PEM_BUFSIZE, 8);
     if (buf == NULL)
         goto err;
 

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -371,8 +371,8 @@ int ossl_provider_info_add_to_store(OSSL_LIB_CTX *libctx,
     if (!CRYPTO_THREAD_write_lock(store->lock))
         return 0;
     if (store->provinfosz == 0) {
-        store->provinfo = OPENSSL_zalloc(sizeof(*store->provinfo)
-                                         * BUILTINS_BLOCK_SIZE);
+        store->provinfo = OPENSSL_calloc(BUILTINS_BLOCK_SIZE,
+                                         sizeof(*store->provinfo));
         if (store->provinfo == NULL)
             goto err;
         store->provinfosz = BUILTINS_BLOCK_SIZE;
@@ -380,8 +380,8 @@ int ossl_provider_info_add_to_store(OSSL_LIB_CTX *libctx,
         OSSL_PROVIDER_INFO *tmpbuiltins;
         size_t newsz = store->provinfosz + BUILTINS_BLOCK_SIZE;
 
-        tmpbuiltins = OPENSSL_realloc(store->provinfo,
-                                      sizeof(*store->provinfo) * newsz);
+        tmpbuiltins = OPENSSL_realloc_array(store->provinfo,
+                                            newsz, sizeof(*store->provinfo));
         if (tmpbuiltins == NULL)
             goto err;
         store->provinfo = tmpbuiltins;
@@ -1119,7 +1119,7 @@ static int provider_init(OSSL_PROVIDER *prov)
 
         /* Allocate one extra item for the "library" name */
         prov->error_strings =
-            OPENSSL_zalloc(sizeof(ERR_STRING_DATA) * (cnt + 1));
+            OPENSSL_calloc(cnt + 1, sizeof(ERR_STRING_DATA));
         if (prov->error_strings == NULL)
             goto end;
 

--- a/crypto/rsa/rsa_gen.c
+++ b/crypto/rsa/rsa_gen.c
@@ -704,7 +704,7 @@ static int rsa_keygen_pairwise_test(RSA *rsa, OSSL_CALLBACK *cb, void *cbarg)
      * decoded.
      */
     plaintxt_len = RSA_size(rsa);
-    plaintxt = OPENSSL_zalloc(plaintxt_len * 3);
+    plaintxt = OPENSSL_calloc(plaintxt_len, 3);
     if (plaintxt == NULL)
         goto err;
     ciphertxt = plaintxt + plaintxt_len;

--- a/crypto/sm2/sm2_crypt.c
+++ b/crypto/sm2/sm2_crypt.c
@@ -177,7 +177,7 @@ int ossl_sm2_encrypt(const EC_KEY *key,
         goto done;
     }
 
-    x2y2 = OPENSSL_zalloc(2 * field_size);
+    x2y2 = OPENSSL_calloc(2, field_size);
     C3 = OPENSSL_zalloc(C3_size);
 
     if (x2y2 == NULL || C3 == NULL)
@@ -343,7 +343,7 @@ int ossl_sm2_decrypt(const EC_KEY *key,
     }
 
     msg_mask = OPENSSL_zalloc(msg_len);
-    x2y2 = OPENSSL_zalloc(2 * field_size);
+    x2y2 = OPENSSL_calloc(2, field_size);
     computed_C3 = OPENSSL_zalloc(hash_size);
 
     if (msg_mask == NULL || x2y2 == NULL || computed_C3 == NULL)

--- a/crypto/sparse_array.c
+++ b/crypto/sparse_array.c
@@ -173,7 +173,7 @@ void *ossl_sa_get(const OPENSSL_SA *sa, ossl_uintmax_t n)
 
 static ossl_inline void **alloc_node(void)
 {
-    return OPENSSL_zalloc(SA_BLOCK_MAX * sizeof(void *));
+    return OPENSSL_calloc(SA_BLOCK_MAX, sizeof(void *));
 }
 
 int ossl_sa_set(OPENSSL_SA *sa, ossl_uintmax_t posn, void *val)

--- a/crypto/srp/srp_lib.c
+++ b/crypto/srp/srp_lib.c
@@ -39,7 +39,7 @@ static BIGNUM *srp_Calc_xy(const BIGNUM *x, const BIGNUM *y, const BIGNUM *N,
         goto err;
     if (y != N && BN_ucmp(y, N) >= 0)
         goto err;
-    if ((tmp = OPENSSL_malloc(numN * 2)) == NULL)
+    if ((tmp = OPENSSL_malloc_array(numN, 2)) == NULL)
         goto err;
     if (BN_bn2binpad(x, tmp, numN) < 0
         || BN_bn2binpad(y, tmp + numN, numN) < 0

--- a/crypto/srp/srp_vfy.c
+++ b/crypto/srp/srp_vfy.c
@@ -681,9 +681,8 @@ char *SRP_create_verifier_ex(const char *user, const char *pass, char **salt,
     if (*salt == NULL) {
         char *tmp_salt;
 
-        if ((tmp_salt = OPENSSL_malloc(SRP_RANDOM_SALT_LEN * 2)) == NULL) {
+        if ((tmp_salt = OPENSSL_malloc_array(SRP_RANDOM_SALT_LEN, 2)) == NULL)
             goto err;
-        }
         if (!t_tob64(tmp_salt, tmp2, SRP_RANDOM_SALT_LEN)) {
             OPENSSL_free(tmp_salt);
             goto err;

--- a/crypto/stack/stack.c
+++ b/crypto/stack/stack.c
@@ -69,7 +69,7 @@ OPENSSL_STACK *OPENSSL_sk_dup(const OPENSSL_STACK *sk)
     }
 
     /* duplicate |sk->data| content */
-    ret->data = OPENSSL_malloc(sizeof(*ret->data) * sk->num_alloc);
+    ret->data = OPENSSL_malloc_array(sk->num_alloc, sizeof(*ret->data));
     if (ret->data == NULL)
         goto err;
     memcpy(ret->data, sk->data, sizeof(void *) * sk->num);
@@ -107,7 +107,7 @@ OPENSSL_STACK *OPENSSL_sk_deep_copy(const OPENSSL_STACK *sk,
     }
 
     ret->num_alloc = sk->num > min_nodes ? sk->num : min_nodes;
-    ret->data = OPENSSL_zalloc(sizeof(*ret->data) * ret->num_alloc);
+    ret->data = OPENSSL_calloc(ret->num_alloc, sizeof(*ret->data));
     if (ret->data == NULL)
         goto err;
 
@@ -197,7 +197,7 @@ static int sk_reserve(OPENSSL_STACK *st, int n, int exact)
          * At this point, |st->num_alloc| and |st->num| are 0;
          * so |num_alloc| value is |n| or |min_nodes| if greater than |n|.
          */
-        if ((st->data = OPENSSL_zalloc(sizeof(void *) * num_alloc)) == NULL)
+        if ((st->data = OPENSSL_calloc(num_alloc, sizeof(void *))) == NULL)
             return 0;
         st->num_alloc = num_alloc;
         return 1;
@@ -215,7 +215,7 @@ static int sk_reserve(OPENSSL_STACK *st, int n, int exact)
         return 1;
     }
 
-    tmpdata = OPENSSL_realloc((void *)st->data, sizeof(void *) * num_alloc);
+    tmpdata = OPENSSL_realloc_array((void *)st->data, num_alloc, sizeof(void *));
     if (tmpdata == NULL)
         return 0;
 

--- a/crypto/threads_common.c
+++ b/crypto/threads_common.c
@@ -355,7 +355,8 @@ int CRYPTO_THREAD_set_local_ex(CRYPTO_THREAD_LOCAL_KEY_ID id,
         /*
          * we didn't find one, but that's ok, just initialize it now
          */
-        mkey = OPENSSL_zalloc(sizeof(MASTER_KEY_ENTRY) * CRYPTO_THREAD_LOCAL_KEY_MAX);
+        mkey = OPENSSL_calloc(CRYPTO_THREAD_LOCAL_KEY_MAX,
+                              sizeof(MASTER_KEY_ENTRY));
         if (mkey == NULL)
             return 0;
         /*

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -454,7 +454,7 @@ static struct rcu_qp *allocate_new_qp_group(CRYPTO_RCU_LOCK *lock,
                                             uint32_t count)
 {
     struct rcu_qp *new =
-        OPENSSL_zalloc(sizeof(*new) * count);
+        OPENSSL_calloc(count, sizeof(*new));
 
     lock->group_count = count;
     return new;

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -128,7 +128,7 @@ static struct rcu_qp *allocate_new_qp_group(struct rcu_lock_st *lock,
                                             uint32_t count)
 {
     struct rcu_qp *new =
-        OPENSSL_zalloc(sizeof(*new) * count);
+        OPENSSL_calloc(count, sizeof(*new));
 
     lock->group_count = count;
     return new;

--- a/crypto/txt_db/txt_db.c
+++ b/crypto/txt_db/txt_db.c
@@ -40,9 +40,9 @@ TXT_DB *TXT_DB_read(BIO *in, int num)
     ret->qual = NULL;
     if ((ret->data = sk_OPENSSL_PSTRING_new_null()) == NULL)
         goto err;
-    if ((ret->index = OPENSSL_malloc(sizeof(*ret->index) * num)) == NULL)
+    if ((ret->index = OPENSSL_malloc_array(num, sizeof(*ret->index))) == NULL)
         goto err;
-    if ((ret->qual = OPENSSL_malloc(sizeof(*(ret->qual)) * num)) == NULL)
+    if ((ret->qual = OPENSSL_malloc_array(num, sizeof(*(ret->qual)))) == NULL)
         goto err;
     for (i = 0; i < num; i++) {
         ret->index[i] = NULL;

--- a/crypto/x509/pcy_tree.c
+++ b/crypto/x509/pcy_tree.c
@@ -186,7 +186,7 @@ static int tree_init(X509_POLICY_TREE **ptree, STACK_OF(X509) *certs,
      * policies of anyPolicy.  (RFC 5280 has the TA at depth 0 and the leaf at
      * depth n, we have the leaf at depth 0 and the TA at depth n).
      */
-    if ((tree->levels = OPENSSL_zalloc(sizeof(*tree->levels)*(n+1))) == NULL) {
+    if ((tree->levels = OPENSSL_calloc(n + 1, sizeof(*tree->levels))) == NULL) {
         OPENSSL_free(tree);
         return X509_PCY_TREE_INTERNAL;
     }

--- a/crypto/x509/x509spki.c
+++ b/crypto/x509/x509spki.c
@@ -61,7 +61,7 @@ char *NETSCAPE_SPKI_b64_encode(NETSCAPE_SPKI *spki)
     if (der_len <= 0)
         return NULL;
     der_spki = OPENSSL_malloc(der_len);
-    b64_str = OPENSSL_malloc(der_len * 2);
+    b64_str = OPENSSL_malloc_array(der_len, 2);
     if (der_spki == NULL || b64_str == NULL) {
         OPENSSL_free(der_spki);
         OPENSSL_free(b64_str);

--- a/demos/quic/poll-server/quic-server-ssl-poll-http.c
+++ b/demos/quic/poll-server/quic-server-ssl-poll-http.c
@@ -975,7 +975,8 @@ create_poll_manager(void)
         return NULL;
 
     ossl_list_pe_init(&pm->pm_head);
-    pm->pm_poll_set = OPENSSL_malloc(sizeof (struct poll_event) * POLL_GROW);
+    pm->pm_poll_set = OPENSSL_malloc_array(POLL_GROW,
+                                           sizeof (struct poll_event));
     if (pm->pm_poll_set != NULL) {
         pm->pm_poll_set_sz = POLL_GROW;
         pm->pm_event_count = 0;
@@ -992,7 +993,6 @@ rebuild_poll_set(struct poll_manager *pm)
 {
     struct poll_event *new_poll_set;
     struct poll_event *pe;
-    size_t new_sz;
     size_t pe_num;
     size_t i;
 
@@ -1004,9 +1004,9 @@ rebuild_poll_set(struct poll_manager *pm)
         /*
          * grow poll set by POLL_GROW
          */
-        new_sz = sizeof (struct poll_event) * (pm->pm_poll_set_sz + POLL_GROW);
-        new_poll_set = (struct poll_event *)OPENSSL_realloc(pm->pm_poll_set,
-                                                            new_sz);
+        new_poll_set = OPENSSL_realloc_array(pm->pm_poll_set,
+                                             pm->pm_poll_set_sz + POLL_GROW,
+                                             sizeof (struct poll_event));
         if (new_poll_set == NULL)
             return -1;
         pm->pm_poll_set = new_poll_set;
@@ -1016,10 +1016,9 @@ rebuild_poll_set(struct poll_manager *pm)
         /*
          * shrink poll set by POLL_DOWNSIZ
          */
-        new_sz = sizeof (struct poll_event) *
-            (pm->pm_poll_set_sz - POLL_DOWNSIZ);
-        new_poll_set = (struct poll_event *)OPENSSL_realloc(pm->pm_poll_set,
-                                                            new_sz);
+        new_poll_set = OPENSSL_realloc_array(pm->pm_poll_set,
+                                             pm->pm_poll_set_sz - POLL_DOWNSIZ,
+                                             sizeof (struct poll_event));
         if (new_poll_set == NULL)
             return -1;
         pm->pm_poll_set = new_poll_set;

--- a/doc/man3/OPENSSL_malloc.pod
+++ b/doc/man3/OPENSSL_malloc.pod
@@ -127,7 +127,13 @@ allows for the caller to specify an alignment value, for instances in
 which the default alignment of malloc is insufficient for the caller's
 needs.  Note, the alignment value must be a power of 2, and the size
 specified must be a multiple of the alignment.
-NOTE: The call to OPENSSL_aligned_alloc() accepts a 3rd argument, I<freeptr>
+NOTES:
+
+=over 4
+
+=item *
+
+The call to OPENSSL_aligned_alloc() accepts a 3rd argument, I<freeptr>
 which must point to a void pointer.  On some platforms, there is no available
 library call to obtain memory allocations with alignment greater than what
 malloc provides.  In this case, OPENSSL_aligned_alloc() implements its own
@@ -135,6 +141,18 @@ alignment routine, allocating additional memory and offsetting the returned
 pointer to be on the requested alignment boundary.  In order to safely free
 allocations made by this method, the caller must return the value
 in the I<freeptr> variable, rather than the returned pointer.
+
+=item *
+
+The call to OPENSSL_aligned_alloc() may fail for reasons other than memory
+exhaustion, depending on the underlying implementation, and, most notably,
+OpenSSL library's build configuration:  for example, it always returns C<NULL>
+without setting any error if OpenSSL is built with C<OPENSSL_SMALL_FOOTPRINT>
+macro defined.  Consequently, caller may need to fall back to a non-aligned
+memory allocation (and open-code the alignment routine if the alignment
+is a requirement).
+
+=back
 
 OPENSSL_clear_realloc() and OPENSSL_clear_free() should be used
 when the buffer at B<addr> holds sensitive information.

--- a/doc/man3/OPENSSL_malloc.pod
+++ b/doc/man3/OPENSSL_malloc.pod
@@ -4,14 +4,19 @@
 
 OPENSSL_malloc_init,
 OPENSSL_malloc, OPENSSL_aligned_alloc, OPENSSL_zalloc, OPENSSL_realloc,
-OPENSSL_free, OPENSSL_clear_realloc, OPENSSL_clear_free, OPENSSL_cleanse,
-CRYPTO_malloc, CRYPTO_aligned_alloc, CRYPTO_zalloc, CRYPTO_realloc, CRYPTO_free,
+OPENSSL_malloc_array, OPENSSL_aligned_alloc_array, OPENSSL_calloc,
+OPENSSL_realloc_array, OPENSSL_free,
+OPENSSL_clear_realloc, OPENSSL_clear_realloc_array,
+OPENSSL_clear_free, OPENSSL_cleanse,
+CRYPTO_malloc, CRYPTO_aligned_alloc, CRYPTO_zalloc,
+CRYPTO_malloc_array, CRYPTO_aligned_alloc_array, CRYPTO_calloc,
+CRYPTO_realloc, CRYPTO_realloc_array, CRYPTO_free,
 OPENSSL_strdup, OPENSSL_strndup,
 OPENSSL_memdup, OPENSSL_strlcpy, OPENSSL_strlcat, OPENSSL_strtoul,
 CRYPTO_strdup, CRYPTO_strndup,
 OPENSSL_mem_debug_push, OPENSSL_mem_debug_pop,
 CRYPTO_mem_debug_push, CRYPTO_mem_debug_pop,
-CRYPTO_clear_realloc, CRYPTO_clear_free,
+CRYPTO_clear_realloc, CRYPTO_clear_realloc_array, CRYPTO_clear_free,
 CRYPTO_malloc_fn, CRYPTO_realloc_fn, CRYPTO_free_fn,
 CRYPTO_get_mem_functions, CRYPTO_set_mem_functions,
 CRYPTO_get_alloc_counts,
@@ -32,6 +37,11 @@ OPENSSL_MALLOC_SEED
  void *OPENSSL_aligned_alloc(size_t num, size_t alignment, void **freeptr);
  void *OPENSSL_zalloc(size_t num);
  void *OPENSSL_realloc(void *addr, size_t num);
+ void *OPENSSL_malloc_array(size_t num, size_t size);
+ void *OPENSSL_aligned_alloc_array(size_t num, size_t size, size_t alignment,
+                                   void **freeptr);
+ void *OPENSSL_calloc(size_t num, size_t size);
+ void *OPENSSL_realloc_array(void *addr, size_t num, size_t size);
  void OPENSSL_free(void *addr);
  char *OPENSSL_strdup(const char *str);
  char *OPENSSL_strndup(const char *str, size_t s);
@@ -40,20 +50,30 @@ OPENSSL_MALLOC_SEED
  int OPENSSL_strtoul(char *src, char **endptr, int base, unsigned long *num);
  void *OPENSSL_memdup(void *data, size_t s);
  void *OPENSSL_clear_realloc(void *p, size_t old_len, size_t num);
+ void *OPENSSL_clear_realloc_array(void *p, size_t old_len, size_t num,
+                                   size_t size);
  void OPENSSL_clear_free(void *str, size_t num);
  void OPENSSL_cleanse(void *ptr, size_t len);
 
  void *CRYPTO_malloc(size_t num, const char *file, int line);
- void *CRYPTO_aligned_alloc(size_t num, size_t align, void **freeptr, 
+ void *CRYPTO_aligned_alloc(size_t num, size_t align, void **freeptr,
                             const char *file, int line);
  void *CRYPTO_zalloc(size_t num, const char *file, int line);
  void *CRYPTO_realloc(void *p, size_t num, const char *file, int line);
- void CRYPTO_free(void *str, const char *, int);
+ void *CRYPTO_malloc_array(size_t num, size_t size, const char *file, int line);
+ void *CRYPTO_aligned_alloc_array(size_t num, size_t size, size_t align,
+                                  void **freeptr, const char *file, int line);
+ void *CRYPTO_calloc(size_t num, size_t size, const char *file, int line);
+ void *CRYPTO_realloc_array(void *p, size_t num, size_t size,
+                            const char *file, int line);
+ void CRYPTO_free(void *str, const char *file, int line);
  char *CRYPTO_strdup(const char *p, const char *file, int line);
  char *CRYPTO_strndup(const char *p, size_t num, const char *file, int line);
  void *CRYPTO_clear_realloc(void *p, size_t old_len, size_t num,
                             const char *file, int line);
- void CRYPTO_clear_free(void *str, size_t num, const char *, int);
+ void *CRYPTO_clear_realloc_array(void *p, size_t old_len, size_t num,
+                                  size_t size, const char *file, int line);
+ void CRYPTO_clear_free(void *str, size_t num, const char *file, int line);
 
  typedef void *(*CRYPTO_malloc_fn)(size_t num, const char *file, int line);
  typedef void *(*CRYPTO_realloc_fn)(void *addr, size_t num, const char *file,
@@ -121,6 +141,15 @@ when the buffer at B<addr> holds sensitive information.
 The old buffer is filled with zero's by calling OPENSSL_cleanse()
 before ultimately calling OPENSSL_free(). If the argument to OPENSSL_free() is
 NULL, nothing is done.
+
+OPENSSL_malloc_array(), OPENSSL_calloc(), OPENSSL_aligned_alloc_array(),
+OPENSSL_realloc_array(), and OPENSSL_clear_realloc_array() are variants
+of OPENSSL_malloc(), OPENSSL_zalloc(), OPENSSL_aligned_alloc(),
+OPENSSL_realloc(), and OPENSSL_clear_realloc(), respectively, that accept
+an additional parameter, B<size>, which enables memory allocation
+operations for an array of B<num> members B<size> bytes each;
+these functions return an error if multiplication of B<num> and B<size>
+leads to an integer overflow, thus preventing allocations of an incorrect size.
 
 OPENSSL_cleanse() fills B<ptr> of size B<len> with a string of 0's.
 Use OPENSSL_cleanse() with care if the memory is a mapping of a file.
@@ -203,9 +232,12 @@ CRYPTO_free(), CRYPTO_clear_free() and CRYPTO_get_mem_functions()
 return no value.
 
 OPENSSL_malloc(), OPENSSL_aligned_alloc(), OPENSSL_zalloc(), OPENSSL_realloc(),
-OPENSSL_clear_realloc(),
+OPENSSL_malloc_array(), OPENSSL_aligned_alloc_array(), OPENSSL_calloc(),
+OPENSSL_realloc_array(),
+OPENSSL_clear_realloc(), OPENSSL_clear_realloc_array(),
 CRYPTO_malloc(), CRYPTO_zalloc(), CRYPTO_realloc(),
-CRYPTO_clear_realloc(),
+CRYPTO_malloc_array(), CRYPTO_calloc(), CRYPTO_realloc_array(),
+CRYPTO_clear_realloc(), CRYPTO_clear_realloc_array(),
 OPENSSL_strdup(), and OPENSSL_strndup()
 return a pointer to allocated memory or NULL on error.
 
@@ -259,6 +291,10 @@ The memory-leak checking has been deprecated in OpenSSL 3.0 in favor of
 clang's memory and leak sanitizer.
 OPENSSL_aligned_alloc(), CRYPTO_aligned_alloc(), OPENSSL_strtoul() were
 added in OpenSSL 3.4.
+OPENSSL_malloc_array(), OPENSSL_calloc(), OPENSSL_aligned_alloc_array(),
+OPENSSL_realloc_array(), OPENSSL_clear_realloc_array(), CRYPTO_malloc_array(),
+CRYPTO_calloc(), CRYPTO_aligned_alloc_array(), CRYPTO_realloc_array(),
+CRYPTO_clear_realloc_array() were added in OpenSSL 3.6.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OPENSSL_malloc.pod
+++ b/doc/man3/OPENSSL_malloc.pod
@@ -259,6 +259,9 @@ CRYPTO_clear_realloc(), CRYPTO_clear_realloc_array(),
 OPENSSL_strdup(), and OPENSSL_strndup()
 return a pointer to allocated memory or NULL on error.
 
+OPENSSL_aligned_alloc() and OPENSSL_aligned_alloc_array() set B<freeptr>
+to NULL on error.
+
 CRYPTO_set_mem_functions() returns 1 on success or 0 on failure (almost
 always because allocations have already happened).
 

--- a/doc/man3/OPENSSL_malloc.pod
+++ b/doc/man3/OPENSSL_malloc.pod
@@ -122,19 +122,19 @@ OPENSSL_malloc(), OPENSSL_realloc(), and OPENSSL_free() are like the
 C malloc(), realloc(), and free() functions.
 OPENSSL_zalloc() calls memset() to zero the memory before returning.
 
-OPENSSL_aligned_alloc() operates just as OPENSSL_malloc does, but it
+OPENSSL_aligned_alloc() operates just as OPENSSL_malloc() does, but it
 allows for the caller to specify an alignment value, for instances in
-which the default alignment of malloc is insufficient for the callers
+which the default alignment of malloc is insufficient for the caller's
 needs.  Note, the alignment value must be a power of 2, and the size
 specified must be a multiple of the alignment.
 NOTE: The call to OPENSSL_aligned_alloc() accepts a 3rd argument, I<freeptr>
 which must point to a void pointer.  On some platforms, there is no available
-library call to obtain memory allocations greater than what malloc provides.  In
-this case, OPENSSL_aligned_alloc implements its own alignment routine,
-allocating additional memory and offsetting the returned pointer to be on the
-requested alignment boundary.  In order to safely free allocations made by this
-method, the caller must return the value in the I<freeptr> variable, rather than
-the returned pointer.
+library call to obtain memory allocations with alignment greater than what
+malloc provides.  In this case, OPENSSL_aligned_alloc() implements its own
+alignment routine, allocating additional memory and offsetting the returned
+pointer to be on the requested alignment boundary.  In order to safely free
+allocations made by this method, the caller must return the value
+in the I<freeptr> variable, rather than the returned pointer.
 
 OPENSSL_clear_realloc() and OPENSSL_clear_free() should be used
 when the buffer at B<addr> holds sensitive information.

--- a/doc/man3/OPENSSL_secure_malloc.pod
+++ b/doc/man3/OPENSSL_secure_malloc.pod
@@ -4,8 +4,9 @@
 
 CRYPTO_secure_malloc_init, CRYPTO_secure_malloc_initialized,
 CRYPTO_secure_malloc_done, OPENSSL_secure_malloc, CRYPTO_secure_malloc,
-OPENSSL_secure_zalloc, CRYPTO_secure_zalloc, OPENSSL_secure_free,
-CRYPTO_secure_free, OPENSSL_secure_clear_free,
+OPENSSL_secure_zalloc, CRYPTO_secure_zalloc, OPENSSL_secure_malloc_array,
+CRYPTO_secure_malloc_array, OPENSSL_secure_calloc, CRYPTO_secure_calloc,
+OPENSSL_secure_free, CRYPTO_secure_free, OPENSSL_secure_clear_free,
 CRYPTO_secure_clear_free, OPENSSL_secure_actual_size,
 CRYPTO_secure_allocated,
 CRYPTO_secure_used - secure heap storage
@@ -25,6 +26,14 @@ CRYPTO_secure_used - secure heap storage
 
  void *OPENSSL_secure_zalloc(size_t num);
  void *CRYPTO_secure_zalloc(size_t num, const char *file, int line);
+
+ void *OPENSSL_secure_malloc_array(size_t num, size_t size);
+ void *CRYPTO_secure_malloc_array(size_t num, size_t size,
+                                  const char *file, int line);
+
+ void *OPENSSL_secure_calloc(size_t num, size_t size);
+ void *CRYPTO_secure_calloc(size_t num, size_t size,
+                            const char *file, int line);
 
  void OPENSSL_secure_free(void* ptr);
  void CRYPTO_secure_free(void *ptr, const char *, int);
@@ -80,6 +89,15 @@ OPENSSL_secure_zalloc() and CRYPTO_secure_zalloc() are like
 OPENSSL_secure_malloc() and CRYPTO_secure_malloc(), respectively,
 except that they call memset() to zero the memory before returning.
 
+OPENSSL_secure_malloc_array(), CRYPTO_secure_malloc_array(),
+OPENSSL_secure_calloc(), and CRYPTO_secure_calloc() are variants
+of OPENSSL_secure_malloc(), CRYPTO_secure_malloc(),
+OPENSSL_secure_zalloc(), and CRYPTO_secure_zalloc(), respectively, that accept
+an additional parameter, B<size>, which enables memory allocation
+operations for an array of B<num> members B<size> bytes each;
+these functions return an error if multiplication of B<num> and B<size>
+leads to an integer overflow, thus preventing allocations of an incorrect size.
+
 OPENSSL_secure_free() releases the memory at C<ptr> back to the heap.
 It must be called with a value previously obtained from
 OPENSSL_secure_malloc().
@@ -116,9 +134,11 @@ CRYPTO_secure_malloc_initialized() returns 1 if the secure heap is
 available (that is, if CRYPTO_secure_malloc_init() has been called,
 but CRYPTO_secure_malloc_done() has not been called or failed) or 0 if not.
 
-OPENSSL_secure_malloc() and OPENSSL_secure_zalloc() return a pointer into
-the secure heap of the requested size, or C<NULL> if memory could not be
-allocated.
+OPENSSL_secure_malloc(), CRYPTO_secure_malloc(), OPENSSL_secure_zalloc(),
+CRYPTO_secure_zalloc(), OPENSSL_secure_malloc_array(),
+CRYPTO_secure_malloc_array(), OPENSSL_secure_calloc(), and CRYPTO_secure_calloc()
+return a pointer into the secure heap of the requested size,
+or C<NULL> if memory could not be allocated.
 
 CRYPTO_secure_allocated() returns 1 if the pointer is in the secure heap, or 0 if not.
 
@@ -137,6 +157,10 @@ The OPENSSL_secure_clear_free() function was added in OpenSSL 1.1.0g.
 
 The second argument to CRYPTO_secure_malloc_init() was changed from an B<int> to
 a B<size_t> in OpenSSL 3.0.
+
+The OPENSSL_secure_malloc_array(), CRYPTO_secure_malloc_array(),
+OPENSSL_secure_calloc(), and CRYPTO_secure_calloc() functions were added
+in OpenSSL 3.6.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OPENSSL_secure_malloc.pod
+++ b/doc/man3/OPENSSL_secure_malloc.pod
@@ -137,8 +137,9 @@ but CRYPTO_secure_malloc_done() has not been called or failed) or 0 if not.
 OPENSSL_secure_malloc(), CRYPTO_secure_malloc(), OPENSSL_secure_zalloc(),
 CRYPTO_secure_zalloc(), OPENSSL_secure_malloc_array(),
 CRYPTO_secure_malloc_array(), OPENSSL_secure_calloc(), and CRYPTO_secure_calloc()
-return a pointer into the secure heap of the requested size,
-or C<NULL> if memory could not be allocated.
+return a pointer into the secure heap of the requested size, if it is
+initialised, a pointer returned by the underlying OPENSSL_malloc() call,
+if it is not, or C<NULL> on error.
 
 CRYPTO_secure_allocated() returns 1 if the pointer is in the secure heap, or 0 if not.
 

--- a/fuzz/hashtable.c
+++ b/fuzz/hashtable.c
@@ -103,7 +103,7 @@ int FuzzerInitialize(int *argc, char ***argv)
 
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     ERR_clear_error();
-    prediction_table = OPENSSL_zalloc(sizeof(FUZZER_VALUE) * 65537);
+    prediction_table = OPENSSL_calloc(65537, sizeof(FUZZER_VALUE));
     if (prediction_table == NULL)
         return -1;
     fuzzer_table = ossl_ht_new(&fuzz_conf);

--- a/fuzz/provider.c
+++ b/fuzz/provider.c
@@ -270,7 +270,7 @@ static OSSL_PARAM *fuzz_params(OSSL_PARAM *param, const uint8_t **buf, size_t *l
     for (p = param; p != NULL && p->key != NULL; p++)
         p_num++;
 
-    fuzzed_parameters = OPENSSL_zalloc(sizeof(OSSL_PARAM) *(p_num + 1));
+    fuzzed_parameters = OPENSSL_calloc(p_num + 1, sizeof(OSSL_PARAM));
     p = fuzzed_parameters;
 
     for (; param != NULL && param->key != NULL; param++) {

--- a/include/internal/mem_alloc_utils.h
+++ b/include/internal/mem_alloc_utils.h
@@ -91,21 +91,23 @@ ossl_size_mul(const size_t num, const size_t size, size_t *bytes,
 
 /*
  * Check the result of size1 and size2 addition for overflow
- * and set error if it is the case.
+ * and set error if it is the case;  returns true if there was no overflow,
+ * false if there was.
  */
 static ossl_inline ossl_unused bool
-ossl_size_add_of(const size_t size1, const size_t size2, size_t *bytes,
-                 const char * const file, const int line)
+ossl_size_add(const size_t size1, const size_t size2, size_t *bytes,
+              const char * const file, const int line)
 {
-    *bytes = size1 + size2;
+    int err = 0;
+    *bytes = safe_add_size_t(size1, size2, &err);
 
-    if (ossl_unlikely(*bytes < size1)) {
+    if (ossl_unlikely(err != 0)) {
         ossl_report_alloc_err_of(file, line);
 
-        return true;
+        return false;
     }
 
-    return false;
+    return true;
 }
 
 #endif /* OSSL_INTERNAL_CHECK_SIZE_OVERFLOW_H */

--- a/include/internal/mem_alloc_utils.h
+++ b/include/internal/mem_alloc_utils.h
@@ -14,10 +14,17 @@
 #ifndef OSSL_INTERNAL_CHECK_SIZE_OVERFLOW_H
 # define OSSL_INTERNAL_CHECK_SIZE_OVERFLOW_H
 
+# include <limits.h>
+# include <stdbool.h>
+# include <stdint.h>
+
 # include "internal/common.h"
+# include "internal/safe_math.h"
 
 # include <openssl/cryptoerr.h>
 # include <openssl/err.h>
+
+OSSL_SAFE_MATH_UNSIGNED(size_t, size_t)
 
 /*
  * A helper routine to report memory allocation errors.
@@ -41,10 +48,38 @@ ossl_report_alloc_err_ex(const char * const file, const int line,
 }
 
 /* Report a memory allocation failure. */
-static inline void
+static ossl_inline ossl_unused void
 ossl_report_alloc_err(const char * const file, const int line)
 {
     ossl_report_alloc_err_ex(file, line, ERR_R_MALLOC_FAILURE);
+}
+
+/* Report an integer overflow during allocation size calculation. */
+static ossl_inline ossl_unused void
+ossl_report_alloc_err_of(const char * const file, const int line)
+{
+    ossl_report_alloc_err_ex(file, line, CRYPTO_R_INTEGER_OVERFLOW);
+}
+
+/*
+ * Check the result of num and size multiplication for overflow
+ * and set error if it is the case;  return true if there was no overflow,
+ * false if there was.
+ */
+static ossl_inline ossl_unused bool
+ossl_size_mul(const size_t num, const size_t size, size_t *bytes,
+              const char * const file, const int line)
+{
+    int err = 0;
+    *bytes = safe_mul_size_t(num, size, &err);
+
+    if (ossl_unlikely(err != 0)) {
+        ossl_report_alloc_err_of(file, line);
+
+        return false;
+    }
+
+    return true;
 }
 
 #endif /* OSSL_INTERNAL_CHECK_SIZE_OVERFLOW_H */

--- a/include/internal/mem_alloc_utils.h
+++ b/include/internal/mem_alloc_utils.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * Utility overflow checking and reporting functions
+ */
+
+#ifndef OSSL_INTERNAL_CHECK_SIZE_OVERFLOW_H
+# define OSSL_INTERNAL_CHECK_SIZE_OVERFLOW_H
+
+# include "internal/common.h"
+
+# include <openssl/cryptoerr.h>
+# include <openssl/err.h>
+
+/*
+ * A helper routine to report memory allocation errors.
+ * Similar to the ERR_raise() macro, but accepts explicit file/line arguments,
+ * pre-defines the library to ERR_LIB_CRYPTO, and avoids emitting an error
+ * if both file set to NULL and line set to 0.
+ */
+static ossl_inline ossl_unused void
+ossl_report_alloc_err_ex(const char * const file, const int line,
+                         const int reason)
+{
+    /*
+     * ossl_err_get_state_int() in err.c uses CRYPTO_zalloc(num, NULL, 0) for
+     * ERR_STATE allocation. Prevent mem alloc error loop while reporting error.
+     */
+    if (file != NULL || line != 0) {
+        ERR_new();
+        ERR_set_debug(file, line, NULL);
+        ERR_set_error(ERR_LIB_CRYPTO, reason, NULL);
+    }
+}
+
+/* Report a memory allocation failure. */
+static inline void
+ossl_report_alloc_err(const char * const file, const int line)
+{
+    ossl_report_alloc_err_ex(file, line, ERR_R_MALLOC_FAILURE);
+}
+
+#endif /* OSSL_INTERNAL_CHECK_SIZE_OVERFLOW_H */

--- a/include/internal/mem_alloc_utils.h
+++ b/include/internal/mem_alloc_utils.h
@@ -61,6 +61,13 @@ ossl_report_alloc_err_of(const char * const file, const int line)
     ossl_report_alloc_err_ex(file, line, CRYPTO_R_INTEGER_OVERFLOW);
 }
 
+/* Report invalid memory allocation call arguments. */
+static ossl_inline ossl_unused void
+ossl_report_alloc_err_inv(const char * const file, const int line)
+{
+    ossl_report_alloc_err_ex(file, line, ERR_R_PASSED_INVALID_ARGUMENT);
+}
+
 /*
  * Check the result of num and size multiplication for overflow
  * and set error if it is the case;  return true if there was no overflow,

--- a/include/internal/mem_alloc_utils.h
+++ b/include/internal/mem_alloc_utils.h
@@ -82,4 +82,23 @@ ossl_size_mul(const size_t num, const size_t size, size_t *bytes,
     return true;
 }
 
+/*
+ * Check the result of size1 and size2 addition for overflow
+ * and set error if it is the case.
+ */
+static ossl_inline ossl_unused bool
+ossl_size_add_of(const size_t size1, const size_t size2, size_t *bytes,
+                 const char * const file, const int line)
+{
+    *bytes = size1 + size2;
+
+    if (ossl_unlikely(*bytes < size1)) {
+        ossl_report_alloc_err_of(file, line);
+
+        return true;
+    }
+
+    return false;
+}
+
 #endif /* OSSL_INTERNAL_CHECK_SIZE_OVERFLOW_H */

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -103,13 +103,25 @@ int CRYPTO_atomic_store(uint64_t *dst, uint64_t val, CRYPTO_RWLOCK *lock);
     CRYPTO_malloc(num, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_zalloc(num) \
     CRYPTO_zalloc(num, OPENSSL_FILE, OPENSSL_LINE)
+# define OPENSSL_malloc_array(num, size) \
+    CRYPTO_malloc_array(num, size, OPENSSL_FILE, OPENSSL_LINE)
+# define OPENSSL_calloc(num, size) \
+    CRYPTO_calloc(num, size, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_aligned_alloc(num, alignment, freeptr) \
     CRYPTO_aligned_alloc(num, alignment, freeptr, \
                          OPENSSL_FILE, OPENSSL_LINE)
+# define OPENSSL_aligned_alloc_array(num, size, alignment, freeptr) \
+    CRYPTO_aligned_alloc_array(num, size, alignment, freeptr, \
+                               OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_realloc(addr, num) \
     CRYPTO_realloc(addr, num, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_clear_realloc(addr, old_num, num) \
     CRYPTO_clear_realloc(addr, old_num, num, OPENSSL_FILE, OPENSSL_LINE)
+# define OPENSSL_realloc_array(addr, num, size) \
+    CRYPTO_realloc_array(addr, num, size, OPENSSL_FILE, OPENSSL_LINE)
+# define OPENSSL_clear_realloc_array(addr, old_num, num, size) \
+    CRYPTO_clear_realloc_array(addr, old_num, num, size, \
+                               OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_clear_free(addr, num) \
     CRYPTO_clear_free(addr, num, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_free(addr) \
@@ -124,6 +136,10 @@ int CRYPTO_atomic_store(uint64_t *dst, uint64_t val, CRYPTO_RWLOCK *lock);
     CRYPTO_secure_malloc(num, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_secure_zalloc(num) \
     CRYPTO_secure_zalloc(num, OPENSSL_FILE, OPENSSL_LINE)
+# define OPENSSL_secure_malloc_array(num, size) \
+    CRYPTO_secure_malloc_array(num, size, OPENSSL_FILE, OPENSSL_LINE)
+# define OPENSSL_secure_calloc(num, size) \
+    CRYPTO_secure_calloc(num, size, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_secure_free(addr) \
     CRYPTO_secure_free(addr, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_secure_clear_free(addr, num) \
@@ -332,9 +348,16 @@ void CRYPTO_get_mem_functions(CRYPTO_malloc_fn *malloc_fn,
 
 OSSL_CRYPTO_ALLOC void *CRYPTO_malloc(size_t num, const char *file, int line);
 OSSL_CRYPTO_ALLOC void *CRYPTO_zalloc(size_t num, const char *file, int line);
+OSSL_CRYPTO_ALLOC void *CRYPTO_malloc_array(size_t num, size_t size,
+                                            const char *file, int line);
+OSSL_CRYPTO_ALLOC void *CRYPTO_calloc(size_t num, size_t size,
+                                      const char *file, int line);
 OSSL_CRYPTO_ALLOC void *CRYPTO_aligned_alloc(size_t num, size_t align,
                                              void **freeptr, const char *file,
                                              int line);
+OSSL_CRYPTO_ALLOC void *CRYPTO_aligned_alloc_array(size_t num, size_t size,
+                                                   size_t align, void **freeptr,
+                                                   const char *file, int line);
 OSSL_CRYPTO_ALLOC void *CRYPTO_memdup(const void *str, size_t siz, const char *file, int line);
 OSSL_CRYPTO_ALLOC char *CRYPTO_strdup(const char *str, const char *file, int line);
 OSSL_CRYPTO_ALLOC char *CRYPTO_strndup(const char *str, size_t s, const char *file, int line);
@@ -343,11 +366,19 @@ void CRYPTO_clear_free(void *ptr, size_t num, const char *file, int line);
 void *CRYPTO_realloc(void *addr, size_t num, const char *file, int line);
 void *CRYPTO_clear_realloc(void *addr, size_t old_num, size_t num,
                            const char *file, int line);
+void *CRYPTO_realloc_array(void *addr, size_t num, size_t size,
+                           const char *file, int line);
+void *CRYPTO_clear_realloc_array(void *addr, size_t old_num, size_t num,
+                                 size_t size, const char *file, int line);
 
 int CRYPTO_secure_malloc_init(size_t sz, size_t minsize);
 int CRYPTO_secure_malloc_done(void);
 OSSL_CRYPTO_ALLOC void *CRYPTO_secure_malloc(size_t num, const char *file, int line);
 OSSL_CRYPTO_ALLOC void *CRYPTO_secure_zalloc(size_t num, const char *file, int line);
+OSSL_CRYPTO_ALLOC void *CRYPTO_secure_malloc_array(size_t num, size_t size,
+                                                   const char *file, int line);
+OSSL_CRYPTO_ALLOC void *CRYPTO_secure_calloc(size_t num, size_t size,
+                                             const char *file, int line);
 void CRYPTO_secure_free(void *ptr, const char *file, int line);
 void CRYPTO_secure_clear_free(void *ptr, size_t num,
                               const char *file, int line);

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -100,36 +100,36 @@ int CRYPTO_atomic_store(uint64_t *dst, uint64_t val, CRYPTO_RWLOCK *lock);
 #define OPENSSL_malloc_init() while(0) continue
 
 # define OPENSSL_malloc(num) \
-        CRYPTO_malloc(num, OPENSSL_FILE, OPENSSL_LINE)
+    CRYPTO_malloc(num, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_zalloc(num) \
-        CRYPTO_zalloc(num, OPENSSL_FILE, OPENSSL_LINE)
+    CRYPTO_zalloc(num, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_aligned_alloc(num, alignment, freeptr) \
-        CRYPTO_aligned_alloc(num, alignment, freeptr, \
-                             OPENSSL_FILE, OPENSSL_LINE)
+    CRYPTO_aligned_alloc(num, alignment, freeptr, \
+                         OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_realloc(addr, num) \
-        CRYPTO_realloc(addr, num, OPENSSL_FILE, OPENSSL_LINE)
+    CRYPTO_realloc(addr, num, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_clear_realloc(addr, old_num, num) \
-        CRYPTO_clear_realloc(addr, old_num, num, OPENSSL_FILE, OPENSSL_LINE)
+    CRYPTO_clear_realloc(addr, old_num, num, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_clear_free(addr, num) \
-        CRYPTO_clear_free(addr, num, OPENSSL_FILE, OPENSSL_LINE)
+    CRYPTO_clear_free(addr, num, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_free(addr) \
-        CRYPTO_free(addr, OPENSSL_FILE, OPENSSL_LINE)
+    CRYPTO_free(addr, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_memdup(str, s) \
-        CRYPTO_memdup((str), s, OPENSSL_FILE, OPENSSL_LINE)
+    CRYPTO_memdup((str), s, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_strdup(str) \
-        CRYPTO_strdup(str, OPENSSL_FILE, OPENSSL_LINE)
+    CRYPTO_strdup(str, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_strndup(str, n) \
-        CRYPTO_strndup(str, n, OPENSSL_FILE, OPENSSL_LINE)
+    CRYPTO_strndup(str, n, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_secure_malloc(num) \
-        CRYPTO_secure_malloc(num, OPENSSL_FILE, OPENSSL_LINE)
+    CRYPTO_secure_malloc(num, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_secure_zalloc(num) \
-        CRYPTO_secure_zalloc(num, OPENSSL_FILE, OPENSSL_LINE)
+    CRYPTO_secure_zalloc(num, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_secure_free(addr) \
-        CRYPTO_secure_free(addr, OPENSSL_FILE, OPENSSL_LINE)
+    CRYPTO_secure_free(addr, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_secure_clear_free(addr, num) \
-        CRYPTO_secure_clear_free(addr, num, OPENSSL_FILE, OPENSSL_LINE)
+    CRYPTO_secure_clear_free(addr, num, OPENSSL_FILE, OPENSSL_LINE)
 # define OPENSSL_secure_actual_size(ptr) \
-        CRYPTO_secure_actual_size(ptr)
+    CRYPTO_secure_actual_size(ptr)
 
 size_t OPENSSL_strlcpy(char *dst, const char *src, size_t siz);
 size_t OPENSSL_strlcat(char *dst, const char *src, size_t siz);

--- a/providers/implementations/encode_decode/ml_common_codecs.c
+++ b/providers/implementations/encode_decode/ml_common_codecs.c
@@ -42,7 +42,7 @@ ossl_ml_common_pkcs8_fmt_order(const char *algorithm_name,
     const char *sep = "\t ,";
 
     /* Reserve an extra terminal slot with fmt == NULL */
-    if ((ret = OPENSSL_zalloc((NUM_PKCS8_FORMATS + 1) * sizeof(*ret))) == NULL)
+    if ((ret = OPENSSL_calloc(NUM_PKCS8_FORMATS + 1, sizeof(*ret))) == NULL)
         return NULL;
 
     /* Entries that match a format will get a non-zero preference. */

--- a/providers/implementations/kdfs/argon2.c.in
+++ b/providers/implementations/kdfs/argon2.c.in
@@ -567,8 +567,8 @@ static int fill_mem_blocks_mt(KDF_ARGON2 *ctx)
     void **t;
     ARGON2_THREAD_DATA *t_data;
 
-    t = OPENSSL_zalloc(sizeof(void *)*ctx->lanes);
-    t_data = OPENSSL_zalloc(ctx->lanes * sizeof(ARGON2_THREAD_DATA));
+    t = OPENSSL_calloc(ctx->lanes, sizeof(void *));
+    t_data = OPENSSL_calloc(ctx->lanes, sizeof(ARGON2_THREAD_DATA));
 
     if (t == NULL || t_data == NULL)
         goto fail;
@@ -736,11 +736,9 @@ static int initialize(KDF_ARGON2 *ctx)
         return 0;
 
     if (ctx->type != ARGON2_D)
-        ctx->memory = OPENSSL_secure_zalloc(ctx->memory_blocks *
-                                            sizeof(BLOCK));
+        ctx->memory = OPENSSL_secure_calloc(ctx->memory_blocks, sizeof(BLOCK));
     else
-        ctx->memory = OPENSSL_zalloc(ctx->memory_blocks *
-                                     sizeof(BLOCK));
+        ctx->memory = OPENSSL_calloc(ctx->memory_blocks, sizeof(BLOCK));
 
     if (ctx->memory == NULL) {
         ERR_raise_data(ERR_LIB_PROV, PROV_R_INVALID_MEMORY_SIZE,

--- a/ssl/priority_queue.c
+++ b/ssl/priority_queue.c
@@ -310,12 +310,12 @@ int ossl_pqueue_reserve(OSSL_PQUEUE *pq, size_t n)
         return 0;
     }
 
-    h = OPENSSL_realloc(pq->heap, new_max * sizeof(*pq->heap));
+    h = OPENSSL_realloc_array(pq->heap, new_max, sizeof(*pq->heap));
     if (h == NULL)
         return 0;
     pq->heap = h;
 
-    e = OPENSSL_realloc(pq->elements, new_max * sizeof(*pq->elements));
+    e = OPENSSL_realloc_array(pq->elements, new_max, sizeof(*pq->elements));
     if (e == NULL)
         return 0;
     pq->elements = e;
@@ -339,8 +339,8 @@ OSSL_PQUEUE *ossl_pqueue_new(int (*compare)(const void *, const void *))
     pq->hmax = min_nodes;
     pq->htop = 0;
     pq->freelist = 0;
-    pq->heap = OPENSSL_malloc(sizeof(*pq->heap) * min_nodes);
-    pq->elements = OPENSSL_malloc(sizeof(*pq->elements) * min_nodes);
+    pq->heap = OPENSSL_malloc_array(min_nodes, sizeof(*pq->heap));
+    pq->elements = OPENSSL_malloc_array(min_nodes, sizeof(*pq->elements));
     if (pq->heap == NULL || pq->elements == NULL) {
         ossl_pqueue_free(pq);
         return NULL;

--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -3160,7 +3160,7 @@ static int txp_el_ensure_iovec(struct txp_el *el, size_t num)
 
     num = el->alloc_iovec != 0 ? el->alloc_iovec * 2 : 8;
 
-    iovec = OPENSSL_realloc(el->iovec, sizeof(OSSL_QTX_IOVEC) * num);
+    iovec = OPENSSL_realloc_array(el->iovec, num, sizeof(OSSL_QTX_IOVEC));
     if (iovec == NULL)
         return 0;
 

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -812,7 +812,7 @@ int tls_get_more_records(OSSL_RECORD_LAYER *rl)
     }
 
     if (mac_size > 0) {
-        macbufs = OPENSSL_zalloc(sizeof(*macbufs) * num_recs);
+        macbufs = OPENSSL_calloc(num_recs, sizeof(*macbufs));
         if (macbufs == NULL) {
             RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_CRYPTO_LIB);
             return OSSL_RECORD_RETURN_FATAL;

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -74,7 +74,7 @@ CERT *ssl_cert_new(size_t ssl_pkey_num)
         return NULL;
 
     ret->ssl_pkey_num = ssl_pkey_num;
-    ret->pkeys = OPENSSL_zalloc(ret->ssl_pkey_num * sizeof(CERT_PKEY));
+    ret->pkeys = OPENSSL_calloc(ret->ssl_pkey_num, sizeof(CERT_PKEY));
     if (ret->pkeys == NULL) {
         OPENSSL_free(ret);
         return NULL;
@@ -105,7 +105,7 @@ CERT *ssl_cert_dup(CERT *cert)
         return NULL;
 
     ret->ssl_pkey_num = cert->ssl_pkey_num;
-    ret->pkeys = OPENSSL_zalloc(ret->ssl_pkey_num * sizeof(CERT_PKEY));
+    ret->pkeys = OPENSSL_calloc(ret->ssl_pkey_num, sizeof(CERT_PKEY));
     if (ret->pkeys == NULL) {
         OPENSSL_free(ret);
         return NULL;
@@ -170,8 +170,8 @@ CERT *ssl_cert_dup(CERT *cert)
 
     /* Configured sigalgs copied across */
     if (cert->conf_sigalgs) {
-        ret->conf_sigalgs = OPENSSL_malloc(cert->conf_sigalgslen
-                                           * sizeof(*cert->conf_sigalgs));
+        ret->conf_sigalgs = OPENSSL_malloc_array(cert->conf_sigalgslen,
+                                                 sizeof(*cert->conf_sigalgs));
         if (ret->conf_sigalgs == NULL)
             goto err;
         memcpy(ret->conf_sigalgs, cert->conf_sigalgs,
@@ -181,8 +181,9 @@ CERT *ssl_cert_dup(CERT *cert)
         ret->conf_sigalgs = NULL;
 
     if (cert->client_sigalgs) {
-        ret->client_sigalgs = OPENSSL_malloc(cert->client_sigalgslen
-                                             * sizeof(*cert->client_sigalgs));
+        ret->client_sigalgs =
+            OPENSSL_malloc_array(cert->client_sigalgslen,
+                                 sizeof(*cert->client_sigalgs));
         if (ret->client_sigalgs == NULL)
             goto err;
         memcpy(ret->client_sigalgs, cert->client_sigalgs,

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -948,7 +948,7 @@ static int ssl_cipher_strength_sort(CIPHER_ORDER **head_p,
         curr = curr->next;
     }
 
-    number_uses = OPENSSL_zalloc(sizeof(int) * (max_strength_bits + 1));
+    number_uses = OPENSSL_calloc(max_strength_bits + 1, sizeof(int));
     if (number_uses == NULL)
         return 0;
 
@@ -1475,7 +1475,7 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_list(SSL_CTX *ctx,
     num_of_ciphers = ssl_method->num_ciphers();
 
     if (num_of_ciphers > 0) {
-        co_list = OPENSSL_malloc(sizeof(*co_list) * num_of_ciphers);
+        co_list = OPENSSL_malloc_array(num_of_ciphers, sizeof(*co_list));
         if (co_list == NULL)
             return NULL;          /* Failure */
     }
@@ -1586,7 +1586,7 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_list(SSL_CTX *ctx,
      */
     num_of_group_aliases = OSSL_NELEM(cipher_aliases);
     num_of_alias_max = num_of_ciphers + num_of_group_aliases + 1;
-    ca_list = OPENSSL_malloc(sizeof(*ca_list) * num_of_alias_max);
+    ca_list = OPENSSL_malloc_array(num_of_alias_max, sizeof(*ca_list));
     if (ca_list == NULL) {
         OPENSSL_free(co_list);
         return NULL;          /* Failure */

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -124,8 +124,8 @@ static int dane_ctx_enable(struct dane_ctx_st *dctx)
     if (dctx->mdevp != NULL)
         return 1;
 
-    mdevp = OPENSSL_zalloc(n * sizeof(*mdevp));
-    mdord = OPENSSL_zalloc(n * sizeof(*mdord));
+    mdevp = OPENSSL_calloc(n, sizeof(*mdevp));
+    mdord = OPENSSL_calloc(n, sizeof(*mdord));
 
     if (mdord == NULL || mdevp == NULL) {
         OPENSSL_free(mdord);
@@ -232,12 +232,12 @@ static int dane_mtype_set(struct dane_ctx_st *dctx,
         uint8_t *mdord;
         int n = ((int)mtype) + 1;
 
-        mdevp = OPENSSL_realloc(dctx->mdevp, n * sizeof(*mdevp));
+        mdevp = OPENSSL_realloc_array(dctx->mdevp, n, sizeof(*mdevp));
         if (mdevp == NULL)
             return -1;
         dctx->mdevp = mdevp;
 
-        mdord = OPENSSL_realloc(dctx->mdord, n * sizeof(*mdord));
+        mdord = OPENSSL_realloc_array(dctx->mdord, n, sizeof(*mdord));
         if (mdord == NULL)
             return -1;
         dctx->mdord = mdord;
@@ -6899,7 +6899,7 @@ int SSL_client_hello_get1_extensions_present(SSL *s, int **out, size_t *outlen)
         *outlen = 0;
         return 1;
     }
-    if ((present = OPENSSL_malloc(sizeof(*present) * num)) == NULL)
+    if ((present = OPENSSL_malloc_array(num, sizeof(*present))) == NULL)
         return 0;
     for (i = 0; i < sc->clienthello->pre_proc_exts_len; i++) {
         ext = sc->clienthello->pre_proc_exts + i;
@@ -7145,7 +7145,7 @@ int ssl_cache_cipherlist(SSL_CONNECTION *s, PACKET *cipher_suites, int sslv2form
          * slightly over allocate because we won't store those. But that isn't a
          * problem.
          */
-        raw = OPENSSL_malloc(numciphers * TLS_CIPHER_LEN);
+        raw = OPENSSL_malloc_array(numciphers, TLS_CIPHER_LEN);
         s->s3.tmp.ciphers_raw = raw;
         if (raw == NULL) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_CRYPTO_LIB);

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -627,7 +627,7 @@ int tls_collect_extensions(SSL_CONNECTION *s, PACKET *packet,
         custom_ext_init(&s->cert->custext);
 
     num_exts = OSSL_NELEM(ext_defs) + (exts != NULL ? exts->meths_count : 0);
-    raw_extensions = OPENSSL_zalloc(num_exts * sizeof(*raw_extensions));
+    raw_extensions = OPENSSL_calloc(num_exts, sizeof(*raw_extensions));
     if (raw_extensions == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_CRYPTO_LIB);
         return 0;

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -664,12 +664,14 @@ static KS_EXTRACTION_RESULT extract_keyshares(SSL_CONNECTION *s, PACKET *key_sha
     unsigned int group_id = 0;
 
     /* Prepare memory to hold the extracted key share groups and related pubkeys */
-    *keyshares_arr = OPENSSL_malloc(*keyshares_max * sizeof(**keyshares_arr));
+    *keyshares_arr = OPENSSL_malloc_array(*keyshares_max,
+                                          sizeof(**keyshares_arr));
     if (*keyshares_arr == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto failure;
     }
-    *encoded_pubkey_arr = OPENSSL_malloc(*keyshares_max * sizeof(**encoded_pubkey_arr));
+    *encoded_pubkey_arr = OPENSSL_malloc_array(*keyshares_max,
+                                               sizeof(**encoded_pubkey_arr));
     if (*encoded_pubkey_arr == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto failure;
@@ -750,16 +752,17 @@ static KS_EXTRACTION_RESULT extract_keyshares(SSL_CONNECTION *s, PACKET *key_sha
         if (*keyshares_cnt == *keyshares_max) {
             PACKET *tmp_pkt;
             uint16_t *tmp =
-                OPENSSL_realloc(*keyshares_arr,
-                                (*keyshares_max + GROUPLIST_INCREMENT) * sizeof(**keyshares_arr));
+                OPENSSL_realloc_array(*keyshares_arr,
+                                      *keyshares_max + GROUPLIST_INCREMENT,
+                                      sizeof(**keyshares_arr));
 
             if (tmp == NULL)
                 goto failure;
             *keyshares_arr = tmp;
             tmp_pkt =
-                OPENSSL_realloc(*encoded_pubkey_arr,
-                                (*keyshares_max + GROUPLIST_INCREMENT) *
-                                sizeof(**encoded_pubkey_arr));
+                OPENSSL_realloc_array(*encoded_pubkey_arr,
+                                      *keyshares_max + GROUPLIST_INCREMENT,
+                                      sizeof(**encoded_pubkey_arr));
             if (tmp_pkt == NULL)
                 goto failure;
             *encoded_pubkey_arr = tmp_pkt;

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2601,7 +2601,7 @@ MSG_PROCESS_RETURN tls_process_certificate_request(SSL_CONNECTION *s,
     if (s->s3.tmp.valid_flags != NULL)
         memset(s->s3.tmp.valid_flags, 0, s->ssl_pkey_num * sizeof(uint32_t));
     else
-        s->s3.tmp.valid_flags = OPENSSL_zalloc(s->ssl_pkey_num * sizeof(uint32_t));
+        s->s3.tmp.valid_flags = OPENSSL_calloc(s->ssl_pkey_num, sizeof(uint32_t));
 
     /* Give up for good if allocation didn't work */
     if (s->s3.tmp.valid_flags == NULL)

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -239,13 +239,13 @@ static int add_provider_groups(const OSSL_PARAM params[], void *data)
         TLS_GROUP_INFO *tmp = NULL;
 
         if (ctx->group_list_max_len == 0)
-            tmp = OPENSSL_malloc(sizeof(TLS_GROUP_INFO)
-                                 * TLS_GROUP_LIST_MALLOC_BLOCK_SIZE);
+            tmp = OPENSSL_malloc_array(TLS_GROUP_LIST_MALLOC_BLOCK_SIZE,
+                                       sizeof(TLS_GROUP_INFO));
         else
-            tmp = OPENSSL_realloc(ctx->group_list,
-                                  (ctx->group_list_max_len
-                                   + TLS_GROUP_LIST_MALLOC_BLOCK_SIZE)
-                                  * sizeof(TLS_GROUP_INFO));
+            tmp = OPENSSL_realloc_array(ctx->group_list,
+                                        ctx->group_list_max_len
+                                        + TLS_GROUP_LIST_MALLOC_BLOCK_SIZE,
+                                        sizeof(TLS_GROUP_INFO));
         if (tmp == NULL)
             return 0;
         ctx->group_list = tmp;
@@ -389,13 +389,13 @@ static int add_provider_sigalgs(const OSSL_PARAM params[], void *data)
         TLS_SIGALG_INFO *tmp = NULL;
 
         if (ctx->sigalg_list_max_len == 0)
-            tmp = OPENSSL_malloc(sizeof(TLS_SIGALG_INFO)
-                                 * TLS_SIGALG_LIST_MALLOC_BLOCK_SIZE);
+            tmp = OPENSSL_malloc_array(TLS_SIGALG_LIST_MALLOC_BLOCK_SIZE,
+                                       sizeof(TLS_SIGALG_INFO));
         else
-            tmp = OPENSSL_realloc(ctx->sigalg_list,
-                                  (ctx->sigalg_list_max_len
-                                   + TLS_SIGALG_LIST_MALLOC_BLOCK_SIZE)
-                                  * sizeof(TLS_SIGALG_INFO));
+            tmp = OPENSSL_realloc_array(ctx->sigalg_list,
+                                        ctx->sigalg_list_max_len
+                                        + TLS_SIGALG_LIST_MALLOC_BLOCK_SIZE,
+                                        sizeof(TLS_SIGALG_INFO));
         if (tmp == NULL)
             return 0;
         ctx->sigalg_list = tmp;
@@ -688,7 +688,7 @@ int ssl_load_sigalgs(SSL_CTX *ctx)
     /* now populate ctx->ssl_cert_info */
     if (ctx->sigalg_list_len > 0) {
         OPENSSL_free(ctx->ssl_cert_info);
-        ctx->ssl_cert_info = OPENSSL_zalloc(sizeof(lu) * ctx->sigalg_list_len);
+        ctx->ssl_cert_info = OPENSSL_calloc(ctx->sigalg_list_len, sizeof(lu));
         if (ctx->ssl_cert_info == NULL)
             return 0;
         for(i = 0; i < ctx->sigalg_list_len; i++) {
@@ -1099,11 +1099,11 @@ int tls1_set_groups(uint16_t **grpext, size_t *grpextlen,
         ERR_raise(ERR_LIB_SSL, SSL_R_BAD_LENGTH);
         return 0;
     }
-    if ((glist = OPENSSL_malloc(ngroups * sizeof(*glist))) == NULL)
+    if ((glist = OPENSSL_malloc_array(ngroups, sizeof(*glist))) == NULL)
         goto err;
-    if ((kslist = OPENSSL_malloc(1 * sizeof(*kslist))) == NULL)
+    if ((kslist = OPENSSL_malloc_array(1, sizeof(*kslist))) == NULL)
         goto err;
-    if ((tpllist = OPENSSL_malloc(1 * sizeof(*tpllist))) == NULL)
+    if ((tpllist = OPENSSL_malloc_array(1, sizeof(*tpllist))) == NULL)
         goto err;
     for (i = 0; i < ngroups; i++) {
         unsigned long idmask;
@@ -1386,8 +1386,9 @@ static int gid_cb(const char *elem, int len, void *arg)
     /* Memory management in case more groups are present compared to initial allocation */
     if (garg->gidcnt == garg->gidmax) {
         uint16_t *tmp =
-            OPENSSL_realloc(garg->gid_arr,
-                            (garg->gidmax + GROUPLIST_INCREMENT) * sizeof(*garg->gid_arr));
+            OPENSSL_realloc_array(garg->gid_arr,
+                                  garg->gidmax + GROUPLIST_INCREMENT,
+                                  sizeof(*garg->gid_arr));
 
         if (tmp == NULL)
             return 0;
@@ -1398,8 +1399,9 @@ static int gid_cb(const char *elem, int len, void *arg)
     /* Memory management for key share groups */
     if (garg->ksidcnt == garg->ksidmax) {
         uint16_t *tmp =
-            OPENSSL_realloc(garg->ksid_arr,
-                            (garg->ksidmax + GROUPLIST_INCREMENT) * sizeof(*garg->ksid_arr));
+            OPENSSL_realloc_array(garg->ksid_arr,
+                                  garg->ksidmax + GROUPLIST_INCREMENT,
+                                  sizeof(*garg->ksid_arr));
 
         if (tmp == NULL)
             return 0;
@@ -1543,8 +1545,9 @@ static int tuple_cb(const char *tuple, int len, void *arg)
     /* Memory management for tuples */
     if (garg->tplcnt == garg->tplmax) {
         size_t *tmp =
-            OPENSSL_realloc(garg->tuplcnt_arr,
-                            (garg->tplmax + GROUPLIST_INCREMENT) * sizeof(*garg->tuplcnt_arr));
+            OPENSSL_realloc_array(garg->tuplcnt_arr,
+                                  garg->tplmax + GROUPLIST_INCREMENT,
+                                  sizeof(*garg->tuplcnt_arr));
 
         if (tmp == NULL)
             return 0;
@@ -1612,14 +1615,14 @@ int tls1_set_groups_list(SSL_CTX *ctx,
     gcb.ctx = ctx;
 
     /* Prepare initial chunks of memory for groups, tuples and keyshares groupIDs */
-    gcb.gid_arr = OPENSSL_malloc(gcb.gidmax * sizeof(*gcb.gid_arr));
+    gcb.gid_arr = OPENSSL_malloc_array(gcb.gidmax, sizeof(*gcb.gid_arr));
     if (gcb.gid_arr == NULL)
         goto end;
-    gcb.tuplcnt_arr = OPENSSL_malloc(gcb.tplmax * sizeof(*gcb.tuplcnt_arr));
+    gcb.tuplcnt_arr = OPENSSL_malloc_array(gcb.tplmax, sizeof(*gcb.tuplcnt_arr));
     if (gcb.tuplcnt_arr == NULL)
         goto end;
     gcb.tuplcnt_arr[0] = 0;
-    gcb.ksid_arr = OPENSSL_malloc(gcb.ksidmax * sizeof(*gcb.ksid_arr));
+    gcb.ksid_arr = OPENSSL_malloc_array(gcb.ksidmax, sizeof(*gcb.ksid_arr));
     if (gcb.ksid_arr == NULL)
         goto end;
 
@@ -2194,11 +2197,11 @@ int ssl_setup_sigalgs(SSL_CTX *ctx)
 
     sigalgs_len = OSSL_NELEM(sigalg_lookup_tbl) + ctx->sigalg_list_len;
 
-    cache = OPENSSL_zalloc(sizeof(const SIGALG_LOOKUP) * sigalgs_len);
+    cache = OPENSSL_calloc(sigalgs_len, sizeof(const SIGALG_LOOKUP));
     if (cache == NULL || tmpkey == NULL)
         goto err;
 
-    tls12_sigalgs_list = OPENSSL_zalloc(sizeof(uint16_t) * sigalgs_len);
+    tls12_sigalgs_list = OPENSSL_calloc(sigalgs_len, sizeof(uint16_t));
     if (tls12_sigalgs_list == NULL)
         goto err;
 
@@ -2956,7 +2959,7 @@ int tls1_set_server_sigalgs(SSL_CONNECTION *s)
     if (s->s3.tmp.valid_flags)
         memset(s->s3.tmp.valid_flags, 0, s->ssl_pkey_num * sizeof(uint32_t));
     else
-        s->s3.tmp.valid_flags = OPENSSL_zalloc(s->ssl_pkey_num * sizeof(uint32_t));
+        s->s3.tmp.valid_flags = OPENSSL_calloc(s->ssl_pkey_num, sizeof(uint32_t));
     if (s->s3.tmp.valid_flags == NULL)
         return 0;
     /*
@@ -3529,7 +3532,7 @@ static int tls1_set_shared_sigalgs(SSL_CONNECTION *s)
     }
     nmatch = tls12_shared_sigalgs(s, NULL, pref, preflen, allow, allowlen);
     if (nmatch) {
-        if ((salgs = OPENSSL_malloc(nmatch * sizeof(*salgs))) == NULL)
+        if ((salgs = OPENSSL_malloc_array(nmatch, sizeof(*salgs))) == NULL)
             return 0;
         nmatch = tls12_shared_sigalgs(s, salgs, pref, preflen, allow, allowlen);
     } else {
@@ -3554,7 +3557,7 @@ int tls1_save_u16(PACKET *pkt, uint16_t **pdest, size_t *pdestlen)
 
     size >>= 1;
 
-    if ((buf = OPENSSL_malloc(size * sizeof(*buf))) == NULL)
+    if ((buf = OPENSSL_malloc_array(size, sizeof(*buf))) == NULL)
         return 0;
     for (i = 0; i < size && PACKET_get_net_2(pkt, &stmp); i++)
         buf[i] = stmp;
@@ -3846,7 +3849,7 @@ int tls1_set_raw_sigalgs(CERT *c, const uint16_t *psigs, size_t salglen,
 {
     uint16_t *sigalgs;
 
-    if ((sigalgs = OPENSSL_malloc(salglen * sizeof(*sigalgs))) == NULL)
+    if ((sigalgs = OPENSSL_malloc_array(salglen, sizeof(*sigalgs))) == NULL)
         return 0;
     memcpy(sigalgs, psigs, salglen * sizeof(*sigalgs));
 
@@ -3870,7 +3873,7 @@ int tls1_set_sigalgs(CERT *c, const int *psig_nids, size_t salglen, int client)
 
     if (salglen & 1)
         return 0;
-    if ((sigalgs = OPENSSL_malloc((salglen / 2) * sizeof(*sigalgs))) == NULL)
+    if ((sigalgs = OPENSSL_malloc_array(salglen / 2, sizeof(*sigalgs))) == NULL)
         return 0;
     for (i = 0, sptr = sigalgs; i < salglen; i += 2) {
         size_t j;

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1334,9 +1334,10 @@ static int gid_cb(const char *elem, int len, void *arg)
                      * First, we restore any keyshare prefix in a new zero-terminated string
                      * (if not already present)
                      */
-                    restored_default_group_string = OPENSSL_malloc((1 /* max prefix length */ +
-                                                                    strlen(default_group_strings[i].group_string) +
-                                                                    1 /* \0 */) * sizeof(char));
+                    restored_default_group_string =
+                        OPENSSL_malloc(1 /* max prefix length */ +
+                                       strlen(default_group_strings[i].group_string) +
+                                       1 /* \0 */);
                     if (restored_default_group_string == NULL)
                         return 0;
                     if (add_keyshare
@@ -1552,7 +1553,7 @@ static int tuple_cb(const char *tuple, int len, void *arg)
     }
 
     /* Convert to \0-terminated string */
-    restored_tuple_string = OPENSSL_malloc((len + 1 /* \0 */) * sizeof(char));
+    restored_tuple_string = OPENSSL_malloc(len + 1 /* \0 */);
     if (restored_tuple_string == NULL)
         return 0;
     memcpy(restored_tuple_string, tuple, len);

--- a/test/bio_prefix_text.c
+++ b/test/bio_prefix_text.c
@@ -96,7 +96,7 @@ static int setup_bio_chain(const char *progname)
     BIO *next = NULL;
     size_t n = amount;
 
-    chain = OPENSSL_zalloc(sizeof(*chain) * n);
+    chain = OPENSSL_calloc(n, sizeof(*chain));
 
     if (chain != NULL) {
         size_t i;

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -2355,7 +2355,7 @@ static int test_rand_range_single(size_t n)
     unsigned int i, v;
     int res = 0;
 
-    if (!TEST_ptr(counts = OPENSSL_zalloc(sizeof(*counts) * range))
+    if (!TEST_ptr(counts = OPENSSL_calloc(range, sizeof(*counts)))
         || !TEST_ptr(rng = BN_new())
         || !TEST_ptr(val = BN_new())
         || !TEST_true(BN_set_word(rng, range)))

--- a/test/build.info
+++ b/test/build.info
@@ -1230,6 +1230,16 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[bio_prefix_text]=.. ../include ../apps/include
   DEPEND[bio_prefix_text]=../libcrypto libtestutil.a
 
+  PROGRAMS{noinst}=mem_alloc_test
+  SOURCE[mem_alloc_test]=mem_alloc_test.c
+  INCLUDE[mem_alloc_test]=../include ../apps/include
+  DEPEND[mem_alloc_test]=../libcrypto libtestutil.a
+
+  PROGRAMS{noinst}=mem_alloc_custom_fns_test
+  SOURCE[mem_alloc_custom_fns_test]=mem_alloc_custom_fns_test.c
+  INCLUDE[mem_alloc_custom_fns_test]=../include ../apps/include
+  DEPEND[mem_alloc_custom_fns_test]=../libcrypto libtestutil.a
+
   IF[{- !$disabled{'deprecated-3.0'} -}]
     PROGRAMS{noinst}=pem_read_depr_test
     SOURCE[pem_read_depr_test]=pem_read_depr_test.c

--- a/test/ec_internal_test.c
+++ b/test/ec_internal_test.c
@@ -549,7 +549,7 @@ static int named_group_creation_test(void)
 int setup_tests(void)
 {
     crv_len = EC_get_builtin_curves(NULL, 0);
-    if (!TEST_ptr(curves = OPENSSL_malloc(sizeof(*curves) * crv_len))
+    if (!TEST_ptr(curves = OPENSSL_malloc_array(crv_len, sizeof(*curves)))
         || !TEST_true(EC_get_builtin_curves(curves, crv_len)))
         return 0;
 

--- a/test/ecdsatest.c
+++ b/test/ecdsatest.c
@@ -399,7 +399,7 @@ int setup_tests(void)
 
     /* get a list of all internal curves */
     crv_len = EC_get_builtin_curves(NULL, 0);
-    if (!TEST_ptr(curves = OPENSSL_malloc(sizeof(*curves) * crv_len))
+    if (!TEST_ptr(curves = OPENSSL_malloc_array(crv_len, sizeof(*curves)))
         || !TEST_true(EC_get_builtin_curves(curves, crv_len))) {
         fake_rand_finish(fake_rand);
         return 0;

--- a/test/ectest.c
+++ b/test/ectest.c
@@ -3125,7 +3125,7 @@ static int ec_d2i_publickey_test(void)
 int setup_tests(void)
 {
     crv_len = EC_get_builtin_curves(NULL, 0);
-    if (!TEST_ptr(curves = OPENSSL_malloc(sizeof(*curves) * crv_len))
+    if (!TEST_ptr(curves = OPENSSL_malloc_array(crv_len, sizeof(*curves)))
         || !TEST_true(EC_get_builtin_curves(curves, crv_len)))
         return 0;
 

--- a/test/evp_kdf_test.c
+++ b/test/evp_kdf_test.c
@@ -38,7 +38,7 @@ static EVP_KDF_CTX *get_kdfbyname(const char *name)
 static OSSL_PARAM *construct_tls1_prf_params(const char *digest, const char *secret,
     const char *seed)
 {
-    OSSL_PARAM *params = OPENSSL_malloc(sizeof(OSSL_PARAM) * 4);
+    OSSL_PARAM *params = OPENSSL_malloc_array(4, sizeof(OSSL_PARAM));
     OSSL_PARAM *p = params;
 
     if (params == NULL)
@@ -194,7 +194,7 @@ static int test_kdf_tls1_prf_1byte_seed(void)
 static OSSL_PARAM *construct_hkdf_params(char *digest, char *key,
     size_t keylen, char *salt, char *info)
 {
-    OSSL_PARAM *params = OPENSSL_malloc(sizeof(OSSL_PARAM) * 5);
+    OSSL_PARAM *params = OPENSSL_malloc_array(5, sizeof(OSSL_PARAM));
     OSSL_PARAM *p = params;
 
     if (params == NULL)
@@ -661,7 +661,7 @@ static int test_kdf_hkdf_empty_salt(void)
 static OSSL_PARAM *construct_pbkdf1_params(char *pass, char *digest, char *salt,
     unsigned int *iter)
 {
-    OSSL_PARAM *params = OPENSSL_malloc(sizeof(OSSL_PARAM) * 5);
+    OSSL_PARAM *params = OPENSSL_malloc_array(5, sizeof(OSSL_PARAM));
     OSSL_PARAM *p = params;
 
     if (params == NULL)
@@ -781,7 +781,7 @@ err:
 static OSSL_PARAM *construct_pbkdf2_params(char *pass, char *digest, char *salt,
     unsigned int *iter, int *mode)
 {
-    OSSL_PARAM *params = OPENSSL_malloc(sizeof(OSSL_PARAM) * 6);
+    OSSL_PARAM *params = OPENSSL_malloc_array(6, sizeof(OSSL_PARAM));
     OSSL_PARAM *p = params;
 
     if (params == NULL)
@@ -1310,7 +1310,7 @@ static int test_kdf_kbkdf_6803_256(void)
 static OSSL_PARAM *construct_kbkdf_params(char *digest, char *mac, unsigned char *key,
     size_t keylen, char *salt, char *info, int *r)
 {
-    OSSL_PARAM *params = OPENSSL_malloc(sizeof(OSSL_PARAM) * 8);
+    OSSL_PARAM *params = OPENSSL_malloc_array(8, sizeof(OSSL_PARAM));
     OSSL_PARAM *p = params;
 
     if (params == NULL)

--- a/test/evp_pkey_provided_test.c
+++ b/test/evp_pkey_provided_test.c
@@ -2143,7 +2143,7 @@ static int test_check_dsa(void)
 static OSSL_PARAM *do_construct_hkdf_params(char *digest, char *key,
                                             size_t keylen, char *salt)
 {
-    OSSL_PARAM *params = OPENSSL_malloc(sizeof(OSSL_PARAM) * 5);
+    OSSL_PARAM *params = OPENSSL_malloc_array(5, sizeof(OSSL_PARAM));
     OSSL_PARAM *p = params;
 
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, digest, 0);

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -4533,7 +4533,7 @@ static int keygen_test_run(EVP_TEST *t)
     }
 
     if (sk_OPENSSL_STRING_num(keygen->in_controls) > 0) {
-        if ((params = OPENSSL_malloc(sizeof(OSSL_PARAM) * 4)) == NULL)
+        if ((params = OPENSSL_malloc_array(4, sizeof(OSSL_PARAM))) == NULL)
             goto err;
         if (!ctrl2params(t, keygen->in_controls,
                          EVP_PKEY_CTX_settable_params(genctx),

--- a/test/mem_alloc_custom_fns_test.c
+++ b/test/mem_alloc_custom_fns_test.c
@@ -1,0 +1,2 @@
+#define USE_CUSTOM_ALLOC_FNS 1
+#include "mem_alloc_test.c"

--- a/test/mem_alloc_test.c
+++ b/test/mem_alloc_test.c
@@ -1,0 +1,869 @@
+/*
+ * Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <openssl/err.h>
+#include <openssl/types.h>
+#include "testutil.h"
+
+#ifndef USE_CUSTOM_ALLOC_FNS
+# define USE_CUSTOM_ALLOC_FNS 0
+#endif
+
+/* Change to 1 to see every call of the custom allocator functions */
+#define CUSTOM_FN_PRINT_CALLS 0
+
+enum exp_ret_flags { EXP_FAIL = 0x10 };
+
+enum exp_ret {
+    /** Expecting success */
+    EXP_NONNULL,
+    /** Zero-size special case: can either return NULL or a special pointer */
+    EXP_ZERO_SIZE,
+    /** Expecting an error due to insufficient memory */
+    EXP_OOM = EXP_FAIL,
+    /** Expecting error due to invalid arguments */
+    EXP_INVAL,
+    /** Expecting error due to integer overflow */
+    EXP_INT_OF,
+};
+
+#define IS_FAIL(exp_) (!!((int) (exp) & (int) EXP_FAIL))
+
+static const char test_fn[] = "test_file_name";
+enum { test_line = 31415926 };
+
+#define SQRT_SIZE_T ((size_t) 1 << (sizeof(size_t) * (CHAR_BIT / 2)))
+#define SQSQRT_SIZE_T ((size_t) 1 << (sizeof(size_t) * (CHAR_BIT / 4)))
+
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+
+#if !defined(OPENSSL_NO_CRYPTO_MDEBUG) || USE_CUSTOM_ALLOC_FNS
+struct call_counts {
+    int malloc;
+    int realloc;
+    int free;
+};
+#endif
+#if !defined(OPENSSL_NO_CRYPTO_MDEBUG)
+static struct call_counts mdebug_counts;
+#endif
+#if USE_CUSTOM_ALLOC_FNS
+static struct call_counts saved_custom_counts, cur_custom_counts;
+#endif
+
+static const struct array_alloc_vector {
+    size_t nmemb;
+    size_t size;
+    enum exp_ret exp_malloc;
+    enum exp_ret exp_calloc;
+} array_alloc_vectors[] = {
+    { 0,                0,                 EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    { 0,                1,                 EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    { 0,                SQRT_SIZE_T - 1,   EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    { 0,                SQRT_SIZE_T,       EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    { 0,                SIZE_MAX,          EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    { 1,                0,                 EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    { SQRT_SIZE_T - 1,  0,                 EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    { SIZE_MAX,         0,                 EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+
+    { 1,                1,                 EXP_NONNULL,   EXP_NONNULL   },
+
+    { SQRT_SIZE_T / 2,  SQRT_SIZE_T,       EXP_OOM,       EXP_OOM       },
+
+    { SQRT_SIZE_T,      SQRT_SIZE_T,       EXP_ZERO_SIZE, EXP_INT_OF    },
+
+    /* Some magic numbers */
+#if SIZE_MAX == 4294967295U
+    { 641, 6700417, EXP_NONNULL, EXP_INT_OF },
+#else /* Of course there are no archutectures other than 32- and 64-bit ones */
+    { 274177, 67280421310721LLU, EXP_NONNULL, EXP_INT_OF },
+#endif
+
+    { SIZE_MAX / 4 * 3, SIZE_MAX / 2, EXP_OOM, EXP_INT_OF },
+};
+
+static const struct array_realloc_vector {
+    size_t size;
+    size_t orig_nmemb;
+    size_t new_nmemb;
+    enum exp_ret exp_orig;
+    enum exp_ret exp_new;
+    enum exp_ret exp_orig_array;
+    enum exp_ret exp_new_array;
+} array_realloc_vectors[] = {
+    { 0, 0, 0,
+      EXP_ZERO_SIZE, EXP_ZERO_SIZE, EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    { 0, 0, 1,
+      EXP_ZERO_SIZE, EXP_ZERO_SIZE, EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    { 0, 0, SIZE_MAX,
+      EXP_ZERO_SIZE, EXP_ZERO_SIZE, EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    { 0, 1, 0,
+      EXP_ZERO_SIZE, EXP_ZERO_SIZE, EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    { 0, SIZE_MAX, 0,
+      EXP_ZERO_SIZE, EXP_ZERO_SIZE, EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    { 0, 1, SIZE_MAX,
+      EXP_ZERO_SIZE, EXP_ZERO_SIZE, EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    { 0, SIZE_MAX, 1,
+      EXP_ZERO_SIZE, EXP_ZERO_SIZE, EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    { 0, SIZE_MAX, SIZE_MAX,
+      EXP_ZERO_SIZE, EXP_ZERO_SIZE, EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+
+    { 1, 0, 0,
+      EXP_ZERO_SIZE, EXP_ZERO_SIZE, EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    { 1, 0, 1,
+      EXP_ZERO_SIZE, EXP_NONNULL,   EXP_ZERO_SIZE, EXP_NONNULL },
+    { 1, 0, SIZE_MAX,
+      EXP_ZERO_SIZE, EXP_OOM,       EXP_ZERO_SIZE, EXP_OOM },
+    { 1, 1, 0,
+      EXP_NONNULL,   EXP_ZERO_SIZE, EXP_NONNULL,   EXP_ZERO_SIZE },
+    { 1, SIZE_MAX, 0,
+      EXP_OOM,       EXP_ZERO_SIZE, EXP_OOM,       EXP_ZERO_SIZE },
+
+    { 1, 123, 345,
+      EXP_NONNULL,   EXP_NONNULL,   EXP_NONNULL,   EXP_NONNULL },
+    { 1, 345, 123,
+      EXP_NONNULL,   EXP_NONNULL,   EXP_NONNULL,   EXP_NONNULL },
+    { 12, 34, 56,
+      EXP_NONNULL,   EXP_NONNULL,   EXP_NONNULL,   EXP_NONNULL },
+    { 12, 56, 34,
+      EXP_NONNULL,   EXP_NONNULL,   EXP_NONNULL,   EXP_NONNULL },
+
+    { SQSQRT_SIZE_T, SIZE_MAX / SQSQRT_SIZE_T + 1, SIZE_MAX / SQSQRT_SIZE_T + 2,
+      EXP_ZERO_SIZE, EXP_NONNULL,   EXP_INT_OF,    EXP_INT_OF },
+    { SQSQRT_SIZE_T, SIZE_MAX / SQSQRT_SIZE_T + 2, SIZE_MAX / SQSQRT_SIZE_T + 1,
+      EXP_NONNULL,   EXP_ZERO_SIZE, EXP_INT_OF,    EXP_INT_OF },
+
+    { 123, 12, SIZE_MAX / 123 + 12,
+      EXP_NONNULL,   EXP_NONNULL,   EXP_NONNULL,   EXP_INT_OF },
+    { 123, SIZE_MAX / 123 + 12, 12,
+      EXP_NONNULL,   EXP_NONNULL,   EXP_INT_OF,    EXP_NONNULL },
+};
+
+static const struct array_aligned_alloc_vector {
+    size_t nmemb;
+    size_t size;
+    size_t align;
+    enum exp_ret exp;
+    enum exp_ret exp_array;
+} array_aligned_alloc_vectors[] = {
+    { 0, 0, 0, EXP_INVAL, EXP_INVAL },
+    { 0, 0, 1, EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    { 0, 0, 2, EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    { 0, 0, 3, EXP_INVAL, EXP_INVAL },
+    { 0, 0, 4, EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    { 0, 0, 64, EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    { 0, 0, SQSQRT_SIZE_T, EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+    /*
+     * This one gets mem_alloc_custom_fns_test killed with SIGKILL
+     * on the linux-arm64 github runner.
+     */
+    /* { 0, 0, SQRT_SIZE_T, EXP_ZERO_SIZE, EXP_ZERO_SIZE }, */
+
+    { 0, 0, 64, EXP_ZERO_SIZE, EXP_ZERO_SIZE },
+
+    { 8, 8, 63, EXP_INVAL, EXP_INVAL },
+    { 8, 8, 64, EXP_NONNULL, EXP_NONNULL },
+    { SIZE_MAX / 8 + 9, 8, 64, EXP_NONNULL, EXP_INT_OF },
+
+    /*
+     * posix_memalign expected to fail with ENOMEM, while the open-coded
+     * implementation tries to alloc size + alignment, which should fail
+     * on integer overflow.
+     */
+    { 1, SIZE_MAX / 2 + 2, SIZE_MAX / 2 + 1,
+#if (defined(_BSD_SOURCE) \
+      || (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L)) \
+    && !USE_CUSTOM_ALLOC_FNS || defined(OPENSSL_SMALL_FOOTPRINT)
+      EXP_OOM, EXP_OOM
+#else
+      EXP_INT_OF, EXP_INT_OF
+#endif
+    },
+};
+
+static int secure_memory_is_secure;
+
+#if USE_CUSTOM_ALLOC_FNS
+static void *my_malloc(const size_t num,
+                       const char * const file, const int line)
+{
+    void * const p = malloc(num);
+
+# if CUSTOM_FN_PRINT_CALLS
+    if (file == test_fn || file == NULL
+        || (strcmp(file, OPENSSL_FILE) == 0 && file[0] != '\0'))
+        TEST_note("[%s:%d]: malloc(%#zx) -> %p", file, line, num, p);
+# endif
+
+    if (cur_custom_counts.malloc < INT_MAX)
+        cur_custom_counts.malloc++;
+
+    return p;
+}
+static void *my_realloc(void * const addr, const size_t num,
+                        const char * const file, const int line)
+{
+# if CUSTOM_FN_PRINT_CALLS
+    const uintptr_t old_addr = (uintptr_t) addr;
+# endif
+    void * const p = realloc(addr, num);
+
+# if CUSTOM_FN_PRINT_CALLS
+    if (file == test_fn || file == NULL
+        || (strcmp(file, OPENSSL_FILE) == 0 && file[0] != '\0'))
+        TEST_note("[%s:%d]: realloc(%#" PRIxPTR ", %#zx) -> %p",
+                  file, line, old_addr, num, p);
+# endif
+
+    if (cur_custom_counts.realloc < INT_MAX)
+        cur_custom_counts.realloc++;
+
+    return p;
+}
+
+static void my_free(void * const addr, const char * const file, const int line)
+{
+# if CUSTOM_FN_PRINT_CALLS
+    if (file == test_fn || file == NULL
+        || (strcmp(file, OPENSSL_FILE) == 0 && file[0] != '\0'))
+        TEST_note("[%s:%d]: free(%p)", file, line, addr);
+# endif
+
+    if (cur_custom_counts.free < INT_MAX)
+        cur_custom_counts.free++;
+
+    free(addr);
+}
+#endif /* USE_CUSTOM_ALLOC_FNS */
+
+static bool check_zero_mem(char *p, size_t sz)
+{
+    for (size_t i = 0; i < sz; i++) {
+        if (p[i] != 0) {
+            TEST_error("Non-zero byte %zu of %zu (%#04hhx)", i, sz, p[i]);
+
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static void save_counts(void)
+{
+#if !defined(OPENSSL_NO_CRYPTO_MDEBUG)
+    CRYPTO_get_alloc_counts(&mdebug_counts.malloc,
+                            &mdebug_counts.realloc,
+                            &mdebug_counts.free);
+#endif
+
+#if USE_CUSTOM_ALLOC_FNS
+    saved_custom_counts = cur_custom_counts;
+#endif
+}
+
+static void check_exp_prep(void)
+{
+    ERR_set_mark();
+
+    save_counts();
+}
+
+/*
+ * Retrieve fresh call counts and check against the expected ones,
+ * when the latter are no less than zero.
+ */
+static bool check_counts(int exp_mallocs, int exp_reallocs, int exp_frees)
+{
+    int test_result = 1;
+
+#if !defined(OPENSSL_NO_CRYPTO_MDEBUG)
+    {
+        struct call_counts cur;
+
+        CRYPTO_get_alloc_counts(&cur.malloc, &cur.realloc, &cur.free);
+        if (exp_mallocs >= 0
+            && !TEST_int_eq(cur.malloc - mdebug_counts.malloc, exp_mallocs))
+            test_result = 0;
+        if (exp_reallocs >= 0
+            && !TEST_int_eq(cur.realloc - mdebug_counts.realloc, exp_reallocs))
+            test_result = 0;
+        if (exp_frees >= 0
+            && !TEST_int_eq(cur.free - mdebug_counts.free, exp_frees))
+            test_result = 0;
+    }
+#endif
+
+#if USE_CUSTOM_ALLOC_FNS
+    if (exp_mallocs >= 0
+        && !TEST_int_eq(cur_custom_counts.malloc - saved_custom_counts.malloc,
+                        exp_mallocs))
+        test_result = 0;
+    if (exp_reallocs >= 0
+        && !TEST_int_eq(cur_custom_counts.realloc - saved_custom_counts.realloc,
+                        exp_reallocs))
+        test_result = 0;
+    if (exp_frees >= 0
+        && !TEST_int_eq(cur_custom_counts.free - saved_custom_counts.free,
+                        exp_frees))
+        test_result = 0;
+#endif
+
+    return test_result;
+}
+
+static int check_exp(const char * const fn, const int ln, const size_t sz,
+                     const bool secure, const bool zero, char * const ret,
+                     const enum exp_ret exp, int exp_mallocs, int exp_reallocs)
+{
+    int num_errs;
+    unsigned long err_code = 0;
+    const char *err_file = NULL;
+    int err_line = 0;
+    const char *err_func = NULL;
+    const char *err_data = NULL;
+    int err_flags = 0;
+    int test_result = 1;
+    unsigned long oom_err;
+
+    num_errs = ERR_count_to_mark();
+    if (num_errs > 0) {
+        err_code = ERR_peek_last_error_all(&err_file, &err_line, &err_func,
+                                           &err_data, &err_flags);
+    }
+
+    switch (exp) {
+    case EXP_OOM:
+        oom_err = secure ? CRYPTO_R_SECURE_MALLOC_FAILURE
+                         : ERR_R_MALLOC_FAILURE;
+        if (!TEST_ptr_null(ret)
+            || !TEST_int_eq(num_errs, 1)
+            || !TEST_ulong_eq(err_code, ERR_PACK(ERR_LIB_CRYPTO, 0, oom_err))
+            || !TEST_str_eq(err_file, fn)
+            || !TEST_int_eq(err_line, ln)
+            || !TEST_str_eq(err_func, "")
+            || !TEST_str_eq(err_data, "")
+            || !TEST_int_eq(err_flags, 0))
+            test_result = 0;
+
+        break;
+
+    case EXP_INVAL:
+        if (!TEST_ptr_null(ret)
+            || !TEST_int_eq(num_errs, 1)
+            || !TEST_ulong_eq(err_code, ERR_PACK(ERR_LIB_CRYPTO, 0,
+                                                 ERR_R_PASSED_INVALID_ARGUMENT))
+            || !TEST_str_eq(err_file, fn)
+            || !TEST_int_eq(err_line, ln)
+            || !TEST_str_eq(err_func, "")
+            || !TEST_str_eq(err_data, "")
+            || !TEST_int_eq(err_flags, 0))
+            test_result = 0;
+
+        break;
+
+    case EXP_INT_OF:
+        if (!TEST_ptr_null(ret)
+            || !TEST_int_eq(num_errs, 1)
+            || !TEST_ulong_eq(err_code, ERR_PACK(ERR_LIB_CRYPTO, 0,
+                                                 CRYPTO_R_INTEGER_OVERFLOW))
+            || !TEST_str_eq(err_file, fn)
+            || !TEST_int_eq(err_line, ln)
+            || !TEST_str_eq(err_func, "")
+            || !TEST_str_eq(err_data, "")
+            || !TEST_int_eq(err_flags, 0))
+            test_result = 0;
+
+        break;
+
+    case EXP_NONNULL:
+        if (!TEST_ptr(ret)
+            || !TEST_int_eq(num_errs, 0)) {
+            test_result = 0;
+        } else if (zero) {
+            if (!check_zero_mem(ret, sz))
+                test_result = 0;
+        }
+
+        break;
+
+    case EXP_ZERO_SIZE:
+        /*
+         * Since the pointer ca either be NULL or non-NULL, depending
+         * on implementation, we can only check for the absence of errors.
+         */
+        if (!TEST_int_eq(num_errs, 0))
+            test_result = 0;
+
+        break;
+
+    default:
+        TEST_error("Unexpected expected result");
+        test_result = 0;
+    }
+
+    ERR_pop_to_mark();
+
+    /*
+     * We don't check for frees here as there's a non-trivial amount
+     * of free calls in the error handling routines.
+     */
+    test_result &= check_counts(exp_mallocs, exp_reallocs, -1);
+
+    return test_result;
+}
+
+static int test_xalloc(const bool secure, const bool array, const bool zero,
+                       const bool macro, const struct array_alloc_vector *td)
+{
+    char *ret;
+    int ln = test_line;
+    size_t sz = td->nmemb * td->size;
+    enum exp_ret exp = array ? td->exp_calloc : td->exp_malloc;
+    bool really_secure = secure && secure_memory_is_secure;
+    int exp_cnt = 0;
+    int res;
+
+    check_exp_prep();
+
+    if (macro) {
+        if (secure) {
+            if (array) {
+                if (zero)
+                    ln = OPENSSL_LINE, ret = OPENSSL_secure_calloc(td->nmemb, td->size);
+                else
+                    ln = OPENSSL_LINE, ret = OPENSSL_secure_malloc_array(td->nmemb, td->size);
+            } else {
+                if (zero)
+                    ln = OPENSSL_LINE, ret = OPENSSL_secure_zalloc(sz);
+                else
+                    ln = OPENSSL_LINE, ret = OPENSSL_secure_malloc(sz);
+            }
+        } else {
+            if (array) {
+                if (zero)
+                    ln = OPENSSL_LINE, ret = OPENSSL_calloc(td->nmemb, td->size);
+                else
+                    ln = OPENSSL_LINE, ret = OPENSSL_malloc_array(td->nmemb, td->size);
+            } else {
+                if (zero)
+                    ln = OPENSSL_LINE, ret = OPENSSL_zalloc(sz);
+                else
+                    ln = OPENSSL_LINE, ret = OPENSSL_malloc(sz);
+            }
+        }
+    } else {
+        if (array) {
+            ret = (secure ? (zero ? CRYPTO_secure_calloc
+                                  : CRYPTO_secure_malloc_array)
+                          : (zero ? CRYPTO_calloc
+                                  : CRYPTO_malloc_array))(td->nmemb, td->size,
+                                                          test_fn, test_line);
+        } else {
+            ret = (secure ? (zero ? CRYPTO_secure_zalloc
+                                  : CRYPTO_secure_malloc)
+                          : (zero ? CRYPTO_zalloc
+                                  : CRYPTO_malloc))(sz, test_fn, test_line);
+        }
+    }
+
+    /*
+     * There is an OPENSSL_calloc in ERR_set_debug, triggered
+     * from ossl_report_alloc_err_ex.
+     */
+    exp_cnt += IS_FAIL(exp) && (!macro || (bool) OPENSSL_FILE[0]);
+    /*
+     * Secure allocations don't trigger alloc counting.
+     * EXP_OOM is special as it comes on return from the (called and counted)
+     * allocation function.
+     */
+    if (!really_secure)
+        exp_cnt += !!(exp == EXP_OOM || !IS_FAIL(exp));
+    res = check_exp(macro ? OPENSSL_FILE : test_fn, ln, sz, really_secure, zero,
+                    ret, exp, exp_cnt, 0);
+
+    if (really_secure)
+        OPENSSL_secure_free(ret);
+    else
+        OPENSSL_free(ret);
+
+    return res;
+}
+
+static int test_xrealloc(const bool clear, const bool array, const bool macro,
+                         const struct array_realloc_vector *td)
+{
+    char *ret = NULL;
+    char *old_ret = NULL;
+    int exp_malloc_cnt, exp_realloc_cnt;
+    int res = 1;
+    size_t i;
+
+    /*
+     * Do two passes, first with NULL ptr, then with the result of the first
+     * call.
+     */
+    for (i = 0; i < 2; i++) {
+        size_t nmemb = i ? td->new_nmemb : td->orig_nmemb;
+        size_t old_nmemb = i ? td->orig_nmemb : 0;
+        size_t sz = nmemb * td->size;
+        size_t old_sz = old_nmemb * td->size;
+        int ln = test_line;
+        enum exp_ret exp = i ? (array ? td->exp_new_array  : td->exp_new)
+                             : (array ? td->exp_orig_array : td->exp_orig);
+        enum exp_ret exp2 = !i ? (array ? td->exp_new_array  : td->exp_new)
+                               : (array ? td->exp_orig_array : td->exp_orig);
+
+        exp_malloc_cnt = exp_realloc_cnt = 0;
+
+        /* clear_realloc_array checks both new and old sizes */
+        if (clear && array && i && exp2 == EXP_INT_OF)
+            exp = EXP_INT_OF;
+
+        if (exp != EXP_INT_OF) {
+            if (clear) {
+                /*
+                 * clear_alloc just calls cleanse if contraction has been
+                 * requested.
+                 */
+                if (ret == NULL || sz > old_sz)
+                    exp_malloc_cnt++;
+            } else {
+                exp_realloc_cnt++;
+#if !USE_CUSTOM_ALLOC_FNS
+                /* CRYPTO_malloc() is called explicitly when p is NULL. */
+                if (ret == NULL)
+                    exp_malloc_cnt++;
+#endif
+            }
+        } else {
+            if (!macro || OPENSSL_FILE[0] != '\0')
+                exp_malloc_cnt++;
+        }
+
+        check_exp_prep();
+
+        if (macro) {
+            if (array) {
+                if (clear)
+                    ln = OPENSSL_LINE, ret = OPENSSL_clear_realloc_array(ret, old_nmemb, nmemb, td->size);
+                else
+                    ln = OPENSSL_LINE, ret = OPENSSL_realloc_array(ret, nmemb, td->size);
+            } else {
+                if (clear)
+                    ln = OPENSSL_LINE, ret = OPENSSL_clear_realloc(ret, old_sz, sz);
+                else
+                    ln = OPENSSL_LINE, ret = OPENSSL_realloc(ret, sz);
+            }
+        } else {
+            if (array) {
+                if (clear)
+                    ret = CRYPTO_clear_realloc_array(ret, old_nmemb, nmemb,
+                                                     td->size,
+                                                     test_fn, test_line);
+                else
+                    ret = CRYPTO_realloc_array(ret, nmemb, td->size,
+                                               test_fn, test_line);
+            } else {
+                if (clear)
+                    ret = CRYPTO_clear_realloc(ret, old_sz, sz,
+                                               test_fn, test_line);
+                else
+                    ret = CRYPTO_realloc(ret, sz, test_fn, test_line);
+            }
+        }
+
+        /*
+         * There is an OPENSSL_calloc in ERR_set_debug, triggered
+         * from ossl_report_alloc_err_ex.
+         */
+        exp_malloc_cnt += !!(exp == EXP_OOM
+                             && (!macro || (bool) OPENSSL_FILE[0]));
+
+        res = check_exp(macro ? OPENSSL_FILE : test_fn, ln, sz, false, false,
+                        ret, exp, exp_malloc_cnt, exp_realloc_cnt);
+        if (res == 0)
+            TEST_error("realloc return code check fail with i = %zu"
+                       ", old_ret = %p, ret = %p, old_nmemb = %#zx"
+                       ", nmemb = %#zx, size = %#zx",
+                       i, (void *) old_ret, (void *) ret, old_nmemb, nmemb,
+                       td->size);
+
+        /* Write data on the first pass and check it on the second */
+        if (res != 0 && exp == EXP_NONNULL && exp2 == EXP_NONNULL) {
+            size_t check_sz = MIN(td->orig_nmemb * td->size,
+                                  td->new_nmemb * td->size);
+            size_t j;
+            size_t num_err = 0;
+
+            if (i != 0) {
+                for (j = 0; j < check_sz; j++) {
+                    char exp_val = (uint8_t) ((uintptr_t) td * 253 + j * 17);
+
+                    if (ret[j] != exp_val) {
+                        if (!num_err)
+                            TEST_error("Memory mismatch at byte %zu of %zu: "
+                                       "%#04hhx != %#04hhx",
+                                       j, check_sz, ret[j], exp_val);
+
+                        res = 0;
+                        num_err++;
+                    }
+                }
+
+                if (num_err != 0)
+                    TEST_error("Total errors: %zu", num_err);
+            } else {
+                for (j = 0; j < check_sz; j++)
+                    ret[j] = (uint8_t) ((uintptr_t) td * 253 + j * 17);
+            }
+        }
+
+        /* Freeing the old allocation if realloc has failed */
+        if (old_ret != 0 && ret == 0 && exp != EXP_ZERO_SIZE)
+            OPENSSL_free(old_ret);
+
+        old_ret = ret;
+    }
+
+    OPENSSL_free(ret);
+
+    return res;
+}
+
+static int test_xaligned_alloc(const bool array, const bool macro,
+                               const struct array_aligned_alloc_vector *td)
+{
+    char *ret;
+    int ln = test_line;
+    size_t sz = td->nmemb * td->size;
+    enum exp_ret exp = array ? td->exp_array : td->exp;
+    int exp_cnt = 0;
+    void *freeptr = &freeptr;
+    int res = 1;
+
+    check_exp_prep();
+
+    if (macro) {
+        if (array) {
+            ln = OPENSSL_LINE, ret = OPENSSL_aligned_alloc_array(td->nmemb, td->size, td->align, &freeptr);
+        } else {
+            ln = OPENSSL_LINE, ret = OPENSSL_aligned_alloc(sz, td->align, &freeptr);
+        }
+    } else {
+        if (array)
+            ret = CRYPTO_aligned_alloc_array(td->nmemb, td->size, td->align,
+                                             &freeptr, test_fn, test_line);
+        else
+            ret = CRYPTO_aligned_alloc(sz, td->align, &freeptr,
+                                       test_fn, test_line);
+    }
+
+#if !defined(OPENSSL_SMALL_FOOTPRINT)
+    /*
+     * aligned_alloc doesn't increment the call counts by itself, and
+     * OPENSSL_malloc is only called when the open-coded implementation
+     * is used.
+     */
+# if USE_CUSTOM_ALLOC_FNS \
+    || !(defined(_BSD_SOURCE) || (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L))
+    exp_cnt += !!(exp != EXP_INT_OF && exp != EXP_INVAL);
+# endif
+#else /* OPENSSL_SMALL_FOOTPRINT */
+    exp = exp == EXP_INT_OF ? EXP_INT_OF : EXP_ZERO_SIZE;
+#endif /* !OPENSSL_SMALL_FOOTPRINT */
+
+    /*
+     * There is an OPENSSL_calloc in ERR_set_debug, triggered
+     * from ossl_report_alloc_err_ex.
+     */
+    exp_cnt += IS_FAIL(exp) && (!macro || (bool) OPENSSL_FILE[0]);
+    res &= check_exp(macro ? OPENSSL_FILE : test_fn, ln, sz, false, false,
+                     ret, exp, exp_cnt, 0);
+
+    /* Check the pointer's alignment */
+    if (exp == EXP_NONNULL) {
+        if (!TEST_uint64_t_eq((uintptr_t) ret & (td->align - 1), 0))
+            res = 0;
+    }
+
+#if !defined(OPENSSL_SMALL_FOOTPRINT)
+    if (IS_FAIL(exp) && !TEST_ptr_null(freeptr))
+        res = 0;
+    if ((exp = EXP_NONNULL) && !TEST_ptr(freeptr))
+        res = 0;
+#else /* OPENSSL_SMALL_FOOTPRINT */
+    if (!TEST_ptr_null(ret) || !TEST_ptr_null(freeptr))
+        res = 0;
+#endif /* !OPENSSL_SMALL_FOOTPRINT */
+
+    OPENSSL_free(freeptr);
+
+    return res;
+}
+
+static int test_malloc(const int i)
+{
+    return test_xalloc(false, false, false, false, array_alloc_vectors + i)
+        && test_xalloc(false, false, false, true,  array_alloc_vectors + i);
+}
+
+static int test_zalloc(const int i)
+{
+    return test_xalloc(false, false, true, false, array_alloc_vectors + i)
+        && test_xalloc(false, false, true, true,  array_alloc_vectors + i);
+}
+
+static int test_malloc_array(const int i)
+{
+    return test_xalloc(false, true, false, false, array_alloc_vectors + i)
+        && test_xalloc(false, true, false, true,  array_alloc_vectors + i);
+}
+
+static int test_calloc(const int i)
+{
+    return test_xalloc(false, true, true, false, array_alloc_vectors + i)
+        && test_xalloc(false, true, true, true,  array_alloc_vectors + i);
+}
+
+static int test_secure_malloc(const int i)
+{
+    return test_xalloc(true, false, false, false, array_alloc_vectors + i)
+        && test_xalloc(true, false, false, true,  array_alloc_vectors + i);
+}
+
+static int test_secure_zalloc(const int i)
+{
+    return test_xalloc(true, false, true, false, array_alloc_vectors + i)
+        && test_xalloc(true, false, true, true,  array_alloc_vectors + i);
+}
+
+static int test_secure_malloc_array(const int i)
+{
+    return test_xalloc(true, true, false, false, array_alloc_vectors + i)
+        && test_xalloc(true, true, false, true,  array_alloc_vectors + i);
+}
+
+static int test_secure_calloc(const int i)
+{
+    return test_xalloc(true, true, true, false, array_alloc_vectors + i)
+        && test_xalloc(true, true, true, true,  array_alloc_vectors + i);
+}
+
+static int test_realloc(const int i)
+{
+    return test_xrealloc(false, false, false, array_realloc_vectors + i)
+        && test_xrealloc(false, false, true,  array_realloc_vectors + i);
+}
+
+static int test_clear_realloc(const int i)
+{
+    return test_xrealloc(true, false, false, array_realloc_vectors + i)
+        && test_xrealloc(true, false, true,  array_realloc_vectors + i);
+}
+
+static int test_realloc_array(const int i)
+{
+    return test_xrealloc(false, true, false, array_realloc_vectors + i)
+        && test_xrealloc(false, true, true,  array_realloc_vectors + i);
+}
+
+static int test_clear_realloc_array(const int i)
+{
+    return test_xrealloc(true, true, false, array_realloc_vectors + i)
+        && test_xrealloc(true, true, true,  array_realloc_vectors + i);
+}
+
+static int test_aligned_alloc(const int i)
+{
+    return test_xaligned_alloc(false, false, array_aligned_alloc_vectors + i)
+        && test_xaligned_alloc(false, true,  array_aligned_alloc_vectors + i);
+}
+
+static int test_aligned_alloc_array(const int i)
+{
+    return test_xaligned_alloc(true, false, array_aligned_alloc_vectors + i)
+        && test_xaligned_alloc(true, true,  array_aligned_alloc_vectors + i);
+}
+
+static int test_free(void)
+{
+    int test_result = 1;
+    void *p;
+
+    save_counts();
+    OPENSSL_free(NULL);
+    if (!TEST_int_eq(check_counts(0, 0, 1), 1))
+        test_result = 0;
+
+    save_counts();
+    CRYPTO_free(NULL, test_fn, test_line);
+    if (!TEST_int_eq(check_counts(0, 0, 1), 1))
+        test_result = 0;
+
+    save_counts();
+    p = OPENSSL_malloc(42);
+    OPENSSL_free(p);
+    if (!TEST_int_eq(check_counts(1, 0, 1), 1))
+        test_result = 0;
+
+    save_counts();
+    p = CRYPTO_calloc(23, 69, test_fn, test_line);
+    CRYPTO_free(p, test_fn, test_line);
+    if (!TEST_int_eq(check_counts(1, 0, 1), 1))
+        test_result = 0;
+
+    return test_result;
+}
+
+int setup_tests(void)
+{
+    secure_memory_is_secure = CRYPTO_secure_malloc_init(65536, 4);
+    TEST_info("secure memory init: %d", secure_memory_is_secure);
+
+    ADD_ALL_TESTS(test_malloc, OSSL_NELEM(array_alloc_vectors));
+    ADD_ALL_TESTS(test_zalloc, OSSL_NELEM(array_alloc_vectors));
+    ADD_ALL_TESTS(test_malloc_array, OSSL_NELEM(array_alloc_vectors));
+    ADD_ALL_TESTS(test_calloc, OSSL_NELEM(array_alloc_vectors));
+
+    ADD_ALL_TESTS(test_secure_malloc, OSSL_NELEM(array_alloc_vectors));
+    ADD_ALL_TESTS(test_secure_zalloc, OSSL_NELEM(array_alloc_vectors));
+    ADD_ALL_TESTS(test_secure_malloc_array, OSSL_NELEM(array_alloc_vectors));
+    ADD_ALL_TESTS(test_secure_calloc, OSSL_NELEM(array_alloc_vectors));
+
+    ADD_ALL_TESTS(test_realloc, OSSL_NELEM(array_realloc_vectors));
+    ADD_ALL_TESTS(test_clear_realloc, OSSL_NELEM(array_realloc_vectors));
+    ADD_ALL_TESTS(test_realloc_array, OSSL_NELEM(array_realloc_vectors));
+    ADD_ALL_TESTS(test_clear_realloc_array, OSSL_NELEM(array_realloc_vectors));
+
+    ADD_ALL_TESTS(test_aligned_alloc, OSSL_NELEM(array_aligned_alloc_vectors));
+    ADD_ALL_TESTS(test_aligned_alloc_array,
+                  OSSL_NELEM(array_aligned_alloc_vectors));
+
+    ADD_TEST(test_free);
+
+    return 1;
+}
+
+#if USE_CUSTOM_ALLOC_FNS
+int global_init(void)
+{
+    if (!CRYPTO_set_mem_functions(my_malloc, my_realloc, my_free)) {
+        fprintf(stderr, "Failed to override allocator functions");
+
+        return 0;
+    }
+
+    return 1;
+}
+#endif

--- a/test/quic-openssl-docker/hq-interop/quic-hq-interop.c
+++ b/test/quic-openssl-docker/hq-interop/quic-hq-interop.c
@@ -567,21 +567,21 @@ static size_t build_request_set(SSL *ssl)
         /*
          * Expand our poll_list, outbiolist, and outnames arrays
          */
-        poll_list = OPENSSL_realloc(poll_list,
-                                    sizeof(SSL_POLL_ITEM) * poll_count);
+        poll_list = OPENSSL_realloc_array(poll_list,
+                                          poll_count, sizeof(SSL_POLL_ITEM));
         if (poll_list == NULL) {
             fprintf(stderr, "Unable to realloc poll_list\n");
             goto err;
         }
 
-        outbiolist = OPENSSL_realloc(outbiolist,
-                                     sizeof(BIO *) * poll_count);
+        outbiolist = OPENSSL_realloc_array(outbiolist,
+                                           poll_count, sizeof(BIO *));
         if (outbiolist == NULL) {
             fprintf(stderr, "Unable to realloc outbiolist\n");
             goto err;
         }
 
-        outnames = OPENSSL_realloc(outnames, sizeof(char *) * poll_count);
+        outnames = OPENSSL_realloc_array(outnames, poll_count, sizeof(char *));
         if (outnames == NULL) {
             fprintf(stderr, "Unable to realloc outnames\n");
             goto err;
@@ -922,7 +922,8 @@ int main(int argc, char *argv[])
 
     while (req != NULL) {
         total_requests++;
-        req_array = OPENSSL_realloc(req_array, sizeof(char *) * total_requests);
+        req_array = OPENSSL_realloc_array(req_array,
+                                          total_requests, sizeof(char *));
         if (req_array == NULL)
             goto end;
         req_array[total_requests - 1] = req;

--- a/test/quic_ackm_test.c
+++ b/test/quic_ackm_test.c
@@ -112,7 +112,7 @@ static int helper_init(struct helper *h, size_t num_pkts)
     /* Allocate our array of packet information. */
     h->num_pkts = num_pkts;
     if (num_pkts > 0) {
-        h->pkts = OPENSSL_zalloc(sizeof(struct pkt_info) * num_pkts);
+        h->pkts = OPENSSL_calloc(num_pkts, sizeof(struct pkt_info));
         if (!TEST_ptr(h->pkts))
             goto err;
     } else {
@@ -936,11 +936,11 @@ static int test_rx_ack_actual(int tidx, int space)
             num_tx += s->num_pn;
 
     /* Allocate packet information structures. */
-    txs = OPENSSL_zalloc(sizeof(*txs) * num_tx);
+    txs = OPENSSL_calloc(num_tx, sizeof(*txs));
     if (!TEST_ptr(txs))
         goto err;
 
-    pkts = OPENSSL_zalloc(sizeof(*pkts) * num_tx);
+    pkts = OPENSSL_calloc(num_tx, sizeof(*pkts));
     if (!TEST_ptr(pkts))
         goto err;
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -1886,7 +1886,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                     goto out;
                 }
 
-                h->threads = OPENSSL_zalloc(op->arg1 * sizeof(struct child_thread_args));
+                h->threads = OPENSSL_calloc(op->arg1, sizeof(struct child_thread_args));
                 if (!TEST_ptr(h->threads))
                     goto out;
 

--- a/test/recipes/02-test_mem_alloc.t
+++ b/test/recipes/02-test_mem_alloc.t
@@ -1,0 +1,16 @@
+#! /usr/bin/env perl
+# Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use OpenSSL::Test::Simple;
+
+{
+    local $ENV{"ASAN_OPTIONS"} = "allocator_may_return_null=true";
+    local $ENV{"MSAN_OPTIONS"} = "allocator_may_return_null=true";
+
+    simple_test("test_mem_alloc", "mem_alloc_test");
+}

--- a/test/recipes/02-test_mem_alloc_custom_fns.t
+++ b/test/recipes/02-test_mem_alloc_custom_fns.t
@@ -1,0 +1,16 @@
+#! /usr/bin/env perl
+# Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use OpenSSL::Test::Simple;
+
+{
+    local $ENV{"ASAN_OPTIONS"} = "allocator_may_return_null=true";
+    local $ENV{"MSAN_OPTIONS"} = "allocator_may_return_null=true";
+
+    simple_test("test_mem_alloc_custom_fns", "mem_alloc_custom_fns_test");
+}

--- a/test/slh_dsa_test.c
+++ b/test/slh_dsa_test.c
@@ -480,7 +480,7 @@ static int slh_dsa_deterministic_usage_test(void)
     if (!TEST_int_eq(EVP_PKEY_sign(sctx, NULL, &sig_len, msg, msg_len), 1))
         goto err;
     len = sig_len;
-    if (!TEST_ptr(sig = OPENSSL_zalloc(sig_len * 2))
+    if (!TEST_ptr(sig = OPENSSL_calloc(2, sig_len))
             || !TEST_int_eq(EVP_PKEY_sign(sctx, sig, &len, msg, msg_len), 1)
             || !TEST_size_t_eq(sig_len, len)
             || !TEST_int_eq(EVP_PKEY_sign(dupctx, sig + sig_len, &len,

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -7969,7 +7969,7 @@ static int ssl_srp_cb(SSL *s, int *ad, void *arg)
 static int create_new_vfile(char *userid, char *password, const char *filename)
 {
     char *gNid = NULL;
-    OPENSSL_STRING *row = OPENSSL_zalloc(sizeof(row) * (DB_NUMBER + 1));
+    OPENSSL_STRING *row = OPENSSL_calloc(DB_NUMBER + 1, sizeof(row));
     TXT_DB *db = NULL;
     int ret = 0;
     BIO *out = NULL, *dummy = BIO_new_mem_buf("", 0);

--- a/test/sslcorrupttest.c
+++ b/test/sslcorrupttest.c
@@ -154,8 +154,8 @@ static int setup_cipher_list(void)
      * so that some of the allocated space will be wasted, but the loss
      * is deemed acceptable...
      */
-    cipher_list = OPENSSL_malloc(sk_SSL_CIPHER_num(sk_ciphers) *
-                                 sizeof(cipher_list[0]));
+    cipher_list = OPENSSL_malloc_array(sk_SSL_CIPHER_num(sk_ciphers),
+                                       sizeof(cipher_list[0]));
     if (!TEST_ptr(cipher_list))
         goto err;
 

--- a/test/testutil/format_output.c
+++ b/test/testutil/format_output.c
@@ -299,7 +299,7 @@ static void test_fail_bignum_common(const char *prefix, const char *file,
 
     len = ((l1 > l2 ? l1 : l2) + bytes - 1) / bytes * bytes;
 
-    if (len > MEM_BUFFER_SIZE && (bufp = OPENSSL_malloc(len * 2)) == NULL) {
+    if (len > MEM_BUFFER_SIZE && (bufp = OPENSSL_malloc_array(2, len)) == NULL) {
         bufp = buffer;
         len = MEM_BUFFER_SIZE;
         test_printf_stderr("WARNING: these BIGNUMs have been truncated\n");

--- a/test/testutil/main.c
+++ b/test/testutil/main.c
@@ -16,10 +16,13 @@ int main(int argc, char *argv[])
 {
     int ret = EXIT_FAILURE;
     int setup_res;
+    int gi_ret;
+
+    gi_ret = global_init();
 
     test_open_streams();
 
-    if (!global_init()) {
+    if (!gi_ret) {
         test_printf_stderr("Global init failed - aborting\n");
         return ret;
     }

--- a/util/ctags.sh
+++ b/util/ctags.sh
@@ -26,7 +26,7 @@ if ! type "${CTAGS}" > /dev/null; then
 fi
 
 if [ $# -eq 0 ]; then
-    set - -R
+    set -- -R
 fi
 
 if ! "${CTAGS}" --version | grep -q "Universal Ctags"; then

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5936,3 +5936,10 @@ CMS_RecipientInfo_kemri_set0_pkey       ?	3_6_0	EXIST::FUNCTION:CMS
 CMS_RecipientInfo_kemri_get0_ctx        ?	3_6_0	EXIST::FUNCTION:CMS
 CMS_RecipientInfo_kemri_get0_kdf_alg    ?	3_6_0	EXIST::FUNCTION:CMS
 CMS_RecipientInfo_kemri_set_ukm         ?	3_6_0	EXIST::FUNCTION:CMS
+CRYPTO_malloc_array                     ?	3_6_0	EXIST::FUNCTION:
+CRYPTO_calloc                           ?	3_6_0	EXIST::FUNCTION:
+CRYPTO_aligned_alloc_array              ?	3_6_0	EXIST::FUNCTION:
+CRYPTO_realloc_array                    ?	3_6_0	EXIST::FUNCTION:
+CRYPTO_clear_realloc_array              ?	3_6_0	EXIST::FUNCTION:
+CRYPTO_secure_malloc_array              ?	3_6_0	EXIST::FUNCTION:
+CRYPTO_secure_calloc                    ?	3_6_0	EXIST::FUNCTION:

--- a/util/other.syms
+++ b/util/other.syms
@@ -430,21 +430,28 @@ OPENSSL_VERSION_BUILD_METADATA          define
 OPENSSL_VERSION_PRE_RELEASE_STR         define
 OPENSSL_VERSION_BUILD_METADATA_STR      define
 OPENSSL_VERSION_TEXT                    define
+OPENSSL_calloc                          define
 OPENSSL_clear_free                      define
 OPENSSL_clear_realloc                   define
+OPENSSL_clear_realloc_array             define
 OPENSSL_free                            define
 OPENSSL_malloc                          define
+OPENSSL_malloc_array                    define
 OPENSSL_aligned_alloc                   define
+OPENSSL_aligned_alloc_array             define
 OPENSSL_malloc_init                     define
 OPENSSL_mem_debug_pop                   define deprecated 3.0.0
 OPENSSL_mem_debug_push                  define deprecated 3.0.0
 OPENSSL_memdup                          define
 OPENSSL_no_config                       define deprecated 1.1.0
 OPENSSL_realloc                         define
+OPENSSL_realloc_array                   define
 OPENSSL_secure_actual_size              define
 OPENSSL_secure_clear_free               define
 OPENSSL_secure_free                     define
+OPENSSL_secure_calloc                   define
 OPENSSL_secure_malloc                   define
+OPENSSL_secure_malloc_array             define
 OPENSSL_secure_zalloc                   define
 OPENSSL_strdup                          define
 OPENSSL_strndup                         define


### PR DESCRIPTION
This patch set adds variants of memory allocation routines suitable for array allocation, that perform an additional check for integer overflow during the size calculation.  Also, in order to add a test for the functions, some cleanup of the existing memory allocation routines' behaviour has been done.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
