### PR TITLE
Fixes #30308

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -186,8 +186,11 @@ int app_passwd(const char *arg1, const char *arg2, char **pass1, char **pass2)
     }
     if (arg2 != NULL) {
         *pass2 = app_get_pass(arg2, same ? 2 : 0);
-        if (*pass2 == NULL)
+        if (*pass2 == NULL) {
+            clear_free(*pass1);
+            *pass1 = NULL;
             return 0;
+        }
     } else if (pass2 != NULL) {
         *pass2 = NULL;
     }


### PR DESCRIPTION
Fix memory leak in `app_passwd()` in `apps/lib/apps.c`. In `app_passwd()`, free `*pass1` before returning when the second `app_get_pass()` call fails.