### PR TITLE
EVP multi-step initialization test and stale-key usage check

### DIFF
--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -5042,12 +5042,11 @@ static int seen_name(const char *name)
 
 static void collect_cipher_cb(EVP_CIPHER *ciph, void *arg)
 {
-    EVP_CIPHER_TEST_INFO *tmp = NULL;
     EVP_CIPHER_TEST_INFO *info = NULL;
     const char *name0 = NULL;
     int taglen = 0;
 
-    (void)arg;
+    size_t *allocated = arg;
 
     if (ciph == NULL)
         return;
@@ -5081,13 +5080,11 @@ static void collect_cipher_cb(EVP_CIPHER *ciph, void *arg)
         || EVP_CIPHER_is_a(ciph, "AES-256-CBC-HMAC-SHA512-ETM"))
         return;
 
-    tmp = OPENSSL_realloc(cipher_list,
-        (cipher_list_n + 1) * sizeof(*tmp));
-
-    if (tmp == NULL)
+    /* First pass only counts ciphers to allocate memory */
+    if (allocated != NULL) {
+        (*allocated)++;
         return;
-
-    cipher_list = tmp;
+    }
 
     info = &cipher_list[cipher_list_n];
 
@@ -5106,8 +5103,19 @@ static void collect_cipher_cb(EVP_CIPHER *ciph, void *arg)
 
 static int setup_cipher_list(void)
 {
+    size_t cipher_list_size = 0;
     cipher_list = NULL;
     cipher_list_n = 0;
+
+    /* first pass goes through counting only for allocating */
+    EVP_CIPHER_do_all_provided(NULL, collect_cipher_cb, &cipher_list_size);
+
+    if (!TEST_size_t_gt(cipher_list_size, 0))
+        return 0;
+
+    cipher_list = OPENSSL_malloc(cipher_list_size * sizeof(*cipher_list));
+    if (!TEST_ptr(cipher_list))
+        return 0;
 
     EVP_CIPHER_do_all_provided(NULL, collect_cipher_cb, NULL);
     return TEST_true(cipher_list_n > 0);


### PR DESCRIPTION
## test: add dynamic EVP multi-step init regression tests for IV-taking ciphers

Add regression tests to `test/evp_extra_test.c` that dynamically
discover all provided ciphers with non-zero IV length and verify
correct multi-step initialization semantics.

The EVP API permits key and IV to be supplied in separate
`EVP_CipherInit_ex()` calls (e.g. key-only followed by IV-only).
A recent bug (PR #29934, ASCON-AEAD128) demonstrated that a
provider may silently ignore a key-only init, resulting in reuse
of a previously loaded key during a subsequent IV-only init.

To prevent similar regressions, this change introduces three
generic tests that automatically cover all IV-taking ciphers:

### 1. Multi-step vs single-step equivalence

Verifies that:
- `init(key) → init(iv)`
- `init(iv) → init(key)`

produce identical ciphertext (and authentication tag for AEAD
ciphers) compared to single-call `init(key, iv)`.

### 2. No stale key on re-init

Primes a context with `key1/iv1`, then re-initializes via
`init(key2) → init(iv2)` and verifies the output matches a fresh
`encrypt(key2, iv2)` operation, ensuring that no previously stored
key is reused.

### 3. Decrypt roundtrip via multi-step

Encrypts using single-call initialization and then decrypts using
multi-step initialization, verifying plaintext recovery. For AEAD
ciphers, this also exercises tag verification through the
multi-step path.

Ciphers are discovered using `EVP_CIPHER_do_all_provided()`,
requiring no maintenance when new IV-taking ciphers are added.
SIV mode is skipped due to its synthetic IV semantics. CCM mode
handling includes required length declarations.

This provides broad regression coverage for the provider
implementations that support multi-step EVP initialization.

@bbbrumley 
CLA: [https://docuseal.com/e/4ToT8de57L7nHb](url)
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
