### PR TITLE
Constify various functions that were non const due to extension cache

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -182,6 +182,14 @@ OpenSSL 4.0
 
    *Ryan Hooper*
 
+ * Constify Various X509 functions:
+   X509_get_pathlen X509_check_ca X509_check_purpose X509_get_proxy_pathlen
+   X509_get_extension_flags X509_get_key_usage X509_get_extended_key_usage
+   X509_get0_subject_key_id X509_get0_authority_key_id X509_get0_authority_issuer
+   X509_get0_authority_serial.
+
+   * Bob Beck *
+
  * Fixed CRLs with invalid ASN1_TIME in invalidityDate extensions,
    where verification incorrectly succeeded. Enforced proper
    handling of ASN1_TIME validation results so that any CRL

--- a/doc/man3/X509_check_ca.pod
+++ b/doc/man3/X509_check_ca.pod
@@ -8,7 +8,7 @@ X509_check_ca - check if given certificate is CA certificate
 
  #include <openssl/x509v3.h>
 
- int X509_check_ca(X509 *cert);
+ int X509_check_ca(const X509 *cert);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/X509_check_purpose.pod
+++ b/doc/man3/X509_check_purpose.pod
@@ -20,7 +20,7 @@ X509_PURPOSE_set - functions related to checking the purpose of a certificate
 
  #include <openssl/x509v3.h>
 
- int X509_check_purpose(X509 *x, int id, int ca);
+ int X509_check_purpose(const X509 *x, int id, int ca);
 
  int X509_PURPOSE_get_count(void);
  int X509_PURPOSE_get_unused_id(OSSL_LIB_CTX *libctx);

--- a/doc/man3/X509_get_extension_flags.pod
+++ b/doc/man3/X509_get_extension_flags.pod
@@ -18,17 +18,17 @@ X509_get_proxy_pathlen - retrieve certificate extension data
 
  #include <openssl/x509v3.h>
 
- long X509_get_pathlen(X509 *x);
- uint32_t X509_get_extension_flags(X509 *x);
- uint32_t X509_get_key_usage(X509 *x);
- uint32_t X509_get_extended_key_usage(X509 *x);
- const ASN1_OCTET_STRING *X509_get0_subject_key_id(X509 *x);
- const ASN1_OCTET_STRING *X509_get0_authority_key_id(X509 *x);
- const GENERAL_NAMES *X509_get0_authority_issuer(X509 *x);
- const ASN1_INTEGER *X509_get0_authority_serial(X509 *x);
+ long X509_get_pathlen(const X509 *x);
+ uint32_t X509_get_extension_flags(const X509 *x);
+ uint32_t X509_get_key_usage(const X509 *x);
+ uint32_t X509_get_extended_key_usage(const X509 *x);
+ const ASN1_OCTET_STRING *X509_get0_subject_key_id(const X509 *x);
+ const ASN1_OCTET_STRING *X509_get0_authority_key_id(const X509 *x);
+ const GENERAL_NAMES *X509_get0_authority_issuer(const X509 *x);
+ const ASN1_INTEGER *X509_get0_authority_serial(const X509 *x);
  void X509_set_proxy_flag(X509 *x);
  void X509_set_proxy_pathlen(int l);
- long X509_get_proxy_pathlen(X509 *x);
+ long X509_get_proxy_pathlen(const X509 *x);
 
 =head1 DESCRIPTION
 

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -313,7 +313,7 @@ struct x509_object_st {
 int ossl_a2i_ipadd(unsigned char *ipout, const char *ipasc);
 int ossl_x509_set1_time(int *modified, ASN1_TIME **ptm, const ASN1_TIME *tm);
 int ossl_x509_print_ex_brief(BIO *bio, X509 *cert, unsigned long neg_cflags);
-int ossl_x509v3_cache_extensions(X509 *x);
+int ossl_x509v3_cache_extensions(const X509 *x);
 int ossl_x509_init_sig_info(X509 *x);
 
 int ossl_x509_set0_libctx(X509 *x, OSSL_LIB_CTX *libctx, const char *propq);

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -530,7 +530,7 @@ int X509_PUBKEY_set(X509_PUBKEY **x, EVP_PKEY *pkey);
 EVP_PKEY *X509_PUBKEY_get0(const X509_PUBKEY *key);
 EVP_PKEY *X509_PUBKEY_get(const X509_PUBKEY *key);
 int X509_get_pubkey_parameters(EVP_PKEY *pkey, STACK_OF(X509) *chain);
-long X509_get_pathlen(X509 *x);
+long X509_get_pathlen(const X509 *x);
 DECLARE_ASN1_ENCODE_FUNCTIONS_only(EVP_PKEY, PUBKEY)
 EVP_PKEY *d2i_PUBKEY_ex(EVP_PKEY **a, const unsigned char **pp, long length,
     OSSL_LIB_CTX *libctx, const char *propq);

--- a/include/openssl/x509v3.h.in
+++ b/include/openssl/x509v3.h.in
@@ -744,22 +744,22 @@ int X509V3_extensions_print(BIO *out, const char *title,
     const STACK_OF(X509_EXTENSION) *exts,
     unsigned long flag, int indent);
 
-int X509_check_ca(X509 *x);
-int X509_check_purpose(X509 *x, int id, int ca);
+int X509_check_ca(const X509 *x);
+int X509_check_purpose(const X509 *x, int id, int ca);
 int X509_supported_extension(X509_EXTENSION *ex);
 int X509_check_issued(X509 *issuer, X509 *subject);
 int X509_check_akid(const X509 *issuer, const AUTHORITY_KEYID *akid);
 void X509_set_proxy_flag(X509 *x);
 void X509_set_proxy_pathlen(X509 *x, long l);
-long X509_get_proxy_pathlen(X509 *x);
+long X509_get_proxy_pathlen(const X509 *x);
 
-uint32_t X509_get_extension_flags(X509 *x);
-uint32_t X509_get_key_usage(X509 *x);
-uint32_t X509_get_extended_key_usage(X509 *x);
-const ASN1_OCTET_STRING *X509_get0_subject_key_id(X509 *x);
-const ASN1_OCTET_STRING *X509_get0_authority_key_id(X509 *x);
-const GENERAL_NAMES *X509_get0_authority_issuer(X509 *x);
-const ASN1_INTEGER *X509_get0_authority_serial(X509 *x);
+uint32_t X509_get_extension_flags(const X509 *x);
+uint32_t X509_get_key_usage(const X509 *x);
+uint32_t X509_get_extended_key_usage(const X509 *x);
+const ASN1_OCTET_STRING *X509_get0_subject_key_id(const X509 *x);
+const ASN1_OCTET_STRING *X509_get0_authority_key_id(const X509 *x);
+const GENERAL_NAMES *X509_get0_authority_issuer(const X509 *x);
+const ASN1_INTEGER *X509_get0_authority_serial(const X509 *x);
 
 int X509_PURPOSE_get_count(void);
 int X509_PURPOSE_get_unused_id(OSSL_LIB_CTX *libctx);


### PR DESCRIPTION
for https://github.com/openssl/openssl/issues/30052

This is a blatent cheat. While I can get pretty close to getting around cheating by cacheing extensions as X509 objects are created it's too fragile at the moment. In a future with a better not-copying all the things X509, we would endeavour to not need this.

In the meantime, in the interest of getting the public API ready to do that, we instead make a blatent cheat in the internal function of

int ossl_x509v3_cache_extensions(const X509 *x);

Which in a future world we can work to make go away.

And then the public API all changes to const.

long X509_get_pathlen(const X509 *x);
int X509_check_ca(const X509 *x);
int X509_check_purpose(const X509 *x, int id, int ca); long X509_get_proxy_pathlen(const X509 *x);
uint32_t X509_get_extension_flags(const X509 *x);
uint32_t X509_get_key_usage(const X509 *x);
uint32_t X509_get_extended_key_usage(const X509 *x);
const ASN1_OCTET_STRING *X509_get0_subject_key_id(const X509 *x); const ASN1_OCTET_STRING *X509_get0_authority_key_id(const X509 *x); 
const GENERAL_NAMES *X509_get0_authority_issuer(const X509 *x); 
const ASN1_INTEGER *X509_get0_authority_serial(const X509 *x);

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
