### PR TITLE
Add test for EVP_KEYMGMT leak in evp_pkey_signature_init() error paths

### DIFF
--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -5800,6 +5800,52 @@ end:
     return testresult;
 }
 
+#ifndef OPENSSL_NO_EC
+/*
+ * Test that EVP_PKEY_sign_init_ex2() with a mismatched key/signature algorithm
+ * (e.g. RSA key with ECDSA signature) correctly fails.
+ */
+static int test_EVP_PKEY_sign_init_mismatched_key_alg(void)
+{
+    EVP_PKEY *rsa_key = NULL;
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY_CTX *pkey_ctx = NULL;
+    EVP_SIGNATURE *ecdsa_sig = NULL;
+    int testresult = 0;
+
+    /* Generate an RSA key */
+    if (!TEST_ptr(pkey_ctx = EVP_PKEY_CTX_new_from_name(testctx, "RSA", NULL))
+        || !TEST_int_gt(EVP_PKEY_keygen_init(pkey_ctx), 0)
+        || !TEST_int_gt(EVP_PKEY_CTX_set_rsa_keygen_bits(pkey_ctx, 2048), 0)
+        || !TEST_int_gt(EVP_PKEY_keygen(pkey_ctx, &rsa_key), 0))
+        goto end;
+
+    EVP_PKEY_CTX_free(pkey_ctx);
+    pkey_ctx = NULL;
+
+    /* Fetch ECDSA signature algorithm - incompatible with RSA key */
+    if (!TEST_ptr(ecdsa_sig = EVP_SIGNATURE_fetch(testctx, "ECDSA", NULL)))
+        goto end;
+
+    /* Try to init sign with mismatched key/algorithm - this should fail */
+    if (!TEST_ptr(ctx = EVP_PKEY_CTX_new_from_pkey(testctx, rsa_key, NULL)))
+        goto end;
+
+    /* This should fail with -2 (operation not supported for key type) */
+    if (!TEST_int_eq(EVP_PKEY_sign_init_ex2(ctx, ecdsa_sig, NULL), -2))
+        goto end;
+
+    testresult = 1;
+
+end:
+    EVP_PKEY_CTX_free(ctx);
+    EVP_PKEY_CTX_free(pkey_ctx);
+    EVP_SIGNATURE_free(ecdsa_sig);
+    EVP_PKEY_free(rsa_key);
+    return testresult;
+}
+#endif
+
 static int aes_gcm_encrypt(const unsigned char *gcm_key, size_t gcm_key_s,
     const unsigned char *gcm_iv, size_t gcm_ivlen,
     const unsigned char *gcm_pt, size_t gcm_pt_s,
@@ -6347,6 +6393,9 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_EVP_PKEY_sign, 3);
 #ifndef OPENSSL_NO_DEPRECATED_3_0
     ADD_ALL_TESTS(test_EVP_PKEY_sign_with_app_method, 2);
+#endif
+#ifndef OPENSSL_NO_EC
+    ADD_TEST(test_EVP_PKEY_sign_init_mismatched_key_alg);
 #endif
     ADD_ALL_TESTS(test_EVP_Enveloped, 2);
     ADD_ALL_TESTS(test_d2i_AutoPrivateKey, OSSL_NELEM(keydata));


### PR DESCRIPTION
This PR adds the requested test case for #29651 

Without the fix in #29651, running the test with ASan enabled will fail with:

```
=================================================================
==3383394==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 256 byte(s) in 1 object(s) allocated from:
    #0 0x7f8fdeebf91f in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x56151ec30840 in CRYPTO_malloc crypto/mem.c:214
    #2 0x56151ec30a44 in CRYPTO_zalloc crypto/mem.c:226
    #3 0x56151ebf41ee in keymgmt_new crypto/evp/keymgmt_meth.c:34
    #4 0x56151ebf41ee in keymgmt_from_algorithm crypto/evp/keymgmt_meth.c:75
    #5 0x56151ebdee71 in construct_evp_method crypto/evp/evp_fetch.c:230
    #6 0x56151ec297f5 in ossl_method_construct_this crypto/core_fetch.c:110
    #7 0x56151ec28f45 in algorithm_do_map crypto/core_algorithm.c:77
    #8 0x56151ec28f45 in algorithm_do_this crypto/core_algorithm.c:122
    ...
::group::Indirect Leaks
Indirect leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x7f8fdeebf91f in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x56151ec30840 in CRYPTO_malloc crypto/mem.c:214
    #2 0x56151ec32c63 in CRYPTO_strndup crypto/o_str.c:47
    #3 0x56151ebf4268 in keymgmt_from_algorithm crypto/evp/keymgmt_meth.c:79
    #4 0x56151ebdee71 in construct_evp_method crypto/evp/evp_fetch.c:230
    #5 0x56151ec297f5 in ossl_method_construct_this crypto/core_fetch.c:110
    #6 0x56151ec28f45 in algorithm_do_map crypto/core_algorithm.c:77
    #7 0x56151ec28f45 in algorithm_do_this crypto/core_algorithm.c:122
    ...
SUMMARY: AddressSanitizer: 260 byte(s) leaked in 2 allocation(s).
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] tests are added or updated
