### PR TITLE
Apply the Beyoncé rule to how we convert time.

### DIFF
--- a/test/asn1_time_test.c
+++ b/test/asn1_time_test.c
@@ -94,6 +94,26 @@ static const struct TESTDATA_asn1_to_utc asn1_to_utc[] = {
         -1,
     },
     {
+        /* test days out of bound (non leap year)*/
+        "210229005959Z",
+        -1,
+    },
+    {
+        /* test days not out of bound (non leap year) */
+        "210228005959Z",
+        1614473999,
+    },
+    {
+        /* test days not out of bound (leap year)*/
+        "200229005959Z",
+        1582937999,
+    },
+    {
+        /* test days out of bound (leap year)*/
+        "200230005959Z",
+        -1
+    },
+    {
         /* test month out of bound */
         "211328005960Z",
         -1,


### PR DESCRIPTION
![beyonce-rule](https://github.com/user-attachments/assets/f6330367-f2d4-4cef-b410-4d66881e7609)

So we currently have certain behaviour around what values we accept when converting times. This includes
that we reject certain values. 

Assuming we care to preserve this behaviour, instead of accidentally changing it, All the ladies sing 
"If you like it then you should have put a test on it". 

So let's put a test on those behaviours. 