### PR TITLE
asn1_write_micalg: comma handling can drop a comma after suppressing duplicate "unknown"

### DIFF
--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -234,9 +234,7 @@ static int asn1_write_micalg(BIO *out, STACK_OF(X509_ALGOR) *mdalgs)
             break;
 
         default:
-            if (have_unknown) {
-                write_comma = 0;
-            } else {
+            if (!have_unknown) {
                 if (BIO_puts(out, "unknown") < 0)
                     goto err;
                 have_unknown = 1;


### PR DESCRIPTION
If there are multiple unknown digest OIDs, the code sets write_comma = 0 on later unknowns. That can remove the comma before the next printed algorithm, producing output like sha1,unknownsha-256.