### PR TITLE
doc: Clarify SSL_get_SSL_CTX returns internal pointer

### DIFF
--- a/doc/man3/SSL_get_SSL_CTX.pod
+++ b/doc/man3/SSL_get_SSL_CTX.pod
@@ -17,7 +17,10 @@ B<ssl> was created with L<SSL_new(3)>.
 
 =head1 RETURN VALUES
 
-The pointer to the SSL_CTX object is returned.
+The pointer to the SSL_CTX object is returned. This is an internal pointer
+and the reference count is not incremented. The returned pointer should not
+be freed. If the caller needs to retain the SSL_CTX for longer than the SSL
+object, it should call L<SSL_CTX_up_ref(3)> to increment the reference count.
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
Document that the returned pointer is internal, not reference counted, and should not be freed.

Fixes #28298