### PR TITLE
ssl/quic/quic_port.c: Fix endianness of supported versions in sent version negotiation packets

### DIFF
--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -2423,7 +2423,6 @@ static void ch_rx_handle_packet(QUIC_CHANNEL *ch, int channel_only)
             if (!PACKET_get_net_4(&vpkt, &supported_ver))
                 return;
 
-            supported_ver = ntohl(supported_ver);
             if (supported_ver == QUIC_VERSION_1) {
                 /*
                  * If the server supports version 1, set it as

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -1270,7 +1270,7 @@ static void port_send_version_negotiation(QUIC_PORT *port, BIO_ADDR *peer,
      * Add the array of supported versions to the end of the packet
      */
     for (i = 0; i < OSSL_NELEM(supported_versions); i++) {
-        if (!WPACKET_put_bytes_u32(&wpkt, htonl(supported_versions[i])))
+        if (!WPACKET_put_bytes_u32(&wpkt, supported_versions[i]))
             return;
     }
 


### PR DESCRIPTION
This PR fixes a bug in [ssl/quic/quic_port.c](https://github.com/openssl/openssl/blob/b20da2328018107414fe896e59e7d4d6c8af8174/ssl/quic/quic_port.c#L1273) where the supported versions in QUIC Version Negotiation packets were not written in network byte order on little-endian systems.

`WPACKET_put_bytes_u32()` already writes 32-bit integers in network byte order (by using `put_value()`):

https://github.com/openssl/openssl/blob/b20da2328018107414fe896e59e7d4d6c8af8174/crypto/packet.c#L211-L227

Adding `htonl()` resulted in a double conversion, causing incorrect version encoding on little-endian systems.
See the attached PCAP showing a version negotiation triggered on the QUIC demo server in [demos/quic/server](https://github.com/openssl/openssl/tree/b20da2328018107414fe896e59e7d4d6c8af8174/demos/quic/server).

[OSSL_3_5_wrong_version_neg_endianness.pcapng.gz](https://github.com/user-attachments/files/21583897/OSSL_3_5_wrong_version_neg_endianness.pcapng.gz)
