### PR TITLE
scrypt: fix no-scrypt build

### DIFF
--- a/providers/implementations/kdfs/scrypt.c
+++ b/providers/implementations/kdfs/scrypt.c
@@ -22,9 +22,10 @@
 #include "prov/provider_ctx.h"
 #include "prov/providercommon.h"
 #include "prov/provider_util.h"
-#include "providers/implementations/kdfs/scrypt.inc"
 
 #ifndef OPENSSL_NO_SCRYPT
+
+# include "providers/implementations/kdfs/scrypt.inc"
 
 static OSSL_FUNC_kdf_newctx_fn kdf_scrypt_new;
 static OSSL_FUNC_kdf_dupctx_fn kdf_scrypt_dup;


### PR DESCRIPTION
In file included from providers/implementations/kdfs/scrypt.c:25: ./providers/implementations/kdfs/scrypt.inc:39:12: error: unused function 'scrypt_set_ctx_params_decoder' ./providers/implementations/kdfs/scrypt.inc:153:12: error: unused function 'scrypt_get_ctx_params_decoder'

Fixes CI: https://github.com/openssl/openssl/actions/runs/18703914875/job/53338064734
