### PR TITLE
Configure: Remove extensive debug output by default

### DIFF
--- a/util/mkinstallvars.pl
+++ b/util/mkinstallvars.pl
@@ -19,6 +19,8 @@ use File::Spec;
 #use List::Util qw(pairs);
 sub _pairs (@);
 
+my $debug = $ENV{OPENSSL_MKINSTALLVARS_DEBUG} || 0;
+
 # These are expected to be set up as absolute directories
 my @absolutes = qw(PREFIX libdir);
 # These may be absolute directories, and if not, they are expected to be set up
@@ -35,7 +37,7 @@ my %all = ( );
 foreach (@absolutes) { $all{$_} = 1 }
 foreach (@subdirs) { foreach (@{$_->[1]}) { $all{$_} = 1 } }
 foreach (@others) { $all{$_} = 1 }
-print STDERR "DEBUG: all keys: ", join(", ", sort keys %all), "\n";
+print STDERR "DEBUG: all keys: ", join(", ", sort keys %all), "\n" if $debug;
 
 my %keys = ();
 my %values = ();
@@ -58,10 +60,10 @@ foreach my $k (sort keys %keys) {
 foreach my $k (@absolutes) {
     my $v = $values{$k} || [ '.' ];
     die "Can't have more than one $k\n" if scalar @$v > 1;
-    print STDERR "DEBUG: $k = $v->[0] => ";
+    print STDERR "DEBUG: $k = $v->[0] => " if $debug;
     $v = [ map { File::Spec->rel2abs($_) } @$v ];
     $values{$k} = $v;
-    print STDERR "$k = $v->[0]\n";
+    print STDERR "$k = $v->[0]\n" if $debug;
 }
 
 # Absolute paths for the subdir variables are computed.  This provides
@@ -79,7 +81,7 @@ foreach my $pair (@subdirs) {
         $values{$k} = [];       # We're rebuilding it
         print STDERR "DEBUG: $k = ",
             (scalar @$v2 > 1 ? "[ " . join(", ", @$v2) . " ]" : $v2->[0]),
-            " => ";
+            " => " if $debug;
         foreach my $v (@$v2) {
             if (File::Spec->file_name_is_absolute($v)) {
                 push @{$values{$k}}, $v;
@@ -98,7 +100,7 @@ foreach my $pair (@subdirs) {
                                          ? "[ " . join(", ", @$v) . " ]"
                                          : $v->[0]);
                           } ($k, $kr)),
-            "\n";
+            "\n" if $debug;
     }
 }
 


### PR DESCRIPTION
These debug logs were added in 6e0fd246e7a (#24687), probably for debugging the script, but they remained active by default.

Change them to appear only if `OPENSSL_MKINSTALLVARS_DEBUG` env var is set.
