### PR TITLE
sock_read: check ret==0 before BIO_sock_should_retry()

### DIFF
--- a/crypto/bio/bss_sock.c
+++ b/crypto/bio/bss_sock.c
@@ -118,10 +118,10 @@ static int sock_read(BIO *b, char *out, int outl)
             ret = readsocket(b->num, out, outl);
         BIO_clear_retry_flags(b);
         if (ret <= 0) {
-            if (BIO_sock_should_retry(ret))
-                BIO_set_retry_read(b);
-            else if (ret == 0)
+            if (ret == 0)
                 b->flags |= BIO_FLAGS_IN_EOF;
+            else if (BIO_sock_should_retry(ret))
+                BIO_set_retry_read(b);
         }
     }
     return ret;


### PR DESCRIPTION
POSIX states errno is only valid when the return value indicates an error.  recv() sets errno only on -1; when it returns 0 (peer closed) errno is unspecified.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated

related to #30869
