### PR TITLE
Remove implicit truncation behaviour in ossl_i2c_ASN1_BIT_STRING

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -206,7 +206,9 @@ OpenSSL 4.0
    *Beat Bolli*
 
  * Added `ASN1_BIT_STRING_set1()` to set a bit string to a value including
-   the length in bytes and the number of unused bits.
+   the length in bytes and the number of unused bits. Internally,
+   'ASN1_BIT_STRING_set_bit()' has also been modified to keep the number of
+   unused bits correct when changing an ASN1_BIT_STRING.
 
    * Bob Beck *
 

--- a/crypto/asn1/asn1_local.h
+++ b/crypto/asn1/asn1_local.h
@@ -78,7 +78,7 @@ void ossl_asn1_template_free(ASN1_VALUE **pval, const ASN1_TEMPLATE *tt);
 
 ASN1_OBJECT *ossl_c2i_ASN1_OBJECT(ASN1_OBJECT **a, const unsigned char **pp,
     long length);
-int ossl_i2c_ASN1_BIT_STRING(ASN1_BIT_STRING *a, unsigned char **pp);
+int ossl_i2c_ASN1_BIT_STRING(const ASN1_BIT_STRING *a, unsigned char **pp);
 ASN1_BIT_STRING *ossl_c2i_ASN1_BIT_STRING(ASN1_BIT_STRING **a,
     const unsigned char **pp, long length);
 int ossl_i2c_ASN1_INTEGER(ASN1_INTEGER *a, unsigned char **pp);

--- a/crypto/asn1/tasn_enc.c
+++ b/crypto/asn1/tasn_enc.c
@@ -590,7 +590,7 @@ static int asn1_ex_i2c(const ASN1_VALUE **pval, unsigned char *cout, int *putype
         break;
 
     case V_ASN1_BIT_STRING:
-        return ossl_i2c_ASN1_BIT_STRING((ASN1_BIT_STRING *)*pval,
+        return ossl_i2c_ASN1_BIT_STRING((const ASN1_BIT_STRING *)*pval,
             cout ? &cout : NULL);
 
     case V_ASN1_INTEGER:


### PR DESCRIPTION
and make ASN1_BIT_STRING_set_bit compute the unused bits of the  BIT_STRING.
    
The implicit trunction behaviour allows you to set a value without
keeping the unused bits consistent, using ASN1_STRING_set, and then
have it magically "fixed" to account for the unused bits in the last
octet on output.

As it turns out, after much searching, nothing is using this behavior,
  
As we now have the new ASN1_BIT_STRING_set1 to set the entire value
and keep the unused bits correct, we make ASN1_BIT_STRING_set_bit
also do the same. Now that both the setters change the object
correctly we remove the implicit trunctation in ossl_i2x_ASN1_BIT_STRING
and make the provided BIT_STRING argument const.

See discussion in https://github.com/openssl/openssl/issues/29185 and in https://github.com/openssl/openssl/issues/29117

For https://github.com/openssl/openssl/issues/29117
Why not pile onto #30095 too, since github has decided to suck about issues..


<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
