### PR TITLE
jitter: add enable-jitter-dynamic configure option

### DIFF
--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -41,18 +41,33 @@ jobs:
           no-tls1_2,
           no-tls1_3,
           enable-trace enable-fips,
+          enable-jitter-dynamic,
           no-ui,
           no-quic
         ]
     runs-on: ubuntu-latest
     steps:
+    - name: checkout jitter
+      uses: actions/checkout@v5
+      with:
+        repository: smuellerDD/jitterentropy-library
+        ref: v3.6.3
+        path: jitter
+        persist-credentials: false
+    - name: build jitter
+      run: |
+        pushd jitter/
+        make
+        ln -s libjitterentropy.so.3.6.3 libjitterentropy.so
+        ln -s libjitterentropy.so.3.6.3 libjitterentropy.so.3
+        popd
     - uses: actions/checkout@v6
       with:
         persist-credentials: false
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
-      run: CC=clang ./config --banner=Configured --strict-warnings ${{ matrix.opt }}
+      run: CC=clang ./config --banner=Configured --strict-warnings ${{ matrix.opt }} --with-jitter-include=jitter/ --with-jitter-lib=jitter/
     - name: config dump
       run: ./configdata.pm --dump
     - name: make
@@ -63,5 +78,5 @@ jobs:
         if [ -x apps/openssl ] ; then ./util/opensslwrap.sh version -c ; fi
     - name: Check platform symbol usage
       run: ./util/checkplatformsyms.pl ./util/platform_symbols/unix-symbols.txt ./libcrypto.so ./libssl.so
-    - name: make test
+    - name: LD_LIBRARY_PATH=$PWD/jitter:$LD_LIBRARY_PATH make test
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -198,6 +198,41 @@ jobs:
       if: steps.sctp_auth.outcome == 'success' && steps.sctp_auth.conclusion == 'success'
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
+  enable-jitter-dynamic:
+    if: github.repository == 'openssl/openssl'
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout jitter
+      uses: actions/checkout@v5
+      with:
+        repository: smuellerDD/jitterentropy-library
+        ref: v3.6.3
+        path: jitter
+        persist-credentials: false
+    - name: build jitter
+      run: |
+        pushd jitter/
+        make
+        ln -s libjitterentropy.so.3.6.3 libjitterentropy.so
+        ln -s libjitterentropy.so.3.6.3 libjitterentropy.so.3
+        popd
+    - name: checkout openssl
+      uses: actions/checkout@v5
+      with:
+        persist-credentials: false
+    - name: checkout fuzz/corpora submodule
+      run: git submodule update --init --depth 1 fuzz/corpora
+    - name: config
+      run: ./config --with-rand-seed=none enable-jitter-dynamic enable-fips-jitter --with-jitter-include=jitter/ --with-jitter-lib=jitter/ -DOPENSSL_DEFAULT_SEED_SRC=JITTER && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: get cpu info
+      run: |
+        cat /proc/cpuinfo
+        ./util/opensslwrap.sh version -c
+    - name: make test
+      run: LD_LIBRARY_PATH=$PWD/jitter:$LD_LIBRARY_PATH make test HARNESS_JOBS=${HARNESS_JOBS:-4}
+
   enable_brotli_dynamic:
     if: github.repository == 'openssl/openssl'
     runs-on: ubuntu-latest

--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -107,7 +107,10 @@ my %targets=(
         ex_libs         =>
             sub {
                 my @libs = ();
-                push(@libs, "-l:libjitterentropy.a") if !defined($disabled{jitter});
+                if (!defined($disabled{jitter})) {
+                    push(@libs, "-l:libjitterentropy.a") if defined($disabled{"jitter-dynamic"});
+                    push(@libs, "-l:libjitterentropy.so") if !defined($disabled{"jitter-dynamic"});
+                }
                 push(@libs, "-lz") if !defined($disabled{zlib}) && defined($disabled{"zlib-dynamic"});
                 if (!defined($disabled{brotli}) && defined($disabled{"brotli-dynamic"})) {
                     push(@libs, "-lbrotlienc");

--- a/Configure
+++ b/Configure
@@ -486,6 +486,7 @@ my @disablables = (
     "idea",
     "integrity-only-ciphers",
     "jitter",
+    "jitter-dynamic",
     "kbkdf",
     "krb5kdf",
     "ktls",
@@ -621,6 +622,7 @@ our %disabled = ( # "what"         => "comment"
                   "fuzz-libfuzzer"      => "default",
                   "pie"                 => "default",
                   "jitter"              => "default",
+                  "jitter-dynamic"      => "default",
                   "ktls"                => "default",
                   "lms"                 => "default",
                   "md2"                 => "default",
@@ -974,6 +976,10 @@ while (@argvcopy)
                 elsif ($1 eq "fips-jitter")
                         {
                         delete $disabled{"fips"};
+                        delete $disabled{"jitter"};
+                        }
+                elsif ($1 eq "jitter-dynamic")
+                        {
                         delete $disabled{"jitter"};
                         }
                 elsif (exists $deprecated_disablables{$1})

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -531,10 +531,10 @@ at the end of this document.
 
 ### jitter
 
-When configured with `enable-jitter`, a "JITTER" RNG is compiled that
-can provide an alternative software seed source. It can be configured
-by setting `seed` option in `openssl.cnf`. A minimal `openssl.cnf` is
-shown below:
+When configured with `enable-jitter` or `enable-jitter-dynamic`, a
+"JITTER" RNG is compiled that can provide an alternative software seed
+source. It can be configured by setting `seed` option in `openssl.cnf`.
+A minimal `openssl.cnf` is shown below:
 
     openssl_conf = openssl_init
 
@@ -544,7 +544,8 @@ shown below:
     [random]
     seed=JITTER
 
-It uses a statically linked [jitterentropy-library] as the seed source.
+It uses a statically linked [jitterentropy-library] as the seed source or
+dynamically linked when configured with `enable-jitter-dynamic`.
 
 Additional configuration flags available:
 
@@ -555,8 +556,8 @@ it is outside the system include path.
 
     --with-jitter-lib=DIR
 
-This is the directory containing the static libjitterentropy.a
-library, if it is outside the system library path.
+This is the directory containing the static libjitterentropy.a or the
+libjitterentropy.so library, if it is outside the system library path.
 
 Setting the FIPS HMAC key
 -------------------------

--- a/doc/man7/EVP_RAND-JITTER.pod
+++ b/doc/man7/EVP_RAND-JITTER.pod
@@ -13,8 +13,9 @@ This software seed source produces randomness based on tiny CPU
 "jitter" fluctuations.
 
 It is available when OpenSSL is compiled with B<enable-jitter>
-option. When available it is listed in B<openssl list
--random-generators> and B<openssl info -seeds>.
+option or B<enable-jitter-dynamic>. The first statically links the
+library while the second dynamically links it. When available it is
+listed in B<openssl list -random-generators> and B<openssl info -seeds>.
 
 =head2 Identity
 
@@ -45,6 +46,8 @@ A context for the seed source can be obtained by calling:
  EVP_RAND_CTX *rctx = EVP_RAND_CTX_new(rand, NULL);
 
 The B<enable-jitter> option was added in OpenSSL 3.4.
+
+The B<enable-jitter-dynamic> option was added in OpenSSL 4.0.
 
 By specifying the B<enable-fips-jitter> configuration option, the FIPS
 provider will use an internal jitter source for its entropy.  Enabling


### PR DESCRIPTION
Add a new configure option called enable-jitter-dynamic to allow building with jitterentropy using the dynamic libjitterentropy.so library instead of only allowing the static libjitterentropy.a.

- [x] documentation is added or updated
- [x] tests are added or updated
