### PR TITLE
Remove the ASN1_STRING_FLAG_X509_TIME flag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,10 @@ OpenSSL 4.0
 
    *Bob Beck*
 
+* The ASN1_STRING_FLAG_X509_TIME define has been removed.
+
+   *Bob Beck*
+
  * various function parameters have been constified,
    in particular for X509-related functions.
 

--- a/include/openssl/asn1.h.in
+++ b/include/openssl/asn1.h.in
@@ -160,8 +160,6 @@ extern "C" {
 #define ASN1_STRING_FLAG_MSTRING 0x040
 /* String is embedded and only content should be freed */
 #define ASN1_STRING_FLAG_EMBED 0x080
-/* String should be parsed in RFC 5280's time format */
-#define ASN1_STRING_FLAG_X509_TIME 0x100
 /* This is the base type that holds just about everything :-) */
 struct asn1_string_st {
     int length;


### PR DESCRIPTION
It's only use was to do some somewhat confused cruftery inside of ossl_asn1_time_to_tm as a special case to implement ASN1_TIME_set_string_X509.

As it turns out, you don't need the cruftery of a special case inside of ossl_asn1_time_to_tm to implement this function, so the flag is completely unnecessary.

This removes flag, and simplifies this to work without it.

It removes the cruft only from ossl_asn1_time_to_tm, minimally. This function really needs some cleanup and makes my eyes bleed but I am resisting the temptation to do that with this PR and making this a the minimal change needed for review. I will clean up that function in a follow on pr.

As tests on the behaviour of ASN1_TIME_set_string_X509 were added with it, Beyonce dances happily for me and I only need to pass the existing tests, not write as bunch of new ones..

For issue #29117
Fixes: [1773](https://github.com/openssl/project/issues/1773)
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
