### PR TITLE
"openssl s_client -quiet" -verify_quiet documentation and testing to confirm -quiet works

### DIFF
--- a/apps/include/s_apps.h
+++ b/apps/include/s_apps.h
@@ -37,7 +37,7 @@ int ssl_print_tmp_key(BIO *out, SSL *s);
 int init_client(int *sock, const char *host, const char *port,
     const char *bindhost, const char *bindport,
     int family, int type, int protocol, int tfo, int doconn,
-    BIO_ADDR **ba_ret);
+    BIO_ADDR **ba_ret, int quiet);
 int should_retry(int i);
 void do_ssl_shutdown(SSL *ssl);
 

--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -206,16 +206,18 @@ int init_client(int *sock, const char *host, const char *port,
         }
         ERR_print_errors(bio_err);
     } else {
-        char *hostname = NULL;
+        if (!quiet) {
+            char *hostname = NULL;
 
-        hostname = BIO_ADDR_hostname_string(BIO_ADDRINFO_address(ai), 1);
-        if (hostname != NULL && !quiet) {
-            BIO_printf(bio_err, "Connecting to %s\n", hostname);
-            OPENSSL_free(hostname);
+            hostname = BIO_ADDR_hostname_string(BIO_ADDRINFO_address(ai), 1);
+            if (hostname != NULL) {
+                BIO_printf(bio_err, "Connecting to %s\n", hostname);
+                OPENSSL_free(hostname);
+            }
+            /* Remove any stale errors from previous connection attempts */
+            ERR_clear_error();
+            ret = 1;
         }
-        /* Remove any stale errors from previous connection attempts */
-        ERR_clear_error();
-        ret = 1;
     }
 out:
     if (bindaddr != NULL) {

--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -75,7 +75,7 @@ BIO_ADDR *ourpeer = NULL;
 int init_client(int *sock, const char *host, const char *port,
     const char *bindhost, const char *bindport,
     int family, int type, int protocol, int tfo, int doconn,
-    BIO_ADDR **ba_ret)
+    BIO_ADDR **ba_ret, int quiet)
 {
     BIO_ADDRINFO *res = NULL;
     BIO_ADDRINFO *bindaddr = NULL;
@@ -209,8 +209,8 @@ int init_client(int *sock, const char *host, const char *port,
         char *hostname = NULL;
 
         hostname = BIO_ADDR_hostname_string(BIO_ADDRINFO_address(ai), 1);
-        if (hostname != NULL) {
-            BIO_printf(bio_out, "Connecting to %s\n", hostname);
+        if (hostname != NULL && !quiet) {
+            BIO_printf(bio_err, "Connecting to %s\n", hostname);
             OPENSSL_free(hostname);
         }
         /* Remove any stale errors from previous connection attempts */

--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -214,10 +214,10 @@ int init_client(int *sock, const char *host, const char *port,
                 BIO_printf(bio_err, "Connecting to %s\n", hostname);
                 OPENSSL_free(hostname);
             }
-            /* Remove any stale errors from previous connection attempts */
-            ERR_clear_error();
-            ret = 1;
         }
+        /* Remove any stale errors from previous connection attempts */
+        ERR_clear_error();
+        ret = 1;
     }
 out:
     if (bindaddr != NULL) {

--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -210,7 +210,7 @@ int init_client(int *sock, const char *host, const char *port,
 
         hostname = BIO_ADDR_hostname_string(BIO_ADDRINFO_address(ai), 1);
         if (hostname != NULL) {
-            BIO_printf(bio_err, "Connecting to %s\n", hostname);
+            BIO_printf(bio_out, "Connecting to %s\n", hostname);
             OPENSSL_free(hostname);
         }
         /* Remove any stale errors from previous connection attempts */

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2426,7 +2426,7 @@ re_start:
     BIO_ADDR_free(peer_addr);
     peer_addr = NULL;
     if (init_client(&sock, host, port, bindhost, bindport, socket_family,
-            socket_type, protocol, tfo, !isquic, &peer_addr)
+            socket_type, protocol, tfo, !isquic, &peer_addr, c_quiet)
         == 0) {
         BIO_printf(bio_err, "connect:errno=%d\n", get_last_socket_error());
         BIO_closesocket(sock);

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -530,8 +530,10 @@ input. This implicitly turns on B<-nocommands> as well.
 
 =item B<-quiet>
 
-Inhibit printing of session and certificate information.  This implicitly
-turns on B<-ign_eof> and B<-nocommands> as well.
+Inhibit printing of session and certificate information. This implicitly 
+turns on B<-ign_eof> and B<-nocommands> as well. To silence cert 
+verification output, B<-verify_quiet> should be used too. Even with both 
+options specified, verification failures will still be printed.
 
 =item B<-no_ign_eof>
 

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -531,7 +531,7 @@ input. This implicitly turns on B<-nocommands> as well.
 =item B<-quiet>
 
 Inhibit printing of session and certificate information. This implicitly 
-turns on B<-ign_eof> and B<-nocommands> as well. To silence cert 
+turns on B<-ign_eof> and B<-nocommands> as well. To silence certificate
 verification output, B<-verify_quiet> should be used too. Even with both 
 options specified, verification failures will still be printed.
 


### PR DESCRIPTION
Fixes #10213

Documentation of -quiet option now mentions usage of -verify_quiet. We (@mjw6944, @finchsdarwin, @Szheng25) could not replicate the "Connecting to 212.227.17.190" message on Ubuntu but cross-compatibility should be tested.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
- [ ] further tests on other os
