### PR TITLE
doc: document SSL_set_client_CA_list NULL behavior

### DIFF
--- a/doc/man3/SSL_CTX_set0_CA_list.pod
+++ b/doc/man3/SSL_CTX_set0_CA_list.pod
@@ -70,6 +70,11 @@ SSL_set_client_CA_list() sets the B<list> of CAs sent to the client when
 requesting a client certificate for the chosen B<ssl>, overriding the
 setting valid for B<ssl>'s SSL_CTX object. Ownership of B<list> is transferred
 to B<s> and it should not be freed by the caller.
+Note that passing NULL for B<list> does not clear the CA list; instead, the
+setting from B<ssl>'s SSL_CTX object will be used. Note also that passing an
+empty stack created with sk_X509_NAME_new_null() will clear the per-connection
+client CA list, but during the handshake the generic CA list (set via
+L<SSL_CTX_set0_CA_list(3)>) may still be used as a fallback.
 
 SSL_CTX_get_client_CA_list() returns the list of client CAs explicitly set for
 B<ctx> using SSL_CTX_set_client_CA_list(). The returned list should not be freed


### PR DESCRIPTION
## Summary
- Document that passing NULL to SSL_set_client_CA_list() does not clear the CA list
- Instead, the SSL_CTX's setting is used when NULL is passed
- To actually clear the list, an empty stack (created with sk_X509_NAME_new_null()) must be passed

Fixes #10795

🤖 Generated with [Claude Code](https://claude.ai/code)