### PR TITLE
apps/enc.c: typo fix in -k option description

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -114,7 +114,7 @@ const OPTIONS enc_options[] = {
     { "S", OPT_UPPER_S, 's', "Salt, in hex" },
     { "iv", OPT_IV, 's', "IV in hex" },
     { "md", OPT_MD, 's', "Use specified digest to create a key from the passphrase" },
-    { "k", OPT_K, 's', "Passphrase (Deprecated" },
+    { "k", OPT_K, 's', "Passphrase (Deprecated)" },
     { "kfile", OPT_KFILE, '<', "Read passphrase from file (Deprecated)" },
     { "pass", OPT_PASS, 's', "Passphrase source" },
     { "iter", OPT_ITER, 'p',


### PR DESCRIPTION
Add missing closing parenthesis.

Fixes: de89ca9347c2 "apps/enc.c: Moved -pass, -k, -kfile to encryption options"