### PR TITLE
Fix of EOF and retry handling in BIO implementations.

### DIFF
--- a/crypto/bio/bf_buff.c
+++ b/crypto/bio/bf_buff.c
@@ -256,6 +256,12 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_EOF:
         if (ctx->ibuf_len > 0)
             return 0;
+        /*
+         * If there is no ctx or no next BIO, BIO_read() returns 0, which means
+         * EOF, BIO_eof() should return 1 in this case.
+         */
+        if (ctx == NULL || b->next_bio == NULL)
+            return 1;
         ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
         break;
     case BIO_CTRL_INFO:

--- a/crypto/bio/bf_null.c
+++ b/crypto/bio/bf_null.c
@@ -74,9 +74,14 @@ static long nullf_ctrl(BIO *b, int cmd, long num, void *ptr)
 {
     long ret;
 
+    /*
+     * If there is no next BIO, BIO_read() returns 0, which means EOF.
+     * BIO_eof() should return 1 in this case.
+     */
     if (b->next_bio == NULL)
-        return 0;
+        return cmd == BIO_CTRL_EOF;
     switch (cmd) {
+    case BIO_CTRL_FLUSH:
     case BIO_C_DO_STATE_MACHINE:
         BIO_clear_retry_flags(b);
         ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
@@ -100,14 +105,24 @@ static long nullf_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 
 static int nullf_gets(BIO *bp, char *buf, int size)
 {
+    int ret = 0;
+
     if (bp->next_bio == NULL)
         return 0;
-    return BIO_gets(bp->next_bio, buf, size);
+    ret = BIO_gets(bp->next_bio, buf, size);
+    BIO_clear_retry_flags(bp);
+    BIO_copy_next_retry(bp);
+    return ret;
 }
 
 static int nullf_puts(BIO *bp, const char *str)
 {
+    int ret = 0;
+
     if (bp->next_bio == NULL)
         return 0;
-    return BIO_puts(bp->next_bio, str);
+    ret = BIO_puts(bp->next_bio, str);
+    BIO_clear_retry_flags(bp);
+    BIO_copy_next_retry(bp);
+    return ret;
 }

--- a/crypto/bio/bss_bio.c
+++ b/crypto/bio/bss_bio.c
@@ -112,6 +112,9 @@ static int bio_read(BIO *bio, char *buf, int size_)
     size_t rest;
     struct bio_bio_st *b, *peer_b;
 
+    if (buf == NULL || size_ <= 0)
+        return 0;
+
     BIO_clear_retry_flags(bio);
 
     if (!bio->init)
@@ -125,9 +128,6 @@ static int bio_read(BIO *bio, char *buf, int size_)
     assert(peer_b->buf != NULL);
 
     peer_b->request = 0; /* will be set in "retry_read" situation */
-
-    if (buf == NULL || size == 0)
-        return 0;
 
     if (peer_b->len == 0) {
         if (peer_b->closed)

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -373,8 +373,9 @@ static int conn_read(BIO *b, char *out, int outl)
         return ret;
     }
 
-    if (out != NULL) {
+    if (out != NULL && outl > 0) {
         clear_socket_error();
+        b->flags &= ~BIO_FLAGS_IN_EOF;
 #ifndef OPENSSL_NO_KTLS
         if (BIO_get_ktls_recv(b))
             ret = ktls_read_record(b->num, out, outl);
@@ -776,6 +777,7 @@ int conn_gets(BIO *bio, char *buf, int size)
     }
 
     clear_socket_error();
+    bio->flags &= ~BIO_FLAGS_IN_EOF;
     while (size-- > 1) {
 #ifndef OPENSSL_NO_KTLS
         if (BIO_get_ktls_recv(bio))

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -427,7 +427,7 @@ static int dgram_read(BIO *b, char *out, int outl)
     BIO_ADDR peer;
     socklen_t len = sizeof(peer);
 
-    if (out != NULL) {
+    if (out != NULL && outl > 0) {
         clear_socket_error();
         BIO_ADDR_clear(&peer);
         dgram_adjust_rcv_timeout(b);

--- a/crypto/bio/bss_fd.c
+++ b/crypto/bio/bss_fd.c
@@ -114,8 +114,9 @@ static int fd_read(BIO *b, char *out, int outl)
 {
     int ret = 0;
 
-    if (out != NULL) {
+    if (out != NULL && outl > 0) {
         clear_sys_error();
+        b->flags &= ~BIO_FLAGS_IN_EOF;
         ret = (int)UP_read(b->num, out, outl);
         BIO_clear_retry_flags(b);
         if (ret <= 0) {

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -137,7 +137,7 @@ static int file_read(BIO *b, char *out, int outl)
 {
     int ret = 0;
 
-    if (b->init && (out != NULL)) {
+    if (b->init != 0 && out != NULL && outl > 0) {
         if (b->flags & BIO_FLAGS_UPLINK_INTERNAL)
             ret = (int)UP_fread(out, 1, outl, b->ptr);
         else

--- a/crypto/bio/bss_log.c
+++ b/crypto/bio/bss_log.c
@@ -91,10 +91,10 @@ static const BIO_METHOD methods_slg = {
     "syslog",
     bwrite_conv,
     slg_write,
-    NULL, /* slg_write_old,    */
-    NULL, /* slg_read,         */
+    NULL, /* slg_read          */
+    NULL, /* slg_read_old      */
     slg_puts,
-    NULL,
+    NULL, /* slg_gets          */
     slg_ctrl,
     slg_new,
     slg_free,

--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -125,6 +125,7 @@ static int mem_init(BIO *bi, unsigned long flags)
     bi->shutdown = 1;
     bi->init = 1;
     bi->num = -1;
+    bi->flags |= BIO_FLAGS_MEM_LEGACY_EOF;
     bi->ptr = (char *)bb;
     return 1;
 }
@@ -288,10 +289,14 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
             ret = -1;
         break;
     case BIO_CTRL_EOF:
-        ret = (long)(bm->length == 0);
+        if (b->num == 0 || (b->flags & BIO_FLAGS_MEM_LEGACY_EOF) != 0)
+            ret = (long)(bm->length == 0);
+        else
+            ret = 0;
         break;
     case BIO_C_SET_BUF_MEM_EOF_RETURN:
         b->num = (int)num;
+        b->flags &= ~BIO_FLAGS_MEM_LEGACY_EOF;
         break;
     case BIO_CTRL_INFO:
         ret = (long)bm->length;

--- a/crypto/bio/bss_sock.c
+++ b/crypto/bio/bss_sock.c
@@ -106,8 +106,9 @@ static int sock_read(BIO *b, char *out, int outl)
 {
     int ret = 0;
 
-    if (out != NULL) {
+    if (out != NULL && outl > 0) {
         clear_socket_error();
+        b->flags &= ~BIO_FLAGS_IN_EOF;
 #ifndef OPENSSL_NO_KTLS
         if (BIO_get_ktls_recv(b))
             ret = ktls_read_record(b->num, out, outl);

--- a/crypto/evp/bio_md.c
+++ b/crypto/evp/bio_md.c
@@ -167,12 +167,22 @@ static long md_ctrl(BIO *b, int cmd, long num, void *ptr)
         else
             ret = 0;
         break;
+    case BIO_CTRL_EOF:
+        /*
+         * If there is no ctx or no next BIO, BIO_read() returns 0, which means
+         * EOF, BIO_eof() should return 1 in this case.
+         */
+        if (ctx == NULL || next == NULL)
+            ret = 1;
+        else
+            ret = BIO_ctrl(next, cmd, num, ptr);
+        break;
+    case BIO_CTRL_FLUSH:
     case BIO_C_DO_STATE_MACHINE:
         BIO_clear_retry_flags(b);
         ret = BIO_ctrl(next, cmd, num, ptr);
         BIO_copy_next_retry(b);
         break;
-
     case BIO_C_SET_MD:
         md = ptr;
         ret = EVP_DigestInit_ex(ctx, md, NULL);

--- a/doc/man3/BIO_ctrl.pod
+++ b/doc/man3/BIO_ctrl.pod
@@ -65,8 +65,11 @@ BIO_tell() returns the current file position of a file related BIO.
 BIO_flush() normally writes out any internally buffered data, in some
 cases it is used to signal EOF and that no more data will be written.
 
-BIO_eof() returns 1 if the BIO has read EOF, the precise meaning of
-"EOF" varies according to the BIO type.
+BIO_eof() returns 1 if the BIO has reached end-of-file as a result of
+the most recent read operation. The precise meaning of "EOF" varies
+according to the BIO type. The function reports the result of the
+previous read attempt and does not update this state based on subsequent
+operations.
 
 BIO_set_close() sets the BIO B<b> close flag to B<flag>. B<flag> can
 take the value BIO_CLOSE or BIO_NOCLOSE. Typically BIO_CLOSE is used

--- a/doc/man3/BIO_s_mem.pod
+++ b/doc/man3/BIO_s_mem.pod
@@ -77,6 +77,11 @@ it will return zero and BIO_should_retry(b) will be false. If B<v> is non
 zero then it will return B<v> when it is empty and it will set the read retry
 flag (that is BIO_read_retry(b) is true). To avoid ambiguity with a normal
 positive return value B<v> should be set to a negative value, typically -1.
+The default behaviour for read-only BIOs is as if BIO_set_mem_eof_return(0)
+were called. The default behaviour for read-write BIOs is special: BIO_eof()
+returns EOF for an empty buffer, while the BIO_read() behaviour remains
+identical to the case BIO_set_mem_eof_return(-1). This default behaviour
+is maintained for backward compatibility.
 Calling this macro will fail for datagram mem BIOs.
 
 BIO_get_mem_data() sets *B<pp> to a pointer to the start of the memory BIOs data

--- a/include/internal/bio.h
+++ b/include/internal/bio.h
@@ -45,6 +45,12 @@ int bread_conv(BIO *bio, char *data, size_t datal, size_t *read);
 #define BIO_CTRL_SET_KTLS_TX_ZEROCOPY_SENDFILE 90
 
 /*
+ * This is used with memory BIOs:
+ * BIO_FLAGS_MEM_LEGACY_EOF means legacy behaviour of BIO_eof()
+ */
+#define BIO_FLAGS_MEM_LEGACY_EOF 0x1000
+
+/*
  * This is used with socket BIOs:
  * BIO_FLAGS_KTLS_TX means we are using ktls with this BIO for sending.
  * BIO_FLAGS_KTLS_TX_CTRL_MSG means we are about to send a ctrl message next.

--- a/test/bio_core_test.c
+++ b/test/bio_core_test.c
@@ -84,6 +84,7 @@ static int test_bio_core(void)
         || !TEST_ptr((cbio = BIO_new_from_core_bio(libctx, &corebio))))
         goto err;
 
+    BIO_set_mem_eof_return(cbio, 0);
     if (!TEST_int_gt(BIO_puts(corebio.bio, msg), 0)
         /* Test a ctrl via BIO_eof */
         || !TEST_false(BIO_eof(cbio))

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -9460,6 +9460,79 @@ end:
     return testresult;
 }
 
+/*
+ * Test that SSL BIO reports EOF correctly
+ * Test 0: EOF after peer close_notify has been received
+ * Test 1: EOF after the underlying BIO reports EOF
+ */
+static int test_ssl_bio_eof(int tst)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    int testresult = 0;
+    BIO *clientbio = BIO_new(BIO_f_ssl());
+    char buf[1];
+    size_t nbytes = 0;
+
+    if (!TEST_ptr(clientbio))
+        goto end;
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(),
+            0, 0,
+            &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL,
+            NULL)))
+        goto end;
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
+        goto end;
+
+    if (!TEST_int_eq(BIO_set_ssl(clientbio, clientssl, BIO_NOCLOSE), 1))
+        goto end;
+
+    /* Check we don't receive EOF in normal flow */
+    if (!TEST_true(SSL_write_ex(serverssl, "1", 1, &nbytes)))
+        goto end;
+    if (!TEST_true(BIO_read_ex(clientbio, buf, 1, &nbytes))
+        || !TEST_false(BIO_eof(clientbio)))
+        goto end;
+    /* Absence of data doesn't cause the EOF state */
+    if (!TEST_false(BIO_read_ex(clientbio, buf, 1, &nbytes))
+        || !TEST_false(BIO_eof(clientbio)))
+        goto end;
+
+    /* In test 0 send close_notify from the server */
+    if (tst == 0)
+        SSL_shutdown(serverssl);
+
+    /* In test 1 force the underlying BIO_s_mem to report EOF at end of data */
+    if (tst == 1) {
+        BIO *rbio = SSL_get_rbio(clientssl);
+        if (!TEST_ptr(rbio)
+            || !TEST_int_eq(BIO_method_type(rbio), BIO_TYPE_MEM))
+            goto end;
+        if (!TEST_true(BIO_set_mem_eof_return(rbio, 0)))
+            goto end;
+    }
+
+    /* Now client should observe EOF on the SSL BIO */
+    if (!TEST_int_eq(BIO_read_ex(clientbio, buf, 1, &nbytes), 0)
+        || !TEST_true(BIO_eof(clientbio)))
+        goto end;
+
+    testresult = 1;
+end:
+    BIO_free_all(clientbio);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
 #if !defined(OPENSSL_NO_TLS1_2) || !defined(OSSL_NO_USABLE_TLS1_3)
 static int cert_cb_cnt;
 
@@ -14017,6 +14090,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_ticket_callbacks, 20);
     ADD_ALL_TESTS(test_shutdown, 7);
     ADD_TEST(test_async_shutdown);
+    ADD_ALL_TESTS(test_ssl_bio_eof, 2);
     ADD_ALL_TESTS(test_incorrect_shutdown, 2);
     ADD_ALL_TESTS(test_cert_cb, 6);
     ADD_ALL_TESTS(test_client_cert_cb, 2);


### PR DESCRIPTION
This PR implements the following changes in the built-in BIO implementation:
- All filter BIOs inherit retry flags from the next_bio after relevant operations;
- For filter BIOs, the behavior of the BIO_read and BIO_eof functions has been made consistent in the absence of a next_bio;
- BIOs using the BIO_FLAGS_IN_EOF flag now reset it before read operations;
- Added handling of negative length values passed to read functions.

Fixes openssl/project#1739

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
