### PR TITLE
minimize contention for ADDED_OBJ hash table

### DIFF
--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -72,8 +72,10 @@ DEFINE_RUN_ONCE_STATIC(obj_api_initialise)
     }
 #endif
     added = lh_ADDED_OBJ_new(added_obj_hash, added_obj_cmp);
-    if (added == NULL)
+    if (added == NULL) {
+        objs_free_locks();
         return 0;
+    }
 
     return 1;
 }

--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -46,7 +46,7 @@ static CRYPTO_RWLOCK *ossl_obj_lock = NULL;
 static CRYPTO_RWLOCK *ossl_obj_nid_lock = NULL;
 #endif
 
-static CRYPTO_ONCE ossl_obj_lock_init = CRYPTO_ONCE_STATIC_INIT;
+static CRYPTO_ONCE ossl_obj_api_init = CRYPTO_ONCE_STATIC_INIT;
 
 static ossl_inline void objs_free_locks(void)
 {
@@ -58,7 +58,7 @@ static ossl_inline void objs_free_locks(void)
 #endif
 }
 
-DEFINE_RUN_ONCE_STATIC(obj_lock_initialise)
+DEFINE_RUN_ONCE_STATIC(obj_api_initialise)
 {
     ossl_obj_lock = CRYPTO_THREAD_lock_new();
     if (ossl_obj_lock == NULL)
@@ -78,18 +78,18 @@ DEFINE_RUN_ONCE_STATIC(obj_lock_initialise)
     return 1;
 }
 
-static ossl_inline int ossl_init_added_lock(void)
+static ossl_inline int ossl_init_added_api(void)
 {
 #ifndef OPENSSL_NO_AUTOLOAD_CONFIG
     /* Make sure we've loaded config before checking for any "added" objects */
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
 #endif
-    return RUN_ONCE(&ossl_obj_lock_init, obj_lock_initialise);
+    return RUN_ONCE(&ossl_obj_api_init, obj_api_initialise);
 }
 
 static ossl_inline int ossl_obj_write_lock(int lock)
 {
-    if (!ossl_init_added_lock())
+    if (!ossl_init_added_api())
         return 0;
     if (!lock)
         return 1;
@@ -98,7 +98,7 @@ static ossl_inline int ossl_obj_write_lock(int lock)
 
 static ossl_inline int ossl_obj_read_lock(int lock)
 {
-    if (!ossl_init_added_lock())
+    if (!ossl_init_added_api())
         return 0;
     if (!lock)
         return 1;

--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -735,7 +735,9 @@ int OBJ_create(const char *oid, const char *sn, const char *ln)
     tmpoid->sn = (char *)sn;
     tmpoid->ln = (char *)ln;
 
-    ok = OBJ_add_object(tmpoid);
+    if (OBJ_add_object(tmpoid) != NID_undef)
+        ok = 1;
+
 
     tmpoid->sn = NULL;
     tmpoid->ln = NULL;

--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -337,8 +337,7 @@ ASN1_OBJECT *OBJ_nid2obj(int n)
         ERR_raise(ERR_LIB_OBJ, ERR_R_UNABLE_TO_GET_READ_LOCK);
         return NULL;
     }
-    if (added != NULL)
-        adp = lh_ADDED_OBJ_retrieve(added, &ad);
+    adp = lh_ADDED_OBJ_retrieve(added, &ad);
     ossl_obj_unlock(1);
     if (adp != NULL)
         return adp->obj;
@@ -397,13 +396,11 @@ static int ossl_obj_obj2nid(const ASN1_OBJECT *a, const int lock)
         ERR_raise(ERR_LIB_OBJ, ERR_R_UNABLE_TO_GET_READ_LOCK);
         return NID_undef;
     }
-    if (added != NULL) {
-        ad.type = ADDED_DATA;
-        ad.obj = (ASN1_OBJECT *)a; /* casting away const is harmless here */
-        adp = lh_ADDED_OBJ_retrieve(added, &ad);
-        if (adp != NULL)
-            nid = adp->obj->nid;
-    }
+    ad.type = ADDED_DATA;
+    ad.obj = (ASN1_OBJECT *)a; /* casting away const is harmless here */
+    adp = lh_ADDED_OBJ_retrieve(added, &ad);
+    if (adp != NULL)
+        nid = adp->obj->nid;
     ossl_obj_unlock(lock);
     return nid;
 }
@@ -643,13 +640,11 @@ int OBJ_ln2nid(const char *s)
         ERR_raise(ERR_LIB_OBJ, ERR_R_UNABLE_TO_GET_READ_LOCK);
         return NID_undef;
     }
-    if (added != NULL) {
-        ad.type = ADDED_LNAME;
-        ad.obj = &o;
-        adp = lh_ADDED_OBJ_retrieve(added, &ad);
-        if (adp != NULL)
-            nid = adp->obj->nid;
-    }
+    ad.type = ADDED_LNAME;
+    ad.obj = &o;
+    adp = lh_ADDED_OBJ_retrieve(added, &ad);
+    if (adp != NULL)
+        nid = adp->obj->nid;
     ossl_obj_unlock(1);
     return nid;
 }
@@ -670,13 +665,11 @@ int OBJ_sn2nid(const char *s)
         ERR_raise(ERR_LIB_OBJ, ERR_R_UNABLE_TO_GET_READ_LOCK);
         return NID_undef;
     }
-    if (added != NULL) {
-        ad.type = ADDED_SNAME;
-        ad.obj = &o;
-        adp = lh_ADDED_OBJ_retrieve(added, &ad);
-        if (adp != NULL)
-            nid = adp->obj->nid;
-    }
+    ad.type = ADDED_SNAME;
+    ad.obj = &o;
+    adp = lh_ADDED_OBJ_retrieve(added, &ad);
+    if (adp != NULL)
+        nid = adp->obj->nid;
     ossl_obj_unlock(1);
     return nid;
 }

--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -299,7 +299,7 @@ static int obj_cmp(const ASN1_OBJECT *const *ap, const unsigned int *bp)
 
 IMPLEMENT_OBJ_BSEARCH_CMP_FN(const ASN1_OBJECT *, unsigned int, obj);
 
-static int ossl_obj_obj2nid(const ASN1_OBJECT *a, const int lock)
+static int ossl_obj_obj2nid(const ASN1_OBJECT *a)
 {
     int nid = NID_undef;
     const unsigned int *op;
@@ -315,7 +315,7 @@ static int ossl_obj_obj2nid(const ASN1_OBJECT *a, const int lock)
     op = OBJ_bsearch_obj(&a, obj_objs, NUM_OBJ);
     if (op != NULL)
         return nid_objs[*op].nid;
-    if (!ossl_obj_read_lock(lock)) {
+    if (!ossl_obj_read_lock(1)) {
         ERR_raise(ERR_LIB_OBJ, ERR_R_UNABLE_TO_GET_READ_LOCK);
         return NID_undef;
     }
@@ -324,7 +324,7 @@ static int ossl_obj_obj2nid(const ASN1_OBJECT *a, const int lock)
     adp = lh_ADDED_OBJ_retrieve(added, &ad);
     if (adp != NULL)
         nid = adp->obj->nid;
-    ossl_obj_unlock(lock);
+    ossl_obj_unlock(1);
     return nid;
 }
 
@@ -720,7 +720,7 @@ int OBJ_create(const char *oid, const char *sn, const char *ln)
 
     /* If NID is not NID_undef then object already exists */
     if (oid != NULL
-        && ossl_obj_obj2nid(tmpoid, 1) != NID_undef) {
+        && ossl_obj_obj2nid(tmpoid) != NID_undef) {
         ERR_raise(ERR_LIB_OBJ, OBJ_R_OID_EXISTS);
         goto err;
     }
@@ -819,5 +819,5 @@ int OBJ_add_object(const ASN1_OBJECT *obj)
 
 int OBJ_obj2nid(const ASN1_OBJECT *a)
 {
-    return ossl_obj_obj2nid(a, 1);
+    return ossl_obj_obj2nid(a);
 }


### PR DESCRIPTION
The ADDED_OBJ hash table holds a write lock very early in the OBJ_create path, and doing so is not needed.  The write lock is held to prevent multiple  parallel additions while the table is:

1) Checked for the existance of an object named by an oid
2) A New object is created for the addition
3) Checked again for the existance of the specified oid in ossl_obj_add_object
4) Finally Added

Step 1 is redundant clearly, and so the critical section can be reduced to the point in ossl_obj_add_object where we do a hashtable lookup followed by a hash table insert.

We can additionally reduce time spent in the critical section by moving the check, and potential allocation of the table to a RUN_ONCE routine, so table creation is handled outside of the write lock.

Preforming this refactoring results in the following comparative performance graph of our handshake test:

<img width="664" height="605" alt="Screenshot From 2025-07-23 17-40-56" src="https://github.com/user-attachments/assets/764e30f8-7a81-4d7a-a02c-89ef4427ba1e" />


Providing a 1%-3.5% decrease in the number of usecs it takes to complete a handshake.