### PR TITLE
Reduce Max number of commands handled per fuzzer pass in quic-lcidm.

### DIFF
--- a/fuzz/quic-lcidm.c
+++ b/fuzz/quic-lcidm.c
@@ -48,7 +48,7 @@ enum {
     CMD_LOOKUP
 };
 
-#define MAX_CMDS    10000
+#define MAX_CMDS    5000
 
 static int get_cid(PACKET *pkt, QUIC_CONN_ID *cid)
 {


### PR DESCRIPTION
We've gotten a few recent reports of a hang in the quic-lcidm fuzzer:

https://issues.oss-fuzz.com/issues/448510502

It looks pretty straightforward (I think).  The fuzzer input buffer is used in this particular case to randomly issue commands to the lcidm hash table (add/delete/query/flush/etc).

The loop for the command processing (based on the input buffer), is limited to 10k commands.  However the fuzzer will on occasion provide very large buffers (500k) which easily saturate that limit.  If the input buffer happens to do something like get biased toward mostly additions, we wind up with a huge hashtable that has to constantly grow and rehash, whcih we've seen leads to timeouts in the past.

Most direct fix I think here, given that this is something of an artificial failure in the fuzzer, is to simply clamp the command limit more.

Fixes openssl/project#1664


##### Checklist
- [x] tests are added or updated
