### PR TITLE
s_client: sbio BIO leak in QUIC reconnect path

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2511,6 +2511,8 @@ re_start:
         sbio = BIO_new_dgram(sock, BIO_NOCLOSE);
         if (!SSL_set1_initial_peer_addr(con, peer_addr)) {
             BIO_puts(bio_err, "Failed to set the initial peer address\n");
+            BIO_free(sbio);
+            sbio = NULL;
             goto shut;
         }
     } else


### PR DESCRIPTION
## Summary of the bug

In `s_client_main()` (`apps/s_client.c`), the QUIC code path allocates a BIO via `BIO_new_dgram()` at line 2511 but does not free it when the immediately following `SSL_set1_initial_peer_addr()` call fails and jumps to `shut:`.

```c
#ifndef OPENSSL_NO_QUIC
    if (isquic) {
        sbio = BIO_new_dgram(sock, BIO_NOCLOSE);   // allocated here
        if (!SSL_set1_initial_peer_addr(con, peer_addr)) {
            BIO_puts(bio_err, "Failed to set the initial peer address\n");
            goto shut;   // ← sbio leaked: not freed, not transferred to SSL
        }
    } else
#endif
```

`SSL_set_bio(con, sbio, sbio)` at line 2570 (which would transfer ownership to `con`) is never reached, so the subsequent `SSL_free(con)` at cleanup does not release `sbio` either.

The analogous DTLS path correctly calls `BIO_free(sbio)` before each early `goto` (lines 2494 and 2500), establishing the pattern that the QUIC path omits.

This is triggered during `-reconnect`: the first QUIC handshake succeeds (setting `qc->started = 1`), then on reconnect `SSL_set1_initial_peer_addr()` rejects the call because the connection was already started, hitting the leak path.

## Affected code

`apps/s_client.c`, function `s_client_main()`, lines 2511–2514.

This affects the `openssl s_client` CLI tool, not the library itself.

## Tested version

```
81cc6cb97ef83ad138eebd47129368b9e963e8cd
```

## Reproducer output

Built OpenSSL with ASan, started a QUIC server using `demos/quic/server/server.c`, then ran s_client with `-quic -reconnect`:

```
$ ASAN_OPTIONS=detect_leaks=1 LD_PRELOAD=$(gcc --print-file-name=libasan.so) \
    LD_LIBRARY_PATH=. ./apps/openssl s_client -quic -connect 127.0.0.1:4433 -reconnect -alpn ossltest

Connecting to 127.0.0.1
CONNECTED(00000003)
[... first handshake succeeds ...]
Connecting to 127.0.0.1
Failed to set the initial peer address

=================================================================
==2712152==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 128 byte(s) in 1 object(s) allocated from:
    #0 0x7f21692bf91f in __interceptor_malloc
    #1 0x7f21683918bb in CRYPTO_malloc crypto/mem.c:214
    #2 0x7f216839191e in CRYPTO_zalloc crypto/mem.c:226
    #3 0x7f21680ef367 in BIO_new_ex crypto/bio/bio_lib.c:83
    #4 0x7f21680ef5c8 in BIO_new crypto/bio/bio_lib.c:116
    #5 0x7f2168104d54 in BIO_new_dgram crypto/bio/bss_dgram.c:266
    #6 0x55f13472ce0c in s_client_main apps/s_client.c:2511

Indirect leak of 264 byte(s) in 1 object(s) allocated from:
    #0 0x7f21692bf91f in __interceptor_malloc
    #1 0x7f21683918bb in CRYPTO_malloc crypto/mem.c:214
    #2 0x7f216839191e in CRYPTO_zalloc crypto/mem.c:226
    #3 0x7f2168104daf in dgram_new crypto/bio/bss_dgram.c:275
    #4 0x7f21680ef4a0 in BIO_new_ex crypto/bio/bio_lib.c:98
    #5 0x7f21680ef5c8 in BIO_new crypto/bio/bio_lib.c:116
    #6 0x7f2168104d54 in BIO_new_dgram crypto/bio/bss_dgram.c:266
    #7 0x55f13472ce0c in s_client_main apps/s_client.c:2511

SUMMARY: AddressSanitizer: 392 byte(s) leaked in 2 allocation(s).
```

After applying the fix, LeakSanitizer reports zero leaks.

## Steps to reproduce

1. Build OpenSSL with ASan and QUIC support:

```bash
./Configure enable-asan -g -O0 -fno-omit-frame-pointer --debug
make -j$(nproc)
```

2. Build the QUIC server demo:

```bash
gcc -g -O0 -I./include demos/quic/server/server.c \
    -L. -Wl,-rpath,. -lssl -lcrypto -o quic_server
```

3. Generate a test certificate:

```bash
LD_LIBRARY_PATH=. ./apps/openssl req -x509 -newkey rsa:2048 \
    -keyout key.pem -out cert.pem -days 1 -nodes -subj '/CN=localhost'
```

4. Start the QUIC server:

```bash
LD_PRELOAD=$(gcc --print-file-name=libasan.so) \
    LD_LIBRARY_PATH=. ./quic_server 4433 cert.pem key.pem
```

5. Run s_client with QUIC and reconnect:

```bash
ASAN_OPTIONS=detect_leaks=1 \
    LD_PRELOAD=$(gcc --print-file-name=libasan.so) \
    LD_LIBRARY_PATH=. ./apps/openssl s_client \
    -quic -connect 127.0.0.1:4433 -reconnect -alpn ossltest
```

The first handshake succeeds, then reconnect triggers `SSL_set1_initial_peer_addr()` failure (because `qc->started == 1`), leaking the `sbio` BIO.

**Note:** LeakSanitizer may not report the leak on every run. The leaked `sbio` pointer remains on the stack as a local variable, and LSAN's stack scanning may classify it as "reachable" rather than "leaked". The leak is deterministic in the code path (no `BIO_free(sbio)` is ever called), but LSAN detection depends on stack/register state at exit. If LSAN does not report, you can verify by inspecting the code: `BIO_new_dgram()` at line 2511 allocates `sbio`, the `goto shut` at line 2514 skips `SSL_set_bio()` (line 2570), and neither `shut:` nor `end:` frees `sbio`.

## Suggested fix

Add `BIO_free(sbio); sbio = NULL;` before `goto shut`, matching the DTLS path discipline:

```diff
     if (!SSL_set1_initial_peer_addr(con, peer_addr)) {
         BIO_puts(bio_err, "Failed to set the initial peer address\n");
+        BIO_free(sbio);
+        sbio = NULL;
         goto shut;
     }
```
