### PR TITLE
Bypass ucontext.h include for HPE NonStop (3.0)

### DIFF
--- a/crypto/async/arch/async_posix.h
+++ b/crypto/async/arch/async_posix.h
@@ -13,7 +13,8 @@
 
 #if defined(OPENSSL_SYS_UNIX) \
     && defined(OPENSSL_THREADS) && !defined(OPENSSL_NO_ASYNC) \
-    && !defined(__ANDROID__) && !defined(__OpenBSD__)
+    && !defined(__ANDROID__) && !defined(__OpenBSD__) \
+    && !defined(OPENSSL_SYS_TANDEM)
 
 # include <unistd.h>
 
@@ -48,7 +49,11 @@
  */
 #   define USE_SWAPCONTEXT
 #  endif
-#  include <ucontext.h>
+#  if defined (OPENSSL_SYS_TANDEM)
+#   include <tdmsig.h>
+#  else
+#   include <ucontext.h>
+#  endif
 #  ifndef USE_SWAPCONTEXT
 #   include <setjmp.h>
 #  endif


### PR DESCRIPTION
Fixes: #28459