### PR TITLE
Explicitly clear the secure extensions on free

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4446,7 +4446,7 @@ void SSL_CTX_free(SSL_CTX *a)
     OPENSSL_free(a->ext.keyshares);
     OPENSSL_free(a->ext.tuples);
     OPENSSL_free(a->ext.alpn);
-    OPENSSL_secure_free(a->ext.secure);
+    OPENSSL_secure_clear_free(a->ext.secure, sizeof(*a->ext.secure));
 
     ssl_evp_md_free(a->md5);
     ssl_evp_md_free(a->sha1);


### PR DESCRIPTION
Secure memory clears anyway but best to be explicit about it.  This, in part at least, helps address the first issue in appendix B of #28401.

