### PR TITLE
Fix prototype typo in X509_NAME_get_index_by_NID

### DIFF
--- a/doc/man3/X509_NAME_get_index_by_NID.pod
+++ b/doc/man3/X509_NAME_get_index_by_NID.pod
@@ -15,7 +15,7 @@ X509_NAME lookup and enumeration functions
                                 const ASN1_OBJECT *obj, int lastpos);
 
  int X509_NAME_entry_count(const X509_NAME *name);
- cont X509_NAME_ENTRY *X509_NAME_get_entry(const X509_NAME *name, int loc);
+ const X509_NAME_ENTRY *X509_NAME_get_entry(const X509_NAME *name, int loc);
 
  Deprecated Functions:
 


### PR DESCRIPTION
Fixes a trivial typo in the prototype for `X509_NAME_get_entr`: s/cont/const/

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
