### PR TITLE
Add freezing callbacks to the `evp_generic_do_all`

### DIFF
--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -622,7 +622,9 @@ void EVP_ASYM_CIPHER_do_all_provided(OSSL_LIB_CTX *libctx,
         (void (*)(void *, void *))fn, arg,
         evp_asym_cipher_from_algorithm,
         evp_asym_cipher_up_ref,
-        evp_asym_cipher_free);
+        evp_asym_cipher_free,
+        evp_asym_cipher_dup_frozen,
+        evp_asym_cipher_frozen_free);
 }
 
 int EVP_ASYM_CIPHER_names_do_all(const EVP_ASYM_CIPHER *cipher,

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -1168,7 +1168,11 @@ void EVP_MD_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_DIGEST,
         (void (*)(void *, void *))fn, arg,
-        evp_md_from_algorithm, evp_md_up_ref, evp_md_free);
+        evp_md_from_algorithm,
+        evp_md_up_ref,
+        evp_md_free,
+        evp_md_dup_frozen,
+        (void (*)(void *))evp_md_frozen_free);
 }
 
 EVP_MD *evp_digest_fetch_from_prov(OSSL_PROVIDER *prov,

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -2112,6 +2112,9 @@ void EVP_CIPHER_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_CIPHER,
         (void (*)(void *, void *))fn, arg,
-        evp_cipher_from_algorithm, evp_cipher_up_ref,
-        evp_cipher_free);
+        evp_cipher_from_algorithm,
+        evp_cipher_up_ref,
+        evp_cipher_free,
+        evp_cipher_dup_frozen,
+        evp_cipher_frozen_free);
 }

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -755,7 +755,9 @@ void evp_generic_do_all(OSSL_LIB_CTX *libctx, int operation_id,
         const OSSL_ALGORITHM *algodef,
         OSSL_PROVIDER *prov),
     int (*up_ref_method)(void *),
-    void (*free_method)(void *))
+    void (*free_method)(void *),
+    void *(*dup_method)(void *),
+    void (*dup_free_method)(void *))
 {
     struct evp_method_data_st methdata;
     struct filter_data_st data;
@@ -763,7 +765,7 @@ void evp_generic_do_all(OSSL_LIB_CTX *libctx, int operation_id,
     methdata.libctx = libctx;
     methdata.tmp_store = NULL;
     (void)inner_evp_generic_fetch(&methdata, NULL, operation_id, NULL, NULL,
-        new_method, up_ref_method, free_method, NULL, NULL);
+        new_method, up_ref_method, free_method, dup_method, dup_free_method);
 
     data.operation_id = operation_id;
     data.user_fn = user_fn;

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -365,7 +365,9 @@ void evp_generic_do_all(OSSL_LIB_CTX *libctx, int operation_id,
         const OSSL_ALGORITHM *algodef,
         OSSL_PROVIDER *prov),
     int (*up_ref_method)(void *),
-    void (*free_method)(void *));
+    void (*free_method)(void *),
+    void *(*dup_method)(void *),
+    void (*dup_free_method)(void *));
 
 /* Internal fetchers for method types that are to be combined with others */
 EVP_KEYMGMT *evp_keymgmt_fetch_by_number(OSSL_LIB_CTX *ctx, int name_id,

--- a/crypto/evp/evp_rand.c
+++ b/crypto/evp/evp_rand.c
@@ -526,7 +526,9 @@ void EVP_RAND_do_all_provided(OSSL_LIB_CTX *libctx,
     evp_generic_do_all(libctx, OSSL_OP_RAND,
         (void (*)(void *, void *))fn, arg,
         evp_rand_from_algorithm, evp_rand_up_ref,
-        evp_rand_free);
+        evp_rand_free,
+        evp_rand_dup_frozen,
+        evp_rand_frozen_free);
 }
 
 int EVP_RAND_names_do_all(const EVP_RAND *rand,

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -744,7 +744,9 @@ void EVP_KEYEXCH_do_all_provided(OSSL_LIB_CTX *libctx,
         (void (*)(void *, void *))fn, arg,
         evp_keyexch_from_algorithm,
         evp_keyexch_up_ref,
-        evp_keyexch_free);
+        evp_keyexch_free,
+        evp_keyexch_dup_frozen,
+        evp_keyexch_frozen_free);
 }
 
 int EVP_KEYEXCH_names_do_all(const EVP_KEYEXCH *keyexch,

--- a/crypto/evp/kdf_meth.c
+++ b/crypto/evp/kdf_meth.c
@@ -294,5 +294,9 @@ void EVP_KDF_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_KDF,
         (void (*)(void *, void *))fn, arg,
-        evp_kdf_from_algorithm, evp_kdf_up_ref, evp_kdf_free);
+        evp_kdf_from_algorithm,
+        evp_kdf_up_ref,
+        evp_kdf_free,
+        evp_kdf_dup_frozen,
+        (void (*)(void *))evp_kdf_frozen_free);
 }

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -564,7 +564,9 @@ void EVP_KEM_do_all_provided(OSSL_LIB_CTX *libctx,
     evp_generic_do_all(libctx, OSSL_OP_KEM, (void (*)(void *, void *))fn, arg,
         evp_kem_from_algorithm,
         evp_kem_up_ref,
-        evp_kem_free);
+        evp_kem_free,
+        evp_kem_dup_frozen,
+        evp_kem_frozen_free);
 }
 
 int EVP_KEM_names_do_all(const EVP_KEM *kem,

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -410,7 +410,9 @@ void EVP_KEYMGMT_do_all_provided(OSSL_LIB_CTX *libctx,
         (void (*)(void *, void *))fn, arg,
         keymgmt_from_algorithm,
         evp_keymgmt_up_ref,
-        evp_keymgmt_free);
+        evp_keymgmt_free,
+        evp_keymgmt_dup_frozen,
+        evp_keymgmt_frozen_free);
 }
 
 int EVP_KEYMGMT_names_do_all(const EVP_KEYMGMT *keymgmt,

--- a/crypto/evp/mac_meth.c
+++ b/crypto/evp/mac_meth.c
@@ -310,7 +310,11 @@ void EVP_MAC_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_MAC,
         (void (*)(void *, void *))fn, arg,
-        evp_mac_from_algorithm, evp_mac_up_ref, evp_mac_free);
+        evp_mac_from_algorithm,
+        evp_mac_up_ref,
+        evp_mac_free,
+        evp_mac_dup_frozen,
+        evp_mac_frozen_free);
 }
 
 EVP_MAC *evp_mac_fetch_from_prov(OSSL_PROVIDER *prov,

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -538,7 +538,10 @@ void EVP_SIGNATURE_do_all_provided(OSSL_LIB_CTX *libctx,
         (void (*)(void *, void *))fn, arg,
         evp_signature_from_algorithm,
         evp_signature_up_ref,
-        evp_signature_free);
+        evp_signature_free,
+        /* TODO(FREEZE): Add callbacks to evp_generic_do_all */
+        NULL,
+        NULL);
 }
 
 int EVP_SIGNATURE_names_do_all(const EVP_SIGNATURE *signature,

--- a/crypto/evp/skeymgmt_meth.c
+++ b/crypto/evp/skeymgmt_meth.c
@@ -203,7 +203,10 @@ void EVP_SKEYMGMT_do_all_provided(OSSL_LIB_CTX *libctx,
         (void (*)(void *, void *))fn, arg,
         skeymgmt_from_algorithm,
         (int (*)(void *))EVP_SKEYMGMT_up_ref,
-        (void (*)(void *))EVP_SKEYMGMT_free);
+        (void (*)(void *))EVP_SKEYMGMT_free,
+        /* TODO(FREEZE): Add callbacks to evp_generic_do_all */
+        NULL,
+        NULL);
 }
 
 int EVP_SKEYMGMT_names_do_all(const EVP_SKEYMGMT *skeymgmt,


### PR DESCRIPTION
If the `evp_generic_do_all` function is called before the freeze, it will populate the method store with objects that do not have frozen methods

Will wait until https://github.com/openssl/project/issues/1836 and https://github.com/openssl/project/issues/1889 are merged to get this in

Fixes https://github.com/openssl/project/issues/1878