### PR TITLE
Updated s_server's verify_return_error option to enable peer verification

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -265,6 +265,11 @@ OpenSSL 3.6
 
    *Dimitri John Ledkov*
 
+ * Enabled Server verification by default in `s_server` when option
+   verify_return_error is enabled.
+
+   *Ryan Hooper*
+
 OpenSSL 3.5
 -----------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,11 @@ OpenSSL 4.0
 
    *Igor Ustinov*
 
+ * Enabled Server verification by default in `s_server` when option
+   verify_return_error is enabled.
+
+   *Ryan Hooper*
+
 OpenSSL 3.6
 -----------
 
@@ -264,11 +269,6 @@ OpenSSL 3.6
    generation to the FIPS provider.
 
    *Dimitri John Ledkov*
-
- * Enabled Server verification by default in `s_server` when option
-   verify_return_error is enabled.
-
-   *Ryan Hooper*
 
 OpenSSL 3.5
 -----------

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1568,6 +1568,7 @@ int s_server_main(int argc, char *argv[])
                 goto end;
             break;
         case OPT_VERIFY_RET_ERROR:
+            s_server_verify = SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE;
             verify_args.return_error = 1;
             break;
         case OPT_VERIFY_QUIET:


### PR DESCRIPTION
Updated s_server's verify_return_error option to enable peer verification. S_client was already behaved this way, so s_server was updated to match the behavior of s_client.

Fixes #15134

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
