### PR TITLE
doc: clarify SSL_SESSION ownership in PSK use session callback

### DIFF
--- a/doc/man3/SSL_CTX_set_psk_client_callback.pod
+++ b/doc/man3/SSL_CTX_set_psk_client_callback.pod
@@ -93,6 +93,14 @@ be used as the basis for a PSK.
 Ownership of the SSL_SESSION object is passed to the OpenSSL library and so it
 should not be freed by the application.
 
+Note that as described above, the callback may be called a second time during a
+handshake. Since ownership of the SSL_SESSION is transferred to OpenSSL on each
+call, if the callback wishes to return the same SSL_SESSION pointer on a
+subsequent invocation, it must first call L<SSL_SESSION_up_ref(3)> to increment
+the reference count. Failure to do so will result in a use-after-free error.
+Alternatively, the callback may return a different SSL_SESSION object on each
+call (e.g., by calling L<SSL_SESSION_dup(3)>).
+
 It is also possible for the callback to succeed but not supply a PSK. In this
 case no PSK will be sent to the server but the handshake will continue. To do
 this the callback should return successfully and ensure that B<*sess> is


### PR DESCRIPTION
## Summary

- Clarify in the documentation that the `psk_use_session` callback may be called multiple times
- Document that ownership of the SSL_SESSION is transferred to OpenSSL on each callback invocation
- Explain that if returning the same SSL_SESSION pointer, the callback must call `SSL_SESSION_up_ref()` first
- Mention `SSL_SESSION_dup()` as an alternative approach

This is a documentation-only fix. As noted by @bob-beck in the issue, the existing behavior is correct per the documented contract - the issue was that the documentation wasn't explicit enough about the implications when the callback is called multiple times.

Fixes #28267

## Test plan

- [x] Run `make doc-nits` to verify documentation standards

🤖 Generated with [Claude Code](https://claude.ai/code)