### PR TITLE
Replace RSA direct HMAC API usage with EVP_MAC

### DIFF
--- a/crypto/rsa/rsa_ossl.c
+++ b/crypto/rsa/rsa_ossl.c
@@ -24,7 +24,7 @@
 #endif
 #include <openssl/evp.h>
 #include <openssl/sha.h>
-#include <openssl/hmac.h>
+#include <openssl/core_names.h>
 
 DEFINE_SPARSE_ARRAY_OF(BN_BLINDING);
 
@@ -435,9 +435,15 @@ static int derive_kdk(int flen, const unsigned char *from, RSA *rsa,
     unsigned char *buf, int num, unsigned char *kdk)
 {
     int ret = 0;
-    HMAC_CTX *hmac = NULL;
+    EVP_MAC *mac = NULL;
+    EVP_MAC_CTX *mctx = NULL;
     EVP_MD *md = NULL;
-    unsigned int md_len = SHA256_DIGEST_LENGTH;
+    size_t md_len = SHA256_DIGEST_LENGTH;
+    static const OSSL_PARAM params[] = {
+        OSSL_PARAM_utf8_string(OSSL_MAC_PARAM_DIGEST, "SHA256",
+            sizeof("SHA256")),
+        OSSL_PARAM_END
+    };
     unsigned char d_hash[SHA256_DIGEST_LENGTH] = { 0 };
     /*
      * because we use d as a handle to rsa->d we need to keep it local and
@@ -480,38 +486,44 @@ static int derive_kdk(int flen, const unsigned char *from, RSA *rsa,
         goto err;
     }
 
-    hmac = HMAC_CTX_new();
-    if (hmac == NULL) {
+    mac = EVP_MAC_fetch(rsa->libctx, "HMAC", NULL);
+    if (mac == NULL) {
+        ERR_raise(ERR_LIB_RSA, ERR_R_CRYPTO_LIB);
+        goto err;
+    }
+    mctx = EVP_MAC_CTX_new(mac);
+    if (mctx == NULL) {
         ERR_raise(ERR_LIB_RSA, ERR_R_CRYPTO_LIB);
         goto err;
     }
 
-    if (HMAC_Init_ex(hmac, d_hash, sizeof(d_hash), md, NULL) <= 0) {
+    if (!EVP_MAC_init(mctx, d_hash, sizeof(d_hash), params)) {
         ERR_raise(ERR_LIB_RSA, ERR_R_INTERNAL_ERROR);
         goto err;
     }
 
     if (flen < num) {
         memset(buf, 0, num - flen);
-        if (HMAC_Update(hmac, buf, num - flen) <= 0) {
+        if (!EVP_MAC_update(mctx, buf, num - flen)) {
             ERR_raise(ERR_LIB_RSA, ERR_R_INTERNAL_ERROR);
             goto err;
         }
     }
-    if (HMAC_Update(hmac, from, flen) <= 0) {
+    if (!EVP_MAC_update(mctx, from, flen)) {
         ERR_raise(ERR_LIB_RSA, ERR_R_INTERNAL_ERROR);
         goto err;
     }
 
     md_len = SHA256_DIGEST_LENGTH;
-    if (HMAC_Final(hmac, kdk, &md_len) <= 0) {
+    if (!EVP_MAC_final(mctx, kdk, &md_len, SHA256_DIGEST_LENGTH)) {
         ERR_raise(ERR_LIB_RSA, ERR_R_INTERNAL_ERROR);
         goto err;
     }
     ret = 1;
 
 err:
-    HMAC_CTX_free(hmac);
+    EVP_MAC_CTX_free(mctx);
+    EVP_MAC_free(mac);
     EVP_MD_free(md);
     return ret;
 }

--- a/crypto/rsa/rsa_pk1.c
+++ b/crypto/rsa/rsa_pk1.c
@@ -23,7 +23,7 @@
 #include <openssl/prov_ssl.h>
 #include <openssl/evp.h>
 #include <openssl/sha.h>
-#include <openssl/hmac.h>
+#include <openssl/core_names.h>
 #include "internal/cryptlib.h"
 #include "crypto/rsa.h"
 #include "rsa_local.h"
@@ -285,10 +285,15 @@ static int ossl_rsa_prf(OSSL_LIB_CTX *ctx,
     uint16_t iter = 0;
     unsigned char be_iter[sizeof(iter)];
     unsigned char be_bitlen[sizeof(bitlen)];
-    HMAC_CTX *hmac = NULL;
-    EVP_MD *md = NULL;
+    EVP_MAC *mac = NULL;
+    EVP_MAC_CTX *mctx = NULL;
     unsigned char hmac_out[SHA256_DIGEST_LENGTH];
-    unsigned int md_len;
+    size_t md_len;
+    static const OSSL_PARAM params[] = {
+        OSSL_PARAM_utf8_string(OSSL_MAC_PARAM_DIGEST, "SHA256",
+            sizeof("SHA256")),
+        OSSL_PARAM_END
+    };
 
     if (tlen * 8 != bitlen) {
         ERR_raise(ERR_LIB_RSA, ERR_R_INTERNAL_ERROR);
@@ -298,12 +303,6 @@ static int ossl_rsa_prf(OSSL_LIB_CTX *ctx,
     be_bitlen[0] = (bitlen >> 8) & 0xff;
     be_bitlen[1] = bitlen & 0xff;
 
-    hmac = HMAC_CTX_new();
-    if (hmac == NULL) {
-        ERR_raise(ERR_LIB_RSA, ERR_R_INTERNAL_ERROR);
-        goto err;
-    }
-
     /*
      * we use hardcoded hash so that migrating between versions that use
      * different hash doesn't provide a Bleichenbacher oracle:
@@ -311,19 +310,24 @@ static int ossl_rsa_prf(OSSL_LIB_CTX *ctx,
      * messages for the same ciphertext, they'll know that the message is
      * synthetically generated, which means that the padding check failed
      */
-    md = EVP_MD_fetch(ctx, "sha256", NULL);
-    if (md == NULL) {
+    mac = EVP_MAC_fetch(ctx, "HMAC", NULL);
+    if (mac == NULL) {
+        ERR_raise(ERR_LIB_RSA, ERR_R_INTERNAL_ERROR);
+        goto err;
+    }
+    mctx = EVP_MAC_CTX_new(mac);
+    if (mctx == NULL) {
         ERR_raise(ERR_LIB_RSA, ERR_R_INTERNAL_ERROR);
         goto err;
     }
 
-    if (HMAC_Init_ex(hmac, kdk, SHA256_DIGEST_LENGTH, md, NULL) <= 0) {
+    if (!EVP_MAC_init(mctx, kdk, SHA256_DIGEST_LENGTH, params)) {
         ERR_raise(ERR_LIB_RSA, ERR_R_INTERNAL_ERROR);
         goto err;
     }
 
     for (pos = 0; pos < tlen; pos += SHA256_DIGEST_LENGTH, iter++) {
-        if (HMAC_Init_ex(hmac, NULL, 0, NULL, NULL) <= 0) {
+        if (!EVP_MAC_init(mctx, NULL, 0, NULL)) {
             ERR_raise(ERR_LIB_RSA, ERR_R_INTERNAL_ERROR);
             goto err;
         }
@@ -331,33 +335,29 @@ static int ossl_rsa_prf(OSSL_LIB_CTX *ctx,
         be_iter[0] = (iter >> 8) & 0xff;
         be_iter[1] = iter & 0xff;
 
-        if (HMAC_Update(hmac, be_iter, sizeof(be_iter)) <= 0) {
-            ERR_raise(ERR_LIB_RSA, ERR_R_INTERNAL_ERROR);
-            goto err;
-        }
-        if (HMAC_Update(hmac, (unsigned char *)label, llen) <= 0) {
-            ERR_raise(ERR_LIB_RSA, ERR_R_INTERNAL_ERROR);
-            goto err;
-        }
-        if (HMAC_Update(hmac, be_bitlen, sizeof(be_bitlen)) <= 0) {
+        if (!EVP_MAC_update(mctx, be_iter, sizeof(be_iter))
+            || !EVP_MAC_update(mctx, (unsigned char *)label, llen)
+            || !EVP_MAC_update(mctx, be_bitlen, sizeof(be_bitlen))) {
             ERR_raise(ERR_LIB_RSA, ERR_R_INTERNAL_ERROR);
             goto err;
         }
 
         /*
-         * HMAC_Final requires the output buffer to fit the whole MAC
+         * EVP_MAC_final requires the output buffer to fit the whole MAC
          * value, so we need to use the intermediate buffer for the last
          * unaligned block
          */
         md_len = SHA256_DIGEST_LENGTH;
         if (pos + SHA256_DIGEST_LENGTH > tlen) {
-            if (HMAC_Final(hmac, hmac_out, &md_len) <= 0) {
+            if (!EVP_MAC_final(mctx, hmac_out, &md_len,
+                    SHA256_DIGEST_LENGTH)) {
                 ERR_raise(ERR_LIB_RSA, ERR_R_INTERNAL_ERROR);
                 goto err;
             }
             memcpy(to + pos, hmac_out, tlen - pos);
         } else {
-            if (HMAC_Final(hmac, to + pos, &md_len) <= 0) {
+            if (!EVP_MAC_final(mctx, to + pos, &md_len,
+                    SHA256_DIGEST_LENGTH)) {
                 ERR_raise(ERR_LIB_RSA, ERR_R_INTERNAL_ERROR);
                 goto err;
             }
@@ -367,8 +367,8 @@ static int ossl_rsa_prf(OSSL_LIB_CTX *ctx,
     ret = 0;
 
 err:
-    HMAC_CTX_free(hmac);
-    EVP_MD_free(md);
+    EVP_MAC_CTX_free(mctx);
+    EVP_MAC_free(mac);
     return ret;
 }
 


### PR DESCRIPTION
- Replace low-level HMAC API (`HMAC_CTX_new`, `HMAC_Init_ex`, `HMAC_Update`, `HMAC_Final`) with the EVP_MAC API in `rsa_ossl.c` and `rsa_pk1.c`
- This ensures the RSA HMAC operations go through the provider layer, which is required for proper FIPS compliance and algorithm fetching
- The RSA call sites intentionally use hardcoded SHA256/HMAC with NULL propq to avoid creating a Bleichenbacher oracle

## Checklist
- [ ] documentation is added or updated
- [ ] tests are added or updated

Fixes #30268
