### PR TITLE
NonStop: reset hpns_connect_attempt at call start and on success

### DIFF
--- a/crypto/rand/rand_egd.c
+++ b/crypto/rand/rand_egd.c
@@ -101,8 +101,6 @@ int hpns_socket(int family,
 
 /*#define socket(a,b,c,...) hpns_socket(a,b,c,__VA_ARGS__) */
 
-static int hpns_connect_attempt = 0;
-
 # endif /* defined(OPENSSL_SYS_HPNS) */
 
 
@@ -114,7 +112,7 @@ int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes)
     unsigned char tempbuf[255];
 
 #if defined(OPENSSL_SYS_TANDEM)
-    hpns_connect_attempt = 0;
+    int hpns_connect_attempt = 0;
 #endif
 
     if (bytes > (int)sizeof(tempbuf))
@@ -138,12 +136,8 @@ int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes)
 
     /* Try to connect */
     for (;;) {
-        if (connect(fd, (struct sockaddr *)&addr, i) == 0) {
-#if defined(OPENSSL_SYS_TANDEM)
-            hpns_connect_attempt = 0;
-#endif
+        if (connect(fd, (struct sockaddr *)&addr, i) == 0)
             break;
-        }
 # ifdef EISCONN
         if (errno == EISCONN)
             break;


### PR DESCRIPTION
Ensure the NonStop fallback state does not leak across calls by clearing hpns_connect_attempt at the beginning of RAND_query_egd_bytes and after a successful connect. No impact on other platforms.