### PR TITLE
slh_dsa: fix leak in early return of slh_sign_internal()

### DIFF
--- a/crypto/slh_dsa/slh_dsa.c
+++ b/crypto/slh_dsa/slh_dsa.c
@@ -83,7 +83,7 @@ static int slh_sign_internal(SLH_DSA_HASH_CTX *hctx,
     if (!WPACKET_init_static_len(wpkt, sig, sig_len_expected, 0))
         return 0;
     if (!PACKET_buf_init(rpkt, m_digest, params->m))
-        return 0;
+        goto err;
 
     pk_seed = SLH_DSA_PK_SEED(priv);
     sk_seed = SLH_DSA_SK_SEED(priv);


### PR DESCRIPTION
In slh_sign_internal(), if calling PACKET_buf_init() failed, this function return without free wpkt. Replace `return 0` with `goto err` to free wpkt before return.