### PR TITLE
Correct the instructions for how to run the krb5 external test.

### DIFF
--- a/test/README-external.md
+++ b/test/README-external.md
@@ -39,7 +39,7 @@ tests against the local OpenSSL build.
 
 You will need a git checkout of krb5 at the top level:
 
-    $ git clone https://github.com/krb5/krb5
+    $ git submodule update --init
 
 krb5's master has to pass this same CI, but a known-good version is
 krb5-1.15.1-final if you want to be sure.


### PR DESCRIPTION

![star-wars-admiral-ackbar](https://github.com/user-attachments/assets/a6080ead-184c-48e6-9cff-1661c3adf5ba)


What is there is a trap. I fell into it. I was sad.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
