### PR TITLE
Fix broken build for non-gnu make

### DIFF
--- a/providers/common/der/build.info
+++ b/providers/common/der/build.info
@@ -81,7 +81,7 @@ IF[{- !$disabled{'ml-dsa'} -}]
   DEPEND[$DER_ML_DSA_GEN]=oids_to_c.pm ML_DSA.asn1
 
   DEPEND[${DER_ML_DSA_GEN/.c/.o}]=$DER_ML_DSA_H
-  DEPEND[${DER_ML_DSA_AUX/.c/.o}]=$DER_ML_DSA_H
+  DEPEND[${DER_ML_DSA_AUX/.c/.o}]=$DER_ML_DSA_H $DER_DIGESTS_H
   GENERATE[$DER_ML_DSA_H]=$INCDIR/der_ml_dsa.h.in
   DEPEND[$DER_ML_DSA_H]=oids_to_c.pm ML_DSA.asn1
 ENDIF


### PR DESCRIPTION
Ml-dsa provider module requires der_digests.h which is generated from der_digets.h.in. The dependency must be explicitly set in build.info otherwise the .h file is missing when
providers/common/der/der_ml_dsa_key.c gets compiled.

The issue seems to affect only make found in base system on OpenBSD. gnu-make (a.k.a gmake) is not affected.

It got introduced by 175cda569df

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
