### PR TITLE
dtls: fix DTLSv1_listen msg_callback to report HelloVerifyRequest

### DIFF
--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -736,10 +736,17 @@ int DTLSv1_listen(SSL *ssl, BIO_ADDR *client)
                    &wbuf[DTLS1_RT_HEADER_LENGTH + DTLS1_HM_HEADER_LENGTH - 3],
                    3);
 
-            if (s->msg_callback)
-                s->msg_callback(1, version, SSL3_RT_HEADER, wbuf,
-                                DTLS1_RT_HEADER_LENGTH, ssl,
-                                s->msg_callback_arg);
+            if (s->msg_callback) {
+                /* Report the outgoing DTLS record header */
+                s->msg_callback(1, (int)version, SSL3_RT_HEADER,
+                                wbuf, DTLS1_RT_HEADER_LENGTH,
+                                ssl, s->msg_callback_arg);
+                /* Report the HelloVerifyRequest handshake message */
+                s->msg_callback(1, (int)version, SSL3_RT_HANDSHAKE,
+                                wbuf + DTLS1_RT_HEADER_LENGTH,
+                                wreclen - DTLS1_RT_HEADER_LENGTH,
+                                ssl, s->msg_callback_arg);
+            }
 
             if ((tmpclient = BIO_ADDR_new()) == NULL) {
                 ERR_raise(ERR_LIB_SSL, ERR_R_BIO_LIB);


### PR DESCRIPTION
DTLSv1_listen built the HelloVerifyRequest in wbuf but invoked msg_callback with buf and DTLS1_RT_HEADER_LENGTH, and version 0. That caused incorrect logging and could disclose the ClientHello to write callbacks. Use wbuf and the actual record version for the record header, and add a second callback that reports the handshake message bytes. No change to on-wire behavior.