### PR TITLE
Rollup fixes for NonStop (3.0)

### DIFF
--- a/crypto/async/arch/async_posix.h
+++ b/crypto/async/arch/async_posix.h
@@ -13,7 +13,8 @@
 
 #if defined(OPENSSL_SYS_UNIX) \
     && defined(OPENSSL_THREADS) && !defined(OPENSSL_NO_ASYNC) \
-    && !defined(__ANDROID__) && !defined(__OpenBSD__)
+    && !defined(__ANDROID__) && !defined(__OpenBSD__) \
+    && !defined(OPENSSL_SYS_TANDEM)
 
 # include <unistd.h>
 


### PR DESCRIPTION
Fixes for NonStop builds on 3.0 to handle OS platform header file changes.

This changes handles the introduction of _POSIX_VERSION into the NonStop x86 header files that tricks OpenSSL into thinking that ucontext.h is available.

Fixes #29023

Signed-off-by: Randall S. Becker <randall.becker@nexbridge.ca>