### PR TITLE
Add PKCS12 fuzzer

### DIFF
--- a/fuzz/build.info
+++ b/fuzz/build.info
@@ -10,7 +10,7 @@
 
 IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
   PROGRAMS{noinst}=asn1 asn1parse bignum bndiv client conf crl server smime
-  PROGRAMS{noinst}=punycode pem decoder hashtable acert
+  PROGRAMS{noinst}=pkcs12 punycode pem decoder hashtable acert
   PROGRAMS{noinst}=v3name
   PROGRAMS{noinst}=provider
 
@@ -81,6 +81,10 @@ IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
   SOURCE[cms]=cms.c driver.c
   INCLUDE[cms]=../include {- $ex_inc -}
   DEPEND[cms]=../libcrypto {- $ex_lib -}
+
+  SOURCE[pkcs12]=pkcs12.c driver.c
+  INCLUDE[pkcs12]=../include {- $ex_inc -}
+  DEPEND[pkcs12]=../libcrypto {- $ex_lib -}
 
   SOURCE[conf]=conf.c driver.c
   INCLUDE[conf]=../include {- $ex_inc -}
@@ -173,7 +177,7 @@ ENDIF
 
 IF[{- !$disabled{tests} -}]
   PROGRAMS{noinst}=asn1-test asn1parse-test bignum-test bndiv-test client-test conf-test crl-test server-test smime-test
-  PROGRAMS{noinst}=punycode-test pem-test decoder-test hashtable-test acert-test
+  PROGRAMS{noinst}=pkcs12-test punycode-test pem-test decoder-test hashtable-test acert-test
   PROGRAMS{noinst}=v3name-test
   PROGRAMS{noinst}=provider-test
 
@@ -257,6 +261,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[cms-test]=cms.c test-corpus.c
   INCLUDE[cms-test]=../include
   DEPEND[cms-test]=../libcrypto
+
+  SOURCE[pkcs12-test]=pkcs12.c test-corpus.c
+  INCLUDE[pkcs12-test]=../include
+  DEPEND[pkcs12-test]=../libcrypto
 
   SOURCE[conf-test]=conf.c test-corpus.c
   INCLUDE[conf-test]=../include

--- a/fuzz/pkcs12.c
+++ b/fuzz/pkcs12.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.openssl.org/source/license.html
+ * or in the file LICENSE in the source distribution.
+ */
+
+/*
+ * Test PKCS12 parsing with fuzzed input.
+ */
+
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/pkcs12.h>
+#include <openssl/x509.h>
+#include "fuzzer.h"
+
+int FuzzerInitialize(int *argc, char ***argv)
+{
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
+    ERR_clear_error();
+    CRYPTO_free_ex_index(0, -1);
+
+    return 1;
+}
+
+int FuzzerTestOneInput(const uint8_t *buf, size_t len)
+{
+    PKCS12 *p12;
+    BIO *in;
+    EVP_PKEY *pkey = NULL;
+    X509 *cert = NULL;
+    STACK_OF(X509) *ca = NULL;
+
+    if (len == 0 || len > INT_MAX)
+        return 0;
+
+    in = BIO_new(BIO_s_mem());
+    OPENSSL_assert((size_t)BIO_write(in, buf, (int)len) == len);
+    p12 = d2i_PKCS12_bio(in, NULL);
+    if (p12 != NULL) {
+        PKCS12_verify_mac(p12, NULL, 0);
+        PKCS12_verify_mac(p12, "", 0);
+
+        PKCS12_parse(p12, NULL, &pkey, &cert, &ca);
+        EVP_PKEY_free(pkey);
+        X509_free(cert);
+        OSSL_STACK_OF_X509_free(ca);
+
+        pkey = NULL;
+        cert = NULL;
+        ca = NULL;
+        PKCS12_parse(p12, "", &pkey, &cert, &ca);
+        EVP_PKEY_free(pkey);
+        X509_free(cert);
+        OSSL_STACK_OF_X509_free(ca);
+
+        PKCS12_free(p12);
+    }
+
+    BIO_free(in);
+    ERR_clear_error();
+
+    return 0;
+}
+
+void FuzzerCleanup(void)
+{
+}

--- a/test/recipes/99-test_fuzz_pkcs12.t
+++ b/test/recipes/99-test_fuzz_pkcs12.t
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+use OpenSSL::Test::Utils;
+
+my $fuzzer = "pkcs12";
+setup("test_fuzz_${fuzzer}");
+
+plan tests => 2; # one more due to below require_ok (...)
+
+require_ok(srctop_file('test','recipes','fuzz.pl'));
+
+fuzz_ok($fuzzer);


### PR DESCRIPTION
Adds a fuzzer for PKCS12 parsing to improve coverage of `crypto/pkcs12/`.

The fuzzer exercises:
- `d2i_PKCS12_bio()` - DER decoding
- `PKCS12_verify_mac()` - MAC verification with NULL and empty passwords
- `PKCS12_parse()` - Full parsing with both NULL and empty password paths

This code path was previously only indirectly fuzzed through the ASN.1 fuzzer which tests structure decoding but not the higher-level parsing logic in `p12_kiss.c`.

Motivated by https://github.blog/security/vulnerability-research/bugs-that-survive-the-heat-of-continuous-fuzzing/ - PKCS12 parsing has known issues like #28615 (stack exhaustion from recursive `parse_bag()` calls) that benefit from dedicated fuzzing coverage.

Test recipe following existing patterns.