### PR TITLE
Do not reformat any changes automatically in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,4 +10,4 @@ repos:
       - id: "clang-format"
         types_or: []
         files: '\.c\.in$|\.h\.in$|\.c$|\.h$'
-        args: ["--style=file"]
+        args: ["--Werror", "--dry-run", "--style=file"]


### PR DESCRIPTION
IMO, clang-format violation should be fixed by user, not by a precommit.

While it is convenient, it could introduce something that was not expected.
This change will make pre-commit fail without any code edits.

Referenced script calls clang-format with -i (inplace) option, --dry-run cancels this.
