### PR TITLE
Check `dkm_len` when cleaning up in kdf_main

### DIFF
--- a/apps/kdf.c
+++ b/apps/kdf.c
@@ -205,6 +205,8 @@ err:
         ERR_print_errors(bio_err);
     if (dkm_len > 0)
         OPENSSL_clear_free(dkm_bytes, dkm_len);
+    else
+        OPENSSL_free(dkm_bytes);
     sk_OPENSSL_STRING_free(opts);
     EVP_KDF_free(kdf);
     EVP_KDF_CTX_free(ctx);

--- a/apps/kdf.c
+++ b/apps/kdf.c
@@ -203,7 +203,8 @@ int kdf_main(int argc, char **argv)
 err:
     if (ret != 0)
         ERR_print_errors(bio_err);
-    OPENSSL_clear_free(dkm_bytes, dkm_len);
+    if (dkm_len > 0)
+        OPENSSL_clear_free(dkm_bytes, dkm_len);
     sk_OPENSSL_STRING_free(opts);
     EVP_KDF_free(kdf);
     EVP_KDF_CTX_free(ctx);


### PR DESCRIPTION
Address [Coverity 1691580](https://scan5.scan.coverity.com/#/project-view/62507/10222?selectedIssue=1691580)

If `dkm_len` is a negative number, it will be interpreted as a very large positive value. 

We do have this check for a negative number, but the error path will still be incorrect.

https://github.com/openssl/openssl/blob/9ca063ad8455d581aead90727a6ac73069856b51/apps/kdf.c#L178-L181

Fixes https://github.com/openssl/project/issues/1930