### PR TITLE
Add new test test_base64_simdutf to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,7 @@ providers/implementations/rands/test_rng.inc
 /test/evp_pkey_ctx_new_from_name
 /test/threadstest_fips
 /test/timing_load_creds
+/test/test_base64_simdutf
 
 # Demo applications
 /demos/bio/client-arg


### PR DESCRIPTION
the test_base64_simdutf test is commonly built but not ignored by our .gitignore file, fix that up

Fixes #29529


##### Checklist
- [x] tests are added or updated
