### PR TITLE
Fix Windows nmake clean target removing test-runs directory. 

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -72,6 +72,7 @@ OPTIONS={- $config{options} -}
 CONFIGURE_ARGS=({- join(", ",quotify_l(@{$config{perlargv}})) -})
 SRCDIR={- $config{sourcedir} -}
 BLDDIR={- $config{builddir} -}
+RESULT_D=$(BLDDIR)/test-runs
 FIPSKEY={- $config{FIPSKEY} -}
 
 VERSION={- "$config{full_version}" -}
@@ -637,7 +638,7 @@ clean: libclean ## Clean the workspace, keep the configuration
 	-find . -name '*{- platform->objext() -}' \! -name '.*' \! -type d -exec $(RM) {} \;
 	$(RM) core
 	$(RM) tags TAGS doc-nits md-nits
-	$(RM) -r test/test-runs
+	$(RM) -r $(RESULT_D)
 	$(RM) providers/fips*.new
 	-find . -type l \! -name '.*' \! -path './pkcs11-provider/*' -exec $(RM) {} \;
 

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -38,6 +38,7 @@
 PLATFORM={- $config{target} -}
 SRCDIR={- $config{sourcedir} -}
 BLDDIR={- $config{builddir} -}
+RESULT_D=$(BLDDIR)\test-runs
 FIPSKEY={- $config{FIPSKEY} -}
 
 VERSION={- "$config{full_version}" -}
@@ -464,7 +465,7 @@ clean: libclean
 	-del /Q /S /F *.d *.obj *.pdb *.ilk *.manifest
 	-del /Q /S /F apps\*.lib apps\*.rc apps\*.res apps\*.exp
 	-del /Q /S /F test\*.exp
-	-rd /Q /S test-runs 2>NUL
+	-@if exist "$(RESULT_D)" rd /Q /S "$(RESULT_D)"
 
 distclean: clean
 	-del /Q /F include\openssl\configuration.h


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

"Fixes #29931"

Problem:
On Windows, `nmake clean` attempts to remove `test\test-runs`,
but the actual directory created by the test suite is `test-runs`
at the repository root.

This results in clean reporting:
"The system cannot find the file specified"
while leaving the real test artifacts intact.

Solution:
Updated the Windows clean target to remove the correct directory:

rd /Q /S test-runs 2>NUL

The stderr redirection prevents unnecessary errors when the
directory does not exist, matching expected clean behavior.

Result:
`nmake clean` now correctly removes test artifacts.


Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated

