### PR TITLE
Add WSAIoctl to allowed platform symbols on Windows

### DIFF
--- a/util/platform_symbols/windows-symbols.txt
+++ b/util/platform_symbols/windows-symbols.txt
@@ -182,6 +182,7 @@ DeleteCriticalSection
 ReleaseSemaphore
 WaitForSingleObject
 WSASocketA
+WSAIoctl
 GetCurrentThreadId
 SetUnhandledExceptionFilter
 GetExitCodeThread


### PR DESCRIPTION
CI breakage fix, urgent.

For some reason this is not detected on 3.6 and master but it should be cherry picked there as well.
