### PR TITLE
Constify X509_print_fp and X509_print_ex_fp

### DIFF
--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -24,12 +24,12 @@ void OSSL_STACK_OF_X509_free(STACK_OF(X509) *certs)
 }
 
 #ifndef OPENSSL_NO_STDIO
-int X509_print_fp(FILE *fp, X509 *x)
+int X509_print_fp(FILE *fp, const X509 *x)
 {
     return X509_print_ex_fp(fp, x, XN_FLAG_COMPAT, X509_FLAG_COMPAT);
 }
 
-int X509_print_ex_fp(FILE *fp, X509 *x, unsigned long nmflag, unsigned long cflag)
+int X509_print_ex_fp(FILE *fp, const X509 *x, unsigned long nmflag, unsigned long cflag)
 {
     BIO *b;
     int ret;

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -825,8 +825,8 @@ int X509_CRL_cmp(const X509_CRL *a, const X509_CRL *b);
 int X509_CRL_match(const X509_CRL *a, const X509_CRL *b);
 int X509_aux_print(BIO *out, const X509 *x, int indent);
 #ifndef OPENSSL_NO_STDIO
-int X509_print_ex_fp(FILE *bp, X509 *x, unsigned long nmflag, unsigned long cflag);
-int X509_print_fp(FILE *bp, X509 *x);
+int X509_print_ex_fp(FILE *bp, const X509 *x, unsigned long nmflag, unsigned long cflag);
+int X509_print_fp(FILE *bp, const X509 *x);
 int X509_CRL_print_fp(FILE *bp, X509_CRL *x);
 int X509_REQ_print_fp(FILE *bp, const X509_REQ *req);
 int X509_NAME_print_ex_fp(FILE *fp, const X509_NAME *nm, int indent, unsigned long flags);


### PR DESCRIPTION
Make the X509 argument to both functions const, as we don't modify the object at all in these functions.

Again, these functions, while public, appear undocumented, and so I'm omitting any HISTORY notes


