### PR TITLE
INSTALL.md: document --manpage-format changes

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1583,6 +1583,16 @@ EOF
           my $section = $1;
           my $name = uc basename($args{src}, ".$section");
           my $pod = $gen0;
+
+          if ($config{manpage_format} eq "mdoc") {
+              return <<"EOF";
+$args{src}: $pod
+	pod2mdoc -n $name -s $section\$(MANSUFFIX) \\
+		 -d \$(RELEASE_DATE) \\
+		 $pod >\$\@
+EOF
+          }
+          die "Unhandled manpage format: $config{manpage_format}" unless ($config{manpage_format} eq "roff");
           return <<"EOF";
 $args{src}: $pod
 	pod2man --name=$name --section=$section\$(MANSUFFIX) --center=OpenSSL \\

--- a/Configure
+++ b/Configure
@@ -27,7 +27,7 @@ use OpenSSL::config;
 my $orig_death_handler = $SIG{__DIE__};
 $SIG{__DIE__} = \&death_handler;
 
-my $usage="Usage: Configure [no-<feature> ...] [enable-<feature> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]thread-pool] [[no-]default-thread-pool] [[no-]shared] [[no-]zlib|zlib-dynamic] [no-asm] [no-egd] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--with-xxx[=vvv]] [--config=FILE] [--help] os/compiler[:flags]\n";
+my $usage="Usage: Configure [no-<feature> ...] [enable-<feature> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]thread-pool] [[no-]default-thread-pool] [[no-]shared] [[no-]zlib|zlib-dynamic] [no-asm] [no-egd] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--with-xxx[=vvv]] [--config=FILE] [--manpage-format={roff,mdoc}] [--help] os/compiler[:flags]\n";
 
 my $banner = <<"EOF";
 
@@ -288,6 +288,7 @@ my $dofile = abs2rel(catfile($srcdir, "util/dofile.pl"));
 
 my $local_config_envname = 'OPENSSL_LOCAL_CONFIG_DIR';
 
+$config{manpage_format} = "roff";
 $config{sourcedir} = abs2rel($srcdir, $blddir);
 $config{builddir} = abs2rel($blddir, $blddir);
 # echo -n 'holy hand grenade of antioch' | openssl sha256
@@ -1021,6 +1022,10 @@ while (@argvcopy)
                 {
                 $config{build_type} = "release";
                 }
+        elsif (/^--manpage-format=(mdoc|roff)$/)
+		{
+		$config{manpage_format}="$1";
+		}
         elsif (/^--pgo$/)
                 {
                 $config{build_type} = "pgo";

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1248,7 +1248,8 @@ Build without support for the specified algorithm.
 
 The `ripemd` algorithm is deprecated and if used is synonymous with `rmd160`.
 
-### Compiler-specific options
+Compiler-specific options
+-------------------------
 
     -Dxxx, -Ixxx, -Wp, -lxxx, -Lxxx, -Wl, -rpath, -R, -framework, -static
 
@@ -1279,7 +1280,17 @@ encoding.
 Take note of the [Environment Variables](#environment-variables) documentation
 below and how these flags interact with those variables.
 
-### Environment Variables
+Miscellaneous options
+---------------------
+
+### --manpage-format
+
+Specify a specific output manpage format. The supported output types are mandoc
+and *roff. The *roff output format is the default for legacy and portability
+reasons.
+
+Environment Variables
+---------------------
 
     VAR=value
 
@@ -1356,10 +1367,18 @@ If `CC` is set, it is advisable to also set `CXX` to ensure both the C and C++
 compiler are in the same "family".  This becomes relevant with
 `enable-external-tests` and `enable-buildtest-c++`.
 
-### Reconfigure
+Reconfigure
+-----------
 
-    reconf
-    reconfigure
+### Make targets
+
+    `$ make reconf`
+
+or
+
+    `$ make reconfigure`
+
+### Description
 
 Reconfigure from earlier data.
 


### PR DESCRIPTION
This change documents the new Configure option, `--manpage-format`.

Address formatting issues and expound on the `Reconfigure` section.