### PR TITLE
Fix CI Provider compatibility test breakage

### DIFF
--- a/test/acvp_test.c
+++ b/test/acvp_test.c
@@ -1310,6 +1310,16 @@ static int rsa_keygen_test(int id)
     OSSL_PARAM *params = NULL;
     const struct rsa_keygen_st *tst = &rsa_keygen_data[id];
 
+    /*
+     * RSA key generation parameters "a" and "b" were added in OpenSSL 4.0,
+     * So skip the test if the FIPS provider is older.
+     */
+    if ((tst->a > 0 || tst->b > 0)
+            && fips_provider_version_lt(libctx, 4, 0, 0)) {
+        TEST_note("ACVP rsa_keygen_test %d test skipped", id);
+        return 1;
+    }
+
     if (!TEST_ptr(bld = OSSL_PARAM_BLD_new())
         || !TEST_ptr(xp1_bn = BN_bin2bn(tst->xp1, (int)tst->xp1_len, NULL))
         || !TEST_ptr(xp2_bn = BN_bin2bn(tst->xp2, (int)tst->xp2_len, NULL))


### PR DESCRIPTION
Fixes #29142

In https://github.com/openssl/openssl/pull/28349 I forgot to tag to run 'extended tests', and the additional RSA keygen acvp test did not check for backwards compatability when testing against older FIPS providers.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
