### PR TITLE
Fix heap buffer overflow in krb5kdf

### DIFF
--- a/providers/implementations/kdfs/krb5kdf.c.in
+++ b/providers/implementations/kdfs/krb5kdf.c.in
@@ -167,7 +167,7 @@ static int krb5kdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     struct krb5kdf_set_ctx_params_st p;
     KRB5KDF_CTX *ctx = vctx;
     OSSL_LIB_CTX *provctx;
-    EVP_CIPHER *cipher;
+    const EVP_CIPHER *cipher;
 
     if (ctx == NULL || !krb5kdf_set_ctx_params_decoder(params, &p))
         return 0;
@@ -182,7 +182,7 @@ static int krb5kdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     if (p.key != NULL && !krb5kdf_set_membuf(&ctx->key, &ctx->key_len, p.key))
         return 0;
 
-    if (ctx->key_len != EVP_CIPHER_get_key_length(cipher))
+    if (ctx->key_len != (size_t)EVP_CIPHER_get_key_length(cipher))
         return 0;
 
     if (p.cnst != NULL

--- a/providers/implementations/kdfs/krb5kdf.c.in
+++ b/providers/implementations/kdfs/krb5kdf.c.in
@@ -167,6 +167,7 @@ static int krb5kdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     struct krb5kdf_set_ctx_params_st p;
     KRB5KDF_CTX *ctx = vctx;
     OSSL_LIB_CTX *provctx;
+    EVP_CIPHER *cipher;
 
     if (ctx == NULL || !krb5kdf_set_ctx_params_decoder(params, &p))
         return 0;
@@ -176,7 +177,12 @@ static int krb5kdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     if (!ossl_prov_cipher_load(&ctx->cipher, p.cipher, p.propq, p.engine, provctx))
         return 0;
 
+    cipher = ossl_prov_cipher_cipher(&ctx->cipher);
+
     if (p.key != NULL && !krb5kdf_set_membuf(&ctx->key, &ctx->key_len, p.key))
+        return 0;
+
+    if (ctx->key_len != EVP_CIPHER_get_key_length(cipher))
         return 0;
 
     if (p.cnst != NULL


### PR DESCRIPTION
oss-fuzz encountered a heap buffer overflow:
https://issues.oss-fuzz.com/issues/447104218

==411==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x77f58790c190 at pc 0x5688ab279f30 bp 0x7ffc9ec47740 sp 0x7ffc9ec46ee8 READ of size 32 at 0x77f58790c190 thread T0
    #0 0x5688ab279f2f in MemcmpInterceptorCommon(void*, int (*)(void const*, void const*, unsigned long), void const*, void const*, unsigned long) /src/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc:849:7
    #1 0x5688ab27a29c in ___interceptor_bcmp /src/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc:894:10
    #2 0x5688ab48c2f8 in aes_xts_check_keys_differ openssl/providers/implementations/ciphers/cipher_aes_xts.c:58:16
    #3 0x5688ab48c2f8 in aes_xts_init openssl/providers/implementations/ciphers/cipher_aes_xts.c:93:14
    #4 0x5688ab48b3bf in aes_xts_einit openssl/providers/implementations/ciphers/cipher_aes_xts.c:109:12
    #5 0x5688ab35a017 in evp_cipher_init_internal openssl/crypto/evp/evp_enc.c:0
    #6 0x5688ab35e5d1 in EVP_CipherInit_ex openssl/crypto/evp/evp_enc.c:653:12
    #7 0x5688ab35e5d1 in EVP_EncryptInit_ex openssl/crypto/evp/evp_enc.c:819:12
    #8 0x5688ab51b3af in cipher_init openssl/providers/implementations/kdfs/krb5kdf.c:483:11
    #9 0x5688ab51b3af in KRB5KDF openssl/providers/implementations/kdfs/krb5kdf.c:542:11
    #10 0x5688ab51b3af in krb5kdf_derive openssl/providers/implementations/kdfs/krb5kdf.c:150:12
    #11 0x5688ab345f6a in do_evp_kdf openssl/fuzz/provider.c:450:9
    #12 0x5688ab342c57 in FuzzerTestOneInput openssl/fuzz/provider.c:620:9
    #13 0x5688ab347bc9 in ExecuteFilesOnyByOne /src/aflplusplus/utils/aflpp_driver/aflpp_driver.c:267:7
    #14 0x5688ab3479c9 in LLVMFuzzerRunDriver /src/aflplusplus/utils/aflpp_driver/aflpp_driver.c:0
    #15 0x5688ab34756b in main /src/aflplusplus/utils/aflpp_driver/aflpp_driver.c:323:10
    #16 0x7bc588600082 in __libc_start_main /build/glibc-LcI20x/glibc-2.31/csu/libc-start.c:308:16
    #17 0x5688ab25abad in _start

It occurs because when setting parameters for key derivation, we neglect to ensure that the key length provided in the key parameter matches the required length of the key for the underlying cipher.  This in turn leads to the underlying cipher (aes-xts in this case), doing a key validation that reads beyond the end of the buffer provided in the parameter.

Fix it by preforming a check during param setting to ensure they cipher key length matches the passed buffer length.

Fixes openssl/project#1648
