### PR TITLE
Make SSL_get_stream_write_state() safe for concluded streams

### DIFF
--- a/include/internal/quic_stream_map.h
+++ b/include/internal/quic_stream_map.h
@@ -316,7 +316,6 @@ struct quic_stream_st {
     /* Set to 1 if this is currently counted in the shutdown flush stream count. */
     unsigned int shutdown_flush : 1;
     unsigned int have_final_size : 1;
-    uint64_t final_size;
 };
 
 #define QUIC_STREAM_INITIATOR_CLIENT 0

--- a/include/internal/quic_stream_map.h
+++ b/include/internal/quic_stream_map.h
@@ -299,7 +299,7 @@ struct quic_stream_st {
      *            STOP_SENDING.]
      *
      *            TODO(QUIC FUTURE): Implement the latter case (currently we
-                                     just always do STOP_SENDING).
+     *                               just always do STOP_SENDING).
      *
      *         and;
      *
@@ -315,6 +315,8 @@ struct quic_stream_st {
     unsigned int ready_for_gc : 1;
     /* Set to 1 if this is currently counted in the shutdown flush stream count. */
     unsigned int shutdown_flush : 1;
+    unsigned int have_final_size : 1;
+    uint64_t final_size;
 };
 
 #define QUIC_STREAM_INITIATOR_CLIENT 0

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4473,14 +4473,14 @@ static void quic_classify_stream(QUIC_CONNECTION *qc,
     uint64_t *app_error_code)
 {
     int local_init;
-    uint64_t final_size;
+    uint64_t scratch_pad; /* throw away value */
 
     local_init = (ossl_quic_stream_is_server_init(qs) == qc->as_server);
 
     if (app_error_code != NULL)
         *app_error_code = UINT64_MAX;
     else
-        app_error_code = &final_size; /* throw away value */
+        app_error_code = &scratch_pad;
 
     if (!ossl_quic_stream_is_bidi(qs) && local_init != is_write) {
         /*

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4513,7 +4513,7 @@ static void quic_classify_stream(QUIC_CONNECTION *qc,
         *app_error_code = !is_write
             ? qs->peer_reset_stream_aec
             : qs->peer_stop_sending_aec;
-    } else if (is_write && ossl_quic_sstream_get_final_size(qs->sstream, &final_size)) {
+    } else if (is_write && qs->have_final_size) {
         /*
          * Stream has been finished. Stream reset takes precedence over this for
          * the write case as peer may not have received all data.

--- a/ssl/quic/quic_stream_map.c
+++ b/ssl/quic/quic_stream_map.c
@@ -451,7 +451,7 @@ int ossl_quic_stream_map_notify_totally_acked(QUIC_STREAM_MAP *qsm,
          * gets called.
          */
         qs->have_final_size = ossl_quic_sstream_get_final_size(qs->sstream,
-            &qs->final_size);
+            NULL);
 
         /* We no longer need a QUIC_SSTREAM in this state. */
         ossl_quic_sstream_free(qs->sstream);

--- a/ssl/quic/quic_stream_map.c
+++ b/ssl/quic/quic_stream_map.c
@@ -446,6 +446,13 @@ int ossl_quic_stream_map_notify_totally_acked(QUIC_STREAM_MAP *qsm,
 
     case QUIC_SSTREAM_STATE_DATA_SENT:
         qs->send_state = QUIC_SSTREAM_STATE_DATA_RECVD;
+        /*
+         * Remember final size in case  SSL_get_stream_write_state()
+         * gets called.
+         */
+        qs->have_final_size = ossl_quic_sstream_get_final_size(qs->sstream,
+            &qs->final_size);
+
         /* We no longer need a QUIC_SSTREAM in this state. */
         ossl_quic_sstream_free(qs->sstream);
         qs->sstream = NULL;

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2078,17 +2078,7 @@ static CRYPTO_THREAD_RETVAL run_script_child_thread(void *arg)
 
 /* 1. Simple single-stream test */
 static const struct script_op script_1[] = {
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-    OP_C_WRITE(DEFAULT, "apple", 5),
-    OP_C_CONCLUDE(DEFAULT),
-    OP_S_BIND_STREAM_ID(a, C_BIDI_ID(0)),
-    OP_S_READ_EXPECT(a, "apple", 5),
-    OP_S_EXPECT_FIN(a),
-    OP_S_WRITE(a, "orange", 6),
-    OP_S_CONCLUDE(a),
-    OP_C_READ_EXPECT(DEFAULT, "orange", 6),
-    OP_C_EXPECT_FIN(DEFAULT),
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -23,6 +23,23 @@
  */
 
 /*
+ * Simple single-stream test
+ */
+DEF_SCRIPT(simple_stream, "single stream test")
+{
+    OP_SIMPLE_PAIR_CONN();
+    OP_WRITE_B(C, "apple");
+    OP_ACCEPT_CONN_WAIT(L, S, 0);
+    OP_CONCLUDE(C);
+    OP_READ_EXPECT_B(S, "apple");
+    OP_EXPECT_FIN(S);
+    OP_WRITE_B(S, "orange");
+    OP_READ_EXPECT_B(C, "orange");
+    OP_CONCLUDE(S);
+    OP_EXPECT_FIN(C);
+}
+
+/*
  * Test: simple_conn
  * -----------------
  */
@@ -299,8 +316,9 @@ DEF_SCRIPT(check_cwm, "check stream obeys cwm")
  * ============================================================================
  */
 static SCRIPT_INFO *const scripts[] = {
+    USE(simple_stream),
     USE(simple_conn),
     USE(simple_thread),
     USE(ssl_poll),
-    USE(check_cwm)
+    USE(check_cwm),
 };


### PR DESCRIPTION
Make SSL_get_stream_write_state() safe for concluded streams

QUIC stack may panic when application calls SSL_get_stream_write_state()
on cocluded QUIC stream onject. The sequence of action which leads
to NULL pointer dereference is as follows:
  - application uses SSL_stream_conclude(ssl_stream, 0) to conclude
    the stream (let remote peer know no to expect more data)

  - application uses SSL_get_stream_write_state(ssl_stream)
    to query stream state.

If underlying sstream object is gone by the time when
SSL_get_stream_wtite_state() is called, then application
may see NULL pointer dereference. The underlying sstream
object is freed when FIN sent on beahalf of SSL_stream_conclude()
is ACKed by remote peer.