### PR TITLE
fips: support oscp and x509 unapproved SHA1 usage

### DIFF
--- a/crypto/ocsp/ocsp_srv.c
+++ b/crypto/ocsp/ocsp_srv.c
@@ -248,7 +248,7 @@ int OCSP_RESPID_set_by_key_ex(OCSP_RESPID *respid, X509 *cert,
 {
     ASN1_OCTET_STRING *byKey = NULL;
     unsigned char md[SHA_DIGEST_LENGTH];
-    EVP_MD *sha1 = EVP_MD_fetch(libctx, "SHA1", propq);
+    EVP_MD *sha1 = EVP_MD_fetch(libctx, "SHA1", "?fips=yes");
     int ret = 0;
 
     if (sha1 == NULL)
@@ -292,7 +292,7 @@ int OCSP_RESPID_match_ex(OCSP_RESPID *respid, X509 *cert, OSSL_LIB_CTX *libctx,
     if (respid->type == V_OCSP_RESPID_KEY) {
         unsigned char md[SHA_DIGEST_LENGTH];
 
-        sha1 = EVP_MD_fetch(libctx, "SHA1", propq);
+        sha1 = EVP_MD_fetch(libctx, "SHA1", "?fips=yes");
         if (sha1 == NULL)
             goto err;
 

--- a/crypto/x509/v3_skid.c
+++ b/crypto/x509/v3_skid.c
@@ -69,7 +69,7 @@ ASN1_OCTET_STRING *ossl_x509_pubkey_hash(X509_PUBKEY *pubkey)
     }
     if (!ossl_x509_PUBKEY_get0_libctx(&libctx, &propq, pubkey))
         return NULL;
-    if ((md = EVP_MD_fetch(libctx, SN_sha1, propq)) == NULL)
+    if ((md = EVP_MD_fetch(libctx, SN_sha1, "?fips=yes")) == NULL)
         return NULL;
     if ((oct = ASN1_OCTET_STRING_new()) == NULL) {
         EVP_MD_free(md);

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -295,7 +295,7 @@ unsigned long X509_NAME_hash_ex(const X509_NAME *x, OSSL_LIB_CTX *libctx,
 {
     unsigned long ret = 0;
     unsigned char md[SHA_DIGEST_LENGTH];
-    EVP_MD *sha1 = EVP_MD_fetch(libctx, "SHA1", propq);
+    EVP_MD *sha1 = EVP_MD_fetch(libctx, "SHA1", "?fips=yes");
     int i2d_ret;
 
     /* Make sure X509_NAME structure contains valid cached encoding */


### PR DESCRIPTION
OSCP and X509 currently must use SHA1 for non-security sensitive
purposes of hashish key subjects.

Prefer, but allow using unapproved SHA1 implementation when computing
these fields.

Currently there is no path forward away from SHA1 for OSCP.

For x509 however, most other implementations are switching to SHA-256/160. See:
- https://github.com/openssl/openssl/issues/28381
