### PR TITLE
fix check return value of PEM_write_bio_PrivateKey in dsaparam

### DIFF
--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -239,6 +239,11 @@ int dsaparam_main(int argc, char **argv)
             i = i2d_PrivateKey_bio(out, pkey);
         else
             i = PEM_write_bio_PrivateKey(out, pkey, NULL, NULL, 0, NULL, NULL);
+        if (i <= 0) {
+            BIO_printf(bio_err,
+                       "Error, unable to write DSA private key\n");
+            goto end;
+        }
     }
     ret = 0;
  end:


### PR DESCRIPTION
The result of PEM_write_bio_PrivateKey was not checked, which could lead to silent failure when writing a generated DSA private key to output.

Now verify the return value and report an error if the write fails, matching the error handling pattern used for other write operations.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>
