### PR TITLE
TLS 1.3 Ticket Renewal on Cipher Change

### DIFF
--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -1489,6 +1489,10 @@ int tls_parse_ctos_psk(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
                  */
                 s->ext.early_data_ok = 1;
             }
+
+            /* If the ticket is for an old cipher, send a new ticket. */
+            if (sess->cipher->id != s->s3.tmp.new_cipher->id)
+                s->ext.ticket_expected = 1;
         }
 
         md = ssl_md(sctx, sess->cipher->algorithm2);


### PR DESCRIPTION
For TLS 1.3 session resumption, when the client's identity (a.k.a "ticket") is for a cipher which is not the same one we want to negotiate, we should issue a new ticket with an updated identity and the cipher we want to negotiate
