### PR TITLE
doc: update PEM examples to use AES-256-CBC instead of 3DES

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,12 @@ OpenSSL 4.0
 
 ### Changes between 3.6 and 4.0 [xx XXX xxxx]
 
+ * Updated documentation examples and command-line apps to use modern cipher
+   fetching with AES-256-CBC instead of the deprecated 3DES cipher. The apps
+   affected are `cms`, `pkcs8`, `pkcs12`, `req`, and `smime`.
+
+   *Koray Onen*
+
  * Added CSHAKE as per [SP 800-185]
 
    *Shane Lontis*

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -968,7 +968,8 @@ int cms_main(int argc, char **argv)
 
     if (operation == SMIME_ENCRYPT) {
         if (!cipher)
-            cipher = (EVP_CIPHER *)EVP_aes_256_cbc();
+            cipher = EVP_CIPHER_fetch(app_get0_libctx(), "AES-256-CBC",
+                app_get0_propq());
         if (secret_key && !secret_keyid) {
             BIO_printf(bio_err, "No secret key id\n");
             goto end;

--- a/apps/pkcs8.c
+++ b/apps/pkcs8.c
@@ -220,6 +220,8 @@ int pkcs8_main(int argc, char **argv)
         goto end;
 
     if (ciphername != NULL) {
+        EVP_CIPHER_free(cipher);
+        cipher = NULL;
         if (!opt_cipher(ciphername, &cipher))
             goto opthelp;
     }

--- a/apps/pkcs8.c
+++ b/apps/pkcs8.c
@@ -170,7 +170,8 @@ int pkcs8_main(int argc, char **argv)
                 goto opthelp;
             }
             if (cipher == NULL)
-                cipher = (EVP_CIPHER *)EVP_aes_256_cbc();
+                cipher = EVP_CIPHER_fetch(app_get0_libctx(), "AES-256-CBC",
+                    app_get0_propq());
             break;
         case OPT_ITER:
             iter = opt_int_arg();
@@ -187,7 +188,8 @@ int pkcs8_main(int argc, char **argv)
             scrypt_r = 8;
             scrypt_p = 1;
             if (cipher == NULL)
-                cipher = (EVP_CIPHER *)EVP_aes_256_cbc();
+                cipher = EVP_CIPHER_fetch(app_get0_libctx(), "AES-256-CBC",
+                    app_get0_propq());
             break;
         case OPT_SCRYPT_N:
             if (!opt_long(opt_arg(), &scrypt_N) || scrypt_N <= 0)
@@ -228,7 +230,8 @@ int pkcs8_main(int argc, char **argv)
     }
 
     if ((pbe_nid == -1) && cipher == NULL)
-        cipher = (EVP_CIPHER *)EVP_aes_256_cbc();
+        cipher = EVP_CIPHER_fetch(app_get0_libctx(), "AES-256-CBC",
+            app_get0_propq());
 
     in = bio_open_default(infile, 'r',
         informat == FORMAT_UNDEF ? FORMAT_PEM : informat);

--- a/apps/req.c
+++ b/apps/req.c
@@ -510,6 +510,8 @@ int req_main(int argc, char **argv)
             newreq = precert = 1;
             break;
         case OPT_CIPHER:
+            EVP_CIPHER_free(cipher);
+            cipher = NULL;
             if (!opt_cipher_any(opt_arg(), &cipher))
                 goto opthelp;
             break;
@@ -723,10 +725,10 @@ int req_main(int argc, char **argv)
         p = app_conf_try_string(req_conf, section, "encrypt_rsa_key");
         if (p == NULL)
             p = app_conf_try_string(req_conf, section, "encrypt_key");
-        if (p != NULL && strcmp(p, "no") == 0)
+        if ((p != NULL && strcmp(p, "no") == 0) || noenc) {
+            EVP_CIPHER_free(cipher);
             cipher = NULL;
-        if (noenc)
-            cipher = NULL;
+        }
 
         i = 0;
     loop:

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -503,7 +503,8 @@ int smime_main(int argc, char **argv)
 
     if (operation == SMIME_ENCRYPT) {
         if (cipher == NULL)
-            cipher = (EVP_CIPHER *)EVP_aes_256_cbc();
+            cipher = EVP_CIPHER_fetch(app_get0_libctx(), "AES-256-CBC",
+                app_get0_propq());
         encerts = sk_X509_new_null();
         if (encerts == NULL)
             goto end;

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -1807,7 +1807,9 @@ with a 128-bit key:
      /* Allow enough space in output buffer for additional block */
      unsigned char inbuf[1024], outbuf[1024 + EVP_MAX_BLOCK_LENGTH];
      int inlen, outlen;
-     EVP_CIPHER_CTX *ctx;
+     EVP_CIPHER_CTX *ctx = NULL;
+     EVP_CIPHER *cipher = NULL;
+     int ret = 0;
      /*
       * Bogus key and IV: we'd normally set these from
       * another source.
@@ -1815,44 +1817,40 @@ with a 128-bit key:
      unsigned char key[] = "0123456789abcdeF";
      unsigned char iv[] = "1234567887654321";
 
-     /* Don't set key or IV right away; we want to check lengths */
      ctx = EVP_CIPHER_CTX_new();
-     if (!EVP_CipherInit_ex2(ctx, EVP_aes_128_cbc(), NULL, NULL,
-                             do_encrypt, NULL)) {
-         /* Error */
-         EVP_CIPHER_CTX_free(ctx);
-         return 0;
-     }
+     cipher = EVP_CIPHER_fetch(NULL, "AES-128-CBC", NULL);
+     if (ctx == NULL || cipher == NULL)
+         goto err;
+
+     /* Don't set key or IV right away; we want to check lengths */
+     if (!EVP_CipherInit_ex2(ctx, cipher, NULL, NULL,
+                             do_encrypt, NULL))
+         goto err;
+
      OPENSSL_assert(EVP_CIPHER_CTX_get_key_length(ctx) == 16);
      OPENSSL_assert(EVP_CIPHER_CTX_get_iv_length(ctx) == 16);
 
      /* Now we can set key and IV */
-     if (!EVP_CipherInit_ex2(ctx, NULL, key, iv, do_encrypt, NULL)) {
-         /* Error */
-         EVP_CIPHER_CTX_free(ctx);
-         return 0;
-     }
+     if (!EVP_CipherInit_ex2(ctx, NULL, key, iv, do_encrypt, NULL))
+         goto err;
 
      for (;;) {
          inlen = fread(inbuf, 1, 1024, in);
          if (inlen <= 0)
              break;
-         if (!EVP_CipherUpdate(ctx, outbuf, &outlen, inbuf, inlen)) {
-             /* Error */
-             EVP_CIPHER_CTX_free(ctx);
-             return 0;
-         }
+         if (!EVP_CipherUpdate(ctx, outbuf, &outlen, inbuf, inlen))
+             goto err;
          fwrite(outbuf, 1, outlen, out);
      }
-     if (!EVP_CipherFinal_ex(ctx, outbuf, &outlen)) {
-         /* Error */
-         EVP_CIPHER_CTX_free(ctx);
-         return 0;
-     }
+     if (!EVP_CipherFinal_ex(ctx, outbuf, &outlen))
+         goto err;
      fwrite(outbuf, 1, outlen, out);
 
+     ret = 1;
+ err:
+     EVP_CIPHER_free(cipher);
      EVP_CIPHER_CTX_free(ctx);
-     return 1;
+     return ret;
  }
 
 Encryption using AES-CBC with a 256-bit key with "CS1" ciphertext stealing.

--- a/doc/man3/PEM_read_bio_PrivateKey.pod
+++ b/doc/man3/PEM_read_bio_PrivateKey.pod
@@ -516,17 +516,25 @@ Write a certificate to a BIO:
      /* Error */
 
 Write a private key (using traditional format) to a BIO using
-triple DES encryption, the pass phrase is prompted for:
+AES-256-CBC encryption, the pass phrase is prompted for:
 
- if (!PEM_write_bio_PrivateKey(bp, key, EVP_des_ede3_cbc(), NULL, 0, 0, NULL))
+ EVP_CIPHER *cipher = EVP_CIPHER_fetch(NULL, "AES-256-CBC", NULL);
+ if (cipher == NULL)
      /* Error */
+ if (!PEM_write_bio_PrivateKey(bp, key, cipher, NULL, 0, 0, NULL))
+     /* Error */
+ EVP_CIPHER_free(cipher);
 
-Write a private key (using PKCS#8 format) to a BIO using triple
-DES encryption, using the pass phrase "hello":
+Write a private key (using PKCS#8 format) to a BIO using
+AES-256-CBC encryption, using the pass phrase "hello":
 
- if (!PEM_write_bio_PKCS8PrivateKey(bp, key, EVP_des_ede3_cbc(),
+ EVP_CIPHER *cipher = EVP_CIPHER_fetch(NULL, "AES-256-CBC", NULL);
+ if (cipher == NULL)
+     /* Error */
+ if (!PEM_write_bio_PKCS8PrivateKey(bp, key, cipher,
                                     NULL, 0, 0, "hello"))
      /* Error */
+ EVP_CIPHER_free(cipher);
 
 Read a private key from a BIO using a pass phrase callback:
 

--- a/doc/man3/PEM_read_bio_PrivateKey.pod
+++ b/doc/man3/PEM_read_bio_PrivateKey.pod
@@ -443,20 +443,35 @@ the function.
 
 The pseudo code to derive the key would look similar to:
 
- EVP_CIPHER* cipher = EVP_des_ede3_cbc();
- EVP_MD* md = EVP_md5();
+ EVP_CIPHER *cipher = NULL;
+ EVP_MD *md = NULL;
+ unsigned char *key = NULL;
+ unsigned int nkey, niv;
+ unsigned char iv[EVP_MAX_IV_LENGTH];
+ int rc;
 
- unsigned int nkey = EVP_CIPHER_get_key_length(cipher);
- unsigned int niv = EVP_CIPHER_get_iv_length(cipher);
- unsigned char key[nkey];
- unsigned char iv[niv];
+ cipher = EVP_CIPHER_fetch(NULL, "DES-EDE3-CBC", NULL);
+ md = EVP_MD_fetch(NULL, "MD5", NULL);
+ if (cipher == NULL || md == NULL)
+     goto err;
+
+ nkey = EVP_CIPHER_get_key_length(cipher);
+ niv = EVP_CIPHER_get_iv_length(cipher);
+ key = OPENSSL_malloc(nkey);
+ if (key == NULL)
+     goto err;
 
  memcpy(iv, HexToBin("3F17F5316E2BAC89"), niv);
  rc = EVP_BytesToKey(cipher, md, iv /*salt*/, pword, plen, 1, key, NULL /*iv*/);
- if (rc != nkey)
-     /* Error */
+ if (rc != (int)nkey)
+     goto err;
 
  /* On success, use key and iv to initialize the cipher */
+
+ err:
+ OPENSSL_free(key);
+ EVP_MD_free(md);
+ EVP_CIPHER_free(cipher);
 
 =head1 BUGS
 

--- a/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
@@ -160,10 +160,16 @@ Reference Implementation:
  {
      OSSL_PARAM params[3];
      your_type_t *key; /* something that you need to implement */
+     EVP_CIPHER *cipher = NULL;
+     int ret = -1;
+
+     cipher = EVP_CIPHER_fetch(NULL, "AES-256-CBC", NULL);
+     if (cipher == NULL)
+         return -1;
 
      if (enc) { /* create new session */
          if (RAND_bytes(iv, EVP_MAX_IV_LENGTH) <= 0)
-             return -1; /* insufficient random */
+             goto err; /* insufficient random */
 
          key = currentkey(); /* something that you need to implement */
          if (key == NULL) {
@@ -174,14 +180,15 @@ Reference Implementation:
                                  * an aes_key, a hmac_key and optionally
                                  * an expire time.
                                  */
-             if (key == NULL) /* key couldn't be created */
-                 return 0;
+             if (key == NULL) { /* key couldn't be created */
+                 ret = 0;
+                 goto err;
+             }
          }
          memcpy(key_name, key->name, 16);
 
-         if (EVP_EncryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, key->aes_key,
-                                iv) == 0)
-            return -1; /* error in cipher initialisation */
+         if (EVP_EncryptInit_ex(ctx, cipher, NULL, key->aes_key, iv) == 0)
+            goto err; /* error in cipher initialisation */
 
          params[0] = OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_KEY,
                                                        key->hmac_key, 32);
@@ -189,16 +196,18 @@ Reference Implementation:
                                                       "sha256", 0);
          params[2] = OSSL_PARAM_construct_end();
          if (EVP_MAC_CTX_set_params(hctx, params) == 0)
-            return -1; /* error in mac initialisation */
+            goto err; /* error in mac initialisation */
 
-         return 1;
+         ret = 1;
 
      } else { /* retrieve session */
          time_t t = time(NULL);
          key = findkey(key_name); /* something that you need to implement */
 
-         if (key == NULL || key->expire < t)
-             return 0;
+         if (key == NULL || key->expire < t) {
+             ret = 0;
+             goto err;
+         }
 
          params[0] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY,
                                                        key->hmac_key, 32);
@@ -206,21 +215,25 @@ Reference Implementation:
                                                       "sha256", 0);
          params[2] = OSSL_PARAM_construct_end();
          if (EVP_MAC_CTX_set_params(hctx, params) == 0)
-            return -1; /* error in mac initialisation */
+            goto err; /* error in mac initialisation */
 
-         if (EVP_DecryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, key->aes_key,
-                                iv) == 0)
-            return -1; /* error in cipher initialisation */
+         if (EVP_DecryptInit_ex(ctx, cipher, NULL, key->aes_key, iv) == 0)
+            goto err; /* error in cipher initialisation */
 
          if (key->expire < t - RENEW_TIME) { /* RENEW_TIME: implement */
              /*
               * return 2 - This session will get a new ticket even though the
               * current one is still valid.
               */
-             return 2;
+             ret = 2;
+         } else {
+             ret = 1;
          }
-         return 1;
      }
+
+ err:
+     EVP_CIPHER_free(cipher);
+     return ret;
  }
 
 =head1 SEE ALSO

--- a/test/bio_enc_test.c
+++ b/test/bio_enc_test.c
@@ -293,7 +293,7 @@ static int do_crypt(FILE *in, FILE *out, int do_encrypt)
 
     /* Don't set key or IV right away; we want to check lengths */
     if (!EVP_CipherInit_ex2(ctx, cipher, NULL, NULL,
-                            do_encrypt, NULL))
+            do_encrypt, NULL))
         goto err;
 
     OPENSSL_assert(EVP_CIPHER_CTX_get_key_length(ctx) == 16);
@@ -426,7 +426,7 @@ static int test_evp_bytes_to_key(void)
     nkey = EVP_CIPHER_get_key_length(cipher);
     niv = EVP_CIPHER_get_iv_length(cipher);
 
-    if (!TEST_uint_eq(nkey, 24)  /* 3DES key length */
+    if (!TEST_uint_eq(nkey, 24) /* 3DES key length */
         || !TEST_uint_eq(niv, 8)) /* 3DES IV length */
         goto err;
 
@@ -436,7 +436,7 @@ static int test_evp_bytes_to_key(void)
 
     memcpy(iv, salt, niv);
     rc = EVP_BytesToKey(cipher, md, iv /*salt*/, (unsigned char *)password,
-                        strlen(password), 1, key, NULL /*iv*/);
+        strlen(password), 1, key, NULL /*iv*/);
     if (!TEST_int_eq(rc, (int)nkey))
         goto err;
 

--- a/test/bio_enc_test.c
+++ b/test/bio_enc_test.c
@@ -304,9 +304,11 @@ static int do_crypt(FILE *in, FILE *out, int do_encrypt)
         goto err;
 
     for (;;) {
-        inlen = fread(inbuf, 1, 1024, in);
-        if (inlen <= 0)
+        size_t nread = fread(inbuf, 1, 1024, in);
+
+        if (nread == 0)
             break;
+        inlen = (int)nread;
         if (!EVP_CipherUpdate(ctx, outbuf, &outlen, inbuf, inlen))
             goto err;
         fwrite(outbuf, 1, outlen, out);
@@ -389,6 +391,7 @@ static int test_evp_bytes_to_key(void)
     unsigned char iv[EVP_MAX_IV_LENGTH];
     unsigned char salt[8] = { 0x3F, 0x17, 0xF5, 0x31, 0x6E, 0x2B, 0xAC, 0x89 };
     const char *password = "testpassword";
+    int passlen = (int)strlen(password);
     int rc;
     int ret = 0;
 
@@ -410,7 +413,7 @@ static int test_evp_bytes_to_key(void)
 
     memcpy(iv, salt, niv);
     rc = EVP_BytesToKey(cipher, md, iv /*salt*/, (unsigned char *)password,
-        strlen(password), 1, key, NULL /*iv*/);
+        passlen, 1, key, NULL /*iv*/);
     if (!TEST_int_eq(rc, (int)nkey))
         goto err;
 

--- a/test/bio_enc_test.c
+++ b/test/bio_enc_test.c
@@ -375,6 +375,7 @@ err:
     return ret;
 }
 
+#ifndef OPENSSL_NO_DES
 /*
  * Test the EVP_BytesToKey example from PEM_read_bio_PrivateKey.pod documentation.
  * This tests key derivation using EVP_CIPHER_fetch and EVP_MD_fetch.
@@ -424,6 +425,7 @@ err:
     EVP_CIPHER_free(cipher);
     return ret;
 }
+#endif
 
 static int test_bio_enc_eof_read_flush(void)
 {
@@ -500,6 +502,8 @@ int setup_tests(void)
 #endif
     ADD_TEST(test_bio_enc_eof_read_flush);
     ADD_TEST(test_do_crypt_roundtrip);
+#ifndef OPENSSL_NO_DES
     ADD_TEST(test_evp_bytes_to_key);
+#endif
     return 1;
 }

--- a/test/recipes/80-test_smime.t
+++ b/test/recipes/80-test_smime.t
@@ -1,0 +1,44 @@
+#! /usr/bin/env perl
+# Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use File::Spec::Functions qw/catfile/;
+use File::Compare qw/compare_text/;
+use OpenSSL::Test qw/:DEFAULT srctop_dir srctop_file bldtop_dir with/;
+use OpenSSL::Test::Utils;
+
+setup("test_smime");
+
+plan skip_all => "smime is not supported by this OpenSSL build"
+    if disabled("des");
+
+my $smdir = srctop_dir("test", "smime-certs");
+my $smcont = srctop_file("test", "smcont.txt");
+my $smrsa1 = catfile($smdir, "smrsa1.pem");
+
+my $provpath = bldtop_dir("providers");
+my @defaultprov = ("-provider-path", $provpath, "-provider", "default");
+
+plan tests => 2;
+
+# Test smime encryption with default cipher (AES-256-CBC)
+ok(run(app(["openssl", "smime", @defaultprov,
+            "-encrypt", "-in", $smcont,
+            "-out", "smime_enc_default.txt",
+            $smrsa1])),
+   "smime encrypt with default cipher");
+
+# Test smime decryption
+ok(run(app(["openssl", "smime", @defaultprov,
+            "-decrypt", "-in", "smime_enc_default.txt",
+            "-recip", $smrsa1,
+            "-out", "smime_dec_default.txt"])) &&
+   compare_text($smcont, "smime_dec_default.txt") == 0,
+   "smime decrypt and verify content");


### PR DESCRIPTION
Fixes #28665