### PR TITLE
Doc changes: the -hmac-env and -hmac-stdin options of openssl-dgst will appear in version 4.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,9 @@ OpenSSL 4.0
 
 ### Changes between 3.6 and 4.0 [xx XXX xxxx]
 
- * none yet
+ * Added `-hmac-env` and `-hmac-stdin` options to openssl-dgst.
+
+   *Igor Ustinov*
 
 OpenSSL 3.6
 -----------

--- a/doc/man1/openssl-dgst.pod.in
+++ b/doc/man1/openssl-dgst.pod.in
@@ -343,7 +343,7 @@ The FIPS-related options were removed in OpenSSL 1.1.0.
 
 The B<-engine> and B<-engine_impl> options were deprecated in OpenSSL 3.0.
 
-The B<-hmac-env> and B<-hmac-stdin> options ware added in OpenSSL 3.6.
+The B<-hmac-env> and B<-hmac-stdin> options were added in OpenSSL 4.0.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
This pull request is an addition to the pull request https://github.com/openssl/openssl/pull/28160: as the changes of that PR will appear in version 4.0, the corresponding changes to the documentation were made.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
