### PR TITLE
Fix for issue #30591. Update default behaviour to return all objects.

### DIFF
--- a/crypto/store/store_result.c
+++ b/crypto/store/store_result.c
@@ -286,7 +286,7 @@ static EVP_PKEY *try_key_value(struct extracted_param_data_st *data,
     OSSL_DECODER_CTX *decoderctx = NULL;
     const unsigned char *pdata = data->octet_data;
     size_t pdatalen = data->octet_data_size;
-    int selection = 0;
+    int selection = OSSL_KEYMGMT_SELECT_ALL;
 
     switch (ctx->expected_type) {
     case 0:

--- a/doc/man3/OSSL_STORE_expect.pod
+++ b/doc/man3/OSSL_STORE_expect.pod
@@ -23,8 +23,10 @@ OSSL_STORE_expect() helps applications filter what OSSL_STORE_load() returns
 by specifying a B<OSSL_STORE_INFO> type.
 By default, no expectations on the types of objects to be loaded are made.
 I<expected_type> may be 0 to indicate explicitly that no expectation is made,
-or it may be any of the known object types (see
-L<OSSL_STORE_INFO(3)/SUPPORTED OBJECTS>) except for B<OSSL_STORE_INFO_NAME>.
+in which case the store will request all available key material from the decoder
+(equivalent to B<OSSL_KEYMGMT_SELECT_ALL>), or it may be any of the known
+object types (see L<OSSL_STORE_INFO(3)/SUPPORTED OBJECTS>) except for
+B<OSSL_STORE_INFO_NAME>.
 For example, if C<file:/foo/bar/store.pem> contains several objects of different
 type and only certificates are interesting, the application can simply say
 that it expects the type B<OSSL_STORE_INFO_CERT>.


### PR DESCRIPTION
Changed default behaviour of OSSL_STORE_load to return all supported objects(OSSL_KEYMGMT_SELECT_ALL) when using 0 as the selection parameter(In this case, 0 is used as the selection when OSSL_STORE_load() is called without calling OSSL_STORE_expect()).  Fixes #30591

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
