### PR TITLE
Removes SSL and SSLv3 from SSL_state_string_long() return.

### DIFF
--- a/ssl/ssl_stat.c
+++ b/ssl/ssl_stat.c
@@ -21,79 +21,79 @@ const char *SSL_state_string_long(const SSL *s)
 
     switch (SSL_get_state(s)) {
     case TLS_ST_CR_CERT_STATUS:
-        return "SSLv3/TLS read certificate status";
+        return "TLS read certificate status";
     case TLS_ST_CW_NEXT_PROTO:
-        return "SSLv3/TLS write next proto";
+        return "TLS write next proto";
     case TLS_ST_SR_NEXT_PROTO:
-        return "SSLv3/TLS read next proto";
+        return "TLS read next proto";
     case TLS_ST_SW_CERT_STATUS:
-        return "SSLv3/TLS write certificate status";
+        return "TLS write certificate status";
     case TLS_ST_BEFORE:
         return "before SSL initialization";
     case TLS_ST_OK:
-        return "SSL negotiation finished successfully";
+        return "TLS negotiation finished successfully";
     case TLS_ST_CW_CLNT_HELLO:
-        return "SSLv3/TLS write client hello";
+        return "TLS write client hello";
     case TLS_ST_CR_SRVR_HELLO:
-        return "SSLv3/TLS read server hello";
+        return "TLS read server hello";
     case TLS_ST_CR_CERT:
-        return "SSLv3/TLS read server certificate";
+        return "TLS read server certificate";
     case TLS_ST_CR_COMP_CERT:
         return "TLSv1.3 read server compressed certificate";
     case TLS_ST_CR_KEY_EXCH:
-        return "SSLv3/TLS read server key exchange";
+        return "TLS read server key exchange";
     case TLS_ST_CR_CERT_REQ:
-        return "SSLv3/TLS read server certificate request";
+        return "TLS read server certificate request";
     case TLS_ST_CR_SESSION_TICKET:
-        return "SSLv3/TLS read server session ticket";
+        return "TLS read server session ticket";
     case TLS_ST_CR_SRVR_DONE:
-        return "SSLv3/TLS read server done";
+        return "TLS read server done";
     case TLS_ST_CW_CERT:
-        return "SSLv3/TLS write client certificate";
+        return "TLS write client certificate";
     case TLS_ST_CW_COMP_CERT:
         return "TLSv1.3 write client compressed certificate";
     case TLS_ST_CW_KEY_EXCH:
-        return "SSLv3/TLS write client key exchange";
+        return "TLS write client key exchange";
     case TLS_ST_CW_CERT_VRFY:
-        return "SSLv3/TLS write certificate verify";
+        return "TLS write certificate verify";
     case TLS_ST_CW_CHANGE:
     case TLS_ST_SW_CHANGE:
-        return "SSLv3/TLS write change cipher spec";
+        return "TLS write change cipher spec";
     case TLS_ST_CW_FINISHED:
     case TLS_ST_SW_FINISHED:
-        return "SSLv3/TLS write finished";
+        return "TLS write finished";
     case TLS_ST_CR_CHANGE:
     case TLS_ST_SR_CHANGE:
-        return "SSLv3/TLS read change cipher spec";
+        return "TLS read change cipher spec";
     case TLS_ST_CR_FINISHED:
     case TLS_ST_SR_FINISHED:
-        return "SSLv3/TLS read finished";
+        return "TLS read finished";
     case TLS_ST_SR_CLNT_HELLO:
-        return "SSLv3/TLS read client hello";
+        return "TLS read client hello";
     case TLS_ST_SW_HELLO_REQ:
-        return "SSLv3/TLS write hello request";
+        return "TLS write hello request";
     case TLS_ST_SW_SRVR_HELLO:
-        return "SSLv3/TLS write server hello";
+        return "TLS write server hello";
     case TLS_ST_SW_CERT:
-        return "SSLv3/TLS write certificate";
+        return "TLS write certificate";
     case TLS_ST_SW_COMP_CERT:
         return "TLSv1.3 write server compressed certificate";
     case TLS_ST_SW_KEY_EXCH:
-        return "SSLv3/TLS write key exchange";
+        return "TLS write key exchange";
     case TLS_ST_SW_CERT_REQ:
-        return "SSLv3/TLS write certificate request";
+        return "TLS write certificate request";
     case TLS_ST_SW_SESSION_TICKET:
-        return "SSLv3/TLS write session ticket";
+        return "TLS write session ticket";
     case TLS_ST_SW_SRVR_DONE:
-        return "SSLv3/TLS write server done";
+        return "TLS write server done";
     case TLS_ST_SR_CERT:
-        return "SSLv3/TLS read client certificate";
+        return "TLS read client certificate";
     case TLS_ST_SR_COMP_CERT:
         return "TLSv1.3 read client compressed certificate";
     case TLS_ST_SR_KEY_EXCH:
-        return "SSLv3/TLS read client key exchange";
+        return "TLS read client key exchange";
     case TLS_ST_SR_CERT_VRFY:
-        return "SSLv3/TLS read certificate verify";
+        return "TLS read certificate verify";
     case DTLS_ST_CR_HELLO_VERIFY_REQUEST:
         return "DTLS1 read hello verify request";
     case DTLS_ST_SW_HELLO_VERIFY_REQUEST:
@@ -107,7 +107,7 @@ const char *SSL_state_string_long(const SSL *s)
     case TLS_ST_SW_CERT_VRFY:
         return "TLSv1.3 write server certificate verify";
     case TLS_ST_CR_HELLO_REQ:
-        return "SSLv3/TLS read hello request";
+        return "TLS read hello request";
     case TLS_ST_SW_KEY_UPDATE:
         return "TLSv1.3 write server key update";
     case TLS_ST_CW_KEY_UPDATE:


### PR DESCRIPTION
Fixes #6165

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
