### PR TITLE
Add small note in Build notes specific to Android platform on 16 KB ELF Alignment

### DIFF
--- a/NOTES-ANDROID.md
+++ b/NOTES-ANDROID.md
@@ -42,8 +42,8 @@ Notes for Android platforms
     ./Configure android-arm64 -D__ANDROID_API__=29
     make
 
- **Note**: 64-bit devices running Android 15 (API Level 35) and above may require native libraries with a 16 KB page file size. OpenSSL libraries with a 16 KB page file size are built by default on version 3.6.0 and above. For prior versions of OpenSSL, you can pass the arguments `-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON` and `-Wl,-z,max-page-size=16384` to `Configure` while building OpenSSL for 64-bit devices. 
- 
+ **Note**: 64-bit devices running Android 15 (API Level 35) and above may require native libraries with a 16 KB page file size. OpenSSL libraries with a 16 KB page file size are built by default on version 3.6.0 and above. For prior versions of OpenSSL, you can pass the arguments `-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON` and `-Wl,-z,max-page-size=16384` to `Configure` while building OpenSSL for 64-bit devices.
+
  Older versions of the NDK have GCC under their common prebuilt tools
  directory, so the bin path will be slightly different. EG: to compile
  for ICS on ARM with NDK 10d:

--- a/NOTES-ANDROID.md
+++ b/NOTES-ANDROID.md
@@ -42,6 +42,8 @@ Notes for Android platforms
     ./Configure android-arm64 -D__ANDROID_API__=29
     make
 
+ **Note**: 64-bit devices running Android 15 (API Level 35) and above may require native libraries with a 16 KB page file size. OpenSSL libraries with a 16 KB page file size are built by default on version 3.6.0 and above. For prior versions of OpenSSL, you can pass the `-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON` and `-Wl,-z,max-page-size=16384` flags to `Configure` while building OpenSSL for 64-bit devices. 
+ 
  Older versions of the NDK have GCC under their common prebuilt tools
  directory, so the bin path will be slightly different. EG: to compile
  for ICS on ARM with NDK 10d:

--- a/NOTES-ANDROID.md
+++ b/NOTES-ANDROID.md
@@ -42,7 +42,7 @@ Notes for Android platforms
     ./Configure android-arm64 -D__ANDROID_API__=29
     make
 
- **Note**: 64-bit devices running Android 15 (API Level 35) and above may require native libraries with a 16 KB page file size. OpenSSL libraries with a 16 KB page file size are built by default on version 3.6.0 and above. For prior versions of OpenSSL, you can pass the `-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON` and `-Wl,-z,max-page-size=16384` flags to `Configure` while building OpenSSL for 64-bit devices. 
+ **Note**: 64-bit devices running Android 15 (API Level 35) and above may require native libraries with a 16 KB page file size. OpenSSL libraries with a 16 KB page file size are built by default on version 3.6.0 and above. For prior versions of OpenSSL, you can pass the arguments `-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON` and `-Wl,-z,max-page-size=16384` to `Configure` while building OpenSSL for 64-bit devices. 
  
  Older versions of the NDK have GCC under their common prebuilt tools
  directory, so the bin path will be slightly different. EG: to compile

--- a/NOTES-ANDROID.md
+++ b/NOTES-ANDROID.md
@@ -42,7 +42,11 @@ Notes for Android platforms
     ./Configure android-arm64 -D__ANDROID_API__=29
     make
 
- **Note**: 64-bit devices running Android 15 (API Level 35) and above may require native libraries with a 16 KB page file size. OpenSSL libraries with a 16 KB page file size are built by default on version 3.6.0 and above. For prior versions of OpenSSL, you can pass the argument `-Wl,-z,max-page-size=16384` to `Configure` while building OpenSSL for 64-bit devices.
+**Note**: 64-bit devices running Android 15 (API Level 35) and above may require
+native libraries with a 16 KB page file size. OpenSSL libraries with a 16 KB
+page file size are built by default on version 3.6.0 and above. For prior
+versions of OpenSSL, you can pass the argument -Wl,-z,max-page-size=16384 to
+Configure while building OpenSSL for 64-bit devices.
 
  Older versions of the NDK have GCC under their common prebuilt tools
  directory, so the bin path will be slightly different. EG: to compile

--- a/NOTES-ANDROID.md
+++ b/NOTES-ANDROID.md
@@ -43,8 +43,8 @@ Notes for Android platforms
     make
 
 **Note**: 64-bit devices running Android 15 (API Level 35) and above may require
-native libraries with a 16 KB page file size. OpenSSL libraries with a 16 KB
-page file size are built by default on version 3.6.0 and above. For prior
+native libraries with a 16 KB page size. OpenSSL libraries with a 16 KB
+page size are built by default on version 3.6.0 and above. For prior
 versions of OpenSSL, you can pass the argument `-Wl,-z,max-page-size=16384`
 to Configure while building OpenSSL for 64-bit devices.
 

--- a/NOTES-ANDROID.md
+++ b/NOTES-ANDROID.md
@@ -45,8 +45,8 @@ Notes for Android platforms
 **Note**: 64-bit devices running Android 15 (API Level 35) and above may require
 native libraries with a 16 KB page file size. OpenSSL libraries with a 16 KB
 page file size are built by default on version 3.6.0 and above. For prior
-versions of OpenSSL, you can pass the argument -Wl,-z,max-page-size=16384 to
-Configure while building OpenSSL for 64-bit devices.
+versions of OpenSSL, you can pass the argument `-Wl,-z,max-page-size=16384` 
+to Configure while building OpenSSL for 64-bit devices.
 
  Older versions of the NDK have GCC under their common prebuilt tools
  directory, so the bin path will be slightly different. EG: to compile

--- a/NOTES-ANDROID.md
+++ b/NOTES-ANDROID.md
@@ -45,7 +45,7 @@ Notes for Android platforms
 **Note**: 64-bit devices running Android 15 (API Level 35) and above may require
 native libraries with a 16 KB page file size. OpenSSL libraries with a 16 KB
 page file size are built by default on version 3.6.0 and above. For prior
-versions of OpenSSL, you can pass the argument `-Wl,-z,max-page-size=16384` 
+versions of OpenSSL, you can pass the argument `-Wl,-z,max-page-size=16384`
 to Configure while building OpenSSL for 64-bit devices.
 
  Older versions of the NDK have GCC under their common prebuilt tools

--- a/NOTES-ANDROID.md
+++ b/NOTES-ANDROID.md
@@ -42,7 +42,7 @@ Notes for Android platforms
     ./Configure android-arm64 -D__ANDROID_API__=29
     make
 
- **Note**: 64-bit devices running Android 15 (API Level 35) and above may require native libraries with a 16 KB page file size. OpenSSL libraries with a 16 KB page file size are built by default on version 3.6.0 and above. For prior versions of OpenSSL, you can pass the arguments `-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON` and `-Wl,-z,max-page-size=16384` to `Configure` while building OpenSSL for 64-bit devices.
+ **Note**: 64-bit devices running Android 15 (API Level 35) and above may require native libraries with a 16 KB page file size. OpenSSL libraries with a 16 KB page file size are built by default on version 3.6.0 and above. For prior versions of OpenSSL, you can pass the argument `-Wl,-z,max-page-size=16384` to `Configure` while building OpenSSL for 64-bit devices.
 
  Older versions of the NDK have GCC under their common prebuilt tools
  directory, so the bin path will be slightly different. EG: to compile


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist

##### Description of this PR
After #28277, when OpenSSL version's `>=3.6.0` are built for Android, the 16 KB alignment requirement is taken care of automatically by `Configure`. However, this is not the case with prior versions (including the present LTS version). This PR adds a small note in `NOTES_ANDROID.md` to help Android devs not familiar with the build system to help them build OpenSSL libraries of prior versions which comply with the above requirement.