### PR TITLE
Fix property method cache insert failure handling

### DIFF
--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -255,6 +255,14 @@ static void impl_free(IMPLEMENTATION *impl)
     }
 }
 
+static ossl_inline void impl_cache_free_unlinked(QUERY *elem)
+{
+    if (elem != NULL) {
+        ossl_method_free(&elem->method);
+        OPENSSL_free(elem);
+    }
+}
+
 static ossl_inline void impl_cache_free(QUERY *elem)
 {
     if (elem != NULL) {
@@ -266,8 +274,7 @@ static ossl_inline void impl_cache_free(QUERY *elem)
 #else
         ossl_list_lru_entry_remove(&sa->lru_list, elem);
 #endif
-        ossl_method_free(&elem->method);
-        OPENSSL_free(elem);
+        impl_cache_free_unlinked(elem);
     }
 }
 
@@ -1120,7 +1127,7 @@ static ossl_inline int ossl_method_store_cache_get_locked(OSSL_METHOD_STORE *sto
                  * owns it as well
                  */
                 if (!ossl_method_up_ref(&r->method)) {
-                    impl_cache_free(r);
+                    OPENSSL_free(r);
                     r = NULL;
                 }
                 /*
@@ -1140,6 +1147,9 @@ static ossl_inline int ossl_method_store_cache_get_locked(OSSL_METHOD_STORE *sto
     if (ossl_method_up_ref(&r->method)) {
         *method = r->method.method;
         res = 1;
+    } else if (*post_insert == r) {
+        impl_cache_free_unlinked(r);
+        *post_insert = NULL;
     }
 err:
 #ifndef ALLOW_VLA
@@ -1183,17 +1193,25 @@ int ossl_method_store_cache_get(OSSL_METHOD_STORE *store, OSSL_PROVIDER *prov,
 
     if (ret == 1 && post_insert != NULL) {
         if (!ossl_property_write_lock(sa)) {
-            impl_cache_free(post_insert);
+            ossl_method_free(&post_insert->method);
+            impl_cache_free_unlinked(post_insert);
             *method = NULL;
             ret = 0;
         } else {
+            int insert_rc;
+
             HT_INIT_KEY_CACHED(&key, post_insert->generic_hash);
 
-            if (!ossl_ht_cache_QUERY_insert(sa->cache, TO_HT_KEY(&key), post_insert, NULL)) {
+            insert_rc = ossl_ht_cache_QUERY_insert(sa->cache, TO_HT_KEY(&key),
+                post_insert, NULL);
+            if (insert_rc != 1) {
                 /*
-                 * We raced with another thread that added the same QUERY, pitch this one
+                 * Another thread may have inserted the same QUERY, or the
+                 * hash table insertion itself may have failed. Drop this
+                 * pending entry and the caller-visible method reference.
                  */
-                impl_cache_free(post_insert);
+                ossl_method_free(&post_insert->method);
+                impl_cache_free_unlinked(post_insert);
                 *method = NULL;
                 ret = 0;
             } else {
@@ -1214,6 +1232,7 @@ static ossl_inline int ossl_method_store_cache_set_locked(OSSL_METHOD_STORE *sto
     ALGORITHM *alg;
     QUERY_KEY key;
     int res = 1;
+    int insert_rc;
     size_t cullcount;
 #ifdef ALLOW_VLA
     uint8_t keybuf[keylen];
@@ -1280,8 +1299,11 @@ static ossl_inline int ossl_method_store_cache_set_locked(OSSL_METHOD_STORE *sto
         if (!ossl_method_up_ref(&p->method))
             goto err;
 
-        if (!ossl_ht_cache_QUERY_insert(sa->cache, TO_HT_KEY(&key), p, &old)) {
-            impl_cache_free(p);
+        insert_rc = ossl_ht_cache_QUERY_insert(sa->cache, TO_HT_KEY(&key), p,
+            &old);
+        if (insert_rc != 1) {
+            impl_cache_free_unlinked(p);
+            p = NULL;
             goto err;
         }
         p->specific_hash = HT_KEY_GET_HASH(&key);
@@ -1304,12 +1326,14 @@ static ossl_inline int ossl_method_store_cache_set_locked(OSSL_METHOD_STORE *sto
         ossl_list_lru_entry_init_elem(p);
         if (!ossl_method_up_ref(&p->method))
             goto err;
-        if (ossl_ht_cache_QUERY_insert(sa->cache, TO_HT_KEY(&key), p, NULL)) {
+        insert_rc = ossl_ht_cache_QUERY_insert(sa->cache, TO_HT_KEY(&key), p,
+            NULL);
+        if (insert_rc == 1) {
             p->specific_hash = 0;
             p->generic_hash = old->generic_hash = HT_KEY_GET_HASH(&key);
             ossl_list_lru_entry_insert_tail(&sa->lru_list, p);
         } else {
-            impl_cache_free(p);
+            impl_cache_free_unlinked(p);
             p = NULL;
             goto err;
         }

--- a/include/internal/hashtable.h
+++ b/include/internal/hashtable.h
@@ -398,7 +398,9 @@ int ossl_ht_flush(HT *htable);
 /*
  * Inserts an element to a hash table, optionally returning
  * replaced data to caller
- * Returns 1 if the insert was successful, 0 on error
+ * Returns 1 if the insert was successful, 0 on duplicate without
+ * replacement, invalid input, or another non-allocation failure, and -1
+ * on allocation failure or if the table could not be grown.
  */
 int ossl_ht_insert(HT *htable, HT_KEY *key, HT_VALUE *data,
     HT_VALUE **olddata);

--- a/test/build.info
+++ b/test/build.info
@@ -82,7 +82,7 @@ IF[{- !$disabled{tests} -}]
   ENDIF
 
   IF[{- !$disabled{'allocfail-tests'} -}]
-    PROGRAMS{noinst}=handshake-memfail x509-memfail load_key_certs_crls_memfail
+    PROGRAMS{noinst}=handshake-memfail x509-memfail load_key_certs_crls_memfail property-memfail
   ENDIF
 
   IF[{- !$disabled{quic} -}]
@@ -632,6 +632,10 @@ IF[{- !$disabled{tests} -}]
           ../crypto/asn1/a_time.c ../crypto/ctype.c
   INCLUDE[load_key_certs_crls_memfail]=.. ../include ../apps/include
   DEPEND[load_key_certs_crls_memfail]=libtestutil.a ../libcrypto.a ../libssl.a
+
+  SOURCE[property-memfail]=property_memfail.c
+  INCLUDE[property-memfail]=../include ../apps/include
+  DEPEND[property-memfail]=../libcrypto.a
 
   SOURCE[ssl_handshake_rtt_test]=ssl_handshake_rtt_test.c helpers/ssltestlib.c
   INCLUDE[ssl_handshake_rtt_test]=../include ../apps/include ..

--- a/test/build.info
+++ b/test/build.info
@@ -82,7 +82,7 @@ IF[{- !$disabled{tests} -}]
   ENDIF
 
   IF[{- !$disabled{'allocfail-tests'} -}]
-    PROGRAMS{noninst}=handshake-memfail x509-memfail
+    PROGRAMS{noninst}=handshake-memfail x509-memfail property-memfail
   ENDIF
 
   IF[{- !$disabled{quic} -}]
@@ -620,6 +620,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[x509-memfail]=x509_memfail.c
   INCLUDE[x509-memfail]=../include ../apps/include
   DEPEND[x509-memfail]=../libcrypto.a libtestutil.a
+
+  SOURCE[property-memfail]=property_memfail.c
+  INCLUDE[property-memfail]=../include ../apps/include
+  DEPEND[property-memfail]=../libcrypto.a
 
   SOURCE[ssl_handshake_rtt_test]=ssl_handshake_rtt_test.c helpers/ssltestlib.c
   INCLUDE[ssl_handshake_rtt_test]=../include ../apps/include ..

--- a/test/property_memfail.c
+++ b/test/property_memfail.c
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <openssl/crypto.h>
+#include "internal/hashtable.h"
+#include "internal/property.h"
+#include "internal/refcount.h"
+
+#define TEST_NID 1024
+
+/*
+ * TEST_NID maps to shard zero with the property cache's current power-of-two
+ * shard count, so this partial view is enough to reach the cache table.
+ */
+typedef struct {
+    void *algs;
+    HT *cache;
+} TEST_STORED_ALGORITHMS;
+
+struct ossl_method_store_st {
+    OSSL_LIB_CTX *ctx;
+    TEST_STORED_ALGORITHMS *algs;
+    CRYPTO_RWLOCK *biglock;
+};
+
+typedef struct {
+    HT_KEY key_header;
+} QUERY_KEY;
+
+/*
+ * We make our OSSL_PROVIDER for testing purposes.  The property cache only
+ * uses the provider pointer as a key, except when tracing asks for its name.
+ */
+struct ossl_provider_st {
+    unsigned int flag_initialized : 1;
+    unsigned int flag_activated : 1;
+    CRYPTO_RWLOCK *flag_lock;
+    CRYPTO_REF_COUNT refcnt;
+    CRYPTO_RWLOCK *activatecnt_lock;
+    int activatecnt;
+    char *name;
+};
+
+static long alloc_count;
+static long fail_at;
+static int fail_enabled;
+static int method_refs;
+
+static void *test_malloc(size_t num, const char *file, int line)
+{
+    (void)file;
+    (void)line;
+
+    if (fail_enabled && ++alloc_count == fail_at)
+        return NULL;
+
+    return malloc(num);
+}
+
+static void *test_realloc(void *ptr, size_t num, const char *file, int line)
+{
+    (void)file;
+    (void)line;
+
+    if (fail_enabled && ++alloc_count == fail_at)
+        return NULL;
+
+    return realloc(ptr, num);
+}
+
+static void test_free(void *ptr, const char *file, int line)
+{
+    (void)file;
+    (void)line;
+
+    free(ptr);
+}
+
+static int up_ref(void *p)
+{
+    (void)p;
+
+    method_refs++;
+    return 1;
+}
+
+static void down_ref(void *p)
+{
+    (void)p;
+
+    method_refs--;
+}
+
+static int delete_providerless_cache_entry(OSSL_METHOD_STORE *store)
+{
+    QUERY_KEY key;
+    uint8_t keybuf[sizeof(int)];
+    size_t keylen = 0;
+    int nid = TEST_NID;
+
+    memcpy(&keybuf[keylen], &nid, sizeof(nid));
+    keylen += sizeof(nid);
+    HT_INIT_KEY_EXTERNAL(&key, keybuf, keylen);
+
+    return ossl_ht_delete(store->algs->cache, TO_HT_KEY(&key));
+}
+
+static int property_cache_workload(int expect_success)
+{
+    static struct ossl_provider_st prov = {
+        .flag_initialized = 1,
+        .flag_activated = 1,
+        .name = "property-memfail"
+    };
+    OSSL_METHOD_STORE *store = NULL;
+    int method = 1;
+    void *result = NULL;
+    int ret = 0;
+
+    method_refs = 0;
+
+    if ((store = ossl_method_store_new(NULL)) == NULL)
+        goto end;
+    if (!ossl_method_store_add(store, (OSSL_PROVIDER *)&prov, TEST_NID, "",
+            &method, up_ref, down_ref))
+        goto end;
+    /*
+     * Restrict failure injection to the cache paths.  Store setup exercises
+     * unrelated global initialization and platform lock allocation.
+     */
+    alloc_count = 0;
+    fail_enabled = 1;
+    if (!ossl_method_store_cache_set(store, (OSSL_PROVIDER *)&prov, TEST_NID,
+            "", &method, up_ref, down_ref))
+        goto end;
+    if (!delete_providerless_cache_entry(store))
+        goto end;
+    if (!ossl_method_store_cache_get(store, NULL, TEST_NID, "", &result)
+        || result != &method)
+        goto end;
+    ret = 1;
+
+end:
+    fail_enabled = 0;
+    if (result != NULL)
+        down_ref(result);
+    ossl_method_store_free(store);
+
+    if (method_refs != 0) {
+        fprintf(stderr, "method reference leak: %d\n", method_refs);
+        return 0;
+    }
+
+    return expect_success ? ret : 1;
+}
+
+int main(int argc, char **argv)
+{
+    int ret = EXIT_FAILURE;
+
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s count | run <allocation-number>\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    if (!CRYPTO_set_mem_functions(test_malloc, test_realloc, test_free)) {
+        fprintf(stderr, "failed to set memory functions\n");
+        return EXIT_FAILURE;
+    }
+
+    if (strcmp(argv[1], "count") == 0) {
+        if (property_cache_workload(1)) {
+            fprintf(stderr, "skip: 0 count %ld\n", alloc_count);
+            ret = EXIT_SUCCESS;
+        }
+    } else if (strcmp(argv[1], "run") == 0 && argc == 3) {
+        fail_at = strtol(argv[2], NULL, 10);
+        if (fail_at > 0 && property_cache_workload(0))
+            ret = EXIT_SUCCESS;
+    } else {
+        fprintf(stderr, "usage: %s count | run <allocation-number>\n", argv[0]);
+    }
+
+    OPENSSL_cleanup();
+    return ret;
+}

--- a/test/property_test.c
+++ b/test/property_test.c
@@ -60,6 +60,21 @@ static void down_ref(void *p)
 {
 }
 
+static int counted_up_ref(void *p)
+{
+    int *refs = p;
+
+    (*refs)++;
+    return 1;
+}
+
+static void counted_down_ref(void *p)
+{
+    int *refs = p;
+
+    (*refs)--;
+}
+
 static int test_property_string(void)
 {
     OSSL_LIB_CTX *ctx;
@@ -627,6 +642,51 @@ err:
     return res;
 }
 
+static int test_query_cache_set_duplicate(void)
+{
+    OSSL_METHOD_STORE *store = NULL;
+    int res = 0;
+    int refs = 0;
+    void *result = NULL;
+    OSSL_PROVIDER prov = {
+        .flag_initialized = 1,
+        .flag_activated = 1,
+        .name = "dummy-test-provider"
+    };
+
+    if (!TEST_ptr(store = ossl_method_store_new(NULL))
+        || !TEST_true(ossl_method_store_add(store, &prov, 1, "", &refs,
+            counted_up_ref, counted_down_ref))
+        || !TEST_true(ossl_method_store_cache_set(store, &prov, 1, "", &refs,
+            counted_up_ref,
+            counted_down_ref))
+        || !TEST_int_eq(refs, 3))
+        goto err;
+
+    /*
+     * Re-adding the same cache key exercises cleanup for a temporary generic
+     * QUERY that cannot be inserted because a providerless entry already
+     * exists.
+     */
+    ossl_method_store_cache_set(store, &prov, 1, "", &refs, counted_up_ref,
+        counted_down_ref);
+    if (!TEST_int_eq(refs, 3)
+        || !TEST_true(ossl_method_store_cache_get(store, &prov, 1, "",
+            &result))
+        || !TEST_ptr_eq(result, &refs))
+        goto err;
+
+    counted_down_ref(result);
+    result = NULL;
+    res = 1;
+
+err:
+    ossl_method_store_free(store);
+    if (!TEST_int_eq(refs, 0))
+        res = 0;
+    return res;
+}
+
 static int test_fips_mode(void)
 {
     int ret = 0;
@@ -739,6 +799,7 @@ int setup_tests(void)
     ADD_TEST(test_register_deregister);
     ADD_TEST(test_property);
     ADD_TEST(test_query_cache_stochastic);
+    ADD_TEST(test_query_cache_set_duplicate);
     ADD_TEST(test_fips_mode);
     ADD_ALL_TESTS(test_property_list_to_string, OSSL_NELEM(to_string_tests));
     ADD_TEST(test_property_list_to_string_bounds);

--- a/test/recipes/90-test_memfail.t
+++ b/test/recipes/90-test_memfail.t
@@ -32,6 +32,8 @@ run(test(["x509-memfail", "count", srctop_file("test", "certs", "servercert.pem"
 
 run(test(["load_key_certs_crls_memfail", "count", srctop_file("test", "certs", "servercert.pem")], stderr => "$resultdir/load_key_certs_crls_countinfo.txt"));
 
+run(test(["property-memfail", "count"], stderr => "$resultdir/propertycountinfo.txt"));
+
 sub get_count_info {
     my ($infile) = @_;
     my ($skipcount, $malloccount) = (0, 0);
@@ -58,7 +60,10 @@ my ($x509skipcount, $x509malloccount) = get_count_info("$resultdir/x509countinfo
 
 my ($load_key_certs_crls_skipcount, $load_key_certs_crls_malloccount) = get_count_info("$resultdir/load_key_certs_crls_countinfo.txt");
 
-my $total_malloccount = $hsmalloccount + $x509malloccount + $load_key_certs_crls_malloccount;
+my (undef, $propertymalloccount) = get_count_info("$resultdir/propertycountinfo.txt");
+
+my $total_malloccount = $hsmalloccount + $x509malloccount
+    + $load_key_certs_crls_malloccount + $propertymalloccount;
 plan skip_all => "could not get malloc counts (one or more count runs failed or output format changed)"
     if $total_malloccount == 0;
 
@@ -95,3 +100,6 @@ run_memfail_test($x509skipcount, $x509malloccount, ["x509-memfail", "run", srcto
 
 run_memfail_test($load_key_certs_crls_skipcount, $load_key_certs_crls_malloccount, ["load_key_certs_crls_memfail", "run", srctop_file("test", "certs", "servercert.pem")]);
 
+for my $idx (1..$propertymalloccount) {
+    ok(run(test(["property-memfail", "run", $idx])));
+}

--- a/test/recipes/90-test_memfail.t
+++ b/test/recipes/90-test_memfail.t
@@ -30,9 +30,10 @@ run(test(["handshake-memfail", "count", srctop_dir("test", "certs")], stderr => 
 
 run(test(["x509-memfail", "count", srctop_file("test", "certs", "servercert.pem")], stderr => "$resultdir/x509countinfo.txt"));
 
+run(test(["property-memfail", "count"], stderr => "$resultdir/propertycountinfo.txt"));
+
 sub get_count_info {
     my ($infile) = @_;
-    my @vals;
 
     # Read in our input file
     open my $handle, '<', "$infile";
@@ -41,29 +42,25 @@ sub get_count_info {
 
     # parse the input file
     foreach(@lines) {
-        if ($_ =~/skip:/) {
-            @vals = split ' ', $_;
-            last;
+        if ($_ =~ /skip:\s*(\d+)\s+count\s+(\d+)/) {
+            return ($1, $2);
         }
     }
-    #
-    #The number of allocations we skip is in argument 2
-    #The number of mallocs we should test is in argument 4
-    #
-    my $skipcount = $vals[2];
-    my $malloccount = $vals[4];
-    return ($skipcount, $malloccount);
+
+    die "Unable to parse allocation count info from $infile\n";
 }
 
 my ($hsskipcount, $hsmalloccount) = get_count_info("$resultdir/hscountinfo.txt");
 
 my ($x509skipcount, $x509malloccount) = get_count_info("$resultdir/x509countinfo.txt");
 
+my (undef, $propertymalloccount) = get_count_info("$resultdir/propertycountinfo.txt");
+
 #
 # Now we can plan our tests.  We plan to run malloccount iterations of this
 # test
 #
-plan tests => $hsmalloccount + $x509malloccount;
+plan tests => $hsmalloccount + $x509malloccount + $propertymalloccount;
 
 sub run_memfail_test {
     my $skipcount = $_[0];
@@ -88,3 +85,6 @@ run_memfail_test($hsskipcount, $hsmalloccount, ["handshake-memfail", "run", srct
 
 run_memfail_test($x509skipcount, $x509malloccount, ["x509-memfail", "run", srctop_file("test", "certs", "servercert.pem")]);
 
+for my $idx (1..$propertymalloccount) {
+    ok(run(test(["property-memfail", "run", $idx])));
+}


### PR DESCRIPTION
Fixes #30890

## Summary

This PR fixes property method cache insertion failure handling and related `QUERY` ownership cleanup in `crypto/property/property.c`.

There are two related ownership issues.

First, `ossl_method_store_cache_set_locked` allocates a temporary `QUERY *p` before ownership is transferred to the method cache. On the first cache insertion failure path, the old code called `impl_cache_free(p)` and then jumped to the common `err` label, which also calls `OPENSSL_free(p)`.

`impl_cache_free()` is intended for entries already linked into the cache LRU list, and it frees the `QUERY` object. Using it for a temporary unlinked entry before jumping to common cleanup creates a double-free-capable cleanup path.

Second, `ossl_ht_cache_QUERY_insert` returns `1` on success. It can also return `0` or `-1` for non-success outcomes, including allocation failure or inability to grow the table. The property method cache code was testing this return value as a boolean, which means `-1` could be treated as success.

This PR updates these paths to treat only `1` as success and separates cleanup for linked cache entries from cleanup for temporary unlinked entries.

## Changes

- Add `impl_cache_free_unlinked` for temporary `QUERY` entries not present in the LRU list.
- Update `ossl_method_store_cache_set_locked` to treat cache insertion as successful only when `ossl_ht_cache_QUERY_insert` returns `1`.
- Avoid using linked-entry cleanup for unlinked temporary `QUERY` objects.
- Null temporary pointers after freeing them on failure paths.
- Fix `ossl_method_store_cache_get` deferred providerless cache insertion cleanup so both the pending cache-entry reference and caller-visible method reference are released on insertion failure.
- Clarify the internal hash-table insertion return-value contract.
- Add a duplicate property cache insertion regression test.
- Add a property cache allocation-failure exerciser and wire it into the existing memfail recipe when allocfail tests are enabled.
- Cover providerless cache miss/rebuild cleanup by deleting the providerless cache entry and forcing a providerless cache lookup.

## Impact

This is a memory ownership fix for rare property method cache insertion failure paths.

The old code had a double-free capable cleanup path for temporary `QUERY` entries and also treated `-1` hash-table insertion failures as success. The known practical trigger requires internal cache insertion failure, most plausibly allocation failure or inability to grow the hash table.

This is a real correctness issue in cache ownership/error handling, although this does not appear to be a typical remote trigger.

## Testing

Validated on Ubuntu 24.04.

Configure and build:
```sh
perl Configure enable-crypto-mdebug enable-allocfail-tests --prefix="$(pwd)/install"
make -j4
```

Regression tests:
```sh
make test TESTS=test_property
make test TESTS=test_memfail
```

Results:

```sh
03-test_property.t .. ok
Files=1, Tests=2
Result: PASS

90-test_memfail.t .. ok
Files=1, Tests=23681, 444 wallclock secs
Result: PASS
```

Focused property cache allocation-failure sweep:

```sh
./test/property-memfail count

for i in $(seq 1 "$count"); do
    ./test/property-memfail run "$i"
done

Result:

skip: 0 count 6
property-memfail passed 6 allocation-failure iterations
```

enable-crypto-mdebug is required because enable-allocfail-tests depends on it.
