### PR TITLE
25-test_verify: adjust incorrect `skip` number

### DIFF
--- a/test/recipes/25-test_verify.t
+++ b/test/recipes/25-test_verify.t
@@ -604,7 +604,7 @@ ok(vfy_root("-CAstore", $rootcert, "-CAfile", $rootcert), "CAfile and existing C
 ok(!vfy_root("-CAstore", "non-existing", "-CAfile", $rootcert), "CAfile and non-existing CAstore");
 
 SKIP: {
-    skip "file names with colons aren't supported on Windows and VMS", 2
+    skip "file names with colons aren't supported on Windows and VMS", 1
         if $^O =~ /^(MSWin32|VMS)$/;
     my $foo_file = "foo:cert.pem";
     copy($rootcert, $foo_file);


### PR DESCRIPTION
When b3e7dad (Fix test/recipes/25-test_verify.t [3.5], 2025-05-04) dropped some test cases, it forgot to adjust the `skip` number accordingly.

As a consequence, on Windows (and on VMS) the total number of tests mismatches with the claimed total number of tests, and `25-test_verify.t` fails.

Let's fix that by adjusting the `skip` number as above-mentioned patch should have done.

##### Checklist
- [x] tests are updated
