### PR TITLE
Constify more X509 arguments and return values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -217,6 +217,10 @@ OpenSSL 4.0
 
    *Daniel Kubec and Eugene Syromiatnikov*
 
+ * X509_get0_distinguishing_id now takes and returns const objects.
+
+   * Bob Beck *
+
  * Added `-hmac-env` and `-hmac-stdin` options to openssl-dgst.
 
    *Igor Ustinov*

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -1058,7 +1058,7 @@ cert_loop:
                 BIO_printf(out, "%s\n", sk_OPENSSL_STRING_value(emlst, j));
             X509_email_free(emlst);
         } else if (i == aliasout) {
-            unsigned char *alstr = X509_alias_get0(x, NULL);
+            const unsigned char *alstr = X509_alias_get0(x, NULL);
 
             if (alstr)
                 BIO_printf(out, "%s\n", alstr);

--- a/crypto/pkcs12/p12_attr.c
+++ b/crypto/pkcs12/p12_attr.c
@@ -14,7 +14,7 @@
 
 /* Add a local keyid to a safebag */
 
-int PKCS12_add_localkeyid(PKCS12_SAFEBAG *bag, unsigned char *name,
+int PKCS12_add_localkeyid(PKCS12_SAFEBAG *bag, const unsigned char *name,
     int namelen)
 {
     if (X509at_add1_attr_by_NID(&bag->attrib, NID_localKeyID,

--- a/crypto/pkcs12/p12_crt.c
+++ b/crypto/pkcs12/p12_crt.c
@@ -20,7 +20,7 @@ static PKCS12_SAFEBAG *pkcs12_add_cert_bag(STACK_OF(PKCS12_SAFEBAG) **pbags,
     X509 *cert,
     const char *name,
     int namelen,
-    unsigned char *keyid,
+    const unsigned char *keyid,
     int keyidlen);
 
 static int copy_bag_attr(PKCS12_SAFEBAG *bag, EVP_PKEY *pkey, int nid)
@@ -46,7 +46,7 @@ PKCS12 *PKCS12_create_ex2(const char *pass, const char *name, EVP_PKEY *pkey,
     unsigned char keyid[EVP_MAX_MD_SIZE];
     unsigned int keyidlen = 0;
     int namelen = -1;
-    unsigned char *pkeyid = NULL;
+    const unsigned char *pkeyid = NULL;
     int pkeyidlen = -1;
 
     /* Set defaults */
@@ -190,7 +190,7 @@ static PKCS12_SAFEBAG *pkcs12_add_cert_bag(STACK_OF(PKCS12_SAFEBAG) **pbags,
     X509 *cert,
     const char *name,
     int namelen,
-    unsigned char *keyid,
+    const unsigned char *keyid,
     int keyidlen)
 {
     PKCS12_SAFEBAG *bag = NULL;
@@ -219,7 +219,7 @@ PKCS12_SAFEBAG *PKCS12_add_cert(STACK_OF(PKCS12_SAFEBAG) **pbags, X509 *cert)
 {
     char *name = NULL;
     int namelen = -1;
-    unsigned char *keyid = NULL;
+    const unsigned char *keyid = NULL;
     int keyidlen = -1;
 
     /*

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -102,13 +102,13 @@ X509_NAME *X509_get_issuer_name(const X509 *a)
     return a->cert_info.issuer;
 }
 
-unsigned long X509_issuer_name_hash(X509 *x)
+unsigned long X509_issuer_name_hash(const X509 *x)
 {
     return X509_NAME_hash_ex(x->cert_info.issuer, NULL, NULL, NULL);
 }
 
 #ifndef OPENSSL_NO_MD5
-unsigned long X509_issuer_name_hash_old(X509 *x)
+unsigned long X509_issuer_name_hash_old(const X509 *x)
 {
     return X509_NAME_hash_old(x->cert_info.issuer);
 }
@@ -135,7 +135,7 @@ unsigned long X509_subject_name_hash(X509 *x)
 }
 
 #ifndef OPENSSL_NO_MD5
-unsigned long X509_subject_name_hash_old(X509 *x)
+unsigned long X509_subject_name_hash_old(const X509 *x)
 {
     return X509_NAME_hash_old(x->cert_info.subject);
 }

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -140,12 +140,12 @@ const ASN1_TIME *X509_get0_notAfter(const X509 *x)
     return x->cert_info.validity.notAfter;
 }
 
-ASN1_TIME *X509_getm_notBefore(const X509 *x)
+ASN1_TIME *X509_getm_notBefore(X509 *x)
 {
     return x->cert_info.validity.notBefore;
 }
 
-ASN1_TIME *X509_getm_notAfter(const X509 *x)
+ASN1_TIME *X509_getm_notAfter(X509 *x)
 {
     return x->cert_info.validity.notAfter;
 }

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -452,7 +452,7 @@ int X509_CRL_get0_by_serial(X509_CRL *crl,
     return 0;
 }
 
-int X509_CRL_get0_by_cert(X509_CRL *crl, X509_REVOKED **ret, X509 *x)
+int X509_CRL_get0_by_cert(X509_CRL *crl, X509_REVOKED **ret, const X509 *x)
 {
     if (crl->meth->crl_lookup)
         return crl->meth->crl_lookup(crl, ret,

--- a/crypto/x509/x_x509.c
+++ b/crypto/x509/x_x509.c
@@ -304,7 +304,7 @@ void X509_set0_distinguishing_id(X509 *x, ASN1_OCTET_STRING *d_id)
     x->distinguishing_id = d_id;
 }
 
-ASN1_OCTET_STRING *X509_get0_distinguishing_id(X509 *x)
+const ASN1_OCTET_STRING *X509_get0_distinguishing_id(const X509 *x)
 {
     return x->distinguishing_id;
 }

--- a/crypto/x509/x_x509a.c
+++ b/crypto/x509/x_x509a.c
@@ -82,7 +82,7 @@ int X509_keyid_set1(X509 *x, const unsigned char *id, int len)
     return ASN1_STRING_set(aux->keyid, id, len);
 }
 
-unsigned char *X509_alias_get0(const X509 *x, int *len)
+const unsigned char *X509_alias_get0(const X509 *x, int *len)
 {
     if (!x->aux || !x->aux->alias)
         return NULL;
@@ -91,7 +91,7 @@ unsigned char *X509_alias_get0(const X509 *x, int *len)
     return x->aux->alias->data;
 }
 
-unsigned char *X509_keyid_get0(const X509 *x, int *len)
+const unsigned char *X509_keyid_get0(const X509 *x, int *len)
 {
     if (!x->aux || !x->aux->keyid)
         return NULL;

--- a/doc/man3/PKCS12_add_localkeyid.pod
+++ b/doc/man3/PKCS12_add_localkeyid.pod
@@ -8,7 +8,7 @@ PKCS12_add_localkeyid - Add the localKeyId attribute to a PKCS#12 safeBag
 
  #include <openssl/pkcs12.h>
 
- int PKCS12_add_localkeyid(PKCS12_SAFEBAG *bag, const char *name,
+ int PKCS12_add_localkeyid(PKCS12_SAFEBAG *bag, const unsigned char *name,
                            int namelen);
 
 =head1 DESCRIPTION

--- a/doc/man3/X509_CRL_get0_by_serial.pod
+++ b/doc/man3/X509_CRL_get0_by_serial.pod
@@ -14,7 +14,7 @@ functions
 
  int X509_CRL_get0_by_serial(X509_CRL *crl,
                              X509_REVOKED **ret, const ASN1_INTEGER *serial);
- int X509_CRL_get0_by_cert(X509_CRL *crl, X509_REVOKED **ret, X509 *x);
+ int X509_CRL_get0_by_cert(X509_CRL *crl, X509_REVOKED **ret, const X509 *x);
 
  STACK_OF(X509_REVOKED) *X509_CRL_get_REVOKED(const X509_CRL *crl);
 

--- a/doc/man3/X509_get0_distinguishing_id.pod
+++ b/doc/man3/X509_get0_distinguishing_id.pod
@@ -10,7 +10,7 @@ X509_REQ_get0_distinguishing_id, X509_REQ_set0_distinguishing_id
 
  #include <openssl/x509.h>
 
- ASN1_OCTET_STRING *X509_get0_distinguishing_id(X509 *x);
+ const ASN1_OCTET_STRING *X509_get0_distinguishing_id(const X509 *x);
  void X509_set0_distinguishing_id(X509 *x, ASN1_OCTET_STRING *distid);
  ASN1_OCTET_STRING *X509_REQ_get0_distinguishing_id(X509_REQ *x);
  void X509_REQ_set0_distinguishing_id(X509_REQ *x, ASN1_OCTET_STRING *distid);

--- a/doc/man3/X509_get_subject_name.pod
+++ b/doc/man3/X509_get_subject_name.pod
@@ -19,7 +19,7 @@ get X509_NAME hashes or get and set issuer or subject names
 
  X509_NAME *X509_get_subject_name(const X509 *x);
  int X509_set_subject_name(X509 *x, const X509_NAME *name);
- unsigned long X509_subject_name_hash(X509 *x);
+ unsigned long X509_subject_name_hash(const X509 *x);
 
  X509_NAME *X509_get_issuer_name(const X509 *x);
  int X509_set_issuer_name(X509 *x, const X509_NAME *name);

--- a/include/openssl/pkcs12.h.in
+++ b/include/openssl/pkcs12.h.in
@@ -191,7 +191,7 @@ STACK_OF(PKCS12_SAFEBAG) *PKCS12_unpack_p7encdata(PKCS7 *p7, const char *pass,
 int PKCS12_pack_authsafes(PKCS12 *p12, STACK_OF(PKCS7) *safes);
 STACK_OF(PKCS7) *PKCS12_unpack_authsafes(const PKCS12 *p12);
 
-int PKCS12_add_localkeyid(PKCS12_SAFEBAG *bag, unsigned char *name,
+int PKCS12_add_localkeyid(PKCS12_SAFEBAG *bag, const unsigned char *name,
     int namelen);
 int PKCS12_add_friendlyname_asc(PKCS12_SAFEBAG *bag, const char *name,
     int namelen);

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -596,14 +596,14 @@ void X509_get0_signature(const ASN1_BIT_STRING **psig,
 int X509_get_signature_nid(const X509 *x);
 
 void X509_set0_distinguishing_id(X509 *x, ASN1_OCTET_STRING *d_id);
-ASN1_OCTET_STRING *X509_get0_distinguishing_id(X509 *x);
+const ASN1_OCTET_STRING *X509_get0_distinguishing_id(const X509 *x);
 void X509_REQ_set0_distinguishing_id(X509_REQ *x, ASN1_OCTET_STRING *d_id);
 ASN1_OCTET_STRING *X509_REQ_get0_distinguishing_id(X509_REQ *x);
 
 int X509_alias_set1(X509 *x, const unsigned char *name, int len);
 int X509_keyid_set1(X509 *x, const unsigned char *id, int len);
-unsigned char *X509_alias_get0(const X509 *x, int *len);
-unsigned char *X509_keyid_get0(const X509 *x, int *len);
+const unsigned char *X509_alias_get0(const X509 *x, int *len);
+const unsigned char *X509_keyid_get0(const X509 *x, int *len);
 
 DECLARE_ASN1_FUNCTIONS(X509_REVOKED)
 DECLARE_ASN1_FUNCTIONS(X509_CRL_INFO)
@@ -613,7 +613,7 @@ X509_CRL *X509_CRL_new_ex(OSSL_LIB_CTX *libctx, const char *propq);
 int X509_CRL_add0_revoked(X509_CRL *crl, X509_REVOKED *rev);
 int X509_CRL_get0_by_serial(X509_CRL *crl,
     X509_REVOKED **ret, const ASN1_INTEGER *serial);
-int X509_CRL_get0_by_cert(X509_CRL *crl, X509_REVOKED **ret, X509 *x);
+int X509_CRL_get0_by_cert(X509_CRL *crl, X509_REVOKED **ret, const X509 *x);
 
 X509_PKEY *X509_PKEY_new(void);
 void X509_PKEY_free(X509_PKEY *a);
@@ -667,10 +667,10 @@ X509_NAME *X509_get_issuer_name(const X509 *a);
 int X509_set_subject_name(X509 *x, const X509_NAME *name);
 X509_NAME *X509_get_subject_name(const X509 *a);
 const ASN1_TIME *X509_get0_notBefore(const X509 *x);
-ASN1_TIME *X509_getm_notBefore(const X509 *x);
+ASN1_TIME *X509_getm_notBefore(X509 *x);
 int X509_set1_notBefore(X509 *x, const ASN1_TIME *tm);
 const ASN1_TIME *X509_get0_notAfter(const X509 *x);
-ASN1_TIME *X509_getm_notAfter(const X509 *x);
+ASN1_TIME *X509_getm_notAfter(X509 *x);
 int X509_set1_notAfter(X509 *x, const ASN1_TIME *tm);
 int X509_up_ref(X509 *x);
 int X509_get_signature_type(const X509 *x);
@@ -792,14 +792,14 @@ int X509_issuer_and_serial_cmp(const X509 *a, const X509 *b);
 unsigned long X509_issuer_and_serial_hash(const X509 *a);
 
 int X509_issuer_name_cmp(const X509 *a, const X509 *b);
-unsigned long X509_issuer_name_hash(X509 *a);
+unsigned long X509_issuer_name_hash(const X509 *a);
 
 int X509_subject_name_cmp(const X509 *a, const X509 *b);
 unsigned long X509_subject_name_hash(X509 *x);
 
 #ifndef OPENSSL_NO_MD5
-unsigned long X509_issuer_name_hash_old(X509 *a);
-unsigned long X509_subject_name_hash_old(X509 *x);
+unsigned long X509_issuer_name_hash_old(const X509 *a);
+unsigned long X509_subject_name_hash_old(const X509 *x);
 #endif
 
 #define X509_ADD_FLAG_DEFAULT 0

--- a/test/verify_extra_test.c
+++ b/test/verify_extra_test.c
@@ -108,7 +108,8 @@ static int test_distinguishing_id(void)
 {
     X509 *x = NULL;
     int ret = 0;
-    ASN1_OCTET_STRING *v = NULL, *v2 = NULL;
+    ASN1_OCTET_STRING *v = NULL;
+    const ASN1_OCTET_STRING *v2 = NULL;
     char *distid = "this is an ID";
 
     x = load_cert_from_file(bad_f);


### PR DESCRIPTION
X509_get0_distinguishing_id
X509_keyid_get0
X509_alias_get0
X509_CRL_get0_by_cert
X509_issuer_name_hash
X509_issuer_name_hash_old
X509_subject_name_hash_old

are all const corrected

And PKCS12_add_localkeyid
as a result

X509_getm_notBefore
X509_getm_notAfter

are const "corrected" by making their argument non-const
as they deliberately return a mutable internal pointer.

Part of https://github.com/openssl/openssl/issues/28654 and https://github.com/openssl/openssl/issues/29117

For #30052 
For #30095 because github sucks.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
