### PR TITLE
Don't return a value we never check from indent_printf()

### DIFF
--- a/apps/storeutl.c
+++ b/apps/storeutl.c
@@ -328,25 +328,14 @@ int storeutl_main(int argc, char *argv[])
     return ret;
 }
 
-static int indent_printf(int indent, BIO *bio, const char *format, ...)
+static void indent_printf(int indent, BIO *bio, const char *format, ...)
 {
     va_list args;
-    int ret, vret;
 
-    ret = BIO_printf(bio, "%*s", indent, "");
-    if (ret < 0)
-        return ret;
-
+    BIO_printf(bio, "%*s", indent, "");
     va_start(args, format);
-    vret = BIO_vprintf(bio, format, args);
+    BIO_vprintf(bio, format, args);
     va_end(args);
-
-    if (vret < 0)
-        return vret;
-    if (vret > INT_MAX - ret)
-        return INT_MAX;
-
-    return ret + vret;
 }
 
 static int process(const char *uri, const UI_METHOD *uimeth, PW_CB_DATA *uidata,


### PR DESCRIPTION
Coverity notices it could overflow, since we don't use this don't bother returning it

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
