### PR TITLE
Fix of SSL_get_error() so that it no longer depends on the state of the error stack

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,12 @@ OpenSSL 4.0
 
    *Neil Horman*
 
+ * SSL_get_error() no longer depends on the state of the error stack,
+   so it is no longer necessary to empty the error queue before the
+   TLS/SSL I/O operations.
+
+   *Igor Ustinov*
+
  * Added configure options to disable KDF algorithms for
    hmac-drbg-kdf, kbkdf, krb5kdf, pvkkdf, snmpkdf, sskdf, sshkdf, x942kdf and x963kdf.
 

--- a/doc/man3/SSL_get_error.pod
+++ b/doc/man3/SSL_get_error.pod
@@ -18,14 +18,6 @@ SSL_read_ex(), SSL_read(), SSL_peek_ex(), SSL_peek(), SSL_shutdown(),
 SSL_write_ex() or SSL_write() on B<ssl>.  The value returned by that TLS/SSL I/O
 function must be passed to SSL_get_error() in parameter B<ret>.
 
-In addition to B<ssl> and B<ret>, SSL_get_error() inspects the
-current thread's OpenSSL error queue.  Thus, SSL_get_error() must be
-used in the same thread that performed the TLS/SSL I/O operation, and no
-other OpenSSL function calls should appear in between.  The current
-thread's error queue must be empty before the TLS/SSL I/O operation is
-attempted, or SSL_get_error() will not work reliably.  Emptying the
-current thread's error queue is done with L<ERR_clear_error(3)>.
-
 =head1 NOTES
 
 Some TLS implementations do not send a close_notify alert on shutdown.
@@ -194,6 +186,10 @@ L<ERR_clear_error(3)>, ERR_print_errors(3), ERR_peek_last_error_all(3)
 
 The SSL_ERROR_WANT_ASYNC error code was added in OpenSSL 1.1.0.
 The SSL_ERROR_WANT_CLIENT_HELLO_CB error code was added in OpenSSL 1.1.1.
+
+Since OpenSSL 4.0 SSL_get_error() no longer depends on the state of the
+error stack, so it is no longer necessary to empty the error queue
+before the TLS/SSL I/O operations.
 
 =head1 COPYRIGHT
 

--- a/include/internal/statem.h
+++ b/include/internal/statem.h
@@ -81,6 +81,12 @@ typedef enum {
     CON_FUNC_DONT_SEND
 } CON_FUNC_RETURN;
 
+typedef enum {
+    ERROR_STATE_NOERROR = 0,
+    ERROR_STATE_SSL,
+    ERROR_STATE_SYSCALL
+} ERROR_STATE;
+
 typedef int (*ossl_statem_mutate_handshake_cb)(const unsigned char *msgin,
     size_t inlen,
     unsigned char **msgout,
@@ -106,6 +112,7 @@ struct ossl_statem_st {
     OSSL_HANDSHAKE_STATE hand_state;
     /* The handshake state requested by an API call (e.g. HelloRequest) */
     OSSL_HANDSHAKE_STATE request_state;
+    ERROR_STATE error_state;
     int in_init;
     int read_state_first_init;
     /* true when we are actually in SSL_accept() or SSL_connect() */

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -131,6 +131,7 @@ void ossl_statem_clear(SSL_CONNECTION *s)
 {
     s->statem.state = MSG_FLOW_UNINITED;
     s->statem.hand_state = TLS_ST_BEFORE;
+    s->statem.error_state = ERROR_STATE_NOERROR;
     ossl_statem_set_in_init(s, 1);
     s->statem.no_cert_verify = 0;
 }
@@ -288,6 +289,7 @@ void ossl_statem_set_hello_verify_done(SSL_CONNECTION *s)
      * sensible.
      */
     s->statem.hand_state = TLS_ST_SR_CLNT_HELLO;
+    s->statem.error_state = ERROR_STATE_NOERROR;
 }
 
 int ossl_statem_connect(SSL *s)

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -3489,7 +3489,7 @@ int setup_tests(void)
         goto err;
 
     cprivkey = test_mk_file_path(certsdir, "ee-key.pem");
-    if (privkey == NULL)
+    if (cprivkey == NULL)
         goto err;
 
     ADD_ALL_TESTS(test_quic_write_read, 3);


### PR DESCRIPTION
We check in relevant functions (SSL_handshake(), SSL_read(), etc.) whether a new error has been pushed onto the error stack, and if so, memorise this fact in the SSL structure. After that SSL_get_error() uses this memorised information instead of checking the error stack itself.

Fixes #11889
Fixes openssl/project#1715

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
