### PR TITLE
crypto/x509/pcy_tree.c: fix leak of tree in X509_policy_check()

### DIFF
--- a/crypto/x509/pcy_tree.c
+++ b/crypto/x509/pcy_tree.c
@@ -680,8 +680,10 @@ int X509_policy_check(X509_POLICY_TREE **ptree, int *pexplicit_policy,
     } else {
         *pexplicit_policy = 1;
         /* Tree empty and requireExplicit True: Error */
-        if (init_ret & X509_PCY_TREE_EMPTY)
+        if (init_ret & X509_PCY_TREE_EMPTY) {
+            X509_policy_tree_free(tree);
             return X509_PCY_TREE_FAILURE;
+        }
     }
 
     ret = tree_evaluate(tree);
@@ -707,13 +709,15 @@ int X509_policy_check(X509_POLICY_TREE **ptree, int *pexplicit_policy,
     if (!ret)
         goto error;
 
-    *ptree = tree;
-
     if (init_ret & X509_PCY_TREE_EXPLICIT) {
         nodes = X509_policy_tree_get0_user_policies(tree);
-        if (sk_X509_POLICY_NODE_num(nodes) <= 0)
+        if (sk_X509_POLICY_NODE_num(nodes) <= 0) {
+            X509_policy_tree_free(tree);
             return X509_PCY_TREE_FAILURE;
+        }
     }
+
+    *ptree = tree;
     return X509_PCY_TREE_VALID;
 
 error:


### PR DESCRIPTION
When init_ret indicates both X509_PCY_TREE_EXPLICIT and X509_PCY_TREE_EMPTY, the function returns without freeing the initialized policy tree.

Free tree before returning, consistent with the earlier TREE_EMPTY branch.

Solves https://github.com/openssl/openssl/issues/30435
Fixes #30435
