### PR TITLE
riscv: Add lpad instructions for CFI support

### DIFF
--- a/crypto/aes/asm/aes-riscv32-zkn.pl
+++ b/crypto/aes/asm/aes-riscv32-zkn.pl
@@ -36,6 +36,11 @@
 
 # $output is the last argument if it looks like a file (it has an extension)
 # $flavour is the first argument if it doesn't look like a file
+use FindBin qw($Bin);
+use lib "$Bin";
+use lib "$Bin/../../perlasm";
+use riscv;
+
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 
@@ -244,6 +249,7 @@ my $code .= <<___;
 .globl rv32i_zkne_encrypt
 .type   rv32i_zkne_encrypt,\@function
 rv32i_zkne_encrypt:
+    @{[lpad 0]}
 ___
 
 $code .= save_regs();
@@ -355,6 +361,7 @@ $code .= <<___;
 .globl rv32i_zknd_decrypt
 .type   rv32i_zknd_decrypt,\@function
 rv32i_zknd_decrypt:
+    @{[lpad 0]}
 ___
 
 $code .= save_regs();
@@ -739,6 +746,7 @@ $code .= <<___;
 .globl rv32i_zkne_set_encrypt_key
 .type rv32i_zkne_set_encrypt_key,\@function
 rv32i_zkne_set_encrypt_key:
+    @{[lpad 0]}
 ___
 
 $code .= save_regs();
@@ -758,6 +766,7 @@ $code .= <<___;
 .globl rv32i_zbkb_zkne_set_encrypt_key
 .type rv32i_zbkb_zkne_set_encrypt_key,\@function
 rv32i_zbkb_zkne_set_encrypt_key:
+    @{[lpad 0]}
 ___
 
 $code .= save_regs();
@@ -1051,6 +1060,7 @@ $code .= <<___;
 .globl rv32i_zknd_zkne_set_decrypt_key
 .type   rv32i_zknd_zkne_set_decrypt_key,\@function
 rv32i_zknd_zkne_set_decrypt_key:
+    @{[lpad 0]}
 ___
 $code .= save_regs();
 $code .= AES_set_common(ke128dec(0), ke192dec(0),ke256dec(0));
@@ -1069,6 +1079,7 @@ $code .= <<___;
 .globl rv32i_zbkb_zknd_zkne_set_decrypt_key
 .type rv32i_zbkb_zknd_zkne_set_decrypt_key,\@function
 rv32i_zbkb_zknd_zkne_set_decrypt_key:
+    @{[lpad 0]}
 ___
 
 $code .= save_regs();

--- a/crypto/aes/asm/aes-riscv32-zkn.pl
+++ b/crypto/aes/asm/aes-riscv32-zkn.pl
@@ -34,13 +34,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# $output is the last argument if it looks like a file (it has an extension)
-# $flavour is the first argument if it doesn't look like a file
 use FindBin qw($Bin);
 use lib "$Bin";
 use lib "$Bin/../../perlasm";
 use riscv;
 
+# $output is the last argument if it looks like a file (it has an extension)
+# $flavour is the first argument if it doesn't look like a file
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
 

--- a/crypto/aes/asm/aes-riscv64-zkn.pl
+++ b/crypto/aes/asm/aes-riscv64-zkn.pl
@@ -132,6 +132,7 @@ my $code .= <<___;
 .globl rv64i_zkne_encrypt
 .type   rv64i_zkne_encrypt,\@function
 rv64i_zkne_encrypt:
+    @{[lpad 0]}
 ___
 
 $code .= save_regs();
@@ -205,6 +206,7 @@ $code .= <<___;
 .globl rv64i_zknd_decrypt
 .type   rv64i_zknd_decrypt,\@function
 rv64i_zknd_decrypt:
+    @{[lpad 0]}
 ___
 
 $code .= save_regs();
@@ -427,6 +429,7 @@ $code .= <<___;
 .globl rv64i_zkne_set_encrypt_key
 .type   rv64i_zkne_set_encrypt_key,\@function
 rv64i_zkne_set_encrypt_key:
+    @{[lpad 0]}
 ___
 $code .= save_regs();
 $code .= AES_set_common(ke128enc(), ke192enc(),ke256enc());
@@ -577,6 +580,7 @@ $code .= <<___;
 .globl rv64i_zknd_set_decrypt_key
 .type   rv64i_zknd_set_decrypt_key,\@function
 rv64i_zknd_set_decrypt_key:
+    @{[lpad 0]}
 ___
 $code .= save_regs();
 $code .= AES_set_common(ke128dec(), ke192dec(),ke256dec());

--- a/crypto/aes/asm/aes-riscv64-zvbb-zvkg-zvkned.pl
+++ b/crypto/aes/asm/aes-riscv64-zvbb-zvkg-zvkned.pl
@@ -425,6 +425,7 @@ $code .= <<___;
 .globl rv64i_zvbb_zvkg_zvkned_aes_xts_encrypt
 .type rv64i_zvbb_zvkg_zvkned_aes_xts_encrypt,\@function
 rv64i_zvbb_zvkg_zvkned_aes_xts_encrypt:
+    @{[lpad 0]}
     @{[compute_xts_iv0]}
 
     # aes block size is 16
@@ -450,6 +451,7 @@ ___
 $code .= <<___;
 .p2align 3
 aes_xts_enc_128:
+    @{[lpad 0]}
     @{[init_first_round]}
     @{[aes_128_load_key]}
 
@@ -499,6 +501,7 @@ ___
 $code .= <<___;
 .p2align 3
 aes_xts_enc_256:
+    @{[lpad 0]}
     @{[init_first_round]}
     @{[aes_256_load_key]}
 
@@ -556,6 +559,7 @@ $code .= <<___;
 .globl rv64i_zvbb_zvkg_zvkned_aes_xts_decrypt
 .type rv64i_zvbb_zvkg_zvkned_aes_xts_decrypt,\@function
 rv64i_zvbb_zvkg_zvkned_aes_xts_decrypt:
+    @{[lpad 0]}
     @{[compute_xts_iv0]}
 
     # aes block size is 16
@@ -579,6 +583,7 @@ ___
 $code .= <<___;
 .p2align 3
 aes_xts_dec_128:
+    @{[lpad 0]}
     @{[init_first_round]}
     @{[aes_128_load_key]}
 
@@ -643,6 +648,7 @@ ___
 $code .= <<___;
 .p2align 3
 aes_xts_dec_256:
+    @{[lpad 0]}
     @{[init_first_round]}
     @{[aes_256_load_key]}
 

--- a/crypto/aes/asm/aes-riscv64-zvkb-zvkned.pl
+++ b/crypto/aes/asm/aes-riscv64-zvkb-zvkned.pl
@@ -116,6 +116,7 @@ $code .= <<___;
 .globl rv64i_zvkb_zvkned_ctr32_encrypt_blocks
 .type rv64i_zvkb_zvkned_ctr32_encrypt_blocks,\@function
 rv64i_zvkb_zvkned_ctr32_encrypt_blocks:
+    @{[lpad 0]}
     beqz $BLOCK_NUM, 1f
 
     # Load number of rounds
@@ -139,6 +140,7 @@ ___
 $code .= <<___;
 .p2align 3
 ctr32_encrypt_blocks_128:
+    @{[lpad 0]}
     # Load all 11 round keys to v1-v11 registers.
     @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
     @{[vle32_v $V1, $KEYP]}
@@ -211,6 +213,7 @@ ___
 $code .= <<___;
 .p2align 3
 ctr32_encrypt_blocks_192:
+    @{[lpad 0]}
     # Load all 13 round keys to v1-v13 registers.
     @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
     @{[vle32_v $V1, $KEYP]}
@@ -289,6 +292,7 @@ ___
 $code .= <<___;
 .p2align 3
 ctr32_encrypt_blocks_256:
+    @{[lpad 0]}
     # Load all 15 round keys to v1-v15 registers.
     @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
     @{[vle32_v $V1, $KEYP]}

--- a/crypto/aes/asm/aes-riscv64-zvkned.pl
+++ b/crypto/aes/asm/aes-riscv64-zvkned.pl
@@ -393,6 +393,7 @@ $code .= <<___;
 .globl rv64i_zvkned_cbc_encrypt
 .type rv64i_zvkned_cbc_encrypt,\@function
 rv64i_zvkned_cbc_encrypt:
+    @{[lpad 0]}
     # check whether the length is a multiple of 16 and >= 16
     li $T1, 16
     blt $LEN, $T1, L_end
@@ -419,6 +420,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_cbc_enc_128:
+    @{[lpad 0]}
     # Load all 11 round keys to v1-v11 registers.
     @{[aes_128_load_key $KEYP]}
 
@@ -454,6 +456,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_cbc_enc_192:
+    @{[lpad 0]}
     # Load all 13 round keys to v1-v13 registers.
     @{[aes_192_load_key $KEYP]}
 
@@ -489,6 +492,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_cbc_enc_256:
+    @{[lpad 0]}
     # Load all 15 round keys to v1-v15 registers.
     @{[aes_256_load_key $KEYP]}
 
@@ -531,6 +535,7 @@ $code .= <<___;
 .globl rv64i_zvkned_cbc_decrypt
 .type rv64i_zvkned_cbc_decrypt,\@function
 rv64i_zvkned_cbc_decrypt:
+    @{[lpad 0]}
     # check whether the length is a multiple of 16 and >= 16
     li $T1, 16
     blt $LEN, $T1, L_end
@@ -557,6 +562,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_cbc_dec_128:
+    @{[lpad 0]}
     # Load all 11 round keys to v1-v11 registers.
     @{[aes_128_load_key $KEYP]}
 
@@ -649,6 +655,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_cbc_dec_192:
+    @{[lpad 0]}
     # Load all 13 round keys to v1-v13 registers.
     @{[aes_192_load_key $KEYP]}
 
@@ -686,6 +693,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_cbc_dec_256:
+    @{[lpad 0]}
     # Load all 15 round keys to v1-v15 registers.
     @{[aes_256_load_key $KEYP]}
 
@@ -737,6 +745,7 @@ $code .= <<___;
 .globl rv64i_zvkned_ecb_encrypt
 .type rv64i_zvkned_ecb_encrypt,\@function
 rv64i_zvkned_ecb_encrypt:
+    @{[lpad 0]}
     # Make the LEN become e32 length.
     srli $LEN32, $LEN, 2
 
@@ -760,6 +769,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_ecb_enc_128:
+    @{[lpad 0]}
     # Load all 11 round keys to v1-v11 registers.
     @{[aes_128_load_key $KEYP]}
 
@@ -787,6 +797,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_ecb_enc_192:
+    @{[lpad 0]}
     # Load all 13 round keys to v1-v13 registers.
     @{[aes_192_load_key $KEYP]}
 
@@ -814,6 +825,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_ecb_enc_256:
+    @{[lpad 0]}
     # Load all 15 round keys to v1-v15 registers.
     @{[aes_256_load_key $KEYP]}
 
@@ -848,6 +860,7 @@ $code .= <<___;
 .globl rv64i_zvkned_ecb_decrypt
 .type rv64i_zvkned_ecb_decrypt,\@function
 rv64i_zvkned_ecb_decrypt:
+    @{[lpad 0]}
     # Make the LEN become e32 length.
     srli $LEN32, $LEN, 2
 
@@ -871,6 +884,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_ecb_dec_128:
+    @{[lpad 0]}
     # Load all 11 round keys to v1-v11 registers.
     @{[aes_128_load_key $KEYP]}
 
@@ -898,6 +912,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_ecb_dec_192:
+    @{[lpad 0]}
     # Load all 13 round keys to v1-v13 registers.
     @{[aes_192_load_key $KEYP]}
 
@@ -925,6 +940,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_ecb_dec_256:
+    @{[lpad 0]}
     # Load all 15 round keys to v1-v15 registers.
     @{[aes_256_load_key $KEYP]}
 
@@ -965,6 +981,8 @@ $code .= <<___;
 .globl rv64i_zvkned_set_encrypt_key
 .type rv64i_zvkned_set_encrypt_key,\@function
 rv64i_zvkned_set_encrypt_key:
+    @{[lpad 0]}
+
     # Get proper routine for key size
     li $T0, 256
     beq $BITS, $T0, L_set_key_256
@@ -981,6 +999,8 @@ $code .= <<___;
 .globl rv64i_zvkned_set_decrypt_key
 .type rv64i_zvkned_set_decrypt_key,\@function
 rv64i_zvkned_set_decrypt_key:
+    @{[lpad 0]}
+
     # Get proper routine for key size
     li $T0, 256
     beq $BITS, $T0, L_set_key_256
@@ -995,6 +1015,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_set_key_128:
+    @{[lpad 0]}
     # Store the number of rounds
     li $T1, 10
     sw $T1, 240($KEYP)
@@ -1047,6 +1068,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_set_key_256:
+    @{[lpad 0]}
     # Store the number of rounds
     li $T1, 14
     sw $T1, 240($KEYP)
@@ -1133,6 +1155,7 @@ $code .= <<___;
 .globl rv64i_zvkned_encrypt
 .type rv64i_zvkned_encrypt,\@function
 rv64i_zvkned_encrypt:
+    @{[lpad 0]}
     # Load number of rounds
     lwu $ROUNDS, 240($KEYP)
 
@@ -1151,6 +1174,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_enc_128:
+    @{[lpad 0]}
     @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
 
     @{[vle32_v $V1, $INP]}
@@ -1197,6 +1221,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_enc_192:
+    @{[lpad 0]}
     @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
 
     @{[vle32_v $V1, $INP]}
@@ -1248,6 +1273,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_enc_256:
+    @{[lpad 0]}
     @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
 
     @{[vle32_v $V1, $INP]}
@@ -1311,6 +1337,7 @@ $code .= <<___;
 .globl rv64i_zvkned_decrypt
 .type rv64i_zvkned_decrypt,\@function
 rv64i_zvkned_decrypt:
+    @{[lpad 0]}
     # Load number of rounds
     lwu $ROUNDS, 240($KEYP)
 
@@ -1329,6 +1356,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_dec_128:
+    @{[lpad 0]}
     @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
 
     @{[vle32_v $V1, $INP]}
@@ -1376,6 +1404,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_dec_192:
+    @{[lpad 0]}
     @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
 
     @{[vle32_v $V1, $INP]}
@@ -1429,6 +1458,7 @@ ___
 $code .= <<___;
 .p2align 3
 L_dec_256:
+    @{[lpad 0]}
     @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
 
     @{[vle32_v $V1, $INP]}

--- a/crypto/aes/asm/aes-riscv64-zvkned.pl
+++ b/crypto/aes/asm/aes-riscv64-zvkned.pl
@@ -420,7 +420,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_cbc_enc_128:
-    @{[lpad 0]}
     # Load all 11 round keys to v1-v11 registers.
     @{[aes_128_load_key $KEYP]}
 
@@ -456,7 +455,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_cbc_enc_192:
-    @{[lpad 0]}
     # Load all 13 round keys to v1-v13 registers.
     @{[aes_192_load_key $KEYP]}
 
@@ -492,7 +490,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_cbc_enc_256:
-    @{[lpad 0]}
     # Load all 15 round keys to v1-v15 registers.
     @{[aes_256_load_key $KEYP]}
 
@@ -562,7 +559,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_cbc_dec_128:
-    @{[lpad 0]}
     # Load all 11 round keys to v1-v11 registers.
     @{[aes_128_load_key $KEYP]}
 
@@ -655,7 +651,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_cbc_dec_192:
-    @{[lpad 0]}
     # Load all 13 round keys to v1-v13 registers.
     @{[aes_192_load_key $KEYP]}
 
@@ -693,7 +688,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_cbc_dec_256:
-    @{[lpad 0]}
     # Load all 15 round keys to v1-v15 registers.
     @{[aes_256_load_key $KEYP]}
 
@@ -769,7 +763,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_ecb_enc_128:
-    @{[lpad 0]}
     # Load all 11 round keys to v1-v11 registers.
     @{[aes_128_load_key $KEYP]}
 
@@ -797,7 +790,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_ecb_enc_192:
-    @{[lpad 0]}
     # Load all 13 round keys to v1-v13 registers.
     @{[aes_192_load_key $KEYP]}
 
@@ -825,7 +817,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_ecb_enc_256:
-    @{[lpad 0]}
     # Load all 15 round keys to v1-v15 registers.
     @{[aes_256_load_key $KEYP]}
 
@@ -884,7 +875,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_ecb_dec_128:
-    @{[lpad 0]}
     # Load all 11 round keys to v1-v11 registers.
     @{[aes_128_load_key $KEYP]}
 
@@ -912,7 +902,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_ecb_dec_192:
-    @{[lpad 0]}
     # Load all 13 round keys to v1-v13 registers.
     @{[aes_192_load_key $KEYP]}
 
@@ -940,7 +929,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_ecb_dec_256:
-    @{[lpad 0]}
     # Load all 15 round keys to v1-v15 registers.
     @{[aes_256_load_key $KEYP]}
 
@@ -1015,7 +1003,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_set_key_128:
-    @{[lpad 0]}
     # Store the number of rounds
     li $T1, 10
     sw $T1, 240($KEYP)
@@ -1068,7 +1055,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_set_key_256:
-    @{[lpad 0]}
     # Store the number of rounds
     li $T1, 14
     sw $T1, 240($KEYP)
@@ -1174,7 +1160,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_enc_128:
-    @{[lpad 0]}
     @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
 
     @{[vle32_v $V1, $INP]}
@@ -1221,7 +1206,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_enc_192:
-    @{[lpad 0]}
     @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
 
     @{[vle32_v $V1, $INP]}
@@ -1273,7 +1257,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_enc_256:
-    @{[lpad 0]}
     @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
 
     @{[vle32_v $V1, $INP]}
@@ -1356,7 +1339,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_dec_128:
-    @{[lpad 0]}
     @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
 
     @{[vle32_v $V1, $INP]}
@@ -1404,7 +1386,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_dec_192:
-    @{[lpad 0]}
     @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
 
     @{[vle32_v $V1, $INP]}
@@ -1458,7 +1439,6 @@ ___
 $code .= <<___;
 .p2align 3
 L_dec_256:
-    @{[lpad 0]}
     @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
 
     @{[vle32_v $V1, $INP]}

--- a/crypto/aes/asm/aes-riscv64.pl
+++ b/crypto/aes/asm/aes-riscv64.pl
@@ -6,6 +6,11 @@
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
+use FindBin qw($Bin);
+use lib "$Bin";
+use lib "$Bin/../../perlasm";
+use riscv;
+
 # $output is the last argument if it looks like a file (it has an extension)
 # $flavour is the first argument if it doesn't look like a file
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
@@ -222,6 +227,7 @@ my $code .= <<___;
 .globl AES_encrypt
 .type   AES_encrypt,\@function
 AES_encrypt:
+    @{[lpad 0]}
 ___
 
 $code .= save_regs();
@@ -456,6 +462,7 @@ $code .= <<___;
 .globl AES_decrypt
 .type   AES_decrypt,\@function
 AES_decrypt:
+    @{[lpad 0]}
 ___
 
 $code .= save_regs();
@@ -770,6 +777,7 @@ $code .= <<___;
 .globl AES_set_encrypt_key
 .type   AES_set_encrypt_key,\@function
 AES_set_encrypt_key:
+    @{[lpad 0]}
 ___
 $code .= save_regs();
 $code .= <<___;
@@ -1064,6 +1072,7 @@ $code .= <<___;
 .globl AES_set_decrypt_key
 .type   AES_set_decrypt_key,\@function
 AES_set_decrypt_key:
+    @{[lpad 0]}
     # Call AES_set_encrypt_key first
     addi    sp,sp,-16
     sd      $KEYP,0(sp) # We need to hold onto this!

--- a/crypto/bn/asm/riscv64-mont.pl
+++ b/crypto/bn/asm/riscv64-mont.pl
@@ -131,6 +131,7 @@ my $code .= <<___;
 .globl bn_mul_mont
 .type bn_mul_mont,\@function
 bn_mul_mont:
+    @{[lpad 0]}
     andi  $numtst, $num, 7
     beqz  $numtst, bn_sqr8x_mont
 .Lmul_mont:

--- a/crypto/chacha/asm/chacha-riscv64-v-zbb.pl
+++ b/crypto/chacha/asm/chacha-riscv64-v-zbb.pl
@@ -245,6 +245,7 @@ $code .= <<___;
 .globl ChaCha20_ctr32@{[$isaext]}
 .type ChaCha20_ctr32@{[$isaext]},\@function
 ChaCha20_ctr32@{[$isaext]}:
+    @{[lpad 0]}
     addi sp, sp, -96
     sd s0, 0(sp)
     sd s1, 8(sp)

--- a/crypto/ec/asm/ecp_sm2p256-riscv64.pl
+++ b/crypto/ec/asm/ecp_sm2p256-riscv64.pl
@@ -373,6 +373,7 @@ $code.=<<___;
 .type	bn_rshift1,%function
 .p2align 5
 bn_rshift1:
+	@{[lpad 0]}
 	// Load inputs
 	ld $t0, 0($i0)
 	ld $t1, 8($i0)
@@ -405,6 +406,7 @@ bn_rshift1:
 .type	bn_sub,%function
 .p2align 5
 bn_sub:
+	@{[lpad 0]}
 	// Load inputs
 	ld $t0, 0($i1)
 	ld $t1, 8($i1)
@@ -449,6 +451,7 @@ bn_sub:
 .type	ecp_sm2p256_mul_by_3,%function
 .p2align 5
 ecp_sm2p256_mul_by_3:
+	@{[lpad 0]}
 // returns r = ( a * 3 ) mod p, where p is a predefined polynomial modulus .Lpoly
 // Input: $i1 = address of operand a
 // Output: $i0 = address for result storage
@@ -601,6 +604,7 @@ $code.=<<___;
 .type	ecp_sm2p256_add,%function
 .p2align 5
 ecp_sm2p256_add:
+	@{[lpad 0]}
 ___
     &bn_mod_add(".Lpoly");
 $code.=<<___;
@@ -612,6 +616,7 @@ $code.=<<___;
 .type	ecp_sm2p256_sub,%function
 .p2align 5
 ecp_sm2p256_sub:
+	@{[lpad 0]}
 ___
     &bn_mod_sub(".Lpoly");
 $code.=<<___;
@@ -623,6 +628,7 @@ $code.=<<___;
 .type	ecp_sm2p256_sub_mod_ord,%function
 .p2align 5
 ecp_sm2p256_sub_mod_ord:
+	@{[lpad 0]}
 ___
     &bn_mod_sub(".Lord");
 $code.=<<___;
@@ -634,6 +640,7 @@ $code.=<<___;
 .type	ecp_sm2p256_div_by_2,%function
 .p2align 5
 ecp_sm2p256_div_by_2:
+	@{[lpad 0]}
 ___
     &bn_mod_div_by_2(".Lpoly_div_2");
 $code.=<<___;
@@ -645,6 +652,7 @@ $code.=<<___;
 .type	ecp_sm2p256_div_by_2_mod_ord,%function
 .p2align 5
 ecp_sm2p256_div_by_2_mod_ord:
+	@{[lpad 0]}
 ___
     &bn_mod_div_by_2(".Lord_div_2");
 $code.=<<___;
@@ -946,6 +954,7 @@ $code.=<<___;
 .type	ecp_sm2p256_mul,%function
 .p2align 5
 ecp_sm2p256_mul:
+	@{[lpad 0]}
 ___
 $code.= save_regs();
 $code.=<<___;
@@ -1135,6 +1144,7 @@ $code.=<<___;
 .type	ecp_sm2p256_sqr,%function
 .p2align 5
 ecp_sm2p256_sqr:
+	@{[lpad 0]}
 ___
 $code.= save_regs();
 $code.=<<___;

--- a/crypto/md5/asm/md5-riscv64-zbb.pl
+++ b/crypto/md5/asm/md5-riscv64-zbb.pl
@@ -239,6 +239,7 @@ $code .= <<___;
 .globl ossl_md5_block_asm_data_order@{[$isaext]}
 .type ossl_md5_block_asm_data_order@{[$isaext]},\@function
 ossl_md5_block_asm_data_order@{[$isaext]}:
+    @{[lpad 0]}
 
     addi sp, sp, -64
 

--- a/crypto/modes/asm/aes-gcm-riscv64-zvkb-zvkg-zvkned.pl
+++ b/crypto/modes/asm/aes-gcm-riscv64-zvkb-zvkg-zvkned.pl
@@ -611,6 +611,7 @@ $code .= <<___;
 .globl rv64i_zvkb_zvkg_zvkned_aes_gcm_encrypt
 .type rv64i_zvkb_zvkg_zvkned_aes_gcm_encrypt,\@function
 rv64i_zvkb_zvkg_zvkned_aes_gcm_encrypt:
+    @{[lpad 0]}
     srli $T0, $LEN, 4
     beqz $T0, .Lenc_end
     slli $LEN32, $T0, 2
@@ -639,6 +640,7 @@ ___
 $code .= <<___;
 .p2align 3
 aes_gcm_enc_blocks_128:
+    @{[lpad 0]}
     srli $CTR, $FULL_BLOCK_LEN32, 2
     slli $T0, $FULL_BLOCK_LEN32, 2
 
@@ -688,6 +690,7 @@ ___
 $code .= <<___;
 .p2align 3
 aes_gcm_enc_blocks_192:
+    @{[lpad 0]}
     srli $CTR, $FULL_BLOCK_LEN32, 2
     slli $T0, $FULL_BLOCK_LEN32, 2
 
@@ -737,6 +740,7 @@ ___
 $code .= <<___;
 .p2align 3
 aes_gcm_enc_blocks_256:
+    @{[lpad 0]}
     srli $CTR, $FULL_BLOCK_LEN32, 2
     slli $T0, $FULL_BLOCK_LEN32, 2
 
@@ -796,6 +800,7 @@ $code .= <<___;
 .globl rv64i_zvkb_zvkg_zvkned_aes_gcm_decrypt
 .type rv64i_zvkb_zvkg_zvkned_aes_gcm_decrypt,\@function
 rv64i_zvkb_zvkg_zvkned_aes_gcm_decrypt:
+    @{[lpad 0]}
     srli $T0, $LEN, 4
     beqz $T0, .Ldec_end
     slli $LEN32, $T0, 2
@@ -823,6 +828,7 @@ ___
 $code .= <<___;
 .p2align 3
 aes_gcm_dec_blocks_128:
+    @{[lpad 0]}
     srli $CTR, $FULL_BLOCK_LEN32, 2
     slli $T0, $FULL_BLOCK_LEN32, 2
 
@@ -872,6 +878,7 @@ ___
 $code .= <<___;
 .p2align 3
 aes_gcm_dec_blocks_192:
+    @{[lpad 0]}
     srli $CTR, $FULL_BLOCK_LEN32, 2
     slli $T0, $FULL_BLOCK_LEN32, 2
 
@@ -921,6 +928,7 @@ ___
 $code .= <<___;
 .p2align 3
 aes_gcm_dec_blocks_256:
+    @{[lpad 0]}
     srli $CTR, $FULL_BLOCK_LEN32, 2
     slli $T0, $FULL_BLOCK_LEN32, 2
 

--- a/crypto/modes/asm/ghash-riscv64-zvkb-zvbc.pl
+++ b/crypto/modes/asm/ghash-riscv64-zvkb-zvbc.pl
@@ -73,6 +73,7 @@ $code .= <<___;
 .globl gcm_init_rv64i_zvkb_zvbc
 .type gcm_init_rv64i_zvkb_zvbc,\@function
 gcm_init_rv64i_zvkb_zvbc:
+    @{[lpad 0]}
     # Load/store data in reverse order.
     # This is needed as a part of endianness swap.
     add $H, $H, 8
@@ -130,6 +131,7 @@ $code .= <<___;
 .globl gcm_gmult_rv64i_zvkb_zvbc
 .type gcm_gmult_rv64i_zvkb_zvbc,\@function
 gcm_gmult_rv64i_zvkb_zvbc:
+    @{[lpad 0]}
     ld $TMP0, ($Htable)
     ld $TMP1, 8($Htable)
     li $TMP2, 63
@@ -250,6 +252,7 @@ $code .= <<___;
 .globl gcm_ghash_rv64i_zvkb_zvbc
 .type gcm_ghash_rv64i_zvkb_zvbc,\@function
 gcm_ghash_rv64i_zvkb_zvbc:
+    @{[lpad 0]}
     ld $TMP0, ($Htable)
     ld $TMP1, 8($Htable)
     li $TMP2, 63

--- a/crypto/modes/asm/ghash-riscv64-zvkg.pl
+++ b/crypto/modes/asm/ghash-riscv64-zvkg.pl
@@ -77,6 +77,7 @@ $code .= <<___;
 .globl gcm_init_rv64i_zvkg
 .type gcm_init_rv64i_zvkg,\@function
 gcm_init_rv64i_zvkg:
+    @{[lpad 0]}
     ld      $VAL0, 0($H)
     ld      $VAL1, 8($H)
     @{[sd_rev8_rv64i $VAL0, $Htable, 0, $TMP0]}
@@ -94,6 +95,7 @@ $code .= <<___;
 .globl gcm_init_rv64i_zvkg_zvkb
 .type gcm_init_rv64i_zvkg_zvkb,\@function
 gcm_init_rv64i_zvkg_zvkb:
+    @{[lpad 0]}
     @{[vsetivli__x0_2_e64_m1_tu_mu]} # vsetivli x0, 2, e64, m1, tu, mu
     @{[vle64_v $V0, $H]}             # vle64.v v0, (a1)
     @{[vrev8_v $V0, $V0]}            # vrev8.v v0, v0
@@ -118,6 +120,7 @@ $code .= <<___;
 .globl gcm_gmult_rv64i_zvkg
 .type gcm_gmult_rv64i_zvkg,\@function
 gcm_gmult_rv64i_zvkg:
+    @{[lpad 0]}
     @{[vsetivli__x0_4_e32_m1_tu_mu]}
     @{[vle32_v $VS2, $Htable]}
     @{[vle32_v $VD, $Xi]}
@@ -146,6 +149,7 @@ $code .= <<___;
 .globl gcm_ghash_rv64i_zvkg
 .type gcm_ghash_rv64i_zvkg,\@function
 gcm_ghash_rv64i_zvkg:
+    @{[lpad 0]}
     @{[vsetivli__x0_4_e32_m1_tu_mu]}
     @{[vle32_v $vH, $Htable]}
     @{[vle32_v $vXi, $Xi]}

--- a/crypto/modes/asm/ghash-riscv64.pl
+++ b/crypto/modes/asm/ghash-riscv64.pl
@@ -74,6 +74,7 @@ $code .= <<___;
 .globl gcm_init_rv64i_zbc
 .type gcm_init_rv64i_zbc,\@function
 gcm_init_rv64i_zbc:
+    @{[lpad 0]}
     ld      $VAL0,0($H)
     ld      $VAL1,8($H)
     @{[brev8_rv64i   $VAL0, $TMP0, $TMP1, $TMP2]}
@@ -93,6 +94,7 @@ $code .= <<___;
 .globl gcm_init_rv64i_zbc__zbb
 .type gcm_init_rv64i_zbc__zbb,\@function
 gcm_init_rv64i_zbc__zbb:
+    @{[lpad 0]}
     ld      $VAL0,0($H)
     ld      $VAL1,8($H)
     @{[brev8_rv64i $VAL0, $TMP0, $TMP1, $TMP2]}
@@ -114,6 +116,7 @@ $code .= <<___;
 .globl gcm_init_rv64i_zbc__zbkb
 .type gcm_init_rv64i_zbc__zbkb,\@function
 gcm_init_rv64i_zbc__zbkb:
+    @{[lpad 0]}
     ld      $TMP0,0($H)
     ld      $TMP1,8($H)
     @{[brev8 $TMP0, $TMP0]}
@@ -152,6 +155,7 @@ $code .= <<___;
 .globl gcm_gmult_rv64i_zbc
 .type gcm_gmult_rv64i_zbc,\@function
 gcm_gmult_rv64i_zbc:
+    @{[lpad 0]}
     # Load Xi and bit-reverse it
     ld        $x0, 0($Xi)
     ld        $x1, 8($Xi)
@@ -209,6 +213,7 @@ $code .= <<___;
 .globl gcm_gmult_rv64i_zbc__zbkb
 .type gcm_gmult_rv64i_zbc__zbkb,\@function
 gcm_gmult_rv64i_zbc__zbkb:
+    @{[lpad 0]}
     # Load Xi and bit-reverse it
     ld        $x0, 0($Xi)
     ld        $x1, 8($Xi)
@@ -277,6 +282,7 @@ $code .= <<___;
 .globl gcm_ghash_rv64i_zbc
 .type gcm_ghash_rv64i_zbc,\@function
 gcm_ghash_rv64i_zbc:
+    @{[lpad 0]}
     # Load Xi and bit-reverse it
     ld        $x0, 0($Xi)
     ld        $x1, 8($Xi)
@@ -348,6 +354,7 @@ $code .= <<___;
 .globl gcm_ghash_rv64i_zbc__zbkb
 .type gcm_ghash_rv64i_zbc__zbkb,\@function
 gcm_ghash_rv64i_zbc__zbkb:
+    @{[lpad 0]}
     # Load Xi and bit-reverse it
     ld        $x0, 0($Xi)
     ld        $x1, 8($Xi)

--- a/crypto/perlasm/riscv.pm
+++ b/crypto/perlasm/riscv.pm
@@ -1129,4 +1129,16 @@ sub vrgather_vv{
     return ".word ".($template | ($vs2 << 20) | ($vs1 << 15 ) | ($vd << 7));
 }
 
+## Zicfilp (Control Flow Integrity - Landing Pad) support
+
+sub lpad {
+    # lpad instruction - landing pad for forward-edge CFI
+    # Encoding: AUIPC x0, <lpl>
+    # On hardware without Zicfilp: executes as AUIPC x0 (writes to zero register, harmless NOP)
+    # On hardware with Zicfilp: performs landing pad check for CFI
+    my $lpl = shift // 0;  # Landing pad label, default to 0
+    my $encoding = 0x00000017 | ($lpl << 12);
+    return "    .word $encoding";
+}
+
 1;

--- a/crypto/riscv32cpuid.pl
+++ b/crypto/riscv32cpuid.pl
@@ -6,6 +6,10 @@
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
+use FindBin qw($Bin);
+use lib "$Bin";
+use lib "$Bin/perlasm";
+use riscv;
 
 # $output is the last argument if it looks like a file (it has an extension)
 # $flavour is the first argument if it doesn't look like a file
@@ -25,6 +29,7 @@ $code.=<<___;
 .globl CRYPTO_memcmp
 .type   CRYPTO_memcmp,\@function
 CRYPTO_memcmp:
+    @{[lpad 0]}
     li      $x,0
     beqz    $len,2f   # len == 0
 1:
@@ -52,6 +57,7 @@ $code.=<<___;
 .globl OPENSSL_cleanse
 .type   OPENSSL_cleanse,\@function
 OPENSSL_cleanse:
+    @{[lpad 0]}
     beqz    $len,2f         # len == 0, return
     srli    $temp1,$len,4
     bnez    $temp1,3f       # len > 15

--- a/crypto/riscv64cpuid.pl
+++ b/crypto/riscv64cpuid.pl
@@ -6,6 +6,10 @@
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
+use FindBin qw($Bin);
+use lib "$Bin";
+use lib "$Bin/perlasm";
+use riscv;
 
 # $output is the last argument if it looks like a file (it has an extension)
 # $flavour is the first argument if it doesn't look like a file
@@ -25,6 +29,7 @@ $code.=<<___;
 .globl CRYPTO_memcmp
 .type   CRYPTO_memcmp,\@function
 CRYPTO_memcmp:
+    @{[lpad 0]}
     li      $x,0
     beqz    $len,2f   # len == 0
 1:
@@ -52,6 +57,7 @@ $code.=<<___;
 .globl OPENSSL_cleanse
 .type   OPENSSL_cleanse,\@function
 OPENSSL_cleanse:
+    @{[lpad 0]}
     beqz    $len,2f         # len == 0, return
     srli    $temp1,$len,4
     bnez    $temp1,3f       # len > 15
@@ -94,6 +100,7 @@ $code .= <<___;
 .globl riscv_vlen_asm
 .type riscv_vlen_asm,\@function
 riscv_vlen_asm:
+    @{[lpad 0]}
     # 0xc22 is CSR vlenb
     csrr $ret, 0xc22
     slli $ret, $ret, 3

--- a/crypto/sha/asm/sha256-riscv64-zbb.pl
+++ b/crypto/sha/asm/sha256-riscv64-zbb.pl
@@ -271,6 +271,7 @@ $code .= <<___;
 .globl sha256_block_data_order@{[$isaext]}
 .type   sha256_block_data_order@{[$isaext]},\@function
 sha256_block_data_order@{[$isaext]}:
+    @{[lpad 0]}
 
     addi sp, sp, -96
 

--- a/crypto/sha/asm/sha256-riscv64-zvkb-zvknha_or_zvknhb.pl
+++ b/crypto/sha/asm/sha256-riscv64-zvkb-zvknha_or_zvknhb.pl
@@ -117,6 +117,7 @@ $code .= <<___;
 .globl sha256_block_data_order_zvkb_zvknha_or_zvknhb
 .type   sha256_block_data_order_zvkb_zvknha_or_zvknhb,\@function
 sha256_block_data_order_zvkb_zvknha_or_zvknhb:
+    @{[lpad 0]}
 
     # Setup v0 mask for the vmerge to replace the first word (idx==0) in key-scheduling.
     # The AVL is 4 in SHA, so we could use a single e8(8 element masking) for masking.

--- a/crypto/sha/asm/sha512-riscv64-zbb.pl
+++ b/crypto/sha/asm/sha512-riscv64-zbb.pl
@@ -196,6 +196,7 @@ $code .= <<___;
 .globl sha512_block_data_order_zbb
 .type   sha512_block_data_order_zbb,\@function
 sha512_block_data_order_zbb:
+    @{[lpad 0]}
 
     addi sp, sp, -96
 

--- a/crypto/sha/asm/sha512-riscv64-zvkb-zvknhb.pl
+++ b/crypto/sha/asm/sha512-riscv64-zvkb-zvknhb.pl
@@ -79,6 +79,8 @@ $code .= <<___;
 .globl sha512_block_data_order_zvkb_zvknhb
 .type sha512_block_data_order_zvkb_zvknhb,\@function
 sha512_block_data_order_zvkb_zvknhb:
+    @{[lpad 0]}
+
     # H is stored as {a,b,c,d},{e,f,g,h}, but we need {f,e,b,a},{h,g,d,c}
     # The dst vtype is e64m2 and the index vtype is e8mf4.
     # We use index-load with the following index pattern at v1.

--- a/crypto/sm3/asm/sm3-riscv64-zbb.pl
+++ b/crypto/sm3/asm/sm3-riscv64-zbb.pl
@@ -302,6 +302,7 @@ $code .= <<___;
 .globl ossl_sm3_block_data_order_zbb
 .type   ossl_sm3_block_data_order_zbb,\@function
 ossl_sm3_block_data_order_zbb:
+    @{[lpad 0]}
 
     addi sp, sp, -96
 

--- a/crypto/sm3/asm/sm3-riscv64-zvksh.pl
+++ b/crypto/sm3/asm/sm3-riscv64-zvksh.pl
@@ -76,6 +76,7 @@ $code .= <<___;
 .globl ossl_hwsm3_block_data_order_zvksh
 .type ossl_hwsm3_block_data_order_zvksh,\@function
 ossl_hwsm3_block_data_order_zvksh:
+    @{[lpad 0]}
     # Obtain VLEN and select the corresponding branch
     csrr t0, vlenb
     srl t1, t0, 5
@@ -246,6 +247,7 @@ ossl_hwsm3_block_data_order_zvksh_zvl256:
     @{[vsetivli "zero", 8, "e32", "m1", "ta", "ma"]}
     j ossl_hwsm3_block_data_order_zvksh_single
 ossl_hwsm3_block_data_order_zvksh_zvl128:
+    @{[lpad 0]}
     @{[vsetivli "zero", 8, "e32", "m2", "ta", "ma"]}
 ossl_hwsm3_block_data_order_zvksh_single:
     # Load initial state of hash context (c->A-H).

--- a/crypto/sm4/asm/sm4-riscv64-zvksed.pl
+++ b/crypto/sm4/asm/sm4-riscv64-zvksed.pl
@@ -624,6 +624,7 @@ $code .= <<___;
 .globl rv64i_zvksed_sm4_set_encrypt_key
 .type rv64i_zvksed_sm4_set_encrypt_key,\@function
 rv64i_zvksed_sm4_set_encrypt_key:
+    @{[lpad 0]}
     @{[vsetivli__x0_4_e32_m1_tu_mu]}
 
     # Load the user key
@@ -680,6 +681,7 @@ $code .= <<___;
 .globl rv64i_zvksed_sm4_set_decrypt_key
 .type rv64i_zvksed_sm4_set_decrypt_key,\@function
 rv64i_zvksed_sm4_set_decrypt_key:
+    @{[lpad 0]}
     @{[vsetivli__x0_4_e32_m1_tu_mu]}
 
     # Load the user key
@@ -738,6 +740,7 @@ $code .= <<___;
 .globl rv64i_zvksed_sm4_encrypt
 .type rv64i_zvksed_sm4_encrypt,\@function
 rv64i_zvksed_sm4_encrypt:
+    @{[lpad 0]}
     @{[vsetivli__x0_4_e32_m1_tu_mu]}
 
     @{[enc_load_key $keys]}
@@ -771,6 +774,7 @@ $code .= <<___;
 .globl rv64i_zvksed_sm4_decrypt
 .type rv64i_zvksed_sm4_decrypt,\@function
 rv64i_zvksed_sm4_decrypt:
+    @{[lpad 0]}
     @{[vsetivli__x0_4_e32_m1_tu_mu]}
 
     @{[dec_load_key $keys]}

--- a/crypto/sm4/asm/sm4-riscv64-zvksed.pl
+++ b/crypto/sm4/asm/sm4-riscv64-zvksed.pl
@@ -248,6 +248,7 @@ $code .= <<___;
 .globl rv64i_zvksed_sm4_cbc_encrypt
 .type rv64i_zvksed_sm4_cbc_encrypt,\@function
 rv64i_zvksed_sm4_cbc_encrypt:
+    @{[lpad 0]}
     # check whether the length is a multiple of 16 and >= 16
     li $tmp, $BLOCK_SIZE
     bltu $len, $tmp, .Lcbc_enc_end
@@ -382,6 +383,7 @@ $code .= <<___;
 .globl rv64i_zvksed_sm4_cbc_decrypt
 .type rv64i_zvksed_sm4_cbc_decrypt,\@function
 rv64i_zvksed_sm4_cbc_decrypt:
+    @{[lpad 0]}
     # check whether the length is a multiple of 16 and >= 16
     li $tmp, $BLOCK_SIZE
     bltu $len, $tmp, .Lcbc_dec_end


### PR DESCRIPTION
Add 'lpad 0' (landing pad) instructions at the beginning of all RISC-V assembly functions to support Forward Control Flow Integrity (Zicfilp extension).

The lpad instruction is encoded as `AUIPC x0, <lpl>`, which is harmless on hardware without Zicfilp support (writes to zero register) and provides CFI protection on hardware with Zicfilp support.

The instruction encoding` (0x00000017 | (lpl << 12)) `is directly emitted as .word, making it compatible with all toolchains.
