### PR TITLE
conf: guard NULL group in NCONF_get_string() error path

### DIFF
--- a/crypto/conf/conf_lib.c
+++ b/crypto/conf/conf_lib.c
@@ -314,7 +314,7 @@ char *NCONF_get_string(const CONF *conf, const char *group, const char *name)
         return NULL;
     }
     ERR_raise_data(ERR_LIB_CONF, CONF_R_NO_VALUE,
-        "group=%s name=%s", group, name);
+        "group=%s name=%s", group != NULL ? group : "", name);
     return NULL;
 }
 


### PR DESCRIPTION
`NCONF_get_string()` passes the `group` parameter directly to `ERR_raise_data()` with a `%s` format specifier on the error path (line 317 of `crypto/conf/conf_lib.c`).

The CONF API explicitly allows `group` to be NULL — it means "default section" — and multiple internal callers rely on this (`conf_diagnostics()`, `CONF_modules_load()`, app code like `ca.c`, `req.c`, etc.).

When the lookup fails, the NULL gets passed to `%s` which is undefined behavior per the C standard. On Linux/glibc this happens to print "(null)", but on Solaris 10 Sparc it crashes in `strlen()` inside the platform `vsnprintf()`. This was exposed after the custom `_dopr()` (which had a NULL guard for `%s` in `fmtstr()`) was replaced with the native `vsnprintf()`.

The fix guards the NULL at the point where the format string is constructed, keeping the CONF API semantics intact. An empty string is used for the missing group to maintain useful diagnostic output.

Fixes #30402

##### Checklist
- [ ] documentation is added or updated
- [ ] tests are added or updated