### PR TITLE
bio/dgram: fix OOB/UB when copying SCTP notification

### DIFF
--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -2020,7 +2020,7 @@ static int dgram_sctp_read(BIO *b, char *out, int outl)
                 copy = (size_t)n < sizeof(snp) ? (size_t)n : sizeof(snp);
 
                 /* Only consult header if we received at least the header */
-                if (copy >= sizeof(snp.sn_header) {
+                if (copy >= sizeof(snp.sn_header)) {
                     memcpy(&snp, out, copy);
 
                     if (snp.sn_header.sn_type == SCTP_SENDER_DRY_EVENT) {


### PR DESCRIPTION
Bound the memcpy of union sctp_notification to min(n, sizeof), zero-initialize the destination, and guard header access to avoid both true OOB reads and use of uninitialized bytes