### PR TITLE
Fix error check for EVP_CTRL_AEAD_GET_TAG

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -2958,8 +2958,9 @@ int speed_main(int argc, char **argv)
                             exit(1);
                         }
 
-                        if (!EVP_CIPHER_CTX_ctrl(loopargs[k].ctx, EVP_CTRL_AEAD_GET_TAG,
-                                TAG_LEN, &loopargs[k].tag)) {
+                        if (EVP_CIPHER_CTX_ctrl(loopargs[k].ctx, EVP_CTRL_AEAD_GET_TAG,
+                                TAG_LEN, &loopargs[k].tag)
+                            <= 0) {
                             BIO_puts(bio_err, "\nFailed to get the tag\n");
                             dofail();
                             exit(1);

--- a/crypto/pkcs12/p12_decr.c
+++ b/crypto/pkcs12/p12_decr.c
@@ -105,7 +105,7 @@ unsigned char *PKCS12_pbe_crypt_ex(const X509_ALGOR *algor,
         if (EVP_CIPHER_CTX_is_encrypting(ctx)) {
             if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG,
                     (int)mac_len, out + outlen)
-                < 0) {
+                <= 0) {
                 OPENSSL_free(out);
                 out = NULL;
                 ERR_raise(ERR_LIB_PKCS12, ERR_R_INTERNAL_ERROR);

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -6242,7 +6242,8 @@ static int test_evp_final_no_tag(int idx)
         goto err;
 
     ctext_len += len;
-    if (!TEST_true(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, 16, tag)))
+    if (!TEST_int_gt(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, 16, tag),
+            0))
         goto err;
     EVP_CIPHER_CTX_free(ctx);
 


### PR DESCRIPTION
"< 0" is definitely wrong as it can return 0 on error. Change the checks that are not of the form "== 1" or "!= 1" to "<= 0".

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
