### PR TITLE
Fix const spec in ssl

### DIFF
--- a/ssl/quic/quic_cfq.c
+++ b/ssl/quic/quic_cfq.c
@@ -26,42 +26,42 @@ struct quic_cfq_item_ex_st {
 
 uint64_t ossl_quic_cfq_item_get_frame_type(const QUIC_CFQ_ITEM *item)
 {
-    QUIC_CFQ_ITEM_EX *ex = (QUIC_CFQ_ITEM_EX *)item;
+    const QUIC_CFQ_ITEM_EX *ex = (const QUIC_CFQ_ITEM_EX *)item;
 
     return ex->frame_type;
 }
 
 const unsigned char *ossl_quic_cfq_item_get_encoded(const QUIC_CFQ_ITEM *item)
 {
-    QUIC_CFQ_ITEM_EX *ex = (QUIC_CFQ_ITEM_EX *)item;
+    const QUIC_CFQ_ITEM_EX *ex = (const QUIC_CFQ_ITEM_EX *)item;
 
     return ex->encoded;
 }
 
 size_t ossl_quic_cfq_item_get_encoded_len(const QUIC_CFQ_ITEM *item)
 {
-    QUIC_CFQ_ITEM_EX *ex = (QUIC_CFQ_ITEM_EX *)item;
+    const QUIC_CFQ_ITEM_EX *ex = (const QUIC_CFQ_ITEM_EX *)item;
 
     return ex->encoded_len;
 }
 
 int ossl_quic_cfq_item_get_state(const QUIC_CFQ_ITEM *item)
 {
-    QUIC_CFQ_ITEM_EX *ex = (QUIC_CFQ_ITEM_EX *)item;
+    const QUIC_CFQ_ITEM_EX *ex = (const QUIC_CFQ_ITEM_EX *)item;
 
     return ex->state;
 }
 
 uint32_t ossl_quic_cfq_item_get_pn_space(const QUIC_CFQ_ITEM *item)
 {
-    QUIC_CFQ_ITEM_EX *ex = (QUIC_CFQ_ITEM_EX *)item;
+    const QUIC_CFQ_ITEM_EX *ex = (const QUIC_CFQ_ITEM_EX *)item;
 
     return ex->pn_space;
 }
 
 int ossl_quic_cfq_item_is_unreliable(const QUIC_CFQ_ITEM *item)
 {
-    QUIC_CFQ_ITEM_EX *ex = (QUIC_CFQ_ITEM_EX *)item;
+    const QUIC_CFQ_ITEM_EX *ex = (const QUIC_CFQ_ITEM_EX *)item;
 
     return (ex->flags & QUIC_CFQ_ITEM_FLAG_UNRELIABLE) != 0;
 }

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -865,7 +865,7 @@ static int port_try_handle_stateless_reset(QUIC_PORT *port, const QUIC_URXE *e)
 
     for (i = 0;; ++i) {
         if (!ossl_quic_srtm_lookup(port->srtm,
-                (QUIC_STATELESS_RESET_TOKEN *)(data + e->data_len
+                (const QUIC_STATELESS_RESET_TOKEN *)(data + e->data_len
                     - sizeof(QUIC_STATELESS_RESET_TOKEN)),
                 i, &opaque, NULL))
             break;

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -741,8 +741,8 @@ static int xname_cmp(const X509_NAME *a, const X509_NAME *b)
     /* X509_NAME_cmp() itself casts away constness in this way, so
      * assume it's safe:
      */
-    alen = i2d_X509_NAME((X509_NAME *)a, &abuf);
-    blen = i2d_X509_NAME((X509_NAME *)b, &bbuf);
+    alen = i2d_X509_NAME(a, &abuf);
+    blen = i2d_X509_NAME(b, &bbuf);
 
     if (alen < 0 || blen < 0)
         ret = -2;
@@ -765,7 +765,7 @@ static int xname_sk_cmp(const X509_NAME *const *a, const X509_NAME *const *b)
 static unsigned long xname_hash(const X509_NAME *a)
 {
     /* This returns 0 also if SHA1 is not available */
-    return X509_NAME_hash_ex((X509_NAME *)a, NULL, NULL, NULL);
+    return X509_NAME_hash_ex(a, NULL, NULL, NULL);
 }
 
 STACK_OF(X509_NAME) *SSL_load_client_CA_file_ex(const char *file,

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -8147,7 +8147,7 @@ int SSL_add_expected_rpk(SSL *s, EVP_PKEY *rpk)
 
 EVP_PKEY *SSL_get0_peer_rpk(const SSL *s)
 {
-    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+    const SSL_CONNECTION *sc = SSL_CONNECTION_FROM_CONST_SSL(s);
 
     if (sc == NULL || sc->session == NULL)
         return NULL;
@@ -8156,7 +8156,7 @@ EVP_PKEY *SSL_get0_peer_rpk(const SSL *s)
 
 int SSL_get_negotiated_client_cert_type(const SSL *s)
 {
-    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+    const SSL_CONNECTION *sc = SSL_CONNECTION_FROM_CONST_SSL(s);
 
     if (sc == NULL)
         return 0;
@@ -8166,7 +8166,7 @@ int SSL_get_negotiated_client_cert_type(const SSL *s)
 
 int SSL_get_negotiated_server_cert_type(const SSL *s)
 {
-    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+    const SSL_CONNECTION *sc = SSL_CONNECTION_FROM_CONST_SSL(s);
 
     if (sc == NULL)
         return 0;

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -61,7 +61,7 @@ void ssl_session_calculate_timeout(SSL_SESSION *ss)
 SSL_SESSION *SSL_get_session(const SSL *ssl)
 /* aka SSL_get0_session; gets 0 objects, just returns a copy of the pointer */
 {
-    const SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(ssl);
+    const SSL_CONNECTION *sc = SSL_CONNECTION_FROM_CONST_SSL(ssl);
 
     if (sc == NULL)
         return NULL;

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -469,7 +469,7 @@ int tls1_export_keying_material(SSL_CONNECTION *s, unsigned char *out,
     if (val == NULL)
         goto ret;
     currentvalpos = 0;
-    memcpy(val + currentvalpos, (unsigned char *)label, llen);
+    memcpy(val + currentvalpos, label, llen);
     currentvalpos += llen;
     memcpy(val + currentvalpos, s->s3.client_random, SSL3_RANDOM_SIZE);
     currentvalpos += SSL3_RANDOM_SIZE;


### PR DESCRIPTION
This patch fixes several const specifiers and undeeded casts (visible with non-default const-qual warning).
