### PR TITLE
Add test coverage for PKCS7_TEXT mode

### DIFF
--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -92,6 +92,15 @@ my @smime_pkcs7_tests = (
       \&final_compare
     ],
 
+    [ "signed text content DER format, RSA key",
+      [ "{cmd1}", @prov, "-sign", "-in", $smcont, "-outform", "DER", "-nodetach",
+        "-certfile", $smroot, "-signer", $smrsa1, "-text",
+        "-out", "{output}.cms" ],
+      [ "{cmd2}",  @prov, "-verify", "-in", "{output}.cms", "-inform", "DER",
+        "-text", "-CAfile", $smroot, "-out", "{output}.txt" ],
+      \&final_compare
+    ],
+
     [ "signed detached content DER format, RSA key",
       [ "{cmd1}", @prov, "-sign", "-in", $smcont, "-outform", "DER",
         "-signer", $smrsa1, "-out", "{output}.cms" ],
@@ -222,6 +231,14 @@ my @smime_pkcs7_tests = (
         catfile($smdir, "smrsa3.pem") ],
       [ "{cmd2}", @defaultprov, "-decrypt", "-recip", $smrsa1,
         "-in", "{output}.cms", "-out", "{output}.txt" ],
+      \&final_compare
+    ],
+
+    [ "enveloped text content streaming S/MIME format, DES, 1 recipient",
+      [ "{cmd1}", @defaultprov, "-encrypt", "-in", $smcont,
+        "-stream", "-text", "-out", "{output}.cms", $smrsa1 ],
+      [ "{cmd2}", @defaultprov, "-decrypt", "-recip", $smrsa1,
+        "-in", "{output}.cms", "-text", "-out", "{output}.txt" ],
       \&final_compare
     ],
 


### PR DESCRIPTION
This was inspired by the following commit
9882d389df71 ("crypto/pkcs7/pk7_smime.c: Add BIO_free() to avoid memory leak") which discovered a bug in PKCS7_verify(..., PKCS7_TEXT). While there is some test coverage for PKCS_verify by ./test/pkcs7_test.c, there is no test coverage whatsoever of the PKCS7_TEXT flag for PKCS7_sign, PKCS7_encrypt and PKCS7_decrypt.
So this adds some test coverage for those functions as well.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
