### PR TITLE
Fix OPENSSL_VERSION_NUMBER to always have zero status bits

### DIFF
--- a/doc/man3/OpenSSL_version.pod
+++ b/doc/man3/OpenSSL_version.pod
@@ -256,6 +256,13 @@ L<crypto(7)>
 The macros and functions described here were added in OpenSSL 3.0,
 except for OPENSSL_VERSION_NUMBER and OpenSSL_version_num().
 
+=head1 BUGS
+
+There was a discrepancy between this manual and commentary + code
+in F<< <openssl/opensslv.h> >>, where the latter suggested that the
+four least significant bits of B<OPENSSL_VERSION_NUMBER> could be
+C<0x0f> in released OpenSSL versions.
+
 =head1 COPYRIGHT
 
 Copyright 2018-2022 The OpenSSL Project Authors. All Rights Reserved.

--- a/include/openssl/opensslv.h.in
+++ b/include/openssl/opensslv.h.in
@@ -89,12 +89,12 @@ extern "C" {
 
 # define OPENSSL_VERSION_TEXT "OpenSSL {- "$config{full_version} $config{release_date}" -}"
 
-/* Synthesize OPENSSL_VERSION_NUMBER with the layout 0xMNN00PPSL */
+/* Synthesize OPENSSL_VERSION_NUMBER with the layout 0xMNN00PP0L */
 # define OPENSSL_VERSION_NUMBER          \
     ( (OPENSSL_VERSION_MAJOR<<28)        \
       |(OPENSSL_VERSION_MINOR<<20)       \
       |(OPENSSL_VERSION_PATCH<<4)        \
-      |{- @config{prerelease} ? "0x0L" : "0xfL" -} )
+      |0x0L )
 
 # ifdef  __cplusplus
 }


### PR DESCRIPTION
The documentation suggested that they were always zero, while the
implementation in <openssl/opensslv.h> suggested that it could be
0xf in OpenSSL releases...  which (almost) never happened because
of a bug in said implementation.

Therefore, we solidify that the status bits are indeed always zero,
at least in all OpenSSL 3 versions.

Resolves: https://github.com/openssl/project/issues/1621
