### PR TITLE
Move CRL extensions from v3_ocsp.c to v3_crldp.c

### DIFF
--- a/crypto/ocsp/v3_ocsp.c
+++ b/crypto/ocsp/v3_ocsp.c
@@ -24,8 +24,6 @@ static int i2r_ocsp_crlid(const X509V3_EXT_METHOD *method, void *nonce,
                           BIO *out, int indent);
 static int i2r_ocsp_acutoff(const X509V3_EXT_METHOD *method, void *nonce,
                             BIO *out, int indent);
-static int i2r_object(const X509V3_EXT_METHOD *method, void *obj, BIO *out,
-                      int indent);
 
 static void *ocsp_nonce_new(void);
 static int i2d_ocsp_nonce(const void *a, unsigned char **pp);
@@ -56,24 +54,6 @@ const X509V3_EXT_METHOD ossl_v3_ocsp_acutoff = {
     0, 0,
     0, 0,
     i2r_ocsp_acutoff, 0,
-    NULL
-};
-
-const X509V3_EXT_METHOD ossl_v3_crl_invdate = {
-    NID_invalidity_date, 0, ASN1_ITEM_ref(ASN1_GENERALIZEDTIME),
-    0, 0, 0, 0,
-    0, 0,
-    0, 0,
-    i2r_ocsp_acutoff, 0,
-    NULL
-};
-
-const X509V3_EXT_METHOD ossl_v3_crl_hold = {
-    NID_hold_instruction_code, 0, ASN1_ITEM_ref(ASN1_OBJECT),
-    0, 0, 0, 0,
-    0, 0,
-    0, 0,
-    i2r_object, 0,
     NULL
 };
 
@@ -146,16 +126,6 @@ static int i2r_ocsp_acutoff(const X509V3_EXT_METHOD *method, void *cutoff,
     if (BIO_printf(bp, "%*s", ind, "") <= 0)
         return 0;
     if (!ASN1_GENERALIZEDTIME_print(bp, cutoff))
-        return 0;
-    return 1;
-}
-
-static int i2r_object(const X509V3_EXT_METHOD *method, void *oid, BIO *bp,
-                      int ind)
-{
-    if (BIO_printf(bp, "%*s", ind, "") <= 0)
-        return 0;
-    if (i2a_ASN1_OBJECT(bp, oid) <= 0)
         return 0;
     return 1;
 }

--- a/crypto/x509/standard_exts.h
+++ b/crypto/x509/standard_exts.h
@@ -34,9 +34,7 @@ static const X509V3_EXT_METHOD *standard_exts[] = {
     &ossl_v3_ext_ku,
     &ossl_v3_delta_crl,
     &ossl_v3_crl_reason,
-#ifndef OPENSSL_NO_OCSP
     &ossl_v3_crl_invdate,
-#endif
     &ossl_v3_sxnet,
     &ossl_v3_info,
     &ossl_v3_audit_identity,
@@ -56,9 +54,7 @@ static const X509V3_EXT_METHOD *standard_exts[] = {
     &ossl_v3_policy_constraints,
     &ossl_v3_targeting_information,
     &ossl_v3_no_rev_avail,
-#ifndef OPENSSL_NO_OCSP
     &ossl_v3_crl_hold,
-#endif
     &ossl_v3_pci,
     &ossl_v3_name_constraints,
     &ossl_v3_policy_mappings,

--- a/crypto/x509/v3_crld.c
+++ b/crypto/x509/v3_crld.c
@@ -481,6 +481,49 @@ static int i2r_crldp(const X509V3_EXT_METHOD *method, void *pcrldp, BIO *out,
     return 1;
 }
 
+static int i2r_crl_invdate(const X509V3_EXT_METHOD *method, void *date,
+                           BIO *out, int indent);
+static int i2r_object(const X509V3_EXT_METHOD *method, void *obj, BIO *out,
+                      int indent);
+
+const X509V3_EXT_METHOD ossl_v3_crl_invdate = {
+    NID_invalidity_date, 0, ASN1_ITEM_ref(ASN1_GENERALIZEDTIME),
+    0, 0, 0, 0,
+    0, 0,
+    0, 0,
+    i2r_crl_invdate, 0,
+    NULL
+};
+
+const X509V3_EXT_METHOD ossl_v3_crl_hold = {
+    NID_hold_instruction_code, 0, ASN1_ITEM_ref(ASN1_OBJECT),
+    0, 0, 0, 0,
+    0, 0,
+    0, 0,
+    i2r_object, 0,
+    NULL
+};
+
+static int i2r_crl_invdate(const X509V3_EXT_METHOD *method, void *date,
+                           BIO *bp, int ind)
+{
+    if (BIO_printf(bp, "%*s", ind, "") <= 0)
+        return 0;
+    if (!ASN1_GENERALIZEDTIME_print(bp, date))
+        return 0;
+    return 1;
+}
+
+static int i2r_object(const X509V3_EXT_METHOD *method, void *oid, BIO *bp,
+                      int ind)
+{
+    if (BIO_printf(bp, "%*s", ind, "") <= 0)
+        return 0;
+    if (i2a_ASN1_OBJECT(bp, oid) <= 0)
+        return 0;
+    return 1;
+}
+
 /* Append any nameRelativeToCRLIssuer in dpn to iname, set in dpn->dpname */
 int DIST_POINT_set_dpname(DIST_POINT_NAME *dpn, const X509_NAME *iname)
 {


### PR DESCRIPTION
Otherwise they will not be handled by no-ocsp build.

This fixes a CI regression.
