### PR TITLE
aes-s390x.pl: Initialize reserved and unused memory

### DIFF
--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -1431,6 +1431,9 @@ $code.=<<___ if (!$softonly);
 	st${g}	$s3,0($sp)			# backchain
 	la	%r1,$stdframe($sp)
 
+	xc	$stdframe+0(64,$sp),$stdframe+0($sp)	# clear reserved/unused
+							# in parameter block
+
 	lmg	$s2,$s3,0($key)			# copy key
 	stg	$s2,$stdframe+80($sp)
 	stg	$s3,$stdframe+88($sp)


### PR DESCRIPTION
The reserved bytes in the parameter block (bytes 0-11) for the KMA instruction should be set to zero to be compatible in case of future architecture changes.

While at it, also the following unused parts of the parameter block (bytes 48-63) are also cleared to avoid false positives with various memory checkers like valgrind.

As it makes - performance wise - no difference to process 12, 48 or 64 bytes with one XC call, but two XC calls are slower than one call, the first 64 bytes of the parameter block will be cleared with a single XC call. This will also initialize the counter in the parameter block (bytes 12-15), although it is not strictly necessary.

This patch should also go to all stable branches, including v1.1.1. It sould apply without problems. Please notify me on any conflicts.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
