### PR TITLE
Instruction reordering to further improve SM4-CBC decryption performance on the RISC-V architecture

### DIFF
--- a/crypto/sm4/asm/sm4-riscv64-zvksed.pl
+++ b/crypto/sm4/asm/sm4-riscv64-zvksed.pl
@@ -451,56 +451,56 @@ rv64i_zvksed_sm4_cbc_decrypt:
     addi $base, $in, -128
     @{[reverse_order_L $vivec, $base]}
 
-    # Save the plaintext (in reverse element order)
-    @{[reverse_order_S $vdata0, $out]}
-    addi $out, $out, $BLOCK_SIZE
-
     @{[vxor_vv $vdata1, $vdata1, $vivec]}
 
     addi $base, $in, -112
     @{[reverse_order_L $vivec, $base]}
-    @{[reverse_order_S $vdata1, $out]}
-    addi $out, $out, $BLOCK_SIZE
 
     @{[vxor_vv $vdata2, $vdata2, $vivec]}
 
     addi $base, $in, -96
     @{[reverse_order_L $vivec, $base]}
-    @{[reverse_order_S $vdata2, $out]}
-    addi $out, $out, $BLOCK_SIZE
 
     @{[vxor_vv $vdata3, $vdata3, $vivec]}
 
     addi $base, $in, -80
     @{[reverse_order_L $vivec, $base]}
-    @{[reverse_order_S $vdata3, $out]}
-    addi $out, $out, $BLOCK_SIZE
 
     @{[vxor_vv $vdata4, $vdata4, $vivec]}
 
     addi $base, $in, -64
     @{[reverse_order_L $vivec, $base]}
-    @{[reverse_order_S $vdata4, $out]}
-    addi $out, $out, $BLOCK_SIZE
 
     @{[vxor_vv $vdata5, $vdata5, $vivec]}
 
     addi $base, $in, -48
     @{[reverse_order_L $vivec, $base]}
-    @{[reverse_order_S $vdata5, $out]}
-    addi $out, $out, $BLOCK_SIZE
 
     @{[vxor_vv $vdata6, $vdata6, $vivec]}
 
     addi $base, $in, -32
     @{[reverse_order_L $vivec, $base]}
-    @{[reverse_order_S $vdata6, $out]}
-    addi $out, $out, $BLOCK_SIZE
 
     @{[vxor_vv $vdata7, $vdata7, $vivec]}
 
     addi $base, $in, -16
     @{[reverse_order_L $vivec, $base]}
+
+    # Save the plaintext (in reverse element order)
+    @{[reverse_order_S $vdata0, $out]}
+    addi $out, $out, $BLOCK_SIZE
+    @{[reverse_order_S $vdata1, $out]}
+    addi $out, $out, $BLOCK_SIZE
+    @{[reverse_order_S $vdata2, $out]}
+    addi $out, $out, $BLOCK_SIZE
+    @{[reverse_order_S $vdata3, $out]}
+    addi $out, $out, $BLOCK_SIZE
+    @{[reverse_order_S $vdata4, $out]}
+    addi $out, $out, $BLOCK_SIZE
+    @{[reverse_order_S $vdata5, $out]}
+    addi $out, $out, $BLOCK_SIZE
+    @{[reverse_order_S $vdata6, $out]}
+    addi $out, $out, $BLOCK_SIZE
     @{[reverse_order_S $vdata7, $out]}
     addi $out, $out, $BLOCK_SIZE
 
@@ -548,28 +548,29 @@ rv64i_zvksed_sm4_cbc_decrypt:
     # Update ciphertext to IV (in reverse element order)
     addi $base, $in, -64
     @{[reverse_order_L $vivec, $base]}
-    # Save the plaintext (in reverse element order)
-    @{[reverse_order_S $vdata0, $out]}
-    addi $out, $out, $BLOCK_SIZE
 
     @{[vxor_vv $vdata1, $vdata1, $vivec]}
 
     addi $base, $in, -48
     @{[reverse_order_L $vivec, $base]}
-    @{[reverse_order_S $vdata1, $out]}
-    addi $out, $out, $BLOCK_SIZE
 
     @{[vxor_vv $vdata2, $vdata2, $vivec]}
 
     addi $base, $in, -32
     @{[reverse_order_L $vivec, $base]}
-    @{[reverse_order_S $vdata2, $out]}
-    addi $out, $out, $BLOCK_SIZE
 
     @{[vxor_vv $vdata3, $vdata3, $vivec]}
 
     addi $base, $in, -16
     @{[reverse_order_L $vivec, $base]}
+
+    # Save the plaintext (in reverse element order)
+    @{[reverse_order_S $vdata0, $out]}
+    addi $out, $out, $BLOCK_SIZE
+    @{[reverse_order_S $vdata1, $out]}
+    addi $out, $out, $BLOCK_SIZE
+    @{[reverse_order_S $vdata2, $out]}
+    addi $out, $out, $BLOCK_SIZE
     @{[reverse_order_S $vdata3, $out]}
     addi $out, $out, $BLOCK_SIZE
 


### PR DESCRIPTION
Further optimizations have been made to the decryption function in PR #29137.

Instructions with RAW (Read After Write) data dependencies were separated to avoid pipeline stalls caused by immediate storage of unready data. The original approach of interleaved storage of plaintext after decryption was adjusted to store multiple blocks of plaintext uniformly after all block XOR operations are completed.

The average result was taken from three test runs performed on a RISC-V virtual machine featuring the Zvksed extensions.

**Performance Improvement**

| Decrypt Test | 	Baseline 	 | Optimized	 | Improvement ratio |
| ------------ | --------------- | ------------- | ----------------- |
| 64 bytes     | 24045.42k       | 24595.82k     | 2%                |
| 256 bytes    | 30145.99k       | 31442.67k     | 4%               |
| 1024 bytes   | 32372.05k       | 33808.69k     | 4%               |
| 8192 bytes   | 32686.89k       | 34410.29k     | 5%                |
| 16384 bytes  | 33030.14k       | 34402.08k     | 4%               |

All tests successful.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
