### PR TITLE
mem_alloc_test: Remove 'for' loop initial declaration

### DIFF
--- a/test/mem_alloc_test.c
+++ b/test/mem_alloc_test.c
@@ -249,6 +249,7 @@ static void my_free(void * const addr, const char * const file, const int line)
 static bool check_zero_mem(char *p, size_t sz)
 {
     size_t i;
+
     for (i = 0; i < sz; i++) {
         if (p[i] != 0) {
             TEST_error("Non-zero byte %zu of %zu (%#04hhx)", i, sz, p[i]);


### PR DESCRIPTION
Fix compiler error: 'for' loop initial declarations are only allowed in C99 mode.

Trivial change.
