### PR TITLE
doc: Clarify SSL_CERT_DIR uses semicolon separator on Windows

### DIFF
--- a/doc/man1/openssl-rehash.pod.in
+++ b/doc/man1/openssl-rehash.pod.in
@@ -36,8 +36,8 @@ directories to be set up like this in order to find certificates.
 
 If any directories are named on the command line, then those are
 processed in turn. If not, then the B<SSL_CERT_DIR> environment variable
-is consulted; this should be a colon-separated list of directories,
-like the Unix B<PATH> variable.
+is consulted; this should be a colon-separated list of directories
+(or semicolon-separated on Windows), like the B<PATH> variable.
 If that is not set then the default directory (installation-specific
 but often F</usr/local/ssl/certs>) is processed.
 

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -283,6 +283,8 @@ This variable is considered a security-sensitive environment variable.
 =item B<SSL_CERT_DIR>, B<SSL_CERT_FILE>
 
 Specify the default directory or file containing CA certificates.
+B<SSL_CERT_DIR> can contain multiple directories separated by colons
+(or semicolons on Windows).
 See L<SSL_CTX_load_verify_locations(3)>.
 
 These variables are considered security-sensitive environment variables,


### PR DESCRIPTION
## Summary
The documentation for `SSL_CERT_DIR` stated that directories are colon-separated, but on Windows the separator is semicolon (as defined in `include/internal/e_os.h`).

Updated documentation in:
- `openssl-rehash.pod.in`: Added "(or semicolon-separated on Windows)" note
- `openssl-env.pod`: Added note about multiple directories and Windows separator

Fixes: #27698

## Test plan
- [x] `podchecker doc/man7/openssl-env.pod` passes
- [x] `make doc` builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)