### PR TITLE
Inconsistency: OSSL_PARAM_print_to_bio should be excluded from FIPS_M…

### DIFF
--- a/crypto/params_from_text.c
+++ b/crypto/params_from_text.c
@@ -198,6 +198,7 @@ static int construct_from_text(OSSL_PARAM *to, const OSSL_PARAM *paramdef,
     return 1;
 }
 
+#ifndef FIPS_MODULE
 /**
  * OSSL_PARAM_print_to_bio - Print OSSL_PARAM array to a bio
  *
@@ -302,6 +303,7 @@ int OSSL_PARAM_print_to_bio(const OSSL_PARAM *p, BIO *bio, int print_values)
 end:
     return ok == -1 ? 0 : 1;
 }
+#endif /* FIPS_MODULE */
 
 int OSSL_PARAM_allocate_from_text(OSSL_PARAM *to,
     const OSSL_PARAM *paramdefs,


### PR DESCRIPTION
Exclude OSSL_PARAM_print_to_bio from the FIPS module build to avoid unwanted BIO dependencies.OSSL_PARAM_print_to_bio is currently compiled into the FIPS module even though it is not used in FIPS builds because all call sites are excluded.The calls to OSSL_PARAM_print_to_bio() are from provider_core.c (ossl_provider_get_params and ossl_provider_gettable_params) are properly guarded by the "#ifndef FIPS_MODULE"
This PR applies the same exclusion to the function definition, ensuring the module does not pull in BIO-related symbols and builds cleanly.

Reference: https://github.com/openssl/openssl/issues/29920