### PR TITLE
ML-KEM, ML-DSA: further sanitize some variables

### DIFF
--- a/crypto/ml_kem/ml_kem.c
+++ b/crypto/ml_kem/ml_kem.c
@@ -1532,7 +1532,9 @@ int decap(uint8_t secret[ML_KEM_SHARED_SECRET_BYTES],
         secret[i] = constant_time_select_8(mask, Kr[i], failure_key[i]);
     OPENSSL_cleanse(decrypted, ML_KEM_SHARED_SECRET_BYTES);
     OPENSSL_cleanse(Kr, sizeof(Kr));
+#ifdef OPENSSL_PEDANTIC_ZEROIZATION
     OPENSSL_cleanse(&mask, sizeof(mask));
+#endif
     return 1;
 }
 

--- a/providers/implementations/keymgmt/ml_dsa_kmgmt.c.in
+++ b/providers/implementations/keymgmt/ml_dsa_kmgmt.c.in
@@ -465,7 +465,11 @@ static void *ml_dsa_gen_init(void *provctx, int selection,
     if ((gctx = OPENSSL_zalloc(sizeof(*gctx))) != NULL) {
         gctx->provctx = provctx;
         if (!ml_dsa_gen_set_params(gctx, params)) {
-            OPENSSL_secure_clear_free(gctx, sizeof(*gctx));
+#ifdef OPENSSL_PEDANTIC_ZEROIZATION
+            OPENSSL_clear_free(gctx, sizeof(*gctx));
+#else
+            OPENSSL_free(gctx)
+#endif
             gctx = NULL;
         }
     }


### PR DESCRIPTION
Those seem to be also good to zeroize throughout the code.