### PR TITLE
SLH_DSA performance - Try doing precaching using the EVP_ interface.

### DIFF
--- a/crypto/slh_dsa/slh_dsa_key.c
+++ b/crypto/slh_dsa/slh_dsa_key.c
@@ -23,12 +23,12 @@ static int slh_dsa_compute_pk_root(SLH_DSA_HASH_CTX *ctx, SLH_DSA_KEY *out, int 
 static void slh_dsa_key_hash_cleanup(SLH_DSA_KEY *key)
 {
     OPENSSL_free(key->propq);
-    if (key->md_big != key->md)
-        EVP_MD_free(key->md_big);
-    key->md_big = NULL;
-    EVP_MD_free(key->md);
+
+    EVP_MD_free(key->md_sha);
+    EVP_MD_free(key->md_sha512);
     EVP_MAC_free(key->hmac);
-    key->md = NULL;
+    key->md_sha = key->md_sha512 = NULL;
+    key->hmac = NULL;
 }
 
 static int slh_dsa_key_hash_init(SLH_DSA_KEY *key)
@@ -37,21 +37,18 @@ static int slh_dsa_key_hash_init(SLH_DSA_KEY *key)
     int security_category = key->params->security_category;
     const char *digest_alg = is_shake ? "SHAKE-256" : "SHA2-256";
 
-    key->md = EVP_MD_fetch(key->libctx, digest_alg, key->propq);
-    if (key->md == NULL)
+    key->md_sha = EVP_MD_fetch(key->libctx, digest_alg, key->propq);
+    if (key->md_sha == NULL)
         return 0;
     /*
      * SHA2 algorithm(s) require SHA256 + HMAC_SHA(X) & MGF1(SHAX)
      * SHAKE algorithm(s) use SHAKE for all functions.
      */
     if (is_shake == 0) {
-        if (security_category == 1) {
-            /* For category 1 SHA2-256 is used for all hash operations */
-            key->md_big = key->md;
-        } else {
+        if (security_category != 1) {
             /* Security categories 3 & 5 also need SHA-512 */
-            key->md_big = EVP_MD_fetch(key->libctx, "SHA2-512", key->propq);
-            if (key->md_big == NULL)
+            key->md_sha512 = EVP_MD_fetch(key->libctx, "SHA2-512", key->propq);
+            if (key->md_sha512 == NULL)
                 goto err;
         }
         key->hmac = EVP_MAC_fetch(key->libctx, "HMAC", key->propq);
@@ -59,7 +56,7 @@ static int slh_dsa_key_hash_init(SLH_DSA_KEY *key)
             goto err;
     }
     key->adrs_func = ossl_slh_get_adrs_fn(is_shake == 0);
-    key->hash_func = ossl_slh_get_hash_fn(is_shake);
+    key->hash_func = ossl_slh_get_hash_fn(is_shake, security_category);
     return 1;
  err:
     slh_dsa_key_hash_cleanup(key);
@@ -68,10 +65,10 @@ static int slh_dsa_key_hash_init(SLH_DSA_KEY *key)
 
 static void slh_dsa_key_hash_dup(SLH_DSA_KEY *dst, const SLH_DSA_KEY *src)
 {
-    if (src->md_big != NULL && src->md_big != src->md)
-        EVP_MD_up_ref(src->md_big);
-    if (src->md != NULL)
-        EVP_MD_up_ref(src->md);
+    if (src->md_sha)
+        EVP_MD_up_ref(src->md_sha);
+    if (src->md_sha512 != NULL)
+        EVP_MD_up_ref(src->md_sha512);
     if (src->hmac != NULL)
         EVP_MAC_up_ref(src->hmac);
 }
@@ -381,7 +378,8 @@ int ossl_slh_dsa_generate_key(SLH_DSA_HASH_CTX *ctx, SLH_DSA_KEY *out,
                 || RAND_bytes_ex(lib_ctx, pub, pk_seed_len, 0) <= 0)
             goto err;
     }
-    if (!slh_dsa_compute_pk_root(ctx, out, 0))
+    if (!ossl_slh_dsa_hash_ctx_prehash_pk_seed(ctx, pub, pk_seed_len)
+            || !slh_dsa_compute_pk_root(ctx, out, 0))
         goto err;
     out->pub = pub;
     out->has_priv = 1;

--- a/crypto/slh_dsa/slh_dsa_key.h
+++ b/crypto/slh_dsa/slh_dsa_key.h
@@ -44,7 +44,7 @@ struct slh_dsa_key_st {
     const SLH_HASH_FUNC *hash_func;
     /* See FIPS 205 Section 11.1 */
 
-    EVP_MD *md; /* Used for SHAKE and SHA-256 */
-    EVP_MD *md_big; /* Used for SHA-256 or SHA-512 */
+    EVP_MD *md_sha;    /* Used for SHAKE and SHA-256 */
+    EVP_MD *md_sha512; /* Used for SHA-512 */
     EVP_MAC *hmac;
 };

--- a/crypto/slh_dsa/slh_dsa_local.h
+++ b/crypto/slh_dsa/slh_dsa_local.h
@@ -47,8 +47,9 @@
  */
 struct slh_dsa_hash_ctx_st {
     const SLH_DSA_KEY *key; /* This key is not owned by this object */
-    EVP_MD_CTX *md_ctx;     /* Either SHAKE OR SHA-256 */
-    EVP_MD_CTX *md_big_ctx; /* Either SHA-512 or points to |md_ctx| for SHA-256*/
+    EVP_MD_CTX *sha_ctx;    /* Either SHAKE OR SHA-256 */
+    EVP_MD_CTX *sha_ctx_pkseed; /* A SHAKE or SHA256 related ctx with PK.seed hashed in it */
+    EVP_MD_CTX *sha512_ctx; /* SHA-512 or NULL */
     EVP_MAC_CTX *hmac_ctx;  /* required by SHA algorithms for PRFmsg() */
     int hmac_digest_used;   /* Used for lazy init of hmac_ctx digest */
 };

--- a/crypto/slh_dsa/slh_hash.h
+++ b/crypto/slh_dsa/slh_hash.h
@@ -20,47 +20,38 @@
 
 # define SLH_HASH_FN_DECLARE(hashf, t) OSSL_SLH_HASHFUNC_##t * t = hashf->t
 
+typedef int (OSSL_SLH_HASHFUNC_HASH)(SLH_DSA_HASH_CTX *ctx,
+                                     const uint8_t *pk_seed,
+                                     const uint8_t *adrs,
+                                     const uint8_t *in, size_t inlen,
+                                     uint8_t *out, size_t out_len);
+
 /*
  * @params out is |m| bytes which ranges from (30..49) bytes
  */
 typedef int (OSSL_SLH_HASHFUNC_H_MSG)(SLH_DSA_HASH_CTX *ctx, const uint8_t *r,
-                                      const uint8_t *pk_seed, const uint8_t *pk_root,
+                                      const uint8_t *pk_seed_and_root,
                                       const uint8_t *msg, size_t msg_len,
                                       uint8_t *out, size_t out_len);
-
-typedef int (OSSL_SLH_HASHFUNC_PRF)(SLH_DSA_HASH_CTX *ctx, const uint8_t *pk_seed,
-                                    const uint8_t *sk_seed, const uint8_t *adrs,
-                                    uint8_t *out, size_t out_len);
 
 typedef int (OSSL_SLH_HASHFUNC_PRF_MSG)(SLH_DSA_HASH_CTX *ctx, const uint8_t *sk_prf,
                                         const uint8_t *opt_rand,
                                         const uint8_t *msg, size_t msg_len,
                                         WPACKET *pkt);
 
-typedef int (OSSL_SLH_HASHFUNC_F)(SLH_DSA_HASH_CTX *ctx, const uint8_t *pk_seed,
-                                  const uint8_t *adrs,
-                                  const uint8_t *m1, size_t m1_len,
-                                  uint8_t *out, size_t out_len);
-
-typedef int (OSSL_SLH_HASHFUNC_H)(SLH_DSA_HASH_CTX *ctx, const uint8_t *pk_seed,
-                                  const uint8_t *adrs,
-                                  const uint8_t *m1, const uint8_t *m2,
-                                  uint8_t *out, size_t out_len);
-
-typedef int (OSSL_SLH_HASHFUNC_T)(SLH_DSA_HASH_CTX *ctx, const uint8_t *pk_seed,
-                                  const uint8_t *adrs,
-                                  const uint8_t *m1, size_t m1_len,
-                                  uint8_t *out, size_t out_len);
+typedef int (OSSL_SLH_HASHFUNC_prehash_pk_seed)(SLH_DSA_HASH_CTX *hctx,
+                                                const uint8_t *pk_seed, size_t n);
 
 typedef struct slh_hash_func_st {
+    OSSL_SLH_HASHFUNC_prehash_pk_seed *prehash_pk_seed;
+    OSSL_SLH_HASHFUNC_HASH *PRF;
+    OSSL_SLH_HASHFUNC_HASH *F;
+    OSSL_SLH_HASHFUNC_HASH *T;
+    OSSL_SLH_HASHFUNC_HASH *H;
     OSSL_SLH_HASHFUNC_H_MSG *H_MSG;
-    OSSL_SLH_HASHFUNC_PRF *PRF;
     OSSL_SLH_HASHFUNC_PRF_MSG *PRF_MSG;
-    OSSL_SLH_HASHFUNC_F *F;
-    OSSL_SLH_HASHFUNC_H *H;
-    OSSL_SLH_HASHFUNC_T *T;
 } SLH_HASH_FUNC;
 
-const SLH_HASH_FUNC *ossl_slh_get_hash_fn(int is_shake);
+const SLH_HASH_FUNC *ossl_slh_get_hash_fn(int is_shake, int security_category);
 
 #endif

--- a/crypto/slh_dsa/slh_hypertree.c
+++ b/crypto/slh_dsa/slh_hypertree.c
@@ -81,7 +81,7 @@ int ossl_slh_ht_sign(SLH_DSA_HASH_CTX *ctx,
                                  WPACKET_get_curr(sig_wpkt) - psig))
                 return 0;
             if (!ossl_slh_xmss_pk_from_sig(ctx, leaf_id, xmss_sig_rpkt, root,
-                                           pk_seed, adrs, root, sizeof(root)))
+                                           pk_seed, adrs, root, n))
                 return 0;
             leaf_id = tree_id & mask;
             tree_id >>= hm;
@@ -126,7 +126,7 @@ int ossl_slh_ht_verify(SLH_DSA_HASH_CTX *ctx, const uint8_t *msg, PACKET *sig_pk
         adrsf->set_layer_address(adrs, layer);
         adrsf->set_tree_address(adrs, tree_id);
         if (!ossl_slh_xmss_pk_from_sig(ctx, leaf_id, sig_pkt, node,
-                                       pk_seed, adrs, node, sizeof(node)))
+                                       pk_seed, adrs, node, n))
             return 0;
         leaf_id = tree_id & mask;
         tree_id >>= tree_height;

--- a/include/crypto/slh_dsa.h
+++ b/include/crypto/slh_dsa.h
@@ -57,6 +57,8 @@ __owur int ossl_slh_dsa_key_type_matches(const SLH_DSA_KEY *key, const char *alg
 __owur SLH_DSA_HASH_CTX *ossl_slh_dsa_hash_ctx_new(const SLH_DSA_KEY *key);
 void ossl_slh_dsa_hash_ctx_free(SLH_DSA_HASH_CTX *ctx);
 __owur SLH_DSA_HASH_CTX *ossl_slh_dsa_hash_ctx_dup(const SLH_DSA_HASH_CTX *src);
+__owur int ossl_slh_dsa_hash_ctx_prehash_pk_seed(SLH_DSA_HASH_CTX *ctx,
+                                                 const uint8_t *pkseed, size_t n);
 
 __owur int ossl_slh_dsa_sign(SLH_DSA_HASH_CTX *slh_ctx,
                              const uint8_t *msg, size_t msg_len,


### PR DESCRIPTION
This has been done to compare the result with using the low level API.
Callgrind results have been added to https://github.com/openssl/openssl/pull/28941