### PR TITLE
Ensure path to libcrypto can be resolved on AIX.

### DIFF
--- a/test/recipes/90-test_includes.t
+++ b/test/recipes/90-test_includes.t
@@ -35,6 +35,9 @@ ok(run(test(["conf_include_test",  "-f", data_file("incdir.cnf")])), "test inclu
 SKIP: {
     skip "Skipping legacy test", 1
         if disabled("legacy");
+    # Ensure libcrypto can be resolved for the legacy provider on AIX.
+    local $ENV{LIBPATH} = abs_path(bldtop_dir("."))
+        if config('target') =~ m|^aix|;
     ok(run(test(["conf_include_test", "-providers", data_file("includes-prov-dir.cnf")])),
        "test directory includes with provider configs");
 }


### PR DESCRIPTION
On AIX, the environment of the test executable for test_includes doesn't contain a resolvable search path to the just built libcrypto. Setup LIBPATH to point to the build results.

Fixes #29352.
