### PR TITLE
Reduce locking contention in ossl_prov_drbg_generate

### DIFF
--- a/providers/implementations/rands/drbg_local.h
+++ b/providers/implementations/rands/drbg_local.h
@@ -82,15 +82,6 @@ struct prov_drbg_st {
     OSSL_FUNC_rand_clear_seed_fn *parent_clear_seed;
 
     /*
-     * Stores the return value of openssl_get_fork_id() as of when we last
-     * reseeded.  The DRBG reseeds automatically whenever drbg->fork_id !=
-     * openssl_get_fork_id().  Used to provide fork-safety and reseed this
-     * DRBG in the child process.
-     */
-    int fork_id;
-    unsigned short flags; /* various external flags */
-
-    /*
      * The following parameters are setup by the per-type "init" function.
      *
      * The supported types and their init functions are:
@@ -110,11 +101,11 @@ struct prov_drbg_st {
      * clarification.
      */
 
-    unsigned int strength;
     size_t max_request;
     size_t min_entropylen, max_entropylen;
     size_t min_noncelen, max_noncelen;
     size_t max_perslen, max_adinlen;
+    unsigned int strength;
 
     /*
      * Counts the number of generate requests since the last reseed
@@ -127,6 +118,15 @@ struct prov_drbg_st {
      * This value is ignored if it is zero.
      */
     unsigned int reseed_interval;
+
+    /*
+     * Stores the return value of openssl_get_fork_id() as of when we last
+     * reseeded.  The DRBG reseeds automatically whenever drbg->fork_id !=
+     * openssl_get_fork_id().  Used to provide fork-safety and reseed this
+     * DRBG in the child process.
+     */
+    int fork_id;
+
     /* Stores the time when the last reseeding occurred */
     time_t reseed_time;
     /*
@@ -148,8 +148,8 @@ struct prov_drbg_st {
     unsigned int reseed_next_counter;
     unsigned int parent_reseed_counter;
 
-    size_t seedlen;
     DRBG_STATUS state;
+    size_t seedlen;
 
     /* DRBG specific data */
     void *data;
@@ -160,6 +160,8 @@ struct prov_drbg_st {
     OSSL_CALLBACK *cleanup_entropy_fn;
     OSSL_INOUT_CALLBACK *get_nonce_fn;
     OSSL_CALLBACK *cleanup_nonce_fn;
+
+    unsigned short flags; /* various external flags */
 
     OSSL_FIPS_IND_DECLARE
 };


### PR DESCRIPTION
In investigating possible lock contention improvements, significant contention was found in  ossl_prov_drbg_generate.

using the randbytes test:
```
Total latency 120471 usec, count 4 (avg 30117.750000 usec)

/home/nhorman/git/worktrees/work1/libcrypto.so.3(CRYPTO_THREAD_write_lock+0x104) [0x7f427a5c85bf]
/home/nhorman/git/worktrees/work1/libcrypto.so.3(+0x2b5a5f) [0x7f427a6b5a5f]
/home/nhorman/git/worktrees/work1/libcrypto.so.3(+0x16faa7) [0x7f427a56faa7]
/home/nhorman/git/worktrees/work1/libcrypto.so.3(+0x1ace54) [0x7f427a5ace54]
/home/nhorman/git/worktrees/work1/libcrypto.so.3(+0x1ac99d) [0x7f427a5ac99d]
/home/nhorman/git/worktrees/work1/libcrypto.so.3(+0x1acb52) [0x7f427a5acb52]
/home/nhorman/git/worktrees/work1/libcrypto.so.3(+0x1acc91) [0x7f427a5acc91]
/home/nhorman/git/worktrees/work1/libcrypto.so.3(+0x1ad171) [0x7f427a5ad171]
/home/nhorman/git/worktrees/work1/libcrypto.so.3(+0x1701c2) [0x7f427a5701c2]
/home/nhorman/git/worktrees/work1/libcrypto.so.3(+0x170494) [0x7f427a570494]
/home/nhorman/git/worktrees/work1/libcrypto.so.3(+0x16f799) [0x7f427a56f799]
/home/nhorman/git/worktrees/work1/libcrypto.so.3(+0x3f351f) [0x7f427a7f351f]
/home/nhorman/git/worktrees/work1/libcrypto.so.3(+0x3f2439) [0x7f427a7f2439]
/home/nhorman/git/worktrees/work1/libcrypto.so.3(+0x177534) [0x7f427a577534]
/home/nhorman/git/worktrees/work1/libcrypto.so.3(EVP_RAND_instantiate+0x59) [0x7f427a57758f]
/home/nhorman/git/worktrees/work1/libcrypto.so.3(+0x2bb9ed) [0x7f427a6bb9ed]
/home/nhorman/git/worktrees/work1/libcrypto.so.3(+0x2bbb07) [0x7f427a6bbb07]
/home/nhorman/git/worktrees/work1/libcrypto.so.3(+0x2bbcd1) [0x7f427a6bbcd1]
/home/nhorman/git/worktrees/work1/libcrypto.so.3(RAND_bytes_ex+0x15b) [0x7f427a6baebf]
/home/nhorman/git/worktrees/work1/libcrypto.so.3(RAND_bytes+0x38) [0x7f427a6baf38]
./randbytes() [0x40079d]
./randbytes() [0x4008ad]
/lib64/libc.so.6(+0x711d4) [0x7f427a27f1d4]
/lib64/libc.so.6(+0xf3cec) [0x7f427a301cec]
```

So we have 120471 usecs of delay due to the write lock in this function.

However, the write lock is held much longer than needed, as it is taken initially to check its need for, and handling of a restart, after which several conditions are checked to trigger a subsequent reseed.

Given that the restart operation is already handled by the ossl_prov_drbg_reseed_unlocked function, which does the reseeding, that restart check is redundant and can be removed, which allows us to then convert the write lock to a read lock, and upgrade to a write lock for a much smaller critical section, which is what this PR does.

The resulting changes reduce this locks contention profile in the randbytes test as follows:
```
Total latency 34423 usec, count 2 (avg 17211.500000 usec)

/home/nhorman/git/openssl/libcrypto.so.3(CRYPTO_THREAD_write_lock+0x104) [0x7fc9629c85bf]
/home/nhorman/git/openssl/libcrypto.so.3(+0x2b5a5f) [0x7fc962ab5a5f]
/home/nhorman/git/openssl/libcrypto.so.3(+0x16faa7) [0x7fc96296faa7]
/home/nhorman/git/openssl/libcrypto.so.3(+0x1ace54) [0x7fc9629ace54]
/home/nhorman/git/openssl/libcrypto.so.3(+0x1ac99d) [0x7fc9629ac99d]
/home/nhorman/git/openssl/libcrypto.so.3(+0x1acb52) [0x7fc9629acb52]
/home/nhorman/git/openssl/libcrypto.so.3(+0x1acc91) [0x7fc9629acc91]
/home/nhorman/git/openssl/libcrypto.so.3(+0x1ad171) [0x7fc9629ad171]
/home/nhorman/git/openssl/libcrypto.so.3(+0x1701c2) [0x7fc9629701c2]
/home/nhorman/git/openssl/libcrypto.so.3(+0x170494) [0x7fc962970494]
/home/nhorman/git/openssl/libcrypto.so.3(+0x16f799) [0x7fc96296f799]
/home/nhorman/git/openssl/libcrypto.so.3(+0x3f34cb) [0x7fc962bf34cb]
/home/nhorman/git/openssl/libcrypto.so.3(+0x3f23f4) [0x7fc962bf23f4]
/home/nhorman/git/openssl/libcrypto.so.3(+0x177534) [0x7fc962977534]
/home/nhorman/git/openssl/libcrypto.so.3(EVP_RAND_instantiate+0x59) [0x7fc96297758f]
/home/nhorman/git/openssl/libcrypto.so.3(+0x2bb9ed) [0x7fc962abb9ed]
/home/nhorman/git/openssl/libcrypto.so.3(+0x2bbb07) [0x7fc962abbb07]
/home/nhorman/git/openssl/libcrypto.so.3(+0x2bbcd1) [0x7fc962abbcd1]
/home/nhorman/git/openssl/libcrypto.so.3(RAND_bytes_ex+0x15b) [0x7fc962abaebf]
/home/nhorman/git/openssl/libcrypto.so.3(RAND_bytes+0x38) [0x7fc962abaf38]
./randbytes() [0x40079d]
./randbytes() [0x4008ad]
/lib64/libc.so.6(+0x711d4) [0x7fc96267f1d4]
/lib64/libc.so.6(+0xf3cec) [0x7fc962701cec]
```

so we save about 86048 usecs over the course of a 5 second test run