### PR TITLE
Add stack test for thunked sorted lookup

### DIFF
--- a/test/stack_test.c
+++ b/test/stack_test.c
@@ -255,6 +255,15 @@ static int test_uchar_stack(int reserve)
         goto end;
     sk_uchar_sort(r);
     sk_uchar_sort(q);
+    for (i = 0; i < n; i++) {
+        int idx = sk_uchar_find(q, v + i);
+
+        if (!TEST_int_ge(idx, 0)
+            || !TEST_int_eq((int)*sk_uchar_value(q, idx), (int)v[i])) {
+            TEST_info("uchar sorted find %d", i);
+            goto end;
+        }
+    }
 
     /* pop */
     for (i = 0; i < n; i++) {

--- a/test/stack_test.c
+++ b/test/stack_test.c
@@ -255,6 +255,15 @@ static int test_uchar_stack(int reserve)
         goto end;
     sk_uchar_sort(r);
     sk_uchar_sort(q);
+    for (i = 0; i < n; i++) {
+        int idx = sk_uchar_find(q, v + i);
+
+        if (!TEST_int_ge(idx, 0)
+            || !TEST_uchar_eq(*sk_uchar_value(q, idx), v[i])) {
+            TEST_info("uchar sorted find %d", i);
+            goto end;
+        }
+    }
 
     /* pop */
     for (i = 0; i < n; i++) {


### PR DESCRIPTION
Add coverage for sorted lookup on a typed stack that has a generated comparison thunk installed.

The `uchar` stack test already constructs a typed stack with `sk_uchar_new(&uchar_compare)`, which installs the generated safestack comparison thunk.
This change extends that test to sort a duplicated stack and then verify that `sk_uchar_find` can locate each value.

## Rationale

Typed stacks created through `sk_TYPE_new(cmp)` install a comparison thunk used by stack lookup paths. This test documents that the generated thunk path remains compatible with sorted lookup after `sk_TYPE_sort`.

## Testing

Tested the same change in configured build trees on Windows and Linux.

Windows, VC-WIN64A:

- `.\test\stack_test.exe`
- `nmake test TESTS=test_stack`

Linux, Ubuntu 24.04 x64:

- `./test/stack_test`
- `make test TESTS=test_stack`
