### PR TITLE
ISSUE-19110: Make get_params mandatory for provided ciphers

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1478,12 +1478,12 @@ static void *evp_cipher_from_algorithm(const int name_id,
     if ((fnciphcnt != 0 && fnciphcnt != 3 && fnciphcnt != 4)
         || (fnciphcnt == 0 && cipher->ccipher == NULL && fnpipecnt == 0)
         || (fnpipecnt != 0 && (fnpipecnt < 3 || cipher->p_cupdate == NULL || cipher->p_cfinal == NULL))
-        || fnctxcnt != 2) {
+        || fnctxcnt != 2
+        || cipher->get_params == NULL) {
         /*
          * In order to be a consistent set of functions we must have at least
          * a complete set of "encrypt" functions, or a complete set of "decrypt"
-         * functions, or a single "cipher" function. In all cases we need both
-         * the "newctx" and "freectx" functions.
+         * functions, or a single "cipher" function.
          */
         ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_PROVIDER_FUNCTIONS);
         goto err;

--- a/doc/man7/provider-cipher.pod
+++ b/doc/man7/provider-cipher.pod
@@ -294,7 +294,7 @@ OSSL_FUNC_cipher_decrypt_skey_init() were introduced in OpenSSL 3.5.
 
 =head1 COPYRIGHT
 
-Copyright 2019-2025 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2019-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/test/build.info
+++ b/test/build.info
@@ -248,7 +248,7 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[evp_libctx_test]=../include ../apps/include
   DEPEND[evp_libctx_test]=../libcrypto.a libtestutil.a
 
-  SOURCE[evp_fetch_prov_test]=evp_fetch_prov_test.c
+  SOURCE[evp_fetch_prov_test]=evp_fetch_prov_test.c fake_cipherprov.c
   INCLUDE[evp_fetch_prov_test]=../include ../apps/include
   DEPEND[evp_fetch_prov_test]=../libcrypto libtestutil.a
 

--- a/test/evp_fetch_prov_test.c
+++ b/test/evp_fetch_prov_test.c
@@ -20,6 +20,7 @@
 #include <openssl/provider.h>
 #include "internal/sizes.h"
 #include "testutil.h"
+#include "fake_cipherprov.h"
 
 static char *config_file = NULL;
 static char *alg = "digest";
@@ -341,6 +342,36 @@ static int test_explicit_EVP_CIPHER_fetch_by_name(void)
 }
 
 /*
+ * Test that a provider cipher without get_params fails to fetch.
+ */
+static int test_cipher_no_getparams(void)
+{
+    int ret = 0;
+    OSSL_LIB_CTX *ctx = NULL;
+    OSSL_PROVIDER *fake_prov = NULL;
+    EVP_CIPHER *cipher = NULL;
+
+    ctx = OSSL_LIB_CTX_new();
+    if (!TEST_ptr(ctx))
+        return 0;
+
+    if (!TEST_ptr(fake_prov = fake_cipher_start(ctx)))
+        goto end;
+
+    /* Fetch must fail for a cipher that has no get_params */
+    cipher = EVP_CIPHER_fetch(ctx, FAKE_CIPHER_NO_GETPARAMS, FAKE_CIPHER_FETCH_PROPS);
+    if (!TEST_ptr_null(cipher))
+        goto end;
+
+    ret = 1;
+end:
+    EVP_CIPHER_free(cipher);
+    fake_cipher_finish(fake_prov);
+    OSSL_LIB_CTX_free(ctx);
+    return ret;
+}
+
+/*
  * idx 0: Allow names from OBJ_obj2txt()
  * idx 1: Force an OID in text form from OBJ_obj2txt()
  */
@@ -408,6 +439,7 @@ int setup_tests(void)
     } else {
         ADD_TEST(test_implicit_EVP_CIPHER_fetch);
         ADD_TEST(test_explicit_EVP_CIPHER_fetch_by_name);
+        ADD_TEST(test_cipher_no_getparams);
         ADD_ALL_TESTS_NOSUBTEST(test_explicit_EVP_CIPHER_fetch_by_X509_ALGOR, 2);
     }
     return 1;

--- a/test/evp_skey_test.c
+++ b/test/evp_skey_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2024-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy

--- a/test/fake_cipherprov.c
+++ b/test/fake_cipherprov.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2024-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -267,8 +267,18 @@ static const OSSL_DISPATCH ossl_fake_functions[] = {
     OSSL_DISPATCH_END
 };
 
+static const OSSL_DISPATCH ossl_fake_no_getparams_functions[] = {
+    { OSSL_FUNC_CIPHER_NEWCTX,
+        (void (*)(void))fake_newctx },
+    { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))fake_freectx },
+    { OSSL_FUNC_CIPHER_CIPHER, (void (*)(void))fake_cipher },
+    OSSL_DISPATCH_END
+};
+
 static const OSSL_ALGORITHM fake_cipher_algs[] = {
     { "fake_cipher", FAKE_CIPHER_FETCH_PROPS, ossl_fake_functions },
+    { FAKE_CIPHER_NO_GETPARAMS, FAKE_CIPHER_FETCH_PROPS,
+        ossl_fake_no_getparams_functions },
     { NULL, NULL, NULL }
 };
 

--- a/test/fake_cipherprov.h
+++ b/test/fake_cipherprov.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2024-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -16,4 +16,5 @@ void fake_cipher_finish(OSSL_PROVIDER *p);
 #define FAKE_PROV_NAME "fake-cipher"
 #define FAKE_CIPHER_FETCH_PROPS "provider=fake-cipher"
 
+#define FAKE_CIPHER_NO_GETPARAMS "fake_cipher_no_getparams"
 #define FAKE_CIPHER_PARAM_KEY_NAME "key_name"


### PR DESCRIPTION
### Description

This PR updates cipher-provider validation so `get_params` is enforced at dispatch-table unpack time.

Previously, providers missing `get_params` failed later during constant caching with `EVP_R_CACHE_CONSTANTS_FAILED`. This made the failure mode less clear and happened after method construction had already progressed.

With this change, missing `get_params` is treated as an invalid provider function set and fails early with `EVP_R_INVALID_PROVIDER_FUNCTIONS`.

Fixes #19110.

### Changes

- Enforced mandatory `get_params` in cipher dispatch validation.
- Removed the prior cache-path workaround approach.
- Updated the no-`get_params` test to assert fetch failure.
- Clarified `provider-cipher(7)` wording so the mandatory/optional split is explicit.
- Added a `provider-cipher(7)` HISTORY note for this behavior.
- Updated `CHANGES.md` to reflect the final behavior and error path.

### Documentation

- `provider-cipher(7)` now explicitly states that functions other than
- `get_params`/`newctx`/`freectx` are optional, and includes a HISTORY note for
this enforcement behavior.
- `provider-cipher(7)` already states that `OSSL_FUNC_cipher_get_params` must be present. This PR aligns implementation behavior with that requirement.

### Testing

- Built successfully.
- `make doc-nits` passes.
- `test_evp_skey` passes, including the updated no-`get_params` test.
- A full-suite run showed unrelated pre-existing failures in:
  - `15-test_ml_kem_codecs.t`
  - `15-test_ecparam.t`
  - `15-test_mp_rsa.t`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
- [x] tests are added or updated
