### PR TITLE
Fix const spec in test

### DIFF
--- a/test/bio_dgram_test.c
+++ b/test/bio_dgram_test.c
@@ -471,7 +471,7 @@ static int random_data(const uint32_t *key, uint8_t *data, size_t data_len, size
     if (cipher == NULL)
         goto err;
 
-    if (EVP_EncryptInit_ex2(ctx, cipher, (uint8_t *)key, (uint8_t *)counter, NULL) == 0)
+    if (EVP_EncryptInit_ex2(ctx, cipher, (const uint8_t *)key, (uint8_t *)counter, NULL) == 0)
         goto err;
 
     while (data_len > 0) {

--- a/test/dhkem_test.inc
+++ b/test/dhkem_test.inc
@@ -572,7 +572,7 @@ static EVP_PKEY *new_raw_private_key(const char *curvename,
 
     if (ecx) {
         if (!OSSL_PARAM_BLD_push_octet_string(bld, OSSL_PKEY_PARAM_PRIV_KEY,
-                                             (char *)priv, privlen))
+                                             priv, privlen))
             goto err;
     } else {
         privbn = BN_bin2bn(priv, (int)privlen, NULL);
@@ -587,7 +587,7 @@ static EVP_PKEY *new_raw_private_key(const char *curvename,
 
     if (pub != NULL) {
         if (!OSSL_PARAM_BLD_push_octet_string(bld, OSSL_PKEY_PARAM_PUB_KEY,
-                                             (char *)pub, publen))
+                                             pub, publen))
             goto err;
     }
     params = OSSL_PARAM_BLD_to_param(bld);

--- a/test/dtlsv1listentest.c
+++ b/test/dtlsv1listentest.c
@@ -312,7 +312,7 @@ static int dtls_listen_test(int i)
     SSL_set0_wbio(ssl, outbio);
 
     /* Set Non-blocking IO behaviour */
-    if (!TEST_ptr(inbio = BIO_new_mem_buf((char *)tp->in, tp->inlen)))
+    if (!TEST_ptr(inbio = BIO_new_mem_buf(tp->in, tp->inlen)))
         goto err;
     BIO_set_mem_eof_return(inbio, -1);
     SSL_set0_rbio(ssl, inbio);

--- a/test/priority_queue_test.c
+++ b/test/priority_queue_test.c
@@ -35,12 +35,12 @@ static int size_t_compare(const size_t *a, const size_t *b)
 
 static int qsort_size_t_compare(const void *a, const void *b)
 {
-    return size_t_compare((size_t *)a, (size_t *)b);
+    return size_t_compare((const size_t *)a, (const size_t *)b);
 }
 
 static int qsort_size_t_compare_rev(const void *a, const void *b)
 {
-    return size_t_compare((size_t *)b, (size_t *)a);
+    return size_t_compare((const size_t *)b, (const size_t *)a);
 }
 
 static void free_checker(ossl_unused size_t *p)

--- a/test/quic_wire_test.c
+++ b/test/quic_wire_test.c
@@ -1321,7 +1321,7 @@ static int test_wire_encode(int idx)
          * truncated encoding is passed as an argument to the deserializer to
          * help it determine whether decoding should fail or not.
          */
-        if (!TEST_int_eq(PACKET_buf_init(&pkt2, (unsigned char *)c->expect_buf, i), 1))
+        if (!TEST_int_eq(PACKET_buf_init(&pkt2, c->expect_buf, i), 1))
             goto err;
 
         if (!TEST_int_eq(c->deserializer(&pkt2, i), 1))
@@ -1485,7 +1485,7 @@ static int test_wire_ack(int idx)
     const struct ack_test_case *c = &ack_cases[idx];
 
     if (!TEST_int_eq(PACKET_buf_init(&pkt,
-                         (unsigned char *)c->input_buf,
+                         c->input_buf,
                          c->input_buf_len),
             1))
         goto err;

--- a/test/testutil/tests.c
+++ b/test/testutil/tests.c
@@ -238,8 +238,8 @@ DEFINE_COMPARISONS(uint64_t, uint64_t, "%llu", unsigned long long)
 DEFINE_COMPARISONS(size_t, size_t, "%zu", size_t)
 DEFINE_COMPARISONS(double, double, "%g", double)
 
-DEFINE_COMPARISON(void *, ptr, eq, ==, "%p", void *)
-DEFINE_COMPARISON(void *, ptr, ne, !=, "%p", void *)
+DEFINE_COMPARISON(void *, ptr, eq, ==, "%p", const void *)
+DEFINE_COMPARISON(void *, ptr, ne, !=, "%p", const void *)
 
 int test_ptr_null(const char *file, int line, const char *s, const void *p)
 {

--- a/test/tls13groupselection_test.c
+++ b/test/tls13groupselection_test.c
@@ -317,7 +317,7 @@ static void server_response_check_cb(int write_p, int version,
     /* Cast arg to SERVER_RESPONSE */
     enum SERVER_RESPONSE *server_response = (enum SERVER_RESPONSE *)arg;
     /* Prepare check for HRR */
-    const uint8_t *incoming_random = (uint8_t *)buf + 6;
+    const uint8_t *incoming_random = (const uint8_t *)buf + 6;
     const uint8_t magic_HRR_random[32] = { 0xCF, 0x21, 0xAD, 0x74, 0xE5, 0x9A, 0x61, 0x11,
         0xBE, 0x1D, 0x8C, 0x02, 0x1E, 0x65, 0xB8, 0x91,
         0xC2, 0xA2, 0x11, 0x16, 0x7A, 0xBB, 0x8C, 0x5E,
@@ -329,7 +329,7 @@ static void server_response_check_cb(int write_p, int version,
         version == TLS1_3_VERSION && /* for TLSv1.3 ... */
         ((uint8_t *)buf)[0] == SSL3_MT_SERVER_HELLO) { /* with message type "ServerHello" */
         /* Check what it is: SH or HRR (compare the 'random' data field with HRR magic number) */
-        if (memcmp((void *)incoming_random, (void *)magic_HRR_random, 32) == 0)
+        if (memcmp(incoming_random, magic_HRR_random, 32) == 0)
             *server_response *= HRR;
         else
             *server_response *= SH;

--- a/test/x509_test.c
+++ b/test/x509_test.c
@@ -152,14 +152,14 @@ static int test_asn1_item_verify(void)
     X509_get0_signature(&sig, &alg, x509);
 
     if (!TEST_int_gt(ASN1_item_verify(ASN1_ITEM_rptr(X509_CINF),
-                         (X509_ALGOR *)alg, (ASN1_BIT_STRING *)sig,
+                         alg, sig,
                          &x509->cert_info, pkey),
             0))
         goto err;
 
     ERR_set_mark();
     if (!TEST_int_lt(ASN1_item_verify(ASN1_ITEM_rptr(X509_CINF),
-                         (X509_ALGOR *)alg, (ASN1_BIT_STRING *)sig,
+                         alg, sig,
                          NULL, pkey),
             0)) {
         ERR_clear_last_mark();


### PR DESCRIPTION
This patch fixes several const specifiers and unneeded casts (visible with non-default const-qual warning).
