### PR TITLE
crypto/bio/bio_print.c: maintain consistent MSVC feature macro guards

### DIFF
--- a/crypto/bio/bio_print.c
+++ b/crypto/bio/bio_print.c
@@ -28,7 +28,7 @@ int BIO_printf(BIO *bio, const char *format, ...)
     return ret;
 }
 
-#if defined(_WIN32)
+#if defined(_MSC_VER) && _MSC_VER < 1900
 /*
  * _MSC_VER described here:
  * https://learn.microsoft.com/en-us/cpp/overview/compiler-versions?view=msvc-170
@@ -70,7 +70,9 @@ static int msvc_bio_vprintf(BIO *bio, const char *format, va_list args)
 
     return ret;
 }
+#endif
 
+#ifdef _WIN32
 /*
  * This function is for unit test on windows only when built with Visual Studio
  */
@@ -85,13 +87,12 @@ int ossl_BIO_snprintf_msvc(char *buf, size_t n, const char *format, ...)
 
     return ret;
 }
-
 #endif
 
 int BIO_vprintf(BIO *bio, const char *format, va_list args)
 {
     va_list cp_args;
-#if !defined(_MSC_VER) || _MSC_VER > 1900
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
     int sz;
 #endif
     int ret = -1;


### PR DESCRIPTION
I hope the code changes are self evident.

Most of all, all uses of `_MSC_VER` and `_WIN32` should be used
consistently, rather than mixing and matching the two.

`ossl_BIO_snprintf_msvc` remains guarded with `_WIN32` 'cause it's
independent from the rest, so that's fine.
