### PR TITLE
Fix sporadic macOS 14 CI failure

### DIFF
--- a/test/quic_tserver_test.c
+++ b/test/quic_tserver_test.c
@@ -320,13 +320,13 @@ static int do_test(int use_thread_assist, int use_fake_time, int use_inject)
 
         if (c_start_idle_test && !c_done_idle_test) {
             /* This is more than our default idle timeout of 30s. */
-            if (idle_units_done < 600) {
+            if (idle_units_done < 6000) {
                 struct timeval tv;
                 int isinf;
 
                 if (!TEST_true(CRYPTO_THREAD_write_lock(fake_time_lock)))
                     goto err;
-                fake_time = ossl_time_add(fake_time, ossl_ms2time(100));
+                fake_time = ossl_time_add(fake_time, ossl_ms2time(10));
                 CRYPTO_THREAD_unlock(fake_time_lock);
 
                 ++idle_units_done;
@@ -340,7 +340,7 @@ static int do_test(int use_thread_assist, int use_fake_time, int use_inject)
                     goto err;
                 if (!isinf && ossl_time_compare(ossl_time_zero(),
                                                 ossl_time_from_timeval(tv)) >= 0)
-                    OSSL_sleep(100); /* Ensure CPU scheduling for test purposes */
+                    OSSL_sleep(10); /* Ensure CPU scheduling for test purposes */
             } else {
                 c_done_idle_test = 1;
             }


### PR DESCRIPTION
`quic_tserver_test` would fail sporadically when using thread_assist mode along with fake_time, specifically on macos-14 machine.

This PR gives the server more opportunities to process events to keep the it connected to the client while still maintaining the original 60s idle timeout period for the test.

I can't say this will definitely solve the issue, but I was able to confirm that doing the opposite caused the test to fail more often. e.g. when I changed fake_time + OSSL_sleep to increment in intervals of 1000ms, the same test failed much more often. I have run `make test` with my changes 50+ times to confirm that the test now consistently passes: https://github.com/andrewkdinh/openssl/actions/runs/16783870352

Fixes https://github.com/openssl/project/issues/1290

##### Checklist

- [x] tests are added or updated