### PR TITLE
Removes duplicated __owur.

### DIFF
--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2556,7 +2556,7 @@ SSL_as_poll_descriptor(SSL *s)
 __owur int SSL_session_reused(const SSL *s);
 __owur int SSL_is_server(const SSL *s);
 
-__owur __owur SSL_CONF_CTX *SSL_CONF_CTX_new(void);
+__owur SSL_CONF_CTX *SSL_CONF_CTX_new(void);
 int SSL_CONF_CTX_finish(SSL_CONF_CTX *cctx);
 void SSL_CONF_CTX_free(SSL_CONF_CTX *cctx);
 unsigned int SSL_CONF_CTX_set_flags(SSL_CONF_CTX *cctx, unsigned int flags);

--- a/providers/implementations/include/prov/ml_dsa_codecs.h
+++ b/providers/implementations/include/prov/ml_dsa_codecs.h
@@ -24,11 +24,9 @@ __owur ML_DSA_KEY *ossl_ml_dsa_d2i_PKCS8(const uint8_t *prvenc, int prvlen,
     int evp_type, PROV_CTX *provctx,
     const char *propq);
 __owur int ossl_ml_dsa_key_to_text(BIO *out, const ML_DSA_KEY *key, int selection);
-__owur
-    __owur int
+__owur int
     ossl_ml_dsa_i2d_pubkey(const ML_DSA_KEY *key, unsigned char **out);
-__owur
-    __owur int
+__owur int
     ossl_ml_dsa_i2d_prvkey(const ML_DSA_KEY *key, unsigned char **out,
         PROV_CTX *provctx, const char *formats);
 

--- a/providers/implementations/include/prov/ml_dsa_codecs.h
+++ b/providers/implementations/include/prov/ml_dsa_codecs.h
@@ -24,11 +24,9 @@ __owur ML_DSA_KEY *ossl_ml_dsa_d2i_PKCS8(const uint8_t *prvenc, int prvlen,
     int evp_type, PROV_CTX *provctx,
     const char *propq);
 __owur int ossl_ml_dsa_key_to_text(BIO *out, const ML_DSA_KEY *key, int selection);
-__owur int
-    ossl_ml_dsa_i2d_pubkey(const ML_DSA_KEY *key, unsigned char **out);
-__owur int
-    ossl_ml_dsa_i2d_prvkey(const ML_DSA_KEY *key, unsigned char **out,
-        PROV_CTX *provctx, const char *formats);
+__owur int ossl_ml_dsa_i2d_pubkey(const ML_DSA_KEY *key, unsigned char **out);
+__owur int ossl_ml_dsa_i2d_prvkey(const ML_DSA_KEY *key, unsigned char **out,
+    PROV_CTX *provctx, const char *formats);
 
 #endif /* OPENSSL_NO_ML_DSA */
 #endif /* PROV_ML_DSA_CODECS_H */

--- a/providers/implementations/include/prov/ml_kem_codecs.h
+++ b/providers/implementations/include/prov/ml_kem_codecs.h
@@ -24,11 +24,9 @@ __owur ML_KEM_KEY *ossl_ml_kem_d2i_PKCS8(const uint8_t *prvenc, int prvlen,
     int evp_type, PROV_CTX *provctx,
     const char *propq);
 __owur int ossl_ml_kem_key_to_text(BIO *out, const ML_KEM_KEY *key, int selection);
-__owur
-    __owur int
+__owur int
     ossl_ml_kem_i2d_pubkey(const ML_KEM_KEY *key, unsigned char **out);
-__owur
-    __owur int
+__owur int
     ossl_ml_kem_i2d_prvkey(const ML_KEM_KEY *key, unsigned char **out,
         PROV_CTX *provctx, const char *formats);
 

--- a/providers/implementations/include/prov/ml_kem_codecs.h
+++ b/providers/implementations/include/prov/ml_kem_codecs.h
@@ -24,11 +24,9 @@ __owur ML_KEM_KEY *ossl_ml_kem_d2i_PKCS8(const uint8_t *prvenc, int prvlen,
     int evp_type, PROV_CTX *provctx,
     const char *propq);
 __owur int ossl_ml_kem_key_to_text(BIO *out, const ML_KEM_KEY *key, int selection);
-__owur int
-    ossl_ml_kem_i2d_pubkey(const ML_KEM_KEY *key, unsigned char **out);
-__owur int
-    ossl_ml_kem_i2d_prvkey(const ML_KEM_KEY *key, unsigned char **out,
-        PROV_CTX *provctx, const char *formats);
+__owur int ossl_ml_kem_i2d_pubkey(const ML_KEM_KEY *key, unsigned char **out);
+__owur int ossl_ml_kem_i2d_prvkey(const ML_KEM_KEY *key, unsigned char **out,
+    PROV_CTX *provctx, const char *formats);
 
 #endif /* OPENSSL_NO_ML_KEM */
 #endif /* PROV_ML_KEM_CODECS_H */


### PR DESCRIPTION
There were a couple of duplicated __owur floating around looks like there were added after some clang format cleanup.