### PR TITLE
doc: update CONTRIBUTING.md to reference clang-format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,8 +77,9 @@ guidelines:
 
  4. Code provided should follow our [coding style] and [documentation policy]
     and compile without warnings.
-    There is a [Perl tool](util/check-format.pl) that helps
-    finding code formatting mistakes and other coding style nits.
+    The repository includes a `.clang-format` configuration file. You can use
+    `clang-format` to automatically format your code, or configure your editor
+    to format on save. A pre-commit hook is also available to check formatting.
     Where `gcc` or `clang` is available, you should use the
     `--strict-warnings` `Configure` option.  OpenSSL compiles on many varied
     platforms: try to ensure you only use portable features.


### PR DESCRIPTION
## Summary

Replace the outdated reference to `util/check-format.pl` (which no longer exists) with information about:
- The `.clang-format` configuration file
- Using `clang-format` to automatically format code
- The available pre-commit hook for format checking

Fixes #29467

🤖 Generated with [Claude Code](https://claude.com/claude-code)