### PR TITLE
apps: fix memory leak in get_str_from_file()

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -3822,6 +3822,7 @@ char *get_str_from_file(const char *filename)
     bio = NULL;
     if (n <= 0) {
         BIO_printf(bio_err, "Error reading from %s\n", filename);
+        OPENSSL_clear_free(buf, MAX_KEY_SIZE);
         return NULL;
     }
     tmp = strchr(buf, '\n');


### PR DESCRIPTION
**Issue Summary**
A memory leak occurs in the `get_str_from_file` function within `apps/lib/apps.c (lines 3797-3831)`. The function allocates a `MAX_KEY_SIZE` (2048 bytes) buffer on the heap to store data read from a file or standard input. If the subsequent read operation (`BIO_gets`) returns `<= 0` (e.g., due to an empty file or an I/O error), the function enters an error-handling block, logs an error, and returns `NULL` without freeing the allocated buffer.

**Problematic Code**

```c
char *get_str_from_file(const char *filename)
{
    // ... [Initialization and BIO setup] ...
    
    // Step 1: Memory is allocated
    buf = app_malloc(MAX_KEY_SIZE, "get_str_from_file"); 
    memset(buf, 0, MAX_KEY_SIZE);
    
    // Step 2: Attempt to read from BIO
    n = BIO_gets(bio, buf, MAX_KEY_SIZE - 1);
    BIO_free_all(bio);
    bio = NULL;
    
    // Step 3: Error path
    if (n <= 0) {
        BIO_printf(bio_err, "Error reading from %s\n", filename);
        return NULL; // <--- BUG: Function returns here, permanently leaking 'buf'
    }
    
    // ... [Success path] ...
    return buf;
}

```

**Root Cause Analysis**
This is a classic "Forget-to-Free on Return" error within an exception path.

1. The function takes ownership of a dynamically allocated heap block (`buf`) using `app_malloc`.
2. When `BIO_gets` encounters an empty file or read error, it returns a value `<= 0`.
3. The code correctly intercepts the error and cleans up the `bio` object via `BIO_free_all(bio)`.
4. However, inside the `if (n <= 0)` block, it fails to release `buf` before executing `return NULL;`. Because `get_str_from_file` is often used to read MAC keys and passwords, an attacker or automated script repeatedly supplying an empty file could silently drain heap memory by 2048 bytes per call, potentially leading to a Denial of Service (OOM crash).


**Proposed Fix**
The fix is to safely clear and free the allocated buffer before returning `NULL` on the error path. Since `get_str_from_file` may handle cryptographic keys, `OPENSSL_clear_free` should be used.


Closes #30367