### PR TITLE
http: fix OOB read in OSSL_HTTP_adapt_proxy

### DIFF
--- a/crypto/http/http_lib.c
+++ b/crypto/http/http_lib.c
@@ -271,6 +271,9 @@ static int use_proxy(const char *no_proxy, const char *server)
         server = host;
     }
 
+    if (sl == 0)
+        return 1;
+
     /*
      * using environment variable names, both lowercase and uppercase variants,
      * compatible with other HTTP client implementations like wget, curl and git

--- a/doc/man3/OSSL_HTTP_parse_url.pod
+++ b/doc/man3/OSSL_HTTP_parse_url.pod
@@ -32,7 +32,9 @@ see L<openssl_user_macros(7)>:
 
 =head1 DESCRIPTION
 
-OSSL_HTTP_adapt_proxy() takes an optional proxy hostname I<proxy>
+OSSL_HTTP_adapt_proxy() determines whether a proxy should be used
+when connecting to the given I<server>.
+It takes an optional proxy hostname I<proxy>
 and returns it transformed according to the optional I<no_proxy> parameter,
 I<server>, I<use_ssl>, and the applicable environment variable, as follows.
 If I<proxy> is NULL, take any default value from the C<http_proxy>
@@ -40,11 +42,13 @@ environment variable, or from C<https_proxy> if I<use_ssl> is nonzero.
 If this still does not yield a proxy hostname,
 take any further default value from the C<HTTP_PROXY>
 environment variable, or from C<HTTPS_PROXY> if I<use_ssl> is nonzero.
-If I<no_proxy> is NULL, take any default exclusion value from the C<no_proxy>
-environment variable, or else from C<NO_PROXY>.
-Return the determined proxy host unless the exclusion value,
-which is a list of proxy hosts separated by C<,> and/or whitespace,
-contains I<server>.
+Return the determined proxy host if I<server> is the empty string
+or I<server> is not in the exclusion list.
+The exclusion list is a list of server hosts separated by C<,>
+and/or whitespace.
+They may be given via the I<no_proxy> parameter.
+If it is NULL, the exclusion list is taken from the C<no_proxy>
+environment variable if set, otherwise from C<NO_PROXY>.
 Otherwise return NULL.
 When I<server> is a string delimited by C<[> and C<]>, which are used for IPv6
 addresses, the enclosing C<[> and C<]> are stripped prior to comparison.

--- a/test/http_test.c
+++ b/test/http_test.c
@@ -575,6 +575,14 @@ static int test_hdr_resp_hdr_limit_256(void)
     return test_http_resp_hdr_limit(256);
 }
 
+static int test_http_adapt_proxy_empty_server(void)
+{
+    const char *proxy = "http://proxy.local:8080";
+
+    return TEST_str_eq(OSSL_HTTP_adapt_proxy(proxy, "abc", "", 0), proxy)
+        && TEST_str_eq(OSSL_HTTP_adapt_proxy(proxy, "abc", "[]", 0), proxy);
+}
+
 void cleanup_tests(void)
 {
     X509_free(x509);
@@ -625,5 +633,6 @@ int setup_tests(void)
     ADD_TEST(test_hdr_resp_hdr_limit_none);
     ADD_TEST(test_hdr_resp_hdr_limit_short);
     ADD_TEST(test_hdr_resp_hdr_limit_256);
+    ADD_TEST(test_http_adapt_proxy_empty_server);
     return 1;
 }


### PR DESCRIPTION

## Summary
This PR fixes a memory safety bug in HTTP proxy adaptation logic.

When an empty server string is passed to OSSL_HTTP_adapt_proxy, the internal use_proxy helper can perform an out-of-bounds read while scanning no_proxy entries. This is reproducible with AddressSanitizer as a global-buffer-overflow.

## Root cause
In use_proxy, an empty server string leads to:
1. sl = 0
2. strstr(no_proxy, server) matching every position
3. repeated scanning and boundary checks that can advance past the end of no_proxy

## Fix
Add an early guard in use_proxy to handle empty server names safely and return before substring scanning.

Changed file:
- http_lib.c

## Tests
Added a regression test that verifies OSSL_HTTP_adapt_proxy handles empty server inputs safely and returns expected results.

Changed file:
- http_test.c

New coverage includes:
1. server = empty string
2. server = []

## Validation
1. Reproduced the crash on openssl-4.0.0 with ASAN using the PoC.
2. Verified no crash on patched code.
3. Ran HTTP test target successfully, including the new regression test.

Code to test the crash: 
```c
#include <openssl/http.h>
#include <stdio.h>

/*
 * PoC for empty-server handling in OSSL_HTTP_adapt_proxy().
 *
 * Vulnerable behavior (before patch): global-buffer-overflow in use_proxy()
 * due to empty match iteration on no_proxy.
 *
 * Build example (from repo root):
 *   gcc -fsanitize=address -fno-omit-frame-pointer -g -O0 \
 *       -Iinclude poc/http_adapt_proxy_empty_server.c -L. -lcrypto -ldl -pthread \
 *       -o /tmp/poc_http_adapt_proxy_empty_server
 *
 * Run example:
 *   ASAN_OPTIONS=abort_on_error=1:detect_leaks=0 /tmp/poc_http_adapt_proxy_empty_server
 */
int main(void)
{
    const char *proxy = "http://proxy.local:8080";
    const char *result;

    result = OSSL_HTTP_adapt_proxy(proxy, "abc", "", 0);
    printf("result=%s\n", result == NULL ? "(null)" : result);
    return 0;
}
```