### PR TITLE
Backports to fix PBKDF2 tests,

### DIFF
--- a/test/recipes/30-test_evp_data/evpkdf_pbkdf2.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_pbkdf2.txt
@@ -232,7 +232,7 @@ Title = FIPS indicator tests
 
 # Test that operations with unapproved parameters are rejected
 Availablein = fips
-FIPSversion = >=3.4.0
+FIPSversion = >=3.4.0 <4.0.0
 KDF = PBKDF2
 Ctrl.pass = pass:password
 Ctrl.salt = salt:salt
@@ -243,7 +243,7 @@ Reason = invalid salt length
 
 # Test that operations with unapproved parameters are reported as unapproved
 Availablein = fips
-FIPSversion = >=3.4.0
+FIPSversion = >=3.4.0 <4.0.0
 KDF = PBKDF2
 Unapproved = 1
 Ctrl.pkcs5 = pkcs5:1
@@ -268,6 +268,7 @@ Output = 043c508e57c6427036fd2c6cd2a02ec7530a412c
 Title = Test that a too low iteration count raises an error
 
 Availablein = fips
+FIPSversion = <4.0.0
 KDF = PBKDF2
 Ctrl.pass = pass:password
 Ctrl.salt = salt:saltydaysarethebest


### PR DESCRIPTION
PR #29055 changes behaviour that makes the PBKDF2 lower bounds checks fail on derive instead of during set_ctx_params(). The FIPS tests need to check for this change on older branches.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
