### PR TITLE
Correct high/low part of product in ARMv8 bn_sqr8x_mont comment

### DIFF
--- a/crypto/bn/asm/armv8-mont.pl
+++ b/crypto/bn/asm/armv8-mont.pl
@@ -780,7 +780,7 @@ __bn_sqr8x_mont:
 	umulh	$t2,$a4,$a0
 	stp	$acc0,$acc1,[$tp],#8*2	// t[0..1]
 	adc	$acc0,xzr,xzr		// t[8]
-	adds	$acc2,$acc2,$t3		// t[2]+lo(a[1]*a[0])
+	adds	$acc2,$acc2,$t3		// t[2]+hi(a[1]*a[0])
 	umulh	$t3,$a5,$a0
 	adcs	$acc3,$acc3,$t0
 	umulh	$t0,$a6,$a0


### PR DESCRIPTION
In the bn_sqr8x_mont function, a comment describing the accumulation step for the partial product a[1]*a[0] incorrectly referenced the low part ('lo') of the product. The value being added to the temporary register t[2] is actually the high part ('hi') of that multiplication. Correct the comment from "t[2]+lo(a[1]*a[0])" to "t[2]+hi(a[1]*a[0])".
