### PR TITLE
Improve bad FFC parameters error messages with L, N arguments

### DIFF
--- a/crypto/ffc/ffc_params_generate.c
+++ b/crypto/ffc/ffc_params_generate.c
@@ -46,7 +46,8 @@ static int ffc_validate_LN(size_t L, size_t N, int type, int verify)
         if (L == 2048 && (N == 224 || N == 256))
             return 112;
 #ifndef OPENSSL_NO_DH
-        ERR_raise(ERR_LIB_DH, DH_R_BAD_FFC_PARAMETERS);
+        ERR_raise_data(ERR_LIB_DH, DH_R_BAD_FFC_PARAMETERS,
+            "(L, N)=(%zu, %zu) should be (2048, 224) or (2048, 256)", L, N);
 #endif
     } else if (type == FFC_PARAM_TYPE_DSA) {
         /* Valid DSA L,N parameters from FIPS 186-4 Section 4.2 */
@@ -58,7 +59,10 @@ static int ffc_validate_LN(size_t L, size_t N, int type, int verify)
         if (L == 3072 && N == 256)
             return 128;
 #ifndef OPENSSL_NO_DSA
-        ERR_raise(ERR_LIB_DSA, DSA_R_BAD_FFC_PARAMETERS);
+        ERR_raise_data(ERR_LIB_DSA, DSA_R_BAD_FFC_PARAMETERS,
+            "(L, N)=(%zu, %zu) should be (1024, 160) (for verification only), "
+            "(2048, 224), (2048, 256), or (3072, 256)",
+            L, N);
 #endif
     }
     return 0;
@@ -74,7 +78,10 @@ static int ffc_validate_LN(size_t L, size_t N, int type, int verify)
         if (L == 2048 && (N == 224 || N == 256))
             return 112;
 #ifndef OPENSSL_NO_DH
-        ERR_raise(ERR_LIB_DH, DH_R_BAD_FFC_PARAMETERS);
+        ERR_raise_data(ERR_LIB_DH, DH_R_BAD_FFC_PARAMETERS,
+            "(L, N)=(%zu, %zu) should be (1024, 160), (2048, 224), or "
+            "(2048, 256)",
+            L, N);
 #endif
     } else if (type == FFC_PARAM_TYPE_DSA) {
         if (L >= 3072 && N >= 256)
@@ -84,7 +91,8 @@ static int ffc_validate_LN(size_t L, size_t N, int type, int verify)
         if (L >= 1024 && N >= 160)
             return 80;
 #ifndef OPENSSL_NO_DSA
-        ERR_raise(ERR_LIB_DSA, DSA_R_BAD_FFC_PARAMETERS);
+        ERR_raise_data(ERR_LIB_DSA, DSA_R_BAD_FFC_PARAMETERS,
+            "(L, N)=(%zu, %zu) should be at least (1024, 160)", L, N);
 #endif
     }
     return 0;


### PR DESCRIPTION
Improve the finite field cryptography (FFC) messages with L, N arguments.

Fixes #17108

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

---

This PR fixes https://github.com/openssl/openssl/issues/17108. I prepared the following repository to show how I tested, and the reproducing commands.

https://github.com/junaruga/report-openssl-improve-ffc-params-error-messages

## How I implemented

I referred to the following part, "is %zu, should be at least %zu" for the changed error message formats in this PR.

https://github.com/openssl/openssl/blob/e1eb88118a95445eb9c2d074c853776feaab4de7/crypto/slh_dsa/slh_dsa.c#L73-L74

## How I tested

The changes are 4 parts = (DH, DSA) x (FIPS, non-FIPS).

Testing DH, DSA non-FIPS FFC parameters error messages

```
$ $OPENSSL_DIR/bin/openssl genpkey -genparam -algorithm DHX \
  -pkeyopt pbits:512 -pkeyopt qbits:160 -pkeyopt dh_paramgen_type:2
genpkey: Generating DHX key parameters failed
40579372397F0000:error:0280007F:Diffie-Hellman routines:ffc_validate_LN:bad ffc parameters:crypto/ffc/ffc_params_generate.c:80:(L, N)=(512, 160) should be (1024, 160), (2048, 224) or (2048, 256)

$ $OPENSSL_DIR/bin/openssl dsaparam -genkey 512
-----BEGIN DSA PARAMETERS-----
MIGlAkEA71d52v5vxskYtZHXhaGVOxTRjCkpq6NNAoblN8tq1m1641Raee8Q0peL
ya7enZHY/2QVGfXXLn2rW3ctyUfz+wIdAK5nkupa0Si5W+JNQRt9FAzNjiX5scYS
jSs7ETUCQQCXwjN/nq8Mayg1bUfCcvUN41GvCSpgO38eehHJim0O294TBfz8q3Ir
S3g5riL1WQgc4bPQfNEMO9rT7aXn3oMx
-----END DSA PARAMETERS-----
dsaparam: Error generating DSA key
4057CB4F337F0000:error:05000072:dsa routines:ffc_validate_LN:bad ffc parameters:crypto/ffc/ffc_params_generate.c:92:(L, N)=(512, 224) should be at least (1024, 160)
```

Testing DH, DSA FIPS FFC parameters error messages

```
$ OPENSSL_CONF=$OPENSSL_DIR/ssl/openssl_fips.cnf \
  $OPENSSL_DIR/bin/openssl genpkey -genparam -algorithm DHX \
  -pkeyopt pbits:512 -pkeyopt qbits:160 -pkeyopt dh_paramgen_type:2
genpkey: Generating DHX key parameters failed
40876AB9C07F0000:error:0280007F:Diffie-Hellman routines:ffc_validate_LN:bad ffc parameters:crypto/ffc/ffc_params_generate.c:49:(L, N)=(512, 160) should be (2048, 224) or (2048, 256)

$ OPENSSL_CONF=$OPENSSL_DIR/ssl/openssl_fips.cnf \
  $OPENSSL_DIR/bin/openssl genpkey -genparam -algorithm DSA \
  -pkeyopt pbits:2048 -pkeyopt qbits:220
genpkey: Generating DSA key parameters failed
40B7840EDF7F0000:error:030000E9:digital envelope routines:evp_keymgmt_gen:provider keymgmt failure:crypto/evp/keymgmt_meth.c:468:DSA key generation:OpenSSL DSA implementation
```

I couldn't find the reproducing `openssl` command to show the ffc parameters error message in DSA FIPS case. It seems that the following error happens at the following part earlier than the FFC parameter check. Could you tell me how to test, or perhaps remove this FFC parameters error messaging logic in DSA FIPS case?

https://github.com/openssl/openssl/blob/e1eb88118a95445eb9c2d074c853776feaab4de7/providers/implementations/keymgmt/dsa_kmgmt.c#L627-L630

## Hard coded numbers

Right now, numbers such as `2048`, `224`, `256` are hard-coded in this PR's changes, because existing numbers are hard-coded. Do you like using macro definitions for the numbers? If we use them, here is a suggestion. I want to hear your opinions.

./include/internal/ffc.h

```
#define FFC_PARAM_FIPS_DH_L_2048 2048
#define FFC_PARAM_FIPS_DH_N_224 224
#define FFC_PARAM_FIPS_DH_N_256 256
#define FFC_PARAM_FIPS_DSA_L_1024 1024
...
#define FFC_PARAM_NO_FIPS_DH_L_1024 1024
#define FFC_PARAM_NO_FIPS_DH_N_160 160
...
```

## Other things

I checked the coding style passed for my change.

```
$ clang-format crypto/ffc/ffc_params_generate.c
```

I confirmed the tests passed on relatively latest e1eb88118a95445eb9c2d074c853776feaab4de7. After I confirmed the tests passed, I rebasd this PR on the latest master branch.

```
$ make test
```

I submitted CLA forum, and signed.

Please let me know what you think.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
