### PR TITLE
Remove Ed25519ctx from the FIPS provider - backport to ver. 3.2 and 3.3

### DIFF
--- a/doc/man7/EVP_SIGNATURE-ED25519.pod
+++ b/doc/man7/EVP_SIGNATURE-ED25519.pod
@@ -118,6 +118,9 @@ since version 1.1.1.
 Valid algorithm names are B<ed25519>, B<ed448> and B<eddsa>. If B<eddsa> is
 specified, then both Ed25519 and Ed448 are benchmarked.
 
+Since Ed25519ctx is not included in FIPS 186-5, it is not present
+in the FIPS provider.
+
 =head1 EXAMPLES
 
 To sign a message using an ED25519 EVP_PKEY structure:

--- a/providers/implementations/signature/eddsa_sig.c
+++ b/providers/implementations/signature/eddsa_sig.c
@@ -536,12 +536,14 @@ static int eddsa_set_ctx_params(void *vpeddsactx, const OSSL_PARAM params[])
             peddsactx->dom2_flag = 0;
             peddsactx->prehash_flag = 0;
             peddsactx->context_string_flag = 0;
+#ifndef FIPS_MODULE
         } else if (OPENSSL_strcasecmp(pinstance_name, SN_Ed25519ctx) == 0) {
             peddsactx->instance_id = ID_Ed25519ctx;
             if (peddsactx->key->type != ECX_KEY_TYPE_ED25519) return 0;
             peddsactx->dom2_flag = 1;
             peddsactx->prehash_flag = 0;
             peddsactx->context_string_flag = 1;
+#endif
         } else if (OPENSSL_strcasecmp(pinstance_name, SN_Ed25519ph) == 0) {
             peddsactx->instance_id = ID_Ed25519ph;
             if (peddsactx->key->type != ECX_KEY_TYPE_ED25519) return 0;

--- a/test/recipes/30-test_evp_data/evppkey_ecx.txt
+++ b/test/recipes/30-test_evp_data/evppkey_ecx.txt
@@ -672,7 +672,7 @@ PublicKeyRaw = EDDSA-TV-6-PUBLIC-Raw:ED25519:dfc9425e4f968f7f0c29f0259cf5f9aed68
 
 PrivPubKeyPair = EDDSA-TV-6-Raw:EDDSA-TV-6-PUBLIC-Raw
 
-FIPSversion = >=3.2.0
+Availablein = default
 OneShotDigestSign = NULL
 Key = EDDSA-TV-6-Raw
 Input = f726936d19c800494e3fdaff20b276a8
@@ -688,7 +688,7 @@ PublicKeyRaw = EDDSA-TV-7-PUBLIC-Raw:ED25519:dfc9425e4f968f7f0c29f0259cf5f9aed68
 
 PrivPubKeyPair = EDDSA-TV-7-Raw:EDDSA-TV-7-PUBLIC-Raw
 
-FIPSversion = >=3.2.0
+Availablein = default
 OneShotDigestSign = NULL
 Key = EDDSA-TV-7-Raw
 Input = f726936d19c800494e3fdaff20b276a8
@@ -704,7 +704,7 @@ PublicKeyRaw = EDDSA-TV-8-PUBLIC-Raw:ED25519:dfc9425e4f968f7f0c29f0259cf5f9aed68
 
 PrivPubKeyPair = EDDSA-TV-8-Raw:EDDSA-TV-8-PUBLIC-Raw
 
-FIPSversion = >=3.2.0
+Availablein = default
 OneShotDigestSign = NULL
 Key = EDDSA-TV-8-Raw
 Input = 508e9e6882b979fea900f62adceaca35
@@ -720,7 +720,7 @@ PublicKeyRaw = EDDSA-TV-9-PUBLIC-Raw:ED25519:0f1d1274943b91415889152e893d80e9327
 
 PrivPubKeyPair = EDDSA-TV-9-Raw:EDDSA-TV-9-PUBLIC-Raw
 
-FIPSversion = >=3.2.0
+Availablein = default
 OneShotDigestSign = NULL
 Key = EDDSA-TV-9-Raw
 Input = f726936d19c800494e3fdaff20b276a8


### PR DESCRIPTION
Backport of PR #29091

Fixes #27502

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
