### PR TITLE
Fix some hash table return code and growth issues

### DIFF
--- a/crypto/hashtable/hashtable.c
+++ b/crypto/hashtable/hashtable.c
@@ -710,8 +710,7 @@ int ossl_ht_insert(HT *h, HT_KEY *key, HT_VALUE *data, HT_VALUE **olddata)
      * to the bucket list
      */
     for (i = 0;
-        (rc = ossl_ht_insert_locked(h, hash, newval, olddata)) == -1
-        && i < 4;
+        (rc = ossl_ht_insert_locked(h, hash, newval, olddata)) == -1 && i <= NEIGHBORHOOD_LEN;
         ++i)
         if (!grow_hashtable(h, h->wpd.neighborhood_len)) {
             rc = -1;

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -1189,7 +1189,7 @@ int ossl_method_store_cache_get(OSSL_METHOD_STORE *store, OSSL_PROVIDER *prov,
         } else {
             HT_INIT_KEY_CACHED(&key, post_insert->generic_hash);
 
-            if (!ossl_ht_cache_QUERY_insert(sa->cache, TO_HT_KEY(&key), post_insert, NULL)) {
+            if (ossl_ht_cache_QUERY_insert(sa->cache, TO_HT_KEY(&key), post_insert, NULL) <= 0) {
                 /*
                  * We raced with another thread that added the same QUERY, pitch this one
                  */
@@ -1280,7 +1280,7 @@ static ossl_inline int ossl_method_store_cache_set_locked(OSSL_METHOD_STORE *sto
         if (!ossl_method_up_ref(&p->method))
             goto err;
 
-        if (!ossl_ht_cache_QUERY_insert(sa->cache, TO_HT_KEY(&key), p, &old)) {
+        if (ossl_ht_cache_QUERY_insert(sa->cache, TO_HT_KEY(&key), p, &old) <= 0) {
             impl_cache_free(p);
             goto err;
         }
@@ -1304,7 +1304,7 @@ static ossl_inline int ossl_method_store_cache_set_locked(OSSL_METHOD_STORE *sto
         ossl_list_lru_entry_init_elem(p);
         if (!ossl_method_up_ref(&p->method))
             goto err;
-        if (ossl_ht_cache_QUERY_insert(sa->cache, TO_HT_KEY(&key), p, NULL)) {
+        if (ossl_ht_cache_QUERY_insert(sa->cache, TO_HT_KEY(&key), p, NULL) > 0) {
             p->specific_hash = 0;
             p->generic_hash = old->generic_hash = HT_KEY_GET_HASH(&key);
             ossl_list_lru_entry_insert_tail(&sa->lru_list, p);


### PR DESCRIPTION

@ifranzki noted in #30588 that if input buffers for key generation hash
    to simmilar values (i.e. low order bytes of the hash are simmilar), we
    frequently map to the same bucket in the hash table, and growing doesn't
    fix that until the neighborhood table mask grows larger than the
    neighborhood size.  As such we should grow at least NEIGHBORHOOD_LEN
    times before giving up.


fix return code checking on hash table
    
    The method store cache assumes that hashtable inserts return a boolean,
    but they can return negative values on failure as well, so we need to
    check for those.  Fix that here

