### PR TITLE
doc: correct X509v3_get_ext_by_NID.pod to reflect CRL/REVOKED extensi…

### DIFF
--- a/doc/man3/X509v3_get_ext_by_NID.pod
+++ b/doc/man3/X509v3_get_ext_by_NID.pod
@@ -104,18 +104,21 @@ that has the same OID as a pre-existing one replaces this earlier one.
 X509_get_ext_count(), X509_get_ext(), X509_get_ext_by_NID(),
 X509_get_ext_by_OBJ(), X509_get_ext_by_critical(), X509_delete_ext()
 and X509_add_ext() operate on the extensions of certificate I<x>. They are
-otherwise identical to the X509v3 functions.
+otherwise identical to the X509v3 functions except that X509_delete_ext()
+behaves like X509v3_delete_extension().
 
 X509_CRL_get_ext_count(), X509_CRL_get_ext(), X509_CRL_get_ext_by_NID(),
 X509_CRL_get_ext_by_OBJ(), X509_CRL_get_ext_by_critical(),
 X509_CRL_delete_ext() and X509_CRL_add_ext() operate on the extensions of
-CRL I<x>. They are otherwise identical to the X509v3 functions.
+CRL I<x>. They are otherwise identical to the X509v3 functions except that
+X509_CRL_delete_ext() behaves like X509v3_delete_extension().
 
 X509_REVOKED_get_ext_count(), X509_REVOKED_get_ext(),
 X509_REVOKED_get_ext_by_NID(), X509_REVOKED_get_ext_by_OBJ(),
 X509_REVOKED_get_ext_by_critical(), X509_REVOKED_delete_ext() and
 X509_REVOKED_add_ext() operate on the extensions of CRL entry I<x>.
-They are otherwise identical to the X509v3 functions.
+They are otherwise identical to the X509v3 functions except that
+X509_REVOKED_delete_ext() behaves like X509v3_delete_extension().
 
 =head1 NOTES
 
@@ -135,6 +138,8 @@ X509v3_delete_ext() and its variants are a bit counter-intuitive
 because these functions do not free the extension they delete.
 They return an B<X509_EXTENSION> object which must be explicitly freed
 using X509_EXTENSION_free().
+X509v3_delete_extension() behaves similarly, but it may also deallocate
+the extension stack if it becomes empty, setting it to NULL.
 
 X509v3_add_ext(), X509v3_add_extensions() and X509_add_ext() ignore any
 B<empty> values of the C<subjectKeyIdentifier> (empty OCTET STRING) or the


### PR DESCRIPTION
The man page previously stated that X509_CRL_delete_ext() and X509_REVOKED_add_ext() are 'otherwise identical to the X509v3 functions,' which is inaccurate. These routines use X509v3_delete_extension(), not X509v3_delete_ext(), following the changes in #30350 and #30518. Update the documentation to accurately describe this difference.

Fixes or Updates Issue #30518 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
