### PR TITLE
doc: Add warning about BIO_set_data on built-in BIO types

### DIFF
--- a/doc/man3/BIO_get_data.pod
+++ b/doc/man3/BIO_get_data.pod
@@ -24,6 +24,11 @@ The BIO_set_data() function associates the custom data pointed to by B<ptr> with
 the BIO. This data can subsequently be retrieved via a call to BIO_get_data().
 This can be used by custom BIOs for storing implementation specific information.
 
+B<Warning:> Do not call BIO_set_data() on BIOs created using built-in BIO types
+such as BIO_s_socket() or BIO_s_file(). These BIO types use the data pointer
+internally, and overwriting it will cause memory corruption or crashes when
+the BIO is freed.
+
 The BIO_set_init() function sets the value of the BIO's "init" flag to indicate
 whether initialisation has been completed for this BIO or not. A nonzero value
 indicates that initialisation is complete, whilst zero indicates that it is not.
@@ -55,7 +60,7 @@ The functions described here were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 
-Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2016-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy


### PR DESCRIPTION
## Summary
- Add a warning that BIO_set_data() should not be called on BIOs created using built-in BIO types
- Built-in BIO types like BIO_s_socket() and BIO_s_file() use the data pointer internally
- Overwriting the data pointer will cause memory corruption or crashes when the BIO is freed

## Test plan
- [x] Verify podchecker passes
- [x] Verify make doc-nits passes

Fixes #29645

🤖 Generated with [Claude Code](https://claude.com/claude-code)