### PR TITLE
Fix memory leak in ossl_uint_set_insert()

### DIFF
--- a/ssl/quic/uint_set.c
+++ b/ssl/quic/uint_set.c
@@ -174,6 +174,7 @@ int ossl_uint_set_insert(UINT_SET *s, const UINT_RANGE *range)
         for (x = ossl_list_uint_set_next(x); x != NULL; x = xnext) {
             xnext = ossl_list_uint_set_next(x);
             ossl_list_uint_set_remove(s, x);
+            OPENSSL_free(x);
         }
         return 1;
     }


### PR DESCRIPTION
There is a missing call to OPENSSL_free() in the branch where existing sets are merged to new range. There is no evidence/POC OpenSSL poject is aware of the leak can be triggered by QUIC protocol operation.

The issue has been kindly reported by Abhinav Agarwal (@abhinavagarwal07)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
