### PR TITLE
Add disabled-optimization and pointer-arith to compiler warnings

### DIFF
--- a/Configure
+++ b/Configure
@@ -181,6 +181,8 @@ my @gcc_devteam_warn = qw(
     -Werror
     -Wmissing-prototypes
     -Wstrict-prototypes
+    -Wdisabled-optimization
+    -Wpointer-arith
 );
 
 # These are used in addition to $gcc_devteam_warn when the compiler is clang.


### PR DESCRIPTION
Another trivia:

These flags seems not to be part of -Wextra, but looks like could be useful in CI. According to gcc man page:

 disabled-optimization
  Warn if a requested optimization pass is disabled.

 pointer-arith
  Warn about anything that depends on the "size of" a function type or of "void".

Fixes: https://github.com/openssl/project/issues/1809

p.s.
note to myself: to check what is in -Wall and -Wextra for gcc, use ``gcc -Wall -Wextra -Q --help=warnings``
