### PR TITLE
doc: clarify TLS, DTLS, and QUIC protocol description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Welcome to the OpenSSL Project
 OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit
 for the Transport Layer Security (TLS, formerly SSL), Datagram TLS (DTLS), and QUIC protocols.
 
-
 The protocol implementations are based on a full-strength general purpose
 cryptographic library, which can also be used stand-alone. Also included is a
 cryptographic module validated to conform with FIPS standards.


### PR DESCRIPTION
This pull request improves the clarity of the README’s introductory description by expanding the acronyms and naming the supported protocols explicitly.

Changed:
- “for the TLS (formerly SSL), DTLS and QUIC protocols.”
to
- “for the Transport Layer Security (TLS, formerly SSL), Datagram TLS (DTLS), and QUIC protocols.”

This change improves readability for new contributors and users.
No functional or code changes.

Signed-off-by: Jack Barsa <jcb5272@rit.edu>
