### PR TITLE
Add a REVIEWERS file and a tool to parse it.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,15 @@ OpenSSL 4.0
 
    *Shane Lontis*
 
+ * A REVIEWERS.json file and utility has been added to drive PR review participation
+
+   In an effort to increase community participation in PR reviews, we have
+   added an in-tree file, REVIEWERS.json, that allows people to select areas of
+   the codebase that interest them, so their Github user IDs can be attached to relevant
+   PRs.
+
+   *Neil Horman*
+
  * New `SSL_get0_sigalg()` and `SSL_get0_shared_sigalg()` functions report the
    TLS signature algorithm name and codepoint for the peer advertised and shared
    algorithms respectively.  These supersede the existing `SSL_get_sigalgs()` and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,13 @@
 HOW TO CONTRIBUTE TO OpenSSL
 ============================
 
+Table of Contents
+=================
+
+ - [Reporting issues](#Reporting-Issues)
+ - [Submitting patches](#Submitting-Patches)
+ - [Reviewing patches](#Reviewing-Patches)
+
 Please visit our [Getting Started] page for other ideas about how to contribute.
 
   [Getting Started]: <https://openssl-library.org/community/getting-started>
@@ -9,8 +16,14 @@ Development is done on GitHub in the [openssl/openssl] repository.
 
   [openssl/openssl]: <https://github.com/openssl/openssl>
 
+Reporting Issues
+================
+
 To request a new feature, ask a question, or report a bug,
 please open an [issue on GitHub](https://github.com/openssl/openssl/issues).
+
+Submitting Patches
+==================
 
 To submit a patch or implement a new feature, please open a
 [pull request on GitHub](https://github.com/openssl/openssl/pulls).
@@ -124,3 +137,53 @@ guidelines:
 
  8. Guidelines on how to integrate error output of new crypto library modules
     can be found in [crypto/err/README.md](crypto/err/README.md).
+
+Reviewing Patches
+=================
+
+The OpenSSL project is large, with many areas of code that fall outside the
+subject matter expertise of the core project developers.  In addition to the
+authoring of features and bug fixes for the project, the entire community
+benefits from the review of these changes by other community members.  Any
+participant is welcome and encouraged to participate in the review process by
+commenting on PRs relevant to their expertise.
+
+If you, as a community member wish to gain more visibility on PRs which you
+feel might be relevant to you and your area of expertise, you are welcome to
+add your GitHub user ID to our `REVIEWERS.json` file, by opening a PR to modify
+it.
+
+The `REVIEWERS.json` file is used by our core development team to
+identify those community members who may be interested in changes affecting
+various areas of code.
+
+The `REVIEWERS.json` file is in JSON format, and consists of 3 main sections
+
+The "groups" section:  This is a JSON array consisting of objects that identify
+topics of potential interest (e.g. "ARM/AARCH64" code).  Each group lists the
+set of GitHub user IDs that belong to that group.
+
+The "platform" section: This is a JSON array listing all of the available
+targets that OpenSSL may be built for.  Each platform names groups in the
+group section, identifying those groups interested in that platform.
+
+The "codegroup" section: The "codegroup" section: This section is a JSON array
+containing regex values to match on changed code paths and on content in a
+patch, along with a list of groups from the "groups" section are interested in
+those corresponding changes.
+
+If you have interest in being informed of a given change, so that you can
+better see reviews relevant to your area of interest, feel free to open a PR
+adding your GitBug user ID to a given group.
+
+Note that, none of the groups, platforms, or codegroups list is meant to remain
+static.  If there is an area of code not currently covered by the codegroups
+array, or a platform not covered by the platform array, or if you feel a new
+group is warranted, feel free to open a PR that adds to any of these to better
+reflect your interests.
+
+The core development team can then use the ([util/get_reviewers.py]) utility to
+parse the `REVIEWERS.json` file and more easily identify you as someone who may
+want to participate in a review by mentioning you in the corresponding PR.
+
+[util/get_reviewers.py]: https://github.com/openssl/openssl/blob/master/util/get_reviewers.py

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,8 @@ OpenSSL 4.0
 
 ### Major changes between OpenSSL 3.6 and OpenSSL 4.0 [under development]
 
+  * A REVIEWERS.json file has been added to drive greater participation in reviews
+
   * Support for Encrypted Client Hello (ECH) was added. See `doc/designs/ech-api.md`
     for details.
 

--- a/REVIEWERS.json
+++ b/REVIEWERS.json
@@ -1,0 +1,346 @@
+{
+  "$schema": "https://raw.githubusercontent.com/openssl/openssl/refs/heads/master/REVIEWERS.json#",
+  "groups": [
+    {
+      "name": "committers",
+      "description": "OpenSSL Committers",
+      "github_ids": [
+        "@openssl/committers"
+      ]
+    },
+    {
+      "name": "CMS Code",
+      "description": "Cryptographic Message Syntax experts",
+      "github_ids": [
+        "@DDvO"
+      ]
+    },
+    {
+      "name": "linux-aarch64-platform",
+      "description": "Community maintainers for linux aarch64",
+      "github_ids": [
+        "@tom-cosgrove-arm",
+        "@zorrorffm",
+        "@xkqian"
+      ]
+    },
+    {
+      "name": "nonstop-platform",
+      "description": "Community maintainers for nonstop",
+      "github_ids": [
+        "@rsbeckerca"
+      ]
+    },
+    {
+      "name": "loongarch64",
+      "description": "Community maintainers for loongarch64",
+      "github_ids": [
+        "@shipujin"
+      ]
+    },
+    {
+      "name": "bsd community",
+      "description": "Community maintainrs for BSD platforms",
+      "github_ids": [
+        "@pkubaj"
+      ]
+    },
+    {
+      "name": "solaris community",
+      "description": "Community maintainers for Solaris platforms",
+      "github_ids": [
+        "@orcl-jlana",
+        "@cernoseka"
+      ]
+    },
+    {
+      "name": "s390x community",
+      "description": "Community maintainers for s390x platforms",
+      "github_ids": [
+        "@holger-dengler",
+        "@ifranzki"
+      ]
+    },
+    {
+      "name": "hurd community",
+      "description": "Community maintainers for hurd platforms",
+      "github_ids": [
+        "@sthibaul"
+      ]
+    },
+    {
+      "name": "ios community",
+      "description": "Community maintainers for ios platforms",
+      "github_ids": [
+        "@fwh-dc"
+      ]
+    },
+    {
+      "name": "ppc64le community",
+      "description": "Community maintainers for ppc64le platforms",
+      "github_ids": [
+        "@dannytsen",
+        "@erichte-ibm",
+        "@naynajain"
+      ]
+    },
+    {
+      "name": "riscv community",
+      "description": "Community maintainers for riscv platforms",
+      "github_ids": [
+        "@ZenithalHourlyRate"
+      ]
+    },
+    {
+      "name": "aix community",
+      "description": "Community maintainers for aix platforms",
+      "github_ids": [
+        "@sanumesh"
+      ]
+    },
+    {
+      "name": "BC64 community",
+      "description": "Community maintainers for Windows/Embarcadero platforms",
+      "github_ids": [
+        "@GermanAizek"
+      ]
+    }
+  ],
+  "platforms": [
+    {
+      "name": "All Primary Platforms",
+      "regexs": [
+        "linux-x86.*",
+        "linux-generic.*",
+        "BSD-x86.*",
+        "VC-WIN.*",
+        "mingw64",
+        "darwin64-.*"
+      ],
+      "groups": [
+        "committers"
+      ]
+    },
+    {
+      "name": "Linux AARCH64 Platform",
+      "regexs": [
+        "linux-aarch64"
+      ],
+      "groups": [
+        "committers",
+        "linux-aarch64-platform"
+      ]
+    },
+    {
+      "name": "Nonstop Platforms",
+      "regexs": [
+        "nonstop*"
+      ],
+      "groups": [
+        "committers",
+        "nonstop-platform"
+      ]
+    },
+    {
+      "name": "Loongarch64 Platform",
+      "regexs": [
+        ".*loongarch.*"
+      ],
+      "groups": [
+        "loongarch64",
+        "committers"
+      ]
+    },
+    {
+      "name": "BSD platforms",
+      "regexs": [
+        "BSD-ppc*",
+        "BSD-risc*",
+        "BSD-arm*"
+      ],
+      "groups": [
+        "bsd community",
+        "committers"
+      ]
+    },
+    {
+      "name": "Solaris platforms",
+      "regexs": [
+        "solaris64-*"
+      ],
+      "groups": [
+        "solaris community",
+        "committers"
+      ]
+    },
+    {
+      "name": "s390x platforms",
+      "regexs": [
+        "linux-s390x*"
+      ],
+      "groups": [
+        "s390x community",
+        "committers"
+      ]
+    },
+    {
+      "name": "hurd platforms",
+      "regexs": [
+        "hurd-*"
+      ],
+      "groups": [
+        "hurd community",
+        "committers"
+      ]
+    },
+    {
+      "name": "ios platforms",
+      "regexs": [
+        "ios*",
+        "iphone*"
+      ],
+      "groups": [
+        "ios community",
+        "committers"
+      ]
+    },
+    {
+      "name": "ppc64le platforms",
+      "regexs": [
+        "linux-ppc64le*"
+      ],
+      "groups": [
+        "ppc64le community",
+        "committers"
+      ]
+    },
+    {
+      "name": "aix platforms",
+      "regexs": [
+        "aix*"
+      ],
+      "groups": [
+        "aix community",
+        "committers"
+      ]
+    },
+    {
+      "name": "aix platforms",
+      "regexs": [
+        "BC-64"
+      ],
+      "groups": [
+        "BC64 community",
+        "committers"
+      ]
+    }
+  ],
+  "codegroups": [
+    {
+      "name": "All OpenSSL Code",
+      "groups": [
+        "committers"
+      ],
+      "filepathregexs": [
+        ".*"
+      ],
+      "filecontentregexs": [
+        ".*"
+      ]
+    },
+    {
+      "name": "CMS Specific code",
+      "groups": [
+        "CMS Code"
+      ],
+      "filepathregexs": [
+        ".*cms.*"
+      ],
+      "filecontentregexs": [
+        ".*cms_.*",
+        ".*CMS_.*"
+      ]
+    },
+    {
+      "name": "RISCV Specific code",
+      "groups": [
+        "riscv community"
+      ],
+      "filepathregexs": [
+        ".*riscv.*"
+      ],
+      "filecontentregexs": [
+        ".*RISCV.*",
+        ".*riscv.*"
+      ]
+    },
+    {
+      "name": "s390x Specific code",
+      "groups": [
+        "s390x community"
+      ],
+      "filepathregexs": [
+        ".*s390.*"
+      ],
+      "filecontentregexs": [
+        ".*s390.*",
+        ".*S390.*"
+      ]
+    },
+    {
+      "name": "loongarch64 specific code",
+      "groups": [
+        "loongarch64"
+      ],
+      "filepathregexs": [
+        ".*loongarch.*"
+      ],
+      "filecontentregexs": [
+        ".*loongarch.*",
+        ".*LOONGARCH.*"
+      ]
+    },
+    {
+      "name": "ARM/AARCH64 specific code",
+      "groups": [
+        "linux-aarch64-platform"
+      ],
+      "filepathregexs": [
+        ".*arm.*",
+        ".*aarch64.*"
+      ],
+      "filecontentregexs": [
+        ".*ARM.*",
+        "_.*arm.*",
+        ".*aarch64.*"
+      ]
+    },
+    {
+      "name": "NonStop specific code",
+      "groups": [
+        "nonstop-platform"
+      ],
+      "filepathregexs": [],
+      "filecontentregexs": [
+        ".*TANDEM.*",
+        ".*Non-Stop.*",
+        ".*NONSTOP.*",
+        ".*_PUT_MODEL_.*",
+        ".*_KLT_MODEL_.*"
+      ]
+    },
+    {
+      "name": "ppc specific code",
+      "groups": [
+        "ppc64le community"
+      ],
+      "filepathregexs": [
+        ".*ppc.*"
+      ],
+      "filecontentregexs": [
+        ".*ppc.*",
+        ".*PPC.*"
+      ]
+    }
+  ]
+}

--- a/REVIEWERS.json.schema
+++ b/REVIEWERS.json.schema
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/openssl/openssl/refs/heads/master/REVIEWERS.json.schema",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "github_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "description",
+          "github_ids",
+          "name"
+        ]
+      }
+    },
+    "platforms": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "regexs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "groups": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "groups",
+          "name",
+          "regexs"
+        ]
+      }
+    },
+    "codegroups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "groups": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "filepathregexs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "filecontentregexs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "filecontentregexs",
+          "filepathregexs",
+          "groups",
+          "name"
+        ]
+      }
+    }
+  },
+  "required": [
+    "$schema",
+    "codegroups",
+    "groups",
+    "platforms"
+  ]
+}

--- a/util/get_reviewers.py
+++ b/util/get_reviewers.py
@@ -1,0 +1,138 @@
+#!/usr/bin/python
+
+import sys
+import json
+import jsonschema
+import argparse
+from unidiff import PatchSet
+import re
+
+def get_group_object(group_name, rev_json):
+    for group in rev_json["groups"]:
+        if group["name"] == group_name:
+            return group
+    return None
+
+def get_patch_reviewers(args, rev_json):
+    patch_set = PatchSet(sys.stdin)
+    ids = []
+    for file in patch_set:
+        for group in rev_json["codegroups"]:
+            for regex in group["filepathregexs"]:
+                match = re.search(regex, file.path)
+                if match:
+                    for idgroup in group["groups"]:
+                        namedgroup = get_group_object(idgroup, rev_json)
+                        if namedgroup != None:
+                            ids = ids + namedgroup["github_ids"] 
+            for regex in group["filecontentregexs"]:
+                match = re.search(regex, str(file))
+                if match:
+                    for idgroup in group["groups"]:
+                        namedgroup = get_group_object(idgroup, rev_json)
+                        if namedgroup != None:
+                            ids = ids + namedgroup["github_ids"] 
+    return ids
+   
+def get_target_reviewers(args, rev_json):
+    ids = []
+    if (args.target == None):
+        return []
+    for platform in rev_json["platforms"]:
+        for regex in platform["regexs"]:
+            match = re.search(regex, args.target)
+            if match:
+                for group in platform["groups"]:
+                    ids = ids + rev_json["groups"][group]["github_ids"]
+    return ids
+
+def load_json_file(filename):
+    try:
+        with open(filename, 'r') as file:
+            return json.load(file)
+    except FileNotFoundError:
+        print(f"Unalbe to load {filename}\n")
+        sys.exit(1)
+    except json.JSONDecodeError:
+        print(f"{filename} is mis-formatted\n")
+        sys.exit(1)
+
+def lint_reviewers(args):
+    rev_json = load_json_file(args.reviewers_file)
+    rev_schema = load_json_file(args.schema)
+    try:
+        jsonschema.validate(instance=rev_json, schema=rev_schema)
+        print(f"{args.reviewers_file} is valid\n")
+    except jsonschema.exceptions.ValidationError as e:
+        print("Invalid JSON data:")
+        print(e)
+        sys.exit(1)
+    # Build a temporary list of groups to do reverse mapping checks
+    grouprefcounts = {}
+    for group in rev_json["groups"]:
+        if group["name"] in grouprefcounts:
+            print(f"Duplicate group name {group["name"]}\n")
+            sys.exit(1)
+        grouprefcounts[group["name"]] = 0
+
+    # Make sure every group listed in all the platforms and 
+    # codegroups arrays is valid
+    for platform in rev_json["platforms"]:
+        for group in platform["groups"]:
+            namedgroup = get_group_object(group, rev_json)
+            if namedgroup != None:
+                grouprefcounts[group] += 1
+            else:
+                print(f"Group {group} does not exist for {platform["name"]}\n")
+                sys.exit(1)
+    for group in rev_json["codegroups"]:
+        for groupid in group["groups"]:
+            namedgroup = get_group_object(groupid, rev_json)
+            if namedgroup != None:
+                grouprefcounts[groupid] += 1
+            else:
+                print(f"Group {groupid} does not exist for {group["name"]}\n")
+                sys.exit(1)
+
+    # Check our group reference counts to note any that are unreferenced
+    for groupkey in grouprefcounts:
+        if grouprefcounts[groupkey] == 0:
+            print(f"NOTE: {groupkey} is unreferenced\n")
+
+    return
+
+def load_and_parse_reviewers(args):
+    reviewers = []
+    rev_json = load_json_file(args.reviewers_file)
+
+    target_reviewers = get_target_reviewers(args, rev_json)
+    reviewers = reviewers + target_reviewers
+    patch_reviewers = get_patch_reviewers(args, rev_json)
+    reviewers = reviewers + patch_reviewers
+    reviewers = list(set(reviewers))
+
+    for reviewer in reviewers:
+        print(f"{reviewer} ")
+
+def main(argv):
+    parser = argparse.ArgumentParser(description="Fetch reviewers")
+
+    parser.add_argument("-r", "--reviewers_file", help="select REVIEWERS file",
+                        default="./REVIEWERS.json")
+    parser.add_argument("-t", "--target", help="specify target")
+    parser.add_argument("-l", "--lint", action='store_true', help="lint REVIEWERS file")
+    parser.add_argument("-s", "--schema", help="select validation schema",
+                        default="./REVIEWERS.json.schema")
+    parser.add_argument("-v", "--verbose", action='store_true', help="verbose parsing output")
+
+    args = parser.parse_args(argv[1:])
+   
+    if args.lint == True:
+        lint_reviewers(args)
+        return 0
+
+    load_and_parse_reviewers(args)
+    return 0
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
We've been talking about trying to increase our community review involvement for a while now to help keep PR's from going stale due to lack of capacity/subject matter expertise/etc:
https://openssl-communities.org/d/DbjtVyEX/reputational-damge-and-reviews

I wanted to try get some traction on improving that situation with this proposal.

Initially we had discussed using githubs CODEOWNERS facility to identify and track individuals who might be relevant for the review of given PR's:
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

Unfortunately, it suffers from what (might be) a fatal flaw. Specifically, from the docs above:

```
People with write permissions for the repository can create or edit the CODEOWNERS file and be listed as code owners.
```

So we can't list people as reviewers who don't have write access to the repository.  Given that we would like to be able to get community members to review PR's that don't have write access to the tree, this seems like a shortcoming.

So instead, I wanted to propose this:

Create a json file that lists data in the following scheema: groups:
   a group is a collection of users that is interested in a given area
   of code
platforms:
   a platform is a build target in the openssl build environment, this
   maps to a list of groups above
codegroups:
   a codegroup is a collection of regexes to search for in paths and
   files within a patch/diff.  A codegroup maps to a list of groups
   to identify users who may be interested in the changes introduced by
   said patch/diff

Along with this file, this PR introduces a new utility utils/get_reviewers.py.  This utiltiy accepts a diff on the command line, parses it, and uses the REVIEWERS file to check for which codegroup regexes match the contents of the diff, returning a list of users (github ids) that would be interested in the changes proposed.

The hope here is that, if this seems workable, we could add a CI job to run on pull request opens to parse the changes in the commits of the pr and add the discovered users to the reviewers list of the PR.

Thoughts?

