### PR TITLE
riscv: fix RV32 issues found during validation

### DIFF
--- a/crypto/info.c
+++ b/crypto/info.c
@@ -180,7 +180,7 @@ DEFINE_RUN_ONCE_STATIC(init_info_strings)
     if (RISCV_HAS_V())
         BIO_snprintf(ossl_cpu_info_str + strlen(ossl_cpu_info_str),
             sizeof(ossl_cpu_info_str) - strlen(ossl_cpu_info_str),
-            " vlen:%lu", riscv_vlen());
+            " vlen:%zu", riscv_vlen());
     if ((env = getenv("OPENSSL_riscvcap")) != NULL)
         BIO_snprintf(ossl_cpu_info_str + strlen(ossl_cpu_info_str),
             sizeof(ossl_cpu_info_str) - strlen(ossl_cpu_info_str),

--- a/doc/man3/OPENSSL_riscvcap.pod
+++ b/doc/man3/OPENSSL_riscvcap.pod
@@ -29,7 +29,7 @@ Vector extension.
  OPENSSL_riscvcap="rv64gc_v_zba_zbb_zbs..."
 
 Note that extension implication is currently not implemented.
-For example, when "rv64gc_b" is provided as the environment variable,
+For example, when C<rv64gc_b> is provided as the environment variable,
 zba/zbb/zbs would not be implied in the capability vector.
 
 Currently only these extensions are recognized:
@@ -200,6 +200,10 @@ there is no way to override the riscv_vlen by the environment variable.
 Disables all instruction set extensions:
 
  export OPENSSL_riscvcap="rv64gc"
+
+Same for an RV32 build:
+
+ export OPENSSL_riscvcap="rv32gc"
 
 Only enable the vector extension:
 

--- a/providers/implementations/ciphers/cipher_aes_xts_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_xts_hw.c
@@ -15,25 +15,27 @@
 
 #include "cipher_aes_xts.h"
 
-#define XTS_SET_KEY_FN(fn_set_enc_key, fn_set_dec_key,           \
-    fn_block_enc, fn_block_dec,                                  \
-    fn_stream_enc, fn_stream_dec)                                \
-    {                                                            \
-        size_t bytes = keylen / 2;                               \
-        size_t bits = bytes * 8;                                 \
-                                                                 \
-        if (ctx->enc) {                                          \
-            fn_set_enc_key(key, (int)bits, &xctx->ks1.ks);       \
-            xctx->xts.block1 = (block128_f)fn_block_enc;         \
-        } else {                                                 \
-            fn_set_dec_key(key, (int)bits, &xctx->ks1.ks);       \
-            xctx->xts.block1 = (block128_f)fn_block_dec;         \
-        }                                                        \
-        fn_set_enc_key(key + bytes, (int)bits, &xctx->ks2.ks);   \
-        xctx->xts.block2 = (block128_f)fn_block_enc;             \
-        xctx->xts.key1 = &xctx->ks1;                             \
-        xctx->xts.key2 = &xctx->ks2;                             \
-        xctx->stream = ctx->enc ? fn_stream_enc : fn_stream_dec; \
+#define XTS_SET_KEY_FN(fn_set_enc_key, fn_set_dec_key,         \
+    fn_block_enc, fn_block_dec,                                \
+    fn_stream_enc, fn_stream_dec)                              \
+    {                                                          \
+        size_t bytes = keylen / 2;                             \
+        size_t bits = bytes * 8;                               \
+                                                               \
+        if (ctx->enc) {                                        \
+            fn_set_enc_key(key, (int)bits, &xctx->ks1.ks);     \
+            xctx->xts.block1 = (block128_f)fn_block_enc;       \
+        } else {                                               \
+            fn_set_dec_key(key, (int)bits, &xctx->ks1.ks);     \
+            xctx->xts.block1 = (block128_f)fn_block_dec;       \
+        }                                                      \
+        fn_set_enc_key(key + bytes, (int)bits, &xctx->ks2.ks); \
+        xctx->xts.block2 = (block128_f)fn_block_enc;           \
+        xctx->xts.key1 = &xctx->ks1;                           \
+        xctx->xts.key2 = &xctx->ks2;                           \
+        xctx->stream = ctx->enc                                \
+            ? (OSSL_xts_stream_fn)(fn_stream_enc)              \
+            : (OSSL_xts_stream_fn)(fn_stream_dec);             \
     }
 
 static int cipher_hw_aes_xts_generic_initkey(PROV_CIPHER_CTX *ctx,


### PR DESCRIPTION
This PR fixes several RV32 issues found while validating the RISC-V crypto backends on current master.

Changes:
  - fix `size_t` formatting for the reported RISC-V vector length
  - fix an RV32 AES-XTS function-pointer assignment that fails under strict/pedantic builds
  - add `OPENSSL_riscvcap(3)` RV32 example

The first two changes are real build/portability fixes for RV32.
The documentation cleanup is small, but came out of the same validation pass.

Validation:
  - local RV32/RV64 RISC-V matrix passed after these fixes

Note that RV32 is not fully supported as a target because Ubuntu lacks an RV32 cross-toolchain package.
Also, I don't think there are many real HW RV32 SoCs targeting Linux.
However, we should still keep an eye on it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
