### PR TITLE
Disallow Message sequence number 2 in DTLSv1_listen

### DIFF
--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -573,7 +573,7 @@ int DTLSv1_listen(SSL *ssl, BIO_ADDR *client)
         }
 
         /* Message sequence number can only be 0 or 1 */
-        if (msgseq > 2) {
+        if (msgseq > 1) {
             ERR_raise(ERR_LIB_SSL, SSL_R_INVALID_SEQUENCE_NUMBER);
             goto end;
         }


### PR DESCRIPTION
"Message sequence number can only be 0 or 1" should be adhered to.