### PR TITLE
Fix AEAD ciphers raise an error when EVP_DecryptFinal_ex() is called without the authentication tag being set.

### DIFF
--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.c.in
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.c.in
@@ -338,8 +338,10 @@ static int chacha20_poly1305_final(void *vctx, unsigned char *out, size_t *outl,
         return 0;
 
     /* The tag must be set before actually decrypting data */
-    if (!ctx->base.enc && ctx->tag_len == 0)
+    if (!ctx->base.enc && ctx->tag_len == 0) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_TAG_NOT_SET);
         return 0;
+    }
 
     if (hw->aead_cipher((PROV_CIPHER_CTX *)ctx, out, outl, NULL, 0) <= 0)
         return 0;

--- a/providers/implementations/ciphers/ciphercommon_ccm.c.in
+++ b/providers/implementations/ciphers/ciphercommon_ccm.c.in
@@ -442,8 +442,10 @@ static int ccm_cipher_internal(PROV_CCM_CTX *ctx, unsigned char *out,
             ctx->tag_set = 1;
         } else {
             /* The tag must be set before actually decrypting data */
-            if (!ctx->tag_set)
+            if (!ctx->tag_set) {
+                ERR_raise(ERR_LIB_PROV, PROV_R_TAG_NOT_SET);
                 goto err;
+            }
 
             if (!hw->auth_decrypt(ctx, in, out, len, ctx->buf, ctx->m))
                 goto err;

--- a/providers/implementations/ciphers/ciphercommon_gcm.c.in
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c.in
@@ -465,8 +465,10 @@ static int gcm_cipher_internal(PROV_GCM_CTX *ctx, unsigned char *out,
         }
     } else {
         /* The tag must be set before actually decrypting data */
-        if (!ctx->enc && ctx->taglen == UNINITIALISED_SIZET)
+        if (!ctx->enc && ctx->taglen == UNINITIALISED_SIZET) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_TAG_NOT_SET);
             goto err;
+        }
         if (!hw->cipherfinal(ctx, ctx->buf))
             goto err;
         ctx->iv_state = IV_STATE_FINISHED; /* Don't reuse the IV */


### PR DESCRIPTION
Fix AEAD ciphers raise an error when EVP_DecryptFinal_ex() is called without the authentication tag being set.

A trivial PR that ensures correct functionality, without aiming to refactor or move checks into the EVP layer. The original issue can remain open, but correct functionality doesn’t need to wait.    

Fixes #28730

