### PR TITLE
DTLS 1.3 Enabling Downgrade tests

### DIFF
--- a/test/recipes/70-test_tls13downgrade.t
+++ b/test/recipes/70-test_tls13downgrade.t
@@ -50,10 +50,6 @@ SKIP: {
 }
 
 SKIP: {
-    # TODO(DTLSv1.3): This test currently does not work for DTLS. It gets stuck
-    # in the first test case.
-    skip "Test does not work correctly currently", $testcount;
-
     skip "DTLS 1.2 or 1.3 is disabled", $testcount if disabled("dtls1_3")
                                                       || disabled("dtls1_2");
     skip "DTLSProxy does not work on Windows", $testcount if $^O =~ /^(MSWin32)$/;


### PR DESCRIPTION
Enabling the downgrade tests for DTLS 1.3.

Fixes: openssl/project#1788

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
