### PR TITLE
4.0: Revert recent deprecation of `X509_cmp_time`, `X509_cmp_current_time`, and `X509_cmp_timeframe`

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -7,7 +7,6 @@
  * https://www.openssl.org/source/license.html
  */
 
-#define OPENSSL_SUPPRESS_DEPRECATED
 #include "internal/deprecated.h"
 
 #include <stdio.h>
@@ -2369,7 +2368,6 @@ static int internal_verify(X509_STORE_CTX *ctx)
     return 1;
 }
 
-#if !defined(OPENSSL_NO_DEPRECATED_4_0)
 int X509_cmp_current_time(const ASN1_TIME *ctm)
 {
     return X509_cmp_time(ctm, NULL);
@@ -2439,7 +2437,6 @@ int X509_cmp_timeframe(const X509_VERIFY_PARAM *vpm,
         return -1;
     return 0;
 }
-#endif /* !defined(OPENSSL_NO_DEPRECATED_4_0) */
 
 ASN1_TIME *X509_gmtime_adj(ASN1_TIME *s, long adj)
 {

--- a/doc/man3/X509_check_certificate_times.pod
+++ b/doc/man3/X509_check_certificate_times.pod
@@ -9,19 +9,15 @@ X509_cmp_time, X509_cmp_current_time, X509_cmp_timeframe - X509 time functions
 
  int X509_check_certificate_times(const X509_VERIFY_PARAM *vpm, const X509 *x,
                                   int *error);
+ int X509_cmp_time(const ASN1_TIME *asn1_time, time_t *in_tm);
+ int X509_cmp_current_time(const ASN1_TIME *asn1_time);
+ int X509_cmp_timeframe(const X509_VERIFY_PARAM *vpm,
+                        const ASN1_TIME *start, const ASN1_TIME *end);
  ASN1_TIME *X509_time_adj(ASN1_TIME *asn1_time, long offset_sec, time_t *in_tm);
  ASN1_TIME *X509_time_adj_ex(ASN1_TIME *asn1_time, int offset_day, long
                              offset_sec, time_t *in_tm);
  ASN1_TIME *X509_gmtime_adj(ASN1_TIME *asn1_time, long offset_sec);
 
-The following functions have been deprecated since OpenSSL 4.0, and can be
-hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
-see L<openssl_user_macros(7)>:
-
- int X509_cmp_time(const ASN1_TIME *asn1_time, time_t *in_tm);
- int X509_cmp_current_time(const ASN1_TIME *asn1_time);
- int X509_cmp_timeframe(const X509_VERIFY_PARAM *vpm,
-                        const ASN1_TIME *start, const ASN1_TIME *end);
 
 =head1 DESCRIPTION
 
@@ -72,12 +68,18 @@ X509_time_adj() with the last parameter as NULL.
 
 =head1 BUGS
 
-Unlike many standard comparison functions, The deprecated functions
+Unlike many standard comparison functions,
 X509_cmp_time() and X509_cmp_current_time() return 0 on error, and
 return -1 when the values are equal.
 
-The deprecated function X509_cmp_timeframe() may accept invalid
-certificate times as infinitely valid.
+X509_cmp_timeframe() may accept invalid certificate times as infinitely valid.
+
+For replacement, consider using X509_check_certificate_times() for use
+with X509 certificates. For applications checking individual ASN1_TIME
+values, consider using ASN1_TIME_to_tm(3) with appropriate validity
+checking of the I<ASN1_TIME> value for your application, and subsequent
+comparison of either the resulting I<tm> structure, or conversion to
+posix seconds via OPENSSL_tm_to_posix(3)
 
 =head1 RETURN VALUES
 
@@ -139,15 +141,7 @@ L<ERR_error_string_n(3)>
 
 =head1 HISTORY
 
-X509_cmp_timeframe(), X509_cmp_current_time(), and
-X509_cmp_timeframe() were deprecated in OpenSSL 4.0
-
-For replacement, consider using X509_check_certificate_times() for use
-with X509 certificates. For applications checking individual ASN1_TIME
-values, consider using ASN1_TIME_to_tm(3) with appropriate validity
-checking of the I<ASN1_TIME> value for your application, and subsequent
-comparison of either the resulting I<tm> structure, or conversion to
-posix seconds via OPENSSL_tm_to_posix(3)
+X509_cmp_timeframe() was added in OpenSSL 3.0.
 
 X509_check_certificate_times() was added in OpenSSL 4.0.
 

--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -49,9 +49,6 @@
 #define OSSL_DEPRECATED_FOR(since, message) __declspec(deprecated)
 #define OSSL_DEPRECATED_MESSAGE(message) __declspec(deprecated)
 #endif
-#define OSSL_BEGIN_ALLOW_DEPRECATED \
-    __pragma(warning(push)) __pragma(warning(disable : 4996))
-#define OSSL_END_ALLOW_DEPRECATED __pragma(warning(pop))
 #elif defined(__GNUC__)
 /*
  * According to GCC documentation, deprecations with message appeared in
@@ -68,20 +65,12 @@
 #define OSSL_DEPRECATED_FOR(since, message) __attribute__((deprecated))
 #define OSSL_DEPRECATED_MESSAGE(message) __attribute__((deprecated))
 #endif
-#define OSSL_BEGIN_ALLOW_DEPRECATED \
-    _Pragma("GCC diagnostic push")  \
-        _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-#define OSSL_END_ALLOW_DEPRECATED _Pragma("GCC diagnostic pop")
 #elif defined(__SUNPRO_C)
 #if (__SUNPRO_C >= 0x5130)
 #define OSSL_DEPRECATED(since) __attribute__((deprecated))
 #define OSSL_DEPRECATED_FOR(since, message) __attribute__((deprecated))
 #define OSSL_DEPRECATED_MESSAGE(message) __attribute__((deprecated))
 #endif
-#define OSSL_BEGIN_ALLOW_DEPRECATED \
-    #pragma error_messages(off, E_DEPRECATED_ATT, E_DEPRECATED_ATT_MESS)
-#define OSSL_END_ALLOW_DEPRECATED \
-    #pragma error_messages(on, E_DEPRECATED_ATT, E_DEPRECATED_ATT_MESS)
 #endif
 #endif
 #endif

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -495,13 +495,10 @@ int X509_ALGOR_copy(X509_ALGOR *dest, const X509_ALGOR *src);
 DECLARE_ASN1_DUP_FUNCTION(X509_NAME)
 DECLARE_ASN1_DUP_FUNCTION(X509_NAME_ENTRY)
 
-#ifndef OPENSSL_NO_DEPRECATED_4_0
-OSSL_DEPRECATEDIN_4_0 int X509_cmp_time(const ASN1_TIME *s, time_t *t);
-OSSL_DEPRECATEDIN_4_0 int X509_cmp_current_time(const ASN1_TIME *s);
-OSSL_DEPRECATEDIN_4_0 int X509_cmp_timeframe(const X509_VERIFY_PARAM *vpm,
-    const ASN1_TIME *start,
-    const ASN1_TIME *end);
-#endif
+int X509_cmp_time(const ASN1_TIME *s, time_t *t);
+int X509_cmp_current_time(const ASN1_TIME *s);
+int X509_cmp_timeframe(const X509_VERIFY_PARAM *vpm,
+    const ASN1_TIME *start, const ASN1_TIME *end);
 int X509_check_certificate_times(const X509_VERIFY_PARAM *vpm, const X509 *x,
     int *error);
 ASN1_TIME *X509_time_adj(ASN1_TIME *s, long adj, time_t *t);

--- a/test/x509_time_test.c
+++ b/test/x509_time_test.c
@@ -214,7 +214,6 @@ static TESTDATA_FORMAT x509_format_tests[] = {
     },
 };
 
-#if !defined(OPENSSL_NO_DEPRECATED_4_0)
 static TESTDATA x509_cmp_tests[] = {
     {
         "20170217180154Z",
@@ -414,9 +413,7 @@ static int test_x509_cmp_time(int idx)
     t.length = (int)strlen(x509_cmp_tests[idx].data);
     t.flags = 0;
 
-    OSSL_BEGIN_ALLOW_DEPRECATED
     result = X509_cmp_time(&t, &x509_cmp_tests[idx].cmp_time);
-    OSSL_END_ALLOW_DEPRECATED
     if (!TEST_int_eq(result, x509_cmp_tests[idx].expected)) {
         TEST_info("test_x509_cmp_time(%d) failed: expected %d, got %d\n",
             idx, x509_cmp_tests[idx].expected, result);
@@ -437,7 +434,6 @@ static int test_x509_cmp_time_current(void)
     asn1_now = ASN1_TIME_adj(NULL, now, 0, 0);
 
     /* X509_cmp_time is expected to return -1 for equal */
-    OSSL_BEGIN_ALLOW_DEPRECATED
     cmp_result = X509_cmp_time(asn1_now, &now);
     if (!TEST_int_eq(cmp_result, -1))
         failed = 1;
@@ -449,7 +445,6 @@ static int test_x509_cmp_time_current(void)
     cmp_result = X509_cmp_time(asn1_after, &now);
     if (!TEST_int_eq(cmp_result, 1))
         failed = 1;
-    OSSL_END_ALLOW_DEPRECATED
 
     ASN1_TIME_free(asn1_before);
     ASN1_TIME_free(asn1_after);
@@ -467,7 +462,6 @@ static int test_X509_cmp_timeframe_vpm(const X509_VERIFY_PARAM *vpm,
         && (X509_VERIFY_PARAM_get_flags(vpm) & X509_V_FLAG_USE_CHECK_TIME) == 0
         && (X509_VERIFY_PARAM_get_flags(vpm) & X509_V_FLAG_NO_CHECK_TIME) != 0;
 
-    OSSL_BEGIN_ALLOW_DEPRECATED
     return asn1_before != NULL && asn1_mid != NULL && asn1_after != NULL
         && TEST_int_eq(X509_cmp_timeframe(vpm, asn1_before, asn1_after), 0)
         && TEST_int_eq(X509_cmp_timeframe(vpm, asn1_before, NULL), 0)
@@ -479,7 +473,6 @@ static int test_X509_cmp_timeframe_vpm(const X509_VERIFY_PARAM *vpm,
             always_0 ? 0 : 1)
         && TEST_int_eq(X509_cmp_timeframe(vpm, asn1_after, asn1_before),
             always_0 ? 0 : 1);
-    OSSL_END_ALLOW_DEPRECATED
 }
 
 static int test_X509_cmp_timeframe(void)
@@ -511,7 +504,6 @@ finish:
 
     return res;
 }
-#endif /* !defined(OPENSSL_NO_DEPRECATED_4_0) */
 
 static int test_x509_time(int idx)
 {
@@ -757,11 +749,9 @@ err:
 
 int setup_tests(void)
 {
-#if !defined(OPENSSL_NO_DEPRECATED_4_0)
     ADD_TEST(test_x509_cmp_time_current);
     ADD_TEST(test_X509_cmp_timeframe);
     ADD_ALL_TESTS(test_x509_cmp_time, OSSL_NELEM(x509_cmp_tests));
-#endif /* !defined(OPENSSL_NO_DEPRECATED_4_0) */
     ADD_ALL_TESTS(test_x509_time, OSSL_NELEM(x509_format_tests));
     ADD_ALL_TESTS(test_days, OSSL_NELEM(day_of_week_tests));
     ADD_ALL_TESTS(test_x509_time_print_rfc_822, OSSL_NELEM(x509_print_tests_rfc_822));

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4398,9 +4398,9 @@ X509_ALGOR_cmp                          ?	4_0_0	EXIST::FUNCTION:
 X509_ALGOR_copy                         ?	4_0_0	EXIST::FUNCTION:
 X509_NAME_dup                           ?	4_0_0	EXIST::FUNCTION:
 X509_NAME_ENTRY_dup                     ?	4_0_0	EXIST::FUNCTION:
-X509_cmp_time                           ?	4_0_0	EXIST::FUNCTION:DEPRECATEDIN_4_0
-X509_cmp_current_time                   ?	4_0_0	EXIST::FUNCTION:DEPRECATEDIN_4_0
-X509_cmp_timeframe                      ?	4_0_0	EXIST::FUNCTION:DEPRECATEDIN_4_0
+X509_cmp_time                           ?	4_0_0	EXIST::FUNCTION:
+X509_cmp_current_time                   ?	4_0_0	EXIST::FUNCTION:
+X509_cmp_timeframe                      ?	4_0_0	EXIST::FUNCTION:
 X509_check_certificate_times            ?	4_0_0	EXIST::FUNCTION:
 X509_time_adj                           ?	4_0_0	EXIST::FUNCTION:
 X509_time_adj_ex                        ?	4_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
This (together with #30088) acts as a quick fix of #29638 as [discussed there](https://github.com/openssl/openssl/issues/29638#issuecomment-3927792539).
