### PR TITLE
Make engine permanent disable and clean engine test configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,7 +588,7 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
-      run: ./config --strict-warnings --banner=Configured --debug no-afalgeng enable-demos enable-h3demo no-shared enable-crypto-mdebug enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 no-fips && perl configdata.pm --dump
+      run: ./config --strict-warnings --banner=Configured --debug enable-demos enable-h3demo no-shared enable-crypto-mdebug enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 no-fips && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: get cpu info
@@ -711,7 +711,7 @@ jobs:
     - name: setup hostname workaround
       run: sudo hostname localhost
     - name: config
-      run: ./config --strict-warnings --banner=Configured --debug no-afalgeng enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 enable-external-tests no-fips && perl configdata.pm --dump
+      run: ./config --strict-warnings --banner=Configured --debug enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 enable-external-tests no-fips && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - uses: dtolnay/rust-toolchain@0f44b27771c32bda9f458f75a1e241b09791b331

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -68,7 +68,7 @@ jobs:
               "extra_config": "no-afalgeng enable-fips"
             }, {
               "branch": "master",
-              "extra_config": "no-afalgeng enable-fips enable-tfo enable-lms enable-crypto-mdebug enable-allocfail-tests"
+              "extra_config": "enable-fips enable-tfo enable-lms enable-crypto-mdebug enable-allocfail-tests"
           }]
           EOF
           )

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -24,7 +24,6 @@ jobs:
       matrix:
         opt: [
           386,
-          no-afalgeng,
           no-apps,
           no-argon2,
           no-aria,
@@ -41,7 +40,6 @@ jobs:
           no-bulk,
           no-cached-fetch,
           no-camellia,
-          no-capieng,
           no-cast,
           no-chacha,
           no-cmac,
@@ -52,7 +50,6 @@ jobs:
           enable-demos,
           no-deprecated,
           no-des,
-#          enable-devcryptoeng,  # Cannot work on Linux
           no-docs,
           no-dsa,
           no-dtls1,
@@ -63,7 +60,6 @@ jobs:
           no-ecdsa,
           enable-ec_nistp_64_gcc_128,
           enable-egd,
-          no-engine,
 #          enable-external-tests,  # Requires extra setup
           enable-fips,
           enable-fips enable-acvp-tests,
@@ -76,7 +72,6 @@ jobs:
           enable-heartbeats,
           enable-hqinterop,
           no-hw,
-          no-hw-padlock,
           no-idea,
           enable-lms,
           no-makedepend,
@@ -87,7 +82,6 @@ jobs:
           no-multiblock,
           no-nextprotoneg,
           no-ocb,
-          no-padlockeng,
           no-pic,
           no-poly1305,
           no-posix-io,
@@ -114,7 +108,7 @@ jobs:
           enable-ssl3,
           enable-ssl3-method,
           enable-sslkeylog,
-          no-static-engine no-shared,
+          no-shared,
           no-tests,
           enable-tfo,
           no-tls1,

--- a/.github/workflows/run-checker-merge.yml
+++ b/.github/workflows/run-checker-merge.yml
@@ -20,9 +20,8 @@ jobs:
         opt: [
           enable-asan enable-ubsan no-shared no-asm -DOPENSSL_SMALL_FOOTPRINT -fno-sanitize=function,
           no-dso,
-          no-dynamic-engine,
           no-ec2m enable-fips,
-          no-engine no-shared,
+          no-shared,
           no-err,
           no-filenames,
           enable-ubsan no-asm -DOPENSSL_SMALL_FOOTPRINT -fno-sanitize=function,

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -2046,7 +2046,7 @@ my %targets = (
         asflags          => sub { vms_info()->{asflags} },
         perlasm_scheme   => sub { vms_info()->{perlasm_scheme} },
 
-        disable          => add('pinshared', 'loadereng'),
+        disable          => add('pinshared'),
 
     },
 

--- a/Configure
+++ b/Configure
@@ -24,14 +24,6 @@ use OpenSSL::config;
 
 # see INSTALL.md for instructions.
 
-# Set this variable to 1 if you want to skip all the Engine related tests
-# Re-enable with 0. (and you also should add back 'afalgeng' in
-# Configurations/10-main.conf to the enable array at (possible) line 697
-# (targets/linux_generic32)
-# This is needed for engine removal process, because we can't do it in one big
-# bulk and otherwise there will be failing tests and we want the CI to be happy.
-my $disable_engine_removal = 1;
-
 my $orig_death_handler = $SIG{__DIE__};
 $SIG{__DIE__} = \&death_handler;
 
@@ -430,7 +422,6 @@ my @dtls = qw(dtls1 dtls1_2);
 
 my @disablables = (
     "acvp-tests",
-    "afalgeng",
     "apps",
     "argon2",
     "aria",
@@ -449,7 +440,6 @@ my @disablables = (
     "bulk",
     "cached-fetch",
     "camellia",
-    "capieng",
     "winstore",
     "cast",
     "chacha",
@@ -466,7 +456,6 @@ my @disablables = (
     "hqinterop",
     "deprecated",
     "des",
-    "devcryptoeng",
     "dgram",
     "dh",
     "docs",
@@ -498,7 +487,6 @@ my @disablables = (
     "ktls",
     "legacy",
     "lms",
-    "loadereng",
     "makedepend",
     "md2",
     "md4",
@@ -511,7 +499,6 @@ my @disablables = (
     "nextprotoneg",
     "ocb",
     "ocsp",
-    "padlockeng",
     "pic",
     "pie",
     "pinshared",
@@ -591,8 +578,8 @@ my %deprecated_disablables = (
     "ssl2" => undef,
     "buf-freelists" => undef,
     "crypto-mdebug-backtrace" => undef,
-    "hw" => "hw",               # causes cascade, but no macro
-    "hw-padlock" => "padlockeng",
+    "hw" => undef,
+    "hw-padlock" => undef,
     "ripemd" => "rmd160",
     "ui" => "ui-console",
     "heartbeats" => undef,
@@ -696,12 +683,11 @@ my @disable_cascades = (
     "pic"               => [ "shared", "module" ],
 
     "engine"            => [ grep(/eng$/, @disablables) ],
-    "hw"                => [ "padlockeng" ],
 
     # no-autoalginit is only useful when building non-shared
     "autoalginit"       => [ "shared", "apps", "fips" ],
 
-    "stdio"             => [ "apps", "capieng", "egd" ],
+    "stdio"             => [ "apps", "egd" ],
     "apps"              => [ "tests" ],
     "tests"             => [ "external-tests" ],
     "comp"              => [ "zlib", "brotli", "zstd" ],
@@ -1816,38 +1802,6 @@ $config{CFLAGS} = [ map { $_ eq '--ossl-strict-warnings'
                               ? @strict_warnings_collection
                               : ( $_ ) }
                     @{$config{CFLAGS}} ];
-
-if ($disable_engine_removal == 1) {
-    disable("engine-removal", "engine");
-    disable("engine-removal", "afalgeng");
-    disable("engine-removal", "capieng");
-    disable("engine-removal", "loadereng");
-    disable("engine-removal", "padlockeng");
-}
-
-unless ($disabled{afalgeng}) {
-    $config{afalgeng}="";
-    if (grep { $_ eq 'afalgeng' } @{$target{enable}}) {
-        push @{$config{engdirs}}, "afalg";
-    } else {
-        disable('not-linux', 'afalgeng');
-    }
-}
-
-unless ($disabled{devcryptoeng}) {
-    if ($target =~ m/^BSD/) {
-        my $maxver = 5*100 + 7;
-        my $sysstr = `uname -s`;
-        my $verstr = `uname -r`;
-        $sysstr =~ s|\R$||;
-        $verstr =~ s|\R$||;
-        my ($ma, $mi, @rest) = split m|\.|, $verstr;
-        my $ver = $ma*100 + $mi;
-        if ($sysstr eq 'OpenBSD' && $ver >= $maxver) {
-            disable('too-new-kernel', 'devcryptoeng');
-        }
-    }
-}
 
 unless ($disabled{ktls}) {
     $config{ktls}="";

--- a/Configure
+++ b/Configure
@@ -469,7 +469,6 @@ my @disablables = (
     "ecdsa",
     "ecx",
     "egd",
-    "engine",
     "err",
     "external-tests",
     "filenames",
@@ -602,6 +601,7 @@ our %disabled = ( # "what"         => "comment"
                   "hqinterop"           => "default",
                   "ec_nistp_64_gcc_128" => "default",
                   "egd"                 => "default",
+                  "engine"              => "default",
                   "external-tests"      => "default",
                   "fuzz-afl"            => "default",
                   "fuzz-libfuzzer"      => "default",
@@ -635,7 +635,7 @@ my @disable_cascades = (
                              "blake2", "bf", "camellia", "cast", "chacha",
                              "cmac", "cms", "cmp", "comp", "ct",
                              "des", "dgram", "dh", "dsa",
-                             "ec", "engine",
+                             "ec",
                              "filenames",
                              "idea", "ktls", "lms",
                              "md4", "ml-dsa", "ml-kem", "multiblock",
@@ -682,7 +682,7 @@ my @disable_cascades = (
     # or modules.
     "pic"               => [ "shared", "module" ],
 
-    "engine"            => [ grep(/eng$/, @disablables) ],
+    "engine"            => [ "static-engine", "dynamic-engine" ],
 
     # no-autoalginit is only useful when building non-shared
     "autoalginit"       => [ "shared", "apps", "fips" ],
@@ -709,7 +709,7 @@ my @disable_cascades = (
 
     "blake2"            => [ "argon2" ],
 
-    "deprecated-3.0"    => [ "engine", "srp" ],
+    "deprecated-3.0"    => [ "srp" ],
 
     "http"              => [ "ocsp" ]
     );

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -584,12 +584,6 @@ In the following list, always the non-default variant is documented: if
 feature `xxxx` is disabled by default then `enable-xxxx` is documented and
 if feature `xxxx` is enabled by default then `no-xxxx` is documented.
 
-### no-afalgeng
-
-Don't build the AFALG engine.
-
-This option will be forced on a platform that does not support AFALG.
-
 ### enable-ktls
 
 Build with Kernel TLS support.
@@ -715,12 +709,6 @@ this option will reduce run-time memory usage but it also introduces a
 significant performance penalty.  This option is primarily designed to help
 with detecting incorrect reference counting.
 
-### no-capieng
-
-Don't build the CAPI engine.
-
-This option will be forced if on a platform that does not support CAPI.
-
 ### no-cmp
 
 Don't build support for Certificate Management Protocol (CMP)
@@ -772,13 +760,6 @@ Don't build and install documentation, i.e. manual pages in various forms.
 ### no-dso
 
 Don't build support for loading Dynamic Shared Objects (DSO)
-
-### enable-devcryptoeng
-
-Build the `/dev/crypto` engine.
-
-This option is automatically selected on the BSD platform, in which case it can
-be disabled with `no-devcryptoeng`.
 
 ### no-dynamic-engine
 
@@ -939,14 +920,6 @@ Don't build support for the Next Protocol Negotiation (NPN) TLS extension.
 ### no-ocsp
 
 Don't build support for Online Certificate Status Protocol (OCSP).
-
-### no-padlockeng
-
-Don't build the padlock engine.
-
-### no-hw-padlock
-
-As synonym for `no-padlockeng`.  Deprecated and should not be used.
 
 ### no-pic
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -761,12 +761,6 @@ Don't build and install documentation, i.e. manual pages in various forms.
 
 Don't build support for loading Dynamic Shared Objects (DSO)
 
-### no-dynamic-engine
-
-Don't build the dynamically loaded engines.
-
-This only has an effect in a shared build.
-
 ### no-ec
 
 Don't build support for Elliptic Curves.
@@ -797,10 +791,6 @@ This option is only supported on platforms:
 ### enable-egd
 
 Build support for gathering entropy from the Entropy Gathering Daemon (EGD).
-
-### no-engine
-
-Don't build support for loading engines.
 
 ### no-err
 
@@ -903,9 +893,7 @@ support.  ML-KEM is based on CRYSTALS-KYBER. See [FIPS 203].
 
 ### no-module
 
-Don't build any dynamically loadable engines.
-
-This also implies `no-dynamic-engine`.
+Don't build any dynamically loadable modules.
 
 ### no-multiblock
 
@@ -1026,12 +1014,6 @@ This removes the `-trace` option from `s_client` and `s_server`, and omits the
 `SSL_trace()` function from libssl.
 
 Disabling `ssl-trace` may provide a small reduction in libssl binary size.
-
-### no-static-engine
-
-Don't build the statically linked engines.
-
-This only has an impact when not built "shared".
 
 ### no-stdio
 
@@ -1521,7 +1503,6 @@ its default):
                    to build your own programs that use libcrypto
                    or libssl.
     lib            Contains the OpenSSL library files.
-    lib/engines    Contains the OpenSSL dynamically loadable engines.
 
     share/man/man1 Contains the OpenSSL command line man-pages.
     share/man/man3 Contains the OpenSSL library calls man-pages.
@@ -1547,8 +1528,6 @@ its default):
                    to build your own programs that use libcrypto
                    or libssl.
     [.LIB.'arch']  Contains the OpenSSL library files.
-    [.ENGINES'sover''pz'.'arch']
-                   Contains the OpenSSL dynamically loadable engines.
     [.SYS$STARTUP] Contains startup, login and shutdown scripts.
                    These define appropriate logical names and
                    command symbols.
@@ -1569,7 +1548,7 @@ for you convenience:
 
 The installation directory should be appropriately protected to ensure
 unprivileged users cannot make changes to OpenSSL binaries or files, or
-install engines.  If you already have a pre-installed version of OpenSSL as
+install providers.  If you already have a pre-installed version of OpenSSL as
 part of your Operating System it is recommended that you do not overwrite
 the system version and instead install to somewhere else.
 


### PR DESCRIPTION
Do not allow usert to reenable engines but set proper defines in configuration.h.

Also remove all engine build configurations as the code is gone. The test no longe contains engine as well.

- [ ] documentation is added or updated
- [x] tests are added or updated

(pls check if Configure is not setup correctly, it is kind of magic...)