### PR TITLE
[3.5] Backport of #30428 "Fix memory leak in load_key_certs_crls() when add/push fails"

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1057,9 +1057,12 @@ int load_key_certs_crls(const char *uri, int format, int maybe_stdin,
                 if (ok)
                     pcert = NULL;
             } else if (pcerts != NULL) {
-                ok = X509_add_cert(*pcerts,
-                    OSSL_STORE_INFO_get1_CERT(info),
-                    X509_ADD_FLAG_DEFAULT);
+                X509 *cert = OSSL_STORE_INFO_get1_CERT(info);
+
+                ok = cert != NULL
+                    && X509_add_cert(*pcerts, cert, X509_ADD_FLAG_DEFAULT);
+                if (!ok)
+                    X509_free(cert);
             }
             ncerts += ok;
             break;
@@ -1069,7 +1072,11 @@ int load_key_certs_crls(const char *uri, int format, int maybe_stdin,
                 if (ok)
                     pcrl = NULL;
             } else if (pcrls != NULL) {
-                ok = sk_X509_CRL_push(*pcrls, OSSL_STORE_INFO_get1_CRL(info));
+                X509_CRL *crl = OSSL_STORE_INFO_get1_CRL(info);
+
+                ok = crl != NULL && sk_X509_CRL_push(*pcrls, crl);
+                if (!ok)
+                    X509_CRL_free(crl);
             }
             ncrls += ok;
             break;


### PR DESCRIPTION
## Description

Backport of openssl/openssl#30428 to **openssl-3.5**.

Fixes a leak in `apps/lib/apps.c::load_key_certs_crls()`: when
`X509_add_cert()` or `sk_X509_CRL_push()` fails, the cert/CRL returned
by `OSSL_STORE_INFO_get1_CERT()` / `OSSL_STORE_INFO_get1_CRL()` was
never freed. The leak is on the failure path only.

Fixes https://github.com/openssl/openssl/issues/30364

Posted as a separate PR per @npajkovsky on #30428: the master commit
does not cherry-pick cleanly to 3.x.

## Implementation Details

- `apps/lib/apps.c`: store the `get1` result in a temporary, free it
  with `X509_free()` / `X509_CRL_free()` on add/push failure.
- The master regression test (`test/load_key_certs_crls_memfail.c`,
  `test/recipes/90-test_memfail.t`) is **not** ported: the
  `allocfail-tests` category does not exist on 3.5.

## Checklist

- [x] Single-file backport of `apps/lib/apps.c`.
- [x] `(cherry picked from commit 9ac29bc8579dd9632bd50900675ff7900f5f7ef1)`
      trailer present.
- [x] Uses existing public API only; no new warnings.
