### PR TITLE
Fix hardcoded INCLUDEDIR and BINDIR in exporters/build.info

### DIFF
--- a/exporters/build.info
+++ b/exporters/build.info
@@ -19,8 +19,8 @@ DEPEND[openssl.pc]=libcrypto.pc libssl.pc
 DEPEND[""]=openssl.pc
 
 GENERATE[../installdata.pm]=../util/mkinstallvars.pl \
-    "PREFIX=$(INSTALLTOP)" BINDIR=bin "LIBDIR=$(LIBDIR)" "libdir=$(libdir)" \
-    INCLUDEDIR=include APPLINKDIR=include/openssl \
+    "PREFIX=$(INSTALLTOP)" "BINDIR=$(BINDIR)" "LIBDIR=$(LIBDIR)" "libdir=$(libdir)" \
+    "INCLUDEDIR=$(INCLUDEDIR)" APPLINKDIR=$(INCLUDEDIR)/openssl \
     "MODULESDIR=$(MODULESDIR)" \
     "PKGCONFIGDIR=$(PKGCONFIGDIR)" "CMAKECONFIGDIR=$(CMAKECONFIGDIR)" \
     "LDLIBS=$(LIB_EX_LIBS)" "VERSION=$(VERSION)"


### PR DESCRIPTION
INCLUDEDIR and BINDIR were hardcoded to 'include' and 'bin' respectively in the mkinstallvars.pl invocation, making them impossible to override via make variables. Replaced with INCLUDEDIR and BINDIR to allow overriding at make time, consistent with other directory variables such as LIBDIR and PKGCONFIGDIR.

Also derived APPLINKDIR from INCLUDEDIR rather than hardcoding 'include/openssl' so it stays consistent if INCLUDEDIR is customised.

Fixes #29552