### PR TITLE
`X509_VERIFY_PARAM_get0()`: add check to defend on out-of-bound table access

### DIFF
--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -186,7 +186,7 @@ int X509_PURPOSE_add(int id, int trust, int flags,
         return 0;
     }
     if (trust < X509_TRUST_DEFAULT || name == NULL || sname == NULL || ck == NULL) {
-        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_INVALID_ARGUMENT);
+        ERR_raise(ERR_LIB_X509V3, ERR_R_PASSED_INVALID_ARGUMENT);
         return 0;
     }
 

--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -635,6 +635,11 @@ const X509_VERIFY_PARAM *X509_VERIFY_PARAM_get0(int id)
 {
     int num = OSSL_NELEM(default_table);
 
+    if (id < 0) {
+        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_INVALID_ARGUMENT);
+        return NULL;
+    }
+
     if (id < num)
         return default_table + id;
     return sk_X509_VERIFY_PARAM_value(param_table, id - num);


### PR DESCRIPTION
This prevents crashing on invalid argument.
I wonder why this was not found by static analysis tools.

On this occasion also harmonize an `ERR_raise()` call of `X509_PURPOSE_add()`.

