### PR TITLE
[WIP] Add a test for multi-threaded OBJ_create

### DIFF
--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -1358,6 +1358,42 @@ static int test_x509_store(void)
     return ret;
 }
 
+/* Test using OBJ_create in multiple threads */
+static void test_obj_create_worker(void)
+{
+    int i, nid, nid2;
+    time_t now;
+    char name[40];
+
+    for (i = 0; i < 4; i++) {
+        now = time(NULL);
+        sprintf(name, "Time in Seconds = %ld", (long) now);
+        while (now == time(NULL))
+            /* no-op */;
+        nid = OBJ_create(NULL, NULL, name);
+        nid2 = OBJ_ln2nid(name);
+        if (nid != NID_undef) {
+            if (nid2 != nid) {
+                TEST_info("oops: name='%s' nid=%d nid2=%d", name, nid, nid2);
+                multi_set_success(0);
+                break;
+            }
+        } else {
+            if (nid2 == NID_undef) {
+                TEST_info("oops: name='%s' nid=%d nid2=%d", name, nid, nid2);
+                multi_set_success(0);
+                break;
+            }
+        }
+    }
+}
+
+static int test_obj_stress(void)
+{
+    return thread_run_test(&test_obj_create_worker, MAXIMUM_THREADS,
+                           &test_obj_create_worker, 0, NULL);
+}
+
 typedef enum OPTION_choice {
     OPT_ERR = -1,
     OPT_EOF = 0,
@@ -1447,6 +1483,7 @@ int setup_tests(void)
 #endif
     ADD_TEST(test_pem_read);
     ADD_TEST(test_x509_store);
+    ADD_TEST(test_obj_stress);
     return 1;
 }
 


### PR DESCRIPTION
After a successful OBJ_create the returned NID should be the same NID that is returned from OBJ_ln2nid and
should not change any more, but after an unsuccessful OBJ_create, another thread must have created the object,
therefore OBJ_ln2nid should not return NID_undef.

@nhorman This demonstrates that OBJ_create is currently not really thread-safe because it is not holding the
write lock during the complete function execution, therefore the results are unreliable.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
