### PR TITLE
Update m_sigver.c

### DIFF
--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -570,6 +570,8 @@ int EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sigret,
             ERR_clear_last_mark();
             return ret;
         }
+        ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
+        return -1;
     }
 
     if (EVP_DigestVerifyUpdate(ctx, tbs, tbslen) <= 0)


### PR DESCRIPTION
This change makes the EVP_PKEY_OP_VERIFYCTX provider path explicit.

Previously, when pctx->op.sig.algctx and pctx->op.sig.signature were set but the provider did not implement 
signature->digest_verify, execution would silently fall through to EVP_DigestVerifyUpdate() / EVP_DigestVerifyFinal().

Static analysis reported this as a potentially unsafe path, since the fallback may operate on a context state that is not valid for the provider-based verify flow.

With this change, the function now returns an explicit error when a provider verify context exists but no digest_verify callback is available, instead of continuing into the generic Update/Final fallback.
