### PR TITLE
Add Ninja build file generation support

### DIFF
--- a/.github/workflows/ninja.yml
+++ b/.github/workflows/ninja.yml
@@ -1,0 +1,119 @@
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+name: Ninja GitHub CI
+
+on: [pull_request, push]
+
+permissions:
+  contents: read
+
+env:
+  OSSL_RUN_CI_TESTS: 1
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+    - name: install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get -yq --no-install-suggests --no-install-recommends install ninja-build
+        sudo gem install mdl
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+    - name: checkout fuzz/corpora submodule
+      run: git submodule update --init --depth 1 fuzz/corpora
+    - name: prepare the build directory
+      run: mkdir _build
+    - name: config
+      working-directory: _build
+      run: BUILDFILE=build.ninja perl ../Configure --banner=Configured --strict-warnings enable-fips enable-lms
+    - name: build
+      run: ninja -C _build -j4
+    - name: test
+      env:
+        HARNESS_JOBS: 4
+      run: ninja -C _build test
+    - name: update generated sources
+      run: ninja -C _build update
+    - name: check generated sources
+      run: git diff --exit-code
+    - name: check documentation
+      run: ninja -C _build doc-nits
+    - name: check markdown
+      run: ninja -C _build md-nits
+
+  windows:
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+    - name: checkout fuzz/corpora submodule
+      run: git submodule update --init --depth 1 fuzz/corpora
+    - name: install build tools
+      run: |
+        choco install nasm ninja
+        "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+    - name: prepare the build directory
+      run: mkdir _build
+    - name: config
+      working-directory: _build
+      shell: cmd
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        set BUILDFILE=build.ninja
+        perl ..\Configure --banner=Configured --strict-warnings no-fips enable-demos -DOSSL_WINCTX=openssl VC-WIN64A
+        perl configdata.pm --dump
+    - name: build
+      working-directory: _build
+      shell: cmd
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        ninja -j4
+    - name: test
+      working-directory: _build
+      shell: cmd
+      env:
+        HARNESS_JOBS: 4
+        TESTS: "-test_fuzz*"
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        ninja test
+
+  macos:
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+    - name: checkout fuzz/corpora submodule
+      run: git submodule update --init --depth 1 fuzz/corpora
+    - name: check build tools
+      run: |
+        perl -v
+        ninja --version
+        clang --version
+    - name: prepare the build directory
+      run: mkdir _build
+    - name: config
+      working-directory: _build
+      run: BUILDFILE=build.ninja perl ../Configure --banner=Configured --strict-warnings shared no-fips darwin64-arm64
+    - name: build
+      run: ninja -C _build -j4
+    - name: test
+      env:
+        HARNESS_JOBS: 4
+      run: ninja -C _build test
+    - name: check no-op rebuild
+      run: |
+        output="$(ninja -C _build -n)"
+        printf '%s\n' "$output"
+        printf '%s\n' "$output" | grep -F "ninja: no work to do."

--- a/Configurations/README.md
+++ b/Configurations/README.md
@@ -481,7 +481,8 @@ Build-file programming with the "unified" build system
 ======================================================
 
 "Build files" are called `Makefile` on Unix-like operating systems,
-`descrip.mms` for MMS on VMS, `makefile` for `nmake` on Windows, etc.
+`descrip.mms` for MMS on VMS, `makefile` for `nmake` on Windows,
+`build.ninja` for Ninja, etc.
 
 To use the "unified" build system, the target configuration needs to
 set the three items `build_scheme`, `build_file` and `build_command`.
@@ -497,6 +498,9 @@ example, if `build_file` is set to `Makefile`, the template could be
 `Configurations/Makefile.tmpl` or `Configurations/unix-Makefile.tmpl`.
 In case both `Configurations/unix-Makefile.tmpl` and
 `Configurations/Makefile.tmpl` are present, the former takes precedence.
+The same lookup rules apply to `build.ninja`, whose generic template is
+`Configurations/build.ninja.tmpl`.  Native Windows targets use the
+platform-specific `Configurations/windows-build.ninja.tmpl` template.
 
 The build-file template is processed with the perl module
 Text::Template, using `{-` and `-}` as delimiters that enclose the

--- a/Configurations/build.ninja.tmpl
+++ b/Configurations/build.ninja.tmpl
@@ -1,0 +1,1109 @@
+##
+## Ninja build file for OpenSSL
+##
+## {- join("\n## ", @autowarntext) -}
+{-
+     use File::Basename;
+     use File::Spec::Functions qw/:DEFAULT abs2rel rel2abs file_name_is_absolute/;
+     use Time::Piece;
+
+     use OpenSSL::Util;
+
+     my $build_scheme = $target{build_scheme};
+     our $builder_platform = $build_scheme->[1];
+     die "The Ninja build template currently supports Unix-like targets only\n"
+         if $builder_platform ne 'unix';
+
+     our $makedep_scheme = $config{makedep_scheme};
+     our $makedepcmd = $config{makedepcmd} // '';
+
+     sub windowsdll { $config{target} =~ /^(?:Cygwin|mingw)/ }
+     sub sharedaix  { !$disabled{shared} && $target{shared_target} =~ /^aix(?!-solib$)/ }
+     sub sharedaix_solib  { !$disabled{shared} && $target{shared_target} =~ /^aix-solib$/ }
+
+     sub nval {
+         my $s = shift // '';
+         $s =~ s/\$/\$\$/g;
+         $s =~ s/\r?\n/ /g;
+         return $s;
+     }
+
+     sub npath {
+         my $s = shift;
+         return () unless defined $s && $s ne '';
+         $s =~ s/\$/\$\$/g;
+         $s =~ s/ /\$ /g;
+         $s =~ s/:/\$:/g;
+         return $s;
+     }
+
+     sub npaths {
+         return join(' ', map { npath($_) } grep { defined $_ && $_ ne '' } @_);
+     }
+
+     sub cmd_quote {
+         my $s = shift // '';
+         return "''" if $s eq '';
+         return $s if $s !~ m|[^A-Za-z0-9_/\.,:=+\@%-]|;
+         $s =~ s/'/'\\''/g;
+         return "'$s'";
+     }
+
+     sub shell_join {
+         return join(' ', grep { defined $_ && $_ ne '' } @_);
+     }
+
+     sub ninja_build {
+         my %args = @_;
+         my @outs = ref($args{out}) eq 'ARRAY' ? @{$args{out}} : ($args{out});
+         my @in = @{$args{in} // []};
+         my @implicit = @{$args{implicit} // []};
+         my @order = @{$args{order} // []};
+         my $result = 'build '.npaths(@outs).' : '.$args{rule};
+         $result .= ' '.npaths(@in) if @in;
+         $result .= ' | '.npaths(@implicit) if @implicit;
+         $result .= ' || '.npaths(@order) if @order;
+         $result .= "\n";
+         foreach my $k (sort keys %{$args{vars} // {}}) {
+             my $v = $args{vars}->{$k};
+             next unless defined $v && $v ne '';
+             $result .= "  $k = ".nval($v)."\n";
+         }
+         return $result;
+     }
+
+     sub run_build {
+         my ($out, $command, $in, $implicit, $order, $desc) = @_;
+         return ninja_build(out => $out, rule => 'run',
+                            in => $in // [], implicit => $implicit // [],
+                            order => $order // [],
+                            vars => { command => $command,
+                                      description => $desc // "GEN $out" });
+     }
+
+     sub run_console_build {
+         my ($out, $command, $in, $implicit, $order, $desc) = @_;
+         return ninja_build(out => $out, rule => 'run_console',
+                            in => $in // [], implicit => $implicit // [],
+                            order => $order // [],
+                            vars => { command => $command,
+                                      description => $desc // $out });
+     }
+
+     our $perl = (fixup_cmd_elements($config{PERL}))[0];
+     our $cc = $config{CROSS_COMPILE}.$config{CC};
+     our $cxx = $config{CXX} ? $config{CROSS_COMPILE}.$config{CXX} : '';
+     our $ar = $config{CROSS_COMPILE}.$config{AR};
+     our $ranlib = $config{RANLIB} ? $config{CROSS_COMPILE}.$config{RANLIB} : 'true';
+     our $rc = $config{CROSS_COMPILE}.$config{RC};
+
+     our $prefix = $config{prefix} || "/usr/local";
+     our $openssldir =
+         $config{openssldir}
+         ? (file_name_is_absolute($config{openssldir})
+            ? $config{openssldir}
+            : catdir($prefix, $config{openssldir}))
+         : catdir($prefix, "ssl");
+     our $libdir = $config{libdir} || "lib$target{multilib}";
+     our $libdir_abs = file_name_is_absolute($libdir) ? $libdir
+                                                      : catdir($prefix, $libdir);
+     our $modulesdir = catdir($libdir_abs, "ossl-modules");
+     our $pkgconfigdir = catdir($libdir_abs, "pkgconfig");
+     our $cmakeconfigdir = catdir($libdir_abs, "cmake", "OpenSSL");
+     our @fipsmodules =
+         grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
+                && $unified_info{attributes}->{modules}->{$_}->{fips} }
+         @{$unified_info{modules}};
+     die "More than one FIPS module" if scalar @fipsmodules > 1;
+     our $fipsmodule = join(" ", map { platform->dso($_) } @fipsmodules);
+
+     my $cppflags1 =
+         join(" ",
+              (map { "-D".$_} @{$config{CPPDEFINES}}),
+              (map { "-I".$_} @{$config{CPPINCLUDES}}),
+              @{$config{CPPFLAGS}});
+     my $cppflags2 =
+         join(' ', $target{cppflags} || (),
+                   (map { "-D".$_} @{$target{defines}}, @{$config{defines}}),
+                   (map { "-I".$_ } @{$target{includes}}, @{$config{includes}}),
+                   @{$config{cppflags}});
+     my $cnf_cflags = join(' ', $target{cflags} || (), @{$config{cflags}});
+     my $cnf_cxxflags = join(' ', $target{cxxflags} || (), @{$config{cxxflags}});
+     my $cnf_lflags = join(' ', $target{lflags} || (), @{$config{lflags}});
+     my $cnf_ex_libs = join(' ', $target{ex_libs} || (), @{$config{ex_libs}});
+
+     our $lib_cppflags =
+         join(' ', $target{lib_cppflags} || (),
+                   $target{shared_cppflag} || (),
+                   (map { '-D'.$_ }
+                        @{$target{lib_defines}},
+                        @{$target{shared_defines}},
+                        @{$config{lib_defines}},
+                        @{$config{shared_defines}}),
+                   (map { '-I'.$_ }
+                        @{$target{lib_includes}},
+                        @{$target{shared_includes}},
+                        @{$config{lib_includes}},
+                        @{$config{shared_includes}}),
+                   @{$config{lib_cppflags}},
+                   @{$config{shared_cppflag}},
+                   (map { '-D'.$_ }
+                        'OPENSSLDIR="\"'.$openssldir.'\""',
+                        'MODULESDIR="\"'.$modulesdir.'\""'),
+                   $cppflags2, $cppflags1);
+     our $lib_cflags =
+         join(' ', $target{lib_cflags} || (),
+                   $target{shared_cflag} || (),
+                   @{$config{lib_cflags}},
+                   @{$config{shared_cflag}},
+                   $cnf_cflags, @{$config{CFLAGS}});
+     our $lib_cxxflags =
+         join(' ', $target{lib_cxxflags} || (),
+                   $target{shared_cxxflag} || (),
+                   @{$config{lib_cxxflags}},
+                   @{$config{shared_cxxflag}},
+                   $cnf_cxxflags, @{$config{CXXFLAGS}});
+     our $lib_lflags =
+         join(' ', $target{shared_ldflag} || (),
+                   $config{shared_ldflag} || (),
+                   $cnf_lflags, @{$config{LDFLAGS}});
+     our $lib_ex_libs = join(' ', $cnf_ex_libs, @{$config{LDLIBS}});
+
+     our $dso_cppflags =
+         join(' ', $target{dso_cppflags} || (),
+                   $target{module_cppflags} || (),
+                   (map { '-D'.$_ }
+                        @{$target{dso_defines}},
+                        @{$target{module_defines}},
+                        @{$config{dso_defines}},
+                        @{$config{module_defines}}),
+                   (map { '-I'.$_ }
+                        @{$target{dso_includes}},
+                        @{$target{module_includes}},
+                        @{$config{dso_includes}},
+                        @{$config{module_includes}}),
+                   @{$config{dso_cppflags}},
+                   @{$config{module_cppflags}},
+                   $cppflags2, $cppflags1);
+     our $dso_cflags =
+         join(' ', $target{dso_cflags} || (),
+                   $target{module_cflags} || (),
+                   @{$config{dso_cflags}},
+                   @{$config{module_cflags}},
+                   $cnf_cflags, @{$config{CFLAGS}});
+     our $dso_cxxflags =
+         join(' ', $target{dso_cxxflags} || (),
+                   $target{module_cxxflags} || (),
+                   @{$config{dso_cxxflags}},
+                   @{$config{module_cxxflag}},
+                   $cnf_cxxflags, @{$config{CXXFLAGS}});
+     our $dso_lflags =
+         join(' ', $target{dso_lflags} || (),
+                   $target{module_ldflags} || (),
+                   @{$config{dso_lflags}},
+                   @{$config{module_ldflags}},
+                   $cnf_lflags, @{$config{LDFLAGS}});
+     our $dso_ex_libs = join(' ', $cnf_ex_libs, @{$config{LDLIBS}});
+
+     our $bin_cppflags =
+         join(' ', $target{bin_cppflags} || (),
+                   (map { '-D'.$_ } @{$config{bin_defines} || ()}),
+                   @{$config{bin_cppflags}},
+                   $cppflags2, $cppflags1);
+     our $bin_cflags =
+         join(' ', $target{bin_cflags} || (),
+                   @{$config{bin_cflags}},
+                   $cnf_cflags, @{$config{CFLAGS}});
+     our $bin_cxxflags =
+         join(' ', $target{bin_cxxflags} || (),
+                   @{$config{bin_cxxflags}},
+                   $cnf_cxxflags, @{$config{CXXFLAGS}});
+     our $bin_lflags =
+         join(' ', $target{bin_lflags} || (),
+                   @{$config{bin_lflags}},
+                   $cnf_lflags, @{$config{LDFLAGS}});
+     our $bin_ex_libs = join(' ', $cnf_ex_libs, @{$config{LDLIBS}});
+
+     our $cppflags_q = do {
+         my $x = join(' ', $lib_cppflags || (), $cppflags2 || (),
+                           $cppflags1 || ());
+         $x =~ s|([\\"])|\\$1|g;
+         $x;
+     };
+
+     my $t = localtime;
+     if ($config{"release_date"}) {
+         eval { $t = Time::Piece->strptime($config{"release_date"}, "%d %b %Y"); }
+             || die "Parsing \$config{release_date} ('$config{release_date}') failed: $@";
+     }
+     our $release_date = $t->strftime("%Y-%m-%d");
+
+     our %makevars = (
+         APPS_OPENSSL => cmd_quote(catfile("apps", "openssl")),
+         BINDIR => "bin$target{multibin}",
+         BLDDIR => $config{builddir},
+         CC => $cc,
+         CMAKECONFIGDIR => $cmakeconfigdir,
+         CPPFLAGS_Q => $cppflags_q,
+         FIPSKEY => $config{FIPSKEY},
+         FIPSMODULE => $fipsmodule,
+         INCLUDEDIR => "include",
+         INSTALLTOP => $prefix,
+         LDLIBS => $lib_ex_libs,
+         LIBDIR => $libdir,
+         LIB_EX_LIBS => $lib_ex_libs,
+         LIB_CFLAGS => $lib_cflags,
+         MODULESDIR => $modulesdir,
+         PKGCONFIGDIR => $pkgconfigdir,
+         PLATFORM => $config{target},
+         PREFIX => $prefix,
+         SRCDIR => $config{sourcedir},
+         SHLIB_TARGET => $target{shared_target},
+         SHLIB_VERSION_NUMBER => $config{shlib_version},
+         VERSION => $config{full_version},
+         LIBRPATH => $libdir_abs,
+         libdir => $libdir_abs,
+     );
+
+     sub expand_makevars {
+         my $s = shift;
+         $s =~ s/\$\(([^)]+)\)/exists $makevars{$1} ? $makevars{$1} : "\$($1)"/ge;
+         return $s;
+     }
+
+     $lib_cppflags = expand_makevars($lib_cppflags);
+     $lib_cflags = expand_makevars($lib_cflags);
+     $lib_cxxflags = expand_makevars($lib_cxxflags);
+     $lib_lflags = expand_makevars($lib_lflags);
+     $lib_ex_libs = expand_makevars($lib_ex_libs);
+     $dso_cppflags = expand_makevars($dso_cppflags);
+     $dso_cflags = expand_makevars($dso_cflags);
+     $dso_cxxflags = expand_makevars($dso_cxxflags);
+     $dso_lflags = expand_makevars($dso_lflags);
+     $dso_ex_libs = expand_makevars($dso_ex_libs);
+     $bin_cppflags = expand_makevars($bin_cppflags);
+     $bin_cflags = expand_makevars($bin_cflags);
+     $bin_cxxflags = expand_makevars($bin_cxxflags);
+     $bin_lflags = expand_makevars($bin_lflags);
+     $bin_ex_libs = expand_makevars($bin_ex_libs);
+
+     sub command_args {
+         return join('', map { ' '.expand_makevars($_) } @_);
+     }
+
+     sub compute_lib_depends {
+         return map { platform->sharedlib_simple($_)
+                      // platform->sharedlib_import($_)
+                      // platform->sharedlib($_)
+                      // platform->staticlib($_) } @_;
+     }
+
+     sub compute_platform_depends {
+         map {
+             my $x = $_;
+             if (grep { $x eq $_ } @{$unified_info{programs}}) {
+                 platform->bin($x);
+             } elsif (grep { $x eq $_ } @{$unified_info{modules}}) {
+                 platform->dso($x);
+             } elsif (grep { $x eq $_ } @{$unified_info{libraries}}) {
+                 compute_lib_depends($x);
+             } else {
+                 platform->convertext($x);
+             }
+         } @_;
+     }
+
+     sub link_flags {
+         my @linkdirs = ();
+         my @linklibs = ();
+         foreach (@_) {
+             next unless defined $_;
+             if (platform->isstaticlib($_)) {
+                 push @linklibs, platform->convertext($_);
+             } else {
+                 my $d = "-L" . dirname($_);
+                 my $l = basename($_);
+                 $l =~ s/^lib//;
+                 $l = "-l" . $l;
+                 push @linklibs, $l;
+                 push @linkdirs, $d unless grep { $d eq $_ } @linkdirs;
+             }
+         }
+         return (join(" ", @linkdirs), join(" ", @linklibs));
+     }
+
+     '';
+-}
+ninja_required_version = 1.8
+
+platform = {- nval($config{target}) -}
+srcdir = {- nval($config{sourcedir}) -}
+blddir = {- nval($config{builddir}) -}
+perl = {- nval($perl) -}
+cc = {- nval($cc) -}
+cxx = {- nval($cxx) -}
+ar = {- nval($ar) -}
+ranlib = {- nval($ranlib) -}
+rc = {- nval($rc) -}
+makedepcmd = {- nval($makedepcmd) -}
+
+rule run
+  command = $command
+  description = $description
+  restat = 1
+
+rule run_console
+  command = $command
+  description = $description
+  pool = console
+
+rule cc
+  command = $cmd $incs $defs $cmdflags -MMD -MF $depfile -c -o $out $srcs
+  depfile = $depfile
+  deps = gcc
+  description = CC $out
+
+rule cc_makedepend
+  command = $cmd $incs $defs $cmdflags $cmdcompile -o $out $srcs && $perl "$srcdir/util/ninja-makedepend.pl" "$out" "$depfile" "$makedepcmd" -f- -Y -- $incs $defs $cmdflags -- $srcs
+  depfile = $depfile
+  deps = gcc
+  description = CC $out
+
+rule cc_nodep
+  command = $cmd $incs $defs $cmdflags $cmdcompile -o $out $srcs
+  description = CC $out
+
+rule ar
+  command = $perl "$srcdir/util/ninja-ar.pl" --ar "$ar" --arflags "$arflags" --ranlib "$ranlib" --out "$out" --rsp "$out.rsp"
+  rspfile = $out.rsp
+  rspfile_content = $in
+  description = AR $out
+
+rule link
+  command = $command
+  description = LINK $out
+
+rule regen_build
+  command = {- nval($perl) -} configdata.pm
+  description = REGEN build.ninja
+  generator = 1
+
+rule regen_config
+  command = {- nval($perl) -} configdata.pm -r
+  description = RECONF configdata.pm
+  generator = 1
+
+build build.ninja: regen_build configdata.pm | {- npaths(@{$config{build_file_templates}}) -}
+build configdata.pm: regen_config {- npaths(catfile($config{sourcedir}, "Configure"), catfile($config{sourcedir}, "config"), @{$config{build_infos}}, @{$config{conf_files}}) -}
+
+build reconfigure reconf: run_console
+  command = {- nval($perl) -} configdata.pm -r
+  description = RECONF
+
+{-
+     my @libs =
+         map { platform->staticlib($_) // () } @{$unified_info{libraries}};
+     my @shlib_deps =
+         map { platform->sharedlib_simple($_)
+               // platform->sharedlib_import($_)
+               // platform->sharedlib($_)
+               // () } @{$unified_info{libraries}};
+     my @modules =
+         map { platform->dso($_) }
+         grep { my $x = $_;
+                !grep { grep { $_ eq $x } @$_ } values %{$unified_info{depends}} }
+         @{$unified_info{modules}};
+     my @programs = map { platform->bin($_) } @{$unified_info{programs}};
+     my @scripts = @{$unified_info{scripts}};
+     my @install_programs =
+         map { platform->bin($_) }
+         grep { !$unified_info{attributes}->{programs}->{$_}->{noinst} }
+         @{$unified_info{programs}};
+     my @install_libs =
+         map { platform->staticlib($_) // () }
+         grep { !$unified_info{attributes}->{libraries}->{$_}->{noinst} }
+         @{$unified_info{libraries}};
+     my @install_modules =
+         map { platform->dso($_) }
+         grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
+                && !$unified_info{attributes}->{modules}->{$_}->{fips} }
+         @{$unified_info{modules}};
+     my @install_fipsmoduleconf =
+         $disabled{fips} ? () : (catfile("providers", "fipsmodule.cnf"));
+     my @bin_scripts =
+         grep { !$unified_info{attributes}->{scripts}->{$_}->{noinst}
+                && !$unified_info{attributes}->{scripts}->{$_}->{misc} }
+         @scripts;
+     my @misc_scripts =
+         grep { !$unified_info{attributes}->{scripts}->{$_}->{noinst}
+                && $unified_info{attributes}->{scripts}->{$_}->{misc} }
+         @scripts;
+     my @generated_mandatory = @{$unified_info{depends}->{""}};
+     my @all_generated = map { platform->convertext($_) } @generated;
+     my @generated_pods =
+         map { my $x = $_;
+               (grep {
+                   $unified_info{attributes}->{depends}->{$x}->{$_}->{pod} // 0
+                } keys %{$unified_info{attributes}->{depends}->{$x}}) ? $x : ();
+         } @generated;
+     my @htmldocs = map { @{$unified_info{htmldocs}->{$_}} } qw(man1 man3 man5 man7);
+     my @mandocs = map { @{$unified_info{mandocs}->{$_}} } qw(man1 man3 man5 man7);
+     my @utils = ();
+     @utils = (catfile("util", "opensslwrap.sh"), catfile("apps", "openssl.cnf"))
+         if $config{sourcedir} ne $config{builddir};
+
+     our %manual_phony_targets = ();
+
+     my $target = sub {
+         my ($name, @deps) = @_;
+         $manual_phony_targets{$name} = 1;
+         push @deps, compute_platform_depends(@{$unified_info{depends}->{$name} // []});
+         my %seen;
+         @deps = grep { !$seen{$_}++ } @deps;
+         return ninja_build(out => $name, rule => 'phony', in => \@deps);
+     };
+
+     my $out = '';
+     my $ninja_build = cmd_quote(catfile($config{sourcedir},
+                                         "util", "ninja-build.pl"));
+     my $action = sub { $perl.' '.$ninja_build.' '.cmd_quote($_[0]); };
+
+     $out .= $target->('build_sw', 'build_generated', 'build_libs_nodep',
+                       'build_modules_nodep', 'build_programs_nodep',
+                       'link-utils');
+     $out .= $target->('build_libs', 'build_generated', 'build_libs_nodep');
+     $out .= $target->('build_modules', 'build_generated', 'build_modules_nodep');
+     $out .= $target->('build_programs', 'build_generated',
+                       'build_programs_nodep');
+     $out .= $target->('build_inst_sw', 'build_generated', 'build_libs_nodep',
+                       'build_modules_nodep', 'build_inst_programs_nodep',
+                       'link-utils');
+     $out .= $target->('build_inst_programs', 'build_generated',
+                       'build_inst_programs_nodep');
+     $out .= $target->('all', 'build_sw', ($disabled{docs} ? () : 'build_docs'));
+     $out .= $target->('build_generated_pods', @generated_pods);
+     $out .= $target->('build_docs', 'build_man_docs', 'build_html_docs');
+     $out .= $target->('build_man_docs', @mandocs);
+     $out .= $target->('build_html_docs', @htmldocs);
+     $out .= $target->('build_generated', @generated_mandatory);
+     $out .= $target->('build_libs_nodep', @libs, @shlib_deps);
+     $out .= $target->('build_modules_nodep', @modules);
+     $out .= $target->('build_programs_nodep', @programs, @scripts);
+     $out .= $target->('build_inst_programs_nodep', @install_programs, @scripts);
+     $out .= $target->('build_apps', 'build_programs');
+     $out .= $target->('build_tests', 'build_programs');
+     $out .= $target->('build_all_generated', @generated_mandatory,
+                       @all_generated, 'build_docs');
+     $out .= $target->('link-utils', @utils);
+     $out .= $target->('install', 'install_sw', 'install_ssldirs',
+                       ($disabled{docs} ? () : 'install_docs'),
+                       ($disabled{fips} ? () : 'install_fips'));
+     $out .= $target->('uninstall',
+                       ($disabled{docs} ? () : 'uninstall_docs'),
+                       'uninstall_sw',
+                       ($disabled{fips} ? () : 'uninstall_fips'));
+     $out .= $target->('install_sw', 'install_dev', 'install_modules',
+                       'install_runtime');
+     $out .= $target->('uninstall_sw', 'uninstall_runtime',
+                       'uninstall_modules', 'uninstall_dev');
+     $out .= $target->('install_docs', 'install_man_docs',
+                       'install_html_docs');
+     $out .= $target->('install_runtime', 'install_programs');
+     $out .= $target->('uninstall_runtime', 'uninstall_programs',
+                       'uninstall_runtime_libs');
+
+     $out .= run_console_build('clean', $action->('clean'), [], [], [],
+                               'CLEAN');
+     $out .= run_console_build('distclean', $action->('distclean'),
+                               [ 'clean' ], [], [], 'DISTCLEAN');
+     $out .= run_console_build('depend', $action->('depend'), [], [], [],
+                               'DEPEND');
+     $out .= run_console_build('install_ssldirs',
+                               $action->('install_ssldirs'),
+                               [ @misc_scripts ], [], [], 'INSTALL SSLDIRS');
+     $out .= run_console_build('install_runtime_libs',
+                               $action->('install_runtime_libs'),
+                               [ 'build_libs' ], [], [], 'INSTALL RUNTIME LIBS');
+     $out .= run_console_build('install_dev', $action->('install_dev'),
+                               [ 'install_runtime_libs', @install_libs ],
+                               [], [], 'INSTALL DEV');
+     $out .= run_console_build('install_modules',
+                               $action->('install_modules'),
+                               [ 'install_runtime_libs', 'build_modules',
+                                 @install_modules ],
+                               [], [], 'INSTALL MODULES');
+     $out .= run_console_build('install_programs',
+                               $action->('install_programs'),
+                               [ 'install_runtime_libs',
+                                 'build_inst_programs', @install_programs,
+                                 @bin_scripts ],
+                               [], [], 'INSTALL PROGRAMS');
+     $out .= run_console_build('install_fips', $action->('install_fips'),
+                               [ 'build_inst_sw', @install_fipsmoduleconf ],
+                               [], [], 'INSTALL FIPS');
+     $out .= run_console_build('install_man_docs',
+                               $action->('install_man_docs'),
+                               [ 'build_man_docs' ], [], [],
+                               'INSTALL MAN DOCS');
+     $out .= run_console_build('install_image_docs',
+                               $action->('install_image_docs'),
+                               [], [], [], 'INSTALL IMAGE DOCS');
+     $out .= run_console_build('install_html_docs',
+                               $action->('install_html_docs'),
+                               [ 'install_image_docs', 'build_html_docs' ],
+                               [], [], 'INSTALL HTML DOCS');
+     $out .= run_console_build('uninstall_runtime_libs',
+                               $action->('uninstall_runtime_libs'),
+                               [], [], [], 'UNINSTALL RUNTIME LIBS');
+     $out .= run_console_build('uninstall_dev',
+                               $action->('uninstall_dev'),
+                               [ 'uninstall_runtime_libs' ], [], [],
+                               'UNINSTALL DEV');
+     $out .= run_console_build('uninstall_modules',
+                               $action->('uninstall_modules'),
+                               [], [], [], 'UNINSTALL MODULES');
+     $out .= run_console_build('uninstall_programs',
+                               $action->('uninstall_programs'),
+                               [], [], [], 'UNINSTALL PROGRAMS');
+     $out .= run_console_build('uninstall_fips',
+                               $action->('uninstall_fips'),
+                               [], [], [], 'UNINSTALL FIPS');
+     $out .= run_console_build('uninstall_man_docs',
+                               $action->('uninstall_man_docs'),
+                               [ 'build_man_docs' ], [], [],
+                               'UNINSTALL MAN DOCS');
+     $out .= run_console_build('uninstall_image_docs',
+                               $action->('uninstall_image_docs'),
+                               [], [], [], 'UNINSTALL IMAGE DOCS');
+     $out .= run_console_build('uninstall_html_docs',
+                               $action->('uninstall_html_docs'),
+                               [ 'uninstall_image_docs' ], [], [],
+                               'UNINSTALL HTML DOCS');
+     $out .= run_console_build('uninstall_docs',
+                               $action->('uninstall_docs'),
+                               [ 'uninstall_man_docs',
+                                 'uninstall_html_docs' ],
+                               [], [], 'UNINSTALL DOCS');
+
+     if (@utils) {
+         foreach my $pair ([ catfile("util", "opensslwrap.sh"),
+                             catfile($config{sourcedir}, "util", "opensslwrap.sh"),
+                             "util" ],
+                           [ catfile("apps", "openssl.cnf"),
+                             catfile($config{sourcedir}, "apps", "openssl.cnf"),
+                             "apps" ]) {
+             my ($dst, $src, $dir) = @$pair;
+             $out .= run_build($dst,
+                               'mkdir -p '.cmd_quote($dir)
+                               .' && ln -sf '.cmd_quote("../$src")
+                               .' '.cmd_quote($dst),
+                               [ 'build.ninja' ], [ $src ], [], "LN $dst");
+         }
+     }
+
+     my $test_command;
+     my $list_command;
+     if ($disabled{tests}) {
+         $test_command = $list_command =
+             'echo "Tests are not supported with your chosen Configure options"';
+     } else {
+         $test_command =
+             'SRCTOP='.cmd_quote($config{sourcedir})
+             .' BLDTOP='.cmd_quote($config{builddir})
+             .' PERL='.cmd_quote($config{PERL})
+             .' FIPSKEY='.cmd_quote($config{FIPSKEY})
+             .' EXE_EXT='.cmd_quote(platform->binext())
+             .' '.$perl.' '.cmd_quote(catfile($config{sourcedir}, "test", "run_tests.pl"))
+             .' ${TESTS}';
+         $list_command =
+             'SRCTOP='.cmd_quote($config{sourcedir})
+             .' '.$perl.' '.cmd_quote(catfile($config{sourcedir}, "test", "run_tests.pl"))
+             .' list';
+     }
+     $out .= run_console_build('run_tests', $test_command,
+                               [ 'build_generated',
+                                 'build_programs_nodep',
+                                 'build_modules_nodep',
+                                 'link-utils' ], [], [], 'TEST');
+     $out .= $target->('tests', 'run_tests');
+     $out .= $target->('test', 'tests');
+     $out .= run_console_build('list-tests', $list_command, [], [], [],
+                               'LIST TESTS');
+     $out .= run_console_build('help',
+                               'echo "Use ninja -t targets to list targets"',
+                               [], [], [], 'HELP');
+     $out .= "\ndefault all\n\n";
+     $out;
+-}
+
+{- # Building targets #####################################################
+
+  sub generatetarget {
+      my %args = @_;
+      our %manual_phony_targets;
+      return '' if $manual_phony_targets{$args{target}};
+      my @deps = compute_platform_depends(@{$args{deps}});
+      return ninja_build(out => $args{target}, rule => 'phony', in => \@deps);
+  }
+
+  sub generatesrc {
+      my %args = @_;
+      my $gen0 = $args{generator}->[0];
+      my $gen_args = command_args(@{$args{generator}}[1..$#{$args{generator}}]);
+      my $gen_incs = join("", map { " -I".cmd_quote($_) } @{$args{generator_incs}});
+      my $incs = join("", map { " -I".cmd_quote($_) } @{$args{incs}});
+      my $defs = join("", map { " -D".$_ } @{$args{defs}});
+      my @deps = compute_platform_depends(@{$args{generator_deps}},
+                                          @{$args{deps}});
+      if ($args{src} =~ /\.html$/) {
+          my $title = basename($args{src}, ".html");
+          my $pod = $gen0;
+          my $cmd = shell_join($perl,
+                               cmd_quote(catfile($config{sourcedir}, "util", "mkpod2html.pl")),
+                               '-i', cmd_quote($pod),
+                               '-o', cmd_quote($args{src}),
+                               '-t', cmd_quote($title),
+                               '-r', cmd_quote(catdir($config{sourcedir}, "doc")));
+          return run_build($args{src}, $cmd, [ $pod ],
+                           [ catfile($config{sourcedir}, "util", "mkpod2html.pl") ],
+                           [], "HTML $args{src}");
+      } elsif ($args{src} =~ /\.(\d)$/) {
+          my $section = $1;
+          my $name = uc basename($args{src}, ".$section");
+          my $pod = $gen0;
+          my $cmd = 'pod2man --name='.cmd_quote($name)
+                    .' --section='.$section.'ossl'
+                    .' --center=OpenSSL'
+                    .' --date='.cmd_quote($release_date)
+                    .' --release='.cmd_quote($config{full_version})
+                    .' '.cmd_quote($pod).' > '.cmd_quote($args{src});
+          return run_build($args{src}, $cmd, [ $pod ], [], [],
+                           "MAN $args{src}");
+      } elsif (platform->isdef($args{src})) {
+          my $out = platform->def($args{src});
+          my $mkdef = catfile($config{sourcedir}, "util", "mkdef.pl");
+          my $ord_ver = $args{intent} eq 'lib'
+              ? ' --version '.cmd_quote($config{version}) : '';
+          my $ord_name = $args{generator}->[1] || $args{product};
+          (my $mkdef_os = $target{shared_target}) =~ s|-shared$||;
+          my $cmd = $perl.' '.cmd_quote($mkdef).$ord_ver
+                    .' --type '.cmd_quote($args{intent})
+                    .' --ordinals '.cmd_quote($gen0)
+                    .' --name '.cmd_quote($ord_name)
+                    .' --OS '.cmd_quote($mkdef_os)
+                    .' > '.cmd_quote($out);
+          return run_build($out, $cmd, [ $gen0 ], [ @deps, $mkdef ],
+                           [], "MKDEF $out");
+      } elsif (platform->isasm($args{src})
+               || platform->iscppasm($args{src})) {
+          my $cppflags = {
+              shlib => "$lib_cflags $lib_cppflags",
+              lib => "$lib_cflags $lib_cppflags",
+              dso => "$dso_cflags $dso_cppflags",
+              bin => "$bin_cflags $bin_cppflags"
+          } -> {$args{intent}};
+          my $cmd;
+          if ($gen0 =~ /\.pl$/) {
+              $cmd = 'CC='.cmd_quote($cc).' '.$perl.$gen_incs.' '
+                     .cmd_quote($gen0).$gen_args.' '
+                     .cmd_quote($target{perlasm_scheme}).$incs.' '
+                     .$cppflags.$defs.' '.$config{processor}.' '
+                     .cmd_quote($args{src});
+          } elsif ($gen0 =~ /\.m4$/) {
+              $cmd = 'm4 -B 8192'.$gen_incs.' '.cmd_quote($gen0).$gen_args
+                     .' > '.cmd_quote($args{src});
+          } elsif ($gen0 =~ /\.S$/) {
+              $cmd = $cc.' '.$incs.' '.$cppflags.$defs.' -E '
+                     .cmd_quote($gen0)
+                     .' | '.$perl.' -ne '
+                     .cmd_quote('/^#(line)?\s*[0-9]+/ or print')
+                     .' > '.cmd_quote($args{src});
+          } else {
+              die "Generator type for $args{src} unknown: $gen0\n";
+          }
+          return run_build($args{src}, $cmd, [ $gen0 ], \@deps, [],
+                           "GENASM $args{src}");
+      } elsif ($gen0 =~ m|^.*\.in$|) {
+          my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
+                                               "util", "dofile.pl")),
+                               rel2abs($config{builddir}));
+          my @perlmodules = ();
+          my %perlmoduleincs = ();
+          my %perlmoduledeps = ();
+          my @raw_deps = @{$args{deps}};
+          push @raw_deps,
+              @{$unified_info{depends}->{generated_source_path($args{src})} // []};
+          my %seen_raw_deps = ();
+          @raw_deps = grep { !$seen_raw_deps{$_}++ } @raw_deps;
+
+          foreach my $x (('configdata.pm', @raw_deps)) {
+              my ($i, $m, $d);
+              if ($x =~ /\|/) {
+                  $i = $`;
+                  $d = $';
+                  $m = $d;
+                  $m =~ s|\.pm$||;
+                  $m =~ s|/|::|g;
+                  $d = catfile($i, $d) if $i;
+              } elsif ($x =~ /\.pm$/) {
+                  $i = dirname($x);
+                  $m = basename($x, '.pm');
+                  $d = $x;
+              } else {
+                  $d = $x;
+              }
+              if ($m) {
+                  my $resolved_d = resolve_perlmodule_path($d);
+                  if ($resolved_d ne $d) {
+                      $d = $resolved_d;
+                      $i = source_path_if_exists($i) if $i;
+                  }
+              }
+              push @perlmodules, '"-M'.$m.'"' if $m;
+              $perlmoduledeps{$d} = 1;
+              $perlmoduleincs{'"-I'.$i.'"'} = 1 if $i;
+          }
+          @deps = compute_platform_depends(@{$args{generator_deps}},
+                                           sort keys %perlmoduledeps);
+          my $perlmodules = join(' ', '', (sort keys %perlmoduleincs),
+                                 @perlmodules);
+          my $cmd = 'if [ -r '.cmd_quote($args{src}).' ]; then chmod u+w '
+                    .cmd_quote($args{src}).'; fi && '
+                    .$perl.$perlmodules.' '.cmd_quote($dofile)
+                    .' '.cmd_quote("-o$config{build_file}")
+                    .' '.cmd_quote($gen0).$gen_args
+                    .' > '.cmd_quote($args{src})
+                    .' && chmod a-w '.cmd_quote($args{src});
+          return run_build($args{src}, $cmd, [ $gen0 ], \@deps, [],
+                           "DOFILE $args{src}");
+      } elsif (grep { $_ eq $gen0 } @{$unified_info{programs}}) {
+          $gen0 = platform->bin($gen0);
+          my $wrap = catfile($config{builddir}, "util", "wrap.pl");
+          my $cmd = $perl.' '.cmd_quote($wrap).' '.cmd_quote($gen0).$gen_args
+                    .' > '.cmd_quote($args{src});
+          return run_build($args{src}, $cmd, [ $gen0 ],
+                           [ @deps, $wrap ], [], "RUN $args{src}");
+      } else {
+          my $cmd = $perl.$gen_incs.' '.cmd_quote($gen0).$gen_args
+                    .' > '.cmd_quote($args{src});
+          return run_build($args{src}, $cmd, [ $gen0 ], \@deps,
+                           [], "GEN $args{src}");
+      }
+  }
+
+  sub src2obj {
+      my %args = @_;
+      my @srcs = @{$args{srcs}};
+      my @deps = (@srcs, @{$args{deps}});
+      my @order = ('build_generated');
+      my $srcs = npaths(@srcs);
+      my @raw_incs = @{$args{incs}};
+      my @raw_defs = @{$args{defs}};
+      if (defined $args{product}) {
+          push @raw_incs,
+              @{$unified_info{includes}->{generated_source_path($args{product})} // []};
+          push @raw_defs,
+              @{$unified_info{defines}->{generated_source_path($args{product})} // []};
+      }
+      my %seen_incs = ();
+      my %seen_defs = ();
+      my $incs = join(" ", map { '-I'.$_ }
+                           grep { !$seen_incs{$_}++ } @raw_incs);
+      my $defs = join(" ", map { "-D".$_ }
+                           grep { !$seen_defs{$_}++ } @raw_defs);
+      my $obj = platform->obj($args{obj});
+      my $cmd = ($srcs[0] =~ /\.(cc|cpp)$/) ? $cxx : $cc;
+      my $cmdflags = ($srcs[0] =~ /\.(cc|cpp)$/)
+          ? {
+              shlib => "$lib_cxxflags $lib_cppflags",
+              lib => "$lib_cxxflags $lib_cppflags",
+              dso => "$dso_cxxflags $dso_cppflags",
+              bin => "$bin_cxxflags $bin_cppflags"
+            }->{$args{intent}}
+          : {
+              shlib => "$lib_cflags $lib_cppflags",
+              lib => "$lib_cflags $lib_cppflags",
+              dso => "$dso_cflags $dso_cppflags",
+              bin => "$bin_cflags $bin_cppflags"
+            }->{$args{intent}};
+
+      if ($srcs[0] =~ /\.rc$/) {
+          return ninja_build(out => $obj, rule => 'cc_nodep',
+                             in => \@deps,
+                             order => \@order,
+                             vars => { srcs => $srcs,
+                                       cmd => $rc,
+                                       cmdflags => join(' ', @{$config{RCFLAGS}},
+                                                        $target{shared_rcflag}),
+                                       cmdcompile => '',
+                                       incs => $incs,
+                                       defs => $defs });
+      } elsif ($srcs[0] =~ /\.s$/) {
+          return ninja_build(out => $obj, rule => 'cc_nodep',
+                             in => \@deps,
+                             order => \@order,
+                             vars => { srcs => $srcs,
+                                       cmd => $cmd,
+                                       cmdflags => "$cmdflags -c",
+                                       cmdcompile => '',
+                                       incs => '',
+                                       defs => '' });
+      } elsif ($srcs[0] =~ /\.S$/) {
+          return ninja_build(out => $obj, rule => 'cc_nodep',
+                             in => \@deps,
+                             order => \@order,
+                             vars => { srcs => $srcs,
+                                       cmd => $cmd,
+                                       cmdflags => "$cmdflags -c",
+                                       cmdcompile => '',
+                                       incs => $incs,
+                                       defs => $defs });
+      } elsif (!$disabled{makedepend} && $makedep_scheme eq 'gcc') {
+          return ninja_build(out => $obj, rule => 'cc',
+                             in => \@deps,
+                             order => \@order,
+                             vars => { srcs => $srcs,
+                                       cmd => $cmd,
+                                       cmdflags => $cmdflags,
+                                       depfile => platform->dep($args{obj}),
+                                       incs => $incs,
+                                       defs => $defs });
+      } elsif (!$disabled{makedepend} && $makedep_scheme eq 'makedepend') {
+          return ninja_build(out => $obj, rule => 'cc_makedepend',
+                             in => \@deps,
+                             order => \@order,
+                             vars => { srcs => $srcs,
+                                       cmd => $cmd,
+                                       cmdflags => $cmdflags,
+                                       cmdcompile => '-c',
+                                       depfile => platform->dep($args{obj}),
+                                       incs => $incs,
+                                       defs => $defs });
+      }
+      return ninja_build(out => $obj, rule => 'cc_nodep',
+                         in => \@deps,
+                         order => \@order,
+                         vars => { srcs => $srcs,
+                                   cmd => $cmd,
+                                   cmdflags => $cmdflags,
+                                   cmdcompile => '-c',
+                                   incs => $incs,
+                                   defs => $defs });
+  }
+
+  sub obj2lib {
+      my %args = @_;
+      my $lib = platform->staticlib($args{lib});
+      my @objs = map { platform->obj($_) } @{$args{objs}};
+      return ninja_build(out => $lib, rule => 'ar', in => \@objs,
+                         vars => { ar => $ar,
+                                   arflags => join(' ', @{$config{ARFLAGS}}),
+                                   ranlib => $ranlib });
+  }
+
+  sub obj2shlib {
+      my %args = @_;
+      my @objs = map { platform->convertext($_) }
+                 grep { !platform->isdef($_) } @{$args{objs}};
+      my @defs = map { platform->def($_) }
+                 grep { platform->isdef($_) } @{$args{objs}};
+      my @deps = compute_lib_depends(@{$args{deps}});
+      die "More than one exported symbol map" if scalar @defs > 1;
+      my $full = platform->sharedlib($args{lib});
+      my $import = platform->sharedlib_import($args{lib});
+      my $simple = platform->sharedlib_simple($args{lib});
+      my ($linkflags, $linklibs) = link_flags(@{$args{deps}});
+      my $shared_soname = defined $target{shared_sonameflag}
+          ? ' '.expand_makevars($target{shared_sonameflag}).basename($full) : '';
+      my $shared_imp = defined $target{shared_impflag} && defined $import
+          ? ' '.expand_makevars($target{shared_impflag}).basename($import) : '';
+      my $shared_def = join("", map { ' '.expand_makevars($target{shared_defflag}).$_ } @defs);
+      my $cmd = $cc.' '.$lib_cflags.' '.$linkflags.' '.$lib_lflags
+                .$shared_soname.$shared_imp
+                .' -o '.cmd_quote($full).$shared_def.' '
+                .join(' ', map { cmd_quote($_) } @objs).' '
+                .$linklibs.' '.$lib_ex_libs;
+      if (windowsdll()) {
+          $cmd .= ' && rm -f apps/'.cmd_quote($full)
+                  .' fuzz/'.cmd_quote($full)
+                  .' && cp -p '.cmd_quote($full).' apps/'
+                  .' && cp -p '.cmd_quote($full).' fuzz/';
+          $cmd .= ' && rm -f test/'.cmd_quote($full)
+                  .' && cp -p '.cmd_quote($full).' test/'
+              unless $disabled{tests};
+      }
+      my $recipe = ninja_build(out => $full, rule => 'link',
+                               in => [ @objs, @defs, @deps ],
+                               vars => { command => $cmd });
+      if (defined $simple && $simple ne $full) {
+          my $cmd = sharedaix()
+              ? 'rm -f '.cmd_quote($simple).' && '.$ar.' r '
+                .cmd_quote($simple).' '.cmd_quote($full)
+              : 'rm -f '.cmd_quote($simple).' && ln -s '
+                .cmd_quote($full).' '.cmd_quote($simple);
+          $recipe .= run_build($simple, $cmd, [ $full ], [], [],
+                               "LINK $simple");
+      }
+      if (defined $import) {
+          if (sharedaix_solib()) {
+              my $cmd = 'rm -f '.cmd_quote($import).' && echo \\#!'
+                        .cmd_quote($full).' > '.cmd_quote($import)
+                        .' && cat '.cmd_quote($defs[0]).' >>'.cmd_quote($import);
+              $recipe .= run_build($import, $cmd, [ $full, $defs[0] ], [], [],
+                                   "IMPORT $import");
+          } else {
+              $recipe .= ninja_build(out => $import, rule => 'phony',
+                                     in => [ $full ]);
+          }
+      }
+      return $recipe;
+  }
+
+  sub obj2dso {
+      my %args = @_;
+      my $dso = platform->dso($args{module});
+      my @objs = map { platform->convertext($_) }
+                 grep { !platform->isdef($_) } @{$args{objs}};
+      my @defs = map { platform->def($_) }
+                 grep { platform->isdef($_) } @{$args{objs}};
+      my @deps = compute_lib_depends(@{$args{deps}});
+      my $shared_def = join("", map { ' '.expand_makevars($target{shared_defflag}).$_ } @defs);
+      $shared_def .= ' '.expand_makevars($target{shared_fipsflag})
+          if (defined $target{shared_fipsflag}
+              && $shared_def =~ m/providers\/fips/);
+      my ($linkflags, $linklibs) = link_flags(@{$args{deps}});
+      my $cmd = $cc.' '.$dso_cflags.' '.$linkflags.' '.$dso_lflags
+                .' -o '.cmd_quote($dso).$shared_def.' '
+                .join(' ', map { cmd_quote($_) } @objs).' '
+                .$linklibs.' '.$dso_ex_libs;
+      return ninja_build(out => $dso, rule => 'link',
+                         in => [ @objs, @defs, @deps ],
+                         vars => { command => $cmd });
+  }
+
+  sub obj2bin {
+      my %args = @_;
+      my $bin = platform->bin($args{bin});
+      my @objs = map { platform->obj($_) } @{$args{objs}};
+      my @deps = compute_lib_depends(@{$args{deps}});
+      my ($linkflags, $linklibs) = link_flags(@{$args{deps}});
+      my $cmd = (grep /_cc\.o$/, @{$args{objs}}) ? $cxx : $cc;
+      my $cmdflags = (grep /_cc\.o$/, @{$args{objs}})
+          ? $bin_cxxflags : $bin_cflags;
+      my $link = $cmd.' '.$cmdflags.' '.$linkflags.' '.$bin_lflags
+                 .' -o '.cmd_quote($bin).' '
+                 .join(' ', map { cmd_quote($_) } @objs).' '
+                 .$linklibs.' '.$bin_ex_libs;
+      return ninja_build(out => $bin, rule => 'link',
+                         in => [ @objs, @deps ],
+                         vars => { command => 'rm -f '.cmd_quote($bin)
+                                              .' && '.$link });
+  }
+
+  sub in2script {
+      my %args = @_;
+      my $script = $args{script};
+      my @sources = @{$args{sources}};
+      my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
+                                           "util", "dofile.pl")),
+                           rel2abs($config{builddir}));
+      my $cmd = 'if [ -r '.cmd_quote($script).' ]; then chmod u+w '
+                .cmd_quote($script).'; fi && rm -f '.cmd_quote($script)
+                .' && '.$perl.' '.cmd_quote("-I$config{builddir}")
+                .' -Mconfigdata '.cmd_quote($dofile)
+                .' '.cmd_quote("-o$config{build_file}")
+                .' '.join(' ', map { cmd_quote($_) } @sources)
+                .' > '.cmd_quote($script)
+                .' && chmod a+x,a-w '.cmd_quote($script);
+      return run_build($script, $cmd, [ @sources, 'configdata.pm' ], [], [],
+                       "SCRIPT $script");
+  }
+
+  sub generatedir {
+      my %args = @_;
+      my $dir = $args{dir};
+      return if $dir eq "test" || $dir eq ".";
+      my @deps = compute_platform_depends(@{$args{deps}});
+      foreach my $type (("dso", "lib", "bin", "script")) {
+          next unless defined($unified_info{dirinfo}->{$dir}->{products}->{$type});
+          next if $type eq "lib";
+          foreach my $prod (@{$unified_info{dirinfo}->{$dir}->{products}->{$type}}) {
+              push @deps, compute_platform_depends($prod) if dirname($prod) eq $dir;
+          }
+      }
+      return ninja_build(out => [ $dir, "$dir/" ], rule => 'phony',
+                         in => \@deps);
+  }
+
+  sub generated_source_path {
+      my $src = shift;
+      return $src if file_name_is_absolute($src) || $src =~ m|^\.\.[\\/]|;
+      return catfile($config{sourcedir}, split m|[\\/]+|, $src);
+  }
+
+  sub resolve_perlmodule_path {
+      my $path = shift;
+      return $path if !defined($path) || $path eq '' || $path eq '.'
+                      || file_name_is_absolute($path)
+                      || $path =~ m|^\.\.[\\/]|
+                      || exists $unified_info{generate}->{$path}
+                      || -e $path;
+      my $source_path = generated_source_path($path);
+      return -e $source_path ? $source_path : $path;
+  }
+
+  sub source_path_if_exists {
+      my $path = shift;
+      return $path if !defined($path) || $path eq ''
+                      || file_name_is_absolute($path)
+                      || $path =~ m|^\.\.[\\/]|;
+      my $source_path = generated_source_path($path);
+      return -e $source_path ? $source_path : $path;
+  }
+
+  sub shadowed_generated_rules {
+      return '' if rel2abs($config{sourcedir}) eq rel2abs($config{builddir});
+
+      # Out-of-tree builds can be configured from a source tree that already
+      # contains ignored generated exporter files.  Add local rules for the
+      # shadowed generated dependencies that the normal generation pass skips.
+      my @fallbacks = qw(
+          OpenSSLConfig.cmake
+          builddata.pm
+          exporters/OpenSSLConfig.cmake
+          exporters/libcrypto.pc
+          exporters/libssl.pc
+          installdata.pm
+          libcrypto.pc
+          libssl.pc
+      );
+      my $out = '';
+
+      for my $src (@fallbacks) {
+          my $generator = $unified_info{generate}->{$src} // next;
+          my $source_path = generated_source_path($src);
+          next unless -e $source_path;
+
+          my $gen0 = $generator->[0];
+          my @deps = @{$unified_info{depends}->{$src}
+                       // $unified_info{depends}->{$source_path}
+                       // []};
+          my %attrs = %{$unified_info{attributes}->{generate}->{$src} // {}};
+
+          $out .= generatesrc(
+              src => $src,
+              product => undef,
+              generator => $generator,
+              generator_incs => $unified_info{includes}->{$gen0} // [],
+              generator_deps => $unified_info{depends}->{$gen0} // [],
+              deps => \@deps,
+              incs => [],
+              defs => [],
+              attrs => { %attrs });
+      }
+
+      return $out;
+  }
+
+  shadowed_generated_rules();
+-}

--- a/Configurations/build.ninja.tmpl
+++ b/Configurations/build.ninja.tmpl
@@ -249,7 +249,7 @@
          FIPSMODULE => $fipsmodule,
          INCLUDEDIR => "include",
          INSTALLTOP => $prefix,
-         LDLIBS => $lib_ex_libs,
+         LDLIBS => join(' ', @{$config{LDLIBS}}),
          LIBDIR => $libdir,
          LIB_EX_LIBS => $lib_ex_libs,
          LIB_CFLAGS => $lib_cflags,
@@ -286,6 +286,7 @@
      $bin_cxxflags = expand_makevars($bin_cxxflags);
      $bin_lflags = expand_makevars($bin_lflags);
      $bin_ex_libs = expand_makevars($bin_ex_libs);
+     $makevars{LIB_EX_LIBS} = $lib_ex_libs;
 
      sub command_args {
          return join('', map { ' '.expand_makevars($_) } @_);
@@ -376,7 +377,7 @@ rule cc_nodep
 rule ar
   command = $perl "$srcdir/util/ninja-ar.pl" --ar "$ar" --arflags "$arflags" --ranlib "$ranlib" --out "$out" --rsp "$out.rsp"
   rspfile = $out.rsp
-  rspfile_content = $in
+  rspfile_content = $objs
   description = AR $out
 
 rule link
@@ -585,6 +586,90 @@ build reconfigure reconf: run_console
                                  'uninstall_html_docs' ],
                                [], [], 'UNINSTALL DOCS');
 
+     # Developer targets (Unix only)
+     $out .= run_console_build('generate_apps',
+                               $action->('generate_apps'),
+                               [], [], [], 'GENERATE apps');
+     $out .= run_console_build('generate_crypto_bn',
+                               $action->('generate_crypto_bn'),
+                               [], [], [], 'GENERATE crypto/bn');
+     $out .= run_console_build('generate_crypto_objects',
+                               $action->('generate_crypto_objects'),
+                               [], [], [], 'GENERATE crypto/objects');
+     $out .= run_console_build('generate_crypto_conf',
+                               $action->('generate_crypto_conf'),
+                               [], [], [], 'GENERATE crypto/conf');
+     $out .= run_console_build('generate_crypto_asn1',
+                               $action->('generate_crypto_asn1'),
+                               [], [], [], 'GENERATE crypto/asn1');
+     $out .= run_console_build('generate_fuzz_oids',
+                               $action->('generate_fuzz_oids'),
+                               [ 'generate_crypto_objects' ], [], [],
+                               'GENERATE fuzz/oids.txt');
+     $out .= $target->('generate', 'generate_apps', 'generate_crypto_bn',
+                       'generate_crypto_objects', 'generate_crypto_conf',
+                       'generate_crypto_asn1', 'generate_fuzz_oids');
+     $out .= run_console_build('generate_doc_buildinfo',
+                               $action->('generate_doc_buildinfo'),
+                               [], [], [], 'GENERATE doc/build.info');
+     $out .= $target->('generate_buildinfo', 'generate_doc_buildinfo');
+     $out .= run_console_build('errors', $action->('errors'),
+                               [], [], [], 'UPDATE errors');
+     $out .= run_console_build('ordinals', $action->('ordinals'),
+                               [ 'build_generated' ], [], [],
+                               'UPDATE ordinals');
+     $out .= run_console_build('renumber', $action->('renumber'),
+                               [ 'build_generated' ], [], [],
+                               'RENUMBER ordinals');
+     # The update action preserves the serial order used by the Make target.
+     $out .= run_console_build('update', $action->('update'),
+                               [ 'build_generated' ], [], [],
+                               'UPDATE generated sources');
+     $out .= run_console_build('doc-nits', $action->('doc_nits'),
+                               [ 'build_generated_pods' ], [], [],
+                               'CHECK documentation');
+     $out .= run_console_build('md-nits', $action->('md_nits'),
+                               [], [], [], 'CHECK markdown');
+     $out .= run_console_build('lint', $action->('lint'),
+                               [], [], [], 'LINT command');
+     $out .= run_console_build('check-clang-format-diff-cmd',
+                               $action->('check_format_cmd'),
+                               [], [], [], 'CHECK clang-format-diff');
+     $out .= run_console_build('check-format', $action->('check_format'),
+                               [ 'check-clang-format-diff-cmd' ], [], [],
+                               'CHECK format');
+     $out .= run_console_build('test_ordinals',
+                               $action->('test_ordinals'),
+                               [ 'build_generated',
+                                 'build_programs_nodep',
+                                 'build_modules_nodep', 'link-utils' ],
+                               [], [], 'TEST ordinals');
+     $out .= $target->('FORCE');
+     $out .= run_console_build([ 'tags', 'TAGS' ], $action->('tags'),
+                               [ 'FORCE', 'build_generated' ], [], [], 'TAGS');
+     $out .= run_console_build('providers/fips.module.sources.new',
+                               $action->('generate_fips_sources'),
+                               [ 'configdata.pm' ], [], [],
+                               'GENERATE FIPS sources');
+     $out .= $target->('generate_fips_sources',
+                       'providers/fips.module.sources.new');
+     $out .= run_console_build('providers/fips.checksum.new',
+                               $action->('fips_checksums'),
+                               [ 'providers/fips.module.sources.new' ],
+                               [], [], 'GENERATE FIPS checksums');
+     $out .= $target->('fips-checksums',
+                       'providers/fips.checksum.new');
+     $out .= run_console_build('update-fips-checksums',
+                               $action->('update_fips_checksums'),
+                               [ 'providers/fips.checksum.new' ], [], [],
+                               'UPDATE FIPS checksums');
+     $out .= run_console_build('diff-fips-checksums',
+                               $action->('diff_fips_checksums'),
+                               [ 'fips-checksums' ], [], [],
+                               'DIFF FIPS checksums');
+     $out .= run_console_build('tar', $action->('tar'),
+                               [], [], [], 'TAR');
+
      if (@utils) {
          foreach my $pair ([ catfile("util", "opensslwrap.sh"),
                              catfile($config{sourcedir}, "util", "opensslwrap.sh"),
@@ -597,7 +682,7 @@ build reconfigure reconf: run_console
                                'mkdir -p '.cmd_quote($dir)
                                .' && ln -sf '.cmd_quote("../$src")
                                .' '.cmd_quote($dst),
-                               [ 'build.ninja' ], [ $src ], [], "LN $dst");
+                               [], [ $src ], [ 'build.ninja' ], "LN $dst");
          }
      }
 
@@ -832,7 +917,7 @@ build reconfigure reconf: run_console
                              in => \@deps,
                              order => \@order,
                              vars => { srcs => $srcs,
-                                       cmd => $rc,
+                                       cmd => cmd_quote($rc),
                                        cmdflags => join(' ', @{$config{RCFLAGS}},
                                                         $target{shared_rcflag}),
                                        cmdcompile => '',
@@ -898,7 +983,8 @@ build reconfigure reconf: run_console
       return ninja_build(out => $lib, rule => 'ar', in => \@objs,
                          vars => { ar => $ar,
                                    arflags => join(' ', @{$config{ARFLAGS}}),
-                                   ranlib => $ranlib });
+                                   ranlib => $ranlib,
+                                   objs => join(' ', map { cmd_quote($_) } @objs) });
   }
 
   sub obj2shlib {

--- a/Configurations/windows-build.ninja.tmpl
+++ b/Configurations/windows-build.ninja.tmpl
@@ -1,0 +1,1091 @@
+##
+## Ninja build file for OpenSSL, native Windows targets
+##
+## {- join("\n## ", @autowarntext) -}
+{-
+     use File::Basename;
+     use File::Spec::Functions qw/:DEFAULT abs2rel rel2abs file_name_is_absolute
+                                    splitpath catpath canonpath/;
+     use Time::Piece;
+
+     use OpenSSL::Util;
+
+     my $build_scheme = $target{build_scheme};
+     our $builder_platform = $build_scheme->[1];
+     die "The Windows Ninja build template supports native Windows targets only\n"
+         if $builder_platform ne 'windows';
+
+     sub nval {
+         my $s = shift // '';
+         $s =~ s/\$/\$\$/g;
+         $s =~ s/\r?\n/ /g;
+         return $s;
+     }
+
+     sub npath {
+         my $s = shift;
+         return () unless defined $s && $s ne '';
+         $s =~ s/\$/\$\$/g;
+         $s =~ s/ /\$ /g;
+         $s =~ s/:/\$:/g;
+         return $s;
+     }
+
+     sub npaths {
+         return join(' ', map { npath($_) } grep { defined $_ && $_ ne '' } @_);
+     }
+
+     sub wq {
+         my $s = shift // '';
+         return '""' if $s eq '';
+         $s =~ s|/|\\|g;
+         $s =~ s/"/\\"/g;
+         return "\"$s\"";
+     }
+
+     sub cmd_c {
+         my $s = shift // '';
+         return $s =~ /^"/ ? 'cmd /C "'.$s.'"' : 'cmd /C '.$s;
+     }
+
+     sub cmd_q_c {
+         my $s = shift // '';
+         return 'cmd /C "'.$s.'"';
+     }
+
+     sub if_exist {
+         my ($path, $command) = @_;
+         return '(if exist '.wq($path).' '.$command.')';
+     }
+
+     sub if_not_exist {
+         my ($path, $command) = @_;
+         return '(if not exist '.wq($path).' '.$command.')';
+     }
+
+     sub shell_join {
+         return join(' ', grep { defined $_ && $_ ne '' } @_);
+     }
+
+     sub ninja_build {
+         my %args = @_;
+         my @outs = ref($args{out}) eq 'ARRAY' ? @{$args{out}} : ($args{out});
+         my @in = @{$args{in} // []};
+         my @implicit = @{$args{implicit} // []};
+         my @order = @{$args{order} // []};
+         my $result = 'build '.npaths(@outs).' : '.$args{rule};
+         $result .= ' '.npaths(@in) if @in;
+         $result .= ' | '.npaths(@implicit) if @implicit;
+         $result .= ' || '.npaths(@order) if @order;
+         $result .= "\n";
+         foreach my $k (sort keys %{$args{vars} // {}}) {
+             my $v = $args{vars}->{$k};
+             next unless defined $v && $v ne '';
+             $result .= "  $k = ".nval($v)."\n";
+         }
+         return $result;
+     }
+
+     sub run_build {
+         my ($out, $command, $in, $implicit, $order, $desc) = @_;
+         return ninja_build(out => $out, rule => 'run',
+                            in => $in // [], implicit => $implicit // [],
+                            order => $order // [],
+                            vars => { command => $command,
+                                      description => $desc // "GEN $out" });
+     }
+
+     sub run_console_build {
+         my ($out, $command, $in, $implicit, $order, $desc) = @_;
+         return ninja_build(out => $out, rule => 'run_console',
+                            in => $in // [], implicit => $implicit // [],
+                            order => $order // [],
+                            vars => { command => $command,
+                                      description => $desc // $out });
+     }
+
+     my $install_flavour = $build_scheme->[$#$build_scheme];
+     my $win_installenv =
+         $install_flavour eq "VC-WOW" ? "ProgramFiles(x86)"
+                                      : "ProgramW6432";
+     my $win_commonenv =
+         $install_flavour eq "VC-WOW" ? "CommonProgramFiles(x86)"
+                                      : "CommonProgramW6432";
+     my $win_installroot =
+         defined($ENV{$win_installenv}) ? $ENV{$win_installenv}
+                                        : $ENV{ProgramFiles};
+     my $win_commonroot =
+         defined($ENV{$win_commonenv}) ? $ENV{$win_commonenv}
+                                      : $ENV{CommonProgramFiles};
+
+     our $perl = (fixup_cmd_elements($config{PERL}))[0];
+     our $cc = $config{CC};
+     our $cpp = $config{CPP};
+     our $ld = $config{LD};
+     our $ar = $config{AR};
+     our $mt = $config{MT};
+     our $as = $config{AS};
+     our $rc = $config{RC};
+
+     our $coutflag = $target{coutflag} // '';
+     our $ldoutflag = $target{ldoutflag} // '';
+     our $ldpostoutflag = $target{ldpostoutflag} // '';
+     our $aroutflag = $target{aroutflag} // '';
+     our $mtinflag = $target{mtinflag} // '';
+     our $mtoutflag = $target{mtoutflag} // '';
+     our $asoutflag = $target{asoutflag} // '';
+     our $rcoutflag = $target{rcoutflag} // '';
+
+     our $prefix = canonpath($config{prefix}
+                             || "$win_installroot\\OpenSSL");
+     our $openssldir =
+         $config{openssldir}
+         ? (file_name_is_absolute($config{openssldir})
+            ? canonpath($config{openssldir})
+            : catdir($prefix, $config{openssldir}))
+         : canonpath("$win_commonroot\\SSL");
+     our $libdir = $config{libdir} || "lib";
+     our $libdir_abs = file_name_is_absolute($libdir) ? $libdir
+                                                      : catdir($prefix, $libdir);
+     our $modulesdir = catdir($libdir_abs, "ossl-modules");
+     our $cmakeconfigdir = catdir($libdir_abs, "cmake", "OpenSSL");
+     our @fipsmodules =
+         grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
+                && $unified_info{attributes}->{modules}->{$_}->{fips} }
+         @{$unified_info{modules}};
+     die "More than one FIPS module" if scalar @fipsmodules > 1;
+     our $fipsmodule = join(" ", map { platform->dso($_) } @fipsmodules);
+
+     my $cppflags1 =
+         join(" ",
+              (map { "-D".$_} @{$config{CPPDEFINES}}),
+              (map { "-I".wq($_)} @{$config{CPPINCLUDES}}),
+              @{$config{CPPFLAGS}});
+     my $cppflags2 =
+         join(' ', $target{cppflags} || (),
+                   (map { '-D'.quotify1($_) }
+                        @{$target{defines}}, @{$config{defines}}),
+                   (map { '-I'.wq($_) }
+                        @{$target{includes}}, @{$config{includes}}),
+                   @{$config{cppflags}});
+     my $cnf_asflags = join(' ', $target{asflags} || (),
+                                 @{$config{asflags}});
+     my $cnf_cflags = join(' ', $target{cflags} || (),
+                                @{$config{cflags}});
+     my $cnf_lflags = join(' ', $target{lflags} || (),
+                                @{$config{lflags}});
+     my $cnf_ex_libs = join(' ', $target{ex_libs} || (),
+                                 @{$config{ex_libs}});
+
+     our $lib_asflags =
+         join(' ', $target{lib_asflags} || (),
+                   @{$config{lib_asflags}},
+                   $cnf_asflags, @{$config{ASFLAGS}});
+     my $lib_cppflags_base =
+         join(' ', $target{lib_cppflags} || (),
+                   $target{shared_cppflag} || (),
+                   (map { '-D'.quotify1($_) }
+                        @{$target{lib_defines}},
+                        @{$target{shared_defines}},
+                        @{$config{lib_defines}},
+                        @{$config{shared_defines}}),
+                   (map { '-I'.wq($_) }
+                        @{$target{lib_includes}},
+                        @{$target{shared_includes}},
+                        @{$config{lib_includes}},
+                        @{$config{shared_includes}}),
+                   @{$config{lib_cppflags}},
+                   @{$config{shared_cppflag}});
+     our $lib_cppflags =
+         join(' ', $lib_cppflags_base,
+                   (map { '-D'.quotify1($_) }
+                        "OPENSSLDIR=\"$openssldir\"",
+                        "MODULESDIR=\"$modulesdir\""),
+                   $cppflags2, $cppflags1);
+     our $lib_cflags =
+         join(' ', $target{lib_cflags} || (),
+                   $target{shared_cflag} || (),
+                   @{$config{lib_cflags}},
+                   @{$config{shared_cflag}},
+                   $cnf_cflags, @{$config{CFLAGS}});
+     our $lib_lflags =
+         join(' ', $target{shared_ldflag} || (),
+                   $config{shared_ldflag} || (),
+                   $cnf_lflags, @{$config{LDFLAGS}});
+     our $lib_ex_libs = join(' ', $cnf_ex_libs, @{$config{LDLIBS}});
+
+     our $dso_asflags =
+         join(' ', $target{dso_asflags} || (),
+                   $target{module_asflags} || (),
+                   @{$config{dso_asflags}},
+                   @{$config{module_asflags}},
+                   $cnf_asflags, @{$config{ASFLAGS}});
+     our $dso_cppflags =
+         join(' ', $target{dso_cppflags} || (),
+                   $target{module_cppflag} || (),
+                   (map { '-D'.quotify1($_) }
+                        @{$target{dso_defines}},
+                        @{$target{module_defines}},
+                        @{$config{dso_defines}},
+                        @{$config{module_defines}}),
+                   (map { '-I'.wq($_) }
+                        @{$target{dso_includes}},
+                        @{$target{module_includes}},
+                        @{$config{dso_includes}},
+                        @{$config{module_includes}}),
+                   @{$config{dso_cppflags}},
+                   @{$config{module_cppflags}},
+                   $cppflags2, $cppflags1);
+     our $dso_cflags =
+         join(' ', $target{dso_cflags} || (),
+                   $target{module_cflags} || (),
+                   @{$config{dso_cflags}},
+                   @{$config{module_cflags}},
+                   $cnf_cflags, @{$config{CFLAGS}});
+     our $dso_lflags =
+         join(' ', $target{dso_lflags} || (),
+                   $target{module_ldflags} || (),
+                   @{$config{dso_lflags}},
+                   @{$config{module_ldflags}},
+                   $cnf_lflags, @{$config{LDFLAGS}});
+     our $dso_ex_libs = join(' ', $cnf_ex_libs, @{$config{LDLIBS}});
+
+     our $bin_asflags =
+         join(' ', $target{bin_asflags} || (),
+                   @{$config{bin_asflags}},
+                   $cnf_asflags, @{$config{ASFLAGS}});
+     our $bin_cppflags =
+         join(' ', $target{bin_cppflags} || (),
+                   (map { '-D'.$_ } @{$config{bin_defines} || ()}),
+                   @{$config{bin_cppflags}},
+                   $cppflags2, $cppflags1);
+     our $bin_cflags =
+         join(' ', $target{bin_cflags} || (),
+                   @{$config{bin_cflags}},
+                   $cnf_cflags, @{$config{CFLAGS}});
+     our $bin_lflags =
+         join(' ', $target{bin_lflags} || (),
+                   @{$config{bin_lflags}},
+                   $cnf_lflags, @{$config{LDFLAGS}});
+     our $bin_ex_libs = join(' ', $cnf_ex_libs, @{$config{LDLIBS}});
+
+     our $cppflags_q = do {
+         my $x = join(' ', $lib_cppflags_base || (), $cppflags2 || (),
+                           $cppflags1 || ());
+         $x =~ s|([\\"])|\\$1|g;
+         $x;
+     };
+     my $t = localtime;
+     if ($config{"release_date"}) {
+         eval { $t = Time::Piece->strptime($config{"release_date"}, "%d %b %Y"); }
+             || die "Parsing \$config{release_date} ('$config{release_date}') failed: $@";
+     }
+     our $release_date = $t->strftime("%Y-%m-%d");
+
+     our %makevars = (
+         APPS_OPENSSL => wq(catfile("apps", "openssl")),
+         BLDDIR => $config{builddir},
+         CC => $cc,
+         CMAKECONFIGDIR => $cmakeconfigdir,
+         CPP => $cpp,
+         CPPFLAGS_Q => $cppflags_q,
+         FIPSKEY => $config{FIPSKEY},
+         FIPSMODULE => $fipsmodule,
+         INSTALLTOP => $prefix,
+         LIBDIR => $libdir,
+         LIB_EX_LIBS => $lib_ex_libs,
+         LIB_CFLAGS => $lib_cflags,
+         MODULESDIR => $modulesdir,
+         PLATFORM => $config{target},
+         PREFIX => $prefix,
+         SRCDIR => $config{sourcedir},
+         VERSION => $config{full_version},
+         libdir => $libdir_abs,
+     );
+
+     sub expand_makevars {
+         my $s = shift;
+         $s =~ s/\$\(([^)]+)\)/exists $makevars{$1} ? $makevars{$1} : "\$($1)"/ge;
+         return $s;
+     }
+
+     sub command_args {
+         return join('', map { ' '.expand_makevars($_) } @_);
+     }
+
+     sub compute_lib_depends {
+         return map { $disabled{shared}
+                      ? platform->staticlib($_)
+                      : platform->sharedlib_import($_) // platform->staticlib($_) } @_;
+     }
+
+     sub compute_platform_depends {
+         map {
+             my $x = $_;
+             if (grep { $x eq $_ } @{$unified_info{programs}}) {
+                 platform->bin($x);
+             } elsif (grep { $x eq $_ } @{$unified_info{modules}}) {
+                 platform->dso($x);
+             } elsif (grep { $x eq $_ } @{$unified_info{libraries}}) {
+                 $disabled{shared}
+                     ? platform->staticlib($x)
+                     : platform->sharedlib_import($x) // platform->staticlib($x);
+             } else {
+                 platform->convertext($x);
+             }
+         } @_;
+     }
+
+     '';
+-}
+ninja_required_version = 1.8
+
+platform = {- nval($config{target}) -}
+srcdir = {- nval($config{sourcedir}) -}
+blddir = {- nval($config{builddir}) -}
+perl = {- nval($perl) -}
+cc = {- nval($cc) -}
+ld = {- nval($ld) -}
+ar = {- nval($ar) -}
+mt = {- nval($mt) -}
+as = {- nval($as) -}
+rc = {- nval($rc) -}
+
+rule run
+  command = $command
+  description = $description
+  restat = 1
+
+rule run_console
+  command = $command
+  description = $description
+  pool = console
+
+rule cc
+  command = $cmd $cmdflags $defs -c $coutflag$out $srcs
+  description = CC $out
+
+rule cc_msvcdeps
+  command = cmd /D /C set VSLANG=1033&& $cmd $cmdflags $defs /showIncludes -c $coutflag$out $srcs
+  deps = msvc
+  msvc_deps_prefix = Note: including file:
+  description = CC $out
+
+rule rc
+  command = $cmd $cmdflags $rcoutflag$out $srcs
+  description = RC $out
+
+rule asm
+  command = $cmd $cmdflags $asoutflag$out $srcs
+  description = ASM $out
+
+rule ar_rsp
+  command = $command
+  rspfile = $rspfile
+  rspfile_content = $rspfile_content
+  description = AR $out
+
+rule link_rsp
+  command = $command
+  rspfile = $rspfile
+  rspfile_content = $rspfile_content
+  description = $description
+
+rule regen_build
+  command = {- nval(wq($perl)) -} configdata.pm
+  description = REGEN build.ninja
+  generator = 1
+
+rule regen_config
+  command = {- nval(wq($perl)) -} configdata.pm -r
+  description = RECONF configdata.pm
+  generator = 1
+
+build build.ninja: regen_build configdata.pm | {- npaths(@{$config{build_file_templates}}) -}
+build configdata.pm: regen_config {- npaths(catfile($config{sourcedir}, "Configure"), @{$config{build_infos}}, @{$config{conf_files}}) -}
+
+build reconfigure reconf: run_console
+  command = {- nval(wq($perl)) -} configdata.pm -r
+  description = RECONF
+
+{-
+     my @libs =
+         map { ( platform->sharedlib_import($_) // (),
+                 platform->staticlib($_) // () ) } @{$unified_info{libraries}};
+     my @modules =
+         map { platform->dso($_) }
+         grep { my $x = $_;
+                !grep { grep { $_ eq $x } @$_ } values %{$unified_info{depends}} }
+         @{$unified_info{modules}};
+     my @programs = map { platform->bin($_) } @{$unified_info{programs}};
+     my @scripts = @{$unified_info{scripts}};
+     my @install_programs =
+         map { platform->bin($_) }
+         grep { !$unified_info{attributes}->{programs}->{$_}->{noinst} }
+         @{$unified_info{programs}};
+     my @install_libs =
+         map { platform->sharedlib_import($_) // platform->staticlib($_) }
+         grep { !$unified_info{attributes}->{libraries}->{$_}->{noinst} }
+         @{$unified_info{libraries}};
+     my @install_modules =
+         map { platform->dso($_) }
+         grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
+                && !$unified_info{attributes}->{modules}->{$_}->{fips} }
+         @{$unified_info{modules}};
+     my @install_fipsmoduleconf =
+         $disabled{fips} ? () : (catfile("providers", "fipsmodule.cnf"));
+     my @bin_scripts =
+         grep { !$unified_info{attributes}->{scripts}->{$_}->{noinst}
+                && !$unified_info{attributes}->{scripts}->{$_}->{misc} }
+         @scripts;
+     my @misc_scripts =
+         grep { !$unified_info{attributes}->{scripts}->{$_}->{noinst}
+                && $unified_info{attributes}->{scripts}->{$_}->{misc} }
+         @scripts;
+     my @generated_mandatory = @{$unified_info{depends}->{""}};
+     my @all_generated = map { platform->convertext($_) } @generated;
+     my @htmldocs = map { @{$unified_info{htmldocs}->{$_}} } qw(man1 man3 man5 man7);
+     my @utils = ();
+     @utils = (catfile("apps", "openssl.cnf"))
+         if $config{sourcedir} ne $config{builddir};
+
+     our %manual_phony_targets = ();
+
+     my $target = sub {
+         my ($name, @deps) = @_;
+         $manual_phony_targets{$name} = 1;
+         push @deps, compute_platform_depends(@{$unified_info{depends}->{$name} // []});
+         my %seen;
+         @deps = grep { !$seen{$_}++ } @deps;
+         return ninja_build(out => $name, rule => 'phony', in => \@deps);
+     };
+
+     my $out = '';
+     my $ninja_build = wq(catfile($config{sourcedir},
+                                  "util", "ninja-build.pl"));
+     my $action = sub {
+         cmd_c(wq($perl).' '.$ninja_build.' '.wq($_[0]));
+     };
+
+     $out .= $target->('build_sw', 'build_generated', 'build_libs_nodep',
+                       'build_modules_nodep', 'build_programs_nodep',
+                       'copy-utils');
+     $out .= $target->('build_libs', 'build_generated', 'build_libs_nodep');
+     $out .= $target->('build_modules', 'build_generated', 'build_modules_nodep');
+     $out .= $target->('build_programs', 'build_generated',
+                       'build_programs_nodep');
+     $out .= $target->('build_inst_sw', 'build_generated', 'build_libs_nodep',
+                       'build_modules_nodep', 'build_inst_programs_nodep',
+                       'copy-utils');
+     $out .= $target->('build_inst_programs', 'build_generated',
+                       'build_inst_programs_nodep');
+     $out .= $target->('all', 'build_sw', ($disabled{docs} ? () : 'build_docs'));
+     $out .= $target->('build_docs', 'build_html_docs');
+     $out .= $target->('build_html_docs', @htmldocs);
+     $out .= $target->('build_generated', @generated_mandatory);
+     $out .= $target->('build_libs_nodep', @libs);
+     $out .= $target->('build_modules_nodep', @modules);
+     $out .= $target->('build_programs_nodep', @programs, @scripts);
+     $out .= $target->('build_inst_programs_nodep', @install_programs, @scripts);
+     $out .= $target->('build_apps', 'build_programs');
+     $out .= $target->('build_tests', 'build_programs');
+     $out .= $target->('build_all_generated', @generated_mandatory,
+                       @all_generated, 'build_docs');
+     $out .= $target->('copy-utils', @utils);
+     $out .= $target->('install', 'install_sw', 'install_ssldirs',
+                       ($disabled{docs} ? () : 'install_docs'),
+                       ($disabled{fips} ? () : 'install_fips'));
+     $out .= $target->('uninstall',
+                       ($disabled{docs} ? () : 'uninstall_docs'),
+                       'uninstall_sw',
+                       ($disabled{fips} ? () : 'uninstall_fips'));
+     $out .= $target->('install_sw', 'install_dev', 'install_modules',
+                       'install_runtime');
+     $out .= $target->('uninstall_sw', 'uninstall_runtime',
+                       'uninstall_modules', 'uninstall_dev');
+     $out .= $target->('install_docs', 'install_html_docs');
+     $out .= $target->('install_runtime', 'install_programs');
+     $out .= $target->('uninstall_runtime', 'uninstall_programs',
+                       'uninstall_runtime_libs');
+
+     $out .= run_console_build('clean', $action->('clean'), [], [], [],
+                               'CLEAN');
+     $out .= run_console_build('distclean', $action->('distclean'),
+                               [ 'clean' ], [], [], 'DISTCLEAN');
+     $out .= run_console_build('depend', $action->('depend'), [], [], [],
+                               'DEPEND');
+     $out .= run_console_build('install_ssldirs',
+                               $action->('install_ssldirs'),
+                               [ @misc_scripts ], [], [], 'INSTALL SSLDIRS');
+     $out .= run_console_build('install_runtime_libs',
+                               $action->('install_runtime_libs'),
+                               [ 'build_libs' ], [], [], 'INSTALL RUNTIME LIBS');
+     $out .= run_console_build('install_dev', $action->('install_dev'),
+                               [ 'install_runtime_libs', @install_libs ],
+                               [], [], 'INSTALL DEV');
+     $out .= run_console_build('install_modules',
+                               $action->('install_modules'),
+                               [ 'install_runtime_libs', 'build_modules',
+                                 @install_modules ],
+                               [], [], 'INSTALL MODULES');
+     $out .= run_console_build('install_programs',
+                               $action->('install_programs'),
+                               [ 'install_runtime_libs',
+                                 'build_inst_programs', @install_programs,
+                                 @bin_scripts ],
+                               [], [], 'INSTALL PROGRAMS');
+     $out .= run_console_build('install_fips', $action->('install_fips'),
+                               [ 'build_inst_sw', @install_fipsmoduleconf ],
+                               [], [], 'INSTALL FIPS');
+     $out .= run_console_build('install_image_docs',
+                               $action->('install_image_docs'),
+                               [], [], [], 'INSTALL IMAGE DOCS');
+     $out .= run_console_build('install_html_docs',
+                               $action->('install_html_docs'),
+                               [ 'install_image_docs', 'build_html_docs' ],
+                               [], [], 'INSTALL HTML DOCS');
+     $out .= run_console_build('uninstall_runtime_libs',
+                               $action->('uninstall_runtime_libs'),
+                               [], [], [], 'UNINSTALL RUNTIME LIBS');
+     $out .= run_console_build('uninstall_dev',
+                               $action->('uninstall_dev'),
+                               [ 'uninstall_runtime_libs' ], [], [],
+                               'UNINSTALL DEV');
+     $out .= run_console_build('uninstall_modules',
+                               $action->('uninstall_modules'),
+                               [], [], [], 'UNINSTALL MODULES');
+     $out .= run_console_build('uninstall_programs',
+                               $action->('uninstall_programs'),
+                               [], [], [], 'UNINSTALL PROGRAMS');
+     $out .= run_console_build('uninstall_fips',
+                               $action->('uninstall_fips'),
+                               [], [], [], 'UNINSTALL FIPS');
+     $out .= run_console_build('uninstall_image_docs',
+                               $action->('uninstall_image_docs'),
+                               [], [], [], 'UNINSTALL IMAGE DOCS');
+     $out .= run_console_build('uninstall_html_docs',
+                               $action->('uninstall_html_docs'),
+                               [ 'uninstall_image_docs' ], [], [],
+                               'UNINSTALL HTML DOCS');
+     $out .= run_console_build('uninstall_docs',
+                               $action->('uninstall_docs'),
+                               [ 'uninstall_html_docs' ], [], [],
+                               'UNINSTALL DOCS');
+
+     if (@utils) {
+         my $src = catfile($config{sourcedir}, "apps", "openssl.cnf");
+         my $dst = catfile("apps", "openssl.cnf");
+         $out .= run_build($dst,
+                           cmd_c(if_not_exist("apps", 'mkdir '.wq("apps"))
+                                 .' & copy /Y '.wq($src).' '.wq($dst)),
+                           [ 'build.ninja' ], [ $src ], [], "COPY $dst");
+     }
+
+     my $test_command;
+     my $list_command;
+     if ($disabled{tests}) {
+         $test_command = $list_command =
+             cmd_c('echo Tests are not supported with your chosen Configure options');
+     } else {
+         my $run_tests =
+             wq($perl).' '.wq(catfile($config{sourcedir}, "test", "run_tests.pl"));
+         $test_command =
+             cmd_q_c('set "SRCTOP='.$config{sourcedir}.'"'
+                     .' & set "BLDTOP='.$config{builddir}.'"'
+                     .' & set "PERL='.$config{PERL}.'"'
+                     .' & set "FIPSKEY='.$config{FIPSKEY}.'"'
+                     .' & if defined TESTS (call '.$run_tests.' %TESTS%)'
+                     .' else (call '.$run_tests.')');
+         $list_command =
+             cmd_c('set "SRCTOP='.$config{sourcedir}.'"'
+                   .' & '.wq($perl).' '
+                   .wq(catfile($config{sourcedir}, "test", "run_tests.pl"))
+                   .' list');
+     }
+     $out .= run_console_build('run_tests', $test_command,
+                               [ 'build_generated',
+                                 'build_programs_nodep',
+                                 'build_modules_nodep',
+                                 'copy-utils' ], [], [], 'TEST');
+     $out .= $target->('tests', 'run_tests');
+     $out .= $target->('test', 'tests');
+     $out .= run_console_build('list-tests', $list_command, [], [], [],
+                               'LIST TESTS');
+     $out .= run_console_build('help',
+                               cmd_c('echo Use ninja -t targets to list targets'),
+                               [], [], [], 'HELP');
+     $out .= "\ndefault all\n\n";
+     $out;
+-}
+
+{- # Building targets #####################################################
+
+  sub generatetarget {
+      my %args = @_;
+      our %manual_phony_targets;
+      return '' if $manual_phony_targets{$args{target}};
+      my @deps = compute_platform_depends(@{$args{deps}});
+      return ninja_build(out => $args{target}, rule => 'phony', in => \@deps);
+  }
+
+  sub generatesrc {
+      my %args = @_;
+      my $gen0 = $args{generator}->[0];
+      my $gen_args = command_args(@{$args{generator}}[1..$#{$args{generator}}]);
+      my $gen_incs = join("", map { " -I".wq($_) } @{$args{generator_incs}});
+      my $incs = join("", map { " -I".wq($_) } @{$args{incs}});
+      my $defs = join("", map { " -D".$_ } @{$args{defs}});
+      my @deps = compute_platform_depends(@{$args{generator_deps}},
+                                          @{$args{deps}});
+      if ($args{src} =~ /\.html$/) {
+          my $title = basename($args{src}, ".html");
+          my $pod = $gen0;
+          my $cmd = cmd_c(wq($perl).' '
+                          .wq(catfile($config{sourcedir}, "util", "mkpod2html.pl"))
+                          .' -i '.wq($pod)
+                          .' -o '.wq($args{src})
+                          .' -t '.wq($title)
+                          .' -r '.wq(catdir($config{sourcedir}, "doc")));
+          return run_build($args{src}, $cmd, [ $pod ],
+                           [ catfile($config{sourcedir}, "util", "mkpod2html.pl") ],
+                           [], "HTML $args{src}");
+      } elsif ($args{src} =~ /\.(\d)$/) {
+          my $section = $1;
+          my $name = uc basename($args{src}, ".$section");
+          my $pod = $gen0;
+          my $cmd = cmd_c('pod2man --name='.wq($name)
+                          .' --section='.$section.'ossl'
+                          .' --center=OpenSSL'
+                          .' --date='.wq($release_date)
+                          .' --release='.wq($config{full_version})
+                          .' '.wq($pod).' > '.wq($args{src}));
+          return run_build($args{src}, $cmd, [ $pod ], [], [],
+                           "MAN $args{src}");
+      } elsif (platform->isdef($args{src})) {
+          my $out = platform->def($args{src});
+          my $mkdef = abs2rel(rel2abs(catfile($config{sourcedir},
+                                              "util", "mkdef.pl")),
+                              rel2abs($config{builddir}));
+          my $ord_ver = $args{intent} eq 'lib'
+              ? ' --version '.quotify1($config{version}) : '';
+          my $ord_name =
+              $args{generator}->[1] || basename(platform->dsoname($args{product}));
+          my $cmd = cmd_c(wq($perl).' '.wq($mkdef).$ord_ver
+                          .' --type '.$args{intent}
+                          .' --ordinals '.wq($gen0)
+                          .' --name '.wq($ord_name)
+                          .' --OS windows > '.wq($out));
+          return run_build($out, $cmd, [ $gen0 ], [ @deps, $mkdef ],
+                           [], "MKDEF $out");
+      } elsif (platform->isasm($args{src})
+               || platform->iscppasm($args{src})) {
+          my $cppflags = {
+              shlib => "$lib_cflags $lib_cppflags",
+              lib => "$lib_cflags $lib_cppflags",
+              dso => "$dso_cflags $dso_cppflags",
+              bin => "$bin_cflags $bin_cppflags"
+          } -> {$args{intent}};
+          my $out = platform->isasm($args{src})
+              ? platform->asm($args{src}) : $args{src};
+          my $cmd;
+          if ($gen0 =~ /\.pl$/) {
+              $cmd = cmd_c('set "ASM='.$as.'" & '.wq($perl).$gen_incs.' '
+                           .wq($gen0).$gen_args.' '
+                           .wq($target{perlasm_scheme}).$incs.' '
+                           .$cppflags.$defs.' '.$config{processor}.' '
+                           .wq($out));
+          } elsif ($gen0 =~ /\.S$/) {
+              $cmd = cmd_c($cpp.' /D__ASSEMBLER__ '.$incs.' '.$cppflags
+                           .$defs.' '.wq($gen0).' > '.wq("$out.i")
+                           .' && move /Y '.wq("$out.i").' '.wq($out));
+          } else {
+              die "Generator type for $args{src} unknown: $gen0\n";
+          }
+          return run_build($out, $cmd, [ $gen0 ], \@deps, [],
+                           "GENASM $out");
+      } elsif ($gen0 =~ m|^.*\.in$|) {
+          my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
+                                               "util", "dofile.pl")),
+                               rel2abs($config{builddir}));
+          my @perlmodules = ();
+          my %perlmoduleincs = ();
+          my %perlmoduledeps = ();
+          my @raw_deps = @{$args{deps}};
+          push @raw_deps,
+              @{$unified_info{depends}->{generated_source_path($args{src})} // []};
+          my %seen_raw_deps = ();
+          @raw_deps = grep { !$seen_raw_deps{$_}++ } @raw_deps;
+
+          foreach my $x (('configdata.pm', @raw_deps)) {
+              my ($i, $m, $d);
+              if ($x =~ /\|/) {
+                  $i = $`;
+                  $d = $';
+                  $m = $d;
+                  $m =~ s|\.pm$||;
+                  $m =~ s|/|::|g;
+                  $d = catfile($i, $d) if $i;
+              } elsif ($x =~ /\.pm$/) {
+                  $i = dirname($x);
+                  $m = basename($x, '.pm');
+                  $d = $x;
+              } else {
+                  $d = $x;
+              }
+              if ($m) {
+                  my $resolved_d = resolve_perlmodule_path($d);
+                  if ($resolved_d ne $d) {
+                      $d = $resolved_d;
+                      $i = source_path_if_exists($i) if $i;
+                  }
+              }
+              push @perlmodules, '"-M'.$m.'"' if $m;
+              $perlmoduledeps{$d} = 1;
+              $perlmoduleincs{'"-I'.$i.'"'} = 1 if $i;
+          }
+          @deps = compute_platform_depends(@{$args{generator_deps}},
+                                           sort keys %perlmoduledeps);
+          my $perlmodules = join(' ', '', (sort keys %perlmoduleincs),
+                                 @perlmodules);
+          my $cmd = cmd_c(if_exist($args{src},
+                                   'attrib -r '.wq($args{src})).' & '
+                          .wq($perl).$perlmodules.' '.wq($dofile)
+                          .' '.wq("-o$config{build_file}")
+                          .' '.wq($gen0).$gen_args
+                          .' > '.wq($args{src})
+                          .' && attrib +r '.wq($args{src}));
+          return run_build($args{src}, $cmd, [ $gen0 ], \@deps, [],
+                           "DOFILE $args{src}");
+      } elsif (grep { $_ eq $gen0 } @{$unified_info{programs}}) {
+          $gen0 = platform->bin($gen0);
+          my $wrap = catfile($config{builddir}, "util", "wrap.pl");
+          my $cmd = cmd_c(wq($perl).' '.wq($wrap).' '.wq($gen0).$gen_args
+                          .' > '.wq($args{src}));
+          return run_build($args{src}, $cmd, [ $gen0 ],
+                           [ @deps, $wrap ], [], "RUN $args{src}");
+      } else {
+          my $cmd = cmd_c(wq($perl).$gen_incs.' '.wq($gen0).$gen_args
+                          .' > '.wq($args{src}));
+          return run_build($args{src}, $cmd, [ $gen0 ], \@deps,
+                           [], "GEN $args{src}");
+      }
+  }
+
+  sub src2obj {
+      my %args = @_;
+      my $asmext = platform->asmext();
+      my @srcs =
+          map { my $x = $_;
+                (platform->isasm($x) && grep { $x eq $_ } @generated)
+                ? platform->asm($x) : $x }
+          @{$args{srcs}};
+      my @deps = (@srcs, @{$args{deps}});
+      my @order = ('build_generated');
+      my $srcs = join(' ', map { wq($_) } @srcs);
+      my @raw_incs = @{$args{incs}};
+      my @raw_defs = @{$args{defs}};
+      if (defined $args{product}) {
+          push @raw_incs,
+              @{$unified_info{includes}->{generated_source_path($args{product})} // []};
+          push @raw_defs,
+              @{$unified_info{defines}->{generated_source_path($args{product})} // []};
+      }
+      my %seen_incs = ();
+      my %seen_defs = ();
+      my $incs = join("", map { ' -I'.wq($_) }
+                          grep { !$seen_incs{$_}++ } @raw_incs);
+      my $defs = join("", map { " -D".$_ }
+                          grep { !$seen_defs{$_}++ } @raw_defs);
+      my $cflags = { shlib => "$lib_cflags",
+                     lib => "$lib_cflags",
+                     dso => "$dso_cflags",
+                     bin => "$bin_cflags" } -> {$args{intent}};
+      $cflags .= $incs;
+      $cflags .= { shlib => " $lib_cppflags",
+                   lib => " $lib_cppflags",
+                   dso => " $dso_cppflags",
+                   bin => " $bin_cppflags" } -> {$args{intent}};
+      my $asflags = { shlib => "$lib_asflags",
+                      lib => "$lib_asflags",
+                      dso => "$dso_asflags",
+                      bin => "$bin_asflags" } -> {$args{intent}};
+
+      if ($srcs[0] =~ /\.rc$/) {
+          my $res = platform->res($args{obj});
+          return ninja_build(out => $res, rule => 'rc', in => \@deps,
+                             order => \@order,
+                             vars => { srcs => $srcs,
+                                       cmd => $rc,
+                                       cmdflags => join(' ', @{$config{RCFLAGS}}),
+                                       rcoutflag => $rcoutflag });
+      }
+
+      my $obj = platform->obj($args{obj});
+      if ($srcs[0] =~ /\Q${asmext}\E$/) {
+          return ninja_build(out => $obj, rule => 'asm', in => \@deps,
+                             order => \@order,
+                             vars => { srcs => $srcs,
+                                       cmd => $as,
+                                       cmdflags => $asflags,
+                                       asoutflag => $asoutflag });
+      } elsif ($srcs[0] =~ /\.S$/) {
+          my $cmd = cmd_c($cc.' /EP -D__ASSEMBLER__ '.$cflags.$defs.' '
+                          .$srcs.' > '.wq("$obj.asm")
+                          .' && '.$as.' '.$asflags.' '.$asoutflag.wq($obj)
+                          .' '.wq("$obj.asm"));
+          return run_build($obj, $cmd, \@deps, [], \@order, "ASM $obj");
+      }
+
+      my $rule = (!$disabled{makedepend}
+                  && ($config{makedep_scheme} // '') eq 'VC')
+          ? 'cc_msvcdeps' : 'cc';
+      return ninja_build(out => $obj, rule => $rule,
+                         in => \@deps,
+                         order => \@order,
+                         vars => { srcs => $srcs,
+                                   cmd => $cc,
+                                   cmdflags => $cflags,
+                                   coutflag => $coutflag,
+                                   defs => $defs });
+  }
+
+  sub obj2lib {
+      my %args = @_;
+      my $lib = platform->staticlib($args{lib});
+      my @objs = map { platform->obj($_) } @{$args{objs}};
+      my $rsp = "$lib.rsp";
+      my $cmd = cmd_c(if_exist($lib, 'del /F /Q '.wq($lib))
+                      .' & '.wq($ar).' '.join(' ', @{$config{ARFLAGS}})
+                      .' '.$aroutflag.wq($lib).' @'.wq($rsp));
+      return ninja_build(out => $lib, rule => 'ar_rsp', in => \@objs,
+                         vars => { command => $cmd,
+                                   rspfile => $rsp,
+                                   rspfile_content => join(' ', map { wq($_) } @objs) });
+  }
+
+  sub obj2shlib {
+      my %args = @_;
+      my $lib = $args{lib};
+      my @objs = map { platform->convertext($_) }
+                 grep { platform->isobj($_) } @{$args{objs}};
+      my @ress = map { platform->convertext($_) }
+                 grep { platform->isres($_) } @{$args{objs}};
+      my @defs = map { platform->def($_) }
+                 grep { platform->isdef($_) } @{$args{objs}};
+      my @deps = compute_lib_depends(@{$args{deps}});
+      die "More than one exported symbols list" if scalar @defs > 1;
+      my $import = platform->sharedlib_import($lib);
+      my $dll = platform->sharedlib($lib);
+      my $rsp = "$dll.rsp";
+      my $shared_def = @defs ? $target{lddefflag}.wq($defs[0]) : '';
+      my $implib_flag = $target{ld_implib_flag}
+                        ? $target{ld_implib_flag}.wq($import) : '';
+      my $rsp_content =
+          join(' ', (map { wq($_) } @objs),
+                    $ldoutflag.wq($dll).$ldpostoutflag,
+                    (map { wq($_) } @deps),
+                    $lib_ex_libs,
+                    $shared_def,
+                    (map { wq($_) } @ress));
+      my $postlink = if_exist("$dll.manifest",
+                              wq($mt).' '.join(' ', @{$config{MTFLAGS}}).' '
+                              .$mtinflag.wq("$dll.manifest").' '.$mtoutflag.wq($dll))
+                     .' & '.if_not_exist("apps", 'mkdir '.wq("apps"))
+                     .' & '.if_not_exist("fuzz", 'mkdir '.wq("fuzz"))
+                     .($disabled{tests} ? ''
+                        : ' & '.if_not_exist("test", 'mkdir '.wq("test")))
+                     .' & copy /Y '.wq($dll).' '.wq("apps")
+                     .' & copy /Y '.wq($dll).' '.wq("fuzz")
+                     .($disabled{tests} ? ''
+                        : ' & copy /Y '.wq($dll).' '.wq("test"));
+      my $cmd = cmd_c(if_exist("$dll.manifest",
+                               'del /F /Q '.wq("$dll.manifest"))
+                      .' & '.if_exist($dll, 'del /F /Q '.wq($dll))
+                      .' & '.if_exist($import, 'del /F /Q '.wq($import))
+                      .' & '.wq($ld).' '.join(' ', @{$config{LDFLAGS}})
+                      .' '.$lib_lflags.' @'.wq($rsp).' '.$implib_flag
+                      .' && ('.$postlink.')');
+      return ninja_build(out => [ $dll, $import ], rule => 'link_rsp',
+                         in => [ @objs, @ress, @defs, @deps ],
+                         vars => { command => $cmd,
+                                   description => "LINK $dll",
+                                   rspfile => $rsp,
+                                   rspfile_content => $rsp_content });
+  }
+
+  sub obj2dso {
+      my %args = @_;
+      my $dso = platform->dso($args{module});
+      my @objs = map { platform->convertext($_) }
+                 grep { platform->isobj($_) } @{$args{objs}};
+      my @ress = map { platform->convertext($_) }
+                 grep { platform->isres($_) } @{$args{objs}};
+      my @defs = map { platform->def($_) }
+                 grep { platform->isdef($_) } @{$args{objs}};
+      my @deps = compute_lib_depends(@{$args{deps}});
+      die "More than one exported symbols list" if scalar @defs > 1;
+      my $rsp = "$dso.rsp";
+      my $shared_def = @defs ? $target{lddefflag}.wq($defs[0]) : '';
+      my $rsp_content =
+          join(' ', (map { wq($_) } @objs),
+                    $ldoutflag.wq($dso).$ldpostoutflag,
+                    (map { wq($_) } @deps),
+                    $dso_ex_libs,
+                    $shared_def,
+                    (map { wq($_) } @ress));
+      my $cmd = cmd_c(if_exist("$dso.manifest",
+                               'del /F /Q '.wq("$dso.manifest"))
+                      .' & '.wq($ld).' '.join(' ', @{$config{LDFLAGS}})
+                      .' '.$dso_lflags.' @'.wq($rsp)
+                      .' && '.if_exist("$dso.manifest",
+                                       wq($mt).' '.join(' ', @{$config{MTFLAGS}}).' '
+                                       .$mtinflag.wq("$dso.manifest").' '.$mtoutflag.wq($dso)));
+      return ninja_build(out => $dso, rule => 'link_rsp',
+                         in => [ @objs, @ress, @defs, @deps ],
+                         vars => { command => $cmd,
+                                   description => "LINK $dso",
+                                   rspfile => $rsp,
+                                   rspfile_content => $rsp_content });
+  }
+
+  sub obj2bin {
+      my %args = @_;
+      my $bin = platform->bin($args{bin});
+      my @objs = map { platform->convertext($_) }
+                 grep { platform->isobj($_) } @{$args{objs}};
+      my @ress = map { platform->convertext($_) }
+                 grep { platform->isres($_) } @{$args{objs}};
+      my @deps = compute_lib_depends(@{$args{deps}});
+      my $rsp = "$bin.rsp";
+      my $rsp_content =
+          join(' ', (map { wq($_) } @objs),
+                    $ldoutflag.wq($bin).$ldpostoutflag,
+                    (map { wq($_) } @deps),
+                    $bin_ex_libs,
+                    (map { wq($_) } @ress));
+      my $cmd = cmd_c(if_exist("$bin.manifest",
+                               'del /F /Q '.wq("$bin.manifest"))
+                      .' & '.wq($ld).' '.join(' ', @{$config{LDFLAGS}})
+                      .' '.$bin_lflags.' @'.wq($rsp)
+                      .' && '.if_exist("$bin.manifest",
+                                       wq($mt).' '.join(' ', @{$config{MTFLAGS}}).' '
+                                       .$mtinflag.wq("$bin.manifest").' '.$mtoutflag.wq($bin)));
+      return ninja_build(out => $bin, rule => 'link_rsp',
+                         in => [ @objs, @ress, @deps ],
+                         vars => { command => $cmd,
+                                   description => "LINK $bin",
+                                   rspfile => $rsp,
+                                   rspfile_content => $rsp_content });
+  }
+
+  sub in2script {
+      my %args = @_;
+      my $script = $args{script};
+      my @sources = @{$args{sources}};
+      my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
+                                           "util", "dofile.pl")),
+                           rel2abs($config{builddir}));
+      my $cmd = cmd_c(if_exist($script, 'attrib -r '.wq($script))
+                      .' & '.wq($perl).' '.wq("-I$config{builddir}")
+                      .' -Mconfigdata '.wq($dofile)
+                      .' '.wq("-o$config{build_file}")
+                      .' '.join(' ', map { wq($_) } @sources)
+                      .' > '.wq($script)
+                      .' && attrib +r '.wq($script));
+      return run_build($script, $cmd, [ @sources, 'configdata.pm' ], [], [],
+                       "SCRIPT $script");
+  }
+
+  sub generatedir {
+      my %args = @_;
+      my $dir = $args{dir};
+      return if $dir eq "test" || $dir eq ".";
+      my @deps = compute_platform_depends(@{$args{deps}});
+      my %extinfo = ( dso => platform->dsoext(),
+                      lib => platform->libext(),
+                      bin => platform->binext() );
+
+      foreach my $type (("dso", "lib", "bin", "script")) {
+          next unless defined($unified_info{dirinfo}->{$dir}->{products}->{$type});
+          next if $type eq "lib";
+          foreach my $prod (@{$unified_info{dirinfo}->{$dir}->{products}->{$type}}) {
+              push @deps, $prod.$extinfo{$type} if dirname($prod) eq $dir;
+          }
+      }
+      return ninja_build(out => [ $dir, "$dir\\" ], rule => 'phony',
+                         in => \@deps);
+  }
+
+  sub generated_source_path {
+      my $src = shift;
+      return $src if file_name_is_absolute($src) || $src =~ m|^\.\.[\\/]|;
+      return catfile($config{sourcedir}, split m|[\\/]+|, $src);
+  }
+
+  sub resolve_perlmodule_path {
+      my $path = shift;
+      return $path if !defined($path) || $path eq '' || $path eq '.'
+                      || file_name_is_absolute($path)
+                      || $path =~ m|^\.\.[\\/]|
+                      || exists $unified_info{generate}->{$path}
+                      || -e $path;
+      my $source_path = generated_source_path($path);
+      return -e $source_path ? $source_path : $path;
+  }
+
+  sub source_path_if_exists {
+      my $path = shift;
+      return $path if !defined($path) || $path eq ''
+                      || file_name_is_absolute($path)
+                      || $path =~ m|^\.\.[\\/]|;
+      my $source_path = generated_source_path($path);
+      return -e $source_path ? $source_path : $path;
+  }
+
+  sub shadowed_generated_rules {
+      return '' if lc canonpath(rel2abs($config{sourcedir}))
+                   eq lc canonpath(rel2abs($config{builddir}));
+
+      # Out-of-tree builds can be configured from a source tree that already
+      # contains ignored generated exporter files.  Add local rules for the
+      # shadowed generated dependencies that the normal generation pass skips.
+      my @fallbacks = (
+          "OpenSSLConfig.cmake",
+          "builddata.pm",
+          catfile("exporters", "OpenSSLConfig.cmake"),
+          catfile("exporters", "libcrypto.pc"),
+          catfile("exporters", "libssl.pc"),
+          "installdata.pm",
+          "libcrypto.pc",
+          "libssl.pc",
+      );
+      my $out = '';
+
+      for my $src (@fallbacks) {
+          my $generator = $unified_info{generate}->{$src} // next;
+          my $source_path = generated_source_path($src);
+          next unless -e $source_path;
+
+          my $gen0 = $generator->[0];
+          my @deps = @{$unified_info{depends}->{$src}
+                       // $unified_info{depends}->{$source_path}
+                       // []};
+          my %attrs = %{$unified_info{attributes}->{generate}->{$src} // {}};
+
+          $out .= generatesrc(
+              src => $src,
+              product => undef,
+              generator => $generator,
+              generator_incs => $unified_info{includes}->{$gen0} // [],
+              generator_deps => $unified_info{depends}->{$gen0} // [],
+              deps => \@deps,
+              incs => [],
+              defs => [],
+              attrs => { %attrs });
+      }
+
+      return $out;
+  }
+
+  shadowed_generated_rules();
+-}

--- a/Configurations/windows-build.ninja.tmpl
+++ b/Configurations/windows-build.ninja.tmpl
@@ -815,7 +815,7 @@ build reconfigure reconf: run_console
           return ninja_build(out => $res, rule => 'rc', in => \@deps,
                              order => \@order,
                              vars => { srcs => $srcs,
-                                       cmd => $rc,
+                                       cmd => wq($rc),
                                        cmdflags => join(' ', @{$config{RCFLAGS}}),
                                        rcoutflag => $rcoutflag });
       }
@@ -825,13 +825,13 @@ build reconfigure reconf: run_console
           return ninja_build(out => $obj, rule => 'asm', in => \@deps,
                              order => \@order,
                              vars => { srcs => $srcs,
-                                       cmd => $as,
+                                       cmd => wq($as),
                                        cmdflags => $asflags,
                                        asoutflag => $asoutflag });
       } elsif ($srcs[0] =~ /\.S$/) {
-          my $cmd = cmd_c($cc.' /EP -D__ASSEMBLER__ '.$cflags.$defs.' '
+          my $cmd = cmd_c(wq($cc).' /EP -D__ASSEMBLER__ '.$cflags.$defs.' '
                           .$srcs.' > '.wq("$obj.asm")
-                          .' && '.$as.' '.$asflags.' '.$asoutflag.wq($obj)
+                          .' && '.wq($as).' '.$asflags.' '.$asoutflag.wq($obj)
                           .' '.wq("$obj.asm"));
           return run_build($obj, $cmd, \@deps, [], \@order, "ASM $obj");
       }
@@ -843,7 +843,7 @@ build reconfigure reconf: run_console
                          in => \@deps,
                          order => \@order,
                          vars => { srcs => $srcs,
-                                   cmd => $cc,
+                                   cmd => wq($cc),
                                    cmdflags => $cflags,
                                    coutflag => $coutflag,
                                    defs => $defs });

--- a/Configure
+++ b/Configure
@@ -2541,7 +2541,7 @@ if ($builder eq "unified") {
                 # $i = full module path in source directory
                 # $i2 = full module path in build directory
                 my $i; my $i2; my $m; my $d; my $d2;
-                if ($unified_info{generate}->{$ddest}
+                if (($unified_info{generate}->{$ddest} || $generate{$dest})
                     && $f =~ m/^(.*?)\|(.*)$/) {
                     $i = $1;
                     $m = $2;

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -208,6 +208,7 @@ Depending on your distribution, you need to run the following command as
 root user or prepend `sudo` to the command:
 
     $ make install
+    $ ninja install                                  # when configured with BUILDFILE=build.ninja
 
 By default, OpenSSL will be installed to
 
@@ -238,6 +239,7 @@ If you are using Visual Studio, open the Developer Command Prompt _elevated_
 and issue the following command.
 
     $ nmake install
+    $ ninja install                                  # when configured with BUILDFILE=build.ninja
 
 The easiest way to elevate the Command Prompt is to press and hold down both
 the `<CTRL>` and `<SHIFT>` keys while clicking the menu item in the task menu.
@@ -1399,11 +1401,18 @@ from `include/openssl/configuration.h.in`.
 
 If none of the generated build files suit your purpose, it's possible to
 write your own build file template and give its name through the environment
-variable `BUILDFILE`.  For example, Ninja build files could be supported by
-writing `Configurations/build.ninja.tmpl` and then configure with `BUILDFILE`
-set like this (Unix syntax shown, you'll have to adapt for other platforms):
+variable `BUILDFILE`.
+
+OpenSSL also includes Ninja build file templates for Unix-like and native
+Windows targets.  To configure OpenSSL to generate `build.ninja`, set
+`BUILDFILE` like this:
 
     $ BUILDFILE=build.ninja perl Configure [options...]
+
+On Windows:
+
+    $ set BUILDFILE=build.ninja
+    $ perl Configure [options...]
 
 ### Out of Tree Builds
 
@@ -1440,6 +1449,7 @@ Build OpenSSL
 Build OpenSSL by running:
 
     $ make                                           # Unix
+    $ ninja                                          # Unix or Windows, when configured with BUILDFILE=build.ninja
     $ mms                                            ! (or mmk) OpenVMS
     $ nmake                                          # Windows
 
@@ -1458,6 +1468,7 @@ After a successful build, and before installing, the libraries should
 be tested.  Run:
 
     $ make test                                      # Unix
+    $ ninja test                                     # Unix or Windows, when configured with BUILDFILE=build.ninja
     $ mms test                                       ! OpenVMS
     $ nmake test                                     # Windows
 
@@ -1474,6 +1485,7 @@ Install OpenSSL
 If everything tests ok, install OpenSSL with
 
     $ make install                                   # Unix
+    $ ninja install                                  # Unix or Windows, when configured with BUILDFILE=build.ninja
     $ mms install                                    ! OpenVMS
     $ nmake install                                  # Windows
 
@@ -1547,6 +1559,7 @@ but have the package installed somewhere else so that it can easily be
 packaged, can use
 
     $ make DESTDIR=/tmp/package-root install         # Unix
+    $ DESTDIR=/tmp/package-root ninja install        # Unix, when configured with BUILDFILE=build.ninja
     $ mms/macro="DESTDIR=TMP:[PACKAGE-ROOT]" install ! OpenVMS
 
 The specified destination directory will be prepended to all installation
@@ -1834,8 +1847,12 @@ change, it might be helpful to clean the build tree before attempting another
 build.  Use this command:
 
     $ make clean                                     # Unix
+    $ ninja clean                                    # Unix or Windows, when configured with BUILDFILE=build.ninja
     $ mms clean                                      ! (or mmk) OpenVMS
     $ nmake clean                                    # Windows
+
+When configured with `BUILDFILE=build.ninja`, use `ninja distclean` for the
+corresponding distclean operation.
 
 Assembler error messages can sometimes be sidestepped by using the `no-asm`
 configuration option. See also [notes](#notes-on-assembler-modules-compilation).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1750,8 +1750,12 @@ described here.  Examine the Makefiles themselves for the full list.
 Running Selected Tests
 ----------------------
 
-You can specify a set of tests to be performed
-using the `make` variable `TESTS`.
+You can specify a set of tests to be performed using the `make` variable
+`TESTS`.  With Ninja, set `TESTS` in the environment instead.  For example:
+
+    $ TESTS=test_cmp_http ninja test                 # Unix
+    $ set TESTS=test_cmp_http                        # Windows
+    $ ninja test                                     # Windows
 
 See the section [Running Selected Tests of
 test/README.md](test/README.md#running-selected-tests).

--- a/util/ninja-ar.pl
+++ b/util/ninja-ar.pl
@@ -1,0 +1,57 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use Getopt::Long;
+use Text::ParseWords;
+
+my $ar = undef;
+my $arflags = '';
+my $ranlib = '';
+my $out = undef;
+my $rsp = undef;
+
+GetOptions('ar=s'      => \$ar,
+           'arflags=s' => \$arflags,
+           'ranlib=s'  => \$ranlib,
+           'out=s'     => \$out,
+           'rsp=s'     => \$rsp)
+    or die "Error in command line arguments\n";
+
+die "No archiver was specified\n" unless defined $ar && $ar ne '';
+die "No output archive was specified\n" unless defined $out && $out ne '';
+die "No response file was specified\n" unless defined $rsp && $rsp ne '';
+
+open my $rfh, '<', $rsp or die "Trying to read $rsp: $!\n";
+my $rspdata = do { local $/; <$rfh> };
+close $rfh;
+
+my @objs = grep { $_ ne '' } shellwords($rspdata);
+die "No object files given for $out\n" unless @objs;
+
+unlink $out if -e $out;
+
+my @arcmd = shellwords($ar);
+my @arflags = shellwords($arflags);
+my $max_per_call = 500;
+
+while (@objs) {
+    my @chunk = splice @objs, 0, $max_per_call;
+    system { $arcmd[0] } @arcmd, @arflags, $out, @chunk;
+    die "Archiver command failed for $out\n" if $? != 0;
+}
+
+if (defined $ranlib && $ranlib ne '' && $ranlib ne 'true') {
+    my @ranlibcmd = shellwords($ranlib);
+    system { $ranlibcmd[0] } @ranlibcmd, $out;
+    warn "ranlib failed for $out; ignoring\n" if $? != 0;
+}
+
+exit 0;

--- a/util/ninja-ar.pl
+++ b/util/ninja-ar.pl
@@ -6,6 +6,8 @@
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
+# Build a static archive in chunks from a Ninja response file.
+
 use strict;
 use warnings;
 

--- a/util/ninja-build.pl
+++ b/util/ninja-build.pl
@@ -1,0 +1,779 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use File::Basename qw(basename dirname);
+use File::Copy qw(copy);
+use File::Find;
+use File::Path qw(make_path remove_tree);
+use File::Spec::Functions qw(:DEFAULT rel2abs file_name_is_absolute canonpath);
+use Text::ParseWords qw(shellwords);
+
+use lib '.';
+use configdata;
+
+my $srcdir = rel2abs($config{sourcedir});
+my $blddir = rel2abs($config{builddir});
+unshift @INC, catdir($srcdir, 'Configurations');
+require platform;
+
+my $action = shift @ARGV // usage();
+my $builder_platform = $target{build_scheme}->[1] // '';
+my $native_windows = $builder_platform eq 'windows';
+my $destdir = $ENV{DESTDIR} // '';
+my $buildfile = $config{build_file} || 'build.ninja';
+
+my %dirs = install_dirs();
+my %actions = (
+    clean                  => \&clean,
+    distclean              => \&distclean,
+    depend                 => \&depend,
+    install_ssldirs        => \&install_ssldirs,
+    install_dev            => \&install_dev,
+    uninstall_dev          => \&uninstall_dev,
+    install_modules        => \&install_modules,
+    uninstall_modules      => \&uninstall_modules,
+    install_runtime_libs   => \&install_runtime_libs,
+    uninstall_runtime_libs => \&uninstall_runtime_libs,
+    install_programs       => \&install_programs,
+    uninstall_programs     => \&uninstall_programs,
+    install_fips           => \&install_fips,
+    uninstall_fips         => \&uninstall_fips,
+    install_man_docs       => \&install_man_docs,
+    uninstall_man_docs     => \&uninstall_man_docs,
+    install_html_docs      => \&install_html_docs,
+    uninstall_html_docs    => \&uninstall_html_docs,
+    install_image_docs     => \&install_image_docs,
+    uninstall_image_docs   => \&uninstall_image_docs,
+    uninstall_docs         => \&uninstall_docs,
+);
+
+usage() unless exists $actions{$action};
+$actions{$action}->();
+
+sub usage {
+    die "Usage: perl util/ninja-build.pl <action>\n";
+}
+
+sub split_path {
+    return grep { $_ ne '' } split m|[\\/]+|, shift;
+}
+
+sub srcpath {
+    my $path = shift;
+    return $path if file_name_is_absolute($path);
+    return catfile($srcdir, split_path($path));
+}
+
+sub bldpath {
+    my $path = shift;
+    return $path if file_name_is_absolute($path);
+    return catfile($blddir, split_path($path));
+}
+
+sub dest_path {
+    my $path = canonpath(shift);
+    return $path if $destdir eq '';
+
+    if ($native_windows) {
+        $path =~ s|^[A-Za-z]:||;
+        $path =~ s|^[\\/]+||;
+        return catfile($destdir, split_path($path));
+    }
+
+    return $destdir . $path;
+}
+
+sub install_dirs {
+    my %d;
+
+    if ($native_windows) {
+        my $install_flavour = $target{build_scheme}->[$#{$target{build_scheme}}];
+        my $win_installenv = $install_flavour eq 'VC-WOW'
+            ? 'ProgramFiles(x86)' : 'ProgramW6432';
+        my $win_commonenv = $install_flavour eq 'VC-WOW'
+            ? 'CommonProgramFiles(x86)' : 'CommonProgramW6432';
+        my $win_installroot = defined $ENV{$win_installenv}
+            ? $ENV{$win_installenv} : $ENV{ProgramFiles};
+        my $win_commonroot = defined $ENV{$win_commonenv}
+            ? $ENV{$win_commonenv} : $ENV{CommonProgramFiles};
+
+        $d{installtop} = canonpath($config{prefix}
+                                   || catdir($win_installroot, 'OpenSSL'));
+        $d{openssldir} = $config{openssldir}
+            ? (file_name_is_absolute($config{openssldir})
+               ? canonpath($config{openssldir})
+               : catdir($d{installtop}, $config{openssldir}))
+            : canonpath(catdir($win_commonroot, 'SSL'));
+        my $libdir = $config{libdir} || 'lib';
+        $d{libdir_rel} = file_name_is_absolute($libdir) ? '' : $libdir;
+        $d{libdir} = file_name_is_absolute($libdir)
+            ? canonpath($libdir) : catdir($d{installtop}, $libdir);
+        $d{bindir_rel} = 'bin';
+        $d{bindir} = catdir($d{installtop}, 'bin');
+        $d{modulesdir} = catdir($d{libdir}, 'ossl-modules');
+        $d{cmakeconfigdir} = catdir($d{libdir}, 'cmake', 'OpenSSL');
+        $d{htmldir} = catdir($d{installtop}, 'html');
+    } else {
+        $d{installtop} = $config{prefix} || '/usr/local';
+        $d{openssldir} = $config{openssldir}
+            ? (file_name_is_absolute($config{openssldir})
+               ? $config{openssldir}
+               : catdir($d{installtop}, $config{openssldir}))
+            : catdir($d{installtop}, 'ssl');
+        my $libdir = $config{libdir} || 'lib' . ($target{multilib} // '');
+        $d{libdir_rel} = file_name_is_absolute($libdir) ? '' : $libdir;
+        $d{libdir} = file_name_is_absolute($libdir)
+            ? $libdir : catdir($d{installtop}, $libdir);
+        my $bindir = $config{bindir} || 'bin' . ($target{multibin} // '');
+        $d{bindir_rel} = file_name_is_absolute($bindir) ? '' : $bindir;
+        $d{bindir} = file_name_is_absolute($bindir)
+            ? $bindir : catdir($d{installtop}, $bindir);
+        $d{modulesdir} = catdir($d{libdir}, 'ossl-modules');
+        $d{pkgconfigdir} = catdir($d{libdir}, 'pkgconfig');
+        $d{cmakeconfigdir} = catdir($d{libdir}, 'cmake', 'OpenSSL');
+        $d{mandir} = catdir($d{installtop}, 'share', 'man');
+        $d{docdir} = catdir($d{installtop}, 'share', 'doc', 'openssl');
+        $d{htmldir} = catdir($d{docdir}, 'html');
+    }
+
+    return %d;
+}
+
+sub check_installtop {
+    die "INSTALLTOP should not be empty\n" if !defined $dirs{installtop}
+        || $dirs{installtop} eq '';
+}
+
+sub run {
+    system(@_) == 0 or die "Command failed: @_\n";
+}
+
+sub capture_to_file {
+    my ($outfile, @cmd) = @_;
+    my $tmp = "$outfile.tmp";
+    make_path(dirname($outfile));
+
+    open my $in, '-|', @cmd or die "Cannot run @cmd: $!\n";
+    open my $out, '>', $tmp or die "Cannot open $tmp for writing: $!\n";
+    while (my $line = <$in>) {
+        print $out $line or die "Cannot write to $tmp: $!\n";
+    }
+    close $in or die "Command failed: @cmd\n";
+    close $out or die "Cannot close $tmp: $!\n";
+    rename $tmp, $outfile or die "Cannot rename $tmp to $outfile: $!\n";
+}
+
+sub rm_f {
+    for my $path (@_) {
+        next unless defined $path && $path ne '';
+        unlink $path if -e $path || -l $path;
+    }
+}
+
+sub rm_rf {
+    for my $path (@_) {
+        next unless defined $path && $path ne '';
+        remove_tree($path, { safe => 1 }) if -e $path;
+    }
+}
+
+sub maybe_rmdir {
+    for my $path (@_) {
+        next unless defined $path && $path ne '';
+        rmdir $path if -d $path;
+    }
+}
+
+sub copy_file {
+    my ($src, $dst, $mode, $atomic) = @_;
+    die "No such file: $src\n" unless -f $src;
+    make_path(dirname($dst));
+
+    my $tmp = $atomic ? "$dst.new" : $dst;
+    unlink $tmp if -e $tmp || -l $tmp;
+    copy($src, $tmp) or die "Cannot copy $src to $tmp: $!\n";
+    chmod $mode, $tmp if defined $mode;
+    if ($atomic) {
+        unlink $dst if -e $dst || -l $dst;
+        rename $tmp, $dst or die "Cannot rename $tmp to $dst: $!\n";
+    }
+    print "install $src -> $dst\n";
+}
+
+sub copy_to_dir {
+    my ($src, $dir, $mode, $atomic) = @_;
+    copy_file($src, catfile($dir, basename($src)), $mode, $atomic);
+}
+
+sub optional_copy_to_dir {
+    my ($src, $dir, $mode, $atomic) = @_;
+    copy_to_dir($src, $dir, $mode, $atomic) if defined $src && -f $src;
+}
+
+sub list_dir_files {
+    my ($dir, $re) = @_;
+    return () unless -d $dir;
+    opendir my $dh, $dir or die "Cannot open directory $dir: $!\n";
+    my @files = map { catfile($dir, $_) }
+                grep { /$re/ && -f catfile($dir, $_) } readdir $dh;
+    closedir $dh;
+    return sort @files;
+}
+
+sub attr {
+    my ($kind, $name, $attr) = @_;
+    return $unified_info{attributes}->{$kind}->{$name}->{$attr};
+}
+
+sub generated_files {
+    my %generatables =
+        map { $_ => 1 }
+        ((map { @{$unified_info{sources}->{$_}} }
+              keys %{$unified_info{sources}}),
+         ($disabled{shared}
+          ? ()
+          : map { @{$unified_info{shared_sources}->{$_}} }
+                keys %{$unified_info{shared_sources}}),
+         (map { $_ eq '' ? () : @{$unified_info{depends}->{$_}} }
+              keys %{$unified_info{depends}}));
+
+    return sort((grep { defined $unified_info{generate}->{$_} }
+                 sort keys %generatables),
+                (grep { defined $unified_info{sources}->{$_} }
+                 @{$unified_info{scripts}}));
+}
+
+sub build_modules {
+    return map { platform->dso($_) }
+           grep {
+               my $x = $_;
+               !grep { grep { $_ eq $x } @$_ } values %{$unified_info{depends}};
+           } @{$unified_info{modules}};
+}
+
+sub fips_modules {
+    return grep { !attr('modules', $_, 'noinst')
+                  && attr('modules', $_, 'fips') }
+           @{$unified_info{modules}};
+}
+
+sub install_modules_list {
+    return map { platform->dso($_) }
+           grep { !attr('modules', $_, 'noinst')
+                  && !attr('modules', $_, 'fips') }
+           @{$unified_info{modules}};
+}
+
+sub install_programs_list {
+    return map { platform->bin($_) }
+           grep { !attr('programs', $_, 'noinst') }
+           @{$unified_info{programs}};
+}
+
+sub install_libs_list {
+    return map {
+               $native_windows
+                   ? (platform->sharedlib_import($_) // platform->staticlib($_))
+                   : (platform->staticlib($_) // ())
+           }
+           grep { !attr('libraries', $_, 'noinst') }
+           @{$unified_info{libraries}};
+}
+
+sub install_shlibs {
+    return map { platform->sharedlib($_) // () }
+           grep { !attr('libraries', $_, 'noinst') }
+           @{$unified_info{libraries}};
+}
+
+sub shlib_info {
+    my ($install_only) = @_;
+    my @libs = $install_only
+        ? grep { !attr('libraries', $_, 'noinst') } @{$unified_info{libraries}}
+        : @{$unified_info{libraries}};
+    return map {
+        my $full = platform->sharedlib($_);
+        $full ? [ $full,
+                  platform->sharedlib_simple($_) // '',
+                  platform->sharedlib_import($_) // '' ] : ();
+    } @libs;
+}
+
+sub exporter_files {
+    my ($type) = @_;
+    return grep {
+        ($unified_info{attributes}->{generate}->{$_}->{exporter} // '') eq $type
+    } sort keys %{$unified_info{generate}};
+}
+
+sub lib_ex_libs {
+    return join(' ', $target{ex_libs} || (),
+                     @{$config{ex_libs}},
+                     @{$config{LDLIBS}});
+}
+
+sub input_path {
+    my $path = shift;
+    return $path if file_name_is_absolute($path) || -f $path;
+    my $src = srcpath($path);
+    return $src if -f $src;
+    return bldpath($path);
+}
+
+sub ensure_installdata {
+    my $outfile = bldpath('installdata.pm');
+    return if -f $outfile;
+
+    my @args = (
+        'COMMENT=This file provides configuration information for OpenSSL',
+        'PREFIX=' . $dirs{installtop},
+        'BINDIR=' . $dirs{bindir_rel},
+        'LIBDIR=' . $dirs{libdir_rel},
+        'libdir=' . $dirs{libdir},
+        'INCLUDEDIR=include',
+        'APPLINKDIR=include/openssl',
+        'MODULESDIR=' . $dirs{modulesdir},
+        'PKGCONFIGDIR=' . ($dirs{pkgconfigdir} // ''),
+        'CMAKECONFIGDIR=' . $dirs{cmakeconfigdir},
+        'LDLIBS=' . lib_ex_libs(),
+        'VERSION=' . $config{full_version},
+    );
+    capture_to_file($outfile, $config{PERL}, srcpath(catfile('util', 'mkinstallvars.pl')),
+                    @args);
+}
+
+sub ensure_generated {
+    my $file = shift;
+    my $outfile = bldpath($file);
+    return if -f $outfile;
+
+    ensure_installdata() if ($unified_info{attributes}->{generate}->{$file}->{exporter} // '');
+
+    my $generator = $unified_info{generate}->{$file}
+        or die "No generator known for $file\n";
+    my ($template, @args) = @$generator;
+
+    my @cmd = ($config{PERL}, '-I.', '-Mconfigdata');
+    push @cmd, '-Minstalldata' if -f bldpath('installdata.pm');
+    push @cmd, srcpath(catfile('util', 'dofile.pl')),
+               "-o$buildfile", input_path($template), @args;
+
+    capture_to_file($outfile, @cmd);
+    chmod 0444, $outfile;
+}
+
+sub bin_scripts {
+    my ($misc) = @_;
+    return map {
+               my $linkname = attr('scripts', $_, 'linkname');
+               !$native_windows && $linkname ? "$_:$linkname" : $_;
+           }
+           grep { !attr('scripts', $_, 'noinst')
+                  && (!!attr('scripts', $_, 'misc') == !!$misc) }
+           @{$unified_info{scripts}};
+}
+
+sub windowsdll {
+    return $config{target} =~ /^(?:Cygwin|mingw)/;
+}
+
+sub sharedaix {
+    return !$disabled{shared} && ($target{shared_target} // '') =~ /^aix(?!-solib$)/;
+}
+
+sub sharedaix_solib {
+    return !$disabled{shared} && ($target{shared_target} // '') =~ /^aix-solib$/;
+}
+
+sub clean {
+    for my $info (shlib_info(0)) {
+        my ($full, $simple, $import) = @$info;
+        rm_f(bldpath($full), bldpath($simple), bldpath($import));
+        if (windowsdll()) {
+            rm_f(map { bldpath(catfile($_, basename($full))) } qw(apps test fuzz));
+        }
+    }
+
+    rm_f(map { bldpath($_) }
+         (map { platform->staticlib($_) // () } @{$unified_info{libraries}}),
+         (map { platform->bin($_) } @{$unified_info{programs}}),
+         build_modules(),
+         (map { platform->dso($_) } fips_modules()),
+         @{$unified_info{scripts}},
+         @{$unified_info{depends}->{''} // []},
+         (map { platform->convertext($_) } generated_files()),
+         (map { @{$unified_info{htmldocs}->{$_}} } qw(man1 man3 man5 man7)),
+         (map { @{$unified_info{mandocs}->{$_}} } qw(man1 man3 man5 man7)));
+
+    rm_f(glob('*' . platform->defext())) if !$native_windows;
+    rm_f(bldpath('core'), bldpath('tags'), bldpath('TAGS'),
+         bldpath('doc-nits'), bldpath('md-nits'));
+    rm_rf(bldpath('test-runs'));
+    rm_f(glob(catfile('providers', 'fips*.new')));
+
+    if ($native_windows) {
+        find({ wanted => sub {
+                   return if -d $_;
+                   rm_f($File::Find::name)
+                       if /\.(?:d|obj|pdb|ilk|manifest|rsp)\z/i;
+               }, no_chdir => 1 }, '.');
+        rm_f(glob(catfile('apps', '*.' . $_))) for qw(lib rc res exp);
+        rm_f(glob(catfile('test', '*.exp')));
+    } else {
+        my $dep_ext = $target{dep_extension} || platform->depext();
+        my $obj_ext = $target{obj_extension} || platform->objext();
+        find({ wanted => sub {
+                   return if $_ =~ /^\./;
+                   return if -d $_;
+                   rm_f($File::Find::name)
+                       if /\Q$dep_ext\E\z/ || /\Q$obj_ext\E\z/ || /\.rsp\z/;
+               }, no_chdir => 1 }, '.');
+        find({ wanted => sub {
+                   return if $File::Find::name =~ m|^\./pkcs11-provider/|;
+                   return if $_ =~ /^\./;
+                   rm_f($File::Find::name) if -l $File::Find::name;
+               }, no_chdir => 1 }, '.');
+    }
+}
+
+sub distclean {
+    rm_f(bldpath(catfile('include', 'openssl', 'configuration.h')),
+         bldpath('configdata.pm'),
+         bldpath($buildfile));
+}
+
+sub depend {
+    if ($disabled{makedepend}) {
+        print "Dependency tracking is disabled for this configuration\n";
+    } else {
+        print "Ninja records compiler dependencies while building\n";
+    }
+}
+
+sub install_ssldirs {
+    check_installtop();
+    my $ossl = dest_path($dirs{openssldir});
+    make_path(catdir($ossl, 'certs'), catdir($ossl, 'private'), catdir($ossl, 'misc'));
+
+    for my $cnf (qw(openssl.cnf ct_log_list.cnf)) {
+        my $src = srcpath(catfile('apps', $cnf));
+        copy_file($src, catfile($ossl, "$cnf.dist"), 0644, 1);
+        copy_file($src, catfile($ossl, $cnf), 0644, 0)
+            unless -e catfile($ossl, $cnf);
+    }
+
+    for my $spec (bin_scripts(1)) {
+        my ($script, $linkname) = split /:/, $spec, 2;
+        my $src = bldpath($script);
+        my $dst = catfile($ossl, 'misc', basename($script));
+        copy_file($src, $dst, 0755, 1);
+        if (defined $linkname && $linkname ne '') {
+            my $link = catfile($ossl, 'misc', basename($linkname));
+            rm_f($link);
+            if (windowsdll() || $native_windows) {
+                copy_file($dst, $link, 0755, 0);
+            } else {
+                symlink basename($script), $link
+                    or die "Cannot symlink $link to " . basename($script) . ": $!\n";
+                print "link $link -> " . basename($script) . "\n";
+            }
+        }
+    }
+}
+
+sub install_runtime_libs {
+    check_installtop();
+    return if $disabled{shared};
+    my $dir = dest_path(windowsdll() || $native_windows
+                        ? $dirs{bindir} : $dirs{libdir});
+    make_path($dir);
+    print "*** Installing runtime libraries\n";
+    copy_to_dir(bldpath($_), $dir, 0755, 1) for install_shlibs();
+
+    if ($native_windows && platform->can('sharedlibpdb')) {
+        optional_copy_to_dir(bldpath(platform->sharedlibpdb($_)), $dir, 0644, 0)
+            for grep { !attr('libraries', $_, 'noinst') } @{$unified_info{libraries}};
+    }
+}
+
+sub install_dev {
+    check_installtop();
+    print "*** Installing development files\n";
+    my $includedir = dest_path(catdir($dirs{installtop}, 'include', 'openssl'));
+    my $libdir = dest_path($dirs{libdir});
+    make_path($includedir, $libdir);
+
+    if (!$disabled{uplink}) {
+        copy_to_dir(srcpath(catfile('ms', 'applink.c')), $includedir, 0644, 0);
+    }
+
+    for my $h (list_dir_files(srcpath(catdir('include', 'openssl')), qr/\.h\z/)) {
+        next if $native_windows && basename($h) =~ /__DECC_/;
+        copy_to_dir($h, $includedir, 0644, 0);
+    }
+    copy_to_dir($_, $includedir, 0644, 0)
+        for list_dir_files(bldpath(catdir('include', 'openssl')), qr/\.h\z/);
+
+    for my $lib (install_libs_list()) {
+        my $src = bldpath($lib);
+        my $dst = catfile($libdir, basename($lib));
+        copy_file($src, $dst, 0644, 1);
+        run(shellwords(($config{CROSS_COMPILE} // '') . $config{RANLIB}), $dst)
+            if !$native_windows && $config{RANLIB};
+    }
+
+    if (!$disabled{shared} && !$native_windows) {
+        for my $info (shlib_info(1)) {
+            my ($full, $simple, $import) = @$info;
+            if (!windowsdll() && !sharedaix() && !sharedaix_solib() && $simple ne '') {
+                my $link = catfile($libdir, basename($simple));
+                rm_f($link);
+                symlink basename($full), $link
+                    or die "Cannot symlink $link to " . basename($full) . ": $!\n";
+                print "link $link -> " . basename($full) . "\n";
+            } elsif ((windowsdll() || sharedaix_solib()) && $import ne '') {
+                copy_to_dir(bldpath($import), $libdir, 0644, 1);
+            }
+        }
+    }
+
+    if (!$native_windows) {
+        my $pcdir = dest_path($dirs{pkgconfigdir});
+        make_path($pcdir);
+        for my $e (exporter_files('pkg-config')) {
+            ensure_generated($e);
+            copy_to_dir(bldpath($e), $pcdir, 0644, 0);
+        }
+    }
+
+    my $cmakedir = dest_path($dirs{cmakeconfigdir});
+    make_path($cmakedir);
+    for my $e (exporter_files('cmake')) {
+        ensure_generated($e);
+        copy_to_dir(bldpath($e), $cmakedir, 0644, 0);
+    }
+}
+
+sub uninstall_dev {
+    print "*** Uninstalling development files\n";
+    my $includedir = dest_path(catdir($dirs{installtop}, 'include', 'openssl'));
+    my $libdir = dest_path($dirs{libdir});
+
+    rm_f(catfile($includedir, 'applink.c')) if !$disabled{uplink};
+    rm_f(catfile($includedir, basename($_)))
+        for list_dir_files(srcpath(catdir('include', 'openssl')), qr/\.h\z/),
+            list_dir_files(bldpath(catdir('include', 'openssl')), qr/\.h\z/);
+    maybe_rmdir($includedir, dirname($includedir));
+
+    rm_f(catfile($libdir, basename($_))) for install_libs_list();
+    if (!$disabled{shared} && !$native_windows) {
+        for my $info (shlib_info(1)) {
+            rm_f(catfile($libdir, basename($_))) for grep { $_ ne '' } @$info;
+        }
+    }
+
+    if (!$native_windows) {
+        my $pcdir = dest_path($dirs{pkgconfigdir});
+        rm_f(catfile($pcdir, basename($_))) for exporter_files('pkg-config');
+        maybe_rmdir($pcdir);
+    }
+    my $cmakedir = dest_path($dirs{cmakeconfigdir});
+    rm_f(catfile($cmakedir, basename($_))) for exporter_files('cmake');
+    maybe_rmdir($cmakedir, dirname($cmakedir), $libdir);
+}
+
+sub install_modules {
+    check_installtop();
+    my $dir = dest_path($dirs{modulesdir});
+    make_path($dir);
+    print "*** Installing modules\n";
+    copy_to_dir(bldpath($_), $dir, 0755, 1) for install_modules_list();
+
+    if ($native_windows && platform->can('dsopdb')) {
+        optional_copy_to_dir(bldpath(platform->dsopdb($_)), $dir, 0644, 0)
+            for grep { !attr('modules', $_, 'noinst') && !attr('modules', $_, 'fips') }
+                @{$unified_info{modules}};
+    }
+}
+
+sub uninstall_modules {
+    print "*** Uninstalling modules\n";
+    my $dir = dest_path($dirs{modulesdir});
+    rm_f(catfile($dir, basename($_))) for install_modules_list();
+    maybe_rmdir($dir);
+}
+
+sub install_programs {
+    check_installtop();
+    my $dir = dest_path($dirs{bindir});
+    make_path($dir);
+    print "*** Installing runtime programs\n";
+    copy_to_dir(bldpath($_), $dir, 0755, 1) for install_programs_list();
+
+    if ($native_windows && platform->can('binpdb')) {
+        optional_copy_to_dir(bldpath(platform->binpdb($_)), $dir, 0644, 0)
+            for grep { !attr('programs', $_, 'noinst') } @{$unified_info{programs}};
+    }
+
+    for my $spec (bin_scripts(0)) {
+        my ($script, $linkname) = split /:/, $spec, 2;
+        copy_to_dir(bldpath($script), $dir, 0755, 1);
+        if (defined $linkname && $linkname ne '') {
+            my $link = catfile($dir, basename($linkname));
+            rm_f($link);
+            symlink basename($script), $link
+                or die "Cannot symlink $link to " . basename($script) . ": $!\n";
+        }
+    }
+}
+
+sub uninstall_programs {
+    print "*** Uninstalling runtime programs\n";
+    my $dir = dest_path($dirs{bindir});
+    rm_f(catfile($dir, basename($_))) for install_programs_list();
+    for my $spec (bin_scripts(0)) {
+        my ($script, $linkname) = split /:/, $spec, 2;
+        rm_f(catfile($dir, basename($script)));
+        rm_f(catfile($dir, basename($linkname))) if defined $linkname;
+    }
+    maybe_rmdir($dir);
+}
+
+sub uninstall_runtime_libs {
+    print "*** Uninstalling runtime libraries\n";
+    my $dir = dest_path(windowsdll() || $native_windows
+                        ? $dirs{bindir} : $dirs{libdir});
+    rm_f(catfile($dir, basename($_))) for install_shlibs();
+    if ($native_windows && platform->can('sharedlibpdb')) {
+        rm_f(catfile($dir, basename(platform->sharedlibpdb($_))))
+            for grep { !attr('libraries', $_, 'noinst') } @{$unified_info{libraries}};
+    }
+}
+
+sub install_fips {
+    if ($disabled{fips}) {
+        print "The 'install_fips' target requires the 'enable-fips' option\n";
+        return;
+    }
+
+    check_installtop();
+    my @mods = fips_modules();
+    die "More than one FIPS module\n" if @mods > 1;
+    return if @mods == 0;
+
+    my $module = platform->dso($mods[0]);
+    my $moduledir = dest_path($dirs{modulesdir});
+    my $ossl = dest_path($dirs{openssldir});
+    make_path($moduledir, $ossl);
+
+    print "*** Installing FIPS module\n";
+    copy_file(bldpath($module), catfile($moduledir, basename($module)), 0755, 1);
+    print "*** Installing FIPS module configuration\n";
+    copy_to_dir(bldpath(catfile('providers', 'fipsmodule.cnf')), $ossl, 0644, 0);
+}
+
+sub uninstall_fips {
+    if ($disabled{fips}) {
+        print "The 'uninstall_fips' target requires the 'enable-fips' option\n";
+        return;
+    }
+
+    my @mods = fips_modules();
+    die "More than one FIPS module\n" if @mods > 1;
+    my $module = @mods ? platform->dso($mods[0]) : undef;
+    print "*** Uninstalling FIPS module configuration\n";
+    rm_f(catfile(dest_path($dirs{openssldir}), 'fipsmodule.cnf'));
+    print "*** Uninstalling FIPS module\n";
+    rm_f(catfile(dest_path($dirs{modulesdir}), basename($module))) if defined $module;
+}
+
+sub install_man_docs {
+    return if $native_windows || $disabled{docs};
+    check_installtop();
+    my $mandir = dest_path($dirs{mandir});
+    make_path(map { catdir($mandir, $_) } qw(man1 man3 man5 man7));
+    print "*** Installing manpages\n";
+
+    for my $section (qw(1 3 5 7)) {
+        my $key = "man$section";
+        my $dir = catdir($mandir, $key);
+        for my $doc (@{$unified_info{mandocs}->{$key}}) {
+            my $fn = basename($doc) . 'ossl';
+            copy_file(bldpath($doc), catfile($dir, $fn), 0644, 0);
+            run($config{PERL}, srcpath(catfile('util', 'write-man-symlinks')),
+                'install', srcpath(catdir('doc', $key)), bldpath(catdir('doc', $key)),
+                $fn, $dir);
+        }
+    }
+}
+
+sub uninstall_man_docs {
+    return if $native_windows || $disabled{docs};
+    print "*** Uninstalling manpages\n";
+    my $mandir = dest_path($dirs{mandir});
+    for my $section (qw(1 3 5 7)) {
+        my $key = "man$section";
+        my $dir = catdir($mandir, $key);
+        for my $doc (@{$unified_info{mandocs}->{$key}}) {
+            my $fn = basename($doc) . 'ossl';
+            rm_f(catfile($dir, $fn));
+            run($config{PERL}, srcpath(catfile('util', 'write-man-symlinks')),
+                'uninstall', srcpath(catdir('doc', $key)), bldpath(catdir('doc', $key)),
+                $fn, $dir);
+        }
+    }
+}
+
+sub install_html_docs {
+    return if $disabled{docs};
+    check_installtop();
+    my $htmldir = dest_path($dirs{htmldir});
+    make_path(map { catdir($htmldir, $_) } qw(man1 man3 man5 man7));
+    print "*** Installing HTML manpages\n";
+    for my $section (qw(1 3 5 7)) {
+        my $key = "man$section";
+        my $dir = catdir($htmldir, $key);
+        copy_to_dir(bldpath($_), $dir, 0644, 0)
+            for @{$unified_info{htmldocs}->{$key}};
+    }
+}
+
+sub uninstall_html_docs {
+    return if $disabled{docs};
+    print "*** Uninstalling HTML manpages\n";
+    my $htmldir = dest_path($dirs{htmldir});
+    for my $section (qw(1 3 5 7)) {
+        my $key = "man$section";
+        my $dir = catdir($htmldir, $key);
+        rm_f(catfile($dir, basename($_))) for @{$unified_info{htmldocs}->{$key}};
+    }
+}
+
+sub install_image_docs {
+    return if $disabled{docs};
+    check_installtop();
+    my $dir = dest_path(catdir($dirs{htmldir}, 'man7', 'img'));
+    make_path($dir);
+    print "*** Installing HTML images\n";
+    copy_to_dir(srcpath($_), $dir, 0644, 0)
+        for @{$unified_info{imagedocs}->{man7}};
+}
+
+sub uninstall_image_docs {
+    return if $disabled{docs};
+    my $dir = dest_path(catdir($dirs{htmldir}, 'man7', 'img'));
+    rm_f(catfile($dir, basename($_))) for @{$unified_info{imagedocs}->{man7}};
+}
+
+sub uninstall_docs {
+    return if $disabled{docs};
+    rm_rf(dest_path($dirs{docdir})) if !$native_windows;
+}

--- a/util/ninja-build.pl
+++ b/util/ninja-build.pl
@@ -10,6 +10,7 @@ use strict;
 use warnings;
 
 use File::Basename qw(basename dirname);
+use File::Compare qw(compare);
 use File::Copy qw(copy);
 use File::Find;
 use File::Path qw(make_path remove_tree);
@@ -35,6 +36,19 @@ my %actions = (
     clean                  => \&clean,
     distclean              => \&distclean,
     depend                 => \&depend,
+    check_format_cmd       => \&check_format_cmd,
+    check_format           => \&check_format,
+    doc_nits               => \&doc_nits,
+    errors                 => \&errors,
+    fips_checksums         => \&fips_checksums,
+    generate_apps          => \&generate_apps,
+    generate_crypto_asn1   => \&generate_crypto_asn1,
+    generate_crypto_bn     => \&generate_crypto_bn,
+    generate_crypto_conf   => \&generate_crypto_conf,
+    generate_crypto_objects => \&generate_crypto_objects,
+    generate_doc_buildinfo => \&generate_doc_buildinfo,
+    generate_fips_sources  => \&generate_fips_sources,
+    generate_fuzz_oids     => \&generate_fuzz_oids,
     install_ssldirs        => \&install_ssldirs,
     install_dev            => \&install_dev,
     uninstall_dev          => \&uninstall_dev,
@@ -53,6 +67,16 @@ my %actions = (
     install_image_docs     => \&install_image_docs,
     uninstall_image_docs   => \&uninstall_image_docs,
     uninstall_docs         => \&uninstall_docs,
+    lint                   => \&lint,
+    md_nits                => \&md_nits,
+    ordinals               => \&ordinals,
+    renumber               => \&renumber,
+    tags                   => \&tags,
+    tar                    => \&tar,
+    test_ordinals          => \&test_ordinals,
+    update                 => \&update,
+    update_fips_checksums  => \&update_fips_checksums,
+    diff_fips_checksums    => \&diff_fips_checksums,
 );
 
 usage() unless exists $actions{$action};
@@ -169,6 +193,396 @@ sub capture_to_file {
     close $in or die "Command failed: @cmd\n";
     close $out or die "Cannot close $tmp: $!\n";
     rename $tmp, $outfile or die "Cannot rename $tmp to $outfile: $!\n";
+}
+
+sub unix_developer_action {
+    die "This action is only available for Unix-like targets\n"
+        if $native_windows;
+}
+
+sub shell_quote {
+    my $value = shift // '';
+    $value =~ s/'/'"'"'/g;
+    return "'$value'";
+}
+
+sub run_shell {
+    run('/bin/sh', '-c', shift);
+}
+
+sub command_words {
+    my ($env_name, $default) = @_;
+    my @words = shellwords($ENV{$env_name} // $default);
+    die "$env_name must name a command\n" unless @words;
+    return @words;
+}
+
+sub command_exists {
+    my $command = shift;
+    return -x $command if $command =~ m|/|;
+    return scalar grep { -x catfile($_, $command) }
+                  grep { $_ ne '' } split /:/, ($ENV{PATH} // '');
+}
+
+sub generate_apps {
+    unix_developer_action();
+    run_shell('cd ' . shell_quote($srcdir)
+              . ' && ' . shell_quote($config{PERL})
+              . ' VMS/VMSify-conf.pl < apps/openssl.cnf > apps/openssl-vms.cnf');
+}
+
+sub generate_crypto_bn {
+    unix_developer_action();
+    chdir $srcdir or die "Cannot change directory to $srcdir: $!\n";
+    capture_to_file(srcpath(catfile('crypto', 'bn', 'bn_prime.h')),
+                    $config{PERL},
+                    srcpath(catfile('crypto', 'bn', 'bn_prime.pl')));
+}
+
+sub generate_crypto_objects {
+    unix_developer_action();
+    chdir $srcdir or die "Cannot change directory to $srcdir: $!\n";
+    my $objects_dir = srcpath(catdir('crypto', 'objects'));
+    my $objects = catfile($objects_dir, 'objects.pl');
+    my $objects_txt = catfile($objects_dir, 'objects.txt');
+    my $obj_mac_num = catfile($objects_dir, 'obj_mac.num');
+    my $obj_mac_new = catfile($objects_dir, 'obj_mac.new');
+    my $obj_mac_h = srcpath(catfile('include', 'openssl', 'obj_mac.h'));
+
+    capture_to_file($obj_mac_new, $config{PERL}, $objects, '-n',
+                    $objects_txt, $obj_mac_num);
+    rename $obj_mac_new, $obj_mac_num
+        or die "Cannot rename $obj_mac_new to $obj_mac_num: $!\n";
+    capture_to_file($obj_mac_h, $config{PERL}, $objects,
+                    $objects_txt, $obj_mac_num);
+    capture_to_file(catfile($objects_dir, 'obj_dat.h'), $config{PERL},
+                    catfile($objects_dir, 'obj_dat.pl'), $obj_mac_h);
+    capture_to_file(catfile($objects_dir, 'obj_xref.h'), $config{PERL},
+                    catfile($objects_dir, 'objxref.pl'), $obj_mac_num,
+                    catfile($objects_dir, 'obj_xref.txt'));
+
+    open my $compat, '<', catfile($objects_dir, 'obj_compat.h')
+        or die "Cannot open obj_compat.h: $!\n";
+    scalar <$compat> for 1..8;
+    open my $mac, '>>', $obj_mac_h or die "Cannot append to $obj_mac_h: $!\n";
+    while (my $line = <$compat>) {
+        print $mac $line or die "Cannot append to $obj_mac_h: $!\n";
+    }
+    close $compat or die "Cannot close obj_compat.h: $!\n";
+    close $mac or die "Cannot close $obj_mac_h: $!\n";
+}
+
+sub generate_crypto_conf {
+    unix_developer_action();
+    chdir $srcdir or die "Cannot change directory to $srcdir: $!\n";
+    capture_to_file(srcpath(catfile('crypto', 'conf', 'conf_def.h')),
+                    $config{PERL},
+                    srcpath(catfile('crypto', 'conf', 'keysets.pl')));
+}
+
+sub generate_crypto_asn1 {
+    unix_developer_action();
+    chdir $srcdir or die "Cannot change directory to $srcdir: $!\n";
+    capture_to_file(srcpath(catfile('crypto', 'asn1', 'charmap.h')),
+                    $config{PERL},
+                    srcpath(catfile('crypto', 'asn1', 'charmap.pl')));
+}
+
+sub generate_fuzz_oids {
+    unix_developer_action();
+    chdir $srcdir or die "Cannot change directory to $srcdir: $!\n";
+    capture_to_file(srcpath(catfile('fuzz', 'oids.txt')), $config{PERL},
+                    srcpath(catfile('fuzz', 'mkfuzzoids.pl')),
+                    srcpath(catfile('crypto', 'objects', 'obj_dat.h')));
+}
+
+sub generate_doc_buildinfo {
+    unix_developer_action();
+    my $buildinfo = srcpath(catfile('doc', 'build.info'));
+    my $new = "$buildinfo.new";
+    capture_to_file($new, $config{PERL}, "-I$blddir", '-Mconfigdata',
+                    srcpath(catfile('util', 'dofile.pl')), '-o', $buildfile,
+                    srcpath(catfile('doc', 'build.info.in')));
+    if (-e $buildinfo && compare($new, $buildinfo) == 0) {
+        unlink $new or die "Cannot remove $new: $!\n";
+    } else {
+        rename $new, $buildinfo
+            or die "Cannot rename $new to $buildinfo: $!\n";
+    }
+}
+
+sub update {
+    unix_developer_action();
+    generate_apps();
+    generate_crypto_bn();
+    generate_crypto_objects();
+    generate_crypto_conf();
+    generate_crypto_asn1();
+    generate_fuzz_oids();
+    errors();
+    ordinals();
+    generate_doc_buildinfo();
+}
+
+sub doc_nits {
+    unix_developer_action();
+    chdir $blddir or die "Cannot change directory to $blddir: $!\n";
+    run($config{PERL}, srcpath(catfile('util', 'find-doc-nits')),
+        qw(-c -n -l -e -i -a));
+}
+
+sub md_nits {
+    unix_developer_action();
+    my @mdl = command_words('MDL', 'mdl');
+    chdir $srcdir or die "Cannot change directory to $srcdir: $!\n";
+    run(@mdl, '-s', srcpath(catfile('util', 'markdownlint.rb')), '.');
+}
+
+sub ordinal_headers {
+    my @sslheaders_tmpl = qw(
+        include/openssl/ssl.h include/openssl/ssl2.h include/openssl/ssl3.h
+        include/openssl/sslerr.h include/openssl/tls1.h
+        include/openssl/dtls1.h include/openssl/srtp.h
+        include/openssl/quic.h include/openssl/sslerr_legacy.h
+        include/openssl/ech.h
+    );
+    my @cryptoheaders_tmpl = qw(
+        include/internal/dso.h include/internal/o_dir.h include/internal/err.h
+        include/internal/evp.h include/internal/pem.h include/internal/asn1.h
+        include/internal/sslconf.h
+    );
+    my @cryptoskipheaders = (
+        @sslheaders_tmpl,
+        qw(include/openssl/conf_api.h include/openssl/ebcdic.h
+           include/openssl/engine.h include/openssl/opensslconf.h
+           include/openssl/symhacks.h)
+    );
+    my (%cryptoheaders, %sslheaders);
+
+    for my $dir (qw(include/openssl include/internal)) {
+        my @patterns = map { catfile($srcdir, split_path($dir), $_) }
+                           qw(*.h *.h.in);
+        for my $file (map { glob($_) } @patterns) {
+            my $base = basename($file);
+            my $base_in = basename($file, '.in');
+            my $header_dir = catdir($srcdir, split_path($dir));
+            if ($base ne $base_in) {
+                $base = $base_in;
+                $header_dir = catdir($blddir, split_path($dir));
+            }
+            my $new_file = catfile($header_dir, $base);
+            my $name = "$dir/$base";
+            $cryptoheaders{$new_file} = 1
+                if (($dir eq 'include/openssl'
+                     || grep { $_ eq $name } @cryptoheaders_tmpl)
+                    && !grep { $_ eq $name } @cryptoskipheaders);
+            $sslheaders{$new_file} = 1
+                if grep { $_ eq $name } @sslheaders_tmpl;
+        }
+    }
+
+    return ([ sort keys %cryptoheaders ], [ sort keys %sslheaders ]);
+}
+
+sub source_files {
+    my (%seen, @sources);
+    for my $product (sort keys %{$unified_info{sources}}) {
+        for my $source (@{$unified_info{sources}->{$product}}) {
+            my @flat = ref($source) eq 'ARRAY' ? @$source : ($source);
+            push @sources, grep { /\.(?:c|cc|cpp)\z/ && !$seen{$_}++ } @flat;
+        }
+    }
+    return @sources;
+}
+
+sub lint {
+    unix_developer_action();
+    my ($cryptoheaders, $sslheaders) = ordinal_headers();
+    print join(' ', 'splint', '-DLINT', '-posixlib', '-preproc',
+               '-D__gnuc_va_list=void', '-I.', '-Iinclude', '-Iapps/include',
+               @$cryptoheaders, @$sslheaders, source_files()), "\n";
+}
+
+sub check_format_cmd {
+    unix_developer_action();
+    my @command = command_words('CLANG_FORMAT_DIFF', 'clang-format-diff');
+    return if command_exists($command[0]);
+    print STDERR "Unable to find $command[0]\n";
+    print STDERR "Please set the CLANG_FORMAT_DIFF environment variable ",
+                 "to your clang-format-diff command\n";
+    exit 1;
+}
+
+sub check_format {
+    unix_developer_action();
+    my @command = command_words('CLANG_FORMAT_DIFF', 'clang-format-diff');
+    run_shell('cd ' . shell_quote($srcdir)
+              . ' && git diff -U0 --no-prefix --no-color | '
+              . join(' ', map { shell_quote($_) } @command));
+}
+
+sub errors {
+    unix_developer_action();
+    my @rebuild = shellwords($ENV{ERROR_REBUILD} // '');
+    chdir $srcdir or die "Cannot change directory to $srcdir: $!\n";
+    run($config{PERL}, catfile('util', 'ck_errf.pl'), qw(-strict -internal));
+    run($config{PERL}, "-I$blddir", catfile('util', 'mkerr.pl'),
+        @rebuild, '-internal');
+}
+
+sub update_ordinals {
+    my $do_renumber = shift;
+    unix_developer_action();
+    my ($cryptoheaders, $sslheaders) = ordinal_headers();
+    my @common = ('--version', $config{version}, '--no-warnings');
+    my @renumber = $do_renumber ? ('--renumber') : ();
+    run($config{PERL}, srcpath(catfile('util', 'mknum.pl')), @common,
+        '--ordinals', srcpath(catfile('util', 'libcrypto.num')),
+        '--symhacks', srcpath(catfile('include', 'openssl', 'symhacks.h')),
+        @renumber, @$cryptoheaders);
+    run($config{PERL}, srcpath(catfile('util', 'mknum.pl')), @common,
+        '--ordinals', srcpath(catfile('util', 'libssl.num')),
+        '--symhacks', srcpath(catfile('include', 'openssl', 'symhacks.h')),
+        @renumber, @$sslheaders);
+}
+
+sub ordinals {
+    update_ordinals(0);
+}
+
+sub renumber {
+    update_ordinals(1);
+}
+
+sub test_ordinals {
+    unix_developer_action();
+    local $ENV{SRCTOP} = $srcdir;
+    local $ENV{BLDTOP} = $blddir;
+    local $ENV{PERL} = $config{PERL};
+    local $ENV{FIPSKEY} = $config{FIPSKEY};
+    local $ENV{EXE_EXT} = platform->binext();
+    run($config{PERL}, srcpath(catfile('test', 'run_tests.pl')),
+        'test_ordinals');
+}
+
+sub tags {
+    unix_developer_action();
+    rm_f(bldpath('TAGS'), bldpath('tags'));
+    chdir $srcdir or die "Cannot change directory to $srcdir: $!\n";
+    system(srcpath(catfile('util', 'ctags.sh')));
+
+    chdir $blddir or die "Cannot change directory to $blddir: $!\n";
+    my @files;
+    find({ wanted => sub {
+               return if -d $_;
+               push @files, $File::Find::name if /\.(?:c|h|pm|inc)\z/;
+           }, no_chdir => 1 }, '.');
+    system('etags', @files);
+}
+
+sub generate_fips_sources {
+    unix_developer_action();
+    local $ENV{NINJA_SRCDIR} = $srcdir;
+    local $ENV{NINJA_CONFIG_SRCDIR} = $config{sourcedir};
+    local $ENV{NINJA_PERL} = $config{PERL};
+    local $ENV{NINJA_CMD} = $ENV{NINJA} // 'ninja';
+    chdir $blddir or die "Cannot change directory to $blddir: $!\n";
+    run_shell(<<'SH');
+set -e
+rm -rf sources-tmp
+mkdir sources-tmp
+cd sources-tmp
+BUILDFILE=build.ninja "$NINJA_PERL" "$NINJA_SRCDIR/Configure" --banner=Configured enable-fips -O0
+"$NINJA_PERL" ./configdata.pm --query 'get_sources("providers/fips")' > sources1
+"$NINJA_CMD" -d keepdepfile -j4 build_generated providers/fips.so
+find . -name '*.d' -type f -exec cat {} + > dep1
+"$NINJA_CMD" distclean
+BUILDFILE=build.ninja "$NINJA_PERL" "$NINJA_SRCDIR/Configure" \
+    --banner=Configured enable-fips no-asm -O0
+"$NINJA_PERL" ./configdata.pm --query 'get_sources("providers/fips")' > sources2
+"$NINJA_CMD" -d keepdepfile -j4 build_generated providers/fips.so
+find . -name '*.d' -type f -exec cat {} + > dep2
+cat sources1 sources2 \
+    | grep -v ' : \\$' | grep -v util/providers.num \
+    | sed -e 's/^ *//' -e 's/ *\\$//' \
+    | sort | uniq > sources
+cat dep1 dep2 \
+    | "$NINJA_PERL" -p -e 's/\\\n//' \
+    | sed -e 's/^.*: *//' -e 's/  */ /g' \
+    | fgrep -f sources \
+    | tr ' ' '\n' \
+    | sort | uniq > deps.raw
+xargs "$NINJA_PERL" ./configdata.pm --query 'get_sources(@ARGV)' < deps.raw \
+    | "$NINJA_PERL" -p -e 's/\\\n//' \
+    | sed -e 's/\./\\\./g' -e 's/ : */:/' -e 's/^/s:/' -e 's/$/:/' \
+    > deps.sed
+sed -f deps.sed deps.raw > deps
+(
+    cat sources deps \
+        | "$NINJA_PERL" -p \
+            -e 's:^ *\Q../\E::;' \
+            -e 's:^\Q$ENV{NINJA_CONFIG_SRCDIR}/\E:: if $ENV{NINJA_CONFIG_SRCDIR} ne ".";' \
+            -e 'my $x; do { $x = $_; s:(^|/)((?!\Q../\E)[^/]*/)\Q..\E($|/):$1: } while ($x ne $_);'
+    cd "$NINJA_SRCDIR"
+    for x in crypto/bn/asm/*.pl crypto/bn/asm/*.S \
+             crypto/aes/asm/*.pl crypto/aes/asm/*.S \
+             crypto/ec/asm/*.pl \
+             crypto/ml_dsa/asm/*.pl \
+             crypto/ml_kem/asm/*.pl \
+             crypto/modes/asm/*.pl \
+             crypto/sha/asm/*.pl \
+             crypto/slh_dsa/asm/*.pl \
+             crypto/*cpuid.pl crypto/*cpuid.S \
+             crypto/*cap.c; do
+        test -e "$x" && echo "$x"
+    done
+) | grep -v sm2p256 | sort | uniq > ../providers/fips.module.sources.new
+cd ..
+rm -rf sources-tmp
+SH
+}
+
+sub fips_checksums {
+    unix_developer_action();
+    die "ERROR: unifdef not in your PATH, FIPS checksums not calculated\n"
+        unless command_exists('unifdef');
+    local $ENV{NINJA_SRCDIR} = $srcdir;
+    local $ENV{NINJA_BLDDIR} = $blddir;
+    run_shell(<<'SH');
+set -e
+cd "$NINJA_SRCDIR"
+xargs ./util/fips-checksums.sh \
+    < "$NINJA_BLDDIR/providers/fips.module.sources.new" \
+    > "$NINJA_BLDDIR/providers/fips-sources.checksums.new"
+cd "$NINJA_BLDDIR"
+sha256sum providers/fips-sources.checksums.new \
+    | sed -e 's|\.new||' > providers/fips.checksum.new
+SH
+}
+
+sub update_fips_checksums {
+    unix_developer_action();
+    for my $file (qw(fips.module.sources fips-sources.checksums fips.checksum)) {
+        run('cp', '-p', bldpath(catfile('providers', "$file.new")),
+            srcpath(catfile('providers', $file)));
+    }
+}
+
+sub diff_fips_checksums {
+    unix_developer_action();
+    for my $file (qw(fips.module.sources fips-sources.checksums fips.checksum)) {
+        run('diff', '-u', srcpath(catfile('providers', $file)),
+            bldpath(catfile('providers', "$file.new")));
+    }
+}
+
+sub tar {
+    unix_developer_action();
+    my $name = $ENV{NAME} // 'openssl-' . $config{full_version};
+    my $tarfile = $ENV{TARFILE} // catfile('..', "$name.tar");
+    chdir $srcdir or die "Cannot change directory to $srcdir: $!\n";
+    run(srcpath(catfile('util', 'mktar.sh')), "--name=$name",
+        "--tarfile=$tarfile");
 }
 
 sub rm_f {

--- a/util/ninja-build.pl
+++ b/util/ninja-build.pl
@@ -300,6 +300,7 @@ sub generate_doc_buildinfo {
     unix_developer_action();
     my $buildinfo = srcpath(catfile('doc', 'build.info'));
     my $new = "$buildinfo.new";
+    chdir $blddir or die "Cannot change directory to $blddir: $!\n";
     capture_to_file($new, $config{PERL}, "-I$blddir", '-Mconfigdata',
                     srcpath(catfile('util', 'dofile.pl')), '-o', $buildfile,
                     srcpath(catfile('doc', 'build.info.in')));

--- a/util/ninja-build.pl
+++ b/util/ninja-build.pl
@@ -6,6 +6,8 @@
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
+# Run the utility, maintenance, and installation actions used by Ninja builds.
+
 use strict;
 use warnings;
 

--- a/util/ninja-makedepend.pl
+++ b/util/ninja-makedepend.pl
@@ -1,0 +1,52 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use File::Spec;
+
+my $target = shift @ARGV // die "Missing target name\n";
+my $depfile = shift @ARGV // die "Missing depfile name\n";
+my $makedepend = shift @ARGV // die "Missing makedepend command\n";
+
+my $tmp = "$depfile.tmp";
+my $saw_target = 0;
+
+my $pid = open my $in, '-|';
+die "Cannot fork to run $makedepend: $!\n" unless defined $pid;
+if ($pid == 0) {
+    open STDERR, '>', File::Spec->devnull
+        or die "Cannot redirect $makedepend stderr: $!\n";
+    exec $makedepend, @ARGV
+        or die "Cannot run $makedepend: $!\n";
+}
+open my $out, '>', $tmp
+    or die "Cannot open $tmp for writing: $!\n";
+
+while (my $line = <$in>) {
+    if (!$saw_target && $line =~ /^[^:]+:/) {
+        $line =~ s/^[^:]+:/$target:/;
+        $saw_target = 1;
+    }
+    print $out $line or die "Cannot write to $tmp: $!\n";
+}
+
+close $in or die "$makedepend failed\n";
+
+if (!$saw_target) {
+    print $out "$target:\n" or die "Cannot write to $tmp: $!\n";
+}
+
+close $out or die "Cannot close $tmp: $!\n";
+rename $tmp, $depfile
+    or die "Cannot rename $tmp to $depfile: $!\n";
+
+END {
+    unlink $tmp if defined $tmp && -e $tmp;
+}

--- a/util/ninja-makedepend.pl
+++ b/util/ninja-makedepend.pl
@@ -6,6 +6,8 @@
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
+# Generate a Ninja depfile by rewriting makedepend output for a given target.
+
 use strict;
 use warnings;
 


### PR DESCRIPTION
## Summary

This PR adds Ninja build file support to OpenSSL. The Ninja backend is selected with:

```sh
BUILDFILE=build.ninja perl Configure ...
```
It adds Unix-like and native Windows Ninja templates, helper scripts for archive/dependency/build handling and documentation for using the new backend.

The implementation covers:

- generation of build.ninja through OpenSSL's existing build-file template machinery
- Unix-like and Windows/MSVC build rules
- static libraries, shared libraries, DSOs/modules, programs, generated files, tests, install targets, and clean targets
- response-file handling where needed
- dependency generation through Ninja-compatible depfiles
- Windows/MSVC command quoting and test invocation
- macOS shared-library flag expansion and ranlib -c handling
- clean-build ordering for generated headers before object compilation
- FIPS providers/fipsmodule.cnf graph generation for Ninja dry-run validation
- ancillary targets including update, doc-nits, md-nits, and related maintenance targets
- Ninja CI coverage on Linux, Windows/MSVC, and macOS

Fixes #28796.

## Commit Layout

This PR is organized as two logical changes:

1. Configure: fix generated Perl module dependencies

   This fixes classification of generated-file dependencies that use the dir|Module.pm Perl include syntax.
2. Add Ninja build file generation support

   This adds the Ninja templates, helper scripts, documentation, and Ninja-specific graph handling.

## Note About The Configure Change

Some generated targets use dependency entries such as:

`util/perl|OpenSSL/paramnames.pm`

In this syntax, | separates the Perl include directory from the module name. It is not a path separator.

The Configure change makes the dependency handling check both the normalized generated-file table and the original GENERATE[...] target key. This matters in out-of-tree or source-distribution-style builds where a generated file, such as include/openssl/core_names.h, already exists in the source tree.

The change is a narrow superset: it only affects declared generated targets whose dependencies use the dir|Module.pm syntax. Existing make, nmake, and MMS builders continue to receive normalized dependency paths rather than literal pipe-containing paths.

## Validation

The implementation was validated on Linux, Windows/MSVC and macOS.

### Linux

Platform and toolset:

- Ubuntu 24.04.4 LTS
- Configure target: linux-x86_64
- Compiler: gcc 13.3.0
- Perl: 5.38.2
- Ninja: 1.11.1
- GNU binutils: 2.42

Fresh out-of-tree build:

```
rm -rf /tmp/openssl_ninja_linux_full_install
BUILDFILE=build.ninja perl Configure \
    linux-x86_64 \
    --prefix=/tmp/openssl_ninja_linux_full_install

ninja -f build.ninja test

```
Result:

```
All tests successful.
Files=363, Tests=4373
Result: PASS
```

### Windows / MSVC

Platform and toolset:

- Windows: 10.0.26200.8246
- Configure target: VC-WIN64A
- Visual Studio: 2022 Professional, vcvars64.bat environment
- Compiler: MSVC cl 19.44.35223 for x64
- Perl: Strawberry Perl 5.42.0
- Ninja: 1.12.0
- NASM: 2.16.01

Fresh out-of-tree build:

```
call "C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvars64.bat"

set BUILDFILE=build.ninja
perl Configure VC-WIN64A ^
    --prefix="C:\dev\tmp\openssl_ninja_win_full_install"
```

Build verification:

`ninja.exe -f build.ninja all`

Result: completed successfully, including documentation targets.

No-op rebuild verification:

`ninja.exe -f build.ninja -d explain -n all`

Result:

`ninja: no work to do.`

Full test run:

`ninja.exe -f build.ninja test`

Result:

```
All tests successful.
Files=363, Tests=4118
Result: PASS
```

### macOS

Platform and toolset:

- macOS: 26.4.1, build 25E253
- Architecture: arm64
- Configure target: darwin64-arm64-cc
- Compiler: Apple clang 15.0.0, clang-1500.3.9.4
- Perl: 5.34.1
- Ninja: 1.13.0.git.kitware.jobserver-pipe-1

No-shared build and test:

```
BUILDFILE=build.ninja perl Configure darwin64-arm64-cc no-shared \
    --prefix=/tmp/openssl_ninja_macos_tests_install

ninja -f build.ninja test
```

Result:

```
All tests successful.
Files=363, Tests=4333
Result: PASS
```

No-op/static-provider follow-up check:

```
ninja -f build.ninja build_sw
ninja -f build.ninja build_sw
```

The first build_sw completed the remaining static-provider archive steps not needed by test; the second returned:

`ninja: no work to do.`

Shared build and test:

```
BUILDFILE=build.ninja perl Configure darwin64-arm64-cc \
    --prefix=/tmp/openssl_ninja_macos_shared_install

ninja -f build.ninja all
ninja -f build.ninja all
ninja -f build.ninja test
```

Repeated all result:

`ninja: no work to do.`

Test result:

```
All tests successful.
Files=363, Tests=4338
Result: PASS
```

### Linux enable-fips

Platform and toolset:

Ubuntu 24.04.4 LTS
Configure target: linux-x86_64
Compiler: gcc 13.3.0
Perl: 5.38.2
Ninja: 1.11.1

Fresh out-of-tree enable-fips build:

```sh
rm -rf /tmp/openssl_ninja_fips_full \
       /tmp/openssl_ninja_fips_full_install \
       /tmp/openssl_ninja_fips_package

mkdir -p /tmp/openssl_ninja_fips_full
cd /tmp/openssl_ninja_fips_full

BUILDFILE=build.ninja perl /mnt/c/dev/prj/Github/openssl_amcrypto/Configure \
    linux-x86_64 enable-fips \
    --prefix=/tmp/openssl_ninja_fips_full_install

ninja -f build.ninja all
ninja -f build.ninja test
```

Result:

```
All tests successful.
Files=363, Tests=4774
Result: PASS
```

Install and no-op checks:

```
DESTDIR=/tmp/openssl_ninja_fips_package ninja -f build.ninja install
ninja -f build.ninja all
ninja -f build.ninja -d explain -n all
```

Results:

```
- install completed successfully
- repeated all: ninja: no work to do.
- dry-run explain: ninja: no work to do.
```

Installed FIPS artifacts included:

```
lib64/ossl-modules/fips.so
ssl/fipsmodule.cnf
```


