### PR TITLE
Fix #19891 CONNECT request for IPv6 targets in OSSL_HTTP_proxy_connect

### DIFF
--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -1466,7 +1466,11 @@ int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
     }
     BIO_push(fbio, bio);
 
-    BIO_printf(fbio, "CONNECT %s:%s " HTTP_1_0 "\r\n", server, port);
+    /* Add square brackets around a naked IPv6 address */
+    if (server[0] != '[' && strchr(server, ':') != NULL)
+        BIO_printf(fbio, "CONNECT [%s]:%s " HTTP_1_0 "\r\n", server, port);
+    else
+        BIO_printf(fbio, "CONNECT %s:%s " HTTP_1_0 "\r\n", server, port);
 
     /*
      * Workaround for broken proxies which would otherwise close


### PR DESCRIPTION
When using `openssl s_client` with `-proxy` to connect to an IPv6 target
(e.g., `openssl s_client -connect [2001:1:1::2]:443 -proxy 10.1.2.57:9090`),
`OSSL_HTTP_proxy_connect()` generates a malformed HTTP CONNECT request:

```
CONNECT 2001:1:1::2:443 HTTP/1.0
```

The IPv6 address is not enclosed in brackets, so HTTP proxies cannot
distinguish the colons in the IPv6 address from the host:port separator.
This causes proxies to reject the request with `400 Bad Request` or similar.

The fix checks whether the `server` parameter contains a colon (indicating
an IPv6 address) and wraps it in brackets when building the CONNECT request line. IPv4 addresses and
hostnames are unaffected since they never contain colons.

Tested with:
- IPv6 target `[2001:1:1::2]:443` through HTTP proxy → CONNECT line now
  correctly reads `CONNECT [2001:1:1::2]:443 HTTP/1.0`, TLS handshake succeeds
- IPv4 target `10.1.1.91:443` through HTTP proxy → unchanged, works as before
- Hostname target `testserver.local:443` through HTTP proxy → unchanged, works
  as before

Fixes #19891

##### Checklist
- [ ] documentation is added or updated
- [x] tests are added or updated
