### PR TITLE
fips: add missing ossl_prov_is_running checks

### DIFF
--- a/providers/implementations/kdfs/hkdf.c.in
+++ b/providers/implementations/kdfs/hkdf.c.in
@@ -160,6 +160,9 @@ static void *kdf_hkdf_dup(void *vctx)
     const KDF_HKDF *src = (const KDF_HKDF *)vctx;
     KDF_HKDF *dest;
 
+    if (!ossl_prov_is_running())
+        return NULL;
+
     dest = kdf_hkdf_new(src->provctx);
     if (dest != NULL) {
         if (!ossl_prov_memdup(src->salt, src->salt_len, &dest->salt,

--- a/providers/implementations/kdfs/hmacdrbg_kdf.c.in
+++ b/providers/implementations/kdfs/hmacdrbg_kdf.c.in
@@ -82,6 +82,10 @@ static void hmac_drbg_kdf_free(void *vctx)
 }
 
 static int ossl_drbg_hmac_dup(PROV_DRBG_HMAC *dst, const PROV_DRBG_HMAC *src) {
+
+    if (!ossl_prov_is_running())
+        return 0;
+
     if (src->ctx != NULL) {
         dst->ctx = EVP_MAC_CTX_dup(src->ctx);
         if (dst->ctx == NULL)
@@ -99,6 +103,9 @@ static void *hmac_drbg_kdf_dup(void *vctx)
 {
     const KDF_HMAC_DRBG *src = (const KDF_HMAC_DRBG *)vctx;
     KDF_HMAC_DRBG *dst;
+
+    if (!ossl_prov_is_running())
+        return NULL;
 
     dst = hmac_drbg_kdf_new(src->provctx);
     if (dst != NULL) {

--- a/providers/implementations/kdfs/kbkdf.c.in
+++ b/providers/implementations/kdfs/kbkdf.c.in
@@ -163,6 +163,9 @@ static void *kbkdf_dup(void *vctx)
     const KBKDF *src = (const KBKDF *)vctx;
     KBKDF *dest;
 
+    if (!ossl_prov_is_running())
+        return NULL;
+
     dest = kbkdf_new(src->provctx);
     if (dest != NULL) {
         dest->ctx_init = EVP_MAC_CTX_dup(src->ctx_init);

--- a/providers/implementations/kdfs/pbkdf2.c.in
+++ b/providers/implementations/kdfs/pbkdf2.c.in
@@ -129,6 +129,9 @@ static void *kdf_pbkdf2_dup(void *vctx)
     const KDF_PBKDF2 *src = (const KDF_PBKDF2 *)vctx;
     KDF_PBKDF2 *dest;
 
+    if (!ossl_prov_is_running())
+        return NULL;
+
     /* We need a new PBKDF2 object but uninitialised since we're filling it */
     dest = kdf_pbkdf2_new_no_init(src->provctx);
     if (dest != NULL) {

--- a/providers/implementations/kdfs/sshkdf.c.in
+++ b/providers/implementations/kdfs/sshkdf.c.in
@@ -98,6 +98,9 @@ static void *kdf_sshkdf_dup(void *vctx)
     const KDF_SSHKDF *src = (const KDF_SSHKDF *)vctx;
     KDF_SSHKDF *dest;
 
+    if (!ossl_prov_is_running())
+        return NULL;
+
     dest = kdf_sshkdf_new(src->provctx);
     if (dest != NULL) {
         if (!ossl_prov_memdup(src->key, src->key_len,

--- a/providers/implementations/kdfs/sskdf.c.in
+++ b/providers/implementations/kdfs/sskdf.c.in
@@ -337,6 +337,9 @@ static void *sskdf_dup(void *vctx)
     const KDF_SSKDF *src = (const KDF_SSKDF *)vctx;
     KDF_SSKDF *dest;
 
+    if (!ossl_prov_is_running())
+        return NULL;
+
     dest = sskdf_new(src->provctx);
     if (dest != NULL) {
         if (src->macctx != NULL) {

--- a/providers/implementations/kdfs/tls1_prf.c.in
+++ b/providers/implementations/kdfs/tls1_prf.c.in
@@ -158,6 +158,9 @@ static void *kdf_tls1_prf_dup(void *vctx)
     const TLS1_PRF *src = (const TLS1_PRF *)vctx;
     TLS1_PRF *dest;
 
+    if (!ossl_prov_is_running())
+        return NULL;
+
     dest = kdf_tls1_prf_new(src->provctx);
     if (dest != NULL) {
         if (src->P_hash != NULL

--- a/providers/implementations/kdfs/x942kdf.c.in
+++ b/providers/implementations/kdfs/x942kdf.c.in
@@ -384,6 +384,9 @@ static void *x942kdf_dup(void *vctx)
     const KDF_X942 *src = (const KDF_X942 *)vctx;
     KDF_X942 *dest;
 
+    if (!ossl_prov_is_running())
+        return NULL;
+
     dest = x942kdf_new(src->provctx);
     if (dest != NULL) {
         if (!ossl_prov_memdup(src->secret, src->secret_len,

--- a/providers/implementations/kem/ml_kem_kem.c.in
+++ b/providers/implementations/kem/ml_kem_kem.c.in
@@ -45,6 +45,9 @@ static void *ml_kem_newctx(void *provctx)
 {
     PROV_ML_KEM_CTX *ctx;
 
+    if (!ossl_prov_is_running())
+        return 0;
+
     if ((ctx = OPENSSL_malloc(sizeof(*ctx))) == NULL)
         return NULL;
 

--- a/providers/implementations/kem/mlx_kem.c
+++ b/providers/implementations/kem/mlx_kem.c
@@ -39,6 +39,9 @@ static void *mlx_kem_newctx(void *provctx)
 {
     PROV_MLX_KEM_CTX *ctx;
 
+    if (!ossl_prov_is_running())
+        return 0;
+
     if ((ctx = OPENSSL_malloc(sizeof(*ctx))) == NULL)
         return NULL;
 

--- a/providers/implementations/macs/kmac_prov.c.in
+++ b/providers/implementations/macs/kmac_prov.c.in
@@ -194,6 +194,9 @@ static void *kmac_fetch_new(void *provctx, const OSSL_PARAM *params)
     struct kmac_data_st *kctx = kmac_new(provctx);
     int md_size;
 
+    if (!ossl_prov_is_running())
+        return NULL;
+
     if (kctx == NULL)
         return 0;
     if (!ossl_prov_digest_load_from_params(&kctx->digest, params,


### PR DESCRIPTION
The analysis was performed similar to a previous similar pr:
- https://github.com/openssl/openssl/pull/25580

Usually new & dup functionality is blocked when in error state for
most algorithms. These appear to not have such a check.

Note only single depth analysis was performed, it is possible some of
these are called from a wrapper that already checks running state, or
any of the subfunction already does such a check.
