### PR TITLE
CRYPTO_R_ cannot be used with ERR_LIB_OSSL_STORE

### DIFF
--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -78,7 +78,7 @@ OSSL_STORE_open_ex(const char *uri, OSSL_LIB_CTX *libctx, const char *propq,
     size_t i;
 
     if (uri == NULL) {
-        ERR_raise(ERR_LIB_OSSL_STORE, CRYPTO_R_INVALID_NULL_ARGUMENT);
+        ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
 


### PR DESCRIPTION
Use ERR_R_PASSED_NULL_PARAMETER instead.

Fixes e9e643bc580e4ba0c6f8f9b4dd2ce59397b1b786
