### PR TITLE
Improve PBKDF2 password strength too weak error message with arguments

### DIFF
--- a/providers/implementations/kdfs/pbkdf2.c
+++ b/providers/implementations/kdfs/pbkdf2.c
@@ -366,7 +366,9 @@ static int kdf_pbkdf2_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     if (p.pw != NULL) {
         if (ctx->lower_bound_checks != 0
             && p.pw->data_size < KDF_PBKDF2_MIN_PASSWORD_LEN) {
-            ERR_raise(ERR_LIB_PROV, PROV_R_PASSWORD_STRENGTH_TOO_WEAK);
+            ERR_raise_data(ERR_LIB_PROV, PROV_R_PASSWORD_STRENGTH_TOO_WEAK,
+                "password length %zu should be at least %d",
+                p.pw->data_size, KDF_PBKDF2_MIN_PASSWORD_LEN);
             return 0;
         }
         if (!pbkdf2_set_membuf(&ctx->pass, &ctx->pass_len, p.pw))


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

This PR is to improve PBKDF2 password strength too weak error message with arguments to make it understandable and actionable for users. It is like the https://github.com/openssl/openssl/pull/30493.

Here is a reproducer. It seems that the check was implemented at the commit https://github.com/openssl/openssl/commit/71ed0fc8b3cdb33cd06059416686f8972ede0248 in OpenSSL 4.0.0 development version. However, when I saw the error message in our Ruby OpenSSL library test, I was not sure how I needed to change the password, and had to debug to understand what the check was doing.

```
$ $OPENSSL_DIR/bin/openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out rsa2048.pem
$ OPENSSL_CONF=$OPENSSL_DIR/ssl/openssl_fips.cnf \
  $OPENSSL_DIR/bin/openssl pkey \
  -in rsa2048.pem \
  -outform DER \
  -aes-128-cbc \
  -passout pass:abcdef
40B732F1D07F0000:error:1C8000FE:Provider routines:kdf_pbkdf2_set_ctx_params:password strength too weak:providers/implementations/kdfs/pbkdf2.c:369:
40B732F1D07F0000:error:11800067:PKCS12 routines:PKCS12_item_i2d_encrypt_ex:encrypt error:crypto/pkcs12/p12_decr.c:211:
40B732F1D07F0000:error:11800067:PKCS12 routines:PKCS8_set0_pbe_ex:encrypt error:crypto/pkcs12/p12_p8e.c:79:
```

With this change, I think the error message is clear about how to change the password to avoid the error message. I confirmed this result on the latest master branch b8df87aca7efa75b3386c237f7a977ef5c6571fc.

```
$ OPENSSL_CONF=$OPENSSL_DIR/ssl/openssl_fips.cnf \
  $OPENSSL_DIR/bin/openssl pkey \
  -in rsa2048.pem \
  -outform DER \
  -aes-128-cbc \
  -passout pass:abcdef
40A7D3DA807F0000:error:1C8000FE:Provider routines:kdf_pbkdf2_set_ctx_params:password strength too weak:providers/implementations/kdfs/pbkdf2.c:369:password length 6 should be at least 8
40A7D3DA807F0000:error:11800067:PKCS12 routines:PKCS12_item_i2d_encrypt_ex:encrypt error:crypto/pkcs12/p12_decr.c:211:
40A7D3DA807F0000:error:11800067:PKCS12 routines:PKCS8_set0_pbe_ex:encrypt error:crypto/pkcs12/p12_p8e.c:79:
```

For the message format, I referred to the following part and https://github.com/openssl/openssl/pull/30493.

https://github.com/openssl/openssl/blob/e1eb88118a95445eb9c2d074c853776feaab4de7/crypto/slh_dsa/slh_dsa.c#L73-L74

Note I see the `pbkdf2_lower_bound_check_passed` has some checks including the `PROV_R_PASSWORD_STRENGTH_TOO_WEAK` in it. I didn't modify the error messages in the function, because it seemed a bit hard. However, you guys may want to modify the error messages to be more readable and actionable for users.

https://github.com/openssl/openssl/blob/b8df87aca7efa75b3386c237f7a977ef5c6571fc/providers/implementations/kdfs/pbkdf2.c#L217-L255

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
