### PR TITLE
Fix the return value of OBJ_create

### DIFF
--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -686,32 +686,32 @@ int OBJ_create_objects(BIO *in)
 int OBJ_create(const char *oid, const char *sn, const char *ln)
 {
     ASN1_OBJECT *tmpoid = NULL;
-    int ok = 0;
+    int ok = NID_undef;
 
     /* With no arguments at all, nothing can be done */
     if (oid == NULL && sn == NULL && ln == NULL) {
         ERR_raise(ERR_LIB_OBJ, ERR_R_PASSED_INVALID_ARGUMENT);
-        return 0;
+        return NID_undef;
     }
 
     /* Check to see if short or long name already present */
     if ((sn != NULL && OBJ_sn2nid(sn) != NID_undef)
             || (ln != NULL && OBJ_ln2nid(ln) != NID_undef)) {
         ERR_raise(ERR_LIB_OBJ, OBJ_R_OID_EXISTS);
-        return 0;
+        return NID_undef;
     }
 
     if (oid != NULL) {
         /* Convert numerical OID string to an ASN1_OBJECT structure */
         tmpoid = OBJ_txt2obj(oid, 1);
         if (tmpoid == NULL)
-            return 0;
+            return NID_undef;
     } else {
         /* Create a no-OID ASN1_OBJECT */
         tmpoid = ASN1_OBJECT_new();
         if (tmpoid == NULL) {
             ERR_raise(ERR_LIB_OBJ, ERR_R_ASN1_LIB);
-            return 0;
+            return NID_undef;
         }
     }
 
@@ -730,9 +730,7 @@ int OBJ_create(const char *oid, const char *sn, const char *ln)
     tmpoid->sn = (char *)sn;
     tmpoid->ln = (char *)ln;
 
-    if (OBJ_add_object(tmpoid) != NID_undef)
-        ok = 1;
-
+    ok = OBJ_add_object(tmpoid);
 
     tmpoid->sn = NULL;
     tmpoid->ln = NULL;

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -5798,6 +5798,8 @@ static int test_custom_md_meth(void)
     nid = OBJ_create("1.3.6.1.4.1.16604.998866.1", "custom-md", "custom-md");
     if (!TEST_int_ne(nid, NID_undef))
         goto err;
+    if (!TEST_int_eq(OBJ_txt2nid("1.3.6.1.4.1.16604.998866.1"), nid))
+        goto err;
     tmp = EVP_MD_meth_new(nid, NID_undef);
     if (!TEST_ptr(tmp))
         goto err;
@@ -5892,6 +5894,8 @@ static int test_custom_ciph_meth(void)
 
     nid = OBJ_create("1.3.6.1.4.1.16604.998866.2", "custom-ciph", "custom-ciph");
     if (!TEST_int_ne(nid, NID_undef))
+        goto err;
+    if (!TEST_int_eq(OBJ_txt2nid("1.3.6.1.4.1.16604.998866.2"), nid))
         goto err;
     tmp = EVP_CIPHER_meth_new(nid, 16, 16);
     if (!TEST_ptr(tmp))


### PR DESCRIPTION
OBJ_create is supposed to return NID_undef on error and the newly created NID in success.

Fixes: 88a1fbb8d1b2 ("reduce lock contention when adding objects to ADDED_OBJ hash table")

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
