### PR TITLE
Make error message helpful when country code exceeds 2 characters

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2147,6 +2147,9 @@ X509_NAME *parse_name(const char *cp, int chtype, int canmulti,
             BIO_printf(bio_err,
                 "%s: Error adding %s name attribute \"/%s=%s\"\n",
                 opt_getprog(), desc, typestr, valstr);
+            if (strcmp(typestr, "C") == 0) {
+            BIO_printf(bio_err, "Country Code should only be two characters.\n");
+            }
             goto err;
         }
     }

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2148,7 +2148,7 @@ X509_NAME *parse_name(const char *cp, int chtype, int canmulti,
                 "%s: Error adding %s name attribute \"/%s=%s\"\n",
                 opt_getprog(), desc, typestr, valstr);
             if (strcmp(typestr, "C") == 0) {
-            BIO_printf(bio_err, "Country Code should only be two characters.\n");
+                BIO_printf(bio_err, "Country Code should only be two characters.\n");
             }
             goto err;
         }

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -501,6 +501,25 @@ subtest "generating certificate requests with SLH-DSA" => sub {
     }
 };
 
+subtest "error message when country code exceeds 2 characters" => sub {
+    plan tests => 1;
+
+    my $errfile = "req-country-code.err";
+
+    ok(!run(app(["openssl", "req",
+                 "-newkey", "rsa:2048",
+                 "-nodes", 
+                 "-keyout", "server.key", 
+                 "-x509", 
+                 "-days", "365",
+                 "-out", "server.crt",
+                 "-subj", "/C=Foo/ST=St/L=Loc/O=Org/OU=mlaunch/CN=localhost"])
+            stderr => $errfile),
+       "Checking that character length of country code fails");
+
+    unlink $errfile;
+};
+
 my @openssl_args = ("req", "-config", srctop_file("apps", "openssl.cnf"));
 
 run_conversion('req conversions',


### PR DESCRIPTION
Fixes #7337 

We (@mjw6944, @finchsdarwin, and @Szheng25) added a message informing the user that country codes should be 2 characters when there is an error with the country code value during certificate creation via the openssl command line tool. 

Input is validated based on if `typestr` is equal to `"C"` and the value does not meet the required 2 character country code format, then the error message "Country code must be exactly two characters." is displayed.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] error message is helpful
- [ ] unit tests are added