### PR TITLE
match last filename for output in ecp_nistp521-ppc64.pl

### DIFF
--- a/crypto/ec/asm/ecp_nistp521-ppc64.pl
+++ b/crypto/ec/asm/ecp_nistp521-ppc64.pl
@@ -19,7 +19,10 @@ use warnings;
 
 my $flavour = shift;
 my $output = "";
-while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {}
+my $arg;
+while ($arg = shift) {
+    $output = $arg if $arg =~ /\w[\w\-]*\.\w+$/;
+}
 if (!$output) {
 	$output = "-";
 }


### PR DESCRIPTION
Fixes #29415

Save the last filename match instead of first. Makefile generates command with `crypto/ec/ecp_nistp521-ppc64.s` as the last param.