### PR TITLE
OSSL_PARAM_BLD_push_octet_*(): Allow NULL buffer with 0 bsize

### DIFF
--- a/crypto/param_build.c
+++ b/crypto/param_build.c
@@ -345,7 +345,7 @@ int OSSL_PARAM_BLD_push_utf8_ptr(OSSL_PARAM_BLD *bld, const char *key,
 {
     OSSL_PARAM_BLD_DEF *pd;
 
-    if (bld == NULL || key == NULL) {
+    if (bld == NULL || key == NULL || buf == NULL) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
@@ -365,7 +365,7 @@ int OSSL_PARAM_BLD_push_octet_string(OSSL_PARAM_BLD *bld, const char *key,
     OSSL_PARAM_BLD_DEF *pd;
     int secure;
 
-    if (bld == NULL || key == NULL || buf == NULL) {
+    if (bld == NULL || key == NULL || (buf == NULL && bsize != 0)) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
@@ -383,7 +383,7 @@ int OSSL_PARAM_BLD_push_octet_ptr(OSSL_PARAM_BLD *bld, const char *key,
 {
     OSSL_PARAM_BLD_DEF *pd;
 
-    if (bld == NULL || key == NULL) {
+    if (bld == NULL || key == NULL || (buf == NULL && bsize != 0)) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }

--- a/test/param_build_test.c
+++ b/test/param_build_test.c
@@ -117,7 +117,11 @@ static int template_public_test(int tstid)
         || !TEST_true(OSSL_PARAM_BLD_push_BN(bld, "negativebignumber", nbn))
         || !TEST_true(OSSL_PARAM_BLD_push_utf8_string(bld, "utf8_s", "foo",
             sizeof("foo")))
+        || !TEST_true(OSSL_PARAM_BLD_push_octet_string(bld, "octet_s", NULL,
+            0))
         || !TEST_true(OSSL_PARAM_BLD_push_utf8_ptr(bld, "utf8_p", "bar-boom",
+            0))
+        || !TEST_true(OSSL_PARAM_BLD_push_octet_ptr(bld, "octet_p", NULL,
             0))
         || !TEST_true(OSSL_PARAM_BLD_push_int(bld, "i", -6))
         || !TEST_ptr(params_blt = OSSL_PARAM_BLD_to_param(bld)))
@@ -189,10 +193,16 @@ static int template_public_test(int tstid)
         || !TEST_str_eq(p->data, "foo")
         || !TEST_true(OSSL_PARAM_get_utf8_string(p, &utf, 0))
         || !TEST_str_eq(utf, "foo")
+        /* Check NULL octet string */
+        || !TEST_ptr(p = OSSL_PARAM_locate(params, "octet_s"))
+        || !TEST_ptr_null(p->data)
         /* Check UTF8 pointer */
         || !TEST_ptr(p = OSSL_PARAM_locate(params, "utf8_p"))
         || !TEST_true(OSSL_PARAM_get_utf8_ptr(p, &cutf))
         || !TEST_str_eq(cutf, "bar-boom")
+        /* Check NULL octet ptr */
+        || !TEST_ptr(p = OSSL_PARAM_locate(params, "octet_p"))
+        || !TEST_ptr_null(p->data)
         /* Check BN (zero BN becomes unsigned integer) */
         || !TEST_ptr(p = OSSL_PARAM_locate(params, "zeronumber"))
         || !TEST_str_eq(p->key, "zeronumber")

--- a/test/param_build_test.c
+++ b/test/param_build_test.c
@@ -195,14 +195,14 @@ static int template_public_test(int tstid)
         || !TEST_str_eq(utf, "foo")
         /* Check NULL octet string */
         || !TEST_ptr(p = OSSL_PARAM_locate(params, "octet_s"))
-        || !TEST_ptr_null(p->data)
+        || !TEST_size_t_eq(p->data_size, 0)
         /* Check UTF8 pointer */
         || !TEST_ptr(p = OSSL_PARAM_locate(params, "utf8_p"))
         || !TEST_true(OSSL_PARAM_get_utf8_ptr(p, &cutf))
         || !TEST_str_eq(cutf, "bar-boom")
         /* Check NULL octet ptr */
         || !TEST_ptr(p = OSSL_PARAM_locate(params, "octet_p"))
-        || !TEST_ptr_null(p->data)
+        || !TEST_size_t_eq(p->data_size, 0)
         /* Check BN (zero BN becomes unsigned integer) */
         || !TEST_ptr(p = OSSL_PARAM_locate(params, "zeronumber"))
         || !TEST_str_eq(p->key, "zeronumber")


### PR DESCRIPTION
Fixes #30728
