### PR TITLE
Configurations/50-masm.conf: add x64 multilib suffix

### DIFF
--- a/Configurations/50-masm.conf
+++ b/Configurations/50-masm.conf
@@ -18,5 +18,6 @@ my %targets = (
         uplink_arch      => 'x86_64',
         asm_arch         => 'x86_64',
         perlasm_scheme   => "masm",
+        multilib         => "-x64",
     },
 );


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

The standard `VC-WIN64A` configuration uses a `-x64` multilib suffix, so let's do the same in `VC-WIN64A-masm` to allow the masm binaries to be drop-in replacements for the standard ones.

Note: This cannot be accomplished by simply renaming the resulting binaries because the import libraries refer to the DLLs using the name they were originally linked with.
