### PR TITLE
doc: Update PEM examples to use AES instead of DES

### DIFF
--- a/doc/man3/PEM_read_bio_PrivateKey.pod
+++ b/doc/man3/PEM_read_bio_PrivateKey.pod
@@ -591,7 +591,7 @@ were added in OpenSSL 3.4.
 
 =head1 COPYRIGHT
 
-Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2001-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy


### PR DESCRIPTION
## Summary
- Replace Triple DES (DES-EDE3-CBC) with AES-256-CBC in PEM documentation examples
- Triple DES is considered legacy; AES is the recommended modern cipher
- Updated PEM encryption format example, pseudo code, and API usage examples

Fixes #28665

## Test plan
- [x] podchecker passes
- [x] doc-nits passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)