### PR TITLE
Update quictestlib.c

### DIFF
--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -24,7 +24,7 @@
 #include "internal/packet.h"
 #include "internal/tsan_assist.h"
 
-#define GROWTH_ALLOWANCE 1024
+#define GROWTH_ALLOWANCE 2048
 
 struct noise_args_data_st {
     BIO *cbio;
@@ -811,7 +811,7 @@ static int packet_plain_mutate(const QUIC_PKT_HDR *hdrin,
      * 14 long header (we assume token length is 0,
      * which is fine for server not so fine for client)
      */
-    grow_allowance = 1200 - (int)bufsz - 16 - 14;
+    grow_allowance = 2048 - (int)bufsz - 16 - 14;
     grow_allowance -= hdrin->dst_conn_id.id_len;
     grow_allowance -= hdrin->src_conn_id.id_len;
     assert(grow_allowance >= 0);


### PR DESCRIPTION
This change increases the buffer space available for growing QUIC packets during test faults or injections, preventing the assertion failure when a test requests a larger packet.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
