### PR TITLE
Gate use of IPV6_PMTUDISC_PROBE on it being defined

### DIFF
--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -961,7 +961,7 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
                 ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
                     "calling setsockopt()");
 
-#elif defined(OPENSSL_SYS_LINUX) && defined(IPV6_MTU_DISCOVER)
+#elif defined(OPENSSL_SYS_LINUX) && defined(IPV6_MTU_DISCOVER) && defined(IPV6_PMTUDISC_PROBE)
             sockopt_val = num ? IPV6_PMTUDISC_PROBE : IPV6_PMTUDISC_DONT;
             if ((ret = setsockopt(b->num, IPPROTO_IPV6, IPV6_MTU_DISCOVER,
                      &sockopt_val, sizeof(sockopt_val)))


### PR DESCRIPTION
We accidentally introduced a use of IPV6_PMTUDISC_PROBE without checking if it was defined in
https://github.com/openssl/openssl/pull/28809

leading to build failures on systems that don't define it.  Fix that.

Fixes #29903

