### PR TITLE
aix: disable sendmmsg/recvmmsg

### DIFF
--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -68,8 +68,8 @@
 #undef NO_RECVMMSG
 #define NO_RECVMMSG
 #endif
-#if defined(_AIX) && !defined(_AIX72)
-/* AIX >= 7.2 provides sendmmsg() and recvmmsg(). */
+#if defined(_AIX)
+/* AIX header files don't properly expose sendmmsg/recvmmsg declarations */
 #undef NO_RECVMMSG
 #define NO_RECVMMSG
 #endif


### PR DESCRIPTION
AIX header files don't properly expose sendmmsg/recvmmsg function declarations. Disable these functions to avoid implicit declaration errors with clang 16+.

This issue was discovered when building Node.js with clang ref: https://github.com/nodejs/node/pull/62656

CLA: trivial
Fixes: https://github.com/openssl/openssl/issues/30806

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->