### PR TITLE
doc: Add HISTORY entry for message signing functions in provider-signature(7)

### DIFF
--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -638,6 +638,11 @@ L<EVP_SIGNATURE_is_a(3)>, L<ASN1_item_sign_ctx(3)>
 
 The provider SIGNATURE interface was introduced in OpenSSL 3.0.
 
+The OSSL_FUNC_signature_sign_message_init(), OSSL_FUNC_signature_sign_message_update(),
+OSSL_FUNC_signature_sign_message_final(), OSSL_FUNC_signature_verify_message_init(),
+OSSL_FUNC_signature_verify_message_update() and OSSL_FUNC_signature_verify_message_final()
+functions were added in OpenSSL 3.4.
+
 The Signature Parameters "fips-indicator", "key-check" and "digest-check" were added in
 OpenSSL 3.4.
 


### PR DESCRIPTION
### Description

This PR adds missing HISTORY documentation for the message signing/verification functions that were introduced in OpenSSL 3.4.

### Issue

Fixes #29088

### Background

The provider SIGNATURE interface includes message-based signing functions that were added in OpenSSL 3.4:
- `OSSL_FUNC_signature_sign_message_init()`
- `OSSL_FUNC_signature_sign_message_update()`
- `OSSL_FUNC_signature_sign_message_final()`
- `OSSL_FUNC_signature_verify_message_init()`
- `OSSL_FUNC_signature_verify_message_update()`
- `OSSL_FUNC_signature_verify_message_final()`

While the corresponding high-level EVP functions are documented with their version in EVP_PKEY_sign(3), the provider-level functions weren't documented in the HISTORY section of provider-signature(7).

### Changes

Added a HISTORY entry documenting that these six message-related provider functions were introduced in OpenSSL 3.4.

### Testing

Documentation change only - no functional code changes.