### PR TITLE
Fix regression of memory allocator functions on s390x

### DIFF
--- a/crypto/s390xcap.c
+++ b/crypto/s390xcap.c
@@ -221,7 +221,7 @@ void OPENSSL_cpuid_setup(void)
         OPENSSL_s390xcex = -1;
     } else {
         OPENSSL_s390xcex = open("/dev/z90crypt", O_RDWR | O_CLOEXEC);
-        OPENSSL_atexit(OPENSSL_s390x_cleanup);
+        atexit(OPENSSL_s390x_cleanup);
     }
     OPENSSL_s390xcex_nodev = 0;
 #endif


### PR DESCRIPTION
OPENSSL_atexit() cannot be called from OPENSSL_cpuid_setup() as that is a constructor.

Urgent as it is a CI fix for https://github.com/openssl/openssl/actions/runs/23950823631/job/69857646733