### PR TITLE
Drop darwin-ppc{,64} targets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -109,9 +109,9 @@ OpenSSL 4.0
 
    *David von Oheimb*
 
- * Drop darwin-i386(-cc) targets from Configurations.
+ * Drop darwin-i386{,-cc} and darwin-ppc{,64}{,-cc} targets from Configurations.
 
-   *Daniel Kubec*
+   *Daniel Kubec and Eugene Syromiatnikov*
 
  * Added `-hmac-env` and `-hmac-stdin` options to openssl-dgst.
 

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1856,35 +1856,6 @@ my %targets = (
         shared_cflag     => "-fPIC",
         shared_extension => ".\$(SHLIB_VERSION_NUMBER).dylib",
     },
-    # Option "freeze" such as -std=gnu9x can't negatively interfere
-    # with future defaults for below two targets, because MacOS X
-    # for PPC has no future, it was discontinued by vendor in 2009.
-    "darwin8-ppc-cc" => {
-        inherit_from => [ "darwin-ppc" ],
-        disable => [ "async" ]
-    },
-    "darwin-ppc-cc" => { inherit_from => [ "darwin-ppc" ] }, # Historic alias
-    "darwin-ppc" => {
-        inherit_from     => [ "darwin-common" ],
-        cflags           => add("-arch ppc -std=gnu9x -Wa,-force_cpusubtype_ALL"),
-        lib_cppflags     => add("-DB_ENDIAN"),
-        shared_cflag     => add("-fno-common"),
-        asm_arch         => 'ppc32',
-        perlasm_scheme   => "osx32",
-    },
-    "darwin8-ppc64-cc" => {
-        inherit_from => [ "darwin64-ppc" ],
-        disable => [ "async" ]
-    },
-    "darwin64-ppc-cc" => { inherit_from => [ "darwin64-ppc" ] }, # Historic alias
-    "darwin64-ppc" => {
-        inherit_from     => [ "darwin-common" ],
-        cflags           => add("-arch ppc64 -std=gnu9x"),
-        lib_cppflags     => add("-DB_ENDIAN"),
-        bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
-        asm_arch         => 'ppc64',
-        perlasm_scheme   => "osx64",
-    },
     "darwin64-x86_64-cc" => { inherit_from => [ "darwin64-x86_64" ] }, # Historic alias
     "darwin64-x86_64" => {
         inherit_from     => [ "darwin-common" ],

--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -145,9 +145,6 @@ my $guess_patterns = [
       }
     ],
     [ 'Paragon.*?:.*',              'i860-intel-osf1' ],
-    [ 'Rhapsody:.*',                'ppc-apple-rhapsody' ],
-    [ 'Darwin:8.*?:.*?:Power.*',    'ppc-apple-darwin8' ],
-    [ 'Darwin:.*?:.*?:Power.*',     'ppc-apple-darwin' ],
     [ 'Darwin:.*',                  '${MACHINE}-apple-darwin' ],
     [ 'SunOS:5\..*',                '${MACHINE}-whatever-solaris2' ],
     [ 'SunOS:.*',                   '${MACHINE}-sun-sunos4' ],
@@ -489,39 +486,6 @@ WARNING! To build 64-bit package, do this:
 EOF
             maybe_abort();
             return { target => "irix-mips3" };
-        }
-      ],
-      [ 'ppc-apple-rhapsody',     { target => "rhapsody-ppc" } ],
-      [ 'ppc-apple-darwin8.*', 
-        sub {
-            my $KERNEL_BITS = $ENV{KERNEL_BITS} // '';
-            my $ISA64 = `sysctl -n hw.optional.64bitops 2>/dev/null`;
-            if ( $ISA64 == 1 && $KERNEL_BITS eq '' ) {
-                print <<EOF;
-WARNING! To build 64-bit package, do this:
-         $WHERE/Configure darwin8-ppc64-cc
-EOF
-                maybe_abort();
-            }
-            return { target => "darwin8-ppc64-cc" }
-                if $ISA64 == 1 && $KERNEL_BITS eq '64';
-            return { target => "darwin8-ppc-cc" };
-        }
-      ],
-      [ 'ppc-apple-darwin.*',
-        sub {
-            my $KERNEL_BITS = $ENV{KERNEL_BITS} // '';
-            my $ISA64 = `sysctl -n hw.optional.64bitops 2>/dev/null`;
-            if ( $ISA64 == 1 && $KERNEL_BITS eq '' ) {
-                print <<EOF;
-WARNING! To build 64-bit package, do this:
-         $WHERE/Configure darwin64-ppc-cc
-EOF
-                maybe_abort();
-            }
-            return { target => "darwin64-ppc" }
-                if $ISA64 == 1 && $KERNEL_BITS eq '64';
-            return { target => "darwin-ppc" };
         }
       ],
       [ 'x86_64-apple-darwin.*',


### PR DESCRIPTION
PowerPC support has been dropped in Mac OS X with the release of Mac OS X Lion (10.7) in 2010, and the last supporting release, Snow Leopard (10.6.x) is out of support since 2011.
Also remove Rhapsody (the Mac OS X precursor) targets.

Complements: https://github.com/openssl/openssl/pull/29653
Depends-on: https://github.com/openssl/openssl/pull/29653