### PR TITLE
Fix max index define that was not updated

### DIFF
--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -118,8 +118,8 @@ typedef struct ossl_ex_data_global_st {
 #define OSSL_LIB_CTX_DECODER_CACHE_INDEX 20
 #define OSSL_LIB_CTX_COMP_METHODS 21
 #define OSSL_LIB_CTX_INDICATOR_CB_INDEX 22
-#define OSSL_LIB_CTX_MAX_INDEXES 22
 #define OSSL_LIB_CTX_SSL_CONF_IMODULE 23
+#define OSSL_LIB_CTX_MAX_INDEXES 23
 
 OSSL_LIB_CTX *ossl_lib_ctx_get_concrete(OSSL_LIB_CTX *ctx);
 int ossl_lib_ctx_is_default(OSSL_LIB_CTX *ctx);


### PR DESCRIPTION
In PR #29145 a new OSSL_LIB_CTX_SSL_CONF_IMODULE was added, but the OSSL_LIB_CTX_MAX_INDEXES value was left behind.

This should probably be converted to an enum, but I'll leave that work to some other brave soul.

NOTE: This values is used nowhere, so it may even be removed I guess..

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
