### PR TITLE
Fix off-by-one overflow in the AST resubmit

### DIFF
--- a/apps/lib/vms_term_sock.c
+++ b/apps/lib/vms_term_sock.c
@@ -529,7 +529,7 @@ static int TerminalDeviceAst (int astparm)
                       TerminalDeviceAst,
                       0,
                       TerminalDeviceBuff,
-                      sizeof(TerminalDeviceBuff) - 1,
+                      sizeof(TerminalDeviceBuff) - 2,
                       0, 0, 0, 0);
 
     /*


### PR DESCRIPTION
`sizeof(TerminalDeviceBuff) - 2,` is correctly used elsewhere.