### PR TITLE
Update external test to use rpki-client 9.6

### DIFF
--- a/test/recipes/95-test_external_rpki-client-portable.t
+++ b/test/recipes/95-test_external_rpki-client-portable.t
@@ -19,7 +19,7 @@ plan skip_all => "No external tests in this configuration"
 
 plan tests => 1;
 
-$RPKI_VERSION = "9.5";
+$RPKI_VERSION = "9.6";
 $RPKI_SRC = "rpki-client-".$RPKI_VERSION;
 $RPKI_SUFFIX = ".tar.gz";
 $RPKI_TARBALL = $RPKI_SRC.$RPKI_SUFFIX;


### PR DESCRIPTION
rpki-client 9.6 was released ten days ago:
https://marc.info/?l=openbsd-announce&m=175847509514928&w=2

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
