### PR TITLE
Constify the return value of X509_get0_pubkey_bitstr()

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -981,7 +981,7 @@ static int add_ocsp_serial(OCSP_REQUEST **req, char *serial,
 {
     OCSP_CERTID *id = NULL;
     const X509_NAME *iname;
-    ASN1_BIT_STRING *ikey;
+    const ASN1_BIT_STRING *ikey;
     ASN1_INTEGER *sno;
 
     if (issuer == NULL) {

--- a/crypto/ocsp/ocsp_lib.c
+++ b/crypto/ocsp/ocsp_lib.c
@@ -24,7 +24,7 @@ OCSP_CERTID *OCSP_cert_to_id(const EVP_MD *dgst, const X509 *subject,
 {
     const X509_NAME *iname;
     const ASN1_INTEGER *serial;
-    ASN1_BIT_STRING *ikey;
+    const ASN1_BIT_STRING *ikey;
 
     if (!dgst)
         dgst = EVP_sha1();

--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -204,7 +204,7 @@ int X509_ocspid_print(BIO *bp, const X509 *x)
     int derlen;
     int i;
     unsigned char SHA1md[SHA_DIGEST_LENGTH];
-    ASN1_BIT_STRING *keybstr;
+    const ASN1_BIT_STRING *keybstr;
     const X509_NAME *subj;
     EVP_MD *md = NULL;
 

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -488,7 +488,7 @@ int i2d_ECPrivateKey_bio(BIO *bp, const EC_KEY *eckey)
 int X509_pubkey_digest(const X509 *data, const EVP_MD *type,
     unsigned char *md, unsigned int *len)
 {
-    ASN1_BIT_STRING *key = X509_get0_pubkey_bitstr(data);
+    const ASN1_BIT_STRING *key = X509_get0_pubkey_bitstr(data);
 
     if (key == NULL)
         return 0;

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -1028,7 +1028,7 @@ int X509_PUBKEY_get0_param(ASN1_OBJECT **ppkalg,
     return 1;
 }
 
-ASN1_BIT_STRING *X509_get0_pubkey_bitstr(const X509 *x)
+const ASN1_BIT_STRING *X509_get0_pubkey_bitstr(const X509 *x)
 {
     if (x == NULL)
         return NULL;

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -690,7 +690,7 @@ void X509_get0_uids(const X509 *x, const ASN1_BIT_STRING **piuid,
     const ASN1_BIT_STRING **psuid);
 const X509_ALGOR *X509_get0_tbs_sigalg(const X509 *x);
 
-ASN1_BIT_STRING *X509_get0_pubkey_bitstr(const X509 *x);
+const ASN1_BIT_STRING *X509_get0_pubkey_bitstr(const X509 *x);
 
 #define X509_REQ_VERSION_1 0
 

--- a/test/localetest.c
+++ b/test/localetest.c
@@ -95,7 +95,7 @@ int setup_tests(void)
     char str1[] = "SubjectPublicKeyInfo", str2[] = "subjectpublickeyinfo";
     int res;
     X509 *cert = NULL;
-    X509_PUBKEY *cert_pubkey = NULL;
+    const X509_PUBKEY *cert_pubkey = NULL;
     const unsigned char *p = der_bytes;
 
     if (setlocale(LC_ALL, "") == NULL)


### PR DESCRIPTION
Part of #28761 and #29117
Fixes: [1772
](https://github.com/openssl/project/issues/1772)
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
