### PR TITLE
Prevent random seed configuration evasion

### DIFF
--- a/.github/workflows/run-checker-merge.yml
+++ b/.github/workflows/run-checker-merge.yml
@@ -78,8 +78,18 @@ jobs:
       run: make -C jitter/
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
-    - name: config
+    - name: config (with fips-jitter)
       run: ./config --with-rand-seed=none enable-jitter enable-fips-jitter --with-jitter-include=jitter/ --with-jitter-lib=jitter/ -DOPENSSL_DEFAULT_SEED_SRC=JITTER && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: get cpu info
+      run: |
+        cat /proc/cpuinfo
+        ./util/opensslwrap.sh version -c
+    - name: make test
+      run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
+    - name: config (without fips-jitter)
+      run: ./config --with-rand-seed=none enable-jitter enable-fips --with-jitter-include=jitter/ --with-jitter-lib=jitter/ -DOPENSSL_DEFAULT_SEED_SRC=JITTER -DOPENSSL_DEFAULT_SEED_PROPQ=-fips && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: get cpu info

--- a/Configure
+++ b/Configure
@@ -1353,7 +1353,8 @@ application.
 
 Instead of manually seeding, a different random generator can be set
 at runtime in openssl.cnf or configured at build time with
--DOPENSSL_DEFAULT_SEED_SRC.
+-DOPENSSL_DEFAULT_SEED_SRC. Optionally, OPENSSL_DEFAULT_SEED_PROPQ can
+also be set if needed.
 
 Please read the 'Note on random number generation' section in the
 INSTALL.md instructions and the RAND_DRBG(7) manual page for more

--- a/crypto/rand/prov_seed.c
+++ b/crypto/rand/prov_seed.c
@@ -45,7 +45,7 @@ size_t ossl_rand_get_user_entropy(OSSL_LIB_CTX *ctx,
                                   unsigned char **pout, int entropy,
                                   size_t min_len, size_t max_len)
 {
-    EVP_RAND_CTX *rng = ossl_rand_get0_seed_noncreating(ctx);
+    EVP_RAND_CTX *rng = ossl_rand_get0_seed_creating(ctx);
 
     if (rng != NULL && evp_rand_can_seed(rng))
         return evp_rand_get_seed(rng, pout, entropy, min_len, max_len,

--- a/doc/man3/RAND_set_DRBG_type.pod
+++ b/doc/man3/RAND_set_DRBG_type.pod
@@ -43,7 +43,8 @@ The default DRBG is "CTR-DRBG" using the "AES-256-CTR" cipher.
 
 The default seed source can be configured when OpenSSL is compiled by
 setting B<-DOPENSSL_DEFAULT_SEED_SRC=SEED-SRC>. If not set then
-"SEED-SRC" is used.
+"SEED-SRC" is used. Optionally, B<-DDOPENSSL_DEFAULT_SEED_PROPQ=-fips>
+can be set if needed. If not set then NULL is used.
 
 =head1 EXAMPLES
 

--- a/include/crypto/rand.h
+++ b/include/crypto/rand.h
@@ -144,6 +144,7 @@ int ossl_pool_add_nonce_data(RAND_POOL *pool);
 EVP_RAND_CTX *ossl_rand_get0_private_noncreating(OSSL_LIB_CTX *ctx);
 # else
 EVP_RAND_CTX *ossl_rand_get0_seed_noncreating(OSSL_LIB_CTX *ctx);
+EVP_RAND_CTX *ossl_rand_get0_seed_creating(OSSL_LIB_CTX *ctx);
 # endif
 
 /* Generate a uniformly distributed random integer in the interval [0, upper) */

--- a/test/fips.cnf
+++ b/test/fips.cnf
@@ -17,3 +17,12 @@ default_properties = "fips=yes"
 
 [provider_sect]
 fips = fips_sect
+# To support testing --with-rand-seed=none
+# -DOPENSSL_DEFAULT_SEED_SRC=JITTER -DOPENSSL_DEFAULT_SEED_PROPQ=-fips
+# As without a base provider, there will be no drbg seeds.  Also not
+# sure if it is realistic to use fips provider without either base or
+# default providers.
+base = base_sect
+
+[base_sect]
+activate = 1


### PR DESCRIPTION
If seed source is outside of the FIPS provider, and one configures it
via `[random] seed=` option, or via OPENSSL_DEFAULT_SEED_SRC,
providers that use ossl_rand_get_user_entropy can sometimes evade this
configuration and fallback to direct call of ossl_rand_get_entropy
entropy pools. Such build configuration is added to the test matrix,
which exposes the problem with many test failures.

It really depends on if one manages to request or create primary drbg,
and thus initialise global random seed first on the core side, before
using any functions from within a provider that does entropy
callback. For example genrsa initialises primary, but ecaparams
-genkey does not.

This leads to very odd behaviour, of sometimes ossl_rand_get_entropy
getting called and using getrandom() yet other times the configured
seed source is used.

To fix this, upgrade ossl_rand_get_user_entropy call to actually do a
creating seed call. This will ensure that once entropy is being
requested via such callback, an attempt is made to initialise seed rng
using random configuration as requested.

Potentially with this in place the fallback to ossl_rand_get_entropy
can be completely removed - although it may expose incorrectly
configured software that doesn't always have access to the desired
seed source.

Fixes #25941
