### PR TITLE
Update ml_dsa_kmgmt.c

### DIFF
--- a/providers/implementations/keymgmt/ml_dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/ml_dsa_kmgmt.c
@@ -278,8 +278,8 @@ static int ml_dsa_key_fromdata(ML_DSA_KEY *key, const OSSL_PARAM params[],
     /* Error if the supplied public key does not match the generated key */
     if (pk_len == 0
         || seed_len + sk_len == 0
-        || memcmp(ossl_ml_dsa_key_get_pub(key), pk, pk_len) == 0)
-        return 1;
+        || (pk != NULL && memcmp(ossl_ml_dsa_key_get_pub(key), pk, pk_len) == 0))
+    return 1;
     ERR_raise_data(ERR_LIB_PROV, PROV_R_INVALID_KEY,
         "explicit %s public key does not match private",
         key_params->alg);


### PR DESCRIPTION
File: providers/implementations/keymgmt/ml_dsa_kmgmt.c 

Fix potential NULL dereference in ml_dsa_fromdata()

In ml_dsa_fromdata(), the pointer `pk` is initialized to NULL and may remain NULL on some control-flow paths.

Later, the code evaluates the following condition:

    if (pk_len == 0
            || seed_len + sk_len == 0
            || memcmp(ossl_ml_dsa_key_get_pub(key), pk, pk_len) == 0)

If `pk == NULL` and `pk_len > 0`, the first two conditions evaluate to false and execution reaches memcmp(), which dereferences `pk`. This change adds an explicit check for `pk == NULL` before calling memcmp(), ensuring that the function does not operate on an invalid pointer and returns an error instead.

This makes the control flow explicit and resolves a confirmed static analysis warning (NULL dereference).