### PR TITLE
Deprecate SSL3 Configure flags

### DIFF
--- a/Configure
+++ b/Configure
@@ -892,8 +892,9 @@ while (@argvcopy)
                         next;
                         }
 
-                # Do not allow users to enable deprecated flags
-                if (/^enable-(.+)$/ && exists $deprecated_disablables{$word})
+                # Do not allow users to enable removed features
+                if (/^enable-(.+)$/ && exists $deprecated_disablables{$word}
+                        && $deprecated_disablables{$word} eq undef)
                         {
                         $unsupported_options{$_} = 1;
                         next;


### PR DESCRIPTION
Show a deprecated warning if users attempt to run Configure script with no-ssl3, no-ssl, or no-ssl3-method.

Also adds a fix to the Configure script preventing users from enabling deprecated flags.

```console
$ ./config disable-ssl3 --banner="Configured"
***** Deprecated options: disable-ssl3
Configuring OpenSSL version 3.6.0-dev for target darwin64-arm64
Using os-specific seed configuration
Created configdata.pm
Running configdata.pm
Created Makefile.in
Created Makefile
Configured
```

```
$ ./config enable-ssl3 --banner="Configured"

Failure!  build file wasn't produced.
Please read INSTALL.md and associated NOTES-* files.  You may also have to
look over your available compiler tool chain or change your configuration.

***** Unsupported options: enable-ssl3
```

```
$ ./config enable-ssl2 --banner="Configured"

Failure!  build file wasn't produced.
Please read INSTALL.md and associated NOTES-* files.  You may also have to
look over your available compiler tool chain or change your configuration.

***** Unsupported options: enable-ssl2
```

Fixes https://github.com/openssl/project/issues/1343

##### Checklist

- [ ] documentation is added or updated