### PR TITLE
Fix potential null pointer dereference in pkey_dh_derive

### DIFF
--- a/crypto/dh/dh_pmeth.c
+++ b/crypto/dh/dh_pmeth.c
@@ -408,7 +408,7 @@ static int pkey_dh_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
     }
     dh = (DH *)EVP_PKEY_get0_DH(ctx->pkey);
     dhpub = EVP_PKEY_get0_DH(ctx->peerkey);
-    if (dhpub == NULL) {
+    if (dhpub == NULL || dh == NULL) {
         ERR_raise(ERR_LIB_DH, DH_R_KEYS_NOT_SET);
         return 0;
     }


### PR DESCRIPTION
### Description

This pull request adds a NULL check for the `dh` pointer returned by `EVP_PKEY_get0_DH()` in the `pkey_dh_derive` function (`crypto/dh/dh_pmeth.c`). This prevents a potential null pointer dereference as reported by static analysis tools.


**Fixes:** #28245


<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->


<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

