### PR TITLE
quic: add missing return 0 after raise_protocol_error for NEW_CONN_ID

### DIFF
--- a/ssl/quic/quic_rx_depack.c
+++ b/ssl/quic/quic_rx_depack.c
@@ -1316,6 +1316,7 @@ static int depack_process_frames(QUIC_CHANNEL *ch, PACKET *pkt,
                     OSSL_QUIC_ERR_PROTOCOL_VIOLATION,
                     frame_type,
                     "NEW_CONN_ID valid only in 0/1-RTT");
+                return 0;
             }
             if (!depack_do_frame_new_conn_id(pkt, ch, ackm_data))
                 return 0;


### PR DESCRIPTION
Every other frame type handler in `depack_process_frames()` returns 0
after calling `ossl_quic_channel_raise_protocol_error()`, but the
`NEW_CONN_ID` case falls through to `depack_do_frame_new_conn_id()`.