### PR TITLE
FIPS: Make ECDSA KAT DRBG robust against wall-clock changes

### DIFF
--- a/providers/fips/self_test_kats.c
+++ b/providers/fips/self_test_kats.c
@@ -987,6 +987,8 @@ static int set_kat_drbg(OSSL_LIB_CTX *ctx,
     EVP_RAND *rand;
     unsigned int strength = 256;
     EVP_RAND_CTX *parent_rand = NULL;
+    int reseed_time_interval = 0;
+    unsigned int reseed_requests = 0;
     OSSL_PARAM drbg_params[3] = {
         OSSL_PARAM_END, OSSL_PARAM_END, OSSL_PARAM_END
     };
@@ -1033,7 +1035,12 @@ static int set_kat_drbg(OSSL_LIB_CTX *ctx,
     EVP_RAND_CTX_free(parent_rand);
     parent_rand = NULL;
 
-    if (!EVP_RAND_instantiate(kat_rand, strength, 0, persstr, persstr_len, NULL))
+    /* Disable time/request based reseeding to make selftests deterministic */
+    drbg_params[0] = OSSL_PARAM_construct_int(OSSL_DRBG_PARAM_RESEED_TIME_INTERVAL,
+        &reseed_time_interval);
+    drbg_params[1] = OSSL_PARAM_construct_uint(OSSL_DRBG_PARAM_RESEED_REQUESTS,
+        &reseed_requests);
+    if (!EVP_RAND_instantiate(kat_rand, strength, 0, persstr, persstr_len, drbg_params))
         goto err;
 
     /* When we set the new private generator this one is freed, so upref it */


### PR DESCRIPTION
The ECDSA KAT_Signature selftest can fail if the system time changes after KAT DRBG initialization, this may trigger a time-based reseed and break KAT determinism.

Disable time-based reseeding for the KAT DRBG to avoid spurious selftest failures during e.g. fipsinstall.

----

This pull request is related to: https://github.com/openssl/openssl/issues/29632
