### PR TITLE
RISC-V, LoongArch: use void * in digest shims

### DIFF
--- a/crypto/md5/md5_riscv.c
+++ b/crypto/md5/md5_riscv.c
@@ -11,10 +11,10 @@
 #include <openssl/md5.h>
 #include "crypto/riscv_arch.h"
 
-void ossl_md5_block_asm_data_order(MD5_CTX *c, const void *p, size_t num);
-void ossl_md5_block_asm_data_order_zbb(MD5_CTX *c, const void *p, size_t num);
-void ossl_md5_block_asm_data_order_riscv64(MD5_CTX *c, const void *p, size_t num);
-void ossl_md5_block_asm_data_order(MD5_CTX *c, const void *p, size_t num)
+void ossl_md5_block_asm_data_order(void *c, const void *p, size_t num);
+void ossl_md5_block_asm_data_order_zbb(void *c, const void *p, size_t num);
+void ossl_md5_block_asm_data_order_riscv64(void *c, const void *p, size_t num);
+void ossl_md5_block_asm_data_order(void *c, const void *p, size_t num)
 {
     if (RISCV_HAS_ZBB()) {
         ossl_md5_block_asm_data_order_zbb(c, p, num);

--- a/crypto/sha/sha_loongarch.c
+++ b/crypto/sha/sha_loongarch.c
@@ -16,9 +16,9 @@
 
 void sha256_block_data_order_la64v100(void *ctx, const void *in, size_t num);
 void sha256_block_data_order_lsx(void *ctx, const void *in, size_t num);
-void sha256_block_data_order(SHA256_CTX *ctx, const void *in, size_t num);
+void sha256_block_data_order(void *ctx, const void *in, size_t num);
 
-void sha256_block_data_order(SHA256_CTX *ctx, const void *in, size_t num)
+void sha256_block_data_order(void *ctx, const void *in, size_t num)
 {
     if (OPENSSL_loongarch_hwcap_P & LOONGARCH_HWCAP_LSX) {
         sha256_block_data_order_lsx(ctx, in, num);
@@ -29,9 +29,9 @@ void sha256_block_data_order(SHA256_CTX *ctx, const void *in, size_t num)
 
 void sha512_block_data_order_la64v100(void *ctx, const void *in, size_t num);
 void sha512_block_data_order_lsx(void *ctx, const void *in, size_t num);
-void sha512_block_data_order(SHA512_CTX *ctx, const void *in, size_t num);
+void sha512_block_data_order(void *ctx, const void *in, size_t num);
 
-void sha512_block_data_order(SHA512_CTX *ctx, const void *in, size_t num)
+void sha512_block_data_order(void *ctx, const void *in, size_t num)
 {
     if (OPENSSL_loongarch_hwcap_P & LOONGARCH_HWCAP_LSX) {
         sha512_block_data_order_lsx(ctx, in, num);

--- a/crypto/sha/sha_riscv.c
+++ b/crypto/sha/sha_riscv.c
@@ -18,9 +18,9 @@ void sha256_block_data_order_zvkb_zvknha_or_zvknhb(void *ctx, const void *in,
     size_t num);
 void sha256_block_data_order_zbb(void *ctx, const void *in, size_t num);
 void sha256_block_data_order_riscv64(void *ctx, const void *in, size_t num);
-void sha256_block_data_order(SHA256_CTX *ctx, const void *in, size_t num);
+void sha256_block_data_order(void *ctx, const void *in, size_t num);
 
-void sha256_block_data_order(SHA256_CTX *ctx, const void *in, size_t num)
+void sha256_block_data_order(void *ctx, const void *in, size_t num)
 {
     if (RISCV_HAS_ZVKB() && (RISCV_HAS_ZVKNHA() || RISCV_HAS_ZVKNHB()) && riscv_vlen() >= 128) {
         sha256_block_data_order_zvkb_zvknha_or_zvknhb(ctx, in, num);
@@ -34,9 +34,9 @@ void sha256_block_data_order(SHA256_CTX *ctx, const void *in, size_t num)
 void sha512_block_data_order_zvkb_zvknhb(void *ctx, const void *in, size_t num);
 void sha512_block_data_order_zbb(void *ctx, const void *in, size_t num);
 void sha512_block_data_order_c(void *ctx, const void *in, size_t num);
-void sha512_block_data_order(SHA512_CTX *ctx, const void *in, size_t num);
+void sha512_block_data_order(void *ctx, const void *in, size_t num);
 
-void sha512_block_data_order(SHA512_CTX *ctx, const void *in, size_t num)
+void sha512_block_data_order(void *ctx, const void *in, size_t num)
 {
     if (RISCV_HAS_ZVKB_AND_ZVKNHB() && riscv_vlen() >= 128) {
         sha512_block_data_order_zvkb_zvknhb(ctx, in, num);


### PR DESCRIPTION
RISC-V and LoongArch use low-level digest context types that are hidden in no-deprecated builds.
This PR switches their shim entry points to void * so they no longer depend on deprecated typed interfaces.

Fixes: openssl/openssl#29357