### PR TITLE
doc: fix -signcert grouping in CA.pl documentation

### DIFF
--- a/doc/man1/CA.pl.pod
+++ b/doc/man1/CA.pl.pod
@@ -106,7 +106,7 @@ If there is an additional argument on the command line it will be used as the
 list box), otherwise the name "My Certificate" is used.
 Delegates work to L<openssl-pkcs12(1)>.
 
-=item B<-sign>, B<-signcert>, B<-xsign>
+=item B<-sign>, B<-xsign>
 
 Calls the L<openssl-ca(1)> command to sign a certificate request. It expects the
 request to be in the file F<newreq.pem>. The new certificate is written to the


### PR DESCRIPTION
## Summary

Remove `-signcert` from the `-sign`/`-xsign` group in CA.pl documentation.

The documentation had contradicting statements:
- Line 109 grouped `-sign`, `-signcert`, `-xsign` together with the same description
- Line 123-127 had a separate entry for `-signcert` explaining it's different (expects a self-signed certificate)

Now `-sign` and `-xsign` are grouped together, and `-signcert` has its own separate entry.

Fixes #29165

🤖 Generated with [Claude Code](https://claude.com/claude-code)