### PR TITLE
Fix a possible crash in ASN1_generate_nconf

### DIFF
--- a/crypto/asn1/asn1_gen.c
+++ b/crypto/asn1/asn1_gen.c
@@ -149,6 +149,8 @@ static ASN1_TYPE *generate_v3(const char *str, X509V3_CTX *cnf, int depth,
     cpy_len = i2d_ASN1_TYPE(ret, &orig_der);
     ASN1_TYPE_free(ret);
     ret = NULL;
+    if (orig_der == NULL)
+        return NULL;
     /* Set point to start copying for modified encoding */
     cpy_start = orig_der;
 

--- a/test/recipes/04-test_asn1_parse.t
+++ b/test/recipes/04-test_asn1_parse.t
@@ -12,7 +12,7 @@ use OpenSSL::Test::Utils;
 
 setup("test_asn1_parse");
 
-plan tests => 3;
+plan tests => 4;
 
 $ENV{OPENSSL_CONF} = srctop_file("test", "test_asn1_parse.cnf");
 
@@ -24,3 +24,6 @@ ok(run(app(([ 'openssl', 'asn1parse',
 
 ok(run(app(([ 'openssl', 'asn1parse',
               '-genstr', 'OID:1.2.3.4.3']))));
+
+ok(run(app(([ 'openssl', 'asn1parse',
+              '-genconf', srctop_file("test", "test_asn1_genconf.cnf")]))));

--- a/test/test_asn1_genconf.cnf
+++ b/test/test_asn1_genconf.cnf
@@ -1,0 +1,5 @@
+asn1=SEQUENCE:seq
+
+[seq]
+impl=IMPLICIT:1,BOOL:true
+expl=EXPLICIT:2,BITWRAP,OCT:X


### PR DESCRIPTION
Due to an out of memory error, the i2d_ASN1_TYPE might fail and cause a segfault.
This adds a missing check for NULL pointer and a test case that exercises IMPLICIT and EXPLICT tagging in generate_v3, since there was no test coverage at all for this code section.


##### Checklist
- [x] tests are added or updated
