### PR TITLE
Add ci test to run against minimal gcc version we support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,31 @@ jobs:
         name: "ci@linux-arm64"
         path: artifacts.tar.gz
 
+  gcc-min-version:
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/gcc:9
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
+    - name: config
+      run: ./config --strict-warnings --banner=Configured enable-fips && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: print gcc version
+      run: |
+        gcc --version
+    - name: get cpu info
+      run: |
+        cat /proc/cpuinfo
+        ./util/opensslwrap.sh version -c
+    - name: make test
+      run: .github/workflows/make-test
+
   linux-x86:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We currently support gcc 9 as a minimum compiler version.  We should run at least one ci job against that minimal version to make sure we don't break anything.

Most notably this will help us catch errors if we attempt to use intrinsics that aren't supported by that compiler.


##### Checklist
- [x] tests are added or updated
