### PR TITLE
s_server: print program not, not port

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1399,7 +1399,7 @@ int s_server_main(int argc, char *argv[])
             if (BIO_parse_hostserv(opt_arg(), NULL, &port, BIO_PARSE_PRIO_SERV) < 1) {
                 BIO_printf(bio_err,
                            "%s: -port argument malformed or ambiguous\n",
-                           port);
+                           prog);
                 goto end;
             }
             break;
@@ -1414,7 +1414,7 @@ int s_server_main(int argc, char *argv[])
             if (BIO_parse_hostserv(opt_arg(), &host, &port, BIO_PARSE_PRIO_SERV) < 1) {
                 BIO_printf(bio_err,
                            "%s: -accept argument malformed or ambiguous\n",
-                           port);
+                           prog);
                 goto end;
             }
             break;


### PR DESCRIPTION
There is no point in printing `port` here.