### PR TITLE
apps/req.c: Always set permissions for private key output

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -719,7 +719,7 @@ int req_main(int argc, char **argv)
             else
                 BIO_printf(bio_err, "'%s'\n", keyout);
         }
-        out = bio_open_owner(keyout, outformat, newreq);
+        out = bio_open_owner(keyout, outformat, 1);
         if (out == NULL)
             goto end;
 


### PR DESCRIPTION
The key output will be always private.

Reported with a proposed fix by Stanislav Fort (Aisle Research).
