### PR TITLE
Revert "rsa: expose pairwise consistency test API"

### DIFF
--- a/crypto/rsa/rsa_gen.c
+++ b/crypto/rsa/rsa_gen.c
@@ -734,18 +734,3 @@ err:
 
     return ret;
 }
-
-#ifdef FIPS_MODULE
-int ossl_rsa_key_pairwise_test(RSA *rsa)
-{
-    OSSL_CALLBACK *stcb;
-    void *stcbarg;
-    int res;
-
-    OSSL_SELF_TEST_get_callback(rsa->libctx, &stcb, &stcbarg);
-    res = rsa_keygen_pairwise_test(rsa, stcb, stcbarg);
-    if (res <= 0)
-        ossl_set_error_state(OSSL_SELF_TEST_TYPE_PCT_IMPORT);
-    return res;
-}
-#endif  /* FIPS_MODULE */

--- a/include/crypto/rsa.h
+++ b/include/crypto/rsa.h
@@ -124,10 +124,6 @@ ASN1_STRING *ossl_rsa_ctx_to_pss_string(EVP_PKEY_CTX *pkctx);
 int ossl_rsa_pss_to_ctx(EVP_MD_CTX *ctx, EVP_PKEY_CTX *pkctx,
                         const X509_ALGOR *sigalg, EVP_PKEY *pkey);
 
-# ifdef FIPS_MODULE
-int ossl_rsa_key_pairwise_test(RSA *rsa);
-# endif /* FIPS_MODULE */
-
 # if defined(FIPS_MODULE) && !defined(OPENSSL_NO_ACVP_TESTS)
 int ossl_rsa_acvp_test_gen_params_new(OSSL_PARAM **dst, const OSSL_PARAM src[]);
 void ossl_rsa_acvp_test_gen_params_free(OSSL_PARAM *dst);


### PR DESCRIPTION
This reverts commit dc5cd6f70a0e "rsa: expose pairwise consistency test API", that has introduced ossl_rsa_key_pairwise_test() function, as the only user has been removed in 7f7f75816f26 "import pct: remove import PCTs for most algorithms".

Complements: 7f7f75816f26 "import pct: remove import PCTs for most algorithms"