### PR TITLE
Reject empty TLS 1.3 HRR cookie

### DIFF
--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -2372,6 +2372,7 @@ int tls_parse_stoc_cookie(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
     PACKET cookie;
 
     if (!PACKET_as_length_prefixed_2(pkt, &cookie)
+        || PACKET_remaining(&cookie) == 0
         || !PACKET_memdup(&cookie, &s->ext.tls13_cookie,
             &s->ext.tls13_cookie_len)) {
         SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_LENGTH_MISMATCH);

--- a/test/recipes/70-test_tls13cookie.t
+++ b/test/recipes/70-test_tls13cookie.t
@@ -31,7 +31,8 @@ plan skip_all => "$test_name needs TLS1.3 enabled"
 
 use constant {
     COOKIE_ONLY => 0,
-    COOKIE_AND_KEY_SHARE => 1
+    COOKIE_AND_KEY_SHARE => 1,
+    EMPTY_COOKIE => 2
 };
 
 my $proxy = TLSProxy::Proxy->new(
@@ -43,6 +44,7 @@ my $proxy = TLSProxy::Proxy->new(
 );
 
 my $cookieseen = 0;
+my $fatal_alert = 0;
 my $testtype;
 
 #Test 1: Inserting a cookie into an HRR should see it echoed in the ClientHello
@@ -57,7 +59,7 @@ if (disabled("ecx")) {
     $proxy->serverflags("-curves X25519");
 }
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
-plan tests => 2;
+plan tests => 3;
 ok(TLSProxy::Message->success() && $cookieseen == 1, "Cookie seen");
 
 #Test 2: Inserting a cookie into an HRR should see it echoed in the ClientHello
@@ -72,18 +74,41 @@ SKIP: {
     ok(TLSProxy::Message->success() && $cookieseen == 1, "Cookie seen");
 }
 
+#Test 3: A client should reject an empty cookie in an HRR
+$testtype = EMPTY_COOKIE;
+$fatal_alert = 0;
+$proxy->clear();
+if (disabled("ecx")) {
+    $proxy->clientflags("-curves ffdhe3072:ffdhe2048");
+    $proxy->serverflags("-curves ffdhe2048");
+} else {
+    $proxy->clientflags("-curves P-256:X25519");
+    $proxy->serverflags("-curves X25519");
+}
+$proxy->start();
+ok($fatal_alert, "Empty cookie rejected");
+
 sub cookie_filter
 {
     my $proxy = shift;
 
+    if ($testtype == EMPTY_COOKIE && $proxy->flight == 2) {
+        $fatal_alert = 1
+            if @{$proxy->record_list}[-1]->is_fatal_alert(0)
+                == TLSProxy::Message::AL_DESC_DECODE_ERROR;
+        return;
+    }
+
     # We're only interested in the HRR and both ClientHellos
     return if ($proxy->flight > 2);
 
-    my $ext = pack "C8",
-        0x00, 0x06, #Cookie Length
-        0x00, 0x01, #Dummy cookie data (6 bytes)
-        0x02, 0x03,
-        0x04, 0x05;
+    my $ext = $testtype == EMPTY_COOKIE
+        ? pack("n", 0)
+        : pack("C8",
+            0x00, 0x06, #Cookie Length
+            0x00, 0x01, #Dummy cookie data (6 bytes)
+            0x02, 0x03,
+            0x04, 0x05);
 
     foreach my $message (@{$proxy->message_list}) {
         if ($message->mt == TLSProxy::Message::MT_SERVER_HELLO


### PR DESCRIPTION
Reject empty TLS 1.3 HelloRetryRequest Cookie extensions.

RFC 8446 defines the TLS 1.3 Cookie extension data as a Cookie structure containing `opaque cookie<1..2^16-1>`, so a zero-length cookie vector is an out-of-range length and must be rejected with a fatal `decode_error`.

The client-side HRR cookie parser accepted an empty cookie because `PACKET_memdup()` succeeds for empty packets, leaving `tls13_cookie_len` set to 0. The client could then continue after the malformed HRR and fail later with a misleading record-layer error.

Add an explicit empty-cookie check in `tls_parse_stoc_cookie()` before storing the parsed cookie, matching the handling used by nearby TLS 1.3 extension parsers.

Also extend `70-test_tls13cookie.t` with a regression test that rewrites the HRR Cookie extension to an empty vector and verifies that the client rejects it with a fatal `decode_error`.

Fixes #30868

Testing:

`HARNESS_JOBS=1 make test TESTS=test_tls13cookie`