### PR TITLE
doc: Fix typos and grammar in BIO_s_accept documentation

### DIFF
--- a/doc/man3/BIO_s_accept.pod
+++ b/doc/man3/BIO_s_accept.pod
@@ -110,8 +110,8 @@ BIO_set_bind_mode() and BIO_get_bind_mode() set and retrieve
 the current bind mode. If B<BIO_BIND_NORMAL> (the default) is set
 then another socket cannot be bound to the same port. If
 B<BIO_BIND_REUSEADDR> is set then other sockets can bind to the
-same port. If B<BIO_BIND_REUSEADDR_IF_UNUSED> is set then and
-attempt is first made to use BIO_BIN_NORMAL, if this fails
+same port. If B<BIO_BIND_REUSEADDR_IF_UNUSED> is set then an
+attempt is first made to use B<BIO_BIND_NORMAL>, if this fails
 and the port is not in use then a second attempt is made
 using B<BIO_BIND_REUSEADDR>. If B<BIO_SOCK_TFO> is set, then
 the socket will be configured to accept TCP Fast Open
@@ -127,7 +127,7 @@ connection, or request a retry in non blocking mode.
 
 When an accept BIO is at the end of a chain it will await an
 incoming connection before processing I/O calls. When an accept
-BIO is not at then end of a chain it passes I/O calls to the next
+BIO is not at the end of a chain it passes I/O calls to the next
 BIO in the chain.
 
 When a connection is established a new socket BIO is created for
@@ -161,10 +161,10 @@ and freeing up the accept BIO after the initial connection.
 
 If the underlying accept socket is nonblocking and BIO_do_accept() is
 called to await an incoming connection it is possible for
-BIO_should_io_special() with the reason BIO_RR_ACCEPT. If this happens
-then it is an indication that an accept attempt would block: the application
-should take appropriate action to wait until the underlying socket has
-accepted a connection and retry the call.
+BIO_should_io_special() to return true with the reason B<BIO_RR_ACCEPT>.
+If this happens then it is an indication that an accept attempt would block:
+the application should take appropriate action to wait until the underlying
+socket has accepted a connection and retry the call.
 
 BIO_set_accept_name(), BIO_get_accept_name(), BIO_set_accept_port(),
 BIO_get_accept_port(), BIO_set_nbio_accept(), BIO_set_accept_bios(),
@@ -244,7 +244,7 @@ BIO_set_tfo_accept() was added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 
-Copyright 2000-2022 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy


### PR DESCRIPTION
## Summary
- Fix "then and attempt" -> "then an attempt"
- Fix typo "BIO_BIN_NORMAL" -> "BIO_BIND_NORMAL"
- Fix "not at then end" -> "not at the end"
- Fix incomplete sentence about BIO_should_io_special() return value

## Test plan
- [x] Verify podchecker passes
- [x] Verify make doc-nits passes

Fixes #24489

🤖 Generated with [Claude Code](https://claude.com/claude-code)