### PR TITLE
FIPS: Fix RSA X.931 padding check

### DIFF
--- a/providers/implementations/signature/rsa_sig.c.in
+++ b/providers/implementations/signature/rsa_sig.c.in
@@ -1503,9 +1503,7 @@ static const OSSL_PARAM *rsa_gettable_ctx_params(ossl_unused void *vprsactx,
 #ifdef FIPS_MODULE
 static int rsa_x931_padding_allowed(PROV_RSA_CTX *ctx)
 {
-    int approved = ((ctx->operation & EVP_PKEY_OP_SIGN) == 0);
-
-    if (!approved) {
+    if (ctx->operation & EVP_PKEY_OP_SIGNMSG || ctx->operation & EVP_PKEY_OP_SIGN) {
         if (!OSSL_FIPS_IND_ON_UNAPPROVED(ctx, OSSL_FIPS_IND_SETTABLE2,
                                          ctx->libctx,
                                          "RSA Sign set ctx", "X931 Padding",


### PR DESCRIPTION
The padding check was not complete and would miss the Message Signature API case, which also needs to be rejected.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
