### PR TITLE
doc/man3/BIO_read.pod: clarify BIO_puts() semantics a bit

### DIFF
--- a/doc/man3/BIO_read.pod
+++ b/doc/man3/BIO_read.pod
@@ -52,7 +52,9 @@ For implementing this, unfortunately the data needs to be read byte-by-byte.
 
 BIO_write() attempts to write I<len> bytes from I<buf> to BIO I<b>.
 
-BIO_puts() attempts to write a NUL-terminated string I<buf> to BIO I<b>.
+BIO_puts() attempts to write a NUL-terminated string I<buf> to BIO I<b>,
+without the terminating NUL byte and without appending '\n'
+(so, similar to fputs(3), and not puts(3)).
 
 =head1 RETURN VALUES
 


### PR DESCRIPTION
Mention that it doesn't write the terminating NUL byte (akin to the way fputs(3) is documented[1][2]), and that it does not append '\n', like puts(3) does.

[1] https://pubs.opengroup.org/onlinepubs/9699919799.2008edition/functions/fputs.html
[2] https://www.man7.org/linux/man-pages/man3/fputs.3.html

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
