### PR TITLE
Remove crypto-mdebug-backtrace option from config

### DIFF
--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -45,7 +45,6 @@ jobs:
           no-cmac,
           no-comp,
           enable-crypto-mdebug,
-          enable-crypto-mdebug-backtrace,
           no-ct,
           enable-demos,
           no-deprecated,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,11 @@ OpenSSL 4.0
 
 ### Changes between 3.6 and 4.0 [xx XXX xxxx]
 
+ * The crypto-mdebug-backtrace configuration option has been entirely removed.
+   The option has been a no-op since 1.0.2.
+
+   *Neil Horman*
+
  * Removed extra leading '00:' when printing key data such as an RSA modulus
    in hexadecimal format where the first (most significant) byte is >= 0x80.
    This had been added artificially to resemble ASN.1 DER encoding internals.

--- a/Configure
+++ b/Configure
@@ -576,7 +576,6 @@ my %deprecated_disablables = (
     "padlockeng" => undef,
     "ssl2" => undef,
     "buf-freelists" => undef,
-    "crypto-mdebug-backtrace" => undef,
     "hw" => undef,
     "hw-padlock" => undef,
     "ripemd" => "rmd160",
@@ -595,7 +594,6 @@ our %disabled = ( # "what"         => "comment"
                   "buildtest-c++"       => "default",
                   "crypto-mdebug"       => "default",
                   "allocfail-tests"     => "default",
-                  "crypto-mdebug-backtrace" => "default",
                   "demos"               => "default",
                   "h3demo"              => "default",
                   "hqinterop"           => "default",
@@ -669,7 +667,7 @@ my @disable_cascades = (
     "tls1_3"            => [ "quic" ],
     "quic"              => [ "unstable-qlog" ],
 
-    "crypto-mdebug"     => [ "crypto-mdebug-backtrace", "allocfail-tests" ],
+    "crypto-mdebug"     => [ "allocfail-tests" ],
 
     "module"            => [ "fips" ],
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -729,10 +729,6 @@ the zlib or `zlib-dynamic` options are also chosen.
 
 This now only enables the `failed-malloc` feature.
 
-### enable-crypto-mdebug-backtrace
-
-This is a no-op; the project uses the compiler's address/leak sanitizer instead.
-
 ### enable-allocfail-tests
 
 This option enables testing that leverages the use of the crypto-mdebug feature

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,8 @@ OpenSSL 4.0
   * ENGINE support was removed. The `no-engine` build option and the
    `OPENSSL_NO_ENGINE` macro is always present.
 
+  * The crypto-mdebug-backtrace configuration option has been entirely removed.
+
 OpenSSL 3.6
 -----------
 


### PR DESCRIPTION
We still build with crypto-mdebug-backtrace enabled in a few ci jobs, but it does nothing.

With the upcoming merge of feature/removesslv3, the code changes there prevent the use of this option (i.e. enabling it results in configuration failure).

It seems the most sensible thing to do here, given we have a major release is to eliminate the option entirely, as it hasn't done anything since 1.0.2.

Fixes openssl/project#1763


##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated
