### PR TITLE
ISSUE-30564: A potential 24-byte memory leak was found in OpenSSL versions 3.0.x and 3.5.4

### DIFF
--- a/crypto/x509/v3_ist.c
+++ b/crypto/x509/v3_ist.c
@@ -33,6 +33,11 @@ ASN1_SEQUENCE(ISSUER_SIGN_TOOL) = {
 
 IMPLEMENT_ASN1_FUNCTIONS(ISSUER_SIGN_TOOL)
 
+/*
+ * ISSUER_SIGN_TOOL_new() allocates empty ASN.1 UTF8String objects for each field.
+ * Populate them with ASN1_STRING_set() only; do not replace the pointers with
+ * ASN1_UTF8STRING_new(), or the original allocations are leaked.
+ */
 static ISSUER_SIGN_TOOL *v2i_issuer_sign_tool(X509V3_EXT_METHOD *method, X509V3_CTX *ctx,
     STACK_OF(CONF_VALUE) *nval)
 {

--- a/doc/man5/x509v3_config.pod
+++ b/doc/man5/x509v3_config.pod
@@ -325,6 +325,25 @@ Example:
 
  issuerAltName = issuer:copy
 
+=head2 Signing Tool of Issuer (issuerSignTool)
+
+This multi-valued extension (OID 1.2.643.100.112) is used with qualified
+certificates in the Russian Federation.  Each entry is a field name and value
+pair.  The supported names are B<signTool>, B<cATool>, B<signToolCert>, and
+B<cAToolCert>; values are UTF-8 strings.
+
+Short form:
+
+ issuerSignTool = signTool:my signing tool,cATool:my CA tool
+
+If a value contains a comma, use the long form with a separate section:
+
+ issuerSignTool = @ist
+
+ [ist]
+ signTool = my signing tool
+ cATool = my CA tool
+
 =head2 Authority Info Access
 
 This extension gives details about how to retrieve information that

--- a/test/issuer-sign-tool-x509.cnf
+++ b/test/issuer-sign-tool-x509.cnf
@@ -1,0 +1,7 @@
+# Config for regression test: issuerSignTool extension (GH openssl/openssl#30564).
+[ext]
+issuerSignTool = @issuer_sign_tool_sect
+
+[issuer_sign_tool_sect]
+signTool = OpenSSL regression test
+cATool = OpenSSL regression CA tool

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 2015-2025 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2015-2026 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -17,7 +17,7 @@ use File::Compare qw/compare_text/;
 
 setup("test_x509");
 
-plan tests => 151;
+plan tests => 153;
 
 # Prevent MSys2 filename munging for arguments that look like file paths but
 # aren't
@@ -543,10 +543,28 @@ ok(get_issuer($a2_cert) =~ /CN=ca.example.com/);
 my $in_csr = srctop_file('test', 'certs', 'x509-check.csr');
 my $in_key = srctop_file('test', 'certs', 'x509-check-key.pem');
 my $invextfile = srctop_file('test', 'invalid-x509.cnf');
-# Test that invalid extensions settings fail
+# Test that invalid extensions settings fail (capture stderr: diagnostics are
+# expected and would otherwise clutter the log next to the issuerSignTool tests)
 ok(!run(app(["openssl", "x509", "-req", "-in", $in_csr, "-signkey", $in_key,
             "-out", "/dev/null", "-days", "3650" , "-extensions", "ext",
-            "-extfile", $invextfile])));
+            "-extfile", $invextfile],
+            stderr => result_file("invalid-x509-ext.stderr"))));
+
+# Regression for https://github.com/openssl/openssl/issues/30564 (issuerSignTool v2i leak)
+my $ist_ext_cnf = srctop_file('test', 'issuer-sign-tool-x509.cnf');
+my $ist_out_cert = result_file("issuer-sign-tool.pem");
+ok(run(app(["openssl", "x509", "-req", "-in", $in_csr, "-signkey", $in_key,
+            "-out", $ist_out_cert, "-days", "365", "-extensions", "ext",
+            "-extfile", $ist_ext_cnf])),
+   "issuerSignTool extension: sign CSR with valid extension config");
+my $ist_text_ok;
+my @ist_lines = run(app(["openssl", "x509", "-text", "-noout", "-in", $ist_out_cert]),
+                    capture => 1, statusvar => \$ist_text_ok);
+my $ist_text = join('', @ist_lines);
+ok($ist_text_ok
+   && $ist_text =~ /Signing Tool of Issuer/
+   && $ist_text =~ /OpenSSL regression test/,
+   "issuerSignTool extension present in certificate text output");
 
 # Tests for issue #16080 (fixed in 1.1.1o)
 my $b_key = "b-key.pem";


### PR DESCRIPTION
*PR [openssl/openssl#30579](https://github.com/openssl/openssl/pull/30579), branch `ISSUE-30564/memory-leak`. This file is the description aligned with the current branch (including reviewer follow-up). The text currently on GitHub may differ until the description is updated there.*

## Problem

[openssl/openssl#30564](https://github.com/openssl/openssl/issues/30564) reported a small heap leak (on the order of tens of bytes per run, e.g. ~24 bytes under AddressSanitizer) when building the **Issuer Sign Tool** X.509v3 extension from configuration, for example via:

```bash
openssl x509 -req -in … -signkey … -out /dev/null … -extensions ext -extfile …
```

**Root cause:** `v2i_issuer_sign_tool()` in `crypto/x509/v3_ist.c` calls `ISSUER_SIGN_TOOL_new()`, which allocates the `ISSUER_SIGN_TOOL` structure **including** empty `ASN1_UTF8STRING` objects for `signTool`, `cATool`, `signToolCert`, and `cAToolCert`. Older code also assigned `ist->signTool = ASN1_UTF8STRING_new()` (and similarly for the other fields), **replacing** those pointers. The previously allocated strings were then unreachable and never freed — a classic leak.

The same leak pattern could also surface on error paths after the replacement (e.g. invalid config still allocating a new string before failing a later check).

**Related upstream fix:** The behavioral fix — stop allocating replacement strings and only call `ASN1_STRING_set()` on the objects returned by `ISSUER_SIGN_TOOL_new()` — was merged in [openssl/openssl#30003](https://github.com/openssl/openssl/pull/30003) (*“Fix a legitimate leak in v2i_issuer_sign_tool”*).

## Implementation in this change

This pull request does **not** reintroduce different runtime behavior where the correct pattern is already present; it reinforces and documents it:

1. **Code comment** in `crypto/x509/v3_ist.c` immediately above `v2i_issuer_sign_tool()` explaining that `ISSUER_SIGN_TOOL_new()` already allocates the UTF-8 string fields and that implementers must **not** replace those pointers with `ASN1_UTF8STRING_new()`, or the original allocations leak.
2. **Logic (unchanged, for clarity):** For each recognized config field (`signTool`, `cATool`, `signToolCert`, `cAToolCert`), validate non-NULL structure members and config value, then `ASN1_STRING_set()` into the existing `ASN1_STRING`. On failure, `ISSUER_SIGN_TOOL_free(ist)` releases the whole structure consistently.

## Review follow-up

- **`test/recipes/25-test_x509.t`:** The existing negative test uses `invalid-x509.cnf`, which intentionally fails `issuerSignTool` parsing; OpenSSL correctly prints errors to stderr. Those messages appeared between TAP `ok` lines and looked like failures in the new issuerSignTool regression tests. The invalid-extension `openssl x509` invocation now redirects **stderr** to `result_file("invalid-x509-ext.stderr")` so the harness log stays clean (expected diagnostics remain in that file if needed).
- **`CHANGES.md`:** The release note no longer states that *this* change “fixes” the leak (the runtime fix is #30003). It describes **documentation** of the correct usage, **`x509v3_config(5)`** coverage, and **regression tests** that keep the successful config path exercised under CI/sanitizers, with brief historical context on the leak pattern.

## Tests added or amended

| Item | Description |
|------|-------------|
| `test/issuer-sign-tool-x509.cnf` | New config: `[ext]` references `@issuer_sign_tool_sect`; section sets `signTool` and `cATool` to fixed regression strings. |
| `test/recipes/25-test_x509.t` | Plan count increased by 2. After the existing invalid-extension test, two new checks: (1) sign `test/certs/x509-check.csr` with the new config and write a PEM cert; (2) run `openssl x509 -text -noout` with capture and assert output contains `Signing Tool of Issuer` and the expected regression string. **Also:** stderr capture on the invalid-extension test (see Review follow-up). |

These tests exercise the **successful** `v2i_issuer_sign_tool` path (full extension encoding), which is what leak sanitizers need to validate the fix under CI or local ASan builds.

## Documentation added or amended

| File | Change |
|------|--------|
| `doc/man5/x509v3_config.pod` | New subsection **Signing Tool of Issuer (issuerSignTool)** — OID, field names, short form (`name:value,...`) and long form (`@section`) examples. |
| `CHANGES.md` | Entry under *Changes between 4.0 and 4.1* describing documentation, correct `ASN1_STRING_set`-only usage, `x509v3_config(5)` and regression test coverage (wording aligned with #30003 as the behavioral leak fix). Credited **John Claus**. |

## Checklist (for reviewers)

- [ ] `make test TESTS=test_x509` (or full `make test`) passes in your environment.
- [ ] `podchecker doc/man5/x509v3_config.pod` (and project doc checks as appropriate).

Fixes: https://github.com/openssl/openssl/issues/30564  
See also: https://github.com/openssl/openssl/pull/30003
