### PR TITLE
crypto: x509: fix unreachable code in X509V3_get_section and X509V3_get_string

### DIFF
--- a/crypto/x509/v3_conf.c
+++ b/crypto/x509/v3_conf.c
@@ -399,9 +399,7 @@ char *X509V3_get_string(X509V3_CTX *ctx, const char *name, const char *section)
         ERR_raise(ERR_LIB_X509V3, X509V3_R_OPERATION_NOT_DEFINED);
         return NULL;
     }
-    if (ctx->db_meth->get_string)
-        return ctx->db_meth->get_string(ctx->db, name, section);
-    return NULL;
+    return ctx->db_meth->get_string(ctx->db, name, section);
 }
 
 STACK_OF(CONF_VALUE) *X509V3_get_section(X509V3_CTX *ctx, const char *section)
@@ -410,9 +408,7 @@ STACK_OF(CONF_VALUE) *X509V3_get_section(X509V3_CTX *ctx, const char *section)
         ERR_raise(ERR_LIB_X509V3, X509V3_R_OPERATION_NOT_DEFINED);
         return NULL;
     }
-    if (ctx->db_meth->get_section)
-        return ctx->db_meth->get_section(ctx->db, section);
-    return NULL;
+    return ctx->db_meth->get_section(ctx->db, section);
 }
 
 void X509V3_string_free(X509V3_CTX *ctx, char *str)


### PR DESCRIPTION
The functions X509V3_get_section() and X509V3_get_string() contain a redundant null check after an identical check has already guaranteed that the function pointer (ctx->db_meth->get_section / get_string) is non-NULL. As a result, the final 'return NULL;' statement is unreachable.

This change removes the redundant condition and the dead code, improving code clarity and eliminating warnings from static analyzers.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
