### PR TITLE
DOC: put an empty line before '=for' directive

### DIFF
--- a/doc/man1/openssl-rehash.pod.in
+++ b/doc/man1/openssl-rehash.pod.in
@@ -10,6 +10,7 @@ openssl-rehash, c_rehash - Create symbolic links to files named by the hash
 values
 
 =head1 SYNOPSIS
+
 =for openssl duplicate options
 
 B<openssl>


### PR DESCRIPTION
This causes the wrong documentation rendering.

https://docs.openssl.org/3.6/man1/openssl-rehash/

<img width="1080" height="479" alt="image" src="https://github.com/user-attachments/assets/98aaf7ec-fe27-4292-89e3-4c6f9b53a826" />

or manpage

<img width="1225" height="242" alt="image" src="https://github.com/user-attachments/assets/2a80c8e8-9b75-4a28-af15-470df33e4797" />


CLA: trivial