### PR TITLE
Rollup fixes for NonStop builds (3.5).

### DIFF
--- a/test/timing_load_creds.c
+++ b/test/timing_load_creds.c
@@ -94,6 +94,10 @@ static void usage(void)
 # endif
 #endif
 
+#if !defined(RUSAGE_SELF) && defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L
+# include <sys/times.h>
+#endif
+
 int main(int ac, char **av)
 {
 #if defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L
@@ -101,7 +105,13 @@ int main(int ac, char **av)
     struct stat sb;
     FILE *fp;
     char *contents;
+# if !defined(RUSAGE_SELF)
+    struct tms rus;
+    struct timeval u_start, u_end, u_elapsed;
+    struct timeval s_start, s_end, s_elapsed;
+# else
     struct rusage start, end, elapsed;
+# endif
     struct timeval e_start, e_end, e_elapsed;
 
     /* Parse JCL. */
@@ -174,10 +184,18 @@ int main(int ac, char **av)
         perror("elapsed start");
         exit(EXIT_FAILURE);
     }
+# if !defined(RUSAGE_SELF)
+    times(&rus);
+    u_start.tv_sec = rus.tms_utime / CLOCKS_PER_SEC;
+    u_start.tv_usec = (rus.tms_utime * 1000000) / CLOCKS_PER_SEC;
+    s_start.tv_sec = rus.tms_stime / CLOCKS_PER_SEC;
+    s_start.tv_usec = (rus.tms_stime * 1000000) / CLOCKS_PER_SEC;
+# else
     if (getrusage(RUSAGE_SELF, &start) < 0) {
         perror("start");
         exit(EXIT_FAILURE);
     }
+# endif
     for (i = count; i > 0; i--) {
         switch (what) {
         case 'c':
@@ -188,20 +206,38 @@ int main(int ac, char **av)
             break;
         }
     }
+# if !defined(RUSAGE_SELF)
+    times(&rus);
+    u_end.tv_sec = rus.tms_utime / CLOCKS_PER_SEC;
+    u_end.tv_usec = (rus.tms_utime * 1000000) / CLOCKS_PER_SEC;
+    s_end.tv_sec = rus.tms_stime / CLOCKS_PER_SEC;
+    s_end.tv_usec = (rus.tms_stime * 1000000) / CLOCKS_PER_SEC;
+# else
     if (getrusage(RUSAGE_SELF, &end) < 0) {
         perror("getrusage");
         exit(EXIT_FAILURE);
     }
+# endif
     if (gettimeofday(&e_end, NULL) < 0) {
         perror("gettimeofday");
         exit(EXIT_FAILURE);
     }
 
+# if !defined(RUSAGE_SELF)
+    timersub(&u_end, &u_start, &u_elapsed);
+    timersub(&s_end, &s_start, &s_elapsed);
+# else
     timersub(&end.ru_utime, &start.ru_stime, &elapsed.ru_stime);
     timersub(&end.ru_utime, &start.ru_utime, &elapsed.ru_utime);
+# endif
     timersub(&e_end, &e_start, &e_elapsed);
+# if !defined(RUSAGE_SELF)
+    print_timeval("user     ", &u_elapsed);
+    print_timeval("sys      ", &s_elapsed);
+# else
     print_timeval("user     ", &elapsed.ru_utime);
     print_timeval("sys      ", &elapsed.ru_stime);
+# endif
     if (debug)
         print_timeval("elapsed??", &e_elapsed);
 


### PR DESCRIPTION
Build a workaround in timing_load_creds.c on NonStop for lack of rusage.
   This simulates getrusage() that is not available on NonStop.

Fixes: #29023

Signed-off-by: Randall S. Becker <randall.becker@nexbridge.ca>

Reviewed-by: Richard Levitte <levitte@openssl.org>
Reviewed-by: Neil Horman <nhorman@openssl.org>
Reviewed-by: Dmitry Belyavskiy <beldmit@gmail.com>
(Merged from https://github.com/openssl/openssl/pull/29024)