### PR TITLE
Update CI macos runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-14, macos-14-large]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -578,7 +578,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-15, macos-15-large]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14, macos-15]
+        os: [macos-14, macos-15, macos-15-large]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -335,7 +335,7 @@ jobs:
   enable_tfo:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14 ]
+        os: [ ubuntu-latest, macos-15, macos-15-large ]
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Github have notified that the macos 13 runner image is deprecated and will be retired on the 4th December 2025. It will also fail temporarily intermittently during November on specific days as a warning.

Notes:
 - The macos-14 and macos-15 labels correspond to arm64, and macos-14-large and macos-15-large correspond to x86_64 (intel).

 - macos x86_64 intel will no longer be supported after the macos 15 runner image is retired in the Fall of 2027. For now we should continue to support this.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
