### PR TITLE
ISSUE-28110: find-doc-nits; check env vars in .t and .pl files

### DIFF
--- a/doc/HOWTO/documenting-functions-and-macros.md
+++ b/doc/HOWTO/documenting-functions-and-macros.md
@@ -175,6 +175,20 @@ can be utilized to check for this. A completely new documentation file
 should also contain a HISTORY section with wording along this line, e.g.
 "These functions have been added in OpenSSL version xxx.".
 
+The option -a checks for undocumented environment variables by scanning
+C (.c, .in) and Perl (.t, .pl) source files; variables intended for end users
+must be documented in the appropriate manual (e.g. `openssl-env(7)`).
+
+Two external files control which names are excluded from that check:
+
+* `util/env-ignore.txt` – system, platform, and third-party variables
+  (e.g. `LANG`, `LC_ALL`, `ASAN_OPTIONS`) that are never OpenSSL-specific
+  and will never need OpenSSL documentation.
+* `util/missingenv.txt` – internal OpenSSL variables (test harness, release
+  tooling, build infrastructure) that are not yet formally documented.
+  Each entry carries a brief description; when a variable is documented
+  (in `doc/internal`, `CONTRIBUTING.md`, etc.), remove it from this file.
+
 Summary
 -------
 

--- a/doc/HOWTO/documenting-functions-and-macros.md
+++ b/doc/HOWTO/documenting-functions-and-macros.md
@@ -175,6 +175,20 @@ can be utilized to check for this. A completely new documentation file
 should also contain a HISTORY section with wording along this line, e.g.
 "These functions have been added in OpenSSL version xxx.".
 
+The option `-a` checks for undocumented environment variables by scanning
+C (.c, .in) and Perl (.t, .pl) source files; variables intended for end users
+must be documented in the appropriate manual (e.g. `openssl-env(7)`).
+
+Two external files control which names are excluded from that check:
+
+* `util/env-ignore.txt` - system, platform, and third-party variables
+  (e.g. `LANG`, `LC_ALL`, `ASAN_OPTIONS`) that are never OpenSSL-specific
+  and will never need OpenSSL documentation.
+* `util/missingenv.txt` - internal OpenSSL variables (test harness, release
+  tooling, build infrastructure) that are not yet formally documented.
+  Each entry carries a brief description; when a variable is documented
+  (in `doc/internal`, `CONTRIBUTING.md`, etc.), remove it from this file.
+
 Summary
 -------
 

--- a/test/recipes/80-test_find_doc_nits.t
+++ b/test/recipes/80-test_find_doc_nits.t
@@ -1,0 +1,40 @@
+#! /usr/bin/env perl
+#
+# Copyright 2025-2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use OpenSSL::Test qw/:DEFAULT bldtop_dir srctop_file indir cmd run/;
+
+setup("test_find_doc_nits");
+
+plan tests => 4;
+
+my $script = srctop_file("util", "find-doc-nits");
+open my $sfh, '<', $script or die "open $script: $!";
+my $find_doc_nits_src = do { local $/; <$sfh> };
+close $sfh;
+
+ok($find_doc_nits_src =~ /push \@env_files.*\.(?:c|in|t|pl)\$/s,
+   "find-doc-nits collects .t and .pl files for environment variable scan");
+
+ok($find_doc_nits_src =~ /env-ignore\.txt/
+   && $find_doc_nits_src =~ /missingenv\.txt/,
+   "find-doc-nits loads env-var ignore lists from external files");
+
+ok(-f srctop_file("util", "env-ignore.txt")
+   && -f srctop_file("util", "missingenv.txt"),
+   "external env-var list files exist in util/");
+
+indir(bldtop_dir() => sub {
+    my @out = run(cmd([ $^X, $script, "-a" ]), capture => 1);
+    my $output = join("", @out);
+    ok($output !~ /Undocumented environment variables:/,
+       "find-doc-nits -a reports no undocumented environment variables");
+});

--- a/test/recipes/80-test_find_doc_nits.t
+++ b/test/recipes/80-test_find_doc_nits.t
@@ -1,0 +1,56 @@
+#! /usr/bin/env perl
+#
+# Copyright 2025-2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use File::Spec::Functions qw(rel2abs);
+use OpenSSL::Test qw/:DEFAULT bldtop_dir bldtop_file srctop_file indir cmd run/;
+
+setup("test_find_doc_nits");
+
+plan tests => 4;
+
+# srctop_file() returns a path relative to the recipe's start directory, but
+# the last test runs the script from the build top, so make it absolute here.
+my $script = rel2abs(srctop_file("util", "find-doc-nits"));
+open my $sfh, '<', $script or die "open $script: $!";
+my $find_doc_nits_src = do { local $/; <$sfh> };
+close $sfh;
+
+ok($find_doc_nits_src =~ /push \@env_files.*\Q\.(?:c|in|t|pl)\E\$/s,
+   "find-doc-nits collects .t and .pl files for environment variable scan");
+
+ok($find_doc_nits_src =~ /env-ignore\.txt/
+   && $find_doc_nits_src =~ /missingenv\.txt/,
+   "find-doc-nits loads env-var ignore lists from external files");
+
+ok(-f srctop_file("util", "env-ignore.txt")
+   && -f srctop_file("util", "missingenv.txt"),
+   "external env-var list files exist in util/");
+
+# find-doc-nits reads every manual page, including the ones generated from
+# .pod.in files, which "make test" does not build.  openssl-ca.pod is one of
+# them and stands in for the whole set.
+my $have_generated_pods = -f bldtop_file("doc", "man1", "openssl-ca.pod");
+
+SKIP: {
+    skip "generated pods are not built, run 'make build_generated_pods'", 1
+        unless $have_generated_pods;
+
+    indir(bldtop_dir() => sub {
+        my $status = 0;
+        my @out = run(cmd([ $^X, $script, "-a" ]), capture => 1,
+                      statusvar => \$status);
+        my $output = join("", @out);
+        ok($status && $output !~ /Undocumented environment variables:/,
+           "find-doc-nits -a reports no undocumented environment variables")
+            or diag($output);
+    });
+}

--- a/util/env-ignore.txt
+++ b/util/env-ignore.txt
@@ -1,0 +1,28 @@
+# System, platform, and third-party environment variables.
+#
+# These are NOT OpenSSL-specific and should never need documentation in
+# openssl-env(7) or internal docs.  find-doc-nits -a silently skips them.
+#
+# One variable name per line.  Blank lines and lines beginning with #
+# are ignored.
+
+# Address/Memory sanitizer runtime options
+ASAN_OPTIONS
+MSAN_OPTIONS
+
+# Memory-debugging (glibc)
+MALLOC_PERTURB_
+
+# Locale
+LANG
+LC_ALL
+
+# Platform / OS
+LIBPATH
+MSYS2_ARG_CONV_EXCL
+NUMBER_OF_PROCESSORS
+TEMP
+TMP
+
+# Reproducible-builds standard (not OpenSSL-specific)
+SOURCE_DATE_EPOCH

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 2002-2025 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2002-2026 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -49,7 +49,9 @@ our($opt_a);
 sub help {
     print <<EOF;
 Find small errors (nits) in documentation.  Options:
-    -a List undocumented env vars
+    -a List undocumented env vars (scans .c, .in, .t, and .pl files;
+       known internal/system vars listed in util/env-ignore.txt and
+       util/missingenv.txt are excluded)
     -c List undocumented commands, undocumented options and unimplemented options.
     -d Detailed list of undocumented (implies -u)
     -e Detailed list of new undocumented (implies -v)
@@ -1285,7 +1287,6 @@ sub check_env_vars {
     my @env_files;
     my @except_dirs = (
         "$config{sourcedir}/demos",
-        "$config{sourcedir}/test",
     );
     my @except_env_files = (
         "$config{sourcedir}/providers/implementations/kem/template_kem.c",
@@ -1296,6 +1297,23 @@ sub check_env_vars {
     );
     my @env_headers;
     my @env_macro;
+
+    # Load env-var ignore lists from external files so they are easy to
+    # maintain and review independently of this script.
+    #   env-ignore.txt  – system/platform vars that never need OpenSSL docs
+    #   missingenv.txt  – internal vars that should eventually be documented
+    my %ignored_env;
+    for my $envfile (qw(util/env-ignore.txt util/missingenv.txt)) {
+        my $path = catfile($config{sourcedir}, $envfile);
+        open my $efh, '<', $path or die "Can't open $path: $!";
+        while (<$efh>) {
+            s/\R$//;
+            next if /^\s*#/ || /^\s*$/;
+            my ($name) = split;
+            $ignored_env{$name} = 1;
+        }
+        close $efh;
+    }
 
     if (open my $gs_file, '<', "$config{sourcedir}/.gitmodules") {
         while (<$gs_file>) {
@@ -1324,12 +1342,12 @@ sub check_env_vars {
     while (<$glf_pipe>) {
         $git_ok = 1;
         s/\R$//; # better chomp
-        push @env_files, $_ if /\.c$|\.in$/;
+        push @env_files, $_ if /\.(?:c|in|t|pl)$/;
     }
     close $glf_pipe;
     # git call has failed, trying to find files manually
     if (!$git_ok) {
-        find(sub { push @env_files, $File::Find::name if /\.c$|\.in$/; },
+        find(sub { push @env_files, $File::Find::name if /\.(?:c|in|t|pl)$/; },
              $config{sourcedir});
     }
 
@@ -1341,33 +1359,36 @@ sub check_env_vars {
         open my $fh, '<', $filename or die "Can't open $filename: $!";
         while (my $line = <$fh>) {
             # for windows
-            # for .in files
-            push @{$env_list{$1}}, "${filename}:$."
-                if ($line =~ /GetEnvironmentVariableW\([\s\S]*"([^"]+)",/
-                    || $line =~ /\$ENV\{([^}"']+)\}/);
-            # this also handles ossl_safe_getenv
-            if ($line =~ /getenv\(([^()\s]+)\)/) {
-                my $env1 = $1;
-                if ($env1 =~ /"([^"]+)"/) {
-                    push @{$env_list{$1}}, "${filename}:$.";
-                } elsif ($env1 =~ /([A-Z0-9_])/) {
-                    push(@env_macro, $env1);
-                }
+            if ($line =~ /GetEnvironmentVariableW\([\s\S]*"([^"]+)",/) {
+                push @{$env_list{$1}}, "${filename}:$.";
             }
-            # match ternary operators; $1 - true, $2 - false
-            if ($line =~ /env\(\s*[^?]+\?\s*([^:( ]+)\s*:\s*([^(]+)\s*\)/) {
-                my ($env1, $env2) = ($1, $2);
-                # if it's a string just add to the list
-                # otherwise look for the constant value later
-                if ($env1 =~ /"([^"]+)"/) {
-                    push @{$env_list{$1}}, "${filename}:$.";
-                } else {
-                    push(@env_macro, $env1);
+            # for .in and Perl (.t/.pl) files: $ENV{NAME}, $ENV{'NAME'}, $ENV{"NAME"}
+            while ($line =~ /\$ENV\{['"]?([^}'"]+)['"]?\}/g) {
+                push @{$env_list{$1}}, "${filename}:$." unless $1 =~ /^\$/;
+            }
+            # C/in only: getenv and ternary (no-op for .t/.pl)
+            if ($filename !~ /\.(?:t|pl)$/) {
+                if ($line =~ /getenv\(([^()\s]+)\)/) {
+                    my $env1 = $1;
+                    if ($env1 =~ /"([^"]+)"/) {
+                        push @{$env_list{$1}}, "${filename}:$.";
+                    } elsif ($env1 =~ /([A-Z0-9_])/) {
+                        push(@env_macro, $env1);
+                    }
                 }
-                if ($env2 =~ /"([^"]+)"/) {
-                    push @{$env_list{$1}}, "${filename}:$.";
-                } else {
-                    push(@env_macro, $env2);
+                # match ternary operators; $1 - true, $2 - false
+                if ($line =~ /env\(\s*[^?]+\?\s*([^:( ]+)\s*:\s*([^(]+)\s*\)/) {
+                    my ($env1, $env2) = ($1, $2);
+                    if ($env1 =~ /"([^"]+)"/) {
+                        push @{$env_list{$1}}, "${filename}:$.";
+                    } else {
+                        push(@env_macro, $env1);
+                    }
+                    if ($env2 =~ /"([^"]+)"/) {
+                        push @{$env_list{$1}}, "${filename}:$.";
+                    } else {
+                        push(@env_macro, $env2);
+                    }
                 }
             }
         }
@@ -1387,6 +1408,8 @@ sub check_env_vars {
             }
         }
     }
+
+    delete @env_list{keys %ignored_env};
 
     # need to save the value before starting to delete from the hash
     my $number_of_env = scalar keys %env_list;

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 2002-2025 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2002-2026 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -48,7 +48,9 @@ our($opt_a);
 sub help {
     print <<EOF;
 Find small errors (nits) in documentation.  Options:
-    -a List undocumented env vars
+    -a List undocumented env vars (scans .c, .in, .t, and .pl files;
+       known internal/system vars listed in util/env-ignore.txt and
+       util/missingenv.txt are excluded)
     -c List undocumented commands, undocumented options and unimplemented options.
     -d Detailed list of undocumented (implies -u)
     -e Detailed list of new undocumented (implies -v)
@@ -1283,7 +1285,6 @@ sub check_env_vars {
     my @env_files;
     my @except_dirs = (
         "$config{sourcedir}/demos",
-        "$config{sourcedir}/test",
     );
     my @except_env_files = (
         "$config{sourcedir}/providers/implementations/kem/template_kem.c",
@@ -1294,6 +1295,23 @@ sub check_env_vars {
     );
     my @env_headers;
     my @env_macro;
+
+    # Load env-var ignore lists from external files so they are easy to
+    # maintain and review independently of this script.
+    #   env-ignore.txt  - system/platform vars that never need OpenSSL docs
+    #   missingenv.txt  - internal vars that should eventually be documented
+    my %ignored_env;
+    for my $envfile (qw(env-ignore.txt missingenv.txt)) {
+        my $path = catfile($config{sourcedir}, 'util', $envfile);
+        open my $efh, '<', $path or die "Can't open $path: $!";
+        while (<$efh>) {
+            s/\R$//;
+            next if /^\s*#/ || /^\s*$/;
+            my ($name) = split;
+            $ignored_env{$name} = 1;
+        }
+        close $efh;
+    }
 
     if (open my $gs_file, '<', "$config{sourcedir}/.gitmodules") {
         while (<$gs_file>) {
@@ -1322,12 +1340,12 @@ sub check_env_vars {
     while (<$glf_pipe>) {
         $git_ok = 1;
         s/\R$//; # better chomp
-        push @env_files, $_ if /\.c$|\.in$/;
+        push @env_files, $_ if /\.(?:c|in|t|pl)$/;
     }
     close $glf_pipe;
     # git call has failed, trying to find files manually
     if (!$git_ok) {
-        find(sub { push @env_files, $File::Find::name if /\.c$|\.in$/; },
+        find(sub { push @env_files, $File::Find::name if /\.(?:c|in|t|pl)$/; },
              $config{sourcedir});
     }
 
@@ -1339,33 +1357,37 @@ sub check_env_vars {
         open my $fh, '<', $filename or die "Can't open $filename: $!";
         while (my $line = <$fh>) {
             # for windows
-            # for .in files
-            push @{$env_list{$1}}, "${filename}:$."
-                if ($line =~ /GetEnvironmentVariableW\([\s\S]*"([^"]+)",/
-                    || $line =~ /\$ENV\{([^}"']+)\}/);
-            # this also handles ossl_safe_getenv
-            if ($line =~ /getenv\(([^()\s]+)\)/) {
-                my $env1 = $1;
-                if ($env1 =~ /"([^"]+)"/) {
-                    push @{$env_list{$1}}, "${filename}:$.";
-                } elsif ($env1 =~ /([A-Z0-9_])/) {
-                    push(@env_macro, $env1);
-                }
+            if ($line =~ /GetEnvironmentVariableW\([\s\S]*"([^"]+)",/) {
+                push @{$env_list{$1}}, "${filename}:$.";
             }
-            # match ternary operators; $1 - true, $2 - false
-            if ($line =~ /env\(\s*[^?]+\?\s*([^:( ]+)\s*:\s*([^(]+)\s*\)/) {
-                my ($env1, $env2) = ($1, $2);
-                # if it's a string just add to the list
-                # otherwise look for the constant value later
-                if ($env1 =~ /"([^"]+)"/) {
-                    push @{$env_list{$1}}, "${filename}:$.";
-                } else {
-                    push(@env_macro, $env1);
+            # for .in and Perl (.t/.pl) files:
+            # $ENV{NAME}, $ENV{'NAME'} and $ENV{"NAME"}
+            while ($line =~ /\$ENV\{['"]?([^}'"]+)['"]?\}/g) {
+                push @{$env_list{$1}}, "${filename}:$." unless $1 =~ /^\$/;
+            }
+            # C/in only: getenv and ternary (no-op for .t/.pl)
+            if ($filename !~ /\.(?:t|pl)$/) {
+                if ($line =~ /getenv\(([^()\s]+)\)/) {
+                    my $env1 = $1;
+                    if ($env1 =~ /"([^"]+)"/) {
+                        push @{$env_list{$1}}, "${filename}:$.";
+                    } elsif ($env1 =~ /([A-Z0-9_])/) {
+                        push(@env_macro, $env1);
+                    }
                 }
-                if ($env2 =~ /"([^"]+)"/) {
-                    push @{$env_list{$1}}, "${filename}:$.";
-                } else {
-                    push(@env_macro, $env2);
+                # match ternary operators; $1 - true, $2 - false
+                if ($line =~ /env\(\s*[^?]+\?\s*([^:( ]+)\s*:\s*([^(]+)\s*\)/) {
+                    my ($env1, $env2) = ($1, $2);
+                    if ($env1 =~ /"([^"]+)"/) {
+                        push @{$env_list{$1}}, "${filename}:$.";
+                    } else {
+                        push(@env_macro, $env1);
+                    }
+                    if ($env2 =~ /"([^"]+)"/) {
+                        push @{$env_list{$1}}, "${filename}:$.";
+                    } else {
+                        push(@env_macro, $env2);
+                    }
                 }
             }
         }
@@ -1385,6 +1407,8 @@ sub check_env_vars {
             }
         }
     }
+
+    delete @env_list{keys %ignored_env};
 
     # need to save the value before starting to delete from the hash
     my $number_of_env = scalar keys %env_list;

--- a/util/missingenv.txt
+++ b/util/missingenv.txt
@@ -1,0 +1,87 @@
+# Internal OpenSSL environment variables not yet formally documented.
+#
+# These are used by the test suite, release tooling, ASM generators, or
+# build infrastructure.  They are not relevant to end users and therefore
+# not documented in openssl-env(7), but they should eventually be covered
+# in doc/internal, CONTRIBUTING.md, or HACKING.md.
+#
+# Format: one variable name per line (first whitespace-delimited token).
+# Everything after the first token is treated as a comment.
+# Blank lines and lines beginning with # are ignored.
+#
+# When a variable gets documented, remove it from this file.
+
+# --- TAP::Harness / OpenSSL::Test harness knobs ---
+HARNESS_ACTIVE                    Set by TAP::Harness while a test is running
+HARNESS_FAILLOG                   Path to failure log written by harness
+HARNESS_JOBS                      Number of parallel test jobs (e.g. make test HARNESS_JOBS=4)
+HARNESS_OSSL_LEVEL                OpenSSL-specific harness verbosity level
+HARNESS_TAP_COPY                  Copy TAP output to this file descriptor
+HARNESS_TIMER                     Enable per-test wall-clock timing
+HARNESS_VERBOSE                   Enable verbose TAP output
+HARNESS_VERBOSE_FAILURE           Show full output only for failing tests
+HARNESS_VERBOSE_FAILURE_PROGRESS  Show progress indicator during verbose failure output
+
+# --- Test framework paths (set by OpenSSL::Test / util/wrap.pl) ---
+BLDTOP                Build tree top directory
+SRCTOP                Source tree top directory
+TOP                   Legacy alias for source tree top
+CERTS_DIR             Path to test certificate store
+CT_DIR                Path to certificate-transparency test data
+TEST_CERTS_DIR        Alternative test certificate path
+TESTDATADIR           Path to test data files
+
+# --- Test behaviour switches ---
+ECSTRESS              Enable EC stress tests (99-test_ecstress.t)
+EVP_TEST_EXTENDED     Run extended EVP tests
+EXE_SHELL             Shell used to execute test binaries
+FILEPREFIX            Prefix for test-generated temporary files
+FIPSKEY               FIPS module integrity key used during testing
+LHASH_WORKERS         Number of worker threads for LHASH tests
+NO_ADDR_VALIDATE      Skip address validation in tests
+NO_FIPS               Skip FIPS-related tests
+NO_LEGACY             Skip legacy-provider tests
+OSSL_RUN_CI_TESTS     Enable CI-only tests (set in GitHub Actions)
+OPENSSL_TEST_GETCOUNTS    Enable test allocation counting
+OPENSSL_TEST_RAND_ORDER   Randomise test execution order
+OPENSSL_TEST_RAND_SEED    Seed for randomised test ordering
+RETAIN_SEED           Preserve random seed across test runs
+REPORT_FAILURES       Report detailed test failures
+REPORT_FAILURES_PROGRESS  Show progress during failure reporting
+VERBOSE               Test verbosity flag (short form)
+VERBOSE_FAILURE       Verbose output on failure (short form)
+VERBOSE_FAILURE_PROGRESS  Progress during verbose failure output
+VF                    Alias for VERBOSE_FAILURE
+VFP                   Alias for VERBOSE_FAILURE_PROGRESS
+
+# --- CMP test infrastructure ---
+OPENSSL_CMP_ASPECTS   CMP test aspects configuration
+OPENSSL_CMP_CONFIG    CMP test configuration file path
+OPENSSL_CMP_SERVER    CMP test server URL
+
+# --- SSL/TLS test knobs ---
+SSL_CIPHER_SUITES     Cipher suites for SSL tests
+SSL_SESSION_FILE      Session file for SSL tests
+SSL_TESTS             SSL test selection filter
+
+# --- Release and build tooling ---
+ADD_DEPENDS_DEBUG             Debug mode for dependency generation
+OPENSSL_MKINSTALLVARS_DEBUG   Debug mode for util/mkinstallvars.pl
+ASM                   Assembly source override for ASM generators
+AUTHOR_TESTING        Enable author-level testing
+CN2                   Alternative CN for test certificates
+MYKEY                 Key name used in test recipes
+PREV_RELEASE_DATE     Previous release date (util/mkrelease.pl)
+PREV_RELEASE_TEXT     Previous release description
+RELEASE               Current release version string
+RELEASE_DATE          Current release date string
+RELEASE_TEXT          Current release description
+SHLIB_VERSION_NUMBER  Shared library version number
+
+# --- RPKI test tooling ---
+RPKI_DOWNLOAD_URL     Download URL for RPKI test data
+RPKI_SRC              Source path for RPKI test data
+RPKI_TARBALL          Path to RPKI test tarball
+
+# --- Miscellaneous ---
+TSDNSECT              TSA distinguished-name section in openssl.cnf

--- a/util/missingenv.txt
+++ b/util/missingenv.txt
@@ -1,0 +1,101 @@
+# Internal OpenSSL environment variables not yet formally documented.
+#
+# These are used by the test suite, release tooling, ASM generators, or
+# build infrastructure.  They are not relevant to end users and therefore
+# not documented in openssl-env(7), but they should eventually be covered
+# in doc/internal, CONTRIBUTING.md, or HACKING.md.
+#
+# Format: one variable name per line (first whitespace-delimited token).
+# Everything after the first token is treated as a comment.
+# Blank lines and lines beginning with # are ignored.
+#
+# When a variable gets documented, remove it from this file.
+
+# --- TAP::Harness / OpenSSL::Test harness knobs ---
+HARNESS_ACTIVE                    Set by TAP::Harness while a test is running
+HARNESS_FAILLOG                   Path to failure log written by harness
+HARNESS_JOBS                      Number of parallel test jobs
+HARNESS_OSSL_LEVEL                OpenSSL-specific harness verbosity level
+HARNESS_TAP_COPY                  Copy TAP output to this file descriptor
+HARNESS_TIMER                     Enable per-test wall-clock timing
+HARNESS_VERBOSE                   Enable verbose TAP output
+HARNESS_VERBOSE_FAILURE           Show full output only for failing tests
+HARNESS_VERBOSE_FAILURE_PROGRESS  Progress indicator in verbose failure output
+
+# --- Test framework paths (set by OpenSSL::Test / util/wrap.pl) ---
+BLDTOP          Build tree top directory
+CERTS_DIR       Path to test certificate store
+CT_DIR          Path to certificate-transparency test data
+SRCTOP          Source tree top directory
+TESTDATADIR     Path to test data files
+TEST_CERTS_DIR  Alternative test certificate path
+TOP             Legacy alias for source tree top
+
+# --- Test behaviour switches ---
+ECSTRESS                     Enable EC stress tests (99-test_ecstress.t)
+EVP_TEST_EXTENDED            Run extended EVP tests
+EXE_SHELL                    Shell used to execute test binaries
+FILEPREFIX                   Prefix for test-generated temporary files
+FIPSKEY                      FIPS module integrity key used during testing
+LHASH_WORKERS                Number of worker threads for LHASH tests
+NO_ADDR_VALIDATE             Skip address validation in tests
+NO_FIPS                      Skip FIPS-related tests
+NO_LEGACY                    Skip legacy-provider tests
+OPENSSL_TEST_GETCOUNTS       Enable test allocation counting
+OPENSSL_TEST_RAND_ORDER      Randomise test execution order
+OPENSSL_TEST_RAND_SEED       Seed for randomised test ordering
+OSSL_RUN_CI_TESTS            Enable CI-only tests (set in GitHub Actions)
+OSSL_TEST_PROVIDER_NO_CACHE  Disable operation caching in the test provider
+REPORT_FAILURES              Report detailed test failures
+REPORT_FAILURES_PROGRESS     Show progress during failure reporting
+RETAIN_SEED                  Preserve random seed across test runs
+VERBOSE                      Test verbosity flag (short form)
+VERBOSE_FAILURE              Verbose output on failure (short form)
+VERBOSE_FAILURE_PROGRESS     Progress during verbose failure output
+VF                           Alias for VERBOSE_FAILURE
+VFP                          Alias for VERBOSE_FAILURE_PROGRESS
+
+# --- Memory-failure injection harness (see test/README.md) ---
+OPENSSL_TEST_MFAIL_BACKTRACE   Print a backtrace at each injection point
+OPENSSL_TEST_MFAIL_COUNT       Override the sampled failure point count
+OPENSSL_TEST_MFAIL_COUNT_ONLY  Run the counting phase only, never inject
+OPENSSL_TEST_MFAIL_DISABLE     Disable the mfail custom allocator
+OPENSSL_TEST_MFAIL_POINT       Run only the given failure point
+OPENSSL_TEST_MFAIL_START       Start iteration at the given failure point
+
+# --- Fuzz corpora test driver (test/recipes/fuzz.pl) ---
+OSSL_FUZZ_TEST_BUDGET  Total wall-clock budget shared by the fuzz tests
+OSSL_FUZZ_TEST_JOBS    Number of parallel fuzz test jobs
+
+# --- CMP test infrastructure ---
+OPENSSL_CMP_ASPECTS  CMP test aspects configuration
+OPENSSL_CMP_CONFIG   CMP test configuration file path
+OPENSSL_CMP_SERVER   CMP test server URL
+
+# --- SSL/TLS test knobs ---
+SSL_CIPHER_SUITES  Cipher suites for SSL tests
+SSL_SESSION_FILE   Session file for SSL tests
+SSL_TESTS          SSL test selection filter
+
+# --- Release and build tooling ---
+ADD_DEPENDS_DEBUG            Debug mode for dependency generation
+ASM                          Assembly source override for ASM generators
+AUTHOR_TESTING               Enable author-level testing
+CN2                          Alternative CN for test certificates
+MYKEY                        Key name used in test recipes
+OPENSSL_MKINSTALLVARS_DEBUG  Debug mode for util/mkinstallvars.pl
+PREV_RELEASE_DATE            Previous release date (util/mkrelease.pl)
+PREV_RELEASE_TEXT            Previous release description
+RELEASE                      Current release version string
+RELEASE_DATE                 Current release date string
+RELEASE_TEXT                 Current release description
+SHLIB_VERSION_NUMBER         Shared library version number
+
+# --- RPKI test tooling ---
+RPKI_DOWNLOAD_URL  Download URL for RPKI test data
+RPKI_SRC           Source path for RPKI test data
+RPKI_TARBALL       Path to RPKI test tarball
+
+# --- Miscellaneous ---
+INDEX     Certificate index used by the TSA test openssl.cnf
+TSDNSECT  TSA distinguished-name section in openssl.cnf


### PR DESCRIPTION
## Summary

`find-doc-nits -a` used to scan only `.c`/`.in` and skipped `test/`, so Perl tests and scripts never contributed. It now scans `.t` and `.pl` as well (still excluding `demos/`), skips `.gitmodules` submodule trees, and uses one `$ENV{...}` regex (quoted or not, `/g` per line) while skipping dynamic keys like `$1`. `getenv` / ternary patterns run only on non-Perl files.

Internal-only names (tests, harness, release tooling, ASM, etc.) are in `%ignored_env` so `make doc-nits` stays about user-facing gaps; add new internal vars there or document them in `openssl-env(7)`.

**Tests:** `80-test_find_doc_nits.t` checks the script still collects `.t`/`.pl` and that `find-doc-nits -a` from the build tree prints no undocumented-env banner.

**Docs:** Help text, HOWTO, and `CHANGES.md` updated accordingly.

| File | Role |
|------|------|
| `util/find-doc-nits` | Scan logic, exclusions, allowlist, `-a` help |
| `test/recipes/80-test_find_doc_nits.t` | Regression |
| `doc/HOWTO/documenting-functions-and-macros.md` | Contributor guidance |
| `CHANGES.md` | Release note |

Fixes #28110

---
