### PR TITLE
Fix SSL_read return value for EOF sockets

### DIFF
--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -404,9 +404,11 @@ int tls_default_read_n(OSSL_RECORD_LAYER *rl, size_t n, size_t max, int extend,
         clear_sys_error();
         if (bio != NULL) {
             ret = BIO_read(bio, pkt + len + left, (int)(max - left));
-            if (ret >= 0) {
+            if (ret > 0) {
                 bioread = ret;
                 ret = OSSL_RECORD_RETURN_SUCCESS;
+	    } else if (ret == 0 && BIO_eof(bio)) {
+                ret = OSSL_RECORD_RETURN_EOF;
             } else if (BIO_should_retry(bio)) {
                 if (rl->prev != NULL) {
                     /*


### PR DESCRIPTION
If a socket is EOF but BIO_should_retry returns true, then we should return 0 in SSL_read rather than -1.  Otherwise the caller could get stuck in an infinite loop.

CLA: trivial
Fixes #30545
Sponsored by:	ConnectWise

##### Checklist
- [ ] tests are added or updated
