### PR TITLE
ASN1: Fix type handling in AKID serial number conversion

### DIFF
--- a/crypto/x509/v3_akid.c
+++ b/crypto/x509/v3_akid.c
@@ -66,7 +66,8 @@ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
         extlist = tmpextlist;
     }
     if (akeyid->serial) {
-        tmp = i2s_ASN1_OCTET_STRING(NULL, akeyid->serial);
+        tmp = i2s_ASN1_INTEGER(NULL, akeyid->serial);
+
         if (tmp == NULL) {
             ERR_raise(ERR_LIB_X509V3, ERR_R_ASN1_LIB);
             goto err;


### PR DESCRIPTION
The Authority Key Identifier's serial number field is an ASN1_INTEGER, so use the appropriate i2s_ASN1_INTEGER function instead of i2s_ASN1_OCTET_STRING for string conversion. This fixes handling of negative serial numbers which were previously displayed incorrectly.

While negative serial numbers are not RFC-compliant, we want to process existing CRLs and certificates that may contain them, as this does not cause any security issues. Rejecting invalid serial numbers during generation is out of scope for this change.

Fixes #27406