### PR TITLE
openssl-enc.pod.in: replaces PKCS#5 with PKCS#7 padding

### DIFF
--- a/doc/man1/openssl-enc.pod.in
+++ b/doc/man1/openssl-enc.pod.in
@@ -279,7 +279,7 @@ Some of the ciphers do not have large keys and others have security
 implications if not used correctly. A beginner is advised to just use
 a strong block cipher, such as AES, in CBC mode.
 
-All the block ciphers normally use PKCS#5 padding, also known as standard
+All the block ciphers normally use PKCS#7 padding, also known as standard
 block padding. This allows a rudimentary integrity or password check to
 be performed. However, since the chance of random data passing the test
 is better than 1 in 256 it isn't a very good test.


### PR DESCRIPTION
Fixes documentation "mistake":
```diff
- All the block ciphers normally use PKCS#5 padding ...
+ All the block ciphers normally use PKCS#7 padding ...
```

RFC for PKCS#5 says:
*The padding string PS shall consist of `8 - (||M|| mod 8)` octets all having value `8 - (||M|| mod 8)`*

Thus it is only valid for block ciphers with 8 bytes (64 bits), and for instance AES has 16 bytes (128 bits) block size, so PKCS#5 would obviously not correct for paddings larger than 8 bytes.

It is called PKCS#7, and extending PKCS#5 with `k` instead of fixed 8, where `k` is block size (variable block length up to 256 bytes).

Thus PKCS#5 is just a subset of PKCS#7 for 8 bytes blocks (and paddings shorter than 8 bytes).

##### Checklist
- [x] documentation is added or updated
