### PR TITLE
FIPS 186-5 auxiliary prime length check condition updated (Fixed #28526)

### DIFF
--- a/crypto/bn/bn_rsa_fips186_4.c
+++ b/crypto/bn/bn_rsa_fips186_4.c
@@ -228,8 +228,8 @@ int ossl_bn_rsa_fips186_4_gen_prob_primes(BIGNUM *p, BIGNUM *Xpout,
     if (!bn_rsa_fips186_4_find_aux_prob_prime(Xp1i, p1i, ctx, rounds, cb)
             || !bn_rsa_fips186_4_find_aux_prob_prime(Xp2i, p2i, ctx, rounds, cb))
         goto err;
-    /* (Table B.1) auxiliary prime Max length check */
-    if ((BN_num_bits(p1i) + BN_num_bits(p2i)) >=
+    /* (Table A.1) auxiliary prime Max length check */
+    if ((BN_num_bits(p1i) + BN_num_bits(p2i)) >
             bn_rsa_fips186_5_aux_prime_max_sum_size_for_prob_primes(nlen))
         goto err;
     /* (Steps 4.3/5.3) - generate prime */


### PR DESCRIPTION
In FIPS 186-4, in table B.1, the condition for probable primes were stated using strict inequalities.
<img width="850" height="302" alt="Screenshot 2025-09-14 at 11 53 22 AM" src="https://github.com/user-attachments/assets/0e5b1538-986a-445b-903c-d3a3937a7eac" />

In FIPS 186-5, table A.1 replaces the previous table B.1 as they dropped the nlen=1024 case, and there was an update to the condition using weak inequalities.
<img width="1108" height="395" alt="Screenshot 2025-09-14 at 11 54 55 AM" src="https://github.com/user-attachments/assets/a0dccb61-401b-4cc2-ac88-16b8785edd34" />

This change directly affects the use of `bn_rsa_fips186_5_aux_prime_max_sum_size_for_prob_primes()` in `bn_rsa_fips186_4.c` which the condition for checking "failure" (lengths of auxiliary primes being too large) should use a strict inequality.

Below is the previous code using a weak inequality.
<img width="525" height="83" alt="Screenshot 2025-09-14 at 12 30 28 PM" src="https://github.com/user-attachments/assets/06c50569-c65f-431a-bc05-9df8a244c234" />

CLA: trivial



<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
