### PR TITLE
Ensure q variable is freed

### DIFF
--- a/test/stack_test.c
+++ b/test/stack_test.c
@@ -321,6 +321,7 @@ static int test_uchar_stack(int reserve)
 end:
     sk_uchar_free(r);
     sk_uchar_free(s);
+    sk_uchar_free(q);
     return testresult;
 }
 


### PR DESCRIPTION
Fixes: d88c43a64408 ("Ensure that empty or 1 element stacks are always sorted.")
Resolves: https://scan5.scan.coverity.com/#/project-view/65138/10222?selectedIssue=1665465
