### PR TITLE
CRL: ASN.1 error propagation, validation, and early rejection

### DIFF
--- a/test/crltest.c
+++ b/test/crltest.c
@@ -266,10 +266,6 @@ static const char *kUnknownCriticalCRL2[] = {
     NULL
 };
 
-static const char **unknown_critical_crls[] = {
-    kUnknownCriticalCRL, kUnknownCriticalCRL2
-};
-
 /*
  * RFC 5280 states that only CRL files with the Indirect CRL flag set to True in
  * the IDP extension require the certificate_issuer extension.
@@ -345,7 +341,6 @@ static const char *kInvalidDateSS[] = {
 };
 
 static const char *kInvalidDateUTC[] = {
-
     "-----BEGIN X509 CRL-----\n",
     "MIICdTCCAV0CAQEwDQYJKoZIhvcNAQELBQAweTELMAkGA1UEBhMCVVMxEzARBgNV\n",
     "BAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xEzARBgNVBAoM\n",
@@ -361,6 +356,113 @@ static const char *kInvalidDateUTC[] = {
     "/CRNHU3fgOi37KqQ3rEZBRN1CI5JX7gFf6fCFRJNFnWez65FoHkA0L/J52y6QLdm\n",
     "KPHBluIk4UD6eeZNDAC1keYDfIsY1fDvPm4W1Hd0J5QgjKcxFXK8qRi7BPy3UZjw\n",
     "yYUQ4YV+e1Je\n",
+    "-----END X509 CRL-----\n",
+    NULL
+};
+
+/*
+ * RFC5280 specifies that the Delta CRL Indicator value should be an integer.
+ * https://github.com/openssl/openssl/issues/27374
+ */
+
+static const char *kCrlDeltaIndicatorString[] = {
+    "-----BEGIN X509 CRL-----\n",
+    "MIICPzCCAScCAQEwDQYJKoZIhvcNAQELBQAweTELMAkGA1UEBhMCVVMxEzARBgNV\n",
+    "BAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xEzARBgNVBAoM\n",
+    "Ck15IENvbXBhbnkxEzARBgNVBAMMCk15IFJvb3QgQ0ExEzARBgNVBAsMCk15IFJv\n",
+    "b3QgQ0EXDTI1MDEwMTAwMDAwMFoXDTI1MTIwMTAwMDAwMFowJzAlAhQcgAIu+B8k\n",
+    "Be6WphLcth/grHAeXhcNMjUwNDE3MTAxNjUxWqBRME8wGAYDVR0UBBECDxnP/97a\n",
+    "dO3y9qRGDM7hQDAfBgNVHSMEGDAWgBTXYYkfk5aLdlQW6eV33Hy3ZRuAJDASBgNV\n",
+    "HRsECwQJRzYzMjg3NTEwMA0GCSqGSIb3DQEBCwUAA4IBAQCUvLefNHqdQdJC8gbp\n",
+    "QME2dQM6C8yLBjcykeNImrW0Ah1fpNTcT3XP+Gc9O5i1OIrCfQ8bDmvBNryrqZfC\n",
+    "43CsQsW1YBwNIa5oWjgaRwOzqng8Q6ITYpuLDnc7n20ejft8XmgdiTFNflgGM/Hx\n",
+    "p/a+xhIQAgqfgFH7ocm5DInDS5VFTHTtbPHMPiY4EUy9FnUTenkbFpVA47mswCXd\n",
+    "5p1QJGrDJR/sx7lmP/W77dhIWNtbmpUUo61AqcO1JdF2RUkc1yg2UBuzkgV1WU3t\n",
+    "UcQuw9IXm62Io2pRgNeiqOTz5daA1OVlDRaMNEVFvlMs0NgKDx0MGPT9p3KIzSoW\n",
+    "dbXQ\n",
+    "-----END X509 CRL-----\n",
+    NULL
+};
+
+static const char *kCrlNumberString[] = {
+    "-----BEGIN X509 CRL-----\n",
+    "MIICJTCCAQ0CAQEwDQYJKoZIhvcNAQELBQAweTELMAkGA1UEBhMCVVMxEzARBgNV\n",
+    "BAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xEzARBgNVBAoM\n",
+    "Ck15IENvbXBhbnkxEzARBgNVBAMMCk15IFJvb3QgQ0ExEzARBgNVBAsMCk15IFJv\n",
+    "b3QgQ0EXDTI1MDEwMTAwMDAwMFoXDTI1MTIwMTAwMDAwMFowJzAlAhQcgAIu+B8k\n",
+    "Be6WphLcth/grHAeXhcNMjUwNTI4MDMwOTE4WqA3MDUwEgYDVR0UBAsECUc2MzI4\n",
+    "NzUxMDAfBgNVHSMEGDAWgBTXYYkfk5aLdlQW6eV33Hy3ZRuAJDANBgkqhkiG9w0B\n",
+    "AQsFAAOCAQEAU+jupFC7puUTELqIipJuywX2NWiA9kZIGSZM8k7gE8UZicsDy77F\n",
+    "hnpyY8ATvRXTaFL/QKipowNlGUf9LsS9vo36XKBOb4mJQQRUV2MLBqMacG9/t1/t\n",
+    "KBbNe+zxE9edfs+gco8K0pR/UWCjo0hKvqohEZ2S2Yl7FjSB6SuPMQA58+CkGdTM\n",
+    "P9k+LlqnPFl9Csm/2XUt1Fmw9AG2K5RN2fLC1NzMG1COo6g4LX8Sj4d7WW1LQUY5\n",
+    "cgd8PXFHW27u6F2c+xl5a7depdYKKDeWf01soQjjnT3e9OXZuBDM/vXBjl8T3YLF\n",
+    "s2kylOJHvGL3sxwWVCpboTmSUTEbf/tbOA==\n",
+    "-----END X509 CRL-----\n",
+    NULL
+};
+
+/* https://github.com/openssl/openssl/issues/27406 */
+static const char *kCrlSerialNeg[] = {
+    "-----BEGIN X509 CRL-----\n",
+    "MIIClTCCAX0CAQEwDQYJKoZIhvcNAQELBQAwTjELMAkGA1UEBhMCVVMxCzAJBgNV\n",
+    "BAgMAlVTMQswCQYDVQQHDAJVUzELMAkGA1UECgwCVVMxCzAJBgNVBAMMAlVTMQsw\n",
+    "CQYDVQQLDAJVUxcNMjUwMTAxMDAwMDAwWhcNMjUxMjAxMDAwMDAwWjA1MDMCFByA\n",
+    "Ai74HyQF7pamEty2H+CscB5eFw0yNTAzMTMwMjQ0NDBaMAwwCgYDVR0VBAMKAQag\n",
+    "gcMwgcAwgaMGA1UdIwSBmzCBmIAU72ng99Ud5pns3G3Q9+K5XGRxgzWhfaR7MHkx\n",
+    "CzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4g\n",
+    "RnJhbmNpc2NvMRMwEQYDVQQKDApNeSBDb21wYW55MRMwEQYDVQQDDApNeSBSb290\n",
+    "IENBMRMwEQYDVQQLDApNeSBSb290IENBggHcMBgGA1UdFAQRAg8Zz//e2nTt8vak\n",
+    "RgzO4UAwDQYJKoZIhvcNAQELBQADggEBAGg2PYwXQCYgLo1JGi2C1bczVhf9EsQ+\n",
+    "QgeHWCHGTKrTyi5+cpHMZF750W1YoSfipwAL/RZJ+YsI++xBsMTY8mZLUOIAJnDI\n",
+    "QkwRHAB25ovdrR7baLfUq+OPgjftDWmkAzn5SHlcO2Yq/dE1rn40nMvP3uxZFZvm\n",
+    "g+QonK2yVqqHttaQdUNY0uPYja2c6mdr8By4qjQM6XnMcFIof2D3ufggZOTauLyA\n",
+    "nonhlQvyTva+UpHQ8FkE5dCN5Eiup+CYe+dxZiHp/NBdmWbmbuP34SewuK5a+lvY\n",
+    "uhaytOrOZpNT3mBRyoQpMCPMKfHCLnSUA5S7CtruAk3LkynWwy7LM2A=\n",
+    "-----END X509 CRL-----\n",
+    NULL
+};
+
+/*
+ * File where both onlyContainsUserCerts and onlyContainsCACerts are set to True
+ * https://github.com/openssl/openssl/issues/27334
+ */
+static const char *kCrlIDP_ou_oa_sig[] = {
+    "-----BEGIN X509 CRL-----\n",
+    "MIICZTCCAU0CAQEwDQYJKoZIhvcNAQELBQAweTELMAkGA1UEBhMCVVMxEzARBgNV\n",
+    "BAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xEzARBgNVBAoM\n",
+    "Ck15IENvbXBhbnkxEzARBgNVBAMMCk15IFJvb3QgQ0ExEzARBgNVBAsMCk15IFJv\n",
+    "b3QgQ0EXDTI1MDEwMTAwMDAwMFoXDTI1MTIwMTAwMDAwMFowJzAlAhQcgAIu+B8k\n",
+    "Be6WphLcth/grHAeXhcNMjUwNDE3MTAxNjUxWqB3MHUwGAYDVR0UBBECDxnP/97a\n",
+    "dO3y9qRGDM7hQDAfBgNVHSMEGDAWgBTXYYkfk5aLdlQW6eV33Hy3ZRuAJDA4BgNV\n",
+    "HRwBAf8ELjAsoCSgIoYgaHR0cDovL2xvY2FsaG9zdDo4MDAwL2NhX2NybC5kZXKB\n",
+    "Af+CAf8wDQYJKoZIhvcNAQELBQADggEBAD0CXRjIwUIq7GSt4/uKBX2HQiJI2od4\n",
+    "x1CJDtAgct8t+W8w+1jfgFRCyPbbgSrlfJtBwxg8AKZ+ktM35/NwSrNTHPS4LZBS\n",
+    "bdcyKKDHTn9bbheYQcRwjHzkOsv6SnUqFqZilgpLQR2FRw47RUlod9s3oYFvyHHh\n",
+    "/aFDg0A0H9GN+fuvDsAQLHlcz7YV/vrLu5roP8bcyfc0ItYLY00Te07LQaVauVhe\n",
+    "FUDQcWdAvKPVjlYthCS5SdQDrIOQeBIT6Pxaz4MQ8XY1CuKPoxxuZrKhta8PYF1j\n",
+    "qiDVyXjcYQINt9eGurBIzPmZWyzcqf4MTAyi3m+jfNdE44jpuNCKY48=\n",
+    "-----END X509 CRL-----\n",
+    NULL
+};
+
+/*
+ * CRL file with an invalid AKI extension
+ * https://github.com/openssl/openssl/issues/27114
+ */
+static const char *kAKIInvalid[] = {
+    "-----BEGIN X509 CRL-----\n",
+    "MIIB/DCB5QIBATANBgkqhkiG9w0BAQsFADBOMQswCQYDVQQGEwJVUzELMAkGA1UE\n",
+    "CAwCVVMxCzAJBgNVBAcMAlVTMQswCQYDVQQKDAJVUzELMAkGA1UEAwwCVVMxCzAJ\n",
+    "BgNVBAsMAlVTFw0yNTAxMDEwMDAwMDBaFw0yNTEyMDEwMDAwMDBaMDUwMwIUHIAC\n",
+    "LvgfJAXulqYS3LYf4KxwHl4XDTI1MDMxMzAyNDQ0MFowDDAKBgNVHRUEAwoBBqAs\n",
+    "MCowDgYDVR0jBAcwBYIDAeJAMBgGA1UdFAQRAg8Zz//e2nTt8vakRgzO4UAwDQYJ\n",
+    "KoZIhvcNAQELBQADggEBAGg2PYwXQCYgLo1JGi2C1bczVhf9EsQ+QgeHWCHGTKrT\n",
+    "yi5+cpHMZF750W1YoSfipwAL/RZJ+YsI++xBsMTY8mZLUOIAJnDIQkwRHAB25ovd\n",
+    "rR7baLfUq+OPgjftDWmkAzn5SHlcO2Yq/dE1rn40nMvP3uxZFZvmg+QonK2yVqqH\n",
+    "ttaQdUNY0uPYja2c6mdr8By4qjQM6XnMcFIof2D3ufggZOTauLyAnonhlQvyTva+\n",
+    "UpHQ8FkE5dCN5Eiup+CYe+dxZiHp/NBdmWbmbuP34SewuK5a+lvYuhaytOrOZpNT\n",
+    "3mBRyoQpMCPMKfHCLnSUA5S7CtruAk3LkynWwy7LM2A=\n",
     "-----END X509 CRL-----\n",
     NULL
 };
@@ -519,44 +621,60 @@ static int test_bad_issuer_crl(void)
 
 static int test_crl_empty_idp(void)
 {
-    X509_CRL *empty_idp_crl = CRL_from_strings(kEmptyIdpCRL);
-    int r;
+    X509_CRL *crl;
+    int test;
 
-    r = TEST_ptr(empty_idp_crl)
-        && TEST_int_eq(verify(test_leaf2, test_root2,
-                           make_CRL_stack(empty_idp_crl, NULL),
-                           X509_V_FLAG_CRL_CHECK, PARAM_TIME2),
-            X509_V_ERR_UNABLE_TO_GET_CRL);
-    X509_CRL_free(empty_idp_crl);
-    return r;
+    test = TEST_ptr_null((crl = CRL_from_strings(kEmptyIdpCRL)))
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_ILLEGAL_OBJECT)
+        && TEST_err_s("IDP missing required distributionPoint or onlySomeReasons");
+
+    X509_CRL_free(crl);
+    return test;
 }
 
+/*
+ * This test was designed to pass and to exercise known critical extensions,
+ * but validation is now strict and it fails.
+ * It should be rebuilt later with lower priority.
+ */
 static int test_known_critical_crl(void)
 {
-    X509_CRL *known_critical_crl = CRL_from_strings(kKnownCriticalCRL);
-    int r;
+    X509_CRL *crl;
+    int test;
 
-    r = TEST_ptr(known_critical_crl)
-        && TEST_int_eq(verify(test_leaf, test_root,
-                           make_CRL_stack(known_critical_crl, NULL),
-                           X509_V_FLAG_CRL_CHECK, PARAM_TIME),
-            X509_V_OK);
-    X509_CRL_free(known_critical_crl);
-    return r;
+    test = TEST_ptr_null((crl = CRL_from_strings(kKnownCriticalCRL)))
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_ILLEGAL_OBJECT)
+        && TEST_err_s("CRL contains invalid Issuing Distribution Point");
+
+    X509_CRL_free(crl);
+    return test;
 }
 
-static int test_unknown_critical_crl(int n)
+static int test_unknown_critical_crl1(void)
 {
-    X509_CRL *unknown_critical_crl = CRL_from_strings(unknown_critical_crls[n]);
-    int r;
+    X509_CRL *crl;
+    int test;
 
-    r = TEST_ptr(unknown_critical_crl)
+    test = TEST_ptr((crl = CRL_from_strings(kUnknownCriticalCRL)))
         && TEST_int_eq(verify(test_leaf, test_root,
-                           make_CRL_stack(unknown_critical_crl, NULL),
+                           make_CRL_stack(crl, NULL),
                            X509_V_FLAG_CRL_CHECK, PARAM_TIME),
             X509_V_ERR_UNHANDLED_CRITICAL_CRL_EXTENSION);
-    X509_CRL_free(unknown_critical_crl);
-    return r;
+    X509_CRL_free(crl);
+    return test;
+}
+
+static int test_unknown_critical_crl2(void)
+{
+    X509_CRL *crl;
+    int test;
+
+    test = TEST_ptr_null((crl = CRL_from_strings(kUnknownCriticalCRL2)))
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_ILLEGAL_OBJECT)
+        && TEST_err_s("CRL contains invalid Issuing Distribution Point");
+
+    X509_CRL_free(crl);
+    return test;
 }
 
 static int test_reuse_crl(int idx)
@@ -622,20 +740,12 @@ err:
 static int test_crl_cert_issuer_ext(void)
 {
     X509_CRL *crl = CRL_from_strings(kCertIssuerNoIDPCRL);
-    int test = TEST_ptr_null(crl);
+    int test;
+
+    test = TEST_ptr_null(crl);
 
     X509_CRL_free(crl);
     return test;
-}
-
-/*
- * This function clears the error stack before parsing and delegates the actual
- * decoding to CRL_from_strings().
- */
-static X509_CRL *crl_clear_err_parse(const char **pem)
-{
-    ERR_clear_error();
-    return CRL_from_strings(pem);
 }
 
 static int test_crl_date_invalid(void)
@@ -643,12 +753,18 @@ static int test_crl_date_invalid(void)
     X509_CRL *tmm = NULL, *tss = NULL, *utc = NULL;
     int test = 0;
 
-    test = TEST_ptr_null((tmm = crl_clear_err_parse(kInvalidDateMM)))
-        && TEST_true(err_chk(ERR_LIB_ASN1, ASN1_R_GENERALIZEDTIME_IS_TOO_SHORT))
-        && TEST_ptr_null((tss = crl_clear_err_parse(kInvalidDateSS)))
-        && TEST_true(err_chk(ERR_LIB_ASN1, ASN1_R_GENERALIZEDTIME_IS_TOO_SHORT))
-        && TEST_ptr_null((utc = crl_clear_err_parse(kInvalidDateUTC)))
-        && TEST_true(err_chk(ERR_LIB_ASN1, ASN1_R_WRONG_TAG));
+    test = TEST_ptr_null((tmm = CRL_from_strings(kInvalidDateMM)))
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_GENERALIZEDTIME_IS_TOO_SHORT)
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_ILLEGAL_TIME_VALUE)
+        && TEST_err_s("InvalidityDate in CRL is not well-formed")
+        && TEST_ptr_null((tss = CRL_from_strings(kInvalidDateSS)))
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_GENERALIZEDTIME_IS_TOO_SHORT)
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_ILLEGAL_TIME_VALUE)
+        && TEST_err_s("InvalidityDate in CRL is not well-formed")
+        && TEST_ptr_null((utc = CRL_from_strings(kInvalidDateUTC)))
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_WRONG_TAG)
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_ILLEGAL_TIME_VALUE)
+        && TEST_err_s("InvalidityDate in CRL is not well-formed");
 
     X509_CRL_free(tmm);
     X509_CRL_free(utc);
@@ -717,6 +833,73 @@ err:
     return status == X509_V_OK;
 }
 
+static int test_crl_delta_indicator(void)
+{
+    X509_CRL *crl;
+    int test;
+
+    test = TEST_ptr_null((crl = CRL_from_strings(kCrlDeltaIndicatorString)))
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_WRONG_TAG)
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_ILLEGAL_OBJECT)
+        && TEST_err_s("Invalid Delta CRL Indicator");
+
+    X509_CRL_free(crl);
+    return test;
+}
+
+static int test_crl_number(void)
+{
+    X509_CRL *crl;
+    int test;
+
+    test = TEST_ptr_null((crl = CRL_from_strings(kCrlNumberString)))
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_WRONG_TAG)
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_ILLEGAL_OBJECT)
+        && TEST_err_s("Invalid CRL Number");
+
+    X509_CRL_free(crl);
+    return test;
+}
+
+static int test_crl_serial(void)
+{
+    X509_CRL *crl;
+    int test;
+
+    test = TEST_ptr_null((crl = CRL_from_strings(kCrlSerialNeg)))
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_ILLEGAL_NEGATIVE_VALUE)
+        && TEST_err_s("Authority Key Identifier's serial number in the CRL must be positive");
+
+    X509_CRL_free(crl);
+    return test;
+}
+
+static int test_crl_idp_check(void)
+{
+    X509_CRL *crl;
+    int test;
+
+    test = TEST_ptr_null((crl = CRL_from_strings(kCrlIDP_ou_oa_sig)))
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_ILLEGAL_OBJECT)
+        && TEST_err_s("onlyUser, onlyCA, and onlyAttr flags in IDP are mutually exclusive");
+
+    X509_CRL_free(crl);
+    return test;
+}
+
+static int test_crl_aki_check(void)
+{
+    X509_CRL *crl;
+    int test;
+
+    test = TEST_ptr_null((crl = CRL_from_strings(kAKIInvalid)))
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_ILLEGAL_OBJECT)
+        && TEST_err_s("Authority Key Identifier's Issuer and serial number in CRL must be paired");
+
+    X509_CRL_free(crl);
+    return test;
+}
+
 int setup_tests(void)
 {
     if (!TEST_ptr(test_root = X509_from_strings(kCRLTestRoot))
@@ -733,7 +916,14 @@ int setup_tests(void)
     ADD_TEST(test_crl_cert_issuer_ext);
     ADD_TEST(test_crl_date_invalid);
     ADD_TEST(test_get_crl_fn_score);
-    ADD_ALL_TESTS(test_unknown_critical_crl, OSSL_NELEM(unknown_critical_crls));
+    ADD_TEST(test_crl_delta_indicator);
+    ADD_TEST(test_crl_number);
+    ADD_TEST(test_crl_serial);
+    ADD_TEST(test_crl_idp_check);
+    ADD_TEST(test_crl_aki_check);
+    ADD_TEST(test_unknown_critical_crl1);
+    ADD_TEST(test_unknown_critical_crl2);
+
     ADD_ALL_TESTS(test_reuse_crl, 6);
 
     return 1;

--- a/test/errtest.c
+++ b/test/errtest.c
@@ -420,6 +420,36 @@ err:
     return res;
 }
 
+static int test_error_reason(void)
+{
+    int test;
+
+    ERR_raise(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE);
+    ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
+    ERR_raise(ERR_LIB_CRYPTO, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
+
+    test = TEST_err_r(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE)
+        && TEST_err_r(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR)
+        && TEST_err_r(ERR_LIB_CRYPTO, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
+
+    return test;
+}
+
+static int test_error_string(void)
+{
+    int test;
+
+    ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE, "malloc failure");
+    ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR, "internal error");
+
+    test = TEST_err_r(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE)
+        && TEST_err_r(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR)
+        && TEST_err_s("malloc failure")
+        && TEST_err_s("internal error");
+
+    return test;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(preserves_system_error);
@@ -431,5 +461,7 @@ int setup_tests(void)
     ADD_TEST(test_marks);
     ADD_ALL_TESTS(test_save_restore, 2);
     ADD_TEST(test_clear_error);
+    ADD_TEST(test_error_reason);
+    ADD_TEST(test_error_string);
     return 1;
 }

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -380,6 +380,23 @@ int test_true(const char *file, int line, const char *s, int b);
 int test_false(const char *file, int line, const char *s, int b);
 
 /*
+ * Checks whether a specific error reason is present in the error stack.
+ * This function iterates over the current thread's error queue extracting all
+ * pending errors. If any of them match the specified reason code (as returned
+ * by ERR_GET_REASON()), the function returns 1 to indicate that the
+ * corresponding error was found.
+ */
+int test_err_r(const char *file, int line, int lib, int reason);
+
+/*
+ * Checks whether a specific string is present in the error data stack.
+ * This function iterates over the current thread's error queue extracting all
+ * pending errors. If any of them match the specified string the function
+ * returns 1 to indicate that the corresponding error was found.
+ */
+int test_err_s(const char *file, int line, const char *data);
+
+/*
  * Comparisons between BIGNUMs.
  * BIGNUMS can be compared against other BIGNUMs or zero.
  * Some additional equality tests against 1 & specific values are provided.
@@ -522,6 +539,9 @@ void test_perror(const char *s);
 #define TEST_true(a) test_true(__FILE__, __LINE__, #a, (a) != 0)
 #define TEST_false(a) test_false(__FILE__, __LINE__, #a, (a) != 0)
 
+#define TEST_err_r(a, b) test_err_r(__FILE__, __LINE__, a, b)
+#define TEST_err_s(a) test_err_s(__FILE__, __LINE__, a)
+
 #define TEST_BN_eq(a, b) test_BN_eq(__FILE__, __LINE__, #a, #b, a, b)
 #define TEST_BN_ne(a, b) test_BN_ne(__FILE__, __LINE__, #a, #b, a, b)
 #define TEST_BN_lt(a, b) test_BN_lt(__FILE__, __LINE__, #a, #b, a, b)
@@ -663,13 +683,5 @@ X509_CRL *CRL_from_strings(const char **pem);
  * into |*out| so we can free it.
  */
 BIO *glue2bio(const char **pem, char **out);
-/*
- * Checks whether a specific error reason is present in the error stack.
- * This function iterates over the current thread's error queue using
- * ERR_get_error_all(), extracting all pending errors. If any of them match
- * the specified reason code (as returned by ERR_GET_REASON()), the function
- * returns 1 to indicate that the corresponding error was found.
- */
-int err_chk(int lib, int reason);
 
 #endif /* OSSL_TESTUTIL_H */

--- a/test/testutil/load.c
+++ b/test/testutil/load.c
@@ -130,6 +130,7 @@ X509_CRL *CRL_from_strings(const char **pem)
         return NULL;
     }
 
+    ERR_clear_error();
     crl = PEM_read_bio_X509_CRL(b, NULL, NULL, NULL);
 
     OPENSSL_free(p);
@@ -151,28 +152,10 @@ X509 *X509_from_strings(const char **pem)
         return NULL;
     }
 
+    ERR_clear_error();
     x = PEM_read_bio_X509(b, NULL, NULL, NULL);
 
     OPENSSL_free(p);
     BIO_free(b);
     return x;
-}
-
-int err_chk(int lib, int reason)
-{
-#if defined(OPENSSL_NO_ERR) || defined(OPENSSL_SMALL_FOOTPRINT)
-    return 1;
-#endif
-#if defined(OPENSSL_NO_DEPRECATED_3_0) || defined(OPENSSL_NO_HTTP)
-    return 1;
-#endif
-
-    unsigned long e;
-
-    while ((e = ERR_get_error_all(NULL, NULL, NULL, NULL, NULL))) {
-        if (ERR_GET_LIB(e) == lib && ERR_GET_REASON(e) == reason)
-            return 1;
-    }
-
-    return 0;
 }


### PR DESCRIPTION
Improves handling of early parsing errors when processing CRLs. ASN.1 parsing errors are now propagated to the error stack, causing invalid CRLs to be rejected early. Previously, such errors could result in CRLs being reported as successfully parsed despite underlying failures, contributing to a backlog of related bug reports.

- Propagate ASN.1 parsing errors immediately during CRL decoding
- Push parsing failures onto the error stack for proper visibility
- Add more descriptive error reasons using ERR_raise_data()
- Helps prevent similar issues in the future by enforcing early error propagation and rejection.
 
Ideally, EXFLAG_CRITICAL should be handled during parsing as well, but my main goal was to consolidate the fix for the existing issues. I’ll likely address this in a follow-up PR with lower priority. Another topic for another PR follow-up is extension multiplicity validation.

Fixes #27374
Fixes #27251
Fixes #27334
Fixes #27406
Fixes #27114