### PR TITLE
ensure destructor key is created prior to any other thread specific key

### DIFF
--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -213,14 +213,15 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_thread_once)
     return 1;
 }
 
-int ossl_init_thread(void) {
-    if (CRYPTO_THREAD_compare_id(recursion_guard, CRYPTO_THREAD_get_current_id()))
+int ossl_init_thread(void)
+{
+    if (CRYPTO_THREAD_compare_id(recursion_guard,
+                                 CRYPTO_THREAD_get_current_id()))
         return 1;
     if (!RUN_ONCE(&ossl_init_thread_runonce, ossl_init_thread_once))
         return 0;
     return 1;
 }
-
 
 void ossl_cleanup_thread(void)
 {

--- a/crypto/threads_none.c
+++ b/crypto/threads_none.c
@@ -165,10 +165,10 @@ int CRYPTO_THREAD_init_local(CRYPTO_THREAD_LOCAL *key, void (*cleanup)(void *))
 {
     int entry_idx = 0;
 
-#ifndef FIPS_MODULE
+# ifndef FIPS_MODULE
     if (!ossl_init_thread())
         return 0;
-#endif
+# endif
 
     for (entry_idx = 0; entry_idx < OPENSSL_CRYPTO_THREAD_LOCAL_KEY_MAX; entry_idx++) {
         if (!thread_local_storage[entry_idx].used)

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -698,10 +698,10 @@ int CRYPTO_THREAD_run_once(CRYPTO_ONCE *once, void (*init)(void))
 int CRYPTO_THREAD_init_local(CRYPTO_THREAD_LOCAL *key, void (*cleanup)(void *))
 {
 
-#ifndef FIPS_MODULE
+# ifndef FIPS_MODULE
     if (!ossl_init_thread())
         return 0;
-#endif
+# endif
 
     if (pthread_key_create(key, cleanup) != 0)
         return 0;

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -549,10 +549,10 @@ int CRYPTO_THREAD_run_once(CRYPTO_ONCE *once, void (*init)(void))
 int CRYPTO_THREAD_init_local(CRYPTO_THREAD_LOCAL *key, void (*cleanup)(void *))
 {
 
-#ifndef FIPS_MODULE
+# ifndef FIPS_MODULE
     if (!ossl_init_thread())
         return 0;
-#endif
+# endif
 
     *key = TlsAlloc();
     if (*key == TLS_OUT_OF_INDEXES)


### PR DESCRIPTION

https://github.com/openssl/openssl/issues/29077 found that, in the event that a pthread key is created prior to the destructor_key, glibc will NULL-ify any thread specific data before the init_thread_destructor runs, leading to leaks.
    
Ensure that we always create the destructor key prior to any other
    thread local storage keys
    
Fixes #29907
