### PR TITLE
doc: clarify -verifyCAfile and related options in s_server

### DIFF
--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -335,20 +335,24 @@ Download CRLs from distribution points given in CDP extensions of certificates
 
 =item B<-verifyCAfile> I<filename>
 
-A file in PEM format CA containing trusted certificates to use
-for verifying client certificates.
+A file in PEM format containing trusted CA certificates to use
+as trust anchors when verifying client certificates.
+Typically this file contains the specific issuing CA certificates that are
+authorized to issue client authentication certificates.
+If root CA certificates are included, then any certificate issued under
+that root CA's PKI hierarchy may be accepted for client authentication.
 
 =item B<-verifyCApath> I<dir>
 
-A directory containing trusted certificates to use
-for verifying client certificates.
+A directory containing trusted CA certificates to use
+as trust anchors when verifying client certificates.
 This directory must be in "hash format",
 see L<openssl-verify(1)> for more information.
 
 =item B<-verifyCAstore> I<uri>
 
-The URI of a store containing trusted certificates to use
-for verifying client certificates.
+The URI of a store containing trusted CA certificates to use
+as trust anchors when verifying client certificates.
 
 =item B<-chainCAfile> I<file>
 


### PR DESCRIPTION
## Summary

- Clarifies that `-verifyCAfile`, `-verifyCApath`, and `-verifyCAstore` should contain CA certificates
- Explains their role as "trust anchors" in client certificate verification
- Adds explicit warning about security implications of including root CAs

## Problem

The original documentation said these options take "trusted certificates" which was ambiguous. System administrators may not realize that including root CA certificates means any certificate issued under that entire PKI hierarchy would be accepted for client authentication, rather than just specific issuing CA certificates.

## Changes

**Before:**
> A file in PEM format CA containing trusted certificates to use for verifying client certificates.

**After:**
> A file in PEM format containing trusted CA certificates to use as trust anchors when verifying client certificates. Typically this file contains the specific issuing CA certificates that are authorized to issue client authentication certificates. If root CA certificates are included, then any certificate issued under that root CA's PKI hierarchy may be accepted for client authentication.

Similar clarifications were made to `-verifyCApath` and `-verifyCAstore`.

## Test plan

- [x] Generated POD file passes `podchecker` validation
- [x] No nits reported by `util/find-doc-nits -n`

Fixes #29584

🤖 Generated with [Claude Code](https://claude.com/claude-code)