### PR TITLE
Make error checks on RSA_public_decrypt() consistent

### DIFF
--- a/crypto/rsa/rsa_pmeth.c
+++ b/crypto/rsa/rsa_pmeth.c
@@ -228,7 +228,7 @@ static int pkey_rsa_verifyrecover(EVP_PKEY_CTX *ctx,
                 return -1;
             ret = RSA_public_decrypt((int)siglen, sig, rctx->tbuf, rsa,
                                      RSA_X931_PADDING);
-            if (ret < 1)
+            if (ret <= 0)
                 return 0;
             ret--;
             if (rctx->tbuf[ret] != RSA_X931_hash_id(EVP_MD_get_type(rctx->md))) {
@@ -255,7 +255,7 @@ static int pkey_rsa_verifyrecover(EVP_PKEY_CTX *ctx,
     } else {
         ret = RSA_public_decrypt((int)siglen, sig, rout, rsa, rctx->pad_mode);
     }
-    if (ret < 0)
+    if (ret <= 0)
         return ret;
     *routlen = ret;
     return 1;
@@ -313,7 +313,7 @@ static int pkey_rsa_verify(EVP_PKEY_CTX *ctx,
             return -1;
         rslen = RSA_public_decrypt((int)siglen, sig, rctx->tbuf,
                                    rsa, rctx->pad_mode);
-        if (rslen == 0)
+        if (rslen <= 0)
             return 0;
     }
 

--- a/providers/implementations/signature/rsa_sig.c.in
+++ b/providers/implementations/signature/rsa_sig.c.in
@@ -955,7 +955,7 @@ static int rsa_verify_recover(void *vprsactx,
                 return 0;
             ret = RSA_public_decrypt((int)siglen, sig, prsactx->tbuf, prsactx->rsa,
                                      RSA_X931_PADDING);
-            if (ret < 1) {
+            if (ret <= 0) {
                 ERR_raise(ERR_LIB_PROV, ERR_R_RSA_LIB);
                 return 0;
             }
@@ -1005,7 +1005,7 @@ static int rsa_verify_recover(void *vprsactx,
     } else {
         ret = RSA_public_decrypt((int)siglen, sig, rout, prsactx->rsa,
                                  prsactx->pad_mode);
-        if (ret < 0) {
+        if (ret <= 0) {
             ERR_raise(ERR_LIB_PROV, ERR_R_RSA_LIB);
             return 0;
         }


### PR DESCRIPTION
Some are only checking for a value < 0, some for <= 0, some for == 0, etc. The documentation tells us that -1 is returned on error, so at least the == 0 ones are wrong. In general, the return values are checked inconsistently. This patch makes the return value checks consistent to the form that seems to occur most.

Note: This was detected using an experimental static analyzer our group is working on. Although I did manual verification it's always possible this is a false alarm or not important.