### PR TITLE
Fix Null dereference

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1102,6 +1102,8 @@ static int check_trust(X509_STORE_CTX *ctx, int num_untrusted)
      */
     for (i = num_untrusted; i < num; i++) {
         x = sk_X509_value(ctx->chain, i);
+        if (x == NULL)
+            return -1;
         trust = X509_check_trust(x, ctx->param->trust, 0);
         /* If explicitly trusted (so not neutral nor rejected) return trusted */
         if (trust == X509_TRUST_TRUSTED)


### PR DESCRIPTION
Returning NULL from sk_X509_value is possible if num_trusted is less than 0 or if one of the ctx->chain->data[i] values is NULL.

Found by Linux Verification Center (linuxtesting.org) with SVACE.

Refer: https://github.com/openssl/openssl/pull/23273