### PR TITLE
only check tserver connection state in thread assist mode

### DIFF
--- a/test/quic_tserver_test.c
+++ b/test/quic_tserver_test.c
@@ -351,8 +351,10 @@ static int do_test(int use_thread_assist, int use_fake_time, int use_inject)
              * If we have finished the fake idling duration, the connection
              * should still be healthy in TA mode.
              */
-            if (!TEST_true(ossl_quic_tserver_is_connected(tserver)))
-                goto err;
+            if (use_thread_assist) {
+                if (!TEST_true(ossl_quic_tserver_is_connected(tserver)))
+                    goto err;
+            }
 
             /* DONE */
             break;


### PR DESCRIPTION
We've been getting these errors sporadically in our CI jobs: https://github.com/openssl/openssl/actions/runs/16350297637/job/46195040556

The quic_tserver_test has been failing with the error:
        # ERROR: (bool) 'ossl_quic_tserver_is_connected(tserver) == true' failed @ ../source/test/quic_tserver_test.c:354
        # false
        # OPENSSL_TEST_RAND_SEED=1752769014
        not ok 6 - iteration 6

I've been unable to reproduce it (what else is new), but looking at the code where the error is generated there is a large comment that claims this is a sanity check in which the connection should still be active when in thread assisted mode.  However, the code checks for the condition in both thread assisted, and non-thread-assisted mode.  It seems fairly clear that in non-ta mode, this could reasonable fail based on exact timings around when we tick the reactor.  So it seems sensible to only do the check when we run this test in TA mode

