### PR TITLE
make `atexit` a deprecated disablable, remove its usage

### DIFF
--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -30,7 +30,6 @@ jobs:
           no-asan,
           no-asm,
           no-async,
-          no-atexit,
           no-autoalginit,
           no-autoerrinit,
           no-autoload-config,

--- a/Configurations/50-nonstop.conf
+++ b/Configurations/50-nonstop.conf
@@ -22,7 +22,6 @@
         ex_libs          => add('-lrld'),
         enable           => ['egd'],
 	# Not currently inherited
-        disable          => ['atexit'],
         dso_scheme       => 'DLFCN',
         sys_id           => 'TANDEM',
     },
@@ -191,7 +190,7 @@
                               'nonstop-archenv-x86_64-oss',
                               'nonstop-ilp32',
                               'nonstop-efloat-x86_64' ],
-        disable          => ['threads','atexit'],
+        disable          => ['threads'],
     },
     'nonstop-nsx_put' => {
         inherit_from     => [ 'nonstop-common',
@@ -201,7 +200,6 @@
                               'nonstop-model-put' ],
         multilib         => '-put',
         multibin         => '-put',
-        disable          => ['atexit'],
     },
     'nonstop-nsx_64' => {
         inherit_from     => [ 'nonstop-common',
@@ -210,7 +208,7 @@
                               'nonstop-efloat-x86_64' ],
         multilib         => '64',
         multibin         => '64',
-        disable          => ['threads','atexit'],
+        disable          => ['threads'],
     },
     'nonstop-nsx_64_put' => {
         inherit_from     => [ 'nonstop-common',
@@ -220,7 +218,6 @@
                               'nonstop-model-put' ],
         multilib         => '64-put',
         multibin         => '64-put',
-        disable          => ['atexit'],
     },
     'nonstop-nsx_64_klt' => {
         inherit_from     => [ 'nonstop-common',
@@ -230,19 +227,18 @@
                               'nonstop-model-klt' ],
         multilib         => '64-klt',
         multibin         => '64-klt',
-        disable          => ['atexit'],
     },
     'nonstop-nsx_g' => {
         inherit_from     => [ 'nonstop-common',
                               'nonstop-archenv-x86_64-guardian',
                               'nonstop-ilp32', 'nonstop-nfloat-x86_64' ],
-        disable          => ['threads','atexit'],
+        disable          => ['threads'],
     },
     'nonstop-nsx_g_tandem' => {
         inherit_from     => [ 'nonstop-common',
                               'nonstop-archenv-x86_64-guardian',
                               'nonstop-ilp32', 'nonstop-tfloat-x86_64' ],
-        disable          => ['threads','atexit'],
+        disable          => ['threads'],
     },
     'nonstop-nsv' => {
         inherit_from     => [ 'nonstop-nsx' ],
@@ -252,7 +248,7 @@
                               'nonstop-archenv-itanium-oss',
                               'nonstop-ilp32',
                               'nonstop-efloat-itanium' ],
-        disable          => ['threads','atexit'],
+        disable          => ['threads'],
     },
     'nonstop-nse_put' => {
         inherit_from     => [ 'nonstop-common',
@@ -262,7 +258,6 @@
                               'nonstop-model-put' ],
         multilib         => '-put',
         multibin         => '-put',
-        disable          => ['atexit'],
     },
     'nonstop-nse_64' => {
         inherit_from     => [ 'nonstop-common',
@@ -271,7 +266,7 @@
                               'nonstop-efloat-itanium' ],
         multilib         => '64',
         multibin         => '64',
-        disable          => ['threads','atexit'],
+        disable          => ['threads'],
     },
     'nonstop-nse_64_put' => {
         inherit_from     => [ 'nonstop-common',
@@ -281,5 +276,4 @@
                               'nonstop-model-put' ],
         multilib         => '64-put',
         multibin         => '64-put',
-        disable          => ['atexit'],
     },

--- a/Configure
+++ b/Configure
@@ -505,7 +505,6 @@ my @disablables_features = (
     "asan",
     "asm",
     "async",
-    "atexit",
     "autoalginit",
     "autoerrinit",
     "autoload-config",
@@ -589,6 +588,7 @@ my @disablables_int = qw(
     );
 
 my %deprecated_disablables = (
+    "atexit" => undef,
     "engine" => undef,
     "static-engine" => undef,
     "dynamic-engine" => undef,
@@ -612,6 +612,7 @@ my %deprecated_disablables = (
 # All of the following are disabled by default:
 
 our %disabled = ( # "what"         => "comment"
+                  "atexit"              => "default",
                   "fips"                => "default",
                   "fips-jitter"         => "default",
                   "asan"                => "default",
@@ -656,7 +657,7 @@ our %disabled = ( # "what"         => "comment"
 my @disable_cascades = (
     # "what"            => [ "cascade", ... ]
     "bulk"              => [ "shared", "dso",
-                             "argon2", "aria", "async", "atexit", "autoload-config",
+                             "argon2", "aria", "async", "autoload-config",
                              "blake2", "bf", "camellia", "cast", "chacha",
                              "cmac", "cms", "cmp", "comp", "ct",
                              "des", "dgram", "dh", "dsa",

--- a/Configure
+++ b/Configure
@@ -511,7 +511,6 @@ my @disablables_features = (
     "asan",
     "asm",
     "async",
-    "atexit",
     "autoalginit",
     "autoerrinit",
     "autoload-config",
@@ -596,6 +595,7 @@ my @disablables_int = qw(
     );
 
 my %deprecated_disablables = (
+    "atexit" => undef,
     "engine" => undef,
     "static-engine" => undef,
     "dynamic-engine" => undef,
@@ -619,6 +619,7 @@ my %deprecated_disablables = (
 # All of the following are disabled by default:
 
 our %disabled = ( # "what"         => "comment"
+                  "atexit"              => "default",
                   "fips"                => "default",
                   "fips-jitter"         => "default",
                   "asan"                => "default",
@@ -664,7 +665,7 @@ our %disabled = ( # "what"         => "comment"
 my @disable_cascades = (
     # "what"            => [ "cascade", ... ]
     "bulk"              => [ "shared", "dso",
-                             "argon2", "aria", "async", "atexit", "autoload-config",
+                             "argon2", "aria", "async", "autoload-config",
                              "blake2", "bf", "camellia", "cast", "chacha",
                              "cmac", "cms", "cmp", "comp", "ct",
                              "des", "dgram", "dh", "dsa",

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -645,7 +645,8 @@ Do not use `atexit()` in libcrypto builds.
 
 Before version 4.0, OpenSSL used to set `atexit()` handler for cleaning up
 global data, and this option allowed to disable that functionality.  `atexit()`
-handler setup was removed in OpenSSL 4.0, so this option does nothing now.
+handler setup was removed in OpenSSL 4.0, so `no-atexit` option is retained
+for compatibility reasons only, always present, and does nothing.
 
 ### no-autoalginit
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -643,9 +643,10 @@ Do not build support for async operations.
 
 Do not use `atexit()` in libcrypto builds.
 
-`atexit()` has varied semantics between platforms and can cause SIGSEGV in some
-circumstances. This option disables the atexit registration of OPENSSL_cleanup.
-By default, NonStop configurations use `no-atexit`.
+Before version 4.0, OpenSSL used to set `atexit()` handler for cleaning up
+global data, and this option allowed to disable that functionality.  `atexit()`
+handler setup was removed in OpenSSL 4.0, so `no-atexit` option is retained
+for compatibility reasons only, always present, and does nothing.
 
 ### no-autoalginit
 


### PR DESCRIPTION
As the `atexit` handler was removed in [1], `no-atexit` configuration option has no effect. Make that explicit by disallowing enabling `atexit`, update the documentation accordingly, and remove its usage in `Configurations/50-nonstop.conf` and `.github/workflows/run-checker-daily.yml`.

[1] https://github.com/openssl/openssl/pull/29385

References: https://github.com/openssl/openssl/issues/30742