### PR TITLE
Fix missing EVP_CIPHER_get_iv_length() guard in PKCS5_pbe2_set_scrypt

### DIFF
--- a/crypto/asn1/p5_scrypt.c
+++ b/crypto/asn1/p5_scrypt.c
@@ -46,7 +46,7 @@ X509_ALGOR *PKCS5_pbe2_set_scrypt(const EVP_CIPHER *cipher,
     uint64_t p)
 {
     X509_ALGOR *scheme = NULL, *ret = NULL;
-    int alg_nid;
+    int alg_nid, ivlen;
     size_t keylen = 0;
     EVP_CIPHER_CTX *ctx = NULL;
     unsigned char iv[EVP_MAX_IV_LENGTH];
@@ -85,10 +85,11 @@ X509_ALGOR *PKCS5_pbe2_set_scrypt(const EVP_CIPHER *cipher,
     }
 
     /* Create random IV */
-    if (EVP_CIPHER_get_iv_length(cipher)) {
+    ivlen = EVP_CIPHER_get_iv_length(cipher);
+    if (ivlen > 0) {
         if (aiv)
-            memcpy(iv, aiv, EVP_CIPHER_get_iv_length(cipher));
-        else if (RAND_bytes(iv, EVP_CIPHER_get_iv_length(cipher)) <= 0)
+            memcpy(iv, aiv, ivlen);
+        else if (RAND_bytes(iv, ivlen) <= 0)
             goto err;
     }
 


### PR DESCRIPTION
## Summary

In `crypto/asn1/p5_scrypt.c` (lines 87–92), `EVP_CIPHER_get_iv_length(cipher)` is called inline three times without storing the result or checking for a negative return value. Since the function returns `int`, a negative value (e.g. `-1`) is implicitly converted to `size_t` when passed to `memcpy`, producing `SIZE_MAX` and causing a stack buffer overflow on the 16-byte `iv[EVP_MAX_IV_LENGTH]` buffer.

The sibling file `crypto/asn1/p5_pbev2.c` (lines 82–88) already handles this correctly by storing the result in a local `int ivlen` and guarding with `if (ivlen > 0)`.

## Vulnerable code

```c
// crypto/asn1/p5_scrypt.c, lines 87-93
if (EVP_CIPHER_get_iv_length(cipher)) {          // -1 is truthy → enters block
    if (aiv)
        memcpy(iv, aiv, EVP_CIPHER_get_iv_length(cipher));   // (size_t)(-1) = SIZE_MAX
    else if (RAND_bytes(iv, EVP_CIPHER_get_iv_length(cipher)) <= 0)
        goto err;
}
```

## Fixed code (matching p5_pbev2.c pattern)

```c
ivlen = EVP_CIPHER_get_iv_length(cipher);
if (ivlen > 0) {
    if (aiv)
        memcpy(iv, aiv, ivlen);
    else if (RAND_bytes_ex(libctx, iv, ivlen, 0) <= 0)
        goto err;
}
```

## Reproduce steps

1. Build OpenSSL from source with ASan:

```bash
cd /path/to/openssl
./Configure enable-asan
make -j$(nproc)
```

2. Compile the PoC:
[poc.c](https://github.com/user-attachments/files/26135668/poc.c)

```bash
gcc -fsanitize=address -g \
    -I/path/to/openssl/include \
    poc.c -o poc_bin \
    -L/path/to/openssl -lcrypto \
    -Wl,-rpath,/path/to/openssl
```

3. Run:

```bash
./poc_bin
```

4. Expected: ASan reports stack buffer overflow at `p5_scrypt.c:90` in `PKCS5_pbe2_set_scrypt`.

## ASan evidence

```
==1004==ERROR: AddressSanitizer: unknown-crash on address 0x7fffe54b1100
READ of size 18446744073709551615 at 0x7fffe54b1100 thread T0
    #0 memcpy /usr/include/x86_64-linux-gnu/bits/string_fortified.h:29
    #1 PKCS5_pbe2_set_scrypt crypto/asn1/p5_scrypt.c:90
```

The `memcpy` at line 90 attempts to read `SIZE_MAX` (18446744073709551615) bytes from `aiv` into a 16-byte stack buffer `iv[EVP_MAX_IV_LENGTH]`.

## Impact

Stack buffer overflow via `memcpy(iv, aiv, SIZE_MAX)` when a provider-backed cipher returns a negative IV length. Requires loading a malicious or buggy OpenSSL provider.
