### PR TITLE
fix: BIO_ADDR_hostname_string() returns a heap-allocated string that …

### DIFF
--- a/crypto/bio/bss_acpt.c
+++ b/crypto/bio/bss_acpt.c
@@ -266,6 +266,9 @@ static int acpt_state(BIO *b, BIO_ACCEPT *c)
                 }
             }
 
+            /* Free old values before assigning new ones to prevent memory leak */
+            OPENSSL_free(c->cache_accepting_name);
+            OPENSSL_free(c->cache_accepting_serv);
             c->cache_accepting_name = BIO_ADDR_hostname_string(&c->cache_accepting_addr, 1);
             c->cache_accepting_serv = BIO_ADDR_service_string(&c->cache_accepting_addr, 1);
             c->state = ACPT_S_ACCEPT;


### PR DESCRIPTION
…must be freed with OPENSSL_free() in function conn_ctrl

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
