### PR TITLE
New providers section "modulesdir" keyword

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1652,6 +1652,8 @@ EOF
           return <<"EOF";
 $args{src}: $gen0 $deps
 	if [ -r "\$@" ]; then chmod u+w \$@; fi
+	SRCTOP=\$(SRCDIR) \\
+	BLDTOP=\$(BLDDIR) \\
 	\$(PERL)$perlmodules "$dofile" "-o$target{build_file}" $gen0$gen_args > \$@
 	chmod a-w \$@
 EOF
@@ -2012,6 +2014,8 @@ EOF
 $script: $sources configdata.pm
 	if [ -r "$script" ]; then chmod u+w $script; fi
 	\$(RM) "$script"
+	SRCTOP=\$(SRCDIR) \\
+	BLDTOP=\$(BLDDIR) \\
 	\$(PERL) "-I\$(BLDDIR)" -Mconfigdata "$dofile" \\
 	    "-o$target{build_file}" $sources > "$script"
 	chmod a+x,a-w $script

--- a/crypto/defaults.c
+++ b/crypto/defaults.c
@@ -106,8 +106,8 @@ out:
 static CRYPTO_ONCE defaults_setup_init = CRYPTO_ONCE_STATIC_INIT;
 
 /**
- * @brief Function to setup default values to run once.
- * Only used in Windows environments.  Does run time initialization
+ * @brief Function to set up default values to run once.
+ * Only used in Windows environments.  Does runtime initialization
  * of openssldir/modulesdir/enginesdir from the registry
  */
 DEFINE_RUN_ONCE_STATIC(do_defaults_setup)

--- a/crypto/provider_local.h
+++ b/crypto/provider_local.h
@@ -18,6 +18,7 @@ DEFINE_STACK_OF(INFOPAIR)
 typedef struct {
     char *name;
     char *path;
+    char *mdir;
     OSSL_provider_init_fn *init;
     STACK_OF(INFOPAIR) *parameters;
     unsigned int is_fallback : 1;

--- a/crypto/provider_predefined.c
+++ b/crypto/provider_predefined.c
@@ -19,14 +19,14 @@ OSSL_provider_init_fn ossl_legacy_provider_init;
 #endif
 const OSSL_PROVIDER_INFO ossl_predefined_providers[] = {
 #ifdef FIPS_MODULE
-    { "fips", NULL, ossl_fips_intern_provider_init, NULL, 1 },
+    { "fips", NULL, NULL, ossl_fips_intern_provider_init, NULL, 1 },
 #else
-    { "default", NULL, ossl_default_provider_init, NULL, 1 },
+    { "default", NULL, NULL, ossl_default_provider_init, NULL, 1 },
 #ifdef STATIC_LEGACY
-    { "legacy", NULL, ossl_legacy_provider_init, NULL, 0 },
+    { "legacy", NULL, NULL, ossl_legacy_provider_init, NULL, 0 },
 #endif
-    { "base", NULL, ossl_base_provider_init, NULL, 0 },
-    { "null", NULL, ossl_null_provider_init, NULL, 0 },
+    { "base", NULL, NULL, ossl_base_provider_init, NULL, 0 },
+    { "null", NULL, NULL, ossl_null_provider_init, NULL, 0 },
 #endif
-    { NULL, NULL, NULL, NULL, 0 }
+    { NULL, NULL, NULL, NULL, NULL, 0 }
 };

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -2,8 +2,8 @@
 
 =head1 NAME
 
-ossl_provider_find, ossl_provider_new, ossl_provider_up_ref,
-ossl_provider_free, ossl_provider_set_module_path,
+ossl_provider_find, ossl_provider_new, ossl_provider_up_ref, ossl_provider_free,
+ossl_provider_set_module_path, ossl_provider_set_module_dir,
 ossl_provider_set_child, ossl_provider_get_parent,
 ossl_provider_up_ref_parent, ossl_provider_free_parent,
 ossl_provider_default_props_update, ossl_provider_get0_dispatch,
@@ -36,6 +36,7 @@ ossl_provider_get_capabilities
 
  /* Setters */
  int ossl_provider_set_module_path(OSSL_PROVIDER *prov, const char *path);
+ int ossl_provider_set_module_dir(OSSL_PROVIDER *prov, const char *mdir);
 
  /* Child Providers */
  int ossl_provider_set_child(OSSL_PROVIDER *prov,
@@ -163,6 +164,11 @@ provider module given the provider object I<prov>.
 This will be used in preference to automatically trying to figure out
 the path from the provider name and the default module directory (more
 on this in L</NOTES>).
+
+ossl_provider_set_module_dir() sets the directory prefix to use when
+the module's shared object filename is either implicit or relative.
+This overrides both the C<OPENSSL_MODULES> environment variable, and
+the and the default module directory (more on this in L</NOTES>).
 
 ossl_provider_libctx() returns the library context the given
 provider I<prov> is registered in.
@@ -330,10 +336,14 @@ platform specific standard extensions added.
 
 =item 2.
 
-If the environment variable B<OPENSSL_MODULES> is defined, assume its
-value is a directory specification and merge it with the module path.
-Otherwise, merge the value of the OpenSSL built in macro B<MODULESDIR>
-with the module path.
+If the module path is already an absolute path, it is used as-is.
+If ossl_provider_set_module_dir() was used to specify a module
+directory (perhaps via a "module_path" directive in the B<providers>
+section of the configuration, that that directory is used to locate
+the module.
+Otherwise, if the environment variable C<OPENSSL_MODULES> is defined, assume
+its value is a directory specification use that.
+As a last resort, use the default B<MODULESDIR>.
 
 =back
 

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -242,10 +242,25 @@ showing that the OID "newoid1" has been added as "1.2.3.4.1".
 =head2 Provider Configuration
 
 The name B<providers> in the initialization section names the section
-containing cryptographic provider configuration. The name/value assignments
-in this section each name a provider, and point to the configuration section
-for that provider. The provider-specific section is used to specify how
-to load the module, activate it, and set other parameters.
+containing cryptographic provider configuration.
+
+The name C<modulesdir> has a reserved meaning in this section.
+If the assigned value is nonempty, for the providers that immedlately follow,
+it overrides both the C<OPENSSL_MODULES> environment variable and the default
+B<MODULESDIR> (as reported with the C<-m> option of L<openssl-version(1)>).
+This can be set multiple times, by adding a unique prefix followed by a C<.> to each
+instance (except perhaps one); each time affecting the immediately following
+providers.
+If set to an empty value, any previous setting is cleared and for the
+immediately following providers the C<OPENSSL_MODULES> environment variable or
+failing that the default B<MODULESDIR> are used instead.
+Providers that that are not activated by default store the value for use with
+later explicit activation.
+
+All other name/value assignments in this section each name a provider, and
+point to the configuration section for that provider.
+The provider-specific section is used to specify how to load the module,
+activate it, and set other parameters.
 
 Within a provider section, the following names have meaning:
 

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -37,7 +37,8 @@ int ossl_provider_up_ref(OSSL_PROVIDER *prov);
 void ossl_provider_free(OSSL_PROVIDER *prov);
 
 /* Setters */
-int ossl_provider_set_module_path(OSSL_PROVIDER *prov, const char *module_path);
+int ossl_provider_set_module_path(OSSL_PROVIDER *prov, const char *path);
+int ossl_provider_set_module_dir(OSSL_PROVIDER *prov, const char *mdir);
 
 int ossl_provider_is_child(const OSSL_PROVIDER *prov);
 int ossl_provider_set_child(OSSL_PROVIDER *prov, const OSSL_CORE_HANDLE *handle);

--- a/test/provider_internal_test.c
+++ b/test/provider_internal_test.c
@@ -80,15 +80,24 @@ static int test_loaded_provider(void)
 }
 
 #ifndef OPENSSL_NO_AUTOLOAD_CONFIG
-static int test_configured_provider(void)
+static int test_active_provider(void)
 {
-    const char *name = "p_test_configured";
+    const char *name = "p_test_active";
     OSSL_PROVIDER *prov = NULL;
     /* This MUST match the config file */
     const char *expected_greeting = "Hello OpenSSL, greetings from Test Provider";
 
     return TEST_ptr(prov = ossl_provider_find(NULL, name, 0))
         && test_provider(prov, expected_greeting);
+}
+
+static int test_passive_provider(void)
+{
+    const char *name = "p_test_passive";
+    OSSL_PROVIDER *prov = NULL;
+
+    return TEST_ptr(prov = ossl_provider_new(NULL, name, PROVIDER_INIT_FUNCTION_NAME, NULL, 0))
+        && test_provider(prov, expected_greeting1(name));
 }
 #endif
 #endif
@@ -132,11 +141,14 @@ err:
 
 int setup_tests(void)
 {
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+
     ADD_TEST(test_builtin_provider);
 #ifndef NO_PROVIDER_MODULE
     ADD_TEST(test_loaded_provider);
 #ifndef OPENSSL_NO_AUTOLOAD_CONFIG
-    ADD_TEST(test_configured_provider);
+    ADD_TEST(test_active_provider);
+    ADD_TEST(test_passive_provider);
 #endif
 #endif
     ADD_TEST(test_cache_flushes);

--- a/test/provider_internal_test.cnf.in
+++ b/test/provider_internal_test.cnf.in
@@ -8,9 +8,16 @@ openssl_conf = openssl_init
 providers = providers
 
 [providers]
-p_test_configured = p_test_configured
+0.modulesdir = ./active
+p_test_active = p_test_active
+1.modulesdir = ./passive
+p_test_passive = p_test_passive
 
-[p_test_configured]
-module = {- platform->dso('p_test') -}
+[p_test_active]
+module = {- platform->dso('p_test_active') -}
 activate = 1
 greeting = Hello OpenSSL, greetings from Test Provider
+
+[p_test_passive]
+module = {- platform->dso('p_test_passive') -}
+activate = 0

--- a/test/recipes/02-test_internal_provider.t
+++ b/test/recipes/02-test_internal_provider.t
@@ -7,13 +7,33 @@
 # https://www.openssl.org/source/license.html
 
 use strict;
-use OpenSSL::Test qw(:DEFAULT bldtop_dir bldtop_file);
+use File::Copy qw(cp);
+use OpenSSL::Test qw(:DEFAULT srctop_dir bldtop_dir);
 use OpenSSL::Test::Simple;
 use OpenSSL::Test::Utils;
 
-setup("test_internal_provider");
+BEGIN {
+    setup("test_internal_provider");
+}
 
-$ENV{OPENSSL_MODULES} = bldtop_dir("test");
-$ENV{OPENSSL_CONF} = bldtop_file("test", "provider_internal_test.cnf");
+use lib srctop_dir('Configurations');
+use lib bldtop_dir('.');
+use platform;
+my $dir = bldtop_dir("test");
+
+if (!disabled("dso")) {
+    my $ext = platform->dsoext();
+    my $dso = platform->dso('p_test');
+    my $active = platform->dso('p_test_active');
+    my $passive = platform->dso('p_test_passive');
+
+    mkdir("active") || die "mkdir(active): $!\n";
+    mkdir("passive") || die "mkdir(passive): $!\n";
+    cp("$dir/$dso", "active/$active") || die "cp $dir/$active: $!\n";
+    cp("$dir/$dso", "passive/$passive") || die "cp $dir/$passive: $!\n";
+}
+
+$ENV{OPENSSL_MODULES} = $dir;
+$ENV{OPENSSL_CONF} = "$dir/provider_internal_test.cnf";
 
 simple_test("test_internal_provider", "provider_internal_test");


### PR DESCRIPTION
In the [providers] section it is now possible to inject an override of both the OPENSSL_MODULES and underlying built-in MODULESDIR default that applies to the immediately following providers, until another such override is added.

Because section name/value pairs are deduplicated by name, to apply multiple settings an option "<whatever>." unique prefix is supported.

    [providers]
    modulesdir = /some/where1
    providerA = ...
    providerB = ...
    1.modulesdir = /some/where2
    providerC = ...
    2.modulesdir =
    providerD =

Setting the value empty clears the override for the subsequent providers, until perhaps another override is added...

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
