### PR TITLE
Add the soversion as a part to the MODULESDIR

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -381,7 +381,7 @@ OPENSSLDIR={- catdir($config{openssldir}) or
 # The same, but for C
 OPENSSLDIR_C={- platform->osslprefix() -}DATAROOT:[000000]
 # Where modules reside, for C
-MODULESDIR_C={- platform->osslprefix() -}MODULES{- $target{pointer_size} -}:
+MODULESDIR_C={- platform->osslprefix() -}MODULES{- $sover_dirname.$target{pointer_size} -}:
 
 ##### User defined commands and flags ################################
 

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -324,7 +324,7 @@ LIBDIR={- our $libdir = $config{libdir};
 # $(libdir) is chosen to be compatible with the GNU coding standards
 libdir={- file_name_is_absolute($libdir)
           ? $libdir : '$(INSTALLTOP)/$(LIBDIR)' -}
-MODULESDIR=$(libdir)/ossl-modules
+MODULESDIR=$(libdir)/ossl-modules-{- $sover_dirname -}
 
 # Convenience variable for those who want to set the rpath in shared
 # libraries and applications

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -214,7 +214,7 @@ MODULESDIR_dev={- use File::Spec::Functions qw(:DEFAULT splitpath catpath);
                       splitpath($modulesprefix, 1);
                   our $modulesdir_dev = $modulesprefix_dev;
                   our $modulesdir_dir =
-                      catdir($modulesprefix_dir, "ossl-modules");
+                      catdir($modulesprefix_dir, "ossl-modules-$sover_dirname");
                   our $modulesdir = catpath($modulesdir_dev, $modulesdir_dir);
                   $modulesdir_dev -}
 MODULESDIR_dir={- canonpath($modulesdir_dir) -}


### PR DESCRIPTION
As we are going to have several versions of openssl supporting providers, it makes sense to separate the folders for various versions.

Despite providers have a well-defined ABIs, it's not clear whether it would be safe to use non-self-contatined providers built against a particular version of libcrypto against the different version of openssl (e.g. because of atexit()-handler etc). Separating the providers per version resolves this problem.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
