### PR TITLE
prevent large latency in base64_simdutf test

### DIFF
--- a/test/test_base64_simdutf.c
+++ b/test/test_base64_simdutf.c
@@ -179,8 +179,6 @@ static int test_encode_line_lengths_reinforced(void)
         for (int partial_ctx_fill = 0; partial_ctx_fill <= 80;
             partial_ctx_fill += 1) {
             for (int ctx_len = 1; ctx_len <= 80; ctx_len += 1) {
-                printf("Trial %d, input length %d, ctx length %d, partial ctx fill %d\n",
-                    t + 1, inl, ctx_len, partial_ctx_fill);
                 EVP_ENCODE_CTX *ctx_simd = EVP_ENCODE_CTX_new();
                 EVP_ENCODE_CTX *ctx_ref = EVP_ENCODE_CTX_new();
 


### PR DESCRIPTION
The base64_simdutf test has a printf statement inside a double for loop that causes a huge amount of latency when run under our perl scripts. Average run time on my system is about 1min 58 seconds.

We shouldn't be using a printf statement there anyway (likely TEST_info instead), but we don't need that either, so just remove the printf entirely.  This decreases the run time to around a second to complete.

##### Checklist
- [x] tests are added or updated
