### PR TITLE
Removes support of SSL_CIPHER environment variable in s_time

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,11 +105,19 @@ OpenSSL 4.0
 
  * The `OSSL_ESS_check_signing_certs_ex()` call has been added.
 
-   This api call is an extention to `OSSL_ESS_check_signing_certs()` to add
+   This api call is an extension to `OSSL_ESS_check_signing_certs()` to add
    the ability to specify a library context and property query when fetching
    algorithms to validate a given certificate.
 
    *Neil Horman*
+
+* s_time: `SSL_CIPHER` environment variable support removed.
+
+  s_time supported setting the TLSv1.2 and below cipher list to be used through
+  and undocumented environment variable. Applications should use the `-cipher`
+  instead.
+
+  *Frederik Wedel-Heinen*
 
  * ASN1_OBJECT_new() has been deprecated.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,7 +105,7 @@ OpenSSL 4.0
 
  * The `OSSL_ESS_check_signing_certs_ex()` call has been added.
 
-   This api call is an extension to `OSSL_ESS_check_signing_certs()` to add
+   This api call is an extention to `OSSL_ESS_check_signing_certs()` to add
    the ability to specify a library context and property query when fetching
    algorithms to validate a given certificate.
 

--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -249,9 +249,6 @@ int s_time_main(int argc, char **argv)
     if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
-    if (cipher == NULL)
-        cipher = getenv("SSL_CIPHER");
-
     if ((ctx = SSL_CTX_new(meth)) == NULL)
         goto end;
 

--- a/doc/man1/openssl-s_time.pod.in
+++ b/doc/man1/openssl-s_time.pod.in
@@ -133,16 +133,6 @@ See L<openssl(1)/TLS Version Options>.
 
 =back
 
-=head1 ENVIRONMENT
-
-=over 4
-
-=item B<SSL_CIPHER>
-
-If the B<-cipher> option is not specified, the contents of this environment
-variable are used to modify the TLSv1.2 and below cipher list sent
-by the client the same way the aforementioned option does.
-
 =back
 
 =head1 NOTES

--- a/doc/man7/openssl-env.pod
+++ b/doc/man7/openssl-env.pod
@@ -289,14 +289,6 @@ These variables are considered security-sensitive environment variables,
 except in L<openssl-rehash(1)>, where B<SSL_CERT_DIR> is not considered
 security-sensitive.
 
-=item B<SSL_CIPHER>
-
-Used by L<openssl-s_time(1)> in case B<-cipher> option (that allows modifying
-TLSv1.2 and below cipher list sent by the client) is not provided,
-for specification of the aforementioned ciphers.
-
-This variable is not considered security-sensitive.
-
 =item B<TSGET>
 
 Additional arguments for the L<tsget(1)> command.


### PR DESCRIPTION
Fixes #5411

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
