### PR TITLE
`http_client.c`: make sure to raise error 404

### DIFF
--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -36,6 +36,7 @@
 #define HTTP_STATUS_CODE_MOVED_PERMANENTLY 301
 #define HTTP_STATUS_CODE_FOUND             302
 #define HTTP_STATUS_CODES_NONFATAL_ERROR   400
+#define HTTP_STATUS_CODE_NOT_FOUND         404
 
 /* Stateful HTTP request code, supporting blocking and non-blocking I/O */
 
@@ -488,11 +489,12 @@ static int parse_http_line1(char *line, int *found_keep_alive)
     case HTTP_STATUS_CODE_FOUND:
         return retcode;
     default:
-        if (retcode < HTTP_STATUS_CODES_NONFATAL_ERROR) {
+        if (retcode == HTTP_STATUS_CODE_NOT_FOUND
+            || retcode < HTTP_STATUS_CODES_NONFATAL_ERROR) {
             ERR_raise_data(ERR_LIB_HTTP, HTTP_R_STATUS_CODE_UNSUPPORTED, "code=%s", code);
             if (*reason != '\0')
                 ERR_add_error_data(2, ", reason=", reason);
-        } /* must return content normally if status >= 400 */
+        } /* must return content normally if status >= 400, still tentatively raised error on 404 */
         return retcode;
     }
 


### PR DESCRIPTION
In particular, this should be done also in case of further errors like content type mismatch,
which may be misleading if raised without the status code 404 being reported as well.

I consider this on the border between an enhancement and minor fix. 

Including it, the error output becomes, e.g.:
```
parse_http_line1:crypto/http/http_client.c:494:CMP error: status code unsupported:code=404, reason=Not Found
OSSL_HTTP_REQ_CTX_nbio:crypto/http/http_client.c:877:CMP error: missing content type:expected=application/pkixcmp
```
while without it, only the missing content type is reported, which for the given case is just a consequence of the 404 status ("not found").
