### PR TITLE
rsa_sig: reject short buffers in verify_recover

### DIFF
--- a/providers/implementations/signature/rsa_sig.c
+++ b/providers/implementations/signature/rsa_sig.c
@@ -988,8 +988,19 @@ static int rsa_verify_recover(void *vprsactx,
             break;
 
         case RSA_PKCS1_PADDING: {
+            int mdsize = EVP_MD_get_size(prsactx->md);
             size_t sltmp;
 
+            if (mdsize <= 0) {
+                ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DIGEST_LENGTH);
+                return 0;
+            }
+            if (routsize < (size_t)mdsize) {
+                ERR_raise_data(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL,
+                    "buffer size is %d, should be %d",
+                    routsize, mdsize);
+                return 0;
+            }
             ret = ossl_rsa_verify(prsactx->mdnid, NULL, 0, rout, &sltmp,
                 sig, siglen, prsactx->rsa);
             if (ret <= 0) {

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4032,12 +4032,11 @@ err:
     return ret;
 }
 
-static int do_RSA_verify_recover_rejects_short_buffer(EVP_PKEY *pkey,
-    const char *propq)
+static int test_RSA_verify_recover_rejects_short_buffer(void)
 {
     int ret = 0;
     int recovered_cap = 0;
-    EVP_MD *sha256 = NULL;
+    EVP_PKEY *pkey = NULL;
     EVP_PKEY_CTX *sign_ctx = NULL, *verify_ctx = NULL;
     unsigned char *sig = NULL, *recovered = NULL;
     size_t sig_len = 0, recovered_len = 0;
@@ -4050,14 +4049,16 @@ static int do_RSA_verify_recover_rejects_short_buffer(EVP_PKEY *pkey,
     for (i = 0; i < sizeof(digest); i++)
         digest[i] = (unsigned char)i;
 
-    if (!TEST_ptr(pkey)
-        || !TEST_ptr(sha256 = EVP_MD_fetch(testctx, "SHA2-256", propq))
-        || !TEST_ptr(sign_ctx = EVP_PKEY_CTX_new_from_pkey(testctx, pkey, propq))
+    if (OSSL_PROVIDER_available(testctx, "fips"))
+        return TEST_skip("Test skipped for FIPS provider");
+
+    if (!TEST_ptr(pkey = load_example_rsa_key())
+        || !TEST_ptr(sign_ctx = EVP_PKEY_CTX_new_from_pkey(testctx, pkey, NULL))
         || !TEST_int_gt(EVP_PKEY_sign_init(sign_ctx), 0)
         || !TEST_int_gt(EVP_PKEY_CTX_set_rsa_padding(sign_ctx,
                             RSA_PKCS1_PADDING),
             0)
-        || !TEST_int_gt(EVP_PKEY_CTX_set_signature_md(sign_ctx, sha256),
+        || !TEST_int_gt(EVP_PKEY_CTX_set_signature_md(sign_ctx, EVP_sha256()),
             0)
         || !TEST_int_gt(EVP_PKEY_sign(sign_ctx, NULL, &sig_len, digest,
                             sizeof(digest)),
@@ -4069,12 +4070,12 @@ static int do_RSA_verify_recover_rejects_short_buffer(EVP_PKEY *pkey,
         || !TEST_int_gt(recovered_cap = EVP_PKEY_get_size(pkey), 0)
         || !TEST_ptr(recovered = OPENSSL_malloc(recovered_cap))
         || !TEST_ptr(verify_ctx = EVP_PKEY_CTX_new_from_pkey(testctx, pkey,
-                         propq))
+                         NULL))
         || !TEST_int_gt(EVP_PKEY_verify_recover_init(verify_ctx), 0)
         || !TEST_int_gt(EVP_PKEY_CTX_set_rsa_padding(verify_ctx,
                             RSA_PKCS1_PADDING),
             0)
-        || !TEST_int_gt(EVP_PKEY_CTX_set_signature_md(verify_ctx, sha256),
+        || !TEST_int_gt(EVP_PKEY_CTX_set_signature_md(verify_ctx, EVP_sha256()),
             0))
         goto done;
 
@@ -4102,59 +4103,11 @@ static int do_RSA_verify_recover_rejects_short_buffer(EVP_PKEY *pkey,
 
     ret = 1;
 done:
-    EVP_MD_free(sha256);
     EVP_PKEY_CTX_free(sign_ctx);
     EVP_PKEY_CTX_free(verify_ctx);
+    EVP_PKEY_free(pkey);
     OPENSSL_free(sig);
     OPENSSL_free(recovered);
-    return ret;
-}
-
-static int test_RSA_verify_recover_rejects_short_buffer(void)
-{
-    int ret = 0;
-    EVP_PKEY *pkey = NULL;
-
-    if (!TEST_ptr(pkey = load_example_rsa_key()))
-        goto done;
-
-    ret = do_RSA_verify_recover_rejects_short_buffer(pkey, NULL);
-
-done:
-    EVP_PKEY_free(pkey);
-    return ret;
-}
-
-static int test_RSA_verify_recover_rejects_short_buffer_fips(void)
-{
-    static const char fips_propq[] = "provider=fips";
-    int fipsver = 0;
-    int ret = 0;
-    EVP_PKEY *pkey = NULL;
-    OSSL_PROVIDER *fipsprov = NULL;
-
-    if (!OSSL_PROVIDER_available(testctx, "fips"))
-        return TEST_skip("Test requires FIPS provider");
-
-    if (!TEST_ptr(fipsprov = OSSL_PROVIDER_load(testctx, "fips")))
-        goto done;
-    if (!TEST_int_ge(fipsver = fips_provider_version_match(testctx,
-                         "!3.0.0 !3.0.8 !3.0.9 !3.1.2"),
-            0))
-        goto done;
-    if (fipsver == 0) {
-        ret = TEST_skip("Test skipped for old FIPS providers");
-        goto done;
-    }
-    if (!TEST_ptr(pkey = EVP_PKEY_Q_keygen(testctx, fips_propq, "RSA",
-                      (size_t)2048)))
-        goto done;
-
-    ret = do_RSA_verify_recover_rejects_short_buffer(pkey, fips_propq);
-
-done:
-    EVP_PKEY_free(pkey);
-    OSSL_PROVIDER_unload(fipsprov);
     return ret;
 }
 
@@ -7964,7 +7917,6 @@ int setup_tests(void)
     ADD_TEST(test_RSA_OAEP_set_get_params);
     ADD_TEST(test_RSA_OAEP_set_null_label);
     ADD_TEST(test_RSA_verify_recover_rejects_short_buffer);
-    ADD_TEST(test_RSA_verify_recover_rejects_short_buffer_fips);
     ADD_TEST(test_RSA_encrypt);
 #ifndef OPENSSL_NO_DEPRECATED_3_0
     ADD_TEST(test_RSA_legacy);

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4147,7 +4147,7 @@ static int test_RSA_verify_recover_rejects_short_buffer_fips(void)
         goto done;
     }
     if (!TEST_ptr(pkey = EVP_PKEY_Q_keygen(testctx, fips_propq, "RSA",
-                      (size_t)OPENSSL_RSA_FIPS_MIN_MODULUS_BITS)))
+                      (size_t)2048)))
         goto done;
 
     ret = do_RSA_verify_recover_rejects_short_buffer(pkey, fips_propq);

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4034,6 +4034,7 @@ err:
 
 static int test_RSA_verify_recover_rejects_short_buffer(void)
 {
+    int fipsver = 0;
     int ret = 0;
     int recovered_cap = 0;
     EVP_PKEY *pkey = NULL;
@@ -4045,6 +4046,13 @@ static int test_RSA_verify_recover_rejects_short_buffer(void)
     const unsigned char shortbuf_expected[] = { 0xa5, 0x5a };
     unsigned char digest[32];
     size_t i;
+
+    if (!TEST_int_ge(fipsver = fips_provider_version_match(testctx,
+                         "!3.0.0 !3.0.8 !3.0.9 !3.1.2"),
+            0))
+        goto done;
+    if (fipsver == 0)
+        return TEST_skip("Test skipped for old FIPS providers");
 
     for (i = 0; i < sizeof(digest); i++)
         digest[i] = (unsigned char)i;

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4032,12 +4032,12 @@ err:
     return ret;
 }
 
-static int test_RSA_verify_recover_rejects_short_buffer(void)
+static int do_RSA_verify_recover_rejects_short_buffer(EVP_PKEY *pkey,
+    const char *propq)
 {
-    int fipsver = 0;
     int ret = 0;
     int recovered_cap = 0;
-    EVP_PKEY *pkey = NULL;
+    EVP_MD *sha256 = NULL;
     EVP_PKEY_CTX *sign_ctx = NULL, *verify_ctx = NULL;
     unsigned char *sig = NULL, *recovered = NULL;
     size_t sig_len = 0, recovered_len = 0;
@@ -4047,23 +4047,17 @@ static int test_RSA_verify_recover_rejects_short_buffer(void)
     unsigned char digest[32];
     size_t i;
 
-    if (!TEST_int_ge(fipsver = fips_provider_version_match(testctx,
-                         "!3.0.0 !3.0.8 !3.0.9 !3.1.2"),
-            0))
-        goto done;
-    if (fipsver == 0)
-        return TEST_skip("Test skipped for old FIPS providers");
-
     for (i = 0; i < sizeof(digest); i++)
         digest[i] = (unsigned char)i;
 
-    if (!TEST_ptr(pkey = load_example_rsa_key())
-        || !TEST_ptr(sign_ctx = EVP_PKEY_CTX_new_from_pkey(testctx, pkey, NULL))
+    if (!TEST_ptr(pkey)
+        || !TEST_ptr(sha256 = EVP_MD_fetch(testctx, "SHA2-256", propq))
+        || !TEST_ptr(sign_ctx = EVP_PKEY_CTX_new_from_pkey(testctx, pkey, propq))
         || !TEST_int_gt(EVP_PKEY_sign_init(sign_ctx), 0)
         || !TEST_int_gt(EVP_PKEY_CTX_set_rsa_padding(sign_ctx,
                             RSA_PKCS1_PADDING),
             0)
-        || !TEST_int_gt(EVP_PKEY_CTX_set_signature_md(sign_ctx, EVP_sha256()),
+        || !TEST_int_gt(EVP_PKEY_CTX_set_signature_md(sign_ctx, sha256),
             0)
         || !TEST_int_gt(EVP_PKEY_sign(sign_ctx, NULL, &sig_len, digest,
                             sizeof(digest)),
@@ -4075,12 +4069,12 @@ static int test_RSA_verify_recover_rejects_short_buffer(void)
         || !TEST_int_gt(recovered_cap = EVP_PKEY_get_size(pkey), 0)
         || !TEST_ptr(recovered = OPENSSL_malloc(recovered_cap))
         || !TEST_ptr(verify_ctx = EVP_PKEY_CTX_new_from_pkey(testctx, pkey,
-                         NULL))
+                         propq))
         || !TEST_int_gt(EVP_PKEY_verify_recover_init(verify_ctx), 0)
         || !TEST_int_gt(EVP_PKEY_CTX_set_rsa_padding(verify_ctx,
                             RSA_PKCS1_PADDING),
             0)
-        || !TEST_int_gt(EVP_PKEY_CTX_set_signature_md(verify_ctx, EVP_sha256()),
+        || !TEST_int_gt(EVP_PKEY_CTX_set_signature_md(verify_ctx, sha256),
             0))
         goto done;
 
@@ -4108,11 +4102,59 @@ static int test_RSA_verify_recover_rejects_short_buffer(void)
 
     ret = 1;
 done:
+    EVP_MD_free(sha256);
     EVP_PKEY_CTX_free(sign_ctx);
     EVP_PKEY_CTX_free(verify_ctx);
-    EVP_PKEY_free(pkey);
     OPENSSL_free(sig);
     OPENSSL_free(recovered);
+    return ret;
+}
+
+static int test_RSA_verify_recover_rejects_short_buffer(void)
+{
+    int ret = 0;
+    EVP_PKEY *pkey = NULL;
+
+    if (!TEST_ptr(pkey = load_example_rsa_key()))
+        goto done;
+
+    ret = do_RSA_verify_recover_rejects_short_buffer(pkey, NULL);
+
+done:
+    EVP_PKEY_free(pkey);
+    return ret;
+}
+
+static int test_RSA_verify_recover_rejects_short_buffer_fips(void)
+{
+    static const char fips_propq[] = "provider=fips";
+    int fipsver = 0;
+    int ret = 0;
+    EVP_PKEY *pkey = NULL;
+    OSSL_PROVIDER *fipsprov = NULL;
+
+    if (!OSSL_PROVIDER_available(testctx, "fips"))
+        return TEST_skip("Test requires FIPS provider");
+
+    if (!TEST_ptr(fipsprov = OSSL_PROVIDER_load(testctx, "fips")))
+        goto done;
+    if (!TEST_int_ge(fipsver = fips_provider_version_match(testctx,
+                         "!3.0.0 !3.0.8 !3.0.9 !3.1.2"),
+            0))
+        goto done;
+    if (fipsver == 0) {
+        ret = TEST_skip("Test skipped for old FIPS providers");
+        goto done;
+    }
+    if (!TEST_ptr(pkey = EVP_PKEY_Q_keygen(testctx, fips_propq, "RSA",
+                      (size_t)OPENSSL_RSA_FIPS_MIN_MODULUS_BITS)))
+        goto done;
+
+    ret = do_RSA_verify_recover_rejects_short_buffer(pkey, fips_propq);
+
+done:
+    EVP_PKEY_free(pkey);
+    OSSL_PROVIDER_unload(fipsprov);
     return ret;
 }
 
@@ -7922,6 +7964,7 @@ int setup_tests(void)
     ADD_TEST(test_RSA_OAEP_set_get_params);
     ADD_TEST(test_RSA_OAEP_set_null_label);
     ADD_TEST(test_RSA_verify_recover_rejects_short_buffer);
+    ADD_TEST(test_RSA_verify_recover_rejects_short_buffer_fips);
     ADD_TEST(test_RSA_encrypt);
 #ifndef OPENSSL_NO_DEPRECATED_3_0
     ADD_TEST(test_RSA_legacy);

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4032,6 +4032,82 @@ err:
     return ret;
 }
 
+static int test_RSA_verify_recover_rejects_short_buffer(void)
+{
+    int ret = 0;
+    int recovered_cap = 0;
+    EVP_PKEY *pkey = NULL;
+    EVP_PKEY_CTX *sign_ctx = NULL, *verify_ctx = NULL;
+    unsigned char *sig = NULL, *recovered = NULL;
+    size_t sig_len = 0, recovered_len = 0;
+    unsigned long err = 0;
+    unsigned char shortbuf[] = { 0xa5, 0x5a };
+    const unsigned char shortbuf_expected[] = { 0xa5, 0x5a };
+    unsigned char digest[32];
+    size_t i;
+
+    for (i = 0; i < sizeof(digest); i++)
+        digest[i] = (unsigned char)i;
+
+    if (!TEST_ptr(pkey = load_example_rsa_key())
+        || !TEST_ptr(sign_ctx = EVP_PKEY_CTX_new_from_pkey(testctx, pkey, NULL))
+        || !TEST_int_gt(EVP_PKEY_sign_init(sign_ctx), 0)
+        || !TEST_int_gt(EVP_PKEY_CTX_set_rsa_padding(sign_ctx,
+                            RSA_PKCS1_PADDING),
+            0)
+        || !TEST_int_gt(EVP_PKEY_CTX_set_signature_md(sign_ctx, EVP_sha256()),
+            0)
+        || !TEST_int_gt(EVP_PKEY_sign(sign_ctx, NULL, &sig_len, digest,
+                            sizeof(digest)),
+            0)
+        || !TEST_ptr(sig = OPENSSL_malloc(sig_len))
+        || !TEST_int_gt(EVP_PKEY_sign(sign_ctx, sig, &sig_len, digest,
+                            sizeof(digest)),
+            0)
+        || !TEST_int_gt(recovered_cap = EVP_PKEY_get_size(pkey), 0)
+        || !TEST_ptr(recovered = OPENSSL_malloc(recovered_cap))
+        || !TEST_ptr(verify_ctx = EVP_PKEY_CTX_new_from_pkey(testctx, pkey,
+                         NULL))
+        || !TEST_int_gt(EVP_PKEY_verify_recover_init(verify_ctx), 0)
+        || !TEST_int_gt(EVP_PKEY_CTX_set_rsa_padding(verify_ctx,
+                            RSA_PKCS1_PADDING),
+            0)
+        || !TEST_int_gt(EVP_PKEY_CTX_set_signature_md(verify_ctx, EVP_sha256()),
+            0))
+        goto done;
+
+    recovered_len = (size_t)recovered_cap;
+    if (!TEST_int_gt(EVP_PKEY_verify_recover(verify_ctx, recovered,
+                         &recovered_len, sig, sig_len),
+            0)
+        || !TEST_size_t_eq(recovered_len, sizeof(digest))
+        || !TEST_mem_eq(recovered, recovered_len, digest, sizeof(digest)))
+        goto done;
+
+    ERR_clear_error();
+    recovered_len = 1;
+    if (!TEST_int_le(EVP_PKEY_verify_recover(verify_ctx, shortbuf,
+                         &recovered_len, sig, sig_len),
+            0))
+        goto done;
+
+    err = ERR_peek_error();
+    if (!TEST_int_eq(ERR_GET_LIB(err), ERR_LIB_PROV)
+        || !TEST_int_eq(ERR_GET_REASON(err), PROV_R_OUTPUT_BUFFER_TOO_SMALL)
+        || !TEST_mem_eq(shortbuf, sizeof(shortbuf), shortbuf_expected,
+            sizeof(shortbuf_expected)))
+        goto done;
+
+    ret = 1;
+done:
+    EVP_PKEY_CTX_free(sign_ctx);
+    EVP_PKEY_CTX_free(verify_ctx);
+    EVP_PKEY_free(pkey);
+    OPENSSL_free(sig);
+    OPENSSL_free(recovered);
+    return ret;
+}
+
 static int test_RSA_encrypt(void)
 {
     int ret = 0;
@@ -7837,6 +7913,7 @@ int setup_tests(void)
     ADD_TEST(test_RSA_get_set_params);
     ADD_TEST(test_RSA_OAEP_set_get_params);
     ADD_TEST(test_RSA_OAEP_set_null_label);
+    ADD_TEST(test_RSA_verify_recover_rejects_short_buffer);
     ADD_TEST(test_RSA_encrypt);
 #ifndef OPENSSL_NO_DEPRECATED_3_0
     ADD_TEST(test_RSA_legacy);


### PR DESCRIPTION
This fixes missing output-size validation in the RSA PKCS#1
verify-recover provider path.

The X9.31 branch already checks `routsize` before copying recovered
output, but the PKCS#1 branch passed the caller buffer directly to
`ossl_rsa_verify()` without validating the available output space first.

This change:
- checks `routsize` against the configured digest size before calling
  `ossl_rsa_verify()`
- returns `PROV_R_OUTPUT_BUFFER_TOO_SMALL` for undersized buffers
- adds a regression test covering both the normal recovery case and the
  short-buffer failure case

I reproduced the issue on the currently maintained OpenSSL 3.x release
families and on `master`. This PR targets `master`; please let me know
if separate backport PRs would be preferred.

Developed and validated jointly by @mayank-jangid-moon and  @Kushalkhemka.

Tested with:
- `./test/evp_extra_test -test test_RSA_verify_recover_rejects_short_buffer`
- `./test/evp_extra_test -test test_RSA_encrypt`
- `./test/evp_extra_test`
- `SRCTOP=. BLDTOP=. PERL5LIB=util/perl /usr/bin/perl test/recipes/30-test_evp_extra.t`

##### Checklist
- [ ] documentation is added or updated
- [x] tests are added or updated
