### PR TITLE
freebsd ktls: avoid unaligned 16 bit length store in ktls_read_record

### DIFF
--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -185,7 +185,8 @@ static ossl_inline int ktls_read_record(int fd, void *data, size_t length)
     p[0] = tgr->tls_type;
     p[1] = tgr->tls_vmajor;
     p[2] = tgr->tls_vminor;
-    *(uint16_t *)(p + 3) = htons(ret);
+    p[3] = (ret >> 8) & 0xff;
+    p[4] = ret & 0xff;
 
     return ret + prepend_length;
 }


### PR DESCRIPTION
This prevents SIGBUS on strict alignment architectures when p+3 is not aligned for 16 bit access. Behavior is unchanged on x86 and matches the Linux path.