### PR TITLE
Adds a test for the gettable params IV, updated IV and AEAD tag size for EVP ciphers.

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -450,7 +450,7 @@ static int aes_ocb_get_ctx_params(void *vctx, OSSL_PARAM params[])
     }
 
     if (p.iv != NULL) {
-        if (ctx->base.ivlen > p.iv->data_size) {
+        if (p.iv->data != NULL && ctx->base.ivlen > p.iv->data_size) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
             return 0;
         }
@@ -462,7 +462,7 @@ static int aes_ocb_get_ctx_params(void *vctx, OSSL_PARAM params[])
     }
 
     if (p.upd_iv != NULL) {
-        if (ctx->base.ivlen > p.upd_iv->data_size) {
+        if (p.upd_iv->data != NULL && ctx->base.ivlen > p.upd_iv->data_size) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
             return 0;
         }
@@ -474,15 +474,23 @@ static int aes_ocb_get_ctx_params(void *vctx, OSSL_PARAM params[])
     }
 
     if (p.tag != NULL) {
-        if (p.tag->data_type != OSSL_PARAM_OCTET_STRING) {
-            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-            return 0;
-        }
-        if (!ctx->base.enc || p.tag->data_size != ctx->taglen) {
+        size_t taglen = ctx->taglen;
+
+        if (p.tag->data != NULL && taglen > p.tag->data_size)
+            taglen = p.tag->data_size;
+
+        if (p.tag->data != NULL && taglen == 0) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG_LENGTH);
             return 0;
         }
-        memcpy(p.tag->data, ctx->tag, ctx->taglen);
+        if (p.tag->data != NULL && !ctx->base.enc) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return 0;
+        }
+        if (!OSSL_PARAM_set_octet_string_or_ptr(p.tag, ctx->tag, ctx->taglen)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return 0;
+        }
     }
     return 1;
 }

--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -450,24 +450,32 @@ static int aes_ocb_get_ctx_params(void *vctx, OSSL_PARAM params[])
     }
 
     if (p.iv != NULL) {
-        if (p.iv->data != NULL && ctx->base.ivlen > p.iv->data_size) {
+        size_t ivlen = ctx->base.ivlen;
+
+        if (p.iv->data != NULL && ivlen > p.iv->data_size)
+            ivlen = p.tag->data_size;
+
+        if (p.iv->data != NULL && ivlen == 0) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
             return 0;
         }
-        if (!OSSL_PARAM_set_octet_string_or_ptr(p.iv, ctx->base.oiv,
-                ctx->base.ivlen)) {
+        if (!OSSL_PARAM_set_octet_string_or_ptr(p.iv, ctx->base.oiv, ivlen)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return 0;
         }
     }
 
     if (p.upd_iv != NULL) {
-        if (p.upd_iv->data != NULL && ctx->base.ivlen > p.upd_iv->data_size) {
+        size_t updivlen = ctx->base.ivlen;
+
+        if (p.upd_iv->data != NULL && updivlen > p.upd_iv->data_size)
+            updivlen = p.tag->data_size;
+
+        if (p.upd_iv->data != NULL && updivlen == 0) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
             return 0;
         }
-        if (!OSSL_PARAM_set_octet_string_or_ptr(p.upd_iv, ctx->base.iv,
-                ctx->base.ivlen)) {
+        if (!OSSL_PARAM_set_octet_string_or_ptr(p.upd_iv, ctx->base.iv, updivlen)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return 0;
         }

--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -458,7 +458,7 @@ static int aes_ocb_get_ctx_params(void *vctx, OSSL_PARAM params[])
         size_t ivlen = ctx->base.ivlen;
 
         if (p.iv->data != NULL && ivlen > p.iv->data_size)
-            ivlen = p.tag->data_size;
+            ivlen = p.iv->data_size;
 
         if (p.iv->data != NULL && ivlen == 0) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
@@ -474,7 +474,7 @@ static int aes_ocb_get_ctx_params(void *vctx, OSSL_PARAM params[])
         size_t updivlen = ctx->base.ivlen;
 
         if (p.upd_iv->data != NULL && updivlen > p.upd_iv->data_size)
-            updivlen = p.tag->data_size;
+            updivlen = p.upd_iv->data_size;
 
         if (p.upd_iv->data != NULL && updivlen == 0) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);

--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -455,7 +455,7 @@ static int aes_ocb_get_ctx_params(void *vctx, OSSL_PARAM params[])
     }
 
     if (p.iv != NULL) {
-        if (ctx->base.ivlen > p.iv->data_size) {
+        if (p.iv->data != NULL && ctx->base.ivlen > p.iv->data_size) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
             return 0;
         }
@@ -467,7 +467,7 @@ static int aes_ocb_get_ctx_params(void *vctx, OSSL_PARAM params[])
     }
 
     if (p.upd_iv != NULL) {
-        if (ctx->base.ivlen > p.upd_iv->data_size) {
+        if (p.upd_iv->data != NULL && ctx->base.ivlen > p.upd_iv->data_size) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
             return 0;
         }
@@ -479,19 +479,23 @@ static int aes_ocb_get_ctx_params(void *vctx, OSSL_PARAM params[])
     }
 
     if (p.tag != NULL) {
-        if (p.tag->data_type != OSSL_PARAM_OCTET_STRING) {
-            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
-            return 0;
-        }
-        if (!ctx->base.enc) {
-            ERR_raise(ERR_LIB_PROV, PROV_R_TAG_NOT_SET);
-            return 0;
-        }
-        if (p.tag->data_size != ctx->taglen) {
+        size_t taglen = ctx->taglen;
+
+        if (p.tag->data != NULL && taglen > p.tag->data_size)
+            taglen = p.tag->data_size;
+
+        if (p.tag->data != NULL && taglen == 0) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG_LENGTH);
             return 0;
         }
-        memcpy(p.tag->data, ctx->tag, ctx->taglen);
+        if (p.tag->data != NULL && !ctx->base.enc) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_TAG_NOT_SET);
+            return 0;
+        }
+        if (!OSSL_PARAM_set_octet_string_or_ptr(p.tag, ctx->tag, ctx->taglen)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return 0;
+        }
     }
     return 1;
 }

--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -455,24 +455,32 @@ static int aes_ocb_get_ctx_params(void *vctx, OSSL_PARAM params[])
     }
 
     if (p.iv != NULL) {
-        if (p.iv->data != NULL && ctx->base.ivlen > p.iv->data_size) {
+        size_t ivlen = ctx->base.ivlen;
+
+        if (p.iv->data != NULL && ivlen > p.iv->data_size)
+            ivlen = p.tag->data_size;
+
+        if (p.iv->data != NULL && ivlen == 0) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
             return 0;
         }
-        if (!OSSL_PARAM_set_octet_string_or_ptr(p.iv, ctx->base.oiv,
-                ctx->base.ivlen)) {
+        if (!OSSL_PARAM_set_octet_string_or_ptr(p.iv, ctx->base.oiv, ivlen)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return 0;
         }
     }
 
     if (p.upd_iv != NULL) {
-        if (p.upd_iv->data != NULL && ctx->base.ivlen > p.upd_iv->data_size) {
+        size_t updivlen = ctx->base.ivlen;
+
+        if (p.upd_iv->data != NULL && updivlen > p.upd_iv->data_size)
+            updivlen = p.tag->data_size;
+
+        if (p.upd_iv->data != NULL && updivlen == 0) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
             return 0;
         }
-        if (!OSSL_PARAM_set_octet_string_or_ptr(p.upd_iv, ctx->base.iv,
-                ctx->base.ivlen)) {
+        if (!OSSL_PARAM_set_octet_string_or_ptr(p.upd_iv, ctx->base.iv, updivlen)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return 0;
         }

--- a/providers/implementations/ciphers/cipher_aes_siv.c
+++ b/providers/implementations/ciphers/cipher_aes_siv.c
@@ -173,8 +173,7 @@ static int aes_siv_get_ctx_params(void *vctx, OSSL_PARAM params[])
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG_LENGTH);
             return 0;
         }
-        if (!OSSL_PARAM_set_octet_string_or_ptr(p.tag, &sctx->tag.byte,
-                                                   taglen)) {
+        if (!OSSL_PARAM_set_octet_string_or_ptr(p.tag, &sctx->tag.byte, taglen)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return 0;
         }

--- a/providers/implementations/ciphers/cipher_aes_siv.c
+++ b/providers/implementations/ciphers/cipher_aes_siv.c
@@ -160,11 +160,21 @@ static int aes_siv_get_ctx_params(void *vctx, OSSL_PARAM params[])
     sctx = &ctx->siv;
 
     if (p.tag != NULL) {
-        if (!ctx->enc
-            || p.tag->data_type != OSSL_PARAM_OCTET_STRING
-            || p.tag->data_size != ctx->taglen
-            || !OSSL_PARAM_set_octet_string(p.tag, &sctx->tag.byte,
-                ctx->taglen)) {
+        size_t taglen = ctx->taglen;
+
+        if (p.tag->data != NULL && taglen > p.tag->data_size)
+            taglen = p.tag->data_size;
+
+        if (!ctx->enc) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_TAG_NOT_SET);
+            return 0;
+        }
+        if (p.tag->data != NULL && taglen == 0) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG_LENGTH);
+            return 0;
+        }
+        if (!OSSL_PARAM_set_octet_string_or_ptr(p.tag, &sctx->tag.byte,
+                                                   taglen)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return 0;
         }

--- a/providers/implementations/ciphers/cipher_chacha20.c
+++ b/providers/implementations/ciphers/cipher_chacha20.c
@@ -119,11 +119,37 @@ static int chacha20_get_ctx_params(void *vctx, OSSL_PARAM params[])
     }
 
     if (p.upd_iv != NULL) {
+        size_t updivlen = CHACHA20_IVLEN;
+
         CHACHA_U32TOU8(ivbuf, ctx->counter[0]);
         CHACHA_U32TOU8(ivbuf + 4, ctx->counter[1]);
         CHACHA_U32TOU8(ivbuf + 8, ctx->counter[2]);
         CHACHA_U32TOU8(ivbuf + 12, ctx->counter[3]);
-        if (!OSSL_PARAM_set_octet_string(p.upd_iv, ivbuf, CHACHA20_IVLEN)) {
+
+        if (p.upd_iv->data != NULL && updivlen > p.upd_iv->data_size)
+            updivlen = p.upd_iv->data_size;
+
+        if (p.upd_iv->data != NULL && updivlen == 0) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
+            return 0;
+        }
+        if (!OSSL_PARAM_set_octet_string_or_ptr(p.upd_iv, ivbuf, updivlen)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return 0;
+        }
+    }
+
+    if (p.iv != NULL) {
+        size_t ivlen = sizeof(ctx->base.oiv);
+
+        if (p.iv->data != NULL && ivlen > p.iv->data_size)
+            ivlen = p.iv->data_size;
+
+        if (p.iv->data != NULL && ivlen == 0) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
+            return 0;
+        }
+        if (!OSSL_PARAM_set_octet_string_or_ptr(p.iv, ctx->base.oiv, ivlen)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return 0;
         }

--- a/providers/implementations/ciphers/cipher_chacha20.inc.in
+++ b/providers/implementations/ciphers/cipher_chacha20.inc.in
@@ -15,6 +15,7 @@ use OpenSSL::paramnames qw(produce_param_decoder);
                          (['OSSL_CIPHER_PARAM_KEYLEN',     'keylen', 'size_t'],
                           ['OSSL_CIPHER_PARAM_IVLEN',      'ivlen',  'size_t'],
                           ['OSSL_CIPHER_PARAM_UPDATED_IV', 'upd_iv', 'octet_string'],
+                          ['OSSL_CIPHER_PARAM_IV',         'iv',     'octet_string'],
                          )); -}
 
 {- produce_param_decoder('chacha20_set_ctx_params',

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.c
@@ -152,9 +152,7 @@ static int chacha20_poly1305_get_ctx_params(void *vctx, OSSL_PARAM params[])
     if (p.iv != NULL) {
         size_t ivlen = CHACHA20_POLY1305_IVLEN;
 
-        if (p.iv->data == NULL || CHACHA20_POLY1305_IVLEN < p.iv->data_size)
-            ivlen = CHACHA20_POLY1305_IVLEN;
-        else
+        if (p.iv->data != NULL && ivlen > p.iv->data_size)
             ivlen = p.iv->data_size;
 
         if (p.iv->data != NULL && ivlen == 0) {

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.c
@@ -114,10 +114,13 @@ static int chacha20_poly1305_get_ctx_params(void *vctx, OSSL_PARAM params[])
         return 0;
     }
 
-    if (p.taglen != NULL
-        && !OSSL_PARAM_set_size_t(p.taglen, ctx->tag_len)) {
-        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-        return 0;
+    if (p.taglen != NULL) {
+        size_t taglen = ctx->tag_len == 0 ? sizeof(ctx->tag) : ctx->tag_len;
+
+        if (!OSSL_PARAM_set_size_t(p.taglen, taglen)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return 0;
+        }
     }
 
     if (p.pad != NULL
@@ -127,19 +130,42 @@ static int chacha20_poly1305_get_ctx_params(void *vctx, OSSL_PARAM params[])
     }
 
     if (p.tag != NULL) {
-        if (p.tag->data_type != OSSL_PARAM_OCTET_STRING) {
-            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-            return 0;
-        }
+        size_t taglen = ctx->tag_len == 0 ? sizeof(ctx->tag) : ctx->tag_len;
+
+        if (p.tag->data != NULL && taglen > p.tag->data_size)
+            taglen = p.tag->data_size;
+
         if (!ctx->base.enc) {
             ERR_raise(ERR_LIB_PROV, PROV_R_TAG_NOT_SET);
             return 0;
         }
-        if (p.tag->data_size == 0 || p.tag->data_size > POLY1305_BLOCK_SIZE) {
+        if (p.tag->data != NULL && taglen == 0) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG_LENGTH);
             return 0;
         }
-        memcpy(p.tag->data, ctx->tag, p.tag->data_size);
+        if (!OSSL_PARAM_set_octet_string_or_ptr(p.tag, ctx->tag, taglen)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return 0;
+        }
+    }
+
+    if (p.iv != NULL) {
+        size_t ivlen = CHACHA20_POLY1305_IVLEN;
+
+        if (p.iv->data == NULL || CHACHA20_POLY1305_IVLEN < p.iv->data_size)
+            ivlen = CHACHA20_POLY1305_IVLEN;
+        else
+            ivlen = p.iv->data_size;
+
+        if (p.iv->data != NULL && ivlen == 0) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
+            return 0;
+        }
+
+        if (!OSSL_PARAM_set_octet_string_or_ptr(p.iv, ctx->base.oiv + CHACHA_CTR_SIZE - ivlen, ivlen)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return 0;
+        }
     }
     return 1;
 }

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.inc.in
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.inc.in
@@ -13,6 +13,7 @@ use OpenSSL::paramnames qw(produce_param_decoder);
 
 {- produce_param_decoder('chacha20_poly1305_get_ctx_params',
                          (['OSSL_CIPHER_PARAM_KEYLEN',            'keylen', 'size_t'],
+                          ['OSSL_CIPHER_PARAM_IV',                'iv',    'octet_string'],
                           ['OSSL_CIPHER_PARAM_IVLEN',             'ivlen',  'size_t'],
                           ['OSSL_CIPHER_PARAM_AEAD_TAGLEN',       'taglen', 'size_t'],
                           ['OSSL_CIPHER_PARAM_AEAD_TAG',          'tag',    'octet_string'],

--- a/providers/implementations/ciphers/ciphercommon_ccm.c
+++ b/providers/implementations/ciphers/ciphercommon_ccm.c
@@ -220,8 +220,7 @@ int ossl_ccm_get_ctx_params(void *vctx, OSSL_PARAM params[])
             return 0;
         }
         if ((p.tag->data == NULL && !OSSL_PARAM_set_octet_string_or_ptr(p.tag, ctx->buf, taglen))
-            || (p.tag->data != NULL && (p.tag->data_type != OSSL_PARAM_OCTET_STRING
-                                        || !ctx->hw->gettag(ctx, p.tag->data, taglen)))) {
+            || (p.tag->data != NULL && (p.tag->data_type != OSSL_PARAM_OCTET_STRING || !ctx->hw->gettag(ctx, p.tag->data, taglen)))) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return 0;
         }

--- a/providers/implementations/ciphers/ciphercommon_gcm.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c
@@ -153,7 +153,6 @@ const OSSL_PARAM *ossl_gcm_gettable_ctx_params(
 int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
 {
     PROV_GCM_CTX *ctx = (PROV_GCM_CTX *)vctx;
-    size_t sz;
     struct ossl_cipher_gcm_get_ctx_params_st p;
 
     if (ctx == NULL || !ossl_cipher_gcm_get_ctx_params_decoder(params, &p))

--- a/providers/implementations/ciphers/ciphercommon_gcm.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c
@@ -213,8 +213,7 @@ int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
     }
 
     if (p.tag != NULL) {
-        size_t taglen = (ctx->taglen != UNINITIALISED_SIZET) ? ctx->taglen :
-                        GCM_TAG_MAX_SIZE;
+        size_t taglen = (ctx->taglen != UNINITIALISED_SIZET) ? ctx->taglen : GCM_TAG_MAX_SIZE;
 
         if (p.tag->data != NULL && taglen > p.tag->data_size)
             taglen = p.tag->data_size;

--- a/providers/implementations/ciphers/ciphercommon_gcm.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c
@@ -221,7 +221,7 @@ int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG_LENGTH);
             return 0;
         }
-        if (!ctx->enc || ctx->taglen == UNINITIALISED_SIZET) {
+        if (!ctx->enc || (p.tag->data != NULL && ctx->taglen == UNINITIALISED_SIZET)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_TAG_NOT_SET);
             return 0;
         }

--- a/providers/implementations/ciphers/ciphercommon_gcm.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c
@@ -213,22 +213,21 @@ int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
     }
 
     if (p.tag != NULL) {
+        size_t taglen = (ctx->taglen != UNINITIALISED_SIZET) ? ctx->taglen :
+                        GCM_TAG_MAX_SIZE;
+
+        if (p.tag->data != NULL && taglen > p.tag->data_size)
+            taglen = p.tag->data_size;
+
+        if (p.tag->data != NULL && taglen == 0) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG_LENGTH);
+            return 0;
+        }
         if (!ctx->enc || ctx->taglen == UNINITIALISED_SIZET) {
             ERR_raise(ERR_LIB_PROV, PROV_R_TAG_NOT_SET);
             return 0;
         }
-        if (p.tag->data == NULL) {
-            /* size query: report the tag length, as for the iv above */
-            sz = ctx->taglen;
-        } else {
-            sz = p.tag->data_size;
-            if (sz > EVP_GCM_TLS_TAG_LEN || sz == 0) {
-                ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG);
-                return 0;
-            }
-        }
-
-        if (!OSSL_PARAM_set_octet_string(p.tag, ctx->buf, sz)) {
+        if (!OSSL_PARAM_set_octet_string_or_ptr(p.tag, ctx->buf, taglen)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return 0;
         }

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4224,11 +4224,11 @@ static int test_evp_cipher_parameter_sizes(void)
         ivlen = OSSL_PARAM_UNMODIFIED;
 
         params[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_IV,
-                                                      NULL, 0);
+            NULL, 0);
         params[1] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_UPDATED_IV,
-                                                      NULL, 0);
+            NULL, 0);
         params[2] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG,
-                                                      NULL, 0);
+            NULL, 0);
         params[3] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_IVLEN, &ivlen);
         params[4] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_AEAD_TAGLEN, &taglen);
         params[5] = OSSL_PARAM_construct_end();
@@ -4239,7 +4239,7 @@ static int test_evp_cipher_parameter_sizes(void)
         if (!TEST_ptr(cipher = EVP_CIPHER_fetch(testctx, t->cipher_name, "")))
             goto next_iteration;
 
-        if(!TEST_true(EVP_CipherInit_ex2(ctx, cipher, NULL, NULL, 1, NULL))
+        if (!TEST_true(EVP_CipherInit_ex2(ctx, cipher, NULL, NULL, 1, NULL))
             || !TEST_true(EVP_CIPHER_CTX_get_params(ctx, params))
             || !TEST_size_t_eq(params[0].return_size, t->ivlen)
             || !TEST_size_t_eq(params[1].return_size, t->updatedivlen)
@@ -4250,7 +4250,7 @@ static int test_evp_cipher_parameter_sizes(void)
             goto err;
         }
 
-next_iteration:
+    next_iteration:
         EVP_CIPHER_CTX_free(ctx);
         ctx = NULL;
         EVP_CIPHER_free(cipher);
@@ -4264,7 +4264,6 @@ err:
     EVP_CIPHER_free(cipher);
     return 0;
 }
-
 
 #if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
 static int test_decrypt_null_chunks(void)
@@ -5991,7 +5990,7 @@ static int aes_gcm_encrypt(const unsigned char *gcm_key, size_t gcm_key_s,
         || !TEST_size_t_eq(params[2].return_size, sizeof(outtag)))
         goto err;
 
-        ret = 1;
+    ret = 1;
 err:
     EVP_CIPHER_free(cipher);
     EVP_CIPHER_CTX_free(ctx);
@@ -6083,11 +6082,11 @@ static int test_aes_gcm_ivlen_change_cve_2023_5363(void)
     };
 
     if (!TEST_true(aes_gcm_encrypt(gcm_key, sizeof(gcm_key), gcm_iv, sizeof(gcm_iv),
-                                   gcm_pt, sizeof(gcm_pt), NULL, 0,
-                                   gcm_ct, sizeof(gcm_ct), gcm_tag, sizeof(gcm_tag)))
+            gcm_pt, sizeof(gcm_pt), NULL, 0,
+            gcm_ct, sizeof(gcm_ct), gcm_tag, sizeof(gcm_tag)))
         || !TEST_true(aes_gcm_decrypt(gcm_key, sizeof(gcm_key), gcm_iv, sizeof(gcm_iv),
-                                     gcm_pt, sizeof(gcm_pt), NULL, 0,
-                                     gcm_ct, sizeof(gcm_ct), gcm_tag, sizeof(gcm_tag))))
+            gcm_pt, sizeof(gcm_pt), NULL, 0,
+            gcm_ct, sizeof(gcm_ct), gcm_tag, sizeof(gcm_tag))))
         return 0;
 
     return 1;

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4128,6 +4128,144 @@ err:
 }
 #endif
 
+typedef struct {
+    const char *cipher_name;
+    size_t ivlen;
+    size_t updatedivlen;
+    size_t aeadtaglen;
+} cipher_params;
+
+static int test_evp_cipher_parameter_sizes(void)
+{
+    static const cipher_params tests[] = {
+        /* --- AES GCM --- */
+        { "AES-128-GCM", 12, 12, 16 },
+        { "AES-192-GCM", 12, 12, 16 },
+        { "AES-256-GCM", 12, 12, 16 },
+
+        /* --- AES CCM --- */
+        { "AES-128-CCM", 7, 7, 12 },
+        { "AES-192-CCM", 7, 7, 12 },
+        { "AES-256-CCM", 7, 7, 12 },
+
+        /* --- AES OCB --- */
+        { "AES-128-OCB", 12, 12, 16 },
+        { "AES-192-OCB", 12, 12, 16 },
+        { "AES-256-OCB", 12, 12, 16 },
+
+        /* --- AES CBC --- */
+        { "AES-128-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-192-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-256-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+
+        /* --- AES CTR --- */
+        { "AES-128-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-192-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-256-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+
+        /* --- AES CFB/OFB --- */
+        { "AES-128-CFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-192-CFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-256-CFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-128-OFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-192-OFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-256-OFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+
+        /* --- AES XTS (no tag) --- */
+        { "AES-128-XTS", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-256-XTS", 16, 16, OSSL_PARAM_UNMODIFIED },
+
+        /* --- ChaCha20 & ChaCha20-Poly1305 --- */
+        { "ChaCha20", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "ChaCha20-Poly1305", 12, OSSL_PARAM_UNMODIFIED, 16 },
+
+        /* --- Camellia --- */
+        { "CAMELLIA-128-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "CAMELLIA-192-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "CAMELLIA-256-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "CAMELLIA-128-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "CAMELLIA-192-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "CAMELLIA-256-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "CAMELLIA-128-GCM", 12, 12, 16 },
+        { "CAMELLIA-192-GCM", 12, 12, 16 },
+        { "CAMELLIA-256-GCM", 12, 12, 16 },
+
+        /* --- ARIA --- */
+        { "ARIA-128-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "ARIA-192-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "ARIA-256-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "ARIA-128-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "ARIA-192-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "ARIA-256-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "ARIA-128-GCM", 12, 12, 16 },
+        { "ARIA-192-GCM", 12, 12, 16 },
+        { "ARIA-256-GCM", 12, 12, 16 },
+
+        /* --- SM4 --- */
+        { "SM4-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "SM4-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "SM4-GCM", 12, 12, 16 },
+
+        /* --- 3DES --- */
+        { "DES-EDE3-CBC", 8, 8, OSSL_PARAM_UNMODIFIED },
+
+        /* --- RC4 --- (no IV, no tag) */
+        { "RC4", 0, 0, OSSL_PARAM_UNMODIFIED },
+    };
+
+    EVP_CIPHER_CTX *ctx = NULL;
+    EVP_CIPHER *cipher = NULL;
+    OSSL_PARAM params[6];
+    size_t i, ivlen, taglen;
+
+    for (i = 0; i < OSSL_NELEM(tests); i++) {
+        const cipher_params *t = &tests[i];
+        taglen = OSSL_PARAM_UNMODIFIED;
+        ivlen = OSSL_PARAM_UNMODIFIED;
+
+        params[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_IV,
+                                                      NULL, 0);
+        params[1] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_UPDATED_IV,
+                                                      NULL, 0);
+        params[2] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG,
+                                                      NULL, 0);
+        params[3] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_IVLEN, &ivlen);
+        params[4] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_AEAD_TAGLEN, &taglen);
+        params[5] = OSSL_PARAM_construct_end();
+
+        if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new()))
+            goto err;
+
+        if (!TEST_ptr(cipher = EVP_CIPHER_fetch(testctx, t->cipher_name, "")))
+            goto next_iteration;
+
+        if(!TEST_true(EVP_CipherInit_ex2(ctx, cipher, NULL, NULL, 1, NULL))
+            || !TEST_true(EVP_CIPHER_CTX_get_params(ctx, params))
+            || !TEST_size_t_eq(params[0].return_size, t->ivlen)
+            || !TEST_size_t_eq(params[1].return_size, t->updatedivlen)
+            || !TEST_size_t_eq(params[2].return_size, t->aeadtaglen)
+            || !TEST_size_t_eq(ivlen, t->ivlen)
+            || !TEST_size_t_eq(taglen, t->aeadtaglen)) {
+            TEST_error("test_evp_cipher_parameter_sizes() failed cipher: %s\n", t->cipher_name);
+            goto err;
+        }
+
+next_iteration:
+        EVP_CIPHER_CTX_free(ctx);
+        ctx = NULL;
+        EVP_CIPHER_free(cipher);
+        cipher = NULL;
+    }
+
+    return 1;
+
+err:
+    EVP_CIPHER_CTX_free(ctx);
+    EVP_CIPHER_free(cipher);
+    return 0;
+}
+
+
 #if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
 static int test_decrypt_null_chunks(void)
 {
@@ -5851,6 +5989,7 @@ static int aes_gcm_encrypt(const unsigned char *gcm_key, size_t gcm_key_s,
         || !TEST_size_t_eq(params[0].return_size, gcm_ivlen)
         || !TEST_size_t_eq(params[1].return_size, gcm_ivlen)
         || !TEST_size_t_eq(params[2].return_size, sizeof(outtag)))
+        goto err;
 
         ret = 1;
 err:
@@ -5943,12 +6082,15 @@ static int test_aes_gcm_ivlen_change_cve_2023_5363(void)
         0xdb, 0x99, 0x6c, 0x21
     };
 
-    return aes_gcm_encrypt(gcm_key, sizeof(gcm_key), gcm_iv, sizeof(gcm_iv),
-               gcm_pt, sizeof(gcm_pt), NULL, 0,
-               gcm_ct, sizeof(gcm_ct), gcm_tag, sizeof(gcm_tag))
-        && aes_gcm_decrypt(gcm_key, sizeof(gcm_key), gcm_iv, sizeof(gcm_iv),
-            gcm_pt, sizeof(gcm_pt), NULL, 0,
-            gcm_ct, sizeof(gcm_ct), gcm_tag, sizeof(gcm_tag));
+    if (!TEST_true(aes_gcm_encrypt(gcm_key, sizeof(gcm_key), gcm_iv, sizeof(gcm_iv),
+                                   gcm_pt, sizeof(gcm_pt), NULL, 0,
+                                   gcm_ct, sizeof(gcm_ct), gcm_tag, sizeof(gcm_tag)))
+        || !TEST_true(aes_gcm_decrypt(gcm_key, sizeof(gcm_key), gcm_iv, sizeof(gcm_iv),
+                                     gcm_pt, sizeof(gcm_pt), NULL, 0,
+                                     gcm_ct, sizeof(gcm_ct), gcm_tag, sizeof(gcm_tag))))
+        return 0;
+
+    return 1;
 }
 
 #ifndef OPENSSL_NO_RC4
@@ -6387,6 +6529,7 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_DEPRECATED_3_0
     ADD_TEST(test_RSA_legacy);
 #endif
+    ADD_TEST(test_evp_cipher_parameter_sizes);
 #if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
     ADD_TEST(test_decrypt_null_chunks);
 #endif

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4135,128 +4135,121 @@ typedef struct {
     size_t aeadtaglen;
 } cipher_params;
 
-static int test_evp_cipher_parameter_sizes(void)
+static const cipher_params evp_cipher_parameter_tests[] = {
+    /* --- AES GCM --- */
+    { "AES-128-GCM", 12, 12, 16 },
+    { "AES-192-GCM", 12, 12, 16 },
+    { "AES-256-GCM", 12, 12, 16 },
+
+    /* --- AES CCM --- */
+    { "AES-128-CCM", 7, 7, 12 },
+    { "AES-192-CCM", 7, 7, 12 },
+    { "AES-256-CCM", 7, 7, 12 },
+
+    /* --- AES OCB --- */
+    { "AES-128-OCB", 12, 12, 16 },
+    { "AES-192-OCB", 12, 12, 16 },
+    { "AES-256-OCB", 12, 12, 16 },
+
+    /* --- AES CBC --- */
+    { "AES-128-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-192-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-256-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+
+    /* --- AES CTR --- */
+    { "AES-128-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-192-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-256-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+
+    /* --- AES CFB/OFB --- */
+    { "AES-128-CFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-192-CFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-256-CFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-128-OFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-192-OFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-256-OFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+
+    /* --- AES XTS (no tag) --- */
+    { "AES-128-XTS", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-256-XTS", 16, 16, OSSL_PARAM_UNMODIFIED },
+
+    /* --- ChaCha20 & ChaCha20-Poly1305 --- */
+    { "ChaCha20", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "ChaCha20-Poly1305", 12, OSSL_PARAM_UNMODIFIED, 16 },
+
+    /* --- Camellia --- */
+    { "CAMELLIA-128-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "CAMELLIA-192-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "CAMELLIA-256-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "CAMELLIA-128-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "CAMELLIA-192-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "CAMELLIA-256-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "CAMELLIA-128-GCM", 12, 12, 16 },
+    { "CAMELLIA-192-GCM", 12, 12, 16 },
+    { "CAMELLIA-256-GCM", 12, 12, 16 },
+
+    /* --- ARIA --- */
+    { "ARIA-128-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "ARIA-192-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "ARIA-256-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "ARIA-128-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "ARIA-192-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "ARIA-256-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "ARIA-128-GCM", 12, 12, 16 },
+    { "ARIA-192-GCM", 12, 12, 16 },
+    { "ARIA-256-GCM", 12, 12, 16 },
+
+    /* --- SM4 --- */
+    { "SM4-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "SM4-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "SM4-GCM", 12, 12, 16 },
+
+    /* --- 3DES --- */
+    { "DES-EDE3-CBC", 8, 8, OSSL_PARAM_UNMODIFIED },
+
+    /* --- RC4 --- (no IV, no tag) */
+    { "RC4", 0, 0, OSSL_PARAM_UNMODIFIED },
+};
+
+static int test_evp_cipher_parameter_sizes(int i)
 {
-    static const cipher_params tests[] = {
-        /* --- AES GCM --- */
-        { "AES-128-GCM", 12, 12, 16 },
-        { "AES-192-GCM", 12, 12, 16 },
-        { "AES-256-GCM", 12, 12, 16 },
-
-        /* --- AES CCM --- */
-        { "AES-128-CCM", 7, 7, 12 },
-        { "AES-192-CCM", 7, 7, 12 },
-        { "AES-256-CCM", 7, 7, 12 },
-
-        /* --- AES OCB --- */
-        { "AES-128-OCB", 12, 12, 16 },
-        { "AES-192-OCB", 12, 12, 16 },
-        { "AES-256-OCB", 12, 12, 16 },
-
-        /* --- AES CBC --- */
-        { "AES-128-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-192-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-256-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-
-        /* --- AES CTR --- */
-        { "AES-128-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-192-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-256-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-
-        /* --- AES CFB/OFB --- */
-        { "AES-128-CFB", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-192-CFB", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-256-CFB", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-128-OFB", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-192-OFB", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-256-OFB", 16, 16, OSSL_PARAM_UNMODIFIED },
-
-        /* --- AES XTS (no tag) --- */
-        { "AES-128-XTS", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-256-XTS", 16, 16, OSSL_PARAM_UNMODIFIED },
-
-        /* --- ChaCha20 & ChaCha20-Poly1305 --- */
-        { "ChaCha20", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "ChaCha20-Poly1305", 12, OSSL_PARAM_UNMODIFIED, 16 },
-
-        /* --- Camellia --- */
-        { "CAMELLIA-128-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "CAMELLIA-192-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "CAMELLIA-256-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "CAMELLIA-128-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "CAMELLIA-192-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "CAMELLIA-256-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "CAMELLIA-128-GCM", 12, 12, 16 },
-        { "CAMELLIA-192-GCM", 12, 12, 16 },
-        { "CAMELLIA-256-GCM", 12, 12, 16 },
-
-        /* --- ARIA --- */
-        { "ARIA-128-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "ARIA-192-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "ARIA-256-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "ARIA-128-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "ARIA-192-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "ARIA-256-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "ARIA-128-GCM", 12, 12, 16 },
-        { "ARIA-192-GCM", 12, 12, 16 },
-        { "ARIA-256-GCM", 12, 12, 16 },
-
-        /* --- SM4 --- */
-        { "SM4-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "SM4-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "SM4-GCM", 12, 12, 16 },
-
-        /* --- 3DES --- */
-        { "DES-EDE3-CBC", 8, 8, OSSL_PARAM_UNMODIFIED },
-
-        /* --- RC4 --- (no IV, no tag) */
-        { "RC4", 0, 0, OSSL_PARAM_UNMODIFIED },
-    };
-
     EVP_CIPHER_CTX *ctx = NULL;
     EVP_CIPHER *cipher = NULL;
     OSSL_PARAM params[6];
-    size_t i, ivlen, taglen;
+    size_t ivlen = OSSL_PARAM_UNMODIFIED, taglen = OSSL_PARAM_UNMODIFIED;
 
-    for (i = 0; i < OSSL_NELEM(tests); i++) {
-        const cipher_params *t = &tests[i];
-        taglen = OSSL_PARAM_UNMODIFIED;
-        ivlen = OSSL_PARAM_UNMODIFIED;
+    const cipher_params *t = evp_cipher_parameter_tests + i;
 
-        params[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_IV,
-            NULL, 0);
-        params[1] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_UPDATED_IV,
-            NULL, 0);
-        params[2] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG,
-            NULL, 0);
-        params[3] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_IVLEN, &ivlen);
-        params[4] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_AEAD_TAGLEN, &taglen);
-        params[5] = OSSL_PARAM_construct_end();
+    params[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_IV,
+        NULL, 0);
+    params[1] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_UPDATED_IV,
+        NULL, 0);
+    params[2] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG,
+        NULL, 0);
+    params[3] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_IVLEN, &ivlen);
+    params[4] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_AEAD_TAGLEN, &taglen);
+    params[5] = OSSL_PARAM_construct_end();
 
-        if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new()))
-            goto err;
+    if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new()))
+        goto err;
 
-        if (!TEST_ptr(cipher = EVP_CIPHER_fetch(testctx, t->cipher_name, "")))
-            goto next_iteration;
+    if (!TEST_ptr(cipher = EVP_CIPHER_fetch(testctx, t->cipher_name, "")))
+        goto skip;
 
-        if (!TEST_true(EVP_CipherInit_ex2(ctx, cipher, NULL, NULL, 1, NULL))
-            || !TEST_true(EVP_CIPHER_CTX_get_params(ctx, params))
-            || !TEST_size_t_eq(params[0].return_size, t->ivlen)
-            || !TEST_size_t_eq(params[1].return_size, t->updatedivlen)
-            || !TEST_size_t_eq(params[2].return_size, t->aeadtaglen)
-            || !TEST_size_t_eq(ivlen, t->ivlen)
-            || !TEST_size_t_eq(taglen, t->aeadtaglen)) {
-            TEST_error("test_evp_cipher_parameter_sizes() failed cipher: %s\n", t->cipher_name);
-            goto err;
-        }
-
-    next_iteration:
-        EVP_CIPHER_CTX_free(ctx);
-        ctx = NULL;
-        EVP_CIPHER_free(cipher);
-        cipher = NULL;
+    if (!TEST_true(EVP_CipherInit_ex2(ctx, cipher, NULL, NULL, 1, NULL))
+        || !TEST_true(EVP_CIPHER_CTX_get_params(ctx, params))
+        || !TEST_size_t_eq(params[0].return_size, t->ivlen)
+        || !TEST_size_t_eq(params[1].return_size, t->updatedivlen)
+        || !TEST_size_t_eq(params[2].return_size, t->aeadtaglen)
+        || !TEST_size_t_eq(ivlen, t->ivlen)
+        || !TEST_size_t_eq(taglen, t->aeadtaglen)) {
+        TEST_error("test_evp_cipher_parameter_sizes() failed cipher: %s\n", t->cipher_name);
+        goto err;
     }
 
+skip:
+    EVP_CIPHER_CTX_free(ctx);
+    EVP_CIPHER_free(cipher);
     return 1;
 
 err:
@@ -6528,7 +6521,8 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_DEPRECATED_3_0
     ADD_TEST(test_RSA_legacy);
 #endif
-    ADD_TEST(test_evp_cipher_parameter_sizes);
+    ADD_ALL_TESTS(test_evp_cipher_parameter_sizes,
+        sizeof(evp_cipher_parameter_tests));
 #if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
     ADD_TEST(test_decrypt_null_chunks);
 #endif

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -6522,7 +6522,7 @@ int setup_tests(void)
     ADD_TEST(test_RSA_legacy);
 #endif
     ADD_ALL_TESTS(test_evp_cipher_parameter_sizes,
-        sizeof(evp_cipher_parameter_tests));
+        OSSL_NELEM(evp_cipher_parameter_tests));
 #if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
     ADD_TEST(test_decrypt_null_chunks);
 #endif

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4422,6 +4422,144 @@ err:
 }
 #endif
 
+typedef struct {
+    const char *cipher_name;
+    size_t ivlen;
+    size_t updatedivlen;
+    size_t aeadtaglen;
+} cipher_params;
+
+static int test_evp_cipher_parameter_sizes(void)
+{
+    static const cipher_params tests[] = {
+        /* --- AES GCM --- */
+        { "AES-128-GCM", 12, 12, 16 },
+        { "AES-192-GCM", 12, 12, 16 },
+        { "AES-256-GCM", 12, 12, 16 },
+
+        /* --- AES CCM --- */
+        { "AES-128-CCM", 7, 7, 12 },
+        { "AES-192-CCM", 7, 7, 12 },
+        { "AES-256-CCM", 7, 7, 12 },
+
+        /* --- AES OCB --- */
+        { "AES-128-OCB", 12, 12, 16 },
+        { "AES-192-OCB", 12, 12, 16 },
+        { "AES-256-OCB", 12, 12, 16 },
+
+        /* --- AES CBC --- */
+        { "AES-128-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-192-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-256-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+
+        /* --- AES CTR --- */
+        { "AES-128-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-192-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-256-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+
+        /* --- AES CFB/OFB --- */
+        { "AES-128-CFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-192-CFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-256-CFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-128-OFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-192-OFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-256-OFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+
+        /* --- AES XTS (no tag) --- */
+        { "AES-128-XTS", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "AES-256-XTS", 16, 16, OSSL_PARAM_UNMODIFIED },
+
+        /* --- ChaCha20 & ChaCha20-Poly1305 --- */
+        { "ChaCha20", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "ChaCha20-Poly1305", 12, OSSL_PARAM_UNMODIFIED, 16 },
+
+        /* --- Camellia --- */
+        { "CAMELLIA-128-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "CAMELLIA-192-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "CAMELLIA-256-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "CAMELLIA-128-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "CAMELLIA-192-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "CAMELLIA-256-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "CAMELLIA-128-GCM", 12, 12, 16 },
+        { "CAMELLIA-192-GCM", 12, 12, 16 },
+        { "CAMELLIA-256-GCM", 12, 12, 16 },
+
+        /* --- ARIA --- */
+        { "ARIA-128-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "ARIA-192-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "ARIA-256-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "ARIA-128-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "ARIA-192-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "ARIA-256-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "ARIA-128-GCM", 12, 12, 16 },
+        { "ARIA-192-GCM", 12, 12, 16 },
+        { "ARIA-256-GCM", 12, 12, 16 },
+
+        /* --- SM4 --- */
+        { "SM4-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "SM4-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+        { "SM4-GCM", 12, 12, 16 },
+
+        /* --- 3DES --- */
+        { "DES-EDE3-CBC", 8, 8, OSSL_PARAM_UNMODIFIED },
+
+        /* --- RC4 --- (no IV, no tag) */
+        { "RC4", 0, 0, OSSL_PARAM_UNMODIFIED },
+    };
+
+    EVP_CIPHER_CTX *ctx = NULL;
+    EVP_CIPHER *cipher = NULL;
+    OSSL_PARAM params[6];
+    size_t i, ivlen, taglen;
+
+    for (i = 0; i < OSSL_NELEM(tests); i++) {
+        const cipher_params *t = &tests[i];
+        taglen = OSSL_PARAM_UNMODIFIED;
+        ivlen = OSSL_PARAM_UNMODIFIED;
+
+        params[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_IV,
+                                                      NULL, 0);
+        params[1] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_UPDATED_IV,
+                                                      NULL, 0);
+        params[2] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG,
+                                                      NULL, 0);
+        params[3] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_IVLEN, &ivlen);
+        params[4] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_AEAD_TAGLEN, &taglen);
+        params[5] = OSSL_PARAM_construct_end();
+
+        if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new()))
+            goto err;
+
+        if (!TEST_ptr(cipher = EVP_CIPHER_fetch(testctx, t->cipher_name, "")))
+            goto next_iteration;
+
+        if(!TEST_true(EVP_CipherInit_ex2(ctx, cipher, NULL, NULL, 1, NULL))
+            || !TEST_true(EVP_CIPHER_CTX_get_params(ctx, params))
+            || !TEST_size_t_eq(params[0].return_size, t->ivlen)
+            || !TEST_size_t_eq(params[1].return_size, t->updatedivlen)
+            || !TEST_size_t_eq(params[2].return_size, t->aeadtaglen)
+            || !TEST_size_t_eq(ivlen, t->ivlen)
+            || !TEST_size_t_eq(taglen, t->aeadtaglen)) {
+            TEST_error("test_evp_cipher_parameter_sizes() failed cipher: %s\n", t->cipher_name);
+            goto err;
+        }
+
+next_iteration:
+        EVP_CIPHER_CTX_free(ctx);
+        ctx = NULL;
+        EVP_CIPHER_free(cipher);
+        cipher = NULL;
+    }
+
+    return 1;
+
+err:
+    EVP_CIPHER_CTX_free(ctx);
+    EVP_CIPHER_free(cipher);
+    return 0;
+}
+
+
 #if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
 static int test_decrypt_null_chunks(void)
 {
@@ -8420,12 +8558,15 @@ static int test_aes_gcm_ivlen_change_cve_2023_5363(void)
         0xdb, 0x99, 0x6c, 0x21
     };
 
-    return aes_gcm_encrypt(gcm_key, sizeof(gcm_key), gcm_iv, sizeof(gcm_iv),
-               gcm_pt, sizeof(gcm_pt), NULL, 0,
-               gcm_ct, sizeof(gcm_ct), gcm_tag, sizeof(gcm_tag))
-        && aes_gcm_decrypt(gcm_key, sizeof(gcm_key), gcm_iv, sizeof(gcm_iv),
-            gcm_pt, sizeof(gcm_pt), NULL, 0,
-            gcm_ct, sizeof(gcm_ct), gcm_tag, sizeof(gcm_tag));
+    if (!TEST_true(aes_gcm_encrypt(gcm_key, sizeof(gcm_key), gcm_iv, sizeof(gcm_iv),
+                                   gcm_pt, sizeof(gcm_pt), NULL, 0,
+                                   gcm_ct, sizeof(gcm_ct), gcm_tag, sizeof(gcm_tag)))
+        || !TEST_true(aes_gcm_decrypt(gcm_key, sizeof(gcm_key), gcm_iv, sizeof(gcm_iv),
+                                     gcm_pt, sizeof(gcm_pt), NULL, 0,
+                                     gcm_ct, sizeof(gcm_ct), gcm_tag, sizeof(gcm_tag))))
+        return 0;
+
+    return 1;
 }
 
 #ifndef OPENSSL_NO_RC4
@@ -10146,6 +10287,7 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_DEPRECATED_3_0
     ADD_TEST(test_RSA_legacy);
 #endif
+    ADD_TEST(test_evp_cipher_parameter_sizes);
 #if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
     ADD_TEST(test_decrypt_null_chunks);
 #endif

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4429,128 +4429,121 @@ typedef struct {
     size_t aeadtaglen;
 } cipher_params;
 
-static int test_evp_cipher_parameter_sizes(void)
+static const cipher_params evp_cipher_parameter_tests[] = {
+    /* --- AES GCM --- */
+    { "AES-128-GCM", 12, 12, 16 },
+    { "AES-192-GCM", 12, 12, 16 },
+    { "AES-256-GCM", 12, 12, 16 },
+
+    /* --- AES CCM --- */
+    { "AES-128-CCM", 7, 7, 12 },
+    { "AES-192-CCM", 7, 7, 12 },
+    { "AES-256-CCM", 7, 7, 12 },
+
+    /* --- AES OCB --- */
+    { "AES-128-OCB", 12, 12, 16 },
+    { "AES-192-OCB", 12, 12, 16 },
+    { "AES-256-OCB", 12, 12, 16 },
+
+    /* --- AES CBC --- */
+    { "AES-128-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-192-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-256-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+
+    /* --- AES CTR --- */
+    { "AES-128-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-192-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-256-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+
+    /* --- AES CFB/OFB --- */
+    { "AES-128-CFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-192-CFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-256-CFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-128-OFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-192-OFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-256-OFB", 16, 16, OSSL_PARAM_UNMODIFIED },
+
+    /* --- AES XTS (no tag) --- */
+    { "AES-128-XTS", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "AES-256-XTS", 16, 16, OSSL_PARAM_UNMODIFIED },
+
+    /* --- ChaCha20 & ChaCha20-Poly1305 --- */
+    { "ChaCha20", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "ChaCha20-Poly1305", 12, OSSL_PARAM_UNMODIFIED, 16 },
+
+    /* --- Camellia --- */
+    { "CAMELLIA-128-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "CAMELLIA-192-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "CAMELLIA-256-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "CAMELLIA-128-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "CAMELLIA-192-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "CAMELLIA-256-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "CAMELLIA-128-GCM", 12, 12, 16 },
+    { "CAMELLIA-192-GCM", 12, 12, 16 },
+    { "CAMELLIA-256-GCM", 12, 12, 16 },
+
+    /* --- ARIA --- */
+    { "ARIA-128-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "ARIA-192-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "ARIA-256-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "ARIA-128-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "ARIA-192-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "ARIA-256-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "ARIA-128-GCM", 12, 12, 16 },
+    { "ARIA-192-GCM", 12, 12, 16 },
+    { "ARIA-256-GCM", 12, 12, 16 },
+
+    /* --- SM4 --- */
+    { "SM4-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "SM4-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
+    { "SM4-GCM", 12, 12, 16 },
+
+    /* --- 3DES --- */
+    { "DES-EDE3-CBC", 8, 8, OSSL_PARAM_UNMODIFIED },
+
+    /* --- RC4 --- (no IV, no tag) */
+    { "RC4", 0, 0, OSSL_PARAM_UNMODIFIED },
+};
+
+static int test_evp_cipher_parameter_sizes(int i)
 {
-    static const cipher_params tests[] = {
-        /* --- AES GCM --- */
-        { "AES-128-GCM", 12, 12, 16 },
-        { "AES-192-GCM", 12, 12, 16 },
-        { "AES-256-GCM", 12, 12, 16 },
-
-        /* --- AES CCM --- */
-        { "AES-128-CCM", 7, 7, 12 },
-        { "AES-192-CCM", 7, 7, 12 },
-        { "AES-256-CCM", 7, 7, 12 },
-
-        /* --- AES OCB --- */
-        { "AES-128-OCB", 12, 12, 16 },
-        { "AES-192-OCB", 12, 12, 16 },
-        { "AES-256-OCB", 12, 12, 16 },
-
-        /* --- AES CBC --- */
-        { "AES-128-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-192-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-256-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-
-        /* --- AES CTR --- */
-        { "AES-128-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-192-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-256-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-
-        /* --- AES CFB/OFB --- */
-        { "AES-128-CFB", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-192-CFB", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-256-CFB", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-128-OFB", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-192-OFB", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-256-OFB", 16, 16, OSSL_PARAM_UNMODIFIED },
-
-        /* --- AES XTS (no tag) --- */
-        { "AES-128-XTS", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "AES-256-XTS", 16, 16, OSSL_PARAM_UNMODIFIED },
-
-        /* --- ChaCha20 & ChaCha20-Poly1305 --- */
-        { "ChaCha20", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "ChaCha20-Poly1305", 12, OSSL_PARAM_UNMODIFIED, 16 },
-
-        /* --- Camellia --- */
-        { "CAMELLIA-128-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "CAMELLIA-192-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "CAMELLIA-256-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "CAMELLIA-128-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "CAMELLIA-192-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "CAMELLIA-256-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "CAMELLIA-128-GCM", 12, 12, 16 },
-        { "CAMELLIA-192-GCM", 12, 12, 16 },
-        { "CAMELLIA-256-GCM", 12, 12, 16 },
-
-        /* --- ARIA --- */
-        { "ARIA-128-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "ARIA-192-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "ARIA-256-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "ARIA-128-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "ARIA-192-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "ARIA-256-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "ARIA-128-GCM", 12, 12, 16 },
-        { "ARIA-192-GCM", 12, 12, 16 },
-        { "ARIA-256-GCM", 12, 12, 16 },
-
-        /* --- SM4 --- */
-        { "SM4-CBC", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "SM4-CTR", 16, 16, OSSL_PARAM_UNMODIFIED },
-        { "SM4-GCM", 12, 12, 16 },
-
-        /* --- 3DES --- */
-        { "DES-EDE3-CBC", 8, 8, OSSL_PARAM_UNMODIFIED },
-
-        /* --- RC4 --- (no IV, no tag) */
-        { "RC4", 0, 0, OSSL_PARAM_UNMODIFIED },
-    };
-
     EVP_CIPHER_CTX *ctx = NULL;
     EVP_CIPHER *cipher = NULL;
     OSSL_PARAM params[6];
-    size_t i, ivlen, taglen;
+    size_t ivlen = OSSL_PARAM_UNMODIFIED, taglen = OSSL_PARAM_UNMODIFIED;
 
-    for (i = 0; i < OSSL_NELEM(tests); i++) {
-        const cipher_params *t = &tests[i];
-        taglen = OSSL_PARAM_UNMODIFIED;
-        ivlen = OSSL_PARAM_UNMODIFIED;
+    const cipher_params *t = evp_cipher_parameter_tests + i;
 
-        params[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_IV,
-            NULL, 0);
-        params[1] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_UPDATED_IV,
-            NULL, 0);
-        params[2] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG,
-            NULL, 0);
-        params[3] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_IVLEN, &ivlen);
-        params[4] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_AEAD_TAGLEN, &taglen);
-        params[5] = OSSL_PARAM_construct_end();
+    params[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_IV,
+        NULL, 0);
+    params[1] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_UPDATED_IV,
+        NULL, 0);
+    params[2] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG,
+        NULL, 0);
+    params[3] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_IVLEN, &ivlen);
+    params[4] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_AEAD_TAGLEN, &taglen);
+    params[5] = OSSL_PARAM_construct_end();
 
-        if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new()))
-            goto err;
+    if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new()))
+        goto err;
 
-        if (!TEST_ptr(cipher = EVP_CIPHER_fetch(testctx, t->cipher_name, "")))
-            goto next_iteration;
+    if (!TEST_ptr(cipher = EVP_CIPHER_fetch(testctx, t->cipher_name, "")))
+        goto skip;
 
-        if (!TEST_true(EVP_CipherInit_ex2(ctx, cipher, NULL, NULL, 1, NULL))
-            || !TEST_true(EVP_CIPHER_CTX_get_params(ctx, params))
-            || !TEST_size_t_eq(params[0].return_size, t->ivlen)
-            || !TEST_size_t_eq(params[1].return_size, t->updatedivlen)
-            || !TEST_size_t_eq(params[2].return_size, t->aeadtaglen)
-            || !TEST_size_t_eq(ivlen, t->ivlen)
-            || !TEST_size_t_eq(taglen, t->aeadtaglen)) {
-            TEST_error("test_evp_cipher_parameter_sizes() failed cipher: %s\n", t->cipher_name);
-            goto err;
-        }
-
-    next_iteration:
-        EVP_CIPHER_CTX_free(ctx);
-        ctx = NULL;
-        EVP_CIPHER_free(cipher);
-        cipher = NULL;
+    if (!TEST_true(EVP_CipherInit_ex2(ctx, cipher, NULL, NULL, 1, NULL))
+        || !TEST_true(EVP_CIPHER_CTX_get_params(ctx, params))
+        || !TEST_size_t_eq(params[0].return_size, t->ivlen)
+        || !TEST_size_t_eq(params[1].return_size, t->updatedivlen)
+        || !TEST_size_t_eq(params[2].return_size, t->aeadtaglen)
+        || !TEST_size_t_eq(ivlen, t->ivlen)
+        || !TEST_size_t_eq(taglen, t->aeadtaglen)) {
+        TEST_error("test_evp_cipher_parameter_sizes() failed cipher: %s\n", t->cipher_name);
+        goto err;
     }
 
+skip:
+    EVP_CIPHER_CTX_free(ctx);
+    EVP_CIPHER_free(cipher);
     return 1;
 
 err:
@@ -10286,7 +10279,8 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_DEPRECATED_3_0
     ADD_TEST(test_RSA_legacy);
 #endif
-    ADD_TEST(test_evp_cipher_parameter_sizes);
+    ADD_ALL_TESTS(test_evp_cipher_parameter_sizes,
+        sizeof(evp_cipher_parameter_tests));
 #if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
     ADD_TEST(test_decrypt_null_chunks);
 #endif

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4518,11 +4518,11 @@ static int test_evp_cipher_parameter_sizes(void)
         ivlen = OSSL_PARAM_UNMODIFIED;
 
         params[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_IV,
-                                                      NULL, 0);
+            NULL, 0);
         params[1] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_UPDATED_IV,
-                                                      NULL, 0);
+            NULL, 0);
         params[2] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG,
-                                                      NULL, 0);
+            NULL, 0);
         params[3] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_IVLEN, &ivlen);
         params[4] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_AEAD_TAGLEN, &taglen);
         params[5] = OSSL_PARAM_construct_end();
@@ -4533,7 +4533,7 @@ static int test_evp_cipher_parameter_sizes(void)
         if (!TEST_ptr(cipher = EVP_CIPHER_fetch(testctx, t->cipher_name, "")))
             goto next_iteration;
 
-        if(!TEST_true(EVP_CipherInit_ex2(ctx, cipher, NULL, NULL, 1, NULL))
+        if (!TEST_true(EVP_CipherInit_ex2(ctx, cipher, NULL, NULL, 1, NULL))
             || !TEST_true(EVP_CIPHER_CTX_get_params(ctx, params))
             || !TEST_size_t_eq(params[0].return_size, t->ivlen)
             || !TEST_size_t_eq(params[1].return_size, t->updatedivlen)
@@ -4544,7 +4544,7 @@ static int test_evp_cipher_parameter_sizes(void)
             goto err;
         }
 
-next_iteration:
+    next_iteration:
         EVP_CIPHER_CTX_free(ctx);
         ctx = NULL;
         EVP_CIPHER_free(cipher);
@@ -4558,7 +4558,6 @@ err:
     EVP_CIPHER_free(cipher);
     return 0;
 }
-
 
 #if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
 static int test_decrypt_null_chunks(void)
@@ -8559,11 +8558,11 @@ static int test_aes_gcm_ivlen_change_cve_2023_5363(void)
     };
 
     if (!TEST_true(aes_gcm_encrypt(gcm_key, sizeof(gcm_key), gcm_iv, sizeof(gcm_iv),
-                                   gcm_pt, sizeof(gcm_pt), NULL, 0,
-                                   gcm_ct, sizeof(gcm_ct), gcm_tag, sizeof(gcm_tag)))
+            gcm_pt, sizeof(gcm_pt), NULL, 0,
+            gcm_ct, sizeof(gcm_ct), gcm_tag, sizeof(gcm_tag)))
         || !TEST_true(aes_gcm_decrypt(gcm_key, sizeof(gcm_key), gcm_iv, sizeof(gcm_iv),
-                                     gcm_pt, sizeof(gcm_pt), NULL, 0,
-                                     gcm_ct, sizeof(gcm_ct), gcm_tag, sizeof(gcm_tag))))
+            gcm_pt, sizeof(gcm_pt), NULL, 0,
+            gcm_ct, sizeof(gcm_ct), gcm_tag, sizeof(gcm_tag))))
         return 0;
 
     return 1;

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -10280,7 +10280,7 @@ int setup_tests(void)
     ADD_TEST(test_RSA_legacy);
 #endif
     ADD_ALL_TESTS(test_evp_cipher_parameter_sizes,
-        sizeof(evp_cipher_parameter_tests));
+        OSSL_NELEM(evp_cipher_parameter_tests));
 #if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
     ADD_TEST(test_decrypt_null_chunks);
 #endif


### PR DESCRIPTION
Fixes #28646.

Checks that the sizes that are returned for
* OSSL_CIPHER_PARAM_UPDATED_IV and OSSL_CIPHER_PARAM_IV with a NULL buffer equals the return of OSSL_CIPHER_PARAM_IVLEN
* OSSL_CIPHER_PARAM_AEAD_TAG with a NULL buffer equals the return of OSSL_CIPHER_PARAM_AEAD_TAGLEN

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
