### PR TITLE
Correct alert when extended master secret support is dropped

### DIFF
--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -678,7 +678,7 @@ int ssl_get_prev_session(SSL_CONNECTION *s, CLIENTHELLO_MSG *hello)
     if (ret->flags & SSL_SESS_FLAG_EXTMS) {
         /* If old session includes extms, but new does not: abort handshake */
         if (!(s->s3.flags & TLS1_FLAGS_RECEIVED_EXTMS)) {
-            SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_INCONSISTENT_EXTMS);
+            SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE, SSL_R_INCONSISTENT_EXTMS);
             fatal = 1;
             goto err;
         }


### PR DESCRIPTION
When resuming session with the extended master secret support dropped we should use SSL_AD_HANDSHAKE_FAILURE instead of SSL_AD_ILLEGAL_PARAMETER according to the RFC7627 section 5.

Fixes #9791
