### PR TITLE
provider_core: make provider_name API slightly safer

### DIFF
--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -414,7 +414,6 @@ int ossl_method_store_add(OSSL_METHOD_STORE *store, const OSSL_PROVIDER *prov,
             BIO_printf(trc_out, "Adding to method store "
                        "nid: %d\nproperties: %s\nprovider: %s\n",
                        nid, properties,
-                       ossl_provider_name(prov) == NULL ? "none" :
                        ossl_provider_name(prov));
         } OSSL_TRACE_END(QUERY);
 #endif
@@ -512,7 +511,6 @@ alg_cleanup_by_provider(ossl_uintmax_t idx, ALGORITHM *alg, void *arg)
                 BIO_printf(trc_out, "Removing implementation from "
                            "query cache\nproperties %s\nprovider %s\n",
                            size == 0 ? "none" : buf,
-                           ossl_provider_name(impl->provider) == NULL ? "none" :
                            ossl_provider_name(impl->provider));
             } OSSL_TRACE_END(QUERY);
 #endif

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1689,6 +1689,8 @@ int OSSL_PROVIDER_available(OSSL_LIB_CTX *libctx, const char *name)
 /* Getters of Provider Object data */
 const char *ossl_provider_name(const OSSL_PROVIDER *prov)
 {
+    if (prov == NULL || prov->name == NULL)
+        return "none";
     return prov->name;
 }
 


### PR DESCRIPTION
Getting provider from other structs can return NULL, because provider
is not bound yet - this is common with EVP_MD. In such cases getting
provider name can lead to a NULL pointer dereference.

It would be nicer if segfault didn't happen, and something more well
defined is returned. Options are:

- return NULL (feels like it will push segfault to the next caller)
- return "" (feels like empty strings will be printed)
- return "none" (is already used when provider is nameless)
