### PR TITLE
Add interop CI testing with openssh

### DIFF
--- a/.github/workflows/interop-tests.yml
+++ b/.github/workflows/interop-tests.yml
@@ -3,7 +3,7 @@
 # filesystem for this job can be reached.  Please note that any changes made to
 # this job involving file system paths should be made prefixed with, or relative
 # to that directory
-name: Interoperability tests with GnuTLS and NSS
+name: Interoperability tests with GnuTLS, NSS and OpenSSH
 on:
   schedule:
     - cron: '55 02 * * *'
@@ -75,10 +75,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        persist-credentials: false
         ref: ${{ matrix.branch.openssl }}
         fetch-depth: 1
     - name: config
-      run: ./config --banner=Configured -fPIC --prefix=/opt/openssl no-docs no-threads shared -Wl,-rpath,/opt/openssl/lib64 && perl configdata.pm --dump
+      run: ./config --banner=Configured -fPIC --prefix=/opt/openssl no-docs shared -Wl,-rpath,/opt/openssl/lib64 && perl configdata.pm --dump
     - name: make
       run: |
         make -s -j4


### PR DESCRIPTION
Testing OpenSSH with their scripts for running tests on
all active openssl branches.

Resolves: https://github.com/openssl/project/issues/1632

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
