### PR TITLE
Initialize EC key using affine coordinates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,13 @@ OpenSSL Releases
 
    *Tim Perry*
 
+ * Added the `OSSL_PARAM_BLD_push_EC_affine_point()` and
+   `OSSL_PARAM_BLD_push_EC_affine_point_ex()` functions, which create an
+   `OSSL_PARAM` object referencing the EC public key with given affine
+   coordinates.
+
+   *Igor Ustinov*
+
  * Dropped `no-ecdsa` and `no-ecdh` options from `Configure` as these options
    did not really disable the implementations. Use `no-ec` to disable the
    elliptic curve support.

--- a/crypto/ec/ecp_oct.c
+++ b/crypto/ec/ecp_oct.c
@@ -312,7 +312,8 @@ int ossl_ec_GFp_simple_oct2point(const EC_GROUP *group, EC_POINT *point,
     enc_len = (form == POINT_CONVERSION_COMPRESSED) ? 1 + field_len : 1 + 2 * field_len;
 
     if (len != (size_t)enc_len) {
-        ERR_raise(ERR_LIB_EC, EC_R_INVALID_ENCODING);
+        ERR_raise_data(ERR_LIB_EC, EC_R_INVALID_ENCODING,
+            "EC affine coordinate length doesn't match the field degree");
         return 0;
     }
 

--- a/crypto/param_build.c
+++ b/crypto/param_build.c
@@ -9,11 +9,17 @@
  */
 
 #include <string.h>
-#include <openssl/err.h>
-#include <openssl/cryptoerr.h>
-#include <openssl/params.h>
-#include <openssl/types.h>
-#include <openssl/safestack.h>
+#include "openssl/err.h"
+#include "openssl/cryptoerr.h"
+#include "openssl/params.h"
+#include "openssl/types.h"
+#include "openssl/safestack.h"
+#include "openssl/ec.h"
+#include "openssl/core_names.h"
+#ifndef OPENSSL_NO_EC
+#include "openssl/obj_mac.h"
+#include "crypto/ec.h"
+#endif
 #include "internal/param_build_set.h"
 
 /*
@@ -28,6 +34,7 @@ typedef struct {
     size_t size;
     size_t alloc_blocks;
     const BIGNUM *bn;
+    void *owned_data;
     const void *string;
     union {
         /*
@@ -105,9 +112,14 @@ OSSL_PARAM_BLD *OSSL_PARAM_BLD_new(void)
 static void free_all_params(OSSL_PARAM_BLD *bld)
 {
     int i, n = sk_OSSL_PARAM_BLD_DEF_num(bld->params);
+    OSSL_PARAM_BLD_DEF *pd;
 
-    for (i = 0; i < n; i++)
-        OPENSSL_free(sk_OSSL_PARAM_BLD_DEF_pop(bld->params));
+    for (i = 0; i < n; i++) {
+        pd = sk_OSSL_PARAM_BLD_DEF_pop(bld->params);
+        if (pd->owned_data != NULL)
+            OPENSSL_free(pd->owned_data);
+        OPENSSL_free(pd);
+    }
 }
 
 void OSSL_PARAM_BLD_free(OSSL_PARAM_BLD *bld)
@@ -304,6 +316,112 @@ int OSSL_PARAM_BLD_push_octet_ptr(OSSL_PARAM_BLD *bld, const char *key,
     pd->string = buf;
     return 1;
 }
+
+int OSSL_PARAM_BLD_push_EC_affine_point_ex(OSSL_PARAM_BLD *bld,
+    const BIGNUM *X, const BIGNUM *Y, unsigned int field_len)
+{
+    unsigned char *buf = NULL;
+    int buflen;
+    OSSL_PARAM_BLD_DEF *pd = NULL;
+
+    if (bld == NULL || X == NULL || Y == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
+    /* Checking if affine coordinates are not too long */
+    if (BN_num_bytes(X) > field_len || BN_num_bytes(Y) > field_len) {
+        ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT,
+            "EC affine coordinate exceeds field length");
+        return 0;
+    }
+
+    /* Converting (X,Y) to the SEC1 uncompressed point encoding blob */
+    buflen = 1 + 2 * field_len;
+    buf = OPENSSL_malloc(buflen);
+    if (buf == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE);
+        return 0;
+    }
+    buf[0] = POINT_CONVERSION_UNCOMPRESSED;
+    if (BN_bn2binpad(X, buf + 1, field_len) < 0) {
+        ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT,
+            "failed to encode X coordinate");
+        goto err;
+    }
+    if (BN_bn2binpad(Y, buf + 1 + field_len, field_len) < 0) {
+        ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT,
+            "failed to encode Y coordinate");
+        goto err;
+    }
+
+    /* Pushing blob to bld */
+    pd = param_push(bld, OSSL_PKEY_PARAM_PUB_KEY, buflen, buflen, OSSL_PARAM_OCTET_STRING, 0);
+    if (pd == NULL)
+        goto err;
+    pd->owned_data = buf;
+    pd->string = pd->owned_data;
+    return 1;
+
+err:
+    OPENSSL_free(buf);
+    return 0;
+}
+
+#ifndef OPENSSL_NO_EC
+int OSSL_PARAM_BLD_push_EC_affine_point(OSSL_PARAM_BLD *bld,
+    const BIGNUM *X, const BIGNUM *Y)
+{
+    const char *group_name = NULL;
+    int nid;
+    EC_GROUP *group = NULL;
+    int field_len;
+    int i, n;
+    OSSL_PARAM_BLD_DEF *pd = NULL;
+
+    if (bld == NULL || X == NULL || Y == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
+    /* Looking for the set group name */
+    if (bld->params == NULL) {
+        ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT,
+            "EC group name must be set in builder before pushing an affine point");
+        return 0;
+    }
+    n = sk_OSSL_PARAM_BLD_DEF_num(bld->params);
+    for (i = n - 1; i >= 0; i--) {
+        pd = sk_OSSL_PARAM_BLD_DEF_value(bld->params, i);
+        if (pd == NULL || pd->key == NULL)
+            continue;
+        if (strcmp(pd->key, OSSL_PKEY_PARAM_GROUP_NAME) == 0)
+            break;
+    }
+    if (i < 0) {
+        ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT,
+            "EC group name must be set in builder before pushing an affine point");
+        return 0;
+    }
+    group_name = pd->string;
+
+    /* Determining the group field length */
+    nid = ossl_ec_curve_name2nid(group_name);
+    if (nid == NID_undef) {
+        ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT,
+            "group is not an EC named curve: %s", group_name);
+        return 0;
+    }
+
+    group = EC_GROUP_new_by_curve_name_ex(NULL, NULL, nid);
+    if (group == NULL)
+        return 0;
+    field_len = (EC_GROUP_get_degree(group) + 7) / 8;
+    EC_GROUP_free(group);
+
+    return OSSL_PARAM_BLD_push_EC_affine_point_ex(bld, X, Y, field_len);
+}
+#endif
 
 static OSSL_PARAM *param_bld_convert(OSSL_PARAM_BLD *bld, OSSL_PARAM *param,
     OSSL_PARAM_ALIGNED_BLOCK *blk,

--- a/doc/man3/OSSL_PARAM_BLD.pod
+++ b/doc/man3/OSSL_PARAM_BLD.pod
@@ -11,7 +11,8 @@ OSSL_PARAM_BLD_push_uint64, OSSL_PARAM_BLD_push_size_t,
 OSSL_PARAM_BLD_push_time_t, OSSL_PARAM_BLD_push_double,
 OSSL_PARAM_BLD_push_BN, OSSL_PARAM_BLD_push_BN_pad,
 OSSL_PARAM_BLD_push_utf8_string, OSSL_PARAM_BLD_push_utf8_ptr,
-OSSL_PARAM_BLD_push_octet_string, OSSL_PARAM_BLD_push_octet_ptr
+OSSL_PARAM_BLD_push_octet_string, OSSL_PARAM_BLD_push_octet_ptr,
+OSSL_PARAM_BLD_push_EC_affine_point, OSSL_PARAM_BLD_push_EC_affine_point_ex
 - functions to assist in the creation of OSSL_PARAM arrays
 
 =head1 SYNOPSIS
@@ -41,6 +42,11 @@ OSSL_PARAM_BLD_push_octet_string, OSSL_PARAM_BLD_push_octet_ptr
                                       const void *buf, size_t bsize);
  int OSSL_PARAM_BLD_push_octet_ptr(OSSL_PARAM_BLD *bld, const char *key,
                                    void *buf, size_t bsize);
+ int OSSL_PARAM_BLD_push_EC_affine_point(OSSL_PARAM_BLD *bld,
+                                         const BIGNUM *X, const BIGNUM *Y);
+ int OSSL_PARAM_BLD_push_EC_affine_point_ex(OSSL_PARAM_BLD *bld,
+                                            const BIGNUM *X, const BIGNUM *Y,
+											unsigned int field_len);
 
 
 =head1 DESCRIPTION
@@ -125,6 +131,16 @@ object that references the octet string specified by I<buf>.
 The memory I<buf> points to is stored by reference and must remain in
 scope until the OSSL_PARAM array is freed.
 
+OSSL_PARAM_BLD_push_EC_affine_point() and
+OSSL_PARAM_BLD_push_EC_affine_points_ex() are functions specific to EC groups
+that will create an OSSL_PARAM object that references the EC public key with
+given affine coordinates I<X> and I<Y>. The length of the field degree
+representation (in bytes) must be passed to
+OSSL_PARAM_BLD_push_EC_affine_points_ex() in the I<field_len> parameter.
+OSSL_PARAM_BLD_push_EC_affine_point() determines this length automatically,
+but it works only for named EC groups and the group name must be pushed to
+I<bld> before calling this function.
+
 =head1 RETURN VALUES
 
 OSSL_PARAM_BLD_new() returns the allocated OSSL_PARAM_BLD structure, or NULL
@@ -142,6 +158,11 @@ OSSL_PARAM_BLD_push_BN() and OSSL_PARAM_BLD_push_BN_pad() only
 support nonnegative B<BIGNUM>s.  They return an error on negative
 B<BIGNUM>s.
 To pass signed B<BIGNUM>s, use OSSL_PARAM_BLD_push_signed_BN().
+
+OSSL_PARAM_BLD_push_EC_affine_point() actually converts affine coordinates
+to the SEC1 uncompressed point encoding blob and pushes it as a "pub" parameter
+type. So it doesn't require any additional support from providers (including
+third-party ones).
 
 =head1 EXAMPLES
 
@@ -205,9 +226,11 @@ L<OSSL_PARAM_int(3)>, L<OSSL_PARAM(3)>, L<OSSL_PARAM_free(3)>
 
 The functions described here were all added in OpenSSL 3.0.
 
+OSSL_PARAM_BLD_push_EC_affine_point() was added in OpenSSL 4.1.
+
 =head1 COPYRIGHT
 
-Copyright 2019-2024 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2019-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/openssl/param_build.h
+++ b/include/openssl/param_build.h
@@ -56,6 +56,12 @@ int OSSL_PARAM_BLD_push_octet_string(OSSL_PARAM_BLD *bld, const char *key,
     const void *buf, size_t bsize);
 int OSSL_PARAM_BLD_push_octet_ptr(OSSL_PARAM_BLD *bld, const char *key,
     void *buf, size_t bsize);
+int OSSL_PARAM_BLD_push_EC_affine_point_ex(OSSL_PARAM_BLD *bld,
+    const BIGNUM *X, const BIGNUM *Y, unsigned int field_len);
+#ifndef OPENSSL_NO_EC
+int OSSL_PARAM_BLD_push_EC_affine_point(OSSL_PARAM_BLD *bld,
+    const BIGNUM *X, const BIGNUM *Y);
+#endif
 
 #ifdef __cplusplus
 }

--- a/test/evp_pkey_provided_test.c
+++ b/test/evp_pkey_provided_test.c
@@ -1601,7 +1601,14 @@ err:
 }
 #endif /* OPENSSL_NO_ECX */
 
-static int test_fromdata_ec(void)
+/*
+ * tst uses indexes 0..3
+ * 0 = uncompressed format
+ * 1 = compressed format
+ * 2 = affine coordinates format via OSSL_PARAM_BLD_push_EC_affine_point()
+ * 3 = affine coordinates format via OSSL_PARAM_BLD_push_EC_affine_point_ex()
+ */
+static int test_fromdata_ec(int tst)
 {
     int ret = 0;
     EVP_PKEY_CTX *ctx = NULL;
@@ -1637,6 +1644,19 @@ static int test_fromdata_ec(void)
         0x02, 0xa5, 0x77, 0x57, 0xc8, 0xa3, 0x47, 0x73,
         0x3a, 0x6a, 0x08, 0x28, 0x39, 0xbd, 0xc9, 0xd2
     };
+    /* SAME IN AFFINE COORDINATES */
+    static const unsigned char X_buf[] = {
+        0x1b, 0x93, 0x67, 0x55, 0x1c, 0x55, 0x9f, 0x63,
+        0xd1, 0x22, 0xa4, 0xd8, 0xd1, 0x0a, 0x60, 0x6d,
+        0x02, 0xa5, 0x77, 0x57, 0xc8, 0xa3, 0x47, 0x73,
+        0x3a, 0x6a, 0x08, 0x28, 0x39, 0xbd, 0xc9, 0xd2
+    };
+    static const unsigned char Y_buf[] = {
+        0x80, 0xec, 0xe9, 0xa7, 0x08, 0x29, 0x71, 0x2f,
+        0xc9, 0x56, 0x82, 0xee, 0x9a, 0x85, 0x0f, 0x6d,
+        0x7f, 0x59, 0x5f, 0x8c, 0xd1, 0x96, 0x0b, 0xdf,
+        0x29, 0x3e, 0x49, 0x07, 0x88, 0x3f, 0x9a, 0x29
+    };
     static const unsigned char ec_priv_keydata[] = {
         0x33, 0xd0, 0x43, 0x83, 0xa9, 0x89, 0x56, 0x03,
         0xd2, 0xd7, 0xfe, 0x6b, 0x01, 0x6f, 0xe4, 0x59,
@@ -1654,6 +1674,8 @@ static int test_fromdata_ec(void)
     BIGNUM *a = NULL;
     BIGNUM *b = NULL;
     BIGNUM *p = NULL;
+    BIGNUM *X = NULL;
+    BIGNUM *Y = NULL;
 
     if (!TEST_ptr(bld = OSSL_PARAM_BLD_new()))
         goto err;
@@ -1673,11 +1695,37 @@ static int test_fromdata_ec(void)
      * `OSSL_PKEY_PARAM_PUB_KEY` and expect to default to uncompressed
      * format.
      */
-    if (OSSL_PARAM_BLD_push_octet_string(bld, OSSL_PKEY_PARAM_PUB_KEY,
-            ec_pub_keydata_compressed,
-            sizeof(ec_pub_keydata_compressed))
-        <= 0)
+    switch (tst) {
+    case 0:
+        if (!TEST_true(OSSL_PARAM_BLD_push_octet_string(bld,
+                OSSL_PKEY_PARAM_PUB_KEY,
+                ec_pub_keydata_compressed,
+                sizeof(ec_pub_keydata_compressed))))
+            goto err;
+        break;
+    case 1:
+        if (!TEST_true(OSSL_PARAM_BLD_push_octet_string(bld,
+                OSSL_PKEY_PARAM_PUB_KEY,
+                ec_pub_keydata, sizeof(ec_pub_keydata))))
+            goto err;
+        break;
+    case 2:
+        if (!TEST_ptr(X = BN_bin2bn(X_buf, sizeof(X_buf), NULL))
+            || !TEST_ptr(Y = BN_bin2bn(Y_buf, sizeof(Y_buf), NULL)))
+            goto err;
+        if (!TEST_true(OSSL_PARAM_BLD_push_EC_affine_point(bld, X, Y)))
+            goto err;
+        break;
+    case 3:
+        if (!TEST_ptr(X = BN_bin2bn(X_buf, sizeof(X_buf), NULL))
+            || !TEST_ptr(Y = BN_bin2bn(Y_buf, sizeof(Y_buf), NULL)))
+            goto err;
+        if (!TEST_true(OSSL_PARAM_BLD_push_EC_affine_point_ex(bld, X, Y, 32)))
+            goto err;
+        break;
+    default:
         goto err;
+    }
     if (OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_PRIV_KEY, ec_priv_bn) <= 0)
         goto err;
     if (!TEST_ptr(fromdata_params = OSSL_PARAM_BLD_to_param(bld)))
@@ -1801,6 +1849,8 @@ err:
     BN_free(p);
     BN_free(bn_priv);
     BN_free(ec_priv_bn);
+    BN_free(X);
+    BN_free(Y);
     OSSL_PARAM_free(fromdata_params);
     OSSL_PARAM_BLD_free(bld);
     EVP_PKEY_free(pk);
@@ -2290,7 +2340,7 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_ECX
     ADD_ALL_TESTS(test_fromdata_ecx, 4 * 3);
 #endif
-    ADD_TEST(test_fromdata_ec);
+    ADD_ALL_TESTS(test_fromdata_ec, 4);
     ADD_TEST(test_ec_dup_no_operation);
     ADD_TEST(test_ec_dup_keygen_operation);
 #endif

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -1766,6 +1766,8 @@ OSSL_PARAM_BLD_push_utf8_string         ?	4_0_0	EXIST::FUNCTION:
 OSSL_PARAM_BLD_push_utf8_ptr            ?	4_0_0	EXIST::FUNCTION:
 OSSL_PARAM_BLD_push_octet_string        ?	4_0_0	EXIST::FUNCTION:
 OSSL_PARAM_BLD_push_octet_ptr           ?	4_0_0	EXIST::FUNCTION:
+OSSL_PARAM_BLD_push_EC_affine_point     ?	4_0_0	EXIST::FUNCTION:EC
+OSSL_PARAM_BLD_push_EC_affine_point_ex  ?	4_0_0	EXIST::FUNCTION:
 OSSL_PARAM_locate                       ?	4_0_0	EXIST::FUNCTION:
 OSSL_PARAM_locate_const                 ?	4_0_0	EXIST::FUNCTION:
 OSSL_PARAM_construct_int                ?	4_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Added the OSSL_PARAM_BLD_push_EC_affine_point() function, which creates an OSSL_PARAM object referencing the EC public key with affine coordinates.
Also added NULL checks for the arguments in OSSL_PARAM_BLD_push_*() functions.
    
 Fixes #16270


<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
