### PR TITLE
Add mandoc output support for manpages

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1580,12 +1580,24 @@ EOF
           my $section = $1;
           my $name = uc basename($args{src}, ".$section");
           my $pod = $gen0;
-          return <<"EOF";
+
+          if ($config{manpage_format} eq "mdoc") {
+              return <<"EOF";
+$args{src}: $pod
+	pod2mdoc -n $name -s $section\$(MANSUFFIX) \\
+		 -d \$(RELEASE_DATE) \\
+		 $pod >\$\@
+EOF
+          } elsif ($config{manpage_format} eq "roff") {
+              return <<"EOF";
 $args{src}: $pod
 	pod2man --name=$name --section=$section\$(MANSUFFIX) --center=OpenSSL \\
 		--date=\$(RELEASE_DATE) --release=\$(VERSION) \\
 		$pod >\$\@
 EOF
+          } else {
+              die "Unhandled manpage format: $config{manpage_format}";
+          }
       } elsif (platform->isdef($args{src})) {
           #
           # Linker script-ish generator

--- a/Configure
+++ b/Configure
@@ -27,7 +27,7 @@ use OpenSSL::config;
 my $orig_death_handler = $SIG{__DIE__};
 $SIG{__DIE__} = \&death_handler;
 
-my $usage="Usage: Configure [no-<feature> ...] [enable-<feature> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]thread-pool] [[no-]default-thread-pool] [[no-]shared] [[no-]zlib|zlib-dynamic] [no-asm] [no-egd] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--with-xxx[=vvv]] [--config=FILE] [--help] os/compiler[:flags]\n";
+my $usage="Usage: Configure [no-<feature> ...] [enable-<feature> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]thread-pool] [[no-]default-thread-pool] [[no-]shared] [[no-]zlib|zlib-dynamic] [no-asm] [no-egd] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--with-xxx[=vvv]] [--config=FILE] [--manpage-format={roff,mdoc}] [--help] os/compiler[:flags]\n";
 
 my $banner = <<"EOF";
 
@@ -295,6 +295,7 @@ my $dofile = abs2rel(catfile($srcdir, "util/dofile.pl"));
 
 my $local_config_envname = 'OPENSSL_LOCAL_CONFIG_DIR';
 
+$config{manpage_format} = "roff";
 $config{sourcedir} = abs2rel($srcdir, $blddir);
 $config{builddir} = abs2rel($blddir, $blddir);
 # echo -n 'holy hand grenade of antioch' | openssl sha256
@@ -1042,6 +1043,10 @@ while (@argvcopy)
                 {
                 $config{build_type} = "release";
                 }
+        elsif (/^--manpage-format=(mdoc|roff)$/)
+		{
+		$config{manpage_format}="$1";
+		}
         elsif (/^--pgo$/)
                 {
                 $config{build_type} = "pgo";

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1200,7 +1200,8 @@ Build without support for the specified algorithm.
 
 The `ripemd` algorithm is deprecated and if used is synonymous with `rmd160`.
 
-### Compiler-specific options
+Compiler-specific options
+-------------------------
 
     -Dxxx, -Ixxx, -Wp, -lxxx, -Lxxx, -Wl, -rpath, -R, -framework, -static
 
@@ -1231,7 +1232,17 @@ encoding.
 Take note of the [Environment Variables](#environment-variables) documentation
 below and how these flags interact with those variables.
 
-### Environment Variables
+Miscellaneous options
+---------------------
+
+### --manpage-format
+
+Specify a specific output manpage format. The supported output types are mandoc
+and *roff. The *roff output format is the default for legacy and portability
+reasons.
+
+Environment Variables
+---------------------
 
     VAR=value
 
@@ -1308,10 +1319,18 @@ If `CC` is set, it is advisable to also set `CXX` to ensure both the C and C++
 compiler are in the same "family".  This becomes relevant with
 `enable-external-tests` and `enable-buildtest-c++`.
 
-### Reconfigure
+Reconfigure
+-----------
 
-    reconf
-    reconfigure
+### Make targets
+
+    `$ make reconf`
+
+or
+
+    `$ make reconfigure`
+
+### Description
 
 Reconfigure from earlier data.
 


### PR DESCRIPTION
This change modifies the Makefile generator to support mandoc format
manpages, in lieu of \*roff format manpages.
    
After this commit the user has the ability of specifying the manpage
format to the `--manpage-format` flag. The 2 supported manpage formats
as of writing are "mdoc" and "roff" and the default remains the "roff"    
format for legacy and portability reasons. 
    
The mandoc format requires pod2mdoc to be installed, whereas the roff
output format requires pod2man to be installed. The former requires an
additional utility be installed, whereas the latter uses pod2man, a
utility that has been present with perl distributions for well over a
decade.
        
mandoc format support is being added as it is an easier/arguably more
structured manpage format to parse, making it easier for downstream
consumers like FreeBSD to implement OS-specific build support, as the
minimum dependencies for the OpenSSL build process are more involved
than the tools available for the FreeBSD OS bootstrapping process.

Closes: #28325 