### PR TITLE
Fix coverity issue CID 1688667

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -1525,7 +1525,7 @@ static int do_body(X509 **xret, EVP_PKEY *pkey, X509 *x509,
         j = ASN1_PRINTABLE_type(ASN1_STRING_get0_data(str),
             ASN1_STRING_length(str));
         if ((type == V_ASN1_T61STRING && j != V_ASN1_T61STRING)
-            || (type == V_ASN1_IA5STRING && type == V_ASN1_PRINTABLESTRING)) {
+            || (type == V_ASN1_IA5STRING && j != V_ASN1_IA5STRING)) {
             BIO_puts(bio_err,
                 "\nThe string contains characters that are illegal for the"
                 " ASN.1 type\n");


### PR DESCRIPTION
Coverity complains with error impossible_and:
    The and condition type == 22 && type == 19
    can never be true because type cannot be equal
    to two different values at the same time.

Resolves: https://scan5.scan.coverity.com/#/project-view/62622/10222?selectedIssue=1688667

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
