### PR TITLE
ssl: avoid LRU corruption on OOM in SSL_CTX_add_session

### DIFF
--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -726,7 +726,6 @@ int ssl_get_prev_session(SSL_CONNECTION *s, CLIENTHELLO_MSG *hello)
 int SSL_CTX_add_session(SSL_CTX *ctx, SSL_SESSION *c)
 {
     int ret = 0;
-    int in_hash;
     SSL_SESSION *s;
 
     /*
@@ -751,7 +750,7 @@ int SSL_CTX_add_session(SSL_CTX *ctx, SSL_SESSION *c)
      * case, s == c should hold (then we did not really modify
      * ctx->sessions), or we're in trouble.
      */
-    if (s != NULL && s != c) {
+    if (s != NULL) {
         /* We *are* in trouble ... */
         SSL_SESSION_list_remove(ctx, s);
         SSL_SESSION_free(s);
@@ -771,10 +770,9 @@ int SSL_CTX_add_session(SSL_CTX *ctx, SSL_SESSION *c)
          * the session to the SSL_SESSION_list at this time
          */
         s = c;
+    } else {
+        ret = 1; /* new entry is successfully inserted */
     }
-
-    /* Only link into LRU if c actually lives in the hash table */
-    in_hash = (lh_SSL_SESSION_retrieve(ctx->sessions, c) != NULL);
 
     /* Adjust last used time, and add back into the cache at the appropriate spot */
     if (ctx->session_cache_mode & SSL_SESS_CACHE_UPDATE_TIME) {
@@ -784,24 +782,29 @@ int SSL_CTX_add_session(SSL_CTX *ctx, SSL_SESSION *c)
 
     if (s == NULL) {
         /*
-         * new cache entry -- remove old ones if cache has become too large
-         * delete cache entry *before* add, so we don't remove the one we're adding!
+         * new cache entry (or out of memory), either  way we try to remove old
+         * ones if cache has become too large delete cache entry.
          */
-
-        ret = 1;
 
         if (SSL_CTX_sess_get_cache_size(ctx) > 0) {
             while (SSL_CTX_sess_number(ctx) >= SSL_CTX_sess_get_cache_size(ctx)) {
+                /*
+                 * very unlikely we happen to remove entry we just inserted,
+                 * but better safe than sorry?
+                 */
+                if (ctx->session_cache_tail == c) {
+                    ret = 0;
+                    s = c; /* drop reference on failure */
+                }
                 if (!remove_session_lock(ctx, ctx->session_cache_tail, 0))
                     break;
                 else
                     ssl_tsan_counter(ctx, &ctx->stats.sess_cache_full);
             }
         }
+        if (ret == 1)
+            SSL_SESSION_list_add(ctx, c);
     }
-
-    if (in_hash)
-        SSL_SESSION_list_add(ctx, c);
 
     if (s != NULL) {
         /*


### PR DESCRIPTION
If lh_SSL_SESSION_insert() returns NULL and a subsequent lh_SSL_SESSION_retrieve() also returns NULL, insertion likely failed (OOM). The function set s = c to drop the extra ref but still unconditionally linked c into the SSL_CTX LRU list and then freed it, leaving a dangling list node.

Gate the LRU insertion with a new add_to_list flag and clear it on the OOM path. We still drop the extra ref (free s == c) but we do not add the freed session to the list.
