### PR TITLE
Fix type-limits and add this warning to default strict warnings

### DIFF
--- a/Configure
+++ b/Configure
@@ -176,7 +176,7 @@ my @gcc_devteam_warn = qw(
     -Wsign-compare
     -Wshadow
     -Wformat
-    -Wno-type-limits
+    -Wtype-limits
     -Wundef
     -Werror
     -Wmissing-prototypes

--- a/crypto/evp/encode.c
+++ b/crypto/evp/encode.c
@@ -451,7 +451,7 @@ int EVP_EncodeUpdate(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl,
 
 void EVP_EncodeFinal(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl)
 {
-    unsigned int ret = 0;
+    int ret = 0;
     int wrap_cnt = 0;
 
     if (ctx->num != 0) {


### PR DESCRIPTION
One mistake recently introduced in commit b6aed64e47b.

Fixes: https://github.com/openssl/project/issues/1815

