### PR TITLE
Code Comment Correction

### DIFF
--- a/crypto/aes/asm/aes-riscv64-zvbb-zvkg-zvkned.pl
+++ b/crypto/aes/asm/aes-riscv64-zvbb-zvkg-zvkned.pl
@@ -633,7 +633,7 @@ aes_xts_dec_128:
     @{[aes_128_dec]}
     @{[vxor_vv $V24, $V24, $V28]}
 
-    # store second to last block plaintext
+    # store last block plaintext
     @{[vse32_v $V24, $OUTPUT]}
 
     ret
@@ -697,7 +697,7 @@ aes_xts_dec_256:
     @{[aes_256_dec]}
     @{[vxor_vv $V24, $V24, $V28]}
 
-    # store second to last block plaintext
+    # store last block plaintext
     @{[vse32_v $V24, $OUTPUT]}
 
     ret


### PR DESCRIPTION
The comments in the tail handling part of the AES-XTS decryption code were incorrect, which hindered understanding, and have now been fixed.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
