### PR TITLE
DTLS 1.3 DTLSv1Listen Tests

### DIFF
--- a/doc/man3/DTLSv1_listen.pod
+++ b/doc/man3/DTLSv1_listen.pod
@@ -15,7 +15,7 @@ DTLSv1_listen
 
 =head1 DESCRIPTION
 
-SSL_stateless() statelessly listens for new incoming TLSv1.3 connections.
+SSL_stateless() statelessly listens for new incoming (D)TLSv1.3 connections.
 DTLSv1_listen() statelessly listens for new incoming DTLS connections. If a
 ClientHello is received that does not contain a cookie, then they respond with a
 request for a new ClientHello that does contain a cookie. If a ClientHello is
@@ -42,7 +42,7 @@ address. In this case a TLSv1.3 application would be susceptible to this attack.
 As a countermeasure to this issue TLSv1.3 and DTLS include a stateless cookie
 mechanism. The idea is that when a client attempts to connect to a server it
 sends a ClientHello message. The server responds with a HelloRetryRequest (in
-TLSv1.3) or a HelloVerifyRequest (in DTLS) which contains a unique cookie. The
+(D)TLSv1.3) or a HelloVerifyRequest (in DTLS) which contains a unique cookie. The
 client then resends the ClientHello, but this time includes the cookie in the
 message thus proving that the client is capable of receiving messages sent to
 that address. All of this can be done by the server without allocating any
@@ -97,14 +97,17 @@ For SSL_stateless() if an entire ClientHello message cannot be read without the
 application's responsibility to ensure that data read from the "read" BIO during
 a single SSL_stateless() call is all from the same peer.
 
-SSL_stateless() will fail (with a 0 return value) if some TLS version less than
-TLSv1.3 is used.
+SSL_stateless() will fail (with a 0 return value) if some (D)TLS version less than
+(D)TLSv1.3 is used.
 
 Both SSL_stateless() and DTLSv1_listen() will clear the error queue when they
 start.
 
 SSL_stateless() cannot be used with QUIC SSL objects and returns an error if
 called on such an object.
+
+For DTLS1.3 to utilize Hello Retry Requests instead of Hello Verify Request,
+please use SSL_stateless() instead of DTLSv1_listen().
 
 =head1 RETURN VALUES
 
@@ -146,7 +149,7 @@ The type of "peer" also changed in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 
-Copyright 2015-2023 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2015-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7335,14 +7335,56 @@ __owur unsigned int ssl_get_split_send_fragment(const SSL_CONNECTION *sc)
 int SSL_stateless(SSL *s)
 {
     int ret;
+    int dtls_hrr_pending = 0;
+    uint16_t dtls_handshake_read_seq = 0;
+    uint16_t dtls_next_handshake_write_seq = 0;
+    uint64_t dtls_rl_read_seq = 0;
+    uint64_t dtls_rl_write_seq = 0;
     SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL_ONLY(s);
 
     if (sc == NULL)
         return 0;
 
+    /*
+     * For DTLS, track whether we have already sent a HelloRetryRequest so
+     * that we can restore handshake_read_seq after SSL_clear() resets it.
+     * After an HRR the client's second ClientHello carries message seq=1;
+     * if handshake_read_seq is left at 0 the message would be treated as
+     * out-of-order and buffered rather than accepted.
+     */
+    if (SSL_CONNECTION_IS_DTLS(sc) && sc->hello_retry_request == SSL_HRR_PENDING
+        && !ossl_statem_in_error(sc)) {
+        dtls_hrr_pending = 1;
+        dtls_handshake_read_seq = sc->d1->handshake_read_seq;
+        dtls_next_handshake_write_seq = sc->d1->next_handshake_write_seq;
+
+        if (sc->rlayer.wrlmethod->get_sequence && sc->rlayer.rrlmethod->get_sequence) {
+            if (!sc->rlayer.rrlmethod->get_sequence(sc->rlayer.rrl, &dtls_rl_read_seq)
+                || !sc->rlayer.wrlmethod->get_sequence(sc->rlayer.wrl, &dtls_rl_write_seq))
+                return 0;
+        }
+    }
+
     /* Ensure there is no state left over from a previous invocation */
     if (!SSL_clear(s))
         return 0;
+
+    /*
+     * If we previously sent a DTLS HelloRetryRequest, SSL_clear() has just
+     * reset handshake_read_seq and next_handshake_write_seq to 0.  Restore
+     * them to 1 so that the incoming ClientHello from HRR is recognised as
+     * the expected next message.
+     */
+    if (dtls_hrr_pending) {
+        sc->d1->handshake_read_seq = dtls_handshake_read_seq;
+        sc->d1->next_handshake_write_seq = dtls_next_handshake_write_seq;
+
+        if (sc->rlayer.wrlmethod->set_sequence && sc->rlayer.rrlmethod->set_sequence) {
+            if (!sc->rlayer.rrlmethod->set_sequence(sc->rlayer.rrl, dtls_rl_read_seq)
+                || !sc->rlayer.wrlmethod->set_sequence(sc->rlayer.wrl, dtls_rl_write_seq))
+                return 0;
+        }
+    }
 
     ERR_clear_error();
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7362,6 +7362,8 @@ int SSL_stateless(SSL *s)
             if (!sc->rlayer.rrlmethod->get_sequence(sc->rlayer.rrl, &dtls_rl_read_seq)
                 || !sc->rlayer.wrlmethod->get_sequence(sc->rlayer.wrl, &dtls_rl_write_seq))
                 return 0;
+        } else {
+            return 0;
         }
     }
 
@@ -7383,6 +7385,8 @@ int SSL_stateless(SSL *s)
             if (!sc->rlayer.rrlmethod->set_sequence(sc->rlayer.rrl, dtls_rl_read_seq)
                 || !sc->rlayer.wrlmethod->set_sequence(sc->rlayer.wrl, dtls_rl_write_seq))
                 return 0;
+        } else {
+            return 0;
         }
     }
 

--- a/test/build.info
+++ b/test/build.info
@@ -470,9 +470,9 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[lhash_test]=../include ../apps/include
   DEPEND[lhash_test]=../libcrypto.a libtestutil.a
 
-  SOURCE[dtlsv1listentest]=dtlsv1listentest.c
+  SOURCE[dtlsv1listentest]=dtlsv1listentest.c helpers/ssltestlib.c
   INCLUDE[dtlsv1listentest]=../include ../apps/include
-  DEPEND[dtlsv1listentest]=../libssl libtestutil.a
+  DEPEND[dtlsv1listentest]=../libcrypto ../libssl libtestutil.a
 
   SOURCE[ct_test]=ct_test.c
   INCLUDE[ct_test]=../include ../apps/include

--- a/test/dtlsv1listentest.c
+++ b/test/dtlsv1listentest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2025 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -13,7 +13,11 @@
 #include <openssl/err.h>
 #include <openssl/conf.h>
 #include "internal/nelem.h"
+#include "helpers/ssltestlib.h"
 #include "testutil.h"
+
+static char *cert = NULL;
+static char *privkey = NULL;
 
 #ifndef OPENSSL_NO_SOCK
 
@@ -216,6 +220,208 @@ static const unsigned char record_short[] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00 /* Record sequence number */
 };
 
+/*
+ * DTLSv1.3 packet variants.
+ *
+ * Per RFC 9147, epoch-0 ClientHellos use the same legacy 13-byte record
+ * header as DTLS 1.2, with legacy_record_version = 0xFEFD and
+ * legacy_client_version = 0xFEFD.  DTLS 1.3 is signalled only via the
+ * supported_versions extension (type 0x002B, value 0xFEFC).
+ *
+ * Each packet below is derived from its DTLS 1.2 counterpart by replacing
+ * the empty extensions block (0x00 0x00) with a 9-byte block:
+ *   0x00 0x07               extensions_len = 7
+ *   0x00 0x2B 0x00 0x03     supported_versions ext, 3 bytes of data
+ *   0x02                    versions list len = 2
+ *   0xFE 0xFC               DTLSv1.3
+ * and adjusting record_len / msg_len / frag_len accordingly (+7).
+ * Fragments that stop before the extensions block only have msg_len updated.
+ */
+
+/* A DTLSv1.3 ClientHello without a cookie */
+static const unsigned char clienthello13_nocookie[] = {
+    0x16, /* Handshake */
+    0xFE, 0xFF, /* legacy record version = DTLSv1.0 */
+    0x00, 0x00, /* Epoch */
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* Record sequence number */
+    0x00, 0x41, /* Record Length (0x3A + 7) */
+    0x01, /* ClientHello */
+    0x00, 0x00, 0x35, /* Message length (0x2E + 7) */
+    0x00, 0x00, /* Message sequence */
+    0x00, 0x00, 0x00, /* Fragment offset */
+    0x00, 0x00, 0x35, /* Fragment length (0x2E + 7) */
+    0xFE, 0xFD, /* legacy_client_version = DTLSv1.2 */
+    0xCA, 0x18, 0x9F, 0x76, 0xEC, 0x57, 0xCE, 0xE5, 0xB3, 0xAB, 0x79, 0x90,
+    0xAD, 0xAC, 0x6E, 0xD1, 0x58, 0x35, 0x03, 0x97, 0x16, 0x10, 0x82, 0x56,
+    0xD8, 0x55, 0xFF, 0xE1, 0x8A, 0xA3, 0x2E, 0xF6, /* Random */
+    0x00, /* Session id len */
+    0x00, /* Cookie len */
+    0x00, 0x04, /* Ciphersuites len */
+    0x13, 0x01, /*  TLS_AES_128_GCM_SHA256 */
+    0x13, 0x02, /* TLS_AES_256_GCM_SHA384 */
+    0x01, /* Compression methods len */
+    0x00, /* Null compression */
+    0x00, 0x07, /* Extensions len */
+    0x00, 0x2B, /* supported_versions */
+    0x00, 0x03, /* ext data len */
+    0x02, /* versions list len */
+    0xFE, 0xFC /* DTLSv1.3 */
+};
+
+/*
+ * First fragment of a DTLSv1.3 ClientHello without a cookie.
+ * Fragment stops after cookie len (before extensions); only msg_len is
+ * updated to reflect the full message size including extensions.
+ */
+static const unsigned char clienthello13_nocookie_frag[] = {
+    0x16, /* Handshake */
+    0xFE, 0xFF, /* legacy record version = DTLSv1.0 */
+    0x00, 0x00, /* Epoch */
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* Record sequence number */
+    0x00, 0x30, /* Record Length (unchanged - fragment content same) */
+    0x01, /* ClientHello */
+    0x00, 0x00, 0x35, /* Message length (0x2E + 7 - full message size) */
+    0x00, 0x00, /* Message sequence */
+    0x00, 0x00, 0x00, /* Fragment offset */
+    0x00, 0x00, 0x24, /* Fragment length (unchanged) */
+    0xFE, 0xFD, /* legacy_client_version = DTLSv1.2 */
+    0xCA, 0x18, 0x9F, 0x76, 0xEC, 0x57, 0xCE, 0xE5, 0xB3, 0xAB, 0x79, 0x90,
+    0xAD, 0xAC, 0x6E, 0xD1, 0x58, 0x35, 0x03, 0x97, 0x16, 0x10, 0x82, 0x56,
+    0xD8, 0x55, 0xFF, 0xE1, 0x8A, 0xA3, 0x2E, 0xF6, /* Random */
+    0x00, /* Session id len */
+    0x00 /* Cookie len */
+};
+
+/* A DTLSv1.3 ClientHello with a good cookie */
+static const unsigned char clienthello13_cookie[] = {
+    0x16, /* Handshake */
+    0xFE, 0xFF, /* legacy record version = DTLSv1.0 */
+    0x00, 0x00, /* Epoch */
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* Record sequence number */
+    0x00, 0x55, /* Record Length (0x4E + 7) */
+    0x01, /* ClientHello */
+    0x00, 0x00, 0x49, /* Message length (0x42 + 7) */
+    0x00, 0x00, /* Message sequence */
+    0x00, 0x00, 0x00, /* Fragment offset */
+    0x00, 0x00, 0x49, /* Fragment length (0x42 + 7) */
+    0xFE, 0xFD, /* legacy_client_version = DTLSv1.2 */
+    0xCA, 0x18, 0x9F, 0x76, 0xEC, 0x57, 0xCE, 0xE5, 0xB3, 0xAB, 0x79, 0x90,
+    0xAD, 0xAC, 0x6E, 0xD1, 0x58, 0x35, 0x03, 0x97, 0x16, 0x10, 0x82, 0x56,
+    0xD8, 0x55, 0xFF, 0xE1, 0x8A, 0xA3, 0x2E, 0xF6, /* Random */
+    0x00, /* Session id len */
+    0x14, /* Cookie len */
+    0x00, 0x01, 0x02, 0x03, 0x04, 005, 0x06, 007, 0x08, 0x09, 0x0A, 0x0B, 0x0C,
+    0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, /* Cookie */
+    0x00, 0x04, /* Ciphersuites len */
+    0x13, 0x01, /*  TLS_AES_128_GCM_SHA256 */
+    0x13, 0x02, /* TLS_AES_256_GCM_SHA384 */
+    0x01, /* Compression methods len */
+    0x00, /* Null compression */
+    0x00, 0x07, /* Extensions len */
+    0x00, 0x2B, /* supported_versions */
+    0x00, 0x03, /* ext data len */
+    0x02, /* versions list len */
+    0xFE, 0xFC /* DTLSv1.3 */
+};
+
+/*
+ * Second fragment of a DTLSv1.3 ClientHello without a cookie.
+ * Mirrors clienthello_2ndfrag but with the DTLSv1.3 full message length.
+ * Fragment offset 2 skips the legacy_client_version field sent in the first
+ * fragment.  Because the fragment offset is non-zero, DTLSv1_listen must
+ * drop this packet (it cannot reconstruct a complete ClientHello from it).
+ *
+ * Full DTLSv1.3 nocookie message body = 0x35 bytes (0x2E + 7 for the
+ * supported_versions extension).  Fragment skips first 2 bytes (version),
+ * so fragment length = 0x35 - 2 = 0x33.
+ * Record length = 1 + 3 + 2 + 3 + 3 + 0x33 = 0x3F.
+ */
+static const unsigned char clienthello13_2ndfrag[] = {
+    0x16, /* Handshake */
+    0xFE, 0xFF, /* legacy record version = DTLSv1.0 */
+    0x00, 0x00, /* Epoch */
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* Record sequence number */
+    0x00, 0x3F, /* Record Length */
+    0x01, /* ClientHello */
+    0x00, 0x00, 0x35, /* Message length (0x2E + 7 - full nocookie message) */
+    0x00, 0x00, /* Message sequence */
+    0x00, 0x00, 0x02, /* Fragment offset */
+    0x00, 0x00, 0x33, /* Fragment length (0x35 - 2 bytes skipped) */
+    /* legacy_client_version skipped - sent in first fragment */
+    0xCA, 0x18, 0x9F, 0x76, 0xEC, 0x57, 0xCE, 0xE5, 0xB3, 0xAB, 0x79, 0x90,
+    0xAD, 0xAC, 0x6E, 0xD1, 0x58, 0x35, 0x03, 0x97, 0x16, 0x10, 0x82, 0x56,
+    0xD8, 0x55, 0xFF, 0xE1, 0x8A, 0xA3, 0x2E, 0xF6, /* Random */
+    0x00, /* Session id len */
+    0x00, /* Cookie len */
+    0x00, 0x04, /* Ciphersuites len */
+    0x13, 0x01, /* TLS_AES_128_GCM_SHA256 */
+    0x13, 0x02, /* TLS_AES_256_GCM_SHA384 */
+    0x01, /* Compression methods len */
+    0x00, /* Null compression */
+    0x00, 0x07, /* Extensions len */
+    0x00, 0x2B, /* supported_versions */
+    0x00, 0x03, /* ext data len */
+    0x02, /* versions list len */
+    0xFE, 0xFC /* DTLSv1.3 */
+};
+
+/* A DTLSv1.3 ClientHello with a bad cookie */
+static const unsigned char clienthello13_badcookie[] = {
+    0x16, /* Handshake */
+    0xFE, 0xFF, /* legacy record version = DTLSv1.0 */
+    0x00, 0x00, /* Epoch */
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* Record sequence number */
+    0x00, 0x55, /* Record Length (0x4E + 7) */
+    0x01, /* ClientHello */
+    0x00, 0x00, 0x49, /* Message length (0x42 + 7) */
+    0x00, 0x00, /* Message sequence */
+    0x00, 0x00, 0x00, /* Fragment offset */
+    0x00, 0x00, 0x49, /* Fragment length (0x42 + 7) */
+    0xFE, 0xFD, /* legacy_client_version = DTLSv1.2 */
+    0xCA, 0x18, 0x9F, 0x76, 0xEC, 0x57, 0xCE, 0xE5, 0xB3, 0xAB, 0x79, 0x90,
+    0xAD, 0xAC, 0x6E, 0xD1, 0x58, 0x35, 0x03, 0x97, 0x16, 0x10, 0x82, 0x56,
+    0xD8, 0x55, 0xFF, 0xE1, 0x8A, 0xA3, 0x2E, 0xF6, /* Random */
+    0x00, /* Session id len */
+    0x14, /* Cookie len */
+    0x01, 0x01, 0x02, 0x03, 0x04, 005, 0x06, 007, 0x08, 0x09, 0x0A, 0x0B, 0x0C,
+    0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, /* Cookie (first byte wrong) */
+    0x00, 0x04, /* Ciphersuites len */
+    0x13, 0x01, /*  TLS_AES_128_GCM_SHA256 */
+    0x13, 0x02, /* TLS_AES_256_GCM_SHA384 */
+    0x01, /* Compression methods len */
+    0x00, /* Null compression */
+    0x00, 0x07, /* Extensions len */
+    0x00, 0x2B, /* supported_versions */
+    0x00, 0x03, /* ext data len */
+    0x02, /* versions list len */
+    0xFE, 0xFC /* DTLSv1.3 */
+};
+
+/*
+ * A DTLSv1.3 fragmented ClientHello with the fragment boundary mid-cookie.
+ * Fragment stops mid-cookie (before extensions); only msg_len is updated.
+ */
+static const unsigned char clienthello13_cookie_short[] = {
+    0x16, /* Handshake */
+    0xFE, 0xFF, /* legacy record version = DTLSv1.0 */
+    0x00, 0x00, /* Epoch */
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* Record sequence number */
+    0x00, 0x43, /* Record Length (unchanged - fragment content same) */
+    0x01, /* ClientHello */
+    0x00, 0x00, 0x49, /* Message length (0x42 + 7 - full message size) */
+    0x00, 0x00, /* Message sequence */
+    0x00, 0x00, 0x00, /* Fragment offset */
+    0x00, 0x00, 0x37, /* Fragment length (unchanged) */
+    0xFE, 0xFD, /* legacy_client_version = DTLSv1.2 */
+    0xCA, 0x18, 0x9F, 0x76, 0xEC, 0x57, 0xCE, 0xE5, 0xB3, 0xAB, 0x79, 0x90,
+    0xAD, 0xAC, 0x6E, 0xD1, 0x58, 0x35, 0x03, 0x97, 0x16, 0x10, 0x82, 0x56,
+    0xD8, 0x55, 0xFF, 0xE1, 0x8A, 0xA3, 0x2E, 0xF6, /* Random */
+    0x00, /* Session id len */
+    0x14, /* Cookie len */
+    0x00, 0x01, 0x02, 0x03, 0x04, 005, 0x06, 007, 0x08, 0x09, 0x0A, 0x0B, 0x0C,
+    0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12 /* Cookie (truncated) */
+};
+
 static const unsigned char verify[] = {
     0x16, /* Handshake */
     0xFE, 0xFF, /* DTLSv1.0 */
@@ -258,6 +464,18 @@ static tests testpackets[9] = {
     { record_short, sizeof(record_short), DROP }
 };
 
+static tests testpackets13[9] = {
+    { clienthello13_nocookie, sizeof(clienthello13_nocookie), VERIFY },
+    { clienthello13_nocookie_frag, sizeof(clienthello13_nocookie_frag), VERIFY },
+    { clienthello_nocookie_short, sizeof(clienthello_nocookie_short), DROP },
+    { clienthello13_2ndfrag, sizeof(clienthello13_2ndfrag), DROP },
+    { clienthello13_cookie, sizeof(clienthello13_cookie), GOOD },
+    { clienthello_cookie_frag, sizeof(clienthello_cookie_frag), GOOD },
+    { clienthello13_badcookie, sizeof(clienthello13_badcookie), VERIFY },
+    { clienthello13_cookie_short, sizeof(clienthello13_cookie_short), DROP },
+    { record_short, sizeof(record_short), DROP }
+};
+
 #define COOKIE_LEN 20
 
 static int cookie_gen(SSL *ssl, unsigned char *cookie, unsigned int *cookie_len)
@@ -287,6 +505,10 @@ static int cookie_verify(SSL *ssl, const unsigned char *cookie,
     return 1;
 }
 
+/*
+ * Combined DTLS listen test covering both DTLS 1.2 and DTLS 1.3 packet
+ * variants.
+ */
 static int dtls_listen_test(int i)
 {
     SSL_CTX *ctx = NULL;
@@ -294,14 +516,33 @@ static int dtls_listen_test(int i)
     BIO *outbio = NULL;
     BIO *inbio = NULL;
     BIO_ADDR *peer = NULL;
-    tests *tp = &testpackets[i];
+    tests *tp;
+    int is_dtls13 = (i >= (int)OSSL_NELEM(testpackets));
     char *data;
     long datalen;
     int ret, success = 0;
 
+    if (is_dtls13) {
+        tp = &testpackets13[i - (int)OSSL_NELEM(testpackets)];
+#if defined(OSSL_NO_USABLE_DTLS1_3)
+        testresult = TEST_skip("DTLSv1.3 not usable");
+        goto end;
+#endif
+    } else {
+        tp = &testpackets[i];
+    }
+
     if (!TEST_ptr(ctx = SSL_CTX_new(DTLS_server_method()))
         || !TEST_ptr(peer = BIO_ADDR_new()))
         goto err;
+
+    /* Constrain to DTLSv1.3 only for the second set of test vectors */
+    if (is_dtls13) {
+        if (!TEST_true(SSL_CTX_set_min_proto_version(ctx, DTLS1_3_VERSION))
+            || !TEST_true(SSL_CTX_set_max_proto_version(ctx, DTLS1_3_VERSION)))
+            goto err;
+    }
+
     SSL_CTX_set_cookie_generate_cb(ctx, cookie_gen);
     SSL_CTX_set_cookie_verify_cb(ctx, cookie_verify);
 
@@ -349,10 +590,150 @@ err:
 }
 #endif
 
+#ifndef OPENSSL_NO_DTLS1_3
+/*
+ * Verify that a DTLS client completes a full handshake through DTLSv1_listen()
+ * and negotiates DTLS 1.3.
+ *
+ * DTLSv1_listen() uses the legacy DTLS 1.2 HelloVerifyRequest mechanism for
+ * the stateless cookie exchange, so the client must allow DTLS 1.2 as a
+ * minimum to handle that exchange.  The server is pinned to DTLS 1.3 only,
+ * which forces the final negotiated version to be DTLS 1.3.  After the
+ * handshake completes we verify that DTLS 1.3 was actually selected and that
+ * application data can be exchanged in both directions.
+ */
+static int test_dtls13_listen(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *serverssl = NULL, *clientssl = NULL;
+    const char msg[] = "Hello DTLS 1.3";
+    char buf[sizeof(msg)];
+    size_t written, readbytes;
+    int testresult = 0;
+
+    /*
+     * Server: DTLS 1.3 only.
+     * Client: DTLS 1.0 minimum so it can handle the HelloVerifyRequest from
+     * DTLSv1_listen(), but prefers DTLS 1.3 as max — the server will enforce
+     * DTLS 1.3 for the actual handshake.
+     */
+    if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
+            DTLS_client_method(),
+            DTLS1_3_VERSION, DTLS1_3_VERSION,
+            &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    /* Allow the client to speak DTLS 1.2 only for the cookie exchange */
+    if (!TEST_true(SSL_CTX_set_min_proto_version(cctx, DTLS1_VERSION)))
+        goto end;
+
+    SSL_CTX_set_cookie_generate_cb(sctx, cookie_gen);
+    SSL_CTX_set_cookie_verify_cb(sctx, cookie_verify);
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL)))
+        goto end;
+
+    /*
+     * The last argument of create_bare_ssl_connection() requests that
+     * DTLSv1_listen() is used on the server before SSL_accept().
+     */
+    if (!TEST_true(create_bare_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE, 1, 1)))
+        goto end;
+
+    /* Confirm DTLS 1.3 was actually negotiated */
+    if (!TEST_int_eq(SSL_version(serverssl), DTLS1_3_VERSION)
+        || !TEST_int_eq(SSL_version(clientssl), DTLS1_3_VERSION))
+        goto end;
+
+    /* Exchange a short application-data message in each direction. */
+    if (!TEST_true(SSL_write_ex(clientssl, msg, sizeof(msg), &written))
+        || !TEST_size_t_eq(written, sizeof(msg)))
+        goto end;
+
+    if (!TEST_true(SSL_read_ex(serverssl, buf, sizeof(buf), &readbytes))
+        || !TEST_size_t_eq(readbytes, sizeof(msg))
+        || !TEST_mem_eq(buf, readbytes, msg, sizeof(msg)))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
+/*
+ * Use SSL_stateless with DTLS if you want to send a
+ * HelloRetryRequest and then continue with the handshake.
+ * DTLSv1_listen only support HelloVerifyRequest, so a pure DTLS 1.3
+ * client is not supported with DTLSv1_listen.
+ */
+static int test_dtls13_listen_client_dtls13_only(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *serverssl = NULL, *clientssl = NULL;
+    int testresult = 0;
+
+    /* Both server and client are restricted to DTLS 1.3 exclusively. */
+    if (!TEST_true(create_ssl_ctx_pair(NULL, DTLS_server_method(),
+            DTLS_client_method(),
+            DTLS1_3_VERSION, DTLS1_3_VERSION,
+            &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    if (!TEST_true(SSL_CTX_set_min_proto_version(cctx, DTLS1_3_VERSION))
+        || !TEST_true(SSL_CTX_set_max_proto_version(cctx, DTLS1_3_VERSION)))
+        goto end;
+
+    SSL_CTX_set_cookie_generate_cb(sctx, cookie_gen);
+    SSL_CTX_set_cookie_verify_cb(sctx, cookie_verify);
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL)))
+        goto end;
+
+    /*
+     * Pass listen=1 so that create_bare_ssl_connection() calls
+     * Verify DTLSv1_listen does not work with a pure DTLS 1.3 client
+     */
+    if (!TEST_false(create_bare_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE, 1, 1)))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+#endif /* OPENSSL_NO_DTLS1_3 */
+
+OPT_TEST_DECLARE_USAGE("certfile privkeyfile\n")
+
 int setup_tests(void)
 {
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
+    if (!TEST_ptr(cert = test_get_argument(0))
+        || !TEST_ptr(privkey = test_get_argument(1)))
+        return 0;
+
 #ifndef OPENSSL_NO_SOCK
-    ADD_ALL_TESTS(dtls_listen_test, (int)OSSL_NELEM(testpackets));
+    ADD_ALL_TESTS(dtls_listen_test,
+        (int)OSSL_NELEM(testpackets) + (int)OSSL_NELEM(testpackets13));
+#ifndef OPENSSL_NO_DTLS1_3
+    ADD_TEST(test_dtls13_listen);
+    ADD_TEST(test_dtls13_listen_client_dtls13_only);
+#endif
 #endif
     return 1;
 }

--- a/test/dtlsv1listentest.c
+++ b/test/dtlsv1listentest.c
@@ -452,7 +452,7 @@ typedef struct {
         DROP } outtype;
 } tests;
 
-static tests testpackets[9] = {
+static tests testpackets[] = {
     { clienthello_nocookie, sizeof(clienthello_nocookie), VERIFY },
     { clienthello_nocookie_frag, sizeof(clienthello_nocookie_frag), VERIFY },
     { clienthello_nocookie_short, sizeof(clienthello_nocookie_short), DROP },
@@ -464,7 +464,7 @@ static tests testpackets[9] = {
     { record_short, sizeof(record_short), DROP }
 };
 
-static tests testpackets13[9] = {
+static tests testpackets13[] = {
     { clienthello13_nocookie, sizeof(clienthello13_nocookie), VERIFY },
     { clienthello13_nocookie_frag, sizeof(clienthello13_nocookie_frag), VERIFY },
     { clienthello_nocookie_short, sizeof(clienthello_nocookie_short), DROP },
@@ -508,6 +508,40 @@ static int cookie_verify(SSL *ssl, const unsigned char *cookie,
 /*
  * Combined DTLS listen test covering both DTLS 1.2 and DTLS 1.3 packet
  * variants.
+ * 0: Test that DTLS 1.2 without a cookie is accepted by DTLSv1_listen().
+ * 1: Test that a fragmented DTLS 1.2 ClientHello without a cookie is
+ *   accepted by DTLSv1_listen().
+ * 2: Test that a truncated DTLS 1.2 ClientHello without a cookie is
+ *   dropped by DTLSv1_listen().
+ * 3: Test that a second fragment of a DTLS 1.2 ClientHello without a
+ *   cookie is dropped by DTLSv1_listen() (it cannot reconstruct a full
+ *   ClientHello from it).
+ * 4: Test that a DTLS 1.2 ClientHello with a good cookie is accepted by
+ *   DTLSv1_listen().
+ * 5: Test that a fragmented DTLS 1.2 ClientHello with a good cookie is
+ *   accepted by DTLSv1_listen().
+ * 6: Test that a DTLS 1.2 ClientHello with a bad cookie is rejected by
+ *   DTLSv1_listen() with a HelloVerifyRequest.
+ * 7: Test that a DTLS 1.2 ClientHello with a truncated cookie is dropped
+ *   by DTLSv1_listen().
+ * 8: Test that a short record is dropped by DTLSv1_listen().
+ * 9: Test that DTLS 1.3 without a cookie is accepted by DTLSv1_listen().
+ * 10: Test that a fragmented DTLS 1.3 ClientHello without a cookie is
+ *   accepted by DTLSv1_listen().
+ * 11: Test that a truncated DTLS 1.3 ClientHello without a cookie is
+ *   dropped by DTLSv1_listen().
+ * 12: Test that a second fragment of a DTLS 1.3 ClientHello without a
+ *   cookie is dropped by DTLSv1_listen() (it cannot reconstruct a full
+ *   ClientHello from it).
+ * 13: Test that a DTLS 1.3 ClientHello with a good cookie is accepted by
+ *   DTLSv1_listen().
+ * 14: Test that a fragmented DTLS 1.3 ClientHello with a good cookie is
+ *   accepted by DTLSv1_listen().
+ * 15: Test that a DTLS 1.3 ClientHello with a bad cookie is rejected by
+ *   DTLSv1_listen() with a HelloVerifyRequest.
+ * 16: Test that a DTLS 1.3 ClientHello with a truncated cookie is dropped
+ *   by DTLSv1_listen().
+ * 17: Test that a short record is dropped by DTLSv1_listen().
  */
 static int dtls_listen_test(int i)
 {

--- a/test/recipes/80-test_dtlsv1listen.t
+++ b/test/recipes/80-test_dtlsv1listen.t
@@ -6,7 +6,15 @@
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
+use OpenSSL::Test::Utils;
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
-use OpenSSL::Test::Simple;
+setup("test_dtlsv1listen");
 
-simple_test("test_dtlsv1listen", "dtlsv1listentest", "dh");
+plan skip_all => "No DTLS protocols are supported by this OpenSSL build"
+    if alldisabled(available_protocols("dtls"));
+
+plan tests => 1;
+
+ok(run(test(["dtlsv1listentest", srctop_file("apps", "server.pem"),
+             srctop_file("apps", "server.pem")])), "running dtlsv1listentest");

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -6999,25 +6999,34 @@ static int verify_stateless_cookie_callback(SSL *ssl, const unsigned char *cooki
     return verify_cookie_callback(ssl, cookie, (unsigned int)cookie_len);
 }
 
-/*
- * DTLS does not need to be tested here. Since DTLS has a Sequence number
- * it cannot use SSL_stateless(). If you want to use stateless DTLS
- * use DTLSv1_listen instead. This test is already covered in
- * dtlsv1listentest.c
- */
-static int test_stateless(void)
+static int test_stateless(int idx)
 {
     SSL_CTX *sctx = NULL, *cctx = NULL;
     SSL *serverssl = NULL, *clientssl = NULL;
     int testresult = 0;
+    const SSL_METHOD *smeth, *cmeth;
+    int vermin, vermax = 0;
+    int testdtls = idx >= 1;
 
-#if defined(OSSL_NO_USABLE_TLS1_3) || defined(OPENSSL_NO_TLS1_2)
-    testresult = TEST_skip("TLSv1.3 not usable or no TLSv1.2");
-    goto end;
+    if (testdtls) {
+        smeth = DTLS_server_method();
+        cmeth = DTLS_client_method();
+        vermin = DTLS1_VERSION;
+#if defined(OSSL_NO_USABLE_DTLS1_3) || defined(OPENSSL_NO_DTLS1_2)
+        testresult = TEST_skip("DTLSv1.3 not usable or no DTLSv1.2");
+        goto end;
 #endif
+    } else {
+        smeth = TLS_server_method();
+        cmeth = TLS_client_method();
+        vermin = TLS1_VERSION;
+#if defined(OSSL_NO_USABLE_TLS1_3) || defined(OPENSSL_NO_TLS1_2)
+        testresult = TEST_skip("TLSv1.3 not usable or no TLSv1.2");
+        goto end;
+#endif
+    }
 
-    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
-            TLS_client_method(), TLS1_VERSION, 0,
+    if (!TEST_true(create_ssl_ctx_pair(libctx, smeth, cmeth, vermin, vermax,
             &sctx, &cctx, cert, privkey)))
         goto end;
 
@@ -7060,6 +7069,16 @@ static int test_stateless(void)
     /* Abandon the connection from this client */
     SSL_free(clientssl);
     clientssl = NULL;
+
+    /*
+     * Since we are using the same server object for multiple tests
+     * we need to clear it outside of SSL_stateless in this test
+     * to properly reset the handshake_req_seq
+     */
+    if (testdtls) {
+        if (!TEST_true(SSL_clear(serverssl)))
+            goto end;
+    }
 
     /*
      * Now create a connection from a new client but with the same server SSL
@@ -15149,7 +15168,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_custom_exts, 3);
 #endif
 #if !defined(OSSL_NO_USABLE_TLS1_3) || !defined(OSSL_NO_USABLE_DTLS1_3)
-    ADD_TEST(test_stateless);
+    ADD_ALL_TESTS(test_stateless, 2);
 #endif
     ADD_ALL_TESTS(test_export_key_mat, 6);
 #if !defined(OSSL_NO_USABLE_TLS1_3) || !defined(OSSL_NO_USABLE_DTLS1_3)


### PR DESCRIPTION
Update DTLSv1ListenTest.c to test a client that supports DTLS1.2 and DTLS1.3. It will use a Hello Verify Request.

Added a test that will fail when a client that only supports DTLS1.3 uses DTLSv1_listen. Instead the user should use SSL_statless.

SSL_stateless was updated to properly keep track of the handshake_read_seq.

Fixes: openssl/project#1829

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
