### PR TITLE
Fix signed integer overflow in OPENSSL_asc2uni()

### DIFF
--- a/crypto/pkcs12/p12_utl.c
+++ b/crypto/pkcs12/p12_utl.c
@@ -8,25 +8,37 @@
  */
 
 #include <stdio.h>
+#include <limits.h>
 #include "internal/cryptlib.h"
+#include "internal/safe_math.h"
 #include <openssl/pkcs12.h>
 #include "p12_local.h"
 #include "crypto/pkcs7/pk7_local.h"
 #include <crypto/asn1.h>
+
+OSSL_SAFE_MATH_SIGNED(int, int)
 
 /* Cheap and nasty Unicode stuff */
 
 unsigned char *OPENSSL_asc2uni(const char *asc, int asclen,
     unsigned char **uni, int *unilen)
 {
-    int ulen, i;
+    int ulen, i, err = 0;
     unsigned char *unitmp;
 
-    if (asclen == -1)
-        asclen = (int)strlen(asc);
+    if (asclen == -1) {
+        size_t len = strlen(asc);
+
+        if (len > INT_MAX)
+            return NULL;
+        asclen = (int)len;
+    }
     if (asclen < 0)
         return NULL;
-    ulen = asclen * 2 + 2;
+    /* If this changes, revisit test_safe_math_asc2uni_boundary() */
+    ulen = safe_add_int(safe_mul_int(asclen, 2, &err), 2, &err);
+    if (err)
+        return NULL;
     if ((unitmp = OPENSSL_malloc(ulen)) == NULL)
         return NULL;
     for (i = 0; i < ulen - 2; i += 2) {

--- a/include/internal/safe_math.h
+++ b/include/internal/safe_math.h
@@ -405,8 +405,8 @@
     }
 
 /* Calculate ranges of types */
-#define OSSL_SAFE_MATH_MINS(type) ((type)1 << (sizeof(type) * 8 - 1))
-#define OSSL_SAFE_MATH_MAXS(type) (~OSSL_SAFE_MATH_MINS(type))
+#define OSSL_SAFE_MATH_MAXS(type) ((type)((((type)1 << (sizeof(type) * 8 - 2)) - 1) * 2 + 1))
+#define OSSL_SAFE_MATH_MINS(type) (-OSSL_SAFE_MATH_MAXS(type) - 1)
 #define OSSL_SAFE_MATH_MAXU(type) (~(type)0)
 
 /*

--- a/test/pkcs12_api_test.c
+++ b/test/pkcs12_api_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2022-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -10,8 +10,10 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <limits.h>
 
 #include "internal/nelem.h"
+#include "internal/safe_math.h"
 
 #include <openssl/pkcs12.h>
 #include <openssl/x509.h>
@@ -23,6 +25,8 @@
 
 static OSSL_LIB_CTX *testctx = NULL;
 static OSSL_PROVIDER *nullprov = NULL;
+
+OSSL_SAFE_MATH_SIGNED(int, int)
 
 static int test_null_args(void)
 {
@@ -309,6 +313,69 @@ err:
     return ret;
 }
 
+/*
+ * The largest asclen that does not overflow is (INT_MAX - 2) / 2, since
+ * OPENSSL_asc2uni() computes asclen * 2 + 2.  Anything larger overflows.
+ */
+static int test_asc2uni_overflow(void)
+{
+    unsigned char *result = NULL;
+    int unilen = 0;
+    int ret = 0;
+
+    /* (INT_MAX - 2) / 2 + 1 is the smallest asclen that overflows */
+    result = OPENSSL_asc2uni("A", (INT_MAX - 2) / 2 + 1, &result, &unilen);
+    if (!TEST_ptr_null(result))
+        goto err;
+
+    /* asclen = INT_MAX/2 overflows */
+    result = OPENSSL_asc2uni("A", INT_MAX / 2, &result, &unilen);
+    if (!TEST_ptr_null(result))
+        goto err;
+
+    /* asclen = INT_MAX also overflows */
+    result = OPENSSL_asc2uni("A", INT_MAX, &result, &unilen);
+    if (!TEST_ptr_null(result))
+        goto err;
+
+    /* asclen = 0 should succeed (just null terminator) */
+    result = OPENSSL_asc2uni("", 0, &result, &unilen);
+    if (!TEST_ptr(result))
+        goto err;
+    if (!TEST_int_eq(unilen, 2))
+        goto err;
+
+    ret = 1;
+err:
+    OPENSSL_free(result);
+    return ret;
+}
+
+/*
+ * Positive test for the largest valid input.  Allocating a buffer for an
+ * INT_MAX-sized BMPString is impractical, so the boundary arithmetic that
+ * OPENSSL_asc2uni() performs is tested directly here.  If the computation in
+ * OPENSSL_asc2uni() changes, this test needs to be updated to match.
+ */
+static int test_safe_math_asc2uni_boundary(void)
+{
+    int err = 0;
+    int ulen;
+    int max_valid = (INT_MAX - 2) / 2;
+
+    /* Largest valid input: result fits in an int, no overflow */
+    ulen = safe_add_int(safe_mul_int(max_valid, 2, &err), 2, &err);
+    if (!TEST_false(err))
+        return 0;
+    if (!TEST_int_eq(ulen, max_valid * 2 + 2))
+        return 0;
+
+    /* One past the largest valid input overflows */
+    err = 0;
+    ulen = safe_add_int(safe_mul_int(max_valid + 1, 2, &err), 2, &err);
+    return TEST_true(err);
+}
+
 int setup_tests(void)
 {
     OPTION_CHOICE o;
@@ -350,6 +417,8 @@ int setup_tests(void)
     ADD_ALL_TESTS(pkcs12_create_ex2_test, 3);
     ADD_TEST(test_PKCS12_set_pbmac1_pbkdf2_saltlen_zero);
     ADD_TEST(test_PKCS12_set_pbmac1_pbkdf2_invalid_saltlen);
+    ADD_TEST(test_asc2uni_overflow);
+    ADD_TEST(test_safe_math_asc2uni_boundary);
     return 1;
 }
 


### PR DESCRIPTION
When asclen is large, the expression asclen * 2 + 2 overflows a signed
int.  This causes OPENSSL_malloc to receive a small (or zero) size
while the subsequent copy loop writes asclen * 2 bytes, resulting in a
heap buffer overflow.

Add a check that asclen does not exceed (INT_MAX - 2) / 2 before the
multiplication.