### PR TITLE
Config: refactor VC-WIN64A-masm to inherit from VC-WIN64A

### DIFF
--- a/Configurations/50-masm.conf
+++ b/Configurations/50-masm.conf
@@ -9,14 +9,11 @@
 
 my %targets = (
     "VC-WIN64A-masm" => {
-        inherit_from    => [ "VC-WIN64-common" ],
+        inherit_from    => [ "VC-WIN64A" ],
         AS              => "ml64",
         ASFLAGS         => "/nologo /Zi",
         asoutflag       => "/Fo",
         asflags         => "/c /Cp /Cx",
-        sys_id          => "WIN64A",
-        uplink_arch      => 'x86_64',
-        asm_arch         => 'x86_64',
         perlasm_scheme   => "masm",
     },
 );


### PR DESCRIPTION
VC-WIN64A-masm is almost a copy of VC-WIN64A, where only the assembler
related attributes differ, so it appears more beneficial to have the
VC-WIN64A-masm inherit from VC-WIN64A and only modify the attributes
that differ.
