### PR TITLE
bn: save space in bn_mont_ctx_st by reordering elements

### DIFF
--- a/crypto/bn/bn_local.h
+++ b/crypto/bn/bn_local.h
@@ -257,7 +257,6 @@ struct bignum_st {
 
 /* Used for montgomery multiplication */
 struct bn_mont_ctx_st {
-    int ri;                     /* number of bits in R */
     BIGNUM RR;                  /* used to convert to montgomery form,
                                    possibly zero-padded */
     BIGNUM N;                   /* The modulus */
@@ -266,6 +265,7 @@ struct bn_mont_ctx_st {
     BN_ULONG n0[2];             /* least significant word(s) of Ni; (type
                                  * changed with 0.9.9, was "BN_ULONG n0;"
                                  * before) */
+    int ri;                     /* number of bits in R */
     int flags;
 };
 


### PR DESCRIPTION
 # pahole -C bn_mont_ctx_st ./crypto/bn/libcrypto-shlib-bn_mont.o

 struct bn_mont_ctx_st {
         int                        ri;                   /*     0     4 */

         /* XXX 4 bytes hole, try to pack */

         BIGNUM                     RR;                   /*     8    24 */
         BIGNUM                     N;                    /*    32    24 */
         BIGNUM                     Ni;                   /*    56    24 */
         /* --- cacheline 1 boundary (64 bytes) was 16 bytes ago --- */
         long unsigned int          n0[2];                /*    80    16 */
         int                        flags;                /*    96     4 */

         /* size: 104, cachelines: 2, members: 6 */
         /* sum members: 96, holes: 1, sum holes: 4 */
         /* padding: 4 */
         /* last cacheline: 40 bytes */
 };

 # pahole -C bn_mont_ctx_st ./crypto/bn/libcrypto-shlib-bn_mont.o

 struct bn_mont_ctx_st {
         int                        ri;                   /*     0     4 */
         int                        flags;                /*     4     4 */
         BIGNUM                     RR;                   /*     8    24 */
         BIGNUM                     N;                    /*    32    24 */
         BIGNUM                     Ni;                   /*    56    24 */
         /* --- cacheline 1 boundary (64 bytes) was 16 bytes ago --- */
         long unsigned int          n0[2];                /*    80    16 */

         /* size: 96, cachelines: 2, members: 6 */
         /* last cacheline: 32 bytes */
 };

8 bytes were saved.