### PR TITLE
Add BIO_sendfile()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -156,6 +156,11 @@ OpenSSL Releases
 
    *Norbert Pócs*
 
+ * Added `BIO_sendfile()` function. The `SSL_sendfile()` function doesn't call
+   `sendfile()` directly and delegates to the BIO instead.
+
+   *Julien Portalier*
+
 ### Changes between 3.6 and 4.0.0 [14 Apr 2026]
 
  * Added `-expected-rpks` option to the `openssl s_client`

--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -405,6 +405,47 @@ int BIO_write_ex(BIO *b, const void *data, size_t dlen, size_t *written)
         || (b != NULL && dlen == 0); /* order is important for *written */
 }
 
+ossl_ssize_t BIO_sendfile(BIO *b, int fd, off_t offset, size_t size, int flags)
+{
+#ifdef OPENSSL_NO_KTLS
+    ERR_raise_data(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR,
+        "can't call BIO_sendfile method, ktls disabled");
+    return -1;
+#else
+    ossl_ssize_t ret;
+    size_t written = 0;
+
+    if (b->method == NULL || b->method->bsendfile == NULL) {
+        ERR_raise(ERR_LIB_BIO, BIO_R_UNSUPPORTED_METHOD);
+        return -2;
+    }
+
+    if (!b->init || !BIO_get_ktls_send(b)) {
+        ERR_raise(ERR_LIB_BIO, BIO_R_UNINITIALIZED);
+        return -1;
+    }
+
+    if (HAS_CALLBACK(b)) {
+        ret = (ossl_ssize_t)bio_call_callback(b, BIO_CB_SENDFILE,
+            NULL, size, fd, (long)offset, 1, NULL);
+        if (ret < 0)
+            return 0;
+    }
+
+    ret = b->method->bsendfile(b, fd, offset, size, flags);
+
+    if (ret >= 0)
+        written = ret;
+
+    if (HAS_CALLBACK(b)) {
+        ret = (ossl_ssize_t)bio_call_callback(b, BIO_CB_SENDFILE | BIO_CB_RETURN,
+            NULL, size, fd, (long)offset, (long)ret, &written);
+    }
+
+    return ret;
+#endif
+}
+
 int BIO_sendmmsg(BIO *b, BIO_MSG *msg,
     size_t stride, size_t num_msg, uint64_t flags,
     size_t *msgs_processed)

--- a/crypto/bio/bio_meth.c
+++ b/crypto/bio/bio_meth.c
@@ -275,3 +275,16 @@ int (*BIO_meth_get_recvmmsg(const BIO_METHOD *biom))(BIO *, BIO_MSG *, size_t, s
     return biom->brecvmmsg;
 }
 #endif
+
+int BIO_meth_set_sendfile(BIO_METHOD *biom,
+    ossl_ssize_t (*bsendfile)(BIO *, int, off_t, size_t, int))
+{
+#ifdef OPENSSL_NO_KTLS
+    ERR_raise_data(ERR_LIB_BIO, ERR_R_INTERNAL_ERROR,
+        "can't set BIO sendfile method, ktls disabled");
+    return 0;
+#else
+    biom->bsendfile = bsendfile;
+    return 1;
+#endif
+}

--- a/crypto/bio/bss_sock.c
+++ b/crypto/bio/bss_sock.c
@@ -44,6 +44,9 @@ static long sock_ctrl(BIO *h, int cmd, long arg1, void *arg2);
 static int sock_new(BIO *h);
 static int sock_free(BIO *data);
 int BIO_sock_should_retry(int s);
+#ifndef OPENSSL_NO_KTLS
+static ossl_ssize_t sock_sendfile(BIO *b, int fd, off_t offset, size_t size, int flags);
+#endif
 
 static const BIO_METHOD methods_sockp = {
     BIO_TYPE_SOCKET,
@@ -58,6 +61,11 @@ static const BIO_METHOD methods_sockp = {
     sock_new,
     sock_free,
     NULL, /* sock_callback_ctrl */
+    NULL, /* sock_sendmmsg */
+    NULL, /* sock_recvmmsg */
+#ifndef OPENSSL_NO_KTLS
+    sock_sendfile,
+#endif
 };
 
 const BIO_METHOD *BIO_s_socket(void)
@@ -294,6 +302,26 @@ static int sock_puts(BIO *bp, const char *str)
     ret = sock_write(bp, str, (int)n);
     return ret;
 }
+
+#ifndef OPENSSL_NO_KTLS
+static ossl_ssize_t sock_sendfile(BIO *b, int fd, off_t offset, size_t size, int flags)
+{
+    ossl_ssize_t sbytes;
+    int ret;
+
+    ret = ktls_sendfile(b->num, fd, offset, size, &sbytes, flags);
+    BIO_clear_retry_flags(b);
+    if (ret < 0) {
+        if (BIO_sock_should_retry(ret)) {
+            BIO_set_retry_write(b);
+            return (sbytes > 0 ? sbytes : ret);
+        } else
+            ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
+                "ktls_sendfile failure");
+    }
+    return sbytes;
+}
+#endif
 
 int BIO_sock_should_retry(int i)
 {

--- a/doc/man3/BIO_meth_new.pod
+++ b/doc/man3/BIO_meth_new.pod
@@ -10,7 +10,8 @@ BIO_meth_set_puts, BIO_meth_get_gets, BIO_meth_set_gets, BIO_meth_get_ctrl,
 BIO_meth_set_ctrl, BIO_meth_get_create, BIO_meth_set_create,
 BIO_meth_get_destroy, BIO_meth_set_destroy, BIO_meth_get_callback_ctrl,
 BIO_meth_set_callback_ctrl, BIO_meth_set_sendmmsg, BIO_meth_get_sendmmsg,
-BIO_meth_set_recvmmsg, BIO_meth_get_recvmmsg - Routines to build up BIO methods
+BIO_meth_set_recvmmsg, BIO_meth_get_recvmmsg, BIO_meth_set_sendfile
+- Routines to build up BIO methods
 
 =head1 SYNOPSIS
 
@@ -50,6 +51,9 @@ BIO_meth_set_recvmmsg, BIO_meth_get_recvmmsg - Routines to build up BIO methods
  int BIO_meth_set_recvmmsg(BIO_METHOD *biom,
                            ossl_ssize_t (*f) (BIO *, BIO_MSG *, size_t,
                                               size_t, uint64_t));
+
+ int BIO_meth_set_sendfile(BIO_METHOD *biom,
+                           ossl_ssize_t (*f)(BIO *, int, off_t, size_t, int));
 
 The following functions have been deprecated since OpenSSL 3.5:
 
@@ -197,6 +201,10 @@ BIO_meth_set_recvmmsg() get and set the functions used for handling
 BIO_sendmmsg() and BIO_recvmmsg() calls respectively. See L<BIO_sendmmsg(3)> for
 more information.
 
+BIO_meth_set_sendfile() sets the function used for handling BIO_sendfile() when
+Kernel TLS support has been compiled in, and it is supported by the negotiated
+ciphersuites and extensions.
+
 =head1 RETURN VALUES
 
 BIO_get_new_index() returns the new BIO type value or -1 if an error occurred.
@@ -225,6 +233,8 @@ L<bio(7)>, L<BIO_find_type(3)>, L<BIO_ctrl(3)>, L<BIO_read_ex(3)>, L<BIO_new(3)>
 
 The functions BIO_meth_get_sendmmsg(), BIO_meth_set_sendmmsg(),
 BIO_meth_get_recvmmsg() and BIO_meth_set_recvmmsg() were added in OpenSSL 3.2.
+
+The BIO_meth_set_sendfile() function was added in OpenSSL 4.1.
 
 All the other functions described here were added in OpenSSL 1.1.0.
 

--- a/doc/man3/BIO_read.pod
+++ b/doc/man3/BIO_read.pod
@@ -3,7 +3,7 @@
 =head1 NAME
 
 BIO_read_ex, BIO_write_ex, BIO_read, BIO_write,
-BIO_gets, BIO_get_line, BIO_puts
+BIO_gets, BIO_get_line, BIO_puts, BIO_sendfile
 - BIO I/O functions
 
 =head1 SYNOPSIS
@@ -18,6 +18,7 @@ BIO_gets, BIO_get_line, BIO_puts
  int BIO_get_line(BIO *b, char *buf, int size);
  int BIO_write(BIO *b, const void *data, int dlen);
  int BIO_puts(BIO *b, const char *buf);
+ ossl_ssize_t BIO_sendfile(BIO *b, int fd, off_t offset, size_t size, int flags);
 
 =head1 DESCRIPTION
 
@@ -55,6 +56,14 @@ BIO_write() attempts to write I<len> bytes from I<buf> to BIO I<b>.
 BIO_puts() attempts to write a NUL-terminated string I<buf> to BIO I<b>,
 without the terminating NUL byte and without appending '\n'
 (so, similar to fputs(3), and not puts(3)).
+
+BIO_sendfile() writes B<size> bytes from offset B<offset> in the file
+descriptor B<fd> to the specified BIO B<b>. This function provides
+efficient zero-copy semantics. BIO_sendfile() is available only when
+Kernel TLS is enabled, which can be checked by calling BIO_get_ktls_send().
+It is provided here to allow users to maintain the same interface.
+The meaning of B<flags> is platform dependent.
+Currently, under Linux it is ignored.
 
 =head1 RETURN VALUES
 
@@ -123,6 +132,8 @@ BIO_get_line() was added in OpenSSL 3.0.
 
 BIO_write_ex() returns 1 if the size of the data to write is 0 and the
 I<written> parameter of the function can be NULL since OpenSSL 3.0.
+
+BIO_sendfile() was added in OpenSSL 4.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/BIO_set_callback.pod
+++ b/doc/man3/BIO_set_callback.pod
@@ -83,7 +83,7 @@ operation, the latter case has B<oper> or'ed with BIO_CB_RETURN.
 =item B<len>
 
 The length of the data requested to be read or written. This is only useful if
-B<oper> is BIO_CB_READ, BIO_CB_WRITE or BIO_CB_GETS.
+B<oper> is BIO_CB_READ, BIO_CB_WRITE, BIO_CB_GETS or BIO_CB_SENDFILE.
 
 =item B<argp> B<argi> B<argl>
 
@@ -94,7 +94,7 @@ the value of B<oper>, that is the operation being performed.
 
 B<processed> is a pointer to a location which will be updated with the amount of
 data that was actually read or written. Only used for BIO_CB_READ, BIO_CB_WRITE,
-BIO_CB_GETS and BIO_CB_PUTS.
+BIO_CB_GETS, BIO_CB_PUTS and BIO_CB_SENDFILE.
 
 =item B<ret>
 
@@ -200,6 +200,24 @@ is called before the operation and
 or
 
  callback(b, BIO_CB_PUTS|BIO_CB_RETURN, buf, 0, 0L, retvalue)
+
+after.
+
+=item B<BIO_sendfile(b, fd, offset, size, flags)>
+
+ callback_ex(b, BIO_CB_SENDFILE, NULL, size, fd, offset, 1L, NULL)
+
+or
+
+ callback(b, BIO_CB_SENDFILE, NULL, fd, offset, 1L)
+
+is called before the operation and
+
+ callback_ex(b, BIO_CB_SENDFILE | BIO_CB_RETURN, NULL, size, fd, offset, retvalue, &written)
+
+or
+
+ callback(b, BIO_CB_SENDFILE|BIO_CB_RETURN, NULL, fd, offset, retvalue)
 
 after.
 

--- a/include/internal/bio.h
+++ b/include/internal/bio.h
@@ -29,6 +29,9 @@ struct bio_method_st {
     long (*callback_ctrl)(BIO *, int, BIO_info_cb *);
     int (*bsendmmsg)(BIO *, BIO_MSG *, size_t, size_t, uint64_t, size_t *);
     int (*brecvmmsg)(BIO *, BIO_MSG *, size_t, size_t, uint64_t, size_t *);
+#ifndef OPENSSL_NO_KTLS
+    ossl_ssize_t (*bsendfile)(BIO *, int, off_t, size_t, int);
+#endif
 };
 
 void bio_free_ex_data(BIO *bio);

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -306,6 +306,7 @@ void BIO_clear_flags(BIO *b, int flags);
 #define BIO_CB_CTRL 0x06
 #define BIO_CB_RECVMMSG 0x07
 #define BIO_CB_SENDMMSG 0x08
+#define BIO_CB_SENDFILE 0x09
 
 /*
  * The callback is called before and after the underling operation, The
@@ -739,6 +740,7 @@ __owur int BIO_sendmmsg(BIO *b, BIO_MSG *msg,
     size_t *msgs_processed);
 __owur int BIO_get_rpoll_descriptor(BIO *b, BIO_POLL_DESCRIPTOR *desc);
 __owur int BIO_get_wpoll_descriptor(BIO *b, BIO_POLL_DESCRIPTOR *desc);
+ossl_ssize_t BIO_sendfile(BIO *b, int fd, off_t offset, size_t size, int flags);
 int BIO_puts(BIO *bp, const char *buf);
 int BIO_indent(BIO *b, int indent, int max);
 long BIO_ctrl(BIO *bp, int cmd, long larg, void *parg);
@@ -987,6 +989,8 @@ int BIO_meth_set_destroy(BIO_METHOD *biom, int (*destroy)(BIO *));
 int BIO_meth_set_callback_ctrl(BIO_METHOD *biom,
     long (*callback_ctrl)(BIO *, int,
         BIO_info_cb *));
+int BIO_meth_set_sendfile(BIO_METHOD *biom,
+    ossl_ssize_t (*f)(BIO *, int, off_t, size_t, int));
 #ifndef OPENSSL_NO_DEPRECATED_3_5
 OSSL_DEPRECATEDIN_3_5 int (*BIO_meth_get_write(const BIO_METHOD *biom))(BIO *, const char *,
     int);

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -221,6 +221,7 @@ typedef INTN ossl_ssize_t;
 #endif
 
 #ifdef _WIN32
+#include <sys/types.h>
 #ifdef _WIN64
 typedef int64_t ossl_ssize_t;
 #define OSSL_SSIZE_MAX INT64_MAX

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2734,10 +2734,7 @@ int ssl_write_internal(SSL *s, const void *buf, size_t num,
 ossl_ssize_t SSL_sendfile(SSL *s, int fd, off_t offset, size_t size, int flags)
 {
     SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL_ONLY(s);
-#ifndef OPENSSL_NO_KTLS
-    ossl_ssize_t sbytes;
-#endif
-    int ret;
+    ossl_ssize_t ret;
 
     if (sc == NULL)
         return 0;
@@ -2793,22 +2790,16 @@ ossl_ssize_t SSL_sendfile(SSL *s, int fd, off_t offset, size_t size, int flags)
     sc->statem.error_state = ERROR_STATE_SSL;
     return -1;
 #else
-    ret = ktls_sendfile(SSL_get_wfd(s), fd, offset, size, &sbytes, flags);
+    ret = BIO_sendfile(sc->wbio, fd, offset, size, flags);
     ssl_update_error_state(sc);
-    BIO_clear_retry_flags(sc->wbio);
-    if (ret < 0) {
-        if (BIO_sock_should_retry(ret)) {
-            BIO_set_retry_write(sc->wbio);
-            return (sbytes > 0 ? sbytes : ret);
-        } else {
-            ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
-                "ktls_sendfile failure");
-            sc->statem.error_state = ERROR_STATE_SYSCALL;
-        }
+    if (ret < 0 && !BIO_should_retry(sc->wbio)) {
+        ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
+            "ktls_sendfile failure");
+        sc->statem.error_state = ERROR_STATE_SYSCALL;
         return ret;
     }
     sc->rwstate = SSL_NOTHING;
-    return sbytes;
+    return ret;
 #endif
 }
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5715,6 +5715,8 @@ OPENSSL_sk_set_cmp_thunks               5712	4_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_set1                    5713	4_0_0	EXIST::FUNCTION:
 OSSL_ESS_check_signing_certs_ex         5714	4_0_0	EXIST::FUNCTION:
 X509v3_delete_extension                 5715	4_0_0	EXIST::FUNCTION:
+BIO_meth_set_sendfile                   ?	4_1_0	EXIST::FUNCTION:
+BIO_sendfile                            ?	4_1_0	EXIST::FUNCTION:
 CTLOG_STORE_add0_log                    ?	4_1_0	EXIST::FUNCTION:CT
 CRYPTO_atomic_load_ptr                  ?	4_1_0	EXIST::FUNCTION:
 CRYPTO_atomic_store_ptr                 ?	4_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
Abstracts the internal implementation of `SSL_sendfile()` to the new configurable `BIO_sendfile()` function, so `SSL_sendfile()` doesn't bypass a custom BIO with direct calls to `sendfile()`.

For consistency reasons I followed the `SSL_sendfile()` function signature that returns an `ossl_ssize_t` instead of following the new _ex functions that return an `int` and take a `size_t *written` argument. Despite the discrepancy the new API might be preferable,  especially after #29744.

Details:
- Added `BIO_meth_set_sendfile()`
- Added `BIO_sendfile()`
- Added `BIO_CB_SENDFILE` for callbacks
- Updated `SSL_sendfile()` to call `BIO_sendfile()`
- Moved retry logic from `SSL_sendfile()` to `BIO_sendfile()`

I didn't add or changed existing tests. `BIO_sendfile()` is indirectly tested through the existing `SSL_sendfile()` tests. I couldn't find explicit tests for the `BIO_meth_set_*` methods, but I might be easily proven wrong.

Fixes #29990

##### Checklist
- [x] documentation is added or updated
- [ ] tests are added or updated