### PR TITLE
corrects fixed cert validity end date in oqsprovider testing

### DIFF
--- a/test/recipes/95-test_external_oqsprovider_data/oqsprovider-ca.sh
+++ b/test/recipes/95-test_external_oqsprovider_data/oqsprovider-ca.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Test openssl CA functionality using oqsprovider for alg $1
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <algorithmname>. Exiting."
+    exit 1
+fi
+
+if [ -z "$OPENSSL_APP" ]; then
+    echo "OPENSSL_APP env var not set. Exiting."
+    exit 1
+fi
+
+if [ -z "$OPENSSL_MODULES" ]; then
+    echo "Warning: OPENSSL_MODULES env var not set."
+fi
+
+if [ -z "$OPENSSL_CONF" ]; then
+    echo "Warning: OPENSSL_CONF env var not set."
+fi
+
+# Set OSX DYLD_LIBRARY_PATH if not already externally set
+if [ -z "$DYLD_LIBRARY_PATH" ]; then
+    export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH
+fi
+
+echo "oqsprovider-ca.sh commencing..."
+
+#rm -rf tmp
+mkdir -p tmp && cd tmp
+rm -rf demoCA && mkdir -p demoCA/newcerts
+touch demoCA/index.txt
+echo '01' > demoCA/serial
+$OPENSSL_APP req -x509 -new -newkey $1 -keyout $1_rootCA.key -out $1_rootCA.crt -subj "/CN=test CA" -nodes
+
+if [ $? -ne 0 ]; then
+   echo "Failed to generate root CA. Exiting."
+   exit 1
+fi
+
+$OPENSSL_APP req -new -newkey $1 -keyout $1.key -out $1.csr -nodes -subj "/CN=test Server"
+
+if [ $? -ne 0 ]; then
+   echo "Failed to generate test server CSR. Exiting."
+   exit 1
+fi
+
+$OPENSSL_APP ca -batch -days 100 -keyfile $1_rootCA.key -cert $1_rootCA.crt -policy policy_anything -notext -out $1.crt -infiles $1.csr
+
+if [ $? -ne 0 ]; then
+   echo "Failed to generate server CRT. Exiting."
+   exit 1
+fi
+
+# Don't forget to use provider(s) when not activated via config file
+$OPENSSL_APP verify -CAfile $1_rootCA.crt $1.crt
+

--- a/test/recipes/95-test_external_oqsprovider_data/oqsprovider.sh
+++ b/test/recipes/95-test_external_oqsprovider_data/oqsprovider.sh
@@ -69,5 +69,7 @@ export OPENSSL_APP="$O_EXE/openssl"
 export OPENSSL_MODULES=$PWD/_build/lib
 export OQS_PROVIDER_TESTSCRIPTS=$SRCTOP/oqs-provider/scripts
 export OPENSSL_CONF=$OQS_PROVIDER_TESTSCRIPTS/openssl-ca.cnf
+# hotfix for wrong cert validity period
+cp $SRCTOP/test/recipes/95-test_external_oqsprovider_data/oqsprovider-ca.sh $SRCTOP/oqs-provider/scripts/
 # Be verbose if harness is verbose:
 $SRCTOP/oqs-provider/scripts/runtests.sh -V


### PR DESCRIPTION
Fixes #28336.

Full fix will be done within downstream project and published via new release but this allows CI to pass again.

