### PR TITLE
Add freeze flag to method store

### DIFF
--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -552,11 +552,11 @@ int ossl_method_store_remove_all_provided(OSSL_METHOD_STORE *store,
     return 1;
 }
 
-int ossl_method_store_freeze(OSSL_METHOD_STORE *store, const char *prop_query)
+int ossl_method_store_freeze(OSSL_METHOD_STORE *store)
 {
     if (store == NULL || store->frozen == 1)
         return 0;
-    /* TODO: FREEZE: Create frozen caches & do something with prop_query */
+    /* TODO: FREEZE: Create frozen caches */
     store->frozen = 1;
     return 1;
 }

--- a/include/internal/property.h
+++ b/include/internal/property.h
@@ -70,7 +70,7 @@ int ossl_method_store_fetch(OSSL_METHOD_STORE *store,
     const OSSL_PROVIDER **prov, void **method);
 int ossl_method_store_remove_all_provided(OSSL_METHOD_STORE *store,
     const OSSL_PROVIDER *prov);
-int ossl_method_store_freeze(OSSL_METHOD_STORE *store, const char *prop_query);
+int ossl_method_store_freeze(OSSL_METHOD_STORE *store);
 
 /* Get the global properties associate with the specified library context */
 OSSL_PROPERTY_LIST **ossl_ctx_global_properties(OSSL_LIB_CTX *ctx,

--- a/test/property_test.c
+++ b/test/property_test.c
@@ -433,7 +433,7 @@ static int test_freeze_flag(void)
         || !TEST_true(ossl_method_store_fetch(store, nid, prop, &fetched_prov, &fetched_meth))
         || !TEST_ptr_eq(&prov, fetched_prov)
         || !TEST_str_eq((char *)fetched_meth, impl)
-        || !TEST_true(ossl_method_store_freeze(store, NULL))
+        || !TEST_true(ossl_method_store_freeze(store))
         || !TEST_false(ossl_method_store_remove(store, nid, impl))
         || !TEST_true(ossl_method_store_fetch(store, nid, prop, &fetched_prov, &fetched_meth))
         || !TEST_ptr_eq(&prov, fetched_prov)
@@ -443,7 +443,7 @@ static int test_freeze_flag(void)
         || !TEST_ptr_eq(&prov, fetched_prov)
         || !TEST_str_eq((char *)fetched_meth, impl)
         || !TEST_false(ossl_method_store_add(store, &prov, nid, prop2, impl2, &up_ref, &down_ref))
-        || !TEST_false(ossl_method_store_freeze(store, NULL)))
+        || !TEST_false(ossl_method_store_freeze(store)))
         goto err;
 
     ret = 1;


### PR DESCRIPTION
Add freeze flag to method store. Also add unit test to check that after freeze, method store cannot be modified and still works as expected.

Fixes https://github.com/openssl/project/issues/1721

##### Checklist

- [x] tests are added or updated