### PR TITLE
Remove disabled-optimization warning again

### DIFF
--- a/Configure
+++ b/Configure
@@ -180,7 +180,6 @@ my @gcc_devteam_warn = qw(
     -Werror
     -Wmissing-prototypes
     -Wstrict-prototypes
-    -Wdisabled-optimization
     -Wpointer-arith
     -Wfloat-conversion
 );


### PR DESCRIPTION
This warning des not play well in combination with sanitizers and its value is dubious. Instead of complicated decisions based on configuration flags just remove it from global list.

Fixes: #29673
