### PR TITLE
add --runtime-openssldir and --runtime-dir configure parameters

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -317,6 +317,16 @@ OPENSSLDIR={- #
                            : catdir($prefix, $config{openssldir}))
                       : catdir($prefix, "ssl");
               $openssldir -}
+RUNTIME_OPENSSLDIR={- # RUNTIME_OPENSSLDIR: the OPENSSLDIR path baked into the C binary.
+                      # When --runtime-openssldir is given this can differ from
+                      # OPENSSLDIR (which is used only for `make install`).
+                      our $runtime_openssldir =
+                          $config{runtime_openssldir} ?
+                              (file_name_is_absolute($config{runtime_openssldir}) ?
+                                   $config{runtime_openssldir}
+                                   : catdir($prefix, $config{runtime_openssldir}))
+                              : $openssldir;
+                      $runtime_openssldir -}
 LIBDIR={- our $libdir = $config{libdir};
           unless ($libdir) {
               $libdir = "lib$target{multilib}";
@@ -326,6 +336,18 @@ LIBDIR={- our $libdir = $config{libdir};
 libdir={- file_name_is_absolute($libdir)
           ? $libdir : '$(INSTALLTOP)/$(LIBDIR)' -}
 MODULESDIR=$(libdir)/ossl-modules
+# RUNTIMEDIR / runtimedir: runtime lib directory for module lookup.
+# --runtime-dir acts as a prefix (same semantics as --prefix); LIBDIR is
+# appended automatically.  MODULESDIR above is still used for `make install`;
+# RUNTIME_MODULESDIR is only passed as a -D flag baked into the binary.
+RUNTIMEDIR={- # When --runtime-dir is given LIBDIR is appended to form the
+               # runtime lib path.
+               our $runtime_dir = $config{runtime_dir}
+                   ? catdir($config{runtime_dir}, $libdir) : $libdir;
+               file_name_is_absolute($runtime_dir) ? "" : $runtime_dir -}
+runtimedir={- file_name_is_absolute($runtime_dir)
+               ? $runtime_dir : '$(INSTALLTOP)/$(RUNTIMEDIR)' -}
+RUNTIME_MODULESDIR=$(runtimedir)/ossl-modules
 
 # Convenience variable for those who want to set the rpath in shared
 # libraries and applications
@@ -440,8 +462,8 @@ LIB_CPPFLAGS={- our $lib_cppflags =
                           @{$config{shared_cppflag}});
                 join(' ', $lib_cppflags,
                           (map { '-D'.$_ }
-                               'OPENSSLDIR="\"$(OPENSSLDIR)\""',
-                               'MODULESDIR="\"$(MODULESDIR)\""'),
+                               'OPENSSLDIR="\"$(RUNTIME_OPENSSLDIR)\""',
+                               'MODULESDIR="\"$(RUNTIME_MODULESDIR)\""'),
                           '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
 LIB_CFLAGS={- join(' ', $target{lib_cflags} || (),
                         $target{shared_cflag} || (),

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -294,39 +294,39 @@ APPS_OPENSSL="{- use File::Spec::Functions;
 # Normally it is left empty.
 DESTDIR=
 
-# Do not edit these manually. Use Configure with --prefix or --openssldir
-# to change this!  Short explanation in the top comment in Configure
-INSTALLTOP={- # $prefix is used in the OPENSSLDIR perl snippet
-	      #
+# Do not edit these manually. Use Configure with --prefix, --openssldir, or
+# --install-prefix to change this!  Short explanation in the top comment in Configure
+INSTALLTOP={- # $prefix: runtime base baked into binaries.
+              # When --install-prefix is given, INSTALLTOP points to the
+              # staging/sandbox area for `make install` while $prefix retains
+              # its role as the runtime base.
 	      our $prefix = $config{prefix} || "/usr/local";
-              $prefix -}
-OPENSSLDIR={- #
-	      # The logic here is that if no --openssldir was given,
-	      # OPENSSLDIR will get the value from $prefix plus "/ssl".
-	      # If --openssldir was given and the value is an absolute
-	      # path, OPENSSLDIR will get its value without change.
-	      # If the value from --openssldir is a relative path,
-	      # OPENSSLDIR will get $prefix with the --openssldir
-	      # value appended as a subdirectory.
-	      #
+              $config{install_prefix} || $prefix -}
+OPENSSLDIR={- # OPENSSLDIR is the install destination for config files.
+              # When --install-prefix is given, it is derived from that value;
+              # otherwise it matches the baked path (BAKED_OPENSSLDIR).
+              #
+              # The logic for the install path:
+              #   no --openssldir:   install_base/ssl
+              #   relative --openssldir: install_base/openssldir
+              #   absolute --openssldir: openssldir unchanged
+              # where install_base is --install-prefix if given, else --prefix.
               use File::Spec::Functions;
+              our $install_base = $config{install_prefix} || $prefix;
               our $openssldir =
                   $config{openssldir} ?
                       (file_name_is_absolute($config{openssldir}) ?
                            $config{openssldir}
-                           : catdir($prefix, $config{openssldir}))
-                      : catdir($prefix, "ssl");
+                           : catdir($install_base, $config{openssldir}))
+                      : catdir($install_base, "ssl");
               $openssldir -}
-RUNTIME_OPENSSLDIR={- # RUNTIME_OPENSSLDIR: the OPENSSLDIR path baked into the C binary.
-                      # When --runtime-openssldir is given this can differ from
-                      # OPENSSLDIR (which is used only for `make install`).
-                      our $runtime_openssldir =
-                          $config{runtime_openssldir} ?
-                              (file_name_is_absolute($config{runtime_openssldir}) ?
-                                   $config{runtime_openssldir}
-                                   : catdir($prefix, $config{runtime_openssldir}))
-                              : $openssldir;
-                      $runtime_openssldir -}
+BAKED_OPENSSLDIR={- # Path baked into the binary for config file lookup.
+                    # Always derived from --prefix (the runtime location).
+                    $config{openssldir} ?
+                        (file_name_is_absolute($config{openssldir}) ?
+                             $config{openssldir}
+                             : catdir($prefix, $config{openssldir}))
+                        : catdir($prefix, "ssl") -}
 LIBDIR={- our $libdir = $config{libdir};
           unless ($libdir) {
               $libdir = "lib$target{multilib}";
@@ -336,18 +336,11 @@ LIBDIR={- our $libdir = $config{libdir};
 libdir={- file_name_is_absolute($libdir)
           ? $libdir : '$(INSTALLTOP)/$(LIBDIR)' -}
 MODULESDIR=$(libdir)/ossl-modules
-# RUNTIMEDIR / runtimedir: runtime lib directory for module lookup.
-# --runtime-dir acts as a prefix (same semantics as --prefix); LIBDIR is
-# appended automatically.  MODULESDIR above is still used for `make install`;
-# RUNTIME_MODULESDIR is only passed as a -D flag baked into the binary.
-RUNTIMEDIR={- # When --runtime-dir is given LIBDIR is appended to form the
-               # runtime lib path.
-               our $runtime_dir = $config{runtime_dir}
-                   ? catdir($config{runtime_dir}, $libdir) : $libdir;
-               file_name_is_absolute($runtime_dir) ? "" : $runtime_dir -}
-runtimedir={- file_name_is_absolute($runtime_dir)
-               ? $runtime_dir : '$(INSTALLTOP)/$(RUNTIMEDIR)' -}
-RUNTIME_MODULESDIR=$(runtimedir)/ossl-modules
+BAKED_MODULESDIR={- # Path baked into the binary for provider module lookup.
+                    # Always derived from --prefix (the runtime location).
+                    file_name_is_absolute($libdir)
+                        ? catdir($libdir, "ossl-modules")
+                        : catdir($prefix, $libdir, "ossl-modules") -}
 
 # Convenience variable for those who want to set the rpath in shared
 # libraries and applications
@@ -462,8 +455,8 @@ LIB_CPPFLAGS={- our $lib_cppflags =
                           @{$config{shared_cppflag}});
                 join(' ', $lib_cppflags,
                           (map { '-D'.$_ }
-                               'OPENSSLDIR="\"$(RUNTIME_OPENSSLDIR)\""',
-                               'MODULESDIR="\"$(RUNTIME_MODULESDIR)\""'),
+                               'OPENSSLDIR="\"$(BAKED_OPENSSLDIR)\""',
+                               'MODULESDIR="\"$(BAKED_MODULESDIR)\""'),
                           '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
 LIB_CFLAGS={- join(' ', $target{lib_cflags} || (),
                         $target{shared_cflag} || (),

--- a/Configure
+++ b/Configure
@@ -27,7 +27,7 @@ use OpenSSL::config;
 my $orig_death_handler = $SIG{__DIE__};
 $SIG{__DIE__} = \&death_handler;
 
-my $usage="Usage: Configure [no-<feature> ...] [enable-<feature> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]thread-pool] [[no-]default-thread-pool] [[no-]shared] [[no-]zlib|zlib-dynamic] [no-asm] [no-egd] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--with-xxx[=vvv]] [--config=FILE] [--help] os/compiler[:flags]\n";
+my $usage="Usage: Configure [no-<feature> ...] [enable-<feature> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]thread-pool] [[no-]default-thread-pool] [[no-]shared] [[no-]zlib|zlib-dynamic] [no-asm] [no-egd] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--install-prefix=DIR] [--with-xxx[=vvv]] [--config=FILE] [--help] os/compiler[:flags]\n";
 
 my $banner = <<"EOF";
 
@@ -54,24 +54,26 @@ EOF
 #               directory as this script.
 # --prefix      prefix for the OpenSSL installation, which includes the
 #               directories bin, lib, include, share/man, share/doc/openssl
-#               This becomes the value of INSTALLTOP in Makefile
+#               This becomes the value of INSTALLTOP in Makefile and is also
+#               the base for paths baked into compiled binaries (OPENSSLDIR,
+#               MODULESDIR).
 #               (Default: /usr/local)
 # --openssldir  OpenSSL data area, such as openssl.cnf, certificates and keys.
 #               If it's a relative directory, it will be added on the directory
 #               given with --prefix.
 #               This becomes the value of OPENSSLDIR in Makefile and in C.
 #               (Default: PREFIX/ssl)
-# --runtime-openssldir
-#               Runtime path for OpenSSL configuration files (openssl.cnf,
-#               certs/, etc.).  Sets OPENSSLDIR in the C binary only; the
-#               Makefile's OPENSSLDIR (used for `make install`) is still
-#               derived from --openssldir / PREFIX/ssl.
-#               Follows the same absolute/relative rules as --openssldir.
-#               (Default: same as OPENSSLDIR)
-# --runtime-dir Runtime prefix for the modules directory.  LIBDIR is
-#               appended to compute MODULESDIR in the C binary.
-#               (Default: same as PREFIX, i.e. LIBDIR is appended as for
-#               install paths)
+# --install-prefix
+#               Override the installation base used by `make install`, while
+#               keeping --prefix as the path baked into compiled binaries.
+#               Useful when building for a target system: set --prefix to the
+#               final runtime location (e.g. /usr/local) and --install-prefix
+#               to a staging area or build sandbox; `make install` places files
+#               under the staging area, but the binaries encode the final paths.
+#               Relative --openssldir is interpreted relative to --install-prefix
+#               for installation and relative to --prefix for the baked value.
+#               Must be an absolute path.
+#               (Default: same as --prefix)
 # --banner=".." Output specified text instead of default completion banner
 #
 # -w            Don't wait after showing a Configure warning
@@ -419,6 +421,7 @@ $config{perl_archname} = $Config{archname};
 
 $config{prefix}="";
 $config{openssldir}="";
+$config{install_prefix}="";
 $config{processor}="";
 $config{libdir}="";
 my $auto_threads=1;    # enable threads automatically? true by default
@@ -1077,13 +1080,9 @@ while (@argvcopy)
                         {
                         $config{openssldir}=$1;
                         }
-                elsif (/^--runtime-openssldir=(.*)$/)
+                elsif (/^--install-prefix=(.*)$/)
                         {
-                        $config{runtime_openssldir}=$1;
-                        }
-                elsif (/^--runtime-dir=(.*)$/)
-                        {
-                        $config{runtime_dir}=$1;
+                        $config{install_prefix}=$1;
                         }
                 elsif (/^--with-jitter-include=(.*)$/)
                         {
@@ -1559,6 +1558,11 @@ foreach (keys %useradd) {
 if ($config{prefix} && !$config{CROSS_COMPILE}) {
     die "Directory given with --prefix MUST be absolute\n"
         unless file_name_is_absolute($config{prefix});
+}
+
+if ($config{install_prefix} && !$config{CROSS_COMPILE}) {
+    die "Directory given with --install-prefix MUST be absolute\n"
+        unless file_name_is_absolute($config{install_prefix});
 }
 
 if (grep { $_ =~ /(?:^|\s)-static(?:\s|$)/ } @{$config{LDFLAGS}}) {

--- a/Configure
+++ b/Configure
@@ -61,6 +61,17 @@ EOF
 #               given with --prefix.
 #               This becomes the value of OPENSSLDIR in Makefile and in C.
 #               (Default: PREFIX/ssl)
+# --runtime-openssldir
+#               Runtime path for OpenSSL configuration files (openssl.cnf,
+#               certs/, etc.).  Sets OPENSSLDIR in the C binary only; the
+#               Makefile's OPENSSLDIR (used for `make install`) is still
+#               derived from --openssldir / PREFIX/ssl.
+#               Follows the same absolute/relative rules as --openssldir.
+#               (Default: same as OPENSSLDIR)
+# --runtime-dir Runtime prefix for the modules directory.  LIBDIR is
+#               appended to compute MODULESDIR in the C binary.
+#               (Default: same as PREFIX, i.e. LIBDIR is appended as for
+#               install paths)
 # --banner=".." Output specified text instead of default completion banner
 #
 # -w            Don't wait after showing a Configure warning
@@ -1065,6 +1076,14 @@ while (@argvcopy)
                 elsif (/^--openssldir=(.*)$/)
                         {
                         $config{openssldir}=$1;
+                        }
+                elsif (/^--runtime-openssldir=(.*)$/)
+                        {
+                        $config{runtime_openssldir}=$1;
+                        }
+                elsif (/^--runtime-dir=(.*)$/)
+                        {
+                        $config{runtime_dir}=$1;
                         }
                 elsif (/^--with-jitter-include=(.*)$/)
                         {


### PR DESCRIPTION
These allow decoupling the paths baked into the binary from the installation prefix used at build time.  

The usecase is building OpenSSL with Bazel/rules_foreign_cc: the sandbox prefix is a temporary directory, so OPENSSLDIR and MODULESDIR would otherwise point at paths that no longer exist at runtime.

Enviroment variables could be an option, but it's not as convenient as having the info embedded in the binary.
In a way, this attempt to replicate the build & install directories split that's available on windows through the registry.

The new options keep the Makefile's OPENSSLDIR / MODULESDIR unchanged (so `make install` still creates directories under the sandbox prefix) while routing new RUNTIME_* variants into the -D compile flags that get baked into the binary.

Passing only --openssldir / --libdir continues to work exactly as before.

Since I'm not sure this is something that you could agree with, I kept the changes to a minimum, ie not much doc and no tests (although I tested the change with our bazel builds and it appears to work as intended)
I'll happily do that (with a bit of guidance) if you think this change is something you could accept.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
