### PR TITLE
Removes trailing whitespace from generated pkg-config .pc files

### DIFF
--- a/exporters/pkg-config/libcrypto.pc.in
+++ b/exporters/pkg-config/libcrypto.pc.in
@@ -10,7 +10,8 @@ libdir={- if (defined $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]) {
           } -}
 includedir={- $OUT = '';
               $OUT .= '${prefix}/' . $_ . ' '
-                  foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX); -}
+                  foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX);
+              $OUT =~ s/\s+\z//; -}
 modulesdir=${libdir}/{- $OpenSSL::safe::installdata::MODULESDIR_REL_LIBDIR[0] -}
 
 Name: OpenSSL-libcrypto
@@ -23,4 +24,5 @@ Cflags:{- $OUT = ' -I${includedir}';
               $OUT = '';
               $OUT .= ' -I${prefix}/' . $_ . ' '
                   foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX);
+              $OUT =~ s/\s+\z//;
           } -}

--- a/exporters/pkg-config/libssl.pc.in
+++ b/exporters/pkg-config/libssl.pc.in
@@ -10,7 +10,8 @@ libdir={- if (defined $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]) {
           } -}
 includedir={- $OUT = '';
               $OUT .= '${prefix}/' . $_ . ' '
-                  foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX); -}
+                  foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX);
+              $OUT =~ s/\s+\z//; -}
 
 Name: OpenSSL-libssl
 Description: Secure Sockets Layer and cryptography libraries
@@ -22,4 +23,5 @@ Cflags:{- $OUT = ' -I${includedir}';
               $OUT = '';
               $OUT .= ' -I${prefix}/' . $_ . ' '
                   foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX);
+              $OUT =~ s/\s+\z//;
           } -}

--- a/exporters/pkg-config/openssl.pc.in
+++ b/exporters/pkg-config/openssl.pc.in
@@ -10,7 +10,8 @@ libdir={- if (defined $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]) {
           } -}
 includedir={- $OUT = '';
               $OUT .= '${prefix}/' . $_ . ' '
-                  foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX); -}
+                  foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX);
+              $OUT =~ s/\s+\z//; -}
 
 Name: OpenSSL
 Description: Secure Sockets Layer and cryptography libraries and tools


### PR DESCRIPTION
Adds logic to trim whitespace from the generated pkg-config .pc files.

Fixes #29993