### PR TITLE
Enable signing of empty files with pkeyutl

### DIFF
--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -837,7 +837,8 @@ static int do_raw_keyop(int pkey_op, EVP_MD_CTX *mctx,
                 "Error: unable to determine file size for oneshot operation\n");
             goto end;
         }
-        mbuf = app_malloc(filesize, "oneshot sign/verify buffer");
+        if (filesize > 0)
+            mbuf = app_malloc(filesize, "oneshot sign/verify buffer");
         switch (pkey_op) {
         case EVP_PKEY_OP_VERIFY:
             buf_len = BIO_read(in, mbuf, filesize);

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3435,7 +3435,7 @@ static void print_connection_info(SSL *con)
     if ((SSL_get_options(con) & SSL_OP_NO_RENEGOTIATION))
         BIO_printf(bio_s_out, "Renegotiation is DISABLED\n");
 
-    if (keymatexportlabel != NULL) {
+    if (keymatexportlabel != NULL && keymatexportlen > 0) {
         BIO_printf(bio_s_out, "Keying material exporter:\n");
         BIO_printf(bio_s_out, "    Label: '%s'\n", keymatexportlabel);
         BIO_printf(bio_s_out, "    Length: %i bytes\n", keymatexportlen);
@@ -4134,7 +4134,7 @@ static int add_session(SSL *ssl, SSL_SESSION *session)
 
     SSL_SESSION_get_id(session, &sess->idlen);
     sess->derlen = i2d_SSL_SESSION(session, NULL);
-    if (sess->derlen < 0) {
+    if (sess->derlen <= 0) {
         BIO_printf(bio_err, "Error encoding session\n");
         OPENSSL_free(sess);
         return 0;


### PR DESCRIPTION
The allocated buffer for the file contents is then zero bytes long, which `app_malloc()` used to refuse.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
