### PR TITLE
Ignore generated assembler files for cpuid functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -341,7 +341,7 @@ providers/implementations/rands/test_rng.c
 # Auto generated assembly language source files
 *.s
 !/crypto/*/asm/*.s
-/crypto/arm*.S
+/crypto/*.S
 /crypto/*/*.S
 *.asm
 !/crypto/*/asm/*.asm


### PR DESCRIPTION
The architecture-specific code to detect CPU features at runtime is generated from Perl Assembler. Modify the ignore pattern to match the generated .S files for all architectures.

##### Checklist
- [ ] documentation is added or updated
- [ ] tests are added or updated
