### PR TITLE
Instruction Reordering Further Optimizes OpenSSL SHA256 Performance on RISC-V

### DIFF
--- a/crypto/aes/asm/aes-riscv64-zvkned.pl
+++ b/crypto/aes/asm/aes-riscv64-zvkned.pl
@@ -210,6 +210,88 @@ ___
     return $code;
 }
 
+# aes-128 decryption with round keys v1-v11
+sub aes_128_decrypt_6 {
+    my $code=<<___;
+    @{[vaesz_vs $V24, $V11]}   # with round key w[40,43]
+    @{[vaesz_vs $V25, $V11]}   # with round key w[40,43]
+    @{[vaesz_vs $V26, $V11]}   # with round key w[40,43]
+    @{[vaesz_vs $V27, $V11]}   # with round key w[40,43]
+    @{[vaesz_vs $V28, $V11]}   # with round key w[40,43]
+    @{[vaesz_vs $V29, $V11]}   # with round key w[40,43]
+    @{[vaesdm_vs $V24, $V10]}  # with round key w[36,39]
+    @{[vaesdm_vs $V25, $V10]}  # with round key w[36,39]
+    @{[vaesdm_vs $V26, $V10]}  # with round key w[36,39]
+    @{[vaesdm_vs $V27, $V10]}  # with round key w[36,39]
+    @{[vaesdm_vs $V28, $V10]}  # with round key w[36,39]
+    @{[vaesdm_vs $V29, $V10]}  # with round key w[36,39]
+    @{[vaesdm_vs $V24, $V9]}   # with round key w[32,35]
+    @{[vaesdm_vs $V25, $V9]}   # with round key w[32,35]
+    @{[vaesdm_vs $V26, $V9]}   # with round key w[32,35]
+    @{[vaesdm_vs $V27, $V9]}   # with round key w[32,35]
+    @{[vaesdm_vs $V28, $V9]}   # with round key w[32,35]
+    @{[vaesdm_vs $V29, $V9]}   # with round key w[32,35]
+
+    @{[vaesdm_vs $V24, $V8]}   # with round key w[28,31]
+    @{[vaesdm_vs $V25, $V8]}   # with round key w[28,31]
+    @{[vaesdm_vs $V26, $V8]}   # with round key w[28,31]
+    @{[vaesdm_vs $V27, $V8]}   # with round key w[28,31]
+    @{[vaesdm_vs $V28, $V8]}   # with round key w[28,31]
+    @{[vaesdm_vs $V29, $V8]}   # with round key w[28,31]
+
+    @{[vaesdm_vs $V24, $V7]}   # with round key w[24,27]
+    @{[vaesdm_vs $V25, $V7]}   # with round key w[24,27]
+    @{[vaesdm_vs $V26, $V7]}   # with round key w[24,27]
+    @{[vaesdm_vs $V27, $V7]}   # with round key w[24,27]
+    @{[vaesdm_vs $V28, $V7]}   # with round key w[24,27]
+    @{[vaesdm_vs $V29, $V7]}   # with round key w[24,27]
+
+    @{[vaesdm_vs $V24, $V6]}   # with round key w[20,23]
+    @{[vaesdm_vs $V25, $V6]}   # with round key w[20,23]
+    @{[vaesdm_vs $V26, $V6]}   # with round key w[20,23]
+    @{[vaesdm_vs $V27, $V6]}   # with round key w[20,23]
+    @{[vaesdm_vs $V28, $V6]}   # with round key w[20,23]
+    @{[vaesdm_vs $V29, $V6]}   # with round key w[20,23]
+    
+    @{[vaesdm_vs $V24, $V5]}   # with round key w[16,19]
+    @{[vaesdm_vs $V25, $V5]}   # with round key w[16,19]
+    @{[vaesdm_vs $V26, $V5]}   # with round key w[16,19]
+    @{[vaesdm_vs $V27, $V5]}   # with round key w[16,19]
+    @{[vaesdm_vs $V28, $V5]}   # with round key w[16,19]
+    @{[vaesdm_vs $V29, $V5]}   # with round key w[16,19]
+
+    @{[vaesdm_vs $V24, $V4]}   # with round key w[12,15]
+    @{[vaesdm_vs $V25, $V4]}   # with round key w[12,15]
+    @{[vaesdm_vs $V26, $V4]}   # with round key w[12,15]
+    @{[vaesdm_vs $V27, $V4]}   # with round key w[12,15]
+    @{[vaesdm_vs $V28, $V4]}   # with round key w[12,15]
+    @{[vaesdm_vs $V29, $V4]}   # with round key w[12,15]
+
+    @{[vaesdm_vs $V24, $V3]}   # with round key w[ 8,11]
+    @{[vaesdm_vs $V25, $V3]}   # with round key w[ 8,11]
+    @{[vaesdm_vs $V26, $V3]}   # with round key w[ 8,11]
+    @{[vaesdm_vs $V27, $V3]}   # with round key w[ 8,11]
+    @{[vaesdm_vs $V28, $V3]}   # with round key w[ 8,11]
+    @{[vaesdm_vs $V29, $V3]}   # with round key w[ 8,11]
+
+    @{[vaesdm_vs $V24, $V2]}   # with round key w[ 4, 7]
+    @{[vaesdm_vs $V25, $V2]}   # with round key w[ 4, 7]
+    @{[vaesdm_vs $V26, $V2]}   # with round key w[ 4, 7]
+    @{[vaesdm_vs $V27, $V2]}   # with round key w[ 4, 7]
+    @{[vaesdm_vs $V28, $V2]}   # with round key w[ 4, 7]
+    @{[vaesdm_vs $V29, $V2]}   # with round key w[ 4, 7]
+
+    @{[vaesdf_vs $V24, $V1]}   # with round key w[ 0, 3]
+    @{[vaesdf_vs $V25, $V1]}   # with round key w[ 0, 3]
+    @{[vaesdf_vs $V26, $V1]}   # with round key w[ 0, 3]
+    @{[vaesdf_vs $V27, $V1]}   # with round key w[ 0, 3]
+    @{[vaesdf_vs $V28, $V1]}   # with round key w[ 0, 3]
+    @{[vaesdf_vs $V29, $V1]}   # with round key w[ 0, 3]
+___
+
+    return $code;
+}
+
 # aes-192 encryption with round keys v1-v13
 sub aes_192_encrypt {
     my $code=<<___;
@@ -481,6 +563,61 @@ L_cbc_dec_128:
     # Load IV.
     @{[vle32_v $V16, $IVP]}
 
+    li $T1, 96
+3:
+    blt $LEN, $T1, L_small 
+
+    @{[vle32_v $V24, $INP]}
+    addi $INP, $INP, 16
+    @{[vle32_v $V25, $INP]}
+    addi $INP, $INP, 16
+    @{[vle32_v $V26, $INP]}
+    addi $INP, $INP, 16
+    @{[vle32_v $V27, $INP]}
+    addi $INP, $INP, 16
+    @{[vle32_v $V28, $INP]}
+    addi $INP, $INP, 16
+    @{[vle32_v $V29, $INP]}
+    addi $INP, $INP, 16
+    @{[vmv_v_v $V17, $V24]}  
+    @{[vmv_v_v $V18, $V25]}
+    @{[vmv_v_v $V19, $V26]} 
+    @{[vmv_v_v $V20, $V27]} 
+    @{[vmv_v_v $V21, $V28]} 
+    @{[vmv_v_v $V22, $V29]}  
+
+    @{[aes_128_decrypt_6]} 
+
+    @{[vxor_vv $V24, $V24, $V16]}  
+    @{[vxor_vv $V25, $V25, $V17]}
+    @{[vxor_vv $V26, $V26, $V18]}
+    @{[vxor_vv $V27, $V27, $V19]}
+    @{[vxor_vv $V28, $V28, $V20]}
+    @{[vxor_vv $V29, $V29, $V21]}
+
+    @{[vse32_v $V24, $OUTP]}
+    addi $OUTP, $OUTP, 16 
+    @{[vse32_v $V25, $OUTP]}
+    addi $OUTP, $OUTP, 16      
+    @{[vse32_v $V26, $OUTP]}
+    addi $OUTP, $OUTP, 16
+    @{[vse32_v $V27, $OUTP]}
+    addi $OUTP, $OUTP, 16   
+    @{[vse32_v $V28, $OUTP]}
+    addi $OUTP, $OUTP, 16
+    @{[vse32_v $V29, $OUTP]}
+    addi $OUTP, $OUTP, 16
+
+    @{[vmv_v_v $V16, $V22]}  
+
+    addi $LEN, $LEN, -96       
+    
+    bnez $LEN, 3b 
+    @{[vse32_v $V16, $IVP]} 
+
+    ret
+
+L_small:
     @{[vle32_v $V24, $INP]}
     @{[vmv_v_v $V17, $V24]}
     j 2f

--- a/crypto/sha/asm/sha256-riscv64-zvkb-zvknha_or_zvknhb.pl
+++ b/crypto/sha/asm/sha256-riscv64-zvkb-zvknha_or_zvknhb.pl
@@ -117,9 +117,11 @@ $code .= <<___;
 .globl sha256_block_data_order_zvkb_zvknha_or_zvknhb
 .type   sha256_block_data_order_zvkb_zvknha_or_zvknhb,\@function
 sha256_block_data_order_zvkb_zvknha_or_zvknhb:
-    @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
 
-    @{[sha_256_load_constant]}
+    # Setup v0 mask for the vmerge to replace the first word (idx==0) in key-scheduling.
+    # The AVL is 4 in SHA, so we could use a single e8(8 element masking) for masking.
+    @{[vsetivli "zero", 1, "e8", "m1", "ta", "ma"]}
+    @{[vmv_v_i $V0, 0x01]}
 
     # H is stored as {a,b,c,d},{e,f,g,h}, but we need {f,e,b,a},{h,g,d,c}
     # The dst vtype is e32m1 and the index vtype is e8mf4.
@@ -141,12 +143,7 @@ sha256_block_data_order_zvkb_zvknha_or_zvknhb:
     @{[vluxei8_v $V6, $H, $V26]}
     @{[vluxei8_v $V7, $H2, $V26]}
 
-    # Setup v0 mask for the vmerge to replace the first word (idx==0) in key-scheduling.
-    # The AVL is 4 in SHA, so we could use a single e8(8 element masking) for masking.
-    @{[vsetivli "zero", 1, "e8", "m1", "ta", "ma"]}
-    @{[vmv_v_i $V0, 0x01]}
-
-    @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
+    @{[sha_256_load_constant]}
 
 L_round_loop:
     # Decrement length by 1


### PR DESCRIPTION
Further optimized the performance of OpenSSL SHA256 on RISC-V. This involves reordering instructions in the core function to reduce the use of two vsetivli instructions, thereby improving performance for packets of 1024KB and smaller.

The average result was taken from three test runs performed on a RISC-V virtual machine featuring the Zvkb, Zvknha, and Zvknhb extensions.

**Performance Improvement**
encrypt:
| Test | Baseline (C) | Optimized | Improvement ratio |
| ---- | ----------------- | --------- | ----------------- |
| 16bytes   | 2375.29k          | 2505.53k  | 5%                |
| 64bytes   | 7494.73k          | 7972.58k  | 6%                |
| 256bytes  | 24337.32k         | 25175.52k | 3%                |
| 1024bytes | 54514.31k         | 55948.01k | 3%                |

decrypt:
| Test | Baseline (C) | Optimized | Improvement ratio |
| ---- | ----------------- | --------- | ----------------- |
| 16bytes   | 2352.02k           | 2372.83k  | 1%                |
| 64bytes   | 7276.74k          | 7487.27k  | 3%                |
| 256bytes  | 23465.56k         | 24151.21k | 3%                |
| 1024bytes | 53510.66k         | 54169.60k | 1%                |

**Test Verification**
All relevant tests pass in the default build configuration:
make test
All tests successful.
Files=350, Tests=4030, 10562 wallclock secs (94.68 usr 23.55 sys + 8298.27 cusr 1984.96 csys = 10401.46 CPU)
Result: PASS



##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
