### PR TITLE
Fix an error check for EVP_PBE_CipherInit_ex()

### DIFF
--- a/crypto/cms/cms_pwri.c
+++ b/crypto/cms/cms_pwri.c
@@ -370,10 +370,10 @@ int ossl_cms_RecipientInfo_pwri_crypt(const CMS_ContentInfo *cms,
 
     /* Finish password based key derivation to setup key in "ctx" */
 
-    if (EVP_PBE_CipherInit_ex(algtmp->algorithm,
-                              (char *)pwri->pass, (int)pwri->passlen,
-                              algtmp->parameter, kekctx, en_de,
-                              cms_ctx->libctx, cms_ctx->propq) < 0) {
+    if (!EVP_PBE_CipherInit_ex(algtmp->algorithm,
+                               (char *)pwri->pass, (int)pwri->passlen,
+                               algtmp->parameter, kekctx, en_de,
+                               cms_ctx->libctx, cms_ctx->propq)) {
         ERR_raise(ERR_LIB_CMS, ERR_R_EVP_LIB);
         goto err;
     }


### PR DESCRIPTION
As pointed out during the review for the recent security issue in this file, this error check is incorrect: as documented, this function has the usual Boolean return values.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
