### PR TITLE
doc: clarify X509_STORE thread safety and lifetime contract

### DIFF
--- a/doc/man3/X509_STORE_CTX_get_by_subject.pod
+++ b/doc/man3/X509_STORE_CTX_get_by_subject.pod
@@ -36,7 +36,7 @@ lookup functions on the same store.
 Applications sharing a store across threads should manage its lifetime with
 L<X509_STORE_up_ref(3)> and L<X509_STORE_free(3)>, and must ensure that
 all lookup operations have completed before the store is freed. See
-L<X509_STORE_new(3)> for more discussion of the B<X509_STORE> threading
+L<X509_STORE_new(3)/Thread Safety> for more discussion of the B<X509_STORE> threading
 model.
 
 =head1 RETURN VALUES
@@ -48,7 +48,7 @@ X509_STORE_CTX_get_obj_by_subject() returns an object on success, else NULL.
 =head1 SEE ALSO
 
 L<X509_LOOKUP_meth_set_get_by_subject(3)>,
-L<X509_LOOKUP_by_subject(3)>
+L<X509_LOOKUP_by_subject(3)>,
 L<X509_STORE_new(3)> 
 
 =head1 COPYRIGHT

--- a/doc/man3/X509_STORE_new.pod
+++ b/doc/man3/X509_STORE_new.pod
@@ -34,7 +34,7 @@ If the argument is NULL, nothing is done.
 
 =head1 NOTES
 
-=head2 Thread safety
+=head2 Thread Safety
 
 When an B<X509_STORE> is shared across multiple threads, each thread or
 component that holds a pointer to it should call X509_STORE_up_ref() to
@@ -45,7 +45,8 @@ Adding certificates or CRLs, for example L<X509_STORE_add_cert(3)> or
 L<X509_STORE_add_crl(3)>, as well as looking up objects from the cache 
 with L<X509_STORE_CTX_get_by_subject(3)> are safe to call concurrently 
 from multiple threads on the same store without external synchronization, 
-but still require acquiring a reference.
+provided the ownership to the X509_STORE is obtained by acquiring a 
+reference in advance.
 
 Store I<configuration> functions (X509_STORE_set_flags(),
 X509_STORE_set_depth(), X509_STORE_set_purpose(), X509_STORE_set_trust(),


### PR DESCRIPTION
Improve the description of X509_STORE_lock() in X509_STORE_new.pod to emphasize it acquires an exclusive write lock.

Add a NOTES section to X509_STORE_new.pod covering which operations are internally thread-safe and which are not, as well as documentation on lifetime management and reference counting.

Add a NOTES section to X509_STORE_CTX_get_by_subject.pod explaining that the store's internal lock is released before the found object's reference count is incremented, so the caller must ensure the store outlives the lookup.

Relates to #30310

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
