### PR TITLE
fips: Bring back FIPS_mode() as a define

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -194,6 +194,13 @@ OpenSSL Releases
 
    *Timo Keller*
 
+ * Add `FIPS_mode()` as a convenience define to
+   `EVP_default_properties_is_fips_enabled(NULL)`, which is
+   shorthand to check whether the `fips=yes` property is currently enabled
+   in the default library context.
+
+   *Dimitri John Ledkov*
+
 ### Changes between 3.6 and 4.0.0 [14 Apr 2026]
 
  * Added `-expected-rpks` option to the `openssl s_client`

--- a/doc/man3/EVP_set_default_properties.pod
+++ b/doc/man3/EVP_set_default_properties.pod
@@ -3,7 +3,8 @@
 =head1 NAME
 
 EVP_set_default_properties, EVP_default_properties_enable_fips,
-EVP_default_properties_is_fips_enabled, EVP_get1_default_properties
+EVP_default_properties_is_fips_enabled, EVP_get1_default_properties,
+FIPS_mode
 - manage default properties for future algorithm fetches
 
 =head1 SYNOPSIS
@@ -14,6 +15,7 @@ EVP_default_properties_is_fips_enabled, EVP_get1_default_properties
  char *EVP_get1_default_properties(OSSL_LIB_CTX *libctx);
  int EVP_default_properties_enable_fips(OSSL_LIB_CTX *libctx, int enable);
  int EVP_default_properties_is_fips_enabled(OSSL_LIB_CTX *libctx);
+ #define FIPS_mode() EVP_default_properties_is_fips_enabled(NULL)
 
 =head1 DESCRIPTION
 
@@ -51,6 +53,12 @@ EVP_get1_default_properties() is not thread safe. The application must ensure
 that the context reference is valid and default fetching properties are not
 being modified by a different thread.
 
+EVP_default_properties_is_fips_enabled() and FIPS_mode() are hints of
+intent, but not proof. If you are looking to validate whether the default
+configuration is using a validated module, many additional checks are
+needed; please consult the documentation of the provider you are using
+and the associated security policy.
+
 =head1 RETURN VALUES
 
 EVP_set_default_properties() and  EVP_default_properties_enable_fips() return 1
@@ -63,6 +71,10 @@ property is set for the given I<libctx>, otherwise it returns 0.
 EVP_get1_default_properties() returns allocated memory that must be freed by
 L<OPENSSL_free(3)> on success and NULL on failure.
 
+FIPS_mode() is a convenience define which calls
+EVP_default_properties_is_fips_enabled(NULL) against the default
+library context.
+
 =head1 SEE ALSO
 
 L<EVP_MD_fetch(3)>
@@ -74,6 +86,8 @@ EVP_default_properties_is_fips_enabled() were added in OpenSSL 3.0.
 
 The function EVP_get1_default_properties() was added in OpenSSL 3.5.
 
+FIPS_mode() is restored as a define to
+EVP_default_properties_is_fips_enabled(NULL) in OpenSSL 4.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man7/fips_module.pod
+++ b/doc/man7/fips_module.pod
@@ -18,7 +18,19 @@ For information related to installing the FIPS module see
 L<https://github.com/openssl/openssl/blob/master/README-FIPS.md>.
 
 Note that the old functions FIPS_mode() and FIPS_mode_set() are no longer
-present so you must remove them from your application if you use them.
+present so you should remove them from your application if you use them. A
+convenience define FIPS_mode() to EVP_default_properties_is_fips_enabled(NULL)
+is provided in the openssl/evp.h header. This is a hint of intent, but not
+proof. If you are looking to validate whether the default configuration is using
+a validated module, many additional checks are needed; please consult the
+security policy of the module you are using. Most applications should load the
+default library context and use it as is, without ever using FIPS_mode() or
+checking EVP_default_properties_is_fips_enabled(). This enables your
+application to work unmodified with all the different types of cryptographic
+providers available to OpenSSL. There are many alternative third-party providers
+that implement FIPS cryptography. For example, the wolfCrypt and SymCrypt
+providers can be used with OpenSSL at run time to also provide FIPS
+cryptography.
 
 Applications written to use the OpenSSL 3.0 FIPS module should not use any
 legacy APIs or features that avoid the FIPS module. Specifically this includes:

--- a/doc/man7/ossl-guide-migration.pod
+++ b/doc/man7/ossl-guide-migration.pod
@@ -643,7 +643,9 @@ implemented by EVP_RAND and EVP_RAND_CTX.
 These functions are legacy APIs that are not applicable to the new provider
 model. Applications should instead use
 L<EVP_default_properties_is_fips_enabled(3)> and
-L<EVP_default_properties_enable_fips(3)>.
+L<EVP_default_properties_enable_fips(3)>. A convenience define from FIPS_mode()
+to L<EVP_default_properties_is_fips_enabled(3)> is provided in the
+<openssl/evp.h> header.
 
 =head4 Key generation is slower
 

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -122,6 +122,7 @@ int EVP_set_default_properties(OSSL_LIB_CTX *libctx, const char *propq);
 char *EVP_get1_default_properties(OSSL_LIB_CTX *libctx);
 int EVP_default_properties_is_fips_enabled(OSSL_LIB_CTX *libctx);
 int EVP_default_properties_enable_fips(OSSL_LIB_CTX *libctx, int enable);
+#define FIPS_mode() EVP_default_properties_is_fips_enabled(NULL)
 
 #define EVP_PKEY_MO_SIGN 0x0001
 #define EVP_PKEY_MO_VERIFY 0x0002

--- a/test/defltfips_test.c
+++ b/test/defltfips_test.c
@@ -17,7 +17,7 @@ static int bad_fips;
 
 static int test_is_fips_enabled(void)
 {
-    int is_fips_enabled, is_fips_loaded;
+    int is_fips_enabled, is_fips_loaded, is_fips_legacy;
     EVP_MD *sha256 = NULL;
 
     /*
@@ -26,16 +26,19 @@ static int test_is_fips_enabled(void)
      * other function calls have auto-loaded the config file.
      */
     is_fips_enabled = EVP_default_properties_is_fips_enabled(NULL);
+    is_fips_legacy = FIPS_mode();
     is_fips_loaded = OSSL_PROVIDER_available(NULL, "fips");
 
     /*
      * Check we're in an expected state. EVP_default_properties_is_fips_enabled
      * can return true even if the FIPS provider isn't loaded - it is only based
      * on the default properties. However we only set those properties if also
-     * loading the FIPS provider.
+     * loading the FIPS provider. Also check that the legacy API matches the
+     * provider API.
      */
     if (!TEST_int_eq(is_fips || bad_fips, is_fips_enabled)
-        || !TEST_int_eq(is_fips && !bad_fips, is_fips_loaded))
+        || !TEST_int_eq(is_fips && !bad_fips, is_fips_loaded)
+        || !TEST_int_eq(is_fips_legacy, is_fips_enabled))
         return 0;
 
     /*

--- a/util/other.syms
+++ b/util/other.syms
@@ -415,6 +415,7 @@ EVP_RSA_gen                             define
 EVP_seed_cfb                            define
 EVP_sm4_cfb                             define
 EXT_UTF8STRING                          define
+FIPS_mode                               define
 OBJ_cleanup                             define deprecated 1.1.0
 OCSP_parse_url                          define
 OCSP_REQ_CTX                            datatype deprecated 3.0.0


### PR DESCRIPTION
Old OpenSSL had a FIPS_mode() function. AWS-LC-FIPS and BoringSSL-FIPS
still have the FIPS_mode() API. RHEL-derived systems also still provide
FIPS_mode() as a define in up-to-date OpenSSL. And feedback from
multiple large commercial software vendors is that there is a lot of
code out there that still has FIPS_mode() sprinkled all over the place.

Add `FIPS_mode()` as a convenience define to
`EVP_default_properties_is_fips_enabled(NULL)` which is a short-hand
to check if `fips=yes` property is currently enabled on the default
library context.

It is a hint of intent, but not a proof. If you are looking to
validate whether the default configuration is using a validated module,
many additional checks are needed; please consult the security policy
of the module you are using. We heavily discourage using this macro.

* BoringSSL implementation:
  - https://github.com/google/boringssl/blob/476f4835186050a44f7fe6f088abbd279b634194/crypto/fipsmodule/self_check/fips.cc.inc#L23 
  - Effectively static build-time configuration; equivalent to "--enable-fips"
  - Does not check if current context is configured with FIPS policy to use FIPS only algorithms
  - available in crypto.h header

* AWS-LC implementation:
  - https://github.com/aws/aws-lc/blob/95187142bb3e7b87bf3a18767ac6e47862c0ea35/crypto/fipsmodule/self_check/fips.c#L25
  - Same as BoringSSL

* RHEL-like implementations:
  - https://gitlab.com/redhat/centos-stream/rpms/openssl/-/blob/c10s/0007-RH-Add-FIPS_mode-compatibility-macro.patch?ref_type=heads
  - `define FIPS_mode() EVP_default_properties_is_fips_enabled(NULL)`
  - Available in fips.h header.

* SUSE:
  - https://build.opensuse.org/projects/openSUSE:Slowroll/packages/openssl-3/files/openssl-Add-FIPS_mode-compatibility-macro.patch?expand=1
  - matches RHEL