### PR TITLE
Only verify software can build if it is not a documentation only PR.

### DIFF
--- a/.github/workflows/ci-doc-changes.yml
+++ b/.github/workflows/ci-doc-changes.yml
@@ -5,7 +5,7 @@
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
-name: GitHub CI
+name: Documentation and Installability CI
 
 on: [pull_request, push]
 

--- a/.github/workflows/ci-doc-changes.yml
+++ b/.github/workflows/ci-doc-changes.yml
@@ -1,0 +1,125 @@
+# Copyright 2021-2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+name: GitHub CI
+
+on: [pull_request, push]
+
+permissions:
+  contents: read
+
+env:
+  OSSL_RUN_CI_TESTS: 1
+
+jobs:
+  check_docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+    - name: config
+      run: ./config --strict-warnings --banner=Configured enable-fips && perl configdata.pm --dump
+    - name: make build_generated
+      run: make -s build_generated
+    - name: make doc-nits
+      run: make doc-nits
+    - name: make help
+      run: make help
+    - name: make md-nits
+      run: |
+          sudo gem install mdl
+          make md-nits
+
+  # out-of-source-and-install checks multiple things at the same time:
+  # - That building, testing and installing works from an out-of-source
+  #   build tree
+  # - That building, testing and installing works with a read-only source
+  #   tree
+  out-of-readonly-source-and-install-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        path: ./source
+        persist-credentials: false
+    - name: checkout fuzz/corpora submodule
+      run: git submodule update --init --depth 1 fuzz/corpora
+      working-directory: ./source
+    - name: make source read-only
+      run: chmod -R a-w ./source
+    - name: create build and install directories
+      run: |
+        mkdir ./build
+        mkdir ./install
+    - name: config
+      run: |
+        ../source/config --banner=Configured enable-demos enable-h3demo enable-fips enable-lms enable-quic enable-acvp-tests --strict-warnings --prefix=$(cd ../install; pwd)
+        perl configdata.pm --dump
+      working-directory: ./build
+    - name: make
+      run: make -s -j4
+      working-directory: ./build
+    - name: get cpu info
+      run: |
+        cat /proc/cpuinfo
+        ./util/opensslwrap.sh version -c
+      working-directory: ./build
+    - name: make test
+      run: ../source/.github/workflows/make-test
+      working-directory: ./build
+    - name: save artifacts
+      if: success() || failure()
+      uses: actions/upload-artifact@v5
+      with:
+        name: "ci@out-of-readonly-source-and-install-ubuntu"
+        path: build/artifacts.tar.gz
+    - name: make install
+      run: make install
+      working-directory: ./build
+
+  out-of-readonly-source-and-install-macos:
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        path: ./source
+        persist-credentials: false
+    - name: checkout fuzz/corpora submodule
+      run: git submodule update --init --depth 1 fuzz/corpora
+      working-directory: ./source
+    - name: make source read-only
+      run: chmod -R a-w ./source
+    - name: create build and install directories
+      run: |
+        mkdir ./build
+        mkdir ./install
+    - name: config
+      run: |
+        ../source/config --banner=Configured enable-fips enable-lms enable-demos enable-h3demo enable-quic enable-acvp-tests --strict-warnings --prefix=$(cd ../install; pwd)
+        perl configdata.pm --dump
+      working-directory: ./build
+    - name: make
+      run: make -s -j4
+      working-directory: ./build
+    - name: get cpu info
+      run: |
+        sysctl machdep.cpu
+        ./util/opensslwrap.sh version -c
+      working-directory: ./build
+    - name: make test
+      run: ../source/.github/workflows/make-test
+      working-directory: ./build
+    - name: save artifacts
+      if: success() || failure()
+      uses: actions/upload-artifact@v5
+      with:
+        name: "ci@out-of-readonly-source-and-install-macos-15"
+        path: build/artifacts.tar.gz
+    - name: make install
+      run: make install
+      working-directory: ./build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,17 @@
 
 name: GitHub CI
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    paths-ignore:
+      - 'doc/**'
+      - '*.md'
+      - '*.pod'
+      - 'README*'
+      - 'funding.json'
+      - 'LICENSE.txt'
+      - 'VERSION.dat'
 
 # for some reason, this does not work:
 # variables:
@@ -44,25 +54,6 @@ jobs:
       run: make update
     - name: git diff
       run: git diff --exit-code
-
-  check_docs:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        persist-credentials: false
-    - name: config
-      run: ./config --strict-warnings --banner=Configured enable-fips && perl configdata.pm --dump
-    - name: make build_generated
-      run: make -s build_generated
-    - name: make doc-nits
-      run: make doc-nits
-    - name: make help
-      run: make help
-    - name: make md-nits
-      run: |
-          sudo gem install mdl
-          make md-nits
 
   # This checks that we use ANSI C language syntax and semantics.
   # We are not as strict with libraries, but rather adapt to what's
@@ -628,95 +619,6 @@ jobs:
       with:
         name: "ci@legacy"
         path: artifacts.tar.gz
-
-  # out-of-source-and-install checks multiple things at the same time:
-  # - That building, testing and installing works from an out-of-source
-  #   build tree
-  # - That building, testing and installing works with a read-only source
-  #   tree
-  out-of-readonly-source-and-install-ubuntu:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        path: ./source
-        persist-credentials: false
-    - name: checkout fuzz/corpora submodule
-      run: git submodule update --init --depth 1 fuzz/corpora
-      working-directory: ./source
-    - name: make source read-only
-      run: chmod -R a-w ./source
-    - name: create build and install directories
-      run: |
-        mkdir ./build
-        mkdir ./install
-    - name: config
-      run: |
-        ../source/config --banner=Configured enable-demos enable-h3demo enable-fips enable-lms enable-quic enable-acvp-tests --strict-warnings --prefix=$(cd ../install; pwd)
-        perl configdata.pm --dump
-      working-directory: ./build
-    - name: make
-      run: make -s -j4
-      working-directory: ./build
-    - name: get cpu info
-      run: |
-        cat /proc/cpuinfo
-        ./util/opensslwrap.sh version -c
-      working-directory: ./build
-    - name: make test
-      run: ../source/.github/workflows/make-test
-      working-directory: ./build
-    - name: save artifacts
-      if: success() || failure()
-      uses: actions/upload-artifact@v5
-      with:
-        name: "ci@out-of-readonly-source-and-install-ubuntu"
-        path: build/artifacts.tar.gz
-    - name: make install
-      run: make install
-      working-directory: ./build
-
-  out-of-readonly-source-and-install-macos:
-    runs-on: macos-15
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        path: ./source
-        persist-credentials: false
-    - name: checkout fuzz/corpora submodule
-      run: git submodule update --init --depth 1 fuzz/corpora
-      working-directory: ./source
-    - name: make source read-only
-      run: chmod -R a-w ./source
-    - name: create build and install directories
-      run: |
-        mkdir ./build
-        mkdir ./install
-    - name: config
-      run: |
-        ../source/config --banner=Configured enable-fips enable-lms enable-demos enable-h3demo enable-quic enable-acvp-tests --strict-warnings --prefix=$(cd ../install; pwd)
-        perl configdata.pm --dump
-      working-directory: ./build
-    - name: make
-      run: make -s -j4
-      working-directory: ./build
-    - name: get cpu info
-      run: |
-        sysctl machdep.cpu
-        ./util/opensslwrap.sh version -c
-      working-directory: ./build
-    - name: make test
-      run: ../source/.github/workflows/make-test
-      working-directory: ./build
-    - name: save artifacts
-      if: success() || failure()
-      uses: actions/upload-artifact@v5
-      with:
-        name: "ci@out-of-readonly-source-and-install-macos-15"
-        path: build/artifacts.tar.gz
-    - name: make install
-      run: make install
-      working-directory: ./build
 
   external-tests-misc:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c # v4.0.0
         id: filter
         with:
           filters: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,14 @@ name: GitHub CI
 
 on:
   pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - '*.md'
+      - '*.pod'
+      - 'README*'
+      - 'funding.json'
+      - 'LICENSE.txt'
+      - 'VERSION.dat'
   push:
     paths-ignore:
       - 'doc/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,26 @@ env:
   OSSL_RUN_CI_TESTS: 1
 
 jobs:
+  check_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.filter.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docs_only:
+              - 'doc/**'
+              - '*.md'
+              - '*.pod'
+              - 'README*'
+
   check_update:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - name: install unifdef
@@ -68,6 +87,8 @@ jobs:
   # We are not as strict with libraries, but rather adapt to what's
   # expected to be available in a certain version of each platform.
   check-c99:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -79,6 +100,8 @@ jobs:
       run: make -s -j4
 
   basic_gcc:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -113,6 +136,8 @@ jobs:
         path: artifacts.tar.gz
 
   basic_clang:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -138,6 +163,8 @@ jobs:
         path: artifacts.tar.gz
 
   linux-arm64:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v6
@@ -163,6 +190,8 @@ jobs:
         path: artifacts.tar.gz
 
   gcc-min-version:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     container:
       image: docker.io/gcc:9
@@ -188,6 +217,8 @@ jobs:
       run: .github/workflows/make-test
 
   linux-x86:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -229,6 +260,8 @@ jobs:
         path: artifacts.tar.gz
 
   freebsd-x86_64:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -273,6 +306,8 @@ jobs:
         path: artifacts.tar.gz
 
   minimal:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -298,6 +333,8 @@ jobs:
         path: artifacts.tar.gz
 
   no-deprecated:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -323,6 +360,8 @@ jobs:
         path: artifacts.tar.gz
 
   no-shared-ubuntu:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -348,6 +387,8 @@ jobs:
         path: artifacts.tar.gz
 
   no-shared-macos:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v6
@@ -373,6 +414,8 @@ jobs:
         path: artifacts.tar.gz
 
   non-caching:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -402,6 +445,8 @@ jobs:
         path: artifacts.tar.gz
 
   address_ub_sanitizer:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -431,6 +476,8 @@ jobs:
         path: artifacts.tar.gz
 
   fuzz_tests:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -461,6 +508,8 @@ jobs:
         if-no-files-found: ignore
 
   memory_sanitizer:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -491,6 +540,8 @@ jobs:
         path: artifacts.tar.gz
 
   threads_sanitizer:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -520,6 +571,8 @@ jobs:
         path: artifacts.tar.gz
 
   enable_non-default_options:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -547,6 +600,8 @@ jobs:
         path: artifacts.tar.gz
 
   full_featured:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -580,6 +635,8 @@ jobs:
         path: artifacts.tar.gz
 
   no-legacy:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -605,6 +662,8 @@ jobs:
         path: artifacts.tar.gz
 
   legacy:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -635,6 +694,8 @@ jobs:
   # - That building, testing and installing works with a read-only source
   #   tree
   out-of-readonly-source-and-install-ubuntu:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -677,6 +738,8 @@ jobs:
       working-directory: ./build
 
   out-of-readonly-source-and-install-macos:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v6
@@ -719,6 +782,8 @@ jobs:
       working-directory: ./build
 
   external-tests-misc:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -763,6 +828,8 @@ jobs:
         grep -q "Reading symbols from.*libcrypto\.so\.4\.debug" results
 
   external-tests-oqs-provider:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -781,6 +848,8 @@ jobs:
       run: make test TESTS="test_external_oqsprovider"
 
   external-tests-pkcs11-provider:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     container: fedora:latest
     steps:
@@ -812,6 +881,8 @@ jobs:
         ./util/opensslwrap.sh version -c
 
   external-tests-pyca:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -845,6 +916,8 @@ jobs:
       run: make test TESTS="test_external_pyca" VERBOSE=1
 
   external-test-bssl:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -869,6 +942,8 @@ jobs:
       run: make test TESTS='test_external_ech_bssl' V=1
 
   external-test-nss:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,29 +25,7 @@ env:
   OSSL_RUN_CI_TESTS: 1
 
 jobs:
-  check_changes:
-    runs-on: ubuntu-latest
-    outputs:
-      docs_only: ${{ steps.filter.outputs.docs_only }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c # v4.0.0
-        id: filter
-        with:
-          filters: |
-            docs_only:
-              - 'doc/**'
-              - '*.md'
-              - '*.pod'
-              - 'README*'
-              - 'funding.json'
-              - 'LICENSE.txt'
-              - 'VERSION.dat'
-
   check_update:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - name: install unifdef
@@ -90,8 +68,6 @@ jobs:
   # We are not as strict with libraries, but rather adapt to what's
   # expected to be available in a certain version of each platform.
   check-c99:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -103,8 +79,6 @@ jobs:
       run: make -s -j4
 
   basic_gcc:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -139,8 +113,6 @@ jobs:
         path: artifacts.tar.gz
 
   basic_clang:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -166,8 +138,6 @@ jobs:
         path: artifacts.tar.gz
 
   linux-arm64:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v6
@@ -193,8 +163,6 @@ jobs:
         path: artifacts.tar.gz
 
   gcc-min-version:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     container:
       image: docker.io/gcc:9
@@ -220,8 +188,6 @@ jobs:
       run: .github/workflows/make-test
 
   linux-x86:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -263,8 +229,6 @@ jobs:
         path: artifacts.tar.gz
 
   freebsd-x86_64:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -309,8 +273,6 @@ jobs:
         path: artifacts.tar.gz
 
   minimal:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -336,8 +298,6 @@ jobs:
         path: artifacts.tar.gz
 
   no-deprecated:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -363,8 +323,6 @@ jobs:
         path: artifacts.tar.gz
 
   no-shared-ubuntu:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -390,8 +348,6 @@ jobs:
         path: artifacts.tar.gz
 
   no-shared-macos:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v6
@@ -417,8 +373,6 @@ jobs:
         path: artifacts.tar.gz
 
   non-caching:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -448,8 +402,6 @@ jobs:
         path: artifacts.tar.gz
 
   address_ub_sanitizer:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -479,8 +431,6 @@ jobs:
         path: artifacts.tar.gz
 
   fuzz_tests:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -511,8 +461,6 @@ jobs:
         if-no-files-found: ignore
 
   memory_sanitizer:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -543,8 +491,6 @@ jobs:
         path: artifacts.tar.gz
 
   threads_sanitizer:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -574,8 +520,6 @@ jobs:
         path: artifacts.tar.gz
 
   enable_non-default_options:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -603,8 +547,6 @@ jobs:
         path: artifacts.tar.gz
 
   full_featured:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -638,8 +580,6 @@ jobs:
         path: artifacts.tar.gz
 
   no-legacy:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -665,8 +605,6 @@ jobs:
         path: artifacts.tar.gz
 
   legacy:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -697,8 +635,6 @@ jobs:
   # - That building, testing and installing works with a read-only source
   #   tree
   out-of-readonly-source-and-install-ubuntu:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -741,8 +677,6 @@ jobs:
       working-directory: ./build
 
   out-of-readonly-source-and-install-macos:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v6
@@ -785,8 +719,6 @@ jobs:
       working-directory: ./build
 
   external-tests-misc:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -831,8 +763,6 @@ jobs:
         grep -q "Reading symbols from.*libcrypto\.so\.4\.debug" results
 
   external-tests-oqs-provider:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -851,8 +781,6 @@ jobs:
       run: make test TESTS="test_external_oqsprovider"
 
   external-tests-pkcs11-provider:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     container: fedora:latest
     steps:
@@ -884,8 +812,6 @@ jobs:
         ./util/opensslwrap.sh version -c
 
   external-tests-pyca:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -919,8 +845,6 @@ jobs:
       run: make test TESTS="test_external_pyca" VERBOSE=1
 
   external-test-bssl:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -945,8 +869,6 @@ jobs:
       run: make test TESTS='test_external_ech_bssl' V=1
 
   external-test-nss:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
               - '*.md'
               - '*.pod'
               - 'README*'
+              - 'funding.json'
+              - 'LICENSE.txt'
+              - 'VERSION.dat'
 
   check_update:
     needs: check_changes

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -7,7 +7,17 @@
 
 name: Cross Compile
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    paths-ignore:
+      - 'doc/**'
+      - '*.md'
+      - '*.pod'
+      - 'README*'
+      - 'funding.json'
+      - 'LICENSE.txt'
+      - 'VERSION.dat'
 
 permissions:
   contents: read

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -9,6 +9,14 @@ name: Cross Compile
 
 on:
   pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - '*.md'
+      - '*.pod'
+      - 'README*'
+      - 'funding.json'
+      - 'LICENSE.txt'
+      - 'VERSION.dat'
   push:
     paths-ignore:
       - 'doc/**'

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -28,6 +28,9 @@ jobs:
               - '*.md'
               - '*.pod'
               - 'README*'
+              - 'funding.json'
+              - 'LICENSE.txt'
+              - 'VERSION.dat'
 
   cross-compilation:
     needs: check_changes

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -13,28 +13,7 @@ permissions:
   contents: read
 
 jobs:
-  check_changes:
-    runs-on: ubuntu-latest
-    outputs:
-      docs_only: ${{ steps.filter.outputs.docs_only }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c # v4.0.0
-        id: filter
-        with:
-          filters: |
-            docs_only:
-              - 'doc/**'
-              - '*.md'
-              - '*.pod'
-              - 'README*'
-              - 'funding.json'
-              - 'LICENSE.txt'
-              - 'VERSION.dat'
-
   cross-compilation:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -19,7 +19,7 @@ jobs:
       docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -13,7 +13,23 @@ permissions:
   contents: read
 
 jobs:
+  check_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.filter.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docs_only:
+              - 'doc/**'
+              - '*.md'
+
   cross-compilation:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -19,13 +19,15 @@ jobs:
       docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c # v4.0.0
         id: filter
         with:
           filters: |
             docs_only:
               - 'doc/**'
               - '*.md'
+              - '*.pod'
+              - 'README*'
 
   cross-compilation:
     needs: check_changes

--- a/.github/workflows/fips-checksums.yml
+++ b/.github/workflows/fips-checksums.yml
@@ -6,7 +6,16 @@
 # https://www.openssl.org/source/license.html
 
 name: FIPS Check and ABIDIFF
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - '*.md'
+      - '*.pod'
+      - 'README*'
+      - 'funding.json'
+      - 'LICENSE.txt'
+      - 'VERSION.dat'
 
 permissions:
   contents: read

--- a/.github/workflows/perl-minimal-checker.yml
+++ b/.github/workflows/perl-minimal-checker.yml
@@ -7,7 +7,17 @@
 
 # Jobs run per pull request submission
 name: Perl-minimal-checker CI
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    paths-ignore:
+      - 'doc/**'
+      - '*.md'
+      - '*.pod'
+      - 'README*'
+      - 'funding.json'
+      - 'LICENSE.txt'
+      - 'VERSION.dat'
 permissions:
   contents: read
 

--- a/.github/workflows/perl-minimal-checker.yml
+++ b/.github/workflows/perl-minimal-checker.yml
@@ -9,6 +9,14 @@
 name: Perl-minimal-checker CI
 on:
   pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - '*.md'
+      - '*.pod'
+      - 'README*'
+      - 'funding.json'
+      - 'LICENSE.txt'
+      - 'VERSION.dat'
   push:
     paths-ignore:
       - 'doc/**'

--- a/.github/workflows/prov-compat-label.yml
+++ b/.github/workflows/prov-compat-label.yml
@@ -10,7 +10,16 @@
 
 name: Provider compatibility for PRs
 
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - '*.md'
+      - '*.pod'
+      - 'README*'
+      - 'funding.json'
+      - 'LICENSE.txt'
+      - 'VERSION.dat'
 
 permissions:
   contents: read

--- a/.github/workflows/riscv-more-cross-compiles.yml
+++ b/.github/workflows/riscv-more-cross-compiles.yml
@@ -10,6 +10,14 @@ name: Cross Compile for RISC-V Extensions
 on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
+    paths-ignore:
+      - 'doc/**'
+      - '*.md'
+      - '*.pod'
+      - 'README*'
+      - 'funding.json'
+      - 'LICENSE.txt'
+      - 'VERSION.dat'
   push:
   schedule:
     - cron: '35 02 * * *'

--- a/.github/workflows/riscv-more-cross-compiles.yml
+++ b/.github/workflows/riscv-more-cross-compiles.yml
@@ -19,14 +19,35 @@ permissions:
   contents: read
 
 jobs:
+  check_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.filter.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c # v4.0.0
+        id: filter
+        with:
+          filters: |
+            docs_only:
+              - 'doc/**'
+              - '*.md'
+              - '*.pod'
+              - 'README*'
+              - 'funding.json'
+              - 'LICENSE.txt'
+              - 'VERSION.dat'
+
   cross-compilation-riscv:
+    needs: check_changes
     # pull request title contains 'riscv'
     # pull request title contains 'RISC-V'
     # pull request body contains '[riscv ci]'
     # push event commit message contains '[riscv ci]'
     # cron job
     # manual dispatch
-    if: contains(github.event.pull_request.title, 'riscv') || contains(github.event.pull_request.title, 'RISC-V') || contains(github.event.pull_request.body, '[riscv ci]') || contains(github.event.head_commit.message, '[riscv ci]') || (github.event_name == 'schedule' && github.repository == 'openssl/openssl') || github.event_name == 'workflow_dispatch'
+    if: needs.check_changes.outputs.docs_only != 'true' && (contains(github.event.pull_request.title, 'riscv') || contains(github.event.pull_request.title, 'RISC-V') || contains(github.event.pull_request.body, '[riscv ci]') || contains(github.event.head_commit.message, '[riscv ci]') || (github.event_name == 'schedule' && github.repository == 'openssl/openssl') || github.event_name == 'workflow_dispatch')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/riscv-more-cross-compiles.yml
+++ b/.github/workflows/riscv-more-cross-compiles.yml
@@ -19,35 +19,14 @@ permissions:
   contents: read
 
 jobs:
-  check_changes:
-    runs-on: ubuntu-latest
-    outputs:
-      docs_only: ${{ steps.filter.outputs.docs_only }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c # v4.0.0
-        id: filter
-        with:
-          filters: |
-            docs_only:
-              - 'doc/**'
-              - '*.md'
-              - '*.pod'
-              - 'README*'
-              - 'funding.json'
-              - 'LICENSE.txt'
-              - 'VERSION.dat'
-
   cross-compilation-riscv:
-    needs: check_changes
     # pull request title contains 'riscv'
     # pull request title contains 'RISC-V'
     # pull request body contains '[riscv ci]'
     # push event commit message contains '[riscv ci]'
     # cron job
     # manual dispatch
-    if: needs.check_changes.outputs.docs_only != 'true' && (contains(github.event.pull_request.title, 'riscv') || contains(github.event.pull_request.title, 'RISC-V') || contains(github.event.pull_request.body, '[riscv ci]') || contains(github.event.head_commit.message, '[riscv ci]') || (github.event_name == 'schedule' && github.repository == 'openssl/openssl') || github.event_name == 'workflow_dispatch')
+    if: contains(github.event.pull_request.title, 'riscv') || contains(github.event.pull_request.title, 'RISC-V') || contains(github.event.pull_request.body, '[riscv ci]') || contains(github.event.head_commit.message, '[riscv ci]') || (github.event_name == 'schedule' && github.repository == 'openssl/openssl') || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -7,7 +7,17 @@
 
 # Jobs run per pull request submission
 name: Run-checker CI
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    paths-ignore:
+      - 'doc/**'
+      - '*.md'
+      - '*.pod'
+      - 'README*'
+      - 'funding.json'
+      - 'LICENSE.txt'
+      - 'VERSION.dat'
 permissions:
   contents: read
 

--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -15,29 +15,7 @@ env:
   OSSL_RUN_CI_TESTS: 1
 
 jobs:
-  check_changes:
-    runs-on: ubuntu-latest
-    outputs:
-      docs_only: ${{ steps.filter.outputs.docs_only }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c # v4.0.0
-        id: filter
-        with:
-          filters: |
-            docs_only:
-              - 'doc/**'
-              - '*.md'
-              - '*.pod'
-              - 'README*'
-              - 'funding.json'
-              - 'LICENSE.txt'
-              - 'VERSION.dat'
-
   run-checker:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c # v4.0.0
         id: filter
         with:
           filters: |

--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -9,6 +9,14 @@
 name: Run-checker CI
 on:
   pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - '*.md'
+      - '*.pod'
+      - 'README*'
+      - 'funding.json'
+      - 'LICENSE.txt'
+      - 'VERSION.dat'
   push:
     paths-ignore:
       - 'doc/**'

--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -15,7 +15,26 @@ env:
   OSSL_RUN_CI_TESTS: 1
 
 jobs:
+  check_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.filter.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docs_only:
+              - 'doc/**'
+              - '*.md'
+              - '*.pod'
+              - 'README*'
+
   run-checker:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -31,6 +31,9 @@ jobs:
               - '*.md'
               - '*.pod'
               - 'README*'
+              - 'funding.json'
+              - 'LICENSE.txt'
+              - 'VERSION.dat'
 
   run-checker:
     needs: check_changes

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -7,7 +7,16 @@
 
 name: Coding style validation 
 
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - '*.md'
+      - '*.pod'
+      - 'README*'
+      - 'funding.json'
+      - 'LICENSE.txt'
+      - 'VERSION.dat'
 
 jobs:
   check-style:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,18 @@
 
 name: Windows GitHub CI
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    paths-ignore:
+      - 'doc/**'
+      - '*.md'
+      - '*.pod'
+      - 'README*'
+      - 'funding.json'
+      - 'LICENSE.txt'
+      - 'VERSION.dat'
+
 
 permissions:
   contents: read

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,6 +9,14 @@ name: Windows GitHub CI
 
 on:
   pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - '*.md'
+      - '*.pod'
+      - 'README*'
+      - 'funding.json'
+      - 'LICENSE.txt'
+      - 'VERSION.dat'
   push:
     paths-ignore:
       - 'doc/**'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,23 @@ permissions:
   contents: read
 
 jobs:
+  check_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.filter.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docs_only:
+              - 'doc/**'
+              - '*.md'
+
   shared:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     # Run a job for each of the specified target architectures:
     strategy:
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,28 +13,7 @@ permissions:
   contents: read
 
 jobs:
-  check_changes:
-    runs-on: ubuntu-latest
-    outputs:
-      docs_only: ${{ steps.filter.outputs.docs_only }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c # v4.0.0
-        id: filter
-        with:
-          filters: |
-            docs_only:
-              - 'doc/**'
-              - '*.md'
-              - '*.pod'
-              - 'README*'
-              - 'funding.json'
-              - 'LICENSE.txt'
-              - 'VERSION.dat'
-
   shared:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     # Run a job for each of the specified target architectures:
     strategy:
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,6 +28,9 @@ jobs:
               - '*.md'
               - '*.pod'
               - 'README*'
+              - 'funding.json'
+              - 'LICENSE.txt'
+              - 'VERSION.dat'
 
   shared:
     needs: check_changes

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ jobs:
       docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,13 +19,15 @@ jobs:
       docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c # v4.0.0
         id: filter
         with:
           filters: |
             docs_only:
               - 'doc/**'
               - '*.md'
+              - '*.pod'
+              - 'README*'
 
   shared:
     needs: check_changes

--- a/.github/workflows/windows_comp.yml
+++ b/.github/workflows/windows_comp.yml
@@ -20,29 +20,7 @@ permissions:
   contents: read
 
 jobs:
-  check_changes:
-    runs-on: ubuntu-latest
-    outputs:
-      docs_only: ${{ steps.filter.outputs.docs_only }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c # v4.0.0
-        id: filter
-        with:
-          filters: |
-            docs_only:
-              - 'doc/**'
-              - '*.md'
-              - '*.pod'
-              - 'README*'
-              - 'funding.json'
-              - 'LICENSE.txt'
-              - 'VERSION.dat'
-
   zstd:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v6
@@ -106,8 +84,6 @@ jobs:
         nmake test VERBOSE_FAILURE=yes TESTS="-test_fuzz* -test_fipsload" HARNESS_JOBS=4
 
   brotli:
-    needs: check_changes
-    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/windows_comp.yml
+++ b/.github/workflows/windows_comp.yml
@@ -20,7 +20,29 @@ permissions:
   contents: read
 
 jobs:
+  check_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.filter.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c # v4.0.0
+        id: filter
+        with:
+          filters: |
+            docs_only:
+              - 'doc/**'
+              - '*.md'
+              - '*.pod'
+              - 'README*'
+              - 'funding.json'
+              - 'LICENSE.txt'
+              - 'VERSION.dat'
+
   zstd:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v6
@@ -84,6 +106,8 @@ jobs:
         nmake test VERBOSE_FAILURE=yes TESTS="-test_fuzz* -test_fipsload" HARNESS_JOBS=4
 
   brotli:
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_only != 'true'
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Skips builds of PR that contain documentation only changes.