### PR TITLE
Fix Windows compilation and test output

### DIFF
--- a/providers/common/der/oids_to_c.pm
+++ b/providers/common/der/oids_to_c.pm
@@ -80,7 +80,7 @@ sub _process {
         # print STDERR "-----BEGIN DEBUG-----\n";
         # print STDERR $text;
         # print STDERR "-----END DEBUG-----\n";
-        use re 'debugcolor';
+        use re 'debug';
         while ($text =~ m/${OID_def_re}/sg) {
             my $comment = $&;
             my $name = $1;

--- a/test/recipes/05-test_rand.t
+++ b/test/recipes/05-test_rand.t
@@ -13,7 +13,7 @@ use OpenSSL::Test::Utils;
 use OpenSSL::Test qw/:DEFAULT srctop_file bldtop_dir/;
 use Cwd qw(abs_path);
 
-plan tests => 5;
+plan tests => 6;
 setup("test_rand");
 
 ok(run(test(["rand_test", srctop_file("test", "default.cnf")])));
@@ -41,8 +41,15 @@ SKIP: {
     chomp(@randdata);
     ok($success && $randdata[0] eq $expected,
        "rand with ossltest provider: Check rand output is as expected");
+}
+
+{
+    my $success;
+    my @randdata;
 
     @randdata = run(app(['openssl', 'rand', '-hex', '2K' ]),
                     capture => 1, statusvar => \$success);
     chomp(@randdata);
+    ok($success && length($randdata[0]) == 4096,
+       "rand: Check rand output is of expected length");
 }


### PR DESCRIPTION
On Windows, there are some messages during compilation and testing that should be removed:

- test_rand is mixed with test output like
`` perl.exe ..\..\util\wrap.pl ..\..\apps\openssl.exe rand  -hex 2K => 0[14:11:00] 05-test_rand.t ......``

- The oids_to_pm with Strawberry Perl often prints these errors: ``Use of uninitialized value in join or string at Strawberry/perl/lib/re.pm line 47.``

This PR tries to fix these.