### PR TITLE
Add target configs for cross-compiling to Windows using Clang-CL and Microsoft CRT

### DIFF
--- a/Configurations/15-wincross.conf
+++ b/Configurations/15-wincross.conf
@@ -1,0 +1,55 @@
+## -*- mode: perl; -*-
+# Targets for cross-compiling to Windows (MSVC) on x86_64 or aarch64 using clang-cl
+# on a Unix-like system.
+#
+
+my %targets = (
+    "win64-cross-clang-cl" => {
+        inherit_from     => [ "VC-WIN64-common" ],
+        template         => 1,
+
+        sys_id           => "WIN64A",
+
+        build_scheme     => [ "unified", "unix" ],
+        build_file       => "Makefile",
+
+        perl_platform    => "Windows::Unix",
+        msvc_syntax      => 1,
+
+        CC               => "clang-cl",
+        cflags           => add("-fuse-ld=lld-link"),
+
+        AR               => "llvm-lib",
+        RC               => "llvm-rc",
+
+        ranlib           => "true",
+        shared_defflag   => '/def:',
+        shared_ldflag    => picker(default => "/LD /link",
+                                   debug   => "/LDd /link"),
+        shared_impflag   => '/implib:',
+
+        bin_lflags       => '/link',
+    },
+
+    "win64-x86_64-cross-clang-cl" => {
+        inherit_from     => [ "win64-cross-clang-cl" ],
+
+        asm_arch         => "x86_64",
+        perlasm_scheme   => "win64",
+        shlib_variant    => "-x64",
+
+        cflags           => add("--target=x86_64-pc-windows-msvc"),
+        ldflags          => add("--target=x86_64-pc-windows-msvc"),
+    },
+
+    "win64-aarch64-cross-clang-cl" => {
+        inherit_from     => [ "win64-cross-clang-cl" ],
+
+        asm_arch         => "aarch64",
+        perlasm_scheme   => "win64",
+        shlib_variant    => "-arm64",
+
+        cflags           => add("--target=arm64-pc-windows-msvc"),
+        ldflags          => add("--target=arm64-pc-windows-msvc"),
+    },
+);

--- a/Configurations/15-wincross.conf
+++ b/Configurations/15-wincross.conf
@@ -35,6 +35,7 @@ my %targets = (
         inherit_from     => [ "win64-cross-clang-cl" ],
 
         asm_arch         => "x86_64",
+        uplink_arch      => 'x86_64',
         perlasm_scheme   => "win64",
         shlib_variant    => "-x64",
 
@@ -46,6 +47,7 @@ my %targets = (
         inherit_from     => [ "win64-cross-clang-cl" ],
 
         asm_arch         => "aarch64",
+        uplink_arch      => "armv8",
         perlasm_scheme   => "win64",
         shlib_variant    => "-arm64",
 

--- a/Configurations/15-wincross.conf
+++ b/Configurations/15-wincross.conf
@@ -29,6 +29,8 @@ my %targets = (
         shared_impflag   => '/implib:',
 
         bin_lflags       => '/link',
+
+        max_objects_per_link_call => 250,
     },
 
     "win64-x86_64-cross-clang-cl" => {

--- a/Configurations/15-wincross.conf
+++ b/Configurations/15-wincross.conf
@@ -1,0 +1,57 @@
+## -*- mode: perl; -*-
+# Targets for cross-compiling to Windows (MSVC) on x86_64 or aarch64 using clang-cl
+# on a Unix-like system.
+#
+
+my %targets = (
+    "win64-cross-clang-cl" => {
+        inherit_from     => [ "VC-WIN64-common" ],
+        template         => 1,
+
+        sys_id           => "WIN64A",
+
+        build_scheme     => [ "unified", "unix" ],
+        build_file       => "Makefile",
+
+        perl_platform    => "Windows::Unix",
+        msvc_syntax      => 1,
+
+        CC               => "clang-cl",
+        cflags           => add("-fuse-ld=lld-link"),
+
+        AR               => "llvm-lib",
+        RC               => "llvm-rc",
+
+        ranlib           => "true",
+        shared_defflag   => '/def:',
+        shared_ldflag    => picker(default => "/LD /link",
+                                   debug   => "/LDd /link"),
+        shared_impflag   => '/implib:',
+
+        bin_lflags       => '/link',
+    },
+
+    "win64-x86_64-cross-clang-cl" => {
+        inherit_from     => [ "win64-cross-clang-cl" ],
+
+        asm_arch         => "x86_64",
+        uplink_arch      => 'x86_64',
+        perlasm_scheme   => "win64",
+        shlib_variant    => "-x64",
+
+        cflags           => add("--target=x86_64-pc-windows-msvc"),
+        ldflags          => add("--target=x86_64-pc-windows-msvc"),
+    },
+
+    "win64-aarch64-cross-clang-cl" => {
+        inherit_from     => [ "win64-cross-clang-cl" ],
+
+        asm_arch         => "aarch64",
+        uplink_arch      => "armv8",
+        perlasm_scheme   => "win64",
+        shlib_variant    => "-arm64",
+
+        cflags           => add("--target=arm64-pc-windows-msvc"),
+        ldflags          => add("--target=arm64-pc-windows-msvc"),
+    },
+);

--- a/Configurations/platform/Windows/Unix.pm
+++ b/Configurations/platform/Windows/Unix.pm
@@ -1,0 +1,25 @@
+package platform::Windows::Unix;
+
+use strict;
+use warnings;
+use Carp;
+
+use vars qw(@ISA);
+
+require platform::Windows;
+@ISA = qw(platform::Windows);
+
+# Assume someone set @INC right before loading this module
+use configdata;
+
+sub makedepcmd          { $disabled{makedepend} ? undef : $config{makedepcmd} }
+
+sub asmext              { '.s' }
+sub resext              { '.res.obj' }
+
+# As with Mingw, there is not any "simpler" shared library name
+sub sharedlib_simple {
+    return undef;
+}
+
+1;

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1778,10 +1778,16 @@ EOF
           if (platform->isstaticlib($_)) {
               push @linklibs, platform->convertext($_);
           } else {
-              my $d = "-L" . dirname($_);
+              my $d = dirname($_);
               my $l = basename($_);
-              $l =~ s/^lib//;
-              $l = "-l" . $l;
+              if ($target{msvc_syntax} // 0) {
+                  $d = "/LIBPATH:" . $d;
+                  $l = $l . '.lib';
+              } else {
+                  $d = "-L" . $d;
+                  $l =~ s/^lib//;
+                  $l = "-l" . $l;
+              }
               push @linklibs, $l;
               push @linkdirs, $d unless grep { $d eq $_ } @linkdirs;
           }
@@ -1877,13 +1883,26 @@ $import: $full
 EOF
           }
       }
-      $recipe .= <<"EOF";
+      if ($target{msvc_syntax} // 0) {
+          # Clang-CL accepts the rest of the command line after /link as linker
+          # options, but does not forward /LIBPATH like GCC/Clang forwards -L
+          # and so on. Therefore, object files must go before linker flags.
+          $recipe .= <<"EOF";
+$full: $fulldeps
+	\$(CC) \$(LIB_CFLAGS) $shared_soname \\
+		-o $full \\
+		$fullobjs \\
+		$linklibs \$(LIB_EX_LIBS) \$(LIB_LDFLAGS) $linkflags $shared_imp $shared_def
+EOF
+      } else {
+          $recipe .= <<"EOF";
 $full: $fulldeps
 	\$(CC) \$(LIB_CFLAGS) $linkflags\$(LIB_LDFLAGS)$shared_soname$shared_imp \\
 		-o $full$shared_def \\
 		$fullobjs \\
 		$linklibs \$(LIB_EX_LIBS)
 EOF
+      }
       if (windowsdll()) {
           $recipe .= <<"EOF";
 	rm -f apps/$full
@@ -1915,10 +1934,16 @@ EOF
           if (platform->isstaticlib($_)) {
               push @linklibs, platform->convertext($_);
           } else {
-              my $d = "-L" . dirname($_);
+              my $d = dirname($_);
               my $l = basename($_);
-              $l =~ s/^lib//;
-              $l = "-l" . $l;
+              if ($target{msvc_syntax} // 0) {
+                  $d = "/LIBPATH:" . $d;
+                  $l = $l . '.lib';
+              } else {
+                  $d = "-L" . $d;
+                  $l =~ s/^lib//;
+                  $l = "-l" . $l;
+              }
               push @linklibs, $l;
               push @linkdirs, $d unless grep { $d eq $_ } @linkdirs;
           }
@@ -1940,13 +1965,23 @@ EOF
                       fill_lines(' ', $COLUMNS - length($dso) - 2,
                                  @objs, @defs, @deps));
 
-      return <<"EOF";
+      if ($target{msvc_syntax} // 0) {
+          return <<"EOF";
+$dso: $deps
+	\$(CC) \$(DSO_CFLAGS) \\
+		-o $dso \\
+		$objs \\
+		$linklibs\$(DSO_EX_LIBS) \$(DSO_LDFLAGS) $linkflags $shared_def
+EOF
+      } else {
+          return <<"EOF";
 $dso: $deps
 	\$(CC) \$(DSO_CFLAGS) $linkflags\$(DSO_LDFLAGS) \\
 		-o $dso$shared_def \\
 		$objs \\
 		$linklibs\$(DSO_EX_LIBS)
 EOF
+      }
   }
   sub obj2lib {
       my %args = @_;
@@ -1994,10 +2029,16 @@ EOF
           if (platform->isstaticlib($_)) {
               push @linklibs, platform->convertext($_);
           } else {
-              my $d = "-L" . dirname($_);
+              my $d = dirname($_);
               my $l = basename($_);
-              $l =~ s/^lib//;
-              $l = "-l" . $l;
+              if ($target{msvc_syntax} // 0) {
+                  $d = "/LIBPATH:" . $d;
+                  $l = $l . '.lib';
+              } else {
+                  $d = "-L" . $d;
+                  $l =~ s/^lib//;
+                  $l = "-l" . $l;
+              }
               push @linklibs, $l;
               push @linkdirs, $d unless grep { $d eq $_ } @linkdirs;
           }
@@ -2016,7 +2057,17 @@ EOF
                       fill_lines(' ', $COLUMNS - length($bin) - 2,
                                  @objs, @deps));
 
-      return <<"EOF";
+      if ($target{msvc_syntax} // 0) {
+          return <<"EOF";
+$bin: $deps
+	rm -f $bin
+	\$\${LDCMD:-$cmd} $cmdflags \\
+		-o $bin \\
+		$objs \\
+		$linklibs\$(BIN_EX_LIBS) \$(BIN_LDFLAGS) $linkflags
+EOF
+      } else {
+          return <<"EOF";
 $bin: $deps
 	rm -f $bin
 	\$\${LDCMD:-$cmd} $cmdflags $linkflags\$(BIN_LDFLAGS) \\
@@ -2024,6 +2075,7 @@ $bin: $deps
 		$objs \\
 		$linklibs\$(BIN_EX_LIBS)
 EOF
+      }
   }
   sub in2script {
       my %args = @_;

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -10,7 +10,7 @@
      our $makedep_scheme = $config{makedep_scheme};
      our $makedepcmd = platform->makedepcmd();
 
-     sub windowsdll { $config{target} =~ /^(?:Cygwin|mingw)/ }
+     sub windowsdll { $config{target} =~ /^(?:Cygwin|mingw|win64)/ }
 
      # Shared AIX support is special. We put libcrypto[64].so.ver into
      # libcrypto.a and use libcrypto_a.a as static one, unless using

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -636,6 +636,8 @@ clean: libclean ## Clean the workspace, keep the configuration
 	$(RM) $(GENERATED_MANDATORY) $(GENERATED)
 	-find . -name '*{- platform->depext() -}' \! -name '.*' \! -type d -exec $(RM) {} \;
 	-find . -name '*{- platform->objext() -}' \! -name '.*' \! -type d -exec $(RM) {} \;
+	{- $config{target} =~ /^win64-/ ? "-find . -name '*.pdb' \\! -name '.*' \\! -type d -exec \$(RM) {} \\;" : "\@ :" -}
+	{- $config{target} =~ /^win64-/ ? "\$(RM) \$(MODULES:.dll=" . platform->libext() . ')' : "\@ :" -}
 	$(RM) core
 	$(RM) tags TAGS doc-nits md-nits
 	$(RM) -r $(RESULT_D)

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1747,6 +1747,14 @@ $obj: $deps
 		mv $dep.tmp $dep; \\
 	fi
 EOF
+      } elsif (($target{msvc_syntax} // 0) && grep /\.rc$/, @srcs) {
+          # Use $(CC) to preprocess the resource script before compiling it
+          $recipe .= <<"EOF";
+$obj: $deps
+	\$(CC) $incs $defs \$(CFLAGS) -E $srcs > $srcs.i
+	$cmd $cmdflags $cmdcompile /fo\$\@ $srcs.i
+	\$(RM) $srcs.i
+EOF
       } else {
           $recipe .= <<"EOF";
 $obj: $deps

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1991,7 +1991,7 @@ EOF
       my @objs = map { platform->obj($_) } @{$args{objs}};
       my $deps = join(" \\\n" . ' ' x (length($lib) + 2),
                       fill_lines(' ', $COLUMNS - length($lib) - 2, @objs));
-      my $max_per_call = 500;
+      my $max_per_call = $target{max_objects_per_link_call} // 500;
       my @objs_grouped;
       push @objs_grouped, join(" ", splice @objs, 0, $max_per_call) while @objs;
       my $rsp = '';

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1889,12 +1889,23 @@ EOF
           # Clang-CL accepts the rest of the command line after /link as linker
           # options, but does not forward /LIBPATH like GCC/Clang forwards -L
           # and so on. Therefore, object files must go before linker flags.
+          # To overcome the low command line length limit on Windows, a
+          # response file must also be used for the objects
+          my $max_per_call = $target{max_objects_per_link_call} // 500;
+          my @objs_grouped;
+          push @objs_grouped, join(" ", splice @fullobjs, 0, $max_per_call)
+              while @fullobjs;
+          my $rsp = "$full.rsp";
+          my $gen_rsp =
+              join("\n\t", (map { "\@echo '$_' >> $rsp" } @objs_grouped));
           $recipe .= <<"EOF";
 $full: $fulldeps
+	\$(RM) $rsp
+	$gen_rsp
 	\$(CC) \$(LIB_CFLAGS) $shared_soname \\
 		-o $full \\
-		$fullobjs \\
-		$linklibs \$(LIB_EX_LIBS) \$(LIB_LDFLAGS) $linkflags $shared_imp $shared_def
+		$linklibs \$(LIB_EX_LIBS) \$(LIB_LDFLAGS) $linkflags $shared_imp $shared_def \@$rsp
+	\$(RM) $rsp
 EOF
       } else {
           $recipe .= <<"EOF";

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1957,11 +1957,25 @@ EOF
       my $max_per_call = 500;
       my @objs_grouped;
       push @objs_grouped, join(" ", splice @objs, 0, $max_per_call) while @objs;
-      my $fill_lib =
-          join("\n\t", (map { "\$(AR) \$(ARFLAGS) $lib $_" } @objs_grouped));
+      my $rsp = '';
+      my $fill_lib;
+      if ($target{msvc_syntax} // 0) {
+          # MSVC-like tools overwrite the lib file and do not support appending
+          # objects in multiple calls. Use response file instead
+          $rsp = "$lib.rsp";
+          my $gen_rsp =
+              join("\n\t", (map { "\@echo '$_' >> $rsp" } @objs_grouped));
+          $fill_lib = $gen_rsp . "\n" . <<"EOF";
+	\$(AR) \$(ARFLAGS) /out:$lib \@$rsp
+	\$(RM) $rsp
+EOF
+      } else {
+          $fill_lib =
+              join("\n\t", (map { "\$(AR) \$(ARFLAGS) $lib $_" } @objs_grouped));
+      }
       return <<"EOF";
 $lib: $deps
-	\$(RM) $lib
+	\$(RM) $lib $rsp
 	$fill_lib
 	\$(RANLIB) \$\@ || echo Never mind.
 EOF

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1795,6 +1795,14 @@ $obj: $deps
 		mv $dep.tmp $dep; \\
 	fi
 EOF
+      } elsif (($target{msvc_syntax} // 0) && grep /\.rc$/, @srcs) {
+          # Use $(CC) to preprocess the resource script before compiling it
+          $recipe .= <<"EOF";
+$obj: $deps
+	\$(CC) $incs $defs \$(CFLAGS) -E $srcs > $srcs.i
+	$cmd $cmdflags $cmdcompile /fo\$\@ $srcs.i
+	\$(RM) $srcs.i
+EOF
       } else {
           $recipe .= <<"EOF";
 $obj: $deps

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -2055,7 +2055,7 @@ EOF
       my @objs = map { platform->obj($_) } @{$args{objs}};
       my $deps = join(" \\\n" . ' ' x (length($lib) + 2),
                       fill_lines(' ', $COLUMNS - length($lib) - 2, @objs));
-      my $max_per_call = 500;
+      my $max_per_call = $target{max_objects_per_link_call} // 500;
       my @objs_grouped;
       push @objs_grouped, join(" ", splice @objs, 0, $max_per_call) while @objs;
       my $rsp = '';

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1939,6 +1939,21 @@ $full: $fulldeps
 		$fullobjs \\
 		$linklibs \$(LIB_EX_LIBS)
 EOF
+      } elsif ($target{msvc_syntax} // 0) {
+          # Clang-CL accepts the rest of the command line after /link as linker
+          # options, but does not forward /LIBPATH like GCC/Clang forwards -L
+          # and so on. Therefore, object files must go before linker flags.
+          $recipe .= <<"EOF";
+$full: $fulldeps
+	\$(file >\$@.lst, \\
+		$fullobjs \\
+	)
+	\$(CC) \$(LIB_CFLAGS) $shared_soname \\
+		-o $full \\
+		@\$@.lst \\
+		$linklibs \$(LIB_EX_LIBS) \$(LIB_LDFLAGS) $linkflags $shared_imp $shared_def
+	rm -f \$@.lst
+EOF
       } else {
           $recipe .= <<"EOF";
 $full: $fulldeps
@@ -2014,13 +2029,23 @@ EOF
                       fill_lines(' ', $COLUMNS - length($dso) - 2,
                                  @objs, @defs, @deps));
 
-      return <<"EOF";
+      if ($target{msvc_syntax} // 0) {
+          return <<"EOF";
+$dso: $deps
+	\$(CC) \$(DSO_CFLAGS) \\
+		-o $dso \\
+		$objs \\
+		$linklibs\$(DSO_EX_LIBS) \$(DSO_LDFLAGS) $linkflags $shared_def
+EOF
+      } else {
+          return <<"EOF";
 $dso: $deps
 	\$(CC) \$(DSO_CFLAGS) $linkflags\$(DSO_LDFLAGS) \\
 		-o $dso$shared_def \\
 		$objs \\
 		$linklibs\$(DSO_EX_LIBS)
 EOF
+      }
   }
   sub obj2lib {
       my %args = @_;
@@ -2105,7 +2130,17 @@ EOF
                       fill_lines(' ', $COLUMNS - length($bin) - 2,
                                  @objs, @deps));
 
-      return <<"EOF";
+      if ($target{msvc_syntax} // 0) {
+          return <<"EOF";
+$bin: $deps
+	rm -f $bin
+	\$\${LDCMD:-$cmd} $cmdflags \\
+		-o $bin \\
+		$objs \\
+		$linklibs\$(BIN_EX_LIBS) \$(BIN_LDFLAGS) $linkflags
+EOF
+      } else {
+          return <<"EOF";
 $bin: $deps
 	rm -f $bin
 	\$\${LDCMD:-$cmd} $cmdflags $linkflags\$(BIN_LDFLAGS)$wrapflags \\
@@ -2113,6 +2148,7 @@ $bin: $deps
 		$objs \\
 		$linklibs\$(BIN_EX_LIBS)$utlibs
 EOF
+      }
   }
   sub in2script {
       my %args = @_;

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -650,6 +650,7 @@ clean: libclean ## Clean the workspace, keep the configuration
 	$(RM) $(MANDOCS7)
 	$(RM) $(PROGRAMS) $(TESTPROGS) $(MODULES) $(FIPSMODULE) $(SCRIPTS)
 	$(RM) $(GENERATED_MANDATORY) $(GENERATED)
+	{- $config{target} =~ /^win64-/ ? "\$(RM) \$(MODULES:.dll=" . platform->libext() . ')' : "\@ :" -}
 	$(RM) core
 	$(RM) tags TAGS doc-nits md-nits
 	$(RM) -r $(RESULT_D)
@@ -671,6 +672,7 @@ clean: libclean ## Clean the workspace, keep the configuration
 	        -o \! -type d \
 	           \( -name '*{- platform->depext() -}' \
 	              -o -name '*{- platform->objext() -}' \
+	              {- $config{target} =~ /^win64-/ ? "-o -name '*.pdb'" : "" -} \
 	              -o -type l \) \
 	           \! -name '.*' \
 	           -exec $(RM) '{}' +

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -10,7 +10,7 @@
      our $makedep_scheme = $config{makedep_scheme};
      our $makedepcmd = platform->makedepcmd();
 
-     sub windowsdll { $config{target} =~ /^(?:Cygwin|mingw)/ }
+     sub windowsdll { $config{target} =~ /^(?:Cygwin|mingw|win64)/ }
      sub run_on_windows { $^O =~ /^(?:cygwin|msys|MSWin32)/ }
 
      # Shared AIX support is special. We put libcrypto[64].so.ver into

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1826,10 +1826,16 @@ EOF
           if (platform->isstaticlib($_)) {
               push @linklibs, platform->convertext($_);
           } else {
-              my $d = "-L" . dirname($_);
+              my $d = dirname($_);
               my $l = basename($_);
-              $l =~ s/^lib//;
-              $l = "-l" . $l;
+              if ($target{msvc_syntax} // 0) {
+                  $d = "/LIBPATH:" . $d;
+                  $l = $l . '.lib';
+              } else {
+                  $d = "-L" . $d;
+                  $l =~ s/^lib//;
+                  $l = "-l" . $l;
+              }
               push @linklibs, $l;
               push @linkdirs, $d unless grep { $d eq $_ } @linkdirs;
           }
@@ -1977,10 +1983,16 @@ EOF
           if (platform->isstaticlib($_)) {
               push @linklibs, platform->convertext($_);
           } else {
-              my $d = "-L" . dirname($_);
+              my $d = dirname($_);
               my $l = basename($_);
-              $l =~ s/^lib//;
-              $l = "-l" . $l;
+              if ($target{msvc_syntax} // 0) {
+                  $d = "/LIBPATH:" . $d;
+                  $l = $l . '.lib';
+              } else {
+                  $d = "-L" . $d;
+                  $l =~ s/^lib//;
+                  $l = "-l" . $l;
+              }
               push @linklibs, $l;
               push @linkdirs, $d unless grep { $d eq $_ } @linkdirs;
           }
@@ -2056,10 +2068,16 @@ EOF
           if (platform->isstaticlib($_)) {
               push @linklibs, platform->convertext($_);
           } else {
-              my $d = "-L" . dirname($_);
+              my $d = dirname($_);
               my $l = basename($_);
-              $l =~ s/^lib//;
-              $l = "-l" . $l;
+              if ($target{msvc_syntax} // 0) {
+                  $d = "/LIBPATH:" . $d;
+                  $l = $l . '.lib';
+              } else {
+                  $d = "-L" . $d;
+                  $l =~ s/^lib//;
+                  $l = "-l" . $l;
+              }
               push @linklibs, $l;
               push @linkdirs, $d unless grep { $d eq $_ } @linkdirs;
           }

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -2019,11 +2019,25 @@ EOF
       my $max_per_call = 500;
       my @objs_grouped;
       push @objs_grouped, join(" ", splice @objs, 0, $max_per_call) while @objs;
-      my $fill_lib =
-          join("\n\t", (map { "\$(AR) \$(ARFLAGS) $lib $_" } @objs_grouped));
+      my $rsp = '';
+      my $fill_lib;
+      if ($target{msvc_syntax} // 0) {
+          # MSVC-like tools overwrite the lib file and do not support appending
+          # objects in multiple calls. Use response file instead
+          $rsp = "$lib.rsp";
+          my $gen_rsp =
+              join("\n\t", (map { "\@echo '$_' >> $rsp" } @objs_grouped));
+          $fill_lib = $gen_rsp . "\n" . <<"EOF";
+	\$(AR) \$(ARFLAGS) /out:$lib \@$rsp
+	\$(RM) $rsp
+EOF
+      } else {
+          $fill_lib =
+              join("\n\t", (map { "\$(AR) \$(ARFLAGS) $lib $_" } @objs_grouped));
+      }
       return <<"EOF";
 $lib: $deps
-	\$(RM) $lib
+	\$(RM) $lib $rsp
 	$fill_lib
 	\$(RANLIB) \$\@ || echo Never mind.
 EOF

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -11,7 +11,13 @@
      our $makedepcmd = platform->makedepcmd();
 
      sub windowsdll { $config{target} =~ /^(?:Cygwin|mingw|win64)/ }
-     sub run_on_windows { $^O =~ /^(?:cygwin|msys|MSWin32)/ }
+     sub use_response_file {
+         # Use a response file instead of splitting commands into batches when
+         # running on Windows (strict command line length limitations) or when
+         # using an MSVC-like toolchain (some tools cannot be run in batches)
+         return $^O =~ /^(?:cygwin|msys|MSWin32)/
+             || ($target{msvc_syntax} // 0);
+     }
 
      # Shared AIX support is special. We put libcrypto[64].so.ver into
      # libcrypto.a and use libcrypto_a.a as static one, unless using
@@ -1911,7 +1917,7 @@ $import: $full
 EOF
           }
       }
-      if (!run_on_windows()) {
+      if (!use_response_file()) {
           $recipe .= <<"EOF";
 $full: $fulldeps
 	\$(CC) \$(LIB_CFLAGS) $linkflags\$(LIB_LDFLAGS)$shared_soname$shared_imp \\

--- a/apps/build.info
+++ b/apps/build.info
@@ -74,7 +74,7 @@ IF[{- !$disabled{apps} -}]
   # always depend on a changed configuration.
   DEPEND[progs.c]=../configdata.pm
 
-  IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-|BC-)/ -}]
+  IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-|BC-|win64-)/ -}]
     GENERATE[openssl.rc]=../util/mkrc.pl openssl
     SOURCE[openssl]=openssl.rc
   ENDIF

--- a/apps/lib/build.info
+++ b/apps/lib/build.info
@@ -1,5 +1,5 @@
 # Auxiliary program source
-IF[{- $config{target} =~ /^(?:VC-|mingw|BC-)/ -}]
+IF[{- $config{target} =~ /^(?:VC-|mingw|BC-|win64-)/ -}]
   # It's called 'init', but doesn't have much 'init' in it...
   $AUXLIBAPPSSRC=win32_init.c
 ENDIF

--- a/build.info
+++ b/build.info
@@ -451,7 +451,7 @@ IF[{- defined $target{shared_defflag} -}]
   DEPEND[libcrypto.ld libssl.ld]=configdata.pm util/perl/OpenSSL/Ordinals.pm
 ENDIF
 
-IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-|BC-)/ -}]
+IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-|BC-|win64-)/ -}]
   GENERATE[libcrypto.rc]=util/mkrc.pl libcrypto
   GENERATE[libssl.rc]=util/mkrc.pl libssl
   DEPEND[libcrypto.rc libssl.rc]=configdata.pm

--- a/build.info
+++ b/build.info
@@ -459,7 +459,7 @@ IF[{- defined $target{shared_defflag} -}]
   DEPEND[libcrypto.ld libssl.ld]=configdata.pm util/perl/OpenSSL/Ordinals.pm
 ENDIF
 
-IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-|BC-)/ -}]
+IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-|BC-|win64-)/ -}]
   GENERATE[libcrypto.rc]=util/mkrc.pl libcrypto
   GENERATE[libssl.rc]=util/mkrc.pl libssl
   DEPEND[libcrypto.rc libssl.rc]=configdata.pm

--- a/crypto/aes/asm/aes-cfb-avx512.pl
+++ b/crypto/aes/asm/aes-cfb-avx512.pl
@@ -12,7 +12,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $avx512vaes=0; # will be non-zero if tooling supports Intel AVX-512 and VAES
 

--- a/crypto/aes/asm/aes-x86_64.pl
+++ b/crypto/aes/asm/aes-x86_64.pl
@@ -38,7 +38,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/aes/asm/aesni-mb-x86_64.pl
+++ b/crypto/aes/asm/aesni-mb-x86_64.pl
@@ -47,7 +47,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/aes/asm/aesni-sha1-x86_64.pl
+++ b/crypto/aes/asm/aesni-sha1-x86_64.pl
@@ -93,7 +93,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/aes/asm/aesni-sha256-x86_64.pl
+++ b/crypto/aes/asm/aesni-sha256-x86_64.pl
@@ -49,7 +49,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/aes/asm/aesni-x86_64.pl
+++ b/crypto/aes/asm/aesni-x86_64.pl
@@ -197,7 +197,8 @@ $PREFIX="aesni";	# if $PREFIX is set to "AES", the script
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/aes/asm/aesni-xts-avx512.pl
+++ b/crypto/aes/asm/aesni-xts-avx512.pl
@@ -26,7 +26,9 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
+
 $avx512vaes=0;
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;

--- a/crypto/aes/asm/bsaes-x86_64.pl
+++ b/crypto/aes/asm/bsaes-x86_64.pl
@@ -102,7 +102,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/aes/asm/vpaes-x86_64.pl
+++ b/crypto/aes/asm/vpaes-x86_64.pl
@@ -59,7 +59,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/bn/asm/rsaz-2k-avx512.pl
+++ b/crypto/bn/asm/rsaz-2k-avx512.pl
@@ -31,7 +31,9 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
+
 $avx512ifma=0;
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;

--- a/crypto/bn/asm/rsaz-2k-avxifma.pl
+++ b/crypto/bn/asm/rsaz-2k-avxifma.pl
@@ -19,7 +19,9 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
+
 $avxifma=0;
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;

--- a/crypto/bn/asm/rsaz-3k-avx512.pl
+++ b/crypto/bn/asm/rsaz-3k-avx512.pl
@@ -30,7 +30,9 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
+
 $avx512ifma=0;
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;

--- a/crypto/bn/asm/rsaz-3k-avxifma.pl
+++ b/crypto/bn/asm/rsaz-3k-avxifma.pl
@@ -19,7 +19,9 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
+
 $avxifma=0;
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;

--- a/crypto/bn/asm/rsaz-4k-avx512.pl
+++ b/crypto/bn/asm/rsaz-4k-avx512.pl
@@ -30,7 +30,9 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
+
 $avx512ifma=0;
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;

--- a/crypto/bn/asm/rsaz-4k-avxifma.pl
+++ b/crypto/bn/asm/rsaz-4k-avxifma.pl
@@ -19,7 +19,9 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
+
 $avxifma=0;
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;

--- a/crypto/bn/asm/rsaz-avx2.pl
+++ b/crypto/bn/asm/rsaz-avx2.pl
@@ -42,7 +42,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/bn/asm/rsaz-x86_64.pl
+++ b/crypto/bn/asm/rsaz-x86_64.pl
@@ -57,7 +57,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/bn/asm/x86_64-gf2m.pl
+++ b/crypto/bn/asm/x86_64-gf2m.pl
@@ -32,7 +32,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/bn/asm/x86_64-mont.pl
+++ b/crypto/bn/asm/x86_64-mont.pl
@@ -51,7 +51,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/bn/asm/x86_64-mont5.pl
+++ b/crypto/bn/asm/x86_64-mont5.pl
@@ -36,7 +36,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -140,6 +140,6 @@ GENERATE[riscv64cpuid.s]=riscv64cpuid.pl
 GENERATE[riscv32cpuid.s]=riscv32cpuid.pl
 
 GENERATE[loongarch64cpuid.s]=loongarch64cpuid.pl
-IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-|BC-)/ -}]
+IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-|win64-|BC-)/ -}]
   SHARED_SOURCE[../libcrypto]=dllmain.c
 ENDIF

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -137,6 +137,6 @@ GENERATE[riscv64cpuid.s]=riscv64cpuid.pl
 GENERATE[riscv32cpuid.s]=riscv32cpuid.pl
 
 GENERATE[loongarch64cpuid.s]=loongarch64cpuid.pl
-IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-|BC-)/ -}]
+IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-|win64-|BC-)/ -}]
   SHARED_SOURCE[../libcrypto]=dllmain.c
 ENDIF

--- a/crypto/camellia/asm/cmll-x86_64.pl
+++ b/crypto/camellia/asm/cmll-x86_64.pl
@@ -40,7 +40,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/chacha/asm/chacha-x86_64.pl
+++ b/crypto/chacha/asm/chacha-x86_64.pl
@@ -63,7 +63,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/ec/asm/ecp_nistz256-x86_64.pl
+++ b/crypto/ec/asm/ecp_nistz256-x86_64.pl
@@ -45,7 +45,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/ec/asm/x25519-x86_64.pl
+++ b/crypto/ec/asm/x25519-x86_64.pl
@@ -66,7 +66,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/md5/asm/md5-x86_64.pl
+++ b/crypto/md5/asm/md5-x86_64.pl
@@ -123,7 +123,8 @@ no warnings qw(uninitialized);
 my $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 my $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-my $win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+my $win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; my $dir=$1; my $xlate;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/modes/asm/aes-gcm-avx512.pl
+++ b/crypto/modes/asm/aes-gcm-avx512.pl
@@ -37,7 +37,7 @@ $output  = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop   : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.|          ? shift : undef;
 
 $win64 = 0;
-$win64 = 1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64 = 1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $avx512vaes = 0;
 

--- a/crypto/modes/asm/aesni-gcm-x86_64.pl
+++ b/crypto/modes/asm/aesni-gcm-x86_64.pl
@@ -45,7 +45,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/modes/asm/ghash-x86_64.pl
+++ b/crypto/modes/asm/ghash-x86_64.pl
@@ -95,7 +95,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/perlasm/x86_64-xlate.pl
+++ b/crypto/perlasm/x86_64-xlate.pl
@@ -91,6 +91,7 @@ if    ($flavour eq "mingw64")	{ $gas=1; $elf=0; $win64=1;
 				  $prefix=`echo __USER_LABEL_PREFIX__ | $ENV{CC} -E -P -`;
 				  $prefix =~ s|\R$||; # Better chomp
 				}
+elsif ($flavour eq "win64")	{ $gas=1; $elf=0; $win64=1; }
 elsif ($flavour eq "macosx")	{ $gas=1; $elf=0; $prefix="_"; $decor="L\$"; }
 elsif ($flavour eq "masm")	{ $gas=0; $elf=0; $masm=$masmref; $win64=1; $decor="\$L\$"; }
 elsif ($flavour eq "nasm")	{ $gas=0; $elf=0; $nasm=$nasmref; $win64=1; $decor="\$L\$"; $PTR=""; }
@@ -419,7 +420,7 @@ my %globals;
 	}
 
 	if ($gas) {
-	    $self->{label} =~ s/^___imp_/__imp__/   if ($flavour eq "mingw64");
+	    $self->{label} =~ s/^___imp_/__imp__/   if ($flavour =~ /^(mingw64|win64)$/);
 
 	    if (defined($self->{index})) {
 		sprintf "%s%s(%s,%%%s,%d)%s",
@@ -945,11 +946,11 @@ my %globals;
                     push(@segment_stack, $current_segment);
 		    if (!$elf && $current_segment eq ".rodata") {
 			if	($flavour eq "macosx") { $self->{value} = ".section\t__DATA,__const"; }
-			elsif	($flavour eq "mingw64")	{ $self->{value} = ".section\t.rodata"; }
+			elsif	($flavour =~ /^(mingw64|win64)$/) { $self->{value} = ".section\t.rodata"; }
 		    }
 		    if (!$elf && $current_segment eq ".init") {
 			if	($flavour eq "macosx")	{ $self->{value} = ".mod_init_func"; }
-			elsif	($flavour eq "mingw64")	{ $self->{value} = ".section\t.ctors"; }
+			elsif	($flavour =~ /^(mingw64|win64)$/) { $self->{value} = ".section\t.ctors"; }
 		    }
 		} elsif ($dir =~ /\.(text|data)/) {
                     $current_segment = pop(@segment_stack);
@@ -963,7 +964,7 @@ my %globals;
 		    push(@segment_stack, $current_segment);
 		} elsif ($dir =~ /\.hidden/) {
 		    if    ($flavour eq "macosx")  { $self->{value} = ".private_extern\t$prefix$$line"; }
-		    elsif ($flavour eq "mingw64") { $self->{value} = ""; }
+		    elsif ($flavour =~ /^(mingw64|win64)$/) { $self->{value} = ""; }
 		} elsif ($dir =~ /\.comm/) {
 		    $self->{value} = "$dir\t$prefix$$line";
 		    $self->{value} =~ s|,([0-9]+),([0-9]+)$|",$1,".log($2)/log(2)|e if ($flavour eq "macosx");
@@ -977,7 +978,7 @@ my %globals;
                         $current_segment = ".text";
                         push(@segment_stack, $current_segment);
                     }
-                    if ($flavour eq "mingw64" || $flavour eq "macosx") {
+                    if ($flavour eq "mingw64" || $flavour eq "win64" || $flavour eq "macosx") {
 		        $self->{value} = $current_segment;
                     }
 		}

--- a/crypto/perlasm/x86_64-xlate.pl
+++ b/crypto/perlasm/x86_64-xlate.pl
@@ -91,6 +91,7 @@ if    ($flavour eq "mingw64")	{ $gas=1; $elf=0; $win64=1;
 				  $prefix=`echo __USER_LABEL_PREFIX__ | $ENV{CC} -E -P -`;
 				  $prefix =~ s|\R$||; # Better chomp
 				}
+elsif ($flavour eq "win64")	{ $gas=1; $elf=0; $win64=1; }
 elsif ($flavour eq "macosx")	{ $gas=1; $elf=0; $prefix="_"; $decor="L\$"; }
 elsif ($flavour eq "masm")	{ $gas=0; $elf=0; $masm=$masmref; $win64=1; $decor="\$L\$"; }
 elsif ($flavour eq "nasm")	{ $gas=0; $elf=0; $nasm=$nasmref; $win64=1; $decor="\$L\$"; $PTR=""; }
@@ -419,7 +420,7 @@ my %globals;
 	}
 
 	if ($gas) {
-	    $self->{label} =~ s/^___imp_/__imp__/   if ($flavour eq "mingw64");
+	    $self->{label} =~ s/^___imp_/__imp__/   if ($flavour =~ /^(mingw64|win64)$/);
 
 	    if (defined($self->{index})) {
 		sprintf "%s%s(%s,%%%s,%d)%s",
@@ -944,11 +945,11 @@ my %globals;
                     push(@segment_stack, $current_segment);
 		    if (!$elf && $current_segment eq ".rodata") {
 			if	($flavour eq "macosx") { $self->{value} = ".section\t__DATA,__const"; }
-			elsif	($flavour eq "mingw64")	{ $self->{value} = ".section\t.rodata"; }
+			elsif	($flavour =~ /^(mingw64|win64)$/) { $self->{value} = ".section\t.rodata"; }
 		    }
 		    if (!$elf && $current_segment eq ".init") {
 			if	($flavour eq "macosx")	{ $self->{value} = ".mod_init_func"; }
-			elsif	($flavour eq "mingw64")	{ $self->{value} = ".section\t.ctors"; }
+			elsif	($flavour =~ /^(mingw64|win64)$/) { $self->{value} = ".section\t.ctors"; }
 		    }
 		} elsif ($dir =~ /\.(text|data)/) {
                     $current_segment = pop(@segment_stack);
@@ -962,7 +963,7 @@ my %globals;
 		    push(@segment_stack, $current_segment);
 		} elsif ($dir =~ /\.hidden/) {
 		    if    ($flavour eq "macosx")  { $self->{value} = ".private_extern\t$prefix$$line"; }
-		    elsif ($flavour eq "mingw64") { $self->{value} = ""; }
+		    elsif ($flavour =~ /^(mingw64|win64)$/) { $self->{value} = ""; }
 		} elsif ($dir =~ /\.comm/) {
 		    $self->{value} = "$dir\t$prefix$$line";
 		    $self->{value} =~ s|,([0-9]+),([0-9]+)$|",$1,".log($2)/log(2)|e if ($flavour eq "macosx");
@@ -976,7 +977,7 @@ my %globals;
                         $current_segment = ".text";
                         push(@segment_stack, $current_segment);
                     }
-                    if ($flavour eq "mingw64" || $flavour eq "macosx") {
+                    if ($flavour eq "mingw64" || $flavour eq "win64" || $flavour eq "macosx") {
 		        $self->{value} = $current_segment;
                     }
 		}

--- a/crypto/poly1305/asm/poly1305-x86_64.pl
+++ b/crypto/poly1305/asm/poly1305-x86_64.pl
@@ -68,7 +68,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/rc4/asm/rc4-md5-x86_64.pl
+++ b/crypto/rc4/asm/rc4-md5-x86_64.pl
@@ -58,7 +58,8 @@ my $D="#" if (!$md5);	# if set to "#", MD5 is stitched into RC4(),
 my $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 my $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-my $win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+my $win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; my $dir=$1; my $xlate;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/rc4/asm/rc4-x86_64.pl
+++ b/crypto/rc4/asm/rc4-x86_64.pl
@@ -116,7 +116,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/sha/asm/keccak1600-x86_64.pl
+++ b/crypto/sha/asm/keccak1600-x86_64.pl
@@ -55,7 +55,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/sha/asm/sha1-mb-x86_64.pl
+++ b/crypto/sha/asm/sha1-mb-x86_64.pl
@@ -43,7 +43,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/sha/asm/sha1-x86_64.pl
+++ b/crypto/sha/asm/sha1-x86_64.pl
@@ -98,7 +98,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/sha/asm/sha256-mb-x86_64.pl
+++ b/crypto/sha/asm/sha256-mb-x86_64.pl
@@ -44,7 +44,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/sha/asm/sha512-x86_64.pl
+++ b/crypto/sha/asm/sha512-x86_64.pl
@@ -118,7 +118,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/sm3/asm/sm3-x86_64.pl
+++ b/crypto/sm3/asm/sm3-x86_64.pl
@@ -19,7 +19,7 @@ $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
 $win64=0;
-$win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/;
 $dir=$1;

--- a/crypto/sm4/asm/sm4-x86_64.pl
+++ b/crypto/sm4/asm/sm4-x86_64.pl
@@ -19,7 +19,7 @@ $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
 $win64=0;
-$win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/;
 $dir=$1;

--- a/crypto/whrlpool/asm/wp-x86_64.pl
+++ b/crypto/whrlpool/asm/wp-x86_64.pl
@@ -42,7 +42,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; my $dir=$1; my $xlate;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/crypto/x86_64cpuid.pl
+++ b/crypto/x86_64cpuid.pl
@@ -12,7 +12,8 @@
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
-$win64=0; $win64=1 if ($flavour =~ /[nm]asm|mingw64/ || $output =~ /\.asm$/);
+$win64=0;
+$win64=1 if ($flavour =~ /[nm]asm|mingw64|win64/ || $output =~ /\.asm$/);
 
 $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 ( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or

--- a/providers/build.info
+++ b/providers/build.info
@@ -121,7 +121,7 @@ IF[{- !$disabled{fips} -}]
   DEPEND[fipsmodule.cnf]=$FIPSGOAL
 
   # Add VERSIONINFO resource for windows
-  IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-|BC-)/ -}]
+  IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-|BC-|win64-)/ -}]
     GENERATE[fips.rc]=../util/mkrc.pl fips
     SOURCE[$FIPSGOAL]=fips.rc
   ENDIF
@@ -155,7 +155,7 @@ IF[{- !$disabled{legacy} -}]
     ENDIF
 
     # Add VERSIONINFO resource for windows
-    IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-|BC-)/ -}]
+    IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-|BC-|win64-)/ -}]
       GENERATE[legacy.rc]=../util/mkrc.pl legacy
       SOURCE[$LEGACYGOAL]=legacy.rc
     ENDIF

--- a/test/build.info
+++ b/test/build.info
@@ -10,7 +10,7 @@ IF[{- !$disabled{hqinterop} -}]
 ENDIF
 
 # Auxiliary program source (copied from ../apps/build.info)
-IF[{- $config{target} =~ /^(?:VC-|mingw|BC-)/ -}]
+IF[{- $config{target} =~ /^(?:VC-|mingw|BC-|win64-)/ -}]
   # It's called 'init', but doesn't have much 'init' in it...
   $AUXLIBAPPSSRC=../apps/lib/win32_init.c
 ENDIF
@@ -575,7 +575,7 @@ IF[{- !$disabled{tests} -}]
 
   SOURCE[bioprinttest]=bioprinttest.c
   INCLUDE[bioprinttest]=../include ../apps/include
-  IF[{- $config{target} =~ /^VC/ -}]
+  IF[{- $config{target} =~ /^(?:VC-|win64-)/ -}]
     DEPEND[bioprinttest]=../libcrypto.a libtestutil.a
   ELSE
     DEPEND[bioprinttest]=../libcrypto libtestutil.a

--- a/test/build.info
+++ b/test/build.info
@@ -14,7 +14,7 @@ IF[{- !$disabled{"unit-tests"} -}]
 ENDIF
 
 # Auxiliary program source (copied from ../apps/build.info)
-IF[{- $config{target} =~ /^(?:VC-|mingw|BC-)/ -}]
+IF[{- $config{target} =~ /^(?:VC-|mingw|BC-|win64-)/ -}]
   # It's called 'init', but doesn't have much 'init' in it...
   $AUXLIBAPPSSRC=../apps/lib/win32_init.c
 ENDIF
@@ -600,7 +600,7 @@ IF[{- !$disabled{tests} -}]
 
   IF[{- !$disabled{sock}
         && $config{target} !~ /djgpp/i
-        && $config{target} !~ /^(?:VC-|mingw|BC-|Cygwin)/i
+        && $config{target} !~ /^(?:VC-|mingw|BC-|Cygwin|win64-)/i
   -}]
     PROGRAMS{noinst}=bio_socket_sigpipe_test
     SOURCE[bio_socket_sigpipe_test]=bio_socket_sigpipe_test.c

--- a/util/mkdef.pl
+++ b/util/mkdef.pl
@@ -127,6 +127,7 @@ my %OS_data = (
                      platforms  => { WIN32                      => 1,
                                      _WIN32                     => 1 } },
     windows     => 'WINDOWS',   # alias
+    win         => 'WINDOWS',   # alias
     WIN32       => 'WINDOWS',   # alias
     win32       => 'WIN32',     # alias
     32          => 'WIN32',     # alias


### PR DESCRIPTION
This adds configurations for cross-compiling to Windows (x86_64 or aarch64) using Clang-CL and other LLVM tools with MSVC-like syntax (llvm-link, llvm-rc, llvm-lib). They use the Microsoft CRT and Windows SDK instead of the mingw toolchain and libraries. A few adjustments to the Unix Makefile template had to be made for this to work, controlled by an option `msvc_syntax`. I tried to make the changes as little intrusive as possible.

I found no obvious pattern in the configuration names. Please let me know if I should name them differently.

Using the existing procedures for generating GCC-/Clang-compatible Assembly, these configurations do not require `no-asm`. Also, `clang-cl` emits warnings about unused parameters when processing assembly files, but I considered this acceptable since doing something with it would probably require more conditional changes. The goal has been to generate output as close to the VC-WIN* configurations as possible.

I have tested this primarily on an M4 Mac, cross compiling mainly from aarch64 to x86_64, with additional testing in Docker on a GNU/Linux system. The Microsoft CRT and Windows SDK were obtained using xwin.

To try to make sure that I did not break anything, I have also tested configurations `mingw64` (MSYS2/Windows), `VC-WIN64A` (Windows with MSVC 2022), `darwin64-x86_64` (macOS 15.5) and `linux-x86_64` (RHEL 9.6).

Note: the `mingw64` configuration did not build successfully because of some very recent changes to `bioprinttest.c`, but that is not related to my changes. I verified that by trying to build from master. If commenting out the lines in that file referencing unknown symbols, the build completes successfully both with and without my changes.

The purpose of these configurations is to enable cross-compilation from macOS or GNU/Linux to Windows without having to use the mingw-based configurations, but I guess it would be possible to use them from e.g. MSYS2 on Windows as well. I had two main reasons for not building on Windows using the VC-WIN* configurations: build times (building on Windows is painfully slow, even with Ccache) and the possibility to build for multiple targets on a single host.

Comparing the libraries and binaries compiled natively against the cross-compiled ones, I observed that the cross-compiled ones generally were a bit larger, except for `libcrypto*.dll`, which was significantly smaller, but none of those deviations were unreasonable. When comparing the outputs of `openssl.exe speed`, the cross-compiled binary fared worse on smaller block sizes in the first tests (the native version computed up to 40-50 % more hashes in 3 seconds), but then in the following tests the cross-compiled version quite consistently outperformed the native version by a large margin (for example hmac and AES), often reaching 2-2,5 times more operations than the native version. I ran both binaries on the same Windows system, one at the time.

This is my first attempt at diving into the OpenSSL build system and I have fairly limited experience with Perl, so there may well be room for improvement. A few questions:
* I added my target configuration file as `15-wincross.conf`, using `15` because I likened it to the Android and iOS configs. Should I have used another number instead?
* Should I have set the `multilib` option? It caused the libraries to be put in `usr/lib-x64`, which looked non-standard to me, so I skipped that option.
* To avoid conflict between static `.lib` files and shared import `.lib` files, I set the extension of static libraries to `_static.lib`, inspired by the Windows scripts. Unfortunately this adds `_static` to a couple of more libraries than when building on Windows, but I am not sure if it matters. There is a comment in Unix.pm saying that this `_static` prefix might be added in the future, but I thought that doing that change now would affect too many other configurations and carry too much risk, so I went with putting the suffix in my build configurations instead. Is this an acceptable solution?
* I added an `msvc_syntax` option that alters the behaviour of certain things in the Unix Makefile template. Is this acceptable or too intrusive in the Unix Makefile template? And is it okay to have one option control three different things (parameter order of the linker command, workaround for lib.exe/llvm-lib not supporting appending objects to archive and special treatment of .rc files because rc.exe/llvm-rc is much less flexible than GNU windres) or should I have made three different options instead?

---

Given that Docker is installed, my suggested solution can be tested by running this script in an empty folder on a Linux x86_64 host:

```bash
#!/usr/bin/env bash

# Download the Microsoft CRT and Windows SDK
docker run --rm -it -u $(id -u):$(id -g) -v "$(pwd):$(pwd)" -w "$(pwd)" axemsolutions/xwin:0.6.2 \
    xwin --accept-license --arch x86_64 splat --preserve-ms-arch-notation --include-debug-libs --output x86_64

# Clone my branch
git clone --depth 1 -b feature/win64-cross-clang-cl https://github.com/erikbs/openssl

# Set environment variables, configure and build
xwindir=$(pwd)/x86_64
CFLAGS="-vctoolsdir ${xwindir}/crt -winsdkdir ${xwindir}/sdk"
LDFLAGS="/vctoolsdir:${xwindir}/crt /winsdkdir:${xwindir}/sdk"
docker run --rm -it -u $(id -u):$(id -g) -v "$(pwd):$(pwd)" -w "$(pwd)/openssl" \
    -e CFLAGS="$CFLAGS" -e LDFLAGS="$LDFLAGS" silkeh/clang:19 \
    bash -c "./Configure win64-x86_64-cross-clang-cl && make -j32"
```