### PR TITLE
Use the default settings for AKIDs in openssl.cnf

### DIFF
--- a/apps/openssl-vms.cnf
+++ b/apps/openssl-vms.cnf
@@ -245,7 +245,8 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
 subjectKeyIdentifier=hash
 
-authorityKeyIdentifier=keyid:always,issuer
+# Use defaults here: "none" for trust root, "keyid,issuer" otherwise
+# authorityKeyIdentifier=keyid
 
 basicConstraints = critical,CA:true
 

--- a/apps/openssl.cnf
+++ b/apps/openssl.cnf
@@ -245,7 +245,8 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
 subjectKeyIdentifier=hash
 
-authorityKeyIdentifier=keyid:always,issuer
+# Use defaults here: "none" for trust root, "keyid,issuer" otherwise
+# authorityKeyIdentifier=keyid
 
 basicConstraints = critical,CA:true
 


### PR DESCRIPTION
so the demoCA trust root certificate has the recommended settings when created e.g. with ./apps/CA.pl -newca
that means; no AKID for the trust root, and AKID=keyid otherwise.
