### PR TITLE
providers: implementations: keymgmt: fix potential NULL deref in ml_dsa_key_fromdata

### DIFF
--- a/providers/implementations/keymgmt/ml_dsa_kmgmt.c.in
+++ b/providers/implementations/keymgmt/ml_dsa_kmgmt.c.in
@@ -265,16 +265,33 @@ static int ml_dsa_key_fromdata(ML_DSA_KEY *key, const OSSL_PARAM params[],
             return 0;
     }
 
-    /* Error if the supplied public key does not match the generated key */
-    if (pk_len == 0
-        || seed_len + sk_len == 0
-        || memcmp(ossl_ml_dsa_key_get_pub(key), pk, pk_len) == 0)
+    /*
+     * Validate: if a public key was provided, it must match the one
+     * derived from the private key or seed.
+     */
+    if (pk_len == 0) {
+        /* No public key was provided - nothing to validate */
         return 1;
-    ERR_raise_data(ERR_LIB_PROV, PROV_R_INVALID_KEY,
-                   "explicit %s public key does not match private",
-                   key_params->alg);
-    ossl_ml_dsa_key_reset(key);
-    return 0;
+    }
+    if (seed_len == 0 && sk_len == 0) {
+        /* No private material - cannot regenerate public key to compare */
+        return 1;
+    }
+    if (pk == NULL) {
+        /* Public key length > 0 but pointer is NULL - invalid */
+        ERR_raise_data(ERR_LIB_PROV, PROV_R_INVALID_KEY,
+                       "supplied public key pointer is NULL");
+        ossl_ml_dsa_key_reset(key);
+        return 0;
+    }
+    if (memcmp(ossl_ml_dsa_key_get_pub(key), pk, pk_len) != 0) {
+        ERR_raise_data(ERR_LIB_PROV, PROV_R_INVALID_KEY,
+                       "explicit %s public key does not match private",
+                       key_params->alg);
+        ossl_ml_dsa_key_reset(key);
+        return 0;
+    }
+    return 1;
 }
 
 static int ml_dsa_import(void *keydata, int selection, const OSSL_PARAM params[])


### PR DESCRIPTION
The public key pointer 'pk' could be NULL while pk_len > 0 if the OSSL_PARAM has a size but no data pointer. In this case, calling memcmp would result in a NULL dereference.

Now explicitly check pk != NULL before memcmp, ensuring safe memory access and fixing static analysis warnings.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->