### PR TITLE
Update EVP_DigestFinal_ex() function in digest.c

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -445,7 +445,7 @@ int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *isize)
     size_t size = 0;
     size_t mdsize = 0;
 
-    if (ossl_unlikely(ctx->digest == NULL))
+    if (ctx && ossl_unlikely(ctx->digest == NULL))
         return 0;
 
     sz = EVP_MD_CTX_get_size(ctx);


### PR DESCRIPTION
Added an additional check for the ctx pointer before dereferencing it in the EVP_DigestFinal_ex(ctx, md, &mdlen) function. In the function body, the first parameter is dereferenced on line 448. Therefore, it is necessary to check if ctx is equal to null before dereferencing. Some calling functions pass this parameter without checking for null.

CLA: regular
