### PR TITLE
[3.5] Windows CI jobs updates

### DIFF
--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -133,8 +133,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, windows-2025]
-    runs-on: ${{ matrix.os }}
+        platform:
+          - os: windows-2022
+            vcvars: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+          - os: windows-2025
+            vcvars: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+    runs-on: ${{ matrix.platform.os }}
     steps:
     - uses: actions/checkout@v6
       with:
@@ -145,23 +149,25 @@ jobs:
       run: |
         choco install nasm
         "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
-    - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 #v1.13.0
     - name: prepare the build directory
       run: mkdir _build
     - name: config
       working-directory: _build
-      run: perl ..\Configure --banner=Configured no-makedepend enable-fips
-    - name: config dump
-      working-directory: _build
-      run: ./configdata.pm --dump
+      shell: cmd
+      run: |
+        call "${{ matrix.platform.vcvars }}"
+        perl ..\Configure --banner=Configured no-makedepend enable-fips
+        perl configdata.pm --dump
     - name: build
       working-directory: _build
-      run: nmake /S
+      shell: cmd
+      run: |
+        call "${{ matrix.platform.vcvars }}"
+        nmake /S
     - name: download coreinfo
-      uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9 #v1.6.0
-      with:
-        url: "https://download.sysinternals.com/files/Coreinfo.zip"
-        target: _build/coreinfo/
+      run: |
+        mkdir _build\coreinfo
+        Invoke-WebRequest -Uri "https://download.sysinternals.com/files/Coreinfo.zip" -outfile "_build\coreinfo\Coreinfo.zip"
     - name: get cpu info
       working-directory: _build
       run: |
@@ -170,7 +176,10 @@ jobs:
         apps/openssl.exe version -c
     - name: test
       working-directory: _build
-      run: nmake test VERBOSE_FAILURE=yes HARNESS_JOBS=4 LHASH_WORKERS=16
+      shell: cmd
+      run: |
+        call "${{ matrix.platform.vcvars }}"
+        nmake test VERBOSE_FAILURE=yes HARNESS_JOBS=4 LHASH_WORKERS=16
 
   linux-arm64:
     runs-on: linux-arm64

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,15 +18,18 @@ jobs:
     strategy:
       matrix:
         platform:
-          - arch: win64
+          - arch: amd64
             os: windows-2022
             config: enable-fips
-          - arch: win64
+            vcvars: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+          - arch: amd64
             os: windows-2025
             config: enable-fips no-thread-pool no-quic
-          - arch: win32
-            os: windows-2025
-            config: --strict-warnings no-fips
+            vcvars: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+          - arch: x86
+            os: windows-2022
+            config: no-fips
+            vcvars: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat
     runs-on: ${{ matrix.platform.os }}
     steps:
     - uses: actions/checkout@v6
@@ -34,28 +37,29 @@ jobs:
         persist-credentials: false
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
-    - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 #v1.13.0
-      with:
-        arch: ${{ matrix.platform.arch }}
     - name: install nasm
       run: |
-        choco install nasm ${{ matrix.platform.arch == 'win32' && '--x86' || '' }}
-        "C:\Program Files${{ matrix.platform.arch == 'win32' && ' (x86)' || '' }}\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+        choco install nasm ${{ matrix.platform.arch == 'x86' && '--x86' || '' }}
+        "C:\Program Files${{ matrix.platform.arch == 'x86' && ' (x86)' || '' }}\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: prepare the build directory
       run: mkdir _build
     - name: config
       working-directory: _build
+      shell: cmd
       run: |
+        call "${{ matrix.platform.vcvars }}"
         perl ..\Configure --banner=Configured no-makedepend -DOSSL_WINCTX=openssl ${{ matrix.platform.config }}
         perl configdata.pm --dump
     - name: build
       working-directory: _build
-      run: nmake /S
+      shell: cmd
+      run: |
+        call "${{ matrix.platform.vcvars }}"
+        nmake /S
     - name: download coreinfo
-      uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9 #v1.6.0
-      with:
-        url: "https://download.sysinternals.com/files/Coreinfo.zip"
-        target: _build/coreinfo/
+      run: |
+        mkdir _build\coreinfo
+        Invoke-WebRequest -Uri "https://download.sysinternals.com/files/Coreinfo.zip" -outfile "_build\coreinfo\Coreinfo.zip"
     - name: Gather openssl version info
       working-directory: _build
       run: |
@@ -87,42 +91,47 @@ jobs:
         perl ../util/checkplatformsyms.pl ../util/platform_symbols/windows-symbols.txt libcrypto-%OSSL_MAJOR%${{ matrix.platform.arch == 'amd64' && '-x64' || '' }}.dll ./libssl-%OSSL_MAJOR%${{ matrix.platform.arch == 'amd64' && '-x64' || '' }}.dll
     - name: test
       working-directory: _build
-      run: nmake test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4
+      shell: cmd
+      run: |
+        call "${{ matrix.platform.vcvars }}"
+        nmake test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4
     - name: install
       # Run on 64 bit only as 32 bit is slow enough already
-      if: ${{ matrix.platform.arch == 'win64' }}
+      if: ${{ matrix.platform.arch == 'amd64' }}
+      working-directory: _build
+      shell: cmd
       run: |
+        call "${{ matrix.platform.vcvars }}"
         mkdir _dest
         nmake install DESTDIR=_dest
-      working-directory: _build
+
   plain:
-    strategy:
-      matrix:
-        os:
-          - windows-2022
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v6
       with:
         persist-credentials: false
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
-    - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 #v1.13.0
     - name: prepare the build directory
       run: mkdir _build
     - name: config
       working-directory: _build
+      shell: cmd
       run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         perl ..\Configure --banner=Configured enable-demos no-makedepend no-shared no-fips enable-md2 enable-rc5 enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-trace enable-crypto-mdebug -DOSSL_WINCTX=openssl VC-WIN64A-masm
         perl configdata.pm --dump
     - name: build
       working-directory: _build
-      run: nmake /S
+      shell: cmd
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        nmake /S
     - name: download coreinfo
-      uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9 #v1.6.0
-      with:
-        url: "https://download.sysinternals.com/files/Coreinfo.zip"
-        target: _build/coreinfo/
+      run: |
+        mkdir _build\coreinfo
+        Invoke-WebRequest -Uri "https://download.sysinternals.com/files/Coreinfo.zip" -outfile "_build\coreinfo\Coreinfo.zip"
     - name: get cpu info
       working-directory: _build
       continue-on-error: true
@@ -132,35 +141,38 @@ jobs:
         ./apps/openssl.exe version -c
     - name: test
       working-directory: _build
-      run: nmake test VERBOSE_FAILURE=yes HARNESS_JOBS=4
+      shell: cmd
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        nmake test VERBOSE_FAILURE=yes HARNESS_JOBS=4
+
   minimal:
-    strategy:
-      matrix:
-        os:
-          - windows-2022
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v6
       with:
         persist-credentials: false
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
-    - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 #v1.13.0
     - name: prepare the build directory
       run: mkdir _build
     - name: config
       working-directory: _build
+      shell: cmd
       run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         perl ..\Configure --banner=Configured enable-demos no-makedepend no-bulk no-deprecated no-fips no-asm no-threads -DOPENSSL_SMALL_FOOTPRINT -DOSSL_WINCTX=openssl
         perl configdata.pm --dump
     - name: build
       working-directory: _build
-      run: nmake # verbose, so no /S here
+      shell: cmd
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        nmake
     - name: download coreinfo
-      uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9 #v1.6.0
-      with:
-        url: "https://download.sysinternals.com/files/Coreinfo.zip"
-        target: _build/coreinfo/
+      run: |
+        mkdir _build\coreinfo
+        Invoke-WebRequest -Uri "https://download.sysinternals.com/files/Coreinfo.zip" -outfile "_build\coreinfo\Coreinfo.zip"
     - name: get cpu info
       working-directory: _build
       continue-on-error: true
@@ -170,7 +182,11 @@ jobs:
         ./apps/openssl.exe version -c
     - name: test
       working-directory: _build
-      run: nmake test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4
+      shell: cmd
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        nmake test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4
+
   cygwin:
     # Run a job for each of the specified target architectures:
     strategy:

--- a/.github/workflows/windows_comp.yml
+++ b/.github/workflows/windows_comp.yml
@@ -32,25 +32,28 @@ jobs:
       run: |
         choco install nasm
         "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
-    - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 #v1.13.0
     - name: prepare the build directory
       run: mkdir _build
     - name: Get zstd
-      working-directory: _build
       run: |
         vcpkg install zstd:x64-windows
+        "C:\vcpkg\packages\zstd_x64-windows\bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: config
       working-directory: _build
+      shell: cmd
       run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         perl ..\Configure enable-comp enable-zstd --with-zstd-include=C:\vcpkg\packages\zstd_x64-windows\include --with-zstd-lib=C:\vcpkg\packages\zstd_x64-windows\lib\zstd.lib no-makedepend -DOSSL_WINCTX=openssl VC-WIN64A
         perl configdata.pm --dump
     - name: build
       working-directory: _build
-      run: nmake
+      shell: cmd
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        nmake
     - name: Gather openssl version info
       working-directory: _build
       run: |
-        $env:Path+=";C:\vcpkg\packages\zstd_x64-windows\bin"
         apps/openssl.exe version -v
         apps/openssl.exe version -v | %{($_ -split '\s+')[1]}
         apps/openssl.exe version -v | %{($_ -split '\s+')[1] -replace '([0-9]+\.[0-9]+)(\..*)','$1'}
@@ -64,23 +67,23 @@ jobs:
         reg.exe add HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v MODULESDIR /t REG_EXPAND_SZ /d TESTOPENSSLDIR /reg:32
         reg.exe query HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v OPENSSLDIR /reg:32
     - name: download coreinfo
-      uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9 #v1.6.0
-      with:
-        url: "https://download.sysinternals.com/files/Coreinfo.zip"
-        target: _build/coreinfo/
+      run: |
+        mkdir _build\coreinfo
+        Invoke-WebRequest -Uri "https://download.sysinternals.com/files/Coreinfo.zip" -outfile "_build\coreinfo\Coreinfo.zip"
     - name: get cpu info
       working-directory: _build
       continue-on-error: true
       run: |
-        $env:Path+=";C:\vcpkg\packages\zstd_x64-windows\bin"
         7z.exe x coreinfo/Coreinfo.zip
         ./Coreinfo64.exe -accepteula -f
         ./apps/openssl.exe version -c
     - name: test
       working-directory: _build
+      shell: cmd
       run: |
-        $env:Path+=";C:\vcpkg\packages\zstd_x64-windows\bin"
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         nmake test VERBOSE_FAILURE=yes TESTS="-test_fuzz* -test_fipsload" HARNESS_JOBS=4
+
   brotli:
     runs-on: windows-latest
     steps:
@@ -93,25 +96,28 @@ jobs:
       run: |
         choco install nasm
         "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
-    - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 #v1.13.0
     - name: prepare the build directory
       run: mkdir _build
     - name: Get brotli
-      working-directory: _build
       run: |
         vcpkg install brotli:x64-windows
+        "C:\vcpkg\packages\brotli_x64-windows\bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: config
       working-directory: _build
+      shell: cmd
       run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         perl ..\Configure enable-comp enable-brotli --with-brotli-include=C:\vcpkg\packages\brotli_x64-windows\include --with-brotli-lib=C:\vcpkg\packages\brotli_x64-windows\lib no-makedepend -DOSSL_WINCTX=openssl VC-WIN64A
         perl configdata.pm --dump
     - name: build
       working-directory: _build
-      run: nmake
+      shell: cmd
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        nmake
     - name: Gather openssl version info
       working-directory: _build
       run: |
-        $env:Path+=";C:\vcpkg\packages\brotli_x64-windows\bin"
         apps/openssl.exe version -v
         apps/openssl.exe version -v | %{($_ -split '\s+')[1]}
         apps/openssl.exe version -v | %{($_ -split '\s+')[1] -replace '([0-9]+\.[0-9]+)(\..*)','$1'}
@@ -125,20 +131,19 @@ jobs:
         reg.exe add HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v MODULESDIR /t REG_EXPAND_SZ /d TESTOPENSSLDIR /reg:32
         reg.exe query HKLM\SOFTWARE\OpenSSL-${Env:OSSL_VERSION}-openssl /v OPENSSLDIR /reg:32
     - name: download coreinfo
-      uses: suisei-cn/actions-download-file@818d6b7dc8fe73f2f924b6241f2b1134ca1377d9 #v1.6.0
-      with:
-        url: "https://download.sysinternals.com/files/Coreinfo.zip"
-        target: _build/coreinfo/
+      run: |
+        mkdir _build\coreinfo
+        Invoke-WebRequest -Uri "https://download.sysinternals.com/files/Coreinfo.zip" -outfile "_build\coreinfo\Coreinfo.zip"
     - name: get cpu info
       working-directory: _build
       continue-on-error: true
       run: |
-        $env:Path+=";C:\vcpkg\packages\brotli_x64-windows\bin"
         7z.exe x coreinfo/Coreinfo.zip
         ./Coreinfo64.exe -accepteula -f
         ./apps/openssl.exe version -c
     - name: test
       working-directory: _build
+      shell: cmd
       run: |
-        $env:Path+=";C:\vcpkg\packages\brotli_x64-windows\bin"
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         nmake test VERBOSE_FAILURE=yes TESTS="-test_fuzz* -test_fipsload" HARNESS_JOBS=4


### PR DESCRIPTION
`windows.yml` and `windows_comp.yml` lacked commit d9044daf1eea "replace GitHub Actions in Windows jobs" in older branches, so the usage of the new `vcvars` variable and the new value of the `arch` variable introduced in commit df8417dcb621 "Update Windows CI workflow to supply correct DLLs to checkplatformsyms.pl" has broken the CI.  Fix it by backporting it. Urgent per broken CI.