### PR TITLE
doc: updates no-pinshared description for 4.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -916,8 +916,8 @@ By default, on supported platforms (such as Linux and GNU Hurd), OpenSSL
 is built with linker options (e.g., `-Wl,-znodelete`) that prevent the
 operating system from unloading the libcrypto and libssl shared libraries
 from memory, even if the application explicitly unloads them using
-`dlclose()`. On platforms that do not support these options (such as
-OpenVMS), this feature is disabled by default.
+`dlclose()`. On platforms that do not support these options, this feature
+is disabled by default.
 
 This option prevents the addition of those linker flags, allowing the
 shared libraries to be completely unloaded from the process address space.


### PR DESCRIPTION
The current documentation heavily references the now removed `atexit()` handlers. This updates the description to better reflect it's current utility (removal of `-Wl,-znodelete` linker flags on Linux and Hurd). 
@bbbrumley 
Fixes #30586

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
- [x] documentation is added or updated

