### PR TITLE
Ensure entries in the neighborhood struct are 8 byte aligned

### DIFF
--- a/crypto/hashtable/hashtable.c
+++ b/crypto/hashtable/hashtable.c
@@ -81,9 +81,11 @@
 #if defined(__GNUC__) || defined(__CLANG__)
 #define PREFETCH_NEIGHBORHOOD(x) __builtin_prefetch(x.entries)
 #define PREFETCH(x) __builtin_prefetch(x)
+#define ALIGN __attribute__((aligned(8)))
 #else
 #define PREFETCH_NEIGHBORHOOD(x)
 #define PREFETCH(x)
+#define ALIGN
 #endif
 
 /*
@@ -111,7 +113,7 @@ struct ht_internal_value_st {
 struct ht_neighborhood_entry_st {
     uint64_t hash;
     struct ht_internal_value_st *value;
-} __attribute__((aligned(8)));
+} ALIGN;
 
 struct ht_neighborhood_st {
     struct ht_neighborhood_entry_st entries[NEIGHBORHOOD_LEN];


### PR DESCRIPTION
This struct is accessed via atomics, which on some platforms require 8 byte alignment.  Generally compilers provide that alignment, since the first element of the struct is a uint64_t, but it appears that not all do.

Force the alignment to be correct

