### PR TITLE
Windows compilation issue - unable to find correct definitions of _In…

### DIFF
--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -174,19 +174,19 @@ static __inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 
 static __inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
-    *ret = _InterlockedExchangeAdd((void *)&refcnt->val, 1) + 1;
+    *ret = _InterlockedExchangeAdd((long volatile *)&refcnt->val, 1) + 1;
     return 1;
 }
 
 static __inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
-    *ret = _InterlockedExchangeAdd((void *)&refcnt->val, -1) - 1;
+    *ret = _InterlockedExchangeAdd((long volatile *)&refcnt->val, -1) - 1;
     return 1;
 }
 
 static __inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
-    *ret = _InterlockedExchangeAdd((void *)&refcnt->val, 0);
+    *ret = _InterlockedExchangeAdd((long volatile *)&refcnt->val, 0);
     return 1;
 }
 

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -174,19 +174,19 @@ static __inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 
 static __inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
-    *ret = _InterlockedExchangeAdd((void *) &refcnt->val, 1) + 1;
+    *ret = _InterlockedExchangeAdd((void *)&refcnt->val, 1) + 1;
     return 1;
 }
 
 static __inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
-    *ret = _InterlockedExchangeAdd((void *) &refcnt->val, -1) - 1;
+    *ret = _InterlockedExchangeAdd((void *)&refcnt->val, -1) - 1;
     return 1;
 }
 
 static __inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
-    *ret = _InterlockedExchangeAdd((void *) &refcnt->val, 0);
+    *ret = _InterlockedExchangeAdd((void *)&refcnt->val, 0);
     return 1;
 }
 

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -174,19 +174,19 @@ static __inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 
 static __inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
-    *ret = _InterlockedExchangeAdd(&refcnt->val, 1) + 1;
+    *ret = _InterlockedExchangeAdd((void *) &refcnt->val, 1) + 1;
     return 1;
 }
 
 static __inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
-    *ret = _InterlockedExchangeAdd(&refcnt->val, -1) - 1;
+    *ret = _InterlockedExchangeAdd((void *) &refcnt->val, -1) - 1;
     return 1;
 }
 
 static __inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
-    *ret = _InterlockedExchangeAdd(&refcnt->val, 0);
+    *ret = _InterlockedExchangeAdd((void *) &refcnt->val, 0);
     return 1;
 }
 

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -174,19 +174,19 @@ static __inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 
 static __inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
-    *ret = _InterlockedExchangeAdd((long volatile *) &refcnt->val, 1) + 1;
+    *ret = _InterlockedExchangeAdd((void *) &refcnt->val, 1) + 1;
     return 1;
 }
 
 static __inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
-    *ret = _InterlockedExchangeAdd((long volatile *) &refcnt->val, -1) - 1;
+    *ret = _InterlockedExchangeAdd((void *) &refcnt->val, -1) - 1;
     return 1;
 }
 
 static __inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
-    *ret = _InterlockedExchangeAdd((long volatile *) &refcnt->val, 0);
+    *ret = _InterlockedExchangeAdd((void *) &refcnt->val, 0);
     return 1;
 }
 

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -174,19 +174,19 @@ static __inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 
 static __inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
-    *ret = _InterlockedExchangeAdd((void *) &refcnt->val, 1) + 1;
+    *ret = _InterlockedExchangeAdd((long volatile *) &refcnt->val, 1) + 1;
     return 1;
 }
 
 static __inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
-    *ret = _InterlockedExchangeAdd((void *) &refcnt->val, -1) - 1;
+    *ret = _InterlockedExchangeAdd((long volatile *) &refcnt->val, -1) - 1;
     return 1;
 }
 
 static __inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
-    *ret = _InterlockedExchangeAdd((void *) &refcnt->val, 0);
+    *ret = _InterlockedExchangeAdd((long volatile *) &refcnt->val, 0);
     return 1;
 }
 


### PR DESCRIPTION
Fixed for below Windows compilation issue with refcount

```
C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\um\winnt.h(3135): note: or       'LONG _InterlockedExchangeAdd(volatile LONG *,LONG)'
C:\WorkSpace\cadp-c\src\build\Windows_NT_10.0.19045.6093_64\include\internal/refcount.h(189): note: 'LONG _InterlockedExchangeAdd(volatile LONG *,LONG)': cannot convert argument 1 from 'volatile int *' to 'volatile LONG *'
C:\WorkSpace\cadp-c\src\build\Windows_NT_10.0.19045.6093_64\include\internal/refcount.h(189): note: Types pointed to are unrelated; conversi
```
Issue number - https://github.com/openssl/openssl/issues/21080

CLA: trivial

- [ ] documentation is added or updated
- [ ] tests are added or updated
