### PR TITLE
Indicate EOF on fatal error in file or winstore

### DIFF
--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -106,6 +106,8 @@ struct file_ctx_st {
 
     /* Expected object type.  May be unspecified */
     int expected_type;
+    /* Fatal error occurred. We should indicate EOF. */
+    int fatal_error;
 };
 
 static void free_file_ctx(struct file_ctx_st *ctx)
@@ -555,8 +557,10 @@ static int file_load_file(struct file_ctx_st *ctx,
 
     /* Setup the decoders (one time shot per session */
 
-    if (!file_setup_decoders(ctx))
+    if (!file_setup_decoders(ctx)) {
+        ctx->fatal_error = 1;
         return 0;
+    }
 
     /* Setup for this object */
 
@@ -753,6 +757,9 @@ static int file_load(void *loaderctx,
 static int file_eof(void *loaderctx)
 {
     struct file_ctx_st *ctx = loaderctx;
+
+    if (ctx->fatal_error)
+        return 1;
 
     switch (ctx->type) {
     case IS_DIR:

--- a/providers/implementations/storemgmt/winstore_store.c
+++ b/providers/implementations/storemgmt/winstore_store.c
@@ -267,8 +267,10 @@ static int winstore_load_using(struct winstore_ctx_st *ctx,
     const unsigned char *der_ = der;
     size_t der_len_ = der_len;
 
-    if (setup_decoder(ctx) == 0)
+    if (setup_decoder(ctx) == 0) {
+        ctx->state = STATE_EOF;
         return 0;
+    }
 
     data.object_cb = object_cb;
     data.object_cbarg = object_cbarg;


### PR DESCRIPTION
If decoders setup fails, this is a fatal error.
We indicate EOF from the store as otherwise the store users will loop indefinitely.

Fixes #28667
