### PR TITLE
Fix Memory leak in CMS_EncryptedData_set1_key

### DIFF
--- a/crypto/cms/cms_enc.c
+++ b/crypto/cms/cms_enc.c
@@ -229,6 +229,10 @@ int CMS_EncryptedData_set1_key(CMS_ContentInfo *cms, const EVP_CIPHER *ciph,
         return 0;
     }
     if (ciph) {
+        if (cms->d.encryptedData != NULL) {
+            M_ASN1_free_of(cms->d.encryptedData, CMS_EncryptedData);
+            cms->d.encryptedData = NULL;
+        }
         cms->d.encryptedData = M_ASN1_new_of(CMS_EncryptedData);
         if (!cms->d.encryptedData) {
             ERR_raise(ERR_LIB_CMS, ERR_R_ASN1_LIB);

--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -385,6 +385,29 @@ end:
     return ret;
 }
 
+static int test_CMS_set1_key_mem_leak()
+{
+    CMS_ContentInfo *cms;
+    unsigned char key[32] = {0};
+    int i, ret = 0;
+
+    if (!TEST_ptr(cms = CMS_ContentInfo_new()))
+        return 0;
+
+    if (!TEST_true(CMS_EncryptedData_set1_key(cms, EVP_aes_256_cbc(),
+                                              key, 32)))
+        goto end;
+
+    if (!TEST_true(CMS_EncryptedData_set1_key(cms, EVP_aes_128_cbc(),
+                                              key, 16)))
+        goto end;
+
+    ret = 1;
+end:
+    CMS_ContentInfo_free(cms);
+    return ret;
+}
+
 OPT_TEST_DECLARE_USAGE("certfile privkeyfile derfile\n")
 
 int setup_tests(void)
@@ -431,6 +454,7 @@ int setup_tests(void)
     ADD_TEST(test_encrypt_decrypt_aes_256_gcm);
     ADD_TEST(test_CMS_add1_cert);
     ADD_TEST(test_d2i_CMS_bio_NULL);
+    ADD_TEST(test_CMS_set1_key_mem_leak);
     ADD_ALL_TESTS(test_d2i_CMS_decode, 2);
     return 1;
 }


### PR DESCRIPTION
When CMS_EncryptedData_set1_key is called repeatedly it will leak data on the second call. This was because
cms->d.encryptedData was already set and needed to be cleared before the call to M_ASN1_new_of.

Fixes: #28606

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
