### PR TITLE
Valgrind test and suppression file

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -184,3 +184,19 @@ To randomise the test ordering:
 To run the tests using the order defined by the random seed `42`:
 
     $ make OPENSSL_TEST_RAND_ORDER=42 test
+
+Running Tests under Valgrind
+----------------------------
+
+Normally, testing for memory leaks is accomplished by building Openssl with the
+enable-asan option, which links the library with the compiler asan library.  However
+some people prefer to use valgrind to do dynamic instrumentation for memory leak checking.
+OpenSSL also offers a suppression file to suppress reachable memory leaks, that are often
+inappropriately considered to be true leaks.  In order to maintain and test this
+suppression file, OpenSSL tests can be run under valgrind automatically.
+
+To run the test suite under valgrind:
+
+    $ make OSSL_USE_VALGRIND=yes test
+
+Doing so will create valgrind.log file for each test under the test-runs subdirectory.

--- a/test/openssl.supp
+++ b/test/openssl.supp
@@ -1,0 +1,90 @@
+#
+# OpenSSL Valgrind suppression file
+#
+
+{
+   reachable_globals_in_openssl
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   obj:*/libcrypto.so.*
+}
+{
+   reachable_globals_in_openssl2
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   obj:*/libssl.so.*
+}
+{
+   reachable_libc_dl_map_new_object
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:malloc
+   fun:strdup
+   fun:_dl_map_new_object
+   fun:dl_open_worker_begin
+#   obj:*lib*/libc.so.*
+}
+{
+   reachable_libc_dl_map_object
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:malloc
+   fun:_dl_new_object
+   fun:_dl_map_object_from_fd
+   fun:_dl_map_new_object
+#   obj:*lib*/libc.so.*
+}
+{
+   reachable_libc_dl_map_object2
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:calloc
+   fun:_dl_new_object
+   fun:_dl_map_object_from_fd
+   fun:_dl_map_new_object
+#   obj:*lib*/libc.so.*
+}
+{
+   reachable_libc_dl_check_map_versions
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:calloc
+   fun:_dl_check_map_versions
+   fun:dl_open_worker_begin
+#   obj:*lib*/libc.so.*
+}
+{
+   reachable_libc_dl_map_new_object2
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:malloc
+   fun:open_path
+   fun:_dl_map_new_object
+#   obj:*lib*/libc.so.*
+}
+{
+   reachable_libc_dl_map_new_object4
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:realloc
+   fun:realloc
+   fun:_dl_new_object
+   fun:_dl_map_object_from_fd
+   fun:_dl_map_new_object
+#   obj:*lib*/libc.so.*
+}
+{
+   reachable_libc_resize
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:malloc
+   fun:add_to_global_resize
+   fun:dl_open_worker_begin
+#   obj:*lib*/libc.so.*
+}

--- a/test/recipes/70-test_quic_multistream.t
+++ b/test/recipes/70-test_quic_multistream.t
@@ -16,6 +16,9 @@ setup("test_quic_multistream");
 plan skip_all => "QUIC protocol is not supported by this OpenSSL build"
     if disabled('quic');
 
+plan skip_all => "Test does not run under Valgrind"
+    if $ENV{OSSL_USE_VALGRIND};
+
 plan tests => 2;
 
 my $qlog_output;

--- a/test/recipes/70-test_quic_radix.t
+++ b/test/recipes/70-test_quic_radix.t
@@ -14,6 +14,9 @@ setup("test_quic_radix");
 plan skip_all => "QUIC protocol is not supported by this OpenSSL build"
     if disabled('quic');
 
+plan skip_all => "Test does not run under Valgrind"
+    if $ENV{OSSL_USE_VALGRIND};
+
 plan tests => 1;
 
 ok(run(test(["quic_radix_test",

--- a/test/recipes/70-test_sslrecords.t
+++ b/test/recipes/70-test_sslrecords.t
@@ -29,6 +29,9 @@ plan skip_all => "$test_name needs the module feature enabled"
 plan skip_all => "$test_name needs the sock feature enabled"
     if disabled("sock");
 
+plan skip_all => "Test does not run under Valgrind"
+    if $ENV{OSSL_USE_VALGRIND};
+
 my $inject_recs_num = undef;
 my $content_type = undef;
 my $boundary_test_type = undef;

--- a/test/recipes/80-test_ca.t
+++ b/test/recipes/80-test_ca.t
@@ -18,6 +18,9 @@ use Time::Local qw/timegm/;
 
 setup("test_ca");
 
+plan skip_all => "Test does not run under Valgrind"
+    if $ENV{OSSL_USE_VALGRIND};
+
 $ENV{OPENSSL} = cmdstr(app(["openssl"]), display => 1);
 
 my $cnf = srctop_file("test","ca-and-certs.cnf");

--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -328,8 +328,13 @@ sub app {
     return sub {
         my @cmdargs = ( @{$cmd} );
         my @prog = __fixup_prg(__apps_file(shift @cmdargs, __exeext()));
-        return cmd([ @prog, @cmdargs ],
-                   exe_shell => $ENV{EXE_SHELL}, %opts) -> (shift);
+        if ($ENV{OSSL_USE_VALGRIND} eq "yes") {
+            return cmd([ "valgrind", "--leak-check=full", "--show-leak-kinds=all", "--log-file=./valgrind.log", "--suppressions=$directories{BLDTEST}/openssl.supp", @prog, @cmdargs ],
+                       exe_shell => $ENV{EXE_SHELL}, %opts) -> (shift);
+        } else {
+            return cmd([ @prog, @cmdargs ],
+                       exe_shell => $ENV{EXE_SHELL}, %opts) -> (shift);
+        }
     }
 }
 
@@ -350,8 +355,13 @@ sub test {
     return sub {
         my @cmdargs = ( @{$cmd} );
         my @prog = __fixup_prg(__test_file(shift @cmdargs, __exeext()));
-        return cmd([ @prog, @cmdargs ],
+        if ($ENV{OSSL_USE_VALGRIND} eq "yes") {
+           return cmd([ "valgrind", "--leak-check=full", "--show-leak-kinds=all", "--log-file=./valgrind.log",  "--suppressions=$directories{BLDTEST}/openssl.supp", @prog, @cmdargs ],
                    exe_shell => $ENV{EXE_SHELL}, %opts) -> (shift);
+        } else {
+            return cmd([ @prog, @cmdargs ],
+                   exe_shell => $ENV{EXE_SHELL}, %opts) -> (shift);
+        }
     }
 }
 


### PR DESCRIPTION
a.k.a forget about your Volkswagen, we deserve Velorex here.

This is simplified version of valgrind support in tests with suppression file.

Still work in progress, but already shows some issues - some test are not working, and there are several tests that reports something that does looks correct.

No cleanup removal used.

Oncle cleared, I would suggest similar suppression file to users that watn to run Valgrind
(I used it myself, see https://gitlab.com/cryptsetup/cryptsetup/-/merge_requests/882)

For discussion @bob-beck @nhorman @Sashan 
