### PR TITLE
[3.3] Revert "rsa_sig.c: Properly duplicate the sig member"

### DIFF
--- a/providers/implementations/signature/rsa_sig.c
+++ b/providers/implementations/signature/rsa_sig.c
@@ -1021,7 +1021,6 @@ static void *rsa_dupctx(void *vprsactx)
     dstctx->mdctx = NULL;
     dstctx->tbuf = NULL;
     dstctx->propq = NULL;
-    dstctx->sig = NULL;
 
     if (srcctx->rsa != NULL && !RSA_up_ref(srcctx->rsa))
         goto err;
@@ -1045,12 +1044,6 @@ static void *rsa_dupctx(void *vprsactx)
     if (srcctx->propq != NULL) {
         dstctx->propq = OPENSSL_strdup(srcctx->propq);
         if (dstctx->propq == NULL)
-            goto err;
-    }
-
-    if (srcctx->sig != NULL) {
-        dstctx->sig = OPENSSL_memdup(srcctx->sig, srcctx->siglen);
-        if (dstctx->sig == NULL)
             goto err;
     }
 


### PR DESCRIPTION
This reverts commit d379cfd1ba30c5efcc427da939a8fcd7d331b74f.

Was accidentally commited to the wrong branch. As per failing CI urgent.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
