### PR TITLE
Make find-doc-nits compatible accross git versions

### DIFF
--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -1296,33 +1296,14 @@ sub check_env_vars {
     my @env_headers;
     my @env_macro;
 
-    # Add submodules to the except_dirs
-    my $git_ok = 0;
-    open my $gs_pipe, '-|', "git config get --all "
-                            . "--file \"$config{sourcedir}/.gitmodules\" "
-                            . "--regexp '.*.path\$'";
-    while (<$gs_pipe>) {
-        $git_ok = 1;
-        s/\R$//; # better chomp
-        print STDERR "DEBUG[check_env_vars]: adding \"$config{sourcedir}/$_\""
-                     . " to except_dirs\n"
-            if $debug;
-        push @except_dirs, "$config{sourcedir}/$_";
-    }
-    close $gs_pipe;
-    # git call has failed, trying to parse .gitmodules manually
-    if (!$git_ok) {
-        print STDERR "DEBUG[check_env_vars]: .gitmodules parsing fallback\n"
-            if $debug;
-        if (open my $gs_file, '<', "$config{sourcedir}/.gitmodules") {
-            while (<$gs_file>) {
-                s/\R$//; # better chomp
-                if ($_ =~ /\s*path\s*=\s*(.*)$/) {
-                    print STDERR "DEBUG[check_env_vars]: adding "
-                                 . "\"$config{sourcedir}/$1\" to except_dirs\n"
-                        if $debug;
-                    push @except_dirs, "$config{sourcedir}/$1";
-                }
+    if (open my $gs_file, '<', "$config{sourcedir}/.gitmodules") {
+        while (<$gs_file>) {
+            s/\R$//; # better chomp
+            if ($_ =~ /\s*path\s*=\s*(.*)$/) {
+                print STDERR "DEBUG[check_env_vars]: adding "
+                             . "\"$config{sourcedir}/$1\" to except_dirs\n"
+                    if $debug;
+                push @except_dirs, "$config{sourcedir}/$1";
             }
         }
     }
@@ -1337,7 +1318,7 @@ sub check_env_vars {
     @except_env_files = map { realpath($_) } @except_env_files;
 
     # look for source files
-    $git_ok = 0;
+    my $git_ok = 0;
     open my $glf_pipe, '-|', "git ls-files -- \"$config{sourcedir}\"";
     while (<$glf_pipe>) {
         $git_ok = 1;


### PR DESCRIPTION
We recently found that the addition of a git config command in util/find-doc-nits is broken in some cases, sepecifically because git around version 2.46 broke command line compatibility, replacing the --regexp option with the --get-regexp option.  So to maintain usage of this specific command to parse the .gitconfig file, we would need to do some extra version detection to construct the proper command line.

However, find-doc-nits already has a fallback condition, which does some pure perl parsing of the gitconfig file, which works perfectly well.

Instead of trying to do version matching to construct the right form of the git config command line, just remove it all, and rely on the perl parrse to do this work for us, which works currently in all cases.

Fixes #29197

