### PR TITLE
The return value of RSA_*_{en,de}crypt() is signed

### DIFF
--- a/crypto/rsa/rsa_gen.c
+++ b/crypto/rsa/rsa_gen.c
@@ -691,12 +691,12 @@ static int rsa_keygen(OSSL_LIB_CTX *libctx, RSA *rsa, int bits, int primes,
 static int rsa_keygen_pairwise_test(RSA *rsa, OSSL_CALLBACK *cb, void *cbarg)
 {
     int ret = 0;
-    unsigned int plaintxt_len;
     unsigned char *plaintxt = NULL;
-    unsigned int ciphertxt_len;
     unsigned char *ciphertxt = NULL;
     unsigned char *decoded = NULL;
-    unsigned int decoded_len;
+    int plaintxt_len;
+    int ciphertxt_len;
+    int decoded_len;
     int padding = RSA_NO_PADDING;
     OSSL_SELF_TEST *st = NULL;
 


### PR DESCRIPTION
The functions RSA_(public|private)_(en|de)crypt() return a signed result, in particular `-1` may be returned on error, so the caller MUST treat the value as signed.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
