### PR TITLE
Fix riscv64 chacha crash due to unaligned data

### DIFF
--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -7,10 +7,7 @@
 
 name: OS Zoo CI
 
-on:
-  schedule:
-    - cron: '50 02 * * *'
-  workflow_dispatch:
+on: [pull_request]
 
 permissions:
   contents: read

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -237,7 +237,7 @@ jobs:
       run: ./util/opensslwrap.sh version -c
     - name: make test
       env:
-        OPENSSL_riscvcap: ZBA_ZBB_ZBC_ZBS_ZKT
+        OPENSSL_riscvcap: RV64GC_ZBA_ZBB_ZBC_ZBS_ZKT_V
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   freebsd-x86_64:

--- a/crypto/chacha/chacha_riscv.c
+++ b/crypto/chacha/chacha_riscv.c
@@ -51,7 +51,9 @@ void ChaCha20_ctr32_v_zbb(unsigned char *out, const unsigned char *inp,
 void ChaCha20_ctr32(unsigned char *out, const unsigned char *inp, size_t len,
                     const unsigned int key[8], const unsigned int counter[4])
 {
-    if (len > CHACHA_BLK_SIZE && RISCV_HAS_ZBB() && riscv_vlen() >= 128) {
+    if (len > CHACHA_BLK_SIZE && RISCV_HAS_ZBB() && riscv_vlen() >= 128
+            && (size_t)out % sizeof(size_t) == 0
+            && (size_t)inp % sizeof(size_t) == 0) {
         if (RISCV_HAS_ZVKB()) {
             ChaCha20_ctr32_v_zbb_zvkb(out, inp, len, key, counter);
         } else {


### PR DESCRIPTION
The linux-riscv64 test machine crashes due to unaligned data,
when the V extension is enabled, while QEMU seems to have no
problems with unaligned data.