### PR TITLE
Some bugfixes for OSSL_FN

### DIFF
--- a/crypto/bn/bnw_mul.c
+++ b/crypto/bn/bnw_mul.c
@@ -350,6 +350,10 @@ void bn_mul_low_recursive(BN_ULONG *r, const BN_ULONG *a, const BN_ULONG *b,
 }
 #endif /* BN_RECURSION */
 
+/*
+ * This function doesn't zero out the rest of r in case of nr>na+nb;
+ * it's the calling function's responsibility to do so.
+ */
 void bn_mul_truncated(BN_ULONG *r, int nr, const BN_ULONG *a, int na,
     const BN_ULONG *b, int nb)
 {

--- a/crypto/fn/fn_addsub.c
+++ b/crypto/fn/fn_addsub.c
@@ -43,8 +43,8 @@ int OSSL_FN_add(OSSL_FN *r, const OSSL_FN *a, const OSSL_FN *b)
      * in |r|.
      *
      * For each stage, |stage_limbs| is used to hold the number
-     * of limbs being treated in that stage, and |borrow| is
-     * used to transport the borrow from one stage to the other.
+     * of limbs being treated in that stage, and |carry| is
+     * used to transport the carry from one stage to the other.
      */
     size_t stage_limbs;
     OSSL_FN_ULONG carry;
@@ -71,7 +71,7 @@ int OSSL_FN_add(OSSL_FN *r, const OSSL_FN *a, const OSSL_FN *b)
         *rp = t2;
         carry &= (t2 == 0);
     }
-    if (stage_limbs == rs)
+    if (stage_limbs == rs - min)
         return 1;
 
     /* Stage 3 */
@@ -139,9 +139,9 @@ int OSSL_FN_sub(OSSL_FN *r, const OSSL_FN *a, const OSSL_FN *b)
         OSSL_FN_ULONG t3 = (t1 - t2 - borrow) & OSSL_FN_MASK;
 
         *rp = t3;
-        borrow &= (t1 <= t2);
+        borrow = (t1 < t2 + borrow);
     }
-    if (stage_limbs == rs)
+    if (stage_limbs == rs - min)
         return 1;
 
     /* Stage 3 */

--- a/crypto/fn/fn_ctx.c
+++ b/crypto/fn/fn_ctx.c
@@ -139,7 +139,7 @@ int OSSL_FN_CTX_start(OSSL_FN_CTX *ctx)
 
 int OSSL_FN_CTX_end(OSSL_FN_CTX *ctx)
 {
-    if (!ossl_assert(ctx != NULL))
+    if (!ossl_assert(ctx != NULL) || !ossl_assert(ctx->last_frame != NULL))
         return 0;
 
     struct ossl_fn_ctx_frame_st *last_frame = ctx->last_frame;
@@ -170,7 +170,6 @@ OSSL_FN *OSSL_FN_CTX_get_limbs(OSSL_FN_CTX *ctx, size_t limbs)
     memset(fn, 0, totalsize);
     fn->dsize = (int)limbs;
     fn->is_securely_allocated = ctx->is_securely_allocated;
-    fn->is_dynamically_allocated = 1;
 
     return fn;
 }

--- a/crypto/fn/fn_lib.c
+++ b/crypto/fn/fn_lib.c
@@ -115,15 +115,12 @@ OSSL_FN *OSSL_FN_copy(OSSL_FN *a, const OSSL_FN *b)
 
     if (al < bl) {
         ERR_raise_data(ERR_LIB_OSSL_FN, OSSL_FN_R_RESULT_ARG_TOO_SMALL,
-            "Needs to be at least %d, but is only %d",
-            bl, al);
+            "Needs to be at least %zu bytes, but is only %zu bytes",
+            bl * sizeof(OSSL_FN_ULONG), al * sizeof(OSSL_FN_ULONG));
         return 0;
     }
 
-    size_t t = ossl_fn_totalsize(bl);
-
-    memcpy(a, b, t);
-    a->dsize = (int)al; /* Restore to its original size */
-    memset(&a->d[a->dsize], 0, sizeof(OSSL_FN_ULONG) * (a->dsize - b->dsize));
+    memcpy(a->d, b->d, bl * sizeof(OSSL_FN_ULONG));
+    memset(a->d + bl, 0, (al - bl) * sizeof(OSSL_FN_ULONG));
     return a;
 }

--- a/include/crypto/fn.h
+++ b/include/crypto/fn.h
@@ -134,7 +134,7 @@ void OSSL_FN_clear(OSSL_FN *f);
  *
  * @param[out]  a       The destination OSSL_FN
  * @param[in]   b       The source OSSL_FN
- * @returns     1 on success, 0 on error.
+ * @returns     The destination on success, NULL on error.
  */
 OSSL_FN *OSSL_FN_copy(OSSL_FN *a, const OSSL_FN *b);
 
@@ -152,6 +152,7 @@ OSSL_FN *OSSL_FN_copy(OSSL_FN *a, const OSSL_FN *b);
  **/
 OSSL_FN_CTX *OSSL_FN_CTX_new(OSSL_LIB_CTX *libctx, size_t max_n_frames,
     size_t max_n_numbers, size_t max_n_limbs);
+
 /**
  * Allocate a new OSSL_FN_CTX in secure memory, given a set of input numbers.
  * Other than allocating in secure memory, this function does exactly the same
@@ -159,6 +160,7 @@ OSSL_FN_CTX *OSSL_FN_CTX_new(OSSL_LIB_CTX *libctx, size_t max_n_frames,
  **/
 OSSL_FN_CTX *OSSL_FN_CTX_secure_new(OSSL_LIB_CTX *libctx, size_t max_n_frames,
     size_t max_n_numbers, size_t max_n_limbs);
+
 /**
  * Free an OSSL_FN_CTX.
  *

--- a/test/fn_api_test.c
+++ b/test/fn_api_test.c
@@ -149,6 +149,17 @@ static const OSSL_FN_ULONG ex_add_num3_num3[] = {
     OSSL_FN_ULONG64_C(0xfdb97530, 0xeca86420),
     OSSL_FN_ULONG_C(0x1),
 };
+static const OSSL_FN_ULONG ex_add_num0_num7[] = {
+    OSSL_FN_ULONG64_C(0x80000000, 0x00000001),
+    OSSL_FN_ULONG64_C(0x00000000, 0x00000000),
+#if OSSL_FN_BYTES == 4
+    OSSL_FN_ULONG_C(0xffffffff)
+#elif OSSL_FN_BYTES == 8
+    OSSL_FN_ULONG64_C(0xffffffff, 0xffffffff)
+#else
+#error "OpenSSL doesn't support large numbers on this platform"
+#endif
+};
 
 static int test_add_common(struct test_case_st test_case)
 {
@@ -227,6 +238,7 @@ static struct test_case_st test_add_cases[] = {
     ADD_CASE(14, num3, num1, ex_add_num1_num3), /* Commutativity check */
     ADD_CASE(15, num3, num2, ex_add_num2_num3), /* Commutativity check */
     ADD_CASE(16, num3, num3, ex_add_num3_num3),
+    ADD_CASE(17, num0, num7, ex_add_num0_num7),
 };
 
 static int test_add(int i)
@@ -266,6 +278,7 @@ static struct test_case_st test_add_truncated_cases[] = {
     ADD_TRUNCATED_CASE(14, num3, num1, ex_add_num1_num3), /* Commutativity check */
     ADD_TRUNCATED_CASE(15, num3, num2, ex_add_num2_num3), /* Commutativity check */
     ADD_TRUNCATED_CASE(16, num3, num3, ex_add_num3_num3),
+    ADD_TRUNCATED_CASE(17, num0, num7, ex_add_num0_num7),
 };
 
 static int test_add_truncated(int i)
@@ -326,6 +339,22 @@ static const OSSL_FN_ULONG ex_sub_num3_num2[] = {
 };
 static const OSSL_FN_ULONG ex_sub_num3_num3[] = {
     OSSL_FN_ULONG64_C(0x00000000, 0x00000000),
+};
+static const OSSL_FN_ULONG ex_sub_num0_num7[] = {
+    OSSL_FN_ULONG64_C(0x80000000, 0x00000001),
+    OSSL_FN_ULONG64_C(0x00000000, 0x00000000),
+    OSSL_FN_ULONG_C(0x1),
+};
+static const OSSL_FN_ULONG ex_sub_num7_num0[] = {
+    OSSL_FN_ULONG64_C(0x7fffffff, 0xffffffff),
+    OSSL_FN_ULONG64_C(0xffffffff, 0xffffffff),
+#if OSSL_FN_BYTES == 4
+    OSSL_FN_ULONG_C(0xfffffffe)
+#elif OSSL_FN_BYTES == 8
+    OSSL_FN_ULONG64_C(0xffffffff, 0xfffffffe)
+#else
+#error "OpenSSL doesn't support large numbers on this platform"
+#endif
 };
 
 static int test_sub_common(struct test_case_st test_case)
@@ -405,6 +434,8 @@ static struct test_case_st test_sub_cases[] = {
     SUB_CASE(14, num3, num1, ex_sub_num3_num1, EXTENDED_LIMB_ZERO),
     SUB_CASE(15, num3, num2, ex_sub_num3_num2, EXTENDED_LIMB_ZERO),
     SUB_CASE(16, num3, num3, ex_sub_num3_num3, EXTENDED_LIMB_ZERO),
+    SUB_CASE(17, num0, num7, ex_sub_num0_num7, EXTENDED_LIMB_MINUS_ONE),
+    SUB_CASE(18, num7, num0, ex_sub_num7_num0, EXTENDED_LIMB_ZERO),
 };
 
 static int test_sub(int i)
@@ -444,6 +475,8 @@ static struct test_case_st test_sub_truncated_cases[] = {
     SUB_TRUNCATED_CASE(14, num3, num1, ex_sub_num3_num1),
     SUB_TRUNCATED_CASE(15, num3, num2, ex_sub_num3_num2),
     SUB_TRUNCATED_CASE(16, num3, num3, ex_sub_num3_num3),
+    SUB_TRUNCATED_CASE(17, num0, num7, ex_sub_num0_num7),
+    SUB_TRUNCATED_CASE(18, num7, num0, ex_sub_num7_num0),
 };
 
 static int test_sub_truncated(int i)
@@ -979,10 +1012,10 @@ static int test_sqr_truncated(int i)
 
 int setup_tests(void)
 {
-    ADD_ALL_TESTS(test_add, 16);
-    ADD_ALL_TESTS(test_add_truncated, 16);
-    ADD_ALL_TESTS(test_sub, 16);
-    ADD_ALL_TESTS(test_sub_truncated, 16);
+    ADD_ALL_TESTS(test_add, 17);
+    ADD_ALL_TESTS(test_add_truncated, 17);
+    ADD_ALL_TESTS(test_sub, 18);
+    ADD_ALL_TESTS(test_sub_truncated, 18);
     ADD_ALL_TESTS(test_mul_feature_r_is_operand, 4);
     ADD_ALL_TESTS(test_mul, OSSL_NELEM(test_mul_cases));
     ADD_ALL_TESTS(test_mul_truncated, OSSL_NELEM(test_mul_truncate_cases));

--- a/test/fn_internal_test.c
+++ b/test/fn_internal_test.c
@@ -117,7 +117,7 @@ static int test_ctx(void)
         goto end;
     }
     if (!TEST_ptr(f = OSSL_FN_CTX_get_bits(ctx, 2048))
-        || !TEST_true(ossl_fn_is_dynamically_allocated(f))
+        || !TEST_false(ossl_fn_is_dynamically_allocated(f))
         || !TEST_false(ossl_fn_is_securely_allocated(f)))
         ret = 0;
     if (!TEST_true(OSSL_FN_CTX_end(ctx))) {
@@ -188,7 +188,7 @@ static int test_secure_ctx(void)
         goto end;
     }
     if (!TEST_ptr(f = OSSL_FN_CTX_get_bits(ctx, 2048))
-        || !TEST_true(ossl_fn_is_dynamically_allocated(f))
+        || !TEST_false(ossl_fn_is_dynamically_allocated(f))
         || !TEST_true(ossl_fn_is_securely_allocated(f)))
         ret = 0;
     if (!TEST_true(OSSL_FN_CTX_end(ctx))) {


### PR DESCRIPTION
- Fixed the stage 2 exit criteria in OSSL_FN_add() and OSSL_FN_sub().
- Fixed the calculation of a-b when a is shorter than b and borrow==1 after stage 1.
- Added sanity check in OSSL_FN_CTX_end().
- Do not set the is_dynamically_allocated flag when getting a new OSSL_FN from OSSL_FN_CTX.
- Added units of measurement to the error message in the OSSL_FN_copy() function.
- Fixed the comment in OSSL_FN_add().
- Added a comment to bn_mul_truncated() that it is a duty of the calling function to zero out the rest of r in case of rn>an+bn.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [X] tests are added or updated
