### PR TITLE
hmac: stop using secure memory for the HMAC key (versions 3.3 and before)

### DIFF
--- a/providers/implementations/macs/hmac_prov.c
+++ b/providers/implementations/macs/hmac_prov.c
@@ -85,7 +85,7 @@ static void hmac_free(void *vmacctx)
     if (macctx != NULL) {
         HMAC_CTX_free(macctx->ctx);
         ossl_prov_digest_reset(&macctx->digest);
-        OPENSSL_secure_clear_free(macctx->key, macctx->keylen);
+        OPENSSL_clear_free(macctx->key, macctx->keylen);
         OPENSSL_free(macctx);
     }
 }
@@ -114,13 +114,13 @@ static void *hmac_dup(void *vsrc)
         return NULL;
     }
     if (src->key != NULL) {
-        /* There is no "secure" OPENSSL_memdup */
-        dst->key = OPENSSL_secure_malloc(src->keylen > 0 ? src->keylen : 1);
+        dst->key = OPENSSL_malloc(src->keylen > 0 ? src->keylen : 1);
         if (dst->key == NULL) {
             hmac_free(dst);
             return 0;
         }
-        memcpy(dst->key, src->key, src->keylen);
+        if (src->keylen > 0)
+            memcpy(dst->key, src->key, src->keylen);
     }
     return dst;
 }
@@ -145,12 +145,14 @@ static int hmac_setkey(struct hmac_data_st *macctx,
     const EVP_MD *digest;
 
     if (macctx->key != NULL)
-        OPENSSL_secure_clear_free(macctx->key, macctx->keylen);
+        OPENSSL_clear_free(macctx->key, macctx->keylen);
     /* Keep a copy of the key in case we need it for TLS HMAC */
-    macctx->key = OPENSSL_secure_malloc(keylen > 0 ? keylen : 1);
+    macctx->key = OPENSSL_malloc(keylen > 0 ? keylen : 1);
     if (macctx->key == NULL)
         return 0;
-    memcpy(macctx->key, key, keylen);
+
+    if (keylen > 0)
+        memcpy(macctx->key, key, keylen);
     macctx->keylen = keylen;
 
     digest = ossl_prov_digest_md(&macctx->digest);


### PR DESCRIPTION
Secure memory is design for long term storage of private material. HMAC keys are not this.

Secure memory use was introduced in July 2020 by commit 3fddbb264e87a8cef2903cbd7b02b8e1a39a2a99.

Fixes #28346

Back port after merge fix.
