### PR TITLE
New suboptions keyenv, keyenvhex, and keyfile were added to -macopt of openssl-mac

### DIFF
--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -140,6 +140,7 @@ EVP_PKEY *load_keyparams_suppress(const char *uri, int format, int maybe_stdin,
                                   const char *keytype, const char *desc,
                                   int suppress_decode_errors);
 char *next_item(char *opt); /* in list separated by comma and/or space */
+char *process_additional_mac_key_arguments(const char *arg);
 int load_cert_certs(const char *uri,
                     X509 **pcert, STACK_OF(X509) **pcerts,
                     int exclude_http, const char *pass, const char *desc,

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -3567,3 +3567,109 @@ int opt_legacy_okay(void)
         return 0;
     return 1;
 }
+
+
+#define MAX_KEY_SIZE 2048 /* Hope nobody needs mac key longer than 2048 bytes */
+
+/*
+ * Implementations of mac algorithms only support getting a key via the
+ * key and hexkey parameters. This function processes additional parameters
+ * for reading a key from an environment variable or from a file
+ * and forms a key or hexkey parameter with the read key.
+ * Leaves other parameters unchanged.
+ * Allocates a string with a new parameter and returns a pointer to this
+ * string, the calling code must free this string by calling OPENSSL_clear_free.
+ * Returns NULL in case of an error.
+ */
+char *process_additional_mac_key_arguments(const char *arg)
+{
+    static BIO *keybio = NULL;
+    char *val=NULL, *outbuf=NULL;
+    unsigned char *inbuf=NULL;
+    size_t total_read = 0;
+    int n;
+    char dummy;
+
+    if (CHECK_AND_SKIP_PREFIX(arg, "keyenv:")) {
+        val = getenv(arg);
+        if (val == NULL) {
+            BIO_printf(bio_err, "No environment variable %s\n", arg);
+            return NULL;
+        }
+        outbuf=app_malloc(strlen("key:")+strlen(val)+1, "MACOPT KEYENV");
+        strcpy(outbuf,"key:");
+        strcat(outbuf,val);
+        return outbuf;
+    }
+    if (CHECK_AND_SKIP_PREFIX(arg, "keyenvhex:")) {
+        val = getenv(arg);
+        if (val == NULL) {
+            BIO_printf(bio_err, "No environment variable %s\n", arg);
+            return NULL;
+        }
+        outbuf=app_malloc(strlen("hexkey:")+strlen(val)+1, "MACOPT KEYENVHEX");
+        strcpy(outbuf,"hexkey:");
+        strcat(outbuf,val);
+        return outbuf;
+    }
+    if (CHECK_AND_SKIP_PREFIX(arg, "keyfile:")) {
+        if (strlen(arg) == 0) {
+            BIO_printf(bio_err, "Empty key file name\n");
+            return NULL;
+        }
+        keybio = BIO_new_file(arg, "rb");
+        if (keybio == NULL) {
+            BIO_printf(bio_err, "Can't open file %s\n", arg);
+            return NULL;
+        }
+        inbuf=app_malloc(MAX_KEY_SIZE, "MACOPT KEYFILE");
+        while (total_read < MAX_KEY_SIZE) {
+            n = BIO_read(keybio, inbuf + total_read, MAX_KEY_SIZE - total_read);
+            if (n < 0) {
+                BIO_printf(bio_err, "Can't read file %s\n", arg);
+                OPENSSL_clear_free(inbuf, total_read);
+                BIO_free(keybio);
+                return NULL;
+            }
+            if (n == 0) /* EOF */
+                break;
+            total_read += n;
+        }
+        if (total_read ==MAX_KEY_SIZE && BIO_read(keybio, &dummy, 1) > 0) {
+            /*File is longer than MAX_KEY_SIZE */
+            BIO_printf(bio_err, "File %s is too long\n", arg);
+            OPENSSL_clear_free(inbuf,total_read);
+            BIO_free(keybio);
+            return NULL;
+        }
+        BIO_free(keybio);
+        outbuf=app_malloc(strlen("hexkey:")+total_read*2+1, "MACOPT KEYFILE");
+        strcpy(outbuf,"hexkey:");
+        OPENSSL_buf2hexstr_ex(outbuf+strlen("hexkey:"), total_read*2+1, NULL,  inbuf, total_read, CH_ZERO);
+        OPENSSL_clear_free(inbuf,total_read);
+        return outbuf;
+    }
+/*    } else if (strcmp(arg, "stdin") == 0) {
+        unbuffer(stdin);
+        pwdbio = dup_bio_in(FORMAT_TEXT);
+        if (pwdbio == NULL) {
+            BIO_printf(bio_err, "Can't open BIO for stdin\n");
+            return NULL;
+        }
+    }
+    i = BIO_gets(pwdbio, tpass, APP_PASS_LEN);
+    if (keepbio != 1) {
+        BIO_free_all(pwdbio);
+        pwdbio = NULL;
+    }
+    if (i <= 0) {
+        BIO_printf(bio_err, "Error reading password from BIO\n");
+        return NULL;
+    }
+    tmp = strchr(tpass, '\n');
+    if (tmp != NULL)
+        *tmp = 0;
+    return OPENSSL_strdup(tpass);
+*/
+    return OPENSSL_strdup(arg);
+}

--- a/apps/mac.c
+++ b/apps/mac.c
@@ -67,8 +67,13 @@ static char *alloc_mac_algorithm_name(STACK_OF(OPENSSL_STRING) **optp,
     BIO_snprintf(res, len, "%s:%s", name, arg);
     if (sk_OPENSSL_STRING_push(*optp, res))
         return res;
-    OPENSSL_free(res);
     return NULL;
+}
+
+
+static void OPENSSL_STRING_clear_free(char *str)
+{
+    if (str) OPENSSL_clear_free(str, strlen(str));
 }
 
 int mac_main(int argc, char **argv)
@@ -89,13 +94,14 @@ int mac_main(int argc, char **argv)
     int inform = FORMAT_BINARY;
     char *digest = NULL, *cipher = NULL;
     OSSL_PARAM *params = NULL;
+    char *new_opt = NULL;
 
     prog = opt_init(argc, argv, mac_options);
     buf = app_malloc(BUFSIZE, "I/O buffer");
     while ((o = opt_next()) != OPT_EOF) {
         switch (o) {
         default:
-opthelp:
+        opthelp:
             BIO_printf(bio_err, "%s: Use -help for summary.\n", prog);
             goto err;
         case OPT_HELP:
@@ -112,10 +118,17 @@ opthelp:
             outfile = opt_arg();
             break;
         case OPT_MACOPT:
+            new_opt = process_additional_mac_key_arguments(opt_arg());
+            if (new_opt == NULL) {
+                ret=1;
+                goto err;
+            }
             if (opts == NULL)
                 opts = sk_OPENSSL_STRING_new_null();
-            if (opts == NULL || !sk_OPENSSL_STRING_push(opts, opt_arg()))
+            if (opts == NULL || !sk_OPENSSL_STRING_push(opts, new_opt)) {
+                OPENSSL_clear_free(new_opt, sizeof(new_opt));
                 goto opthelp;
+            }
             break;
         case OPT_CIPHER:
             OPENSSL_free(cipher);
@@ -225,9 +238,7 @@ err:
     if (ret != 0)
         ERR_print_errors(bio_err);
     OPENSSL_clear_free(buf, BUFSIZE);
-    OPENSSL_free(cipher);
-    OPENSSL_free(digest);
-    sk_OPENSSL_STRING_free(opts);
+    sk_OPENSSL_STRING_pop_free(opts, OPENSSL_STRING_clear_free);
     BIO_free(in);
     BIO_free(out);
     EVP_MAC_CTX_free(ctx);

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -17,7 +17,6 @@
 #include "internal/to_hex.h"
 
 #define DEFAULT_SEPARATOR ':'
-#define CH_ZERO '\0'
 
 char *CRYPTO_strdup(const char *str, const char* file, int line)
 {

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -131,6 +131,7 @@ int CRYPTO_atomic_store(uint64_t *dst, uint64_t val, CRYPTO_RWLOCK *lock);
 # define OPENSSL_secure_actual_size(ptr) \
         CRYPTO_secure_actual_size(ptr)
 
+#define CH_ZERO '\0'
 size_t OPENSSL_strlcpy(char *dst, const char *src, size_t siz);
 size_t OPENSSL_strlcat(char *dst, const char *src, size_t siz);
 size_t OPENSSL_strnlen(const char *str, size_t maxlen);

--- a/test/recipes/20-test_mac.t
+++ b/test/recipes/20-test_mac.t
@@ -10,7 +10,7 @@
 use strict;
 use warnings;
 
-use OpenSSL::Test;
+use OpenSSL::Test qw(:DEFAULT data_file);
 use OpenSSL::Test::Utils;
 use Storable qw(dclone);
 
@@ -52,6 +52,23 @@ my @mac_tests = (
      input => '000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7',
      expected => 'D5BE731C954ED7732846BB59DBE3A8E30F83E77A4BFF4459F2F1C2B4ECEBB8CE67BA01C62E8AB8578D2D499BD1BB276768781190020A306A97DE281DCC30305D',
      desc => 'KMAC256 with xof len of 64' },
+    { cmd => [qw{openssl mac -digest SHA256 -macopt keyenv:MACKEY}],
+      env => {'MACKEY' => 'ASCII_key_for_HMAC_tests' },
+      type => 'HMAC',
+      input => unpack("H*", "Sample message for additional key options"),
+      expected => 'E5079E941452F852E70F7DB8B4EEBBA3D4ED719A76F18E55C32E827D488B7D39',
+      desc => 'HMAC with keyenv' },
+    { cmd => [qw{openssl mac -digest SHA256 -macopt keyenvhex:MACKEY}],
+      env => {'MACKEY' => '404142434445464748494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F' },
+      type => 'HMAC',
+      input => unpack("H*", "Sample message for additional key options"),
+      expected => '5D1FAD0ACBE0750921FC1CB2A1E427C297FCF2B044CBFD2792B1C6C6F9F3D240',
+      desc => 'HMAC with keyenvhex' },
+    { cmd => [qw{openssl mac -digest SHA256}, '-macopt', 'keyfile:' . data_file("keyfile.dat")],
+      type => 'HMAC',
+      input => unpack("H*", "Sample message for additional key options"),
+      expected => '70B1E97C0EDDBD4CB4866E28FEBA45343BD35FD88437F17880B7ADAC058B161B',
+      desc => 'HMAC with keyfile' },
 );
 
 my @siphash_tests = (
@@ -121,11 +138,25 @@ my $test_count = 0;
 
 foreach (@mac_tests) {
     $test_count++;
-    ok(compareline($_->{cmd}, $_->{type}, $_->{input}, $_->{expected}, $_->{err}), $_->{desc});
+    if ($_->{env}) {
+        ok( do {
+                local @ENV{keys %{$_->{env}}} = values %{$_->{env}};
+                sub {compareline($_->{cmd}, $_->{type}, $_->{input}, $_->{expected}, $_->{err})}
+               }, $_->{desc});
+    } else {
+        ok(compareline($_->{cmd}, $_->{type}, $_->{input}, $_->{expected}, $_->{err}), $_->{desc});
+    }
 }
 foreach (@mac_tests) {
     $test_count++;
-    ok(comparefile($_->{cmd}, $_->{type}, $_->{input}, $_->{expected}), $_->{desc});
+    if ($_->{env}) {
+        ok( do {
+                local @ENV{keys %{$_->{env}}} = values %{$_->{env}};
+                sub {comparefile($_->{cmd}, $_->{type}, $_->{input}, $_->{expected})}
+               }, $_->{desc});
+    } else {
+        ok(comparefile($_->{cmd}, $_->{type}, $_->{input}, $_->{expected}), $_->{desc});
+    }
 }
 
 foreach (@mac_fail_tests) {

--- a/test/recipes/20-test_mac_data/keyfile.dat
+++ b/test/recipes/20-test_mac_data/keyfile.dat
@@ -1,0 +1,1 @@
+ASCII_key_for_HMAC_tests


### PR DESCRIPTION
#24584 resolved for openssl-mac: new suboptions keyenv, keyenvhex, and keyfile were added to -macopt.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
