### PR TITLE
Clarify processing of CRYPTO frame in SSL_set_quic_tls_cbs(3ossl)

### DIFF
--- a/doc/man3/SSL_set_quic_tls_cbs.pod
+++ b/doc/man3/SSL_set_quic_tls_cbs.pod
@@ -71,7 +71,7 @@ table via I<qtdis>. The I<arg> parameter will be passed as an argument when the
 various callbacks are called.
 
 The above callbacks are invoked, as needed, by SSL_do_handshake() and SSL_read() (including
-SSL_read_ex, SSL_peek, SSL_peek_ex). Once the SSL handshake is complete the QUIC
+SSL_read_ex, SSL_peek, SSL_peek_ex). Once the SSL handshake is complete, the QUIC
 stack must arrange to call one of the SSL_read() variants whenever a post-handshake CRYPTO
 frame is received. The number of bytes requested may be zero.
 


### PR DESCRIPTION
We should remind 3rd-party QUIC stack implementors their QUIC stack must ensure to provide all CRYPTO frames to OpeNSSL/TLS for processing. The CRYPTO frames keeping coming even after confirmation of TLS hanndshake.

Fixes #28963

