### PR TITLE
ssl: Fix ssl_do_config to clean up errors on success with ERR_set_mark

### DIFF
--- a/ssl/ssl_mcnf.c
+++ b/ssl/ssl_mcnf.c
@@ -45,6 +45,8 @@ static int ssl_do_config(SSL *s, SSL_CTX *ctx, const char *name, int system)
     OSSL_LIB_CTX *libctx = NULL, *prev_libctx = NULL;
     CONF_IMODULE *imod = NULL;
 
+    ERR_set_mark();
+
     if (s == NULL && ctx == NULL) {
         ERR_raise(ERR_LIB_SSL, ERR_R_PASSED_NULL_PARAMETER);
         goto err;
@@ -113,7 +115,20 @@ static int ssl_do_config(SSL *s, SSL_CTX *ctx, const char *name, int system)
 err:
     OSSL_LIB_CTX_set0_default(prev_libctx);
     SSL_CONF_CTX_free(cctx);
-    return err == 0 || (system && !conf_diagnostics);
+    if (err == 0) {
+        ERR_pop_to_mark();
+        return 1;
+    }
+    if (system && !conf_diagnostics) {
+        /*
+         * Discard errors so that SSL_CTX_new does not return
+         * success with stale errors on the error stack.
+         */
+        ERR_pop_to_mark();
+        return 1;
+    }
+    ERR_clear_last_mark();
+    return 0;
 }
 
 int SSL_config(SSL *s, const char *name)

--- a/test/recipes/90-test_sysdefault_data/sysdefault-ignore.cnf
+++ b/test/recipes/90-test_sysdefault_data/sysdefault-ignore.cnf
@@ -19,5 +19,6 @@ system_default = ssl_default_sect
 
 [ssl_default_sect]
 SignatureAlgorithms = RSA+SHA256:nonex
+Ciphersuites = INVALID_CIPHERSUITE
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2

--- a/test/sysdefaulttest.c
+++ b/test/sysdefaulttest.c
@@ -11,6 +11,7 @@
 #include <openssl/opensslconf.h>
 
 #include <string.h>
+#include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/ssl.h>
 #include <openssl/tls1.h>
@@ -35,6 +36,8 @@ static int test_func(void)
             TEST_info("min/max version setting incorrect");
             goto err;
         }
+        if (!TEST_long_eq(ERR_peek_error(), 0))
+            goto err;
     }
     ret = 1;
 err:


### PR DESCRIPTION
`ssl_do_config()` could leave stale errors on the error stack even on
success, so that later error checking operations could mistakenly
surface these errors. For example, when `Ciphersuites` contains an
invalid value and `config_diagnostics` is off, `SSL_CONF_cmd()` pushes
`SSL_R_NO_CIPHER_MATCH` onto the error stack. The old code returned
success (`system && !conf_diagnostics`) but never cleaned up the error
stack.

Use `ERR_set_mark()`/`ERR_pop_to_mark()` to cleanly discard errors
when the function succeeds or when system config errors are non-fatal.

Fixes https://github.com/openssl/openssl/issues/30760
Relates to https://github.com/openssl/openssl/pull/24275

**Note:** I wasn't sure if this warrants a CHANGES.md entry. Happy to
add one if reviewers think it's appropriate.

##### Checklist
- [x] tests are added or updated

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
