### PR TITLE
Update S/MIME tool documentation

### DIFF
--- a/doc/man1/openssl-smime.pod.in
+++ b/doc/man1/openssl-smime.pod.in
@@ -54,8 +54,9 @@ I<recipcert> ...
 
 =head1 DESCRIPTION
 
-This command handles S/MIME mail. It can encrypt, decrypt, sign
-and verify S/MIME messages.
+This command handles S/MIME according to RFC 2311 (1998) with no CMS support. 
+It can encrypt, decrypt, sign and verify S/MIME 2.0 messages. For newer messages
+use the OpenSSL CMS tool.
 
 =head1 OPTIONS
 


### PR DESCRIPTION
This PR aims to update the S/MIME tool's description to accurately convey that it is very old and does not properly handle modern S/MIME nor CMS it relies on.

This is such a common pitfall that now even LLMs suggest people use the `smime` tool, which they really shouldn't.

Fixes https://github.com/openssl/openssl/issues/29928

##### Checklist
- [X] documentation is added or updated
