### PR TITLE
Make QUIC radix tests friendly to clang-format

### DIFF
--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -299,8 +299,8 @@ DEF_SCRIPT(check_cwm, "check stream obeys cwm")
  * ============================================================================
  */
 static SCRIPT_INFO *const scripts[] = {
-    USE(simple_conn)
-        USE(simple_thread)
-            USE(ssl_poll)
-                USE(check_cwm)
+    USE(simple_conn),
+    USE(simple_thread),
+    USE(ssl_poll),
+    USE(check_cwm)
 };

--- a/test/radix/terp.c
+++ b/test/radix/terp.c
@@ -858,4 +858,4 @@ err:
 }
 
 #define SCRIPT(name) (&script_info_##name)
-#define USE(name) SCRIPT(name),
+#define USE(name) SCRIPT(name)


### PR DESCRIPTION
this is yet another small fallout from clang-format style change. This time for radix tests.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
