### PR TITLE
Fix b->init set before return value check in conn_ctrl

### DIFF
--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -508,7 +508,6 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     case BIO_C_SET_CONNECT:
         if (ptr != NULL) {
-            b->init = 1;
             if (num == 0) { /* BIO_set_conn_hostname */
                 char *hold_service = data->param_service;
                 /* We affect the hostname regardless.  However, the input
@@ -524,10 +523,14 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
                     BIO_PARSE_PRIO_HOST);
                 if (hold_service != data->param_service)
                     OPENSSL_free(hold_service);
+                if (ret > 0)
+                    b->init = 1;
             } else if (num == 1) { /* BIO_set_conn_port */
                 OPENSSL_free(data->param_service);
                 if ((data->param_service = OPENSSL_strdup(ptr)) == NULL)
                     ret = 0;
+                else
+                    b->init = 1;
             } else if (num == 2) { /* BIO_set_conn_address */
                 const BIO_ADDR *addr = (const BIO_ADDR *)ptr;
                 char *host = BIO_ADDR_hostname_string(addr, 1);
@@ -542,12 +545,14 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
                     BIO_ADDRINFO_free(data->addr_first);
                     data->addr_first = NULL;
                     data->addr_iter = NULL;
+                    b->init = 1;
                 } else {
                     OPENSSL_free(host);
                     OPENSSL_free(service);
                 }
             } else if (num == 3) { /* BIO_set_conn_ip_family */
                 data->connect_family = *(int *)ptr;
+                b->init = 1;
             } else {
                 ret = 0;
             }


### PR DESCRIPTION
## Summary

In `crypto/bio/bss_conn.c`, the `BIO_C_SET_CONNECT` handler unconditionally sets `b->init = 1` at the top (line 511) before any of the fallible sub-operations (`BIO_parse_hostserv`, `OPENSSL_strdup`, `BIO_ADDR_hostname_string`). If any of these operations fail, the BIO is incorrectly marked as initialized with NULL internal fields, which can lead to downstream NULL pointer dereferences (e.g., `BIO_lookup(NULL, ...)` in `conn_state()`).

The sibling file `crypto/bio/bss_acpt.c` was already fixed with the correct guard pattern (`if (ret > 0) b->init = 1`), but `bss_conn.c` was not updated.

## Vulnerable code

```c
// crypto/bio/bss_conn.c, conn_ctrl(), case BIO_C_SET_CONNECT:
b->init = 1;                          // unconditional — before any fallible call
if (num == 0) {
    ...
    ret = BIO_parse_hostserv(ptr, ...);  // can fail
    // if ret <= 0: b->init == 1 but param_hostname is NULL
} else if (num == 1) {
    if ((data->param_service = OPENSSL_strdup(ptr)) == NULL)
        ret = 0;                         // b->init == 1 but param_service is NULL
}
```

## Fixed code (matching bss_acpt.c pattern)

```c
if (num == 0) {
    ...
    ret = BIO_parse_hostserv(ptr, ...);
    ...
    if (ret > 0)
        b->init = 1;
} else if (num == 1) {
    if ((data->param_service = OPENSSL_strdup(ptr)) == NULL)
        ret = 0;
    else
        b->init = 1;
} else if (num == 2) {
    ...
    if (ret) {
        ...
        b->init = 1;
    }
} else if (num == 3) {
    data->connect_family = *(int *)ptr;
    b->init = 1;
}
```

## Reproduce steps

1. Build OpenSSL from source:

```bash
cd /path/to/openssl
./Configure enable-asan
make -j$(nproc)
```

2. Compile the PoC:
[poc.c](https://github.com/user-attachments/files/26142752/poc.c)



```bash
gcc -fsanitize=address -g \
    -I/path/to/openssl/include \
    poc.c -o poc \
    /path/to/openssl/libcrypto.a \
    -lpthread -ldl
```

3. Run:

```bash
./poc
```

5. Expected (before fix): `BIO_get_init after failed set: 1` — BIO incorrectly marked as initialized despite `BIO_set_conn_hostname` returning failure.

6. Expected (after fix): `BIO_get_init after failed set: 0`.

