### PR TITLE
Simplify ossl_namemap_name2num with ossl_namemap_name2num_n

### DIFF
--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -141,28 +141,9 @@ int ossl_namemap_doall_names(const OSSL_NAMEMAP *namemap, int number,
 
 int ossl_namemap_name2num(const OSSL_NAMEMAP *namemap, const char *name)
 {
-    int number = 0;
-    HT_VALUE *val;
-    NAMENUM_KEY key;
-
-#ifndef FIPS_MODULE
-    if (namemap == NULL)
-        namemap = ossl_namemap_stored(NULL);
-#endif
-
-    if (namemap == NULL || name == NULL)
+    if (name == NULL)
         return 0;
-
-    HT_INIT_RAW_KEY(&key);
-    HT_COPY_RAW_KEY_CASE(TO_HT_KEY(&key), name, strlen(name));
-
-    val = ossl_ht_get(namemap->namenum_ht, TO_HT_KEY(&key));
-
-    if (val != NULL)
-        /* We store a (small) int directly instead of a pointer to it. */
-        number = (int)(intptr_t)val->value;
-
-    return number;
+    return ossl_namemap_name2num_n(namemap, name, strlen(name));
 }
 
 int ossl_namemap_name2num_n(const OSSL_NAMEMAP *namemap,


### PR DESCRIPTION
The two functions do the same; there is no reason to maintain duplicit
code.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
