### PR TITLE
Consity X509_add_cert and X509_self_signed

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -99,7 +99,7 @@ static int null_callback(int ok, X509_STORE_CTX *e)
  * to match issuer and subject names (i.e., the cert being self-issued) and any
  * present authority key identifier to match the subject key identifier, etc.
  */
-int X509_self_signed(X509 *cert, int verify_signature)
+int X509_self_signed(const X509 *cert, int verify_signature)
 {
     EVP_PKEY *pkey;
 
@@ -107,7 +107,7 @@ int X509_self_signed(X509 *cert, int verify_signature)
         ERR_raise(ERR_LIB_X509, X509_R_UNABLE_TO_GET_CERTS_PUBLIC_KEY);
         return -1;
     }
-    if (!ossl_x509v3_cache_extensions(cert))
+    if (!ossl_x509v3_cache_extensions((X509 *)cert))
         return -1;
     if ((cert->ex_flags & EXFLAG_SS) == 0)
         return 0;

--- a/doc/man3/X509_add_cert.pod
+++ b/doc/man3/X509_add_cert.pod
@@ -10,7 +10,7 @@ X509 certificate list addition functions
 
  #include <openssl/x509.h>
 
- int X509_add_cert(STACK_OF(X509) *sk, X509 *cert, int flags);
+ int X509_add_cert(STACK_OF(X509) *sk, const X509 *cert, int flags);
  int X509_add_certs(STACK_OF(X509) *sk, const STACK_OF(X509) *certs, int flags);
 
 =head1 DESCRIPTION
@@ -64,6 +64,8 @@ L<X509_self_signed(3)>
 
 The functions X509_add_cert() and X509_add_certs()
 were added in OpenSSL 3.0.
+
+X509_add_cert() had its cert parameter converted to be I<const> in OpenSSL 4.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/X509_verify.pod
+++ b/doc/man3/X509_verify.pod
@@ -12,7 +12,7 @@ verify certificate, certificate request, or CRL signature
  #include <openssl/x509.h>
 
  int X509_verify(X509 *x, EVP_PKEY *pkey);
- int X509_self_signed(X509 *cert, int verify_signature);
+ int X509_self_signed(const X509 *cert, int verify_signature);
 
  int X509_REQ_verify_ex(X509_REQ *a, EVP_PKEY *pkey, OSSL_LIB_CTX *libctx,
                         const char *propq);
@@ -76,6 +76,8 @@ functions are available in all versions of OpenSSL.
 X509_REQ_verify_ex(), and X509_self_signed() were added in OpenSSL 3.0.
 
 X509_ACERT_verify() was added in OpenSSL 3.4.
+
+X509_self_signed() had its cert parameter modified to be I<const> in OpenSSL 4.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -328,7 +328,7 @@ void *X509_CRL_get_meth_data(X509_CRL *crl);
 const char *X509_verify_cert_error_string(long n);
 
 int X509_verify(const X509 *a, EVP_PKEY *r);
-int X509_self_signed(X509 *cert, int verify_signature);
+int X509_self_signed(const X509 *cert, int verify_signature);
 
 int X509_REQ_verify_ex(X509_REQ *a, EVP_PKEY *r, OSSL_LIB_CTX *libctx,
     const char *propq);
@@ -807,7 +807,7 @@ unsigned long X509_subject_name_hash_old(X509 *x);
 #define X509_ADD_FLAG_PREPEND 0x2
 #define X509_ADD_FLAG_NO_DUP 0x4
 #define X509_ADD_FLAG_NO_SS 0x8
-int X509_add_cert(STACK_OF(X509) *sk, X509 *cert, int flags);
+int X509_add_cert(STACK_OF(X509) *sk, const X509 *cert, int flags);
 int X509_add_certs(STACK_OF(X509) *sk, const STACK_OF(X509) *certs, int flags);
 
 int X509_cmp(const X509 *a, const X509 *b);


### PR DESCRIPTION
As part of the effort to not allow mutable X509 objects where they aren't needed, constify the cert parameter for these two functions

Note: This is blocked on the addition of PR #30035, which constifies X509_verify, at which point the XXX note in X509_self_signed can be dropped from this pr along with its cast, and come out of draft
