### PR TITLE
Fix intermittent hang in 82-test_ech_client_server.t

### DIFF
--- a/test/recipes/82-test_ech_client_server.t
+++ b/test/recipes/82-test_ech_client_server.t
@@ -131,6 +131,8 @@ sub start_ech_client_server
                 ;
             } elsif (/^Setting secondary/) {
                 ;
+            } elsif (/^Failed reading from/) {
+                ;
             } else {
                 last;
             }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
The test hangs intermittently when run repeatedly (e.g. `seq 1000 | xargs -Iz make test TESTS="*server"`).

Root cause: both `s_server` and `s_client` stderr are captured via `gensym` (creating separate pipes) but never read. When stderr output fills the OS pipe buffer (~64KB), the child blocks, preventing stdout output and hanging the parent's read loop. This is a classic pipe deadlock.

Verified via `IPC::Open3` source — without `gensym`, `open3` merges stderr with stdout (no separate pipe). This matches the pattern in `70-test_sslkeylogfile.t`.

Changes:
- Remove `gensym` from both `open3` calls — eliminates the deadlock
- Move server kill before client output reading — prevents process leaks
- Add `eval`/`alarm` timeout (60s) — safety net against unforeseen hangs

Fixes #30277
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
