### PR TITLE
doc: Clarify SSL_SESSION_get0_hostname behavior for TLSv1.3

### DIFF
--- a/doc/man3/SSL_SESSION_get0_hostname.pod
+++ b/doc/man3/SSL_SESSION_get0_hostname.pod
@@ -24,9 +24,10 @@ SSL_SESSION_set1_alpn_selected
 =head1 DESCRIPTION
 
 SSL_SESSION_get0_hostname() retrieves the Server Name Indication (SNI) value
-that was sent by the client when the session was created if the server
-acknowledged the client's SNI extension by including an empty SNI extension
-in response. Otherwise NULL is returned.
+associated with the session. For TLSv1.3, this returns the hostname sent by the
+client. For TLSv1.2 and earlier, this returns the hostname only if the server
+acknowledged the extension. If no hostname is associated with the session,
+NULL is returned.
 
 The value returned is a pointer to memory maintained within B<s> and
 should not be free'd.


### PR DESCRIPTION
## Summary

The documentation for `SSL_SESSION_get0_hostname()` incorrectly implied the function would return NULL for TLSv1.3 sessions because it mentioned requiring server acknowledgment via an empty SNI extension response - a mechanism TLSv1.3 does not use.

Updated the documentation to clarify:
- For TLSv1.3: returns the hostname sent by the client
- For TLSv1.2 and earlier: returns the hostname only if the server acknowledged the extension

Fixes #26547

## Test plan

- [x] Documentation builds correctly
- [x] No functional changes, documentation-only

🤖 Generated with [Claude Code](https://claude.ai/code)