### PR TITLE
Change free call to secure free call.

### DIFF
--- a/crypto/ml_dsa/ml_dsa_key.c
+++ b/crypto/ml_dsa/ml_dsa_key.c
@@ -492,7 +492,7 @@ int ossl_ml_dsa_generate_key(ML_DSA_KEY *out)
                 "explicit %s private key does not match seed",
                 out->params->alg);
         }
-        OPENSSL_free(sk);
+        OPENSSL_secure_clear_free(sk, out->params->sk_len);
     }
     return ret;
 }


### PR DESCRIPTION
Freeing secure memory using OPENSSL_free causes badness.  Use the proper free call instead.

Fixes #30302
