### PR TITLE
FIPS: Add HMAC key size compliance check to the MAC legacy bridge.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ providers/implementations/keymgmt/mlx_kmgmt.inc
 providers/implementations/keymgmt/slh_dsa_kmgmt.inc
 providers/implementations/keymgmt/template_kmgmt.inc
 providers/implementations/signature/eddsa_sig.inc
+providers/implementations/signature/mac_legacy_sig.inc
 providers/implementations/signature/ml_dsa_sig.inc
 providers/implementations/signature/rsa_sig.inc
 providers/implementations/signature/slh_dsa_sig.inc

--- a/build.info
+++ b/build.info
@@ -91,6 +91,7 @@ DEPEND[]=include/openssl/asn1.h \
          providers/implementations/signature/dsa_sig.inc \
          providers/implementations/signature/ecdsa_sig.inc \
          providers/implementations/signature/eddsa_sig.inc \
+         providers/implementations/signature/mac_legacy_sig.inc \
          providers/implementations/signature/ml_dsa_sig.inc \
          providers/implementations/signature/rsa_sig.inc \
          providers/implementations/signature/slh_dsa_sig.inc \
@@ -214,6 +215,7 @@ DEPEND[providers/implementations/asymciphers/rsa_enc.inc \
        providers/implementations/signature/dsa_sig.inc \
        providers/implementations/signature/ecdsa_sig.inc \
        providers/implementations/signature/eddsa_sig.inc \
+       providers/implementations/signature/mac_legacy_sig.inc \
        providers/implementations/signature/ml_dsa_sig.inc \
        providers/implementations/signature/rsa_sig.inc \
        providers/implementations/signature/slh_dsa_sig.inc \
@@ -352,6 +354,8 @@ GENERATE[providers/implementations/signature/ecdsa_sig.inc]=\
     providers/implementations/signature/ecdsa_sig.inc.in
 GENERATE[providers/implementations/signature/eddsa_sig.inc]=\
     providers/implementations/signature/eddsa_sig.inc.in
+GENERATE[providers/implementations/signature/mac_legacy_sig.inc]=\
+    providers/implementations/signature/mac_legacy_sig.inc.in
 GENERATE[providers/implementations/signature/ml_dsa_sig.inc]=\
     providers/implementations/signature/ml_dsa_sig.inc.in
 GENERATE[providers/implementations/signature/rsa_sig.inc]=\

--- a/providers/implementations/signature/mac_legacy_sig.c
+++ b/providers/implementations/signature/mac_legacy_sig.c
@@ -8,7 +8,6 @@
  */
 
 #include <stdbool.h>
-
 #include <openssl/crypto.h>
 #include <openssl/evp.h>
 #include <openssl/core_dispatch.h>

--- a/providers/implementations/signature/mac_legacy_sig.c
+++ b/providers/implementations/signature/mac_legacy_sig.c
@@ -117,7 +117,8 @@ static int hmac_check_key(PROV_MAC_CTX *macctx, const unsigned char *key, size_t
 
     if (!approved) {
         if (!OSSL_FIPS_IND_ON_UNAPPROVED(macctx, OSSL_FIPS_IND_SETTABLE0,
-                macctx->libctx, "HMAC", "keysize", ossl_fips_config_hmac_key_check)) {
+                macctx->libctx, "HMAC", "keysize",
+                FIPS_CONFIG_HMAC_KEY_CHECK)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
             return 0;
         }

--- a/providers/implementations/signature/mac_legacy_sig.c
+++ b/providers/implementations/signature/mac_legacy_sig.c
@@ -7,6 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <stdbool.h>
+
 #include <openssl/crypto.h>
 #include <openssl/evp.h>
 #include <openssl/core_dispatch.h>
@@ -43,22 +45,18 @@ static OSSL_FUNC_signature_settable_ctx_params_fn mac_siphash_settable_ctx_param
 static OSSL_FUNC_signature_settable_ctx_params_fn mac_poly1305_settable_ctx_params;
 static OSSL_FUNC_signature_settable_ctx_params_fn mac_cmac_settable_ctx_params;
 
-typedef struct prov_mac_ctx_st PROV_MAC_CTX;
-typedef int(SETKEY_FUNC)(PROV_MAC_CTX *macctx, const unsigned char *key, size_t keylen);
-
-struct prov_mac_ctx_st {
+typedef struct {
     OSSL_LIB_CTX *libctx;
     char *propq;
     MAC_KEY *key;
     EVP_MAC_CTX *macctx;
 #ifdef FIPS_MODULE
-    SETKEY_FUNC *on_setkey;
+    bool hmac_keysize_check;
     OSSL_FIPS_IND_DECLARE
 #endif
-};
+} PROV_MAC_CTX;
 
-static void *mac_newctx(void *provctx, const char *propq, const char *macname,
-    SETKEY_FUNC func)
+static void *mac_newctx(void *provctx, const char *propq, const char *macname)
 {
     PROV_MAC_CTX *pmacctx;
     EVP_MAC *mac = NULL;
@@ -84,7 +82,7 @@ static void *mac_newctx(void *provctx, const char *propq, const char *macname,
 
     EVP_MAC_free(mac);
 #ifdef FIPS_MODULE
-    pmacctx->on_setkey = func;
+    pmacctx->hmac_keysize_check = (strcmp(macname, "HMAC") == 0);
     /* Set FIPS indicator to approved */
     OSSL_FIPS_IND_INIT(pmacctx)
 #endif
@@ -97,15 +95,24 @@ err:
     return NULL;
 }
 
-#define MAC_NEWCTX(funcname, macname, func)                                \
+#define MAC_NEWCTX(funcname, macname)                                      \
     static void *mac_##funcname##_newctx(void *provctx, const char *propq) \
     {                                                                      \
-        return mac_newctx(provctx, propq, macname, func);                  \
+        return mac_newctx(provctx, propq, macname);                        \
     }
 
-static int hmac_setkey(PROV_MAC_CTX *macctx, const unsigned char *key, size_t keylen)
-{
+MAC_NEWCTX(hmac, "HMAC")
+MAC_NEWCTX(siphash, "SIPHASH")
+MAC_NEWCTX(poly1305, "POLY1305")
+MAC_NEWCTX(cmac, "CMAC")
+
 #ifdef FIPS_MODULE
+/*
+ * The fips indicator check is done at this level because HMAC will be created
+ * as an 'internal' sub-algorithm which will not perform the tests in hmac_prov.c
+ */
+static int hmac_check_key(PROV_MAC_CTX *macctx, const unsigned char *key, size_t keylen)
+{
     int approved = ossl_mac_check_key_size(keylen);
 
     if (!approved) {
@@ -115,14 +122,9 @@ static int hmac_setkey(PROV_MAC_CTX *macctx, const unsigned char *key, size_t ke
             return 0;
         }
     }
-#endif
     return 1;
 }
-
-MAC_NEWCTX(hmac, "HMAC", hmac_setkey)
-MAC_NEWCTX(siphash, "SIPHASH", NULL)
-MAC_NEWCTX(poly1305, "POLY1305", NULL)
-MAC_NEWCTX(cmac, "CMAC", NULL)
+#endif
 
 static int mac_digest_sign_init(void *vpmacctx, const char *mdname, void *vkey,
     const OSSL_PARAM params[])
@@ -156,10 +158,9 @@ static int mac_digest_sign_init(void *vpmacctx, const char *mdname, void *vkey,
         return 0;
 
 #ifdef FIPS_MODULE
-    if (pmacctx->on_setkey != NULL) {
-        if (!pmacctx->on_setkey(pmacctx, pmacctx->key->priv_key, pmacctx->key->priv_key_len))
-            return 0;
-    }
+    if (pmacctx->hmac_keysize_check
+        && !hmac_check_key(pmacctx, pmacctx->key->priv_key, pmacctx->key->priv_key_len))
+        return 0;
 #endif
     if (!EVP_MAC_init(pmacctx->macctx, pmacctx->key->priv_key,
             pmacctx->key->priv_key_len, NULL))
@@ -241,7 +242,7 @@ static int mac_set_ctx_params(void *vpmacctx, const OSSL_PARAM params[])
     PROV_MAC_CTX *ctx = (PROV_MAC_CTX *)vpmacctx;
 
 #ifdef FIPS_MODULE
-    if (ctx->on_setkey != NULL) {
+    if (ctx->hmac_keysize_check) {
         struct mac_legacy_set_ctx_params_st p;
 
         if (!mac_legacy_set_ctx_params_decoder(params, &p))
@@ -249,7 +250,7 @@ static int mac_set_ctx_params(void *vpmacctx, const OSSL_PARAM params[])
         if (p.key != NULL) {
             if (p.key->data_type != OSSL_PARAM_OCTET_STRING)
                 return 0;
-            if (!ctx->on_setkey(ctx, p.key->data, p.key->data_size))
+            if (!hmac_check_key(ctx, p.key->data, p.key->data_size))
                 return 0;
         }
     }

--- a/providers/implementations/signature/mac_legacy_sig.c
+++ b/providers/implementations/signature/mac_legacy_sig.c
@@ -247,6 +247,8 @@ static int mac_set_ctx_params(void *vpmacctx, const OSSL_PARAM params[])
 
         if (!mac_legacy_set_ctx_params_decoder(params, &p))
             return 0;
+        if (!OSSL_FIPS_IND_SET_CTX_FROM_PARAM(ctx, OSSL_FIPS_IND_SETTABLE0, p.ind_k))
+            return 0;
         if (p.key != NULL) {
             if (p.key->data_type != OSSL_PARAM_OCTET_STRING)
                 return 0;

--- a/providers/implementations/signature/mac_legacy_sig.inc.in
+++ b/providers/implementations/signature/mac_legacy_sig.inc.in
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the \"License\").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+{-
+use OpenSSL::paramnames qw(produce_param_decoder);
+-}
+
+{- produce_param_decoder('mac_legacy_get_ctx_params',
+                         (['OSSL_ALG_PARAM_FIPS_APPROVED_INDICATOR', 'ind',    'int', 'fips'],
+                         )); -}
+
+{- produce_param_decoder('mac_legacy_set_ctx_params',
+                         (['OSSL_MAC_PARAM_KEY', 'key', 'octet_string'],
+                         )); -}

--- a/providers/implementations/signature/mac_legacy_sig.inc.in
+++ b/providers/implementations/signature/mac_legacy_sig.inc.in
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the \"License\").  You may not use
  * this file except in compliance with the License.  You can obtain a copy

--- a/providers/implementations/signature/mac_legacy_sig.inc.in
+++ b/providers/implementations/signature/mac_legacy_sig.inc.in
@@ -17,4 +17,5 @@ use OpenSSL::paramnames qw(produce_param_decoder);
 
 {- produce_param_decoder('mac_legacy_set_ctx_params',
                          (['OSSL_MAC_PARAM_KEY', 'key', 'octet_string'],
+                          ['OSSL_MAC_PARAM_FIPS_KEY_CHECK', 'ind_k',   'int', 'fips'],
                          )); -}

--- a/test/recipes/20-test_mac.t
+++ b/test/recipes/20-test_mac.t
@@ -10,7 +10,7 @@
 use strict;
 use warnings;
 
-use OpenSSL::Test qw(:DEFAULT data_file);
+use OpenSSL::Test qw(:DEFAULT data_file srctop_file);
 use OpenSSL::Test::Utils;
 use Storable qw(dclone);
 
@@ -138,8 +138,9 @@ my @siphash_fail_tests = (
 
 push @mac_fail_tests, @siphash_fail_tests unless disabled("siphash");
 
-plan tests => (scalar @mac_tests * 2) + scalar @mac_fail_tests;
+plan tests => (scalar @mac_tests * 2) + (scalar @mac_fail_tests) + 2;
 
+my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 my $test_count = 0;
 
 foreach (@mac_tests) {
@@ -172,6 +173,28 @@ foreach (@mac_tests) {
 foreach (@mac_fail_tests) {
     $test_count++;
     ok(compareline($_->{cmd}, $_->{type}, $_->{input}, $_->{expected}, $_->{err}), $_->{desc});
+}
+
+SKIP: {
+    skip "Skipping FIPS tests", 2
+        if $no_fips;
+
+    my $fipsconf = srctop_file("test", "fips-and-base.cnf");
+
+    # This is only valid after OpenSSL 4.0
+    run(test(["fips_version_test", "-config", $fipsconf, ">=4.0.0"]),
+             capture => 1, statusvar => \my $exit);
+    skip "FIPS provider version is too old for this test", 1
+        if !$exit;
+
+    $ENV{OPENSSL_CONF} = $fipsconf;
+    ok(!run(app(['openssl', 'dgst', '-provider', 'fips', '-sha256', '-hmac',
+                 '1234', srctop_file("test", "testec-p112r1.pem")])),
+        "Checking bad key size fails in FIPS provider");
+    ok(run(app(['openssl', 'dgst', '-provider', 'fips', '-sha256', '-hmac',
+                 '123456789ABCDE', srctop_file("test", "testec-p112r1.pem")])),
+        "Checking good key size passes in FIPS provider");
+    delete $ENV{OPENSSL_CONF};
 }
 
 # Create a temp input file and save the input data into it, and

--- a/test/recipes/20-test_mac.t
+++ b/test/recipes/20-test_mac.t
@@ -184,7 +184,7 @@ SKIP: {
     # This is only valid after OpenSSL 4.0
     run(test(["fips_version_test", "-config", $fipsconf, ">=4.0.0"]),
              capture => 1, statusvar => \my $exit);
-    skip "FIPS provider version is too old for this test", 1
+    skip "FIPS provider version is too old for this test", 2
         if !$exit;
 
     $ENV{OPENSSL_CONF} = $fipsconf;

--- a/test/recipes/20-test_mac.t
+++ b/test/recipes/20-test_mac.t
@@ -181,8 +181,8 @@ SKIP: {
 
     my $fipsconf = srctop_file("test", "fips-and-base.cnf");
 
-    # This is only valid after OpenSSL 4.0
-    run(test(["fips_version_test", "-config", $fipsconf, ">=4.0.0"]),
+    # This is only valid after OpenSSL 4.1
+    run(test(["fips_version_test", "-config", $fipsconf, ">=4.1.0"]),
              capture => 1, statusvar => \my $exit);
     skip "FIPS provider version is too old for this test", 2
         if !$exit;


### PR DESCRIPTION
Addresses an issue raised in #30012

The hmac fips provider implementation used by the EVP_MAC API handles key size checks, but it only does the test for the internal case. Previously HMAC was implemented using EVP_DigestSign related functions, and these are implemented using a mac_legacy_sig bridge, because of this the MAC is external. For external cases the caller is responsible for doing any key checks, so a FIPS indicator has been added.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
