### PR TITLE
cmp_http: do not shadow keep_alive function with variable

### DIFF
--- a/crypto/cmp/cmp_http.c
+++ b/crypto/cmp/cmp_http.c
@@ -11,9 +11,9 @@
 
 #include "cmp_local.h"
 
-static int keep_alive(int keep_alive, int body_type, BIO **bios)
+static int keep_alive(int want_keep_alive, int body_type, BIO **bios)
 {
-    if (keep_alive != 0 && bios == NULL
+    if (want_keep_alive != 0 && bios == NULL
         /*
          * Ask for persistent connection only if may need more round trips.
          * Do so even with disableConfirm because polling might be needed.
@@ -23,8 +23,8 @@ static int keep_alive(int keep_alive, int body_type, BIO **bios)
             && body_type != OSSL_CMP_PKIBODY_P10CR
             && body_type != OSSL_CMP_PKIBODY_KUR
             && body_type != OSSL_CMP_PKIBODY_POLLREQ)
-        keep_alive = 0;
-    return keep_alive;
+        want_keep_alive = 0;
+    return want_keep_alive;
 }
 
 /*


### PR DESCRIPTION
As in the title.