### PR TITLE
Fix BE breakage in ssl trace output of inner content type

### DIFF
--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1093,9 +1093,12 @@ int tls13_common_post_process_record(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *rec)
         return 0;
     }
 
-    if (rl->msg_callback != NULL)
-        rl->msg_callback(0, rl->version, SSL3_RT_INNER_CONTENT_TYPE, &rec->type,
-                        1, rl->cbarg);
+    if (rl->msg_callback != NULL) {
+        unsigned char ctype = (unsigned char)rec->type;
+
+        rl->msg_callback(0, rl->version, SSL3_RT_INNER_CONTENT_TYPE, &ctype,
+                         1, rl->cbarg);
+    }
 
     /*
      * TLSv1.3 alert and handshake records are required to be non-zero in

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -13758,6 +13758,9 @@ static int test_ssl_trace(void)
     char *grouplist = "MLKEM512:MLKEM768:MLKEM1024:X25519MLKEM768:SecP256r1MLKEM768"
         ":SecP384r1MLKEM1024:secp521r1:secp384r1:secp256r1";
 
+    if (!fips_provider_version_ge(libctx, 3, 5, 0))
+        return TEST_skip("FIPS provider does not support MLKEM algorithms");
+
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
                                        TLS_client_method(),
                                        TLS1_3_VERSION, TLS1_3_VERSION,

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -130,17 +130,13 @@ static X509 *ocspcert = NULL;
 #define CLIENT_VERSION_LEN      2
 
 /* The ssltrace test assumes some options are switched on/off */
-/*
- * Disable SSL_TRACE_TEST to fix up CI pipeline a following commit
- * will resolve the testing issue
- * #if !defined(OPENSSL_NO_SSL_TRACE) \
- *   && defined(OPENSSL_NO_BROTLI) && defined(OPENSSL_NO_ZSTD) \
- *   && !defined(OPENSSL_NO_ECX) && !defined(OPENSSL_NO_DH) \
- *   && !defined(OPENSSL_NO_ML_DSA) && !defined(OPENSSL_NO_ML_KEM) \
- *   && !defined(OPENSSL_NO_TLS1_3)
- * # define DO_SSL_TRACE_TEST
- * #endif
- */
+#if !defined(OPENSSL_NO_SSL_TRACE) \
+        && defined(OPENSSL_NO_BROTLI) && defined(OPENSSL_NO_ZSTD) \
+        && !defined(OPENSSL_NO_ECX) && !defined(OPENSSL_NO_DH) \
+        && !defined(OPENSSL_NO_ML_DSA) && !defined(OPENSSL_NO_ML_KEM) \
+        && !defined(OPENSSL_NO_TLS1_3)
+# define DO_SSL_TRACE_TEST
+#endif
 
 /*
  * This structure is used to validate that the correct number of log messages


### PR DESCRIPTION
Also skip ssl_trace_test() with older FIPS providers and re-enable it.
