### PR TITLE
Don't print values from an uninitialized terp

### DIFF
--- a/test/radix/terp.c
+++ b/test/radix/terp.c
@@ -871,8 +871,9 @@ err:
     }
 
     GEN_SCRIPT_cleanup(&gen_script);
-    BIO_printf(debug_bio, "Stats:\n  Ops executed: %16llu\n\n",
-               (unsigned long long)terp.ops_executed);
+    if (have_terp)
+        BIO_printf(debug_bio, "Stats:\n  Ops executed: %16llu\n\n",
+                   (unsigned long long)terp.ops_executed);
     SCRIPT_INFO_print(script_info, debug_bio, /*error=*/!ok,
                       ok ? "completed" : "failed, exiting");
     return ok;


### PR DESCRIPTION
Noticed by coverity

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
