### PR TITLE
Correct the documentation for OPENSSL_sk_find

### DIFF
--- a/doc/man3/DEFINE_STACK_OF.pod
+++ b/doc/man3/DEFINE_STACK_OF.pod
@@ -303,10 +303,6 @@ was changed to return 0 in this condition as for other errors.
 
 OPENSSL_sk_set_thunks() was added in OpenSSL 3.6.0.
 
-Before OpenSSL 3.6.0 B<sk_I<TYPE>_find>() would potentially mutate an unsorted I<sk>, by sorting it
-before searching with a binary search. It was changed to not mutate an unsorted I<sk>, and to do
-a linear seach instead of a binary search on an unsorted I<sk>.
-
 =head1 COPYRIGHT
 
 Copyright 2000-2025 The OpenSSL Project Authors. All Rights Reserved.


### PR DESCRIPTION
Since April of 2023 with commit eb0935f, these functions have not sorted the stack if it was not sorted. The documentation was not changed at the time to reflect this changed behaviour.
  
This corrects the documentation to reflect the current behaviour of these functions.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
