### PR TITLE
crypto/bio/bss_acpt: reset accept_sock and b->num after close in ACPT…

### DIFF
--- a/crypto/bio/bss_acpt.c
+++ b/crypto/bio/bss_acpt.c
@@ -248,6 +248,8 @@ static int acpt_state(BIO *b, BIO_ACCEPT *c)
                                 BIO_ADDRINFO_address(c->addr_iter),
                                 c->bind_mode)) {
                     BIO_closesocket(c->accept_sock);
+                    c->accept_sock = (int)INVALID_SOCKET;
+                    b->num = (int)INVALID_SOCKET;
                     goto exit_loop;
                 }
             }
@@ -259,6 +261,8 @@ static int acpt_state(BIO *b, BIO_ACCEPT *c)
                 if (!BIO_sock_info(c->accept_sock, BIO_SOCK_INFO_ADDRESS,
                                    &info)) {
                     BIO_closesocket(c->accept_sock);
+                    c->accept_sock = (int)INVALID_SOCKET;
+                    b->num = (int)INVALID_SOCKET;
                     goto exit_loop;
                 }
             }


### PR DESCRIPTION
…_S_LISTEN failures

On BIO_listen or BIO_sock_info failure we close the socket but leave accept_sock and b->num pointing at the old fd. Later cleanup can double close.

Set both to INVALID_SOCKET immediately after BIO_closesocket.