### PR TITLE
Add missing Z==1 test Point-to-affine conversion

### DIFF
--- a/crypto/ec/ec_local.h
+++ b/crypto/ec/ec_local.h
@@ -393,6 +393,8 @@ int ossl_ec_GFp_simple_get_Jprojective_coordinates_GFp(const EC_GROUP *,
 int ossl_ec_GFp_simple_point_set_affine_coordinates(const EC_GROUP *, EC_POINT *,
     const BIGNUM *x,
     const BIGNUM *y, BN_CTX *);
+int ossl_ec_GFp_check_affine_point(const EC_GROUP *, const EC_POINT *, 
+    BIGNUM *x, BIGNUM *y, BIGNUM *decoded_z, int *zisone, BN_CTX*);
 int ossl_ec_GFp_simple_point_get_affine_coordinates(const EC_GROUP *,
     const EC_POINT *, BIGNUM *x,
     BIGNUM *y, BN_CTX *);

--- a/crypto/ec/ecp_nistp224.c
+++ b/crypto/ec/ecp_nistp224.c
@@ -1321,26 +1321,14 @@ int ossl_ec_GFp_nistp224_point_get_affine_coordinates(const EC_GROUP *group,
 {
     felem z1, z2, x_in, y_in, x_out, y_out;
     widefelem tmp;
-
-    if (EC_POINT_is_at_infinity(group, point)) {
-        ERR_raise(ERR_LIB_EC, EC_R_POINT_AT_INFINITY);
-        return 0;
-    }
+    int zisone = 0;
 
     /* Fast check if Z = 1 (point already in affine form) */
-    if (BN_is_one(point->Z)) {
-        if (x != NULL) {
-            if (!BN_copy(x, point->X)) {
-                ERR_raise(ERR_LIB_EC, ERR_R_BN_LIB);
-                return 0;
-            }
-        }
-        if (y != NULL) {
-            if (!BN_copy(y, point->Y)) {
-                ERR_raise(ERR_LIB_EC, ERR_R_BN_LIB);
-                return 0;
-            }
-        }
+    if (!ossl_ec_GFp_check_affine_point(group, point,  x, y, NULL, &zisone, ctx))
+        return 0;
+    if (zisone) {
+        /* In this case, point is already in affine form, and 
+           coordinates were extracted. */
         return 1;
     }
 

--- a/crypto/ec/ecp_nistp256.c
+++ b/crypto/ec/ecp_nistp256.c
@@ -1941,26 +1941,14 @@ int ossl_ec_GFp_nistp256_point_get_affine_coordinates(const EC_GROUP *group,
     felem z1, z2, x_in, y_in;
     smallfelem x_out, y_out;
     longfelem tmp;
-
-    if (EC_POINT_is_at_infinity(group, point)) {
-        ERR_raise(ERR_LIB_EC, EC_R_POINT_AT_INFINITY);
-        return 0;
-    }
+    int zisone = 0;
 
     /* Fast check if Z = 1 (point already in affine form) */
-    if (BN_is_one(point->Z)) {
-        if (x != NULL) {
-            if (!BN_copy(x, point->X)) {
-                ERR_raise(ERR_LIB_EC, ERR_R_BN_LIB);
-                return 0;
-            }
-        }
-        if (y != NULL) {
-            if (!BN_copy(y, point->Y)) {
-                ERR_raise(ERR_LIB_EC, ERR_R_BN_LIB);
-                return 0;
-            }
-        }
+    if (!ossl_ec_GFp_check_affine_point(group, point,  x, y, NULL, &zisone, ctx))
+        return 0;
+    if (zisone) {
+        /* In this case, point is already in affine form, and 
+           coordinates were extracted. */
         return 1;
     }
 

--- a/crypto/ec/ecp_nistp384.c
+++ b/crypto/ec/ecp_nistp384.c
@@ -1664,26 +1664,14 @@ int ossl_ec_GFp_nistp384_point_get_affine_coordinates(const EC_GROUP *group,
 {
     felem z1, z2, x_in, y_in, x_out, y_out;
     widefelem tmp;
-
-    if (EC_POINT_is_at_infinity(group, point)) {
-        ERR_raise(ERR_LIB_EC, EC_R_POINT_AT_INFINITY);
-        return 0;
-    }
+    int zisone = 0;
 
     /* Fast check if Z = 1 (point already in affine form) */
-    if (BN_is_one(point->Z)) {
-        if (x != NULL) {
-            if (!BN_copy(x, point->X)) {
-                ERR_raise(ERR_LIB_EC, ERR_R_BN_LIB);
-                return 0;
-            }
-        }
-        if (y != NULL) {
-            if (!BN_copy(y, point->Y)) {
-                ERR_raise(ERR_LIB_EC, ERR_R_BN_LIB);
-                return 0;
-            }
-        }
+    if (!ossl_ec_GFp_check_affine_point(group, point,  x, y, NULL, &zisone, ctx))
+        return 0;
+    if (zisone) {
+        /* In this case, point is already in affine form, and 
+           coordinates were extracted. */
         return 1;
     }
 

--- a/crypto/ec/ecp_nistp521.c
+++ b/crypto/ec/ecp_nistp521.c
@@ -1754,26 +1754,14 @@ int ossl_ec_GFp_nistp521_point_get_affine_coordinates(const EC_GROUP *group,
 {
     felem z1, z2, x_in, y_in, x_out, y_out;
     largefelem tmp;
-
-    if (EC_POINT_is_at_infinity(group, point)) {
-        ERR_raise(ERR_LIB_EC, EC_R_POINT_AT_INFINITY);
-        return 0;
-    }
+    int zisone = 0;
 
     /* Fast check if Z = 1 (point already in affine form) */
-    if (BN_is_one(point->Z)) {
-        if (x != NULL) {
-            if (!BN_copy(x, point->X)) {
-                ERR_raise(ERR_LIB_EC, ERR_R_BN_LIB);
-                return 0;
-            }
-        }
-        if (y != NULL) {
-            if (!BN_copy(y, point->Y)) {
-                ERR_raise(ERR_LIB_EC, ERR_R_BN_LIB);
-                return 0;
-            }
-        }
+    if (!ossl_ec_GFp_check_affine_point(group, point,  x, y, NULL, &zisone, ctx))
+        return 0;
+    if (zisone) {
+        /* In this case, point is already in affine form, and 
+           coordinates were extracted. */
         return 1;
     }
 


### PR DESCRIPTION
Fixes #29719

This MR adds a simple Z==1 test in Point-to-affine conversion for `nistp224`, `nistp256`, `nistp384`, and `nistp521`. 
This simple test was already implemented in the `ossl_ec_GFp_simple_point_get_affine_coordinates()` function, which is the default generic implementation when a given curve does not have an optimized implementation.


