### PR TITLE
Fix logic errors for HMAC-DRBG

### DIFF
--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -437,7 +437,7 @@ static int drbg_fetch_algs_from_prov(const OSSL_PARAM params[],
 
     p = OSSL_PARAM_locate_const(params, OSSL_ALG_PARAM_DIGEST);
     if (p) {
-        if (OSSL_PARAM_get_utf8_string_ptr(p, &digest_name)) {
+        if (!OSSL_PARAM_get_utf8_string_ptr(p, &digest_name)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_VALUE_ERROR);
             goto done;
         }
@@ -458,7 +458,7 @@ static int drbg_fetch_algs_from_prov(const OSSL_PARAM params[],
     if (p == NULL) {
         hmac_name = "HMAC";
     } else {
-        if (OSSL_PARAM_get_utf8_string_ptr(p, &hmac_name)) {
+        if (!OSSL_PARAM_get_utf8_string_ptr(p, &hmac_name)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_VALUE_ERROR);
             goto done;
         }


### PR DESCRIPTION
Bug introduced in https://github.com/openssl/openssl/pull/29570

https://github.com/openssl/openssl/pull/29570 for OpenSSL 3.5 had two logic errors (missing negation). This issue doesn't affect 3.6 and master.

Fixes https://github.com/openssl/private/issues/865