### PR TITLE
missing free in statem_clint.c

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1897,6 +1897,7 @@ static MSG_PROCESS_RETURN tls_process_as_hello_retry_request(SSL_CONNECTION *s,
         goto err;
     }
 
+    OPENSSL_free(extensions);
     return MSG_PROCESS_FINISHED_READING;
 err:
     OPENSSL_free(extensions);


### PR DESCRIPTION

This one-liner adds a missing free.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
