### PR TITLE
Added SSL_CTX_get0_alpn_protos() and SSL_get0_alpn_protos()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -93,6 +93,10 @@ OpenSSL 4.0
 
    *Igor Ustinov*
 
+ * Added SSL_CTX_get0_alpn_protos() and SSL_get0_alpn_protos().
+
+   *Daniel Kubec*
+
  * Enabled Server verification by default in `s_server` when option
    verify_return_error is enabled.
 

--- a/doc/man3/SSL_CTX_set_alpn_select_cb.pod
+++ b/doc/man3/SSL_CTX_set_alpn_select_cb.pod
@@ -2,7 +2,8 @@
 
 =head1 NAME
 
-SSL_CTX_set_alpn_protos, SSL_set_alpn_protos, SSL_CTX_set_alpn_select_cb,
+SSL_CTX_set_alpn_protos, SSL_set_alpn_protos, SSL_CTX_get0_alpn_protos,
+SSL_get0_alpn_protos, SSL_CTX_set_alpn_select_cb,
 SSL_CTX_set_next_proto_select_cb, SSL_CTX_set_next_protos_advertised_cb,
 SSL_select_next_proto, SSL_get0_alpn_selected, SSL_get0_next_proto_negotiated
 - handle application layer protocol negotiation (ALPN)
@@ -47,6 +48,11 @@ SSL_select_next_proto, SSL_get0_alpn_selected, SSL_get0_next_proto_negotiated
  void SSL_get0_next_proto_negotiated(const SSL *s, const unsigned char **data,
                              unsigned *len);
 
+ void SSL_CTX_get0_alpn_protos(SSL_CTX *ctx, const unsigned char **protos,
+    unsigned int *protos_len);
+ void SSL_get0_alpn_protos(SSL *ssl, const unsigned char **protos,
+    unsigned int *protos_len);
+
 =head1 DESCRIPTION
 
 SSL_CTX_set_alpn_protos() and SSL_set_alpn_protos() are used by the client to
@@ -54,6 +60,12 @@ set the list of protocols available to be negotiated. The B<protos> must be in
 protocol-list format, described below. The length of B<protos> is specified in
 B<protos_len>. Setting B<protos_len> to 0 clears any existing list of ALPN
 protocols and no ALPN extension will be sent to the server.
+
+SSL_CTX_get0_alpn_protos() and SSL_get0_alpn_protos() are used by the client to
+get the list of protocols available to be negotiated. The B<protos> are in
+protocol-list format, described below. Returns a pointer to protocol list in
+B<protos> with length B<protos_len>. It is not NUL-terminated. B<protos> must
+not be freed.
 
 SSL_CTX_set_alpn_select_cb() sets the application callback B<cb> used by a
 server to select which protocol to use for the incoming connection. When B<cb>

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -825,6 +825,10 @@ void SSL_CTX_set_alpn_select_cb(SSL_CTX *ctx,
     void *arg);
 void SSL_get0_alpn_selected(const SSL *ssl, const unsigned char **data,
     unsigned int *len);
+void SSL_CTX_get0_alpn_protos(SSL_CTX *ctx, const unsigned char **protos,
+    unsigned int *protos_len);
+void SSL_get0_alpn_protos(SSL *ssl, const unsigned char **protos,
+    unsigned int *protos_len);
 
 #ifndef OPENSSL_NO_PSK
 /*

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3772,6 +3772,47 @@ int SSL_set_alpn_protos(SSL *ssl, const unsigned char *protos,
 }
 
 /*
+ * SSL_CTX_set_get0_protos gets the ALPN protocol list on |ctx| to |protos|.
+ */
+void SSL_CTX_get0_alpn_protos(SSL_CTX *ctx, const unsigned char **protos,
+    unsigned int *protos_len)
+{
+    unsigned char *p = NULL;
+    unsigned int len = 0;
+
+    if (ctx != NULL) {
+        p = ctx->ext.alpn;
+        len = (unsigned int)ctx->ext.alpn_len;
+    }
+
+    if (protos != NULL)
+        *protos = p;
+    if (protos_len != NULL)
+        *protos_len = len;
+}
+
+/*
+ * SSL_get0_alpn_protos gets the ALPN protocol list on |ssl| to |protos|.
+ */
+void SSL_get0_alpn_protos(SSL *ssl, const unsigned char **protos,
+    unsigned int *protos_len)
+{
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(ssl);
+    unsigned char *p = NULL;
+    unsigned int len = 0;
+
+    if (sc != NULL) {
+        p = sc->ext.alpn;
+        len = (unsigned int)sc->ext.alpn_len;
+    }
+
+    if (protos != NULL)
+        *protos = p;
+    if (protos_len != NULL)
+        *protos_len = len;
+}
+
+/*
  * SSL_CTX_set_alpn_select_cb sets a callback function on |ctx| that is
  * called during ClientHello processing in order to select an ALPN protocol
  * from the client's list of offered protocols.

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -54,6 +54,8 @@ SSL_get0_next_proto_negotiated          ?	4_0_0	EXIST::FUNCTION:NEXTPROTONEG
 SSL_select_next_proto                   ?	4_0_0	EXIST::FUNCTION:
 SSL_CTX_set_alpn_protos                 ?	4_0_0	EXIST::FUNCTION:
 SSL_set_alpn_protos                     ?	4_0_0	EXIST::FUNCTION:
+SSL_CTX_get0_alpn_protos                ?	4_0_0	EXIST::FUNCTION:
+SSL_get0_alpn_protos                    ?	4_0_0	EXIST::FUNCTION:
 SSL_CTX_set_alpn_select_cb              ?	4_0_0	EXIST::FUNCTION:
 SSL_get0_alpn_selected                  ?	4_0_0	EXIST::FUNCTION:
 SSL_CTX_set_psk_client_callback         ?	4_0_0	EXIST::FUNCTION:PSK


### PR DESCRIPTION
Added useful SSL_CTX_get0_alpn_protos() and SSL_get0_alpn_protos().

Normally I would use size_t for length, but here I prioritize the consistency. I think I only violated that by checking for NULL parameters, which is proper for public functions. Maybe in the next small PR I'll add similar checks to the surrounding functions.

Fixes #4952
