### PR TITLE
apps: fix resource leak in crls_http_cb()

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2675,7 +2675,7 @@ static STACK_OF(X509_CRL) *crls_http_cb(const X509_STORE_CTX *ctx,
 
 error:
     X509_CRL_free(crl);
-    sk_X509_CRL_free(crls);
+    sk_X509_CRL_pop_free(crls, X509_CRL_free);
     return NULL;
 }
 


### PR DESCRIPTION
**Issue Summary**
A resource leak occurs in the `crls_http_cb` function within `apps/lib/apps.c (lines 2647-2680)`. When the function successfully downloads and pushes the first CRL to the stack but fails to push the second CRL (Delta CRL), it jumps to the `error` label. Inside the error handling block, it uses `sk_X509_CRL_free(crls)` instead of `sk_X509_CRL_pop_free(crls, X509_CRL_free)`. This destroys the stack container but orphans any previously pushed `X509_CRL` objects, leading to a memory leak.

**Problematic Code**

```c
static STACK_OF(X509_CRL) *crls_http_cb(const X509_STORE_CTX *ctx,
    const X509_NAME *nm)
{
    const X509 *x;
    STACK_OF(X509_CRL) *crls = NULL;
    X509_CRL *crl;
    STACK_OF(DIST_POINT) *crldp;

    crls = sk_X509_CRL_new_null();
    if (!crls)
        return NULL;
    x = X509_STORE_CTX_get_current_cert(ctx);
    crldp = X509_get_ext_d2i(x, NID_crl_distribution_points, NULL, NULL);
    crl = load_crl_crldp(crldp);
    sk_DIST_POINT_pop_free(crldp, DIST_POINT_free);

    if (crl == NULL || !sk_X509_CRL_push(crls, crl))
        goto error;

    /* Try to download delta CRL */
    crldp = X509_get_ext_d2i(x, NID_freshest_crl, NULL, NULL);
    crl = load_crl_crldp(crldp);
    sk_DIST_POINT_pop_free(crldp, DIST_POINT_free);

    if (crl != NULL && !sk_X509_CRL_push(crls, crl))
        goto error;

    return crls;

error:
    X509_CRL_free(crl);
    sk_X509_CRL_free(crls);
    return NULL;
}

```

**Root Cause Analysis**
The logical flaw lies in misunderstanding the OpenSSL Safestack API semantics:

1. `sk_X509_CRL_free()` strictly deallocates the stack structure itself (the array holding the pointers) but does **not** free the actual objects the pointers refer to.
2. If `crl = load_crl_crldp(crldp);` succeeds the first time and the CRL is pushed, `crls` assumes ownership of that `X509_CRL` object.
3. If the second `sk_X509_CRL_push(crls, crl)` fails, the code handles the local `crl` correctly via `X509_CRL_free(crl)` but calls `sk_X509_CRL_free(crls)` to destroy the stack.
4. Because `sk_X509_CRL_free` does not clean up its members, the Base CRL loaded in step 1 is permanently leaked.

**Proposed Fix**
Replace `sk_X509_CRL_free` with `sk_X509_CRL_pop_free` passing `X509_CRL_free` as the cleanup routine to ensure deep deallocation of any pushed items.

```diff
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
 
 error:
     X509_CRL_free(crl);
-    sk_X509_CRL_free(crls);
+    sk_X509_CRL_pop_free(crls, X509_CRL_free);
     return NULL;
 }

```

Closes #30366

**Environment**

* OS: Ubuntu 2004 x86_64 GNU/Linux
* Compiler: gcc
* Component: `apps/lib/apps.c`

---