### PR TITLE
DTLS 1.3 Enable Cookie tests

### DIFF
--- a/test/recipes/70-test_tls13cookie.t
+++ b/test/recipes/70-test_tls13cookie.t
@@ -40,9 +40,6 @@ SKIP: {
 }
 
 SKIP: {
-    # TODO(DTLSv1.3): This test currently does not work for DTLS. It gets stuck
-    # in the first test case.
-    skip "Test does not work correctly currently", $testcount;
     skip "DTLS 1.3 is disabled", $testcount if disabled("dtls1_3");
     skip "DTLSProxy does not work on Windows", $testcount if $^O =~ /^(MSWin32)$/;
     run_tests(1);
@@ -80,6 +77,7 @@ sub run_tests
 
     #Test 1: Inserting a cookie into an HRR should see it echoed in the ClientHello
     #        (when a key share is required)
+    $proxy->clear();
     $testtype = COOKIE_AND_KEY_SHARE;
     $proxy->filter(\&cookie_filter);
     if (disabled("ecx")) {


### PR DESCRIPTION
Enabling the DTLS1.3 Cookie tests.

Fixes: openssl/project#1787

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
