### PR TITLE
Avoid performance regression in ossl_init_thread() on Windows

### DIFF
--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -200,10 +200,16 @@ static void init_thread_destructor(void *hands)
 }
 
 static CRYPTO_ONCE ossl_init_thread_runonce = CRYPTO_ONCE_STATIC_INIT;
+/* MSVC linker can use other segment for uninitialized (zeroed) variables */
+#if defined(OPENSSL_SYS_WINDOWS)
+static CRYPTO_THREAD_ID recursion_guard = (CRYPTO_THREAD_ID)-1;
+#else
 static CRYPTO_THREAD_ID recursion_guard = (CRYPTO_THREAD_ID)0;
+#endif
 
 DEFINE_RUN_ONCE_STATIC(ossl_init_thread_once)
 {
+    /* CRYPTO_THREAD_init_local() can call ossl_init_threads() again */
     recursion_guard = CRYPTO_THREAD_get_current_id();
     if (!CRYPTO_THREAD_init_local(&destructor_key.value,
             init_thread_destructor))


### PR DESCRIPTION
The recursion_guard variable, initialized to 0, can trigger MSVC linker optimization for unitialized variables, placing it to a diferent segment than initialized (-1) variant.

See for example this discussion
https://alt.os.development.narkive.com/s3fpABlo/misc-question-msvc-and-data-bss-start-end

This could cause visible performance penalty, seen in "newrawkey.exe -a ml-kem-512 32" test from perftools.

The patch basically reverts initialization to -1 on Windows, which behaves exactly same, but for linker it appears as initialized variable.

Note that both 0 and (unsigned)-1 is non-existent Windows thread id.

Fixes: https://github.com/openssl/private/issues/866
