### PR TITLE
include C++ extern in ech.h

### DIFF
--- a/include/openssl/ech.h
+++ b/include/openssl/ech.h
@@ -15,6 +15,10 @@
 #define OPENSSL_ECH_H
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <openssl/ssl.h>
 #include <openssl/hpke.h>
 
@@ -121,6 +125,10 @@ int SSL_CTX_ech_set1_outer_alpn_protos(SSL_CTX *s, const unsigned char *protos,
     const size_t protos_len);
 void SSL_CTX_ech_set_callback(SSL_CTX *ctx, SSL_ech_cb_func f);
 int SSL_set1_ech_config_list(SSL *ssl, const uint8_t *ecl, size_t ecl_len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 #endif


### PR DESCRIPTION
This PR changes `include/openssl/ech.h` to address #30784  by adding `extern "C" {` to the ECH header file.

I'm not sure if this is too late for the 4.0.0 release, but here it is, if it's needed, correct and timely.
