### PR TITLE
Allow 0 length comparisons in OBJ_CMP to return 0 without UB memcmp.

### DIFF
--- a/crypto/objects/obj_lib.c
+++ b/crypto/objects/obj_lib.c
@@ -59,5 +59,7 @@ int OBJ_cmp(const ASN1_OBJECT *a, const ASN1_OBJECT *b)
     ret = (a->length - b->length);
     if (ret)
         return ret;
+    if (a->length == 0)
+        return 0;
     return memcmp(a->data, b->data, a->length);
 }

--- a/test/x509_test.c
+++ b/test/x509_test.c
@@ -103,6 +103,21 @@ static int test_x509_tbs_cache(void)
     return ret;
 }
 
+static int test_x509_verify_with_new(void)
+{
+    int ret;
+    EVP_PKEY *pkey = NULL;
+    X509 *x = NULL;
+
+    ret = TEST_ptr(x = X509_new())
+        && TEST_ptr(pkey = EVP_PKEY_new())
+        && TEST_int_eq(X509_verify(x, pkey), -1)
+        && TEST_int_eq(X509_verify(x, pubkey), -1);
+    X509_free(x);
+    EVP_PKEY_free(pkey);
+    return ret;
+}
+
 /*
  * Test for Regression discussed in PR #19388
  * In order for this simple test to fail, it requires the digest used for
@@ -484,6 +499,7 @@ int setup_tests(void)
     ADD_TEST(test_x509_revoked_delete_last_extension);
     ADD_TEST(test_drop_empty_cert_keyids);
     ADD_TEST(test_drop_empty_csr_keyids);
+    ADD_TEST(test_x509_verify_with_new);
     return 1;
 }
 


### PR DESCRIPTION
X509_verify is documented to return -1 if the algorithm is invalid or can't be compared for any reason.

Sadly this implies that it is legitimate to pass it an incorrect X509 object and it should see this. If we hand it a new X509 object with nothing filled in, it will memcmp(NULL...) at the end of a stack of FOO_cmp abstractions, which is UB.

FIx this by checking for a 0 length comparison in OBJ_cmp, as suggested by slontis@ and botovq@ and boring and libre, etc.. 

Fixes: https://github.com/openssl/openssl/issues/30922

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
