### PR TITLE
doc/man3/X509_STORE_get0_param.pod: mention how to free the returned objects

### DIFF
--- a/doc/man3/X509_STORE_get0_param.pod
+++ b/doc/man3/X509_STORE_get0_param.pod
@@ -25,8 +25,9 @@ parameters for I<xs>. The returned pointer must not be freed by the
 calling application
 
 X509_STORE_get1_objects() returns a snapshot of all objects in the store's X509
-cache. The cache contains B<X509> and B<X509_CRL> objects. The caller is
-responsible for freeing the returned list.
+cache. The cache contains B<X509> and B<X509_CRL> objects. The caller
+is responsible for freeing the returned list,
+using sk_X509_OBJECT_pop_free(sk, X509_OBJECT_free).
 
 X509_STORE_get0_objects() was deprecated in OpenSSL 4.0. Applications
 should instead use X509_STORE_get1_objects() to avoid potential
@@ -41,7 +42,8 @@ required to acquire the store lock via X509_STORE_lock() before
 invoking X509_STORE_get0_objects().
 
 X509_STORE_get1_all_certs() returns a list of all certificates in the store.
-The caller is responsible for freeing the returned list.
+The caller is responsible for freeing the returned list
+with OSSL_STACK_OF_X509_free().
 
 =head1 RETURN VALUES
 
@@ -60,6 +62,7 @@ certificates on success, else NULL.
 
 =head1 SEE ALSO
 
+L<DEFINE_STACK_OF(3)>,
 L<X509_STORE_new(3)>
 
 =head1 HISTORY


### PR DESCRIPTION
It is not entirely obvious from the description how the objects returned by `X509_STORE_get1_objects()` and `X509_STORE_get1_all_certs()` are supposed to be freed, explicitly mention the relevant calls, and provide a reference to `DEFINE_STACK_OF(3)`.

##### Checklist
- [x] documentation is added or updated