### PR TITLE
pkey(1) missing setup for interactive pass prompt

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2324,11 +2324,15 @@ int encode_private_key(BIO *out, const char *output_type, const EVP_PKEY *pkey,
     if (ectx == NULL)
         return 0;
 
-    if (cipher != NULL)
-        if (!OSSL_ENCODER_CTX_set_cipher(ectx, EVP_CIPHER_get0_name(cipher), NULL)
-            || !OSSL_ENCODER_CTX_set_passphrase(ectx, (const unsigned char *)pass,
-                strlen(pass)))
+    if (cipher != NULL) {
+        if (!OSSL_ENCODER_CTX_set_cipher(ectx, EVP_CIPHER_get0_name(cipher), NULL))
             goto end;
+        OSSL_ENCODER_CTX_set_passphrase_ui(ectx, get_ui_method(), NULL);
+        if (pass != NULL
+            && !OSSL_ENCODER_CTX_set_passphrase(ectx,
+                (const unsigned char *)pass, strlen(pass)))
+            goto end;
+    }
 
     if (encopt != NULL) {
         int i, n = sk_OPENSSL_STRING_num(encopt);


### PR DESCRIPTION
The changes in #29324 neglected some setup needed for interactive password prompting, leading to a segfaul when pkey(1) is asked to encrypt, but not given an explicit `-pass` argument.

The required plumbing is added.

Fixes: #30889

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
