### PR TITLE
OpenSSL Enforcing no-Scrypt Tag

### DIFF
--- a/test/recipes/20-test_cli_list.t
+++ b/test/recipes/20-test_cli_list.t
@@ -13,7 +13,9 @@ use OpenSSL::Test qw/:DEFAULT bldtop_file srctop_file bldtop_dir with/;
 use OpenSSL::Test::Utils;
 
 setup("test_cli_list");
-plan tests => 4;
+
+plan tests => 12;
+
 my $fipsconf = srctop_file("test", "fips-and-base.cnf");
 my $defaultconf = srctop_file("test", "default.cnf");
 
@@ -29,7 +31,91 @@ sub check_skey_manager_list {
        "Several skey managers are listed - $provider provider");
 }
 
+# Checks a list of algorithms for any disabled algorithms
+sub check_list_against_disabled {
+    my ($algorithms_ref, $validator, $list_name) = @_;
+    my @algorithms = @$algorithms_ref;
+    my @disabled = run(app(["openssl", "list", "-disabled"]), capture => 1);
+
+    chomp @algorithms;
+    chomp @disabled;
+    my $unmatched = 1;
+    foreach my $manager (@algorithms){
+      foreach my $algorithm (@disabled) {
+        if (!$validator->($manager, $algorithm)) {
+          print "Disabled algorithm found in $list_name list: $algorithm\n";
+        }
+        $unmatched = $unmatched && $validator->($manager, $algorithm);    
+      }
+    }
+    ok($unmatched, "No disabled algorithms appear in ".$list_name." list");
+}
+
+# Checks the key manager list for any disabled algorithms
+sub check_key_manager_list {
+    my @keymanagers = run(app(["openssl", "list", "-key-managers"]), capture => 1);
+    my $validator = sub {return !($_[0] =~ /IDs:.*\b\Q$_[1]\E\b/)};
+    check_list_against_disabled(\@keymanagers, $validator, "key manager");
+}
+
+# Checks the public key algorithms list for any disabled algorithms
+sub check_public_key_algorithms_list {
+    my @pkalgorithms = run(app(["openssl", "list", "-public-key-algorithms"]), capture => 1);
+    my $validator = sub {return !($_[0] =~ /IDs:.*\b\Q$_[1]\E\b/)};
+    check_list_against_disabled(\@pkalgorithms, $validator, "public key algorithms");
+}
+
+# Checks the key exchange algorithms list for any disabled algorithms
+sub check_key_exchange_algorithms_list {
+    my @pkalgorithms = run(app(["openssl", "list", "-key-exchange-algorithms"]), capture => 1);
+    my $validator = sub {return !($_[0] =~ /{.*[0-9],.*\b\Q$_[1]\E\b/)};
+    check_list_against_disabled(\@pkalgorithms, $validator, "key exchange algorithms");
+}
+
+# Checks the mac algorithms list for any disabled algorithms
+sub check_mac_algorithms_list {
+    my @pkalgorithms = run(app(["openssl", "list", "-mac-algorithms"]), capture => 1);
+    my $validator = sub {return !($_[0] =~ /{.*[0-9],.*\b\Q$_[1]\E\b/)};
+    check_list_against_disabled(\@pkalgorithms, $validator, "mac algorithms");
+}
+
+# Checks the cipher algorithms list for any disabled algorithms
+sub check_cipher_algorithms_list {
+    my @pkalgorithms = run(app(["openssl", "list", "-cipher-algorithms"]), capture => 1);
+    my $validator = sub { return !($_[0] =~ /{.*[0-9],.*\b\Q$_[1]\E\b/) };
+    check_list_against_disabled(\@pkalgorithms, $validator, "cipher algorithms");
+}
+
+# Checks the kem algorithms list for any disabled algorithms
+sub check_kem_algorithms_list {
+    my @pkalgorithms = run(app(["openssl", "list", "-kem-algorithms"]), capture => 1);
+    my $validator = sub { return !($_[0] =~ /{.*[0-9],.*\b\Q$_[1]\E\b/) };
+    check_list_against_disabled(\@pkalgorithms, $validator, "kem algorithms");
+}
+
+# Checks the signature algorithms list for any disabled algorithms
+sub check_signature_algorithms_list {
+    my @pkalgorithms = run(app(["openssl", "list", "-signature-algorithms"]), capture => 1);
+    my $validator = sub { return !($_[0] =~ /{.*[0-9],.*\b\Q$_[1]\E\b/) };
+    check_list_against_disabled(\@pkalgorithms, $validator, "signature algorithms");
+}
+
+# Checks the asymcipher algorithms list for any disabled algorithms
+sub check_asymcipher_algorithms_list {
+    my @pkalgorithms = run(app(["openssl", "list", "-asymcipher-algorithms"]), capture => 1);
+    my $validator = sub { return !($_[0] =~ /{.*[0-9],.*\b\Q$_[1]\E\b/) };
+    check_list_against_disabled(\@pkalgorithms, $validator, "asymcipher algorithms");
+}
+
 check_skey_manager_list("default");
+check_key_manager_list();
+check_public_key_algorithms_list();
+check_key_exchange_algorithms_list();
+check_mac_algorithms_list();
+check_cipher_algorithms_list();
+check_kem_algorithms_list();
+check_signature_algorithms_list();
+check_asymcipher_algorithms_list();
 
 SKIP: {
     my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);


### PR DESCRIPTION
FIXES: #29513 

In OpenSSL 3.5.4 when configured with no-scrypt tag, scrypt is still listed as available in these following commands:

`openssl list -key-managers`
`openssl list -public-key-algorithms`

We (@ocapraro @emmieono) solved this bug by adding #ifndef to `defltprov.c` and added tests to crosscheck the key managers and public key algorithms list with the disabled list.

## Before
```c
...
{ PROV_NAMES_SCRYPT, "provider=default", ossl_kdf_keymgmt_functions, PROV_DESCS_SCRYPT_SIGN },
...
```

## After
```c
...
#ifndef OPENSSL_NO_SCRYPT
    { PROV_NAMES_SCRYPT, "provider=default", ossl_kdf_keymgmt_functions,
        PROV_DESCS_SCRYPT_SIGN },
#endif
...
```

Checklist
- [X] tests are added or updated
