### PR TITLE
Fix names of X509_V_ERR_ERROR_IN_CERT_* constants in man page

### DIFF
--- a/doc/man3/X509_check_certificate_times.pod
+++ b/doc/man3/X509_check_certificate_times.pod
@@ -89,9 +89,9 @@ value it points to will be set to an error code when the certificate
 is not temporally valid, or 0 when the certificate is temporally valid.
 
 The integer pointed to by I<error> will be set to
-X509_V_ERROR_ERROR_IN_CERT_NOT_BEFORE_FIELD
+X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD
 or
-X509_V_ERROR_ERROR_IN_CERT_NOT_AFTER_FIELD
+X509_V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD
 if the certificate has an invalid notBefore or notAfter field, respectively.
 
 The integer pointed to by I<error> will be set to


### PR DESCRIPTION
The names of the X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD and X509_V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD in the man page have the first _ERR_ spelt out as _ERROR_ instead.

##### Checklist
- [x] documentation is added or updated
