### PR TITLE
Updating the Client's parsing of the Cert Status Body

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2947,8 +2947,6 @@ int tls_process_cert_status_body(SSL_CONNECTION *s, size_t chainidx, PACKET *pkt
             return 0;
         }
 
-        ;
-
         if ((respder = OPENSSL_malloc(resplen)) == NULL) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_CRYPTO_LIB);
             return 0;

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2942,29 +2942,32 @@ int tls_process_cert_status_body(SSL_CONNECTION *s, size_t chainidx, PACKET *pkt
             return 0;
         }
 
-        if (resplen > 0) {
-            respder = OPENSSL_malloc(resplen);
-
-            if (respder == NULL) {
-                SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_CRYPTO_LIB);
-                return 0;
-            }
-
-            if (!PACKET_copy_bytes(pkt, respder, resplen)) {
-                SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_LENGTH_MISMATCH);
-                OPENSSL_free(respder);
-                return 0;
-            }
-            p = respder;
-            resp = d2i_OCSP_RESPONSE(NULL, &p, (long)resplen);
-            OPENSSL_free(respder);
-            if (resp == NULL) {
-                SSLfatal(s, TLS1_AD_BAD_CERTIFICATE_STATUS_RESPONSE,
-                         SSL_R_TLSV1_BAD_CERTIFICATE_STATUS_RESPONSE);
-                return 0;
-            }
-            sk_OCSP_RESPONSE_insert(s->ext.ocsp.resp_ex, resp, (int)chainidx);
+        if (resplen == 0) {
+            SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_BAD_PACKET);
+            return 0;
         }
+
+        respder = OPENSSL_malloc(resplen);
+
+        if (respder == NULL) {
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_CRYPTO_LIB);
+            return 0;
+        }
+
+        if (!PACKET_copy_bytes(pkt, respder, resplen)) {
+            SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_LENGTH_MISMATCH);
+            OPENSSL_free(respder);
+            return 0;
+        }
+        p = respder;
+        resp = d2i_OCSP_RESPONSE(NULL, &p, (long)resplen);
+        OPENSSL_free(respder);
+        if (resp == NULL) {
+            SSLfatal(s, TLS1_AD_BAD_CERTIFICATE_STATUS_RESPONSE,
+                     SSL_R_TLSV1_BAD_CERTIFICATE_STATUS_RESPONSE);
+            return 0;
+        }
+        sk_OCSP_RESPONSE_insert(s->ext.ocsp.resp_ex, resp, (int)chainidx);
     }
 
 #endif

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2947,9 +2947,9 @@ int tls_process_cert_status_body(SSL_CONNECTION *s, size_t chainidx, PACKET *pkt
             return 0;
         }
 
-        respder = OPENSSL_malloc(resplen);
+        ;
 
-        if (respder == NULL) {
+        if ((respder = OPENSSL_malloc(resplen)) == NULL) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_CRYPTO_LIB);
             return 0;
         }


### PR DESCRIPTION
When a Cert status body is received and the length of the response is zero error out.

This PR is dependent on
https://github.com/openssl/openssl/pull/28955

It will not pass tests until this PR is merged into master.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] tests are added or updated
