### PR TITLE
Revert "fips-jitter: Force use jitter entropy in the FIPS 3.0.9 provider callback"

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -2456,7 +2456,6 @@ static void core_self_test_get_callback(OPENSSL_CORE_CTX *libctx,
     OSSL_SELF_TEST_get_callback((OSSL_LIB_CTX *)libctx, cb, cbarg);
 }
 
-#ifdef OPENSSL_NO_FIPS_JITTER
 static size_t rand_get_entropy(const OSSL_CORE_HANDLE *handle,
     unsigned char **pout, int entropy,
     size_t min_len, size_t max_len)
@@ -2464,31 +2463,6 @@ static size_t rand_get_entropy(const OSSL_CORE_HANDLE *handle,
     return ossl_rand_get_entropy((OSSL_LIB_CTX *)core_get_libctx(handle),
         pout, entropy, min_len, max_len);
 }
-#else
-/*
- * OpenSSL FIPS providers prior to 3.2 call rand_get_entropy API from
- * core, instead of the newer get_user_entropy. Newer API call honors
- * runtime configuration of random seed source and can be configured
- * to use os getranom() or another seed source, such as
- * JITTER. However, 3.0.9 only calls this API. Note that no other
- * providers known to use this, and it is core <-> provider only
- * API. Public facing EVP and getrandom bytes already correctly honor
- * runtime configuration for seed source. There are no other providers
- * packaged in Wolfi, or even known to exist that use this api. Thus
- * it is safe to say any caller of this API is in fact 3.0.9 FIPS
- * provider. Also note that the passed in handle is invalid and cannot
- * be safely dereferences in such cases. Due to a bug in FIPS
- * providers 3.0.0, 3.0.8 and 3.0.9. See
- * https://github.com/openssl/openssl/blob/master/doc/internal/man3/ossl_rand_get_entropy.pod#notes
- */
-size_t ossl_rand_jitter_get_seed(unsigned char **, int, size_t, size_t);
-static size_t rand_get_entropy(const OSSL_CORE_HANDLE *handle,
-    unsigned char **pout, int entropy,
-    size_t min_len, size_t max_len)
-{
-    return ossl_rand_jitter_get_seed(pout, entropy, min_len, max_len);
-}
-#endif
 
 static size_t rand_get_user_entropy(const OSSL_CORE_HANDLE *handle,
     unsigned char **pout, int entropy,

--- a/providers/implementations/rands/seed_src_jitter.c
+++ b/providers/implementations/rands/seed_src_jitter.c
@@ -291,24 +291,6 @@ static size_t jitter_get_seed(void *vseed, unsigned char **pout,
     return ret;
 }
 
-#ifndef OPENSSL_NO_FIPS_JITTER
-size_t ossl_rand_jitter_get_seed(unsigned char **pout, int entropy, size_t min_len, size_t max_len)
-{
-    size_t ret = 0;
-    OSSL_PARAM params[1] = { OSSL_PARAM_END };
-    PROV_JITTER *s = jitter_new(NULL, NULL, NULL);
-
-    if (s == NULL)
-        return ret;
-    if (!jitter_instantiate(s, 0, 0, NULL, 0, params))
-        goto end;
-    ret = jitter_get_seed(s, pout, entropy, min_len, max_len, 0, NULL, 0);
-end:
-    jitter_free(s);
-    return ret;
-}
-#endif
-
 static void jitter_clear_seed(ossl_unused void *vdrbg,
     unsigned char *out, size_t outlen)
 {


### PR DESCRIPTION
This reverts commit aa5f1b4cf562d7f0b65ae7ef93179ebc1102fbeb.

Whilst this is still useful with pre-3.2 providers, it is actually unlikely to be deployed. And there are now openssl fips providers getting validated with statically linked jitterentropy source already.

See background info at:
- https://github.com/openssl/openssl/pull/25930

Fixes: https://github.com/openssl/openssl/issues/26903
