### PR TITLE
[3.3, 3.0] Backport of "Fix invalid expression syntax" (in `.github/workflows/windows.yml`) to `openssl-3.3` and `openssl-3.0`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -71,7 +71,7 @@ jobs:
       run: nmake test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4
     - name: install
       # Run on 64 bit only as 32 bit is slow enough already
-      if: $${{ matrix.platform.arch == 'win64' }}
+      if: ${{ matrix.platform.arch == 'win64' }}
       run: |
         mkdir _dest
         nmake install DESTDIR=_dest


### PR DESCRIPTION
This is a backport of [1] to `openssl-3.3` and `openssl-3.0`, as the issue is still present there.

[1] https://github.com/openssl/openssl/pull/24325