### PR TITLE
[3.4, 3.3] Add `_get_osfhandle` to `util/platform_symbols/windows-symbols.txt`

### DIFF
--- a/util/platform_symbols/windows-symbols.txt
+++ b/util/platform_symbols/windows-symbols.txt
@@ -109,6 +109,7 @@ _execute_onexit_table
 _exit
 _fileno
 _fstat64i32
+_get_osfhandle
 _gmtime64_s
 _initialize_narrow_environment
 _initialize_onexit_table


### PR DESCRIPTION
This is a backport of [1] to `openssl-3.4` and `openssl-3.3`.

[1] https://github.com/openssl/openssl/pull/30634