### PR TITLE
Pairwise check for EC keys import as part of FIPS

### DIFF
--- a/crypto/ec/ec_backend.c
+++ b/crypto/ec/ec_backend.c
@@ -486,6 +486,12 @@ int ossl_ec_key_fromdata(EC_KEY *ec, const OSSL_PARAM params[], int include_priv
         && !EC_KEY_set_public_key(ec, pub_point))
         goto err;
 
+#ifdef FIPS_MODULE
+    if (priv_key != NULL && pub_key != NULL)
+        if (ossl_ec_key_pairwise_check(ec, ctx) == 0)
+            goto err;
+#endif
+
     ok = 1;
 
  err:

--- a/providers/fips/self_test_kats.c
+++ b/providers/fips/self_test_kats.c
@@ -548,12 +548,6 @@ static int self_test_digest_sign(const ST_KAT_SIGN *t,
 
     OSSL_SELF_TEST_onbegin(st, typ, t->desc);
 
-    if (t->entropy != NULL) {
-        if (!set_kat_drbg(libctx, t->entropy, t->entropy_len,
-                          t->nonce, t->nonce_len, t->persstr, t->persstr_len))
-            goto err;
-    }
-
     paramskey = kat_params_to_ossl_params(libctx, t->key, NULL);
     paramsinit = kat_params_to_ossl_params(libctx, t->init, NULL);
     paramsverify = kat_params_to_ossl_params(libctx, t->verify, NULL);
@@ -576,6 +570,12 @@ static int self_test_digest_sign(const ST_KAT_SIGN *t,
         goto err;
 
     digested = ((t->mode & SIGNATURE_MODE_DIGESTED) != 0);
+
+    if (t->entropy != NULL) {
+        if (!set_kat_drbg(libctx, t->entropy, t->entropy_len,
+                          t->nonce, t->nonce_len, t->persstr, t->persstr_len))
+            goto err;
+    }
 
     if ((t->mode & SIGNATURE_MODE_VERIFY_ONLY) != 0) {
         siglen = t->sig_expected_len;


### PR DESCRIPTION
the self_test_digest_sig() test fails when EC PCT is enabled because ossl_ec_key_pairwise_check() consumes entropy when

  generator * priv_key = pub_key

is calculated in EC_POINT_mul().

  #0  RAND_priv_bytes_ex
  #1  bnrand
  #2  BN_priv_rand_ex
  #3  ec_GF2m_simple_ladder_pre
  #4  ec_point_ladder_pre
  #5  ossl_ec_scalar_mul_ladder
  #6  ec_GF2m_simple_points_mul
  #7  EC_POINT_mul
  #8  ossl_ec_key_pairwise_check

which led to the different signature than expected in the ecdsa_prime_expected_sig.

Moving set_kat_drbg() after the EVP_PKEY_fromdata() fixed the problem.

Fixes https://github.com/openssl/project/issues/1302
