### PR TITLE
x509: Accept keyUsage contentCommitment as alias for nonRepudiation

### DIFF
--- a/crypto/asn1/t_bitst.c
+++ b/crypto/asn1/t_bitst.c
@@ -17,8 +17,19 @@ int ASN1_BIT_STRING_name_print(BIO *out, ASN1_BIT_STRING *bs,
 {
     BIT_STRING_BITNAME *bnam;
     char first = 1;
+    int last_seen_bit = -1;
+
     BIO_printf(out, "%*s", indent, "");
     for (bnam = tbl; bnam->lname; bnam++) {
+        /*
+         * Skip duplicate entries for the same bit in the BIT_STRING_BITNAME
+         * table. Those are aliases, but we only want to print the first entry
+         * when converting to a string.
+         */
+        if (last_seen_bit == bnam->bitnum)
+            continue;
+        last_seen_bit = bnam->bitnum;
+
         if (ASN1_BIT_STRING_get_bit(bs, bnam->bitnum)) {
             if (!first)
                 BIO_puts(out, ", ");

--- a/crypto/x509/v3_bitst.c
+++ b/crypto/x509/v3_bitst.c
@@ -28,6 +28,7 @@ static BIT_STRING_BITNAME ns_cert_type_table[] = {
 static BIT_STRING_BITNAME key_usage_type_table[] = {
     {0, "Digital Signature", "digitalSignature"},
     {1, "Non Repudiation", "nonRepudiation"},
+    {1, "Content Commitment", "contentCommitment"},
     {2, "Key Encipherment", "keyEncipherment"},
     {3, "Data Encipherment", "dataEncipherment"},
     {4, "Key Agreement", "keyAgreement"},
@@ -48,7 +49,17 @@ STACK_OF(CONF_VALUE) *i2v_ASN1_BIT_STRING(X509V3_EXT_METHOD *method,
                                           STACK_OF(CONF_VALUE) *ret)
 {
     BIT_STRING_BITNAME *bnam;
+    int last_seen_bit = -1;
+
     for (bnam = method->usr_data; bnam->lname; bnam++) {
+        /*
+         * If the bitnumber did not change from the last iteration, this entry
+         * is an an alias for the previous bit; treat the first result as
+         * canonical and ignore the rest.
+         */
+        if (last_seen_bit == bnam->bitnum)
+            continue;
+        last_seen_bit = bnam->bitnum;
         if (ASN1_BIT_STRING_get_bit(bits, bnam->bitnum))
             X509V3_add_value(bnam->lname, NULL, &ret);
     }

--- a/doc/man1/openssl-verification-options.pod
+++ b/doc/man1/openssl-verification-options.pod
@@ -661,7 +661,8 @@ This is used as a workaround if the basicConstraints extension is absent.
 =item B<S/MIME Signing> (C<smimesign>)
 
 In addition to the common S/MIME checks, for target certificates
-the key usage must allow for C<digitalSignature> and/or B<nonRepudiation>.
+the key usage must allow for C<digitalSignature> and/or B<nonRepudiation> (or
+its alias name B<contentCommitment>).
 
 =item B<S/MIME Encryption> (C<smimeencrypt>)
 
@@ -685,7 +686,8 @@ For all other certificates the normal CA checks apply.
 =item B<Timestamp Signing> (C<timestampsign>)
 
 For target certificates, if the key usage extension is present, it must include
-C<digitalSignature> and/or C<nonRepudiation> and must not include other bits.
+C<digitalSignature> and/or C<nonRepudiation> (or its alias name
+C<contentCommitment>) and must not include other bits.
 The EKU extension must be present and contain C<timeStamping> only.
 Moreover, it must be marked as critical.
 

--- a/doc/man5/x509v3_config.pod
+++ b/doc/man5/x509v3_config.pod
@@ -130,12 +130,15 @@ any sub-CA's, and can only sign end-entity certificates.
 
 Key usage is a multi-valued extension consisting of a list of names of
 the permitted key usages.  The defined values are: C<digitalSignature>,
-C<nonRepudiation>, C<keyEncipherment>, C<dataEncipherment>, C<keyAgreement>,
-C<keyCertSign>, C<cRLSign>, C<encipherOnly>, and C<decipherOnly>.
+C<nonRepudiation> (with an alternative name C<contentCommitment>),
+C<keyEncipherment>, C<dataEncipherment>, C<keyAgreement>, C<keyCertSign>,
+C<cRLSign>, C<encipherOnly>, and C<decipherOnly>.
 
 Examples:
 
  keyUsage = digitalSignature, nonRepudiation
+
+ keyUsage = digitalSignature, contentCommitment
 
  keyUsage = critical, keyCertSign
 

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -15,7 +15,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_req");
 
-plan tests => 113;
+plan tests => 116;
 
 require_ok(srctop_file('test', 'recipes', 'tconversion.pl'));
 
@@ -747,6 +747,13 @@ $cert = "self-signed_CA_with_keyUsages.pem";
 generate_cert($cert, "-in", srctop_file(@certs, "ext-check.csr"),
     "-copy_extensions", "copy");
 has_keyUsage($cert, 1);
+
+# keyUsage=contentCommitment is an alias for nonRepudiation
+$cert = "self-issued-v3_CA_keyUsage_contentCommitment.pem";
+generate_cert($cert, "-addext", "keyUsage = contentCommitment",
+    "-in", srctop_file(@certs, "x509-check.csr"));
+cert_contains($cert, "Non Repudiation", 1);
+cert_contains($cert, "Content Commitment", 0);
 
 # Generate cert using req with '-modulus'
 ok(run(app(["openssl", "req", "-x509", "-new", "-days", "365",


### PR DESCRIPTION
ITU-T X.509 (10/2019) section 9.2.2.3 [[1]] defines 'contentCommitment' as the current name for what had previously been called 'nonRepudiation', and deprecates the old name:

> It is not incorrect to refer to this keyUsage bit using the identifier nonRepudiation. However, the use of this identifier has been deprecated.

Allow 'contentCommitment' as an alias wherever 'nonRepudiation' has been accepted before, so that passing
```
-addext keyUsage=critical,contentCommitment
```
works as expected.

Add a test that checks that contentCommitment sets the same keyUsage bit as nonRepudiation. Adjust the docs to mention the available alias name.

Other implementations of X.509 seem to have moved to the new name completely, see https://github.com/smallstep/certificates/issues/2348. This can lead to a bad user experience, and it doesn't cost us a lot to accept the new name as an alias.

*Question for the reviewer(s)*: Do we want to switch to the new name completely (i.e., also in the `x509 -text` output) and keep the old name as alias instead?

[1]: https://www.itu.int/rec/T-REC-X.509-201910-I/en

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
