### PR TITLE
doc: clarify -CAfile and -verifyCAfile semantics in openssl-s_server .pod.in

### DIFF
--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -342,6 +342,12 @@ see L<openssl-verify(1)> for more information.
 The URI of a store containing trusted certificates to use
 for verifying the server's certificate.
 
+When any of B<-verifyCAfile>, B<-verifyCApath>, or B<-verifyCAstore> is
+specified, they are loaded into a separate verification store (via
+L<SSL_CTX_set1_verify_cert_store(3)>) and used for server certificate
+verification instead of the store built from B<-CAfile>, B<-CApath>, and
+B<-CAstore>.
+
 =item B<-chainCAfile> I<file>
 
 A file in PEM format containing trusted certificates to use

--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -341,8 +341,8 @@ Download CRLs from distribution points given in CDP extensions of certificates
 
 =item B<-verifyCAfile> I<filename>
 
-A file in PEM format CA containing trusted certificates to use
-for verifying client certificates.
+A file in PEM format containing trusted CA certificates (root and/or
+intermediate) used to verify the client certificate chain.
 
 =item B<-verifyCApath> I<dir>
 
@@ -355,6 +355,15 @@ see L<openssl-verify(1)> for more information.
 
 The URI of a store containing trusted certificates to use
 for verifying client certificates.
+
+When any of B<-verifyCAfile>, B<-verifyCApath>, or B<-verifyCAstore> is
+specified, they are loaded into a separate verification store (via
+L<SSL_CTX_set1_verify_cert_store(3)>) and used for client certificate
+verification instead of the store built from B<-CAfile>, B<-CApath>, and
+B<-CAstore>. Note that B<-CAfile> is the sole source of acceptable issuing
+CA names sent to the client in the Certificate Request message during the
+handshake; B<-CApath>, B<-CAstore>, and the B<-verifyCA*> options do not
+contribute to this list.
 
 =item B<-chainCAfile> I<file>
 


### PR DESCRIPTION
Adds a clarification in the relationship between -verifyCAfile and -CAfile options in the openssl-s_server documentation. When -verifyCAfile is specified, it is used for client certificate verification instead of -CAfile, while -CAfile continues to be used solely for building the acceptable CA names list sent to the client during the handshake.


Fixes #29586


@bbbrumley 
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
