### PR TITLE
DTLS 1.3 Epoch bits that don't match are from a prior epoch

### DIFF
--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -561,7 +561,7 @@ again:
 
             /*
              * RFC 9147 Section 4.2.2 Says that after the handshake phase (epoch 3+)
-             * if the poech bits do not match the current epoch we should use the
+             * if the epoch bits do not match the current epoch we should use the
              * last epoch value. That would result in dropping the packet.
              */
             if ((epoch64 & DTLS13_UNI_HDR_EPOCH_BITS_MASK) != eebits) {

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -560,22 +560,24 @@ again:
             }
 
             /*
-             * We should not be getting records from a previous epoch so
-             * choose the current epoch if the bits match or else choose the
-             * next epoch with matching bits
+             * RFC 9147 Section 4.2.2 Says that after the handshake phase (epoch 3+)
+             * if the poech bits do not match the current epoch we should use the
+             * last epoch value. That would result in dropping the packet.
              */
-            if ((epoch64 & DTLS13_UNI_HDR_EPOCH_BITS_MASK) > eebits) {
-                int err = 0;
-                epoch64 = safe_add_uint64_t(epoch64, DTLS13_UNI_HDR_EPOCH_BITS_MASK + 1, &err);
-                if (err) {
-                    /* Overflow, silently discard record */
+            if ((epoch64 & DTLS13_UNI_HDR_EPOCH_BITS_MASK) != eebits) {
+                /*
+                 * Since we do not transition out of early data until after we receive the next
+                 * record if we are in Early Data (epoch 1) and get an
+                 * epoch 2 record we must increment the epoch
+                 */
+                if (epoch64 == 1 && ((epoch64 & DTLS13_UNI_HDR_EPOCH_BITS_MASK) + 1) == eebits) {
+                    epoch64++;
+                } else {
                     rr->length = 0;
                     rl->packet_length = 0;
                     goto again;
                 }
             }
-            epoch64 = (epoch64 & ~DTLS13_UNI_HDR_EPOCH_BITS_MASK) | eebits;
-
         } else {
             if (!PACKET_get_net_2(&dtlsrecord, &record_version)
                 || !PACKET_get_net_2(&dtlsrecord, &epoch)


### PR DESCRIPTION
When receiving a unified header if the epoch lower bytes do not match we assumed it was from a future epoch. The RFC says we should assume it is from a prior epoch.

Updating the code to match the RFC. For early data (epoch 1) we still need to increment the epoch if it is a handshake message in epoch 2.

Fixes: openssl/project#1912

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
