### PR TITLE
check_cert_crl(): Set CRL score for CRLs returned by get_crl callback

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1356,7 +1356,7 @@ static int check_cert_crl(X509_STORE_CTX *ctx)
         if (ctx->get_crl != NULL) {
             X509 *crl_issuer = NULL;
             unsigned int reasons = 0;
-            
+
             ok = ctx->get_crl(ctx, &crl, x);
             if (crl != NULL) {
                 ctx->current_crl_score = get_crl_score(ctx, &crl_issuer,

--- a/test/crltest.c
+++ b/test/crltest.c
@@ -691,7 +691,6 @@ static int test_get_crl_fn_score(void)
     X509_VERIFY_PARAM *param = X509_VERIFY_PARAM_new();
     STACK_OF(X509) *roots = sk_X509_new_null();
 
-    
     int status = X509_V_ERR_UNSPECIFIED;
 
     if (!TEST_ptr(ctx)
@@ -726,7 +725,7 @@ static int test_get_crl_fn_score(void)
                                         : X509_STORE_CTX_get_error(ctx);
 
     TEST_int_eq(status, X509_V_OK);
-    
+
 err:
     OSSL_STACK_OF_X509_free(roots);
     X509_VERIFY_PARAM_free(param);
@@ -734,8 +733,6 @@ err:
     X509_STORE_free(store);
     return status == X509_V_OK;
 }
-
-
 
 int setup_tests(void)
 {


### PR DESCRIPTION
Fixes #26786
For CRLs retrieved using the `get_crl` callback set with `X509_STORE_CTX_set_get_crl()`, sets the `current_crl_score`, `current_issuer`, and `current_reasons` inside the `check_cert_crl` function, thus providing enough information for `X509_verify_cert()` to properly check the CRL.

##### Checklist
- [x] tests are added or updated
