### PR TITLE
Fix -Wdiscarded-qualifiers warnings shown when glibc-2.43 is used

### DIFF
--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -304,7 +304,7 @@ static int validate_local_part(const char *name, size_t len,
 static int validate_email_name(const char *name, size_t len, int rfc822)
 {
     size_t dns_len, local_len;
-    char *at, *next, *dnsname;
+    const char *at, *next, *dnsname;
     ossl_charset_t local_charset;
 
     /*


### PR DESCRIPTION
When building with glibc-2.43 there is the following warning:

    crypto/x509/x509_vpm.c: In function 'validate_email_name':
    crypto/x509/x509_vpm.c:317:13: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
      317 |     if ((at = memchr(name, '@', len)) == NULL)
          |             ^

This is due to a change described in the NEWS file of glibc-2.43:

    * For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

Systems using this recent glibc version will likely also be using GCC 15 or later which default to `-std=gnu23`, meaning that this warning will show up without modifying `CFLAGS`.

We can make these pointers const since we never write to them.
