### PR TITLE
Use OPENSSL_assert for Windows RCU for missing lock

### DIFF
--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -610,7 +610,8 @@ int CRYPTO_THREAD_compare_id(CRYPTO_THREAD_ID a, CRYPTO_THREAD_ID b)
 int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
 {
 #if (defined(NO_INTERLOCKEDOR64))
-    if (lock == NULL || !CRYPTO_THREAD_write_lock(lock))
+    OPENSSL_assert(lock != NULL);
+    if (!CRYPTO_THREAD_write_lock(lock))
         return 0;
     *val += amount;
     *ret = *val;
@@ -630,7 +631,8 @@ int CRYPTO_atomic_add64(uint64_t *val, uint64_t op, uint64_t *ret,
     CRYPTO_RWLOCK *lock)
 {
 #if (defined(NO_INTERLOCKEDOR64))
-    if (lock == NULL || !CRYPTO_THREAD_write_lock(lock))
+    OPENSSL_assert(lock != NULL);
+    if (!CRYPTO_THREAD_write_lock(lock))
         return 0;
     *val += op;
     *ret = *val;
@@ -649,7 +651,8 @@ int CRYPTO_atomic_and(uint64_t *val, uint64_t op, uint64_t *ret,
     CRYPTO_RWLOCK *lock)
 {
 #if (defined(NO_INTERLOCKEDOR64))
-    if (lock == NULL || !CRYPTO_THREAD_write_lock(lock))
+    OPENSSL_assert(lock != NULL);
+    if (!CRYPTO_THREAD_write_lock(lock))
         return 0;
     *val &= op;
     *ret = *val;
@@ -668,7 +671,8 @@ int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
     CRYPTO_RWLOCK *lock)
 {
 #if (defined(NO_INTERLOCKEDOR64))
-    if (lock == NULL || !CRYPTO_THREAD_write_lock(lock))
+    OPENSSL_assert(lock != NULL);
+    if (!CRYPTO_THREAD_write_lock(lock))
         return 0;
     *val |= op;
     *ret = *val;
@@ -686,7 +690,8 @@ int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
 int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock)
 {
 #if (defined(NO_INTERLOCKEDOR64))
-    if (lock == NULL || !CRYPTO_THREAD_read_lock(lock))
+    OPENSSL_assert(lock != NULL);
+    if (!CRYPTO_THREAD_read_lock(lock))
         return 0;
     *ret = *val;
     if (!CRYPTO_THREAD_unlock(lock))
@@ -702,7 +707,8 @@ int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock)
 int CRYPTO_atomic_store(uint64_t *dst, uint64_t val, CRYPTO_RWLOCK *lock)
 {
 #if (defined(NO_INTERLOCKEDOR64))
-    if (lock == NULL || !CRYPTO_THREAD_read_lock(lock))
+    OPENSSL_assert(lock != NULL);
+    if (!CRYPTO_THREAD_read_lock(lock))
         return 0;
     *dst = val;
     if (!CRYPTO_THREAD_unlock(lock))
@@ -718,7 +724,8 @@ int CRYPTO_atomic_store(uint64_t *dst, uint64_t val, CRYPTO_RWLOCK *lock)
 int CRYPTO_atomic_load_int(int *val, int *ret, CRYPTO_RWLOCK *lock)
 {
 #if (defined(NO_INTERLOCKEDOR64))
-    if (lock == NULL || !CRYPTO_THREAD_read_lock(lock))
+    OPENSSL_assert(lock != NULL);
+    if (!CRYPTO_THREAD_read_lock(lock))
         return 0;
     *ret = *val;
     if (!CRYPTO_THREAD_unlock(lock))
@@ -735,7 +742,8 @@ int CRYPTO_atomic_load_int(int *val, int *ret, CRYPTO_RWLOCK *lock)
 int CRYPTO_atomic_store_int(int *dst, int val, CRYPTO_RWLOCK *lock)
 {
 #if (defined(NO_INTERLOCKEDOR64))
-    if (lock == NULL || !CRYPTO_THREAD_read_lock(lock))
+    OPENSSL_assert(lock != NULL);
+    if (!CRYPTO_THREAD_read_lock(lock))
         return 0;
     *dst = val;
     if (!CRYPTO_THREAD_unlock(lock))


### PR DESCRIPTION
If NO_INTERLOCKEDOR64 is defined, Windows RCU code must use thread locks.

The lock *must* be provided in that case otherwise it is an internal code error, not a runtime error.
Use OPENSSL_assert here.

This also fixes several unititialized variable warnings as analyzer no longer see this impossible paths in code.
