### PR TITLE
document the new build option "enable-static-vcruntime"

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -584,6 +584,15 @@ In the following list, always the non-default variant is documented: if
 feature `xxxx` is disabled by default then `enable-xxxx` is documented and
 if feature `xxxx` is enabled by default then `no-xxxx` is documented.
 
+### enable-static-vcruntime
+
+Build binaries that do not require that VC runtimes are installed
+
+This option will produce binaries that are "self contained", that do not
+depend upon VC runtime libraries being installed, so can be used on any
+computer running MS Windows.  Without this option, the build will produce
+binaries that rely on the VC runtimes being installed and available.
+
 ### enable-ktls
 
 Build with Kernel TLS support.

--- a/NOTES-WINDOWS.md
+++ b/NOTES-WINDOWS.md
@@ -92,6 +92,13 @@ Quick start
        dependency feature can speed up build times by up to 50%:
        `perl Configure no-makedepend`
 
+    b. If you want the OpenSSL binaries to be "self contained", usable on any
+       computer running MS Windows, use 'perl Configure enable-static-vcruntime'.
+       Otherwise, build will produce binaries that depend on the VC runtime
+       libraries being installed and available, and will not work on computers
+       that do not have them.  (This option adds 1 MB to the total size of the
+       two dll's.)
+
  6. `nmake`
 
  7. `nmake test`


### PR DESCRIPTION
I placed these new notes prominently based upon how important I think that they are for applications developers targeting Windows platforms.  With this new option, contributed (but not documented) by @nhorman in Commit 9431cc2, standalone executable applications can be distributed that do not require an installer and do not require modification of the target computer.

I have tested this new option in my repo and it appears to work aok.  Yippee!  Thank you, Mr. Horman.

This pull request only contains documentation.  See Mr. Horman's commit for the code change.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x ] documentation is added or updated
- [ ] tests are added or updated

CLA: trivial