### PR TITLE
remove condition which can never be met

### DIFF
--- a/crypto/idea/i_cfb64.c
+++ b/crypto/idea/i_cfb64.c
@@ -28,7 +28,7 @@ void IDEA_cfb64_encrypt(const unsigned char *in, unsigned char *out,
     unsigned char *ivec, int *num, int encrypt)
 {
     register unsigned long v0, v1, t;
-    register int n = *num & 0x07;
+    register int n = *num;
     register long l = length;
     unsigned long ti[2];
     unsigned char *iv, c, cc;
@@ -37,6 +37,7 @@ void IDEA_cfb64_encrypt(const unsigned char *in, unsigned char *out,
         *num = -1;
         return;
     }
+    n = n & 0x07;
 
     iv = (unsigned char *)ivec;
     if (encrypt) {


### PR DESCRIPTION
after doing `n = n & 0x07` the n can never be less than 0 (n < 0)

Resolves: https://scan5.scan.coverity.com/#/project-view/62622/10222?selectedIssue=1689816
Resolves: https://scan5.scan.coverity.com/#/project-view/62622/10222?selectedIssue=1689815

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
