### PR TITLE
Fix RSA key size validation in EVP_PKEY_RSA_keygen demo

### DIFF
--- a/demos/pkey/EVP_PKEY_RSA_keygen.c
+++ b/demos/pkey/EVP_PKEY_RSA_keygen.c
@@ -254,7 +254,7 @@ int main(int argc, char **argv)
 
     if (argc > 1) {
         bits_i = atoi(argv[1]);
-        if (bits < 512) {
+        if (bits_i < 512) {
             fprintf(stderr, "Invalid RSA key size\n");
             return EXIT_FAILURE;
         }


### PR DESCRIPTION
The validation was checking the default 'bits' value (4096) instead of the parsed 'bits_i' from the command line arguments, allowing invalid key sizes to bypass the 512-bit minimum.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->