### PR TITLE
Avoid doublefree of OCSP_SINGLERESP

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -6461,9 +6461,6 @@ static int ct_extract_ocsp_response_scts(SSL_CONNECTION *s)
 
             scts = OCSP_SINGLERESP_get1_ext_d2i(single,
                                                 NID_ct_cert_scts, NULL, NULL);
-
-            OCSP_SINGLERESP_free(single);
-
             if (scts == NULL)  {
                 scts_extracted = -1;
                 goto err;


### PR DESCRIPTION
It is referenced by OCSP_BASICRESP and will be
freed when that is freed.

Issue and a proposed fix reported by Stanislav Fort (Aisle Research).
