### PR TITLE
threadstest: handle NULL return from CRYPTO_zalloc

### DIFF
--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -125,7 +125,8 @@ static void rwwriter_fn(int id, int *iterations)
     t1 = ossl_time_now();
 
     for (count = 0;; count++) {
-        new = CRYPTO_zalloc(sizeof(int), NULL, 0);
+        new = OPENSSL_zalloc(sizeof(int));
+        OPENSSL_assert(new != NULL);
         if (contention == 0)
             OSSL_sleep(1000);
         if (!CRYPTO_THREAD_write_lock(rwtorturelock))
@@ -323,7 +324,8 @@ static void writer_fn(int id, int *iterations)
     t1 = ossl_time_now();
 
     for (count = 0;; count++) {
-        new = CRYPTO_malloc(sizeof(uint64_t), NULL, 0);
+        new = OPENSSL_zalloc(sizeof(uint64_t));
+        OPENSSL_assert(new != NULL);
         *new = (uint64_t)0xBAD;
         if (contention == 0)
             OSSL_sleep(1000);


### PR DESCRIPTION
Check the return value of CRYPTO_zalloc() in rwwriter_fn() before dereferencing the allocated pointer.

Also guard the iterations output pointer before writing to it.

Fixes #30017

Signed-off-by: Aditya Patil <ap4078@rit.edu> , <adityapatil.id@gmail.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
