### PR TITLE
fips: implement deterministic ECDSA

### DIFF
--- a/crypto/build.info
+++ b/crypto/build.info
@@ -100,13 +100,13 @@ $UTIL_COMMON=\
         threads_pthread.c threads_win.c threads_none.c threads_common.c \
         initthread.c context.c sparse_array.c asn1_dsa.c packet.c \
         param_build.c param_build_set.c der_writer.c threads_lib.c \
-        params_dup.c time.c array_alloc.c
+        params_dup.c time.c array_alloc.c deterministic_nonce.c
 
 SOURCE[../libcrypto]=$UTIL_COMMON \
         mem.c mem_sec.c \
         comp_methods.c cversion.c info.c cpt_err.c ebcdic.c uid.c o_time.c \
         o_dir.c o_fopen.c getenv.c o_init.c init.c trace.c provider.c \
-        provider_child.c punycode.c passphrase.c sleep.c deterministic_nonce.c \
+        provider_child.c punycode.c passphrase.c sleep.c \
         quic_vlint.c time.c defaults.c ssl_err.c
 SOURCE[../providers/libfips.a]=$UTIL_COMMON
 

--- a/crypto/ec/ecdsa_ossl.c
+++ b/crypto/ec/ecdsa_ossl.c
@@ -198,13 +198,11 @@ static int ecdsa_sign_setup(EC_KEY *eckey, BN_CTX *ctx_in,
 
             if (dgst != NULL) {
                 if (nonce_type == 1) {
-#ifndef FIPS_MODULE
                     res = ossl_gen_deterministic_nonce_rfc6979(k, order,
                                                                priv_key,
                                                                dgst, dlen,
                                                                digestname,
                                                                libctx, propq);
-#endif
                 } else {
                     res = ossl_bn_gen_dsa_nonce_fixed_top(k, order, priv_key,
                                                           dgst, dlen, ctx);

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -426,6 +426,7 @@ static const OSSL_ALGORITHM fips_kdfs[] = {
     { PROV_NAMES_TLS1_PRF, FIPS_DEFAULT_PROPERTIES,
       ossl_kdf_tls1_prf_functions },
     { PROV_NAMES_KBKDF, FIPS_DEFAULT_PROPERTIES, ossl_kdf_kbkdf_functions },
+    { PROV_NAMES_HMAC_DRBG_KDF, FIPS_DEFAULT_PROPERTIES, ossl_kdf_hmac_drbg_functions },
     { NULL, NULL, NULL }
 };
 

--- a/providers/implementations/kdfs/build.info
+++ b/providers/implementations/kdfs/build.info
@@ -13,7 +13,7 @@ $SSKDF_GOAL=../../libdefault.a ../../libfips.a
 $SCRYPT_GOAL=../../libdefault.a
 $SSHKDF_GOAL=../../libdefault.a ../../libfips.a
 $X942KDF_GOAL=../../libdefault.a ../../libfips.a
-$HMAC_DRBG_KDF_GOAL=../../libdefault.a
+$HMAC_DRBG_KDF_GOAL=../../libdefault.a ../../libfips.a
 $ARGON2_GOAL=../../libdefault.a
 
 SOURCE[$TLS1_PRF_GOAL]=tls1_prf.c


### PR DESCRIPTION
[FIPS 186-5](https://doi.org/10.6028/NIST.FIPS.186-5) approved deterministic ECDSA in the same manner as [RFC 6979](https://datatracker.ietf.org/doc/html/rfc6979).

Thus add deterministic ECDSA capability to the FIPS provider.

DSA signature generation has been deprecated and removed from FIPS
186-5, thus deterministic DSA signature creation is not added to the
FIPS provider.

Testing can be done by performing 20-test_dgst.t but need to version
guarded against different FIPS provider versions. Thus is left out of
this PR for now.

It is not clear if HMAC-DRBG-KDF should be exposed publically for
direct usage as an approved usage, or if it should be marked as
unapproved or better yet made completely internal to the FIPS
provider.
