### PR TITLE
potential memory leak when channel initialization fails

### DIFF
--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -478,7 +478,7 @@ QUIC_CHANNEL *ossl_quic_channel_alloc(const QUIC_CHANNEL_ARGS *args)
         OPENSSL_free(ch->qlog_title);
 #endif
         OPENSSL_free(ch);
-        return NULL;
+        ch = NULL;
     }
 
     return ch;

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -437,7 +437,7 @@ QUIC_CHANNEL *ossl_quic_channel_alloc(const QUIC_CHANNEL_ARGS *args)
     QUIC_CHANNEL *ch;
 
     if ((ch = OPENSSL_zalloc(sizeof(*ch))) == NULL)
-        goto err;
+        return NULL;
 
     ch->port = args->port;
     ch->is_server = args->is_server;

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -473,8 +473,13 @@ QUIC_CHANNEL *ossl_quic_channel_alloc(const QUIC_CHANNEL_ARGS *args)
     if (!ossl_quic_rxfc_init(&ch->conn_rxfc, NULL,
             ch->tx_init_max_data,
             DEFAULT_CONN_RXFC_MAX_WND_MUL * ch->tx_init_max_data,
-            get_time, ch))
+            get_time, ch)) {
+#ifndef OPENSSL_NO_QLOG
+        OPENSSL_free(ch->qlog_title);
+#endif
+        OPENSSL_free(ch);
         return NULL;
+    }
 
     return ch;
 }

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -434,10 +434,10 @@ void ossl_quic_channel_bind_qrx(QUIC_CHANNEL *tserver_ch, OSSL_QRX *qrx)
 
 QUIC_CHANNEL *ossl_quic_channel_alloc(const QUIC_CHANNEL_ARGS *args)
 {
-    QUIC_CHANNEL *ch = NULL;
+    QUIC_CHANNEL *ch;
 
     if ((ch = OPENSSL_zalloc(sizeof(*ch))) == NULL)
-        return NULL;
+        goto err;
 
     ch->port = args->port;
     ch->is_server = args->is_server;
@@ -450,10 +450,8 @@ QUIC_CHANNEL *ossl_quic_channel_alloc(const QUIC_CHANNEL_ARGS *args)
     ch->use_qlog = args->use_qlog;
 
     if (ch->use_qlog && args->qlog_title != NULL) {
-        if ((ch->qlog_title = OPENSSL_strdup(args->qlog_title)) == NULL) {
-            OPENSSL_free(ch);
-            return NULL;
-        }
+        if ((ch->qlog_title = OPENSSL_strdup(args->qlog_title)) == NULL)
+            goto err;
     }
 #endif
 
@@ -474,14 +472,17 @@ QUIC_CHANNEL *ossl_quic_channel_alloc(const QUIC_CHANNEL_ARGS *args)
             ch->tx_init_max_data,
             DEFAULT_CONN_RXFC_MAX_WND_MUL * ch->tx_init_max_data,
             get_time, ch)) {
-#ifndef OPENSSL_NO_QLOG
-        OPENSSL_free(ch->qlog_title);
-#endif
-        OPENSSL_free(ch);
-        ch = NULL;
+        goto err;
     }
 
     return ch;
+
+err:
+#ifndef OPENSSL_NO_QLOG
+    OPENSSL_free(ch->qlog_title);
+#endif
+    OPENSSL_free(ch);
+    return NULL;
 }
 
 void ossl_quic_channel_free(QUIC_CHANNEL *ch)


### PR DESCRIPTION
this fixes missing OPENSSL_free() in error path.

introduced by  #35dc6c353bf (QUIC: Make more transport parameters configurable)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
