### PR TITLE
[3.0, 3.2] Coverity fixes for issues 1665143..1665162

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -252,6 +252,8 @@ int enc_main(int argc, char **argv)
                 goto opthelp;
             if (k)
                 n *= 1024;
+            if (n > INT_MAX)
+                goto opthelp;
             bsize = (int)n;
             break;
         case OPT_K:

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -672,7 +672,8 @@ redo_accept:
                 resp =
                     OCSP_response_create(OCSP_RESPONSE_STATUS_MALFORMEDREQUEST,
                                          NULL);
-                send_ocsp_response(cbio, resp);
+                if (resp != NULL)
+                    send_ocsp_response(cbio, resp);
             }
             goto done_resp;
         }
@@ -770,16 +771,18 @@ redo_accept:
         BIO_free(derbio);
     }
 
-    i = OCSP_response_status(resp);
-    if (i != OCSP_RESPONSE_STATUS_SUCCESSFUL) {
-        BIO_printf(out, "Responder Error: %s (%d)\n",
-                   OCSP_response_status_str(i), i);
-        if (!ignore_err)
+    if (resp != NULL) {
+        i = OCSP_response_status(resp);
+        if (i != OCSP_RESPONSE_STATUS_SUCCESSFUL) {
+            BIO_printf(out, "Responder Error: %s (%d)\n",
+                       OCSP_response_status_str(i), i);
+            if (!ignore_err)
                 goto end;
-    }
+        }
 
-    if (resp_text)
-        OCSP_RESPONSE_print(out, resp, 0);
+        if (resp_text)
+            OCSP_RESPONSE_print(out, resp, 0);
+    }
 
     /* If running as responder don't verify our own response */
     if (cbio != NULL) {

--- a/crypto/x509/t_req.c
+++ b/crypto/x509/t_req.c
@@ -40,7 +40,7 @@ int X509_REQ_print_ex(BIO *bp, X509_REQ *x, unsigned long nmflags,
     long l;
     int i;
     EVP_PKEY *pkey;
-    STACK_OF(X509_EXTENSION) *exts;
+    STACK_OF(X509_EXTENSION) *exts = NULL;
     char mlch = ' ';
     int nmindent = 0, printok = 0;
 
@@ -191,6 +191,7 @@ int X509_REQ_print_ex(BIO *bp, X509_REQ *x, unsigned long nmflags,
                     goto err;
             }
             sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
+            exts = NULL;
         }
     }
 
@@ -204,6 +205,7 @@ int X509_REQ_print_ex(BIO *bp, X509_REQ *x, unsigned long nmflags,
 
     return 1;
  err:
+    sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
     ERR_raise(ERR_LIB_X509, ERR_R_BUF_LIB);
     return 0;
 }

--- a/doc/man1/openssl-enc.pod.in
+++ b/doc/man1/openssl-enc.pod.in
@@ -191,10 +191,12 @@ Print out the key and IV used.
 Print out the key and IV used then immediately exit: don't do any encryption
 or decryption.
 
-=item B<-bufsize> I<number>
+=item B<-bufsize> I<number>[B<k>]
 
 Set the buffer size for I/O.
 The maximum size that can be specified is B<2^31-1> (2147483647) bytes.
+The B<k> suffix can be specified to indicate that I<number> is provided
+in kibibytes (multiples of 1024 bytes).
 
 =item B<-nopad>
 

--- a/doc/man1/openssl-enc.pod.in
+++ b/doc/man1/openssl-enc.pod.in
@@ -194,6 +194,7 @@ or decryption.
 =item B<-bufsize> I<number>
 
 Set the buffer size for I/O.
+The maximum size that can be specified is B<2^31-1> (2147483647) bytes.
 
 =item B<-nopad>
 


### PR DESCRIPTION
This is a backport of [1] to the `openssl-3.0` and `openssl-3.2` branches.

[1] https://github.com/openssl/openssl/pull/28405

References: https://github.com/openssl/project/issues/1362