### PR TITLE
bn: Remove the BN_MUL_COMBA cpp define

### DIFF
--- a/crypto/bn/bn_asm.c
+++ b/crypto/bn/bn_asm.c
@@ -429,7 +429,7 @@ BN_ULONG bn_sub_words(BN_ULONG *r, const BN_ULONG *a, const BN_ULONG *b,
     return c;
 }
 
-#if defined(BN_MUL_COMBA) && !defined(OPENSSL_SMALL_FOOTPRINT)
+#ifndef OPENSSL_SMALL_FOOTPRINT
 
 /* mul_add_c(a,b,c0,c1,c2)  -- c+=a*b for three word number c=(c2,c1,c0) */
 /* mul_add_c2(a,b,c0,c1,c2) -- c+=2*a*b for three word number c=(c2,c1,c0) */
@@ -991,7 +991,7 @@ int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
 #endif /* OPENSSL_BN_ASM_MONT */
 #endif
 
-#else /* !BN_MUL_COMBA */
+#else /* OPENSSL_SMALL_FOOTPRINT */
 
 /* hmm... is it faster just to do a multiply? */
 void bn_sqr_comba4(BN_ULONG *r, const BN_ULONG *a)
@@ -1078,4 +1078,4 @@ int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
 #endif /* OPENSSL_BN_ASM_MONT */
 #endif
 
-#endif /* !BN_MUL_COMBA */
+#endif /* !OPENSSL_SMALL_FOOTPRINT */

--- a/crypto/bn/bn_local.h
+++ b/crypto/bn/bn_local.h
@@ -53,7 +53,6 @@
 #endif
 
 #ifndef OPENSSL_SMALL_FOOTPRINT
-#define BN_MUL_COMBA
 #define BN_SQR_COMBA
 #define BN_RECURSION
 #endif

--- a/crypto/bn/bn_local.h
+++ b/crypto/bn/bn_local.h
@@ -53,7 +53,6 @@
 #endif
 
 #ifndef OPENSSL_SMALL_FOOTPRINT
-#define BN_SQR_COMBA
 #define BN_RECURSION
 #endif
 

--- a/crypto/bn/bn_local.h
+++ b/crypto/bn/bn_local.h
@@ -52,10 +52,6 @@
 #define BN_SOFT_LIMIT (4096 / BN_BYTES)
 #endif
 
-#ifndef OPENSSL_SMALL_FOOTPRINT
-#define BN_RECURSION
-#endif
-
 /*
  * This next option uses the C libraries (2 word)/(1 word) function. If it is
  * not defined, I use my C version (which is slower). The reason for this

--- a/crypto/bn/bn_mul.c
+++ b/crypto/bn/bn_mul.c
@@ -180,13 +180,7 @@ void bn_mul_recursive(BN_ULONG *r, BN_ULONG *a, BN_ULONG *b, int n2,
     unsigned int neg, zero;
     BN_ULONG ln, lo, *p;
 
-#ifdef BN_MUL_COMBA
-#if 0
-    if (n2 == 4) {
-        bn_mul_comba4(r, a, b);
-        return;
-    }
-#endif
+#ifndef OPENSSL_SMALL_FOOTPRINT
     /*
      * Only call bn_mul_comba 8 if n2 == 8 and the two arrays are complete
      * [steve]
@@ -195,7 +189,7 @@ void bn_mul_recursive(BN_ULONG *r, BN_ULONG *a, BN_ULONG *b, int n2,
         bn_mul_comba8(r, a, b);
         return;
     }
-#endif /* BN_MUL_COMBA */
+#endif /* OPENSSL_SMALL_FOOTPRINT */
     /* Else do normal multiply */
     if (n2 < BN_MUL_RECURSIVE_SIZE_NORMAL) {
         bn_mul_normal(r, a, n2 + dna, b, n2 + dnb);
@@ -240,7 +234,7 @@ void bn_mul_recursive(BN_ULONG *r, BN_ULONG *a, BN_ULONG *b, int n2,
         break;
     }
 
-#ifdef BN_MUL_COMBA
+#ifndef OPENSSL_SMALL_FOOTPRINT
     if (n == 4 && dna == 0 && dnb == 0) { /* XXX: bn_mul_comba4 could take
                                            * extra args to do this well */
         if (!zero)
@@ -261,7 +255,7 @@ void bn_mul_recursive(BN_ULONG *r, BN_ULONG *a, BN_ULONG *b, int n2,
         bn_mul_comba8(r, a, b);
         bn_mul_comba8(&(r[n2]), &(a[n]), &(b[n]));
     } else
-#endif /* BN_MUL_COMBA */
+#endif /* OPENSSL_SMALL_FOOTPRINT */
     {
         p = &(t[n2 * 2]);
         if (!zero)
@@ -509,7 +503,7 @@ int bn_mul_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, BN_CTX *ctx)
     int ret = 0;
     int top, al, bl;
     BIGNUM *rr;
-#if defined(BN_MUL_COMBA) || defined(BN_RECURSION)
+#if !defined(OPENSSL_SMALL_FOOTPRINT) || defined(BN_RECURSION)
     int i;
 #endif
 #ifdef BN_RECURSION
@@ -537,10 +531,10 @@ int bn_mul_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, BN_CTX *ctx)
     } else
         rr = r;
 
-#if defined(BN_MUL_COMBA) || defined(BN_RECURSION)
+#if !defined(OPENSSL_SMALL_FOOTPRINT) || defined(BN_RECURSION)
     i = al - bl;
 #endif
-#ifdef BN_MUL_COMBA
+#ifndef OPENSSL_SMALL_FOOTPRINT
     if (i == 0) {
 #if 0
         if (al == 4) {
@@ -559,7 +553,7 @@ int bn_mul_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, BN_CTX *ctx)
             goto end;
         }
     }
-#endif /* BN_MUL_COMBA */
+#endif /* OPENSSL_SMALL_FOOTPRINT */
 #ifdef BN_RECURSION
     if ((al >= BN_MULL_SIZE_NORMAL) && (bl >= BN_MULL_SIZE_NORMAL)) {
         if (i >= -1 && i <= 1) {
@@ -604,7 +598,7 @@ int bn_mul_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, BN_CTX *ctx)
     rr->top = top;
     bn_mul_normal(rr->d, a->d, al, b->d, bl);
 
-#if defined(BN_MUL_COMBA) || defined(BN_RECURSION)
+#if !defined(OPENSSL_SMALL_FOOTPRINT) || defined(BN_RECURSION)
 end:
 #endif
     rr->neg = a->neg ^ b->neg;

--- a/crypto/bn/bn_mul.c
+++ b/crypto/bn/bn_mul.c
@@ -154,7 +154,7 @@ BN_ULONG bn_sub_part_words(BN_ULONG *r,
 }
 #endif
 
-#ifdef BN_RECURSION
+#ifndef OPENSSL_SMALL_FOOTPRINT
 /*
  * Karatsuba recursive multiplication algorithm (cf. Knuth, The Art of
  * Computer Programming, Vol. 2)
@@ -180,7 +180,6 @@ void bn_mul_recursive(BN_ULONG *r, BN_ULONG *a, BN_ULONG *b, int n2,
     unsigned int neg, zero;
     BN_ULONG ln, lo, *p;
 
-#ifndef OPENSSL_SMALL_FOOTPRINT
     /*
      * Only call bn_mul_comba 8 if n2 == 8 and the two arrays are complete
      * [steve]
@@ -189,7 +188,7 @@ void bn_mul_recursive(BN_ULONG *r, BN_ULONG *a, BN_ULONG *b, int n2,
         bn_mul_comba8(r, a, b);
         return;
     }
-#endif /* OPENSSL_SMALL_FOOTPRINT */
+
     /* Else do normal multiply */
     if (n2 < BN_MUL_RECURSIVE_SIZE_NORMAL) {
         bn_mul_normal(r, a, n2 + dna, b, n2 + dnb);
@@ -234,7 +233,6 @@ void bn_mul_recursive(BN_ULONG *r, BN_ULONG *a, BN_ULONG *b, int n2,
         break;
     }
 
-#ifndef OPENSSL_SMALL_FOOTPRINT
     if (n == 4 && dna == 0 && dnb == 0) { /* XXX: bn_mul_comba4 could take
                                            * extra args to do this well */
         if (!zero)
@@ -254,9 +252,7 @@ void bn_mul_recursive(BN_ULONG *r, BN_ULONG *a, BN_ULONG *b, int n2,
 
         bn_mul_comba8(r, a, b);
         bn_mul_comba8(&(r[n2]), &(a[n]), &(b[n]));
-    } else
-#endif /* OPENSSL_SMALL_FOOTPRINT */
-    {
+    } else {
         p = &(t[n2 * 2]);
         if (!zero)
             bn_mul_recursive(&(t[n2]), t, &(t[n]), n, 0, 0, p);
@@ -486,7 +482,7 @@ void bn_mul_low_recursive(BN_ULONG *r, BN_ULONG *a, BN_ULONG *b, int n2,
         bn_add_words(&(r[n]), &(r[n]), &(t[n]), n);
     }
 }
-#endif /* BN_RECURSION */
+#endif /* OPENSSL_SMALL_FOOTPRINT */
 
 int BN_mul(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, BN_CTX *ctx)
 {
@@ -503,10 +499,8 @@ int bn_mul_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, BN_CTX *ctx)
     int ret = 0;
     int top, al, bl;
     BIGNUM *rr;
-#if !defined(OPENSSL_SMALL_FOOTPRINT) || defined(BN_RECURSION)
+#if !defined(OPENSSL_SMALL_FOOTPRINT)
     int i;
-#endif
-#ifdef BN_RECURSION
     BIGNUM *t = NULL;
     int j = 0, k;
 #endif
@@ -531,10 +525,9 @@ int bn_mul_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, BN_CTX *ctx)
     } else
         rr = r;
 
-#if !defined(OPENSSL_SMALL_FOOTPRINT) || defined(BN_RECURSION)
+#if !defined(OPENSSL_SMALL_FOOTPRINT)
     i = al - bl;
-#endif
-#ifndef OPENSSL_SMALL_FOOTPRINT
+
     if (i == 0) {
 #if 0
         if (al == 4) {
@@ -553,8 +546,7 @@ int bn_mul_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, BN_CTX *ctx)
             goto end;
         }
     }
-#endif /* OPENSSL_SMALL_FOOTPRINT */
-#ifdef BN_RECURSION
+
     if ((al >= BN_MULL_SIZE_NORMAL) && (bl >= BN_MULL_SIZE_NORMAL)) {
         if (i >= -1 && i <= 1) {
             /*
@@ -592,13 +584,13 @@ int bn_mul_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, BN_CTX *ctx)
             goto end;
         }
     }
-#endif /* BN_RECURSION */
+#endif /* OPENSSL_SMALL_FOOTPRINT */
     if (bn_wexpand(rr, top) == NULL)
         goto err;
     rr->top = top;
     bn_mul_normal(rr->d, a->d, al, b->d, bl);
 
-#if !defined(OPENSSL_SMALL_FOOTPRINT) || defined(BN_RECURSION)
+#if !defined(OPENSSL_SMALL_FOOTPRINT)
 end:
 #endif
     rr->neg = a->neg ^ b->neg;

--- a/crypto/bn/bn_sqr.c
+++ b/crypto/bn/bn_sqr.c
@@ -50,14 +50,14 @@ int bn_sqr_fixed_top(BIGNUM *r, const BIGNUM *a, BN_CTX *ctx)
         goto err;
 
     if (al == 4) {
-#ifndef BN_SQR_COMBA
+#ifdef OPENSSL_SMALL_FOOTPRINT
         BN_ULONG t[8];
         bn_sqr_normal(rr->d, a->d, 4, t);
 #else
         bn_sqr_comba4(rr->d, a->d);
 #endif
     } else if (al == 8) {
-#ifndef BN_SQR_COMBA
+#ifdef OPENSSL_SMALL_FOOTPRINT
         BN_ULONG t[16];
         bn_sqr_normal(rr->d, a->d, 8, t);
 #else
@@ -160,14 +160,14 @@ void bn_sqr_recursive(BN_ULONG *r, const BN_ULONG *a, int n2, BN_ULONG *t)
     BN_ULONG ln, lo, *p;
 
     if (n2 == 4) {
-#ifndef BN_SQR_COMBA
+#ifdef OPENSSL_SMALL_FOOTPRINT
         bn_sqr_normal(r, a, 4, t);
 #else
         bn_sqr_comba4(r, a);
 #endif
         return;
     } else if (n2 == 8) {
-#ifndef BN_SQR_COMBA
+#ifdef OPENSSL_SMALL_FOOTPRINT
         bn_sqr_normal(r, a, 8, t);
 #else
         bn_sqr_comba8(r, a);


### PR DESCRIPTION
It does not represent a feature that some arch may or may not possess, but instead is entirely dependent on the OPENSSL_SMALL_FOOTPRINT option.

I found having `BN_MUL_COMBA` a little more confusing when porting OpenSSL to a new architecture.