### PR TITLE
FIPS: Don't allow SHA512-224 and SHA512-256 for ECDSA/DSA signatures

### DIFF
--- a/providers/common/securitycheck_fips.c
+++ b/providers/common/securitycheck_fips.c
@@ -98,18 +98,33 @@ int ossl_fips_ind_digest_exch_check(OSSL_FIPS_IND *ind, int id,
 int ossl_fips_ind_digest_sign_check(OSSL_FIPS_IND *ind, int id,
                                     OSSL_LIB_CTX *libctx,
                                     int nid, int sha1_allowed,
+                                    int sha512_trunc_allowed,
                                     const char *desc,
                                     OSSL_FIPS_IND_CHECK_CB *config_check_f)
 {
     int approved;
+    const char *op = "none";
 
-    if (nid == NID_undef)
+    switch (nid) {
+    case NID_undef:
         approved = 0;
-    else
-        approved = sha1_allowed || nid != NID_sha1;
+        break;
+    case NID_sha512_224:
+    case NID_sha512_256:
+        approved = sha512_trunc_allowed;
+        op = "Digest Truncated SHA512";
+        break;
+    case NID_sha1:
+        approved = sha1_allowed;
+        op = "Digest SHA1";
+        break;
+    default:
+        approved = 1;
+        break;
+    }
 
     if (!approved) {
-        if (!ossl_FIPS_IND_on_unapproved(ind, id, libctx, desc, "Digest SHA1",
+        if (!ossl_FIPS_IND_on_unapproved(ind, id, libctx, desc, op,
                                          config_check_f)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DIGEST);
             return 0;

--- a/providers/fips/include/fips/fipsindicator.h
+++ b/providers/fips/include/fips/fipsindicator.h
@@ -144,6 +144,7 @@ int ossl_fips_ind_digest_exch_check(OSSL_FIPS_IND *ind, int id, OSSL_LIB_CTX *li
 int ossl_fips_ind_digest_sign_check(OSSL_FIPS_IND *ind, int id,
                                     OSSL_LIB_CTX *libctx,
                                     int nid, int sha1_allowed,
+                                    int sha512_trunc_allowed,
                                     const char *desc,
                                     OSSL_FIPS_IND_CHECK_CB *config_check_f);
 

--- a/providers/implementations/signature/dsa_sig.c.in
+++ b/providers/implementations/signature/dsa_sig.c.in
@@ -196,7 +196,7 @@ static int dsa_setup_md(PROV_DSA_CTX *ctx,
             if (!ossl_fips_ind_digest_sign_check(OSSL_FIPS_IND_GET(ctx),
                                                  OSSL_FIPS_IND_SETTABLE1,
                                                  ctx->libctx,
-                                                 md_nid, sha1_allowed, desc,
+                                                 md_nid, sha1_allowed, 0, desc,
                                                  ossl_fips_config_signature_digest_check))
                 goto err;
         }

--- a/providers/implementations/signature/ecdsa_sig.c.in
+++ b/providers/implementations/signature/ecdsa_sig.c.in
@@ -222,7 +222,7 @@ static int ecdsa_setup_md(PROV_ECDSA_CTX *ctx,
         if (!ossl_fips_ind_digest_sign_check(OSSL_FIPS_IND_GET(ctx),
                                              OSSL_FIPS_IND_SETTABLE1,
                                              ctx->libctx,
-                                             md_nid, sha1_allowed, desc,
+                                             md_nid, sha1_allowed, 0, desc,
                                              ossl_fips_config_signature_digest_check))
             goto err;
     }

--- a/providers/implementations/signature/rsa_sig.c.in
+++ b/providers/implementations/signature/rsa_sig.c.in
@@ -414,7 +414,7 @@ static int rsa_setup_md(PROV_RSA_CTX *ctx, const char *mdname,
             if (!ossl_fips_ind_digest_sign_check(OSSL_FIPS_IND_GET(ctx),
                                                  OSSL_FIPS_IND_SETTABLE1,
                                                  ctx->libctx,
-                                                 md_nid, sha1_allowed, desc,
+                                                 md_nid, sha1_allowed, 1, desc,
                                                  ossl_fips_config_signature_digest_check))
                 goto err;
         }

--- a/test/recipes/30-test_evp_data/evppkey_ecdsa.txt
+++ b/test/recipes/30-test_evp_data/evppkey_ecdsa.txt
@@ -268,6 +268,15 @@ Ctrl = digest:SHA1
 Input = "0123456789ABCDEF1234"
 Result = KEYOP_MISMATCH
 
+FIPSversion = >=3.6.0
+Sign = P-256
+Securitycheck = 1
+Unapproved = 1
+CtrlInit = digest-check:0
+Ctrl = digest:SHA512-224
+Input = "0123456789ABCDEF1234"
+Result = KEYOP_ERROR
+
 Title = XOF disallowed
 
 DigestVerify = SHAKE256


### PR DESCRIPTION
These algorithms do not have OIDS (Note that RSA does have OIDS), and are not valid values for FIPS.
Note that this was only possible if the "ECDSA" algorithm is fetched. Note that "ECDSA-SHA512-256" and "ECDSA-SHA512-224" are not currently fetchable.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
