### PR TITLE
Remove import PCTs

### DIFF
--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -209,18 +209,6 @@ static int dh_import(void *keydata, int selection, const OSSL_PARAM params[])
             selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY ? 1 : 0;
 
         ok = ok && ossl_dh_key_fromdata(dh, params, include_private);
-#ifdef FIPS_MODULE
-        /*
-         * FIPS 140-3 IG 10.3.A additional comment 1 mandates that a pairwise
-         * consistency check be undertaken on key import.  The required test
-         * is described in SP 800-56Ar3 5.6.2.1.4.
-         */
-        if (ok > 0 && !ossl_fips_self_testing()) {
-            ok = ossl_dh_check_pairwise(dh, 1);
-            if (ok <= 0)
-                ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT_IMPORT);
-        }
-#endif  /* FIPS_MODULE */
     }
 
     return ok;

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -431,21 +431,6 @@ int common_import(void *keydata, int selection, const OSSL_PARAM params[],
     if ((selection & OSSL_KEYMGMT_SELECT_OTHER_PARAMETERS) != 0)
         ok = ok && ossl_ec_key_otherparams_fromdata(ec, params);
 
-#ifdef FIPS_MODULE
-    if (ok > 0
-            && !ossl_fips_self_testing()
-            && EC_KEY_get0_public_key(ec) != NULL
-            && EC_KEY_get0_private_key(ec) != NULL
-            && EC_KEY_get0_group(ec) != NULL) {
-        BN_CTX *bnctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(ec));
-
-        ok = bnctx != NULL && ossl_ec_key_pairwise_check(ec, bnctx);
-        BN_CTX_free(bnctx);
-        if (ok <= 0)
-            ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT_IMPORT);
-    }
-#endif  /* FIPS_MODULE */
-
     return ok;
 }
 

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -197,23 +197,6 @@ static int rsa_import(void *keydata, int selection, const OSSL_PARAM params[])
         ok = ok && ossl_rsa_fromdata(rsa, params, include_private);
     }
 
-#ifdef FIPS_MODULE
-    if (ok > 0 && !ossl_fips_self_testing()) {
-        const BIGNUM *n, *e, *d, *dp, *dq, *iq, *p, *q;
-
-        RSA_get0_key(rsa, &n, &e, &d);
-        RSA_get0_crt_params(rsa, &dp, &dq, &iq);
-        p = RSA_get0_p(rsa);
-        q = RSA_get0_q(rsa);
-
-        /* Check for the public key */
-        if (n != NULL && e != NULL)
-            /* Check for private key in straightforward or CRT form */
-            if (d != NULL || (p != NULL && q != NULL && dp != NULL
-                              && dq != NULL && iq != NULL))
-                ok = ossl_rsa_key_pairwise_test(rsa);
-    }
-#endif  /* FIPS_MODULE */
     return ok;
 }
 

--- a/providers/implementations/keymgmt/slh_dsa_kmgmt.c.in
+++ b/providers/implementations/keymgmt/slh_dsa_kmgmt.c.in
@@ -119,7 +119,7 @@ static int slh_dsa_validate(const void *key_data, int selection, int check_type)
 static int slh_dsa_import(void *keydata, int selection, const OSSL_PARAM params[])
 {
     SLH_DSA_KEY *key = keydata;
-    int include_priv, res;
+    int include_priv;
     struct slh_dsa_import_st p;
 
     if (!ossl_prov_is_running()
@@ -131,21 +131,7 @@ static int slh_dsa_import(void *keydata, int selection, const OSSL_PARAM params[
         return 0;
 
     include_priv = ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0);
-    res = ossl_slh_dsa_key_fromdata(key, p.pub, p.priv, include_priv);
-#ifdef FIPS_MODULE
-    /*
-     * FIPS 140-3 IG 10.3.A additional comment 1 mandates that a pairwise
-     * consistency check be undertaken on key import.  The required test
-     * is described in SP 800-56Ar3 5.6.2.1.4.
-     */
-    if (res > 0 && ossl_slh_dsa_key_has(key, OSSL_KEYMGMT_SELECT_KEYPAIR) > 0)
-        if (!slh_dsa_fips140_pairwise_test(key, NULL)) {
-            ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT_IMPORT);
-            ossl_slh_dsa_key_reset(key);
-            res = 0;
-        }
-#endif  /* FIPS_MODULE */
-    return res;
+    return ossl_slh_dsa_key_fromdata(key, p.pub, p.priv, include_priv);
 }
 
 static const OSSL_PARAM *slh_dsa_imexport_types(int selection)

--- a/test/slh_dsa_test.c
+++ b/test/slh_dsa_test.c
@@ -186,19 +186,12 @@ static int slh_dsa_key_validate_failure_test(void)
     key = slh_dsa_key_from_data("SLH-DSA-SHA2-128f",
                                 slh_dsa_sha2_128s_0_keygen_priv,
                                 sizeof(slh_dsa_sha2_128s_0_keygen_priv), 0);
-    if (OSSL_PROVIDER_available(lib_ctx, "fips")
-            && fips_provider_version_match(lib_ctx, ">3.5.2")) {
-        /* The new pairwise test should fail in fips mode */
-        if (!TEST_ptr_null(key))
-            goto end;
-    } else {
-        if (!TEST_ptr(key))
-            goto end;
-        if (!TEST_ptr(vctx = EVP_PKEY_CTX_new_from_pkey(lib_ctx, key, NULL)))
-            goto end;
-        if (!TEST_int_eq(EVP_PKEY_pairwise_check(vctx), 0))
-            goto end;
-    }
+    if (!TEST_ptr(key))
+        goto end;
+    if (!TEST_ptr(vctx = EVP_PKEY_CTX_new_from_pkey(lib_ctx, key, NULL)))
+        goto end;
+    if (!TEST_int_eq(EVP_PKEY_pairwise_check(vctx), 0))
+        goto end;
     ret = 1;
 end:
     EVP_PKEY_CTX_free(vctx);


### PR DESCRIPTION
These are no longer required by NIST as part of a FIPS 140-3 validation.
For discussion see #28326.

- [ ] documentation is added or updated
- [x] tests are added or updated
