### PR TITLE
Add a global constructor function for libcrypto

### DIFF
--- a/crypto/dllmain.c
+++ b/crypto/dllmain.c
@@ -30,13 +30,16 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     switch (fdwReason) {
     case DLL_PROCESS_ATTACH:
+#if defined(OSSL_DLLMAIN_CONSTRUCTOR)
+        ossl_crypto_constructor();
+#endif /* defined(OSSL_DLLMAIN_CONSTRUCTOR) */
         break;
     case DLL_THREAD_ATTACH:
         break;
     case DLL_THREAD_DETACH:
-# ifndef __CYGWIN__
+#ifndef __CYGWIN__
         OPENSSL_thread_stop();
-# endif
+#endif
         break;
     case DLL_PROCESS_DETACH:
 #if defined(OSSL_DLLMAIN_DESTRUCTOR)

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -498,6 +498,7 @@ void OPENSSL_cleanup(void)
 #endif /* defined(DO_NOT_SKIP_OPENSSL_CLEANUP) */
 }
 
+#if defined(OSSL_USE_GLOBAL_CONSTRUCTOR) || defined(OSSL_DLLMAIN_CONSTRUCTOR)
 /*
  * Global library constructor function.
  *
@@ -518,3 +519,4 @@ void ossl_crypto_constructor(void)
      */
     OPENSSL_cpuid_setup();
 }
+#endif /* defined(OSSL_USE_GLOBAL_CONSTRUCTOR) || defined(OSSL_DLLMAIN_CONSTRUTOR) */

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -497,3 +497,24 @@ void OPENSSL_cleanup(void)
     ossl_cleanup_destructor();
 #endif /* defined(DO_NOT_SKIP_OPENSSL_CLEANUP) */
 }
+
+/*
+ * Global library constructor function.
+ *
+ * If we have constructor support, this function is installed and
+ * always run as a global constructor.
+ *
+ */
+void ossl_crypto_constructor(void)
+{
+    /*
+     * Ensure we know about CPU features and do not need to directly
+     * call this as a constructor from assembly language files.
+     *
+     * In the incredibly improbable world where for some reason you
+     * both require detection of modern CPU features, but are building
+     * with a toolchain from the days of hammer pants and telephones
+     * with cords, you might not get automatic CPU feature detection.
+     */
+    OPENSSL_cpuid_setup();
+}

--- a/include/internal/e_os.h
+++ b/include/internal/e_os.h
@@ -7,7 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
-#ifndef OSSL_E_OS_H
+#if !defined(OSSL_E_OS_H)
 #define OSSL_E_OS_H
 
 #include <limits.h>
@@ -365,8 +365,6 @@ typedef _locale_t locale_t;
 #endif
 #endif
 
-#endif
-
 /*
  * Can we use a global destructor?  We can use a global destructor via
  * __attribute__ on anything like a modern gcc/clang.  We can also use
@@ -412,8 +410,11 @@ void ossl_cleanup_destructor(void) __attribute__((destructor));
 void ossl_cleanup_destructor(void);
 #endif /* __has_attribute(destructor) */
 #if __has_attribute(constructor)
+#define OSSL_USE_GLOBAL_CONSTRUCTOR
 /* constructor is installed by compiler */
 void ossl_crypto_constructor(void) __attribute__((constructor));
 #endif /* __has_attribute(constructor) */
 #endif /* defined (__has_attribute) */
 #endif /* defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_WIN64) */
+
+#endif /* !defined(OSSL_E_OS_H) */

--- a/include/internal/e_os.h
+++ b/include/internal/e_os.h
@@ -382,12 +382,14 @@ typedef _locale_t locale_t;
 #if defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_WIN64)
 #define OSSL_CLEANUP_USING_DESTRUCTOR
 #define OSSL_DLLMAIN_DESTRUCTOR
+#define OSSL_DLLMAIN_CONSTRUCTOR
 /*
- * destructor will be installed in libcrypto's dllmain.c
- * This means effectively anything not win16 or dos will handle
- * this.
+ * constructor and destructor will be installed in libcrypto's
+ * dllmain.c This means effectively anything not win16 or dos will
+ * handle this.
  */
 void ossl_cleanup_destructor(void);
+void ossl_crypto_constructor(void);
 #else
 #if defined(__has_attribute)
 #if __has_attribute(destructor)
@@ -408,6 +410,10 @@ void ossl_cleanup_destructor(void) __attribute__((destructor));
  * more than 20 years old.
  */
 void ossl_cleanup_destructor(void);
-#endif /* defined (__has_attribute(destructor) */
+#endif /* __has_attribute(destructor) */
+#if __has_attribute(constructor)
+/* constructor is installed by compiler */
+void ossl_crypto_constructor(void) __attribute__((constructor));
+#endif /* __has_attribute(constructor) */
 #endif /* defined (__has_attribute) */
 #endif /* defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_WIN64) */


### PR DESCRIPTION
This adds a global constructor function that is conditionally installed and used if we detect toolchain support for using a global constructor. This should work on basically anything using any sort of non-decrepit toolchain.

We call OPENSSL_cpuid_setup() in the global constructor so that CPU features may be known before we get into any assembly language code, and therefore avoid needing to care about doing such things in assembly.

Speeds up legacy sha256 on my crappy threadripper loonix box by about a factor of 3.

Fixes: https://github.com/openssl/openssl/issues/29340

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
