### PR TITLE
ossl_bsearch: Fix possible integer overflow bug

### DIFF
--- a/crypto/bsearch.c
+++ b/crypto/bsearch.c
@@ -25,7 +25,7 @@ const void *ossl_bsearch(const void *key, const void *base, int num,
     l = 0;
     h = num;
     while (l < h) {
-        i = (l + h) / 2;
+        i = l + (h - l) / 2;
         p = &(base_[i * size]);
         if (cmp_thunk != NULL)
             c = cmp_thunk((cmpthunk_fn)cmp, key, (const void *)p);


### PR DESCRIPTION
Adding the high and low limits might cause the classic binary search overflow bug. Probably not a concern but its one less thing to worry about.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
