### PR TITLE
FIPS: Change EC_GROUP_check() so that it fails for explicit curves.

### DIFF
--- a/crypto/ec/ec_check.c
+++ b/crypto/ec/ec_check.c
@@ -50,7 +50,7 @@ int EC_GROUP_check(const EC_GROUP *group, BN_CTX *ctx)
      * ECC domain parameter validation.
      * See SP800-56A R3 5.5.2 "Assurances of Domain-Parameter Validity" Part 1b.
      */
-    return EC_GROUP_check_named_curve(group, 1, ctx) >= 0 ? 1 : 0;
+    return EC_GROUP_check_named_curve(group, 1, ctx) > 0 ? 1 : 0;
 #else
     int ret = 0;
     const BIGNUM *order;


### PR DESCRIPTION
Explicit curves returned a NID of NID_undef ( = 0) which resulted in the check >= 0 passing.
Changing the result to > addresses the issue.
Note that this is a NON issue in master since explicit curves are now disabled by default. Note also that any EC operation that tries to use a loaded EC key in the FIPS provider checks that the curve and security strength are valid.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
