### PR TITLE
Remove OPENSSL_INIT_ENGINE_* definitions

### DIFF
--- a/doc/man3/OPENSSL_init_crypto.pod
+++ b/doc/man3/OPENSSL_init_crypto.pod
@@ -119,55 +119,6 @@ option.
 With this option the library with automatically initialise the libcrypto async
 sub-library (see L<ASYNC_start_job(3)>). This is a default option.
 
-=item OPENSSL_INIT_ENGINE_RDRAND
-
-With this option the library will automatically load and initialise the
-RDRAND engine (if available). This not a default option and is deprecated
-in OpenSSL 3.0.
-
-=item OPENSSL_INIT_ENGINE_DYNAMIC
-
-With this option the library will automatically load and initialise the
-dynamic engine. This not a default option and is deprecated
-in OpenSSL 3.0.
-
-=item OPENSSL_INIT_ENGINE_OPENSSL
-
-With this option the library will automatically load and initialise the
-openssl engine. This not a default option and is deprecated
-in OpenSSL 3.0.
-
-=item OPENSSL_INIT_ENGINE_CRYPTODEV
-
-With this option the library will automatically load and initialise the
-cryptodev engine (if available). This not a default option and is deprecated
-in OpenSSL 3.0.
-
-=item OPENSSL_INIT_ENGINE_CAPI
-
-With this option the library will automatically load and initialise the
-CAPI engine (if available). This not a default option and is deprecated
-in OpenSSL 3.0.
-
-=item OPENSSL_INIT_ENGINE_PADLOCK
-
-With this option the library will automatically load and initialise the
-padlock engine (if available). This not a default option and is deprecated
-in OpenSSL 3.0.
-
-=item OPENSSL_INIT_ENGINE_AFALG
-
-With this option the library will automatically load and initialise the
-AFALG engine. This not a default option and is deprecated
-in OpenSSL 3.0.
-
-=item OPENSSL_INIT_ENGINE_ALL_BUILTIN
-
-With this option the library will automatically load and initialise all the
-built in engines listed above with the exception of the openssl and afalg
-engines. This not a default option and is deprecated
-in OpenSSL 3.0.
-
 =item OPENSSL_INIT_ATFORK
 
 With this option the library will register its fork handlers.

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -480,13 +480,6 @@ int CRYPTO_memcmp(const void * in_a, const void * in_b, size_t len);
 # define OPENSSL_INIT_LOAD_CONFIG            0x00000040L
 # define OPENSSL_INIT_NO_LOAD_CONFIG         0x00000080L
 # define OPENSSL_INIT_ASYNC                  0x00000100L
-# define OPENSSL_INIT_ENGINE_RDRAND          0x00000200L
-# define OPENSSL_INIT_ENGINE_DYNAMIC         0x00000400L
-# define OPENSSL_INIT_ENGINE_OPENSSL         0x00000800L
-# define OPENSSL_INIT_ENGINE_CRYPTODEV       0x00001000L
-# define OPENSSL_INIT_ENGINE_CAPI            0x00002000L
-# define OPENSSL_INIT_ENGINE_PADLOCK         0x00004000L
-# define OPENSSL_INIT_ENGINE_AFALG           0x00008000L
 /* FREE:                                     0x00010000L */
 # define OPENSSL_INIT_ATFORK                 0x00020000L
 /* OPENSSL_INIT_BASE_ONLY                    0x00040000L */
@@ -500,11 +493,18 @@ int CRYPTO_memcmp(const void * in_a, const void * in_b, size_t len);
 /* FREE: 0x80000000L */
 /* Max OPENSSL_INIT flag value is 0x80000000 */
 
-/* openssl and dasync not counted as builtin */
-# define OPENSSL_INIT_ENGINE_ALL_BUILTIN \
-    (OPENSSL_INIT_ENGINE_RDRAND | OPENSSL_INIT_ENGINE_DYNAMIC \
-    | OPENSSL_INIT_ENGINE_CRYPTODEV | OPENSSL_INIT_ENGINE_CAPI | \
-    OPENSSL_INIT_ENGINE_PADLOCK)
+/* ENGINEs are no longer available */
+# define OPENSSL_INIT_ENGINE_ALL_BUILTIN      0
+
+# ifdef OPENSSL_ENGINE_STUBS
+#  define OPENSSL_INIT_ENGINE_RDRAND          0
+#  define OPENSSL_INIT_ENGINE_DYNAMIC         0
+#  define OPENSSL_INIT_ENGINE_OPENSSL         0
+#  define OPENSSL_INIT_ENGINE_CRYPTODEV       0
+#  define OPENSSL_INIT_ENGINE_CAPI            0
+#  define OPENSSL_INIT_ENGINE_PADLOCK         0
+#  define OPENSSL_INIT_ENGINE_AFALG           0
+# endif
 
 /* Library initialisation functions */
 void OPENSSL_cleanup(void);

--- a/include/openssl/engine.h
+++ b/include/openssl/engine.h
@@ -417,22 +417,15 @@ ENGINE_FUNC(ENGINE *, ENGINE_by_id, (const char *id), (id), NULL)
 #  endif
 
 #  ifndef OPENSSL_NO_DEPRECATED_1_1_0
-#   define ENGINE_load_openssl() \
-        OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_OPENSSL, NULL)
-#   define ENGINE_load_dynamic() \
-        OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_DYNAMIC, NULL)
+ENGINE_FUNC_NOARGS(int, ENGINE_load_openssl, 0)
+ENGINE_FUNC_NOARGS(int, ENGINE_load_dynamic, 0)
+ENGINE_FUNC_NOARGS(int, ENGINE_load_cryptodev, 0)
+ENGINE_FUNC_NOARGS(int, ENGINE_load_rdrand, 0)
 #   ifndef OPENSSL_NO_STATIC_ENGINE
-#    define ENGINE_load_padlock() \
-        OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_PADLOCK, NULL)
-#    define ENGINE_load_capi() \
-        OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_CAPI, NULL)
-#    define ENGINE_load_afalg() \
-        OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_AFALG, NULL)
+ENGINE_FUNC_NOARGS(int, ENGINE_load_padlock, 0)
+ENGINE_FUNC_NOARGS(int, ENGINE_load_capi, 0)
+ENGINE_FUNC_NOARGS(int, ENGINE_load_afalg, 0)
 #   endif
-#   define ENGINE_load_cryptodev() \
-        OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_CRYPTODEV, NULL)
-#   define ENGINE_load_rdrand() \
-        OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_RDRAND, NULL)
 #  endif
 #  ifndef OPENSSL_NO_DEPRECATED_3_0
 /* OSSL_DEPRECATEDIN_3_0 void ENGINE_load_builtin_engines(void); */


### PR DESCRIPTION
Keeping OPENSSL_INIT_ENGINE_ALL_BUILTIN to be defined always to zero as
it might be the most used one outside of the library, meanwhile keeping
the others undefined unless OPENSSL_ENGINE_STUBS is defined.

Resolves: https://github.com/openssl/project/issues/1428

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
