### PR TITLE
Don't modify the provider store when finding a provider.

### DIFF
--- a/crypto/stack/stack.c
+++ b/crypto/stack/stack.c
@@ -279,14 +279,25 @@ int OPENSSL_sk_insert(OPENSSL_STACK *st, const void *data, int loc)
         return 0;
 
     if ((loc >= st->num) || (loc < 0)) {
-        st->data[st->num] = data;
+        loc = st->num;
+        st->data[loc] = data;
     } else {
         memmove(&st->data[loc + 1], &st->data[loc],
                 sizeof(st->data[0]) * (st->num - loc));
         st->data[loc] = data;
     }
     st->num++;
-    st->sorted = 0;
+    if (st->sorted && st->num > 1) {
+        if (st->comp != NULL) {
+            if (loc > 0 && (st->comp(&st->data[loc - 1], &st->data[loc]) > 0))
+                st->sorted = 0;
+            if (loc < st->num - 1
+                && (st->comp(&st->data[loc + 1], &st->data[loc]) < 0))
+                st->sorted = 0;
+        } else {
+            st->sorted = 0;
+        }
+    }
     return st->num;
 }
 

--- a/test/stack_test.c
+++ b/test/stack_test.c
@@ -158,6 +158,29 @@ static int test_int_stack(int reserve)
             goto end;
         }
 
+    if (!TEST_true(sk_sint_is_sorted(s)))
+        goto end;
+
+    for (i = 0; i < n_exfinds; i++) {
+        int loc = sk_sint_find_ex(s, &exfinds[i].value);
+        int value = *sk_sint_value(s, loc);
+        /* inserting in the correct location should preserve is_sorted */
+        if (value < exfinds[i].value)
+            loc++;
+        sk_sint_insert(s, &exfinds[i].value, loc);
+        if (!TEST_true(sk_sint_is_sorted(s)))
+            goto end;
+    }
+
+    if (!TEST_true(sk_sint_is_sorted(s)))
+        goto end;
+
+    /* inserting out of order should make the array unsorted again */
+    sk_sint_insert(s, v + 6, 0);
+
+    if (!TEST_false(sk_sint_is_sorted(s)))
+        goto end;
+
     /* shift */
     if (!TEST_ptr_eq(sk_sint_shift(s), v + 6))
         goto end;


### PR DESCRIPTION
Providers are currently kept in the provider store based upon a sorted STACK_OF providers. They are found with sk_OSSL_PROVIDER_find.

We take a write lock on the store every time we find one, because we sort store->providers before searching, every time.

Meanwhile, the only places we add providers to store->providers, we already have the store lock held for write. This change sorts the provider list upon the add of a provider, rather than sorting it every time you look one up. While yes, sorting a sorted stack_of is basically free, the write lock is potentially costly. We potentially do more sorting work in total by sorting the provider list on each add, but presumably we have many more finds than adds, and this list should still be relatively small.

This allows find (which is basically a read operation) to not potentially modify the store, so it need only take a read lock.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
