### PR TITLE
[4.0] Run clang-format on the source tree

### DIFF
--- a/crypto/dllmain.c
+++ b/crypto/dllmain.c
@@ -34,9 +34,9 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
     case DLL_THREAD_ATTACH:
         break;
     case DLL_THREAD_DETACH:
-# ifndef __CYGWIN__
+#ifndef __CYGWIN__
         OPENSSL_thread_stop();
-# endif
+#endif
         break;
     case DLL_PROCESS_DETACH:
 #if defined(OSSL_DLLMAIN_DESTRUCTOR)

--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -49,7 +49,7 @@ long PKCS7_ctrl(PKCS7 *p7, int cmd, long larg, char *parg)
     case PKCS7_OP_GET_DETACHED_SIGNATURE:
         if (nid == NID_pkcs7_signed) {
             if (p7->d.sign == NULL || p7->d.sign->contents == NULL
-                    || p7->d.sign->contents->d.ptr == NULL)
+                || p7->d.sign->contents->d.ptr == NULL)
                 ret = 1;
             else
                 ret = 0;

--- a/crypto/rand/rand_egd.c
+++ b/crypto/rand/rand_egd.c
@@ -104,7 +104,6 @@ static int hpns_connect_attempt = 0;
 
 #endif /* defined(OPENSSL_SYS_HPNS) */
 
-
 int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes)
 {
     FILE *fp = NULL;
@@ -137,7 +136,7 @@ int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes)
     for (;;) {
         if (connect(fd, (struct sockaddr *)&addr, i) == 0)
             break;
-# ifdef EISCONN
+#ifdef EISCONN
         if (errno == EISCONN)
             break;
 #endif

--- a/providers/fips/self_test.c
+++ b/providers/fips/self_test.c
@@ -123,9 +123,9 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
         init();
         break;
     case DLL_PROCESS_DETACH:
-# ifndef __CYGWIN__
+#ifndef __CYGWIN__
         cleanup();
-# endif
+#endif
         break;
     default:
         break;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -10369,7 +10369,7 @@ static int test_session_cache_overflow(int idx)
      * would free the get_sess_val, causing a use-after-free error.
      */
     if (!TEST_true(CRYPTO_GET_REF(&get_sess_val->references, &references))
-            || !TEST_int_ge(references, 2))
+        || !TEST_int_ge(references, 2))
         goto end;
     sess = SSL_get1_session(clientssl);
     if (!TEST_ptr(sess))


### PR DESCRIPTION
This patch is a result of running the following commads:

    $ for i in `git ls-files '*.c' '*.h' '*.c.in' '*.h.in'`; do \
          echo -- "$i"; clang-format-21 --style=file:.clang-format -i "$i"; \
      done
    $ git checkout crypto/asn1/charmap.h crypto/bn/bn_prime.h \
          crypto/conf/conf_def.h crypto/objects/obj_dat.h \
          crypto/objects/obj_xref.h include/openssl/obj_mac.h

Release: yes
Fixes: f22fa1928434 "pkcs7: fix NULL contents dereference in PKCS7_ctrl"
Fixes: 65940a0bb62f "Disable DLL detach handlers on cygwin"
Fixes: d0abfd1844c0 "NonStop: reset hpns_connect_attempt at call start and on success"
Fixes: 19854b5adf36 "Fix error handling in SSL_CTX_add_session"