### PR TITLE
Fix behavior change with EC keygen after commit "crypto/evp: compensate for providers not adding error queue entries for keymgmt, sigver, and asymcipher"

### DIFF
--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -261,10 +261,12 @@ int EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx,
 
     cipher = ctx->op.ciph.cipher;
     desc = cipher->description != NULL ? cipher->description : "";
+    ERR_set_mark();
     ret = cipher->encrypt(ctx->op.ciph.algctx, out, outlen, (out == NULL ? 0 : *outlen), in, inlen);
-    if (ret <= 0)
+    if (ret <= 0 && ERR_count_to_mark() == 0)
         ERR_raise_data(ERR_LIB_EVP, EVP_R_PROVIDER_ASYM_CIPHER_FAILURE,
                        "%s encrypt:%s", cipher->type_name, desc);
+    ERR_clear_last_mark();
     return ret;
 
  legacy:
@@ -309,10 +311,12 @@ int EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx,
 
     cipher = ctx->op.ciph.cipher;
     desc = cipher->description != NULL ? cipher->description : "";
+    ERR_set_mark();
     ret = cipher->decrypt(ctx->op.ciph.algctx, out, outlen, (out == NULL ? 0 : *outlen), in, inlen);
-    if (ret <= 0)
+    if (ret <= 0 && ERR_count_to_mark() == 0)
         ERR_raise_data(ERR_LIB_EVP, EVP_R_PROVIDER_ASYM_CIPHER_FAILURE,
                        "%s decrypt:%s", cipher->type_name, desc);
+    ERR_clear_last_mark();
 
     return ret;
 

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -460,10 +460,12 @@ void *evp_keymgmt_gen(const EVP_KEYMGMT *keymgmt, void *genctx,
         return NULL;
     }
 
+    ERR_set_mark();
     ret = keymgmt->gen(genctx, cb, cbarg);
-    if (ret == NULL)
+    if (ret == NULL && ERR_count_to_mark() == 0)
         ERR_raise_data(ERR_LIB_EVP, EVP_R_PROVIDER_KEYMGMT_FAILURE,
                        "%s key generation:%s", keymgmt->type_name, desc);
+    ERR_clear_last_mark();
     return ret;
 }
 

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -426,10 +426,12 @@ int EVP_DigestSignUpdate(EVP_MD_CTX *ctx, const void *data, size_t dsize)
         return 0;
     }
 
+    ERR_set_mark();
     ret = signature->digest_sign_update(pctx->op.sig.algctx, data, dsize);
-    if (ret <= 0)
+    if (ret <= 0 && ERR_count_to_mark() == 0)
         ERR_raise_data(ERR_LIB_EVP, EVP_R_PROVIDER_SIGNATURE_FAILURE,
                        "%s digest_sign_update:%s", signature->type_name, desc);
+    ERR_clear_last_mark();
     return ret;
 
  legacy:
@@ -470,10 +472,12 @@ int EVP_DigestVerifyUpdate(EVP_MD_CTX *ctx, const void *data, size_t dsize)
         return 0;
     }
 
+    ERR_set_mark();
     ret = signature->digest_verify_update(pctx->op.sig.algctx, data, dsize);
-    if (ret <= 0)
+    if (ret <= 0 && ERR_count_to_mark() == 0)
         ERR_raise_data(ERR_LIB_EVP, EVP_R_PROVIDER_SIGNATURE_FAILURE,
                        "%s digest_verify_update:%s", signature->type_name, desc);
+    ERR_clear_last_mark();
     return ret;
 
  legacy:
@@ -523,11 +527,13 @@ int EVP_DigestSignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
             pctx = dctx;
     }
 
+    ERR_set_mark();
     r = signature->digest_sign_final(pctx->op.sig.algctx, sigret, siglen,
                                      sigret == NULL ? 0 : *siglen);
-    if (!r)
+    if (!r && ERR_count_to_mark() == 0)
         ERR_raise_data(ERR_LIB_EVP, EVP_R_PROVIDER_SIGNATURE_FAILURE,
                        "%s digest_sign_final:%s", signature->type_name, desc);
+    ERR_clear_last_mark();
     if (dctx == NULL && sigret != NULL)
         ctx->flags |= EVP_MD_CTX_FLAG_FINALISED;
     else
@@ -634,11 +640,13 @@ int EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sigret, size_t *siglen,
 
             if (sigret != NULL)
                 ctx->flags |= EVP_MD_CTX_FLAG_FINALISED;
+            ERR_set_mark();
             ret = signature->digest_sign(pctx->op.sig.algctx, sigret, siglen,
                                          sigret == NULL ? 0 : *siglen, tbs, tbslen);
-            if (ret <= 0)
+            if (ret <= 0 && ERR_count_to_mark() == 0)
                 ERR_raise_data(ERR_LIB_EVP, EVP_R_PROVIDER_SIGNATURE_FAILURE,
                                "%s digest_sign:%s", signature->type_name, desc);
+            ERR_clear_last_mark();
             return ret;
         }
     } else {
@@ -689,10 +697,12 @@ int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig,
             pctx = dctx;
     }
 
+    ERR_set_mark();
     r = signature->digest_verify_final(pctx->op.sig.algctx, sig, siglen);
-    if (!r)
+    if (!r && ERR_count_to_mark() == 0)
         ERR_raise_data(ERR_LIB_EVP, EVP_R_PROVIDER_SIGNATURE_FAILURE,
                        "%s digest_verify_final:%s", signature->type_name, desc);
+    ERR_clear_last_mark();
     if (dctx == NULL)
         ctx->flags |= EVP_MD_CTX_FLAG_FINALISED;
     else
@@ -765,10 +775,12 @@ int EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sigret,
             int ret;
 
             ctx->flags |= EVP_MD_CTX_FLAG_FINALISED;
+            ERR_set_mark();
             ret = signature->digest_verify(pctx->op.sig.algctx, sigret, siglen, tbs, tbslen);
-            if (ret <= 0)
+            if (ret <= 0 && ERR_count_to_mark() == 0)
                 ERR_raise_data(ERR_LIB_EVP, EVP_R_PROVIDER_SIGNATURE_FAILURE,
                                "%s digest_verify:%s", signature->type_name, desc);
+            ERR_clear_last_mark();
             return ret;
         }
     } else {

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -2419,6 +2419,11 @@ static int core_pop_error_to_mark(const OSSL_CORE_HANDLE *handle)
     return ERR_pop_to_mark();
 }
 
+static int core_count_to_mark(const OSSL_CORE_HANDLE *handle)
+{
+    return ERR_count_to_mark();
+}
+
 static void core_indicator_get_callback(OPENSSL_CORE_CTX *libctx,
                                         OSSL_INDICATOR_CALLBACK **cb)
 {
@@ -2600,6 +2605,7 @@ static const OSSL_DISPATCH core_dispatch_[] = {
     { OSSL_FUNC_CORE_CLEAR_LAST_ERROR_MARK,
       (void (*)(void))core_clear_last_error_mark },
     { OSSL_FUNC_CORE_POP_ERROR_TO_MARK, (void (*)(void))core_pop_error_to_mark },
+    { OSSL_FUNC_CORE_COUNT_TO_MARK, (void (*)(void))core_count_to_mark },
     { OSSL_FUNC_BIO_NEW_FILE, (void (*)(void))ossl_core_bio_new_file },
     { OSSL_FUNC_BIO_NEW_MEMBUF, (void (*)(void))ossl_core_bio_new_mem_buf },
     { OSSL_FUNC_BIO_READ_EX, (void (*)(void))ossl_core_bio_read_ex },

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -154,6 +154,10 @@ provider):
  core_new_error                 OSSL_FUNC_CORE_NEW_ERROR
  core_set_error_debug           OSSL_FUNC_CORE_SET_ERROR_DEBUG
  core_vset_error                OSSL_FUNC_CORE_VSET_ERROR
+ core_set_error_mark            OSSL_FUNC_CORE_SET_ERROR_MARK
+ core_clear_last_error_mark     OSSL_FUNC_CORE_CLEAR_LAST_ERROR_MARK
+ core_pop_error_to_mark         OSSL_FUNC_CORE_POP_ERROR_TO_MARK
+ core_count_to_mark             OSSL_FUNC_CORE_COUNT_TO_MARK
  core_obj_add_sigid             OSSL_FUNC_CORE_OBJ_ADD_SIGID
  core_obj_create                OSSL_FUNC_CORE_OBJ_CREATE
  CRYPTO_malloc                  OSSL_FUNC_CRYPTO_MALLOC
@@ -269,6 +273,33 @@ I<file> and I<line> may also be passed to indicate exactly where the
 error occurred or was reported.
 
 This corresponds to the OpenSSL function L<ERR_vset_error(3)>.
+
+=item core_set_error_mark()
+
+sets a mark on the current topmost error record if there is one.
+
+This corresponds to the OpenSSL function L<ERR_set_mark(3)>.
+
+=item core_clear_last_error_mark()
+
+removes the last mark added if there is one.
+
+This corresponds to the OpenSSL function L<ERR_clear_last_mark(3)>.
+
+=item core_pop_error_to_mark()
+
+pops the top of the error stack until a mark is found. The mark is then removed.
+If there is no mark, the whole stack is removed.
+
+This corresponds to the OpenSSL function L<ERR_pop_to_mark(3)>.
+
+=item core_count_to_mark()
+
+returns the number of entries on the error stack above the most recently
+marked entry, not including that entry. If there is no mark in the error stack,
+the number of entries in the error stack is returned.
+
+This corresponds to the OpenSSL function L<ERR_count_to_mark(3)>.
 
 =back
 

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -253,6 +253,10 @@ OSSL_CORE_MAKE_FUNC(int, provider_up_ref,
 OSSL_CORE_MAKE_FUNC(int, provider_free,
                     (const OSSL_CORE_HANDLE *prov, int deactivate))
 
+/* Additional error functions provided by the core */
+# define OSSL_FUNC_CORE_COUNT_TO_MARK          120
+OSSL_CORE_MAKE_FUNC(int, core_count_to_mark, (const OSSL_CORE_HANDLE *prov))
+
 /* Functions provided by the provider to the Core, reserved numbers 1024-1535 */
 # define OSSL_FUNC_PROVIDER_TEARDOWN           1024
 OSSL_CORE_MAKE_FUNC(void, provider_teardown, (void *provctx))

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -65,6 +65,7 @@ static OSSL_FUNC_core_vset_error_fn *c_vset_error;
 static OSSL_FUNC_core_set_error_mark_fn *c_set_error_mark;
 static OSSL_FUNC_core_clear_last_error_mark_fn *c_clear_last_error_mark;
 static OSSL_FUNC_core_pop_error_to_mark_fn *c_pop_error_to_mark;
+static OSSL_FUNC_core_count_to_mark_fn *c_count_to_mark;
 static OSSL_FUNC_CRYPTO_malloc_fn *c_CRYPTO_malloc;
 static OSSL_FUNC_CRYPTO_zalloc_fn *c_CRYPTO_zalloc;
 static OSSL_FUNC_CRYPTO_free_fn *c_CRYPTO_free;
@@ -834,6 +835,9 @@ int OSSL_provider_init_int(const OSSL_CORE_HANDLE *handle,
         case OSSL_FUNC_CORE_POP_ERROR_TO_MARK:
             set_func(c_pop_error_to_mark, OSSL_FUNC_core_pop_error_to_mark(in));
             break;
+        case OSSL_FUNC_CORE_COUNT_TO_MARK:
+            set_func(c_count_to_mark, OSSL_FUNC_core_count_to_mark(in));
+            break;
         case OSSL_FUNC_CRYPTO_MALLOC:
             set_func(c_CRYPTO_malloc, OSSL_FUNC_CRYPTO_malloc(in));
             break;
@@ -1070,6 +1074,11 @@ int ERR_clear_last_mark(void)
 int ERR_pop_to_mark(void)
 {
     return c_pop_error_to_mark(NULL);
+}
+
+int ERR_count_to_mark(void)
+{
+    return c_count_to_mark != NULL ? c_count_to_mark(NULL) : 0;
 }
 
 /*

--- a/providers/legacyprov.c
+++ b/providers/legacyprov.c
@@ -48,6 +48,7 @@ static OSSL_FUNC_core_vset_error_fn *c_vset_error;
 static OSSL_FUNC_core_set_error_mark_fn *c_set_error_mark;
 static OSSL_FUNC_core_clear_last_error_mark_fn *c_clear_last_error_mark;
 static OSSL_FUNC_core_pop_error_to_mark_fn *c_pop_error_to_mark;
+static OSSL_FUNC_core_count_to_mark_fn *c_count_to_mark;
 #endif
 
 /* Parameters we provide to the core */
@@ -234,6 +235,9 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
         case OSSL_FUNC_CORE_POP_ERROR_TO_MARK:
             set_func(c_pop_error_to_mark, OSSL_FUNC_core_pop_error_to_mark(tmp));
             break;
+        case OSSL_FUNC_CORE_COUNT_TO_MARK:
+            set_func(c_count_to_mark, OSSL_FUNC_core_count_to_mark(in));
+            break;
         }
     }
 #endif
@@ -300,5 +304,10 @@ int ERR_clear_last_mark(void)
 int ERR_pop_to_mark(void)
 {
     return c_pop_error_to_mark(NULL);
+}
+
+int ERR_count_to_mark(void)
+{
+    return c_count_to_mark != NULL ? c_count_to_mark(NULL) : 0;
 }
 #endif


### PR DESCRIPTION
This is an attempt to implement the changes suggested in https://github.com/openssl/openssl/issues/27992 after commit 72351b0d18078170af270418b2d5e9fc579cb1af .

To build the fips provider with the changes of the second commit, I needed to add the ERR_count_to_mark() function to be made available to the provider via core dispatch array, thus the first commit. 

There are already 3 error-mark functions provided that way (although not documented), I now added ERR_count_to_mark() as 4th one (and documented all 4). If you don't like that, then we might need to #ifdef the changes out for FIPS_MODULE...

I added the OSSL_FUNC_CORE_COUNT_TO_MARK at the end of the currently used numbers (with a little gap to the last one). Let me know if you prefer to use a different number. We obviously can't renumber the existing ones.

I made the change to add a generic error only if the provider did not add one to all places that have been changed by commit 72351b0d18078170af270418b2d5e9fc579cb1af, not only to the key generation. I think it should not hurt that way, we don't know if there are applications that rely on specific errors for the other operations, too. 

