### PR TITLE
quic: fix NULL pointer dereference in ossl_uint_set_remove()

### DIFF
--- a/ssl/quic/uint_set.c
+++ b/ssl/quic/uint_set.c
@@ -303,6 +303,8 @@ int ossl_uint_set_remove(UINT_SET *s, const UINT_RANGE *range)
              * handled by the above cases.
              */
             y = create_set_item(end + 1, z->range.end);
+            if (y == NULL)
+                return 0;
             ossl_list_uint_set_insert_after(s, z, y);
             z->range.end = start - 1;
             break;


### PR DESCRIPTION

In the range-splitting branch of `ossl_uint_set_remove()`,
`create_set_item()` can return NULL under memory pressure. The returned
pointer was passed directly to `ossl_list_uint_set_insert_after()`
without a NULL check.

The list insertion macro in `include/internal/list.h` dereferences the
element unconditionally, so a failed allocation leads to an immediate
NULL pointer dereference. This code path is exercised during normal QUIC
ACK range processing — any connection handling acknowledgements under
memory pressure can trigger the crash.

This patch adds a NULL check before the list insertion and returns 0 on
allocation failure, consistent with the existing error return at the top
of the function. On failure the set is left unchanged, since
`z->range.end` is only modified after the insertion succeeds.

- [x] Checked that `ossl_uint_set_insert()` already handles
  `create_set_item()` failure the same way (returns 0)