### PR TITLE
Fix leak in `SSL_set_tlsext_status_ocsp_resp`

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3715,6 +3715,9 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
             resp = d2i_OCSP_RESPONSE(NULL, (const unsigned char **)&p, larg);
             if (resp != NULL)
                 sk_OCSP_RESPONSE_push(sc->ext.ocsp.resp_ex, resp);
+
+            sc->ext.ocsp.resp = parg;
+            sc->ext.ocsp.resp_len = larg;
         }
 #endif
         break;

--- a/test/helpers/handshake.c
+++ b/test/helpers/handshake.c
@@ -285,8 +285,6 @@ static int server_ocsp_cb(SSL *s, void *arg)
         return SSL_TLSEXT_ERR_ALERT_FATAL;
     }
 
-    OPENSSL_free(respder);
-
     return SSL_TLSEXT_ERR_OK;
 }
 

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1950,7 +1950,6 @@ static int ocsp_server_cb_single(SSL *s, void *arg)
         OPENSSL_free(ocsp_resp_der);
         return SSL_TLSEXT_ERR_ALERT_FATAL;
     }
-    OPENSSL_free(ocsp_resp_der);
 
     ocsp_server_called = 1;
     return SSL_TLSEXT_ERR_OK;


### PR DESCRIPTION
The changes introduced in b1b4b15 cause the `resp` parameter to no longer be assigned to the `SSL` object.
Since it is not freed either, and the caller used to expect that, the memory is now leaked.
This commit frees `resp` right away. There is an early error return when `sk_OCSP_RESPONSE_new_reserve` fails where the memory is not freed.
I'm not sure whether it makes sense to free the memory in that case, as the documentation does not mention anything.

Fixes #28888

CLA: trivial

##### Checklist
