### PR TITLE
Fix NULL rwlock dereference in secure heap functions

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -263,6 +263,8 @@ size_t CRYPTO_secure_used(void)
     size_t ret = 0;
 
 #ifndef OPENSSL_NO_SECURE_MEMORY
+    if (!secure_mem_initialized)
+        return 0;
     if (!CRYPTO_THREAD_read_lock(sec_malloc_lock))
         return 0;
 
@@ -277,7 +279,9 @@ size_t CRYPTO_secure_actual_size(void *ptr)
 {
 #ifndef OPENSSL_NO_SECURE_MEMORY
     size_t actual_size;
-
+    
+    if (!secure_mem_initialized)
+        return 0;
     if (!CRYPTO_THREAD_read_lock(sec_malloc_lock))
         return 0;
     actual_size = sh_actual_size(ptr);


### PR DESCRIPTION
Hello,
This PR fixes a NULL rwlock dereference issue in OpenSSL's secure heap functions

Problem:
When CRYPTO_secure_used() and CRYPTO_secure_actual_size() functions are called before secure heap initialization
CRYPTO_THREAD_read_lock() is called on a NULL sec_malloc_lock (rwlock), causing segmentation fault

Solution:
Added secure_mem_initialized flag checks to both functions
If not initialized, safely return 0 (maintaining consistency with existing behavior)
This approach follows the same pattern already used in CRYPTO_secure_allocated()

Changes:
Before: No secure heap initialization check → segfault occurred
After: Check secure_mem_initialized before using rwlock → safe return of 0

Testing:
Custom test confirmed functions return 0 without segfault when called before initialization
Existing secmemtest passes, ensuring no regressions

Related Issue:
Fixes: #28669
I welcome any feedback and reviews
Have a great day