### PR TITLE
Fix #28109 find_doc_nits: Exclude .gitmodules from the env var check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,14 +44,6 @@ jobs:
     - name: git diff
       run: git diff --exit-code
 
-  check_docs:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: config
-      run: ./config --strict-warnings --banner=Configured enable-fips && perl configdata.pm --dump
-    - name: make build_generated
-      run: make -s build_generated
   check_docs:  
     runs-on: ubuntu-latest  
     steps:  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,22 @@ jobs:
       run: ./config --strict-warnings --banner=Configured enable-fips && perl configdata.pm --dump
     - name: make build_generated
       run: make -s build_generated
+  check_docs:  
+    runs-on: ubuntu-latest  
+    steps:  
+    - uses: actions/checkout@v4  
+    - name: config  
+      run: ./config --strict-warnings --banner=Configured enable-fips && perl configdata.pm --dump  
+    - name: make build_generated  
+      run: make -s build_generated  
     - name: make doc-nits
       run: make doc-nits
     - name: make help
       run: make help
     - name: make md-nits
       run: |
-          sudo gem install mdl
-          make md-nits
+        sudo gem install mdl
+        make md-nits
 
   # This checks that we use ANSI C language syntax and semantics.
   # We are not as strict with libraries, but rather adapt to what's

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1189,7 +1189,13 @@ doc-nits: build_generated_pods ## Evaluate OpenSSL documentation
 # Finally, there's a Node.js version, which we haven't tried, that
 # can be found at https://github.com/DavidAnson/markdownlint
 md-nits: ## Evaluate markdown files via "mdl"
-	mdl -s $(SRCDIR)/util/markdownlint.rb .
+	@SUBMODULE_EXCLUDES=""; \
+	if [ -f $(SRCDIR)/.gitmodules ]; then \
+		for path in $$(git config --file $(SRCDIR)/.gitmodules --get-regexp path | awk '{print $$2}'); do \
+			SUBMODULE_EXCLUDES="$$SUBMODULE_EXCLUDES --ignore-path $$path"; \
+		done; \
+	fi; \
+	mdl -s $(SRCDIR)/util/markdownlint.rb $$SUBMODULE_EXCLUDES $(SRCDIR)
 
 # Test coverage is a good idea for the future
 #coverage: $(PROGRAMS) $(TESTPROGRAMS)

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -44,6 +44,27 @@ our($opt_c);
 our($opt_i);
 our($opt_a);
 
+# Get submodule paths from .gitmodules
+sub get_submodule_paths {
+    my @submodule_paths = ();
+    my $gitmodules_file = catfile($config{sourcedir}, '.gitmodules');
+    
+    return @submodule_paths unless -f $gitmodules_file;
+    
+    open my $fh, '<', $gitmodules_file or return @submodule_paths;
+    while (my $line = <$fh>) {
+        chomp $line;
+        if ($line =~ /^\s*path\s*=\s*(.+)$/) {
+            my $path = $1;
+            $path =~ s/^\s+|\s+$//g;  # trim whitespace
+            push @submodule_paths, catfile($config{sourcedir}, $path);
+        }
+    }
+    close $fh;
+    
+    return @submodule_paths;
+}
+
 # Print usage message and exit.
 sub help {
     print <<EOF;
@@ -1289,9 +1310,17 @@ sub check_env_vars {
     my @env_headers;
     my @env_macro;
 
+    # Get submodule paths to exclude
+    my @submodule_paths = get_submodule_paths();
+
     # look for source files
-    find(sub { push @env_files, $File::Find::name if /\.c$|\.in$/; },
-         $config{sourcedir});
+    find(sub { 
+        # Skip if we're in a submodule directory
+        for my $submodule_path (@submodule_paths) {
+            return if index($File::Find::name, $submodule_path) == 0;
+        }
+        push @env_files, $File::Find::name if /\.c$|\.in$/; 
+    }, $config{sourcedir});
 
     foreach my $filename (@env_files) {
         next if $filename =~ /test\/|demos\//
@@ -1333,8 +1362,13 @@ sub check_env_vars {
     }
 
     # look for constants in header files
-    find(sub { push @env_headers, $File::Find::name if /\.h$/; },
-         $config{sourcedir});
+    find(sub { 
+        # Skip if we're in a submodule directory
+        for my $submodule_path (@submodule_paths) {
+            return if index($File::Find::name, $submodule_path) == 0;
+        }
+        push @env_headers, $File::Find::name if /\.h$/; 
+    }, $config{sourcedir});
 
      foreach my $filename (@env_headers) {
         open my $fh, '<', $filename or die "Can't open $filename: $!";


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
