### PR TITLE
Document X509V3_EXT_print API const change in manual page

### DIFF
--- a/doc/man3/X509V3_EXT_print.pod
+++ b/doc/man3/X509V3_EXT_print.pod
@@ -8,7 +8,7 @@ X509V3_EXT_print, X509V3_EXT_print_fp - pretty print X509 certificate extensions
 
  #include <openssl/x509v3.h>
 
- int X509V3_EXT_print(BIO *out, X509_EXTENSION *ext, unsigned long flag, int indent);
+ int X509V3_EXT_print(BIO *out, const X509_EXTENSION *ext, unsigned long flag, int indent);
  int X509V3_EXT_print_fp(FILE *out, X509_EXTENSION *ext, int flag, int indent);
 
 =head1 DESCRIPTION


### PR DESCRIPTION
Commit e75bd84ffc7 made the ext argument of 509V3_EXT_print const but did not update the man page to match the implementation.

This implements only the missing man page change for OpenSSL 4.0 as requested in #30572 

##### Checklist
- [x] documentation is added or updated
