### PR TITLE
[4.0, master] INSTALL.md, NOTES-NONSTOP.md: update/remove `no-atexit` mentions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -643,9 +643,9 @@ Do not build support for async operations.
 
 Do not use `atexit()` in libcrypto builds.
 
-`atexit()` has varied semantics between platforms and can cause SIGSEGV in some
-circumstances. This option disables the atexit registration of OPENSSL_cleanup.
-By default, NonStop configurations use `no-atexit`.
+Before version 4.0, OpenSSL used to set `atexit()` handler for cleaning up
+global data, and this option allowed to disable that functionality.  `atexit()`
+handler setup was removed in OpenSSL 4.0, so this option does nothing now.
 
 ### no-autoalginit
 

--- a/NOTES-NONSTOP.md
+++ b/NOTES-NONSTOP.md
@@ -55,26 +55,6 @@ option to `./Configure`.
 TNS/E has moved to a limited support state, so fixes for this platform will not
 be guaranteed in future.
 
-Linking and Loading Considerations
-----------------------------------
-
-Because of how the NonStop Common Runtime Environment (CRE) works, there are
-restrictions on how programs can link and load with OpenSSL libraries.
-On current NonStop platforms, programs cannot both statically link OpenSSL
-libraries and dynamically load OpenSSL shared libraries concurrently. If this
-is done, there is a high probability of encountering a SIGSEGV condition
-relating to `atexit()` processing when a shared library is unloaded and when
-the program terminates. This limitation applies to all OpenSSL shared library
-components.
-
-A control has been added as of 3.3.x to disable calls to `atexit()` within the
-`libcrypto` builds (specifically in `crypto/init.c`). This switch can be
-controlled using `disable-atexit` or `enable-atexit`, and is disabled by default
-for NonStop builds. If you need to have `atexit()` functionality, set
-`enabled-atexit` when configuring OpenSSL to enable the `atexit()` call to
-register `OPENSSL_cleanup()` automatically. Preferably, you can explicitly call
-`OPENSSL_cleanup()` from your application.
-
 Secure Memory
 -------------
 


### PR DESCRIPTION
This is a doc-only alternative to [1] that doesn't touch `Configuration` and also updates `NOTES-NONSTOP.md`.

[1] https://github.com/openssl/openssl/pull/30767