### PR TITLE
Add base code to serialize SHA3.

### DIFF
--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -290,6 +290,8 @@ struct evp_md_st {
     OSSL_FUNC_digest_freectx_fn *freectx;
     OSSL_FUNC_digest_copyctx_fn *copyctx;
     OSSL_FUNC_digest_dupctx_fn *dupctx;
+    OSSL_FUNC_digest_serialize_fn *serialize;
+    OSSL_FUNC_digest_deserialize_fn *deserialize;
     OSSL_FUNC_digest_get_params_fn *get_params;
     OSSL_FUNC_digest_set_ctx_params_fn *set_ctx_params;
     OSSL_FUNC_digest_get_ctx_params_fn *get_ctx_params;

--- a/include/internal/packet.h
+++ b/include/internal/packet.h
@@ -304,6 +304,17 @@ __owur static ossl_inline int PACKET_get_net_8(PACKET *pkt, uint64_t *data)
     return 1;
 }
 
+__owur static ossl_inline int PACKET_get_net_8_len(PACKET *pkt, size_t *data)
+{
+    uint64_t i;
+    int ret = PACKET_get_net_8(pkt, &i);
+
+    if (ret)
+        *data = (size_t)i;
+
+    return 1;
+}
+
 /* Peek ahead at 1 byte from |pkt| and store the value in |*data| */
 __owur static ossl_inline int PACKET_peek_1(const PACKET *pkt,
                                             unsigned int *data)

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -346,6 +346,8 @@ OSSL_CORE_MAKE_FUNC(int, SSL_QUIC_TLS_alert,
 # define OSSL_FUNC_DIGEST_GETTABLE_CTX_PARAMS       13
 # define OSSL_FUNC_DIGEST_SQUEEZE                   14
 # define OSSL_FUNC_DIGEST_COPYCTX                   15
+# define OSSL_FUNC_DIGEST_SERIALIZE                 16
+# define OSSL_FUNC_DIGEST_DESERIALIZE               17
 
 OSSL_CORE_MAKE_FUNC(void *, digest_newctx, (void *provctx))
 OSSL_CORE_MAKE_FUNC(int, digest_init, (void *dctx, const OSSL_PARAM params[]))
@@ -376,7 +378,10 @@ OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, digest_settable_ctx_params,
                     (void *dctx, void *provctx))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, digest_gettable_ctx_params,
                     (void *dctx, void *provctx))
-
+OSSL_CORE_MAKE_FUNC(int, digest_serialize,
+                    (void *vctx, unsigned char *out, size_t *outlen))
+OSSL_CORE_MAKE_FUNC(int, digest_deserialize,
+                    (void *vctx, const unsigned char *in, size_t inlen))
 /* Symmetric Ciphers */
 
 # define OSSL_FUNC_CIPHER_NEWCTX                     1

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -765,6 +765,10 @@ __owur int EVP_DigestFinalXOF(EVP_MD_CTX *ctx, unsigned char *out,
                               size_t outlen);
 __owur int EVP_DigestSqueeze(EVP_MD_CTX *ctx, unsigned char *out,
                              size_t outlen);
+__owur int EVP_DigestSerialize(EVP_MD_CTX *ctx,
+                               unsigned char *out, size_t *outlen);
+__owur int EVP_DigestDeserialize(EVP_MD_CTX *ctx,
+                                 const unsigned char *in, size_t inlen);
 
 __owur EVP_MD *EVP_MD_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                             const char *properties);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5951,3 +5951,5 @@ OPENSSL_posix_to_tm                     ?	4_0_0	EXIST::FUNCTION:
 OPENSSL_tm_to_posix                     ?	4_0_0	EXIST::FUNCTION:
 OPENSSL_timegm                          ?	4_0_0	EXIST::FUNCTION:
 OSSL_PARAM_clear_free                   ?	4_0_0	EXIST::FUNCTION:
+EVP_DigestSerialize                     ?	4_0_0	EXIST::FUNCTION:
+EVP_DigestDeserialize                   ?	4_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
This is a suggested alternative to PR #28837.

Adds serialize and deserialize functions to the digest dispatch tables. This uses PACKET and WPACKET for serialization.

One of the advantages of this method is that it can handle changes in EVP_MD_CTX state after deserializing a provider object. i.e. EVP_DigestDeserialize() could set ctx->flags |= EVP_MD_CTX_FLAG_FINALISED; if required.. (That would still need a getter to retrieve the state from the provider object).

Some general design choices that can be done multiple ways.

1) EVP_DigestInit_ex(ctx, md, NULL) needs to be done before serialization - so some constant fields do not need to be persisted. This ties into (2)
2) An algorithm name or id may not be required to be stored, but the bounds of fields need to be checked on deserialization.
3) Should this be called SerializeState?
4) Some form of versioning needs to be saved to allow for future requirements. The deserialize would need to handle all versions that are supported.

The serializing testing for XOF would need to also cover:
1) squeeze
2) absorb of exactly a multiple of the blocksize
3) absorb of input larger that a blocksize.
4) DigestFinal

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
