### PR TITLE
re-constructorize the cpuid stuff, but fix riscv to not depend on BIO_snprintf.

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -69,6 +69,10 @@ uint32_t OPENSSL_rdtsc(void)
 
 /* First determine if getauxval() is available (OSSL_IMPLEMENT_GETAUXVAL) */
 
+#if defined(__GNUC__) && __GNUC__ >= 2
+void OPENSSL_cpuid_setup(void) __attribute__((constructor));
+#endif
+
 #if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
 #if __GLIBC_PREREQ(2, 16)
 #include <sys/auxv.h>

--- a/crypto/dllmain.c
+++ b/crypto/dllmain.c
@@ -30,13 +30,14 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     switch (fdwReason) {
     case DLL_PROCESS_ATTACH:
+        OPENSSL_cpuid_setup();
         break;
     case DLL_THREAD_ATTACH:
         break;
     case DLL_THREAD_DETACH:
-# ifndef __CYGWIN__
+#ifndef __CYGWIN__
         OPENSSL_thread_stop();
-# endif
+#endif
         break;
     case DLL_PROCESS_DETACH:
 #if defined(OSSL_DLLMAIN_DESTRUCTOR)

--- a/crypto/perlasm/x86gas.pl
+++ b/crypto/perlasm/x86gas.pl
@@ -14,6 +14,8 @@ package x86gas;
 $::lbdecor=$::aout?"L":".L";		# local label decoration
 $nmdecor=($::aout or $::coff)?"_":"";	# external name decoration
 
+$initseg="";
+
 $align=16;
 $align=log($align)/log(2) if ($::aout);
 $com_start="#" if ($::aout or $::coff);
@@ -171,6 +173,7 @@ sub ::file_end
 	elsif ($::elf)	{ push (@out,"$tmp,4\n"); }
 	else		{ push (@out,"$tmp\n"); }
     }
+    push(@out,$initseg) if ($initseg);
     if ($::elf) {
 	push(@out,"
 	.section \".note.gnu.property\", \"a\"
@@ -232,6 +235,48 @@ sub ::picmeup
     }
     else
     {	&::lea($dst,&::DWP($sym));	}
+}
+
+sub ::initseg
+{ my $f=$nmdecor.shift;
+
+    if ($::android)
+    {	$initseg.=<<___;
+.section	.init_array
+.align	4
+.long	$f
+___
+    }
+    elsif ($::elf)
+    {	$initseg.=<<___;
+.section	.init
+	call	$f
+___
+    }
+    elsif ($::coff)
+    {   $initseg.=<<___;	# applies to both Cygwin and Mingw
+.section	.ctors
+.long	$f
+___
+    }
+    elsif ($::macosx)
+    {	$initseg.=<<___;
+.mod_init_func
+.align 2
+.long   $f
+___
+    }
+    elsif ($::aout)
+    {	my $ctor="${nmdecor}_GLOBAL_\$I\$$f";
+	$initseg.=".text\n";
+	$initseg.=".type	$ctor,\@function\n" if ($::pic);
+	$initseg.=<<___;	# OpenBSD way...
+.globl	$ctor
+.align	2
+$ctor:
+	jmp	$f
+___
+    }
 }
 
 sub ::dataseg

--- a/crypto/perlasm/x86masm.pl
+++ b/crypto/perlasm/x86masm.pl
@@ -14,6 +14,7 @@ package x86masm;
 $::lbdecor="\$L";	# local label decoration
 $nmdecor="_";		# external name decoration
 
+$initseg="";
 $segment="";
 
 sub ::generic
@@ -148,6 +149,7 @@ ___
 	grep {s/(^EXTERN\s+${nmdecor}OPENSSL_ia32cap_P)/\;$1/} @out;
 	push (@out,$comm);
     }
+    push (@out,$initseg) if ($initseg);
     push (@out,"END\n");
 }
 
@@ -179,6 +181,17 @@ sub ::align
 sub ::picmeup
 { my($dst,$sym)=@_;
     &::lea($dst,&::DWP($sym));
+}
+
+sub ::initseg
+{ my $f=$nmdecor.shift;
+
+    $initseg.=<<___;
+.CRT\$XCU	SEGMENT DWORD PUBLIC 'DATA'
+EXTERN	$f:NEAR
+DD	$f
+.CRT\$XCU	ENDS
+___
 }
 
 sub ::dataseg

--- a/crypto/perlasm/x86nasm.pl
+++ b/crypto/perlasm/x86nasm.pl
@@ -15,6 +15,8 @@ $::lbdecor="L\$";		# local label decoration
 $nmdecor="_";			# external name decoration
 $drdecor=$::mwerks?".":"";	# directive decoration
 
+$initseg="";
+
 sub ::generic
 { my $opcode=shift;
   my $tmp;
@@ -131,6 +133,7 @@ ___
 	grep {s/(^extern\s+${nmdecor}OPENSSL_ia32cap_P)/\;$1/} @out;
 	push (@out,$comm)
     }
+    push (@out,$initseg) if ($initseg);
 }
 
 sub ::comment {   foreach (@_) { push(@out,"\t; $_\n"); }   }
@@ -156,6 +159,17 @@ sub ::align
 sub ::picmeup
 { my($dst,$sym)=@_;
     &::lea($dst,&::DWP($sym));
+}
+
+sub ::initseg
+{ my $f=$nmdecor.shift;
+    if ($::win32)
+    {	$initseg=<<___;
+segment	.CRT\$XCU data align=4
+extern	$f
+dd	$f
+___
+    }
 }
 
 sub ::dataseg

--- a/crypto/ppccap.c
+++ b/crypto/ppccap.c
@@ -134,6 +134,9 @@ static unsigned long getauxval(unsigned long key)
 #define HWCAP_ARCH_3_00 (1U << 23)
 #define HWCAP_ARCH_3_1 (1U << 18)
 
+#if defined(__GNUC__) && __GNUC__ >= 2
+__attribute__((constructor))
+#endif
 void OPENSSL_cpuid_setup(void)
 {
     char *e;

--- a/crypto/riscvcap.c
+++ b/crypto/riscvcap.c
@@ -129,6 +129,9 @@ size_t riscv_vlen(void)
     return vlen;
 }
 
+#if defined(__GNUC__) && __GNUC__ >= 2
+__attribute__((constructor))
+#endif
 void OPENSSL_cpuid_setup(void)
 {
     char *e;

--- a/crypto/s390xcpuid.pl
+++ b/crypto/s390xcpuid.pl
@@ -527,6 +527,11 @@ s390x_flip_endian64:
 ___
 }
 
+$code.=<<___;
+.section	.init
+	brasl	$ra,OPENSSL_cpuid_setup
+___
+
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
 close STDOUT or die "error closing STDOUT: $!";	# force flush

--- a/crypto/sparccpuid.S
+++ b/crypto/sparccpuid.S
@@ -422,3 +422,7 @@ _sparcv9_vis1_instrument_bus2:
 	sub	%o3,%o1,%o0
 .type	_sparcv9_vis1_instrument_bus2,#function
 .size	_sparcv9_vis1_instrument_bus2,.-_sparcv9_vis1_instrument_bus2
+
+.section	".init",#alloc,#execinstr
+	call	OPENSSL_cpuid_setup
+	nop

--- a/crypto/x86_64cpuid.pl
+++ b/crypto/x86_64cpuid.pl
@@ -30,6 +30,9 @@ print<<___;
 #include crypto/cryptlib.h
 .extern		OPENSSL_cpuid_setup
 .hidden		OPENSSL_cpuid_setup
+.section	.init
+	call	OPENSSL_cpuid_setup
+
 .hidden	OPENSSL_ia32cap_P
 .comm	OPENSSL_ia32cap_P,40,4	# <--Should match with internal/cryptlib.h OPENSSL_IA32CAP_P_MAX_INDEXES
 .text

--- a/crypto/x86cpuid.pl
+++ b/crypto/x86cpuid.pl
@@ -493,6 +493,8 @@ my $rdop = shift;
 &gen_random("rdrand");
 &gen_random("rdseed");
 
+&initseg("OPENSSL_cpuid_setup");
+
 &hidden("OPENSSL_cpuid_setup");
 &hidden("OPENSSL_ia32cap_P");
 


### PR DESCRIPTION
So my previous attempt with a global constructor won't work in general, because it will not get
run correctly on statically linked binaries.  The easy cheat won't work. 

Since the problem in general as the reason for #27466, is that using high level library functions
don't work in a constructor when the library hasn't been initialized.  This is more or less a known
problem with the cpuid stuff when run as a constructor.   The particular problem motivating this
was that the riscV cpuid stuff would not work, because it was using BIO_snprintf() to prepend
and underscore to a string to search for it.

While I'm not strictly happy with a constructor in assembly solution either, at the moment it
has known performance properties, Trying to add OPENSSL_init_crypto() calls to the legacy
initialization paths adds a locking call to a formerly not locking path, (My initial experiments show this
path is about a 15 to 20% performance loss due to the added locking on my dumb simple tests) 
so we may be able to pare that down, but again that will require some more fiddling and testing.
(And should really have some CI in place noticing this before we attempt it)

So, I think the correct way to go about this is to fix the riscV stuff is

1) Fix the riscv stuff to not use higher level library functions
2) Revert the de-constructorization of all the CPUid stuff introduced by #27466

This fixes the performance regression in 3.6 and 4.0, and is likely the safest way given that's
the code we have used forever.

Then assuming we truly desire for other reasons we want to get out of the constructor in assembly game:

3) Raise an issue to find a better way to ensure we know the CPU properties early, including legacy,
    and ensure any such solution examines the performance impact before landing it. We can then
    attempt to see if we find something we like better for 4.1

Fixes: https://github.com/openssl/openssl/issues/29340 (and actually the wider issue that all CPU based hardware accelleration got turned off when you aren't using EVP) 

cc @ZenithalHourlyRate for #27466
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
