### PR TITLE
key2any: free val if string is empty

### DIFF
--- a/providers/implementations/encode_decode/encode_key2any.c
+++ b/providers/implementations/encode_decode/encode_key2any.c
@@ -1181,7 +1181,12 @@ static int key2any_set_ctx_params(void *vctx, const OSSL_PARAM params[])
         if (!OSSL_PARAM_get_utf8_string(p.output_formats, &val, 0))
             return 0;
         OPENSSL_free(ctx->output_formats);
-        ctx->output_formats = *val != '\0' ? val : NULL;
+        if (*val != '\0') {
+            ctx->output_formats = val;
+        } else {
+            OPENSSL_free(val);
+            ctx->output_formats = NULL;
+        }
     }
 
     return 1;


### PR DESCRIPTION
key2any_set_ctx_params() calls OSSL_PARAM_get_utf8_string(..., &val, ...) which allocates space, but it never calls free() for a case when string is empty.

Resolves: https://scan5.scan.coverity.com/#/project-view/65138/10222?selectedIssue=1675327