### PR TITLE
apps: Make s_client -quiet really quiet

### DIFF
--- a/apps/include/s_apps.h
+++ b/apps/include/s_apps.h
@@ -37,7 +37,7 @@ int ssl_print_tmp_key(BIO *out, SSL *s);
 int init_client(int *sock, const char *host, const char *port,
     const char *bindhost, const char *bindport,
     int family, int type, int protocol, int tfo, int doconn,
-    BIO_ADDR **ba_ret);
+    BIO_ADDR **ba_ret, int c_quiet);
 int should_retry(int i);
 void do_ssl_shutdown(SSL *ssl);
 

--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -75,7 +75,7 @@ BIO_ADDR *ourpeer = NULL;
 int init_client(int *sock, const char *host, const char *port,
     const char *bindhost, const char *bindport,
     int family, int type, int protocol, int tfo, int doconn,
-    BIO_ADDR **ba_ret)
+    BIO_ADDR **ba_ret, int c_quiet)
 {
     BIO_ADDRINFO *res = NULL;
     BIO_ADDRINFO *bindaddr = NULL;
@@ -208,10 +208,12 @@ int init_client(int *sock, const char *host, const char *port,
     } else {
         char *hostname = NULL;
 
-        hostname = BIO_ADDR_hostname_string(BIO_ADDRINFO_address(ai), 1);
-        if (hostname != NULL) {
-            BIO_printf(bio_err, "Connecting to %s\n", hostname);
-            OPENSSL_free(hostname);
+        if (!c_quiet) {
+            hostname = BIO_ADDR_hostname_string(BIO_ADDRINFO_address(ai), 1);
+            if (hostname != NULL) {
+                BIO_printf(bio_err, "Connecting to %s\n", hostname);
+                OPENSSL_free(hostname);
+            }
         }
         /* Remove any stale errors from previous connection attempts */
         ERR_clear_error();

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1291,7 +1291,7 @@ int s_client_main(int argc, char **argv)
             crlf = 1;
             break;
         case OPT_QUIET:
-            c_quiet = c_ign_eof = 1;
+            verify_args.quiet = c_quiet = c_ign_eof = 1;
             break;
         case OPT_NBIO:
             c_nbio = 1;
@@ -2426,7 +2426,7 @@ re_start:
     BIO_ADDR_free(peer_addr);
     peer_addr = NULL;
     if (init_client(&sock, host, port, bindhost, bindport, socket_family,
-            socket_type, protocol, tfo, !isquic, &peer_addr)
+            socket_type, protocol, tfo, !isquic, &peer_addr, c_quiet)
         == 0) {
         BIO_printf(bio_err, "connect:errno=%d\n", get_last_socket_error());
         BIO_closesocket(sock);

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -530,8 +530,8 @@ input. This implicitly turns on B<-nocommands> as well.
 
 =item B<-quiet>
 
-Inhibit printing of session and certificate information.  This implicitly
-turns on B<-ign_eof> and B<-nocommands> as well.
+Inhibit printing any non-error-related information.  This implicitly
+turns on B<-ign_eof>, B<-nocommands> and B<-verify_quiet> as well.
 
 =item B<-no_ign_eof>
 


### PR DESCRIPTION
Desptie the -quiet option s_client still reports the host it connects to and the certifcate chain. Since -quiet is documented as "No s_client output" hide all non-error output.

Pass the quiet option to init_client() to supress the host output. Set verify's quiet flag if quiet is passed.
