### PR TITLE
Clarify the documentation about interleaving SSL_read()/SSL_write()

### DIFF
--- a/doc/man3/SSL_get_error.pod
+++ b/doc/man3/SSL_get_error.pod
@@ -88,12 +88,16 @@ B<SSL_ERROR_WANT_WRITE> indicates that the OpenSSL internal send buffer for a
 given QUIC stream has been filled. Likewise, B<SSL_ERROR_WANT_READ> indicates
 that the OpenSSL internal receive buffer for a given QUIC stream is empty.
 
-It is safe to call SSL_read() or SSL_read_ex() when more data is available
-even when the call that set this error was an SSL_write() or SSL_write_ex().
-However, if the call was an SSL_write() or SSL_write_ex(), it should be called
-again to continue sending the application data. If you get B<SSL_ERROR_WANT_WRITE>
-from SSL_write() or SSL_write_ex() then you should not do any other operation
-that could trigger B<IO> other than to repeat the previous SSL_write() call.
+It is safe to call SSL_write() or SSL_write_ex() after a previous
+SSL_read()/SSL_read_ex() or SSL_write()/SSL_write_ex() call has signalled
+B<SSL_ERROR_WANT_READ> or B<SSL_ERROR_WANT_WRITE>.
+It is also safe to call SSL_read() or SSL_read_ex() after a previous
+SSL_write()/SSL_write_ex() call has signalled B<SSL_ERROR_WANT_READ>.
+It is not safe to call SSL_read() or SSL_read_ex() after a previous
+SSL_write()/SSL_write_ex() call has signalled B<SSL_ERROR_WANT_WRITE>. If you
+get B<SSL_ERROR_WANT_WRITE> from SSL_write() or SSL_write_ex() then you should
+not do any other operation that could trigger B<IO> other than to repeat the
+previous SSL_write() call.
 
 For socket B<BIO>s (e.g. when SSL_set_fd() was used), select() or
 poll() on the underlying socket can be used to find out when the

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -14658,6 +14658,290 @@ end:
     return testresult;
 }
 
+/*
+ * Test calling SSL_write() after SSL_read() has signalled SSL_ERROR_WANT_WRITE
+ * This scenario is allowed.
+ */
+static int test_write_after_read_want_write(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *serverssl = NULL, *clientssl = NULL;
+    int testresult = 0;
+    unsigned char buf = 0;
+    BIO *tmp = NULL;
+    BIO *bretry = BIO_new(bio_s_always_retry());
+
+    if (!TEST_ptr(bretry))
+        goto end;
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(), 0, 0,
+            &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL,
+            NULL)))
+        goto end;
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
+        goto end;
+
+    /*
+     * Force the client into a state where the next SSL_read will give us
+     * SSL_ERROR_WANT_WRITE
+     */
+    tmp = SSL_get_wbio(clientssl);
+    if (!TEST_ptr(tmp) || !TEST_true(BIO_up_ref(tmp))) {
+        tmp = NULL;
+        goto end;
+    }
+    SSL_set0_wbio(clientssl, bretry);
+    bretry = NULL;
+    if (!TEST_true(SSL_key_update(clientssl, SSL_KEY_UPDATE_NOT_REQUESTED)))
+        goto end;
+    if (!TEST_int_le(SSL_read(clientssl, &buf, sizeof(buf)), 0))
+        goto end;
+    if (!TEST_int_eq(SSL_get_error(clientssl, 0), SSL_ERROR_WANT_WRITE))
+        goto end;
+
+    SSL_set0_wbio(clientssl, tmp);
+    tmp = NULL;
+
+    /* Now check we can write without error */
+    if (!TEST_int_gt(SSL_write(clientssl, &buf, sizeof(buf)), 0))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    BIO_free(bretry);
+    BIO_free(tmp);
+
+    return testresult;
+}
+
+/*
+ * Test calling SSL_write() after SSL_read() has signalled SSL_ERROR_WANT_READ
+ * This scenario is allowed.
+ */
+static int test_write_after_read_want_read(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *serverssl = NULL, *clientssl = NULL;
+    int testresult = 0;
+    unsigned char buf = 0;
+    BIO *mem = BIO_new(BIO_s_mem());
+    BIO *tmp = NULL;
+
+    if (!TEST_ptr(mem))
+        goto end;
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(), 0, 0,
+            &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL,
+            NULL)))
+        goto end;
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
+        goto end;
+
+    /* Send an app data record to the client */
+    if (!TEST_int_gt(SSL_write(serverssl, &buf, sizeof(buf)), 0))
+        goto end;
+
+    /* Temporarily replace the client's rbio */
+    tmp = SSL_get_rbio(clientssl);
+    if (!TEST_ptr(tmp) || !TEST_true(BIO_up_ref(tmp))) {
+        tmp = NULL;
+        goto end;
+    }
+    BIO_up_ref(mem);
+    SSL_set0_rbio(clientssl, mem);
+
+    /*
+     * Move a byte of data from the record that the server wrote into the
+     * client's temporary rbio
+     */
+    if (!TEST_int_eq(BIO_read(tmp, &buf, 1), 1))
+        goto end;
+    if (!TEST_int_eq(BIO_write(mem, &buf, 1), 1))
+        goto end;
+
+    /*
+     * We expect to only be able to read a partial record, and therefore will
+     * get an SSL_ERROR_WANT_READ.
+     */
+    if (!TEST_int_le(SSL_read(clientssl, &buf, sizeof(buf)), 0))
+        goto end;
+
+    if (!TEST_int_eq(SSL_get_error(clientssl, 0), SSL_ERROR_WANT_READ))
+        goto end;
+
+    /* Resurrect the client's original rbio */
+    SSL_set0_rbio(clientssl, tmp);
+    tmp = NULL;
+    BIO_free(mem);
+    mem = NULL;
+
+    /* Now check we can write without error */
+    if (!TEST_int_gt(SSL_write(clientssl, &buf, sizeof(buf)), 0))
+        goto end;
+
+    /*
+     * Also check that we are still able to read the partial record we started
+     * to read earlier.
+     */
+    if (!TEST_int_eq(SSL_read(clientssl, &buf, sizeof(buf)), 1))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    BIO_free(mem);
+    BIO_free(tmp);
+
+    return testresult;
+}
+
+/*
+ * Test calling SSL_read() after SSL_write() has signalled SSL_ERROR_WANT_READ
+ * This scenario is allowed.
+ */
+static int test_read_after_write_want_read(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *serverssl = NULL, *clientssl = NULL;
+    int testresult = 0;
+    unsigned char buf = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(), TLS1_2_VERSION, TLS1_2_VERSION,
+            &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL,
+            NULL)))
+        goto end;
+    SSL_set_options(serverssl, SSL_OP_ALLOW_CLIENT_RENEGOTIATION);
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
+        goto end;
+
+    if (!TEST_true(SSL_renegotiate(clientssl)))
+        goto end;
+    if (!TEST_int_le(SSL_write(clientssl, &buf, sizeof(buf)), 0))
+        goto end;
+    /*
+     * The server has not processed the reneg yet, so we should get an
+     * SSL_ERROR_WANT_READ response.
+     */
+    if (!TEST_int_eq(SSL_get_error(clientssl, 0), SSL_ERROR_WANT_READ))
+        goto end;
+
+    /* Now complete the handshake and send some data on the server side */
+    if (!TEST_int_gt(SSL_write(serverssl, &buf, sizeof(buf)), 0))
+        goto end;
+
+    /* Now check we can read without error */
+    if (!TEST_int_gt(SSL_read(clientssl, &buf, sizeof(buf)), 0))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
+/*
+ * Test calling SSL_read() after SSL_wrote() has signalled SSL_ERROR_WANT_WRITE
+ * This scenario is NOT allowed.
+ */
+static int test_read_after_write_want_write(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *serverssl = NULL, *clientssl = NULL;
+    int testresult = 0;
+    unsigned char buf = 0;
+    BIO *bretry = BIO_new(bio_s_always_retry());
+    BIO *tmp;
+
+    if (!TEST_ptr(bretry))
+        goto end;
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(), TLS1_2_VERSION, TLS1_2_VERSION,
+            &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    SSL_set_options(serverssl, SSL_OP_ALLOW_CLIENT_RENEGOTIATION);
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL,
+            NULL)))
+        goto end;
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
+        goto end;
+
+    /*
+     * Force the server into a state so that SSL_write will cause
+     * SSL_ERROR_WANT_WRITE
+     */
+    tmp = SSL_get_wbio(serverssl);
+    if (!TEST_ptr(tmp) || !TEST_true(BIO_up_ref(tmp))) {
+        tmp = NULL;
+        goto end;
+    }
+    SSL_set0_wbio(serverssl, bretry);
+    bretry = NULL;
+
+    if (!TEST_int_le(SSL_write(serverssl, &buf, sizeof(buf)), 0))
+        goto end;
+
+    if (!TEST_int_eq(SSL_get_error(serverssl, 0), SSL_ERROR_WANT_WRITE))
+        goto end;
+
+    SSL_set0_wbio(serverssl, tmp);
+    tmp = NULL;
+
+    /*
+     * Force the server into a state such that an SSL_read call will try and
+     * write something.
+     */
+    if (!TEST_true(SSL_renegotiate(clientssl)))
+        goto end;
+    if (!TEST_int_le(SSL_write(clientssl, &buf, sizeof(buf)), 0))
+        goto end;
+    if (!TEST_int_eq(SSL_get_error(clientssl, 0), SSL_ERROR_WANT_READ))
+        goto end;
+
+    /*
+     * Now call SSL_read(). We expect this to cause a fatal error. You are not
+     * allowed to call SSL_read() after SSL_write().
+     */
+    if (!TEST_int_le(SSL_read(serverssl, &buf, sizeof(buf)), 0))
+        goto end;
+    if (!TEST_int_eq(SSL_get_error(serverssl, 0), SSL_ERROR_SSL))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+
+    return testresult;
+}
+
 OPT_TEST_DECLARE_USAGE("certfile privkeyfile srpvfile tmpfile provider config dhfile\n")
 
 int setup_tests(void)
@@ -15003,7 +15287,14 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_http_verbs, 3);
 #if !defined(OSSL_NO_USABLE_TLS1_3)
     ADD_TEST(test_grease);
+    ADD_TEST(test_write_after_read_want_write);
+    ADD_TEST(test_write_after_read_want_read);
 #endif
+#ifndef OPENSSL_NO_TLS1_2
+    ADD_TEST(test_read_after_write_want_read);
+    ADD_TEST(test_read_after_write_want_write);
+#endif
+
     return 1;
 
 err:

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -16800,6 +16800,290 @@ end:
     return testresult;
 }
 
+/*
+ * Test calling SSL_write() after SSL_read() has signalled SSL_ERROR_WANT_WRITE
+ * This scenario is allowed.
+ */
+static int test_write_after_read_want_write(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *serverssl = NULL, *clientssl = NULL;
+    int testresult = 0;
+    unsigned char buf = 0;
+    BIO *tmp = NULL;
+    BIO *bretry = BIO_new(bio_s_always_retry());
+
+    if (!TEST_ptr(bretry))
+        goto end;
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(), 0, 0,
+            &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL,
+            NULL)))
+        goto end;
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
+        goto end;
+
+    /*
+     * Force the client into a state where the next SSL_read will give us
+     * SSL_ERROR_WANT_WRITE
+     */
+    tmp = SSL_get_wbio(clientssl);
+    if (!TEST_ptr(tmp) || !TEST_true(BIO_up_ref(tmp))) {
+        tmp = NULL;
+        goto end;
+    }
+    SSL_set0_wbio(clientssl, bretry);
+    bretry = NULL;
+    if (!TEST_true(SSL_key_update(clientssl, SSL_KEY_UPDATE_NOT_REQUESTED)))
+        goto end;
+    if (!TEST_int_le(SSL_read(clientssl, &buf, sizeof(buf)), 0))
+        goto end;
+    if (!TEST_int_eq(SSL_get_error(clientssl, 0), SSL_ERROR_WANT_WRITE))
+        goto end;
+
+    SSL_set0_wbio(clientssl, tmp);
+    tmp = NULL;
+
+    /* Now check we can write without error */
+    if (!TEST_int_gt(SSL_write(clientssl, &buf, sizeof(buf)), 0))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    BIO_free(bretry);
+    BIO_free(tmp);
+
+    return testresult;
+}
+
+/*
+ * Test calling SSL_write() after SSL_read() has signalled SSL_ERROR_WANT_READ
+ * This scenario is allowed.
+ */
+static int test_write_after_read_want_read(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *serverssl = NULL, *clientssl = NULL;
+    int testresult = 0;
+    unsigned char buf = 0;
+    BIO *mem = BIO_new(BIO_s_mem());
+    BIO *tmp = NULL;
+
+    if (!TEST_ptr(mem))
+        goto end;
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(), 0, 0,
+            &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL,
+            NULL)))
+        goto end;
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
+        goto end;
+
+    /* Send an app data record to the client */
+    if (!TEST_int_gt(SSL_write(serverssl, &buf, sizeof(buf)), 0))
+        goto end;
+
+    /* Temporarily replace the client's rbio */
+    tmp = SSL_get_rbio(clientssl);
+    if (!TEST_ptr(tmp) || !TEST_true(BIO_up_ref(tmp))) {
+        tmp = NULL;
+        goto end;
+    }
+    BIO_up_ref(mem);
+    SSL_set0_rbio(clientssl, mem);
+
+    /*
+     * Move a byte of data from the record that the server wrote into the
+     * client's temporary rbio
+     */
+    if (!TEST_int_eq(BIO_read(tmp, &buf, 1), 1))
+        goto end;
+    if (!TEST_int_eq(BIO_write(mem, &buf, 1), 1))
+        goto end;
+
+    /*
+     * We expect to only be able to read a partial record, and therefore will
+     * get an SSL_ERROR_WANT_READ.
+     */
+    if (!TEST_int_le(SSL_read(clientssl, &buf, sizeof(buf)), 0))
+        goto end;
+
+    if (!TEST_int_eq(SSL_get_error(clientssl, 0), SSL_ERROR_WANT_READ))
+        goto end;
+
+    /* Resurrect the client's original rbio */
+    SSL_set0_rbio(clientssl, tmp);
+    tmp = NULL;
+    BIO_free(mem);
+    mem = NULL;
+
+    /* Now check we can write without error */
+    if (!TEST_int_gt(SSL_write(clientssl, &buf, sizeof(buf)), 0))
+        goto end;
+
+    /*
+     * Also check that we are still able to read the partial record we started
+     * to read earlier.
+     */
+    if (!TEST_int_eq(SSL_read(clientssl, &buf, sizeof(buf)), 1))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    BIO_free(mem);
+    BIO_free(tmp);
+
+    return testresult;
+}
+
+/*
+ * Test calling SSL_read() after SSL_write() has signalled SSL_ERROR_WANT_READ
+ * This scenario is allowed.
+ */
+static int test_read_after_write_want_read(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *serverssl = NULL, *clientssl = NULL;
+    int testresult = 0;
+    unsigned char buf = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(), TLS1_2_VERSION, TLS1_2_VERSION,
+            &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL,
+            NULL)))
+        goto end;
+    SSL_set_options(serverssl, SSL_OP_ALLOW_CLIENT_RENEGOTIATION);
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
+        goto end;
+
+    if (!TEST_true(SSL_renegotiate(clientssl)))
+        goto end;
+    if (!TEST_int_le(SSL_write(clientssl, &buf, sizeof(buf)), 0))
+        goto end;
+    /*
+     * The server has not processed the reneg yet, so we should get an
+     * SSL_ERROR_WANT_READ response.
+     */
+    if (!TEST_int_eq(SSL_get_error(clientssl, 0), SSL_ERROR_WANT_READ))
+        goto end;
+
+    /* Now complete the handshake and send some data on the server side */
+    if (!TEST_int_gt(SSL_write(serverssl, &buf, sizeof(buf)), 0))
+        goto end;
+
+    /* Now check we can read without error */
+    if (!TEST_int_gt(SSL_read(clientssl, &buf, sizeof(buf)), 0))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
+/*
+ * Test calling SSL_read() after SSL_wrote() has signalled SSL_ERROR_WANT_WRITE
+ * This scenario is NOT allowed.
+ */
+static int test_read_after_write_want_write(void)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *serverssl = NULL, *clientssl = NULL;
+    int testresult = 0;
+    unsigned char buf = 0;
+    BIO *bretry = BIO_new(bio_s_always_retry());
+    BIO *tmp;
+
+    if (!TEST_ptr(bretry))
+        goto end;
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(), TLS1_2_VERSION, TLS1_2_VERSION,
+            &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    SSL_set_options(serverssl, SSL_OP_ALLOW_CLIENT_RENEGOTIATION);
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL,
+            NULL)))
+        goto end;
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
+        goto end;
+
+    /*
+     * Force the server into a state so that SSL_write will cause
+     * SSL_ERROR_WANT_WRITE
+     */
+    tmp = SSL_get_wbio(serverssl);
+    if (!TEST_ptr(tmp) || !TEST_true(BIO_up_ref(tmp))) {
+        tmp = NULL;
+        goto end;
+    }
+    SSL_set0_wbio(serverssl, bretry);
+    bretry = NULL;
+
+    if (!TEST_int_le(SSL_write(serverssl, &buf, sizeof(buf)), 0))
+        goto end;
+
+    if (!TEST_int_eq(SSL_get_error(serverssl, 0), SSL_ERROR_WANT_WRITE))
+        goto end;
+
+    SSL_set0_wbio(serverssl, tmp);
+    tmp = NULL;
+
+    /*
+     * Force the server into a state such that an SSL_read call will try and
+     * write something.
+     */
+    if (!TEST_true(SSL_renegotiate(clientssl)))
+        goto end;
+    if (!TEST_int_le(SSL_write(clientssl, &buf, sizeof(buf)), 0))
+        goto end;
+    if (!TEST_int_eq(SSL_get_error(clientssl, 0), SSL_ERROR_WANT_READ))
+        goto end;
+
+    /*
+     * Now call SSL_read(). We expect this to cause a fatal error. You are not
+     * allowed to call SSL_read() after SSL_write().
+     */
+    if (!TEST_int_le(SSL_read(serverssl, &buf, sizeof(buf)), 0))
+        goto end;
+    if (!TEST_int_eq(SSL_get_error(serverssl, 0), SSL_ERROR_SSL))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+
+    return testresult;
+}
+
 OPT_TEST_DECLARE_USAGE("certfile privkeyfile srpvfile tmpfile provider config dhfile\n")
 
 int setup_tests(void)
@@ -17176,7 +17460,14 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_http_verbs, 3);
 #if !defined(OSSL_NO_USABLE_TLS1_3)
     ADD_TEST(test_grease);
+    ADD_TEST(test_write_after_read_want_write);
+    ADD_TEST(test_write_after_read_want_read);
 #endif
+#ifndef OPENSSL_NO_TLS1_2
+    ADD_TEST(test_read_after_write_want_read);
+    ADD_TEST(test_read_after_write_want_write);
+#endif
+
     return 1;
 
 err:

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -16800,6 +16800,7 @@ end:
     return testresult;
 }
 
+#if !defined(OSSL_NO_USABLE_TLS1_3)
 /*
  * Test calling SSL_write() after SSL_read() has signalled SSL_ERROR_WANT_WRITE
  * This scenario is allowed.
@@ -16955,6 +16956,119 @@ end:
 }
 
 /*
+ * Demonstrate that a server requesting post-handshake authentication while the
+ * client has an application-data write pending retry breaks the client if the
+ * client switches to reading at that point.
+ *
+ * The client streams application data until, over a finite BIO pair with the
+ * server not reading, its SSL_write() stalls with SSL_ERROR_WANT_WRITE and a
+ * write is left pending.  The server then requests post-handshake
+ * authentication; the CertificateRequest reaches the client.  When the client
+ * next reads, it processes the request and tries to send its Certificate
+ * flight through ssl3_write_bytes() while the application write is still
+ * pending.  The pending-write length guard fires and the connection dies with
+ * SSL_R_BAD_LENGTH.
+ *
+ * Though reading while a write is pending is sometimes desirable (e.g.
+ * draining the peer to avoid a write-write deadlock), it is not always safe, a
+ * post-handshake request during that read makes the client emit a write that
+ * collides with the pending one.  The "do not interleave SSL_read() with a
+ * pending SSL_write()" caution is still relevant in TLS 1.3, since, though
+ * renegotiation is gone, post-handshake auth / key update can also solicit
+ * handshake writes.  The client need not even hold a certificate: an empty
+ * Certificate response collides just the same.
+ */
+static int test_pha_pending_write(void)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    BIO *sbio = NULL, *cbio = NULL;
+    static unsigned char data[16384];
+    unsigned char buf[16384];
+    int ret, iter;
+    int testresult = 0;
+
+    memset(data, 0xA5, sizeof(data));
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(), TLS1_VERSION, 0,
+            &sctx, &cctx, cert, privkey)))
+        return 0;
+
+    if (!TEST_true(SSL_CTX_set_min_proto_version(sctx, TLS1_3_VERSION))
+        || !TEST_true(SSL_CTX_set_max_proto_version(sctx, TLS1_3_VERSION))
+        || !TEST_true(SSL_CTX_set_min_proto_version(cctx, TLS1_3_VERSION))
+        || !TEST_true(SSL_CTX_set_max_proto_version(cctx, TLS1_3_VERSION)))
+        goto end;
+
+    SSL_CTX_set_post_handshake_auth(cctx, 1);
+
+    if (!TEST_ptr(serverssl = SSL_new(sctx))
+        || !TEST_ptr(clientssl = SSL_new(cctx))
+        || !TEST_true(BIO_new_bio_pair(&sbio, 65536, &cbio, 65536)))
+        goto end;
+
+    SSL_set_bio(serverssl, sbio, sbio);
+    SSL_set_bio(clientssl, cbio, cbio);
+    sbio = cbio = NULL;
+    SSL_set_accept_state(serverssl);
+    SSL_set_connect_state(clientssl);
+
+    if (!TEST_true(create_bare_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE, 0, 0)))
+        goto end;
+
+    /*
+     * The client streams application data until it blocks: the server is not
+     * reading, so the client->server direction fills and SSL_write() stalls,
+     * leaving a write pending.
+     */
+    for (iter = ret = 0; iter < 100; iter++) {
+        if ((ret = SSL_write(clientssl, data, sizeof(data))) > 0)
+            continue;
+        break;
+    }
+    if (!TEST_int_lt(iter, 100)
+        || !TEST_int_eq(SSL_get_error(clientssl, ret), SSL_ERROR_WANT_WRITE))
+        goto end;
+
+    /*
+     * The server requests post-handshake authentication.  The server->client
+     * direction is drained, so the CertificateRequest goes out; the request
+     * is asynchronous, so SSL_do_handshake() returns success without waiting.
+     */
+    SSL_set_verify(serverssl, SSL_VERIFY_PEER, NULL);
+    if (!TEST_true(SSL_verify_client_post_handshake(serverssl))
+        || !TEST_int_eq(SSL_do_handshake(serverssl), 1))
+        goto end;
+
+    /*
+     * The client, blocked on its write, reads.  It consumes the
+     * CertificateRequest and tries to send its Certificate flight while the
+     * application write is still pending: ssl3_write_bytes() rejects it with
+     * SSL_R_BAD_LENGTH and the connection is torn down.
+     */
+    ERR_clear_error();
+    ret = SSL_read(clientssl, buf, sizeof(buf));
+    if (!TEST_int_le(ret, 0)
+        || !TEST_int_eq(SSL_get_error(clientssl, ret), SSL_ERROR_SSL)
+        || !TEST_int_eq(ERR_GET_REASON(ERR_peek_error()), SSL_R_BAD_LENGTH))
+        goto end;
+
+    testresult = 1;
+end:
+    BIO_free(sbio);
+    BIO_free(cbio);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+#endif
+
+#ifndef OPENSSL_NO_TLS1_2
+/*
  * Test calling SSL_read() after SSL_write() has signalled SSL_ERROR_WANT_READ
  * This scenario is allowed.
  */
@@ -17083,6 +17197,7 @@ end:
 
     return testresult;
 }
+#endif
 
 OPT_TEST_DECLARE_USAGE("certfile privkeyfile srpvfile tmpfile provider config dhfile\n")
 
@@ -17462,6 +17577,7 @@ int setup_tests(void)
     ADD_TEST(test_grease);
     ADD_TEST(test_write_after_read_want_write);
     ADD_TEST(test_write_after_read_want_read);
+    ADD_TEST(test_pha_pending_write);
 #endif
 #ifndef OPENSSL_NO_TLS1_2
     ADD_TEST(test_read_after_write_want_read);


### PR DESCRIPTION
Inspired by https://github.com/openssl/openssl/discussions/30934 I tried to clarify the documentation about what is supposed to happen when interleaving SSL_read() and SSL_write() calls.

I also added some tests for the various scenarios.