### PR TITLE
Update SCTP support fot DTLS1.3

### DIFF
--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -2607,9 +2607,9 @@ int ssl_get_min_max_version(const SSL_CONNECTION *s, int *min_version,
  * define key-material export for DTLS 1.2 and below.
  */
 #ifndef OPENSSL_NO_SCTP
-        if (SSL_CONNECTION_IS_DTLS(s) && BIO_dgram_is_sctp(SSL_get_wbio(SSL_CONNECTION_GET_SSL(s)))) {
-            if (DTLS_VERSION_GT(vent->version, DTLS1_2_VERSION))
-                continue;
+        if (SSL_CONNECTION_IS_DTLS(s) && DTLS_VERSION_GT(vent->version, DTLS1_2_VERSION)
+            && BIO_dgram_is_sctp(SSL_get_wbio(SSL_CONNECTION_GET_SSL(s)))) {
+            continue;
         }
 #endif
         method = vent->cmeth();

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -2295,6 +2295,18 @@ int ssl_choose_server_version(SSL_CONNECTION *s, CLIENTHELLO_MSG *hello,
                 || (best_vers != best_vers_init
                     && ssl_version_cmp(s, candidate_vers, best_vers) <= 0))
                 continue;
+#ifndef OPENSSL_NO_SCTP
+            /*
+             * DTLS 1.3 is not supported over SCTP.  If the client offers
+             * DTLSv1.3 but the transport is SCTP, thus fall back to
+             * DTLSv1.2 (or lower) during server-version selection.
+             */
+            if (SSL_CONNECTION_IS_DTLS(s)
+                && candidate_vers == DTLS1_3_VERSION
+                && BIO_dgram_is_sctp(SSL_get_wbio(
+                    SSL_CONNECTION_GET_SSL(s))))
+                continue;
+#endif
             if (ssl_version_supported(s, candidate_vers, &best_method))
                 best_vers = candidate_vers;
         }
@@ -2395,6 +2407,21 @@ int ssl_choose_client_version(SSL_CONNECTION *s, int version,
         SSLfatal(s, SSL_AD_PROTOCOL_VERSION, SSL_R_WRONG_SSL_VERSION);
         return 0;
     }
+
+#ifndef OPENSSL_NO_SCTP
+    /*
+     * DTLS 1.3 over SCTP is not supported.  If the server selected
+     * DTLSv1.3 but the transport is SCTP, treat it as a protocol
+     * version mismatch so the handshake is aborted cleanly.
+     */
+    if (SSL_CONNECTION_IS_DTLS(s)
+        && s->version == DTLS1_3_VERSION
+        && BIO_dgram_is_sctp(SSL_get_wbio(ssl))) {
+        s->version = origv;
+        SSLfatal(s, SSL_AD_PROTOCOL_VERSION, SSL_R_UNSUPPORTED_PROTOCOL);
+        return 0;
+    }
+#endif
 
     switch (ssl->method->version) {
     default:
@@ -2575,6 +2602,16 @@ int ssl_get_min_max_version(const SSL_CONNECTION *s, int *min_version,
             tmp_real_max = 0;
             continue;
         }
+/*
+ * DTLS 1.3 over SCTP is not supported.  RFC 6083 and its successors only
+ * define key-material export for DTLS 1.2 and below.
+ */
+#ifndef OPENSSL_NO_SCTP
+        if (SSL_CONNECTION_IS_DTLS(s) && BIO_dgram_is_sctp(SSL_get_wbio(SSL_CONNECTION_GET_SSL(s)))) {
+            if (DTLS_VERSION_GT(vent->version, DTLS1_2_VERSION))
+                continue;
+        }
+#endif
         method = vent->cmeth();
 
         if (hole == 1 && tmp_real_max == 0)

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -54,7 +54,8 @@ my $is_default_tls = (disabled("ssl3") && !disabled("tls1") &&
                       !disabled("tls1_1") && !disabled("tls1_2") &&
                       !disabled("tls1_3") && (!disabled("ec") || !disabled("dh")));
 
-my $is_default_dtls = (!disabled("dtls1") && !disabled("dtls1_2"));
+my $is_default_dtls = (!disabled("dtls1") && !disabled("dtls1_2") &&
+                        !disabled("dtls1_3"));
 
 my @all_pre_tls1_3 = ("ssl3", "tls1", "tls1_1", "tls1_2");
 my $no_tls = alldisabled(available_protocols("tls"));

--- a/test/ssl-tests/29-dtls-sctp-label-bug.cnf
+++ b/test/ssl-tests/29-dtls-sctp-label-bug.cnf
@@ -28,6 +28,7 @@ VerifyMode = Peer
 [test-0]
 EnableClientSCTPLabelBug = No
 EnableServerSCTPLabelBug = No
+ExpectedProtocol = DTLSv1.2
 ExpectedResult = Success
 Method = DTLS
 UseSCTP = Yes
@@ -55,6 +56,7 @@ VerifyMode = Peer
 [test-1]
 EnableClientSCTPLabelBug = Yes
 EnableServerSCTPLabelBug = Yes
+ExpectedProtocol = DTLSv1.2
 ExpectedResult = Success
 Method = DTLS
 UseSCTP = Yes
@@ -72,7 +74,6 @@ client = 2-SCTPLabelBug-bad1-client
 [2-SCTPLabelBug-bad1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [2-SCTPLabelBug-bad1-client]
@@ -100,7 +101,6 @@ client = 3-SCTPLabelBug-bad2-client
 [3-SCTPLabelBug-bad2-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [3-SCTPLabelBug-bad2-client]

--- a/test/ssl-tests/29-dtls-sctp-label-bug.cnf.in
+++ b/test/ssl-tests/29-dtls-sctp-label-bug.cnf.in
@@ -25,7 +25,8 @@ our @tests = (
             "UseSCTP" => "Yes",
             "EnableClientSCTPLabelBug" => "No",
             "EnableServerSCTPLabelBug" => "No",
-            "ExpectedResult" => "Success"
+            "ExpectedResult" => "Success",
+            "ExpectedProtocol" => "DTLSv1.2"
         }
     },
     {
@@ -37,15 +38,13 @@ our @tests = (
             "UseSCTP" => "Yes",
             "EnableClientSCTPLabelBug" => "Yes",
             "EnableServerSCTPLabelBug" => "Yes",
-            "ExpectedResult" => "Success"
+            "ExpectedResult" => "Success",
+            "ExpectedProtocol" => "DTLSv1.2"
         }
     },
     {
         name => "SCTPLabelBug-bad1",
-        # TODO(DTLSv1.3): Fix SCTP support
-        server => {
-            MaxProtocol => "DTLSv1.2"
-        },
+        server => {},
         client => {},
         test => {
             "Method" => "DTLS",
@@ -57,10 +56,7 @@ our @tests = (
     },
     {
         name => "SCTPLabelBug-bad2",
-        # TODO(DTLSv1.3): Fix SCTP support
-        server => {
-            MaxProtocol => "DTLSv1.2"
-        },
+        server => {},
         client => {},
         test => {
             "Method" => "DTLS",


### PR DESCRIPTION
There is a draft RFC for DTLS1.3 over SCTP. This PR does not address that draft RFC. Instead what it does is force DTLS connections over SCTP to downgrade to DTLS1.2.

Fixes: openssl/project#1793

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
