### PR TITLE
dtls_get_reassembled_message():Fix potential use-after-realloc

### DIFF
--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -946,7 +946,8 @@ static int dtls_get_reassembled_message(SSL_CONNECTION *s, int *errtype,
     }
 
     if (frag_len > 0) {
-        p += DTLS1_HM_HEADER_LENGTH;
+        /* dtls1_preprocess_fragment() above could reallocate init_buf */
+        p = (unsigned char *)s->init_buf->data + DTLS1_HM_HEADER_LENGTH;
 
         i = ssl->method->ssl_read_bytes(ssl, SSL3_RT_HANDSHAKE, NULL,
                                         &p[frag_off], frag_len, 0, &readbytes);


### PR DESCRIPTION
Fortunately due to the initial size of the allocated buffer and the limit for unfragmented DTLS record size the use-after-realloc cannot be triggered.

But we fix the potentially problematic code anyway.

Reported Joshua Rogers. It was found with the
ZeroPath security tooling.
