### PR TITLE
Req: No outfile crashes without config

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -552,15 +552,18 @@ int req_main(int argc, char **argv)
         goto end;
     }
 
-    if ((req_conf = app_load_config_verbose(template, verbose)) == NULL)
-        goto end;
-    if (addext_bio != NULL) {
-        if (verbose)
-            BIO_puts(bio_err,
-                "Using additional configuration from -addext options\n");
-        if ((addext_conf = app_load_config_bio(addext_bio, NULL)) == NULL)
+    if (outfile != NULL) {
+        if ((req_conf = app_load_config_verbose(template, verbose)) == NULL)
             goto end;
+        if (addext_bio != NULL) {
+            if (verbose)
+                BIO_puts(bio_err,
+                    "Using additional configuration from -addext options\n");
+            if ((addext_conf = app_load_config_bio(addext_bio, NULL)) == NULL)
+                goto end;
+        }
     }
+
     if (template != default_config_file && !app_load_modules(req_conf))
         goto end;
 

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -572,21 +572,21 @@ subtest "generating certificate requests with -pkeyopt" => sub {
         my $req = "testreq-pkeyopt.pem";
         my $text = "testreq-pkeyopt.txt";
 
-        ok(run(app([ "openssl", "req", "-new",
-            "-config", srctop_file("test", "test.cnf"),
-            "-newkey", "ec", "-pkeyopt", "ec_paramgen_curve:P-384",
-            "-nodes", "-keyout", $key, "-out", $req ])),
-            "Generating request with -pkeyopt ec_paramgen_curve:P-384");
+        ok(run(app(["openssl", "req", "-new",
+                    "-config", srctop_file("test", "test.cnf"),
+                    "-newkey", "ec", "-pkeyopt", "ec_paramgen_curve:P-384",
+                    "-nodes", "-keyout", $key, "-out", $req])),
+           "Generating request with -pkeyopt ec_paramgen_curve:P-384");
 
-        run(app([ "openssl", "req", "-in", $req, "-noout", "-text",
-            "-out", $text ]));
+        run(app(["openssl", "req", "-in", $req, "-noout", "-text",
+                 "-out", $text]));
         test_file_contains("request", $text, "ASN1 OID: secp384r1", 1);
 
-        ok(!run(app([ "openssl", "req", "-new",
-            "-config", srctop_file("test", "test.cnf"),
-            "-newkey", "ec", "-pkeyopt", "bogus_opt:1",
-            "-nodes", "-keyout", $key, "-out", $req ])),
-            "Supplying an unknown -pkeyopt fails");
+        ok(!run(app(["openssl", "req", "-new",
+                     "-config", srctop_file("test", "test.cnf"),
+                     "-newkey", "ec", "-pkeyopt", "bogus_opt:1",
+                     "-nodes", "-keyout", $key, "-out", $req])),
+           "Supplying an unknown -pkeyopt fails");
     }
 };
 
@@ -595,17 +595,17 @@ subtest "Generate cert without system config" => sub {
     plan tests => 3;
 
     ok(run(app(["openssl", "genrsa", "-out", "testreq-key.key", "2048"])),
-                "generate a private key");
+        "generate a private key");
 
     ok(run(app(["openssl", "req",
-                "-new", "-config", srctop_file("test", "test.cnf"),
-                "-key", "testreq-key.key", "-out", "testreq-csr.pem"])),
-                "generate CSR");
+        "-new", "-config", srctop_file("test", "test.cnf"),
+        "-key", "testreq-key.key", "-out", "testreq-csr.pem"])),
+        "generate CSR");
 
     # No system config file. Expect to not segfault/fail
     ok(run(app(["openssl", "req", "-in", "testreq-csr.pem", "-noout"],
-                env => { OPENSSL_CONF => "/dev/null" })),
-                "attempt to read the CSR without a config");
+        env => { OPENSSL_CONF => "/dev/null" })),
+        "attempt to read the CSR without a config");
 };
 
 my @openssl_args = ("req", "-config", srctop_file("apps", "openssl.cnf"));

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -15,7 +15,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_req");
 
-plan tests => 133;
+plan tests => 134;
 
 require_ok(srctop_file('test', 'recipes', 'tconversion.pl'));
 
@@ -572,22 +572,40 @@ subtest "generating certificate requests with -pkeyopt" => sub {
         my $req = "testreq-pkeyopt.pem";
         my $text = "testreq-pkeyopt.txt";
 
-        ok(run(app(["openssl", "req", "-new",
-                    "-config", srctop_file("test", "test.cnf"),
-                    "-newkey", "ec", "-pkeyopt", "ec_paramgen_curve:P-384",
-                    "-nodes", "-keyout", $key, "-out", $req])),
-           "Generating request with -pkeyopt ec_paramgen_curve:P-384");
+        ok(run(app([ "openssl", "req", "-new",
+            "-config", srctop_file("test", "test.cnf"),
+            "-newkey", "ec", "-pkeyopt", "ec_paramgen_curve:P-384",
+            "-nodes", "-keyout", $key, "-out", $req ])),
+            "Generating request with -pkeyopt ec_paramgen_curve:P-384");
 
-        run(app(["openssl", "req", "-in", $req, "-noout", "-text",
-                 "-out", $text]));
+        run(app([ "openssl", "req", "-in", $req, "-noout", "-text",
+            "-out", $text ]));
         test_file_contains("request", $text, "ASN1 OID: secp384r1", 1);
 
-        ok(!run(app(["openssl", "req", "-new",
-                     "-config", srctop_file("test", "test.cnf"),
-                     "-newkey", "ec", "-pkeyopt", "bogus_opt:1",
-                     "-nodes", "-keyout", $key, "-out", $req])),
-           "Supplying an unknown -pkeyopt fails");
+        ok(!run(app([ "openssl", "req", "-new",
+            "-config", srctop_file("test", "test.cnf"),
+            "-newkey", "ec", "-pkeyopt", "bogus_opt:1",
+            "-nodes", "-keyout", $key, "-out", $req ])),
+            "Supplying an unknown -pkeyopt fails");
     }
+};
+
+# Read a CSR without a system config
+subtest "Generate cert without system config" => sub {
+    plan tests => 3;
+
+    ok(run(app(["openssl", "genrsa", "-out", "testreq-key.key", "2048"])),
+                "generate a private key");
+
+    ok(run(app(["openssl", "req",
+                "-new", "-config", srctop_file("test", "test.cnf"),
+                "-key", "testreq-key.key", "-out", "testreq-csr.pem"])),
+                "generate CSR");
+
+    # No system config file. Expect to not segfault/fail
+    ok(run(app(["openssl", "req", "-in", "testreq-csr.pem", "-noout"],
+                env => { OPENSSL_CONF => "/dev/null" })),
+                "attempt to read the CSR without a config");
 };
 
 my @openssl_args = ("req", "-config", srctop_file("apps", "openssl.cnf"));


### PR DESCRIPTION
If the `openssl.cnf` is missing, `req` will crash, even if the `out` option is unused and despite seemingly only being relevant when `out` is used per the top of the [apps/openssl.cnf](https://github.com/openssl/openssl/blob/master/apps/openssl.cnf) file:

>  This is mostly being used for generation of certificate requests,
>  but may be used for auto loading of providers

For example, the following snippet will cause result in `req` crashing when trying to read the CSR:

```
openssl req -new -key priv.key -out csr.pem
rm /usr/local/ssl/openssl.cnf
openssl req -in csr.pem 
```

Fixes #29470