### PR TITLE
doc: Add warning about using BIO_set_data with built-in BIOs

### DIFF
--- a/doc/man3/BIO_get_data.pod
+++ b/doc/man3/BIO_get_data.pod
@@ -24,6 +24,14 @@ The BIO_set_data() function associates the custom data pointed to by B<ptr> with
 the BIO. This data can subsequently be retrieved via a call to BIO_get_data().
 This can be used by custom BIOs for storing implementation specific information.
 
+B<Warning>: BIO_set_data() should only be used with custom BIO types created
+via L<BIO_meth_new(3)>.
+Using it on OpenSSL's built-in BIO types (such as those returned by
+L<BIO_s_socket(3)>, L<BIO_s_file(3)>, etc.) will cause undefined behavior,
+typically resulting in crashes when the BIO is freed, because built-in BIOs
+manage their own internal data and their cleanup functions may attempt to
+free the replaced pointer.
+
 The BIO_set_init() function sets the value of the BIO's "init" flag to indicate
 whether initialisation has been completed for this BIO or not. A nonzero value
 indicates that initialisation is complete, whilst zero indicates that it is not.
@@ -55,7 +63,7 @@ The functions described here were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 
-Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy


### PR DESCRIPTION
## Summary
Added a warning to the `BIO_get_data(3)` man page clarifying that `BIO_set_data()` should only be used with custom BIO types created via `BIO_meth_new(3)`.

Using `BIO_set_data()` on built-in BIO types like `BIO_s_socket()` or `BIO_s_file()` causes undefined behavior, typically resulting in crashes when `BIO_free()` is called, because the BIO's cleanup function will attempt to free the replaced pointer.

Fixes: #29645

## Test plan
- [x] `podchecker doc/man3/BIO_get_data.pod` passes
- [x] `make doc` builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)