### PR TITLE
apps: Move PATH_MAX define out of the win32 block

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -18,9 +18,9 @@
 #if defined(_WIN32)
 /* Included before async.h to avoid some warnings */
 #include <windows.h>
+#endif
 #if !defined(OPENSSL_NO_ECH) && !defined(PATH_MAX)
 #define PATH_MAX 4096
-#endif
 #endif
 
 #include <openssl/e_os2.h>


### PR DESCRIPTION
The PATH_MAX define is needed on HURD which is now skipped since it is winthin the _WIN32 block.

Move the PATH_MAX check+define outside of the _WIN32 block.