### PR TITLE
let UEFI code in OpenSSL to use integers from <stdint.h>

### DIFF
--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -193,21 +193,7 @@ extern "C" {
 /* Standard integer types */
 #define OPENSSL_NO_INTTYPES_H
 #define OPENSSL_NO_STDINT_H
-#if defined(OPENSSL_SYS_UEFI)
-typedef INT8 int8_t;
-typedef UINT8 uint8_t;
-typedef INT16 int16_t;
-typedef UINT16 uint16_t;
-typedef INT32 int32_t;
-typedef UINT32 uint32_t;
-typedef INT64 int64_t;
-typedef UINT64 uint64_t;
-typedef UINTN uintptr_t;
-#ifndef OSSL_SSIZE_MAX
-typedef INTN ossl_ssize_t;
-#define OSSL_SSIZE_MAX MAX_INTN
-#endif
-#elif (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || defined(__osf__) || defined(__sgi) || defined(__hpux) || defined(OPENSSL_SYS_VMS) || defined(__OpenBSD__)
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || defined(__osf__) || defined(__sgi) || defined(__hpux) || defined(OPENSSL_SYS_VMS) || defined(__OpenBSD__)
 #include <inttypes.h>
 #undef OPENSSL_NO_INTTYPES_H
 /* Because the specs say that inttypes.h includes stdint.h if present */


### PR DESCRIPTION
@kraxel
@liyi77 
@ajkhoury 

the UEFI seems to be the only platform which derives standard integer types from int types specific to its platform. Do we still need this code? if we do I'll close the PR unmerged.

thanks.