### PR TITLE
ossl_err_get_state_int(): Avoid saving the last sys error if not needed

### DIFF
--- a/crypto/err/err_blocks.c
+++ b/crypto/err/err_blocks.c
@@ -15,7 +15,7 @@ void ERR_new(void)
 {
     ERR_STATE *es;
 
-    es = ossl_err_get_state_int();
+    es = ossl_err_get_state_int(1);
     if (es == NULL)
         return;
 
@@ -28,7 +28,7 @@ void ERR_set_debug(const char *file, int line, const char *func)
 {
     ERR_STATE *es;
 
-    es = ossl_err_get_state_int();
+    es = ossl_err_get_state_int(1);
     if (es == NULL)
         return;
 
@@ -52,7 +52,7 @@ void ERR_vset_error(int lib, int reason, const char *fmt, va_list args)
     unsigned long flags = 0;
     size_t i;
 
-    es = ossl_err_get_state_int();
+    es = ossl_err_get_state_int(1);
     if (es == NULL)
         return;
     i = es->top;

--- a/crypto/err/err_local.h
+++ b/crypto/err/err_local.h
@@ -112,6 +112,6 @@ static ossl_inline void err_clear(ERR_STATE *es, size_t i, int deall)
     es->err_func[i] = NULL;
 }
 
-ERR_STATE *ossl_err_get_state_int(void);
+ERR_STATE *ossl_err_get_state_int(int save_sys_error);
 void ossl_err_string_int(unsigned long e, const char *func,
     char *buf, size_t len);

--- a/crypto/err/err_mark.c
+++ b/crypto/err/err_mark.c
@@ -14,7 +14,7 @@ int ERR_set_mark(void)
 {
     ERR_STATE *es;
 
-    es = ossl_err_get_state_int();
+    es = ossl_err_get_state_int(0);
     if (es == NULL)
         return 0;
 
@@ -28,7 +28,7 @@ int ERR_pop(void)
 {
     ERR_STATE *es;
 
-    es = ossl_err_get_state_int();
+    es = ossl_err_get_state_int(0);
     if (es == NULL || es->bottom == es->top)
         return 0;
 
@@ -41,7 +41,7 @@ int ERR_pop_to_mark(void)
 {
     ERR_STATE *es;
 
-    es = ossl_err_get_state_int();
+    es = ossl_err_get_state_int(0);
     if (es == NULL)
         return 0;
 
@@ -62,7 +62,7 @@ int ERR_count_to_mark(void)
     ERR_STATE *es;
     int count = 0, top;
 
-    es = ossl_err_get_state_int();
+    es = ossl_err_get_state_int(1);
     if (es == NULL)
         return 0;
 
@@ -81,7 +81,7 @@ int ERR_clear_last_mark(void)
     ERR_STATE *es;
     int top;
 
-    es = ossl_err_get_state_int();
+    es = ossl_err_get_state_int(0);
     if (es == NULL)
         return 0;
 

--- a/crypto/err/err_save.c
+++ b/crypto/err/err_save.c
@@ -32,7 +32,7 @@ void OSSL_ERR_STATE_save(ERR_STATE *es)
     for (i = 0; i < ERR_NUM_ERRORS; i++)
         err_clear(es, i, 1);
 
-    thread_es = ossl_err_get_state_int();
+    thread_es = ossl_err_get_state_int(1);
     if (thread_es == NULL)
         return;
 
@@ -50,7 +50,7 @@ void OSSL_ERR_STATE_save_to_mark(ERR_STATE *es)
     if (es == NULL)
         return;
 
-    thread_es = ossl_err_get_state_int();
+    thread_es = ossl_err_get_state_int(1);
     if (thread_es == NULL) {
         for (i = 0; i < ERR_NUM_ERRORS; ++i)
             err_clear(es, i, 1);
@@ -116,7 +116,7 @@ void OSSL_ERR_STATE_restore(const ERR_STATE *es)
     if (es == NULL || es->bottom == es->top)
         return;
 
-    thread_es = ossl_err_get_state_int();
+    thread_es = ossl_err_get_state_int(0);
     if (thread_es == NULL)
         return;
 


### PR DESCRIPTION
In calls like ERR_set_mark(), ERR_clear_last_mark() and others, there is no point in saving the last sys error.

It can be potentially expensive (on Windows).
