### PR TITLE
quic: fix underflow when logging zero-length STREAM chunks

### DIFF
--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -2467,10 +2467,16 @@ static int txp_generate_stream_frames(OSSL_QUIC_TX_PACKETISER *txp,
             fc_new_hwm = shdr->offset + shdr->len;
 
         /* Log chunk to TXPIM. */
-        chunk.stream_id         = shdr->stream_id;
-        chunk.start             = shdr->offset;
-        chunk.end               = shdr->offset + shdr->len - 1;
-        chunk.has_fin           = shdr->is_fin;
+        chunk.stream_id = shdr->stream_id;
+        if (shdr->len > 0) {
+            chunk.start = shdr->offset;
+            chunk.end   = shdr->offset + shdr->len - 1;
+        } else {
+            /* No data carried in this frame. */
+            chunk.start = UINT64_MAX;
+            chunk.end   = 0;
+        }
+        chunk.has_fin = shdr->is_fin;
         chunk.has_stop_sending  = 0;
         chunk.has_reset_stream  = 0;
         if (!ossl_quic_txpim_pkt_append_chunk(tpkt, &chunk))


### PR DESCRIPTION
A FIN-only STREAM frame can be produced with len==0 (for example when the frame carries only FIN, or when data is clamped by flow control or segmentation). We logged such frames to TXPIM as [offset, offset + len - 1], which becomes negative.

Record zero-length STREAM frames using the existing sentinel used elsewhere: start = UINT64_MAX, end = 0. This avoids bogus ranges and keeps TXPIM accounting and loss recovery sane.

Small proof-of-concept of this happening:

1. In demos/guide, run `LD_LIBRARY_PATH=../.. ./quic-server-block 4443 server.crt server.key`
2. In demos/guide, run `LD_LIBRARY_PATH=../.. ../../apps/openssl s_client -quic  -connect 127.0.0.1:4443 -alpn http/1.0 -servername localhost -adv` and type `{fin}` and press enter.  With a small patch like the following, we can `chunk.end = -1`:
```
diff --git a/ssl/quic/quic_txp.c b/ssl/quic/quic_txp.c
index c93987e..34fdc79 100644
--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -2470,6 +2470,7 @@ static int txp_generate_stream_frames(OSSL_QUIC_TX_PACKETISER *txp,
         chunk.stream_id         = shdr->stream_id;
         chunk.start             = shdr->offset;
         chunk.end               = shdr->offset + shdr->len - 1;
+        printf("dbg: %d, %d, %d\n", shdr->offset, shdr->len, chunk.end);
         chunk.has_fin           = shdr->is_fin;
         chunk.has_stop_sending  = 0;
         chunk.has_reset_stream  = 0;
```