### PR TITLE
ossl_comp_zlib_init(): Fail if zlib cannot be loaded

### DIFF
--- a/crypto/comp/c_zlib.c
+++ b/crypto/comp/c_zlib.c
@@ -300,6 +300,8 @@ DEFINE_RUN_ONCE_STATIC(ossl_comp_zlib_init)
             ossl_comp_zlib_cleanup();
             return 0;
         }
+    } else {
+        return 0;
     }
 #endif
     return 1;


### PR DESCRIPTION
Fixes #23563

Also reported by Stanislav Fort (Aisle Research)
