### PR TITLE
Fix TLS 1.3 missing key_share alert

### DIFF
--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1659,12 +1659,12 @@ static int final_key_share(SSL_CONNECTION *s, unsigned int context, int sent)
      */
     if (!s->server
         && !sent) {
-        if ((s->ext.psk_kex_mode & TLSEXT_KEX_MODE_FLAG_KE) == 0) {
-            SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_NO_SUITABLE_KEY_SHARE);
-            return 0;
-        }
         if (!s->hit) {
             SSLfatal(s, SSL_AD_MISSING_EXTENSION, SSL_R_NO_SUITABLE_KEY_SHARE);
+            return 0;
+        }
+        if ((s->ext.psk_kex_mode & TLSEXT_KEX_MODE_FLAG_KE) == 0) {
+            SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_NO_SUITABLE_KEY_SHARE);
             return 0;
         }
     }

--- a/test/recipes/70-test_key_share.t
+++ b/test/recipes/70-test_key_share.t
@@ -48,6 +48,7 @@ use constant {
 my $testtype;
 my $direction;
 my $selectedgroupid;
+my $fatal_alert = 0;
 
 my $test_name = "test_key_share";
 setup($test_name);
@@ -89,7 +90,7 @@ if (disabled("ec")) {
     $proxy->serverflags("-groups P-384");
 }
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
-plan tests => 25;
+plan tests => 26;
 ok(TLSProxy::Message->success(), "Success after HRR");
 
 #Test 2: The server sending an HRR requesting a group the client already sent
@@ -241,25 +242,32 @@ if (disabled("ecx")) {
 $proxy->start();
 ok(TLSProxy::Message->fail(), "Non offered key_share");
 
-#Test 16: Too short group_id in ServerHello should fail
+#Test 16: Missing key_share in ServerHello should fail with missing_extension
+$proxy->clear();
+$fatal_alert = 0;
+$testtype = MISSING_EXTENSION;
+$proxy->start();
+ok($fatal_alert, "Missing key_share extension in ServerHello");
+
+#Test 17: Too short group_id in ServerHello should fail
 $proxy->clear();
 $testtype = GROUP_ID_TOO_SHORT;
 $proxy->start();
 ok(TLSProxy::Message->fail(), "Group id too short in ServerHello");
 
-#Test 17: key_exchange length mismatch in ServerHello should fail
+#Test 18: key_exchange length mismatch in ServerHello should fail
 $proxy->clear();
 $testtype = KEX_LEN_MISMATCH;
 $proxy->start();
 ok(TLSProxy::Message->fail(), "key_exchange length mismatch in ServerHello");
 
-#Test 18: Zero length key_exchange in ServerHello should fail
+#Test 19: Zero length key_exchange in ServerHello should fail
 $proxy->clear();
 $testtype = ZERO_LEN_KEX_DATA;
 $proxy->start();
 ok(TLSProxy::Message->fail(), "zero length key_exchange data in ServerHello");
 
-#Test 19: Trailing data on key_share in ServerHello should fail
+#Test 20: Trailing data on key_share in ServerHello should fail
 $proxy->clear();
 $testtype = TRAILING_DATA;
 $proxy->start();
@@ -268,7 +276,7 @@ ok(TLSProxy::Message->fail(), "key_share trailing data in ServerHello");
 SKIP: {
     skip "No TLSv1.2 support in this OpenSSL build", 2 if disabled("tls1_2");
 
-    #Test 20: key_share should not be sent if the client is not capable of
+    #Test 21: key_share should not be sent if the client is not capable of
     #         negotiating TLSv1.3
     $proxy->clear();
     $proxy->filter(undef);
@@ -280,7 +288,7 @@ SKIP: {
        "No key_share for TLS<=1.2 client");
     $proxy->filter(\&modify_key_shares_filter);
 
-    #Test 21: A server not capable of negotiating TLSv1.3 should not attempt to
+    #Test 22: A server not capable of negotiating TLSv1.3 should not attempt to
     #         process a key_share
     $proxy->clear();
     $direction = CLIENT_TO_SERVER;
@@ -290,7 +298,7 @@ SKIP: {
     ok(TLSProxy::Message->success(), "Ignore key_share for TLS<=1.2 server");
 }
 
-#Test 22: The server sending an HRR but not requesting a new key_share should
+#Test 23: The server sending an HRR but not requesting a new key_share should
 #         fail
 $proxy->clear();
 $direction = SERVER_TO_CLIENT;
@@ -305,7 +313,7 @@ ok(TLSProxy::Message->fail(), "Server sends HRR with no key_shares");
 
 SKIP: {
     skip "No EC support in this OpenSSL build", 3 if disabled("ec");
-    #Test 23: Trailing data on key_share in ServerHello should fail
+    #Test 24: Client sends a key_share for a non-TLSv1.3 group
     $proxy->clear();
     $direction = CLIENT_TO_SERVER;
     if (disabled("ecx")) {
@@ -322,7 +330,7 @@ SKIP: {
     ok(TLSProxy::Message->success() && $ishrr,
        "Client sends a key_share for a Non TLSv1.3 group");
 
-    #Test 24: Client sends a large number of key shares. We should ignore them.
+    #Test 25: Client sends a large number of key shares. We should ignore them.
     $proxy->clear();
     $direction = CLIENT_TO_SERVER;
     $testtype = LARGE_NUM_KEY_SHARES;
@@ -330,7 +338,7 @@ SKIP: {
     $proxy->start();
     ok(TLSProxy::Message->success(), "Large number of key shares");
 
-    #Test 25: Client sends a large number of supported groups. We should ignore
+    #Test 26: Client sends a large number of supported groups. We should ignore
     #         them.
     $proxy->clear();
     $direction = CLIENT_TO_SERVER;
@@ -347,6 +355,15 @@ SKIP: {
 sub modify_key_shares_filter
 {
     my $proxy = shift;
+
+    if ($testtype == MISSING_EXTENSION
+            && $direction == SERVER_TO_CLIENT
+            && $proxy->flight == 2) {
+        $fatal_alert = 1
+            if @{$proxy->record_list}[-1]->is_fatal_alert(0)
+               == TLSProxy::Message::AL_DESC_MISSING_EXTENSION;
+        return;
+    }
 
     # We're only interested in the initial ClientHello/SererHello/HRR
     if (($direction == CLIENT_TO_SERVER && $proxy->flight != 0
@@ -503,11 +520,12 @@ sub modify_key_shares_filter
         } elsif ($message->mt == TLSProxy::Message::MT_SERVER_HELLO
                      && $direction == SERVER_TO_CLIENT) {
             my $ext;
-            my $key_share =
-                $message->extension_data->{TLSProxy::Message::EXT_KEY_SHARE};
-            $selectedgroupid = unpack("n", $key_share);
+            my $key_share;
 
             if ($testtype == LOOK_ONLY) {
+                $key_share =
+                    $message->extension_data->{TLSProxy::Message::EXT_KEY_SHARE};
+                $selectedgroupid = unpack("n", $key_share);
                 return;
             }
             if ($testtype == NO_KEY_SHARES_IN_HRR) {
@@ -516,6 +534,14 @@ sub modify_key_shares_filter
                 $message->repack();
                 return;
             }
+            if ($testtype == MISSING_EXTENSION) {
+                $message->delete_extension(TLSProxy::Message::EXT_KEY_SHARE);
+                $message->repack();
+                return;
+            }
+            $key_share =
+                $message->extension_data->{TLSProxy::Message::EXT_KEY_SHARE};
+            $selectedgroupid = unpack("n", $key_share);
             if ($testtype == SELECT_X25519) {
                 $ext = pack "C4H64",
                     0x00, 0x1d, #x25519
@@ -548,5 +574,3 @@ sub modify_key_shares_filter
         }
     }
 }
-
-


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

- Reorder the client-side checks in final_key_share().
- Send missing_extension for a non-resumed TLS 1.3 ServerHello
  that omits key_share.
- Preserve illegal_parameter for the PSK/non-DHE path.
- Add a regression test covering a ServerHello without key_share.

Fixes #30818 
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated

