### PR TITLE
Allow deciphering AES-GCM without authentication tag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,11 @@ OpenSSL 4.0
 
 ### Changes between 3.6 and 4.0 [xx XXX xxxx]
 
+ * Allow deciphering AES-GCM without authentication tag by explicitely
+   providing a 0 length tag using the EVP_CIPHER_CTX_ctrl() API.
+
+   *Nicolas Coq*
+
  * Removed extra leading '00:' when printing key data such as an RSA modulus
    in hexadecimal format where the first (most significant) byte is >= 0x80.
    This had been added artificially to resemble ASN.1 DER encoding internals.

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -1490,7 +1490,7 @@ static int s390x_aes_gcm_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
     case EVP_CTRL_AEAD_SET_TAG:
         buf = EVP_CIPHER_CTX_buf_noconst(c);
         enc = EVP_CIPHER_CTX_is_encrypting(c);
-        if (arg <= 0 || arg > 16 || enc)
+        if (arg < 0 || arg > 16 || enc)
             return 0;
 
         memcpy(buf, ptr, arg);
@@ -2687,7 +2687,7 @@ static int aes_gcm_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
         return 1;
 
     case EVP_CTRL_AEAD_SET_TAG:
-        if (arg <= 0 || arg > 16 || c->encrypt)
+        if (arg < 0 || arg > 16 || c->encrypt)
             return 0;
         memcpy(c->buf, ptr, arg);
         gctx->taglen = arg;

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -1522,7 +1522,7 @@ B<EVP_CTRL_AEAD_SET_TAG>.
 =item EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG, taglen, tag)
 
 When decrypting, this call sets the expected tag to C<taglen> bytes from C<tag>.
-C<taglen> must be between 1 and 16 inclusive.
+C<taglen> must be between 0 and 16 inclusive.
 The tag must be set prior to any call to EVP_DecryptFinal() or
 EVP_DecryptFinal_ex().
 


### PR DESCRIPTION
Allow deciphering AES-GCM without authentication tag by explicitely providing a 0 length tag

CLA: trivial

This change allows to decipher an AES-GCM ciphertext without an authentication tag by providing a 0 length tag through the EVP_CIPHER_CTX_ctrl() API with the EVP_CTRL_AEAD_SET_TAG command.
The default behavior is kept, if the control EVP_CTRL_AEAD_SET_TAG is never set, the EVP_DecryptFinal_ex() will still return an error because the taglen is initialized to -1.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
