### PR TITLE
ISSUE-24410: Fix KBKDF + KMAC NULL deref with zero-length Ki

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,13 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * Fixed a NULL pointer dereference when using KBKDF with KMAC and a
+   zero-length key derivation key `Ki`. KMAC keys may be any length per
+   SP 800-185, including zero; the KMAC implementation no longer rejects
+   such keys solely based on length.
+
+   *John Claus*
+
  * Improved DTLS handshake robustness under UDP reordering by buffering and
    replaying early ChangeCipherSpec (CCS) records at the expected state.
 

--- a/doc/man7/EVP_MAC-KMAC.pod
+++ b/doc/man7/EVP_MAC-KMAC.pod
@@ -41,7 +41,8 @@ EVP_MAC_CTX_get_params(), or with EVP_MAC_CTX_get_block_size().
 
 Sets the MAC key.
 Setting this parameter is identical to passing a I<key> to L<EVP_MAC_init(3)>.
-The length of the key (in bytes) must be in the range 4...512.
+The length of the key (in bytes) must be at most 512.
+SP 800-185 allows any key length, including zero.
 
 =item "custom" (B<OSSL_MAC_PARAM_CUSTOM>) <octet string>
 
@@ -159,7 +160,7 @@ L<SP 800-185 8.4.2|https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP
 
 =head1 COPYRIGHT
 
-Copyright 2018-2024 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2018-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/providers/implementations/kdfs/kbkdf.c
+++ b/providers/implementations/kdfs/kbkdf.c
@@ -462,11 +462,24 @@ static int kbkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     if (p.sep != NULL && !OSSL_PARAM_get_int(p.sep, &ctx->use_separator))
         return 0;
 
-    /* Set up digest context, if we can. */
-    if (ctx->ctx_init != NULL && ctx->ki_len != 0) {
-        if ((ctx->is_kmac && !kmac_init(ctx->ctx_init, ctx->label, ctx->label_len))
-            || !EVP_MAC_init(ctx->ctx_init, ctx->ki, ctx->ki_len, NULL))
-            return 0;
+    /*
+     * Initialize the MAC PRF. KMAC-based KBKDF uses a shortcut derive path
+     * that calls EVP_MAC_update/final on ctx_init, so the MAC must be inited
+     * even when Ki is empty (SP 800-185 allows len(K) == 0).
+     */
+    if (ctx->ctx_init != NULL) {
+        if (ctx->is_kmac) {
+            const unsigned char *ki = ctx->ki;
+
+            if (ctx->ki_len == 0 && ki == NULL)
+                ki = (const unsigned char *)"";
+            if (!kmac_init(ctx->ctx_init, ctx->label, ctx->label_len)
+                || !EVP_MAC_init(ctx->ctx_init, ki, ctx->ki_len, NULL))
+                return 0;
+        } else if (ctx->ki_len != 0) {
+            if (!EVP_MAC_init(ctx->ctx_init, ctx->ki, ctx->ki_len, NULL))
+                return 0;
+        }
     }
     return 1;
 }

--- a/providers/implementations/kdfs/kbkdf.c
+++ b/providers/implementations/kdfs/kbkdf.c
@@ -78,6 +78,8 @@ typedef struct {
     int use_l;
     int is_kmac;
     int use_separator;
+    /* KI was explicitly supplied, possibly with length zero. */
+    int ki_set;
     OSSL_FIPS_IND_DECLARE
 } KBKDF;
 
@@ -114,6 +116,7 @@ static void init(KBKDF *ctx)
     ctx->use_l = 1;
     ctx->use_separator = 1;
     ctx->is_kmac = 0;
+    ctx->ki_set = 0;
 }
 
 static void *kbkdf_new(void *provctx)
@@ -187,6 +190,7 @@ static void *kbkdf_dup(void *vctx)
         dest->use_l = src->use_l;
         dest->use_separator = src->use_separator;
         dest->is_kmac = src->is_kmac;
+        dest->ki_set = src->ki_set;
         OSSL_FIPS_IND_COPY(dest, src)
     }
     return dest;
@@ -327,6 +331,12 @@ static int kbkdf_derive(void *vctx, unsigned char *key, size_t keylen,
         return 0;
     }
 
+    /* KI may be empty, but only when it was explicitly supplied. */
+    if (ctx->is_kmac && !ctx->ki_set) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_NO_KEY_SET);
+        return 0;
+    }
+
     /* Fail if the output length is zero */
     if (keylen == 0) {
         ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
@@ -426,6 +436,8 @@ static int kbkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
             &ctx->ki_len)
         == 0)
         return 0;
+    if (p.key != NULL)
+        ctx->ki_set = 1;
 #ifdef FIPS_MODULE
     if (p.key != NULL && !fips_kbkdf_key_check_passed(ctx))
         return 0;
@@ -462,11 +474,31 @@ static int kbkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     if (p.sep != NULL && !OSSL_PARAM_get_int(p.sep, &ctx->use_separator))
         return 0;
 
-    /* Set up digest context, if we can. */
-    if (ctx->ctx_init != NULL && ctx->ki_len != 0) {
-        if ((ctx->is_kmac && !kmac_init(ctx->ctx_init, ctx->label, ctx->label_len))
-            || !EVP_MAC_init(ctx->ctx_init, ctx->ki, ctx->ki_len, NULL))
-            return 0;
+    /*
+     * Initialize the MAC PRF. KMAC-based KBKDF uses a shortcut derive path
+     * that calls EVP_MAC_update/final on ctx_init, so once Ki has been
+     * supplied the MAC must be inited even when Ki is empty (SP 800-185
+     * allows len(K) == 0).  An empty Ki must not reach EVP_MAC_init() as
+     * NULL: that means "reuse the previous key", and KMAC's encode_string
+     * would encode a NULL key as no bytes at all rather than as an empty
+     * string, so substitute "".  A Ki that was never supplied leaves the
+     * MAC uninitialized and derive will fail.
+     */
+    if (ctx->ctx_init != NULL) {
+        if (ctx->is_kmac) {
+            if (ctx->ki_set) {
+                const unsigned char *ki = ctx->ki;
+
+                if (ki == NULL)
+                    ki = (const unsigned char *)"";
+                if (!kmac_init(ctx->ctx_init, ctx->label, ctx->label_len)
+                    || !EVP_MAC_init(ctx->ctx_init, ki, ctx->ki_len, NULL))
+                    return 0;
+            }
+        } else if (ctx->ki_len != 0) {
+            if (!EVP_MAC_init(ctx->ctx_init, ctx->ki, ctx->ki_len, NULL))
+                return 0;
+        }
     }
     return 1;
 }

--- a/providers/implementations/macs/kmac_prov.c
+++ b/providers/implementations/macs/kmac_prov.c
@@ -101,7 +101,6 @@ static OSSL_FUNC_mac_final_fn kmac_final;
 
 /* Maximum key size in bytes = 512 (4096 bits) */
 #define KMAC_MAX_KEY 512
-#define KMAC_MIN_KEY 4
 
 /*
  * Maximum Encoded Key size will be padded to a multiple of the blocksize
@@ -262,7 +261,19 @@ static int kmac_setkey(struct kmac_data_st *kctx, const unsigned char *key,
     const EVP_MD *digest = ossl_prov_digest_md(&kctx->digest);
     int w = EVP_MD_get_block_size(digest);
 
-    if (keylen < KMAC_MIN_KEY || keylen > KMAC_MAX_KEY) {
+    /*
+     * SP 800-185 allows any key length including zero; ossl_sp800_185_encode_string
+     * requires a non-NULL pointer when in_len is zero.
+     */
+    if (key == NULL) {
+        if (keylen == 0) {
+            key = (const unsigned char *)"";
+        } else {
+            ERR_raise(ERR_LIB_PROV, PROV_R_NULL_LENGTH_POINTER);
+            return 0;
+        }
+    }
+    if (keylen > KMAC_MAX_KEY) {
         ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
         return 0;
     }

--- a/providers/implementations/macs/kmac_prov.c
+++ b/providers/implementations/macs/kmac_prov.c
@@ -101,7 +101,6 @@ static OSSL_FUNC_mac_final_fn kmac_final;
 
 /* Maximum key size in bytes = 512 (4096 bits) */
 #define KMAC_MAX_KEY 512
-#define KMAC_MIN_KEY 4
 
 /*
  * Maximum Encoded Key size will be padded to a multiple of the blocksize
@@ -262,7 +261,20 @@ static int kmac_setkey(struct kmac_data_st *kctx, const unsigned char *key,
     const EVP_MD *digest = ossl_prov_digest_md(&kctx->digest);
     int w = EVP_MD_get_block_size(digest);
 
-    if (keylen < KMAC_MIN_KEY || keylen > KMAC_MAX_KEY) {
+    /*
+     * SP 800-185 allows any key length including zero, but
+     * ossl_sp800_185_encode_string encodes a NULL pointer as no output at
+     * all rather than as the empty string, so substitute "".
+     */
+    if (key == NULL) {
+        if (keylen == 0) {
+            key = (const unsigned char *)"";
+        } else {
+            ERR_raise(ERR_LIB_PROV, PROV_R_NULL_LENGTH_POINTER);
+            return 0;
+        }
+    }
+    if (keylen > KMAC_MAX_KEY) {
         ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
         return 0;
     }

--- a/test/evp_kdf_test.c
+++ b/test/evp_kdf_test.c
@@ -2219,6 +2219,40 @@ static int test_kdf_kbkdf_kmac(void)
     EVP_KDF_CTX_free(kctx);
     return ret;
 }
+
+/*
+ * Regression for https://github.com/openssl/openssl/issues/24410:
+ * KBKDF with KMAC and a zero-length Ki must not crash and must be stable.
+ */
+static int test_kdf_kbkdf_kmac_empty_ki(void)
+{
+    int ret = 0;
+    EVP_KDF_CTX *kctx = NULL;
+    OSSL_PARAM params[5], *p = params;
+    static const char empty_ki[] = "";
+    static char *mac = "KMAC256";
+    static char *digest = "SHA256";
+    unsigned char out1[32], out2[32];
+
+    *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, digest, 0);
+    *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_MAC, mac, 0);
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY,
+        (unsigned char *)empty_ki, 0);
+    *p = OSSL_PARAM_construct_end();
+
+    if (!TEST_ptr(kctx = get_kdfbyname("KBKDF")))
+        return 0;
+    if (!TEST_true(EVP_KDF_CTX_set_params(kctx, params)))
+        goto end;
+    if (!TEST_int_gt(EVP_KDF_derive(kctx, out1, sizeof(out1), NULL), 0))
+        goto end;
+    if (!TEST_int_gt(EVP_KDF_derive(kctx, out2, sizeof(out2), NULL), 0))
+        goto end;
+    ret = TEST_mem_eq(out1, sizeof(out1), out2, sizeof(out2));
+end:
+    EVP_KDF_CTX_free(kctx);
+    return ret;
+}
 #endif /* OPENSSL_NO_KBKDF */
 
 #ifndef OPENSSL_NO_SSKDF
@@ -2690,6 +2724,7 @@ int setup_tests(void)
 #endif
     if (fips_provider_version_ge(NULL, 3, 1, 0))
         ADD_TEST(test_kdf_kbkdf_kmac);
+    ADD_TEST(test_kdf_kbkdf_kmac_empty_ki);
 #endif /* OPENSSL_NO_KBKDF */
     ADD_TEST(test_kdf_get_kdf);
     ADD_TEST(test_kdf_tls1_prf);

--- a/test/evp_kdf_test.c
+++ b/test/evp_kdf_test.c
@@ -1893,6 +1893,65 @@ static int test_kdf_kbkdf_kmac(void)
     EVP_KDF_CTX_free(kctx);
     return ret;
 }
+
+/*
+ * Regression for https://github.com/openssl/openssl/issues/24410:
+ * KBKDF with KMAC and a zero-length Ki must not crash and must be stable.
+ */
+static int test_kdf_kbkdf_kmac_empty_ki(void)
+{
+    int ret = 0;
+    EVP_KDF_CTX *kctx = NULL;
+    OSSL_PARAM params[5], *p = params;
+    static const char empty_ki[] = "";
+    static char *mac = "KMAC256";
+    static char *digest = "SHA256";
+    unsigned char out1[32], out2[32];
+
+    *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, digest, 0);
+    *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_MAC, mac, 0);
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY,
+        (unsigned char *)empty_ki, 0);
+    *p = OSSL_PARAM_construct_end();
+
+    if (!TEST_ptr(kctx = get_kdfbyname("KBKDF")))
+        return 0;
+    if (!TEST_true(EVP_KDF_CTX_set_params(kctx, params)))
+        goto end;
+    if (!TEST_int_gt(EVP_KDF_derive(kctx, out1, sizeof(out1), NULL), 0))
+        goto end;
+    if (!TEST_int_gt(EVP_KDF_derive(kctx, out2, sizeof(out2), NULL), 0))
+        goto end;
+    ret = TEST_mem_eq(out1, sizeof(out1), out2, sizeof(out2));
+end:
+    EVP_KDF_CTX_free(kctx);
+    return ret;
+}
+
+/*
+ * A KI of length zero is only valid when it was explicitly supplied;
+ * deriving without ever setting a KI must keep failing.
+ */
+static int test_kdf_kbkdf_kmac_missing_ki(void)
+{
+    int ret;
+    EVP_KDF_CTX *kctx;
+    OSSL_PARAM params[2], *p = params;
+    static char *mac = "KMAC256";
+    unsigned char result[32] = { 0 };
+
+    *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_MAC, mac, 0);
+    *p = OSSL_PARAM_construct_end();
+
+    /* Negative test case - derive should fail */
+    kctx = get_kdfbyname("KBKDF");
+    ret = TEST_ptr(kctx)
+        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_int_eq(EVP_KDF_derive(kctx, result, sizeof(result), NULL), 0);
+
+    EVP_KDF_CTX_free(kctx);
+    return ret;
+}
 #endif /* OPENSSL_NO_KBKDF */
 
 #ifndef OPENSSL_NO_SSKDF
@@ -2431,6 +2490,11 @@ int setup_tests(void)
 #endif
     if (fips_provider_version_ge(NULL, 3, 1, 0))
         ADD_TEST(test_kdf_kbkdf_kmac);
+    /* The fix for KBKDF+KMAC with a zero-length KI first appears in 4.1.0 */
+    if (fips_provider_version_ge(NULL, 4, 1, 0)) {
+        ADD_TEST(test_kdf_kbkdf_kmac_empty_ki);
+        ADD_TEST(test_kdf_kbkdf_kmac_missing_ki);
+    }
 #endif /* OPENSSL_NO_KBKDF */
     ADD_TEST(test_kdf_get_kdf);
     ADD_TEST(test_kdf_ctx_get_kdf);


### PR DESCRIPTION
## Description

**KBKDF** with **KMAC** and a **zero-length** key derivation key `Ki` could **crash** (invalid / NULL digest update path) instead of completing derive or failing cleanly ([openssl/openssl#24410](https://github.com/openssl/openssl/issues/24410)).

**SP 800-185** defines the KMAC key **K** as a bit string of **any length, including zero**; the previous behavior skipped MAC initialization for empty `Ki` while still using the KMAC shortcut derive path, and the KMAC provider rejected keys shorter than four bytes.

This PR initializes the KMAC PRF correctly for empty `Ki` and allows zero-length (and other short) keys per SP 800-185 within the existing maximum key size.

Fixes #24410

## Implementation Details

- **`providers/implementations/macs/kmac_prov.c`**: Remove the artificial four-byte minimum; allow key lengths **0…512**; normalize **`NULL` + length 0** for `ossl_sp800_185_encode_string`; raise an error for **`NULL` + non-zero** length.

- **`providers/implementations/kdfs/kbkdf.c`**: For **`ctx->is_kmac`**, always run **`kmac_init`** and **`EVP_MAC_init`** when `ctx_init` is set, including when **`Ki` is empty** (use `""` when `ctx->ki` is `NULL` and length is 0). Non-KMAC behavior unchanged: **`EVP_MAC_init`** only when **`ki_len != 0`**.

- **`doc/man7/EVP_MAC-KMAC.pod`**: Document key length up to 512 bytes and that SP 800-185 allows zero length; bump copyright end year in that file.

- **`test/evp_kdf_test.c`**: Add **`test_kdf_kbkdf_kmac_empty_ki`**: KBKDF + **KMAC256** + **SHA256** + empty `Ki`; derive twice and require identical output. Registered whenever KBKDF is enabled.

- **`CHANGES.md`**: User-visible entry under the current development section.

## Checklist

- [x] Self-contained change (KMAC + KBKDF + doc + test + `CHANGES.md`).
- [x] Regression test added for the reported scenario.
- [x] Man page updated for changed key-length behavior.
- [x] `CHANGES.md` updated for user-visible fix.
- [x] Commit message includes **`Fixes #24410`** (CONTRIBUTING.md form).
- [ ] **`./Configure --strict-warnings`** / clean build and **`make test`** (or CI green) — run locally or rely on GitHub Actions.
- [ ] **`make doc-nits`** if maintainers request a doc pass beyond the `.pod` edit.
- [ ] **CLA** on file with OpenSSL; **`Reviewed-by:`** added by reviewers after approval.
