### PR TITLE
Add FIPS conditioning back into the various parameter arrays.

### DIFF
--- a/providers/implementations/asymciphers/rsa_enc.c.in
+++ b/providers/implementations/asymciphers/rsa_enc.c.in
@@ -372,7 +372,7 @@ static void *rsa_dupctx(void *vprsactx)
                           ['ASYM_CIPHER_PARAM_TLS_CLIENT_VERSION',      'tlsver', 'uint'],
                           ['ASYM_CIPHER_PARAM_TLS_NEGOTIATED_VERSION',  'negver', 'uint'],
                           ['ASYM_CIPHER_PARAM_IMPLICIT_REJECTION',      'imrej',  'uint'],
-                          ['ASYM_CIPHER_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int'],
+                          ['ASYM_CIPHER_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int', 'fips'],
                          )); -}
 
 static int rsa_get_ctx_params(void *vprsactx, OSSL_PARAM *params)
@@ -469,8 +469,8 @@ static const OSSL_PARAM *rsa_gettable_ctx_params(ossl_unused void *vprsactx,
                           ['ASYM_CIPHER_PARAM_TLS_CLIENT_VERSION',           'tlsver',  'uint'],
                           ['ASYM_CIPHER_PARAM_TLS_NEGOTIATED_VERSION',       'negver',  'uint'],
                           ['ASYM_CIPHER_PARAM_IMPLICIT_REJECTION',           'imrej',   'uint'],
-                          ['ASYM_CIPHER_PARAM_FIPS_KEY_CHECK',               'ind_k',   'int'],
-                          ['ASYM_CIPHER_PARAM_FIPS_RSA_PKCS15_PAD_DISABLED', 'ind_pad', 'int'],
+                          ['ASYM_CIPHER_PARAM_FIPS_KEY_CHECK',               'ind_k',   'int', 'fips'],
+                          ['ASYM_CIPHER_PARAM_FIPS_RSA_PKCS15_PAD_DISABLED', 'ind_pad', 'int', 'fips'],
                          )); -}
 
 static int rsa_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])

--- a/providers/implementations/exchange/dh_exch.c.in
+++ b/providers/implementations/exchange/dh_exch.c.in
@@ -349,8 +349,8 @@ err:
                           ['EXCHANGE_PARAM_KDF_OUTLEN',        'len',    'size_t'],
                           ['EXCHANGE_PARAM_KDF_UKM',           'ukm',    'octet_string'],
                           ['KDF_PARAM_CEK_ALG',                'cekalg', 'utf8_string'],
-                          ['EXCHANGE_PARAM_FIPS_KEY_CHECK',    'ind_k',  'int'],
-                          ['EXCHANGE_PARAM_FIPS_DIGEST_CHECK', 'ind_d',  'int'],
+                          ['EXCHANGE_PARAM_FIPS_KEY_CHECK',    'ind_k',  'int', 'fips'],
+                          ['EXCHANGE_PARAM_FIPS_DIGEST_CHECK', 'ind_d',  'int', 'fips'],
                          )); -}
 
 static int dh_set_ctx_params(void *vpdhctx, const OSSL_PARAM params[])
@@ -471,7 +471,7 @@ static const OSSL_PARAM *dh_settable_ctx_params(ossl_unused void *vpdhctx,
                           ['EXCHANGE_PARAM_KDF_OUTLEN',         'len',    'size_t'],
                           ['EXCHANGE_PARAM_KDF_UKM',            'ukm',    'octet_ptr'],
                           ['KDF_PARAM_CEK_ALG',                 'cekalg', 'utf8_string'],
-                          ['ALG_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int'],
+                          ['ALG_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int', 'fips'],
                          )); -}
 
 static const OSSL_PARAM *dh_gettable_ctx_params(ossl_unused void *vpdhctx,

--- a/providers/implementations/exchange/ecdh_exch.c.in
+++ b/providers/implementations/exchange/ecdh_exch.c.in
@@ -254,9 +254,9 @@ void *ecdh_dupctx(void *vpecdhctx)
                           ['EXCHANGE_PARAM_KDF_DIGEST_PROPS',         'propq',     'utf8_string'],
                           ['EXCHANGE_PARAM_KDF_OUTLEN',               'len',       'size_t'],
                           ['EXCHANGE_PARAM_KDF_UKM',                  'ukm',       'octet_string'],
-                          ['EXCHANGE_PARAM_FIPS_KEY_CHECK',           'ind_k',     'int'],
-                          ['EXCHANGE_PARAM_FIPS_DIGEST_CHECK',        'ind_d',     'int'],
-                          ['EXCHANGE_PARAM_FIPS_ECDH_COFACTOR_CHECK', 'ind_cofac', 'int'],
+                          ['EXCHANGE_PARAM_FIPS_KEY_CHECK',           'ind_k',     'int', 'fips'],
+                          ['EXCHANGE_PARAM_FIPS_DIGEST_CHECK',        'ind_d',     'int', 'fips'],
+                          ['EXCHANGE_PARAM_FIPS_ECDH_COFACTOR_CHECK', 'ind_cofac', 'int', 'fips'],
                          )); -}
 
 static
@@ -370,7 +370,7 @@ const OSSL_PARAM *ecdh_settable_ctx_params(ossl_unused void *vpecdhctx,
                           ['EXCHANGE_PARAM_KDF_DIGEST',            'digest', 'utf8_string'],
                           ['EXCHANGE_PARAM_KDF_OUTLEN',            'len',    'size_t'],
                           ['EXCHANGE_PARAM_KDF_UKM',               'ukm',    'octet_ptr'],
-                          ['ALG_PARAM_FIPS_APPROVED_INDICATOR',    'ind',    'int'],
+                          ['ALG_PARAM_FIPS_APPROVED_INDICATOR',    'ind',    'int', 'fips'],
                          )); -}
 
 static

--- a/providers/implementations/exchange/ecx_exch.c.in
+++ b/providers/implementations/exchange/ecx_exch.c.in
@@ -182,7 +182,7 @@ static void *ecx_dupctx(void *vecxctx)
 
 #ifdef FIPS_MODULE
 {- produce_param_decoder('ecx_get_ctx_params',
-                         (['ALG_PARAM_FIPS_APPROVED_INDICATOR', 'ind', 'int'],
+                         (['ALG_PARAM_FIPS_APPROVED_INDICATOR', 'ind', 'int', 'fips'],
                          )); -}
 #endif
 

--- a/providers/implementations/kem/rsa_kem.c.in
+++ b/providers/implementations/kem/rsa_kem.c.in
@@ -176,9 +176,8 @@ static int rsakem_decapsulate_init(void *vprsactx, void *vrsa,
                        "RSA Decapsulate Init");
 }
 
-
 {- produce_param_decoder('rsakem_get_ctx_params',
-                         (['KEM_PARAM_FIPS_APPROVED_INDICATOR', 'ind', 'int'],
+                         (['KEM_PARAM_FIPS_APPROVED_INDICATOR', 'ind', 'int', 'fips'],
                          )); -}
 
 static int rsakem_get_ctx_params(void *vprsactx, OSSL_PARAM *params)
@@ -202,7 +201,7 @@ static const OSSL_PARAM *rsakem_gettable_ctx_params(ossl_unused void *vprsactx,
 
 {- produce_param_decoder('rsakem_set_ctx_params',
                          (['KEM_PARAM_OPERATION',       'op',    'utf8_string'],
-                          ['KEM_PARAM_FIPS_KEY_CHECK',  'ind_k', 'int'],
+                          ['KEM_PARAM_FIPS_KEY_CHECK',  'ind_k', 'int', 'fips'],
                          )); -}
 
 static int rsakem_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])

--- a/providers/implementations/macs/cmac_prov.c.in
+++ b/providers/implementations/macs/cmac_prov.c.in
@@ -206,7 +206,7 @@ static int cmac_final(void *vmacctx, unsigned char *out, size_t *outl,
 {- produce_param_decoder('cmac_get_ctx_params',
                          (['MAC_PARAM_SIZE',                    'size',   'size_t'],
                           ['MAC_PARAM_BLOCK_SIZE',              'bsize',  'size_t'],
-                          ['ALG_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int'],
+                          ['ALG_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int', 'fips'],
                          )); -}
 
 static const OSSL_PARAM *cmac_gettable_ctx_params(ossl_unused void *ctx,
@@ -240,7 +240,7 @@ static int cmac_get_ctx_params(void *vmacctx, OSSL_PARAM params[])
                           ['ALG_PARAM_ENGINE',                'engine', 'utf8_string', 'hidden'],
                           ['MAC_PARAM_PROPERTIES',            'propq',  'utf8_string'],
                           ['MAC_PARAM_KEY',                   'key',    'octet_string'],
-                          ['CIPHER_PARAM_FIPS_ENCRYPT_CHECK', 'ind_ec', 'int'],
+                          ['CIPHER_PARAM_FIPS_ENCRYPT_CHECK', 'ind_ec', 'int', 'fips'],
                          )); -}
 
 static const OSSL_PARAM *cmac_settable_ctx_params(ossl_unused void *ctx,

--- a/providers/implementations/macs/hmac_prov.c.in
+++ b/providers/implementations/macs/hmac_prov.c.in
@@ -273,7 +273,7 @@ static int hmac_final(void *vmacctx, unsigned char *out, size_t *outl,
 {- produce_param_decoder('hmac_get_ctx_params',
                          (['MAC_PARAM_SIZE',                    'size',   'size_t'],
                           ['MAC_PARAM_BLOCK_SIZE',              'bsize',  'size_t'],
-                          ['ALG_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int'],
+                          ['ALG_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int', 'fips'],
                          )); -}
 
 static const OSSL_PARAM *hmac_gettable_ctx_params(ossl_unused void *ctx,
@@ -315,7 +315,7 @@ static int hmac_get_ctx_params(void *vmacctx, OSSL_PARAM params[])
                           ['MAC_PARAM_PROPERTIES',     'propq',   'utf8_string'],
                           ['MAC_PARAM_KEY',            'key',     'octet_string'],
                           ['MAC_PARAM_TLS_DATA_SIZE',  'tlssize', 'size_t'],
-                          ['MAC_PARAM_FIPS_KEY_CHECK', 'ind_k',   'int'],
+                          ['MAC_PARAM_FIPS_KEY_CHECK', 'ind_k',   'int', 'fips'],
                          )); -}
 
 static const OSSL_PARAM *hmac_settable_ctx_params(ossl_unused void *ctx,

--- a/providers/implementations/macs/kmac_prov.c.in
+++ b/providers/implementations/macs/kmac_prov.c.in
@@ -395,7 +395,7 @@ static int kmac_final(void *vmacctx, unsigned char *out, size_t *outl,
 {- produce_param_decoder('kmac_get_ctx_params',
                          (['MAC_PARAM_SIZE',                    'size',   'size_t'],
                           ['MAC_PARAM_BLOCK_SIZE',              'bsize',  'size_t'],
-                          ['ALG_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int'],
+                          ['ALG_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int', 'fips'],
                          )); -}
 
 static const OSSL_PARAM *kmac_gettable_ctx_params(ossl_unused void *ctx,
@@ -433,8 +433,8 @@ static int kmac_get_ctx_params(void *vmacctx, OSSL_PARAM params[])
                           ['MAC_PARAM_SIZE',              'size',    'size_t'],
                           ['MAC_PARAM_KEY',               'key',     'octet_string'],
                           ['MAC_PARAM_CUSTOM',            'custom',  'octet_string'],
-                          ['MAC_PARAM_FIPS_KEY_CHECK',    'ind_k',   'int'],
-                          ['MAC_PARAM_FIPS_NO_SHORT_MAC', 'ind_sht', 'int'],
+                          ['MAC_PARAM_FIPS_KEY_CHECK',    'ind_k',   'int', 'fips'],
+                          ['MAC_PARAM_FIPS_NO_SHORT_MAC', 'ind_sht', 'int', 'fips'],
                          )); -}
 
 static const OSSL_PARAM *kmac_settable_ctx_params(ossl_unused void *ctx,

--- a/providers/implementations/rands/drbg_ctr.c.in
+++ b/providers/implementations/rands/drbg_ctr.c.in
@@ -689,7 +689,7 @@ static void drbg_ctr_free(void *vdrbg)
                           ['DRBG_PARAM_RESEED_TIME',            'reseed_time', 'time_t'],
                           ['DRBG_PARAM_RESEED_REQUESTS',        'reseed_req',  'uint'],
                           ['DRBG_PARAM_RESEED_TIME_INTERVAL',   'reseed_int',  'uint64'],
-                          ['KDF_PARAM_FIPS_APPROVED_INDICATOR', 'ind',         'int'],
+                          ['KDF_PARAM_FIPS_APPROVED_INDICATOR', 'ind',         'int', 'fips'],
                          )); -}
 
 static int drbg_ctr_get_ctx_params(void *vdrbg, OSSL_PARAM params[])

--- a/providers/implementations/rands/drbg_hash.c.in
+++ b/providers/implementations/rands/drbg_hash.c.in
@@ -491,7 +491,7 @@ static void drbg_hash_free(void *vdrbg)
                           ['DRBG_PARAM_RESEED_TIME',            'reseed_time', 'time_t'],
                           ['DRBG_PARAM_RESEED_REQUESTS',        'reseed_req',  'uint'],
                           ['DRBG_PARAM_RESEED_TIME_INTERVAL',   'reseed_int',  'uint64'],
-                          ['KDF_PARAM_FIPS_APPROVED_INDICATOR', 'ind',         'int'],
+                          ['KDF_PARAM_FIPS_APPROVED_INDICATOR', 'ind',         'int', 'fips'],
                          )); -}
 
 static int drbg_hash_get_ctx_params(void *vdrbg, OSSL_PARAM params[])
@@ -634,7 +634,7 @@ static int drbg_hash_set_ctx_params_locked
                           ['PROV_PARAM_CORE_PROV_NAME',       'prov',        'utf8_string'],
                           ['DRBG_PARAM_RESEED_REQUESTS',      'reseed_req',  'uint'],
                           ['DRBG_PARAM_RESEED_TIME_INTERVAL', 'reseed_time', 'uint64'],
-                          ['KDF_PARAM_FIPS_DIGEST_CHECK',     'ind_d',       'int'],
+                          ['KDF_PARAM_FIPS_DIGEST_CHECK',     'ind_d',       'int', 'fips'],
                          )); -}
 
 static int drbg_hash_set_ctx_params(void *vctx, const OSSL_PARAM params[])

--- a/providers/implementations/rands/drbg_hmac.c.in
+++ b/providers/implementations/rands/drbg_hmac.c.in
@@ -384,7 +384,7 @@ static void drbg_hmac_free(void *vdrbg)
                           ['DRBG_PARAM_RESEED_TIME',            'reseed_time', 'time_t'],
                           ['DRBG_PARAM_RESEED_REQUESTS',        'reseed_req',  'uint'],
                           ['DRBG_PARAM_RESEED_TIME_INTERVAL',   'reseed_int',  'uint64'],
-                          ['KDF_PARAM_FIPS_APPROVED_INDICATOR', 'ind',         'int'],
+                          ['KDF_PARAM_FIPS_APPROVED_INDICATOR', 'ind',         'int', 'fips'],
                          )); -}
 
 static int drbg_hmac_get_ctx_params(void *vdrbg, OSSL_PARAM params[])
@@ -557,7 +557,7 @@ static int drbg_hmac_set_ctx_params_locked
                           ['PROV_PARAM_CORE_PROV_NAME',       'prov',        'utf8_string'],
                           ['DRBG_PARAM_RESEED_REQUESTS',      'reseed_req',  'uint'],
                           ['DRBG_PARAM_RESEED_TIME_INTERVAL', 'reseed_time', 'uint64'],
-                          ['KDF_PARAM_FIPS_DIGEST_CHECK',     'ind_d',       'int'],
+                          ['KDF_PARAM_FIPS_DIGEST_CHECK',     'ind_d',       'int', 'fips'],
                          )); -}
 
 static int drbg_hmac_set_ctx_params(void *vctx, const OSSL_PARAM params[])

--- a/providers/implementations/rands/fips_crng_test.c.in
+++ b/providers/implementations/rands/fips_crng_test.c.in
@@ -369,7 +369,7 @@ static void crng_test_unlock(ossl_unused void *vcrngt)
                          (['RAND_PARAM_STATE',                   'state',  'int'],
                           ['RAND_PARAM_STRENGTH',                'str',    'uint'],
                           ['RAND_PARAM_MAX_REQUEST',             'maxreq', 'size_t'],
-                          ['RAND_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int'],
+                          ['RAND_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int', 'fips'],
                          )); -}
 
 static int crng_test_get_ctx_params(void *vcrngt, OSSL_PARAM params[])

--- a/providers/implementations/rands/test_rng.c.in
+++ b/providers/implementations/rands/test_rng.c.in
@@ -190,7 +190,7 @@ static size_t test_rng_nonce(void *vtest, unsigned char *out,
                           ['RAND_PARAM_STRENGTH',                'str',    'uint'],
                           ['RAND_PARAM_MAX_REQUEST',             'maxreq', 'size_t'],
                           ['RAND_PARAM_GENERATE',                'gen',    'uint'],
-                          ['RAND_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int'],
+                          ['RAND_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int', 'fips'],
                          )); -}
 
 static int test_rng_get_ctx_params(void *vtest, OSSL_PARAM params[])

--- a/providers/implementations/signature/dsa_sig.c.in
+++ b/providers/implementations/signature/dsa_sig.c.in
@@ -676,7 +676,7 @@ static void *dsa_dupctx(void *vpdsactx)
                          (['SIGNATURE_PARAM_ALGORITHM_ID',            'algid',  'octet_string'],
                           ['SIGNATURE_PARAM_DIGEST',                  'digest', 'utf8_string'],
                           ['SIGNATURE_PARAM_NONCE_TYPE',              'nonce',  'uint'],
-                          ['SIGNATURE_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int'],
+                          ['SIGNATURE_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int', 'fips'],
                          )); -}
 
 static int dsa_get_ctx_params(void *vpdsactx, OSSL_PARAM *params)
@@ -714,9 +714,11 @@ static const OSSL_PARAM *dsa_gettable_ctx_params(ossl_unused void *ctx,
 struct dsa_all_set_ctx_params_st {
     OSSL_PARAM *digest;     /* dsa_set_ctx_params */
     OSSL_PARAM *propq;      /* dsa_set_ctx_params */
+#ifdef FIPS_MODULE
     OSSL_PARAM *ind_d;
     OSSL_PARAM *ind_k;
     OSSL_PARAM *ind_sign;
+#endif
     OSSL_PARAM *nonce;
     OSSL_PARAM *sig;        /* dsa_sigalg_set_ctx_params */
 };
@@ -751,9 +753,9 @@ static int dsa_common_set_ctx_params(PROV_DSA_CTX *pdsactx,
                          (['SIGNATURE_PARAM_DIGEST',            'digest',   'utf8_string'],
                           ['SIGNATURE_PARAM_PROPERTIES',        'propq',    'utf8_string'],
                           ['SIGNATURE_PARAM_NONCE_TYPE',        'nonce',    'uint'],
-                          ['SIGNATURE_PARAM_FIPS_KEY_CHECK',    'ind_k',    'int'],
-                          ['SIGNATURE_PARAM_FIPS_DIGEST_CHECK', 'ind_d',    'int'],
-                          ['SIGNATURE_PARAM_FIPS_SIGN_CHECK',   'ind_sign', 'int'],
+                          ['SIGNATURE_PARAM_FIPS_KEY_CHECK',    'ind_k',    'int', 'fips'],
+                          ['SIGNATURE_PARAM_FIPS_DIGEST_CHECK', 'ind_d',    'int', 'fips'],
+                          ['SIGNATURE_PARAM_FIPS_SIGN_CHECK',   'ind_sign', 'int', 'fips'],
                          )); -}
 
 static int dsa_set_ctx_params(void *vpdsactx, const OSSL_PARAM params[])
@@ -939,9 +941,9 @@ static const char **dsa_sigalg_query_key_types(void)
 {- produce_param_decoder('dsa_sigalg_set_ctx_params',
                          (['SIGNATURE_PARAM_SIGNATURE',         'sig',      'octet_string'],
                           ['SIGNATURE_PARAM_NONCE_TYPE',        'nonce',    'uint'],
-                          ['SIGNATURE_PARAM_FIPS_KEY_CHECK',    'ind_k',    'int'],
-                          ['SIGNATURE_PARAM_FIPS_DIGEST_CHECK', 'ind_d',    'int'],
-                          ['SIGNATURE_PARAM_FIPS_SIGN_CHECK',   'ind_sign', 'int'],
+                          ['SIGNATURE_PARAM_FIPS_KEY_CHECK',    'ind_k',    'int', 'fips'],
+                          ['SIGNATURE_PARAM_FIPS_DIGEST_CHECK', 'ind_d',    'int', 'fips'],
+                          ['SIGNATURE_PARAM_FIPS_SIGN_CHECK',   'ind_sign', 'int', 'fips'],
                          )); -}
 
 static const OSSL_PARAM *dsa_sigalg_settable_ctx_params(void *vpdsactx,

--- a/providers/implementations/signature/ecdsa_sig.c.in
+++ b/providers/implementations/signature/ecdsa_sig.c.in
@@ -680,8 +680,8 @@ static void *ecdsa_dupctx(void *vctx)
                           ['SIGNATURE_PARAM_DIGEST_SIZE',             'size',   'size_t'],
                           ['SIGNATURE_PARAM_DIGEST',                  'digest', 'utf8_string'],
                           ['SIGNATURE_PARAM_NONCE_TYPE',              'nonce',  'uint'],
-                          ['SIGNATURE_PARAM_FIPS_VERIFY_MESSAGE',     'verify', 'uint'],
-                          ['SIGNATURE_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int'],
+                          ['SIGNATURE_PARAM_FIPS_VERIFY_MESSAGE',     'verify', 'uint', 'fips'],
+                          ['SIGNATURE_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int', 'fips'],
                          )); -}
 
 static int ecdsa_get_ctx_params(void *vctx, OSSL_PARAM *params)
@@ -730,9 +730,13 @@ struct ecdsa_all_set_ctx_params_st {
     OSSL_PARAM *digest;     /* ecdsa_set_ctx_params */
     OSSL_PARAM *propq;      /* ecdsa_set_ctx_params */
     OSSL_PARAM *size;       /* ecdsa_set_ctx_params */
+#ifdef FIPS_MODULE
     OSSL_PARAM *ind_d;
     OSSL_PARAM *ind_k;
+#endif
+#if !defined(OPENSSL_NO_ACVP_TESTS)
     OSSL_PARAM *kat;
+#endif
     OSSL_PARAM *nonce;
     OSSL_PARAM *sig;        /* ecdsa_sigalg_set_ctx_params */
 };
@@ -768,10 +772,11 @@ static int ecdsa_common_set_ctx_params(PROV_ECDSA_CTX *ctx,
                          (['SIGNATURE_PARAM_DIGEST',            'digest',   'utf8_string'],
                           ['SIGNATURE_PARAM_PROPERTIES',        'propq',    'utf8_string'],
                           ['SIGNATURE_PARAM_DIGEST_SIZE',       'size',     'size_t'],
-                          ['SIGNATURE_PARAM_KAT',               'kat',      'uint'],
+                          ['SIGNATURE_PARAM_KAT',               'kat',      'uint',
+                           "#if !defined(OPENSSL_NO_ACVP_TESTS)"],
                           ['SIGNATURE_PARAM_NONCE_TYPE',        'nonce',    'uint'],
-                          ['SIGNATURE_PARAM_FIPS_KEY_CHECK',    'ind_k',    'int'],
-                          ['SIGNATURE_PARAM_FIPS_DIGEST_CHECK', 'ind_d',    'int'],
+                          ['SIGNATURE_PARAM_FIPS_KEY_CHECK',    'ind_k',    'int', 'fips'],
+                          ['SIGNATURE_PARAM_FIPS_DIGEST_CHECK', 'ind_d',    'int', 'fips'],
                          )); -}
 
 static int ecdsa_set_ctx_params(void *vctx, const OSSL_PARAM params[])
@@ -956,10 +961,11 @@ static const char **ecdsa_sigalg_query_key_types(void)
 
 {- produce_param_decoder('ecdsa_sigalg_set_ctx_params',
                          (['SIGNATURE_PARAM_SIGNATURE',         'sig',   'octet_string'],
-                          ['SIGNATURE_PARAM_KAT',               'kat',   'uint'],
+                          ['SIGNATURE_PARAM_KAT',               'kat',   'uint',
+                           "#if !defined(OPENSSL_NO_ACVP_TESTS)"],
                           ['SIGNATURE_PARAM_NONCE_TYPE',        'nonce', 'uint'],
-                          ['SIGNATURE_PARAM_FIPS_KEY_CHECK',    'ind_k', 'int'],
-                          ['SIGNATURE_PARAM_FIPS_DIGEST_CHECK', 'ind_d', 'int'],
+                          ['SIGNATURE_PARAM_FIPS_KEY_CHECK',    'ind_k', 'int', 'fips'],
+                          ['SIGNATURE_PARAM_FIPS_DIGEST_CHECK', 'ind_d', 'int', 'fips'],
                          )); -}
 
 static const OSSL_PARAM *ecdsa_sigalg_settable_ctx_params(void *vctx,

--- a/providers/implementations/signature/rsa_sig.c.in
+++ b/providers/implementations/signature/rsa_sig.c.in
@@ -1393,8 +1393,8 @@ static void *rsa_dupctx(void *vprsactx)
                           ['SIGNATURE_PARAM_MGF1_DIGEST',             'mgf1',   'utf8_string'],
                           ['SIGNATURE_PARAM_PSS_SALTLEN',             'slen',   'utf8_string'],
                           ['SIGNATURE_PARAM_PSS_SALTLEN',             'slen',   'int'],
-                          ['SIGNATURE_PARAM_FIPS_VERIFY_MESSAGE',     'verify', 'uint'],
-                          ['SIGNATURE_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int'],
+                          ['SIGNATURE_PARAM_FIPS_VERIFY_MESSAGE',     'verify', 'uint', 'fips'],
+                          ['SIGNATURE_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int', 'fips'],
                          )); -}
 
 static int rsa_get_ctx_params(void *vprsactx, OSSL_PARAM *params)
@@ -1532,10 +1532,10 @@ static int rsa_x931_padding_allowed(PROV_RSA_CTX *ctx)
                           ['SIGNATURE_PARAM_MGF1_PROPERTIES',            'mgf1pq',   'utf8_string'],
                           ['SIGNATURE_PARAM_PSS_SALTLEN',                'slen',     'utf8_string'],
                           ['SIGNATURE_PARAM_PSS_SALTLEN',                'slen',     'int'],
-                          ['SIGNATURE_PARAM_FIPS_KEY_CHECK',             'ind_k',    'int'],
-                          ['SIGNATURE_PARAM_FIPS_DIGEST_CHECK',          'ind_d',    'int'],
-                          ['SIGNATURE_PARAM_FIPS_RSA_PSS_SALTLEN_CHECK', 'ind_slen', 'int'],
-                          ['SIGNATURE_PARAM_FIPS_SIGN_X931_PAD_CHECK',   'ind_xpad', 'int'],
+                          ['SIGNATURE_PARAM_FIPS_KEY_CHECK',             'ind_k',    'int', 'fips'],
+                          ['SIGNATURE_PARAM_FIPS_DIGEST_CHECK',          'ind_d',    'int', 'fips'],
+                          ['SIGNATURE_PARAM_FIPS_RSA_PSS_SALTLEN_CHECK', 'ind_slen', 'int', 'fips'],
+                          ['SIGNATURE_PARAM_FIPS_SIGN_X931_PAD_CHECK',   'ind_xpad', 'int', 'fips'],
                          )); -}
 
 #define rsa_set_ctx_params_no_digest_st  rsa_set_ctx_params_st
@@ -1547,10 +1547,10 @@ static int rsa_x931_padding_allowed(PROV_RSA_CTX *ctx)
                           ['SIGNATURE_PARAM_MGF1_PROPERTIES',            'mgf1pq',   'utf8_string'],
                           ['SIGNATURE_PARAM_PSS_SALTLEN',                'slen',     'utf8_string'],
                           ['SIGNATURE_PARAM_PSS_SALTLEN',                'slen',     'int'],
-                          ['SIGNATURE_PARAM_FIPS_KEY_CHECK',             'ind_k',    'int'],
-                          ['SIGNATURE_PARAM_FIPS_DIGEST_CHECK',          'ind_d',    'int'],
-                          ['SIGNATURE_PARAM_FIPS_RSA_PSS_SALTLEN_CHECK', 'ind_slen', 'int'],
-                          ['SIGNATURE_PARAM_FIPS_SIGN_X931_PAD_CHECK',   'ind_xpad', 'int'],
+                          ['SIGNATURE_PARAM_FIPS_KEY_CHECK',             'ind_k',    'int', 'fips'],
+                          ['SIGNATURE_PARAM_FIPS_DIGEST_CHECK',          'ind_d',    'int', 'fips'],
+                          ['SIGNATURE_PARAM_FIPS_RSA_PSS_SALTLEN_CHECK', 'ind_slen', 'int', 'fips'],
+                          ['SIGNATURE_PARAM_FIPS_SIGN_X931_PAD_CHECK',   'ind_xpad', 'int', 'fips'],
                          )); -}
 
 static int rsa_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])


### PR DESCRIPTION
Add FIPS conditionals to parameters.  These were lost as part of the autogenerated parser refactoring.  They are now being put back.

There should be no functional difference beyond correct advertising of the available parameters.  Previous the parser would find them but ignore them during processing.