### PR TITLE
CMS_verify: tmpin BIO leak in SMIME_BINARY error path

### DIFF
--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -467,16 +467,16 @@ int CMS_verify(CMS_ContentInfo *cms, const STACK_OF(X509) *certs,
 
     ret = 1;
 err:
-    if (!(flags & SMIME_BINARY) && dcont) {
+    if (!(flags & SMIME_BINARY) && dcont != NULL) {
         do_free_upto(cmsbio, tmpout);
-        if (tmpin != dcont)
-            BIO_free(tmpin);
     } else {
-        if (dcont && (tmpin == dcont))
+        if (dcont != NULL && tmpin == dcont)
             do_free_upto(cmsbio, dcont);
         else
             BIO_free_all(cmsbio);
     }
+    if (tmpin != dcont)
+        BIO_free(tmpin);
 
     if (out != tmpout)
         BIO_free_all(tmpout);


### PR DESCRIPTION
## Summary of the bug

In `CMS_verify()` (`crypto/cms/cms_smime.c`), when all three conditions hold:

1. `dcont` is a non-NULL, non-empty `BIO_TYPE_MEM` BIO
2. The `CMS_BINARY` flag is set
3. `CMS_dataInit()` returns NULL (e.g. empty `digestAlgorithms` in SignedData)

the function allocates a new BIO via `BIO_new_mem_buf()` at line 412 (`tmpin != dcont`), then jumps to the `err:` label when `CMS_dataInit()` fails. The cleanup code in the `else` branch (BINARY path, lines 474-478) never frees `tmpin`:

```c
    } else {
        if (dcont && (tmpin == dcont))       // FALSE — tmpin is a new allocation
            do_free_upto(cmsbio, dcont);
        else
            BIO_free_all(cmsbio);            // cmsbio is NULL → no-op
        // tmpin is NEVER freed
    }
```

The non-BINARY branch (lines 470-473) handles this correctly:

```c
    if (!(flags & SMIME_BINARY) && dcont) {
        do_free_upto(cmsbio, tmpout);
        if (tmpin != dcont)
            BIO_free(tmpin);                 // ← correctly frees tmpin
    }
```

Each call leaks one BIO object (~128 bytes direct + indirect allocations). An attacker can craft a CMS SignedData with an empty `digestAlgorithms` SET (valid ASN.1, parses without error) and send it repeatedly to a server that calls `CMS_verify()` with `CMS_BINARY` and detached content, causing heap exhaustion.

## Affected code

`crypto/cms/cms_smime.c`, function `CMS_verify()`, lines 469-479.

This bug exists in mainline OpenSSL — it is not related to the OCSP multi-stapling feature.

## Tested version

```
81cc6cb97ef83ad138eebd47129368b9e963e8cd
```

## Reproducer output

Built OpenSSL with ASan, then ran the attached PoC (10 iterations):

```
=== CMS_verify() tmpin BIO Memory Leak PoC ===

[*] Generating RSA-2048 key + self-signed cert...
[*] Crafting malformed CMS (empty digestAlgorithms)...
[+] Malformed CMS DER ready (1164 bytes)
[*] Simulating server processing crafted CMS 10 times...

[iter 1] CMS_verify returned 0 (0=fail, tmpin BIO leaked at cms_smime.c:412)

=================================================================
==1704005==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 1280 byte(s) in 10 object(s) allocated from:
    #0 0x749fae0bf91f in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x749fad5918bb in CRYPTO_malloc crypto/mem.c:214
    #2 0x749fad59191e in CRYPTO_zalloc crypto/mem.c:226
    #3 0x749fad2ef367 in BIO_new_ex crypto/bio/bio_lib.c:83
    #4 0x749fad2ef5c8 in BIO_new crypto/bio/bio_lib.c:116
    #5 0x749fad3136c3 in BIO_new_mem_buf crypto/bio/bss_mem.c:94
    #6 0x749fad3c5ccc in CMS_verify crypto/cms/cms_smime.c:412
    #7 0x55fca9b092f9 in simulate_server_verify poc_cms_leak.c:222
    #8 0x55fca9b099fe in main poc_cms_leak.c:279

SUMMARY: AddressSanitizer: 2080 byte(s) leaked in 40 allocation(s).
```

After applying the fix, LeakSanitizer reports zero leaks.

## Steps to reproduce

1. Build OpenSSL with ASan:

```bash
./Configure enable-asan -g -O1 -fno-omit-frame-pointer
make -j$(nproc)
```

2. Build the PoC (from the OpenSSL source root): 
[poc_cms_leak.c](https://github.com/user-attachments/files/26063495/poc_cms_leak.c)


```bash
gcc -g -O0 -fsanitize=address \
    -I ./include -I . \
    -o poc_cms_leak poc_cms_leak.c \
    -L . -Wl,-rpath,. -lcrypto -lpthread -ldl
```

Note: `-I .` is needed because the PoC uses the internal header `crypto/cms/cms_local.h` to craft the malformed CMS payload. The victim-side code (`simulate_server_verify`) uses only the public API.

3. Run it:

```bash
ASAN_OPTIONS="detect_leaks=1:halt_on_error=0" ./poc_cms_leak
```

The PoC:
- Generates a self-signed RSA-2048 certificate
- Creates a valid CMS SignedData, then empties the `digestAlgorithms` SET
- Serializes to DER (also saved as `crafted_malformed.der`)
- Calls `CMS_verify()` with `CMS_BINARY` flag and detached content as a memory BIO, 10 times
- Each call leaks one BIO allocated at `cms_smime.c:412`

## Suggested fix

Add `BIO_free(tmpin)` in the `else` branch when `tmpin != dcont`, mirroring the non-BINARY branch:

```diff
     } else {
         if (dcont && (tmpin == dcont))
             do_free_upto(cmsbio, dcont);
-        else
+        else {
             BIO_free_all(cmsbio);
+            if (tmpin != dcont)
+                BIO_free(tmpin);
+        }
     }
```
