### PR TITLE
ssl/quic/quic_port.c: fix leak in port_make_channel()

### DIFF
--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -562,8 +562,9 @@ static QUIC_CHANNEL *port_make_channel(QUIC_PORT *port, SSL *tls, OSSL_QRX *qrx,
      */
     ch->use_qlog = 1;
     if (ch->tls != NULL && ch->tls->ctx->qlog_title != NULL) {
+        OPENSSL_free(ch->qlog_title);
         if ((ch->qlog_title = OPENSSL_strdup(ch->tls->ctx->qlog_title)) == NULL) {
-            OPENSSL_free(ch);
+            ossl_quic_channel_free(ch);
             return NULL;
         }
     }


### PR DESCRIPTION
Replace OPENSSL_free(ch) with ossl_quic_channel_free(ch) on failure paths to ensure channel resources are fully released.

Solves https://github.com/openssl/openssl/issues/30440
Fixes #30440
