### PR TITLE
Fix silent failure in ASYNC_start_job when size is 0

### DIFF
--- a/crypto/async/async.c
+++ b/crypto/async/async.c
@@ -255,7 +255,8 @@ int ASYNC_start_job(ASYNC_JOB **job, ASYNC_WAIT_CTX *wctx, int *ret,
         if ((ctx->currjob = async_get_pool_job()) == NULL)
             return ASYNC_NO_JOBS;
 
-        if (args != NULL) {
+        /* Check for size > 0 to avoid malloc(0) */
+        if (args != NULL && size > 0) {
             ctx->currjob->funcargs = OPENSSL_malloc(size);
             if (ctx->currjob->funcargs == NULL) {
                 async_release_job(ctx->currjob);


### PR DESCRIPTION
This PR fixes a silent failure issue in `ASYNC_start_job` when it is called with a valid `args` pointer but a `size` of 0.

**The Problem:**
Currently, `crypto/async/async.c` attempts to allocate memory for function arguments using `OPENSSL_malloc(size)` whenever `args` is not NULL, regardless of whether `size` is 0.
```c
if (args != NULL) {
    ctx->currjob->funcargs = OPENSSL_malloc(size); // size can be 0 here
    if (ctx->currjob->funcargs == NULL) {
        // ... returns ASYNC_ERR
    }
    // ...
}
```

The behavior of `malloc(0)` is implementation-defined. In many standard environments (e.g., glibc on standard Linux), it returns a unique pointer. However, in certain environments (e.g., specific Docker container configurations, hardened memory allocators, or specific libc implementations), `malloc(0)` returns `NULL`.

When `OPENSSL_malloc(0)` returns `NULL`, `ASYNC_start_job` interprets this as an allocation failure (OOM) and returns `ASYNC_ERR` immediately. Crucially, it does so **without raising any error code** on the OpenSSL error stack. To the caller, this looks like a generic failure with `ret == 0` and `errno == 0`, making debugging extremely difficult.

**The Fix:**
This patch modifies the logic to explicitly check if `size > 0` before attempting allocation.
- If `args != NULL` and `size > 0`: Proceed with `OPENSSL_malloc` and `memcpy`.
- If `size == 0`: Skip allocation and set `funcargs` to `NULL`. This treats the request as a valid "no-copy" scenario, which is the correct semantic behavior when the data size is zero.

**Verification:**
This issue was encountered during the development of a custom provider using Async jobs in a Dockerized environment. The patch resolves the silent failure and allows the Async job to start correctly with zero-sized arguments.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated