### PR TITLE
s390x: set minimum architecture level to z10

### DIFF
--- a/crypto/sha/asm/keccak1600-s390x.pl
+++ b/crypto/sha/asm/keccak1600-s390x.pl
@@ -67,6 +67,7 @@ my @rhotates = ([  0,  1, 62, 28, 27 ],
 
 $code.=<<___;
 .text
+.machine	"z10"
 
 .type	__KeccakF1600,\@function
 .align	32


### PR DESCRIPTION
The keccak1600 perlasm file (`keccak1600-s390x.pl`) emits `cijne`, a
z10 compare-immediate-and-branch instruction, without declaring a
minimum architecture level. GCC defaults to `-march=z900` on s390x,
causing assembler errors when building with the default toolchain
flags:

    keccak1600-s390x.S:399: Error: Unrecognized opcode: `cijne'

z900 has been out of service since 2014, the Linux kernel requires
z196 minimum, and clang already defaults to z10 on s390x. A
`.machine "z10"` GAS directive in the generated assembly resolves the
error by declaring the architecture level the file already requires.

Ref: #27323