### PR TITLE
Fix error in PAC/BTI AArch64 build caused by Clang Format

### DIFF
--- a/crypto/arm_arch.h
+++ b/crypto/arm_arch.h
@@ -192,7 +192,9 @@ extern unsigned int OPENSSL_armv8_rsa_neonized;
 #endif
 
 #if GNU_PROPERTY_AARCH64_POINTER_AUTH != 0 || GNU_PROPERTY_AARCH64_BTI != 0
-.pushsection.note.gnu.property, "a";
+/* clang-format off */
+.pushsection .note.gnu.property, "a";
+/* clang-format on */
 .balign 8;
 .long 4;
 .long 0x10;


### PR DESCRIPTION
Hi all,

The Clang format patch has broken Aarch64 builds by unfortunately mis-formatting some inline assembly code (it removes a rather vital space)

This patch fixes that, but running Clang Format will break it again (and thus this patch will not pass the format check)

This is something of an issue, and I'm not sure where best to proceed from here. Is there any way to tell Clang format not to touch a small amount of code?