### PR TITLE
CHANGES.md: remove duplicating "Added support for RFC 8701 GREASE.." entry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,17 +76,6 @@ OpenSSL Releases
 
 ### Changes between 3.6 and 4.0 [xx XXX xxxx]
 
- * Added support for RFC 8701 GREASE (Generate Random Extensions And Sustain
-   Extensibility). When `SSL_OP_GREASE` is set, the TLS client injects
-   reserved GREASE values into cipher suites, supported versions, supported
-   groups, signature algorithms, key share, and extensions in the ClientHello
-   to prevent ecosystem ossification. The `openssl s_client` command gains a
-   `-grease` option to enable this.
-
-   *William McCormack*
-
-### Changes between 3.6 and 4.0 [xx XXX xxxx]
-
  * Added `-expected-rpks` option to the `openssl s_client`
    and `openssl s_server` commands.  This makes it possible to specify
    one or more public keys expected from the remote peer that are then used


### PR DESCRIPTION
A cleanup after merge conflict resolution in a1420a699d25 "Implement RFC 8701 GREASE for TLS ClientHello".

Fixes: a1420a699d25 "Implement RFC 8701 GREASE for TLS ClientHello".