### PR TITLE
`25-test_verify.t`: fix misleading test case names and file variable name

### DIFF
--- a/test/recipes/25-test_verify.t
+++ b/test/recipes/25-test_verify.t
@@ -607,13 +607,15 @@ SKIP: {
         if $^O =~ /^(MsWin32|VMS)$/;
     my $foo_file = "foo:cert.pem";
     copy($rootcert, $foo_file);
-    ok(vfy_root("-CAstore", $foo_file), "CAstore foo:file");
-    ok(vfy_root("-CAstore", "file:".$foo_file), "CAstore file:foo:file");
+    ok(vfy_root("-CAstore", $foo_file), "CAstore foo:cert.pem");
+    ok(vfy_root("-CAstore", "file:".$foo_file), "CAstore file:foo:cert.pem");
 }
-my $foo_file = "cert.pem";
-copy($rootcert, $foo_file);
-ok(vfy_root("-CAstore", $foo_file), "CAstore foo:file");
-ok(vfy_root("-CAstore", "file:".$foo_file), "CAstore file:foo:file");
+
+my $file = "cert.pem";
+copy($rootcert, $file);
+ok(vfy_root("-CAstore", $file), "CAstore cert.pem");
+ok(vfy_root("-CAstore", "file:".$file), "CAstore file:cert.pem");
+
 my $abs_cert = abs_path($rootcert);
 # Windows file: URIs should have a path part starting with a slash, i.e.
 # file://authority/C:/what/ever/foo.pem and file:///C:/what/ever/foo.pem


### PR DESCRIPTION
This just fixes misleading test case names and a file variable name,
which recently came up [further discussing #27984](https://github.com/openssl/openssl/issues/27984#issuecomment-3257294835).
BTW, that discussion was tedious and did not bring up any further points to fix here.
