### PR TITLE
DTLS 1.3 remove the last TODO in Proxy.pm and Clean up Double Free

### DIFF
--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -217,6 +217,29 @@ void dtls1_clear_sent_buffer(SSL_CONNECTION *s, int keep_unacked_msgs)
     pqueue_free(remaining_sent_messages);
 }
 
+/*
+ * Before RECORD_LAYER_clear() frees s->rlayer.wrl, null out any
+ * saved_retransmit_state.wrl pointers in the sent_messages queue that
+ * reference it.  This transfers ownership of that free exclusively to
+ * RECORD_LAYER_clear and prevents dtls1_clear_sent_buffer from freeing
+ * the same pointer a second time.  Entries with a different (older) wrl
+ * pointer are left untouched and will be freed correctly later.
+ */
+void dtls1_clear_current_wrl_from_sent_buffer(SSL_CONNECTION *s)
+{
+    pitem *item;
+    piterator iter = pqueue_iterator(&s->d1->sent_messages);
+
+    while ((item = pqueue_next(&iter)) != NULL) {
+        dtls_sent_msg *sent_msg = (dtls_sent_msg *)item->data;
+
+        if (sent_msg->saved_retransmit_state.wrl == s->rlayer.wrl) {
+            sent_msg->saved_retransmit_state.wrl = NULL;
+            sent_msg->saved_retransmit_state.wrlmethod = NULL;
+        }
+    }
+}
+
 int dtls_any_sent_messages_are_missing_acknowledge(SSL_CONNECTION *s)
 {
     pitem *item;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1466,10 +1466,11 @@ void ossl_ssl_connection_free(SSL *ssl)
      * entries pointing to the current s->rlayer.wrl. RECORD_LAYER_clear
      * is about to free and NULL out that pointer. If we let
      * dtls1_clear_sent_buffer (called later via ssl_deinit) compare
-     * saved.wrl against a now-NULL s->rlayer.wrl, it will incorrectly
-     * attempt to free already-freed memory (double-free). Preemptively
-     * null out any saved_retransmit_state entry that references the
-     * current wrl so that RECORD_LAYER_clear owns that free exclusively.
+     * saved.wrl against current s->rlayer.wrl to set the
+     * saved_retransmit_state.wrl to NULL so it doesn't get freed
+     * a second time.
+     * Preemptively null out any saved_retransmit_state entry that references
+     * the current wrl so that RECORD_LAYER_clear owns that free exclusively.
      * Entries with a different (older) saved wrl pointer are unaffected
      * and will be freed correctly by dtls1_clear_sent_buffer.
      */

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1461,32 +1461,8 @@ void ossl_ssl_connection_free(SSL *ssl)
     if (s == NULL)
         return;
 
-    /*
-     * For DTLS, the sent_messages queue may hold saved_retransmit_state
-     * entries pointing to the current s->rlayer.wrl. RECORD_LAYER_clear
-     * is about to free and NULL out that pointer. If we let
-     * dtls1_clear_sent_buffer (called later via ssl_deinit) compare
-     * saved.wrl against current s->rlayer.wrl to set the
-     * saved_retransmit_state.wrl to NULL so it doesn't get freed
-     * a second time.
-     * Preemptively null out any saved_retransmit_state entry that references
-     * the current wrl so that RECORD_LAYER_clear owns that free exclusively.
-     * Entries with a different (older) saved wrl pointer are unaffected
-     * and will be freed correctly by dtls1_clear_sent_buffer.
-     */
-    if (SSL_CONNECTION_IS_DTLS(s) && s->d1 != NULL && s->rlayer.wrl != NULL) {
-        pitem *item;
-        piterator iter = pqueue_iterator(&s->d1->sent_messages);
-
-        while ((item = pqueue_next(&iter)) != NULL) {
-            dtls_sent_msg *sent_msg = (dtls_sent_msg *)item->data;
-
-            if (sent_msg->saved_retransmit_state.wrl == s->rlayer.wrl) {
-                sent_msg->saved_retransmit_state.wrl = NULL;
-                sent_msg->saved_retransmit_state.wrlmethod = NULL;
-            }
-        }
-    }
+    if (s->d1 != NULL && s->rlayer.wrl != NULL)
+        dtls1_clear_current_wrl_from_sent_buffer(s);
 
     /*
      * Ignore return values. This could result in user callbacks being called

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1462,6 +1462,32 @@ void ossl_ssl_connection_free(SSL *ssl)
         return;
 
     /*
+     * For DTLS, the sent_messages queue may hold saved_retransmit_state
+     * entries pointing to the current s->rlayer.wrl. RECORD_LAYER_clear
+     * is about to free and NULL out that pointer. If we let
+     * dtls1_clear_sent_buffer (called later via ssl_deinit) compare
+     * saved.wrl against a now-NULL s->rlayer.wrl, it will incorrectly
+     * attempt to free already-freed memory (double-free). Preemptively
+     * null out any saved_retransmit_state entry that references the
+     * current wrl so that RECORD_LAYER_clear owns that free exclusively.
+     * Entries with a different (older) saved wrl pointer are unaffected
+     * and will be freed correctly by dtls1_clear_sent_buffer.
+     */
+    if (SSL_CONNECTION_IS_DTLS(s) && s->d1 != NULL && s->rlayer.wrl != NULL) {
+        pitem *item;
+        piterator iter = pqueue_iterator(&s->d1->sent_messages);
+
+        while ((item = pqueue_next(&iter)) != NULL) {
+            dtls_sent_msg *sent_msg = (dtls_sent_msg *)item->data;
+
+            if (sent_msg->saved_retransmit_state.wrl == s->rlayer.wrl) {
+                sent_msg->saved_retransmit_state.wrl = NULL;
+                sent_msg->saved_retransmit_state.wrlmethod = NULL;
+            }
+        }
+    }
+
+    /*
      * Ignore return values. This could result in user callbacks being called
      * e.g. for the QUIC TLS record layer. So we do this early before we have
      * freed other things.

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2877,6 +2877,7 @@ __owur int dtls1_handle_timeout(SSL_CONNECTION *s);
 void dtls1_start_timer(SSL_CONNECTION *s);
 void dtls1_stop_timer(SSL_CONNECTION *s);
 __owur int dtls1_is_timer_expired(SSL_CONNECTION *s);
+void dtls1_clear_current_wrl_from_sent_buffer(SSL_CONNECTION *s);
 __owur int dtls_raw_hello_verify_request(WPACKET *pkt, unsigned char *cookie,
     size_t cookie_len);
 __owur size_t dtls1_min_mtu(SSL_CONNECTION *s);

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -285,6 +285,27 @@ sub start
     #
     $ENV{OPENSSL_s390xcap} = "kmac:~0:~f000";
 
+    # For DTLS, s_client must bind to a fixed client port so the proxy knows
+    # where to send packets back.  The port was chosen once at new() time, but
+    # a prior s_client from a previous start() call may not have fully released
+    # it yet.  Re-select a free port on every start() to avoid EADDRINUSE.
+    if ($self->{isdtls}) {
+        my $found_port = 0;
+        my $test_client_addr = $self->{client_addr};
+        for (my $i = 0; $i <= 10; $i++) {
+            my $candidate = 49152 + int(rand(65535 - 49152));
+            my $test_sock = $IP_factory->(LocalPort => $candidate,
+                                          LocalAddr => $test_client_addr);
+            if ($test_sock) {
+                $test_sock->close();
+                $self->{client_port} = $candidate;
+                $found_port = 1;
+                last;
+            }
+        }
+        die "Unable to find usable port for TLSProxy" if $found_port == 0;
+    }
+
     # Create the Proxy socket
     my $proxaddr = $self->{proxy_addr};
     $proxaddr =~ s/[\[\]]//g; # Remove [ and ]

--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -603,13 +603,7 @@ sub clientstart
         # it's done already, just collect the exit code [and reap]...
         waitpid($pid, 0);
 
-        # TODO(DTLSv1.3): The server is not able to shut down correctly
-        #                 when the client sends an alert in epoch 0 and the
-        #                 server has sent its Finished message.
-        #                 As a workaround we accept a bad exit code for a failing
-        #                 DTLS test run.
-        die "exit code $? from s_server process\n"
-            if $? != 0 && (!$self->{isdtls} || $success == 1);
+        die "exit code $? from s_server process\n" if $? != 0;
     } else {
         # It's a bit counter-intuitive spot to make next connection to
         # the s_server. Rationale is that established connection works


### PR DESCRIPTION
When removing the last todo in proxy it encountered a double free. The changes are to address that double free.

Fixes: openssl/project#1795

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
