### PR TITLE
asn1: use ASN1_STRING accessors in dh, dsa, ec, evp, pkcs12, providers

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -25,8 +25,6 @@
 #include <openssl/ocsp.h>
 #include <openssl/pem.h>
 
-#include <crypto/asn1.h>
-
 #ifndef W_OK
 #ifdef OPENSSL_SYS_VMS
 #include <unistd.h>

--- a/crypto/dh/dh_ameth.c
+++ b/crypto/dh/dh_ameth.c
@@ -21,9 +21,9 @@
 #include <openssl/param_build.h>
 #include "internal/ffc.h"
 #include "internal/cryptlib.h"
-#include "crypto/asn1.h"
 #include "crypto/dh.h"
 #include "crypto/evp.h"
+#include "crypto/asn1.h"
 #include "dh_local.h"
 
 /*
@@ -79,8 +79,8 @@ static int dh_pub_decode(EVP_PKEY *pkey, const X509_PUBKEY *pubkey)
     }
 
     pstr = pval;
-    pm = pstr->data;
-    pmlen = pstr->length;
+    pm = ASN1_STRING_get0_data(pstr);
+    pmlen = ASN1_STRING_length(pstr);
 
     if ((dh = d2i_dhp(pkey, &pm, pmlen)) == NULL) {
         ERR_raise(ERR_LIB_DH, DH_R_DECODE_ERROR);
@@ -124,10 +124,15 @@ static int dh_pub_encode(X509_PUBKEY *pk, const EVP_PKEY *pkey)
         ERR_raise(ERR_LIB_DH, ERR_R_ASN1_LIB);
         goto err;
     }
-    str->length = i2d_dhp(pkey, dh, &str->data);
-    if (str->length <= 0) {
-        ERR_raise(ERR_LIB_DH, ERR_R_ASN1_LIB);
-        goto err;
+    {
+        unsigned char *strdata = NULL;
+        int strsize = i2d_dhp(pkey, dh, &strdata);
+        if (strsize <= 0) {
+            OPENSSL_free(strdata);
+            ERR_raise(ERR_LIB_DH, ERR_R_ASN1_LIB);
+            goto err;
+        }
+        ASN1_STRING_set0(str, strdata, strsize);
     }
     ptype = V_ASN1_SEQUENCE;
 
@@ -181,19 +186,23 @@ static int dh_priv_encode(PKCS8_PRIV_KEY_INFO *p8, const EVP_PKEY *pkey)
     unsigned char *dp = NULL;
     int dplen;
 
-    params = ASN1_STRING_new();
+    params = ASN1_STRING_type_new(V_ASN1_SEQUENCE);
 
     if (params == NULL) {
         ERR_raise(ERR_LIB_DH, ERR_R_ASN1_LIB);
         goto err;
     }
 
-    params->length = i2d_dhp(pkey, pkey->pkey.dh, &params->data);
-    if (params->length <= 0) {
-        ERR_raise(ERR_LIB_DH, ERR_R_ASN1_LIB);
-        goto err;
+    {
+        unsigned char *paramsdata = NULL;
+        int paramssize = i2d_dhp(pkey, pkey->pkey.dh, &paramsdata);
+        if (paramssize <= 0) {
+            OPENSSL_free(paramsdata);
+            ERR_raise(ERR_LIB_DH, ERR_R_ASN1_LIB);
+            goto err;
+        }
+        ASN1_STRING_set0(params, paramsdata, paramssize);
     }
-    params->type = V_ASN1_SEQUENCE;
 
     /* Get private key into integer */
     prkey = BN_to_ASN1_INTEGER(pkey->pkey.dh->priv_key, NULL);

--- a/crypto/dh/dh_backend.c
+++ b/crypto/dh/dh_backend.c
@@ -22,8 +22,6 @@
 #include "crypto/dh.h"
 #include "dh_local.h"
 
-#include <crypto/asn1.h>
-
 /*
  * The intention with the "backend" source file is to offer backend functions
  * for legacy backends (EVP_PKEY_ASN1_METHOD) and provider implementations
@@ -204,8 +202,8 @@ DH *ossl_dh_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
         goto decerr;
 
     pstr = pval;
-    pm = pstr->data;
-    pmlen = pstr->length;
+    pm = ASN1_STRING_get0_data(pstr);
+    pmlen = ASN1_STRING_length(pstr);
     switch (OBJ_obj2nid(palg->algorithm)) {
     case NID_dhKeyAgreement:
         dh = d2i_DHparams(NULL, &pm, pmlen);

--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -20,9 +20,9 @@
 #include <openssl/core_names.h>
 #include <openssl/param_build.h>
 #include "internal/cryptlib.h"
-#include "crypto/asn1.h"
 #include "crypto/dsa.h"
 #include "crypto/evp.h"
+#include "crypto/asn1.h"
 #include "internal/ffc.h"
 #include "dsa_local.h"
 
@@ -44,8 +44,8 @@ static int dsa_pub_decode(EVP_PKEY *pkey, const X509_PUBKEY *pubkey)
 
     if (ptype == V_ASN1_SEQUENCE) {
         pstr = pval;
-        pm = pstr->data;
-        pmlen = pstr->length;
+        pm = ASN1_STRING_get0_data(pstr);
+        pmlen = ASN1_STRING_length(pstr);
 
         if ((dsa = d2i_DSAparams(NULL, &pm, pmlen)) == NULL) {
             ERR_raise(ERR_LIB_DSA, DSA_R_DECODE_ERROR);
@@ -103,10 +103,15 @@ static int dsa_pub_encode(X509_PUBKEY *pk, const EVP_PKEY *pkey)
             ERR_raise(ERR_LIB_DSA, ERR_R_ASN1_LIB);
             goto err;
         }
-        str->length = i2d_DSAparams(dsa, &str->data);
-        if (str->length <= 0) {
-            ERR_raise(ERR_LIB_DSA, ERR_R_ASN1_LIB);
-            goto err;
+        {
+            unsigned char *strdata = NULL;
+            int strsize = i2d_DSAparams(dsa, &strdata);
+            if (strsize <= 0) {
+                OPENSSL_free(strdata);
+                ERR_raise(ERR_LIB_DSA, ERR_R_ASN1_LIB);
+                goto err;
+            }
+            ASN1_STRING_set0(str, strdata, strsize);
         }
         ptype = V_ASN1_SEQUENCE;
     } else
@@ -171,19 +176,23 @@ static int dsa_priv_encode(PKCS8_PRIV_KEY_INFO *p8, const EVP_PKEY *pkey)
         goto err;
     }
 
-    params = ASN1_STRING_new();
+    params = ASN1_STRING_type_new(V_ASN1_SEQUENCE);
 
     if (params == NULL) {
         ERR_raise(ERR_LIB_DSA, ERR_R_ASN1_LIB);
         goto err;
     }
 
-    params->length = i2d_DSAparams(pkey->pkey.dsa, &params->data);
-    if (params->length <= 0) {
-        ERR_raise(ERR_LIB_DSA, ERR_R_ASN1_LIB);
-        goto err;
+    {
+        unsigned char *paramsdata = NULL;
+        int paramssize = i2d_DSAparams(pkey->pkey.dsa, &paramsdata);
+        if (paramssize <= 0) {
+            OPENSSL_free(paramsdata);
+            ERR_raise(ERR_LIB_DSA, ERR_R_ASN1_LIB);
+            goto err;
+        }
+        ASN1_STRING_set0(params, paramsdata, paramssize);
     }
-    params->type = V_ASN1_SEQUENCE;
 
     /* Get private key into integer */
     prkey = BN_to_ASN1_INTEGER(pkey->pkey.dsa->priv_key, NULL);
@@ -383,8 +392,8 @@ static int dsa_sig_print(BIO *bp, const X509_ALGOR *sigalg,
         else
             return 1;
     }
-    p = sig->data;
-    dsa_sig = d2i_DSA_SIG(NULL, &p, sig->length);
+    p = ASN1_STRING_get0_data(sig);
+    dsa_sig = d2i_DSA_SIG(NULL, &p, ASN1_STRING_length(sig));
     if (dsa_sig != NULL) {
         int rv = 0;
         const BIGNUM *r, *s;

--- a/crypto/dsa/dsa_backend.c
+++ b/crypto/dsa/dsa_backend.c
@@ -21,8 +21,6 @@
 #include "crypto/dsa.h"
 #include "dsa_local.h"
 
-#include <crypto/asn1.h>
-
 /*
  * The intention with the "backend" source file is to offer backend functions
  * for legacy backends (EVP_PKEY_ASN1_METHOD) and provider implementations
@@ -142,12 +140,12 @@ DSA *ossl_dsa_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
 
     if ((privkey = d2i_ASN1_INTEGER(NULL, &p, pklen)) == NULL)
         goto decerr;
-    if (privkey->type == V_ASN1_NEG_INTEGER || ptype != V_ASN1_SEQUENCE)
+    if (ASN1_STRING_type(privkey) == V_ASN1_NEG_INTEGER || ptype != V_ASN1_SEQUENCE)
         goto decerr;
 
     pstr = pval;
-    pm = pstr->data;
-    pmlen = pstr->length;
+    pm = ASN1_STRING_get0_data(pstr);
+    pmlen = ASN1_STRING_length(pstr);
     if ((dsa = d2i_DSAparams(NULL, &pm, pmlen)) == NULL)
         goto decerr;
     /* We have parameters now set private key */

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -531,17 +531,21 @@ EC_GROUP *EC_GROUP_new_from_ecparameters(const ECPARAMETERS *params)
      * compatibility.
      */
     if (params->curve == NULL
-        || params->curve->a == NULL || params->curve->a->data == NULL
-        || params->curve->b == NULL || params->curve->b->data == NULL) {
+        || params->curve->a == NULL
+        || ASN1_STRING_get0_data(params->curve->a) == NULL
+        || params->curve->b == NULL
+        || ASN1_STRING_get0_data(params->curve->b) == NULL) {
         ERR_raise(ERR_LIB_EC, EC_R_ASN1_ERROR);
         goto err;
     }
-    a = BN_bin2bn(params->curve->a->data, params->curve->a->length, NULL);
+    a = BN_bin2bn(ASN1_STRING_get0_data(params->curve->a),
+        ASN1_STRING_length(params->curve->a), NULL);
     if (a == NULL) {
         ERR_raise(ERR_LIB_EC, ERR_R_BN_LIB);
         goto err;
     }
-    b = BN_bin2bn(params->curve->b->data, params->curve->b->length, NULL);
+    b = BN_bin2bn(ASN1_STRING_get0_data(params->curve->b),
+        ASN1_STRING_length(params->curve->b), NULL);
     if (b == NULL) {
         ERR_raise(ERR_LIB_EC, ERR_R_BN_LIB);
         goto err;
@@ -680,22 +684,22 @@ EC_GROUP *EC_GROUP_new_from_ecparameters(const ECPARAMETERS *params)
          * and causes the OPENSSL_malloc below to choke on the
          * zero length allocation request.
          */
-        if (params->curve->seed->length == 0) {
+        if (ASN1_STRING_length(params->curve->seed) == 0) {
             ERR_raise(ERR_LIB_EC, EC_R_ASN1_ERROR);
             goto err;
         }
         OPENSSL_free(ret->seed);
-        if ((ret->seed = OPENSSL_malloc(params->curve->seed->length)) == NULL)
+        ret->seed_len = ASN1_STRING_length(params->curve->seed);
+        if ((ret->seed = OPENSSL_malloc(ret->seed_len)) == NULL)
             goto err;
-        memcpy(ret->seed, params->curve->seed->data,
-            params->curve->seed->length);
-        ret->seed_len = params->curve->seed->length;
+        memcpy(ret->seed, ASN1_STRING_get0_data(params->curve->seed),
+            ret->seed_len);
     }
 
     if (params->order == NULL
         || params->base == NULL
-        || params->base->data == NULL
-        || params->base->length == 0) {
+        || ASN1_STRING_get0_data(params->base) == NULL
+        || ASN1_STRING_length(params->base) == 0) {
         ERR_raise(ERR_LIB_EC, EC_R_ASN1_ERROR);
         goto err;
     }
@@ -704,11 +708,11 @@ EC_GROUP *EC_GROUP_new_from_ecparameters(const ECPARAMETERS *params)
         goto err;
 
     /* set the point conversion form */
-    EC_GROUP_set_point_conversion_form(ret, (point_conversion_form_t)(params->base->data[0] & ~0x01));
+    EC_GROUP_set_point_conversion_form(ret, (point_conversion_form_t)(ASN1_STRING_get0_data(params->base)[0] & ~0x01));
 
     /* extract the ec point */
-    if (!EC_POINT_oct2point(ret, point, params->base->data,
-            params->base->length, NULL)) {
+    if (!EC_POINT_oct2point(ret, point, ASN1_STRING_get0_data(params->base),
+            ASN1_STRING_length(params->base), NULL)) {
         ERR_raise(ERR_LIB_EC, ERR_R_EC_LIB);
         goto err;
     }

--- a/crypto/ec/ec_backend.c
+++ b/crypto/ec/ec_backend.c
@@ -27,8 +27,6 @@
 #include "internal/nelem.h"
 #include "internal/param_build_set.h"
 
-#include <crypto/asn1.h>
-
 /* Mapping between a flag and a name */
 static const OSSL_ITEM encoding_nameid_map[] = {
     { OPENSSL_EC_EXPLICIT_CURVE, OSSL_PKEY_EC_ENCODING_EXPLICIT },
@@ -747,8 +745,8 @@ int ossl_x509_algor_is_sm2(const X509_ALGOR *palg)
 
     if (ptype == V_ASN1_SEQUENCE) {
         const ASN1_STRING *str = pval;
-        const unsigned char *der = str->data;
-        int derlen = str->length;
+        const unsigned char *der = ASN1_STRING_get0_data(str);
+        int derlen = ASN1_STRING_length(str);
         EC_GROUP *group;
         int ret;
 
@@ -780,8 +778,8 @@ EC_KEY *ossl_ec_key_param_from_x509_algor(const X509_ALGOR *palg,
 
     if (ptype == V_ASN1_SEQUENCE) {
         const ASN1_STRING *pstr = pval;
-        const unsigned char *pm = pstr->data;
-        int pmlen = pstr->length;
+        const unsigned char *pm = ASN1_STRING_get0_data(pstr);
+        int pmlen = ASN1_STRING_length(pstr);
 
         if (d2i_ECParameters(&eckey, &pm, pmlen) == NULL) {
             ERR_raise(ERR_LIB_EC, EC_R_DECODE_ERROR);

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -98,7 +98,7 @@ static int ecx_priv_decode_ex(EVP_PKEY *pkey, const PKCS8_PRIV_KEY_INFO *p8,
 static int ecx_priv_encode(PKCS8_PRIV_KEY_INFO *p8, const EVP_PKEY *pkey)
 {
     const ECX_KEY *ecxkey = pkey->pkey.ecx;
-    ASN1_OCTET_STRING oct;
+    ASN1_OCTET_STRING *oct;
     unsigned char *penc = NULL;
     int penclen;
 
@@ -107,11 +107,18 @@ static int ecx_priv_encode(PKCS8_PRIV_KEY_INFO *p8, const EVP_PKEY *pkey)
         return 0;
     }
 
-    oct.data = ecxkey->privkey;
-    oct.length = KEYLEN(pkey);
-    oct.flags = 0;
-
-    penclen = i2d_ASN1_OCTET_STRING(&oct, &penc);
+    oct = ASN1_OCTET_STRING_new();
+    if (oct == NULL) {
+        ERR_raise(ERR_LIB_EC, ERR_R_ASN1_LIB);
+        return 0;
+    }
+    if (!ASN1_OCTET_STRING_set(oct, ecxkey->privkey, KEYLEN(pkey))) {
+        ASN1_OCTET_STRING_free(oct);
+        ERR_raise(ERR_LIB_EC, ERR_R_ASN1_LIB);
+        return 0;
+    }
+    penclen = i2d_ASN1_OCTET_STRING(oct, &penc);
+    ASN1_OCTET_STRING_free(oct);
     if (penclen < 0) {
         ERR_raise(ERR_LIB_EC, ERR_R_ASN1_LIB);
         return 0;

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -21,8 +21,6 @@
 #include "crypto/evp.h"
 #include "evp_local.h"
 
-#include <crypto/asn1.h>
-
 void evp_md_ctx_clear_digest(EVP_MD_CTX *ctx, int force, int keep_fetched)
 {
     if (ctx->algctx != NULL) {
@@ -89,7 +87,7 @@ EVP_MD_CTX *evp_md_ctx_new_ex(EVP_PKEY *pkey, const ASN1_OCTET_STRING *id,
         goto err;
     }
 
-    if (id != NULL && EVP_PKEY_CTX_set1_id(pctx, id->data, id->length) <= 0)
+    if (id != NULL && EVP_PKEY_CTX_set1_id(pctx, ASN1_STRING_get0_data(id), ASN1_STRING_length(id)) <= 0)
         goto err;
 
     EVP_MD_CTX_set_pkey_ctx(ctx, pctx);

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -28,9 +28,9 @@
 #include "crypto/cryptlib.h"
 #include "internal/provider.h"
 #include "evp_local.h"
+#include "crypto/asn1.h"
 
 #if !defined(FIPS_MODULE)
-#include "crypto/asn1.h"
 
 int EVP_CIPHER_param_to_asn1(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
 {

--- a/crypto/evp/p5_crpt.c
+++ b/crypto/evp/p5_crpt.c
@@ -15,8 +15,6 @@
 #include <openssl/core_names.h>
 #include <openssl/kdf.h>
 
-#include <crypto/asn1.h>
-
 /*
  * Doesn't do anything now: Builtin PBE algorithms in static table.
  */
@@ -35,7 +33,7 @@ int PKCS5_PBE_keyivgen_ex(EVP_CIPHER_CTX *cctx, const char *pass, int passlen,
     int ivl, kl;
     PBEPARAM *pbe = NULL;
     int saltlen, iter;
-    unsigned char *salt;
+    const unsigned char *salt;
     int mdsize;
     int rv = 0;
     EVP_KDF *kdf;
@@ -70,8 +68,8 @@ int PKCS5_PBE_keyivgen_ex(EVP_CIPHER_CTX *cctx, const char *pass, int passlen,
         iter = 1;
     else
         iter = ASN1_INTEGER_get(pbe->iter);
-    salt = pbe->salt->data;
-    saltlen = pbe->salt->length;
+    salt = ASN1_STRING_get0_data(pbe->salt);
+    saltlen = ASN1_STRING_length(pbe->salt);
 
     if (pass == NULL)
         passlen = 0;
@@ -90,7 +88,7 @@ int PKCS5_PBE_keyivgen_ex(EVP_CIPHER_CTX *cctx, const char *pass, int passlen,
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_PASSWORD,
         (char *)pass, (size_t)passlen);
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
-        salt, saltlen);
+        (void *)salt, saltlen);
     *p++ = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_ITER, &iter);
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
         (char *)mdname, 0);

--- a/crypto/evp/p5_crpt2.c
+++ b/crypto/evp/p5_crpt2.c
@@ -19,8 +19,6 @@
 #include "crypto/evp.h"
 #include "evp_local.h"
 
-#include <crypto/asn1.h>
-
 int ossl_pkcs5_pbkdf2_hmac_ex(const char *pass, int passlen,
     const unsigned char *salt, int saltlen, int iter,
     const EVP_MD *digest, int keylen, unsigned char *out,
@@ -179,7 +177,8 @@ int PKCS5_v2_PBKDF2_keyivgen_ex(EVP_CIPHER_CTX *ctx, const char *pass,
     const EVP_CIPHER *c, const EVP_MD *md, int en_de,
     OSSL_LIB_CTX *libctx, const char *propq)
 {
-    unsigned char *salt, key[EVP_MAX_KEY_LENGTH];
+    const unsigned char *salt;
+    unsigned char key[EVP_MAX_KEY_LENGTH];
     int saltlen, iter, t;
     int rv = 0;
     unsigned int keylen = 0;
@@ -239,8 +238,8 @@ int PKCS5_v2_PBKDF2_keyivgen_ex(EVP_CIPHER_CTX *ctx, const char *pass,
     }
 
     /* it seems that its all OK */
-    salt = kdf->salt->value.octet_string->data;
-    saltlen = kdf->salt->value.octet_string->length;
+    salt = ASN1_STRING_get0_data(kdf->salt->value.octet_string);
+    saltlen = ASN1_STRING_length(kdf->salt->value.octet_string);
     iter = ASN1_INTEGER_get(kdf->iter);
     if (!ossl_pkcs5_pbkdf2_hmac_ex(pass, passlen, salt, saltlen, iter, prfmd,
             keylen, key, libctx, propq))

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -788,8 +788,8 @@ const unsigned char *EVP_PKEY_get0_hmac(const EVP_PKEY *pkey, size_t *len)
     }
     os = evp_pkey_get_legacy((EVP_PKEY *)pkey);
     if (os != NULL) {
-        *len = os->length;
-        return os->data;
+        *len = ASN1_STRING_length(os);
+        return ASN1_STRING_get0_data(os);
     }
     return NULL;
 }
@@ -804,8 +804,8 @@ const unsigned char *EVP_PKEY_get0_poly1305(const EVP_PKEY *pkey, size_t *len)
     }
     os = evp_pkey_get_legacy((EVP_PKEY *)pkey);
     if (os != NULL) {
-        *len = os->length;
-        return os->data;
+        *len = ASN1_STRING_length(os);
+        return ASN1_STRING_get0_data(os);
     }
     return NULL;
 }
@@ -822,8 +822,8 @@ const unsigned char *EVP_PKEY_get0_siphash(const EVP_PKEY *pkey, size_t *len)
     }
     os = evp_pkey_get_legacy((EVP_PKEY *)pkey);
     if (os != NULL) {
-        *len = os->length;
-        return os->data;
+        *len = ASN1_STRING_length(os);
+        return ASN1_STRING_get0_data(os);
     }
     return NULL;
 }

--- a/crypto/evp/pmeth_check.c
+++ b/crypto/evp/pmeth_check.c
@@ -14,7 +14,6 @@
 #include <openssl/evp.h>
 #include "crypto/bn.h"
 #ifndef FIPS_MODULE
-#include "crypto/asn1.h"
 #endif
 #include "crypto/evp.h"
 #include "evp_local.h"

--- a/crypto/evp/pmeth_gn.c
+++ b/crypto/evp/pmeth_gn.c
@@ -18,10 +18,10 @@
 #include <openssl/evp.h>
 #include "crypto/bn.h"
 #ifndef FIPS_MODULE
-#include "crypto/asn1.h"
 #endif
 #include "crypto/evp.h"
 #include "evp_local.h"
+#include "crypto/asn1.h"
 
 static int gen_init(EVP_PKEY_CTX *ctx, int operation)
 {

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -22,7 +22,6 @@
 #include <openssl/kdf.h>
 #include "internal/cryptlib.h"
 #ifndef FIPS_MODULE
-#include "crypto/asn1.h"
 #endif
 #include "crypto/evp.h"
 #include "crypto/dh.h"

--- a/crypto/pkcs12/p12_attr.c
+++ b/crypto/pkcs12/p12_attr.c
@@ -12,8 +12,6 @@
 #include <openssl/pkcs12.h>
 #include "p12_local.h"
 
-#include <crypto/asn1.h>
-
 /* Add a local keyid to a safebag */
 
 int PKCS12_add_localkeyid(PKCS12_SAFEBAG *bag, const unsigned char *name,
@@ -117,8 +115,8 @@ char *PKCS12_get_friendlyname(PKCS12_SAFEBAG *bag)
         return NULL;
     if (atype->type != V_ASN1_BMPSTRING)
         return NULL;
-    return OPENSSL_uni2utf8(atype->value.bmpstring->data,
-        atype->value.bmpstring->length);
+    return OPENSSL_uni2utf8(ASN1_STRING_get0_data(atype->value.bmpstring),
+        ASN1_STRING_length(atype->value.bmpstring));
 }
 
 const STACK_OF(X509_ATTRIBUTE) *

--- a/crypto/pkcs12/p12_crpt.c
+++ b/crypto/pkcs12/p12_crpt.c
@@ -14,8 +14,6 @@
 #include "crypto/evp.h"
 #include <openssl/pkcs12.h>
 
-#include <crypto/asn1.h>
-
 /* PKCS#12 PBE algorithms now in static table */
 
 void PKCS12_PBE_add(void)
@@ -29,7 +27,7 @@ int PKCS12_PBE_keyivgen_ex(EVP_CIPHER_CTX *ctx, const char *pass, int passlen,
 {
     PBEPARAM *pbe;
     int saltlen, iter, ret;
-    unsigned char *salt;
+    const unsigned char *salt;
     unsigned char key[EVP_MAX_KEY_LENGTH], iv[EVP_MAX_IV_LENGTH];
     unsigned char *piv = iv;
 
@@ -48,9 +46,9 @@ int PKCS12_PBE_keyivgen_ex(EVP_CIPHER_CTX *ctx, const char *pass, int passlen,
         iter = 1;
     else
         iter = ASN1_INTEGER_get(pbe->iter);
-    salt = pbe->salt->data;
-    saltlen = pbe->salt->length;
-    if (!PKCS12_key_gen_utf8_ex(pass, passlen, salt, saltlen, PKCS12_KEY_ID,
+    salt = ASN1_STRING_get0_data(pbe->salt);
+    saltlen = ASN1_STRING_length(pbe->salt);
+    if (!PKCS12_key_gen_utf8_ex(pass, passlen, (unsigned char *)salt, saltlen, PKCS12_KEY_ID,
             iter, EVP_CIPHER_get_key_length(cipher),
             key, md,
             libctx, propq)) {
@@ -59,7 +57,7 @@ int PKCS12_PBE_keyivgen_ex(EVP_CIPHER_CTX *ctx, const char *pass, int passlen,
         return 0;
     }
     if (EVP_CIPHER_get_iv_length(cipher) > 0) {
-        if (!PKCS12_key_gen_utf8_ex(pass, passlen, salt, saltlen, PKCS12_IV_ID,
+        if (!PKCS12_key_gen_utf8_ex(pass, passlen, (unsigned char *)salt, saltlen, PKCS12_IV_ID,
                 iter, EVP_CIPHER_get_iv_length(cipher),
                 iv, md,
                 libctx, propq)) {

--- a/crypto/pkcs12/p12_decr.c
+++ b/crypto/pkcs12/p12_decr.c
@@ -12,8 +12,6 @@
 #include <openssl/pkcs12.h>
 #include <openssl/trace.h>
 
-#include <crypto/asn1.h>
-
 /*
  * Encrypt/Decrypt a buffer based on password and algor, result in a
  * OPENSSL_malloc'ed buffer
@@ -153,7 +151,7 @@ void *PKCS12_item_decrypt_d2i_ex(const X509_ALGOR *algor, const ASN1_ITEM *it,
         return NULL;
     }
 
-    if (!PKCS12_pbe_crypt_ex(algor, pass, passlen, oct->data, oct->length,
+    if (!PKCS12_pbe_crypt_ex(algor, pass, passlen, ASN1_STRING_get0_data(oct), ASN1_STRING_length(oct),
             &out, &outlen, 0, libctx, propq))
         return NULL;
     p = out;
@@ -206,11 +204,17 @@ ASN1_OCTET_STRING *PKCS12_item_i2d_encrypt_ex(X509_ALGOR *algor,
         ERR_raise(ERR_LIB_PKCS12, PKCS12_R_ENCODE_ERROR);
         goto err;
     }
-    if (!PKCS12_pbe_crypt_ex(algor, pass, passlen, in, inlen, &oct->data,
-            &oct->length, 1, ctx, propq)) {
-        ERR_raise(ERR_LIB_PKCS12, PKCS12_R_ENCRYPT_ERROR);
-        OPENSSL_free(in);
-        goto err;
+    {
+        unsigned char *encdata = NULL;
+        int enclen = 0;
+        if (!PKCS12_pbe_crypt_ex(algor, pass, passlen, in, inlen,
+                &encdata, &enclen, 1, ctx, propq)) {
+            OPENSSL_free(encdata);
+            ERR_raise(ERR_LIB_PKCS12, PKCS12_R_ENCRYPT_ERROR);
+            OPENSSL_free(in);
+            goto err;
+        }
+        ASN1_STRING_set0(oct, encdata, enclen);
     }
     if (zbuf)
         OPENSSL_cleanse(in, inlen);

--- a/crypto/pkcs12/p12_mutl.c
+++ b/crypto/pkcs12/p12_mutl.c
@@ -22,8 +22,6 @@
 #include <openssl/pkcs12.h>
 #include "p12_local.h"
 
-#include <crypto/asn1.h>
-
 static int pkcs12_pbmac1_pbkdf2_key_gen(const char *pass, int passlen,
     unsigned char *salt, int saltlen,
     int id, int iter, int keylen,
@@ -156,7 +154,7 @@ static int PBMAC1_PBKDF2_HMAC(OSSL_LIB_CTX *ctx, const char *propq,
         goto err;
     }
 
-    if (PKCS5_PBKDF2_HMAC(pass, passlen, pbkdf2_salt->data, pbkdf2_salt->length,
+    if (PKCS5_PBKDF2_HMAC(pass, passlen, ASN1_STRING_get0_data(pbkdf2_salt), ASN1_STRING_length(pbkdf2_salt),
             ASN1_INTEGER_get(pbkdf2_param->iter), kdf_md, keylen, key)
         <= 0) {
         ERR_raise(ERR_LIB_PKCS12, ERR_R_INTERNAL_ERROR);
@@ -185,7 +183,8 @@ static int pkcs12_gen_mac(PKCS12 *p12, const char *pass, int passlen,
 {
     int ret = 0;
     EVP_MD *md;
-    unsigned char key[EVP_MAX_MD_SIZE], *salt;
+    unsigned char key[EVP_MAX_MD_SIZE];
+    const unsigned char *salt;
     int saltlen, iter;
     char md_name[80];
     int keylen = 0;
@@ -208,8 +207,8 @@ static int pkcs12_gen_mac(PKCS12 *p12, const char *pass, int passlen,
 
     libctx = p12->authsafes->ctx.libctx;
     propq = p12->authsafes->ctx.propq;
-    salt = p12->mac->salt->data;
-    saltlen = p12->mac->salt->length;
+    salt = ASN1_STRING_get0_data(p12->mac->salt);
+    saltlen = ASN1_STRING_length(p12->mac->salt);
     if (p12->mac->iter == NULL)
         iter = 1;
     else
@@ -246,7 +245,7 @@ static int pkcs12_gen_mac(PKCS12 *p12, const char *pass, int passlen,
                    || md_nid == NID_id_GostR3411_2012_512)
         && ossl_safe_getenv("LEGACY_GOST_PKCS12") == NULL) {
         keylen = TK26_MAC_KEY_LEN;
-        if (!pkcs12_gen_gost_mac_key(pass, passlen, salt, saltlen, iter,
+        if (!pkcs12_gen_gost_mac_key(pass, passlen, (unsigned char *)salt, saltlen, iter,
                 keylen, key, md)) {
             ERR_raise(ERR_LIB_PKCS12, PKCS12_R_KEY_GEN_ERROR);
             goto err;
@@ -266,7 +265,7 @@ static int pkcs12_gen_mac(PKCS12 *p12, const char *pass, int passlen,
             fetched = 1;
         }
         if (pkcs12_key_gen != NULL) {
-            int res = (*pkcs12_key_gen)(pass, passlen, salt, saltlen, PKCS12_MAC_ID,
+            int res = (*pkcs12_key_gen)(pass, passlen, (unsigned char *)salt, saltlen, PKCS12_MAC_ID,
                 iter, keylen, key, hmac_md, libctx, propq);
 
             if (fetched)
@@ -279,7 +278,7 @@ static int pkcs12_gen_mac(PKCS12 *p12, const char *pass, int passlen,
             if (fetched)
                 EVP_MD_free(hmac_md);
             /* Default to UTF-8 password */
-            if (!PKCS12_key_gen_utf8_ex(pass, passlen, salt, saltlen, PKCS12_MAC_ID,
+            if (!PKCS12_key_gen_utf8_ex(pass, passlen, (unsigned char *)salt, saltlen, PKCS12_MAC_ID,
                     iter, keylen, key, md, libctx, propq)) {
                 ERR_raise(ERR_LIB_PKCS12, PKCS12_R_KEY_GEN_ERROR);
                 goto err;
@@ -287,7 +286,7 @@ static int pkcs12_gen_mac(PKCS12 *p12, const char *pass, int passlen,
         }
     }
     if (EVP_Q_mac(libctx, "HMAC", propq, md_name, NULL, key, keylen,
-            p12->authsafes->d.data->data, p12->authsafes->d.data->length,
+            ASN1_STRING_get0_data(p12->authsafes->d.data), ASN1_STRING_length(p12->authsafes->d.data),
             mac, md_sz, &outlen)
         == NULL)
         goto err;
@@ -424,16 +423,21 @@ static int pkcs12_setup_mac(PKCS12 *p12, int iter, unsigned char *salt, int salt
         saltlen = PKCS12_SALT_LEN;
     else if (saltlen < 0)
         return 0;
-    if ((p12->mac->salt->data = OPENSSL_malloc(saltlen)) == NULL)
-        return 0;
-    p12->mac->salt->length = saltlen;
-    if (salt == NULL) {
-        if (RAND_bytes_ex(p12->authsafes->ctx.libctx, p12->mac->salt->data,
-                (size_t)saltlen, 0)
-            <= 0)
+    {
+        unsigned char *saltbuf = OPENSSL_malloc(saltlen);
+        if (saltbuf == NULL)
             return 0;
-    } else {
-        memcpy(p12->mac->salt->data, salt, saltlen);
+        if (salt == NULL) {
+            if (RAND_bytes_ex(p12->authsafes->ctx.libctx, saltbuf,
+                    (size_t)saltlen, 0)
+                <= 0) {
+                OPENSSL_free(saltbuf);
+                return 0;
+            }
+        } else {
+            memcpy(saltbuf, salt, saltlen);
+        }
+        ASN1_STRING_set0(p12->mac->salt, saltbuf, saltlen);
     }
     X509_SIG_getm(p12->mac->dinfo, &macalg, NULL);
     if (!X509_ALGOR_set0(macalg, OBJ_nid2obj(nid), V_ASN1_NULL, NULL)) {

--- a/crypto/pkcs12/p12_npas.c
+++ b/crypto/pkcs12/p12_npas.c
@@ -15,8 +15,6 @@
 #include <openssl/pkcs12.h>
 #include "p12_local.h"
 
-#include <crypto/asn1.h>
-
 /* PKCS#12 password change routine */
 
 static int newpass_p12(PKCS12 *p12, const char *oldpass, const char *newpass);
@@ -237,7 +235,7 @@ static int alg_get(const X509_ALGOR *alg, int *pnid, int *piter,
             X509_ALGOR_get0(&aoid, NULL, NULL, kdf->prf);
             prfnid = OBJ_obj2nid(aoid);
         }
-        *psaltlen = kdf->salt->value.octet_string->length;
+        *psaltlen = ASN1_STRING_length(kdf->salt->value.octet_string);
         *piter = ASN1_INTEGER_get(kdf->iter);
         *pnid = prfnid;
         *cipherid = encnid;
@@ -248,7 +246,7 @@ static int alg_get(const X509_ALGOR *alg, int *pnid, int *piter,
             goto done;
         *pnid = OBJ_obj2nid(alg->algorithm);
         *piter = ASN1_INTEGER_get(pbe->iter);
-        *psaltlen = pbe->salt->length;
+        *psaltlen = ASN1_STRING_length(pbe->salt);
         *cipherid = NID_undef;
         ret = 1;
         break;

--- a/providers/implementations/encode_decode/decode_epki2pki.c
+++ b/providers/implementations/encode_decode/decode_epki2pki.c
@@ -26,8 +26,6 @@
 #include "prov/endecoder_local.h"
 #include "providers/implementations/encode_decode/decode_epki2pki.inc"
 
-#include <crypto/asn1.h>
-
 static OSSL_FUNC_decoder_newctx_fn epki2pki_newctx;
 static OSSL_FUNC_decoder_freectx_fn epki2pki_freectx;
 static OSSL_FUNC_decoder_decode_fn epki2pki_decode;
@@ -145,7 +143,7 @@ int ossl_epki2pki_der_decode(unsigned char *der, long der_len, int selection,
 
             X509_SIG_get0(p8, &alg, &oct);
             if (!PKCS12_pbe_crypt_ex(alg, pbuf, (int)plen,
-                    oct->data, oct->length,
+                    ASN1_STRING_get0_data(oct), ASN1_STRING_length(oct),
                     &new_der, &new_der_len, 0,
                     libctx, propq)) {
                 ok = 0;


### PR DESCRIPTION
## Summary

Replace direct `ASN1_STRING` struct member access (`->data`, `->length`,
`->type`) with public accessor functions (`ASN1_STRING_get0_data`,
`ASN1_STRING_length`, `ASN1_STRING_type`, `ASN1_STRING_set0`,
`ASN1_STRING_type_new`) across 22 files in `apps/`, `crypto/dh/`,
`crypto/dsa/`, `crypto/ec/`, `crypto/evp/`, `crypto/pkcs12/`, and
`providers/`; treating `ASN1_STRING` as opaque as consumer code should,
following the pattern established in prior PRs in this series.

Partially addresses #29861. Follow-up to #29862 (which made
`struct asn1_string_st` opaque), #30126, #30223, and #30525.

## ⚠️ This PR has been split

Per @bob-beck's review, the three difficult portions of the original
#30685 scope have been factored out into standalone PRs:

| PR | Scope |
|----|-------|
| #30946 | `test/` files (heap-alloc opaque ASN1 objects, rewrite `test_asn1_time_compare`) |
| #30947 | `ssl/ssl_asn1.c` (heap OCTET_STRINGs, drop `= NULL` ownership hack) |
| #30948 | `ASN1_BIT_STRING` flag mashing → `ASN1_BIT_STRING_set1` (dh_asn1.c, ec_asn1.c bit-string sites, cms_ec.c, cms_dh.c, cmp_protect.c) |

This PR covers only what remains — the straightforward member-access
conversions in the original scope.

## Files

### Include fully removed

| File | Accesses converted |
|------|--------------------|
| apps/ca.c | Include was unused |
| crypto/dh/dh_backend.c | `->data`, `->length` reads |
| crypto/dsa/dsa_backend.c | `->data`, `->length` reads |
| crypto/ec/ec_backend.c | `->data`, `->length` reads |
| crypto/evp/digest.c | `->data`, `->length` reads |
| crypto/evp/p5_crpt.c | `->data`, `->length` reads |
| crypto/evp/p5_crpt2.c | `->data`, `->length` reads |
| crypto/evp/pmeth_check.c | `->data`, `->length` reads |
| crypto/evp/pmeth_lib.c | `->data`, `->length` reads |
| crypto/pkcs12/p12_attr.c | `->data`, `->length` reads |
| crypto/pkcs12/p12_crpt.c | `->data`, `->length` reads |
| crypto/pkcs12/p12_decr.c | `PKCS12_pbe_crypt_ex` out-param write to `&oct->data` / `&oct->length` replaced with temp buf + `ASN1_STRING_set0()` |
| crypto/pkcs12/p12_mutl.c | `OPENSSL_malloc` direct assign replaced with temp buf + `ASN1_STRING_set0()` |
| crypto/pkcs12/p12_npas.c | `->data`, `->length` reads |
| providers/implementations/encode_decode/decode_epki2pki.c | `->data`, `->length` reads |

### Include retained (other internal-API usage remains)

| File | Accesses converted | Reason include stays |
|------|--------------------|----------------------|
| crypto/dh/dh_ameth.c | `i2d_dhp(&str->data)` writes replaced with temp buf + `ASN1_STRING_set0()`; `->type = V_ASN1_SEQUENCE` replaced with `ASN1_STRING_type_new()` | `EVP_PKEY_ASN1_METHOD` struct definition |
| crypto/dsa/dsa_ameth.c | `i2d_DSAparams(&str->data)` writes replaced with temp buf + `ASN1_STRING_set0()`; `->type = V_ASN1_SEQUENCE` replaced with `ASN1_STRING_type_new()` | `EVP_PKEY_ASN1_METHOD` struct definition |
| crypto/ec/ec_asn1.c | `->data`, `->length` reads across `EC_GROUP_new_from_ecparameters` | `ossl_asn1_bit_string_set_unused_bits` calls (addressed in #30948) |
| crypto/ec/ecx_meth.c | Stack-allocated `ASN1_OCTET_STRING` converted to `ASN1_OCTET_STRING_new()` + `_set()` + `_free()` | `EVP_PKEY_ASN1_METHOD` struct definition |
| crypto/evp/evp_lib.c | `->data`, `->length` reads | `ossl_asn1_type_get/set_octetstring_int` |
| crypto/evp/p_lib.c | `->data`, `->length` reads on HMAC / Poly1305 / SipHash key getters | `EVP_PKEY_ASN1_METHOD` struct definition |
| crypto/evp/pmeth_gn.c | `->data`, `->length` reads | `EVP_PKEY_ASN1_METHOD` struct definition |

### `&str->data` / `&str->length` direct-return audit

Per @bob-beck's review comment: *"direct returns of `&str->data` and
`&str->length`. You should point those out and convert them. If the
object it's returning into can be made const, it may be fine to return
the result of get0_data, otherwise a copy will need to be made."*

A sweep of every file in this PR's scope via `grep -rE
'&[a-zA-Z_][a-zA-Z0-9_]*->(data|length)'` finds **zero sites**. The
only tree-wide hit outside this PR's scope is
`crypto/pkcs7/pk7_lib.c:762` (covered by the already-merged #30525
series).

## Behavioral notes

- **Transient memory**: the i2d-write conversions in `dh_ameth.c`,
  `dsa_ameth.c`, `p12_decr.c`, and `p12_mutl.c` use a temp buffer +
  `ASN1_STRING_set0()` pattern, which transfers ownership without
  copying. The `ecx_meth.c` stack→heap conversion does add one
  `ASN1_OCTET_STRING_new()` + `_set()` copy per encode.
- **New failure modes**: the allocation-based conversions can now fail
  with 0 return if the `ASN1_OCTET_STRING_new` or `ASN1_STRING_type_new`
  returns NULL. All public callers already handle the existing 0 return.
- **Stack→heap in `ecx_meth.c`**: previously a stack `ASN1_OCTET_STRING`
  aliased caller-owned data; now heap-allocated with a `_free` cleanup
  on the error path. No key material leaks.

## Test plan

- [x] `make test HARNESS_VERBOSE=1` passes on Linux x86_64 (4373 tests)
- [x] `clang-query` confirms zero remaining `memberExpr` on
      `asn1_string_st` across all 22 files
- [x] `grep` sweep confirms zero `&str->data` / `&str->length`
      direct-return sites

## References

Follow-up to #29862, #30126, #30223, #30525. Companion to the
split-out standalone PRs: #30946 (test/), #30947 (ssl_asn1.c),
#30948 (bit-string flags).

Tagging @bbbrumley.
