### PR TITLE
ssl/ech/ech_store.c: do not raise errors on allocation failures

### DIFF
--- a/ssl/ech/ech_store.c
+++ b/ssl/ech/ech_store.c
@@ -360,7 +360,7 @@ static int ech_decode_one_entry(OSSL_ECHSTORE_ENTRY **rent, PACKET *pkt,
     }
     thiskemid = (uint16_t)tmpi;
     ee->nsuites = (unsigned int)(suiteoctets / OSSL_ECH_CIPHER_LEN);
-    ee->suites = OPENSSL_malloc(ee->nsuites * sizeof(*ee->suites));
+    ee->suites = OPENSSL_malloc_array(ee->nsuites, sizeof(*ee->suites));
     if (ee->suites == NULL)
         goto err;
     while (PACKET_copy_bytes(&cipher_suites, cipher,


### PR DESCRIPTION
Per discussion with @mattcaswell in [1], it seems that there is no need to raise an error on allocation failures explicitly, so remove it in the places where it was done so.  Also, while at it, use `OPENSSL_malloc_array()` for array allocation.

[1] https://github.com/openssl/openssl/pull/30143