### PR TITLE
Adaptation of GOST TLS 1.2 for work with provider

### DIFF
--- a/ssl/record/methods/tls1_meth.c
+++ b/ssl/record/methods/tls1_meth.c
@@ -336,6 +336,7 @@ static int tls1_cipher(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *recs,
 
     if (!rl->isdtls && rl->tlstree) {
         int decrement_seq = 0;
+        OSSL_PARAM params[2], *p = params;
 
         /*
          * When sending, seq is incremented after MAC calculation.
@@ -345,10 +346,9 @@ static int tls1_cipher(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *recs,
         if (sending && !rl->use_etm)
             decrement_seq = 1;
 
-        if (EVP_CIPHER_CTX_ctrl(ds, EVP_CTRL_TLSTREE, decrement_seq,
-                rl->sequence)
-            <= 0) {
-
+        *p++ = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_TLSTREE, rl->sequence, decrement_seq);
+        *p++ = OSSL_PARAM_construct_end();
+        if (EVP_CIPHER_CTX_set_params(ds, params) != 1) {
             RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
             return 0;
         }
@@ -436,10 +436,14 @@ static int tls1_mac(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *rec, unsigned char *md
         mac_ctx = hmac;
     }
 
-    if (!rl->isdtls
-        && rl->tlstree
-        && EVP_MD_CTX_ctrl(mac_ctx, EVP_MD_CTRL_TLSTREE, 0, seq) <= 0)
-        goto end;
+    if (!rl->isdtls && rl->tlstree) {
+        OSSL_PARAM params[2], *p = params;
+
+        *p++ = OSSL_PARAM_construct_octet_string(OSSL_DIGEST_PARAM_TLSTREE, seq, 0);
+        *p++ = OSSL_PARAM_construct_end();
+        if (EVP_MD_CTX_set_params(mac_ctx, params) != 1)
+            goto end;
+    }
 
     if (rl->isdtls) {
         unsigned char dtlsseq[8], *p = dtlsseq;

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -129,13 +129,13 @@ static int ssl_cipher_info_find(const ssl_cipher_table *table,
 
 static const int default_mac_pkey_id[SSL_MD_NUM_IDX] = {
     /* MD5, SHA, GOST94, MAC89 */
-    EVP_PKEY_HMAC, EVP_PKEY_HMAC, EVP_PKEY_HMAC, NID_undef,
+    EVP_PKEY_HMAC, EVP_PKEY_HMAC, EVP_PKEY_HMAC, NID_id_Gost28147_89_MAC,
     /* SHA256, SHA384, GOST2012_256, MAC89-12 */
-    EVP_PKEY_HMAC, EVP_PKEY_HMAC, EVP_PKEY_HMAC, NID_undef,
+    EVP_PKEY_HMAC, EVP_PKEY_HMAC, EVP_PKEY_HMAC, NID_gost_mac_12,
     /* GOST2012_512 */
     EVP_PKEY_HMAC,
     /* MD5/SHA1, SHA224, SHA512, MAGMAOMAC, KUZNYECHIKOMAC */
-    NID_undef, NID_undef, NID_undef, NID_undef, NID_undef
+    NID_undef, NID_undef, NID_undef, NID_magma_mac, NID_kuznyechik_mac
 };
 
 #define CIPHER_ADD 1
@@ -274,6 +274,22 @@ static const SSL_CIPHER cipher_aliases[] = {
 
 };
 
+static int is_gost(int nid)
+{
+    switch (nid) {
+    case NID_id_GostR3411_94:
+    case NID_id_Gost28147_89_MAC:
+    case NID_id_GostR3411_2012_256:
+    case NID_gost_mac_12:
+    case NID_id_GostR3411_2012_512:
+    case NID_magma_mac:
+    case NID_kuznyechik_mac:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
 int ssl_load_ciphers(SSL_CTX *ctx)
 {
     size_t i;
@@ -293,6 +309,11 @@ int ssl_load_ciphers(SSL_CTX *ctx)
                 ctx->disabled_enc_mask |= t->mask;
         }
     }
+
+#ifdef OPENSSL_NO_GOST
+    ctx->disabled_enc_mask |= SSL_eGOST2814789CNT | SSL_eGOST2814789CNT12 | SSL_MAGMA | SSL_KUZNYECHIK;
+#endif
+
     ctx->disabled_mac_mask = 0;
     for (i = 0, t = ssl_cipher_table_mac; i < SSL_MD_NUM_IDX; i++, t++) {
         /*
@@ -308,6 +329,8 @@ int ssl_load_ciphers(SSL_CTX *ctx)
         ctx->ssl_digest_methods[i] = md;
         if (md == NULL) {
             ctx->disabled_mac_mask |= t->mask;
+        } else if (is_gost(t->nid)) {
+            ctx->ssl_mac_secret_size[i] = 32;
         } else {
             int tmpsize = EVP_MD_get_size(md);
 
@@ -316,6 +339,12 @@ int ssl_load_ciphers(SSL_CTX *ctx)
             ctx->ssl_mac_secret_size[i] = tmpsize;
         }
     }
+    memcpy(ctx->ssl_mac_pkey_id, default_mac_pkey_id,
+        sizeof(ctx->ssl_mac_pkey_id));
+
+#ifdef OPENSSL_NO_GOST
+    ctx->disabled_mac_mask |= SSL_GOST89MAC | SSL_GOST89MAC12 | SSL_MAGMAOMAC | SSL_KUZNYECHIKOMAC;
+#endif
 
     ctx->disabled_mkey_mask = 0;
     ctx->disabled_auth_mask = 0;
@@ -345,6 +374,29 @@ int ssl_load_ciphers(SSL_CTX *ctx)
         ctx->disabled_auth_mask |= SSL_aECDSA;
     else
         EVP_SIGNATURE_free(sig);
+#ifndef OPENSSL_NO_GOST
+    sig = EVP_SIGNATURE_fetch(ctx->libctx, SN_id_GostR3410_2001, ctx->propq);
+    if (sig == NULL) {
+        ctx->disabled_auth_mask |= SSL_aGOST01 | SSL_aGOST12;
+        ctx->disabled_mkey_mask |= SSL_kGOST;
+    } else {
+        EVP_SIGNATURE_free(sig);
+    }
+    sig = EVP_SIGNATURE_fetch(ctx->libctx, SN_id_GostR3410_2012_256, ctx->propq);
+    if (sig == NULL) {
+        ctx->disabled_auth_mask |= SSL_aGOST12;
+        ctx->disabled_mkey_mask |= SSL_kGOST18;
+    } else {
+        EVP_SIGNATURE_free(sig);
+    }
+    sig = EVP_SIGNATURE_fetch(ctx->libctx, SN_id_GostR3410_2012_512, ctx->propq);
+    if (sig == NULL) {
+        ctx->disabled_auth_mask |= SSL_aGOST12;
+        ctx->disabled_mkey_mask |= SSL_kGOST18;
+    } else {
+        EVP_SIGNATURE_free(sig);
+    }
+#endif
     ERR_pop_to_mark();
 
 #ifdef OPENSSL_NO_PSK
@@ -354,49 +406,10 @@ int ssl_load_ciphers(SSL_CTX *ctx)
 #ifdef OPENSSL_NO_SRP
     ctx->disabled_mkey_mask |= SSL_kSRP;
 #endif
-
-    /*
-     * Check for presence of GOST 34.10 algorithms, and if they are not
-     * present, disable appropriate auth and key exchange
-     */
-    memcpy(ctx->ssl_mac_pkey_id, default_mac_pkey_id,
-        sizeof(ctx->ssl_mac_pkey_id));
-
-    ctx->ssl_mac_pkey_id[SSL_MD_GOST89MAC_IDX] = 0;
-    if (ctx->ssl_mac_pkey_id[SSL_MD_GOST89MAC_IDX])
-        ctx->ssl_mac_secret_size[SSL_MD_GOST89MAC_IDX] = 32;
-    else
-        ctx->disabled_mac_mask |= SSL_GOST89MAC;
-
-    ctx->ssl_mac_pkey_id[SSL_MD_GOST89MAC12_IDX] = 0;
-    if (ctx->ssl_mac_pkey_id[SSL_MD_GOST89MAC12_IDX])
-        ctx->ssl_mac_secret_size[SSL_MD_GOST89MAC12_IDX] = 32;
-    else
-        ctx->disabled_mac_mask |= SSL_GOST89MAC12;
-
-    ctx->ssl_mac_pkey_id[SSL_MD_MAGMAOMAC_IDX] = 0;
-    if (ctx->ssl_mac_pkey_id[SSL_MD_MAGMAOMAC_IDX])
-        ctx->ssl_mac_secret_size[SSL_MD_MAGMAOMAC_IDX] = 32;
-    else
-        ctx->disabled_mac_mask |= SSL_MAGMAOMAC;
-
-    ctx->ssl_mac_pkey_id[SSL_MD_KUZNYECHIKOMAC_IDX] = 0;
-    if (ctx->ssl_mac_pkey_id[SSL_MD_KUZNYECHIKOMAC_IDX])
-        ctx->ssl_mac_secret_size[SSL_MD_KUZNYECHIKOMAC_IDX] = 32;
-    else
-        ctx->disabled_mac_mask |= SSL_KUZNYECHIKOMAC;
-
+#ifdef OPENSSL_NO_GOST
     ctx->disabled_auth_mask |= SSL_aGOST01 | SSL_aGOST12;
-    ctx->disabled_auth_mask |= SSL_aGOST12;
-    ctx->disabled_auth_mask |= SSL_aGOST12;
-    /*
-     * Disable GOST key exchange if no GOST signature algs are available *
-     */
-    if ((ctx->disabled_auth_mask & (SSL_aGOST01 | SSL_aGOST12)) == (SSL_aGOST01 | SSL_aGOST12))
-        ctx->disabled_mkey_mask |= SSL_kGOST;
-
-    if ((ctx->disabled_auth_mask & SSL_aGOST12) == SSL_aGOST12)
-        ctx->disabled_mkey_mask |= SSL_kGOST18;
+    ctx->disabled_mkey_mask |= SSL_kGOST | SSL_kGOST18;
+#endif
 
     return 1;
 }

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -3716,6 +3716,8 @@ static int tls_construct_cke_gost(SSL_CONNECTION *s, WPACKET *pkt)
     unsigned char *pms = NULL;
     size_t pmslen = 0;
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
+    EVP_MD *md = NULL;
+    OSSL_PARAM params[2], *p = params;
 
     if ((s->s3.tmp.new_cipher->algorithm_auth & SSL_aGOST12) != 0)
         dgst_nid = NID_id_GostR3411_2012_256;
@@ -3757,6 +3759,12 @@ static int tls_construct_cke_gost(SSL_CONNECTION *s, WPACKET *pkt)
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;
     };
+
+    md = EVP_MD_fetch(sctx->libctx, OBJ_nid2sn(dgst_nid), sctx->propq);
+    if (md == NULL) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        goto err;
+    }
     /*
      * Compute shared IV and store it in algorithm-specific context
      * data
@@ -3781,9 +3789,12 @@ static int tls_construct_cke_gost(SSL_CONNECTION *s, WPACKET *pkt)
     ukm_md = NULL;
     EVP_MD_CTX_free(ukm_hash);
     ukm_hash = NULL;
-    if (EVP_PKEY_CTX_ctrl(pkey_ctx, -1, EVP_PKEY_OP_ENCRYPT,
-            EVP_PKEY_CTRL_SET_IV, 8, shared_ukm)
-        <= 0) {
+    EVP_MD_free(md);
+    md = NULL;
+
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_EXCHANGE_PARAM_KDF_UKM, shared_ukm, 8);
+    *p++ = OSSL_PARAM_construct_end();
+    if (EVP_PKEY_CTX_set_params(pkey_ctx, params) != 1) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_R_LIBRARY_BUG);
         goto err;
     }
@@ -3811,6 +3822,7 @@ static int tls_construct_cke_gost(SSL_CONNECTION *s, WPACKET *pkt)
     return 1;
 err:
     EVP_PKEY_CTX_free(pkey_ctx);
+    EVP_MD_free(md);
     OPENSSL_clear_free(pms, pmslen);
     EVP_MD_CTX_free(ukm_hash);
     return 0;
@@ -3869,9 +3881,16 @@ static int tls_construct_cke_gost18(SSL_CONNECTION *s, WPACKET *pkt)
     size_t pmslen = 0;
     size_t msglen;
     int cipher_nid = ossl_gost18_cke_cipher_nid(s);
+    const char *cipher_sn;
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
+    OSSL_PARAM params[3], *p = params;
 
     if (cipher_nid == NID_undef) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+
+    if ((cipher_sn = OBJ_nid2sn(cipher_nid)) == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return 0;
     }
@@ -3915,16 +3934,15 @@ static int tls_construct_cke_gost18(SSL_CONNECTION *s, WPACKET *pkt)
     };
 
     /* Reuse EVP_PKEY_CTRL_SET_IV */
-    if (EVP_PKEY_CTX_ctrl(pkey_ctx, -1, EVP_PKEY_OP_ENCRYPT,
-            EVP_PKEY_CTRL_SET_IV, 32, rnd_dgst)
-        <= 0) {
-        SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_R_LIBRARY_BUG);
-        goto err;
-    }
-
-    if (EVP_PKEY_CTX_ctrl(pkey_ctx, -1, EVP_PKEY_OP_ENCRYPT,
-            EVP_PKEY_CTRL_CIPHER, cipher_nid, NULL)
-        <= 0) {
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_EXCHANGE_PARAM_KDF_UKM, rnd_dgst, 32);
+    *p++ = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_CIPHER,
+        /*
+         * Cast away the const. This is read
+         * only so should be safe
+         */
+        (char *)cipher_sn, 0);
+    *p++ = OSSL_PARAM_construct_end();
+    if (EVP_PKEY_CTX_set_params(pkey_ctx, params) != 1) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_R_LIBRARY_BUG);
         goto err;
     }

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -545,7 +545,8 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL_CONNECTION *s, PACKET *pkt)
     }
 #ifndef OPENSSL_NO_GOST
     {
-        int pktype = EVP_PKEY_get_id(pkey);
+        const char *typename = EVP_PKEY_get0_type_name(pkey);
+        int pktype = OBJ_txt2nid(typename);
         if (pktype == NID_id_GostR3410_2001
             || pktype == NID_id_GostR3410_2012_256
             || pktype == NID_id_GostR3410_2012_512) {

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3649,11 +3649,6 @@ static int tls_process_cke_gost(SSL_CONNECTION *s, PACKET *pkt)
         /* SSLfatal() already called */
         goto err;
     }
-    /* Check if pubkey from client certificate was used */
-    if (EVP_PKEY_CTX_ctrl(pkey_ctx, -1, -1, EVP_PKEY_CTRL_PEER_KEY, 2,
-            NULL)
-        > 0)
-        s->statem.no_cert_verify = 1;
 
     ret = 1;
 err:
@@ -3678,9 +3673,16 @@ static int tls_process_cke_gost18(SSL_CONNECTION *s, PACKET *pkt)
     size_t outlen = sizeof(premaster_secret), inlen = 0;
     int ret = 0;
     int cipher_nid = ossl_gost18_cke_cipher_nid(s);
+    const char *cipher_sn;
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
+    OSSL_PARAM params[3], *p = params;
 
     if (cipher_nid == NID_undef) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+
+    if ((cipher_sn = OBJ_nid2sn(cipher_nid)) == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return 0;
     }
@@ -3707,16 +3709,15 @@ static int tls_process_cke_gost18(SSL_CONNECTION *s, PACKET *pkt)
         goto err;
     }
 
-    if (EVP_PKEY_CTX_ctrl(pkey_ctx, -1, EVP_PKEY_OP_DECRYPT,
-            EVP_PKEY_CTRL_SET_IV, 32, rnd_dgst)
-        <= 0) {
-        SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_R_LIBRARY_BUG);
-        goto err;
-    }
-
-    if (EVP_PKEY_CTX_ctrl(pkey_ctx, -1, EVP_PKEY_OP_DECRYPT,
-            EVP_PKEY_CTRL_CIPHER, cipher_nid, NULL)
-        <= 0) {
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_EXCHANGE_PARAM_KDF_UKM, rnd_dgst, 32);
+    *p++ = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_CIPHER,
+        /*
+         * Cast away the const. This is read
+         * only so should be safe
+         */
+        (char *)cipher_sn, 0);
+    *p++ = OSSL_PARAM_construct_end();
+    if (EVP_PKEY_CTX_set_params(pkey_ctx, params) != 1) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_R_LIBRARY_BUG);
         goto err;
     }

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2309,7 +2309,7 @@ int ssl_setup_sigalgs(SSL_CTX *ctx)
     uint16_t *tls12_sigalgs_list = NULL;
     EVP_PKEY *tmpkey = EVP_PKEY_new();
     int istls;
-    int ret = 0;
+    int ret = 0, tmpret = 0;
 
     if (ctx == NULL)
         goto err;
@@ -2348,9 +2348,21 @@ int ssl_setup_sigalgs(SSL_CTX *ctx)
             continue;
         }
 
+        /* Try to use legacy key initialization */
         if (!EVP_PKEY_set_type(tmpkey, lu->sig)) {
-            cache[i].available = 0;
-            continue;
+            /* Otherwise initialization with provider */
+            EVP_KEYMGMT *keymgmt = EVP_KEYMGMT_fetch(ctx->libctx, OBJ_nid2sn(lu->sig), ctx->propq);
+            if (!keymgmt) {
+                cache[i].available = 0;
+                continue;
+            }
+
+            tmpret = EVP_PKEY_set_type_by_keymgmt(tmpkey, keymgmt);
+            EVP_KEYMGMT_free(keymgmt);
+            if (!tmpret) {
+                cache[i].available = 0;
+                continue;
+            }
         }
         pctx = EVP_PKEY_CTX_new_from_pkey(ctx->libctx, tmpkey, ctx->propq);
         /* If unable to create pctx we assume the sig algorithm is unavailable */

--- a/util/perl/OpenSSL/paramnames.pm
+++ b/util/perl/OpenSSL/paramnames.pm
@@ -164,6 +164,8 @@ my %params = (
     'OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_ENC_IN' =>             "tls1multi_encin",     # octet_string
     'OSSL_CIPHER_PARAM_TLS1_MULTIBLOCK_ENC_LEN' =>            "tls1multi_enclen",    # size_t
 
+    'OSSL_CIPHER_PARAM_TLSTREE' => "tlstree", # octet_string
+
 # digest parameters
     'OSSL_DIGEST_PARAM_XOFLEN' =>       "xoflen",       # size_t
     'OSSL_DIGEST_PARAM_SSL3_MS' =>      "ssl3-ms",      # octet string
@@ -182,6 +184,8 @@ my %params = (
     'OSSL_DIGEST_PARAM_MU_CONTEXT_STRING' => "context-string",             # octet string
     'OSSL_DIGEST_PARAM_MU_DIGEST' =>         '*OSSL_ALG_PARAM_DIGEST',     # utf8 string
     'OSSL_DIGEST_PARAM_MU_PROPERTIES' =>     '*OSSL_ALG_PARAM_PROPERTIES', # utf8 string
+
+    'OSSL_DIGEST_PARAM_TLSTREE' => "tlstree", # octet_string
 
 # MAC parameters
     'OSSL_MAC_PARAM_KEY' =>            "key",           # octet string


### PR DESCRIPTION
* Use EVP\_\*\_CTX_set_params instead of legacy EVP\_\*\_CTX_ctrl. The next
  controls have been replaced with params:
  - EVP_PKEY_CTRL_SET_IV to OSSL_EXCHANGE_PARAM_KDF_UKM
  - EVP_PKEY_CTRL_CIPHER to OSSL_PKEY_PARAM_CIPHER
  - EVP_MD_CTRL_TLSTREE to OSSL_DIGEST_PARAM_TLSTREE
  - EVP_CTRL_TLSTREE to OSSL_CIPHER_PARAM_TLSTREE
* Use provider interface during TLS setup and routines
* Use EVP_PKEY_get0_type_name instead of legacy EVP_PKEY_get_id
* Don't translate EVP_PKEY_CTRL_PEER_KEY to params. Key exchange algorithms
  use this control with static keys which can't be achieved with encrypt
  context (only derive context supports setting peer key). This therefore
  results in the inability to use the next ciphersuites in some cases (see
  draft-chudov-cryptopro-cptls-04) with provider-implemented PKEYs:
  - TLS_GOSTR341094_WITH_28147_CNT_IMIT
  - TLS_GOSTR341001_WITH_28147_CNT_IMIT
  - TLS_GOSTR341094_WITH_NULL_GOSTR3411
  - TLS_GOSTR341001_WITH_NULL_GOSTR3411

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
