### PR TITLE
doc: fix RSA_set_method return value documentation

### DIFF
--- a/doc/man3/RSA_set_method.pod
+++ b/doc/man3/RSA_set_method.pod
@@ -138,9 +138,7 @@ and RSA_get_method() return pointers to the respective RSA_METHODs.
 
 RSA_set_default_method() returns no value.
 
-RSA_set_method() returns a pointer to the old RSA_METHOD implementation
-that was replaced. The return type may be replaced with a B<void>
-declaration in a future release.
+RSA_set_method() returns 1 for success. It always succeeds.
 
 RSA_new_method() returns NULL and sets an error code that can be obtained
 by L<ERR_get_error(3)> if the allocation fails. Otherwise


### PR DESCRIPTION
## Summary
- Fix incorrect return value documentation for RSA_set_method()
- The documentation said it returns "a pointer to the old RSA_METHOD" but it actually returns int (1 for success)
- The SYNOPSIS correctly shows `int RSA_set_method(...)` but the RETURN VALUES section was wrong

Fixes #13884

🤖 Generated with [Claude Code](https://claude.ai/code)