### PR TITLE
Fixing comment out tests for DTLS1.3

### DIFF
--- a/include/internal/recordmethod.h
+++ b/include/internal/recordmethod.h
@@ -328,6 +328,11 @@ struct ossl_record_method_st {
     int (*get_epoch)(OSSL_RECORD_LAYER *rl, uint16_t *epoch);
 
     /*
+     * Set the current MTU length to be used for the record layer.
+     */
+    int (*set_curr_mtu)(OSSL_RECORD_LAYER *rl, size_t curr_mtu);
+
+    /*
      * Allocate read or write buffers. Does nothing if already allocated.
      * Assumes default buffer length and 1 pipeline.
      */

--- a/include/internal/recordmethod.h
+++ b/include/internal/recordmethod.h
@@ -313,6 +313,21 @@ struct ossl_record_method_st {
     int (*increment_sequence_ctr)(OSSL_RECORD_LAYER *rl);
 
     /*
+     * Get the Sequence number
+     */
+    int (*get_sequence)(OSSL_RECORD_LAYER *rl, uint64_t *sequence);
+
+    /*
+     * Set the Sequence number to a specific value
+     */
+    int (*set_sequence)(OSSL_RECORD_LAYER *rl, uint64_t sequence);
+
+    /*
+     * Get the Epoch value
+     */
+    int (*get_epoch)(OSSL_RECORD_LAYER *rl, uint16_t *epoch);
+
+    /*
      * Allocate read or write buffers. Does nothing if already allocated.
      * Assumes default buffer length and 1 pipeline.
      */

--- a/ssl/d1_msg.c
+++ b/ssl/d1_msg.c
@@ -19,6 +19,13 @@ int dtls1_write_app_data_bytes(SSL *s, uint8_t type, const void *buf_,
     if (sc == NULL)
         return -1;
 
+    /*
+     * If we are supposed to be sending a KeyUpdate or NewSessionTicket then go
+     * into init - in which case we should finish doing that first.
+     */
+    if (sc->key_update != SSL_KEY_UPDATE_NONE || sc->ext.extra_tickets_expected > 0)
+        ossl_statem_set_in_init(sc, 1);
+
     if (SSL_in_init(s) && !ossl_statem_get_in_handshake(sc)) {
         i = sc->handshake_func(s);
         if (i < 0)

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -592,6 +592,9 @@ static const OSSL_RECORD_METHOD quic_tls_record_method = {
     quic_set_max_frag_len,
     quic_get_max_record_overhead, /* Never called */
     quic_increment_sequence_ctr, /* Never called */
+    NULL,
+    NULL,
+    NULL,
     quic_alloc_buffers,
     quic_free_buffers
 };

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -595,6 +595,7 @@ static const OSSL_RECORD_METHOD quic_tls_record_method = {
     NULL,
     NULL,
     NULL,
+    NULL,
     quic_alloc_buffers,
     quic_free_buffers
 };

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -961,19 +961,19 @@ static size_t dtls_get_max_record_overhead(OSSL_RECORD_LAYER *rl)
     return rchdrlen + rl->eivlen + blocksize + rl->taglen + contenttypelen;
 }
 
-int dtls_get_sequence_number(OSSL_RECORD_LAYER *rl, uint64_t *sequence)
+static int dtls_get_sequence_number(OSSL_RECORD_LAYER *rl, uint64_t *sequence)
 {
     *sequence = rl->sequence;
     return 1;
 }
 
-int dtls_set_sequence_number(OSSL_RECORD_LAYER *rl, uint64_t sequence)
+static int dtls_set_sequence_number(OSSL_RECORD_LAYER *rl, uint64_t sequence)
 {
     rl->sequence = sequence;
     return 1;
 }
 
-int dtls_get_epoch(OSSL_RECORD_LAYER *rl, uint16_t *epoch)
+static int dtls_get_epoch(OSSL_RECORD_LAYER *rl, uint16_t *epoch)
 {
     *epoch = rl->epoch;
     return 1;

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -979,6 +979,12 @@ static int dtls_get_epoch(OSSL_RECORD_LAYER *rl, uint16_t *epoch)
     return 1;
 }
 
+static int dtls_set_curr_mtu(OSSL_RECORD_LAYER *rl, size_t mtu)
+{
+    rl->curr_mtu = mtu;
+    return 1;
+}
+
 const OSSL_RECORD_METHOD ossl_dtls_record_method = {
     dtls_new_record_layer,
     dtls_free,
@@ -1006,6 +1012,7 @@ const OSSL_RECORD_METHOD ossl_dtls_record_method = {
     dtls_get_sequence_number,
     dtls_set_sequence_number,
     dtls_get_epoch,
+    dtls_set_curr_mtu,
     tls_alloc_buffers,
     tls_free_buffers
 };

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -662,8 +662,8 @@ int dtls_get_more_records(OSSL_RECORD_LAYER *rl)
      */
     if (DTLS13_UNI_HDR_FIX_BITS_IS_SET(rr->type)
             && rl->version == DTLS1_3_VERSION
-            && ossl_assert(rl->sn_enc_ctx != NULL)
-            && (!ossl_assert(rl->packet_length >= rechdrlen + DTLS13_CIPHERTEXT_MINSIZE)
+            && rl->sn_enc_ctx != NULL
+            && ((rl->packet_length < rechdrlen + DTLS13_CIPHERTEXT_MINSIZE)
                 || !dtls_crypt_sequence_number(rl->sn_enc_ctx,
                                                recseqnum + recseqnumoffs,
                                                recseqnumlen,
@@ -961,6 +961,24 @@ static size_t dtls_get_max_record_overhead(OSSL_RECORD_LAYER *rl)
     return rchdrlen + rl->eivlen + blocksize + rl->taglen + contenttypelen;
 }
 
+int dtls_get_sequence_number(OSSL_RECORD_LAYER *rl, uint64_t *sequence)
+{
+    *sequence = rl->sequence;
+    return 1;
+}
+
+int dtls_set_sequence_number(OSSL_RECORD_LAYER *rl, uint64_t sequence)
+{
+    rl->sequence = sequence;
+    return 1;
+}
+
+int dtls_get_epoch(OSSL_RECORD_LAYER *rl, uint16_t *epoch)
+{
+    *epoch = rl->epoch;
+    return 1;
+}
+
 const OSSL_RECORD_METHOD ossl_dtls_record_method = {
     dtls_new_record_layer,
     dtls_free,
@@ -985,6 +1003,9 @@ const OSSL_RECORD_METHOD ossl_dtls_record_method = {
     tls_set_max_frag_len,
     dtls_get_max_record_overhead,
     tls_increment_sequence_ctr,
+    dtls_get_sequence_number,
+    dtls_set_sequence_number,
+    dtls_get_epoch,
     tls_alloc_buffers,
     tls_free_buffers
 };

--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -616,6 +616,7 @@ const OSSL_RECORD_METHOD ossl_ktls_record_method = {
     NULL,
     NULL,
     NULL,
+    NULL,
     ktls_alloc_buffers,
     ktls_free_buffers
 };

--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -613,6 +613,9 @@ const OSSL_RECORD_METHOD ossl_ktls_record_method = {
     tls_set_max_frag_len,
     NULL,
     tls_increment_sequence_ctr,
+    NULL,
+    NULL,
+    NULL,
     ktls_alloc_buffers,
     ktls_free_buffers
 };

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -359,6 +359,9 @@ struct ossl_record_layer_st {
     /* renegotiation starts a new set of sequence numbers */
     DTLS_BITMAP next_bitmap;
 
+    /* DTLS curr mtu size */
+    size_t curr_mtu;
+
     /*
      * Whether we are currently in a handshake or not. Only maintained for DTLS
      */

--- a/ssl/record/methods/tls13_meth.c
+++ b/ssl/record/methods/tls13_meth.c
@@ -387,6 +387,7 @@ static int tls13_add_record_padding(OSSL_RECORD_LAYER *rl,
                                     TLS_RL_RECORD *thiswr)
 {
     size_t rlen;
+    size_t max_frag_len = rl->max_frag_len;
 
     /* Nothing to be done in the case of a plaintext alert */
     if (rl->allow_plain_alerts && thistempl->type != SSL3_RT_ALERT)
@@ -398,11 +399,14 @@ static int tls13_add_record_padding(OSSL_RECORD_LAYER *rl,
     }
     TLS_RL_RECORD_add_length(thiswr, 1);
 
+    if (rl->isdtls && rl->curr_mtu != 0 && rl->curr_mtu < max_frag_len)
+        max_frag_len = rl->curr_mtu;
+
     /* Add TLS1.3 padding */
     rlen = TLS_RL_RECORD_get_length(thiswr);
-    if (rlen < rl->max_frag_len) {
+    if (rlen < max_frag_len) {
         size_t padding = 0;
-        size_t max_padding = rl->max_frag_len - rlen;
+        size_t max_padding = max_frag_len - rlen;
 
         /*
          * We might want to change the "else if" below so that

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1265,6 +1265,8 @@ tls_int_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
      */
     rl->max_frag_len = SSL3_RT_MAX_PLAIN_LENGTH;
 
+    rl->curr_mtu = 0;
+
     /* Loop through all the settings since they must all be understood */
     if (settings != NULL) {
         for (p = settings; p->key != NULL; p++) {
@@ -2216,6 +2218,7 @@ const OSSL_RECORD_METHOD ossl_tls_record_method = {
     tls_set_max_frag_len,
     NULL,
     tls_increment_sequence_ctr,
+    NULL,
     NULL,
     NULL,
     NULL,

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -2216,6 +2216,9 @@ const OSSL_RECORD_METHOD ossl_tls_record_method = {
     tls_set_max_frag_len,
     NULL,
     tls_increment_sequence_ctr,
+    NULL,
+    NULL,
+    NULL,
     tls_alloc_buffers,
     tls_free_buffers
 };

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -563,9 +563,8 @@ int dtls1_read_bytes(SSL *s, uint8_t type, uint8_t *recvd_type,
 
         /*
          * To get here we must be trying to read app data but found handshake
-         * data. But if we're trying to read app data, and we're not in init
-         * (which is tested for at the top of this function) then init must be
-         * finished
+         * data. This can be because we are in early data and receive the rest
+         * of the handshake.
          */
 
         /* We found handshake data, so we're going back into init */

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -559,16 +559,13 @@ int dtls1_read_bytes(SSL *s, uint8_t type, uint8_t *recvd_type,
 
     if (!ossl_statem_get_in_handshake(sc)
         && (rr->type == SSL3_RT_HANDSHAKE || rr->type == SSL3_RT_ACK)) {
+        int ined = (sc->early_data_state == SSL_EARLY_DATA_READING);
         /*
          * To get here we must be trying to read app data but found handshake
          * data. But if we're trying to read app data, and we're not in init
          * (which is tested for at the top of this function) then init must be
          * finished
          */
-        if (!ossl_assert(SSL_is_init_finished(s))) {
-            SSLfatal(sc, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-            return -1;
-        }
 
         /* We found handshake data, so we're going back into init */
         ossl_statem_set_in_init(sc, 1);
@@ -578,6 +575,14 @@ int dtls1_read_bytes(SSL *s, uint8_t type, uint8_t *recvd_type,
         if (i < 0)
             return i;
         if (i == 0)
+            return -1;
+
+        /*
+         * If we were actually trying to read early data and we found a
+         * handshake message, then we don't want to continue to try and read
+         * the application data any more. It won't be "early" now.
+         */
+        if (ined)
             return -1;
 
         if (!(sc->mode & SSL_MODE_AUTO_RETRY)) {
@@ -697,8 +702,10 @@ int do_dtls1_write(SSL_CONNECTION *sc, uint8_t type, const unsigned char *buf,
         /* if it went, fall through and send more stuff */
     }
 
-    if (len == 0)
-        return 0;
+    if (len == 0) {
+        *written = 0;
+        return 1;
+    }
 
     if (len > ssl_get_max_send_fragment(sc)) {
         SSLfatal(sc, SSL_AD_INTERNAL_ERROR, SSL_R_EXCEEDS_MAX_FRAGMENT_SIZE);

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -559,7 +559,8 @@ int dtls1_read_bytes(SSL *s, uint8_t type, uint8_t *recvd_type,
 
     if (!ossl_statem_get_in_handshake(sc)
         && (rr->type == SSL3_RT_HANDSHAKE || rr->type == SSL3_RT_ACK)) {
-        int ined = (sc->early_data_state == SSL_EARLY_DATA_READING);
+        int in_early_data = (sc->early_data_state == SSL_EARLY_DATA_READING);
+
         /*
          * To get here we must be trying to read app data but found handshake
          * data. But if we're trying to read app data, and we're not in init
@@ -582,7 +583,7 @@ int dtls1_read_bytes(SSL *s, uint8_t type, uint8_t *recvd_type,
          * handshake message, then we don't want to continue to try and read
          * the application data any more. It won't be "early" now.
          */
-        if (ined)
+        if (in_early_data)
             return -1;
 
         if (!(sc->mode & SSL_MODE_AUTO_RETRY)) {

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1264,7 +1264,7 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
     int use_early_data = 0;
     uint32_t max_early_data;
     COMP_METHOD *compm = (comp == NULL) ? NULL : comp->method;
-    uint16_t epoch;
+    uint16_t epoch_zero;
     uint64_t seq;
 
     meth = ssl_select_next_record_layer(s, direction, level);
@@ -1377,8 +1377,8 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
     if (direction == OSSL_RECORD_DIRECTION_WRITE
             && SSL_CONNECTION_IS_DTLS(s)
             && s->rlayer.wrl != NULL
-            && meth->get_epoch(s->rlayer.wrl, &epoch) == 1
-            && epoch == 0) {
+            && meth->get_epoch(s->rlayer.wrl, &epoch_zero) == 1
+            && epoch_zero == 0) {
         if (meth->get_sequence(s->rlayer.wrl,
                                &seq) != 1) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
@@ -1501,8 +1501,8 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
      */
     if (direction == OSSL_RECORD_DIRECTION_WRITE
             && SSL_CONNECTION_IS_DTLS(s)
-            && meth->get_epoch(newrl, &epoch) == 1
-            && epoch == 0) {
+            && meth->get_epoch(newrl, &epoch_zero) == 1
+            && epoch_zero == 0) {
 
         if (meth->set_sequence(newrl,
                                s->rlayer.wlayer_epoch_zero_sequence) != 1) {

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1264,6 +1264,8 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
     int use_early_data = 0;
     uint32_t max_early_data;
     COMP_METHOD *compm = (comp == NULL) ? NULL : comp->method;
+    uint16_t epoch;
+    uint64_t seq;
 
     meth = ssl_select_next_record_layer(s, direction, level);
 
@@ -1367,6 +1369,24 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
 
     *set = OSSL_PARAM_construct_end();
 
+    /*
+     * For DTLS save off the sequence number for epoch 0 when we are setting up
+     * a new write record layer. This is needed for handling in case of HRR
+     * and we create a new write record layer for epoch 0.
+     */
+    if (direction == OSSL_RECORD_DIRECTION_WRITE
+            && SSL_CONNECTION_IS_DTLS(s)
+            && s->rlayer.wrl != NULL
+            && meth->get_epoch(s->rlayer.wrl, &epoch) == 1
+            && epoch == 0) {
+        if (meth->get_sequence(s->rlayer.wrl,
+                               &seq) != 1) {
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+            return 0;
+        }
+        s->rlayer.wlayer_epoch_zero_sequence = seq;
+    }
+
     for (;;) {
         int rlret;
         BIO *prev = NULL;
@@ -1469,6 +1489,23 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
             || direction == OSSL_RECORD_DIRECTION_READ
             || pqueue_peek(&s->d1->sent_messages) == NULL) {
         if (*thismethod != NULL && !(*thismethod)->free(*thisrl)) {
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+            return 0;
+        }
+    }
+
+    /*
+     * For DTLS if we created a new write record layer
+     * for epoch zero we need to set the sequence number.
+     * This is needed for handling HRR case.
+     */
+    if (direction == OSSL_RECORD_DIRECTION_WRITE
+            && SSL_CONNECTION_IS_DTLS(s)
+            && meth->get_epoch(newrl, &epoch) == 1
+            && epoch == 0) {
+
+        if (meth->set_sequence(newrl,
+                               s->rlayer.wlayer_epoch_zero_sequence) != 1) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
             return 0;
         }

--- a/ssl/record/record.h
+++ b/ssl/record/record.h
@@ -122,6 +122,8 @@ typedef struct record_layer_st {
     /* Record layer data to be processed */
     TLS_RECORD tlsrecs[SSL_MAX_PIPELINES];
 
+    /* DTLS epoch zero write sequence number */
+    uint64_t wlayer_epoch_zero_sequence;
 } RECORD_LAYER;
 
 /*****************************************************************************

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1618,7 +1618,7 @@ int tls_psk_do_binder(SSL_CONNECTION *s, const EVP_MD *md,
     if (s->hello_retry_request == SSL_HRR_PENDING) {
         size_t hdatalen;
         long hdatalen_l;
-        void *hdata;
+        unsigned char *hdata;
 
         hdatalen = hdatalen_l =
             BIO_get_mem_data(s->s3.handshake_buffer, &hdata);
@@ -1627,28 +1627,69 @@ int tls_psk_do_binder(SSL_CONNECTION *s, const EVP_MD *md,
             goto err;
         }
 
-        /*
-         * For servers the handshake buffer data will include the second
-         * ClientHello - which we don't want - so we need to take that bit off.
-         */
-        if (s->server) {
+        if (s->negotiated_version == DTLS1_3_VERSION) {
             PACKET hashprefix, msg;
+            unsigned long dtlsbodylen;
+            unsigned int dtls_offset = DTLS1_HM_HEADER_LENGTH - SSL3_HM_HEADER_LENGTH;
 
-            /* Find how many bytes are left after the first two messages */
+            /*
+             * RFC 9147 states that for DTLS 1.3 all transcripts should be
+             * calculated without the message_seq, fragment_offset and
+             * fragment_length values. See Section 5.2
+             *
+             * Since the data is coming from handshake_buffer it hasn't
+             * been processed in ssl3_finish_mac where these values are
+             * removed. Therefore for both the server and client we will
+             * need to not supply them to the Digest Update
+             */
             if (!PACKET_buf_init(&hashprefix, hdata, hdatalen)
                     || !PACKET_forward(&hashprefix, 1)
                     || !PACKET_get_length_prefixed_3(&hashprefix, &msg)
                     || !PACKET_forward(&hashprefix, 1)
-                    || !PACKET_get_length_prefixed_3(&hashprefix, &msg)) {
+                    || !PACKET_get_net_3(&hashprefix, &dtlsbodylen)) {
                 SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
                 goto err;
             }
-            hdatalen -= PACKET_remaining(&hashprefix);
-        }
 
-        if (EVP_DigestUpdate(mctx, hdata, hdatalen) <= 0) {
-            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-            goto err;
+            hdatalen -= PACKET_remaining(&hashprefix);
+
+            if (EVP_DigestUpdate(mctx, hdata, hdatalen) <= 0) {
+                SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+                goto err;
+            }
+
+            /*
+             * Now skip the four bytes for the part of the DTLS header to not
+             * include in the transcript.
+             */
+            if (EVP_DigestUpdate(mctx, hdata + hdatalen + dtls_offset, dtlsbodylen) <= 0) {
+                SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+                goto err;
+            }
+        } else {
+            /*
+             * For servers the handshake buffer data will include the second
+             * ClientHello - which we don't want - so we need to take that bit off.
+             */
+            if (s->server) {
+                PACKET hashprefix, msg;
+
+                /* Find how many bytes are left after the first two messages */
+                if (!PACKET_buf_init(&hashprefix, hdata, hdatalen)
+                        || !PACKET_forward(&hashprefix, 1)
+                        || !PACKET_get_length_prefixed_3(&hashprefix, &msg)
+                        || !PACKET_forward(&hashprefix, 1)
+                        || !PACKET_get_length_prefixed_3(&hashprefix, &msg)) {
+                    SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+                    goto err;
+                }
+                hdatalen -= PACKET_remaining(&hashprefix);
+            }
+
+            if (EVP_DigestUpdate(mctx, hdata, hdatalen) <= 0) {
+                SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+                goto err;
+            }
         }
     }
 

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -776,6 +776,7 @@ int ossl_statem_dtls_client_use_timer(SSL_CONNECTION *s)
 WORK_STATE ossl_statem_client_pre_work(SSL_CONNECTION *s, WORK_STATE wst)
 {
     OSSL_STATEM *st = &s->statem;
+    const int versionany = SSL_CONNECTION_IS_DTLS(s) ? DTLS_ANY_VERSION : TLS_ANY_VERSION;
 
     switch (st->hand_state) {
     default:
@@ -798,7 +799,7 @@ WORK_STATE ossl_statem_client_pre_work(SSL_CONNECTION *s, WORK_STATE wst)
              * write record layer in order to write in plaintext again.
              */
             if (!ssl_set_new_record_layer(s,
-                                          TLS_ANY_VERSION,
+                                          versionany,
                                           OSSL_RECORD_DIRECTION_WRITE,
                                           OSSL_RECORD_PROTECTION_LEVEL_NONE,
                                           NULL, 0, NULL, NULL, 0, NULL, 0,

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -495,6 +495,10 @@ static WRITE_TRAN ossl_statem_client13_write_transition(SSL_CONNECTION *s)
         /* Fall through */
 
     case TLS_ST_CW_END_OF_EARLY_DATA:
+        if (SSL_CONNECTION_IS_DTLS13(s)) {
+            /* If we are done with early data we need to clean up Epoch 1 messages sent*/
+            dtls1_clear_sent_buffer(s, 0);
+        }
     case TLS_ST_CW_CHANGE:
         if (s->s3.tmp.cert_req == 0)
             st->hand_state = TLS_ST_CW_FINISHED;

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -499,6 +499,8 @@ static WRITE_TRAN ossl_statem_client13_write_transition(SSL_CONNECTION *s)
             /* If we are done with early data we need to clean up Epoch 1 messages sent */
             dtls1_clear_sent_buffer(s, 0);
         }
+        /* Fall through */
+
     case TLS_ST_CW_CHANGE:
         if (s->s3.tmp.cert_req == 0)
             st->hand_state = TLS_ST_CW_FINISHED;

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -496,7 +496,7 @@ static WRITE_TRAN ossl_statem_client13_write_transition(SSL_CONNECTION *s)
 
     case TLS_ST_CW_END_OF_EARLY_DATA:
         if (SSL_CONNECTION_IS_DTLS13(s)) {
-            /* If we are done with early data we need to clean up Epoch 1 messages sent*/
+            /* If we are done with early data we need to clean up Epoch 1 messages sent */
             dtls1_clear_sent_buffer(s, 0);
         }
     case TLS_ST_CW_CHANGE:

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -293,7 +293,10 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t recordtype)
              * then the best thing to do is probably carry on regardless.
              */
             assert(s->s3.tmp.new_compression != NULL
-                   || BIO_wpending(s->wbio) <= (int)s->d1->mtu);
+                   || BIO_wpending(s->wbio) <= (int)s->d1->mtu
+                   || s->rlayer.record_padding_cb != NULL
+                   || s->rlayer.hs_padding != 0
+                   || s->rlayer.block_padding != 0);
 
             if (recordtype == SSL3_RT_HANDSHAKE && !s->d1->retransmitting
                     && s->init_off == 0) {

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -618,7 +618,11 @@ static WRITE_TRAN ossl_statem_server13_write_transition(SSL_CONNECTION *s)
         }
         /* Fall through */
     case TLS_ST_SW_KEY_UPDATE:
-        st->hand_state = TLS_ST_OK;
+        if (SSL_CONNECTION_IS_DTLS13(s))
+            /* We wait for ACK */
+            return WRITE_TRAN_FINISHED;
+        else
+            st->hand_state = TLS_ST_OK;
         return WRITE_TRAN_CONTINUE;
 
     case TLS_ST_SW_SESSION_TICKET:

--- a/test/helpers/ssltestlib.c
+++ b/test/helpers/ssltestlib.c
@@ -761,6 +761,20 @@ static long mempacket_test_ctrl(BIO *bio, int cmd, long num, void *ptr)
     case MEMPACKET_CTRL_SET_DUPLICATE_REC:
         ctx->duprec = (int)num;
         break;
+    /*
+     * TODO (DTLSv1.3):
+     * The dtlstest is setup for DTLS1.2 and a
+     * small MTU. The tests want to drop records
+     * and move packets around. Changing the MTU
+     * will affect the number of records. Thus
+     * several tests will start to fail with this
+     * change. Since dtlstest still needs to be
+     * modified to support DTLS1.3 we should look
+     * at changing this when dtlstest is reworked.
+     * case BIO_CTRL_DGRAM_QUERY_MTU:
+     * ret = 1500;
+     * break;
+     */
     case BIO_CTRL_RESET:
     case BIO_CTRL_DUP:
     case BIO_CTRL_PUSH:

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -4761,7 +4761,7 @@ static int early_data_skip_helper(int testdtls, int testtype, int cipher, int id
             if (testdtls) {
                 /*
                  * Injecting bad DTLS data, but since the sequence number needs
-                 * to be encrypted the SSL_Read below will result in a different
+                 * to be encrypted the SSL_read() below will result in a different
                  * error message. This is cause the packet gets dropped.
                  */
                 if (!TEST_true(BIO_write_ex(wbio, bad_early_data_dtls,
@@ -7065,7 +7065,7 @@ static int verify_stateless_cookie_callback(SSL *ssl, const unsigned char *cooki
 
 /*
  * DTLS does not need to be tested here. Since DTLS has a Sequence number
- * it cannot use SSL_Stateless. If you want to use stateless DTLS
+ * it cannot use SSL_stateless(). If you want to use stateless DTLS
  * use DTLSv1_listen instead. This test is already covered in
  * dtlsv1listentest.c
  */

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -4128,13 +4128,12 @@ static int test_early_data_read_write(int idx)
         testresult = TEST_skip("DTLSv1.3 is not usable");
         goto end;
 # endif
-    }
+    } else {
 # if defined(OSSL_NO_USABLE_TLS1_3)
-    else {
         testresult = TEST_skip("TLSv1.3 is not usable");
         goto end;
-    }
 # endif
+    }
 
     /* Artificially give the next 2 tickets some age for non PSK sessions */
     if (idx != 2)
@@ -7088,9 +7087,9 @@ static int test_stateless(void)
     SSL *serverssl = NULL, *clientssl = NULL;
     int testresult = 0;
 
- # if defined(OSSL_NO_USABLE_TLS1_3) || defined(OPENSSL_NO_TLS1_2)
-        testresult = TEST_skip("TLSv1.3 not usable or no TLSv1.2");
-        goto end;
+# if defined(OSSL_NO_USABLE_TLS1_3) || defined(OPENSSL_NO_TLS1_2)
+    testresult = TEST_skip("TLSv1.3 not usable or no TLSv1.2");
+    goto end;
 # endif
 
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
@@ -8309,13 +8308,12 @@ static int test_key_update_peer_in_read(int idx)
     if (!testdtls) {
         if (!TEST_int_eq(BIO_new_bio_pair(&lbio, bio_size, &pbio, bio_size), 1))
             goto end;
-    }
+    } else {
 # if !defined(OSSL_NO_USABLE_DTLS1_3)
-    else {
         if (!TEST_int_eq(BIO_new_bio_dgram_pair(&lbio, bio_size, &pbio, bio_size), 1))
             goto end;
-    }
 # endif
+    }
 
     SSL_set_bio(local, lbio, lbio);
     SSL_set_bio(peer, pbio, pbio);
@@ -8631,13 +8629,13 @@ static int test_key_update_local_in_read(int idx)
     if (!testdtls) {
         if (!TEST_int_eq(BIO_new_bio_pair(&lbio, bio_size, &pbio, bio_size), 1))
             goto end;
-    }
+    } else {
 # if !defined(OSSL_NO_USABLE_DTLS1_3)
-    else {
         if (!TEST_int_eq(BIO_new_bio_dgram_pair(&lbio, bio_size, &pbio, bio_size), 1))
             goto end;
-    }
 # endif
+    }
+
 
     SSL_set_bio(local, lbio, lbio);
     SSL_set_bio(peer, pbio, pbio);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -4739,6 +4739,8 @@ static int early_data_skip_helper(int testdtls, int testtype, int cipher, int id
             const unsigned char bad_early_data[] = {
                 0x17, 0x03, 0x03, 0x00, 0x01, 0x00
             };
+
+            /* A record with the DTLS1.3 Unified Header */
             const unsigned char bad_early_data_dtls[] = {
                 0x2D, 0x00, 0x00, 0x00, 0x01, 0x00
             };

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -7077,7 +7077,7 @@ static int verify_stateless_cookie_callback(SSL *ssl, const unsigned char *cooki
  * use DTLSv1_listen instead. This test is already covered in
  * dtlsv1listentest.c
  */
-static int test_stateless()
+static int test_stateless(void)
 {
     SSL_CTX *sctx = NULL, *cctx = NULL;
     SSL *serverssl = NULL, *clientssl = NULL;


### PR DESCRIPTION
Several tests where commented out for the behavior of DTLS1.3 is different then TLS1.3. The main difference is around the ACK message. This means some tests needed to be massaged to for the peer to ACK to a certain message.

This PR does not remove all TODO's for DTLS1.3. Currently there are two TODOs. One around padding for messages less than 16 bytes and one for authentication and integrity only messages.

Also this PR still has a lot of memory leaks. Looking into it it has to deal with how new record layers are allocated for new epochs. Because record layers are also stored in a list of messages sent in case they need to be resent it wasn't a simple fix. I feel like the memory leaks should be tackled in a separate PR.

Fixes: https://github.com/openssl/project/issues/1667

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
