### PR TITLE
Use EVP_MD_fetch() in X509/TLS digest lookups to support provider-only digests

### DIFF
--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -211,9 +211,11 @@ int X509_get_signature_info(const X509 *x, int *mdnid, int *pknid, int *secbits,
 
 /* Modify *siginf according to alg and sig. Return 1 on success, else 0. */
 static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
-    const ASN1_STRING *sig, const EVP_PKEY *pubkey)
+    const ASN1_STRING *sig, const EVP_PKEY *pubkey,
+    OSSL_LIB_CTX *libctx, const char *propq)
 {
     int pknid, mdnid, md_size;
+    EVP_MD *fetched_md = NULL;
     const EVP_MD *md;
     const EVP_PKEY_ASN1_METHOD *ameth;
 
@@ -276,11 +278,19 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
         break;
     default:
         /* Security bits: half number of bits in digest */
-        if ((md = EVP_get_digestbynid(mdnid)) == NULL) {
+        ERR_set_mark();
+        fetched_md = EVP_MD_fetch(libctx, OBJ_nid2sn(mdnid), propq);
+        if (fetched_md != NULL)
+            md = fetched_md;
+        else
+            md = EVP_get_digestbynid(mdnid);
+        ERR_pop_to_mark();
+        if (md == NULL) {
             ERR_raise(ERR_LIB_X509, X509_R_ERROR_GETTING_MD_BY_NID);
             return 0;
         }
         md_size = EVP_MD_get_size(md);
+        EVP_MD_free(fetched_md);
         if (md_size <= 0)
             return 0;
         siginf->secbits = md_size * 4;
@@ -301,5 +311,5 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
 int ossl_x509_init_sig_info(const X509 *x, X509_SIG_INFO *info)
 {
     return x509_sig_info_init(info, &x->sig_alg, &x->signature,
-        X509_PUBKEY_get0(x->cert_info.key));
+        X509_PUBKEY_get0(x->cert_info.key), x->libctx, x->propq);
 }

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -215,8 +215,7 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
     OSSL_LIB_CTX *libctx, const char *propq)
 {
     int pknid, mdnid, md_size;
-    EVP_MD *fetched_md = NULL;
-    const EVP_MD *md;
+    EVP_MD *md;
     const EVP_PKEY_ASN1_METHOD *ameth;
 
     siginf->mdnid = NID_undef;
@@ -278,19 +277,14 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
         break;
     default:
         /* Security bits: half number of bits in digest */
-        ERR_set_mark();
-        fetched_md = EVP_MD_fetch(libctx, OBJ_nid2sn(mdnid), propq);
-        if (fetched_md != NULL)
-            md = fetched_md;
-        else
-            md = EVP_get_digestbynid(mdnid);
-        ERR_pop_to_mark();
+        md = EVP_MD_fetch(libctx, OBJ_nid2sn(mdnid), propq);
         if (md == NULL) {
-            ERR_raise(ERR_LIB_X509, X509_R_ERROR_GETTING_MD_BY_NID);
+            ERR_raise_data(ERR_LIB_X509, X509_R_ERROR_GETTING_MD_BY_NID,
+                "nid=%d name=%s", mdnid, OBJ_nid2sn(mdnid));
             return 0;
         }
         md_size = EVP_MD_get_size(md);
-        EVP_MD_free(fetched_md);
+        EVP_MD_free(md);
         if (md_size <= 0)
             return 0;
         siginf->secbits = md_size * 4;

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -277,11 +277,20 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
         break;
     default:
         /* Security bits: half number of bits in digest */
-        md = EVP_MD_fetch(libctx, OBJ_nid2sn(mdnid), propq);
-        if (md == NULL) {
-            ERR_raise_data(ERR_LIB_X509, X509_R_ERROR_GETTING_MD_BY_NID,
-                "nid=%d name=%s", mdnid, OBJ_nid2sn(mdnid));
-            return 0;
+        {
+            const char *md_name = OBJ_nid2sn(mdnid);
+
+            if (md_name == NULL) {
+                ERR_raise_data(ERR_LIB_X509, X509_R_ERROR_GETTING_MD_BY_NID,
+                    "nid=%d", mdnid);
+                return 0;
+            }
+            md = EVP_MD_fetch(libctx, md_name, propq);
+            if (md == NULL) {
+                ERR_raise_data(ERR_LIB_X509, X509_R_ERROR_GETTING_MD_BY_NID,
+                    "nid=%d name=%s", mdnid, md_name);
+                return 0;
+            }
         }
         md_size = EVP_MD_get_size(md);
         EVP_MD_free(md);

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -278,9 +278,11 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
     default:
         /* Security bits: half number of bits in digest */
         {
-            const char *md_name = OBJ_nid2sn(mdnid);
+            char md_name[80];
+            ASN1_OBJECT *md_obj = OBJ_nid2obj(mdnid);
 
-            if (md_name == NULL) {
+            if (md_obj == NULL
+                || i2t_ASN1_OBJECT(md_name, sizeof(md_name), md_obj) <= 0) {
                 ERR_raise_data(ERR_LIB_X509, X509_R_ERROR_GETTING_MD_BY_NID,
                     "nid=%d", mdnid);
                 return 0;

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1318,9 +1318,9 @@ static int check_cert_ocsp_resp(X509_STORE_CTX *ctx)
         sr_cert_id = (OCSP_CERTID *)OCSP_SINGLERESP_get0_id(sr);
         OCSP_id_get0_info(NULL, &cert_id_md_oid, NULL, NULL, sr_cert_id);
         if (cert_id_md_oid != NULL) {
-            const char *md_name = OBJ_nid2sn(OBJ_obj2nid(cert_id_md_oid));
+            char md_name[80];
 
-            if (md_name != NULL)
+            if (i2t_ASN1_OBJECT(md_name, sizeof(md_name), cert_id_md_oid) > 0)
                 cert_id_md = EVP_MD_fetch(ctx->libctx, md_name, ctx->propq);
         }
 

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1285,7 +1285,6 @@ static int check_cert_ocsp_resp(X509_STORE_CTX *ctx)
     ASN1_GENERALIZEDTIME *rev, *thisupd, *nextupd;
     ASN1_OBJECT *cert_id_md_oid;
     EVP_MD *cert_id_md = NULL;
-    EVP_MD *fetched_cert_id_md = NULL;
     OCSP_CERTID *cert_id = NULL;
     int ret = V_OCSP_CERTSTATUS_UNKNOWN;
     int num;
@@ -1318,24 +1317,17 @@ static int check_cert_ocsp_resp(X509_STORE_CTX *ctx)
         /* determine the md algorithm which was used to create cert id */
         sr_cert_id = (OCSP_CERTID *)OCSP_SINGLERESP_get0_id(sr);
         OCSP_id_get0_info(NULL, &cert_id_md_oid, NULL, NULL, sr_cert_id);
-        if (cert_id_md_oid != NULL) {
-            ERR_set_mark();
-            fetched_cert_id_md = EVP_MD_fetch(ctx->libctx,
+        if (cert_id_md_oid != NULL)
+            cert_id_md = EVP_MD_fetch(ctx->libctx,
                 OBJ_nid2sn(OBJ_obj2nid(cert_id_md_oid)),
                 ctx->propq);
-            if (fetched_cert_id_md != NULL)
-                cert_id_md = fetched_cert_id_md;
-            else
-                cert_id_md = (EVP_MD *)EVP_get_digestbyobj(cert_id_md_oid);
-            ERR_pop_to_mark();
-        } else {
+        else
             cert_id_md = NULL;
-        }
 
         /* search the stack for the requested OCSP response */
         cert_id = OCSP_cert_to_id(cert_id_md, ctx->current_cert, ctx->current_issuer);
-        EVP_MD_free(fetched_cert_id_md);
-        fetched_cert_id_md = NULL;
+        EVP_MD_free(cert_id_md);
+        cert_id_md = NULL;
         if (cert_id == NULL) {
             ret = X509_V_ERR_OCSP_RESP_INVALID;
             goto end;

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1321,8 +1321,8 @@ static int check_cert_ocsp_resp(X509_STORE_CTX *ctx)
         if (cert_id_md_oid != NULL) {
             ERR_set_mark();
             fetched_cert_id_md = EVP_MD_fetch(ctx->libctx,
-                                              OBJ_nid2sn(OBJ_obj2nid(cert_id_md_oid)),
-                                              ctx->propq);
+                OBJ_nid2sn(OBJ_obj2nid(cert_id_md_oid)),
+                ctx->propq);
             if (fetched_cert_id_md != NULL)
                 cert_id_md = fetched_cert_id_md;
             else

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1317,12 +1317,12 @@ static int check_cert_ocsp_resp(X509_STORE_CTX *ctx)
         /* determine the md algorithm which was used to create cert id */
         sr_cert_id = (OCSP_CERTID *)OCSP_SINGLERESP_get0_id(sr);
         OCSP_id_get0_info(NULL, &cert_id_md_oid, NULL, NULL, sr_cert_id);
-        if (cert_id_md_oid != NULL)
-            cert_id_md = EVP_MD_fetch(ctx->libctx,
-                OBJ_nid2sn(OBJ_obj2nid(cert_id_md_oid)),
-                ctx->propq);
-        else
-            cert_id_md = NULL;
+        if (cert_id_md_oid != NULL) {
+            const char *md_name = OBJ_nid2sn(OBJ_obj2nid(cert_id_md_oid));
+
+            if (md_name != NULL)
+                cert_id_md = EVP_MD_fetch(ctx->libctx, md_name, ctx->propq);
+        }
 
         /* search the stack for the requested OCSP response */
         cert_id = OCSP_cert_to_id(cert_id_md, ctx->current_cert, ctx->current_issuer);

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1284,7 +1284,8 @@ static int check_cert_ocsp_resp(X509_STORE_CTX *ctx)
     OCSP_CERTID *sr_cert_id = NULL;
     ASN1_GENERALIZEDTIME *rev, *thisupd, *nextupd;
     ASN1_OBJECT *cert_id_md_oid;
-    EVP_MD *cert_id_md;
+    EVP_MD *cert_id_md = NULL;
+    EVP_MD *fetched_cert_id_md = NULL;
     OCSP_CERTID *cert_id = NULL;
     int ret = V_OCSP_CERTSTATUS_UNKNOWN;
     int num;
@@ -1317,13 +1318,24 @@ static int check_cert_ocsp_resp(X509_STORE_CTX *ctx)
         /* determine the md algorithm which was used to create cert id */
         sr_cert_id = (OCSP_CERTID *)OCSP_SINGLERESP_get0_id(sr);
         OCSP_id_get0_info(NULL, &cert_id_md_oid, NULL, NULL, sr_cert_id);
-        if (cert_id_md_oid != NULL)
-            cert_id_md = (EVP_MD *)EVP_get_digestbyobj(cert_id_md_oid);
-        else
+        if (cert_id_md_oid != NULL) {
+            ERR_set_mark();
+            fetched_cert_id_md = EVP_MD_fetch(ctx->libctx,
+                                              OBJ_nid2sn(OBJ_obj2nid(cert_id_md_oid)),
+                                              ctx->propq);
+            if (fetched_cert_id_md != NULL)
+                cert_id_md = fetched_cert_id_md;
+            else
+                cert_id_md = (EVP_MD *)EVP_get_digestbyobj(cert_id_md_oid);
+            ERR_pop_to_mark();
+        } else {
             cert_id_md = NULL;
+        }
 
         /* search the stack for the requested OCSP response */
         cert_id = OCSP_cert_to_id(cert_id_md, ctx->current_cert, ctx->current_issuer);
+        EVP_MD_free(fetched_cert_id_md);
+        fetched_cert_id_md = NULL;
         if (cert_id == NULL) {
             ret = X509_V_ERR_OCSP_RESP_INVALID;
             goto end;

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -3752,11 +3752,7 @@ static int tls_construct_cke_gost(SSL_CONNECTION *s, WPACKET *pkt)
      * data
      */
     ukm_hash = EVP_MD_CTX_new();
-    ERR_set_mark();
     ukm_md = EVP_MD_fetch(sctx->libctx, OBJ_nid2sn(dgst_nid), sctx->propq);
-    if (ukm_md == NULL)
-        ukm_md = (EVP_MD *)EVP_get_digestbynid(dgst_nid);
-    ERR_pop_to_mark();
     if (ukm_hash == NULL
         || ukm_md == NULL
         || EVP_DigestInit_ex(ukm_hash, ukm_md, NULL) <= 0

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -3701,6 +3701,7 @@ static int tls_construct_cke_gost(SSL_CONNECTION *s, WPACKET *pkt)
     unsigned int md_len;
     unsigned char shared_ukm[32], tmp[256];
     EVP_MD_CTX *ukm_hash = NULL;
+    EVP_MD *ukm_md = NULL;
     int dgst_nid = NID_id_GostR3411_94;
     unsigned char *pms = NULL;
     size_t pmslen = 0;
@@ -3751,8 +3752,14 @@ static int tls_construct_cke_gost(SSL_CONNECTION *s, WPACKET *pkt)
      * data
      */
     ukm_hash = EVP_MD_CTX_new();
+    ERR_set_mark();
+    ukm_md = EVP_MD_fetch(sctx->libctx, OBJ_nid2sn(dgst_nid), sctx->propq);
+    if (ukm_md == NULL)
+        ukm_md = (EVP_MD *)EVP_get_digestbynid(dgst_nid);
+    ERR_pop_to_mark();
     if (ukm_hash == NULL
-        || EVP_DigestInit(ukm_hash, EVP_get_digestbynid(dgst_nid)) <= 0
+        || ukm_md == NULL
+        || EVP_DigestInit_ex(ukm_hash, ukm_md, NULL) <= 0
         || EVP_DigestUpdate(ukm_hash, s->s3.client_random,
                SSL3_RANDOM_SIZE)
             <= 0
@@ -3760,9 +3767,12 @@ static int tls_construct_cke_gost(SSL_CONNECTION *s, WPACKET *pkt)
                SSL3_RANDOM_SIZE)
             <= 0
         || EVP_DigestFinal_ex(ukm_hash, shared_ukm, &md_len) <= 0) {
+        EVP_MD_free(ukm_md);
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;
     }
+    EVP_MD_free(ukm_md);
+    ukm_md = NULL;
     EVP_MD_CTX_free(ukm_hash);
     ukm_hash = NULL;
     if (EVP_PKEY_CTX_ctrl(pkey_ctx, -1, EVP_PKEY_OP_ENCRYPT,


### PR DESCRIPTION
Some code paths in X509 signature info, the GOST TLS handshake, and OCSP cert ID matching still call EVP_get_digestbynid() or EVP_get_digestbyobj(), which only searches the legacy built-in table and silently fails for provider-only digests even when the provider is loaded and the digest is fetchable. This replaces those calls with EVP_MD_fetch() (using the available libctx/propq), falling back to the legacy lookup when the fetch returns NULL so existing behaviour is preserved. x509_sig_info_init() picks up two new parameters that its caller already has from the X509 struct. Fixes #30604