### PR TITLE
riscv: fix missing VLEN >= 128 guard in AES-GCM dispatch

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_gcm_hw_rv64i.inc
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw_rv64i.inc
@@ -103,10 +103,9 @@ static const PROV_GCM_HW rv64i_zvkb_zvkg_zvkned_gcm = {
 };
 
 const PROV_GCM_HW *ossl_prov_aes_hw_gcm(size_t keybits) {
-    if (RISCV_HAS_ZVKNED()) {
-      if (RISCV_HAS_ZVKB() && RISCV_HAS_ZVKG() && riscv_vlen() >= 128) {
+    if (RISCV_HAS_ZVKNED() && riscv_vlen() >= 128) {
+      if (RISCV_HAS_ZVKB() && RISCV_HAS_ZVKG())
         return &rv64i_zvkb_zvkg_zvkned_gcm;
-      }
       return &rv64i_zvkned_gcm;
     }
 


### PR DESCRIPTION
ossl_prov_aes_hw_gcm() returned &rv64i_zvkned_gcm when RISCV_HAS_ZVKNED() was true but RISCV_HAS_ZVKB()/RISCV_HAS_ZVKG() were false, without checking riscv_vlen() >= 128. All Zvkned instructions require VLEN >= 128; on VLEN=64 hardware this would cause illegal-instruction traps.

All other Zvk* dispatch sites already guard on riscv_vlen() >= 128. Hoist the check to the outer if (RISCV_HAS_ZVKNED()) condition to cover both return paths uniformly.