### PR TITLE
Explicitly define `SIO_UDP_NETRESET` for MinGW builds.

### DIFF
--- a/ssl/quic/quic_reactor.c
+++ b/ssl/quic/quic_reactor.c
@@ -79,7 +79,7 @@ void ossl_quic_reactor_cleanup(QUIC_REACTOR *rtor)
 
 /* Work around for MinGW builds. */
 #if defined(__MINGW32__) && !defined(SIO_UDP_NETRESET)
-#  define SIO_UDP_NETRESET _WSAIOW(IOC_VENDOR, 15)
+#define SIO_UDP_NETRESET _WSAIOW(IOC_VENDOR, 15)
 #endif
 
 /*


### PR DESCRIPTION
This patch explicitly defines the value `SIO_UDP_NETRESET` according to both what Windows and ReactOS does.

Fixes: #29818.
