### PR TITLE
Skip LMS tests if fetch for LMS algorithm fails

### DIFF
--- a/test/lms_test.c
+++ b/test/lms_test.c
@@ -551,6 +551,7 @@ int setup_tests(void)
 {
     OPTION_CHOICE o;
     char *config_file = NULL;
+    EVP_PKEY_CTX *ctx = NULL;
 
     /* Swap the libctx to test non-default context only */
     propq = "provider=default";
@@ -570,6 +571,11 @@ int setup_tests(void)
     }
     if (!test_get_libctx(&libctx, &nullprov, config_file, &libprov, NULL))
         return 0;
+
+    ctx = EVP_PKEY_CTX_new_from_name(libctx, "LMS", propq);
+    if (ctx == NULL && ERR_get_error() == EVP_R_UNSUPPORTED_ALGORITHM)
+        return TEST_skip("LMS algorithm is not available in provider");
+    EVP_PKEY_CTX_free(ctx);
 
     ADD_TEST(lms_bad_pub_len_test);
     ADD_TEST(lms_key_validate_test);


### PR DESCRIPTION
Will follow up with PR to backport this into 3.6

Fixes https://github.com/openssl/project/issues/1609

##### Checklist

- [x] tests are added or updated