### PR TITLE
Remove duplicate function asn1_bit_string_set_unused_bits and better naming

### DIFF
--- a/crypto/asn1/a_bitstr.c
+++ b/crypto/asn1/a_bitstr.c
@@ -110,7 +110,7 @@ ASN1_BIT_STRING *ossl_c2i_ASN1_BIT_STRING(ASN1_BIT_STRING **a,
      * We do this to preserve the settings.  If we modify the settings, via
      * the _set_bit function, we will recalculate on output
      */
-    ossl_asn1_string_set_bits_left(ret, i);
+    ossl_asn1_bit_string_set_unused_bits(ret, i);
 
     if (len-- > 1) { /* using one because of the bits left byte */
         s = OPENSSL_malloc((int)len);
@@ -292,5 +292,7 @@ int ASN1_BIT_STRING_set1(ASN1_BIT_STRING *abs, const uint8_t *data, size_t lengt
         return 0;
     abs->type = V_ASN1_BIT_STRING;
 
-    return asn1_bit_string_set_unused_bits(abs, unused_bits);
+    ossl_asn1_bit_string_set_unused_bits(abs, unused_bits);
+
+    return 1;
 }

--- a/crypto/asn1/a_bitstr.c
+++ b/crypto/asn1/a_bitstr.c
@@ -15,25 +15,6 @@
 
 #include <crypto/asn1.h>
 
-static void
-asn1_bit_string_clear_unused_bits(ASN1_BIT_STRING *abs)
-{
-    abs->flags &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07);
-}
-
-static int asn1_bit_string_set_unused_bits(ASN1_BIT_STRING *abs,
-    uint8_t unused_bits)
-{
-    if (unused_bits > 7)
-        return 0;
-
-    asn1_bit_string_clear_unused_bits(abs);
-
-    abs->flags |= ASN1_STRING_FLAG_BITS_LEFT | unused_bits;
-
-    return 1;
-}
-
 int ASN1_BIT_STRING_set(ASN1_BIT_STRING *x, unsigned char *d, int len)
 {
     return ASN1_STRING_set(x, d, len);
@@ -187,9 +168,7 @@ int ASN1_BIT_STRING_set_bit(ASN1_BIT_STRING *a, int n, int value)
             unused_bits -= 2;
         if ((u8 & 0x55) != 0)
             unused_bits -= 1;
-
-        if (!asn1_bit_string_set_unused_bits(a, unused_bits))
-            return 0;
+        ossl_asn1_bit_string_set_unused_bits(a, unused_bits);
     }
     return 1;
 }

--- a/crypto/asn1/a_sign.c
+++ b/crypto/asn1/a_sign.c
@@ -100,7 +100,7 @@ int ASN1_sign(i2d_of_void *i2d, X509_ALGOR *algor1, X509_ALGOR *algor2,
      * In the interests of compatibility, I'll make sure that the bit string
      * has a 'not-used bits' value of 0
      */
-    ossl_asn1_string_set_bits_left(signature, 0);
+    ossl_asn1_bit_string_set_unused_bits(signature, 0);
 err:
     EVP_MD_CTX_free(ctx);
     OPENSSL_clear_free((char *)buf_in, inll);
@@ -288,7 +288,7 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it, X509_ALGOR *algor1,
      * In the interests of compatibility, I'll make sure that the bit string
      * has a 'not-used bits' value of 0
      */
-    ossl_asn1_string_set_bits_left(signature, 0);
+    ossl_asn1_bit_string_set_unused_bits(signature, 0);
 err:
     OPENSSL_clear_free((char *)buf_in, inl);
     OPENSSL_clear_free((char *)buf_out, outll);

--- a/crypto/asn1/asn1_gen.c
+++ b/crypto/asn1/asn1_gen.c
@@ -724,7 +724,7 @@ static ASN1_TYPE *asn1_str2type(const char *str, int format, int utype)
         }
 
         if ((utype == V_ASN1_BIT_STRING) && no_unused)
-            ossl_asn1_string_set_bits_left(atmp->value.asn1_string, 0);
+            ossl_asn1_bit_string_set_unused_bits(atmp->value.asn1_string, 0);
 
         break;
 

--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -248,7 +248,7 @@ int ASN1_object_size(int constructed, int length, int tag)
     return ret + length;
 }
 
-void ossl_asn1_string_set_bits_left(ASN1_STRING *str, unsigned int num)
+void ossl_asn1_bit_string_set_unused_bits(ASN1_STRING *str, unsigned int num)
 {
     str->flags &= ~0x07;
     str->flags |= ASN1_STRING_FLAG_BITS_LEFT | (num & 0x07);

--- a/crypto/cmp/cmp_protect.c
+++ b/crypto/cmp/cmp_protect.c
@@ -88,7 +88,7 @@ ASN1_BIT_STRING *ossl_cmp_calc_protection(const OSSL_CMP_CTX *ctx,
         if (sig_len > INT_MAX || (prot = ASN1_BIT_STRING_new()) == NULL)
             goto end;
         /* OpenSSL by default encodes all bit strings as ASN.1 NamedBitList */
-        ossl_asn1_string_set_bits_left(prot, 0);
+        ossl_asn1_bit_string_set_unused_bits(prot, 0);
         if (!ASN1_BIT_STRING_set(prot, protection, (int)sig_len)) {
             ASN1_BIT_STRING_free(prot);
             prot = NULL;

--- a/crypto/cms/cms_dh.c
+++ b/crypto/cms/cms_dh.c
@@ -240,7 +240,7 @@ static int dh_cms_encrypt(CMS_RecipientInfo *ri)
         if (penclen <= 0)
             goto err;
         ASN1_STRING_set0(pubkey, penc, penclen);
-        ossl_asn1_string_set_bits_left(pubkey, 0);
+        ossl_asn1_bit_string_set_unused_bits(pubkey, 0);
 
         penc = NULL;
         (void)X509_ALGOR_set0(talg, OBJ_nid2obj(NID_dhpublicnumber),

--- a/crypto/cms/cms_ec.c
+++ b/crypto/cms/cms_ec.c
@@ -288,7 +288,7 @@ static int ecdh_cms_encrypt(CMS_RecipientInfo *ri)
         if (enckeylen > INT_MAX || enckeylen == 0)
             goto err;
         ASN1_STRING_set0(pubkey, penc, (int)enckeylen);
-        ossl_asn1_string_set_bits_left(pubkey, 0);
+        ossl_asn1_bit_string_set_unused_bits(pubkey, 0);
 
         penc = NULL;
         (void)X509_ALGOR_set0(talg, OBJ_nid2obj(NID_X9_62_id_ecPublicKey),

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -348,7 +348,7 @@ static int ec_asn1_group2curve(const EC_GROUP *group, X9_62_CURVE *curve)
                 ERR_raise(ERR_LIB_EC, ERR_R_ASN1_LIB);
                 goto err;
             }
-        ossl_asn1_string_set_bits_left(curve->seed, 0);
+        ossl_asn1_bit_string_set_unused_bits(curve->seed, 0);
         if (!ASN1_BIT_STRING_set(curve->seed, group->seed,
                 (int)group->seed_len)) {
             ERR_raise(ERR_LIB_EC, ERR_R_ASN1_LIB);
@@ -1071,7 +1071,7 @@ int i2d_ECPrivateKey(const EC_KEY *a, unsigned char **out)
             goto err;
         }
 
-        ossl_asn1_string_set_bits_left(priv_key->publicKey, 0);
+        ossl_asn1_bit_string_set_unused_bits(priv_key->publicKey, 0);
         ASN1_STRING_set0(priv_key->publicKey, pub, (int)publen);
         pub = NULL;
     }

--- a/crypto/x509/v3_addr.c
+++ b/crypto/x509/v3_addr.c
@@ -421,7 +421,7 @@ static int make_addressPrefix(IPAddressOrRange **result, unsigned char *addr,
         goto err;
     if (bitlen > 0)
         aor->u.addressPrefix->data[bytelen - 1] &= ~(0xFF >> bitlen);
-    ossl_asn1_string_set_bits_left(aor->u.addressPrefix, 8 - bitlen);
+    ossl_asn1_bit_string_set_unused_bits(aor->u.addressPrefix, 8 - bitlen);
 
     *result = aor;
     return 1;
@@ -463,7 +463,7 @@ static int make_addressRange(IPAddressOrRange **result,
         ;
     if (!ASN1_BIT_STRING_set(aor->u.addressRange->min, min, i))
         goto err;
-    ossl_asn1_string_set_bits_left(aor->u.addressRange->min, 0);
+    ossl_asn1_bit_string_set_unused_bits(aor->u.addressRange->min, 0);
     if (i > 0) {
         unsigned char b = min[i - 1];
         int j = 1;
@@ -477,7 +477,7 @@ static int make_addressRange(IPAddressOrRange **result,
         ;
     if (!ASN1_BIT_STRING_set(aor->u.addressRange->max, max, i))
         goto err;
-    ossl_asn1_string_set_bits_left(aor->u.addressRange->max, 0);
+    ossl_asn1_bit_string_set_unused_bits(aor->u.addressRange->max, 0);
     if (i > 0) {
         unsigned char b = max[i - 1];
         int j = 1;

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -999,7 +999,7 @@ void X509_PUBKEY_set0_public_key(X509_PUBKEY *pub,
     unsigned char *penc, int penclen)
 {
     ASN1_STRING_set0(pub->public_key, penc, penclen);
-    ossl_asn1_string_set_bits_left(pub->public_key, 0);
+    ossl_asn1_bit_string_set_unused_bits(pub->public_key, 0);
 }
 
 int X509_PUBKEY_set0_param(X509_PUBKEY *pub, ASN1_OBJECT *aobj,

--- a/include/crypto/asn1.h
+++ b/include/crypto/asn1.h
@@ -183,7 +183,7 @@ EVP_PKEY *ossl_d2i_PrivateKey_legacy(int keytype, EVP_PKEY **a,
     OSSL_LIB_CTX *libctx, const char *propq);
 X509_ALGOR *ossl_X509_ALGOR_from_nid(int nid, int ptype, void *pval);
 
-void ossl_asn1_string_set_bits_left(ASN1_STRING *str, unsigned int num);
+void ossl_asn1_bit_string_set_unused_bits(ASN1_STRING *str, unsigned int num);
 
 int asn1_item_embed_d2i(ASN1_VALUE **pval, const unsigned char **in,
     long len, const ASN1_ITEM *it, int tag, int aclass,


### PR DESCRIPTION
asn1_bit_string_set_unused_bits is more descriptive name than set_bits_left.
also the function is a duplicit.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
