### PR TITLE
Fix windows build failure for arm64ec

### DIFF
--- a/crypto/evp/enc_b64_avx2.c
+++ b/crypto/evp/enc_b64_avx2.c
@@ -6,6 +6,7 @@
 #include "evp_local.h"
 
 #if defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64)
+#if !defined(_M_ARM64EC)
 #define STRINGIFY_IMPLEMENTATION_(a) #a
 #define STRINGIFY(a) STRINGIFY_IMPLEMENTATION_(a)
 
@@ -667,4 +668,5 @@ int encode_base64_avx2(EVP_ENCODE_CTX *ctx, unsigned char *dst,
     return (int)(out - (uint8_t *)dst) + +evp_encodeblock_int(ctx, out, src + i, srclen - i, final_wrap_cnt);
 }
 OPENSSL_UNTARGET_AVX2
+#endif /* !defined(_M_ARM64EC) */
 #endif

--- a/crypto/evp/enc_b64_avx2.h
+++ b/crypto/evp/enc_b64_avx2.h
@@ -4,9 +4,11 @@
 #include <openssl/evp.h>
 
 #if defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64)
+#if !defined(_M_ARM64EC)
 int encode_base64_avx2(EVP_ENCODE_CTX *ctx,
     unsigned char *out, const unsigned char *src, int srclen,
     int newlines, int *wrap_cnt);
+#endif /* !defined(_M_ARM64EC) */
 #endif
 
 #endif

--- a/crypto/evp/encode.c
+++ b/crypto/evp/encode.c
@@ -16,8 +16,9 @@
 #include "evp_local.h"
 
 #if defined(OPENSSL_CPUID_OBJ) && !defined(OPENSSL_NO_ASM) && (defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64))
-
+#if !defined(_M_ARM64EC)
 #define HAS_IA32CAP_IS_64
+#endif /* !defined(_M_ARM64EC) */
 #endif
 
 #include "enc_b64_avx2.h"


### PR DESCRIPTION
Fixes #30361

The new b64 encoder code uses __m256 which is not currently supported in ARM64EC code, since it does not natively support x64-specific instruction sets like AVX. Disable the fast AVX path if arm64EC is used.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
