### PR TITLE
Setting statem.error_state more carefully in ssl_update_error_state()

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2271,14 +2271,13 @@ static void ssl_update_error_state(SSL_CONNECTION *sc)
     if (sc == NULL)
         return;
 
-    if (sc->statem.state == MSG_FLOW_ERROR) {
+    if (sc->statem.state == MSG_FLOW_ERROR
+        && sc->statem.error_state == ERROR_STATE_NOERROR) {
         l = ERR_peek_error();
-        if (l != 0) {
-            if (ERR_GET_LIB(l) == ERR_LIB_SYS)
-                sc->statem.error_state = ERROR_STATE_SYSCALL;
-            else
-                sc->statem.error_state = ERROR_STATE_SSL;
-        }
+        if (l == 0 || ERR_GET_LIB(l) == ERR_LIB_SYS)
+            sc->statem.error_state = ERROR_STATE_SYSCALL;
+        else
+            sc->statem.error_state = ERROR_STATE_SSL;
     }
 }
 


### PR DESCRIPTION
Don't change error_state if it's already set.
Set ERROR_STATE_SYSCALL if the error stack is empty.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
