### PR TITLE
Remove Ed25519ctx from the FIPS provider

### DIFF
--- a/doc/man7/EVP_SIGNATURE-ED25519.pod
+++ b/doc/man7/EVP_SIGNATURE-ED25519.pod
@@ -134,6 +134,9 @@ since version 1.1.1.
 Valid algorithm names are B<ed25519>, B<ed448> and B<eddsa>. If B<eddsa> is
 specified, then both Ed25519 and Ed448 are benchmarked.
 
+Since Ed25519ctx is not included in FIPS 186-5, it is not present
+in the FIPS provider.
+
 =head1 EXAMPLES
 
 To sign a message using an ED25519 EVP_PKEY structure:

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -519,8 +519,6 @@ static const OSSL_ALGORITHM fips_signature[] = {
       ossl_ed25519_signature_functions },
     { PROV_NAMES_ED25519ph, FIPS_DEFAULT_PROPERTIES,
       ossl_ed25519ph_signature_functions },
-    { PROV_NAMES_ED25519ctx, FIPS_DEFAULT_PROPERTIES,
-      ossl_ed25519ctx_signature_functions },
     { PROV_NAMES_ED448, FIPS_DEFAULT_PROPERTIES,
       ossl_ed448_signature_functions },
     { PROV_NAMES_ED448ph, FIPS_DEFAULT_PROPERTIES,

--- a/providers/implementations/signature/eddsa_sig.c
+++ b/providers/implementations/signature/eddsa_sig.c
@@ -197,6 +197,7 @@ static int eddsa_setup_instance(void *vpeddsactx, int instance_id,
         peddsactx->prehash_flag = 0;
         peddsactx->context_string_flag = 0;
         break;
+#ifndef FIPS_MODULE
     case ID_Ed25519ctx:
         if (peddsactx->key->type != ECX_KEY_TYPE_ED25519)
             return 0;
@@ -204,6 +205,7 @@ static int eddsa_setup_instance(void *vpeddsactx, int instance_id,
         peddsactx->prehash_flag = 0;
         peddsactx->context_string_flag = 1;
         break;
+#endif
     case ID_Ed25519ph:
         if (peddsactx->key->type != ECX_KEY_TYPE_ED25519)
             return 0;
@@ -844,9 +846,11 @@ static int eddsa_set_ctx_params_internal
         if (OPENSSL_strcasecmp(pinstance_name, SN_Ed25519) == 0) {
             eddsa_setup_instance(peddsactx, ID_Ed25519, 0,
                                  peddsactx->prehash_by_caller_flag);
+#ifndef FIPS_MODULE
         } else if (OPENSSL_strcasecmp(pinstance_name, SN_Ed25519ctx) == 0) {
             eddsa_setup_instance(peddsactx, ID_Ed25519ctx, 0,
                                  peddsactx->prehash_by_caller_flag);
+#endif
         } else if (OPENSSL_strcasecmp(pinstance_name, SN_Ed25519ph) == 0) {
             eddsa_setup_instance(peddsactx, ID_Ed25519ph, 0,
                                  peddsactx->prehash_by_caller_flag);
@@ -858,6 +862,10 @@ static int eddsa_set_ctx_params_internal
                                  peddsactx->prehash_by_caller_flag);
         } else {
             /* we did not recognize the instance */
+            ERR_raise_data(ERR_LIB_PROV,
+                           PROV_R_INVALID_EDDSA_INSTANCE_FOR_ATTEMPTED_OPERATION,
+                           "unknown INSTANCE name: %s",
+                           pinstance_name != NULL ? pinstance_name : "<null>");
             return 0;
         }
 

--- a/test/recipes/30-test_evp_data/evppkey_ecx.txt
+++ b/test/recipes/30-test_evp_data/evppkey_ecx.txt
@@ -702,7 +702,7 @@ PublicKeyRaw = EDDSA-TV-6-PUBLIC-Raw:ED25519:dfc9425e4f968f7f0c29f0259cf5f9aed68
 
 PrivPubKeyPair = EDDSA-TV-6-Raw:EDDSA-TV-6-PUBLIC-Raw
 
-FIPSversion = >=3.2.0
+Availablein = default
 OneShotDigestSign = NULL
 Key = EDDSA-TV-6-Raw
 Input = f726936d19c800494e3fdaff20b276a8
@@ -718,7 +718,7 @@ PublicKeyRaw = EDDSA-TV-7-PUBLIC-Raw:ED25519:dfc9425e4f968f7f0c29f0259cf5f9aed68
 
 PrivPubKeyPair = EDDSA-TV-7-Raw:EDDSA-TV-7-PUBLIC-Raw
 
-FIPSversion = >=3.2.0
+Availablein = default
 OneShotDigestSign = NULL
 Key = EDDSA-TV-7-Raw
 Input = f726936d19c800494e3fdaff20b276a8
@@ -734,7 +734,7 @@ PublicKeyRaw = EDDSA-TV-8-PUBLIC-Raw:ED25519:dfc9425e4f968f7f0c29f0259cf5f9aed68
 
 PrivPubKeyPair = EDDSA-TV-8-Raw:EDDSA-TV-8-PUBLIC-Raw
 
-FIPSversion = >=3.2.0
+Availablein = default
 OneShotDigestSign = NULL
 Key = EDDSA-TV-8-Raw
 Input = 508e9e6882b979fea900f62adceaca35
@@ -750,7 +750,7 @@ PublicKeyRaw = EDDSA-TV-9-PUBLIC-Raw:ED25519:0f1d1274943b91415889152e893d80e9327
 
 PrivPubKeyPair = EDDSA-TV-9-Raw:EDDSA-TV-9-PUBLIC-Raw
 
-FIPSversion = >=3.2.0
+Availablein = default
 OneShotDigestSign = NULL
 Key = EDDSA-TV-9-Raw
 Input = f726936d19c800494e3fdaff20b276a8

--- a/test/recipes/30-test_evp_data/evppkey_ecx_sigalg.txt
+++ b/test/recipes/30-test_evp_data/evppkey_ecx_sigalg.txt
@@ -442,7 +442,7 @@ PublicKeyRaw = EDDSA-TV-6-PUBLIC-Raw:ED25519:dfc9425e4f968f7f0c29f0259cf5f9aed68
 
 PrivPubKeyPair = EDDSA-TV-6-Raw:EDDSA-TV-6-PUBLIC-Raw
 
-FIPSversion = >=3.4.0
+Availablein = default
 Sign-Message = ED25519ctx:EDDSA-TV-6-Raw
 Input = f726936d19c800494e3fdaff20b276a8
 Ctrl = hexcontext-string:666f6f
@@ -456,7 +456,7 @@ PublicKeyRaw = EDDSA-TV-7-PUBLIC-Raw:ED25519:dfc9425e4f968f7f0c29f0259cf5f9aed68
 
 PrivPubKeyPair = EDDSA-TV-7-Raw:EDDSA-TV-7-PUBLIC-Raw
 
-FIPSversion = >=3.4.0
+Availablein = default
 Sign-Message = Ed25519ctx:EDDSA-TV-7-Raw
 Input = f726936d19c800494e3fdaff20b276a8
 Ctrl = hexcontext-string:626172
@@ -470,7 +470,7 @@ PublicKeyRaw = EDDSA-TV-8-PUBLIC-Raw:ED25519:dfc9425e4f968f7f0c29f0259cf5f9aed68
 
 PrivPubKeyPair = EDDSA-TV-8-Raw:EDDSA-TV-8-PUBLIC-Raw
 
-FIPSversion = >=3.4.0
+Availablein = default
 Sign-Message = Ed25519ctx:EDDSA-TV-8-Raw
 Input = 508e9e6882b979fea900f62adceaca35
 Ctrl = hexcontext-string:666f6f
@@ -484,7 +484,7 @@ PublicKeyRaw = EDDSA-TV-9-PUBLIC-Raw:ED25519:0f1d1274943b91415889152e893d80e9327
 
 PrivPubKeyPair = EDDSA-TV-9-Raw:EDDSA-TV-9-PUBLIC-Raw
 
-FIPSversion = >=3.4.0
+Availablein = default
 Sign-Message = Ed25519ctx:EDDSA-TV-9-Raw
 Input = f726936d19c800494e3fdaff20b276a8
 Ctrl = hexcontext-string:666f6f


### PR DESCRIPTION
The FIPS 186-5 does not specify Ed25519ctx
Fixes #27502

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
