### PR TITLE
pkcs12: fix PKCS12_set_pbmac1_pbkdf2 error-path leaks

### DIFF
--- a/crypto/pkcs12/p12_mutl.c
+++ b/crypto/pkcs12/p12_mutl.c
@@ -528,6 +528,8 @@ int PKCS12_set_pbmac1_pbkdf2(PKCS12 *p12, const char *pass, int passlen,
     X509_ALGOR_free(param->messageAuthScheme);
     param->keyDerivationFunc = alg;
     param->messageAuthScheme = hmac_alg;
+    alg = NULL;
+    hmac_alg = NULL;
 
     X509_SIG_getm(p12->mac->dinfo, &macalg, &macoct);
     if (!ASN1_TYPE_pack_sequence(ASN1_ITEM_rptr(PBMAC1PARAM), param, &macalg->parameter))
@@ -549,6 +551,8 @@ int PKCS12_set_pbmac1_pbkdf2(PKCS12 *p12, const char *pass, int passlen,
     ret = 1;
 
 err:
+    X509_ALGOR_free(alg);
+    X509_ALGOR_free(hmac_alg);
     PBMAC1PARAM_free(param);
     OPENSSL_free(known_salt);
     return ret;

--- a/test/pkcs12_api_test.c
+++ b/test/pkcs12_api_test.c
@@ -280,6 +280,35 @@ err:
     return ret;
 }
 
+static int test_PKCS12_set_pbmac1_pbkdf2_invalid_saltlen(void)
+{
+    int ret = 0;
+    unsigned char salt[8] = { 0 };
+    EVP_PKEY *key = NULL;
+    X509 *cert = NULL;
+    STACK_OF(X509) *ca = NULL;
+    PKCS12 *p12 = NULL;
+
+    if (!TEST_ptr(p12 = PKCS12_load(in_file)))
+        return 0;
+    if (!TEST_true(PKCS12_parse(p12, in_pass, &key, &cert, &ca)))
+        goto err;
+    PKCS12_free(p12);
+
+    if (!TEST_ptr(p12 = PKCS12_create_ex2("pass", NULL, key, cert, ca,
+                      NID_undef, NID_undef, 0, -1, 0,
+                      testctx, NULL, NULL, NULL)))
+        goto err;
+    ret = TEST_false(PKCS12_set_pbmac1_pbkdf2(p12, "pass", -1,
+        salt, -1, 0, NULL, NULL));
+err:
+    PKCS12_free(p12);
+    EVP_PKEY_free(key);
+    X509_free(cert);
+    OSSL_STACK_OF_X509_free(ca);
+    return ret;
+}
+
 int setup_tests(void)
 {
     OPTION_CHOICE o;
@@ -320,6 +349,7 @@ int setup_tests(void)
     ADD_TEST(pkcs12_parse_test);
     ADD_ALL_TESTS(pkcs12_create_ex2_test, 3);
     ADD_TEST(test_PKCS12_set_pbmac1_pbkdf2_saltlen_zero);
+    ADD_TEST(test_PKCS12_set_pbmac1_pbkdf2_invalid_saltlen);
     return 1;
 }
 


### PR DESCRIPTION
In `PKCS12_set_pbmac1_pbkdf2` function (`crypto/pkcs12/p12_mutl.c`), there is a memory leak when `PKCS5_pbkdf2_set` fails after allocating `hmac_alg`.

The function allocates three resources in sequence:
Allocation sequence (lines 484-486):
```c
param = PBMAC1PARAM_new();
hmac_alg = X509_ALGOR_new();
alg = PKCS5_pbkdf2_set(...);
```

Ownership of hmac_alg and alg is only transferred later via:
```c
param->keyDerivationFunc = alg;
param->messageAuthScheme = hmac_alg;
```

If `PKCS5_pbkdf2_set` fails (returns NULL), the code jumps to the `err` label (line 488). However, the error handling block only frees `param` and `known_salt`:

```c
err:
    PBMAC1PARAM_free(param);
    OPENSSL_free(known_salt);
    return ret;
```

The `hmac_alg` pointer (and potentially `alg`) is never freed, causing a memory leak.

Fix by freeing alg and hmac_alg on the error path, and nulling the local pointers after ownership transfer to avoid double free.

Add an API regression test covering the invalid-salt error path.

To trigger the leak, you can compile & run the following PoC with ASan enabled:


```c
// leak_poc.c
#include <stdio.h>
#include <openssl/pkcs12.h>
#include <openssl/evp.h>
#include <openssl/err.h>

int main(void)
{
    PKCS12 *p12 = NULL;
    unsigned char salt[8] = {1, 2, 3, 4, 5, 6, 7, 8};
    int i;

    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);

    p12 = PKCS12_init(NID_pkcs7_data);
    if (p12 == NULL) {
        fprintf(stderr, "Failed to create PKCS12\n");
        ERR_print_errors_fp(stderr);
        return 1;
    }

    /* Trigger the leak 100 times to make it visible in LeakSanitizer */
    for (i = 0; i < 100; i++) {
        /*
         * Call with negative saltlen (-1) and non-NULL salt.
         * This triggers failure in PKCS5_pbkdf2_set_ex() after
         * hmac_alg has been allocated, causing it to leak.
         */
        PKCS12_set_pbmac1_pbkdf2(p12, "password", -1,
                                  salt, -1,      /* negative saltlen */
                                  10000,
                                  EVP_sha256(),
                                  NULL);
    }

    ERR_clear_error();
    PKCS12_free(p12);

    return 0;
}
```

```bash
# Build OpenSSL with ASan
./Configure enable-asan -g -O1 -fno-omit-frame-pointer
make clean && make -j$(nproc)

# Build PoC
gcc -fsanitize=address -fsanitize=leak -g -O1 leak_poc.c \
    -I/path/to/openssl/include -L/path/to/openssl \
    -lssl -lcrypto -lpthread -ldl \
    -Wl,-rpath,/path/to/openssl -o leak_poc

# Run with leak detection
./leak_poc
```
This will give:
```c
% ./leak_poc                                                                 
=================================================================
==203185==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 1600 byte(s) in 100 object(s) allocated from:
    #0 0x7ff7b76bf91f in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7ff7b6aae14f in CRYPTO_malloc crypto/mem.c:214
    #2 0x7ff7b6aae31f in CRYPTO_zalloc crypto/mem.c:226
    #3 0x7ff7b68afa83 in asn1_item_embed_new crypto/asn1/tasn_new.c:135
    #4 0x7ff7b68afe5d in ASN1_item_ex_new crypto/asn1/tasn_new.c:56
    #5 0x7ff7b68aff08 in ASN1_item_new crypto/asn1/tasn_new.c:32
    #6 0x7ff7b68b3654 in X509_ALGOR_new crypto/asn1/x_algor.c:26
    #7 0x7ff7b6bcd184 in PKCS12_set_pbmac1_pbkdf2 crypto/pkcs12/p12_mutl.c:509
    #8 0x55e7b1229420 in main /scratch/weidong/poc_playground/output/openssl/poc/pkcs12-set-pbmac1-hmac-alg-leak-adf936/poc/leak_poc.c:63

SUMMARY: AddressSanitizer: 1600 byte(s) leaked in 100 allocation(s).
```
Thanks for looking into this and we appreciate any feedback!