### PR TITLE
test/quic-openssl-docker/Dockerfile: Pin curl to last version supporting OpenSSL QUIC

### DIFF
--- a/test/quic-openssl-docker/Dockerfile
+++ b/test/quic-openssl-docker/Dockerfile
@@ -7,6 +7,8 @@ ENV LD_LIBRARY_PATH=/usr/lib64:/usr/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PA
 # The branch of openssl to clone
 ARG OPENSSL_URL=https://github.com/openssl/openssl.git
 ARG OPENSSL_BRANCH=master
+# The version of curl to clone
+ARG CURL_VERSION=curl-8_18_0
 
 # Install needed tools
 RUN apt-get update && apt-get install -y \
@@ -35,7 +37,7 @@ RUN git clone --depth 1 -b $OPENSSL_BRANCH $OPENSSL_URL && \
     rm -rf /openssl
 
 # Build curl
-RUN git clone --depth 1 https://github.com/curl/curl.git && \
+RUN git clone --depth 1 -b $CURL_VERSION https://github.com/curl/curl.git && \
     cd curl && \
     autoreconf -fi && ./configure --with-openssl-quic --with-openssl --with-nghttp3 --prefix=/usr && \
     make -j 4 && \


### PR DESCRIPTION
curl has dropped its experimental support for OpenSSL's QUIC implementation: curl/curl#20226

In the "Run openssl quic interop testing" workflow, [the "update_quay_container" job fails](https://github.com/openssl/openssl/actions/runs/21234753543/job/61100224586#step:4:8974) because curl is not pinned to a fixed version but rather cloned from master.

This PR pins the curl version to the last release that still supports OpenSSL QUIC through the `—with-openssl-quic` flag.