### PR TITLE
match last filename for output in ecp_nistp521-ppc64.pl

### DIFF
--- a/crypto/ec/asm/ecp_nistp384-ppc64.pl
+++ b/crypto/ec/asm/ecp_nistp384-ppc64.pl
@@ -19,9 +19,12 @@
 use strict;
 use warnings;
 
-my $flavour = shift;
-my $output = "";
-while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {}
+my ($flavour, $output);
+
+# $flavour is the first argument if it doesn't look like a file
+# $output is the last argument if it looks like a file (it has an extension)
+$flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
+$output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 if (!$output) {
         $output = "-";
 }

--- a/crypto/ec/asm/ecp_nistp521-ppc64.pl
+++ b/crypto/ec/asm/ecp_nistp521-ppc64.pl
@@ -17,9 +17,12 @@
 use strict;
 use warnings;
 
-my $flavour = shift;
-my $output = "";
-while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {}
+my ($flavour, $output);
+
+# $flavour is the first argument if it doesn't look like a file
+# $output is the last argument if it looks like a file (it has an extension)
+$flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
+$output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 if (!$output) {
 	$output = "-";
 }


### PR DESCRIPTION
Fixes https://github.com/openssl/openssl/issues/29415

Save the last filename match instead of first. Makefile generates command with crypto/ec/ecp_nistp521-ppc64.s as the last param.