### PR TITLE
X509V3_EXT_print(): Return only 0 or 1 as the callers expect

### DIFF
--- a/crypto/x509/v3_prn.c
+++ b/crypto/x509/v3_prn.c
@@ -191,9 +191,9 @@ static int unknown_ext_print(BIO *out, const unsigned char *ext, int extlen,
         return 1;
 
     case X509V3_EXT_PARSE_UNKNOWN:
-        return ASN1_parse_dump(out, ext, extlen, indent, -1);
+        return ASN1_parse_dump(out, ext, extlen, indent, -1) > 0;
     case X509V3_EXT_DUMP_UNKNOWN:
-        return BIO_dump_indent(out, (const char *)ext, extlen, indent);
+        return BIO_dump_indent(out, (const char *)ext, extlen, indent) > 0;
 
     default:
         return 1;


### PR DESCRIPTION
Alternative to #29793 