### PR TITLE
X509_dup_ref

### DIFF
--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -125,13 +125,6 @@ int X509_up_ref(const X509 *x)
     return i > 1;
 }
 
-void X509_down_ref(const X509 *x)
-{
-    int i;
-
-    X509_free((X509 *)x);
-}
-
 X509 *X509_dup_ref(const X509 *x)
 {
     if (x == NULL)

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -125,6 +125,13 @@ int X509_up_ref(const X509 *x)
     return i > 1;
 }
 
+void X509_down_ref(const X509 *x)
+{
+    int i;
+
+    X509_free((X509 *)x);
+}
+
 X509 *X509_dup_ref(const X509 *x)
 {
     if (x == NULL)

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -113,16 +113,25 @@ int X509_set_pubkey(X509 *x, EVP_PKEY *pkey)
     return 1;
 }
 
-int X509_up_ref(X509 *x)
+int X509_up_ref(const X509 *x)
 {
     int i;
 
-    if (CRYPTO_UP_REF(&x->references, &i) <= 0)
+    if (CRYPTO_UP_REF(&((X509 *)x)->references, &i) <= 0)
         return 0;
 
     REF_PRINT_COUNT("X509", i, x);
     REF_ASSERT_ISNT(i < 2);
     return i > 1;
+}
+
+X509 *X509_dup_ref(const X509 *x)
+{
+    if (x == NULL)
+        return NULL;
+    if (X509_up_ref(x))
+        return (X509 *)x;
+    return NULL;
 }
 
 long X509_get_version(const X509 *x)

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -113,11 +113,11 @@ int X509_set_pubkey(X509 *x, EVP_PKEY *pkey)
     return 1;
 }
 
-int X509_up_ref(const X509 *x)
+int X509_up_ref(X509 *x)
 {
     int i;
 
-    if (CRYPTO_UP_REF(&((X509 *)x)->references, &i) <= 0)
+    if (CRYPTO_UP_REF(&x->references, &i) <= 0)
         return 0;
 
     REF_PRINT_COUNT("X509", i, x);

--- a/doc/man3/X509_new.pod
+++ b/doc/man3/X509_new.pod
@@ -16,7 +16,6 @@ OSSL_STACK_OF_X509_free
  X509 *X509_new_ex(OSSL_LIB_CTX *libctx, const char *propq);
  void X509_free(X509 *a);
  int X509_up_ref(const X509 *a);
- void X509_down_ref(const X509 *a);
  X509 * X509_dup_ref(const X509 *a);
  STACK_OF(X509) *X509_chain_up_ref(STACK_OF(X509) *x);
  void OSSL_STACK_OF_X509_free(STACK_OF(X509) *certs);
@@ -48,10 +47,6 @@ owned non-const "shallow copy" of B<a> by virtue of having increased
 the reference count. The returned value should be also considered not
 mutable, but once finished with B<a> you may lower the reference count
 by calling X509_free() on the returned value.
-
-X509_down_ref() decrements the reference count of B<a>. This should be used
-when you have retained a reference on a const X509 where you expect the owner
-to call X509_free();
 
 X509_chain_up_ref() increases the reference count of all certificates in
 chain B<x> and returns a copy of the stack, or an empty stack if B<a> is NULL.

--- a/doc/man3/X509_new.pod
+++ b/doc/man3/X509_new.pod
@@ -15,7 +15,7 @@ OSSL_STACK_OF_X509_free
  X509 *X509_new(void);
  X509 *X509_new_ex(OSSL_LIB_CTX *libctx, const char *propq);
  void X509_free(X509 *a);
- int X509_up_ref(const X509 *a);
+ int X509_up_ref(X509 *a);
  X509 * X509_dup_ref(const X509 *a);
  STACK_OF(X509) *X509_chain_up_ref(STACK_OF(X509) *x);
  void OSSL_STACK_OF_X509_free(STACK_OF(X509) *certs);

--- a/doc/man3/X509_new.pod
+++ b/doc/man3/X509_new.pod
@@ -16,6 +16,7 @@ OSSL_STACK_OF_X509_free
  X509 *X509_new_ex(OSSL_LIB_CTX *libctx, const char *propq);
  void X509_free(X509 *a);
  int X509_up_ref(const X509 *a);
+ void X509_down_ref(const X509 *a);
  X509 * X509_dup_ref(const X509 *a);
  STACK_OF(X509) *X509_chain_up_ref(STACK_OF(X509) *x);
  void OSSL_STACK_OF_X509_free(STACK_OF(X509) *certs);
@@ -47,6 +48,10 @@ owned non-const "shallow copy" of B<a> by virtue of having increased
 the reference count. The returned value should be also considered not
 mutable, but once finished with B<a> you may lower the reference count
 by calling X509_free() on the returned value.
+
+X509_down_ref() decrements the reference count of B<a>. This should be used
+when you have retained a reference on a const X509 where you expect the owner
+to call X509_free();
 
 X509_chain_up_ref() increases the reference count of all certificates in
 chain B<x> and returns a copy of the stack, or an empty stack if B<a> is NULL.

--- a/doc/man3/X509_new.pod
+++ b/doc/man3/X509_new.pod
@@ -3,7 +3,7 @@
 =head1 NAME
 
 X509_new, X509_new_ex,
-X509_free, X509_up_ref,
+X509_free, X509_up_ref, X509_dup_ref,
 X509_chain_up_ref,
 OSSL_STACK_OF_X509_free
 - X509 certificate ASN1 allocation and deallocation functions
@@ -15,7 +15,8 @@ OSSL_STACK_OF_X509_free
  X509 *X509_new(void);
  X509 *X509_new_ex(OSSL_LIB_CTX *libctx, const char *propq);
  void X509_free(X509 *a);
- int X509_up_ref(X509 *a);
+ int X509_up_ref(const X509 *a);
+ X509 * X509_dup_ref(const X509 *a);
  STACK_OF(X509) *X509_chain_up_ref(STACK_OF(X509) *x);
  void OSSL_STACK_OF_X509_free(STACK_OF(X509) *certs);
 
@@ -40,6 +41,12 @@ frees it up if the reference count is zero. If the argument is NULL,
 nothing is done.
 
 X509_up_ref() increments the reference count of B<a>.
+
+X509_dup_ref() increments the reference count of B<a>, returning an
+owned non-const "shallow copy" of B<a> by virtue of having increased
+the reference count. The returned value should be also considered not
+mutable, but once finished with B<a> you may lower the reference count
+by calling X509_free() on the returned value.
 
 X509_chain_up_ref() increases the reference count of all certificates in
 chain B<x> and returns a copy of the stack, or an empty stack if B<a> is NULL.
@@ -66,6 +73,8 @@ code that can be obtained by L<ERR_get_error(3)>.
 Otherwise it returns a pointer to the newly allocated structure.
 
 X509_up_ref() returns 1 for success and 0 for failure.
+
+X509_dup_ref() returns a non const copy of B<a> for success and NULL for failure.
 
 X509_chain_up_ref() returns a copy of the stack or NULL if an error occurred.
 

--- a/doc/man7/ossl-guide-migration.pod
+++ b/doc/man7/ossl-guide-migration.pod
@@ -170,6 +170,12 @@ X509_TRUST_add
 X509v3_addr_validate_resource_set
 X509v3_asid_validate_resource_set
 
+X509_up_ref will take a const X509* pointer. However of note, like C free
+functions, X509_free() will not. If you are keeping an owning "shallow copy"
+of a const X509 somewhere that you wish to up_ref and then free, use X509_dup_ref()
+instead. The resulting X509 * is a non-const shallow copy which should not be
+modified, but you may then call X509_free.
+
 The following two functions we "un-constified" As they were documented as returning
 an explicitly mutable pointer from within an B<X509> object:
 

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -673,6 +673,7 @@ const ASN1_TIME *X509_get0_notAfter(const X509 *x);
 ASN1_TIME *X509_getm_notAfter(X509 *x);
 int X509_set1_notAfter(X509 *x, const ASN1_TIME *tm);
 int X509_up_ref(const X509 *x);
+void X509_down_ref(const X509 *x);
 X509 *X509_dup_ref(const X509 *x);
 int X509_get_signature_type(const X509 *x);
 

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -673,7 +673,6 @@ const ASN1_TIME *X509_get0_notAfter(const X509 *x);
 ASN1_TIME *X509_getm_notAfter(X509 *x);
 int X509_set1_notAfter(X509 *x, const ASN1_TIME *tm);
 int X509_up_ref(const X509 *x);
-void X509_down_ref(const X509 *x);
 X509 *X509_dup_ref(const X509 *x);
 int X509_get_signature_type(const X509 *x);
 

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -672,7 +672,8 @@ int X509_set1_notBefore(X509 *x, const ASN1_TIME *tm);
 const ASN1_TIME *X509_get0_notAfter(const X509 *x);
 ASN1_TIME *X509_getm_notAfter(X509 *x);
 int X509_set1_notAfter(X509 *x, const ASN1_TIME *tm);
-int X509_up_ref(X509 *x);
+int X509_up_ref(const X509 *x);
+X509 *X509_dup_ref(const X509 *x);
 int X509_get_signature_type(const X509 *x);
 
 #ifndef OPENSSL_NO_DEPRECATED_1_1_0

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -672,7 +672,7 @@ int X509_set1_notBefore(X509 *x, const ASN1_TIME *tm);
 const ASN1_TIME *X509_get0_notAfter(const X509 *x);
 ASN1_TIME *X509_getm_notAfter(X509 *x);
 int X509_set1_notAfter(X509 *x, const ASN1_TIME *tm);
-int X509_up_ref(const X509 *x);
+int X509_up_ref(X509 *x);
 X509 *X509_dup_ref(const X509 *x);
 int X509_get_signature_type(const X509 *x);
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5714,3 +5714,4 @@ OSSL_ENCODER_CTX_ctrl_string            ?	4_0_0	EXIST::FUNCTION:
 OPENSSL_sk_set_cmp_thunks               ?	4_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_set1                    ?	4_0_0	EXIST::FUNCTION:
 OSSL_ESS_check_signing_certs_ex         ?	4_0_0	EXIST::FUNCTION:
+X509_dup_ref                            ?	4_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Partly based on what is done in boringssl.

This makes a special "dup_ref" function which increases the refcount when you want to hang on to a const X509 object, returning you an X509 * on which you should call X509_free() when done. This mimics ownership without
making an actual copy.

X509_free in this case should remain unchanged and only take non-const. 

For #30095 
Fixes: #30237

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
