### PR TITLE
Only write to pdays/psecs if they are not null

### DIFF
--- a/crypto/asn1/a_time_posix.c
+++ b/crypto/asn1/a_time_posix.c
@@ -271,8 +271,10 @@ int OPENSSL_gmtime_diff(int *out_days, int *out_secs, const struct tm *from,
     daydiff = timediff / SECS_PER_DAY;
     timediff %= SECS_PER_DAY;
 
-    *out_secs = (int) timediff;
-    *out_days = (int) daydiff;
+    if (out_secs != NULL)
+        *out_secs = (int) timediff;
+    if (out_days != NULL)
+        *out_days = (int) daydiff;
 
     return 1;
 }


### PR DESCRIPTION
We have a few cases in which one of the paramters passed to ASN1_TIME_diff is null (i.e. the caller doesn't care about the psec differnce and so passes NULL as that pointer parameter).

However, OPENSSL_gmtime_diff assumes both pointers are valid, and so writes to them unilaterally resulting in a crash as observed here: https://github.com/openssl/openssl/pull/29333#issuecomment-3628103959

Check the pointers before writing to them.
