### PR TITLE
Add targets to skip build of non-installable programs

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -491,6 +491,8 @@ NODEBUG=@
 {- dependmagic('build_libs'); -} : build_libs_nodep
 {- dependmagic('build_modules'); -} : build_modules_nodep
 {- dependmagic('build_programs'); -} : build_programs_nodep
+{- dependmagic('build_inst_sw'); -} : build_libs_nodep, build_modules_nodep, build_inst_programs_nodep
+{- dependmagic('build_inst_programs'); -} : build_inst_programs_nodep
 
 build_generated_pods : $(GENERATED_PODS)
 build_docs : build_html_docs
@@ -500,6 +502,7 @@ build_generated : $(GENERATED_MANDATORY)
 build_libs_nodep : $(LIBS), $(SHLIBS)
 build_modules_nodep : $(MODULES)
 build_programs_nodep : $(PROGRAMS), $(SCRIPTS)
+build_inst_programs_nodep : $(INSTALL_PROGRAMS), $(SCRIPTS)
 
 # Kept around for backward compatibility
 build_apps build_tests : build_programs
@@ -606,7 +609,7 @@ install_docs : install_html_docs
 uninstall_docs : uninstall_html_docs
 
 {- output_off() if $disabled{fips}; "" -}
-install_fips : build_sw $(INSTALL_FIPSMODULECONF)
+install_fips : build_inst_sw $(INSTALL_FIPSMODULECONF)
 	@ WRITE SYS$OUTPUT "*** Installing FIPS module"
 	- CREATE/DIR ossl_installroot:[MODULES{- $target{pointer_size} -}.'arch']
 	- CREATE/DIR/PROT=(S:RWED,O:RWE,G:RE,W:RE) OSSL_DATAROOT:[000000]
@@ -687,7 +690,7 @@ install_runtime_libs : check_INSTALLTOP build_libs
                 @install_shlibs) -}
         @ {- output_on() if $disabled{shared}; "" -} !
 
-install_programs : check_INSTALLTOP install_runtime_libs build_programs
+install_programs : check_INSTALLTOP install_runtime_libs build_inst_programs
         @ {- output_off() if $disabled{apps}; "" -} !
         @ ! Install the main program
         - CREATE/DIR ossl_installroot:[EXE.'arch']

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -531,7 +531,9 @@ LANG=C
 {- dependmagic('build_sw', 'Build all the software (default target)'); -}: build_libs_nodep build_modules_nodep build_programs_nodep link-utils
 {- dependmagic('build_libs', 'Build the libraries libssl and libcrypto'); -}: build_libs_nodep
 {- dependmagic('build_modules', 'Build the modules (i.e. providers and engines)'); -}: build_modules_nodep
-{- dependmagic('build_programs', 'Build the openssl executables and scripts'); -}: build_programs_nodep
+{- dependmagic('build_programs', 'Build the openssl executables, scripts and all other programs as configured (e.g. tests or demos)'); -}: build_programs_nodep
+{- dependmagic('build_inst_sw', 'Build all the software to be installed'); -}: build_libs_nodep build_modules_nodep build_inst_programs_nodep link-utils
+{- dependmagic('build_inst_programs', 'Build only the installable openssl executables and scripts'); -}: build_inst_programs_nodep
 
 all: build_sw {- "build_docs" if !$disabled{docs}; -} ## Build software and documentation
 debuginfo: $(SHLIBS)
@@ -553,6 +555,7 @@ build_generated: $(GENERATED_MANDATORY)
 build_libs_nodep: $(LIBS) {- join(" ",map { platform->sharedlib_simple($_) // platform->sharedlib_import($_) // platform->sharedlib($_) // () } @{$unified_info{libraries}}) -}
 build_modules_nodep: $(MODULES)
 build_programs_nodep: $(PROGRAMS) $(SCRIPTS)
+build_inst_programs_nodep: $(INSTALL_PROGRAMS) $(SCRIPTS)
 
 # Kept around for backward compatibility
 build_apps build_tests: build_programs
@@ -671,7 +674,7 @@ uninstall_docs: uninstall_man_docs uninstall_html_docs ## Uninstall manpages and
 	$(RM) -r "$(DESTDIR)$(DOCDIR)"
 
 {- output_off() if $disabled{fips}; "" -}
-install_fips: build_sw $(INSTALL_FIPSMODULECONF)
+install_fips: build_inst_sw $(INSTALL_FIPSMODULECONF)
 	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
 	@$(PERL) $(SRCDIR)/util/mkdir-p.pl "$(DESTDIR)$(MODULESDIR)"
 	@$(PERL) $(SRCDIR)/util/mkdir-p.pl "$(DESTDIR)$(OPENSSLDIR)"
@@ -956,7 +959,7 @@ install_runtime_libs: build_libs
 		: {- output_on() if windowsdll(); "" -}; \
 	done
 
-install_programs: install_runtime_libs build_programs
+install_programs: install_runtime_libs build_inst_programs
 	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
 	@$(PERL) $(SRCDIR)/util/mkdir-p.pl "$(DESTDIR)$(bindir)"
 	@$(ECHO) "*** Installing runtime programs"

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -418,6 +418,8 @@ PROCESSOR= {- $config{processor} -}
 {- dependmagic('build_libs'); -}: build_libs_nodep
 {- dependmagic('build_modules'); -}: build_modules_nodep
 {- dependmagic('build_programs'); -}: build_programs_nodep
+{- dependmagic('build_inst_sw'); -}: build_libs_nodep build_modules_nodep build_inst_programs_nodep copy-utils
+{- dependmagic('build_inst_programs'); -}: build_inst_programs_nodep
 
 build_docs: build_html_docs
 build_html_docs: $(HTMLDOCS1) $(HTMLDOCS3) $(HTMLDOCS5) $(HTMLDOCS7)
@@ -429,6 +431,8 @@ build_libs_nodep: $(LIBS) {- join(" ",map { platform->sharedlib_import($_) // ()
 build_modules_nodep: $(MODULES)
 	@
 build_programs_nodep: $(PROGRAMS) $(SCRIPTS)
+	@
+build_inst_programs_nodep: $(INSTALL_PROGRAMS) $(SCRIPTS)
 	@
 
 # Kept around for backward compatibility
@@ -507,7 +511,7 @@ install_docs: install_html_docs
 uninstall_docs: uninstall_html_docs
 
 {- output_off() if $disabled{fips}; "" -}
-install_fips: build_sw $(INSTALL_FIPSMODULECONF)
+install_fips: build_inst_sw $(INSTALL_FIPSMODULECONF)
 #	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
 	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(MODULESDIR)"
 	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(OPENSSLDIR)"
@@ -607,7 +611,7 @@ install_runtime_libs: build_libs
 	 "$(PERL)" "$(SRCDIR)\util\copy.pl" $(INSTALL_SHLIBPDBS) \
                                         "$(INSTALLTOP)\bin"
 
-install_programs: install_runtime_libs build_programs
+install_programs: install_runtime_libs build_inst_programs
 	@if "$(INSTALLTOP)"=="" ( $(ECHO) "INSTALLTOP should not be empty" & exit 1 )
 	@$(ECHO) "*** Installing runtime programs"
 	@if not "$(INSTALL_PROGRAMS)"=="" \

--- a/util/help.pl
+++ b/util/help.pl
@@ -14,7 +14,7 @@ while (<>) {
     chomp;	# strip record separator
     @Fld = split($FS, $_, -1);
     if (/^[a-zA-Z0-9_\-]+:.*?##/) {
-	printf "  \033[36m%-15s\033[0m %s\n", $Fld[0], $Fld[1]
+	printf "  \033[36m%-19s\033[0m %s\n", $Fld[0], $Fld[1]
     }
     if (/^##@/) {
 	printf "\n\033[1m%s\033[0m\n", substr($Fld[$_], (5)-1);


### PR DESCRIPTION
This PR introduces two new convenience Make targets, `build_installable_sw` and `build_installable_programs`.

We would like to use these when packaging OpenSSL in Fedora/RHEL so that we can:
1. build installable SW with some set of compiler flags and then build tests with another set of compiler flags (e.g., disabling LTO);
2. skip the build of tests completely even though the project is configured to build them.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
