### PR TITLE
ci: Fix CYGWIN build

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -216,7 +216,11 @@ jobs:
 #    - name: Clone repo
 #      run: bash -c "pwd && git clone --branch ${{ github.ref_name }} --depth 1 https://github.com/${{ github.repository }}.git"
     - name: Full build
-      run: bash -c "gcc --version && ./config ${{ matrix.platform.config }} && make $MAKE_PARAMS"
+      shell: bash
+      run: |
+        gcc --version
+        ./config ${{ matrix.platform.config }}
+        make $MAKE_PARAMS
 # Disable testing for now. TBD: Need local cygwin installation to debug .
 #    - name: Run openssl tests
 #      run: bash -c "cd openssl && make V=1 test"


### PR DESCRIPTION
The build should run with -j4 option, but this option was never propagated to run command (lost in Powershell).

Just set bash as shell here. This speedups CYGWIN CI build significantly.
(cca from 40 minutes to 15)
