### PR TITLE
Increase the query cache insert grow retry

### DIFF
--- a/crypto/hashtable/hashtable.c
+++ b/crypto/hashtable/hashtable.c
@@ -711,7 +711,7 @@ int ossl_ht_insert(HT *h, HT_KEY *key, HT_VALUE *data, HT_VALUE **olddata)
      */
     for (i = 0;
         (rc = ossl_ht_insert_locked(h, hash, newval, olddata)) == -1
-        && i < 4;
+        && i <= (int)NEIGHBORHOOD_LEN;
         ++i)
         if (!grow_hashtable(h, h->wpd.neighborhood_len)) {
             rc = -1;


### PR DESCRIPTION
On s390x, the distribution of the query cache hash values is different compared to other architectures, probably because of endianess and pointer alignment being different (the hash key contains pointer values and integers). This leads to the fact that ossl_ht_cache_QUERY_insert() is not always able to add a query during the FIPS selftests, and thus ossl_ht_cache_QUERY_insert() returns -1 is such cases.

Increase the number of retries inside ossl_ht_insert() to at least the number elements per neighborhood plus 1. With this it is able to grow the hash table enough so that the queries used during the FIPS selftest can all be added to the hash table, even on s390x.

There is still no guarantee that the number of retries is enough for all possible queries. It can still happen that certain queries can't be added to the cache, even on other architectures. This does not really hurt, such queries will just not be cached and are freshly fetched again the next time.

Note that to fully fix issue https://github.com/openssl/openssl/issues/30588 the changes from PR https://github.com/openssl/openssl/pull/30891 are also required to fix the return code handling of `ossl_ht_cache_QUERY_insert()` when it returns -1 due to failing to grow the hash table enough to be able to insert a query. 