### PR TITLE
doc: Add const to SSL_CTX_set1_groups/curves documentation

### DIFF
--- a/doc/man3/SSL_CTX_set1_curves.pod
+++ b/doc/man3/SSL_CTX_set1_curves.pod
@@ -13,22 +13,22 @@ SSL_get1_curves, SSL_get_shared_curve, SSL_CTX_get0_implemented_groups
 
  #include <openssl/ssl.h>
 
- int SSL_CTX_set1_groups(SSL_CTX *ctx, int *glist, int glistlen);
- int SSL_CTX_set1_groups_list(SSL_CTX *ctx, char *list);
+ int SSL_CTX_set1_groups(SSL_CTX *ctx, const int *glist, int glistlen);
+ int SSL_CTX_set1_groups_list(SSL_CTX *ctx, const char *list);
 
- int SSL_set1_groups(SSL *ssl, int *glist, int glistlen);
- int SSL_set1_groups_list(SSL *ssl, char *list);
+ int SSL_set1_groups(SSL *ssl, const int *glist, int glistlen);
+ int SSL_set1_groups_list(SSL *ssl, const char *list);
 
  int SSL_get1_groups(SSL *ssl, int *groups);
  int SSL_get0_iana_groups(SSL *ssl, uint16_t **out);
  int SSL_get_shared_group(SSL *s, int n);
  int SSL_get_negotiated_group(SSL *s);
 
- int SSL_CTX_set1_curves(SSL_CTX *ctx, int *clist, int clistlen);
- int SSL_CTX_set1_curves_list(SSL_CTX *ctx, char *list);
+ int SSL_CTX_set1_curves(SSL_CTX *ctx, const int *clist, int clistlen);
+ int SSL_CTX_set1_curves_list(SSL_CTX *ctx, const char *list);
 
- int SSL_set1_curves(SSL *ssl, int *clist, int clistlen);
- int SSL_set1_curves_list(SSL *ssl, char *list);
+ int SSL_set1_curves(SSL *ssl, const int *clist, int clistlen);
+ int SSL_set1_curves_list(SSL *ssl, const char *list);
 
  int SSL_get1_curves(SSL *ssl, int *curves);
  int SSL_get_shared_curve(SSL *s, int n);


### PR DESCRIPTION
## Summary

- Add `const` qualifier to input parameters in the documentation for `SSL_CTX_set1_groups()`, `SSL_CTX_set1_groups_list()`, `SSL_set1_groups()`, `SSL_set1_groups_list()`, and their `curves` equivalents
- These functions do not modify their input arrays/strings, so the documentation should reflect const-correct signatures

Fixes #27422

## Test plan

- [x] Documentation builds correctly
- [x] No functional changes, documentation-only

🤖 Generated with [Claude Code](https://claude.ai/code)