### PR TITLE
Cherry pick the dynamic key change, and use it with separate hash tables for propq and default algs.

### DIFF
--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -357,14 +357,9 @@ inner_evp_generic_fetch(struct evp_method_data_st *methdata,
         return NULL;
     }
 
-    if (ossl_method_store_is_frozen(store)) {
-        const char *store_propq = ossl_method_store_frozen_propq(store);
-
-        if (*propq == '\0' || strcmp(store_propq, propq) == 0) {
-            ossl_frozen_method_store_cache_get(store, name, propq, &method);
-            return method;
-        }
-    }
+    if (ossl_method_store_is_frozen(store)
+        && ossl_frozen_method_store_cache_get(store, name, propq, &method))
+        return method;
 
     /* If we haven't received a name id yet, try to get one for the name */
     name_id = name != NULL ? ossl_namemap_name2num(namemap, name) : 0;

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -69,8 +69,10 @@ struct ossl_method_store_st {
     OSSL_LIB_CTX *ctx;
     SPARSE_ARRAY_OF(ALGORITHM) * algs;
 
-    /* (nid, propq) -> method  */
+    /* (nid) -> method */
     HT *frozen_algs;
+    /* (nid) -> method for store's frozen_propq */
+    HT *frozen_algs_pq;
     /*
      * Lock to protect the |algs| array from concurrent writing, when
      * individual implementations or queries are inserted.  This is used
@@ -113,8 +115,6 @@ DEFINE_STACK_OF(ALGORITHM)
 
 HT_START_KEY_DEFN(frozen_cache_key)
 HT_DEF_KEY_FIELD_CHAR_ARRAY(name, 64)
-/* TODO(FREEZE): allow variable length propq */
-HT_DEF_KEY_FIELD_CHAR_ARRAY(propq, 64)
 HT_END_KEY_DEFN(FROZEN_CACHE_KEY)
 
 typedef struct ossl_global_properties_st {
@@ -304,8 +304,8 @@ void ossl_method_store_free(OSSL_METHOD_STORE *store)
     if (store != NULL) {
         if (store->algs != NULL)
             ossl_sa_ALGORITHM_doall_arg(store->algs, &alg_cleanup, store);
-        if (store->frozen_algs != NULL)
-            ossl_ht_free(store->frozen_algs);
+        ossl_ht_free(store->frozen_algs);
+        ossl_ht_free(store->frozen_algs_pq);
         ossl_sa_ALGORITHM_free(store->algs);
         CRYPTO_THREAD_lock_free(store->lock);
         CRYPTO_THREAD_lock_free(store->biglock);
@@ -1020,28 +1020,66 @@ end:
     return res;
 }
 
+static void ossl_frozen_ht_bucket_fetch(HT *ht, const char *alg_name, void **method)
+{
+    HT_VALUE *val = NULL;
+
+    FROZEN_CACHE_KEY key;
+    HT_INIT_RAW_KEY(&key);
+    HT_COPY_RAW_KEY_CASE(TO_HT_KEY(&key), alg_name, (int)strlen(alg_name));
+    val = ossl_ht_get(ht, TO_HT_KEY(&key));
+
+    if (val != NULL)
+        *method = ((METHOD *)val->value)->method;
+}
+
+static int ossl_frozen_ht_bucket_insert(HT *ht, const char *alg_name, HT_VALUE *val)
+{
+    FROZEN_CACHE_KEY key;
+    HT_INIT_RAW_KEY(&key);
+    HT_COPY_RAW_KEY_CASE(TO_HT_KEY(&key), alg_name, (int)strlen(alg_name));
+    return ossl_ht_insert(ht, TO_HT_KEY(&key), val, NULL);
+}
+
+/*
+ * Fetch matching method from frozen cache.
+ *
+ * returns 1 on success, when the cache has an authoritative answer for name and propq
+ * indicating that *method should be used.
+ *
+ * returns 0 on failure, when the cache does not have an authoritative answer for
+ * name and propq, indicating that other means must be used to find a method.
+ *
+ * on success, *method will the matching method from the cache for
+ * name and propq, or to NULL if there is no such method.
+ */
 int ossl_frozen_method_store_cache_get(OSSL_METHOD_STORE *store,
     const char *alg_name, const char *prop_query, void **method)
 {
-    FROZEN_CACHE_KEY key;
-    HT_VALUE *val;
+    int ret = 0;
 
     if (store == NULL
         || alg_name == NULL
-        || prop_query == NULL
-        || store->frozen_algs == NULL)
-        return 0;
+        || store->frozen_algs == NULL
+        || store->frozen_algs_pq == NULL)
+        goto done;
 
-    HT_INIT_KEY(&key);
-    HT_SET_KEY_STRING_CASE(&key, name, alg_name);
-    HT_SET_KEY_STRING(&key, propq, prop_query);
+    /*
+     * XXX Empty string propquery means "no propquery" for
+     * the moment because of HT. perhaps switch to only NULL?
+     */
+    if (prop_query == NULL || *prop_query == '\0') {
+        *method = NULL;
+        ossl_frozen_ht_bucket_fetch(store->frozen_algs, alg_name, method);
+        ret = 1;
+    } else if (strcmp(prop_query, store->frozen_propq) == 0) {
+        *method = NULL;
+        ossl_frozen_ht_bucket_fetch(store->frozen_algs_pq, alg_name, method);
+        ret = 1;
+    }
 
-    val = ossl_ht_get(store->frozen_algs, TO_HT_KEY(&key));
-    if (val == NULL)
-        return 1;
-    *method = ((METHOD *)val->value)->method;
-
-    return 1;
+done:
+    return ret;
 }
 
 struct alg_freeze_st {
@@ -1066,15 +1104,11 @@ static int freeze_alg(OSSL_METHOD_STORE *store, ALGORITHM *alg,
 {
     int ret = 0;
     IMPLEMENTATION *best_impl = NULL;
-    FROZEN_CACHE_KEY key;
     HT_VALUE val = { 0 };
     const OSSL_PROVIDER *prov = NULL;
+    void *method;
 
-    HT_INIT_KEY(&key);
-    HT_SET_KEY_STRING_CASE(&key, name, alg_name);
-    HT_SET_KEY_STRING(&key, propq, propq);
-
-    if (ossl_ht_get(store->frozen_algs, TO_HT_KEY(&key)) != NULL)
+    if (ossl_frozen_method_store_cache_get(store, alg_name, propq, &method) && method != NULL)
         return 1;
 
     ret = ossl_method_store_fetch_best_impl(store,
@@ -1088,7 +1122,11 @@ static int freeze_alg(OSSL_METHOD_STORE *store, ALGORITHM *alg,
     if (val.value == NULL)
         return ret;
 
-    ret = ossl_ht_insert(store->frozen_algs, TO_HT_KEY(&key), &val, NULL);
+    if (propq == NULL || *propq == '\0')
+        ret = ossl_frozen_ht_bucket_insert(store->frozen_algs, alg_name, &val);
+    else
+        ret = ossl_frozen_ht_bucket_insert(store->frozen_algs_pq, alg_name, &val);
+
     if (ret <= 0) {
         frozen_cache_free(&val);
         return 0;
@@ -1164,6 +1202,9 @@ int ossl_method_store_freeze_cache(OSSL_METHOD_STORE *store, const char *propq)
     store->frozen_algs = ossl_ht_new(&ht_conf);
     if (store->frozen_algs == NULL)
         goto err;
+    store->frozen_algs_pq = ossl_ht_new(&ht_conf);
+    if (store->frozen_algs == NULL)
+        goto err;
 
     if (evp_md_fetch_all(store->ctx) <= 0)
         goto err;
@@ -1180,9 +1221,11 @@ int ossl_method_store_freeze_cache(OSSL_METHOD_STORE *store, const char *propq)
 
 err:
     OPENSSL_free(store->frozen_propq);
+    store->frozen_propq = NULL;
     ossl_ht_free(store->frozen_algs);
     store->frozen_algs = NULL;
-    store->frozen_propq = NULL;
+    ossl_ht_free(store->frozen_algs_pq);
+    store->frozen_algs_pq = NULL;
 
     return 0;
 }

--- a/include/internal/hashtable.h
+++ b/include/internal/hashtable.h
@@ -24,6 +24,7 @@ typedef struct ht_internal_st HT;
  */
 typedef struct ht_key_header_st {
     size_t keysize;
+    size_t bufsize;
     uint8_t *keybuf;
 } HT_KEY;
 
@@ -107,11 +108,62 @@ typedef struct ht_config_st {
 /*
  * Initializes a key
  */
-#define HT_INIT_KEY(key)                                                \
-    do {                                                                \
-        memset((key), 0, sizeof(*(key)));                               \
-        (key)->key_header.keysize = (sizeof(*(key)) - sizeof(HT_KEY));  \
-        (key)->key_header.keybuf = (((uint8_t *)key) + sizeof(HT_KEY)); \
+#define HT_INIT_KEY(key)                                                                           \
+    do {                                                                                           \
+        memset((key), 0, sizeof(*(key)));                                                          \
+        (key)->key_header.keysize = (key)->key_header.bufsize = (sizeof(*(key)) - sizeof(HT_KEY)); \
+        (key)->key_header.keybuf = (((uint8_t *)key) + sizeof(HT_KEY));                            \
+    } while (0)
+
+/*
+ * Initializes a key as a raw buffer
+ * This operates identically to HT_INIT_KEY
+ * but it treats the provided key as a raw buffer
+ * and iteratively accounts the running amount of
+ * data copied into the key from the caller.
+ *
+ * This MUST be used with the RAW macros below:
+ * HT_COPY_RAW_KEY
+ * HT_COPY_RAW_KEY_CASE
+ */
+#define HT_INIT_RAW_KEY(key)           \
+    do {                               \
+        HT_INIT_KEY((key));            \
+        (key)->key_header.keysize = 0; \
+    } while (0)
+
+/*
+ * Helper function to copy raw data into a key
+ * This should not be called independently
+ * use the HT_COPY_RAW_KEY macro instead
+ */
+static ossl_inline ossl_unused int ossl_key_raw_copy(HT_KEY *key, const uint8_t *buf, size_t len)
+{
+    if (key->keysize + len > key->bufsize)
+        return 0;
+    memcpy(&key->keybuf[key->keysize], buf, len);
+    key->keysize += len;
+    return 1;
+}
+
+/*
+ * Copy data directly into a key
+ * When initialized with HT_INIT_RAW_KEY, this macro
+ * can be used to copy packed data into a key for hashtable usage
+ * It is advantageous as it limits the amount of data that needs to
+ * be hashed when doing inserts/lookups/deletes, as it tracks how much
+ * key data is actually valid
+ */
+#define HT_COPY_RAW_KEY(key, buf, len) ossl_key_raw_copy(key, buf, len)
+
+/*
+ * Similar to HT_COPY_RAW_KEY but accepts a character buffer, and copies
+ * data while converting case for case insensitive matches
+ */
+#define HT_COPY_RAW_KEY_CASE(key, buf, len)                                         \
+    do {                                                                            \
+        ossl_ht_strcase((key), (char *)&((key)->keybuf[(key)->keysize]), buf, len); \
+        (key)->keysize += len;                                                      \
     } while (0)
 
 /*
@@ -140,9 +192,9 @@ typedef struct ht_config_st {
  * This is useful for instances in which we want upper and lower case
  * key value to hash to the same entry
  */
-#define HT_SET_KEY_STRING_CASE(key, member, value)                                            \
-    do {                                                                                      \
-        ossl_ht_strcase((key)->keyfields.member, value, sizeof((key)->keyfields.member) - 1); \
+#define HT_SET_KEY_STRING_CASE(key, member, value)                                                  \
+    do {                                                                                            \
+        ossl_ht_strcase(NULL, (key)->keyfields.member, value, sizeof((key)->keyfields.member) - 1); \
     } while (0)
 
 /*
@@ -159,12 +211,12 @@ typedef struct ht_config_st {
     } while (0)
 
 /* Same as HT_SET_KEY_STRING_CASE but also takes length of the string. */
-#define HT_SET_KEY_STRING_CASE_N(key, member, value, len)                                         \
-    do {                                                                                          \
-        if ((size_t)len < sizeof((key)->keyfields.member))                                        \
-            ossl_ht_strcase((key)->keyfields.member, value, len);                                 \
-        else                                                                                      \
-            ossl_ht_strcase((key)->keyfields.member, value, sizeof((key)->keyfields.member) - 1); \
+#define HT_SET_KEY_STRING_CASE_N(key, member, value, len)                                               \
+    do {                                                                                                \
+        if ((size_t)len < sizeof((key)->keyfields.member))                                              \
+            ossl_ht_strcase(NULL, (key)->keyfields.member, value, len);                                 \
+        else                                                                                            \
+            ossl_ht_strcase(NULL, (key)->keyfields.member, value, sizeof((key)->keyfields.member) - 1); \
     } while (0)
 
 /*
@@ -261,7 +313,7 @@ typedef struct ht_config_st {
 /*
  * Helper function to construct case insensitive keys
  */
-static void ossl_unused ossl_ht_strcase(char *tgt, const char *src, int len)
+static ossl_inline ossl_unused void ossl_ht_strcase(HT_KEY *key, char *tgt, const char *src, int len)
 {
     int i;
 #if defined(CHARSET_EBCDIC) && !defined(CHARSET_EBCDIC_TEST)
@@ -272,6 +324,14 @@ static void ossl_unused ossl_ht_strcase(char *tgt, const char *src, int len)
 
     if (src == NULL)
         return;
+
+    /*
+     * If we're passed a key, we're doing raw key copies
+     * so check that we don't overflow here, and truncate if
+     * we copy more space than we have available
+     */
+    if (key != NULL && key->keysize + len > key->bufsize)
+        len = (int)(key->bufsize - key->keysize);
 
     for (i = 0; src[i] != '\0' && i < len; i++)
         tgt[i] = case_adjust & src[i];


### PR DESCRIPTION
With this we beat legacy on the speedy crappy things (like doing one sha256)


beck@loonix:~/openssl/shatest$ time ./shatest -l
Using legacy sha256 interface
did 49999992 sha256's in 24 threads

real	0m0.767s
user	0m18.185s
sys	0m0.005s
beck@loonix:~/openssl/shatest$ time ./shatest
Using evp sha256 interface
did 49999992 sha256's in 24 threads

real	0m6.554s
user	2m19.510s
sys	0m0.027s
beck@loonix:~/openssl/shatest$ time ./shatest -f
Using evp sha256 interface
Freezing method store
did 49999992 sha256's in 24 threads

real	0m0.560s
user	0m13.117s
sys	0m0.008s
beck@loonix:~/openssl/shatest$ 


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
