### PR TITLE
Fix SSL_SESSION leak in tls_parse_ctos_psk() on ticket error paths

### DIFF
--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -1442,13 +1442,13 @@ int tls_parse_ctos_psk(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
 
             if (ret == SSL_TICKET_EMPTY) {
                 SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_BAD_EXTENSION);
-                return 0;
+                goto err;
             }
 
             if (ret == SSL_TICKET_FATAL_ERR_MALLOC
                 || ret == SSL_TICKET_FATAL_ERR_OTHER) {
                 SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-                return 0;
+                goto err;
             }
             if (ret == SSL_TICKET_NONE || ret == SSL_TICKET_NO_DECRYPT)
                 continue;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -9203,6 +9203,106 @@ end:
 }
 
 /*
+ * Callback that always returns ABORT for successfully decrypted tickets.
+ * Used by test_ticket_abort_session_leak to exercise the error path in
+ * tls_parse_ctos_psk() that previously leaked the SSL_SESSION.
+ */
+static SSL_TICKET_RETURN dec_tick_abort_cb(SSL *s, SSL_SESSION *ss,
+    const unsigned char *keyname,
+    size_t keyname_length,
+    SSL_TICKET_STATUS status,
+    void *arg)
+{
+    if (status == SSL_TICKET_SUCCESS || status == SSL_TICKET_SUCCESS_RENEW)
+        return SSL_TICKET_RETURN_ABORT;
+
+    return SSL_TICKET_RETURN_IGNORE_RENEW;
+}
+
+/*
+ * Test that returning SSL_TICKET_RETURN_ABORT from the decrypt ticket callback
+ * during TLS 1.3 resumption does not leak the SSL_SESSION allocated by
+ * tls_decrypt_ticket().  Before the fix, tls_parse_ctos_psk() would execute a
+ * bare "return 0" instead of "goto err", bypassing SSL_SESSION_free(sess).
+ * When run under LeakSanitizer the leaked session will be reported.
+ */
+static int test_ticket_abort_session_leak(void)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    SSL_SESSION *clntsess = NULL;
+    int testresult = 0;
+
+#ifdef OSSL_NO_USABLE_TLS1_3
+    return 1;
+#endif
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(),
+            TLS1_3_VERSION, TLS1_3_VERSION,
+            &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    if (!TEST_true(SSL_CTX_set_session_cache_mode(sctx, SSL_SESS_CACHE_OFF)))
+        goto end;
+
+    /* First handshake: use the normal gen/dec callbacks to get a ticket */
+    if (!TEST_true(SSL_CTX_set_session_ticket_cb(sctx, gen_tick_cb, dec_tick_cb,
+            NULL)))
+        goto end;
+
+    gen_tick_called = dec_tick_called = tick_key_cb_called = 0;
+    tick_dec_ret = SSL_TICKET_RETURN_USE_RENEW;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL))
+        || !TEST_true(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE)))
+        goto end;
+
+    clntsess = SSL_get1_session(clientssl);
+    if (!TEST_ptr(clntsess))
+        goto end;
+
+    SSL_shutdown(clientssl);
+    SSL_shutdown(serverssl);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    serverssl = clientssl = NULL;
+
+    /*
+     * Second handshake (resumption): switch to the abort callback.
+     * The server will decrypt the ticket, allocate an SSL_SESSION, then the
+     * callback returns ABORT.  The handshake must fail, and the session
+     * allocated inside tls_decrypt_ticket() must be freed (not leaked).
+     */
+    if (!TEST_true(SSL_CTX_set_session_ticket_cb(sctx, gen_tick_cb,
+            dec_tick_abort_cb, NULL)))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL))
+        || !TEST_true(SSL_set_session(clientssl, clntsess)))
+        goto end;
+
+    /* Resumption should fail because the callback aborts */
+    if (!TEST_false(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_SSL)))
+        goto end;
+
+    testresult = 1;
+
+end:
+    SSL_SESSION_free(clntsess);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+
+    return testresult;
+}
+
+/*
  * Test incorrect shutdown.
  * Test 0: client does not shutdown properly,
  *         server does not set SSL_OP_IGNORE_UNEXPECTED_EOF,
@@ -14519,6 +14619,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_ssl_pending, 2);
     ADD_ALL_TESTS(test_ssl_get_shared_ciphers, OSSL_NELEM(shared_ciphers_data));
     ADD_ALL_TESTS(test_ticket_callbacks, 20);
+    ADD_TEST(test_ticket_abort_session_leak);
     ADD_ALL_TESTS(test_shutdown, 7);
     ADD_TEST(test_async_shutdown);
     ADD_ALL_TESTS(test_ssl_bio_eof, 2);


### PR DESCRIPTION
## Summary of the bug

In `tls_parse_ctos_psk()` (`ssl/statem/extensions_srvr.c`), two early `return 0` statements (lines 1445 and 1451) bypass the `err:` label cleanup at line 1548-1549, which is responsible for calling `SSL_SESSION_free(sess)`.

When `tls_decrypt_ticket()` successfully decodes a TLS 1.3 session ticket into an `SSL_SESSION` but the registered `decrypt_ticket_cb` returns `SSL_TICKET_RETURN_ABORT`, `tls_decrypt_ticket()` sets `ret = SSL_TICKET_FATAL_ERR_OTHER` without freeing the allocated `SSL_SESSION`. Control returns to `tls_parse_ctos_psk()`, which hits:

```c
if (ret == SSL_TICKET_FATAL_ERR_MALLOC
    || ret == SSL_TICKET_FATAL_ERR_OTHER) {
    SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
    return 0;       // BUG: skips SSL_SESSION_free(sess) at err: label
}
```

The same pattern applies to the `SSL_TICKET_EMPTY` check just above it (line 1445).

Each resumption handshake that triggers this path leaks one `SSL_SESSION` object (~928 bytes of cryptographic keying material). Under sustained traffic this exhausts server memory.

## Affected code

In `ssl/statem/extensions_srvr.c`, function `tls_parse_ctos_psk()`:

```c
            ret = tls_decrypt_ticket(s, PACKET_data(&identity),
                PACKET_remaining(&identity), NULL, 0,
                &sess);                                    // line 1439: sess allocated

            if (ret == SSL_TICKET_EMPTY) {
                SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_BAD_EXTENSION);
                return 0;                                  // line 1445: skips cleanup
            }

            if (ret == SSL_TICKET_FATAL_ERR_MALLOC
                || ret == SSL_TICKET_FATAL_ERR_OTHER) {
                SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
                return 0;                                  // line 1451: skips cleanup
            }

            // ...

err:
    SSL_SESSION_free(sess);                                // line 1549: never reached
    return 0;
```

## Tested version

```
81cc6cb97ef83ad138eebd47129368b9e963e8cd
```

## Reproducer output

Built OpenSSL with ASan, then ran the attached PoC. LSan reports a leaked `SSL_SESSION`:

```
[*] Step 1: Initial handshake to obtain session ticket...
[+] Session ticket obtained (208 bytes)
[*] Step 2: Resumption handshake with abort callback (triggers leak)...
[cb] Ticket decrypted (ss=0x519000012780). Returning ABORT -> BUG:
    tls_parse_ctos_psk() will `return 0` bypassing SSL_SESSION_free()
[*] Done. Check LSAN output for leaked SSL_SESSION.

=================================================================
==1572956==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 928 byte(s) in 1 object(s) allocated from:
    #0 0x773a326bf91f in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x773a317918bb in CRYPTO_malloc crypto/mem.c:214
    #2 0x773a3179191e in CRYPTO_zalloc crypto/mem.c:226
    #3 0x773a3230a482 in SSL_SESSION_new ssl/ssl_sess.c:108
    #4 0x773a322ba723 in d2i_SSL_SESSION_ex ssl/ssl_asn1.c:280
    #5 0x773a32329606 in tls_decrypt_ticket ssl/t1_lib.c:3366
    #6 0x773a3246107d in tls_parse_ctos_psk ssl/statem/extensions_srvr.c:1439
    #7 0x773a32436a85 in tls_parse_extension ssl/statem/extensions.c:943
    #8 0x773a3230d198 in ssl_get_prev_session ssl/ssl_sess.c:603
    #9 0x773a324b0dab in tls_early_post_process_client_hello ssl/statem/statem_srvr.c:2016
    #10 0x773a324b406b in tls_post_process_client_hello ssl/statem/statem_srvr.c:2445
    #11 0x773a324ad485 in ossl_statem_server_post_process_message ssl/statem/statem_srvr.c:1471
    #12 0x773a3246b778 in read_state_machine ssl/statem/statem.c:730
    #13 0x773a3246a47b in state_machine ssl/statem/statem.c:483
    #14 0x773a324698c2 in ossl_statem_accept ssl/statem/statem.c:312
    #15 0x773a322f14bf in SSL_do_handshake ssl/ssl_lib.c:5191
    #16 0x773a322e1a3b in SSL_accept ssl/ssl_lib.c:2303
    #17 0x5bc568e8b6ec in drive_handshake poc_ssl_session_leak.c:82
    #18 0x5bc568e8c199 in main poc_ssl_session_leak.c:199

SUMMARY: AddressSanitizer: 928 byte(s) leaked in 1 allocation(s).
```

After applying the fix and rebuilding, LeakSanitizer reports zero leaks.

## Steps to reproduce

1. Build OpenSSL with ASan:

```bash
./Configure enable-asan -g -O1 -fno-omit-frame-pointer
make -j$(nproc)
```

2. Build the PoC (from the OpenSSL source root): [poc_ssl_session_leak.c](https://github.com/user-attachments/files/26062156/poc_ssl_session_leak.c)

```bash
gcc -g -O0 -fsanitize=address -fno-omit-frame-pointer \
    -o poc_ssl_session_leak poc_ssl_session_leak.c \
    -I include -L . -lssl -lcrypto -Wl,-rpath,.
```

3. Run it:

```bash
TEST_CERTS_DIR=test/certs ASAN_OPTIONS=detect_leaks=1 ./poc_ssl_session_leak
```

The PoC:
- Creates a TLS 1.3 server with a `decrypt_ticket_cb` that returns `SSL_TICKET_RETURN_ABORT` for successfully decrypted tickets
- Performs an initial handshake to obtain a `NewSessionTicket`
- Reconnects presenting the saved ticket in the ClientHello PSK extension
- The server's callback fires, `tls_parse_ctos_psk()` hits `return 0` bypassing `SSL_SESSION_free(sess)`
- LeakSanitizer detects the leaked `SSL_SESSION` on process exit

## Suggested fix

Replace the two bare `return 0` with `goto err` so that the existing cleanup at the `err:` label frees `sess`:

```diff
             if (ret == SSL_TICKET_EMPTY) {
                 SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_BAD_EXTENSION);
-                return 0;
+                goto err;
             }

             if (ret == SSL_TICKET_FATAL_ERR_MALLOC
                 || ret == SSL_TICKET_FATAL_ERR_OTHER) {
                 SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-                return 0;
+                goto err;
             }
```

The `err:` label already handles cleanup correctly:

```c
err:
    SSL_SESSION_free(sess);
    return 0;
```

When `sess` is `NULL` (e.g. `SSL_TICKET_EMPTY` case), `SSL_SESSION_free(NULL)` is a safe no-op.
