### PR TITLE
Windows: Enable parallel builds with jom and use it in CI

### DIFF
--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -153,6 +153,8 @@ jobs:
       run: |
         choco install nasm
         "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+    - name: install jom
+      run:  choco install jom
     - name: prepare the build directory
       run: mkdir _build
     - name: config
@@ -167,7 +169,7 @@ jobs:
       shell: cmd
       run: |
         call "${{ matrix.platform.vcvars }}"
-        nmake /S
+        jom /j4 /S
     - name: download coreinfo
       run: |
         mkdir _build\coreinfo
@@ -183,7 +185,7 @@ jobs:
       shell: cmd
       run: |
         call "${{ matrix.platform.vcvars }}"
-        nmake test VERBOSE_FAILURE=yes HARNESS_JOBS=4 LHASH_WORKERS=16
+        jom test VERBOSE_FAILURE=yes HARNESS_JOBS=4 LHASH_WORKERS=16
 
   linux-arm64:
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,6 +41,8 @@ jobs:
       run: |
         choco install nasm ${{ matrix.platform.arch == 'x86' && '--x86' || '' }}
         "C:\Program Files${{ matrix.platform.arch == 'x86' && ' (x86)' || '' }}\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+    - name: install jom
+      run: choco install jom
     - name: prepare the build directory
       run: mkdir _build
     - name: config
@@ -55,7 +57,7 @@ jobs:
       shell: cmd
       run: |
         call "${{ matrix.platform.vcvars }}"
-        nmake /S
+        jom /j4 /S
     - name: download coreinfo
       run: |
         mkdir _build\coreinfo
@@ -93,7 +95,7 @@ jobs:
       shell: cmd
       run: |
         call "${{ matrix.platform.vcvars }}"
-        nmake test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4
+        jom test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4
     - name: install
       # Run on 64 bit only as 32 bit is slow enough already
       if: ${{ matrix.platform.arch == 'amd64' }}
@@ -102,7 +104,7 @@ jobs:
       run: |
         call "${{ matrix.platform.vcvars }}"
         mkdir _dest
-        nmake install DESTDIR=_dest
+        jom /j4 install DESTDIR=_dest
 
   plain:
     runs-on: windows-2022
@@ -114,6 +116,8 @@ jobs:
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: prepare the build directory
       run: mkdir _build
+    - name: install jom
+      run:  choco install jom
     - name: config
       working-directory: _build
       shell: cmd
@@ -126,7 +130,7 @@ jobs:
       shell: cmd
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        nmake /S
+        jom /j4 /S
     - name: download coreinfo
       run: |
         mkdir _build\coreinfo
@@ -155,6 +159,8 @@ jobs:
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: prepare the build directory
       run: mkdir _build
+    - name: install jom
+      run:  choco install jom
     - name: config
       working-directory: _build
       shell: cmd
@@ -167,7 +173,7 @@ jobs:
       shell: cmd
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        nmake
+        jom /j4 /S
     - name: download coreinfo
       run: |
         mkdir _build\coreinfo
@@ -184,7 +190,7 @@ jobs:
       shell: cmd
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        nmake test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4
+        jom test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4
 
   cygwin:
     # Run a job for each of the specified target architectures:

--- a/.github/workflows/windows_comp.yml
+++ b/.github/workflows/windows_comp.yml
@@ -32,6 +32,8 @@ jobs:
       run: |
         choco install nasm
         "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+    - name: install jom
+      run:  choco install jom
     - name: prepare the build directory
       run: mkdir _build
     - name: Get zstd
@@ -50,7 +52,7 @@ jobs:
       shell: cmd
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        nmake
+        jom /j4 /S
     - name: Gather openssl version info
       working-directory: _build
       run: |
@@ -81,7 +83,7 @@ jobs:
       shell: cmd
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        nmake test VERBOSE_FAILURE=yes TESTS="-test_fuzz* -test_fipsload" HARNESS_JOBS=4
+        jom test VERBOSE_FAILURE=yes TESTS="-test_fuzz* -test_fipsload" HARNESS_JOBS=4
 
   brotli:
     runs-on: windows-latest
@@ -95,6 +97,8 @@ jobs:
       run: |
         choco install nasm
         "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+    - name: install jom
+      run:  choco install jom
     - name: prepare the build directory
       run: mkdir _build
     - name: Get brotli
@@ -113,7 +117,7 @@ jobs:
       shell: cmd
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        nmake
+        jom /j4 /S
     - name: Gather openssl version info
       working-directory: _build
       run: |
@@ -144,4 +148,4 @@ jobs:
       shell: cmd
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        nmake test VERBOSE_FAILURE=yes TESTS="-test_fuzz* -test_fipsload" HARNESS_JOBS=4
+        jom test VERBOSE_FAILURE=yes TESTS="-test_fuzz* -test_fipsload" HARNESS_JOBS=4

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1541,10 +1541,10 @@ my %targets = (
                                 "UNICODE", "_UNICODE",
                                 "_CRT_SECURE_NO_DEPRECATE",
                                 "_WINSOCK_DEPRECATED_NO_WARNINGS"),
-        lib_cflags       => add("/Zi /Fdossl_static.pdb"),
+        lib_cflags       => add("/Z7"),
         lib_defines      => add("L_ENDIAN"),
-        dso_cflags       => "/Zi /Fddso.pdb",
-        bin_cflags       => "/Zi /Fdapp.pdb",
+        dso_cflags       => "/Z7",
+        bin_cflags       => "/Z7",
         # def_flag made to empty string so a .def file gets generated
         shared_defflag   => '',
         shared_ldflag    => "/dll",

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -450,7 +450,7 @@ uninstall: {- "uninstall_docs" if !$disabled{docs}; -} uninstall_sw {- $disabled
 
 libclean:
 	"$(PERL)" -e "map { m/(.*)\.dll$$/; unlink glob """{.,apps,test,fuzz}/$$1.*"""; } @ARGV" $(SHLIBS)
-	-del /Q /F $(LIBS) libcrypto.* libssl.* ossl_static.pdb
+	-del /Q /F $(LIBS) libcrypto.* libssl.*
 
 clean: libclean
 	{- join("\n\t", map { "-if exist $_ del /Q /F $_" } @HTMLDOCS1) || "\@rem" -}
@@ -545,8 +545,6 @@ install_dev: install_runtime_libs
 				       "$(INSTALLTOP)\include\openssl"
 	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(libdir)"
 	@"$(PERL)" "$(SRCDIR)\util\copy.pl" $(INSTALL_LIBS) "$(libdir)"
-	@if "$(SHLIBS)"=="" \
-	 "$(PERL)" "$(SRCDIR)\util\copy.pl" ossl_static.pdb "$(libdir)"
 	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(CMAKECONFIGDIR)"
 	@"$(PERL)" "$(SRCDIR)\util\copy.pl" $(INSTALL_EXPORTERS_CMAKE) "$(CMAKECONFIGDIR)"
 


### PR DESCRIPTION
MSVC compilation on Windows cannot be reliably parallelized with tools like jom (an nmake replacement) due to contention on shared .pdb files used for debug info. Writes to a shared  .pdb must be serialized.
    
The /FS compiler flag serializes concurrent compiler writes,  but does not resolve contention when the compiler and linker access the same .pdb file. With shared .pdb files (e.g. app.pdb),  the makefile does not prevent races between the linker and  compilation of multiple targets.
    
This can be resolved either by restructuring the makefile to introduce sentinel dependencies that serialize the conflicting steps, or by eliminating the shared .pdb entirely.
    
This patch takes the latter approach: it replaces /Zi with /Z7, which embeds debug info directly into each .obj file and avoids any shared-file contention. /Z7 is supported by all MSVC versions.
    
The linker-generated .pdb is unaffected.
    
Side effects: object files are slightly larger, and all .pdb files are now named after their target — the shared app.pdb, ossl_static.pdb,  and dso.pdb no longer exist.
    
With this change, jom can be used to parallelize the build.

Second patch uses jom.exe in CI. Tests are already parallelized through HARNESS_JOBS (and tests take most of the time now).

NOTE: static *.libs are now significantly larger as it contain debug info. But I think it is expected...

Fixes: #9931 
