### PR TITLE
NULL pointer dereference of `key` argument ossl_lms_key_to_text()

### DIFF
--- a/providers/implementations/encode_decode/lms_codecs.c
+++ b/providers/implementations/encode_decode/lms_codecs.c
@@ -152,13 +152,16 @@ static const char *get_digest(const char *name)
 
 int ossl_lms_key_to_text(BIO *out, const LMS_KEY *key, int selection)
 {
-    const LMS_PARAMS *lms_params = key->lms_params;
-    const LM_OTS_PARAMS *ots_params = key->ots_params;
+    const LMS_PARAMS *lms_params;
+    const LM_OTS_PARAMS *ots_params;
 
     if (out == NULL || key == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
+    lms_params = key->lms_params;
+    ots_params = key->ots_params;
+
     if (key->pub.encoded == NULL || key->pub.encodedlen == 0) {
         /* Regardless of the |selection|, there must be a public key */
         ERR_raise_data(ERR_LIB_PROV, PROV_R_MISSING_KEY,


### PR DESCRIPTION
Resolves: https://scan5.scan.coverity.com/#/project-view/65248/10222?selectedIssue=1681465
Complements: 3d82b990d1f Added LMS support for OpenSSL commandline signature verification using pkeyutl.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
