### PR TITLE
Remove  ASN1_STRING_data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,10 @@ OpenSSL 4.0
 
 ### Changes between 3.6 and 4.0 [xx XXX xxxx]
 
+ * The deprecated function ASN1_STRING_data has been removed.
+
+   *Bob Beck*
+
  * various function parameters have been constified,
    in particular for X509-related functions.
 

--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -424,13 +424,6 @@ const unsigned char *ASN1_STRING_get0_data(const ASN1_STRING *x)
     return x->data;
 }
 
-#ifndef OPENSSL_NO_DEPRECATED_1_1_0
-unsigned char *ASN1_STRING_data(ASN1_STRING *x)
-{
-    return x->data;
-}
-#endif
-
 /* |max_len| excludes NUL terminator and may be 0 to indicate no restriction */
 char *ossl_sk_ASN1_UTF8STRING2text(STACK_OF(ASN1_UTF8STRING) *text,
                                    const char *sep, size_t max_len)

--- a/doc/man3/ASN1_STRING_length.pod
+++ b/doc/man3/ASN1_STRING_length.pod
@@ -3,7 +3,7 @@
 =head1 NAME
 
 ASN1_STRING_dup, ASN1_STRING_cmp, ASN1_STRING_set, ASN1_STRING_length,
-ASN1_STRING_type, ASN1_STRING_get0_data, ASN1_STRING_data,
+ASN1_STRING_type, ASN1_STRING_get0_data,
 ASN1_STRING_to_UTF8 - ASN1_STRING utility functions
 
 =head1 SYNOPSIS
@@ -12,7 +12,6 @@ ASN1_STRING_to_UTF8 - ASN1_STRING utility functions
 
  int ASN1_STRING_length(ASN1_STRING *x);
  const unsigned char *ASN1_STRING_get0_data(const ASN1_STRING *x);
- unsigned char *ASN1_STRING_data(ASN1_STRING *x);
 
  ASN1_STRING *ASN1_STRING_dup(const ASN1_STRING *a);
 
@@ -33,10 +32,6 @@ ASN1_STRING_length() returns the length of the content of I<x>. I<x> B<MUST NOT>
 ASN1_STRING_get0_data() returns an internal pointer to the data of I<x>.
 Since this is an internal pointer it should B<not> be freed or
 modified in any way. I<x> B<MUST NOT> be NULL.
-
-ASN1_STRING_data() is similar to ASN1_STRING_get0_data() except the
-returned value is not constant. This function is deprecated:
-applications should use ASN1_STRING_get0_data() instead.
 
 ASN1_STRING_dup() returns a copy of the structure I<a>.
 
@@ -68,11 +63,12 @@ These functions should B<not> be used to examine or modify B<ASN1_INTEGER>
 or B<ASN1_ENUMERATED> types: the relevant B<INTEGER> or B<ENUMERATED>
 utility functions should be used instead.
 
-In general it cannot be assumed that the data returned by ASN1_STRING_data()
-is null terminated or does not contain embedded nulls. The actual format
-of the data will depend on the actual string type itself: for example
-for an IA5String the data will be ASCII, for a BMPString two bytes per
-character in big endian format, and for a UTF8String it will be in UTF8 format.
+In general it cannot be assumed that the data returned by
+ASN1_STRING_get0_data() is null terminated or does not contain
+embedded nulls. The actual format of the data will depend on the
+actual string type itself: for example for an IA5String the data will
+be ASCII, for a BMPString two bytes per character in big endian
+format, and for a UTF8String it will be in UTF8 format.
 
 Similar care should be take to ensure the data is in the correct format
 when calling ASN1_STRING_set().
@@ -81,7 +77,7 @@ when calling ASN1_STRING_set().
 
 ASN1_STRING_length() returns the length of the content of I<x>.
 
-ASN1_STRING_get0_data() and ASN1_STRING_data() return an internal pointer to
+ASN1_STRING_get0_data() returns an internal pointer to
 the data of I<x>.
 
 ASN1_STRING_dup() returns a valid B<ASN1_STRING> structure or NULL if an

--- a/include/openssl/asn1.h.in
+++ b/include/openssl/asn1.h.in
@@ -585,9 +585,6 @@ int ASN1_STRING_length(const ASN1_STRING *x);
 OSSL_DEPRECATEDIN_3_0 void ASN1_STRING_length_set(ASN1_STRING *x, int n);
 # endif
 int ASN1_STRING_type(const ASN1_STRING *x);
-# ifndef OPENSSL_NO_DEPRECATED_1_1_0
-OSSL_DEPRECATEDIN_1_1_0 unsigned char *ASN1_STRING_data(ASN1_STRING *x);
-# endif
 const unsigned char *ASN1_STRING_get0_data(const ASN1_STRING *x);
 
 DECLARE_ASN1_FUNCTIONS(ASN1_BIT_STRING)

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -2827,7 +2827,6 @@ ASN1_STRING_set0                        ?	4_0_0	EXIST::FUNCTION:
 ASN1_STRING_length                      ?	4_0_0	EXIST::FUNCTION:
 ASN1_STRING_length_set                  ?	4_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 ASN1_STRING_type                        ?	4_0_0	EXIST::FUNCTION:
-ASN1_STRING_data                        ?	4_0_0	EXIST::FUNCTION:DEPRECATEDIN_1_1_0
 ASN1_STRING_get0_data                   ?	4_0_0	EXIST::FUNCTION:
 d2i_ASN1_BIT_STRING                     ?	4_0_0	EXIST::FUNCTION:
 i2d_ASN1_BIT_STRING                     ?	4_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
This has been deprecated since 1.1.0 and is in the way for improvements that could make ASN1_STRING opaque. 

#29117

We thank it for being a good function for it's time, and send it to the special farm where it can play with the other deprecated functions behind the barn in the happy fields all day.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
