### PR TITLE
Add cert-fingerprint command to extract SHA-256 fingerprint from X.509 certs without colons

### DIFF
--- a/apps/build.info
+++ b/apps/build.info
@@ -18,7 +18,8 @@ $OPENSSLSRC=\
         pkcs8.c pkey.c pkeyparam.c pkeyutl.c prime.c rand.c req.c \
         s_client.c s_server.c s_time.c sess_id.c skeyutl.c smime.c speed.c \
         spkac.c verify.c version.c x509.c rehash.c storeutl.c \
-        list.c info.c fipsinstall.c pkcs12.c
+        list.c info.c fipsinstall.c pkcs12.c \
+        cert_fingerprint.c
 IF[{- !$disabled{'ec'} -}]
   $OPENSSLSRC=$OPENSSLSRC ec.c ecparam.c
 ENDIF

--- a/apps/cert_fingerprint.c
+++ b/apps/cert_fingerprint.c
@@ -4,6 +4,13 @@
 #include <openssl/bio.h>
 #include <openssl/err.h>
 #include <stdio.h>
+#include "apps.h"
+#include "opt.h"
+
+// Define dummy/empty options for now, expand as needed
+const OPTIONS cert_fingerprint_options[] = {
+    {NULL}
+};
 
 int cert_fingerprint_main(int argc, char **argv)
 {

--- a/apps/cert_fingerprint.c
+++ b/apps/cert_fingerprint.c
@@ -5,11 +5,21 @@
 #include <openssl/err.h>
 #include <stdio.h>
 #include "apps.h"
+#include "progs.h"
 #include "opt.h"
 
-// Define dummy/empty options for now, expand as needed
+#define OPT_IN         1
+#define OPT_SHA256     2
+#define OPT_SHA1       3
+#define OPT_NO_COLONS  4
+
 const OPTIONS cert_fingerprint_options[] = {
-    {NULL}
+    { "help", OPT_HELP, '-', "Display this summary" },
+    { "in",   OPT_IN, '<', "Input PEM certificate file" },
+    { "sha256", OPT_SHA256, '-', "Use SHA-256 fingerprint (default)" },
+    { "sha1",   OPT_SHA1, '-', "Use SHA-1 fingerprint" },
+    { "no-colons", OPT_NO_COLONS, '-', "Omit colons from output (lowercase)" },
+    { NULL }
 };
 
 int cert_fingerprint_main(int argc, char **argv)

--- a/apps/cert_fingerprint.c
+++ b/apps/cert_fingerprint.c
@@ -43,8 +43,10 @@ int cert_fingerprint_main(int argc, char **argv)
     int i, o;
 
     /* Parse command-line options */
-    opt_init(argc, argv, cert_fingerprint_options);
-    while ((o = opt_next()) != OPT_EOF) {
+    if (!opt_init(argc, argv, cert_fingerprint_options))
+    return 1;
+
+while ((o = opt_next()) != -1) {  // use -1 instead of OPT_EOF if not defined
         switch (o) {
         case OPT_HELP:
             opt_help(cert_fingerprint_options);

--- a/apps/cert_fingerprint.c
+++ b/apps/cert_fingerprint.c
@@ -1,103 +1,84 @@
 #include <stdio.h>
-#include <string.h>
-#include <openssl/x509.h>
-#include <openssl/pem.h>
-#include <openssl/evp.h>
 #include <openssl/bio.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
 #include <openssl/err.h>
-
 #include "apps.h"
-#include "progs.h"
 #include "opt.h"
 
-#define DEFAULT_DIGEST EVP_sha256()
+typedef enum OPTION_choice {
+    OPT_COMMON,
+    OPT_IN
+} OPTION_CHOICE;
 
-/* Command-line options enum */
-enum {
-    OPT_HELP = 1,
-    OPT_IN,
-    OPT_SHA256,
-    OPT_SHA1,
-    OPT_NO_COLONS
-};
-
-/* Define options array */
 const OPTIONS cert_fingerprint_options[] = {
-    { "help", OPT_HELP, '-', "Display this summary" },
-    { "in",   OPT_IN, '<', "Input PEM certificate file" },
-    { "sha256", OPT_SHA256, '-', "Use SHA-256 fingerprint (default)" },
-    { "sha1",   OPT_SHA1, '-', "Use SHA-1 fingerprint" },
-    { "no-colons", OPT_NO_COLONS, '-', "Omit colons from output (lowercase)" },
-    { NULL }
+    {"help", OPT_HELP, '-', "Display this summary"},
+    {"in", OPT_IN, '<', "Input certificate file (PEM format)"},
+    {NULL}
 };
 
 int cert_fingerprint_main(int argc, char **argv)
 {
-    BIO *in = NULL;
+    BIO *bio_err = NULL, *bio_out = NULL, *in = NULL;
     X509 *cert = NULL;
-    const EVP_MD *md = DEFAULT_DIGEST;
-    unsigned char digest[EVP_MAX_MD_SIZE];
-    unsigned int digest_len = 0;
+    unsigned char md[EVP_MAX_MD_SIZE];
+    unsigned int n = 0;
+    const EVP_MD *digest = EVP_sha256();
     char *infile = NULL;
-    int no_colons = 0;
-    int i, o;
+    int ret = 1;
 
-    /* Parse command-line options */
+    bio_err = BIO_new_fp(stderr, BIO_NOCLOSE);
+    bio_out = BIO_new_fp(stdout, BIO_NOCLOSE);
+
     if (!opt_init(argc, argv, cert_fingerprint_options))
-    return 1;
+        return 1;
 
-while ((o = opt_next()) != -1) {  // use -1 instead of OPT_EOF if not defined
+    OPTION_CHOICE o;
+    while ((o = opt_next()) != OPT_EOF) {
         switch (o) {
-        case OPT_HELP:
-            opt_help(cert_fingerprint_options);
-            return 0;
         case OPT_IN:
             infile = opt_arg();
             break;
-        case OPT_SHA1:
-            md = EVP_sha1();
-            break;
-        case OPT_SHA256:
-            md = EVP_sha256();
-            break;
-        case OPT_NO_COLONS:
-            no_colons = 1;
-            break;
+        case OPT_HELP:
+            opt_help(cert_fingerprint_options);
+            return 0;
         default:
+            BIO_printf(bio_err, "✗ Unknown option\n");
             return 1;
         }
     }
 
-    /* Open input file */
-    in = bio_open_default(infile, 'r', FORMAT_PEM);
-    if (in == NULL)
-        return 1;
-
-    /* Read certificate */
-    cert = PEM_read_bio_X509(in, NULL, 0, NULL);
-    if (cert == NULL) {
-        BIO_printf(bio_err, "Error reading certificate from %s\n", infile);
-        BIO_free(in);
+    if (infile == NULL) {
+        BIO_printf(bio_err, "✗ No input file provided with -in\n");
         return 1;
     }
 
-    /* Compute fingerprint */
-    if (!X509_digest(cert, md, digest, &digest_len)) {
-        BIO_printf(bio_err, "Error computing certificate fingerprint\n");
-        X509_free(cert);
-        BIO_free(in);
-        return 1;
+    in = BIO_new_file(infile, "r");
+    if (!in) {
+        BIO_printf(bio_err, "✗ Error opening file: %s\n", infile);
+        goto end;
     }
 
-    /* Print fingerprint */
-    for (i = 0; i < (int)digest_len; i++) {
-        if (no_colons)
-            BIO_printf(bio_out, "%02x", digest[i]);
-        else
-            BIO_printf(bio_out, "%02X%c", digest[i], (i + 1 == digest_len) ? '\n' : ':');
+    cert = PEM_read_bio_X509(in, NULL, NULL, NULL);
+    if (!cert) {
+        BIO_printf(bio_err, "✗ Error reading certificate from: %s\n", infile);
+        goto end;
     }
 
-    X509_free(cert);
+    if (!X509_digest(cert, digest, md, &n)) {
+        BIO_printf(bio_err, "✗ Error computing fingerprint\n");
+        goto end;
+    }
+
+    for (unsigned int i = 0; i < n; i++)
+        BIO_printf(bio_out, "%02x", md[i]);
+    BIO_printf(bio_out, "\n");
+
+    ret = 0;
+
+end:
     BIO_free(in);
-    return 0;
+    X509_free(cert);
+    return ret;
 }

--- a/apps/cert_fingerprint.c
+++ b/apps/cert_fingerprint.c
@@ -1,0 +1,65 @@
+#include <openssl/x509.h>
+#include <openssl/pem.h>
+#include <openssl/evp.h>
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <stdio.h>
+
+int cert_fingerprint_main(int argc, char **argv)
+{
+    const char *infile = NULL;
+    int no_colons = 0;
+    const EVP_MD *md = EVP_sha256(); // default
+
+    // Basic arg parsing
+    for (int i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "-in") && i + 1 < argc) {
+            infile = argv[++i];
+        } else if (!strcmp(argv[i], "-sha256")) {
+            md = EVP_sha256();
+        } else if (!strcmp(argv[i], "-sha1")) {
+            md = EVP_sha1();
+        } else if (!strcmp(argv[i], "-no-colons")) {
+            no_colons = 1;
+        } else {
+            fprintf(stderr, "Unknown argument: %s\n", argv[i]);
+            return 1;
+        }
+    }
+
+    if (!infile) {
+        fprintf(stderr, "Usage: openssl cert-fingerprint -in file.pem [-sha256] [-no-colons]\n");
+        return 1;
+    }
+
+    FILE *fp = fopen(infile, "r");
+    if (!fp) {
+        perror("fopen");
+        return 1;
+    }
+
+    X509 *cert = PEM_read_X509(fp, NULL, NULL, NULL);
+    fclose(fp);
+
+    if (!cert) {
+        fprintf(stderr, "Failed to parse certificate\n");
+        return 1;
+    }
+
+    unsigned char mdout[EVP_MAX_MD_SIZE];
+    unsigned int mdlen;
+
+    if (!X509_digest(cert, md, mdout, &mdlen)) {
+        fprintf(stderr, "Failed to compute digest\n");
+        X509_free(cert);
+        return 1;
+    }
+
+    for (unsigned int i = 0; i < mdlen; i++) {
+        printf(no_colons ? "%02x" : "%02X%c", mdout[i], no_colons ? '\0' : (i < mdlen - 1 ? ':' : '\n'));
+    }
+    if (no_colons) printf("\n");
+
+    X509_free(cert);
+    return 0;
+}

--- a/apps/progs.h
+++ b/apps/progs.h
@@ -1,1 +1,0 @@
-int cert_fingerprint_main(int argc, char **argv);

--- a/apps/progs.h
+++ b/apps/progs.h
@@ -1,1 +1,1 @@
-extern int cert_fingerprint_main(int argc, char *argv[]);
+int cert_fingerprint_main(int argc, char **argv);

--- a/apps/progs.h
+++ b/apps/progs.h
@@ -1,0 +1,1 @@
+extern int cert_fingerprint_main(int argc, char *argv[]);

--- a/apps/progs.pl
+++ b/apps/progs.pl
@@ -170,7 +170,7 @@ EOF
         des3  => "des",
         desx  => "des",
         cast5 => "cast",
-        cert-fingerprint => "cert_fingerprint",
+        "cert-fingerprint" => "cert_fingerprint",
     );
     foreach my $cmd (
         "aes-128-cbc", "aes-128-ecb",

--- a/apps/progs.pl
+++ b/apps/progs.pl
@@ -170,6 +170,7 @@ EOF
         des3  => "des",
         desx  => "des",
         cast5 => "cast",
+        cert-fingerprint => "cert_fingerprint",
     );
     foreach my $cmd (
         "aes-128-cbc", "aes-128-ecb",

--- a/apps/progs.pl
+++ b/apps/progs.pl
@@ -170,7 +170,7 @@ EOF
         des3  => "des",
         desx  => "des",
         cast5 => "cast",
-        "cert-fingerprint" => "cert_fingerprint",
+        "cert_fingerprint" => "cert-fingerprint",
     );
     foreach my $cmd (
         "aes-128-cbc", "aes-128-ecb",


### PR DESCRIPTION
This pull request introduces a new cert-fingerprint command to the OpenSSL CLI tools.

Accepts a PEM-encoded X.509 certificate via -in flag
Outputs the SHA-256 fingerprint in lowercase hex (without colons)
Includes help flag (--help) and standard error handling

Usage:
openssl cert-fingerprint -in cert.pem
for help openssl cert-fingerprint --help

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
