### PR TITLE
CMP: enforce single CertResponse in is_crep_with_waiting

### DIFF
--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -117,6 +117,10 @@ static int is_crep_with_waiting(const OSSL_CMP_MSG *resp, int rid)
         return 0;
 
     crepmsg = resp->body->value.ip; /* same for cp and kup */
+
+    if (sk_OSSL_CMP_CERTRESPONSE_num(crepmsg->response) > 1)
+        return 0;
+
     crep = ossl_cmp_certrepmessage_get0_certresponse(crepmsg, rid);
 
     return (crep != NULL


### PR DESCRIPTION
is_crep_with_waiting() did not enforce the single CertResponse rule. This was inconsistent with cert_response() and unprotected_exception(), which already reject messages that contain more than one CertResponse.

A malformed multi response could be misclassified as waiting, which caused save_senderNonce_if_waiting() to save first_senderNonce and change client state before the message is rejected later.

Add a count check and return 0 if more than one CertResponse is present.

This aligns behavior with other paths, avoids inconsistent state, and does not affect conforming servers.