### PR TITLE
ML-KEM: add FIPS 203 encap and decap input checks

### DIFF
--- a/crypto/ml_kem/ml_kem.c
+++ b/crypto/ml_kem/ml_kem.c
@@ -1986,6 +1986,7 @@ int ossl_ml_kem_encap_seed(uint8_t *ctext, size_t clen,
     return ret;
 }
 
+#ifdef FIPS_MODULE
 /*
  * FIPS 203, Section 7.2: Input validation for ML-KEM.Encaps
  * Performs type check and modulus check on the encapsulation key.
@@ -2009,9 +2010,8 @@ static int validate_encapsulation_key(const ML_KEM_KEY *key)
     /* Type check: Ensure the key is a valid ML-KEM variant */
     if (vinfo->evp_type != EVP_PKEY_ML_KEM_512 &&
         vinfo->evp_type != EVP_PKEY_ML_KEM_768 &&
-        vinfo->evp_type != EVP_PKEY_ML_KEM_1024) {
+        vinfo->evp_type != EVP_PKEY_ML_KEM_1024)
         return 0;
-    }
 
     /* Modulus check: test <- ByteEncode12(ByteDecode12(ek[0 : 384k])) */
     vector_bytes_384k = 384 * vinfo->rank;
@@ -2045,6 +2045,7 @@ cleanup:
     OPENSSL_free(decoded_t);
     return ret;
 }
+#endif /* FIPS_MODULE */
 
 int ossl_ml_kem_encap_rand(uint8_t *ctext, size_t clen,
                            uint8_t *shared_secret, size_t slen,
@@ -2069,6 +2070,7 @@ int ossl_ml_kem_encap_rand(uint8_t *ctext, size_t clen,
                                   r, sizeof(r), key);
 }
 
+#ifdef FIPS_MODULE
 /*
  * FIPS 203, Section 7.3: Input validation for ML-KEM.Decaps
  * Performs ciphertext type check, decapsulation key type check, and hash check.
@@ -2096,9 +2098,8 @@ static int validate_decapsulation_inputs(const uint8_t *ctext, size_t clen,
     /* Decapsulation key type check */
     if (vinfo->evp_type != EVP_PKEY_ML_KEM_512 &&
         vinfo->evp_type != EVP_PKEY_ML_KEM_768 &&
-        vinfo->evp_type != EVP_PKEY_ML_KEM_1024) {
+        vinfo->evp_type != EVP_PKEY_ML_KEM_1024)
         return 0;
-    }
 
     /* Hash check: test <- H(dk[384k : 768k + 32]) vs dk[768k+32 : 768k+64] */
     prvkey_enc = OPENSSL_malloc(vinfo->prvkey_bytes);
@@ -2129,6 +2130,7 @@ cleanup:
     OPENSSL_clear_free(prvkey_enc, vinfo->prvkey_bytes);
     return ret;
 }
+#endif /* FIPS_MODULE */
 
 int ossl_ml_kem_decap(uint8_t *shared_secret, size_t slen,
                       const uint8_t *ctext, size_t clen,

--- a/crypto/ml_kem/ml_kem.c
+++ b/crypto/ml_kem/ml_kem.c
@@ -1986,6 +1986,66 @@ int ossl_ml_kem_encap_seed(uint8_t *ctext, size_t clen,
     return ret;
 }
 
+/*
+ * FIPS 203, Section 7.2: Input validation for ML-KEM.Encaps
+ * Performs type check and modulus check on the encapsulation key.
+ */
+static int validate_encapsulation_key(const ML_KEM_KEY *key)
+{
+    uint8_t *pubkey_enc = NULL;
+    uint8_t *test_buf = NULL;
+    scalar *decoded_t = NULL;
+    size_t vector_bytes_384k;
+    const ML_KEM_VINFO *vinfo;
+    int ret = 0;
+
+    if (key == NULL)
+        return 0;
+
+    vinfo = key->vinfo;
+    if (vinfo == NULL)
+        return 0;
+
+    /* Type check: Ensure the key is a valid ML-KEM variant */
+    if (vinfo->evp_type != EVP_PKEY_ML_KEM_512 &&
+        vinfo->evp_type != EVP_PKEY_ML_KEM_768 &&
+        vinfo->evp_type != EVP_PKEY_ML_KEM_1024) {
+        return 0;
+    }
+
+    /* Modulus check: test <- ByteEncode12(ByteDecode12(ek[0 : 384k])) */
+    vector_bytes_384k = 384 * vinfo->rank;
+
+    pubkey_enc = OPENSSL_malloc(vinfo->pubkey_bytes);
+    test_buf = OPENSSL_malloc(vector_bytes_384k);
+    decoded_t = OPENSSL_malloc(vinfo->rank * sizeof(scalar));
+
+    if (pubkey_enc == NULL || test_buf == NULL || decoded_t == NULL)
+        goto cleanup;
+
+    /* Get the encoded public key */
+    if (!ossl_ml_kem_encode_public_key(pubkey_enc, vinfo->pubkey_bytes, key))
+        goto cleanup;
+
+    /* Decode the first 384*k bytes and re-encode them */
+    if (!vector_decode_12(decoded_t, pubkey_enc, vinfo->rank))
+        goto cleanup;
+
+    vector_encode(test_buf, decoded_t, 12, vinfo->rank);
+
+    /* Compare the re-encoded bytes with the original */
+    if (memcmp(test_buf, pubkey_enc, vector_bytes_384k) != 0)
+        goto cleanup;
+
+    ret = 1;
+
+cleanup:
+    OPENSSL_free(pubkey_enc);
+    OPENSSL_free(test_buf);
+    OPENSSL_free(decoded_t);
+    return ret;
+}
+
 int ossl_ml_kem_encap_rand(uint8_t *ctext, size_t clen,
                            uint8_t *shared_secret, size_t slen,
                            const ML_KEM_KEY *key)
@@ -1995,12 +2055,79 @@ int ossl_ml_kem_encap_rand(uint8_t *ctext, size_t clen,
     if (key == NULL)
         return 0;
 
+#ifdef FIPS_MODULE
+    /* FIPS 203, Section 7.2: Validate encapsulation key */
+    if (!validate_encapsulation_key(key))
+        return 0;
+#endif /* FIPS_MODULE */
+
     if (RAND_bytes_ex(key->libctx, r, ML_KEM_RANDOM_BYTES,
                       key->vinfo->secbits) < 1)
         return 0;
 
     return ossl_ml_kem_encap_seed(ctext, clen, shared_secret, slen,
                                   r, sizeof(r), key);
+}
+
+/*
+ * FIPS 203, Section 7.3: Input validation for ML-KEM.Decaps
+ * Performs ciphertext type check, decapsulation key type check, and hash check.
+ */
+static int validate_decapsulation_inputs(const uint8_t *ctext, size_t clen,
+                                         const ML_KEM_KEY *key, EVP_MD_CTX *mdctx)
+{
+    uint8_t *prvkey_enc = NULL;
+    uint8_t computed_hash[ML_KEM_PKHASH_BYTES];
+    const ML_KEM_VINFO *vinfo;
+    const uint8_t *pubkey_start, *stored_hash;
+    int ret = 0;
+
+    if (key == NULL || ctext == NULL || mdctx == NULL)
+        return 0;
+
+    vinfo = key->vinfo;
+    if (vinfo == NULL)
+        return 0;
+
+    /* Ciphertext type check */
+    if (clen != vinfo->ctext_bytes)
+        return 0;
+
+    /* Decapsulation key type check */
+    if (vinfo->evp_type != EVP_PKEY_ML_KEM_512 &&
+        vinfo->evp_type != EVP_PKEY_ML_KEM_768 &&
+        vinfo->evp_type != EVP_PKEY_ML_KEM_1024) {
+        return 0;
+    }
+
+    /* Hash check: test <- H(dk[384k : 768k + 32]) vs dk[768k+32 : 768k+64] */
+    prvkey_enc = OPENSSL_malloc(vinfo->prvkey_bytes);
+    if (prvkey_enc == NULL)
+        goto cleanup;
+
+    /* Get the encoded private key */
+    if (!ossl_ml_kem_encode_private_key(prvkey_enc, vinfo->prvkey_bytes, key))
+        goto cleanup;
+
+    /* Extract public key portion: dk[384k : 768k + 32] */
+    pubkey_start = prvkey_enc + vinfo->vector_bytes;
+
+    /* Extract stored hash: dk[768k+32 : 768k+64] */
+    stored_hash = prvkey_enc + vinfo->vector_bytes + vinfo->pubkey_bytes;
+
+    /* Compute hash of public key portion */
+    if (!hash_h(computed_hash, pubkey_start, vinfo->pubkey_bytes, mdctx, key))
+        goto cleanup;
+
+    /* Compare computed hash with stored hash */
+    if (memcmp(computed_hash, stored_hash, ML_KEM_PKHASH_BYTES) != 0)
+        goto cleanup;
+
+    ret = 1;
+
+cleanup:
+    OPENSSL_clear_free(prvkey_enc, vinfo->prvkey_bytes);
+    return ret;
 }
 
 int ossl_ml_kem_decap(uint8_t *shared_secret, size_t slen,
@@ -2026,6 +2153,17 @@ int ossl_ml_kem_decap(uint8_t *shared_secret, size_t slen,
                             ML_KEM_SHARED_SECRET_BYTES, vinfo->secbits);
         return 0;
     }
+
+#ifdef FIPS_MODULE
+    /* FIPS 203, Section 7.3: Validate decapsulation inputs */
+    if (!validate_decapsulation_inputs(ctext, clen, key, mdctx)) {
+        (void)RAND_bytes_ex(key->libctx, shared_secret,
+                            ML_KEM_SHARED_SECRET_BYTES, vinfo->secbits);
+        EVP_MD_CTX_free(mdctx);
+        return 0;
+    }
+#endif /* FIPS_MODULE */
+
 #if defined(OPENSSL_CONSTANT_TIME_VALIDATION)
     /*
      * Data derived from |s| and |z| defaults secret, and to avoid side-channel

--- a/test/ml_kem_internal_test.c
+++ b/test/ml_kem_internal_test.c
@@ -258,6 +258,7 @@ static int sanity_test(void)
     return ret == 0;
 }
 
+#ifdef FIPS_MODULE
 /* Test FIPS 203 input validation - encap should fail with corrupted public key */
 static int test_encap_validation_failure(void)
 {
@@ -320,8 +321,10 @@ static int test_encap_validation_failure(void)
         goto cleanup;
 
     /* Corrupt the encoded public key to break modulus check */
-    /* We need to corrupt it in a way that passes parsing but fails ByteEncode12(ByteDecode12()) validation */
-    /* Corrupt a few bytes in the t vector portion to create invalid coefficients */
+    /*
+     * We need to corrupt it in a way that passes parsing but fails ByteEncode12(ByteDecode12())
+     * validation. Corrupt a few bytes in the t vector portion to create invalid coefficients
+     */
     encoded_public_key[10] = 0xFF;  /* Make some coefficients > 2^12 */
     encoded_public_key[11] = 0xFF;
     encoded_public_key[12] = 0xFF;
@@ -341,8 +344,8 @@ static int test_encap_validation_failure(void)
 
     /* Encap should fail due to FIPS 203 modulus validation */
     if (!TEST_false(ossl_ml_kem_encap_rand(ciphertext, v->ctext_bytes,
-                                          shared_secret, sizeof(shared_secret),
-                                          public_key)))
+                                           shared_secret, sizeof(shared_secret),
+                                           public_key)))
         goto cleanup;
 
     ret = 1;
@@ -418,8 +421,8 @@ static int test_decap_validation_failure(void)
 
     /* Generate a valid ciphertext first */
     if (!TEST_true(ossl_ml_kem_encap_rand(ciphertext, v->ctext_bytes,
-                                         shared_secret, sizeof(shared_secret),
-                                         key)))
+                                          shared_secret, sizeof(shared_secret),
+                                          key)))
         goto cleanup;
 
     /* Corrupt the stored hash in the key to break hash validation */
@@ -430,8 +433,8 @@ static int test_decap_validation_failure(void)
 
     /* Decap should fail due to FIPS 203 hash validation */
     if (!TEST_false(ossl_ml_kem_decap(shared_secret, sizeof(shared_secret),
-                                     ciphertext, v->ctext_bytes,
-                                     key)))
+                                      ciphertext, v->ctext_bytes,
+                                      key)))
         goto cleanup;
 
     ret = 1;
@@ -443,6 +446,7 @@ cleanup:
     ossl_ml_kem_key_free(key);
     return ret;
 }
+#endif /* FIPS_MODULE */
 
 int setup_tests(void)
 {

--- a/test/ml_kem_internal_test.c
+++ b/test/ml_kem_internal_test.c
@@ -258,11 +258,201 @@ static int sanity_test(void)
     return ret == 0;
 }
 
+/* Test FIPS 203 input validation - encap should fail with corrupted public key */
+static int test_encap_validation_failure(void)
+{
+    ML_KEM_KEY *private_key = NULL;
+    ML_KEM_KEY *public_key = NULL;
+    uint8_t *encoded_public_key = NULL;
+    uint8_t *ciphertext = NULL;
+    uint8_t shared_secret[ML_KEM_SHARED_SECRET_BYTES];
+    const ML_KEM_VINFO *v;
+    EVP_RAND_CTX *privctx;
+    OSSL_PARAM params[3];
+    unsigned int strength = 256;
+    int ret = 0;
+
+    /* Set up entropy for key generation */
+    if (!TEST_ptr(privctx = RAND_get0_private(NULL)))
+        return 0;
+
+    params[0] = OSSL_PARAM_construct_octet_string(OSSL_RAND_PARAM_TEST_ENTROPY,
+                                                  ml_kem_private_entropy,
+                                                  sizeof(ml_kem_private_entropy));
+    params[1] = OSSL_PARAM_construct_uint(OSSL_RAND_PARAM_STRENGTH, &strength);
+    params[2] = OSSL_PARAM_construct_end();
+    if (!TEST_true(EVP_RAND_CTX_set_params(privctx, params)))
+        return 0;
+
+    /* Create ML-KEM-768 keys */
+    public_key = ossl_ml_kem_key_new(NULL, NULL, EVP_PKEY_ML_KEM_768);
+    private_key = ossl_ml_kem_key_new(NULL, NULL, EVP_PKEY_ML_KEM_768);
+    if (!TEST_ptr(private_key) || !TEST_ptr(public_key))
+        return 0;
+
+    v = ossl_ml_kem_key_vinfo(public_key);
+    if (!TEST_ptr(v))
+        goto cleanup;
+
+    encoded_public_key = OPENSSL_malloc(v->pubkey_bytes);
+    ciphertext = OPENSSL_malloc(v->ctext_bytes);
+    if (!TEST_ptr(encoded_public_key) || !TEST_ptr(ciphertext))
+        goto cleanup;
+
+    /* Generate a valid key pair */
+    if (!TEST_true(ossl_ml_kem_genkey(encoded_public_key, v->pubkey_bytes, private_key)))
+        goto cleanup;
+
+    /* Set up public entropy for encap operations */
+    EVP_RAND_CTX *pubctx;
+    if (!TEST_ptr(pubctx = RAND_get0_public(NULL)))
+        goto cleanup;
+
+    params[0] = OSSL_PARAM_construct_octet_string(OSSL_RAND_PARAM_TEST_ENTROPY,
+                                                  ml_kem_public_entropy,
+                                                  sizeof(ml_kem_public_entropy));
+    params[1] = OSSL_PARAM_construct_uint(OSSL_RAND_PARAM_STRENGTH, &strength);
+    params[2] = OSSL_PARAM_construct_end();
+    if (!TEST_true(EVP_RAND_CTX_set_params(pubctx, params)))
+        goto cleanup;
+
+    if (!TEST_true(ossl_ml_kem_parse_public_key(encoded_public_key, v->pubkey_bytes, public_key)))
+        goto cleanup;
+
+    /* Corrupt the encoded public key to break modulus check */
+    /* We need to corrupt it in a way that passes parsing but fails ByteEncode12(ByteDecode12()) validation */
+    /* Corrupt a few bytes in the t vector portion to create invalid coefficients */
+    encoded_public_key[10] = 0xFF;  /* Make some coefficients > 2^12 */
+    encoded_public_key[11] = 0xFF;
+    encoded_public_key[12] = 0xFF;
+
+    /* Re-parse the corrupted public key - this should succeed in parsing */
+    ossl_ml_kem_key_reset(public_key);
+    public_key = ossl_ml_kem_key_new(NULL, NULL, EVP_PKEY_ML_KEM_768);
+    if (!TEST_ptr(public_key))
+        goto cleanup;
+
+    /* Parse should succeed but create invalid internal state */
+    if (!ossl_ml_kem_parse_public_key(encoded_public_key, v->pubkey_bytes, public_key)) {
+        /* If parsing fails, skip the validation test */
+        ret = 1;
+        goto cleanup;
+    }
+
+    /* Encap should fail due to FIPS 203 modulus validation */
+    if (!TEST_false(ossl_ml_kem_encap_rand(ciphertext, v->ctext_bytes,
+                                          shared_secret, sizeof(shared_secret),
+                                          public_key)))
+        goto cleanup;
+
+    ret = 1;
+
+cleanup:
+    OPENSSL_free(encoded_public_key);
+    OPENSSL_free(ciphertext);
+    ossl_ml_kem_key_free(private_key);
+    ossl_ml_kem_key_free(public_key);
+    return ret;
+}
+
+/* Test FIPS 203 input validation - decap should fail with corrupted private key */
+static int test_decap_validation_failure(void)
+{
+    ML_KEM_KEY *key = NULL;
+    uint8_t *encoded_public_key = NULL;
+    uint8_t *encoded_private_key = NULL;
+    uint8_t *ciphertext = NULL;
+    uint8_t shared_secret[ML_KEM_SHARED_SECRET_BYTES];
+    const ML_KEM_VINFO *v;
+    EVP_RAND_CTX *privctx;
+    OSSL_PARAM params[3];
+    unsigned int strength = 256;
+    int ret = 0;
+
+    /* Set up entropy for key generation */
+    if (!TEST_ptr(privctx = RAND_get0_private(NULL)))
+        return 0;
+
+    params[0] = OSSL_PARAM_construct_octet_string(OSSL_RAND_PARAM_TEST_ENTROPY,
+                                                  ml_kem_private_entropy,
+                                                  sizeof(ml_kem_private_entropy));
+    params[1] = OSSL_PARAM_construct_uint(OSSL_RAND_PARAM_STRENGTH, &strength);
+    params[2] = OSSL_PARAM_construct_end();
+    if (!TEST_true(EVP_RAND_CTX_set_params(privctx, params)))
+        return 0;
+
+    /* Create a ML-KEM-768 key */
+    key = ossl_ml_kem_key_new(NULL, NULL, EVP_PKEY_ML_KEM_768);
+    if (!TEST_ptr(key))
+        return 0;
+
+    v = ossl_ml_kem_key_vinfo(key);
+    if (!TEST_ptr(v))
+        goto cleanup;
+
+    encoded_public_key = OPENSSL_malloc(v->pubkey_bytes);
+    encoded_private_key = OPENSSL_malloc(v->prvkey_bytes);
+    ciphertext = OPENSSL_malloc(v->ctext_bytes);
+    if (!TEST_ptr(encoded_public_key) || !TEST_ptr(encoded_private_key) || !TEST_ptr(ciphertext))
+        goto cleanup;
+
+    /* Generate a valid key pair */
+    if (!TEST_true(ossl_ml_kem_genkey(encoded_public_key, v->pubkey_bytes, key)))
+        goto cleanup;
+
+    if (!TEST_true(ossl_ml_kem_encode_private_key(encoded_private_key, v->prvkey_bytes, key)))
+        goto cleanup;
+
+    /* Set up entropy for encap operation */
+    EVP_RAND_CTX *pubctx;
+    if (!TEST_ptr(pubctx = RAND_get0_public(NULL)))
+        goto cleanup;
+
+    params[0] = OSSL_PARAM_construct_octet_string(OSSL_RAND_PARAM_TEST_ENTROPY,
+                                                  ml_kem_public_entropy,
+                                                  sizeof(ml_kem_public_entropy));
+    params[1] = OSSL_PARAM_construct_uint(OSSL_RAND_PARAM_STRENGTH, &strength);
+    params[2] = OSSL_PARAM_construct_end();
+    if (!TEST_true(EVP_RAND_CTX_set_params(pubctx, params)))
+        goto cleanup;
+
+    /* Generate a valid ciphertext first */
+    if (!TEST_true(ossl_ml_kem_encap_rand(ciphertext, v->ctext_bytes,
+                                         shared_secret, sizeof(shared_secret),
+                                         key)))
+        goto cleanup;
+
+    /* Corrupt the stored hash in the key to break hash validation */
+    /* This bypasses parsing and directly tests the validation */
+    if (key->pkhash != NULL) {
+        key->pkhash[0] ^= 0xFF; /* Corrupt the first byte of the hash */
+    }
+
+    /* Decap should fail due to FIPS 203 hash validation */
+    if (!TEST_false(ossl_ml_kem_decap(shared_secret, sizeof(shared_secret),
+                                     ciphertext, v->ctext_bytes,
+                                     key)))
+        goto cleanup;
+
+    ret = 1;
+
+cleanup:
+    OPENSSL_free(encoded_public_key);
+    OPENSSL_free(encoded_private_key);
+    OPENSSL_free(ciphertext);
+    ossl_ml_kem_key_free(key);
+    return ret;
+}
+
 int setup_tests(void)
 {
     if (!TEST_true(RAND_set_DRBG_type(NULL, "TEST-RAND", "fips=no", NULL, NULL)))
         return 0;
 
     ADD_TEST(sanity_test);
+#ifdef FIPS_MODULE
+    ADD_TEST(test_encap_validation_failure);
+    ADD_TEST(test_decap_validation_failure);
+#endif /* FIPS_MODULE */
     return 1;
 }


### PR DESCRIPTION
FIPS 203 Sections 7.2 and 7.3 mandate various input/key checks for both encapsulation and decapsulation. This includes type check and modulus check for encap and ciphertext type check, key type check and hash check for decap. Both operations will fail if any of the checks fails.

Add a test case that at least tests if the modulus and hash checks work.

Source: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
