### PR TITLE
Fix Hello Retry Request failure in QUIC

### DIFF
--- a/include/internal/quic_record_rx.h
+++ b/include/internal/quic_record_rx.h
@@ -168,6 +168,17 @@ int ossl_qrx_provide_secret(OSSL_QRX              *qrx,
                             size_t                 secret_len);
 
 /*
+ * Utility function to update the pn space from a src to a dst qrx.
+ * Occasionally we use a temporary qrx to do packet validation on quic frames
+ * that are not yet associated with a channel, and in the event a validation is
+ * successful AND we allocate a new qrx for the newly created channel, we need
+ * to migrate the largest_pn values recorded in the tmp qrx to the channel qrx.
+ * If we don't then PN decoding fails in cases where the initial PN is a large value.
+ * This function does that migration for us
+ */
+void ossl_qrx_update_pn_space(OSSL_QRX *src, OSSL_QRX *dst);
+
+/*
  * Informs the QRX that it can now discard key material for a given EL. The QRX
  * will no longer be able to process incoming packets received at that
  * encryption level. This function is idempotent and succeeds if the EL has

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -1331,8 +1331,20 @@ static int ch_on_transport_params(const unsigned char *params,
     ossl_unused uint64_t rx_max_idle_timeout = 0;
     ossl_unused const void *stateless_reset_token_p = NULL;
     QUIC_PREFERRED_ADDR pfa;
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(ch->tls);
 
-    if (ch->got_remote_transport_params) {
+    /*
+     * When HRR happens the client sends the transport params in the new client
+     * hello again. Reset the transport params here and load them again.
+     */
+    if (ch->is_server && sc->hello_retry_request != SSL_HRR_NONE
+        && ch->got_remote_transport_params) {
+        ch->max_local_streams_bidi = 0;
+        ch->max_local_streams_uni = 0;
+        ch->got_local_transport_params = 0;
+        OPENSSL_free(ch->local_transport_params);
+        ch->local_transport_params = NULL;
+    } else if (ch->got_remote_transport_params) {
         reason = "multiple transport parameter extensions";
         goto malformed;
     }

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -1694,6 +1694,7 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
          */
         while (ossl_qrx_read_pkt(qrx_src, &qrx_pkt) == 1)
             ossl_quic_channel_inject_pkt(new_ch, qrx_pkt);
+        ossl_qrx_update_pn_space(qrx_src, new_ch->qrx);
     }
 
     /*

--- a/ssl/quic/quic_record_rx.c
+++ b/ssl/quic/quic_record_rx.c
@@ -237,6 +237,16 @@ static void qrx_cleanup_urxl(OSSL_QRX *qrx, QUIC_URXE_LIST *l)
     }
 }
 
+void ossl_qrx_update_pn_space(OSSL_QRX *src, OSSL_QRX *dst)
+{
+    size_t i;
+
+    for (i = 0; i < QUIC_PN_SPACE_NUM; i++)
+        dst->largest_pn[i] = src->largest_pn[i];
+
+    return;
+}
+
 void ossl_qrx_free(OSSL_QRX *qrx)
 {
     uint32_t i;

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -3018,6 +3018,63 @@ static int test_accept_stream(void)
     return testresult;
 }
 
+/*
+ * When the server has a different primary group than the client, the server
+ * should not fail on the client hello retry.
+ */
+static int test_client_hello_retry(void)
+{
+#if !defined(OPENSSL_NO_EC) && !defined(OPENSSL_NO_ECX)
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL, *qlistener = NULL;
+    int testresult = 0, i = 0, ret = 0;
+
+    if (!TEST_ptr(sctx = create_server_ctx())
+        || !TEST_ptr(cctx = create_client_ctx()))
+        goto err;
+    /*
+     * set the specific groups for the test
+     */
+    if (!TEST_true(SSL_CTX_set1_groups_list(cctx, "secp384r1:secp256r1")))
+        goto err;
+    if (!TEST_true(SSL_CTX_set1_groups_list(sctx, "secp256r1")))
+        goto err;
+
+    if (!create_quic_ssl_objects(sctx, cctx, &qlistener, &clientssl))
+        goto err;
+
+    /* Send ClientHello and server retry */
+    for (i = 0; i < 2; i++) {
+        ret = SSL_connect(clientssl);
+        if (!TEST_int_le(ret, 0)
+            || !TEST_int_eq(SSL_get_error(clientssl, ret), SSL_ERROR_WANT_READ))
+            goto err;
+        SSL_handle_events(qlistener);
+    }
+
+    /* We expect a server SSL object which has not yet completed its handshake */
+    serverssl = SSL_accept_connection(qlistener, 0);
+
+    /* Call SSL_accept() and SSL_connect() until we are connected */
+    if (!TEST_true(create_bare_ssl_connection(serverssl, clientssl,
+                                              SSL_ERROR_NONE, 0, 0)))
+        goto err;
+
+    testresult = 1;
+
+err:
+    SSL_CTX_free(cctx);
+    SSL_CTX_free(sctx);
+    SSL_free(clientssl);
+    SSL_free(serverssl);
+    SSL_free(qlistener);
+
+    return testresult;
+#else
+    return TEST_skip("EC(X) keys are not supported in this build");
+#endif
+}
+
 /***********************************************************************************/
 OPT_TEST_DECLARE_USAGE("provider config certsdir datadir\n")
 
@@ -3120,6 +3177,7 @@ int setup_tests(void)
     ADD_TEST(test_ssl_accept_connection);
     ADD_TEST(test_ssl_set_verify);
     ADD_TEST(test_accept_stream);
+    ADD_TEST(test_client_hello_retry);
     return 1;
  err:
     cleanup_tests();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

When a HRR happens, the clients new hello message contains transport parameters extension which we currently handle with a fail. In this fix I went with the option to drop the first params and reread the new ones. I am not 100% sure if that's the correct way - and not keeping the params from the first client hello - so please correct me if that's wrong.

Unfortunately this does not solve the quic interop CI issue with ngtcp2.

Fixes: https://github.com/openssl/project/issues/1296

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
