### PR TITLE
Fix S390 ECDSA Deterministic mode fails tests in FIPS mode.

### DIFF
--- a/crypto/ec/ecp_s390x_nistp.c
+++ b/crypto/ec/ecp_s390x_nistp.c
@@ -135,6 +135,7 @@ static ECDSA_SIG *ecdsa_s390x_nistp_sign_sig(const unsigned char *dgst,
     ECDSA_SIG *sig;
     const EC_GROUP *group;
     const BIGNUM *privkey;
+    BN_CTX *bn_ctx = NULL;
     int off;
 
     group = EC_KEY_get0_group(eckey);
@@ -189,8 +190,12 @@ static ECDSA_SIG *ecdsa_s390x_nistp_sign_sig(const unsigned char *dgst,
              goto ret;
          }
     } else {
+        bn_ctx = BN_CTX_secure_new_ex(ossl_ec_key_get_libctx(eckey));
+        if (bn_ctx == NULL)
+            goto ret;
+
         /* Reconstruct k = (k^-1)^-1. */
-        if (ossl_ec_group_do_inverse_ord(group, k, kinv, NULL) == 0
+        if (ossl_ec_group_do_inverse_ord(group, k, kinv, bn_ctx) == 0
             || BN_bn2binpad(k, param + S390X_OFF_RN(len), len) == -1) {
             ERR_raise(ERR_LIB_EC, ERR_R_BN_LIB);
             goto ret;
@@ -212,6 +217,7 @@ static ECDSA_SIG *ecdsa_s390x_nistp_sign_sig(const unsigned char *dgst,
 
     ok = 1;
 ret:
+    BN_CTX_free(bn_ctx);
     OPENSSL_cleanse(param, sizeof(param));
     if (ok != 1) {
         ECDSA_SIG_free(sig);


### PR DESCRIPTION
Fixes #28313

Recently Deterministic ECDSA was added to the FIPS provider.

I cant run s390 directly but I suspect the call to ossl_ec_group_do_inverse_ord() fails because it passes a NULL bn_ctx.

This potentially then calls ec_field_inverse_mod_ord() that has code in it that fails in fips mode if the BN_CTX is not passed.

It cant create it internally since it does not know what the OSSL_LIB_CTX is, which is required when creating a BN_CTX.

The solution is to create a BN_CTX that uses the ec_key lib ctx and pass that in.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
