### PR TITLE
Cleanup in cryptlib.h.

### DIFF
--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -500,8 +500,3 @@ void *CRYPTO_get_ex_data(const CRYPTO_EX_DATA *ad, int idx)
         return NULL;
     return sk_void_value(ad->sk, idx);
 }
-
-OSSL_LIB_CTX *ossl_crypto_ex_data_get_ossl_lib_ctx(const CRYPTO_EX_DATA *ad)
-{
-    return ad->ctx;
-}

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -46,7 +46,6 @@ int openssl_get_fork_id(void);
 
 char *ossl_safe_getenv(const char *name);
 
-extern CRYPTO_RWLOCK *memdbg_lock;
 int openssl_strerror_r(int errnum, char *buf, size_t buflen);
 #if !defined(OPENSSL_NO_STDIO)
 FILE *openssl_fopen(const char *filename, const char *mode);
@@ -133,7 +132,6 @@ OSSL_EX_DATA_GLOBAL *ossl_lib_ctx_get_ex_data_global(OSSL_LIB_CTX *ctx);
 
 const char *ossl_lib_ctx_get_descriptor(OSSL_LIB_CTX *libctx);
 
-OSSL_LIB_CTX *ossl_crypto_ex_data_get_ossl_lib_ctx(const CRYPTO_EX_DATA *ad);
 int ossl_crypto_new_ex_data_ex(OSSL_LIB_CTX *ctx, int class_index, void *obj,
     CRYPTO_EX_DATA *ad);
 int ossl_crypto_get_ex_new_index_ex(OSSL_LIB_CTX *ctx, int class_index,


### PR DESCRIPTION
Remove unused ossl_crypto_ex_data_get_ossl_lib_ctx() and memdbg_lock.
