### PR TITLE
Don't setup a default context while tearing down private contexts

### DIFF
--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -122,6 +122,7 @@ typedef struct ossl_ex_data_global_st {
 
 OSSL_LIB_CTX *ossl_lib_ctx_get_concrete(OSSL_LIB_CTX *ctx);
 int ossl_lib_ctx_is_default(OSSL_LIB_CTX *ctx);
+int ossl_lib_ctx_is_default_nocreate(OSSL_LIB_CTX *ctx);
 int ossl_lib_ctx_is_global_default(OSSL_LIB_CTX *ctx);
 
 /* Functions to retrieve pointers to data by index */


### PR DESCRIPTION
In providers/applications that create custom libctx'es via OSSL_LIB_CTX_new, its possible, if the default provider has never been initaialized during the lifetime of the linked libcrypto, that we actually wind up creating the default libctx when we free the aforementioned custom libctx via, as an example:
```
legacy_teardown->
 OSSL_LIB_CTX_free->
  ossl_lib_ctx_is_default->
   get_default_context->
    get_thread_default_context->
     default_context_do_init
```
While this isn't catastrophic, its needless, and in some cases has the potential to leak memory (for instance if a provider is loaded and unloaded repeatedly in an environment in which the provider is linked to libcrypto.so while the calling application is statically linked to libcrypto.a

Its also fairly easy to clean up, by adding an internal parameter to gate the creation of the default libctx on the request of the caller, so do that here

Fixes openssl/project#1846

