### PR TITLE
evp_pkey_type: Make base_id_conversion table static

### DIFF
--- a/crypto/evp/evp_pkey_type.c
+++ b/crypto/evp/evp_pkey_type.c
@@ -31,7 +31,7 @@ struct pkid2bid {
     int pkey_base_id;
 };
 
-const struct pkid2bid base_id_conversion[] = {
+static const struct pkid2bid base_id_conversion[] = {
     {EVP_PKEY_RSA, EVP_PKEY_RSA},
     {EVP_PKEY_RSA2, EVP_PKEY_RSA},
     {EVP_PKEY_RSA_PSS, EVP_PKEY_RSA_PSS},


### PR DESCRIPTION
Urgent as this commit fixes daily checker CI failures

https://github.com/openssl/openssl/actions/runs/16361194525/job/46229267770

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
