### PR TITLE
Disable clang-format around this macro

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -25,9 +25,11 @@
 #include "internal/provider.h"
 #include "internal/common.h"
 
+/* clang-format off */
 #ifndef OPENSSL_DEFAULT_SEED_SRC
-#define OPENSSL_DEFAULT_SEED_SRC SEED - SRC
+#define OPENSSL_DEFAULT_SEED_SRC SEED-SRC
 #endif
+/* clang-format on */
 
 typedef struct rand_global_st {
     /*


### PR DESCRIPTION
clang-format sensibly thinks this is an arithmatic operation, and formats the math. Sadly it does not know we eventually stringify this behind several other layers of nested macros and so putting spaces in here is bad.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
