### PR TITLE
apps/cmp.c: fix leak of out_trusted in setup_verification_ctx()

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1425,7 +1425,10 @@ static int setup_verification_ctx(OSSL_CMP_CTX *ctx)
         out_vpm = X509_STORE_get0_param(out_trusted);
         X509_VERIFY_PARAM_clear_flags(out_vpm, X509_V_FLAG_USE_CHECK_TIME);
 
-        (void)OSSL_CMP_CTX_set_certConf_cb_arg(ctx, out_trusted);
+        if (!OSSL_CMP_CTX_set_certConf_cb_arg(ctx, out_trusted)) {
+            X509_STORE_free(out_trusted);
+            return 0;
+        }
     }
 
     if (opt_disable_confirm)


### PR DESCRIPTION
setup_verification_ctx() allocates out_trusted via load_trusted() and passes it to OSSL_CMP_CTX_set_certConf_cb_arg(). Since the argument is not consumed, it must be freed on failure. The fix is to free out_trusted if OSSL_CMP_CTX_set_certConf_cb_arg() fails.

Resolves: https://github.com/openssl/openssl/issues/30377 
Fixes #30377
