### PR TITLE
This patch fix #29815 that built on big-endian ppc64 failed.

### DIFF
--- a/crypto/modes/asm/aes-gcm-ppc.pl
+++ b/crypto/modes/asm/aes-gcm-ppc.pl
@@ -409,7 +409,6 @@ my $code.=<<___;
 ################################################################################
 .align 4
 aes_gcm_crypt_1x:
-.localentry	aes_gcm_crypt_1x,0
 
 	cmpdi	5, 16
 	bge	__More_1x
@@ -492,7 +491,6 @@ __Encrypt_1x:
 ################################################################################
 .align 4
 __Process_partial:
-.localentry	__Process_partial,0
 
 	# create partial mask
 	vspltisb 16, -1
@@ -564,7 +562,6 @@ __Encrypt_partial:
 .global ppc_aes_gcm_encrypt
 .align 5
 ppc_aes_gcm_encrypt:
-.localentry     ppc_aes_gcm_encrypt,0
 
 	SAVE_REGS
 	LOAD_HASH_TABLE
@@ -752,7 +749,6 @@ __Process_more_enc:
 .global ppc_aes_gcm_decrypt
 .align 5
 ppc_aes_gcm_decrypt:
-.localentry	ppc_aes_gcm_decrypt, 0
 
 	SAVE_REGS
 	LOAD_HASH_TABLE
@@ -1032,7 +1028,6 @@ __Process_more_dec:
 .size   ppc_aes_gcm_decrypt,.-ppc_aes_gcm_decrypt
 
 aes_gcm_out:
-.localentry	aes_gcm_out,0
 
 	mr	3, 11			# return count
 


### PR DESCRIPTION
This patch fix #29815 that built on big-endian ppc64 failed.
Removed .localentry directive to prevent mixing ELFv1 ABI and ELFv2 ABI directives.

Signed-off-by: Danny Tsen <dtsen@us.ibm.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
