### PR TITLE
pkcs7: Fix negative index handling in PKCS7_get_issuer_and_serial

### DIFF
--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -1171,7 +1171,7 @@ PKCS7_ISSUER_AND_SERIAL *PKCS7_get_issuer_and_serial(PKCS7 *p7, int idx)
     rsk = p7->d.signed_and_enveloped->recipientinfo;
     if (rsk == NULL)
         return NULL;
-    if (sk_PKCS7_RECIP_INFO_num(rsk) <= idx)
+    if (idx < 0 || sk_PKCS7_RECIP_INFO_num(rsk) <= idx)
         return NULL;
     ri = sk_PKCS7_RECIP_INFO_value(rsk, idx);
     return ri->issuer_and_serial;

--- a/test/pkcs7_test.c
+++ b/test/pkcs7_test.c
@@ -15,6 +15,30 @@
 #include "internal/nelem.h"
 #include "testutil.h"
 
+static int pkcs7_issuer_and_serial_negative_idx_test(void)
+{
+    PKCS7 *p7 = NULL;
+    PKCS7_RECIP_INFO *ri = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(p7 = PKCS7_new())
+        || !TEST_true(PKCS7_set_type(p7, NID_pkcs7_signedAndEnveloped))
+        || !TEST_ptr(ri = PKCS7_RECIP_INFO_new())
+        || !TEST_true(PKCS7_add_recipient_info(p7, ri)))
+        goto end;
+    ri = NULL;
+
+    if (!TEST_ptr(PKCS7_get_issuer_and_serial(p7, 0))
+        || !TEST_ptr_null(PKCS7_get_issuer_and_serial(p7, -1)))
+        goto end;
+
+    ret = 1;
+end:
+    PKCS7_RECIP_INFO_free(ri);
+    PKCS7_free(p7);
+    return ret;
+}
+
 #ifndef OPENSSL_NO_EC
 static const unsigned char cert_der[] = {
     0x30, 0x82, 0x01, 0x51, 0x30, 0x81, 0xf7, 0xa0, 0x03, 0x02, 0x01, 0x02,
@@ -389,6 +413,7 @@ end:
 
 int setup_tests(void)
 {
+    ADD_TEST(pkcs7_issuer_and_serial_negative_idx_test);
 #ifndef OPENSSL_NO_EC
     ADD_TEST(pkcs7_verify_test);
     ADD_TEST(pkcs7_inner_content_verify_test);


### PR DESCRIPTION
`PKCS7_get_issuer_and_serial` checked only the upper bound of the recipient-info index. A negative `idx` could therefore reach `sk_PKCS7_RECIP_INFO_value`, return `NULL` and then be dereferenced.

Reject negative indices explicitly and return `NULL`, matching the existing out-of-range behavior for indices greater than or equal to the recipient-info stack size.

A regression test is added for `idx == -1`, while also checking that `idx == 0` still returns the expected issuer-and-serial value.

Fixes #30910.

The PR commit applies cleanly to master and all four upstream branches openssl-3.4, openssl-3.5, openssl-3.6 and openssl-4.0.