### PR TITLE
test/bioprinttest.c: skip failing checks on HPE NonStop

### DIFF
--- a/test/bioprinttest.c
+++ b/test/bioprinttest.c
@@ -162,7 +162,9 @@ static const struct int_data {
     { { .hh = 0x42 }, AT_CHAR, "%+hhu", "66" },
     { { .hh = 0x88 }, AT_CHAR, "%hhd", "-120" },
     { { .hh = 0x0 }, AT_CHAR, "%hho", "0" },
+#if !defined(__TANDEM)
     { { .hh = 0x0 }, AT_CHAR, "%#hho", "0" },
+#endif
     { { .hh = 0x1 }, AT_CHAR, "%hho", "1" },
     { { .hh = 0x1 }, AT_CHAR, "%#hho", "01" },
     { { .hh = 0x0 }, AT_CHAR, "%+hhx", "0" },
@@ -341,14 +343,20 @@ static const struct wp_data {
     { { .i = 01234 }, "%#*" PRIoPTR, "       01234", 1, 12 },
     { { .i = 01234 }, "%#.*" PRIxPTR, "0x00000000029c", 1, 12 },
 
+#if !defined(__TANDEM)
     { { .i = 0 }, "|%#*" PRIoPTR "|", "| 0|", 1, 2 },
+#endif
     { { .i = 0 }, "|%#.*" PRIoPTR "|", "|00|", 1, 2 },
+#if !defined(__TANDEM)
     { { .i = 0 }, "|%#.*" PRIoPTR "|", "|0|", 1, 1 },
+#endif
 #if !defined(__OpenBSD__)
     { { .i = 0 }, "|%#.*" PRIoPTR "|", "|0|", 1, 0 },
 #endif
     { { .i = 0 }, "|%.*" PRIoPTR "|", "||", 1, 0 },
+#if !defined(__TANDEM)
     { { .i = 0 }, "|%#.*" PRIoPTR "|", "|0|", 1, -12 },
+#endif
 
     { { .i = 0 }, "|%#.*" PRIxPTR "|", "||", 1, 0 },
     { { .i = 0 }, "|%#.*" PRIxPTR "|", "|0|", 1, -12 },


### PR DESCRIPTION
Apparently, NonStop libc's printf implementation is not standard-conforming in its handling of "0" flag with "o" specifier: per [1], "it shall increase the precision, if and only if necessary, to force the first digit of the result to be a zero", however, NonStop libc adds a superfluous zero in cases where precision is 1;  see also commit 0f107c709c73 "crypto/bio/bio_print.c: avoid superfluous zero padding in %#o".  Avoid test case failures by wrapping the relevant test cases in "if !defined(__TANDEM)".

[1] https://pubs.opengroup.org/onlinepubs/9699919799/functions/printf.html

Resolves: https://github.com/openssl/openssl/issues/29025
Complements: a29d157fdb6d "Replace homebrewed implementation of *printf*() functions with libc"

##### Checklist
- [x] tests are added or updated
