### PR TITLE
Remove dead code in ossl_ech_copy_inner2outer

### DIFF
--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -503,10 +503,8 @@ int ossl_ech_copy_inner2outer(SSL_CONNECTION *s, uint16_t ext_type,
             ext_type);
     }
     OSSL_TRACE_END(TLS);
+
     /*
-     * This one wasn't in inner, so re-do processing. We don't
-     * actually do this currently, but could.
-     *
      * copy inner value to outer
      */
     if (PACKET_data(&myext->data) != NULL


### PR DESCRIPTION
Theres an additional NULL check in this function that can never be NULL at the point at which it is checked.  Remove it

Fixes https://scan5.scan.coverity.com/#/project-view/60762/10222?selectedIssue=1681461
