### PR TITLE
apps/lib/tlssrp_depr.c: fix leak of vb in `set_up_srp_verifier_file()`

### DIFF
--- a/apps/include/s_apps.h
+++ b/apps/include/s_apps.h
@@ -110,5 +110,6 @@ typedef struct srpsrvparm_st {
 
 int set_up_srp_verifier_file(SSL_CTX *ctx, srpsrvparm *srp_callback_parm,
     char *srpuserseed, char *srp_verifier_file);
+void cleanup_srp(srpsrvparm *srp_callback_parm);
 void lookup_srp_user(srpsrvparm *srp_callback_parm, BIO *bio_s_out);
 #endif /* OPENSSL_NO_SRP */

--- a/apps/lib/tlssrp_depr.c
+++ b/apps/lib/tlssrp_depr.c
@@ -203,6 +203,8 @@ int set_up_srp_verifier_file(SSL_CTX *ctx, srpsrvparm *srp_callback_parm,
         BIO_printf(bio_err,
             "Cannot initialize SRP verifier file \"%s\":ret=%d\n",
             srp_verifier_file, ret);
+        SRP_VBASE_free(srp_callback_parm->vb);
+        srp_callback_parm->vb = NULL;
         return 0;
     }
     SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, verify_callback);

--- a/apps/lib/tlssrp_depr.c
+++ b/apps/lib/tlssrp_depr.c
@@ -226,3 +226,11 @@ void lookup_srp_user(srpsrvparm *srp_callback_parm, BIO *bio_s_out)
     else
         BIO_puts(bio_s_out, "LOOKUP not successful\n");
 }
+
+void cleanup_srp(srpsrvparm *srp_callback_parm)
+{
+    SRP_user_pwd_free(srp_callback_parm->user);
+    srp_callback_parm->user = NULL;
+    SRP_VBASE_free(srp_callback_parm->vb);
+    srp_callback_parm->vb = NULL;
+}

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3121,6 +3121,8 @@ int s_server_main(int argc, char *argv[])
 end:
     SSL_CTX_free(ctx);
 #ifndef OPENSSL_NO_SRP
+    SRP_user_pwd_free(srp_callback_parm.user);
+    srp_callback_parm.user = NULL;
     SRP_VBASE_free(srp_callback_parm.vb);
     srp_callback_parm.vb = NULL;
 #endif

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3120,6 +3120,10 @@ int s_server_main(int argc, char *argv[])
     ret = 0;
 end:
     SSL_CTX_free(ctx);
+#ifndef OPENSSL_NO_SRP
+    SRP_VBASE_free(srp_callback_parm.vb);
+    srp_callback_parm.vb = NULL;
+#endif
     SSL_SESSION_free(psksess);
     set_keylog_file(NULL, NULL);
     X509_free(s_cert);

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3121,10 +3121,7 @@ int s_server_main(int argc, char *argv[])
 end:
     SSL_CTX_free(ctx);
 #ifndef OPENSSL_NO_SRP
-    SRP_user_pwd_free(srp_callback_parm.user);
-    srp_callback_parm.user = NULL;
-    SRP_VBASE_free(srp_callback_parm.vb);
-    srp_callback_parm.vb = NULL;
+    cleanup_srp(&srp_callback_parm);
 #endif
     SSL_SESSION_free(psksess);
     set_keylog_file(NULL, NULL);


### PR DESCRIPTION
set_up_srp_verifier_file() allocates srp_callback_parm->vb via SRP_VBASE_new(). If SRP_VBASE_init() fails, vb must be freed before returning.

Solves https://github.com/openssl/openssl/issues/30362 
Fixes #30362