### PR TITLE
s_server: Add an option to accept on a provided fd

### DIFF
--- a/apps/include/s_apps.h
+++ b/apps/include/s_apps.h
@@ -25,6 +25,9 @@ int do_server(int *accept_sock, const char *host, const char *port,
               int family, int type, int protocol, do_server_cb cb,
               unsigned char *context, int naccept, BIO *bio_s_out,
               int tfo);
+int do_server_unix_fd(int fd, int type, int protocol,
+                      do_server_cb cb, unsigned char *context, int naccept,
+                      BIO *bio_s_out);
 int verify_callback(int ok, X509_STORE_CTX *ctx);
 
 int set_cert_stuff(SSL_CTX *ctx, char *cert_file, char *key_file);

--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -13,6 +13,7 @@ B<openssl> B<s_server>
 [B<-help>]
 [B<-port> I<+int>]
 [B<-accept> I<val>]
+[B<-accept_fd> I<+int>]
 [B<-unix> I<val>]
 [B<-4>]
 [B<-6>]
@@ -160,6 +161,14 @@ The TCP port to listen on for connections. If not specified 4433 is used.
 =item B<-accept> I<val>
 
 The optional TCP host and port to listen on for connections. If not specified, *:4433 is used.
+
+=item B<-accept_fd> I<+int>
+
+The file descriptor number to accept connections on. This option allows
+the SSL server to use a pre-existing file descriptor that is already listening
+for connections. When this option is used, the server will directly call accept()
+on the descriptor. This option is mutually exclusive with B<-port>, B<-accept>,
+B<-unix>, and B<-tfo>.
 
 =item B<-unix> I<val>
 


### PR DESCRIPTION
This commits adds a new option to s_server to make use of an additional stdio fd (e.g. fd 3) as the server to accept on. The motivation is to let an outer driver script handle port/interface selection. For example, we use `s_server` in the julia (https://github.com/JuliaLang/julia) test suite to test various SSL client scenarios. The machines we run these tests on are shared and often run multiple copies of the test suite at the same time. As such, we randomize and probe for free ports for s_server to listen on. However, because we need to release the port before providing it to `s_server`, there is a window where a different process may acquire the port, causing confusion. One solution would be to implement the port probing logic in s_server and pass it back out to the client, but the specification of the probe range/interfaces may be non-trivial. It seems simplest just to allow the outer driver to provide an additional file descriptor to use. Of course on linux a similar effect can already be achieved with existing options and `/proc/self/fd`, but that is platform specific. The proposed option would work on all platforms (as well as Windows with msvcrt, although the setup on the caller is a little more complicated, but well-abstracted in most modern scripting languages).

I've tested the implementation on my machine, but is a bit of quick-and-dirty thing and needs testing on other platforms (windows in particular). At this stage, I'm primarily looking for feedback on whether the feature is acceptable. If so, I'll try to add a test, CLA, etc and test elsewhere.