### PR TITLE
Do not use RW mutexes on RISC-V arch

### DIFF
--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -92,8 +92,10 @@ __tsan_mutex_post_lock((x), 0, 0)
 /*
  * The Non-Stop KLT thread model currently seems broken in its rwlock
  * implementation
+ * Likewise is there a problem with the glibc implementation on riscv.
  */
-# if defined(PTHREAD_RWLOCK_INITIALIZER) && !defined(_KLT_MODEL_)
+# if defined(PTHREAD_RWLOCK_INITIALIZER) && !defined(_KLT_MODEL_) \
+                                         && !defined(__riscv)
 #  define USE_RWLOCK
 # endif
 


### PR DESCRIPTION
For unknown reasons using RW mutexes on RISC-V arch seems to be broken, at least with glibc.

Fixes #28550
