### PR TITLE
ISSUE-13825: Change pkcs12 app to allow parsing key/certificate(s) in any order on input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -883,7 +883,7 @@ jobs:
         mkdir nss
         cd nss
         git clone --depth 1 --branch NSS_3_112_3_RTM https://github.com/nss-dev/nss.git
-        hg clone https://hg.mozilla.org/projects/nspr -r NSPR_4_36_BRANCH
+        git clone --depth 1 https://github.com/nss-dev/nspr.git
         cd nss
         USE_64=1 make nss_build_all
         USE_64=1 make install

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,12 @@ OpenSSL Releases
 
    *Helen Zhang*
 
+ * The B<openssl pkcs12 -export> command now accepts key and certificate(s)
+   in any order in the B<-in> file when B<-inkey> is not used.
+   Previously the private key had to appear before the certificates.
+
+   *John Claus*
+
 ### Changes between 3.6 and 4.0 [xx XXX xxxx]
 
  * Added `-expected-rpks` option to the `openssl s_client`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -390,6 +390,14 @@ OpenSSL 4.1
 
    *Helen Zhang*
 
+ * The `openssl pkcs12 -export` command now reads the private key and
+   certificate(s) from the `-in` input in a single pass when `-inkey` is
+   not used, so they may appear in any order.  Previously the input was
+   read twice, and when it was not seekable (e.g. standard input from a
+   pipe) certificates preceding the private key were silently dropped.
+
+   *John Claus*
+
  * Added AVX-512 and VAES optimizations for AES-CBC decryption. Decryption
    performance for large inputs (1024 bytes or more) improved by 3.5x to 3.8x.
 

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -587,19 +587,43 @@ int pkcs12_main(int argc, char **argv)
             BIO_puts(bio_err, "Warning: -chain option ignored with -nocerts\n");
         }
 
-        if (!(options & NOKEYS)) {
-            key = load_key(keyname ? keyname : infile,
-                FORMAT_PEM, 1, passin,
-                keyname ? "private key from -inkey file" : "private key from -in file");
-            if (key == NULL)
-                goto export_end;
+        /*
+         * Load key and/or certs.  When -inkey is set, key comes from -inkey
+         * and certs from -in.  When -inkey is not set, both come from -in
+         * and may appear in any order (we use load_key_certs_crls for that).
+         */
+        if (keyname != NULL) {
+            if (!(options & NOKEYS)) {
+                key = load_key(keyname, FORMAT_PEM, 1, passin,
+                    "private key from -inkey file");
+                if (key == NULL)
+                    goto export_end;
+            }
+            if (!(options & NOCERTS)) {
+                if (!load_certs(infile, 1, &certs, passin,
+                        "certificates from -in file"))
+                    goto export_end;
+            }
+        } else {
+            /* Key and/or certs from -in file; order does not matter */
+            if (!(options & NOKEYS) && (options & NOCERTS)) {
+                if (!load_key_certs_crls(infile, FORMAT_PEM, 1, passin,
+                        "private key from -in file", 0,
+                        &key, NULL, NULL, NULL, NULL, NULL, NULL, NULL))
+                    goto export_end;
+            } else if ((options & NOKEYS) && !(options & NOCERTS)) {
+                if (!load_certs(infile, 1, &certs, passin,
+                        "certificates from -in file"))
+                    goto export_end;
+            } else if (!(options & NOKEYS) && !(options & NOCERTS)) {
+                if (!load_key_certs_crls(infile, FORMAT_PEM, 1, passin,
+                        "key and certificates from -in file", 0,
+                        &key, NULL, NULL, NULL, &certs, NULL, NULL, NULL))
+                    goto export_end;
+            }
         }
 
-        /* Load all certs in input file */
         if (!(options & NOCERTS)) {
-            if (!load_certs(infile, 1, &certs, passin,
-                    "certificates from -in file"))
-                goto export_end;
             if (sk_X509_num(certs) < 1) {
                 BIO_printf(bio_err, "No certificate in -in file %s\n", infile);
                 goto export_end;

--- a/test/recipes/80-test_pkcs12.t
+++ b/test/recipes/80-test_pkcs12.t
@@ -56,7 +56,7 @@ $ENV{OPENSSL_WIN32_UTF8}=1;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
-plan tests => 59 + ($no_fips ? 0 : 5);
+plan tests => 67 + ($no_fips ? 0 : 5);
 
 # Test different PKCS#12 formats
 ok(run(test(["pkcs12_format_test"])), "test pkcs12 formats");
@@ -141,6 +141,56 @@ ok(run(app(["openssl", "pkcs12",
             "-passin", "pass:v3-certs",
             "-nomacver", "-nodes"])),
   "test_import_pkcs12_cert_key_cert");
+
+# Regression: single -in file with cert(s) before key (no -inkey)
+# Previously failed with "No private key found"; now key/cert order is arbitrary
+{
+    my $out_cert_key_order = "out_cert_key_order.p12";
+    ok(run(app(["openssl", "pkcs12", "-export",
+                "-in", srctop_file(@path, "cert-key-cert.pem"),
+                "-passout", "pass:v3-certs",
+                "-nomac", "-out", $out_cert_key_order])),
+       "test_export_pkcs12_single_in_cert_then_key");
+    ok(run(app(["openssl", "pkcs12", "-in", $out_cert_key_order,
+                "-passin", "pass:v3-certs", "-nomacver", "-nodes"])),
+       "test_import_pkcs12_cert_then_key");
+}
+
+# Regression: single -in file with key before cert(s) (no -inkey)
+{
+    ok(run(app(["openssl", "pkey", "-in", srctop_file(@path, "cert-key-cert.pem"),
+                "-out", "keyonly.pem"])), "extract key for keyfirst test");
+    ok(run(app(["openssl", "x509", "-in", srctop_file(@path, "cert-key-cert.pem"),
+                "-out", "certonly.pem"])), "extract cert for keyfirst test");
+    open my $out, '>', 'keyfirst.pem' or die $!;
+    open my $k, '<', 'keyonly.pem' or die $!;
+    open my $c, '<', 'certonly.pem' or die $!;
+    print $out $_ while <$k>;
+    print $out $_ while <$c>;
+    close $out;
+    close $k;
+    close $c;
+    ok(run(app(["openssl", "pkcs12", "-export", "-in", "keyfirst.pem",
+                "-passout", "pass:test", "-nomac", "-out", "out_keyfirst.p12"])),
+       "test_export_pkcs12_single_in_key_then_cert");
+    ok(run(app(["openssl", "pkcs12", "-in", "out_keyfirst.p12",
+                "-passin", "pass:test", "-nomacver", "-nodes"])),
+       "test_import_pkcs12_key_then_cert");
+}
+
+# Regression: single -in with -nocerts when key is not first (key-only export)
+# Exercises load_key_certs_crls with only ppkey requested; key appears after cert(s)
+{
+    my $out_nocerts_order = "out_nocerts_cert_then_key.p12";
+    ok(run(app(["openssl", "pkcs12", "-export", "-nocerts",
+                "-in", srctop_file(@path, "cert-key-cert.pem"),
+                "-passout", "pass:v3-certs",
+                "-nomac", "-out", $out_nocerts_order])),
+       "test_export_pkcs12_single_in_nocerts_cert_then_key");
+    ok(run(app(["openssl", "pkcs12", "-in", $out_nocerts_order,
+                "-passin", "pass:v3-certs", "-nomacver", "-nodes", "-nocerts"])),
+       "test_import_pkcs12_nocerts_key_only");
+}
 
 ok(run(app(["openssl", "pkcs12", "-export", "-out", $outfile5,
             "-in", srctop_file(@path, "ee-cert.pem"), "-caname", "testname",

--- a/test/recipes/80-test_pkcs12.t
+++ b/test/recipes/80-test_pkcs12.t
@@ -56,7 +56,7 @@ $ENV{OPENSSL_WIN32_UTF8}=1;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
-plan tests => 65 + ($no_fips ? 0 : 5);
+plan tests => 68 + ($no_fips ? 0 : 5);
 
 # Test different PKCS#12 formats
 ok(run(test(["pkcs12_format_test"])), "test pkcs12 formats");
@@ -141,6 +141,25 @@ ok(run(app(["openssl", "pkcs12",
             "-passin", "pass:v3-certs",
             "-nomacver", "-nodes"])),
   "test_import_pkcs12_cert_key_cert");
+
+# Regression test for reading key and certificates from stdin (single pass).
+# Previously the input was read twice (key, then certs), so with stdin the
+# certificate(s) preceding the private key were silently dropped.
+{
+    my $out_stdin = "out_stdin_cert_then_key.p12";
+    ok(run(app(["openssl", "pkcs12", "-export",
+                "-passout", "pass:v3-certs", "-nomac", "-out", $out_stdin],
+               stdin => srctop_file(@path, "cert-key-cert.pem"))),
+       "test_export_pkcs12_stdin_cert_then_key");
+    my @stdin_certs = run(app(["openssl", "pkcs12", "-in", $out_stdin,
+                               "-passin", "pass:v3-certs",
+                               "-nomacver", "-nokeys"]), capture => 1);
+    ok(grep(/^-----BEGIN CERTIFICATE-----/, @stdin_certs) == 2,
+       "test_export_pkcs12_stdin_keeps_all_certs");
+    ok(run(app(["openssl", "pkcs12", "-in", $out_stdin,
+                "-passin", "pass:v3-certs", "-nomacver", "-nodes"])),
+       "test_import_pkcs12_stdin_cert_then_key");
+}
 
 ok(run(app(["openssl", "pkcs12", "-export", "-out", $outfile5,
             "-in", srctop_file(@path, "ee-cert.pem"), "-caname", "testname",


### PR DESCRIPTION
# Allow `openssl pkcs12 -export` to read key and certificate(s) in any order from `-in` file

Fixes #13825

## Problem

When creating a PKCS#12 file with `openssl pkcs12 -export -in <file> -passout ...` (i.e. without `-inkey`), the input file had to list the **private key before the certificate(s)**. If the file contained certificate(s) first and the key later (e.g. `cat cert.pem key.pem > combined.pem`), the command failed with "No private key found". Users had to either reorder the file or use `-inkey` pointing at a separate key file.

## Solution

The pkcs12 app now accepts key and certificate(s) in **any order** in the single `-in` file when `-inkey` is not used.

## Implementation

- **When `-inkey` is set:** Behavior is unchanged. The key is read from the `-inkey` file and certificates from the `-in` file via the existing `load_key()` and `load_certs()` calls.
- **When `-inkey` is not set:** Key and/or certificates are read from the `-in` file using `load_key_certs_crls()` where needed, which walks the file once and collects the requested items regardless of order. This matches the approach suggested in the issue (see [t8m's comment](https://github.com/openssl/openssl/issues/13825#issuecomment-798978589)).

The three cases without `-inkey` are handled explicitly:

1. **Key and certs:** One `load_key_certs_crls(infile, ..., &key, ..., &certs, ...)` call so both are loaded in any order.
2. **Key only** (e.g. `-nocerts`): `load_key_certs_crls(..., &key, ..., NULL, ...)` so the key can appear anywhere in the file.
3. **Certs only** (e.g. `-nokeys`): Still using `load_certs(infile, ...)` as before.

No new options or APIs; existing scripts that already use key-then-cert order continue to work. The man page already states that "The order of credentials in a file doesn't matter" for `-in` with `-export`; this change makes the implementation match that description.

## Documentation

- **CHANGES.md:** Added an entry under "Changes between 4.0 and 4.1" describing that `openssl pkcs12 -export` now accepts key and certificate(s) in any order in the `-in` file when `-inkey` is not used, and that previously the private key had to appear before the certificates.
- **Man page:** No change. `doc/man1/openssl-pkcs12.pod.in` already documents that the order of credentials in the file does not matter; no new options were added.

## Tests

- **test/recipes/80-test_pkcs12.t**
  - **Cert-then-key (key + certs):** Export using only `-in` with a file that has certificate(s) first, then the key (no `-inkey`). Asserts export succeeds and the resulting PKCS#12 can be imported. This case previously failed with "No private key found".
  - **Key-then-cert (key + certs):** Build a temporary file with key first, then cert(s), and run export with only `-in`. Asserts export and import succeed so the existing key-first order still works.
  - **Key-only with cert-then-key file (`-nocerts`):** Export with `-nocerts` and `-in` pointing at a file where the key appears after the certificate(s). Asserts export succeeds and the resulting PKCS#12 (key only) can be imported. Exercises the path where only the key is requested from `-in` and the key is not first in the file.
  - Test plan count updated to include the new subtests (8 new `ok()` calls; plan 66/71 for no_fips/fips).

##### Checklist

- [x] documentation is added or updated (CHANGES.md)
- [x] tests are added or updated (80-test_pkcs12.t)
