### PR TITLE
Correction of grammar error in doc/man1/openssl-req.pod.in

### DIFF
--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -403,7 +403,7 @@ If an extension is added using this option that has the same OID as one
 defined in the extension section of the config file, it overrides that one.
 
 This option can be given multiple times.
-Doing so, the same key most not be given more than once.
+Doing so, the same key must not be given more than once.
 
 =item B<-precert>
 


### PR DESCRIPTION
I changed the word "most" with the correct word "must" at the line 406.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

