### PR TITLE
Fix EVP_PKEY_can_sign() handling of NULL from query_operation_name()

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1135,15 +1135,14 @@ int EVP_PKEY_can_sign(const EVP_PKEY *pkey)
     } else {
         const OSSL_PROVIDER *prov = EVP_KEYMGMT_get0_provider(pkey->keymgmt);
         OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
-        const char *supported_sig =
-            pkey->keymgmt->query_operation_name != NULL
-            ? pkey->keymgmt->query_operation_name(OSSL_OP_SIGNATURE)
-            : EVP_KEYMGMT_get0_name(pkey->keymgmt);
-        EVP_SIGNATURE *signature = NULL;
+        EVP_SIGNATURE *sig;
+        const char *name;
 
-        signature = EVP_SIGNATURE_fetch(libctx, supported_sig, NULL);
-        if (signature != NULL) {
-            EVP_SIGNATURE_free(signature);
+        name = evp_keymgmt_util_query_operation_name(pkey->keymgmt,
+                                                     OSSL_OP_SIGNATURE);
+        sig = EVP_SIGNATURE_fetch(libctx, name, NULL);
+        if (sig != NULL) {
+            EVP_SIGNATURE_free(sig);
             return 1;
         }
     }

--- a/test/fake_rsaprov.c
+++ b/test/fake_rsaprov.c
@@ -35,6 +35,8 @@ static int exptypes_selection;
 static int query_id;
 static int key_deleted;
 
+unsigned fake_rsa_query_operation_name = 0;
+
 typedef struct {
     OSSL_LIB_CTX *libctx;
 } PROV_FAKE_RSA_CTX;
@@ -90,7 +92,7 @@ static const char *fake_rsa_keymgmt_query(int id)
     /* record global for checking */
     query_id = id;
 
-    return "RSA";
+    return fake_rsa_query_operation_name ? NULL: "RSA";
 }
 
 static int fake_rsa_keymgmt_import(void *keydata, int selection,

--- a/test/fake_rsaprov.h
+++ b/test/fake_rsaprov.h
@@ -14,5 +14,14 @@
 /* Fake RSA provider implementation */
 OSSL_PROVIDER *fake_rsa_start(OSSL_LIB_CTX *libctx);
 void fake_rsa_finish(OSSL_PROVIDER *p);
+
 OSSL_PARAM *fake_rsa_key_params(int priv);
 void fake_rsa_restore_store_state(void);
+
+/*
+ * When fake_rsa_query_operation_name is set to a non-zero value,
+ * query_operation_name() will return NULL.
+ *
+ * By default, it is 0, in which case query_operation_name() will return "RSA".
+ */
+extern unsigned fake_rsa_query_operation_name;


### PR DESCRIPTION
EVP_PKEY_can_sign() assumed query_operation_name(OSSL_OP_SIGNATURE) always returns a non-NULL string. According to the documentation, query_operation_name() may return NULL, in which case EVP_KEYMGMT_get0_name() should be used as a fallback.

Fixes #27790

- [x] tests are added or updated