### PR TITLE
.pc files: use paths defined in installdata.pm instead of builddata.pm

### DIFF
--- a/build.info
+++ b/build.info
@@ -394,11 +394,11 @@ DEPEND[""]=OpenSSLConfigVersion.cmake
 
 # This file sets the build directory up for pkg-config
 GENERATE[libcrypto.pc]=exporters/pkg-config/libcrypto.pc.in
-DEPEND[libcrypto.pc]=builddata.pm
+DEPEND[libcrypto.pc]=installdata.pm
 GENERATE[libssl.pc]=exporters/pkg-config/libssl.pc.in
-DEPEND[libssl.pc]=builddata.pm
+DEPEND[libssl.pc]=installdata.pm
 GENERATE[openssl.pc]=exporters/pkg-config/openssl.pc.in
-DEPEND[openssl.pc]=builddata.pm
+DEPEND[openssl.pc]=installdata.pm
 DEPEND[openssl.pc]=libcrypto.pc libssl.pc
 
 GENERATE[builddata.pm]=util/mkinstallvars.pl \


### PR DESCRIPTION
The former item contains a stripped down set of paths/directories which should be used when compiling/linking OpenSSL's libcrypto and libssl libraries.

This prevents build environment data from getting included in .pc files as noted in the related issue.

Closes:	#28803