### PR TITLE
Fix: Add free to avoid memory leak.

### DIFF
--- a/demos/bio/saccept.c
+++ b/demos/bio/saccept.c
@@ -53,7 +53,8 @@ int main(int argc, char *argv[])
 {
     char *port = NULL;
     BIO *in = NULL;
-    BIO *ssl_bio, *tmp;
+    BIO *ssl_bio = NULL;
+    BIO *tmp;
     SSL_CTX *ctx;
     char buf[512];
     int ret = EXIT_FAILURE, i;
@@ -83,6 +84,7 @@ int main(int argc, char *argv[])
      * Basically it means the SSL BIO will be automatically setup
      */
     BIO_set_accept_bios(in, ssl_bio);
+    ssl_bio = NULL;
 
     /* Arrange to leave server loop on interrupt */
     sigsetup();
@@ -121,5 +123,6 @@ int main(int argc, char *argv[])
     if (ret != EXIT_SUCCESS)
         ERR_print_errors_fp(stderr);
     BIO_free(in);
+    BIO_free_all(ssl_bio);
     return ret;
 }

--- a/demos/bio/server-arg.c
+++ b/demos/bio/server-arg.c
@@ -23,7 +23,8 @@
 int main(int argc, char *argv[])
 {
     char *port = "*:4433";
-    BIO *ssl_bio, *tmp;
+    BIO *ssl_bio = NULL;
+    BIO *tmp;
     SSL_CTX *ctx;
     SSL_CONF_CTX *cctx;
     char buf[512];
@@ -105,6 +106,7 @@ int main(int argc, char *argv[])
      * Basically it means the SSL BIO will be automatically setup
      */
     BIO_set_accept_bios(in, ssl_bio);
+    ssl_bio = NULL;
 
  again:
     /*
@@ -140,5 +142,6 @@ int main(int argc, char *argv[])
     if (ret != EXIT_SUCCESS)
         ERR_print_errors_fp(stderr);
     BIO_free(in);
+    BIO_free_all(ssl_bio);
     return ret;
 }

--- a/demos/bio/server-cmod.c
+++ b/demos/bio/server-cmod.c
@@ -24,7 +24,8 @@ int main(int argc, char *argv[])
     unsigned char buf[512];
     char *port = "*:4433";
     BIO *in = NULL;
-    BIO *ssl_bio, *tmp;
+    BIO *ssl_bio = NULL;
+    BIO *tmp;
     SSL_CTX *ctx;
     int ret = EXIT_FAILURE, i;
 
@@ -52,6 +53,7 @@ int main(int argc, char *argv[])
      * Basically it means the SSL BIO will be automatically setup
      */
     BIO_set_accept_bios(in, ssl_bio);
+    ssl_bio = NULL;
 
  again:
     /*
@@ -90,5 +92,6 @@ int main(int argc, char *argv[])
     if (ret != EXIT_SUCCESS)
         ERR_print_errors_fp(stderr);
     BIO_free(in);
+    BIO_free_all(ssl_bio);
     return ret;
 }

--- a/demos/bio/server-conf.c
+++ b/demos/bio/server-conf.c
@@ -25,7 +25,8 @@ int main(int argc, char *argv[])
 {
     char *port = "*:4433";
     BIO *in = NULL;
-    BIO *ssl_bio, *tmp;
+    BIO *ssl_bio = NULL;
+    BIO *tmp;
     SSL_CTX *ctx;
     SSL_CONF_CTX *cctx = NULL;
     CONF *conf = NULL;
@@ -97,6 +98,7 @@ int main(int argc, char *argv[])
      * Basically it means the SSL BIO will be automatically setup
      */
     BIO_set_accept_bios(in, ssl_bio);
+    ssl_bio = NULL;
 
  again:
     /*
@@ -135,5 +137,6 @@ int main(int argc, char *argv[])
     if (ret != EXIT_SUCCESS)
         ERR_print_errors_fp(stderr);
     BIO_free(in);
+    BIO_free_all(ssl_bio);
     return ret;
 }


### PR DESCRIPTION
`BIO_new_ssl` in demos/bio/saccept.c:75, demos/bio/server-arg.c:07, demos/bio/server-cmod.c:44, demos/bio/server-conf.c:89 need "BIO_free_all(ssl_bio);" to avoid memory leak. 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
