### PR TITLE
SM2 digest sign/verify context initialisation fix

### DIFF
--- a/providers/implementations/signature/sm2_sig.c.in
+++ b/providers/implementations/signature/sm2_sig.c.in
@@ -219,6 +219,12 @@ static int sm2sig_digest_signverify_init(void *vpsm2ctx, const char *mdname,
     int ret = 0;
     unsigned char *aid = NULL;
 
+    /*
+     * Each EVP_Digest{Sign,Verify}Init_ex(3) starts with fresh content, that
+     * needs to recompute the "Z" digest.
+     */
+    ctx->flag_compute_z_digest = 1;
+
     if (!sm2sig_signature_init(vpsm2ctx, ec, params)
         || !sm2sig_set_mdname(ctx, mdname))
         return ret;
@@ -251,8 +257,6 @@ static int sm2sig_digest_signverify_init(void *vpsm2ctx, const char *mdname,
 
     if (!EVP_DigestInit_ex2(ctx->mdctx, ctx->md, params))
         goto error;
-
-    ctx->flag_compute_z_digest = 1;
 
     ret = 1;
 


### PR DESCRIPTION
SM digest sign/verify context initialisation needs to set the "compute_z_digest" flag earlier, before calling sm2sig_signature_init(), to process the provided parameters, because otherwise attempts to set the "distinguished identifier" will erroneously fail.

Backport fix from master branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
