### PR TITLE
Do not use RW mutexes on RISC-V arch backport

### DIFF
--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -41,7 +41,11 @@
 
 # include <assert.h>
 
-# ifdef PTHREAD_RWLOCK_INITIALIZER
+/*
+ * The Non-Stop KLT thread model currently seems broken in its rwlock
+ * implementation
+ */
+# if defined(PTHREAD_RWLOCK_INITIALIZER) && !defined(_KLT_MODEL_)
 #  define USE_RWLOCK
 # endif
 

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -44,8 +44,10 @@
 /*
  * The Non-Stop KLT thread model currently seems broken in its rwlock
  * implementation
+ * Likewise is there a problem with the glibc implementation on riscv.
  */
-# if defined(PTHREAD_RWLOCK_INITIALIZER) && !defined(_KLT_MODEL_)
+# if defined(PTHREAD_RWLOCK_INITIALIZER) && !defined(_KLT_MODEL_) \
+                                         && !defined(__riscv)
 #  define USE_RWLOCK
 # endif
 


### PR DESCRIPTION
Backport of RW MUTEX fixes for RISC-V and likely also necessary
NonStop KLT threading model