### PR TITLE
Bugfix of bn_sqr_mont procedure on SPARC sun4v

### DIFF
--- a/crypto/bn/asm/sparcv9-mont.pl
+++ b/crypto/bn/asm/sparcv9-mont.pl
@@ -394,11 +394,11 @@ $code.=<<___;
 
 	mulx	$car1,$mul1,$car1
 	mulx	$npj,$mul1,$acc1
+	add	$tmp1,$car0,$car0
 	add	$tmp0,$car1,$car1
 	and	$car0,$mask,$acc0
 	ld	[$np+8],$npj			! np[2]
 	srlx	$car1,32,$car1
-	add	$tmp1,$car1,$car1
 	srlx	$car0,32,$car0
 	add	$acc0,$car1,$car1
 	and	$car0,1,$sbit

--- a/test/recipes/10-test_bn_data/bnmod.txt
+++ b/test/recipes/10-test_bn_data/bnmod.txt
@@ -2010,6 +2010,14 @@ A = ca6c51ba2f410d09bf71d60fe
 B = 8bdfa8fe5ef3b2ad02bc63c4d
 M = 84daecf412b8c50ad6dfdb546c3eb783dcc6f32003eda914bb
 
+# These test vectors satisfy A ^ 2 = ModSqr (mod M) and 0 <= ModSqr < M.
+
+Title = ModSqr tests
+
+# Regression test for https://github.com/openssl/openssl/issues/15587
+ModSqr = 166794ed50cb31b6e6a319f7474416c266d5c3f3115ea2a7ed9638367d1f955f66a7179ee3ce5ee5e04e63c46781f1192beac3abb26ff238f5ed2f5505ae06003ff
+A = 1407833bd4c893195cc32f56a507f15140be687a1994febe0bdbe793125f010a3c1c814737b10ab690498b7990ce4e625ad2f32cbf42626cb9649da38a5c9c76a99
+M = 1ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 
 # These test vectors satisfy A ^ E = ModExp (mod M) and 0 <= ModExp < M.
 


### PR DESCRIPTION
Fixes #15587
The fix itself comes from Andy Polyakov (@dot-asm)
The test was developed and checked on UltraSPARC-IIIi under Solaris 10. Unfortunately, it's the only sparc computer I can access, but I hope it will work properly on all relevant computers.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
