### PR TITLE
CI: Disable scheduled Fuzzing action in forks

### DIFF
--- a/.github/workflows/oss-fuzz.yml
+++ b/.github/workflows/oss-fuzz.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   Fuzzing:
+    if: github.event_name != 'schedule' || github.repository == 'openssl/openssl'
     runs-on: ubuntu-latest
     steps:
     - name: Clear unnecessary files


### PR DESCRIPTION
There is no reason to run it in forks.

Similar to 6e5ce1ebb5bac84043e4327caa467401973dafb8.