### PR TITLE
Mask *num in legacy OFB/CFB code

### DIFF
--- a/crypto/bf/bf_cfb64.c
+++ b/crypto/bf/bf_cfb64.c
@@ -27,7 +27,7 @@ void BF_cfb64_encrypt(const unsigned char *in, unsigned char *out,
     unsigned char *ivec, int *num, int encrypt)
 {
     register BF_LONG v0, v1, t;
-    register int n = *num;
+    register int n = *num & 0x07;
     register long l = length;
     BF_LONG ti[2];
     unsigned char *iv, c, cc;

--- a/crypto/bf/bf_ofb64.c
+++ b/crypto/bf/bf_ofb64.c
@@ -26,7 +26,7 @@ void BF_ofb64_encrypt(const unsigned char *in, unsigned char *out,
     unsigned char *ivec, int *num)
 {
     register BF_LONG v0, v1, t;
-    register int n = *num;
+    register int n = *num & 0x07;
     register long l = length;
     unsigned char d[8];
     register char *dp;

--- a/crypto/cast/c_cfb64.c
+++ b/crypto/cast/c_cfb64.c
@@ -27,7 +27,7 @@ void CAST_cfb64_encrypt(const unsigned char *in, unsigned char *out,
     unsigned char *ivec, int *num, int enc)
 {
     register CAST_LONG v0, v1, t;
-    register int n = *num;
+    register int n = *num & 0x07;
     register long l = length;
     CAST_LONG ti[2];
     unsigned char *iv, c, cc;

--- a/crypto/cast/c_ofb64.c
+++ b/crypto/cast/c_ofb64.c
@@ -26,7 +26,7 @@ void CAST_ofb64_encrypt(const unsigned char *in, unsigned char *out,
     unsigned char *ivec, int *num)
 {
     register CAST_LONG v0, v1, t;
-    register int n = *num;
+    register int n = *num & 0x07;
     register long l = length;
     unsigned char d[8];
     register char *dp;

--- a/crypto/idea/i_cfb64.c
+++ b/crypto/idea/i_cfb64.c
@@ -28,7 +28,7 @@ void IDEA_cfb64_encrypt(const unsigned char *in, unsigned char *out,
     unsigned char *ivec, int *num, int encrypt)
 {
     register unsigned long v0, v1, t;
-    register int n = *num;
+    register int n = *num & 0x07;
     register long l = length;
     unsigned long ti[2];
     unsigned char *iv, c, cc;

--- a/crypto/idea/i_ofb64.c
+++ b/crypto/idea/i_ofb64.c
@@ -27,7 +27,7 @@ void IDEA_ofb64_encrypt(const unsigned char *in, unsigned char *out,
     unsigned char *ivec, int *num)
 {
     register unsigned long v0, v1, t;
-    register int n = *num;
+    register int n = *num & 0x07;
     register long l = length;
     unsigned char d[8];
     register char *dp;

--- a/crypto/rc2/rc2cfb64.c
+++ b/crypto/rc2/rc2cfb64.c
@@ -27,7 +27,7 @@ void RC2_cfb64_encrypt(const unsigned char *in, unsigned char *out,
     int *num, int encrypt)
 {
     register unsigned long v0, v1, t;
-    register int n = *num;
+    register int n = *num & 0x07;
     register long l = length;
     unsigned long ti[2];
     unsigned char *iv, c, cc;

--- a/crypto/rc2/rc2ofb64.c
+++ b/crypto/rc2/rc2ofb64.c
@@ -26,7 +26,7 @@ void RC2_ofb64_encrypt(const unsigned char *in, unsigned char *out,
     int *num)
 {
     register unsigned long v0, v1, t;
-    register int n = *num;
+    register int n = *num & 0x07;
     register long l = length;
     unsigned char d[8];
     register char *dp;

--- a/crypto/rc5/rc5cfb64.c
+++ b/crypto/rc5/rc5cfb64.c
@@ -27,7 +27,7 @@ void RC5_32_cfb64_encrypt(const unsigned char *in, unsigned char *out,
     unsigned char *ivec, int *num, int encrypt)
 {
     register unsigned long v0, v1, t;
-    register int n = *num;
+    register int n = *num & 0x07;
     register long l = length;
     unsigned long ti[2];
     unsigned char *iv, c, cc;

--- a/crypto/rc5/rc5ofb64.c
+++ b/crypto/rc5/rc5ofb64.c
@@ -26,7 +26,7 @@ void RC5_32_ofb64_encrypt(const unsigned char *in, unsigned char *out,
     unsigned char *ivec, int *num)
 {
     register unsigned long v0, v1, t;
-    register int n = *num;
+    register int n = *num & 0x07;
     register long l = length;
     unsigned char d[8];
     register char *dp;


### PR DESCRIPTION
This change masks the caller-maintained `*num` parameter on entry in the
deprecated low-level OFB64/CFB64 implementations for Blowfish, CAST,
IDEA, RC2, and RC5.

These functions use `n` as a byte offset into an 8-byte feedback state.
Currently they initialize it as:
```
    register int n = *num;
```
If an unexpected caller-supplied value is present, this value can be
used before the existing wraparound logic takes effect.

This patch changes those implementations to initialize `n` as:
```
    register int n = *num & 0x07;
```
This ensures the internal byte offset always remains within the
8-byte feedback state from the first access onward and aligns the
behavior with the existing DES implementation.

This is intended as a robustness and consistency improvement for
deprecated low-level APIs, not a security fix.

##### Checklist
- [ ] documentation is added or updated
- [ ] tests are added or updated