### PR TITLE
ts_conf: fix memory leak in TS_CONF_set_policies

### DIFF
--- a/crypto/ts/ts_conf.c
+++ b/crypto/ts/ts_conf.c
@@ -342,8 +342,10 @@ int TS_CONF_set_policies(CONF *conf, const char *section, TS_RESP_CTX *ctx)
             ts_CONF_invalid(section, ENV_OTHER_POLICIES);
             goto err;
         }
-        if (!TS_RESP_CTX_add_policy(ctx, objtmp))
+        if (!TS_RESP_CTX_add_policy(ctx, objtmp)) {
+            ASN1_OBJECT_free(objtmp);
             goto err;
+        }
         ASN1_OBJECT_free(objtmp);
     }
 


### PR DESCRIPTION
TS_CONF_set_policies() allocated ASN1_OBJECTs via OBJ_txt2obj()
but did not free them after calling TS_RESP_CTX_add_policy().
Since TS_RESP_CTX_add_policy() duplicates the object internally,
the temporary ASN1_OBJECT must always be freed.

This patch ensures ASN1_OBJECT_free() is called on both success
and failure paths, preventing a per-policy memory leak.

Fixes #28628

