### PR TITLE
sm2: check buffer size before writing ciphertext

### DIFF
--- a/crypto/sm2/sm2_crypt.c
+++ b/crypto/sm2/sm2_crypt.c
@@ -253,8 +253,19 @@ again:
         goto done;
     }
 
-    ciphertext_leni = i2d_SM2_Ciphertext(&ctext_struct, &ciphertext_buf);
+    ciphertext_leni = i2d_SM2_Ciphertext(&ctext_struct, NULL);
     /* Ensure cast to size_t is safe */
+    if (ciphertext_leni < 0) {
+        ERR_raise(ERR_LIB_SM2, ERR_R_INTERNAL_ERROR);
+        goto done;
+    }
+
+    if (*ciphertext_len < (size_t)ciphertext_leni) {
+        ERR_raise(ERR_LIB_SM2, SM2_R_BUFFER_TOO_SMALL);
+        goto done;
+    }
+
+    ciphertext_leni = i2d_SM2_Ciphertext(&ctext_struct, &ciphertext_buf);
     if (ciphertext_leni < 0) {
         ERR_raise(ERR_LIB_SM2, ERR_R_INTERNAL_ERROR);
         goto done;

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -2689,8 +2689,10 @@ static int test_EVP_SM2(void)
 #ifndef OPENSSL_NO_X963KDF
     uint8_t ciphertext[128];
     size_t ctext_len = sizeof(ciphertext);
+    size_t ctext_len_param = 0;
     uint8_t plaintext[8];
     size_t ptext_len = sizeof(plaintext);
+    size_t ptext_len_param = 0;
     OSSL_PARAM sparams[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
     OSSL_PARAM gparams[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
     int i;
@@ -2818,7 +2820,8 @@ static int test_EVP_SM2(void)
         if (!TEST_true(EVP_PKEY_CTX_set_params(cctx, sparams)))
             goto done;
 
-        if (!TEST_true(EVP_PKEY_encrypt(cctx, ciphertext, &ctext_len, kMsg,
+        ctext_len_param = ctext_len;
+        if (!TEST_true(EVP_PKEY_encrypt(cctx, ciphertext, &ctext_len_param, kMsg,
                 sizeof(kMsg))))
             goto done;
 
@@ -2828,8 +2831,9 @@ static int test_EVP_SM2(void)
         if (!TEST_true(EVP_PKEY_CTX_set_params(cctx, sparams)))
             goto done;
 
-        if (!TEST_int_gt(EVP_PKEY_decrypt(cctx, plaintext, &ptext_len, ciphertext,
-                             ctext_len),
+        ptext_len_param = ptext_len;
+        if (!TEST_int_gt(EVP_PKEY_decrypt(cctx, plaintext, &ptext_len_param, ciphertext,
+                             ctext_len_param),
                 0))
             goto done;
 
@@ -2849,7 +2853,7 @@ static int test_EVP_SM2(void)
             goto done;
         }
 
-        if (!TEST_true(ptext_len == sizeof(kMsg)))
+        if (!TEST_true(ptext_len_param == sizeof(kMsg)))
             goto done;
 
         if (!TEST_true(memcmp(plaintext, kMsg, sizeof(kMsg)) == 0))


### PR DESCRIPTION
## Summary

`ossl_sm2_encrypt()` in `crypto/sm2/sm2_crypt.c` writes cipher text into a caller-provided buffer using `i2d_SM2_Ciphertext()` without first validating that the buffer is large enough. An undersized ciphertext buffer can lead to an out-of-bounds write.

Applications that use a properly sized buffer, or that first query the required size with a `NULL` output buffer, follow the expected API usage and do not encounter this problem.

## Description

In the default provider's SM2 asymcipher implementation:

```c
static int sm2_asym_encrypt(void *vpsm2ctx, unsigned char *out, size_t *outlen,
    size_t outsize, const unsigned char *in,
    size_t inlen)
{
  	// [...]
    if (out == NULL) {
        if (!ossl_sm2_ciphertext_size(psm2ctx->key, md, inlen, outlen)) {
          // [...]
        }
      	// [...]
    }
    return ossl_sm2_encrypt(psm2ctx->key, md, in, inlen, out, outlen);
}	
```

- `providers/implementations/asymciphers/sm2_enc.c:sm2_asym_encrypt()` returns the size when `out == NULL` using `ossl_sm2_ciphertext_size()`.
- When `out != NULL`, it directly calls `ossl_sm2_encrypt()`

In `crypto/sm2/sm2_crypt.c`, `ossl_sm2_encrypt()` writes to `ciphertext_buf` without verifying capacity:

```c
int ossl_sm2_encrypt(const EC_KEY *key,
    const EVP_MD *digest,
    const uint8_t *msg, size_t msg_len,
    uint8_t *ciphertext_buf, size_t *ciphertext_len)
{
  	// [...]

  	// [1]
    memset(ciphertext_buf, 0, *ciphertext_len);

    msg_mask = OPENSSL_zalloc(msg_len);
    if (msg_mask == NULL)
        goto done;
  	// [...]

  	// [2]
    ciphertext_leni = i2d_SM2_Ciphertext(&ctext_struct, &ciphertext_buf);
  	// [...]
}
```

- It wipes the caller buffer based on [1] `*ciphertext_len`:
  - `memset(ciphertext_buf, 0, *ciphertext_len);`
- It then encodes into [2] `ciphertext_buf`:
  - `i2d_SM2_Ciphertext(&ctext_struct, &ciphertext_buf);`

## Reproduction

- Arch: x86_64 Linux
- OpenSSL: `OpenSSL 4.0.0-dev  (Library: OpenSSL 4.0.0-dev )` commit `9f01bfa`
- Build: `./Configure enable-asan enable-ubsan`

```c
    EVP_PKEY_CTX *kctx = NULL;
    const unsigned char msg[] = "hello";
    unsigned char out[1];
    size_t outlen = sizeof(out);
    // [...]
    kctx = EVP_PKEY_CTX_new_from_name(NULL, "SM2", NULL);
    // [...]
    if (EVP_PKEY_encrypt(ectx, out, &outlen, msg, sizeof(msg) - 1) <= 0) {
        fprintf(stderr, "EVP_PKEY_encrypt returned an error\n");
        print_errors();
    }
```

```
==75==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7f479d700071 at pc 0x7f47a0c76b47 bp 0x7ffd25fd5c50 sp 0x7ffd25fd5c40
WRITE of size 1 at 0x7f479d700071 thread T0
    #0 0x7f47a0c76b46 in asn1_put_length crypto/asn1/asn1_lib.c:206
    #1 0x7f47a0c76b46 in ASN1_put_object crypto/asn1/asn1_lib.c:186
    #2 0x7f47a0ca1df0 in ASN1_item_ex_i2d crypto/asn1/tasn_enc.c:190
    #3 0x7f47a0ca235a in asn1_item_flags_i2d crypto/asn1/tasn_enc.c:73
    #4 0x7f47a0ca235a in ASN1_item_i2d crypto/asn1/tasn_enc.c:45
    #5 0x7f47a1207ea4 in ossl_sm2_encrypt crypto/sm2/sm2_crypt.c:256
    #6 0x7f47a0ef824d in EVP_PKEY_encrypt crypto/evp/asymcipher.c:236
...
  This frame has 4 object(s):
    [48, 56) 'pkey' (line 22)
    [80, 88) 'outlen' (line 26)
    [112, 113) 'out' (line 25) <== Memory access at offset 113 overflows this variable
    [128, 134) 'msg' (line 24)
```

## Tests

Some existing tests use the affected calling pattern, but the output buffer size is large enough.

https://github.com/openssl/openssl/blob/b8df87aca7efa75b3386c237f7a977ef5c6571fc/test/evp_extra_test.c#L452

https://github.com/openssl/openssl/blob/b8df87aca7efa75b3386c237f7a977ef5c6571fc/test/evp_extra_test.c#L2690-L2691

https://github.com/openssl/openssl/blob/b8df87aca7efa75b3386c237f7a977ef5c6571fc/test/evp_extra_test.c#L2821-L2823

Updating them to cover this issue properly would require a broader change to the current tests, so this PR does not add a dedicated test yet. But we can add a new test if needed.

## Credits

@GGAutomaton, Yuan Tan (@Reset816), xia0o0o0o0 (@Nyaaaaa_ovo), Bird Liu

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
