### PR TITLE
crypto/pkcs12/p12_add.c: Restore ERR_set_mark and ERR_pop_to_mark

### DIFF
--- a/crypto/pkcs12/p12_add.c
+++ b/crypto/pkcs12/p12_add.c
@@ -109,7 +109,9 @@ PKCS7 *PKCS12_pack_p7encdata_ex(int pbe_nid, const char *pass, int passlen,
         goto err;
     }
 
+    ERR_set_mark();
     pbe_ciph = EVP_CIPHER_fetch(ctx, OBJ_nid2sn(pbe_nid), propq);
+    ERR_pop_to_mark();
 
     if (pbe_ciph != NULL) {
         pbe = PKCS5_pbe2_set_iv_ex(pbe_ciph, iter, salt, saltlen, NULL, -1, ctx);

--- a/test/recipes/80-test_pkcs12.t
+++ b/test/recipes/80-test_pkcs12.t
@@ -56,7 +56,7 @@ $ENV{OPENSSL_WIN32_UTF8}=1;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
-plan tests => $no_fips ? 58 : 63;
+plan tests => 59 + ($no_fips ? 0 : 5);
 
 # Test different PKCS#12 formats
 ok(run(test(["pkcs12_format_test"])), "test pkcs12 formats");
@@ -107,7 +107,7 @@ SKIP: {
 }
 
 SKIP: {
-    skip "Skipping legacy PKCS#12 test because the required algorithms are disabled", 1
+    skip "Skipping legacy PKCS#12 test because the required algorithms are disabled", 2
         if disabled("des") || disabled("rc2") || disabled("legacy");
     # Test reading legacy PKCS#12 file
     ok(run(app(["openssl", "pkcs12", "-export",
@@ -115,8 +115,12 @@ SKIP: {
                 "-passin", "pass:v3-certs",
                 "-provider", "default", "-provider", "legacy",
                 "-nokeys", "-passout", "pass:v3-certs", "-descert",
-                "-out", $outfile3])),
+                "-out", $outfile3], stderr => "outerr2.txt")),
     "test_pkcs12_passcerts_legacy");
+    open DATA, "outerr2.txt";
+    my @match = grep /:error:/, <DATA>;
+    close DATA;
+    ok(scalar @match > 0 ? 0 : 1, "test_pkcs12_passcerts_legacy_outerr2_empty");
 }
 
 # Test export of PEM file with both cert and key


### PR DESCRIPTION
The commit 2ea6e785f526f88f913cc6f49372aae9dc54bc63 removed the ERR_set_mark and ERR_pop_to_mark calls before and after the EVP_CIPHER_fetch call in several files.

However, in PKCS12_pack_p7encdata_ex, crypto/pkcs12/p12_add.c, there is a valid case that EVP_CIPHER_fetch returns NULL, raising an error, and calls PKCS5_pbe_set_ex. The case is such as PBE-SHA1-3DES.

PKCS12_pack_p7encdata_ex, crypto/pkcs12/p12_add.c:
```
...
    pbe_ciph = EVP_CIPHER_fetch(ctx, OBJ_nid2sn(pbe_nid), propq);

    if (pbe_ciph != NULL) {
        pbe = PKCS5_pbe2_set_iv_ex(pbe_ciph, iter, salt, saltlen, NULL, -1, ctx);
    } else {
        pbe = PKCS5_pbe_set_ex(pbe_nid, iter, salt, saltlen, ctx);
    }
...
```

So, we need to restore ERR_set_mark and ERR_pop_to_mark calls before and after the EVP_CIPHER_fetch call for this case.

A reproducer is below.

```
$ openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -nodes \
  -subj "/CN=Test" 2> /dev/null
$ openssl pkcs12 \
    -export -in cert.pem -inkey key.pem -out test.p12 -passout pass: \
    -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES
40276EC7677F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:crypto/evp/evp_fetch.c:376:Global default library context, Algorithm (PBE-SHA1-3DES : 0), Properties (<null>)
$ echo $?
0
```

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
