### PR TITLE
Constify X509_CRL_get0_by_cert

### DIFF
--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -451,7 +451,7 @@ int X509_CRL_get0_by_serial(X509_CRL *crl,
     return 0;
 }
 
-int X509_CRL_get0_by_cert(X509_CRL *crl, X509_REVOKED **ret, X509 *x)
+int X509_CRL_get0_by_cert(X509_CRL *crl, X509_REVOKED **ret, const X509 *x)
 {
     if (crl->meth->crl_lookup)
         return crl->meth->crl_lookup(crl, ret,

--- a/doc/man3/X509_CRL_get0_by_serial.pod
+++ b/doc/man3/X509_CRL_get0_by_serial.pod
@@ -14,7 +14,7 @@ functions
 
  int X509_CRL_get0_by_serial(X509_CRL *crl,
                              X509_REVOKED **ret, const ASN1_INTEGER *serial);
- int X509_CRL_get0_by_cert(X509_CRL *crl, X509_REVOKED **ret, X509 *x);
+ int X509_CRL_get0_by_cert(X509_CRL *crl, X509_REVOKED **ret, const X509 *x);
 
  STACK_OF(X509_REVOKED) *X509_CRL_get_REVOKED(const X509_CRL *crl);
 
@@ -104,6 +104,8 @@ L<X509V3_get_d2i(3)>,
 L<X509_verify_cert(3)>
 
 =head1 HISTORY
+
+X509_CRL_get0_by_cert() was constified in OpenSSL 4.0.
 
 X509_CRL_get_REVOKED() was constified in OpenSSL 4.0.
 

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -613,7 +613,7 @@ X509_CRL *X509_CRL_new_ex(OSSL_LIB_CTX *libctx, const char *propq);
 int X509_CRL_add0_revoked(X509_CRL *crl, X509_REVOKED *rev);
 int X509_CRL_get0_by_serial(X509_CRL *crl,
     X509_REVOKED **ret, const ASN1_INTEGER *serial);
-int X509_CRL_get0_by_cert(X509_CRL *crl, X509_REVOKED **ret, X509 *x);
+int X509_CRL_get0_by_cert(X509_CRL *crl, X509_REVOKED **ret, const X509 *x);
 
 X509_PKEY *X509_PKEY_new(void);
 void X509_PKEY_free(X509_PKEY *a);


### PR DESCRIPTION
Work towards https://github.com/openssl/openssl/issues/30052, constify X509_CRL_get0_by_cert .
I don't have access to add myself as responsible sucker in the spreadsheet, so will pick out some functions that are yet to be taken.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

