### PR TITLE
ML-DSA: Validate signature length before decoding

### DIFF
--- a/crypto/ml_dsa/ml_dsa_sign.c
+++ b/crypto/ml_dsa/ml_dsa_sign.c
@@ -371,9 +371,8 @@ static int ml_dsa_verify_internal(const ML_DSA_KEY *pub,
     vector_init(&ct1_ntt, p + k, k);
 
     /* FIPS 204 compliance: Validate signature length before decoding */
-    if (sig_enc_len != params->sig_len) {
+    if (sig_enc_len != params->sig_len)
         goto err;
-    }
 
     if (!ossl_ml_dsa_sig_decode(&sig, sig_enc, sig_enc_len, pub->params)
             || !matrix_expand_A(md_ctx, pub->shake128_md, pub->rho, &a_ntt))


### PR DESCRIPTION
Page 27 of https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf mentions the Input: Signature length depending on the parameters, so the signature length should be checked before we proceed with decode.