### PR TITLE
Fix reallocation failure condition in qtx_resize_txe()

### DIFF
--- a/ssl/quic/quic_record_tx.c
+++ b/ssl/quic/quic_record_tx.c
@@ -279,12 +279,12 @@ static TXE *qtx_resize_txe(OSSL_QTX *qtx, TXE_LIST *txl, TXE *txe, size_t n)
      * data.
      */
     txe2 = OPENSSL_realloc(txe, sizeof(TXE) + n);
-    if (txe2 == NULL || txe == txe2) {
+    if (txe2 == NULL) {
         if (p == NULL)
             ossl_list_txe_insert_head(txl, txe);
         else
             ossl_list_txe_insert_after(txl, p, txe);
-        return txe2;
+        return NULL;
     }
 
     if (p == NULL)


### PR DESCRIPTION
Returning the same pointer does not mean that the reallocation failed, it would also prevent updating alloc_len down below. This is similar code and a similar change to 043a41ddee.

Note: this was detected using an experimental static analyzer we're developing to detect semantically reocurring bugs/code snippets. The source snippet for this detection was 043a41ddee.