### PR TITLE
Fix wrong free pointer in hashtable grow cleanup

### DIFF
--- a/crypto/hashtable/hashtable.c
+++ b/crypto/hashtable/hashtable.c
@@ -507,7 +507,7 @@ static int grow_hashtable(HT *h, size_t oldsize)
             }
             if (rehashed == 0) {
                 /* we ran out of space in a neighborhood, grow again */
-                OPENSSL_free(newmd->neighborhoods);
+                OPENSSL_free(newmd->neighborhood_ptr_to_free);
                 OPENSSL_free(newmd);
                 return grow_hashtable(h, newsize);
             }
@@ -538,7 +538,7 @@ static int grow_hashtable(HT *h, size_t oldsize)
 out:
     return rc;
 out_free:
-    OPENSSL_free(newmd->neighborhoods);
+    OPENSSL_free(newmd->neighborhood_ptr_to_free);
     OPENSSL_free(newmd);
     goto out;
 }


### PR DESCRIPTION
## Summary

Update `grow_hashtable` cleanup to free the neighborhood allocation through `newmd->neighborhood_ptr_to_free` instead of `newmd->neighborhoods`.

## Rationale

`alloc_new_neighborhood_list` may allocate the neighborhood table with `OPENSSL_aligned_alloc_array`. In that case, `newmd->neighborhoods` is the aligned pointer returned to the caller, while `newmd->neighborhood_ptr_to_free` is the allocation pointer that must be passed to `OPENSSL_free`.

Most hashtable cleanup paths already use `neighborhood_ptr_to_free`. The rehash-failure path in `grow_hashtable` did not, so it could free the wrong pointer on platforms that use OpenSSL's fallback aligned allocation path.

This also updates the allocation-failure cleanup path to use the same owner pointer for consistency. That path is defensive because the aligned allocation helper sets the free pointer to `NULL` on failure.

## Testing

Windows:

```text
nmake test\lhash_test.exe
test\lhash_test.exe -test 3
```

Ubuntu 24.04 x86_64:

```text
./test/lhash_test -test 3
```