### PR TITLE
CRL: Validate Certificate Issuer extension with IDP Indirect=TRUE

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1669,9 +1669,7 @@ static int get_crl_score(X509_STORE_CTX *ctx, X509 **pissuer,
     }
 
     *preasons = tmp_reasons;
-
     return crl_score;
-
 }
 
 static void crl_akid_check(X509_STORE_CTX *ctx, X509_CRL *crl,

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -103,6 +103,18 @@ static int crl_set_issuers(X509_CRL *crl)
         }
 
         if (gtmp != NULL) {
+            /*
+             * Validation to ensure Certificate Issuer extensions in CRL
+             * entries only appear when the Indirect CRL flag is TRUE in the
+             * Issuing Distribution Point (IDP) extension, as required by
+             * RFC 5280 section 5.3.3.
+             */
+            if (crl->idp == NULL || !crl->idp->indirectCRL) {
+                crl->flags |= EXFLAG_INVALID;
+                GENERAL_NAMES_free(gtmp);
+                return 0;
+            }
+
             if (crl->issuers == NULL) {
                 crl->issuers = sk_GENERAL_NAMES_new_null();
                 if (crl->issuers == NULL) {


### PR DESCRIPTION
CRL: RFC 5280 compliance for Certificate Issuer extension

Add validation to ensure Certificate Issuer extensions in CRL entries only appear when the Indirect CRL flag is TRUE in the Issuing Distribution Point (IDP) extension, as required by RFC 5280 section 5.3.3.

Fixes #27465

