### PR TITLE
SLH_DSA: signing operation incorrectly returned 1 on failure.

### DIFF
--- a/crypto/slh_dsa/slh_dsa.c
+++ b/crypto/slh_dsa/slh_dsa.c
@@ -119,11 +119,11 @@ static int slh_sign_internal(SLH_DSA_HASH_CTX *hctx,
         /* Generate ht signature and append to the SLH-DSA signature */
         && ossl_slh_ht_sign(hctx, pk_fors, sk_seed, pk_seed, tree_id, leaf_id,
             wpkt);
-    *sig_len = sig_len_expected;
-    ret = 1;
 err:
     if (!WPACKET_finish(wpkt))
         ret = 0;
+    if (ret)
+        *sig_len = sig_len_expected;
     return ret;
 }
 


### PR DESCRIPTION
Fixes #30414

A block copy bug incorrectly set ret = 1 straight after assigning ret.

Setting the *sig_len has been delayed to the err path in case WPACKET_finish fails.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
