### PR TITLE
[3.6] Post-3.5.3 updates in 3.6's CHANGES and NEWS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,7 +36,7 @@ OpenSSL 3.6
    *Dr Paul Dale*
 
  * `openssl req` no longer generates certificates with an empty extension list
-   when SKID/AKID are set to `none` during generation
+   when SKID/AKID are set to `none` during generation.
 
    *David Benjamin*
 
@@ -58,7 +58,7 @@ OpenSSL 3.6
 
    *Viktor Dukhovni*
 
- * Added support for EVP_SKEY opaque symmetric key objects to the key
+ * Added support for `EVP_SKEY` opaque symmetric key objects to the key
    derivation and key exchange provider methods. Added `EVP_KDF_CTX_set_SKEY()`,
    `EVP_KDF_derive_SKEY()`, and `EVP_PKEY_derive_SKEY()` functions.
 
@@ -119,8 +119,8 @@ OpenSSL 3.6
 
    *Julian Zhu*
 
- * Added options `CRYPTO_MEM_SEC` and `CRYPTO_MEM_SEC_MINSIZE` to openssl app to
-   initialize secure memory at the beginning of openssl app.
+ * Added options `CRYPTO_MEM_SEC` and `CRYPTO_MEM_SEC_MINSIZE` to openssl app
+   to initialize secure memory at the beginning of openssl app.
 
    *Norbert Pocs*
 
@@ -191,14 +191,14 @@ OpenSSL 3.6
 
    *Viktor Dukhovni*
 
- * Added an `openssl configutl` utility for processing the openssl
+ * Added an `openssl configutl` utility for processing the OpenSSL
    configuration file and dumping the equal configuration file.
 
    *Dmitry Belyavskiy based on Clemens Lang's code*
 
- * Support setting a free function thunk to `OPENSSL_sk` stack types. Using a thunk
-   allows the type specific free function to be called with the correct type
-   information from generic functions like `OPENSSL_sk_pop_free()`.
+ * Support setting a free function thunk to `OPENSSL_sk` stack types. Using
+   a thunk allows the type specific free function to be called with the correct
+   type information from generic functions like `OPENSSL_sk_pop_free()`.
 
    *Frederik Wedel-Heinen*
 
@@ -240,8 +240,8 @@ OpenSSL 3.6
 
    *Theo Buehler*
 
- * HKDF with (SHA-256, SHA-384, SHA-512) has assigned OIDs. Added ability to load
-   HKDF configured with these explicit digests by name or OID.
+ * HKDF with (SHA-256, SHA-384, SHA-512) has assigned OIDs. Added ability
+   to load HKDF configured with these explicit digests by name or OID.
 
    *Daniel Van Geest (CryptoNext Security)*
 
@@ -254,9 +254,11 @@ OpenSSL 3.6
  * Added support for TLS 1.3 OCSP multi-stapling for server certs.
      * new `s_client` options:
        * `-ocsp_check_leaf`: Checks the status of the leaf (server) certificate.
-       * `-ocsp_check_all`: Checks the status of all certificates in the server chain.
+       * `-ocsp_check_all`: Checks the status of all certificates in the server
+         chain.
      * new `s_server` option:
-       * `-status_all` Provides OCSP status information for the entire server certificate chain (multi-stapling) for TLS 1.3 and later.
+       * `-status_all` Provides OCSP status information for the entire server
+         certificate chain (multi-stapling) for TLS 1.3 and later.
 
      * Improved `-status_file` option can now be given multiple times to provide
        multiple files containing OCSP responses.

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,7 +29,7 @@ OpenSSL 3.6
 This release incorporates the following potentially significant or incompatible
 changes:
 
-  * Added FIPS 140-3 PCT on DH key generation
+  * Added FIPS 140-3 PCT on DH key generation.
 
   * Added NIST security categories for PKEY objects.
 
@@ -45,7 +45,7 @@ changes:
 
   * The VxWorks platforms have been removed.
 
-  * Added an `openssl configutl` utility for processing the openssl
+  * Added an `openssl configutl` utility for processing the OpenSSL
     configuration file and dumping the equal configuration file.
 
   * Added support for FIPS 186-5 deterministic ECDSA signature


### PR DESCRIPTION
This patch set includes the following:
 * Forward-port 3.5.3 CHANGES/NEWS to 3.6.
 * Removing PCT on key import for SLH-DSA mention.
 * Adding missing periods.
 * Consistently using "OpenSSL" as the project's name.
 * Fixing the "`EVP_SKEY`" formatting reverted by a merge resolution in f815ee19e066 "Harden RSA public encrypt".
 * Fitting the lines in 80 characters, do a bit more semantic line breaks.