### PR TITLE
Fix NID bug in SSL_CERT_LOOKUP array construction

### DIFF
--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -1332,13 +1332,13 @@ int ssl_cert_lookup_by_nid(int nid, size_t *pidx, SSL_CTX *ctx)
     size_t i;
 
     for (i = 0; i < OSSL_NELEM(ssl_cert_info); i++) {
-        if (ssl_cert_info[i].nid == nid) {
+        if (ssl_cert_info[i].pkey_nid == nid) {
             *pidx = i;
             return 1;
         }
     }
     for (i = 0; i < ctx->sigalg_list_len; i++) {
-        if (ctx->ssl_cert_info[i].nid == nid) {
+        if (ctx->ssl_cert_info[i].pkey_nid == nid) {
             *pidx = SSL_PKEY_NUM + i;
             return 1;
         }
@@ -1354,8 +1354,8 @@ const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk, size_t *pidx,
     for (i = 0; i < OSSL_NELEM(ssl_cert_info); i++) {
         const SSL_CERT_LOOKUP *tmp_lu = &ssl_cert_info[i];
 
-        if (EVP_PKEY_is_a(pk, OBJ_nid2sn(tmp_lu->nid))
-            || EVP_PKEY_is_a(pk, OBJ_nid2ln(tmp_lu->nid))) {
+        if (EVP_PKEY_is_a(pk, OBJ_nid2sn(tmp_lu->pkey_nid))
+            || EVP_PKEY_is_a(pk, OBJ_nid2ln(tmp_lu->pkey_nid))) {
             if (pidx != NULL)
                 *pidx = i;
             return tmp_lu;
@@ -1365,8 +1365,8 @@ const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk, size_t *pidx,
     for (i = 0; i < ctx->sigalg_list_len; i++) {
         SSL_CERT_LOOKUP *tmp_lu = &(ctx->ssl_cert_info[i]);
 
-        if (EVP_PKEY_is_a(pk, OBJ_nid2sn(tmp_lu->nid))
-            || EVP_PKEY_is_a(pk, OBJ_nid2ln(tmp_lu->nid))) {
+        if (EVP_PKEY_is_a(pk, OBJ_nid2sn(tmp_lu->pkey_nid))
+            || EVP_PKEY_is_a(pk, OBJ_nid2ln(tmp_lu->pkey_nid))) {
             if (pidx != NULL)
                 *pidx = SSL_PKEY_NUM + i;
             return &ctx->ssl_cert_info[i];

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -773,7 +773,7 @@ typedef struct tls_sigalg_info_st {
  * CERT_PKEY entries
  */
 typedef struct {
-    int nid; /* NID of public key algorithm */
+    int pkey_nid; /* NID of public key algorithm */
     uint32_t amask; /* authmask corresponding to key type */
 } SSL_CERT_LOOKUP;
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -698,7 +698,7 @@ int ssl_load_sigalgs(SSL_CTX *ctx)
             return 0;
         for(i = 0; i < ctx->sigalg_list_len; i++) {
             const char *keytype = inferred_keytype(&ctx->sigalg_list[i]);
-            ctx->ssl_cert_info[i].nid = OBJ_txt2nid(keytype);
+            ctx->ssl_cert_info[i].pkey_nid = OBJ_txt2nid(keytype);
             ctx->ssl_cert_info[i].amask = SSL_aANY;
         }
     }
@@ -4473,7 +4473,7 @@ static int tls12_get_cert_sigalg_idx(const SSL_CONNECTION *s,
     /* If not recognised or not supported by cipher mask it is not suitable */
     if (clu == NULL
             || (clu->amask & s->s3.tmp.new_cipher->algorithm_auth) == 0
-            || (clu->nid == EVP_PKEY_RSA_PSS
+            || (clu->pkey_nid == EVP_PKEY_RSA_PSS
                 && (s->s3.tmp.new_cipher->algorithm_mkey & SSL_kRSA) != 0))
         return -1;
 

--- a/test/ssl_cert_table_internal_test.c
+++ b/test/ssl_cert_table_internal_test.c
@@ -26,14 +26,14 @@ static int do_test_cert_table(int nid, uint32_t amask, size_t idx,
 {
     const SSL_CERT_LOOKUP *clu = &ssl_cert_info[idx];
 
-    if (clu->nid == nid && clu->amask == amask)
+    if (clu->pkey_nid == nid && clu->amask == amask)
         return 1;
 
     TEST_error("Invalid table entry for certificate type %s, index %zu",
                idxname, idx);
-    if (clu->nid != nid)
+    if (clu->pkey_nid != nid)
         TEST_note("Expected %s, got %s\n", OBJ_nid2sn(nid),
-                  OBJ_nid2sn(clu->nid));
+                  OBJ_nid2sn(clu->pkey_nid));
     if (clu->amask != amask)
         TEST_note("Expected auth mask 0x%x, got 0x%x\n",
                   (unsigned int)amask, (unsigned int)clu->amask);


### PR DESCRIPTION
The SSL_CERT_LOOKUP NID should be for the public key algorithm (what is
often called the "key type".  Yet, when populating the SSL_CERT_LOOKUP
table with `ssl_load_sigalgs`, only the sigalg name is used to find a
NID.

This is perfectly OK to do, *if* the sigalg and the associated key type
share the same name.  However, that's not always the case.

This change infers the key type name in `ssl_load_sigalgs` the same way
as it was already done in `add_provider_sigalgs`.

Related-to: https://github.com/openssl/openssl/pull/29019#discussion_r2472219647

-----

For further clarification, I've also renamed the SSL_CERT_LOOKUP.nid
field to `pkey_nid`.  That's in a separate commit, and can be thrown
away if people disagree.
