### PR TITLE
windows.yml: Remove leftover call from a backport

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -83,7 +83,6 @@ jobs:
       working-directory: _build
       shell: cmd
       run: |
-        call "${{ matrix.platform.vcvars }}"
         perl ../util/checkplatformsyms.pl ../util/platform_symbols/windows-symbols.txt libcrypto-%OSSL_MAJOR%${{ matrix.platform.arch == 'amd64' && '-x64' || '' }}.dll ./libssl-%OSSL_MAJOR%${{ matrix.platform.arch == 'amd64' && '-x64' || '' }}.dll
     - name: test
       working-directory: _build


### PR DESCRIPTION
This fixes Windows CI breakage on 3.5 and 3.4 so it is urgent.
