### PR TITLE
Add several new configuration options to the SSL_CONF API

### DIFF
--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -376,6 +376,11 @@ These options indicate a file or directory used for building certificate
 chains or verifying certificate chains. These options are only supported
 if certificate operations are permitted.
 
+=item B<AddCAFile>, B<AddCAPath>
+
+These options indicate a file or directory containing trusted certificate
+authorities for validation.
+
 =item B<RequestCAFile>
 
 This option indicates a file containing a set of certificates in PEM form.
@@ -545,7 +550,7 @@ sure to also leave TLS 1.1 enabled.
 =item B<Options>
 
 The B<value> argument is a comma separated list of various flags to set.
-If a flag string is preceded B<-> it is disabled.
+If a flag string is preceded by B<-> that flag is disabled.
 See the L<SSL_CTX_set_options(3)> function for more details of
 individual options.
 
@@ -689,6 +694,139 @@ to request a certificate post-handshake. Servers only. TLSv1.3 only.
 A file or directory of certificates in PEM format whose names are used as the
 set of acceptable names for client CAs. Servers only. This option is only
 supported if certificate operations are permitted.
+
+=item B<SetCertificateFlags>
+
+The B<value> argument is a comma separated list of certificate validation
+flags to set.  If a flag string is preceded by B<-> that flag is disabled.
+See the L<X509_VERIFY_PARAM_set_flags(3)> function for more details of
+individual options.
+
+All supported flags are listed below.
+
+B<UseCheckTime> Equivalent to B<X509_V_FLAG_USE_CHECK_TIME>.
+
+B<CRLCheck> enables CRL checking for the leaf certificate.  Equivalent
+to B<X509_V_FLAG_CRL_CHECK>.
+
+B<CRLCheckAll> enables CRL checking for the entire certificate chain.
+Equivalent to B<X509_V_FLAG_CRL_CHECK_ALL>.
+
+B<IgnoreCritical> disables critical extension checking.  Equivalent to
+B<X509_V_FLAG_IGNORE_CRITICAL>.
+
+B<Strict> disables workarounds for some broken certificates, and
+strictly applies X509 rules.  Equivalent to B<X509_V_FLAG_X509_STRICT>.
+
+B<AllowProxyCerts> enables proxy certificate verification.  Equivalent
+to B<X509_V_FLAG_ALLOW_PROXY_CERTS>.
+
+B<PolicyCheck> enables certificate policy checking.  Equivalent to
+B<X509_V_FLAG_POLICY_CHECK>.
+
+B<ExplicitPolicy> sets the require explicit policy flag as defined
+in RFC3280.  Equivalent to B<X509_V_FLAG_EXPLICIT_POLICY>.
+
+B<InhibitAnyPolicy> sets the inhibit any policy flag as defined in
+RFC3280.  Equivalent to B<X509_V_FLAG_INHIBIT_ANY>.
+
+B<InhibitPolicyMapping> sets the inhibit policy mapping flag as
+defined in RFC3280.  Equivalent to B<X509_V_FLAG_INHIBIT_MAP>.
+
+B<NotifyPolicy> Equivalent to B<X509_V_FLAG_NOTIFY_POLICY>.
+
+B<ExtendedCRLFeatures> enables additional features such as indirect
+CRLs and CRLs signed by different keys. Equivalent to
+B<X509_V_FLAG_EXTENDED_CRL_SUPPORT>.
+
+B<EnableDeltaCRLs> use delta CRLs to determine certificate status.
+Equivalent to B<X509_V_FLAG_USE_DELTAS>.
+
+B<CheckSelfSignedSign> enables checking the self-signature of the
+last certificate in a chain.  Equivalent to
+B<X509_V_FLAG_CHECK_SS_SIGNATURE>.
+
+B<PartialChain> causes non-self-signed certificates in the trust
+store to be treated as trust anchors.  Equivalent to
+B<X509_V_FLAG_PARTIAL_CHAIN>.
+
+B<NoCheckTime> suppresses checking the validity period of certificate
+and CRLs.  Equivalent to B<X509_V_FLAG_NO_CHECK_TIME>.
+
+=item B<SetHostFlags>
+
+The B<value> argument is a comma separated list of host validation flags
+to set.  If a flag string is preceded by B<-> that flag is disabled.
+See the L<X509_VERIFY_PARAM_set_hostflags(3)> function for more details of
+individual options.
+
+All supported flags are listed below.
+
+B<AlwaysCheckSubject> causes certificate DNS hostname verification to
+always consider the subject DN.  Equivalent to
+B<X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT>.
+
+B<NoWildcards> disables wildcard expansion when checking a DNS hostname.
+Equivalent to B<X509_CHECK_FLAG_NO_WILDCARDS>.
+
+B<NoPartialWildcards> suppresses support for "*" as wildcard pattern in
+labels that have a prefix or suffix, such as: "www*" or "*www"
+when checking a DNS hostname.  Equivalent to
+B<X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS>.
+
+B<MultiLabelWildcards> allows a "*" that constitutes the complete
+label of a DNS name (e.g. "*.example.com") to match more than one
+label in name when checking a DNS hostname.  Equivalent to
+B<X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS>.
+
+B<SingleLabelSubdomains> restricts name values which start with ".",
+that would otherwise match any sub-domain in the peer certificate, to
+only match direct child sub-domains when checking a DNS hostname.
+Equivalent to B<X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS>.
+
+B<NeverCheckSubject> causes certificate hostname verification to
+never consider the subject DN.  Equivalent to
+B<X509_CHECK_FLAG_NEVER_CHECK_SUBJECT>.
+
+=item B<SetExpectedDNSName>
+
+The B<value> argument is the expected DNS hostname or a comma-
+or semicolomn-separated list of DNS hostnames to use for
+certificate verification.  There should be no whitespace around the
+comma or semicolon.  Any previous value is cleared.  This option
+is intended for configurations that are dedicated to connecting to a single
+server or cluster of servers, and not appropriate for configurations that
+are used to connect to a diverse set of destinations.
+
+=item B<AddExpectedDNSName>
+
+The B<value> argument is an expected DNS hostname or a comma-
+or semicolon-separated list of DNS hostnames to use for
+certificate verification, in addition to any previously set value.
+There should be no whitespace around the comma or semicolon.  This option
+is intended for configurations that are dedicated to connecting to a single
+server or cluster of servers, and not appropriate for configurations that
+are used to connect to a diverse set of destinations.
+
+=item B<SetExpectedIPAddress>
+
+The B<value> argument is the expected IPv4 or IPv6 address or a comma-
+or semicolomn-separated list of IPv4 or IPv6 addresses to use for
+certificate verification.  There should be no whitespace around the
+comma or semicolon.  Any previous value is cleared.  This option
+is intended for configurations that are dedicated to connecting to a single
+server or cluster of servers, and not appropriate for configurations that
+are used to connect to a diverse set of destinations.
+
+=item B<AddExpectedIPAddress>
+
+The B<value> argument is an expected IPv4 or IPv6 address or a comma-
+or semicolomn-separated list of IPv4 or IPv6 addresses to use for
+certificate verification, in addition to any previously set value.
+There should be no whitespace around the comma or semicolon.  This option
+is intended for configurations that are dedicated to connecting to a single
+server or cluster of servers, and not appropriate for configurations that
+are used to connect to a diverse set of destinations.
 
 =back
 

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -9,12 +9,14 @@
 
 #include "internal/e_os.h"
 
+#include <assert.h>
 #include <stdio.h>
 #include "ssl_local.h"
 #include <openssl/conf.h>
 #include <openssl/objects.h>
 #include <openssl/decoder.h>
 #include <openssl/core_dispatch.h>
+#include <openssl/x509v3.h>
 #include "internal/nelem.h"
 #include "internal/ssl_unwrap.h"
 
@@ -46,6 +48,10 @@ typedef struct {
 #define SSL_TFLAG_CERT 0x100
 /* Flag is for verify mode */
 #define SSL_TFLAG_VFY 0x200
+/* Flag is for certificate validation */
+#define SSL_TFLAG_CERTVAL 0x300
+/* Flag is for hostname verification */
+#define SSL_TFLAG_HOSTVER 0x400
 /* Option can only be used for clients */
 #define SSL_TFLAG_CLIENT SSL_CONF_FLAG_CLIENT
 /* Option can only be used for servers */
@@ -69,6 +75,12 @@ typedef struct {
     { str, (int)(sizeof(str) - 1), SSL_TFLAG_VFY | SSL_TFLAG_CLIENT, flag }
 #define SSL_FLAG_VFY_SRV(str, flag) \
     { str, (int)(sizeof(str) - 1), SSL_TFLAG_VFY | SSL_TFLAG_SERVER, flag }
+
+#define SSL_FLAG_CERTVAL(str, flag) \
+    { str, (int)(sizeof(str) - 1), SSL_TFLAG_CERTVAL | SSL_TFLAG_BOTH, flag }
+
+#define SSL_FLAG_HOSTVER(str, flag) \
+    { str, (int)(sizeof(str) - 1), SSL_TFLAG_HOSTVER | SSL_TFLAG_BOTH, flag }
 
 /*
  * Opaque structure containing SSL configuration context.
@@ -100,6 +112,12 @@ struct ssl_conf_ctx_st {
     int *min_version;
     /* Pointer to SSL or SSL_CTX max_version field or NULL if none */
     int *max_version;
+    /* Pointer to context PARAM field or NULL if none */
+    X509_VERIFY_PARAM *param;
+    /* Copy of SSL_STORE_CTX flags */
+    long unsigned int pcertval_flags;
+    /* Copy of X509_VERIFY_PARAM_ID flags */
+    unsigned int phostver_flags;
     /* Current flag table being worked on */
     const ssl_flag_tbl *tbl;
     /* Size of table */
@@ -132,6 +150,23 @@ static void ssl_set_option(SSL_CONF_CTX *cctx, unsigned int name_flags,
             *cctx->poptions |= option_value;
         else
             *cctx->poptions &= ~option_value;
+        return;
+
+    case SSL_TFLAG_CERTVAL:
+        if (onoff)
+            cctx->pcertval_flags |= option_value;
+        else
+            cctx->pcertval_flags &= ~option_value;
+        X509_VERIFY_PARAM_clear_flags(cctx->param, ~cctx->pcertval_flags);
+        X509_VERIFY_PARAM_set_flags(cctx->param, cctx->pcertval_flags);
+        return;
+
+    case SSL_TFLAG_HOSTVER:
+        if (onoff)
+            cctx->phostver_flags |= option_value;
+        else
+            cctx->phostver_flags &= ~option_value;
+        X509_VERIFY_PARAM_set_hostflags(cctx->param, cctx->phostver_flags);
         return;
 
     default:
@@ -435,6 +470,169 @@ static int cmd_VerifyMode(SSL_CONF_CTX *cctx, const char *value)
     return CONF_parse_list(value, ',', 1, ssl_set_option_list, cctx);
 }
 
+static int cmd_SetCertificateFlags(SSL_CONF_CTX *cctx, const char *value)
+{
+    static const ssl_flag_tbl ssl_certval_list[] = {
+        SSL_FLAG_CERTVAL("UseCheckTime", X509_V_FLAG_USE_CHECK_TIME),
+        SSL_FLAG_CERTVAL("CRLCheck", X509_V_FLAG_CRL_CHECK),
+        SSL_FLAG_CERTVAL("CRLCheckAll", X509_V_FLAG_CRL_CHECK_ALL),
+        SSL_FLAG_CERTVAL("IgnoreCritical", X509_V_FLAG_IGNORE_CRITICAL),
+        SSL_FLAG_CERTVAL("Strict", X509_V_FLAG_X509_STRICT),
+        SSL_FLAG_CERTVAL("AllowProxyCerts", X509_V_FLAG_ALLOW_PROXY_CERTS),
+        SSL_FLAG_CERTVAL("PolicyCheck", X509_V_FLAG_POLICY_CHECK),
+        SSL_FLAG_CERTVAL("ExplicitPolicy", X509_V_FLAG_EXPLICIT_POLICY),
+        SSL_FLAG_CERTVAL("InhibitAnyPolicy", X509_V_FLAG_INHIBIT_ANY),
+        SSL_FLAG_CERTVAL("InhibitPolicyMapping", X509_V_FLAG_INHIBIT_MAP),
+        SSL_FLAG_CERTVAL("NotifyPolicy", X509_V_FLAG_NOTIFY_POLICY),
+        SSL_FLAG_CERTVAL("ExtendedCRLFeatures", X509_V_FLAG_EXTENDED_CRL_SUPPORT),
+        SSL_FLAG_CERTVAL("EnableDeltaCRLs", X509_V_FLAG_USE_DELTAS),
+        SSL_FLAG_CERTVAL("CheckSelfSignedSign", X509_V_FLAG_CHECK_SS_SIGNATURE),
+        SSL_FLAG_CERTVAL("PartialChain", X509_V_FLAG_PARTIAL_CHAIN),
+        SSL_FLAG_CERTVAL("NoCheckTime", X509_V_FLAG_NO_CHECK_TIME),
+    };
+
+    if (value == NULL)
+        return -3;
+    cctx->tbl = ssl_certval_list;
+    cctx->ntbl = (sizeof(ssl_certval_list) / sizeof(ssl_certval_list[0]));
+    return CONF_parse_list(value, ',', 1, ssl_set_option_list, cctx);
+}
+
+typedef int (*cb_func)(X509_VERIFY_PARAM *param, const char *value, size_t len);
+
+static int set_expected(SSL_CONF_CTX *cctx, const char *value,
+                        cb_func set_func, cb_func add_func)
+{
+    int rv = 0;
+    X509_VERIFY_PARAM *param = NULL;
+    char *buf, *ptr, *token;
+    cb_func cb;
+
+    if (cctx->ssl) {
+        SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(cctx->ssl);
+
+        if (sc == NULL)
+            return 0;
+        param = sc->param;
+    } else if (cctx->ctx) {
+        param = cctx->ctx->param;
+    }
+    if (param == NULL)
+        return 0;
+    if (value == NULL || strpbrk(value, ",;") == NULL)
+        return set_func(param, value, 0);
+
+    if ((buf = OPENSSL_strdup(value)) == NULL)
+        return 0;
+
+    ptr = buf;
+    cb = set_func;
+    do {
+        token = strpbrk(ptr, ",;");
+        if(token != NULL)
+            *token = '\0';
+        if (*ptr != '\0') {
+            rv = cb(param, ptr, 0);
+            if (rv <= 0)
+                goto end;
+            cb = add_func;
+        }
+        if(token != NULL)
+            ptr = token + 1;
+    } while (token != NULL);
+end:
+    OPENSSL_free(buf);
+    return rv;
+}
+
+static int cmd_SetExpectedDNSName(SSL_CONF_CTX *cctx, const char *value)
+{
+    return set_expected(cctx, value,
+                        X509_VERIFY_PARAM_set1_host,
+                        X509_VERIFY_PARAM_add1_host);
+}
+
+static int cmd_AddExpectedDNSName(SSL_CONF_CTX *cctx, const char *value)
+{
+    return set_expected(cctx, value,
+                        X509_VERIFY_PARAM_add1_host,
+                        X509_VERIFY_PARAM_add1_host);
+}
+
+static int cmd_SetExpectedIPAddress(SSL_CONF_CTX *cctx, const char *value)
+{
+    return set_expected(cctx, value,
+                        (cb_func)X509_VERIFY_PARAM_set1_ip_asc,
+                        (cb_func)X509_VERIFY_PARAM_add1_ip_asc);
+}
+
+static int cmd_AddExpectedIPAddress(SSL_CONF_CTX *cctx, const char *value)
+{
+    return set_expected(cctx, value,
+                        (cb_func)X509_VERIFY_PARAM_add1_ip_asc,
+                        (cb_func)X509_VERIFY_PARAM_add1_ip_asc);
+}
+
+static int cmd_SetHostFlags(SSL_CONF_CTX *cctx, const char *value)
+{
+    static const ssl_flag_tbl ssl_host_flags_list[] = {
+        SSL_FLAG_HOSTVER("AlwaysCheckSubject", X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT),
+        SSL_FLAG_HOSTVER("NoWildcards", X509_CHECK_FLAG_NO_WILDCARDS),
+        SSL_FLAG_HOSTVER("NoPartialWildcards", X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS),
+        SSL_FLAG_HOSTVER("MultiLabelWildcards", X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS),
+        SSL_FLAG_HOSTVER("SingleLabelSubdomains", X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS),
+        SSL_FLAG_HOSTVER("NeverCheckSubject", X509_CHECK_FLAG_NEVER_CHECK_SUBJECT),
+    };
+
+    if (value == NULL)
+        return -3;
+    cctx->tbl = ssl_host_flags_list;
+    cctx->ntbl = (sizeof(ssl_host_flags_list) / sizeof(ssl_host_flags_list[0]));
+    return CONF_parse_list(value, ',', 1, ssl_set_option_list, cctx);
+}
+
+static int do_add(SSL_CONF_CTX *cctx,
+    const char *CAfile, const char *CApath)
+{
+    X509_STORE **st;
+    SSL_CTX *ctx;
+    OSSL_LIB_CTX *libctx = NULL;
+    const char *propq = NULL;
+
+    if (cctx->ctx != NULL) {
+        ctx = cctx->ctx;
+    } else if (cctx->ssl != NULL) {
+        ctx = cctx->ssl->ctx;
+    } else {
+        return 1;
+    }
+    assert(ctx != NULL);
+    libctx = ctx->libctx;
+    propq = ctx->propq;
+    st = &ctx->cert_store;
+    if (*st == NULL) {
+        *st = X509_STORE_new();
+        if (*st == NULL)
+            return 0;
+    }
+
+    if (CAfile != NULL && !X509_STORE_load_file_ex(*st, CAfile, libctx, propq))
+        return 0;
+    if (CApath != NULL && !X509_STORE_load_path(*st, CApath))
+        return 0;
+    return 1;
+}
+
+static int cmd_AddCAPath(SSL_CONF_CTX *cctx, const char *value)
+{
+    return do_add(cctx, NULL, value);
+}
+
+static int cmd_AddCAFile(SSL_CONF_CTX *cctx, const char *value)
+{
+    return do_add(cctx, value, NULL);
+}
+
 static int cmd_Certificate(SSL_CONF_CTX *cctx, const char *value)
 {
     int rv = 1;
@@ -515,10 +713,9 @@ static int do_store(SSL_CONF_CTX *cctx,
     } else {
         return 1;
     }
-    if (ctx != NULL) {
-        libctx = ctx->libctx;
-        propq = ctx->propq;
-    }
+    assert(ctx != NULL);
+    libctx = ctx->libctx;
+    propq = ctx->propq;
     st = verify_store ? &cert->verify_store : &cert->chain_store;
     if (*st == NULL) {
         *st = X509_STORE_new();
@@ -799,6 +996,16 @@ static const ssl_conf_cmd_tbl ssl_conf_cmds[] = {
     SSL_CONF_CMD_STRING(MaxProtocol, "max_protocol", 0),
     SSL_CONF_CMD_STRING(Options, NULL, 0),
     SSL_CONF_CMD_STRING(VerifyMode, NULL, 0),
+    SSL_CONF_CMD_STRING(SetCertificateFlags, NULL, 0),
+    SSL_CONF_CMD_STRING(SetHostFlags, NULL, SSL_CONF_FLAG_CERTIFICATE),
+    SSL_CONF_CMD_STRING(SetExpectedDNSName, NULL, SSL_CONF_FLAG_CERTIFICATE),
+    SSL_CONF_CMD_STRING(AddExpectedDNSName, NULL, SSL_CONF_FLAG_CERTIFICATE),
+    SSL_CONF_CMD_STRING(SetExpectedIPAddress, NULL, SSL_CONF_FLAG_CERTIFICATE),
+    SSL_CONF_CMD_STRING(AddExpectedIPAddress, NULL, SSL_CONF_FLAG_CERTIFICATE),
+    SSL_CONF_CMD(AddCAPath, "addCApath", SSL_CONF_FLAG_CERTIFICATE,
+        SSL_CONF_TYPE_DIR),
+    SSL_CONF_CMD(AddCAFile, "addCAfile", SSL_CONF_FLAG_CERTIFICATE,
+        SSL_CONF_TYPE_FILE),
     SSL_CONF_CMD(Certificate, "cert", SSL_CONF_FLAG_CERTIFICATE,
         SSL_CONF_TYPE_FILE),
     SSL_CONF_CMD(PrivateKey, "key", SSL_CONF_FLAG_CERTIFICATE,
@@ -1173,6 +1380,9 @@ void SSL_CONF_CTX_set_ssl(SSL_CONF_CTX *cctx, SSL *ssl)
         cctx->max_version = &sc->max_proto_version;
         cctx->pcert_flags = &sc->cert->cert_flags;
         cctx->pvfy_flags = &sc->verify_mode;
+        cctx->param = SSL_get0_param(ssl);
+        cctx->pcertval_flags = X509_VERIFY_PARAM_get_flags(cctx->param);
+        cctx->phostver_flags = X509_VERIFY_PARAM_get_hostflags(cctx->param);
         cctx->cert_filename = OPENSSL_zalloc(sc->ssl_pkey_num
             * sizeof(*cctx->cert_filename));
         if (cctx->cert_filename != NULL)
@@ -1183,6 +1393,9 @@ void SSL_CONF_CTX_set_ssl(SSL_CONF_CTX *cctx, SSL *ssl)
         cctx->max_version = NULL;
         cctx->pcert_flags = NULL;
         cctx->pvfy_flags = NULL;
+        cctx->param = NULL;
+        cctx->pcertval_flags = 0;
+        cctx->phostver_flags = 0;
     }
 }
 
@@ -1197,6 +1410,9 @@ void SSL_CONF_CTX_set_ssl_ctx(SSL_CONF_CTX *cctx, SSL_CTX *ctx)
         cctx->max_version = &ctx->max_proto_version;
         cctx->pcert_flags = &ctx->cert->cert_flags;
         cctx->pvfy_flags = &ctx->verify_mode;
+        cctx->param = SSL_CTX_get0_param(ctx);
+        cctx->pcertval_flags = X509_VERIFY_PARAM_get_flags(cctx->param);
+        cctx->phostver_flags = X509_VERIFY_PARAM_get_hostflags(cctx->param);
         cctx->cert_filename = OPENSSL_zalloc((SSL_PKEY_NUM + ctx->sigalg_list_len)
             * sizeof(*cctx->cert_filename));
         if (cctx->cert_filename != NULL)
@@ -1207,5 +1423,8 @@ void SSL_CONF_CTX_set_ssl_ctx(SSL_CONF_CTX *cctx, SSL_CTX *ctx)
         cctx->max_version = NULL;
         cctx->pcert_flags = NULL;
         cctx->pvfy_flags = NULL;
+        cctx->param = NULL;
+        cctx->pcertval_flags = 0;
+        cctx->phostver_flags = 0;
     }
 }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -14704,6 +14704,238 @@ end:
     return testresult;
 }
 
+static int test_ssl_conf_SetCertificateFlags(SSL_CONF_CTX *confctx,
+    SSL_CTX *ssl_ctx,
+    SSL *ssl)
+{
+    int ret = 0;
+    X509_VERIFY_PARAM *param;
+    unsigned long flags;
+
+    if (ssl_ctx != NULL) {
+        param = SSL_CTX_get0_param(ssl_ctx);
+    } else if (ssl != NULL) {
+        param = SSL_get0_param(ssl);
+    } else {
+        goto end;
+    }
+
+    /* Verify that we can set and clear flags using "SetCertificateFlags" */
+    if (!TEST_int_eq(SSL_CONF_cmd(confctx, "SetCertificateFlags", "UseCheckTime"), 2))
+        goto end;
+
+    flags = X509_VERIFY_PARAM_get_flags(param);
+    if (!TEST_int_no(flags & X509_V_FLAG_USE_CHECK_TIME))
+        goto end;
+
+    if (!TEST_int_eq(SSL_CONF_cmd(confctx, "SetCertificateFlags", "-UseCheckTime"), 2))
+        goto end;
+
+    flags = X509_VERIFY_PARAM_get_flags(param);
+    if (!TEST_int_eq(flags & X509_V_FLAG_USE_CHECK_TIME))
+        goto end;
+
+    ret = 1;
+end:
+    return ret;
+}
+
+static int test_ssl_conf_SetHostFlags(SSL_CONF_CTX *confctx,
+    SSL_CTX *ssl_ctx,
+    SSL *ssl)
+{
+    int ret = 0;
+    X509_VERIFY_PARAM *param;
+    unsigned int flags;
+
+    if (ssl_ctx != NULL) {
+        param = SSL_CTX_get0_param(ssl_ctx);
+    } else if (ssl != NULL) {
+        param = SSL_get0_param(ssl);
+    } else {
+        goto end;
+    }
+
+    /* Verify that we can set and clear flags using "SetHostFlags" */
+    if (!TEST_int_eq(SSL_CONF_cmd(confctx, "SetHostFlags", "AlwaysCheckSubject"), 2))
+        goto end;
+
+    flags = X509_VERIFY_PARAM_get_hostflags(param);
+    if (!TEST_int_ne(flags & X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT))
+        goto end;
+
+    if (!TEST_int_eq(SSL_CONF_cmd(confctx, "SetHostFlags", "-AlwaysCheckSubject"), 2))
+        goto end;
+
+    flags = X509_VERIFY_PARAM_get_flags(param);
+    if (!TEST_int_eq(flags & X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT))
+        goto end;
+
+    ret = 1;
+end:
+    return ret;
+}
+
+static int test_ssl_conf_SetExpectedDNSName(SSL_CONF_CTX *confctx,
+    SSL_CTX *ssl_ctx,
+    SSL *ssl)
+{
+    static const char *first_hostname = "host1.openssl.org";
+    static const char *second_hostname = "host2.openssl.org";
+    static const char *third_hostname = "host3.openssl.org";
+    int ret = 0;
+    X509_VERIFY_PARAM *param;
+    char *host;
+
+    if (ssl_ctx != NULL) {
+        param = SSL_CTX_get0_param(ssl_ctx);
+    } else if (ssl != NULL) {
+        param = SSL_get0_param(ssl);
+    } else {
+        goto end;
+    }
+
+    /* Verify that we can set, add, and clear valid hosts using "SetExpectedDNSName" and "AddExpectedDNSName" */
+    if (!TEST_int_eq(SSL_CONF_cmd(confctx, "SetExpectedDNSName", first_hostname), 2))
+        goto end;
+
+    host = X509_VERIFY_PARAM_get0_host(param, 0);
+    if (!TEST_str_eq(host, first_hostname))
+        goto end;
+
+    if (!TEST_int_eq(SSL_CONF_cmd(confctx, "SetExpectedDNSName", second_hostname), 2))
+        goto end;
+
+    host = X509_VERIFY_PARAM_get0_host(param, 0);
+    if (!TEST_str_eq(host, second_hostname))
+        goto end;
+
+    if (!TEST_int_eq(SSL_CONF_cmd(confctx, "AddExpectedDNSName", third_hostname), 2))
+        goto end;
+
+    host = X509_VERIFY_PARAM_get0_host(param, 0);
+    if (!TEST_str_eq(host, second_hostname))
+        goto end;
+
+    host = X509_VERIFY_PARAM_get0_host(param, 1);
+    if (!TEST_str_eq(host, third_hostname))
+        goto end;
+
+    if (!TEST_int_eq(SSL_CONF_cmd(confctx, "SetExpectedDNSName", ""), 2))
+        goto end;
+
+    host = X509_VERIFY_PARAM_get0_host(param, 0);
+    if (!TEST_true(host == NULL))
+        goto end;
+
+    ret = 1;
+end:
+    return ret;
+}
+
+static int test_ssl_conf_SetExpectedIPAddress(SSL_CONF_CTX *confctx,
+    SSL_CTX *ssl_ctx,
+    SSL *ssl)
+{
+    static const char *first_ip = "192.168.29.65";
+    static const char *second_ip = "10.10.10.19";
+    int ret = 0;
+    X509_VERIFY_PARAM *param;
+    char *ip_str = NULL;
+
+    if (ssl_ctx != NULL) {
+        param = SSL_CTX_get0_param(ssl_ctx);
+    } else if (ssl != NULL) {
+        param = SSL_get0_param(ssl);
+    } else {
+        goto end;
+    }
+
+    /* Verify that we can set and replace valid IP addresses using "SetExpectedIPAddress" */
+    if (!TEST_int_eq(SSL_CONF_cmd(confctx, "SetExpectedIPAddress", first_ip), 2))
+        goto end;
+
+    ip_str = X509_VERIFY_PARAM_get1_ip_asc(param);
+    if (!TEST_str_eq(ip_str, first_ip))
+        goto end;
+    OPENSSL_free(ip_str);
+    ip_str = NULL;
+
+    if (!TEST_int_eq(SSL_CONF_cmd(confctx, "SetExpectedIPAddress", second_ip), 2))
+        goto end;
+
+    ip_str = X509_VERIFY_PARAM_get1_ip_asc(param);
+    if (!TEST_str_eq(ip_str, second_ip))
+        goto end;
+
+    ret = 1;
+end:
+    OPENSSL_free(ip_str);
+    return ret;
+}
+
+static int test_ssl_conf(void)
+{
+    int ret = 0;
+    SSL_CTX *ssl_ctx = NULL;
+    SSL *ssl = NULL;
+    SSL_CONF_CTX *confctx = NULL;
+
+    /* Test SSL_CONF commands using an SSL_CTX */
+    if (!TEST_ptr(ssl_ctx = SSL_CTX_new_ex(libctx, NULL, TLS_server_method())))
+        goto end;
+    if (!TEST_ptr(confctx = SSL_CONF_CTX_new()))
+        goto end;
+    SSL_CONF_CTX_set_flags(confctx, SSL_CONF_FLAG_FILE | SSL_CONF_FLAG_CERTIFICATE | SSL_CONF_FLAG_SERVER);
+    SSL_CONF_CTX_set_ssl_ctx(confctx, ssl_ctx);
+
+    if (!test_ssl_conf_SetCertificateFlags(confctx, ssl_ctx, NULL))
+        goto end;
+
+    if (!test_ssl_conf_SetHostFlags(confctx, ssl_ctx, NULL))
+        goto end;
+
+    if (!test_ssl_conf_SetExpectedDNSName(confctx, ssl_ctx, NULL))
+        goto end;
+
+    if (!test_ssl_conf_SetExpectedIPAddress(confctx, ssl_ctx, NULL))
+        goto end;
+
+    SSL_CONF_CTX_free(confctx);
+    confctx = NULL;
+    SSL_CTX_free(ssl_ctx);
+    ssl_ctx = NULL;
+
+    /* Test SSL_CONF commands using an SSL */
+    if (!TEST_ptr(ssl_ctx = SSL_CTX_new_ex(libctx, NULL, TLS_server_method())))
+        goto end;
+    if (!TEST_ptr(ssl = SSL_new(ssl_ctx)))
+        goto end;
+    if (!TEST_ptr(confctx = SSL_CONF_CTX_new()))
+        goto end;
+    SSL_CONF_CTX_set_flags(confctx, SSL_CONF_FLAG_FILE | SSL_CONF_FLAG_CERTIFICATE | SSL_CONF_FLAG_SERVER);
+    SSL_CONF_CTX_set_ssl(confctx, ssl);
+
+    if (!test_ssl_conf_SetCertificateFlags(confctx, NULL, ssl))
+        goto end;
+
+    if (!test_ssl_conf_SetHostFlags(confctx, NULL, ssl))
+        goto end;
+
+    if (!test_ssl_conf_SetExpectedDNSName(confctx, NULL, ssl))
+        goto end;
+
+    if (!test_ssl_conf_SetExpectedIPAddress(confctx, NULL, ssl))
+        goto end;
+
+    ret = 1;
+end:
+    SSL_CONF_CTX_free(confctx);
+    SSL_free(ssl);
+    SSL_CTX_free(ssl_ctx);
+    return ret;
+}
+
 OPT_TEST_DECLARE_USAGE("certfile privkeyfile srpvfile tmpfile provider config dhfile\n")
 
 int setup_tests(void)
@@ -15048,6 +15280,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_ssl_set_groups_unsupported_keyshare, 2);
     ADD_TEST(test_ssl_conf_flags);
     ADD_ALL_TESTS(test_http_verbs, 3);
+    ADD_TEST(test_ssl_conf);
 #if !defined(OSSL_NO_USABLE_TLS1_3)
     ADD_TEST(test_grease);
 #endif

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -14725,14 +14725,14 @@ static int test_ssl_conf_SetCertificateFlags(SSL_CONF_CTX *confctx,
         goto end;
 
     flags = X509_VERIFY_PARAM_get_flags(param);
-    if (!TEST_int_no(flags & X509_V_FLAG_USE_CHECK_TIME))
+    if (!TEST_int_ne(flags & X509_V_FLAG_USE_CHECK_TIME, 0))
         goto end;
 
     if (!TEST_int_eq(SSL_CONF_cmd(confctx, "SetCertificateFlags", "-UseCheckTime"), 2))
         goto end;
 
     flags = X509_VERIFY_PARAM_get_flags(param);
-    if (!TEST_int_eq(flags & X509_V_FLAG_USE_CHECK_TIME))
+    if (!TEST_int_eq(flags & X509_V_FLAG_USE_CHECK_TIME, 0))
         goto end;
 
     ret = 1;
@@ -14761,14 +14761,14 @@ static int test_ssl_conf_SetHostFlags(SSL_CONF_CTX *confctx,
         goto end;
 
     flags = X509_VERIFY_PARAM_get_hostflags(param);
-    if (!TEST_int_ne(flags & X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT))
+    if (!TEST_int_ne(flags & X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT, 0))
         goto end;
 
     if (!TEST_int_eq(SSL_CONF_cmd(confctx, "SetHostFlags", "-AlwaysCheckSubject"), 2))
         goto end;
 
     flags = X509_VERIFY_PARAM_get_flags(param);
-    if (!TEST_int_eq(flags & X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT))
+    if (!TEST_int_eq(flags & X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT, 0))
         goto end;
 
     ret = 1;


### PR DESCRIPTION
Add several new configuration options to the SSL_CONF API to allow projects using said API in their config files to have greater control over the OpenSSL configuration.

- [X] documentation is added or updated
- [X] tests are added or updated
  - ~~I don't see any tests dedicated to the CONF API~~