### PR TITLE
[master] .github/workflows: remove `openssl-3.2` and `openssl-3.3` from CI jobs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -31,12 +31,6 @@ jobs:
             branch: '3.4',
             cppflags: 'CPPFLAGS=-ansi'
           }, {
-            branch: '3.3',
-            cppflags: 'CPPFLAGS=-ansi',
-          }, {
-            branch: '3.2',
-            cppflags: 'CPPFLAGS=-ansi'
-          }, {
             branch: '3.0',
             cppflags: 'CPPFLAGS=-ansi'
           }

--- a/.github/workflows/interop-tests.yml
+++ b/.github/workflows/interop-tests.yml
@@ -72,7 +72,6 @@ jobs:
           { openssl: 'openssl-3.6', openssh: 'openssl-3.6', openssl_config: 'no-docs'},
           { openssl: 'openssl-3.5', openssh: 'openssl-3.5', openssl_config: 'no-docs'},
           { openssl: 'openssl-3.4', openssh: 'openssl-3.4', openssl_config: 'no-docs'},
-          { openssl: 'openssl-3.3', openssh: 'openssl-3.3', openssl_config: 'no-docs'},
           { openssl: 'openssl-3.0', openssh: 'openssl-3.0', openssl_config: ''}
         ]
     runs-on: ubuntu-latest

--- a/.github/workflows/prov-compat-label.yml
+++ b/.github/workflows/prov-compat-label.yml
@@ -116,11 +116,6 @@ jobs:
             tgz: branch-3.0.tar.gz,
             extra_config: "",
           }, {
-            name: openssl-3.3,
-            dir: branch-3.3,
-            tgz: branch-3.3.tar.gz,
-            extra_config: "",
-          }, {
             name: openssl-3.4,
             dir: branch-3.4,
             tgz: branch-3.4.tar.gz,
@@ -210,7 +205,7 @@ jobs:
         # Note that releases are not used as a test environment for
         # later providers.  Problems in these situations ought to be
         # caught by cross branch testing before the release.
-        tree_a: [ branch-4.0, branch-3.6, branch-3.5, branch-3.4, branch-3.3, branch-3.0,
+        tree_a: [ branch-4.0, branch-3.6, branch-3.5, branch-3.4, branch-3.0,
                   openssl-3.0.0, openssl-3.0.8, openssl-3.0.9, openssl-3.1.2 ]
         tree_b: [ PR ]
         include:
@@ -224,8 +219,6 @@ jobs:
             tree_b: branch-3.5
           - tree_a: PR
             tree_b: branch-3.4
-          - tree_a: PR
-            tree_b: branch-3.3
           - tree_a: PR
             tree_b: branch-3.0
     steps:

--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -120,11 +120,6 @@ jobs:
             tgz: branch-3.0.tar.gz,
             extra_config: "",
           }, {
-            name: openssl-3.3,
-            dir: branch-3.3,
-            tgz: branch-3.3.tar.gz,
-            extra_config: "",
-          }, {
             name: openssl-3.4,
             dir: branch-3.4,
             tgz: branch-3.4.tar.gz,
@@ -219,10 +214,10 @@ jobs:
         # later providers.  Problems in these situations ought to be
         # caught by cross branch testing before the release.
         tree_a: [ branch-master, branch-4.0, branch-3.6, branch-3.5, branch-3.4,
-                  branch-3.3, branch-3.0,
+                  branch-3.0,
                   openssl-3.0.0, openssl-3.0.8, openssl-3.0.9, openssl-3.1.2 ]
         tree_b: [ branch-master, branch-4.0, branch-3.6, branch-3.5, branch-3.4,
-                  branch-3.3, branch-3.0  ]
+                  branch-3.0  ]
     steps:
       - name: early exit checks
         id: early_exit


### PR DESCRIPTION
These branches are EOL, so there is no need to keep running CI jobs for them.

This PR is for CI jobs in the `master` branch only, the CI jobs in stable branches that run on PRs/pushes also require similar updates, but need to be synced up with the `master` version first, so the update for them will be posted separately.