### PR TITLE
fix: added missing conditional macro when disabling the SipHash algor…

### DIFF
--- a/apps/list.c
+++ b/apps/list.c
@@ -1436,6 +1436,9 @@ static void list_disabled(void)
 #ifdef OPENSSL_NO_DSA
     BIO_puts(bio_out, "DSA\n");
 #endif
+#ifdef OPENSSL_NO_SIPHASH
+    BIO_puts(bio_out, "SIPHASH\n");
+#endif
 #if defined(OPENSSL_NO_DTLS)
     BIO_puts(bio_out, "DTLS\n");
 #endif

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -494,8 +494,10 @@ static const OSSL_ALGORITHM deflt_signature[] = {
     { PROV_NAMES_ML_DSA_87, "provider=default", ossl_ml_dsa_87_signature_functions },
 #endif
     { PROV_NAMES_HMAC, "provider=default", ossl_mac_legacy_hmac_signature_functions },
+#ifndef OPENSSL_NO_SIPHASH
     { PROV_NAMES_SIPHASH, "provider=default",
         ossl_mac_legacy_siphash_signature_functions },
+#endif
 #ifndef OPENSSL_NO_POLY1305
     { PROV_NAMES_POLY1305, "provider=default",
         ossl_mac_legacy_poly1305_signature_functions },
@@ -613,8 +615,10 @@ static const OSSL_ALGORITHM deflt_keymgmt[] = {
         PROV_DESCS_SCRYPT_SIGN },
     { PROV_NAMES_HMAC, "provider=default", ossl_mac_legacy_keymgmt_functions,
         PROV_DESCS_HMAC_SIGN },
+#ifndef OPENSSL_NO_SIPHASH
     { PROV_NAMES_SIPHASH, "provider=default", ossl_mac_legacy_keymgmt_functions,
         PROV_DESCS_SIPHASH_SIGN },
+#endif
 #ifndef OPENSSL_NO_POLY1305
     { PROV_NAMES_POLY1305, "provider=default", ossl_mac_legacy_keymgmt_functions,
         PROV_DESCS_POLY1305_SIGN },

--- a/providers/implementations/include/prov/implementations.h
+++ b/providers/implementations/include/prov/implementations.h
@@ -274,7 +274,9 @@ extern const OSSL_DISPATCH ossl_kmac256_internal_functions[];
 #endif
 extern const OSSL_DISPATCH ossl_kmac128_functions[];
 extern const OSSL_DISPATCH ossl_kmac256_functions[];
+#ifndef OPENSSL_NO_SIPHASH
 extern const OSSL_DISPATCH ossl_siphash_functions[];
+#endif
 extern const OSSL_DISPATCH ossl_poly1305_functions[];
 
 /* KDFs / PRFs */


### PR DESCRIPTION
Fixes #29514

Makes me wonder if a lot of those are lurking in the codebase ? `OPENSSL_NO_ECDSA` ?
