### PR TITLE
Fix `EVP_KEYMGMT` leak in `evp_pkey_signature_init()` error paths

### DIFF
--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -641,7 +641,8 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, EVP_SIGNATURE *signature,
                     break;
             if (*keytypes == NULL) {
                 ERR_raise(ERR_LIB_EVP, EVP_R_SIGNATURE_TYPE_AND_KEY_TYPE_INCOMPATIBLE);
-                return -2;
+                ret = -2;
+                goto end;
             }
         } else {
             /*
@@ -667,12 +668,13 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, EVP_SIGNATURE *signature,
             /* If none of the fallbacks helped, we're lost */
             if (!ok) {
                 ERR_raise(ERR_LIB_EVP, EVP_R_SIGNATURE_TYPE_AND_KEY_TYPE_INCOMPATIBLE);
-                return -2;
+                ret = -2;
+                goto end;
             }
         }
 
         if (!EVP_SIGNATURE_up_ref(signature))
-            return 0;
+            goto err;
     } else {
         /* Without a pre-fetched signature, it must be figured out somehow */
         ERR_set_mark();


### PR DESCRIPTION
When `EVP_PKEY_sign_init_ex2()` is called with a pre-fetched signature algorithm that is incompatible with the key type (e.g., ECDSA signature with an RSA key), the function leaks the `tmp_keymgmt` object due to early returns that bypass cleanup.

In `evp_pkey_signature_init()`, when a pre-fetched `EVP_SIGNATURE` is provided:

1. A `tmp_keymgmt` is fetched via `evp_keymgmt_fetch_from_prov()` and the key is exported to the provider
https://github.com/openssl/openssl/blob/84ee443446116b25030b23c0a0b5b1fe5479d987/crypto/evp/signature.c#L617-L622
2. If the signature/key type compatibility check fails, the function returns -2 directly at lines 644 or 670
https://github.com/openssl/openssl/blob/84ee443446116b25030b23c0a0b5b1fe5479d987/crypto/evp/signature.c#L642-L645
https://github.com/openssl/openssl/blob/84ee443446116b25030b23c0a0b5b1fe5479d987/crypto/evp/signature.c#L668-L671
3. If `EVP_SIGNATURE_up_ref()` fails, the function returns 0 directly at line 675
https://github.com/openssl/openssl/blob/84ee443446116b25030b23c0a0b5b1fe5479d987/crypto/evp/signature.c#L674-L675

All three of these early returns bypass the cleanup labels (`end:` and `err:`) where `EVP_KEYMGMT_free(tmp_keymgmt)` is called, causing the keymgmt's reference count to remain elevated and the object to never be freed.

To trigger the leak, you can compile & run the following program with ASan enabled:

```c
#include <stdio.h>
#include <string.h>
#include <openssl/evp.h>
#include <openssl/rsa.h>
#include <openssl/err.h>
#include <openssl/provider.h>

int main(void)
{
    OSSL_LIB_CTX *libctx = NULL;
    EVP_PKEY *rsa_key = NULL;
    EVP_PKEY_CTX *pkey_ctx = NULL;
    EVP_SIGNATURE *ecdsa_sig = NULL;
    int ret = 1;
    int iterations = 100;
    int i;

    /* Create a library context */
    libctx = OSSL_LIB_CTX_new();
    if (libctx == NULL)
        goto cleanup;

    /* Generate an RSA key */
    pkey_ctx = EVP_PKEY_CTX_new_from_name(libctx, "RSA", NULL);
    if (pkey_ctx == NULL)
        goto cleanup;

    if (EVP_PKEY_keygen_init(pkey_ctx) <= 0)
        goto cleanup;

    if (EVP_PKEY_CTX_set_rsa_keygen_bits(pkey_ctx, 2048) <= 0)
        goto cleanup;

    if (EVP_PKEY_keygen(pkey_ctx, &rsa_key) <= 0)
        goto cleanup;

    EVP_PKEY_CTX_free(pkey_ctx);
    pkey_ctx = NULL;

    /* Fetch ECDSA signature algorithm */
    ecdsa_sig = EVP_SIGNATURE_fetch(libctx, "ECDSA", NULL);
    if (ecdsa_sig == NULL)
        goto cleanup;

    for (i = 0; i < iterations; i++) {
        EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_from_pkey(libctx, rsa_key, NULL);
        if (ctx == NULL)
            goto cleanup;

        /*
         * Leak one EVP_KEYMGMT reference due to early return at line 670
         */
        int init_ret = EVP_PKEY_sign_init_ex2(ctx, ecdsa_sig, NULL);
        if (init_ret != -2)
            printf("   Iteration %d: Unexpected return value: %d (expected -2)\n", i, init_ret);

        EVP_PKEY_CTX_free(ctx);
    }

    ret = 0;

cleanup:
    EVP_PKEY_CTX_free(pkey_ctx);
    EVP_SIGNATURE_free(ecdsa_sig);
    EVP_PKEY_free(rsa_key);
    OSSL_LIB_CTX_free(libctx);
    return ret;
}
```

This will give:

```
=================================================================
==1710261==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 256 byte(s) in 1 object(s) allocated from:
    #0 0x7f69d80bf91f in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x56167a462480 in CRYPTO_malloc crypto/mem.c:214
    #2 0x56167a4624e3 in CRYPTO_zalloc crypto/mem.c:226
    #3 0x56167a7d6a0f in keymgmt_new crypto/evp/keymgmt_meth.c:34
    #4 0x56167a7d6cfd in keymgmt_from_algorithm crypto/evp/keymgmt_meth.c:75
    #5 0x56167a7b8de4 in construct_evp_method crypto/evp/evp_fetch.c:230
    #6 0x56167a7fe425 in ossl_method_construct_this crypto/core_fetch.c:110
    #7 0x56167a45a417 in algorithm_do_map crypto/core_algorithm.c:77
    #8 0x56167a45a89d in algorithm_do_this crypto/core_algorithm.c:122
    #9 0x56167a47cee5 in ossl_provider_doall_activated crypto/provider_core.c:1609
    #10 0x56167a45ac8a in ossl_algorithm_do_all crypto/core_algorithm.c:164
    #11 0x56167a7fe825 in ossl_method_construct crypto/core_fetch.c:157
    #12 0x56167a7b95c9 in inner_evp_generic_fetch crypto/evp/evp_fetch.c:333
    #13 0x56167a7b9b68 in evp_generic_fetch crypto/evp/evp_fetch.c:404
    #14 0x56167a7d7fbe in EVP_KEYMGMT_fetch crypto/evp/keymgmt_meth.c:283
    #15 0x56167a4493a8 in int_ctx_new crypto/evp/pmeth_lib.c:120
    #16 0x56167a449724 in EVP_PKEY_CTX_new_from_name crypto/evp/pmeth_lib.c:195
    #17 0x56167a43a8c8 in main .../test.c:24
    #18 0x7f69d7c29d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
....
SUMMARY: AddressSanitizer: 873 byte(s) leaked in 12 allocation(s).
```

Thanks for looking into this and we appreciate any feedback!