### PR TITLE
RISC-V AES: allow independent Zkne/Zknd acceleration

### DIFF
--- a/.github/workflows/riscv-more-cross-compiles.yml
+++ b/.github/workflows/riscv-more-cross-compiles.yml
@@ -71,6 +71,28 @@ jobs:
             opensslcapsname: riscvcap, # OPENSSL_riscvcap
             opensslcaps: "rv64gc_zbb_zbc_zbkb_zknd_zkne"
           }, {
+            # RV64GC with Zkne only (no Zknd)
+            #   crypto/aes/asm/aes-riscv64-zkn.pl (encrypt path)
+            #   providers/implementations/ciphers/cipher_aes_hw_rv64i.inc
+            arch: riscv64-linux-gnu,
+            libs: libc6-dev-riscv64-cross,
+            target: linux64-riscv64,
+            fips: no,
+            qemucpu: "rv64,zkne=true,zknd=false",
+            opensslcapsname: riscvcap, # OPENSSL_riscvcap
+            opensslcaps: "rv64gc_zkne"
+          }, {
+            # RV64GC with Zknd only (no Zkne)
+            #   crypto/aes/asm/aes-riscv64-zkn.pl (decrypt path)
+            #   providers/implementations/ciphers/cipher_aes_hw_rv64i.inc
+            arch: riscv64-linux-gnu,
+            libs: libc6-dev-riscv64-cross,
+            target: linux64-riscv64,
+            fips: no,
+            qemucpu: "rv64,zknd=true,zkne=false",
+            opensslcapsname: riscvcap, # OPENSSL_riscvcap
+            opensslcaps: "rv64gc_zknd"
+          }, {
             # RV64GC ZBC ZBB, but without ZBKB
             #   crypto/modes/gcm128.c
             arch: riscv64-linux-gnu,

--- a/include/crypto/riscv_arch.h
+++ b/include/crypto/riscv_arch.h
@@ -108,6 +108,7 @@ static const size_t kRISCVNumCaps =
 
 /* Extension combination tests. */
 #define RISCV_HAS_ZBB_AND_ZBC() (RISCV_HAS_ZBB() && RISCV_HAS_ZBC())
+#define RISCV_HAS_ZBKB_AND_ZKNE() (RISCV_HAS_ZBKB() && RISCV_HAS_ZKNE())
 #define RISCV_HAS_ZBKB_AND_ZKND_AND_ZKNE() (RISCV_HAS_ZBKB() && RISCV_HAS_ZKND() && RISCV_HAS_ZKNE())
 #define RISCV_HAS_ZKND_AND_ZKNE() (RISCV_HAS_ZKND() && RISCV_HAS_ZKNE())
 /*

--- a/providers/implementations/ciphers/cipher_aes_ccm_hw_rv32i.inc
+++ b/providers/implementations/ciphers/cipher_aes_ccm_hw_rv32i.inc
@@ -8,12 +8,15 @@
  */
 
 /*-
- * RISC-V 32 ZKND ZKNE support for AES CCM.
+ * RISC-V 32 ZKNE support for AES CCM.
  * This file is included by cipher_aes_ccm_hw.c
+ *
+ * CCM uses AES only in the encrypt direction (CTR + CBC-MAC), so only
+ * Zkne is required; Zknd is not needed.
  */
 
-static int ccm_rv32i_zknd_zkne_initkey(PROV_CCM_CTX *ctx, const unsigned char *key,
-                                       size_t keylen)
+static int ccm_rv32i_zkne_initkey(PROV_CCM_CTX *ctx, const unsigned char *key,
+                                  size_t keylen)
 {
     PROV_AES_CCM_CTX *actx = (PROV_AES_CCM_CTX *)ctx;
 
@@ -22,8 +25,8 @@ static int ccm_rv32i_zknd_zkne_initkey(PROV_CCM_CTX *ctx, const unsigned char *k
     return 1;
 }
 
-static int ccm_rv32i_zbkb_zknd_zkne_initkey(PROV_CCM_CTX *ctx, const unsigned char *key,
-                                            size_t keylen)
+static int ccm_rv32i_zbkb_zkne_initkey(PROV_CCM_CTX *ctx, const unsigned char *key,
+                                       size_t keylen)
 {
     PROV_AES_CCM_CTX *actx = (PROV_AES_CCM_CTX *)ctx;
 
@@ -32,8 +35,8 @@ static int ccm_rv32i_zbkb_zknd_zkne_initkey(PROV_CCM_CTX *ctx, const unsigned ch
     return 1;
 }
 
-static const PROV_CCM_HW rv32i_zknd_zkne_ccm = {
-    ccm_rv32i_zknd_zkne_initkey,
+static const PROV_CCM_HW rv32i_zkne_ccm = {
+    ccm_rv32i_zkne_initkey,
     ossl_ccm_generic_setiv,
     ossl_ccm_generic_setaad,
     ossl_ccm_generic_auth_encrypt,
@@ -41,8 +44,8 @@ static const PROV_CCM_HW rv32i_zknd_zkne_ccm = {
     ossl_ccm_generic_gettag
 };
 
-static const PROV_CCM_HW rv32i_zbkb_zknd_zkne_ccm = {
-    ccm_rv32i_zbkb_zknd_zkne_initkey,
+static const PROV_CCM_HW rv32i_zbkb_zkne_ccm = {
+    ccm_rv32i_zbkb_zkne_initkey,
     ossl_ccm_generic_setiv,
     ossl_ccm_generic_setaad,
     ossl_ccm_generic_auth_encrypt,
@@ -52,9 +55,9 @@ static const PROV_CCM_HW rv32i_zbkb_zknd_zkne_ccm = {
 
 const PROV_CCM_HW *ossl_prov_aes_hw_ccm(size_t keybits)
 {
-    if (RISCV_HAS_ZBKB_AND_ZKND_AND_ZKNE())
-        return &rv32i_zbkb_zknd_zkne_ccm;
-    if (RISCV_HAS_ZKND_AND_ZKNE())
-        return &rv32i_zknd_zkne_ccm;
+    if (RISCV_HAS_ZBKB_AND_ZKNE())
+        return &rv32i_zbkb_zkne_ccm;
+    if (RISCV_HAS_ZKNE())
+        return &rv32i_zkne_ccm;
     return &aes_ccm;
 }

--- a/providers/implementations/ciphers/cipher_aes_ccm_hw_rv64i.inc
+++ b/providers/implementations/ciphers/cipher_aes_ccm_hw_rv64i.inc
@@ -8,12 +8,15 @@
  */
 
 /*-
- * RISC-V 64 ZKND ZKNE support for AES CCM.
+ * RISC-V 64 ZKNE support for AES CCM.
  * This file is included by cipher_aes_ccm_hw.c
+ *
+ * CCM uses AES only in the encrypt direction (CTR + CBC-MAC), so only
+ * Zkne is required; Zknd is not needed.
  */
 
-static int ccm_rv64i_zknd_zkne_initkey(PROV_CCM_CTX *ctx, const unsigned char *key,
-                             size_t keylen)
+static int ccm_rv64i_zkne_initkey(PROV_CCM_CTX *ctx, const unsigned char *key,
+                                  size_t keylen)
 {
     PROV_AES_CCM_CTX *actx = (PROV_AES_CCM_CTX *)ctx;
 
@@ -22,8 +25,8 @@ static int ccm_rv64i_zknd_zkne_initkey(PROV_CCM_CTX *ctx, const unsigned char *k
     return 1;
 }
 
-static const PROV_CCM_HW rv64i_zknd_zkne_ccm = {
-    ccm_rv64i_zknd_zkne_initkey,
+static const PROV_CCM_HW rv64i_zkne_ccm = {
+    ccm_rv64i_zkne_initkey,
     ossl_ccm_generic_setiv,
     ossl_ccm_generic_setaad,
     ossl_ccm_generic_auth_encrypt,
@@ -64,8 +67,8 @@ const PROV_CCM_HW *ossl_prov_aes_hw_ccm(size_t keybits)
 {
     if (RISCV_HAS_ZVKNED() && riscv_vlen() >= 128)
         return &rv64i_zvkned_ccm;
-    else if (RISCV_HAS_ZKND_AND_ZKNE())
-        return &rv64i_zknd_zkne_ccm;
+    else if (RISCV_HAS_ZKNE())
+        return &rv64i_zkne_ccm;
     else
         return &aes_ccm;
 }

--- a/providers/implementations/ciphers/cipher_aes_gcm_hw_rv32i.inc
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw_rv32i.inc
@@ -8,12 +8,15 @@
  */
 
 /*-
- * RISC-V 32 ZKND ZKNE support for AES GCM.
+ * RISC-V 32 ZKNE support for AES GCM.
  * This file is included by cipher_aes_gcm_hw.c
+ *
+ * GCM uses AES only in the encrypt direction (CTR mode), so only Zkne is
+ * required; Zknd is not needed.
  */
 
-static int rv32i_zknd_zkne_gcm_initkey(PROV_GCM_CTX *ctx, const unsigned char *key,
-                                       size_t keylen)
+static int rv32i_zkne_gcm_initkey(PROV_GCM_CTX *ctx, const unsigned char *key,
+                                  size_t keylen)
 {
     PROV_AES_GCM_CTX *actx = (PROV_AES_GCM_CTX *)ctx;
     AES_KEY *ks = &actx->ks.ks;
@@ -23,9 +26,9 @@ static int rv32i_zknd_zkne_gcm_initkey(PROV_GCM_CTX *ctx, const unsigned char *k
     return 1;
 }
 
-static int rv32i_zbkb_zknd_zkne_gcm_initkey(PROV_GCM_CTX *ctx,
-                                            const unsigned char *key,
-                                            size_t keylen)
+static int rv32i_zbkb_zkne_gcm_initkey(PROV_GCM_CTX *ctx,
+                                       const unsigned char *key,
+                                       size_t keylen)
 {
     PROV_AES_GCM_CTX *actx = (PROV_AES_GCM_CTX *)ctx;
     AES_KEY *ks = &actx->ks.ks;
@@ -35,8 +38,8 @@ static int rv32i_zbkb_zknd_zkne_gcm_initkey(PROV_GCM_CTX *ctx,
     return 1;
 }
 
-static const PROV_GCM_HW rv32i_zknd_zkne_gcm = {
-    rv32i_zknd_zkne_gcm_initkey,
+static const PROV_GCM_HW rv32i_zkne_gcm = {
+    rv32i_zkne_gcm_initkey,
     ossl_gcm_setiv,
     ossl_gcm_aad_update,
     generic_aes_gcm_cipher_update,
@@ -44,8 +47,8 @@ static const PROV_GCM_HW rv32i_zknd_zkne_gcm = {
     ossl_gcm_one_shot
 };
 
-static const PROV_GCM_HW rv32i_zbkb_zknd_zkne_gcm = {
-    rv32i_zbkb_zknd_zkne_gcm_initkey,
+static const PROV_GCM_HW rv32i_zbkb_zkne_gcm = {
+    rv32i_zbkb_zkne_gcm_initkey,
     ossl_gcm_setiv,
     ossl_gcm_aad_update,
     generic_aes_gcm_cipher_update,
@@ -55,9 +58,9 @@ static const PROV_GCM_HW rv32i_zbkb_zknd_zkne_gcm = {
 
 const PROV_GCM_HW *ossl_prov_aes_hw_gcm(size_t keybits)
 {
-    if (RISCV_HAS_ZBKB_AND_ZKND_AND_ZKNE())
-        return &rv32i_zbkb_zknd_zkne_gcm;
-    if (RISCV_HAS_ZKND_AND_ZKNE())
-        return &rv32i_zknd_zkne_gcm;
+    if (RISCV_HAS_ZBKB_AND_ZKNE())
+        return &rv32i_zbkb_zkne_gcm;
+    if (RISCV_HAS_ZKNE())
+        return &rv32i_zkne_gcm;
     return &aes_gcm;
 }

--- a/providers/implementations/ciphers/cipher_aes_gcm_hw_rv64i.inc
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw_rv64i.inc
@@ -13,10 +13,13 @@
  */
 
 /*-
- * RISC-V 64 ZKND and ZKNE support for AES GCM.
+ * RISC-V 64 ZKNE support for AES GCM.
+ *
+ * GCM uses AES only in the encrypt direction (CTR mode), so only Zkne is
+ * required; Zknd is not needed.
  */
-static int rv64i_zknd_zkne_gcm_initkey(PROV_GCM_CTX *ctx, const unsigned char *key,
-                                       size_t keylen)
+static int rv64i_zkne_gcm_initkey(PROV_GCM_CTX *ctx, const unsigned char *key,
+                                  size_t keylen)
 {
     PROV_AES_GCM_CTX *actx = (PROV_AES_GCM_CTX *)ctx;
     AES_KEY *ks = &actx->ks.ks;
@@ -25,8 +28,8 @@ static int rv64i_zknd_zkne_gcm_initkey(PROV_GCM_CTX *ctx, const unsigned char *k
     return 1;
 }
 
-static const PROV_GCM_HW rv64i_zknd_zkne_gcm = {
-    rv64i_zknd_zkne_gcm_initkey,
+static const PROV_GCM_HW rv64i_zkne_gcm = {
+    rv64i_zkne_gcm_initkey,
     ossl_gcm_setiv,
     ossl_gcm_aad_update,
     generic_aes_gcm_cipher_update,
@@ -110,8 +113,8 @@ const PROV_GCM_HW *ossl_prov_aes_hw_gcm(size_t keybits) {
       return &rv64i_zvkned_gcm;
     }
 
-    if (RISCV_HAS_ZKND_AND_ZKNE()) {
-      return &rv64i_zknd_zkne_gcm;
+    if (RISCV_HAS_ZKNE()) {
+      return &rv64i_zkne_gcm;
     }
 
     return &aes_gcm;

--- a/providers/implementations/ciphers/cipher_aes_hw_rv32i.inc
+++ b/providers/implementations/ciphers/cipher_aes_hw_rv32i.inc
@@ -8,72 +8,56 @@
  */
 
 /*-
- * RISC-V 32 ZKND ZKNE support for AES modes ecb, cbc, ofb, cfb, ctr.
+ * RISC-V 32 ZKND/ZKNE support for AES modes ecb, cbc, ofb, cfb, ctr.
  * This file is included by cipher_aes_hw.c
+ *
+ * On RV32, rv32i_zknd_zkne_set_decrypt_key requires both Zkne and Zknd
+ * (it uses aes32esi from Zkne to implement InvMixColumns in the key schedule,
+ * since there is no aes32im equivalent).  rv32i_zkne_set_encrypt_key needs
+ * only Zkne.  Therefore:
+ *   - Zkne present: hardware encrypt path; hardware decrypt path only when
+ *     Zknd is also present, otherwise software decrypt fallback.
+ *   - Zknd without Zkne: no hardware path available (key schedule unusable).
  */
 
-#define cipher_hw_rv32i_zknd_zkne_cbc    ossl_cipher_hw_generic_cbc
-#define cipher_hw_rv32i_zknd_zkne_ecb    ossl_cipher_hw_generic_ecb
-#define cipher_hw_rv32i_zknd_zkne_ofb128 ossl_cipher_hw_generic_ofb128
-#define cipher_hw_rv32i_zknd_zkne_cfb128 ossl_cipher_hw_generic_cfb128
-#define cipher_hw_rv32i_zknd_zkne_cfb8   ossl_cipher_hw_generic_cfb8
-#define cipher_hw_rv32i_zknd_zkne_cfb1   ossl_cipher_hw_generic_cfb1
-#define cipher_hw_rv32i_zknd_zkne_ctr    ossl_cipher_hw_generic_ctr
+#define cipher_hw_rv32i_zkne_cbc    ossl_cipher_hw_generic_cbc
+#define cipher_hw_rv32i_zkne_ecb    ossl_cipher_hw_generic_ecb
+#define cipher_hw_rv32i_zkne_ofb128 ossl_cipher_hw_generic_ofb128
+#define cipher_hw_rv32i_zkne_cfb128 ossl_cipher_hw_generic_cfb128
+#define cipher_hw_rv32i_zkne_cfb8   ossl_cipher_hw_generic_cfb8
+#define cipher_hw_rv32i_zkne_cfb1   ossl_cipher_hw_generic_cfb1
+#define cipher_hw_rv32i_zkne_ctr    ossl_cipher_hw_generic_ctr
 
-#define cipher_hw_rv32i_zbkb_zknd_zkne_cbc    ossl_cipher_hw_generic_cbc
-#define cipher_hw_rv32i_zbkb_zknd_zkne_ecb    ossl_cipher_hw_generic_ecb
-#define cipher_hw_rv32i_zbkb_zknd_zkne_ofb128 ossl_cipher_hw_generic_ofb128
-#define cipher_hw_rv32i_zbkb_zknd_zkne_cfb128 ossl_cipher_hw_generic_cfb128
-#define cipher_hw_rv32i_zbkb_zknd_zkne_cfb8   ossl_cipher_hw_generic_cfb8
-#define cipher_hw_rv32i_zbkb_zknd_zkne_cfb1   ossl_cipher_hw_generic_cfb1
-#define cipher_hw_rv32i_zbkb_zknd_zkne_ctr    ossl_cipher_hw_generic_ctr
-
-static int cipher_hw_rv32i_zknd_zkne_initkey(PROV_CIPHER_CTX *dat,
-                                             const unsigned char *key, size_t keylen)
+static int cipher_hw_rv32i_zkne_initkey(PROV_CIPHER_CTX *dat,
+                                        const unsigned char *key, size_t keylen)
 {
     int ret;
     PROV_AES_CTX *adat = (PROV_AES_CTX *)dat;
     AES_KEY *ks = &adat->ks.ks;
 
     dat->ks = ks;
+    dat->stream.cbc = NULL;
 
     if ((dat->mode == EVP_CIPH_ECB_MODE || dat->mode == EVP_CIPH_CBC_MODE)
         && !dat->enc) {
-        ret = rv32i_zknd_zkne_set_decrypt_key(key, keylen * 8, ks);
-        dat->block = (block128_f) rv32i_zknd_decrypt;
-        dat->stream.cbc = NULL;
+        if (RISCV_HAS_ZBKB_AND_ZKND_AND_ZKNE()) {
+            ret = rv32i_zbkb_zknd_zkne_set_decrypt_key(key, keylen * 8, ks);
+            dat->block = (block128_f) rv32i_zknd_decrypt;
+        } else if (RISCV_HAS_ZKND_AND_ZKNE()) {
+            ret = rv32i_zknd_zkne_set_decrypt_key(key, keylen * 8, ks);
+            dat->block = (block128_f) rv32i_zknd_decrypt;
+        } else {
+            /* Zknd absent or Zkne absent: key schedule needs both on RV32 */
+            ret = AES_set_decrypt_key(key, (int)(keylen * 8), ks);
+            dat->block = (block128_f) AES_decrypt;
+        }
     } else {
-        ret = rv32i_zkne_set_encrypt_key(key, keylen * 8, ks);
+        if (RISCV_HAS_ZBKB_AND_ZKNE()) {
+            ret = rv32i_zbkb_zkne_set_encrypt_key(key, keylen * 8, ks);
+        } else {
+            ret = rv32i_zkne_set_encrypt_key(key, keylen * 8, ks);
+        }
         dat->block = (block128_f) rv32i_zkne_encrypt;
-        dat->stream.cbc = NULL;
-    }
-
-    if (ret < 0) {
-        ERR_raise(ERR_LIB_PROV, PROV_R_KEY_SETUP_FAILED);
-        return 0;
-    }
-
-    return 1;
-}
-
-static int cipher_hw_rv32i_zbkb_zknd_zkne_initkey(PROV_CIPHER_CTX *dat,
-                                                  const unsigned char *key, size_t keylen)
-{
-    int ret;
-    PROV_AES_CTX *adat = (PROV_AES_CTX *)dat;
-    AES_KEY *ks = &adat->ks.ks;
-
-    dat->ks = ks;
-
-    if ((dat->mode == EVP_CIPH_ECB_MODE || dat->mode == EVP_CIPH_CBC_MODE)
-        && !dat->enc) {
-        ret = rv32i_zbkb_zknd_zkne_set_decrypt_key(key, keylen * 8, ks);
-        dat->block = (block128_f) rv32i_zknd_decrypt;
-        dat->stream.cbc = NULL;
-    } else {
-        ret = rv32i_zbkb_zkne_set_encrypt_key(key, keylen * 8, ks);
-        dat->block = (block128_f) rv32i_zkne_encrypt;
-        dat->stream.cbc = NULL;
     }
 
     if (ret < 0) {
@@ -85,18 +69,11 @@ static int cipher_hw_rv32i_zbkb_zknd_zkne_initkey(PROV_CIPHER_CTX *dat,
 }
 
 #define PROV_CIPHER_HW_declare(mode)                                           \
-static const PROV_CIPHER_HW rv32i_zknd_zkne_##mode = {                         \
-    cipher_hw_rv32i_zknd_zkne_initkey,                                         \
-    cipher_hw_rv32i_zknd_zkne_##mode,                                          \
-    cipher_hw_aes_copyctx                                                      \
-};                                                                             \
-static const PROV_CIPHER_HW rv32i_zbkb_zknd_zkne_##mode = {                    \
-    cipher_hw_rv32i_zbkb_zknd_zkne_initkey,                                    \
-    cipher_hw_rv32i_zbkb_zknd_zkne_##mode,                                     \
+static const PROV_CIPHER_HW rv32i_zkne_##mode = {                              \
+    cipher_hw_rv32i_zkne_initkey,                                              \
+    cipher_hw_rv32i_zkne_##mode,                                               \
     cipher_hw_aes_copyctx                                                      \
 };
 #define PROV_CIPHER_HW_select(mode)                                            \
-if (RISCV_HAS_ZBKB_AND_ZKND_AND_ZKNE())                                        \
-    return &rv32i_zbkb_zknd_zkne_##mode;                                       \
-if (RISCV_HAS_ZKND_AND_ZKNE())                                                 \
-    return &rv32i_zknd_zkne_##mode;
+if (RISCV_HAS_ZKNE())                                                          \
+    return &rv32i_zkne_##mode;

--- a/providers/implementations/ciphers/cipher_aes_hw_rv64i.inc
+++ b/providers/implementations/ciphers/cipher_aes_hw_rv64i.inc
@@ -8,36 +8,56 @@
  */
 
 /*-
- * RISC-V 64 ZKND ZKNE support for AES modes ecb, cbc, ofb, cfb, ctr.
+ * RISC-V 64 ZKND/ZKNE support for AES modes ecb, cbc, ofb, cfb, ctr.
  * This file is included by cipher_aes_hw.c
+ *
+ * Instruction set dependencies:
+ *   rv64i_zkne_set_encrypt_key / rv64i_zkne_encrypt: aes64ks1i, aes64ks2,
+ *     aes64es, aes64esm  ->  Zkne only
+ *   rv64i_zknd_set_decrypt_key / rv64i_zknd_decrypt: aes64ks1i, aes64ks2
+ *     (both present in Zknd), aes64im, aes64ds, aes64dsm  ->  Zknd only
+ *
+ * Therefore encryption and decryption can be accelerated independently:
+ *   - Zkne present: hardware encrypt path, software decrypt fallback
+ *   - Zknd present: hardware decrypt path, software encrypt fallback
+ *   - Both present: hardware for both directions
  */
 
-#define cipher_hw_rv64i_zknd_zkne_cbc    ossl_cipher_hw_generic_cbc
-#define cipher_hw_rv64i_zknd_zkne_ecb    ossl_cipher_hw_generic_ecb
-#define cipher_hw_rv64i_zknd_zkne_ofb128 ossl_cipher_hw_generic_ofb128
-#define cipher_hw_rv64i_zknd_zkne_cfb128 ossl_cipher_hw_generic_cfb128
-#define cipher_hw_rv64i_zknd_zkne_cfb8   ossl_cipher_hw_generic_cfb8
-#define cipher_hw_rv64i_zknd_zkne_cfb1   ossl_cipher_hw_generic_cfb1
-#define cipher_hw_rv64i_zknd_zkne_ctr    ossl_cipher_hw_generic_ctr
+#define cipher_hw_rv64i_zkn_cbc    ossl_cipher_hw_generic_cbc
+#define cipher_hw_rv64i_zkn_ecb    ossl_cipher_hw_generic_ecb
+#define cipher_hw_rv64i_zkn_ofb128 ossl_cipher_hw_generic_ofb128
+#define cipher_hw_rv64i_zkn_cfb128 ossl_cipher_hw_generic_cfb128
+#define cipher_hw_rv64i_zkn_cfb8   ossl_cipher_hw_generic_cfb8
+#define cipher_hw_rv64i_zkn_cfb1   ossl_cipher_hw_generic_cfb1
+#define cipher_hw_rv64i_zkn_ctr    ossl_cipher_hw_generic_ctr
 
-static int cipher_hw_rv64i_zknd_zkne_initkey(PROV_CIPHER_CTX *dat,
-                                   const unsigned char *key, size_t keylen)
+static int cipher_hw_rv64i_zkn_initkey(PROV_CIPHER_CTX *dat,
+                                       const unsigned char *key, size_t keylen)
 {
     int ret;
     PROV_AES_CTX *adat = (PROV_AES_CTX *)dat;
     AES_KEY *ks = &adat->ks.ks;
 
     dat->ks = ks;
+    dat->stream.cbc = NULL;
 
     if ((dat->mode == EVP_CIPH_ECB_MODE || dat->mode == EVP_CIPH_CBC_MODE)
         && !dat->enc) {
-        ret = rv64i_zknd_set_decrypt_key(key, keylen * 8, ks);
-        dat->block = (block128_f) rv64i_zknd_decrypt;
-        dat->stream.cbc = NULL;
+        if (RISCV_HAS_ZKND()) {
+            ret = rv64i_zknd_set_decrypt_key(key, keylen * 8, ks);
+            dat->block = (block128_f) rv64i_zknd_decrypt;
+        } else {
+            ret = AES_set_decrypt_key(key, (int)(keylen * 8), ks);
+            dat->block = (block128_f) AES_decrypt;
+        }
     } else {
-        ret = rv64i_zkne_set_encrypt_key(key, keylen * 8, ks);
-        dat->block = (block128_f) rv64i_zkne_encrypt;
-        dat->stream.cbc = NULL;
+        if (RISCV_HAS_ZKNE()) {
+            ret = rv64i_zkne_set_encrypt_key(key, keylen * 8, ks);
+            dat->block = (block128_f) rv64i_zkne_encrypt;
+        } else {
+            ret = AES_set_encrypt_key(key, (int)(keylen * 8), ks);
+            dat->block = (block128_f) AES_encrypt;
+        }
     }
 
     if (ret < 0) {
@@ -118,9 +138,9 @@ static int cipher_hw_rv64i_zvkned_initkey(PROV_CIPHER_CTX *dat,
 }
 
 #define PROV_CIPHER_HW_declare(mode)                                           \
-static const PROV_CIPHER_HW rv64i_zknd_zkne_##mode = {                         \
-    cipher_hw_rv64i_zknd_zkne_initkey,                                         \
-    cipher_hw_rv64i_zknd_zkne_##mode,                                          \
+static const PROV_CIPHER_HW rv64i_zkn_##mode = {                               \
+    cipher_hw_rv64i_zkn_initkey,                                               \
+    cipher_hw_rv64i_zkn_##mode,                                                \
     cipher_hw_aes_copyctx                                                      \
 };                                                                             \
 static const PROV_CIPHER_HW rv64i_zvkned_##mode = {                            \
@@ -131,5 +151,5 @@ static const PROV_CIPHER_HW rv64i_zvkned_##mode = {                            \
 #define PROV_CIPHER_HW_select(mode)                                            \
 if (RISCV_HAS_ZVKNED() && riscv_vlen() >= 128)                                 \
     return &rv64i_zvkned_##mode;                                               \
-else if (RISCV_HAS_ZKND_AND_ZKNE())                                            \
-    return &rv64i_zknd_zkne_##mode;
+else if (RISCV_HAS_ZKNE() || RISCV_HAS_ZKND())                                 \
+    return &rv64i_zkn_##mode;

--- a/providers/implementations/ciphers/cipher_aes_ocb_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb_hw.c
@@ -109,9 +109,28 @@ static int cipher_hw_aes_ocb_rv64i_zknd_zkne_initkey(PROV_CIPHER_CTX *vctx,
     size_t keylen)
 {
     PROV_AES_OCB_CTX *ctx = (PROV_AES_OCB_CTX *)vctx;
+    block128_f fn_enc, fn_dec;
 
-    OCB_SET_KEY_FN(rv64i_zkne_set_encrypt_key, rv64i_zknd_set_decrypt_key,
-        rv64i_zkne_encrypt, rv64i_zknd_decrypt, NULL, NULL);
+    CRYPTO_ocb128_cleanup(&ctx->ocb);
+
+    if (RISCV_HAS_ZKNE()) {
+        rv64i_zkne_set_encrypt_key(key, (int)(keylen * 8), &ctx->ksenc.ks);
+        fn_enc = (block128_f)rv64i_zkne_encrypt;
+    } else {
+        AES_set_encrypt_key(key, (int)(keylen * 8), &ctx->ksenc.ks);
+        fn_enc = (block128_f)AES_encrypt;
+    }
+    if (RISCV_HAS_ZKND()) {
+        rv64i_zknd_set_decrypt_key(key, (int)(keylen * 8), &ctx->ksdec.ks);
+        fn_dec = (block128_f)rv64i_zknd_decrypt;
+    } else {
+        AES_set_decrypt_key(key, (int)(keylen * 8), &ctx->ksdec.ks);
+        fn_dec = (block128_f)AES_decrypt;
+    }
+    if (!CRYPTO_ocb128_init(&ctx->ocb, &ctx->ksenc.ks, &ctx->ksdec.ks,
+            fn_enc, fn_dec, NULL))
+        return 0;
+    ctx->key_set = 1;
     return 1;
 }
 
@@ -147,47 +166,59 @@ static int cipher_hw_aes_ocb_rv64i_zvkned_initkey(PROV_CIPHER_CTX *vctx,
 #define PROV_CIPHER_HW_select()                    \
     if (RISCV_HAS_ZVKNED() && riscv_vlen() >= 128) \
         return &aes_rv64i_zvkned_ocb;              \
-    else if (RISCV_HAS_ZKND_AND_ZKNE())            \
+    else if (RISCV_HAS_ZKNE() || RISCV_HAS_ZKND()) \
         return &aes_rv64i_zknd_zkne_ocb;
 
 #elif defined(OPENSSL_CPUID_OBJ) && defined(__riscv) && __riscv_xlen == 32
 
-static int cipher_hw_aes_ocb_rv32i_zknd_zkne_initkey(PROV_CIPHER_CTX *vctx,
+static int cipher_hw_aes_ocb_rv32i_zkne_initkey(PROV_CIPHER_CTX *vctx,
     const unsigned char *key,
     size_t keylen)
 {
     PROV_AES_OCB_CTX *ctx = (PROV_AES_OCB_CTX *)vctx;
+    block128_f fn_enc, fn_dec;
 
-    OCB_SET_KEY_FN(rv32i_zkne_set_encrypt_key, rv32i_zknd_zkne_set_decrypt_key,
-        rv32i_zkne_encrypt, rv32i_zknd_decrypt, NULL, NULL);
+    CRYPTO_ocb128_cleanup(&ctx->ocb);
+
+    /*
+     * On RV32, the encrypt key schedule (rv32i_zkne_set_encrypt_key) only
+     * needs Zkne. The decrypt key schedule (rv32i_zknd_zkne_set_decrypt_key)
+     * needs both Zkne and Zknd (uses aes32esi from Zkne for InvMixColumns).
+     * Select the best available encrypt and decrypt paths independently.
+     */
+    if (RISCV_HAS_ZBKB_AND_ZKNE()) {
+        rv32i_zbkb_zkne_set_encrypt_key(key, (int)(keylen * 8), &ctx->ksenc.ks);
+    } else {
+        rv32i_zkne_set_encrypt_key(key, (int)(keylen * 8), &ctx->ksenc.ks);
+    }
+    fn_enc = (block128_f)rv32i_zkne_encrypt;
+
+    if (RISCV_HAS_ZKND_AND_ZKNE()) {
+        if (RISCV_HAS_ZBKB())
+            rv32i_zbkb_zknd_zkne_set_decrypt_key(key, (int)(keylen * 8), &ctx->ksdec.ks);
+        else
+            rv32i_zknd_zkne_set_decrypt_key(key, (int)(keylen * 8), &ctx->ksdec.ks);
+        fn_dec = (block128_f)rv32i_zknd_decrypt;
+    } else {
+        AES_set_decrypt_key(key, (int)(keylen * 8), &ctx->ksdec.ks);
+        fn_dec = (block128_f)AES_decrypt;
+    }
+
+    if (!CRYPTO_ocb128_init(&ctx->ocb, &ctx->ksenc.ks, &ctx->ksdec.ks,
+            fn_enc, fn_dec, NULL))
+        return 0;
+    ctx->key_set = 1;
     return 1;
 }
 
-static int cipher_hw_aes_ocb_rv32i_zbkb_zknd_zkne_initkey(PROV_CIPHER_CTX *vctx,
-    const unsigned char *key,
-    size_t keylen)
-{
-    PROV_AES_OCB_CTX *ctx = (PROV_AES_OCB_CTX *)vctx;
-
-    OCB_SET_KEY_FN(rv32i_zbkb_zkne_set_encrypt_key, rv32i_zbkb_zknd_zkne_set_decrypt_key,
-        rv32i_zkne_encrypt, rv32i_zknd_decrypt, NULL, NULL);
-    return 1;
-}
-
-#define PROV_CIPHER_HW_declare()                                 \
-    static const PROV_CIPHER_HW aes_rv32i_zknd_zkne_ocb = {      \
-        cipher_hw_aes_ocb_rv32i_zknd_zkne_initkey,               \
-        NULL                                                     \
-    };                                                           \
-    static const PROV_CIPHER_HW aes_rv32i_zbkb_zknd_zkne_ocb = { \
-        cipher_hw_aes_ocb_rv32i_zbkb_zknd_zkne_initkey,          \
-        NULL                                                     \
+#define PROV_CIPHER_HW_declare()                       \
+    static const PROV_CIPHER_HW aes_rv32i_zkne_ocb = { \
+        cipher_hw_aes_ocb_rv32i_zkne_initkey,          \
+        NULL                                           \
     };
-#define PROV_CIPHER_HW_select()               \
-    if (RISCV_HAS_ZBKB_AND_ZKND_AND_ZKNE())   \
-        return &aes_rv32i_zbkb_zknd_zkne_ocb; \
-    if (RISCV_HAS_ZKND_AND_ZKNE())            \
-        return &aes_rv32i_zknd_zkne_ocb;
+#define PROV_CIPHER_HW_select() \
+    if (RISCV_HAS_ZKNE())       \
+        return &aes_rv32i_zkne_ocb;
 #else
 #define PROV_CIPHER_HW_declare()
 #define PROV_CIPHER_HW_select()

--- a/providers/implementations/ciphers/cipher_aes_xts_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_xts_hw.c
@@ -193,12 +193,37 @@ static int cipher_hw_aes_xts_rv64i_zknd_zkne_initkey(PROV_CIPHER_CTX *ctx,
     size_t keylen)
 {
     PROV_AES_XTS_CTX *xctx = (PROV_AES_XTS_CTX *)ctx;
-    OSSL_xts_stream_fn stream_enc = NULL;
-    OSSL_xts_stream_fn stream_dec = NULL;
+    size_t bytes = keylen / 2;
+    size_t bits = bytes * 8;
 
-    XTS_SET_KEY_FN(rv64i_zkne_set_encrypt_key, rv64i_zknd_set_decrypt_key,
-        rv64i_zkne_encrypt, rv64i_zknd_decrypt,
-        stream_enc, stream_dec);
+    if (ctx->enc) {
+        if (RISCV_HAS_ZKNE()) {
+            rv64i_zkne_set_encrypt_key(key, (int)bits, &xctx->ks1.ks);
+            xctx->xts.block1 = (block128_f)rv64i_zkne_encrypt;
+        } else {
+            AES_set_encrypt_key(key, (int)bits, &xctx->ks1.ks);
+            xctx->xts.block1 = (block128_f)AES_encrypt;
+        }
+    } else {
+        if (RISCV_HAS_ZKND()) {
+            rv64i_zknd_set_decrypt_key(key, (int)bits, &xctx->ks1.ks);
+            xctx->xts.block1 = (block128_f)rv64i_zknd_decrypt;
+        } else {
+            AES_set_decrypt_key(key, (int)bits, &xctx->ks1.ks);
+            xctx->xts.block1 = (block128_f)AES_decrypt;
+        }
+    }
+    /* Tweak key always uses the encrypt direction */
+    if (RISCV_HAS_ZKNE()) {
+        rv64i_zkne_set_encrypt_key(key + bytes, (int)bits, &xctx->ks2.ks);
+        xctx->xts.block2 = (block128_f)rv64i_zkne_encrypt;
+    } else {
+        AES_set_encrypt_key(key + bytes, (int)bits, &xctx->ks2.ks);
+        xctx->xts.block2 = (block128_f)AES_encrypt;
+    }
+    xctx->xts.key1 = &xctx->ks1;
+    xctx->xts.key2 = &xctx->ks2;
+    xctx->stream = NULL;
     return 1;
 }
 
@@ -268,51 +293,64 @@ static int cipher_hw_aes_xts_rv64i_zvkned_initkey(PROV_CIPHER_CTX *ctx,
         return &aes_xts_rv64i_zvbb_zvkg_zvkned;                                            \
     if (RISCV_HAS_ZVKNED() && riscv_vlen() >= 128)                                         \
         return &aes_xts_rv64i_zvkned;                                                      \
-    else if (RISCV_HAS_ZKND_AND_ZKNE())                                                    \
+    else if (RISCV_HAS_ZKNE() || RISCV_HAS_ZKND())                                         \
         return &aes_xts_rv64i_zknd_zkne;
 
 #elif defined(OPENSSL_CPUID_OBJ) && defined(__riscv) && __riscv_xlen == 32
 
-static int cipher_hw_aes_xts_rv32i_zknd_zkne_initkey(PROV_CIPHER_CTX *ctx,
+static int cipher_hw_aes_xts_rv32i_zkne_initkey(PROV_CIPHER_CTX *ctx,
     const unsigned char *key,
     size_t keylen)
 {
     PROV_AES_XTS_CTX *xctx = (PROV_AES_XTS_CTX *)ctx;
+    size_t bytes = keylen / 2;
+    size_t bits = bytes * 8;
 
-    XTS_SET_KEY_FN(rv32i_zkne_set_encrypt_key, rv32i_zknd_zkne_set_decrypt_key,
-        rv32i_zkne_encrypt, rv32i_zknd_decrypt,
-        NULL, NULL);
+    /*
+     * On RV32, the decrypt key schedule (rv32i_zknd_zkne_set_decrypt_key)
+     * needs both Zkne and Zknd. Select the best available paths independently.
+     */
+    if (ctx->enc) {
+        if (RISCV_HAS_ZBKB_AND_ZKNE()) {
+            rv32i_zbkb_zkne_set_encrypt_key(key, (int)bits, &xctx->ks1.ks);
+        } else {
+            rv32i_zkne_set_encrypt_key(key, (int)bits, &xctx->ks1.ks);
+        }
+        xctx->xts.block1 = (block128_f)rv32i_zkne_encrypt;
+    } else {
+        if (RISCV_HAS_ZKND_AND_ZKNE()) {
+            if (RISCV_HAS_ZBKB())
+                rv32i_zbkb_zknd_zkne_set_decrypt_key(key, (int)bits, &xctx->ks1.ks);
+            else
+                rv32i_zknd_zkne_set_decrypt_key(key, (int)bits, &xctx->ks1.ks);
+            xctx->xts.block1 = (block128_f)rv32i_zknd_decrypt;
+        } else {
+            AES_set_decrypt_key(key, (int)bits, &xctx->ks1.ks);
+            xctx->xts.block1 = (block128_f)AES_decrypt;
+        }
+    }
+    /* Tweak key always uses the encrypt direction */
+    if (RISCV_HAS_ZBKB_AND_ZKNE()) {
+        rv32i_zbkb_zkne_set_encrypt_key(key + bytes, (int)bits, &xctx->ks2.ks);
+    } else {
+        rv32i_zkne_set_encrypt_key(key + bytes, (int)bits, &xctx->ks2.ks);
+    }
+    xctx->xts.block2 = (block128_f)rv32i_zkne_encrypt;
+    xctx->xts.key1 = &xctx->ks1;
+    xctx->xts.key2 = &xctx->ks2;
+    xctx->stream = NULL;
     return 1;
 }
 
-static int cipher_hw_aes_xts_rv32i_zbkb_zknd_zkne_initkey(PROV_CIPHER_CTX *ctx,
-    const unsigned char *key,
-    size_t keylen)
-{
-    PROV_AES_XTS_CTX *xctx = (PROV_AES_XTS_CTX *)ctx;
-
-    XTS_SET_KEY_FN(rv32i_zbkb_zkne_set_encrypt_key, rv32i_zbkb_zknd_zkne_set_decrypt_key,
-        rv32i_zkne_encrypt, rv32i_zknd_decrypt,
-        NULL, NULL);
-    return 1;
-}
-
-#define PROV_CIPHER_HW_declare_xts()                             \
-    static const PROV_CIPHER_HW aes_xts_rv32i_zknd_zkne = {      \
-        cipher_hw_aes_xts_rv32i_zknd_zkne_initkey,               \
-        NULL,                                                    \
-        cipher_hw_aes_xts_copyctx                                \
-    };                                                           \
-    static const PROV_CIPHER_HW aes_xts_rv32i_zbkb_zknd_zkne = { \
-        cipher_hw_aes_xts_rv32i_zbkb_zknd_zkne_initkey,          \
-        NULL,                                                    \
-        cipher_hw_aes_xts_copyctx                                \
+#define PROV_CIPHER_HW_declare_xts()                   \
+    static const PROV_CIPHER_HW aes_xts_rv32i_zkne = { \
+        cipher_hw_aes_xts_rv32i_zkne_initkey,          \
+        NULL,                                          \
+        cipher_hw_aes_xts_copyctx                      \
     };
-#define PROV_CIPHER_HW_select_xts()           \
-    if (RISCV_HAS_ZBKB_AND_ZKND_AND_ZKNE())   \
-        return &aes_xts_rv32i_zbkb_zknd_zkne; \
-    if (RISCV_HAS_ZKND_AND_ZKNE())            \
-        return &aes_xts_rv32i_zknd_zkne;
+#define PROV_CIPHER_HW_select_xts() \
+    if (RISCV_HAS_ZKNE())           \
+        return &aes_xts_rv32i_zkne;
 #else
 /* The generic case */
 #define PROV_CIPHER_HW_declare_xts()


### PR DESCRIPTION
  This PR addresses #25334.

  Currently, the RISC-V AES provider code generally requires `Zkne` and `Zknd` together before selecting the accelerated implementation. This PR changes that so encryption and decryption can be accelerated independently, where the implementation allows it.

  The PR is split into two commits:

  1. `RISC-V AES: accelerate encrypt and decrypt independently with Zkne/Zknd`
  2. `CI: add RISC-V AES Zkne-only and Zknd-only cross-compile configurations`

  The motivation is that the ISA defines `Zkne` and `Zknd` separately, and some modes only need one direction. For example, CCM and GCM only use AES encryption, so requiring both extensions there is stricter than necessary.

  Pros:
  - makes use of available hardware support when only one of `Zkne` / `Zknd` is present
  - matches the architectural split of the RISC-V crypto extensions
  - adds CI coverage for `Zkne`-only and `Zknd`-only configurations

  Cons:
  - increases code complexity in the AES provider paths
  - adds maintenance burden for configurations that may be uncommon in practice
  - the practical benefit may be limited if Linux-class RISC-V SoCs usually ship with either neither extension or both together

  I am not strongly in favor of this being merged. I think the PR is technically valid, but I am not sure it is worth the added complexity unless there are real users for partial-extension configurations. I am posting it mainly to get feedback on that tradeoff.