### PR TITLE
Set socket to invalid state after close

### DIFF
--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -137,8 +137,7 @@ int init_client(int *sock, const char *host, const char *port,
         if (bi != NULL) {
             if (!BIO_bind(*sock, BIO_ADDRINFO_address(bi),
                     BIO_SOCK_REUSEADDR)) {
-                BIO_closesocket(*sock);
-                *sock = INVALID_SOCKET;
+                BIO_closesocket(sock);
                 continue;
             }
         }
@@ -154,8 +153,7 @@ int init_client(int *sock, const char *host, const char *port,
             BIO *tmpbio = BIO_new_dgram_sctp(*sock, BIO_NOCLOSE);
 
             if (tmpbio == NULL) {
-                BIO_closesocket(*sock);
-                *sock = INVALID_SOCKET;
+                BIO_closesocket(sock);
                 continue;
             }
             BIO_free(tmpbio);
@@ -168,8 +166,7 @@ int init_client(int *sock, const char *host, const char *port,
         }
 
         if (doconn && !BIO_connect(*sock, BIO_ADDRINFO_address(ai), options)) {
-            BIO_closesocket(*sock);
-            *sock = INVALID_SOCKET;
+            BIO_closesocket(sock);
             continue;
         }
 
@@ -177,8 +174,7 @@ int init_client(int *sock, const char *host, const char *port,
         if (tfo || !doconn) {
             if (ba_ret == NULL) {
                 BIO_puts(bio_err, "Internal error\n");
-                BIO_closesocket(*sock);
-                *sock = INVALID_SOCKET;
+                BIO_closesocket(sock);
                 goto out;
             }
 
@@ -364,8 +360,7 @@ int do_server(int *accept_sock, const char *host, const char *port,
         || !BIO_listen(asock, sock_address, sock_options)) {
         BIO_ADDRINFO_free(res);
         ERR_print_errors(bio_err);
-        if (asock != INVALID_SOCKET)
-            BIO_closesocket(asock);
+        BIO_closesocket(&asock);
         goto end;
     }
 
@@ -381,7 +376,7 @@ int do_server(int *accept_sock, const char *host, const char *port,
 
         if (tmpbio == NULL) {
             BIO_ADDRINFO_free(res);
-            BIO_closesocket(asock);
+            BIO_closesocket(&asock);
             ERR_print_errors(bio_err);
             goto end;
         }
@@ -395,7 +390,7 @@ int do_server(int *accept_sock, const char *host, const char *port,
     res = NULL;
 
     if (!report_server_accept(bio_s_out, asock, sock_port == 0, 0)) {
-        BIO_closesocket(asock);
+        BIO_closesocket(&asock);
         ERR_print_errors(bio_err);
         goto end;
     }
@@ -411,7 +406,7 @@ int do_server(int *accept_sock, const char *host, const char *port,
             BIO_ADDR_free(ourpeer);
             ourpeer = BIO_ADDR_new();
             if (ourpeer == NULL) {
-                BIO_closesocket(asock);
+                BIO_closesocket(&asock);
                 ERR_print_errors(bio_err);
                 goto end;
             }
@@ -420,7 +415,7 @@ int do_server(int *accept_sock, const char *host, const char *port,
             } while (sock < 0 && BIO_sock_should_retry(sock));
             if (sock < 0) {
                 ERR_print_errors(bio_err);
-                BIO_closesocket(asock);
+                BIO_closesocket(&asock);
                 break;
             }
 
@@ -455,7 +450,7 @@ int do_server(int *accept_sock, const char *host, const char *port,
             } while (select(sock + 1, &readfds, NULL, NULL, &timeout) > 0
                 && readsocket(sock, sink, sizeof(sink)) > 0);
 
-            BIO_closesocket(sock);
+            BIO_closesocket(&sock);
         } else {
             if (naccept != -1)
                 naccept--;
@@ -464,8 +459,7 @@ int do_server(int *accept_sock, const char *host, const char *port,
         }
 
         if (i < 0 || naccept == 0) {
-            BIO_closesocket(asock);
-            asock = INVALID_SOCKET;
+            BIO_closesocket(&asock);
             ret = i;
             break;
         }

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2437,7 +2437,7 @@ re_start:
             socket_type, protocol, tfo, !isquic, &peer_addr)
         == 0) {
         BIO_printf(bio_err, "connect:errno=%d\n", get_last_socket_error());
-        BIO_closesocket(sock);
+        BIO_closesocket(&sock);
         goto end;
     }
     BIO_printf(bio_c_out, "CONNECTED(%08X)\n", sock);
@@ -2469,7 +2469,7 @@ re_start:
         if (sbio == NULL || (peer_info.addr = BIO_ADDR_new()) == NULL) {
             BIO_puts(bio_err, "memory allocation failure\n");
             BIO_free(sbio);
-            BIO_closesocket(sock);
+            BIO_closesocket(&sock);
             goto end;
         }
         if (!BIO_sock_info(sock, BIO_SOCK_INFO_ADDRESS, &peer_info)) {
@@ -2477,7 +2477,7 @@ re_start:
                 get_last_socket_error());
             BIO_free(sbio);
             BIO_ADDR_free(peer_info.addr);
-            BIO_closesocket(sock);
+            BIO_closesocket(&sock);
             goto end;
         }
 
@@ -2527,7 +2527,7 @@ re_start:
 
     if (sbio == NULL) {
         BIO_puts(bio_err, "Unable to create BIO\n");
-        BIO_closesocket(sock);
+        BIO_closesocket(&sock);
         goto end;
     }
 
@@ -3174,7 +3174,9 @@ re_start:
                         "drop connection and then reconnect\n");
                     do_ssl_shutdown(con);
                     SSL_set_connect_state(con);
-                    BIO_closesocket(SSL_get_fd(con));
+                    int sock = SSL_get_fd(con);
+                    BIO_closesocket(&sock);
+                    SSL_set_fd(con, sock);
                     goto re_start;
                 }
             }
@@ -3533,7 +3535,9 @@ shut:
     } while (select(sock + 1, &readfds, NULL, NULL, &timeout) > 0
         && BIO_read(sbio, sbuf, BUFSIZZ) > 0);
 
-    BIO_closesocket(SSL_get_fd(con));
+    int sock_tmp = SSL_get_fd(con);
+    BIO_closesocket(&sock_tmp);
+    SSL_set_fd(con, sock_tmp);
 end:
     if (ret > 0)
         ERR_print_errors(bio_err); /* show any new or remaining errors */
@@ -4260,7 +4264,9 @@ static int user_data_execute(struct user_data_st *user_data, int cmd, char *arg)
         BIO_puts(bio_err, "RECONNECTING\n");
         do_ssl_shutdown(user_data->con);
         SSL_set_connect_state(user_data->con);
-        BIO_closesocket(SSL_get_fd(user_data->con));
+        int sock_tmp = SSL_get_fd(user_data->con);
+        BIO_closesocket(&sock_tmp);
+        SSL_set_fd(user_data->con, sock_tmp);
         return USER_DATA_PROCESS_RESTART;
 
     case USER_COMMAND_RENEGOTIATE:

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3506,7 +3506,7 @@ static int sv_body(int s, int stype, int prot, unsigned char *context)
                 if ((i <= 0) || (buf[0] == 'Q')) {
                     BIO_puts(bio_s_out, "DONE\n");
                     (void)BIO_flush(bio_s_out);
-                    BIO_closesocket(s);
+                    BIO_closesocket(&s);
                     close_accept_socket();
                     ret = -11;
                     goto err;
@@ -3515,7 +3515,7 @@ static int sv_body(int s, int stype, int prot, unsigned char *context)
                     BIO_puts(bio_s_out, "DONE\n");
                     (void)BIO_flush(bio_s_out);
                     if (SSL_version(con) != DTLS1_VERSION)
-                        BIO_closesocket(s);
+                        BIO_closesocket(&s);
                     /*
                      * close_accept_socket(); ret= -11;
                      */
@@ -3720,7 +3720,7 @@ static void close_accept_socket(void)
 {
     BIO_puts(bio_err, "shutdown accept socket\n");
     if (accept_socket >= 0) {
-        BIO_closesocket(accept_socket);
+        BIO_closesocket(&accept_socket);
     }
 }
 

--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -309,7 +309,9 @@ int s_time_main(int argc, char **argv)
                 bytes_read += i;
         }
         SSL_set_shutdown(scon, SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN);
-        BIO_closesocket(SSL_get_fd(scon));
+        int sock_tmp = SSL_get_fd(scon);
+        BIO_closesocket(&sock_tmp);
+        SSL_set_fd(scon, sock_tmp);
 
         nConn += 1;
         if (SSL_session_reused(scon)) {
@@ -361,7 +363,7 @@ next:
     }
     SSL_set_shutdown(scon, SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN);
     if ((fd = SSL_get_fd(scon)) >= 0)
-        BIO_closesocket(fd);
+        BIO_closesocket(&fd);
 
     nConn = 0;
     totalTime = 0.0;
@@ -389,7 +391,7 @@ next:
         }
         SSL_set_shutdown(scon, SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN);
         if ((fd = SSL_get_fd(scon)) >= 0)
-            BIO_closesocket(fd);
+            BIO_closesocket(&fd);
 
         nConn += 1;
         if (SSL_session_reused(scon)) {

--- a/crypto/bio/bio_sock.c
+++ b/crypto/bio/bio_sock.c
@@ -275,8 +275,7 @@ int BIO_get_accept_socket(char *host, int bind_mode)
 
     if (!BIO_listen(s, BIO_ADDRINFO_address(res),
             bind_mode ? BIO_SOCK_REUSEADDR : 0)) {
-        BIO_closesocket(s);
-        s = INVALID_SOCKET;
+        BIO_closesocket(&s);
     }
 
 err:
@@ -315,8 +314,7 @@ int BIO_accept(int sock, char **ip_port)
         }
 
         if (*ip_port == NULL) {
-            BIO_closesocket(ret);
-            ret = (int)INVALID_SOCKET;
+            BIO_closesocket(&ret);
         } else {
             strcpy(*ip_port, host);
             strcat(*ip_port, ":");

--- a/crypto/bio/bio_sock2.c
+++ b/crypto/bio/bio_sock2.c
@@ -446,10 +446,12 @@ int BIO_accept_ex(int accept_sock, BIO_ADDR *addr_, int options)
  * BIO_closesocket - Close a socket
  * @sock: the socket to close
  */
-int BIO_closesocket(int sock)
+int BIO_closesocket(int* sock)
 {
-    if (sock < 0 || closesocket(sock) < 0)
+    if (*sock < 0 || closesocket(*sock) < 0)
         return 0;
+
+    sock = INVALID_SOCKET;
     return 1;
 }
 #endif

--- a/crypto/bio/bss_acpt.c
+++ b/crypto/bio/bss_acpt.c
@@ -246,8 +246,7 @@ static int acpt_state(BIO *b, BIO_ACCEPT *c)
             if (!BIO_listen(c->accept_sock,
                     BIO_ADDRINFO_address(c->addr_iter),
                     c->bind_mode)) {
-                BIO_closesocket(c->accept_sock);
-                c->accept_sock = (int)INVALID_SOCKET;
+                BIO_closesocket(&c->accept_sock);
                 b->num = (int)INVALID_SOCKET;
                 goto exit_loop;
             }
@@ -259,8 +258,7 @@ static int acpt_state(BIO *b, BIO_ACCEPT *c)
                 info.addr = &c->cache_accepting_addr;
                 if (!BIO_sock_info(c->accept_sock, BIO_SOCK_INFO_ADDRESS,
                         &info)) {
-                    BIO_closesocket(c->accept_sock);
-                    c->accept_sock = (int)INVALID_SOCKET;
+                    BIO_closesocket(&c->accept_sock);
                     b->num = (int)INVALID_SOCKET;
                     goto exit_loop;
                 }
@@ -357,7 +355,7 @@ exit_loop:
     if (bio != NULL)
         BIO_free(bio);
     else if (s >= 0)
-        BIO_closesocket(s);
+        BIO_closesocket(&s);
 end:
     return ret;
 }

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -206,7 +206,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
                     /*
                      * if there are more addresses to try, do that first
                      */
-                    BIO_closesocket(b->num);
+                    BIO_closesocket(&b->num);
                     c->state = BIO_CONN_S_CREATE_SOCKET;
                     ERR_pop_to_mark();
                     break;
@@ -238,7 +238,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
                     /*
                      * if there are more addresses to try, do that first
                      */
-                    BIO_closesocket(b->num);
+                    BIO_closesocket(&b->num);
                     c->state = BIO_CONN_S_CREATE_SOCKET;
                     break;
                 }
@@ -329,8 +329,7 @@ static void conn_close_socket(BIO *bio)
         /* Only do a shutdown if things were established */
         if (c->state == BIO_CONN_S_OK)
             shutdown(bio->num, 2);
-        BIO_closesocket(bio->num);
-        bio->num = (int)INVALID_SOCKET;
+        BIO_closesocket(&bio->num);
     }
 }
 

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -301,7 +301,7 @@ static int dgram_clear(BIO *a)
         return 0;
     if (a->shutdown) {
         if (a->init) {
-            BIO_closesocket(a->num);
+            BIO_closesocket(&a->num);
         }
         a->init = 0;
         a->flags = 0;

--- a/crypto/bio/bss_sock.c
+++ b/crypto/bio/bss_sock.c
@@ -93,7 +93,7 @@ static int sock_free(BIO *a)
         return 0;
     if (a->shutdown) {
         if (a->init) {
-            BIO_closesocket(a->num);
+            BIO_closesocket(&a->num);
         }
         a->init = 0;
         a->flags = 0;
@@ -175,7 +175,7 @@ static long sock_ctrl(BIO *b, int cmd, long num, void *ptr)
         /* minimal sock_free() */
         if (b->shutdown) {
             if (b->init)
-                BIO_closesocket(b->num);
+                BIO_closesocket(&b->num);
             b->flags = 0;
         }
         b->num = *((int *)ptr);

--- a/demos/guide/quic-client-block.c
+++ b/demos/guide/quic-client-block.c
@@ -59,15 +59,13 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
 
         /* Connect the socket to the server's address */
         if (!BIO_connect(sock, BIO_ADDRINFO_address(ai), 0)) {
-            BIO_closesocket(sock);
-            sock = -1;
+            BIO_closesocket(&sock);
             continue;
         }
 
         /* Set to nonblocking mode */
         if (!BIO_socket_nbio(sock, 1)) {
-            BIO_closesocket(sock);
-            sock = -1;
+            BIO_closesocket(&sock);
             continue;
         }
 
@@ -77,7 +75,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
     if (sock != -1) {
         *peer_addr = BIO_ADDR_dup(BIO_ADDRINFO_address(ai));
         if (*peer_addr == NULL) {
-            BIO_closesocket(sock);
+            BIO_closesocket(&sock);
             return NULL;
         }
     }
@@ -92,7 +90,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
     /* Create a BIO to wrap the socket */
     bio = BIO_new(BIO_s_datagram());
     if (bio == NULL) {
-        BIO_closesocket(sock);
+        BIO_closesocket(&sock);
         return NULL;
     }
 

--- a/demos/guide/quic-client-non-block.c
+++ b/demos/guide/quic-client-non-block.c
@@ -60,15 +60,13 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
 
         /* Connect the socket to the server's address */
         if (!BIO_connect(sock, BIO_ADDRINFO_address(ai), 0)) {
-            BIO_closesocket(sock);
-            sock = -1;
+            BIO_closesocket(&sock);
             continue;
         }
 
         /* Set to nonblocking mode */
         if (!BIO_socket_nbio(sock, 1)) {
-            BIO_closesocket(sock);
-            sock = -1;
+            BIO_closesocket(&sock);
             continue;
         }
 
@@ -78,7 +76,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
     if (sock != -1) {
         *peer_addr = BIO_ADDR_dup(BIO_ADDRINFO_address(ai));
         if (*peer_addr == NULL) {
-            BIO_closesocket(sock);
+            BIO_closesocket(&sock);
             return NULL;
         }
     }
@@ -93,7 +91,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
     /* Create a BIO to wrap the socket */
     bio = BIO_new(BIO_s_datagram());
     if (bio == NULL) {
-        BIO_closesocket(sock);
+        BIO_closesocket(&sock);
         return NULL;
     }
 

--- a/demos/guide/quic-multi-stream.c
+++ b/demos/guide/quic-multi-stream.c
@@ -59,15 +59,13 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
 
         /* Connect the socket to the server's address */
         if (!BIO_connect(sock, BIO_ADDRINFO_address(ai), 0)) {
-            BIO_closesocket(sock);
-            sock = -1;
+            BIO_closesocket(&sock);
             continue;
         }
 
         /* Set to nonblocking mode */
         if (!BIO_socket_nbio(sock, 1)) {
-            BIO_closesocket(sock);
-            sock = -1;
+            BIO_closesocket(&sock);
             continue;
         }
 
@@ -77,7 +75,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
     if (sock != -1) {
         *peer_addr = BIO_ADDR_dup(BIO_ADDRINFO_address(ai));
         if (*peer_addr == NULL) {
-            BIO_closesocket(sock);
+            BIO_closesocket(&sock);
             return NULL;
         }
     }
@@ -92,7 +90,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
     /* Create a BIO to wrap the socket */
     bio = BIO_new(BIO_s_datagram());
     if (bio == NULL) {
-        BIO_closesocket(sock);
+        BIO_closesocket(&sock);
         return NULL;
     }
 

--- a/demos/guide/quic-server-block.c
+++ b/demos/guide/quic-server-block.c
@@ -190,14 +190,14 @@ static int create_socket(uint16_t port)
     /* Bind to the new UDP socket on localhost */
     if (bind(fd, (const struct sockaddr *)&sa, sizeof(sa)) < 0) {
         fprintf(stderr, "cannot bind to %u\n", port);
-        BIO_closesocket(fd);
+        BIO_closesocket(&fd);
         goto err;
     }
 
     return fd;
 
 err:
-    BIO_closesocket(fd);
+    BIO_closesocket(&fd);
     return -1;
 }
 
@@ -316,14 +316,14 @@ int main(int argc, char *argv[])
     /* QUIC server connection acceptance loop. */
     if (!run_quic_server(ctx, fd)) {
         SSL_CTX_free(ctx);
-        BIO_closesocket(fd);
+        BIO_closesocket(&fd);
         ERR_print_errors_fp(stderr);
         errx(res, "Error in QUIC server loop");
     }
 
     /* Free resources. */
     SSL_CTX_free(ctx);
-    BIO_closesocket(fd);
+    BIO_closesocket(&fd);
     res = EXIT_SUCCESS;
     return res;
 }

--- a/demos/guide/quic-server-non-block.c
+++ b/demos/guide/quic-server-non-block.c
@@ -190,14 +190,14 @@ static int create_socket(uint16_t port)
     /* Bind to the new UDP socket on localhost */
     if (bind(fd, (const struct sockaddr *)&sa, sizeof(sa)) < 0) {
         fprintf(stderr, "cannot bind to %u\n", port);
-        BIO_closesocket(fd);
+        BIO_closesocket(&fd);
         return -1;
     }
 
     /* Set port to nonblocking mode */
     if (BIO_socket_nbio(fd, 1) <= 0) {
         fprintf(stderr, "Unable to set port to nonblocking mode");
-        BIO_closesocket(fd);
+        BIO_closesocket(&fd);
         return -1;
     }
 
@@ -501,14 +501,14 @@ int main(int argc, char *argv[])
     /* QUIC server connection acceptance loop. */
     if (run_quic_server(ctx, fd) < 0) {
         SSL_CTX_free(ctx);
-        BIO_closesocket(fd);
+        BIO_closesocket(&fd);
         ERR_print_errors_fp(stderr);
         errx(res, "Error in QUIC server loop");
     }
 
     /* Free resources. */
     SSL_CTX_free(ctx);
-    BIO_closesocket(fd);
+    BIO_closesocket(&fd);
     res = EXIT_SUCCESS;
     return res;
 }

--- a/demos/guide/tls-client-block.c
+++ b/demos/guide/tls-client-block.c
@@ -58,8 +58,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port, int family
 
         /* Connect the socket to the server's address */
         if (!BIO_connect(sock, BIO_ADDRINFO_address(ai), BIO_SOCK_NODELAY)) {
-            BIO_closesocket(sock);
-            sock = -1;
+            BIO_closesocket(&sock);
             continue;
         }
 
@@ -77,7 +76,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port, int family
     /* Create a BIO to wrap the socket */
     bio = BIO_new(BIO_s_socket());
     if (bio == NULL) {
-        BIO_closesocket(sock);
+        BIO_closesocket(&sock);
         return NULL;
     }
 

--- a/demos/guide/tls-client-non-block.c
+++ b/demos/guide/tls-client-non-block.c
@@ -59,8 +59,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port, int family
 
         /* Connect the socket to the server's address */
         if (!BIO_connect(sock, BIO_ADDRINFO_address(ai), BIO_SOCK_NODELAY)) {
-            BIO_closesocket(sock);
-            sock = -1;
+            BIO_closesocket(&sock);
             continue;
         }
 
@@ -84,7 +83,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port, int family
     /* Create a BIO to wrap the socket */
     bio = BIO_new(BIO_s_socket());
     if (bio == NULL) {
-        BIO_closesocket(sock);
+        BIO_closesocket(&sock);
         return NULL;
     }
 

--- a/demos/http3/ossl-nghttp3-demo-server.c
+++ b/demos/http3/ossl-nghttp3-demo-server.c
@@ -956,7 +956,7 @@ static int create_socket(uint16_t port)
 
 err:
     if (fd >= 0)
-        BIO_closesocket(fd);
+        BIO_closesocket(&fd);
 
     return -1;
 }
@@ -1377,7 +1377,7 @@ err:
     SSL_CTX_free(ctx);
 
     if (fd != -1)
-        BIO_closesocket(fd);
+        BIO_closesocket(&fd);
 
     return rc;
 }

--- a/demos/http3/ossl-nghttp3.c
+++ b/demos/http3/ossl-nghttp3.c
@@ -390,7 +390,7 @@ create_socket_bio(const BIO_ADDRINFO *bai)
 
     return bio;
 err:
-    BIO_closesocket(sock);
+    BIO_closesocket(&sock);
 
     return NULL;
 }

--- a/demos/quic/poll-server/quic-server-ssl-poll-http.c
+++ b/demos/quic/poll-server/quic-server-ssl-poll-http.c
@@ -1898,14 +1898,14 @@ create_socket(uint16_t port)
     /* Bind to the new UDP socket on localhost */
     if (bind(fd, (const struct sockaddr *)&sa, sizeof(sa)) < 0) {
         DPRINTF(stderr, "cannot bind to %u\n", port);
-        BIO_closesocket(fd);
+        BIO_closesocket(&fd);
         return -1;
     }
 
     /* Set port to nonblocking mode */
     if (BIO_socket_nbio(fd, 1) <= 0) {
         DPRINTF(stderr, "Unable to set port to nonblocking mode");
-        BIO_closesocket(fd);
+        BIO_closesocket(&fd);
         return -1;
     }
 
@@ -1958,7 +1958,7 @@ int main(int argc, char *argv[])
     /* QUIC server connection acceptance loop. */
     if (run_quic_server(ctx, pm, fd) < 0) {
         SSL_CTX_free(ctx);
-        BIO_closesocket(fd);
+        BIO_closesocket(&fd);
         ERR_print_errors_fp(stderr);
         errx(res, "Error in QUIC server loop");
     }
@@ -1966,7 +1966,7 @@ int main(int argc, char *argv[])
     destroy_poll_manager(pm);
     /* Free resources. */
     SSL_CTX_free(ctx);
-    BIO_closesocket(fd);
+    BIO_closesocket(&fd);
     res = EXIT_SUCCESS;
     return res;
 }

--- a/demos/quic/server/server.c
+++ b/demos/quic/server/server.c
@@ -99,7 +99,7 @@ static int create_socket(uint16_t port)
 
 err:
     if (fd >= 0)
-        BIO_closesocket(fd);
+        BIO_closesocket(&fd);
 
     return -1;
 }
@@ -237,7 +237,7 @@ err:
     SSL_CTX_free(ctx);
 
     if (fd != -1)
-        BIO_closesocket(fd);
+        BIO_closesocket(&fd);
 
     return rc;
 }

--- a/doc/man3/BIO_connect.pod
+++ b/doc/man3/BIO_connect.pod
@@ -14,7 +14,7 @@ socket communication setup routines
  int BIO_connect(int sock, const BIO_ADDR *addr, int options);
  int BIO_listen(int sock, const BIO_ADDR *addr, int options);
  int BIO_accept_ex(int accept_sock, BIO_ADDR *peer, int options);
- int BIO_closesocket(int sock);
+ int BIO_closesocket(int *sock);
 
 =head1 DESCRIPTION
 

--- a/doc/man7/ossl-guide-quic-client-block.pod
+++ b/doc/man7/ossl-guide-quic-client-block.pod
@@ -116,15 +116,13 @@ for TCP).
 
         /* Connect the socket to the server's address */
         if (!BIO_connect(sock, BIO_ADDRINFO_address(ai), 0)) {
-            BIO_closesocket(sock);
-            sock = -1;
+            BIO_closesocket(&sock);
             continue;
         }
 
         /* Set to nonblocking mode */
         if (!BIO_socket_nbio(sock, 1)) {
-            BIO_closesocket(sock);
-            sock = -1;
+            BIO_closesocket(&sock);
             continue;
         }
 
@@ -134,7 +132,7 @@ for TCP).
     if (sock != -1) {
         *peer_addr = BIO_ADDR_dup(BIO_ADDRINFO_address(ai));
         if (*peer_addr == NULL) {
-            BIO_closesocket(sock);
+            BIO_closesocket(&sock);
             return NULL;
         }
     }
@@ -168,7 +166,7 @@ associate it with a BIO object:
     /* Create a BIO to wrap the socket */
     bio = BIO_new(BIO_s_datagram());
     if (bio == NULL) {
-        BIO_closesocket(sock);
+        BIO_closesocket(&sock);
         return NULL;
     }
 

--- a/doc/man7/ossl-guide-quic-server-block.pod
+++ b/doc/man7/ossl-guide-quic-server-block.pod
@@ -167,7 +167,7 @@ UDP socket and bind to it on localhost.
     /* Bind to the new UDP socket on localhost */
     if (bind(fd, (const struct sockaddr *)&sa, sizeof(sa)) < 0) {
         fprintf(stderr, "cannot bind to %u\n", port);
-        BIO_closesocket(fd);
+        BIO_closesocket(&fd);
         goto err;
     }
 
@@ -258,7 +258,7 @@ be ready to exit, it would deallocate the constructed B<SSL>.
 And in the main function, it would deallocate the constructed B<SSL_CTX>.
 
     SSL_CTX_free(ctx);
-    BIO_closesocket(fd);
+    BIO_closesocket(&fd);
     res = EXIT_SUCCESS;
     return res;
 

--- a/doc/man7/ossl-guide-quic-server-non-block.pod
+++ b/doc/man7/ossl-guide-quic-server-non-block.pod
@@ -177,14 +177,14 @@ UDP socket and bind to it on localhost.
     /* Bind to the new UDP socket on localhost */
     if (bind(fd, (const struct sockaddr *)&sa, sizeof(sa)) < 0) {
         fprintf(stderr, "cannot bind to %u\n", port);
-        BIO_closesocket(fd);
+        BIO_closesocket(&fd);
         return -1;
     }
 
     /* Set port to nonblocking mode */
     if (BIO_socket_nbio(fd, 1) <= 0) {
         fprintf(stderr, "Unable to set port to nonblocking mode");
-        BIO_closesocket(fd);
+        BIO_closesocket(&fd);
         return -1;
     }
 
@@ -351,7 +351,7 @@ be ready to exit, it would deallocate the constructed B<SSL>.
 And in the main function, it would deallocate the constructed B<SSL_CTX>.
 
     SSL_CTX_free(ctx);
-    BIO_closesocket(fd);
+    BIO_closesocket(&fd);
 
 =head1 SEE ALSO
 

--- a/doc/man7/ossl-guide-tls-client-block.pod
+++ b/doc/man7/ossl-guide-tls-client-block.pod
@@ -196,8 +196,7 @@ integrate into the OpenSSL error system to log error data, e.g.
 
         /* Connect the socket to the server's address */
         if (!BIO_connect(sock, BIO_ADDRINFO_address(ai), BIO_SOCK_NODELAY)) {
-            BIO_closesocket(sock);
-            sock = -1;
+            BIO_closesocket(&sock);
             continue;
         }
 
@@ -227,7 +226,7 @@ BIO object:
     /* Create a BIO to wrap the socket */
     bio = BIO_new(BIO_s_socket());
     if (bio == NULL) {
-        BIO_closesocket(sock);
+        BIO_closesocket(&sock);
         return NULL;
     }
 

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -903,7 +903,7 @@ int BIO_connect(int sock, const BIO_ADDR *addr, int options);
 int BIO_bind(int sock, const BIO_ADDR *addr, int options);
 int BIO_listen(int sock, const BIO_ADDR *addr, int options);
 int BIO_accept_ex(int accept_sock, BIO_ADDR *addr, int options);
-int BIO_closesocket(int sock);
+int BIO_closesocket(int *sock);
 
 BIO *BIO_new_socket(int sock, int close_flag);
 BIO *BIO_new_connect(const char *host_port);

--- a/ssl/rio/rio_notifier.c
+++ b/ssl/rio/rio_notifier.c
@@ -136,7 +136,7 @@ static int create_socket(int domain, int socktype, int protocol)
     if (setsockopt(fd, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, (void *)&on, sizeof(on)) < 0) {
         ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
             "calling setsockopt()");
-        BIO_closesocket(fd);
+        BIO_closesocket(&fd);
         return INVALID_SOCKET;
     }
 
@@ -159,7 +159,7 @@ static int create_socket(int domain, int socktype, int protocol)
     if (!set_cloexec(fd)) {
         ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
             "calling set_cloexec()");
-        BIO_closesocket(fd);
+        BIO_closesocket(&fd);
         return INVALID_SOCKET;
     }
 #endif
@@ -271,7 +271,7 @@ int ossl_rio_notifier_init(RIO_NOTIFIER *nfy)
     }
 
     /* Close the listener, which we don't need anymore. */
-    BIO_closesocket(lfd);
+    BIO_closesocket(&lfd);
     lfd = -1;
 
     /*
@@ -302,12 +302,9 @@ int ossl_rio_notifier_init(RIO_NOTIFIER *nfy)
     return 1;
 
 err:
-    if (lfd != INVALID_SOCKET)
-        BIO_closesocket(lfd);
-    if (wfd != INVALID_SOCKET)
-        BIO_closesocket(wfd);
-    if (rfd != INVALID_SOCKET)
-        BIO_closesocket(rfd);
+    BIO_closesocket(&lfd);
+    BIO_closesocket(&wfd);
+    BIO_closesocket(&rfd);
     return 0;
 }
 
@@ -359,8 +356,8 @@ int ossl_rio_notifier_init(RIO_NOTIFIER *nfy)
     return 1;
 
 err:
-    BIO_closesocket(fds[1]);
-    BIO_closesocket(fds[0]);
+    BIO_closesocket(&fds[1]);
+    BIO_closesocket(&fds[0]);
     return 0;
 }
 
@@ -371,8 +368,8 @@ void ossl_rio_notifier_cleanup(RIO_NOTIFIER *nfy)
     if (nfy->rfd < 0)
         return;
 
-    BIO_closesocket(nfy->wfd);
-    BIO_closesocket(nfy->rfd);
+    BIO_closesocket(&nfy->wfd);
+    BIO_closesocket(&nfy->rfd);
     nfy->rfd = nfy->wfd = -1;
 #if defined(OPENSSL_SYS_WINDOWS)
     wsa_done();

--- a/test/bio_dgram_test.c
+++ b/test/bio_dgram_test.c
@@ -416,10 +416,8 @@ static int test_bio_dgram_impl(int af, int use_local)
 err:
     BIO_free(b1);
     BIO_free(b2);
-    if (fd1 >= 0)
-        BIO_closesocket(fd1);
-    if (fd2 >= 0)
-        BIO_closesocket(fd2);
+    BIO_closesocket(&fd1);
+    BIO_closesocket(&fd2);
     BIO_ADDR_free(addr1);
     BIO_ADDR_free(addr2);
     BIO_ADDR_free(addr3);

--- a/test/bio_tfo_test.c
+++ b/test/bio_tfo_test.c
@@ -404,9 +404,9 @@ err:
     if (ai != NULL)
         freeaddrinfo(ai);
     BIO_ADDR_free(baddr);
-    BIO_closesocket(cfd);
-    BIO_closesocket(sfd);
-    BIO_closesocket(afd);
+    BIO_closesocket(&cfd);
+    BIO_closesocket(&sfd);
+    BIO_closesocket(&afd);
     return ret;
 }
 #endif

--- a/test/helpers/handshake.c
+++ b/test/helpers/handshake.c
@@ -1462,8 +1462,7 @@ static int create_sctp_socks(int *ssock, int *csock)
         if (!set_sock_as_sctp(lsock)
             || !BIO_listen(lsock, BIO_ADDRINFO_address(ai),
                 BIO_SOCK_REUSEADDR)) {
-            BIO_closesocket(lsock);
-            lsock = INVALID_SOCKET;
+            BIO_closesocket(&lsock);
             continue;
         }
 
@@ -1501,12 +1500,9 @@ static int create_sctp_socks(int *ssock, int *csock)
 
 err:
     BIO_ADDRINFO_free(res);
-    if (consock != INVALID_SOCKET)
-        BIO_closesocket(consock);
-    if (lsock != INVALID_SOCKET)
-        BIO_closesocket(lsock);
-    if (asock != INVALID_SOCKET)
-        BIO_closesocket(asock);
+    BIO_closesocket(&consock);
+    BIO_closesocket(&lsock);
+    BIO_closesocket(&asock);
     return ret;
 }
 #endif

--- a/test/quic-openssl-docker/hq-interop/quic-hq-interop-server.c
+++ b/test/quic-openssl-docker/hq-interop/quic-hq-interop-server.c
@@ -356,7 +356,7 @@ static BIO *create_socket(uint16_t port)
 err:
     BIO_ADDR_free(addr);
     BIO_free(sock);
-    BIO_closesocket(fd);
+    BIO_closesocket(&fd);
     return NULL;
 }
 

--- a/test/quic-openssl-docker/hq-interop/quic-hq-interop.c
+++ b/test/quic-openssl-docker/hq-interop/quic-hq-interop.c
@@ -130,8 +130,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
 
         /* Connect the socket to the server's address */
         if (!BIO_connect(sock, BIO_ADDRINFO_address(ai), 0)) {
-            BIO_closesocket(sock);
-            sock = -1;
+            BIO_closesocket(&sock);
             continue;
         }
 
@@ -141,8 +140,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
          * <= 0 if something goes wrong, so catch them all here
          */
         if (BIO_socket_nbio(sock, 1) <= 0) {
-            BIO_closesocket(sock);
-            sock = -1;
+            BIO_closesocket(&sock);
             continue;
         }
 
@@ -152,7 +150,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
     if (sock != -1) {
         *peer_addr = BIO_ADDR_dup(BIO_ADDRINFO_address(ai));
         if (*peer_addr == NULL) {
-            BIO_closesocket(sock);
+            BIO_closesocket(&sock);
             return NULL;
         }
     }
@@ -167,7 +165,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
     /* Create a BIO to wrap the socket */
     bio = BIO_new(BIO_s_datagram());
     if (bio == NULL) {
-        BIO_closesocket(sock);
+        BIO_closesocket(&sock);
         return NULL;
     }
 
@@ -179,7 +177,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
      * needed.
      */
     if (BIO_set_fd(bio, sock, BIO_CLOSE) <= 0) {
-        BIO_closesocket(sock);
+        BIO_closesocket(&sock);
         BIO_free(bio);
         return NULL;
     }

--- a/test/quic_client_test.c
+++ b/test/quic_client_test.c
@@ -165,8 +165,8 @@ err:
     SSL_CTX_free(c_ctx);
     BIO_ADDR_free(s_addr_);
     BIO_free(c_net_bio_own);
-    if (fd_arg == INVALID_SOCKET && c_fd != INVALID_SOCKET)
-        BIO_closesocket(c_fd);
+    if (fd_arg == INVALID_SOCKET)
+        BIO_closesocket(&c_fd);
     return testresult;
 }
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -656,15 +656,9 @@ static void helper_cleanup(struct helper *h)
     qtest_fault_free(h->qtf);
     h->qtf = NULL;
 
-    if (h->s_fd >= 0) {
-        BIO_closesocket(h->s_fd);
-        h->s_fd = -1;
-    }
+    BIO_closesocket(&h->s_fd);
 
-    if (h->c_fd >= 0) {
-        BIO_closesocket(h->c_fd);
-        h->c_fd = -1;
-    }
+    BIO_closesocket(&h->c_fd);
 
     BIO_ADDR_free(h->s_net_bio_addr);
     h->s_net_bio_addr = NULL;
@@ -1861,8 +1855,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
         } break;
 
         case OPK_C_CLOSE_SOCKET: {
-            BIO_closesocket(h->c_fd);
-            h->c_fd = -1;
+            BIO_closesocket(&h->c_fd);
         } break;
 
         case OPK_C_EXPECT_SSL_ERR: {

--- a/test/quic_tserver_test.c
+++ b/test/quic_tserver_test.c
@@ -403,10 +403,8 @@ err:
     BIO_free(c_net_bio_own);
     BIO_free(c_pair_own);
     BIO_free(s_pair_own);
-    if (s_fd >= 0)
-        BIO_closesocket(s_fd);
-    if (c_fd >= 0)
-        BIO_closesocket(c_fd);
+    BIO_closesocket(&s_fd);
+    BIO_closesocket(&c_fd);
     return testresult;
 }
 

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -124,7 +124,7 @@ static int test_quic_write_read(int idx)
 
             if (idx >= 2 && j > 0)
                 /* Introduce permanent socket error */
-                BIO_closesocket(csock);
+                BIO_closesocket(&csock);
 
             ossl_quic_tserver_tick(qtserv);
             if (!TEST_true(ossl_quic_tserver_write(qtserv, sid,
@@ -892,8 +892,7 @@ static int test_quic_set_fd(int idx)
 err:
     SSL_free(ssl);
     SSL_CTX_free(ctx);
-    if (fd >= 0)
-        BIO_closesocket(fd);
+    BIO_closesocket(&fd);
     return testresult;
 }
 

--- a/test/radix/quic_ops.c
+++ b/test/radix/quic_ops.c
@@ -109,7 +109,7 @@ static int ssl_create_bound_socket(uint16_t listen_port,
     ok = 1;
 err:
     if (!ok && fd >= 0)
-        BIO_closesocket(fd);
+        BIO_closesocket(&fd);
     else if (ok) {
         *p_fd = fd;
         if (p_result_port != NULL)
@@ -129,7 +129,7 @@ static int ssl_attach_bio_dgram(SSL *ssl,
         return 0;
 
     if (!TEST_ptr(bio = BIO_new_dgram(s_fd, BIO_CLOSE))) {
-        BIO_closesocket(s_fd);
+        BIO_closesocket(&s_fd);
         return 0;
     }
 


### PR DESCRIPTION
Prevent socket double close

Found by Linux Verification Center (linuxtesting.org) with SVACE.

- [x] documentation is added or updated
