### PR TITLE
Enable LMS on provider compat fips build for 3.6

### DIFF
--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -141,7 +141,7 @@ jobs:
             name: openssl-3.6,
             dir: branch-3.6,
             tgz: branch-3.6.tar.gz,
-            extra_config: "",
+            extra_config: "enable-lms",
           }, {
             name: master,
             dir: branch-master,


### PR DESCRIPTION
The LMS test for fips assumes that LMS is available in the provider in any version equal to or later than 3.6.

We should probably augment the test such that instead of just checking the openssl version, we instead query the provider to see if the needed algs are available to use LMS.

But given the current state of affairs, it seems more sensible to just enable lms in the 3.6 fips provider build to ensure lms gets tested.

This corrects the CI failure we are seeing when the lms test is run between the master and 3.6 branches in our provider compat tests (hence the urgent label)

Fixes openssl/project#1435

