### PR TITLE
Fix changes test

### DIFF
--- a/.github/workflows/check-news-changes.yml
+++ b/.github/workflows/check-news-changes.yml
@@ -49,7 +49,7 @@ jobs:
         if: ${{ env.FOUND_NEWS_CHANGES_ADDITION == 'no' }}
         run: |
           set +e
-          grep -q "include\/openssl" ./names.txt
+          grep -q "include/openssl" ./names.txt
           if [ $? -eq 0 ]; then
             echo "Changes in this PR may impact public APIS's"
             echo "NEED_NEWS_CHANGES=yes" >> $GITHUB_ENV


### PR DESCRIPTION
Fix search pattern in check-news-changes CI job
    
The check for impacting a public api had an incorrect pattern in the
    search, leading to erroneous failures.  Fix it up.

##### Checklist
- [x] tests are added or updated
