### PR TITLE
Fix fips provider compatibility test

### DIFF
--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -9768,6 +9768,9 @@ static int test_cert_cb_int(int prot, int tst)
         return 1;
 #endif
 
+    if (!fips_provider_version_ge(libctx, 3, 5, 0))
+        return TEST_skip("FIPS provider does not support MLKEM algorithms");
+
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
             TLS_client_method(),
             prot,


### PR DESCRIPTION
Recently the sslapi test modified the cert_cb test to use ML-DSA keys. While this is fine, it doesn't work on fips providers prior to 3.5.  As such our fips compatibility ci job is failing.

Add a check to skip the test in the event we are using an older provider.



##### Checklist
- [x] tests are added or updated
