### PR TITLE
asn_mime: guard empty inputs and fix S/MIME message type detection

### DIFF
--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -333,7 +333,7 @@ int SMIME_write_ASN1_ex(BIO *bio, ASN1_VALUE *val, BIO *data, int flags,
     } else if (ctype_nid == NID_pkcs7_signed) {
         if (econt_nid == NID_id_smime_ct_receipt)
             msg_type = "signed-receipt";
-        else if (sk_X509_ALGOR_num(mdalgs) >= 0)
+        else if (mdalgs != NULL && sk_X509_ALGOR_num(mdalgs) > 0)
             msg_type = "signed-data";
         else
             msg_type = "certs-only";


### PR DESCRIPTION
This hardens crypto/asn1/asn_mime.c in four places to avoid edge-case crashes and mislabeling.

Changes:

- strip_end: return NULL for empty strings so the backward scan does not underflow. 

- strip_eol: handle len <= 0 up front to avoid reading linebuf[-1]. 

- multi_split: do not push a NULL BIO when a MIME section is empty. Allocate only when needed and push only a valid BIO. 

- SMIME_write_ASN1_ex: only mark as signed-data when mdalgs exists and has items; otherwise prefer certs-only. Prevents calling sk_X509_ALGOR_num on a NULL stack and avoids misclassifying an empty digest list.