### PR TITLE
Unalias DSA sig dupctx "aid" field

### DIFF
--- a/providers/implementations/signature/dsa_sig.c
+++ b/providers/implementations/signature/dsa_sig.c
@@ -415,6 +415,7 @@ static void *dsa_dupctx(void *vpdsactx)
     dstctx->md = NULL;
     dstctx->mdctx = NULL;
     dstctx->propq = NULL;
+    dstctx->aid = NULL;
 
     if (srcctx->dsa != NULL && !DSA_up_ref(srcctx->dsa))
         goto err;
@@ -435,6 +436,18 @@ static void *dsa_dupctx(void *vpdsactx)
         if (dstctx->propq == NULL)
             goto err;
     }
+    /*
+     * The DER-encoding of the algorithm OID is written at the end of aid_buf.
+     * Check that srcctx->aid points into the source aid_buf and then use the
+     * same offset into dstctx->aid_buf.
+     */
+    if (srcctx->aid != NULL
+        && srcctx->aid_len > 0
+        && srcctx->aid >= srcctx->aid_buf
+        && srcctx->aid + srcctx->aid_len <= srcctx->aid_buf + sizeof(srcctx->aid_buf))
+        dstctx->aid = dstctx->aid_buf + (srcctx->aid - srcctx->aid_buf);
+    else
+        dstctx->aid_len = 0;
 
     return dstctx;
 err:


### PR DESCRIPTION
It points into a static buffer in each context, use the same offset into the copied buffer when duplicating.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
