### PR TITLE
Change test/recipes/95-test_external_oqsprovider.t to allow out-of-source builds

### DIFF
--- a/test/recipes/95-test_external_oqsprovider.t
+++ b/test/recipes/95-test_external_oqsprovider.t
@@ -19,10 +19,10 @@ plan skip_all => "oqsprovider tests not available on Windows or VMS"
     if $^O =~ /^(VMS|MSWin32)$/;
 plan skip_all => "oqsprovider tests only available in a shared build"
     if disabled("shared");
-plan skip_all => "oqsprovider tests not supported in out of tree builds"
-    if bldtop_dir() ne srctop_dir();
 
 plan tests => 1;
+
+$ENV{SHLIB_VERSION_NUMBER} = config('shlib_version');
 
 ok(run(cmd(["sh", data_file("oqsprovider.sh")])),
    "running oqsprovider tests");


### PR DESCRIPTION
Unfortunately, CMake's FindOpenSSL.cmake module doesn't handle OpenSSL's
build tree very well when it's out-of-source.  This is resolved by create
a local OpenSSL "installation" with a minimum amount of symbolic links,
and using that.
