### PR TITLE
doc: Fix X509_NAME_print documentation to reflect actual behavior

### DIFF
--- a/doc/man3/X509_NAME_print_ex.pod
+++ b/doc/man3/X509_NAME_print_ex.pod
@@ -32,9 +32,8 @@ I<size> is ignored.
 Otherwise, at most I<size> bytes will be written, including the ending '\0',
 and I<buf> is returned.
 
-X509_NAME_print() prints out I<name> to I<bp> indenting each line by I<obase>
-characters. Multiple lines are used if the output (including indent) exceeds
-80 characters.
+X509_NAME_print() prints out I<name> to I<bp> on a single line.
+The I<obase> parameter is ignored and retained only for API compatibility.
 
 =head1 NOTES
 


### PR DESCRIPTION
## Summary
- Fix incorrect documentation for X509_NAME_print()
- The documentation claimed obase was used for indentation and that lines would wrap at 80 characters
- In reality, obase is ignored and the function always outputs on a single line (this has been the case since 2007 when the line-wrapping code was removed)

Fixes #18004

## Test plan
- [x] podchecker passes
- [x] doc-nits passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)