### PR TITLE
macctx: remove unused function

### DIFF
--- a/providers/common/include/prov/provider_util.h
+++ b/providers/common/include/prov/provider_util.h
@@ -108,30 +108,6 @@ int ossl_prov_set_macctx(EVP_MAC_CTX *macctx,
                          const char *properties,
                          const OSSL_PARAM param[]);
 
-/* MAC functions */
-/*
- * Load an EVP_MAC_CTX* from the specified parameters with the specified
- * library context.
- * The params "mac" and "properties" are used to determine the implementation
- * used, and the parameters "digest", "cipher", "engine" and "properties" are
- * passed to the MAC via the created MAC context if they are given.
- * If there is already a created MAC context, it will be replaced if the "mac"
- * parameter is found, otherwise it will simply be used as is, and passed the
- * parameters to pilfer as it sees fit.
- *
- * As an option, a MAC name may be explicitly given, and if it is, the "mac"
- * parameter will be ignored.
- * Similarly, as an option, a cipher name or a digest name may be explicitly
- * given, and if any of them is, the "digest" and "cipher" parameters are
- * ignored.
- */
-int ossl_prov_macctx_load_from_params(EVP_MAC_CTX **macctx,
-                                      const OSSL_PARAM params[],
-                                      const char *macname,
-                                      const char *ciphername,
-                                      const char *mdname,
-                                      OSSL_LIB_CTX *ctx);
-
 typedef struct ag_capable_st {
     OSSL_ALGORITHM alg;
     int (*capable)(void);

--- a/providers/common/provider_util.c
+++ b/providers/common/provider_util.c
@@ -323,22 +323,6 @@ int ossl_prov_macctx_load(EVP_MAC_CTX **macctx,
     return 0;
 }
 
-int ossl_prov_macctx_load_from_params(EVP_MAC_CTX **macctx,
-                                      const OSSL_PARAM params[],
-                                      const char *macname,
-                                      const char *ciphername,
-                                      const char *mdname,
-                                      OSSL_LIB_CTX *libctx)
-{
-    return ossl_prov_macctx_load
-            (macctx, OSSL_PARAM_locate_const(params, OSSL_ALG_PARAM_MAC),
-             OSSL_PARAM_locate_const(params, OSSL_ALG_PARAM_CIPHER),
-             OSSL_PARAM_locate_const(params, OSSL_ALG_PARAM_DIGEST),
-             OSSL_PARAM_locate_const(params, OSSL_ALG_PARAM_PROPERTIES),
-             OSSL_PARAM_locate_const(params, OSSL_ALG_PARAM_ENGINE),
-             macname, ciphername, mdname, libctx);
-}
-
 void ossl_prov_cache_exported_algorithms(const OSSL_ALGORITHM_CAPABLE *in,
                                          OSSL_ALGORITHM *out)
 {


### PR DESCRIPTION
The `ossl_prov_macctx_load_from_params()` function is no longer used. Since it isn't public, it can be removed.
