### PR TITLE
update CI macos large runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,11 +263,7 @@ jobs:
         path: artifacts.tar.gz
 
   no-shared-macos:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-14, macos-14-large]
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
@@ -286,7 +282,7 @@ jobs:
       if: success() || failure()
       uses: actions/upload-artifact@v4
       with:
-        name: "ci@no-shared-${{ matrix.os }}"
+        name: "ci@no-shared-macos-14"
         path: artifacts.tar.gz
 
   non-caching:
@@ -575,11 +571,7 @@ jobs:
       working-directory: ./build
 
   out-of-readonly-source-and-install-macos:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-15, macos-15-large]
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
       with:
@@ -613,7 +605,7 @@ jobs:
       if: success() || failure()
       uses: actions/upload-artifact@v4
       with:
-        name: "ci@out-of-readonly-source-and-install-${{ matrix.os }}"
+        name: "ci@out-of-readonly-source-and-install-macos-15"
         path: build/artifacts.tar.gz
     - name: make install
       run: make install

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -104,14 +104,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-15, macos-15-large]
+        os: [macos-14, macos-14-large, macos-15, macos-15-large]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
-      run: ./config --strict-warnings --banner=Configured enable-fips
+      run: ./config --strict-warnings --banner=Configured enable-fips enable-demos enable-h3demo
     - name: config dump
       run: ./configdata.pm --dump
     - name: make


### PR DESCRIPTION
Running CI jobs on MacOS large runners on each pull request is problematic for forks. These runners are not free and require billing to setup. Therefore it makes more sense to move `macos-14-large` and `macos-15-large` into `os-zoo.yml` which is scheduled to run nightly.


Obsoletes #29005
