### PR TITLE
doc/man3/OPENSSL_malloc.pod: mention rationale for OPENSSL_cleanse()

### DIFF
--- a/doc/man3/OPENSSL_malloc.pod
+++ b/doc/man3/OPENSSL_malloc.pod
@@ -151,6 +151,10 @@ these functions return an error if multiplication of B<num> and B<size>
 leads to an integer overflow, thus preventing allocations of an incorrect size.
 
 OPENSSL_cleanse() fills B<ptr> of size B<len> with a string of 0's.
+It is useful in cases when it is needed to ensure that memory (that contains
+sensitive information) is overwritten (for example, before it is reclaimed,
+or when it is stored on stack), and such operation is not optimised out
+by compiler optimisations such as dead store elimination (as memset(3) may be).
 Use OPENSSL_cleanse() with care if the memory is a mapping of a file.
 If the storage controller uses write compression, then it's possible
 that sensitive tail bytes will survive zeroization because the block of


### PR DESCRIPTION
It was not entirely clear from the sole description, what is  the reason for preferring `OPENSSL_cleanse()` over `memset()`.  Add a note about situations in which `OPENSSL_cleanse()` should be chosen.

##### Checklist
- [x] documentation is added or updated
