### PR TITLE
test: use runtime FIPS detection instead of compile-time check

### DIFF
--- a/test/ecdsatest.c
+++ b/test/ecdsatest.c
@@ -96,10 +96,8 @@ static int x9_62_tests(int n)
 
     TEST_info("ECDSA KATs for curve %s", OBJ_nid2sn(nid));
 
-#ifdef FIPS_MODULE
-    if (EC_curve_nid2nist(nid) == NULL)
-        return TEST_skip("skip non approved curves");
-#endif /* FIPS_MODULE */
+    if (OSSL_PROVIDER_available(NULL, "fips") && EC_curve_nid2nist(nid) == NULL)
+        return TEST_skip("skip non approved curves in FIPS mode");
 
     if (!TEST_ptr(mctx = EVP_MD_CTX_new())
         /* get the message digest */


### PR DESCRIPTION
## Summary

Replace `#ifdef FIPS_MODULE` with `OSSL_PROVIDER_available()` runtime check in `ecdsatest.c`.

The compile-time check is not meaningful for test cases as the test binary may be compiled without `FIPS_MODULE` but run with the FIPS provider loaded.

## Changes

```c
// Before (compile-time):
#ifdef FIPS_MODULE
    if (EC_curve_nid2nist(nid) == NULL)
        return TEST_skip("skip non approved curves");
#endif /* FIPS_MODULE */

// After (runtime):
if (OSSL_PROVIDER_available(NULL, "fips") && EC_curve_nid2nist(nid) == NULL)
    return TEST_skip("skip non approved curves in FIPS mode");
```

Fixes #28255

CLA: trivial