### PR TITLE
Disable HW acceleration when running TLSProxy tests

### DIFF
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -275,6 +275,16 @@ sub start
     my ($self) = shift;
     my $pid;
 
+    #
+    # s390x is a somewhat special case here.  It uses hw acceleration under
+    # the covers when computing MACs, and in so doing avoids the use of the
+    # needed ossltest provider when computing the underlying digest.  Since
+    # TLSProxy needs the ossltest provider to compute reliable known data in
+    # the digest, we disable MAC hw accleration here to ensure that the provider
+    # gets used, just as it does with other architectures.
+    #
+    $ENV{OPENSSL_s390xcap} = "kmac:~0:~f000";
+
     # Create the Proxy socket
     my $proxaddr = $self->{proxy_addr};
     $proxaddr =~ s/[\[\]]//g; # Remove [ and ]


### PR DESCRIPTION
IBM reported that, since the introduction of the ossltest provider, several tests are failing on s390x

They are failing because MAC computation on s390x uses hardware acceleration, which bypasses the use of the ossltest provided digests.

Because TLSProxy tests rely on the return of known consistent data (which the ossltest provider gives us), the HW acceleration ignores this giving us real MAC's instead, causing the test to fail.

We could write an HMAC provided algorithm to override that behavior, but since this only occurs on s390, and only in cases in which the TLSprovider is used, it seems simpler, and more maintainable to just disable hw acceleration on those tests (given that we don't want to use the accelerated path anyway).

Set the capabilities register for s390 to enforce this in the TLSProxy code.

Fixes #28630


##### Checklist
- [x] tests are added or updated
