### PR TITLE
Enabling the DTLS 1.3 Message tests

### DIFF
--- a/test/recipes/70-test_tls13messages.t
+++ b/test/recipes/70-test_tls13messages.t
@@ -256,9 +256,6 @@ sub run_tests
     $proxy->clearClient();
     $proxy->cipherc("DEFAULT:\@SECLEVEL=2");
     $proxy->clientflags("-no_rx_cert_comp -sess_in " . $session);
-    if ($run_test_as_dtls == 1) {
-        $proxy->reopenUDPSocket();
-    }
     $proxy->clientstart();
     checkhandshake($proxy, checkhandshake::RESUME_HANDSHAKE,
         (checkhandshake::DEFAULT_EXTENSIONS

--- a/util/perl/TLSProxy/Message.pm
+++ b/util/perl/TLSProxy/Message.pm
@@ -260,6 +260,9 @@ sub get_messages
                 } else {
                     #This is just part of the total message
                     if ($isdtls) {
+                        # DTLS 1.3 has a unified header before the handshake header.
+                        # We have processed the unified header and need to skip the
+                        # handshake header.
                         $payload .= substr($record->decrypt_data, DTLS_MESSAGE_HEADER_LENGTH, length($record->decrypt_data) - DTLS_MESSAGE_HEADER_LENGTH);
                         $recoffset = $record->decrypt_len;
                     } else {

--- a/util/perl/TLSProxy/Message.pm
+++ b/util/perl/TLSProxy/Message.pm
@@ -259,8 +259,13 @@ sub get_messages
                     $payload = "";
                 } else {
                     #This is just part of the total message
-                    $payload .= $record->decrypt_data;
-                    $recoffset = $record->decrypt_len;
+                    if ($isdtls) {
+                        $payload .= substr($record->decrypt_data, DTLS_MESSAGE_HEADER_LENGTH, length($record->decrypt_data) - DTLS_MESSAGE_HEADER_LENGTH);
+                        $recoffset = $record->decrypt_len;
+                    } else {
+                        $payload .= $record->decrypt_data;
+                        $recoffset = $record->decrypt_len;
+                    }
                     push @message_frag_lens, $record->decrypt_len;
                 }
                 print "  Partial message data read: ".$recoffset." bytes\n";

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -201,38 +201,6 @@ sub DESTROY
     $self->{proxy_sock}->close() if $self->{proxy_sock};
 }
 
-sub reopenUDPSocket()
-{
-    my $self = shift;
-
-    if ($self->{proxy_sock})
-    {
-        if (!$self->{proxy_sock}->opened) {
-            my $clientaddr = $self->{client_addr};
-            $clientaddr =~ s/[\[\]]//g; # Remove [ and ]
-            my $proxaddr = $self->{proxy_addr};
-            $proxaddr =~ s/[\[\]]//g; # Remove [ and ]
-
-            my @proxyargs = (
-                LocalHost   => $proxaddr,
-                LocalPort   => $self->{proxy_port},
-                PeerHost    => $clientaddr,
-                PeerPort    => $self->{client_port},
-                Proto       => "udp",
-            );
-
-            if (my $sock = $IP_factory->(@proxyargs)) {
-                $self->{proxy_sock} = $sock;
-            } else {
-                warn "Failed creating proxy socket (".$self->{proxy_addr}.",0): $!\n";
-                return 0;
-            }
-        }
-    }
-
-    return 1;
-}
-
 sub clearClient
 {
     my $self = shift;
@@ -614,7 +582,9 @@ sub clientstart
         }
 
         #Closing this also kills the child process
-        $client_sock->close();
+        if (!$self->{isdtls}) {
+            $client_sock->close();
+        }
     }
 
     my $pid;

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -201,6 +201,38 @@ sub DESTROY
     $self->{proxy_sock}->close() if $self->{proxy_sock};
 }
 
+sub reopenUDPSocket()
+{
+    my $self = shift;
+
+    if ($self->{proxy_sock})
+    {
+        if (!$self->{proxy_sock}->opened) {
+            my $clientaddr = $self->{client_addr};
+            $clientaddr =~ s/[\[\]]//g; # Remove [ and ]
+            my $proxaddr = $self->{proxy_addr};
+            $proxaddr =~ s/[\[\]]//g; # Remove [ and ]
+
+            my @proxyargs = (
+                LocalHost   => $proxaddr,
+                LocalPort   => $self->{proxy_port},
+                PeerHost    => $clientaddr,
+                PeerPort    => $self->{client_port},
+                Proto       => "udp",
+            );
+
+            if (my $sock = $IP_factory->(@proxyargs)) {
+                $self->{proxy_sock} = $sock;
+            } else {
+                warn "Failed creating proxy socket (".$self->{proxy_addr}.",0): $!\n";
+                return 0;
+            }
+        }
+    }
+
+    return 1;
+}
+
 sub clearClient
 {
     my $self = shift;

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -496,7 +496,6 @@ sub clientstart
         if ($self->debug) {
             print STDERR "Client command: $execcmd\n";
         }
-
         open(my $savedout, ">&STDOUT");
         # If we open pipe with new descriptor, attempt to close it,
         # explicitly or implicitly, would incur waitpid and effectively


### PR DESCRIPTION
There were a couple of problems with the test. First the Proxy needed to reOpen the UDP socket after the client closes it. Without this traffic will not flow through the proxy. The second issue is around sending the Sever socket an alert message. Since we are DTLS1.3 closing the socket doesn't notify the server to close the connection. Thus this is done by sending an Alert message via the Proxy.

Fixes: openssl/project#1790

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
