### PR TITLE
docs: replace DES-EDE3-CBC with AES-256-CBC in PEM examples (fix #28665)

### DIFF
--- a/doc/man3/PEM_read_bio_PrivateKey.pod
+++ b/doc/man3/PEM_read_bio_PrivateKey.pod
@@ -416,7 +416,7 @@ The private key (or other data) takes the following form:
 
  -----BEGIN RSA PRIVATE KEY-----
  Proc-Type: 4,ENCRYPTED
- DEK-Info: DES-EDE3-CBC,3F17F5316E2BAC89
+ DEK-Info: AES-256-CBC,3F17F5316E2BAC89
 
  ...base64 encoded data...
  -----END RSA PRIVATE KEY-----
@@ -443,7 +443,7 @@ the function.
 
 The pseudo code to derive the key would look similar to:
 
- EVP_CIPHER* cipher = EVP_des_ede3_cbc();
+ EVP_CIPHER* cipher = EVP_aes_256_cbc();
  EVP_MD* md = EVP_md5();
 
  unsigned int nkey = EVP_CIPHER_get_key_length(cipher);
@@ -516,15 +516,15 @@ Write a certificate to a BIO:
      /* Error */
 
 Write a private key (using traditional format) to a BIO using
-triple DES encryption, the pass phrase is prompted for:
+AES-256-CBC encryption, the pass phrase is prompted for:
+ 
+  if (!PEM_write_bio_PrivateKey(bp, key, EVP_aes_256_cbc(), NULL, 0, 0, NULL))
+      /* Error */
 
- if (!PEM_write_bio_PrivateKey(bp, key, EVP_des_ede3_cbc(), NULL, 0, 0, NULL))
-     /* Error */
+Write a private key (using PKCS#8 format) to a BIO using
+AES-256-CBC encryption, using the pass phrase "hello":
 
-Write a private key (using PKCS#8 format) to a BIO using triple
-DES encryption, using the pass phrase "hello":
-
- if (!PEM_write_bio_PKCS8PrivateKey(bp, key, EVP_des_ede3_cbc(),
+ if (!PEM_write_bio_PKCS8PrivateKey(bp, key, EVP_aes_256_cbc(),
                                     NULL, 0, 0, "hello"))
      /* Error */
 


### PR DESCRIPTION
This fixes old examples that use DES-EDE3-CBC.  
I replaced EVP_des_ede3_cbc() with EVP_aes_256_cbc() in doc/man3/PEM_read_bio_PrivateKey.pod.

Documentation-only change. ~Closes~ Handles part of #28665
