### PR TITLE
SSL_select_next_proto(): Remove need to cast away const

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -300,7 +300,7 @@ typedef struct tlsextnextprotoctx_st {
 
 static tlsextnextprotoctx next_proto;
 
-static int next_proto_cb(SSL *s, unsigned char **out, unsigned char *outlen,
+static int next_proto_cb(SSL *s, const unsigned char **out, unsigned char *outlen,
     const unsigned char *in, unsigned int inlen,
     void *arg)
 {

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1139,7 +1139,7 @@ static int alpn_cb(SSL *s, const unsigned char **out, unsigned char *outlen,
         BIO_write(bio_s_out, "\n", 1);
     }
 
-    if (SSL_select_next_proto((unsigned char **)out, outlen, alpn_ctx->data,
+    if (SSL_select_next_proto(out, outlen, alpn_ctx->data,
             (unsigned int)alpn_ctx->len, in, inlen)
         != OPENSSL_NPN_NEGOTIATED)
         return SSL_TLSEXT_ERR_ALERT_FATAL;

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -809,7 +809,7 @@ void SSL_CTX_set_next_protos_advertised_cb(SSL_CTX *s,
 #define SSL_CTX_set_npn_advertised_cb SSL_CTX_set_next_protos_advertised_cb
 
 typedef int (*SSL_CTX_npn_select_cb_func)(SSL *s,
-    unsigned char **out,
+    const unsigned char **out,
     unsigned char *outlen,
     const unsigned char *in,
     unsigned int inlen,
@@ -824,7 +824,7 @@ void SSL_get0_next_proto_negotiated(const SSL *s, const unsigned char **data,
 #define SSL_get0_npn_negotiated SSL_get0_next_proto_negotiated
 #endif
 
-__owur int SSL_select_next_proto(unsigned char **out, unsigned char *outlen,
+__owur int SSL_select_next_proto(const unsigned char **out, unsigned char *outlen,
     const unsigned char *server, unsigned int server_len,
     const unsigned char *client,
     unsigned int client_len);

--- a/ssl/quic/quic_tserver.c
+++ b/ssl/quic/quic_tserver.c
@@ -66,7 +66,7 @@ static int alpn_select_cb(SSL *ssl, const unsigned char **out,
         alpnlen = srv->args.alpnlen;
     }
 
-    if (SSL_select_next_proto((unsigned char **)out, outlen, alpn,
+    if (SSL_select_next_proto(out, outlen, alpn,
             (unsigned int)alpnlen,
             in, inlen)
         != OPENSSL_NPN_NEGOTIATED)

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3750,7 +3750,7 @@ int SSL_get_servername_type(const SSL *s)
  * case 2. It returns either OPENSSL_NPN_NEGOTIATED if a common protocol was
  * found, or OPENSSL_NPN_NO_OVERLAP if the fallback case was reached.
  */
-int SSL_select_next_proto(unsigned char **out, unsigned char *outlen,
+int SSL_select_next_proto(const unsigned char **out, unsigned char *outlen,
     const unsigned char *server,
     unsigned int server_len,
     const unsigned char *client, unsigned int client_len)
@@ -3769,7 +3769,7 @@ int SSL_select_next_proto(unsigned char **out, unsigned char *outlen,
      * Set the default opportunistic protocol. Will be overwritten if we find
      * a match.
      */
-    *out = (unsigned char *)PACKET_data(&csubpkt);
+    *out = PACKET_data(&csubpkt);
     *outlen = (unsigned char)PACKET_remaining(&csubpkt);
 
     /*
@@ -3784,7 +3784,7 @@ int SSL_select_next_proto(unsigned char **out, unsigned char *outlen,
                     if (PACKET_equal(&csubpkt, PACKET_data(&ssubpkt),
                             PACKET_remaining(&ssubpkt))) {
                         /* We found a match */
-                        *out = (unsigned char *)PACKET_data(&ssubpkt);
+                        *out = PACKET_data(&ssubpkt);
                         *outlen = (unsigned char)PACKET_remaining(&ssubpkt);
                         return OPENSSL_NPN_NEGOTIATED;
                     }

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -1898,7 +1898,7 @@ static int ssl_next_proto_validate(SSL_CONNECTION *s, PACKET *pkt)
 int tls_parse_stoc_npn(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
     X509 *x, size_t chainidx)
 {
-    unsigned char *selected;
+    const unsigned char *selected;
     unsigned char selected_len;
     PACKET tmppkt;
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);

--- a/test/helpers/handshake.c
+++ b/test/helpers/handshake.c
@@ -443,7 +443,7 @@ err:
  * protocols, or the server doesn't advertise any, it SHOULD select the first
  * protocol that it supports.
  */
-static int client_npn_cb(SSL *s, unsigned char **out, unsigned char *outlen,
+static int client_npn_cb(SSL *s, const unsigned char **out, unsigned char *outlen,
     const unsigned char *in, unsigned int inlen,
     void *arg)
 {
@@ -482,19 +482,15 @@ static int server_alpn_cb(SSL *s, const unsigned char **out,
     CTX_DATA *ctx_data = (CTX_DATA *)(arg);
     int ret;
 
-    /* SSL_select_next_proto isn't const-correct... */
-    unsigned char *tmp_out;
-
     /*
      * The result points either to |in| or to |ctx_data->alpn_protocols|.
      * The callback is allowed to point to |in| or to a long-lived buffer,
      * so we can return directly without storing a copy.
      */
-    ret = SSL_select_next_proto(&tmp_out, outlen,
+    ret = SSL_select_next_proto(out, outlen,
         ctx_data->alpn_protocols,
         (unsigned int)ctx_data->alpn_protocols_len, in, inlen);
 
-    *out = tmp_out;
     /* Unlike NPN, we don't tolerate a mismatch. */
     return ret == OPENSSL_NPN_NEGOTIATED ? SSL_TLSEXT_ERR_OK
                                          : SSL_TLSEXT_ERR_ALERT_FATAL;

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -2527,7 +2527,7 @@ static int select_alpn(SSL *ssl, const unsigned char **out,
 {
     static unsigned char alpn[] = { 8, 'o', 's', 's', 'l', 't', 'e', 's', 't' };
 
-    if (SSL_select_next_proto((unsigned char **)out, out_len, alpn, sizeof(alpn),
+    if (SSL_select_next_proto(out, out_len, alpn, sizeof(alpn),
             in, in_len)
         == OPENSSL_NPN_NEGOTIATED)
         return SSL_TLSEXT_ERR_OK;

--- a/test/radix/quic_ops.c
+++ b/test/radix/quic_ops.c
@@ -32,7 +32,7 @@ static int ssl_ctx_select_alpn(SSL *ssl,
     const unsigned char *in, unsigned int in_len,
     void *arg)
 {
-    if (SSL_select_next_proto((unsigned char **)out, out_len,
+    if (SSL_select_next_proto(out, out_len,
             alpn_ossltest, sizeof(alpn_ossltest), in, in_len)
         != OPENSSL_NPN_NEGOTIATED)
         return SSL_TLSEXT_ERR_ALERT_FATAL;

--- a/test/ssl_old_test.c
+++ b/test/ssl_old_test.c
@@ -112,7 +112,7 @@ static int npn_client = 0;
 static int npn_server = 0;
 static int npn_server_reject = 0;
 
-static int cb_client_npn(SSL *s, unsigned char **out, unsigned char *outlen,
+static int cb_client_npn(SSL *s, const unsigned char **out, unsigned char *outlen,
     const unsigned char *in, unsigned int inlen,
     void *arg)
 {
@@ -121,7 +121,7 @@ static int cb_client_npn(SSL *s, unsigned char **out, unsigned char *outlen,
      * prefixed set. We assume that NEXT_PROTO_STRING is a one element list
      * and remove the first byte to chop off the length prefix.
      */
-    *out = (unsigned char *)NEXT_PROTO_STRING + 1;
+    *out = (const unsigned char *)NEXT_PROTO_STRING + 1;
     *outlen = sizeof(NEXT_PROTO_STRING) - 2;
     return SSL_TLSEXT_ERR_OK;
 }
@@ -295,7 +295,7 @@ static int cb_server_alpn(SSL *s, const unsigned char **out,
         abort();
     }
 
-    if (SSL_select_next_proto((unsigned char **)out, outlen, protos,
+    if (SSL_select_next_proto(out, outlen, protos,
             (unsigned int)protos_len,
             in, inlen)
         != OPENSSL_NPN_NEGOTIATED) {

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -13111,7 +13111,8 @@ static int test_select_next_proto(int idx)
 {
     struct next_proto_st *np = &next_proto_tests[idx];
     int ret = 0;
-    unsigned char *out, *client, *server;
+    const unsigned char *out;
+    unsigned char *client, *server;
     unsigned char outlen;
     unsigned int clientlen, serverlen;
 
@@ -13174,7 +13175,7 @@ static int npn_advert_cb(SSL *ssl, const unsigned char **out,
     }
 }
 
-static int npn_select_cb(SSL *s, unsigned char **out, unsigned char *outlen,
+static int npn_select_cb(SSL *s, const unsigned char **out, unsigned char *outlen,
     const unsigned char *in, unsigned int inlen, void *arg)
 {
     int *idx = (int *)arg;


### PR DESCRIPTION
SSL_select_next_proto() was declared with the out parameter being unsigned char **. This function is usually called from a SSL_CTX_set_next_proto_select_cb() or SSL_CTX_set_alpn_select_cb() callback function, whose out parameters are passed as const unsigned char **. This meant that calling SSL_select_next_proto() required (dangerously) casting away const.

Modifying SSL_select_next_proto() so that the out parameter is const unsigned char **, and removing a cast within the function, means that the need to cast away const in the SSL_CTX_set...select_cb() functions is no longer required.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
