### PR TITLE
[master, 4.0] Add `_get_osfhandle` to `util/platform_symbols/windows-symbols.txt`

### DIFF
--- a/util/platform_symbols/windows-symbols.txt
+++ b/util/platform_symbols/windows-symbols.txt
@@ -109,6 +109,7 @@ _execute_onexit_table
 _exit
 _fileno
 _fstat64i32
+_get_osfhandle
 _gmtime64_s
 _initialize_narrow_environment
 _initialize_onexit_table


### PR DESCRIPTION
Its usage has been introduced in commit b238d36c50a1 "Fix certificate read from stdin on Windows" and now `checkplatformsyms.pl` is complaining about it.
