### PR TITLE
ISSUE-30487: dtlsserver fuzzer crash due use-after free

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,16 +70,12 @@ OpenSSL Releases
 
    *William McCormack*
 
-### Changes between 3.6 and 4.0 [xx XXX xxxx]
+ * Fixed a use-after-free in DTLS when the read record layer was replaced (e.g.
+   at ChangeCipherSpec). Unprocessed records are now released through the old
+   record layer before it is freed, so the next read does not use descriptors
+   pointing into freed memory.
 
- * Added support for RFC 8701 GREASE (Generate Random Extensions And Sustain
-   Extensibility). When `SSL_OP_GREASE` is set, the TLS client injects
-   reserved GREASE values into cipher suites, supported versions, supported
-   groups, signature algorithms, key share, and extensions in the ClientHello
-   to prevent ecosystem ossification. The `openssl s_client` command gains a
-   `-grease` option to enable this.
-
-   *William McCormack*
+   *John Claus*
 
 ### Changes between 3.6 and 4.0 [xx XXX xxxx]
 

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -24,6 +24,12 @@
 #include "internal/comp.h"
 #include "internal/ssl_unwrap.h"
 
+#define RECORD_LAYER_reset_read_state(rl) \
+    do {                                  \
+        (rl)->curr_rec = 0;               \
+        (rl)->num_recs = 0;               \
+    } while (0)
+
 void RECORD_LAYER_init(RECORD_LAYER *rl, SSL_CONNECTION *s)
 {
     rl->s = s;
@@ -1459,6 +1465,21 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
     if (!SSL_CONNECTION_IS_DTLS(s)
         || direction == OSSL_RECORD_DIRECTION_READ
         || pqueue_peek(s->d1->sent_messages) == NULL) {
+        if (SSL_CONNECTION_IS_DTLS(s) && direction == OSSL_RECORD_DIRECTION_READ) {
+            /*
+             * Release any unprocessed records through the old layer before we
+             * free it. Otherwise the next read would use descriptors pointing
+             * into the old layer's freed buffer (use-after-free).
+             */
+            while (s->rlayer.curr_rec < s->rlayer.num_recs) {
+                TLS_RECORD *rr = &s->rlayer.tlsrecs[s->rlayer.curr_rec];
+
+                if (!ssl_release_record(s, rr, 0)) {
+                    /* SSLfatal already called */
+                    return 0;
+                }
+            }
+        }
         if (*thismethod != NULL && !(*thismethod)->free(*thisrl)) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
             return 0;
@@ -1467,6 +1488,13 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
 
     *thisrl = newrl;
     *thismethod = meth;
+
+    /*
+     * When replacing the read record layer, reset read state so the next
+     * read fetches from the new layer.
+     */
+    if (direction == OSSL_RECORD_DIRECTION_READ)
+        RECORD_LAYER_reset_read_state(&s->rlayer);
 
     return ssl_post_record_layer_select(s, direction);
 }

--- a/test/recipes/99-test_fuzz_dtlsserver.t
+++ b/test/recipes/99-test_fuzz_dtlsserver.t
@@ -18,6 +18,8 @@ setup("test_fuzz_${fuzzer}");
 plan skip_all => "This test requires dtls support"
     if disabled("dtls");
 
+# Running the dtlsserver corpus with ASan also guards against use-after-free
+# when the read record layer is replaced at ChangeCipherSpec (issue #30487).
 plan tests => 2; # one more due to below require_ok(...)
 
 require_ok(srctop_file('test','recipes','fuzz.pl'));


### PR DESCRIPTION
## Problem

oss-fuzz reported a **heap use-after-free** in the dtlsserver fuzzer (AddressSanitizer), triggered when the server processed certain DTLS handshake sequences. The crash was a regression introduced by the changes around PR #30225 (e.g. deferred record-size checks and DTLS CCS buffering for reorder tolerance).

**Crash summary:**

- **Use:** `dtls1_read_bytes` in `ssl/record/rec_layer_d1.c` (line 348) performed a `memcpy(buf, &(rr->data[rr->off]), n)`. The pointer `rr` is `s->rlayer.tlsrecs[s->rlayer.curr_rec]`, and `rr->data` points into the **current read record layer’s** buffer.
- **Free:** While processing a received ChangeCipherSpec, the stack `tls_process_change_cipher_spec` → `tls1_change_cipher_state` → `ssl_set_new_record_layer(..., OSSL_RECORD_DIRECTION_READ, ...)` **freed the old read record layer** (and its read buffer) and installed a new one.
- **Bug:** The connection’s read state (`s->rlayer.curr_rec` and `s->rlayer.num_recs`) was **not** updated. On the next call into `dtls1_read_bytes`, the code still had `curr_rec < num_recs`, so it reused the same `rr` from `tlsrecs[]`. That `rr->data` still pointed into the **freed** buffer, leading to use-after-free when copying out payload.

So the issue was: after replacing the read record layer, we freed the old layer’s buffer but left `RECORD_LAYER`’s read state (and thus `tlsrecs[]` descriptors) referring to that buffer.

## Solution

When we replace the **read** record layer in `ssl_set_new_record_layer` (e.g. at ChangeCipherSpec), we **release any unprocessed records through the old layer before freeing it**, then reset read state so the next read uses the new layer:

- **Before** calling `(*thismethod)->free(*thisrl)` (and only when `SSL_CONNECTION_IS_DTLS(s)` and `direction == OSSL_RECORD_DIRECTION_READ`): loop over `s->rlayer.curr_rec` to `s->rlayer.num_recs` and call `ssl_release_record(s, rr, 0)` for each `TLS_RECORD` in `tlsrecs[]`. This releases those records through the **old** read record layer, which still owns their buffers and rechandles.
- **After** assigning the new `*thisrl` and `*thismethod`: set `s->rlayer.curr_rec = 0` and `s->rlayer.num_recs = 0` when `direction == OSSL_RECORD_DIRECTION_READ` so the next read path fetches from the new layer.

**Why this approach:**

- **Proper teardown:** Releasing unprocessed records via the old layer’s `release_record` before freeing the layer ensures buffers and rechandles are cleaned up through the correct implementation, rather than leaving descriptors that point into memory that is about to be freed.
- **Correct by construction:** After the release loop and free, the next call into `dtls1_read_bytes` sees `curr_rec >= num_recs` (or equivalent after the reset), so it calls `get_more_records` and pulls fresh records from the **new** read record layer. No code path continues to use `tlsrecs[]` entries that point at the old, freed buffer.
- **Read direction only:** We only release and reset when replacing the **read** record layer. Replacing the write layer does not leave dangling read descriptors, so no change is needed there.

This approach follows the feedback from the issue (mattcaswell’s tentative fix and tlhc’s question). In-code comments in `ssl/record/rec_layer_s3.c` document the release loop and the reset.

## Tests

- **No new standalone regression test.** The existing **`test_fuzz_dtlsserver`** already runs the dtlsserver fuzz corpus; with this fix, that test passes under ASan. CI therefore acts as the regression test for this bug.
- A short **comment** was added in `test/recipes/99-test_fuzz_dtlsserver.t` stating that running the dtlsserver corpus with ASan also guards against the use-after-free from issue #30487.
- Verification performed:
  - Configure and build with `enable-asan`, then run `make test TESTS=test_fuzz_dtlsserver` (passes).
  - Run `make test TESTS=test_dtls` and `make test TESTS=test_dtls_ccs_reorder` (both pass).

## Documentation

- **CHANGES.md:** Under “Changes between 4.0 and 4.1”, added a bullet describing the fix: DTLS use-after-free when the read record layer was replaced (e.g. at ChangeCipherSpec); unprocessed records are now released through the old record layer before it is freed, so the next read does not use descriptors pointing into freed memory (**issue #30487**).
- **Code comments:** In `ssl_set_new_record_layer` in `ssl/record/rec_layer_s3.c`, added a comment above the release loop (release any unprocessed records through the old layer before we free it to avoid use-after-free) and a short comment above the reset (when replacing the read record layer, reset read state so the next read fetches from the new layer).

## Files changed

| File | Change |
|------|--------|
| `ssl/record/rec_layer_s3.c` | When freeing the old read record layer (DTLS, read direction), release any unprocessed records via `ssl_release_record(s, rr, 0)` in a loop before calling `(*thismethod)->free(*thisrl)`. After assigning the new layer, reset `s->rlayer.curr_rec` and `s->rlayer.num_recs` when `direction == OSSL_RECORD_DIRECTION_READ`. In-code comments document both steps. |
| `CHANGES.md` | New bullet in 4.0→4.1 section: unprocessed records are now released through the old record layer before it is freed (issue #30487). |
| `test/recipes/99-test_fuzz_dtlsserver.t` | Comment that the dtlsserver fuzz test (with ASan) guards against this use-after-free. |
