### PR TITLE
apps: unload provider on app_provider_load() failure

### DIFF
--- a/apps/lib/app_provider.c
+++ b/apps/lib/app_provider.c
@@ -47,6 +47,7 @@ int app_provider_load(OSSL_LIB_CTX *libctx, const char *provider_name)
         app_providers = sk_OSSL_PROVIDER_new_null();
     if (app_providers == NULL
         || !sk_OSSL_PROVIDER_push(app_providers, prov)) {
+        OSSL_PROVIDER_unload(prov);
         app_providers_cleanup();
         return 0;
     }


### PR DESCRIPTION
This draft PR fixes a memory leak in app_provider_load() in apps/lib/app_provider.c.

If OSSL_PROVIDER_load() succeeds but app_providers is NULL or sk_OSSL_PROVIDER_push(app_providers, prov) fails, the loaded provider handle is not released before returning. Since prov was never inserted into app_providers, app_providers_cleanup() does not unload it.

This change calls OSSL_PROVIDER_unload(prov) on that failure path before running app_providers_cleanup().

Fixes #30309

@bbbrumley