### PR TITLE
ech test retry-configs unavailable if server finished corrupted (2nd try)

### DIFF
--- a/test/ech_corrupt_test.c
+++ b/test/ech_corrupt_test.c
@@ -1730,7 +1730,7 @@ static int ech_retry_config_test(int idx)
                     err_reason, err_str);
         } while (err_reason != exp_err);
         if (verbose)
-            TEST_info("ech_retry_config_test: retry configs witheld\n");
+            TEST_info("ech_retry_config_test: retry configs withheld\n");
     }
     res = 1;
 end:


### PR DESCRIPTION
This adds a test to check that retry-configs (authenticated under the public-name) are not made available if the handshake fails later. This test complements https://github.com/openssl/openssl/pull/30175.

Note that the implementation of this test may be a bit 'cheeky': what we want to do is inject a bad server Finished message into the handshake in order to demonstrate that the retry-configs are not returned in that case. To do that we use the SSL_set_msg_callback() function, which, it turns out, returns a pointer to the actual message buffer to the caller, thus allowing the caller to corrupt that message via XOR. That's not a documented feature as far as I can see.

While the cheekiness is documented in the test code, I guess its possible that behaviour might change in future. If there's a better way to do this test, happy to change to use that.

##### Checklist
- [ ] documentation is added or updated
- [x] tests are added or updated

Mea culpa: I previously submitted  this as #30240 but mucked that up, hopefully this PR is clean.
