### PR TITLE
Consistent naming of the -msg and -trace option in s_client and s_server

### DIFF
--- a/apps/include/s_apps.h
+++ b/apps/include/s_apps.h
@@ -45,7 +45,7 @@ long bio_dump_callback(BIO *bio, int cmd, const char *argp, size_t len,
     int argi, long argl, int ret, size_t *processed);
 
 void apps_ssl_info_callback(const SSL *s, int where, int ret);
-void msg_cb(int write_p, int version, int content_type, const void *buf,
+void msg_hex_cb(int write_p, int version, int content_type, const void *buf,
     size_t len, SSL *ssl, void *arg);
 void tlsext_cb(SSL *s, int client_server, int type, const unsigned char *data,
     int len, void *arg);

--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -656,7 +656,7 @@ static STRINT_PAIR handshakes[] = {
     { NULL }
 };
 
-void msg_cb(int write_p, int version, int content_type, const void *buf,
+void msg_hex_cb(int write_p, int version, int content_type, const void *buf,
     size_t len, SSL *ssl, void *arg)
 {
     BIO *bio = arg;

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -512,9 +512,9 @@ typedef enum OPTION_choice {
     OPT_STATUS_OCSP_CHECK_LEAF,
     OPT_STATUS_OCSP_CHECK_ALL,
 #endif
-    OPT_MSG,
-    OPT_MSGFILE,
-    OPT_TRACE,
+    OPT_TRACE_HEX,
+    OPT_TRACE_TEXT,
+    OPT_TRACE_FILE,
     OPT_SECURITY_DEBUG,
     OPT_SECURITY_DEBUG_VERBOSE,
     OPT_SHOWCERTS,
@@ -721,9 +721,12 @@ const OPTIONS s_client_options[] = {
     { "showcerts", OPT_SHOWCERTS, '-',
         "Show all certificates sent by the server" },
     { "debug", OPT_DEBUG, '-', "Extra output" },
-    { "msg", OPT_MSG, '-', "Show protocol messages" },
-    { "msgfile", OPT_MSGFILE, '>',
-        "File to send output of -msg or -trace, instead of stdout" },
+    { "trace_hex", OPT_TRACE_HEX, '-', "Show protocol messages with hex-dump" },
+#ifndef OPENSSL_NO_SSL_TRACE
+    { "trace_text", OPT_TRACE_TEXT, '-', "Show protocol messages in human-readable format" },
+#endif
+     { "trace_file", OPT_TRACE_FILE, '>',
+        "File to send output of -trace_hex or -trace_text, instead of stdout" },
     { "nbio_test", OPT_NBIO_TEST, '-', "More ssl protocol testing" },
     { "state", OPT_STATE, '-', "Print the ssl states" },
     { "keymatexport", OPT_KEYMATEXPORT, 's',
@@ -734,9 +737,6 @@ const OPTIONS s_client_options[] = {
         "Enable security debug messages" },
     { "security_debug_verbose", OPT_SECURITY_DEBUG_VERBOSE, '-',
         "Output more security debug output" },
-#ifndef OPENSSL_NO_SSL_TRACE
-    { "trace", OPT_TRACE, '-', "Show trace output of protocol messages" },
-#endif
 #ifdef WATT32
     { "wdebug", OPT_WDEBUG, '-', "WATT-32 tcp debugging" },
 #endif
@@ -1024,12 +1024,12 @@ int s_client_main(int argc, char **argv)
         = use_unknown;
     int count4or6 = 0;
     uint8_t maxfraglen = 0;
-    int c_nbio = 0, c_msg = 0, c_ign_eof = 0, c_brief = 0;
+    int c_nbio = 0, c_trace = 0, c_ign_eof = 0, c_brief = 0;
     int c_tlsextdebug = 0;
 #ifndef OPENSSL_NO_OCSP
     int c_status_req = 0;
 #endif
-    BIO *bio_c_msg = NULL;
+    BIO *bio_c_trace = NULL;
     const char *keylog_file = NULL, *early_data_file = NULL;
     int isdtls = 0, isquic = 0;
     char *psksessf = NULL;
@@ -1289,19 +1289,19 @@ int s_client_main(int argc, char **argv)
             dbug_init();
 #endif
             break;
-        case OPT_MSG:
-            c_msg = 1;
+        case OPT_TRACE_HEX:
+            c_trace = 1;
             break;
-        case OPT_MSGFILE:
-            bio_c_msg = BIO_new_file(opt_arg(), "w");
-            if (bio_c_msg == NULL) {
+        case OPT_TRACE_FILE:
+            bio_c_trace = BIO_new_file(opt_arg(), "w");
+            if (bio_c_trace == NULL) {
                 BIO_printf(bio_err, "Error writing file %s\n", opt_arg());
                 goto end;
             }
             break;
-        case OPT_TRACE:
+        case OPT_TRACE_TEXT:
 #ifndef OPENSSL_NO_SSL_TRACE
-            c_msg = 2;
+            c_trace = 2;
 #endif
             break;
         case OPT_SECURITY_DEBUG:
@@ -1856,9 +1856,9 @@ int s_client_main(int argc, char **argv)
     if (bio_c_out == NULL) {
         if (c_quiet && !c_debug) {
             bio_c_out = BIO_new(BIO_s_null());
-            if (c_msg && bio_c_msg == NULL) {
-                bio_c_msg = dup_bio_out(FORMAT_TEXT);
-                if (bio_c_msg == NULL) {
+            if (c_trace && bio_c_trace == NULL) {
+                bio_c_trace = dup_bio_out(FORMAT_TEXT);
+                if (bio_c_trace == NULL) {
                     BIO_printf(bio_err, "Out of memory\n");
                     goto end;
                 }
@@ -2088,7 +2088,7 @@ int s_client_main(int argc, char **argv)
     }
 #ifndef OPENSSL_NO_SRP
     if (srp_arg.srplogin != NULL
-        && !set_up_srp_arg(ctx, &srp_arg, srp_lateuser, c_msg, c_debug))
+        && !set_up_srp_arg(ctx, &srp_arg, srp_lateuser, c_trace, c_debug))
         goto end;
 #endif
 
@@ -2336,14 +2336,14 @@ re_start:
         BIO_set_callback_ex(sbio, bio_dump_callback);
         BIO_set_callback_arg(sbio, (char *)bio_c_out);
     }
-    if (c_msg) {
+    if (c_trace) {
 #ifndef OPENSSL_NO_SSL_TRACE
-        if (c_msg == 2)
+        if (c_trace == 2)
             SSL_set_msg_callback(con, SSL_trace);
         else
 #endif
-            SSL_set_msg_callback(con, msg_cb);
-        SSL_set_msg_callback_arg(con, bio_c_msg ? bio_c_msg : bio_c_out);
+            SSL_set_msg_callback(con, msg_hex_cb);
+        SSL_set_msg_callback_arg(con, bio_c_trace ? bio_c_trace : bio_c_out);
     }
 
     if (c_tlsextdebug) {
@@ -3359,8 +3359,8 @@ end:
     clear_free(proxypass);
     BIO_free(bio_c_out);
     bio_c_out = NULL;
-    BIO_free(bio_c_msg);
-    bio_c_msg = NULL;
+    BIO_free(bio_c_trace);
+    bio_c_trace = NULL;
     return ret;
 }
 

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -51,18 +51,18 @@ B<openssl> B<s_client>
 [B<-prexit>]
 [B<-no-interactive>]
 [B<-debug>]
-[B<-trace>]
+[B<-trace_hex>]
+[B<-trace_text>]
+[B<-trace_file> I<filename>]
 [B<-nocommands>]
 [B<-adv>]
 [B<-security_debug>]
 [B<-security_debug_verbose>]
-[B<-msg>]
 [B<-timeout>]
 [B<-mtu> I<size>]
 [B<-no_ems>]
 [B<-keymatexport> I<label>]
 [B<-keymatexportlen> I<len>]
-[B<-msgfile> I<filename>]
 [B<-nbio_test>]
 [B<-state>]
 [B<-nbio>]
@@ -458,9 +458,17 @@ Enable security debug messages.
 
 Output more security debug output.
 
-=item B<-msg>
+=item B<-trace_hex>
 
-Show protocol messages.
+Show all protocol messages with hex dump.
+
+=item B<-trace_text>
+
+Show verbose trace output of protocol messages in human-readable format.
+
+=item B<-trace_file> I<filename>
+
+File to send output of B<-trace_hex> or B<-trace_text> to, default standard output.
 
 =item B<-timeout>
 
@@ -481,16 +489,6 @@ Export keying material using the specified label.
 =item B<-keymatexportlen> I<len>
 
 Export the specified number of bytes of keying material; default is 20.
-
-Show all protocol messages with hex dump.
-
-=item B<-trace>
-
-Show verbose trace output of protocol messages.
-
-=item B<-msgfile> I<filename>
-
-File to send output of B<-msg> or B<-trace> to, default standard output.
 
 =item B<-nbio_test>
 

--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -39,8 +39,9 @@ B<openssl> B<s_server>
 [B<-nbio_test>]
 [B<-crlf>]
 [B<-debug>]
-[B<-msg>]
-[B<-msgfile> I<outfile>]
+[B<-trace_hex>]
+[B<-trace_text>]
+[B<-trace_file> I<outfile>]
 [B<-state>]
 [B<-nocert>]
 [B<-quiet>]
@@ -82,7 +83,6 @@ B<openssl> B<s_server>
 [B<-status_url> I<val>]
 [B<-status_file> I<infile>]
 [B<-ssl_config> I<val>]
-[B<-trace>]
 [B<-security_debug>]
 [B<-security_debug_verbose>]
 [B<-brief>]
@@ -308,13 +308,17 @@ Print output from SSL/TLS security framework.
 
 Print more output from SSL/TLS security framework
 
-=item B<-msg>
+=item B<-trace_hex>
 
 Show all protocol messages with hex dump.
 
-=item B<-msgfile> I<outfile>
+=item B<-trace_text>
 
-File to send output of B<-msg> or B<-trace> to, default standard output.
+Show verbose trace output of protocol messages in human-readable format.
+
+=item B<-trace_file> I<outfile>
+
+File to send output of B<-trace_hex> or B<-trace_text> to, default standard output.
 
 =item B<-state>
 
@@ -546,9 +550,7 @@ certificates in the server certificate chain.
 
 Configure SSL_CTX using the given configuration value.
 
-=item B<-trace>
 
-Show verbose trace output of protocol messages.
 
 =item B<-brief>
 


### PR DESCRIPTION
This PR propose two things : 

- First, the `-trace` option should be under the `Debug` category.
- Second, rename `-msg` to `-trace_hex` and `-trace` to `-trace_text`. Option `-msgfile` is also renamed to `-trace_file`.

I was thinking about using the `msg` prefix instead of the `trace` prefix. It makes more sense from a user perspective to use the `trace` prefix : the `msg` prefix was probably used because of the `SSL_*_set_msg_callback` function the app uses under the hood.
It was also difficult to see that both `-msg` and `-trace` option were related in some way, since they were not in the same category, and has completly different naming. The only way to understand that is by reading the `-msgfile` option, or just by reading the source code.
