### PR TITLE
Avoid failing macos-large CI runners in cloned repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-14, macos-14-large]
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ github.repository != 'openssl/openssl' && matrix.os == 'macos-14-large' && 'macos-15' || matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
@@ -579,7 +579,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-15, macos-15-large]
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ github.repository == 'openssl/openssl' && matrix.os == 'macos-15-large' && 'macos-14' || matrix.os }}
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Those runners do only run successfully in the openssl repository, cloned github repos get typically a failure like this each time:

The job was not started because recent account payments have failed or your spending limit needs to be increased.
Please check the 'Billing & plans' section in your settings

- [x] tests are added or updated
