### PR TITLE
Fix double free when reusing PSK sessions

### DIFF
--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -887,8 +887,10 @@ EXT_RETURN tls_construct_ctos_early_data(SSL_CONNECTION *s, WPACKET *pkt,
     }
 #endif  /* OPENSSL_NO_PSK */
 
-    SSL_SESSION_free(s->psksession);
-    s->psksession = psksess;
+    if (s->psksession != psksess) {
+        SSL_SESSION_free(s->psksession);
+        s->psksession = psksess;
+    }
     if (psksess != NULL) {
         OPENSSL_free(s->psksession_id);
         s->psksession_id = OPENSSL_memdup(id, idlen);


### PR DESCRIPTION
Avoid freeing the psk session on subsequent calls to tls_construct_ctos_early_data.

Fixes #28267

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
