### PR TITLE
asn1_d2i_read_bio fix to read headers correctly without blocking

### DIFF
--- a/crypto/asn1/a_d2i_fp.c
+++ b/crypto/asn1/a_d2i_fp.c
@@ -140,7 +140,7 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
             }
             i = BIO_read(in, &(b->data[len]), (int)want);
 
-            if (i <= 0 && diff == 0) {
+            if (i <= 0) {
                 ERR_raise(ERR_LIB_ASN1, ASN1_R_NOT_ENOUGH_DATA);
                 goto err;
             }
@@ -162,25 +162,29 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
         q = p;
         diff = len - off;
         if (diff == 0)
-            goto err;
+           goto err;
 
         diff--;
         if ((*(q++) & V_ASN1_PRIMITIVE_TAG) == V_ASN1_PRIMITIVE_TAG) {
+            /* Multi-byte tag.  See if we have the whole thing yet */
             do {
                 diff--;
             } while (diff > 0 && *(q++) & 0x80);
-        }
 
-        if (diff == 0) {
-            want = HEADER_SIZE + q - p;
-            if (*q & 0x80) {
-                want++;
+            if (diff == 0) {
+                /* End of current data, will need at least 1 more byte for
+                 * length.  2 if the tag is still incomplete */
+                want = q - p + 2;
+                if (*q & 0x80) {
+                    want++;
+                }
+                continue;
             }
-            continue;
         }
 
         diff--;
-        /* Check the length.  This should also work for indefinite length */
+        /* Check the length.  This should also work for indefinite length
+         */
         if (*q & 0x80) {
             unsigned int i = *q & 0x7f;
             if (i > sizeof(long)) {
@@ -193,7 +197,8 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
             }
         }
 
-        /* We have a complete header now.  Parse the tag and length */
+        /* We have a complete header now, assuming we didn't hit EOF. Parse the
+         * tag and length */
         q = p;
         diff = len - off;
         inf = ASN1_get_object(&q, &slen, &tag, &xclass, (int)diff);

--- a/crypto/asn1/a_d2i_fp.c
+++ b/crypto/asn1/a_d2i_fp.c
@@ -161,8 +161,11 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
         p = (unsigned char *)&(b->data[off]);
         q = p;
         diff = len - off;
-        if (diff == 0)
-           goto err;
+        if (diff < 2) {
+            /* Failed sanity check */
+            ERR_raise(ERR_LIB_ASN1, ASN1_R_NOT_ENOUGH_DATA);
+            goto err;
+        }
 
         diff--;
         if ((*(q++) & V_ASN1_PRIMITIVE_TAG) == V_ASN1_PRIMITIVE_TAG) {
@@ -172,8 +175,10 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
             } while (diff > 0 && *(q++) & 0x80);
 
             if (diff == 0) {
-                /* End of current data, will need at least 1 more byte for
-                 * length.  2 if the tag is still incomplete */
+                /*
+                 * End of current data, will need at least 1 more byte for
+                 * length.  2 if the tag is still incomplete
+                 */
                 want = q - p + 2;
                 if (*q & 0x80) {
                     want++;
@@ -182,9 +187,8 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
             }
         }
 
+        /* Check the length.  This should also work for indefinite length */
         diff--;
-        /* Check the length.  This should also work for indefinite length
-         */
         if (*q & 0x80) {
             unsigned int i = *q & 0x7f;
             if (i > sizeof(long)) {
@@ -197,8 +201,10 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
             }
         }
 
-        /* We have a complete header now, assuming we didn't hit EOF. Parse the
-         * tag and length */
+        /*
+         * We have a complete header now, assuming we didn't hit EOF. Parse the
+         * tag and length
+         */
         q = p;
         diff = len - off;
         inf = ASN1_get_object(&q, &slen, &tag, &xclass, (int)diff);

--- a/crypto/asn1/a_d2i_fp.c
+++ b/crypto/asn1/a_d2i_fp.c
@@ -168,8 +168,7 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
         if ((*(q++) & V_ASN1_PRIMITIVE_TAG) == V_ASN1_PRIMITIVE_TAG) {
             do {
                 diff--;
-            }
-            while (diff > 0 && *(q++) & 0x80);
+            } while (diff > 0 && *(q++) & 0x80);
         }
 
         if (diff == 0) {
@@ -183,7 +182,7 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
         diff--;
         /* Check the length.  This should also work for indefinite length */
         if (*q & 0x80) {
-            int i = *q & 0x7f;
+            unsigned int i = *q & 0x7f;
             if (i > diff) {
                 want = q - p + i + 1;
                 continue;

--- a/crypto/asn1/a_d2i_fp.c
+++ b/crypto/asn1/a_d2i_fp.c
@@ -183,6 +183,10 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
         /* Check the length.  This should also work for indefinite length */
         if (*q & 0x80) {
             unsigned int i = *q & 0x7f;
+            if (i > sizeof(long)) {
+                ERR_raise(ERR_LIB_ASN1, ASN1_R_TOO_LONG);
+                goto err;
+            }
             if (i > diff) {
                 want = q - p + i + 1;
                 continue;

--- a/crypto/asn1/a_d2i_fp.c
+++ b/crypto/asn1/a_d2i_fp.c
@@ -104,7 +104,7 @@ void *ASN1_item_d2i_fp(const ASN1_ITEM *it, FILE *in, void *x)
 }
 #endif
 
-#define HEADER_SIZE 8
+#define HEADER_SIZE 2
 #define ASN1_CHUNK_INITIAL_SIZE (16 * 1024)
 int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
 {
@@ -157,11 +157,42 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
         }
         /* else data already loaded */
 
+        /* make sure there is enough data for a complete header */
         p = (unsigned char *)&(b->data[off]);
         q = p;
         diff = len - off;
         if (diff == 0)
             goto err;
+
+        diff--;
+        if ((*(q++) & V_ASN1_PRIMITIVE_TAG) == V_ASN1_PRIMITIVE_TAG) {
+            do {
+                diff--;
+            }
+            while (diff > 0 && *(q++) & 0x80);
+        }
+
+        if (diff == 0) {
+            want = HEADER_SIZE + q - p;
+            if (*q & 0x80) {
+                want++;
+            }
+            continue;
+        }
+
+        diff--;
+        /* Check the length.  This should also work for indefinite length */
+        if (*q & 0x80) {
+            int i = *q & 0x7f;
+            if (i > diff) {
+                want = q - p + i + 1;
+                continue;
+            }
+        }
+
+        /* We have a complete header now.  Parse the tag and length */
+        q = p;
+        diff = len - off;
         inf = ASN1_get_object(&q, &slen, &tag, &xclass, (int)diff);
         if (inf & 0x80) {
             unsigned long e;

--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -129,7 +129,7 @@ static int asn1_get_length(const unsigned char **pp, int *inf, long *rl,
         *inf = 0;
         i = *p & 0x7f;
         if (*p++ & 0x80) {
-            if (max < i + 1)
+            if (max < i)
                 return 0;
             /* Skip leading zeroes */
             while (i > 0 && *p == 0) {


### PR DESCRIPTION
Fixes #22704

This answers the "help wanted" for issue #22704.  Its purpose is to correctly read enough bytes for a full header, even if it is more than 8 bytes.  This also prevents blocking on a socket connection for short messages, which can be as small as 2 bytes.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist

