### PR TITLE
quic/quic_demux: Mirror int overflow check from demux_alloc_urxe into…

### DIFF
--- a/ssl/quic/quic_demux.c
+++ b/ssl/quic/quic_demux.c
@@ -181,6 +181,9 @@ static QUIC_URXE *demux_resize_urxe(QUIC_DEMUX *demux, QUIC_URXE *e,
     prev = ossl_list_urxe_prev(e);
     ossl_list_urxe_remove(&demux->urx_free, e);
 
+    if (new_alloc_len >= SIZE_MAX - sizeof(QUIC_URXE))
+        return NULL;
+
     e2 = OPENSSL_realloc(e, sizeof(QUIC_URXE) + new_alloc_len);
     if (e2 == NULL) {
         /* Failed to resize, abort. */


### PR DESCRIPTION
… demux_resize_urxe

Simple hardening. In practice new_alloc_len usually comes from demux->mtu or test injection length, but adding the same check here quiets analyzers.