### PR TITLE
make PCT on key import a transient error state not a permanent one

### DIFF
--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -1079,6 +1079,7 @@ PROV_R_FAILED_TO_SIGN:175:failed to sign
 PROV_R_FINAL_CALL_OUT_OF_ORDER:237:final call out of order
 PROV_R_FIPS_MODULE_CONDITIONAL_ERROR:227:fips module conditional error
 PROV_R_FIPS_MODULE_ENTERING_ERROR_STATE:224:fips module entering error state
+PROV_R_FIPS_MODULE_IMPORT_PCT_ERROR:253:fips module import pct error
 PROV_R_FIPS_MODULE_IN_ERROR_STATE:225:fips module in error state
 PROV_R_GENERATE_ERROR:191:generate error
 PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE:165:\

--- a/crypto/rsa/rsa_gen.c
+++ b/crypto/rsa/rsa_gen.c
@@ -745,7 +745,7 @@ int ossl_rsa_key_pairwise_test(RSA *rsa)
     OSSL_SELF_TEST_get_callback(rsa->libctx, &stcb, &stcbarg);
     res = rsa_keygen_pairwise_test(rsa, stcb, stcbarg);
     if (res <= 0)
-        ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT);
+        ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT_IMPORT);
     return res;
 }
 #endif  /* FIPS_MODULE */

--- a/doc/man7/OSSL_PROVIDER-FIPS.pod
+++ b/doc/man7/OSSL_PROVIDER-FIPS.pod
@@ -366,7 +366,11 @@ Known answer test for a Deterministic Random Bit Generator.
 
 =item "Conditional_PCT" (B<OSSL_SELF_TEST_TYPE_PCT>)
 
-Conditional test that is run during the generation or importing of key pairs.
+Conditional test that is run during the generation of key pairs.
+
+=item "Import_PCT" (B<OSSL_SELF_TEST_TYPE_PCT_IMPORT>)
+
+Conditional test that is run during the import of key pairs.
 
 =item "Conditional_KAT" (B<OSSL_SELF_TEST_TYPE_PCT_KAT>)
 

--- a/include/openssl/proverr.h
+++ b/include/openssl/proverr.h
@@ -49,6 +49,7 @@
 # define PROV_R_FINAL_CALL_OUT_OF_ORDER                   237
 # define PROV_R_FIPS_MODULE_CONDITIONAL_ERROR             227
 # define PROV_R_FIPS_MODULE_ENTERING_ERROR_STATE          224
+# define PROV_R_FIPS_MODULE_IMPORT_PCT_ERROR              253
 # define PROV_R_FIPS_MODULE_IN_ERROR_STATE                225
 # define PROV_R_GENERATE_ERROR                            191
 # define PROV_R_ILLEGAL_OR_UNSUPPORTED_PADDING_MODE       165

--- a/include/openssl/self_test.h
+++ b/include/openssl/self_test.h
@@ -31,6 +31,7 @@ extern "C" {
 # define OSSL_SELF_TEST_TYPE_CRNG               "Continuous_RNG_Test"
 # define OSSL_SELF_TEST_TYPE_PCT                "Conditional_PCT"
 # define OSSL_SELF_TEST_TYPE_PCT_KAT            "Conditional_KAT"
+# define OSSL_SELF_TEST_TYPE_PCT_IMPORT         "Import_PCT"
 # define OSSL_SELF_TEST_TYPE_KAT_INTEGRITY      "KAT_Integrity"
 # define OSSL_SELF_TEST_TYPE_KAT_CIPHER         "KAT_Cipher"
 # define OSSL_SELF_TEST_TYPE_KAT_ASYM_CIPHER    "KAT_AsymmetricCipher"

--- a/providers/common/provider_err.c
+++ b/providers/common/provider_err.c
@@ -63,6 +63,8 @@ static const ERR_STRING_DATA PROV_str_reasons[] = {
      "fips module conditional error"},
     {ERR_PACK(ERR_LIB_PROV, 0, PROV_R_FIPS_MODULE_ENTERING_ERROR_STATE),
      "fips module entering error state"},
+    {ERR_PACK(ERR_LIB_PROV, 0, PROV_R_FIPS_MODULE_IMPORT_PCT_ERROR),
+     "fips module import pct error"},
     {ERR_PACK(ERR_LIB_PROV, 0, PROV_R_FIPS_MODULE_IN_ERROR_STATE),
      "fips module in error state"},
     {ERR_PACK(ERR_LIB_PROV, 0, PROV_R_GENERATE_ERROR), "generate error"},

--- a/providers/fips/self_test.c
+++ b/providers/fips/self_test.c
@@ -426,9 +426,18 @@ void SELF_TEST_disable_conditional_error_state(void)
 
 void ossl_set_error_state(const char *type)
 {
-    int cond_test = (type != NULL && strcmp(type, OSSL_SELF_TEST_TYPE_PCT) == 0);
+    int cond_test = 0;
+    int import_pct = 0;
 
-    if (!cond_test || (FIPS_conditional_error_check == 1)) {
+    if (type != NULL) {
+        cond_test = strcmp(type, OSSL_SELF_TEST_TYPE_PCT) == 0;
+        import_pct = strcmp(type, OSSL_SELF_TEST_TYPE_PCT_IMPORT) == 0;
+    }
+
+    if (import_pct) {
+        /* Failure to import is transient to avoid a DoS attack */
+        ERR_raise(ERR_LIB_PROV, PROV_R_FIPS_MODULE_IMPORT_PCT_ERROR);
+    } else if (!cond_test || (FIPS_conditional_error_check == 1)) {
         set_fips_state(FIPS_STATE_ERROR);
         ERR_raise(ERR_LIB_PROV, PROV_R_FIPS_MODULE_ENTERING_ERROR_STATE);
     } else {

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -218,7 +218,7 @@ static int dh_import(void *keydata, int selection, const OSSL_PARAM params[])
         if (ok > 0 && !ossl_fips_self_testing()) {
             ok = ossl_dh_check_pairwise(dh, 1);
             if (ok <= 0)
-                ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT);
+                ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT_IMPORT);
         }
 #endif  /* FIPS_MODULE */
     }

--- a/providers/implementations/keymgmt/ecx_kmgmt.c.in
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c.in
@@ -234,7 +234,7 @@ static int ecx_import(void *keydata, int selection, const OSSL_PARAM params[])
         if (key->haspubkey && key->privkey != NULL) {
             ok = ecd_fips140_pairwise_test(key, key->type, 1);
             if (ok <= 0)
-                ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT);
+                ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT_IMPORT);
         }
 #endif  /* FIPS_MODULE */
     return ok;

--- a/providers/implementations/keymgmt/ml_dsa_kmgmt.c.in
+++ b/providers/implementations/keymgmt/ml_dsa_kmgmt.c.in
@@ -281,6 +281,7 @@ static int ml_dsa_import(void *keydata, int selection, const OSSL_PARAM params[]
 {
     ML_DSA_KEY *key = keydata;
     int include_priv;
+    int res;
 
     if (!ossl_prov_is_running() || key == NULL)
         return 0;
@@ -289,7 +290,17 @@ static int ml_dsa_import(void *keydata, int selection, const OSSL_PARAM params[]
         return 0;
 
     include_priv = ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0);
-    return ml_dsa_key_fromdata(key, params, include_priv);
+    res = ml_dsa_key_fromdata(key, params, include_priv);
+#ifdef FIPS_MODULE
+    if (res > 0) {
+        res = ml_dsa_pairwise_test(key);
+        if (!res) {
+            ossl_ml_dsa_key_free(key);
+            ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT_IMPORT);
+        }
+    }
+#endif  /* FIPS_MODULE */
+    return res;
 }
 
 static const OSSL_PARAM *ml_dsa_imexport_types(int selection)

--- a/providers/implementations/keymgmt/ml_dsa_kmgmt.c.in
+++ b/providers/implementations/keymgmt/ml_dsa_kmgmt.c.in
@@ -295,7 +295,7 @@ static int ml_dsa_import(void *keydata, int selection, const OSSL_PARAM params[]
     if (res > 0) {
         res = ml_dsa_pairwise_test(key);
         if (!res) {
-            ossl_ml_dsa_key_free(key);
+            ossl_ml_dsa_key_reset(key);
             ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT_IMPORT);
         }
     }

--- a/providers/implementations/keymgmt/ml_kem_kmgmt.c.in
+++ b/providers/implementations/keymgmt/ml_kem_kmgmt.c.in
@@ -482,7 +482,7 @@ static int ml_kem_import(void *vkey, int selection, const OSSL_PARAM params[])
     if (res > 0 && include_private
         && !ml_kem_pairwise_test(key, key->prov_flags)) {
 #ifdef FIPS_MODULE
-        ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT);
+        ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT_IMPORT);
 #endif
         ossl_ml_kem_key_reset(key);
         res = 0;
@@ -509,7 +509,7 @@ static const OSSL_PARAM *ml_kem_gettable_params(void *provctx)
 }
 
 #ifndef FIPS_MODULE
-void *ml_kem_load(const void *reference, size_t reference_sz)
+static void *ml_kem_load(const void *reference, size_t reference_sz)
 {
     ML_KEM_KEY *key = NULL;
     uint8_t *encoded_dk = NULL;


### PR DESCRIPTION
This is to prevent DoS attacks via the import mechanism while retaining adherence to the FIPS requirements.

- [x] documentation is added or updated
- [ ] tests are added or updated
