### PR TITLE
Fix unit tests when run under fuzz builds

### DIFF
--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -130,6 +130,13 @@ This output usually makes sense only if you know OpenSSL internals well.
 The value of this environment variable is a comma-separated list of names,
 with the following available:
 
+=item B<OPENSSL_RUNNING_UNIT_TESTS>
+
+This environment variable is used to flag the fact that unit tests are being run
+(i.e. `make test`).  It is used to detect when the OpenSSL should behave in a special
+manner during unit tests (i.e. when unit tests are being run on fuzzing builds).  It should
+generally not be set by users.
+
 =over 4
 
 =item B<ALL>

--- a/providers/implementations/kdfs/pkcs12kdf.c
+++ b/providers/implementations/kdfs/pkcs12kdf.c
@@ -273,7 +273,7 @@ static int kdf_pkcs12_set_ctx_params(void *vctx, const OSSL_PARAM params[])
      * 100 so we don't time out running the derivation for
      * a really long time
      */
-    if (getenv("RUNNING_UNIT_TESTS") == NULL && p.iter != NULL && ctx->iter > 100)
+    if (getenv("OPENSSL_RUNNING_UNIT_TESTS") == NULL && p.iter != NULL && ctx->iter > 100)
         ctx->iter = 100;
 #endif
     return 1;

--- a/util/wrap.pl.in
+++ b/util/wrap.pl.in
@@ -78,7 +78,7 @@ if ($ARGV[0] eq '-jitter') {
     $std_openssl_conf_include = catdir($there, 'providers');
 }
 
-local $ENV{RUNNING_UNIT_TESTS} = "yes";
+local $ENV{OPENSSL_RUNNING_UNIT_TESTS} = "yes";
 
 local $ENV{OPENSSL_CONF_INCLUDE} = $std_openssl_conf_include
     if defined $std_openssl_conf_include


### PR DESCRIPTION
PR https://github.com/openssl/openssl/pull/30045

Fixed an oss-fuzz failure that occured because we feed random data into the pkcs12 kdf, which sometimes results in a huge iteration count, that leads to timeouts in oss-fuzz.

The fix was to simply limit the number of iterations that we go through during derivation.  This breaks the kdf of course, but it doesn't really matter during fuzzing, because we don't expect random input data to produce reasonable results, so no harm, no foul.

except.

We also, in our CI, build our fuzzer tests and run them through our regular CI unit tests, during which we both provide valid data, and expect valid results, and pr 30045 breaks that expectation.

The conventional wisdom is to simply skip unit tests that break under these sorts of conditions (we do this for things like 70-test_quic_record.t already).

however, the tests that broke here are 25_test_x509, 30_test_evp, 80_test_pkcs12, and 90_test_store_cases.  It seems like we would want to keep testing those unless we absolutely have to skip them.

So instead, lets indicate that we are running the unit tests with an environment variable, and check that variable when we have an UNSAFE_FOR_PRODUCTION build, skiping the iteration clamp in pkcs12kdf if it is.  This allows us to continue running these unit tests, while still getting the oss-fuzz runs to pass.

marking as urgent as this is breaking CI currently.

##### Checklist
- [x] tests are added or updated
