### PR TITLE
doc: fix incorrect parameter reference in EVP_MAC key parameter

### DIFF
--- a/doc/man3/EVP_MAC.pod
+++ b/doc/man3/EVP_MAC.pod
@@ -259,7 +259,7 @@ The standard parameter names are:
 Its value is the MAC key as an array of bytes.
 
 For MACs that use an underlying computation algorithm, the algorithm
-must be set first, see parameter names "algorithm" below.
+must be set first, see the "cipher" and "digest" parameters below.
 
 =item "iv" (B<OSSL_MAC_PARAM_IV>) <octet string>
 


### PR DESCRIPTION
## Summary
- Fix the documentation for the EVP_MAC "key" parameter which incorrectly references a non-existent "algorithm" parameter
- Update to correctly reference the "cipher" and "digest" parameters which are used to set the underlying computation algorithm

## Test plan
- [x] Documentation lint passes (`util/find-doc-nits`)

Fixes #12580

🤖 Generated with [Claude Code](https://claude.com/claude-code)