### PR TITLE
doc: changed data_size value for OSSL_PARAM_octet_string() in EVP_SIG…

### DIFF
--- a/doc/man7/EVP_SIGNATURE-SLH-DSA.pod
+++ b/doc/man7/EVP_SIGNATURE-SLH-DSA.pod
@@ -96,7 +96,7 @@ To sign a message using an SLH-DSA EVP_PKEY structure:
         size_t sig_len;
         unsigned char *sig = NULL;
         const OSSL_PARAM params[] = {
-            OSSL_PARAM_octet_string("context-string", (unsigned char *)"A context string", 33),
+            OSSL_PARAM_octet_string("context-string", (unsigned char *)"A context string", 16),
             OSSL_PARAM_END
         };
         EVP_PKEY_CTX *sctx = EVP_PKEY_CTX_new_from_pkey(NULL, pkey, NULL);


### PR DESCRIPTION
Fixes: incorrect octet length in slhdsa example #29914
…NATURE-SLH-DSA.pod
@bbbrumley 
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
