### PR TITLE
[3.5] test/recipes/25-test_verify.t: correct the number of skipped tests on Win/VMS

### DIFF
--- a/test/recipes/25-test_verify.t
+++ b/test/recipes/25-test_verify.t
@@ -604,7 +604,7 @@ ok(vfy_root("-CAstore", $rootcert, "-CAfile", $rootcert), "CAfile and existing C
 ok(!vfy_root("-CAstore", "non-existing", "-CAfile", $rootcert), "CAfile and non-existing CAstore");
 
 SKIP: {
-    skip "file names with colons aren't supported on Windows and VMS", 2
+    skip "file names with colons aren't supported on Windows and VMS", 1
         if $^O =~ /^(MSWin32|VMS)$/;
     my $foo_file = "foo:cert.pem";
     copy($rootcert, $foo_file);


### PR DESCRIPTION
On 3.5, there is one test fewer to be skipped due to absence of support of colon in filenames after the commit b3e7dad7ac08 "Fix test/recipes/25-test_verify.t [3.5]", provide the correct number in the skip call.

Fixes: b3e7dad7ac08 "Fix test/recipes/25-test_verify.t [3.5]"

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
