### PR TITLE
Fix vpsm4_ex-armv8.pl implementation bug

### DIFF
--- a/crypto/sm4/asm/vpsm4_ex-armv8.pl
+++ b/crypto/sm4/asm/vpsm4_ex-armv8.pl
@@ -476,12 +476,13 @@ sub load_sbox () {
 
 $code.=<<___;
 	adrp $xtmp2, .Lsbox_magic
-	ldr $MaskQ, [$xtmp2, #:lo12:.Lsbox_magic]
-	ldr $TAHMatQ, [$xtmp2, #:lo12:.Lsbox_magic+16]
-	ldr $TALMatQ, [$xtmp2, #:lo12:.Lsbox_magic+32]
-	ldr $ATAHMatQ, [$xtmp2, #:lo12:.Lsbox_magic+48]
-	ldr $ATALMatQ, [$xtmp2, #:lo12:.Lsbox_magic+64]
-	ldr $ANDMaskQ, [$xtmp2, #:lo12:.Lsbox_magic+80]
+	add $xtmp2, $xtmp2, #:lo12:.Lsbox_magic
+	ldr $MaskQ, [$xtmp2]
+	ldr $TAHMatQ, [$xtmp2, 16]
+	ldr $TALMatQ, [$xtmp2, 32]
+	ldr $ATAHMatQ, [$xtmp2, 48]
+	ldr $ATALMatQ, [$xtmp2, 64]
+	ldr $ANDMaskQ, [$xtmp2, 80]
 ___
 }
 


### PR DESCRIPTION
Load .Lsbox_magic base once via adrp+add and use plain immediate offsets for q loads, avoiding potential low-12-bit truncation issues with #:lo12:symbol+offset.

fix #30409 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
