### PR TITLE
Fix ML-KEM key equality check when either unset

### DIFF
--- a/crypto/ml_kem/ml_kem.c
+++ b/crypto/ml_kem/ml_kem.c
@@ -2080,5 +2080,5 @@ int ossl_ml_kem_pubkey_cmp(const ML_KEM_KEY *key1, const ML_KEM_KEY *key2)
      * No match if just one of the public keys is not available, otherwise both
      * are unavailable, and for now such keys are considered equal.
      */
-    return (ossl_ml_kem_have_pubkey(key1) ^ ossl_ml_kem_have_pubkey(key2));
+    return (!(ossl_ml_kem_have_pubkey(key1) ^ ossl_ml_kem_have_pubkey(key2)));
 }

--- a/test/ml_kem_evp_extra_test.c
+++ b/test/ml_kem_evp_extra_test.c
@@ -140,7 +140,17 @@ static int test_ml_kem(void)
     if (!TEST_int_gt(EVP_PKEY_copy_parameters(bkey, akey), 0))
         goto err;
 
+    /* Bob's empty key is not equal to Alice's */
+    if (!TEST_false(EVP_PKEY_eq(akey, bkey))
+        || !TEST_false(EVP_PKEY_eq(bkey, akey)))
+        goto err;
+
     if (!TEST_true(EVP_PKEY_set1_encoded_public_key(bkey, rawpub, publen)))
+        goto err;
+
+    /* Bob's copy of Alice's public key makes the two equal */
+    if (!TEST_true(EVP_PKEY_eq(akey, bkey))
+        || !TEST_true(EVP_PKEY_eq(bkey, akey)))
         goto err;
 
     /* Encapsulate Bob's key */


### PR DESCRIPTION
The original code returned the negation of the desired value.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated

Fixes #28563 