### PR TITLE
APPS: small fixes on `load_*` functions

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -767,6 +767,16 @@ static int set_verbosity(int level)
     return 1;
 }
 
+static EVP_PKEY *load_pubkey_pwd(const char *uri, int format,
+                                 const char *source, ENGINE *eng, const char *desc)
+{
+    char *pass = get_passwd(source, desc);
+    EVP_PKEY *pkey = load_pubkey(uri, format, 0, pass, eng, desc);
+
+    clear_free(pass);
+    return pkey;
+}
+
 static EVP_PKEY *load_key_pwd(const char *uri, int format,
                               const char *source, ENGINE *eng, const char *desc)
 {
@@ -1876,7 +1886,7 @@ static int setup_request_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
             desc = opt_csr == NULL
                 ? "fallback public key for cert to be enrolled"
                 : "public key for checking cert resulting from p10cr";
-            pkey = load_pubkey(file, format, 0, pass, engine, desc);
+            pkey = load_pubkey_pwd(file, format, pass, engine, desc);
             priv = 0;
         }
 

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -768,22 +768,21 @@ static int set_verbosity(int level)
 }
 
 static EVP_PKEY *load_key_pwd(const char *uri, int format,
-                              const char *pass, ENGINE *eng, const char *desc)
+                              const char *source, ENGINE *eng, const char *desc)
 {
-    char *pass_string = get_passwd(pass, desc);
-    EVP_PKEY *pkey = load_key(uri, format, 0, pass_string, eng, desc);
+    char *pass = get_passwd(source, desc);
+    EVP_PKEY *pkey = load_key(uri, format, 0, pass, eng, desc);
 
-    clear_free(pass_string);
+    clear_free(pass);
     return pkey;
 }
 
-static X509 *load_cert_pwd(const char *uri, const char *pass, const char *desc)
+static X509 *load_cert_pwd(const char *uri, const char *source, const char *desc)
 {
-    X509 *cert;
-    char *pass_string = get_passwd(pass, desc);
+    char *pass = get_passwd(source, desc);
+    X509 *cert = load_cert_pass(uri, FORMAT_UNDEF, 0, pass, desc);
 
-    cert = load_cert_pass(uri, FORMAT_UNDEF, 0, pass_string, desc);
-    clear_free(pass_string);
+    clear_free(pass);
     return cert;
 }
 

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -144,9 +144,9 @@ int load_cert_certs(const char *uri,
                     X509 **pcert, STACK_OF(X509) **pcerts,
                     int exclude_http, const char *pass, const char *desc,
                     X509_VERIFY_PARAM *vpm);
-STACK_OF(X509) *load_certs_multifile(char *files, const char *pass,
+STACK_OF(X509) *load_certs_multifile(char *files, const char *source,
                                      const char *desc, X509_VERIFY_PARAM *vpm);
-X509_STORE *load_certstore(char *input, const char *pass, const char *desc,
+X509_STORE *load_certstore(char *input, const char *source, const char *desc,
                            X509_VERIFY_PARAM *vpm);
 int load_certs(const char *uri, int maybe_stdin, STACK_OF(X509) **certs,
                const char *pass, const char *desc);

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -957,7 +957,7 @@ int load_key_certs_crls(const char *uri, int format, int maybe_stdin,
                         X509 **pcert, STACK_OF(X509) **pcerts,
                         X509_CRL **pcrl, STACK_OF(X509_CRL) **pcrls)
 {
-    PW_CB_DATA uidata;
+    PW_CB_DATA uidata = { pass, uri };
     OSSL_STORE_CTX *ctx = NULL;
     OSSL_LIB_CTX *libctx = app_get0_libctx();
     const char *propq = app_get0_propq();
@@ -1015,9 +1015,6 @@ int load_key_certs_crls(const char *uri, int format, int maybe_stdin,
          */
         SET_EXPECT(OSSL_STORE_INFO_CRL);
     }
-
-    uidata.password = pass;
-    uidata.prompt_info = uri;
 
     if ((input_type = format2string(format)) != NULL) {
         itp[0] = OSSL_PARAM_construct_utf8_string(OSSL_STORE_PARAM_INPUT_TYPE,
@@ -1154,7 +1151,7 @@ int load_key_certs_crls(const char *uri, int format, int maybe_stdin,
             pcrls = NULL;
         failed = FAIL_NAME;
         if (failed != NULL && !quiet)
-            BIO_printf(bio_err, "Could not find");
+            BIO_printf(bio_err, "Could not find or decode");
     }
 
     if (failed != NULL && !quiet) {

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -785,9 +785,10 @@ int load_cert_certs(const char *uri,
     return ret;
 }
 
-STACK_OF(X509) *load_certs_multifile(char *files, const char *pass,
+STACK_OF(X509) *load_certs_multifile(char *files, const char *source,
                                      const char *desc, X509_VERIFY_PARAM *vpm)
 {
+    char *pass = get_passwd(source, desc);
     STACK_OF(X509) *certs = NULL;
     STACK_OF(X509) *result = sk_X509_new_null();
 
@@ -808,11 +809,13 @@ STACK_OF(X509) *load_certs_multifile(char *files, const char *pass,
         certs = NULL;
         files = next;
     }
+    clear_free(pass);
     return result;
 
  oom:
     BIO_printf(bio_err, "out of memory\n");
  err:
+    clear_free(pass);
     OSSL_STACK_OF_X509_free(certs);
     OSSL_STACK_OF_X509_free(result);
     return NULL;
@@ -840,9 +843,10 @@ static X509_STORE *sk_X509_to_store(X509_STORE *store /* may be NULL */,
  * Create cert store structure with certificates read from given file(s).
  * Returns pointer to created X509_STORE on success, NULL on error.
  */
-X509_STORE *load_certstore(char *input, const char *pass, const char *desc,
+X509_STORE *load_certstore(char *input, const char *source, const char *desc,
                            X509_VERIFY_PARAM *vpm)
 {
+    char *pass = get_passwd(source, desc);
     X509_STORE *store = NULL;
     STACK_OF(X509) *certs = NULL;
 
@@ -852,15 +856,19 @@ X509_STORE *load_certstore(char *input, const char *pass, const char *desc,
 
         if (!load_cert_certs(input, NULL, &certs, 1, pass, desc, vpm)) {
             X509_STORE_free(store);
-            return NULL;
+            store = NULL;
+            goto end;
         }
         ok = (store = sk_X509_to_store(store, certs)) != NULL;
         OSSL_STACK_OF_X509_free(certs);
         certs = NULL;
         if (!ok)
-            return NULL;
+            goto end;
         input = next;
     }
+
+ end:
+    clear_free(pass);
     return store;
 }
 


### PR DESCRIPTION
* fix `load_certs_multifile()` and `load_certstore()` w.r.t. password source vs. actual password
* `load_key_certs_crls()`: refactor `uidata` use and tweak error message


