### PR TITLE
ISSUE-30725: Validate lengths in BIO_f_buffer buffer_ctrl()

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,11 +38,46 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: install nasm
+      shell: pwsh
       run: |
-        choco install nasm ${{ matrix.platform.arch == 'x86' && '--x86' || '' }}
-        "C:\Program Files${{ matrix.platform.arch == 'x86' && ' (x86)' || '' }}\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
-    - name: install jom
-      run: choco install jom
+        $ErrorActionPreference = 'Stop'
+        $isX86 = '${{ matrix.platform.arch }}' -eq 'x86'
+        $chocoExtra = @()
+        if ($isX86) { $chocoExtra += '--x86' }
+        $chocoOk = $false
+        foreach ($i in 1..5) {
+          choco install nasm @chocoExtra -y --no-progress
+          if ($LASTEXITCODE -eq 0) { $chocoOk = $true; break }
+          Write-Host "choco install nasm failed (attempt $i), retrying in 20s..."
+          Start-Sleep -Seconds 20
+        }
+        $progNasm = if ($isX86) {
+          Join-Path ${env:ProgramFiles(x86)} 'NASM'
+        } else {
+          Join-Path $env:ProgramFiles 'NASM'
+        }
+        $nasmDir = $null
+        if ($chocoOk -and (Test-Path (Join-Path $progNasm 'nasm.exe'))) {
+          $nasmDir = $progNasm
+        }
+        if ($null -eq $nasmDir) {
+          Write-Host 'Installing NASM from nasm.us (Chocolatey unavailable or incomplete)'
+          $ver = '2.16.03'
+          $rel = if ($isX86) { 'win32' } else { 'win64' }
+          $url = "https://www.nasm.us/pub/nasm/releasebuilds/$ver/$rel/nasm-$ver-$rel.zip"
+          $zip = Join-Path $env:RUNNER_TEMP "nasm-$ver-$rel.zip"
+          $dest = Join-Path $env:RUNNER_TEMP "nasm-$ver-$rel"
+          Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
+          if (Test-Path $dest) { Remove-Item -Recurse -Force $dest }
+          Expand-Archive -Path $zip -DestinationPath $dest -Force
+          $inner = Get-ChildItem -LiteralPath $dest -Directory | Select-Object -First 1
+          if ($null -eq $inner) { throw 'NASM zip: no top-level directory' }
+          $nasmDir = $inner.FullName
+        }
+        if (-not (Test-Path (Join-Path $nasmDir 'nasm.exe'))) {
+          throw "nasm.exe missing under $nasmDir"
+        }
+        Add-Content -Path $env:GITHUB_PATH -Value $nasmDir
     - name: prepare the build directory
       run: mkdir _build
     - name: config
@@ -57,7 +92,7 @@ jobs:
       shell: cmd
       run: |
         call "${{ matrix.platform.vcvars }}"
-        jom /j4 /S
+        nmake /S
     - name: download coreinfo
       run: |
         mkdir _build\coreinfo
@@ -95,7 +130,7 @@ jobs:
       shell: cmd
       run: |
         call "${{ matrix.platform.vcvars }}"
-        jom test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4
+        nmake test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4
     - name: install
       # Run on 64 bit only as 32 bit is slow enough already
       if: ${{ matrix.platform.arch == 'amd64' }}
@@ -104,7 +139,7 @@ jobs:
       run: |
         call "${{ matrix.platform.vcvars }}"
         mkdir _dest
-        jom /j4 install DESTDIR=_dest
+        nmake install DESTDIR=_dest
 
   plain:
     runs-on: windows-2022
@@ -114,10 +149,42 @@ jobs:
         persist-credentials: false
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
+    - name: install nasm
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $isX86 = $false
+        $chocoOk = $false
+        foreach ($i in 1..5) {
+          choco install nasm -y --no-progress
+          if ($LASTEXITCODE -eq 0) { $chocoOk = $true; break }
+          Write-Host "choco install nasm failed (attempt $i), retrying in 20s..."
+          Start-Sleep -Seconds 20
+        }
+        $progNasm = Join-Path $env:ProgramFiles 'NASM'
+        $nasmDir = $null
+        if ($chocoOk -and (Test-Path (Join-Path $progNasm 'nasm.exe'))) {
+          $nasmDir = $progNasm
+        }
+        if ($null -eq $nasmDir) {
+          Write-Host 'Installing NASM from nasm.us (Chocolatey unavailable or incomplete)'
+          $ver = '2.16.03'
+          $url = "https://www.nasm.us/pub/nasm/releasebuilds/$ver/win64/nasm-$ver-win64.zip"
+          $zip = Join-Path $env:RUNNER_TEMP "nasm-$ver-win64.zip"
+          $dest = Join-Path $env:RUNNER_TEMP "nasm-$ver-win64"
+          Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
+          if (Test-Path $dest) { Remove-Item -Recurse -Force $dest }
+          Expand-Archive -Path $zip -DestinationPath $dest -Force
+          $inner = Get-ChildItem -LiteralPath $dest -Directory | Select-Object -First 1
+          if ($null -eq $inner) { throw 'NASM zip: no top-level directory' }
+          $nasmDir = $inner.FullName
+        }
+        if (-not (Test-Path (Join-Path $nasmDir 'nasm.exe'))) {
+          throw "nasm.exe missing under $nasmDir"
+        }
+        Add-Content -Path $env:GITHUB_PATH -Value $nasmDir
     - name: prepare the build directory
       run: mkdir _build
-    - name: install jom
-      run:  choco install jom
     - name: config
       working-directory: _build
       shell: cmd
@@ -130,7 +197,7 @@ jobs:
       shell: cmd
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        jom /j4 /S
+        nmake /S
     - name: download coreinfo
       run: |
         mkdir _build\coreinfo
@@ -159,8 +226,6 @@ jobs:
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: prepare the build directory
       run: mkdir _build
-    - name: install jom
-      run:  choco install jom
     - name: config
       working-directory: _build
       shell: cmd
@@ -173,7 +238,7 @@ jobs:
       shell: cmd
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        jom /j4 /S
+        nmake
     - name: download coreinfo
       run: |
         mkdir _build\coreinfo
@@ -190,7 +255,7 @@ jobs:
       shell: cmd
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        jom test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4
+        nmake test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4
 
   cygwin:
     # Run a job for each of the specified target architectures:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,13 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * Fixed buffer BIO control operations to reject invalid length arguments
+   (negative values, values larger than `INT_MAX`, or a NULL data pointer
+   when a non-zero length is supplied for `BIO_set_buffer_read_data`, and
+   invalid arguments for `BIO_CTRL_PEEK` on a buffer BIO). Previously some
+   combinations could invoke `memcpy` with an invalid size. Invalid
+   arguments are now rejected before altering buffered data or retry state.
+
  * Improved DTLS handshake robustness under UDP reordering by buffering and
    replaying early ChangeCipherSpec (CCS) records at the expected state.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,13 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * Fixed buffer BIO control operations to reject invalid length arguments
+   (negative values, values larger than `INT_MAX`, or a NULL data pointer
+   when a non-zero length is supplied for `BIO_set_buffer_read_data`, and
+   invalid arguments for `BIO_CTRL_PEEK` on a buffer BIO). Previously some
+   combinations could invoke `memcpy` with an invalid size. Invalid
+   arguments are now rejected before altering buffered data or retry state.
+
  * Added -testmode option for `s_time` app.
 
    *Jakub Zelenka*

--- a/crypto/bio/bf_buff.c
+++ b/crypto/bio/bf_buff.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <errno.h>
+#include <limits.h>
 #include "bio_local.h"
 #include "internal/cryptlib.h"
 
@@ -292,46 +293,69 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         }
         break;
     case BIO_C_SET_BUFF_READ_DATA:
+        if (num < 0)
+            return 0;
+#if LONG_MAX > INT_MAX
+        if (num > INT_MAX)
+            return 0;
+#endif
+        if (num > 0 && ptr == NULL)
+            return 0;
         if (num > ctx->ibuf_size) {
-            if (num <= 0)
-                return 0;
             p1 = OPENSSL_malloc((size_t)num);
             if (p1 == NULL)
                 return 0;
             OPENSSL_free(ctx->ibuf);
             ctx->ibuf = p1;
+            ctx->ibuf_size = (int)num;
         }
         ctx->ibuf_off = 0;
         ctx->ibuf_len = (int)num;
-        memcpy(ctx->ibuf, ptr, (int)num);
+        if (num > 0)
+            memcpy(ctx->ibuf, ptr, (size_t)num);
         ret = 1;
         break;
     case BIO_C_SET_BUFF_SIZE:
         if (ptr != NULL) {
             ip = (int *)ptr;
             if (*ip == 0) {
+                if (num < 0)
+                    return 0;
+#if LONG_MAX > INT_MAX
+                if (num > INT_MAX)
+                    return 0;
+#endif
                 ibs = (int)num;
                 obs = ctx->obuf_size;
             } else { /* if (*ip == 1) */
-
+                if (num < 0)
+                    return 0;
+#if LONG_MAX > INT_MAX
+                if (num > INT_MAX)
+                    return 0;
+#endif
                 ibs = ctx->ibuf_size;
                 obs = (int)num;
             }
         } else {
+            if (num < 0)
+                return 0;
+#if LONG_MAX > INT_MAX
+            if (num > INT_MAX)
+                return 0;
+#endif
             ibs = (int)num;
             obs = (int)num;
         }
         p1 = ctx->ibuf;
         p2 = ctx->obuf;
         if ((ibs > DEFAULT_BUFFER_SIZE) && (ibs != ctx->ibuf_size)) {
-            if (num <= 0)
-                return 0;
-            p1 = OPENSSL_malloc((size_t)num);
+            p1 = OPENSSL_malloc((size_t)ibs);
             if (p1 == NULL)
                 return 0;
         }
         if ((obs > DEFAULT_BUFFER_SIZE) && (obs != ctx->obuf_size)) {
-            p2 = OPENSSL_malloc((size_t)num);
+            p2 = OPENSSL_malloc((size_t)obs);
             if (p2 == NULL) {
                 if (p1 != ctx->ibuf)
                     OPENSSL_free(p1);
@@ -395,6 +419,12 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
             ret = 0;
         break;
     case BIO_CTRL_PEEK:
+        if (num < 0)
+            return 0;
+        if (num > 0 && ptr == NULL)
+            return 0;
+        if (num == 0)
+            return 0;
         /* Ensure there's stuff in the input buffer */
         {
             char fake_buf[1];
@@ -402,7 +432,7 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         }
         if (num > ctx->ibuf_len)
             num = ctx->ibuf_len;
-        memcpy(ptr, &(ctx->ibuf[ctx->ibuf_off]), num);
+        memcpy(ptr, &(ctx->ibuf[ctx->ibuf_off]), (size_t)num);
         ret = num;
         break;
     default:

--- a/doc/man3/BIO_f_buffer.pod
+++ b/doc/man3/BIO_f_buffer.pod
@@ -40,10 +40,18 @@ set the read, write or both read and write buffer sizes to B<size>. The initial
 buffer size is DEFAULT_BUFFER_SIZE, currently 4096. Any attempt to reduce the
 buffer size below DEFAULT_BUFFER_SIZE is ignored. Any buffered data is cleared
 when the buffer is resized.
+B<size> must be between 0 and B<INT_MAX> inclusive; otherwise these controls
+fail.
 
 BIO_set_buffer_read_data() clears the read buffer and fills it with B<num>
 bytes of B<buf>. If B<num> is larger than the current buffer size the buffer
 is expanded.
+B<num> must be between 0 and B<INT_MAX> inclusive; if B<num> is greater than
+zero, B<buf> must not be NULL.
+The C<BIO_buffer_peek> macro passes its length argument to L<BIO_ctrl(3)>
+as B<BIO_CTRL_PEEK>; that length must be nonnegative and the destination
+pointer must not be NULL when any bytes would be copied. A peek length of
+zero succeeds as a no-op (nothing is copied and the next BIO is not read).
 
 =head1 NOTES
 
@@ -93,7 +101,7 @@ L<BIO_ctrl(3)>.
 
 =head1 COPYRIGHT
 
-Copyright 2000-2020 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/test/bio_f_buffer_test.c
+++ b/test/bio_f_buffer_test.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <limits.h>
+#include <string.h>
+#include <openssl/bio.h>
+#include "testutil.h"
+
+/*
+ * Regression tests for buffer BIO ctrl paths that take a signed length
+ * (see https://github.com/openssl/openssl/issues/30725).
+ */
+static int test_buffer_invalid_lengths(void)
+{
+    BIO *mem = NULL, *bufbio = NULL;
+    char buf[16] = { 0 };
+    int testresult = 0;
+
+    if (!TEST_ptr(mem = BIO_new(BIO_s_mem())))
+        goto err;
+    if (!TEST_ptr(bufbio = BIO_new(BIO_f_buffer()))) {
+        BIO_free(mem);
+        goto err;
+    }
+    BIO_push(bufbio, mem);
+
+    if (!TEST_long_eq(BIO_ctrl(bufbio, BIO_C_SET_BUFF_READ_DATA, -1, buf), 0))
+        goto err;
+#if LONG_MAX > INT_MAX
+    if (!TEST_long_eq(BIO_ctrl(bufbio, BIO_C_SET_BUFF_READ_DATA,
+                          (long)INT_MAX + 1, buf),
+            0))
+        goto err;
+#endif
+    if (!TEST_long_eq(BIO_ctrl(bufbio, BIO_C_SET_BUFF_READ_DATA, 1, NULL), 0)
+        || !TEST_long_eq(BIO_buffer_peek(bufbio, buf, -1), 0)
+        || !TEST_long_eq(BIO_buffer_peek(bufbio, NULL, 1), 0)
+        || !TEST_long_eq(BIO_set_buffer_size(bufbio, -1), 0)
+        || !TEST_long_eq(BIO_int_ctrl(bufbio, BIO_C_SET_BUFF_SIZE, -1, 0), 0)
+        || !TEST_long_eq(BIO_int_ctrl(bufbio, BIO_C_SET_BUFF_SIZE, -1, 1), 0))
+        goto err;
+
+    testresult = 1;
+err:
+    BIO_free_all(bufbio);
+    return testresult;
+}
+
+static int test_buffer_failed_read_data_preserves_state(void)
+{
+    BIO *mem = NULL, *bufbio = NULL;
+    static const char seed[] = "abcde";
+    char out[16];
+    int testresult = 0;
+
+    if (!TEST_ptr(mem = BIO_new(BIO_s_mem())))
+        goto err;
+    if (!TEST_ptr(bufbio = BIO_new(BIO_f_buffer()))) {
+        BIO_free(mem);
+        goto err;
+    }
+    BIO_push(bufbio, mem);
+
+    if (!TEST_long_eq(BIO_set_buffer_read_data(bufbio, (void *)seed,
+                          (long)sizeof(seed) - 1),
+            1))
+        goto err;
+
+    if (!TEST_long_eq(BIO_ctrl(bufbio, BIO_C_SET_BUFF_READ_DATA, 1, NULL), 0))
+        goto err;
+
+    memset(out, 0, sizeof(out));
+    if (!TEST_long_eq(BIO_buffer_peek(bufbio, out, (int)sizeof(seed) - 1),
+            (long)sizeof(seed) - 1))
+        goto err;
+    if (!TEST_str_eq(out, seed))
+        goto err;
+
+    testresult = 1;
+err:
+    BIO_free_all(bufbio);
+    return testresult;
+}
+
+static int test_buffer_failed_peek_preserves_state(void)
+{
+    BIO *mem = NULL, *bufbio = NULL;
+    static const char seed[] = "xy";
+    char out[16];
+    int testresult = 0;
+
+    if (!TEST_ptr(mem = BIO_new(BIO_s_mem())))
+        goto err;
+    if (!TEST_ptr(bufbio = BIO_new(BIO_f_buffer()))) {
+        BIO_free(mem);
+        goto err;
+    }
+    BIO_push(bufbio, mem);
+
+    if (!TEST_long_eq(BIO_set_buffer_read_data(bufbio, (void *)seed, 2), 1))
+        goto err;
+
+    if (!TEST_long_eq(BIO_buffer_peek(bufbio, NULL, 1), 0))
+        goto err;
+    if (!TEST_long_eq(BIO_buffer_peek(bufbio, out, -1), 0))
+        goto err;
+    if (!TEST_long_eq(BIO_buffer_peek(bufbio, NULL, 0), 0))
+        goto err;
+
+    memset(out, 0, sizeof(out));
+    if (!TEST_long_eq(BIO_buffer_peek(bufbio, out, 2), 2))
+        goto err;
+    out[2] = '\0';
+    if (!TEST_str_eq(out, seed))
+        goto err;
+
+    testresult = 1;
+err:
+    BIO_free_all(bufbio);
+    return testresult;
+}
+
+int setup_tests(void)
+{
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
+    ADD_TEST(test_buffer_invalid_lengths);
+    ADD_TEST(test_buffer_failed_read_data_preserves_state);
+    ADD_TEST(test_buffer_failed_peek_preserves_state);
+    return 1;
+}

--- a/test/build.info
+++ b/test/build.info
@@ -55,7 +55,7 @@ IF[{- !$disabled{tests} -}]
           ssl_test_ctx_test ssl_test x509aux cipherlist_test asynciotest \
           bio_callback_test bio_memleak_test bio_core_test bio_dgram_test param_build_test \
           sslapitest ssl_handshake_rtt_test dtlstest sslcorrupttest \
-          bio_base64_test bio_enc_test pkey_meth_kdf_test evp_kdf_test uitest \
+          bio_base64_test bio_enc_test bio_f_buffer_test pkey_meth_kdf_test evp_kdf_test uitest \
           cipherbytes_test threadstest_fips threadpool_test \
           asn1_encode_test asn1_decode_test asn1_string_table_test asn1_stable_parse_test \
           x509_time_test x509_dup_cert_test x509_check_cert_pkey_test \
@@ -566,6 +566,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[bio_eof_test]=bio_eof_test.c
   INCLUDE[bio_eof_test]=../include ../apps/include
   DEPEND[bio_eof_test]=../libcrypto libtestutil.a
+
+  SOURCE[bio_f_buffer_test]=bio_f_buffer_test.c
+  INCLUDE[bio_f_buffer_test]=../include ../apps/include
+  DEPEND[bio_f_buffer_test]=../libcrypto libtestutil.a
 
   IF[{- !$disabled{sock}
         && $config{target} !~ /djgpp/i

--- a/test/build.info
+++ b/test/build.info
@@ -55,7 +55,7 @@ IF[{- !$disabled{tests} -}]
           ssl_test_ctx_test ssl_test x509aux cipherlist_test asynciotest \
           bio_callback_test bio_memleak_test bio_core_test bio_dgram_test param_build_test \
           sslapitest ssl_handshake_rtt_test dtlstest sslcorrupttest \
-          bio_base64_test bio_enc_test pkey_meth_kdf_test evp_kdf_test uitest \
+          bio_base64_test bio_enc_test bio_f_buffer_test pkey_meth_kdf_test evp_kdf_test uitest \
           cipherbytes_test threadstest_fips threadpool_test \
           asn1_encode_test asn1_decode_test asn1_string_table_test asn1_stable_parse_test \
           x509_time_test x509_dup_cert_test x509_check_cert_pkey_test \
@@ -594,6 +594,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[bio_eof_test]=bio_eof_test.c
   INCLUDE[bio_eof_test]=../include ../apps/include
   DEPEND[bio_eof_test]=../libcrypto libtestutil.a
+
+  SOURCE[bio_f_buffer_test]=bio_f_buffer_test.c
+  INCLUDE[bio_f_buffer_test]=../include ../apps/include
+  DEPEND[bio_f_buffer_test]=../libcrypto libtestutil.a
 
   IF[{- !$disabled{sock}
         && $config{target} !~ /djgpp/i

--- a/test/recipes/04-test_bio_f_buffer.t
+++ b/test/recipes/04-test_bio_f_buffer.t
@@ -1,0 +1,12 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_bio_f_buffer", "bio_f_buffer_test");


### PR DESCRIPTION
## Description

Buffer BIO control operations (`BIO_C_SET_BUFF_READ_DATA`, `BIO_C_SET_BUFF_SIZE`, and `BIO_CTRL_PEEK`) accepted signed `long` length arguments without rejecting negative values or other invalid combinations. In those cases the implementation could call `memcpy` with a value that converted to a very large `size_t`, or otherwise corrupt buffer state (see [issue #30725](https://github.com/openssl/openssl/issues/30725)).

This change validates lengths and pointers so invalid API use fails safely instead of invoking undefined behavior. It also aligns `OPENSSL_malloc` sizes with the intended read/write buffer dimensions when resizing.

Fixes https://github.com/openssl/openssl/issues/30725

## Implementation Details

- Harden `buffer_ctrl()` in `crypto/bio/bf_buff.c`:
  - `BIO_C_SET_BUFF_READ_DATA`: require `num` in `0`..`INT_MAX`; require non-`NULL` `ptr` when `num > 0`; copy with `(size_t)num`.
  - `BIO_C_SET_BUFF_SIZE`: reject `num` outside `0`..`INT_MAX` for each code path; allocate with `(size_t)ibs` / `(size_t)obs` instead of `(size_t)num` where appropriate.
  - `BIO_CTRL_PEEK`: reject negative `num` or `NULL` `ptr`; `memcpy` with `(size_t)num`.
- Add `#include <limits.h>` for `INT_MAX`.
- New regression test `test/bio_f_buffer_test.c` and recipe `test/recipes/04-test_bio_f_buffer.t`; register in `test/build.info`.
- Document behavior in `doc/man3/BIO_f_buffer.pod` (including `BIO_buffer_peek` / `BIO_CTRL_PEEK` expectations; wording satisfies `doc-nits`).
- Add an entry to `CHANGES.md` under the 4.0 → 4.1 section.

## Checklist

- [x] Code follows project style and builds with strict warnings (`./config --strict-warnings` and `enable-unit-test` where tests are needed).
- [x] Regression tests added (`bio_f_buffer_test`).
- [x] Documentation updated (`BIO_f_buffer.pod`) and `CHANGES.md` entry added.
- [x] Change is self-contained to the buffer BIO and related tests/docs.
