### PR TITLE
Fix integer truncation in ppc_aes_gcm_crypt

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_gcm_hw_ppc.inc
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw_ppc.inc
@@ -44,8 +44,8 @@ static inline u32 add32TOU(unsigned char buf[4], u32 n)
 static size_t ppc_aes_gcm_crypt(const unsigned char *in, unsigned char *out, size_t len,
                                 const void *key, unsigned char ivec[16], u64 *Xi, int encrypt)
 {
-    int s = 0;
-    int ndone = 0;
+    size_t s = 0;
+    size_t ndone = 0;
     int ctr_reset = 0;
     u64 blocks_unused;
     u64 nb = len / 16;


### PR DESCRIPTION
### Problem

In `ppc_aes_gcm_crypt()`, the PPC64 assembly functions `ppc_aes_gcm_encrypt`
and `ppc_aes_gcm_decrypt` are declared as returning `size_t` (64-bit on PPC64)
in `include/crypto/aes_platform.h`, but their return values are stored in local
`int` variables (`s` and `ndone`), which are 32-bit signed.

This causes silent truncation for inputs exceeding 2GB, which is reachable
through `EVP_Cipher()` (takes `unsigned int` length).

Fixes #30381

### Fix

Change the types of `s` and `ndone` from `int` to `size_t` to match the
return type of the assembly functions and the return type of
`ppc_aes_gcm_crypt` itself.

### Testing

Built and tested on IBM POWER8 S824 (ppc64le, Ubuntu 20.04):

- `make test TESTS='test_evp test_evp_extra test_aes_wrap test_cipherlist'` — **all pass**
- AES-128-GCM benchmark: **2.94 GB/s** with hardware acceleration (`CPUINFO: OPENSSL_ppccap=0x2e`)

```
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
AES-128-GCM      10449.57k    37975.17k   142365.87k  1131144.53k  2739066.20k  2938301.10k
```

CLA: trivial