### PR TITLE
Sparc asm: remove whitespace that breaks asm syntax in generated files

### DIFF
--- a/include/crypto/sparc_arch.h
+++ b/include/crypto/sparc_arch.h
@@ -79,10 +79,14 @@
 
 #if defined(__arch64__)
 
+/* clang-format off */
 #define SPARC_LOAD_ADDRESS(SYM, reg) \
     setx SYM, %o7, reg;
+/* clang-format on */
 #define LDPTR ldx
+/* clang-format off */
 #define SIZE_T_CC %xcc
+/* clang-format on */
 #define STACK_FRAME 192
 #define STACK_BIAS 2047
 #define STACK_7thARG (STACK_BIAS + 176)
@@ -92,7 +96,9 @@
 #define SPARC_LOAD_ADDRESS(SYM, reg) \
     set SYM, reg;
 #define LDPTR ld
+/* clang-format off */
 #define SIZE_T_CC %icc
+/* clang-format on */
 #define STACK_FRAME 112
 #define STACK_BIAS 0
 #define STACK_7thARG 92


### PR DESCRIPTION
This fixes #29808.

Trivial fix.