### PR TITLE
ECH add back code snippet needed for correct ECH backend confirmation

### DIFF
--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1704,7 +1704,8 @@ MSG_PROCESS_RETURN tls_process_client_hello(SSL_CONNECTION *s, PACKET *pkt)
                 goto err;
             }
             if (ossl_ech_intbuf_add(s, s->ext.ech.innerch,
-                    s->ext.ech.innerch_len, 0) != 1) {
+                    s->ext.ech.innerch_len, 0)
+                != 1) {
                 SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
                 goto err;
             }


### PR DESCRIPTION
ECH split-mode was omitted from the ECH feature branch as agreeing the API required will take some more time. So only ECH shared-mode is part of the code recently merged from the feature branch. However, a shared mode server can still act as an ECH split-mode backend server as doing so is relatively trivial and could in future be useful, depending on which servers are updated when.

We (well, I;-) omitted a snippet of code required to do that correctly in an earlier PR for the feature branch. This PR fixes that.

This change is not needed for ECH shared-mode interoperability, which is why I didn't detect it not working until I ran some tests checking the master branch against my ECH split-mode code which hasn't been a part of the feature branch and isn't part of the master branch now.

Not sure if one'd consider this a bug or not. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
