### PR TITLE
mkbuildinf: strip path prefix from CC

### DIFF
--- a/util/mkbuildinf.pl
+++ b/util/mkbuildinf.pl
@@ -10,9 +10,11 @@ use strict;
 use warnings;
 
 my $platform = pop @ARGV;
+my $cc = shift @ARGV;
+($cc) = $cc =~ /([^\/]+)$/;
 my $cflags = join(' ', @ARGV);
 $cflags =~ s(\\)(\\\\)g;
-$cflags = "compiler: $cflags";
+$cflags = "compiler: $cc $cflags";
 
 # Use the value of the envvar SOURCE_DATE_EPOCH, even if it's
 # zero or the empty string.


### PR DESCRIPTION
The path to the compiler used is not actually very useful, and is itself a potential source for build impurities, e.g. if the compiler is located in a temporary build root. It makes sense to keep track of the compiler that was used, but not where that compiler was located on the build system.

On the nix build, adding the full compiler path to `buildinfo.h` results in a runtime dependency on the build-time compiler. While we could keep this patch out of the openssl tree to work around that silly behavior, the value of keeping the absolute path to the used compiler is not clear.

This was tested by Linux build, without spaces in the path to the compiler. Extra fixes might be necessary to make this work on windows to not regress #26253, though I am too unfamiliar with perl to make that happen. Part of the issue here is the fact `$(CC)` is passed entirely unquoted on command line, which means what should be argv 1 might actually be split accross multiple args if paths have spaces. There is no good way to work around that limitation that I can see.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
