### PR TITLE
Fix Provider compatibility cross test when using the 4.0 FIPS provider

### DIFF
--- a/test/lms_test.c
+++ b/test/lms_test.c
@@ -281,15 +281,21 @@ static int lms_digest_verify_fail_test(void)
     LMS_ACVP_TEST_DATA *td = &lms_testdata[0];
     EVP_PKEY *pub = NULL;
     EVP_MD_CTX *vctx = NULL;
+    int expected = 0;
 
     if (!TEST_ptr(pub = lms_pubkey_from_data(td->pub, td->publen)))
         return 0;
     if (!TEST_ptr(vctx = EVP_MD_CTX_new()))
         goto err;
+
+    /* Prior to OpenSSL 4.0, EVP_DigestVerify is not supported for LMS */
+    if (OSSL_PROVIDER_available(libctx, "fips")
+        && fips_provider_version_match(libctx, ">=4.0.0"))
+        expected = 1;
     /* Only one shot mode is supported, streaming fails to initialise */
     if (!TEST_int_eq(EVP_DigestVerifyInit_ex(vctx, NULL, NULL, libctx, NULL,
                          pub, NULL),
-            0))
+            expected))
         goto err;
     ret = 1;
 err:


### PR DESCRIPTION
OpenSSL 4.0 adds support for using EVP_DigestVerify for LMS. Since OpenSSL 3.6 tests if this fails, it must be updated to check if the OpenSSL 4.0 fips provider is being used.

Related to fixing CI failure in PR #29381

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
