### PR TITLE
Fix partial-chain revocation boundary and CRL issuer matching

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -79,6 +79,8 @@ static void get_delta_sk(X509_STORE_CTX *ctx, X509_CRL **dcrl,
     STACK_OF(X509_CRL) *crls);
 static void crl_akid_check(X509_STORE_CTX *ctx, X509_CRL *crl, X509 **pissuer,
     int *pcrl_score);
+static int matching_crl_issuer_and_akid(const X509_CRL *crl,
+    const X509 *issuer, const X509_NAME *crl_issuer_name);
 static int crl_crldp_check(X509 *x, X509_CRL *crl, int crl_score,
     unsigned int *preasons);
 static int check_crl_path(X509_STORE_CTX *ctx, X509 *x);
@@ -1766,7 +1768,7 @@ static void crl_akid_check(X509_STORE_CTX *ctx, X509_CRL *crl,
 
     crl_issuer = sk_X509_value(ctx->chain, cidx);
 
-    if (X509_check_akid(crl_issuer, crl->akid) == X509_V_OK) {
+    if (matching_crl_issuer_and_akid(crl, crl_issuer, cnm)) {
         if (*pcrl_score & CRL_SCORE_ISSUER_NAME) {
             *pcrl_score |= CRL_SCORE_AKID | CRL_SCORE_ISSUER_CERT;
             *pissuer = crl_issuer;
@@ -1776,9 +1778,7 @@ static void crl_akid_check(X509_STORE_CTX *ctx, X509_CRL *crl,
 
     for (cidx++; cidx < sk_X509_num(ctx->chain); cidx++) {
         crl_issuer = sk_X509_value(ctx->chain, cidx);
-        if (X509_NAME_cmp(X509_get_subject_name(crl_issuer), cnm))
-            continue;
-        if (X509_check_akid(crl_issuer, crl->akid) == X509_V_OK) {
+        if (matching_crl_issuer_and_akid(crl, crl_issuer, cnm)) {
             *pcrl_score |= CRL_SCORE_AKID | CRL_SCORE_SAME_PATH;
             *pissuer = crl_issuer;
             return;
@@ -1795,14 +1795,22 @@ static void crl_akid_check(X509_STORE_CTX *ctx, X509_CRL *crl,
      */
     for (i = 0; i < sk_X509_num(ctx->untrusted); i++) {
         crl_issuer = sk_X509_value(ctx->untrusted, i);
-        if (X509_NAME_cmp(X509_get_subject_name(crl_issuer), cnm) != 0)
-            continue;
-        if (X509_check_akid(crl_issuer, crl->akid) == X509_V_OK) {
+        if (matching_crl_issuer_and_akid(crl, crl_issuer, cnm)) {
             *pissuer = crl_issuer;
             *pcrl_score |= CRL_SCORE_AKID;
             return;
         }
     }
+}
+
+static int matching_crl_issuer_and_akid(const X509_CRL *crl,
+    const X509 *issuer, const X509_NAME *crl_issuer_name)
+{
+    if (issuer == NULL)
+        return 0;
+    if (X509_NAME_cmp(X509_get_subject_name(issuer), crl_issuer_name) != 0)
+        return 0;
+    return X509_check_akid(issuer, crl->akid) == X509_V_OK;
 }
 
 /*

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -58,6 +58,7 @@ static int check_name_constraints(X509_STORE_CTX *ctx);
 static int check_id(X509_STORE_CTX *ctx);
 static int check_trust(X509_STORE_CTX *ctx, int num_untrusted);
 static int check_revocation(X509_STORE_CTX *ctx);
+static int revocation_check_end(X509_STORE_CTX *ctx, int check_all);
 #ifndef OPENSSL_NO_OCSP
 static int check_cert_ocsp_resp(X509_STORE_CTX *ctx);
 #endif
@@ -1173,6 +1174,20 @@ trusted:
     return X509_TRUST_UNTRUSTED;
 }
 
+/*
+ * Return the last chain depth whose revocation status should be checked.
+ * With X509_V_FLAG_*_CHECK_ALL and X509_V_FLAG_PARTIAL_CHAIN, revocation
+ * checking stops before the first trusted certificate in the chain.
+ */
+static int revocation_check_end(X509_STORE_CTX *ctx, int check_all)
+{
+    if (!check_all)
+        return 0;
+    return (ctx->param->flags & X509_V_FLAG_PARTIAL_CHAIN) == 0
+        ? sk_X509_num(ctx->chain) - 1
+        : ctx->num_untrusted - 1;
+}
+
 /* Sadly, returns 0 also on internal error. */
 static int check_revocation(X509_STORE_CTX *ctx)
 {
@@ -1190,10 +1205,10 @@ static int check_revocation(X509_STORE_CTX *ctx)
         /*
          * certificate status checking with OCSP
          */
-        if (ocsp_check_all_enabled)
-            last = sk_X509_num(ctx->chain) - 1;
-        else if (!crl_check_all_enabled && ctx->parent != NULL)
+        if (!ocsp_check_all_enabled && !crl_check_all_enabled
+            && ctx->parent != NULL)
             return 1; /* If checking CRL paths this isn't the EE certificate */
+        last = revocation_check_end(ctx, ocsp_check_all_enabled);
 
         for (i = 0; i <= last; i++) {
             ctx->error_depth = i;
@@ -1256,14 +1271,9 @@ static int check_revocation(X509_STORE_CTX *ctx)
 
     if (crl_check_enabled && !ocsp_check_all_enabled) {
         /* certificate status check with CRLs */
-        if (crl_check_all_enabled) {
-            last = sk_X509_num(ctx->chain) - 1;
-        } else {
-            /* If checking CRL paths this isn't the EE certificate */
-            if (ctx->parent != NULL)
-                return 1;
-            last = 0;
-        }
+        if (!crl_check_all_enabled && ctx->parent != NULL)
+            return 1; /* If checking CRL paths this isn't the EE certificate */
+        last = revocation_check_end(ctx, crl_check_all_enabled);
 
         /*
          * in the case that OCSP is only enabled for the server certificate

--- a/test/recipes/25-test_verify.t
+++ b/test/recipes/25-test_verify.t
@@ -30,7 +30,47 @@ sub verify {
     run(app([@args]));
 }
 
-plan tests => 221;
+sub make_empty_crl {
+    my ($prefix, $ca_cert, $ca_key, $crl) = @_;
+    my $index = "$prefix-index.txt";
+    my $serial = "$prefix-serial.txt";
+    my $cnf = "$prefix.cnf";
+    my $ca_cert_file = "$prefix-ca-cert.pem";
+    my $ca_key_file = "$prefix-ca-key.pem";
+
+    open my $index_fh, ">", $index or return 0;
+    close $index_fh;
+    open my $serial_fh, ">", $serial or return 0;
+    print $serial_fh "01\n";
+    close $serial_fh;
+    copy($ca_cert, $ca_cert_file) or return 0;
+    copy($ca_key, $ca_key_file) or return 0;
+    open my $cnf_fh, ">", $cnf or return 0;
+    print $cnf_fh <<"EOF";
+[ ca ]
+default_ca = test_ca
+
+[ test_ca ]
+database = $index
+serial = $serial
+new_certs_dir = .
+certificate = $ca_cert_file
+private_key = $ca_key_file
+default_md = sha256
+default_days = 365
+default_crl_days = 365
+policy = policy_any
+
+[ policy_any ]
+commonName = optional
+EOF
+    close $cnf_fh;
+
+    run(app(["openssl", "ca", "-batch", "-config", $cnf, "-gencrl",
+             "-out", $crl]));
+}
+
+plan tests => 222;
 
 # Canonical success
 ok(verify("ee-cert", "sslserver", ["root-cert"], ["ca-cert"]),
@@ -146,6 +186,13 @@ ok(!verify("ee-cert", "sslserver", [], [qw(ca-cert)], "-partial_chain"),
    "fail untrusted partial chain");
 ok(verify("ee-cert", "sslserver", [qw(ca-cert)], [], "-partial_chain"),
    "accept trusted partial chain");
+ok(make_empty_crl("partial-chain-ca", srctop_file(@certspath, "ca-cert.pem"),
+                  srctop_file(@certspath, "ca-key.pem"),
+                  "partial-chain-ca.crl")
+   && verify("ee-cert", "sslserver", [qw(ca-cert)], [],
+             "-partial_chain", "-crl_check_all", "-CRLfile",
+             "partial-chain-ca.crl"),
+   "accept trusted partial chain with CRL_CHECK_ALL");
 ok(!verify("ee-cert", "sslserver", [qw(ca-expired)], [], "-partial_chain"),
    "reject expired trusted partial chain"); # this check is beyond RFC 5280
 ok(!verify("ee-cert", "sslserver", [qw(root-expired)], [qw(ca-cert)]),


### PR DESCRIPTION
Fixes #30932.

When `X509_V_FLAG_PARTIAL_CHAIN` accepts a non-self-signed certificate as the trust anchor, revocation checking should stop before that certificate. The trusted object is the trust anchor for the constructed path, so `CRL_CHECK_ALL` shouldn't try to verify a CRL for that anchor using an issuer outside the partial chain.

This updates revocation checking so that, with partial chains:

- `CRL_CHECK_ALL` stops at `ctx->num_untrusted - 1`
- `OCSP_RESP_CHECK_ALL` uses the same boundary
- direct checking still covers non-anchor end-entity certificates

This replaces the earlier store-lookup approach. After the discussion in #30932, the fix is to avoid checking the partial-chain trust anchor rather than searching for the issuer of that anchor's CRL.

A second ~cleanup~ fix tightens CRL issuer selection by requiring a candidate CRL issuer certificate subject to match the CRL issuer name before accepting an AKID match. This prevents selecting the truncated chain anchor solely because the CRL has no AKID.

Tests added:

- `test/recipes/25-test_verify.t`: a CLI-level regression test ("accept trusted partial chain with CRL_CHECK_ALL"). It builds an empty CRL issued by `ca-cert` (via `openssl ca -gencrl`) and verifies `ee-cert` with `ca-cert` accepted as the trust anchor through `-partial_chain -crl_check_all`.

Note: `OCSP_RESP_CHECK_ALL` shares the exact same boundary helper (`revocation_check_end`), so it is covered at the logic level by the same change. A dedicated CLI-level OCSP test is impractical with the current `openssl verify` OCSP support: tracked separately in #31337.

