### PR TITLE
evp: freeze SIGNATURE fetch cache and expand signature fetch tests

### DIFF
--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -157,6 +157,7 @@ struct evp_keyexch_st {
 
 struct evp_signature_st {
     int name_id;
+    int origin;
     char *type_name;
     const char *description;
     OSSL_PROVIDER *prov;
@@ -465,3 +466,4 @@ int evp_mac_fetch_all(OSSL_LIB_CTX *ctx);
 int evp_keymgmt_fetch_all(OSSL_LIB_CTX *ctx);
 int evp_kem_fetch_all(OSSL_LIB_CTX *ctx);
 int evp_asym_cipher_fetch_all(OSSL_LIB_CTX *ctx);
+int evp_signature_fetch_all(OSSL_LIB_CTX *ctx);

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -17,6 +17,7 @@
 #include "internal/cryptlib.h"
 #include "internal/provider.h"
 #include "internal/core.h"
+#include <string.h>
 #include "crypto/evp.h"
 #include "evp_local.h"
 
@@ -28,6 +29,54 @@ static void evp_signature_free(void *data)
 static int evp_signature_up_ref(void *data)
 {
     return EVP_SIGNATURE_up_ref(data);
+}
+
+static void evp_signature_free_int(EVP_SIGNATURE *signature)
+{
+    OPENSSL_free(signature->type_name);
+    ossl_provider_free(signature->prov);
+    CRYPTO_FREE_REF(&signature->refcnt);
+    OPENSSL_free(signature);
+}
+
+static void *evp_signature_dup_frozen(void *vin)
+{
+    EVP_SIGNATURE *in = vin;
+    EVP_SIGNATURE *out;
+
+    out = OPENSSL_malloc(sizeof(*out));
+    if (out == NULL)
+        return NULL;
+    memcpy(out, in, sizeof(*out));
+    if (!CRYPTO_NEW_REF(&out->refcnt, 1))
+        goto err;
+    out->type_name = OPENSSL_strdup(in->type_name);
+    if (out->type_name == NULL)
+        goto err;
+    out->origin = EVP_ORIG_FROZEN;
+    if (out->prov != NULL && !ossl_provider_up_ref(out->prov)) {
+        OPENSSL_free(out->type_name);
+        goto err;
+    }
+    return out;
+err:
+    CRYPTO_FREE_REF(&out->refcnt);
+    OPENSSL_free(out);
+    return NULL;
+}
+
+static void evp_signature_frozen_free(void *vin)
+{
+    EVP_SIGNATURE *signature = vin;
+    int i;
+
+    if (signature == NULL || signature->origin != EVP_ORIG_FROZEN)
+        return;
+
+    CRYPTO_DOWN_REF(&signature->refcnt, &i);
+    if (i > 0)
+        return;
+    evp_signature_free_int(signature);
 }
 
 static EVP_SIGNATURE *evp_signature_new(OSSL_PROVIDER *prov)
@@ -456,22 +505,20 @@ void EVP_SIGNATURE_free(EVP_SIGNATURE *signature)
 {
     int i;
 
-    if (signature == NULL)
+    if (signature == NULL || signature->origin != EVP_ORIG_DYNAMIC)
         return;
     CRYPTO_DOWN_REF(&signature->refcnt, &i);
     if (i > 0)
         return;
-    OPENSSL_free(signature->type_name);
-    ossl_provider_free(signature->prov);
-    CRYPTO_FREE_REF(&signature->refcnt);
-    OPENSSL_free(signature);
+    evp_signature_free_int(signature);
 }
 
 int EVP_SIGNATURE_up_ref(EVP_SIGNATURE *signature)
 {
     int ref = 0;
 
-    CRYPTO_UP_REF(&signature->refcnt, &ref);
+    if (signature->origin == EVP_ORIG_DYNAMIC)
+        CRYPTO_UP_REF(&signature->refcnt, &ref);
     return 1;
 }
 
@@ -486,7 +533,19 @@ EVP_SIGNATURE *EVP_SIGNATURE_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
     return evp_generic_fetch(ctx, OSSL_OP_SIGNATURE, algorithm, properties,
         evp_signature_from_algorithm,
         evp_signature_up_ref,
-        evp_signature_free, NULL, NULL);
+        evp_signature_free,
+        evp_signature_dup_frozen,
+        evp_signature_frozen_free);
+}
+
+int evp_signature_fetch_all(OSSL_LIB_CTX *ctx)
+{
+    return evp_generic_fetch_all(ctx, OSSL_OP_SIGNATURE,
+        evp_signature_from_algorithm,
+        evp_signature_up_ref,
+        evp_signature_free,
+        evp_signature_dup_frozen,
+        evp_signature_frozen_free);
 }
 
 EVP_SIGNATURE *evp_signature_fetch_from_prov(OSSL_PROVIDER *prov,
@@ -498,8 +557,8 @@ EVP_SIGNATURE *evp_signature_fetch_from_prov(OSSL_PROVIDER *prov,
         evp_signature_from_algorithm,
         evp_signature_up_ref,
         evp_signature_free,
-        NULL,
-        NULL);
+        evp_signature_dup_frozen,
+        evp_signature_frozen_free);
 }
 
 int EVP_SIGNATURE_is_a(const EVP_SIGNATURE *signature, const char *name)

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -1177,7 +1177,8 @@ int ossl_method_store_freeze_cache(OSSL_METHOD_STORE *store, const char *propq)
         || evp_keymgmt_fetch_all(store->ctx) <= 0
         || evp_kdf_fetch_all(store->ctx) <= 0
         || evp_kem_fetch_all(store->ctx) <= 0
-        || evp_asym_cipher_fetch_all(store->ctx) <= 0)
+        || evp_asym_cipher_fetch_all(store->ctx) <= 0
+        || evp_signature_fetch_all(store->ctx) <= 0)
         goto err;
 
     ossl_sa_ALGORITHM_doall_arg(store->algs, &alg_freeze, &af);

--- a/test/evp_fetch_prov_test.c
+++ b/test/evp_fetch_prov_test.c
@@ -641,6 +641,160 @@ static int test_explicit_EVP_KDF_fetch_by_name(void)
     return test_explicit_EVP_KDF_fetch("PBKDF2");
 }
 
+static int sign_verify(const EVP_SIGNATURE *signature,
+    OSSL_LIB_CTX *libctx, const char *propq)
+{
+    unsigned char tbs[] = "Hello world";
+    unsigned char md[SHA256_DIGEST_LENGTH];
+    size_t mdlen = 0;
+    EVP_PKEY *pkey = NULL;
+    EVP_PKEY_CTX *sctx = NULL, *vctx = NULL;
+    unsigned char *sig = NULL;
+    size_t siglen = 0;
+    int ret = 0;
+
+    if (!TEST_int_eq(EVP_Q_digest(libctx, "SHA256", propq, tbs, sizeof(tbs) - 1, md, &mdlen),
+            1)
+        || !TEST_ptr(pkey = EVP_PKEY_Q_keygen(libctx, propq, "RSA", (size_t)2048))
+        || !TEST_ptr(sctx = EVP_PKEY_CTX_new_from_pkey(libctx, pkey, propq))
+        || !TEST_int_gt(EVP_PKEY_sign_init_ex2(sctx, (EVP_SIGNATURE *)signature, NULL), 0)
+        || !TEST_int_gt(EVP_PKEY_sign(sctx, NULL, &siglen, md, mdlen), 0)
+        || !TEST_size_t_gt(siglen, 0))
+        goto err;
+
+    if (!TEST_ptr(sig = OPENSSL_zalloc(siglen))
+        || !TEST_int_eq(EVP_PKEY_sign(sctx, sig, &siglen, md, mdlen), 1)
+        || !TEST_ptr(vctx = EVP_PKEY_CTX_new_from_pkey(libctx, pkey, propq))
+        || !TEST_int_gt(EVP_PKEY_verify_init_ex2(vctx, (EVP_SIGNATURE *)signature, NULL), 0)
+        || !TEST_int_eq(EVP_PKEY_verify(vctx, sig, siglen, md, mdlen), 1))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_PKEY_CTX_free(vctx);
+    EVP_PKEY_CTX_free(sctx);
+    EVP_PKEY_free(pkey);
+    OPENSSL_free(sig);
+    return ret;
+}
+
+static int test_signature(OSSL_LIB_CTX *libctx, const char *propq,
+    const EVP_SIGNATURE *signature, const char *name)
+{
+    return TEST_ptr(signature)
+        && TEST_true(EVP_SIGNATURE_is_a(signature, name))
+        && TEST_true(sign_verify(signature, libctx, propq));
+}
+
+static int test_EVP_SIGNATURE_fetch_freeze(void)
+{
+#if defined(OPENSSL_NO_CACHED_FETCH)
+    /*
+     * Test does not make sense if cached fetch is disabled.
+     * There's nothing to freeze, and test will fail.
+     */
+    return 1;
+#endif
+
+    EVP_SIGNATURE *signature = NULL;
+    int ret = 0;
+    OSSL_LIB_CTX *ctx = NULL;
+    OSSL_PROVIDER *prov[2] = { NULL, NULL };
+
+    if (use_default_ctx == 0 && !load_providers(&ctx, prov))
+        goto err;
+
+    if (!TEST_ptr(signature = EVP_SIGNATURE_fetch(ctx, "RSA-SHA256", NULL))
+        || !TEST_true(test_signature(ctx, NULL, signature, "RSA-SHA256"))
+        || !TEST_int_ne(signature->origin, EVP_ORIG_FROZEN))
+        goto err;
+    EVP_SIGNATURE_free(signature);
+    signature = NULL;
+
+    if (!TEST_int_eq(OSSL_LIB_CTX_freeze(ctx, "?fips=true"), 1)
+        || !TEST_ptr(signature = EVP_SIGNATURE_fetch(ctx, "RSA-SHA256", NULL))
+        || !TEST_true(test_signature(ctx, NULL, signature, "RSA-SHA256"))
+        || !TEST_int_eq(signature->origin, EVP_ORIG_FROZEN))
+        goto err;
+    /* Technically, frozen version doesn't need to be freed */
+    EVP_SIGNATURE_free(signature);
+    signature = NULL;
+
+    if (!TEST_ptr(signature = EVP_SIGNATURE_fetch(ctx, "RSA-SHA256", "?fips=true"))
+        || !TEST_true(test_signature(ctx, "?fips=true", signature, "RSA-SHA256"))
+        || !TEST_int_eq(signature->origin, EVP_ORIG_FROZEN))
+        goto err;
+    EVP_SIGNATURE_free(signature);
+    signature = NULL;
+
+    /* Falls back to slow path */
+    if (!TEST_ptr(signature = EVP_SIGNATURE_fetch(ctx, "RSA-SHA256", "?provider=default"))
+        || !TEST_true(test_signature(ctx, "?provider=default", signature, "RSA-SHA256"))
+        || !TEST_int_ne(signature->origin, EVP_ORIG_FROZEN))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_SIGNATURE_free(signature);
+    unload_providers(&ctx, prov);
+    return ret;
+}
+
+static int test_implicit_EVP_SIGNATURE_fetch(void)
+{
+    OSSL_LIB_CTX *ctx = NULL;
+    OSSL_PROVIDER *prov[2] = { NULL, NULL };
+    EVP_SIGNATURE *signature = NULL;
+    int ret = 0;
+
+    if (use_default_ctx == 0 && !load_providers(&ctx, prov))
+        goto err;
+
+    if (!TEST_ptr(signature = EVP_SIGNATURE_fetch(ctx, "RSA-SHA256", NULL))
+        || !TEST_true(test_signature(ctx, NULL, signature, "RSA-SHA256")))
+        goto err;
+    ret = 1;
+err:
+    EVP_SIGNATURE_free(signature);
+    unload_providers(&ctx, prov);
+    return ret;
+}
+
+static int test_explicit_EVP_SIGNATURE_fetch(const char *id)
+{
+    OSSL_LIB_CTX *ctx = NULL;
+    EVP_SIGNATURE *signature = NULL;
+    OSSL_PROVIDER *prov[2] = { NULL, NULL };
+    int ret = 0;
+
+    if (use_default_ctx == 0 && !load_providers(&ctx, prov))
+        goto err;
+
+    signature = EVP_SIGNATURE_fetch(ctx, id, fetch_property);
+    if (expected_fetch_result != 0) {
+        if (!test_signature(ctx, fetch_property, signature, id))
+            goto err;
+
+        if (!TEST_true(EVP_SIGNATURE_up_ref(signature)))
+            goto err;
+        /* Ref count should now be 2. Release first one here */
+        EVP_SIGNATURE_free(signature);
+    } else {
+        if (!TEST_ptr_null(signature))
+            goto err;
+    }
+    ret = 1;
+err:
+    EVP_SIGNATURE_free(signature);
+    unload_providers(&ctx, prov);
+    return ret;
+}
+
+static int test_explicit_EVP_SIGNATURE_fetch_by_name(void)
+{
+    return test_explicit_EVP_SIGNATURE_fetch("RSA-SHA256");
+}
+
 /*
  * Test EVP_CIPHER_fetch()
  */
@@ -1561,6 +1715,10 @@ int setup_tests(void)
         ADD_TEST(test_EVP_ASYM_CIPHER_fetch_freeze);
         ADD_TEST(test_implicit_EVP_ASYM_CIPHER_fetch);
         ADD_TEST(test_explicit_EVP_ASYM_CIPHER_fetch_by_name);
+    } else if (strcmp(alg, "signature") == 0) {
+        ADD_TEST(test_EVP_SIGNATURE_fetch_freeze);
+        ADD_TEST(test_implicit_EVP_SIGNATURE_fetch);
+        ADD_TEST(test_explicit_EVP_SIGNATURE_fetch_by_name);
     } else {
         TEST_error("Unknown fetch type: %s", alg);
         return 0;

--- a/test/recipes/30-test_evp_fetch_prov.t
+++ b/test/recipes/30-test_evp_fetch_prov.t
@@ -21,7 +21,8 @@ use lib bldtop_dir('.');
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
-my @types = ( "digest", "cipher", "rand", "mac", "kmgmt", "kem", "kdf", "asymcipher" );
+my @types = ( "digest", "cipher", "rand", "mac", "kmgmt", "kem", "kdf", "asymcipher",
+              "signature" );
 
 my @testdata = (
     { config    => srctop_file("test", "default.cnf"),


### PR DESCRIPTION
Add frozen-method support for EVP_SIGNATURE fetches by wiring dup/free callbacks and populating SIGNATURE entries during OSSL_LIB_CTX_freeze().

Resolves https://github.com/openssl/project/issues/1836