### PR TITLE
Return the correct error message in ossl_X509_print_ex_brief

### DIFF
--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -404,10 +404,9 @@ int ossl_x509_print_ex_brief(BIO *bio, X509 *cert, unsigned long neg_cflags)
         goto err;
 
     if (!X509_check_certificate_times(vpm, cert, &error)) {
-        char msg[128];
-
-        ERR_error_string_n(error, msg, sizeof(msg));
-        if (BIO_printf(bio, "        %s\n", msg) <= 0)
+        if (BIO_printf(bio, "        %s\n",
+                X509_verify_cert_error_string(error))
+            <= 0)
             goto err;
     }
     ret = X509_print_ex(bio, cert, flags,

--- a/doc/man3/X509_check_certificate_times.pod
+++ b/doc/man3/X509_check_certificate_times.pod
@@ -135,7 +135,7 @@ L<ASN1_GENERALIZEDTIME_check(3)>
 L<ASN1_UTCTIME_check(3)>
 L<ASN1_TIME_to_tm(3)>
 L<OPENSSL_tm_to_posix(3)> L<OPENSSL_posix_to_tm(3)>
-L<ERR_error_string_n(3)>
+L<X509_verify_cert_error_string(3)>
 
 =head1 HISTORY
 


### PR DESCRIPTION
X509_verify_cert_times returns a verify error code, so X509_verify_cert_error_string() must be used to convert it to text.

Remove erroneous man page xref to ERR_error_string_n

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
