### PR TITLE
Run CIFuzz workflow only on schedule

### DIFF
--- a/.github/workflows/oss-fuzz.yml
+++ b/.github/workflows/oss-fuzz.yml
@@ -6,7 +6,10 @@
 # https://www.openssl.org/source/license.html
 
 name: CIFuzz
-on: [push]
+on:
+  schedule:
+    - cron: '50 01 * * *'
+  workflow_dispatch:
 permissions:
   contents: read
 


### PR DESCRIPTION
~~There is no point to run oss-fuzz on each pull request. This workflow doesn't checkout the pull request branch and build_fuzzers action always builds the same set of active openssl branches:
https://github.com/google/oss-fuzz/blob/85631ab8f2d594ce9eeeb3bda1e8e8f8042090c5/projects/openssl/Dockerfile~~

Actually CIFuzz runs fuzz testing against the PR branch but as @t8m said below it's a waste of resources to run this workflow on pull request in the current form when all active branches are built each run.
