### PR TITLE
Restore previous semantics of authorityKeyIdentifier=keyid

### DIFF
--- a/crypto/x509/v3_akid.c
+++ b/crypto/x509/v3_akid.c
@@ -107,7 +107,7 @@ static AUTHORITY_KEYID *v2i_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
     ASN1_INTEGER *serial = NULL;
     X509_EXTENSION *ext;
     X509 *issuer_cert;
-    int same_issuer, ss;
+    int self_signed = 0;
     AUTHORITY_KEYID *akeyid = AUTHORITY_KEYID_new();
 
     if (akeyid == NULL)
@@ -156,36 +156,36 @@ static AUTHORITY_KEYID *v2i_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
         ERR_raise(ERR_LIB_X509V3, X509V3_R_NO_ISSUER_CERTIFICATE);
         goto err;
     }
-    same_issuer = ctx->subject_cert == ctx->issuer_cert;
-    ERR_set_mark();
-    if (ctx->issuer_pkey != NULL)
-        ss = X509_check_private_key(ctx->subject_cert, ctx->issuer_pkey);
-    else
-        ss = same_issuer;
-    ERR_pop_to_mark();
+
+    if (ctx->subject_cert != NULL && ctx->issuer_pkey != NULL) {
+        ERR_set_mark();
+        self_signed = X509_check_private_key(ctx->subject_cert,
+                                             ctx->issuer_pkey);
+        ERR_pop_to_mark();
+    }
 
     /* unless forced with "always", AKID is suppressed for self-signed certs */
-    if (keyid == 2 || (keyid == 1 && !ss)) {
+    if (keyid == 2 || (keyid == 1 && !self_signed)) {
         /*
          * prefer any pre-existing subject key identifier of the issuer cert
-         * except issuer cert is same as subject cert and is not self-signed
+         * except issuer cert is same as subject cert and private key is given
          */
-        i = X509_get_ext_by_NID(issuer_cert, NID_subject_key_identifier, -1);
-        if (i >= 0 && (ext = X509_get_ext(issuer_cert, i)) != NULL
-            && !(same_issuer && !ss)) {
-            ikeyid = X509V3_EXT_d2i(ext);
-            if (ASN1_STRING_length(ikeyid) == 0) /* indicating "none" */ {
-                ASN1_OCTET_STRING_free(ikeyid);
-                ikeyid = NULL;
-            }
-        }
-        if (ikeyid == NULL && same_issuer && ctx->issuer_pkey != NULL) {
+        if (ctx->subject_cert == issuer_cert && ctx->issuer_pkey != NULL) {
             /* generate fallback AKID, emulating s2i_skey_id(..., "hash") */
             X509_PUBKEY *pubkey = NULL;
 
             if (X509_PUBKEY_set(&pubkey, ctx->issuer_pkey))
                 ikeyid = ossl_x509_pubkey_hash(pubkey);
             X509_PUBKEY_free(pubkey);
+        } else {
+            i = X509_get_ext_by_NID(issuer_cert, NID_subject_key_identifier, -1);
+            if (i >= 0 && (ext = X509_get_ext(issuer_cert, i)) != NULL) {
+                ikeyid = X509V3_EXT_d2i(ext);
+                if (ASN1_STRING_length(ikeyid) == 0) /* indicating "none" */ {
+                    ASN1_OCTET_STRING_free(ikeyid);
+                    ikeyid = NULL;
+                }
+            }
         }
         if (keyid == 2 && ikeyid == NULL) {
             ERR_raise(ERR_LIB_X509V3, X509V3_R_UNABLE_TO_GET_ISSUER_KEYID);
@@ -193,16 +193,13 @@ static AUTHORITY_KEYID *v2i_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
         }
     }
 
-    if (issuer == 2 || (issuer == 1 && !ss && ikeyid == NULL)) {
+    if (issuer == 2 || (issuer == 1 && ikeyid == NULL && !self_signed)) {
         isname = X509_NAME_dup(X509_get_issuer_name(issuer_cert));
         serial = ASN1_INTEGER_dup(X509_get0_serialNumber(issuer_cert));
         if (isname == NULL || serial == NULL) {
             ERR_raise(ERR_LIB_X509V3, X509V3_R_UNABLE_TO_GET_ISSUER_DETAILS);
             goto err;
         }
-    }
-
-    if (isname != NULL) {
         if ((gens = sk_GENERAL_NAME_new_null()) == NULL
             || (gen = GENERAL_NAME_new()) == NULL) {
             ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
@@ -217,8 +214,6 @@ static AUTHORITY_KEYID *v2i_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
     }
 
     akeyid->issuer = gens;
-    gen = NULL;
-    gens = NULL;
     akeyid->serial = serial;
     akeyid->keyid = ikeyid;
 

--- a/doc/man5/x509v3_config.pod
+++ b/doc/man5/x509v3_config.pod
@@ -211,13 +211,17 @@ or both of them, separated by C<,>.
 Either or both can have the option B<always>,
 indicated by putting a colon C<:> between the value and this option.
 For self-signed certificates the AKID is suppressed unless B<always> is present.
+In order to find out, if the certificate is about to be self-signed, the
+private key as given by B<X509V3_set_issuer_pkey> is compared to the
+public key in the subject_certificate.
+When there is no private key available, the AKID will not be suppressed.
 
 By default the B<x509>, B<req>, and B<ca> apps behave as if B<none> was given
 for self-signed certificates and B<keyid>C<,> B<issuer> otherwise.
 
 If B<keyid> is present, an attempt is made to
 copy the subject key identifier (SKID) from the issuer certificate except if
-the issuer certificate is the same as the current one and it is not self-signed.
+the issuer certificate does not have the subject key identifier extension.
 The hash of the public key related to the signing key is taken as fallback
 if the issuer certificate is the same as the current certificate.
 If B<always> is present but no value can be obtained, an error is returned.


### PR DESCRIPTION
when the function X509V3_set_issuer_pkey is not used, since that
would break code written for 1.1.1 and before, where e.g.
X509V3_EXT_conf(NULL, &ctx, "authorityKeyIdentifier", "keyid,issuer");
was guaranteed to never fail and always generate a valid
extension, and not an empty AKID.
But due to the change, which happened between 1.1.1 and 3.0
that is no longer the case.
Code written for 3.0 must use X509V3_set_issuer_pkey and
detect the possible empty extensions, or use keyid:always
and be prepared that it may be impossible to create this
extension.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
