### PR TITLE
Fix memory leak in method store cache

### DIFF
--- a/crypto/hashtable/hashtable.c
+++ b/crypto/hashtable/hashtable.c
@@ -711,7 +711,7 @@ int ossl_ht_insert(HT *h, HT_KEY *key, HT_VALUE *data, HT_VALUE **olddata)
      */
     for (i = 0;
         (rc = ossl_ht_insert_locked(h, hash, newval, olddata)) == -1
-        && i < 4;
+        && i <= (int)NEIGHBORHOOD_LEN;
         ++i)
         if (!grow_hashtable(h, h->wpd.neighborhood_len)) {
             rc = -1;

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -1189,7 +1189,7 @@ int ossl_method_store_cache_get(OSSL_METHOD_STORE *store, OSSL_PROVIDER *prov,
         } else {
             HT_INIT_KEY_CACHED(&key, post_insert->generic_hash);
 
-            if (!ossl_ht_cache_QUERY_insert(sa->cache, TO_HT_KEY(&key), post_insert, NULL)) {
+            if (ossl_ht_cache_QUERY_insert(sa->cache, TO_HT_KEY(&key), post_insert, NULL) <= 0) {
                 /*
                  * We raced with another thread that added the same QUERY, pitch this one
                  */
@@ -1280,7 +1280,7 @@ static ossl_inline int ossl_method_store_cache_set_locked(OSSL_METHOD_STORE *sto
         if (!ossl_method_up_ref(&p->method))
             goto err;
 
-        if (!ossl_ht_cache_QUERY_insert(sa->cache, TO_HT_KEY(&key), p, &old)) {
+        if (ossl_ht_cache_QUERY_insert(sa->cache, TO_HT_KEY(&key), p, &old) <= 0) {
             impl_cache_free(p);
             goto err;
         }
@@ -1304,7 +1304,7 @@ static ossl_inline int ossl_method_store_cache_set_locked(OSSL_METHOD_STORE *sto
         ossl_list_lru_entry_init_elem(p);
         if (!ossl_method_up_ref(&p->method))
             goto err;
-        if (ossl_ht_cache_QUERY_insert(sa->cache, TO_HT_KEY(&key), p, NULL)) {
+        if (ossl_ht_cache_QUERY_insert(sa->cache, TO_HT_KEY(&key), p, NULL) > 0) {
             p->specific_hash = 0;
             p->generic_hash = old->generic_hash = HT_KEY_GET_HASH(&key);
             ossl_list_lru_entry_insert_tail(&sa->lru_list, p);


### PR DESCRIPTION
Function `ossl_ht_cache_QUERY_insert()` returns 1 on success and 0 on failure. However, it can also return -1 when there is not enough space in the hash table to add the entry. Not enough space can also mean that after growing the hash table 4 times the element would still to be added to a neighborhood that is already fully occupied.

Fix the return code checking to also treat -1 as a failure and thus free the element to-be-added also in this error cases to avoid a memory leak.

On s390x, the distribution of the hash values is different compared to other architectures, probably because of endianess and pointer alignment being different (the hash key contains pointer values and integers). This leads to the fact that `ossl_ht_cache_QUERY_insert()` is not able to add a query during the FIPS selftests, and thus triggers the memory leak.

Also increase the number of retries inside `ossl_ht_insert()` to at least the number elements per neighborhood plus 1. With this it is able to grow the hash table enough so that the queries used during the FIPS selftest can all be added to the hash table.

There is still no guarantee that the number of retries is enough for all possible queries. It can still happen that certain queries can't be added to the cache, even on other architectures. This does not really hurt, such queries will just not be cached and are freshly fetched again the next time. With the fix in `ossl_ht_cache_QUERY_insert()` this at least does not cause a memory leak anymore.

This fixes the memory leak reported in https://github.com/openssl/openssl/issues/30588 .