### PR TITLE
doc: document deprecated engine configure options

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -855,6 +855,14 @@ Note that if this feature is enabled then GOST ciphersuites are only available
 if the GOST algorithms are also available through loading an externally supplied
 engine.
 
+### no-{engine-option}
+
+    no-{engine|static-engine|dynamic-engine}
+
+These options are deprecated and do nothing.  They are retained for backwards
+compatibility only.  The ENGINE API has been deprecated in OpenSSL 3.0 and
+applications should transition to using providers instead.
+
 ### no-http
 
 Disable HTTP support.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -855,13 +855,12 @@ Note that if this feature is enabled then GOST ciphersuites are only available
 if the GOST algorithms are also available through loading an externally supplied
 engine.
 
-### no-{engine-option}
+### no-engine, no-static-engine, no-dynamic-engine
 
-    no-{engine|static-engine|dynamic-engine}
-
-These options are deprecated and do nothing.  They are retained for backwards
-compatibility only.  The ENGINE API has been deprecated in OpenSSL 3.0 and
-applications should transition to using providers instead.
+The `no-engine` option is always present.  These options are deprecated and do
+nothing, and are retained for backwards compatibility only.  The ENGINE API was
+deprecated in OpenSSL 3.0 and removed in OpenSSL 4.0, so applications should
+transition to using providers instead.
 
 ### no-http
 


### PR DESCRIPTION
## Summary
- Document that `no-engine`, `no-static-engine`, and `no-dynamic-engine` configure options are deprecated and do nothing
- These options are retained for backwards compatibility only

The issue reports that `no-static-engine` appears to have no effect (the feature still shows as enabled). This is because these options are in the `%deprecated_disablables` hash in Configure with value `undef`, meaning they're recognized but don't actually disable anything.

Fixes #27473

## Test plan
- [x] Documentation change only - no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)