### PR TITLE
dtls: only retry EMSGSIZE send after MTU change (fix #27905)

### DIFF
--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -255,7 +255,11 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
              */
             if (retry && BIO_ctrl(SSL_get_wbio(ssl), BIO_CTRL_DGRAM_MTU_EXCEEDED, 0, NULL) > 0) {
                 if (!(SSL_get_options(ssl) & SSL_OP_NO_QUERY_MTU)) {
+                    size_t old_mtu = s->d1->mtu;
                     if (!dtls1_query_mtu(s))
+                        return -1;
+                    /* If MTU didn't change, retry is meaningless */
+                    if (s->d1->mtu == old_mtu)
                         return -1;
                     /* Have one more go */
                     retry = 0;


### PR DESCRIPTION
Fixes #27905
When a DTLS send returns EMSGSIZE, the code previously unconditionally retried after querying the MTU. This retry is only meaningful if the MTU actually changed. The patch records the old MTU and only retries when it differs.
Verification: built locally and ran test/bad_dtls_test — ok 1 - test_bad_dtls
Please review.