### PR TITLE
Allow get_params to return length of AES-GCM IV and tag parameters

### DIFF
--- a/providers/implementations/ciphers/ciphercommon_gcm.c.in
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c.in
@@ -194,7 +194,7 @@ int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
     if (p.iv != NULL) {
         if (ctx->iv_state == IV_STATE_UNINITIALISED)
             return 0;
-        if (ctx->ivlen > p.iv->data_size) {
+        if (p.iv->data != NULL && ctx->ivlen > p.iv->data_size) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
             return 0;
         }
@@ -207,7 +207,7 @@ int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
     if (p.updiv != NULL) {
         if (ctx->iv_state == IV_STATE_UNINITIALISED)
             return 0;
-        if (ctx->ivlen > p.updiv->data_size) {
+        if (p.updiv->data != NULL && ctx->ivlen > p.updiv->data_size) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
             return 0;
         }

--- a/providers/implementations/ciphers/ciphercommon_gcm.c.in
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c.in
@@ -224,13 +224,15 @@ int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
 
     if (p.tag != NULL) {
         sz = p.tag->data_size;
-        if (sz == 0
-            || sz > EVP_GCM_TLS_TAG_LEN
-            || !ctx->enc
-            || ctx->taglen == UNINITIALISED_SIZET) {
+        if (!ctx->enc || ctx->taglen == UNINITIALISED_SIZET) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG);
             return 0;
         }
+        if (p.tag->data != NULL && (sz > EVP_GCM_TLS_TAG_LEN || sz == 0)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG);
+            return 0;
+        }
+
         if (!OSSL_PARAM_set_octet_string(p.tag, ctx->buf, sz)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return 0;

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -6304,8 +6304,8 @@ static int aes_gcm_encrypt(const unsigned char *gcm_key, size_t gcm_key_s,
     int outlen, tmplen;
     unsigned char outbuf[1024];
     unsigned char outtag[16];
-    OSSL_PARAM params[2] = {
-        OSSL_PARAM_END, OSSL_PARAM_END
+    OSSL_PARAM params[3] = {
+        OSSL_PARAM_END, OSSL_PARAM_END, OSSL_PARAM_END
     };
 
     if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new())
@@ -6331,6 +6331,15 @@ static int aes_gcm_encrypt(const unsigned char *gcm_key, size_t gcm_key_s,
             || !TEST_mem_eq(outbuf, outlen, gcm_ct, gcm_ct_s)
             || !TEST_mem_eq(outtag, gcm_tag_s, gcm_tag, gcm_tag_s))
         goto err;
+
+    params[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_IV,
+                                                  NULL, 0);
+    params[1] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_UPDATED_IV,
+                                                  NULL, 0);
+    params[2] = OSSL_PARAM_construct_end();
+    if (!TEST_true(EVP_CIPHER_CTX_get_params(ctx, params))
+            || !TEST_size_t_eq(params[0].return_size, gcm_ivlen)
+            || !TEST_size_t_eq(params[1].return_size, gcm_ivlen))
 
     ret = 1;
 err:

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -6304,8 +6304,8 @@ static int aes_gcm_encrypt(const unsigned char *gcm_key, size_t gcm_key_s,
     int outlen, tmplen;
     unsigned char outbuf[1024];
     unsigned char outtag[16];
-    OSSL_PARAM params[3] = {
-        OSSL_PARAM_END, OSSL_PARAM_END, OSSL_PARAM_END
+    OSSL_PARAM params[4] = {
+        OSSL_PARAM_END, OSSL_PARAM_END, OSSL_PARAM_END, OSSL_PARAM_END
     };
 
     if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new())
@@ -6336,10 +6336,13 @@ static int aes_gcm_encrypt(const unsigned char *gcm_key, size_t gcm_key_s,
                                                   NULL, 0);
     params[1] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_UPDATED_IV,
                                                   NULL, 0);
-    params[2] = OSSL_PARAM_construct_end();
+    params[2] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG,
+                                                  NULL, 0);
+    params[3] = OSSL_PARAM_construct_end();
     if (!TEST_true(EVP_CIPHER_CTX_get_params(ctx, params))
             || !TEST_size_t_eq(params[0].return_size, gcm_ivlen)
-            || !TEST_size_t_eq(params[1].return_size, gcm_ivlen))
+            || !TEST_size_t_eq(params[1].return_size, gcm_ivlen)
+            || !TEST_size_t_eq(params[2].return_size, sizeof(outtag)))
 
     ret = 1;
 err:


### PR DESCRIPTION
This is a fix for #28157.

Previously, `iv`, `updated-iv` and `tag` did not behave as documented when called with a NULL data pointer. Now they do.

##### Checklist
- [ ] tests are added or updated
