### PR TITLE
ISSUE-30451 64 bit build fail from incorrect type

### DIFF
--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -743,7 +743,7 @@ int CRYPTO_atomic_store_int(int *dst, int val, CRYPTO_RWLOCK *lock)
 
     return 1;
 #else
-    InterlockedExchange(dst, val);
+    InterlockedExchange((LONG volatile *)dst, val);
     return 1;
 #endif
 }


### PR DESCRIPTION
Draft PR addresses an incorrect type in InterlockedExchange64 in crypto/threads_win.c 

Initially Reported by Splediferous

Fixes #30451

CLA: trivial

@bbbrumley