### PR TITLE
Add OSSL_FN_copy_truncate() function, which allows to copy a longer number to a shorter one, truncating the high bytes

### DIFF
--- a/crypto/fn/fn_lib.c
+++ b/crypto/fn/fn_lib.c
@@ -127,3 +127,21 @@ OSSL_FN *OSSL_FN_copy(OSSL_FN *a, const OSSL_FN *b)
     memset(&a->d[a->dsize], 0, sizeof(OSSL_FN_ULONG) * (a->dsize - b->dsize));
     return a;
 }
+
+OSSL_FN *OSSL_FN_copy_truncate(OSSL_FN *a, const OSSL_FN *b)
+{
+    if (ossl_unlikely(a == b))
+        return a;
+
+    size_t al = a->dsize;
+    size_t bl = b->dsize;
+
+    if (ossl_unlikely(al > bl)) {
+        memcpy(a->d, b->d, bl * sizeof(OSSL_FN_ULONG));
+        memset(&a->d[bl], 0, sizeof(OSSL_FN_ULONG) * (al - bl));
+    } else {
+        memcpy(a->d, b->d, al * sizeof(OSSL_FN_ULONG));
+    }
+
+    return a;
+}

--- a/crypto/fn/fn_sqr.c
+++ b/crypto/fn/fn_sqr.c
@@ -49,12 +49,10 @@ int OSSL_FN_sqr(OSSL_FN *r, const OSSL_FN *a, OSSL_FN_CTX *ctx)
 
     if (rr != r) {
         /*
-         * Because OSSL_FN_copy() expects to make a full copy, but r
-         * may be smaller than rr, rr's size is modified to truncate.
+         * We use OSSL_FN_copy_truncate() here, because OSSL_FN_copy() expects
+         * to make a full copy, but r may be smaller than rr
          */
-        rr->dsize = r->dsize;
-        if (OSSL_FN_copy(r, rr) == NULL)
-            goto err;
+        OSSL_FN_copy_truncate(r, rr);
     }
 
 #ifdef BN_SQR_COMBA

--- a/include/crypto/fn.h
+++ b/include/crypto/fn.h
@@ -139,6 +139,16 @@ void OSSL_FN_clear(OSSL_FN *f);
 OSSL_FN *OSSL_FN_copy(OSSL_FN *a, const OSSL_FN *b);
 
 /**
+ * Copy the contents of one OSSL_FN instance to another,
+ * normally the shorter one, truncating the high bytes.
+ *
+ * @param[out]  a       The destination OSSL_FN
+ * @param[in]   b       The source OSSL_FN
+ * @returns     the destination.
+ */
+OSSL_FN *OSSL_FN_copy_truncate(OSSL_FN *a, const OSSL_FN *b);
+
+/**
  * Allocate a new OSSL_FN_CTX, given a set of input numbers.
  *
  * @param[in]   libctx          OpenSSL library context (currently unused)


### PR DESCRIPTION
This function allows avoiding dirty hacks when we need to copy only the low part of a number.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
