### PR TITLE
Fix const spec in apps

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2663,7 +2663,7 @@ BIO *app_http_tls_cb(BIO *bio, void *arg, int connect, int detail)
         BIO *sbio = NULL;
         X509_STORE *ts = SSL_CTX_get_cert_store(ssl_ctx);
         X509_VERIFY_PARAM *vpm = X509_STORE_get0_param(ts);
-        const char *host = vpm == NULL ? NULL : X509_VERIFY_PARAM_get0_host(vpm, 0 /* first hostname */);
+        char *host = vpm == NULL ? NULL : X509_VERIFY_PARAM_get0_host(vpm, 0 /* first hostname */);
 
         /* adapt after fixing callback design flaw, see #17088 */
         if ((info->use_proxy

--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -471,7 +471,7 @@ long bio_dump_callback(BIO *bio, int cmd, const char *argp, size_t len,
     int argi, long argl, int ret, size_t *processed)
 {
     BIO *out;
-    BIO_MMSG_CB_ARGS *mmsgargs;
+    const BIO_MMSG_CB_ARGS *mmsgargs;
     size_t i;
 
     out = (BIO *)BIO_get_callback_arg(bio);
@@ -502,14 +502,14 @@ long bio_dump_callback(BIO *bio, int cmd, const char *argp, size_t len,
         break;
 
     case (BIO_CB_RECVMMSG | BIO_CB_RETURN):
-        mmsgargs = (BIO_MMSG_CB_ARGS *)argp;
+        mmsgargs = (const BIO_MMSG_CB_ARGS *)argp;
         if (ret > 0) {
             for (i = 0; i < *(mmsgargs->msgs_processed); i++) {
                 BIO_MSG *msg = (BIO_MSG *)((char *)mmsgargs->msg
                     + (i * mmsgargs->stride));
 
                 BIO_printf(out, "read from %p [%p] (%zu bytes => %zu (0x%zX))\n",
-                    (void *)bio, (void *)msg->data, msg->data_len,
+                    (void *)bio, msg->data, msg->data_len,
                     msg->data_len, msg->data_len);
                 if (msg->data_len <= INT_MAX)
                     BIO_dump(out, msg->data, (int)msg->data_len);
@@ -518,19 +518,19 @@ long bio_dump_callback(BIO *bio, int cmd, const char *argp, size_t len,
             BIO_MSG *msg = mmsgargs->msg;
 
             BIO_printf(out, "read from %p [%p] (%zu bytes => %d)\n",
-                (void *)bio, (void *)msg->data, msg->data_len, ret);
+                (void *)bio, msg->data, msg->data_len, ret);
         }
         break;
 
     case (BIO_CB_SENDMMSG | BIO_CB_RETURN):
-        mmsgargs = (BIO_MMSG_CB_ARGS *)argp;
+        mmsgargs = (const BIO_MMSG_CB_ARGS *)argp;
         if (ret > 0) {
             for (i = 0; i < *(mmsgargs->msgs_processed); i++) {
                 BIO_MSG *msg = (BIO_MSG *)((char *)mmsgargs->msg
                     + (i * mmsgargs->stride));
 
                 BIO_printf(out, "write to %p [%p] (%zu bytes => %zu (0x%zX))\n",
-                    (void *)bio, (void *)msg->data, msg->data_len,
+                    (void *)bio, msg->data, msg->data_len,
                     msg->data_len, msg->data_len);
                 if (msg->data_len <= INT_MAX)
                     BIO_dump(out, msg->data, (int)msg->data_len);
@@ -539,7 +539,7 @@ long bio_dump_callback(BIO *bio, int cmd, const char *argp, size_t len,
             BIO_MSG *msg = mmsgargs->msg;
 
             BIO_printf(out, "write to %p [%p] (%zu bytes => %d)\n",
-                (void *)bio, (void *)msg->data, msg->data_len, ret);
+                (void *)bio, msg->data, msg->data_len, ret);
         }
         break;
 

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -995,7 +995,7 @@ int s_client_main(int argc, char **argv)
 #if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_MSDOS)
     struct timeval tv;
 #endif
-    const char *servername = NULL;
+    char *servername = NULL;
     char *sname_alloc = NULL;
     int noservername = 0;
     const char *alpn_in = NULL;
@@ -2648,10 +2648,10 @@ re_start:
         int bytes = 0;
         int ssl_flg = 0x800;
         int pos;
-        const unsigned char *packet = (const unsigned char *)sbuf;
+        unsigned char *packet = (unsigned char *)sbuf;
 
         /* Receiving Initial Handshake packet. */
-        bytes = BIO_read(sbio, (void *)packet, BUFSIZZ);
+        bytes = BIO_read(sbio, packet, BUFSIZZ);
         if (bytes < 0) {
             BIO_printf(bio_err, "BIO_read failed\n");
             goto shut;
@@ -3689,7 +3689,7 @@ static int ocsp_resp_cb(SSL *s, void *arg)
         rsp = d2i_OCSP_RESPONSE(NULL, &p, len);
         if (rsp == NULL) {
             BIO_puts(arg, "OCSP response parse error\n");
-            BIO_dump_indent(arg, (char *)p, len, 4);
+            BIO_dump_indent(arg, p, len, 4);
             return 0;
         }
         print_ocsp_response(arg, rsp);


### PR DESCRIPTION
This patch fixes several const specifiers
(visible with non-default const-qual warning).

 - Functions like SSL_set_tlsext_host_name takes non-cost hostname parameter.

 - packet buffer is read in BIO_read, so it cannot be const

The rest is missing const specifiers where casting to non-cost is not needed.
