### PR TITLE
ISSUE-30341: Remove unused vpaes_ecb_decrypt from ARMv8 vpaes assembly

### DIFF
--- a/crypto/aes/asm/vpaes-armv8.pl
+++ b/crypto/aes/asm/vpaes-armv8.pl
@@ -1254,48 +1254,6 @@ vpaes_ecb_encrypt:
 	AARCH64_VALIDATE_LINK_REGISTER
 	ret
 .size	vpaes_ecb_encrypt,.-vpaes_ecb_encrypt
-
-.globl	vpaes_ecb_decrypt
-.type	vpaes_ecb_decrypt,%function
-.align	4
-vpaes_ecb_decrypt:
-	AARCH64_SIGN_LINK_REGISTER
-	stp	x29,x30,[sp,#-16]!
-	add	x29,sp,#0
-	stp	d8,d9,[sp,#-16]!	// ABI spec says so
-	stp	d10,d11,[sp,#-16]!
-	stp	d12,d13,[sp,#-16]!
-	stp	d14,d15,[sp,#-16]!
-
-	mov	x17, $len
-	mov	x2,  $key
-	bl	_vpaes_decrypt_preheat
-	tst	x17, #16
-	b.eq	.Lecb_dec_loop
-
-	ld1	{v7.16b}, [$inp],#16
-	bl	_vpaes_encrypt_core
-	st1	{v0.16b}, [$out],#16
-	subs	x17, x17, #16
-	b.ls	.Lecb_dec_done
-
-.align	4
-.Lecb_dec_loop:
-	ld1	{v14.16b,v15.16b}, [$inp], #32
-	bl	_vpaes_decrypt_2x
-	st1	{v0.16b,v1.16b}, [$out], #32
-	subs	x17, x17, #32
-	b.hi	.Lecb_dec_loop
-
-.Lecb_dec_done:
-	ldp	d14,d15,[sp],#16
-	ldp	d12,d13,[sp],#16
-	ldp	d10,d11,[sp],#16
-	ldp	d8,d9,[sp],#16
-	ldp	x29,x30,[sp],#16
-	AARCH64_VALIDATE_LINK_REGISTER
-	ret
-.size	vpaes_ecb_decrypt,.-vpaes_ecb_decrypt
 ___
 }	}
 print $code;


### PR DESCRIPTION
## Problem

In `crypto/aes/asm/vpaes-armv8.pl`, the function `vpaes_ecb_decrypt` was never used. ECB mode is implemented via `AES_ecb_encrypt` → `AES_encrypt` / `AES_decrypt` (single-block routines), so the bulk `vpaes_ecb_encrypt` / `vpaes_ecb_decrypt` entry points are not referenced anywhere.

The function was also incorrect: for the single remaining block it called `_vpaes_encrypt_core` instead of `_vpaes_decrypt_core`, so it would have encrypted instead of decrypted. This was a copy-paste error from the encrypt path.

See [issue #30341](https://github.com/openssl/openssl/issues/30341).

## Fix

Removed the unused `vpaes_ecb_decrypt` function from `crypto/aes/asm/vpaes-armv8.pl` (from `.globl vpaes_ecb_decrypt` through `.size vpaes_ecb_decrypt`). `vpaes_ecb_encrypt` is unchanged and remains in the file.

## Testing

- **Build:** `./Configure --strict-warnings` and `make` on darwin64-arm64 (target that builds vpaes-armv8) — success.
- **Tests:** `make test TESTS='test_evp test_evp_extra test_evp_fetch_prov'` — all 128 tests passed. AES/EVP behaviour is unchanged because the removed symbol was never used.
- **Lint:** `make doc-nits` — passed. No new documentation was added; none was required for this cleanup.

## Documentation and tests

No documentation or tests needed to be removed. No `.pod` or other docs mention `vpaes_ecb_decrypt` or `vpaes_ecb_encrypt`. No test references `vpaes_ecb_decrypt`. AES ECB is covered by existing tests that use the public API (`AES_ecb_encrypt` / single-block routines), which were never wired to this dead code.
