### PR TITLE
crypto/err/err_all.c: load SM2 error strings

### DIFF
--- a/crypto/err/err_all.c
+++ b/crypto/err/err_all.c
@@ -39,6 +39,7 @@
 #include "crypto/cmperr.h"
 #include "crypto/cterr.h"
 #include "crypto/asyncerr.h"
+#include "crypto/sm2err.h"
 #include "crypto/storeerr.h"
 #include "crypto/esserr.h"
 #include "internal/propertyerr.h"
@@ -100,6 +101,9 @@ int ossl_err_load_crypto_strings(void)
 #endif
         || ossl_err_load_ESS_strings() == 0
         || ossl_err_load_ASYNC_strings() == 0
+#ifndef OPENSSL_NO_SM2
+        || ossl_err_load_SM2_strings() == 0
+#endif
         || ossl_err_load_OSSL_STORE_strings() == 0
         || ossl_err_load_PROP_strings() == 0
         || ossl_err_load_PROV_strings() == 0


### PR DESCRIPTION
The function ossl_err_load_SM2_strings() exists, but wasn't called in ossl_err_load_crypto_strings().  Rescind this omission.

Fixes: 3d328a445c2a "Add SM2 signature and ECIES schemes"