### PR TITLE
fips: mark X448MLKEM1024 as non-approved

### DIFF
--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -587,7 +587,7 @@ static const OSSL_ALGORITHM fips_asym_kem[] = {
     { PROV_NAMES_ML_KEM_1024, FIPS_DEFAULT_PROPERTIES, ossl_ml_kem_asym_kem_functions },
 #if !defined(OPENSSL_NO_ECX)
     { PROV_NAMES_X25519MLKEM768, FIPS_DEFAULT_PROPERTIES, ossl_mlx_kem_asym_kem_functions },
-    { PROV_NAMES_X448MLKEM1024, FIPS_DEFAULT_PROPERTIES, ossl_mlx_kem_asym_kem_functions },
+    { PROV_NAMES_X448MLKEM1024, FIPS_UNAPPROVED_PROPERTIES, ossl_mlx_kem_asym_kem_functions },
 #endif
 #if !defined(OPENSSL_NO_EC)
     { PROV_NAMES_SecP256r1MLKEM768, FIPS_DEFAULT_PROPERTIES, ossl_mlx_kem_asym_kem_functions },


### PR DESCRIPTION
The [FIPS 140-3 I.G.](https://csrc.nist.gov/csrc/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS%20140-3%20IG.pdf) Section D.S Key Encapsulation Mechanisms have been substantially updated on April 9, 2026.

It now explicitely lists that hybrid mechanisms must be fixed
combinations with both portions being in boundary, and the intent
should be to use them with an approved combiner such as HKDF as part
of a protocol. With the combinations from the
https://datatracker.ietf.org/doc/draft-ietf-tls-ecdhe-mlkem
explicitely mentioned that they can reach appoved or allowed claims.

Note that consensus for TLS group for X448MLKEM1024 failed to reach on
the [pqc forum](https://mailarchive.ietf.org/arch/browse/tls/?gbt=1&index=YIHJrbWVPdXIr8q57nsEUUmuaIo) and is not part of the
https://datatracker.ietf.org/doc/draft-ietf-tls-ecdhe-mlkem. And there
are no other protocols defined that use this hybrid with an approved
combiner. The IETF draft is referenced by the FIPS 140-3 IG.

Also on https://test.openquantumsafe.org/ there is x448_mlkem768 but
no X448MLKEM1024.

To avoid any confusion, it is best to mark this hybrid as non-approved
going forward. It is likely also worthfile to deprecate X448MLKEM1024
altogether, and eventually remove.

cc: @vdukhovni - was there ever a TLS group defined for X448MLKEM1024?

Fixes: https://github.com/openssl/openssl/pull/26220
