### PR TITLE
Introduce app_malloc_array()

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -1916,7 +1916,7 @@ static int do_body(X509 **xret, EVP_PKEY *pkey, X509 *x509,
         goto end;
     }
 
-    irow = app_malloc(sizeof(*irow) * (DB_NUMBER + 1), "row space");
+    irow = app_malloc_array(DB_NUMBER + 1, sizeof(*irow), "row space");
     for (i = 0; i < DB_NUMBER; i++)
         irow[i] = row[i];
     irow[DB_NUMBER] = NULL;
@@ -2145,7 +2145,7 @@ static int do_revoke(X509 *x509, CA_DB *db, REVINFO_TYPE rev_type,
             goto end;
         }
 
-        irow = app_malloc(sizeof(*irow) * (DB_NUMBER + 1), "row ptr");
+        irow = app_malloc_array(DB_NUMBER + 1, sizeof(*irow), "row ptr");
         for (i = 0; i < DB_NUMBER; i++)
             irow[i] = row[i];
         irow[DB_NUMBER] = NULL;

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -70,7 +70,7 @@ static int list_builtin_curves(BIO *out)
     EC_builtin_curve *curves = NULL;
     size_t n, crv_len = EC_get_builtin_curves(NULL, 0);
 
-    curves = app_malloc((int)sizeof(*curves) * crv_len, "list curves");
+    curves = app_malloc_array(crv_len, sizeof(*curves), "list curves");
     EC_get_builtin_curves(curves, crv_len);
 
     for (n = 0; n < crv_len; n++) {

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -230,7 +230,26 @@ typedef struct ca_db_st {
 extern int do_updatedb(CA_DB *db, time_t *now);
 
 void app_bail_out(char *fmt, ...);
+/**
+ * OPENSSL_malloc() wrapper that bails out with a meaningful message on failure.
+ *
+ * @param sz   Number of bytes to allocate.
+ * @param what Description of the object being allocated.
+ * @return On success, returns a pointer to the newly allocated memory.
+ *         on failure, calls app_bail_out() to terminate the program.
+ */
 void *app_malloc(size_t sz, const char *what);
+/**
+ * OPENSSL_malloc_array() wrapper that bails out with a meaningful message
+ * on failure.
+ *
+ * @param n    Number of objects to allocate memory for.
+ * @param sz   Size in bytes of each object to be allocated.
+ * @param what Description of the array being allocated.
+ * @return On success, returns a pointer to the newly allocated memory;
+ *         on failure, calls app_bail_out() to terminate the program.
+ */
+void *app_malloc_array(size_t n, size_t sz, const char *what);
 
 /* load_serial, save_serial, and rotate_serial are also used for CRL numbers */
 BIGNUM *load_serial(const char *serialfile, int *exists, int create,

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -3297,7 +3297,7 @@ void wait_for_async(SSL *s)
         return;
     if (numfds == 0)
         return;
-    fds = app_malloc(sizeof(OSSL_ASYNC_FD) * numfds, "allocate async fds");
+    fds = app_malloc_array(numfds, sizeof(*fds), "allocate async fds");
     if (!SSL_get_all_async_fds(s, fds, &numfds)) {
         OPENSSL_free(fds);
         return;

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -695,6 +695,16 @@ void *app_malloc(size_t sz, const char *what)
     return vp;
 }
 
+void *app_malloc_array(size_t n, size_t sz, const char *what)
+{
+    void *vp = OPENSSL_malloc_array(n, sz);
+
+    if (vp == NULL)
+        app_bail_out("%s: Could not allocate %zu*%zu bytes for %s\n",
+                     opt_getprog(), n, sz, what);
+    return vp;
+}
+
 char *next_item(char *opt) /* in list separated by comma and/or space */
 {
     /* advance to separator (comma or whitespace), if any */

--- a/apps/lib/http_server.c
+++ b/apps/lib/http_server.c
@@ -92,7 +92,8 @@ void spawn_loop(const char *prog)
                   strerror(errno));
         exit(1);
     }
-    kidpids = app_malloc(n_responders * sizeof(*kidpids), "child PID array");
+    kidpids = app_malloc_array(n_responders, sizeof(*kidpids),
+                               "child PID array");
     for (i = 0; i < n_responders; ++i)
         kidpids[i] = 0;
 

--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -391,7 +391,7 @@ int ssl_print_groups(BIO *out, SSL *s, int noshared)
     ngroups = SSL_get1_groups(s, NULL);
     if (ngroups <= 0)
         return 1;
-    groups = app_malloc(ngroups * sizeof(int), "groups to print");
+    groups = app_malloc_array(ngroups, sizeof(*groups), "groups to print");
     SSL_get1_groups(s, groups);
 
     BIO_puts(out, "Supported groups: ");

--- a/apps/rsautl.c
+++ b/apps/rsautl.c
@@ -215,7 +215,7 @@ int rsautl_main(int argc, char **argv)
 
     keysize = EVP_PKEY_get_size(pkey);
 
-    rsa_in = app_malloc(keysize * 2, "hold rsa key");
+    rsa_in = app_malloc_array(2, keysize, "hold rsa key");
     rsa_out = app_malloc(keysize, "output rsa key");
     rsa_outlen = keysize;
 

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -2499,7 +2499,7 @@ int speed_main(int argc, char **argv)
 
     loopargs_len = (async_jobs == 0 ? 1 : async_jobs);
     loopargs =
-        app_malloc(loopargs_len * sizeof(loopargs_t), "array of loopargs");
+        app_malloc_array(loopargs_len, sizeof(loopargs_t), "array of loopargs");
     memset(loopargs, 0, loopargs_len * sizeof(loopargs_t));
 
     buflen = lengths[size_num - 1];
@@ -4885,7 +4885,7 @@ static int do_multi(int multi, int size_num)
     int status;
     static char sep[] = ":";
 
-    fds = app_malloc(sizeof(*fds) * multi, "fd buffer for do_multi");
+    fds = app_malloc_array(multi, sizeof(*fds), "fd buffer for do_multi");
     for (n = 0; n < multi; ++n) {
         if (pipe(fd) == -1) {
             BIO_printf(bio_err, "pipe failure\n");

--- a/apps/srp.c
+++ b/apps/srp.c
@@ -97,7 +97,7 @@ static int update_index(CA_DB *db, char **row)
     char **irow;
     int i;
 
-    irow = app_malloc(sizeof(*irow) * (DB_NUMBER + 1), "row pointers");
+    irow = app_malloc_array(DB_NUMBER + 1, sizeof(*irow), "row pointers");
     for (i = 0; i < DB_NUMBER; i++)
         irow[i] = row[i];
     irow[DB_NUMBER] = NULL;

--- a/test/testutil/apps_shims.c
+++ b/test/testutil/apps_shims.c
@@ -29,6 +29,21 @@ void *app_malloc(size_t sz, const char *what)
     return vp;
 }
 
+void *app_malloc_array(size_t n, size_t sz, const char *what)
+{
+    void *vp;
+
+    /*
+     * Instead of exiting with a failure, abort() is called which makes sure
+     * that there will be a good stack trace for debugging purposes.
+     */
+    if (!TEST_ptr(vp = OPENSSL_malloc_array(n, sz))) {
+        TEST_info("Could not allocate %zu*%zu bytes for %s\n", n, sz, what);
+        abort();
+    }
+    return vp;
+}
+
 /* shim to prevent sucking in too much from apps */
 
 int opt_legacy_okay(void)


### PR DESCRIPTION
With similar rationale as in #28059 wrt array allocation;  since apps use their own `OPENSSL_malloc()` wrapper, provide one for array allocation and use it where appropriate.
