### PR TITLE
limit number of iterations for fuzzer in pkcs12kdf

### DIFF
--- a/providers/implementations/kdfs/pkcs12kdf.c
+++ b/providers/implementations/kdfs/pkcs12kdf.c
@@ -267,6 +267,15 @@ static int kdf_pkcs12_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 
     if (p.iter != NULL && !OSSL_PARAM_get_uint64(p.iter, &ctx->iter))
         return 0;
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    /*
+     * If we're running the fuzzer, limit iteration count to
+     * 100 so we don't time out running the derivation for
+     * a really long time
+     */
+    if (p.iter != NULL && ctx->iter > 100)
+        ctx->iter = 100;
+#endif
     return 1;
 }
 


### PR DESCRIPTION
OSS-FUZZ tripped over a timeout:
    https://issues.oss-fuzz.com/issues/477959320
    
It occurs because the pkcs12 data the fuzzer feeds into the mac
    verification routine requests a large number of iterations (I think gdb
    read it as 15346721 or some such), which causes very long processing
    times while verifying the mac.  This is something of an artificial
    problem unique to the fuzzer, as the fuzzer contains a 60 second timeout
    on any single test iteration.
    
Fix it by limiting the iteration count to 100 only when running the
    fuzzer tests.
    
Fixes openssl/srt#89

##### Checklist
- [x] tests are added or updated
