### PR TITLE
Add CRYPTO_FREE_REF to ossl_quic_free_token_store

### DIFF
--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4778,6 +4778,7 @@ void ossl_quic_free_token_store(SSL_TOKEN_STORE *hdl)
     ossl_crypto_mutex_free(&hdl->mutex);
     lh_QUIC_TOKEN_doall(hdl->cache, free_this_token);
     lh_QUIC_TOKEN_free(hdl->cache);
+    CRYPTO_FREE_REF(&hdl->references);
     OPENSSL_free(hdl);
     return;
 }


### PR DESCRIPTION
ossl_quic_free_token_store doesn't call CRYPTO_FREE_REF on the hdl->reference object, which could lead to memory leaks on platforms that don't support atomics (where the call to CRYPTO_NEW_REF allocates a mutex as part of its function.  It wasn't caught before because all the platforms we do ci on support threads.

Fixes #28241
