### PR TITLE
doc: document OSSL_PKEY_PARAM_BITS meaning for each key type

### DIFF
--- a/doc/man3/EVP_PKEY_get_size.pod
+++ b/doc/man3/EVP_PKEY_get_size.pod
@@ -40,7 +40,61 @@ receive that length), to avoid bugs.
 
 EVP_PKEY_get_bits() returns the cryptographic length of the cryptosystem
 to which the key in I<pkey> belongs, in bits.  Note that the definition
-of cryptographic length is specific to the key cryptosystem.
+of cryptographic length is specific to the key cryptosystem:
+
+=over 4
+
+=item B<RSA>
+
+The bit length of the modulus B<n>.
+
+=item B<DSA>
+
+The bit length of the prime B<p>.
+
+=item B<DH>
+
+The bit length of the prime B<p>.
+
+=item B<EC>
+
+The bit length of the group order.
+
+=item B<X25519>
+
+253 (fixed for the curve).
+
+=item B<X448>
+
+448 (fixed for the curve).
+
+=item B<Ed25519>
+
+256 (fixed for the curve).
+
+=item B<Ed448>
+
+456 (fixed for the curve).
+
+=item B<ML-DSA>
+
+The bit size of the public key (8 times the public key length in bytes).
+For B<ML-DSA-44>, B<ML-DSA-65>, and B<ML-DSA-87>, this is 10496, 15616, and
+20736 bits respectively.
+
+=item B<SLH-DSA>
+
+The bit size of the public key (8 times the public key length in bytes).
+For B<SLH-DSA*128*>, B<SLH-DSA*192*>, and B<SLH-DSA*256*> variants, this is
+256, 384, and 512 bits respectively.
+
+=item B<ML-KEM>
+
+The security strength indicator from the algorithm name: 512, 768, or 1024
+for B<ML-KEM-512>, B<ML-KEM-768>, and B<ML-KEM-1024> respectively.
+
+=back
+
 This length corresponds to the provider parameter B<OSSL_PKEY_PARAM_BITS>.
 
 EVP_PKEY_get_security_bits() returns the number of security bits of the given


### PR DESCRIPTION
## Summary

- Adds detailed documentation for what `OSSL_PKEY_PARAM_BITS` (returned by `EVP_PKEY_get_bits()`) means for each supported key type
- Previously, the documentation only stated that "the definition of cryptographic length is specific to the key cryptosystem" without explaining what that means for each type

The new documentation covers:
- **RSA**: bit length of the modulus n
- **DSA**: bit length of the prime p
- **DH**: bit length of the prime p
- **EC**: bit length of the group order
- **X25519**: 253 (fixed)
- **X448**: 448 (fixed)
- **Ed25519**: 256 (fixed)
- **Ed448**: 456 (fixed)
- **ML-DSA**: bit size of the public key
- **SLH-DSA**: bit size of the public key
- **ML-KEM**: security strength indicator from algorithm name

Fixes #28337

## Test plan

- [x] POD syntax validated with `podchecker`
- [x] Passed `util/find-doc-nits` checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)