### PR TITLE
Update the ssl trace reference for test_sslapi

### DIFF
--- a/test/recipes/90-test_sslapi_data/ssltraceref-zlib.txt
+++ b/test/recipes/90-test_sslapi_data/ssltraceref-zlib.txt
@@ -123,24 +123,24 @@ Certificate:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (2048 bit)
                 Modulus:
-                    00:d5:5d:60:6a:df:fc:61:ee:48:aa:8c:11:48:43:
-                    a5:6d:b6:52:5d:aa:98:49:b1:61:92:35:b1:fc:3a:
-                    04:25:0c:6d:79:ff:b4:d5:c9:e9:5c:1c:3b:e0:ab:
-                    b3:b8:7d:a3:de:6d:bd:e0:dd:d7:5a:bf:14:47:11:
-                    42:5e:a6:82:d0:61:c1:7f:dd:13:46:e6:09:85:07:
-                    0e:f2:d4:fc:1a:64:d2:0a:ad:20:ab:20:6b:96:f0:
-                    ad:cc:c4:19:53:55:dc:01:1d:a4:b3:ef:8a:b4:49:
-                    53:5d:8a:05:1c:f1:dc:e1:44:bf:c5:d7:e2:77:19:
-                    57:5c:97:0b:75:ee:88:43:71:0f:ca:6c:c1:b4:b2:
-                    50:a7:77:46:6c:58:0f:11:bf:f1:76:24:5a:ae:39:
-                    42:b7:51:67:29:e1:d0:55:30:6f:17:e4:91:ea:ad:
-                    f8:28:c2:43:6f:a2:64:a9:fb:9d:98:92:62:48:3e:
-                    eb:0d:4f:82:4a:8a:ff:3f:72:ee:96:b5:ae:a1:c1:
-                    98:ba:ef:7d:90:75:6d:ff:5a:52:9e:ab:f5:c0:7e:
-                    d0:87:43:db:85:07:07:0f:7d:38:7a:fd:d1:d3:ee:
-                    65:1d:d3:ea:39:6a:87:37:ee:4a:d3:e0:0d:6e:f5:
-                    70:ac:c2:bd:f1:6e:f3:92:95:5e:a9:f0:a1:65:95:
-                    93:8d
+                    d5:5d:60:6a:df:fc:61:ee:48:aa:8c:11:48:43:a5:
+                    6d:b6:52:5d:aa:98:49:b1:61:92:35:b1:fc:3a:04:
+                    25:0c:6d:79:ff:b4:d5:c9:e9:5c:1c:3b:e0:ab:b3:
+                    b8:7d:a3:de:6d:bd:e0:dd:d7:5a:bf:14:47:11:42:
+                    5e:a6:82:d0:61:c1:7f:dd:13:46:e6:09:85:07:0e:
+                    f2:d4:fc:1a:64:d2:0a:ad:20:ab:20:6b:96:f0:ad:
+                    cc:c4:19:53:55:dc:01:1d:a4:b3:ef:8a:b4:49:53:
+                    5d:8a:05:1c:f1:dc:e1:44:bf:c5:d7:e2:77:19:57:
+                    5c:97:0b:75:ee:88:43:71:0f:ca:6c:c1:b4:b2:50:
+                    a7:77:46:6c:58:0f:11:bf:f1:76:24:5a:ae:39:42:
+                    b7:51:67:29:e1:d0:55:30:6f:17:e4:91:ea:ad:f8:
+                    28:c2:43:6f:a2:64:a9:fb:9d:98:92:62:48:3e:eb:
+                    0d:4f:82:4a:8a:ff:3f:72:ee:96:b5:ae:a1:c1:98:
+                    ba:ef:7d:90:75:6d:ff:5a:52:9e:ab:f5:c0:7e:d0:
+                    87:43:db:85:07:07:0f:7d:38:7a:fd:d1:d3:ee:65:
+                    1d:d3:ea:39:6a:87:37:ee:4a:d3:e0:0d:6e:f5:70:
+                    ac:c2:bd:f1:6e:f3:92:95:5e:a9:f0:a1:65:95:93:
+                    8d
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Subject Key Identifier: 

--- a/test/recipes/90-test_sslapi_data/ssltraceref.txt
+++ b/test/recipes/90-test_sslapi_data/ssltraceref.txt
@@ -121,24 +121,24 @@ Certificate:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (2048 bit)
                 Modulus:
-                    00:d5:5d:60:6a:df:fc:61:ee:48:aa:8c:11:48:43:
-                    a5:6d:b6:52:5d:aa:98:49:b1:61:92:35:b1:fc:3a:
-                    04:25:0c:6d:79:ff:b4:d5:c9:e9:5c:1c:3b:e0:ab:
-                    b3:b8:7d:a3:de:6d:bd:e0:dd:d7:5a:bf:14:47:11:
-                    42:5e:a6:82:d0:61:c1:7f:dd:13:46:e6:09:85:07:
-                    0e:f2:d4:fc:1a:64:d2:0a:ad:20:ab:20:6b:96:f0:
-                    ad:cc:c4:19:53:55:dc:01:1d:a4:b3:ef:8a:b4:49:
-                    53:5d:8a:05:1c:f1:dc:e1:44:bf:c5:d7:e2:77:19:
-                    57:5c:97:0b:75:ee:88:43:71:0f:ca:6c:c1:b4:b2:
-                    50:a7:77:46:6c:58:0f:11:bf:f1:76:24:5a:ae:39:
-                    42:b7:51:67:29:e1:d0:55:30:6f:17:e4:91:ea:ad:
-                    f8:28:c2:43:6f:a2:64:a9:fb:9d:98:92:62:48:3e:
-                    eb:0d:4f:82:4a:8a:ff:3f:72:ee:96:b5:ae:a1:c1:
-                    98:ba:ef:7d:90:75:6d:ff:5a:52:9e:ab:f5:c0:7e:
-                    d0:87:43:db:85:07:07:0f:7d:38:7a:fd:d1:d3:ee:
-                    65:1d:d3:ea:39:6a:87:37:ee:4a:d3:e0:0d:6e:f5:
-                    70:ac:c2:bd:f1:6e:f3:92:95:5e:a9:f0:a1:65:95:
-                    93:8d
+                    d5:5d:60:6a:df:fc:61:ee:48:aa:8c:11:48:43:a5:
+                    6d:b6:52:5d:aa:98:49:b1:61:92:35:b1:fc:3a:04:
+                    25:0c:6d:79:ff:b4:d5:c9:e9:5c:1c:3b:e0:ab:b3:
+                    b8:7d:a3:de:6d:bd:e0:dd:d7:5a:bf:14:47:11:42:
+                    5e:a6:82:d0:61:c1:7f:dd:13:46:e6:09:85:07:0e:
+                    f2:d4:fc:1a:64:d2:0a:ad:20:ab:20:6b:96:f0:ad:
+                    cc:c4:19:53:55:dc:01:1d:a4:b3:ef:8a:b4:49:53:
+                    5d:8a:05:1c:f1:dc:e1:44:bf:c5:d7:e2:77:19:57:
+                    5c:97:0b:75:ee:88:43:71:0f:ca:6c:c1:b4:b2:50:
+                    a7:77:46:6c:58:0f:11:bf:f1:76:24:5a:ae:39:42:
+                    b7:51:67:29:e1:d0:55:30:6f:17:e4:91:ea:ad:f8:
+                    28:c2:43:6f:a2:64:a9:fb:9d:98:92:62:48:3e:eb:
+                    0d:4f:82:4a:8a:ff:3f:72:ee:96:b5:ae:a1:c1:98:
+                    ba:ef:7d:90:75:6d:ff:5a:52:9e:ab:f5:c0:7e:d0:
+                    87:43:db:85:07:07:0f:7d:38:7a:fd:d1:d3:ee:65:
+                    1d:d3:ea:39:6a:87:37:ee:4a:d3:e0:0d:6e:f5:70:
+                    ac:c2:bd:f1:6e:f3:92:95:5e:a9:f0:a1:65:95:93:
+                    8d
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Subject Key Identifier: 


### PR DESCRIPTION
The SSL tracing reference comparison was added also to the sslapitest in the mean time. We must update it as well.

Fixes ec114826

This is urgent as this fixes a CI breakage.
