### PR TITLE
cmp_mock_srv: fix resource leak in process_genm()

### DIFF
--- a/apps/lib/cmp_mock_srv.c
+++ b/apps/lib/cmp_mock_srv.c
@@ -591,6 +591,7 @@ static int process_genm(OSSL_CMP_SRV_CTX *srv_ctx,
         if (rsp != NULL && sk_OSSL_CMP_ITAV_push(*out, rsp))
             return 1;
         sk_OSSL_CMP_ITAV_free(*out);
+        OSSL_CMP_ITAV_free(rsp);
         return 0;
     }
 


### PR DESCRIPTION
**Issue Summary**
A resource leak occurs in the `process_genm` function within `apps/cmp_mock_srv.c (lines 567-600)`. The function dynamically creates a response ITAV object (`rsp`), but if the subsequent attempt to push it into the `out` stack fails (e.g., memory allocation failure during `sk_OSSL_CMP_ITAV_push`), the code enters an error path where it frees the stack container but permanently abandons the newly allocated `rsp` object, leading to a memory leak.

**Problematic Code**

```c
static int process_genm(OSSL_CMP_SRV_CTX *srv_ctx,
                        const OSSL_CMP_MSG *genm,
                        const STACK_OF(OSSL_CMP_ITAV) *in,
                        STACK_OF(OSSL_CMP_ITAV) **out)
{
    // ...
    if (sk_OSSL_CMP_ITAV_num(in) == 1) {
        OSSL_CMP_ITAV *req = sk_OSSL_CMP_ITAV_value(in, 0), *rsp;
        ASN1_OBJECT *obj = OSSL_CMP_ITAV_get0_type(req);

        if ((*out = sk_OSSL_CMP_ITAV_new_reserve(NULL, 1)) == NULL)
            return 0;
            
        // Allocation: rsp is generated and allocated here
        rsp = process_genm_itav(ctx, OBJ_obj2nid(obj), req);
        
        // Failed Transfer: if push fails, it returns 0
        if (rsp != NULL && sk_OSSL_CMP_ITAV_push(*out, rsp))
            return 1;
            
        // Error Path
        sk_OSSL_CMP_ITAV_free(*out);
        return 0; // <--- BUG: `rsp` is never freed here!
    }
    // ...
}

```

**Root Cause Analysis**
This is a "Failed Ownership Transfer" memory leak.

1. `process_genm_itav` returns a pointer to a newly allocated `OSSL_CMP_ITAV` object, passing ownership to `process_genm`.
2. `process_genm` attempts to transfer this ownership to the `*out` stack using `sk_OSSL_CMP_ITAV_push`.
3. If the push fails (returning 0), the condition short-circuits.
4. The cleanup path correctly calls `sk_OSSL_CMP_ITAV_free(*out)` to destroy the empty stack, but it fails to invoke `OSSL_CMP_ITAV_free(rsp)`. The `rsp` pointer is destroyed when the function returns `0`, stranding the object in heap memory.

**Proposed Fix**
The fix is to explicitly free `rsp` if it exists and wasn't pushed successfully.

Closes #30368