### PR TITLE
riscv: add scalar Zksed SM4 support

### DIFF
--- a/.github/workflows/riscv-more-cross-compiles.yml
+++ b/.github/workflows/riscv-more-cross-compiles.yml
@@ -91,6 +91,17 @@ jobs:
             opensslcapsname: riscvcap, # OPENSSL_riscvcap
             opensslcaps: "rv64gc_zbc"
           }, {
+            # RV64GC with scalar ZKSED only
+            #   crypto/sm4/asm/sm4-riscv-zksed.pl
+            #   providers/implementations/ciphers/cipher_sm4*_rv64i.inc
+            arch: riscv64-linux-gnu,
+            libs: libc6-dev-riscv64-cross,
+            target: linux64-riscv64,
+            fips: no,
+            qemucpu: "rv64,zksed=true",
+            opensslcapsname: riscvcap, # OPENSSL_riscvcap
+            opensslcaps: "rv64gc_zksed"
+          }, {
           # Vector Crypto
             # RV64GC V ZBB, but without ZVKB
             # For chacha20 vector-only path from #24069

--- a/crypto/sm4/asm/sm4-riscv-zksed.pl
+++ b/crypto/sm4/asm/sm4-riscv-zksed.pl
@@ -1,0 +1,472 @@
+#! /usr/bin/env perl
+# This file is dual-licensed, meaning that you can use it under your
+# choice of either of the following two licenses:
+#
+# Copyright 2022-2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License"). You can obtain
+# a copy in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+#
+# or
+#
+# Copyright (c) 2022, Hongren (Zenithal) Zheng <i@zenithal.me>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# $output is the last argument if it looks like a file (it has an extension)
+# $flavour is the first argument if it doesn't look like a file
+$output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
+$flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
+
+$output and open STDOUT, ">$output";
+
+my $is_rv32 = defined($output) && $output =~ /riscv32/i;
+my $slot_size = $is_rv32 ? 4 : 8;
+my $store_insn = $is_rv32 ? "sw" : "sd";
+my $load_insn = $is_rv32 ? "lw" : "ld";
+my $sm4_prefix = $is_rv32 ? "rv32i_zksed_sm4" : "rv64i_zksed_sm4";
+
+################################################################################
+# Utility functions to help with keeping track of which registers to stack/
+# unstack when entering / exiting routines.
+################################################################################
+{
+    # Callee-saved registers
+    my @callee_saved = map("x$_", (2, 8, 9, 18 .. 27));
+    # Caller-saved registers
+    my @caller_saved = map("x$_", (1, 5 .. 7, 10 .. 17, 28 .. 31));
+    my @must_save;
+    sub use_reg {
+        my $reg = shift;
+        if (grep(/^$reg$/, @callee_saved)) {
+            push(@must_save, $reg);
+        } elsif (!grep(/^$reg$/, @caller_saved)) {
+            die("Unusable register " . $reg);
+        }
+        return $reg;
+    }
+    sub use_regs {
+        return map(use_reg("x$_"), @_);
+    }
+    sub save_regs {
+        my $ret = '';
+        my $stack_reservation = ($#must_save + 1) * $slot_size;
+        my $stack_offset = $stack_reservation;
+        if ($stack_reservation % 16) {
+            $stack_reservation += 16 - ($stack_reservation % 16);
+        }
+        $ret .= "    addi    sp,sp,-$stack_reservation\n";
+        foreach (@must_save) {
+            $stack_offset -= $slot_size;
+            $ret .= "    $store_insn      $_,$stack_offset(sp)\n";
+        }
+        return $ret;
+    }
+    sub load_regs {
+        my $ret = '';
+        my $stack_reservation = ($#must_save + 1) * $slot_size;
+        my $stack_offset = $stack_reservation;
+        if ($stack_reservation % 16) {
+            $stack_reservation += 16 - ($stack_reservation % 16);
+        }
+        foreach (@must_save) {
+            $stack_offset -= $slot_size;
+            $ret .= "    $load_insn      $_,$stack_offset(sp)\n";
+        }
+        $ret .= "    addi    sp,sp,$stack_reservation\n";
+        return $ret;
+    }
+    sub clear_regs {
+        @must_save = ();
+    }
+}
+
+################################################################################
+# Util for encoding scalar crypto extension instructions
+################################################################################
+
+my @regs = map("x$_", (0 .. 31));
+my %reglookup;
+@reglookup{@regs} = @regs;
+
+sub read_reg {
+    my $reg = lc shift;
+    if (!exists($reglookup{$reg})) {
+        die("Unknown register " . $reg);
+    }
+    my $regstr = $reglookup{$reg};
+    if (!($regstr =~ /^x([0-9]+)$/)) {
+        die("Could not process register " . $reg);
+    }
+    return $1;
+}
+
+sub sm4ed {
+    my $template = 0b00_11000_00000_00000_000_00000_0110011;
+    my $rd = read_reg shift;
+    my $rs1 = read_reg shift;
+    my $rs2 = read_reg shift;
+    my $bs = shift;
+
+    return ".word " . ($template | ($bs << 30) | ($rs2 << 20)
+        | ($rs1 << 15) | ($rd << 7));
+}
+
+sub sm4ks {
+    my $template = 0b00_11010_00000_00000_000_00000_0110011;
+    my $rd = read_reg shift;
+    my $rs1 = read_reg shift;
+    my $rs2 = read_reg shift;
+    my $bs = shift;
+
+    return ".word " . ($template | ($bs << 30) | ($rs2 << 20)
+        | ($rs1 << 15) | ($rd << 7));
+}
+
+################################################################################
+# Register assignment for ${sm4_prefix}_encrypt / decrypt
+################################################################################
+
+my ($Q0, $Q1, $Q2, $Q3) = use_regs(6 .. 7, 28 .. 29);
+my ($INP, $OUTP, $KEYP) = use_regs(10 .. 12);
+my ($T0, $T1, $T2, $T3) = use_regs(13 .. 16);
+my ($T) = use_regs(17);
+my ($XOR) = use_regs(31);
+
+################################################################################
+# Utility for ${sm4_prefix}_encrypt / decrypt
+################################################################################
+
+sub input {
+    my $ret = '';
+$ret .= <<___;
+    lw      $Q0,0($INP)
+    lw      $Q1,4($INP)
+    lw      $Q2,8($INP)
+    lw      $Q3,12($INP)
+___
+    return $ret;
+}
+
+sub key {
+    my $ret = '';
+$ret .= <<___;
+    lw      $T0,0($KEYP)
+    lw      $T1,4($KEYP)
+    lw      $T2,8($KEYP)
+    lw      $T3,12($KEYP)
+___
+    return $ret;
+}
+
+sub output {
+    my $ret = '';
+$ret .= <<___;
+    sw      $Q3,0($OUTP)
+    sw      $Q2,4($OUTP)
+    sw      $Q1,8($OUTP)
+    sw      $Q0,12($OUTP)
+___
+    return $ret;
+}
+
+sub sm4ed4 {
+    my $rd = shift;
+    my $rs1 = shift;
+    my $rs2 = shift;
+    my $ret = '';
+$ret .= <<___;
+    @{[sm4ed $rd,$rs1,$rs2,0]}
+    @{[sm4ed $rd,$rs1,$rs2,1]}
+    @{[sm4ed $rd,$rs1,$rs2,2]}
+    @{[sm4ed $rd,$rs1,$rs2,3]}
+___
+    return $ret;
+}
+
+sub sm4ed4r {
+    my $ret = '';
+$ret .= <<___;
+    xor     $XOR,$Q2,$Q3
+    xor     $T,$Q1,$T0
+    xor     $T,$T,$XOR
+    @{[sm4ed4 $Q0,$Q0,$T]}
+
+    xor     $T,$Q0,$T1
+    xor     $T,$T,$XOR
+    @{[sm4ed4 $Q1,$Q1,$T]}
+
+    xor     $XOR,$Q0,$Q1
+    xor     $T,$Q3,$T2
+    xor     $T,$T,$XOR
+    @{[sm4ed4 $Q2,$Q2,$T]}
+
+    xor     $T,$Q2,$T3
+    xor     $T,$T,$XOR
+    @{[sm4ed4 $Q3,$Q3,$T]}
+___
+    return $ret;
+}
+
+sub sm4ed32r {
+    my $ret = '';
+    my $i = 0;
+    while ($i < 8) {
+$ret .= <<___;
+    @{[key]}
+    @{[sm4ed4r]}
+    add     $KEYP,$KEYP,16
+___
+        $i++;
+    }
+    return $ret;
+}
+
+my $code = <<___;
+.text
+.balign 16
+.globl ${sm4_prefix}_encrypt
+.type   ${sm4_prefix}_encrypt,\@function
+${sm4_prefix}_encrypt:
+___
+$code .= save_regs();
+$code .= <<___;
+    @{[input]}
+    @{[sm4ed32r]}
+    @{[output]}
+___
+$code .= load_regs();
+$code .= <<___;
+    ret
+___
+
+$code .= <<___;
+.text
+.balign 16
+.globl ${sm4_prefix}_decrypt
+.type   ${sm4_prefix}_decrypt,\@function
+${sm4_prefix}_decrypt:
+___
+$code .= save_regs();
+$code .= <<___;
+    @{[input]}
+    @{[sm4ed32r]}
+    @{[output]}
+___
+$code .= load_regs();
+$code .= <<___;
+    ret
+___
+
+clear_regs();
+
+################################################################################
+# Register assignment for ${sm4_prefix}_set_[en/de]crypt_key
+################################################################################
+
+my ($UKEY, $KS) = use_regs(10 .. 11);
+my ($KQ0, $KQ1, $KQ2, $KQ3) = use_regs(6 .. 7, 28 .. 29);
+my ($CKP) = use_regs(31);
+my ($KT0, $KT1, $KT2, $KT3) = use_regs(13 .. 16);
+my ($KT) = use_regs(17);
+my ($KXOR) = use_regs(30);
+
+sub ukey {
+    my $ret = '';
+$ret .= <<___;
+    lw      $KQ0,0($UKEY)
+    lw      $KQ1,4($UKEY)
+    lw      $KQ2,8($UKEY)
+    lw      $KQ3,12($UKEY)
+    li      $KT,0xC6BAB1A3
+    xor     $KQ0,$KQ0,$KT
+    li      $KT,0x5033AA56
+    xor     $KQ1,$KQ1,$KT
+    li      $KT,0x97917D67
+    xor     $KQ2,$KQ2,$KT
+    li      $KT,0xDC2270B2
+    xor     $KQ3,$KQ3,$KT
+___
+    return $ret;
+}
+
+sub ckey {
+    my $ret = '';
+$ret .= <<___;
+    lw      $KT0,0($CKP)
+    lw      $KT1,4($CKP)
+    lw      $KT2,8($CKP)
+    lw      $KT3,12($CKP)
+___
+    return $ret;
+}
+
+sub keypenc {
+    my $ret = '';
+$ret .= <<___;
+    sw      $KQ0,0($KS)
+    sw      $KQ1,4($KS)
+    sw      $KQ2,8($KS)
+    sw      $KQ3,12($KS)
+___
+    return $ret;
+}
+
+sub keypdec {
+    my $ret = '';
+$ret .= <<___;
+    sw      $KQ3,0($KS)
+    sw      $KQ2,4($KS)
+    sw      $KQ1,8($KS)
+    sw      $KQ0,12($KS)
+___
+    return $ret;
+}
+
+sub sm4ks4 {
+    my $rd = shift;
+    my $rs1 = shift;
+    my $rs2 = shift;
+    my $ret = '';
+$ret .= <<___;
+    @{[sm4ks $rd,$rs1,$rs2,0]}
+    @{[sm4ks $rd,$rs1,$rs2,1]}
+    @{[sm4ks $rd,$rs1,$rs2,2]}
+    @{[sm4ks $rd,$rs1,$rs2,3]}
+___
+    return $ret;
+}
+
+sub sm4ks4r {
+    my $ret = '';
+$ret .= <<___;
+    xor     $KXOR,$KQ2,$KQ3
+    xor     $KT,$KQ1,$KT0
+    xor     $KT,$KT,$KXOR
+    @{[sm4ks4 $KQ0,$KQ0,$KT]}
+
+    xor     $KT,$KQ0,$KT1
+    xor     $KT,$KT,$KXOR
+    @{[sm4ks4 $KQ1,$KQ1,$KT]}
+
+    xor     $KXOR,$KQ0,$KQ1
+    xor     $KT,$KQ3,$KT2
+    xor     $KT,$KT,$KXOR
+    @{[sm4ks4 $KQ2,$KQ2,$KT]}
+
+    xor     $KT,$KQ2,$KT3
+    xor     $KT,$KT,$KXOR
+    @{[sm4ks4 $KQ3,$KQ3,$KT]}
+___
+    return $ret;
+}
+
+sub sm4ks32r {
+    my $ret = '';
+    my $i = 0;
+    my $save = shift;
+    while ($i < 8) {
+$ret .= <<___;
+    @{[ckey]}
+    @{[sm4ks4r]}
+    add     $CKP,$CKP,16
+    $save
+___
+        $i++;
+    }
+    return $ret;
+}
+
+sub sm4ksenc {
+    my $save = <<___;
+    @{[keypenc]}
+    add     $KS,$KS,16
+___
+    return sm4ks32r($save);
+}
+
+sub sm4ksdec {
+    my $save = <<___;
+    @{[keypdec]}
+    add     $KS,$KS,-16
+___
+    return sm4ks32r($save);
+}
+
+$code .= <<___;
+.text
+.balign 16
+.globl ${sm4_prefix}_set_encrypt_key
+.type   ${sm4_prefix}_set_encrypt_key,\@function
+${sm4_prefix}_set_encrypt_key:
+___
+$code .= save_regs();
+$code .= <<___;
+    @{[ukey]}
+    la      $CKP,CK
+    @{[sm4ksenc]}
+___
+$code .= load_regs();
+$code .= <<___;
+    li      a0,0
+    ret
+___
+
+$code .= <<___;
+.text
+.balign 16
+.globl ${sm4_prefix}_set_decrypt_key
+.type   ${sm4_prefix}_set_decrypt_key,\@function
+${sm4_prefix}_set_decrypt_key:
+___
+$code .= save_regs();
+$code .= <<___;
+    @{[ukey]}
+    la      $CKP,CK
+    add     $KS,$KS,112
+    @{[sm4ksdec]}
+___
+$code .= load_regs();
+$code .= <<___;
+    li      a0,0
+    ret
+___
+
+$code .= <<___;
+.section .rodata
+.p2align    12
+.type   CK,\@object
+CK:
+.word 0x150E0700U, 0x312A231CU, 0x4D463F38U, 0x69625B54U
+.word 0x857E7770U, 0xA19A938CU, 0xBDB6AFA8U, 0xD9D2CBC4U
+.word 0xF5EEE7E0U, 0x110A03FCU, 0x2D261F18U, 0x49423B34U
+.word 0x655E5750U, 0x817A736CU, 0x9D968F88U, 0xB9B2ABA4U
+.word 0xD5CEC7C0U, 0xF1EAE3DCU, 0x0D06FFF8U, 0x29221B14U
+.word 0x453E3730U, 0x615A534CU, 0x7D766F68U, 0x99928B84U
+.word 0xB5AEA7A0U, 0xD1CAC3BCU, 0xEDE6DFD8U, 0x0902FBF4U
+.word 0x251E1710U, 0x413A332CU, 0x5D564F48U, 0x79726B64U
+___
+
+print $code;
+close STDOUT or die "error closing STDOUT: $!";

--- a/crypto/sm4/build.info
+++ b/crypto/sm4/build.info
@@ -5,7 +5,10 @@ IF[{- !$disabled{asm} -}]
   $SM4ASM_aarch64=sm4-armv8.S vpsm4-armv8.S vpsm4_ex-armv8.S
 
   $SM4DEF_riscv64=SM4_ASM
-  $SM4ASM_riscv64=sm4-riscv64-zvksed.s
+  $SM4ASM_riscv64=sm4-riscv64-zvksed.s sm4-riscv64-zksed.s
+
+  $SM4DEF_riscv32=SM4_ASM
+  $SM4ASM_riscv32=sm4-riscv32-zksed.s
 
   $SM4DEF_x86_64=SM4_ASM
   $SM4ASM_x86_64=sm4-x86_64.S
@@ -41,4 +44,6 @@ INCLUDE[sm4-armv8.o]=..
 INCLUDE[vpsm4-armv8.o]=..
 INCLUDE[vpsm4_ex-armv8.o]=..
 GENERATE[sm4-riscv64-zvksed.s]=asm/sm4-riscv64-zvksed.pl
+GENERATE[sm4-riscv64-zksed.s]=asm/sm4-riscv-zksed.pl
+GENERATE[sm4-riscv32-zksed.s]=asm/sm4-riscv-zksed.pl
 GENERATE[sm4-x86_64.S]=asm/sm4-x86_64.pl

--- a/include/crypto/sm4_platform.h
+++ b/include/crypto/sm4_platform.h
@@ -35,10 +35,11 @@ static inline int vpsm4_ex_capable(void)
 #define HWSM4_cbc_encrypt sm4_v8_cbc_encrypt
 #define HWSM4_ecb_encrypt sm4_v8_ecb_encrypt
 #define HWSM4_ctr32_encrypt_blocks sm4_v8_ctr32_encrypt_blocks
-#elif defined(OPENSSL_CPUID_OBJ) && defined(__riscv) && __riscv_xlen == 64
-/* RV64 support */
+#elif defined(OPENSSL_CPUID_OBJ) && defined(__riscv)
+/* RISC-V support */
 #include "riscv_arch.h"
-/* Zvksed extension (vector crypto SM4). */
+#if __riscv_xlen == 64
+/* RV64 Zvksed extension (vector crypto SM4). */
 int rv64i_zvksed_sm4_set_encrypt_key(const unsigned char *userKey,
     SM4_KEY *key);
 int rv64i_zvksed_sm4_set_decrypt_key(const unsigned char *userKey,
@@ -53,6 +54,27 @@ void rv64i_zvksed_sm4_cbc_encrypt(const unsigned char *in, unsigned char *out,
 void rv64i_zvksed_sm4_cbc_decrypt(const unsigned char *in, unsigned char *out,
     size_t len, const SM4_KEY *key,
     unsigned char *iv, int enc);
+#endif
+/* Scalar Zksed SM4 support. */
+#if __riscv_xlen == 64
+int rv64i_zksed_sm4_set_encrypt_key(const unsigned char *userKey,
+    SM4_KEY *key);
+int rv64i_zksed_sm4_set_decrypt_key(const unsigned char *userKey,
+    SM4_KEY *key);
+void rv64i_zksed_sm4_encrypt(const unsigned char *in, unsigned char *out,
+    const SM4_KEY *key);
+void rv64i_zksed_sm4_decrypt(const unsigned char *in, unsigned char *out,
+    const SM4_KEY *key);
+#elif __riscv_xlen == 32
+int rv32i_zksed_sm4_set_encrypt_key(const unsigned char *userKey,
+    SM4_KEY *key);
+int rv32i_zksed_sm4_set_decrypt_key(const unsigned char *userKey,
+    SM4_KEY *key);
+void rv32i_zksed_sm4_encrypt(const unsigned char *in, unsigned char *out,
+    const SM4_KEY *key);
+void rv32i_zksed_sm4_decrypt(const unsigned char *in, unsigned char *out,
+    const SM4_KEY *key);
+#endif
 #elif (defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64))
 /* Intel x86_64 support */
 #include "internal/cryptlib.h"

--- a/providers/implementations/ciphers/cipher_sm4_ccm_hw.c
+++ b/providers/implementations/ciphers/cipher_sm4_ccm_hw.c
@@ -62,6 +62,8 @@ static const PROV_CCM_HW ccm_sm4 = {
 
 #if defined(OPENSSL_CPUID_OBJ) && defined(__riscv) && __riscv_xlen == 64
 #include "cipher_sm4_ccm_hw_rv64i.inc"
+#elif defined(OPENSSL_CPUID_OBJ) && defined(__riscv) && __riscv_xlen == 32
+#include "cipher_sm4_ccm_hw_rv32i.inc"
 #elif defined(OPENSSL_CPUID_OBJ) && (defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64))
 #include "cipher_sm4_ccm_hw_x86_64.inc"
 #else

--- a/providers/implementations/ciphers/cipher_sm4_ccm_hw_rv32i.inc
+++ b/providers/implementations/ciphers/cipher_sm4_ccm_hw_rv32i.inc
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*-
+ * RISC-V 32 scalar ZKSED support for SM4 CCM.
+ * This file is included by cipher_sm4_ccm_hw.c
+ */
+
+static int rv32i_zksed_sm4_ccm_initkey(PROV_CCM_CTX *ctx,
+                                       const unsigned char *key,
+                                       size_t keylen)
+{
+    PROV_SM4_CCM_CTX *actx = (PROV_SM4_CCM_CTX *)ctx;
+
+    SM4_HW_CCM_SET_KEY_FN(rv32i_zksed_sm4_set_encrypt_key,
+                          rv32i_zksed_sm4_encrypt, NULL, NULL);
+    return 1;
+}
+
+static const PROV_CCM_HW rv32i_zksed_sm4_ccm = {
+    rv32i_zksed_sm4_ccm_initkey,
+    ossl_ccm_generic_setiv,
+    ossl_ccm_generic_setaad,
+    ossl_ccm_generic_auth_encrypt,
+    ossl_ccm_generic_auth_decrypt,
+    ossl_ccm_generic_gettag
+};
+
+const PROV_CCM_HW *ossl_prov_sm4_hw_ccm(size_t keybits)
+{
+    if (RISCV_HAS_ZKSED())
+        return &rv32i_zksed_sm4_ccm;
+    return &ccm_sm4;
+}

--- a/providers/implementations/ciphers/cipher_sm4_ccm_hw_rv64i.inc
+++ b/providers/implementations/ciphers/cipher_sm4_ccm_hw_rv64i.inc
@@ -32,10 +32,31 @@ static const PROV_CCM_HW rv64i_zvksed_sm4_ccm = {
     ossl_ccm_generic_gettag
 };
 
+static int rv64i_zksed_sm4_ccm_initkey(PROV_CCM_CTX *ctx,
+                                       const unsigned char *key,
+                                       size_t keylen)
+{
+    PROV_SM4_CCM_CTX *actx = (PROV_SM4_CCM_CTX *)ctx;
+
+    SM4_HW_CCM_SET_KEY_FN(rv64i_zksed_sm4_set_encrypt_key,
+                          rv64i_zksed_sm4_encrypt, NULL, NULL);
+    return 1;
+}
+
+static const PROV_CCM_HW rv64i_zksed_sm4_ccm = {
+    rv64i_zksed_sm4_ccm_initkey,
+    ossl_ccm_generic_setiv,
+    ossl_ccm_generic_setaad,
+    ossl_ccm_generic_auth_encrypt,
+    ossl_ccm_generic_auth_decrypt,
+    ossl_ccm_generic_gettag
+};
+
 const PROV_CCM_HW *ossl_prov_sm4_hw_ccm(size_t keybits)
 {
     if (RISCV_HAS_ZVKB_AND_ZVKSED() && riscv_vlen() >= 128)
         return &rv64i_zvksed_sm4_ccm;
-    else
-        return &ccm_sm4;
+    if (RISCV_HAS_ZKSED())
+        return &rv64i_zksed_sm4_ccm;
+    return &ccm_sm4;
 }

--- a/providers/implementations/ciphers/cipher_sm4_gcm_hw.c
+++ b/providers/implementations/ciphers/cipher_sm4_gcm_hw.c
@@ -91,6 +91,8 @@ static const PROV_GCM_HW sm4_gcm = {
 
 #if defined(OPENSSL_CPUID_OBJ) && defined(__riscv) && __riscv_xlen == 64
 #include "cipher_sm4_gcm_hw_rv64i.inc"
+#elif defined(OPENSSL_CPUID_OBJ) && defined(__riscv) && __riscv_xlen == 32
+#include "cipher_sm4_gcm_hw_rv32i.inc"
 #elif defined(OPENSSL_CPUID_OBJ) && (defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64))
 #include "cipher_sm4_gcm_hw_x86_64.inc"
 #else

--- a/providers/implementations/ciphers/cipher_sm4_gcm_hw_rv32i.inc
+++ b/providers/implementations/ciphers/cipher_sm4_gcm_hw_rv32i.inc
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*-
+ * RISC-V 32 scalar ZKSED support for SM4 GCM.
+ * This file is included by cipher_sm4_gcm_hw.c
+ */
+
+static int rv32i_zksed_sm4_gcm_initkey(PROV_GCM_CTX *ctx,
+                                       const unsigned char *key,
+                                       size_t keylen)
+{
+    PROV_SM4_GCM_CTX *actx = (PROV_SM4_GCM_CTX *)ctx;
+    SM4_KEY *ks = &actx->ks.ks;
+
+    SM4_GCM_HW_SET_KEY_CTR_FN(ks, rv32i_zksed_sm4_set_encrypt_key,
+                              rv32i_zksed_sm4_encrypt, NULL);
+    return 1;
+}
+
+static const PROV_GCM_HW rv32i_zksed_sm4_gcm = {
+    rv32i_zksed_sm4_gcm_initkey,
+    ossl_gcm_setiv,
+    ossl_gcm_aad_update,
+    hw_gcm_cipher_update,
+    ossl_gcm_cipher_final,
+    ossl_gcm_one_shot
+};
+
+const PROV_GCM_HW *ossl_prov_sm4_hw_gcm(size_t keybits)
+{
+    if (RISCV_HAS_ZKSED())
+        return &rv32i_zksed_sm4_gcm;
+    return &sm4_gcm;
+}

--- a/providers/implementations/ciphers/cipher_sm4_gcm_hw_rv64i.inc
+++ b/providers/implementations/ciphers/cipher_sm4_gcm_hw_rv64i.inc
@@ -33,10 +33,32 @@ static const PROV_GCM_HW rv64i_zvksed_sm4_gcm = {
     ossl_gcm_one_shot
 };
 
+static int rv64i_zksed_sm4_gcm_initkey(PROV_GCM_CTX *ctx,
+                                       const unsigned char *key,
+                                       size_t keylen)
+{
+    PROV_SM4_GCM_CTX *actx = (PROV_SM4_GCM_CTX *)ctx;
+    SM4_KEY *ks = &actx->ks.ks;
+
+    SM4_GCM_HW_SET_KEY_CTR_FN(ks, rv64i_zksed_sm4_set_encrypt_key,
+                              rv64i_zksed_sm4_encrypt, NULL);
+    return 1;
+}
+
+static const PROV_GCM_HW rv64i_zksed_sm4_gcm = {
+    rv64i_zksed_sm4_gcm_initkey,
+    ossl_gcm_setiv,
+    ossl_gcm_aad_update,
+    hw_gcm_cipher_update,
+    ossl_gcm_cipher_final,
+    ossl_gcm_one_shot
+};
+
 const PROV_GCM_HW *ossl_prov_sm4_hw_gcm(size_t keybits)
 {
     if (RISCV_HAS_ZVKB_AND_ZVKSED() && riscv_vlen() >= 128)
         return &rv64i_zvksed_sm4_gcm;
-    else
-        return &sm4_gcm;
+    if (RISCV_HAS_ZKSED())
+        return &rv64i_zksed_sm4_gcm;
+    return &sm4_gcm;
 }

--- a/providers/implementations/ciphers/cipher_sm4_hw.c
+++ b/providers/implementations/ciphers/cipher_sm4_hw.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <openssl/proverr.h>
 #include "cipher_sm4.h"
 
 static int cipher_hw_sm4_initkey(PROV_CIPHER_CTX *ctx,
@@ -136,6 +137,8 @@ IMPLEMENT_CIPHER_HW_COPYCTX(cipher_hw_sm4_copyctx, PROV_SM4_CTX)
 
 #if defined(OPENSSL_CPUID_OBJ) && defined(__riscv) && __riscv_xlen == 64
 #include "cipher_sm4_hw_rv64i.inc"
+#elif defined(OPENSSL_CPUID_OBJ) && defined(__riscv) && __riscv_xlen == 32
+#include "cipher_sm4_hw_rv32i.inc"
 #elif defined(OPENSSL_CPUID_OBJ) && (defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64))
 #include "cipher_sm4_hw_x86_64.inc"
 #else

--- a/providers/implementations/ciphers/cipher_sm4_hw_rv32i.inc
+++ b/providers/implementations/ciphers/cipher_sm4_hw_rv32i.inc
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*-
+ * RISC-V 32 scalar ZKSED support for SM4 modes ecb, cbc, ofb, cfb, ctr.
+ * This file is included by cipher_sm4_hw.c
+ */
+
+#define cipher_hw_rv32i_zksed_sm4_cbc    ossl_cipher_hw_generic_cbc
+#define cipher_hw_rv32i_zksed_sm4_ecb    ossl_cipher_hw_generic_ecb
+#define cipher_hw_rv32i_zksed_sm4_ofb128 ossl_cipher_hw_generic_ofb128
+#define cipher_hw_rv32i_zksed_sm4_cfb128 ossl_cipher_hw_generic_cfb128
+#define cipher_hw_rv32i_zksed_sm4_ctr    ossl_cipher_hw_generic_ctr
+
+static int cipher_hw_rv32i_zksed_sm4_initkey(PROV_CIPHER_CTX *ctx,
+                                             const unsigned char *key,
+                                             size_t keylen)
+{
+    int ret;
+    PROV_SM4_CTX *sctx = (PROV_SM4_CTX *)ctx;
+    SM4_KEY *ks = &sctx->ks.ks;
+
+    ctx->ks = ks;
+
+    if (ctx->enc
+        || (ctx->mode != EVP_CIPH_ECB_MODE && ctx->mode != EVP_CIPH_CBC_MODE)) {
+        ret = rv32i_zksed_sm4_set_encrypt_key(key, ks);
+        ctx->block = (block128_f)rv32i_zksed_sm4_encrypt;
+        ctx->stream.cbc = NULL;
+    } else {
+        ret = rv32i_zksed_sm4_set_decrypt_key(key, ks);
+        ctx->block = (block128_f)rv32i_zksed_sm4_decrypt;
+        ctx->stream.cbc = NULL;
+    }
+
+    if (ret < 0) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_KEY_SETUP_FAILED);
+        return 0;
+    }
+
+    return 1;
+}
+
+#define PROV_CIPHER_HW_declare(mode)                                   \
+static const PROV_CIPHER_HW rv32i_zksed_sm4_##mode = {                 \
+    cipher_hw_rv32i_zksed_sm4_initkey,                                 \
+    cipher_hw_rv32i_zksed_sm4_##mode,                                  \
+    cipher_hw_sm4_copyctx                                              \
+};
+#define PROV_CIPHER_HW_select(mode)                                    \
+if (RISCV_HAS_ZKSED())                                                 \
+    return &rv32i_zksed_sm4_##mode;

--- a/providers/implementations/ciphers/cipher_sm4_hw_rv64i.inc
+++ b/providers/implementations/ciphers/cipher_sm4_hw_rv64i.inc
@@ -8,7 +8,7 @@
  */
 
 /*-
- * RV64 ZVKSED support for AES modes ecb, cbc, ofb, cfb, ctr.
+ * RV64 ZVKSED and scalar ZKSED support for SM4 modes ecb, cbc, ofb, cfb, ctr.
  * This file is included by cipher_sm4_hw.c
  */
 
@@ -50,12 +50,54 @@ static int cipher_hw_rv64i_zvksed_sm4_initkey(PROV_CIPHER_CTX *ctx,
     return 1;
 }
 
+#define cipher_hw_rv64i_zksed_sm4_cbc    ossl_cipher_hw_generic_cbc
+#define cipher_hw_rv64i_zksed_sm4_ecb    ossl_cipher_hw_generic_ecb
+#define cipher_hw_rv64i_zksed_sm4_ofb128 ossl_cipher_hw_generic_ofb128
+#define cipher_hw_rv64i_zksed_sm4_cfb128 ossl_cipher_hw_generic_cfb128
+#define cipher_hw_rv64i_zksed_sm4_ctr    ossl_cipher_hw_generic_ctr
+
+static int cipher_hw_rv64i_zksed_sm4_initkey(PROV_CIPHER_CTX *ctx,
+                                             const unsigned char *key,
+                                             size_t keylen)
+{
+    int ret;
+    PROV_SM4_CTX *sctx = (PROV_SM4_CTX *)ctx;
+    SM4_KEY *ks = &sctx->ks.ks;
+
+    ctx->ks = ks;
+
+    if (ctx->enc
+        || (ctx->mode != EVP_CIPH_ECB_MODE && ctx->mode != EVP_CIPH_CBC_MODE)) {
+        ret = rv64i_zksed_sm4_set_encrypt_key(key, ks);
+        ctx->block = (block128_f)rv64i_zksed_sm4_encrypt;
+        ctx->stream.cbc = NULL;
+    } else {
+        ret = rv64i_zksed_sm4_set_decrypt_key(key, ks);
+        ctx->block = (block128_f)rv64i_zksed_sm4_decrypt;
+        ctx->stream.cbc = NULL;
+    }
+
+    if (ret < 0) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_KEY_SETUP_FAILED);
+        return 0;
+    }
+
+    return 1;
+}
+
 #define PROV_CIPHER_HW_declare(mode)                                   \
 static const PROV_CIPHER_HW rv64i_zvksed_sm4_##mode = {                \
     cipher_hw_rv64i_zvksed_sm4_initkey,                                \
     cipher_hw_rv64i_zvksed_sm4_##mode,                                 \
     cipher_hw_sm4_copyctx                                              \
+};                                                                     \
+static const PROV_CIPHER_HW rv64i_zksed_sm4_##mode = {                 \
+    cipher_hw_rv64i_zksed_sm4_initkey,                                 \
+    cipher_hw_rv64i_zksed_sm4_##mode,                                  \
+    cipher_hw_sm4_copyctx                                              \
 };
 #define PROV_CIPHER_HW_select(mode)                                    \
 if (RISCV_HAS_ZVKB_AND_ZVKSED() && riscv_vlen() >= 128)                \
-    return &rv64i_zvksed_sm4_##mode;
+    return &rv64i_zvksed_sm4_##mode;                                   \
+if (RISCV_HAS_ZKSED())                                                 \
+    return &rv64i_zksed_sm4_##mode;


### PR DESCRIPTION
This PR adopts and updates the original scalar RISC-V SM4 Zksed work from #18285.

OpenSSL already has RV64 Zvksed SM4 support upstream. This series adds scalar Zksed SM4 support and integrates it with the current provider layout for ECB, CBC, OFB, CFB, CTR, GCM, and CCM.

The implementation is based on the original work from @ZenithalHourlyRate (who is listed as co-author).

In addition to the backend itself, the series adds RV64 CI coverage for scalar Zksed SM4 so it is exercised independently from the existing vector Zvksed coverage.

Validation:
- local RV64 and RV32 RISC-V test matrix passed
- in-tree CI coverage was extended for RV64 scalar Zksed

This PR supersedes/adopts:
- #18285

This PR also includes a fix for #26989 (an issue in the original code).