### PR TITLE
QUIC LCID hash table collapse on Windows/32-bit due to SipHash digest…

### DIFF
--- a/ssl/quic/quic_lcidm.c
+++ b/ssl/quic/quic_lcidm.c
@@ -87,7 +87,6 @@ static unsigned long lcid_hash(const QUIC_LCID *lcid_obj)
 
     /*
      * Truncate the 64-bit SipHash digest into an unsigned long.
-     * Copy the least significant bytes; this is sufficient for LHASH.
      */
     memcpy(&hashval, digest, sizeof(hashval) < sizeof(digest) ? sizeof(hashval) : sizeof(digest));
 out:


### PR DESCRIPTION
… size misuse

Using sizeof(unsigned long) as SipHash digest size; SipHash supports only 8 or 16 bytes. On platforms where sizeof(unsigned long) == 4, the call fails, and lcid_hash returns the zero-initialized value, degrading the hash table into list.

The issue was kindly reported by Stanislav Fort at Aisle Research.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
