### PR TITLE
Make the Unix build process more repeatable

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -3,6 +3,8 @@
 ##
 ## {- join("\n## ", @autowarntext) -}
 {-
+     use Time::Piece;
+
      use OpenSSL::Util;
 
      our $makedep_scheme = $config{makedep_scheme};
@@ -74,6 +76,15 @@ FIPSKEY={- $config{FIPSKEY} -}
 
 VERSION={- "$config{full_version}" -}
 VERSION_NUMBER={- "$config{version}" -}
+RELEASE_DATE={- my $t = localtime;
+		if ($config{"release_date"}) {
+			# Provide the user with a more meaningful error message
+			# than the default internal parsing error from
+			# `Time::Piece->strptime(..)`.
+			eval { $t = Time::Piece->strptime($config{"release_date"}, "%d %b %Y"); } ||
+				die "Parsing \$config{release_date} ('$config{release_date}') failed: $@";
+		}
+		$t->strftime("%Y-%m-%d") -}
 MAJOR={- $config{major} -}
 MINOR={- $config{minor} -}
 SHLIB_VERSION_NUMBER={- $config{shlib_version} -}
@@ -1575,7 +1586,8 @@ EOF
           return <<"EOF";
 $args{src}: $pod
 	pod2man --name=$name --section=$section\$(MANSUFFIX) --center=OpenSSL \\
-		--release=\$(VERSION) $pod >\$\@
+		--date=\$(RELEASE_DATE) --release=\$(VERSION) \\
+		$pod >\$\@
 EOF
       } elsif (platform->isdef($args{src})) {
           #


### PR DESCRIPTION
Before this change all manpages would contain the date when pod2man was                    
run. This resulted in outputs that differed between builds--or              
potentially across a single build if the host clock "ticked" to the next  
day when the build was being run.

This commit modifies the manpage generation process as follows:
- The date all manpages were generated will be normalized to a single   
  date instead of a potentially rolling date.                                      
- The release date specified in `VERSION.dat` is used instead of the   
  date/time when `pod2man` was executed OR--in the event a date
  isn't specified in `VERSION.dat`--the time when the Makefiles were
  last regenerated.

Embedding a consistent date into the generated manpages helps ensure that                                                 
the build process as a whole is more repeatable and helps ensure that    
release versions of OpenSSL create artifacts consistent with the date          
that the official release was cut.

Closes: #28323 