### PR TITLE
other.syms: Add OPENSSL_ppccap as it is now documented

### DIFF
--- a/util/other.syms
+++ b/util/other.syms
@@ -3,6 +3,7 @@
 # assembly language, etc.
 #
 OPENSSL_ia32cap                         environment
+OPENSSL_ppccap                          environment
 OPENSSL_s390xcap                        environment
 OPENSSL_riscvcap                        environment
 OPENSSL_MALLOC_FD                       environment


### PR DESCRIPTION
This fixes doc nits CI regression on 3.5 branch so it is urgent.
