### PR TITLE
BIO: avoid returning internal FILE * with UPLINK-enabled builds on Windows

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1849,11 +1849,18 @@ CA_DB *load_index(const char *dbfile, DB_ATTR *db_attr)
         goto err;
 
 #ifndef OPENSSL_NO_POSIX_IO
-    BIO_get_fp(in, &dbfp);
-    if (fstat(fileno(dbfp), &dbst) == -1) {
-        ERR_raise_data(ERR_LIB_SYS, errno,
-            "calling fstat(%s)", dbfile);
-        goto err;
+    if (BIO_get_fp(in, &dbfp) > 0 && dbfp != NULL) {
+        if (fstat(fileno(dbfp), &dbst) == -1) {
+            ERR_raise_data(ERR_LIB_SYS, errno,
+                "calling fstat(%s)", dbfile);
+            goto err;
+        }
+    } else {
+        if (stat(dbfile, &dbst) == -1) {
+            ERR_raise_data(ERR_LIB_SYS, errno,
+                "calling stat(%s)", dbfile);
+            goto err;
+        }
     }
 #endif
 

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -74,7 +74,7 @@ static int do_responder(OCSP_REQUEST **preq, BIO **pcbio, BIO *acbio,
 static int send_ocsp_response(BIO *cbio, const OCSP_RESPONSE *resp);
 static char *prog;
 
-#ifdef HTTP_DAEMON
+#ifndef OPENSSL_NO_POSIX_IO
 static int index_changed(CA_DB *);
 #endif
 
@@ -680,7 +680,7 @@ int ocsp_main(int argc, char **argv)
 redo_accept:
 
     if (acbio != NULL) {
-#ifdef HTTP_DAEMON
+#ifndef OPENSSL_NO_POSIX_IO
         if (index_changed(rdb)) {
             CA_DB *newrdb = load_index(ridx_filename, NULL);
 
@@ -926,7 +926,7 @@ end:
     return ret;
 }
 
-#ifdef HTTP_DAEMON
+#ifndef OPENSSL_NO_POSIX_IO
 
 static int index_changed(CA_DB *rdb)
 {
@@ -937,7 +937,11 @@ static int index_changed(CA_DB *rdb)
             || rdb->dbst.st_ctime != sb.st_ctime
             || rdb->dbst.st_ino != sb.st_ino
             || rdb->dbst.st_dev != sb.st_dev) {
+#ifdef HTTP_DAEMON
             syslog(LOG_INFO, "index file changed, reloading");
+#else
+            BIO_printf(bio_err, "%s: index file changed, reloading\n", prog);
+#endif
             return 1;
         }
     }

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -340,10 +340,12 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
         if (ptr != NULL) {
             fpp = (FILE **)ptr;
             if (BIO_FLAGS_UPLINK_INTERNAL == 0
-                || b->flags & BIO_FLAGS_UPLINK_INTERNAL)
+                || b->flags & BIO_FLAGS_UPLINK_INTERNAL) {
                 *fpp = (FILE *)b->ptr;
-            else /* avoid returning internal FILE * to the app */
+            } else { /* avoid returning internal FILE * to the app */
                 *fpp = NULL;
+                ret = 0;
+            }
         }
         break;
     case BIO_CTRL_GET_CLOSE:

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -339,7 +339,11 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
         /* the ptr parameter is actually a FILE ** in this case. */
         if (ptr != NULL) {
             fpp = (FILE **)ptr;
-            *fpp = (FILE *)b->ptr;
+            if (BIO_FLAGS_UPLINK_INTERNAL == 0
+                || b->flags & BIO_FLAGS_UPLINK_INTERNAL)
+                *fpp = (FILE *)b->ptr;
+            else /* avoid returning internal FILE * to the app */
+                *fpp = NULL;
         }
         break;
     case BIO_CTRL_GET_CLOSE:

--- a/doc/man3/BIO_s_file.pod
+++ b/doc/man3/BIO_s_file.pod
@@ -14,8 +14,8 @@ BIO_rw_filename - FILE bio
  BIO *BIO_new_file(const char *filename, const char *mode);
  BIO *BIO_new_fp(FILE *stream, int flags);
 
- BIO_set_fp(BIO *b, FILE *fp, int flags);
- BIO_get_fp(BIO *b, FILE **fpp);
+ long BIO_set_fp(BIO *b, FILE *fp, int flags);
+ long BIO_get_fp(BIO *b, FILE **fpp);
 
  int BIO_read_filename(BIO *b, char *name);
  int BIO_write_filename(BIO *b, char *name);
@@ -87,8 +87,7 @@ BIO_s_file() returns the file BIO method.
 BIO_new_file() and BIO_new_fp() return a file BIO or NULL if an error
 occurred.
 
-BIO_set_fp() and BIO_get_fp() return 1 for success or <=0 for failure
-(although the current implementation never return 0).
+BIO_set_fp() and BIO_get_fp() return 1 for success or <=0 for failure.
 
 BIO_seek() returns 0 for success or negative values for failure.
 


### PR DESCRIPTION
On Windows with `UPLINK` enabled, `BIO_get_fp()` may return a `FILE *` pointer that refers to an internal, non-standard representation incompatible with the MSVC C runtime (CRT). Using standard I/O functions like `ftello()` on such a pointer may result in undefined behavior or incorrect results.

To allow applications to avoid such issues, this patch ensures that `BIO_get_fp()` returns NULL in these cases, allowing applications to detect the condition and handle it gracefully.

The patch modifies the handling of the `BIO_CTRL_INFO` command in `file_ctrl()` to return NULL when `UPLINK` is active and the `FILE *` is potentially unsafe. This prevents leaking internal file pointers to the application and ensures consistent behavior across platforms.

POSIX systems are unaffected, as their `FILE *` semantics remain standard.

### Example failure

On Fedora with OpenSSL 3.5.1 (expected behavior):
```
current offset = 4
```

On Windows with OpenSSL 3.5.1 (UPLINK enabled):
```
current offset = -1703641136
ftello: No error
```
or
```
current offset = 0
ftello: No error
```

### Minimal reproducer

```c
#include <openssl/bio.h>

int main(void)
{
    static const char MAGIC[4] = { 'A', 'B', 'C', 'D' };
    int64_t pos;
    FILE *file;
    BIO *bio = BIO_new_file("abcd.txt", "wb");

    if (!bio) {
        printf("BIO_new_file() failed\n");
        return 1;
    }
    if (BIO_write(bio, MAGIC, 4) != 4) {
        printf("BIO_write() failed\n");
        BIO_free(bio);
        return 1;
    }
    if (BIO_get_fp(bio, &file) != 1 || file == NULL) {
        fprintf(stderr, "BIO_get_fp() failed\n");
        return 1;
    }
    pos = ftello(file);
    printf("current offset = %ld\n", pos);
    if (pos < 0) {
        perror("ftello");
        return 1;
    }
    return 0;
}
```

### Summary
This patch ensures that `BIO_get_fp()` reliably fails (returns NULL) when `UPLINK` is active and the underlying `FILE *` is not CRT-compatible. It prevents exposing potentially unsafe internal pointers to the application and preserves the expectation that only valid, CRT-compatible `FILE *` values are returned.
