### PR TITLE
Update our CI jobs to cover the 3.6 stable branch

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -17,30 +17,50 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['3.6', '3.5', '3.4', '3.3', '3.2', '3.0']
+        release: [
+          {
+            branch: '3.6',
+            cppflags: ''
+          }, {
+            branch: '3.5',
+            cppflags: 'CPPFLAGS=-ansi'
+          }, {
+            branch: '3.4',
+            cppflags: 'CPPFLAGS=-ansi'
+          }, {
+            branch: '3.3',
+            cppflags: 'CPPFLAGS=-ansi',
+          }, {
+            branch: '3.2',
+            cppflags: 'CPPFLAGS=-ansi'
+          }, {
+            branch: '3.0',
+            cppflags: 'CPPFLAGS=-ansi'
+          }
+        ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      if: ${{ contains(join(github.event.pull_request.labels.*.name,','),matrix.branch) }}
+      if: ${{ contains(join(github.event.pull_request.labels.*.name,','),matrix.release.branch) }}
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
     - name: cherry-pick
-      if: ${{ contains(join(github.event.pull_request.labels.*.name,','),matrix.branch) }}
+      if: ${{ contains(join(github.event.pull_request.labels.*.name,','),matrix.release.branch) }}
       run: |
            REFEND=$(git rev-parse HEAD)
            REFSTART=$(git rev-parse $REFEND~${{ github.event.pull_request.commits }})
-           git checkout ${{ format('openssl-{0}', matrix.branch) }}
+           git checkout ${{ format('openssl-{0}', matrix.release.branch) }}
            git config user.name "OpenSSL Machine"
            git config user.email "openssl-machine@openssl.org"
            echo Cherry-picking $REFSTART..$REFEND
            git cherry-pick $REFSTART..$REFEND
     - name: config
-      if: ${{ contains(join(github.event.pull_request.labels.*.name,','),matrix.branch) }}
-      run: CPPFLAGS=-ansi ./config --strict-warnings --banner=Configured no-asm enable-fips --strict-warnings -D_DEFAULT_SOURCE && perl configdata.pm --dump
+      if: ${{ contains(join(github.event.pull_request.labels.*.name,','),matrix.release.branch) }}
+      run: ${{ matrix.release.cppflags }} ./config --strict-warnings --banner=Configured no-asm enable-fips --strict-warnings -D_DEFAULT_SOURCE && perl configdata.pm --dump
     - name: make
-      if: ${{ contains(join(github.event.pull_request.labels.*.name,','),matrix.branch) }}
+      if: ${{ contains(join(github.event.pull_request.labels.*.name,','),matrix.release.branch) }}
       run: make -s -j4
     - name: make test
-      if: ${{ contains(join(github.event.pull_request.labels.*.name,','),matrix.branch) }}
+      if: ${{ contains(join(github.event.pull_request.labels.*.name,','),matrix.release.branch) }}
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['3.5', '3.4', '3.3', '3.2', '3.0']
+        branch: ['3.6', '3.5', '3.4', '3.3', '3.2', '3.0']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -43,6 +43,9 @@ jobs:
           else
           MATRIX=$(cat << EOF
           [{
+              "branch": "openssl-3.6",
+              "extra_config": "no-afalgeng enable-fips enable-tfo"
+            },{
               "branch": "openssl-3.5",
               "extra_config": "no-afalgeng enable-fips enable-tfo"
             },{

--- a/.github/workflows/prov-compat-label.yml
+++ b/.github/workflows/prov-compat-label.yml
@@ -130,6 +130,10 @@ jobs:
             dir: branch-3.5,
             tgz: branch-3.5.tar.gz,
           }, {
+            name: openssl-3.6,
+            dir: branch-3.6,
+            tgz: branch-3.6.tar.gz,
+          }, {
             name: master,
             dir: branch-master,
             tgz: branch-master.tar.gz,

--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -138,6 +138,11 @@ jobs:
             tgz: branch-3.5.tar.gz,
             extra_config: "",
           }, {
+            name: openssl-3.6,
+            dir: branch-3.6,
+            tgz: branch-3.6.tar.gz,
+            extra_config: "",
+          }, {
             name: master,
             dir: branch-master,
             tgz: branch-master.tar.gz,

--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -214,10 +214,10 @@ jobs:
         # Note that releases are not used as a test environment for
         # later providers.  Problems in these situations ought to be
         # caught by cross branch testing before the release.
-        tree_a: [ branch-master, branch-3.5, branch-3.4, branch-3.3,
+        tree_a: [ branch-master, branch-3.6, branch-3.5, branch-3.4, branch-3.3,
                   branch-3.2, branch-3.0,
                   openssl-3.0.0, openssl-3.0.8, openssl-3.0.9, openssl-3.1.2 ]
-        tree_b: [ branch-master, branch-3.5, branch-3.4, branch-3.3,
+        tree_b: [ branch-master, branch-3.6, branch-3.5, branch-3.4, branch-3.3,
                   branch-3.2, branch-3.0  ]
     steps:
       - name: early exit checks


### PR DESCRIPTION
The coveralls, prov-compat and provider-compatibiity CI jobs test each of the stable branches.  We need to add 3.6 to the list in each of those tests

Fixes openssl/project#1424


