### PR TITLE
fixes crash on NetBSD

### DIFF
--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -237,11 +237,7 @@ static void init_thread_destructor(void *hands)
 }
 
 static CRYPTO_ONCE ossl_init_thread_runonce = CRYPTO_ONCE_STATIC_INIT;
-#if defined(__NetBSD__) && defined(OPENSSL_THREADS)
 static CRYPTO_THREAD_ID recursion_guard = (CRYPTO_THREAD_ID)0;
-#else
-static CRYPTO_THREAD_ID recursion_guard = (CRYPTO_THREAD_ID)-1;
-#endif
 
 DEFINE_RUN_ONCE_STATIC(ossl_init_thread_once)
 {

--- a/crypto/threads_none.c
+++ b/crypto/threads_none.c
@@ -217,7 +217,7 @@ int CRYPTO_THREAD_cleanup_local(CRYPTO_THREAD_LOCAL *key)
 
 CRYPTO_THREAD_ID CRYPTO_THREAD_get_current_id(void)
 {
-    return 0;
+    return 1;
 }
 
 int CRYPTO_THREAD_compare_id(CRYPTO_THREAD_ID a, CRYPTO_THREAD_ID b)


### PR DESCRIPTION
commit 5bf627c977f7 introduced recursion_guard which is by default set to -1 of CRYPTO_THREAD_ID type. NetBSD pthread_equal dereferences pthread_t in order to check t1->pt_magic == PT_MAGIC. Setting to -1 is not wise, it's better to set it to 0. Dereferencing of the pthread_t happens only if t1/t2 are not NULL.

NetBSD defines pthread_equal:

  int
  pthread_equal(pthread_t t1, pthread_t t2)
  {
  ...
      pthread__error(0, "Invalid thread",
          (t1 != NULL) && (t1->pt_magic == PT_MAGIC));
  ...
      /* Nothing special here. */
      return (t1 == t2);
  }

The problem only occurs only when ossl is compiled with threads on NetBSD.

Fixes #29828
Fixes: 5bf627c977f7 ("ensure destructor key is created prior to any other thread specific key")

Note: commit 5bf627c977f7 is not in the master. I have to check why.