### PR TITLE
Long list of functions in the migration guide

### DIFF
--- a/doc/man7/ossl-guide-migration.pod
+++ b/doc/man7/ossl-guide-migration.pod
@@ -66,11 +66,19 @@ The flags member of B<ASN1_STRING> has become inaccessible, and the definitions
 of the flags are no longer public. This includes the public definition
 of the flags:
 
-ASN1_STRING_FLAG_NDEF, 
-ASN1_STRING_FLAG_CONT, 
-ASN1_STRING_FLAG_MSTRING, 
-ASN1_STRING_FLAG_EMBED, 
-ASN1_STRING_FLAG_BITS_LEFT
+=over 4
+
+=item B<ASN1_STRING_FLAG_NDEF>
+
+=item B<ASN1_STRING_FLAG_CONT>
+
+=item B<ASN1_STRING_FLAG_MSTRING>
+
+=item B<ASN1_STRING_FLAG_EMBED>
+
+=item B<ASN1_STRING_FLAG_BITS_LEFT>
+
+=back
 
 For the first four values, these were internal use flags which were never
 user settable in a way that would not cause things to break.


### PR DESCRIPTION
The long list of ASN1_STRING flags that are no longer public doesn't wrap in [the HTML docs](https://docs.openssl.org/4.0/man7/ossl-guide-migration/#the-asn1_string-type-is-now-opaque) for some reason. Removing the bold and adding a comma plus space solves the problem. 

Meanwhile, the long list of X509 functions comes with a suggestion to consult their manual pages, so I added links. Unfortunately some of these functions aren't documented and those links break. The ideal thing would be to document those functions, but that's a bigger bite that I intended to take. I've left off the links instead.

There's a short list of "un-constified" functions. I changed it to an itemized list. That's probably overkill for the really long lists, but it's nicer for short lists when reading.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
