### PR TITLE
Don't leave a UAF trap for the verify callback.

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1392,6 +1392,8 @@ static int check_cert_crl(X509_STORE_CTX *ctx)
                 goto done;
         }
 
+        ctx->current_crl = NULL;
+
         /*
          * If reasons not updated we won't get anywhere by another iteration,
          * so exit loop.


### PR DESCRIPTION
While it saddens me to fix anything about it as I believe I am possibly the world's biggest hater of the verify callback,

I think this is obviously wrong. the callback is encouraged by tradition which makes it ok, to call things like the undocumented X509_STORE_CTX_get0_current_crl function to look at things and decide to log things, have side effects, or change the verifier behaviour by overriding ok.

If it does this with the free calls happening before the callback is invoked, ctx->current_crl may be handed to it after having been free'd.

While you do need a lot of prayer and clean living if you use the verifier callback, let's at least not go out of our way to feed a use after free condition to it.

Noticed while reviewing one of t8m's changes.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
