### PR TITLE
Fix incorrect error return in ppc_aes_gcm_cipher_update decrypt path

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_gcm_hw_ppc.inc
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw_ppc.inc
@@ -119,7 +119,7 @@ static int ppc_aes_gcm_cipher_update(PROV_GCM_CTX *ctx, const unsigned char *in,
                 size_t res = (16 - ctx->gcm.mres) % 16;
 
                 if (CRYPTO_gcm128_decrypt(&ctx->gcm, in, out, res))
-                    return -1;
+                    return 0;
 
                 bulk = ppc_aes_gcm_crypt(in + res, out + res, len - res,
                                          ctx->gcm.key,


### PR DESCRIPTION
## Summary

Fix incorrect `-1` error return in the PPC AES-GCM decrypt pre-alignment path. The function contract is to return `1` on success and `0` on failure, but the decrypt path returned `-1`.

## Problem

In `ppc_aes_gcm_cipher_update()`, the decrypt pre-alignment check at line 122 returns `-1` when `CRYPTO_gcm128_decrypt()` fails:

```c
// Decrypt path (WRONG — was returning -1):
if (CRYPTO_gcm128_decrypt(&ctx->gcm, in, out, res))
    return -1;

// Encrypt path (CORRECT — returns 0):
if (CRYPTO_gcm128_encrypt(&ctx->gcm, in, out, res))
    return 0;
```

The caller at `ciphercommon_gcm.c:460` checks `if (!hw->cipherupdate(...))`. Since `!(-1)` evaluates to `0` (false in C), the `goto err` branch is **not taken** and GCM processing continues with potentially corrupt state.

This is the only `return -1` in all GCM cipher implementation files. All five other error returns in the same function correctly return `0`.

## Fix

Change `return -1` to `return 0` to match the encrypt path and the function's documented contract.

Fixes #30380

CLA: Signed (on file from PR #9932 on wolfSSL, also applicable here — OpenSSL CLA was completed for #30437).