### PR TITLE
Work around "Use of uninitialized value..." in mkinstallvars.pl

### DIFF
--- a/exporters/build.info
+++ b/exporters/build.info
@@ -19,6 +19,7 @@ DEPEND[openssl.pc]=libcrypto.pc libssl.pc
 DEPEND[""]=openssl.pc
 
 GENERATE[../installdata.pm]=../util/mkinstallvars.pl \
+    COMMENT="This file provides configuration information for OpenSSL" \
     "PREFIX=$(INSTALLTOP)" BINDIR=bin "LIBDIR=$(LIBDIR)" "libdir=$(libdir)" \
     INCLUDEDIR=include APPLINKDIR=include/openssl \
     "MODULESDIR=$(MODULESDIR)" \


### PR DESCRIPTION
Avoid "Use of uninitialized value in concatenation (.) or string at util/mkinstallvars.pl line 139." message by supplying COMMENT in the mkinstallvars.pl call exporters/build.info.