### PR TITLE
`OSSL_CMP_SRV_process_request()`: fix detection of new transactions and the context re-initialization 

### DIFF
--- a/crypto/cmp/cmp_server.c
+++ b/crypto/cmp/cmp_server.c
@@ -654,12 +654,6 @@ OSSL_CMP_MSG *OSSL_CMP_SRV_process_request(OSSL_CMP_SRV_CTX *srv_ctx,
     if (!OSSL_CMP_CTX_set1_recipient(ctx, hdr->sender->d.directoryName))
         goto err;
 
-    if (srv_ctx->polling && req_type != OSSL_CMP_PKIBODY_POLLREQ
-        && req_type != OSSL_CMP_PKIBODY_ERROR) {
-        ERR_raise(ERR_LIB_CMP, CMP_R_EXPECTED_POLLREQ);
-        goto err;
-    }
-
     if (assuming_new_transaction(ctx, req)) {
         /* start of a new transaction, reset transactionID and senderNonce */
         if (!transaction_reinit(srv_ctx))
@@ -671,6 +665,11 @@ OSSL_CMP_MSG *OSSL_CMP_SRV_process_request(OSSL_CMP_SRV_CTX *srv_ctx,
             ERR_raise(ERR_LIB_CMP, CMP_R_UNEXPECTED_PKIBODY);
             goto err;
 #endif
+        }
+        if (srv_ctx->polling && req_type != OSSL_CMP_PKIBODY_POLLREQ
+            && req_type != OSSL_CMP_PKIBODY_ERROR) {
+            ERR_raise(ERR_LIB_CMP, CMP_R_EXPECTED_POLLREQ);
+            goto err;
         }
     }
 

--- a/crypto/cmp/cmp_server.c
+++ b/crypto/cmp/cmp_server.c
@@ -55,7 +55,6 @@ OSSL_CMP_SRV_CTX *OSSL_CMP_SRV_CTX_new(OSSL_LIB_CTX *libctx, const char *propq)
     if ((ctx->ctx = OSSL_CMP_CTX_new(libctx, propq)) == NULL)
         goto err;
     ctx->certReqId = OSSL_CMP_CERTREQID_INVALID;
-    ctx->polling = 0;
 
     /* all other elements are initialized to 0 or NULL, respectively */
     return ctx;
@@ -571,6 +570,54 @@ static int unprotected_exception(const OSSL_CMP_CTX *ctx,
     return 0;
 }
 
+static int assuming_new_transaction(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *req)
+{
+    int body_type = OSSL_CMP_MSG_get_bodytype(req);
+    ASN1_OCTET_STRING *tid;
+
+    if (ctx->transactionID == NULL) /* no currently active transaction */
+        return 1;
+
+    tid = OSSL_CMP_HDR_get0_transactionID(OSSL_CMP_MSG_get0_header(req));
+    if (tid != NULL && ASN1_OCTET_STRING_cmp(tid, ctx->transactionID) != 0) {
+        char *ctx_str = i2s_ASN1_OCTET_STRING(NULL, ctx->transactionID);
+        char *tid_str = i2s_ASN1_OCTET_STRING(NULL, tid);
+
+        ossl_cmp_log2(WARN, ctx, "Assuming that last transaction with ID=%s got aborted, new ID=%s",
+            ctx_str, tid_str);
+        OPENSSL_free(tid_str);
+        OPENSSL_free(ctx_str);
+        return 1;
+    }
+
+    switch (body_type) {
+    case OSSL_CMP_PKIBODY_IR:
+    case OSSL_CMP_PKIBODY_CR:
+    case OSSL_CMP_PKIBODY_P10CR:
+    case OSSL_CMP_PKIBODY_KUR:
+    case OSSL_CMP_PKIBODY_RR:
+    case OSSL_CMP_PKIBODY_GENM:
+        ossl_cmp_log1(WARN, ctx, "Assuming new transaction due to received body type %s",
+            ossl_cmp_bodytype_to_string(body_type));
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+/* Prepare for next transaction */
+static int transaction_reinit(OSSL_CMP_SRV_CTX *srv_ctx)
+{
+    srv_ctx->ctx->status = OSSL_CMP_PKISTATUS_unspecified; /* transaction closed */
+    srv_ctx->certReqId = OSSL_CMP_CERTREQID_INVALID;
+    srv_ctx->polling = 0;
+
+    return OSSL_CMP_CTX_set1_transactionID(srv_ctx->ctx, NULL)
+        && OSSL_CMP_CTX_set1_senderNonce(srv_ctx->ctx, NULL)
+        && (srv_ctx->clean_transaction == NULL
+            || srv_ctx->clean_transaction(srv_ctx, srv_ctx->ctx->transactionID));
+}
+
 /*
  * returns created message and NULL on internal error
  */
@@ -613,36 +660,11 @@ OSSL_CMP_MSG *OSSL_CMP_SRV_process_request(OSSL_CMP_SRV_CTX *srv_ctx,
         goto err;
     }
 
-    switch (req_type) {
-    case OSSL_CMP_PKIBODY_IR:
-    case OSSL_CMP_PKIBODY_CR:
-    case OSSL_CMP_PKIBODY_P10CR:
-    case OSSL_CMP_PKIBODY_KUR:
-    case OSSL_CMP_PKIBODY_RR:
-    case OSSL_CMP_PKIBODY_GENM:
-    case OSSL_CMP_PKIBODY_ERROR:
-        if (ctx->transactionID != NULL) {
-            char *tid = i2s_ASN1_OCTET_STRING(NULL, ctx->transactionID);
-
-            if (tid != NULL)
-                ossl_cmp_log1(WARN, ctx,
-                    "Assuming that last transaction with ID=%s got aborted",
-                    tid);
-            OPENSSL_free(tid);
-        }
+    if (assuming_new_transaction(ctx, req)) {
         /* start of a new transaction, reset transactionID and senderNonce */
-        if (!OSSL_CMP_CTX_set1_transactionID(ctx, NULL)
-            || !OSSL_CMP_CTX_set1_senderNonce(ctx, NULL))
+        if (!transaction_reinit(srv_ctx))
             goto err;
-
-        if (srv_ctx->clean_transaction != NULL
-            && !srv_ctx->clean_transaction(srv_ctx, NULL)) {
-            ERR_raise(ERR_LIB_CMP, CMP_R_ERROR_PROCESSING_MESSAGE);
-            goto err;
-        }
-
-        break;
-    default:
+    } else {
         /* transactionID should be already initialized */
         if (ctx->transactionID == NULL) {
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
@@ -735,13 +757,9 @@ err:
     case OSSL_CMP_PKIBODY_PKICONF:
     case OSSL_CMP_PKIBODY_GENP:
         /* Other terminating response message types are not supported */
-        srv_ctx->certReqId = OSSL_CMP_CERTREQID_INVALID;
-        /* Prepare for next transaction, ignoring any errors here: */
-        if (srv_ctx->clean_transaction != NULL)
-            (void)srv_ctx->clean_transaction(srv_ctx, ctx->transactionID);
-        (void)OSSL_CMP_CTX_set1_transactionID(ctx, NULL);
-        (void)OSSL_CMP_CTX_set1_senderNonce(ctx, NULL);
-        ctx->status = OSSL_CMP_PKISTATUS_unspecified; /* transaction closed */
+
+        /* Prepare for next transaction, ignoring any errors here */
+        (void)transaction_reinit(srv_ctx);
 
     default: /* not closing transaction in other cases */
         break;

--- a/crypto/cmp/cmp_server.c
+++ b/crypto/cmp/cmp_server.c
@@ -584,7 +584,8 @@ static int assuming_new_transaction(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *req)
         char *tid_str = i2s_ASN1_OCTET_STRING(NULL, tid);
 
         ossl_cmp_log2(WARN, ctx, "Assuming that last transaction with ID=%s got aborted, new ID=%s",
-            ctx_str, tid_str);
+            ctx_str != NULL ? ctx_str : "(null)",
+            tid_str != NULL ? tid_str : "(null)");
         OPENSSL_free(tid_str);
         OPENSSL_free(ctx_str);
         return 1;
@@ -608,14 +609,19 @@ static int assuming_new_transaction(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *req)
 /* Prepare for next transaction */
 static int transaction_reinit(OSSL_CMP_SRV_CTX *srv_ctx)
 {
+    int ret = 1;
+
     srv_ctx->ctx->status = OSSL_CMP_PKISTATUS_unspecified; /* transaction closed */
     srv_ctx->certReqId = OSSL_CMP_CERTREQID_INVALID;
     srv_ctx->polling = 0;
 
-    return ((srv_ctx->clean_transaction == NULL
-                || srv_ctx->clean_transaction(srv_ctx, srv_ctx->ctx->transactionID))
-        && OSSL_CMP_CTX_set1_transactionID(srv_ctx->ctx, NULL)
-        && OSSL_CMP_CTX_set1_senderNonce(srv_ctx->ctx, NULL));
+    if (srv_ctx->clean_transaction != NULL)
+        ret = srv_ctx->clean_transaction(srv_ctx, srv_ctx->ctx->transactionID);
+    if (!OSSL_CMP_CTX_set1_transactionID(srv_ctx->ctx, NULL))
+        ret = 0;
+    if (!OSSL_CMP_CTX_set1_senderNonce(srv_ctx->ctx, NULL))
+        ret = 0;
+    return ret;
 }
 
 /*
@@ -655,9 +661,16 @@ OSSL_CMP_MSG *OSSL_CMP_SRV_process_request(OSSL_CMP_SRV_CTX *srv_ctx,
         goto err;
 
     if (assuming_new_transaction(ctx, req)) {
-        /* start of a new transaction, reset transactionID and senderNonce */
-        if (!transaction_reinit(srv_ctx))
+        /*
+         * Start of a new transaction, resetting transactionID and senderNonce.
+         * Must in this case reset transactionID beforehand such that the clean()
+         * callback function gets a NULL transactionID argument, as documented.
+         */
+        (void)OSSL_CMP_CTX_set1_transactionID(ctx, NULL);
+        if (!transaction_reinit(srv_ctx)) {
+            ERR_raise(ERR_LIB_CMP, CMP_R_ERROR_PROCESSING_MESSAGE);
             goto err;
+        }
     } else {
         /* transactionID should be already initialized */
         if (ctx->transactionID == NULL) {

--- a/crypto/cmp/cmp_server.c
+++ b/crypto/cmp/cmp_server.c
@@ -612,10 +612,10 @@ static int transaction_reinit(OSSL_CMP_SRV_CTX *srv_ctx)
     srv_ctx->certReqId = OSSL_CMP_CERTREQID_INVALID;
     srv_ctx->polling = 0;
 
-    return OSSL_CMP_CTX_set1_transactionID(srv_ctx->ctx, NULL)
-        && OSSL_CMP_CTX_set1_senderNonce(srv_ctx->ctx, NULL)
-        && (srv_ctx->clean_transaction == NULL
-            || srv_ctx->clean_transaction(srv_ctx, srv_ctx->ctx->transactionID));
+    return ((srv_ctx->clean_transaction == NULL
+                || srv_ctx->clean_transaction(srv_ctx, srv_ctx->ctx->transactionID))
+        && OSSL_CMP_CTX_set1_transactionID(srv_ctx->ctx, NULL)
+        && OSSL_CMP_CTX_set1_senderNonce(srv_ctx->ctx, NULL));
 }
 
 /*

--- a/doc/man3/OSSL_CMP_SRV_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_SRV_CTX_new.pod
@@ -110,6 +110,9 @@ Otherwise it should be called again with the next request message of the same
 transaction (which can be a certificate confirmation or poll request message).
 The function should not be called by multiple threads sharing
 the same I<srv_ctx>; calling it in parallel leads to undefined behavior.
+When an earlier call did not yet finish the respective transaction,
+calling it in an interleaved way with a new request belonging to a different
+transaction will abort the earlier transaction and begin the new one.
 
 OSSL_CMP_CTX_server_perform() is an interface to
 OSSL_CMP_SRV_process_request() that can be used by a CMP client

--- a/doc/man3/OSSL_CMP_SRV_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_SRV_CTX_new.pod
@@ -94,15 +94,22 @@ OSSL_CMP_SRV_CTX_set_grant_implicit_confirm
 
 =head1 DESCRIPTION
 
-OSSL_CMP_SRV_process_request() implements the generic aspects of a CMP server.
-Its arguments are the B<OSSL_CMP_SRV_CTX> I<srv_ctx> and the CMP request message
+OSSL_CMP_SRV_process_request() implements the generic core aspects of a CMP server.
+Its arguments are the B<OSSL_CMP_SRV_CTX> I<srv_ctx> and a CMP request message
 I<req>. It does the typical generic checks on I<req>, calls
 the respective callback function (if present) for more specific processing,
-and then assembles a result message, which may be a CMP error message.
+and then assembles a response message, which may be a CMP error message.
+
+Since OSSL_CMP_SRV_process_request() handles only a single CMP request message,
+it may need to be called multiple times until a CMP transaction has ended.
 If after return of the function the expression
 I<OSSL_CMP_CTX_get_status(OSSL_CMP_SRV_CTX_get0_cmp_ctx(srv_ctx))> yields -1
 then the function has closed the current transaction,
 which may be due to normal successful end of the transaction or due to an error.
+Otherwise it should be called again with the next request message of the same
+transaction (which can be a certificate confirmation or poll request message).
+The function should not be called by multiple threads sharing
+the same I<srv_ctx>; calling it in parallel leads to undefined behavior.
 
 OSSL_CMP_CTX_server_perform() is an interface to
 OSSL_CMP_SRV_process_request() that can be used by a CMP client
@@ -160,10 +167,20 @@ confirmation of newly enrolled certificates if requested.
 
 CMP is defined in RFC 9810 (and CRMF in RFC 4211).
 
-So far the CMP server implementation is limited to one request per CMP message
-(and consequently to at most one response component per CMP message).
+Like the OpenSSL CMP client, the CMP server implementation documented here
+focuses on the Lightweight CMP Profile (RFC 9483).
+Among others, this implies that only commonly used CMP message types are supported
+and that each CMP message may not contain multiple certificate requests or responses.
+
+So far, this server implementation is single-threaded and
+should not be called in parallel for any given B<OSSL_CMP_SRV_CTX> I<srv_ctx>.
+It can handle only one CMP transaction at a time (which of course is not a problem
+for transactions consisting of just a single request/response message pair).
 
 =head1 RETURN VALUES
+
+OSSL_CMP_SRV_process_request() returns a CMP response message, which may be an
+error message, or NULL on internal errors that preclude producing a response.
 
 OSSL_CMP_SRV_CTX_new() returns a B<OSSL_CMP_SRV_CTX> structure on success,
 NULL on error.

--- a/doc/man3/OSSL_CMP_exec_certreq.pod
+++ b/doc/man3/OSSL_CMP_exec_certreq.pod
@@ -51,8 +51,9 @@ OSSL_CMP_get1_certReqTemplate
                                    OSSL_CMP_ATAVS **keySpec);
 =head1 DESCRIPTION
 
-This is the OpenSSL API for doing CMP (Certificate Management Protocol)
-client-server transactions, i.e., sequences of CMP requests and responses.
+This is the OpenSSL main API for CMP (Certificate Management Protocol) clients.
+Each of the OSSL_CMP_exec_*() functions performs a whole CMP transaction,
+which is a sequence of related CMP request messages and response messages.
 
 All functions take a populated OSSL_CMP_CTX structure as their first argument.
 Usually the server name, port, and path ("CMP alias") need to be set, as well as
@@ -185,8 +186,9 @@ Both must be freed by the caller.
 
 CMP is defined in RFC 9810 (and CRMF in RFC 4211).
 
-The CMP client implementation is limited to one request per CMP message
-(and consequently to at most one response component per CMP message).
+This CMP implementation focuses on the Lightweight CMP Profile (RFC 9483).
+Among others, this implies that only commonly used CMP message types are supported
+and that each CMP message may not contain multiple certificate requests or responses.
 
 When a client obtains from a CMP server CA certificates that it is going to
 trust, for instance via the caPubs field of a certificate response or using

--- a/test/cmp_client_test.c
+++ b/test/cmp_client_test.c
@@ -109,9 +109,7 @@ static int execute_exec_GENM_ses_test_single(CMP_SES_TEST_FIXTURE *fixture)
 
     sk_OSSL_CMP_ITAV_pop_free(itavs, OSSL_CMP_ITAV_free);
     return TEST_int_eq(OSSL_CMP_CTX_get_status(ctx), fixture->expected)
-            && fixture->expected == OSSL_CMP_PKISTATUS_accepted
-        ? TEST_ptr(itavs)
-        : TEST_ptr_null(itavs);
+        && (fixture->expected == OSSL_CMP_PKISTATUS_accepted ? TEST_ptr(itavs) : TEST_ptr_null(itavs));
 }
 
 static int execute_exec_GENM_ses_test(CMP_SES_TEST_FIXTURE *fixture)

--- a/test/cmp_client_test.c
+++ b/test/cmp_client_test.c
@@ -147,9 +147,7 @@ static int execute_exec_GENM_ses_test_single(CMP_SES_TEST_FIXTURE *fixture)
 
     sk_OSSL_CMP_ITAV_pop_free(itavs, OSSL_CMP_ITAV_free);
     return TEST_int_eq(OSSL_CMP_CTX_get_status(ctx), fixture->expected)
-            && fixture->expected == OSSL_CMP_PKISTATUS_accepted
-        ? TEST_ptr(itavs)
-        : TEST_ptr_null(itavs);
+        && (fixture->expected == OSSL_CMP_PKISTATUS_accepted ? TEST_ptr(itavs) : TEST_ptr_null(itavs));
 }
 
 static int execute_exec_GENM_ses_test(CMP_SES_TEST_FIXTURE *fixture)

--- a/test/cmp_client_test.c
+++ b/test/cmp_client_test.c
@@ -140,14 +140,18 @@ static int execute_exec_GENM_ses_test_single(CMP_SES_TEST_FIXTURE *fixture)
     ASN1_OBJECT *type = OBJ_txt2obj("1.3.6.1.5.5.7.4.2", 1);
     OSSL_CMP_ITAV *itav = OSSL_CMP_ITAV_create(type, NULL);
     STACK_OF(OSSL_CMP_ITAV) *itavs;
+    int ret;
 
     OSSL_CMP_CTX_push0_genm_ITAV(ctx, itav);
     itavs = OSSL_CMP_exec_GENM_ses(ctx);
     print_errors_PKIStatusInfo(ctx);
 
+    ret = TEST_int_eq(OSSL_CMP_CTX_get_status(ctx), fixture->expected)
+        && (fixture->expected == OSSL_CMP_PKISTATUS_accepted
+                ? TEST_ptr(itavs)
+                : TEST_ptr_null(itavs));
     sk_OSSL_CMP_ITAV_pop_free(itavs, OSSL_CMP_ITAV_free);
-    return TEST_int_eq(OSSL_CMP_CTX_get_status(ctx), fixture->expected)
-        && (fixture->expected == OSSL_CMP_PKISTATUS_accepted ? TEST_ptr(itavs) : TEST_ptr_null(itavs));
+    return ret;
 }
 
 static int execute_exec_GENM_ses_test(CMP_SES_TEST_FIXTURE *fixture)


### PR DESCRIPTION
* fix wrong handling of aborted polling transaction
  as well as the related test, where missing parentheses prevented reporting failure.
  
  The check for acceptable response body types during polling
  should only be done when we are in an active transaction.
* make detection of new transactions and the context re-initialization more complete.
  This motivated factoring out new functions: `assuming_new_transaction()` and `transaction_reinit()`.
  
  This includes a minor fix:
  So far, receiving an error message from the client was taken is an indication for a new transaction, 
  which does not make much sense. So this case has been dropped in assuming_new_transaction().

