### PR TITLE
Fix double-free of tlsmac in cipher dupctx implementations

### DIFF
--- a/providers/implementations/ciphers/cipher_aes.c
+++ b/providers/implementations/ciphers/cipher_aes.c
@@ -44,7 +44,10 @@ static void *aes_dupctx(void *ctx)
     if (ret == NULL)
         return NULL;
     in->base.hw->copyctx(&ret->base, &in->base);
-
+    if (!ossl_cipher_generic_dupctx_tlsmac(&ret->base, &in->base)) {
+        OPENSSL_clear_free(ret, sizeof(*ret));
+        return NULL;
+    }
     return ret;
 }
 

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
@@ -307,6 +307,7 @@ static void *aes_cbc_hmac_sha1_newctx(void *provctx, size_t kbits,
 static void *aes_cbc_hmac_sha1_dupctx(void *provctx)
 {
     PROV_AES_HMAC_SHA1_CTX *ctx = provctx;
+    PROV_AES_HMAC_SHA1_CTX *dctx;
 
     if (!ossl_prov_is_running())
         return NULL;
@@ -314,7 +315,14 @@ static void *aes_cbc_hmac_sha1_dupctx(void *provctx)
     if (ctx == NULL)
         return NULL;
 
-    return OPENSSL_memdup(ctx, sizeof(*ctx));
+    dctx = OPENSSL_memdup(ctx, sizeof(*ctx));
+    if (dctx != NULL
+        && !ossl_cipher_generic_dupctx_tlsmac(&dctx->base_ctx.base,
+            &ctx->base_ctx.base)) {
+        OPENSSL_clear_free(dctx, sizeof(*dctx));
+        return NULL;
+    }
+    return dctx;
 }
 
 static void aes_cbc_hmac_sha1_freectx(void *vctx)
@@ -356,11 +364,22 @@ static void *aes_cbc_hmac_sha256_newctx(void *provctx, size_t kbits,
 static void *aes_cbc_hmac_sha256_dupctx(void *provctx)
 {
     PROV_AES_HMAC_SHA256_CTX *ctx = provctx;
+    PROV_AES_HMAC_SHA256_CTX *dctx;
 
     if (!ossl_prov_is_running())
         return NULL;
 
-    return OPENSSL_memdup(ctx, sizeof(*ctx));
+    if (ctx == NULL)
+        return NULL;
+
+    dctx = OPENSSL_memdup(ctx, sizeof(*ctx));
+    if (dctx != NULL
+        && !ossl_cipher_generic_dupctx_tlsmac(&dctx->base_ctx.base,
+            &ctx->base_ctx.base)) {
+        OPENSSL_clear_free(dctx, sizeof(*dctx));
+        return NULL;
+    }
+    return dctx;
 }
 
 static void aes_cbc_hmac_sha256_freectx(void *vctx)

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha_etm.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha_etm.c
@@ -203,11 +203,19 @@ static void aes_cbc_hmac_sha1_etm_freectx(void *vctx)
 static void *aes_cbc_hmac_sha1_etm_dupctx(void *provctx)
 {
     PROV_AES_HMAC_SHA1_ETM_CTX *ctx = provctx;
+    PROV_AES_HMAC_SHA1_ETM_CTX *dctx;
 
     if (ctx == NULL)
         return NULL;
 
-    return OPENSSL_memdup(ctx, sizeof(*ctx));
+    dctx = OPENSSL_memdup(ctx, sizeof(*ctx));
+    if (dctx != NULL
+        && !ossl_cipher_generic_dupctx_tlsmac(&dctx->base_ctx.base,
+            &ctx->base_ctx.base)) {
+        OPENSSL_clear_free(dctx, sizeof(*dctx));
+        return NULL;
+    }
+    return dctx;
 }
 
 static void *aes_cbc_hmac_sha256_etm_newctx(void *provctx, size_t kbits,
@@ -240,11 +248,19 @@ static void aes_cbc_hmac_sha256_etm_freectx(void *vctx)
 static void *aes_cbc_hmac_sha256_etm_dupctx(void *provctx)
 {
     PROV_AES_HMAC_SHA256_ETM_CTX *ctx = provctx;
+    PROV_AES_HMAC_SHA256_ETM_CTX *dctx;
 
     if (ctx == NULL)
         return NULL;
 
-    return OPENSSL_memdup(ctx, sizeof(*ctx));
+    dctx = OPENSSL_memdup(ctx, sizeof(*ctx));
+    if (dctx != NULL
+        && !ossl_cipher_generic_dupctx_tlsmac(&dctx->base_ctx.base,
+            &ctx->base_ctx.base)) {
+        OPENSSL_clear_free(dctx, sizeof(*dctx));
+        return NULL;
+    }
+    return dctx;
 }
 
 static void *aes_cbc_hmac_sha512_etm_newctx(void *provctx, size_t kbits,
@@ -277,11 +293,19 @@ static void aes_cbc_hmac_sha512_etm_freectx(void *vctx)
 static void *aes_cbc_hmac_sha512_etm_dupctx(void *provctx)
 {
     PROV_AES_HMAC_SHA512_ETM_CTX *ctx = provctx;
+    PROV_AES_HMAC_SHA512_ETM_CTX *dctx;
 
     if (ctx == NULL)
         return NULL;
 
-    return OPENSSL_memdup(ctx, sizeof(*ctx));
+    dctx = OPENSSL_memdup(ctx, sizeof(*ctx));
+    if (dctx != NULL
+        && !ossl_cipher_generic_dupctx_tlsmac(&dctx->base_ctx.base,
+            &ctx->base_ctx.base)) {
+        OPENSSL_clear_free(dctx, sizeof(*dctx));
+        return NULL;
+    }
+    return dctx;
 }
 
 #define IMPLEMENT_CIPHER(nm, sub, kbits, blkbits, ivbits, flags)                    \

--- a/providers/implementations/ciphers/cipher_aes_wrp.c
+++ b/providers/implementations/ciphers/cipher_aes_wrp.c
@@ -76,14 +76,10 @@ static void *aes_wrap_dupctx(void *wctx)
     if (ctx == NULL)
         return NULL;
     dctx = OPENSSL_memdup(ctx, sizeof(*ctx));
-
-    if (dctx != NULL && dctx->base.tlsmac != NULL && dctx->base.alloced) {
-        dctx->base.tlsmac = OPENSSL_memdup(dctx->base.tlsmac,
-            dctx->base.tlsmacsize);
-        if (dctx->base.tlsmac == NULL) {
-            OPENSSL_free(dctx);
-            dctx = NULL;
-        }
+    if (dctx != NULL
+        && !ossl_cipher_generic_dupctx_tlsmac(&dctx->base, &ctx->base)) {
+        OPENSSL_clear_free(dctx, sizeof(*dctx));
+        return NULL;
     }
     return dctx;
 }

--- a/providers/implementations/ciphers/cipher_chacha20.c
+++ b/providers/implementations/ciphers/cipher_chacha20.c
@@ -79,16 +79,14 @@ static void *chacha20_dupctx(void *vctx)
     PROV_CHACHA20_CTX *ctx = (PROV_CHACHA20_CTX *)vctx;
     PROV_CHACHA20_CTX *dupctx = NULL;
 
-    if (ctx != NULL) {
-        dupctx = OPENSSL_memdup(ctx, sizeof(*dupctx));
-        if (dupctx != NULL && dupctx->base.tlsmac != NULL && dupctx->base.alloced) {
-            dupctx->base.tlsmac = OPENSSL_memdup(dupctx->base.tlsmac,
-                dupctx->base.tlsmacsize);
-            if (dupctx->base.tlsmac == NULL) {
-                OPENSSL_free(dupctx);
-                dupctx = NULL;
-            }
-        }
+    if (ctx == NULL)
+        return NULL;
+
+    dupctx = OPENSSL_memdup(ctx, sizeof(*dupctx));
+    if (dupctx != NULL
+        && !ossl_cipher_generic_dupctx_tlsmac(&dupctx->base, &ctx->base)) {
+        OPENSSL_clear_free(dupctx, sizeof(*dupctx));
+        return NULL;
     }
     return dupctx;
 }

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.c
@@ -69,13 +69,10 @@ static void *chacha20_poly1305_dupctx(void *provctx)
     if (ctx == NULL)
         return NULL;
     dctx = OPENSSL_memdup(ctx, sizeof(*ctx));
-    if (dctx != NULL && dctx->base.tlsmac != NULL && dctx->base.alloced) {
-        dctx->base.tlsmac = OPENSSL_memdup(dctx->base.tlsmac,
-            dctx->base.tlsmacsize);
-        if (dctx->base.tlsmac == NULL) {
-            OPENSSL_free(dctx);
-            dctx = NULL;
-        }
+    if (dctx != NULL
+        && !ossl_cipher_generic_dupctx_tlsmac(&dctx->base, &ctx->base)) {
+        OPENSSL_clear_free(dctx, sizeof(*dctx));
+        return NULL;
     }
     return dctx;
 }

--- a/providers/implementations/ciphers/cipher_rc4_hmac_md5.c
+++ b/providers/implementations/ciphers/cipher_rc4_hmac_md5.c
@@ -76,10 +76,18 @@ static void rc4_hmac_md5_freectx(void *vctx)
 static void *rc4_hmac_md5_dupctx(void *vctx)
 {
     PROV_RC4_HMAC_MD5_CTX *ctx = vctx;
+    PROV_RC4_HMAC_MD5_CTX *dctx;
 
     if (ctx == NULL)
         return NULL;
-    return OPENSSL_memdup(ctx, sizeof(*ctx));
+
+    dctx = OPENSSL_memdup(ctx, sizeof(*ctx));
+    if (dctx != NULL
+        && !ossl_cipher_generic_dupctx_tlsmac(&dctx->base, &ctx->base)) {
+        OPENSSL_clear_free(dctx, sizeof(*dctx));
+        return NULL;
+    }
+    return dctx;
 }
 
 static int rc4_hmac_md5_einit(void *ctx, const unsigned char *key,

--- a/providers/implementations/ciphers/ciphercommon.c
+++ b/providers/implementations/ciphers/ciphercommon.c
@@ -148,6 +148,25 @@ void ossl_cipher_generic_reset_ctx(PROV_CIPHER_CTX *ctx)
     }
 }
 
+/*
+ * Deep-copy the tlsmac buffer after a shallow dupctx copy.
+ * Must be called after OPENSSL_memdup or *dctx = *sctx to avoid
+ * double-free when both contexts are freed.
+ * Returns 1 on success, 0 on allocation failure.
+ */
+int ossl_cipher_generic_dupctx_tlsmac(PROV_CIPHER_CTX *dst,
+    const PROV_CIPHER_CTX *src)
+{
+    if (src->tlsmac != NULL && src->alloced) {
+        dst->tlsmac = OPENSSL_memdup(src->tlsmac, src->tlsmacsize);
+        if (dst->tlsmac == NULL) {
+            dst->alloced = 0;
+            return 0;
+        }
+    }
+    return 1;
+}
+
 static int cipher_generic_init_internal(PROV_CIPHER_CTX *ctx,
     const unsigned char *key, size_t keylen,
     const unsigned char *iv, size_t ivlen,

--- a/providers/implementations/include/prov/ciphercommon.h
+++ b/providers/implementations/include/prov/ciphercommon.h
@@ -106,6 +106,8 @@ struct prov_cipher_hw_st {
 };
 
 void ossl_cipher_generic_reset_ctx(PROV_CIPHER_CTX *ctx);
+int ossl_cipher_generic_dupctx_tlsmac(PROV_CIPHER_CTX *dst,
+    const PROV_CIPHER_CTX *src);
 OSSL_FUNC_cipher_encrypt_init_fn ossl_cipher_generic_einit;
 OSSL_FUNC_cipher_decrypt_init_fn ossl_cipher_generic_dinit;
 OSSL_FUNC_cipher_update_fn ossl_cipher_generic_block_update;

--- a/test/build.info
+++ b/test/build.info
@@ -773,6 +773,11 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[cipher_overhead_test]=.. ../include ../apps/include
   DEPEND[cipher_overhead_test]=../libcrypto.a ../libssl.a libtestutil.a
 
+  PROGRAMS{noinst}=cipher_dupctx_test
+  SOURCE[cipher_dupctx_test]=cipher_dupctx_test.c
+  INCLUDE[cipher_dupctx_test]=../include ../apps/include
+  DEPEND[cipher_dupctx_test]=../libcrypto libtestutil.a
+
   SOURCE[uitest]=uitest.c ../apps/lib/apps_ui.c
   INCLUDE[uitest]=.. ../include ../apps/include
   DEPEND[uitest]=../libcrypto ../libssl libtestutil.a

--- a/test/cipher_dupctx_test.c
+++ b/test/cipher_dupctx_test.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * Test that EVP_CIPHER_CTX_copy correctly deep-copies the tlsmac buffer
+ * to prevent double-free when both contexts are freed.
+ * See https://github.com/openssl/openssl/issues/30548
+ */
+
+#include <string.h>
+#include <openssl/evp.h>
+#include <openssl/err.h>
+#include <openssl/params.h>
+#include <openssl/core_names.h>
+#include <openssl/prov_ssl.h>
+#include "testutil.h"
+
+/*
+ * Test that duplicating a cipher context with a heap-allocated tlsmac
+ * buffer does not cause a double-free when both contexts are freed.
+ *
+ * The tlsmac buffer is allocated during TLS CBC decryption via
+ * ossl_cipher_tlsunpadblock -> ssl3_cbc_copy_mac -> OPENSSL_malloc.
+ * Without the fix, the shallow copy in dupctx causes both the original
+ * and duplicated context to share the same pointer, leading to a
+ * double-free in ossl_cipher_generic_reset_ctx.
+ */
+static int test_dupctx_tlsmac(int idx)
+{
+    static const char *cipher_names[] = {
+        "AES-128-CBC",
+        "AES-256-CBC"
+    };
+    const char *name = cipher_names[idx];
+    EVP_CIPHER_CTX *ctx = NULL, *dupctx = NULL;
+    EVP_CIPHER *cipher = NULL;
+    unsigned char key[32] = { 0 };
+    unsigned char iv[16] = { 0 };
+    unsigned char buf[64];
+    int outl = 0;
+    int ret = 0;
+    unsigned int tls_ver = TLS1_VERSION;
+    size_t mac_size = 20; /* SHA1 */
+    OSSL_PARAM params[3];
+
+    cipher = EVP_CIPHER_fetch(NULL, name, NULL);
+    if (!TEST_ptr(cipher))
+        goto err;
+
+    ctx = EVP_CIPHER_CTX_new();
+    if (!TEST_ptr(ctx))
+        goto err;
+
+    if (!TEST_true(EVP_DecryptInit_ex(ctx, cipher, NULL, key, iv)))
+        goto err;
+
+    /* Set TLS parameters to trigger tlsmac allocation */
+    params[0] = OSSL_PARAM_construct_uint(OSSL_CIPHER_PARAM_TLS_VERSION,
+        &tls_ver);
+    params[1] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_TLS_MAC_SIZE,
+        &mac_size);
+    params[2] = OSSL_PARAM_construct_end();
+
+    if (!EVP_CIPHER_CTX_set_params(ctx, params)) {
+        TEST_skip("Cipher %s does not support TLS params", name);
+        ret = 1;
+        goto err;
+    }
+
+    /*
+     * Perform a decrypt update with enough data to trigger tlsmac
+     * allocation. Buffer needs at least: block_size + mac_size + 1.
+     * For AES-CBC: 16 + 20 + 1 = 37 minimum. Use 64 for safety.
+     * Last byte is padding length (0 = 1 byte of padding).
+     */
+    memset(buf, 0, sizeof(buf));
+    ERR_clear_error();
+    if (!EVP_DecryptUpdate(ctx, buf, &outl, buf, sizeof(buf)))
+        ERR_clear_error();
+
+    /*
+     * Duplicate the context. Before the fix, this created a shallow
+     * copy that shared the tlsmac pointer.
+     */
+    dupctx = EVP_CIPHER_CTX_new();
+    if (!TEST_ptr(dupctx))
+        goto err;
+
+    if (!EVP_CIPHER_CTX_copy(dupctx, ctx)) {
+        TEST_skip("Cipher %s does not support context copy", name);
+        ret = 1;
+        goto err;
+    }
+
+    /*
+     * Free both contexts. Without the fix, the second free triggers
+     * a double-free on the shared tlsmac pointer.
+     * With ASan enabled, this would be detected as "attempting double-free".
+     */
+    EVP_CIPHER_CTX_free(ctx);
+    ctx = NULL;
+    EVP_CIPHER_CTX_free(dupctx);
+    dupctx = NULL;
+
+    ret = 1;
+
+err:
+    EVP_CIPHER_CTX_free(ctx);
+    EVP_CIPHER_CTX_free(dupctx);
+    EVP_CIPHER_free(cipher);
+    return ret;
+}
+
+int setup_tests(void)
+{
+    ADD_ALL_TESTS(test_dupctx_tlsmac, 2);
+    return 1;
+}

--- a/test/cipher_dupctx_test.c
+++ b/test/cipher_dupctx_test.c
@@ -67,11 +67,8 @@ static int test_dupctx_tlsmac(int idx)
         &mac_size);
     params[2] = OSSL_PARAM_construct_end();
 
-    if (!EVP_CIPHER_CTX_set_params(ctx, params)) {
-        TEST_skip("Cipher %s does not support TLS params", name);
-        ret = 1;
+    if (!TEST_true(EVP_CIPHER_CTX_set_params(ctx, params)))
         goto err;
-    }
 
     /*
      * Perform a decrypt update with enough data to trigger tlsmac
@@ -92,11 +89,8 @@ static int test_dupctx_tlsmac(int idx)
     if (!TEST_ptr(dupctx))
         goto err;
 
-    if (!EVP_CIPHER_CTX_copy(dupctx, ctx)) {
-        TEST_skip("Cipher %s does not support context copy", name);
-        ret = 1;
+    if (!TEST_true(EVP_CIPHER_CTX_copy(dupctx, ctx)))
         goto err;
-    }
 
     /*
      * Free both contexts. Without the fix, the second free triggers

--- a/test/recipes/30-test_cipher_dupctx.t
+++ b/test/recipes/30-test_cipher_dupctx.t
@@ -1,0 +1,16 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use OpenSSL::Test;
+use OpenSSL::Test::Utils;
+
+setup("test_cipher_dupctx");
+
+plan tests => 1;
+
+ok(run(test(["cipher_dupctx_test"])), "cipher dupctx tlsmac deep copy");


### PR DESCRIPTION
## Description

Fix double-free of heap-allocated `tlsmac` via shallow copy in multiple cipher `dupctx` implementations.

### Problem

Multiple cipher `dupctx` functions perform shallow copies (via `OPENSSL_memdup` or `*dctx = *sctx` through `IMPLEMENT_CIPHER_HW_COPYCTX`) without deep-copying the heap-allocated `tlsmac` buffer. Both the original and duplicated context share the same `tlsmac` pointer with `alloced = 1`. When both contexts are freed, `ossl_cipher_generic_reset_ctx` calls `OPENSSL_free(ctx->tlsmac)` twice on the same address, causing a double-free.

### Fix

Add `ossl_cipher_generic_dupctx_tlsmac()` as a centralized helper in `ciphercommon.c` that deep-copies `tlsmac` after any shallow `dupctx` copy. This follows the pattern already used in `chacha20_poly1305_dupctx`, but centralizes it so all current and future cipher implementations benefit.

Applied to all affected implementations listed in the issue:
- `aes_dupctx` (via `IMPLEMENT_CIPHER_HW_COPYCTX`)
- `aes_cbc_hmac_sha1_dupctx`, `aes_cbc_hmac_sha256_dupctx`
- `aes_cbc_hmac_sha1_etm_dupctx`, `aes_cbc_hmac_sha256_etm_dupctx`, `aes_cbc_hmac_sha512_etm_dupctx`
- `rc4_hmac_md5_dupctx`

Also unified the hand-rolled inline fixes in `cipher_aes_wrp.c` and `cipher_chacha20.c` to use the same helper.

### Note

Other cipher `dupctx` implementations (aria, camellia, des, tdes, sm4, blowfish, cast5, rc2, rc5, idea, rc4, seed) have the same shallow-copy pattern. They were not listed in the original report. Happy to extend this fix to cover them in this PR or a follow-up.

### Testing

Added `cipher_dupctx_test.c` that:
- Sets up AES-CBC decryption with TLS parameters to trigger `tlsmac` heap allocation
- Duplicates the context via `EVP_CIPHER_CTX_copy`
- Frees both contexts (triggers double-free without the fix)
- Tested with ASan-enabled build — no errors

Fixes #30548

##### Checklist
- [ ] documentation is added or updated
- [x] tests are added or updated
