### PR TITLE
Remove unnecessary argc assign

### DIFF
--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -196,7 +196,6 @@ int passwd_main(int argc, char **argv)
     }
 
     /* All remaining arguments are the password text */
-    argc = opt_num_rest();
     argv = opt_rest();
     if (*argv != NULL) {
         if (pw_source_defined)

--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -550,7 +550,6 @@ int rehash_main(int argc, char **argv)
     }
 
     /* Optional arguments are directories to scan. */
-    argc = opt_num_rest();
     argv = opt_rest();
 
     evpmd = EVP_sha1();


### PR DESCRIPTION
Found by Linux Verification Center (linuxtesting.org) with SVACE.

CLA:trivial