### PR TITLE
Fix a memory leak in sctp code

### DIFF
--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -156,7 +156,7 @@ int init_client(int *sock, const char *host, const char *port,
             if (tmpbio == NULL) {
                 BIO_closesocket(*sock);
                 *sock = INVALID_SOCKET;
-                goto out;
+                continue;
             }
             BIO_free(tmpbio);
         }
@@ -380,6 +380,7 @@ int do_server(int *accept_sock, const char *host, const char *port,
         BIO *tmpbio = BIO_new_dgram_sctp(asock, BIO_NOCLOSE);
 
         if (tmpbio == NULL) {
+            BIO_ADDRINFO_free(res);
             BIO_closesocket(asock);
             ERR_print_errors(bio_err);
             goto end;


### PR DESCRIPTION
There is a memory leak of the addrinfo struct when `./openssl s_server -dtls -sctp -accept 127.0.0.1:4433` is used, but `sysctl -w net.sctp.auth_enable=1`
is not done before.
Additionally this fixes an oversight, when
`./openssl s_client -dtls -sctp -connect localhost:4433` is used to connect to above server.
The first connect attempt is to IPv6 ::1, which might fail, but the second attempt might still succeed, so continue to try all addesses even when the SCTP socket fails for one of them.

