### PR TITLE
Skip symbol_presence test on AIX

### DIFF
--- a/test/recipes/01-test_symbol_presence.t
+++ b/test/recipes/01-test_symbol_presence.t
@@ -24,6 +24,8 @@ use platform;
 plan skip_all => "Test is disabled on NonStop" if config('target') =~ m|^nonstop|;
 # MacOS arranges symbol names differently
 plan skip_all => "Test is disabled on MacOS" if config('target') =~ m|^darwin|;
+# AIX reports symbol names differently
+plan skip_all => "Test is disabled on AIX" if config('target') =~ m|^aix|;
 plan skip_all => "This is unsupported on platforms that don't have 'nm'"
     unless IPC::Cmd::can_run('nm');
 


### PR DESCRIPTION
AIX `nm` reports symbols in a different way.

Please also apply to OpenSSL 3.5 LTS. Thanks!
Do not apply the patch to branches older than 3.2, because the old implementation is not affected.

Fix for: #29247
Replaces PR #29250 