### PR TITLE
Set key state to MLX_HAVE_NOKEYS when only copy params are present

### DIFF
--- a/providers/implementations/keymgmt/mlx_kmgmt.c
+++ b/providers/implementations/keymgmt/mlx_kmgmt.c
@@ -731,6 +731,7 @@ static void *mlx_kem_dup(const void *vkey, int selection)
     switch (selection & OSSL_KEYMGMT_SELECT_KEYPAIR) {
     case 0:
         ret->xkey = ret->mkey = NULL;
+        ret->state = MLX_HAVE_NOKEYS;
         return ret;
     case OSSL_KEYMGMT_SELECT_KEYPAIR:
         ret->mkey = EVP_PKEY_dup(key->mkey);


### PR DESCRIPTION
Set key state to MLX_HAVE_NOKEYS when only copy params are present, otherwise, the key state may be incorrect.