### PR TITLE
rand_lib: do not silently ignore custom seed source failures

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -524,22 +524,30 @@ static EVP_RAND_CTX *rand_new_seed(OSSL_LIB_CTX *libctx)
     const char *propq;
     char *name;
     EVP_RAND_CTX *ctx = NULL;
+    int fallback = 0;
 # ifdef OPENSSL_NO_FIPS_JITTER
     RAND_GLOBAL *dgbl = rand_get_global(libctx);
 
     if (dgbl == NULL)
         return NULL;
     propq = dgbl->seed_propq;
-    name = dgbl->seed_name != NULL ? dgbl->seed_name
-                                   : OPENSSL_MSTR(OPENSSL_DEFAULT_SEED_SRC);
+    if (dgbl->seed_name != NULL) {
+        name = dgbl->seed_name;
+    } else {
+        fallback = 1;
+        name = OPENSSL_MSTR(OPENSSL_DEFAULT_SEED_SRC);
+    }
 # else /* !OPENSSL_NO_FIPS_JITTER */
     name = "JITTER";
     propq = "";
 # endif /* OPENSSL_NO_FIPS_JITTER */
 
+    ERR_set_mark();
     rand = EVP_RAND_fetch(libctx, name, propq);
+    ERR_pop_to_mark();
     if (rand == NULL) {
-        ERR_raise(ERR_LIB_RAND, RAND_R_UNABLE_TO_FETCH_DRBG);
+        if (!fallback)
+            ERR_raise(ERR_LIB_RAND, RAND_R_UNABLE_TO_FETCH_DRBG);
         goto err;
     }
     ctx = EVP_RAND_CTX_new(rand, NULL);
@@ -692,6 +700,11 @@ static EVP_RAND_CTX *rand_get0_primary(OSSL_LIB_CTX *ctx, RAND_GLOBAL *dgbl)
     if (seed == NULL) {
         ERR_set_mark();
         seed = newseed = rand_new_seed(ctx);
+        if (ERR_count_to_mark() > 0) {
+            EVP_RAND_CTX_free(newseed);
+            ERR_clear_last_mark();
+            return NULL;
+        }
         ERR_pop_to_mark();
     }
 #endif  /* !FIPS_MODULE || !OPENSSL_NO_FIPS_JITTER */


### PR DESCRIPTION
If a custom seed source is specified in the config file, it can be
silently ignored. For example if it is missing, fails to be created,
or fails to initialize it can be silently ignored and fallback to os
entropy instead.

To reproduce this, perform default configuration of openssl without
jitter entropy source, and then specify jitter entropy
source. Currently entropy will fall back to getrandom, instead of
erroring out.

This is not unique to jitter entropy source, there are a few other
entropy source providers out there on the market, and in all cases if
one is configuring OpenSSL to use a given seed source by name, it
should be honored.

Currently this will output a fresh rsa key, with this change however
it will now result in an error:

```
./Configure
make
./util/wrap.pl -jitter ./apps/openssl genrsa
Warning: generating random key material may take a long time
if the system has a poor entropy source
genrsa: Error generating RSA key
80ABAB8F9F7F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:crypto/evp/evp_fetch.c:375:Global default library context, Algorithm (JITTER : 0), Properties (<null>)
80ABAB8F9F7F0000:error:12000090:random number generator:rand_new_seed:unable to fetch drbg:crypto/rand/rand_lib.c:613:
80ABAB8F9F7F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:crypto/evp/evp_fetch.c:375:Global default library context, Algorithm (JITTER : 0), Properties (<null>)
80ABAB8F9F7F0000:error:12000090:random number generator:rand_new_seed:unable to fetch drbg:crypto/rand/rand_lib.c:613:
```

IMHO, if a user is configuring a custom seed source, it should be
honored without silently eating errors.

Note this partially reverts 1d180bbe8e2103f35328cf82fbde7fd23602735a
"rand: allow seed-src to be missing", which as far as I understand was
done to ensure that fallback seedsource is allowed to be missing. This
new implementation preserves this behaviour by ensuring error is not
raised if SEED-SRC (which since the above commit was changed to a
macro define OPENSSL_DEFAULT_SEED_SRC) is used as a fallback, and it
fails to be fetched. Previously all errors were popped unconditionaly,
thus same behaviour is preserved if SEED-SRC is completely missing and
it wasn't configured in the config file. cc @paulidale, also see: -
https://github.com/openssl/openssl/pull/13640
