### PR TITLE
Fix a one byte buffer overflow in s_client

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -4199,7 +4199,11 @@ static void user_data_init(struct user_data_st *user_data, SSL *con, char *buf,
 
 static int user_data_add(struct user_data_st *user_data, size_t i)
 {
-    if (user_data->buflen != 0 || i > user_data->bufmax)
+    /*
+     * We must allow one byte for a NUL terminator so i must be less than
+     * bufmax
+     */
+    if (user_data->buflen != 0 || i >= user_data->bufmax)
         return 0;
 
     user_data->buflen = i;


### PR DESCRIPTION
The buffer used to process user commands when using advanced mode ("-adv") can overflow the buffer by one byte if the the read buffer is exactly BUFSIZZ bytes in length (16k). When processing the buffer we add a NUL terminator to the buffer, so if the buffer is already full then we overwrite by one byte when we add the NUL terminator.

This does not represent a security issue because this is entirely local and would be "self-inflicted", i.e. not under attacker control.

This issue was reported to use by Igor Morgenstern from AISLE.
