### PR TITLE
ssl/statem/statem_dtls.c: fix leak in dtls1_buffer_message()

### DIFF
--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -1177,7 +1177,11 @@ int dtls1_buffer_message(SSL_CONNECTION *s, int is_ccs)
         return 0;
     }
 
-    pqueue_insert(s->d1->sent_messages, item);
+    if (pqueue_insert(s->d1->sent_messages, item) == NULL) {
+        dtls1_hm_fragment_free(frag);
+        pitem_free(item);
+        return 0;
+    }
     return 1;
 }
 


### PR DESCRIPTION
pqueue_insert() may fail, but its return value was not checked. This could leak the allocated pitem and handshake fragment. Free them when insertion fails.

Solves https://github.com/openssl/openssl/issues/30442
Fixes #30442