### PR TITLE
Optimization to Windows RCU

### DIFF
--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -347,9 +347,9 @@ static struct rcu_qp *update_qp(CRYPTO_RCU_LOCK *lock, uint32_t *curr_id)
     InterlockedExchange((LONG volatile *)&lock->reader_idx, tmp);
 #endif
 
+    ossl_crypto_mutex_unlock(lock->alloc_lock);
     /* wake up any waiters */
     ossl_crypto_condvar_signal(lock->alloc_signal);
-    ossl_crypto_mutex_unlock(lock->alloc_lock);
     return &lock->qp_group[current_idx];
 }
 
@@ -358,8 +358,8 @@ static void retire_qp(CRYPTO_RCU_LOCK *lock,
 {
     ossl_crypto_mutex_lock(lock->alloc_lock);
     lock->writers_alloced--;
-    ossl_crypto_condvar_signal(lock->alloc_signal);
     ossl_crypto_mutex_unlock(lock->alloc_lock);
+    ossl_crypto_condvar_signal(lock->alloc_signal);
 }
 
 void ossl_synchronize_rcu(CRYPTO_RCU_LOCK *lock)
@@ -388,8 +388,8 @@ void ossl_synchronize_rcu(CRYPTO_RCU_LOCK *lock)
     } while (count != (uint64_t)0);
 
     lock->next_to_retire++;
-    ossl_crypto_condvar_broadcast(lock->prior_signal);
     ossl_crypto_mutex_unlock(lock->prior_lock);
+    ossl_crypto_condvar_broadcast(lock->prior_signal);
 
     retire_qp(lock, qp);
 

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -348,7 +348,7 @@ static struct rcu_qp *update_qp(CRYPTO_RCU_LOCK *lock, uint32_t *curr_id)
 #endif
 
     /* wake up any waiters */
-    ossl_crypto_condvar_broadcast(lock->alloc_signal);
+    ossl_crypto_condvar_signal(lock->alloc_signal);
     ossl_crypto_mutex_unlock(lock->alloc_lock);
     return &lock->qp_group[current_idx];
 }
@@ -358,7 +358,7 @@ static void retire_qp(CRYPTO_RCU_LOCK *lock,
 {
     ossl_crypto_mutex_lock(lock->alloc_lock);
     lock->writers_alloced--;
-    ossl_crypto_condvar_broadcast(lock->alloc_signal);
+    ossl_crypto_condvar_signal(lock->alloc_signal);
     ossl_crypto_mutex_unlock(lock->alloc_lock);
 }
 


### PR DESCRIPTION
While testing Windows builds, there was a significant difference in lhash_test runtime compared to Linux on the same HW.

This patchset tries to optimize two things
- aligns Windows RCU implementation not to use signal broadcast, but signal only one thread
(this was probably an implementation mistake from the beginning)

- optimize not to spend time waiting twice by switching the order of unlock/signal (note: this is a Windows-only optimization, and it is not needed, and even cannot be done, for pthreads).

Some analysis was done using Claude code, fixing and ignoring other suggested stupid optimization by me :-)

The lhash_test now runs in almost the same time as on Linux on an identical VM (32 CPUs) - 1 minute, whereas the original took over 6 minutes.