### PR TITLE
Sanity check the AES GCM IV length on s390x in legacy codepath

### DIFF
--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -1466,7 +1466,7 @@ static int s390x_aes_gcm_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
         return 1;
 
     case EVP_CTRL_AEAD_SET_IVLEN:
-        if (arg <= 0)
+        if (arg <= 0 || arg > EVP_MAX_IV_LENGTH)
             return 0;
 
         if (arg != 12) {


### PR DESCRIPTION
We check that the AES GCM IV length is within sane bounds in the s390x legacy codepath to avoid a potential overflow.

This was reported to openssl-security by Stanislav Fort from AISLE research. It was analysed and determined to be a "bug or hardening only".
