### PR TITLE
Modify the IV update method to further improve the performance of SM4-CBC encryption on the RISC-V architecture

### DIFF
--- a/crypto/perlasm/riscv.pm
+++ b/crypto/perlasm/riscv.pm
@@ -470,11 +470,11 @@ sub vadd_vv {
 
 sub vrgather_vv {
     # vrgather.vv vd, vs2, vs1, vm
-    my $template = 0b001100_0_00000_00000_000_00000_1010111;  
-    my $vd = read_vreg shift;    
-    my $vs2 = read_vreg shift;  
-    my $vs1 = read_vreg shift;   
-    my $vm = read_mask_vreg shift;  
+    my $template = 0b001100_0_00000_00000_000_00000_1010111;
+    my $vd = read_vreg shift;
+    my $vs2 = read_vreg shift;
+    my $vs1 = read_vreg shift;
+    my $vm = read_mask_vreg shift;
     return ".word ".($template | ($vm << 25) | ($vs2 << 20) | ($vs1 << 15) | ($vd << 7));
 }
 

--- a/crypto/sm4/asm/sm4-riscv64-zvksed.pl
+++ b/crypto/sm4/asm/sm4-riscv64-zvksed.pl
@@ -240,7 +240,7 @@ my ($vindex)=("v0");
 
 $code .= <<___;
 .section .rodata
-.align 4           
+.align 4
 .Lreverse_index:
     .word 3, 2, 1, 0
 .text
@@ -263,7 +263,7 @@ rv64i_zvksed_sm4_cbc_encrypt:
 
     # Load the reverse index (for IV updates)
     la $tmp, .Lreverse_index
-    @{[vle32_v $vindex, $tmp]}    
+    @{[vle32_v $vindex, $tmp]}
 # =====================================================
 # If data length ≥ 64 bytes, process 4 blocks in batch:
 # 4-block CBC encryption pipeline:
@@ -304,7 +304,7 @@ rv64i_zvksed_sm4_cbc_encrypt:
     @{[enc_blk $vdata1]}
     @{[vrev8_v $vdata1, $vdata1]}
 
-    #Update IV to ciphertext block 1    
+    #Update IV to ciphertext block 1
     @{[vrgather_vv $vivec, $vdata1, $vindex]}
 
     @{[vxor_vv $vdata2, $vdata2, $vivec]}
@@ -325,16 +325,16 @@ rv64i_zvksed_sm4_cbc_encrypt:
     #Update IV to ciphertext block 3
     @{[vrgather_vv $vivec, $vdata3, $vindex]}
 
-    # Save the ciphertext (in reverse element order)   
+    # Save the ciphertext (in reverse element order)
     li $tmp_stride, $STRIDE
     @{[reverse_order_S $vdata0, $out]}
-    addi $out, $out, $BLOCK_SIZE 
+    addi $out, $out, $BLOCK_SIZE
     @{[reverse_order_S $vdata1, $out]}
-    addi $out, $out, $BLOCK_SIZE 
-    @{[reverse_order_S $vdata2, $out]} 
-    addi $out, $out, $BLOCK_SIZE 
+    addi $out, $out, $BLOCK_SIZE
+    @{[reverse_order_S $vdata2, $out]}
+    addi $out, $out, $BLOCK_SIZE
     @{[reverse_order_S $vdata3, $out]}
-    addi $out, $out, $BLOCK_SIZE  
+    addi $out, $out, $BLOCK_SIZE
 
     addi $len, $len, -$FOUR_BLOCKS
     bnez $len, .Lcbc_enc_loop
@@ -344,27 +344,27 @@ rv64i_zvksed_sm4_cbc_encrypt:
 
 .Lcbc_enc_single:
     # Load input data0
-    @{[vle32_v $vdata0, $in]}  
+    @{[vle32_v $vdata0, $in]}
     addi $in, $in, $BLOCK_SIZE
-    #XOR with IV                                                      
-    @{[vxor_vv $vdata0, $vdata0, $vivec]}  
-    
-    @{[vrev8_v $vdata0, $vdata0]}     
-    # Encrypt with all keys    
-    @{[enc_blk $vdata0]}
-    @{[vrev8_v $vdata0, $vdata0]} 
+    #XOR with IV
+    @{[vxor_vv $vdata0, $vdata0, $vivec]}
 
-    # Update IV to ciphertext block 0   
+    @{[vrev8_v $vdata0, $vdata0]}
+    # Encrypt with all keys
+    @{[enc_blk $vdata0]}
+    @{[vrev8_v $vdata0, $vdata0]}
+
+    # Update IV to ciphertext block 0
     @{[vrgather_vv $vivec, $vdata0, $vindex]}
-    
+
     # Save the ciphertext (in reverse element order)
     li $tmp_stride, $STRIDE
-    @{[reverse_order_S $vdata0, $out]} 
+    @{[reverse_order_S $vdata0, $out]}
     addi $out, $out, $BLOCK_SIZE
     addi $len, $len, -$BLOCK_SIZE
 
     li $tmp, $BLOCK_SIZE
-    bgeu $len, $tmp, .Lcbc_enc_single  
+    bgeu $len, $tmp, .Lcbc_enc_single
     # Save the final IV
     @{[vse32_v $vivec, $ivp]}
 .Lcbc_enc_end:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
Further optimizations to the encryption function in pr #29137 

The original method of updating the IV involved loading ciphertext from memory, which impacted encryption performance. It has now been modified to implement IV updates using indexing and the vrgather.vv instruction, resulting in some improvement in encryption performance.

The average result was taken from three test runs performed on a RISC-V virtual machine featuring the Zvksed extensions.

**Performance Improvement**

| Encrypt Test | 	Baseline 	 | Optimized	 | Improvement ratio |
| ------------ | --------------- | ------------- | ----------------- |
| 64 bytes     | 29065.79k       | 30943.27k     | 6%                |
| 256 bytes    | 35295.70k       | 38984.79k     | 10%               |
| 1024 bytes   | 37176.58k       | 41333.38k     | 11%               |
| 8192 bytes   | 37956.19k       | 41026.91k     | 8%                |
| 16384 bytes  | 38098.26k       | 42245.69k     | 11%               |

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
