### PR TITLE
Implement ASN1_BIT_STRING_set1()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,12 @@ OpenSSL 4.0
 
 ### Changes between 3.6 and 4.0 [xx XXX xxxx]
 
+ * Added accessors for ASN1_BIT_STRING values - ASN1_BIT_STRING_set1 and ASN1_BIT_STRING_get_length()
+   to ensure there are ways to retrieve and set values keeping the unused_bits correct, without
+   touching ASN1_STRING internals.
+
+   *Bob Beck*
+
  * Added configure options to disable KDF algorithms for
    hmac-drbg-kdf, kbkdf, krb5kdf, pvkkdf, snmpkdf, sskdf, sshkdf, x942kdf and x963kdf.
 

--- a/crypto/asn1/a_bitstr.c
+++ b/crypto/asn1/a_bitstr.c
@@ -13,6 +13,25 @@
 #include <openssl/asn1.h>
 #include "asn1_local.h"
 
+static void
+asn1_abs_clear_unused_bits(ASN1_BIT_STRING *abs)
+{
+    abs->flags &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07);
+}
+
+static int
+asn1_abs_set_unused_bits(ASN1_BIT_STRING *abs, uint8_t unused_bits)
+{
+    if (unused_bits > 7)
+        return 0;
+
+    asn1_abs_clear_unused_bits(abs);
+
+    abs->flags |= ASN1_STRING_FLAG_BITS_LEFT | unused_bits;
+
+    return 1;
+}
+
 int ASN1_BIT_STRING_set(ASN1_BIT_STRING *x, unsigned char *d, int len)
 {
     return ASN1_STRING_set(x, d, len);
@@ -162,7 +181,7 @@ int ASN1_BIT_STRING_set_bit(ASN1_BIT_STRING *a, int n, int value)
     if (a == NULL)
         return 0;
 
-    a->flags &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07); /* clear, set on write */
+    asn1_abs_clear_unused_bits(a);
 
     if ((a->length < (w + 1)) || (a->data == NULL)) {
         if (!value)
@@ -252,4 +271,32 @@ int ASN1_BIT_STRING_get_length(const ASN1_BIT_STRING *abs, size_t *out_length,
     *out_unused_bits = unused_bits;
 
     return 1;
+}
+
+int ASN1_BIT_STRING_set1(ASN1_BIT_STRING *abs, const uint8_t *data, size_t length,
+    int unused_bits)
+{
+    if (abs == NULL)
+        return 0;
+
+    if (length > INT_MAX || unused_bits < 0 || unused_bits > 7)
+        return 0;
+
+    if (length == 0 && unused_bits != 0)
+        return 0;
+
+    if (length > 0 && (data[length - 1] & ((1 << unused_bits) - 1)) != 0)
+        return 0;
+
+    /*
+     * XXX - ASN1_STRING_set() and asn1_abs_set_unused_bits() preserve the
+     * state of flags irrelevant to ASN1_BIT_STRING. Should we explicitly
+     * clear them?
+     */
+
+    abs->type = V_ASN1_BIT_STRING;
+    if (!ASN1_STRING_set(abs, data, (int)length))
+        return 0;
+
+    return asn1_abs_set_unused_bits(abs, unused_bits);
 }

--- a/doc/build.info
+++ b/doc/build.info
@@ -515,10 +515,6 @@ DEPEND[html/man3/ASN1_STRING_new.html]=man3/ASN1_STRING_new.pod
 GENERATE[html/man3/ASN1_STRING_new.html]=man3/ASN1_STRING_new.pod
 DEPEND[man/man3/ASN1_STRING_new.3]=man3/ASN1_STRING_new.pod
 GENERATE[man/man3/ASN1_STRING_new.3]=man3/ASN1_STRING_new.pod
-DEPEND[html/man3/ASN1_BIT_STRING_get_length.html]=man3/ASN1_BIT_STRING_get_length.pod
-GENERATE[html/man3/ASN1_BIT_STRING_get_length.html]=man3/ASN1_BIT_STRING_get_length.pod
-DEPEND[man/man3/ASN1_BIT_STRING_get_length.3]=man3/ASN1_BIT_STRING_get_length.pod
-GENERATE[man/man3/ASN1_BIT_STRING_get_length.3]=man3/ASN1_BIT_STRING_get_length.pod
 DEPEND[html/man3/ASN1_STRING_print_ex.html]=man3/ASN1_STRING_print_ex.pod
 GENERATE[html/man3/ASN1_STRING_print_ex.html]=man3/ASN1_STRING_print_ex.pod
 DEPEND[man/man3/ASN1_STRING_print_ex.3]=man3/ASN1_STRING_print_ex.pod
@@ -3174,7 +3170,6 @@ html/man3/ASN1_OBJECT_new.html \
 html/man3/ASN1_STRING_TABLE_add.html \
 html/man3/ASN1_STRING_length.html \
 html/man3/ASN1_STRING_new.html \
-html/man3/ASN1_BIT_STRING_get_length.html \
 html/man3/ASN1_STRING_print_ex.html \
 html/man3/ASN1_TIME_set.html \
 html/man3/ASN1_TYPE_get.html \
@@ -3846,7 +3841,6 @@ man/man3/ASN1_OBJECT_new.3 \
 man/man3/ASN1_STRING_TABLE_add.3 \
 man/man3/ASN1_STRING_length.3 \
 man/man3/ASN1_STRING_new.3 \
-man/man3/ASN1_BIT_STRING_get_length.3 \
 man/man3/ASN1_STRING_print_ex.3 \
 man/man3/ASN1_TIME_set.3 \
 man/man3/ASN1_TYPE_get.3 \

--- a/doc/man3/ASN1_BIT_STRING_get_length.pod
+++ b/doc/man3/ASN1_BIT_STRING_get_length.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+ASN1_BIT_STRING_set1,
 ASN1_BIT_STRING_get_length - ASN1_BIT_STRING accessors
 
 =head1 SYNOPSIS
@@ -9,6 +10,7 @@ ASN1_BIT_STRING_get_length - ASN1_BIT_STRING accessors
   #include <openssl/asn1.h>
 
   int ASN1_BIT_STRING_get_length(const ASN1_BIT_STRING *bitstr, size_t *length, int *unused_bits);
+  int ASN1_BIT_STRING_set1(ASN1_BIT_STRING *abs, const uint8_t *data, size_t length, int unused_bits);
 
 =head1 DESCRIPTION
 
@@ -17,15 +19,28 @@ containing bit values in I<length> and the number of unused bits in
 the last octet in I<unused_bits>. The value returned in
 I<unused_bits> is guaranteed to be between 0 and 7, inclusive.
 
+ASN1_BIT_STRING_set1() sets the value of the bit string I<abs> to be a
+copy of I<length> octets from I<data>, with I<unused_bits> of unused
+bits in the last octet of the bit string, ensuring the internal state
+of the bit string is consistent given the length and unused bits
+values. This API should always be used instead of ASN1_STRING_set()
+when setting the value of a bit string.
+
 =head1 RETURN VALUES
 
 ASN1_BIT_STRING_get_length() returns 1 on success or 0 if the encoding
 of I<bitstr> is internally inconsistent, or if one of I<bitstr>,
 I<length>, or I<unused_bits> is NULL.
 
+ASN1_BIT_STRING_set1() returns 1 on success or 0 on failure. It
+will fail if I<abs> is NULL, if <length> or <unused_bits> are out of
+range, if the <length> and <unused_bits>, are not consistent, or if
+the last <unused_bits> in the last octet of <data> are not zero, or
+if memory allocation fails.
+
 =head1 COPYRIGHT
 
-Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/openssl/asn1.h.in
+++ b/include/openssl/asn1.h.in
@@ -586,6 +586,8 @@ int ASN1_BIT_STRING_set_asc(ASN1_BIT_STRING *bs, const char *name, int value,
     BIT_STRING_BITNAME *tbl);
 int ASN1_BIT_STRING_get_length(const ASN1_BIT_STRING *abs, size_t *length,
     int *unused_bits);
+int ASN1_BIT_STRING_set1(ASN1_BIT_STRING *abs, const uint8_t *data,
+    size_t length, int unused_bits);
 
 /* clang-format off */
 {-

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -2583,6 +2583,7 @@ ASN1_BIT_STRING_free                    ?	4_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_new                     ?	4_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_it                      ?	4_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_set                     ?	4_0_0	EXIST::FUNCTION:
+ASN1_BIT_STRING_set1                    ?	4_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_set_bit                 ?	4_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_get_bit                 ?	4_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_check                   ?	4_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
From <tb@openbsd.org> with tests adapted for OpenSSL by beck

tb tested this with rpki-client which uses this for IP addresses
in the CCR. It was also tested with Ruby and it is enough to implement
all write accesses to the flags in ASN1_BIT_STRINGs that were found.

Fixes: https://github.com/openssl/openssl/issues/29185
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
