### PR TITLE
Fix const qualifiers from strchr where discarded

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -258,15 +258,15 @@ static char *app_get_pass(const char *arg, int keepbio)
             }
         } else {
             /* argument syntax error; do not reveal too much about arg */
-            tmp = strchr(arg, ':');
-            if (tmp == NULL || tmp - arg > PASS_SOURCE_SIZE_MAX)
+            const char *arg_ptr = strchr(arg, ':');
+            if (arg_ptr == NULL || arg_ptr - arg > PASS_SOURCE_SIZE_MAX)
                 BIO_printf(bio_err,
                     "Invalid password argument, missing ':' within the first %d chars\n",
                     PASS_SOURCE_SIZE_MAX + 1);
             else
                 BIO_printf(bio_err,
                     "Invalid password argument, starting with \"%.*s\"\n",
-                    (int)(tmp - arg + 1), arg);
+                    (int)(arg_ptr - arg + 1), arg);
             return NULL;
         }
     }

--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -356,7 +356,7 @@ static CONF_MODULE *module_find(const char *name)
     CONF_MODULE *tmod;
     int i;
     size_t nchar;
-    char *p;
+    const char *p;
     STACK_OF(CONF_MODULE) *mods;
 
     p = strrchr(name, '.');

--- a/crypto/punycode.c
+++ b/crypto/punycode.c
@@ -271,7 +271,7 @@ int ossl_a2ulabel(const char *in, char *out, size_t outlen)
         return -1;
 
     while (1) {
-        char *tmpptr = strchr(inptr, '.');
+        const char *tmpptr = strchr(inptr, '.');
         size_t delta = tmpptr != NULL ? (size_t)(tmpptr - inptr) : strlen(inptr);
 
         if (!HAS_PREFIX(inptr, "xn--")) {

--- a/crypto/x509/v3_cpols.c
+++ b/crypto/x509/v3_cpols.c
@@ -256,7 +256,7 @@ err:
 
 static int displaytext_get_tag_len(const char *tagstr)
 {
-    char *colon = strchr(tagstr, ':');
+    const char *colon = strchr(tagstr, ':');
 
     return (colon == NULL) ? -1 : (int)(colon - tagstr);
 }

--- a/crypto/x509/v3_san.c
+++ b/crypto/x509/v3_san.c
@@ -630,7 +630,8 @@ GENERAL_NAME *v2i_GENERAL_NAME_ex(GENERAL_NAME *out,
 
 static int do_othername(GENERAL_NAME *gen, const char *value, X509V3_CTX *ctx)
 {
-    char *objtmp = NULL, *p;
+    char *objtmp = NULL;
+    const char *p;
     size_t objlen;
 
     if ((p = strchr(value, ';')) == NULL)

--- a/crypto/x509/v3_utl.c
+++ b/crypto/x509/v3_utl.c
@@ -1121,15 +1121,16 @@ ASN1_OCTET_STRING *a2i_IPADDRESS_NC(const char *ipasc)
     ASN1_OCTET_STRING *ret = NULL;
     unsigned char ipout[32];
     char *iptmp = NULL, *p;
+    const char *slash;
     int iplen1, iplen2;
 
-    p = strchr(ipasc, '/');
-    if (p == NULL)
+    slash = strchr(ipasc, '/');
+    if (slash == NULL)
         return NULL;
     iptmp = OPENSSL_strdup(ipasc);
     if (iptmp == NULL)
         return NULL;
-    p = iptmp + (p - ipasc);
+    p = iptmp + (slash - ipasc);
     *p++ = 0;
 
     iplen1 = ossl_a2i_ipadd(ipout, iptmp);

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1294,7 +1294,7 @@ static int gid_cb(const char *elem, int len, void *arg)
     int found_group = 0;
     char etmp[GROUP_NAME_BUFFER_LENGTH];
     int retval = 1; /* We assume success */
-    char *current_prefix;
+    const char *current_prefix;
     int ignore_unknown = 0;
     int add_keyshare = 0;
     int remove_group = 0;

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -2737,7 +2737,7 @@ static int pkey_test_ctrl(EVP_TEST *t, EVP_PKEY_CTX *pctx,
 static int pkey_add_control(EVP_TEST *t, STACK_OF(OPENSSL_STRING) *controls,
     const char *value)
 {
-    char *p;
+    const char *p;
 
     if (controls == NULL)
         return 0;


### PR DESCRIPTION
- Fixes #30135

This patch fixes several const qualifiers byu adding where required.

    warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]

Since glibc-2.43 and ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
