### PR TITLE
revert changes in "FIPS Check and ABIDIFF" workflow

### DIFF
--- a/.github/workflows/fips-checksums.yml
+++ b/.github/workflows/fips-checksums.yml
@@ -117,7 +117,7 @@ jobs:
       - name: save PR number
         run: echo ${{ github.event.number }} > ./artifact/pr_num
       - name: save artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: abidiff
           path: artifact/

--- a/.github/workflows/fips-label.yml
+++ b/.github/workflows/fips-label.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: 'Download fipscheck artifact'
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -48,7 +48,7 @@ jobs:
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
       - name: 'Check artifact and apply'
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -85,7 +85,7 @@ jobs:
 
       - name: 'Download abidiff artifact'
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -108,7 +108,7 @@ jobs:
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
       - name: 'Check artifact and apply'
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |


### PR DESCRIPTION
Applying labels is not possible from pull request context. This commit reverts changes from
[8948ccdf03435368cd894b944b116e6c5a17ec59](https://github.com/openssl/openssl/commit/8948ccdf03435368cd894b944b116e6c5a17ec59#diff-2b630ed8ab072c30edc68e13748e813a813c334ad3d0c451a1ccaf5fb27fda5d) commit. Fixes https://github.com/openssl/project/issues/1714.
