### PR TITLE
fix: Fix uninstall_dev failing to remove empty dir

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -879,6 +879,7 @@ uninstall_dev: uninstall_runtime_libs
 	done
 	-$(RMDIR) "$(DESTDIR)$(PKGCONFIGDIR)"
 	-$(RMDIR) "$(DESTDIR)$(CMAKECONFIGDIR)"
+	-$(RMDIR) "$(DESTDIR)$(libdir)/cmake"
 	-$(RMDIR) "$(DESTDIR)$(libdir)"
 
 _install_modules_deps: install_runtime_libs build_modules


### PR DESCRIPTION
Fix this error:
```
rmdir "$PREFIX/lib64/cmake/OpenSSL"
rmdir "$PREFIX/lib64"
rmdir: failed to remove '$PREFIX/lib64': Directory not empty
```
Because `rmdir $PREFIX/lib64/cmake` is missing

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist

