### PR TITLE
Constify X509_find_by_subject

### DIFF
--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -361,7 +361,7 @@ X509 *X509_find_by_issuer_and_serial(const STACK_OF(X509) *sk, const X509_NAME *
     return NULL;
 }
 
-X509 *X509_find_by_subject(const STACK_OF(X509) *sk, const X509_NAME *name)
+const X509 *X509_find_by_subject(const STACK_OF(X509) *sk, const X509_NAME *name)
 {
     X509 *x509;
     int i;
@@ -369,7 +369,7 @@ X509 *X509_find_by_subject(const STACK_OF(X509) *sk, const X509_NAME *name)
     for (i = 0; i < sk_X509_num(sk); i++) {
         x509 = sk_X509_value(sk, i);
         if (X509_NAME_cmp(X509_get_subject_name(x509), name) == 0)
-            return x509;
+            return (const X509 *)x509;
     }
     return NULL;
 }

--- a/doc/man3/OCSP_resp_find_status.pod
+++ b/doc/man3/OCSP_resp_find_status.pod
@@ -37,7 +37,7 @@ OCSP_check_validity, OCSP_basic_verify
  const OCSP_RESPDATA *OCSP_resp_get0_respdata(const OCSP_BASICRESP *bs);
  const STACK_OF(X509) *OCSP_resp_get0_certs(const OCSP_BASICRESP *bs);
 
- int OCSP_resp_get0_signer(OCSP_BASICRESP *bs, X509 **signer,
+ int OCSP_resp_get0_signer(OCSP_BASICRESP *bs, const X509 **signer,
                            STACK_OF(X509) *extra_certs);
 
  int OCSP_resp_get0_id(const OCSP_BASICRESP *bs,
@@ -207,6 +207,10 @@ L<OCSP_REQUEST_new(3)>,
 L<OCSP_response_status(3)>,
 L<OCSP_sendreq_new(3)>,
 L<X509_VERIFY_PARAM_set_flags(3)>
+
+=head1 HISTORY
+
+OCSP_resp_get0_signer() was constified in OpenSSL 4.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/ocsp.h.in
+++ b/include/openssl/ocsp.h.in
@@ -232,7 +232,7 @@ OCSP_BASICRESP *OCSP_response_get1_basic(OCSP_RESPONSE *resp);
 const ASN1_OCTET_STRING *OCSP_resp_get0_signature(const OCSP_BASICRESP *bs);
 const X509_ALGOR *OCSP_resp_get0_tbs_sigalg(const OCSP_BASICRESP *bs);
 const OCSP_RESPDATA *OCSP_resp_get0_respdata(const OCSP_BASICRESP *bs);
-int OCSP_resp_get0_signer(OCSP_BASICRESP *bs, X509 **signer,
+int OCSP_resp_get0_signer(OCSP_BASICRESP *bs, const X509 **signer,
     const STACK_OF(X509) *extra_certs);
 
 int OCSP_resp_count(OCSP_BASICRESP *bs);

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -1024,7 +1024,7 @@ int EVP_PKEY_add1_attr_by_txt(EVP_PKEY *key,
 /* lookup a cert from a X509 STACK */
 X509 *X509_find_by_issuer_and_serial(const STACK_OF(X509) *sk, const X509_NAME *name,
     const ASN1_INTEGER *serial);
-X509 *X509_find_by_subject(const STACK_OF(X509) *sk, const X509_NAME *name);
+const X509 *X509_find_by_subject(const STACK_OF(X509) *sk, const X509_NAME *name);
 
 DECLARE_ASN1_FUNCTIONS(PBEPARAM)
 DECLARE_ASN1_FUNCTIONS(PBE2PARAM)

--- a/test/ocspapitest.c
+++ b/test/ocspapitest.c
@@ -112,7 +112,8 @@ err:
 static int test_resp_signer(void)
 {
     OCSP_BASICRESP *bs = NULL;
-    X509 *signer = NULL, *tmp;
+    X509 *signer = NULL;
+    const X509 *tmp;
     EVP_PKEY *key = NULL;
     STACK_OF(X509) *extra_certs = NULL;
     int ret = 0;


### PR DESCRIPTION
Transitively, this also requires the constification of OCSP_resp_get0_signer

Note: Please pay extra attention to the constification of OCSP_resp_get0_signer().  I'm not sure if what we want there is:
```
const X509 **signer
```
or
```
X509 * const *signer
```

