### PR TITLE
fix OSSL_parse_url userinfo scan to respect authority boundary

### DIFF
--- a/crypto/http/http_lib.c
+++ b/crypto/http/http_lib.c
@@ -55,6 +55,7 @@ int OSSL_parse_url(const char *url, char **pscheme, char **puser, char **phost,
     char **ppath, char **pquery, char **pfrag)
 {
     const char *p, *tmp;
+    const char *authority_end;
     const char *scheme, *scheme_end;
     const char *user, *user_end;
     const char *host, *host_end;
@@ -92,7 +93,10 @@ int OSSL_parse_url(const char *url, char **pscheme, char **puser, char **phost,
 
     /* parse optional "userinfo@" */
     user = user_end = host = p;
-    host = strchr(p, '@');
+    authority_end = strpbrk(p, "/?#");
+    if (authority_end == NULL)
+        authority_end = p + strlen(p);
+    host = memchr(p, '@', authority_end - p);
     if (host != NULL)
         user_end = host++;
     else

--- a/test/http_test.c
+++ b/test/http_test.c
@@ -331,6 +331,18 @@ static int test_http_url_path_query_ok(const char *url, const char *exp_path_qu)
     return res;
 }
 
+static int test_http_url_host_ok(const char *url, const char *exp_host)
+{
+    char *host;
+    int res;
+
+    res = TEST_true(OSSL_HTTP_parse_url(url, NULL, NULL, &host, NULL, NULL,
+              NULL, NULL, NULL))
+        && TEST_str_eq(host, exp_host);
+    OPENSSL_free(host);
+    return res;
+}
+
 static int test_http_url_dns(void)
 {
     return test_http_url_ok("host:65535/path", 0, "host", "65535", "/path");
@@ -356,6 +368,13 @@ static int test_http_url_path_query(void)
 static int test_http_url_userinfo_query_fragment(void)
 {
     return test_http_url_ok("user:pass@host/p?q#fr", 0, "host", "80", "/p");
+}
+
+static int test_http_url_at_sign_outside_authority(void)
+{
+    return test_http_url_host_ok("http://host/p@attacker.test", "host")
+        && test_http_url_host_ok("http://host/p?q=@attacker.test", "host")
+        && test_http_url_host_ok("http://host/p?q#fr@attacker.test", "host");
 }
 
 static int test_http_url_ipv4(void)
@@ -576,6 +595,7 @@ int setup_tests(void)
     ADD_TEST(test_http_url_timestamp);
     ADD_TEST(test_http_url_path_query);
     ADD_TEST(test_http_url_userinfo_query_fragment);
+    ADD_TEST(test_http_url_at_sign_outside_authority);
     ADD_TEST(test_http_url_ipv4);
     ADD_TEST(test_http_url_ipv6);
     ADD_TEST(test_http_url_invalid_prefix);


### PR DESCRIPTION
# PR description (for github.com/openssl/openssl)

## title

fix OSSL_parse_url userinfo scan to respect authority boundary

## body

`OSSL_parse_url()` uses `strchr(p, '@')` to locate the userinfo delimiter, but this scans the entire remaining URL string rather than only the authority component. per RFC 3986, the authority ends at the first `/`, `?`, or `#`. an `@` in the path, query, or fragment should not be interpreted as a userinfo delimiter.

this matters for callers that use the extracted host for security decisions, such as `nc_uri()` in `crypto/x509/v3_ncons.c` (URI nameConstraints matching during certificate verification).

the fix bounds the `@` search to the authority component using `memchr` over the authority length (delimited by `strpbrk(p, "/?#")`).

example:
- input: `https://victim.com/path@attacker.com`
- before: extracted host = `attacker.com` (wrong, `@` is in the path)
- after: extracted host = `victim.com` (correct, `@` outside authority is ignored)

includes regression test covering `@` in path, query, and fragment positions.
