### PR TITLE
Add missing NULL check in i2r_HASH

### DIFF
--- a/crypto/x509/v3_attrdesc.c
+++ b/crypto/x509/v3_attrdesc.c
@@ -67,6 +67,8 @@ static int i2r_HASH(X509V3_EXT_METHOD *method,
     }
     if (BIO_printf(out, "%*sHash Value: ", indent, "") <= 0)
         return 0;
+    if (hash->hashValue == NULL)
+        return 0;
     return ossl_bio_print_hex(out, hash->hashValue->data, hash->hashValue->length);
 }
 


### PR DESCRIPTION
oss-fuzz identified a crash in the crl fuzz test. This PR adds a missing NULL check to prevent dereferencing an uninitialized field, ensuring safe access.

Before:

```console
$ fuzz/crl-test ./clusterfuzz-testcase-2025-08-07
crl-test(127,0x20d2960c0) malloc: nano zone abandoned due to inability to reserve vm space.
# ./clusterfuzz-testcase-2025-08-07
crypto/x509/v3_attrdesc.c:70:53: runtime error: member access within null pointer of type 'ASN1_BIT_STRING' (aka 'struct asn1_string_st')
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior crypto/x509/v3_attrdesc.c:70:53 
zsh: abort      fuzz/crl-test ./clusterfuzz-testcase-2025-08-07
```

After:

```console
$ fuzz/crl-test ./clusterfuzz-testcase-2025-08-07
crl-test(94064,0x20d2960c0) malloc: nano zone abandoned due to inability to reserve vm space.
# ./clusterfuzz-testcase-2025-08-07
```

Fixes https://github.com/openssl/project/issues/1314 and https://issues.oss-fuzz.com/issues/436876970
