### PR TITLE
cleanse tls 1.3 key schedule secrets

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -607,6 +607,30 @@ int ossl_ssl_connection_reset(SSL *s)
     sc->first_packet = 0;
 
     sc->key_update = SSL_KEY_UPDATE_NONE;
+
+    /* Cleanse TLS 1.3 key schedule secrets (RFC 8446 §7.1) */
+    OPENSSL_cleanse(sc->early_secret, sizeof(sc->early_secret));
+    OPENSSL_cleanse(sc->handshake_secret, sizeof(sc->handshake_secret));
+    OPENSSL_cleanse(sc->master_secret, sizeof(sc->master_secret));
+    OPENSSL_cleanse(sc->resumption_master_secret,
+                    sizeof(sc->resumption_master_secret));
+    OPENSSL_cleanse(sc->client_finished_secret,
+                    sizeof(sc->client_finished_secret));
+    OPENSSL_cleanse(sc->server_finished_secret,
+                    sizeof(sc->server_finished_secret));
+    OPENSSL_cleanse(sc->server_finished_hash,
+                    sizeof(sc->server_finished_hash));
+    OPENSSL_cleanse(sc->handshake_traffic_hash,
+                    sizeof(sc->handshake_traffic_hash));
+    OPENSSL_cleanse(sc->client_app_traffic_secret,
+                    sizeof(sc->client_app_traffic_secret));
+    OPENSSL_cleanse(sc->server_app_traffic_secret,
+                    sizeof(sc->server_app_traffic_secret));
+    OPENSSL_cleanse(sc->exporter_master_secret,
+                    sizeof(sc->exporter_master_secret));
+    OPENSSL_cleanse(sc->early_exporter_master_secret,
+                    sizeof(sc->early_exporter_master_secret));
+
     memset(sc->ext.compress_certificate_from_peer, 0,
         sizeof(sc->ext.compress_certificate_from_peer));
     sc->ext.compress_certificate_sent = 0;
@@ -1595,6 +1619,29 @@ void ossl_ssl_connection_free(SSL *ssl)
 #ifndef OPENSSL_NO_ECH
     ossl_ech_conn_clear(&s->ext.ech);
 #endif
+
+    /* Cleanse TLS 1.3 key schedule secrets (RFC 8446 §7.1) */
+    OPENSSL_cleanse(s->early_secret, sizeof(s->early_secret));
+    OPENSSL_cleanse(s->handshake_secret, sizeof(s->handshake_secret));
+    OPENSSL_cleanse(s->master_secret, sizeof(s->master_secret));
+    OPENSSL_cleanse(s->resumption_master_secret,
+                    sizeof(s->resumption_master_secret));
+    OPENSSL_cleanse(s->client_finished_secret,
+                    sizeof(s->client_finished_secret));
+    OPENSSL_cleanse(s->server_finished_secret,
+                    sizeof(s->server_finished_secret));
+    OPENSSL_cleanse(s->server_finished_hash,
+                    sizeof(s->server_finished_hash));
+    OPENSSL_cleanse(s->handshake_traffic_hash,
+                    sizeof(s->handshake_traffic_hash));
+    OPENSSL_cleanse(s->client_app_traffic_secret,
+                    sizeof(s->client_app_traffic_secret));
+    OPENSSL_cleanse(s->server_app_traffic_secret,
+                    sizeof(s->server_app_traffic_secret));
+    OPENSSL_cleanse(s->exporter_master_secret,
+                    sizeof(s->exporter_master_secret));
+    OPENSSL_cleanse(s->early_exporter_master_secret,
+                    sizeof(s->early_exporter_master_secret));
 }
 
 void SSL_set0_rbio(SSL *s, BIO *rbio)

--- a/test/build.info
+++ b/test/build.info
@@ -54,7 +54,7 @@ IF[{- !$disabled{tests} -}]
           dtlsv1listentest ct_test threadstest d2i_test \
           ssl_test_ctx_test ssl_test x509aux cipherlist_test asynciotest \
           bio_callback_test bio_memleak_test bio_core_test bio_dgram_test param_build_test \
-          sslapitest ssl_handshake_rtt_test dtlstest sslcorrupttest \
+          sslapitest ssl_handshake_rtt_test tls13secretcleansetest dtlstest sslcorrupttest \
           bio_base64_test bio_enc_test pkey_meth_kdf_test evp_kdf_test uitest \
           cipherbytes_test threadstest_fips threadpool_test \
           asn1_encode_test asn1_decode_test asn1_string_table_test asn1_stable_parse_test \
@@ -612,6 +612,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[sslapitest]=sslapitest.c helpers/ssltestlib.c filterprov.c tls-provider.c
   INCLUDE[sslapitest]=../include ../apps/include ../providers/common/include ..
   DEPEND[sslapitest]=../libcrypto.a ../libssl.a libtestutil.a
+
+  SOURCE[tls13secretcleansetest]=tls13secretcleansetest.c helpers/ssltestlib.c
+  INCLUDE[tls13secretcleansetest]=../include ../apps/include ..
+  DEPEND[tls13secretcleansetest]=../libcrypto.a ../libssl.a libtestutil.a
 
   SOURCE[handshake-memfail]=handshake-memfail.c helpers/ssltestlib.c
   INCLUDE[handshake-memfail]=../include ../apps/include

--- a/test/recipes/90-test_tls13secretcleanse.t
+++ b/test/recipes/90-test_tls13secretcleanse.t
@@ -1,0 +1,24 @@
+#! /usr/bin/env perl
+# Copyright 2025-2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+use OpenSSL::Test::Utils;
+
+my $test_name = "test_tls13secretcleanse";
+setup($test_name);
+
+plan skip_all => "$test_name is not supported in this build"
+    if disabled("tls1_3")
+       || (disabled("ec") && disabled("dh"));
+
+plan tests => 1;
+
+ok(run(test(["tls13secretcleansetest",
+             srctop_file("test", "certs", "servercert.pem"),
+             srctop_file("test", "certs", "serverkey.pem")])),
+   "running tls13secretcleansetest");

--- a/test/tls13secretcleansetest.c
+++ b/test/tls13secretcleansetest.c
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2025-2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * Tests for TLS 1.3 key schedule secret cleansing.
+ *
+ * Verify that OPENSSL_cleanse() is called on TLS 1.3 key schedule secrets
+ * in SSL_CONNECTION during connection reset (SSL_clear) and free (SSL_free),
+ * per RFC 8446 §7.1.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <openssl/opensslconf.h>
+#include <openssl/bio.h>
+#include <openssl/crypto.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
+#include "helpers/ssltestlib.h"
+#include "testutil.h"
+#include "testutil/output.h"
+#include "internal/ssl_unwrap.h"
+#include "../ssl/ssl_local.h"
+
+#undef OSSL_NO_USABLE_TLS1_3
+#if defined(OPENSSL_NO_TLS1_3) \
+    || (defined(OPENSSL_NO_EC) && defined(OPENSSL_NO_DH))
+# define OSSL_NO_USABLE_TLS1_3
+#endif
+
+static char *cert = NULL;
+static char *privkey = NULL;
+
+#ifndef OSSL_NO_USABLE_TLS1_3
+
+/*
+ * Test that all TLS 1.3 key schedule secrets are zeroed after SSL_clear().
+ *
+ * Completes a TLS 1.3 handshake, verifies secrets were populated, then calls
+ * SSL_clear() and checks that ossl_ssl_connection_reset() erased every secret
+ * field via OPENSSL_cleanse().
+ */
+static int test_tls13_secret_cleanse_on_clear(void)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    SSL_CONNECTION *sc = NULL;
+    int testresult = 0;
+    unsigned char zero[EVP_MAX_MD_SIZE];
+
+    memset(zero, 0, sizeof(zero));
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(),
+                                       TLS_client_method(),
+                                       TLS1_3_VERSION, TLS1_3_VERSION,
+                                       &sctx, &cctx, cert, privkey)))
+        goto err;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+                                      NULL, NULL)))
+        goto err;
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl,
+                                         SSL_ERROR_NONE)))
+        goto err;
+
+    if (!TEST_int_eq(SSL_version(serverssl), TLS1_3_VERSION))
+        goto err;
+
+    sc = SSL_CONNECTION_FROM_SSL(serverssl);
+    if (!TEST_ptr(sc))
+        goto err;
+
+    /* Verify that secrets were actually set during the handshake */
+    if (!TEST_true(memcmp(sc->master_secret, zero,
+                          sizeof(sc->master_secret)) != 0)) {
+        TEST_info("master_secret was zero after handshake - test inconclusive");
+        goto err;
+    }
+
+    /*
+     * SSL_clear() calls ossl_ssl_connection_reset() which should cleanse
+     * all TLS 1.3 key schedule secrets.
+     */
+    if (!TEST_true(SSL_clear(serverssl)))
+        goto err;
+
+    sc = SSL_CONNECTION_FROM_SSL(serverssl);
+    if (!TEST_ptr(sc))
+        goto err;
+
+    if (!TEST_true(memcmp(sc->early_secret, zero,
+                          sizeof(sc->early_secret)) == 0)) {
+        TEST_info("early_secret not erased after SSL_clear()");
+        goto err;
+    }
+    if (!TEST_true(memcmp(sc->handshake_secret, zero,
+                          sizeof(sc->handshake_secret)) == 0)) {
+        TEST_info("handshake_secret not erased after SSL_clear()");
+        goto err;
+    }
+    if (!TEST_true(memcmp(sc->master_secret, zero,
+                          sizeof(sc->master_secret)) == 0)) {
+        TEST_info("master_secret not erased after SSL_clear()");
+        goto err;
+    }
+    if (!TEST_true(memcmp(sc->resumption_master_secret, zero,
+                          sizeof(sc->resumption_master_secret)) == 0)) {
+        TEST_info("resumption_master_secret not erased after SSL_clear()");
+        goto err;
+    }
+    if (!TEST_true(memcmp(sc->exporter_master_secret, zero,
+                          sizeof(sc->exporter_master_secret)) == 0)) {
+        TEST_info("exporter_master_secret not erased after SSL_clear()");
+        goto err;
+    }
+    if (!TEST_true(memcmp(sc->client_app_traffic_secret, zero,
+                          sizeof(sc->client_app_traffic_secret)) == 0)) {
+        TEST_info("client_app_traffic_secret not erased after SSL_clear()");
+        goto err;
+    }
+    if (!TEST_true(memcmp(sc->server_app_traffic_secret, zero,
+                          sizeof(sc->server_app_traffic_secret)) == 0)) {
+        TEST_info("server_app_traffic_secret not erased after SSL_clear()");
+        goto err;
+    }
+
+    testresult = 1;
+
+ err:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
+/*
+ * Test that secrets from a previous TLS 1.3 session do not leak across
+ * SSL_clear() when the SSL object is reused (connection pooling scenario).
+ *
+ * Saves a known secret before SSL_clear(), then verifies it has been erased
+ * afterwards not merely overwritten by a new handshake.
+ */
+static int test_tls13_secret_leak_on_reuse(void)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    SSL_CONNECTION *sc = NULL;
+    int testresult = 0;
+    unsigned char zero[EVP_MAX_MD_SIZE];
+    unsigned char saved_master_secret[EVP_MAX_MD_SIZE];
+
+    memset(zero, 0, sizeof(zero));
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(),
+                                       TLS_client_method(),
+                                       TLS1_3_VERSION, TLS1_3_VERSION,
+                                       &sctx, &cctx, cert, privkey)))
+        goto err;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+                                      NULL, NULL)))
+        goto err;
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl,
+                                         SSL_ERROR_NONE)))
+        goto err;
+
+    sc = SSL_CONNECTION_FROM_SSL(serverssl);
+    if (!TEST_ptr(sc))
+        goto err;
+
+    memcpy(saved_master_secret, sc->master_secret, sizeof(saved_master_secret));
+
+    if (!TEST_true(memcmp(saved_master_secret, zero, sizeof(zero)) != 0)) {
+        TEST_info("master_secret was zero - test inconclusive");
+        goto err;
+    }
+
+    if (!TEST_true(SSL_clear(serverssl)))
+        goto err;
+
+    sc = SSL_CONNECTION_FROM_SSL(serverssl);
+    if (!TEST_ptr(sc))
+        goto err;
+
+    if (!TEST_true(memcmp(sc->master_secret, zero, sizeof(zero)) == 0)) {
+        TEST_info("master_secret persists after SSL_clear() "
+                  "(CWE-459: Incomplete Cleanup)");
+        TEST_info("The old master_secret matches the saved copy: %s",
+                  memcmp(sc->master_secret, saved_master_secret,
+                         sizeof(saved_master_secret)) == 0 ? "YES" : "NO");
+        goto err;
+    }
+
+    testresult = 1;
+
+ err:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    OPENSSL_cleanse(saved_master_secret, sizeof(saved_master_secret));
+    return testresult;
+}
+
+#endif /* OSSL_NO_USABLE_TLS1_3 */
+
+OPT_TEST_DECLARE_USAGE("certfile privkeyfile\n")
+
+int setup_tests(void)
+{
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
+    if (!TEST_ptr(cert = test_get_argument(0))
+        || !TEST_ptr(privkey = test_get_argument(1)))
+        return 0;
+
+#ifndef OSSL_NO_USABLE_TLS1_3
+    ADD_TEST(test_tls13_secret_cleanse_on_clear);
+    ADD_TEST(test_tls13_secret_leak_on_reuse);
+#endif
+
+    return 1;
+}
+
+void cleanup_tests(void)
+{
+}


### PR DESCRIPTION
Fixes #30849

Twelve TLS 1.3 key schedule secret fields in `SSL_CONNECTION` are never zeroed via `OPENSSL_cleanse()` on `SSL_free()` or `SSL_clear()`. They persist as cleartext in heap memory until the allocator reuses the pages.

This is inconsistent with how OpenSSL treats comparable secrets elsewhere (e.g., `SSL_SESSION_free()` cleanses `master_key`, `tls13_update_key()` cleanses its local secret buffer).

RFC 8446 §7.1 recommends (SHOULD) erasing secrets once all derived values are computed.

### Fix

Add `OPENSSL_cleanse()` calls for all twelve secret arrays in two locations:

| Location | Why  `OPENSSL_cleanse()` |
|---|---|
| `ossl_ssl_connection_free()` | Zero secrets before the struct is freed |
| `ossl_ssl_connection_reset()` | Zero secrets on `SSL_clear()` so pooled/reused connection objects do not retain prior session key material |

**Fields cleansed:** `early_secret`, `handshake_secret`, `master_secret`, `resumption_master_secret`, `client_finished_secret`, `server_finished_secret`, `server_finished_hash`, `handshake_traffic_hash`, `client_app_traffic_secret`, `server_app_traffic_secret`, `exporter_master_secret`, `early_exporter_master_secret`.

##### Checklist
- [ ] documentation is added or updated
- [ x] tests are added or updated
