### PR TITLE
crypto: evp: fix potential null pointer dereference in EVP_DigestSign in m_sigver.c

### DIFF
--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -434,6 +434,10 @@ int EVP_DigestSignUpdate(EVP_MD_CTX *ctx, const void *data, size_t dsize)
 
  legacy:
     if (pctx != NULL) {
+        if (pctx->pmeth == NULL) {
+            ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
+            return 0;
+        }
         /* do_sigver_init() checked that |digest_custom| is non-NULL */
         if (pctx->flag_call_digest_custom
             && !ctx->pctx->pmeth->digest_custom(ctx->pctx, ctx))


### PR DESCRIPTION


A static analysis tool detected a potential null pointer dereference in EVP_DigestSign() function. The issue occurs when sigret is not NULL, but pctx->pmeth is NULL, leading to a crash in EVP_DigestSignUpdate().

This fix adds a proper check for pctx->pmeth != NULL before calling EVP_DigestSignUpdate() and EVP_DigestSignFinal() to prevent the null pointer dereference.

Fixes potential crash in signature operations with improperly initialized context.

CLA: trivial
Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->


