### PR TITLE
Fix the uses of X509_check_certificate_times

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -682,12 +682,8 @@ static void warn_cert(const char *uri, X509 *cert, int warn_EE,
     int error;
     uint32_t ex_flags = X509_get_extension_flags(cert);
 
-    if (!X509_check_certificate_times(vpm, cert, &error)) {
-        char msg[128];
-
-        ERR_error_string_n(error, msg, sizeof(msg));
-        warn_cert_msg(uri, cert, msg);
-    }
+    if (!X509_check_certificate_times(vpm, cert, &error))
+        warn_cert_msg(uri, cert, X509_verify_cert_error_string(error));
 
     if (warn_EE && (ex_flags & EXFLAG_V1) == 0 && (ex_flags & EXFLAG_CA) == 0)
         warn_cert_msg(uri, cert, "is not a CA cert");

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -1138,7 +1138,7 @@ cert_loop:
         X509_VERIFY_PARAM *vpm;
         time_t tcheck = time(NULL) + checkoffset;
         int expired = 0;
-        int error, valid;
+        int error;
 
         if ((vpm = X509_VERIFY_PARAM_new()) == NULL) {
             BIO_puts(out, "Malloc failed\n");
@@ -1147,16 +1147,11 @@ cert_loop:
         X509_VERIFY_PARAM_set_flags(vpm, X509_V_FLAG_USE_CHECK_TIME);
         X509_VERIFY_PARAM_set_time(vpm, tcheck);
 
-        valid = X509_check_certificate_times(vpm, x, &error);
-        if (!valid) {
-            char msg[128];
-
-            ERR_error_string_n(error, msg, sizeof(msg));
-            BIO_printf(out, "%s\n", msg);
-        }
-        if (error == X509_V_ERR_CERT_HAS_EXPIRED) {
-            BIO_puts(out, "Certificate will expire\n");
-            expired = 1;
+        if (!X509_check_certificate_times(vpm, x, &error)) {
+            if (error == X509_V_ERR_CERT_HAS_EXPIRED) {
+                BIO_puts(out, "Certificate will expire\n");
+                expired = 1;
+            }
         } else {
             BIO_puts(out, "Certificate will not expire\n");
         }

--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -404,9 +404,7 @@ int ossl_x509_print_ex_brief(BIO *bio, X509 *cert, unsigned long neg_cflags)
         goto err;
 
     if (!X509_check_certificate_times(vpm, cert, &error)) {
-        if (BIO_printf(bio, "        %s\n",
-                X509_verify_cert_error_string(error))
-            <= 0)
+        if (BIO_printf(bio, "        %s\n", X509_verify_cert_error_string(error)) <= 0)
             goto err;
     }
     ret = X509_print_ex(bio, cert, flags,


### PR DESCRIPTION
The "error" parameter to 'X509_check_certificate_times' gets an X509 error
value, which isn't a OpenSSL ERR reason code.  Unfortunately, this was
conflated.

This restores the behaviour in the places of conflation to something
similar enough to what was done before 'X509_check_certificate_times'
was implemented.
