### PR TITLE
clang deprecates sprintf on macos

### DIFF
--- a/demos/http3/ossl-nghttp3-demo-server.c
+++ b/demos/http3/ossl-nghttp3-demo-server.c
@@ -1166,17 +1166,17 @@ static int run_quic_server(SSL_CTX *ctx, int fd)
             /* We don't find the file: use default test string */
             h3ssl.ptr_data = nulldata;
             h3ssl.ldata = nulldata_sz;
-            sprintf(slength, "%zu", h3ssl.ldata);
+            snprintf(slength, sizeof(slength), "%zu", h3ssl.ldata);
             /* content-type: text/html */
             make_nv(&resp[num_nv++], "content-type", "text/html");
         } else if (h3ssl.ldata == INT_MAX) {
             /* endless file for tests */
-            sprintf(slength, "%zu", h3ssl.ldata);
+            snprintf(slength, sizeof(slength), "%zu", h3ssl.ldata);
             h3ssl.ptr_data = (uint8_t *) malloc(4096);
             memset(h3ssl.ptr_data, 'A', 4096);
         } else {
             /* normal file we have opened */
-            sprintf(slength, "%zu", h3ssl.ldata);
+            snprintf(slength, sizeof(slength), "%zu", h3ssl.ldata);
             h3ssl.ptr_data = (uint8_t *) get_file_data(&h3ssl);
             if (h3ssl.ptr_data == NULL)
                 abort();

--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -1373,7 +1373,7 @@ static void test_obj_create_worker(void)
 
     for (i = 0; i < 4; i++) {
         now = time(NULL);
-        sprintf(name, "Time in Seconds = %ld", (long) now);
+        snprintf(name, sizeof(name), "Time in Seconds = %ld", (long) now);
         while (now == time(NULL))
             /* no-op */;
         nid = OBJ_create(NULL, NULL, name);


### PR DESCRIPTION
test/threadstest.c:1376:9: error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.
 1376 |         sprintf(name, "Time in Seconds = %ld", (long) now);

Fixes: 5909d0d3fc9b ("Add a test for multi-threaded OBJ_create")