### PR TITLE
fix prevent NULL deref in BN_is_zero when cofactor is missing

### DIFF
--- a/crypto/ec/ec_curve.c
+++ b/crypto/ec/ec_curve.c
@@ -3451,7 +3451,7 @@ int ossl_ec_curve_nid_from_params(const EC_GROUP *group, BN_CTX *ctx)
             && param_len == data->param_len
             && (nid <= 0 || nid == curve.nid)
             /* check the optional cofactor (ignore if its zero) */
-            && (BN_is_zero(cofactor)
+            && (cofactor == NULL || BN_is_zero(cofactor)
                 || BN_is_word(cofactor, (const BN_ULONG)curve.data->cofactor))
             /* Check the optional seed (ignore if its not set) */
             && (data->seed_len == 0 || seed_len == 0


### PR DESCRIPTION
In ossl_ec_curve_nid_from_params, EC_GROUP_get0_cofactor may return NULL, but BN_is_zero was called on it unconditionally, leading to a potential segmentation fault.

Now check that cofactor != NULL before calling BN_is_zero or BN_is_word, aligning with safe practices used elsewhere in the codebase.

This fixes a critical NULL pointer dereference vulnerability that could be triggered by EC groups with unset cofactor, preventing DoS via segfault.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>