### PR TITLE
NULL Pointer Dereference in X509_ALGOR_set_md via Provider-Fetched Digest

### DIFF
--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -737,6 +737,7 @@ err:
     return ret;
 }
 
+#ifndef OPENSSL_NO_MD5
 static int test_X509_ALGOR_set_md_md5(void)
 {
     X509_ALGOR *alg = NULL;
@@ -759,6 +760,7 @@ err:
     X509_ALGOR_free(alg);
     return ret;
 }
+#endif /* OPENSSL_NO_MD5 */
 
 /*
  * An EVP_MD with NID_undef type but a name that OBJ_txt2obj() can resolve.
@@ -1089,7 +1091,9 @@ int setup_tests(void)
     ADD_TEST(tests_x509_check_ext_duplicity_nid_dynamic);
 
     ADD_TEST(test_X509_ALGOR_set_md_sha1);
+#ifndef OPENSSL_NO_MD5
     ADD_TEST(test_X509_ALGOR_set_md_md5);
+#endif
     ADD_TEST(test_X509_ALGOR_set_md_nid_undef_known_name);
     ADD_TEST(test_X509_ALGOR_set_md_null_obj);
     return 1;

--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -18,6 +18,7 @@
 #include "testutil.h"
 #include "internal/nelem.h"
 #include "crypto/x509.h"
+#include "crypto/evp.h"
 
 /**********************************************************************
  *
@@ -706,6 +707,122 @@ err:
     return ret;
 }
 
+/**********************************************************************
+ *
+ * Tests for X509_ALGOR_set_md null pointer fix
+ * (see crypto/asn1/x_algor.c)
+ *
+ ***/
+
+static int test_X509_ALGOR_set_md_sha1(void)
+{
+    X509_ALGOR *alg = NULL;
+    const ASN1_OBJECT *aobj = NULL;
+    int ptype = V_ASN1_EOC;
+    int ret = 0;
+
+    if (!TEST_ptr(alg = X509_ALGOR_new()))
+        goto err;
+    /* SHA-1 has EVP_MD_FLAG_DIGALGID_ABSENT, so parameter type is V_ASN1_UNDEF */
+    if (!TEST_true(X509_ALGOR_set_md(alg, EVP_sha1())))
+        goto err;
+    X509_ALGOR_get0(&aobj, &ptype, NULL, alg);
+    if (!TEST_int_eq(OBJ_obj2nid(aobj), NID_sha1))
+        goto err;
+    if (!TEST_int_eq(ptype, V_ASN1_UNDEF))
+        goto err;
+    ret = 1;
+err:
+    X509_ALGOR_free(alg);
+    return ret;
+}
+
+static int test_X509_ALGOR_set_md_md5(void)
+{
+    X509_ALGOR *alg = NULL;
+    const ASN1_OBJECT *aobj = NULL;
+    int ptype = V_ASN1_EOC;
+    int ret = 0;
+
+    if (!TEST_ptr(alg = X509_ALGOR_new()))
+        goto err;
+    /* MD5 does not have EVP_MD_FLAG_DIGALGID_ABSENT, so parameter type is V_ASN1_NULL */
+    if (!TEST_true(X509_ALGOR_set_md(alg, EVP_md5())))
+        goto err;
+    X509_ALGOR_get0(&aobj, &ptype, NULL, alg);
+    if (!TEST_int_eq(OBJ_obj2nid(aobj), NID_md5))
+        goto err;
+    if (!TEST_int_eq(ptype, V_ASN1_NULL))
+        goto err;
+    ret = 1;
+err:
+    X509_ALGOR_free(alg);
+    return ret;
+}
+
+/*
+ * An EVP_MD with NID_undef type but a name that OBJ_txt2obj() can resolve.
+ * This exercises the OBJ_txt2obj() branch in X509_ALGOR_set_md.
+ */
+static const EVP_MD custom_md_known_oid = {
+    .type = NID_undef,
+    .pkey_type = NID_undef,
+    .type_name = "SHA256", /* OBJ_txt2obj() resolves this via OBJ_sn2nid() */
+};
+
+static int test_X509_ALGOR_set_md_nid_undef_known_name(void)
+{
+    X509_ALGOR *alg = NULL;
+    const ASN1_OBJECT *aobj = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(alg = X509_ALGOR_new()))
+        goto err;
+    /*
+     * NID_undef forces the OBJ_txt2obj() path; name "SHA256" resolves
+     * to the SHA-256 OID so the call must succeed and set the algorithm.
+     */
+    if (!TEST_true(X509_ALGOR_set_md(alg, &custom_md_known_oid)))
+        goto err;
+    X509_ALGOR_get0(&aobj, NULL, NULL, alg);
+    if (!TEST_int_eq(OBJ_obj2nid(aobj), NID_sha256))
+        goto err;
+    ret = 1;
+err:
+    X509_ALGOR_free(alg);
+    return ret;
+}
+
+/*
+ * An EVP_MD with NID_undef type and a name that OBJ_txt2obj() cannot resolve.
+ * Before the null-pointer fix, X509_ALGOR_set0 was called with a NULL obj,
+ * causing undefined behaviour.  After the fix, X509_ALGOR_set_md returns 0.
+ */
+static const EVP_MD custom_md_unknown_oid = {
+    .type = NID_undef,
+    .pkey_type = NID_undef,
+    .type_name = "not-a-known-oid-name",
+};
+
+static int test_X509_ALGOR_set_md_null_obj(void)
+{
+    X509_ALGOR *alg = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(alg = X509_ALGOR_new()))
+        goto err;
+    /*
+     * OBJ_txt2obj("not-a-known-oid-name", 0) returns NULL, so
+     * X509_ALGOR_set_md must return 0 rather than crash.
+     */
+    if (!TEST_false(X509_ALGOR_set_md(alg, &custom_md_unknown_oid)))
+        goto err;
+    ret = 1;
+err:
+    X509_ALGOR_free(alg);
+    return ret;
+}
+
 /* https://github.com/openssl/openssl/issues/26325 */
 static const char *kRootExtensionDuplicity[] = {
     "-----BEGIN CERTIFICATE-----\n",
@@ -971,5 +1088,9 @@ int setup_tests(void)
     ADD_TEST(tests_x509_check_ext_duplicity_nid_undef);
     ADD_TEST(tests_x509_check_ext_duplicity_nid_dynamic);
 
+    ADD_TEST(test_X509_ALGOR_set_md_sha1);
+    ADD_TEST(test_X509_ALGOR_set_md_md5);
+    ADD_TEST(test_X509_ALGOR_set_md_nid_undef_known_name);
+    ADD_TEST(test_X509_ALGOR_set_md_null_obj);
     return 1;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

`X509_ALGOR_set_md()` silently corrupts an `X509_ALGOR` object when called with a provider-based `EVP_MD` whose name is not resolvable as an OID. The function returns success (1) but leaves `alg->algorithm == NULL`. Any subsequent use of the object, comparison, DER encoding, CMS signing, dereferences the NULL pointer and crashes.

Trigger Conditions:

- Application uses EVP_MD_fetch() to obtain a digest from a provider
- That digest has no legacy NID mapping (i.e., EVP_MD_type() returns NID_undef)
- The digest's name is not registered in OpenSSL's OBJ table (i.e., not a known algorithm short/long name and not a numeric OID string)
- The application then calls X509_ALGOR_set_md() with that digest — for example during CMS signing, RSA-PSS parameter encoding, or certificate request generation

This is reachable through custom/third-party providers, or future built-in algorithms that lack legacy NID entries.

Impact: Denial of service (process crash). Not believed to be exploitable for code execution given the NULL dereference is in a comparison/encoding path. The crash is deterministic for any application hitting this code path with the described input.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- Just a minor fix, no real documentation or unit tests added


