### PR TITLE
Fix hanging of test_external_cf_quiche

### DIFF
--- a/test/recipes/95-test_external_cf_quiche_data/quiche-server.sh
+++ b/test/recipes/95-test_external_cf_quiche_data/quiche-server.sh
@@ -24,6 +24,6 @@ test -d "$QUICHE_TARGET_PATH" || exit 1
 
 "$QUICHE_TARGET_PATH/debug/quiche-server" --cert "$SRCTOP/test/certs/servercert.pem" \
     --key "$SRCTOP/test/certs/serverkey.pem" --disable-gso \
-    --http-version HTTP/0.9 --root "$SRCTOP" --no-grease --disable-hystart &
+    --http-version HTTP/0.9 --root "$SRCTOP" --no-grease --disable-hystart > quiche_server_log 2>&1 &
 
 echo $! >server.pid


### PR DESCRIPTION
The commit "Remove HARNESS_OSSL_PREFIX manipulation in the test harness" forced all the output to be processed by the test harness, which means that any process that keeps the stdout FD open prevents the run() call from finishing, as was the case in the test_external_cf_quiche test that ran quiche server in the background, but retaining the std{in,out,err} descriptors.  Avoid that by explicitly redirecting them to a log file.

Reported-by: Tomas Mraz <tomas@openssl.org>
Fixes: 70c05fcde53cf "Remove HARNESS_OSSL_PREFIX manipulation in the test harness"
