### PR TITLE
Add float-conversion to default strict warnings

### DIFF
--- a/Configure
+++ b/Configure
@@ -183,6 +183,7 @@ my @gcc_devteam_warn = qw(
     -Wstrict-prototypes
     -Wdisabled-optimization
     -Wpointer-arith
+    -Wfloat-conversion
 );
 
 # These are used in addition to $gcc_devteam_warn when the compiler is clang.

--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -479,10 +479,14 @@ static int test_default_ct_policy_eval_ctx_time_is_now(void)
     int success = 0;
     CT_POLICY_EVAL_CTX *ct_policy_ctx = CT_POLICY_EVAL_CTX_new();
     const time_t default_time = (time_t)(CT_POLICY_EVAL_CTX_get_time(ct_policy_ctx) / 1000);
-    const time_t time_tolerance = 600; /* 10 minutes */
+    const double time_tolerance = 600; /* 10 minutes */
+    double seconds;
 
-    if (!TEST_time_t_le(abs((int)difftime(time(NULL), default_time)),
-            time_tolerance))
+    seconds = difftime(time(NULL), default_time);
+    if (seconds < 0.0)
+        seconds = -seconds;
+
+    if (!TEST_double_le(seconds, time_tolerance))
         goto end;
 
     success = 1;


### PR DESCRIPTION
As discussed, bad-function-cast and conversion produces strange results.

Add at least float-conversion - Warn for implicit conversions that reduce the precision of a real value.

Also fix ct_test absolute value seconds calculation (without using math.h) and then converts is to time_t.
(n.b. this is not stricly needed for the relaxed warnings, but it is more readable)

Fixes: https://github.com/openssl/project/issues/1816
