### PR TITLE
Enable AES and SHA3 optimisations on Apple Silicon M5-based macOS systems

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -297,7 +297,8 @@ void OPENSSL_cpuid_setup(void)
                ((strncmp(uarch, "Apple M1", 8) == 0) ||
                 (strncmp(uarch, "Apple M2", 8) == 0) ||
                 (strncmp(uarch, "Apple M3", 8) == 0) ||
-                (strncmp(uarch, "Apple M4", 8) == 0))) {
+                (strncmp(uarch, "Apple M4", 8) == 0) ||
+                (strncmp(uarch, "Apple M5", 8) == 0))) {
                 OPENSSL_armcap_P |= ARMV8_UNROLL8_EOR3;
                 OPENSSL_armcap_P |= ARMV8_HAVE_SHA3_AND_WORTH_USING;
             }


### PR DESCRIPTION
ARMV8_UNROLL8_EOR3 gives a performance improvement of 6-35%.

ARMV8_HAVE_SHA3_AND_WORTH_USING gives 3-4% improvement.

Still no performance gain from ARMV8_UNROLL12_EOR3.

Reviewed and approved internally