### PR TITLE
Fix `use-of-uninitialized-value` in `p12_decr.c`

### DIFF
--- a/crypto/pkcs12/p12_decr.c
+++ b/crypto/pkcs12/p12_decr.c
@@ -77,7 +77,7 @@ unsigned char *PKCS12_pbe_crypt_ex(const X509_ALGOR *algor,
         }
     }
 
-    if ((out = OPENSSL_malloc(max_out_len)) == NULL)
+    if ((out = OPENSSL_zalloc(max_out_len)) == NULL)
         goto err;
 
     if (!EVP_CipherUpdate(ctx, out, &i, in, inlen)) {


### PR DESCRIPTION
The following issue was found in a memory sanitizer build of ClickHouse (which uses OpenSSL 3.5.4, from this [commit](https://github.com/ClickHouse/openssl/tree/ClickHouse/openssl-3.5.4)).

The affected method is `ossl_epki2pki_der_decode` in `decode_epki2pki.c`.
We seem to initialize less bytes in `PKCS12_pbe_crypt_ex` (by `EVP_CipherUpdate` and `EVP_CipherUpdate_ex`) than later accessed by `d2i_PKCS8_PRIV_KEY_INFO`, leading to use of an uninitialized value. 

```
==1155903==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x5571e03fe712 in ASN1_get_object cmake-build-release-msan/./contrib/openssl/crypto/asn1/asn1_lib.c:62:11
    #1 0x5571e0408981 in asn1_check_tlen cmake-build-release-msan/./contrib/openssl/crypto/asn1/tasn_dec.c:1164:13
    #2 0x5571e04048c8 in asn1_item_embed_d2i cmake-build-release-msan/./contrib/openssl/crypto/asn1/tasn_dec.c:346:15
    #3 0x5571e04043ba in asn1_item_ex_d2i_intern cmake-build-release-msan/./contrib/openssl/crypto/asn1/tasn_dec.c:118:10
    #4 0x5571e04043ba in ASN1_item_d2i_ex cmake-build-release-msan/./contrib/openssl/crypto/asn1/tasn_dec.c:144:9
    #5 0x5571e04043ba in ASN1_item_d2i cmake-build-release-msan/./contrib/openssl/crypto/asn1/tasn_dec.c:154:12
    #6 0x5571e08460ad in ossl_epki2pki_der_decode cmake-build-release-msan/./contrib/openssl/providers/implementations/encode_decode/decode_epki2pki.c:161:13
    #7 0x5571e084c5a3 in pem2der_decode cmake-build-release-msan/./contrib/openssl/providers/implementations/encode_decode/decode_pem2der.c:227:18
    #8 0x5571e053827e in decoder_process cmake-build-release-msan/./contrib/openssl/crypto/encode_decode/decoder_lib.c:1101:14
    #9 0x5571e0537016 in OSSL_DECODER_from_bio cmake-build-release-msan/./contrib/openssl/crypto/encode_decode/decoder_lib.c:82:10
    #10 0x5571e067f5c4 in pem_read_bio_key_decoder cmake-build-release-msan/./contrib/openssl/crypto/pem/pem_pkey.c:60:13
    #11 0x5571e067f5c4 in pem_read_bio_key cmake-build-release-msan/./contrib/openssl/crypto/pem/pem_pkey.c:241:11
    #12 0x5571e06801d3 in PEM_read_bio_PrivateKey_ex cmake-build-release-msan/./contrib/openssl/crypto/pem/pem_pkey.c:304:12
    #13 0x5571e0350beb in SSL_CTX_use_PrivateKey_file cmake-build-release-msan/./contrib/openssl/ssl/ssl_rsa.c:415:16
    #14 0x5571dd4dfa6a in Poco::Net::Context::init(Poco::Net::Context::Params const&) cmake-build-release-msan/./base/poco/NetSSL_OpenSSL/src/Context.cpp:296:14
    #15 0x5571dd4deb28 in Poco::Net::Context::Context(Poco::Net::Context::Usage, Poco::Net::Context::Params const&) cmake-build-release-msan/./base/poco/NetSSL_OpenSSL/src/Context.cpp:54:2
    #16 0x5571dd4f5c2d in Poco::Net::SSLManager::initDefaultContext(bool) cmake-build-release-msan/./base/poco/NetSSL_OpenSSL/src/SSLManager.cpp:287:34
    #17 0x5571dd4f220b in Poco::Net::SSLManager::defaultServerContext() cmake-build-release-msan/./base/poco/NetSSL_OpenSSL/src/SSLManager.cpp:125:3
    #18 0x5571cf03e24e in DB::CertificateReloader::findOrInsert(ssl_ctx_st*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) cmake-build-release-msan/./src/Server/CertificateReloader.cpp:134:57
    #19 0x5571cf038968 in DB::CertificateReloader::tryLoadImpl(Poco::Util::AbstractConfiguration const&, ssl_ctx_st*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) cmake-build-release-msan/./src/Server/CertificateReloader.cpp:202:19
    #20 0x5571cf0377be in DB::CertificateReloader::tryLoad(Poco::Util::AbstractConfiguration const&, ssl_ctx_st*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) cmake-build-release-msan/./src/Server/CertificateReloader.cpp:117:5
    #21 0x5571cf0377be in DB::CertificateReloader::tryLoad(Poco::Util::AbstractConfiguration const&) cmake-build-release-msan/./src/Server/CertificateReloader.cpp:104:5
    #22 0x5571a6dd25b6 in DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) cmake-build-release-msan/./programs/server/Server.cpp:2548:37
    #23 0x5571dd55924b in Poco::Util::Application::run() cmake-build-release-msan/./base/poco/Util/src/Application.cpp:315:8
    #24 0x5571a6d7be66 in DB::Server::run() cmake-build-release-msan/./programs/server/Server.cpp:660:25
    #25 0x5571dd5a373a in Poco::Util::ServerApplication::run(int, char**) cmake-build-release-msan/./base/poco/Util/src/ServerApplication.cpp:131:9
    #26 0x5571a6d73b43 in mainEntryClickHouseServer(int, char**) cmake-build-release-msan/./programs/server/Server.cpp:447:20
    #27 0x55718152671d in main cmake-build-release-msan/./programs/main.cpp:380:21
    #28 0x7feb2b627634 in __libc_start_call_main /usr/src/debug/glibc/glibc/csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #29 0x7feb2b6276e8 in __libc_start_main /usr/src/debug/glibc/glibc/csu/../csu/libc-start.c:360:3
    #30 0x55718148ce6d in _start (/home/thevar1able/nvmemount/clickhouse/cmake-build-release-msan/programs/clickhouse+0xa889e6d) (BuildId: 0ab37401c8c27a02d94eb81b9cc50d79736b4266)
```

```
  Uninitialized value was created by a heap allocation
    #0 0x55718151d58d in malloc (/home/thevar1able/nvmemount/clickhouse/cmake-build-release-msan/programs/clickhouse+0xa91a58d) (BuildId: 0ab37401c8c27a02d94eb81b9cc50d79736b4266)
    #1 0x5571e0634a19 in CRYPTO_malloc cmake-build-release-msan/./contrib/openssl/crypto/mem.c:211:11
    #2 0x5571e06840ef in PKCS12_pbe_crypt_ex cmake-build-release-msan/./contrib/openssl/crypto/pkcs12/p12_decr.c:78:16
    #3 0x5571e0845f0a in ossl_epki2pki_der_decode cmake-build-release-msan/./contrib/openssl/providers/implementations/encode_decode/decode_epki2pki.c:143:18
    #4 0x5571e084c5a3 in pem2der_decode cmake-build-release-msan/./contrib/openssl/providers/implementations/encode_decode/decode_pem2der.c:227:18
    #5 0x5571e053827e in decoder_process cmake-build-release-msan/./contrib/openssl/crypto/encode_decode/decoder_lib.c:1101:14
    #6 0x5571e0537016 in OSSL_DECODER_from_bio cmake-build-release-msan/./contrib/openssl/crypto/encode_decode/decoder_lib.c:82:10
    #7 0x5571e067f5c4 in pem_read_bio_key_decoder cmake-build-release-msan/./contrib/openssl/crypto/pem/pem_pkey.c:60:13
    #8 0x5571e067f5c4 in pem_read_bio_key cmake-build-release-msan/./contrib/openssl/crypto/pem/pem_pkey.c:241:11
    #9 0x5571e06801d3 in PEM_read_bio_PrivateKey_ex cmake-build-release-msan/./contrib/openssl/crypto/pem/pem_pkey.c:304:12
    #10 0x5571e0350beb in SSL_CTX_use_PrivateKey_file cmake-build-release-msan/./contrib/openssl/ssl/ssl_rsa.c:415:16
    #11 0x5571dd4dfa6a in Poco::Net::Context::init(Poco::Net::Context::Params const&) cmake-build-release-msan/./base/poco/NetSSL_OpenSSL/src/Context.cpp:296:14
    #12 0x5571dd4deb28 in Poco::Net::Context::Context(Poco::Net::Context::Usage, Poco::Net::Context::Params const&) cmake-build-release-msan/./base/poco/NetSSL_OpenSSL/src/Context.cpp:54:2
    #13 0x5571dd4f5c2d in Poco::Net::SSLManager::initDefaultContext(bool) cmake-build-release-msan/./base/poco/NetSSL_OpenSSL/src/SSLManager.cpp:287:34
    #14 0x5571dd4f220b in Poco::Net::SSLManager::defaultServerContext() cmake-build-release-msan/./base/poco/NetSSL_OpenSSL/src/SSLManager.cpp:125:3
    #15 0x5571cf03e24e in DB::CertificateReloader::findOrInsert(ssl_ctx_st*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) cmake-build-release-msan/./src/Server/CertificateReloader.cpp:134:57
    #16 0x5571cf038968 in DB::CertificateReloader::tryLoadImpl(Poco::Util::AbstractConfiguration const&, ssl_ctx_st*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) cmake-build-release-msan/./src/Server/CertificateReloader.cpp:202:19
    #17 0x5571cf0377be in DB::CertificateReloader::tryLoad(Poco::Util::AbstractConfiguration const&, ssl_ctx_st*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) cmake-build-release-msan/./src/Server/CertificateReloader.cpp:117:5
    #18 0x5571cf0377be in DB::CertificateReloader::tryLoad(Poco::Util::AbstractConfiguration const&) cmake-build-release-msan/./src/Server/CertificateReloader.cpp:104:5
    #19 0x5571a6dd25b6 in DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) cmake-build-release-msan/./programs/server/Server.cpp:2548:37
    #20 0x5571dd55924b in Poco::Util::Application::run() cmake-build-release-msan/./base/poco/Util/src/Application.cpp:315:8
    #21 0x5571a6d7be66 in DB::Server::run() cmake-build-release-msan/./programs/server/Server.cpp:660:25
```

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
