### PR TITLE
doc: Fix incorrect parameter reference in EVP_MAC

### DIFF
--- a/doc/man3/EVP_MAC.pod
+++ b/doc/man3/EVP_MAC.pod
@@ -259,7 +259,7 @@ The standard parameter names are:
 Its value is the MAC key as an array of bytes.
 
 For MACs that use an underlying computation algorithm, the algorithm
-must be set first, see parameter names "algorithm" below.
+must be set first, see "cipher" and "digest" parameters below.
 
 =item "iv" (B<OSSL_MAC_PARAM_IV>) <octet string>
 


### PR DESCRIPTION
Fix reference to non-existent "algorithm" parameter; change to "cipher" and "digest".

Fixes #12580