### PR TITLE
Fix segfault in SSL_use_cert_and_key

### DIFF
--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -1091,7 +1091,7 @@ out:
 int SSL_use_cert_and_key(SSL *ssl, X509 *x509, EVP_PKEY *privatekey,
     STACK_OF(X509) *chain, int override)
 {
-    return ssl_set_cert_and_key(ssl, NULL, x509, privatekey, chain, override);
+    return ssl_set_cert_and_key(ssl, SSL_get_SSL_CTX(ssl), x509, privatekey, chain, override);
 }
 
 int SSL_CTX_use_cert_and_key(SSL_CTX *ctx, X509 *x509, EVP_PKEY *privatekey,


### PR DESCRIPTION
A segfault was reported in SSL_use_cert_and_key:

```
Program received signal SIGSEGV, Segmentation fault. 0x00007ffff76b97f2 in ssl_cert_lookup_by_pkey (pk=0x424d00,
    pidx=0x7fffffffd258, ctx=0x0) at ssl/ssl_cert.c:1364
1364	    for (i = 0; i < ctx->sigalg_list_len; i++) {
(gdb) bt
 #0  0x00007ffff76b97f2 in ssl_cert_lookup_by_pkey (pk=0x424d00,
    pidx=0x7fffffffd258, ctx=0x0) at ssl/ssl_cert.c:1364
 #1  0x00007ffff76d97fa in ssl_set_cert_and_key (ssl=0x4aadf0, ctx=0x0,
    x509=0x482e90, privatekey=0x424d00, chain=0x0, override=0)
    at ssl/ssl_rsa.c:1042
 #2  0x00007ffff76d9b0d in SSL_use_cert_and_key (ssl=0x4aadf0, x509=0x482e90,
    privatekey=0x424d00, chain=0x0, override=0) at ssl/ssl_rsa.c:1092
 #3  0x0000000000400e81 in main () at test.c:83
```

It was introduced via commit 535d51511832d8566be198449b6abd3e2d614255 which adds a call to ssl_cert_lookup_by_pkey to the call path.

This function iterates over the ctx->ssl_cert_info array, implying an assumption that ctx is never NULL.

This condition can arise however, in the event that the passed SSL object has no associated connection, which falls back to the passed in ctx for iteration use.  Because SSL_use_cert_and_key explicitly passes NULL as the ctx value, we get the above crash.

Fix seems pretty straightforward, just pass the return value of SSL_get_SSL_CTX as the ctx parameter instead of NULL.

Fixes #30786

