### PR TITLE
Deprecate the ASN1_BIT_STRING name related functions.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,12 @@ OpenSSL Releases
 
    *Shane Lontis*
 
+ * The functions `ASN1_BIT_STRING_name_print()`, `ASN1_BIT_STRING_num_asc(),
+   and `ASN1_BIT_STRING_set_asc()`, have been deprecated. Refer to the manual
+   pages for more information.
+
+   *Bob Beck*
+
  * The API functions `CRYPTO_atomic_load_ptr`, `CRYPTO_atomic_store_ptr`, and
    `CRYPTO_atomic_cmp_exch_ptr` have been added to libcrypto.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,12 @@ OpenSSL Releases
 
    *Shane Lontis*
 
+ * The functions `ASN1_BIT_STRING_name_print()`, `ASN1_BIT_STRING_num_asc(),
+   and `ASN1_BIT_STRING_set_asc()`, have been deprecated. Refer to the manual
+   pages for more information.
+
+   *Bob Beck*
+
  * The API functions `CRYPTO_atomic_load_ptr`, `CRYPTO_atomic_store_ptr`, and
    `CRYPTO_atomic_cmp_exch_ptr` have been added to libcrypto.
 

--- a/crypto/asn1/t_bitst.c
+++ b/crypto/asn1/t_bitst.c
@@ -12,6 +12,8 @@
 #include <openssl/conf.h>
 #include <openssl/x509v3.h>
 
+#if !defined(OPENSSL_NO_DEPRECATED_4_1)
+OSSL_BEGIN_ALLOW_DEPRECATED
 int ASN1_BIT_STRING_name_print(BIO *out, ASN1_BIT_STRING *bs,
     BIT_STRING_BITNAME *tbl, int indent)
 {
@@ -69,3 +71,5 @@ int ASN1_BIT_STRING_num_asc(const char *name, BIT_STRING_BITNAME *tbl)
     }
     return -1;
 }
+OSSL_END_ALLOW_DEPRECATED
+#endif /* !defined(OPENSSL_NO_DEPRECATED_4_1) */

--- a/crypto/asn1/t_bitst.c
+++ b/crypto/asn1/t_bitst.c
@@ -12,6 +12,8 @@
 #include <openssl/conf.h>
 #include <openssl/x509v3.h>
 
+#if !defined(OPENSSL_NO_DEPRECATED_4_1)
+OSSL_BEGIN_ALLOW_DEPRECATED
 int ASN1_BIT_STRING_name_print(BIO *out, ASN1_BIT_STRING *bs,
     BIT_STRING_BITNAME *tbl, int indent)
 {
@@ -65,3 +67,5 @@ int ASN1_BIT_STRING_num_asc(const char *name, BIT_STRING_BITNAME *tbl)
     }
     return -1;
 }
+OSSL_END_ALLOW_DEPRECATED
+#endif /* !defined(OPENSSL_NO_DEPRECATED_4_1) */

--- a/doc/man3/ASN1_BIT_STRING_get_length.pod
+++ b/doc/man3/ASN1_BIT_STRING_get_length.pod
@@ -26,15 +26,21 @@ ASN1_BIT_STRING_get_length - ASN1_BIT_STRING accessors
   int ASN1_BIT_STRING_check(const ASN1_BIT_STRING *a,
     const unsigned char *flags, int flags_len);
 
-  int ASN1_BIT_STRING_name_print(BIO *out, ASN1_BIT_STRING *bs,
-    BIT_STRING_BITNAME *tbl, int indent);
-  int ASN1_BIT_STRING_num_asc(const char *name, BIT_STRING_BITNAME *tbl);
-  int ASN1_BIT_STRING_set_asc(ASN1_BIT_STRING *bs, const char *name,
-    int value, BIT_STRING_BITNAME *tbl);
   int ASN1_BIT_STRING_get_length(const ASN1_BIT_STRING *bitstr,
     size_t *length, int *unused_bits);
   int ASN1_BIT_STRING_set1(ASN1_BIT_STRING *bitstr, const uint8_t *data,
     size_t length, int unused_bits);
+
+The following functions have been deprecated since OpenSSL 4.1, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
+
+  int ASN1_BIT_STRING_name_print(BIO *out, ASN1_BIT_STRING *bs,
+   BIT_STRING_BITNAME *tbl, int indent);
+  int ASN1_BIT_STRING_num_asc(const char *name, BIT_STRING_BITNAME *tbl);
+  int ASN1_BIT_STRING_set_asc(ASN1_BIT_STRING *bs, const char *name,
+    int value, BIT_STRING_BITNAME *tbl);
+
 
 =head1 DESCRIPTION
 
@@ -55,17 +61,6 @@ ASN1_BIT_STRING_check() checks if the I<a> bit string contains only bits
 specified by the I<flags> vector. I<flags_len> is the length of I<flags>
 in bytes.
 
-ASN1_BIT_STRING_name_print() prints the corresponding bit name specified
-in I<tbl> to I<out> based on the bit string I<bs>. I<indent> might be
-specified for a number of spaces to indent the line.
-
-ASN1_BIT_STRING_num_asc() searches for the provided I<name> in I<lname>
-and I<sname> fields of I<tbl>'s elements and returns the corresponding
-I<bitnum> field value in case there is a match found.
-
-ASN1_BIT_STRING_set_asc() sets the corresponding bit to I<name> in I<bs>
-based on the conversion table I<tbl>.
-
 ASN1_BIT_STRING_get_length() returns the number of octets in I<bitstr>
 containing bit values in I<length> and the number of unused bits in
 the last octet in I<unused_bits>. The value returned in
@@ -75,6 +70,29 @@ ASN1_BIT_STRING_set1() sets the type of I<bitstr> to
 I<V_ASN1_BIT_STRING> and its octets to the bits in the byte string
 I<data> of length I<length> octets, making sure that the last
 I<unused_bits> bits in the last byte are zero.
+
+ASN1_BIT_STRING_name_print() prints the corresponding bit name specified
+in I<tbl> to I<out> based on the bit string I<bs>. I<indent> might be
+specified for a number of spaces to indent the line. This function has
+been deprecated as of OpenSSL 4.1. For a replacement strategy, consider
+using a descriptive #define for the bit value, or if your application
+truly needs to do this with strings, implementing your own string to
+integer lookup table.
+
+ASN1_BIT_STRING_num_asc() searches for the provided I<name> in I<lname>
+and I<sname> fields of I<tbl>'s elements and returns the corresponding
+I<bitnum> field value in case there is a match found. This function has
+been deprecated as of OpenSSL 4.1. For a replacement strategy, consider
+using a descriptive #define for the bit value, or if your application
+truly needs to do this with strings, implementing your own string to
+integer lookup table.
+
+ASN1_BIT_STRING_set_asc() sets the corresponding bit to I<name> in I<bs>
+based on the conversion table I<tbl>.  This function has
+been deprecated as of OpenSSL 4.1. For a replacement strategy, consider
+using a descriptive #define for the bit value, or if your application
+truly needs to do this with strings, implementing your own string to
+integer lookup table.
 
 =head1 RETURN VALUES
 
@@ -109,6 +127,12 @@ nonzero.
 
 Functions ASN1_BIT_STRING_get_length() and ASN1_BIT_STRING_set1() were
 added in OpenSSL version 4.0.
+
+ASN1_BIT_STRING_name_print() ASN1_BIT_STRING_num_asc(), and
+ASN1_BIT_STRING_set_asc(), Along with the BIT_STRING_BITNAME structure
+were present but undocumented in all versions of OpenSSL as public
+API.  They are unused by the library. They were documented and then
+deprecated in OpenSSL 4.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/ASN1_BIT_STRING_get_length.pod
+++ b/doc/man3/ASN1_BIT_STRING_get_length.pod
@@ -27,11 +27,6 @@ ASN1_BIT_STRING_get_length - ASN1_BIT_STRING accessors
   int ASN1_BIT_STRING_check(const ASN1_BIT_STRING *a,
     const unsigned char *flags, int flags_len);
 
-  int ASN1_BIT_STRING_name_print(BIO *out, ASN1_BIT_STRING *bs,
-    BIT_STRING_BITNAME *tbl, int indent);
-  int ASN1_BIT_STRING_num_asc(const char *name, BIT_STRING_BITNAME *tbl);
-  int ASN1_BIT_STRING_set_asc(ASN1_BIT_STRING *bs, const char *name,
-    int value, BIT_STRING_BITNAME *tbl);
   int ASN1_BIT_STRING_get_length(const ASN1_BIT_STRING *bitstr,
     size_t *length, int *unused_bits);
   int ASN1_BIT_STRING_set1(ASN1_BIT_STRING *bitstr, const uint8_t *data,
@@ -42,6 +37,11 @@ hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
 see L<openssl_user_macros(7)>:
 
   int ASN1_BIT_STRING_set(ASN1_BIT_STRING *a, unsigned char *d, int length);
+  int ASN1_BIT_STRING_name_print(BIO *out, ASN1_BIT_STRING *bs,
+   BIT_STRING_BITNAME *tbl, int indent);
+  int ASN1_BIT_STRING_num_asc(const char *name, BIT_STRING_BITNAME *tbl);
+  int ASN1_BIT_STRING_set_asc(ASN1_BIT_STRING *bs, const char *name,
+    int value, BIT_STRING_BITNAME *tbl);
 
 =head1 DESCRIPTION
 
@@ -62,17 +62,6 @@ ASN1_BIT_STRING_check() checks if the I<a> bit string contains only bits
 specified by the I<flags> vector. I<flags_len> is the length of I<flags>
 in bytes.
 
-ASN1_BIT_STRING_name_print() prints the corresponding bit name specified
-in I<tbl> to I<out> based on the bit string I<bs>. I<indent> might be
-specified for a number of spaces to indent the line.
-
-ASN1_BIT_STRING_num_asc() searches for the provided I<name> in I<lname>
-and I<sname> fields of I<tbl>'s elements and returns the corresponding
-I<bitnum> field value in case there is a match found.
-
-ASN1_BIT_STRING_set_asc() sets the corresponding bit to I<name> in I<bs>
-based on the conversion table I<tbl>.
-
 ASN1_BIT_STRING_get_length() returns the number of octets in I<bitstr>
 containing bit values in I<length> and the number of unused bits in
 the last octet in I<unused_bits>. The value returned in
@@ -85,6 +74,29 @@ ASN1_BIT_STRING_set1() sets the type of I<bitstr> to
 I<V_ASN1_BIT_STRING> and its octets to the bits in the byte string
 I<data> of length I<length> octets, making sure that the last
 I<unused_bits> bits in the last byte are zero.
+
+ASN1_BIT_STRING_name_print() prints the corresponding bit name specified
+in I<tbl> to I<out> based on the bit string I<bs>. I<indent> might be
+specified for a number of spaces to indent the line. This function has
+been deprecated as of OpenSSL 4.1. For a replacement strategy, consider
+using a descriptive #define for the bit value, or if your application
+truly needs to do this with strings, implementing your own string to
+integer lookup table.
+
+ASN1_BIT_STRING_num_asc() searches for the provided I<name> in I<lname>
+and I<sname> fields of I<tbl>'s elements and returns the corresponding
+I<bitnum> field value in case there is a match found. This function has
+been deprecated as of OpenSSL 4.1. For a replacement strategy, consider
+using a descriptive #define for the bit value, or if your application
+truly needs to do this with strings, implementing your own string to
+integer lookup table.
+
+ASN1_BIT_STRING_set_asc() sets the corresponding bit to I<name> in I<bs>
+based on the conversion table I<tbl>.  This function has
+been deprecated as of OpenSSL 4.1. For a replacement strategy, consider
+using a descriptive #define for the bit value, or if your application
+truly needs to do this with strings, implementing your own string to
+integer lookup table.
 
 =head1 RETURN VALUES
 
@@ -126,6 +138,11 @@ added in OpenSSL version 4.0.
 
 ASN1_BIT_STRING_set() was deprecated in OpenSSL 4.1 in favour of
 ASN1_BIT_STRING_set1().
+ASN1_BIT_STRING_name_print() ASN1_BIT_STRING_num_asc(), and
+ASN1_BIT_STRING_set_asc(), Along with the BIT_STRING_BITNAME structure
+were present but undocumented in all versions of OpenSSL as public
+API.  They are unused by the library. They were documented and then
+deprecated in OpenSSL 4.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/ASN1_BIT_STRING_get_length.pod
+++ b/doc/man3/ASN1_BIT_STRING_get_length.pod
@@ -38,7 +38,7 @@ see L<openssl_user_macros(7)>:
 
   int ASN1_BIT_STRING_set(ASN1_BIT_STRING *a, unsigned char *d, int length);
   int ASN1_BIT_STRING_name_print(BIO *out, ASN1_BIT_STRING *bs,
-   BIT_STRING_BITNAME *tbl, int indent);
+    BIT_STRING_BITNAME *tbl, int indent);
   int ASN1_BIT_STRING_num_asc(const char *name, BIT_STRING_BITNAME *tbl);
   int ASN1_BIT_STRING_set_asc(ASN1_BIT_STRING *bs, const char *name,
     int value, BIT_STRING_BITNAME *tbl);

--- a/include/openssl/asn1.h.in
+++ b/include/openssl/asn1.h.in
@@ -555,11 +555,13 @@ int ASN1_BIT_STRING_get_bit(const ASN1_BIT_STRING *a, int n);
 int ASN1_BIT_STRING_check(const ASN1_BIT_STRING *a,
     const unsigned char *flags, int flags_len);
 
-int ASN1_BIT_STRING_name_print(BIO *out, ASN1_BIT_STRING *bs,
+#if !defined(OPENSSL_NO_DEPRECATED_4_1)
+OSSL_DEPRECATEDIN_4_1 int ASN1_BIT_STRING_name_print(BIO *out, ASN1_BIT_STRING *bs,
     BIT_STRING_BITNAME *tbl, int indent);
-int ASN1_BIT_STRING_num_asc(const char *name, BIT_STRING_BITNAME *tbl);
-int ASN1_BIT_STRING_set_asc(ASN1_BIT_STRING *bs, const char *name, int value,
+OSSL_DEPRECATEDIN_4_1 int ASN1_BIT_STRING_num_asc(const char *name, BIT_STRING_BITNAME *tbl);
+OSSL_DEPRECATEDIN_4_1 int ASN1_BIT_STRING_set_asc(ASN1_BIT_STRING *bs, const char *name, int value,
     BIT_STRING_BITNAME *tbl);
+#endif /* !defined(OPENSSL_NO_DEPRECATED_4_1) */
 int ASN1_BIT_STRING_get_length(const ASN1_BIT_STRING *abs, size_t *length,
     int *unused_bits);
 int ASN1_BIT_STRING_set1(ASN1_BIT_STRING *abs, const uint8_t *data,

--- a/include/openssl/asn1.h.in
+++ b/include/openssl/asn1.h.in
@@ -551,11 +551,13 @@ int ASN1_BIT_STRING_get_bit(const ASN1_BIT_STRING *a, int n);
 int ASN1_BIT_STRING_check(const ASN1_BIT_STRING *a,
     const unsigned char *flags, int flags_len);
 
-int ASN1_BIT_STRING_name_print(BIO *out, ASN1_BIT_STRING *bs,
+#if !defined(OPENSSL_NO_DEPRECATED_4_1)
+OSSL_DEPRECATEDIN_4_1 int ASN1_BIT_STRING_name_print(BIO *out, ASN1_BIT_STRING *bs,
     BIT_STRING_BITNAME *tbl, int indent);
-int ASN1_BIT_STRING_num_asc(const char *name, BIT_STRING_BITNAME *tbl);
-int ASN1_BIT_STRING_set_asc(ASN1_BIT_STRING *bs, const char *name, int value,
+OSSL_DEPRECATEDIN_4_1 int ASN1_BIT_STRING_num_asc(const char *name, BIT_STRING_BITNAME *tbl);
+OSSL_DEPRECATEDIN_4_1 int ASN1_BIT_STRING_set_asc(ASN1_BIT_STRING *bs, const char *name, int value,
     BIT_STRING_BITNAME *tbl);
+#endif /* !defined(OPENSSL_NO_DEPRECATED_4_1) */
 int ASN1_BIT_STRING_get_length(const ASN1_BIT_STRING *abs, size_t *length,
     int *unused_bits);
 int ASN1_BIT_STRING_set1(ASN1_BIT_STRING *abs, const uint8_t *data,

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -2587,9 +2587,9 @@ ASN1_BIT_STRING_set_bit                 2585	4_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_get_bit                 2586	4_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_check                   2587	4_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_get_length              2588	4_0_0	EXIST::FUNCTION:
-ASN1_BIT_STRING_name_print              2589	4_0_0	EXIST::FUNCTION:
-ASN1_BIT_STRING_num_asc                 2590	4_0_0	EXIST::FUNCTION:
-ASN1_BIT_STRING_set_asc                 2591	4_0_0	EXIST::FUNCTION:
+ASN1_BIT_STRING_name_print              2589	4_0_0	EXIST::FUNCTION:DEPRECATEDIN_4_1
+ASN1_BIT_STRING_num_asc                 2590	4_0_0	EXIST::FUNCTION:DEPRECATEDIN_4_1
+ASN1_BIT_STRING_set_asc                 2591	4_0_0	EXIST::FUNCTION:DEPRECATEDIN_4_1
 d2i_ASN1_INTEGER                        2592	4_0_0	EXIST::FUNCTION:
 i2d_ASN1_INTEGER                        2593	4_0_0	EXIST::FUNCTION:
 ASN1_INTEGER_free                       2594	4_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -2587,9 +2587,9 @@ ASN1_BIT_STRING_set_bit                 2585	4_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_get_bit                 2586	4_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_check                   2587	4_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_get_length              2588	4_0_0	EXIST::FUNCTION:
-ASN1_BIT_STRING_name_print              2589	4_0_0	EXIST::FUNCTION:
-ASN1_BIT_STRING_num_asc                 2590	4_0_0	EXIST::FUNCTION:
-ASN1_BIT_STRING_set_asc                 2591	4_0_0	EXIST::FUNCTION:
+ASN1_BIT_STRING_name_print              2589	4_0_0	EXIST::FUNCTION:DEPRECATED_4_1
+ASN1_BIT_STRING_num_asc                 2590	4_0_0	EXIST::FUNCTION:DEPRECATED_4_1
+ASN1_BIT_STRING_set_asc                 2591	4_0_0	EXIST::FUNCTION:DEPRECATED_4_1
 d2i_ASN1_INTEGER                        2592	4_0_0	EXIST::FUNCTION:
 i2d_ASN1_INTEGER                        2593	4_0_0	EXIST::FUNCTION:
 ASN1_INTEGER_free                       2594	4_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
These seem to have been from something long long ago that nothing uses anymore. It seems like this is just something we should not be doing in this way.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
