### PR TITLE
Enable win32 legacy thread on systems older than winxp

### DIFF
--- a/include/internal/thread_arch.h
+++ b/include/internal/thread_arch.h
@@ -24,11 +24,9 @@
 #elif defined(OPENSSL_THREADS) && defined(OPENSSL_SYS_WINDOWS) && defined(_WIN32_WINNT)
 #if _WIN32_WINNT >= 0x0600
 #define OPENSSL_THREADS_WINNT
-#elif _WIN32_WINNT >= 0x0501
+#else
 #define OPENSSL_THREADS_WINNT
 #define OPENSSL_THREADS_WINNT_LEGACY
-#else
-#define OPENSSL_THREADS_NONE
 #endif
 #else
 #define OPENSSL_THREADS_NONE


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
Currently openssl supports using legacy thread apis to run on older windows versions, but those are only enabled for windows xp/vista.
The used legacy apis are actually available on the entire family of windows systems, so they can be unconditionally enabled if the target is lower than windows vista/7.
I don't konw if this change is trivial, as it doesn't change code in any meaningful way (other than making builds that targeted very old windows versions no longer implicitly single thread)