### PR TITLE
ssl: fix OOB write in SSL_get_shared_ciphers when no shared ciphers

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3476,17 +3476,19 @@ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int size)
             continue;
 
         n = (int)OPENSSL_strnlen(c->name, size);
-        if (n >= size) {
-            if (p != buf)
-                --p;
-            *p = '\0';
-            return buf;
-        }
+        if (n >= size)
+            break;
+
         memcpy(p, c->name, n);
         p += n;
         *(p++) = ':';
         size -= n + 1;
     }
+
+    /* No overlap */
+    if (p == buf)
+        return NULL;
+
     p[-1] = '\0';
     return buf;
 }


### PR DESCRIPTION
When no cipher names are appended, p remains at buf and the unconditional p[-1] = '\0' underflows. Only NUL-terminate if at least one cipher was written; otherwise return an empty string safely.