### PR TITLE
hashtable: add option to disable RCU locks

### DIFF
--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -547,7 +547,7 @@ OSSL_NAMEMAP *ossl_namemap_stored(OSSL_LIB_CTX *libctx)
 OSSL_NAMEMAP *ossl_namemap_new(OSSL_LIB_CTX *libctx)
 {
     OSSL_NAMEMAP *namemap;
-    HT_CONFIG htconf = { NULL, NULL, NULL, NAMEMAP_HT_BUCKETS, 1, 1 };
+    HT_CONFIG htconf = { NULL, NULL, NULL, NAMEMAP_HT_BUCKETS, 1, 1, 0 };
 
     htconf.ctx = libctx;
 

--- a/crypto/hashtable/hashtable.c
+++ b/crypto/hashtable/hashtable.c
@@ -624,7 +624,6 @@ static int ossl_ht_insert_locked(HT *h, uint64_t hash,
                     md->neighborhoods[neigh_idx].entries[j].hash = hash;
                     *olddata = (HT_VALUE *)md->neighborhoods[neigh_idx].entries[j].value;
                     md->neighborhoods[neigh_idx].entries[j].value = newval;
-                    free_old_ht_value(*olddata);
                 }
                 h->wpd.need_sync = 1;
                 return 1;
@@ -805,7 +804,7 @@ int ossl_ht_delete(HT *h, HT_KEY *key)
             continue;
         if (compare_hash(hash, h->md->neighborhoods[neigh_idx].entries[j].hash)
             && match_key(key, &v->value.key)) {
-            if (ossl_ht_get_cfg_no_rcu(h)) {
+            if (!ossl_ht_get_cfg_no_rcu(h)) {
                 if (!CRYPTO_atomic_store(&h->md->neighborhoods[neigh_idx].entries[j].hash,
                                          0, h->atomic_lock))
                     break;

--- a/doc/internal/man3/ossl_ht_new.pod
+++ b/doc/internal/man3/ossl_ht_new.pod
@@ -67,6 +67,7 @@ of:
     I<ht_free_fn> The function to call to free a value, may be NULL.
     I<ht_hash_fn> The function to generate a hash value for a key, may be NULL.
     I<init_neighborhoods> The initial number of neighborhoods in the hash table.
+    I<no_rcu> Disables RCU locking.
 
 Note that init_bucket_len may be set to zero, which will use the default initial
 bucket size, which will be automatically expanded with the hash table load
@@ -83,6 +84,9 @@ Note that lockless_write operations are done at your own risk.  Lockless
     operation in a multithreaded environment will cause data corruption.  It
     is the callers responsibility in this mode of operation to provide thread
     synchronization.
+
+Note that if RCU locks are disabled, calls to ossl_ht_[read/write]_[lock/unlock]
+have no effect.
 
 =item *
 
@@ -110,7 +114,8 @@ called to release the element data.
 =item *
 
 ossl_ht_insert() inserts an B<HT_VALUE> element into the hash table, to be
-hashed using the corresponding B<HT_KEY> value.
+hashed using the corresponding B<HT_KEY> value. The returned pointer olddata must
+be freed only when RCU is disabled and insert performs a replacement.
 
 =item *
 

--- a/fuzz/hashtable.c
+++ b/fuzz/hashtable.c
@@ -99,7 +99,7 @@ static void fuzz_free_cb(HT_VALUE *v)
 
 int FuzzerInitialize(int *argc, char ***argv)
 {
-    HT_CONFIG fuzz_conf = {NULL, fuzz_free_cb, NULL, 0, 1};
+    HT_CONFIG fuzz_conf = {NULL, fuzz_free_cb, NULL, 0, 1, 0};
 
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     ERR_clear_error();

--- a/include/internal/hashtable.h
+++ b/include/internal/hashtable.h
@@ -54,6 +54,7 @@ typedef struct ht_config_st {
     size_t init_neighborhoods;
     uint32_t collision_check;
     uint32_t lockless_reads;
+    uint32_t no_rcu;
 } HT_CONFIG;
 
 /*
@@ -221,7 +222,10 @@ pfx ossl_unused vtype *ossl_unused ossl_ht_##name##_##vtype##_get(HT *h,       \
     vv = ossl_ht_get(h, key);                                                  \
     if (vv == NULL)                                                            \
         return NULL;                                                           \
-    *v = ossl_rcu_deref(&vv);                                                  \
+    if (!ossl_ht_get_cfg_no_rcu(h))                                            \
+        *v = ossl_rcu_deref(&vv);                                              \
+    else                                                                       \
+        *v = vv;                                                               \
     return ossl_ht_##name##_##vtype##_from_value(*v);                          \
 }                                                                              \
                                                                                \
@@ -351,5 +355,10 @@ void ossl_ht_value_list_free(HT_VALUE_LIST *list);
  * on key.  Returns NULL if the element was not found.
  */
 HT_VALUE *ossl_ht_get(HT *htable, HT_KEY *key);
+
+/*
+ * Returns config option *no_rcu* value.
+ */
+int ossl_ht_get_cfg_no_rcu(HT *htable);
 
 #endif

--- a/include/internal/hashtable.h
+++ b/include/internal/hashtable.h
@@ -50,7 +50,7 @@ typedef struct ht_value_list_st {
 typedef struct ht_config_st {
     OSSL_LIB_CTX *ctx;
     void (*ht_free_fn)(HT_VALUE *obj);
-    uint64_t (*ht_hash_fn)(uint8_t *key, size_t keylen);
+    uint64_t (*ht_hash_fn)(HT_KEY *key);
     size_t init_neighborhoods;
     uint32_t collision_check;
     uint32_t lockless_reads;

--- a/include/internal/hashtable.h
+++ b/include/internal/hashtable.h
@@ -199,8 +199,11 @@ pfx ossl_unused int ossl_ht_##name##_##vtype##_insert(HT *h, HT_KEY *key,      \
     inval.value = data;                                                        \
     inval.type_id = &name##_##vtype##_id;                                      \
     rc = ossl_ht_insert(h, key, &inval, olddata == NULL ? NULL : &oval);       \
-    if (oval != NULL)                                                          \
+    if (oval != NULL) {                                                        \
         *olddata = (vtype *)oval->value;                                       \
+        if (ossl_ht_get_cfg_no_rcu(h))                                         \
+            OPENSSL_free(oval);                                                \
+    }                                                                          \
     return rc;                                                                 \
 }                                                                              \
                                                                                \

--- a/test/lhash_test.c
+++ b/test/lhash_test.c
@@ -207,9 +207,9 @@ static int int_foreach(HT_VALUE *v, void *arg)
     return 1;
 }
 
-static uint64_t hashtable_hash(uint8_t *key, size_t keylen)
+static uint64_t hashtable_hash(HT_KEY *key)
 {
-    return (uint64_t)(*(uint32_t *)key);
+    return (uint64_t)(*(uint32_t *)key->keybuf);
 }
 
 static int test_int_hashtable(void)

--- a/test/lhash_test.c
+++ b/test/lhash_test.c
@@ -212,7 +212,7 @@ static uint64_t hashtable_hash(HT_KEY *key)
     return (uint64_t)(*(uint32_t *)key->keybuf);
 }
 
-static int test_int_hashtable(void)
+static int test_int_hashtable(int idx)
 {
     static struct {
         int data;
@@ -227,11 +227,8 @@ static int test_int_hashtable(void)
     };
     const size_t n_dels = OSSL_NELEM(dels);
     HT_CONFIG hash_conf = {
-        NULL,
-        NULL,
-        NULL,
-        0,
-        1,
+        .collision_check = 1,
+        .no_rcu = idx,
     };
     INTKEY key;
     int rc = 0;
@@ -405,13 +402,14 @@ static int test_hashtable_stress(int idx)
     unsigned int i;
     int testresult = 0, *p;
     HT_CONFIG hash_conf = {
-        NULL,              /* use default context */
-        hashtable_intfree, /* our free function */
-        hashtable_hash,    /* our hash function */
-        625000,            /* preset hash size */
-        1,                 /* Check collisions */
-        0                  /* Lockless reads */
+        .ht_free_fn = hashtable_intfree,
+        .ht_hash_fn = hashtable_hash,
+        .init_neighborhoods = 625000,
+        .collision_check = 1,
+        .lockless_reads = idx % 2,
+        .no_rcu = idx / 2,
     };
+
     HT *h;
     INTKEY key;
     HT_VALUE *v;
@@ -419,9 +417,11 @@ static int test_hashtable_stress(int idx)
     struct timeval start, end, delta;
 #endif
 
-    hash_conf.lockless_reads = idx;
     h = ossl_ht_new(&hash_conf);
-
+    if (h == NULL
+        && hash_conf.no_rcu
+        && hash_conf.lockless_reads)
+        return 1;
 
     if (!TEST_ptr(h))
         goto end;
@@ -456,7 +456,7 @@ static int test_hashtable_stress(int idx)
         const int j = (7 * i + 4) % n * 3 + 1;
         HT_SET_KEY_FIELD(&key, mykey, j);
 
-        switch (idx) {
+        switch (idx % 2) {
         case 0:
             if (!TEST_int_eq((ossl_ht_delete(h, TO_HT_KEY(&key))), 1)) {
                 TEST_info("hashtable didn't delete key %d\n", j);
@@ -503,9 +503,14 @@ HT_END_KEY_DEFN(MTKEY)
 
 IMPLEMENT_HT_VALUE_TYPE_FNS(TEST_MT_ENTRY, mt, static)
 
+struct ht_internal_st {
+    HT_CONFIG config;
+};
+
 static int worker_num = 0;
 static CRYPTO_RWLOCK *worker_lock;
 static CRYPTO_RWLOCK *testrand_lock;
+static CRYPTO_RWLOCK *no_rcu_lock;
 static int free_failure = 0;
 static int shutting_down = 0;
 static int global_iteration = 0;
@@ -573,21 +578,36 @@ static void do_mt_hash_work(void)
         }
         switch(behavior) {
         case DO_LOOKUP:
-            if (!ossl_ht_read_lock(m_ht))
-                break;
+            if (!m_ht->config.no_rcu) {
+                if (!ossl_ht_read_lock(m_ht))
+                    break;
+            } else {
+                if (!TEST_true(CRYPTO_THREAD_read_lock(no_rcu_lock)))
+                    break;
+            }
             m = ossl_ht_mt_TEST_MT_ENTRY_get(m_ht, TO_HT_KEY(&key), &v);
             if (m != NULL && m != expected_m) {
                 worker_exits[num] = "Read unexpected value from hashtable";
                 TEST_info("Iteration %d Read unexpected value %p when %p expected",
                           giter, (void *)m, (void *)expected_m);
             }
-            ossl_ht_read_unlock(m_ht);
+            if (!m_ht->config.no_rcu) {
+                ossl_ht_read_unlock(m_ht);
+            } else {
+                if (!TEST_true(CRYPTO_THREAD_unlock(no_rcu_lock)))
+                    break;
+            }
             if (worker_exits[num] != NULL)
                 return;
             break;
         case DO_INSERT:
         case DO_REPLACE:
-            ossl_ht_write_lock(m_ht);
+            if (!m_ht->config.no_rcu) {
+                ossl_ht_write_lock(m_ht);
+            } else {
+                if (!TEST_true(CRYPTO_THREAD_write_lock(no_rcu_lock)))
+                    break;
+            }
             if (behavior == DO_REPLACE) {
                 expected_rc = 1;
                 r = &m;
@@ -607,12 +627,22 @@ static void do_mt_hash_work(void)
             }
             if (expected_rc == 1)
                 expected_m->in_table = 1;
-            ossl_ht_write_unlock(m_ht);
+            if (!m_ht->config.no_rcu) {
+                ossl_ht_write_unlock(m_ht);
+            } else {
+                if (!TEST_true(CRYPTO_THREAD_unlock(no_rcu_lock)))
+                    break;
+            }
             if (worker_exits[num] != NULL)
                 return;
             break;
         case DO_DELETE:
-            ossl_ht_write_lock(m_ht);
+            if (!m_ht->config.no_rcu) {
+                ossl_ht_write_lock(m_ht);
+            } else {
+                if (!TEST_true(CRYPTO_THREAD_write_lock(no_rcu_lock)))
+                    break;
+            }
             expected_rc = expected_m->in_table;
             if (expected_rc == 1) {
                 /*
@@ -632,7 +662,12 @@ static void do_mt_hash_work(void)
                           expected_m->in_table ? "in table" : "not in table");
                 worker_exits[num] = "Failure on delete";
             }
-            ossl_ht_write_unlock(m_ht);
+            if (!m_ht->config.no_rcu) {
+                ossl_ht_write_unlock(m_ht);
+            } else {
+                if (!TEST_true(CRYPTO_THREAD_unlock(no_rcu_lock)))
+                    break;
+            }
             if (worker_exits[num] != NULL)
                 return;
             break;
@@ -643,14 +678,13 @@ static void do_mt_hash_work(void)
     }
 }
 
-static int test_hashtable_multithread(void)
+static int test_hashtable_multithread(int idx)
 {
     HT_CONFIG hash_conf = {
-        NULL,              /* use default context */
-        hashtable_mt_free, /* our free function */
-        NULL,              /* default hash function */
-        0,                 /* default hash size */
-        1,                 /* Check collisions */
+        .ht_free_fn = hashtable_mt_free,
+        .init_neighborhoods = 0,
+        .collision_check = 1,
+        .no_rcu = idx,
     };
     int ret = 0;
     thread_t workers[NUM_WORKERS];
@@ -671,6 +705,8 @@ static int test_hashtable_multithread(void)
     if (!TEST_ptr(worker_lock = CRYPTO_THREAD_lock_new()))
         goto end_free;
     if (!TEST_ptr(testrand_lock = CRYPTO_THREAD_lock_new()))
+        goto end_free;
+    if (!TEST_ptr(no_rcu_lock = CRYPTO_THREAD_lock_new()))
         goto end_free;
 #ifdef MEASURE_HASH_PERFORMANCE
     gettimeofday(&start, NULL);
@@ -709,11 +745,15 @@ shutdown:
     TEST_info("multithread stress runs 40000 ops in %ld.%ld seconds", delta.tv_sec, delta.tv_usec);
 #endif
 
+    worker_num = 0;
+    free_failure = 0;
+    global_iteration = 0;
 end_free:
     shutting_down = 1;
     ossl_ht_free(m_ht);
     CRYPTO_THREAD_lock_free(worker_lock);
     CRYPTO_THREAD_lock_free(testrand_lock);
+    CRYPTO_THREAD_lock_free(no_rcu_lock);
 end:
     return ret;
 }
@@ -722,8 +762,8 @@ int setup_tests(void)
 {
     ADD_TEST(test_int_lhash);
     ADD_TEST(test_stress);
-    ADD_TEST(test_int_hashtable);
-    ADD_ALL_TESTS(test_hashtable_stress, 2);
-    ADD_TEST(test_hashtable_multithread);
+    ADD_ALL_TESTS(test_int_hashtable, 2);
+    ADD_ALL_TESTS(test_hashtable_stress, 4);
+    ADD_ALL_TESTS(test_hashtable_multithread, 2);
     return 1;
 }


### PR DESCRIPTION
a new config option _no_rcu_ is added into HT_CONFIG. When _no_rcu_ is
set then hashtable can be guarded with any other locking primitives,
and behives as ordinary hashtable. Also, all the impact of the
atomics used internally to the hash table was mitigated.

```
RCU performance

   # INFO:  @ test/lhash_test.c:747
   # multithread stress runs 40000 ops in 40.779656 seconds

No RCU, guarded with RWLOCK

   # INFO:  @ test/lhash_test.c:747
   # multithread stress runs 40000 ops in 36.976926 seconds
```