### PR TITLE
fix vpsm4_ex bug in AARCH64 big-endian platform

### DIFF
--- a/crypto/sm4/asm/vpsm4_ex-armv8.pl
+++ b/crypto/sm4/asm/vpsm4_ex-armv8.pl
@@ -559,13 +559,25 @@ _${prefix}_consts:
 .Lshuffles:
 	.quad 0x0B0A090807060504,0x030201000F0E0D0C
 .Lxts_magic:
+#ifndef __AARCH64EB__
 	.quad 0x0101010101010187,0x0101010101010101
+#else
+	.quad 0x0101010101010101,0x0101010101010187
+#endif
 .Lsbox_magic:
+#ifndef __AARCH64EB__
 	.quad 0x0b0e0104070a0d00,0x0306090c0f020508
 	.quad 0x62185a2042387a00,0x22581a6002783a40
 	.quad 0x15df62a89e54e923,0xc10bb67c4a803df7
 	.quad 0xb9aa6b78c1d21300,0x1407c6d56c7fbead
 	.quad 0x6404462679195b3b,0xe383c1a1fe9edcbc
+#else
+	.quad 0x0306090c0f020508,0x0b0e0104070a0d00
+	.quad 0x22581a6002783a40,0x62185a2042387a00
+	.quad 0xc10bb67c4a803df7,0x15df62a89e54e923
+	.quad 0x1407c6d56c7fbead,0xb9aa6b78c1d21300
+	.quad 0xe383c1a1fe9edcbc,0x6404462679195b3b
+#endif
 	.quad 0x0f0f0f0f0f0f0f0f,0x0f0f0f0f0f0f0f0f
 
 .size	_${prefix}_consts,.-_${prefix}_consts


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
Found a vpsm4_ex bug on the AARCH64 big-endian platform.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
