### PR TITLE
Fix OCSP_BASICRESP memory leak in ossl_get_ocsp_response()

### DIFF
--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -508,8 +508,8 @@ OCSP_RESPONSE *ossl_get_ocsp_response(SSL_CONNECTION *s, int chainidx)
              * happening because of test cases.
              */
             ERR_set_mark();
-            if (((bs = OCSP_response_get1_basic(resp)) != NULL)
-                && ((sr = OCSP_resp_get0(bs, 0)) != NULL)) {
+            bs = OCSP_response_get1_basic(resp);
+            if (bs != NULL && (sr = OCSP_resp_get0(bs, 0)) != NULL) {
                 /* use the first single response to get the algorithm used */
                 cid = (OCSP_CERTID *)OCSP_SINGLERESP_get0_id(sr);
 
@@ -565,6 +565,8 @@ OCSP_RESPONSE *ossl_get_ocsp_response(SSL_CONNECTION *s, int chainidx)
                  */
                 if (i == num)
                     resp = NULL;
+            } else {
+                OCSP_BASICRESP_free(bs);
             }
 
             /*


### PR DESCRIPTION
## Summary of the bug

In `ossl_get_ocsp_response()` (`ssl/statem/statem_srvr.c`), `OCSP_BASICRESP *bs` is allocated via `OCSP_response_get1_basic()` at line 511. The allocation and subsequent check are combined in a single `&&` condition:

```c
if (((bs = OCSP_response_get1_basic(resp)) != NULL)
    && ((sr = OCSP_resp_get0(bs, 0)) != NULL)) {
    // ... uses bs ...
    OCSP_BASICRESP_free(bs);   // line 560: only reachable inside this block
}
```

When the OCSP response contains zero `SingleResponse` entries, `OCSP_resp_get0(bs, 0)` returns `NULL`. C short-circuit evaluation skips the entire `if` block, so `OCSP_BASICRESP_free(bs)` is never called and `bs` is leaked.

### Trigger condition

A TLS server receives (via its OCSP stapling callback) an OCSP response that:
- Has `responseStatus = successful`
- Contains a valid `BasicOCSPResponse` with **zero** `SingleResponse` entries

This is an unusual but ASN.1-legal structure. Each TLS handshake with such a response leaks one `OCSP_BASICRESP` object (~80 bytes plus indirect allocations), enabling a remote denial-of-service via memory exhaustion against long-running TLS servers.

### Affected code

`ssl/statem/statem_srvr.c`, function `ossl_get_ocsp_response()`, lines 511-568.

Introduced in commit `b1b4b154fd` ("Add support for TLS 1.3 OCSP multi-stapling for server certs"), merged via PR #20945.

### Tested version

```
81cc6cb97ef83ad138eebd47129368b9e963e8cd
```

### Fix

Split the allocation out of the `&&` condition and add an `else` branch to free `bs` when `sr` is `NULL`:

```diff
-            if (((bs = OCSP_response_get1_basic(resp)) != NULL)
-                && ((sr = OCSP_resp_get0(bs, 0)) != NULL)) {
+            bs = OCSP_response_get1_basic(resp);
+            if (bs != NULL && (sr = OCSP_resp_get0(bs, 0)) != NULL) {
                 ...
                 if (i == num)
                     resp = NULL;
-            }
+            } else {
+                OCSP_BASICRESP_free(bs);
+            }
```

### Reproducer output

Built OpenSSL with ASan + LeakSanitizer, then ran the attached PoC:

```
[*] Crafted empty-single-response OCSP response: 419 bytes
[*] Starting TLS handshake ...
[+] Handshake succeeded.
[*] Done. With LeakSanitizer enabled, expect a heap leak report
    originating from ASN1_item_unpack <- OCSP_response_get1_basic
    <- ossl_get_ocsp_response in ssl/statem/statem_srvr.c

=================================================================
==1025449==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x744fcc8bf91f in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x744fcb9918bb in CRYPTO_malloc crypto/mem.c:214
    #2 0x744fcb99191e in CRYPTO_zalloc crypto/mem.c:226
    #3 0x744fcb6cc110 in asn1_item_embed_new crypto/asn1/tasn_new.c:135
    #4 0x744fcb6cbbb9 in ossl_asn1_item_ex_new_intern crypto/asn1/tasn_new.c:51
    #5 0x744fcb6c2462 in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:392
    #6 0x744fcb6c102e in asn1_item_ex_d2i_intern crypto/asn1/tasn_dec.c:143
    #7 0x744fcb6c1226 in ASN1_item_d2i_ex crypto/asn1/tasn_dec.c:169
    #8 0x744fcb6c1306 in ASN1_item_d2i crypto/asn1/tasn_dec.c:180
    #9 0x744fcb6b43e7 in ASN1_item_unpack crypto/asn1/asn_pack.c:60
    #10 0x744fcbab31ae in OCSP_response_get1_basic crypto/ocsp/ocsp_cl.c:128
    #11 0x744fcc6a849c in ossl_get_ocsp_response ssl/statem/statem_srvr.c:511
    ...

SUMMARY: AddressSanitizer: 1600+ byte(s) leaked in 8+ allocation(s).
```

After applying the fix and rebuilding, LeakSanitizer reports zero leaks.

### Steps to reproduce

1. Build OpenSSL with ASan:

```bash
./Configure enable-asan -g -O1 -fno-omit-frame-pointer
make -j$(nproc)
```

2. Build the PoC (from the OpenSSL source root):
[ocsp_leak_poc.c](https://github.com/user-attachments/files/26060460/ocsp_leak_poc.c)

```bash
gcc -g -O1 -fsanitize=address,leak -fno-omit-frame-pointer \
    -o ocsp_leak_poc ocsp_leak_poc.c \
    -I include -L . -lssl -lcrypto -Wl,-rpath,.
```

3. Run it:

```bash
TEST_CERTS_DIR=test/certs ASAN_OPTIONS=detect_leaks=1 ./ocsp_leak_poc
```

The PoC:
- Creates a signed `BasicOCSPResponse` with **zero** `SingleResponse` entries (calls `OCSP_basic_sign()` without calling `OCSP_basic_add1_status()`)
- Wraps it in an `OCSP_RESPONSE` with `responseStatus = successful`
- Sets up an in-memory TLS server/client pair with the server's OCSP stapling callback returning this crafted response
- Performs a TLS handshake, triggering `ossl_get_ocsp_response()` on the server side
- LeakSanitizer detects the leaked `OCSP_BASICRESP` on process exit
