### PR TITLE
docs: use local HOWTO references

### DIFF
--- a/doc/HOWTO/certificates.txt
+++ b/doc/HOWTO/certificates.txt
@@ -35,7 +35,7 @@ you want an RSA private key, or if you want a DSA private key:
 
 The private keys created by these commands are not passphrase protected;
 it might or might not be the desirable thing.  Further information on how to
-create private keys can be found at https://github.com/openssl/openssl/blob/master/doc/HOWTO/keys.txt.
+create private keys can be found in doc/HOWTO/keys.txt.
 The rest of this text assumes you have a private key in the file privkey.pem.
 
 

--- a/doc/HOWTO/keys.txt
+++ b/doc/HOWTO/keys.txt
@@ -102,5 +102,4 @@ it may be reasonable to avoid protecting it with a password, since
 otherwise someone would have to type in the password every time the
 server needs to access the key.
 
-To generate keys using C code refer to the demos located in
-https://github.com/openssl/openssl/blob/master/demos/pkey.
+To generate keys using C code refer to the demos in demos/pkey/.


### PR DESCRIPTION

**Repo:** openssl/openssl (⭐ 27000)
**Type:** docs
**Files changed:** 2
**Lines:** +2/-3

## What
This change updates two HOWTO documents to reference content within the source tree instead of hardcoded GitHub `blob/master` URLs. `doc/HOWTO/certificates.txt` now points readers to `doc/HOWTO/keys.txt` locally, and `doc/HOWTO/keys.txt` now points to the in-tree `demos/pkey/` examples.

## Why
The previous links depended on GitHub and a specific branch name, which is unnecessary for files that already exist in the checkout. Using repository-local paths makes the documentation more robust for offline readers, source tarball users, and anyone browsing the repo without relying on branch-pinned external links.

## Testing
No code execution was needed for this docs-only change. Verified locally by reviewing the committed diff and confirming the updated references point to existing in-tree locations.

## Risk
Low / documentation-only change that narrows references to existing local paths.
