### PR TITLE
Make OpenSSL generated error files use the current clang-format rules

### DIFF
--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -447,8 +447,8 @@ EOF
             }
         } else {
             print OUT <<"EOF";
-# define ${lib}err(f, r) ERR_${lib}_error(0, (r), OPENSSL_FILE, OPENSSL_LINE)
-# define ERR_R_${lib}_LIB ERR_${lib}_lib()
+#define ${lib}err(f, r) ERR_${lib}_error(0, (r), OPENSSL_FILE, OPENSSL_LINE)
+#define ERR_R_${lib}_LIB ERR_${lib}_lib()
 EOF
             if ( ! $static ) {
                 print OUT <<"EOF";


### PR DESCRIPTION
Anytime a new error code is added it generates error related files. These are generated using a perl script which used readable indenting. The indenting has been removed.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
