### PR TITLE
ci.yml: Update macos runners as macos-13 is discontinued

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-14, macos-14-large]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -350,7 +350,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-15, macos-15-large]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This is to be applied to all branches except for master where we already have it.
Please see #28737 for reasoning.