### PR TITLE
Fix off-by-one s_client overflows (3.6/3.5/3.4/3.0 backport)

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2549,7 +2549,7 @@ re_start:
                          "xmlns='jabber:%s' to='%s' version='1.0'>",
             starttls_proto == PROTO_XMPP ? "client" : "server",
             protohost ? protohost : host);
-        seen = BIO_read(sbio, mbuf, BUFSIZZ);
+        seen = BIO_read(sbio, mbuf, BUFSIZZ - 1);
         if (seen < 0) {
             BIO_printf(bio_err, "BIO_read failed\n");
             goto end;
@@ -2558,7 +2558,7 @@ re_start:
         while (!strstr(mbuf, "<starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'")
             && !strstr(mbuf,
                 "<starttls xmlns=\"urn:ietf:params:xml:ns:xmpp-tls\"")) {
-            seen = BIO_read(sbio, mbuf, BUFSIZZ);
+            seen = BIO_read(sbio, mbuf, BUFSIZZ - 1);
 
             if (seen <= 0)
                 goto shut;
@@ -2567,7 +2567,7 @@ re_start:
         }
         BIO_printf(sbio,
             "<starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/>");
-        seen = BIO_read(sbio, sbuf, BUFSIZZ);
+        seen = BIO_read(sbio, sbuf, BUFSIZZ - 1);
         if (seen < 0) {
             BIO_printf(bio_err, "BIO_read failed\n");
             goto shut;
@@ -2792,7 +2792,7 @@ re_start:
                 "Didn't find STARTTLS in server response,"
                 " trying anyway...\n");
         BIO_printf(sbio, "STARTTLS\r\n");
-        mbuf_len = BIO_read(sbio, mbuf, BUFSIZZ);
+        mbuf_len = BIO_read(sbio, mbuf, BUFSIZZ - 1);
         if (mbuf_len < 0) {
             BIO_printf(bio_err, "BIO_read failed\n");
             goto end;
@@ -2833,7 +2833,7 @@ re_start:
                 "Didn't find STARTTLS in server response,"
                 " trying anyway...\n");
         BIO_printf(sbio, "STARTTLS\r\n");
-        mbuf_len = BIO_read(sbio, mbuf, BUFSIZZ);
+        mbuf_len = BIO_read(sbio, mbuf, BUFSIZZ - 1);
         if (mbuf_len < 0) {
             BIO_printf(bio_err, "BIO_read failed\n");
             goto end;


### PR DESCRIPTION
There are one byte buffer overflows possible in s_client's handling of STARTTLS in various protocols. If a server's response fills the entire buffer (16k) then we attempt to add a NUL terminator one byte off the end of the buffer.

This was reported by Igor Morgenstern from AISLE to openssl-security and assessed by the security team as "bug or hardening only".
