### PR TITLE
PBKDF2: FIPS bounds checking cleanup.

### DIFF
--- a/test/evp_kdf_test.c
+++ b/test/evp_kdf_test.c
@@ -1019,6 +1019,7 @@ static int test_kdf_pbkdf2_small_salt(void)
     unsigned int iterations = 4096;
     int mode = 0;
     OSSL_PARAM *params;
+    unsigned char out[25];
 
     params = construct_pbkdf2_params("passwordPASSWORDpassword", "sha256",
                                      "saltSALT",
@@ -1027,7 +1028,7 @@ static int test_kdf_pbkdf2_small_salt(void)
     if (!TEST_ptr(params)
         || !TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_PBKDF2))
         /* A salt that is too small should fail */
-        || !TEST_false(EVP_KDF_CTX_set_params(kctx, params)))
+        || !TEST_int_eq(EVP_KDF_derive(kctx, out, sizeof(out), params), 0))
         goto err;
 
     ret = 1;
@@ -1044,6 +1045,7 @@ static int test_kdf_pbkdf2_small_iterations(void)
     unsigned int iterations = 1;
     int mode = 0;
     OSSL_PARAM *params;
+    unsigned char out[25];
 
     params = construct_pbkdf2_params("passwordPASSWORDpassword", "sha256",
                                      "saltSALTsaltSALTsaltSALTsaltSALTsalt",
@@ -1052,7 +1054,7 @@ static int test_kdf_pbkdf2_small_iterations(void)
     if (!TEST_ptr(params)
         || !TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_PBKDF2))
         /* An iteration count that is too small should fail */
-        || !TEST_false(EVP_KDF_CTX_set_params(kctx, params)))
+        || !TEST_int_eq(EVP_KDF_derive(kctx, out, sizeof(out), params), 0))
         goto err;
 
     ret = 1;
@@ -1088,8 +1090,7 @@ static int test_kdf_pbkdf2_small_salt_pkcs5(void)
     mode_params[1] = OSSL_PARAM_construct_end();
 
     /* If the "pkcs5" mode is disabled then the derive will now fail */
-    if (!TEST_true(EVP_KDF_CTX_set_params(kctx, mode_params))
-        || !TEST_int_eq(EVP_KDF_derive(kctx, out, sizeof(out), NULL), 0))
+    if (!TEST_int_eq(EVP_KDF_derive(kctx, out, sizeof(out), mode_params), 0))
         goto err;
 
     ret = 1;
@@ -1116,8 +1117,7 @@ static int test_kdf_pbkdf2_small_iterations_pkcs5(void)
     if (!TEST_ptr(params)
         || !TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_PBKDF2))
         /* An iteration count that is too small will pass in pkcs5 mode */
-        || !TEST_true(EVP_KDF_CTX_set_params(kctx, params))
-        || !TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out), NULL), 0))
+        || !TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out), params), 0))
         goto err;
 
     mode = 0;
@@ -1125,8 +1125,7 @@ static int test_kdf_pbkdf2_small_iterations_pkcs5(void)
     mode_params[1] = OSSL_PARAM_construct_end();
 
     /* If the "pkcs5" mode is disabled then the derive will now fail */
-    if (!TEST_true(EVP_KDF_CTX_set_params(kctx, mode_params))
-        || !TEST_int_eq(EVP_KDF_derive(kctx, out, sizeof(out), NULL), 0))
+    if (!TEST_int_eq(EVP_KDF_derive(kctx, out, sizeof(out), mode_params), 0))
         goto err;
 
     ret = 1;

--- a/test/recipes/30-test_evp_data/evpkdf_pbkdf2.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_pbkdf2.txt
@@ -232,13 +232,14 @@ Title = FIPS indicator tests
 
 # Test that operations with unapproved parameters are rejected
 Availablein = fips
-FIPSversion = >=3.4.0
+FIPSversion = >=4.0.0
 KDF = PBKDF2
 Ctrl.pass = pass:password
 Ctrl.salt = salt:salt
 Ctrl.iter = iter:4096
 Ctrl.digest = digest:sha1
-Result = KDF_CTRL_ERROR
+Output = 0102030405060708091011121314
+Result = KDF_DERIVE_ERROR
 Reason = invalid salt length
 
 # Test that operations with unapproved parameters are reported as unapproved
@@ -268,12 +269,14 @@ Output = 043c508e57c6427036fd2c6cd2a02ec7530a412c
 Title = Test that a too low iteration count raises an error
 
 Availablein = fips
+FIPSversion = >=4.0.0
 KDF = PBKDF2
 Ctrl.pass = pass:password
 Ctrl.salt = salt:saltydaysarethebest
 Ctrl.iter = iter:10
 Ctrl.digest = digest:sha1
-Result = KDF_CTRL_ERROR
+Output = 0102030405060708091011121314
+Result = KDF_DERIVE_ERROR
 Reason = invalid iteration count
 
 Availablein = default
@@ -282,5 +285,29 @@ Ctrl.pass = pass:password
 Ctrl.salt = salt:salt
 Ctrl.iter = iter:0
 Ctrl.digest = digest:sha1
-Result = KDF_CTRL_ERROR
+Result = KDF_DERIVE_ERROR
 Reason = invalid iteration count
+
+Title = Test that a small key length raises an error
+
+Availablein = fips
+FIPSversion = >=4.0.0
+KDF = PBKDF2
+Ctrl.pass = pass:password
+Ctrl.salt = salt:saltydaysarethebest
+Ctrl.iter = iter:1000
+Ctrl.digest = digest:sha1
+Output = 01020304050607080910111213
+Result = KDF_DERIVE_ERROR
+Reason = key size too small
+
+Availablein = fips
+FIPSversion = >=4.0.0
+KDF = PBKDF2
+Ctrl.pkcs5 = pkcs5:1
+Unapproved = 1
+Ctrl.pass = pass:password
+Ctrl.salt = salt:saltydaysarethebest
+Ctrl.iter = iter:1000
+Ctrl.digest = digest:sha1
+Output = 8915d6c7940f9f9f


### PR DESCRIPTION
For PBKDF2
set_ctx_params() accepts a "pkcs5" parameter which was being used inside set_ctx_params() to control logic related to other parameters. Since set_ctx_params() can be called multiple times we should not rely on the order, and those checks should be deferred until after all set_ctx_params() calls. This can only happen in the derive(). This aligns with the documentation that says that the approved indicator should only be read after the derive().

The actual lower bounds check runs similiar code for both the FIPS and non FIPS cases, so the code has been reworked to make it easier to follow.

Note that this will break evp_tests since the 'Result' field will change, and these tests will need to be backported.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
