### PR TITLE
Fix printing of raw public keys in TLS 1.2 SSL traces

### DIFF
--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -1332,6 +1332,7 @@ static int ssl_print_raw_public_key(BIO *bio, const SSL_CONNECTION *sc,
     int server, int indent, const unsigned char **pmsg, size_t *pmsglen)
 {
     EVP_PKEY *pkey;
+    SSL_CTX *ctx = SSL_CONNECTION_GET_CTX(sc);
     size_t clen;
     const unsigned char *msg = *pmsg;
     size_t msglen = *pmsglen;
@@ -1362,8 +1363,7 @@ static int ssl_print_raw_public_key(BIO *bio, const SSL_CONNECTION *sc,
     BIO_indent(bio, indent, 80);
     BIO_printf(bio, "raw_public_key, length=%d\n", (int)clen);
 
-    pkey = d2i_PUBKEY_ex(NULL, &msg, (long)clen,
-        sc->ssl.ctx->libctx, sc->ssl.ctx->propq);
+    pkey = d2i_PUBKEY_ex(NULL, &msg, (long)clen, ctx->libctx, ctx->propq);
     if (pkey == NULL)
         return 0;
     EVP_PKEY_print_public(bio, pkey, indent + 2, NULL);


### PR DESCRIPTION
The wire form of the TLS 1.2 RPK "certificate" message is different in TLS 1.2, with no explicit RPK length inside the extension, because unlike the TLS 1.3 case with TLS 1.2 the SPKI is the entire extension content.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
