### PR TITLE
x509-store: reduce number of pre-allocated hashtable buckets

### DIFF
--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -17,7 +17,7 @@
 #include <openssl/x509v3.h>
 #include "x509_local.h"
 
-#define X509_OBJS_HT_BUCKETS 512
+#define X509_OBJS_HT_BUCKETS 8
 
 X509_LOOKUP *X509_LOOKUP_new(X509_LOOKUP_METHOD *method)
 {


### PR DESCRIPTION
pre-allocating too much hashtable objects to avoid the hashtable regrowing is a mistake, and had immediate impact on memory footprint.

Resolves: https://github.com/openssl/project/issues/1679
Link: https://openssl-library.org/performance/
Fixes: 04589b59ef50 ("x509store: reduce lock contention in X509_STORE")
