### PR TITLE
Use fixed version of curl in quic-interop-container

### DIFF
--- a/test/quic-openssl-docker/Dockerfile
+++ b/test/quic-openssl-docker/Dockerfile
@@ -35,8 +35,11 @@ RUN git clone --depth 1 -b $OPENSSL_BRANCH $OPENSSL_URL && \
     rm -rf /openssl
 
 # Build curl
-RUN git clone --depth 1 https://github.com/curl/curl.git && \
+# Note we have to build from commit 5a4cd758634d194ed280112a53e5ce5dc258b77a
+# or earlier here, as curl has dropped quic support with openssl
+RUN git clone https://github.com/curl/curl.git && \
     cd curl && \
+    git checkout 5a4cd758634d194ed280112a53e5ce5dc258b77a && \
     autoreconf -fi && ./configure --with-openssl-quic --with-openssl --with-nghttp3 --prefix=/usr && \
     make -j 4 && \
     make install && \


### PR DESCRIPTION
As part of 6aaac9dd388a64d0f511544496608693e1105d13 in https://github.com/curl/curl.git

Curl dropped support for using the quic-tls interface to use our quic stack.  Because our interop testing relies on using curl to do testing, our builds broke.

Until we can find an alternate client to do https transfers over http3/quic, we need to back off our quic build point to a commit prior to the above so we can maintain our interop testing.

Long term, we need to enhance our own http3 demo client to support the download/resumption/etc features that we need for interop.  We're tracking that effort in:
https://github.com/openssl/project/issues/1850

Fixes openssl/project#1848

##### Checklist
- [x] tests are added or updated

Note: marking as urgent as this is causing nightly CI failures
