### PR TITLE
cms: Fix no-signed-attributes for unknown hashless algorithms

### DIFF
--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -480,10 +480,15 @@ static const struct {
 static const char *cms_mdless_signing(EVP_PKEY *pkey)
 {
     unsigned int i;
+    int def_nid = NID_undef;
 
     for (i = 0; key2data[i].name != NULL; i++) {
         if (EVP_PKEY_is_a(pkey, key2data[i].name))
             return key2data[i].name;
+    }
+    if (EVP_PKEY_get_default_digest_nid(pkey, &def_nid) <= 0) {
+        /* Key doesn't have default digest, it's mdless */
+        return EVP_PKEY_get0_type_name(pkey);
     }
     return NULL;
 }
@@ -553,7 +558,11 @@ static int ossl_cms_adjust_md(EVP_PKEY *pk, const EVP_MD **md, unsigned int flag
         return 1;
     }
 
+    if (*md != NULL)
+        (void)ERR_set_mark(); /* No error if no default md and user-supplied md is set */
     tmp_md = ossl_cms_get_default_md(pk, &md_a_must);
+    if (*md != NULL)
+        (void)ERR_pop_to_mark();
     if (md_a_must)
         *md = tmp_md;
     else if (*md == NULL)


### PR DESCRIPTION
Fix CMS signing without signed-attributes for unknown (provider-supplied) algorithms with don't operate on a digest (e.g. Falcon).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
