### PR TITLE
Update app_params.c

### DIFF
--- a/apps/lib/app_params.c
+++ b/apps/lib/app_params.c
@@ -69,7 +69,6 @@ static int describe_param_type(char *buf, size_t bufsz, const OSSL_PARAM *param)
             param->data_size);
     if (printed_len > 0) {
         buf += printed_len;
-        bufsz -= printed_len;
     }
     *buf = '\0';
     return 1;


### PR DESCRIPTION
File: apps/lib/app_params.c (describe_param_type, ~line 72)

Remove redundant update of bufsz.

In the final block of describe_param_type(), the value of bufsz is decreased but never used afterwards:

    bufsz -= printed_len;

Since no further writes to the buffer occur after this point and the function only sets the terminating null byte, this update is unnecessary.

This change removes a harmless dead store reported by static analysis without affecting functionality.