### PR TITLE
DTLS 1.3 Update Epoch to a 64 bit counter and don't allow wrapping

### DIFF
--- a/doc/designs/quic-design/record-layer.md
+++ b/doc/designs/quic-design/record-layer.md
@@ -401,7 +401,7 @@ struct ossl_record_method_st {
                             const char *propq, int vers,
                             int role, int direction,
                             int level,
-                            uint16_t epoch,
+                            uint64_t epoch,
                             unsigned char *key,
                             size_t keylen,
                             unsigned char *iv,

--- a/include/internal/recordmethod.h
+++ b/include/internal/recordmethod.h
@@ -116,7 +116,7 @@ struct ossl_record_method_st {
         const char *propq, int vers,
         int role, int direction,
         int level,
-        uint16_t epoch,
+        uint64_t epoch,
         unsigned char *secret,
         size_t secretlen,
         unsigned char *snkey,
@@ -324,7 +324,7 @@ struct ossl_record_method_st {
     /*
      * Get the Epoch value
      */
-    int (*get_epoch)(OSSL_RECORD_LAYER *rl, uint16_t *epoch);
+    int (*get_epoch)(OSSL_RECORD_LAYER *rl, uint64_t *epoch);
 
     /*
      * Set the current MTU length to be used for the record layer.

--- a/include/internal/recordmethod.h
+++ b/include/internal/recordmethod.h
@@ -229,7 +229,7 @@ struct ossl_record_method_st {
      */
     int (*read_record)(OSSL_RECORD_LAYER *rl, void **rechandle, int *rversion,
         uint8_t *type, const unsigned char **data, size_t *datalen,
-        uint16_t *epoch, uint64_t *seq_num);
+        uint64_t *epoch, uint64_t *seq_num);
     /*
      * Release length bytes from a buffer associated with a record previously
      * read with read_record. Once all the bytes from a record are released, the

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -153,7 +153,7 @@ DTLS1_RECORD_NUMBER *dtls1_record_number_new(uint64_t epoch, uint64_t seqnum)
     return recnum;
 }
 
-void dtls1_acknowledge_sent_buffer(SSL_CONNECTION *s, uint16_t before_epoch)
+void dtls1_acknowledge_sent_buffer(SSL_CONNECTION *s, uint64_t before_epoch)
 {
     pitem *item = NULL;
     piterator iter = pqueue_iterator(&s->d1->sent_messages);

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -97,7 +97,7 @@ static int quic_free(OSSL_RECORD_LAYER *r);
 
 static int
 quic_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
-    int role, int direction, int level, uint16_t epoch,
+    int role, int direction, int level, uint64_t epoch,
     unsigned char *secret, size_t secretlen,
     unsigned char *snkey, unsigned char *key, size_t keylen,
     unsigned char *iv, size_t ivlen,

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -365,7 +365,7 @@ static int quic_retry_write_records(OSSL_RECORD_LAYER *rl)
 
 static int quic_read_record(OSSL_RECORD_LAYER *rl, void **rechandle,
     int *rversion, uint8_t *type, const unsigned char **data,
-    size_t *datalen, uint16_t *epoch,
+    size_t *datalen, uint64_t *epoch,
     uint64_t *seq_num)
 {
     if (rl->recread != 0 || rl->recunreleased != 0)

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -800,7 +800,7 @@ static int dtls_free(OSSL_RECORD_LAYER *rl)
 
 static int
 dtls_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
-    int role, int direction, int level, uint16_t epoch,
+    int role, int direction, int level, uint64_t epoch,
     unsigned char *secret, size_t secretlen,
     unsigned char *snkey, unsigned char *key, size_t keylen,
     unsigned char *iv, size_t ivlen,
@@ -978,7 +978,7 @@ static int dtls_set_sequence_number(OSSL_RECORD_LAYER *rl, uint64_t sequence)
     return 1;
 }
 
-static int dtls_get_epoch(OSSL_RECORD_LAYER *rl, uint16_t *epoch)
+static int dtls_get_epoch(OSSL_RECORD_LAYER *rl, uint64_t *epoch)
 {
     *epoch = rl->epoch;
     return 1;

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -11,6 +11,9 @@
 #include "../../ssl_local.h"
 #include "../record_local.h"
 #include "recmethod_local.h"
+#include "internal/safe_math.h"
+
+OSSL_SAFE_MATH_UNSIGNED(uint64_t, uint64_t)
 
 /* mod 128 saturating subtract of two 64-bit values */
 static int satsub64(uint64_t l1, uint64_t l2)
@@ -561,8 +564,17 @@ again:
              * choose the current epoch if the bits match or else choose the
              * next epoch with matching bits
              */
-            while (eebits != (epoch64 & DTLS13_UNI_HDR_EPOCH_BITS_MASK))
-                epoch64++;
+            if ((epoch64 & DTLS13_UNI_HDR_EPOCH_BITS_MASK) > eebits) {
+                int err = 0;
+                epoch64 = safe_add_uint64_t(epoch64, DTLS13_UNI_HDR_EPOCH_BITS_MASK + 1, &err);
+                if (err) {
+                    /* Overflow, silently discard record */
+                    rr->length = 0;
+                    rl->packet_length = 0;
+                    goto again;
+                }
+            }
+            epoch64 = (epoch64 & ~DTLS13_UNI_HDR_EPOCH_BITS_MASK) | eebits;
 
         } else {
             if (!PACKET_get_net_2(&dtlsrecord, &record_version)

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -469,6 +469,7 @@ again:
         || rl->packet_length < DTLS1_RT_HEADER_LENGTH) {
         PACKET dtlsrecord;
         unsigned int record_type, record_version, epoch, length;
+        uint64_t epoch64;
 
         rret = rl->funcs->read_n(rl, DTLS1_RT_HEADER_LENGTH,
             TLS_BUFFER_get_len(&rl->rbuf), 0, 1, &nread);
@@ -531,7 +532,7 @@ again:
             uint16_t eebits = rr->type & DTLS13_UNI_HDR_EPOCH_BITS_MASK;
 
             record_version = DTLS1_2_VERSION;
-            epoch = rl->epoch;
+            epoch64 = rl->epoch;
             recseqnumlen = sbitisset ? 2 : 1;
             recseqnumoffs = sizeof(recseqnum) - recseqnumlen;
 
@@ -560,8 +561,8 @@ again:
              * choose the current epoch if the bits match or else choose the
              * next epoch with matching bits
              */
-            while (eebits != (epoch & DTLS13_UNI_HDR_EPOCH_BITS_MASK))
-                epoch++;
+            while (eebits != (epoch64 & DTLS13_UNI_HDR_EPOCH_BITS_MASK))
+                epoch64++;
 
         } else {
             if (!PACKET_get_net_2(&dtlsrecord, &record_version)
@@ -572,14 +573,14 @@ again:
                 rl->packet_length = 0;
                 goto again;
             }
-
+            epoch64 = epoch;
             recseqnumoffs = 0;
             recseqnumlen = 6;
         }
 
         rechdrlen = PACKET_data(&dtlsrecord) - rl->packet;
         rr->rec_version = (int)record_version;
-        rr->epoch = epoch;
+        rr->epoch = epoch64;
         rr->length = length;
 
         if (rl->msg_callback != NULL)

--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -402,7 +402,7 @@ static int ktls_post_process_record(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *rec)
 
 static int
 ktls_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
-    int role, int direction, int level, uint16_t epoch,
+    int role, int direction, int level, uint64_t epoch,
     unsigned char *secret, size_t secretlen,
     unsigned char *snkey, unsigned char *key, size_t keylen,
     unsigned char *iv, size_t ivlen,

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -483,7 +483,7 @@ int tls_get_alert_code(OSSL_RECORD_LAYER *rl);
 int tls_set1_bio(OSSL_RECORD_LAYER *rl, BIO *bio);
 int tls_read_record(OSSL_RECORD_LAYER *rl, void **rechandle, int *rversion,
     uint8_t *type, const unsigned char **data, size_t *datalen,
-    uint16_t *epoch, uint64_t *seq_num);
+    uint64_t *epoch, uint64_t *seq_num);
 int tls_release_record(OSSL_RECORD_LAYER *rl, void *rechandle, size_t length);
 int tls_set_protocol_version(OSSL_RECORD_LAYER *rl, int version);
 void tls_set_plain_alerts(OSSL_RECORD_LAYER *rl, int allow);

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -72,7 +72,7 @@ typedef struct tls_rl_record_st {
     unsigned char *comp;
     /* epoch number, needed by DTLS1 */
     /* r */
-    uint16_t epoch;
+    uint64_t epoch;
     /* sequence number, needed by DTLS1 */
     /* r */
     uint64_t seq_num;
@@ -219,7 +219,7 @@ struct ossl_record_layer_st {
     int level;
     const EVP_MD *md;
     /* DTLS only */
-    uint16_t epoch;
+    uint64_t epoch;
 
     /*
      * A BIO containing any data read in the previous epoch that was destined

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1106,7 +1106,7 @@ int tls13_common_post_process_record(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *rec)
 
 int tls_read_record(OSSL_RECORD_LAYER *rl, void **rechandle, int *rversion,
     uint8_t *type, const unsigned char **data, size_t *datalen,
-    uint16_t *epoch, uint64_t *seq_num)
+    uint64_t *epoch, uint64_t *seq_num)
 {
     TLS_RL_RECORD *rec;
 

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1383,7 +1383,7 @@ err:
 
 static int
 tls_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
-    int role, int direction, int level, uint16_t epoch,
+    int role, int direction, int level, uint64_t epoch,
     unsigned char *secret, size_t secretlen,
     unsigned char *snkey, unsigned char *key, size_t keylen,
     unsigned char *iv, size_t ivlen,

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -789,6 +789,9 @@ int do_dtls1_write(SSL_CONNECTION *sc, uint8_t type, const unsigned char *buf,
 int dtls1_increment_epoch(SSL_CONNECTION *s, int rw)
 {
     if (rw & SSL3_CC_READ) {
+        if (!SSL_CONNECTION_IS_DTLS13(s) && s->rlayer.d->r_conn_epoch == UINT16_MAX)
+            return 0;
+
         s->rlayer.d->r_conn_epoch++;
 
         /*
@@ -801,6 +804,9 @@ int dtls1_increment_epoch(SSL_CONNECTION *s, int rw)
             /* We've wrapped around, so clear the buffer just in case */
             return 0;
     } else {
+        if (!SSL_CONNECTION_IS_DTLS13(s) && s->rlayer.d->w_conn_epoch == UINT16_MAX)
+            return 0;
+
         s->rlayer.d->w_conn_epoch++;
 
         if (s->rlayer.d->w_conn_epoch == 0)

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -543,7 +543,7 @@ start:
          * This may just be a stale retransmit. Also sanity check that we have
          * at least enough record bytes for a message header
          */
-        if (rr->epoch != dtls1_get_serialized_epoch(sc, SSL3_CC_READ)
+        if (rr->epoch != dtls1_get_epoch(sc, SSL3_CC_READ)
             || rr->length < DTLS1_HM_HEADER_LENGTH) {
             if (!ssl_release_record(sc, rr, 0))
                 return -1;
@@ -817,7 +817,7 @@ int dtls1_increment_epoch(SSL_CONNECTION *s, int rw)
     return 1;
 }
 
-uint64_t dtls1_get_connection_epoch(SSL_CONNECTION *s, int rw)
+uint64_t dtls1_get_epoch(SSL_CONNECTION *s, int rw)
 {
     uint64_t epoch;
 
@@ -827,16 +827,4 @@ uint64_t dtls1_get_connection_epoch(SSL_CONNECTION *s, int rw)
         epoch = s->rlayer.d->w_conn_epoch;
 
     return epoch;
-}
-
-uint16_t dtls1_get_serialized_epoch(SSL_CONNECTION *s, int rw)
-{
-    uint64_t epoch;
-
-    if (rw & SSL3_CC_READ)
-        epoch = s->rlayer.d->r_conn_epoch;
-    else
-        epoch = s->rlayer.d->w_conn_epoch;
-
-    return epoch & 0xffff;
 }

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -204,7 +204,7 @@ int dtls1_read_bytes(SSL *s, uint8_t type, uint8_t *recvd_type,
     void (*cb)(const SSL *ssl, int type2, int val) = NULL;
     SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
     int is_dtls13;
-    uint16_t curr_epoch;
+    uint64_t curr_epoch;
     int in_early_data;
 
     if (sc == NULL)
@@ -543,7 +543,7 @@ start:
          * This may just be a stale retransmit. Also sanity check that we have
          * at least enough record bytes for a message header
          */
-        if (rr->epoch != dtls1_get_epoch(sc, SSL3_CC_READ)
+        if (rr->epoch != dtls1_get_serialized_epoch(sc, SSL3_CC_READ)
             || rr->length < DTLS1_HM_HEADER_LENGTH) {
             if (!ssl_release_record(sc, rr, 0))
                 return -1;
@@ -786,29 +786,51 @@ int do_dtls1_write(SSL_CONNECTION *sc, uint8_t type, const unsigned char *buf,
     return ret;
 }
 
-void dtls1_increment_epoch(SSL_CONNECTION *s, int rw)
+int dtls1_increment_epoch(SSL_CONNECTION *s, int rw)
 {
     if (rw & SSL3_CC_READ) {
-        s->rlayer.d->r_epoch++;
+        s->rlayer.d->r_conn_epoch++;
 
         /*
          * We must not use any buffered messages received from the previous
          * epoch
          */
         dtls1_clear_received_buffer(s);
+
+        if (s->rlayer.d->r_conn_epoch == 0)
+            /* We've wrapped around, so clear the buffer just in case */
+            return 0;
     } else {
-        s->rlayer.d->w_epoch++;
+        s->rlayer.d->w_conn_epoch++;
+
+        if (s->rlayer.d->w_conn_epoch == 0)
+            /* We've wrapped around, so clear the buffer just in case */
+            return 0;
     }
+
+    return 1;
 }
 
-uint16_t dtls1_get_epoch(SSL_CONNECTION *s, int rw)
+uint64_t dtls1_get_connection_epoch(SSL_CONNECTION *s, int rw)
 {
-    uint16_t epoch;
+    uint64_t epoch;
 
     if (rw & SSL3_CC_READ)
-        epoch = s->rlayer.d->r_epoch;
+        epoch = s->rlayer.d->r_conn_epoch;
     else
-        epoch = s->rlayer.d->w_epoch;
+        epoch = s->rlayer.d->w_conn_epoch;
 
     return epoch;
+}
+
+uint16_t dtls1_get_serialized_epoch(SSL_CONNECTION *s, int rw)
+{
+    uint64_t epoch;
+
+    if (rw & SSL3_CC_READ)
+        epoch = s->rlayer.d->r_conn_epoch;
+    else
+        epoch = s->rlayer.d->w_conn_epoch;
+
+    return epoch & 0xffff;
 }

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1401,7 +1401,7 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
             prev = s->rlayer.rrlnext;
             if (SSL_CONNECTION_IS_DTLS(s)
                 && level != OSSL_RECORD_PROTECTION_LEVEL_NONE)
-                epoch = dtls1_get_connection_epoch(s, SSL3_CC_READ); /* new epoch */
+                epoch = dtls1_get_epoch(s, SSL3_CC_READ); /* new epoch */
 
 #ifndef OPENSSL_NO_DGRAM
             if (SSL_CONNECTION_IS_DTLS(s))
@@ -1418,7 +1418,7 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
         } else {
             if (SSL_CONNECTION_IS_DTLS(s)
                 && level != OSSL_RECORD_PROTECTION_LEVEL_NONE)
-                epoch = dtls1_get_connection_epoch(s, SSL3_CC_WRITE); /* new epoch */
+                epoch = dtls1_get_epoch(s, SSL3_CC_WRITE); /* new epoch */
         }
 
         /*

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1266,7 +1266,7 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
     int use_early_data = 0;
     uint32_t max_early_data;
     COMP_METHOD *compm = (comp == NULL) ? NULL : comp->method;
-    uint16_t epoch_zero;
+    uint64_t epoch_zero;
     uint64_t seq;
 
     meth = ssl_select_next_record_layer(s, direction, level);
@@ -1393,7 +1393,7 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
         int rlret;
         BIO *prev = NULL;
         BIO *next = NULL;
-        unsigned int epoch = 0;
+        uint64_t epoch = 0;
         OSSL_DISPATCH rlayer_dispatch_tmp[OSSL_NELEM(rlayer_dispatch)];
         size_t i, j;
 
@@ -1401,7 +1401,7 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
             prev = s->rlayer.rrlnext;
             if (SSL_CONNECTION_IS_DTLS(s)
                 && level != OSSL_RECORD_PROTECTION_LEVEL_NONE)
-                epoch = dtls1_get_epoch(s, SSL3_CC_READ); /* new epoch */
+                epoch = dtls1_get_connection_epoch(s, SSL3_CC_READ); /* new epoch */
 
 #ifndef OPENSSL_NO_DGRAM
             if (SSL_CONNECTION_IS_DTLS(s))
@@ -1418,7 +1418,7 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
         } else {
             if (SSL_CONNECTION_IS_DTLS(s)
                 && level != OSSL_RECORD_PROTECTION_LEVEL_NONE)
-                epoch = dtls1_get_epoch(s, SSL3_CC_WRITE); /* new epoch */
+                epoch = dtls1_get_connection_epoch(s, SSL3_CC_WRITE); /* new epoch */
         }
 
         /*

--- a/ssl/record/record.h
+++ b/ssl/record/record.h
@@ -49,8 +49,8 @@ typedef struct dtls_record_layer_st {
      * undefined, and starts at zero once the initial handshake is
      * completed
      */
-    uint16_t r_conn_epoch;
-    uint16_t w_conn_epoch;
+    uint64_t r_conn_epoch;
+    uint64_t w_conn_epoch;
 
     /*
      * Buffered application records. Only for records between CCS and

--- a/ssl/record/record.h
+++ b/ssl/record/record.h
@@ -34,7 +34,7 @@ typedef struct tls_record_st {
     size_t length;
     /* Offset into the data buffer where to start reading */
     size_t off;
-    /* epoch number. DTLS only */
+    /* Serialized DTLS epoch */
     uint16_t epoch;
     /* sequence number. DTLS only */
     uint64_t seq_num;
@@ -45,12 +45,12 @@ typedef struct tls_record_st {
 
 typedef struct dtls_record_layer_st {
     /*
-     * The current data and handshake epoch.  This is initially
+     * The current data and handshake epoch. This is initially
      * undefined, and starts at zero once the initial handshake is
      * completed
      */
-    uint16_t r_epoch;
-    uint16_t w_epoch;
+    uint16_t r_conn_epoch;
+    uint16_t w_conn_epoch;
 
     /*
      * Buffered application records. Only for records between CCS and
@@ -160,8 +160,9 @@ __owur int dtls1_write_bytes(SSL_CONNECTION *s, uint8_t type, const void *buf,
     size_t len, size_t *written);
 int do_dtls1_write(SSL_CONNECTION *s, uint8_t type, const unsigned char *buf,
     size_t len, size_t *written);
-void dtls1_increment_epoch(SSL_CONNECTION *s, int rw);
-uint16_t dtls1_get_epoch(SSL_CONNECTION *s, int rw);
+int dtls1_increment_epoch(SSL_CONNECTION *s, int rw);
+uint64_t dtls1_get_connection_epoch(SSL_CONNECTION *s, int rw);
+uint16_t dtls1_get_serialized_epoch(SSL_CONNECTION *s, int rw);
 uint64_t dtls1_get_record_sequence_number(SSL_CONNECTION *s);
 int ssl_release_record(SSL_CONNECTION *s, TLS_RECORD *rr, size_t length);
 

--- a/ssl/record/record.h
+++ b/ssl/record/record.h
@@ -35,7 +35,7 @@ typedef struct tls_record_st {
     /* Offset into the data buffer where to start reading */
     size_t off;
     /* Serialized DTLS epoch */
-    uint16_t epoch;
+    uint64_t epoch;
     /* sequence number. DTLS only */
     uint64_t seq_num;
 #ifndef OPENSSL_NO_SCTP
@@ -161,8 +161,7 @@ __owur int dtls1_write_bytes(SSL_CONNECTION *s, uint8_t type, const void *buf,
 int do_dtls1_write(SSL_CONNECTION *s, uint8_t type, const unsigned char *buf,
     size_t len, size_t *written);
 int dtls1_increment_epoch(SSL_CONNECTION *s, int rw);
-uint64_t dtls1_get_connection_epoch(SSL_CONNECTION *s, int rw);
-uint16_t dtls1_get_serialized_epoch(SSL_CONNECTION *s, int rw);
+uint64_t dtls1_get_epoch(SSL_CONNECTION *s, int rw);
 uint64_t dtls1_get_record_sequence_number(SSL_CONNECTION *s);
 int ssl_release_record(SSL_CONNECTION *s, TLS_RECORD *rr, size_t length);
 

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2869,7 +2869,7 @@ void dtls1_get_queue_priority(unsigned char *prio64be, unsigned short seq,
 int dtls1_retransmit_sent_messages(SSL_CONNECTION *s);
 void dtls1_clear_received_buffer(SSL_CONNECTION *s);
 void dtls1_clear_sent_buffer(SSL_CONNECTION *s, int keep_unacked_msgs);
-void dtls1_acknowledge_sent_buffer(SSL_CONNECTION *s, uint16_t before_epoch);
+void dtls1_acknowledge_sent_buffer(SSL_CONNECTION *s, uint64_t before_epoch);
 __owur OSSL_TIME dtls1_default_timeout(void);
 __owur int dtls1_get_timeout(const SSL_CONNECTION *s, OSSL_TIME *timeleft);
 __owur int dtls1_check_timeout_num(SSL_CONNECTION *s);

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -1133,7 +1133,7 @@ CON_FUNC_RETURN dtls_construct_ack(SSL_CONNECTION *s, WPACKET *pkt)
 
         recnumnext = ossl_list_record_number_next(recnum);
 
-        if (recnum->epoch <= dtls1_get_connection_epoch(s, SSL3_CC_WRITE)) {
+        if (recnum->epoch <= dtls1_get_epoch(s, SSL3_CC_WRITE)) {
             /*
              * rfc9147:
              * During the handshake, ACK records MUST be sent with an epoch which

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -1133,7 +1133,7 @@ CON_FUNC_RETURN dtls_construct_ack(SSL_CONNECTION *s, WPACKET *pkt)
 
         recnumnext = ossl_list_record_number_next(recnum);
 
-        if (recnum->epoch <= dtls1_get_epoch(s, SSL3_CC_WRITE)) {
+        if (recnum->epoch <= dtls1_get_connection_epoch(s, SSL3_CC_WRITE)) {
             /*
              * rfc9147:
              * During the handshake, ACK records MUST be sent with an epoch which

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -236,8 +236,10 @@ int tls1_change_cipher_state(SSL_CONNECTION *s, int which)
         direction = OSSL_RECORD_DIRECTION_WRITE;
     }
 
-    if (SSL_CONNECTION_IS_DTLS(s))
-        dtls1_increment_epoch(s, which);
+    if (SSL_CONNECTION_IS_DTLS(s) && !dtls1_increment_epoch(s, which)) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        goto err;
+    }
 
     if (!ssl_set_new_record_layer(s, s->version, direction,
             OSSL_RECORD_PROTECTION_LEVEL_APPLICATION,

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -823,7 +823,7 @@ int tls13_change_cipher_state(SSL_CONNECTION *s, int which)
             }
         }
 
-        if (level == OSSL_RECORD_PROTECTION_LEVEL_HANDSHAKE && dtls1_get_connection_epoch(s, which) == 1) {
+        if (level == OSSL_RECORD_PROTECTION_LEVEL_HANDSHAKE && dtls1_get_epoch(s, which) == 1) {
             /*
              * We must manually increment epoch because
              * client early traffic was not sent/recv

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -816,16 +816,22 @@ int tls13_change_cipher_state(SSL_CONNECTION *s, int which)
          * For DTLS1.3 The Compressed Certificate should still be sent in Epoch 2
          * not Epoch 3.
          */
-        if (s->version != DTLS1_3_VERSION || (which & SSL3_CC_COMP_CERT) == 0)
-            dtls1_increment_epoch(s, which);
+        if (s->version != DTLS1_3_VERSION || (which & SSL3_CC_COMP_CERT) == 0) {
+            if (!dtls1_increment_epoch(s, which)) {
+                SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+                goto err;
+            }
+        }
 
-        if (level == OSSL_RECORD_PROTECTION_LEVEL_HANDSHAKE
-            && dtls1_get_epoch(s, which) == 1) {
+        if (level == OSSL_RECORD_PROTECTION_LEVEL_HANDSHAKE && dtls1_get_connection_epoch(s, which) == 1) {
             /*
              * We must manually increment epoch because
              * client early traffic was not sent/recv
              */
-            dtls1_increment_epoch(s, which);
+            if (!dtls1_increment_epoch(s, which)) {
+                SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+                goto err;
+            }
         }
 
         /* We have moved to the next flight lets clear out old messages */
@@ -906,7 +912,10 @@ int tls13_update_key(SSL_CONNECTION *s, int sending)
     memcpy(insecret, secret, hashlen);
 
     if (SSL_CONNECTION_IS_DTLS(s)) {
-        dtls1_increment_epoch(s, which);
+        if (!dtls1_increment_epoch(s, which)) {
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+            goto err;
+        }
         snenc = s->s3.tmp.new_sym_enc_sn;
         snoffs = s->s3.tmp.new_sym_enc_sn_offs;
     }

--- a/test/tls13secretstest.c
+++ b/test/tls13secretstest.c
@@ -259,7 +259,7 @@ void dtls1_acknowledge_sent_buffer(SSL_CONNECTION *s, uint64_t before_epoch)
 {
 }
 
-uint64_t dtls1_get_connection_epoch(SSL_CONNECTION *s, int rw)
+uint64_t dtls1_get_epoch(SSL_CONNECTION *s, int rw)
 {
     return 0;
 }

--- a/test/tls13secretstest.c
+++ b/test/tls13secretstest.c
@@ -255,17 +255,18 @@ void dtls1_clear_sent_buffer(SSL_CONNECTION *s, int keep_unacked_msgs)
 {
 }
 
-void dtls1_acknowledge_sent_buffer(SSL_CONNECTION *s, uint16_t before_epoch)
+void dtls1_acknowledge_sent_buffer(SSL_CONNECTION *s, uint64_t before_epoch)
 {
 }
 
-uint16_t dtls1_get_epoch(SSL_CONNECTION *s, int rw)
+uint64_t dtls1_get_connection_epoch(SSL_CONNECTION *s, int rw)
 {
     return 0;
 }
 
-void dtls1_increment_epoch(SSL_CONNECTION *s, int rw)
+int dtls1_increment_epoch(SSL_CONNECTION *s, int rw)
 {
+    return 0;
 }
 
 /* End of mocked out code */


### PR DESCRIPTION
This is based off a prior PR that was closed. The epoch was updated for a 64 bit counter. A 16 bit epoch is kept when we read the epoch from the wire in store it in the record layer.

Fixes: openssl/project#1796

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
