### PR TITLE
Add release notes from NEWS.md when making a release

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -42,6 +42,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       run: |
-        VERSION="$(echo "$GITHUB_REF_NAME" | cut -d '-' -f 2-)"
+        VERSION=$(echo "$GITHUB_REF_NAME" | cut -d "-" -f 2-)
         PRE_RELEASE=$([[ "$GITHUB_REF_NAME" =~ alpha|beta ]] && echo "-p" || echo "")
-        gh release create "$GITHUB_REF_NAME" $PRE_RELEASE -t "OpenSSL $VERSION" -d --notes " " -R "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME/assets/"*
+        NOTES=$(curl -s "https://api.openssl.org/release-metadata/news/?version=$VERSION&capture_title=False")
+        gh release create "$GITHUB_REF_NAME" $PRE_RELEASE -t "OpenSSL $VERSION" -d --notes "$NOTES" -R "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME/assets/"*


### PR DESCRIPTION
This PR updates release workflow. It adds release notes from NEWS.md for the releasing version via https://api.openssl.org/release-metadata/news/ endpoint.

Here is the test run for tag `openssl-3.6.0-alpha1`: https://github.com/quarckster/openssl-fork/actions/runs/19698296712

Draft release

<img width="2072" height="1668" alt="image" src="https://github.com/user-attachments/assets/9fa75e5c-b12b-4263-b4dc-cb6fc89ca42f" />



