### PR TITLE
Fix typo in BN_generate_prime docs

### DIFF
--- a/doc/man3/BN_generate_prime.pod
+++ b/doc/man3/BN_generate_prime.pod
@@ -130,7 +130,7 @@ or all the tests passed.
 If B<p> passes all these tests, it is considered a probable prime.
 
 The test performed on B<p> are trial division by a number of small primes
-and rounds of the of the Miller-Rabin probabilistic primality test.
+and rounds of the Miller-Rabin probabilistic primality test.
 
 The functions do at least 64 rounds of the Miller-Rabin test giving a maximum
 false positive rate of 2^-128.
@@ -148,7 +148,7 @@ and BN_is_prime_fasttest() are deprecated.
 
 BN_is_prime_fasttest() and BN_is_prime() behave just like
 BN_is_prime_fasttest_ex() and BN_is_prime_ex() respectively, but with the old
-style call back.
+style callback.
 
 B<ctx> is a preallocated B<BN_CTX> (to save the overhead of allocating and
 freeing the structure in a loop), or B<NULL>.


### PR DESCRIPTION
Just a minor typo fix in man3/BN_generate_prime.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
