### PR TITLE
CONF: Fix config file handling per OSSL_LIB_CTX

### DIFF
--- a/include/internal/conf.h
+++ b/include/internal/conf.h
@@ -11,6 +11,9 @@
 # define OSSL_INTERNAL_CONF_H
 # pragma once
 
+# include "internal/dso.h"
+# include "internal/thread_once.h"
+
 # include <openssl/conf.h>
 
 # define DEFAULT_CONF_MFLAGS \
@@ -22,6 +25,40 @@ struct ossl_init_settings_st {
     char *filename;
     char *appname;
     unsigned long flags;
+};
+
+/*
+ * This structure contains a data about supported modules. entries in this
+ * table correspond to either dynamic or static modules.
+ */
+
+struct conf_module_st {
+    /* DSO of this module or NULL if static */
+    DSO *dso;
+    /* Name of the module */
+    char *name;
+    /* Init function */
+    conf_init_func *init;
+    /* Finish function */
+    conf_finish_func *finish;
+    /* Number of successfully initialized modules */
+    int links;
+    void *usr_data;
+};
+
+/*
+ * This structure contains information about modules that have been
+ * successfully initialized. There may be more than one entry for a given
+ * module.
+ */
+
+struct conf_imodule_st {
+    CONF_MODULE *pmod;
+    OSSL_LIB_CTX *libctx;
+    char *name;
+    char *value;
+    unsigned long flags;
+    void *usr_data;
 };
 
 int ossl_config_int(const OPENSSL_INIT_SETTINGS *);

--- a/include/internal/core.h
+++ b/include/internal/core.h
@@ -11,6 +11,8 @@
 # define OSSL_INTERNAL_CORE_H
 # pragma once
 
+# include <openssl/conf.h>
+
 /*
  * namespaces:
  *
@@ -68,4 +70,7 @@ __owur int ossl_lib_ctx_write_lock(OSSL_LIB_CTX *ctx);
 __owur int ossl_lib_ctx_read_lock(OSSL_LIB_CTX *ctx);
 int ossl_lib_ctx_unlock(OSSL_LIB_CTX *ctx);
 int ossl_lib_ctx_is_child(OSSL_LIB_CTX *ctx);
+int ossl_lib_ctx_attach_ssl_conf_imodule(OSSL_LIB_CTX *ctx, CONF_IMODULE *md);
+int ossl_lib_ctx_detach_ssl_conf_imodule(OSSL_LIB_CTX *ctx, CONF_IMODULE *md);
+
 #endif

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -121,6 +121,7 @@ typedef struct ossl_ex_data_global_st {
 # define OSSL_LIB_CTX_COMP_METHODS                  21
 # define OSSL_LIB_CTX_INDICATOR_CB_INDEX            22
 # define OSSL_LIB_CTX_MAX_INDEXES                   22
+# define OSSL_LIB_CTX_SSL_CONF_IMODULE              23
 
 OSSL_LIB_CTX *ossl_lib_ctx_get_concrete(OSSL_LIB_CTX *ctx);
 int ossl_lib_ctx_is_default(OSSL_LIB_CTX *ctx);

--- a/include/internal/sslconf.h
+++ b/include/internal/sslconf.h
@@ -13,9 +13,30 @@
 
 typedef struct ssl_conf_cmd_st SSL_CONF_CMD;
 
-const SSL_CONF_CMD *conf_ssl_get(size_t idx, const char **name, size_t *cnt);
-int conf_ssl_name_find(const char *name, size_t *idx);
-void conf_ssl_get_cmd(const SSL_CONF_CMD *cmd, size_t idx, char **cmdstr,
-                      char **arg);
+/*
+ * SSL library configuration module placeholder. We load it here but defer
+ * all decisions about its contents to libssl.
+ */
+
+struct ssl_conf_name_st {
+    /* Name of this set of commands */
+    char *name;
+    /* List of commands */
+    SSL_CONF_CMD *cmds;
+    /* Number of commands */
+    size_t cmd_count;
+};
+
+struct ssl_conf_cmd_st {
+    /* Command */
+    char *cmd;
+    /* Argument */
+    char *arg;
+};
+
+const SSL_CONF_CMD *conf_ssl_get(CONF_IMODULE *m, size_t idx, const char **name,
+                                 size_t *cnt);
+int conf_ssl_name_find(CONF_IMODULE *m, const char *name, size_t *idx);
+void conf_ssl_get_cmd(const SSL_CONF_CMD *c, size_t idx, char **cmd, char **arg);
 
 #endif

--- a/ssl/ssl_mcnf.c
+++ b/ssl/ssl_mcnf.c
@@ -10,14 +10,27 @@
 #include <stdio.h>
 #include <openssl/conf.h>
 #include <openssl/ssl.h>
+#include <openssl/trace.h>
 #include "ssl_local.h"
 #include "internal/sslconf.h"
+#include "internal/cryptlib.h"
 
 /* SSL library configuration module. */
 
 void SSL_add_ssl_module(void)
 {
     /* Do nothing. This will be added automatically by libcrypto */
+}
+
+static CONF_IMODULE *ssl_do_lookup_module(OSSL_LIB_CTX *libctx)
+{
+    CONF_IMODULE *m = OSSL_LIB_CTX_get_data(libctx, OSSL_LIB_CTX_SSL_CONF_IMODULE);
+
+    if (m != NULL)
+        return m;
+
+    libctx = OSSL_LIB_CTX_get0_global_default();
+    return OSSL_LIB_CTX_get_data(libctx, OSSL_LIB_CTX_SSL_CONF_IMODULE);
 }
 
 static int ssl_do_config(SSL *s, SSL_CTX *ctx, const char *name, int system)
@@ -29,32 +42,37 @@ static int ssl_do_config(SSL *s, SSL_CTX *ctx, const char *name, int system)
     unsigned int conf_diagnostics = 0;
     const SSL_METHOD *meth;
     const SSL_CONF_CMD *cmds;
-    OSSL_LIB_CTX *prev_libctx = NULL;
-    OSSL_LIB_CTX *libctx = NULL;
+    OSSL_LIB_CTX *libctx = NULL, *prev_libctx = NULL;
+    CONF_IMODULE *imod = NULL;
 
     if (s == NULL && ctx == NULL) {
         ERR_raise(ERR_LIB_SSL, ERR_R_PASSED_NULL_PARAMETER);
         goto err;
     }
-
     if (name == NULL && system)
         name = "system_default";
-    if (!conf_ssl_name_find(name, &idx)) {
+
+    libctx = s != NULL ? s->ctx->libctx: ctx->libctx;
+    imod = ssl_do_lookup_module(libctx);
+    if (!conf_ssl_name_find(imod, name, &idx)) {
         if (!system)
             ERR_raise_data(ERR_LIB_SSL, SSL_R_INVALID_CONFIGURATION_NAME,
                            "name=%s", name);
         goto err;
     }
-    cmds = conf_ssl_get(idx, &name, &cmd_count);
+
+    cmds = conf_ssl_get(imod, idx, &name, &cmd_count);
+    flags = SSL_CONF_FLAG_FILE;
+    if (!system)
+        flags |= SSL_CONF_FLAG_CERTIFICATE | SSL_CONF_FLAG_REQUIRE_PRIVATE;
+
     cctx = SSL_CONF_CTX_new();
     if (cctx == NULL) {
         /* this is a fatal error, always report */
         system = 0;
         goto err;
     }
-    flags = SSL_CONF_FLAG_FILE;
-    if (!system)
-        flags |= SSL_CONF_FLAG_CERTIFICATE | SSL_CONF_FLAG_REQUIRE_PRIVATE;
+
     if (s != NULL) {
         meth = s->method;
         SSL_CONF_CTX_set_ssl(cctx, s);
@@ -64,6 +82,7 @@ static int ssl_do_config(SSL *s, SSL_CTX *ctx, const char *name, int system)
         SSL_CONF_CTX_set_ssl_ctx(cctx, ctx);
         libctx = ctx->libctx;
     }
+
     conf_diagnostics = OSSL_LIB_CTX_get_conf_diagnostics(libctx);
     if (conf_diagnostics)
         flags |= SSL_CONF_FLAG_SHOW_ERRORS;

--- a/test/build.info
+++ b/test/build.info
@@ -66,7 +66,7 @@ IF[{- !$disabled{tests} -}]
           context_internal_test aesgcmtest params_test evp_pkey_dparams_test \
           keymgmt_internal_test hexstr_test provider_status_test defltfips_test \
           bio_readbuffer_test user_property_test pkcs7_test upcallstest \
-          provfetchtest prov_config_test rand_test \
+          provfetchtest prov_config_test libctx_config_test rand_test \
           ca_internals_test bio_tfo_test membio_test bio_dgram_test list_test \
           fips_version_test x509_test hpke_test pairwise_fail_test \
           nodefltctxtest evp_xof_test x509_load_cert_file_test bio_meth_test \
@@ -252,6 +252,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[prov_config_test]=prov_config_test.c
   INCLUDE[prov_config_test]=../include ../apps/include
   DEPEND[prov_config_test]=../libcrypto libtestutil.a
+
+  SOURCE[libctx_config_test]=libctx_config_test.c
+  INCLUDE[libctx_config_test]=../include ../apps/include
+  DEPEND[libctx_config_test]=../libcrypto ../libssl libtestutil.a
 
   SOURCE[evp_pkey_provided_test]=evp_pkey_provided_test.c
   INCLUDE[evp_pkey_provided_test]=../include ../apps/include
@@ -1172,6 +1176,7 @@ IF[{- !$disabled{tests} -}]
   IF[{- $disabled{module} || !$target{dso_scheme} -}]
     DEFINE[provider_test]=NO_PROVIDER_MODULE
     DEFINE[prov_config_test]=NO_PROVIDER_MODULE
+    DEFINE[libctx_config_test]=NO_PROVIDER_MODULE
     DEFINE[provider_internal_test]=NO_PROVIDER_MODULE
   ENDIF
   DEPEND[]=provider_internal_test.cnf

--- a/test/libctx_config_test.c
+++ b/test/libctx_config_test.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021-2024 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <sys/stat.h>
+#include <openssl/conf.h>
+#include <openssl/ssl.h>
+#include "testutil.h"
+
+static char *cfg1 = NULL;
+static char *cfg2 = NULL;
+
+static const struct cfg_proto_version {
+    char **file;
+    long minver, maxver;
+} cfg_proto_version[] = {
+    { &cfg1, TLS1_1_VERSION, TLS1_1_VERSION },
+    { &cfg2, TLS1_2_VERSION, TLS1_2_VERSION }
+};
+
+static int test_config_libctx_global(int idx)
+{
+    const struct cfg_proto_version *cpv = &cfg_proto_version[idx];
+    SSL_CTX *ctx = NULL;
+    int test;
+
+    CONF_modules_load_file(*cpv->file, NULL, 0);
+
+    test = TEST_ptr(ctx = SSL_CTX_new(TLS_method()))
+        && TEST_int_eq(SSL_CTX_get_min_proto_version(ctx), cpv->minver)
+        && TEST_int_eq(SSL_CTX_get_max_proto_version(ctx), cpv->maxver);
+
+    CONF_modules_unload(0);
+    SSL_CTX_free(ctx);
+    return test;
+}
+
+static int test_config_libctx_local(void)
+{
+    OSSL_LIB_CTX *lib1 = NULL, *lib2 = NULL;
+    SSL_CTX *ctx1 = NULL, *ctx2 = NULL;
+    int test;
+
+    test = TEST_ptr(lib1 = OSSL_LIB_CTX_new())
+        && TEST_ptr(lib2 = OSSL_LIB_CTX_new())
+        && TEST_int_eq(OSSL_LIB_CTX_load_config(lib1, cfg1), 1)
+        && TEST_int_eq(OSSL_LIB_CTX_load_config(lib2, cfg2), 1)
+        && TEST_ptr(ctx1 = SSL_CTX_new_ex(lib1, NULL, TLS_server_method()))
+        && TEST_ptr(ctx2 = SSL_CTX_new_ex(lib2, NULL, TLS_server_method()))
+        && TEST_int_eq(SSL_CTX_get_min_proto_version(ctx1), TLS1_1_VERSION)
+        && TEST_int_eq(SSL_CTX_get_min_proto_version(ctx2), TLS1_2_VERSION)
+        && TEST_int_eq(SSL_CTX_get_max_proto_version(ctx1), TLS1_1_VERSION)
+        && TEST_int_eq(SSL_CTX_get_max_proto_version(ctx2), TLS1_2_VERSION);
+
+    SSL_CTX_free(ctx1);
+    SSL_CTX_free(ctx2);
+    OSSL_LIB_CTX_free(lib1);
+    OSSL_LIB_CTX_free(lib2);
+    return test;
+}
+
+OPT_TEST_DECLARE_USAGE("configfile\n")
+
+int setup_tests(void)
+{
+    int test;
+
+    test = TEST_true(test_skip_common_options())
+        && TEST_ptr(cfg1 = test_get_argument(0))
+        && TEST_ptr(cfg2 = test_get_argument(1));
+
+    ADD_TEST(test_config_libctx_local);
+    ADD_ALL_TESTS(test_config_libctx_global, OSSL_NELEM(cfg_proto_version));
+
+    return test;
+}

--- a/test/recipes/30-test_libctx_config.t
+++ b/test/recipes/30-test_libctx_config.t
@@ -1,0 +1,25 @@
+#! /usr/bin/env perl
+# Copyright 2021-2024 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test::Simple;
+use OpenSSL::Test qw/:DEFAULT srctop_file srctop_dir bldtop_dir/;
+use OpenSSL::Test::Utils;
+
+BEGIN {
+setup("test_prov_config");
+}
+
+use lib srctop_dir('Configurations');
+use lib bldtop_dir('.');
+
+plan tests => 1;
+
+ok(run(test(["libctx_config_test", srctop_file("test", "tls-max-v11.cnf"),
+                                 srctop_file("test", "tls-max-v12.cnf")])),
+    "running libctx_config_test default.cnf");

--- a/test/tls-max-v11.cnf
+++ b/test/tls-max-v11.cnf
@@ -1,0 +1,15 @@
+openssl_conf = openssl_init
+
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
+[openssl_init]
+ssl_conf = ssl_configuration
+
+[ssl_configuration]
+system_default = tls_system_default
+
+[tls_system_default]
+MinProtocol = TLSv1.1
+MaxProtocol = TLSv1.1
+

--- a/test/tls-max-v12.cnf
+++ b/test/tls-max-v12.cnf
@@ -1,0 +1,15 @@
+openssl_conf = openssl_init
+
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
+[openssl_init]
+ssl_conf = ssl_configuration
+
+[ssl_configuration]
+system_default = tls_system_default
+
+[tls_system_default]
+MinProtocol = TLSv1.2
+MaxProtocol = TLSv1.2
+


### PR DESCRIPTION
CONF: Add support for config file handling per OSSL_LIB_CTX  and fix cross-context overrides.

Fixes #19248
Fixes #19243