### PR TITLE
Align the decoding of parameters that can have two different types associated with one name

### DIFF
--- a/providers/implementations/asymciphers/rsa_enc.c.in
+++ b/providers/implementations/asymciphers/rsa_enc.c.in
@@ -383,35 +383,30 @@ static int rsa_get_ctx_params(void *vprsactx, OSSL_PARAM *params)
     if (prsactx == NULL || !rsa_get_ctx_params_decoder(params, &p))
         return 0;
 
-    if (p.pad != NULL)
-        switch (p.pad->data_type) {
-        case OSSL_PARAM_INTEGER: /* Support for legacy pad mode number */
+    if (p.pad != NULL) {
+        if (p.pad->data_type != OSSL_PARAM_UTF8_STRING) {
+            /* Support for legacy pad mode number */
             if (!OSSL_PARAM_set_int(p.pad, prsactx->pad_mode))
                 return 0;
-            break;
-        case OSSL_PARAM_UTF8_STRING:
-            {
-                int i;
-                const char *word = NULL;
+        } else {
+            int i;
+            const char *word = NULL;
 
-                for (i = 0; padding_item[i].id != 0; i++) {
-                    if (prsactx->pad_mode == (int)padding_item[i].id) {
-                        word = padding_item[i].ptr;
-                        break;
-                    }
-                }
-
-                if (word != NULL) {
-                    if (!OSSL_PARAM_set_utf8_string(p.pad, word))
-                        return 0;
-                } else {
-                    ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+            for (i = 0; padding_item[i].id != 0; i++) {
+                if (prsactx->pad_mode == (int)padding_item[i].id) {
+                    word = padding_item[i].ptr;
+                    break;
                 }
             }
-            break;
-        default:
-            return 0;
+
+            if (word != NULL) {
+                if (!OSSL_PARAM_set_utf8_string(p.pad, word))
+                    return 0;
+            } else {
+                ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+            }
         }
+    }
 
     if (p.oaep != NULL && !OSSL_PARAM_set_utf8_string(p.oaep, prsactx->oaep_md == NULL
                                                               ? ""
@@ -510,28 +505,22 @@ static int rsa_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
     if (p.pad != NULL) {
         int pad_mode = 0;
 
-        switch (p.pad->data_type) {
-        case OSSL_PARAM_INTEGER: /* Support for legacy pad mode number */
+        if (p.pad->data_type != OSSL_PARAM_UTF8_STRING) {
+            /* Support for legacy pad mode as a number */
             if (!OSSL_PARAM_get_int(p.pad, &pad_mode))
                 return 0;
-            break;
-        case OSSL_PARAM_UTF8_STRING:
-            {
-                int i;
+        } else {
+            int i;
 
-                if (p.pad->data == NULL)
-                    return 0;
+            if (p.pad->data == NULL)
+                return 0;
 
-                for (i = 0; padding_item[i].id != 0; i++) {
-                    if (strcmp(p.pad->data, padding_item[i].ptr) == 0) {
-                        pad_mode = padding_item[i].id;
-                        break;
-                    }
+            for (i = 0; padding_item[i].id != 0; i++) {
+                if (strcmp(p.pad->data, padding_item[i].ptr) == 0) {
+                    pad_mode = padding_item[i].id;
+                    break;
                 }
             }
-            break;
-        default:
-            return 0;
         }
 
         /*

--- a/providers/implementations/kdfs/hkdf.c.in
+++ b/providers/implementations/kdfs/hkdf.c.in
@@ -456,7 +456,7 @@ static int hkdf_common_get_ctx_params(void *vctx, OSSL_PARAM params[])
             default:
                 return 0;
             }
-        } else if (p.mode->data_type == OSSL_PARAM_INTEGER) {
+        } else {
             if (!OSSL_PARAM_set_int(p.mode, ctx->mode))
                 return 0;
         }

--- a/providers/implementations/signature/rsa_sig.c.in
+++ b/providers/implementations/signature/rsa_sig.c.in
@@ -1417,33 +1417,29 @@ static int rsa_get_ctx_params(void *vprsactx, OSSL_PARAM *params)
             return 0;
     }
 
-    if (p.pad != NULL)
-        switch (p.pad->data_type) {
-        default:
+    if (p.pad != NULL) {
+        if (p.pad->data_type != OSSL_PARAM_UTF8_STRING) {
             if (!OSSL_PARAM_set_int(p.pad, prsactx->pad_mode))
                 return 0;
-            break;
-        case OSSL_PARAM_UTF8_STRING:
-            {
-                int i;
-                const char *word = NULL;
+        } else {
+            int i;
+            const char *word = NULL;
 
-                for (i = 0; padding_item[i].id != 0; i++) {
-                    if (prsactx->pad_mode == (int)padding_item[i].id) {
-                        word = padding_item[i].ptr;
-                        break;
-                    }
-                }
-
-                if (word != NULL) {
-                    if (!OSSL_PARAM_set_utf8_string(p.pad, word))
-                        return 0;
-                } else {
-                    ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+            for (i = 0; padding_item[i].id != 0; i++) {
+                if (prsactx->pad_mode == (int)padding_item[i].id) {
+                    word = padding_item[i].ptr;
+                    break;
                 }
             }
-            break;
+
+            if (word != NULL) {
+                if (!OSSL_PARAM_set_utf8_string(p.pad, word))
+                    return 0;
+            } else {
+                ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+            }
         }
+    }
 
     if (p.digest != NULL && !OSSL_PARAM_set_utf8_string(p.digest, prsactx->mdname))
         return 0;
@@ -1613,26 +1609,22 @@ static int rsa_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
     if (p.pad != NULL) {
         const char *err_extra_text = NULL;
 
-        switch (p.pad->data_type) {
-        default: /* Support for legacy pad mode number */
+        if (p.pad->data_type != OSSL_PARAM_UTF8_STRING) {
+            /* Support for legacy pad mode number */
             if (!OSSL_PARAM_get_int(p.pad, &pad_mode))
                 return 0;
-            break;
-        case OSSL_PARAM_UTF8_STRING:
-            {
-                int i;
+        } else {
+            int i;
 
-                if (p.pad->data == NULL)
-                    return 0;
+            if (p.pad->data == NULL)
+                return 0;
 
-                for (i = 0; padding_item[i].id != 0; i++) {
-                    if (strcmp(p.pad->data, padding_item[i].ptr) == 0) {
-                        pad_mode = padding_item[i].id;
-                        break;
-                    }
+            for (i = 0; padding_item[i].id != 0; i++) {
+                if (strcmp(p.pad->data, padding_item[i].ptr) == 0) {
+                    pad_mode = padding_item[i].id;
+                    break;
                 }
             }
-            break;
         }
 
         switch (pad_mode) {
@@ -1696,12 +1688,11 @@ static int rsa_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
             return 0;
         }
 
-        switch (p.slen->data_type) {
-        default: /* Support for legacy pad mode number */
+        if (p.slen->data_type != OSSL_PARAM_UTF8_STRING) {
+            /* Support for legacy pad mode number */
             if (!OSSL_PARAM_get_int(p.slen, &saltlen))
                 return 0;
-            break;
-        case OSSL_PARAM_UTF8_STRING:
+        } else {
             if (strcmp(p.slen->data, OSSL_PKEY_RSA_PSS_SALT_LEN_DIGEST) == 0)
                 saltlen = RSA_PSS_SALTLEN_DIGEST;
             else if (strcmp(p.slen->data, OSSL_PKEY_RSA_PSS_SALT_LEN_MAX) == 0)
@@ -1712,7 +1703,6 @@ static int rsa_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
                 saltlen = RSA_PSS_SALTLEN_AUTO_DIGEST_MAX;
             else
                 saltlen = atoi(p.slen->data);
-            break;
         }
 
         /*


### PR DESCRIPTION

As noted in (this discussion)[https://github.com/openssl/openssl/pull/28145#discussion_r2268602828], this is the followup PR that brings the decoding of parameters that have dual times into line.

The advantages of coding it this way are:
1. A bad type error will be produced for incorrectly typed parameters.  Previous, this was sometimes raised and sometimes not.
2. All numeric types are accepted instead of just the type checked for.  Thus, unsigned int and int become interchangeable from the user's perspective.
