### PR TITLE
Fix certificate read from stdin on Windows

### DIFF
--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -218,8 +218,19 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_INFO:
         if (b->flags & BIO_FLAGS_UPLINK_INTERNAL)
             ret = UP_ftell(b->ptr);
-        else
+        else {
+#if defined(OPENSSL_SYS_WINDOWS)
+            /*
+             * On Windows, for non-seekable files (stdin), ftell() is undefined.
+             */
+            if (GetFileType((HANDLE)_get_osfhandle(_fileno(fp))) != FILE_TYPE_DISK)
+                ret = -1;
+            else
+                ret = ftell(fp);
+#else
             ret = ftell(fp);
+#endif
+        }
         break;
     case BIO_C_SET_FILE_PTR:
         file_free(b);

--- a/test/recipes/61-test_bio_readbuffer.t
+++ b/test/recipes/61-test_bio_readbuffer.t
@@ -16,7 +16,7 @@ setup('test_bio_readbuffer');
 my $pemfile = srctop_file("test", "certs", "leaf.pem");
 my $derfile = 'readbuffer_leaf.der';
 
-plan tests => 3;
+plan tests => 4;
 
 ok(run(app([ 'openssl', 'x509', '-inform', 'PEM', '-in', $pemfile,
              '-outform', 'DER', '-out', $derfile])),
@@ -27,3 +27,7 @@ ok(run(test(["bio_readbuffer_test", $derfile])),
 
 ok(run(test(["bio_readbuffer_test", $pemfile])),
    "Running bio_readbuffer_test $pemfile");
+
+ok(run(app([ 'openssl', 'x509', '-inform', 'DER', '-outform', 'PEM',
+             '-noout' ], stdin => $derfile)),
+   "Test stdin read buffer in openssl app");


### PR DESCRIPTION
On Windows, reading certificate from stdin could fail like
  type cert.der| openssl.exe x509 -inform DER -outform PEM
  Could not find or decode certificate from <stdin>

The issue is that pipe is non-seekable but ftell() does not return -1 as it should.

Fixes: #19508 