### PR TITLE
Do not hardcode CI workspace path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -792,7 +792,7 @@ jobs:
         persist-credentials: false
     - name: checkout fuzz/corpora and pkcs11-provider submodule
       run: |
-        git config --global --add safe.directory /__w/openssl/openssl
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
         git submodule update --init --depth 1 fuzz/corpora
         git submodule update --init --depth 1 pkcs11-provider
     - name: config

--- a/.github/workflows/interop-tests.yml
+++ b/.github/workflows/interop-tests.yml
@@ -50,7 +50,7 @@ jobs:
           sed -i "/^%{_bindir}\/c_rehash$/ d" openssl.spec
           yum-builddep -y /build/SPECS/openssl.spec # just for sure nothing is missing
           mkdir -p /build/SOURCES
-          tar --transform "s/^__w\/openssl\/openssl/openssl-$MAJOR.$MINOR.$PATCH/" -czf /build/SOURCES/openssl-$MAJOR.$MINOR.$PATCH.tar.gz /__w/openssl/openssl/
+          tar --transform "s/^__w\/openssl\/openssl/openssl-$MAJOR.$MINOR.$PATCH/" -czf /build/SOURCES/openssl-$MAJOR.$MINOR.$PATCH.tar.gz "$GITHUB_WORKSPACE"
           rpmbuild -bb /build/SPECS/openssl.spec
           rpm -i --force /build/RPMS/x86_64/openssl-*
           cp ${GITHUB_WORKSPACE}/interop/openssl/openssl.cnf /etc/pki/tls/openssl.cnf


### PR DESCRIPTION
CI jobs with hard coded workspace path in mirrors will fail. We should use `$GITHUB_WORKSPACE` environment variable instead.