### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/workflows/ @quarckster


### PR DESCRIPTION
GitHub allows to assign owners of the specific parts of code using [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file. Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. I want to get review requests on all changes in `/.github/workflows` directory.

This PR should be backported to all active branches.
