### PR TITLE
Modernize header macros for C23 compatibility

### DIFF
--- a/include/openssl/dh.h
+++ b/include/openssl/dh.h
@@ -175,10 +175,10 @@ DECLARE_ASN1_ITEM(DHparams)
 #   define DH_CHECK_P_NOT_STRONG_PRIME     DH_CHECK_P_NOT_SAFE_PRIME
 
 #   define d2i_DHparams_fp(fp, x) \
-        (DH *)ASN1_d2i_fp((char *(*)())DH_new, \
-                          (char *(*)())d2i_DHparams, \
+        (DH *)ASN1_d2i_fp((void *(*)(void))DH_new, \
+                          (d2i_of_void *)d2i_DHparams, \
                           (fp), \
-                          (unsigned char **)(x))
+                          (void **)(x))
 #   define i2d_DHparams_fp(fp, x) \
         ASN1_i2d_fp(i2d_DHparams,(fp), (unsigned char *)(x))
 #   define d2i_DHparams_bio(bp, x) \
@@ -187,10 +187,10 @@ DECLARE_ASN1_ITEM(DHparams)
         ASN1_i2d_bio_of(DH, i2d_DHparams, bp, x)
 
 #   define d2i_DHxparams_fp(fp,x) \
-        (DH *)ASN1_d2i_fp((char *(*)())DH_new, \
-                          (char *(*)())d2i_DHxparams, \
+        (DH *)ASN1_d2i_fp((void *(*)(void))DH_new, \
+                          (d2i_of_void *)d2i_DHxparams, \
                           (fp), \
-                          (unsigned char **)(x))
+                          (void **)(x))
 #   define i2d_DHxparams_fp(fp, x) \
         ASN1_i2d_fp(i2d_DHxparams,(fp), (unsigned char *)(x))
 #   define d2i_DHxparams_bio(bp, x) \

--- a/include/openssl/dsa.h
+++ b/include/openssl/dsa.h
@@ -104,9 +104,9 @@ int DSA_SIG_set0(DSA_SIG *sig, BIGNUM *r, BIGNUM *s);
 /* typedef struct dsa_method DSA_METHOD; */
 
 #   define d2i_DSAparams_fp(fp, x) \
-        (DSA *)ASN1_d2i_fp((char *(*)())DSA_new, \
-                           (char *(*)())d2i_DSAparams, (fp), \
-                           (unsigned char **)(x))
+        (DSA *)ASN1_d2i_fp((void *(*)(void))DSA_new, \
+                           (d2i_of_void *)d2i_DSAparams, (fp), \
+                           (void **)(x))
 #   define i2d_DSAparams_fp(fp, x) \
         ASN1_i2d_fp(i2d_DSAparams, (fp), (unsigned char *)(x))
 #   define d2i_DSAparams_bio(bp, x) \

--- a/include/openssl/ocsp.h.in
+++ b/include/openssl/ocsp.h.in
@@ -142,19 +142,19 @@ typedef struct ocsp_service_locator_st OCSP_SERVICELOC;
 #  define d2i_OCSP_RESPONSE_bio(bp,p) ASN1_d2i_bio_of(OCSP_RESPONSE,OCSP_RESPONSE_new,d2i_OCSP_RESPONSE,bp,p)
 
 #  define PEM_read_bio_OCSP_REQUEST(bp,x,cb) (OCSP_REQUEST *)PEM_ASN1_read_bio( \
-     (char *(*)())d2i_OCSP_REQUEST,PEM_STRING_OCSP_REQUEST, \
+     (d2i_of_void *)d2i_OCSP_REQUEST,PEM_STRING_OCSP_REQUEST, \
      bp,(char **)(x),cb,NULL)
 
 #  define PEM_read_bio_OCSP_RESPONSE(bp,x,cb) (OCSP_RESPONSE *)PEM_ASN1_read_bio(\
-     (char *(*)())d2i_OCSP_RESPONSE,PEM_STRING_OCSP_RESPONSE, \
+     (d2i_of_void *)d2i_OCSP_RESPONSE,PEM_STRING_OCSP_RESPONSE, \
      bp,(char **)(x),cb,NULL)
 
 #  define PEM_write_bio_OCSP_REQUEST(bp,o) \
-    PEM_ASN1_write_bio((int (*)())i2d_OCSP_REQUEST,PEM_STRING_OCSP_REQUEST,\
+    PEM_ASN1_write_bio((i2d_of_void *)i2d_OCSP_REQUEST,PEM_STRING_OCSP_REQUEST,\
                         bp,(char *)(o), NULL,NULL,0,NULL,NULL)
 
 #  define PEM_write_bio_OCSP_RESPONSE(bp,o) \
-    PEM_ASN1_write_bio((int (*)())i2d_OCSP_RESPONSE,PEM_STRING_OCSP_RESPONSE,\
+    PEM_ASN1_write_bio((i2d_of_void *)i2d_OCSP_RESPONSE,PEM_STRING_OCSP_RESPONSE,\
                         bp,(char *)(o), NULL,NULL,0,NULL,NULL)
 
 #  define i2d_OCSP_RESPONSE_bio(bp,o) ASN1_i2d_bio_of(OCSP_RESPONSE,i2d_OCSP_RESPONSE,bp,o)


### PR DESCRIPTION
Replace old-style (int (*)()) and (char *(*)()) casts with proper typed
prototypes (i2d_of_void *, d2i_of_void *, void *(*)(void)) to comply
with stricter C23 function pointer rules.

Fixes #27938

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
