### PR TITLE
Fix memory leak in `EC_GROUP_copy()` by freeing pre_comp before overwrite

### DIFF
--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -175,6 +175,8 @@ int EC_GROUP_copy(EC_GROUP *dest, const EC_GROUP *src)
     dest->libctx = src->libctx;
     dest->curve_name = src->curve_name;
 
+    EC_pre_comp_free(dest);
+
     /* Copy precomputed */
     dest->pre_comp_type = src->pre_comp_type;
     switch (src->pre_comp_type) {


### PR DESCRIPTION
`EC_GROUP_copy()` in `crypto/ec/ec_lib.c:162-267` leaks memory when copying to a destination group that already has precomputed multiplication values. The destination's existing `pre_comp` is overwritten without being freed first (lines 178-212). The `EC_*_pre_comp_dup()` functions increment reference counts, so the old pointer becomes orphaned with a stuck refcount, causing permanent memory leaks (~105KB per occurrence with P-384).

At lines 178-212, `EC_GROUP_copy()` copies precomputed values from source to destination without first freeing the destination's existing `pre_comp`:

```c
/* Copy precomputed */
dest->pre_comp_type = src->pre_comp_type;
switch (src->pre_comp_type) {
case PCT_none:
    dest->pre_comp.ec = NULL;
    break;
case PCT_nistz256:
    dest->pre_comp.nistz256 = EC_nistz256_pre_comp_dup(src->pre_comp.nistz256);
    // ...
case PCT_ec:
    dest->pre_comp.ec = EC_ec_pre_comp_dup(src->pre_comp.ec);
    break;
}
```

The `*_dup` functions use reference counting (increment refcount). When the destination's old `pre_comp` pointer is overwritten, its refcount is never decremented, causing the memory to be orphaned.

To trigger the leak, you can compile & run the following PoC with ASan enabled:

[poc_ec_group_copy_leak.c](https://github.com/user-attachments/files/25840212/poc_ec_group_copy_leak.c)

```bash
# Build OpenSSL with ASan
./Configure enable-asan -g -O1 -fno-omit-frame-pointer
make clean && make -j$(nproc)

# Build PoC
gcc -fsanitize=address -g -O1 -fno-omit-frame-pointer \
    -I<path_to_openssl>/include \
    -L<path_to_openssl> \
    -Wl,-rpath,<path_to_openssl> \
    poc_ec_group_copy_leak.c -lcrypto -o poc_ec_group_copy_leak

# Run with leak detection
ASAN_OPTIONS=detect_leaks=1 ./poc_ec_group_copy_leak
```
This will give:
```c
=================================================================
==2644435==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 56 byte(s) in 1 object(s) allocated from:
    #0 0x7f1c5a2bf91f in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7f1c59ad1585 in CRYPTO_malloc crypto/mem.c:214
    #2 0x7f1c59ad1755 in CRYPTO_zalloc crypto/mem.c:226
    #3 0x7f1c599e8509 in ec_pre_comp_new crypto/ec/ec_mult.c:57
    #4 0x7f1c599e8509 in ossl_ec_wNAF_precompute_mult crypto/ec/ec_mult.c:832
    #5 0x7f1c599e348f in EC_GROUP_precompute_mult crypto/ec/ec_lib.c:1160
    ...

Indirect leak of 18432 byte(s) in 384 object(s) allocated from:
    #0 0x7f1c5a2bf91f in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7f1c59ad1585 in CRYPTO_malloc crypto/mem.c:214
    #2 0x7f1c59ad1755 in CRYPTO_zalloc crypto/mem.c:226
    #3 0x7f1c599dfbb2 in EC_POINT_new crypto/ec/ec_lib.c:727
    ...
...
SUMMARY: AddressSanitizer: 105936 byte(s) leaked in 2690 allocation(s).
```
Thanks for looking into this and we appreciate any feedback!
