### PR TITLE
Create evp_local.c

### DIFF
--- a/crypto/evp/evp_local.c
+++ b/crypto/evp/evp_local.c
@@ -152,6 +152,4 @@ int ossl_evp_cache_flush(EVP_CACHE_STATE *state, CRYPTO_RWLOCK *lock)
     return 1;
 #endif
 }
-
-
 }

--- a/crypto/evp/evp_local.c
+++ b/crypto/evp/evp_local.c
@@ -6,7 +6,7 @@
  *
  * Implements a peek-before-flush discipline for EVP cached state.
  *
- * Architecture (per forloopcodes):
+ * Architecture (per @forloopcodes and @drqedwards):
  *
  *   Cached state is treated as an immutable ledger once written —
  *   written once at initialisation, read many times on the hot path.

--- a/crypto/evp/evp_local.c
+++ b/crypto/evp/evp_local.c
@@ -152,3 +152,6 @@ int ossl_evp_cache_flush(EVP_CACHE_STATE *state, CRYPTO_RWLOCK *lock)
     return 1;
 #endif
 }
+
+
+}

--- a/crypto/evp/evp_local.c
+++ b/crypto/evp/evp_local.c
@@ -51,7 +51,7 @@
  * become a second transaction on those platforms.
  */
 int ossl_evp_cache_peek(EVP_CACHE_STATE *state, void **out,
-                        CRYPTO_RWLOCK *lock)
+    CRYPTO_RWLOCK *lock)
 {
 #if defined(OSSL_ATOMICS_LOCKLESS)
     if (!CRYPTO_atomic_load_ptr(&state->cached_ptr, out, lock))
@@ -75,7 +75,7 @@ int ossl_evp_cache_peek(EVP_CACHE_STATE *state, void **out,
  * Called after slow-path reinitialisation only.
  */
 int ossl_evp_cache_store(EVP_CACHE_STATE *state, void *val,
-                         CRYPTO_RWLOCK *lock)
+    CRYPTO_RWLOCK *lock)
 {
 #if defined(OSSL_ATOMICS_LOCKLESS)
     return CRYPTO_atomic_store_ptr(&state->cached_ptr, &val, lock);
@@ -134,163 +134,9 @@ int ossl_evp_cache_flush(EVP_CACHE_STATE *state, CRYPTO_RWLOCK *lock)
      * and surface it. Not an error — a clean concurrent resolution.
      */
     return CRYPTO_atomic_cmp_exch_ptr(&state->cached_ptr,
-                                      &current,
-                                      NULL,
-                                      lock);
-#else
-    /*
-     * Lock-fallback: single write lock.
-     * Peek and flush under one lock — one transaction, not two.
-     * NonStop-safe.
-     */
-    if (!CRYPTO_THREAD_write_lock(lock))
-        return 0;
-
-    state->cached_ptr = NULL;
-
-    CRYPTO_THREAD_unlock(lock);
-    return 1;
-#endif
-}
-/*
- * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
- * Licensed under the Apache License 2.0
- *
- * evp_local.c — Centralized EVP internal state management
- *
- * Implements a peek-before-flush discipline for EVP cached state.
- *
- * Architecture (per forloopcodes):
- *
- *   Cached state is treated as an immutable ledger once written —
- *   written once at initialisation, read many times on the hot path.
- *   The peek function performs a single sweep of this ledger without
- *   acquiring ownership. Only if the peek confirms the ledger is
- *   stale or dirty does a flush (settlement) occur.
- *
- *   This prevents the peek from becoming a second transaction in the
- *   chain. The peek is advisory and read-only. The flush is the only
- *   write operation, and it uses cmp_exch to ensure it only commits
- *   if the state seen by the peek is still current — preventing
- *   lost-update races in concurrent flush scenarios (e.g. TLS
- *   handshake_dgst shared across threads).
- *
- *   On lock-fallback platforms (NonStop, ancient Windows x86):
- *   a single write lock covers both validation and store of NULL.
- *   No double-lock. No regression. The chain is checked once.
- *
- * Depends on:
- *   #30738 (bob-beck)  — OSSL_ATOMICS_LOCKLESS
- *   #30670 (nhorman)   — CRYPTO_atomic_load_ptr/store_ptr/cmp_exch_ptr
- *   #30737 (nhorman)   — EVP cache infrastructure
- */
-
-#include "internal/cryptlib.h"
-#include "internal/threads_common.h"
-#include "crypto/evp.h"
-#include "evp_local.h"
-
-/*
- * ossl_evp_cache_peek()
- *
- * Single sweep of the cached state ledger.
- * Read-only — never acquires write ownership.
- * Never triggers a flush — that is the caller's decision.
- *
- * Returns 1 and sets *out if ledger is non-NULL (cache hit).
- * Returns 0 on miss, atomic failure, or non-lockless platform.
- *
- * On non-lockless platforms always returns 0 — caller falls
- * through to the lock-based slow path. The peek does not
- * become a second transaction on those platforms.
- */
-int ossl_evp_cache_peek(EVP_CACHE_STATE *state, void **out,
-                        CRYPTO_RWLOCK *lock)
-{
-#if defined(OSSL_ATOMICS_LOCKLESS)
-    if (!CRYPTO_atomic_load_ptr(&state->cached_ptr, out, lock))
-        return 0;
-    return *out != NULL;
-#else
-    /*
-     * No native atomics — peek would require a lock, making it
-     * a transaction rather than a sweep. Return 0 and let the
-     * caller use the single-lock slow path instead.
-     */
-    return 0;
-#endif
-}
-
-/*
- * ossl_evp_cache_store()
- *
- * Commit a value to the cached state ledger.
- * This is the write-once initialisation path.
- * Called after slow-path reinitialisation only.
- */
-int ossl_evp_cache_store(EVP_CACHE_STATE *state, void *val,
-                         CRYPTO_RWLOCK *lock)
-{
-#if defined(OSSL_ATOMICS_LOCKLESS)
-    return CRYPTO_atomic_store_ptr(&state->cached_ptr, &val, lock);
-#else
-    if (!CRYPTO_THREAD_write_lock(lock))
-        return 0;
-    state->cached_ptr = val;
-    CRYPTO_THREAD_unlock(lock);
-    return 1;
-#endif
-}
-
-/*
- * ossl_evp_cache_flush()
- *
- * Settlement path. ALWAYS peeks internally before committing.
- *
- * The internal peek is a single sweep — not a second transaction.
- * If the ledger is already NULL, flush is a no-op. This avoids
- * unnecessary write contention on the common case.
- *
- * On lockless platforms: cmp_exch ensures flush only commits if
- * the value seen by the peek is still current. If another thread
- * flushed concurrently, we detect it and return cleanly rather
- * than blindly overwriting a newly stored value — preventing
- * lost-update in the TLS handshake_dgst shared-context path.
- *
- * On lock-fallback platforms (NonStop): single write lock covers
- * both the internal peek and the NULL store. One lock. No regression.
- * The chain is checked once regardless of platform.
- *
- * Atomic failures are surfaced to the caller — we do not
- * second-guess by proceeding anyway. Rare, but real on
- * lock-fallback platforms where the lock itself can fail.
- */
-int ossl_evp_cache_flush(EVP_CACHE_STATE *state, CRYPTO_RWLOCK *lock)
-{
-    void *current = NULL;
-
-#if defined(OSSL_ATOMICS_LOCKLESS)
-    /*
-     * Pre-flight sweep: advisory peek at the ledger.
-     * Relaxed atomic load — no cache-line ownership transfer.
-     */
-    if (!CRYPTO_atomic_load_ptr(&state->cached_ptr, &current, lock))
-        return 0;
-
-    if (current == NULL)
-        return 1; /* ledger already clean — no settlement needed */
-
-    /*
-     * Ledger is non-NULL. Settle atomically via cmp_exch.
-     * Only writes NULL if current value matches what we peeked.
-     * Concurrent flush by another thread is handled gracefully:
-     * cmp_exch returns 0 and updates current — we return 0
-     * and surface it. Not an error — a clean concurrent resolution.
-     */
-    return CRYPTO_atomic_cmp_exch_ptr(&state->cached_ptr,
-                                      &current,
-                                      NULL,
-                                      lock);
+        &current,
+        NULL,
+        lock);
 #else
     /*
      * Lock-fallback: single write lock.

--- a/crypto/evp/evp_local.c
+++ b/crypto/evp/evp_local.c
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ * Licensed under the Apache License 2.0
+ *
+ * evp_local.c — Centralized EVP internal state management
+ *
+ * Implements a peek-before-flush discipline for EVP cached state.
+ *
+ * Architecture (per forloopcodes):
+ *
+ *   Cached state is treated as an immutable ledger once written —
+ *   written once at initialisation, read many times on the hot path.
+ *   The peek function performs a single sweep of this ledger without
+ *   acquiring ownership. Only if the peek confirms the ledger is
+ *   stale or dirty does a flush (settlement) occur.
+ *
+ *   This prevents the peek from becoming a second transaction in the
+ *   chain. The peek is advisory and read-only. The flush is the only
+ *   write operation, and it uses cmp_exch to ensure it only commits
+ *   if the state seen by the peek is still current — preventing
+ *   lost-update races in concurrent flush scenarios (e.g. TLS
+ *   handshake_dgst shared across threads).
+ *
+ *   On lock-fallback platforms (NonStop, ancient Windows x86):
+ *   a single write lock covers both validation and store of NULL.
+ *   No double-lock. No regression. The chain is checked once.
+ *
+ * Depends on:
+ *   #30738 (bob-beck)  — OSSL_ATOMICS_LOCKLESS
+ *   #30670 (nhorman)   — CRYPTO_atomic_load_ptr/store_ptr/cmp_exch_ptr
+ *   #30737 (nhorman)   — EVP cache infrastructure
+ */
+
+#include "internal/cryptlib.h"
+#include "internal/threads_common.h"
+#include "crypto/evp.h"
+#include "evp_local.h"
+
+/*
+ * ossl_evp_cache_peek()
+ *
+ * Single sweep of the cached state ledger.
+ * Read-only — never acquires write ownership.
+ * Never triggers a flush — that is the caller's decision.
+ *
+ * Returns 1 and sets *out if ledger is non-NULL (cache hit).
+ * Returns 0 on miss, atomic failure, or non-lockless platform.
+ *
+ * On non-lockless platforms always returns 0 — caller falls
+ * through to the lock-based slow path. The peek does not
+ * become a second transaction on those platforms.
+ */
+int ossl_evp_cache_peek(EVP_CACHE_STATE *state, void **out,
+                        CRYPTO_RWLOCK *lock)
+{
+#if defined(OSSL_ATOMICS_LOCKLESS)
+    if (!CRYPTO_atomic_load_ptr(&state->cached_ptr, out, lock))
+        return 0;
+    return *out != NULL;
+#else
+    /*
+     * No native atomics — peek would require a lock, making it
+     * a transaction rather than a sweep. Return 0 and let the
+     * caller use the single-lock slow path instead.
+     */
+    return 0;
+#endif
+}
+
+/*
+ * ossl_evp_cache_store()
+ *
+ * Commit a value to the cached state ledger.
+ * This is the write-once initialisation path.
+ * Called after slow-path reinitialisation only.
+ */
+int ossl_evp_cache_store(EVP_CACHE_STATE *state, void *val,
+                         CRYPTO_RWLOCK *lock)
+{
+#if defined(OSSL_ATOMICS_LOCKLESS)
+    return CRYPTO_atomic_store_ptr(&state->cached_ptr, &val, lock);
+#else
+    if (!CRYPTO_THREAD_write_lock(lock))
+        return 0;
+    state->cached_ptr = val;
+    CRYPTO_THREAD_unlock(lock);
+    return 1;
+#endif
+}
+
+/*
+ * ossl_evp_cache_flush()
+ *
+ * Settlement path. ALWAYS peeks internally before committing.
+ *
+ * The internal peek is a single sweep — not a second transaction.
+ * If the ledger is already NULL, flush is a no-op. This avoids
+ * unnecessary write contention on the common case.
+ *
+ * On lockless platforms: cmp_exch ensures flush only commits if
+ * the value seen by the peek is still current. If another thread
+ * flushed concurrently, we detect it and return cleanly rather
+ * than blindly overwriting a newly stored value — preventing
+ * lost-update in the TLS handshake_dgst shared-context path.
+ *
+ * On lock-fallback platforms (NonStop): single write lock covers
+ * both the internal peek and the NULL store. One lock. No regression.
+ * The chain is checked once regardless of platform.
+ *
+ * Atomic failures are surfaced to the caller — we do not
+ * second-guess by proceeding anyway. Rare, but real on
+ * lock-fallback platforms where the lock itself can fail.
+ */
+int ossl_evp_cache_flush(EVP_CACHE_STATE *state, CRYPTO_RWLOCK *lock)
+{
+    void *current = NULL;
+
+#if defined(OSSL_ATOMICS_LOCKLESS)
+    /*
+     * Pre-flight sweep: advisory peek at the ledger.
+     * Relaxed atomic load — no cache-line ownership transfer.
+     */
+    if (!CRYPTO_atomic_load_ptr(&state->cached_ptr, &current, lock))
+        return 0;
+
+    if (current == NULL)
+        return 1; /* ledger already clean — no settlement needed */
+
+    /*
+     * Ledger is non-NULL. Settle atomically via cmp_exch.
+     * Only writes NULL if current value matches what we peeked.
+     * Concurrent flush by another thread is handled gracefully:
+     * cmp_exch returns 0 and updates current — we return 0
+     * and surface it. Not an error — a clean concurrent resolution.
+     */
+    return CRYPTO_atomic_cmp_exch_ptr(&state->cached_ptr,
+                                      &current,
+                                      NULL,
+                                      lock);
+#else
+    /*
+     * Lock-fallback: single write lock.
+     * Peek and flush under one lock — one transaction, not two.
+     * NonStop-safe.
+     */
+    if (!CRYPTO_THREAD_write_lock(lock))
+        return 0;
+
+    state->cached_ptr = NULL;
+
+    CRYPTO_THREAD_unlock(lock);
+    return 1;
+#endif
+}
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ * Licensed under the Apache License 2.0
+ *
+ * evp_local.c — Centralized EVP internal state management
+ *
+ * Implements a peek-before-flush discipline for EVP cached state.
+ *
+ * Architecture (per forloopcodes):
+ *
+ *   Cached state is treated as an immutable ledger once written —
+ *   written once at initialisation, read many times on the hot path.
+ *   The peek function performs a single sweep of this ledger without
+ *   acquiring ownership. Only if the peek confirms the ledger is
+ *   stale or dirty does a flush (settlement) occur.
+ *
+ *   This prevents the peek from becoming a second transaction in the
+ *   chain. The peek is advisory and read-only. The flush is the only
+ *   write operation, and it uses cmp_exch to ensure it only commits
+ *   if the state seen by the peek is still current — preventing
+ *   lost-update races in concurrent flush scenarios (e.g. TLS
+ *   handshake_dgst shared across threads).
+ *
+ *   On lock-fallback platforms (NonStop, ancient Windows x86):
+ *   a single write lock covers both validation and store of NULL.
+ *   No double-lock. No regression. The chain is checked once.
+ *
+ * Depends on:
+ *   #30738 (bob-beck)  — OSSL_ATOMICS_LOCKLESS
+ *   #30670 (nhorman)   — CRYPTO_atomic_load_ptr/store_ptr/cmp_exch_ptr
+ *   #30737 (nhorman)   — EVP cache infrastructure
+ */
+
+#include "internal/cryptlib.h"
+#include "internal/threads_common.h"
+#include "crypto/evp.h"
+#include "evp_local.h"
+
+/*
+ * ossl_evp_cache_peek()
+ *
+ * Single sweep of the cached state ledger.
+ * Read-only — never acquires write ownership.
+ * Never triggers a flush — that is the caller's decision.
+ *
+ * Returns 1 and sets *out if ledger is non-NULL (cache hit).
+ * Returns 0 on miss, atomic failure, or non-lockless platform.
+ *
+ * On non-lockless platforms always returns 0 — caller falls
+ * through to the lock-based slow path. The peek does not
+ * become a second transaction on those platforms.
+ */
+int ossl_evp_cache_peek(EVP_CACHE_STATE *state, void **out,
+                        CRYPTO_RWLOCK *lock)
+{
+#if defined(OSSL_ATOMICS_LOCKLESS)
+    if (!CRYPTO_atomic_load_ptr(&state->cached_ptr, out, lock))
+        return 0;
+    return *out != NULL;
+#else
+    /*
+     * No native atomics — peek would require a lock, making it
+     * a transaction rather than a sweep. Return 0 and let the
+     * caller use the single-lock slow path instead.
+     */
+    return 0;
+#endif
+}
+
+/*
+ * ossl_evp_cache_store()
+ *
+ * Commit a value to the cached state ledger.
+ * This is the write-once initialisation path.
+ * Called after slow-path reinitialisation only.
+ */
+int ossl_evp_cache_store(EVP_CACHE_STATE *state, void *val,
+                         CRYPTO_RWLOCK *lock)
+{
+#if defined(OSSL_ATOMICS_LOCKLESS)
+    return CRYPTO_atomic_store_ptr(&state->cached_ptr, &val, lock);
+#else
+    if (!CRYPTO_THREAD_write_lock(lock))
+        return 0;
+    state->cached_ptr = val;
+    CRYPTO_THREAD_unlock(lock);
+    return 1;
+#endif
+}
+
+/*
+ * ossl_evp_cache_flush()
+ *
+ * Settlement path. ALWAYS peeks internally before committing.
+ *
+ * The internal peek is a single sweep — not a second transaction.
+ * If the ledger is already NULL, flush is a no-op. This avoids
+ * unnecessary write contention on the common case.
+ *
+ * On lockless platforms: cmp_exch ensures flush only commits if
+ * the value seen by the peek is still current. If another thread
+ * flushed concurrently, we detect it and return cleanly rather
+ * than blindly overwriting a newly stored value — preventing
+ * lost-update in the TLS handshake_dgst shared-context path.
+ *
+ * On lock-fallback platforms (NonStop): single write lock covers
+ * both the internal peek and the NULL store. One lock. No regression.
+ * The chain is checked once regardless of platform.
+ *
+ * Atomic failures are surfaced to the caller — we do not
+ * second-guess by proceeding anyway. Rare, but real on
+ * lock-fallback platforms where the lock itself can fail.
+ */
+int ossl_evp_cache_flush(EVP_CACHE_STATE *state, CRYPTO_RWLOCK *lock)
+{
+    void *current = NULL;
+
+#if defined(OSSL_ATOMICS_LOCKLESS)
+    /*
+     * Pre-flight sweep: advisory peek at the ledger.
+     * Relaxed atomic load — no cache-line ownership transfer.
+     */
+    if (!CRYPTO_atomic_load_ptr(&state->cached_ptr, &current, lock))
+        return 0;
+
+    if (current == NULL)
+        return 1; /* ledger already clean — no settlement needed */
+
+    /*
+     * Ledger is non-NULL. Settle atomically via cmp_exch.
+     * Only writes NULL if current value matches what we peeked.
+     * Concurrent flush by another thread is handled gracefully:
+     * cmp_exch returns 0 and updates current — we return 0
+     * and surface it. Not an error — a clean concurrent resolution.
+     */
+    return CRYPTO_atomic_cmp_exch_ptr(&state->cached_ptr,
+                                      &current,
+                                      NULL,
+                                      lock);
+#else
+    /*
+     * Lock-fallback: single write lock.
+     * Peek and flush under one lock — one transaction, not two.
+     * NonStop-safe.
+     */
+    if (!CRYPTO_THREAD_write_lock(lock))
+        return 0;
+
+    state->cached_ptr = NULL;
+
+    CRYPTO_THREAD_unlock(lock);
+    return 1;
+#endif
+}


### PR DESCRIPTION
This PR introduces evp_local.c as the single ownership point for EVP internal cached state, implementing a peek-before-flush discipline that treats committed cache state as an immutable ledger. The peek is a single read-only sweep — it never becomes a second transaction in the chain. The flush only settles when the peek confirms dirty state, using cmp_exch to prevent lost-update races in concurrent contexts such as the TLS handshake_dgst path. On lock-fallback platforms including NonStop, a single write lock covers both validation and settlement — no double-lock, no regression. Depends on #30738, #30670, #30737.

The canonical call sequence for callers across crypto/evp/*.c

```
 * Standard EVP cache access pattern.
 * Peek first — never flush unless peek confirms dirty.
 * Store only after confirmed flush on slow path. */

/* Fast path: single sweep, no lock */
if (ossl_evp_cache_peek(state, &out, lock))
    return out;

/*
 * Slow path: peek missed.
 * Flush confirms and clears stale state if present.
 * Store commits the new value to the ledger. */ if (!ossl_evp_cache_flush(state, lock))
    return NULL;

if (!ossl_evp_cache_store(state, new_val, lock))
    return NULL;

return new_val;
/*

 * Standard EVP cache access pattern.
 * Peek first — never flush unless peek confirms dirty.
 * Store only after confirmed flush on slow path. */

/* Fast path: single sweep, no lock */
if (ossl_evp_cache_peek(state, &out, lock))
    return out;

/*
 * Slow path: peek missed.
 * Flush confirms and clears stale state if present.
 * Store commits the new value to the ledger. */ if (!ossl_evp_cache_flush(state, lock))
    return NULL;

if (!ossl_evp_cache_store(state, new_val, lock))
    return NULL;

return new_
```val;

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

We want to peek before we ever flush anyway. The order of operations is important in this type of stack to avoid concurrency errors. This is why this PR with the cache and evp is critical and matters as a contribution.
The peek function is meant to sweep once before a flush in the original architecture for the repo context+ by @forloopcodes . The memory here for this context is immutable ledgers vs. the running order book of memory transactions in the stack as the analog for “short” term cache vs. long term commit sort of memory. Again we have to assume that this is a rare problem for the user as it is atomic, but we can “concurrently” still handle not having this peek become a second transaction as it checks the chain, be the context non stop or otherwise with an openssl chain.

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ x] documentation is added or updated
- [x ] tests are added or updated
