### PR TITLE
crypto/cms/cms_enc.c: Add ASN1_TYPE_free before goto err

### DIFF
--- a/crypto/cms/cms_enc.c
+++ b/crypto/cms/cms_enc.c
@@ -174,11 +174,15 @@ BIO *ossl_cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec,
             aparams.iv_len = ivlen;
             aparams.tag_len = EVP_CIPHER_CTX_get_tag_length(ctx);
             if (aparams.tag_len <= 0)
+                ASN1_TYPE_free(calg->parameter);
+                calg->parameter = NULL;
                 goto err;
         }
 
         if (evp_cipher_param_to_asn1_ex(ctx, calg->parameter, &aparams) <= 0) {
             ERR_raise(ERR_LIB_CMS, CMS_R_CIPHER_PARAMETER_INITIALISATION_ERROR);
+            ASN1_TYPE_free(calg->parameter);
+            calg->parameter = NULL;
             goto err;
         }
         /* If parameter type not set omit parameter */


### PR DESCRIPTION
Fixed memory leak caused by wrap->parameter not being freed.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
