### PR TITLE
[3.6] Backport of #30428 "Fix memory leak in load_key_certs_crls() when add/push fails"

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1107,9 +1107,12 @@ int load_key_certs_crls(const char *uri, int format, int maybe_stdin,
                 if (ok)
                     pcert = NULL;
             } else if (pcerts != NULL) {
-                ok = X509_add_cert(*pcerts,
-                    OSSL_STORE_INFO_get1_CERT(info),
-                    X509_ADD_FLAG_DEFAULT);
+                X509 *cert = OSSL_STORE_INFO_get1_CERT(info);
+
+                ok = cert != NULL
+                    && X509_add_cert(*pcerts, cert, X509_ADD_FLAG_DEFAULT);
+                if (!ok)
+                    X509_free(cert);
             }
             ncerts += ok;
             break;
@@ -1119,7 +1122,11 @@ int load_key_certs_crls(const char *uri, int format, int maybe_stdin,
                 if (ok)
                     pcrl = NULL;
             } else if (pcrls != NULL) {
-                ok = sk_X509_CRL_push(*pcrls, OSSL_STORE_INFO_get1_CRL(info));
+                X509_CRL *crl = OSSL_STORE_INFO_get1_CRL(info);
+
+                ok = crl != NULL && sk_X509_CRL_push(*pcrls, crl);
+                if (!ok)
+                    X509_CRL_free(crl);
             }
             ncrls += ok;
             break;

--- a/test/build.info
+++ b/test/build.info
@@ -77,7 +77,7 @@ IF[{- !$disabled{tests} -}]
   ENDIF
 
   IF[{- !$disabled{'allocfail-tests'} -}]
-    PROGRAMS{noninst}=handshake-memfail
+    PROGRAMS{noinst}=handshake-memfail load_key_certs_crls_memfail
   ENDIF
 
   IF[{- !$disabled{'deprecated-3.0'} -}]
@@ -590,6 +590,13 @@ IF[{- !$disabled{tests} -}]
   SOURCE[handshake-memfail]=handshake-memfail.c helpers/ssltestlib.c
   INCLUDE[handshake-memfail]=../include ../apps/include
   DEPEND[handshake-memfail]=../libcrypto.a ../libssl.a libtestutil.a
+
+  SOURCE[load_key_certs_crls_memfail]=load_key_certs_crls_memfail.c ../apps/lib/apps.c \
+          ../apps/lib/app_rand.c ../apps/lib/app_provider.c ../apps/lib/app_libctx.c \
+          ../apps/lib/fmt.c ../apps/lib/apps_ui.c ../apps/lib/app_x509.c \
+          ../crypto/asn1/a_time.c ../crypto/ctype.c
+  INCLUDE[load_key_certs_crls_memfail]=.. ../include ../apps/include
+  DEPEND[load_key_certs_crls_memfail]=libtestutil.a ../libcrypto.a ../libssl.a
 
   SOURCE[ssl_handshake_rtt_test]=ssl_handshake_rtt_test.c helpers/ssltestlib.c
   INCLUDE[ssl_handshake_rtt_test]=../include ../apps/include ..

--- a/test/load_key_certs_crls_memfail.c
+++ b/test/load_key_certs_crls_memfail.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ *
+ * Regression test for issue #30364: memory leak in load_key_certs_crls()
+ * when X509_add_cert() or sk_X509_CRL_push() fails. Exercises the add/push
+ * path under OPENSSL_MALLOC_FAILURES so that with the fix the cert/CRL is
+ * freed on failure (memory_sanitizer would report a leak without the fix).
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <openssl/x509.h>
+#include <openssl/crypto.h>
+#include "apps.h"
+#include "app_libctx.h"
+#include "testutil.h"
+
+char *default_config_file = NULL;
+
+static char *certfile = NULL;
+static int mcount, rcount, fcount, scount;
+
+static int do_load_key_certs_crls(int allow_failure)
+{
+    STACK_OF(X509) *certs = NULL;
+    int ret = (allow_failure == 1) ? 0 : 1;
+    char uri[1024];
+
+    if (certfile == NULL)
+        return 0;
+
+    (void)snprintf(uri, sizeof(uri), "file:%s", certfile);
+    if (!TEST_true(load_key_certs_crls(uri, FORMAT_UNDEF, 0, NULL, "cert",
+            1, NULL, NULL, NULL, NULL, &certs,
+            NULL, NULL, NULL)))
+        goto err;
+
+    ret = 1;
+err:
+    sk_X509_pop_free(certs, X509_free);
+    return ret;
+}
+
+static int test_record_alloc_counts(void)
+{
+    return do_load_key_certs_crls(1);
+}
+
+static int test_alloc_failures(void)
+{
+    return do_load_key_certs_crls(0);
+}
+
+static int test_report_alloc_counts(void)
+{
+    CRYPTO_get_alloc_counts(&mcount, &rcount, &fcount);
+    TEST_info("skip: %d count %d\n", scount, mcount - scount);
+    return 1;
+}
+
+int setup_tests(void)
+{
+    int ret = 0;
+    char *opmode = NULL;
+
+    if (app_create_libctx() == NULL)
+        return 0;
+
+    if (!TEST_ptr(opmode = test_get_argument(0)))
+        goto err;
+
+    if (!TEST_ptr(certfile = test_get_argument(1)))
+        goto err;
+
+    if (strcmp(opmode, "count") == 0) {
+        CRYPTO_get_alloc_counts(&scount, &rcount, &fcount);
+        ADD_TEST(test_record_alloc_counts);
+        ADD_TEST(test_report_alloc_counts);
+    } else {
+        ADD_TEST(test_alloc_failures);
+    }
+    ret = 1;
+err:
+    return ret;
+}
+
+void cleanup_tests(void)
+{
+}

--- a/test/recipes/90-test_load_key_certs_crls_memfail.t
+++ b/test/recipes/90-test_load_key_certs_crls_memfail.t
@@ -1,0 +1,80 @@
+#! /usr/bin/env perl
+# Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use OpenSSL::Test qw/:DEFAULT srctop_file result_dir/;
+use OpenSSL::Test::Utils;
+use File::Temp qw(tempfile);
+use File::Path 2.00 qw(rmtree mkpath);
+
+setup("test_load_key_certs_crls_memfail");
+
+#
+# Don't run this test if allocfail-tests isn't enabled, it won't work
+#
+plan skip_all => "$test_name requires allocfail-tests to be enabled"
+    if disabled("allocfail-tests");
+
+#
+# We need to know how many mallocs we plan to fail, so run the test in count mode
+# To tell us how many mallocs it executes
+# We capture the result of the test into countinfo.txt
+# and parse that to figure out what our values are
+#
+my $resultdir = result_dir();
+run(test(["load_key_certs_crls_memfail", "count",
+          srctop_file("test", "certs", "servercert.pem")],
+         stderr => "$resultdir/load_key_certs_crls_countinfo.txt"));
+
+#
+# Read the result file into an array
+#
+open my $handle, '<', "$resultdir/load_key_certs_crls_countinfo.txt";
+chomp(my @lines = <$handle>);
+close $handle;
+
+#
+# Some line contains our counts, find and split that into an array
+#
+my @vals;
+foreach (@lines) {
+    if (/\bskip:\s*(\d+)\s+count\s+(\d+)/) {
+        @vals = ($1, $2);
+        last;
+    }
+}
+
+#
+# The number of mallocs we need to skip is in entry 0
+# The number of mallocs to test is in entry 1
+#
+my $skipcount = $vals[0];
+my $malloccount = $vals[1];
+
+plan skip_all => "could not get malloc counts (count run failed or output format changed)"
+    if !$malloccount;
+
+#
+# Now we can plan our tests.  We plan to run malloccount iterations of this
+# test
+#
+plan tests => $malloccount;
+
+my @seq = (1..$malloccount);
+for my $idx (@seq) {
+    #
+    # We need to setup our openssl malloc failures env var to fail the target malloc
+    # the format of this string is a series of A@B;C@D tuples where A,C are the number
+    # of mallocs to consider, and B,D are the likelihood that they should fail.
+    # We always skip the first "skip" allocations, then iteratively guarantee that
+    # next <idx> mallocs pass, followed by the next single malloc failing, with the remainder
+    # passing
+    #
+    $ENV{OPENSSL_MALLOC_FAILURES} = "$skipcount\@0;$idx\@0;1\@100;0\@0";
+    ok(run(test(["load_key_certs_crls_memfail", "run",
+                 srctop_file("test", "certs", "servercert.pem")])));
+}


### PR DESCRIPTION
## Description

Backport of openssl/openssl#30428 to **openssl-3.6**.

Fixes a leak in `apps/lib/apps.c::load_key_certs_crls()`: when
`X509_add_cert()` or `sk_X509_CRL_push()` fails, the cert/CRL returned
by `OSSL_STORE_INFO_get1_CERT()` / `OSSL_STORE_INFO_get1_CRL()` was
never freed. The leak is on the failure path only.

Fixes https://github.com/openssl/openssl/issues/30364

Posted as a separate PR per @npajkovsky on #30428: the master commit
does not cherry-pick cleanly to 3.x.

## Implementation Details

- `apps/lib/apps.c`: store the `get1` result in a temporary, free it
  with `X509_free()` / `X509_CRL_free()` on add/push failure.
- The master regression test (`test/load_key_certs_crls_memfail.c`,
  `test/recipes/90-test_memfail.t`) is **not** ported: the
  `allocfail-tests` category does not exist on 3.6.

## Checklist

- [x] Single-file backport of `apps/lib/apps.c`.
- [x] `(cherry picked from commit 9ac29bc8579dd9632bd50900675ff7900f5f7ef1)`
      trailer present.
- [x] Uses existing public API only; no new warnings.
