### PR TITLE
Doc: clarify AAD outl semantics in EVP_EncryptInit

### DIFF
--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -1496,7 +1496,12 @@ depending on the mode specified.
 To specify additional authenticated data (AAD), a call to EVP_CipherUpdate(),
 EVP_EncryptUpdate() or EVP_DecryptUpdate() should be made with the output
 parameter I<out> set to NULL. In this case, on success, the parameter
-I<outl> is set to the number of bytes authenticated.
+I<outl> is set to the number of AAD bytes processed in that call
+(that is, the value of I<inl>), and does not include any plaintext
+or ciphertext bytes processed by other calls.
+
+If no AAD is used, this call can be omitted. See the mode-specific notes
+below for any exceptions.
 
 When decrypting, the return value of EVP_DecryptFinal() or EVP_CipherFinal()
 indicates whether the operation was successful. If it does not indicate success,


### PR DESCRIPTION
Fixes #29761

The EVP_EncryptInit(3) documentation currently says that when AAD is
passed with `out == NULL`, `outl` is set to "the number of bytes
authenticated", which is ambiguous.

This updates the wording to clarify that:
- `outl` reflects the number of AAD bytes processed in that call, and
- if no AAD is used, the AAD call can be omitted, subject to any
  mode-specific exceptions documented below.

This is a documentation-only change.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x ] documentation is added or updated
- [ ] tests are added or updated
