### PR TITLE
kdf: Fix PVK KDF provider build.info typo

### DIFF
--- a/providers/implementations/kdfs/build.info
+++ b/providers/implementations/kdfs/build.info
@@ -28,7 +28,7 @@ SOURCE[$PBKDF1_GOAL]=pbkdf1.c
 
 SOURCE[$PBKDF2_GOAL]=pbkdf2.c
 
-SOURCE[$PBKDF1_GOAL]=pvkkdf.c
+SOURCE[$PVKKDF_GOAL]=pvkkdf.c
 
 SOURCE[$PKCS12KDF_GOAL]=pkcs12kdf.c
 


### PR DESCRIPTION
Fix the pvkkdf.c build when using PVKKDF1_GOAL
