### PR TITLE
Replace paid runners with free ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         path: artifacts.tar.gz
 
   linux-arm64:
-    runs-on: ${{ github.repository == 'openssl/openssl' && 'linux-arm64' || 'ubuntu-24.04-arm' }}
+    runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v4
     - name: config

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-14-large, macos-15, macos-15-large]
+        os: [macos-14, macos-15, macos-15-intel]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -174,8 +174,7 @@ jobs:
         nmake test VERBOSE_FAILURE=yes HARNESS_JOBS=4
 
   linux-arm64:
-    runs-on: linux-arm64
-    if: github.repository == 'openssl/openssl'
+    runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v4
     - name: config

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -336,7 +336,7 @@ jobs:
   enable_tfo:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-15, macos-15-large ]
+        os: [ubuntu-latest, macos-15, macos-15-intel]
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub [provides](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories) free runners for both MacOS x86_64 and Linux aarch64 platforms. No need to use paid runners anymore.