### PR TITLE
bio/connect: fix busy spin in nonblocking connect

### DIFF
--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -229,7 +229,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
 
         case BIO_CONN_S_BLOCKED_CONNECT:
             /* wait for socket being writable, before querying BIO_sock_error */
-            if (BIO_socket_wait(b->num, 0, time(NULL)) == 0)
+            if (BIO_socket_wait(b->num, 0, time(NULL) + 1) == 0)
                 break;
             i = BIO_sock_error(b->num);
             if (i != 0) {


### PR DESCRIPTION
BIO_socket_wait uses an absolute deadline. Passing time(NULL) causes an immediate timeout and a tight loop. Use time(NULL) + 1 to actually wait.