### PR TITLE
Fix coverity issue 1681421

### DIFF
--- a/crypto/x509/t_acert.c
+++ b/crypto/x509/t_acert.c
@@ -62,8 +62,10 @@ static int print_attribute(BIO *bp, X509_ATTRIBUTE *a)
         case V_ASN1_SEQUENCE:
             if (BIO_puts(bp, "\n") <= 0)
                 goto err;
-            ASN1_parse_dump(bp, at->value.sequence->data,
-                at->value.sequence->length, i, 1);
+            if (ASN1_parse_dump(bp, at->value.sequence->data,
+                    at->value.sequence->length, i, 1)
+                <= 0)
+                goto err;
             break;
         default:
             if (BIO_printf(bp, "unable to print attribute of type 0x%X\n",


### PR DESCRIPTION
Check the return value of ASN1_parse_dump

Signed-off-by: Norbert Pocs <norbertp@openssl.org>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
