### PR TITLE
c_rehash: Strip \r from hash filename on msys2

### DIFF
--- a/tools/c_rehash.in
+++ b/tools/c_rehash.in
@@ -192,6 +192,7 @@ sub compute_hash {
             print STDERR "Cannot compute hash on '$fname'\n";
             return;
         }
+        binmode($fh, ":crlf");
     }
     return (<$fh>, <$fh>);
 }


### PR DESCRIPTION
Sample output for c_rehash -v on ucrt64 env:
```
Doing .
.0nk my.pem -> 472bcb3c
.0nk ca-bundle.crt -> cd8c0d63
WARNING: Skipping duplicate certificate ca-bundle.trust.crt
```