### PR TITLE
Various Coveralls config updates

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -47,7 +47,7 @@ jobs:
           MATRIX=$(cat << EOF
           [{
               "branch": "openssl-4.0",
-              "extra_config": "enable-fips enable-tfo enable-lms"
+              "extra_config": "enable-fips enable-tfo enable-lms enable-crypto-mdebug enable-allocfail-tests"
             },{
               "branch": "openssl-3.6",
               "extra_config": "no-afalgeng enable-fips enable-tfo enable-lms"

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -58,15 +58,6 @@ jobs:
               "branch": "openssl-3.4",
               "extra_config": "no-afalgeng enable-fips enable-tfo"
             }, {
-              "branch": "openssl-3.3",
-              "extra_config": "no-afalgeng enable-fips enable-tfo"
-            }, {
-              "branch": "openssl-3.2",
-              "extra_config": "no-afalgeng enable-fips enable-tfo"
-            }, {
-              "branch": "openssl-3.1",
-              "extra_config": "no-afalgeng enable-fips"
-            }, {
               "branch": "openssl-3.0",
               "extra_config": "no-afalgeng enable-fips"
             }, {

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -46,6 +46,9 @@ jobs:
           else
           MATRIX=$(cat << EOF
           [{
+              "branch": "master",
+              "extra_config": "enable-fips enable-tfo enable-lms enable-crypto-mdebug enable-allocfail-tests"
+            }, {
               "branch": "openssl-4.0",
               "extra_config": "enable-fips enable-tfo enable-lms enable-crypto-mdebug enable-allocfail-tests"
             },{
@@ -60,9 +63,6 @@ jobs:
             }, {
               "branch": "openssl-3.0",
               "extra_config": "no-afalgeng enable-fips"
-            }, {
-              "branch": "master",
-              "extra_config": "enable-fips enable-tfo enable-lms enable-crypto-mdebug enable-allocfail-tests"
           }]
           EOF
           )

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -47,10 +47,10 @@ jobs:
           MATRIX=$(cat << EOF
           [{
               "branch": "openssl-4.0",
-              "extra_config": "enable-fips enable-tfo"
+              "extra_config": "enable-fips enable-tfo enable-lms"
             },{
               "branch": "openssl-3.6",
-              "extra_config": "no-afalgeng enable-fips enable-tfo"
+              "extra_config": "no-afalgeng enable-fips enable-tfo enable-lms"
             },{
               "branch": "openssl-3.5",
               "extra_config": "no-afalgeng enable-fips enable-tfo"

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -47,7 +47,7 @@ jobs:
           MATRIX=$(cat << EOF
           [{
               "branch": "openssl-4.0",
-              "extra_config": "no-afalgeng enable-fips enable-tfo"
+              "extra_config": "enable-fips enable-tfo"
             },{
               "branch": "openssl-3.6",
               "extra_config": "no-afalgeng enable-fips enable-tfo"


### PR DESCRIPTION
Miscellaneous update to the Coveralls CI job config matrix:
 * drop `openssl-3.1`, `openssl-3.2`, `openssl-3.3` branches from the test matrix;
 * remove `no-afalgeng` option from `openssl-4.0` branch;
 * add `enable-lms` to `openssl-3.6`/`openssl-4.0` branches and `enable-crypto-mdebug enable-allocfail-tests` to `openssl-4.0`;
 * move the `master` branch to the top of the list.

The latter three changes bring the latest branches' configs more in line with the `master` one and make copying over `master` config options to the newly created branch more natural.