### PR TITLE
cmp: use server CMP context in mock server

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -3263,7 +3263,7 @@ static int cmp_server(OSSL_CMP_CTX *srv_cmp_ctx)
                 goto next;
             }
             OPENSSL_free(path);
-            resp = OSSL_CMP_CTX_server_perform(cmp_ctx, req);
+            resp = OSSL_CMP_CTX_server_perform(srv_cmp_ctx, req);
             OSSL_CMP_MSG_free(req);
             if (resp == NULL) {
                 (void)http_server_send_status(prog, cbio,


### PR DESCRIPTION
Previously, the wrong variable was passed to `OSSL_CMP_CTX_server_perform()`.