### PR TITLE
quic: zero-initialize scid and odcid in port_default_packet_handler

### DIFF
--- a/include/internal/quic_channel.h
+++ b/include/internal/quic_channel.h
@@ -297,7 +297,6 @@ void ossl_quic_channel_on_new_conn_id(QUIC_CHANNEL *ch,
 
 /* Temporarily exposed during QUIC_PORT transition. */
 int ossl_quic_channel_on_new_conn(QUIC_CHANNEL *ch, const BIO_ADDR *peer,
-    const QUIC_CONN_ID *peer_scid,
     const QUIC_CONN_ID *peer_dcid);
 
 /* For use by QUIC_PORT. You should not need to call this directly. */
@@ -540,8 +539,7 @@ uint64_t ossl_quic_channel_get_active_conn_id_limit_request(const QUIC_CHANNEL *
 uint64_t ossl_quic_channel_get_active_conn_id_limit_peer_request(const QUIC_CHANNEL *ch);
 
 int ossl_quic_bind_channel(QUIC_CHANNEL *ch, const BIO_ADDR *peer,
-    const QUIC_CONN_ID *scid, const QUIC_CONN_ID *dcid,
-    const QUIC_CONN_ID *odcid);
+    const QUIC_CONN_ID *dcid, const QUIC_CONN_ID *odcid);
 
 void ossl_quic_channel_set_tcause(QUIC_CHANNEL *ch, uint64_t app_error_code,
     const char *app_reason);

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -3672,7 +3672,6 @@ static void ch_on_idle_timeout(QUIC_CHANNEL *ch)
  * @return         1 on success, 0 on failure to set required elements.
  */
 static int ch_on_new_conn_common(QUIC_CHANNEL *ch, const BIO_ADDR *peer,
-    const QUIC_CONN_ID *peer_scid,
     const QUIC_CONN_ID *peer_dcid,
     const QUIC_CONN_ID *peer_odcid)
 {
@@ -3681,7 +3680,6 @@ static int ch_on_new_conn_common(QUIC_CHANNEL *ch, const BIO_ADDR *peer,
         return 0;
 
     ch->init_dcid = *peer_dcid;
-    ch->cur_remote_dcid = *peer_scid;
     ch->odcid.id_len = 0;
 
     if (peer_odcid != NULL)
@@ -3725,7 +3723,6 @@ static int ch_on_new_conn_common(QUIC_CHANNEL *ch, const BIO_ADDR *peer,
 
 /* Called when we, as a server, get a new incoming connection. */
 int ossl_quic_channel_on_new_conn(QUIC_CHANNEL *ch, const BIO_ADDR *peer,
-    const QUIC_CONN_ID *peer_scid,
     const QUIC_CONN_ID *peer_dcid)
 {
     if (!ossl_assert(ch->state == QUIC_CHANNEL_STATE_IDLE && ch->is_server))
@@ -3735,7 +3732,7 @@ int ossl_quic_channel_on_new_conn(QUIC_CHANNEL *ch, const BIO_ADDR *peer,
     if (!ossl_quic_lcidm_generate_initial(ch->lcidm, ch, &ch->cur_local_cid))
         return 0;
 
-    return ch_on_new_conn_common(ch, peer, peer_scid, peer_dcid, NULL);
+    return ch_on_new_conn_common(ch, peer, peer_dcid, NULL);
 }
 
 /**
@@ -3762,7 +3759,6 @@ int ossl_quic_channel_on_new_conn(QUIC_CHANNEL *ch, const BIO_ADDR *peer,
  *         met (e.g., channel is not idle or not a server, or binding fails).
  */
 int ossl_quic_bind_channel(QUIC_CHANNEL *ch, const BIO_ADDR *peer,
-    const QUIC_CONN_ID *peer_scid,
     const QUIC_CONN_ID *peer_dcid,
     const QUIC_CONN_ID *peer_odcid)
 {
@@ -3781,7 +3777,7 @@ int ossl_quic_bind_channel(QUIC_CHANNEL *ch, const BIO_ADDR *peer,
      * peer_odcid <=> is initial dst conn id chosen by peer in its
      * first initial packet we received without token.
      */
-    return ch_on_new_conn_common(ch, peer, peer_scid, peer_dcid, peer_odcid);
+    return ch_on_new_conn_common(ch, peer, peer_dcid, peer_odcid);
 }
 
 SSL *ossl_quic_channel_get0_ssl(QUIC_CHANNEL *ch)

--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -810,7 +810,7 @@ static void port_rx_pre(QUIC_PORT *port)
  * to *new_ch.
  */
 static void port_bind_channel(QUIC_PORT *port, const BIO_ADDR *peer,
-    const QUIC_CONN_ID *scid, const QUIC_CONN_ID *dcid,
+    const QUIC_CONN_ID *dcid,
     const QUIC_CONN_ID *odcid, OSSL_QRX *qrx,
     QUIC_CHANNEL **new_ch)
 {
@@ -860,7 +860,7 @@ static void port_bind_channel(QUIC_PORT *port, const BIO_ADDR *peer,
          * See RFC 9000 s. 8.1
          */
         ossl_quic_tx_packetiser_set_validated(ch->txp);
-        if (!ossl_quic_bind_channel(ch, peer, scid, dcid, odcid)) {
+        if (!ossl_quic_bind_channel(ch, peer, dcid, odcid)) {
             ossl_quic_channel_free(ch);
             return;
         }
@@ -869,7 +869,7 @@ static void port_bind_channel(QUIC_PORT *port, const BIO_ADDR *peer,
          * No odcid means we didn't do server validation, so we need to
          * generate a cid via ossl_quic_channel_on_new_conn
          */
-        if (!ossl_quic_channel_on_new_conn(ch, peer, scid, dcid)) {
+        if (!ossl_quic_channel_on_new_conn(ch, peer, dcid)) {
             ossl_quic_channel_free(ch);
             return;
         }
@@ -1416,8 +1416,7 @@ static void port_send_version_negotiation(QUIC_PORT *port, BIO_ADDR *peer,
  *   configurable in the future.
  */
 static int port_validate_token(QUIC_PKT_HDR *hdr, QUIC_PORT *port,
-    BIO_ADDR *peer, QUIC_CONN_ID *odcid,
-    QUIC_CONN_ID *scid, uint8_t *gen_new_token)
+    BIO_ADDR *peer, QUIC_CONN_ID *odcid, uint8_t *gen_new_token)
 {
     int ret = 0;
     QUIC_VALIDATION_TOKEN token = { 0 };
@@ -1477,11 +1476,9 @@ static int port_validate_token(QUIC_PKT_HDR *hdr, QUIC_PORT *port,
                 != 0)
             goto err;
         *odcid = token.odcid;
-        *scid = token.rscid;
     } else {
         if (!ossl_quic_lcidm_get_unused_cid(port->lcidm, odcid))
             goto err;
-        *scid = hdr->src_conn_id;
     }
 
     /*
@@ -1570,7 +1567,7 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
     PACKET pkt;
     QUIC_PKT_HDR hdr;
     QUIC_CHANNEL *ch = NULL, *new_ch = NULL;
-    QUIC_CONN_ID odcid, scid;
+    QUIC_CONN_ID odcid;
     uint8_t gen_new_token = 0;
     OSSL_QRX *qrx = NULL;
     OSSL_QRX *qrx_src = NULL;
@@ -1720,8 +1717,7 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
      */
     if (hdr.token != NULL
         && port_validate_token(&hdr, port, &e->peer,
-               &odcid, &scid,
-               &gen_new_token)
+               &odcid, &gen_new_token)
             == 0) {
         /*
          * RFC 9000 s 8.1.3
@@ -1754,7 +1750,7 @@ static void port_default_packet_handler(QUIC_URXE *e, void *arg,
         qrx = NULL;
     }
 
-    port_bind_channel(port, &e->peer, &scid, &hdr.dst_conn_id,
+    port_bind_channel(port, &e->peer, &hdr.dst_conn_id,
         &odcid, qrx, &new_ch);
 
     /*


### PR DESCRIPTION
  QUIC_CONN_ID scid and odcid are declared without initialization.
  When validate_addr == 0 and the client's Initial has no token,
  port_validate_token() is never called, so scid is never written.
  The uninitialized scid is passed to port_bind_channel() ->
  ossl_quic_channel_on_new_conn(), where garbage data is copied
  to ch->cur_remote_dcid.

  Zero-initialize both variables to prevent use of uninitialized
  memory.

  CWE-457

  Reported-by: Sunwoo Lee <sunwoolee@kentech.ac.kr>

  CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
