### PR TITLE
Limit the number of PSKs we accept

### DIFF
--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -21,6 +21,7 @@
 
 #define MAX_SUPPORTED_GROUPS 128
 #define MAX_KEY_SHARES 16
+#define MAX_PRE_SHARED_KEYS 16
 
 /*
  * 2 bytes for packet length, 2 bytes for format version, 2 bytes for
@@ -1332,7 +1333,7 @@ int tls_parse_ctos_psk(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
     }
 
     s->ext.ticket_expected = 0;
-    for (id = 0; PACKET_remaining(&identities) != 0; id++) {
+    for (id = 0; PACKET_remaining(&identities) != 0 && id < MAX_PRE_SHARED_KEYS; id++) {
         PACKET identity;
         unsigned long ticket_agel;
         size_t idlen;

--- a/test/recipes/70-test_tls13psk.t
+++ b/test/recipes/70-test_tls13psk.t
@@ -153,15 +153,15 @@ sub modify_psk_filter
         #Deliberately break the connection
         $message->set_extension(TLSProxy::Message::EXT_SUPPORTED_GROUPS, "");
     } else {
-        my $psklist = pack "C184",
-            0x00, 0x8c, #Identities length
+        my $psklist = pack "C*",
+            0x00, 0x77, #Identities length
             ((
                 0x00, 0x01, #Identity length
                 0x01, #Identity data
                 0x00, 0x00, 0x00, 0x00 #Obfuscated ticket age
-            ) x 20), #20 identities
-            0x00, 0x28, #Binder length
-            (0x01) x 40; #Twenty fake binders, each with 1 length byte, and 1 payload byte
+            ) x 17), #17 identities
+            0x00, 0x22, #Binder length
+            (0x01) x 34; #17 fake binders, each with 1 length byte, and 1 payload byte
         $message->set_extension(TLSProxy::Message::EXT_PSK, $psklist);
     }
     $message->repack();

--- a/test/recipes/70-test_tls13psk.t
+++ b/test/recipes/70-test_tls13psk.t
@@ -39,7 +39,8 @@ my $proxy = TLSProxy::Proxy->new(
 
 use constant {
     PSK_LAST_FIRST_CH => 0,
-    ILLEGAL_EXT_SECOND_CH => 1
+    ILLEGAL_EXT_SECOND_CH => 1,
+    TOO_MANY_PSKS => 2
 };
 
 #Most PSK tests are done in test_ssl_new. This tests various failure scenarios
@@ -51,7 +52,7 @@ $proxy->clientflags("-sess_out ".$session);
 $proxy->serverflags("-servername localhost");
 $proxy->sessionfile($session);
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
-plan tests => 5;
+plan tests => 6;
 ok(TLSProxy::Message->success(), "Initial connection");
 
 #Test 2: Attempt a resume with PSK not in last place. Should fail
@@ -111,6 +112,15 @@ $proxy->filter(\&remove_sig_algs_filter);
 $proxy->start();
 ok(TLSProxy::Message->success(), "Remove sig algs");
 
+#Test 6: Attempt a resume with too many PSKs. Handshake should still succeed.
+#        It will just ignore the PSKs.
+$proxy->clear();
+$proxy->clientflags("-sess_in ".$session);
+$proxy->filter(\&modify_psk_filter);
+$testtype = TOO_MANY_PSKS;
+$proxy->start();
+ok(TLSProxy::Message->success(), "Too many PSKs");
+
 unlink $session;
 
 sub modify_psk_filter
@@ -119,19 +129,19 @@ sub modify_psk_filter
     my $flight;
     my $message;
 
-    if ($testtype == PSK_LAST_FIRST_CH) {
-        $flight = 0;
-    } else {
+    if ($testtype == ILLEGAL_EXT_SECOND_CH) {
         $flight = 2;
+    } else {
+        $flight = 0;
     }
 
     # Only look at the first or second ClientHello
     return if $proxy->flight != $flight;
 
-    if ($testtype == PSK_LAST_FIRST_CH) {
-        $message = ${$proxy->message_list}[0];
-    } else {
+    if ($testtype == ILLEGAL_EXT_SECOND_CH) {
         $message = ${$proxy->message_list}[2];
+    } else {
+        $message = ${$proxy->message_list}[0];
     }
 
     return if (!defined $message
@@ -139,9 +149,20 @@ sub modify_psk_filter
 
     if ($testtype == PSK_LAST_FIRST_CH) {
         $message->set_extension(TLSProxy::Message::EXT_FORCE_LAST, "");
-    } else {
+    } elsif ($testtype == ILLEGAL_EXT_SECOND_CH) {
         #Deliberately break the connection
         $message->set_extension(TLSProxy::Message::EXT_SUPPORTED_GROUPS, "");
+    } else {
+        my $psklist = pack "C184",
+            0x00, 0x8c, #Identities length
+            ((
+                0x00, 0x01, #Identity length
+                0x01, #Identity data
+                0x00, 0x00, 0x00, 0x00 #Obfuscated ticket age
+            ) x 20), #20 identities
+            0x00, 0x28, #Binder length
+            (0x01) x 40; #Twenty fake binders, each with 1 length byte, and 1 payload byte
+        $message->set_extension(TLSProxy::Message::EXT_PSK, $psklist);
     }
     $message->repack();
 }


### PR DESCRIPTION
To prevent attacks where an unauthenticated client sends us a large
number of PSKs, we place a limit on the number we are prepared to
accept.
