### PR TITLE
DTLS 1.3 ACK test cleanup

### DIFF
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -752,7 +752,6 @@ sub seen_session_ticket_ack
 {
     my $self = shift;
     my $record = shift;
-    my $start_time = time();
 
     my $ack_hash = $self->{saw_session_ticket_ack};
     return if !$self->{saw_session_ticket} || scalar(keys %{$ack_hash}) == 2;

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -570,7 +570,6 @@ sub clientstart
         if ($self->{isdtls} && $self->is_tls13()) {
             my $alert_message = $self->construct_alert_message($self->{client_epoch}, $self->{client_sequence_number} + 1);
             $server_sock->syswrite($alert_message) or warn "Failed to send close_notify alert: $!\n";
-            sleep(1);
         }
         $server_sock->close();
         $self->{server_sock} = undef;
@@ -581,7 +580,6 @@ sub clientstart
         if ($self->{isdtls} && $self->is_tls13() && defined($self->{sessionfile})) {
             my $alert_message = $self->construct_alert_message($self->{server_epoch}, $self->{server_sequence_number} + 1);
             $client_sock->syswrite($alert_message) or warn "Failed to send close_notify alert: $!\n";
-            sleep(1);
         }
 
         #Closing this also kills the child process


### PR DESCRIPTION
The DTLS1.3 ACK test is flaky. Usually when you run it the client sends the "test" data before processing the Server's NewSessionTicket. Though in scenarios when the client process the NewSessionTicket and send the ACK for it before sending the "test" data we will end up exiting the test before seeing the second NewSessionTicket and the corresponding ACK.

I updated the code to check for the two NewSessionTicket ACKs to wait for two unique NewSessionTicket ACK messages. I believe what was happening is the one ACK message was being counted twice thus breaking the test.

Fixes: openssl/project#1806

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
