### PR TITLE
`cmp_vfy.c`: fix major duplications and minor mistakes in diagnostic output on  failure validating CMP messages

### DIFF
--- a/crypto/cmp/cmp_vfy.c
+++ b/crypto/cmp/cmp_vfy.c
@@ -518,14 +518,14 @@ static int check_msg_find_cert(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg)
 
     res = check_msg_all_certs(ctx, msg, 0 /* using ctx->trusted */)
         || check_msg_all_certs(ctx, msg, 1 /* 3gpp */);
-    ctx->log_cb = backup_log_cb;
-    if (res) {
-        /* discard any diagnostic information on trying to use certs */
-        (void)ERR_pop_to_mark();
+
+    ctx->log_cb = backup_log_cb; /* re-enable logging */
+    /* discard any previous diagnostic information on trying to use certs */
+    (void)ERR_pop_to_mark();
+
+    if (res)
         goto end;
-    }
     /* failed finding a sender cert that verifies the message signature */
-    (void)ERR_clear_last_mark();
 
     sname = X509_NAME_oneline(sender->d.directoryName, NULL, 0);
     skid_str = skid == NULL ? NULL : i2s_ASN1_OCTET_STRING(NULL, skid);

--- a/crypto/cmp/cmp_vfy.c
+++ b/crypto/cmp/cmp_vfy.c
@@ -56,8 +56,10 @@ static int verify_signature(const OSSL_CMP_CTX *cmp_ctx,
 sig_err:
     res = ossl_x509_print_ex_brief(bio, cert, X509_FLAG_NO_EXTENSIONS);
     ERR_raise(ERR_LIB_CMP, CMP_R_ERROR_VALIDATING_SIGNATURE);
-    if (res)
-        ERR_add_error_mem_bio("\n", bio);
+    if (res) {
+        ERR_add_error_txt(NULL, "\n");
+        ERR_add_error_mem_bio(NULL, bio);
+    }
     res = 0;
 
 end:
@@ -405,7 +407,7 @@ static int check_msg_with_certs(OSSL_CMP_CTX *ctx, const STACK_OF(X509) *certs,
     int i;
 
     if (sk_X509_num(certs) <= 0) {
-        ossl_cmp_log1(WARN, ctx, "no %s", desc);
+        ossl_cmp_log1(INFO, ctx, "no %s", desc);
         return 0;
     }
 
@@ -425,7 +427,7 @@ static int check_msg_with_certs(OSSL_CMP_CTX *ctx, const STACK_OF(X509) *certs,
         }
     }
     if (in_extraCerts && n_acceptable_certs == 0)
-        ossl_cmp_warn(ctx, "no acceptable cert in extraCerts");
+        ossl_cmp_log1(WARN, ctx, "no acceptable %s", desc);
     return 0;
 }
 


### PR DESCRIPTION
* prevent needless and confusing duplication of diagnostic output on failure validating CMP messages
* small fixes on content and layout of diagnostics on failure validating signature-based message protection