### PR TITLE
asn1: use ASN1_STRING accessors in crypto/cmp, crypto/ct, crypto/sm2, crypto/ts

### DIFF
--- a/crypto/cmp/cmp_protect.c
+++ b/crypto/cmp/cmp_protect.c
@@ -72,8 +72,8 @@ ASN1_BIT_STRING *ossl_cmp_calc_protection(const OSSL_CMP_CTX *ctx,
         prot_part_der_len = (size_t)len;
 
         pbm_str = (ASN1_STRING *)ppval;
-        pbm_str_uc = pbm_str->data;
-        pbm = d2i_OSSL_CRMF_PBMPARAMETER(NULL, &pbm_str_uc, pbm_str->length);
+        pbm_str_uc = ASN1_STRING_get0_data(pbm_str);
+        pbm = d2i_OSSL_CRMF_PBMPARAMETER(NULL, &pbm_str_uc, ASN1_STRING_length(pbm_str));
         if (pbm == NULL) {
             ERR_raise(ERR_LIB_CMP, CMP_R_WRONG_ALGORITHM_OID);
             goto end;
@@ -81,7 +81,7 @@ ASN1_BIT_STRING *ossl_cmp_calc_protection(const OSSL_CMP_CTX *ctx,
 
         if (!OSSL_CRMF_pbm_new(ctx->libctx, ctx->propq,
                 pbm, prot_part_der, prot_part_der_len,
-                ctx->secretValue->data, ctx->secretValue->length,
+                ASN1_STRING_get0_data(ctx->secretValue), ASN1_STRING_length(ctx->secretValue),
                 &protection, &sig_len))
             goto end;
 

--- a/crypto/sm2/sm2_crypt.c
+++ b/crypto/sm2/sm2_crypt.c
@@ -25,8 +25,6 @@
 #include <openssl/asn1t.h>
 #include <string.h>
 
-#include <crypto/asn1.h>
-
 typedef struct SM2_Ciphertext_st SM2_Ciphertext;
 DECLARE_ASN1_FUNCTIONS(SM2_Ciphertext)
 
@@ -80,7 +78,7 @@ int ossl_sm2_plaintext_size(const unsigned char *ct, size_t ct_size,
         return 0;
     }
 
-    *pt_size = sm2_ctext->C2->length;
+    *pt_size = ASN1_STRING_length(sm2_ctext->C2);
     SM2_Ciphertext_free(sm2_ctext);
 
     return 1;
@@ -316,14 +314,14 @@ int ossl_sm2_decrypt(const EC_KEY *key,
         goto done;
     }
 
-    if (sm2_ctext->C3->length != hash_size) {
+    if (ASN1_STRING_length(sm2_ctext->C3) != hash_size) {
         ERR_raise(ERR_LIB_SM2, SM2_R_INVALID_ENCODING);
         goto done;
     }
 
-    C2 = sm2_ctext->C2->data;
-    C3 = sm2_ctext->C3->data;
-    msg_len = sm2_ctext->C2->length;
+    C2 = ASN1_STRING_get0_data(sm2_ctext->C2);
+    C3 = ASN1_STRING_get0_data(sm2_ctext->C3);
+    msg_len = ASN1_STRING_length(sm2_ctext->C2);
     if (*ptext_len < (size_t)msg_len) {
         ERR_raise(ERR_LIB_SM2, SM2_R_BUFFER_TOO_SMALL);
         goto done;

--- a/crypto/ts/ts_asn1.c
+++ b/crypto/ts/ts_asn1.c
@@ -12,8 +12,6 @@
 #include <openssl/asn1t.h>
 #include "ts_local.h"
 
-#include <crypto/asn1.h>
-
 ASN1_SEQUENCE(TS_MSG_IMPRINT) = {
     ASN1_SIMPLE(TS_MSG_IMPRINT, hash_algo, X509_ALGOR),
     ASN1_SIMPLE(TS_MSG_IMPRINT, hashed_msg, ASN1_OCTET_STRING)
@@ -231,6 +229,6 @@ TS_TST_INFO *PKCS7_to_TS_TST_INFO(PKCS7 *token)
         return NULL;
     }
     tst_info_der = tst_info_wrapper->value.octet_string;
-    p = tst_info_der->data;
-    return d2i_TS_TST_INFO(NULL, &p, tst_info_der->length);
+    p = ASN1_STRING_get0_data(tst_info_der);
+    return d2i_TS_TST_INFO(NULL, &p, ASN1_STRING_length(tst_info_der));
 }

--- a/crypto/ts/ts_rsp_sign.c
+++ b/crypto/ts/ts_rsp_sign.c
@@ -19,8 +19,6 @@
 #include "crypto/ess.h"
 #include "ts_local.h"
 
-#include <crypto/asn1.h>
-
 DEFINE_STACK_OF_CONST(EVP_MD)
 
 static ASN1_INTEGER *def_serial_cb(struct TS_resp_ctx *, void *);
@@ -489,7 +487,7 @@ static int ts_RESP_check_request(TS_RESP_CTX *ctx)
         return 0;
     }
     digest = msg_imprint->hashed_msg;
-    if (digest->length != md_size) {
+    if (ASN1_STRING_length(digest) != md_size) {
         TS_RESP_CTX_set_status_info(ctx, TS_STATUS_REJECTION,
             "Bad message digest.");
         TS_RESP_CTX_add_failure_info(ctx, TS_INFO_BAD_DATA_FORMAT);

--- a/crypto/ts/ts_rsp_verify.c
+++ b/crypto/ts/ts_rsp_verify.c
@@ -16,8 +16,6 @@
 #include "crypto/ess.h"
 #include "ts_local.h"
 
-#include <crypto/asn1.h>
-
 static int ts_verify_cert(X509_STORE *store, STACK_OF(X509) *untrusted,
     X509 *signer, STACK_OF(X509) **chain);
 static int ts_check_signing_certs(const PKCS7_SIGNER_INFO *si,
@@ -213,8 +211,8 @@ static ESS_SIGNING_CERT *ossl_ess_get_signing_cert(const PKCS7_SIGNER_INFO *si)
     attr = PKCS7_get_signed_attribute(si, NID_id_smime_aa_signingCertificate);
     if (attr == NULL || attr->type != V_ASN1_SEQUENCE)
         return NULL;
-    p = attr->value.sequence->data;
-    return d2i_ESS_SIGNING_CERT(NULL, &p, attr->value.sequence->length);
+    p = ASN1_STRING_get0_data(attr->value.sequence);
+    return d2i_ESS_SIGNING_CERT(NULL, &p, ASN1_STRING_length(attr->value.sequence));
 }
 
 static ESS_SIGNING_CERT_V2 *ossl_ess_get_signing_cert_v2(const PKCS7_SIGNER_INFO *si)
@@ -225,8 +223,8 @@ static ESS_SIGNING_CERT_V2 *ossl_ess_get_signing_cert_v2(const PKCS7_SIGNER_INFO
     attr = PKCS7_get_signed_attribute(si, NID_id_smime_aa_signingCertificateV2);
     if (attr == NULL || attr->type != V_ASN1_SEQUENCE)
         return NULL;
-    p = attr->value.sequence->data;
-    return d2i_ESS_SIGNING_CERT_V2(NULL, &p, attr->value.sequence->length);
+    p = ASN1_STRING_get0_data(attr->value.sequence);
+    return d2i_ESS_SIGNING_CERT_V2(NULL, &p, ASN1_STRING_length(attr->value.sequence));
 }
 
 static int ts_check_signing_certs(const PKCS7_SIGNER_INFO *si,


### PR DESCRIPTION
Part of #29861. Follows from #29862.

Replace direct `ASN1_STRING` struct member access (`->data`, `->length`)
with public accessor functions (`ASN1_STRING_get0_data()`,
`ASN1_STRING_length()`) in consumer code across four subsystems.

---

### Files changed

| File | Changes |
|---|---|
| `crypto/ct/ct_oct.c` | Remove `<crypto/asn1.h>`; replace `->data`/`->length` in `d2i_SCT_LIST()`; fix `i2d_SCT_LIST()` to heap-allocate `ASN1_OCTET_STRING` (stack allocation no longer valid with opaque struct) |
| `crypto/sm2/sm2_crypt.c` | Remove `<crypto/asn1.h>`; replace 5 accesses on `C2`/`C3` fields |
| `crypto/ts/ts_asn1.c` | Remove `<crypto/asn1.h>`; replace `->data`/`->length` on `tst_info_der` |
| `crypto/ts/ts_rsp_sign.c` | Remove `<crypto/asn1.h>`; replace `->length` on `digest` |
| `crypto/ts/ts_rsp_verify.c` | Remove `<crypto/asn1.h>`; replace 4 accesses across `ossl_ess_get_signing_cert()` and `ossl_ess_get_signing_cert_v2()` |
| `crypto/cmp/cmp_protect.c` | Replace 3 accesses; retain `<crypto/asn1.h>` for `ossl_X509_ALGOR_from_nid()` and `ossl_asn1_string_set_bits_left()` |

---

### Notes

- `->type` accesses in `ts_asn1.c` and `ts_rsp_verify.c` were left
  unchanged — they are on `ASN1_TYPE *` and `PKCS7 *` respectively,
  which are still public structs.
- `apps/pkcs12.c` was already converted in #29862 and required no changes.

---

### Testing

All tests pass on WSL Fedora 43 (GCC 15.2.1):

No new tests or documentation were added.

---
### Future Work
This is part of a series working through all consumer files identified in #29861:

- **Part 3**: `crypto/x509/` — read-only accessor sites
- **Part 4**: `crypto/x509/` — write-side + `crypto/ocsp/` + `crypto/rsa/`
- **Part 5**: `crypto/cms/` + `crypto/crmf/` + `crypto/pkcs7/`
- **Part 6**: `crypto/dh/` + `crypto/dsa/` + `crypto/ec/` + providers + ssl + test

---

*Tagging for contribution tracking: @bbbrumley*