### PR TITLE
Change HPE NonStop PUT configuration to explicitly not use secure memory (3.0)

### DIFF
--- a/Configurations/50-nonstop.conf
+++ b/Configurations/50-nonstop.conf
@@ -167,12 +167,14 @@
     # Build models
     'nonstop-model-put' => {
         template         => 1,
+        disable          => [ 'secure-memory' ],
         defines          => ['_PUT_MODEL_',
                              '_REENTRANT', '_THREAD_SUPPORT_FUNCTIONS'],
         ex_libs          => '-lput',
     },
     'nonstop-model-spt' => {
         template         => 1,
+        disable          => [ 'secure-memory' ],
         defines          => ['_SPT_MODEL_',
                              '_REENTRANT', '_ENABLE_FLOSS_THREADS'],
         ex_libs          => '-lspt',


### PR DESCRIPTION
Fixes: #28498
