### PR TITLE
prov-compat-label.yml: Add missing build of 3.6 branch

### DIFF
--- a/.github/workflows/prov-compat-label.yml
+++ b/.github/workflows/prov-compat-label.yml
@@ -126,6 +126,10 @@ jobs:
             dir: branch-3.5,
             tgz: branch-3.5.tar.gz,
           }, {
+            name: openssl-3.6,
+            dir: branch-3.6,
+            tgz: branch-3.6.tar.gz,
+          }, {
             name: master,
             dir: branch-master,
             tgz: branch-master.tar.gz,


### PR DESCRIPTION
This was missed when cherry-picking the addition of 3.6 to stable branches.