### PR TITLE
Add static_ASN1_SEQUENCE_END to the list of statement macros

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -243,6 +243,7 @@ StatementMacros:
   - "ASN1_SEQUENCE_END_enc"
   - "ASN1_SEQUENCE_END_name"
   - "ASN1_SEQUENCE_END_ref"
+  - "static_ASN1_SEQUENCE_END"
   # This isn't quite right, but it causes clang-format to do a slightly better
   # job formatting this macro.
   - "ASN1_EX_TEMPLATE_TYPE"

--- a/providers/implementations/encode_decode/decode_der2key.c
+++ b/providers/implementations/encode_decode/decode_der2key.c
@@ -60,11 +60,13 @@ ASN1_SEQUENCE(BARE_ALGOR) = {
     ASN1_SIMPLE(BARE_ALGOR, oid, ASN1_OBJECT),
 } static_ASN1_SEQUENCE_END(BARE_ALGOR)
 
-    ASN1_SEQUENCE(BARE_PUBKEY)
-    = { ASN1_EMBED(BARE_PUBKEY, algor, BARE_ALGOR), ASN1_SIMPLE(BARE_PUBKEY, pubkey, ASN1_BIT_STRING) } static_ASN1_SEQUENCE_END(BARE_PUBKEY)
+ASN1_SEQUENCE(BARE_PUBKEY) = {
+    ASN1_EMBED(BARE_PUBKEY, algor, BARE_ALGOR),
+    ASN1_SIMPLE(BARE_PUBKEY, pubkey, ASN1_BIT_STRING)
+} static_ASN1_SEQUENCE_END(BARE_PUBKEY)
 #endif /* OPENSSL_NO_SLH_DSA */
 
-        struct der2key_ctx_st; /* Forward declaration */
+struct der2key_ctx_st; /* Forward declaration */
 typedef int check_key_fn(void *, struct der2key_ctx_st *ctx);
 typedef void adjust_key_fn(void *, struct der2key_ctx_st *ctx);
 typedef void free_key_fn(void *);


### PR DESCRIPTION
This one is pretty special, we should ponder simplifying some of
the clever preprocessor stuff here, but for now..

For the uninitiated, this list is a list of macros that include semicolons at the end of them, so that clang-format will treat them as such

Normally I'd say we should avoid such things. (or encase in do{} while(0)) etc

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
