### PR TITLE
Correct the synthetisized OPENSSL_VERSION_NUMBER

### DIFF
--- a/include/openssl/opensslv.h.in
+++ b/include/openssl/opensslv.h.in
@@ -90,16 +90,11 @@ extern "C" {
 # define OPENSSL_VERSION_TEXT "OpenSSL {- "$config{full_version} $config{release_date}" -}"
 
 /* Synthesize OPENSSL_VERSION_NUMBER with the layout 0xMNN00PPSL */
-# ifdef OPENSSL_VERSION_PRE_RELEASE
-#  define _OPENSSL_VERSION_PRE_RELEASE 0x0L
-# else
-#  define _OPENSSL_VERSION_PRE_RELEASE 0xfL
-# endif
 # define OPENSSL_VERSION_NUMBER          \
     ( (OPENSSL_VERSION_MAJOR<<28)        \
       |(OPENSSL_VERSION_MINOR<<20)       \
       |(OPENSSL_VERSION_PATCH<<4)        \
-      |_OPENSSL_VERSION_PRE_RELEASE )
+      |{- @config{prerelease} ? "0x0L" : "0xfL" -} )
 
 # ifdef  __cplusplus
 }


### PR DESCRIPTION
The last hex digit always became 0x0L, even of `OPENSSL_VERSION_PRE_RELEASE`
was the empty string.

Resolves: https://github.com/openssl/openssl/issues/28227
