### PR TITLE
Remove unnecessary fetch-depth in build_quic_interop_container workflow

### DIFF
--- a/.github/workflows/build_quic_interop_container.yml
+++ b/.github/workflows/build_quic_interop_container.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-         fetch-depth: 0
       - name: "log in to quay.io"
         run: |
           docker login -u openssl-ci+machine -p ${{ secrets.QUAY_IO_PASSWORD }} quay.io


### PR DESCRIPTION
This PR removes the `fetch-depth: 0` parameter in the build_quic_interop_container.yml file. Since only a single commit is needed to trigger the workflow, there's no need to fetch the full history. This helps optimize the workflow speed and resource usage.