### PR TITLE
doc: Clarify OSSL_DISPATCH array usage in provider-base(7)

### DIFF
--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -141,8 +141,13 @@ For example, the "function" core_gettable_params() has these:
  static ossl_inline OSSL_NAME_core_gettable_params_fn
      OSSL_FUNC_core_gettable_params(const OSSL_DISPATCH *opf);
 
-L<OSSL_DISPATCH(3)> arrays are indexed by numbers that are provided as
-macros in L<openssl-core_dispatch.h(7)>, as follows:
+L<OSSL_DISPATCH(3)> array entries use B<function_id> values that are
+provided as macros in L<openssl-core_dispatch.h(7)>.
+Note that these arrays are not indexed directly by these macros; instead,
+to retrieve a function pointer, code must iterate through the array entries
+and match the B<function_id> field against the desired macro value (see the
+L</EXAMPLES> section below).
+The function identifier macros are as follows:
 
 For I<in> (the L<OSSL_DISPATCH(3)> array passed from F<libcrypto> to the
 provider):


### PR DESCRIPTION
## Summary
- Clarified that OSSL_DISPATCH arrays are not directly indexed by the function_id macro values
- Added explanation that code must iterate through array entries and match the function_id field
- Added reference to the EXAMPLES section which demonstrates the correct usage pattern

The previous wording "OSSL_DISPATCH arrays are indexed by numbers" was misleading as it suggested direct array indexing like `in[OSSL_FUNC_BIO_READ_EX]`.

Fixes: #27125

## Test plan
- [x] `podchecker doc/man7/provider-base.pod` passes
- [x] Verify documentation renders correctly with `make doc`

🤖 Generated with [Claude Code](https://claude.ai/code)