### PR TITLE
apps/s_socket: fix FD and addrinfo leak on SCTP failure in init_client

### DIFF
--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -156,7 +156,7 @@ int init_client(int *sock, const char *host, const char *port,
             if (tmpbio == NULL) {
                 BIO_closesocket(*sock);
                 *sock = INVALID_SOCKET;
-                continue;
+                goto out;
             }
             BIO_free(tmpbio);
         }


### PR DESCRIPTION
If BIO_new_dgram_sctp(*sock, BIO_NOCLOSE) fails we returned 0 directly, skipping the out: cleanup and leaking the just created socket plus the addrinfo lists. Close the socket, reset *sock, and continue to the next address so normal cleanup runs.