### PR TITLE
70-test_tls13ticket.t: No separate ecx disablable in 3.0

### DIFF
--- a/test/recipes/70-test_tls13ticket.t
+++ b/test/recipes/70-test_tls13ticket.t
@@ -15,8 +15,8 @@ setup("test_tls13ticket");
 plan skip_all => "needs TLSv1.3 enabled"
     if disabled("tls1_3");
 
-plan skip_all => "needs ECX enabled"
-    if disabled("ecx");
+plan skip_all => "needs EC enabled"
+    if disabled("ec");
 
 
 plan tests => 1;


### PR DESCRIPTION
There is no separate no-ecx configure option in 3.0. We have to use the ec disablable for the skip check.

Fixes CI regression - urgent.
