### PR TITLE
Remove unnecessary fetch-depth in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build_quic_interop_container.yml
+++ b/.github/workflows/build_quic_interop_container.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-         fetch-depth: 0
       - name: "log in to quay.io"
         run: |
           docker login -u openssl-ci+machine -p ${{ secrets.QUAY_IO_PASSWORD }} quay.io


### PR DESCRIPTION
Fixes #28107

The build_quic_interop_container.yml workflow does not need the full git history. Removing fetch-depth: 0 reduces unnecessary checkout.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->