### PR TITLE
Add Ed25519 Cert. Support for DTLS 1.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,11 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * Added support for Ed25519 and Ed448 certificates in DTLS 1.2. Previously,
+   these certificate types were only supported in TLS 1.2 and TLS 1.3.
+
+   *Adriano Sela Aviles*
+
  * SubjectPublicKeyInfo blobs whose AlgorithmIdentifier uses id-RSAES-OAEP
    (NID_rsaesOaep, 1.2.840.113549.1.1.7) with a plain RSAPublicKey body
    are now decoded as RSA keys.  This is required for interoperability

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4825,10 +4825,13 @@ void ssl_set_masks(SSL_CONNECTION *s)
 
     /*
      * If we only have an RSA-PSS certificate allow RSA authentication
-     * if TLS 1.2 and peer supports it.
+     * if TLS 1.2 or DTLS 1.2 and peer supports it.
      */
 
-    if (rsa_enc || rsa_sign || (ssl_has_cert(s, SSL_PKEY_RSA_PSS_SIGN) && pvalid[SSL_PKEY_RSA_PSS_SIGN] & CERT_PKEY_EXPLICIT_SIGN && TLS1_get_version(&s->ssl) == TLS1_2_VERSION))
+    if (rsa_enc || rsa_sign
+        || (ssl_has_cert(s, SSL_PKEY_RSA_PSS_SIGN)
+            && pvalid[SSL_PKEY_RSA_PSS_SIGN] & CERT_PKEY_EXPLICIT_SIGN
+            && (SSL_version(&s->ssl) == XTLS(&s->ssl, 1, 2))))
         mask_a |= SSL_aRSA;
 
     if (dsa_sign) {
@@ -4847,7 +4850,7 @@ void ssl_set_masks(SSL_CONNECTION *s)
     }
     if (pvalid[SSL_PKEY_ECC] & CERT_PKEY_RPK)
         mask_a |= SSL_aECDSA;
-    if (TLS1_get_version(&s->ssl) == TLS1_2_VERSION) {
+    if (SSL_version(&s->ssl) == XTLS(&s->ssl, 1, 2)) {
         if (pvalid[SSL_PKEY_RSA_PSS_SIGN] & CERT_PKEY_RPK)
             mask_a |= SSL_aRSA;
         if (pvalid[SSL_PKEY_ED25519] & CERT_PKEY_RPK
@@ -4868,16 +4871,16 @@ void ssl_set_masks(SSL_CONNECTION *s)
         if (ecdsa_ok)
             mask_a |= SSL_aECDSA;
     }
-    /* Allow Ed25519 for TLS 1.2 if peer supports it */
+    /* Allow Ed25519 for TLS 1.2 and DTLS 1.2 if peer supports it */
     if (!(mask_a & SSL_aECDSA) && ssl_has_cert(s, SSL_PKEY_ED25519)
         && pvalid[SSL_PKEY_ED25519] & CERT_PKEY_EXPLICIT_SIGN
-        && TLS1_get_version(&s->ssl) == TLS1_2_VERSION)
+        && (SSL_version(&s->ssl) == XTLS(&s->ssl, 1, 2)))
         mask_a |= SSL_aECDSA;
 
-    /* Allow Ed448 for TLS 1.2 if peer supports it */
+    /* Allow Ed448 for TLS 1.2 and DTLS 1.2 if peer supports it */
     if (!(mask_a & SSL_aECDSA) && ssl_has_cert(s, SSL_PKEY_ED448)
         && pvalid[SSL_PKEY_ED448] & CERT_PKEY_EXPLICIT_SIGN
-        && TLS1_get_version(&s->ssl) == TLS1_2_VERSION)
+        && (SSL_version(&s->ssl) == XTLS(&s->ssl, 1, 2)))
         mask_a |= SSL_aECDSA;
 
     mask_k |= SSL_kECDHE;

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -63,6 +63,8 @@
 #define DTLS_VERSION_GE(v1, v2) (dtls_ver_ordinal(v1) <= dtls_ver_ordinal(v2))
 #define DTLS_VERSION_LT(v1, v2) (dtls_ver_ordinal(v1) > dtls_ver_ordinal(v2))
 #define DTLS_VERSION_LE(v1, v2) (dtls_ver_ordinal(v1) >= dtls_ver_ordinal(v2))
+/* TLS/DTLS version for the given SSL object: XTLS(ssl, 1, 2) == TLS 1.2 or DTLS 1.2 */
+#define XTLS(ssl, m, n) (SSL_is_dtls(ssl) ? (((0xFF - m) << 8) | (0xFF - n)) : (((0x02 + m) << 8) | (0x01 + n)))
 
 #define SSL_AD_NO_ALERT -1
 

--- a/test/ssl-tests/20-cert-select.cnf
+++ b/test/ssl-tests/20-cert-select.cnf
@@ -1,6 +1,6 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 59
+num_tests = 63
 
 test-0 = 0-ECDSA CipherString Selection
 test-1 = 1-ECDSA CipherString Selection
@@ -21,46 +21,50 @@ test-15 = 15-Ed25519 CipherString and Signature Algorithm Selection
 test-16 = 16-Ed448 CipherString and Signature Algorithm Selection
 test-17 = 17-TLS 1.2 Ed25519 Client Auth
 test-18 = 18-TLS 1.2 Ed448 Client Auth
-test-19 = 19-ECDSA Signature Algorithm Selection SHA1
-test-20 = 20-ECDSA with brainpool
-test-21 = 21-Ed25519 CipherString and Curves Selection
-test-22 = 22-Ed448 CipherString and Curves Selection
-test-23 = 23-RSA-PSS Certificate CipherString Selection
-test-24 = 24-RSA-PSS Certificate Legacy Signature Algorithm Selection
-test-25 = 25-RSA-PSS Certificate Unified Signature Algorithm Selection
-test-26 = 26-Only RSA-PSS Certificate
-test-27 = 27-Only RSA-PSS Certificate Valid Signature Algorithms
-test-28 = 28-RSA-PSS Certificate, no PSS signature algorithms
-test-29 = 29-Only RSA-PSS Restricted Certificate
-test-30 = 30-RSA-PSS Restricted Certificate Valid Signature Algorithms
-test-31 = 31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm
-test-32 = 32-RSA-PSS Restricted Certificate Invalid Signature Algorithms
-test-33 = 33-RSA key exchange with only RSA-PSS certificate
-test-34 = 34-Only RSA-PSS Certificate, TLS v1.1
-test-35 = 35-TLS 1.3 ECDSA Signature Algorithm Selection
-test-36 = 36-TLS 1.3 ECDSA Signature Algorithm Selection compressed point
-test-37 = 37-TLS 1.3 ECDSA Signature Algorithm Selection SHA1
-test-38 = 38-TLS 1.3 ECDSA Signature Algorithm Selection with PSS
-test-39 = 39-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS
-test-40 = 40-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate
-test-41 = 41-TLS 1.3 RSA Signature Algorithm Selection, no PSS
-test-42 = 42-TLS 1.3 RSA-PSS Signature Algorithm Selection
-test-43 = 43-TLS 1.3 RSA Client Auth Signature Algorithm Selection
-test-44 = 44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names
-test-45 = 45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection
-test-46 = 46-TLS 1.3 Ed25519 Signature Algorithm Selection
-test-47 = 47-TLS 1.3 Ed448 Signature Algorithm Selection
-test-48 = 48-TLS 1.3 Ed25519 CipherString and Groups Selection
-test-49 = 49-TLS 1.3 Ed448 CipherString and Groups Selection
-test-50 = 50-TLS 1.3 Ed25519 Client Auth
-test-51 = 51-TLS 1.3 Ed448 Client Auth
-test-52 = 52-TLS 1.3 ECDSA with brainpool but no suitable groups
-test-53 = 53-TLS 1.3 ECDSA with brainpool
-test-54 = 54-TLS 1.3 SM2
-test-55 = 55-TLS 1.2 DSA Certificate Test
-test-56 = 56-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms
-test-57 = 57-TLS 1.3 DSA Certificate Test
-test-58 = 58-TLS 1.3 ML-DSA Certificate Test
+test-19 = 19-DTLS 1.2 Ed25519 CipherString and Signature Algorithm Selection
+test-20 = 20-DTLS 1.2 Ed448 CipherString and Signature Algorithm Selection
+test-21 = 21-DTLS 1.2 Ed25519 Client Auth
+test-22 = 22-DTLS 1.2 Ed448 Client Auth
+test-23 = 23-ECDSA Signature Algorithm Selection SHA1
+test-24 = 24-ECDSA with brainpool
+test-25 = 25-Ed25519 CipherString and Curves Selection
+test-26 = 26-Ed448 CipherString and Curves Selection
+test-27 = 27-RSA-PSS Certificate CipherString Selection
+test-28 = 28-RSA-PSS Certificate Legacy Signature Algorithm Selection
+test-29 = 29-RSA-PSS Certificate Unified Signature Algorithm Selection
+test-30 = 30-Only RSA-PSS Certificate
+test-31 = 31-Only RSA-PSS Certificate Valid Signature Algorithms
+test-32 = 32-RSA-PSS Certificate, no PSS signature algorithms
+test-33 = 33-Only RSA-PSS Restricted Certificate
+test-34 = 34-RSA-PSS Restricted Certificate Valid Signature Algorithms
+test-35 = 35-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm
+test-36 = 36-RSA-PSS Restricted Certificate Invalid Signature Algorithms
+test-37 = 37-RSA key exchange with only RSA-PSS certificate
+test-38 = 38-Only RSA-PSS Certificate, TLS v1.1
+test-39 = 39-TLS 1.3 ECDSA Signature Algorithm Selection
+test-40 = 40-TLS 1.3 ECDSA Signature Algorithm Selection compressed point
+test-41 = 41-TLS 1.3 ECDSA Signature Algorithm Selection SHA1
+test-42 = 42-TLS 1.3 ECDSA Signature Algorithm Selection with PSS
+test-43 = 43-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS
+test-44 = 44-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate
+test-45 = 45-TLS 1.3 RSA Signature Algorithm Selection, no PSS
+test-46 = 46-TLS 1.3 RSA-PSS Signature Algorithm Selection
+test-47 = 47-TLS 1.3 RSA Client Auth Signature Algorithm Selection
+test-48 = 48-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names
+test-49 = 49-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection
+test-50 = 50-TLS 1.3 Ed25519 Signature Algorithm Selection
+test-51 = 51-TLS 1.3 Ed448 Signature Algorithm Selection
+test-52 = 52-TLS 1.3 Ed25519 CipherString and Groups Selection
+test-53 = 53-TLS 1.3 Ed448 CipherString and Groups Selection
+test-54 = 54-TLS 1.3 Ed25519 Client Auth
+test-55 = 55-TLS 1.3 Ed448 Client Auth
+test-56 = 56-TLS 1.3 ECDSA with brainpool but no suitable groups
+test-57 = 57-TLS 1.3 ECDSA with brainpool
+test-58 = 58-TLS 1.3 SM2
+test-59 = 59-TLS 1.2 DSA Certificate Test
+test-60 = 60-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms
+test-61 = 61-TLS 1.3 DSA Certificate Test
+test-62 = 62-TLS 1.3 ML-DSA Certificate Test
 # ===========================================================
 
 [0-ECDSA CipherString Selection]
@@ -668,14 +672,150 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[19-ECDSA Signature Algorithm Selection SHA1]
-ssl_conf = 19-ECDSA Signature Algorithm Selection SHA1-ssl
+[19-DTLS 1.2 Ed25519 CipherString and Signature Algorithm Selection]
+ssl_conf = 19-DTLS 1.2 Ed25519 CipherString and Signature Algorithm Selection-ssl
 
-[19-ECDSA Signature Algorithm Selection SHA1-ssl]
-server = 19-ECDSA Signature Algorithm Selection SHA1-server
-client = 19-ECDSA Signature Algorithm Selection SHA1-client
+[19-DTLS 1.2 Ed25519 CipherString and Signature Algorithm Selection-ssl]
+server = 19-DTLS 1.2 Ed25519 CipherString and Signature Algorithm Selection-server
+client = 19-DTLS 1.2 Ed25519 CipherString and Signature Algorithm Selection-client
 
-[19-ECDSA Signature Algorithm Selection SHA1-server]
+[19-DTLS 1.2 Ed25519 CipherString and Signature Algorithm Selection-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[19-DTLS 1.2 Ed25519 CipherString and Signature Algorithm Selection-client]
+CipherString = aECDSA
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+SignatureAlgorithms = ed25519:eCdsa+SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-19]
+ExpectedResult = Success
+ExpectedServerCANames = empty
+ExpectedServerCertType = Ed25519
+ExpectedServerSignType = Ed25519
+
+
+# ===========================================================
+
+[20-DTLS 1.2 Ed448 CipherString and Signature Algorithm Selection]
+ssl_conf = 20-DTLS 1.2 Ed448 CipherString and Signature Algorithm Selection-ssl
+
+[20-DTLS 1.2 Ed448 CipherString and Signature Algorithm Selection-ssl]
+server = 20-DTLS 1.2 Ed448 CipherString and Signature Algorithm Selection-server
+client = 20-DTLS 1.2 Ed448 CipherString and Signature Algorithm Selection-client
+
+[20-DTLS 1.2 Ed448 CipherString and Signature Algorithm Selection-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[20-DTLS 1.2 Ed448 CipherString and Signature Algorithm Selection-client]
+CipherString = aECDSA
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-ed448-cert.pem
+SignatureAlgorithms = ed448:EcDSA+SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-ed448-cert.pem
+VerifyMode = Peer
+
+[test-20]
+ExpectedResult = Success
+ExpectedServerCANames = empty
+ExpectedServerCertType = Ed448
+ExpectedServerSignType = Ed448
+
+
+# ===========================================================
+
+[21-DTLS 1.2 Ed25519 Client Auth]
+ssl_conf = 21-DTLS 1.2 Ed25519 Client Auth-ssl
+
+[21-DTLS 1.2 Ed25519 Client Auth-ssl]
+server = 21-DTLS 1.2 Ed25519 Client Auth-server
+client = 21-DTLS 1.2 Ed25519 Client Auth-client
+
+[21-DTLS 1.2 Ed25519 Client Auth-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+[21-DTLS 1.2 Ed25519 Client Auth-client]
+CipherString = DEFAULT
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/client-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/client-ed25519-key.pem
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-21]
+ExpectedClientCertType = Ed25519
+ExpectedClientSignType = Ed25519
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[22-DTLS 1.2 Ed448 Client Auth]
+ssl_conf = 22-DTLS 1.2 Ed448 Client Auth-ssl
+
+[22-DTLS 1.2 Ed448 Client Auth-ssl]
+server = 22-DTLS 1.2 Ed448 Client Auth-server
+client = 22-DTLS 1.2 Ed448 Client Auth-client
+
+[22-DTLS 1.2 Ed448 Client Auth-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+[22-DTLS 1.2 Ed448 Client Auth-client]
+CipherString = DEFAULT
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/client-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/client-ed448-key.pem
+MaxProtocol = DTLSv1.2
+MinProtocol = DTLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-22]
+ExpectedClientCertType = Ed448
+ExpectedClientSignType = Ed448
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[23-ECDSA Signature Algorithm Selection SHA1]
+ssl_conf = 23-ECDSA Signature Algorithm Selection SHA1-ssl
+
+[23-ECDSA Signature Algorithm Selection SHA1-ssl]
+server = 23-ECDSA Signature Algorithm Selection SHA1-server
+client = 23-ECDSA Signature Algorithm Selection SHA1-client
+
+[23-ECDSA Signature Algorithm Selection SHA1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT:@SECLEVEL=0
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -687,13 +827,13 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[19-ECDSA Signature Algorithm Selection SHA1-client]
+[23-ECDSA Signature Algorithm Selection SHA1-client]
 CipherString = DEFAULT:@SECLEVEL=0
-SignatureAlgorithms = ECdSa+SHA1
+SignatureAlgorithms = ECdsa+SHA1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-19]
+[test-23]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignHash = SHA1
@@ -702,20 +842,20 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[20-ECDSA with brainpool]
-ssl_conf = 20-ECDSA with brainpool-ssl
+[24-ECDSA with brainpool]
+ssl_conf = 24-ECDSA with brainpool-ssl
 
-[20-ECDSA with brainpool-ssl]
-server = 20-ECDSA with brainpool-server
-client = 20-ECDSA with brainpool-client
+[24-ECDSA with brainpool-ssl]
+server = 24-ECDSA with brainpool-server
+client = 24-ECDSA with brainpool-client
 
-[20-ECDSA with brainpool-server]
+[24-ECDSA with brainpool-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-cert.pem
 CipherString = DEFAULT
 Groups = brainpoolP256r1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-key.pem
 
-[20-ECDSA with brainpool-client]
+[24-ECDSA with brainpool-client]
 CipherString = aECDSA
 Groups = brainpoolP256r1
 MaxProtocol = TLSv1.2
@@ -723,7 +863,7 @@ RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-20]
+[test-24]
 ExpectedResult = Success
 ExpectedServerCANames = empty
 ExpectedServerCertType = brainpoolP256r1
@@ -732,14 +872,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[21-Ed25519 CipherString and Curves Selection]
-ssl_conf = 21-Ed25519 CipherString and Curves Selection-ssl
+[25-Ed25519 CipherString and Curves Selection]
+ssl_conf = 25-Ed25519 CipherString and Curves Selection-ssl
 
-[21-Ed25519 CipherString and Curves Selection-ssl]
-server = 21-Ed25519 CipherString and Curves Selection-server
-client = 21-Ed25519 CipherString and Curves Selection-client
+[25-Ed25519 CipherString and Curves Selection-ssl]
+server = 25-Ed25519 CipherString and Curves Selection-server
+client = 25-Ed25519 CipherString and Curves Selection-client
 
-[21-Ed25519 CipherString and Curves Selection-server]
+[25-Ed25519 CipherString and Curves Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -751,15 +891,15 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[21-Ed25519 CipherString and Curves Selection-client]
+[25-Ed25519 CipherString and Curves Selection-client]
 CipherString = aECDSA
 Curves = X25519
 MaxProtocol = TLSv1.2
-SignatureAlgorithms = ecDSA+SHA256:Ed25519
+SignatureAlgorithms = eCDsA+SHA256:ed25519
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-21]
+[test-25]
 ExpectedResult = Success
 ExpectedServerCertType = Ed25519
 ExpectedServerSignType = Ed25519
@@ -767,14 +907,14 @@ ExpectedServerSignType = Ed25519
 
 # ===========================================================
 
-[22-Ed448 CipherString and Curves Selection]
-ssl_conf = 22-Ed448 CipherString and Curves Selection-ssl
+[26-Ed448 CipherString and Curves Selection]
+ssl_conf = 26-Ed448 CipherString and Curves Selection-ssl
 
-[22-Ed448 CipherString and Curves Selection-ssl]
-server = 22-Ed448 CipherString and Curves Selection-server
-client = 22-Ed448 CipherString and Curves Selection-client
+[26-Ed448 CipherString and Curves Selection-ssl]
+server = 26-Ed448 CipherString and Curves Selection-server
+client = 26-Ed448 CipherString and Curves Selection-client
 
-[22-Ed448 CipherString and Curves Selection-server]
+[26-Ed448 CipherString and Curves Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -786,15 +926,15 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[22-Ed448 CipherString and Curves Selection-client]
+[26-Ed448 CipherString and Curves Selection-client]
 CipherString = aECDSA
 Curves = X448
 MaxProtocol = TLSv1.2
-SignatureAlgorithms = ECDSa+SHA256:ED448
+SignatureAlgorithms = EcdSa+SHA256:Ed448
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-ed448-cert.pem
 VerifyMode = Peer
 
-[test-22]
+[test-26]
 ExpectedResult = Success
 ExpectedServerCertType = Ed448
 ExpectedServerSignType = Ed448
@@ -802,14 +942,14 @@ ExpectedServerSignType = Ed448
 
 # ===========================================================
 
-[23-RSA-PSS Certificate CipherString Selection]
-ssl_conf = 23-RSA-PSS Certificate CipherString Selection-ssl
+[27-RSA-PSS Certificate CipherString Selection]
+ssl_conf = 27-RSA-PSS Certificate CipherString Selection-ssl
 
-[23-RSA-PSS Certificate CipherString Selection-ssl]
-server = 23-RSA-PSS Certificate CipherString Selection-server
-client = 23-RSA-PSS Certificate CipherString Selection-client
+[27-RSA-PSS Certificate CipherString Selection-ssl]
+server = 27-RSA-PSS Certificate CipherString Selection-server
+client = 27-RSA-PSS Certificate CipherString Selection-client
 
-[23-RSA-PSS Certificate CipherString Selection-server]
+[27-RSA-PSS Certificate CipherString Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -823,13 +963,13 @@ PSS.Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 PSS.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[23-RSA-PSS Certificate CipherString Selection-client]
+[27-RSA-PSS Certificate CipherString Selection-client]
 CipherString = aRSA
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-23]
+[test-27]
 ExpectedResult = Success
 ExpectedServerCertType = RSA-PSS
 ExpectedServerSignType = RSA-PSS
@@ -837,14 +977,14 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[24-RSA-PSS Certificate Legacy Signature Algorithm Selection]
-ssl_conf = 24-RSA-PSS Certificate Legacy Signature Algorithm Selection-ssl
+[28-RSA-PSS Certificate Legacy Signature Algorithm Selection]
+ssl_conf = 28-RSA-PSS Certificate Legacy Signature Algorithm Selection-ssl
 
-[24-RSA-PSS Certificate Legacy Signature Algorithm Selection-ssl]
-server = 24-RSA-PSS Certificate Legacy Signature Algorithm Selection-server
-client = 24-RSA-PSS Certificate Legacy Signature Algorithm Selection-client
+[28-RSA-PSS Certificate Legacy Signature Algorithm Selection-ssl]
+server = 28-RSA-PSS Certificate Legacy Signature Algorithm Selection-server
+client = 28-RSA-PSS Certificate Legacy Signature Algorithm Selection-client
 
-[24-RSA-PSS Certificate Legacy Signature Algorithm Selection-server]
+[28-RSA-PSS Certificate Legacy Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -858,13 +998,13 @@ PSS.Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 PSS.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[24-RSA-PSS Certificate Legacy Signature Algorithm Selection-client]
+[28-RSA-PSS Certificate Legacy Signature Algorithm Selection-client]
 CipherString = DEFAULT
-SignatureAlgorithms = rSA-pSS+SHA256
+SignatureAlgorithms = rSa-PSS+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-24]
+[test-28]
 ExpectedResult = Success
 ExpectedServerCertType = RSA
 ExpectedServerSignHash = SHA256
@@ -873,14 +1013,14 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[25-RSA-PSS Certificate Unified Signature Algorithm Selection]
-ssl_conf = 25-RSA-PSS Certificate Unified Signature Algorithm Selection-ssl
+[29-RSA-PSS Certificate Unified Signature Algorithm Selection]
+ssl_conf = 29-RSA-PSS Certificate Unified Signature Algorithm Selection-ssl
 
-[25-RSA-PSS Certificate Unified Signature Algorithm Selection-ssl]
-server = 25-RSA-PSS Certificate Unified Signature Algorithm Selection-server
-client = 25-RSA-PSS Certificate Unified Signature Algorithm Selection-client
+[29-RSA-PSS Certificate Unified Signature Algorithm Selection-ssl]
+server = 29-RSA-PSS Certificate Unified Signature Algorithm Selection-server
+client = 29-RSA-PSS Certificate Unified Signature Algorithm Selection-client
 
-[25-RSA-PSS Certificate Unified Signature Algorithm Selection-server]
+[29-RSA-PSS Certificate Unified Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -894,112 +1034,9 @@ PSS.Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 PSS.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[25-RSA-PSS Certificate Unified Signature Algorithm Selection-client]
+[29-RSA-PSS Certificate Unified Signature Algorithm Selection-client]
 CipherString = DEFAULT
-SignatureAlgorithms = rsA_PsS_PsS_sHa256
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-25]
-ExpectedResult = Success
-ExpectedServerCertType = RSA-PSS
-ExpectedServerSignHash = SHA256
-ExpectedServerSignType = RSA-PSS
-
-
-# ===========================================================
-
-[26-Only RSA-PSS Certificate]
-ssl_conf = 26-Only RSA-PSS Certificate-ssl
-
-[26-Only RSA-PSS Certificate-ssl]
-server = 26-Only RSA-PSS Certificate-server
-client = 26-Only RSA-PSS Certificate-client
-
-[26-Only RSA-PSS Certificate-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
-
-[26-Only RSA-PSS Certificate-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-26]
-ExpectedResult = Success
-ExpectedServerCertType = RSA-PSS
-ExpectedServerSignHash = SHA256
-ExpectedServerSignType = RSA-PSS
-
-
-# ===========================================================
-
-[27-Only RSA-PSS Certificate Valid Signature Algorithms]
-ssl_conf = 27-Only RSA-PSS Certificate Valid Signature Algorithms-ssl
-
-[27-Only RSA-PSS Certificate Valid Signature Algorithms-ssl]
-server = 27-Only RSA-PSS Certificate Valid Signature Algorithms-server
-client = 27-Only RSA-PSS Certificate Valid Signature Algorithms-client
-
-[27-Only RSA-PSS Certificate Valid Signature Algorithms-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
-
-[27-Only RSA-PSS Certificate Valid Signature Algorithms-client]
-CipherString = DEFAULT
-SignatureAlgorithms = rsa_psS_psS_sHa512
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-27]
-ExpectedResult = Success
-ExpectedServerCertType = RSA-PSS
-ExpectedServerSignHash = SHA512
-ExpectedServerSignType = RSA-PSS
-
-
-# ===========================================================
-
-[28-RSA-PSS Certificate, no PSS signature algorithms]
-ssl_conf = 28-RSA-PSS Certificate, no PSS signature algorithms-ssl
-
-[28-RSA-PSS Certificate, no PSS signature algorithms-ssl]
-server = 28-RSA-PSS Certificate, no PSS signature algorithms-server
-client = 28-RSA-PSS Certificate, no PSS signature algorithms-client
-
-[28-RSA-PSS Certificate, no PSS signature algorithms-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
-
-[28-RSA-PSS Certificate, no PSS signature algorithms-client]
-CipherString = DEFAULT
-SignatureAlgorithms = rsa+SHA256
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-28]
-ExpectedResult = ServerFail
-
-
-# ===========================================================
-
-[29-Only RSA-PSS Restricted Certificate]
-ssl_conf = 29-Only RSA-PSS Restricted Certificate-ssl
-
-[29-Only RSA-PSS Restricted Certificate-ssl]
-server = 29-Only RSA-PSS Restricted Certificate-server
-client = 29-Only RSA-PSS Restricted Certificate-client
-
-[29-Only RSA-PSS Restricted Certificate-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
-
-[29-Only RSA-PSS Restricted Certificate-client]
-CipherString = DEFAULT
+SignatureAlgorithms = rsa_Pss_PsS_sHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1012,21 +1049,20 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[30-RSA-PSS Restricted Certificate Valid Signature Algorithms]
-ssl_conf = 30-RSA-PSS Restricted Certificate Valid Signature Algorithms-ssl
+[30-Only RSA-PSS Certificate]
+ssl_conf = 30-Only RSA-PSS Certificate-ssl
 
-[30-RSA-PSS Restricted Certificate Valid Signature Algorithms-ssl]
-server = 30-RSA-PSS Restricted Certificate Valid Signature Algorithms-server
-client = 30-RSA-PSS Restricted Certificate Valid Signature Algorithms-client
+[30-Only RSA-PSS Certificate-ssl]
+server = 30-Only RSA-PSS Certificate-server
+client = 30-Only RSA-PSS Certificate-client
 
-[30-RSA-PSS Restricted Certificate Valid Signature Algorithms-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
+[30-Only RSA-PSS Certificate-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 
-[30-RSA-PSS Restricted Certificate Valid Signature Algorithms-client]
+[30-Only RSA-PSS Certificate-client]
 CipherString = DEFAULT
-SignatureAlgorithms = RSa_pSS_pSs_sHA256:rsa_PsS_PSs_sHA512
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1039,48 +1075,48 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm]
-ssl_conf = 31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-ssl
+[31-Only RSA-PSS Certificate Valid Signature Algorithms]
+ssl_conf = 31-Only RSA-PSS Certificate Valid Signature Algorithms-ssl
 
-[31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-ssl]
-server = 31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-server
-client = 31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-client
+[31-Only RSA-PSS Certificate Valid Signature Algorithms-ssl]
+server = 31-Only RSA-PSS Certificate Valid Signature Algorithms-server
+client = 31-Only RSA-PSS Certificate Valid Signature Algorithms-client
 
-[31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
+[31-Only RSA-PSS Certificate Valid Signature Algorithms-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 
-[31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-client]
+[31-Only RSA-PSS Certificate Valid Signature Algorithms-client]
 CipherString = DEFAULT
-SignatureAlgorithms = rsA_pss_psS_sha512:rsA_pSS_PSs_ShA256
+SignatureAlgorithms = RSA_psS_PsS_shA512
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-31]
 ExpectedResult = Success
 ExpectedServerCertType = RSA-PSS
-ExpectedServerSignHash = SHA256
+ExpectedServerSignHash = SHA512
 ExpectedServerSignType = RSA-PSS
 
 
 # ===========================================================
 
-[32-RSA-PSS Restricted Certificate Invalid Signature Algorithms]
-ssl_conf = 32-RSA-PSS Restricted Certificate Invalid Signature Algorithms-ssl
+[32-RSA-PSS Certificate, no PSS signature algorithms]
+ssl_conf = 32-RSA-PSS Certificate, no PSS signature algorithms-ssl
 
-[32-RSA-PSS Restricted Certificate Invalid Signature Algorithms-ssl]
-server = 32-RSA-PSS Restricted Certificate Invalid Signature Algorithms-server
-client = 32-RSA-PSS Restricted Certificate Invalid Signature Algorithms-client
+[32-RSA-PSS Certificate, no PSS signature algorithms-ssl]
+server = 32-RSA-PSS Certificate, no PSS signature algorithms-server
+client = 32-RSA-PSS Certificate, no PSS signature algorithms-client
 
-[32-RSA-PSS Restricted Certificate Invalid Signature Algorithms-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
+[32-RSA-PSS Certificate, no PSS signature algorithms-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 
-[32-RSA-PSS Restricted Certificate Invalid Signature Algorithms-client]
+[32-RSA-PSS Certificate, no PSS signature algorithms-client]
 CipherString = DEFAULT
-SignatureAlgorithms = rSa_PSS_pSS_sHa512
+SignatureAlgorithms = rSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1090,145 +1126,125 @@ ExpectedResult = ServerFail
 
 # ===========================================================
 
-[33-RSA key exchange with only RSA-PSS certificate]
-ssl_conf = 33-RSA key exchange with only RSA-PSS certificate-ssl
+[33-Only RSA-PSS Restricted Certificate]
+ssl_conf = 33-Only RSA-PSS Restricted Certificate-ssl
 
-[33-RSA key exchange with only RSA-PSS certificate-ssl]
-server = 33-RSA key exchange with only RSA-PSS certificate-server
-client = 33-RSA key exchange with only RSA-PSS certificate-client
+[33-Only RSA-PSS Restricted Certificate-ssl]
+server = 33-Only RSA-PSS Restricted Certificate-server
+client = 33-Only RSA-PSS Restricted Certificate-client
 
-[33-RSA key exchange with only RSA-PSS certificate-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
+[33-Only RSA-PSS Restricted Certificate-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
 CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
 
-[33-RSA key exchange with only RSA-PSS certificate-client]
-CipherString = kRSA
-MaxProtocol = TLSv1.2
+[33-Only RSA-PSS Restricted Certificate-client]
+CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-33]
-ExpectedResult = ServerFail
+ExpectedResult = Success
+ExpectedServerCertType = RSA-PSS
+ExpectedServerSignHash = SHA256
+ExpectedServerSignType = RSA-PSS
 
 
 # ===========================================================
 
-[34-Only RSA-PSS Certificate, TLS v1.1]
-ssl_conf = 34-Only RSA-PSS Certificate, TLS v1.1-ssl
+[34-RSA-PSS Restricted Certificate Valid Signature Algorithms]
+ssl_conf = 34-RSA-PSS Restricted Certificate Valid Signature Algorithms-ssl
 
-[34-Only RSA-PSS Certificate, TLS v1.1-ssl]
-server = 34-Only RSA-PSS Certificate, TLS v1.1-server
-client = 34-Only RSA-PSS Certificate, TLS v1.1-client
+[34-RSA-PSS Restricted Certificate Valid Signature Algorithms-ssl]
+server = 34-RSA-PSS Restricted Certificate Valid Signature Algorithms-server
+client = 34-RSA-PSS Restricted Certificate Valid Signature Algorithms-client
 
-[34-Only RSA-PSS Certificate, TLS v1.1-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
-CipherString = DEFAULT:@SECLEVEL=0
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
+[34-RSA-PSS Restricted Certificate Valid Signature Algorithms-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
 
-[34-Only RSA-PSS Certificate, TLS v1.1-client]
-CipherString = DEFAULT:@SECLEVEL=0
-MaxProtocol = TLSv1.1
+[34-RSA-PSS Restricted Certificate Valid Signature Algorithms-client]
+CipherString = DEFAULT
+SignatureAlgorithms = rSa_PSS_psS_Sha256:Rsa_pss_Pss_sha512
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-34]
-ExpectedResult = ServerFail
+ExpectedResult = Success
+ExpectedServerCertType = RSA-PSS
+ExpectedServerSignHash = SHA256
+ExpectedServerSignType = RSA-PSS
 
 
 # ===========================================================
 
-[35-TLS 1.3 ECDSA Signature Algorithm Selection]
-ssl_conf = 35-TLS 1.3 ECDSA Signature Algorithm Selection-ssl
+[35-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm]
+ssl_conf = 35-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-ssl
 
-[35-TLS 1.3 ECDSA Signature Algorithm Selection-ssl]
-server = 35-TLS 1.3 ECDSA Signature Algorithm Selection-server
-client = 35-TLS 1.3 ECDSA Signature Algorithm Selection-client
+[35-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-ssl]
+server = 35-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-server
+client = 35-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-client
 
-[35-TLS 1.3 ECDSA Signature Algorithm Selection-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+[35-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
 CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
-Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
-Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
-Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
-Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
 
-[35-TLS 1.3 ECDSA Signature Algorithm Selection-client]
+[35-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-client]
 CipherString = DEFAULT
-SignatureAlgorithms = ECDsa+SHA256
+SignatureAlgorithms = RsA_PSS_pSs_ShA512:rSA_PsS_PsS_sha256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-35]
 ExpectedResult = Success
-ExpectedServerCANames = empty
-ExpectedServerCertType = P-256
+ExpectedServerCertType = RSA-PSS
 ExpectedServerSignHash = SHA256
-ExpectedServerSignType = EC
+ExpectedServerSignType = RSA-PSS
 
 
 # ===========================================================
 
-[36-TLS 1.3 ECDSA Signature Algorithm Selection compressed point]
-ssl_conf = 36-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-ssl
+[36-RSA-PSS Restricted Certificate Invalid Signature Algorithms]
+ssl_conf = 36-RSA-PSS Restricted Certificate Invalid Signature Algorithms-ssl
 
-[36-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-ssl]
-server = 36-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-server
-client = 36-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-client
+[36-RSA-PSS Restricted Certificate Invalid Signature Algorithms-ssl]
+server = 36-RSA-PSS Restricted Certificate Invalid Signature Algorithms-server
+client = 36-RSA-PSS Restricted Certificate Invalid Signature Algorithms-client
 
-[36-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+[36-RSA-PSS Restricted Certificate Invalid Signature Algorithms-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
 CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-cecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-cecdsa-key.pem
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
 
-[36-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-client]
+[36-RSA-PSS Restricted Certificate Invalid Signature Algorithms-client]
 CipherString = DEFAULT
-SignatureAlgorithms = ecDSA+SHA256
+SignatureAlgorithms = rSA_PSs_psS_sha512
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-36]
-ExpectedResult = Success
-ExpectedServerCANames = empty
-ExpectedServerCertType = P-256
-ExpectedServerSignHash = SHA256
-ExpectedServerSignType = EC
+ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[37-TLS 1.3 ECDSA Signature Algorithm Selection SHA1]
-ssl_conf = 37-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-ssl
+[37-RSA key exchange with only RSA-PSS certificate]
+ssl_conf = 37-RSA key exchange with only RSA-PSS certificate-ssl
 
-[37-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-ssl]
-server = 37-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-server
-client = 37-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-client
+[37-RSA key exchange with only RSA-PSS certificate-ssl]
+server = 37-RSA key exchange with only RSA-PSS certificate-server
+client = 37-RSA key exchange with only RSA-PSS certificate-client
 
-[37-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT:@SECLEVEL=0
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
-Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
-Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
-Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
-Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+[37-RSA key exchange with only RSA-PSS certificate-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 
-[37-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-client]
-CipherString = DEFAULT:@SECLEVEL=0
-SignatureAlgorithms = eCDSa+SHA1
+[37-RSA key exchange with only RSA-PSS certificate-client]
+CipherString = kRSA
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1238,14 +1254,38 @@ ExpectedResult = ServerFail
 
 # ===========================================================
 
-[38-TLS 1.3 ECDSA Signature Algorithm Selection with PSS]
-ssl_conf = 38-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-ssl
+[38-Only RSA-PSS Certificate, TLS v1.1]
+ssl_conf = 38-Only RSA-PSS Certificate, TLS v1.1-ssl
 
-[38-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-ssl]
-server = 38-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-server
-client = 38-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-client
+[38-Only RSA-PSS Certificate, TLS v1.1-ssl]
+server = 38-Only RSA-PSS Certificate, TLS v1.1-server
+client = 38-Only RSA-PSS Certificate, TLS v1.1-client
 
-[38-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-server]
+[38-Only RSA-PSS Certificate, TLS v1.1-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
+CipherString = DEFAULT:@SECLEVEL=0
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
+
+[38-Only RSA-PSS Certificate, TLS v1.1-client]
+CipherString = DEFAULT:@SECLEVEL=0
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-38]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[39-TLS 1.3 ECDSA Signature Algorithm Selection]
+ssl_conf = 39-TLS 1.3 ECDSA Signature Algorithm Selection-ssl
+
+[39-TLS 1.3 ECDSA Signature Algorithm Selection-ssl]
+server = 39-TLS 1.3 ECDSA Signature Algorithm Selection-server
+client = 39-TLS 1.3 ECDSA Signature Algorithm Selection-client
+
+[39-TLS 1.3 ECDSA Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1258,16 +1298,15 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[38-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-client]
+[39-TLS 1.3 ECDSA Signature Algorithm Selection-client]
 CipherString = DEFAULT
-RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-SignatureAlgorithms = eCdsA+SHA256:rsA-pSs+SHA256
+SignatureAlgorithms = ecDsa+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-38]
+[test-39]
 ExpectedResult = Success
-ExpectedServerCANames = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+ExpectedServerCANames = empty
 ExpectedServerCertType = P-256
 ExpectedServerSignHash = SHA256
 ExpectedServerSignType = EC
@@ -1275,77 +1314,48 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[39-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS]
-ssl_conf = 39-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-ssl
+[40-TLS 1.3 ECDSA Signature Algorithm Selection compressed point]
+ssl_conf = 40-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-ssl
 
-[39-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-ssl]
-server = 39-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-server
-client = 39-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-client
+[40-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-ssl]
+server = 40-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-server
+client = 40-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-client
 
-[39-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-server]
+[40-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
-Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
-Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
-Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
-Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-cecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-cecdsa-key.pem
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[39-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-client]
+[40-TLS 1.3 ECDSA Signature Algorithm Selection compressed point-client]
 CipherString = DEFAULT
-SignatureAlgorithms = ECdsA+SHA384:RSa-psS+SHA384
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-39]
-ExpectedResult = Success
-ExpectedServerCertType = RSA
-ExpectedServerSignHash = SHA384
-ExpectedServerSignType = RSA-PSS
-
-
-# ===========================================================
-
-[40-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate]
-ssl_conf = 40-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl
-
-[40-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl]
-server = 40-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-server
-client = 40-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-client
-
-[40-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[40-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-client]
-CipherString = DEFAULT
-SignatureAlgorithms = eCDSA+SHA256
+SignatureAlgorithms = EcdSa+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-40]
-ExpectedResult = ServerFail
+ExpectedResult = Success
+ExpectedServerCANames = empty
+ExpectedServerCertType = P-256
+ExpectedServerSignHash = SHA256
+ExpectedServerSignType = EC
 
 
 # ===========================================================
 
-[41-TLS 1.3 RSA Signature Algorithm Selection, no PSS]
-ssl_conf = 41-TLS 1.3 RSA Signature Algorithm Selection, no PSS-ssl
+[41-TLS 1.3 ECDSA Signature Algorithm Selection SHA1]
+ssl_conf = 41-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-ssl
 
-[41-TLS 1.3 RSA Signature Algorithm Selection, no PSS-ssl]
-server = 41-TLS 1.3 RSA Signature Algorithm Selection, no PSS-server
-client = 41-TLS 1.3 RSA Signature Algorithm Selection, no PSS-client
+[41-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-ssl]
+server = 41-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-server
+client = 41-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-client
 
-[41-TLS 1.3 RSA Signature Algorithm Selection, no PSS-server]
+[41-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
 ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
 Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
@@ -1356,9 +1366,9 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[41-TLS 1.3 RSA Signature Algorithm Selection, no PSS-client]
-CipherString = DEFAULT
-SignatureAlgorithms = RSA+SHA256
+[41-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-client]
+CipherString = DEFAULT:@SECLEVEL=0
+SignatureAlgorithms = EcDSa+SHA1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1368,14 +1378,14 @@ ExpectedResult = ServerFail
 
 # ===========================================================
 
-[42-TLS 1.3 RSA-PSS Signature Algorithm Selection]
-ssl_conf = 42-TLS 1.3 RSA-PSS Signature Algorithm Selection-ssl
+[42-TLS 1.3 ECDSA Signature Algorithm Selection with PSS]
+ssl_conf = 42-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-ssl
 
-[42-TLS 1.3 RSA-PSS Signature Algorithm Selection-ssl]
-server = 42-TLS 1.3 RSA-PSS Signature Algorithm Selection-server
-client = 42-TLS 1.3 RSA-PSS Signature Algorithm Selection-client
+[42-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-ssl]
+server = 42-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-server
+client = 42-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-client
 
-[42-TLS 1.3 RSA-PSS Signature Algorithm Selection-server]
+[42-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1388,13 +1398,143 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[42-TLS 1.3 RSA-PSS Signature Algorithm Selection-client]
+[42-TLS 1.3 ECDSA Signature Algorithm Selection with PSS-client]
 CipherString = DEFAULT
-SignatureAlgorithms = Rsa-PSS+SHA256
+RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+SignatureAlgorithms = eCDSa+SHA256:rsA-pSS+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-42]
+ExpectedResult = Success
+ExpectedServerCANames = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+ExpectedServerCertType = P-256
+ExpectedServerSignHash = SHA256
+ExpectedServerSignType = EC
+
+
+# ===========================================================
+
+[43-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS]
+ssl_conf = 43-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-ssl
+
+[43-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-ssl]
+server = 43-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-server
+client = 43-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-client
+
+[43-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[43-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS-client]
+CipherString = DEFAULT
+SignatureAlgorithms = ECDSA+SHA384:Rsa-PSS+SHA384
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-43]
+ExpectedResult = Success
+ExpectedServerCertType = RSA
+ExpectedServerSignHash = SHA384
+ExpectedServerSignType = RSA-PSS
+
+
+# ===========================================================
+
+[44-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate]
+ssl_conf = 44-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl
+
+[44-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl]
+server = 44-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-server
+client = 44-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-client
+
+[44-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[44-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate-client]
+CipherString = DEFAULT
+SignatureAlgorithms = ECDSa+SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-44]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[45-TLS 1.3 RSA Signature Algorithm Selection, no PSS]
+ssl_conf = 45-TLS 1.3 RSA Signature Algorithm Selection, no PSS-ssl
+
+[45-TLS 1.3 RSA Signature Algorithm Selection, no PSS-ssl]
+server = 45-TLS 1.3 RSA Signature Algorithm Selection, no PSS-server
+client = 45-TLS 1.3 RSA Signature Algorithm Selection, no PSS-client
+
+[45-TLS 1.3 RSA Signature Algorithm Selection, no PSS-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[45-TLS 1.3 RSA Signature Algorithm Selection, no PSS-client]
+CipherString = DEFAULT
+SignatureAlgorithms = rSA+SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-45]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[46-TLS 1.3 RSA-PSS Signature Algorithm Selection]
+ssl_conf = 46-TLS 1.3 RSA-PSS Signature Algorithm Selection-ssl
+
+[46-TLS 1.3 RSA-PSS Signature Algorithm Selection-ssl]
+server = 46-TLS 1.3 RSA-PSS Signature Algorithm Selection-server
+client = 46-TLS 1.3 RSA-PSS Signature Algorithm Selection-client
+
+[46-TLS 1.3 RSA-PSS Signature Algorithm Selection-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[46-TLS 1.3 RSA-PSS Signature Algorithm Selection-client]
+CipherString = DEFAULT
+SignatureAlgorithms = RsA-PsS+SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-46]
 ExpectedResult = Success
 ExpectedServerCertType = RSA
 ExpectedServerSignHash = SHA256
@@ -1403,22 +1543,22 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[43-TLS 1.3 RSA Client Auth Signature Algorithm Selection]
-ssl_conf = 43-TLS 1.3 RSA Client Auth Signature Algorithm Selection-ssl
+[47-TLS 1.3 RSA Client Auth Signature Algorithm Selection]
+ssl_conf = 47-TLS 1.3 RSA Client Auth Signature Algorithm Selection-ssl
 
-[43-TLS 1.3 RSA Client Auth Signature Algorithm Selection-ssl]
-server = 43-TLS 1.3 RSA Client Auth Signature Algorithm Selection-server
-client = 43-TLS 1.3 RSA Client Auth Signature Algorithm Selection-client
+[47-TLS 1.3 RSA Client Auth Signature Algorithm Selection-ssl]
+server = 47-TLS 1.3 RSA Client Auth Signature Algorithm Selection-server
+client = 47-TLS 1.3 RSA Client Auth Signature Algorithm Selection-client
 
-[43-TLS 1.3 RSA Client Auth Signature Algorithm Selection-server]
+[47-TLS 1.3 RSA Client Auth Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-ClientSignatureAlgorithms = PSS+SHA256
+ClientSignatureAlgorithms = pSs+SHA256
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[43-TLS 1.3 RSA Client Auth Signature Algorithm Selection-client]
+[47-TLS 1.3 RSA Client Auth Signature Algorithm Selection-client]
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-client-chain.pem
 ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-key.pem
@@ -1429,7 +1569,7 @@ RSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-43]
+[test-47]
 ExpectedClientCANames = empty
 ExpectedClientCertType = RSA
 ExpectedClientSignHash = SHA256
@@ -1439,23 +1579,23 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names]
-ssl_conf = 44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-ssl
+[48-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names]
+ssl_conf = 48-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-ssl
 
-[44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-ssl]
-server = 44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-server
-client = 44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-client
+[48-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-ssl]
+server = 48-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-server
+client = 48-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-client
 
-[44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-server]
+[48-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-ClientSignatureAlgorithms = Pss+SHA256
+ClientSignatureAlgorithms = pSS+SHA256
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-client]
+[48-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-client]
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-client-chain.pem
 ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-key.pem
@@ -1466,7 +1606,7 @@ RSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-44]
+[test-48]
 ExpectedClientCANames = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 ExpectedClientCertType = RSA
 ExpectedClientSignHash = SHA256
@@ -1476,22 +1616,22 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection]
-ssl_conf = 45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-ssl
+[49-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection]
+ssl_conf = 49-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-ssl
 
-[45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-ssl]
-server = 45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-server
-client = 45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-client
+[49-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-ssl]
+server = 49-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-server
+client = 49-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-client
 
-[45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-server]
+[49-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-ClientSignatureAlgorithms = ECDsA+SHA256
+ClientSignatureAlgorithms = EcdSA+SHA256
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-client]
+[49-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-client]
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-client-chain.pem
 ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-key.pem
@@ -1502,7 +1642,7 @@ RSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-45]
+[test-49]
 ExpectedClientCertType = P-256
 ExpectedClientSignHash = SHA256
 ExpectedClientSignType = EC
@@ -1511,14 +1651,14 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[46-TLS 1.3 Ed25519 Signature Algorithm Selection]
-ssl_conf = 46-TLS 1.3 Ed25519 Signature Algorithm Selection-ssl
+[50-TLS 1.3 Ed25519 Signature Algorithm Selection]
+ssl_conf = 50-TLS 1.3 Ed25519 Signature Algorithm Selection-ssl
 
-[46-TLS 1.3 Ed25519 Signature Algorithm Selection-ssl]
-server = 46-TLS 1.3 Ed25519 Signature Algorithm Selection-server
-client = 46-TLS 1.3 Ed25519 Signature Algorithm Selection-client
+[50-TLS 1.3 Ed25519 Signature Algorithm Selection-ssl]
+server = 50-TLS 1.3 Ed25519 Signature Algorithm Selection-server
+client = 50-TLS 1.3 Ed25519 Signature Algorithm Selection-client
 
-[46-TLS 1.3 Ed25519 Signature Algorithm Selection-server]
+[50-TLS 1.3 Ed25519 Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1531,13 +1671,13 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[46-TLS 1.3 Ed25519 Signature Algorithm Selection-client]
+[50-TLS 1.3 Ed25519 Signature Algorithm Selection-client]
 CipherString = DEFAULT
 SignatureAlgorithms = eD25519
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-46]
+[test-50]
 ExpectedResult = Success
 ExpectedServerCertType = Ed25519
 ExpectedServerSignType = Ed25519
@@ -1545,14 +1685,14 @@ ExpectedServerSignType = Ed25519
 
 # ===========================================================
 
-[47-TLS 1.3 Ed448 Signature Algorithm Selection]
-ssl_conf = 47-TLS 1.3 Ed448 Signature Algorithm Selection-ssl
+[51-TLS 1.3 Ed448 Signature Algorithm Selection]
+ssl_conf = 51-TLS 1.3 Ed448 Signature Algorithm Selection-ssl
 
-[47-TLS 1.3 Ed448 Signature Algorithm Selection-ssl]
-server = 47-TLS 1.3 Ed448 Signature Algorithm Selection-server
-client = 47-TLS 1.3 Ed448 Signature Algorithm Selection-client
+[51-TLS 1.3 Ed448 Signature Algorithm Selection-ssl]
+server = 51-TLS 1.3 Ed448 Signature Algorithm Selection-server
+client = 51-TLS 1.3 Ed448 Signature Algorithm Selection-client
 
-[47-TLS 1.3 Ed448 Signature Algorithm Selection-server]
+[51-TLS 1.3 Ed448 Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1565,13 +1705,13 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[47-TLS 1.3 Ed448 Signature Algorithm Selection-client]
+[51-TLS 1.3 Ed448 Signature Algorithm Selection-client]
 CipherString = DEFAULT
-SignatureAlgorithms = eD448
+SignatureAlgorithms = ED448
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-ed448-cert.pem
 VerifyMode = Peer
 
-[test-47]
+[test-51]
 ExpectedResult = Success
 ExpectedServerCertType = Ed448
 ExpectedServerSignType = Ed448
@@ -1579,14 +1719,14 @@ ExpectedServerSignType = Ed448
 
 # ===========================================================
 
-[48-TLS 1.3 Ed25519 CipherString and Groups Selection]
-ssl_conf = 48-TLS 1.3 Ed25519 CipherString and Groups Selection-ssl
+[52-TLS 1.3 Ed25519 CipherString and Groups Selection]
+ssl_conf = 52-TLS 1.3 Ed25519 CipherString and Groups Selection-ssl
 
-[48-TLS 1.3 Ed25519 CipherString and Groups Selection-ssl]
-server = 48-TLS 1.3 Ed25519 CipherString and Groups Selection-server
-client = 48-TLS 1.3 Ed25519 CipherString and Groups Selection-client
+[52-TLS 1.3 Ed25519 CipherString and Groups Selection-ssl]
+server = 52-TLS 1.3 Ed25519 CipherString and Groups Selection-server
+client = 52-TLS 1.3 Ed25519 CipherString and Groups Selection-client
 
-[48-TLS 1.3 Ed25519 CipherString and Groups Selection-server]
+[52-TLS 1.3 Ed25519 CipherString and Groups Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1599,14 +1739,14 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[48-TLS 1.3 Ed25519 CipherString and Groups Selection-client]
+[52-TLS 1.3 Ed25519 CipherString and Groups Selection-client]
 CipherString = DEFAULT
 Groups = X25519
-SignatureAlgorithms = EcdSA+SHA256:eD25519
+SignatureAlgorithms = ECDSA+SHA256:ED25519
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-48]
+[test-52]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignType = EC
@@ -1614,14 +1754,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[49-TLS 1.3 Ed448 CipherString and Groups Selection]
-ssl_conf = 49-TLS 1.3 Ed448 CipherString and Groups Selection-ssl
+[53-TLS 1.3 Ed448 CipherString and Groups Selection]
+ssl_conf = 53-TLS 1.3 Ed448 CipherString and Groups Selection-ssl
 
-[49-TLS 1.3 Ed448 CipherString and Groups Selection-ssl]
-server = 49-TLS 1.3 Ed448 CipherString and Groups Selection-server
-client = 49-TLS 1.3 Ed448 CipherString and Groups Selection-client
+[53-TLS 1.3 Ed448 CipherString and Groups Selection-ssl]
+server = 53-TLS 1.3 Ed448 CipherString and Groups Selection-server
+client = 53-TLS 1.3 Ed448 CipherString and Groups Selection-client
 
-[49-TLS 1.3 Ed448 CipherString and Groups Selection-server]
+[53-TLS 1.3 Ed448 CipherString and Groups Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -1634,14 +1774,14 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[49-TLS 1.3 Ed448 CipherString and Groups Selection-client]
+[53-TLS 1.3 Ed448 CipherString and Groups Selection-client]
 CipherString = DEFAULT
 Groups = X448
-SignatureAlgorithms = eCDSa+SHA256:ED448
+SignatureAlgorithms = eCDSA+SHA256:Ed448
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-49]
+[test-53]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignType = EC
@@ -1649,21 +1789,21 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[50-TLS 1.3 Ed25519 Client Auth]
-ssl_conf = 50-TLS 1.3 Ed25519 Client Auth-ssl
+[54-TLS 1.3 Ed25519 Client Auth]
+ssl_conf = 54-TLS 1.3 Ed25519 Client Auth-ssl
 
-[50-TLS 1.3 Ed25519 Client Auth-ssl]
-server = 50-TLS 1.3 Ed25519 Client Auth-server
-client = 50-TLS 1.3 Ed25519 Client Auth-client
+[54-TLS 1.3 Ed25519 Client Auth-ssl]
+server = 54-TLS 1.3 Ed25519 Client Auth-server
+client = 54-TLS 1.3 Ed25519 Client Auth-client
 
-[50-TLS 1.3 Ed25519 Client Auth-server]
+[54-TLS 1.3 Ed25519 Client Auth-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[50-TLS 1.3 Ed25519 Client Auth-client]
+[54-TLS 1.3 Ed25519 Client Auth-client]
 CipherString = DEFAULT
 EdDSA.Certificate = ${ENV::TEST_CERTS_DIR}/client-ed25519-cert.pem
 EdDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/client-ed25519-key.pem
@@ -1672,7 +1812,7 @@ MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-50]
+[test-54]
 ExpectedClientCertType = Ed25519
 ExpectedClientSignType = Ed25519
 ExpectedResult = Success
@@ -1680,21 +1820,21 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[51-TLS 1.3 Ed448 Client Auth]
-ssl_conf = 51-TLS 1.3 Ed448 Client Auth-ssl
+[55-TLS 1.3 Ed448 Client Auth]
+ssl_conf = 55-TLS 1.3 Ed448 Client Auth-ssl
 
-[51-TLS 1.3 Ed448 Client Auth-ssl]
-server = 51-TLS 1.3 Ed448 Client Auth-server
-client = 51-TLS 1.3 Ed448 Client Auth-client
+[55-TLS 1.3 Ed448 Client Auth-ssl]
+server = 55-TLS 1.3 Ed448 Client Auth-server
+client = 55-TLS 1.3 Ed448 Client Auth-client
 
-[51-TLS 1.3 Ed448 Client Auth-server]
+[55-TLS 1.3 Ed448 Client Auth-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[51-TLS 1.3 Ed448 Client Auth-client]
+[55-TLS 1.3 Ed448 Client Auth-client]
 CipherString = DEFAULT
 EdDSA.Certificate = ${ENV::TEST_CERTS_DIR}/client-ed448-cert.pem
 EdDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/client-ed448-key.pem
@@ -1703,7 +1843,7 @@ MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-51]
+[test-55]
 ExpectedClientCertType = Ed448
 ExpectedClientSignType = Ed448
 ExpectedResult = Success
@@ -1711,45 +1851,45 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[52-TLS 1.3 ECDSA with brainpool but no suitable groups]
-ssl_conf = 52-TLS 1.3 ECDSA with brainpool but no suitable groups-ssl
+[56-TLS 1.3 ECDSA with brainpool but no suitable groups]
+ssl_conf = 56-TLS 1.3 ECDSA with brainpool but no suitable groups-ssl
 
-[52-TLS 1.3 ECDSA with brainpool but no suitable groups-ssl]
-server = 52-TLS 1.3 ECDSA with brainpool but no suitable groups-server
-client = 52-TLS 1.3 ECDSA with brainpool but no suitable groups-client
+[56-TLS 1.3 ECDSA with brainpool but no suitable groups-ssl]
+server = 56-TLS 1.3 ECDSA with brainpool but no suitable groups-server
+client = 56-TLS 1.3 ECDSA with brainpool but no suitable groups-client
 
-[52-TLS 1.3 ECDSA with brainpool but no suitable groups-server]
+[56-TLS 1.3 ECDSA with brainpool but no suitable groups-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-cert.pem
 CipherString = DEFAULT
 Groups = brainpoolP256r1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-key.pem
 
-[52-TLS 1.3 ECDSA with brainpool but no suitable groups-client]
+[56-TLS 1.3 ECDSA with brainpool but no suitable groups-client]
 CipherString = aECDSA
 Groups = brainpoolP256r1
 RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-52]
+[test-56]
 ExpectedResult = ClientFail
 
 
 # ===========================================================
 
-[53-TLS 1.3 ECDSA with brainpool]
-ssl_conf = 53-TLS 1.3 ECDSA with brainpool-ssl
+[57-TLS 1.3 ECDSA with brainpool]
+ssl_conf = 57-TLS 1.3 ECDSA with brainpool-ssl
 
-[53-TLS 1.3 ECDSA with brainpool-ssl]
-server = 53-TLS 1.3 ECDSA with brainpool-server
-client = 53-TLS 1.3 ECDSA with brainpool-client
+[57-TLS 1.3 ECDSA with brainpool-ssl]
+server = 57-TLS 1.3 ECDSA with brainpool-server
+client = 57-TLS 1.3 ECDSA with brainpool-client
 
-[53-TLS 1.3 ECDSA with brainpool-server]
+[57-TLS 1.3 ECDSA with brainpool-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-cert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-key.pem
 
-[53-TLS 1.3 ECDSA with brainpool-client]
+[57-TLS 1.3 ECDSA with brainpool-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
@@ -1757,45 +1897,45 @@ RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-53]
+[test-57]
 ExpectedResult = Success
 
 
 # ===========================================================
 
-[54-TLS 1.3 SM2]
-ssl_conf = 54-TLS 1.3 SM2-ssl
+[58-TLS 1.3 SM2]
+ssl_conf = 58-TLS 1.3 SM2-ssl
 
-[54-TLS 1.3 SM2-ssl]
-server = 54-TLS 1.3 SM2-server
-client = 54-TLS 1.3 SM2-client
+[58-TLS 1.3 SM2-ssl]
+server = 58-TLS 1.3 SM2-server
+client = 58-TLS 1.3 SM2-client
 
-[54-TLS 1.3 SM2-server]
+[58-TLS 1.3 SM2-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/sm2.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2.key
 
-[54-TLS 1.3 SM2-client]
+[58-TLS 1.3 SM2-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-root.crt
 VerifyMode = Peer
 
-[test-54]
+[test-58]
 ExpectedResult = Success
 
 
 # ===========================================================
 
-[55-TLS 1.2 DSA Certificate Test]
-ssl_conf = 55-TLS 1.2 DSA Certificate Test-ssl
+[59-TLS 1.2 DSA Certificate Test]
+ssl_conf = 59-TLS 1.2 DSA Certificate Test-ssl
 
-[55-TLS 1.2 DSA Certificate Test-ssl]
-server = 55-TLS 1.2 DSA Certificate Test-server
-client = 55-TLS 1.2 DSA Certificate Test-client
+[59-TLS 1.2 DSA Certificate Test-ssl]
+server = 59-TLS 1.2 DSA Certificate Test-server
+client = 59-TLS 1.2 DSA Certificate Test-client
 
-[55-TLS 1.2 DSA Certificate Test-server]
+[59-TLS 1.2 DSA Certificate Test-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = ALL
 DHParameters = ${ENV::TEST_CERTS_DIR}/dhp2048.pem
@@ -1805,52 +1945,52 @@ MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[55-TLS 1.2 DSA Certificate Test-client]
+[59-TLS 1.2 DSA Certificate Test-client]
 CipherString = ALL
-SignatureAlgorithms = DSA+SHA256:DSa+SHA1
+SignatureAlgorithms = dsA+SHA256:dSA+SHA1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-55]
+[test-59]
 ExpectedResult = Success
 
 
 # ===========================================================
 
-[56-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms]
-ssl_conf = 56-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-ssl
+[60-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms]
+ssl_conf = 60-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-ssl
 
-[56-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-ssl]
-server = 56-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-server
-client = 56-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-client
+[60-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-ssl]
+server = 60-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-server
+client = 60-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-client
 
-[56-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-server]
+[60-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-ClientSignatureAlgorithms = ecDSA+SHA1:DsA+SHA256:rsA+SHA256
+ClientSignatureAlgorithms = ECDsa+SHA1:Dsa+SHA256:RSa+SHA256
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Request
 
-[56-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-client]
+[60-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-56]
+[test-60]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[57-TLS 1.3 DSA Certificate Test]
-ssl_conf = 57-TLS 1.3 DSA Certificate Test-ssl
+[61-TLS 1.3 DSA Certificate Test]
+ssl_conf = 61-TLS 1.3 DSA Certificate Test-ssl
 
-[57-TLS 1.3 DSA Certificate Test-ssl]
-server = 57-TLS 1.3 DSA Certificate Test-server
-client = 57-TLS 1.3 DSA Certificate Test-client
+[61-TLS 1.3 DSA Certificate Test-ssl]
+server = 61-TLS 1.3 DSA Certificate Test-server
+client = 61-TLS 1.3 DSA Certificate Test-client
 
-[57-TLS 1.3 DSA Certificate Test-server]
+[61-TLS 1.3 DSA Certificate Test-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = ALL
 DSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-dsa-cert.pem
@@ -1859,42 +1999,42 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[57-TLS 1.3 DSA Certificate Test-client]
+[61-TLS 1.3 DSA Certificate Test-client]
 CipherString = ALL
-SignatureAlgorithms = dSA+SHA1:DSA+SHA256:ecDsa+SHA256
+SignatureAlgorithms = DsA+SHA1:Dsa+SHA256:ECdsa+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-57]
+[test-61]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[58-TLS 1.3 ML-DSA Certificate Test]
-ssl_conf = 58-TLS 1.3 ML-DSA Certificate Test-ssl
+[62-TLS 1.3 ML-DSA Certificate Test]
+ssl_conf = 62-TLS 1.3 ML-DSA Certificate Test-ssl
 
-[58-TLS 1.3 ML-DSA Certificate Test-ssl]
-server = 58-TLS 1.3 ML-DSA Certificate Test-server
-client = 58-TLS 1.3 ML-DSA Certificate Test-client
+[62-TLS 1.3 ML-DSA Certificate Test-ssl]
+server = 62-TLS 1.3 ML-DSA Certificate Test-server
+client = 62-TLS 1.3 ML-DSA Certificate Test-client
 
-[58-TLS 1.3 ML-DSA Certificate Test-server]
+[62-TLS 1.3 ML-DSA Certificate Test-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-ml-dsa-44-cert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ml-dsa-44-key.pem
-SignatureAlgorithms = mlDsA44
+SignatureAlgorithms = MLdsA44
 
-[58-TLS 1.3 ML-DSA Certificate Test-client]
+[62-TLS 1.3 ML-DSA Certificate Test-client]
 CipherString = DEFAULT
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
-SignatureAlgorithms = mlDSa44
+SignatureAlgorithms = MlDSa44
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-ml-dsa-44-cert.pem
 VerifyMode = Peer
 
-[test-58]
+[test-62]
 ExpectedResult = Success
 
 

--- a/test/ssl-tests/20-cert-select.cnf.in
+++ b/test/ssl-tests/20-cert-select.cnf.in
@@ -380,6 +380,79 @@ our @tests = (
             "ExpectedResult" => "Success"
         },
     },
+    {
+        name => "DTLS 1.2 Ed25519 CipherString and Signature Algorithm Selection",
+        server => $server,
+        client => {
+            "CipherString" => "aECDSA",
+            "MinProtocol" => "DTLSv1.2",
+            "MaxProtocol" => "DTLSv1.2",
+            "SignatureAlgorithms" => randcase("ed25519:ECDSA+SHA256"),
+            "RequestCAFile" => test_pem("root-cert.pem"),
+        },
+        test   => {
+            "ExpectedServerCertType" =>, "Ed25519",
+            "ExpectedServerSignType" =>, "Ed25519",
+            # Note: certificate_authorities not sent for DTLS < 1.3
+            "ExpectedServerCANames" =>, "empty",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
+        name => "DTLS 1.2 Ed448 CipherString and Signature Algorithm Selection",
+        server => $server,
+        client => {
+            "CipherString" => "aECDSA",
+            "MinProtocol" => "DTLSv1.2",
+            "MaxProtocol" => "DTLSv1.2",
+            "SignatureAlgorithms" => randcase("ed448:ECDSA+SHA256"),
+            "RequestCAFile" => test_pem("root-ed448-cert.pem"),
+            "VerifyCAFile" => test_pem("root-ed448-cert.pem"),
+        },
+        test   => {
+            "ExpectedServerCertType" =>, "Ed448",
+            "ExpectedServerSignType" =>, "Ed448",
+            # Note: certificate_authorities not sent for DTLS < 1.3
+            "ExpectedServerCANames" =>, "empty",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
+        name => "DTLS 1.2 Ed25519 Client Auth",
+        server => {
+            "VerifyCAFile" => test_pem("root-cert.pem"),
+            "VerifyMode" => "Require"
+        },
+        client => {
+            "Ed25519.Certificate" => test_pem("client-ed25519-cert.pem"),
+            "Ed25519.PrivateKey" => test_pem("client-ed25519-key.pem"),
+            "MinProtocol" => "DTLSv1.2",
+            "MaxProtocol" => "DTLSv1.2"
+        },
+        test   => {
+            "ExpectedClientCertType" => "Ed25519",
+            "ExpectedClientSignType" => "Ed25519",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
+        name => "DTLS 1.2 Ed448 Client Auth",
+        server => {
+            "VerifyCAFile" => test_pem("root-cert.pem"),
+            "VerifyMode" => "Require"
+        },
+        client => {
+            "Ed448.Certificate" => test_pem("client-ed448-cert.pem"),
+            "Ed448.PrivateKey" => test_pem("client-ed448-key.pem"),
+            "MinProtocol" => "DTLSv1.2",
+            "MaxProtocol" => "DTLSv1.2"
+        },
+        test   => {
+            "ExpectedClientCertType" => "Ed448",
+            "ExpectedClientSignType" => "Ed448",
+            "ExpectedResult" => "Success"
+        },
+    },
 );
 
 my @tests_non_fips = (


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

## Add Ed25519 Cert. Support for DTLS 1.2

Closes https://github.com/openssl/openssl/issues/20122

### Building:

```
./Configure
make
```

### Generating Tests:

```
SRCTOP=. BLDTOP=. PERL5LIB=./util/perl:./test:./test/ssl-tests perl test/generate_ssl_tests.pl test/ssl-tests/20-cert-select.cnf.in > test/ssl-tests/20-cert-select.cnf
```

### Running Tests:

```
08:58 $ make test TESTS='test_ssl_new'
"/Applications/Xcode.app/Contents/Developer/usr/bin/make" depend && "/Applications/Xcode.app/Contents/Developer/usr/bin/make" _tests
"/Applications/Xcode.app/Contents/Developer/usr/bin/make" run_tests
( SRCTOP=. \
	  BLDTOP=. \
	  PERL="perl" \
	  FIPSKEY="f4556650ac31d35461610bac4ed81b1a181b2d8a43ea2854cbae22ca74560813" \
	  EXE_EXT= \
	  perl ./test/run_tests.pl test_ssl_new )
Using HARNESS_JOBS=8

[09:03:25] 00-prep_fipsmodule_cnf.t .. skipped: FIPS module config file only supported in a fips build
[09:03:25]
Files=1, Tests=0,  0 wallclock secs ( 0.01 usr  0.01 sys +  0.08 cusr  0.01 csys =  0.11 CPU)
Result: NOTESTS
[09:03:26] 80-test_ssl_new.t .. ok    11518 ms ( 0.09 usr  0.01 sys +  8.75 cusr  1.80 csys = 10.65 CPU)
[09:03:37]
All tests successful.
Files=1, Tests=31, 12 wallclock secs ( 0.09 usr  0.01 sys +  8.75 cusr  1.80 csys = 10.65 CPU)
Result: PASS
```

### Manual Testing:

Server:

<details>

```
✔ ~/go/src/github.com/adrianosela/openssl [ed25519_cert_support_for_dtls12|…11]
09:26 $ DYLD_LIBRARY_PATH=. ./apps/openssl s_server -dtls1_2 -accept 127.0.0.1:5684 -cert test-certs/serverEdDsa.pem -CAfile test-certs/caEdDsaTrustStore.pem -Verify 5
verify depth is 5, must return a certificate
Using default temp DH parameters
ACCEPT
depth=1 CN=Test CA EdDSA
verify return:1
depth=0 CN=Test Client
verify return:1
-----BEGIN SSL SESSION PARAMETERS-----
MIIBmQIBAQIDAP79BALALAQABDCZjglFLKNigjlTQ4Dx6H6YXY6oYPjh2UXv47Ev
jQKE+eZ1yGd+saCEUaXF1YAt3sqhBgIEaY9e66IEAgIcIKOCATUwggExMIHkoAMC
AQICFCKMWAMqhI47slwRZb0z23ALPytEMAUGAytlcDAYMRYwFAYDVQQDDA1UZXN0
IENBIEVkRFNBMB4XDTI2MDIxMzE3MDg0M1oXDTI3MDIxMzE3MDg0M1owFjEUMBIG
A1UEAwwLVGVzdCBDbGllbnQwKjAFBgMrZXADIQBGApubpLJduTa6uU4yD6EdlIfm
7mvkyql1O/cG5ealhKNCMEAwHQYDVR0OBBYEFFFLXJHtZQzx8PF8DN/QUXoyUZXf
MB8GA1UdIwQYMBaAFMDefqS+45q2Uu+aD5kxFhy22nxEMAUGAytlcANBADuthHIC
ifJbyUx7RWDkrsZwaef9UEtWZq+B+dHnO7+RTFPLgMS1lXAIRBwJeCu2Ao6yJpcl
7U20ya9GWA9Q0QukBgQEAQAAAK0DAgEBswMCAR0=
-----END SSL SESSION PARAMETERS-----
Client certificate
-----BEGIN CERTIFICATE-----
MIIBMTCB5KADAgECAhQijFgDKoSOO7JcEWW9M9twCz8rRDAFBgMrZXAwGDEWMBQG
A1UEAwwNVGVzdCBDQSBFZERTQTAeFw0yNjAyMTMxNzA4NDNaFw0yNzAyMTMxNzA4
NDNaMBYxFDASBgNVBAMMC1Rlc3QgQ2xpZW50MCowBQYDK2VwAyEARgKbm6SyXbk2
urlOMg+hHZSH5u5r5MqpdTv3BuXmpYSjQjBAMB0GA1UdDgQWBBRRS1yR7WUM8fDx
fAzf0FF6MlGV3zAfBgNVHSMEGDAWgBTA3n6kvuOatlLvmg+ZMRYcttp8RDAFBgMr
ZXADQQA7rYRyAonyW8lMe0Vg5K7GcGnn/VBLVmavgfnR5zu/kUxTy4DEtZVwCEQc
CXgrtgKOsiaXJe1NtMmvRlgPUNEL
-----END CERTIFICATE-----
subject=CN=Test Client
issuer=CN=Test CA EdDSA
Shared ciphers:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:DHE-RSA-AES256-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA
Signature Algorithms: ECDSA+SHA256:ECDSA+SHA384:ECDSA+SHA512:ed25519:ed448:rsa_pss_pss_sha256:rsa_pss_pss_sha384:rsa_pss_pss_sha512:RSA-PSS+SHA256:RSA-PSS+SHA384:RSA-PSS+SHA512:RSA+SHA256:RSA+SHA384:RSA+SHA512:ECDSA+SHA224:RSA+SHA224:DSA+SHA224:DSA+SHA256:DSA+SHA384:DSA+SHA512
Shared Signature Algorithms: ECDSA+SHA256:ECDSA+SHA384:ECDSA+SHA512:ed25519:ed448:rsa_pss_pss_sha256:rsa_pss_pss_sha384:rsa_pss_pss_sha512:RSA-PSS+SHA256:RSA-PSS+SHA384:RSA-PSS+SHA512:RSA+SHA256:RSA+SHA384:RSA+SHA512:ECDSA+SHA224:RSA+SHA224:DSA+SHA224:DSA+SHA256:DSA+SHA384:DSA+SHA512
Peer signature type: ed25519
Supported Elliptic Curve Point Formats: uncompressed
Supported groups: x25519:secp256r1:x448:secp384r1:secp521r1
Shared groups: x25519:secp256r1:x448:secp384r1:secp521r1
CIPHER is ECDHE-ECDSA-AES256-GCM-SHA384
Secure Renegotiation IS supported
```
</details>

Client


<details>

```
✔ ~/go/src/github.com/adrianosela/openssl [ed25519_cert_support_for_dtls12|…11]
09:26 $ DYLD_LIBRARY_PATH=. ./apps/openssl s_client -dtls1_2 -connect 127.0.0.1:5684 -cert test-certs/clientEdDsa.pem -CAfile test-certs/caEdDsaTrustStore.pem
Connecting to 127.0.0.1
CONNECTED(00000003)
Can't use SSL_get_servername
depth=1 CN=Test CA EdDSA
verify return:1
depth=0 CN=localhost
verify return:1
---
Certificate chain
 0 s:CN=localhost
   i:CN=Test CA EdDSA
   a:PKEY: ED25519, 256 (bit); sigalg: ED25519
   v:NotBefore: Feb 13 17:08:27 2026 GMT; NotAfter: Feb 13 17:08:27 2027 GMT
 1 s:CN=Test CA EdDSA
   i:CN=Test CA EdDSA
   a:PKEY: ED25519, 256 (bit); sigalg: ED25519
   v:NotBefore: Feb 13 17:08:18 2026 GMT; NotAfter: Feb 13 17:08:18 2027 GMT
---
Server certificate
-----BEGIN CERTIFICATE-----
MIIBLzCB4qADAgECAhQijFgDKoSOO7JcEWW9M9twCz8rQzAFBgMrZXAwGDEWMBQG
A1UEAwwNVGVzdCBDQSBFZERTQTAeFw0yNjAyMTMxNzA4MjdaFw0yNzAyMTMxNzA4
MjdaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDAqMAUGAytlcAMhAHew3mIsZXtC3uGg
worQiONJmU/gPTKF+K6KLFmN0q6Co0IwQDAdBgNVHQ4EFgQUylZRg8PtJXqRewtW
d7bOg3rwL2YwHwYDVR0jBBgwFoAUwN5+pL7jmrZS75oPmTEWHLbafEQwBQYDK2Vw
A0EAvmo3j2xWarhlqDEAhfZ+KfVRyLpV6FJx1FHbrWM8x1sjzPfhCiBJBNVW8FLk
zv2O1VFpOqW3eEK/wlZiR52aBQ==
-----END CERTIFICATE-----
subject=CN=localhost
issuer=CN=Test CA EdDSA
---
Acceptable client certificate CA names
CN=Test CA EdDSA
Client Certificate Types: RSA sign, DSA sign, ECDSA sign
Requested Signature Algorithms: ECDSA+SHA256:ECDSA+SHA384:ECDSA+SHA512:ed25519:ed448:rsa_pss_pss_sha256:rsa_pss_pss_sha384:rsa_pss_pss_sha512:RSA-PSS+SHA256:RSA-PSS+SHA384:RSA-PSS+SHA512:RSA+SHA256:RSA+SHA384:RSA+SHA512:ECDSA+SHA224:RSA+SHA224:DSA+SHA224:DSA+SHA256:DSA+SHA384:DSA+SHA512
Shared Requested Signature Algorithms: ECDSA+SHA256:ECDSA+SHA384:ECDSA+SHA512:ed25519:ed448:rsa_pss_pss_sha256:rsa_pss_pss_sha384:rsa_pss_pss_sha512:RSA-PSS+SHA256:RSA-PSS+SHA384:RSA-PSS+SHA512:RSA+SHA256:RSA+SHA384:RSA+SHA512:ECDSA+SHA224:RSA+SHA224:DSA+SHA224:DSA+SHA256:DSA+SHA384:DSA+SHA512
Peer signature type: ed25519
Peer Temp Key: X25519, 253 bits
---
SSL handshake has read 1792 bytes and written 1404 bytes
Verification: OK
---
New, TLSv1.2, Cipher is ECDHE-ECDSA-AES256-GCM-SHA384
Protocol: DTLSv1.2
Server public key is 256 bit
Secure Renegotiation IS supported
Compression: NONE
Expansion: NONE
No ALPN negotiated
SSL-Session:
    Protocol  : DTLSv1.2
    Cipher    : ECDHE-ECDSA-AES256-GCM-SHA384
    Session-ID: 48743A5C73EE62513FD395C3E894A2B358D8F326975F3312BE1F0EB21E1CAAB7
    Session-ID-ctx:
    Master-Key: 998E09452CA3628239534380F1E87E985D8EA860F8E1D945EFE3B12F8D0284F9E675C8677EB1A08451A5C5D5802DDECA
    PSK identity: None
    PSK identity hint: None
    SRP username: None
    TLS session ticket lifetime hint: 7200 (seconds)
    TLS session ticket:
    0000 - 26 87 fe 0d 5d 9f fe fa-2e 28 33 c5 e2 6d 5d ed   &...]....(3..m].
    0010 - ae 44 e1 73 84 c4 4d 96-d9 2e a1 8f c5 e3 a4 ac   .D.s..M.........
    0020 - 3a 6e cd c0 09 9f b2 76-a6 91 d4 e1 24 02 60 9e   :n.....v....$.`.
    0030 - 1e e3 ef c3 a4 e5 d7 e6-96 fd e2 1e 58 25 92 ff   ............X%..
    0040 - 5a 44 c2 0d 03 34 5f 35-b4 f8 8d ea 07 6a 1f 82   ZD...4_5.....j..
    0050 - 5c fc 51 58 a4 53 b4 fe-1e 10 01 a8 9c 2b 02 7b   \.QX.S.......+.{
    0060 - 47 44 9d 35 11 0b 5a 06-82 9b b3 fd 3f 8d 10 33   GD.5..Z.....?..3
    0070 - 64 06 a1 13 6f 2f 39 02-c8 92 aa 69 60 96 e0 c0   d...o/9....i`...
    0080 - f4 f3 e3 67 05 47 43 43-a1 b9 fd 73 72 33 e0 fa   ...g.GCC...sr3..
    0090 - 82 4c 31 b1 dd 9f 6f 3d-1e ad 7d 9f 3f ff 53 fa   .L1...o=..}.?.S.
    00a0 - 9c 94 d9 8b ba cc 0c 9d-a9 49 55 b7 62 9b 85 e9   .........IU.b...
    00b0 - 25 46 71 19 b9 e7 b0 66-08 3e 92 c3 39 5e 17 d5   %Fq....f.>..9^..
    00c0 - b0 60 37 e9 81 ca 1b fd-b5 5a 1f 14 99 21 5c db   .`7......Z...!\.
    00d0 - 73 98 99 cd 4c 3e 59 8e-c5 73 2e 62 51 fa 83 cb   s...L>Y..s.bQ...
    00e0 - 0c d6 14 a8 9a 07 ca fb-f0 b4 c8 95 e4 ae 17 2e   ................
    00f0 - bd bc eb 16 75 2d 19 96-b0 93 ec 4a a5 e9 12 75   ....u-.....J...u
    0100 - a8 f4 23 39 ea ad 48 75-15 70 0f 96 d3 8b 09 04   ..#9..Hu.p......
    0110 - d3 bb 1a 8b 25 d3 46 44-92 a9 b1 26 cc a7 10 90   ....%.FD...&....
    0120 - 5f e9 35 d9 72 c6 e7 85-b5 bb 71 49 0a 21 20 de   _.5.r.....qI.! .
    0130 - a6 45 04 f4 3c 76 13 70-d5 28 13 64 25 f8 f7 7d   .E..<v.p.(.d%..}
    0140 - f6 79 23 84 fa ab 62 53-32 38 6a 82 42 bb 86 fc   .y#...bS28j.B...
    0150 - 7e 71 2a 7c 91 ce f0 d4-c8 54 de 6f f9 53 76 73   ~q*|.....T.o.Svs
    0160 - 79 be c3 d3 47 d6 f3 eb-f8 f1 bf 3c 66 72 14 f3   y...G......<fr..
    0170 - 20 06 e3 aa 3b 85 d9 f4-01 72 03 c6 52 2e b7 24    ...;....r..R..$
    0180 - 42 14 6a c6 89 73 a8 9e-80 53 8a 11 80 46 3f 43   B.j..s...S...F?C
    0190 - 11 90 26 59 74 10 58 6f-90 29 0d ef 00 76 87 cb   ..&Yt.Xo.)...v..
    01a0 - 7e d4 ee be bf a1 97 90-7e b8 75 e1 ca 31 13 1a   ~.......~.u..1..
    01b0 - df 73 b1 d1 ef 4b f4 6d-62 b7 9a 1e e0 cf a5 c2   .s...K.mb.......
    01c0 - bd 83 cc 70 96 ba ca 6a-49 06 ec 65 6e 5c 29 27   ...p...jI..en\)'
    01d0 - 89 05 12 46 db 94 79 b7-0c 64 f4 a2 ed 95 91 5f   ...F..y..d....._

    Start Time: 1771003627
    Timeout   : 7200 (sec)
    Verify return code: 0 (ok)
    Extended master secret: yes
---
```

</details>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated