### PR TITLE
include/openssl/x509_acert.h.in: add extern "C" linkage specification for C++

### DIFF
--- a/include/openssl/x509_acert.h.in
+++ b/include/openssl/x509_acert.h.in
@@ -23,6 +23,10 @@ use OpenSSL::stackhash qw(generate_stack_macros);
 #include <openssl/x509.h>
 #include <openssl/pem.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct X509_acert_st X509_ACERT;
 typedef struct X509_acert_info_st X509_ACERT_INFO;
 typedef struct ossl_object_digest_info_st OSSL_OBJECT_DIGEST_INFO;
@@ -205,5 +209,9 @@ DECLARE_ASN1_FUNCTIONS(OSSL_AUTHORITY_ATTRIBUTE_ID_SYNTAX)
     generate_stack_macros("OSSL_ISSUER_SERIAL");
 -}
 /* clang-format on */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
[1] prompted some manual checking of header files in `include/openssl` for presence of `extern "C"` linkage specification;  apparently, it seems that the only other file that misses it and also contains function declarations is `x509_acert.h.in`;  rescind this omission.

[1] https://github.com/openssl/openssl/issues/30784

Fixes: dcee34c8f921 "Add RFC 5755 attribute certificate support"