### PR TITLE
doc/man3/OPENSSL_malloc: clarify OPENSSL_clear_free() w/ NULL

### DIFF
--- a/doc/man3/OPENSSL_malloc.pod
+++ b/doc/man3/OPENSSL_malloc.pod
@@ -119,8 +119,8 @@ the returned pointer.
 OPENSSL_clear_realloc() and OPENSSL_clear_free() should be used
 when the buffer at B<addr> holds sensitive information.
 The old buffer is filled with zero's by calling OPENSSL_cleanse()
-before ultimately calling OPENSSL_free(). If the argument to OPENSSL_free() is
-NULL, nothing is done.
+before ultimately calling OPENSSL_free(). If the argument to
+OPENSSL_clear_free() is NULL, nothing is done.
 
 OPENSSL_cleanse() fills B<ptr> of size B<len> with a string of 0's.
 Use OPENSSL_cleanse() with care if the memory is a mapping of a file.


### PR DESCRIPTION
It wasn't explicitly clear that it was safe to call OPENSSL_clear_free() with a NULL because, as worded, it sounded like it may call OPENSSL_cleanse() on NULL before calling OPENSSL_free().

