### PR TITLE
Make `openssl speed` test signatures without errors

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -2281,9 +2281,11 @@ int speed_main(int argc, char **argv)
         }
 #endif /* OPENSSL_NO_DSA */
         /* skipping these algs as tested elsewhere - and b/o setup is a pain */
-        else if (strcmp(sig_name, "ED25519") &&
-                 strcmp(sig_name, "ED448") &&
-                 strcmp(sig_name, "ECDSA") &&
+        else if (strncmp(sig_name, "RSA", 3) &&
+                 strncmp(sig_name, "DSA", 3) &&
+                 strncmp(sig_name, "ED25519", 7) &&
+                 strncmp(sig_name, "ED448", 5) &&
+                 strncmp(sig_name, "ECDSA", 5) &&
                  strcmp(sig_name, "HMAC") &&
                  strcmp(sig_name, "SIPHASH") &&
                  strcmp(sig_name, "POLY1305") &&


### PR DESCRIPTION
This PR deals with two related issues in the `openssl speed` app:
-  The app wasn't yet adapted to deal with features implemented in #23416. When enumerating supported signature algorithms to speed-test, it finds composite signature algorithm names such as "RSA-SHA256" and tries to create keys from these names, which is not supported (see also #27855), resulting in errors. The first commit disables speed-testing of these composite algorithms. To support them in the future, the app would have to map composite algorithm names to key types, which could be done, e.g. by exposing the `query_key_types` member of the `EVP_SIGNATURE` struct type.
- The app tries to initialize every signature using `EVP_sign_init` irrespective of the algorithm. This function fails, e.g., for ML-DSA and SLH-DSA, which need to be initialized via `EVP_sign_message_init`. The second commit makes `openssl-speed` try both of these initialization functions before reporting an error.

<!---
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
