### PR TITLE
Remove redundant BIO_free() call

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -57,10 +57,10 @@ int RECORD_LAYER_clear(RECORD_LAYER *rl)
         rl->rrlmethod->free(rl->rrl); /* Ignore return value */
     if (rl->wrlmethod != NULL)
         rl->wrlmethod->free(rl->wrl); /* Ignore return value */
-    BIO_free(rl->rrlnext);
+
     rl->rrlmethod = NULL;
     rl->wrlmethod = NULL;
-    rl->rrlnext = NULL;
+
     rl->rrl = NULL;
     rl->wrl = NULL;
 


### PR DESCRIPTION
Fixes [#29283](https://github.com/openssl/openssl/issues/29283) - Redundant BIO_free(rl->rrlnext) call in RECORD_LAYER_clear() function

CLA: trivial