### PR TITLE
Remove ENGINESDIR variable and engines installation from Makefiles.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -70,7 +70,6 @@ jobs:
       run: |
         echo ${Env:OSSL_VERSION}
         reg.exe add HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v OPENSSLDIR /t REG_EXPAND_SZ /d TESTOPENSSLDIR /reg:32
-        reg.exe add HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v ENGINESDIR /t REG_EXPAND_SZ /d TESTOPENSSLDIR /reg:32
         reg.exe add HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v MODULESDIR /t REG_EXPAND_SZ /d TESTOPENSSLDIR /reg:32
         reg.exe query HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v OPENSSLDIR /reg:32
     - name: get cpu info

--- a/.github/workflows/windows_comp.yml
+++ b/.github/workflows/windows_comp.yml
@@ -61,7 +61,6 @@ jobs:
       run: |
         echo ${Env:OSSL_VERSION}
         reg.exe add HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v OPENSSLDIR /t REG_EXPAND_SZ /d TESTOPENSSLDIR /reg:32
-        reg.exe add HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v ENGINESDIR /t REG_EXPAND_SZ /d TESTOPENSSLDIR /reg:32
         reg.exe add HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v MODULESDIR /t REG_EXPAND_SZ /d TESTOPENSSLDIR /reg:32
         reg.exe query HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v OPENSSLDIR /reg:32
     - name: download coreinfo
@@ -126,7 +125,6 @@ jobs:
       run: |
         echo ${Env:OSSL_VERSION}
         reg.exe add HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v OPENSSLDIR /t REG_EXPAND_SZ /d TESTOPENSSLDIR /reg:32
-        reg.exe add HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v ENGINESDIR /t REG_EXPAND_SZ /d TESTOPENSSLDIR /reg:32
         reg.exe add HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v MODULESDIR /t REG_EXPAND_SZ /d TESTOPENSSLDIR /reg:32
         reg.exe query HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v OPENSSLDIR /reg:32
     - name: download coreinfo

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -56,13 +56,8 @@
       map { platform->sharedname($_) // () }
       grep { !$unified_info{attributes}->{libraries}->{$_}->{noinst} }
       @{$unified_info{libraries}};
-  our @install_engines =
-      grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
-             && $unified_info{attributes}->{modules}->{$_}->{engine} }
-      @{$unified_info{modules}};
   our @install_modules =
       grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
-             && !$unified_info{attributes}->{modules}->{$_}->{engine}
              && !$unified_info{attributes}->{modules}->{$_}->{fips} }
       @{$unified_info{modules}};
   our @install_fipsmodules =
@@ -109,7 +104,6 @@
                 @{$config{lib_defines}}, @{$config{shared_defines}},
                 @cnf_defines,
                 'OPENSSLDIR="""$(OPENSSLDIR_C)"""',
-                'ENGINESDIR="""$(ENGINESDIR_C)"""',
                 'MODULESDIR="""$(MODULESDIR_C)"""'
                 )
       . '$(DEFINES)'
@@ -353,7 +347,6 @@ GENERATED={- # common0.tmpl provides @generated
 
 INSTALL_LIBS={- join(", ", map { "-\n\t".$_.".OLB" } @install_libs) -}
 INSTALL_SHLIBS={- join(", ", map { "-\n\t".$_.".EXE" } @install_shlibs) -}
-INSTALL_ENGINES={- join(", ", map { "-\n\t".$_.".EXE" } @install_engines) -}
 INSTALL_MODULES={- join(", ", map { "-\n\t".$_.".EXE" } @install_modules) -}
 INSTALL_FIPSMODULE={- join(", ", map { "-\n\t".$_.".EXE" } @install_fipsmodules) -}
 INSTALL_FIPSMODULECONF=[.providers]fipsmodule.cnf
@@ -387,8 +380,6 @@ OPENSSLDIR={- catdir($config{openssldir}) or
                               : "SYS\$COMMON:[OPENSSL-COMMON]" -}
 # The same, but for C
 OPENSSLDIR_C={- platform->osslprefix() -}DATAROOT:[000000]
-# Where installed ENGINE modules reside, for C
-ENGINESDIR_C={- platform->osslprefix() -}ENGINES{- $sover_dirname.$target{pointer_size} -}:
 # Where modules reside, for C
 MODULESDIR_C={- platform->osslprefix() -}MODULES{- $target{pointer_size} -}:
 
@@ -598,10 +589,10 @@ depend : descrip.mms
 
 # Install helper targets #############################################
 
-install_sw : install_dev install_engines install_modules -
+install_sw : install_dev install_modules -
              install_runtime install_startup install_ivp
 
-uninstall_sw : uninstall_dev uninstall_modules uninstall_engines -
+uninstall_sw : uninstall_dev uninstall_modules -
                uninstall_runtime uninstall_startup uninstall_ivp
 
 install_docs : install_html_docs
@@ -659,15 +650,6 @@ install_dev : check_INSTALLTOP install_runtime_libs
         {- join("\n        ",
                 map { "COPY/PROT=W:R $_.OLB ossl_installroot:[LIB.'arch']" }
                 @install_libs) -}
-
-install_engines : check_INSTALLTOP install_runtime_libs build_modules
-        @ {- output_off() unless scalar @install_engines; "" -} !
-        @ WRITE SYS$OUTPUT "*** Installing engines"
-        - CREATE/DIR ossl_installroot:[ENGINES{- $sover_dirname.$target{pointer_size} -}.'arch']
-        {- join("\n        ",
-                map { "COPY/PROT=W:RE $_.EXE ossl_installroot:[ENGINES$sover_dirname$target{pointer_size}.'arch']" }
-                @install_engines) -}
-        @ {- output_on() unless scalar @install_engines; "" -} !
 
 install_modules : check_INSTALLTOP install_runtime_libs build_modules
         @ {- output_off() unless scalar @install_modules; "" -} !

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -183,20 +183,11 @@ INSTALL_SHLIB_INFO={-
                         grep { !$unified_info{attributes}->{libraries}->{$_}->{noinst} }
                         @{$unified_info{libraries}}))
 -}
-INSTALL_ENGINES={-
-        join(" \\\n" . ' ' x 16,
-             fill_lines(" ", $COLUMNS - 16,
-                        map { platform->dso($_) }
-                        grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
-                               && $unified_info{attributes}->{modules}->{$_}->{engine} }
-                        @{$unified_info{modules}}))
--}
 INSTALL_MODULES={-
         join(" \\\n" . ' ' x 16,
              fill_lines(" ", $COLUMNS - 16,
                         map { platform->dso($_) }
                         grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
-                               && !$unified_info{attributes}->{modules}->{$_}->{engine}
                                && !$unified_info{attributes}->{modules}->{$_}->{fips} }
                         @{$unified_info{modules}}))
 -}
@@ -333,7 +324,6 @@ LIBDIR={- our $libdir = $config{libdir};
 # $(libdir) is chosen to be compatible with the GNU coding standards
 libdir={- file_name_is_absolute($libdir)
           ? $libdir : '$(INSTALLTOP)/$(LIBDIR)' -}
-ENGINESDIR=$(libdir)/engines-{- $sover_dirname -}
 MODULESDIR=$(libdir)/ossl-modules
 
 # Convenience variable for those who want to set the rpath in shared
@@ -450,7 +440,6 @@ LIB_CPPFLAGS={- our $lib_cppflags =
                 join(' ', $lib_cppflags,
                           (map { '-D'.$_ }
                                'OPENSSLDIR="\"$(OPENSSLDIR)\""',
-                               'ENGINESDIR="\"$(ENGINESDIR)\""',
                                'MODULESDIR="\"$(MODULESDIR)\""'),
                           '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
 LIB_CFLAGS={- join(' ', $target{lib_cflags} || (),
@@ -541,7 +530,7 @@ LANG=C
 
 {- dependmagic('build_sw', 'Build all the software (default target)'); -}: build_libs_nodep build_modules_nodep build_programs_nodep link-utils
 {- dependmagic('build_libs', 'Build the libraries libssl and libcrypto'); -}: build_libs_nodep
-{- dependmagic('build_modules', 'Build the modules (i.e. providers and engines)'); -}: build_modules_nodep
+{- dependmagic('build_modules', 'Build the modules (i.e. providers)'); -}: build_modules_nodep
 {- dependmagic('build_programs', 'Build the openssl executables, scripts and all other programs as configured (e.g. tests or demos)'); -}: build_programs_nodep
 {- dependmagic('build_inst_sw', 'Build all the software to be installed'); -}: build_libs_nodep build_modules_nodep build_inst_programs_nodep link-utils
 {- dependmagic('build_inst_programs', 'Build only the installable openssl executables and scripts'); -}: build_inst_programs_nodep
@@ -675,9 +664,9 @@ install: Makefile ## Install software and documentation, create OpenSSL director
 
 uninstall: {- "uninstall_docs" if !$disabled{docs}; -} uninstall_sw {- $disabled{fips} ? "" : "uninstall_fips" -} ## Uninstall software and documentation
 
-install_sw: install_dev install_engines install_modules install_runtime ## Install just the software and libraries
+install_sw: install_dev install_modules install_runtime ## Install just the software and libraries
 
-uninstall_sw: uninstall_runtime uninstall_modules uninstall_engines uninstall_dev ## Uninstall the software and libraries
+uninstall_sw: uninstall_runtime uninstall_modules uninstall_dev ## Uninstall the software and libraries
 
 install_docs: install_man_docs install_html_docs ## Install manpages and HTML documentation
 
@@ -893,30 +882,6 @@ uninstall_dev: uninstall_runtime_libs
 	-$(RMDIR) "$(DESTDIR)$(libdir)"
 
 _install_modules_deps: install_runtime_libs build_modules
-
-install_engines: _install_modules_deps
-	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
-	@$(PERL) $(SRCDIR)/util/mkdir-p.pl "$(DESTDIR)$(ENGINESDIR)/"
-	@$(ECHO) "*** Installing engines"
-	@set -e; for e in dummy $(INSTALL_ENGINES); do \
-		if [ "$$e" = "dummy" ]; then continue; fi; \
-		fn=`basename $$e`; \
-		$(ECHO) "install $$e -> $(DESTDIR)$(ENGINESDIR)/$$fn"; \
-		cp $$e "$(DESTDIR)$(ENGINESDIR)/$$fn.new"; \
-		chmod 755 "$(DESTDIR)$(ENGINESDIR)/$$fn.new"; \
-		mv -f "$(DESTDIR)$(ENGINESDIR)/$$fn.new" \
-		      "$(DESTDIR)$(ENGINESDIR)/$$fn"; \
-	done
-
-uninstall_engines:
-	@$(ECHO) "*** Uninstalling engines"
-	@set -e; for e in dummy $(INSTALL_ENGINES); do \
-		if [ "$$e" = "dummy" ]; then continue; fi; \
-		fn=`basename $$e`; \
-		$(ECHO) "$(RM) $(DESTDIR)$(ENGINESDIR)/$$fn"; \
-		$(RM) "$(DESTDIR)$(ENGINESDIR)/$$fn"; \
-	done
-	-$(RMDIR) "$(DESTDIR)$(ENGINESDIR)"
 
 install_modules: _install_modules_deps
 	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -101,29 +101,15 @@ INSTALL_SHLIBPDBS={-
                   grep { !$unified_info{attributes}->{libraries}->{$_}->{noinst} }
                   @{$unified_info{libraries}})
 -}
-INSTALL_ENGINES={-
-        join(" ", map { quotify1(platform->dso($_)) }
-                  grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
-                         && $unified_info{attributes}->{modules}->{$_}->{engine} }
-                  @{$unified_info{modules}})
--}
-INSTALL_ENGINEPDBS={-
-        join(" ", map { quotify1(platform->dsopdb($_)) }
-                  grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
-                         && $unified_info{attributes}->{modules}->{$_}->{engine} }
-                  @{$unified_info{modules}})
--}
 INSTALL_MODULES={-
         join(" ", map { quotify1(platform->dso($_)) }
                   grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
-                          && !$unified_info{attributes}->{modules}->{$_}->{engine}
                           && !$unified_info{attributes}->{modules}->{$_}->{fips} }
                   @{$unified_info{modules}})
 -}
 INSTALL_MODULEPDBS={-
         join(" ", map { quotify1(platform->dsopdb($_)) }
-                  grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
-                         && !$unified_info{attributes}->{modules}->{$_}->{engine} }
+                  grep { !$unified_info{attributes}->{modules}->{$_}->{noinst} }
                   @{$unified_info{modules}})
 -}
 INSTALL_FIPSMODULE={-
@@ -230,23 +216,15 @@ MODULESDIR_dev={- use File::Spec::Functions qw(:DEFAULT splitpath catpath);
                   our $modulesdir_dir =
                       catdir($modulesprefix_dir, "ossl-modules");
                   our $modulesdir = catpath($modulesdir_dev, $modulesdir_dir);
-                  our $enginesdir_dev = $modulesprefix_dev;
-                  our $enginesdir_dir =
-                      catdir($modulesprefix_dir, "engines-$sover_dirname");
-                  our $enginesdir = catpath($enginesdir_dev, $enginesdir_dir);
                   $modulesdir_dev -}
 MODULESDIR_dir={- canonpath($modulesdir_dir) -}
-ENGINESDIR_dev={- $enginesdir_dev -}
-ENGINESDIR_dir={- canonpath($enginesdir_dir) -}
 !IF "$(DESTDIR)" != ""
 INSTALLTOP=$(DESTDIR)$(INSTALLTOP_dir)
 OPENSSLDIR=$(DESTDIR)$(OPENSSLDIR_dir)
-ENGINESDIR=$(DESTDIR)$(ENGINESDIR_dir)
 MODULESDIR=$(DESTDIR)$(MODULESDIR_dir)
 !ELSE
 INSTALLTOP=$(INSTALLTOP_dev)$(INSTALLTOP_dir)
 OPENSSLDIR=$(OPENSSLDIR_dev)$(OPENSSLDIR_dir)
-ENGINESDIR=$(ENGINESDIR_dev)$(ENGINESDIR_dir)
 MODULESDIR=$(MODULESDIR_dev)$(MODULESDIR_dir)
 !ENDIF
 
@@ -344,7 +322,6 @@ LIB_CPPFLAGS={- our $lib_cppflags =
                 join(' ', $lib_cppflags,
                           (map { '-D'.quotify1($_) }
                                "OPENSSLDIR=\"$openssldir\"",
-                               "ENGINESDIR=\"$enginesdir\"",
                                "MODULESDIR=\"$modulesdir\""),
                           '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
 LIB_CFLAGS={- join(' ', $target{lib_cflags} || (),
@@ -485,7 +462,6 @@ clean: libclean
 	{- join("\n\t", map { "-del /Q /F $_" } @GENERATED_MANDATORY) || "\@rem" -}
 	{- join("\n\t", map { "-del /Q /F $_" } @GENERATED) || "\@rem" -}
 	-del /Q /S /F *.d *.obj *.pdb *.ilk *.manifest
-	-del /Q /S /F engines\*.lib engines\*.exp
 	-del /Q /S /F apps\*.lib apps\*.rc apps\*.res apps\*.exp
 	-del /Q /S /F test\*.exp
 	-rd /Q /S test\test-runs
@@ -502,9 +478,9 @@ depend: makefile
 
 # Install helper targets #############################################
 
-install_sw: install_dev install_engines install_modules install_runtime
+install_sw: install_dev install_modules install_runtime
 
-uninstall_sw: uninstall_runtime uninstall_modules uninstall_engines uninstall_dev
+uninstall_sw: uninstall_runtime uninstall_modules uninstall_dev
 
 install_docs: install_html_docs
 
@@ -576,17 +552,6 @@ install_dev: install_runtime_libs
 uninstall_dev:
 
 _install_modules_deps: install_runtime_libs build_modules
-
-install_engines: _install_modules_deps
-	@if "$(INSTALLTOP)"=="" ( $(ECHO) "INSTALLTOP should not be empty" & exit 1 )
-	@$(ECHO) "*** Installing engines"
-	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(ENGINESDIR)"
-	@if not "$(INSTALL_ENGINES)"=="" \
-	 "$(PERL)" "$(SRCDIR)\util\copy.pl" $(INSTALL_ENGINES) "$(ENGINESDIR)"
-	@if not "$(INSTALL_ENGINES)"=="" \
-	 "$(PERL)" "$(SRCDIR)\util\copy.pl" $(INSTALL_ENGINEPDBS) "$(ENGINESDIR)"
-
-uninstall_engines:
 
 install_modules: _install_modules_deps
 	@if "$(INSTALLTOP)"=="" ( $(ECHO) "INSTALLTOP should not be empty" & exit 1 )

--- a/NOTES-WINDOWS.md
+++ b/NOTES-WINDOWS.md
@@ -112,11 +112,10 @@ install it to a variety of locations.
 The following keys:
 
     `\\HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\OpenSSL-<version>-<ctx>\OPENSSLDIR`
-    `\\HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\OpenSSL-<version>-<ctx>\ENGINESDIR`
     `\\HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\OpenSSL-<version>-<ctx>\MODULESDIR`
 
 Can be administratively set, and openssl will take the paths found there as the
-values for OPENSSLDIR, ENGINESDIR and MODULESDIR respectively.
+values for OPENSSLDIR and MODULESDIR respectively.
 
 To enable the reading of registry keys from windows builds, add
 `-DOSSL_WINCTX=<string>`to the Configure command line.  This define is used

--- a/build.info
+++ b/build.info
@@ -416,7 +416,7 @@ DEPEND[openssl.pc]=libcrypto.pc libssl.pc
 GENERATE[builddata.pm]=util/mkinstallvars.pl \
     PREFIX=. BINDIR=apps APPLINKDIR=ms \
     LIBDIR= INCLUDEDIR=include "INCLUDEDIR=$(SRCDIR)/include" \
-    ENGINESDIR=engines MODULESDIR=providers \
+    MODULESDIR=providers \
     "VERSION=$(VERSION)" "LDLIBS=$(LIB_EX_LIBS)"
 
 DEPEND[""]=openssl.pc

--- a/crypto/cversion.c
+++ b/crypto/cversion.c
@@ -52,9 +52,6 @@ extern char ossl_cpu_info_str[];
 /* size: MAX_PATH + sizeof("OPENSSLDIR: \"\"") */
 static char openssldir[MAX_PATH + 15];
 
-/* size: MAX_PATH + sizeof("ENGINESDIR: \"\"") */
-static char enginesdir[MAX_PATH + 15];
-
 /* size: MAX_PATH + sizeof("MODULESDIR: \"\"") */
 static char modulesdir[MAX_PATH + 15];
 
@@ -64,8 +61,6 @@ DEFINE_RUN_ONCE_STATIC(version_strings_setup)
 {
     BIO_snprintf(openssldir, sizeof(openssldir), "OPENSSLDIR: \"%s\"",
                  ossl_get_openssldir());
-    BIO_snprintf(enginesdir, sizeof(enginesdir), "ENGINESDIR: \"%s\"",
-                 ossl_get_enginesdir());
     BIO_snprintf(modulesdir, sizeof(modulesdir), "MODULESDIR: \"%s\"",
                  ossl_get_modulesdir());
     return 1;
@@ -99,8 +94,6 @@ const char *OpenSSL_version(int t)
 #if defined(_WIN32) && defined(OSSL_WINCTX)
     case OPENSSL_DIR:
         return openssldir;
-    case OPENSSL_ENGINES_DIR:
-        return enginesdir;
     case OPENSSL_MODULES_DIR:
         return modulesdir;
 #else
@@ -109,12 +102,6 @@ const char *OpenSSL_version(int t)
         return "OPENSSLDIR: \"" OPENSSLDIR "\"";
 # else
         return "OPENSSLDIR: N/A";
-# endif
-    case OPENSSL_ENGINES_DIR:
-# ifdef ENGINESDIR
-        return "ENGINESDIR: \"" ENGINESDIR "\"";
-# else
-        return "ENGINESDIR: N/A";
 # endif
     case OPENSSL_MODULES_DIR:
 # ifdef MODULESDIR
@@ -134,6 +121,8 @@ const char *OpenSSL_version(int t)
 #else
         return "OSSL_WINCTX: Undefined";
 #endif
+    case OPENSSL_ENGINES_DIR:
+        return "ENGINESDIR: N/A";
     }
     return "not available";
 }

--- a/crypto/defaults.c
+++ b/crypto/defaults.c
@@ -33,17 +33,6 @@ static char openssldir[MAX_PATH + 1];
 static char *openssldirptr = NULL;
 
 /**
- * @brief The directory where OpenSSL engines are located.
- */
-
-static char enginesdir[MAX_PATH + 1];
-
-/**
- * @brief The pointer to the enginesdir buffer
- */
-static char *enginesdirptr = NULL;
-
-/**
  * @brief The directory where OpenSSL modules are located.
  */
 static char modulesdir[MAX_PATH + 1];
@@ -122,7 +111,6 @@ static CRYPTO_ONCE defaults_setup_init = CRYPTO_ONCE_STATIC_INIT;
 DEFINE_RUN_ONCE_STATIC(do_defaults_setup)
 {
     get_windows_regdirs(openssldir, sizeof(openssldir), L"OPENSSLDIR");
-    get_windows_regdirs(enginesdir, sizeof(enginesdir), L"ENGINESDIR");
     get_windows_regdirs(modulesdir, sizeof(modulesdir), L"MODULESDIR");
 
     /*
@@ -130,9 +118,6 @@ DEFINE_RUN_ONCE_STATIC(do_defaults_setup)
      */
     if (strlen(openssldir) > 0)
         openssldirptr = openssldir;
-
-    if (strlen(enginesdir) > 0)
-        enginesdirptr = enginesdir;
 
     if (strlen(modulesdir) > 0)
         modulesdirptr = modulesdir;
@@ -154,22 +139,6 @@ const char *ossl_get_openssldir(void)
     return (const char *)openssldirptr;
 # else
     return OPENSSLDIR;
-#endif
-}
-
-/**
- * @brief Get the directory where OpenSSL engines are located.
- *
- * @return A pointer to a string containing the engines directory path.
- */
-const char *ossl_get_enginesdir(void)
-{
-#if defined(_WIN32) && defined (OSSL_WINCTX)
-    if (!RUN_ONCE(&defaults_setup_init, do_defaults_setup))
-        return NULL;
-    return (const char *)enginesdirptr;
-#else
-    return ENGINESDIR;
 #endif
 }
 

--- a/crypto/engine/eng_list.c
+++ b/crypto/engine/eng_list.c
@@ -452,8 +452,7 @@ ENGINE *ENGINE_by_id(const char *id)
      * Prevent infinite recursion if we're looking for the dynamic engine.
      */
     if (strcmp(id, "dynamic")) {
-        if ((load_dir = ossl_safe_getenv("OPENSSL_ENGINES")) == NULL)
-            load_dir = ossl_get_enginesdir();
+        load_dir = ossl_safe_getenv("OPENSSL_ENGINES");
         iterator = ENGINE_by_id("dynamic");
         if (!iterator || !ENGINE_ctrl_cmd_string(iterator, "ID", id, 0) ||
             !ENGINE_ctrl_cmd_string(iterator, "DIR_LOAD", "2", 0) ||

--- a/crypto/info.c
+++ b/crypto/info.c
@@ -221,7 +221,7 @@ const char *OPENSSL_info(int t)
     case OPENSSL_INFO_CONFIG_DIR:
         return ossl_get_openssldir();
     case OPENSSL_INFO_ENGINES_DIR:
-        return ossl_get_enginesdir();
+        return NULL;
     case OPENSSL_INFO_MODULES_DIR:
         return ossl_get_modulesdir();
     case OPENSSL_INFO_DSO_EXTENSION:

--- a/doc/man3/OpenSSL_version.pod
+++ b/doc/man3/OpenSSL_version.pod
@@ -142,12 +142,6 @@ if available, or C<platform: information not available> otherwise.
 The B<OPENSSLDIR> setting of the library build in the form C<OPENSSLDIR: "...">
 if available, or C<OPENSSLDIR: N/A> otherwise.
 
-=item OPENSSL_ENGINES_DIR
-
-The B<ENGINESDIR> setting of the library build in the form C<ENGINESDIR: "...">
-if available, or C<ENGINESDIR: N/A> otherwise. This option is deprecated in
-OpenSSL 3.0.
-
 =item OPENSSL_MODULES_DIR
 
 The B<MODULESDIR> setting of the library build in the form C<MODULESDIR: "...">
@@ -183,11 +177,6 @@ OPENSSL_info() also returns different strings depending on I<t>:
 
 The configured C<OPENSSLDIR>, which is the default location for
 OpenSSL configuration files.
-
-=item OPENSSL_INFO_ENGINES_DIR
-
-The configured C<ENGINESDIR>, which is the default location for
-OpenSSL engines.
 
 =item OPENSSL_INFO_MODULES_DIR
 
@@ -255,6 +244,13 @@ L<crypto(7)>
 
 The macros and functions described here were added in OpenSSL 3.0,
 except for OPENSSL_VERSION_NUMBER and OpenSSL_version_num().
+
+The B<ENGINESDIR> setting of the library is no longer supported
+since OpenSSL 4.0.
+
+The B<OPENSSL_ENGINES_DIR> and B<OPENSSL_INFO_ENGINES_DIR> strings
+are no longer supported and, for compatibility reasons, will always
+return values indicating that engine support was disabled.
 
 =head1 COPYRIGHT
 

--- a/exporters/build.info
+++ b/exporters/build.info
@@ -21,6 +21,6 @@ DEPEND[""]=openssl.pc
 GENERATE[../installdata.pm]=../util/mkinstallvars.pl \
     "PREFIX=$(INSTALLTOP)" BINDIR=bin "LIBDIR=$(LIBDIR)" "libdir=$(libdir)" \
     INCLUDEDIR=include APPLINKDIR=include/openssl \
-    "ENGINESDIR=$(ENGINESDIR)" "MODULESDIR=$(MODULESDIR)" \
+    "MODULESDIR=$(MODULESDIR)" \
     "PKGCONFIGDIR=$(PKGCONFIGDIR)" "CMAKECONFIGDIR=$(CMAKECONFIGDIR)" \
     "LDLIBS=$(LIB_EX_LIBS)" "VERSION=$(VERSION)"

--- a/exporters/cmake/OpenSSLConfig.cmake.in
+++ b/exporters/cmake/OpenSSLConfig.cmake.in
@@ -133,7 +133,6 @@ set(OPENSSL_LIBRARY_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata:
 set(OPENSSL_INCLUDE_DIR{- $OUT = '';
                           $OUT .= ' "${_ossl_prefix}/' . $_ . '"'
                               foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX); -})
-set(OPENSSL_ENGINES_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0], 1); -}/{- unixify($OpenSSL::safe::installdata::ENGINESDIR_REL_LIBDIR[0], 1); -}")
 set(OPENSSL_MODULES_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0], 1); -}/{- unixify($OpenSSL::safe::installdata::MODULESDIR_REL_LIBDIR[0], 1); -}")
 set(OPENSSL_RUNTIME_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::BINDIR_REL_PREFIX[0], 1); -}")
 {- output_off() if $disabled{uplink}; "" -}

--- a/exporters/pkg-config/libcrypto.pc.in
+++ b/exporters/pkg-config/libcrypto.pc.in
@@ -11,7 +11,6 @@ libdir={- if (defined $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]) {
 includedir={- $OUT = '';
               $OUT .= '${prefix}/' . $_ . ' '
                   foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX); -}
-enginesdir=${libdir}/{- $OpenSSL::safe::installdata::ENGINESDIR_REL_LIBDIR[0] -}
 modulesdir=${libdir}/{- $OpenSSL::safe::installdata::MODULESDIR_REL_LIBDIR[0] -}
 
 Name: OpenSSL-libcrypto

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -229,7 +229,6 @@ static ossl_inline int ossl_is_absolute_path(const char *path)
 }
 
 const char *ossl_get_openssldir(void);
-const char *ossl_get_enginesdir(void);
 const char *ossl_get_modulesdir(void);
 const char *ossl_get_wininstallcontext(void);
 

--- a/test/recipes/02-test_windows_registry.t
+++ b/test/recipes/02-test_windows_registry.t
@@ -42,8 +42,6 @@ plan tests => 3;
 
 my @expectossldir = run(cmd(["reg.exe", "query", $regkey, "/reg:32", "/t", "REG_EXPAND_SZ", "/v", "OPENSSLDIR"]), capture => 1);
 
-my @expectengdir = run(cmd(["reg.exe", "query", $regkey, "/reg:32", "/t", "REG_EXPAND_SZ", "/v", "ENGINESDIR"]), capture => 1);
-
 my @expectmoddir = run(cmd(["reg.exe", "query", $regkey, "/reg:32", "/t", "REG_EXPAND_SZ", "/v", "MODULESDIR"]), capture => 1);
 
 my @ossldir = run(app(["openssl", "version", "-d"]), capture => 1);
@@ -58,18 +56,6 @@ $expect =~ s/ .*$//;
 $actual =~ s/OPENSSLDIR: *//;
 
 ok(grep(/$expect/,$actual), "Confirming version output for openssldir from registry");
-
-my @osslengineout = run(app(["openssl", "version", "-e"]), capture => 1);
-
-$expect = "@expectengdir";
-$actual = "@osslengineout";
-$expect =~ s/HKEY_LOCAL_MACHINE.*\n*//;
-$expect =~ s/\n//g;
-$expect =~ s/.*REG_EXPAND_SZ *//;
-$expect =~ s/ .*$//;
-$actual =~ s/ENGINESDIR: *//;
-
-ok(grep(/$expect/, $actual) == 1, "Confirming version output for enginesdir from registry");
 
 my @osslmoduleout = run(app(["openssl", "version", "-m"]), capture => 1);
 

--- a/util/mkinstallvars.pl
+++ b/util/mkinstallvars.pl
@@ -26,7 +26,7 @@ my @absolutes = qw(PREFIX libdir);
 # since the LIBDIR subdirectories depend on the calculation of LIBDIR from
 # PREFIX.
 my @subdirs = _pairs (PREFIX => [ qw(BINDIR LIBDIR INCLUDEDIR APPLINKDIR) ],
-                      LIBDIR => [ qw(ENGINESDIR MODULESDIR PKGCONFIGDIR
+                      LIBDIR => [ qw(MODULESDIR PKGCONFIGDIR
                                      CMAKECONFIGDIR) ]);
 # For completeness, other expected variables
 my @others = qw(VERSION LDLIBS);


### PR DESCRIPTION
This removes support for ENGINESDIR and install/unistall Makefile targets.

For compatibility reasons, OPENSSL_ENGINES_DIR and OPENSSL_INFO_ENGINES_DIR are still supported but return values like with engines disabled.
    
The OPENSSL_ENGINES environment variable will be removed with engine removal later.
    
Resolves: https://github.com/openssl/project/issues/1425

This should be not so controversial change as engines will be not installed even if compiled, but who knows :)
 
- [x] documentation is added or updated
- [x] tests are added or updated
