### PR TITLE
[3.6] Update CHANGES.md and NEWS.md in preparation for the 3.6.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,36 +31,10 @@ OpenSSL 3.6
 
 ### Changes between 3.5 and 3.6 [xx XXX xxxx]
 
- * Secure memory allocation calls are no longer used for HMAC keys.
-
-   *Dr Paul Dale*
-
- * `openssl req` no longer generates certificates with an empty extension list
-   when SKID/AKID are set to `none` during generation.
-
-   *David Benjamin*
-
- * The man page date is now derived from the release date provided
-   in `VERSION.dat` and not the current date for the released builds.
-
-   *Enji Cooper*
-
- * Hardened the provider implementation of the RSA public key "encrypt"
-   operation to add a missing check that the caller-indicated output buffer
-   size is at least as large as the byte count of the RSA modulus.  The issue
-   was reported by Arash Ale Ebrahim from SYSPWN.
-
-   This operation is typically invoked via `EVP_PKEY_encrypt(3)`.  Callers that
-   in fact provide a sufficiently large buffer, but fail to correctly indicate
-   its size may now encounter unexpected errors.  In applications that attempt
-   RSA public encryption into a buffer that is too small, an out-of-bounds
-   write is now avoided and an error is reported instead.
-
-   *Viktor Dukhovni*
-
  * Added support for `EVP_SKEY` opaque symmetric key objects to the key
-   derivation and key exchange provider methods. Added `EVP_KDF_CTX_set_SKEY()`,
-   `EVP_KDF_derive_SKEY()`, and `EVP_PKEY_derive_SKEY()` functions.
+   derivation and key exchange provider methods.  Added
+   `EVP_KDF_CTX_set_SKEY()`, `EVP_KDF_derive_SKEY()`,
+   and `EVP_PKEY_derive_SKEY()` functions.
 
    *Dmitry Belyavskiy and Simo Sorce*
 
@@ -68,16 +42,12 @@ OpenSSL 3.6
 
    *Dr Paul Dale*
 
- * Added FIPS 140-3 PCT on DH key generation.
-
-   *Nikola Pajkovsky*
-
  * Added `i2d_PKCS8PrivateKey(3)` API to complement `i2d_PrivateKey(3)`,
    the former always outputs PKCS#8.
 
    *Viktor Dukhovni*
 
- * Implemented interleaved AES-CBC+HMAC-SHA algorithm on aarch64.
+ * Implemented interleaved AES-CBC+HMAC-SHA algorithm on AArch64.
 
    *Fangming Fang*
 
@@ -85,16 +55,12 @@ OpenSSL 3.6
 
    *Dr Paul Dale*
 
- * Added notification when all stream FINs are acknowledged in QUIC. Introduced
+ * Added notification when all stream FINs are acknowledged in QUIC.  Introduced
    `ossl_quic_channel_notify_flush_done()` so that once final FINs are ACKed,
    the channel transitions to terminating and `SSL_poll()` signals completion.
    This allows applications to progress shutdown reliably.
 
-   *Alexandr Nedvedicky*
-
- * Fixed the synthesised `OPENSSL_VERSION_NUMBER`.
-
-   *Richard Levitte*
+   *Alexandr Nedvědický*
 
  * Added array memory allocation routines and converted suitable memory
    allocation calls in the library to them.
@@ -102,14 +68,14 @@ OpenSSL 3.6
    *Eugene Syromiatnikov*
 
  * Fixed behavior change of EC keygen by adding the generic error entry if the
-   provider did not itself add an error entry onto the queue. That way, there
+   provider did not itself add an error entry onto the queue.  That way, there
    always is an error on the error queue in case of a failure, but no behavior
    change in case the provider emitted the error entry itself.
 
    *Ingo Franzki*
 
- * Documented all the environment variables used across the project in
-   `openssl-env(7)` and in specific man pages.
+ * Documented all the environment variables used across the project
+   in `openssl-env(7)` and in specific man pages.
 
    *Eugene Syromiatnikov*
 
@@ -119,23 +85,23 @@ OpenSSL 3.6
 
    *Julian Zhu*
 
- * Added options `CRYPTO_MEM_SEC` and `CRYPTO_MEM_SEC_MINSIZE` to openssl app
-   to initialize secure memory at the beginning of openssl app.
+ * Added options `CRYPTO_MEM_SEC` and `CRYPTO_MEM_SEC_MINSIZE` to `openssl` app
+   to initialize secure memory at the beginning of `openssl` app.
 
-   *Norbert Pocs*
+   *Norbert Pócs*
 
  * Resolved compiler warnings on Win64 builds.
 
-   *Tomas Mraz*
+   *Tomáš Mráz*
 
- * Extended new `CRYPTO_THREAD_[get|set]_local` api to reduce our reliance
-   on OS thread-local variables.
+ * Extended new `CRYPTO_THREAD_[get|set]_local` API to reduce the usage
+   of OS thread-local variables.
 
    *Neil Horman*
 
- * Added make targets `build_inst_sw` and `build_inst_programs` which have the
-   functionality to split the build into two parts, e.g.: when tests should be
-   built with different compiler flags than installed software.
+ * Added `make` targets `build_inst_sw` and `build_inst_programs` which have
+   the functionality to split the build into two parts, e.g. when tests
+   should be built with different compiler flags than the installed software.
 
    *Pavol Zacik*
 
@@ -143,38 +109,38 @@ OpenSSL 3.6
    parsers are used instead of `OSSL_PARAM_locate()` calls.  This should
    also ensure that the list of acceptable parameters better matches
    those which are actually processed.  It should also provide a small
-   performance improvement because repeated iteration over passed
+   performance improvement, because repeated iteration over passed
    parameter arrays is avoided.
 
    *Dr Paul Dale*
 
- * Introduce `SSL_OP_SERVER_PREFERENCE` superceding misleadingly
+ * Introduced `SSL_OP_SERVER_PREFERENCE`, superseding misleadingly
    named `SSL_OP_CIPHER_SERVER_PREFERENCE`.
 
    *Michael Baentsch*
 
- * Added LMS signature verification support as per [SP 800-208].  This
-   support is present in both the FIPS and default providers.
+ * Added LMS signature verification support as per [SP 800-208].
+   This support is present in both the FIPS and default providers.
 
    *Shane Lontis and Paul Dale*
 
- * Introduces use of `<stdbool.h>` when handling JSON encoding in
-   the OpenSSL codebase, replacing the previous use of `int` for
-   these boolean values.
+ * Introduced use of `<stdbool.h>` when handling JSON encoding
+   in the OpenSSL codebase, replacing the previous use of `int`
+   for these boolean values.
 
    *Alexis Goodfellow*
 
- * An ANSI-C toolchain is no longer sufficient for building OpenSSL. The code
-   should build on compilers supporting C-99 features.
+ * An ANSI-C toolchain is no longer sufficient for building OpenSSL.
+   The code should be built using compilers supporting C-99 features.
 
-   *Alexandr Nedvedicky*
+   *Alexandr Nedvědický*
 
- * The VxWorks platforms have been removed. These platforms were unadopted,
-   unmaintained and reported to be non-functional.
+ * Support for the VxWorks platforms has been removed.  These platforms
+   were unadopted, unmaintained and reported to be non-functional.
 
    *Anthony Ioppolo*
 
- * Relax the path check in OpenSSL's `file:` scheme implementation for
+ * Relaxed the path check in OpenSSL's `file:` scheme implementation for
    `OSSL_STORE`.  Previously, when the `file:` scheme is an explicit part
    of the URI, our implementation required an absolute path, such as
    `file:/path/to/file.pem`.  This requirement is now relaxed, allowing
@@ -183,8 +149,8 @@ OpenSSL 3.6
    *Richard Levitte*
 
  * Changed `openssl-pkey(1)` to match the documentation when private keys
-   are output in DER format (`-outform DER`) by producing the `PKCS#8` form by
-   default.  Previously this would output the *traditional* form for those
+   are output in DER format (`-outform DER`) by producing the PKCS#8 form
+   by default.  Previously, this would output the *traditional* form for those
    older key types (`DSA`, `RSA`, `ECDSA`) that had such a form.  The
    `-traditional` flag has been extended to support explicit requests to output
    that format in DER format (it was previously PEM-only).
@@ -196,14 +162,15 @@ OpenSSL 3.6
 
    *Dmitry Belyavskiy based on Clemens Lang's code*
 
- * Support setting a free function thunk to `OPENSSL_sk` stack types. Using
-   a thunk allows the type specific free function to be called with the correct
-   type information from generic functions like `OPENSSL_sk_pop_free()`.
+ * Added support for setting a free function thunk to `OPENSSL_sk` stack types.
+   Using a thunk allows the type specific free function to be called
+   with the correct type information from generic functions like
+   `OPENSSL_sk_pop_free()`.
 
    *Frederik Wedel-Heinen*
 
  * Enabled x86-64 SM4 optimizations with SM4 ISA Extension available starting
-   Lunar Lake and Arrow Lake S CPUs. The expected performance improvement
+   Lunar Lake and Arrow Lake S CPUs.  The expected performance improvement
    is ~3.6x for `sm4-cbc`, ~2.9x for `sm4-gcm`, ~9.2x for `sm4-xts`,
    ~5.3x for `sm4-ccm` (on average, may vary depending on the data size)
    on Arrow Lake S.
@@ -211,61 +178,60 @@ OpenSSL 3.6
    *Alina Elizarova*
 
  * Enabled x86-64 SM3 optimizations with SM3 ISA Extension available starting
-   Lunar Lake and Arrow Lake S CPUs. The expected performance improvement is
-   ~ 2.2-4.7x (depends on the data size) on Arrow Lake S.
+   Lunar Lake and Arrow Lake S CPUs.  The expected performance improvement
+   is ~2.2—4.7x (depends on the data size) on Arrow Lake S.
 
    *Alina Elizarova*
 
  * Enabled x86-64 SHA-512 optimizations with SHA512 ISA Extension.
    Optimized digests: `sha384`, `sha512`, `sha512-224`, `sha512-256`.
-   `openssl speed` shows speedups ranging from 1.6x to 4.5x on
-   the P-cores of Intel Core Ultra 5 238V.
+   `openssl speed` shows speedups ranging from 1.6x to 4.5x
+   on the P-cores of Intel Core Ultra 5 238V.
 
    *Adrian Stanciu*
 
- * Change default EC point formats configuration to support only 'uncompressed'
-   format, and add `SSL_OP_LEGACY_EC_POINT_FORMATS` flag and options to re-enable
-   previous default if required.
+ * Changed default EC point formats configuration to support only 'uncompressed'
+   format, and added `SSL_OP_LEGACY_EC_POINT_FORMATS` flag and options
+   to re-enable previous default, if required.
 
    *Tim Perry*
 
- * Increase PKCS12 default macsaltlen from 8 to 16, as per NIST SP
-   800-132 this improves interoperability for newly generated PKCS12
+ * Increased PKCS#12 default `macsaltlen` from 8 to 16, as, per NIST
+   [SP 800-132], this improves interoperability for newly generated PKCS#12
    stores between FIPS and non-FIPS implementations.
 
    *Dimitri John Ledkov*
 
- * Add `X509_CRL_get0_tbs_sigalg()` accessor for the signature
-   `AlgorithmIdentifier` inside a CRL's `TBSCertList`.
+ * Added `X509_CRL_get0_tbs_sigalg()` accessor for the signature
+   `AlgorithmIdentifier` inside CRL's `TBSCertList`.
 
    *Theo Buehler*
 
- * HKDF with (SHA-256, SHA-384, SHA-512) has assigned OIDs. Added ability
+ * Added OIDS for HKDFs with SHA-256, SHA-384, and SHA-512.  Added ability
    to load HKDF configured with these explicit digests by name or OID.
 
    *Daniel Van Geest (CryptoNext Security)*
 
  * Added Intel AVX-512 and VAES optimizations for AES-CFB128 algorithms.
-   Encryption performance on large buffers improved by 1.5-1.7x,
-   while decryption speed increased by 20-23x.
+   Encryption performance on large buffers improved by 1.5—1.7x,
+   while decryption speed increased by 20—23x.
 
    *Adrian Stanciu*
 
  * Added support for TLS 1.3 OCSP multi-stapling for server certs.
-     * new `s_client` options:
+    * new `s_client` options:
        * `-ocsp_check_leaf`: Checks the status of the leaf (server) certificate.
        * `-ocsp_check_all`: Checks the status of all certificates in the server
          chain.
-     * new `s_server` option:
+    * new `s_server` option:
        * `-status_all` Provides OCSP status information for the entire server
          certificate chain (multi-stapling) for TLS 1.3 and later.
-
-     * Improved `-status_file` option can now be given multiple times to provide
-       multiple files containing OCSP responses.
+    * Improved `-status_file` option can now be given multiple times to provide
+      multiple files containing OCSP responses.
 
    *Michael Krueger, Martin Rauch*
 
- * Added KEMRecipientInfo (RFC 9629) and ML-KEM (draft-ietf-lamps-cms-kyber)
+ * Added `KEMRecipientInfo` (RFC 9629) and ML-KEM (`draft-ietf-lamps-cms-kyber`)
    support to CMS.
 
    *Daniel Van Geest (CryptoNext Security)*
@@ -278,7 +244,7 @@ OpenSSL 3.6
 OpenSSL 3.5
 -----------
 
-### Changes between 3.5.3 and 3.5.4 [xx XXX xxxx]
+### Changes between 3.5.3 and 3.5.4 [30 Sep 2025]
 
  * Fix Out-of-bounds read & write in RFC 3211 KEK Unwrap
 
@@ -21801,4 +21767,5 @@ ndif
 [CVE-2002-0655]: https://www.openssl.org/news/vulnerabilities.html#CVE-2002-0655
 [CMVP]: https://csrc.nist.gov/projects/cryptographic-module-validation-program
 [ESV]: https://csrc.nist.gov/Projects/cryptographic-module-validation-program/entropy-validations
+[SP 800-132]: https://csrc.nist.gov/pubs/sp/800/132/final
 [SP 800-208]: https://csrc.nist.gov/pubs/sp/800/208/final

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,21 +29,19 @@ OpenSSL 3.6
 This release incorporates the following potentially significant or incompatible
 changes:
 
-  * Added FIPS 140-3 PCT on DH key generation.
-
   * Added NIST security categories for PKEY objects.
 
   * Added support for `EVP_SKEY` opaque symmetric key objects to the key
     derivation and key exchange provider methods. Added `EVP_KDF_CTX_set_SKEY()`,
     `EVP_KDF_derive_SKEY()`, and `EVP_PKEY_derive_SKEY()` functions.
 
-  * Added LMS signature verification support as per [SP 800-208]. This
-    support is present in both the FIPS and default providers.
+  * Added LMS signature verification support as per [SP 800-208].
+    This support is present in both the FIPS and default providers.
 
-  * An ANSI-C toolchain is no longer sufficient for building OpenSSL. The code
-    should build on compilers supporting C-99 features.
+  * An ANSI-C toolchain is no longer sufficient for building OpenSSL.
+    The code should be built using compilers supporting C-99 features.
 
-  * The VxWorks platforms have been removed.
+  * Support for the VxWorks platforms has been removed.
 
   * Added an `openssl configutl` utility for processing the OpenSSL
     configuration file and dumping the equal configuration file.
@@ -51,12 +49,12 @@ changes:
   * Added support for FIPS 186-5 deterministic ECDSA signature
     generation to the FIPS provider.
 
-  * Deprecated `EVP_PKEY_ASN1_METHOD` related functions.
+  * Deprecated `EVP_PKEY_ASN1_METHOD`-related functions.
 
 OpenSSL 3.5
 -----------
 
-### Major changes between OpenSSL 3.5.3 and OpenSSL 3.5.4 [under development]
+### Major changes between OpenSSL 3.5.3 and OpenSSL 3.5.4 [30 Sep 2025]
 
 OpenSSL 3.5.4 is a security patch release. The most severe CVE fixed in this
 release is Moderate.


### PR DESCRIPTION
This includes a forward-port of 3.5.4 CHANGES/NEWS updates, as well as massaging of 3.6 CHANGES/NEWS.