### PR TITLE
Add explicit error queue instructions in d2i_X509(3) and SSL_get_error(3)

### DIFF
--- a/doc/man3/SSL_get_error.pod
+++ b/doc/man3/SSL_get_error.pod
@@ -23,7 +23,8 @@ current thread's OpenSSL error queue.  Thus, SSL_get_error() must be
 used in the same thread that performed the TLS/SSL I/O operation, and no
 other OpenSSL function calls should appear in between.  The current
 thread's error queue must be empty before the TLS/SSL I/O operation is
-attempted, or SSL_get_error() will not work reliably.
+attempted, or SSL_get_error() will not work reliably.  Emptying the
+current thread's error queue is done with L<ERR_clear_error(3)>.
 
 =head1 NOTES
 
@@ -181,9 +182,13 @@ connection and SSL_shutdown() must not be called.
 
 =back
 
+The OpenSSL error queue can be inspected with the B<ERR> family of functions,
+such as L<ERR_print_errors(3)> and L<ERR_peek_last_error_all(3)>.
+
 =head1 SEE ALSO
 
-L<ssl(7)>
+L<ssl(7)>,
+L<ERR_clear_error(3)>, ERR_print_errors(3), ERR_peek_last_error_all(3)
 
 =head1 HISTORY
 

--- a/doc/man3/d2i_X509.pod
+++ b/doc/man3/d2i_X509.pod
@@ -592,6 +592,10 @@ B<i2d_I<TYPE>_bio>() and B<i2d_I<TYPE>_fp>(),
 as well as i2d_ASN1_bio_stream(),
 return 1 for success and 0 if an error occurs.
 
+On error, these functions may record the error in the OpenSSL error queue.
+That error queue can be inspected with the B<ERR> family of functions, such as
+L<ERR_print_errors(3)> and L<ERR_peek_last_error_all(3)>.
+
 =head1 EXAMPLES
 
 Allocate and encode the DER encoding of an X509 structure:
@@ -703,6 +707,10 @@ B<i2d_I<TYPE>_bio>() or B<i2d_I<TYPE>_fp>()) may return a stale encoding if the
 structure has been modified after deserialization or previous
 serialization. This is because some objects cache the encoding for
 efficiency reasons.
+
+=head1 SEE ALSO
+
+ERR_print_errors(3), ERR_peek_last_error_all(3)
 
 =head1 HISTORY
 


### PR DESCRIPTION
-----

This is related to https://github.com/openssl/openssl/issues/28263, but does not complete it (further efforts necessary).
This is triggered by discussions on documentation emanating from https://github.com/curl/curl/issues/18190
