### PR TITLE
Alternate fix for CVE-2025-69419

### DIFF
--- a/crypto/pkcs12/p12_utl.c
+++ b/crypto/pkcs12/p12_utl.c
@@ -175,7 +175,7 @@ static int bmp_to_utf8(char *str, const unsigned char *utf16, int len)
         utf32chr += 0x10000;
     }
 
-    return UTF8_putc((unsigned char *)str, len > 4 ? 4 : len, utf32chr);
+    return UTF8_putc((unsigned char *)str, 4, utf32chr);
 }
 
 char *OPENSSL_uni2utf8(const unsigned char *uni, int unilen)

--- a/test/asn1_internal_test.c
+++ b/test/asn1_internal_test.c
@@ -20,6 +20,7 @@
 
 #include <openssl/asn1.h>
 #include <openssl/evp.h>
+#include <openssl/pkcs12.h>
 #include <openssl/objects.h>
 #include <openssl/posix_time.h>
 #include "testutil.h"
@@ -570,6 +571,22 @@ static int test_mbstring_ncopy(void)
     return 1;
 }
 
+static int test_ossl_uni2utf8(void)
+{
+    const unsigned char in[] = { 0x21, 0x92 }; /* unicode right arrow */
+    int inlen = 2;
+    char *out = NULL;
+    int ok = 0;
+
+    /* reproducer for CVE-2025-69419 */
+    out = OPENSSL_uni2utf8(in, inlen);
+    if (TEST_str_eq(out, "\xe2\x86\x92"))
+        ok = 1;
+
+    OPENSSL_free(out);
+    return ok;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(test_tbl_standard);
@@ -582,5 +599,6 @@ int setup_tests(void)
     ADD_TEST(posix_time_test);
     ADD_TEST(test_asn1_time_tm_conversions);
     ADD_TEST(test_mbstring_ncopy);
+    ADD_TEST(test_ossl_uni2utf8);
     return 1;
 }


### PR DESCRIPTION
This affects the function OPENSSL_uni2utf8
which caused heap buffer overflow when certain
unicode characters are converted.
The current fix is incomplete and does only prevent the crash by making OPENSSL_uni2utf8 return a NULL pointer. But with this change the OPENSSL_uni2utf8 will return the correct utf8 string instead of a NULL pointer.
Additionally we add a simple test case that demonstrates the original CVE.

##### Checklist
- [x] tests are added or updated
