### PR TITLE
Fix msquic-openssl workflow to build container correctly

### DIFF
--- a/.github/workflows/build_quic_interop_container.yml
+++ b/.github/workflows/build_quic_interop_container.yml
@@ -38,7 +38,8 @@ jobs:
           docker login -u openssl-ci+machine -p ${{ secrets.QUAY_IO_PASSWORD }} quay.io
       - name: Patch qns.Dockerfile
         run: |
-          sed 's/RUN     cmake -DQUIC_BUILD_TOOLS=on -DQUIC_ENABLE_LOGGING=on ../RUN     cmake -DQUIC_BUILD_TOOLS=on -DQUIC_ENABLE_LOGGING=on -DQUIC_TLS_LIB=openssl ../' ./scripts/qns.Dockerfile
+          sed -i 's/RUN     cmake -DQUIC_BUILD_TOOLS=on -DQUIC_ENABLE_LOGGING=on ../RUN     cmake -DQUIC_BUILD_TOOLS=on -DQUIC_ENABLE_LOGGING=on -DQUIC_TLS_LIB=openssl ../' ./scripts/qns.Dockerfile
+          if grep -q "RUN     cmake -DQUIC_BUILD_TOOLS=on -DQUIC_ENABLE_LOGGING=on -DQUIC_TLS_LIB=openssl .." ./scripts/qns.Dockerfile; then echo "Patched successfully"; else exit 1; fi
       - name: "Build container"
         run: |
           docker build -f ./scripts/qns.Dockerfile -t quay.io/openssl-ci/msquic-openssl:latest .


### PR DESCRIPTION
Fix inline file replacement on qns.Dockerfile to properly build container. Add check to ensure patch command actually succeeded.

Successful GitHub Actions runs on my own fork:
- Build msquic-openssl container: https://github.com/andrewkdinh/openssl/actions/runs/16654150994
- QUIC interop run: https://github.com/andrewkdinh/openssl/actions/runs/16652984739

Fixes https://github.com/openssl/project/issues/1298

##### Checklist

- [x] tests are added or updated