### PR TITLE
vms_term_sock: fix system resource leak in TerminalSocket()

### DIFF
--- a/apps/lib/vms_term_sock.c
+++ b/apps/lib/vms_term_sock.c
@@ -230,6 +230,7 @@ int TerminalSocket(int FunctionCode, int *ReturnSocket)
             LogMessage("TerminalSocket: SYS$QIO () - %08X", status);
             close(TerminalSocketPair[0]);
             close(TerminalSocketPair[1]);
+            sys$dassgn(TerminalDeviceChan);
             return TERM_SOCK_FAILURE;
         }
 
@@ -248,6 +249,7 @@ int TerminalSocket(int FunctionCode, int *ReturnSocket)
             LogMessage("TerminalSocket: SYS$CANCEL () - %08X", status);
             close(TerminalSocketPair[0]);
             close(TerminalSocketPair[1]);
+            sys$dassgn(TerminalDeviceChan);
             return TERM_SOCK_FAILURE;
         }
 


### PR DESCRIPTION
**Issue Summary**
A system resource leak occurs in the `TerminalSocket` function within `apps/lib/vms_term_sock.c (lines 181-290)` (specific to OpenVMS builds). When establishing a terminal socket (`TERM_SOCK_CREATE`), the code successfully allocates an I/O channel via `sys$assign`. However, if the subsequent async I/O read operation (`sys$qio`) fails, the error-handling path returns early without freeing the allocated channel via `sys$dassgn`. A similar issue exists in the `TERM_SOCK_DELETE` branch if `sys$cancel` fails. Repeated triggers of these error paths will exhaust the OpenVMS process I/O channel quota (BYTLM/FILLM), leading to a Denial of Service.

**Problematic Code**

```c
int TerminalSocket(int FunctionCode, int *ReturnSocket)
{
    // ...
    case TERM_SOCK_CREATE:
        // ... [Socket pair creation] ...
        
        /* 1. Channel is successfully assigned (allocated) */
        status = sys$assign(&TerminalDeviceDesc, &TerminalDeviceChan, 0, 0, 0);
        if (!(status & 1)) {
            // ...
            return TERM_SOCK_FAILURE;
        }

        /* 2. Attempt to use the channel */
        status = sys$qio(EFN$C_ENF, TerminalDeviceChan, IO$_READVBLK, ...);
        
        /* 3. Error path */
        if (!(status & 1)) {
            LogMessage("TerminalSocket: SYS$QIO () - %08X", status);
            close(TerminalSocketPair[0]);
            close(TerminalSocketPair[1]);
            
            // <--- BUG: Returns immediately. sys$dassgn(TerminalDeviceChan) is entirely missing!
            return TERM_SOCK_FAILURE;
        }
        // ...

```

**Root Cause Analysis**
In OpenVMS, `sys$assign` and `sys$dassgn` are the equivalent of `open` and `close` (or `malloc` and `free`) for hardware/device I/O channels.

1. The code takes ownership of an I/O channel by invoking `sys$assign`.
2. The code attempts an asynchronous read via `sys$qio`. In OpenVMS semantics, an even `status` return value indicates an error (`!(status & 1)`).
3. In the error path for `sys$qio`, the developer correctly closes the socket pairs but completely forgets to release the `TerminalDeviceChan`.
4. Proof of oversight: In the exact same file, inside the `CreateSocketPair` function, an identical error path correctly calls `sys$dassgn(TcpDeviceChan)` when `sys$qio` fails. This confirms that the omission in `TerminalSocket` is a true leak.


**Proposed Fix**
The fix requires adding `sys$dassgn(TerminalDeviceChan)` in the `sys$qio` error path during creation, and ensuring `dassgn` executes regardless of whether `sys$cancel` succeeds during deletion.

Closes #30369