### PR TITLE
test: Workarounds for QUIC multistream test

### DIFF
--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -930,9 +930,10 @@ int qtest_fault_prepend_frame(QTEST_FAULT *fault, const unsigned char *frame,
     old_len = fault->pplainio.buf_len;
 
     /* Extend the size of the packet by the size of the new frame */
-    if (!TEST_true(qtest_fault_resize_plain_packet(fault,
-            old_len + frame_len)))
+    if (!qtest_fault_resize_plain_packet(fault, old_len + frame_len)) {
+        TEST_info("Cannot extend packet (%zu + %zu)", old_len, frame_len);
         return 0;
+    }
 
     memmove(buf + frame_len, buf, old_len);
     memcpy(buf, frame, frame_len);

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -1098,7 +1098,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
             first = 0;
             offset = 0;
             op_start_time = ossl_time_now();
-            op_deadline = ossl_time_add(op_start_time, ossl_ms2time(60000));
+            op_deadline = ossl_time_add(op_start_time, ossl_ms2time(180000));
         }
 
         if (!TEST_int_le(ossl_time_compare(ossl_time_now(), op_deadline), 0)) {


### PR DESCRIPTION
I see regular failures of QUIC multistream test when running with HARNESS_JOBS (parallel run).

These two workarounds seems to decrerase these failures to acceptable level (I can actually reproduce the fail with almost 100% success rate on Windows):

- Increase timeout for worker. For some reason, the value is still not enough with some specific timings even with multicore CPU system
- Make packet extension failure not fatal. IMO there is no way to recover for test here.

The long-term solution would be to rewrite these tests.
For now, I think it is worth to apply these workarounds.