### PR TITLE
CSHAKE: Fix memory leak related to propq.

### DIFF
--- a/providers/implementations/digests/cshake_prov.c
+++ b/providers/implementations/digests/cshake_prov.c
@@ -222,6 +222,7 @@ static void cshake_freectx(void *vctx)
 {
     CSHAKE_CTX *ctx = (CSHAKE_CTX *)vctx;
 
+    OPENSSL_free(ctx->propq);
     EVP_MD_free(ctx->md);
     EVP_MD_CTX_destroy(ctx->mdctx);
     OPENSSL_clear_free(ctx, sizeof(*ctx));

--- a/test/recipes/30-test_evp_data/evpmd_sha.txt
+++ b/test/recipes/30-test_evp_data/evpmd_sha.txt
@@ -455,6 +455,7 @@ Digest = CSHAKE-256
 Input = 13D101DA
 Ctrl = function-name:TupleHash
 Ctrl = customization:q8gN}O&V*VDU4Y.^5J13tG2,1^Lw~C2rw $AB3.SX)=@z
+Ctrl = properties:?fips=true
 Output = 43163A57FC1EE8F1C501A2ADD927698CA5A4B52C0D3EF3FD6D91D8D2386765E0AE
 
 FIPSversion = >=4.0.0


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated

This fixes a memory leak that was already fixed in the TupleHash code.
