### PR TITLE
X509: Fix ASN.1 handling to distinguish no-data from critical errors.

### DIFF
--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -229,7 +229,8 @@ static int x509_pubkey_ex_d2i_ex(ASN1_VALUE **pval,
     }
 
     ERR_pop_to_mark();
-    ret = 1;
+    if (pubkey != NULL && pubkey->pkey != NULL)
+        ret = 1;
 end:
     OSSL_DECODER_CTX_free(dctx);
     OPENSSL_free(tmpbuf);

--- a/providers/implementations/encode_decode/decode_der2key.c
+++ b/providers/implementations/encode_decode/decode_der2key.c
@@ -265,20 +265,17 @@ static int der2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
         goto next;
 
     ok = 0; /* Assume that we fail */
-
     ERR_set_mark();
     if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
         derp = der;
-        if (ctx->desc->d2i_PKCS8 != NULL) {
+        if (ctx->desc->d2i_PKCS8 != NULL)
             key = ctx->desc->d2i_PKCS8(&derp, der_len, ctx);
-            if (ctx->flag_fatal) {
-                ERR_clear_last_mark();
-                goto end;
-            }
-        } else if (ctx->desc->d2i_private_key != NULL) {
+        else if (ctx->desc->d2i_private_key != NULL)
             key = ctx->desc->d2i_private_key(NULL, &derp, der_len);
-        }
-        if (key == NULL && ctx->selection != 0) {
+        if (ctx->flag_fatal != 0) {
+            ERR_clear_last_mark();
+            goto end;
+        } else if (key == NULL && ctx->selection != 0) {
             ERR_clear_last_mark();
             goto next;
         }
@@ -289,7 +286,10 @@ static int der2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
             key = ctx->desc->d2i_PUBKEY(&derp, der_len, ctx);
         else if (ctx->desc->d2i_public_key != NULL)
             key = ctx->desc->d2i_public_key(NULL, &derp, der_len);
-        if (key == NULL && ctx->selection != 0) {
+        if (ctx->flag_fatal != 0) {
+            ERR_clear_last_mark();
+            goto end;
+        } else if (key == NULL && ctx->selection != 0) {
             ERR_clear_last_mark();
             goto next;
         }
@@ -298,7 +298,10 @@ static int der2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
         derp = der;
         if (ctx->desc->d2i_key_params != NULL)
             key = ctx->desc->d2i_key_params(NULL, &derp, der_len);
-        if (key == NULL && ctx->selection != 0) {
+        if (ctx->flag_fatal != 0) {
+            ERR_clear_last_mark();
+            goto end;
+        } else if (key == NULL && ctx->selection != 0) {
             ERR_clear_last_mark();
             goto next;
         }
@@ -901,7 +904,12 @@ static void *
 rsa_d2i_PUBKEY(const unsigned char **der, long der_len,
     ossl_unused struct der2key_ctx_st *ctx)
 {
-    return d2i_RSA_PUBKEY(NULL, der, der_len);
+    void *key = d2i_RSA_PUBKEY(NULL, der, der_len);
+    if (key != NULL)
+        return key;
+
+    ctx->flag_fatal = 1;
+    return NULL;
 }
 
 static int rsa_check(void *key, struct der2key_ctx_st *ctx)


### PR DESCRIPTION
Error handling in ASN.1 parsing to prevent malformed X.509 objects from being processed when a critical decoding failure occurs.

The goal is, at least for well-defined ASN.1 structures, to distinguish between “no data” and a fatal parsing error. The API functions populate the error stack nicely and descriptively, but when we call through providers, the informational value is lower if a parsing error occurs and the input data is invalid.