### PR TITLE
windows-makefile: make clean target less noisy

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -453,15 +453,15 @@ libclean:
 	-del /Q /F $(LIBS) libcrypto.* libssl.* ossl_static.pdb
 
 clean: libclean
-	{- join("\n\t", map { "-del /Q /F $_" } @HTMLDOCS1) || "\@rem" -}
-	{- join("\n\t", map { "-del /Q /F $_" } @HTMLDOCS3) || "\@rem" -}
-	{- join("\n\t", map { "-del /Q /F $_" } @HTMLDOCS5) || "\@rem" -}
-	{- join("\n\t", map { "-del /Q /F $_" } @HTMLDOCS7) || "\@rem" -}
-	{- join("\n\t", map { "-del /Q /F $_" } @PROGRAMS) || "\@rem" -}
-	{- join("\n\t", map { "-del /Q /F $_" } @MODULES) || "\@rem" -}
-	{- join("\n\t", map { "-del /Q /F $_" } @SCRIPTS) || "\@rem" -}
-	{- join("\n\t", map { "-del /Q /F $_" } @GENERATED_MANDATORY) || "\@rem" -}
-	{- join("\n\t", map { "-del /Q /F $_" } @GENERATED) || "\@rem" -}
+	{- join("\n\t", map { "-if exist $_ del /Q /F $_" } @HTMLDOCS1) || "\@rem" -}
+	{- join("\n\t", map { "-if exist $_ del /Q /F $_" } @HTMLDOCS3) || "\@rem" -}
+	{- join("\n\t", map { "-if exist $_ del /Q /F $_" } @HTMLDOCS5) || "\@rem" -}
+	{- join("\n\t", map { "-if exist $_ del /Q /F $_" } @HTMLDOCS7) || "\@rem" -}
+	{- join("\n\t", map { "-if exist $_ del /Q /F $_" } @PROGRAMS) || "\@rem" -}
+	{- join("\n\t", map { "-if exist $_ del /Q /F $_" } @MODULES) || "\@rem" -}
+	{- join("\n\t", map { "-if exist $_ del /Q /F $_" } @SCRIPTS) || "\@rem" -}
+	{- join("\n\t", map { "-if exist $_ del /Q /F $_" } @GENERATED_MANDATORY) || "\@rem" -}
+	{- join("\n\t", map { "-if exist $_ del /Q /F $_" } @GENERATED) || "\@rem" -}
 	-del /Q /S /F *.d *.obj *.pdb *.ilk *.manifest
 	-del /Q /S /F apps\*.lib apps\*.rc apps\*.res apps\*.exp
 	-del /Q /S /F test\*.exp


### PR DESCRIPTION
Using del on files that are not present creates many warning messages. 
Let's wrap them in "if exists" check to make them silent if not present.
