### PR TITLE
Note about different exclusion of GREASE extensions in SSL_client_hello_* functions

### DIFF
--- a/doc/man3/SSL_CTX_set_client_hello_cb.pod
+++ b/doc/man3/SSL_CTX_set_client_hello_cb.pod
@@ -69,6 +69,9 @@ holding the numerical value of the TLS extension types in the order they appear
 in the ClientHello.  B<*outlen> contains the number of elements in the array.
 In situations when the ClientHello has no extensions, the function will return
 success with B<*out> set to NULL and B<*outlen> set to 0.
+Note that SSL_client_hello_get1_extensions_present() returns only recognised
+extensions; therefore, unrecognised (including GREASE) extensions will not
+appear in the output.
 
 SSL_client_hello_get_extension_order() is similar to
 SSL_client_hello_get1_extensions_present(), without internal memory allocation.
@@ -101,8 +104,12 @@ not use a servername callback, in order to avoid unexpected behavior that
 occurs due to the relative order of processing between things like session
 resumption and the historical servername callback.
 
-The SSL_client_hello_* family of functions may only be called from code executing
-within a ClientHello callback.
+The SSL_client_hello_* family of functions may only be called from code
+executing within a ClientHello callback.
+
+The SSL_client_hello_get0_*() functions return raw ClientHello data, whereas
+SSL_client_hello_get1_extensions_present() returns only recognized extensions
+(so unknown/GREASE-extensions are not included).
 
 =head1 RETURN VALUES
 


### PR DESCRIPTION
Fixes #27580

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
