### PR TITLE
Add one more trace message to the torture_rcu_high test

### DIFF
--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -321,7 +321,8 @@ static void writer_fn(int id, int *iterations)
     t1 = ossl_time_now();
 
     for (count = 0; ; count++) {
-        new = CRYPTO_zalloc(sizeof(uint64_t), NULL, 0);
+        new = CRYPTO_malloc(sizeof(uint64_t), NULL, 0);
+        *new = (uint64_t)0xBAD;
         if (contention == 0)
             OSSL_sleep(1000);
         ossl_rcu_write_lock(rcu_lock);
@@ -387,6 +388,8 @@ static void reader_fn(int *iterations)
 
         if (oldval > val) {
             TEST_info("rcu torture value went backwards! %llu : %llu", (unsigned long long)oldval, (unsigned long long)val);
+            if (valp == NULL)
+                TEST_info("ossl_rcu_deref did return NULL!");
             rcu_torture_result = 0;
         }
         oldval = val; /* just try to deref the pointer */


### PR DESCRIPTION
It is interesting that in the very rare cases, where this test failure has been observed so far, the rcu torture value went always backwards to 0.  This could be either due to ossl_rcu_deref(&writer_ptr) returning NULL, or the initial value of "new = CRYPTO_zalloc(sizeof(uint64_t), NULL, 0)" still visible despite ossl_rcu_assign_ptr(&writer_ptr, &new) immediatley after the "*new = global_ctr++" statement. Add one additional trace message to find out what exactly happens here, when it happens again.

Related to #27267

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
