### PR TITLE
MinGW does not know __int64, it should use int64_t instead

### DIFF
--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -212,19 +212,6 @@ typedef INTN ossl_ssize_t;
 #undef OPENSSL_NO_INTTYPES_H
 /* Because the specs say that inttypes.h includes stdint.h if present */
 #undef OPENSSL_NO_STDINT_H
-#elif defined(_MSC_VER) && _MSC_VER < 1600
-/*
- * minimally required typdefs for systems not supporting inttypes.h or
- * stdint.h: currently just older VC++
- */
-typedef signed char int8_t;
-typedef unsigned char uint8_t;
-typedef short int16_t;
-typedef unsigned short uint16_t;
-typedef int int32_t;
-typedef unsigned int uint32_t;
-typedef __int64 int64_t;
-typedef unsigned __int64 uint64_t;
 #elif defined(OPENSSL_SYS_TANDEM)
 #include <stdint.h>
 #include <sys/types.h>
@@ -235,8 +222,8 @@ typedef unsigned __int64 uint64_t;
 
 #ifdef _WIN32
 #ifdef _WIN64
-typedef __int64 ossl_ssize_t;
-#define OSSL_SSIZE_MAX _I64_MAX
+typedef int64_t ossl_ssize_t;
+#define OSSL_SSIZE_MAX INT64_MAX
 #else
 typedef int ossl_ssize_t;
 #define OSSL_SSIZE_MAX INT_MAX


### PR DESCRIPTION
Fixes: #29548

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
