### PR TITLE
doc: Clarify -verifyCA* options in s_server documentation

### DIFF
--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -335,20 +335,26 @@ Download CRLs from distribution points given in CDP extensions of certificates
 
 =item B<-verifyCAfile> I<filename>
 
-A file in PEM format CA containing trusted certificates to use
+A file in PEM format containing CA certificates to use
 for verifying client certificates.
+These certificates are used as trust anchors during the certificate chain
+verification process and may include both root and intermediate CA certificates.
 
 =item B<-verifyCApath> I<dir>
 
-A directory containing trusted certificates to use
+A directory containing CA certificates to use
 for verifying client certificates.
+These certificates are used as trust anchors during the certificate chain
+verification process and may include both root and intermediate CA certificates.
 This directory must be in "hash format",
 see L<openssl-verify(1)> for more information.
 
 =item B<-verifyCAstore> I<uri>
 
-The URI of a store containing trusted certificates to use
+The URI of a store containing CA certificates to use
 for verifying client certificates.
+These certificates are used as trust anchors during the certificate chain
+verification process and may include both root and intermediate CA certificates.
 
 =item B<-chainCAfile> I<file>
 


### PR DESCRIPTION
## Summary
- Fixed grammatical error in `-verifyCAfile` description ("in PEM format CA containing" → "in PEM format containing CA certificates")
- Changed "trusted certificates" to "CA certificates" for clarity across `-verifyCAfile`, `-verifyCApath`, and `-verifyCAstore` options
- Added explanation that these certificates are used as trust anchors during the certificate chain verification process and may include both root and intermediate CA certificates

This addresses the confusion noted in #29584 where "trusted certificates" was interpreted by many to mean only self-signed root CAs.

Fixes: #29584

## Test plan
- [x] Verify documentation renders correctly with `make doc`

🤖 Generated with [Claude Code](https://claude.ai/code)