### PR TITLE
SLH-DSA: Fix Integer overflow in msg_encode leading to buffer overflow

### DIFF
--- a/crypto/slh_dsa/slh_dsa.c
+++ b/crypto/slh_dsa/slh_dsa.c
@@ -247,6 +247,8 @@ static uint8_t *msg_encode(const uint8_t *msg, size_t msg_len,
 
     /* Pure encoding */
     encoded_len = 1 + 1 + ctx_len + msg_len;
+    if (encoded_len < msg_len) /* Check for overflow */
+        return NULL;
     *out_len = encoded_len;
     if (encoded_len <= tmp_len) {
         encoded = tmp;
@@ -264,8 +266,8 @@ static uint8_t *msg_encode(const uint8_t *msg, size_t msg_len,
         if (encoded != tmp)
             OPENSSL_free(encoded);
         encoded = NULL;
+        WPACKET_cleanup(&pkt);
     }
-    WPACKET_cleanup(&pkt);
     return encoded;
 }
 


### PR DESCRIPTION
Reported by Zehua Qiao and me@snkth.com

An encode message buffer M = 00 || CXT_LEN || CTX || MSG was being allocated followed by memcpy's into the buffer for CTX and MSG. If len(MSG) was close to size_t the allocated buffer would be overwritten.

The fix uses WPACKET to perform the message encoding M = 00 || CXT_LEN || CTX || MSG

Although ML_DSA does a similiar operation, SLH-DSA has to buffer the encoding because the encoded message is processed multiple times for PRF_MSG and H_MSG. FOr ML_DSA the encoded message can just be hashed.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
