### PR TITLE
Add test coverage for X509V3_EXT_add_alias

### DIFF
--- a/crypto/x509/v3_lib.c
+++ b/crypto/x509/v3_lib.c
@@ -33,6 +33,8 @@ int X509V3_EXT_add(X509V3_EXT_METHOD *ext)
         ERR_raise(ERR_LIB_X509V3, ERR_R_CRYPTO_LIB);
         return 0;
     }
+    /* Ideally, this would be done under a lock */
+    sk_X509V3_EXT_METHOD_sort(ext_list);
     return 1;
 }
 
@@ -63,8 +65,6 @@ const X509V3_EXT_METHOD *X509V3_EXT_get_nid(int nid)
         return *ret;
     if (!ext_list)
         return NULL;
-    /* Ideally, this would be done under a lock */
-    sk_X509V3_EXT_METHOD_sort(ext_list);
     idx = sk_X509V3_EXT_METHOD_find(ext_list, &tmp);
     /* A failure to locate the item is handled by the value method */
     return sk_X509V3_EXT_METHOD_value(ext_list, idx);

--- a/test/v3ext.c
+++ b/test/v3ext.c
@@ -39,6 +39,95 @@ end:
     return ret;
 }
 
+static int test_custom_ext(void)
+{
+    EVP_PKEY *pkey = NULL;
+    X509 *x509 = NULL;
+    X509_NAME *name = NULL;
+    X509_EXTENSION *ex = NULL;
+    int nid = 0;
+    int ret = 0;
+
+    if (!TEST_ptr(pkey = EVP_PKEY_Q_keygen(NULL, NULL, "RSA", (size_t)512))
+            || !TEST_ptr(x509 = X509_new()))
+        goto err;
+
+    if (!TEST_true(X509_set_version(x509, X509_VERSION_3))
+            || !TEST_true(ASN1_INTEGER_set(X509_get_serialNumber(x509), 12345))
+            || !TEST_true(X509_gmtime_adj(X509_getm_notBefore(x509), 0))
+            || !TEST_true(X509_gmtime_adj(X509_getm_notAfter(x509),
+                                          (long)60 * 60 * 34 * 365))
+            || !TEST_true(X509_set_pubkey(x509, pkey)))
+        goto err;
+
+    if (!TEST_ptr(name = X509_get_subject_name(x509))
+            || !TEST_true(X509_NAME_add_entry_by_txt(name, "C", MBSTRING_ASC,
+                                                     (unsigned char *)"EU",
+                                                     -1, -1, 0))
+            || !TEST_true(X509_NAME_add_entry_by_txt(name, "O", MBSTRING_ASC,
+                                                     (unsigned char *)"Test",
+                                                     -1, -1, 0))
+            || !TEST_true(X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+                                                     (unsigned char *)"MyCA",
+                                                     -1, -1, 0))
+            || !TEST_true(X509_set_issuer_name(x509, name)))
+        goto err;
+
+    /*
+     * Add extension using V3 code: we can set the config file as NULL
+     * because we wont reference any other sections. We can also set the
+     * context to NULL because none of these extensions below will need to
+     * access it.
+     */
+    if (!TEST_ptr(ex = X509V3_EXT_conf_nid(NULL, NULL, NID_netscape_cert_type,
+                                           "server"))
+            || !TEST_true(X509_add_ext(x509, ex, -1)))
+        goto err;
+
+    X509_EXTENSION_free(ex);
+    ex = NULL;
+
+    if (!TEST_ptr(ex = X509V3_EXT_conf_nid(NULL, NULL, NID_netscape_comment,
+                                           "example comment extension"))
+            || !TEST_true(X509_add_ext(x509, ex, -1)))
+        goto err;
+
+    X509_EXTENSION_free(ex);
+    ex = NULL;
+
+    if (!TEST_ptr(ex = X509V3_EXT_conf_nid(NULL, NULL, NID_basic_constraints,
+                                           "critical,CA:TRUE"))
+            || !TEST_true(X509_add_ext(x509, ex, -1)))
+        goto err;
+
+    X509_EXTENSION_free(ex);
+    ex = NULL;
+
+    if (!TEST_true(nid = OBJ_create("1.2.3.4.5.6", "MyAlias",
+                                    "My Test Alias Extension"))
+            || !TEST_true(X509V3_EXT_add_alias(nid, NID_netscape_comment))
+            || !TEST_ptr(ex = X509V3_EXT_conf_nid(NULL, NULL, nid,
+                                                  "example comment alias"))
+            || !TEST_true(X509_add_ext(x509, ex, -1)))
+        goto err;
+
+    if (!TEST_true(X509_sign(x509, pkey, EVP_sha1()))
+            || !TEST_true(X509_print_fp(stdout, x509))
+            || !TEST_true(PEM_write_X509(stdout, x509))
+            || !TEST_true(PEM_write_PrivateKey(stdout, pkey, NULL, NULL,
+                                               0, NULL, NULL)))
+        goto err;
+
+    ret = 1;
+
+err:
+    X509_EXTENSION_free(ex);
+    X509_free(x509);
+    EVP_PKEY_free(pkey);
+    X509V3_EXT_cleanup();
+    return ret;
+}
+
 #ifndef OPENSSL_NO_RFC3779
 static int test_asid(void)
 {
@@ -476,6 +565,7 @@ int setup_tests(void)
         return 0;
 
     ADD_TEST(test_pathlen);
+    ADD_TEST(test_custom_ext);
 #ifndef OPENSSL_NO_RFC3779
     ADD_TEST(test_asid);
     ADD_TEST(test_addr_ranges);


### PR DESCRIPTION
This was inspired by the following commit
5f661e4e96bc ("crypto/x509/v3_lib.c: Free tmpext if X509V3_EXT_add() fails to avoid memory leak")
which fixed a bug in X509V3_EXT_add_alias although there has never been any test coverage for this function at all.
And additionally this also fixes a possible multi-threading issue because X509V3_EXT_add and X509V3_EXT_cleanup can be assumed to be running single-threaded, while
X509V3_EXT_get_nid may be running in parallel threads, and could screw up the sorting when both threads try to do it.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
