### PR TITLE
constify X509_check_trust, X509_TRUST_add

### DIFF
--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -85,12 +85,16 @@ static int xp_cmp(const X509_PURPOSE *const *a, const X509_PURPOSE *const *b)
  * If id == -1 it just calls x509v3_cache_extensions() for its side-effect.
  * Returns 1 on success, 0 if x does not allow purpose, -1 on (internal) error.
  */
-int X509_check_purpose(X509 *x, int id, int non_leaf)
+int X509_check_purpose(const X509 *x, int id, int non_leaf)
 {
     int idx;
     const X509_PURPOSE *pt;
 
-    if (!ossl_x509v3_cache_extensions(x))
+    /*
+     * TODO: This cast can be dropped when https://github.com/openssl/openssl/pull/30067
+     * gets merged
+     */
+    if (!ossl_x509v3_cache_extensions((X509 *)x))
         return -1;
     if (id == -1)
         return 1;

--- a/crypto/x509/x509_trust.c
+++ b/crypto/x509/x509_trust.c
@@ -15,12 +15,12 @@
 static int tr_cmp(const X509_TRUST *const *a, const X509_TRUST *const *b);
 static void trtable_free(X509_TRUST *p);
 
-static int trust_1oidany(X509_TRUST *trust, X509 *x, int flags);
-static int trust_1oid(X509_TRUST *trust, X509 *x, int flags);
-static int trust_compat(X509_TRUST *trust, X509 *x, int flags);
+static int trust_1oidany(X509_TRUST *trust, const X509 *x, int flags);
+static int trust_1oid(X509_TRUST *trust, const X509 *x, int flags);
+static int trust_compat(X509_TRUST *trust, const X509 *x, int flags);
 
-static int obj_trust(int id, X509 *x, int flags);
-static int (*default_trust)(int id, X509 *x, int flags) = obj_trust;
+static int obj_trust(int id, const X509 *x, int flags);
+static int (*default_trust)(int id, const X509 *x, int flags) = obj_trust;
 
 /*
  * WARNING: the following table should be kept in order of trust and without
@@ -54,17 +54,17 @@ static int tr_cmp(const X509_TRUST *const *a, const X509_TRUST *const *b)
     return (*a)->trust - (*b)->trust;
 }
 
-int (*X509_TRUST_set_default(int (*trust)(int, X509 *, int)))(int, X509 *,
+int (*X509_TRUST_set_default(int (*trust)(int, const X509 *, int)))(int, const X509 *,
     int)
 {
-    int (*oldtrust)(int, X509 *, int);
+    int (*oldtrust)(int, const X509 *, int);
     oldtrust = default_trust;
     default_trust = trust;
     return oldtrust;
 }
 
 /* Returns X509_TRUST_TRUSTED, X509_TRUST_REJECTED, or X509_TRUST_UNTRUSTED */
-int X509_check_trust(X509 *x, int id, int flags)
+int X509_check_trust(const X509 *x, int id, int flags)
 {
     X509_TRUST *pt;
     int idx;
@@ -124,7 +124,7 @@ int X509_TRUST_set(int *t, int trust)
     return 1;
 }
 
-int X509_TRUST_add(int id, int flags, int (*ck)(X509_TRUST *, X509 *, int),
+int X509_TRUST_add(int id, int flags, int (*ck)(X509_TRUST *, const X509 *, int),
     const char *name, int arg1, void *arg2)
 {
     int idx;
@@ -214,7 +214,7 @@ int X509_TRUST_get_trust(const X509_TRUST *xp)
     return xp->trust;
 }
 
-static int trust_1oidany(X509_TRUST *trust, X509 *x, int flags)
+static int trust_1oidany(X509_TRUST *trust, const X509 *x, int flags)
 {
     /*
      * Declare the chain verified if the desired trust OID is not rejected in
@@ -226,7 +226,7 @@ static int trust_1oidany(X509_TRUST *trust, X509 *x, int flags)
     return obj_trust(trust->arg1, x, flags);
 }
 
-static int trust_1oid(X509_TRUST *trust, X509 *x, int flags)
+static int trust_1oid(X509_TRUST *trust, const X509 *x, int flags)
 {
     /*
      * Declare the chain verified only if the desired trust OID is not
@@ -237,7 +237,7 @@ static int trust_1oid(X509_TRUST *trust, X509 *x, int flags)
     return obj_trust(trust->arg1, x, flags);
 }
 
-static int trust_compat(X509_TRUST *trust, X509 *x, int flags)
+static int trust_compat(X509_TRUST *trust, const X509 *x, int flags)
 {
     /* Call for side-effect of setting EXFLAG_SS for self-signed-certs */
     if (X509_check_purpose(x, -1, 0) != 1)
@@ -255,7 +255,7 @@ static int trust_compat(X509_TRUST *trust, X509 *x, int flags)
  * If |flags| includes X509_TRUST_OK_ANY_EKU then anyEKU serves as wildcard.
  * Return X509_TRUST_UNTRUSTED if no clear decision has been reached here.
  */
-static int obj_trust(int id, X509 *x, int flags)
+static int obj_trust(int id, const X509 *x, int flags)
 {
     X509_CERT_AUX *ax = x->aux;
     int i;

--- a/doc/man3/X509_check_purpose.pod
+++ b/doc/man3/X509_check_purpose.pod
@@ -20,7 +20,7 @@ X509_PURPOSE_set - functions related to checking the purpose of a certificate
 
  #include <openssl/x509v3.h>
 
- int X509_check_purpose(X509 *x, int id, int ca);
+ int X509_check_purpose(const X509 *x, int id, int ca);
 
  int X509_PURPOSE_get_count(void);
  int X509_PURPOSE_get_unused_id(OSSL_LIB_CTX *libctx);
@@ -170,6 +170,8 @@ X509_PURPOSE_add() or X509_PURPOSE_cleanup(void) is being called.
 =head1 HISTORY
 
 X509_PURPOSE_get_unused_id() was added in OpensSL 3.5.
+
+X509_check_purpose() had its B<X509> parameter converted to const in OpenSSL 4.0.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/x509_vfy.h.in
+++ b/include/openssl/x509_vfy.h.in
@@ -83,7 +83,7 @@ typedef enum {
 typedef struct x509_trust_st {
     int trust;
     int flags;
-    int (*check_trust)(struct x509_trust_st *, X509 *, int);
+    int (*check_trust)(struct x509_trust_st *, const X509 *, int);
     char *name;
     int arg1;
     void *arg2;
@@ -127,7 +127,7 @@ int X509_TRUST_set(int *t, int trust);
 int X509_TRUST_get_count(void);
 X509_TRUST *X509_TRUST_get0(int idx);
 int X509_TRUST_get_by_id(int id);
-int X509_TRUST_add(int id, int flags, int (*ck)(X509_TRUST *, X509 *, int),
+int X509_TRUST_add(int id, int flags, int (*ck)(X509_TRUST *, const X509 *, int),
     const char *name, int arg1, void *arg2);
 void X509_TRUST_cleanup(void);
 int X509_TRUST_get_flags(const X509_TRUST *xp);
@@ -142,9 +142,9 @@ void X509_reject_clear(X509 *x);
 STACK_OF(ASN1_OBJECT) *X509_get0_trust_objects(const X509 *x);
 STACK_OF(ASN1_OBJECT) *X509_get0_reject_objects(const X509 *x);
 
-int (*X509_TRUST_set_default(int (*trust)(int, X509 *, int)))(int, X509 *,
+int (*X509_TRUST_set_default(int (*trust)(int, const X509 *, int)))(int, const X509 *,
     int);
-int X509_check_trust(X509 *x, int id, int flags);
+int X509_check_trust(const X509 *x, int id, int flags);
 
 int X509_verify_cert(X509_STORE_CTX *ctx);
 int X509_STORE_CTX_verify(X509_STORE_CTX *ctx);

--- a/include/openssl/x509v3.h.in
+++ b/include/openssl/x509v3.h.in
@@ -745,7 +745,7 @@ int X509V3_extensions_print(BIO *out, const char *title,
     unsigned long flag, int indent);
 
 int X509_check_ca(X509 *x);
-int X509_check_purpose(X509 *x, int id, int ca);
+int X509_check_purpose(const X509 *x, int id, int ca);
 int X509_supported_extension(X509_EXTENSION *ex);
 int X509_check_issued(X509 *issuer, X509 *subject);
 int X509_check_akid(const X509 *issuer, const AUTHORITY_KEYID *akid);


### PR DESCRIPTION
Turn the X509 parameters to X509_check_trust and X509_TRUST_add into consts.

Interesting side notes: X509_TRUST_add and some others that we're modified as a result of this pr, are listed as public functions, but have no documentation for them, and make doc-nits doesn't complain about it.  Unsure as to why, but we should probably look at that eventually

