### PR TITLE
crypto/bn/rsaz_exp.h: use constant_time_select_bn in bn_select_words

### DIFF
--- a/crypto/bn/rsaz_exp.h
+++ b/crypto/bn/rsaz_exp.h
@@ -63,7 +63,7 @@ static ossl_inline void bn_select_words(BN_ULONG *r, BN_ULONG mask,
     size_t i;
 
     for (i = 0; i < num; i++) {
-        r[i] = constant_time_select_64(mask, a[i], b[i]);
+        r[i] = constant_time_select_bn(mask, a[i], b[i]);
     }
 }
 


### PR DESCRIPTION
MSVC complained about possible loss of data on assignment, and it seems
that constant_time_select_bn is more suitable here than
constant_time_select_64, change the call to the former.
    
Fixes: 6d702cebfce3 "Add an extra reduction step to RSAZ mod_exp implementations"

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
