### PR TITLE
Fix signed integer overflow in OPENSSL_asc2uni()

### DIFF
--- a/crypto/pkcs12/p12_utl.c
+++ b/crypto/pkcs12/p12_utl.c
@@ -25,6 +25,8 @@ unsigned char *OPENSSL_asc2uni(const char *asc, int asclen,
         asclen = (int)strlen(asc);
     if (asclen < 0)
         return NULL;
+    if (asclen > (INT_MAX - 2) / 2)
+        return NULL;
     ulen = asclen * 2 + 2;
     if ((unitmp = OPENSSL_malloc(ulen)) == NULL)
         return NULL;

--- a/test/pkcs12_api_test.c
+++ b/test/pkcs12_api_test.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <limits.h>
 
 #include "internal/nelem.h"
 
@@ -309,6 +310,35 @@ err:
     return ret;
 }
 
+static int test_asc2uni_overflow(void)
+{
+    unsigned char *result = NULL;
+    int unilen = 0;
+
+    /* asclen = INT_MAX/2 + 1 causes asclen * 2 + 2 to overflow int */
+    result = OPENSSL_asc2uni("A", INT_MAX / 2 + 1, &result, &unilen);
+    if (!TEST_ptr_null(result))
+        return 0;
+
+    /* asclen = INT_MAX also overflows */
+    result = OPENSSL_asc2uni("A", INT_MAX, &result, &unilen);
+    if (!TEST_ptr_null(result))
+        return 0;
+
+    /* asclen = INT_MAX/2 is the boundary: (INT_MAX/2)*2+2 fits in int */
+    /* We cannot actually allocate ~2GB so just verify the overflow check */
+    /* does not reject values at or below the safe boundary. */
+    /* asclen = 0 should succeed (just null terminator) */
+    result = OPENSSL_asc2uni("", 0, &result, &unilen);
+    if (!TEST_ptr(result))
+        return 0;
+    if (!TEST_int_eq(unilen, 2))
+        return 0;
+    OPENSSL_free(result);
+
+    return 1;
+}
+
 int setup_tests(void)
 {
     OPTION_CHOICE o;
@@ -350,6 +380,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(pkcs12_create_ex2_test, 3);
     ADD_TEST(test_PKCS12_set_pbmac1_pbkdf2_saltlen_zero);
     ADD_TEST(test_PKCS12_set_pbmac1_pbkdf2_invalid_saltlen);
+    ADD_TEST(test_asc2uni_overflow);
     return 1;
 }
 


### PR DESCRIPTION
## Summary

`OPENSSL_asc2uni()` in `crypto/pkcs12/p12_utl.c` computes `asclen * 2 + 2` using `int` arithmetic. When `asclen > INT_MAX/2`, this overflows, producing a negative or small value that is then passed to `OPENSSL_malloc()`. On 32-bit platforms this could lead to a small allocation followed by a heap buffer overflow in the copy loop.

- Add a check that `asclen` does not exceed `(INT_MAX - 2) / 2` before the multiplication
- Add a regression test in `test/pkcs12_api_test.c` (`test_asc2uni_overflow`)

As noted, this is primarily relevant on 32-bit platforms where a ~1GB PKCS#12 input would be needed, but the safety check should be present regardless.

## Test plan

- [x] `test_asc2uni_overflow` verifies `asclen = INT_MAX/2 + 1` returns NULL
- [x] `test_asc2uni_overflow` verifies `asclen = INT_MAX` returns NULL
- [x] `test_asc2uni_overflow` verifies `asclen = 0` still succeeds