### PR TITLE
Disable DLL detach handlers on cygwin

### DIFF
--- a/crypto/dllmain.c
+++ b/crypto/dllmain.c
@@ -34,7 +34,9 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
     case DLL_THREAD_ATTACH:
         break;
     case DLL_THREAD_DETACH:
+# ifndef __CYGWIN__
         OPENSSL_thread_stop();
+# endif
         break;
     case DLL_PROCESS_DETACH:
         break;

--- a/providers/fips/self_test.c
+++ b/providers/fips/self_test.c
@@ -102,7 +102,9 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
         init();
         break;
     case DLL_PROCESS_DETACH:
+# ifndef __CYGWIN__
         cleanup();
+# endif
         break;
     default:
         break;


### PR DESCRIPTION
This patch is from cygwin, and was originally added in:

https://cygwin.com/cgit/cygwin-packages/openssl/commit/?id=da80cc438622f6b1801fb3fbb06818c3ee070495

In cygwin, it's not safe to call into libc from
DLL_THREAD/PROCESS_DETACH, and it results in crashes.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
