### PR TITLE
Add NULL checks for the arguments in OSSL_PARAM_BLD_push_*() functions.

### DIFF
--- a/crypto/param_build.c
+++ b/crypto/param_build.c
@@ -121,12 +121,22 @@ void OSSL_PARAM_BLD_free(OSSL_PARAM_BLD *bld)
 
 int OSSL_PARAM_BLD_push_int(OSSL_PARAM_BLD *bld, const char *key, int num)
 {
+    if (bld == NULL || key == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
     return param_push_num(bld, key, &num, sizeof(num), OSSL_PARAM_INTEGER);
 }
 
 int OSSL_PARAM_BLD_push_uint(OSSL_PARAM_BLD *bld, const char *key,
     unsigned int num)
 {
+    if (bld == NULL || key == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
     return param_push_num(bld, key, &num, sizeof(num),
         OSSL_PARAM_UNSIGNED_INTEGER);
 }
@@ -134,12 +144,22 @@ int OSSL_PARAM_BLD_push_uint(OSSL_PARAM_BLD *bld, const char *key,
 int OSSL_PARAM_BLD_push_long(OSSL_PARAM_BLD *bld, const char *key,
     long int num)
 {
+    if (bld == NULL || key == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
     return param_push_num(bld, key, &num, sizeof(num), OSSL_PARAM_INTEGER);
 }
 
 int OSSL_PARAM_BLD_push_ulong(OSSL_PARAM_BLD *bld, const char *key,
     unsigned long int num)
 {
+    if (bld == NULL || key == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
     return param_push_num(bld, key, &num, sizeof(num),
         OSSL_PARAM_UNSIGNED_INTEGER);
 }
@@ -147,12 +167,22 @@ int OSSL_PARAM_BLD_push_ulong(OSSL_PARAM_BLD *bld, const char *key,
 int OSSL_PARAM_BLD_push_int32(OSSL_PARAM_BLD *bld, const char *key,
     int32_t num)
 {
+    if (bld == NULL || key == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
     return param_push_num(bld, key, &num, sizeof(num), OSSL_PARAM_INTEGER);
 }
 
 int OSSL_PARAM_BLD_push_uint32(OSSL_PARAM_BLD *bld, const char *key,
     uint32_t num)
 {
+    if (bld == NULL || key == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
     return param_push_num(bld, key, &num, sizeof(num),
         OSSL_PARAM_UNSIGNED_INTEGER);
 }
@@ -160,12 +190,22 @@ int OSSL_PARAM_BLD_push_uint32(OSSL_PARAM_BLD *bld, const char *key,
 int OSSL_PARAM_BLD_push_int64(OSSL_PARAM_BLD *bld, const char *key,
     int64_t num)
 {
+    if (bld == NULL || key == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
     return param_push_num(bld, key, &num, sizeof(num), OSSL_PARAM_INTEGER);
 }
 
 int OSSL_PARAM_BLD_push_uint64(OSSL_PARAM_BLD *bld, const char *key,
     uint64_t num)
 {
+    if (bld == NULL || key == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
     return param_push_num(bld, key, &num, sizeof(num),
         OSSL_PARAM_UNSIGNED_INTEGER);
 }
@@ -173,6 +213,11 @@ int OSSL_PARAM_BLD_push_uint64(OSSL_PARAM_BLD *bld, const char *key,
 int OSSL_PARAM_BLD_push_size_t(OSSL_PARAM_BLD *bld, const char *key,
     size_t num)
 {
+    if (bld == NULL || key == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
     return param_push_num(bld, key, &num, sizeof(num),
         OSSL_PARAM_UNSIGNED_INTEGER);
 }
@@ -180,6 +225,11 @@ int OSSL_PARAM_BLD_push_size_t(OSSL_PARAM_BLD *bld, const char *key,
 int OSSL_PARAM_BLD_push_time_t(OSSL_PARAM_BLD *bld, const char *key,
     time_t num)
 {
+    if (bld == NULL || key == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
     return param_push_num(bld, key, &num, sizeof(num),
         OSSL_PARAM_INTEGER);
 }
@@ -187,6 +237,11 @@ int OSSL_PARAM_BLD_push_time_t(OSSL_PARAM_BLD *bld, const char *key,
 int OSSL_PARAM_BLD_push_double(OSSL_PARAM_BLD *bld, const char *key,
     double num)
 {
+    if (bld == NULL || key == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
     return param_push_num(bld, key, &num, sizeof(num), OSSL_PARAM_REAL);
 }
 
@@ -195,6 +250,11 @@ static int push_BN(OSSL_PARAM_BLD *bld, const char *key,
 {
     int n, secure = 0;
     OSSL_PARAM_BLD_DEF *pd;
+
+    if (bld == NULL || key == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
 
     if (!ossl_assert(type == OSSL_PARAM_UNSIGNED_INTEGER
             || type == OSSL_PARAM_INTEGER))
@@ -233,6 +293,11 @@ static int push_BN(OSSL_PARAM_BLD *bld, const char *key,
 int OSSL_PARAM_BLD_push_BN(OSSL_PARAM_BLD *bld, const char *key,
     const BIGNUM *bn)
 {
+    if (bld == NULL || key == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
     if (bn != NULL && BN_is_negative(bn))
         return push_BN(bld, key, bn, BN_num_bytes(bn) + 1,
             OSSL_PARAM_INTEGER);
@@ -243,6 +308,11 @@ int OSSL_PARAM_BLD_push_BN(OSSL_PARAM_BLD *bld, const char *key,
 int OSSL_PARAM_BLD_push_BN_pad(OSSL_PARAM_BLD *bld, const char *key,
     const BIGNUM *bn, size_t sz)
 {
+    if (bld == NULL || key == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
     if (bn != NULL && BN_is_negative(bn))
         return push_BN(bld, key, bn, BN_num_bytes(bn),
             OSSL_PARAM_INTEGER);
@@ -254,6 +324,11 @@ int OSSL_PARAM_BLD_push_utf8_string(OSSL_PARAM_BLD *bld, const char *key,
 {
     OSSL_PARAM_BLD_DEF *pd;
     int secure;
+
+    if (bld == NULL || key == NULL || buf == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
 
     if (bsize == 0)
         bsize = strlen(buf);
@@ -270,6 +345,11 @@ int OSSL_PARAM_BLD_push_utf8_ptr(OSSL_PARAM_BLD *bld, const char *key,
 {
     OSSL_PARAM_BLD_DEF *pd;
 
+    if (bld == NULL || key == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
     if (bsize == 0)
         bsize = strlen(buf);
     pd = param_push(bld, key, bsize, sizeof(buf), OSSL_PARAM_UTF8_PTR, 0);
@@ -285,6 +365,11 @@ int OSSL_PARAM_BLD_push_octet_string(OSSL_PARAM_BLD *bld, const char *key,
     OSSL_PARAM_BLD_DEF *pd;
     int secure;
 
+    if (bld == NULL || key == NULL || buf == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
     secure = CRYPTO_secure_allocated(buf);
     pd = param_push(bld, key, bsize, bsize, OSSL_PARAM_OCTET_STRING, secure);
     if (pd == NULL)
@@ -297,6 +382,11 @@ int OSSL_PARAM_BLD_push_octet_ptr(OSSL_PARAM_BLD *bld, const char *key,
     void *buf, size_t bsize)
 {
     OSSL_PARAM_BLD_DEF *pd;
+
+    if (bld == NULL || key == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
 
     pd = param_push(bld, key, bsize, sizeof(buf), OSSL_PARAM_OCTET_PTR, 0);
     if (pd == NULL)
@@ -362,10 +452,18 @@ OSSL_PARAM *OSSL_PARAM_BLD_to_param(OSSL_PARAM_BLD *bld)
 {
     OSSL_PARAM_ALIGNED_BLOCK *blk, *s = NULL;
     OSSL_PARAM *params, *last;
-    const int num = sk_OSSL_PARAM_BLD_DEF_num(bld->params);
-    const size_t p_blks = ossl_param_bytes_to_blocks((1 + num) * sizeof(*params));
-    const size_t total = OSSL_PARAM_ALIGN_SIZE * (p_blks + bld->total_blocks);
-    const size_t ss = OSSL_PARAM_ALIGN_SIZE * bld->secure_blocks;
+    int num;
+    size_t p_blks, total, ss;
+
+    if (bld == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
+    num = sk_OSSL_PARAM_BLD_DEF_num(bld->params);
+    p_blks = ossl_param_bytes_to_blocks((1 + num) * sizeof(*params));
+    total = OSSL_PARAM_ALIGN_SIZE * (p_blks + bld->total_blocks);
+    ss = OSSL_PARAM_ALIGN_SIZE * bld->secure_blocks;
 
     if (ss > 0) {
         s = OPENSSL_secure_malloc(ss);


### PR DESCRIPTION
This check is necessary because these functions are part of the public API, and at least the *blk* parameter is dereferenced there. 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
