### PR TITLE
doc: add return value documentation for EVP_CIPHER_*_params functions

### DIFF
--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -1468,6 +1468,9 @@ for failure.
 EVP_CIPHER_names_do_all() returns 1 if the callback was called for all names.
 A return value of 0 means that the callback was not called for any names.
 
+EVP_CIPHER_get_params(), EVP_CIPHER_CTX_get_params() and
+EVP_CIPHER_CTX_set_params() return 1 for success and 0 for failure.
+
 =head1 CIPHER LISTING
 
 All algorithms have a fixed key length unless otherwise stated.


### PR DESCRIPTION
## Summary

Document the return values for EVP_CIPHER_get_params(), EVP_CIPHER_CTX_get_params() and EVP_CIPHER_CTX_set_params() functions.

## Details

These functions were missing from the RETURN VALUES section of EVP_EncryptInit(3). All three functions return 1 for success and 0 for failure, consistent with other EVP functions.

Fixes #29725

CLA: trivial

🤖 Generated with [Claude Code](https://claude.com/claude-code)