### PR TITLE
Mostly deprecated is slightly not deprecated....

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -195,6 +195,12 @@ OpenSSL 4.0
 
    *Daniel Kubec*
 
+ * Rather than being documented as "should be considered deprecated",
+   X509_NAME_get_text_by_NID, and X509_NAME_get_text_by_OBJ are now
+   actually deprecated, and documented as such.
+
+   * Bob Beck *
+
  * ENGINE support was removed. The `no-engine` build option and the
    `OPENSSL_NO_ENGINE` macro is always present.
    Applications using `ENGINE_` functions unguarded with `OPENSSL_NO_ENGINE`

--- a/crypto/x509/x509name.c
+++ b/crypto/x509/x509name.c
@@ -6,6 +6,7 @@
  * in the file LICENSE in the source distribution or at
  * https://www.openssl.org/source/license.html
  */
+#include "internal/deprecated.h"
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
@@ -16,6 +17,8 @@
 #include <openssl/x509.h>
 #include "crypto/x509.h"
 
+OSSL_BEGIN_ALLOW_DEPRECATED
+#if !defined(OPENSSL_NO_DEPRECATED_4_0)
 int X509_NAME_get_text_by_NID(const X509_NAME *name, int nid,
     char *buf, int len)
 {
@@ -46,6 +49,8 @@ int X509_NAME_get_text_by_OBJ(const X509_NAME *name, const ASN1_OBJECT *obj,
     buf[i] = '\0';
     return i;
 }
+#endif /* !defined(OPENSSL_NO_DEPRECATED_4_0) */
+OSSL_END_ALLOW_DEPRECATED
 
 int X509_NAME_entry_count(const X509_NAME *name)
 {

--- a/doc/man3/X509_NAME_get_index_by_NID.pod
+++ b/doc/man3/X509_NAME_get_index_by_NID.pod
@@ -17,6 +17,8 @@ X509_NAME lookup and enumeration functions
  int X509_NAME_entry_count(const X509_NAME *name);
  X509_NAME_ENTRY *X509_NAME_get_entry(const X509_NAME *name, int loc);
 
+ Deprecated Functions:
+
  int X509_NAME_get_text_by_NID(const X509_NAME *name, int nid,
                                char *buf, int len);
  int X509_NAME_get_text_by_OBJ(const X509_NAME *name, const ASN1_OBJECT *obj,
@@ -51,13 +53,12 @@ of space needed in B<buf> (excluding the final null) is returned.
 
 =head1 NOTES
 
-X509_NAME_get_text_by_NID() and X509_NAME_get_text_by_OBJ() should be
-considered deprecated because they
-have various limitations which make them
-of minimal use in practice. They can only find the first matching
-entry and will copy the contents of the field verbatim: this can
-be highly confusing if the target is a multicharacter string type
-like a BMPString or a UTF8String.
+X509_NAME_get_text_by_NID() and X509_NAME_get_text_by_OBJ() have been
+deprecated since OpenSSL 4.0. They have various limitations which make
+them of minimal use in practice. They can only find the first matching
+entry and will copy the contents of the field verbatim: this can be
+highly confusing if the target is a multicharacter string type like a
+BMPString or a UTF8String.
 
 For a more general solution X509_NAME_get_index_by_NID() or
 X509_NAME_get_index_by_OBJ() should be used followed by

--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -94,6 +94,8 @@
 #define OSSL_DEPRECATED(since) extern
 #define OSSL_DEPRECATED_FOR(since, message) extern
 #define OSSL_DEPRECATED_MESSAGE(message)
+#define OSSL_BEGIN_ALLOW_DEPRECATED
+#define OSSL_END_ALLOW_DEPRECATED
 #endif
 
 /*

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -843,10 +843,12 @@ int X509_REQ_print_ex(BIO *bp, const X509_REQ *x, unsigned long nmflag, unsigned
 int X509_REQ_print(BIO *bp, const X509_REQ *req);
 
 int X509_NAME_entry_count(const X509_NAME *name);
-int X509_NAME_get_text_by_NID(const X509_NAME *name, int nid,
-    char *buf, int len);
-int X509_NAME_get_text_by_OBJ(const X509_NAME *name, const ASN1_OBJECT *obj,
-    char *buf, int len);
+#if !defined(OPENSSL_NO_DEPRECATED_4_0)
+OSSL_DEPRECATEDIN_4_0 int X509_NAME_get_text_by_NID(const X509_NAME *name,
+    int nid, char *buf, int len);
+OSSL_DEPRECATEDIN_4_0 int X509_NAME_get_text_by_OBJ(const X509_NAME *name,
+    const ASN1_OBJECT *obj, char *buf, int len);
+#endif /* !defined(OPENSSL_NO_DEPRECATED_4_0) */
 
 /*
  * NOTE: you should be passing -1, not 0 as lastpos. The functions that use

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4685,8 +4685,8 @@ X509_CRL_print                          ?	4_0_0	EXIST::FUNCTION:
 X509_REQ_print_ex                       ?	4_0_0	EXIST::FUNCTION:
 X509_REQ_print                          ?	4_0_0	EXIST::FUNCTION:
 X509_NAME_entry_count                   ?	4_0_0	EXIST::FUNCTION:
-X509_NAME_get_text_by_NID               ?	4_0_0	EXIST::FUNCTION:
-X509_NAME_get_text_by_OBJ               ?	4_0_0	EXIST::FUNCTION:
+X509_NAME_get_text_by_NID               ?	4_0_0	EXIST::FUNCTION:DEPRECATED_4_0
+X509_NAME_get_text_by_OBJ               ?	4_0_0	EXIST::FUNCTION:DEPRECATED_4_0
 X509_NAME_get_index_by_NID              ?	4_0_0	EXIST::FUNCTION:
 X509_NAME_get_index_by_OBJ              ?	4_0_0	EXIST::FUNCTION:
 X509_NAME_get_entry                     ?	4_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
X509_NAME_get_text_by_NID and  X509_NAME_get_text_by_OBJ  were already documented
as "should be considered deprecated"

![mostly deprecated](https://github.com/user-attachments/assets/4ee5eca2-af0d-46f4-b06d-074ec1598946)

Let's actually mark this as deprecated so eventually we can move to the "go through it's pockets
and look for spare change" stage.

Part of https://github.com/openssl/openssl/issues/28654 and https://github.com/openssl/openssl/issues/29117.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
