### PR TITLE
Fix more memfail failures

### DIFF
--- a/crypto/encode_decode/decoder_pkey.c
+++ b/crypto/encode_decode/decoder_pkey.c
@@ -928,6 +928,7 @@ OSSL_DECODER_CTX_new_for_pkey(EVP_PKEY **pkey,
             (void)lh_DECODER_CACHE_ENTRY_insert(cache->hashtable, newcache);
             if (lh_DECODER_CACHE_ENTRY_error(cache->hashtable)) {
                 ctx = NULL;
+                CRYPTO_THREAD_unlock(cache->lock);
                 ERR_raise(ERR_LIB_OSSL_DECODER, ERR_R_CRYPTO_LIB);
                 goto err;
             }

--- a/crypto/hashtable/hashtable.c
+++ b/crypto/hashtable/hashtable.c
@@ -636,6 +636,7 @@ int ossl_ht_insert(HT *h, HT_KEY *key, HT_VALUE *data, HT_VALUE **olddata)
     if (data->value == NULL)
         goto out;
 
+    rc = -1;
     newval = alloc_new_value(h, key, data->value, data->type_id);
     if (newval == NULL)
         goto out;

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -603,7 +603,7 @@ int tls13_change_cipher_state(SSL_CONNECTION *s, int which)
 
             if (!ssl_log_secret(s, EARLY_EXPORTER_SECRET_LABEL,
                                 s->early_exporter_master_secret, hashlen)) {
-                /* SSLfatal() already called */
+                SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
                 goto err;
             }
         } else if (which & SSL3_CC_HANDSHAKE) {


### PR DESCRIPTION
Our coveralls tests, which enables debug (transitively enabling ossl_assert aborts) caught several new memfail failures.  This patch series corrects them:

1) we remove the ossl_assert during insert to the core_namemap, as it was there under the assumption that we couldn't fail the insert, which was never true, as we can fail due to memory allocation failures

2) we add a call to SSLFatal that was assumed to be made, but never was in the case that ssl_log_secret fails due to memory allocation failure

3) We fix a missing unlock case in OSSL_DECODER_CTX_new_for_pkey, which maintains a write lock when a memory failure occurs, causing subsequent locks to fail with an EBUSY return, triggering an assert.
