### PR TITLE
Add ONC RPC support for StartTLS

### DIFF
--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -623,7 +623,7 @@ normal verbose output.
 Send the protocol-specific message(s) to switch to TLS for communication.
 I<protocol> is a keyword for the intended protocol.  Currently, the only
 supported keywords are "smtp", "pop3", "imap", "ftp", "xmpp", "xmpp-server",
-"irc", "postgres", "mysql", "lmtp", "nntp", "sieve" and "ldap".
+"irc", "postgres", "mysql", "lmtp", "nntp", "sieve", "ldap", and "rpc".
 
 =item B<-xmpphost> I<hostname>
 


### PR DESCRIPTION
As currently defined by RFC-9289, enable s_client to send appropriate STARTTLS verifier.  This allows remote examination of certificates presented by NFS servers that have implemented ONCRPC over TLS.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated