### PR TITLE
Return error if testing non-real test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -729,10 +729,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -yq install bison gettext keyutils ldap-utils libldap2-dev libkeyutils-dev python3 python3-paste python3-pyrad slapd tcsh python3-virtualenv virtualenv python3-kdcproxy gdb libtls-dev wget gpg
-    - name: install cpanm and Test2::V0 for gost_engine testing
-      uses: perl-actions/install-with-cpanm@10d60f00b4073f484fc29d45bfbe2f776397ab3d # v1.7
-      with:
-        install: Test2::V0
     - name: setup hostname workaround
       run: sudo hostname localhost
     - name: config
@@ -746,8 +742,6 @@ jobs:
       run: |
         cat /proc/cpuinfo
         ./util/opensslwrap.sh version -c
-    - name: test external gost-engine
-      run: make test TESTS="test_external_gost_engine"
     - name: test external krb5
       run: make test TESTS="test_external_krb5"
     - name: test external tlsfuzzer

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -128,6 +128,7 @@ open $openssl_args{'tap_copy'}, ">$outfilename"
 
 my @alltests = find_matching_tests("*");
 my %tests = ();
+my $has_null_tests = 0;
 
 sub reorder {
     my $key = pop;
@@ -161,11 +162,12 @@ foreach my $arg (@ARGV ? @ARGV : ('alltests')) {
         if ($sign eq '-' && $initial_arg) {
             %tests = map { $_ => 1 } @alltests;
         }
-
+        # Flag if test isn't real so we can return an error.
         if (scalar @matches == 0) {
             warn "Test $test found no match, skipping ",
                 ($sign eq '-' ? "removal" : "addition"),
                 "...\n";
+            $has_null_tests = 1;
         } else {
             foreach $test (@matches) {
                 if ($sign eq '-') {
@@ -391,9 +393,11 @@ if (ref($ret) ne "TAP::Parser::Aggregator" || !$ret->has_errors) {
 
 # If this is a TAP::Parser::Aggregator, $ret->has_errors is the count of
 # tests that failed.  We don't bother with that exact number, just exit
-# with an appropriate exit code when it isn't zero.
+# with an appropriate exit code when it isn't zero. We also make sure 
+# that no non-existent tests are run without signaling an error to the
+# user, so we verify has_null_tests is 0.
 if (ref($ret) eq "TAP::Parser::Aggregator") {
-    exit 0 unless $ret->has_errors;
+    exit 0 unless $ret->has_errors || $has_null_tests;
     exit 1 unless $^O eq 'VMS';
     # On VMS, perl converts an exit 1 to SS$_ABORT (%SYSTEM-F-ABORT), which
     # is a bit harsh.  As per perl recommendations, we explicitly use the


### PR DESCRIPTION
Fixes #15510 
It was requested that an error be returned when running a non-existent test.

We (@mjw6944, @finchsdarwin, @szheng25) added a mechanism for flagging if tests being ran contains a non-existent test, returns an error if at least 1 test is non-existent.

Existing tests will still execute as expected, STDERR will contain messages about missing tests and error.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->