### PR TITLE
[Coverity 1689815] crypto/idea/i_ofb64.c: mask the num value after negativity check

### DIFF
--- a/crypto/idea/i_ofb64.c
+++ b/crypto/idea/i_ofb64.c
@@ -27,7 +27,7 @@ void IDEA_ofb64_encrypt(const unsigned char *in, unsigned char *out,
     unsigned char *ivec, int *num)
 {
     register unsigned long v0, v1, t;
-    register int n = *num & 0x07;
+    register int n = *num;
     register long l = length;
     unsigned char d[8];
     register char *dp;
@@ -39,6 +39,7 @@ void IDEA_ofb64_encrypt(const unsigned char *in, unsigned char *out,
         *num = -1;
         return;
     }
+    n = n & 0x07;
 
     iv = (unsigned char *)ivec;
     n2l(iv, v0);


### PR DESCRIPTION
Commit 5ba9029bc7b3 "Mask *num on entry in deprecated low-level OFB/CFB implementations" introduced masking of the user-supplied num value in several functions, which rendered the exiting *num negativity check introduced in 1634b2df9f12 "enc: fix coverity 1451499, 1451501, 1451506, 1451507, 1351511, 1451514, 1451517, 1451523, 1451526m 1451528, 1451539, 1451441, 1451549, 1451568 & 1451572: improper use of negative value" ineffectual.  While commit b73a5743253d "crypto/idea/i_cfb64.c: condition 'n < 0' can never be met after doing 'n = n & 0x07'" has addressed the issue in crypto/idea/i_cfb64.c:IDEA_cfb64_encrypt(), this commit addresses the same issue
in crypto/idea/i_ofb64.c:IDEA_ofb64_encrypt() in similar fashion, by postponing the masking after the negativity check.

The issue has initially reported by Coverity, ID 1689815.

Resolves: https://scan5.scan.coverity.com/#/project-view/62622/10222?selectedIssue=1689815
Fixes: 5ba9029bc7b3 "Mask *num on entry in deprecated low-level OFB/CFB implementations"
References: b73a5743253d "crypto/idea/i_cfb64.c: condition 'n < 0' can never be met after doing 'n = n & 0x07'"