### PR TITLE
Correct version used to check for elf_aux_info() on FreeBSD

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -76,7 +76,7 @@ uint32_t OPENSSL_rdtsc(void)
 # endif
 # if defined(__FreeBSD__) || defined(__OpenBSD__)
 #  include <sys/param.h>
-#  if (defined(__FreeBSD__) && __FreeBSD_version >= 1200000) || \
+#  if (defined(__FreeBSD__) && __FreeBSD_version >= 1104000) || \
     (defined(__OpenBSD__) && OpenBSD >= 202409)
 #   include <sys/auxv.h>
 #   define OSSL_IMPLEMENT_GETAUXVAL

--- a/crypto/ppccap.c
+++ b/crypto/ppccap.c
@@ -101,7 +101,7 @@ size_t OPENSSL_instrument_bus2(unsigned int *out, size_t cnt, size_t max)
 
 #if defined(__FreeBSD__) || defined(__OpenBSD__)
 # include <sys/param.h>
-# if (defined(__FreeBSD__) && __FreeBSD_version >= 1200000) || \
+# if (defined(__FreeBSD__) && __FreeBSD_version >= 1104000) || \
     (defined(__OpenBSD__) && OpenBSD >= 202409)
 #  include <sys/auxv.h>
 #  define OSSL_IMPLEMENT_GETAUXVAL


### PR DESCRIPTION
FreeBSD also added elf_aux_info() to the 11 branch and was shipped with 11.4.

https://github.com/freebsd/freebsd-src/commit/03444a7d439755189e4dc8ccd56403bbaef3d6b0