### PR TITLE
ISSUE-11677: Use memory-mapped files for `pkeyutl -rawin` and `dgst`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,17 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * The B<openssl pkeyutl> command now uses memory-mapped I/O when reading
+   raw input from a file for oneshot sign/verify operations (such as Ed25519,
+   Ed448, and ML-DSA) on platforms that support it (Unix-like). The
+   B<openssl dgst> command uses the same approach for one-shot sign/verify
+   when the input is from a file, removing the previous 16 MB limit for
+   file-based input. This improves performance and supports large files
+   without doubling memory use. Other platforms and stdin input continue to
+   use the existing buffer-based path.
+
+   *John Claus*
+
  * Added AVX2 optimized ML-DSA NTT operations on `x86_64`.
 
    *Marcel Cornu and Tomasz Kantecki*

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -7,10 +7,10 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "apps.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include "apps.h"
 #include "progs.h"
 #include <openssl/bio.h>
 #include <openssl/err.h>
@@ -20,6 +20,7 @@
 #include <openssl/pem.h>
 #include <openssl/hmac.h>
 #include <ctype.h>
+#include <sys/stat.h>
 
 #undef BUFSIZE
 #define BUFSIZE 1024 * 8
@@ -482,7 +483,7 @@ int dgst_main(int argc, char **argv)
         BIO_set_fp(in, stdin, BIO_NOCLOSE);
         if (oneshot_sign)
             ret = do_fp_oneshot_sign(out, signctx, in, separator, out_bin,
-                sigkey, sigbuf, siglen, NULL, "stdin");
+                sigkey, sigbuf, siglen, NULL, NULL);
         else
             ret = do_fp(out, buf, inp, separator, out_bin, xoflen,
                 sigkey, sigbuf, siglen, NULL, md_name, "stdin");
@@ -723,6 +724,43 @@ end:
 }
 
 /*
+ * Perform one-shot verify or sign on a contiguous data buffer.
+ * Returns 0 on failure, 1 on success.
+ */
+static int do_oneshot_verify_sign(EVP_MD_CTX *ctx, BIO *out,
+    unsigned char *sigin, int siglen, EVP_PKEY *key,
+    const unsigned char *data, size_t len,
+    int sep, int binout, const char *sig_name, const char *file)
+{
+    int res;
+    size_t siglen_out = 0;
+    unsigned char *sig = NULL;
+
+    if (sigin != NULL) {
+        res = EVP_DigestVerify(ctx, sigin, siglen, data, len);
+        print_verify_result(out, res);
+        return res > 0;
+    }
+    if (key != NULL) {
+        if (EVP_DigestSign(ctx, NULL, &siglen_out, data, len) != 1) {
+            BIO_puts(bio_err, "Error getting maximum length of signed data\n");
+            return 0;
+        }
+        sig = app_malloc(siglen_out, "Signature buffer");
+        if (EVP_DigestSign(ctx, sig, &siglen_out, data, len) != 1) {
+            BIO_puts(bio_err, "Error signing data\n");
+            OPENSSL_free(sig);
+            return 0;
+        }
+        print_out(out, sig, siglen_out, sep, binout, sig_name, NULL, file);
+        OPENSSL_free(sig);
+        return 1;
+    }
+    BIO_puts(bio_err, "key must be set for one-shot algorithms\n");
+    return 0;
+}
+
+/*
  * Some new algorithms only support one shot operations.
  * For these we need to buffer all input and then do the sign on the
  * total buffered input. These algorithms set a NULL digest name which is
@@ -732,43 +770,42 @@ static int do_fp_oneshot_sign(BIO *out, EVP_MD_CTX *ctx, BIO *in, int sep, int b
     EVP_PKEY *key, unsigned char *sigin, int siglen,
     const char *sig_name, const char *file)
 {
-    int res, ret = EXIT_FAILURE;
-    size_t len = 0;
+    int ret = EXIT_FAILURE;
     size_t buflen = 0;
     size_t maxlen = 16 * 1024 * 1024;
-    uint8_t *buf = NULL, *sig = NULL;
+    uint8_t *buf = NULL;
 
-    if (!bio_to_mem(&buf, &buflen, maxlen, in)) {
-        BIO_printf(bio_err, "Read error in %s\n", file);
-        return ret;
-    }
-    if (sigin != NULL) {
-        res = EVP_DigestVerify(ctx, sigin, siglen, buf, buflen);
-        print_verify_result(out, res);
-        if (res > 0)
-            ret = EXIT_SUCCESS;
-        goto end;
-    }
-    if (key != NULL) {
-        if (EVP_DigestSign(ctx, NULL, &len, buf, buflen) != 1) {
-            BIO_puts(bio_err, "Error getting maximum length of signed data\n");
-            goto end;
-        }
-        sig = app_malloc(len, "Signature buffer");
-        if (EVP_DigestSign(ctx, sig, &len, buf, buflen) != 1) {
-            BIO_puts(bio_err, "Error signing data\n");
-            goto end;
-        }
-        print_out(out, sig, len, sep, binout, sig_name, NULL, file);
-        ret = EXIT_SUCCESS;
-    } else {
-        BIO_puts(bio_err, "key must be set for one-shot algorithms\n");
-        goto end;
-    }
+#if defined(OPENSSL_SYS_UNIX) && defined(_POSIX_MAPPED_FILES) && _POSIX_MAPPED_FILES > 0
+    if (file != NULL) {
+        const unsigned char *data = NULL;
+        size_t filesize = 0;
+        int r = app_mmap_file(file, bio_err, (size_t)-1, &data, &filesize);
 
-end:
-    OPENSSL_free(sig);
-    OPENSSL_clear_free(buf, buflen);
+        if (r == 1) {
+            ret = do_oneshot_verify_sign(ctx, out, sigin, siglen, key, data,
+                      filesize, sep, binout, sig_name, file)
+                ? EXIT_SUCCESS
+                : EXIT_FAILURE;
+            munmap((void *)data, filesize);
+            return ret;
+        }
+        if (r == -1)
+            return EXIT_FAILURE; /* error already printed */
+        /* r == 0: empty file, fall through to buffer path */
+    }
+#endif
+
+    {
+        const char *display_file = file != NULL ? file : "stdin";
+
+        if (!bio_to_mem(&buf, &buflen, maxlen, in))
+            return EXIT_FAILURE;
+        ret = do_oneshot_verify_sign(ctx, out, sigin, siglen, key, buf, buflen,
+                  sep, binout, sig_name, display_file)
+            ? EXIT_SUCCESS
+            : EXIT_FAILURE;
+        OPENSSL_clear_free(buf, buflen);
+    }
 
     return ret;
 }

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -10,6 +10,16 @@
 #ifndef OSSL_APPS_H
 #define OSSL_APPS_H
 
+#if defined(__linux__) || defined(__sun__) || defined(__hpux)
+/*
+ * Allow open() and stat() to work with files larger than 2GB on 32-bit
+ * systems.  See crypto/o_fopen.c and crypto/bio/bss_file.c.
+ */
+#ifndef _FILE_OFFSET_BITS
+#define _FILE_OFFSET_BITS 64
+#endif
+#endif
+
 #include "internal/common.h" /* for HAS_PREFIX */
 #include "internal/nelem.h"
 #include <assert.h>
@@ -22,6 +32,19 @@
 #endif
 
 #include <openssl/e_os2.h>
+#if defined(OPENSSL_SYS_UNIX) && defined(_POSIX_MAPPED_FILES) && _POSIX_MAPPED_FILES > 0
+#include <sys/mman.h>
+#include <unistd.h>
+/*
+ * Map a file read-only into memory.  Returns 1 on success (*out_data and
+ * *out_size set; caller must munmap when done), 0 when file size is 0 (no
+ * error, caller may use buffer path), or -1 on error (message printed to
+ * bio_err).  known_size: (size_t)-1 = stat to get size; 0 = do not map
+ * (return 0); > 0 = use this size (caller obtained it from stat of same path).
+ */
+int app_mmap_file(const char *path, BIO *err_bio, size_t known_size,
+    const unsigned char **out_data, size_t *out_size);
+#endif
 #include <openssl/types.h>
 #include <openssl/bio.h>
 #include <openssl/x509.h>

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2202,6 +2202,63 @@ int bio_to_mem(unsigned char **out, size_t *outlen, size_t maxlen, BIO *in)
     return 1;
 }
 
+#if defined(OPENSSL_SYS_UNIX) && defined(_POSIX_MAPPED_FILES) && _POSIX_MAPPED_FILES > 0
+int app_mmap_file(const char *path, BIO *err_bio, size_t known_size,
+    const unsigned char **out_data, size_t *out_size)
+{
+    struct stat st;
+    size_t filesize;
+    int fd;
+    void *p;
+
+    *out_data = NULL;
+    *out_size = 0;
+
+    if (known_size == 0)
+        return 0;
+
+    if (known_size == (size_t)-1) {
+        if (stat(path, &st) != 0 || st.st_size < 0) {
+            BIO_printf(err_bio, "Error: failed to get size of file '%s'\n", path);
+            return -1;
+        }
+        if (!S_ISREG(st.st_mode)) {
+            /*
+             * mmap() is only for regular files. Directories and other non-regular
+             * paths can report st_size == 0; do not treat those like empty files
+             * and fall back to the buffer path in callers.
+             */
+            BIO_puts(err_bio, "Error: failed to use memory-mapped file\n");
+            return -1;
+        }
+        filesize = (size_t)st.st_size;
+        if ((off_t)filesize != st.st_size) {
+            BIO_puts(err_bio, "Error: failed to convert file size, likely too big\n");
+            return -1;
+        }
+        if (filesize == 0)
+            return 0;
+    } else {
+        filesize = known_size;
+    }
+
+    fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        BIO_puts(err_bio, "Error opening file for memory mapping\n");
+        return -1;
+    }
+    p = mmap(NULL, filesize, PROT_READ, MAP_PRIVATE, fd, 0);
+    (void)close(fd);
+    if (p == MAP_FAILED) {
+        BIO_puts(err_bio, "Error: failed to use memory-mapped file\n");
+        return -1;
+    }
+    *out_data = (const unsigned char *)p;
+    *out_size = filesize;
+    return 1;
+}
+#endif
+
 int pkey_ctrl_string(EVP_PKEY_CTX *ctx, const char *value)
 {
     int rv = 0;

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -9,6 +9,7 @@
 
 #include "apps.h"
 #include "progs.h"
+#include <limits.h>
 #include <string.h>
 #include <openssl/err.h>
 #include <openssl/pem.h>
@@ -37,8 +38,8 @@ static int do_keyop(EVP_PKEY_CTX *ctx, int pkey_op,
     unsigned char *secret, size_t *psecretlen);
 
 static int do_raw_keyop(int pkey_op, EVP_MD_CTX *mctx,
-    EVP_PKEY *pkey, BIO *in,
-    int filesize, unsigned char *sig, size_t siglen,
+    EVP_PKEY *pkey, BIO *in, const char *infile,
+    size_t filesize, unsigned char *sig, size_t siglen,
     unsigned char **out, size_t *poutlen);
 
 static int only_nomd(EVP_PKEY *pkey)
@@ -162,7 +163,7 @@ int pkeyutl_main(int argc, char **argv)
     int rawin = 0;
     EVP_MD_CTX *mctx = NULL;
     EVP_MD *md = NULL;
-    int filesize = -1;
+    size_t filesize = (size_t)-1; /* (size_t)-1 means unknown */
     OSSL_LIB_CTX *libctx = app_get0_libctx();
 
     prog = opt_init(argc, argv, pkeyutl_options);
@@ -454,8 +455,11 @@ int pkeyutl_main(int argc, char **argv)
         if (infile != NULL) {
             struct stat st;
 
-            if (stat(infile, &st) == 0 && st.st_size <= INT_MAX)
-                filesize = (int)st.st_size;
+            if (stat(infile, &st) == 0 && st.st_size >= 0) {
+                filesize = (size_t)st.st_size;
+                if ((off_t)filesize != st.st_size)
+                    filesize = (size_t)-1;
+            }
         }
         if (in == NULL)
             goto end;
@@ -539,7 +543,7 @@ int pkeyutl_main(int argc, char **argv)
 
     if (pkey_op == EVP_PKEY_OP_VERIFY) {
         if (rawin) {
-            rv = do_raw_keyop(pkey_op, mctx, pkey, in, filesize, sig, siglen,
+            rv = do_raw_keyop(pkey_op, mctx, pkey, in, infile, filesize, sig, siglen,
                 NULL, 0);
         } else {
             rv = EVP_PKEY_verify(ctx, sig, siglen, buf_in, buf_inlen);
@@ -554,7 +558,7 @@ int pkeyutl_main(int argc, char **argv)
     }
     if (rawin) {
         /* rawin allocates the buffer in do_raw_keyop() */
-        rv = do_raw_keyop(pkey_op, mctx, pkey, in, filesize, NULL, 0,
+        rv = do_raw_keyop(pkey_op, mctx, pkey, in, infile, filesize, NULL, 0,
             &buf_out, &buf_outlen);
     } else {
         if (kdflen != 0) {
@@ -821,8 +825,8 @@ static int do_keyop(EVP_PKEY_CTX *ctx, int pkey_op,
 #define TBUF_MAXSIZE 2048
 
 static int do_raw_keyop(int pkey_op, EVP_MD_CTX *mctx,
-    EVP_PKEY *pkey, BIO *in,
-    int filesize, unsigned char *sig, size_t siglen,
+    EVP_PKEY *pkey, BIO *in, const char *infile,
+    size_t filesize, unsigned char *sig, size_t siglen,
     unsigned char **out, size_t *poutlen)
 {
     int rv = 0;
@@ -832,32 +836,72 @@ static int do_raw_keyop(int pkey_op, EVP_MD_CTX *mctx,
 
     /* Some algorithms only support oneshot digests */
     if (only_nomd(pkey)) {
-        if (filesize < 0) {
+        if (filesize == (size_t)-1) {
+            BIO_printf(bio_err,
+                "Error: unable to determine size of file '%s' for oneshot operation\n",
+                infile);
+            goto end;
+        }
+#if defined(OPENSSL_SYS_UNIX) && defined(_POSIX_MAPPED_FILES) && _POSIX_MAPPED_FILES > 0
+        if (infile != NULL) {
+            struct stat st;
+
+            if (stat(infile, &st) == 0 && !S_ISREG(st.st_mode)) {
+                BIO_puts(bio_err, "Error: failed to use memory-mapped file\n");
+                goto end;
+            }
+        }
+        if (filesize > 0 && infile != NULL) {
+            const unsigned char *data = NULL;
+            size_t mapped_size = 0;
+
+            if (app_mmap_file(infile, bio_err, filesize, &data, &mapped_size) == 1) {
+                switch (pkey_op) {
+                case EVP_PKEY_OP_VERIFY:
+                    rv = EVP_DigestVerify(mctx, sig, siglen, data, mapped_size);
+                    break;
+                case EVP_PKEY_OP_SIGN:
+                    rv = EVP_DigestSign(mctx, NULL, poutlen, data, mapped_size);
+                    if (rv == 1 && out != NULL) {
+                        *out = app_malloc(*poutlen, "buffer output");
+                        rv = EVP_DigestSign(mctx, *out, poutlen, data, mapped_size);
+                    }
+                    break;
+                default:
+                    break;
+                }
+                munmap((void *)data, mapped_size);
+            }
+            /* Success or mmap failure: do not fall back to buffer path */
+            goto end;
+        }
+#endif
+        if (filesize > INT_MAX) {
             BIO_puts(bio_err,
-                "Error: unable to determine file size for oneshot operation\n");
+                "Error: file too large for oneshot operation without memory mapping\n");
             goto end;
         }
         if (filesize > 0)
             mbuf = app_malloc(filesize, "oneshot sign/verify buffer");
         switch (pkey_op) {
         case EVP_PKEY_OP_VERIFY:
-            buf_len = BIO_read(in, mbuf, filesize);
-            if (buf_len != filesize) {
+            buf_len = BIO_read(in, mbuf, (int)filesize);
+            if (buf_len < 0 || (size_t)buf_len != filesize) {
                 BIO_puts(bio_err, "Error reading raw input data\n");
                 goto end;
             }
-            rv = EVP_DigestVerify(mctx, sig, siglen, mbuf, buf_len);
+            rv = EVP_DigestVerify(mctx, sig, siglen, mbuf, filesize);
             break;
         case EVP_PKEY_OP_SIGN:
-            buf_len = BIO_read(in, mbuf, filesize);
-            if (buf_len != filesize) {
+            buf_len = BIO_read(in, mbuf, (int)filesize);
+            if (buf_len < 0 || (size_t)buf_len != filesize) {
                 BIO_puts(bio_err, "Error reading raw input data\n");
                 goto end;
             }
-            rv = EVP_DigestSign(mctx, NULL, poutlen, mbuf, buf_len);
+            rv = EVP_DigestSign(mctx, NULL, poutlen, mbuf, filesize);
             if (rv == 1 && out != NULL) {
                 *out = app_malloc(*poutlen, "buffer output");
-                rv = EVP_DigestSign(mctx, *out, poutlen, mbuf, buf_len);
+                rv = EVP_DigestSign(mctx, *out, poutlen, mbuf, filesize);
             }
             break;
         }

--- a/doc/man1/openssl-dgst.pod.in
+++ b/doc/man1/openssl-dgst.pod.in
@@ -118,10 +118,11 @@ Filename to output to, or standard output by default.
 Digitally sign the digest using the given private key.
 
 Note that for algorithms that only support one-shot signing
-(such as Ed25519, ED448, ML-DSA-44, ML-DSA-65 andML-DSA-87) the digest must not
+(such as Ed25519, ED448, ML-DSA-44, ML-DSA-65 and ML-DSA-87) the digest must not
 be set. For these algorithms the input is buffered (and not digested) before
-signing. For these algorithms, if the input is larger than 16MB an error
-will occur.
+signing. When the input is from a file, memory-mapped I/O is used on
+supported platforms (Unix\-like), allowing large files without a size limit; when
+input is from stdin or on unsupported platforms, input is limited to 16MB.
 
 =item B<-keyform> B<DER>|B<PEM>|B<P12>
 
@@ -143,6 +144,10 @@ see L<openssl-passphrase-options(1)>.
 
 Verify the signature using the public key in "filename".
 The output is either "Verified OK" or "Verification Failure".
+For one-shot verification algorithms (e.g. Ed25519, Ed448), when the input
+is from a file, memory-mapped I/O is used on supported platforms (Unix\-like),
+allowing large files; when input is from stdin or on unsupported platforms,
+input is limited to 16MB.
 
 =item B<-prverify> I<filename>
 
@@ -330,6 +335,11 @@ The FIPS-related options were removed in OpenSSL 1.1.0.
 The B<-engine> and B<-engine_impl> options were removed in OpenSSL 4.0.
 
 The B<-hmac-env> and B<-hmac-stdin> options were added in OpenSSL 4.0.
+
+Since OpenSSL 4.1, one-shot sign and verify (e.g. Ed25519, Ed448) with input
+from a file uses memory-mapped I/O on supported platforms (Unix\-like), allowing
+large files to be processed without the previous 16MB limit for file-based
+input.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -77,6 +77,10 @@ is implied since OpenSSL 3.5, and required in earlier versions.
 
 The B<-digest> option implies B<-rawin> since OpenSSL 3.5.
 
+When the input is read from a file (B<-in> I<filename>), the command may
+use memory-mapped I/O on supported platforms for better performance and
+to handle large files without loading the entire file into memory.
+
 =item B<-digest> I<algorithm>
 
 This option can only be used with B<-sign> and B<-verify>.
@@ -680,6 +684,11 @@ Also since OpenSSL 3.5, the B<-kemop> option is no longer required for any of
 the supported algorithms, the only supported B<mode> is now the default.
 
 The B<-engine> option was removed in OpenSSL 4.0.
+
+Since OpenSSL 4.1, when reading raw input from a file (B<-in> I<filename>) for
+oneshot sign/verify (such as Ed25519, Ed448, and ML-DSA), the command uses
+memory-mapped I/O on supported platforms, allowing large files to be processed
+without loading the entire file into memory.
 
 =head1 COPYRIGHT
 

--- a/test/recipes/20-test_dgst.t
+++ b/test/recipes/20-test_dgst.t
@@ -12,13 +12,13 @@ use warnings;
 
 use File::Spec;
 use File::Basename;
-use OpenSSL::Test qw/:DEFAULT with srctop_file data_file bldtop_dir/;
+use OpenSSL::Test qw/:DEFAULT with srctop_file srctop_dir data_file bldtop_dir/;
 use OpenSSL::Test::Utils;
 use Cwd qw(abs_path);
 
 setup("test_dgst");
 
-plan tests => 24;
+plan tests => 25;
 
 sub tsignverify {
     my $testtext = shift;
@@ -89,91 +89,143 @@ sub tsignverify_sha512 {
        $testtext.": Expect failure verifying mismatching data");
 }
 
-SKIP: {
-    skip "RSA is not supported by this OpenSSL build", 1
-        if disabled("rsa");
-
-    subtest "RSA signature generation and verification with `dgst` CLI" => sub {
-        tsignverify("RSA",
-                    srctop_file("test","testrsa.pem"),
-                    srctop_file("test","testrsapub.pem"));
-    };
-
-    subtest "RSA signature generation and verification with `sha512` CLI" => sub {
-        tsignverify_sha512("RSA",
-                           srctop_file("test","testrsa2048.pem"),
-                           srctop_file("test","testrsa2048pub.pem"));
-    };
-}
-
-SKIP: {
-    skip "DSA is not supported by this OpenSSL build", 1
-        if disabled("dsa");
-
-    subtest "DSA signature generation and verification with `dgst` CLI" => sub {
-        tsignverify("DSA",
-                    srctop_file("test","testdsa.pem"),
-                    srctop_file("test","testdsapub.pem"));
-    };
-}
-
-SKIP: {
-    skip "ECDSA is not supported by this OpenSSL build", 1
-        if disabled("ec");
-
-    subtest "ECDSA signature generation and verification with `dgst` CLI" => sub {
-        tsignverify("ECDSA",
-                    srctop_file("test","testec-p256.pem"),
-                    srctop_file("test","testecpub-p256.pem"));
-    };
-}
-
-SKIP: {
-    skip "EdDSA is not supported by this OpenSSL build", 2
-        if disabled("ecx");
-
-    subtest "Ed25519 signature generation and verification with `dgst` CLI" => sub {
-        tsignverify("Ed25519",
-                    srctop_file("test","tested25519.pem"),
-                    srctop_file("test","tested25519pub.pem"));
-    };
-
-    subtest "Ed448 signature generation and verification with `dgst` CLI" => sub {
-        tsignverify("Ed448",
-                    srctop_file("test","tested448.pem"),
-                    srctop_file("test","tested448pub.pem"));
-    };
-}
-
-SKIP: {
-    skip "ML-DSA is not supported by this OpenSSL build", 3
-        if disabled("ml-dsa");
-
-    subtest "ML-DSA-44 signature generation and verification with `dgst` CLI" => sub {
-        tsignverify("Ml-DSA-44",
-                    srctop_file("test","testmldsa44.pem"),
-                    srctop_file("test","testmldsa44pub.pem"));
-    };
-    subtest "ML-DSA-65 signature generation and verification with `dgst` CLI" => sub {
-        tsignverify("Ml-DSA-65",
-                    srctop_file("test","testmldsa65.pem"),
-                    srctop_file("test","testmldsa65pub.pem"));
-    };
-    subtest "ML-DSA-87 signature generation and verification with `dgst` CLI" => sub {
-        tsignverify("Ml-DSA-87",
-                    srctop_file("test","testmldsa87.pem"),
-                    srctop_file("test","testmldsa87pub.pem"));
-    };
-}
-
-SKIP: {
-    skip "dgst with provider is not supported by this OpenSSL build", 1
-        if disabled("module");
-
-    subtest "SHA1 generation by provider with `dgst` CLI" => sub {
+subtest "RSA signature generation and verification with `dgst` CLI" => sub {
+    if (disabled("rsa")) {
         plan tests => 1;
+        ok(1, "Skipped (RSA not supported)");
+        return;
+    }
+    tsignverify("RSA",
+                srctop_file("test","testrsa.pem"),
+                srctop_file("test","testrsapub.pem"));
+};
 
-        $ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
+subtest "RSA signature generation and verification with `sha512` CLI" => sub {
+    if (disabled("rsa")) {
+        plan tests => 1;
+        ok(1, "Skipped (RSA not supported)");
+        return;
+    }
+    tsignverify_sha512("RSA",
+                       srctop_file("test","testrsa2048.pem"),
+                       srctop_file("test","testrsa2048pub.pem"));
+};
+
+subtest "DSA signature generation and verification with `dgst` CLI" => sub {
+    if (disabled("dsa")) {
+        plan tests => 1;
+        ok(1, "Skipped (DSA not supported)");
+        return;
+    }
+    tsignverify("DSA",
+                srctop_file("test","testdsa.pem"),
+                srctop_file("test","testdsapub.pem"));
+};
+
+subtest "ECDSA signature generation and verification with `dgst` CLI" => sub {
+    if (disabled("ec")) {
+        plan tests => 1;
+        ok(1, "Skipped (ECDSA not supported)");
+        return;
+    }
+    tsignverify("ECDSA",
+                srctop_file("test","testec-p256.pem"),
+                srctop_file("test","testecpub-p256.pem"));
+};
+
+subtest "Ed25519 signature generation and verification with `dgst` CLI" => sub {
+    if (disabled("ecx")) {
+        plan tests => 1;
+        ok(1, "Skipped (EdDSA not supported)");
+        return;
+    }
+    tsignverify("Ed25519",
+                srctop_file("test","tested25519.pem"),
+                srctop_file("test","tested25519pub.pem"));
+};
+
+subtest "Ed448 signature generation and verification with `dgst` CLI" => sub {
+    if (disabled("ecx")) {
+        plan tests => 1;
+        ok(1, "Skipped (EdDSA not supported)");
+        return;
+    }
+    tsignverify("Ed448",
+                srctop_file("test","tested448.pem"),
+                srctop_file("test","tested448pub.pem"));
+};
+
+subtest "dgst one-shot: no buffer fallback when mmap path fails (Unix)" => sub {
+    if ($^O eq 'MSWin32' || disabled("ecx")) {
+        plan tests => 1;
+        ok(1, "Skipped (Unix/mmap or EdDSA not available)");
+        return;
+    }
+    plan tests => 2;
+
+    # Use a directory with non-zero st_size so app_mmap_file() attempts open+mmap
+    # (curdir "." often has st_size 0 on some FS, which skips mmap and breaks this test).
+    # mmap() on a directory must fail; we must not fall back to bio_to_mem.
+    my $key = srctop_file("test", "tested25519.pem");
+    my $dir = srctop_dir("test");
+    my $stderr_file = "dgst_nofallback_err.txt";
+
+    with({ exit_checker => sub { return shift != 0; } },
+         sub {
+             ok(run(app(['openssl', 'dgst', '-sign', $key, $dir],
+                        stderr => $stderr_file)),
+                "dgst one-shot with un-mmapable file fails (no fallback)");
+         });
+    if (open(my $fh, '<', $stderr_file)) {
+        my $err = do { local $/; <$fh> };
+        close($fh);
+        ok($err =~ /Error: failed to use memory-mapped file/, "stderr mentions mmap failure");
+    } else {
+        ok(0, "could not read stderr file");
+    }
+    unlink($stderr_file) if -f $stderr_file;
+};
+
+subtest "ML-DSA-44 signature generation and verification with `dgst` CLI" => sub {
+    if (disabled("ml-dsa")) {
+        plan tests => 1;
+        ok(1, "Skipped (ML-DSA not supported)");
+        return;
+    }
+    tsignverify("Ml-DSA-44",
+                srctop_file("test","testmldsa44.pem"),
+                srctop_file("test","testmldsa44pub.pem"));
+};
+subtest "ML-DSA-65 signature generation and verification with `dgst` CLI" => sub {
+    if (disabled("ml-dsa")) {
+        plan tests => 1;
+        ok(1, "Skipped (ML-DSA not supported)");
+        return;
+    }
+    tsignverify("Ml-DSA-65",
+                srctop_file("test","testmldsa65.pem"),
+                srctop_file("test","testmldsa65pub.pem"));
+};
+subtest "ML-DSA-87 signature generation and verification with `dgst` CLI" => sub {
+    if (disabled("ml-dsa")) {
+        plan tests => 1;
+        ok(1, "Skipped (ML-DSA not supported)");
+        return;
+    }
+    tsignverify("Ml-DSA-87",
+                srctop_file("test","testmldsa87.pem"),
+                srctop_file("test","testmldsa87pub.pem"));
+};
+
+subtest "SHA1 generation by provider with `dgst` CLI" => sub {
+    if (disabled("module")) {
+        plan tests => 1;
+        ok(1, "Skipped (dgst with provider not supported)");
+        return;
+    }
+    plan tests => 1;
+
+    $ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("test"));
         my $testdata = srctop_file('test', 'data.bin');
         my @macdata = run(app(['openssl', 'dgst', '-sha1',
                                '-provider', "p_ossltest",
@@ -183,8 +235,7 @@ SKIP: {
         chomp(@macdata);
         my $expected = qr/SHA1\(\Q$testdata\E\)= 000102030405060708090a0b0c0d0e0f10111213/;
         ok($macdata[0] =~ $expected, "SHA1: Check HASH value is as expected ($macdata[0]) vs ($expected)");
-    }
-}
+};
 
 subtest "HMAC generation with `dgst` CLI" => sub {
     plan tests => 2;
@@ -357,33 +408,40 @@ subtest "SHAKE digest generation with no xoflen set `dgst` CLI" => sub {
     ok(!run(app(['openssl', 'dgst', '-shake256', $testdata])), "SHAKE256 must fail without xoflen");
 };
 
-SKIP: {
-    skip "ECDSA is not supported by this OpenSSL build", 2
-        if disabled("ec");
-
-    subtest "signing with xoflen is not supported `dgst` CLI" => sub {
+subtest "signing with xoflen is not supported `dgst` CLI" => sub {
+    if (disabled("ec")) {
         plan tests => 1;
-        my $data_to_sign = srctop_file('test', 'data.bin');
-
-        ok(!run(app(['openssl', 'dgst', '-shake256', '-xoflen', '64',
-                     '-sign', srctop_file("test","testec-p256.pem"),
-                     '-out', 'test.sig',
-                     srctop_file('test', 'data.bin')])),
-                     "Generating signature with xoflen should fail");
-    };
-
-    skip "HMAC-DRBG-KDF is not supported by this OpenSSL build", 1
-        if disabled("hmac-drbg-kdf");
-
-    subtest "signing using the nonce-type sigopt" => sub {
-        plan tests => 1;
-        my $data_to_sign = srctop_file('test', 'data.bin');
-
-        ok(run(app(['openssl', 'dgst', '-sha256',
-                     '-sign', srctop_file("test","testec-p256.pem"),
-                     '-out', 'test.sig',
-                     '-sigopt', 'nonce-type:1',
-                     srctop_file('test', 'data.bin')])),
-                     "Sign using the nonce-type sigopt");
+        ok(1, "Skipped (ECDSA not supported)");
+        return;
     }
-}
+    plan tests => 1;
+    my $data_to_sign = srctop_file('test', 'data.bin');
+
+    ok(!run(app(['openssl', 'dgst', '-shake256', '-xoflen', '64',
+                 '-sign', srctop_file("test","testec-p256.pem"),
+                 '-out', 'test.sig',
+                 srctop_file('test', 'data.bin')])),
+                 "Generating signature with xoflen should fail");
+};
+
+subtest "signing using the nonce-type sigopt" => sub {
+    if (disabled("ec")) {
+        plan tests => 1;
+        ok(1, "Skipped (ECDSA not supported)");
+        return;
+    }
+    if (disabled("hmac-drbg-kdf")) {
+        plan tests => 1;
+        ok(1, "Skipped (HMAC-DRBG-KDF not supported)");
+        return;
+    }
+    plan tests => 1;
+    my $data_to_sign = srctop_file('test', 'data.bin');
+
+    ok(run(app(['openssl', 'dgst', '-sha256',
+                 '-sign', srctop_file("test","testec-p256.pem"),
+                 '-out', 'test.sig',
+                 '-sigopt', 'nonce-type:1',
+                 srctop_file('test', 'data.bin')])),
+                 "Sign using the nonce-type sigopt");
+};

--- a/test/recipes/20-test_pkeyutl.t
+++ b/test/recipes/20-test_pkeyutl.t
@@ -11,13 +11,13 @@ use warnings;
 
 use File::Spec;
 use File::Basename;
-use OpenSSL::Test qw/:DEFAULT srctop_file ok_nofips with/;
+use OpenSSL::Test qw/:DEFAULT srctop_file srctop_dir ok_nofips with/;
 use OpenSSL::Test::Utils;
 use File::Compare qw/compare_text compare/;
 
 setup("test_pkeyutl");
 
-plan tests => 27;
+plan tests => 29;
 
 # For the tests below we use the cert itself as the TBS file
 
@@ -214,8 +214,64 @@ SKIP: {
 }
 
 SKIP: {
-    skip "EdDSA is not supported by this OpenSSL build", 4
+    skip "EdDSA is not supported by this OpenSSL build", 6
         if disabled("ecx");
+
+    subtest "pkeyutl -rawin oneshot with file input (mmap or buffer path)" => sub {
+        my $data = srctop_file("test", "data.bin");
+        my $ed25519_key = srctop_file("test", "tested25519.pem");
+        my $ed25519_pub = srctop_file("test", "tested25519pub.pem");
+        my $ed448_key = srctop_file("test", "tested448.pem");
+        my $ed448_pub = srctop_file("test", "tested448pub.pem");
+
+        plan tests => 4;
+
+        # -in <file> for oneshot: uses mmap on Unix when supported, else buffer+BIO_read
+        ok(run(app(['openssl', 'pkeyutl', '-sign', '-rawin', '-inkey', $ed25519_key,
+                    '-in', $data, '-out', 'rawin_file_ed25519.sig'])),
+           "Ed25519 -rawin sign from file");
+        ok(run(app(['openssl', 'pkeyutl', '-verify', '-rawin', '-pubin', '-inkey', $ed25519_pub,
+                    '-sigfile', 'rawin_file_ed25519.sig', '-in', $data])),
+           "Ed25519 -rawin verify from file");
+        ok(run(app(['openssl', 'pkeyutl', '-sign', '-rawin', '-inkey', $ed448_key,
+                    '-in', $data, '-out', 'rawin_file_ed448.sig'])),
+           "Ed448 -rawin sign from file");
+        ok(run(app(['openssl', 'pkeyutl', '-verify', '-rawin', '-pubin', '-inkey', $ed448_pub,
+                    '-sigfile', 'rawin_file_ed448.sig', '-in', $data])),
+           "Ed448 -rawin verify from file");
+    };
+
+    subtest "pkeyutl -rawin oneshot: no buffer fallback when mmap path fails (Unix)" => sub {
+        if ($^O eq 'MSWin32') {
+            plan tests => 1;
+            ok(1, "Skipped (Unix/mmap only)");
+            return;
+        }
+        plan tests => 2;
+
+        # Use a directory with non-zero st_size so the mmap path is attempted
+        # (curdir "." often has st_size 0 on some FS and skips mmap).
+        my $ed25519_key = srctop_file("test", "tested25519.pem");
+        my $dir = srctop_dir("test");
+        my $stderr_file = "pkeyutl_nofallback_err.txt";
+
+        with({ exit_checker => sub { return shift != 0; } },
+             sub {
+                 ok(run(app(['openssl', 'pkeyutl', '-sign', '-rawin', '-inkey', $ed25519_key,
+                             '-in', $dir, '-out', 'nofallback.sig'],
+                            stderr => $stderr_file)),
+                    "pkeyutl -rawin with un-mmapable input fails (no fallback)");
+             });
+        if (open(my $fh, '<', $stderr_file)) {
+            my $err = do { local $/; <$fh> };
+            close($fh);
+            ok($err =~ /Error(?: opening file for memory mapping|: failed to use memory-mapped file)/,
+               "stderr mentions mmap failure");
+        } else {
+            ok(0, "could not read stderr file");
+        }
+        unlink($stderr_file) if -f $stderr_file;
+    };
 
     subtest "Ed2559 CLI signature generation and verification" => sub {
         tsignverify("Ed25519",


### PR DESCRIPTION
## Description

When using `openssl pkeyutl -rawin` for oneshot sign/verify operations (e.g. Ed25519, Ed448), the input was previously read by allocating a buffer as large as the file and copying the contents via `BIO_read()`. This change uses memory-mapped I/O (`mmap()`) on platforms that support it (Unix) when the input is read from a file, avoiding the extra allocation and copy. That improves performance and allows handling large files without doubling memory use.

On platforms without mmap or when input is not from a file (e.g. stdin), behaviour is unchanged: the existing buffer-based path is used.

**Review follow-ups (vdukhovni):**

* **File size handling:** File size is represented as `size_t` with a check that `(off_t)filesize == st.st_size` so we only set size when it fits in `size_t`. In the buffer fallback path, the code now errors with a clear message when `filesize > INT_MAX` instead of truncating the read length.
* **32-bit Linux large files:** `_FILE_OFFSET_BITS 64` is defined in `apps/include/apps.h` on Linux, Sun, and HP-UX so `open()` and `stat()` work with files larger than 2GB on 32-bit systems, matching `crypto/o_fopen.c` and `crypto/bio/bss_file.c`.
* **openssl dgst one-shot:** When `openssl dgst` is used for one-shot sign/verify (e.g. Ed25519, Ed448) with input from a file (not stdin), the same mmap approach is used so large files are supported without the previous 16MB limit; otherwise the existing `bio_to_mem` path is used.
* **EXIT_SUCCESS/EXIT_FAILURE:** Used only as return value from `main()` or argument to `exit(3)`. The helper `do_oneshot_verify_sign()` returns 0 on failure and 1 on success; callers map to `EXIT_FAILURE`/`EXIT_SUCCESS` when returning to main.
* **Zero-length files (dgst):** Empty files are handled by the buffer path (mmap only when `filesize > 0`), so we read nothing and verify/sign a zero-length buffer without special-casing mmap for size 0.
* **close(fd) after mmap (dgst):** The file descriptor is closed unconditionally immediately after `mmap()`, before checking for `MAP_FAILED`, using `(void)close(fd)`; no second `close(fd)` after `munmap()`.
* **Error messages (dgst):** Open failure reports "Error opening file for memory mapping"; stat/size/mmap failures report "Error: failed to use memory-mapped file". When `bio_to_mem()` fails we do not print a generic "Read error" (it may be file-too-large); detailed errors would require reporting from inside `bio_to_mem()`.
* **Style (dgst):** `display_file` assigned without extra parentheses around the ternary (`file != NULL ? file : "stdin"`).

**Review follow-up (npajkovsky):** Mmap blocks refactored to fail fast with explicit error checks and returns instead of a single `goto mmap_failed` label.

**Review follow-up (DDvO): No fallback when mmap path is attempted but fails**

When mmap is available and we attempt the mmap path for file input, we no longer fall back to the buffer-based path if `open()` or `mmap()` fails. Falling back would defeat the purpose (avoiding the extra allocation) and could hide configuration or permission issues.

* **pkeyutl:** If `open(infile)` fails we now print "Error opening file for memory mapping" and exit. If `mmap()` fails we close the fd, print "Error memory mapping file" and exit. No buffer allocation or `BIO_read()` fallback in these cases.
* **dgst:** If we have file input (not stdin) on Unix but the mmap path does not succeed (e.g. `stat`, `open`, or `mmap` fails), we print "Error: failed to use memory-mapped file" and return failure instead of falling through to `bio_to_mem()`.

## Implementation details

* **`apps/include/apps.h`:** Defines `_FILE_OFFSET_BITS 64` on Linux, Sun, and HP-UX and includes `fcntl.h`, `sys/mman.h`, and `unistd.h` when `OPENSSL_SYS_UNIX` and `_POSIX_MAPPED_FILES` are set, so pkeyutl and dgst need no duplicate definitions.
* **`apps/pkeyutl.c`:** Added a `const char *infile` parameter to `do_raw_keyop()` so the input path is available. In the oneshot path (`only_nomd(pkey)`), when `filesize > 0` and `infile != NULL`, the code tries `open()` + `mmap(PROT_READ, MAP_PRIVATE)` under `#if defined(OPENSSL_SYS_UNIX)`. On success it calls `EVP_DigestVerify` / `EVP_DigestSign` on the mapped region, then `munmap()` and `close()`. On open or mmap failure it errors out with a clear message and does not fall back to the buffer path. On non-Unix or when not file input, the existing buffer path is used. File size is set from `stat` using a `size_t`/`off_t` check; the buffer path errors if `filesize > INT_MAX`.
* **`apps/dgst.c`:** For one-shot sign/verify, when the input is a file (not stdin), the code tries `stat()` + `open()` + `mmap()` under the same Unix/POSIX guards only when `filesize > 0`; zero-length files use the buffer path. On mmap success it runs verify or sign on the mapped region, then `munmap()` (fd already closed after `mmap()`). On stat/size/mmap failure it returns failure with the appropriate message and does not call `bio_to_mem()`. On open failure it reports "Error opening file for memory mapping". The helper `do_oneshot_verify_sign()` returns 0/1; callers map to `EXIT_FAILURE`/`EXIT_SUCCESS`. When `bio_to_mem()` fails, no error message is printed (failure may be file-too-large). Otherwise (e.g. stdin or empty file) it uses the existing `bio_to_mem()` path (16MB limit for non-file).
* **Tests:** Extended `test/recipes/20-test_pkeyutl.t` with a subtest for pkeyutl -rawin oneshot with file input (mmap or buffer path), covering Ed25519 and Ed448 sign/verify from a file. Added regression subtests (Unix-only) to ensure we do not fall back to the buffer path when the mmap path fails: pkeyutl with a directory as `-in` (mmap fails) must fail with "Error ... memory mapping" and dgst one-shot with a directory as file argument must fail with "Error: failed to use memory-mapped file". Extended `test/recipes/20-test_dgst.t` with the same no-fallback regression for dgst one-shot.
* **Documentation:** Updated `doc/man1/openssl-pkeyutl.pod.in` under the `-rawin` option to note that file input may use memory-mapped I/O on supported platforms. Updated `doc/man1/openssl-dgst.pod.in` as needed. Added an entry in `CHANGES.md` under "Changes between 4.0 and 4.1" describing the change and referencing issue #11677.

## Checklist

* Code follows project coding style and compiles without warnings
* Tests added (extensions in `test/recipes/20-test_pkeyutl.t` and `test/recipes/20-test_dgst.t`, including no-fallback regression tests)
* Documentation updated (man pages and CHANGES.md)
* Change is self-contained and explains what changed and why
