### PR TITLE
Initialize thread id on NonStop where pthread_id is not a primitive type

### DIFF
--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -203,6 +203,8 @@ static CRYPTO_ONCE ossl_init_thread_runonce = CRYPTO_ONCE_STATIC_INIT;
 /* MSVC linker can use other segment for uninitialized (zeroed) variables */
 #if defined(OPENSSL_SYS_WINDOWS)
 static CRYPTO_THREAD_ID recursion_guard = (CRYPTO_THREAD_ID)-1;
+#elif defined(OPENSSL_SYS_TANDEM) && (defined(_PUT_MODEL_) || defined(_KLT_MODEL_))
+static CRYPTO_THREAD_ID recursion_guard = { (void *)-1, (short)-1, (short)-1 };
 #else
 static CRYPTO_THREAD_ID recursion_guard = (CRYPTO_THREAD_ID)0;
 #endif
@@ -215,7 +217,11 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_thread_once)
             init_thread_destructor))
         return 0;
 
+#if defined(OPENSSL_SYS_TANDEM)
+    memset(&recursion_guard, 0, sizeof(recursion_guard));
+#else
     recursion_guard = (CRYPTO_THREAD_ID)0;
+#endif
     return 1;
 }
 


### PR DESCRIPTION
Fixes: #29854
