### PR TITLE
ASN.1: Propagate additional errors in crl_set_issuers()

### DIFF
--- a/test/crltest.c
+++ b/test/crltest.c
@@ -628,27 +628,23 @@ static int test_crl_cert_issuer_ext(void)
     return test;
 }
 
-/*
- * This function clears the error stack before parsing and delegates the actual
- * decoding to CRL_from_strings().
- */
-static X509_CRL *crl_clear_err_parse(const char **pem)
-{
-    ERR_clear_error();
-    return CRL_from_strings(pem);
-}
-
 static int test_crl_date_invalid(void)
 {
     X509_CRL *tmm = NULL, *tss = NULL, *utc = NULL;
     int test = 0;
 
-    test = TEST_ptr_null((tmm = crl_clear_err_parse(kInvalidDateMM)))
-        && TEST_true(err_chk(ERR_LIB_ASN1, ASN1_R_GENERALIZEDTIME_IS_TOO_SHORT))
-        && TEST_ptr_null((tss = crl_clear_err_parse(kInvalidDateSS)))
-        && TEST_true(err_chk(ERR_LIB_ASN1, ASN1_R_GENERALIZEDTIME_IS_TOO_SHORT))
-        && TEST_ptr_null((utc = crl_clear_err_parse(kInvalidDateUTC)))
-        && TEST_true(err_chk(ERR_LIB_ASN1, ASN1_R_WRONG_TAG));
+    test = TEST_ptr_null((tmm = CRL_from_strings(kInvalidDateMM)))
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_GENERALIZEDTIME_IS_TOO_SHORT)
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_ILLEGAL_TIME_VALUE)
+        && TEST_err_s("invalidityDate in CRL is not well-formed")
+        && TEST_ptr_null((tss = CRL_from_strings(kInvalidDateSS)))
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_GENERALIZEDTIME_IS_TOO_SHORT)
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_ILLEGAL_TIME_VALUE)
+        && TEST_err_s("invalidityDate in CRL is not well-formed")
+        && TEST_ptr_null((utc = CRL_from_strings(kInvalidDateUTC)))
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_WRONG_TAG)
+        && TEST_err_r(ERR_LIB_ASN1, ASN1_R_ILLEGAL_TIME_VALUE)
+        && TEST_err_s("invalidityDate in CRL is not well-formed");
 
     X509_CRL_free(tmm);
     X509_CRL_free(utc);

--- a/test/errtest.c
+++ b/test/errtest.c
@@ -420,6 +420,36 @@ err:
     return res;
 }
 
+static int test_error_reason(void)
+{
+    int test;
+
+    ERR_raise(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE);
+    ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
+    ERR_raise(ERR_LIB_CRYPTO, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
+
+    test = TEST_err_r(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE)
+        && TEST_err_r(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR)
+        && TEST_err_r(ERR_LIB_CRYPTO, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
+
+    return test;
+}
+
+static int test_error_string(void)
+{
+    int test;
+
+    ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE, "malloc failure");
+    ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR, "internal error");
+
+    test = TEST_err_r(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE)
+        && TEST_err_r(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR)
+        && TEST_err_s("malloc failure")
+        && TEST_err_s("internal error");
+
+    return test;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(preserves_system_error);
@@ -431,5 +461,7 @@ int setup_tests(void)
     ADD_TEST(test_marks);
     ADD_ALL_TESTS(test_save_restore, 2);
     ADD_TEST(test_clear_error);
+    ADD_TEST(test_error_reason);
+    ADD_TEST(test_error_string);
     return 1;
 }

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -380,6 +380,23 @@ int test_true(const char *file, int line, const char *s, int b);
 int test_false(const char *file, int line, const char *s, int b);
 
 /*
+ * Checks whether a specific error reason is present in the error stack.
+ * This function iterates over the current thread's error queue extracting all
+ * pending errors. If any of them match the specified reason code (as returned
+ * by ERR_GET_REASON()), the function returns 1 to indicate that the
+ * corresponding error was found.
+ */
+int test_err_r(const char *file, int line, int lib, int reason);
+
+/*
+ * Checks whether a specific string is present in the error data stack.
+ * This function iterates over the current thread's error queue extracting all
+ * pending errors. If any of them match the specified string the function
+ * returns 1 to indicate that the corresponding error was found.
+ */
+int test_err_s(const char *file, int line, const char *data);
+
+/*
  * Comparisons between BIGNUMs.
  * BIGNUMS can be compared against other BIGNUMs or zero.
  * Some additional equality tests against 1 & specific values are provided.
@@ -519,6 +536,9 @@ void test_perror(const char *s);
 
 #define TEST_true(a) test_true(__FILE__, __LINE__, #a, (a) != 0)
 #define TEST_false(a) test_false(__FILE__, __LINE__, #a, (a) != 0)
+
+#define TEST_err_r(a, b) test_err_r(__FILE__, __LINE__, a, b)
+#define TEST_err_s(a) test_err_s(__FILE__, __LINE__, a)
 
 #define TEST_BN_eq(a, b) test_BN_eq(__FILE__, __LINE__, #a, #b, a, b)
 #define TEST_BN_ne(a, b) test_BN_ne(__FILE__, __LINE__, #a, #b, a, b)
@@ -661,13 +681,5 @@ X509_CRL *CRL_from_strings(const char **pem);
  * into |*out| so we can free it.
  */
 BIO *glue2bio(const char **pem, char **out);
-/*
- * Checks whether a specific error reason is present in the error stack.
- * This function iterates over the current thread's error queue using
- * ERR_get_error_all(), extracting all pending errors. If any of them match
- * the specified reason code (as returned by ERR_GET_REASON()), the function
- * returns 1 to indicate that the corresponding error was found.
- */
-int err_chk(int lib, int reason);
 
 #endif /* OSSL_TESTUTIL_H */

--- a/test/testutil/load.c
+++ b/test/testutil/load.c
@@ -130,6 +130,7 @@ X509_CRL *CRL_from_strings(const char **pem)
         return NULL;
     }
 
+    ERR_clear_error();
     crl = PEM_read_bio_X509_CRL(b, NULL, NULL, NULL);
 
     OPENSSL_free(p);
@@ -151,28 +152,10 @@ X509 *X509_from_strings(const char **pem)
         return NULL;
     }
 
+    ERR_clear_error();
     x = PEM_read_bio_X509(b, NULL, NULL, NULL);
 
     OPENSSL_free(p);
     BIO_free(b);
     return x;
-}
-
-int err_chk(int lib, int reason)
-{
-#if defined(OPENSSL_NO_ERR) || defined(OPENSSL_SMALL_FOOTPRINT)
-    return 1;
-#endif
-#if defined(OPENSSL_NO_DEPRECATED_3_0) || defined(OPENSSL_NO_HTTP)
-    return 1;
-#endif
-
-    unsigned long e;
-
-    while ((e = ERR_get_error_all(NULL, NULL, NULL, NULL, NULL))) {
-        if (ERR_GET_LIB(e) == lib && ERR_GET_REASON(e) == reason)
-            return 1;
-    }
-
-    return 0;
 }


### PR DESCRIPTION
Additional ASN.1 parsing errors are now propagated to the error stack, allowing invalid CRLs to be rejected early with detailed error messages. It also includes additional tests, testing utilities, and minor code cleanups useful for upcoming PRs, as part of a broader effort to reject fatal errors quickly with sufficiently descriptive error messages.

Decomposition of the following draft: https://github.com/openssl/openssl/pull/29444
