### PR TITLE
SSL_use_cert_and_key NPE with provided keys (3.3)

### DIFF
--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -1010,7 +1010,9 @@ static int ssl_set_cert_and_key(SSL *ssl, SSL_CTX *ctx, X509 *x509, EVP_PKEY *pr
             goto out;
         }
     }
-    if (ssl_cert_lookup_by_pkey(pubkey, &i, ctx) == NULL) {
+    if (ssl_cert_lookup_by_pkey(pubkey, &i,
+            sc != NULL ? SSL_CONNECTION_GET_CTX(sc) : ctx)
+        == NULL) {
         ERR_raise(ERR_LIB_SSL, SSL_R_UNKNOWN_CERTIFICATE_TYPE);
         goto out;
     }


### PR DESCRIPTION
Backport from master sans test changes which require ML-DSA support, so 3.5 or later.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
