### PR TITLE
Remove TEST_strn2_ functions

### DIFF
--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -33,8 +33,8 @@ OSSL_provider_init_fn ossl_legacy_provider_init;
 /* Extended test macros to allow passing file & line number */
 #define TEST_FL_ptr(a) test_ptr(file, line, #a, a)
 #define TEST_FL_mem_eq(a, m, b, n) test_mem_eq(file, line, #a, #b, a, m, b, n)
-#define TEST_FL_strn_eq(a, b, n) test_strn_eq(file, line, #a, #b, a, n, b, n)
-#define TEST_FL_strn2_eq(a, m, b, n) test_strn_eq(file, line, #a, #b, a, m, b, n)
+#define TEST_FL_strn_eq(a, b, n) test_strn_eq(file, line, #a, #b, a, b, n)
+#define TEST_FL_size_t_eq(a, b) test_size_t_eq(file, line, #a, #b, a, b)
 #define TEST_FL_int_eq(a, b) test_int_eq(file, line, #a, #b, a, b)
 #define TEST_FL_int_ge(a, b) test_int_ge(file, line, #a, #b, a, b)
 #define TEST_FL_int_gt(a, b) test_int_gt(file, line, #a, #b, a, b)
@@ -507,7 +507,8 @@ static int test_text(const char *file, const int line,
     const void *data1, size_t data1_len,
     const void *data2, size_t data2_len)
 {
-    return TEST_FL_strn2_eq(data1, data1_len, data2, data2_len);
+    return TEST_FL_size_t_eq(data1_len, data2_len)
+        && TEST_FL_strn_eq(data1, data2, data1_len);
 }
 
 static int test_mem(const char *file, const int line,

--- a/test/endecoder_legacy_test.c
+++ b/test/endecoder_legacy_test.c
@@ -293,8 +293,8 @@ static int test_membio_str_eq(BIO *bio_provided, BIO *bio_legacy)
 
     return TEST_long_ge(len_legacy, 0)
         && TEST_long_ge(len_provided, 0)
-        && TEST_strn2_eq(str_provided, len_provided,
-            str_legacy, len_legacy);
+        && TEST_size_t_eq(len_provided, len_legacy)
+        && TEST_strn_eq(str_provided, str_legacy, len_provided);
 }
 
 static int test_protected_PEM(const char *keytype, int evp_type,

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -355,9 +355,9 @@ DECLARE_COMPARISON(char *, str, ne)
  * Same as above, but for strncmp.
  */
 int test_strn_eq(const char *file, int line, const char *, const char *,
-    const char *a, size_t an, const char *b, size_t bn);
+    const char *a, const char *b, size_t n);
 int test_strn_ne(const char *file, int line, const char *, const char *,
-    const char *a, size_t an, const char *b, size_t bn);
+    const char *a, const char *b, size_t n);
 
 /*
  * Equality test for memory blocks where NULL is a legitimate value.
@@ -511,10 +511,8 @@ void test_perror(const char *s);
 
 #define TEST_str_eq(a, b) test_str_eq(__FILE__, __LINE__, #a, #b, a, b)
 #define TEST_str_ne(a, b) test_str_ne(__FILE__, __LINE__, #a, #b, a, b)
-#define TEST_strn_eq(a, b, n) test_strn_eq(__FILE__, __LINE__, #a, #b, a, n, b, n)
-#define TEST_strn_ne(a, b, n) test_strn_ne(__FILE__, __LINE__, #a, #b, a, n, b, n)
-#define TEST_strn2_eq(a, m, b, n) test_strn_eq(__FILE__, __LINE__, #a, #b, a, m, b, n)
-#define TEST_strn2_ne(a, m, b, n) test_strn_ne(__FILE__, __LINE__, #a, #b, a, m, b, n)
+#define TEST_strn_eq(a, b, n) test_strn_eq(__FILE__, __LINE__, #a, #b, a, b, n)
+#define TEST_strn_ne(a, b, n) test_strn_ne(__FILE__, __LINE__, #a, #b, a, b, n)
 
 #define TEST_mem_eq(a, m, b, n) test_mem_eq(__FILE__, __LINE__, #a, #b, a, m, b, n)
 #define TEST_mem_ne(a, m, b, n) test_mem_ne(__FILE__, __LINE__, #a, #b, a, m, b, n)

--- a/test/testutil/tests.c
+++ b/test/testutil/tests.c
@@ -302,28 +302,28 @@ int test_str_ne(const char *file, int line, const char *st1, const char *st2,
 }
 
 int test_strn_eq(const char *file, int line, const char *st1, const char *st2,
-    const char *s1, size_t n1, const char *s2, size_t n2)
+    const char *s1, const char *s2, size_t n)
 {
     if (s1 == NULL && s2 == NULL)
         return 1;
-    if (n1 != n2 || s1 == NULL || s2 == NULL || strncmp(s1, s2, n1) != 0) {
+    if (s1 == NULL || s2 == NULL || strncmp(s1, s2, n) != 0) {
         test_fail_string_message(NULL, file, line, "string", st1, st2, "==",
-            s1, s1 == NULL ? 0 : OPENSSL_strnlen(s1, n1),
-            s2, s2 == NULL ? 0 : OPENSSL_strnlen(s2, n2));
+            s1, s1 == NULL ? 0 : OPENSSL_strnlen(s1, n),
+            s2, s2 == NULL ? 0 : OPENSSL_strnlen(s2, n));
         return 0;
     }
     return 1;
 }
 
 int test_strn_ne(const char *file, int line, const char *st1, const char *st2,
-    const char *s1, size_t n1, const char *s2, size_t n2)
+    const char *s1, const char *s2, size_t n)
 {
     if ((s1 == NULL) ^ (s2 == NULL))
         return 1;
-    if (n1 != n2 || s1 == NULL || strncmp(s1, s2, n1) == 0) {
+    if (s1 == NULL || strncmp(s1, s2, n) == 0) {
         test_fail_string_message(NULL, file, line, "string", st1, st2, "!=",
-            s1, s1 == NULL ? 0 : OPENSSL_strnlen(s1, n1),
-            s2, s2 == NULL ? 0 : OPENSSL_strnlen(s2, n2));
+            s1, s1 == NULL ? 0 : OPENSSL_strnlen(s1, n),
+            s2, s2 == NULL ? 0 : OPENSSL_strnlen(s2, n));
         return 0;
     }
     return 1;

--- a/test/trace_api_test.c
+++ b/test/trace_api_test.c
@@ -147,7 +147,7 @@ static int test_trace_channel(void)
 
     ret = put_trace_output();
     len = BIO_get_mem_data(bio, &p_buf);
-    if (!TEST_strn2_eq(p_buf, len, expected, expected_len))
+    if (!TEST_size_t_eq(len, expected_len) || !TEST_strn_eq(p_buf, expected, len))
         ret = 0;
     ret = TEST_int_eq(OSSL_trace_set_channel(OSSL_TRACE_CATEGORY_HTTP, NULL), 1)
         && ret;


### PR DESCRIPTION
These functions are rarely used and the _ne flavour is unused.  Passing two lengths to a wrapper for `strncmp(3)` makes defining semantics rather tricky (especially in the _ne case).

Alternative to #29390

- [ ] documentation is added or updated
- [x] tests are added or updated
