### PR TITLE
ossl_curve448_scalar_halve(): Fix -ansi build [3.5, 3.4, 3.0]

### DIFF
--- a/crypto/ec/curve448/scalar.c
+++ b/crypto/ec/curve448/scalar.c
@@ -210,10 +210,10 @@ void ossl_curve448_scalar_encode(unsigned char ser[C448_SCALAR_BYTES],
 void ossl_curve448_scalar_halve(curve448_scalar_t out, const curve448_scalar_t a)
 {
     c448_word_t mask = 0 - (a->limb[0] & 1);
-    mask = value_barrier_c448(mask);
     c448_dword_t chain = 0;
     unsigned int i;
 
+    mask = value_barrier_c448(mask);
     for (i = 0; i < C448_SCALAR_LIMBS; i++) {
         chain = (chain + a->limb[i]) + (sc_p->limb[i] & mask);
         out->limb[i] = (c448_word_t)chain;


### PR DESCRIPTION
Move statement after declarations.
Fixes 4247fb98def703bcc55952f17f426331cce08d09

Urgent CI fix