### PR TITLE
Make the test output show how long each test takes by default.

### DIFF
--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -46,7 +46,7 @@ if (!defined($jobs)) {
     }
     if (!defined($cpus) && -r "/proc/cpuinfo") {
         # Smells like Linux or something else attempting bug for bug
-        # compatibilty with the /proc paradigm.
+        # compatibility with the /proc paradigm.
         my $tmp = qx(grep -c ^processor /proc/cpuinfo 2>/dev/null);
         if ($? == 0 && $tmp > 0) {
             $cpus = $tmp;
@@ -77,12 +77,18 @@ $ENV{CTLOG_FILE} = rel2abs(catfile($srctop, "test", "ct", "log_list.cnf"));
 # some situations.
 $ENV{'MALLOC_PERTURB_'} = '128' if !defined $ENV{'MALLOC_PERTURB_'};
 
+my $tap_verbosity = exists $ENV{'HARNESS_VERBOSE'} ? $ENV{'HARNESS_VERBOSE'} : 0;
+# Show test times by default, unless we have lowered verbosity.
+my $tap_timer =  ($tap_verbosity >= 0) ? 1 : 0;
+# But also ensure HARNESS_TIMER is respected if it is set.
+$tap_timer = exists $ENV{'HARNESS_TIMER'} ? $ENV{'HARNESS_TIMER'} : $tap_timer;
+
 my %tapargs =
-    ( verbosity         => $ENV{HARNESS_VERBOSE} ? 1 : 0,
+    ( verbosity         => $tap_verbosity,
       lib               => [ $libdir ],
       switches          => '-w',
       merge             => 1,
-      timer             => $ENV{HARNESS_TIMER} ? 1 : 0,
+      timer             => $tap_timer,
     );
 
 if ($jobs > 1) {


### PR DESCRIPTION
Unless we have reduced the verbosity level, or overridden it with a HARNESS_TIMER setting.

This makes it easier to realize when you are making a test that is starting to dominate testing time for developers, and makes it easier for developers to see it.

For: https://github.com/openssl/project/issues/1767

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
