### PR TITLE
Better documentation for alternative TLS key/cert support

### DIFF
--- a/doc/man3/SSL_CTX_use_certificate.pod
+++ b/doc/man3/SSL_CTX_use_certificate.pod
@@ -54,6 +54,13 @@ SSL_CTX_use_cert_and_key, SSL_use_cert_and_key
 These functions load the certificates and private keys into the SSL_CTX
 or SSL object, respectively.
 
+Each SSL_CTX or SSL object can hold multiple certificates and
+private key pairs simultaneously, provided they are of different
+key types (for example RSA, ECDSA, Ed25519).
+Certificates and private keys are stored internally by key type;
+loading a new certificate or private key replaces only an existing item
+of the same type and does not affect other configured types.
+
 The SSL_CTX_* class of functions loads the certificates and keys into the
 SSL_CTX object B<ctx>. The information is passed to SSL objects B<ssl>
 created from B<ctx> with L<SSL_new(3)> by copying, so that
@@ -114,6 +121,9 @@ securely, such that it cannot be accessed by OpenSSL.
 The reference counts of B<x>, B<pkey>, and the certificates in B<chain> are
 incremented; the caller should free its own references when they are no
 longer needed.
+This function may be called multiple times to configure multiple
+certificate and private key pairs of different types on the same
+SSL_CTX or SSL object.
 
 SSL_CTX_use_PrivateKey_ASN1() adds the private key of type B<pk>
 stored at memory location B<d> (length B<len>) to B<ctx>.
@@ -132,11 +142,16 @@ RSA key found to B<ssl>. B<ctx> B<MUST NOT> be NULL.
 
 SSL_CTX_check_private_key() checks the consistency of a private key with
 the corresponding certificate loaded into B<ctx>. If more than one
-key/certificate pair (RSA/DSA) is installed, the last item installed will
-be checked. If e.g. the last item was an RSA certificate or key, the RSA
-key/certificate pair will be checked. SSL_check_private_key() performs
-the same check for B<ssl>. If no key/certificate was explicitly added for
-this B<ssl>, the last item added into B<ctx> will be checked.
+key/certificate pair is installed, the last item installed
+will be checked.
+For example, if the last item installed was an RSA certificate or key,
+the RSA key/certificate pair will be checked.
+SSL_check_private_key() performs the same check for B<ssl>.
+If no key/certificate was explicitly added for this B<ssl>,
+the last item added into B<ctx> will be checked.
+
+Applications that load multiple certificate types should call this
+function after configuring each certificate and key pair.
 
 =head1 NOTES
 


### PR DESCRIPTION
doc: expand NOTES to clarify multi-certificate behaviour

Improve the NOTES section of SSL_CTX_use_certificate(3) to clarify that
each SSL_CTX or SSL object maintains its own internal certificate store,
rather than using a global store.

Document that multiple private key/certificate pairs of different key
types (e.g., RSA, ECDSA, or post-quantum algorithms) may be configured
simultaneously on a single context or connection. Explain that OpenSSL
automatically selects the appropriate certificate during the TLS
handshake based on the negotiated protocol version, cipher suite, and
the signature algorithms advertised by the client.

Also clarify that multiple key/certificate pairs are configured by
calling the loading functions multiple times with different key types.

This replaces the previous wording which only stated that certificate
selection depends on the cipher, and did not explain the per-context
store or multi-certificate configuration model.

Fixes #<issue-number>

Signed-off-by: Nigel Joseph ncj2394@rit.edu

- [x] documentation is added or updated

Fixes #28425 
