### PR TITLE
Fix stack buffer over-read in DES OFB/CFB64 via unchecked num parameter

### DIFF
--- a/crypto/des/cfb64ede.c
+++ b/crypto/des/cfb64ede.c
@@ -28,7 +28,7 @@ void DES_ede3_cfb64_encrypt(const unsigned char *in, unsigned char *out,
 {
     register DES_LONG v0, v1;
     register long l = length;
-    register int n = *num;
+    register int n = *num & 0x07;
     DES_LONG ti[2];
     unsigned char *iv, c, cc;
 

--- a/crypto/des/cfb64enc.c
+++ b/crypto/des/cfb64enc.c
@@ -27,7 +27,7 @@ void DES_cfb64_encrypt(const unsigned char *in, unsigned char *out,
 {
     register DES_LONG v0, v1;
     register long l = length;
-    register int n = *num;
+    register int n = *num & 0x07;
     DES_LONG ti[2];
     unsigned char *iv, c, cc;
 

--- a/crypto/des/ofb64ede.c
+++ b/crypto/des/ofb64ede.c
@@ -26,7 +26,7 @@ void DES_ede3_ofb64_encrypt(register const unsigned char *in,
     DES_key_schedule *k3, DES_cblock *ivec, int *num)
 {
     register DES_LONG v0, v1;
-    register int n = *num;
+    register int n = *num & 0x07;
     register long l = length;
     DES_cblock d;
     register char *dp;

--- a/crypto/des/ofb64enc.c
+++ b/crypto/des/ofb64enc.c
@@ -25,7 +25,7 @@ void DES_ofb64_encrypt(register const unsigned char *in,
     DES_key_schedule *schedule, DES_cblock *ivec, int *num)
 {
     register DES_LONG v0, v1, t;
-    register int n = *num;
+    register int n = *num & 0x07;
     register long l = length;
     DES_cblock d;
     register unsigned char *dp;

--- a/providers/implementations/ciphers/ciphercommon.c
+++ b/providers/implementations/ciphers/ciphercommon.c
@@ -650,6 +650,10 @@ int ossl_cipher_common_set_ctx_params(PROV_CIPHER_CTX *ctx, const struct ossl_ci
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
             return 0;
         }
+        if (ctx->blocksize > 0 && num >= (unsigned int)ctx->blocksize) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+            return 0;
+        }
         ctx->num = num;
     }
     return 1;


### PR DESCRIPTION
## Summary

The `num` parameter in DES OFB64/CFB64 functions tracks the byte offset within an 8-byte DES block (valid range: 0–7). Neither the EVP `set_params` path nor the low-level DES functions validated this bound, allowing an out-of-range `num` to cause a **stack buffer over-read** when used as an array index into the 8-byte keystream buffer `d[]`.

## Root Cause

In `ossl_cipher_common_set_ctx_params()` (`ciphercommon.c`), the `OSSL_CIPHER_PARAM_NUM` parameter is accepted without range checking. This value propagates to `ctx->num`, which is passed as `*num` to the low-level DES functions. In these functions, `n = *num` is used directly as an index into an 8-byte stack buffer (e.g., `d[n]` in `ofb64ede.c:58`), causing an OOB read when `num >= 8`.

## Fix

Two-level defense:

1. **Provider layer** (`ciphercommon.c`): Reject `num >= blocksize` in `ossl_cipher_common_set_ctx_params()` before it reaches the cipher implementation.
2. **Low-level DES**: Mask `*num` with `& 0x07` on entry to `DES_ofb64_encrypt`, `DES_ede3_ofb64_encrypt`, `DES_cfb64_encrypt`, and `DES_ede3_cfb64_encrypt`. This is consistent with how `n` is already masked at the end of these functions before being written back to `*num`.

## Reproduction

```c
EVP_CIPHER *cipher = EVP_CIPHER_fetch(NULL, "DES-EDE3-OFB", NULL);
EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
EVP_EncryptInit_ex2(ctx, cipher, key, iv, NULL);

unsigned int bad_num = 8;  /* valid: 0-7 */
OSSL_PARAM params[] = {
    OSSL_PARAM_construct_uint(OSSL_CIPHER_PARAM_NUM, &bad_num),
    OSSL_PARAM_construct_end()
};
EVP_CIPHER_CTX_set_params(ctx, params);  /* accepted without validation */
EVP_EncryptUpdate(ctx, out, &outlen, in, 16);  /* stack-buffer-overflow in d[8] */
```

ASan output on unpatched OpenSSL:
```
==7674==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fff92256e88
READ of size 1 at 0x7fff92256e88 thread T0
    #0 DES_ede3_ofb64_encrypt ofb64ede.c:58:30
  [32, 40) 'd' (line 31) <== Memory access at offset 40 overflows this variable
```

After applying this fix, `set_params(num=8)` correctly returns 0 (rejected).

Fixes #30284