### PR TITLE
Add zero signlen check to prevent assertion crash in openssl

### DIFF
--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2823,8 +2823,10 @@ CON_FUNC_RETURN tls_construct_server_key_exchange(SSL_CONNECTION *s,
         }
 
         if (EVP_DigestSign(md_ctx, NULL, &siglen, tbs, tbslen) <=0
+                || siglen == 0
                 || !WPACKET_sub_reserve_bytes_u16(pkt, siglen, &sigbytes1)
                 || EVP_DigestSign(md_ctx, sigbytes1, &siglen, tbs, tbslen) <= 0
+                || siglen == 0
                 || !WPACKET_sub_allocate_bytes_u16(pkt, siglen, &sigbytes2)
                 || sigbytes1 != sigbytes2) {
             OPENSSL_free(tbs);


### PR DESCRIPTION


- WPACKET_sub_allocate_bytes_u16 function calls  WPACKET_allocate_bytes > WPACKET_reserve_bytes which has assert on the length.
- If len is passed as zero then assert hits and openssl crashes.
- Add safety check of zero length before calling WPACKET_sub_allocate_bytes_u16
- This way openssl crash will be prevented.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
