### PR TITLE
add check before releasing retry-configs

### DIFF
--- a/doc/man3/SSL_set1_echstore.pod
+++ b/doc/man3/SSL_set1_echstore.pod
@@ -207,6 +207,16 @@ and can then access the ECH retry config values via SSL_ech_get1_retry_config()
 where the I<ec> value returned will contain a binary-encoded ECHConfigList
 of length I<eclen>.
 
+If a client makes a real attempt at ECH that fails then the server can also
+return retry config values, and those can be used if they were authenticated
+under the outer SNI used for the session. In this case the TLS session fails
+returning the error B<SSL_R_ECH_REQUIRED>, and the ECH status of
+B<SSL_ECH_STATUS_FAILED_ECH> indicates that retry config values can be
+accessed using SSL_ech_get1_retry_config().  The application can then choose to
+use those in a subsequent attempt to establish a TLS session with the server.
+If the TLS session fails for some other reason (e.g. a bad server Finished
+message), then the retry config values will not be returned to the application.
+
 "GREASEing" (defined in RFC8701) is a mechanism intended to discourage protocol
 ossification that can be used for ECH.
 

--- a/ssl/ech/ech_local.h
+++ b/ssl/ech/ech_local.h
@@ -235,6 +235,13 @@ typedef struct ossl_ech_conn_st {
      * calculation based on the SH (or 2nd SH in case of HRR)
      */
     int success;
+    /*
+     * we set this when we've gotten to the end of the handshake and
+     * the only thing that went wrong was ECH - in that case we're
+     * ok to provide the retry-configs to the client, otherwise better
+     * not.
+     */
+    int retry_configs_ok;
     int grease; /* 1 if we're GREASEing, 0 otherwise */
     char *grease_suite; /* HPKE suite string for GREASEing */
     unsigned char *sent; /* GREASEy ECH value sent, in case needed for re-tx */

--- a/ssl/ech/ech_ssl_apis.c
+++ b/ssl/ech/ech_ssl_apis.c
@@ -313,6 +313,17 @@ int SSL_ech_get1_retry_config(SSL *ssl, unsigned char **ec, size_t *eclen)
         return 1;
     }
     /*
+     * before returning retry-configs check we're in a good
+     * state - either the session has worked, or else it
+     * failed but ECH was the only failure (we only set the
+     * retry_configs_ok flag when all else worked and we're
+     * about to send the ECH required alert)
+     */
+    if (SSL_is_init_finished(ssl) != 1 && s->ext.ech.retry_configs_ok != 1) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_OSSL_STORE_LIB);
+        goto err;
+    }
+    /*
      * To not hand rubbish to application, we'll decode the value we have
      * so only syntactically good things are passed up. We won't insist
      * though that every entry in the retry_config list seems good - it

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -3395,6 +3395,7 @@ int tls_process_initial_server_flight(SSL_CONNECTION *s)
         && s->ext.ech.attempted == 1
         && s->ext.ech.success != 1
         && s->ext.ech.grease != OSSL_ECH_IS_GREASE) {
+        s->ext.ech.retry_configs_ok = 1; /* note those are good */
         SSLfatal(s, SSL_AD_ECH_REQUIRED, SSL_R_ECH_REQUIRED);
         return 0;
     }


### PR DESCRIPTION

@mattcaswell noticed that we were still returning retry config values that were authenticated under the public_name even if the handshake later failed for some other reason (e.g. a bad server Finished message). Doing that could lead to an undesirable outcome, so this PR adds a flag to the ECH connection state (`retry_configs_ok`) that is only set after the server's flight is all good, and that is checked before we release retry configs if the client tried real ECH. (If the client deliberately GREASE'd and the session succeeded we'll also release the retry configs.)

If it's useful, I can add a test for this once #30155 has landed, meanwhile I've verified this via gdb by causing the server Finished check to fail and it seems fine.

This also adds a bit more explanation to the documentation for `SSL_get1_ech_retry_config()` to explain the above.

Great catch btw!

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
