### PR TITLE
TLS1.3 session resumption EBCDIC fix

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2864,7 +2864,9 @@ MSG_PROCESS_RETURN tls_process_new_session_ticket(SSL_CONNECTION *s,
         const EVP_MD *md = ssl_handshake_md(s);
         int hashleni = EVP_MD_get_size(md);
         size_t hashlen;
-        static const unsigned char nonce_label[] = "resumption";
+        /* ASCII: "resumption", in hex for EBCDIC compatibility */
+        static const unsigned char nonce_label[] = { 0x72, 0x65, 0x73, 0x75, 0x6D,
+                                                     0x70, 0x74, 0x69, 0x6F, 0x6E };
 
         /* Ensure cast to size_t is safe */
         if (!ossl_assert(hashleni > 0)) {
@@ -2875,7 +2877,7 @@ MSG_PROCESS_RETURN tls_process_new_session_ticket(SSL_CONNECTION *s,
 
         if (!tls13_hkdf_expand(s, md, s->resumption_master_secret,
                                nonce_label,
-                               sizeof(nonce_label) - 1,
+                               sizeof(nonce_label),
                                PACKET_data(&nonce),
                                PACKET_remaining(&nonce),
                                s->session->master_key,

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -4202,7 +4202,9 @@ CON_FUNC_RETURN tls_construct_new_session_ticket(SSL_CONNECTION *s, WPACKET *pkt
     if (SSL_CONNECTION_IS_TLS13(s)) {
         size_t i, hashlen;
         uint64_t nonce;
-        static const unsigned char nonce_label[] = "resumption";
+        /* ASCII: "resumption", in hex for EBCDIC compatibility */
+        static const unsigned char nonce_label[] = { 0x72, 0x65, 0x73, 0x75, 0x6D,
+                                                     0x70, 0x74, 0x69, 0x6F, 0x6E };
         const EVP_MD *md = ssl_handshake_md(s);
         int hashleni = EVP_MD_get_size(md);
 
@@ -4249,7 +4251,7 @@ CON_FUNC_RETURN tls_construct_new_session_ticket(SSL_CONNECTION *s, WPACKET *pkt
 
         if (!tls13_hkdf_expand(s, md, s->resumption_master_secret,
                                nonce_label,
-                               sizeof(nonce_label) - 1,
+                               sizeof(nonce_label),
                                tick_nonce,
                                TICKET_NONCE_SIZE,
                                s->session->master_key,


### PR DESCRIPTION
Fixes #27815

CLA:trivial

TLS1.3 session resumption fails when communicating between EBCDIC and ASCII systems. This behavior was noticed on platforms such as z/TPF and z/OS. The nonce_label used in binder verification was changed from the string literal "resumption" to the hex ASCII equivalent to match the existing OpenSSL code.