### PR TITLE
bio/dgram: use IPV6_PMTUDISC_* with IPV6_MTU_DISCOVER

### DIFF
--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -932,8 +932,8 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
                 ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
                                "calling setsockopt()");
 
-#  elif defined(OPENSSL_SYS_LINUX) && defined(IPV6_MTUDISCOVER)
-            sockopt_val = num ? IP_PMTUDISC_PROBE : IP_PMTUDISC_DONT;
+#  elif defined(OPENSSL_SYS_LINUX) && defined(IPV6_MTU_DISCOVER)
+            sockopt_val = num ? IPV6_PMTUDISC_PROBE : IPV6_PMTUDISC_DONT;
             if ((ret = setsockopt(b->num, IPPROTO_IPV6, IPV6_MTU_DISCOVER,
                                   &sockopt_val, sizeof(sockopt_val))) < 0)
                 ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),


### PR DESCRIPTION
`IPV6_MTUDISCOVER` does not exist on Linux.