### PR TITLE
windows: Fix no-shared build failure

### DIFF
--- a/apps/lib/win32_init.c
+++ b/apps/lib/win32_init.c
@@ -10,7 +10,6 @@
 #include <windows.h>
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
 
 #if defined(CP_UTF8)
 


### PR DESCRIPTION
The functions malloc, realloc and free are included from stdlib,
therefore no need for redundant malloc.h include.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
