### PR TITLE
ssl: set tmp.pkey only after successful derive

### DIFF
--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -2005,11 +2005,12 @@ EXT_RETURN tls_construct_stoc_key_share(SSL_CONNECTION *s, WPACKET *pkt,
         /*
          * This causes the crypto state to be updated based on the derived keys
          */
-        s->s3.tmp.pkey = skey;
         if (ssl_derive(s, skey, ckey, 1) == 0) {
             /* SSLfatal() already called */
+            EVP_PKEY_free(skey);
             return EXT_RETURN_FAIL;
         }
+        s->s3.tmp.pkey = skey;
     } else {
         /* KEM mode */
         unsigned char *ct = NULL;


### PR DESCRIPTION
Assign s->s3.tmp.pkey after ssl_derive succeeds and free skey on failure to avoid a dangling state.