### PR TITLE
fix test_strn_ne handling of differing lengths

### DIFF
--- a/test/test_test.c
+++ b/test/test_test.c
@@ -278,6 +278,26 @@ err:
     return 0;
 }
 
+static int test_string_n(void)
+{
+    if (!TEST(1, TEST_strn_eq(NULL, NULL, 0))
+        || !TEST(1, TEST_strn_ne("abc", NULL, 3))
+        || !TEST(1, TEST_strn_eq("abc", "abcd", 3))
+        || !TEST(0, TEST_strn_ne("abc", "abcd", 3))
+        || !TEST(1, TEST_strn_eq("abc", "abc", 10))
+        || !TEST(0, TEST_strn_ne("abc", "abc", 10))
+        || !TEST(1, TEST_strn_ne("abc", "abx", 3))
+        || !TEST(0, TEST_strn_eq("abc", "abx", 3))
+        || !TEST(0, TEST_strn2_eq("abcdef", 3, "abcxyz", 6))
+        || !TEST(0, TEST_strn2_ne("abcdef", 3, "abcxyz", 6))
+        || !TEST(1, TEST_strn2_ne("abcdef", 3, "axyzef", 6)))
+        goto err;
+    return 1;
+
+err:
+    return 0;
+}
+
 static int test_memory(void)
 {
     static char buf[] = "xyz";
@@ -563,6 +583,7 @@ int setup_tests(void)
     ADD_TEST(test_pointer);
     ADD_TEST(test_bool);
     ADD_TEST(test_string);
+    ADD_TEST(test_string_n);
     ADD_TEST(test_memory);
     ADD_TEST(test_memory_overflow);
     ADD_TEST(test_bignum);

--- a/test/testutil/tests.c
+++ b/test/testutil/tests.c
@@ -320,7 +320,7 @@ int test_strn_ne(const char *file, int line, const char *st1, const char *st2,
 {
     if ((s1 == NULL) ^ (s2 == NULL))
         return 1;
-    if (n1 != n2 || s1 == NULL || strncmp(s1, s2, n1) == 0) {
+    if (s1 == NULL || strncmp(s1, s2, n1 > n2 ? n2 : n1) == 0) {
         test_fail_string_message(NULL, file, line, "string", st1, st2, "!=",
             s1, s1 == NULL ? 0 : OPENSSL_strnlen(s1, n1),
             s2, s2 == NULL ? 0 : OPENSSL_strnlen(s2, n2));


### PR DESCRIPTION
test_strn_ne() incorrectly reported equality when the comparison lengths differed. Treat differing n values as not equal, matching the intended semantics.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

Fixes #23386 