### PR TITLE
Remove ENGINE usage from crypto/dh/*

### DIFF
--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -67,11 +67,11 @@ DH *ossl_dh_new_ex(OSSL_LIB_CTX *libctx)
     return dh_new_intern(NULL, libctx);
 }
 
-static DH *dh_new_intern(ENGINE *engine, OSSL_LIB_CTX *libctx)
+static DH *dh_new_intern(ossl_unused ENGINE *engine, OSSL_LIB_CTX *libctx)
 {
     DH *ret = OPENSSL_zalloc(sizeof(*ret));
 
-    if (ret == NULL)
+    if (ret == NULL || engine != NULL)
         return NULL;
 
     ret->lock = CRYPTO_THREAD_lock_new();


### PR DESCRIPTION
The functiontality here was already removed by the OPENSSL_NO_ENGINE guard.
This PR makes the internal function shiny.

Resolves: https://github.com/openssl/project/issues/1625

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
