### PR TITLE
Fail immediately if we have no key shares to send

### DIFF
--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -745,6 +745,7 @@ EXT_RETURN tls_construct_ctos_key_share(SSL_CONNECTION *s, WPACKET *pkt,
             /* SSLfatal() already called */
             return EXT_RETURN_FAIL;
         }
+        valid_keyshare++;
     } else {
         if (s->ext.supportedgroups == NULL) /* use default */
             add_only_one = 1;
@@ -766,11 +767,16 @@ EXT_RETURN tls_construct_ctos_key_share(SSL_CONNECTION *s, WPACKET *pkt,
                 /* SSLfatal() already called */
                 return EXT_RETURN_FAIL;
             }
+            valid_keyshare++;
             if (add_only_one)
                 break;
-
-            valid_keyshare++;
         }
+    }
+
+    if (valid_keyshare == 0) {
+        /* No key shares were allowed */
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_R_NO_SUITABLE_KEY_SHARE);
+        return EXT_RETURN_FAIL;
     }
 
     if (!WPACKET_close(pkt) || !WPACKET_close(pkt)) {

--- a/test/tls13groupselection_test.c
+++ b/test/tls13groupselection_test.c
@@ -499,8 +499,8 @@ static int test_groupnegotiation(const struct tls13groupselection_test_st *curre
     } else {
         TEST_false_or_end(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE));
         if (test_type == TEST_NEGOTIATION_FAILURE &&
-              !TEST_int_eq((int)current_test_vector->expected_server_response,
-                           (int)server_response))
+                !TEST_int_eq((int)current_test_vector->expected_server_response,
+                             (int)server_response))
             goto end;
         ok = 1;
     }

--- a/test/tls13groupselection_test.c
+++ b/test/tls13groupselection_test.c
@@ -311,17 +311,17 @@ static const struct tls13groupselection_test_st tls13groupselection_tests[] =
         { "X25519:secp256r1:X448:secp521r1:-X448:-secp256r1:-X25519:-secp521r1",
           "",
           CLIENT_PREFERENCE,
-          NEGOTIATION_FAILURE
+          NEGOTIATION_FAILURE, INIT
         },
         { "secp384r1:secp521r1:X25519", /* test 39 */
           "prime256v1:X448",
           CLIENT_PREFERENCE,
-          NEGOTIATION_FAILURE
+          NEGOTIATION_FAILURE, INIT
         },
         { "secp521r1:secp384r1:X25519", /* test 40 */
           "prime256v1:X448",
           SERVER_PREFERENCE,
-          NEGOTIATION_FAILURE
+          NEGOTIATION_FAILURE, INIT
         },
         /*
          * These are allowed
@@ -340,6 +340,15 @@ static const struct tls13groupselection_test_st tls13groupselection_tests[] =
           SERVER_PREFERENCE,
           "secp521r1", SH
         },
+        /*
+         * Not a syntax error, but invalid because brainpoolP256r1 is the only
+         * key share and is not valid in TLSv1.3
+         */
+        { "*brainpoolP256r1:X25519", /* test 43 */
+          "X25519",
+          SERVER_PREFERENCE,
+          NEGOTIATION_FAILURE, INIT
+        }
     };
 
 static void server_response_check_cb(int write_p, int version,
@@ -489,6 +498,10 @@ static int test_groupnegotiation(const struct tls13groupselection_test_st *curre
             ok = 1;
     } else {
         TEST_false_or_end(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE));
+        if (test_type == TEST_NEGOTIATION_FAILURE &&
+              !TEST_int_eq((int)current_test_vector->expected_server_response,
+                           (int)server_response))
+            goto end;
         ok = 1;
     }
 


### PR DESCRIPTION
If we are configured in such a way that we have no valid key shares to
send in the ClientHello we should immediately abort the connection.

Fixes https://github.com/openssl/openssl/issues/28281
