### PR TITLE
[3.0] doc/man3/X509_STORE_get0_param.pod: mention how to free the returned objects

### DIFF
--- a/doc/man3/X509_STORE_get0_param.pod
+++ b/doc/man3/X509_STORE_get0_param.pod
@@ -29,7 +29,8 @@ X509 object cache. The cache contains B<X509> and B<X509_CRL> objects. The
 returned pointer must not be freed by the calling application.
 
 X509_STORE_get1_all_certs() returns a list of all certificates in the store.
-The caller is responsible for freeing the returned list.
+The caller is responsible for freeing the returned list
+with sk_X509_pop_free(sk, X509_free).
 
 =head1 RETURN VALUES
 
@@ -45,6 +46,7 @@ certificates on success, else NULL.
 
 =head1 SEE ALSO
 
+L<DEFINE_STACK_OF(3)>,
 L<X509_STORE_new(3)>
 
 =head1 HISTORY


### PR DESCRIPTION
It is not entirely obvious from the description how the objects returned by X509_STORE_get1_all_certs() are supposed to be freed, explicitly mention the relevant call, and provide a reference to DEFINE_STACK_OF(3).

This patch is a backport of [1] to `openssl-3.0` branch.

[1] https://github.com/openssl/openssl/pull/29002

##### Checklist
- [x] documentation is added or updated