### PR TITLE
apps: ocsp.c: fix null dereference in ocsp_response

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -1091,6 +1091,12 @@ static void make_ocsp_response(BIO *err, OCSP_RESPONSE **resp, OCSP_REQUEST *req
         for (jj = 0; jj < sk_X509_num(ca) && !found; jj++) {
             X509 *ca_cert = sk_X509_value(ca, jj);
             OCSP_CERTID *ca_id = OCSP_cert_to_id(cert_id_md, NULL, ca_cert);
+            
+            if (ca_id == NULL) {
+                *resp = OCSP_response_create(OCSP_RESPONSE_STATUS_INTERNALERROR,
+                                             NULL);
+                goto end;
+            }
 
             if (OCSP_id_issuer_cmp(ca_id, cid) == 0) {
                 found = 1;


### PR DESCRIPTION
Report of the static analyzer:
Function 'OCSP_cert_to_id' may return NULL on allocation failure, but its return value is dereferenced in 'OCSP_id_issuer_cmp' without prior NULL check at ocsp.c:1088. This can lead to a null pointer dereference and cause a segmentation fault, resulting in a denial-of-service (DoS) condition. Although such failures are rare, an attacker could potentially trigger them under memory pressure. All other calls to 'OCSP_cert_to_id' in the codebase (e.g., add_ocsp_cert, add_ocsp_serial) properly check for NULL, making this instance a clear omission.

Correct explained:
Added a NULL check after calling OCSP_cert_to_id() when creating 'ca_id' inside the issuer lookup loop. If the allocation fails, the function now safely returns an internal error response instead of risking a crash. This change aligns the code with existing error-handling patterns in the same file and improves robustness against resource exhaustion attacks.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->


