### PR TITLE
crypto/ml_dsa: fix public_from_private() error path to return failure

### DIFF
--- a/crypto/ml_dsa/ml_dsa_key.c
+++ b/crypto/ml_dsa/ml_dsa_key.c
@@ -319,6 +319,7 @@ int ossl_ml_dsa_key_has(const ML_DSA_KEY *key, int selection)
 static int public_from_private(const ML_DSA_KEY *key, EVP_MD_CTX *md_ctx,
                                VECTOR *t1, VECTOR *t0)
 {
+    int ret = 0;
     const ML_DSA_PARAMS *params = key->params;
     uint32_t k = (uint32_t)params->k, l = (uint32_t)params->l;
     POLY *polys;
@@ -351,9 +352,10 @@ static int public_from_private(const ML_DSA_KEY *key, EVP_MD_CTX *md_ctx,
 
     /* Zeroize secret */
     vector_zero(&s1_ntt);
+    ret = 1;
 err:
     OPENSSL_free(polys);
-    return 0;
+    return ret;
 }
 
 int ossl_ml_dsa_key_public_from_private(ML_DSA_KEY *key)


### PR DESCRIPTION
The error label returned success (1) even on failure. Make it return failure (0) instead. Fixes #28562

I audited all references to public_from_private() in the tree. The function is internal. All call sites treat its return value as a boolean success (1) / failure (0) and propagate failures accordingly; none rely on the previous (buggy) success-on-error behavior. Therefore, no behavior changes or follow-up adjustments are required.