### PR TITLE
pkcs11-provider submodule update

### DIFF
--- a/test/recipes/95-test_external_pkcs11_provider_data/pkcs11-provider.sh
+++ b/test/recipes/95-test_external_pkcs11_provider_data/pkcs11-provider.sh
@@ -64,7 +64,7 @@ echo "Running tests"
 echo "------------------------------------------------------------------"
 
 # For maintenance reasons and simplicity we only run test with kryoptic token
-meson test -C $PKCS11_PROVIDER_BUILDDIR --suite=kryoptic
+SUPPORT_ML_DSA=0 meson test -C $PKCS11_PROVIDER_BUILDDIR --suite=kryoptic
 
 if [ $? -ne 0 ]; then
     cat $PKCS11_PROVIDER_BUILDDIR/meson-logs/testlog.txt


### PR DESCRIPTION
Submodule pkcs11-provider is updated to 663dea3 and pkcs11-provider-external test has now temporarily disabled MLDSA tests (new tests in this version of the provider). They require kryoptic >= 1.2 that is not yet present in fedora:latest (42).
