### PR TITLE
Ensure TLS 1.3 ciphersuites are actually for TLS 1.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,13 @@ OpenSSL 4.0
 
 ### Changes between 3.6 and 4.0 [xx XXX xxxx]
 
+ * Fixed bug that allowed TLS 1.2 ciphers to be added to the TLS 1.3
+   ciphersuites list, and for that list to contain duplicates.
+   Cipher configuration strings for both TLS 1.2 and 1.3 are now
+   case-insenstive.
+
+   *Viktor Dukhovni*
+
  * New `SSL_get0_sigalg()` and `SSL_get0_shared_sigalg()` functions report the
    TLS signature algorithm name and codepoint for the peer advertised and shared
    algorithms respectively.  These supersede the existing `SSL_get_sigalgs()` and
@@ -105,7 +112,7 @@ OpenSSL 4.0
 
    *Neil Horman*
 
- * ASN1_OBJECT_new() has been deprecated.
+ * `ASN1_OBJECT_new()` has been deprecated.
 
    Refer to ossl-migration-guide(7) for more info.
 
@@ -148,10 +155,10 @@ OpenSSL 4.0
 
    *kovan*
 
- * ASN1_STRING has been made opaque.
+ * `ASN1_STRING` has been made opaque.
 
-   Access to values from ASN1_STRING and related types should be done with the
-   appropriate accessor functions. The various ASN1_STRING_FLAG values have
+   Access to values from `ASN1_STRING` and related types should be done with the
+   appropriate accessor functions. The various `ASN1_STRING_FLAG` values have
    been made private.
 
    *Bob Beck*
@@ -244,7 +251,7 @@ OpenSSL 4.0
 
  * The `X509_verify()` function now takes a `const X509 *` argument
 
-   * Bob Beck *
+   *Bob Beck*
 
  * The crypto-mdebug-backtrace configuration option has been entirely removed.
    The option has been a no-op since 1.0.2.
@@ -265,10 +272,10 @@ OpenSSL 4.0
 
  * Added `ASN1_BIT_STRING_set1()` to set a bit string to a value including
    the length in bytes and the number of unused bits. Internally,
-   'ASN1_BIT_STRING_set_bit()' has also been modified to keep the number of
-   unused bits correct when changing an ASN1_BIT_STRING.
+   `ASN1_BIT_STRING_set_bit()` has also been modified to keep the number of
+   unused bits correct when changing an `ASN1_BIT_STRING`.
 
-   * Bob Beck *
+   *Bob Beck*
 
  * The deprecated function `ASN1_STRING_data` has been removed.
 
@@ -299,9 +306,9 @@ OpenSSL 4.0
 
    *Daniel Kubec and Eugene Syromiatnikov*
 
- * X509_get0_distinguishing_id now takes and returns const objects.
+ * `X509_get0_distinguishing_id()` now takes and returns const objects.
 
-   * Bob Beck *
+   *Bob Beck*
 
  * Added `-hmac-env` and `-hmac-stdin` options to openssl-dgst.
 
@@ -317,12 +324,13 @@ OpenSSL 4.0
    *Ryan Hooper*
 
  * Constify Various X509 functions:
-   X509_get_pathlen X509_check_ca X509_check_purpose X509_get_proxy_pathlen
-   X509_get_extension_flags X509_get_key_usage X509_get_extended_key_usage
-   X509_get0_subject_key_id X509_get0_authority_key_id X509_get0_authority_issuer
-   X509_get0_authority_serial.
+   `X509_get_pathlen()`, `X509_check_ca()`, `X509_check_purpose()`,
+   `X509_get_proxy_pathlen()`, `X509_get_extension_flags()`,
+   `X509_get_key_usage()`, `X509_get_extended_key_usage()`,
+   `X509_get0_subject_key_id()`, `X509_get0_authority_key_id()`,
+   `X509_get0_authority_issuer()`, `X509_get0_authority_serial()`.
 
-   * Bob Beck *
+   *Bob Beck*
 
  * Fixed CRLs with invalid `ASN1_TIME` in invalidityDate extensions,
    where verification incorrectly succeeded. Enforced proper
@@ -341,7 +349,7 @@ OpenSSL 4.0
    `X509_NAME_get_text_by_NID()`, and `X509_NAME_get_text_by_OBJ()` are now
    actually deprecated, and documented as such.
 
-   * Bob Beck *
+   *Bob Beck*
 
  * ENGINE support was removed. The `no-engine` build option and the
    `OPENSSL_NO_ENGINE` macro is always present.
@@ -392,18 +400,18 @@ OpenSSL 4.0
 
    *Stephen Farrell* (with much support from *Matt Caswell* and *Tomáš Mráz*)
 
- * X509_cmp_time, X509_cmp_current_time, and X509_cmp_timeframe have
+ * `X509_cmp_time()`, `X509_cmp_current_time()`, and `X509_cmp_timeframe()` have
    had documentation added, and have then been deprecated.  A new
-   function, X509_check_certificate_times has been added, as well as
-   the <openssl/posix_time.h> interface from BoringSSL/LibreSSL. For
+   function, `X509_check_certificate_times()` has been added, as well as
+   the `<openssl/posix_time.h>` interface from BoringSSL/LibreSSL. For
    details of these functions and non-deprecated replacement
-   strategies, see X509_check_certificate_times(3).
+   strategies, see `X509_check_certificate_times(3)`.
 
-   * Bob Beck *
+   *Bob Beck*
 
- * Added BIO_set_send_flags() function that allows setting flags passed to
+ * Added `BIO_set_send_flags()` function that allows setting flags passed to
    send(), sendto(), and sendmsg(). The main intention is to allow setting
-   the MSG_NOSIGNAL flag to avoid a crash on receiving the SIGPIPE signal.
+   the `MSG_NOSIGNAL` flag to avoid a crash on receiving the SIGPIPE signal.
 
    *Igor Ustinov*
 

--- a/doc/man1/openssl-ciphers.pod.in
+++ b/doc/man1/openssl-ciphers.pod.in
@@ -30,6 +30,9 @@ This command converts textual OpenSSL cipher lists into
 ordered SSL cipher preference lists. It can be used to
 determine the appropriate cipherlist.
 
+As of OpenSSL 4.0 the list of TLS 1.3 ciphersuites I<val> and TLS 1.2 ciphers
+I<cipherlist> are processed case-insensitively.
+
 =head1 OPTIONS
 
 =over 4
@@ -810,6 +813,9 @@ Support for standard IANA names in cipher lists was added in
 OpenSSL 3.2.0.
 
 The support for TLS v1.3 integrity-only cipher suites was added in OpenSSL 3.4.
+
+The list of TLS 1.3 ciphersuites I<val> and TLS 1.2 ciphers
+I<cipherlist> were case-sensitive prior to OpenSSL 4.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set_cipher_list.pod
+++ b/doc/man3/SSL_CTX_set_cipher_list.pod
@@ -25,18 +25,24 @@ OSSL_default_ciphersuites
 
 =head1 DESCRIPTION
 
-SSL_CTX_set_cipher_list() sets the list of available ciphers (TLSv1.2 and below)
-for B<ctx> using the control string B<str>. The format of the string is described
-in L<openssl-ciphers(1)>. The list of ciphers is inherited by all
-B<ssl> objects created from B<ctx>. This function does not impact TLSv1.3
-ciphersuites. Use SSL_CTX_set_ciphersuites() to configure those. B<ctx> B<MUST NOT> be NULL.
+SSL_CTX_set_cipher_list() sets the list of available ciphers (TLSv1.2 and
+below) for B<ctx> using the control string B<str>.
+The format of the string is described in L<openssl-ciphers(1)>.
+As of OpenSSL 4.0, B<str> is processed case-insensitively.
+The list of ciphers is inherited by all B<ssl> objects created from B<ctx>.
+This function does not affect TLSv1.3 ciphersuites.
+Use SSL_CTX_set_ciphersuites() to configure those.
+B<ctx> B<MUST NOT> be NULL.
 
 SSL_set_cipher_list() sets the list of ciphers (TLSv1.2 and below) only for
 B<ssl>.
 
 SSL_CTX_set_ciphersuites() is used to configure the available TLSv1.3
-ciphersuites for B<ctx>. This is a simple colon (":") separated list of TLSv1.3
-ciphersuite names in order of preference. Valid TLSv1.3 ciphersuite names are:
+ciphersuites for B<ctx>.
+This is a simple colon (":") separated list of TLSv1.3 ciphersuite names in
+order of preference.
+As of OpenSSL 4.0, B<str> is processed case-insensitively.
+Valid TLSv1.3 ciphersuite names are:
 
 =over 4
 
@@ -124,6 +130,8 @@ L<openssl-ciphers(1)>
 =head1 HISTORY
 
 OSSL_default_cipher_list() and OSSL_default_ciphersites() are new in 3.0.
+
+Cipher names were case-sensitive prior to OpenSSL 4.0.
 
 =head1 COPYRIGHT
 

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4725,18 +4725,32 @@ const SSL_CIPHER *ssl3_get_cipher_by_id(uint32_t id)
     return OBJ_bsearch_ssl_cipher_id(&c, ssl3_scsvs, SSL3_NUM_SCSVS);
 }
 
+const SSL_CIPHER *ssl3_get_tls13_cipher_by_std_name(const char *stdname)
+{
+    SSL_CIPHER *end = &tls13_ciphers[TLS13_NUM_CIPHERS];
+
+    /* this is not efficient, necessary to optimize this? */
+    for (SSL_CIPHER *c = tls13_ciphers; c < end; ++c) {
+        if (c->stdname == NULL)
+            continue;
+        if (OPENSSL_strcasecmp(stdname, c->stdname) == 0)
+            return c;
+    }
+    return NULL;
+}
+
 const SSL_CIPHER *ssl3_get_cipher_by_std_name(const char *stdname)
 {
     SSL_CIPHER *tbl;
-    SSL_CIPHER *alltabs[] = { tls13_ciphers, ssl3_ciphers, ssl3_scsvs };
-    size_t i, j, tblsize[] = { TLS13_NUM_CIPHERS, SSL3_NUM_CIPHERS, SSL3_NUM_SCSVS };
+    SSL_CIPHER *alltabs[] = { ssl3_ciphers, ssl3_scsvs };
+    size_t i, j, tblsize[] = { SSL3_NUM_CIPHERS, SSL3_NUM_SCSVS };
 
     /* this is not efficient, necessary to optimize this? */
     for (j = 0; j < OSSL_NELEM(alltabs); j++) {
         for (i = 0, tbl = alltabs[j]; i < tblsize[j]; i++, tbl++) {
             if (tbl->stdname == NULL)
                 continue;
-            if (strcmp(stdname, tbl->stdname) == 0) {
+            if (OPENSSL_strcasecmp(stdname, tbl->stdname) == 0) {
                 return tbl;
             }
         }

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2532,6 +2532,7 @@ __owur unsigned int ssl_get_split_send_fragment(const SSL_CONNECTION *sc);
 
 __owur const SSL_CIPHER *ssl3_get_cipher_by_id(uint32_t id);
 __owur const SSL_CIPHER *ssl3_get_cipher_by_std_name(const char *stdname);
+__owur const SSL_CIPHER *ssl3_get_tls13_cipher_by_std_name(const char *stdname);
 __owur const SSL_CIPHER *ssl3_get_cipher_by_char(const unsigned char *p);
 __owur int ssl3_put_cipher_by_char(const SSL_CIPHER *c, WPACKET *pkt,
     size_t *len);

--- a/test/fatalerrtest.c
+++ b/test/fatalerrtest.c
@@ -35,10 +35,13 @@ static int test_fatalerr(void)
 
     /*
      * Deliberately set the cipher lists for client and server to be different
-     * to force a handshake failure.
+     * to force a handshake failure. Also make sure the client and server don't
+     * accept TLS 1.2 ciphers as TLS 1.3 ciphersuites.
      */
     if (!TEST_true(SSL_CTX_set_cipher_list(sctx, "AES128-SHA"))
         || !TEST_true(SSL_CTX_set_cipher_list(cctx, "AES256-SHA"))
+        || !TEST_false(SSL_CTX_set_ciphersuites(sctx, "AES128-SHA"))
+        || !TEST_false(SSL_CTX_set_ciphersuites(cctx, "AES256-SHA"))
         || !TEST_true(SSL_CTX_set_ciphersuites(sctx,
             "TLS_AES_128_GCM_SHA256"))
         || !TEST_true(SSL_CTX_set_ciphersuites(cctx,

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -782,7 +782,7 @@ static int test_client_hello_cb(void)
     /* Avoid problems where the default seclevel has been changed */
     SSL_CTX_set_security_level(cctx, 2);
     if (!TEST_true(SSL_CTX_set_cipher_list(cctx,
-            "AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384"))
+            "aes256-gcm-sha384:ecdhe-ecdsa-aes256-gcm-sha384"))
         || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
             &clientssl, NULL, NULL))
         || !TEST_false(create_ssl_connection(serverssl, clientssl,
@@ -886,7 +886,7 @@ static int test_ccs_change_cipher(void)
         || !TEST_true(SSL_CTX_set_options(sctx, SSL_OP_NO_TICKET))
         || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
             NULL, NULL))
-        || !TEST_true(SSL_set_cipher_list(clientssl, "AES128-GCM-SHA256"))
+        || !TEST_true(SSL_set_cipher_list(clientssl, "aes128-gcm-sha256"))
         || !TEST_true(create_ssl_connection(serverssl, clientssl,
             SSL_ERROR_NONE))
         || !TEST_ptr(sesspre = SSL_get0_session(serverssl))
@@ -901,7 +901,7 @@ static int test_ccs_change_cipher(void)
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
             NULL, NULL))
         || !TEST_true(SSL_set_session(clientssl, sess))
-        || !TEST_true(SSL_set_cipher_list(clientssl, "AES256-GCM-SHA384:AES128-GCM-SHA256"))
+        || !TEST_true(SSL_set_cipher_list(clientssl, "aes256-gcm-sha384:aes128-gcm-sha256"))
         || !TEST_true(create_ssl_connection(serverssl, clientssl,
             SSL_ERROR_NONE))
         || !TEST_true(SSL_session_reused(clientssl))
@@ -920,11 +920,11 @@ static int test_ccs_change_cipher(void)
      */
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
             NULL, NULL))
-        || !TEST_true(SSL_set_cipher_list(clientssl, "AES128-GCM-SHA256"))
+        || !TEST_true(SSL_set_cipher_list(clientssl, "aes128-gcm-sha256"))
         || !TEST_true(create_ssl_connection(serverssl, clientssl,
             SSL_ERROR_NONE))
         || !TEST_ptr(sesspre = SSL_get0_session(serverssl))
-        || !TEST_true(SSL_set_cipher_list(clientssl, "AES256-GCM-SHA384"))
+        || !TEST_true(SSL_set_cipher_list(clientssl, "aes256-gcm-sha384"))
         || !TEST_true(SSL_renegotiate(clientssl))
         || !TEST_true(SSL_renegotiate_pending(clientssl)))
         goto end;
@@ -4337,18 +4337,18 @@ static int test_early_data_replay(int idx)
 }
 
 static const char *ciphersuites[] = {
-    "TLS_AES_128_CCM_8_SHA256",
-    "TLS_AES_128_GCM_SHA256",
-    "TLS_AES_256_GCM_SHA384",
-    "TLS_AES_128_CCM_SHA256",
+    "tls_aes_128_ccm_8_sha256",
+    "tls_aes_128_gcm_sha256",
+    "tls_aes_256_gcm_sha384",
+    "tls_aes_128_ccm_sha256",
 #if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
-    "TLS_CHACHA20_POLY1305_SHA256",
+    "tls_chacha20_poly1305_sha256",
 #else
     NULL,
 #endif
 #if !defined(OPENSSL_NO_INTEGRITY_ONLY_CIPHERS)
-    "TLS_SHA256_SHA256",
-    "TLS_SHA384_SHA384"
+    "tls_sha256_sha256",
+    "tls_sha384_sha384"
 #endif
 };
 
@@ -5150,12 +5150,12 @@ static int test_set_ciphersuite(int idx)
             TLS_client_method(), TLS1_VERSION, 0,
             &sctx, &cctx, cert, privkey))
         || !TEST_true(SSL_CTX_set_ciphersuites(sctx,
-            "TLS_AES_128_GCM_SHA256:TLS_AES_128_CCM_SHA256")))
+            "tls_aes_128_gcm_sha256:tls_aes_128_ccm_sha256")))
         goto end;
 
     if (idx >= 4 && idx <= 7) {
         /* SSL_CTX explicit cipher list */
-        if (!TEST_true(SSL_CTX_set_cipher_list(cctx, "AES256-GCM-SHA384")))
+        if (!TEST_true(SSL_CTX_set_cipher_list(cctx, "aes256-gcm-sha384")))
             goto end;
     }
 
@@ -5189,7 +5189,7 @@ static int test_set_ciphersuite(int idx)
     } else if (idx == 3 || idx == 7 || idx == 9) {
         /* Non default ciphersuite */
         if (!TEST_true(SSL_set_ciphersuites(clientssl,
-                "TLS_AES_128_CCM_SHA256")))
+                "tls_aes_128_ccm_sha256")))
             goto end;
     }
 
@@ -5220,9 +5220,9 @@ static int test_ciphersuite_change(void)
             TLS_client_method(), TLS1_VERSION, 0,
             &sctx, &cctx, cert, privkey))
         || !TEST_true(SSL_CTX_set_ciphersuites(sctx,
-            "TLS_AES_128_GCM_SHA256:"
+            "tls_aes_128_gcm_sha256:"
             "TLS_AES_256_GCM_SHA384:"
-            "TLS_AES_128_CCM_SHA256"))
+            "tls_aes_128_ccm_sha256"))
         || !TEST_true(SSL_CTX_set_ciphersuites(cctx,
             "TLS_AES_128_GCM_SHA256")))
         goto end;
@@ -7028,7 +7028,9 @@ static int test_export_key_mat(int tst)
     OPENSSL_assert(tst >= 0 && (size_t)tst < OSSL_NELEM(protocols));
     SSL_CTX_set_max_proto_version(cctx, protocols[tst]);
     SSL_CTX_set_min_proto_version(cctx, protocols[tst]);
-    if ((protocols[tst] < TLS1_2_VERSION) && (!SSL_CTX_set_cipher_list(cctx, "DEFAULT:@SECLEVEL=0") || !SSL_CTX_set_cipher_list(sctx, "DEFAULT:@SECLEVEL=0")))
+    if ((protocols[tst] < TLS1_2_VERSION)
+        && (!SSL_CTX_set_cipher_list(cctx, "default:@seclevel=0")
+            || !SSL_CTX_set_cipher_list(sctx, "DEFAULT:@SECLEVEL=0")))
         goto end;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL,
@@ -8675,9 +8677,9 @@ static int test_ssl_pending(int tst)
          * Default sigalgs are SHA1 based in <DTLS1.2 which is in security
          * level 0
          */
-        if (!TEST_true(SSL_CTX_set_cipher_list(sctx, "DEFAULT:@SECLEVEL=0"))
+        if (!TEST_true(SSL_CTX_set_cipher_list(sctx, "DEFAULT:@seclevel=0"))
             || !TEST_true(SSL_CTX_set_cipher_list(cctx,
-                "DEFAULT:@SECLEVEL=0")))
+                "default:@SECLEVEL=0")))
             goto end;
 #endif
 #else
@@ -11368,7 +11370,7 @@ static int test_dh_auto(int idx)
     EVP_PKEY *tmpkey = NULL;
     char *thiscert = NULL, *thiskey = NULL;
     size_t expdhsize = 0;
-    const char *ciphersuite = "DHE-RSA-AES128-SHA";
+    const char *ciphersuite = "dhe-rsa-aes128-sha";
 
     if (!TEST_ptr(tlsprov))
         goto end;
@@ -11417,11 +11419,11 @@ static int test_dh_auto(int idx)
             testresult = 1;
             goto end;
         }
-        ciphersuite = "ADH-AES128-SHA256:@SECLEVEL=0";
+        ciphersuite = "adh-aes128-sha256:@seclevel=0";
         expdhsize = 1024;
         break;
     case 6:
-        ciphersuite = "ADH-AES256-SHA256:@SECLEVEL=0";
+        ciphersuite = "adh-aes256-sha256:@seclevel=0";
         expdhsize = 3072;
         break;
     default:
@@ -11499,60 +11501,60 @@ static int test_no_shared_ffdhe_group(int idx)
     case 0:
         clientgroup = "ffdhe2048";
         servergroup = "ffdhe3072";
-        ciphersuite = "DHE-RSA-AES128-SHA256:AES128-SHA256";
+        ciphersuite = "dhe-rsa-aes128-sha256:aes128-sha256";
         break;
     case 1:
         clientgroup = "ffdhe3072";
         servergroup = "ffdhe4096";
-        ciphersuite = "DHE-RSA-AES128-SHA256:AES128-SHA256";
+        ciphersuite = "dhe-rsa-aes128-sha256:aes128-sha256";
         break;
     case 2:
         clientgroup = "ffdhe4096";
         servergroup = "ffdhe6144";
-        ciphersuite = "DHE-RSA-AES128-SHA256:AES128-SHA256";
+        ciphersuite = "dhe-rsa-aes128-sha256:aes128-sha256";
         break;
     case 3:
         clientgroup = "ffdhe6144";
         servergroup = "ffdhe8192";
-        ciphersuite = "DHE-RSA-AES128-SHA256:AES128-SHA256";
+        ciphersuite = "dhe-rsa-aes128-sha256:aes128-sha256";
         break;
     case 4:
         clientgroup = "ffdhe8192";
         servergroup = "ffdhe2048";
-        ciphersuite = "DHE-RSA-AES128-SHA256:AES128-SHA256";
+        ciphersuite = "dhe-rsa-aes128-sha256:aes128-sha256";
         break;
     case 5:
         clientgroup = "ffdhe2048";
         servergroup = "ffdhe3072";
-        ciphersuite = "DHE-RSA-AES128-SHA256";
+        ciphersuite = "dhe-rsa-aes128-sha256";
         expected = 0;
         want_error = SSL_ERROR_SSL;
         break;
     case 6:
         clientgroup = "ffdhe3072";
         servergroup = "ffdhe4096";
-        ciphersuite = "DHE-RSA-AES128-SHA256";
+        ciphersuite = "dhe-rsa-aes128-sha256";
         expected = 0;
         want_error = SSL_ERROR_SSL;
         break;
     case 7:
         clientgroup = "ffdhe4096";
         servergroup = "ffdhe6144";
-        ciphersuite = "DHE-RSA-AES128-SHA256";
+        ciphersuite = "dhe-rsa-aes128-sha256";
         expected = 0;
         want_error = SSL_ERROR_SSL;
         break;
     case 8:
         clientgroup = "ffdhe6144";
         servergroup = "ffdhe8192";
-        ciphersuite = "DHE-RSA-AES128-SHA256";
+        ciphersuite = "dhe-rsa-aes128-sha256";
         expected = 0;
         want_error = SSL_ERROR_SSL;
         break;
     case 9:
         clientgroup = "ffdhe8192";
         servergroup = "ffdhe2048";
-        ciphersuite = "DHE-RSA-AES128-SHA256";
+        ciphersuite = "dhe-rsa-aes128-sha256";
         expected = 0;
         want_error = SSL_ERROR_SSL;
         break;
@@ -12528,9 +12530,9 @@ static int test_version(int idx)
             version, &sctx, &cctx, cert, privkey)))
         goto end;
 
-    if (!TEST_true(SSL_CTX_set_cipher_list(sctx, "DEFAULT:@SECLEVEL=0"))
+    if (!TEST_true(SSL_CTX_set_cipher_list(sctx, "default:@SECLEVEL=0"))
         || !TEST_true(SSL_CTX_set_cipher_list(cctx,
-            "DEFAULT:@SECLEVEL=0")))
+            "DEFAULT:@seclevel=0")))
         goto end;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,


### PR DESCRIPTION
- Also suppress duplicate ciphersuites
- Also ignore case in both TLS 1.3 and TLS 1.2 ciphers

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
