### PR TITLE
Fix util/mkinstallvars.pl to treat LIBDIR and libdir correctly

### DIFF
--- a/util/mkinstallvars.pl
+++ b/util/mkinstallvars.pl
@@ -45,6 +45,17 @@ foreach (@ARGV) {
     push @{$values{$k}}, $v;
 }
 
+# special case for LIBDIR vs libdir.
+# For installations, They both get their value from ./Configure's --libdir or
+# corresponding config target attribute, but LIBDIR only gets a value if the
+# configuration is a relative path, while libdir always gets a value, so if
+# the former doesn't have a value, we give it the latter's value, and rely
+# on mechanisms further down to do the rest of the processing.
+# If they're both empty, it's still fine.
+print STDERR "DEBUG: LIBDIR = $values{LIBDIR}->[0], libdir = $values{libdir}->[0] => ";
+$values{LIBDIR}->[0] = $values{libdir}->[0] unless $values{LIBDIR}->[0];
+print STDERR "LIBDIR = $values{LIBDIR}->[0]\n";
+
 # warn if there are missing values, and also if there are unexpected values
 foreach my $k (sort keys %all) {
     warn "No value given for $k\n" unless $keys{$k};


### PR DESCRIPTION
OpenSSL's build file (Makefile) handles library directories via two
variables, 'LIBDIR' and 'libdir', where the former is empty when the
path given through ./Configure's '--libdir' is absolute.

This was forgotten when treating the resulting values in,
util/mkinstallvars.pl, which got libdir in exporters/libcrypto.pc
to not be quite right if .Configure was called with a '--libdir'
with an absolute path.

The fix turns out to be quite easy.

Resolves: https://github.com/openssl/openssl/issues/28779
