### PR TITLE
Fix logic errors in torture_rw_high/low test

### DIFF
--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -183,13 +183,16 @@ static void rwreader_fn(int *iterations)
         CRYPTO_atomic_add(&rwwriter2_done, 0, &lw2, atomiclock);
 
         count++;
-        if (rwwriter_ptr != NULL && old > *rwwriter_ptr) {
-            TEST_info("rwwriter pointer went backwards\n");
-            rw_torture_result = 0;
+        if (rwwriter_ptr != NULL) {
+            if (old > *rwwriter_ptr) {
+                TEST_info("rwwriter pointer went backwards! %d : %d\n",
+                          old, *rwwriter_ptr);
+                rw_torture_result = 0;
+            }
+            old = *rwwriter_ptr;
         }
         if (CRYPTO_THREAD_unlock(rwtorturelock) == 0)
             abort();
-        *iterations = count;
         if (rw_torture_result == 0) {
             *iterations = count;
             return;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
