### PR TITLE
Fix: resolve redefinition of typedef 'RSA_OEAP_PARAMS' in RHEL6

### DIFF
--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -333,13 +333,13 @@ struct rsa_pss_params_st {
 DECLARE_ASN1_FUNCTIONS(RSA_PSS_PARAMS)
 DECLARE_ASN1_DUP_FUNCTION(RSA_PSS_PARAMS)
 
-typedef struct rsa_oaep_params_st {
+struct rsa_oaep_params_st {
     X509_ALGOR *hashFunc;
     X509_ALGOR *maskGenFunc;
     X509_ALGOR *pSourceFunc;
     /* Decoded hash algorithm from maskGenFunc */
     X509_ALGOR *maskHash;
-} RSA_OAEP_PARAMS;
+};
 
 DECLARE_ASN1_FUNCTIONS(RSA_OAEP_PARAMS)
 

--- a/include/openssl/types.h
+++ b/include/openssl/types.h
@@ -149,7 +149,9 @@ typedef struct dsa_method DSA_METHOD;
 typedef struct rsa_st RSA;
 typedef struct rsa_meth_st RSA_METHOD;
 #endif
+
 typedef struct rsa_pss_params_st RSA_PSS_PARAMS;
+typedef struct rsa_oaep_params_st RSA_OAEP_PARAMS;
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
 typedef struct ec_key_st EC_KEY;


### PR DESCRIPTION
I moved RSA_OAEP_PARAMS typedef to openssl/types.h to avoid redefinition.
Fixes #29985

CLA: trivial
