### PR TITLE
Make tests run faster on typical platforms.

### DIFF
--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -48,14 +48,14 @@ if (!defined($jobs)) {
         # Smells like Linux or something else attempting bug for bug
         # compatibilty with the /proc paradigm.
         my $tmp = qx(grep -c ^processor /proc/cpuinfo 2>/dev/null);
-        if ($? eq 0 && $tmp > 0) {
+        if ($? == 0 && $tmp > 0) {
             $cpus = $tmp;
         }
     }
     if (!defined($cpus)) {
         # OpenBSD, FreeBSD, MacOS
         my $tmp = qx(sysctl -n hw.ncpu 2>/dev/null);
-        if ($? eq 0 && $tmp > 0) {
+        if ($? == 0 && $tmp > 0) {
             $cpus = $tmp;
         }
     }

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -39,22 +39,22 @@ if (!defined($jobs)) {
         # Perl was built on Linux, so try nproc, which is apparently
         # the less worse way if you are restricted in a
         # container/cgroup
-        my $tmp = `nproc 2>/dev/null`;
-        if ($? eq 0 && $tmp > 0) {
+        my $tmp = qx(nproc 2>/dev/null);
+        if ($? == 0 && $tmp > 0) {
             $cpus = $tmp;
         }
     }
     if (!defined($cpus) && -r "/proc/cpuinfo") {
         # Smells like Linux or something else attempting bug for bug
         # compatibilty with the /proc paradigm.
-        my $tmp = `grep -c ^processor /proc/cpuinfo 2>/dev/null`;
+        my $tmp = qx(grep -c ^processor /proc/cpuinfo 2>/dev/null);
         if ($? eq 0 && $tmp > 0) {
             $cpus = $tmp;
         }
     }
     if (!defined($cpus)) {
         # OpenBSD, FreeBSD, MacOS
-        my $tmp = `sysctl -n hw.ncpu 2>/dev/null`;
+        my $tmp = qx(sysctl -n hw.ncpu 2>/dev/null);
         if ($? eq 0 && $tmp > 0) {
             $cpus = $tmp;
         }

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -31,7 +31,41 @@ my $srctop = $ENV{SRCTOP} || $ENV{TOP};
 my $bldtop = $ENV{BLDTOP} || $ENV{TOP};
 my $recipesdir = catdir($srctop, "test", "recipes");
 my $libdir = rel2abs(catdir($srctop, "util", "perl"));
-my $jobs = $ENV{HARNESS_JOBS} // 1;
+
+my $jobs = $ENV{HARNESS_JOBS};
+if (!defined($jobs)) {
+    my $cpus = $ENV{"NUMBER_OF_PROCESSORS"}; # Windows sets this.
+    if (!defined($cpus) && $^O =~ /linux/) {
+        # Perl was built on Linux, so try nproc, which is apparently
+        # the less worse way if you are restricted in a
+        # container/cgroup
+        my $tmp = `nproc 2>/dev/null`;
+        if ($? eq 0 && $tmp > 0) {
+            $cpus = $tmp;
+        }
+    }
+    if (!defined($cpus) && -r "/proc/cpuinfo") {
+        # Smells like Linux or something else attempting bug for bug
+        # compatibilty with the /proc paradigm.
+        my $tmp = `grep -c ^processor /proc/cpuinfo 2>/dev/null`;
+        if ($? eq 0 && $tmp > 0) {
+            $cpus = $tmp;
+        }
+    }
+    if (!defined($cpus)) {
+        # OpenBSD, FreeBSD, MacOS
+        my $tmp = `sysctl -n hw.ncpu 2>/dev/null`;
+        if ($? eq 0 && $tmp > 0) {
+            $cpus = $tmp;
+        }
+    }
+
+    if (defined($cpus) && $cpus > 0) {
+        $jobs = $cpus;
+    } else {
+        $jobs = 1;
+    }
+}
 
 $ENV{OPENSSL_CONF} = rel2abs(catfile($srctop, "apps", "openssl.cnf"));
 $ENV{OPENSSL_CONF_INCLUDE} = rel2abs(catdir($bldtop, "test"));


### PR DESCRIPTION
Sadly not doable in make as it is notoriously bad at telling you the parallelism being used by make -j.

If the HARNESS_JOBS environment variable has not been set, this makes the perl script attempt to figure out how many cpu's are available on anything linux/macos/bsd like, and if it can be successfully detected, we use that value. if not, we use 1 as before.

Fixes: [1633
](https://github.com/openssl/project/issues/1633)

Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
