### PR TITLE
Add support for DIT in AArch64

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,13 @@ OpenSSL 4.0
 
 ### Changes between 3.6 and 4.0 [xx XXX xxxx]
 
+ * Add Support for Data Independent Timing (DIT) on AArch64 chipsets that
+   support it (Armv8.4-A or newer). This flag tells the CPU to avoid
+   optimisations that may change instruction timing based on the values of the
+   data being operated on.
+
+   *Paul Elliott / Tom Cosgrove*
+
  * Added CSHAKE as per [SP 800-185]
 
    *Shane Lontis*

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,7 +33,12 @@ OpenSSL 4.1
 
 ### Changes between 4.1 and 4.2 [xx XXX xxxx]
 
- * none yet
+ * Add support for Data Independent Timing (DIT) on AArch64 chipsets that
+   support it (Armv8.4-A or newer). This flag tells the CPU to avoid
+   optimisations that may change instruction timing based on the values of the
+   data being operated on.
+
+   *Paul Elliott / Tom Cosgrove*
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 

--- a/crypto/arm64cpuid.pl
+++ b/crypto/arm64cpuid.pl
@@ -218,6 +218,14 @@ _armv8_rng_probe:
 	mrs	x0, s3_3_c2_c4_1	// rndrrs
 	ret
 .size	_armv8_rng_probe,.-_armv8_rng_probe
+
+.globl	_armv8_dit_probe
+.type	_armv8_dit_probe,%function
+_armv8_dit_probe:
+	AARCH64_VALID_CALL_TARGET
+	mrs	x0, s3_3_c4_c2_5	// dit
+	ret
+.size	_armv8_dit_probe,.-_armv8_dit_probe
 ___
 
 sub gen_random {

--- a/crypto/arm_arch.h
+++ b/crypto/arm_arch.h
@@ -83,6 +83,7 @@ extern unsigned int OPENSSL_armv8_rsa_neonized;
 #define ARMV8_HAVE_SHA3_AND_WORTH_USING (1 << 15)
 #define ARMV8_UNROLL12_EOR3 (1 << 16)
 #define ARMV9_SVE2_POLY1305 (1 << 17)
+#define ARMV8_DIT (1 << 18)
 
 /*
  * MIDR_EL1 system register

--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <openssl/crypto.h>
+#include <crypto/aarch64_dit.h>
 #ifdef __APPLE__
 #include <sys/sysctl.h>
 #else
@@ -146,6 +147,7 @@ static unsigned long getauxval(unsigned long key)
 #define OSSL_HWCAP_CE_SM4 (1 << 19)
 #define OSSL_HWCAP_CE_SHA512 (1 << 21)
 #define OSSL_HWCAP_SVE (1 << 22)
+#define OSSL_HWCAP_DIT (1 << 24)
 /* AT_HWCAP2 */
 #define OSSL_HWCAP2 26
 #define OSSL_HWCAP2_SVE2 (1 << 1)
@@ -221,6 +223,7 @@ void _armv8_eor3_probe(void);
 void _armv8_sve_probe(void);
 void _armv8_sve2_probe(void);
 void _armv8_rng_probe(void);
+void _armv8_dit_probe(void);
 #endif
 #endif /* !__APPLE__ && !OSSL_IMPLEMENT_GETAUXVAL */
 
@@ -298,6 +301,7 @@ void OPENSSL_cpuid_setup(void)
         /* More recent extensions are indicated by sysctls */
         OPENSSL_armcap_P |= sysctl_query("hw.optional.armv8_2_sha512", ARMV8_SHA512);
         OPENSSL_armcap_P |= sysctl_query("hw.optional.armv8_2_sha3", ARMV8_SHA3);
+        OPENSSL_armcap_P |= sysctl_query("hw.optional.arm.FEAT_DIT", ARMV8_DIT);
 
         if (OPENSSL_armcap_P & ARMV8_SHA3) {
             char uarch[64];
@@ -350,6 +354,9 @@ void OPENSSL_cpuid_setup(void)
     if (getauxval(OSSL_HWCAP) & OSSL_HWCAP_SVE)
         OPENSSL_armcap_P |= ARMV8_SVE;
 
+    if (getauxval(OSSL_HWCAP) & OSSL_HWCAP_DIT)
+        OPENSSL_armcap_P |= ARMV8_DIT;
+
     if (getauxval(OSSL_HWCAP2) & OSSL_HWCAP2_SVE2)
         OPENSSL_armcap_P |= ARMV9_SVE2;
 
@@ -398,6 +405,7 @@ void OPENSSL_cpuid_setup(void)
     OPENSSL_armcap_P |= arm_probe_for(_armv8_sve_probe, ARMV8_SVE);
     OPENSSL_armcap_P |= arm_probe_for(_armv8_sve2_probe, ARMV9_SVE2);
     OPENSSL_armcap_P |= arm_probe_for(_armv8_rng_probe, ARMV8_RNG);
+    OPENSSL_armcap_P |= arm_probe_for(_armv8_dit_probe, ARMV8_DIT);
 #endif
 
     /*
@@ -475,3 +483,66 @@ void OPENSSL_cpuid_setup(void)
 #endif
 }
 #endif /* _WIN32, __ARM_MAX_ARCH__ >= 7 */
+
+#if defined(__aarch64__) && !defined(OSSL_NO_DIT)
+
+/* For PSTATE.DIT */
+
+/* Gets the current value of the DIT flag as 0 or 1 */
+/* MUST NOT be called unless OPENSSL_armcap_P has ARMV8_DIT set */
+static ossl_inline uint64_t ossl_get_dit(void)
+{
+    uint64_t val = 0;
+
+    /* In case we're used with an older assembler that doesn't understand DIT */
+    __asm__ volatile("mrs %0, s3_3_c4_c2_5" : "=r"(val));
+
+    return (val >> 24) & 1;
+}
+
+/* Sets DIT on: MUST NOT be called unless OPENSSL_armcap_P has ARMV8_DIT set */
+static ossl_inline void ossl_set_dit_on(void)
+{
+    __asm__ volatile(".inst 0xD503415F"); /* msr dit, #1 */
+}
+
+/* Sets DIT off: MUST NOT be called unless OPENSSL_armcap_P has ARMV8_DIT set */
+static ossl_inline void ossl_set_dit_off(void)
+{
+    __asm__ volatile(".inst 0xD503405F"); /* msr dit, #0 */
+}
+
+/*
+ * Sets DIT on and returns original value (0 or value given, for off and on respectively)
+ * (we allow the caller to supply the "on" value returned, so that bit flags
+ * can be supported more easily).
+ */
+int ossl_ensure_dit_on(int value_for_on)
+{
+    if (!(OPENSSL_armcap_P & ARMV8_DIT))
+        return 0;
+
+    if (ossl_get_dit()) /* It's already enabled */
+        return value_for_on; /* Tell caller to leave it on */
+
+    ossl_set_dit_on();
+
+    return 0;
+}
+
+/*
+ * Sets the DIT flag to its previous value, either off (*dit_prev == 0) or
+ * on (*dit_prev != 0). To be called when DIT is already on.
+ */
+void ossl_restore_original_dit(volatile int *dit_prev)
+{
+    if (!(OPENSSL_armcap_P & ARMV8_DIT)) /* Nothing to do */
+        return;
+
+    if (*dit_prev) /* Was previously set, so leave */
+        return;
+
+    ossl_set_dit_off();
+}
+
+#endif

--- a/crypto/ec/curve25519.c
+++ b/crypto/ec/curve25519.c
@@ -15,6 +15,7 @@
 
 #include <string.h>
 #include "crypto/ecx.h"
+#include "crypto/aarch64_dit.h"
 #include "ec_local.h"
 #include <openssl/evp.h>
 #include <openssl/sha.h>
@@ -5638,6 +5639,8 @@ int ossl_ed25519_sign(uint8_t *out_sig, const uint8_t *tbs, size_t tbs_len,
     unsigned int sz;
     int res = 0;
 
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     if (context == NULL)
         context_len = 0;
 
@@ -5698,6 +5701,8 @@ err:
 int ossl_ed25519_pubkey_verify(const uint8_t *pub, size_t pub_len)
 {
     ge_p3 A;
+
+    /* OSSL_ENABLE_DIT_FOR_SCOPE explicitly omitted on verify */
 
     if (pub_len != ED25519_KEYLEN)
         return 0;
@@ -5820,6 +5825,8 @@ int ossl_ed25519_public_from_private(OSSL_LIB_CTX *ctx, uint8_t out_public_key[3
     int r;
     EVP_MD *sha512 = NULL;
 
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     sha512 = EVP_MD_fetch(ctx, SN_sha512, propq);
     if (sha512 == NULL)
         return 0;
@@ -5845,6 +5852,9 @@ int ossl_x25519(uint8_t out_shared_key[32], const uint8_t private_key[32],
     const uint8_t peer_public_value[32])
 {
     static const uint8_t kZeros[32] = { 0 };
+
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     x25519_scalar_mult(out_shared_key, private_key, peer_public_value);
     /* The all-zero output results when the input is a point of small order. */
     return CRYPTO_memcmp(kZeros, out_shared_key, 32) != 0;
@@ -5856,6 +5866,8 @@ void ossl_x25519_public_from_private(uint8_t out_public_value[32],
     uint8_t e[32];
     ge_p3 A;
     fe zplusy, zminusy, zminusy_inv;
+
+    OSSL_ENABLE_DIT_FOR_SCOPE
 
     memcpy(e, private_key, 32);
     e[0] &= 248;

--- a/crypto/ec/curve25519.c
+++ b/crypto/ec/curve25519.c
@@ -15,6 +15,7 @@
 
 #include <string.h>
 #include "crypto/ecx.h"
+#include "crypto/aarch64_dit.h"
 #include "ec_local.h"
 #include <openssl/evp.h>
 #include <openssl/sha.h>
@@ -5645,6 +5646,8 @@ int ossl_ed25519_sign(uint8_t *out_sig, const uint8_t *tbs, size_t tbs_len,
     unsigned int sz;
     int res = 0;
 
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     if (context == NULL)
         context_len = 0;
 
@@ -5705,6 +5708,8 @@ err:
 int ossl_ed25519_pubkey_verify(const uint8_t *pub, size_t pub_len)
 {
     ge_p3 A;
+
+    /* OSSL_ENABLE_DIT_FOR_SCOPE explicitly omitted on verify */
 
     if (pub_len != ED25519_KEYLEN)
         return 0;
@@ -5827,6 +5832,8 @@ int ossl_ed25519_public_from_private(OSSL_LIB_CTX *ctx, uint8_t out_public_key[3
     int r;
     EVP_MD *sha512 = NULL;
 
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     sha512 = EVP_MD_fetch(ctx, SN_sha512, propq);
     if (sha512 == NULL)
         return 0;
@@ -5852,6 +5859,9 @@ int ossl_x25519(uint8_t out_shared_key[32], const uint8_t private_key[32],
     const uint8_t peer_public_value[32])
 {
     static const uint8_t kZeros[32] = { 0 };
+
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     x25519_scalar_mult(out_shared_key, private_key, peer_public_value);
     /* The all-zero output results when the input is a point of small order. */
     return CRYPTO_memcmp(kZeros, out_shared_key, 32) != 0;
@@ -5863,6 +5873,8 @@ void ossl_x25519_public_from_private(uint8_t out_public_value[32],
     uint8_t e[32];
     ge_p3 A;
     fe zplusy, zminusy, zminusy_inv;
+
+    OSSL_ENABLE_DIT_FOR_SCOPE
 
     memcpy(e, private_key, 32);
     e[0] &= 248;

--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -15,6 +15,7 @@
 #include "internal/provider.h"
 #include "internal/core.h"
 #include "crypto/evp.h"
+#include "crypto/aarch64_dit.h"
 #include "evp_local.h"
 
 static void evp_asym_cipher_free(void *data)
@@ -216,6 +217,8 @@ int EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx,
     const char *desc;
     int ret;
 
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
         return -2;
@@ -258,6 +261,8 @@ int EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx,
     EVP_ASYM_CIPHER *cipher;
     const char *desc;
     int ret;
+
+    OSSL_ENABLE_DIT_FOR_SCOPE
 
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);

--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -15,6 +15,7 @@
 #include "internal/provider.h"
 #include "internal/core.h"
 #include "crypto/evp.h"
+#include "crypto/aarch64_dit.h"
 #include "evp_local.h"
 
 static void evp_asym_cipher_free(void *data)
@@ -232,6 +233,8 @@ int EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx,
     const char *desc;
     int ret;
 
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
         return -2;
@@ -274,6 +277,8 @@ int EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx,
     EVP_ASYM_CIPHER *cipher;
     const char *desc;
     int ret;
+
+    OSSL_ENABLE_DIT_FOR_SCOPE
 
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -21,6 +21,7 @@
 #include "internal/common.h"
 #include "internal/safe_math.h"
 #include "crypto/evp.h"
+#include "crypto/aarch64_dit.h"
 #include "evp_local.h"
 
 OSSL_SAFE_MATH_SIGNED(int, int)
@@ -654,6 +655,8 @@ int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
     size_t soutl, inl_ = (size_t)inl;
     int blocksize;
 
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     if (ossl_likely(outl != NULL)) {
         *outl = 0;
     } else {
@@ -710,6 +713,8 @@ int EVP_EncryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
     size_t soutl;
     int blocksize;
 
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     if (outl != NULL) {
         *outl = 0;
     } else {
@@ -759,6 +764,8 @@ int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
     int ret;
     size_t soutl, inl_ = (size_t)inl;
     int blocksize;
+
+    OSSL_ENABLE_DIT_FOR_SCOPE
 
     if (ossl_likely(outl != NULL)) {
         *outl = 0;
@@ -815,6 +822,8 @@ int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
     size_t soutl;
     int ret;
     int blocksize;
+
+    OSSL_ENABLE_DIT_FOR_SCOPE
 
     if (outl != NULL) {
         *outl = 0;

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -21,6 +21,7 @@
 #include "internal/common.h"
 #include "internal/safe_math.h"
 #include "crypto/evp.h"
+#include "crypto/aarch64_dit.h"
 #include "evp_local.h"
 
 OSSL_SAFE_MATH_SIGNED(int, int)
@@ -656,6 +657,8 @@ int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
     size_t soutl, inl_ = (size_t)inl;
     int blocksize;
 
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     if (inl < 0) {
         ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_LENGTH);
         return 0;
@@ -717,6 +720,8 @@ int EVP_EncryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
     size_t soutl;
     int blocksize;
 
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     if (outl != NULL) {
         *outl = 0;
     } else {
@@ -766,6 +771,8 @@ int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
     int ret;
     size_t soutl, inl_ = (size_t)inl;
     int blocksize;
+
+    OSSL_ENABLE_DIT_FOR_SCOPE
 
     if (inl < 0) {
         ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_LENGTH);
@@ -827,6 +834,8 @@ int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
     size_t soutl;
     int ret;
     int blocksize;
+
+    OSSL_ENABLE_DIT_FOR_SCOPE
 
     if (outl != NULL) {
         *outl = 0;

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -15,6 +15,7 @@
 #include "internal/provider.h"
 #include "internal/core.h"
 #include "crypto/evp.h"
+#include "crypto/aarch64_dit.h"
 #include "evp_local.h"
 
 static void evp_kem_free(void *data)
@@ -225,6 +226,8 @@ int EVP_PKEY_encapsulate(EVP_PKEY_CTX *ctx,
     unsigned char *out, size_t *outlen,
     unsigned char *secret, size_t *secretlen)
 {
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     if (ctx == NULL)
         return 0;
 
@@ -262,6 +265,8 @@ int EVP_PKEY_decapsulate(EVP_PKEY_CTX *ctx,
     unsigned char *secret, size_t *secretlen,
     const unsigned char *in, size_t inlen)
 {
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     if (ctx == NULL
         || (in == NULL || inlen == 0)
         || (secret == NULL && secretlen == NULL))

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -15,6 +15,7 @@
 #include "internal/provider.h"
 #include "internal/core.h"
 #include "crypto/evp.h"
+#include "crypto/aarch64_dit.h"
 #include "evp_local.h"
 
 static void evp_kem_free(void *data)
@@ -242,6 +243,8 @@ int EVP_PKEY_encapsulate(EVP_PKEY_CTX *ctx,
     unsigned char *out, size_t *outlen,
     unsigned char *secret, size_t *secretlen)
 {
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     if (ctx == NULL)
         return 0;
 
@@ -279,6 +282,8 @@ int EVP_PKEY_decapsulate(EVP_PKEY_CTX *ctx,
     unsigned char *secret, size_t *secretlen,
     const unsigned char *in, size_t inlen)
 {
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     if (ctx == NULL
         || (in == NULL || inlen == 0)
         || (secret == NULL && secretlen == NULL))

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -12,6 +12,7 @@
 #include <openssl/evp.h>
 #include <openssl/objects.h>
 #include "crypto/evp.h"
+#include "crypto/aarch64_dit.h"
 #include "internal/provider.h"
 #include "internal/numbers.h" /* includes SIZE_MAX */
 #include "internal/common.h"
@@ -337,6 +338,8 @@ int EVP_DigestSignUpdate(EVP_MD_CTX *ctx, const void *data, size_t dsize)
     EVP_PKEY_CTX *pctx = ctx->pctx;
     int ret;
 
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     if ((ctx->flags & EVP_MD_CTX_FLAG_FINALISED) != 0) {
         ERR_raise(ERR_LIB_EVP, EVP_R_UPDATE_ERROR);
         return 0;
@@ -412,6 +415,8 @@ int EVP_DigestSignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
     int r = 0;
     EVP_PKEY_CTX *dctx = NULL, *pctx = ctx->pctx;
 
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     if ((ctx->flags & EVP_MD_CTX_FLAG_FINALISED) != 0) {
         ERR_raise(ERR_LIB_EVP, EVP_R_FINAL_ERROR);
         return 0;
@@ -464,6 +469,8 @@ int EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sigret, size_t *siglen,
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         return 0;
     }
+
+    OSSL_ENABLE_DIT_FOR_SCOPE
 
     if ((ctx->flags & EVP_MD_CTX_FLAG_FINALISED) != 0) {
         ERR_raise(ERR_LIB_EVP, EVP_R_FINAL_ERROR);

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -12,6 +12,7 @@
 #include <openssl/evp.h>
 #include <openssl/objects.h>
 #include "crypto/evp.h"
+#include "crypto/aarch64_dit.h"
 #include "internal/provider.h"
 #include "internal/numbers.h" /* includes SIZE_MAX */
 #include "internal/common.h"
@@ -332,6 +333,8 @@ int EVP_DigestSignUpdate(EVP_MD_CTX *ctx, const void *data, size_t dsize)
     EVP_PKEY_CTX *pctx = ctx->pctx;
     int ret;
 
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     if ((ctx->flags & EVP_MD_CTX_FLAG_FINALISED) != 0) {
         ERR_raise(ERR_LIB_EVP, EVP_R_UPDATE_ERROR);
         return 0;
@@ -407,6 +410,8 @@ int EVP_DigestSignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
     int r = 0;
     EVP_PKEY_CTX *dctx = NULL, *pctx = ctx->pctx;
 
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     if ((ctx->flags & EVP_MD_CTX_FLAG_FINALISED) != 0) {
         ERR_raise(ERR_LIB_EVP, EVP_R_FINAL_ERROR);
         return 0;
@@ -459,6 +464,8 @@ int EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sigret, size_t *siglen,
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         return 0;
     }
+
+    OSSL_ENABLE_DIT_FOR_SCOPE
 
     if ((ctx->flags & EVP_MD_CTX_FLAG_FINALISED) != 0) {
         ERR_raise(ERR_LIB_EVP, EVP_R_FINAL_ERROR);

--- a/crypto/evp/pmeth_gn.c
+++ b/crypto/evp/pmeth_gn.c
@@ -21,6 +21,7 @@
 #include "crypto/asn1.h"
 #endif
 #include "crypto/evp.h"
+#include "crypto/aarch64_dit.h"
 #include "evp_local.h"
 
 static int gen_init(EVP_PKEY_CTX *ctx, int operation)
@@ -106,6 +107,8 @@ int EVP_PKEY_generate(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
     EVP_PKEY *allocated_pkey = NULL;
     /* Legacy compatible keygen callback info, only used with provider impls */
     int gentmp[2];
+
+    OSSL_ENABLE_DIT_FOR_SCOPE
 
     if (ppkey == NULL)
         return -1;

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -18,6 +18,7 @@
 #include "internal/provider.h"
 #include "internal/core.h"
 #include "crypto/evp.h"
+#include "crypto/aarch64_dit.h"
 #include "evp_local.h"
 
 static void evp_signature_free(void *data)
@@ -905,6 +906,8 @@ int EVP_PKEY_sign_message_update(EVP_PKEY_CTX *ctx,
     const char *desc;
     int ret;
 
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
         return -1;
@@ -936,6 +939,8 @@ int EVP_PKEY_sign_message_final(EVP_PKEY_CTX *ctx,
     EVP_SIGNATURE *signature;
     const char *desc;
     int ret;
+
+    OSSL_ENABLE_DIT_FOR_SCOPE
 
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
@@ -970,6 +975,8 @@ int EVP_PKEY_sign(EVP_PKEY_CTX *ctx,
     EVP_SIGNATURE *signature;
     const char *desc;
     int ret;
+
+    OSSL_ENABLE_DIT_FOR_SCOPE
 
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
@@ -1052,6 +1059,8 @@ int EVP_PKEY_verify_message_update(EVP_PKEY_CTX *ctx,
     EVP_SIGNATURE *signature;
     const char *desc;
     int ret;
+
+    /* OSSL_ENABLE_DIT_FOR_SCOPE explicitly omitted on verify */
 
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -18,6 +18,7 @@
 #include "internal/provider.h"
 #include "internal/core.h"
 #include "crypto/evp.h"
+#include "crypto/aarch64_dit.h"
 #include "evp_local.h"
 
 static void evp_signature_free(void *data)
@@ -924,6 +925,8 @@ int EVP_PKEY_sign_message_update(EVP_PKEY_CTX *ctx,
     const char *desc;
     int ret;
 
+    OSSL_ENABLE_DIT_FOR_SCOPE
+
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
         return -1;
@@ -955,6 +958,8 @@ int EVP_PKEY_sign_message_final(EVP_PKEY_CTX *ctx,
     EVP_SIGNATURE *signature;
     const char *desc;
     int ret;
+
+    OSSL_ENABLE_DIT_FOR_SCOPE
 
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
@@ -989,6 +994,8 @@ int EVP_PKEY_sign(EVP_PKEY_CTX *ctx,
     EVP_SIGNATURE *signature;
     const char *desc;
     int ret;
+
+    OSSL_ENABLE_DIT_FOR_SCOPE
 
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
@@ -1071,6 +1078,8 @@ int EVP_PKEY_verify_message_update(EVP_PKEY_CTX *ctx,
     EVP_SIGNATURE *signature;
     const char *desc;
     int ret;
+
+    /* OSSL_ENABLE_DIT_FOR_SCOPE explicitly omitted on verify */
 
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -1679,9 +1679,10 @@ This call is only valid when decrypting data.
 Where possible the B<EVP> interface to symmetric ciphers should be used in
 preference to the low-level interfaces. This is because the code then becomes
 transparent to the cipher used and much more flexible. Additionally, the
-B<EVP> interface will ensure the use of platform specific cryptographic
-acceleration such as AES-NI (the low-level interfaces do not provide the
-guarantee).
+B<EVP> interface will ensure the use of platform-specific cryptographic
+acceleration such as AES-NI and platform-provided data-independent timing
+protection such as DIT (the low-level interfaces do not provide these
+guarantees).
 
 PKCS padding works by adding B<n> padding bytes of value B<n> to make the total
 length of the encrypted data a multiple of the block size. Padding is always

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -1695,9 +1695,10 @@ This call is only valid when decrypting data.
 Where possible the B<EVP> interface to symmetric ciphers should be used in
 preference to the low-level interfaces. This is because the code then becomes
 transparent to the cipher used and much more flexible. Additionally, the
-B<EVP> interface will ensure the use of platform specific cryptographic
-acceleration such as AES-NI (the low-level interfaces do not provide the
-guarantee).
+B<EVP> interface will ensure the use of platform-specific cryptographic
+acceleration such as AES-NI and platform-provided data-independent timing
+protection such as DIT (the low-level interfaces do not provide these
+guarantees).
 
 PKCS padding works by adding B<n> padding bytes of value B<n> to make the total
 length of the encrypted data a multiple of the block size. Padding is always

--- a/include/arch/arm_arch.h
+++ b/include/arch/arm_arch.h
@@ -83,6 +83,7 @@ extern unsigned int OPENSSL_armv8_rsa_neonized;
 #define ARMV8_HAVE_SHA3_AND_WORTH_USING (1 << 15)
 #define ARMV8_UNROLL12_EOR3 (1 << 16)
 #define ARMV9_SVE2_POLY1305 (1 << 17)
+#define ARMV8_DIT (1 << 18)
 
 /*
  * MIDR_EL1 system register

--- a/include/crypto/aarch64_dit.h
+++ b/include/crypto/aarch64_dit.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 The OpenSSL Project Authors. All Rights Reserved. Copyright
+ * (c) 2002, Oracle and/or its affiliates. All rights reserved
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OPENSSL_AARCH64_DIT_H
+#define OPENSSL_AARCH64_DIT_H
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Data-independent timing.
+ *
+ * OSSL_ENABLE_DIT_FOR_SCOPE must be placed before code that uses instructions
+ * whose timing depends on their data - otherwise constant-time code might not
+ * be.
+ *
+ * OSSL_ENABLE_DIT_FOR_SCOPE can be placed at the beginning of a code section
+ * that makes repeated calls to crypto functions.
+ *
+ * DIT state will automatically be restored to its previous value at the end of
+ * the scope.
+ *
+ * This can reduce the overhead of repeatedly setting and resetting the state.
+ *
+ * Note that this requires the cleanup attribute to function, and that this
+ * attribute is not supported in clang versions before 15. Support for the
+ * cleanup attribute was introduced into GCC in version 4.0, which pre-dates
+ * AArch64. Currently only these two compilers are supported; other compilers
+ * can be added to the list below provided they support
+ * __attribute__((cleanup()).
+ */
+
+#if defined(__aarch64__) && !defined(OSSL_NO_DIT)
+#if !(defined(__GNUC__) || (defined(__clang__) && (__clang_major__ >= 15)))
+#warning "Unsupported compiler - disabling DIT"
+#define OSSL_NO_DIT
+#endif
+#endif
+
+#if defined(__aarch64__) && !defined(OSSL_NO_DIT)
+
+/* Internal functions used by OSSL_ENABLE_DIT_FOR_SCOPE */
+void ossl_restore_original_dit(volatile int *dit_prev);
+int ossl_ensure_dit_on(int);
+
+#define OSSL_ENABLE_DIT_FOR_SCOPE                           \
+    volatile int dit_prev_                                  \
+        __attribute__((cleanup(ossl_restore_original_dit))) \
+        __attribute__((unused))                             \
+        = ossl_ensure_dit_on(1);
+
+#else
+
+#define OSSL_ENABLE_DIT_FOR_SCOPE
+
+#endif /* __aarch64__ && !OSSL_NO_DIT */
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/include/crypto/aarch64_dit.h
+++ b/include/crypto/aarch64_dit.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024-2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OPENSSL_AARCH64_DIT_H
+#define OPENSSL_AARCH64_DIT_H
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Data-independent timing.
+ *
+ * OSSL_ENABLE_DIT_FOR_SCOPE must be placed before code that uses instructions
+ * whose timing depends on their data - otherwise constant-time code might not
+ * be.
+ *
+ * OSSL_ENABLE_DIT_FOR_SCOPE can be placed at the beginning of a code section
+ * that makes repeated calls to crypto functions.
+ *
+ * DIT state will automatically be restored to its previous value at the end of
+ * the scope.
+ *
+ * This can reduce the overhead of repeatedly setting and resetting the state.
+ *
+ * Note that this requires the cleanup attribute to function, and that this
+ * attribute is not supported in clang versions before 15. Support for the
+ * cleanup attribute was introduced into GCC in version 4.0, which pre-dates
+ * AArch64. Currently only these two compilers are supported; other compilers
+ * can be added to the list below provided they support
+ * __attribute__((cleanup())).
+ */
+
+#if defined(__aarch64__) && !defined(OSSL_NO_DIT)
+#if !defined(__GNUC__) || (defined(__clang__) && __clang_major__ < 15)
+#warning "Unsupported compiler - disabling DIT"
+#define OSSL_NO_DIT
+#endif
+#endif
+
+#if defined(__aarch64__) && !defined(OSSL_NO_DIT)
+
+/* Internal functions used by OSSL_ENABLE_DIT_FOR_SCOPE */
+void ossl_restore_original_dit(volatile int *dit_prev);
+int ossl_ensure_dit_on(int);
+
+#define OSSL_ENABLE_DIT_FOR_SCOPE                           \
+    volatile int dit_prev_                                  \
+        __attribute__((cleanup(ossl_restore_original_dit))) \
+        __attribute__((unused))                             \
+        = ossl_ensure_dit_on(1);
+
+#else
+
+#define OSSL_ENABLE_DIT_FOR_SCOPE
+
+#endif /* __aarch64__ && !OSSL_NO_DIT */
+
+#ifdef __cplusplus
+}
+#endif
+#endif


### PR DESCRIPTION
The Arm v8.4-A architecture added a data independent timing flag (DIT) which tells the CPU to avoid making optimisations that may change instruction timing based on the value of the data they operate on.
    
Enabling this is crucial for constant-time cryptographic code, but it may reduce performance, so it needs to only be set at as low a level in the code as possible (but above cryptographic operations whose timing is important).

This change enables DIT on AArch64, with a macro OSSL_NO_DIT that may be used to disable it.

A macro OSSL_ENABLE_DIT_FOR_SCOPE is provided, which will turn DIT on (if it is not already) and arrange for it to be returned to its previous state when the current scope (function) exits.

DIT is only enabled in the EVP interfaces - obviously a more optimal implementation could be achieved, but this would obviously be a great deal more work to do and would touch a great many more files.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
