### PR TITLE
doc: clarify -cipher option syntax in man pages

### DIFF
--- a/doc/man1/openssl-enc.pod.in
+++ b/doc/man1/openssl-enc.pod.in
@@ -61,7 +61,9 @@ either by itself or in addition to the encryption or decryption.
 
 =item B<-I<cipher>>
 
-The cipher to use.
+The cipher to use. This option is specified by prepending a hyphen to the
+cipher name (e.g., B<-aes-256-cbc>), not as an argument to a C<-cipher> flag.
+Use C<openssl list -cipher-algorithms> to see the available ciphers.
 
 =item B<-help>
 

--- a/doc/man1/openssl-genpkey.pod.in
+++ b/doc/man1/openssl-genpkey.pod.in
@@ -74,10 +74,15 @@ see L<openssl-passphrase-options(1)>.
 
 =item B<-I<cipher>>
 
-Encrypts the private key using the specified algorithm. The algorithm can be
-specified using a name that is accepted by the EVP_get_cipherbyname() function.
-For example, use the syntax B<-aes-128-cbc> to specify the AES encryption
-algorithm with a 128-bit key in CBC mode.
+Encrypts the private key with the specified cipher. This option is specified
+by prepending a hyphen to the cipher name. For example, to encrypt with
+AES-128 in CBC mode, use B<-aes-128-cbc>. To encrypt with AES-256 in CBC mode,
+use B<-aes-256-cbc>.
+
+Note: the cipher name is used directly as the option (e.g., B<-aes-256-cbc>),
+not as an argument to a C<-cipher> flag.
+
+Use C<openssl list -cipher-algorithms> to see the available ciphers.
 
 =item B<-algorithm> I<alg>
 

--- a/doc/man1/openssl-pkey.pod.in
+++ b/doc/man1/openssl-pkey.pod.in
@@ -130,10 +130,12 @@ See L<EVP_PKEY-ML-DSA(7)> and L<EVP_PKEY-ML-KEM(7)> for details.
 
 =item B<-I<cipher>>
 
-Encrypt the PEM encoded private key with the supplied cipher. Any algorithm
-name accepted by EVP_get_cipherbyname() is acceptable such as B<aes128>.
+Encrypt the PEM encoded private key with the supplied cipher. This option is
+specified by prepending a hyphen to the cipher name (e.g., B<-aes-256-cbc>
+or B<-aes128>), not as an argument to a C<-cipher> flag.
 In B<DER> output form encryption is supported only in the default B<PKCS#8>
-form and and is not available when the B<-traditional> option is used.
+form and is not available when the B<-traditional> option is used.
+Use C<openssl list -cipher-algorithms> to see the available ciphers.
 
 =item B<-passout> I<arg>
 


### PR DESCRIPTION
## Summary

Users reading the documentation for the `-<cipher>` option often misunderstand
the syntax. The notation `B<-I<cipher>>` renders as "-cipher" with "cipher" in
italics, leading users to think they should type `-cipher aes-128-cbc` when the
correct usage is `-aes-128-cbc` (the cipher name directly as the option).

See: https://unix.stackexchange.com/questions/787468/

This PR updates the documentation in:
- **openssl-genpkey**: Added explicit clarification and multiple examples
- **openssl-enc**: Added clarification about the option syntax
- **openssl-pkey**: Added clarification and fixed a typo ("and and" → "and")

All three now:
- Explicitly state that the cipher name is prepended with a hyphen
- Clarify that it's NOT an argument to a `-cipher` flag
- Reference `openssl list -cipher-algorithms` to discover available ciphers

Fixes #26089

## Test plan
- [x] Verified changes are syntactically correct POD
- [x] Reviewed rendered man page output

🤖 Generated with [Claude Code](https://claude.com/claude-code)