### PR TITLE
evp_test.c: Check error stack for new errors and not stale ones

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -1273,18 +1273,23 @@ static int cipher_test_enc(EVP_TEST *t, int enc, size_t out_misalign,
     if (expected->iv != NULL) {
         /* Some (e.g., GCM) tests use IVs longer than EVP_MAX_IV_LENGTH. */
         unsigned char iv[128];
+
+        ERR_set_mark();
         if (!TEST_true(EVP_CIPHER_CTX_get_updated_iv(ctx_base, iv, sizeof(iv)))
             || ((EVP_CIPHER_get_flags(expected->cipher) & EVP_CIPH_CUSTOM_IV) == 0
                 && !TEST_mem_eq(expected->iv, expected->iv_len, iv,
                     expected->iv_len))) {
             t->err = "INVALID_IV";
+            ERR_clear_last_mark();
             goto err;
         } else {
-            if (fips_no_silent_error && !TEST_false(ERR_peek_error())) {
+            if (fips_no_silent_error && !TEST_int_eq(ERR_count_to_mark(), 0)) {
                 t->err = "GET_UPDATED_IV_SILENT_ERROR";
+                ERR_clear_last_mark();
                 goto err;
             }
         }
+        ERR_clear_last_mark();
     }
 
     /* Test that the cipher dup functions correctly if it is supported */
@@ -1571,17 +1576,21 @@ static int cipher_test_enc(EVP_TEST *t, int enc, size_t out_misalign,
     if (expected->next_iv != NULL) {
         /* Some (e.g., GCM) tests use IVs longer than EVP_MAX_IV_LENGTH. */
         unsigned char iv[128];
+        ERR_set_mark();
         if (!TEST_true(EVP_CIPHER_CTX_get_updated_iv(ctx, iv, sizeof(iv)))
             || !TEST_mem_eq(expected->next_iv, expected->iv_len, iv,
                 expected->iv_len)) {
             t->err = "INVALID_NEXT_IV";
+            ERR_clear_last_mark();
             goto err;
         } else {
-            if (fips_no_silent_error && !TEST_false(ERR_peek_error())) {
+            if (fips_no_silent_error && !TEST_int_eq(ERR_count_to_mark(), 0)) {
                 t->err = "GET_UPDATED_IV_SILENT_ERROR";
+                ERR_clear_last_mark();
                 goto err;
             }
         }
+        ERR_clear_last_mark();
     }
 
     t->err = NULL;


### PR DESCRIPTION
The error stack might have stale entries but
we are interested only in those coming from the
EVP call being tested.

Fixes #30454

This is an alternative to #30494. Not necessarily exclusive alternative but I am afraid of the side effects from #30494.
