### PR TITLE
Fix double-free in mlx_kem_dup() default case

### DIFF
--- a/providers/implementations/keymgmt/mlx_kmgmt.c
+++ b/providers/implementations/keymgmt/mlx_kmgmt.c
@@ -749,6 +749,7 @@ static void *mlx_kem_dup(const void *vkey, int selection)
     default:
         ERR_raise_data(ERR_LIB_PROV, PROV_R_UNSUPPORTED_SELECTION,
             "duplication of partial key material not supported");
+        ret->mkey = ret->xkey = NULL;
         break;
     }
 

--- a/providers/implementations/keymgmt/mlx_kmgmt.c
+++ b/providers/implementations/keymgmt/mlx_kmgmt.c
@@ -719,15 +719,17 @@ static void *mlx_kem_dup(const void *vkey, int selection)
         || (ret = OPENSSL_memdup(key, sizeof(*ret))) == NULL)
         return NULL;
 
-    if (ret->propq != NULL
-        && (ret->propq = OPENSSL_strdup(ret->propq)) == NULL) {
+    ret->mkey = ret->xkey = NULL;
+
+    if (key->propq != NULL
+        && (ret->propq = OPENSSL_strdup(key->propq)) == NULL) {
         OPENSSL_free(ret);
         return NULL;
     }
 
     /* Absent key material, nothing left to do */
-    if (ret->mkey == NULL) {
-        if (ret->xkey == NULL)
+    if (key->mkey == NULL) {
+        if (key->xkey == NULL)
             return ret;
         /* Fail if the source key is an inconsistent state */
         OPENSSL_free(ret->propq);
@@ -737,7 +739,6 @@ static void *mlx_kem_dup(const void *vkey, int selection)
 
     switch (selection & OSSL_KEYMGMT_SELECT_KEYPAIR) {
     case 0:
-        ret->xkey = ret->mkey = NULL;
         ret->state = MLX_HAVE_NOKEYS;
         return ret;
     case OSSL_KEYMGMT_SELECT_KEYPAIR:
@@ -749,7 +750,6 @@ static void *mlx_kem_dup(const void *vkey, int selection)
     default:
         ERR_raise_data(ERR_LIB_PROV, PROV_R_UNSUPPORTED_SELECTION,
             "duplication of partial key material not supported");
-        ret->mkey = ret->xkey = NULL;
         break;
     }
 

--- a/test/ml_kem_evp_extra_test.c
+++ b/test/ml_kem_evp_extra_test.c
@@ -20,6 +20,7 @@
 #include <openssl/param_build.h>
 #include <openssl/rand.h>
 #include <crypto/ml_kem.h>
+#include "crypto/evp.h"
 #include "testutil.h"
 
 static OSSL_LIB_CTX *testctx = NULL;
@@ -420,6 +421,70 @@ static int test_ml_kem_from_data_propq(void)
     return ret;
 }
 
+static const char *mlx_kem_algs[] = {
+    "X25519MLKEM768",
+    "SecP256r1MLKEM768",
+    "SecP384r1MLKEM1024",
+};
+
+/*
+ * Test that mlx_kem_dup() with partial selection (public-only) does not
+ * corrupt the original key. Before the fix, the default branch of the
+ * switch in mlx_kem_dup() would call mlx_kem_key_free() on a shallow copy
+ * without nulling mkey/xkey first, causing a double-free when the original
+ * key was later freed.
+ */
+static int test_mlx_kem_dup_partial_selection(int idx)
+{
+    const char *alg = mlx_kem_algs[idx];
+    EVP_PKEY_CTX *genctx = NULL;
+    EVP_PKEY_CTX *encctx = NULL;
+    EVP_PKEY *keypair = NULL;
+    EVP_PKEY *dest = NULL;
+    size_t wrpkeylen = 0, genkeylen = 0;
+    int ret = 0;
+
+    /* Generate an MLX KEM keypair */
+    if (!TEST_ptr(genctx = EVP_PKEY_CTX_new_from_name(testctx, alg, NULL))
+        || !TEST_int_eq(EVP_PKEY_keygen_init(genctx), 1)
+        || !TEST_int_eq(EVP_PKEY_keygen(genctx, &keypair), 1))
+        goto err;
+
+    /*
+     * Attempt a partial copy (public-key only). EVP_PKEY_PUBLIC_KEY includes
+     * OSSL_KEYMGMT_SELECT_PUBLIC_KEY (0x02) but not private, so
+     * selection & OSSL_KEYMGMT_SELECT_KEYPAIR == 0x02 which hits the default
+     * branch in mlx_kem_dup(). This should fail gracefully without corrupting
+     * the source key.
+     */
+    if (!TEST_ptr(dest = EVP_PKEY_new()))
+        goto err;
+    /* Expected to fail — partial duplication is not supported for MLX KEM */
+    evp_keymgmt_util_copy(dest, keypair, EVP_PKEY_PUBLIC_KEY);
+    ERR_clear_error();
+
+    /*
+     * Verify the original keypair is still intact by performing an
+     * encapsulate operation. If the partial copy corrupted the key
+     * (double-freed mkey/xkey), this would crash or trigger ASan.
+     */
+    if (!TEST_ptr(encctx = EVP_PKEY_CTX_new_from_pkey(testctx, keypair, NULL))
+        || !TEST_int_gt(EVP_PKEY_encapsulate_init(encctx, NULL), 0)
+        || !TEST_int_gt(EVP_PKEY_encapsulate(encctx, NULL, &wrpkeylen,
+                                             NULL, &genkeylen), 0)
+        || !TEST_size_t_gt(wrpkeylen, 0)
+        || !TEST_size_t_gt(genkeylen, 0))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_PKEY_CTX_free(encctx);
+    EVP_PKEY_free(dest);
+    EVP_PKEY_free(keypair);
+    EVP_PKEY_CTX_free(genctx);
+    return ret;
+}
+
 int setup_tests(void)
 {
     int test_rand = 0;
@@ -448,5 +513,6 @@ int setup_tests(void)
 
     ADD_TEST(test_ml_kem);
     ADD_TEST(test_ml_kem_from_data_propq);
+    ADD_ALL_TESTS(test_mlx_kem_dup_partial_selection, OSSL_NELEM(mlx_kem_algs));
     return 1;
 }

--- a/test/ml_kem_evp_extra_test.c
+++ b/test/ml_kem_evp_extra_test.c
@@ -423,9 +423,9 @@ static int test_ml_kem_from_data_propq(void)
 
 #ifndef OPENSSL_NO_EC
 static const char *mlx_kem_algs[] = {
-# ifndef OPENSSL_NO_ECX
+#ifndef OPENSSL_NO_ECX
     "X25519MLKEM768",
-# endif
+#endif
     "SecP256r1MLKEM768",
     "SecP384r1MLKEM1024",
 };
@@ -476,8 +476,8 @@ static int test_mlx_kem_dup_partial_selection(int idx)
     if (!TEST_ptr(encctx = EVP_PKEY_CTX_new_from_pkey(testctx, keypair, NULL))
         || !TEST_int_gt(EVP_PKEY_encapsulate_init(encctx, NULL), 0)
         || !TEST_int_gt(EVP_PKEY_encapsulate(encctx, NULL, &wrpkeylen,
-                                             NULL, &genkeylen),
-                        0)
+                            NULL, &genkeylen),
+            0)
         || !TEST_size_t_gt(wrpkeylen, 0)
         || !TEST_size_t_gt(genkeylen, 0))
         goto err;

--- a/test/ml_kem_evp_extra_test.c
+++ b/test/ml_kem_evp_extra_test.c
@@ -421,11 +421,15 @@ static int test_ml_kem_from_data_propq(void)
     return ret;
 }
 
+#ifndef OPENSSL_NO_EC
 static const char *mlx_kem_algs[] = {
+# ifndef OPENSSL_NO_ECX
     "X25519MLKEM768",
+# endif
     "SecP256r1MLKEM768",
     "SecP384r1MLKEM1024",
 };
+#endif
 
 /*
  * Test that mlx_kem_dup() with partial selection (public-only) does not
@@ -434,6 +438,7 @@ static const char *mlx_kem_algs[] = {
  * without nulling mkey/xkey first, causing a double-free when the original
  * key was later freed.
  */
+#ifndef OPENSSL_NO_EC
 static int test_mlx_kem_dup_partial_selection(int idx)
 {
     const char *alg = mlx_kem_algs[idx];
@@ -471,7 +476,8 @@ static int test_mlx_kem_dup_partial_selection(int idx)
     if (!TEST_ptr(encctx = EVP_PKEY_CTX_new_from_pkey(testctx, keypair, NULL))
         || !TEST_int_gt(EVP_PKEY_encapsulate_init(encctx, NULL), 0)
         || !TEST_int_gt(EVP_PKEY_encapsulate(encctx, NULL, &wrpkeylen,
-                                             NULL, &genkeylen), 0)
+                                             NULL, &genkeylen),
+                        0)
         || !TEST_size_t_gt(wrpkeylen, 0)
         || !TEST_size_t_gt(genkeylen, 0))
         goto err;
@@ -484,6 +490,7 @@ err:
     EVP_PKEY_CTX_free(genctx);
     return ret;
 }
+#endif /* OPENSSL_NO_EC */
 
 int setup_tests(void)
 {
@@ -513,6 +520,8 @@ int setup_tests(void)
 
     ADD_TEST(test_ml_kem);
     ADD_TEST(test_ml_kem_from_data_propq);
+#ifndef OPENSSL_NO_EC
     ADD_ALL_TESTS(test_mlx_kem_dup_partial_selection, OSSL_NELEM(mlx_kem_algs));
+#endif
     return 1;
 }


### PR DESCRIPTION
## Summary

In `providers/implementations/keymgmt/mlx_kmgmt.c`, `mlx_kem_dup()` uses `OPENSSL_memdup` to create a shallow copy of the key structure. In the `default` branch of the `switch(selection & OSSL_KEYMGMT_SELECT_KEYPAIR)`, the function raises an error and falls through to `mlx_kem_key_free(ret)`. However, `ret->mkey` and `ret->xkey` still point to the same objects as the original key. `mlx_kem_key_free` calls `EVP_PKEY_free` on both, dropping their refcount to 0 and destroying them. When the original key is later freed, it triggers a double-free / heap-use-after-free on the already-freed sub-keys.

The `case 0` branch already handles this correctly by nulling out `ret->mkey` and `ret->xkey` before returning.

## Vulnerable code

```c
// providers/implementations/keymgmt/mlx_kmgmt.c, ~line 749
default:
    ERR_raise_data(ERR_LIB_PROV, PROV_R_UNSUPPORTED_SELECTION,
        "duplication of partial key material not supported");
    break;   // ret->mkey/xkey still point to original key's sub-objects!
}

mlx_kem_key_free(ret);  // frees original key's mkey and xkey via shallow copy
return NULL;
```

## Fixed code

```c
default:
    ERR_raise_data(ERR_LIB_PROV, PROV_R_UNSUPPORTED_SELECTION,
        "duplication of partial key material not supported");
    ret->mkey = ret->xkey = NULL;
    break;
}

mlx_kem_key_free(ret);  // now only frees the shallow-copied shell
return NULL;
```

## Reproduce steps

1. Build OpenSSL from source with ASan:

```bash
cd /path/to/openssl
./Configure enable-asan
make -j$(nproc)
```

2. Compile the PoC (generates an X25519MLKEM768 keypair, then calls `evp_keymgmt_util_copy` with `EVP_PKEY_PUBLIC_KEY` selection to trigger the `default` branch):
[poc.c](https://github.com/user-attachments/files/26137124/poc.c)

```bash
gcc -fsanitize=address -g \
    -I/path/to/openssl/include -I/path/to/openssl \
    poc.c -o poc \
    /path/to/openssl/libcrypto.a \
    -lpthread -ldl
```

3. Run:

```bash
./poc
```

4. Expected: ASan reports `heap-use-after-free` when freeing the original keypair.

## ASan evidence

```
==PID==ERROR: AddressSanitizer: heap-use-after-free
    #0 EVP_PKEY_free
    #1 mlx_kem_key_free
    ...
    freed by:
    #0 EVP_PKEY_free
    #1 mlx_kem_key_free
    #2 mlx_kem_dup
    #3 evp_keymgmt_dup
    #4 evp_keymgmt_util_copy
```

## Impact

Double-free / use-after-free via public API. Triggerable by calling `evp_keymgmt_util_copy()` with partial selection (e.g. `EVP_PKEY_PUBLIC_KEY`) on any MLX KEM keypair (X25519MLKEM768, X448MLKEM1024, SecP256r1MLKEM768, SecP384r1MLKEM1024). Does not require loading a custom provider — only standard OpenSSL API calls are needed.
