### PR TITLE
DOC: improve `X509_VERIFY_PARAM_set_flags.pod`

### DIFF
--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -198,7 +198,7 @@ X509_VERIFY_PARAM_get0_email() returns the expected RFC822 email address.
 X509_VERIFY_PARAM_set1_email() sets the expected RFC822 email address to
 I<email>.
 If I<email> is NULL, email checking is disabled. Otherwise,
-if I<emaillen> is zero, I<email> must be NUL-terminated, otherwise
+if I<emaillen> is zero, I<email> must be NUL-terminated; if I<emaillen> is nonzero,
 I<emaillen> must be set to the length of I<email>.  When an email address
 is specified, certificate verification automatically invokes
 L<X509_check_email(3)>.


### PR DESCRIPTION
Three doc-only commits carved out from #27357.

* Add recommendation that TLS clients should use `SSL_set_tlsext_host_name()` for SNI
and that this should be done jointly with using `{SSL,X509_VERIFY_PARAM}_{set1,add1}_host()`.
* fix doc of NULL param to `X509_VERIFY_PARAM_set1_email()` and `X509_VERIFY_PARAM_set1{,_ip}()`
* remove heavily outdated texts on `X509_V_FLAG_NO_ALT_CHAINS`; other small fixes
