### PR TITLE
fix null deref in ossl_namemap_name2num

### DIFF
--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -150,7 +150,7 @@ int ossl_namemap_name2num(const OSSL_NAMEMAP *namemap, const char *name)
         namemap = ossl_namemap_stored(NULL);
 #endif
 
-    if (namemap == NULL)
+    if (namemap == NULL || name == NULL)
         return 0;
 
     HT_INIT_RAW_KEY(&key);

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -364,7 +364,7 @@ inner_ossl_encoder_fetch(struct encoder_data_st *methdata,
         return NULL;
     }
 
-    id = name != NULL ? ossl_namemap_name2num(namemap, name) : 0;
+    id = ossl_namemap_name2num(namemap, name);
 
     /*
      * If we haven't found the name yet, chances are that the algorithm to

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -289,7 +289,7 @@ inner_evp_generic_fetch(struct evp_method_data_st *methdata,
     }
 
     /* If we haven't received a name id yet, try to get one for the name */
-    name_id = name != NULL ? ossl_namemap_name2num(namemap, name) : 0;
+    name_id = ossl_namemap_name2num(namemap, name);
 
     /*
      * If we have a name id, calculate a method id with evp_method_id().
@@ -350,7 +350,7 @@ inner_evp_generic_fetch(struct evp_method_data_st *methdata,
                 name_id = ossl_namemap_name2num(namemap, name);
             if (name_id == 0) {
                 ERR_raise_data(ERR_LIB_EVP, ERR_R_FETCH_FAILED,
-                    "Algorithm %s cannot be found", name);
+                    "Algorithm %s cannot be found", name != NULL ? name : "<null>");
                 free_method(method);
                 method = NULL;
             } else {

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -302,7 +302,7 @@ inner_loader_fetch(struct loader_data_st *methdata,
     }
 
     /* If we haven't received a name id yet, try to get one for the name */
-    id = scheme != NULL ? ossl_namemap_name2num(namemap, scheme) : 0;
+    id = ossl_namemap_name2num(namemap, scheme);
 
     /*
      * If we haven't found the name yet, chances are that the algorithm to


### PR DESCRIPTION
Fixes: aec9e7fe1693 ("Allow core_namemap to limit hashtable key sizes")
Resolves: https://scan5.scan.coverity.com/#/project-view/65138/10222?selectedIssue=1683247
Resolves: https://scan5.scan.coverity.com/#/project-view/65138/10222?selectedIssue=1683248
Resolves: https://scan5.scan.coverity.com/#/project-view/65138/10222?selectedIssue=1683249
