### PR TITLE
Harden digest context deserialization

### DIFF
--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -340,6 +340,11 @@ different OpenSSL version and does not guarantee interoperability between
 different providers. Some providers may not allow export/import across
 process boundaries.
 
+NOTE: Applications must guarantee that only trusted data is used during
+deserialization. The deserialization operation is not built to address
+adversarial data compromise, and only basic checks to protect from simple
+mistakes are implemented.
+
 =item EVP_MD_CTX_dup()
 
 Can be used to duplicate the message digest state from I<in>.  This is useful


### PR DESCRIPTION
The deserialization functions for SHA2 and SHA3 digest contexts did not sufficiently validate the incoming data. Corruption in transmission or on saved disk data could cause a out-of-bounds memory access if buffer sizes did not match expected values.

Add sanity checks to the SHA2 and SHA3 deserialization functions to validate buffer-related fields before they are used. The serialization format for these digests has been changed to place these critical fields early in the stream to enable this validation.

Additionally, add a note to the EVP_DigestInit man page to warn users that deserialization should only be performed on trusted data. The checks we implement are not meant to address processing of untrusted data maliciously crafted by an attacker.

Application that need to store data or transmit it through untrusted media SHOULD implement proper encryption and message authentication on their own using things like CMS or other appropriate secure message containers.

These check have been added also to quiet a bit security researchers that try to find any way to claim CVE bounties even in completely unlikely or invalid scenarios.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
