### PR TITLE
Remove superfluous volatile for RCU on Windows

### DIFF
--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -51,7 +51,7 @@ typedef struct {
  * atomically updated
  */
 struct rcu_qp {
-    volatile uint64_t users;
+    uint64_t users;
 };
 
 struct thread_qp {


### PR DESCRIPTION
When compiling on the MINGW platform, there are many warnings like this:

  warning: passing argument 1 of 'CRYPTO_atomic_add64' discards 'volatile'
  qualifier from pointer target type [-Wdiscarded-qualifiers]
  CRYPTO_atomic_add64(&lock->qp_group[qp_idx].users, (uint64_t)1, &tmp64,
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
The warning actually shows several issues with volatile in struct rcu_qp:

 - all handling functions using it do not use the volatile modifier, so that the compiler can treat this pointer as non-volatile already (Posix pthread variant does not use volatile here at all.)

 - thread safety is already guaranteed by using locks (NO_INTERLOCKEDOR64) or Interlocked*64 Win32 API functions.

 - the volatile removal modifier should always be explicit

In short, I think the volatile in struct rcu_qp on Windows has no additional value and can be removed.

This also fixes the warnings mentioned above :-)

Thanks Claude & ChatGPT for consultations and some useful points...