### PR TITLE
fips: remove X25519 and X448

### DIFF
--- a/doc/designs/fips_indicator.md
+++ b/doc/designs/fips_indicator.md
@@ -276,7 +276,6 @@ There are a few places where we do not enforce key size that need to be addresse
 - ECDSA B & K curves are deprecated, but still approved according to (IG C.K Resolution 4).\
   If we chose not to remove them , then we need to check that OSSL_PKEY_PARAM_USE_COFACTOR_ECDH is set for key agreement if the cofactor is not 1.
 - ED25519 and ED448 are now approved.
-- X25519 and X448 are not approved currently. keygen and keyexchange would also need an indicator if we allow them?
 - RSA encryption(for key agreement/key transport) using PKCSV15 is no longer allowed. (Note that this breaks TLS 1.2 using RSA for KeyAgreement),
   Padding mode updates required. Check RSA KEM also.
 - RSA signing using PKCS1 is still allowed (i.e. signature uses shaXXXWithRSAEncryption)

--- a/doc/man7/fips_module.pod
+++ b/doc/man7/fips_module.pod
@@ -561,16 +561,6 @@ See L<EVP_RAND-TEST-RAND(7)/Supported parameters>
 The indicator callback is NOT triggered for this algorithm since it is used
 internally for non security purposes.
 
-=item X25519 and X448 Key Generation and Key Exchange
-
-=back
-
-The unapproved (non FIPS validated) algorithms have a property query value of
-"fips=no".
-
-The following algorithms use a unique indicator and do not trigger the
-indicator callback.
-
 =over 4
 
 =item AES-GCM ciphers support the indicator "iv-generated"

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -447,10 +447,6 @@ static const OSSL_ALGORITHM fips_keyexch[] = {
 #endif
 #ifndef OPENSSL_NO_EC
     { PROV_NAMES_ECDH, FIPS_DEFAULT_PROPERTIES, ossl_ecdh_keyexch_functions },
-# ifndef OPENSSL_NO_ECX
-    { PROV_NAMES_X25519, FIPS_UNAPPROVED_PROPERTIES, ossl_x25519_keyexch_functions },
-    { PROV_NAMES_X448, FIPS_UNAPPROVED_PROPERTIES, ossl_x448_keyexch_functions },
-# endif
 #endif
     { PROV_NAMES_TLS1_PRF, FIPS_DEFAULT_PROPERTIES,
       ossl_kdf_tls1_prf_keyexch_functions },
@@ -572,10 +568,6 @@ static const OSSL_ALGORITHM fips_asym_kem[] = {
     { PROV_NAMES_ML_KEM_512, FIPS_DEFAULT_PROPERTIES, ossl_ml_kem_asym_kem_functions },
     { PROV_NAMES_ML_KEM_768, FIPS_DEFAULT_PROPERTIES, ossl_ml_kem_asym_kem_functions },
     { PROV_NAMES_ML_KEM_1024, FIPS_DEFAULT_PROPERTIES, ossl_ml_kem_asym_kem_functions },
-# if !defined(OPENSSL_NO_ECX)
-    { "X25519MLKEM768", FIPS_DEFAULT_PROPERTIES, ossl_mlx_kem_asym_kem_functions },
-    { "X448MLKEM1024", FIPS_DEFAULT_PROPERTIES, ossl_mlx_kem_asym_kem_functions },
-# endif
 # if !defined(OPENSSL_NO_EC)
     { "SecP256r1MLKEM768", FIPS_DEFAULT_PROPERTIES, ossl_mlx_kem_asym_kem_functions },
     { "SecP384r1MLKEM1024", FIPS_DEFAULT_PROPERTIES, ossl_mlx_kem_asym_kem_functions },
@@ -603,10 +595,6 @@ static const OSSL_ALGORITHM fips_keymgmt[] = {
     { PROV_NAMES_EC, FIPS_DEFAULT_PROPERTIES, ossl_ec_keymgmt_functions,
       PROV_DESCS_EC },
 # ifndef OPENSSL_NO_ECX
-    { PROV_NAMES_X25519, FIPS_UNAPPROVED_PROPERTIES, ossl_x25519_keymgmt_functions,
-      PROV_DESCS_X25519 },
-    { PROV_NAMES_X448, FIPS_UNAPPROVED_PROPERTIES, ossl_x448_keymgmt_functions,
-      PROV_DESCS_X448 },
     { PROV_NAMES_ED25519, FIPS_DEFAULT_PROPERTIES, ossl_ed25519_keymgmt_functions,
       PROV_DESCS_ED25519 },
     { PROV_NAMES_ED448, FIPS_DEFAULT_PROPERTIES, ossl_ed448_keymgmt_functions,
@@ -642,12 +630,6 @@ static const OSSL_ALGORITHM fips_keymgmt[] = {
       PROV_DESCS_ML_KEM_768 },
     { PROV_NAMES_ML_KEM_1024, FIPS_DEFAULT_PROPERTIES, ossl_ml_kem_1024_keymgmt_functions,
       PROV_DESCS_ML_KEM_1024 },
-# if !defined(OPENSSL_NO_ECX)
-    { PROV_NAMES_X25519MLKEM768, FIPS_DEFAULT_PROPERTIES, ossl_mlx_x25519_kem_kmgmt_functions,
-      PROV_DESCS_X25519MLKEM768 },
-    { PROV_NAMES_X448MLKEM1024, FIPS_DEFAULT_PROPERTIES, ossl_mlx_x448_kem_kmgmt_functions,
-      PROV_DESCS_X448MLKEM1024 },
-# endif
 # if !defined(OPENSSL_NO_EC)
     { PROV_NAMES_SecP256r1MLKEM768, FIPS_DEFAULT_PROPERTIES, ossl_mlx_p256_kem_kmgmt_functions,
       PROV_DESCS_SecP256r1MLKEM768 },


### PR DESCRIPTION
In [NIST Proposes to Update SP 800-56A and Revise SP
800-56C](https://www.nist.gov/news-events/news/2025/07/nist-proposes-update-sp-800-56a-and-revise-sp-800-56c)
it is explicitely stated that X25519 and X448 will not be approved
neither on their own or as part of hybrid scheme. And this is direct response to the received public comments requesting to approve X25519 and X448.

This is different to their previous messaging, which used to state
that they might be added in the future.

It seems like there is no way forward for X25519 and X448, and only
Ed25519 signatures will be allowed until PQC transition completion.
