### PR TITLE
adds test of ECH fail then using retry configs

### DIFF
--- a/test/ech_test.c
+++ b/test/ech_test.c
@@ -1822,7 +1822,7 @@ static int ech_grease_test(int idx)
         goto end;
     /* for 4th test, set a real but wrong ECHConfig which'll override GREASE setting */
     if (idx == 3) {
-        if(!TEST_true(SSL_set1_ech_config_list(clientssl, (unsigned char *)ec_kp1,
+        if (!TEST_true(SSL_set1_ech_config_list(clientssl, (unsigned char *)ec_kp1,
                 ec_kp1len)))
             goto end;
         /* real but wrong => failure, due to ECH */


### PR DESCRIPTION

This PR adds another test to `ech_grease_test()` where the client uses the wrong ECHConfig, sees the connection fail with the ECH status being `SSL_ECH_STATUS_FAILED_ECH` and then retrieves and uses the retry-configs.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
