### PR TITLE
x509_store: fix unreliable value of objs inside the second locked section

### DIFF
--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -868,6 +868,8 @@ STACK_OF(X509) *X509_STORE_CTX_get1_certs(X509_STORE_CTX *ctx,
             objs = ossl_x509_store_ht_get_by_name(store, nm);
             if (objs == NULL)
                 goto end;
+        } else {
+            objs = store->objs;
         }
         idx = x509_object_idx_cnt(objs, X509_LU_X509, nm, &cnt);
     }


### PR DESCRIPTION
objs has been incorrectly passed from one critical section to another one.

Resolves: https://scan5.scan.coverity.com/#/project-view/65138/10222?selectedIssue=1667132
Fixes: 04589b59ef50 ("x509store: reduce lock contention in X509_STORE")

