### PR TITLE
Add SSL_client_hello_get0_extensions() raw accessor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,12 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * Added SSL_client_hello_get0_extensions() to provide zero-copy access
+   to the raw extension bytes from a ClientHello message, complementing
+   the existing SSL_client_hello_get0_ciphers() and related functions.
+
+   *Sergei Khomenkov*
+
  * Improved DTLS handshake robustness under UDP reordering by buffering and
    replaying early ChangeCipherSpec (CCS) records at the expected state.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,8 @@ OpenSSL 4.1
 
 ### Major changes between OpenSSL 4.0 and OpenSSL 4.1 [under development]
 
+  * Added `SSL_client_hello_get0_extensions()` for zero-copy access to the
+    raw ClientHello extensions buffer during the client hello callback.
   * API calls `CRYPTO_atomic_load_ptr`, `CRYPTO_atomic_store_ptr`, and
     `CRYPTO_atomic_cmp_exch_ptr` have been added.
 

--- a/doc/man3/SSL_CTX_set_client_hello_cb.pod
+++ b/doc/man3/SSL_CTX_set_client_hello_cb.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-SSL_CTX_set_client_hello_cb, SSL_client_hello_cb_fn, SSL_client_hello_isv2, SSL_client_hello_get0_legacy_version, SSL_client_hello_get0_random, SSL_client_hello_get0_session_id, SSL_client_hello_get0_ciphers, SSL_client_hello_get0_compression_methods, SSL_client_hello_get1_extensions_present, SSL_client_hello_get_extension_order, SSL_client_hello_get0_ext - callback functions for early server-side ClientHello processing
+SSL_CTX_set_client_hello_cb, SSL_client_hello_cb_fn, SSL_client_hello_isv2, SSL_client_hello_get0_legacy_version, SSL_client_hello_get0_random, SSL_client_hello_get0_session_id, SSL_client_hello_get0_ciphers, SSL_client_hello_get0_compression_methods, SSL_client_hello_get0_extensions, SSL_client_hello_get1_extensions_present, SSL_client_hello_get_extension_order, SSL_client_hello_get0_ext - callback functions for early server-side ClientHello processing
 
 =head1 SYNOPSIS
 
@@ -15,6 +15,7 @@ SSL_CTX_set_client_hello_cb, SSL_client_hello_cb_fn, SSL_client_hello_isv2, SSL_
  size_t SSL_client_hello_get0_ciphers(SSL *s, const unsigned char **out);
  size_t SSL_client_hello_get0_compression_methods(SSL *s,
                                                   const unsigned char **out);
+ size_t SSL_client_hello_get0_extensions(SSL *s, const unsigned char **out);
  int SSL_client_hello_get1_extensions_present(SSL *s, int **out,
                                               size_t *outlen);
  int SSL_client_hello_get_extension_order(SSL *s, uint16_t *exts,
@@ -54,6 +55,18 @@ SSL_client_hello_get0_ciphers(), and
 SSL_client_hello_get0_compression_methods() provide access to the corresponding
 ClientHello fields, returning the field length and optionally setting an out
 pointer to the octets of that field.
+
+SSL_client_hello_get0_extensions() provides access to the raw extension
+bytes from the ClientHello, returning the total length and optionally
+setting an out pointer to the octets. The pointer returned via B<out> is
+valid only for the duration of the ClientHello callback; it must not be
+used after the callback returns. Unlike
+SSL_client_hello_get1_extensions_present(), this function returns all
+extensions as received on the wire, including any GREASE values and
+extension types not otherwise known to the library. The returned data
+uses the standard TLS extension wire format (a sequence of
+type(2 bytes), length(2 bytes), data(length bytes) entries). The
+2-byte total extensions length prefix is not included.
 
 Similarly, SSL_client_hello_get0_ext() provides access to individual extensions
 from the ClientHello on a per-extension basis.  For the provided wire
@@ -125,8 +138,8 @@ SSL_CLIENT_HELLO_RETRY to suspend processing.
 SSL_client_hello_isv2() returns 0.
 
 SSL_client_hello_get0_random(), SSL_client_hello_get0_session_id(),
-SSL_client_hello_get0_ciphers(), and
-SSL_client_hello_get0_compression_methods() return the length of the
+SSL_client_hello_get0_ciphers(), SSL_client_hello_get0_compression_methods(),
+and SSL_client_hello_get0_extensions() return the length of the
 corresponding ClientHello fields.  If zero is returned, the output pointer
 should not be assumed to be valid.
 
@@ -151,6 +164,8 @@ SSL_client_hello_get0_ext(), and SSL_client_hello_get1_extensions_present()
 were added in OpenSSL 1.1.1.
 SSL_client_hello_get_extension_order()
 was added in OpenSSL 3.2.0.
+SSL_client_hello_get0_extensions()
+was added in OpenSSL 4.1.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -1970,6 +1970,7 @@ size_t SSL_client_hello_get0_session_id(SSL *s, const unsigned char **out);
 size_t SSL_client_hello_get0_ciphers(SSL *s, const unsigned char **out);
 size_t SSL_client_hello_get0_compression_methods(SSL *s,
     const unsigned char **out);
+size_t SSL_client_hello_get0_extensions(SSL *s, const unsigned char **out);
 int SSL_client_hello_get1_extensions_present(SSL *s, int **out, size_t *outlen);
 int SSL_client_hello_get_extension_order(SSL *s, uint16_t *exts,
     size_t *num_exts);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7047,6 +7047,20 @@ size_t SSL_client_hello_get0_compression_methods(SSL *s, const unsigned char **o
     return sc->clienthello->compressions_len;
 }
 
+size_t SSL_client_hello_get0_extensions(SSL *s, const unsigned char **out)
+{
+    const SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    if (sc == NULL)
+        return 0;
+
+    if (sc->clienthello == NULL)
+        return 0;
+    if (out != NULL)
+        *out = PACKET_data(&sc->clienthello->extensions);
+    return PACKET_remaining(&sc->clienthello->extensions);
+}
+
 int SSL_client_hello_get1_extensions_present(SSL *s, int **out, size_t *outlen)
 {
     RAW_EXTENSION *ext;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -732,6 +732,12 @@ static int full_client_hello_callback(SSL *s, int *al, void *arg)
     int *ctr = arg;
     const unsigned char *p;
     int *exts;
+    const unsigned char *ext_data = NULL;
+    size_t ext_len, ext_len_null, ext_offset, ext_body_len;
+    unsigned int ext_type;
+    const unsigned char *single_ext_data = NULL;
+    size_t single_ext_len = 0;
+    int found_crosscheck;
 #ifdef OPENSSL_NO_EC
     const unsigned char expected_ciphers[] = { 0x00, 0x9d };
 #else
@@ -757,6 +763,52 @@ static int full_client_hello_callback(SSL *s, int *al, void *arg)
             SSL_client_hello_get0_compression_methods(s, &p), 1)
         || !TEST_int_eq(*p, 0))
         return SSL_CLIENT_HELLO_ERROR;
+
+    /* Test SSL_client_hello_get0_extensions: raw extension buffer */
+
+    /* Test out==NULL (length-only query) */
+    ext_len_null = SSL_client_hello_get0_extensions(s, NULL);
+    if (!TEST_size_t_gt(ext_len_null, 0))
+        return SSL_CLIENT_HELLO_ERROR;
+
+    ext_len = SSL_client_hello_get0_extensions(s, &ext_data);
+    if (!TEST_size_t_gt(ext_len, 0) || !TEST_ptr(ext_data))
+        return SSL_CLIENT_HELLO_ERROR;
+    if (!TEST_size_t_eq(ext_len_null, ext_len))
+        return SSL_CLIENT_HELLO_ERROR;
+
+    /*
+     * Walk all extensions to find one with non-zero body that is also
+     * recognized by SSL_client_hello_get0_ext, then cross-check its data.
+     */
+    ext_offset = 0;
+    found_crosscheck = 0;
+    while (ext_offset + 4 <= ext_len) {
+        ext_type = ((unsigned int)ext_data[ext_offset] << 8) | ext_data[ext_offset + 1];
+        ext_body_len = ((size_t)ext_data[ext_offset + 2] << 8)
+                       | ext_data[ext_offset + 3];
+        if (!TEST_size_t_le(ext_body_len, ext_len - ext_offset - 4))
+            return SSL_CLIENT_HELLO_ERROR;
+
+        if (ext_body_len > 0
+            && SSL_client_hello_get0_ext(s, ext_type,
+                                         &single_ext_data,
+                                         &single_ext_len) == 1) {
+            if (!TEST_size_t_eq(single_ext_len, ext_body_len))
+                return SSL_CLIENT_HELLO_ERROR;
+            if (!TEST_mem_eq(single_ext_data, single_ext_len,
+                             ext_data + ext_offset + 4, ext_body_len))
+                return SSL_CLIENT_HELLO_ERROR;
+            found_crosscheck = 1;
+            break;
+        }
+        ext_offset += 4 + ext_body_len;
+    }
+    if (!TEST_int_eq(found_crosscheck, 1)) {
+        TEST_info("No recognized non-zero-body extension found for cross-check");
+        return SSL_CLIENT_HELLO_ERROR;
+    }
+
     if (!SSL_client_hello_get1_extensions_present(s, &exts, &len))
         return SSL_CLIENT_HELLO_ERROR;
     if (len != OSSL_NELEM(expected_extensions) || memcmp(exts, expected_extensions, len * sizeof(*exts)) != 0) {

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -626,3 +626,4 @@ SSL_CTX_ech_set1_outer_alpn_protos      625	4_0_0	EXIST::FUNCTION:ECH
 SSL_set1_ech_config_list                626	4_0_0	EXIST::FUNCTION:ECH
 SSL_get0_sigalg                         627	4_0_0	EXIST::FUNCTION:
 SSL_get0_shared_sigalg                  628	4_0_0	EXIST::FUNCTION:
+SSL_client_hello_get0_extensions        ?	4_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
Fixes #30867

Add a zero-copy accessor for raw ClientHello extension bytes, completing
the `get0_*` accessor family alongside `get0_random`, `get0_session_id`,
`get0_ciphers`, and `get0_compression_methods`.

`SSL_client_hello_get1_extensions_present()` only returns extensions
recognized by `ext_defs[]`, omitting GREASE values and types unknown to
the library. The documentation itself notes this limitation. Meanwhile,
`SSL_client_hello_get0_ciphers()` returns raw cipher bytes including
GREASE -- there is no equivalent for extensions.

The new function follows the identical pattern of `get0_ciphers()`:
return a pointer into the PACKET buffer and the byte count. The pointer
is valid for the duration of `client_hello_cb`, matching the lifetime
semantics of the other `get0_*` accessors.

Related: #18286, #27580.

Tests added to the existing `full_client_hello_callback` in
`test/sslapitest.c`, including length-only query, TLV parsing, and
cross-check against `SSL_client_hello_get0_ext()`.

##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated