### PR TITLE
Fix util/find-doc-nits' check_env_vars

### DIFF
--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -13,6 +13,7 @@ use strict;
 
 use Carp qw(:DEFAULT cluck);
 use Pod::Checker;
+use Cwd qw(realpath);
 use File::Find;
 use File::Basename;
 use File::Spec::Functions;
@@ -1286,9 +1287,11 @@ sub check_env_vars {
         "$config{sourcedir}/test",
     );
     my @except_env_files = (
-        "$config{sourcedir}/providers/implementations/keymgmt/template_kmgmt.c",
         "$config{sourcedir}/providers/implementations/kem/template_kem.c",
-        "$config{sourcedir}/Makefile.in",
+        # The following files are generated, and are therefore found in the
+        # build directory rather than the source directory
+        "$config{builddir}/providers/implementations/keymgmt/template_kmgmt.c",
+        "$config{builddir}/Makefile.in",
     );
     my @env_headers;
     my @env_macro;
@@ -1323,13 +1326,23 @@ sub check_env_vars {
         }
     }
 
+    # Because we compare against them, make sure that all elements in
+    # @except_dirs and @except_env_files are real paths.  Otherwise,
+    # we may get false positives because relative paths to the same
+    # file could look different.
+    # For example, './foo.c' == '../dir/foo.c', but turning them into
+    # real paths will have them actually look the same.
+    @except_dirs = map { realpath($_) } @except_dirs;
+    @except_env_files = map { realpath($_) } @except_env_files;
+
     # look for source files
     find(sub { push @env_files, $File::Find::name if /\.c$|\.in$/; },
          $config{sourcedir});
 
     foreach my $filename (@env_files) {
-        next if (grep { $filename =~ /^$_\// } @except_dirs)
-                || grep { $_ eq $filename } @except_env_files;
+        my $realfilename = realpath($filename);
+        next if (grep { $realfilename =~ /^$_\// } @except_dirs)
+                || grep { $_ eq $realfilename } @except_env_files;
 
         open my $fh, '<', $filename or die "Can't open $filename: $!";
         while (my $line = <$fh>) {

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -1309,6 +1309,7 @@ sub check_env_vars {
             if $debug;
         push @except_dirs, "$config{sourcedir}/$_";
     }
+    close $gs_pipe;
     # git call has failed, trying to parse .gitmodules manually
     if (!$git_ok) {
         print STDERR "DEBUG[check_env_vars]: .gitmodules parsing fallback\n"
@@ -1336,8 +1337,19 @@ sub check_env_vars {
     @except_env_files = map { realpath($_) } @except_env_files;
 
     # look for source files
-    find(sub { push @env_files, $File::Find::name if /\.c$|\.in$/; },
-         $config{sourcedir});
+    $git_ok = 0;
+    open my $glf_pipe, '-|', "git ls-files -- \"$config{sourcedir}\"";
+    while (<$glf_pipe>) {
+        $git_ok = 1;
+        s/\R$//; # better chomp
+        push @env_files, $_ if /\.c$|\.in$/;
+    }
+    close $glf_pipe;
+    # git call has failed, trying to find files manually
+    if (!$git_ok) {
+        find(sub { push @env_files, $File::Find::name if /\.c$|\.in$/; },
+             $config{sourcedir});
+    }
 
     foreach my $filename (@env_files) {
         my $realfilename = realpath($filename);

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -1348,13 +1348,14 @@ sub check_env_vars {
         while (my $line = <$fh>) {
             # for windows
             # for .in files
-            $env_list{$1} = 1 if ($line =~ /GetEnvironmentVariableW\([\s\S]*"([^"]+)",/
-                || $line =~ /\$ENV\{([^}"']+)\}/);
+            push @{$env_list{$1}}, "${filename}:$."
+                if ($line =~ /GetEnvironmentVariableW\([\s\S]*"([^"]+)",/
+                    || $line =~ /\$ENV\{([^}"']+)\}/);
             # this also handles ossl_safe_getenv
             if ($line =~ /getenv\(([^()\s]+)\)/) {
                 my $env1 = $1;
                 if ($env1 =~ /"([^"]+)"/) {
-                    $env_list{$1} = 1;
+                    push @{$env_list{$1}}, "${filename}:$.";
                 } elsif ($env1 =~ /([A-Z0-9_])/) {
                     push(@env_macro, $env1);
                 }
@@ -1365,12 +1366,12 @@ sub check_env_vars {
                 # if it's a string just add to the list
                 # otherwise look for the constant value later
                 if ($env1 =~ /"([^"]+)"/) {
-                    $env_list{$1} = 1;
+                    push @{$env_list{$1}}, "${filename}:$.";
                 } else {
                     push(@env_macro, $env1);
                 }
                 if ($env2 =~ /"([^"]+)"/) {
-                    $env_list{$1} = 1;
+                    push @{$env_list{$1}}, "${filename}:$.";
                 } else {
                     push(@env_macro, $env2);
                 }
@@ -1383,14 +1384,15 @@ sub check_env_vars {
     find(sub { push @env_headers, $File::Find::name if /\.h$/; },
          $config{sourcedir});
 
-     foreach my $filename (@env_headers) {
+    foreach my $filename (@env_headers) {
         open my $fh, '<', $filename or die "Can't open $filename: $!";
         while (my $line = <$fh>) {
             foreach my $em (@env_macro) {
-                $env_list{$1} = 1 if ($line =~ /define\s+\Q$em\E\s+"(\S+)"/);
+                push @{$env_list{$1}}, "${filename}:$."
+                    if ($line =~ /define\s+\Q$em\E\s+"(\S+)"/);
             }
         }
-     }
+    }
 
     # need to save the value before starting to delete from the hash
     my $number_of_env = scalar keys %env_list;
@@ -1417,7 +1419,12 @@ sub check_env_vars {
     $number_of_env = scalar keys %env_list;
     if ($number_of_env != 0) {
         print "Undocumented environment variables:\n";
-        print join("\n", sort keys %env_list)."\n";
+        foreach my $env_name (sort keys %env_list) {
+            print $env_name;
+            print " (found in '", join("', '", @{$env_list{$env_name}}), "')"
+                if ref $env_list{$env_name} eq 'ARRAY';
+            print "\n";
+        }
         err("Total:".$number_of_env."\n");
     }
 }


### PR DESCRIPTION
This contains multiple fixes:

- **Fix util/find-doc-nits' environment variable check exceptions**

  Some files in @except_env_files are located in the build directory,
  not the source directory.

  Furthermore, because the files and directories in @except_dirs and
  @except_env_files may look different than the elements in what find()
  returns, realpath() must be used to ensure that file name comparison
  matches when it should.

- **Fix util/find-doc-nits' check_env_vars to show where envvars were found**

  This displays the list of files with line number for each envvar.

- **Fix util/find-doc-nits' check_env_vars to look for files with 'git ls-files'**

  If that fails, it will fall back to finding the files with Find::file.
