### PR TITLE
test: add Windows RIO notifier smoke test

### DIFF
--- a/ssl/ssl_init.c
+++ b/ssl/ssl_init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -15,7 +15,6 @@
 #include <openssl/trace.h>
 #include "ssl_local.h"
 #include "internal/thread_once.h"
-#include "internal/rio_notifier.h" /* for ossl_wsa_cleanup() */
 
 static int stopped;
 

--- a/test/build.info
+++ b/test/build.info
@@ -88,6 +88,9 @@ IF[{- !$disabled{tests} -}]
   IF[{- !$disabled{quic} -}]
     PROGRAMS{noinst}=priority_queue_test quicfaultstest quicapitest \
                      quic_newcid_test quic_srt_gen_test
+    IF[{- $config{target} =~ /^(?:VC-|mingw|BC-)/ -}]
+      PROGRAMS{noinst}=rio_notifier_test
+    ENDIF
   ENDIF
 
   IF[{- !$disabled{quic} && !$disabled{qlog} -}]
@@ -385,6 +388,12 @@ IF[{- !$disabled{tests} -}]
   DEPEND[packettest]=../libcrypto libtestutil.a
 
   IF[{- !$disabled{'quic'} -}]
+    IF[{- $config{target} =~ /^(?:VC-|mingw|BC-)/ -}]
+      SOURCE[rio_notifier_test]=rio_notifier_test.c
+      INCLUDE[rio_notifier_test]=.. ../include ../apps/include
+      DEPEND[rio_notifier_test]=../libcrypto.a ../libssl.a libtestutil.a
+    ENDIF
+
       SOURCE[quic_wire_test]=quic_wire_test.c
       INCLUDE[quic_wire_test]=../include ../apps/include
       DEPEND[quic_wire_test]=../libcrypto.a ../libssl.a libtestutil.a

--- a/test/recipes/70-test_rio_notifier.t
+++ b/test/recipes/70-test_rio_notifier.t
@@ -1,0 +1,22 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use OpenSSL::Test;
+use OpenSSL::Test::Utils;
+
+setup("test_rio_notifier");
+
+plan skip_all => "RIO notifier tests require QUIC"
+    if disabled("quic");
+
+plan skip_all => "RIO notifier WSA tests are only available on Windows"
+    if config("target") !~ /^(?:VC-|mingw|BC-)/i;
+
+plan tests => 1;
+
+ok(run(test(["rio_notifier_test"])));

--- a/test/rio_notifier_test.c
+++ b/test/rio_notifier_test.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "internal/rio_notifier.h"
+#include "testutil.h"
+
+static int test_rio_notifier_smoke(void)
+{
+    RIO_NOTIFIER nfy = { -1, -1 };
+    int ret = 0;
+
+    if (!TEST_true(ossl_rio_notifier_init(&nfy)))
+        goto err;
+
+    if (!TEST_int_ne(ossl_rio_notifier_as_fd(&nfy), (int)INVALID_SOCKET)
+        || !TEST_true(ossl_rio_notifier_signal(&nfy))
+        || !TEST_true(ossl_rio_notifier_unsignal(&nfy)))
+        goto err;
+
+    ret = 1;
+
+err:
+    ossl_rio_notifier_cleanup(&nfy);
+    return ret;
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(test_rio_notifier_smoke);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Add Windows-only smoke coverage for the RIO notifier.

The RIO WSA startup/cleanup lifecycle fix originally carried by this PR has now landed via #31339. This PR is rebased on top of that change and keeps the remaining useful coverage only: a minimal Windows RIO notifier test that exercises initialization, signalling, unsignalling, and cleanup without any test-only library hooks.

This change also removes the stale `internal/rio_notifier.h` include and `ossl_wsa_cleanup` comment from `ssl/ssl_init.c`: that cleanup path no longer exists after #31339.

## Testing

Added `test/recipes/70-test_rio_notifier.t` and `test/rio_notifier_test.c`.

The test is Windows-only and requires QUIC. It links against the normal `libssl` build and does not compile `ssl/rio/rio_notifier.c` directly or define `OSSL_RIO_NOTIFIER_TEST`.

Locally verified after rebasing:

- `perl -Iutil/perl -c test/recipes/70-test_rio_notifier.t` passes.
