### PR TITLE
threads_pthread: make lock contention log location configurable

### DIFF
--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -28,6 +28,8 @@
 #define _GNU_SOURCE
 #include <execinfo.h>
 #include <unistd.h>
+#include <limits.h>
+#include <stdlib.h>
 #endif
 
 #include <openssl/crypto.h>
@@ -674,12 +676,16 @@ static ossl_inline pid_t get_tid(void)
 static void *init_contention_data(void)
 {
     struct stack_traces *traces;
-    char fname_fmt[] = "lock-contention-log" FIPS_SFX ".%d.txt";
-    char fname[sizeof(fname_fmt) + sizeof(int) * 3];
+    char fname[PATH_MAX];
+    const char *log_dir;
+    const char *dir;
 
     traces = OPENSSL_zalloc(sizeof(struct stack_traces));
 
-    snprintf(fname, sizeof(fname), fname_fmt, get_tid());
+    log_dir = getenv("OPENSSL_LOCK_CONTENTION_DIR");
+    dir = (log_dir != NULL && log_dir[0] != '\0') ? log_dir : ".";
+    snprintf(fname, sizeof(fname), "%s/lock-contention-log" FIPS_SFX ".%d.txt",
+        dir, get_tid());
 
     traces->fd = open(fname, O_WRONLY | O_APPEND | O_CLOEXEC | O_CREAT, 0600);
 

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -77,6 +77,15 @@ than 1, outputs information about every processed feature.
 
 This variable is not considered security-sensitive.
 
+=item B<OPENSSL_LOCK_CONTENTION_DIR>
+
+Specifies the directory where lock contention log files are written
+when OpenSSL is built with the B<enable-report-rwlock-contention> option.
+If not set, log files are written to the current working directory.
+The log files are named C<lock-contention-log.E<lt>pidE<gt>.txt>.
+
+This variable is not considered security-sensitive.
+
 =item B<OPENSSL_MALLOC_FAILURES>, B<OPENSSL_MALLOC_FD>, B<OPENSSL_MALLOC_SEED>
 
 If built with debugging, this allows memory allocation to fail.


### PR DESCRIPTION
## Summary

  Add support for `OPENSSL_LOCK_CONTENTION_DIR` environment variable to configure the directory where lock contention log files are written.

  ## Problem

  The lock contention debugging feature (added in #27884) writes log files to the current working directory with a hardcoded path. This is inflexible for developers who want to organize logs in a specific location. [Comments](https://github.com/openssl/openssl/pull/27884#discussion_r2180755197)

  ## Solution

  Check for `OPENSSL_LOCK_CONTENTION_DIR` environment variable:
  - If set: use it as the directory prefix for log files
  - If not set: use current directory (existing behavior)

  ## Usage

  ```bash
  export OPENSSL_LOCK_CONTENTION_DIR=/tmp/contention-logs
  ./Configure -DREPORT_RWLOCK_CONTENTION && make

  ```
 Fixes #27975
 CLA: trivial