### PR TITLE
Added -expected-rpks s_client/server option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,12 @@ OpenSSL 4.0
 
 ### Changes between 3.6 and 4.0 [xx XXX xxxx]
 
+ * New `-expected-rpks` option in the `openssl-s_client(1)` and `openssl-s_server(1)`
+   command line utilities.  This makes it possible to specify one more public keys
+   expected from the remote peer that are then used to authenticate the connection.
+
+   *Viktor Dukhovni*
+
  * New `SSL_get0_sigalg()` and `SSL_get0_shared_sigalg()` functions report the
    TLS signature algorithm name and codepoint for the peer advertised and shared
    algorithms respectively.  These supersede the existing `SSL_get_sigalgs()` and
@@ -105,7 +111,7 @@ OpenSSL 4.0
 
    *Neil Horman*
 
- * ASN1_OBJECT_new() has been deprecated.
+ * `ASN1_OBJECT_new()` has been deprecated.
 
    Refer to ossl-migration-guide(7) for more info.
 
@@ -148,10 +154,10 @@ OpenSSL 4.0
 
    *kovan*
 
- * ASN1_STRING has been made opaque.
+ * `ASN1_STRING` has been made opaque.
 
-   Access to values from ASN1_STRING and related types should be done with the
-   appropriate accessor functions. The various ASN1_STRING_FLAG values have
+   Access to values from `ASN1_STRING` and related types should be done with the
+   appropriate accessor functions. The various `ASN1_STRING_FLAG` values have
    been made private.
 
    *Bob Beck*
@@ -265,8 +271,8 @@ OpenSSL 4.0
 
  * Added `ASN1_BIT_STRING_set1()` to set a bit string to a value including
    the length in bytes and the number of unused bits. Internally,
-   'ASN1_BIT_STRING_set_bit()' has also been modified to keep the number of
-   unused bits correct when changing an ASN1_BIT_STRING.
+   `ASN1_BIT_STRING_set_bit()` has also been modified to keep the number of
+   unused bits correct when changing an `ASN1_BIT_STRING`.
 
    * Bob Beck *
 
@@ -299,7 +305,7 @@ OpenSSL 4.0
 
    *Daniel Kubec and Eugene Syromiatnikov*
 
- * X509_get0_distinguishing_id now takes and returns const objects.
+ * `X509_get0_distinguishing_id()` now takes and returns const objects.
 
    * Bob Beck *
 
@@ -317,10 +323,11 @@ OpenSSL 4.0
    *Ryan Hooper*
 
  * Constify Various X509 functions:
-   X509_get_pathlen X509_check_ca X509_check_purpose X509_get_proxy_pathlen
-   X509_get_extension_flags X509_get_key_usage X509_get_extended_key_usage
-   X509_get0_subject_key_id X509_get0_authority_key_id X509_get0_authority_issuer
-   X509_get0_authority_serial.
+   `X509_get_pathlen()`, `X509_check_ca()`, `X509_check_purpose()`,
+   `X509_get_proxy_pathlen()`, `X509_get_extension_flags()`,
+   `X509_get_key_usage()`, `X509_get_extended_key_usage()`,
+   `X509_get0_subject_key_id()`, `X509_get0_authority_key_id()`,
+   `X509_get0_authority_issuer()`, `X509_get0_authority_serial()`.
 
    * Bob Beck *
 
@@ -392,18 +399,18 @@ OpenSSL 4.0
 
    *Stephen Farrell* (with much support from *Matt Caswell* and *Tomáš Mráz*)
 
- * X509_cmp_time, X509_cmp_current_time, and X509_cmp_timeframe have
+ * `X509_cmp_time()`, `X509_cmp_current_time()`, and `X509_cmp_timeframe()` have
    had documentation added, and have then been deprecated.  A new
-   function, X509_check_certificate_times has been added, as well as
-   the <openssl/posix_time.h> interface from BoringSSL/LibreSSL. For
+   function, `X509_check_certificate_times()` has been added, as well as
+   the `<openssl/posix_time.h>` interface from BoringSSL/LibreSSL. For
    details of these functions and non-deprecated replacement
-   strategies, see X509_check_certificate_times(3).
+   strategies, see `X509_check_certificate_times(3)`.
 
    * Bob Beck *
 
- * Added BIO_set_send_flags() function that allows setting flags passed to
+ * Added `BIO_set_send_flags()` function that allows setting flags passed to
    send(), sendto(), and sendmsg(). The main intention is to allow setting
-   the MSG_NOSIGNAL flag to avoid a crash on receiving the SIGPIPE signal.
+   the `MSG_NOSIGNAL` flag to avoid a crash on receiving the SIGPIPE signal.
 
    *Igor Ustinov*
 

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -163,6 +163,7 @@ int load_key_certs_crls(const char *uri, int format, int maybe_stdin,
     EVP_SKEY **pskey);
 EVP_SKEY *load_skey(const char *uri, int format, int maybe_stdin,
     const char *pass, int quiet);
+int load_rpk_file(SSL *ssl, const char *file);
 X509_STORE *setup_verify(const char *CAfile, int noCAfile,
     const char *CApath, int noCApath,
     const char *CAstore, int noCAstore);

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -122,6 +122,7 @@ B<openssl> B<s_client>
 {- $OpenSSL::safe::opt_v_synopsis -}
 [B<-enable_server_rpk>]
 [B<-enable_client_rpk>]
+[B<-expected-rpks>]
 [I<host>:I<port>]
 [B<-ech_config_list>]
 [B<-ech_outer_alpn> I<protocols>]
@@ -374,7 +375,8 @@ Enable RFC6698/RFC7671 DANE TLSA authentication and specify the
 TLSA base domain which becomes the default SNI hint and the primary
 reference identifier for hostname checks.  This must be used in
 combination with at least one instance of the B<-dane_tlsa_rrdata>
-option below.
+option below, or else at least one B<-expected-rpks> option (from
+which associated TLSA "3 1 0" records are synthesised internally).
 
 When DANE authentication succeeds, the diagnostic output will include
 the lowest (closest to 0) depth at which a TLSA record authenticated
@@ -816,6 +818,28 @@ provided a suitable key and public certificate pair is configured.
 Some servers may nevertheless not request any client credentials,
 or may request a certificate.
 
+=item B<-expected-rpks> I<file>
+
+This option implies the B<-enable_server_rpk> option and can be specified
+multiple times.
+Each PEM I<file> should contain one or more public keys, private keys or
+certificates.
+With a private key or certificate an attempt is made to extract the associated
+public key.
+Each resulting public key is added (via a call to L<SSL_add_expected_rpk(3)> as
+a valid raw public key that the server may present to be considered verified.
+If a server nevertheless presents an X.509 certificate, the enclosed public key
+is validated as though it were presented as a raw public key instead.
+
+If the B<-dane_tlsa_domain> and B<-dane_tlsa_rrdata> options (with certificate
+usage B<DANE-EE(3)> and selector B<SPKI(1)>) are also used then the specified
+TLSA records are used in combination with the keys found via the
+B<-expected-rpks> option(s).
+
+Verification success or failure is reported as a DANE verification success or
+failure, because verification of raw public keys is internally mapped to
+verification of DANE TLSA records derived from the specified keys.
+
 =item I<host>:I<port>
 
 Rather than providing B<-connect>, the target host and optional port may
@@ -1108,6 +1132,8 @@ and B<-ocsp_check_all>
 options were added in OpenSSL 3.6.
 
 The B<ech> options were added in OpenSSL 4.0.
+
+The B<-expected-rpks> option was added in OpenSSL 4.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -135,6 +135,7 @@ B<openssl> B<s_server>
 {- $OpenSSL::safe::opt_provider_synopsis -}
 [B<-enable_server_rpk>]
 [B<-enable_client_rpk>]
+[B<-expected-rpks>]
 [B<-ech_key> I<filename>]
 [B<-ech_dir> I<dirname>]
 [B<-ech_noretry_dir> I<dirname>]
@@ -820,7 +821,24 @@ support raw public keys may elect to use them.
 Clients that don't support raw public keys or prefer to use X.509
 certificates can still elect to send X.509 certificates as usual.
 
-Raw public keys are extracted from the configured certificate/private key.
+=item B<-expected-rpks> I<file>
+
+This option implies the B<-enable_client_rpk> option and can be specified
+multiple times.
+Each PEM I<file> should contain one or more public keys, private keys or
+certificates.
+With a private key or certificate an attempt is made to extract the associated
+public key.
+Each resulting public key is added (via a call to L<SSL_add_expected_rpk(3)> as
+a valid raw public key that the client may present to be considered verified.
+If a client nevertheless presents an X.509 certificate, the enclosed public key
+is validated as though it were presented as a raw public key instead.
+
+Verification success or failure is reported as a DANE verification success or
+failure, because verification of raw public keys is internally mapped to
+verification of DANE TLSA records derived from the specified keys.
+
+=item I<host>:I<port>
 
 =item B<-ech_key> I<filename>
 
@@ -964,7 +982,9 @@ The B<-status_all> option was added in OpenSSL 3.6.
 
 The B<ech> options were added in OpenSSL 4.0.
 
-The B<engine> option was removed in OpenSSL 4.0.
+The B<-engine> option was removed in OpenSSL 4.0.
+
+The B<-expected-rpks> option was added in OpenSSL 4.0.
 
 =head1 COPYRIGHT
 

--- a/test/recipes/70-test_expected_rpk.t
+++ b/test/recipes/70-test_expected_rpk.t
@@ -1,0 +1,61 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use OpenSSL::Test qw/:DEFAULT cmdstr srctop_file bldtop_dir/;
+use OpenSSL::Test::Utils;
+use TLSProxy::Proxy;
+use Cwd qw(abs_path);
+
+my $test_name = "test_expected_rpk";
+setup($test_name);
+
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+
+plan skip_all => "TLSProxy isn't usable on $^O"
+    if $^O =~ /^(VMS)$/;
+
+plan skip_all => "$test_name needs the module feature enabled"
+    if disabled("module");
+
+plan skip_all => "$test_name needs the sock feature enabled"
+    if disabled("sock");
+
+plan tests => 2;
+
+my $proxy = TLSProxy::Proxy->new(
+    sub { return; },
+    cmdstr(app(["openssl"]), display => 1),
+    srctop_file("apps", "server.pem"),
+    (!$ENV{HARNESS_ACTIVE} || $ENV{HARNESS_VERBOSE})
+);
+
+SKIP: {
+    skip "No TLS 1.2 support in this OpenSSL build", 1 if disabled("tls1_2");
+    $proxy->clear();
+    $proxy->clientflags("-tls1_2 -verify 1 -verify_return_error -enable_client_rpk".
+                        " -cert ". srctop_file("apps", "server.pem").
+                        " -expected-rpks ". srctop_file("apps", "server.pem"));
+    $proxy->serverflags("-tls1_2 -Verify 1 -verify_return_error -enable_server_rpk".
+                        " -expected-rpks ". srctop_file("apps", "server.pem"));
+
+    $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
+    ok(TLSProxy::Message->success, "Verified TLS 1.2 mutual RPK");
+}
+
+SKIP: {
+    skip "No TLS 1.3 support in this OpenSSL build", 1 if disabled("tls1_3");
+    $proxy->clear();
+    $proxy->clientflags("-tls1_3 -verify 1 -verify_return_error -enable_client_rpk".
+                        " -cert ". srctop_file("apps", "server.pem").
+                        " -expected-rpks ". srctop_file("apps", "server.pem"));
+    $proxy->serverflags("-tls1_3 -Verify 1 -verify_return_error -enable_server_rpk".
+                        " -expected-rpks ". srctop_file("apps", "server.pem"));
+    $proxy->start();
+    ok(TLSProxy::Message->success, "Verified TLS 1.3 mutual RPK");
+}

--- a/util/perl/TLSProxy/EncryptedExtensions.pm
+++ b/util/perl/TLSProxy/EncryptedExtensions.pm
@@ -1,4 +1,4 @@
-# Copyright 2016-2025 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2016-2026 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -102,6 +102,17 @@ sub extension_data
     my $self = shift;
     if (@_) {
         $self->{extension_data} = shift;
+    }
+    my $exts = $self->{extension_data};
+    if (defined($exts) && defined(my $data = $exts->{TLSProxy::Message::EXT_CLIENT_CERT_TYPE})) {
+        die "Invalid client certificate type extension\n"
+            if length($data) != 1;
+        TLSProxy::Certificate->client_type(unpack("C", $data));
+    }
+    if (defined($exts) && defined(my $data = $exts->{TLSProxy::Message::EXT_SERVER_CERT_TYPE})) {
+        die "Invalid server certificate type extension\n"
+            if length($data) != 1;
+        TLSProxy::Certificate->server_type(unpack("C", $data));
     }
     return $self->{extension_data};
 }


### PR DESCRIPTION
Makes it easier to exercise the RPK functionality via the command line utilities.

* Adds support for RPKs in TLSProxy
* Fixes a bug in SSL tracing when attempting to print TLS 1.2 RPKs.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
