### PR TITLE
NOTES-WINDOWS.md: correct the Windows context macro name

### DIFF
--- a/NOTES-WINDOWS.md
+++ b/NOTES-WINDOWS.md
@@ -125,7 +125,7 @@ format:
 `\\HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432node\OpenSSL-<version>-<ctx>`
 
 Where `<version>` is the major.minor version of the library being
-built, and `<ctx>` is the value specified by `-DOPENSSL_WINCTX`.  This allows
+built, and `<ctx>` is the value specified by `-DOSSL_WINCTX`.  This allows
 for multiple openssl builds to be created and installed on a single system, in
 which each library can use its own set of registry keys.
 


### PR DESCRIPTION
Fix incorrect Windows context macro spelling "OPENSSL_WINCTX" by replacing it with "OSSL_WINCTX".

Reported-by: https://github.com/sjan1970
Resolves: https://github.com/openssl/openssl/issues/28329
Fixes: 630e3a168446 "Change WININSTALLCONTEXT to OSSL_WINCTX"
Complements: c2ab75e30a21 "doc: fix OSSL_WINCTX spelling windows notes"

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
