### PR TITLE
Configure: Warn about deprecated option when enabled

### DIFF
--- a/Configure
+++ b/Configure
@@ -984,6 +984,10 @@ while (@argvcopy)
                         delete $disabled{"fips"};
                         delete $disabled{"jitter"};
                         }
+                elsif (exists $deprecated_disablables{$1})
+                        {
+                        $deprecated_options{$_} = 1;
+                        }
                 my $algo = $1;
                 delete $disabled{$algo};
 


### PR DESCRIPTION
Currently the deprecated configure option is warned only when
"(no|disabled)-feature" is used, but wasn't warning when
"enable-feature" was passed as a config option.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
