### PR TITLE
backport `X509_VERIFY_PARAM_get0()`: add check to defend on out-of-bound table access

### DIFF
--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -629,6 +629,11 @@ const X509_VERIFY_PARAM *X509_VERIFY_PARAM_get0(int id)
 {
     int num = OSSL_NELEM(default_table);
 
+    if (id < 0) {
+        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_INVALID_ARGUMENT);
+        return NULL;
+    }
+
     if (id < num)
         return default_table + id;
     return sk_X509_VERIFY_PARAM_value(param_table, id - num);


### PR DESCRIPTION
This backports #28370 to 3.4 etc.
