### PR TITLE
Use proper compiler features abstraction for older compilers

### DIFF
--- a/include/openssl/engine.h
+++ b/include/openssl/engine.h
@@ -39,27 +39,27 @@
 
 #define ENGINE_FUNC(ret_type, name, args, default_val) \
     OSSL_DEPRECATED_MESSAGE(#name ENGINE_INFO_MSG)     \
-    static inline ret_type name args                   \
+    static ossl_inline ret_type name args              \
     {                                                  \
         return default_val; /* stub return */          \
     }
 
 #define ENGINE_FUNC_NOARGS(ret_type, name, default_val) \
     OSSL_DEPRECATED_MESSAGE(#name ENGINE_INFO_MSG)      \
-    static inline ret_type name(void)                   \
+    static ossl_inline ret_type name(void)              \
     {                                                   \
         return default_val; /* stub return */           \
     }
 
 #define ENGINE_VOID_FUNC(name, args)               \
     OSSL_DEPRECATED_MESSAGE(#name ENGINE_INFO_MSG) \
-    static inline void name args                   \
+    static ossl_inline void name args              \
     {                                              \
     }
 
 #define ENGINE_VOID_FUNC_NOARGS(name)              \
     OSSL_DEPRECATED_MESSAGE(#name ENGINE_INFO_MSG) \
-    static inline void name(void)                  \
+    static ossl_inline void name(void)             \
     {                                              \
     }
 #else /* OPENSSL_ENGINE_STUBS */

--- a/test/asn1_string_test.c
+++ b/test/asn1_string_test.c
@@ -225,14 +225,14 @@ abs_get_length_test(const struct abs_get_length_test *tbl, int idx)
 
     p = test->der;
     if (!TEST_ptr(abs = d2i_ASN1_BIT_STRING(NULL, &p, test->der_len))) {
-        TEST_info("%s, (idx=%d) - d2i_ASN1_BIT_STRING faled", __func__, idx);
+        TEST_info("%s, (idx=%d) - d2i_ASN1_BIT_STRING faled", OPENSSL_FUNC, idx);
         goto err;
     }
 
     ret = ASN1_BIT_STRING_get_length(abs, &length, &unused_bits);
     if (!TEST_int_eq(test->valid, ret)) {
         TEST_info("%s (idx=%d): %s ASN1_BIT_STRING_get_length want %d, got %d\n",
-            __func__, idx, test->descr, test->valid, ret);
+            OPENSSL_FUNC, idx, test->descr, test->valid, ret);
         goto err;
     }
     if (!test->valid)
@@ -240,7 +240,7 @@ abs_get_length_test(const struct abs_get_length_test *tbl, int idx)
 
     if (!TEST_size_t_eq(length, test->length)
         || !TEST_int_eq(unused_bits, test->unused_bits)) {
-        TEST_info("%s: (idx=%d) %s: want (%zu, %d), got (%zu, %d)\n", __func__,
+        TEST_info("%s: (idx=%d) %s: want (%zu, %d), got (%zu, %d)\n", OPENSSL_FUNC,
             idx, test->descr, test->length, test->unused_bits, length,
             unused_bits);
         goto err;
@@ -615,14 +615,14 @@ abs_set1_test(const struct abs_set1_test *tbl, int idx)
     int success = 0;
 
     if (!TEST_ptr(abs = ASN1_BIT_STRING_new())) {
-        TEST_info("%s: (idx = %d) %s ASN1_BIT_STRING_new()", __func__, idx, test->descr);
+        TEST_info("%s: (idx = %d) %s ASN1_BIT_STRING_new()", OPENSSL_FUNC, idx, test->descr);
         goto err;
     }
 
     ret = ASN1_BIT_STRING_set1(abs, test->data, test->length, test->unused_bits);
     if (!TEST_int_eq(ret, test->valid)) {
         TEST_info("%s: (idx = %d) %s ASN1_BIT_STRING_set1(): want %d, got %d",
-            __func__, idx, test->descr, test->valid, ret);
+            OPENSSL_FUNC, idx, test->descr, test->valid, ret);
         goto err;
     }
 
@@ -632,14 +632,14 @@ abs_set1_test(const struct abs_set1_test *tbl, int idx)
     der = NULL;
     if (!TEST_int_eq((der_len = i2d_ASN1_BIT_STRING(abs, &der)), test->der_len)) {
         TEST_info("%s: (idx=%d), %s i2d_ASN1_BIT_STRING(): want %d, got %d",
-            __func__, idx, test->descr, test->der_len, der_len);
+            OPENSSL_FUNC, idx, test->descr, test->der_len, der_len);
         if (der_len < 0)
             der_len = 0;
         goto err;
     }
 
     if (!TEST_mem_eq(der, der_len, test->der, test->der_len)) {
-        TEST_info("%s: (idx = %d)  %s DER mismatch", __func__, idx, test->descr);
+        TEST_info("%s: (idx = %d)  %s DER mismatch", OPENSSL_FUNC, idx, test->descr);
         goto err;
     }
 

--- a/test/base64_simdutf_test.c
+++ b/test/base64_simdutf_test.c
@@ -32,7 +32,7 @@ static void fuzz_fill_encode_ctx(EVP_ENCODE_CTX *ctx, int max_fill)
         ctx->enc_data[i] = (unsigned char)(rand() & 0xFF);
     ctx->line_num = rand() % (EVP_ENCODE_B64_LENGTH + 1);
 }
-static inline uint32_t next_u32(uint32_t *state)
+static ossl_inline uint32_t next_u32(uint32_t *state)
 {
     *state = (*state * 1664525u) + 1013904223u;
     return *state;

--- a/test/ech_test.c
+++ b/test/ech_test.c
@@ -1060,7 +1060,7 @@ static int ech_test_file_read(int run)
     fullname = OPENSSL_malloc(fnlen);
     if (fullname == NULL)
         goto end;
-    snprintf(fullname, fnlen, "%s/%s", certsdir, ft->fname);
+    BIO_snprintf(fullname, fnlen, "%s/%s", certsdir, ft->fname);
     if (verbose)
         TEST_info("testing read of %s", fullname);
     in = BIO_new_file(fullname, "r");
@@ -1320,7 +1320,7 @@ static int test_ech_roundtrip_helper(int idx, int combo)
     aeadind = idx % aeadsz;
     /* initialise early data stuff, just in case */
     memset(ed, 'A', sizeof(ed));
-    snprintf(suitestr, 100, "%s,%s,%s", kem_str_list[kemind],
+    BIO_snprintf(suitestr, 100, "%s,%s,%s", kem_str_list[kemind],
         kdf_str_list[kdfind], aead_str_list[aeadind]);
     if (verbose)
         TEST_info("Doing: iter: %d, suite: %s", idx, suitestr);


### PR DESCRIPTION
`"inline"` -> `"ossl_inline"`
`"__func__"` -> `"OPENSSL_FUNC"`
`"snprintf"` -> `"BIO_snprintf"`

The problems were found while building using VS2013.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
