### PR TITLE
SSL BIO: allow disabling auto renegotiation thresholds

### DIFF
--- a/doc/man3/BIO_f_ssl.pod
+++ b/doc/man3/BIO_f_ssl.pod
@@ -66,11 +66,12 @@ is 1 client mode is set. If B<client> is 0 server mode is set.
 BIO_set_ssl_renegotiate_bytes() sets the renegotiate byte count of SSL BIO B<b>
 to B<num>. When set after every B<num> bytes of I/O (read and write)
 the SSL session is automatically renegotiated. B<num> must be at
-least 512 bytes.
+least 512 bytes. Setting B<num> to 0 disables byte-based renegotiation.
 
 BIO_set_ssl_renegotiate_timeout() sets the renegotiate timeout of SSL BIO B<b>
 to B<seconds>.
 When the renegotiate timeout elapses the session is automatically renegotiated.
+B<seconds> must be at least 5. Setting B<seconds> to 0 disables timeout-based renegotiation.
 
 BIO_get_num_renegotiates() returns the total number of session
 renegotiations due to I/O or timeout of SSL BIO B<b>.

--- a/ssl/bio_ssl.c
+++ b/ssl/bio_ssl.c
@@ -274,15 +274,24 @@ static long ssl_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     case BIO_C_SET_SSL_RENEGOTIATE_TIMEOUT:
         ret = bs->renegotiate_timeout;
-        if (num < 60)
-            num = 5;
-        bs->renegotiate_timeout = (unsigned long)num;
+        if (num == 0) {
+            bs->renegotiate_timeout = 0;  /* Disable timeout-based renegotiation */
+        } else if (num < 60) {
+            bs->renegotiate_timeout = 5;  /* Apply minimum timeout of 5 seconds */
+        } else {
+            bs->renegotiate_timeout = (unsigned long)num;
+        }
         bs->last_time = (unsigned long)time(NULL);
         break;
     case BIO_C_SET_SSL_RENEGOTIATE_BYTES:
         ret = bs->renegotiate_count;
-        if ((long)num >= 512)
+        if (num == 0) {
+            bs->renegotiate_count = 0;  /* Disable byte-based renegotiation */
+        } else if (num < 512) {
+            bs->renegotiate_count = 512;  /* Apply minimum byte count of 512 */
+        } else {
             bs->renegotiate_count = (unsigned long)num;
+        }
         break;
     case BIO_C_GET_SSL_NUM_RENEGOTIATES:
         ret = bs->num_renegotiates;


### PR DESCRIPTION
- Allow BIO_C_SET_SSL_RENEGOTIATE_TIMEOUT with value 0 to disable timeout-based renegotiation
- Allow BIO_C_SET_SSL_RENEGOTIATE_BYTES with value 0 to disable byte-based renegotiation
- Apply minimum thresholds (5 seconds, 512 bytes) only to non-zero values
- Update documentation to clarify the behavior and minimum requirements

Fixes #28833

- [x] documentation is added or updated
