### PR TITLE
Code comment correction

### DIFF
--- a/crypto/sm4/asm/sm4-riscv64-zvksed.pl
+++ b/crypto/sm4/asm/sm4-riscv64-zvksed.pl
@@ -252,7 +252,7 @@ rv64i_zvksed_sm4_decrypt:
     addi $keys, $keys, 16
     @{[vle32_v $vk4, $keys]} # rk[19:16]
     addi $keys, $keys, 16
-    @{[vle32_v $vk3, $keys]} # rk[15:11]
+    @{[vle32_v $vk3, $keys]} # rk[15:12]
     addi $keys, $keys, 16
     @{[vle32_v $vk2, $keys]} # rk[11:8]
     addi $keys, $keys, 16
@@ -264,7 +264,7 @@ rv64i_zvksed_sm4_decrypt:
     @{[vle32_v $vdata, $in]}
     @{[vrev8_v $vdata, $vdata]}
 
-    # Encrypt with all keys
+    # Decrypt with all keys
     @{[vsm4r_vs $vdata, $vk7]}
     @{[vsm4r_vs $vdata, $vk6]}
     @{[vsm4r_vs $vdata, $vk5]}
@@ -274,7 +274,7 @@ rv64i_zvksed_sm4_decrypt:
     @{[vsm4r_vs $vdata, $vk1]}
     @{[vsm4r_vs $vdata, $vk0]}
 
-    # Save the ciphertext (in reverse element order)
+    # Save the plaintext (in reverse element order)
     @{[vrev8_v $vdata, $vdata]}
     li $stride, -4
     addi $out, $out, 12


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
There are three comment errors in the source code function rv64i_zvksed_sm4_decrypt:
1) The instruction comment for loading the round key should be changed to #rk[15:12]
2) The instruction comment for vsm4r_vs should be changed to #decrypt using all keys
3) The last line should store plaintext, not ciphertext.
issues: #29133 
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
