### PR TITLE
safe_math: documentation example fix

### DIFF
--- a/doc/internal/man3/OSSL_SAFE_MATH_SIGNED.pod
+++ b/doc/internal/man3/OSSL_SAFE_MATH_SIGNED.pod
@@ -80,7 +80,7 @@ This example is of a function that computes the size of a record that
 has a four byte element count which is followed by that many elements.
 It returns zero on overflow.
 
- OSSL_SAFE_MATH_UNSIGNED(sizet, size_t, SIZE_MAX)
+ OSSL_SAFE_MATH_UNSIGNED(sizet, size_t)
 
  size_t compute_record_size(uint32_t n)
  {


### PR DESCRIPTION
The example was for an older version of the code which used triadic macros to define the functions.  The code was simplified making these dyadic but the example was skipped.  This fixes the example.

- [x] documentation is added or updated
- [ ] tests are added or updated
