### PR TITLE
Incorrect alert type for unsupported profiles

### DIFF
--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -1788,7 +1788,7 @@ int tls_parse_stoc_use_srtp(SSL_CONNECTION *s, PACKET *pkt,
     /* Throw an error if the server gave us an unsolicited extension */
     clnt = SSL_get_srtp_profiles(SSL_CONNECTION_GET_SSL(s));
     if (clnt == NULL) {
-        SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_NO_SRTP_PROFILES);
+        SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_NO_SRTP_PROFILES);
         return 0;
     }
 
@@ -1805,7 +1805,7 @@ int tls_parse_stoc_use_srtp(SSL_CONNECTION *s, PACKET *pkt,
         }
     }
 
-    SSLfatal(s, SSL_AD_DECODE_ERROR,
+    SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER,
         SSL_R_BAD_SRTP_PROTECTION_PROFILE_LIST);
     return 0;
 }


### PR DESCRIPTION
Fixes #27464

This addresses issue https://github.com/openssl/openssl/issues/27464 by setting the TLS alert for SRTP failures to illegal_parameter when:
- There is no MKI (this was already done)
- The server responded with an unsolicited use_srtp extension 
- The server responded with an invalid SRTP profile id.

Sanity tested using the following:
```
LD_LIBRARY_PATH="${OPENSSL_DIR}" ./apps/openssl s_server -dtls -cert_chain chain.pem -cert servcert.pem -key servkey.pem -accept 4444 -use_srtp SRTP_AEAD_AES_256_GCM -tlsextdebug
LD_LIBRARY_PATH="${OPENSSL_DIR}" ./apps/openssl s_client -dtls -connect localhost:4444 -use_srtp SRTP_AEAD_AES_256_GCM 
```

Maybe we should add another error message to distinguish extension parsing failures from invalid SRTP profile ids, though.