### PR TITLE
[3.5, 3.6] Address coverity issues 16654{20,22,23,27,28,30}

### DIFF
--- a/apps/storeutl.c
+++ b/apps/storeutl.c
@@ -331,14 +331,22 @@ int storeutl_main(int argc, char *argv[])
 static int indent_printf(int indent, BIO *bio, const char *format, ...)
 {
     va_list args;
-    int ret;
+    int ret, vret;
+
+    ret = BIO_printf(bio, "%*s", indent, "");
+    if (ret < 0)
+        return ret;
 
     va_start(args, format);
-
-    ret = BIO_printf(bio, "%*s", indent, "") + BIO_vprintf(bio, format, args);
-
+    vret = BIO_vprintf(bio, format, args);
     va_end(args);
-    return ret;
+
+    if (vret < 0)
+        return vret;
+    if (vret > INT_MAX - ret)
+        return INT_MAX;
+
+    return ret + vret;
 }
 
 static int process(const char *uri, const UI_METHOD *uimeth, PW_CB_DATA *uidata,

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -287,7 +287,7 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
         if (fp == NULL) {
             ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
                            "calling fopen(%s, %s)",
-                           ptr, p);
+                           (const char *)ptr, p);
             ERR_raise(ERR_LIB_BIO, ERR_R_SYS_LIB);
             ret = 0;
             break;

--- a/crypto/evp/ctrl_params_translate.c
+++ b/crypto/evp/ctrl_params_translate.c
@@ -1357,7 +1357,7 @@ static int fix_rsa_padding_mode(enum state state,
         if (i == OSSL_NELEM(str_value_map)) {
             ERR_raise_data(ERR_LIB_RSA, RSA_R_UNKNOWN_PADDING_TYPE,
                            "[action:%d, state:%d] padding name %s",
-                           ctx->action_type, state, ctx->p1);
+                           ctx->action_type, state, (const char *)ctx->p2);
             ctx->p1 = ret = -2;
         } else if (state == POST_CTRL_TO_PARAMS) {
             /* EVP_PKEY_CTRL_GET_RSA_PADDING weirdness explained further up */

--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -224,7 +224,8 @@ int X509_ocspid_print(BIO *bp, X509 *x)
         goto err;
     if ((der = dertmp = OPENSSL_malloc(derlen)) == NULL)
         goto err;
-    i2d_X509_NAME(subj, &dertmp);
+    if (i2d_X509_NAME(subj, &dertmp) < 0)
+        goto err;
 
     md = EVP_MD_fetch(x->libctx, SN_sha1, x->propq);
     if (md == NULL)

--- a/test/radix/terp.c
+++ b/test/radix/terp.c
@@ -871,8 +871,10 @@ err:
     }
 
     GEN_SCRIPT_cleanup(&gen_script);
-    BIO_printf(debug_bio, "Stats:\n  Ops executed: %16llu\n\n",
-               (unsigned long long)terp.ops_executed);
+    if (have_terp) {
+        BIO_printf(debug_bio, "Stats:\n  Ops executed: %16llu\n\n",
+                   (unsigned long long)terp.ops_executed);
+    }
     SCRIPT_INFO_print(script_info, debug_bio, /*error=*/!ok,
                       ok ? "completed" : "failed, exiting");
     return ok;

--- a/test/wpackettest.c
+++ b/test/wpackettest.c
@@ -588,7 +588,7 @@ static int test_WPACKET_quic_vlint_random(void)
 
     for (i = 0; i < 10000; ++i) {
         if (!TEST_int_gt(RAND_bytes(rand_data, sizeof(rand_data)), 0))
-            return cleanup(&pkt);
+            return 0;
 
         memcpy(&expected, rand_data, sizeof(expected));
 


### PR DESCRIPTION
This is a backport of [1] to `openssl-3.5` and `openssl-3.6` branches.  The patch set is essentially identical, sans minor typo corrections in the commit messages.

[1] https://github.com/openssl/openssl/pull/28546

References: https://github.com/openssl/project/issues/1619