### PR TITLE
Fix cipher protocol ID type in docs

### DIFF
--- a/doc/man3/SSL_CIPHER_get_name.pod
+++ b/doc/man3/SSL_CIPHER_get_name.pod
@@ -37,7 +37,7 @@ SSL_CIPHER_get_protocol_id
  int SSL_CIPHER_is_aead(const SSL_CIPHER *c);
  const SSL_CIPHER *SSL_CIPHER_find(SSL *ssl, const unsigned char *ptr);
  uint32_t SSL_CIPHER_get_id(const SSL_CIPHER *c);
- uint32_t SSL_CIPHER_get_protocol_id(const SSL_CIPHER *c);
+ uint16_t SSL_CIPHER_get_protocol_id(const SSL_CIPHER *c);
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
The cipher protocol ID, the return type of `SSL_CIPHER_get_protocol_id`, is `uint16_t` and correctly described in docs to be 2 bytes, however the function signature on the same page incorrectly pointed to it being `uint32_t`, which is 4 bytes.

##### Checklist

- [x] documentation is added or updated
