### PR TITLE
Correct BN_copy error handling by using explicit NULL checks

### DIFF
--- a/crypto/bn/bn_div.c
+++ b/crypto/bn/bn_div.c
@@ -288,7 +288,7 @@ int bn_div_fixed_top(BIGNUM *dv, BIGNUM *rm, const BIGNUM *num,
         goto err;
 
     /* First we normalise the numbers */
-    if (!BN_copy(sdiv, divisor))
+    if (BN_copy(sdiv, divisor) == NULL)
         goto err;
     norm_shift = bn_left_align(sdiv);
     sdiv->neg = 0;

--- a/crypto/bn/bn_exp.c
+++ b/crypto/bn/bn_exp.c
@@ -206,7 +206,7 @@ int BN_mod_exp_recp(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
 
     if (m->neg) {
         /* ignore sign of 'm' */
-        if (!BN_copy(aa, m))
+        if (BN_copy(aa, m) == NULL)
             goto err;
         aa->neg = 0;
         if (BN_RECP_CTX_set(&recp, aa, ctx) <= 0)

--- a/crypto/bn/bn_gcd.c
+++ b/crypto/bn/bn_gcd.c
@@ -167,7 +167,7 @@ static ossl_inline BIGNUM *bn_mod_inverse_no_branch(BIGNUM *in,
     if (BN_is_one(A)) {
         /* Y*a == 1  (mod |n|) */
         if (!Y->neg && BN_ucmp(Y, n) < 0) {
-            if (!BN_copy(R, Y))
+            if (BN_copy(R, Y) == NULL)
                 goto err;
         } else {
             if (!BN_nnmod(R, Y, n, ctx))
@@ -456,7 +456,7 @@ BIGNUM *int_bn_mod_inverse(BIGNUM *in,
                     if (!BN_lshift(tmp, X, 2))
                         goto err;
                 } else if (D->top == 1) {
-                    if (!BN_copy(tmp, X))
+                    if (BN_copy(tmp, X) == NULL)
                         goto err;
                     if (!BN_mul_word(tmp, D->d[0]))
                         goto err;
@@ -492,7 +492,7 @@ BIGNUM *int_bn_mod_inverse(BIGNUM *in,
     if (BN_is_one(A)) {
         /* Y*a == 1  (mod |n|) */
         if (!Y->neg && BN_ucmp(Y, n) < 0) {
-            if (!BN_copy(R, Y))
+            if (BN_copy(R, Y) == NULL)
                 goto err;
         } else {
             if (!BN_nnmod(R, Y, n, ctx))

--- a/crypto/bn/bn_gf2m.c
+++ b/crypto/bn/bn_gf2m.c
@@ -568,7 +568,7 @@ static int BN_GF2m_mod_inv_vartime(BIGNUM *r, const BIGNUM *a,
     if (BN_is_zero(u))
         goto err;
 
-    if (!BN_copy(v, p))
+    if (BN_copy(v, p) == NULL)
         goto err;
 #if 0
     if (!BN_one(b))
@@ -696,7 +696,7 @@ static int BN_GF2m_mod_inv_vartime(BIGNUM *r, const BIGNUM *a,
     }
 #endif
 
-    if (!BN_copy(r, b))
+    if (BN_copy(r, b) == NULL)
         goto err;
     bn_check_top(r);
     ret = 1;
@@ -881,7 +881,7 @@ int BN_GF2m_mod_exp_arr(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
                 goto err;
         }
     }
-    if (!BN_copy(r, u))
+    if (BN_copy(r, u) == NULL)
         goto err;
     bn_check_top(r);
     ret = 1;
@@ -1020,7 +1020,7 @@ int BN_GF2m_mod_solve_quad_arr(BIGNUM *r, const BIGNUM *a_, const int p[],
 
     if (p[0] & 0x1) { /* m is odd */
         /* compute half-trace of a */
-        if (!BN_copy(z, a))
+        if (BN_copy(z, a) == NULL)
             goto err;
         for (j = 1; j <= (p[0] - 1) / 2; j++) {
             if (!BN_GF2m_mod_sqr_arr(z, z, p, ctx))
@@ -1045,7 +1045,7 @@ int BN_GF2m_mod_solve_quad_arr(BIGNUM *r, const BIGNUM *a_, const int p[],
             if (!BN_GF2m_mod_arr(rho, rho, p))
                 goto err;
             BN_zero(z);
-            if (!BN_copy(w, rho))
+            if (BN_copy(w, rho) == NULL)
                 goto err;
             for (j = 1; j <= p[0] - 1; j++) {
                 if (!BN_GF2m_mod_sqr_arr(z, z, p, ctx))
@@ -1076,7 +1076,7 @@ int BN_GF2m_mod_solve_quad_arr(BIGNUM *r, const BIGNUM *a_, const int p[],
         goto err;
     }
 
-    if (!BN_copy(r, z))
+    if (BN_copy(r, z) == NULL)
         goto err;
     bn_check_top(r);
 

--- a/crypto/bn/bn_kron.c
+++ b/crypto/bn/bn_kron.c
@@ -38,10 +38,10 @@ int BN_kronecker(const BIGNUM *a, const BIGNUM *b, BN_CTX *ctx)
     if (B == NULL)
         goto end;
 
-    err = !BN_copy(A, a);
+    err = BN_copy(A, a) == NULL;
     if (err)
         goto end;
-    err = !BN_copy(B, b);
+    err = BN_copy(B, b) == NULL;
     if (err)
         goto end;
 

--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -322,7 +322,7 @@ BIGNUM *BN_dup(const BIGNUM *a)
     t = BN_get_flags(a, BN_FLG_SECURE) ? BN_secure_new() : BN_new();
     if (t == NULL)
         return NULL;
-    if (!BN_copy(t, a)) {
+    if (BN_copy(t, a) == NULL) {
         BN_free(t);
         return NULL;
     }

--- a/crypto/bn/bn_mont.c
+++ b/crypto/bn/bn_mont.c
@@ -192,7 +192,7 @@ int bn_from_mont_fixed_top(BIGNUM *ret, const BIGNUM *a, BN_MONT_CTX *mont,
     if (t2 == NULL)
         goto err;
 
-    if (!BN_copy(t1, a))
+    if (BN_copy(t1, a) == NULL)
         goto err;
     BN_mask_bits(t1, mont->ri);
 
@@ -270,7 +270,7 @@ int BN_MONT_CTX_set(BN_MONT_CTX *mont, const BIGNUM *mod, BN_CTX *ctx)
     if ((Ri = BN_CTX_get(ctx)) == NULL)
         goto err;
     R = &(mont->RR); /* grab RR as a temp */
-    if (!BN_copy(&(mont->N), mod))
+    if (BN_copy(&(mont->N), mod) == NULL)
         goto err; /* Set N */
     if (BN_get_flags(mod, BN_FLG_CONSTTIME) != 0)
         BN_set_flags(&(mont->N), BN_FLG_CONSTTIME);
@@ -411,11 +411,11 @@ BN_MONT_CTX *BN_MONT_CTX_copy(BN_MONT_CTX *to, BN_MONT_CTX *from)
     if (to == from)
         return to;
 
-    if (!BN_copy(&(to->RR), &(from->RR)))
+    if (BN_copy(&(to->RR), &(from->RR) == NULL))
         return NULL;
-    if (!BN_copy(&(to->N), &(from->N)))
+    if (BN_copy(&(to->N), &(from->N) == NULL))
         return NULL;
-    if (!BN_copy(&(to->Ni), &(from->Ni)))
+    if (BN_copy(&(to->Ni), &(from->Ni) == NULL))
         return NULL;
     to->ri = from->ri;
     to->n0[0] = from->n0[0];

--- a/crypto/bn/bn_prime.c
+++ b/crypto/bn/bn_prime.c
@@ -420,7 +420,7 @@ int ossl_bn_miller_rabin_is_prime(const BIGNUM *w, int iterations, BN_CTX *ctx,
         /* (Step 4.7) for j = 1 to a-1 */
         for (j = 1; j < a; ++j) {
             /* (Step 4.7.1 - 4.7.2) x = z. z = x^2 mod w */
-            if (!BN_copy(x, z) || !BN_mod_mul(z, x, x, w, ctx))
+            if (BN_copy(x, z) == NULL || !BN_mod_mul(z, x, x, w, ctx))
                 goto err;
             /* (Step 4.7.3) */
             if (BN_cmp(z, w1) == 0)
@@ -431,13 +431,13 @@ int ossl_bn_miller_rabin_is_prime(const BIGNUM *w, int iterations, BN_CTX *ctx,
         }
         /* At this point z = b^((w-1)/2) mod w */
         /* (Steps 4.8 - 4.9) x = z, z = x^2 mod w */
-        if (!BN_copy(x, z) || !BN_mod_mul(z, x, x, w, ctx))
+        if (BN_copy(x, z) == NULL || !BN_mod_mul(z, x, x, w, ctx))
             goto err;
         /* (Step 4.10) */
         if (BN_is_one(z))
             goto composite;
         /* (Step 4.11) x = b^(w-1) mod w */
-        if (!BN_copy(x, z))
+        if (BN_copy(x, z) == NULL)
             goto err;
     composite:
         if (enhanced) {

--- a/crypto/bn/bn_recp.c
+++ b/crypto/bn/bn_recp.c
@@ -42,7 +42,7 @@ void BN_RECP_CTX_free(BN_RECP_CTX *recp)
 
 int BN_RECP_CTX_set(BN_RECP_CTX *recp, const BIGNUM *d, BN_CTX *ctx)
 {
-    if (BN_is_zero(d) || !BN_copy(&(recp->N), d))
+    if (BN_is_zero(d) || BN_copy(&(recp->N), d) == NULL)
         return 0;
     BN_zero(&(recp->Nr));
     recp->num_bits = BN_num_bits(d);
@@ -95,7 +95,7 @@ int BN_div_recp(BIGNUM *dv, BIGNUM *rem, const BIGNUM *m,
 
     if (BN_ucmp(m, &(recp->N)) < 0) {
         BN_zero(d);
-        if (!BN_copy(r, m)) {
+        if (BN_copy(r, m) == NULL) {
             BN_CTX_end(ctx);
             return 0;
         }

--- a/crypto/bn/bn_sqrt.c
+++ b/crypto/bn/bn_sqrt.c
@@ -160,7 +160,7 @@ BIGNUM *BN_mod_sqrt(BIGNUM *in, const BIGNUM *a, const BIGNUM *p, BN_CTX *ctx)
         if (!BN_mod_mul(x, x, t, p, ctx))
             goto end;
 
-        if (!BN_copy(ret, x))
+        if (BN_copy(ret, x) == NULL)
             goto end;
         err = 0;
         goto vrfy;
@@ -170,7 +170,7 @@ BIGNUM *BN_mod_sqrt(BIGNUM *in, const BIGNUM *a, const BIGNUM *p, BN_CTX *ctx)
      * e > 2, so we really have to use the Tonelli/Shanks algorithm. First,
      * find some y that is not a square.
      */
-    if (!BN_copy(q, p))
+    if (BN_copy(q, p) == NULL)
         goto end; /* use 'q' as temp */
     q->neg = 0;
     i = 2;
@@ -297,7 +297,7 @@ BIGNUM *BN_mod_sqrt(BIGNUM *in, const BIGNUM *a, const BIGNUM *p, BN_CTX *ctx)
          */
 
         if (BN_is_one(b)) {
-            if (!BN_copy(ret, x))
+            if (BN_copy(ret, x) == NULL)
                 goto end;
             err = 0;
             goto vrfy;
@@ -323,7 +323,7 @@ BIGNUM *BN_mod_sqrt(BIGNUM *in, const BIGNUM *a, const BIGNUM *p, BN_CTX *ctx)
         }
 
         /* t := y^2^(e - i - 1) */
-        if (!BN_copy(t, y))
+        if (BN_copy(t, y) == NULL)
             goto end;
         for (j = e - i - 1; j > 0; j--) {
             if (!BN_mod_sqr(t, t, p, ctx))

--- a/crypto/bn/bn_x931p.c
+++ b/crypto/bn/bn_x931p.c
@@ -24,7 +24,7 @@ static int bn_x931_derive_pi(BIGNUM *pi, const BIGNUM *Xpi, BN_CTX *ctx,
     BN_GENCB *cb)
 {
     int i = 0, is_prime;
-    if (!BN_copy(pi, Xpi))
+    if (BN_copy(pi, Xpi) == NULL)
         return 0;
     if (!BN_is_odd(pi) && !BN_add_word(pi, 1))
         return 0;
@@ -121,7 +121,7 @@ int BN_X931_derive_prime_ex(BIGNUM *p, BIGNUM *p1, BIGNUM *p2,
     for (;;) {
         int i = 1;
         BN_GENCB_call(cb, 0, i++);
-        if (!BN_copy(pm1, p))
+        if (BN_copy(pm1, p) == NULL)
             goto err;
         if (!BN_sub_word(pm1, 1))
             goto err;

--- a/crypto/ec/ec2_smpl.c
+++ b/crypto/ec/ec2_smpl.c
@@ -74,11 +74,11 @@ void ossl_ec_GF2m_simple_group_clear_finish(EC_GROUP *group)
  */
 int ossl_ec_GF2m_simple_group_copy(EC_GROUP *dest, const EC_GROUP *src)
 {
-    if (!BN_copy(dest->field, src->field))
+    if (BN_copy(dest->field, src->field) == NULL)
         return 0;
-    if (!BN_copy(dest->a, src->a))
+    if (BN_copy(dest->a, src->a) == NULL)
         return 0;
-    if (!BN_copy(dest->b, src->b))
+    if (BN_copy(dest->b, src->b) == NULL)
         return 0;
     dest->poly[0] = src->poly[0];
     dest->poly[1] = src->poly[1];
@@ -103,7 +103,7 @@ int ossl_ec_GF2m_simple_group_set_curve(EC_GROUP *group,
     int ret = 0, i;
 
     /* group->field */
-    if (!BN_copy(group->field, p))
+    if (BN_copy(group->field, p) == NULL)
         goto err;
     i = BN_GF2m_poly2arr(group->field, group->poly, 6) - 1;
     if ((i != 5) && (i != 3)) {
@@ -142,17 +142,17 @@ int ossl_ec_GF2m_simple_group_get_curve(const EC_GROUP *group, BIGNUM *p,
     int ret = 0;
 
     if (p != NULL) {
-        if (!BN_copy(p, group->field))
+        if (BN_copy(p, group->field) == NULL)
             return 0;
     }
 
     if (a != NULL) {
-        if (!BN_copy(a, group->a))
+        if (BN_copy(a, group->a) == NULL)
             goto err;
     }
 
     if (b != NULL) {
-        if (!BN_copy(b, group->b))
+        if (BN_copy(b, group->b) == NULL)
             goto err;
     }
 
@@ -255,11 +255,11 @@ void ossl_ec_GF2m_simple_point_clear_finish(EC_POINT *point)
  */
 int ossl_ec_GF2m_simple_point_copy(EC_POINT *dest, const EC_POINT *src)
 {
-    if (!BN_copy(dest->X, src->X))
+    if (BN_copy(dest->X, src->X) == NULL)
         return 0;
-    if (!BN_copy(dest->Y, src->Y))
+    if (BN_copy(dest->Y, src->Y) == NULL)
         return 0;
-    if (!BN_copy(dest->Z, src->Z))
+    if (BN_copy(dest->Z, src->Z) == NULL)
         return 0;
     dest->Z_is_one = src->Z_is_one;
     dest->curve_name = src->curve_name;
@@ -295,13 +295,13 @@ int ossl_ec_GF2m_simple_point_set_affine_coordinates(const EC_GROUP *group,
         return 0;
     }
 
-    if (!BN_copy(point->X, x))
+    if (BN_copy(point->X, x) == NULL)
         goto err;
     BN_set_negative(point->X, 0);
-    if (!BN_copy(point->Y, y))
+    if (BN_copy(point->Y, y) == NULL)
         goto err;
     BN_set_negative(point->Y, 0);
-    if (!BN_copy(point->Z, BN_value_one()))
+    if (BN_copy(point->Z, BN_value_one() == NULL))
         goto err;
     BN_set_negative(point->Z, 0);
     point->Z_is_one = 1;
@@ -332,12 +332,12 @@ int ossl_ec_GF2m_simple_point_get_affine_coordinates(const EC_GROUP *group,
         return 0;
     }
     if (x != NULL) {
-        if (!BN_copy(x, point->X))
+        if (BN_copy(x, point->X) == NULL)
             goto err;
         BN_set_negative(x, 0);
     }
     if (y != NULL) {
-        if (!BN_copy(y, point->Y))
+        if (BN_copy(y, point->Y) == NULL)
             goto err;
         BN_set_negative(y, 0);
     }
@@ -393,18 +393,18 @@ int ossl_ec_GF2m_simple_add(const EC_GROUP *group, EC_POINT *r,
         goto err;
 
     if (a->Z_is_one) {
-        if (!BN_copy(x0, a->X))
+        if (BN_copy(x0, a->X) == NULL)
             goto err;
-        if (!BN_copy(y0, a->Y))
+        if (BN_copy(y0, a->Y) == NULL)
             goto err;
     } else {
         if (!EC_POINT_get_affine_coordinates(group, a, x0, y0, ctx))
             goto err;
     }
     if (b->Z_is_one) {
-        if (!BN_copy(x1, b->X))
+        if (BN_copy(x1, b->X) == NULL)
             goto err;
-        if (!BN_copy(y1, b->Y))
+        if (BN_copy(y1, b->Y) == NULL)
             goto err;
     } else {
         if (!EC_POINT_get_affine_coordinates(group, b, x1, y1, ctx))
@@ -655,9 +655,9 @@ int ossl_ec_GF2m_simple_make_affine(const EC_GROUP *group, EC_POINT *point,
 
     if (!EC_POINT_get_affine_coordinates(group, point, x, y, ctx))
         goto err;
-    if (!BN_copy(point->X, x))
+    if (BN_copy(point->X, x) == NULL)
         goto err;
-    if (!BN_copy(point->Y, y))
+    if (BN_copy(point->Y, y) == NULL)
         goto err;
     if (!BN_one(point->Z))
         goto err;

--- a/crypto/ec/ec_backend.c
+++ b/crypto/ec/ec_backend.c
@@ -645,7 +645,7 @@ EC_KEY *ossl_ec_key_dup(const EC_KEY *src, int selection)
             /* no parameter-less keys allowed */
             goto err;
         ret->priv_key = BN_new();
-        if (ret->priv_key == NULL || !BN_copy(ret->priv_key, src->priv_key))
+        if (ret->priv_key == NULL || BN_copy(ret->priv_key, src->priv_key) == NULL)
             goto err;
         if (ret->group->meth->keycopy
             && ret->group->meth->keycopy(ret, src) == 0)

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -136,7 +136,7 @@ EC_KEY *EC_KEY_copy(EC_KEY *dest, const EC_KEY *src)
                 if (dest->priv_key == NULL)
                     return NULL;
             }
-            if (!BN_copy(dest->priv_key, src->priv_key))
+            if (BN_copy(dest->priv_key, src->priv_key) == NULL)
                 return NULL;
             if (src->group->meth->keycopy
                 && src->group->meth->keycopy(dest, src) == 0)

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -242,9 +242,9 @@ int EC_GROUP_copy(EC_GROUP *dest, const EC_GROUP *src)
     }
 
     if ((src->meth->flags & EC_FLAGS_CUSTOM_CURVE) == 0) {
-        if (!BN_copy(dest->order, src->order))
+        if (BN_copy(dest->order, src->order) == NULL)
             return 0;
-        if (!BN_copy(dest->cofactor, src->cofactor))
+        if (BN_copy(dest->cofactor, src->cofactor) == NULL)
             return 0;
     }
 
@@ -348,7 +348,7 @@ static int ec_guess_cofactor(EC_GROUP *group)
         if (!BN_set_bit(q, BN_num_bits(group->field) - 1))
             goto err;
     } else {
-        if (!BN_copy(q, group->field))
+        if (BN_copy(q, group->field) == NULL)
             goto err;
     }
 
@@ -411,12 +411,12 @@ int EC_GROUP_set_generator(EC_GROUP *group, const EC_POINT *generator,
     if (!EC_POINT_copy(group->generator, generator))
         return 0;
 
-    if (!BN_copy(group->order, order))
+    if (BN_copy(group->order, order) == NULL)
         return 0;
 
     /* Either take the provided positive cofactor, or try to compute it */
     if (cofactor != NULL && !BN_is_zero(cofactor)) {
-        if (!BN_copy(group->cofactor, cofactor))
+        if (BN_copy(group->cofactor, cofactor) == NULL)
             return 0;
     } else if (!ec_guess_cofactor(group)) {
         BN_zero(group->cofactor);
@@ -451,7 +451,7 @@ int EC_GROUP_get_order(const EC_GROUP *group, BIGNUM *order, BN_CTX *ctx)
 {
     if (group->order == NULL)
         return 0;
-    if (!BN_copy(order, group->order))
+    if (BN_copy(order, group->order) == NULL)
         return 0;
 
     return !BN_is_zero(order);
@@ -499,7 +499,7 @@ int EC_GROUP_get_cofactor(const EC_GROUP *group, BIGNUM *cofactor,
 {
     if (group->cofactor == NULL)
         return 0;
-    if (!BN_copy(cofactor, group->cofactor))
+    if (BN_copy(cofactor, group->cofactor) == NULL)
         return 0;
 
     return !BN_is_zero(group->cofactor);

--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -213,7 +213,7 @@ int ossl_ec_scalar_mul_ladder(const EC_GROUP *group, EC_POINT *r,
         goto err;
     }
 
-    if (!BN_copy(k, scalar)) {
+    if (BN_copy(k, scalar) == NULL) {
         ERR_raise(ERR_LIB_EC, ERR_R_BN_LIB);
         goto err;
     }

--- a/crypto/ec/ecp_mont.c
+++ b/crypto/ec/ecp_mont.c
@@ -294,7 +294,7 @@ int ossl_ec_GFp_mont_field_set_to_one(const EC_GROUP *group, BIGNUM *r,
         return 0;
     }
 
-    if (!BN_copy(r, group->field_data2))
+    if (BN_copy(r, group->field_data2) == NULL)
         return 0;
     return 1;
 }

--- a/crypto/ec/ecp_nistz256.c
+++ b/crypto/ec/ecp_nistz256.c
@@ -1533,7 +1533,7 @@ static int ecp_nistz256group_full_init(EC_GROUP *group,
     }
     if (!EC_POINT_copy(group->generator, P))
         goto err;
-    if (!BN_copy(group->order, order))
+    if (BN_copy(group->order, order) == NULL)
         goto err;
     if (!BN_set_word(group->cofactor, 1))
         goto err;

--- a/crypto/ec/ecp_smpl.c
+++ b/crypto/ec/ecp_smpl.c
@@ -126,11 +126,11 @@ void ossl_ec_GFp_simple_group_clear_finish(EC_GROUP *group)
 
 int ossl_ec_GFp_simple_group_copy(EC_GROUP *dest, const EC_GROUP *src)
 {
-    if (!BN_copy(dest->field, src->field))
+    if (BN_copy(dest->field, src->field) == NULL)
         return 0;
-    if (!BN_copy(dest->a, src->a))
+    if (BN_copy(dest->a, src->a) == NULL)
         return 0;
-    if (!BN_copy(dest->b, src->b))
+    if (BN_copy(dest->b, src->b) == NULL)
         return 0;
 
     dest->a_is_minus3 = src->a_is_minus3;
@@ -164,7 +164,7 @@ int ossl_ec_GFp_simple_group_set_curve(EC_GROUP *group,
         goto err;
 
     /* group->field */
-    if (!BN_copy(group->field, p))
+    if (BN_copy(group->field, p) == NULL)
         goto err;
     BN_set_negative(group->field, 0);
 
@@ -174,7 +174,7 @@ int ossl_ec_GFp_simple_group_set_curve(EC_GROUP *group,
     if (group->meth->field_encode != NULL) {
         if (!group->meth->field_encode(group, group->a, tmp_a, ctx))
             goto err;
-    } else if (!BN_copy(group->a, tmp_a))
+    } else if (BN_copy(group->a, tmp_a) == NULL)
         goto err;
 
     /* group->b */
@@ -204,7 +204,7 @@ int ossl_ec_GFp_simple_group_get_curve(const EC_GROUP *group, BIGNUM *p,
     BN_CTX *new_ctx = NULL;
 
     if (p != NULL) {
-        if (!BN_copy(p, group->field))
+        if (BN_copy(p, group->field) == NULL)
             return 0;
     }
 
@@ -225,11 +225,11 @@ int ossl_ec_GFp_simple_group_get_curve(const EC_GROUP *group, BIGNUM *p,
             }
         } else {
             if (a != NULL) {
-                if (!BN_copy(a, group->a))
+                if (BN_copy(a, group->a) == NULL)
                     goto err;
             }
             if (b != NULL) {
-                if (!BN_copy(b, group->b))
+                if (BN_copy(b, group->b) == NULL)
                     goto err;
             }
         }
@@ -277,9 +277,9 @@ int ossl_ec_GFp_simple_group_check_discriminant(const EC_GROUP *group,
         if (!group->meth->field_decode(group, b, group->b, ctx))
             goto err;
     } else {
-        if (!BN_copy(a, group->a))
+        if (BN_copy(a, group->a) == NULL)
             goto err;
-        if (!BN_copy(b, group->b))
+        if (BN_copy(b, group->b) == NULL)
             goto err;
     }
 
@@ -352,11 +352,11 @@ void ossl_ec_GFp_simple_point_clear_finish(EC_POINT *point)
 
 int ossl_ec_GFp_simple_point_copy(EC_POINT *dest, const EC_POINT *src)
 {
-    if (!BN_copy(dest->X, src->X))
+    if (BN_copy(dest->X, src->X) == NULL)
         return 0;
-    if (!BN_copy(dest->Y, src->Y))
+    if (BN_copy(dest->Y, src->Y) == NULL)
         return 0;
-    if (!BN_copy(dest->Z, src->Z))
+    if (BN_copy(dest->Z, src->Z) == NULL)
         return 0;
     dest->Z_is_one = src->Z_is_one;
     dest->curve_name = src->curve_name;
@@ -460,15 +460,15 @@ int ossl_ec_GFp_simple_get_Jprojective_coordinates_GFp(const EC_GROUP *group,
         }
     } else {
         if (x != NULL) {
-            if (!BN_copy(x, point->X))
+            if (BN_copy(x, point->X) == NULL)
                 goto err;
         }
         if (y != NULL) {
-            if (!BN_copy(y, point->Y))
+            if (BN_copy(y, point->Y) == NULL)
                 goto err;
         }
         if (z != NULL) {
-            if (!BN_copy(z, point->Z))
+            if (BN_copy(z, point->Z) == NULL)
                 goto err;
         }
     }
@@ -548,11 +548,11 @@ int ossl_ec_GFp_simple_point_get_affine_coordinates(const EC_GROUP *group,
             }
         } else {
             if (x != NULL) {
-                if (!BN_copy(x, point->X))
+                if (BN_copy(x, point->X) == NULL)
                     goto err;
             }
             if (y != NULL) {
-                if (!BN_copy(y, point->Y))
+                if (BN_copy(y, point->Y) == NULL)
                     goto err;
             }
         }
@@ -656,9 +656,9 @@ int ossl_ec_GFp_simple_add(const EC_GROUP *group, EC_POINT *r, const EC_POINT *a
 
     /* n1, n2 */
     if (b->Z_is_one) {
-        if (!BN_copy(n1, a->X))
+        if (BN_copy(n1, a->X) == NULL)
             goto end;
-        if (!BN_copy(n2, a->Y))
+        if (BN_copy(n2, a->Y) == NULL)
             goto end;
         /* n1 = X_a */
         /* n2 = Y_a */
@@ -678,9 +678,9 @@ int ossl_ec_GFp_simple_add(const EC_GROUP *group, EC_POINT *r, const EC_POINT *a
 
     /* n3, n4 */
     if (a->Z_is_one) {
-        if (!BN_copy(n3, b->X))
+        if (BN_copy(n3, b->X) == NULL)
             goto end;
-        if (!BN_copy(n4, b->Y))
+        if (BN_copy(n4, b->Y) == NULL)
             goto end;
         /* n3 = X_b */
         /* n4 = Y_b */
@@ -732,14 +732,14 @@ int ossl_ec_GFp_simple_add(const EC_GROUP *group, EC_POINT *r, const EC_POINT *a
 
     /* Z_r */
     if (a->Z_is_one && b->Z_is_one) {
-        if (!BN_copy(r->Z, n5))
+        if (BN_copy(r->Z, n5) == NULL)
             goto end;
     } else {
         if (a->Z_is_one) {
-            if (!BN_copy(n0, b->Z))
+            if (BN_copy(n0, b->Z) == NULL)
                 goto end;
         } else if (b->Z_is_one) {
-            if (!BN_copy(n0, a->Z))
+            if (BN_copy(n0, a->Z) == NULL)
                 goto end;
         } else {
             if (!field_mul(group, n0, a->Z, b->Z, ctx))
@@ -883,7 +883,7 @@ int ossl_ec_GFp_simple_dbl(const EC_GROUP *group, EC_POINT *r, const EC_POINT *a
 
     /* Z_r */
     if (a->Z_is_one) {
-        if (!BN_copy(n0, a->Y))
+        if (BN_copy(n0, a->Y) == NULL)
             goto err;
     } else {
         if (!field_mul(group, n0, a->Y, a->Z, ctx))
@@ -1241,7 +1241,7 @@ int ossl_ec_GFp_simple_points_make_affine(const EC_GROUP *group, size_t num,
      */
 
     if (!BN_is_zero(points[0]->Z)) {
-        if (!BN_copy(prod_Z[0], points[0]->Z))
+        if (BN_copy(prod_Z[0], points[0]->Z) == NULL)
             goto err;
     } else {
         if (group->meth->field_set_to_one != 0) {
@@ -1259,7 +1259,7 @@ int ossl_ec_GFp_simple_points_make_affine(const EC_GROUP *group, size_t num,
                     ctx))
                 goto err;
         } else {
-            if (!BN_copy(prod_Z[i], prod_Z[i - 1]))
+            if (BN_copy(prod_Z[i], prod_Z[i - 1]) == NULL)
                 goto err;
         }
     }
@@ -1303,14 +1303,14 @@ int ossl_ec_GFp_simple_points_make_affine(const EC_GROUP *group, size_t num,
             if (!group->meth->field_mul(group, tmp, tmp, points[i]->Z, ctx))
                 goto err;
             /* Replace points[i]->Z by its inverse. */
-            if (!BN_copy(points[i]->Z, tmp_Z))
+            if (BN_copy(points[i]->Z, tmp_Z) == NULL)
                 goto err;
         }
     }
 
     if (!BN_is_zero(points[0]->Z)) {
         /* Replace points[0]->Z by its inverse. */
-        if (!BN_copy(points[0]->Z, tmp))
+        if (BN_copy(points[0]->Z, tmp) == NULL)
             goto err;
     }
 

--- a/crypto/ffc/ffc_params_generate.c
+++ b/crypto/ffc/ffc_params_generate.c
@@ -259,7 +259,7 @@ static int generate_p(BN_CTX *ctx, const EVP_MD *evpmd, int max_counter, int n,
          * X = W + 2^(L-1) where W < 2^(L-1)
          */
         if (!BN_mask_bits(W, L - 1)
-            || !BN_copy(X, W)
+            || BN_copy(X, W) == NULL
             || !BN_add(X, X, test)
             /*
              * A.1.1.2 Step (11.4) AND

--- a/crypto/rsa/rsa_sp800_56b_check.c
+++ b/crypto/rsa/rsa_sp800_56b_check.c
@@ -104,7 +104,7 @@ int ossl_rsa_check_prime_factor_range(const BIGNUM *p, int nbits, BN_CTX *ctx)
         goto err;
 
     /* set low = (√2)(2^(nbits/2 - 1) */
-    if (!BN_copy(low, &ossl_bn_inv_sqrt_2))
+    if (BN_copy(low, &ossl_bn_inv_sqrt_2) == NULL)
         goto err;
 
     if (shift >= 0) {

--- a/ssl/tls_srp.c
+++ b/ssl/tls_srp.c
@@ -254,7 +254,7 @@ int SSL_set_srp_server_param(SSL *s, const BIGNUM *N, const BIGNUM *g,
 
     if (N != NULL) {
         if (sc->srp_ctx.N != NULL) {
-            if (!BN_copy(sc->srp_ctx.N, N)) {
+            if (BN_copy(sc->srp_ctx.N, N) == NULL) {
                 BN_free(sc->srp_ctx.N);
                 sc->srp_ctx.N = NULL;
             }
@@ -263,7 +263,7 @@ int SSL_set_srp_server_param(SSL *s, const BIGNUM *N, const BIGNUM *g,
     }
     if (g != NULL) {
         if (sc->srp_ctx.g != NULL) {
-            if (!BN_copy(sc->srp_ctx.g, g)) {
+            if (BN_copy(sc->srp_ctx.g, g) == NULL) {
                 BN_free(sc->srp_ctx.g);
                 sc->srp_ctx.g = NULL;
             }
@@ -272,7 +272,7 @@ int SSL_set_srp_server_param(SSL *s, const BIGNUM *N, const BIGNUM *g,
     }
     if (sa != NULL) {
         if (sc->srp_ctx.s != NULL) {
-            if (!BN_copy(sc->srp_ctx.s, sa)) {
+            if (BN_copy(sc->srp_ctx.s, sa) == NULL) {
                 BN_free(sc->srp_ctx.s);
                 sc->srp_ctx.s = NULL;
             }
@@ -281,7 +281,7 @@ int SSL_set_srp_server_param(SSL *s, const BIGNUM *N, const BIGNUM *g,
     }
     if (v != NULL) {
         if (sc->srp_ctx.v != NULL) {
-            if (!BN_copy(sc->srp_ctx.v, v)) {
+            if (BN_copy(sc->srp_ctx.v, v) == NULL) {
                 BN_free(sc->srp_ctx.v);
                 sc->srp_ctx.v = NULL;
             }


### PR DESCRIPTION
Fix BN_copy return value checks to explicitly compare against NULL

`BN_copy()` returns a `BIGNUM *` on success and `NULL` on failure.
Some code paths were using implicit boolean checks such as
`!BN_copy(a, b)`, which is less explicit and may be misleading.

This change updates those checks to use explicit comparisons:
`BN_copy(a, b) == NULL`, improving clarity and aligning with
the documented return semantics.

No functional change is intended.

Fixes #30565
CLA: trivial