### PR TITLE
git: add x942kdf.c to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ providers/implementations/kdfs/scrypt.c
 providers/implementations/kdfs/sshkdf.c
 providers/implementations/kdfs/sskdf.c
 providers/implementations/kdfs/tls1_prf.c
+providers/implementations/kdfs/x942kdf.c
 providers/implementations/keymgmt/ml_dsa_kmgmt.c
 providers/implementations/keymgmt/ml_kem_kmgmt.c
 providers/implementations/keymgmt/mlx_kmgmt.c


### PR DESCRIPTION
It is now a generated file. See:
- https://github.com/openssl/openssl/pull/27923

Specifically https://github.com/openssl/openssl/pull/27923/files#r2209188890