### PR TITLE
Fix NULL pointer dereference in QUIC ssl3_free()

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3444,6 +3444,7 @@ void ssl3_free(SSL *s)
     OPENSSL_free(sc->s3.alpn_selected);
     OPENSSL_free(sc->s3.alpn_proposed);
     ossl_quic_tls_free(sc->qtls);
+    sc->qtls = NULL;
 
 #ifndef OPENSSL_NO_PSK
     OPENSSL_free(sc->s3.tmp.psk);


### PR DESCRIPTION
Problem:
QUIC SSL objects experienced use-after-free and double-free bugs during SSL object cleanup in ssl3_free() due to unset NULL pointer after freeing sc->qtls

Changes:
ssl/s3_lib.c: Added NULL assignment after freeing QUIC TLS pointer in ssl3_free() function (line 3446)

Testing:
All existing QUIC tests pass successfully: quic_ackm_test, quic_fc_test, quic_lcidm_test, quic_rcidm_test, quic_srtm_test, quic_txp_test
No regressions in QUIC functionality
Manual verification that double-free scenario is prevented

Related Issue:
Fixes: #28722

I welcome any feedback and reviews. Have a great day!