### PR TITLE
CI: Prevent scheduled jobs from running in forks

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -73,6 +73,7 @@ jobs:
           echo "branches<<EOF"$'\n'"$MATRIX"$'\n'EOF >> "$GITHUB_OUTPUT"
 
   coverage:
+    if: github.repository == 'openssl/openssl'
     needs: define-matrix
     permissions:
       checks: write     # for coverallsapp/github-action to create new checks

--- a/.github/workflows/interop-tests.yml
+++ b/.github/workflows/interop-tests.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'openssl/openssl'
     runs-on: ubuntu-22.04
     container:
       image: docker.io/fedora:40
@@ -54,6 +55,7 @@ jobs:
           openssl version
           echo "Finished - important to prevent unwanted output truncating"
   openssh_interop:
+    if: github.repository == 'openssl/openssl'
     name: "openssh interop ${{ matrix.branch.openssl }}"
     strategy:
       fail-fast: false

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   alpine:
+    if: github.repository == 'openssl/openssl'
     strategy:
       fail-fast: false
       matrix:
@@ -52,6 +53,7 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   linux:
+    if: github.repository == 'openssl/openssl'
     strategy:
       fail-fast: false
       matrix:
@@ -101,6 +103,7 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   macos:
+    if: github.repository == 'openssl/openssl'
     strategy:
       fail-fast: false
       matrix:
@@ -124,6 +127,7 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   windows:
+    if: github.repository == 'openssl/openssl'
     strategy:
       fail-fast: false
       matrix:
@@ -245,6 +249,7 @@ jobs:
 
   freebsd-x86_64:
     runs-on: ubuntu-latest
+    if: github.repository == 'openssl/openssl'
     steps:
     - uses: actions/checkout@v4
     - name: config

--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -28,6 +28,7 @@ env:
 
 jobs:
   fips-releases:
+    if: github.repository == 'openssl/openssl'
     strategy:
       matrix:
         release: [
@@ -103,6 +104,7 @@ jobs:
           retention-days: 7
 
   development-branches:
+    if: github.repository == 'openssl/openssl'
     strategy:
       matrix:
         branch: [
@@ -203,6 +205,7 @@ jobs:
           retention-days: 7
 
   cross-testing:
+    if: github.repository == 'openssl/openssl'
     needs: [fips-releases, development-branches]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/riscv-more-cross-compiles.yml
+++ b/.github/workflows/riscv-more-cross-compiles.yml
@@ -26,7 +26,7 @@ jobs:
     # push event commit message contains '[riscv ci]'
     # cron job
     # manual dispatch
-    if: contains(github.event.pull_request.title, 'riscv') || contains(github.event.pull_request.title, 'RISC-V') || contains(github.event.pull_request.body, '[riscv ci]') || contains(github.event.head_commit.message, '[riscv ci]') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: contains(github.event.pull_request.title, 'riscv') || contains(github.event.pull_request.title, 'RISC-V') || contains(github.event.pull_request.body, '[riscv ci]') || contains(github.event.head_commit.message, '[riscv ci]') || (github.event_name == 'schedule' && github.repository == 'openssl/openssl') || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   run-checker:
+    if: github.repository == 'openssl/openssl'
     strategy:
       fail-fast: false
       matrix:
@@ -154,6 +155,7 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   run-checker-sctp:
+    if: github.repository == 'openssl/openssl'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -193,6 +195,7 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   enable_brotli_dynamic:
+    if: github.repository == 'openssl/openssl'
     runs-on: ubuntu-latest
     steps:
     - name: install brotli
@@ -215,6 +218,7 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   enable_zstd_dynamic:
+    if: github.repository == 'openssl/openssl'
     runs-on: ubuntu-latest
     steps:
     - name: install zstd
@@ -237,6 +241,7 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   enable_brotli_and_zstd_dynamic:
+    if: github.repository == 'openssl/openssl'
     runs-on: ubuntu-latest
     steps:
     - name: install brotli and zstd
@@ -260,6 +265,7 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   malloc_failure_testing:
+    if: github.repository == 'openssl/openssl'
     runs-on: ubuntu-latest
     steps:
     - name: checkout openssl
@@ -282,6 +288,7 @@ jobs:
         make TESTS=test_handshake-memfail test
 
   enable_brotli_and_asan_ubsan:
+    if: github.repository == 'openssl/openssl'
     runs-on: ubuntu-latest
     steps:
     - name: install brotli
@@ -308,6 +315,7 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4} OPENSSL_TEST_RAND_ORDER=0
 
   enable_zstd_and_asan_ubsan:
+    if: github.repository == 'openssl/openssl'
     runs-on: ubuntu-latest
     steps:
     - name: install zstd
@@ -334,6 +342,7 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4} OPENSSL_TEST_RAND_ORDER=0
 
   enable_tfo:
+    if: github.repository == 'openssl/openssl'
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-15, macos-15-large ]
@@ -352,6 +361,7 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   enable_buildtest:
+    if: github.repository == 'openssl/openssl'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -369,6 +379,7 @@ jobs:
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   memory_sanitizer_slh_dsa:
+    if: github.repository == 'openssl/openssl'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
There is no reason to run them in forks, and some of them fail because they try to run on macos-15-large which is not generally available.
