### PR TITLE
[4.0, master] X509_EXTENSION_set_object.pod, X509v3_get_ext_by_NID.pod: add missing const

### DIFF
--- a/doc/man3/X509_EXTENSION_set_object.pod
+++ b/doc/man3/X509_EXTENSION_set_object.pod
@@ -21,9 +21,9 @@ functions
                                               const ASN1_OBJECT *obj, int crit,
                                               ASN1_OCTET_STRING *data);
 
- const ASN1_OBJECT *X509_EXTENSION_get_object(X509_EXTENSION *ex);
+ const ASN1_OBJECT *X509_EXTENSION_get_object(const X509_EXTENSION *ex);
  int X509_EXTENSION_get_critical(const X509_EXTENSION *ex);
- const ASN1_OCTET_STRING *X509_EXTENSION_get_data(X509_EXTENSION *ne);
+ const ASN1_OCTET_STRING *X509_EXTENSION_get_data(const X509_EXTENSION *ne);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/X509v3_get_ext_by_NID.pod
+++ b/doc/man3/X509v3_get_ext_by_NID.pod
@@ -30,7 +30,7 @@ X509_REVOKED_get_ext_by_critical, X509_REVOKED_delete_ext, X509_REVOKED_add_ext
  X509_EXTENSION *X509v3_delete_ext(STACK_OF(X509_EXTENSION) *x, int loc);
  X509_EXTENSION *X509v3_delete_extension(STACK_OF(X509_EXTENSION) **x, int loc);
  STACK_OF(X509_EXTENSION) *X509v3_add_ext(STACK_OF(X509_EXTENSION) **x,
-                                          X509_EXTENSION *ex, int loc);
+                                          const X509_EXTENSION *ex, int loc);
  STACK_OF(X509_EXTENSION)
       *X509v3_add_extensions(STACK_OF(X509_EXTENSION) **target,
                              const STACK_OF(X509_EXTENSION) *exts);


### PR DESCRIPTION
Update the documentation to include that added const qualifiers to the arguments of X509_EXTENSION_get_object(), X509_EXTENSION_get_data(), and X509v3_add_ext().

Also, this shows that the commit message in the offending commit is somewhat misleading, as not all they "took const".

Complements: e75bd84ffc73 "Constify X509_get_ext() and friends.."