### PR TITLE
Fix heap buffer overflow in SRTPKDF

### DIFF
--- a/providers/implementations/kdfs/srtpkdf.c
+++ b/providers/implementations/kdfs/srtpkdf.c
@@ -252,10 +252,9 @@ static int kdf_srtpkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
             return 0;
     }
 
-    if (p.index != NULL) {
-        if (!srtpkdf_set_membuf(&ctx->index, &ctx->index_len, p.index))
-            return 0;
-    }
+    if ((p.index != NULL)
+        && !srtpkdf_set_membuf(&ctx->index, &ctx->index_len, p.index))
+        return 0;
 
     if (p.kdr != NULL) {
         if (!OSSL_PARAM_get_uint32(p.kdr, &ctx->kdr))


### PR DESCRIPTION
OSS-FUZZ caught a heap buffer overflow:
https://oss-fuzz.com/testcase-detail/6120637956685824

It occurs because, the srtpkdf derivation function requires that, if an index and label are provided, that a specific index length be available dependent on the label set.  However, the set_ctx_params function that precedes the derivation never checks for those preconditions, leading to the derivation function accessing the index array beyond the bounds set if the array is shorter than expected.

Fix it by adding a check to kdf_srtpkdf_set_ctx_params, specifically Check that if both the label and index are set, ensure that the length of the index array is exactly the expected amount of data (4 bytes for labels 3, 4, and 5 and 6 bytes for all other labels).

NOTE: We could relax this check somewhat, and just require those minimal lengths, and allow more, but since the derivation function only uses those exact lengths, it seems prudent to do an exact check.

Fixes openssl/project#1870


##### Checklist
- [x] tests are added or updated
