### PR TITLE
Make ext argument of X509V3_EXT_print_fp const

### DIFF
--- a/crypto/x509/v3_prn.c
+++ b/crypto/x509/v3_prn.c
@@ -201,7 +201,7 @@ static int unknown_ext_print(BIO *out, const unsigned char *ext, int extlen,
 }
 
 #ifndef OPENSSL_NO_STDIO
-int X509V3_EXT_print_fp(FILE *fp, X509_EXTENSION *ext, int flag, int indent)
+int X509V3_EXT_print_fp(FILE *fp, const X509_EXTENSION *ext, int flag, int indent)
 {
     BIO *bio_tmp;
     int ret;

--- a/doc/man3/X509V3_EXT_print.pod
+++ b/doc/man3/X509V3_EXT_print.pod
@@ -9,7 +9,7 @@ X509V3_EXT_print, X509V3_EXT_print_fp - pretty print X509 certificate extensions
  #include <openssl/x509v3.h>
 
  int X509V3_EXT_print(BIO *out, const X509_EXTENSION *ext, unsigned long flag, int indent);
- int X509V3_EXT_print_fp(FILE *out, X509_EXTENSION *ext, int flag, int indent);
+ int X509V3_EXT_print_fp(FILE *out, const X509_EXTENSION *ext, int flag, int indent);
 
 =head1 DESCRIPTION
 

--- a/include/openssl/x509v3.h.in
+++ b/include/openssl/x509v3.h.in
@@ -747,7 +747,7 @@ void X509V3_EXT_val_prn(BIO *out, STACK_OF(CONF_VALUE) *val, int indent,
 int X509V3_EXT_print(BIO *out, const X509_EXTENSION *ext, unsigned long flag,
     int indent);
 #ifndef OPENSSL_NO_STDIO
-int X509V3_EXT_print_fp(FILE *out, X509_EXTENSION *ext, int flag, int indent);
+int X509V3_EXT_print_fp(FILE *out, const X509_EXTENSION *ext, int flag, int indent);
 #endif
 int X509V3_extensions_print(BIO *out, const char *title,
     const STACK_OF(X509_EXTENSION) *exts,


### PR DESCRIPTION
Commit e75bd84 made the ext argument of 509V3_EXT_print const
but did not give 509V3_EXT_print_fp which is essentially is a wrapper
around X509V3_EXT_print the same treatment.

This also updates the man page to match the implementation.

This commit aligns the two functions again.
##### Checklist
- [x] documentation is added or updated
