### PR TITLE
Derive EC public key from private key if missing

### DIFF
--- a/crypto/ec/ec_backend.c
+++ b/crypto/ec/ec_backend.c
@@ -483,6 +483,15 @@ int ossl_ec_key_fromdata(EC_KEY *ec, const OSSL_PARAM params[], int include_priv
         && !EC_KEY_set_public_key(ec, pub_point))
         goto err;
 
+    /* Fallback computation of public key if not provided */
+    if (priv_key != NULL && pub_point == NULL) {
+        if ((pub_point = EC_POINT_new(ecg)) == NULL
+            || !EC_KEY_set_public_key(ec, pub_point))
+            goto err;
+        if (!ossl_ec_key_simple_generate_public_key(ec))
+            goto err;
+    }
+
     ok = 1;
 
 err:

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1477,13 +1477,11 @@ static int test_EC_priv_pub(void)
     bld = NULL;
 
     /*
-     * We indicate only parameters here, in spite of having built a key that
-     * has a private part, because the PEM_write_bio_PrivateKey_ex call is
-     * expected to fail because it does not support exporting a private EC
-     * key without a corresponding public key
+     * ossl_ec_key_fromdata() automatically generates the public key on import
+     * if one is not provided, so fail the test if a public key is not
+     * available.
      */
-    if (!test_selection(params_and_priv, OSSL_KEYMGMT_SELECT_ALL_PARAMETERS)
-        || test_selection(params_and_priv, OSSL_KEYMGMT_SELECT_PUBLIC_KEY))
+    if (!test_selection(params_and_priv, OSSL_KEYMGMT_SELECT_KEYPAIR))
         goto err;
 
     /* Test !priv and pub */


### PR DESCRIPTION
Most of the key management implementations seem to generate public key material from private keys when the public key is not provided on import, however this is not available for classic EC keys.

This PR: https://github.com/latchset/kryoptic/pull/357 tests (and depends on) this functionality for Edwards and Montgomery Curves as well as Mldsa, Mlkem and Slhdsa.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
