### PR TITLE
Instruction Reordering Further Optimizes OpenSSL SHA256 Performance on RISC-V

### DIFF
--- a/crypto/sha/asm/sha256-riscv64-zvkb-zvknha_or_zvknhb.pl
+++ b/crypto/sha/asm/sha256-riscv64-zvkb-zvknha_or_zvknhb.pl
@@ -117,9 +117,11 @@ $code .= <<___;
 .globl sha256_block_data_order_zvkb_zvknha_or_zvknhb
 .type   sha256_block_data_order_zvkb_zvknha_or_zvknhb,\@function
 sha256_block_data_order_zvkb_zvknha_or_zvknhb:
-    @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
 
-    @{[sha_256_load_constant]}
+    # Setup v0 mask for the vmerge to replace the first word (idx==0) in key-scheduling.
+    # The AVL is 4 in SHA, so we could use a single e8(8 element masking) for masking.
+    @{[vsetivli "zero", 1, "e8", "m1", "ta", "ma"]}
+    @{[vmv_v_i $V0, 0x01]}
 
     # H is stored as {a,b,c,d},{e,f,g,h}, but we need {f,e,b,a},{h,g,d,c}
     # The dst vtype is e32m1 and the index vtype is e8mf4.
@@ -141,12 +143,7 @@ sha256_block_data_order_zvkb_zvknha_or_zvknhb:
     @{[vluxei8_v $V6, $H, $V26]}
     @{[vluxei8_v $V7, $H2, $V26]}
 
-    # Setup v0 mask for the vmerge to replace the first word (idx==0) in key-scheduling.
-    # The AVL is 4 in SHA, so we could use a single e8(8 element masking) for masking.
-    @{[vsetivli "zero", 1, "e8", "m1", "ta", "ma"]}
-    @{[vmv_v_i $V0, 0x01]}
-
-    @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
+    @{[sha_256_load_constant]}
 
 L_round_loop:
     # Decrement length by 1


### PR DESCRIPTION
Further optimized the performance of OpenSSL SHA256 on RISC-V. This involves reordering instructions in the core function to reduce the use of two vsetivli instructions, thereby improving performance for packets of 1024KB and smaller.

The average result was taken from three test runs performed on a RISC-V virtual machine featuring the Zvkb, Zvknha, and Zvknhb extensions.

openssl speed -elapsed -seconds 1 -evp sha256

**Performance Improvement**

| Test | Baseline (C) | Optimized | Improvement ratio |
| ---- | ----------------- | --------- | ----------------- |
| 16bytes   | 2375.29k          | 2505.53k  | 5%                |
| 64bytes   | 7494.73k          | 7972.58k  | 6%                |
| 256bytes  | 24337.32k         | 25175.52k | 3%                |
| 1024bytes | 54514.31k         | 55948.01k | 3%                |

**Test Verification**
All relevant tests pass in the default build configuration:
make test
All tests successful.
Files=350, Tests=4030, 10562 wallclock secs (94.68 usr 23.55 sys + 8298.27 cusr 1984.96 csys = 10401.46 CPU)
Result: PASS

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
