### PR TITLE
evp: freeze KDF fetch cache and expand KDF fetch tests

### DIFF
--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -458,6 +458,7 @@ int evp_method_id2name_id_op_id(uint32_t meth_id, int *name_id,
     unsigned int *operation_id);
 int evp_md_fetch_all(OSSL_LIB_CTX *ctx);
 int evp_cipher_fetch_all(OSSL_LIB_CTX *ctx);
+int evp_kdf_fetch_all(OSSL_LIB_CTX *ctx);
 int evp_rand_fetch_all(OSSL_LIB_CTX *ctx);
 int evp_mac_fetch_all(OSSL_LIB_CTX *ctx);
 int evp_keymgmt_fetch_all(OSSL_LIB_CTX *ctx);

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -1172,11 +1172,10 @@ int ossl_method_store_freeze_cache(OSSL_METHOD_STORE *store, const char *propq)
 
     if (evp_md_fetch_all(store->ctx) <= 0
         || evp_cipher_fetch_all(store->ctx) <= 0
-        || evp_rand_fetch_all(store->ctx) <= 0)
-        goto err;
-    if (evp_mac_fetch_all(store->ctx) <= 0)
-        goto err;
-    if (evp_keymgmt_fetch_all(store->ctx) <= 0)
+        || evp_rand_fetch_all(store->ctx) <= 0
+        || evp_mac_fetch_all(store->ctx) <= 0
+        || evp_keymgmt_fetch_all(store->ctx) <= 0
+        || evp_kdf_fetch_all(store->ctx) <= 0)
         goto err;
     if (evp_kem_fetch_all(store->ctx) <= 0)
         goto err;

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -231,6 +231,7 @@ struct evp_mac_st {
 struct evp_kdf_st {
     OSSL_PROVIDER *prov;
     int name_id;
+    int origin;
     char *type_name;
     const char *description;
     CRYPTO_REF_COUNT refcnt;

--- a/test/evp_fetch_prov_test.c
+++ b/test/evp_fetch_prov_test.c
@@ -18,6 +18,7 @@
 #include <openssl/sha.h>
 #include <openssl/evp.h>
 #include <openssl/core_names.h>
+#include <openssl/kdf.h>
 #include <openssl/provider.h>
 #include "internal/sizes.h"
 #include "testutil.h"
@@ -484,6 +485,160 @@ err:
 static int test_explicit_EVP_MAC_fetch_by_name(void)
 {
     return test_explicit_EVP_MAC_fetch("HMAC");
+}
+
+static int derive_pbkdf2(EVP_KDF *kdf)
+{
+    int ret = 0;
+    EVP_KDF_CTX *ctx = NULL;
+    unsigned char out[25];
+    static const unsigned char password[] = "passwordPASSWORDpassword";
+    static const unsigned char salt[] = "saltSALTsaltSALTsaltSALTsaltSALTsalt";
+    unsigned int iterations = 4096;
+    int mode = 0;
+    OSSL_PARAM params[6], *p = params;
+    static const unsigned char expected[sizeof(out)] = {
+        0x34, 0x8c, 0x89, 0xdb, 0xcb, 0xd3, 0x2b, 0x2f,
+        0x32, 0xd8, 0x14, 0xb8, 0x11, 0x6e, 0x84, 0xcf,
+        0x2b, 0x17, 0x34, 0x7e, 0xbc, 0x18, 0x00, 0x18,
+        0x1c
+    };
+
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_PASSWORD,
+        (void *)password,
+        sizeof(password) - 1);
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
+        (void *)salt, sizeof(salt) - 1);
+    *p++ = OSSL_PARAM_construct_uint(OSSL_KDF_PARAM_ITER, &iterations);
+    *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, "sha256", 0);
+    *p++ = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_PKCS5, &mode);
+    *p = OSSL_PARAM_construct_end();
+
+    if (!TEST_ptr(ctx = EVP_KDF_CTX_new(kdf))
+        || !TEST_int_gt(EVP_KDF_derive(ctx, out, sizeof(out), params), 0)
+        || !TEST_mem_eq(out, sizeof(out), expected, sizeof(expected)))
+        goto err;
+    ret = 1;
+err:
+    EVP_KDF_CTX_free(ctx);
+    return ret;
+}
+
+static int test_kdf(EVP_KDF *kdf, const char *name)
+{
+    return TEST_ptr(kdf)
+        && TEST_ptr(EVP_KDF_get0_provider(kdf))
+        && TEST_true(EVP_KDF_is_a(kdf, name))
+        && TEST_true(derive_pbkdf2(kdf));
+}
+
+static int test_implicit_EVP_KDF_fetch(void)
+{
+    OSSL_LIB_CTX *ctx = NULL;
+    OSSL_PROVIDER *prov[2] = { NULL, NULL };
+    EVP_KDF *kdf = NULL;
+    int ret = 0;
+
+    if (use_default_ctx == 0 && !load_providers(&ctx, prov))
+        goto err;
+
+    if (!TEST_ptr(kdf = EVP_KDF_fetch(ctx, OSSL_KDF_NAME_PBKDF2, NULL))
+        || !TEST_true(test_kdf(kdf, OSSL_KDF_NAME_PBKDF2)))
+        goto err;
+    ret = 1;
+err:
+    EVP_KDF_free(kdf);
+    unload_providers(&ctx, prov);
+    return ret;
+}
+
+static int test_explicit_EVP_KDF_fetch(const char *id)
+{
+    OSSL_LIB_CTX *ctx = NULL;
+    EVP_KDF *kdf = NULL;
+    OSSL_PROVIDER *prov[2] = { NULL, NULL };
+    int ret = 0;
+
+    if (use_default_ctx == 0 && !load_providers(&ctx, prov))
+        goto err;
+
+    kdf = EVP_KDF_fetch(ctx, id, fetch_property);
+    if (expected_fetch_result != 0) {
+        if (!test_kdf(kdf, id))
+            goto err;
+
+        if (!TEST_true(EVP_KDF_up_ref(kdf)))
+            goto err;
+        /* Ref count should now be 2. Release first one here */
+        EVP_KDF_free(kdf);
+    } else {
+        if (!TEST_ptr_null(kdf))
+            goto err;
+    }
+    ret = 1;
+err:
+    EVP_KDF_free(kdf);
+    unload_providers(&ctx, prov);
+    return ret;
+}
+
+static int test_EVP_KDF_fetch_freeze(void)
+{
+#if defined(OPENSSL_NO_CACHED_FETCH)
+    /*
+     * Test does not make sense if cached fetch is disabled.
+     * There's nothing to freeze, and test will fail.
+     */
+    return 1;
+#endif
+
+    EVP_KDF *kdf = NULL;
+    int ret = 0;
+    OSSL_LIB_CTX *ctx = NULL;
+    OSSL_PROVIDER *prov[2] = { NULL, NULL };
+
+    if (use_default_ctx == 0 && !load_providers(&ctx, prov))
+        goto err;
+
+    if (!TEST_ptr(kdf = EVP_KDF_fetch(ctx, "PBKDF2", NULL))
+        || !TEST_true(test_kdf(kdf, "PBKDF2"))
+        || !TEST_int_ne(kdf->origin, EVP_ORIG_FROZEN))
+        goto err;
+    EVP_KDF_free(kdf);
+    kdf = NULL;
+
+    if (!TEST_int_eq(OSSL_LIB_CTX_freeze(ctx, "?fips=true"), 1)
+        || !TEST_ptr(kdf = EVP_KDF_fetch(ctx, "PBKDF2", NULL))
+        || !TEST_true(test_kdf(kdf, "PBKDF2"))
+        || !TEST_int_eq(kdf->origin, EVP_ORIG_FROZEN))
+        goto err;
+    /* Technically, frozen version doesn't need to be freed */
+    EVP_KDF_free(kdf);
+    kdf = NULL;
+
+    if (!TEST_ptr(kdf = EVP_KDF_fetch(ctx, "PBKDF2", "?fips=true"))
+        || !TEST_true(test_kdf(kdf, "PBKDF2"))
+        || !TEST_int_eq(kdf->origin, EVP_ORIG_FROZEN))
+        goto err;
+    EVP_KDF_free(kdf);
+    kdf = NULL;
+
+    /* Falls back to slow path */
+    if (!TEST_ptr(kdf = EVP_KDF_fetch(ctx, "PBKDF2", "?provider=default"))
+        || !TEST_true(test_kdf(kdf, "PBKDF2"))
+        || !TEST_int_ne(kdf->origin, EVP_ORIG_FROZEN))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_KDF_free(kdf);
+    unload_providers(&ctx, prov);
+    return ret;
+}
+
+static int test_explicit_EVP_KDF_fetch_by_name(void)
+{
+    return test_explicit_EVP_KDF_fetch("PBKDF2");
 }
 
 /*
@@ -1220,6 +1375,10 @@ int setup_tests(void)
         ADD_TEST(test_implicit_EVP_CIPHER_fetch);
         ADD_TEST(test_explicit_EVP_CIPHER_fetch_by_name);
         ADD_ALL_TESTS_NOSUBTEST(test_explicit_EVP_CIPHER_fetch_by_X509_ALGOR, 2);
+    } else if (strcmp(alg, "kdf") == 0) {
+        ADD_TEST(test_EVP_KDF_fetch_freeze);
+        ADD_TEST(test_implicit_EVP_KDF_fetch);
+        ADD_TEST(test_explicit_EVP_KDF_fetch_by_name);
     } else if (strcmp(alg, "rand") == 0) {
         ADD_TEST(test_EVP_RAND_fetch_freeze);
         ADD_TEST(test_implicit_EVP_RAND_fetch);

--- a/test/recipes/30-test_evp_fetch_prov.t
+++ b/test/recipes/30-test_evp_fetch_prov.t
@@ -21,7 +21,7 @@ use lib bldtop_dir('.');
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
-my @types = ( "digest", "cipher", "rand", "mac", "kmgmt", "kem" );
+my @types = ( "digest", "cipher", "rand", "mac", "kmgmt", "kem", "kdf" );
 
 my @testdata = (
     { config    => srctop_file("test", "default.cnf"),


### PR DESCRIPTION
Add frozen-method support for EVP_KDF fetches by wiring dup/free callbacks and populating KDF entries during OSSL_LIB_CTX_freeze().

perftools shows no performance gains

  $ ./evp_kdf -o evp_isolated 64 -f
  Average time per computation: 8181.213888us
  $ ./evp_kdf -o evp_isolated 64
  Average time per computation: 8307.157135us

Resolves https://github.com/openssl/project/issues/1834
