### PR TITLE
MINGW - fix compilation warnings

### DIFF
--- a/crypto/x509/x509_def.c
+++ b/crypto/x509/x509_def.c
@@ -30,7 +30,7 @@ static char *x509_cert_fileptr = NULL;
 
 static void get_windows_default_path(char *pathname, const char *suffix)
 {
-    char *ossldir;
+    const char *ossldir;
 
     ossldir = ossl_get_openssldir();
 

--- a/include/internal/sockets.h
+++ b/include/internal/sockets.h
@@ -73,6 +73,15 @@ struct servent *PASCAL getservbyname(const char *, const char *);
 #define SHUT_RDWR SD_BOTH
 #endif
 
+/*
+ * Recent MINGW versions use Windows-style unsigned INVALID_SOCKET.
+ * Since OpenSSL uses int, this only silences an already-ignored warning.
+ */
+#if defined(__MINGW32__) && defined(INVALID_SOCKET)
+#undef INVALID_SOCKET
+#define INVALID_SOCKET (INT_PTR)(~0)
+#endif
+
 #else
 #if defined(__APPLE__)
 /*

--- a/ssl/rio/rio_notifier.c
+++ b/ssl/rio/rio_notifier.c
@@ -13,6 +13,7 @@
 #include "internal/thread_once.h"
 #include "internal/rio_notifier.h"
 
+#if !defined(OPENSSL_SYS_WINDOWS) || RIO_NOTIFIER_METHOD == RIO_NOTIFIER_METHOD_SOCKETPAIR
 /*
  * Sets a socket as close-on-exec, except that this is a no-op if we are certain
  * we do not need to do this or the OS does not support the concept.
@@ -25,6 +26,7 @@ static int set_cloexec(int fd)
     return 1;
 #endif
 }
+#endif
 
 #if defined(OPENSSL_SYS_WINDOWS)
 


### PR DESCRIPTION
This patchet fixes few remaining MINGW compilation warnings:

- get_windows_default_path should use const for storing ossl_get_openssldir output

- static set_cloexec is used ony in some configurations, guard it by ifdefs

- ignore long-term standing issue with INVALID_SOCKET defined as unsigned in MINGW
(see https://github.com/openssl/openssl/issues/7282 and https://sourceforge.net/p/mingw-w64/discussion/723797/thread/71522d10/)
