### PR TITLE
Fix memory leak in error path of ec_gen_init()

### DIFF
--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -1017,7 +1017,7 @@ static void *ec_gen_init(void *provctx, int selection,
         gctx->ecdh_mode = 0;
         OSSL_FIPS_IND_INIT(gctx)
         if (!ec_gen_set_params(gctx, params)) {
-            OPENSSL_free(gctx);
+            ec_gen_cleanup(gctx);
             gctx = NULL;
         }
     }


### PR DESCRIPTION
ec_gen_set_params() can fail after some big numbers have already been copied over. Those need to be cleaned to avoid a memory leak on failure. This can be done with ec_gen_cleanup(), which is also consistent in how the ecx_gen code does it.

Note: This was detected using an experimental static analyzer our group is working on. Although I did manual verification it's always possible this is a false alarm or not important.