### PR TITLE
Revert #28193 and work around OSSL_sleep()'s uselessness

### DIFF
--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -385,7 +385,7 @@ void CRYPTO_clear_free(void *str, size_t num, const char *file, int line)
 {
     if (str == NULL)
         return;
-    if (num)
+    if (num != 0)
         OPENSSL_cleanse(str, num);
     CRYPTO_free(str, file, line);
 }

--- a/ssl/quic/quic_rstream.c
+++ b/ssl/quic/quic_rstream.c
@@ -95,7 +95,7 @@ static int read_internal(QUIC_RSTREAM *qrs, unsigned char *buf, size_t size,
             break;
 
         if (data == NULL) {
-            size_t max_len;
+            size_t max_len = 0;
 
             data = ring_buf_get_ptr(&qrs->rbuf, range.start, &max_len);
             if (!ossl_assert(data != NULL))
@@ -193,7 +193,7 @@ int ossl_quic_rstream_get_record(QUIC_RSTREAM *qrs,
                                  int *fin)
 {
     const unsigned char *record_ = NULL;
-    size_t rec_len_, max_len;
+    size_t rec_len_, max_len = 0;
 
     if (!ossl_sframe_list_lock_head(&qrs->fl, &qrs->head_range, &record_, fin)) {
         /* No head frame to lock and return */

--- a/test/build.info
+++ b/test/build.info
@@ -23,6 +23,7 @@ IF[{- !$disabled{uplink} -}]
   $INITSRC=../ms/applink.c
 ENDIF
 $LIBAPPSSRC=../apps/lib/opt.c $AUXLIBAPPSSRC
+$LIBCRYPTOSRC=../crypto/time.c
 
 IF[{- !$disabled{tests} -}]
   LIBS{noinst,has_main}=libtestutil.a
@@ -31,7 +32,8 @@ IF[{- !$disabled{tests} -}]
           testutil/format_output.c testutil/load.c testutil/fake_random.c \
           testutil/test_cleanup.c testutil/main.c testutil/testutil_init.c \
           testutil/options.c testutil/test_options.c testutil/provider.c \
-          testutil/apps_shims.c testutil/random.c testutil/helper.c $LIBAPPSSRC
+          testutil/apps_shims.c testutil/random.c testutil/helper.c \
+          $LIBAPPSSRC $LIBCRYPTOSRC
   INCLUDE[libtestutil.a]=../include ../apps/include ..
   DEPEND[libtestutil.a]=../libcrypto
 

--- a/test/radix/quic_ops.c
+++ b/test/radix/quic_ops.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 #include "internal/sockets.h"
+#include "internal/time.h"
 #include <openssl/rand.h>
 
 static const unsigned char alpn_ossltest[] = {
@@ -1023,7 +1024,23 @@ DEF_FUNC(hf_sleep)
 
     F_POP(ms);
 
-    OSSL_sleep(ms);
+    /*
+     * We cannot rely on the fact that OSSL_sleep() delays
+     * for the requested amount of time, as it is prohibited
+     * to do so, so we have to call it in loop until
+     * the needed time is passed.
+     */
+    {
+        OSSL_TIME now = ossl_time_now();
+        OSSL_TIME finish = ossl_time_add(now, ossl_ms2time(ms));
+        uint64_t left = ms;
+
+        do {
+            OSSL_sleep(left);
+            now = ossl_time_now();
+            left = ossl_time2ms(ossl_time_subtract(finish, now));
+        } while (ossl_time_compare(now, finish) <= 0);
+    }
 
     ok = 1;
 err:

--- a/test/sanitytest.c
+++ b/test/sanitytest.c
@@ -13,10 +13,6 @@
 #include "internal/numbers.h"
 #include "internal/time.h"
 
-#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
-# include <signal.h>
-#endif
-
 static int test_sanity_null_zero(void)
 {
     char *p;
@@ -134,74 +130,22 @@ static int test_sanity_memcmp(void)
     return CRYPTO_memcmp("ab", "cd", 2);
 }
 
-static const struct sleep_test_vector {
-    uint64_t val;
-} sleep_test_vectors[] = { { 0 }, { 1 }, { 999 }, { 1000 } };
-
-#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
-static void
-alrm_handler(int sig)
+static int test_sanity_sleep(void)
 {
-}
-#endif /* defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L */
-
-static int test_sanity_sleep(int i)
-{
-    const struct sleep_test_vector * const td = sleep_test_vectors + i;
     OSSL_TIME start = ossl_time_now();
-    uint64_t ms;
-
-#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
-    /*
-     * Set up an interrupt timer to check that OSSL_sleep doesn't return early
-     * due to interrupts.
-     */
-    do {
-        static const struct sigaction sa = { .sa_handler = alrm_handler };
-        static const struct itimerval it = { .it_value.tv_usec = 111111 };
-        sigset_t mask;
-
-        if (sigaction(SIGALRM, &sa, NULL)) {
-            TEST_perror("test_sanity_sleep: sigaction");
-            break;
-        }
-
-        sigemptyset(&mask);
-        sigaddset(&mask, SIGALRM);
-        if (sigprocmask(SIG_UNBLOCK, &mask, NULL)) {
-            TEST_perror("test_sanity_sleep: sigprocmask");
-            break;
-        }
-
-        if (setitimer(ITIMER_REAL, &it, NULL)) {
-            TEST_perror("test_sanity_sleep: arm setitimer");
-            break;
-        }
-    } while (0);
-#endif /* defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L */
+    uint64_t seconds;
 
     /*
-     * On any reasonable system this must sleep at least the specified time
-     * but not more than 20 seconds more than that.
+     * On any reasonable system this must sleep at least one second
+     * but not more than 20.
+     * Assuming there is no interruption.
      */
-    OSSL_sleep(td->val);
+    OSSL_sleep(1000);
 
-#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
-    /* disarm the timer */
-    do {
-        static const struct itimerval it;
+    seconds = ossl_time2seconds(ossl_time_subtract(ossl_time_now(), start));
 
-        if (setitimer(ITIMER_REAL, &it, NULL)) {
-            TEST_perror("test_sanity_sleep: disarm setitimer");
-            break;
-        }
-    } while (0);
-#endif /* defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L */
-
-    ms = ossl_time2ms(ossl_time_subtract(ossl_time_now(), start));
-
-    if (!TEST_uint64_t_ge(ms, td->val) + !TEST_uint64_t_le(ms, td->val + 20000))
-        return 0;
+    if (!TEST_uint64_t_ge(seconds, 1) || !TEST_uint64_t_le(seconds, 20))
+       return 0;
     return 1;
 }
 
@@ -214,6 +158,6 @@ int setup_tests(void)
     ADD_TEST(test_sanity_unsigned_conversion);
     ADD_TEST(test_sanity_range);
     ADD_TEST(test_sanity_memcmp);
-    ADD_ALL_TESTS(test_sanity_sleep, OSSL_NELEM(sleep_test_vectors));
+    ADD_TEST(test_sanity_sleep);
     return 1;
 }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -200,7 +200,7 @@ static int compare_hex_encoded_buffer(const char *hex_encoded,
         return 1;
 
     for (i = j = 0; i < raw_length && j + 1 < hex_length; i++, j += 2) {
-        BIO_snprintf(hexed, sizeof(hexed), "%02x", raw[i]);
+        BIO_snprintf(hexed, sizeof(hexed), "%02hhx", raw[i]);
         if (!TEST_int_eq(hexed[0], hex_encoded[j])
                 || !TEST_int_eq(hexed[1], hex_encoded[j + 1]))
             return 1;

--- a/test/testutil/provider.c
+++ b/test/testutil/provider.c
@@ -171,7 +171,7 @@ int fips_provider_version_ge(OSSL_LIB_CTX *libctx, int major, int minor, int pat
 int fips_provider_version_match(OSSL_LIB_CTX *libctx, const char *versions)
 {
     const char *p;
-    int major, minor, patch, r;
+    int major, minor, patch, r = -1;
     enum {
         MODE_EQ, MODE_NE, MODE_LE, MODE_LT, MODE_GT, MODE_GE
     } mode;


### PR DESCRIPTION
Per @levitte's suggestion[1], restoring `OSSL_sleep()`'s behaviour to its useless pre-#28193 state, which also means that every call site that expects that the requested delay is honored has to implement the waiting routine by itself.

[1] https://github.com/openssl/openssl/pull/28507#issuecomment-3278567065

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
