### PR TITLE
Convert ossltest engine to a provider

### DIFF
--- a/crypto/evp/mac_lib.c
+++ b/crypto/evp/mac_lib.c
@@ -289,10 +289,15 @@ unsigned char *EVP_Q_mac(OSSL_LIB_CTX *libctx,
     }
 
     /*
-     * If we passed in a propery query, make sure the underlying algorithm uses it
-     * if its a compound alg and needs to fetch its own internally
-     * If we don't do this then passing a property doesn't get used when constructing
-     * compund algorithms like hmacs
+     * If we passed in a property query, make sure the underlying algorithm uses it.
+     * Compound algorithms may fetch other underlying algorithms (i.e. a MAC algorithm
+     * may use a digest algorithm as part of its internal work), and the MAC decides which
+     * implementation of the underlying digest to use based on the
+     * OSSL_ALG_PARAM_PROPERTIES parameter, rather than the propq value passed in the
+     * EVP_MAC_fetch call above.
+     * If we don't set this parameter, then the MAC alg may use the default provider
+     * to allocate an underlying digest, rather than the one that we would have gotten
+     * by using the propq value here.
      */
     if (propq != NULL)
         *p++ = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_PROPERTIES,

--- a/crypto/evp/mac_lib.c
+++ b/crypto/evp/mac_lib.c
@@ -259,8 +259,9 @@ unsigned char *EVP_Q_mac(OSSL_LIB_CTX *libctx,
                          unsigned char *out, size_t outsize, size_t *outlen)
 {
     EVP_MAC *mac = EVP_MAC_fetch(libctx, name, propq);
-    OSSL_PARAM subalg_param[] = { OSSL_PARAM_END, OSSL_PARAM_END };
-    EVP_MAC_CTX *ctx  = NULL;
+    OSSL_PARAM subalg_param[] = { OSSL_PARAM_END, OSSL_PARAM_END, OSSL_PARAM_END };
+    int p_idx = 0;
+    EVP_MAC_CTX *ctx = NULL;
     size_t len = 0;
     unsigned char *res = NULL;
 
@@ -284,8 +285,21 @@ unsigned char *EVP_Q_mac(OSSL_LIB_CTX *libctx,
                 goto err;
             }
         }
-        subalg_param[0] =
+        subalg_param[p_idx] =
             OSSL_PARAM_construct_utf8_string(param_name, (char *)subalg, 0);
+        p_idx++;
+    }
+
+    /*
+     * If we passed in a propery query, make sure the underlying algorithm uses it
+     * if its a compound alg and needs to fetch its own internally
+     * If we don't do this then passing a property doesn't get used when constructing
+     * compund algorithms like hmacs
+     */
+    if (propq != NULL) {
+        subalg_param[p_idx] = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_PROPERTIES,
+                                                               (char *)propq, 0);
+        p_idx++;
     }
     /* Single-shot - on NULL key input, set dummy key value for EVP_MAC_Init. */
     if (key == NULL && keylen == 0)

--- a/providers/common/include/prov/provider_util.h
+++ b/providers/common/include/prov/provider_util.h
@@ -111,7 +111,8 @@ int ossl_prov_set_macctx(EVP_MAC_CTX *macctx,
                          const char *ciphername,
                          const char *mdname,
                          const char *engine,
-                         const char *properties);
+                         const char *properties,
+                         const OSSL_PARAM param[]);
 
 /* MAC functions */
 /*

--- a/providers/common/provider_util.c
+++ b/providers/common/provider_util.c
@@ -243,9 +243,12 @@ int ossl_prov_set_macctx(EVP_MAC_CTX *macctx,
                          const char *ciphername,
                          const char *mdname,
                          const char *engine,
-                         const char *properties)
+                         const char *properties,
+                         const OSSL_PARAM param[])
 {
-    OSSL_PARAM mac_params[5], *mp = mac_params;
+    OSSL_PARAM mac_params[5], *mp = mac_params, *mergep;
+    int free_merge = 0;
+    int ret;
 
     if (mdname != NULL)
         *mp++ = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
@@ -265,8 +268,29 @@ int ossl_prov_set_macctx(EVP_MAC_CTX *macctx,
 
     *mp = OSSL_PARAM_construct_end();
 
-    return EVP_MAC_CTX_set_params(macctx, mac_params);
+    /*
+     * OSSL_PARAM_merge returns NULL and sets an error if either
+     * list passed to it is NULL, and we aren't guaranteed that the
+     * passed in value of param is not NULL here.
+     * Given that we just want the union of the two lists, even if one
+     * is empty, we have to check for that case, and if param is NULL,
+     * just use the mac_params list.  In turn we only free the merge
+     * result if we actually did the merge
+     */
+    if (param == NULL) {
+        mergep = mac_params;
+    } else {
+        free_merge = 1;
+        mergep = OSSL_PARAM_merge(mac_params, param);
+        if (mergep == NULL)
+            return 0;
+    }
 
+    ret = EVP_MAC_CTX_set_params(macctx, mac_params);
+
+    if (free_merge == 1)
+        OSSL_PARAM_free(mergep);
+    return ret;
 }
 
 int ossl_prov_macctx_load(EVP_MAC_CTX **macctx,
@@ -313,7 +337,7 @@ int ossl_prov_macctx_load(EVP_MAC_CTX **macctx,
     if (pengine != NULL && !OSSL_PARAM_get_utf8_string_ptr(pengine, &engine))
         return 0;
 
-    if (ossl_prov_set_macctx(*macctx, ciphername, mdname, engine, properties))
+    if (ossl_prov_set_macctx(*macctx, ciphername, mdname, engine, properties, NULL))
         return 1;
 
     EVP_MAC_CTX_free(*macctx);

--- a/providers/common/provider_util.c
+++ b/providers/common/provider_util.c
@@ -286,7 +286,7 @@ int ossl_prov_set_macctx(EVP_MAC_CTX *macctx,
             return 0;
     }
 
-    ret = EVP_MAC_CTX_set_params(macctx, mac_params);
+    ret = EVP_MAC_CTX_set_params(macctx, mergep);
 
     if (free_merge == 1)
         OSSL_PARAM_free(mergep);

--- a/providers/implementations/signature/mac_legacy_sig.c
+++ b/providers/implementations/signature/mac_legacy_sig.c
@@ -126,11 +126,11 @@ static int mac_digest_sign_init(void *vpmacctx, const char *mdname, void *vkey,
                               (char *)ciphername,
                               (char *)mdname,
                               (char *)engine,
-                              pmacctx->key->properties))
+                              pmacctx->key->properties, params))
         return 0;
 
     if (!EVP_MAC_init(pmacctx->macctx, pmacctx->key->priv_key,
-                      pmacctx->key->priv_key_len, params))
+                      pmacctx->key->priv_key_len, NULL))
         return 0;
 
     return 1;

--- a/ssl/record/methods/tls1_meth.c
+++ b/ssl/record/methods/tls1_meth.c
@@ -28,7 +28,7 @@ static int tls1_set_crypto_state(OSSL_RECORD_LAYER *rl, int level,
 {
     EVP_CIPHER_CTX *ciph_ctx;
     EVP_PKEY *mac_key;
-    OSSL_PARAM params[3], *p = params;
+    OSSL_PARAM params[2], *p = params;
     int enc = (rl->direction == OSSL_RECORD_DIRECTION_WRITE) ? 1 : 0;
 
     if (level != OSSL_RECORD_PROTECTION_LEVEL_APPLICATION)
@@ -74,9 +74,6 @@ static int tls1_set_crypto_state(OSSL_RECORD_LAYER *rl, int level,
             mac_key = EVP_PKEY_new_mac_key(mactype, NULL, mackey,
                                            (int)mackeylen);
         }
-
-        *p++ = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
-                                                (char *)EVP_MD_get0_name(md), 0);
 
         /*
          * We want the underlying mac to use our passed property query when allocating

--- a/ssl/record/methods/tls1_meth.c
+++ b/ssl/record/methods/tls1_meth.c
@@ -533,8 +533,8 @@ static int tls1_mac(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *rec, unsigned char *md
 
         *p++ = OSSL_PARAM_construct_size_t(OSSL_MAC_PARAM_TLS_DATA_SIZE,
                                            &rec->orig_len);
-
         *p++ = OSSL_PARAM_construct_end();
+
         if (!EVP_PKEY_CTX_set_params(EVP_MD_CTX_get_pkey_ctx(mac_ctx),
                                      tls_hmac_params))
             goto end;

--- a/ssl/record/methods/tls1_meth.c
+++ b/ssl/record/methods/tls1_meth.c
@@ -28,6 +28,7 @@ static int tls1_set_crypto_state(OSSL_RECORD_LAYER *rl, int level,
 {
     EVP_CIPHER_CTX *ciph_ctx;
     EVP_PKEY *mac_key;
+    OSSL_PARAM params[3], *p = params;
     int enc = (rl->direction == OSSL_RECORD_DIRECTION_WRITE) ? 1 : 0;
 
     if (level != OSSL_RECORD_PROTECTION_LEVEL_APPLICATION)
@@ -73,10 +74,24 @@ static int tls1_set_crypto_state(OSSL_RECORD_LAYER *rl, int level,
             mac_key = EVP_PKEY_new_mac_key(mactype, NULL, mackey,
                                            (int)mackeylen);
         }
+
+        *p++ = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
+                                                (char *)EVP_MD_get0_name(md), 0);
+
+        /*
+         * We want the underlying mac to use our passed property query when allocating
+         * its internal digest as well
+         */
+        if (rl->propq != NULL)
+            *p++ = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_PROPERTIES,
+                                                    (char *)rl->propq, 0);
+
+        *p = OSSL_PARAM_construct_end();
+
         if (mac_key == NULL
             || EVP_DigestSignInit_ex(rl->md_ctx, NULL, EVP_MD_get0_name(md),
                                      rl->libctx, rl->propq, mac_key,
-                                     NULL) <= 0) {
+                                     params) <= 0) {
             EVP_PKEY_free(mac_key);
             ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
             return OSSL_RECORD_RETURN_FATAL;
@@ -518,8 +533,8 @@ static int tls1_mac(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *rec, unsigned char *md
 
         *p++ = OSSL_PARAM_construct_size_t(OSSL_MAC_PARAM_TLS_DATA_SIZE,
                                            &rec->orig_len);
-        *p++ = OSSL_PARAM_construct_end();
 
+        *p++ = OSSL_PARAM_construct_end();
         if (!EVP_PKEY_CTX_set_params(EVP_MD_CTX_get_pkey_ctx(mac_ctx),
                                      tls_hmac_params))
             goto end;

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1668,7 +1668,7 @@ int tls_psk_do_binder(SSL_CONNECTION *s, const EVP_MD *md,
     if (!sign)
         binderout = tmpbinder;
 
-    if (sctx->propq) {
+    if (sctx->propq != NULL) {
         params[0] = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
                                                      (char *)EVP_MD_get0_name(md), 0);
         params[1] = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_PROPERTIES,

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1537,7 +1537,7 @@ int tls_psk_do_binder(SSL_CONNECTION *s, const EVP_MD *md,
     int ret = -1;
     int usepskfored = 0;
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
-    OSSL_PARAM params[3] = { OSSL_PARAM_END, OSSL_PARAM_END, OSSL_PARAM_END };
+    OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
 
     /* Ensure cast to size_t is safe */
     if (!ossl_assert(hashsizei > 0)) {
@@ -1668,12 +1668,9 @@ int tls_psk_do_binder(SSL_CONNECTION *s, const EVP_MD *md,
     if (!sign)
         binderout = tmpbinder;
 
-    if (sctx->propq != NULL) {
-        params[0] = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
-                                                     (char *)EVP_MD_get0_name(md), 0);
-        params[1] = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_PROPERTIES,
+    if (sctx->propq != NULL)
+        params[0] = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_PROPERTIES,
                                                      (char *)sctx->propq, 0);
-    }
     bindersize = hashsize;
     if (EVP_DigestSignInit_ex(mctx, NULL, EVP_MD_get0_name(md), sctx->libctx,
                               sctx->propq, mackey, params) <= 0

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -19,6 +19,7 @@
 #include "../ssl_local.h"
 #include "statem_local.h"
 #include <openssl/ocsp.h>
+#include <openssl/core_names.h>
 
 static int final_renegotiate(SSL_CONNECTION *s, unsigned int context, int sent);
 static int init_server_name(SSL_CONNECTION *s, unsigned int context);
@@ -1536,6 +1537,7 @@ int tls_psk_do_binder(SSL_CONNECTION *s, const EVP_MD *md,
     int ret = -1;
     int usepskfored = 0;
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
+    OSSL_PARAM params[3] = { OSSL_PARAM_END, OSSL_PARAM_END, OSSL_PARAM_END };
 
     /* Ensure cast to size_t is safe */
     if (!ossl_assert(hashsizei > 0)) {
@@ -1666,9 +1668,15 @@ int tls_psk_do_binder(SSL_CONNECTION *s, const EVP_MD *md,
     if (!sign)
         binderout = tmpbinder;
 
+    if (sctx->propq) {
+        params[0] = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
+                                                     (char *)EVP_MD_get0_name(md), 0);
+        params[1] = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_PROPERTIES,
+                                                     (char *)sctx->propq, 0);
+    }
     bindersize = hashsize;
     if (EVP_DigestSignInit_ex(mctx, NULL, EVP_MD_get0_name(md), sctx->libctx,
-                              sctx->propq, mackey, NULL) <= 0
+                              sctx->propq, mackey, params) <= 0
             || EVP_DigestSignUpdate(mctx, hash, hashsize) <= 0
             || EVP_DigestSignFinal(mctx, binderout, &bindersize) <= 0
             || bindersize != hashsize) {

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -39,7 +39,7 @@ int tls13_hkdf_expand_ex(OSSL_LIB_CTX *libctx, const char *propq,
 {
     EVP_KDF *kdf = EVP_KDF_fetch(libctx, OSSL_KDF_NAME_TLS1_3_KDF, propq);
     EVP_KDF_CTX *kctx;
-    OSSL_PARAM params[7], *p = params;
+    OSSL_PARAM params[8], *p = params;
     int mode = EVP_PKEY_HKDEF_MODE_EXPAND_ONLY;
     const char *mdname = EVP_MD_get0_name(md);
     int ret;
@@ -84,6 +84,10 @@ int tls13_hkdf_expand_ex(OSSL_LIB_CTX *libctx, const char *propq,
         *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_DATA,
                                                  (unsigned char *)data,
                                                  datalen);
+    if (propq != NULL)
+        *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_PROPERTIES,
+                                                (char *)propq, 0);
+
     *p++ = OSSL_PARAM_construct_end();
 
     ret = EVP_KDF_derive(kctx, out, outlen, params) <= 0;

--- a/test/build.info
+++ b/test/build.info
@@ -1145,11 +1145,15 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[provider_test]=../include ../apps/include ..
   DEPEND[provider_test]=../libcrypto libtestutil.a
   IF[{- !$disabled{module} -}]
-    MODULES{noinst}=p_test
+    MODULES{noinst}=p_test p_ossltest
     SOURCE[p_test]=p_test.c
+    SOURCE[p_ossltest]=p_ossltest.c ../providers/prov_running.c
     INCLUDE[p_test]=../include ..
+    INCLUDE[p_ossltest]=../include .. ../providers/common/include ../providers/implementations/include ../providers/implementations
+    DEPEND[p_ossltest]=../providers/libcommon.a ../libcrypto
     IF[{- defined $target{shared_defflag} -}]
       SOURCE[p_test]=p_test.ld
+      SOURCE[p_ossltest]=p_test.ld
       GENERATE[p_test.ld]=../util/providers.num
     ENDIF
     MODULES{noinst}=p_minimal

--- a/test/p_ossltest.c
+++ b/test/p_ossltest.c
@@ -23,8 +23,8 @@
  * The SHA1, SHA256, SHA384 and SHA512 digests
  * The CTR-DRBG random number generator
  *
- * Note that, like the old engine, the implementations of the above algoritms
- * are designed not to actually follow the prescribed algoritms themselves, but rather
+ * Note that, like the old engine, the implementations of the above algorithms
+ * are designed not to actually follow the prescribed algorithms themselves, but rather
  * just to returns known/predictable data values for the purposes of testing.  As such
  * DO NOT USE THIS PROVIDER FOR ANY PRODUCTION PURPOSE.  TESTING ONLY!!!!
  *
@@ -173,7 +173,7 @@ static int ossltest_dgst_update(void *ctx, const void *data,
 }
 
 /**
- * @brief Finalize the disget output.
+ * @brief Finalize the digest output.
  *
  * provide pre-set data (increasing count) for the MD5 DIGEST
  *
@@ -464,6 +464,9 @@ static int ossl_test_aes128cbc_update(void *vprovctx, char *out, size_t *outl,
      * record our input buffer
      */
     ctx->inbuf = OPENSSL_zalloc(inl);
+    if (ctx->inbuf == NULL)
+        return 0;
+
     memcpy(ctx->inbuf, in, inl);
 
     soutl = EVP_Cipher(ctx->sub_ctx, (unsigned char *)out, in, (unsigned int)inl);
@@ -935,7 +938,7 @@ static int ossl_test_aes128gcm_set_ctx_params(void *vprovctx, const OSSL_PARAM p
 }
 
 /**
- * @brief Describe parameters that can be queriedn aes-128-gcm.
+ * @brief Describe parameters that can be queried aes-128-gcm.
  *
  * @param vprovctx void *vprovctx.
  * @return const OSSL_PARAM *.
@@ -1027,6 +1030,9 @@ static void *ossl_testaes128cbchmacsha1_newctx(void *provctx)
         return NULL;
 
     new = OPENSSL_zalloc(sizeof(PROV_EVP_AES128_CBC_HMAC_SHA1_CTX));
+    if (new == NULL)
+        return NULL;
+
     new->libctx = PROV_LIBCTX_OF(provctx);
     new->payload_length = NO_PAYLOAD_LENGTH;
 
@@ -1183,7 +1189,7 @@ static int ossl_test_aes128cbchmacsha1_update(void *vprovctx, unsigned char *out
                     return 0;
             /*
              * We need to return the actual dummied up payload of this
-             * operatiion, so reduce the length of the output by the padding
+             * operation, so reduce the length of the output by the padding
              * size that we just stripped as well as the leading IV, which
              * is the first AES_BLOCK_SIZE bytes
              */
@@ -1504,7 +1510,7 @@ static int drbg_ctr_uninstantiate_wrapper(void *vdrbg)
 }
 
 /**
- * @brief Generate pseudorandom bytes from the CTR DRBG.
+ * @brief Generate pseudo-random bytes from the CTR DRBG.
  *
  * @param vdrbg void *vdrbg.
  * @param out unsigned char *out.

--- a/test/p_ossltest.c
+++ b/test/p_ossltest.c
@@ -471,7 +471,7 @@ static int ossl_test_aes128cbc_update(void *vprovctx, char *out, size_t *outl,
 
     if (soutl <= 0)
         goto err;
-    
+
     /*
      * replace the ciphertext with our plain text
      */

--- a/test/p_ossltest.c
+++ b/test/p_ossltest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -460,17 +460,18 @@ static int ossl_test_aes128cbc_update(void *vprovctx, char *out, size_t *outl,
 
     if (EVP_CIPHER_CTX_is_encrypting(ctx->sub_ctx)) {
         /*
-         * On encrypt, Make sure output buffer is large enough to hold the crypto
-         * result plus any needed padding, keeping in mind that for inputs
-         * less than the block size (16), we pad the remainder of this block
-         * plus a full extra block.
+         * On encrypt, Make sure output buffer is large enough to hold the
+         * crypto result plus any needed padding, keeping in mind that for
+         * inputs less than the block size (16), we pad to the remainder of this
+         * block (i.e. up to 15 bytes). For inputs equal to the block size, we
+         * add an additional block of padding (16 bytes).
          */
         if (outsize < inl + (16 - (inl % 16)))
             goto err;
     } else {
         /*
          * On decrypt we just need to make sure the output buffer is at least
-         * least as large as the input buffer, to store the result
+         * as large as the input buffer, to store the result.
          */
         if (outsize < inl)
             goto err;

--- a/test/p_ossltest.c
+++ b/test/p_ossltest.c
@@ -736,6 +736,7 @@ static void ossl_test_aes128gcm_freectx(void *vprovctx)
     PROV_EVP_AES128_GCM_CTX *ctx = (PROV_EVP_AES128_GCM_CTX *)vprovctx;
 
     EVP_CIPHER_CTX_free(ctx->sub_ctx);
+    OPENSSL_free(ctx);
 }
 
 /**

--- a/test/p_ossltest.c
+++ b/test/p_ossltest.c
@@ -494,6 +494,13 @@ static int ossl_test_aes128cbc_update(void *vprovctx, char *out, size_t *outl,
          * padval, which is the number of padding bytes - 1;
          */
         padnum = out[inl - 1];
+
+        /*
+         * Make sure the soutl doesn't go negative
+         */
+        if (soutl <= padnum + 16)
+            goto err;
+
         soutl -= padnum + 1;
         /*
          * shorten by explicit iv length

--- a/test/p_ossltest.c
+++ b/test/p_ossltest.c
@@ -1,0 +1,1790 @@
+/*
+ * Copyright 2019-2025 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/**
+ * @file p_ossltest.c
+ * @brief a test provider for use in several of our unit tests
+ *
+ * This file implements a provider that reproduces the functionality
+ * of our old ossltest engine.
+ *
+ * It implements the following algorithms
+ *
+ * The AES-128-CBC cipher
+ * The AES-128-GCM cipher
+ * The AES-128-CBC-HMAC-SHA1 cipher
+ * The MD5 digest
+ * The SHA1, SHA256, SHA384 and SHA512 digests
+ * The CTR-DRBG random number generator
+ *
+ * Note that, like the old engine, the implementations of the above algoritms
+ * are designed not to actually follow the prescribed algoritms themselves, but rather
+ * just to returns known/predictable data values for the purposes of testing.  As such
+ * DO NOT USE THIS PROVIDER FOR ANY PRODUCTION PURPOSE.  TESTING ONLY!!!!
+ *
+ * The digests all return incremental data in accordance with the size of their message
+ * digest
+ *
+ * The ciphers all return data that is a copy of their input plaintext, padded and augmented
+ * according to the specific ciphers needs
+ *
+ * The random number generator just returns incremental data of the requested size
+ */
+#include "internal/deprecated.h"
+
+#include <openssl/core_dispatch.h>
+#include <openssl/core_names.h>
+#include <openssl/params.h>
+#include <openssl/rand.h> /* RAND_get0_public() */
+#include <openssl/proverr.h>
+#include <openssl/md5.h>
+#include <openssl/sha.h>
+#include <openssl/prov_ssl.h>
+#include "prov/provider_ctx.h"
+#include "prov/digestcommon.h"
+#include "prov/ciphercommon.h"
+#include "prov/names.h"
+#include "prov/implementations.h"
+#include "ciphers/cipher_aes.h"
+#include "internal/cryptlib.h"
+#include "internal/provider.h"
+#include "crypto/context.h"
+#include "internal/core.h"
+
+/**
+ * @brief Release resources and clean up the context.
+ *
+ * @param provctx void *provctx.
+ * @return void.
+ */
+
+static void ossltest_teardown(void *provctx)
+{
+    OSSL_LIB_CTX_free(PROV_LIBCTX_OF(provctx));
+    ossl_prov_ctx_free(provctx);
+}
+
+static const OSSL_PARAM ossltest_param_types[] = {
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_NAME, OSSL_PARAM_UTF8_PTR, NULL, 0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_VERSION, OSSL_PARAM_UTF8_PTR, NULL, 0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_BUILDINFO, OSSL_PARAM_UTF8_PTR, NULL, 0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_STATUS, OSSL_PARAM_INTEGER, NULL, 0),
+    OSSL_PARAM_END
+};
+
+/**
+ * @brief Describe parameters that can be queried.
+ *
+ * Just returns the standard provider query-able parameters
+ * OSSL_PROV_PARAM_NAME - The name of our provider
+ * OSSL_PROV_PARAM_VERSION - The version of this provider build
+ * OSSL_PROV_PARAM_BUILDINFO - The configuartion it was built with
+ * OSSL_PROV_PARAM_STATUS - Weather or not its currently activated
+ *
+ * @param provctx void *provctx.
+ * @return const OSSL_PARAM *.
+ */
+
+static const OSSL_PARAM *ossltest_gettable_params(void *provctx)
+{
+    return ossltest_param_types;
+}
+
+/**
+ * @brief Return provider parameters.
+ *
+ * @param provctx void *provctx.
+ * @param params OSSL_PARAM params[].
+ * @return int.
+ */
+
+static int ossltest_get_params(void *provctx, OSSL_PARAM params[])
+{
+    OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_NAME);
+    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "OpenSSL ossltest Provider"))
+        return 0;
+    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_VERSION);
+    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, OPENSSL_VERSION_STR))
+        return 0;
+    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_BUILDINFO);
+    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, OPENSSL_FULL_VERSION_STR))
+        return 0;
+    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_STATUS);
+    if (p != NULL && !OSSL_PARAM_set_int(p, ossl_prov_is_running()))
+        return 0;
+    return 1;
+}
+
+/**
+ * @brief Fill a buffer with deterministic test bytes.
+ *
+ * @param md unsigned char *md.
+ * @param len unsigned int len.
+ * @return void.
+ */
+
+static void fill_known_data(unsigned char *md, unsigned int len)
+{
+    unsigned int i;
+
+    for (i = 0; i < len; i++)
+        md[i] = (unsigned char)(i & 0xff);
+}
+
+/**
+ * @brief Initialize the context state for our digests.
+ *
+ * Because all our digests return known data in this provider
+ * this can just be a no-op function.  Its used for each digest we support
+ *
+ * @param ctx void *ctx.
+ * @return int.
+ */
+
+static int ossltest_dgst_init(void *ctx)
+{
+    return 1;
+}
+
+/**
+ * @brief Process input data to update the digest state.
+ * Since This provider returns fixed data for each digest
+ * we don't actually have to do any work here, just return 1.
+ * This is used for all our provided digests
+ *
+ * @param ctx void *ctx.
+ * @param data const void *data.
+ * @param count size_t count.
+ * @return int.
+ */
+
+static int ossltest_dgst_update(void *ctx, const void *data,
+                                size_t count)
+{
+    return 1;
+}
+
+/**
+ * @brief Finalize the disget output.
+ *
+ * provide pre-set data (increasing count) for the MD5 DIGEST
+ *
+ * @param md unsigned char *md.
+ * @param ctx void *ctx.
+ * @return int.
+ */
+
+static int ossltest_MD5_final(unsigned char *md, void *ctx)
+{
+    fill_known_data(md, MD5_DIGEST_LENGTH);
+    return 1;
+}
+
+/**
+ * @brief Finalize the digest output.
+ *
+ * provide pre-set data (increasing count) for the SHA1 DIGEST
+ *
+ * @param md unsigned char *md.
+ * @param ctx void *ctx.
+ * @return int.
+ */
+
+static int ossltest_SHA1_final(unsigned char *md, void *ctx)
+{
+    fill_known_data(md, SHA_DIGEST_LENGTH);
+    return 1;
+}
+
+/**
+ * @brief Finalize the digest output.
+ *
+ * provide pre-set data (increasing count) for the SHA256 DIGEST
+ *
+ * @param md unsigned char *md.
+ * @param ctx void *ctx.
+ * @return int.
+ */
+
+static int ossltest_SHA256_final(unsigned char *md, void *ctx)
+{
+    fill_known_data(md, SHA256_DIGEST_LENGTH);
+    return 1;
+}
+
+/**
+ * @brief Finalize the digest output.
+ *
+ * provide pre-set data (increasing count) for the SHA384 DIGEST
+ *
+ * @param md unsigned char *md.
+ * @param ctx void *ctx.
+ * @return int.
+ */
+
+static int ossltest_SHA384_final(unsigned char *md, void *ctx)
+{
+    fill_known_data(md, SHA384_DIGEST_LENGTH);
+    return 1;
+}
+
+/**
+ * @brief Finalize the digest output.
+ *
+ * provide pre-set data (increasing count) for the SHA512 DIGEST
+ *
+ * @param md unsigned char *md.
+ * @param ctx void *ctx.
+ * @return int.
+ */
+
+static int ossltest_SHA512_final(unsigned char *md, void *ctx)
+{
+    fill_known_data(md, SHA512_DIGEST_LENGTH);
+    return 1;
+}
+
+/*
+ * NOTE: These externs are just here to make the compiler happy
+ * The IMPLEMENT_digest_functions macros below define these arrays
+ * as non-static so that real providers can pick them up in other C files
+ * And they get externed in other header files.  But we only use them internally
+ * to this provider here.  To avoid having to re-implement and co-ordinate the below
+ * macros in what is already a large C file, just define them as extern to prevent some
+ * compilers from complaining about a non-static definition with no prior extern declaration
+ * mark them as such here.  They won't get exported anyway as p_ossltest only gets built as
+ * a DSO, and the linker map we use doesn't list them as exported
+ */
+extern const OSSL_DISPATCH ossl_testmd5_functions[];
+extern const OSSL_DISPATCH ossl_testsha1_functions[];
+extern const OSSL_DISPATCH ossl_testsha256_functions[];
+extern const OSSL_DISPATCH ossl_testsha384_functions[];
+extern const OSSL_DISPATCH ossl_testsha512_functions[];
+
+IMPLEMENT_digest_functions(testmd5, MD5_CTX, MD5_CBLOCK, MD5_DIGEST_LENGTH, 0,
+                           ossltest_dgst_init, ossltest_dgst_update, ossltest_MD5_final)
+
+#define SHA2_FLAGS PROV_DIGEST_FLAG_ALGID_ABSENT
+IMPLEMENT_digest_functions(testsha1, SHA_CTX, SHA_CBLOCK, SHA_DIGEST_LENGTH, SHA2_FLAGS,
+                           ossltest_dgst_init, ossltest_dgst_update, ossltest_SHA1_final)
+
+IMPLEMENT_digest_functions(testsha256, SHA256_CTX,
+                           SHA256_CBLOCK, SHA256_DIGEST_LENGTH, SHA2_FLAGS,
+                           ossltest_dgst_init, ossltest_dgst_update, ossltest_SHA256_final)
+
+IMPLEMENT_digest_functions(testsha384, SHA512_CTX,
+                           SHA512_CBLOCK, SHA512_DIGEST_LENGTH, SHA2_FLAGS,
+                           ossltest_dgst_init, ossltest_dgst_update, ossltest_SHA384_final)
+
+IMPLEMENT_digest_functions(testsha512, SHA512_CTX,
+                           SHA512_CBLOCK, SHA512_DIGEST_LENGTH, SHA2_FLAGS,
+                           ossltest_dgst_init, ossltest_dgst_update, ossltest_SHA512_final)
+
+#define ALG(NAMES, FUNC) \
+    { NAMES, "provider=p_ossltest", FUNC }
+
+static const OSSL_ALGORITHM ossltest_digests[] = {
+    ALG(PROV_NAMES_MD5, ossl_testmd5_functions),
+    ALG(PROV_NAMES_SHA1, ossl_testsha1_functions),
+    ALG(PROV_NAMES_SHA2_256, ossl_testsha256_functions),
+    ALG(PROV_NAMES_SHA2_384, ossl_testsha384_functions),
+    ALG(PROV_NAMES_SHA2_512, ossl_testsha512_functions),
+    {NULL, NULL, NULL}
+};
+
+typedef struct {
+    OSSL_LIB_CTX *libctx;
+    EVP_CIPHER_CTX *sub_ctx;
+    unsigned char *inbuf;
+} PROV_EVP_AES128_CBC_CTX;
+
+/**
+ * @brief Allocate and initialize a new aes-128-cbc context.
+ *
+ * @param provctx void *provctx.
+ * @return void *.
+ */
+
+static void *ossl_testaes128_cbc_newctx(void *provctx)
+{
+    PROV_EVP_AES128_CBC_CTX *new;
+    EVP_CIPHER *cph = NULL;
+    int ret;
+
+    if (!ossl_prov_is_running())
+        return NULL;
+
+    new = OPENSSL_zalloc(sizeof(PROV_EVP_AES128_CBC_CTX));
+    if (new == NULL)
+        return NULL;
+    new->sub_ctx = EVP_CIPHER_CTX_new();
+    if (new->sub_ctx == NULL)
+        goto err;
+
+    new->libctx = PROV_LIBCTX_OF(provctx);
+
+    cph = EVP_CIPHER_fetch(new->libctx, "AES-128-CBC", "provider=default");
+    if (cph == NULL)
+        goto err;
+
+    ret = EVP_CipherInit_ex2(new->sub_ctx, cph, NULL, NULL, 1, NULL);
+
+    EVP_CIPHER_free(cph);
+
+    if (ret <= 0)
+        goto err;
+
+    return new;
+err:
+    EVP_CIPHER_CTX_free(new->sub_ctx);
+    OPENSSL_free(new);
+    return NULL;
+}
+
+/**
+ * @brief Release resources and clean up an aes-128-cbc context.
+ *
+ * @param vprovctx void *vprovctx.
+ * @return void.
+ */
+
+static void ossl_test_aes128cbc_freectx(void *vprovctx)
+{
+    PROV_EVP_AES128_CBC_CTX *ctx = (PROV_EVP_AES128_CBC_CTX *)vprovctx;
+
+    EVP_CIPHER_CTX_free(ctx->sub_ctx);
+    OPENSSL_free(ctx->inbuf);
+    OPENSSL_free(ctx);
+}
+
+/**
+ * @brief Duplicate an aes-128-cbc context.
+ *
+ * @param vprovctx void *vprovctx.
+ * @return void *.
+ */
+
+static void *ossl_test_aes128cbc_dupctx(void *vprovctx)
+{
+    PROV_EVP_AES128_CBC_CTX *ctx = (PROV_EVP_AES128_CBC_CTX *)vprovctx;
+    PROV_EVP_AES128_CBC_CTX *dup;
+
+    dup = OPENSSL_memdup(ctx, sizeof(PROV_EVP_AES128_CBC_CTX));
+
+    dup->sub_ctx = EVP_CIPHER_CTX_dup(ctx->sub_ctx);
+
+    return dup;
+}
+
+/**
+ * @brief Initialize an aes-129-cbc context for encryption.
+ *
+ * @param vprovctx void *vprovctx.
+ * @param key const unsigned char *key.
+ * @param keylen size_t keylen.
+ * @param iv const unsigned char *iv.
+ * @param ivlen size_t ivlen.
+ * @param params const OSSL_PARAM params[].
+ * @return int.
+ */
+
+static int ossl_test_aes128cbc_einit(void *vprovctx, const unsigned char *key,
+                                     size_t keylen, const unsigned char *iv,
+                                     size_t ivlen, const OSSL_PARAM params[])
+{
+    PROV_EVP_AES128_CBC_CTX *ctx = (PROV_EVP_AES128_CBC_CTX *)vprovctx;
+
+    OPENSSL_free(ctx->inbuf);
+    ctx->inbuf = NULL;
+
+    return EVP_CipherInit_ex2(ctx->sub_ctx, NULL, key, iv, 1, params);
+}
+
+/**
+ * @brief Initialize an aes-128-cbc context for decryption
+ *
+ * @param vprovctx void *vprovctx.
+ * @param key const unsigned char *key.
+ * @param keylen size_t keylen.
+ * @param iv const unsigned char *iv.
+ * @param ivlen size_t ivlen.
+ * @param params const OSSL_PARAM params[].
+ * @return int.
+ */
+
+static int ossl_test_aes128cbc_dinit(void *vprovctx, const unsigned char *key,
+                                     size_t keylen, const unsigned char *iv,
+                                     size_t ivlen, const OSSL_PARAM params[])
+{
+    PROV_EVP_AES128_CBC_CTX *ctx = (PROV_EVP_AES128_CBC_CTX *)vprovctx;
+
+    OPENSSL_free(ctx->inbuf);
+    ctx->inbuf = NULL;
+
+    return EVP_CipherInit_ex2(ctx->sub_ctx, NULL, key, iv, 0, params);
+}
+
+/**
+ * @brief en/decrypt data for aes-128-cbc.
+ *
+ *
+ * @param vprovctx void *vprovctx.
+ * @param out char *out.
+ * @param outl size_t *outl.
+ * @param outsize size_t outsize.
+ * @param in const unsigned char *in.
+ * @param inl size_t inl.
+ * @return int.
+ */
+
+static int ossl_test_aes128cbc_update(void *vprovctx, char *out, size_t *outl,
+                                      size_t outsize, const unsigned char *in,
+                                      size_t inl)
+{
+    PROV_EVP_AES128_CBC_CTX *ctx = (PROV_EVP_AES128_CBC_CTX *)vprovctx;
+    int soutl;
+    int padnum;
+    unsigned char padval;
+    size_t loop;
+
+    /*
+     * record our input buffer
+     */
+    ctx->inbuf = OPENSSL_zalloc(inl);
+    memcpy(ctx->inbuf, in, inl);
+
+    soutl = EVP_Cipher(ctx->sub_ctx, (unsigned char *)out, in, (unsigned int)inl);
+    /*
+     * replace the ciphertext with our plain text
+     */
+    memcpy(out, ctx->inbuf, inl);
+
+    if (EVP_CIPHER_CTX_is_encrypting(ctx->sub_ctx)) {
+        padnum = (int)(16 - (inl % 16));
+        padval = (unsigned char)(padnum - 1);
+        for (loop = inl; loop < inl + padnum; loop++)
+            out[loop] = padval;
+        soutl += padnum;
+    } else {
+        /*
+         * on decrypt the last byte in the buffer should be
+         * padval, which is the number of padding bytes - 1;
+         */
+        padnum = out[inl - 1];
+        soutl -= padnum + 1;
+        /*
+         * shorten by explicit iv length
+         */
+        soutl -= 16;
+    }
+
+    *outl = soutl;
+    OPENSSL_free(ctx->inbuf);
+    ctx->inbuf = NULL;
+    return 1;
+}
+
+/**
+ * @brief Finalize the operation and produce any remaining output for aes-cbc-128
+ *
+ * @param vprovctx void *vprovctx.
+ * @param out unsigned char *out.
+ * @param outl size_t *outl.
+ * @param outsize size_t outsize.
+ * @return int.
+ */
+
+static int ossl_test_aes128cbc_final(void *vprovctx, unsigned char *out, size_t *outl,
+                                     size_t outsize)
+{
+    PROV_EVP_AES128_CBC_CTX *ctx = (PROV_EVP_AES128_CBC_CTX *)vprovctx;
+    int soutl;
+    int ret;
+
+    ret = EVP_CipherFinal_ex(ctx->sub_ctx, out, &soutl);
+
+    return ret;
+}
+
+/**
+ * @brief Implement ossl test aes128cbc cipher.
+ *
+ * Note, nothing in TLS should be using this function, as we are a provider
+ * we just need it for completeness.
+ *
+ * @param vprovctx void *vprovctx.
+ * @param out unsigned char *out.
+ * @param outl size_t *outl.
+ * @param outsize size_t outsize.
+ * @param in const unsigned char *in.
+ * @param inl size_t inl.
+ * @return int.
+ */
+
+static int ossl_test_aes128cbc_cipher(void *vprovctx, unsigned char *out, size_t *outl,
+                                      size_t outsize, const unsigned char *in, size_t inl)
+{
+    PROV_EVP_AES128_CBC_CTX *ctx = (PROV_EVP_AES128_CBC_CTX *)vprovctx;
+
+    return EVP_Cipher(ctx->sub_ctx, out, in, (int) inl);
+}
+
+/**
+ * @brief Return provider or algorithm parameters.
+ *
+ * @param params OSSL_PARAM params[].
+ * @return int.
+ */
+
+static int ossl_test_aes128cbc_get_params(OSSL_PARAM params[])
+{
+    return ossl_cipher_generic_get_params(params, EVP_CIPH_CBC_MODE, 0, 128, 128, 128);
+}
+
+/**
+ * @brief Query parameters from the aes-128-cbc context.
+ *
+ * @param vprovctx void *vprovctx.
+ * @param params OSSL_PARAM params[].
+ * @return int.
+ */
+
+static int ossl_test_aes128cbc_get_ctx_params(void *vprovctx, OSSL_PARAM params[])
+{
+    PROV_EVP_AES128_CBC_CTX *ctx = (PROV_EVP_AES128_CBC_CTX *)vprovctx;
+
+    return EVP_CIPHER_CTX_get_params(ctx->sub_ctx, params);
+}
+
+/**
+ * @brief Set parameters on the aes-128-cbc context.
+ *
+ * @param vprovctx void *vprovctx.
+ * @param params const OSSL_PARAM params[].
+ * @return int.
+ */
+
+static int ossl_test_aes128cbc_set_ctx_params(void *vprovctx, const OSSL_PARAM params[])
+{
+    /*
+     * Normally this gets called to set
+     * OSSL_CIPHER_PARAM_TLS_VERSION
+     * OSSL_CIPHER_PARAM_TLS_MAC_SIZE
+     * but we don't want the underlying cipher to do that, we will
+     * handle that padding in cbc_update on our own, so intercept and
+     * squash that here
+     */
+    return 1;
+}
+
+/**
+ * @brief Describe parameters that can be queried for aes-128-cbc
+ *
+ * @param vprovctx void *vprovctx.
+ * @return const OSSL_PARAM *.
+ */
+
+static const OSSL_PARAM *ossl_test_aes128cbc_gettable_params(void *vprovctx)
+{
+    PROV_EVP_AES128_CBC_CTX *ctx = (PROV_EVP_AES128_CBC_CTX *)vprovctx;
+
+    return EVP_CIPHER_gettable_params(EVP_CIPHER_CTX_get0_cipher(ctx->sub_ctx));
+}
+
+/**
+ * @brief Describe context parameters that can be queried for aes-128-cbc.
+ *
+ * @param cctx void *cctx.
+ * @param vprovctx void *vprovctx.
+ * @return const OSSL_PARAM *.
+ */
+
+static const OSSL_PARAM *ossl_test_aes128cbc_gettable_ctx_params(void *cctx, void *vprovctx)
+{
+    return ossl_cipher_generic_gettable_ctx_params(cctx, vprovctx);
+}
+
+/**
+ * @brief Describe context parameters that can be set for aes-128-cbc.
+ *
+ * @param cctx void *cctx.
+ * @param vprovctx void *vprovctx.
+ * @return const OSSL_PARAM *.
+ */
+
+static const OSSL_PARAM *ossl_test_aes128cbc_settable_ctx_params(void *cctx, void *vprovctx)
+{
+    PROV_EVP_AES128_CBC_CTX *ctx = (PROV_EVP_AES128_CBC_CTX *)vprovctx;
+
+    return EVP_CIPHER_CTX_settable_params(ctx->sub_ctx);
+}
+
+static const OSSL_DISPATCH ossl_testaes128_cbc_functions[] = {
+    { OSSL_FUNC_CIPHER_NEWCTX,
+      (void (*)(void)) ossl_testaes128_cbc_newctx },
+    { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void)) ossl_test_aes128cbc_freectx },
+    { OSSL_FUNC_CIPHER_DUPCTX, (void (*)(void)) ossl_test_aes128cbc_dupctx },
+    { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))ossl_test_aes128cbc_einit },
+    { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))ossl_test_aes128cbc_dinit },
+    { OSSL_FUNC_CIPHER_UPDATE, (void (*)(void))ossl_test_aes128cbc_update },
+    { OSSL_FUNC_CIPHER_FINAL, (void (*)(void))ossl_test_aes128cbc_final },
+    { OSSL_FUNC_CIPHER_CIPHER, (void (*)(void))ossl_test_aes128cbc_cipher },
+    { OSSL_FUNC_CIPHER_GET_PARAMS,
+      (void (*)(void)) ossl_test_aes128cbc_get_params },
+    { OSSL_FUNC_CIPHER_GET_CTX_PARAMS,
+      (void (*)(void))ossl_test_aes128cbc_get_ctx_params },
+    { OSSL_FUNC_CIPHER_SET_CTX_PARAMS,
+      (void (*)(void))ossl_test_aes128cbc_set_ctx_params },
+    { OSSL_FUNC_CIPHER_GETTABLE_PARAMS,
+      (void (*)(void))ossl_test_aes128cbc_gettable_params },
+    { OSSL_FUNC_CIPHER_GETTABLE_CTX_PARAMS,
+      (void (*)(void))ossl_test_aes128cbc_gettable_ctx_params },
+    { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,
+      (void (*)(void))ossl_test_aes128cbc_settable_ctx_params },
+    OSSL_DISPATCH_END
+};
+
+typedef struct {
+    OSSL_LIB_CTX *libctx;
+    EVP_CIPHER_CTX *sub_ctx;
+    unsigned char *inbuf;
+} PROV_EVP_AES128_GCM_CTX;
+
+/**
+ * @brief Allocate and initialize a new algorithm context for aes-128-gcm.
+ *
+ * @param provctx void *provctx.
+ * @return void *.
+ */
+
+static void *ossl_testaes128_gcm_newctx(void *provctx)
+{
+    PROV_EVP_AES128_GCM_CTX *new;
+    EVP_CIPHER *cph = NULL;
+    int ret;
+
+    if (!ossl_prov_is_running())
+        return NULL;
+
+    new = OPENSSL_zalloc(sizeof(PROV_EVP_AES128_GCM_CTX));
+    if (new == NULL)
+        return NULL;
+
+    new->sub_ctx = EVP_CIPHER_CTX_new();
+    if (new->sub_ctx == NULL)
+        goto err;
+
+    new->libctx = PROV_LIBCTX_OF(provctx);
+
+    cph = EVP_CIPHER_fetch(new->libctx, "aes-128-gcm", "provider=default");
+    if (cph == NULL)
+        goto err;
+
+    ret = EVP_EncryptInit_ex2(new->sub_ctx, cph, NULL, NULL, NULL);
+    EVP_CIPHER_free(cph);
+
+    if (ret <= 0)
+        goto err;
+
+    return new;
+err:
+    EVP_CIPHER_CTX_free(new->sub_ctx);
+    OPENSSL_free(new);
+    return NULL;
+
+}
+
+/**
+ * @brief Release resources and clean up the context for aes-128-gcm.
+ *
+ * @param vprovctx void *vprovctx.
+ * @return void.
+ */
+
+static void ossl_test_aes128gcm_freectx(void *vprovctx)
+{
+    PROV_EVP_AES128_GCM_CTX *ctx = (PROV_EVP_AES128_GCM_CTX *)vprovctx;
+
+    EVP_CIPHER_CTX_free(ctx->sub_ctx);
+    OPENSSL_free(ctx->inbuf);
+    OPENSSL_free(ctx);
+}
+
+/**
+ * @brief Duplicate an aes-128-gcm context.
+ *
+ * @param vprovctx void *vprovctx.
+ * @return void *.
+ */
+
+static void *ossl_test_aes128gcm_dupctx(void *vprovctx)
+{
+    PROV_EVP_AES128_GCM_CTX *ctx = (PROV_EVP_AES128_GCM_CTX *)vprovctx;
+    PROV_EVP_AES128_GCM_CTX *dup;
+
+    dup = OPENSSL_memdup(ctx, sizeof(PROV_EVP_AES128_GCM_CTX));
+
+    dup->sub_ctx = EVP_CIPHER_CTX_dup(ctx->sub_ctx);
+
+    return dup;
+}
+
+/**
+ * @brief Initialize the aes-128-gcm encryption operation context.
+ *
+ * @param vprovctx void *vprovctx.
+ * @param key const unsigned char *key.
+ * @param keylen size_t keylen.
+ * @param iv const unsigned char *iv.
+ * @param ivlen size_t ivlen.
+ * @param params const OSSL_PARAM params[].
+ * @return int.
+ */
+
+static int ossl_test_aes128gcm_einit(void *vprovctx, const unsigned char *key,
+                                     size_t keylen, const unsigned char *iv,
+                                     size_t ivlen, const OSSL_PARAM params[])
+{
+    PROV_EVP_AES128_GCM_CTX *ctx = (PROV_EVP_AES128_GCM_CTX *)vprovctx;
+
+    OPENSSL_free(ctx->inbuf);
+    ctx->inbuf = NULL;
+
+    return EVP_EncryptInit_ex2(ctx->sub_ctx, NULL, key, iv, params);
+}
+
+/**
+ * @brief Initialize the aes-128-gcm decryption operation context.
+ *
+ * @param vprovctx void *vprovctx.
+ * @param key const unsigned char *key.
+ * @param keylen size_t keylen.
+ * @param iv const unsigned char *iv.
+ * @param ivlen size_t ivlen.
+ * @param params const OSSL_PARAM params[].
+ * @return int.
+ */
+
+static int ossl_test_aes128gcm_dinit(void *vprovctx, const unsigned char *key,
+                                     size_t keylen, const unsigned char *iv,
+                                     size_t ivlen, const OSSL_PARAM params[])
+{
+    PROV_EVP_AES128_GCM_CTX *ctx = (PROV_EVP_AES128_GCM_CTX *)vprovctx;
+
+    OPENSSL_free(ctx->inbuf);
+    ctx->inbuf = NULL;
+
+    return EVP_DecryptInit_ex2(ctx->sub_ctx, NULL, key, iv, params);
+}
+
+/**
+ * @brief en/decrypt aes-128-gcm data.
+ *
+ * @param vprovctx void *vprovctx.
+ * @param out char *out.
+ * @param outl size_t *outl.
+ * @param outsize size_t outsize.
+ * @param in const unsigned char *in.
+ * @param inl size_t inl.
+ * @return int.
+ */
+
+static int ossl_test_aes128gcm_update(void *vprovctx, char *out, size_t *outl,
+                                      size_t outsize, const unsigned char *in,
+                                      size_t inl)
+{
+    PROV_EVP_AES128_GCM_CTX *ctx = (PROV_EVP_AES128_GCM_CTX *)vprovctx;
+    int ret, soutl;
+
+    ctx->inbuf = OPENSSL_memdup(in, inl);
+
+    if (EVP_CIPHER_CTX_is_encrypting(ctx->sub_ctx))
+        ret = EVP_EncryptUpdate(ctx->sub_ctx, (unsigned char *)out,
+                                &soutl, in, (int)inl);
+    else
+        ret = EVP_DecryptUpdate(ctx->sub_ctx, (unsigned char *)out,
+                                &soutl, in, (int)inl);
+    *outl = soutl;
+
+    /*
+     * Once the cipher is complete, throw it away and use the
+     * plaintext as our output
+     */
+    if (ctx->inbuf != NULL && out != NULL)
+        memcpy(out, ctx->inbuf, inl);
+    OPENSSL_free(ctx->inbuf);
+    ctx->inbuf = NULL;
+
+    return ret;
+}
+
+/**
+ * @brief Finalize the aes-128-gcm en/decryption and produce any remaining output.
+ *
+ * @param vprovctx void *vprovctx.
+ * @param out unsigned char *out.
+ * @param outl size_t *outl.
+ * @param outsize size_t outsize.
+ * @return int.
+ */
+
+static int ossl_test_aes128gcm_final(void *vprovctx, unsigned char *out, size_t *outl,
+                                     size_t outsize)
+{
+    int ret;
+
+    *outl = 0;
+    ret = 1;
+    return ret;
+}
+
+/**
+ * @brief Implement ossl test aes128gcm cipher.
+ *
+ * @param vprovctx void *vprovctx.
+ * @param out unsigned char *out.
+ * @param outl size_t *outl.
+ * @param outsize size_t outsize.
+ * @param in const unsigned char *in.
+ * @param inl size_t inl.
+ * @return int.
+ */
+
+static int ossl_test_aes128gcm_cipher(void *vprovctx, unsigned char *out, size_t *outl,
+                                      size_t outsize, const unsigned char *in, size_t inl)
+{
+    PROV_EVP_AES128_GCM_CTX *ctx = (PROV_EVP_AES128_GCM_CTX *)vprovctx;
+
+    return EVP_Cipher(ctx->sub_ctx, out, in, (int) inl);
+}
+
+#define AEAD_FLAGS (PROV_CIPHER_FLAG_AEAD | PROV_CIPHER_FLAG_CUSTOM_IV)
+
+/**
+ * @brief Return aes-128-gcm parameters.
+ *
+ * @param params OSSL_PARAM params[].
+ * @return int.
+ */
+
+static int ossl_test_aes128gcm_get_params(OSSL_PARAM params[])
+{
+    return ossl_cipher_generic_get_params(params, EVP_CIPH_GCM_MODE, AEAD_FLAGS, 128, 8, 96);
+}
+
+/**
+ * @brief Query parameters from the aes-128-gcm context.
+ *
+ * @param vprovctx void *vprovctx.
+ * @param params OSSL_PARAM params[].
+ * @return int.
+ */
+
+static int ossl_test_aes128gcm_get_ctx_params(void *vprovctx, OSSL_PARAM params[])
+{
+    PROV_EVP_AES128_GCM_CTX *ctx = (PROV_EVP_AES128_GCM_CTX *)vprovctx;
+    OSSL_PARAM *p;
+    int ret;
+    uint8_t *tagval = NULL;
+    size_t taglen;
+
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_AEAD_TAG);
+    if (p != NULL) {
+        if (OSSL_PARAM_get_octet_string_ptr(p, (void *)&tagval, &taglen))
+            memset(tagval, 0, taglen);
+        ret = 1;
+    } else {
+        ret = EVP_CIPHER_CTX_get_params(ctx->sub_ctx, params);
+    }
+
+    return ret;
+
+}
+
+/**
+ * @brief Set parameters on the aes-128-gcm context.
+ *
+ * @param vprovctx void *vprovctx.
+ * @param params const OSSL_PARAM params[].
+ * @return int.
+ */
+
+static int ossl_test_aes128gcm_set_ctx_params(void *vprovctx, const OSSL_PARAM params[])
+{
+    PROV_EVP_AES128_GCM_CTX *ctx = (PROV_EVP_AES128_GCM_CTX *)vprovctx;
+
+    return EVP_CIPHER_CTX_set_params(ctx->sub_ctx, params);
+}
+
+/**
+ * @brief Describe parameters that can be queriedn aes-128-gcm.
+ *
+ * @param vprovctx void *vprovctx.
+ * @return const OSSL_PARAM *.
+ */
+
+static const OSSL_PARAM *ossl_test_aes128gcm_gettable_params(void *vprovctx)
+{
+    PROV_EVP_AES128_GCM_CTX *ctx = (PROV_EVP_AES128_GCM_CTX *)vprovctx;
+
+    return EVP_CIPHER_gettable_params(EVP_CIPHER_CTX_get0_cipher(ctx->sub_ctx));
+}
+
+/**
+ * @brief aes-128-gcm context parameters that can be queried.
+ *
+ * @param cctx void *cctx.
+ * @param vprovctx void *vprovctx.
+ * @return const OSSL_PARAM *.
+ */
+
+static const OSSL_PARAM *ossl_test_aes128gcm_gettable_ctx_params(void *cctx, void *vprovctx)
+{
+    return ossl_cipher_generic_gettable_ctx_params(cctx, vprovctx);
+}
+
+/**
+ * @brief Describe aes-128-gcm context parameters that can be set.
+ *
+ * @param cctx void *cctx.
+ * @param vprovctx void *vprovctx.
+ * @return const OSSL_PARAM *.
+ */
+
+static const OSSL_PARAM *ossl_test_aes128gcm_settable_ctx_params(void *cctx, void *vprovctx)
+{
+    PROV_EVP_AES128_GCM_CTX *ctx = (PROV_EVP_AES128_GCM_CTX *)vprovctx;
+
+    return EVP_CIPHER_CTX_settable_params(ctx->sub_ctx);
+}
+
+static const OSSL_DISPATCH ossl_testaes128_gcm_functions[] = {
+    { OSSL_FUNC_CIPHER_NEWCTX,
+      (void (*)(void)) ossl_testaes128_gcm_newctx },
+    { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void)) ossl_test_aes128gcm_freectx },
+    { OSSL_FUNC_CIPHER_DUPCTX, (void (*)(void)) ossl_test_aes128gcm_dupctx },
+    { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))ossl_test_aes128gcm_einit },
+    { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))ossl_test_aes128gcm_dinit },
+    { OSSL_FUNC_CIPHER_UPDATE, (void (*)(void))ossl_test_aes128gcm_update },
+    { OSSL_FUNC_CIPHER_FINAL, (void (*)(void))ossl_test_aes128gcm_final },
+    { OSSL_FUNC_CIPHER_CIPHER, (void (*)(void))ossl_test_aes128gcm_cipher },
+    { OSSL_FUNC_CIPHER_GET_PARAMS,
+      (void (*)(void)) ossl_test_aes128gcm_get_params },
+    { OSSL_FUNC_CIPHER_GET_CTX_PARAMS,
+      (void (*)(void))ossl_test_aes128gcm_get_ctx_params },
+    { OSSL_FUNC_CIPHER_SET_CTX_PARAMS,
+      (void (*)(void))ossl_test_aes128gcm_set_ctx_params },
+    { OSSL_FUNC_CIPHER_GETTABLE_PARAMS,
+      (void (*)(void))ossl_test_aes128gcm_gettable_params },
+    { OSSL_FUNC_CIPHER_GETTABLE_CTX_PARAMS,
+      (void (*)(void))ossl_test_aes128gcm_gettable_ctx_params },
+    { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,
+      (void (*)(void))ossl_test_aes128gcm_settable_ctx_params },
+    OSSL_DISPATCH_END
+};
+
+#define NO_PAYLOAD_LENGTH ((size_t)-1)
+
+typedef struct {
+    OSSL_LIB_CTX *libctx;
+    int encrypting;
+    size_t payload_length;
+    unsigned int tls_ver;
+    size_t pad_size;
+    unsigned char *inbuf;
+} PROV_EVP_AES128_CBC_HMAC_SHA1_CTX;
+
+/**
+ * @brief Allocate and initialize a new aes-128-cbc-hmac-sha1 algorithm context.
+ *
+ * @param provctx void *provctx.
+ * @return a provider aes-128-cbc-hmac-sha1 context as a void pointer.
+ */
+
+static void *ossl_testaes128cbchmacsha1_newctx(void *provctx)
+{
+    PROV_EVP_AES128_CBC_HMAC_SHA1_CTX *new;
+
+    if (!ossl_prov_is_running())
+        return NULL;
+
+    new = OPENSSL_zalloc(sizeof(PROV_EVP_AES128_CBC_HMAC_SHA1_CTX));
+    new->libctx = PROV_LIBCTX_OF(provctx);
+    new->payload_length = NO_PAYLOAD_LENGTH;
+
+    return new;
+}
+
+/**
+ * @brief Release resources and clean up the aes-128-cbc-hmac-sha1 context.
+ *
+ * @param vprovctx void *vprovctx.
+ * @return void.
+ */
+
+static void ossl_test_aes128cbchmacsha1_freectx(void *vprovctx)
+{
+    PROV_EVP_AES128_CBC_HMAC_SHA1_CTX *ctx = (PROV_EVP_AES128_CBC_HMAC_SHA1_CTX *)vprovctx;
+
+    OPENSSL_free(ctx->inbuf);
+    OPENSSL_free(ctx);
+}
+
+/**
+ * @brief Duplicate an aes-128-cbc-hmac-sha1 algorithm context.
+ *
+ * @param vprovctx void *vprovctx.
+ * @return a new aes-128-cbc-hmac-sha1 context as a void pointer.
+ */
+
+static void *ossl_test_aes128cbchmacsha1_dupctx(void *vprovctx)
+{
+    PROV_EVP_AES128_CBC_HMAC_SHA1_CTX *ctx = (PROV_EVP_AES128_CBC_HMAC_SHA1_CTX *)vprovctx;
+    PROV_EVP_AES128_CBC_HMAC_SHA1_CTX *dup;
+
+    dup = OPENSSL_memdup(ctx, sizeof(PROV_EVP_AES128_CBC_HMAC_SHA1_CTX));
+
+    return dup;
+}
+
+/**
+ * @brief Initialize the aes-128-cbc-hmac-sha1 context for encryption.
+ *
+ * @param vprovctx void *vprovctx.
+ * @param key const unsigned char *key.
+ * @param keylen size_t keylen.
+ * @param iv const unsigned char *iv.
+ * @param ivlen size_t ivlen.
+ * @param params const OSSL_PARAM params[].
+ * @return int.
+ */
+
+static int ossl_test_aes128cbchmacsha1_einit(void *vprovctx, const unsigned char *key,
+                                             size_t keylen, const unsigned char *iv,
+                                             size_t ivlen, const OSSL_PARAM params[])
+{
+    PROV_EVP_AES128_CBC_HMAC_SHA1_CTX *ctx = (PROV_EVP_AES128_CBC_HMAC_SHA1_CTX *)vprovctx;
+
+    OPENSSL_free(ctx->inbuf);
+    ctx->inbuf = NULL;
+    ctx->payload_length = NO_PAYLOAD_LENGTH;
+    ctx->encrypting = 1;
+    return 1;
+}
+
+/**
+ * @brief Initialize the aes-128-cbc-hmac-sha1 context for encryption.
+ *
+ * @param vprovctx void *vprovctx.
+ * @param key const unsigned char *key.
+ * @param keylen size_t keylen.
+ * @param iv const unsigned char *iv.
+ * @param ivlen size_t ivlen.
+ * @param params const OSSL_PARAM params[].
+ * @return int.
+ */
+
+static int ossl_test_aes128cbchmacsha1_dinit(void *vprovctx, const unsigned char *key,
+                                             size_t keylen, const unsigned char *iv,
+                                             size_t ivlen, const OSSL_PARAM params[])
+{
+    PROV_EVP_AES128_CBC_HMAC_SHA1_CTX *ctx = (PROV_EVP_AES128_CBC_HMAC_SHA1_CTX *)vprovctx;
+
+    OPENSSL_free(ctx->inbuf);
+    ctx->inbuf = NULL;
+    ctx->payload_length = NO_PAYLOAD_LENGTH;
+    ctx->encrypting = 0;
+    return 1;
+}
+
+/**
+ * @brief do en/decryption for aes-128-cbc-hmac-sha1
+ *
+ * @param vprovctx void *vprovctx.
+ * @param out unsigned char *out.
+ * @param outl size_t *outl.
+ * @param outsize size_t outsize.
+ * @param in const unsigned char *in.
+ * @param inl size_t inl.
+ * @return int.
+ */
+
+static int ossl_test_aes128cbchmacsha1_update(void *vprovctx, unsigned char *out, size_t *outl,
+                                              size_t outsize, const unsigned char *in,
+                                              size_t inl)
+{
+    PROV_EVP_AES128_CBC_HMAC_SHA1_CTX *ctx = (PROV_EVP_AES128_CBC_HMAC_SHA1_CTX *)vprovctx;
+    size_t l;
+    size_t plen = ctx->payload_length;
+    size_t orig_inl = inl;
+    const unsigned char *outtmp;
+
+    if (ctx->encrypting) {
+        if (plen == NO_PAYLOAD_LENGTH)
+            plen = inl;
+        else if (inl !=
+                 ((plen + SHA_DIGEST_LENGTH +
+                   AES_BLOCK_SIZE) & (-AES_BLOCK_SIZE)))
+            return 0;
+
+        memmove(out, in, plen);
+
+        if (plen != inl) {      /* "TLS" mode of operation */
+            /* calculate HMAC and append it to payload */
+            fill_known_data(out + plen, SHA_DIGEST_LENGTH);
+
+            /* pad the payload|hmac */
+            plen += SHA_DIGEST_LENGTH;
+            for (l = (unsigned int)(inl - plen - 1); plen < inl; plen++)
+                out[plen] = (unsigned char)l;
+        }
+    } else {
+        /* decrypt HMAC|padding at once */
+        memmove(out, in, inl);
+
+        if (plen != NO_PAYLOAD_LENGTH) { /* "TLS" mode of operation */
+            unsigned int maxpad, pad;
+
+            if (ctx->tls_ver >= TLS1_1_VERSION) {
+                if (inl < (AES_BLOCK_SIZE + SHA_DIGEST_LENGTH + 1))
+                    return 0;
+
+                /* omit explicit iv */
+                in += AES_BLOCK_SIZE;
+                inl -= AES_BLOCK_SIZE;
+            } else {
+                if (inl < (SHA_DIGEST_LENGTH + 1))
+                    return 0;
+            }
+
+            outtmp = out + AES_BLOCK_SIZE;
+            /* figure out payload length */
+            pad = outtmp[inl - 1];
+            maxpad = (unsigned int)(inl - (SHA_DIGEST_LENGTH + 1));
+            if (pad > maxpad)
+                return 0;
+            for (plen = inl - pad - 1; plen < inl; plen++)
+                if (outtmp[plen] != pad)
+                    return 0;
+            /*
+             * We need to return the actual dummied up payload of this
+             * operatiion, so reduce the length of the output by the padding
+             * size that we just stripped as well as the leading IV, which
+             * is the first AES_BLOCK_SIZE bytes
+             */
+            orig_inl -= pad + 1 + SHA_DIGEST_LENGTH;
+            orig_inl -= AES_BLOCK_SIZE;
+        }
+    }
+    *outl = orig_inl;
+    return 1;
+}
+
+/**
+ * @brief finalize aes-128-cbc-hmac-sha1 en/decrypt operation
+ *
+ * @param vprovctx void *vprovctx.
+ * @param out unsigned char *out.
+ * @param outl size_t *outl.
+ * @param outsize size_t outsize.
+ * @return int.
+ */
+
+static int ossl_test_aes128cbchmacsha1_final(void *vprovctx, unsigned char *out, size_t *outl,
+                                             size_t outsize)
+{
+    /*
+     * Since we don't do any real en/decryption in this alg, this is a no-op
+     * so just return success
+     */
+    return 1;
+}
+
+/**
+ * @brief Implement ossl test aes128cbchmacsha1 cipher.
+ *
+ * @param vprovctx void *vprovctx.
+ * @param out unsigned char *out.
+ * @param outl size_t *outl.
+ * @param outsize size_t outsize.
+ * @param in const unsigned char *in.
+ * @param inl size_t inl.
+ * @return int.
+ */
+
+static int ossl_test_aes128cbchmacsha1_cipher(void *vprovctx,
+                                              unsigned char *out, size_t *outl,
+                                              size_t outsize, const unsigned char *in, size_t inl)
+{
+    return 1;
+}
+
+#define AES_CBC_HMAC_SHA_FLAGS (PROV_CIPHER_FLAG_AEAD | PROV_CIPHER_FLAG_TLS1_MULTIBLOCK)
+/**
+ * @brief Return aes-128-cbc-hmac-sha1 gettable parameters.
+ *
+ * @param params OSSL_PARAM params[].
+ * @return int.
+ */
+
+static int ossl_test_aes128cbchmacsha1_get_params(OSSL_PARAM params[])
+{
+    int ret;
+
+    ret = ossl_cipher_generic_get_params(params, EVP_CIPH_CBC_MODE,
+                                         AES_CBC_HMAC_SHA_FLAGS, 128, 128, 128);
+
+    return ret;
+}
+
+/**
+ * @brief Query aes-128-cbc-hmac-sha1 context parameters.
+ *
+ * @param vprovctx void *vprovctx.
+ * @param params OSSL_PARAM params[].
+ * @return int.
+ */
+
+static int ossl_test_aes128cbchmacsha1_get_ctx_params(void *vprovctx, OSSL_PARAM params[])
+{
+    PROV_EVP_AES128_CBC_HMAC_SHA1_CTX *ctx = (PROV_EVP_AES128_CBC_HMAC_SHA1_CTX *)vprovctx;
+    OSSL_PARAM *p;
+
+    /*
+     * lifted from aes_get_ctx_params
+     */
+#if !defined(OPENSSL_NO_MULTIBLOCK)
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_MAX_BUFSIZE);
+    if (p != NULL) {
+        /*
+         * Don't know how to handle any of these
+         */
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
+    }
+
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_INTERLEAVE);
+    if (p != NULL) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
+    }
+
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_AAD_PACKLEN);
+    if (p != NULL) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
+    }
+
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_ENC_LEN);
+    if (p != NULL) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
+    }
+#endif /* !defined(OPENSSL_NO_MULTIBLOCK) */
+
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_AEAD_TLS1_AAD_PAD);
+    if (p != NULL && !OSSL_PARAM_set_size_t(p, ctx->pad_size)) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
+    }
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_KEYLEN);
+    if (p != NULL && !OSSL_PARAM_set_size_t(p, 128 / 8)) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
+    }
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IVLEN);
+    if (p != NULL && !OSSL_PARAM_set_size_t(p, 128 / 8)) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
+    }
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IV);
+    if (p != NULL) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
+    }
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_UPDATED_IV);
+    if (p != NULL) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
+    }
+
+    return 1;
+}
+
+/**
+ * @brief Set aes-128-cbc-hmac-sha1 context parameters.
+ *
+ * @param vprovctx void *vprovctx.
+ * @param params const OSSL_PARAM params[].
+ * @return int.
+ */
+
+static int ossl_test_aes128cbchmacsha1_set_ctx_params(void *vprovctx, const OSSL_PARAM params[])
+{
+    PROV_EVP_AES128_CBC_HMAC_SHA1_CTX *ctx = (PROV_EVP_AES128_CBC_HMAC_SHA1_CTX *)vprovctx;
+    OSSL_PARAM *p;
+    uint8_t *val;
+    size_t vlen;
+    unsigned int len;
+
+    p = OSSL_PARAM_locate((OSSL_PARAM *)params, OSSL_CIPHER_PARAM_AEAD_TLS1_AAD);
+    if (p != NULL) {
+        OSSL_PARAM_get_octet_string_ptr(p, (const void **)&val, &vlen);
+        len = val[EVP_AEAD_TLS1_AAD_LEN - 2] << 8 | val[EVP_AEAD_TLS1_AAD_LEN - 1];
+        ctx->tls_ver = val[EVP_AEAD_TLS1_AAD_LEN - 4] << 8 | val[EVP_AEAD_TLS1_AAD_LEN -3];
+
+        if (ctx->encrypting) {
+            ctx->payload_length = len;
+            if (ctx->tls_ver >= TLS1_1_VERSION) {
+                if (len < AES_BLOCK_SIZE)
+                    return 0;
+                len -= AES_BLOCK_SIZE;
+                val[EVP_AEAD_TLS1_AAD_LEN - 2] = len >> 8;
+                val[EVP_AEAD_TLS1_AAD_LEN - 1] = len;
+                ctx->pad_size = ((len + SHA_DIGEST_LENGTH +
+                                  AES_BLOCK_SIZE) & (-AES_BLOCK_SIZE)) - len;
+            }
+        } else {
+            ctx->payload_length = EVP_AEAD_TLS1_AAD_LEN;
+            ctx->pad_size = SHA_DIGEST_LENGTH;
+        }
+
+    }
+
+    return 1;
+}
+
+/**
+ * @brief Describe parameters that can be queried for aes-128-cbc-hmac-sha1.
+ *
+ * @param vprovctx void *vprovctx.
+ * @return const OSSL_PARAM *.
+ */
+
+static const OSSL_PARAM *ossl_test_aes128cbchmacsha1_gettable_params(void *vprovctx)
+{
+    return NULL;
+}
+
+/**
+ * @brief Describe context parameters that can be queried for an aes-128-cbc-hamc-sha1 ctx.
+ *
+ * @param cctx void *cctx.
+ * @param vprovctx void *vprovctx.
+ * @return const OSSL_PARAM *.
+ */
+
+static const OSSL_PARAM *ossl_test_aes128cbchmacsha1_gettable_ctx_params(void *cctx, void *vprovctx)
+{
+    return ossl_cipher_generic_gettable_ctx_params(cctx, vprovctx);
+}
+
+/**
+ * @brief Describe context parameters that can be set on an aes-128-cbc-hmac-sha1 ctx.
+ *
+ * @param cctx void *cctx.
+ * @param vprovctx void *vprovctx.
+ * @return const OSSL_PARAM *.
+ */
+
+static const OSSL_PARAM *ossl_test_aes128cbchmacsha1_settable_ctx_params(void *cctx, void *vprovctx)
+{
+    return NULL;
+}
+
+static const OSSL_DISPATCH ossl_testaes128cbchmacsha1_functions[] = {
+    { OSSL_FUNC_CIPHER_NEWCTX,
+      (void (*)(void)) ossl_testaes128cbchmacsha1_newctx },
+    { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void)) ossl_test_aes128cbchmacsha1_freectx },
+    { OSSL_FUNC_CIPHER_DUPCTX, (void (*)(void)) ossl_test_aes128cbchmacsha1_dupctx },
+    { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))ossl_test_aes128cbchmacsha1_einit },
+    { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))ossl_test_aes128cbchmacsha1_dinit },
+    { OSSL_FUNC_CIPHER_UPDATE, (void (*)(void))ossl_test_aes128cbchmacsha1_update },
+    { OSSL_FUNC_CIPHER_FINAL, (void (*)(void))ossl_test_aes128cbchmacsha1_final },
+    { OSSL_FUNC_CIPHER_CIPHER, (void (*)(void))ossl_test_aes128cbchmacsha1_cipher },
+    { OSSL_FUNC_CIPHER_GET_PARAMS,
+      (void (*)(void)) ossl_test_aes128cbchmacsha1_get_params },
+    { OSSL_FUNC_CIPHER_GET_CTX_PARAMS,
+      (void (*)(void))ossl_test_aes128cbchmacsha1_get_ctx_params },
+    { OSSL_FUNC_CIPHER_SET_CTX_PARAMS,
+      (void (*)(void))ossl_test_aes128cbchmacsha1_set_ctx_params },
+    { OSSL_FUNC_CIPHER_GETTABLE_PARAMS,
+      (void (*)(void))ossl_test_aes128cbchmacsha1_gettable_params },
+    { OSSL_FUNC_CIPHER_GETTABLE_CTX_PARAMS,
+      (void (*)(void))ossl_test_aes128cbchmacsha1_gettable_ctx_params },
+    { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,
+      (void (*)(void))ossl_test_aes128cbchmacsha1_settable_ctx_params },
+    OSSL_DISPATCH_END
+};
+
+static const OSSL_ALGORITHM ossltest_ciphers[] = {
+    ALG(PROV_NAMES_AES_128_CBC, ossl_testaes128_cbc_functions),
+    ALG(PROV_NAMES_AES_128_GCM, ossl_testaes128_gcm_functions),
+    ALG(PROV_NAMES_AES_128_CBC_HMAC_SHA1, ossl_testaes128cbchmacsha1_functions),
+    {NULL, NULL, NULL}
+};
+
+typedef struct ossl_test_rand_ctx {
+    size_t unused;
+} OSSL_TEST_RAND_CTX;
+
+/**
+ * @brief Implement drbg ctr new wrapper.
+ *
+ * @param provctx void *provctx.
+ * @param parent void *parent.
+ * @param parent_dispatch const OSSL_DISPATCH *parent_dispatch.
+ * @return void *.
+ */
+
+static void *drbg_ctr_new_wrapper(void *provctx, void *parent,
+                                  const OSSL_DISPATCH *parent_dispatch)
+{
+    return OPENSSL_zalloc(sizeof(OSSL_TEST_RAND_CTX));
+}
+
+/**
+ * @brief Release resources and clean up the context.
+ *
+ * @param vdrbg void *vdrbg.
+ * @return void.
+ */
+
+static void drbg_ctr_free(void *vdrbg)
+{
+    OPENSSL_free(vdrbg);
+}
+
+/**
+ * @brief Instantiate the CTR DRBG with the given inputs.
+ *
+ * @param vdrbg void *vdrbg.
+ * @param strength unsigned int strength.
+ * @param prediction_resistance int prediction_resistance.
+ * @param pstr const unsigned char *pstr.
+ * @param pstr_len size_t pstr_len.
+ * @param params const OSSL_PARAM params[].
+ * @return int.
+ */
+
+static int drbg_ctr_instantiate_wrapper(void *vdrbg, unsigned int strength,
+                                        int prediction_resistance,
+                                        const unsigned char *pstr,
+                                        size_t pstr_len,
+                                        const OSSL_PARAM params[])
+{
+    return 1;
+}
+
+/**
+ * @brief Instantiate the CTR DRBG with the given inputs.
+ *
+ * @param vdrbg void *vdrbg.
+ * @return int.
+ */
+
+static int drbg_ctr_uninstantiate_wrapper(void *vdrbg)
+{
+    return 1;
+}
+
+/**
+ * @brief Generate pseudorandom bytes from the CTR DRBG.
+ *
+ * @param vdrbg void *vdrbg.
+ * @param out unsigned char *out.
+ * @param outlen size_t outlen.
+ * @param strength unsigned int strength.
+ * @param prediction_resistance int prediction_resistance.
+ * @param adin const unsigned char *adin.
+ * @param adin_len size_t adin_len.
+ * @return int.
+ */
+
+static int drbg_ctr_generate_wrapper(void *vdrbg, unsigned char *out,
+                                     size_t outlen, unsigned int strength,
+                                     int prediction_resistance,
+                                     const unsigned char *adin, size_t adin_len)
+{
+    unsigned char val = 1;
+    size_t copylen = 0;
+
+    while (copylen < outlen) {
+        *out++ = val++;
+        copylen++;
+    }
+
+    return 1;
+}
+
+/**
+ * @brief Reseed the CTR DRBG with fresh entropy.
+ *
+ * @param vdrbg void *vdrbg.
+ * @param prediction_resistance int prediction_resistance.
+ * @param ent const unsigned char *ent.
+ * @param ent_len size_t ent_len.
+ * @param adin const unsigned char *adin.
+ * @param adin_len size_t adin_len.
+ * @return int.
+ */
+
+static int drbg_ctr_reseed_wrapper(void *vdrbg, int prediction_resistance,
+                                   const unsigned char *ent, size_t ent_len,
+                                   const unsigned char *adin, size_t adin_len)
+{
+    return 1;
+}
+
+/**
+ * @brief Enable internal locking for thread safety.
+ *
+ * @param vctx void *vctx.
+ * @return int.
+ */
+
+static int ossl_drbg_enable_locking(void *vctx)
+{
+    return 1;
+}
+
+/**
+ * @brief Acquire the internal lock.
+ *
+ * @param vctx void *vctx.
+ * @return int.
+ */
+
+static int ossl_drbg_lock(void *vctx)
+{
+    return 1;
+}
+
+/**
+ * @brief Release the internal lock.
+ *
+ * @param vctx void *vctx.
+ * @return void.
+ */
+
+static void ossl_drbg_unlock(void *vctx)
+{
+    return;
+}
+
+/**
+ * @brief Describe context parameters that can be set.
+ *
+ * @param vctx ossl_unused void *vctx.
+ * @param provctx ossl_unused void *provctx.
+ * @return const OSSL_PARAM *.
+ */
+
+static const OSSL_PARAM *drbg_ctr_settable_ctx_params(ossl_unused void *vctx,
+                                                      ossl_unused void *provctx)
+{
+    return NULL;
+}
+
+/**
+ * @brief Set parameters on the algorithm context.
+ *
+ * @param vctx void *vctx.
+ * @param params const OSSL_PARAM params[].
+ * @return int.
+ */
+
+static int drbg_ctr_set_ctx_params(void *vctx, const OSSL_PARAM params[])
+{
+    return 1;
+}
+
+/**
+ * @brief Describe context parameters that can be queried.
+ *
+ * @param vctx ossl_unused void *vctx.
+ * @param provctx ossl_unused void *provctx.
+ * @return const OSSL_PARAM *.
+ */
+
+static const OSSL_PARAM *drbg_ctr_gettable_ctx_params(ossl_unused void *vctx,
+                                                      ossl_unused void *provctx)
+{
+    return NULL;
+}
+
+/**
+ * @brief Query parameters from the algorithm context.
+ *
+ * @param vdrbg void *vdrbg.
+ * @param params OSSL_PARAM params[].
+ * @return int.
+ */
+
+static int drbg_ctr_get_ctx_params(void *vdrbg, OSSL_PARAM params[])
+{
+    OSSL_PARAM *p = OSSL_PARAM_locate(params, OSSL_RAND_PARAM_MAX_REQUEST);
+
+    if (p != NULL)
+        OSSL_PARAM_set_size_t(p, (size_t)(1 << 16));
+
+    return 1;
+}
+
+/**
+ * @brief Verify that sensitive buffers are cleared to zero.
+ *
+ * @param vdrbg void *vdrbg.
+ * @return int.
+ */
+
+static int drbg_ctr_verify_zeroization(void *vdrbg)
+{
+    return 1;
+}
+
+/**
+ * @brief Return the stored test seed buffer if present.
+ *
+ * @param vdrbg void *vdrbg.
+ * @param pout unsigned char **pout.
+ * @param entropy int entropy.
+ * @param min_len size_t min_len.
+ * @param max_len size_t max_len.
+ * @param prediction_resistance int prediction_resistance.
+ * @param adin const unsigned char *adin.
+ * @param adin_len size_t adin_len.
+ * @return size_t.
+ */
+
+static size_t ossl_drbg_get_seed(void *vdrbg, unsigned char **pout,
+                                 int entropy, size_t min_len,
+                                 size_t max_len, int prediction_resistance,
+                                 const unsigned char *adin, size_t adin_len)
+{
+    size_t needed = entropy;
+
+    if (needed < min_len)
+        needed = min_len;
+    if (needed > max_len)
+        needed = max_len;
+    return needed;
+}
+
+/**
+ * @brief Clear any stored test seed buffer.
+ *
+ * @param vdrbg ossl_unused void *vdrbg.
+ * @param out unsigned char *out.
+ * @param outlen size_t outlen.
+ * @return void.
+ */
+
+static void ossl_drbg_clear_seed(ossl_unused void *vdrbg,
+                                 unsigned char *out, size_t outlen)
+{
+    return;
+}
+
+static const OSSL_DISPATCH ossl_test_drbg_ctr_functions[] = {
+    { OSSL_FUNC_RAND_NEWCTX, (void(*)(void))drbg_ctr_new_wrapper },
+    { OSSL_FUNC_RAND_FREECTX, (void(*)(void))drbg_ctr_free },
+    { OSSL_FUNC_RAND_INSTANTIATE,
+      (void(*)(void))drbg_ctr_instantiate_wrapper },
+    { OSSL_FUNC_RAND_UNINSTANTIATE,
+      (void(*)(void))drbg_ctr_uninstantiate_wrapper },
+    { OSSL_FUNC_RAND_GENERATE, (void(*)(void))drbg_ctr_generate_wrapper },
+    { OSSL_FUNC_RAND_RESEED, (void(*)(void))drbg_ctr_reseed_wrapper },
+    { OSSL_FUNC_RAND_ENABLE_LOCKING, (void(*)(void))ossl_drbg_enable_locking },
+    { OSSL_FUNC_RAND_LOCK, (void(*)(void))ossl_drbg_lock },
+    { OSSL_FUNC_RAND_UNLOCK, (void(*)(void))ossl_drbg_unlock },
+    { OSSL_FUNC_RAND_SETTABLE_CTX_PARAMS,
+      (void(*)(void))drbg_ctr_settable_ctx_params },
+    { OSSL_FUNC_RAND_SET_CTX_PARAMS, (void(*)(void))drbg_ctr_set_ctx_params },
+    { OSSL_FUNC_RAND_GETTABLE_CTX_PARAMS,
+      (void(*)(void))drbg_ctr_gettable_ctx_params },
+    { OSSL_FUNC_RAND_GET_CTX_PARAMS, (void(*)(void))drbg_ctr_get_ctx_params },
+    { OSSL_FUNC_RAND_VERIFY_ZEROIZATION,
+      (void(*)(void))drbg_ctr_verify_zeroization },
+    { OSSL_FUNC_RAND_GET_SEED, (void(*)(void))ossl_drbg_get_seed },
+    { OSSL_FUNC_RAND_CLEAR_SEED, (void(*)(void))ossl_drbg_clear_seed },
+    OSSL_DISPATCH_END
+};
+
+static const OSSL_ALGORITHM ossltest_rands[] = {
+    ALG(PROV_NAMES_CTR_DRBG, ossl_test_drbg_ctr_functions),
+    {NULL, NULL, NULL}
+};
+
+/**
+ * @brief Implement ossltest query.
+ *
+ * @param provctx void *provctx.
+ * @param operation_id int operation_id.
+ * @param no_cache int *no_cache.
+ * @return const OSSL_ALGORITHM *.
+ */
+
+static const OSSL_ALGORITHM *ossltest_query(void *provctx, int operation_id,
+                                            int *no_cache)
+{
+    *no_cache = 0;
+    switch (operation_id) {
+    case OSSL_OP_DIGEST:
+        return ossltest_digests;
+    case OSSL_OP_CIPHER:
+        return ossltest_ciphers;
+    case OSSL_OP_RAND:
+        return ossltest_rands;
+    }
+    return NULL;
+}
+
+static const OSSL_DISPATCH ossltest_dispatch_table[] = {
+    { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))ossltest_teardown },
+    { OSSL_FUNC_PROVIDER_GETTABLE_PARAMS, (void (*)(void))ossltest_gettable_params },
+    { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))ossltest_get_params },
+    { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))ossltest_query },
+    OSSL_DISPATCH_END
+};
+
+OSSL_provider_init_fn OSSL_provider_init_int;
+/**
+ * @brief Initialize the context or operation state.
+ *
+ * @param handle const OSSL_CORE_HANDLE *handle.
+ * @param in const OSSL_DISPATCH *in.
+ * @param out const OSSL_DISPATCH **out.
+ * @param provctx void **provctx.
+ * @return int.
+ */
+int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
+                       const OSSL_DISPATCH *in,
+                       const OSSL_DISPATCH **out,
+                       void **provctx)
+{
+    OSSL_LIB_CTX *libctx = NULL;
+
+    if ((*provctx = ossl_prov_ctx_new()) == NULL
+        || (libctx = OSSL_LIB_CTX_new_child(handle, in)) == NULL) {
+        OSSL_LIB_CTX_free(libctx);
+        ossltest_teardown(*provctx);
+        *provctx = NULL;
+        return 0;
+    }
+
+    ossl_prov_ctx_set0_libctx(*provctx, libctx);
+    ossl_prov_ctx_set0_handle(*provctx, handle);
+
+    *out = ossltest_dispatch_table;
+
+    return 1;
+}

--- a/test/p_ossltest.c
+++ b/test/p_ossltest.c
@@ -379,8 +379,13 @@ static void *ossl_test_aes128cbc_dupctx(void *vprovctx)
 
     dup = OPENSSL_memdup(ctx, sizeof(PROV_EVP_AES128_CBC_CTX));
 
-    dup->sub_ctx = EVP_CIPHER_CTX_dup(ctx->sub_ctx);
-
+    if (dup != NULL) {
+        dup->sub_ctx = EVP_CIPHER_CTX_dup(ctx->sub_ctx);
+        if (dup->sub_ctx == NULL) {
+            OPENSSL_free(dup);
+            dup = NULL;
+        }
+    }
     return dup;
 }
 
@@ -732,8 +737,13 @@ static void *ossl_test_aes128gcm_dupctx(void *vprovctx)
 
     dup = OPENSSL_memdup(ctx, sizeof(PROV_EVP_AES128_GCM_CTX));
 
-    dup->sub_ctx = EVP_CIPHER_CTX_dup(ctx->sub_ctx);
-
+    if (dup != NULL) {
+        dup->sub_ctx = EVP_CIPHER_CTX_dup(ctx->sub_ctx);
+        if (dup->sub_ctx == NULL) {
+            OPENSSL_free(dup);
+            dup = NULL;
+        }
+    }
     return dup;
 }
 
@@ -1048,11 +1058,8 @@ static void ossl_test_aes128cbchmacsha1_freectx(void *vprovctx)
 static void *ossl_test_aes128cbchmacsha1_dupctx(void *vprovctx)
 {
     PROV_EVP_AES128_CBC_HMAC_SHA1_CTX *ctx = (PROV_EVP_AES128_CBC_HMAC_SHA1_CTX *)vprovctx;
-    PROV_EVP_AES128_CBC_HMAC_SHA1_CTX *dup;
 
-    dup = OPENSSL_memdup(ctx, sizeof(PROV_EVP_AES128_CBC_HMAC_SHA1_CTX));
-
-    return dup;
+    return OPENSSL_memdup(ctx, sizeof(PROV_EVP_AES128_CBC_HMAC_SHA1_CTX));
 }
 
 /**

--- a/test/recipes/05-test_rand.t
+++ b/test/recipes/05-test_rand.t
@@ -10,7 +10,8 @@ use strict;
 use warnings;
 use OpenSSL::Test;
 use OpenSSL::Test::Utils;
-use OpenSSL::Test qw/:DEFAULT srctop_file/;
+use OpenSSL::Test qw/:DEFAULT srctop_file bldtop_dir/;
+use Cwd qw(abs_path);
 
 plan tests => 6;
 setup("test_rand");
@@ -34,11 +35,12 @@ SKIP: {
     my @randdata;
     my $expected = '0102030405060708090a0b0c0d0e0f10';
 
-    @randdata = run(app(['openssl', 'rand', '-engine', 'ossltest', '-hex', '16' ]),
+    $ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+    @randdata = run(app(['openssl', 'rand', '-provider', 'p_ossltest', '-provider', 'default', '-propquery', '?provider=p_ossltest', '-hex', '16' ]),
                     capture => 1, statusvar => \$success);
     chomp(@randdata);
     ok($success && $randdata[0] eq $expected,
-       "rand with ossltest: Check rand output is as expected");
+       "rand with ossltest provider: Check rand output is as expected");
 
     @randdata = run(app(['openssl', 'rand', '-hex', '2K' ]),
                     capture => 1, statusvar => \$success);

--- a/test/recipes/20-test_dgst.t
+++ b/test/recipes/20-test_dgst.t
@@ -14,6 +14,7 @@ use File::Spec;
 use File::Basename;
 use OpenSSL::Test qw/:DEFAULT with srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
+use Cwd qw(abs_path);
 
 setup("test_dgst");
 
@@ -172,7 +173,7 @@ SKIP: {
     subtest "SHA1 generation by provider with `dgst` CLI" => sub {
         plan tests => 1;
 
-        $ENV{OPENSSL_MODULES} = bldtop_dir("test");
+        $ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
         my $testdata = srctop_file('test', 'data.bin');
         my @macdata = run(app(['openssl', 'dgst', '-sha1',
                                '-provider', "p_ossltest",

--- a/test/recipes/20-test_dgst.t
+++ b/test/recipes/20-test_dgst.t
@@ -166,17 +166,18 @@ SKIP: {
 }
 
 SKIP: {
-    skip "dgst with engine is not supported by this OpenSSL build", 1
-        if disabled("engine") || disabled("dynamic-engine");
+    skip "dgst with provider is not supported by this OpenSSL build", 1
+        if disabled("module");
 
-    subtest "SHA1 generation by engine with `dgst` CLI" => sub {
+    subtest "SHA1 generation by provider with `dgst` CLI" => sub {
         plan tests => 1;
 
+        $ENV{OPENSSL_MODULES} = bldtop_dir("test");
         my $testdata = srctop_file('test', 'data.bin');
-        # intentionally using -engine twice, please do not remove the duplicate line
         my @macdata = run(app(['openssl', 'dgst', '-sha1',
-                               '-engine', "ossltest",
-                               '-engine', "ossltest",
+                               '-provider', "p_ossltest",
+                               '-provider', "default",
+                               '-propquery', '?provider=p_ossltest',
                                $testdata]), capture => 1);
         chomp(@macdata);
         my $expected = qr/SHA1\(\Q$testdata\E\)= 000102030405060708090a0b0c0d0e0f10111213/;

--- a/test/recipes/70-test_certtypeext.t
+++ b/test/recipes/70-test_certtypeext.t
@@ -10,15 +10,18 @@ use strict;
 use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
+use Cwd qw(abs_path);
 
 my $test_name = "test_certtypeext";
 setup($test_name);
 
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");

--- a/test/recipes/70-test_comp.t
+++ b/test/recipes/70-test_comp.t
@@ -11,15 +11,18 @@ use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file srctop_dir bldtop_dir/;
 use OpenSSL::Test::Utils;
 use File::Temp qw(tempfile);
 use TLSProxy::Proxy;
+use Cwd qw(abs_path);
 
 my $test_name = "test_comp";
 setup($test_name);
 
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");

--- a/test/recipes/70-test_key_share.t
+++ b/test/recipes/70-test_key_share.t
@@ -11,6 +11,7 @@ use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
 use File::Temp qw(tempfile);
+use Cwd qw(abs_path);
 
 use constant {
     LOOK_ONLY => 0,
@@ -49,11 +50,13 @@ my $selectedgroupid;
 my $test_name = "test_key_share";
 setup($test_name);
 
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");

--- a/test/recipes/70-test_npn.t
+++ b/test/recipes/70-test_npn.t
@@ -7,19 +7,21 @@
 # https://www.openssl.org/source/license.html
 
 use strict;
-use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file/;
+use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
-
+use Cwd qw(abs_path);
 use TLSProxy::Proxy;
 
 my $test_name = "test_npn";
 setup($test_name);
 
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");

--- a/test/recipes/70-test_renegotiation.t
+++ b/test/recipes/70-test_renegotiation.t
@@ -13,7 +13,6 @@ use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
 use Cwd qw(abs_path);
 
-
 my $test_name = "test_renegotiation";
 setup($test_name);
 

--- a/test/recipes/70-test_renegotiation.t
+++ b/test/recipes/70-test_renegotiation.t
@@ -11,15 +11,19 @@ use List::Util 'first';
 use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
+use Cwd qw(abs_path);
+
 
 my $test_name = "test_renegotiation";
 setup($test_name);
 
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");

--- a/test/recipes/70-test_sslcbcpadding.t
+++ b/test/recipes/70-test_sslcbcpadding.t
@@ -12,15 +12,19 @@ use feature 'state';
 use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
+use Cwd qw(abs_path);
+
 
 my $test_name = "test_sslcbcpadding";
 setup($test_name);
 
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");

--- a/test/recipes/70-test_sslcbcpadding.t
+++ b/test/recipes/70-test_sslcbcpadding.t
@@ -14,7 +14,6 @@ use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
 use Cwd qw(abs_path);
 
-
 my $test_name = "test_sslcbcpadding";
 setup($test_name);
 

--- a/test/recipes/70-test_sslcertstatus.t
+++ b/test/recipes/70-test_sslcertstatus.t
@@ -12,7 +12,6 @@ use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
 use Cwd qw(abs_path);
 
-
 my $test_name = "test_sslcertstatus";
 setup($test_name);
 

--- a/test/recipes/70-test_sslcertstatus.t
+++ b/test/recipes/70-test_sslcertstatus.t
@@ -10,15 +10,19 @@ use strict;
 use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
+use Cwd qw(abs_path);
+
 
 my $test_name = "test_sslcertstatus";
 setup($test_name);
 
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");

--- a/test/recipes/70-test_sslextension.t
+++ b/test/recipes/70-test_sslextension.t
@@ -12,15 +12,19 @@ use feature 'state';
 use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
+use Cwd qw(abs_path);
+
 
 my $test_name = "test_sslextension";
 setup($test_name);
 
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");

--- a/test/recipes/70-test_sslextension.t
+++ b/test/recipes/70-test_sslextension.t
@@ -14,7 +14,6 @@ use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
 use Cwd qw(abs_path);
 
-
 my $test_name = "test_sslextension";
 setup($test_name);
 

--- a/test/recipes/70-test_sslmessages.t
+++ b/test/recipes/70-test_sslmessages.t
@@ -14,7 +14,6 @@ use TLSProxy::Proxy;
 use checkhandshake qw(checkhandshake @handmessages @extensions);
 use Cwd qw(abs_path);
 
-
 my $test_name = "test_sslmessages";
 setup($test_name);
 

--- a/test/recipes/70-test_sslmessages.t
+++ b/test/recipes/70-test_sslmessages.t
@@ -12,15 +12,19 @@ use OpenSSL::Test::Utils;
 use File::Temp qw(tempfile);
 use TLSProxy::Proxy;
 use checkhandshake qw(checkhandshake @handmessages @extensions);
+use Cwd qw(abs_path);
+
 
 my $test_name = "test_sslmessages";
 setup($test_name);
 
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");

--- a/test/recipes/70-test_sslrecords.t
+++ b/test/recipes/70-test_sslrecords.t
@@ -13,15 +13,18 @@ use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
 use TLSProxy::Message;
+use Cwd qw(abs_path);
 
 my $test_name = "test_sslrecords";
 setup($test_name);
 
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");

--- a/test/recipes/70-test_sslsessiontick.t
+++ b/test/recipes/70-test_sslsessiontick.t
@@ -11,15 +11,18 @@ use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
 use File::Temp qw(tempfile);
+use Cwd qw(abs_path);
 
 my $test_name = "test_sslsessiontick";
 setup($test_name);
 
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");

--- a/test/recipes/70-test_sslsigalgs.t
+++ b/test/recipes/70-test_sslsigalgs.t
@@ -12,7 +12,6 @@ use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
 use Cwd qw(abs_path);
 
-
 my $test_name = "test_sslsigalgs";
 setup($test_name);
 

--- a/test/recipes/70-test_sslsigalgs.t
+++ b/test/recipes/70-test_sslsigalgs.t
@@ -10,15 +10,19 @@ use strict;
 use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
+use Cwd qw(abs_path);
+
 
 my $test_name = "test_sslsigalgs";
 setup($test_name);
 
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");

--- a/test/recipes/70-test_sslsignature.t
+++ b/test/recipes/70-test_sslsignature.t
@@ -12,7 +12,6 @@ use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
 use Cwd qw(abs_path);
 
-
 my $test_name = "test_sslsignature";
 setup($test_name);
 

--- a/test/recipes/70-test_sslsignature.t
+++ b/test/recipes/70-test_sslsignature.t
@@ -10,15 +10,19 @@ use strict;
 use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
+use Cwd qw(abs_path);
+
 
 my $test_name = "test_sslsignature";
 setup($test_name);
 
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");

--- a/test/recipes/70-test_sslskewith0p.t
+++ b/test/recipes/70-test_sslskewith0p.t
@@ -12,7 +12,6 @@ use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
 use Cwd qw(abs_path);
 
-
 my $test_name = "test_sslskewith0p";
 setup($test_name);
 

--- a/test/recipes/70-test_sslskewith0p.t
+++ b/test/recipes/70-test_sslskewith0p.t
@@ -10,15 +10,19 @@ use strict;
 use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
+use Cwd qw(abs_path);
+
 
 my $test_name = "test_sslskewith0p";
 setup($test_name);
 
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "dh is not supported by this OpenSSL build"
     if disabled("dh");

--- a/test/recipes/70-test_sslversions.t
+++ b/test/recipes/70-test_sslversions.t
@@ -11,6 +11,7 @@ use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
 use File::Temp qw(tempfile);
+use Cwd qw(abs_path);
 
 use constant {
     REVERSE_ORDER_VERSIONS => 1,
@@ -27,11 +28,13 @@ my $testtype;
 my $test_name = "test_sslversions";
 setup($test_name);
 
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");

--- a/test/recipes/70-test_sslvertol.t
+++ b/test/recipes/70-test_sslvertol.t
@@ -12,7 +12,6 @@ use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
 use Cwd qw(abs_path);
 
-
 my $test_name = "test_sslvertol";
 setup($test_name);
 

--- a/test/recipes/70-test_sslvertol.t
+++ b/test/recipes/70-test_sslvertol.t
@@ -10,15 +10,19 @@ use strict;
 use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
+use Cwd qw(abs_path);
+
 
 my $test_name = "test_sslvertol";
 setup($test_name);
 
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");

--- a/test/recipes/70-test_tls13alerts.t
+++ b/test/recipes/70-test_tls13alerts.t
@@ -10,15 +10,19 @@ use strict;
 use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
+use Cwd qw(abs_path);
+
 
 my $test_name = "test_tls13alerts";
 setup($test_name);
 
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");

--- a/test/recipes/70-test_tls13alerts.t
+++ b/test/recipes/70-test_tls13alerts.t
@@ -12,7 +12,6 @@ use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
 use Cwd qw(abs_path);
 
-
 my $test_name = "test_tls13alerts";
 setup($test_name);
 

--- a/test/recipes/70-test_tls13certcomp.t
+++ b/test/recipes/70-test_tls13certcomp.t
@@ -14,7 +14,6 @@ use TLSProxy::Proxy;
 use checkhandshake qw(checkhandshake @handmessages @extensions);
 use Cwd qw(abs_path);
 
-
 my $test_name = "test_tls13certcomp";
 setup($test_name);
 

--- a/test/recipes/70-test_tls13certcomp.t
+++ b/test/recipes/70-test_tls13certcomp.t
@@ -12,15 +12,19 @@ use OpenSSL::Test::Utils;
 use File::Temp qw(tempfile);
 use TLSProxy::Proxy;
 use checkhandshake qw(checkhandshake @handmessages @extensions);
+use Cwd qw(abs_path);
+
 
 my $test_name = "test_tls13certcomp";
 setup($test_name);
 
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");

--- a/test/recipes/70-test_tls13cookie.t
+++ b/test/recipes/70-test_tls13cookie.t
@@ -10,15 +10,19 @@ use strict;
 use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
+use Cwd qw(abs_path);
+
 
 my $test_name = "test_tls13cookie";
 setup($test_name);
 
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");

--- a/test/recipes/70-test_tls13cookie.t
+++ b/test/recipes/70-test_tls13cookie.t
@@ -12,7 +12,6 @@ use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
 use Cwd qw(abs_path);
 
-
 my $test_name = "test_tls13cookie";
 setup($test_name);
 

--- a/test/recipes/70-test_tls13downgrade.t
+++ b/test/recipes/70-test_tls13downgrade.t
@@ -10,6 +10,7 @@ use strict;
 use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
+use Cwd qw(abs_path);
 
 my $test_name = "test_tls13downgrade";
 setup($test_name);
@@ -17,8 +18,8 @@ setup($test_name);
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");
@@ -26,6 +27,8 @@ plan skip_all => "$test_name needs the sock feature enabled"
 plan skip_all => "$test_name needs TLS1.3 and TLS1.2 enabled"
     if disabled("tls1_3") || disabled("tls1_2")
         || (disabled("ec") && disabled("dh"));
+
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
 
 my $proxy = TLSProxy::Proxy->new(
     undef,

--- a/test/recipes/70-test_tls13hrr.t
+++ b/test/recipes/70-test_tls13hrr.t
@@ -11,6 +11,7 @@ use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
 use TLSProxy::Message;
+use Cwd qw(abs_path);
 
 my $test_name = "test_tls13hrr";
 setup($test_name);
@@ -18,14 +19,16 @@ setup($test_name);
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");
 
 plan skip_all => "$test_name needs TLS1.3 enabled"
     if disabled("tls1_3") || (disabled("ec") && disabled("dh"));
+
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
 
 my $proxy = TLSProxy::Proxy->new(
     undef,

--- a/test/recipes/70-test_tls13kexmodes.t
+++ b/test/recipes/70-test_tls13kexmodes.t
@@ -12,6 +12,7 @@ use OpenSSL::Test::Utils;
 use File::Temp qw(tempfile);
 use TLSProxy::Proxy;
 use checkhandshake qw(checkhandshake @handmessages @extensions);
+use Cwd qw(abs_path);
 
 my $test_name = "test_tls13kexmodes";
 setup($test_name);
@@ -19,8 +20,8 @@ setup($test_name);
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");
@@ -183,6 +184,8 @@ use constant {
     UNKNOWN_KEX_MODES => 4,
     BOTH_KEX_MODES => 5
 };
+
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
 
 my $proxy = TLSProxy::Proxy->new(
     undef,

--- a/test/recipes/70-test_tls13messages.t
+++ b/test/recipes/70-test_tls13messages.t
@@ -12,6 +12,7 @@ use OpenSSL::Test::Utils;
 use File::Temp qw(tempfile);
 use TLSProxy::Proxy;
 use checkhandshake qw(checkhandshake @handmessages @extensions);
+use Cwd qw(abs_path);
 
 my $test_name = "test_tls13messages";
 setup($test_name);
@@ -19,8 +20,8 @@ setup($test_name);
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");
@@ -198,6 +199,8 @@ plan skip_all => "$test_name needs EC enabled"
 
     [0,0,0,0]
 );
+
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
 
 my $proxy = TLSProxy::Proxy->new(
     undef,

--- a/test/recipes/70-test_tls13psk.t
+++ b/test/recipes/70-test_tls13psk.t
@@ -11,6 +11,7 @@ use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file srctop_dir bldtop_dir/;
 use OpenSSL::Test::Utils;
 use File::Temp qw(tempfile);
 use TLSProxy::Proxy;
+use Cwd qw(abs_path);
 
 my $test_name = "test_tls13psk";
 setup($test_name);
@@ -18,14 +19,16 @@ setup($test_name);
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");
 
 plan skip_all => "$test_name needs TLSv1.3 enabled"
     if disabled("tls1_3") || (disabled("ec") && disabled("dh"));
+
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
 
 my $proxy = TLSProxy::Proxy->new(
     undef,

--- a/test/recipes/70-test_tlsextms.t
+++ b/test/recipes/70-test_tlsextms.t
@@ -11,6 +11,7 @@ use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils;
 use TLSProxy::Proxy;
 use File::Temp qw(tempfile);
+use Cwd qw(abs_path);
 
 my $test_name = "test_tlsextms";
 setup($test_name);
@@ -18,8 +19,8 @@ setup($test_name);
 plan skip_all => "TLSProxy isn't usable on $^O"
     if $^O =~ /^(VMS)$/;
 
-plan skip_all => "$test_name needs the dynamic engine feature enabled"
-    if disabled("engine") || disabled("dynamic-engine");
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
 
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");
@@ -36,6 +37,8 @@ my $srmextms = 0;
 my $cextms = 0;
 my $sextms = 0;
 my $fullhand = 0;
+
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
 
 my $proxy = TLSProxy::Proxy->new(
     \&extms_filter,

--- a/test/recipes/81-test_cmp_cli.t
+++ b/test/recipes/81-test_cmp_cli.t
@@ -48,12 +48,6 @@ my @cmp_server_tests = (
     [ "with polling",             [ "-poll_count", "1"       ], 1 ]
     );
 
-# loader_attic doesn't build on VMS, so we don't test it
-push @cmp_server_tests, (
-    [ "with loader_attic engine", [ "-engine", "loader_attic"], 1 ]
-    )
-    unless disabled('loadereng');
-
 plan tests => @cmp_basic_tests + @cmp_server_tests;
 
 foreach (@cmp_basic_tests) {

--- a/test/recipes/90-test_store.t
+++ b/test/recipes/90-test_store.t
@@ -97,7 +97,6 @@ my @noexist_file_files =
 
 # There is more than one method to get a 'file:' loader.
 # The default is a built-in provider implementation.
-# However, there is also an engine, specially for testing purposes.
 #
 # @methods is a collection of extra 'openssl storeutl' arguments used to
 # try the different methods.
@@ -105,8 +104,6 @@ my @methods;
 my @prov_method = qw(-provider default);
 push @prov_method, qw(-provider legacy) unless disabled('legacy');
 push @methods, [ @prov_method ];
-push @methods, [qw(-engine loader_attic)]
-    unless disabled('loadereng');
 
 my $n = 4 + scalar @methods
     * ( (3 * scalar @noexist_files)
@@ -117,17 +114,6 @@ my $n = 4 + scalar @methods
         + (scalar @noexist_file_files)
         + 3
         + 11 );
-
-# Test doesn't work under msys because the file name munging doesn't work
-# correctly with the "ot:" prefix
-my $do_test_ossltest_store =
-    !(disabled("engine") || disabled("dynamic-engine") || $^O =~ /^msys$/);
-
-if ($do_test_ossltest_store) {
-    # test loading with apps 'org.openssl.engine:' loader, using the
-    # ossltest engine.
-    $n += 4 * scalar @src_rsa_files;
-}
 
 plan skip_all => "No plan" if $n == 0;
 
@@ -142,32 +128,6 @@ ok(!run(app(["openssl", "storeutl", $test_x509, "-crls"])),
    "storeutil with extra parameter (at end) should fail");
 
 indir "store_$$" => sub {
-    if ($do_test_ossltest_store) {
-        # ossltest loads PEM files, with names prefixed with 'ot:'.
-        # This prefix ensures that the files are, in fact, loaded through
-        # that engine and not mistakenly going through the 'file:' loader.
-
-        my $engine_scheme = 'org.openssl.engine:';
-        $ENV{OPENSSL_ENGINES} = bldtop_dir("engines");
-
-        foreach (@src_rsa_files) {
-            my $file = srctop_file($_);
-            my $file_abs = to_abs_file($file);
-            my @pubin = $_ =~ m|pub\.pem$| ? ("-pubin") : ();
-
-            ok(run(app(["openssl", "rsa", "-text", "-noout", @pubin,
-                        "-engine", "ossltest", "-inform", "engine",
-                        "-in", "ot:$file"])));
-            ok(run(app(["openssl", "rsa", "-text", "-noout", @pubin,
-                        "-engine", "ossltest", "-inform", "engine",
-                        "-in", "ot:$file_abs"])));
-            ok(run(app(["openssl", "rsa", "-text", "-noout", @pubin,
-                        "-in", "${engine_scheme}ossltest:ot:$file"])));
-            ok(run(app(["openssl", "rsa", "-text", "-noout", @pubin,
-                        "-in", "${engine_scheme}ossltest:ot:$file_abs"])));
-        }
-    }
-
  SKIP:
     {
         init() or die "init failed";

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -424,7 +424,7 @@ sub clientstart
         my $pid;
         my $execcmd = $self->execute
              ." s_client -provider=p_ossltest -provider=default -propquery ?provider=p_ossltest"
-             ." -keylogfile ./keys.log -connect $self->{proxy_addr}:$self->{proxy_port}";
+             ." -connect $self->{proxy_addr}:$self->{proxy_port}";
         if ($self->{isdtls}) {
             $execcmd .= " -dtls -max_protocol DTLSv1.2"
                         # TLSProxy does not support message fragmentation. So

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -318,7 +318,7 @@ sub start
     }
 
     my $execcmd = $self->execute
-        ." s_server -no_comp -engine ossltest -state"
+        ." s_server -no_comp -provider=p_ossltest -provider=default -propquery ?provider=p_ossltest -state"
         #In TLSv1.3 we issue two session tickets. The default session id
         #callback gets confused because the ossltest engine causes the same
         #session id to be created twice due to the changed random number
@@ -423,8 +423,8 @@ sub clientstart
     if ($self->execute) {
         my $pid;
         my $execcmd = $self->execute
-             ." s_client -engine ossltest"
-             ." -connect $self->{proxy_addr}:$self->{proxy_port}";
+             ." s_client -provider=p_ossltest -provider=default -propquery ?provider=p_ossltest"
+             ." -keylogfile ./keys.log -connect $self->{proxy_addr}:$self->{proxy_port}";
         if ($self->{isdtls}) {
             $execcmd .= " -dtls -max_protocol DTLSv1.2"
                         # TLSProxy does not support message fragmentation. So


### PR DESCRIPTION
Replace the ossltest engine with a provider

As part of our effort to remove support for ENGINES in openssl, we have to remove the ossltest engine.  This engine is the core of several of our unit tests (the TLSProxy code relies on its, and in turn most/all of our tls unit tests rely on TLSProxy). 

As such, to preserve the ability to run those tests we need to re-create all the algorithms that the ossltest engine implements as a provider.  Note all of these algorithms are dummy versions of algorithms in the default provider that instead return known/predictable data for the purposes of testing (hence our need to re-implement them rather than just use those in the default provider)

This PR does the following:
1) Creates a provider that implements:
    a) AES-128-CBC, AES-128-GCM and AES-128-CBC-HMAC-SHA1 ciphers
    b) MD5, SHA1, SHA256, SHA384 and SHA512 message digests
    c) The CTR-DRBG random number generator

2) Replaces the use of the ossltest engine with the provider in (1) in TLSProxy.pm

3) Updates all the dependent tests to set OPENSSL_MODULES to the test dir so that the provider can be found

4) Removes the gating of the tests in (3) such that the tests are no longer skipped if engines aren't enabled

5) Updates the test_rand and test_dgst methods to directly use this provider rather than the ossltest engine

6) Removes tests that rely on the loader_attic (which is typically used with ossltest) as, based on input from @levitte we have a default provider which implement the file:store loader, making these test effectively redundant.

##### Checklist
- [x] tests are added or updated
