### PR TITLE
doc/man3/SSL_CTX_set_domain_flags: fix version in HISTORY section

### DIFF
--- a/doc/man3/SSL_CTX_set_domain_flags.pod
+++ b/doc/man3/SSL_CTX_set_domain_flags.pod
@@ -106,7 +106,7 @@ L<SSL_new_domain(3)>, L<openssl-quic-concurrency(7)>
 
 =head1 HISTORY
 
-These functions were added in @QUIC_SERVER_VERSION@.
+These functions were added in OpenSSL 3.5.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
Replaced the `@QUIC_SERVER_VERSION@` placeholder in the HISTORY section of the [SSL_CTX_set_domain_flags](https://docs.openssl.org/master/man3/SSL_CTX_set_domain_flags/#history) man page with the actual OpenSSL version (3.5).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ x] documentation is added or updated
