### PR TITLE
SSL_CONF_FLAG: Prevent setting both CMDLINE and FILE flags

### DIFF
--- a/doc/man3/SSL_CONF_CTX_set_flags.pod
+++ b/doc/man3/SSL_CONF_CTX_set_flags.pod
@@ -28,8 +28,9 @@ Currently the following B<flags> values are recognised:
 
 =item SSL_CONF_FLAG_CMDLINE, SSL_CONF_FLAG_FILE
 
-recognise options intended for command line or configuration file use. At
-least one of these flags must be set.
+recognise options intended for command line or configuration file use. One of
+these flags, but not both, must be set. If an attempt is made to set one of
+these flags when the other is already set then the new flag is ignored.
 
 =item SSL_CONF_FLAG_CLIENT, SSL_CONF_FLAG_SERVER
 

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -1123,6 +1123,14 @@ void SSL_CONF_CTX_free(SSL_CONF_CTX *cctx)
 
 unsigned int SSL_CONF_CTX_set_flags(SSL_CONF_CTX *cctx, unsigned int flags)
 {
+    if ((cctx->flags & SSL_CONF_FLAG_CMDLINE)
+        && (flags & SSL_CONF_FLAG_FILE))
+        flags &= ~SSL_CONF_FLAG_FILE;
+
+    if ((cctx->flags & SSL_CONF_FLAG_FILE)
+        && (flags & SSL_CONF_FLAG_CMDLINE))
+        flags &= ~SSL_CONF_FLAG_CMDLINE;
+
     cctx->flags |= flags;
     return cctx->flags;
 }


### PR DESCRIPTION
The `SSL_CONF_CTX_set_flags` function did not prevent setting both `SSL_CONF_FLAG_CMDLINE` and `SSL_CONF_FLAG_FILE` flags, which is an invalid combination. This commit adds a check to prevent this and updates the documentation to clarify that only one of these flags can be set.

A new test case is also added to verify the correct behavior.

Fixes https://github.com/openssl/openssl/issues/15508

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
