### PR TITLE
Fix missing bounds check in GCM setivinv()

### DIFF
--- a/providers/implementations/ciphers/ciphercommon_gcm.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2019-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -135,6 +135,9 @@ static int setivinv(PROV_GCM_CTX *ctx, unsigned char *in, size_t inl)
     if (!ctx->iv_gen
         || !ctx->key_set
         || ctx->enc)
+        return 0;
+
+    if (inl == 0 || inl > ctx->ivlen)
         return 0;
 
     memcpy(ctx->iv + ctx->ivlen - inl, in, inl);

--- a/test/aesgcmtest.c
+++ b/test/aesgcmtest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2019-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -8,6 +8,8 @@
  */
 
 #include <openssl/evp.h>
+#include <openssl/core_names.h>
+#include <openssl/params.h>
 #include "testutil.h"
 
 static const unsigned char gcm_key[] = {
@@ -136,10 +138,80 @@ static int ivgen_test(void)
         && do_decrypt(iv_gen, ct, ctlen, tag, taglen);
 }
 
+/*
+ * Test that setivinv() rejects inl values that would cause integer underflow.
+ *
+ * Prior to the fix, setivinv() computed `ctx->iv + ctx->ivlen - inl` without
+ * checking whether inl > ctx->ivlen.  For AES-256-GCM the default ivlen is 12;
+ * passing inl=64 wraps the size_t subtraction and causes an out-of-bounds write
+ * via memcpy.  The fix adds `if (inl == 0 || inl > ctx->ivlen) return 0;`.
+ */
+static int setivinv_bounds_test(void)
+{
+    int ret = 0;
+    EVP_CIPHER_CTX *ctx = NULL;
+    EVP_CIPHER *cipher = NULL;
+    unsigned char key[32] = { 0 };
+    /* fixed part of the TLS IV (4 bytes for GCM) */
+    unsigned char fixed_iv[4] = { 0x01, 0x02, 0x03, 0x04 };
+    /* A buffer larger than the default GCM ivlen (12 bytes) */
+    unsigned char big_ivinv[64];
+    /* A buffer exactly ivlen bytes */
+    unsigned char exact_ivinv[12];
+    OSSL_PARAM params[2];
+
+    memset(big_ivinv, 'A', sizeof(big_ivinv));
+    memset(exact_ivinv, 'B', sizeof(exact_ivinv));
+
+    if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new())
+        || !TEST_ptr(cipher = EVP_CIPHER_fetch(NULL, "AES-256-GCM", NULL)))
+        goto err;
+
+    /* Initialise decryption with a key so that key_set=1, enc=0 */
+    if (!TEST_true(EVP_DecryptInit_ex2(ctx, cipher, key, NULL, NULL) > 0))
+        goto err;
+
+    /* Set fixed IV portion: this sets ctx->iv_gen=1 */
+    if (!TEST_int_gt(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IV_FIXED,
+                         (int)sizeof(fixed_iv), fixed_iv),
+            0))
+        goto err;
+
+    /* --- Negative: inl == 0 must be rejected --- */
+    params[0] = OSSL_PARAM_construct_octet_string(
+        OSSL_CIPHER_PARAM_AEAD_TLS1_SET_IV_INV, big_ivinv, 0);
+    params[1] = OSSL_PARAM_construct_end();
+    if (!TEST_false(EVP_CIPHER_CTX_set_params(ctx, params)))
+        goto err;
+
+    /* --- Negative: inl > ivlen (64 > 12) must be rejected --- */
+    params[0] = OSSL_PARAM_construct_octet_string(
+        OSSL_CIPHER_PARAM_AEAD_TLS1_SET_IV_INV,
+        big_ivinv, sizeof(big_ivinv));
+    params[1] = OSSL_PARAM_construct_end();
+    if (!TEST_false(EVP_CIPHER_CTX_set_params(ctx, params)))
+        goto err;
+
+    /* --- Positive: inl == ivlen (12 == 12) must be accepted --- */
+    params[0] = OSSL_PARAM_construct_octet_string(
+        OSSL_CIPHER_PARAM_AEAD_TLS1_SET_IV_INV,
+        exact_ivinv, sizeof(exact_ivinv));
+    params[1] = OSSL_PARAM_construct_end();
+    if (!TEST_true(EVP_CIPHER_CTX_set_params(ctx, params)))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_CIPHER_CTX_free(ctx);
+    EVP_CIPHER_free(cipher);
+    return ret;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(kat_test);
     ADD_TEST(badkeylen_test);
     ADD_TEST(ivgen_test);
+    ADD_TEST(setivinv_bounds_test);
     return 1;
 }


### PR DESCRIPTION
setivinv() computes ctx->iv + ctx->ivlen - inl without verifying
that inl <= ctx->ivlen.  Since both values are size_t, the subtraction
wraps around when inl > ctx->ivlen, causing memcpy to write to an
out-of-bounds address.  For example, with the default GCM ivlen of 12
and inl of 64, the destination offset wraps to 0xFFFFFFFFFFFFFFCC.

Add a bounds check rejecting inl == 0 and inl > ctx->ivlen.

Fixes: 11b4435986 ("Add GCM support for EVP_CTRL_GCM_IV_GEN and EVP_CTRL_GCM_SET_IV_INV to providers")