### PR TITLE
Enable send-/recvmmsg for AIX >= 7.2 and disable SUPPORT_LOCAL_ADDR.

### DIFF
--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -141,7 +141,8 @@
  * For AF_INET6 there seem to be limitations how local addresses
  * are handled on AIX. So, disable the support for now.
  */
-#if (defined(IP_PKTINFO) || defined(IP_RECVDSTADDR)) && defined(IPV6_RECVPKTINFO) && !defined(_AIX)
+#if (defined(IP_PKTINFO) || defined(IP_RECVDSTADDR)) && defined(IPV6_RECVPKTINFO) \
+    && !defined(_AIX)
 #define SUPPORT_LOCAL_ADDR
 #endif
 #endif


### PR DESCRIPTION
AIX doesn't support this implementation for local addresses. The AF_INET case is unimplemented when sending. The AF_INET6 case is limited to 110 messages. The limiting factor is currently unclear.

The patch should be pulled into 3.6, 3.5, 3.4, and 3.3, too.

Fixes #29292
