### PR TITLE
test: use ASN1_STRING accessors; heap-allocate opaque ASN1 objects

### DIFF
--- a/test/asn1_time_test.c
+++ b/test/asn1_time_test.c
@@ -657,58 +657,59 @@ static struct testdata tbl_testdata_neg_64bit[] = {
 };
 
 /* A baseline time to compare to */
-static ASN1_TIME gtime = {
-    15,
-    V_ASN1_GENERALIZEDTIME,
-    (unsigned char *)"19991231000000Z",
-    0
-};
+static ASN1_TIME *gtime = NULL;
 static time_t gtime_t = 946598400;
 
 static int test_table(struct testdata *tbl, int idx)
 {
     int error = 0;
-    ASN1_TIME atime;
+    ASN1_TIME *atime = NULL;
     ASN1_TIME *ptime;
     struct testdata *td = &tbl[idx];
     int day, sec;
 
-    atime.data = (unsigned char *)td->data;
-    atime.length = (int)strlen((char *)atime.data);
-    atime.type = td->type;
-    atime.flags = 0;
+    if (!TEST_ptr(atime = ASN1_STRING_type_new(td->type))
+        || !TEST_true(ASN1_STRING_set(atime, td->data,
+            (int)strlen(td->data)))) {
+        ASN1_TIME_free(atime);
+        return 0;
+    }
 
-    if (!TEST_int_eq(ASN1_TIME_check(&atime), td->check_result)) {
-        TEST_info("ASN1_TIME_check(%s) unexpected result", atime.data);
+    if (!TEST_int_eq(ASN1_TIME_check(atime), td->check_result)) {
+        TEST_info("ASN1_TIME_check(%s) unexpected result", td->data);
         error = 1;
     }
-    if (td->check_result == 0)
+    if (td->check_result == 0) {
+        ASN1_TIME_free(atime);
         return 1;
+    }
 
-    if (!TEST_int_eq(ASN1_TIME_cmp_time_t(&atime, td->t), 0)) {
-        TEST_info("ASN1_TIME_cmp_time_t(%s vs %ld) compare failed", atime.data, (long)td->t);
+    if (!TEST_int_eq(ASN1_TIME_cmp_time_t(atime, td->t), 0)) {
+        TEST_info("ASN1_TIME_cmp_time_t(%s vs %ld) compare failed",
+            td->data, (long)td->t);
         error = 1;
     }
 
-    if (!TEST_true(ASN1_TIME_diff(&day, &sec, &atime, &atime))) {
-        TEST_info("ASN1_TIME_diff(%s) to self failed", atime.data);
+    if (!TEST_true(ASN1_TIME_diff(&day, &sec, atime, atime))) {
+        TEST_info("ASN1_TIME_diff(%s) to self failed", td->data);
         error = 1;
     }
     if (!TEST_int_eq(day, 0) || !TEST_int_eq(sec, 0)) {
-        TEST_info("ASN1_TIME_diff(%s) to self not equal", atime.data);
+        TEST_info("ASN1_TIME_diff(%s) to self not equal", td->data);
         error = 1;
     }
 
-    if (!TEST_true(ASN1_TIME_diff(&day, &sec, &gtime, &atime))) {
-        TEST_info("ASN1_TIME_diff(%s) to baseline failed", atime.data);
+    if (!TEST_true(ASN1_TIME_diff(&day, &sec, gtime, atime))) {
+        TEST_info("ASN1_TIME_diff(%s) to baseline failed", td->data);
         error = 1;
     } else if (!((td->cmp_result == 0 && TEST_true((day == 0 && sec == 0))) || (td->cmp_result == -1 && TEST_true((day < 0 || sec < 0))) || (td->cmp_result == 1 && TEST_true((day > 0 || sec > 0))))) {
-        TEST_info("ASN1_TIME_diff(%s) to baseline bad comparison", atime.data);
+        TEST_info("ASN1_TIME_diff(%s) to baseline bad comparison", td->data);
         error = 1;
     }
 
-    if (!TEST_int_eq(ASN1_TIME_cmp_time_t(&atime, gtime_t), td->cmp_result)) {
-        TEST_info("ASN1_TIME_cmp_time_t(%s) to baseline bad comparison", atime.data);
+    if (!TEST_int_eq(ASN1_TIME_cmp_time_t(atime, gtime_t), td->cmp_result)) {
+        TEST_info("ASN1_TIME_cmp_time_t(%s) to baseline bad comparison",
+            td->data);
         error = 1;
     }
 
@@ -720,15 +721,16 @@ static int test_table(struct testdata *tbl, int idx)
         int local_error = 0;
         if (!TEST_int_eq(ASN1_TIME_cmp_time_t(ptime, td->t), 0)) {
             TEST_info("ASN1_TIME_set(%ld) compare failed (%s->%s)",
-                (long)td->t, td->data, ptime->data);
+                (long)td->t, td->data, ASN1_STRING_get0_data(ptime));
             local_error = error = 1;
         }
-        if (!TEST_int_eq(ptime->type, td->expected_type)) {
+        if (!TEST_int_eq(ASN1_STRING_type(ptime), td->expected_type)) {
             TEST_info("ASN1_TIME_set(%ld) unexpected type", (long)td->t);
             local_error = error = 1;
         }
         if (local_error)
-            TEST_info("ASN1_TIME_set() = %*s", ptime->length, ptime->data);
+            TEST_info("ASN1_TIME_set() = %*s", ASN1_STRING_length(ptime),
+                ASN1_STRING_get0_data(ptime));
         ASN1_TIME_free(ptime);
     }
 
@@ -746,12 +748,12 @@ static int test_table(struct testdata *tbl, int idx)
             TEST_info("ASN1_TIME_normalize(%s) failed", td->data);
             local_error = error = 1;
         }
-        if (!TEST_int_eq(ptime->type, td->expected_type)) {
+        if (!TEST_int_eq(ASN1_STRING_type(ptime), td->expected_type)) {
             TEST_info("ASN1_TIME_set_string_gmt(%s) unexpected type", td->data);
             local_error = error = 1;
         }
         day = sec = 0;
-        if (!TEST_true(ASN1_TIME_diff(&day, &sec, ptime, &atime)) || !TEST_int_eq(day, 0) || !TEST_int_eq(sec, 0)) {
+        if (!TEST_true(ASN1_TIME_diff(&day, &sec, ptime, atime)) || !TEST_int_eq(day, 0) || !TEST_int_eq(sec, 0)) {
             TEST_info("ASN1_TIME_diff(day=%d, sec=%d, %s) after ASN1_TIME_set_string_gmt() failed", day, sec, td->data);
             local_error = error = 1;
         }
@@ -760,7 +762,9 @@ static int test_table(struct testdata *tbl, int idx)
             local_error = error = 1;
         }
         if (local_error)
-            TEST_info("ASN1_TIME_set_string_gmt() = %*s", ptime->length, ptime->data);
+            TEST_info("ASN1_TIME_set_string_gmt() = %*s",
+                ASN1_STRING_length(ptime),
+                ASN1_STRING_get0_data(ptime));
         ASN1_TIME_free(ptime);
     }
 
@@ -775,7 +779,7 @@ static int test_table(struct testdata *tbl, int idx)
             local_error = error = 1;
         }
         day = sec = 0;
-        if (!TEST_true(ASN1_TIME_diff(&day, &sec, ptime, &atime)) || !TEST_int_eq(day, 0) || !TEST_int_eq(sec, 0)) {
+        if (!TEST_true(ASN1_TIME_diff(&day, &sec, ptime, atime)) || !TEST_int_eq(day, 0) || !TEST_int_eq(sec, 0)) {
             TEST_info("ASN1_TIME_diff(day=%d, sec=%d, %s) after ASN1_TIME_set_string() failed", day, sec, td->data);
             local_error = error = 1;
         }
@@ -784,21 +788,25 @@ static int test_table(struct testdata *tbl, int idx)
             local_error = error = 1;
         }
         if (local_error)
-            TEST_info("ASN1_TIME_set_string() = %*s", ptime->length, ptime->data);
+            TEST_info("ASN1_TIME_set_string() = %*s",
+                ASN1_STRING_length(ptime),
+                ASN1_STRING_get0_data(ptime));
         ASN1_TIME_free(ptime);
     }
 
     if (td->type == V_ASN1_UTCTIME) {
-        ptime = ASN1_TIME_to_generalizedtime(&atime, NULL);
+        ptime = ASN1_TIME_to_generalizedtime(atime, NULL);
         if (td->convert_result == 1 && !TEST_ptr(ptime)) {
-            TEST_info("ASN1_TIME_to_generalizedtime(%s) failed", atime.data);
+            TEST_info("ASN1_TIME_to_generalizedtime(%s) failed", td->data);
             error = 1;
         } else if (td->convert_result == 0 && !TEST_ptr_null(ptime)) {
-            TEST_info("ASN1_TIME_to_generalizedtime(%s) should have failed", atime.data);
+            TEST_info("ASN1_TIME_to_generalizedtime(%s) should have failed",
+                td->data);
             error = 1;
         }
         if (ptime != NULL && !TEST_int_eq(ASN1_TIME_cmp_time_t(ptime, td->t), 0)) {
-            TEST_info("ASN1_TIME_to_generalizedtime(%s->%s) bad result", atime.data, ptime->data);
+            TEST_info("ASN1_TIME_to_generalizedtime(%s->%s) bad result",
+                td->data, ASN1_STRING_get0_data(ptime));
             error = 1;
         }
         ASN1_TIME_free(ptime);
@@ -806,8 +814,9 @@ static int test_table(struct testdata *tbl, int idx)
     /* else cannot simply convert GENERALIZEDTIME to UTCTIME */
 
     if (error)
-        TEST_error("atime=%s", atime.data);
+        TEST_error("atime=%s", td->data);
 
+    ASN1_TIME_free(atime);
     return !error;
 }
 
@@ -831,49 +840,109 @@ static int test_table_neg_64bit(int idx)
     return test_table(tbl_testdata_neg_64bit, idx);
 }
 
-struct compare_testdata {
-    ASN1_TIME t1;
-    ASN1_TIME t2;
-    int result;
-};
+static const char TODAY_GEN_STR[] = "20170825000000Z";
+static const char TOMORROW_GEN_STR[] = "20170826000000Z";
+static const char TODAY_UTC_STR[] = "170825000000Z";
+static const char TOMORROW_UTC_STR[] = "170826000000Z";
 
-static unsigned char TODAY_GEN_STR[] = "20170825000000Z";
-static unsigned char TOMORROW_GEN_STR[] = "20170826000000Z";
-static unsigned char TODAY_UTC_STR[] = "170825000000Z";
-static unsigned char TOMORROW_UTC_STR[] = "170826000000Z";
-
-#define TODAY_GEN { sizeof(TODAY_GEN_STR) - 1, V_ASN1_GENERALIZEDTIME, TODAY_GEN_STR, 0 }
-#define TOMORROW_GEN { sizeof(TOMORROW_GEN_STR) - 1, V_ASN1_GENERALIZEDTIME, TOMORROW_GEN_STR, 0 }
-#define TODAY_UTC { sizeof(TODAY_UTC_STR) - 1, V_ASN1_UTCTIME, TODAY_UTC_STR, 0 }
-#define TOMORROW_UTC { sizeof(TOMORROW_UTC_STR) - 1, V_ASN1_UTCTIME, TOMORROW_UTC_STR, 0 }
-
-static struct compare_testdata tbl_compare_testdata[] = {
-    { TODAY_GEN, TODAY_GEN, 0 },
-    { TODAY_GEN, TODAY_UTC, 0 },
-    { TODAY_GEN, TOMORROW_GEN, -1 },
-    { TODAY_GEN, TOMORROW_UTC, -1 },
-
-    { TODAY_UTC, TODAY_GEN, 0 },
-    { TODAY_UTC, TODAY_UTC, 0 },
-    { TODAY_UTC, TOMORROW_GEN, -1 },
-    { TODAY_UTC, TOMORROW_UTC, -1 },
-
-    { TOMORROW_GEN, TODAY_GEN, 1 },
-    { TOMORROW_GEN, TODAY_UTC, 1 },
-    { TOMORROW_GEN, TOMORROW_GEN, 0 },
-    { TOMORROW_GEN, TOMORROW_UTC, 0 },
-
-    { TOMORROW_UTC, TODAY_GEN, 1 },
-    { TOMORROW_UTC, TODAY_UTC, 1 },
-    { TOMORROW_UTC, TOMORROW_GEN, 0 },
-    { TOMORROW_UTC, TOMORROW_UTC, 0 }
-};
-
-static int test_table_compare(int idx)
+static ASN1_TIME *make_asn1_time(const char *s, int type)
 {
-    struct compare_testdata *td = &tbl_compare_testdata[idx];
+    ASN1_TIME *t = ASN1_STRING_type_new(type);
 
-    return TEST_int_eq(ASN1_TIME_compare(&td->t1, &td->t2), td->result);
+    if (t == NULL)
+        return NULL;
+    if (!ASN1_STRING_set(t, s, (int)strlen(s))) {
+        ASN1_TIME_free(t);
+        return NULL;
+    }
+    return t;
+}
+
+/*
+ * Unit test for ASN1_TIME_compare.
+ *
+ * Per the man page, ASN1_TIME_compare(a, b) returns:
+ *   -1 if a < b, 0 if a == b, 1 if a > b, and -2 on error.
+ *
+ * Covers:
+ *   - pairwise equality / ordering of today/tomorrow strings represented
+ *     as both GENERALIZEDTIME and UTCTIME (they must compare as equal
+ *     across representations),
+ *   - the -2 error return for malformed ASN1_TIME inputs,
+ *   - limit/unusual values using the min and max POSIX times.
+ */
+static int test_asn1_time_compare(void)
+{
+    static const struct {
+        const char *s;
+        int type;
+    } vals[] = {
+        { TODAY_GEN_STR, V_ASN1_GENERALIZEDTIME },
+        { TODAY_UTC_STR, V_ASN1_UTCTIME },
+        { TOMORROW_GEN_STR, V_ASN1_GENERALIZEDTIME },
+        { TOMORROW_UTC_STR, V_ASN1_UTCTIME }
+    };
+    /*
+     * Expected result for ASN1_TIME_compare(times[i], times[j]).
+     * Indices 0,1 are "today" (GEN and UTC), 2,3 are "tomorrow".
+     */
+    static const int expected[4][4] = {
+        { 0, 0, -1, -1 },
+        { 0, 0, -1, -1 },
+        { 1, 1, 0, 0 },
+        { 1, 1, 0, 0 }
+    };
+    ASN1_TIME *times[4] = { NULL, NULL, NULL, NULL };
+    ASN1_TIME *bad = NULL;
+    ASN1_TIME *min = NULL, *max = NULL;
+    size_t i, j;
+    int ret = 0;
+
+    for (i = 0; i < OSSL_NELEM(times); i++) {
+        if (!TEST_ptr(times[i] = make_asn1_time(vals[i].s, vals[i].type)))
+            goto err;
+    }
+
+    for (i = 0; i < OSSL_NELEM(times); i++) {
+        for (j = 0; j < OSSL_NELEM(times); j++) {
+            if (!TEST_int_eq(ASN1_TIME_compare(times[i], times[j]),
+                    expected[i][j])) {
+                TEST_info("ASN1_TIME_compare(%s, %s) unexpected",
+                    vals[i].s, vals[j].s);
+                goto err;
+            }
+        }
+    }
+
+    /* Error return: malformed ASN1_TIME should produce -2. */
+    if (!TEST_ptr(bad = ASN1_STRING_type_new(V_ASN1_UTCTIME))
+        || !TEST_true(ASN1_STRING_set(bad, "not-a-time", 10)))
+        goto err;
+    if (!TEST_int_eq(ASN1_TIME_compare(bad, times[0]), -2)
+        || !TEST_int_eq(ASN1_TIME_compare(times[0], bad), -2))
+        goto err;
+
+    /* Limit values: min POSIX time < today < max POSIX time. */
+    if (!TEST_ptr(min = make_asn1_time("00000101000000Z",
+                      V_ASN1_GENERALIZEDTIME))
+        || !TEST_ptr(max = make_asn1_time("99991231235959Z",
+                         V_ASN1_GENERALIZEDTIME)))
+        goto err;
+    if (!TEST_int_eq(ASN1_TIME_compare(min, max), -1)
+        || !TEST_int_eq(ASN1_TIME_compare(max, min), 1)
+        || !TEST_int_eq(ASN1_TIME_compare(min, min), 0)
+        || !TEST_int_eq(ASN1_TIME_compare(min, times[0]), -1)
+        || !TEST_int_eq(ASN1_TIME_compare(max, times[0]), 1))
+        goto err;
+
+    ret = 1;
+err:
+    for (i = 0; i < OSSL_NELEM(times); i++)
+        ASN1_TIME_free(times[i]);
+    ASN1_TIME_free(bad);
+    ASN1_TIME_free(min);
+    ASN1_TIME_free(max);
+    return ret;
 }
 
 static int test_time_dup(void)
@@ -1536,6 +1605,10 @@ int setup_tests(void)
      */
     time_t t = -1;
 
+    if (!TEST_ptr(gtime = ASN1_STRING_type_new(V_ASN1_GENERALIZEDTIME))
+        || !TEST_true(ASN1_STRING_set(gtime, "19991231000000Z", 15)))
+        return 0;
+
     ADD_ALL_TESTS(test_table_pos, OSSL_NELEM(tbl_testdata_pos));
     if (!(t > 0)) {
         TEST_info("Adding negative-sign time_t tests");
@@ -1549,11 +1622,16 @@ int setup_tests(void)
             ADD_ALL_TESTS(test_table_neg_64bit, OSSL_NELEM(tbl_testdata_neg_64bit));
         }
     }
-    ADD_ALL_TESTS(test_table_compare, OSSL_NELEM(tbl_compare_testdata));
+    ADD_TEST(test_asn1_time_compare);
     ADD_TEST(test_time_dup);
     ADD_ALL_TESTS(convert_asn1_to_time_t, OSSL_NELEM(asn1_to_utc));
     ADD_TEST(convert_tm_to_asn1_time);
     ADD_TEST(test_gmtime_diff_limits);
     ADD_TEST(test_gmtime_range);
     return 1;
+}
+
+void cleanup_tests(void)
+{
+    ASN1_TIME_free(gtime);
 }

--- a/test/asn1_time_test.c
+++ b/test/asn1_time_test.c
@@ -868,61 +868,66 @@ static ASN1_TIME *make_asn1_time(const char *s, int type)
  *   - pairwise equality / ordering of today/tomorrow strings represented
  *     as both GENERALIZEDTIME and UTCTIME (they must compare as equal
  *     across representations),
- *   - the -2 error return for malformed ASN1_TIME inputs,
- *   - limit/unusual values using the min and max POSIX times.
+ *   - the -2 error return for a type-mismatched ASN1_TIME input,
+ *   - limit values using the minimum and maximum representable
+ *     GENERALIZED time.
  */
 static int test_asn1_time_compare(void)
 {
-    static const struct {
-        const char *s;
-        int type;
-    } vals[] = {
-        { TODAY_GEN_STR, V_ASN1_GENERALIZEDTIME },
-        { TODAY_UTC_STR, V_ASN1_UTCTIME },
-        { TOMORROW_GEN_STR, V_ASN1_GENERALIZEDTIME },
-        { TOMORROW_UTC_STR, V_ASN1_UTCTIME }
-    };
-    /*
-     * Expected result for ASN1_TIME_compare(times[i], times[j]).
-     * Indices 0,1 are "today" (GEN and UTC), 2,3 are "tomorrow".
-     */
-    static const int expected[4][4] = {
-        { 0, 0, -1, -1 },
-        { 0, 0, -1, -1 },
-        { 1, 1, 0, 0 },
-        { 1, 1, 0, 0 }
-    };
-    ASN1_TIME *times[4] = { NULL, NULL, NULL, NULL };
+    ASN1_TIME *today_gen = NULL, *today_utc = NULL;
+    ASN1_TIME *tomorrow_gen = NULL, *tomorrow_utc = NULL;
     ASN1_TIME *bad = NULL;
     ASN1_TIME *min = NULL, *max = NULL;
-    size_t i, j;
     int ret = 0;
 
-    for (i = 0; i < OSSL_NELEM(times); i++) {
-        if (!TEST_ptr(times[i] = make_asn1_time(vals[i].s, vals[i].type)))
-            goto err;
-    }
+    if (!TEST_ptr(today_gen = make_asn1_time(TODAY_GEN_STR, V_ASN1_GENERALIZEDTIME))
+        || !TEST_ptr(today_utc = make_asn1_time(TODAY_UTC_STR, V_ASN1_UTCTIME))
+        || !TEST_ptr(tomorrow_gen = make_asn1_time(TOMORROW_GEN_STR,
+                         V_ASN1_GENERALIZEDTIME))
+        || !TEST_ptr(tomorrow_utc = make_asn1_time(TOMORROW_UTC_STR,
+                         V_ASN1_UTCTIME)))
+        goto err;
 
-    for (i = 0; i < OSSL_NELEM(times); i++) {
-        for (j = 0; j < OSSL_NELEM(times); j++) {
-            if (!TEST_int_eq(ASN1_TIME_compare(times[i], times[j]),
-                    expected[i][j])) {
-                TEST_info("ASN1_TIME_compare(%s, %s) unexpected",
-                    vals[i].s, vals[j].s);
-                goto err;
-            }
-        }
-    }
+    /* today == today across both representations */
+    if (!TEST_int_eq(ASN1_TIME_compare(today_gen, today_gen), 0)
+        || !TEST_int_eq(ASN1_TIME_compare(today_gen, today_utc), 0)
+        || !TEST_int_eq(ASN1_TIME_compare(today_utc, today_gen), 0)
+        || !TEST_int_eq(ASN1_TIME_compare(today_utc, today_utc), 0))
+        goto err;
 
-    /* Error return: malformed ASN1_TIME should produce -2. */
+    /* tomorrow == tomorrow across both representations */
+    if (!TEST_int_eq(ASN1_TIME_compare(tomorrow_gen, tomorrow_gen), 0)
+        || !TEST_int_eq(ASN1_TIME_compare(tomorrow_gen, tomorrow_utc), 0)
+        || !TEST_int_eq(ASN1_TIME_compare(tomorrow_utc, tomorrow_gen), 0)
+        || !TEST_int_eq(ASN1_TIME_compare(tomorrow_utc, tomorrow_utc), 0))
+        goto err;
+
+    /* today < tomorrow across both representations */
+    if (!TEST_int_eq(ASN1_TIME_compare(today_gen, tomorrow_gen), -1)
+        || !TEST_int_eq(ASN1_TIME_compare(today_gen, tomorrow_utc), -1)
+        || !TEST_int_eq(ASN1_TIME_compare(today_utc, tomorrow_gen), -1)
+        || !TEST_int_eq(ASN1_TIME_compare(today_utc, tomorrow_utc), -1))
+        goto err;
+
+    /* tomorrow > today across both representations */
+    if (!TEST_int_eq(ASN1_TIME_compare(tomorrow_gen, today_gen), 1)
+        || !TEST_int_eq(ASN1_TIME_compare(tomorrow_gen, today_utc), 1)
+        || !TEST_int_eq(ASN1_TIME_compare(tomorrow_utc, today_gen), 1)
+        || !TEST_int_eq(ASN1_TIME_compare(tomorrow_utc, today_utc), 1))
+        goto err;
+
+    /*
+     * Error return: a generalized-time string (15 chars) in a UTCTIME
+     * container is a type mismatch that should produce -2.
+     */
     if (!TEST_ptr(bad = ASN1_STRING_type_new(V_ASN1_UTCTIME))
-        || !TEST_true(ASN1_STRING_set(bad, "not-a-time", 10)))
+        || !TEST_true(ASN1_STRING_set(bad, "20260423171736Z", 15)))
         goto err;
-    if (!TEST_int_eq(ASN1_TIME_compare(bad, times[0]), -2)
-        || !TEST_int_eq(ASN1_TIME_compare(times[0], bad), -2))
+    if (!TEST_int_eq(ASN1_TIME_compare(bad, today_gen), -2)
+        || !TEST_int_eq(ASN1_TIME_compare(today_gen, bad), -2))
         goto err;
 
-    /* Limit values: min POSIX time < today < max POSIX time. */
+    /* Limit values: min generalized time < today < max generalized time. */
     if (!TEST_ptr(min = make_asn1_time("00000101000000Z",
                       V_ASN1_GENERALIZEDTIME))
         || !TEST_ptr(max = make_asn1_time("99991231235959Z",
@@ -931,14 +936,16 @@ static int test_asn1_time_compare(void)
     if (!TEST_int_eq(ASN1_TIME_compare(min, max), -1)
         || !TEST_int_eq(ASN1_TIME_compare(max, min), 1)
         || !TEST_int_eq(ASN1_TIME_compare(min, min), 0)
-        || !TEST_int_eq(ASN1_TIME_compare(min, times[0]), -1)
-        || !TEST_int_eq(ASN1_TIME_compare(max, times[0]), 1))
+        || !TEST_int_eq(ASN1_TIME_compare(min, today_gen), -1)
+        || !TEST_int_eq(ASN1_TIME_compare(max, today_gen), 1))
         goto err;
 
     ret = 1;
 err:
-    for (i = 0; i < OSSL_NELEM(times); i++)
-        ASN1_TIME_free(times[i]);
+    ASN1_TIME_free(today_gen);
+    ASN1_TIME_free(today_utc);
+    ASN1_TIME_free(tomorrow_gen);
+    ASN1_TIME_free(tomorrow_utc);
     ASN1_TIME_free(bad);
     ASN1_TIME_free(min);
     ASN1_TIME_free(max);

--- a/test/cmp_ctx_test.c
+++ b/test/cmp_ctx_test.c
@@ -611,20 +611,20 @@ typedef OSSL_HTTP_bio_cb_t OSSL_CMP_http_cb_t;
         return OSSL_CMP_CTX_##GETN##_##FIELD(ctx, ARG);                   \
     }
 
-#define DEFINE_SET_GET1_STR_FN(SETN, FIELD)                                                \
-    static int OSSL_CMP_CTX_##SETN##_##FIELD##_str(CMP_CTX *ctx, char *val)                \
-    {                                                                                      \
-        return OSSL_CMP_CTX_##SETN##_##FIELD(ctx, (unsigned char *)val,                    \
-            (int)strlen(val));                                                             \
-    }                                                                                      \
-                                                                                           \
-    static char *OSSL_CMP_CTX_get1_##FIELD##_str(const CMP_CTX *ctx)                       \
-    {                                                                                      \
-        const ASN1_OCTET_STRING *bytes = NULL;                                             \
-                                                                                           \
-        RET_IF_NULL_ARG(ctx, NULL);                                                        \
-        bytes = ctx->FIELD;                                                                \
-        return bytes == NULL ? NULL : OPENSSL_strndup((char *)bytes->data, bytes->length); \
+#define DEFINE_SET_GET1_STR_FN(SETN, FIELD)                                                                                   \
+    static int OSSL_CMP_CTX_##SETN##_##FIELD##_str(CMP_CTX *ctx, char *val)                                                   \
+    {                                                                                                                         \
+        return OSSL_CMP_CTX_##SETN##_##FIELD(ctx, (unsigned char *)val,                                                       \
+            (int)strlen(val));                                                                                                \
+    }                                                                                                                         \
+                                                                                                                              \
+    static char *OSSL_CMP_CTX_get1_##FIELD##_str(const CMP_CTX *ctx)                                                          \
+    {                                                                                                                         \
+        const ASN1_OCTET_STRING *bytes = NULL;                                                                                \
+                                                                                                                              \
+        RET_IF_NULL_ARG(ctx, NULL);                                                                                           \
+        bytes = ctx->FIELD;                                                                                                   \
+        return bytes == NULL ? NULL : OPENSSL_strndup((const char *)ASN1_STRING_get0_data(bytes), ASN1_STRING_length(bytes)); \
     }
 
 #define push 0

--- a/test/cmp_status_test.c
+++ b/test/cmp_status_test.c
@@ -57,7 +57,7 @@ static int execute_PKISI_test(CMP_STATUS_TEST_FIXTURE *fixture)
     if (!TEST_ptr(statusString = sk_ASN1_UTF8STRING_value(ossl_cmp_pkisi_get0_statusString(si),
                       0))
         || !TEST_mem_eq(fixture->text, strlen(fixture->text),
-            (char *)statusString->data, statusString->length))
+            ASN1_STRING_get0_data(statusString), ASN1_STRING_length(statusString)))
         goto end;
 
     if (!TEST_int_eq(fixture->pkifailure,

--- a/test/time_offset_test.c
+++ b/test/time_offset_test.c
@@ -18,8 +18,6 @@
 #include "testutil.h"
 #include "internal/nelem.h"
 
-#include <crypto/asn1.h>
-
 typedef struct {
     const char *data;
     int time_result;
@@ -58,28 +56,24 @@ static TESTDATA tests[] = {
 };
 
 static time_t the_time = 975628800;
-static ASN1_TIME the_asn1_time = {
-    15,
-    V_ASN1_GENERALIZEDTIME,
-    (unsigned char *)"20001201000000Z",
-    0
-};
+static ASN1_TIME *the_asn1_time = NULL;
 
 static int test_offset(int idx)
 {
-    ASN1_TIME at;
+    ASN1_TIME *at = NULL;
     const TESTDATA *testdata = &tests[idx];
     int ret = -2;
     int day, sec;
 
-    at.data = (unsigned char *)testdata->data;
-    at.length = (int)strlen(testdata->data);
-    at.type = testdata->type;
-    at.flags = 0;
+    if (!TEST_ptr(at = ASN1_STRING_type_new(testdata->type))
+        || !TEST_true(ASN1_STRING_set(at, testdata->data,
+            (int)strlen(testdata->data))))
+        goto err;
 
-    if (!TEST_true(ASN1_TIME_diff(&day, &sec, &the_asn1_time, &at))) {
-        TEST_info("ASN1_TIME_diff() failed for %s\n", at.data);
-        return 0;
+    if (!TEST_true(ASN1_TIME_diff(&day, &sec, the_asn1_time, at))) {
+        TEST_info("ASN1_TIME_diff() failed for %s\n",
+            (const char *)ASN1_STRING_get0_data(at));
+        goto err;
     }
     if (day > 0)
         ret = 1;
@@ -93,22 +87,37 @@ static int test_offset(int idx)
         ret = 0;
 
     if (!TEST_int_eq(testdata->time_result, ret)) {
-        TEST_info("ASN1_TIME_diff() test failed for %s day=%d sec=%d\n", at.data, day, sec);
-        return 0;
+        TEST_info("ASN1_TIME_diff() test failed for %s day=%d sec=%d\n",
+            (const char *)ASN1_STRING_get0_data(at), day, sec);
+        goto err;
     }
 
-    ret = ASN1_TIME_cmp_time_t(&at, the_time);
+    ret = ASN1_TIME_cmp_time_t(at, the_time);
 
     if (!TEST_int_eq(testdata->time_result, ret)) {
-        TEST_info("ASN1_UTCTIME_cmp_time_t() test failed for %s\n", at.data);
-        return 0;
+        TEST_info("ASN1_UTCTIME_cmp_time_t() test failed for %s\n",
+            (const char *)ASN1_STRING_get0_data(at));
+        goto err;
     }
 
+    ASN1_TIME_free(at);
     return 1;
+
+err:
+    ASN1_TIME_free(at);
+    return 0;
 }
 
 int setup_tests(void)
 {
+    if (!TEST_ptr(the_asn1_time = ASN1_STRING_type_new(V_ASN1_GENERALIZEDTIME))
+        || !TEST_true(ASN1_STRING_set(the_asn1_time, "20001201000000Z", 15)))
+        return 0;
     ADD_ALL_TESTS(test_offset, OSSL_NELEM(tests));
     return 1;
+}
+
+void cleanup_tests(void)
+{
+    ASN1_TIME_free(the_asn1_time);
 }

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -1671,8 +1671,8 @@ static int xorx_pki_priv_to_der(const void *vecxkey, unsigned char **pder)
 {
     XORKEY *xorxkey = (XORKEY *)vecxkey;
     unsigned char *buf = NULL;
-    ASN1_OCTET_STRING oct;
-    int keybloblen;
+    ASN1_OCTET_STRING *oct = NULL;
+    int keybloblen = 0;
 
     if (xorxkey == NULL) {
         ERR_raise(ERR_LIB_USER, ERR_R_PASSED_NULL_PARAMETER);
@@ -1680,18 +1680,26 @@ static int xorx_pki_priv_to_der(const void *vecxkey, unsigned char **pder)
     }
 
     buf = OPENSSL_secure_malloc(XOR_KEY_SIZE);
+    if (buf == NULL) {
+        ERR_raise(ERR_LIB_USER, ERR_R_MALLOC_FAILURE);
+        return 0;
+    }
     memcpy(buf, xorxkey->privkey, XOR_KEY_SIZE);
 
-    oct.data = buf;
-    oct.length = XOR_KEY_SIZE;
-    oct.flags = 0;
+    if ((oct = ASN1_OCTET_STRING_new()) == NULL
+        || !ASN1_OCTET_STRING_set(oct, buf, XOR_KEY_SIZE)) {
+        ERR_raise(ERR_LIB_USER, ERR_R_MALLOC_FAILURE);
+        goto end;
+    }
 
-    keybloblen = i2d_ASN1_OCTET_STRING(&oct, pder);
+    keybloblen = i2d_ASN1_OCTET_STRING(oct, pder);
     if (keybloblen < 0) {
         ERR_raise(ERR_LIB_USER, ERR_R_MALLOC_FAILURE);
         keybloblen = 0;
     }
 
+end:
+    ASN1_STRING_clear_free(oct);
     OPENSSL_secure_clear_free(buf, XOR_KEY_SIZE);
     return keybloblen;
 }

--- a/test/v3ext.c
+++ b/test/v3ext.c
@@ -194,17 +194,22 @@ static int test_addr_ranges(void)
         ip1 = a2i_IPADDRESS(ranges[i].ip1);
         if (!TEST_ptr(ip1))
             goto end;
-        if (!TEST_true(ip1->length == 4 || ip1->length == 16))
+        if (!TEST_true(ASN1_STRING_length(ip1) == 4
+                || ASN1_STRING_length(ip1) == 16))
             goto end;
         ip2 = a2i_IPADDRESS(ranges[i].ip2);
         if (!TEST_ptr(ip2))
             goto end;
-        if (!TEST_int_eq(ip2->length, ip1->length))
+        if (!TEST_int_eq(ASN1_STRING_length(ip2), ASN1_STRING_length(ip1)))
             goto end;
-        if (!TEST_true(memcmp(ip1->data, ip2->data, ip1->length) <= 0))
+        if (!TEST_true(memcmp(ASN1_STRING_get0_data(ip1),
+                           ASN1_STRING_get0_data(ip2), ASN1_STRING_length(ip1))
+                <= 0))
             goto end;
 
-        if (!TEST_true(X509v3_addr_add_range(addr, ranges[i].afi, NULL, ip1->data, ip2->data)))
+        if (!TEST_true(X509v3_addr_add_range(addr, ranges[i].afi, NULL,
+                (unsigned char *)ASN1_STRING_get0_data(ip1),
+                (unsigned char *)ASN1_STRING_get0_data(ip2))))
             goto end;
 
         if (!TEST_true(X509v3_addr_is_canonical(addr)))
@@ -248,7 +253,9 @@ static int test_addr_fam_len(void)
     ip2 = a2i_IPADDRESS(ranges[0].ip2);
     if (!TEST_ptr(ip2))
         goto end;
-    if (!TEST_true(X509v3_addr_add_range(addr, ranges[0].afi, NULL, ip1->data, ip2->data)))
+    if (!TEST_true(X509v3_addr_add_range(addr, ranges[0].afi, NULL,
+            (unsigned char *)ASN1_STRING_get0_data(ip1),
+            (unsigned char *)ASN1_STRING_get0_data(ip2))))
         goto end;
     if (!TEST_true(X509v3_addr_is_canonical(addr)))
         goto end;
@@ -433,7 +440,8 @@ static int test_addr_subset(void)
             || !TEST_ptr(ip1[i] = a2i_IPADDRESS(ranges[i].ip1))
             || !TEST_ptr(ip2[i] = a2i_IPADDRESS(ranges[i].ip2))
             || !TEST_true(X509v3_addr_add_range(addr[i], ranges[i].afi, NULL,
-                ip1[i]->data, ip2[i]->data)))
+                (unsigned char *)ASN1_STRING_get0_data(ip1[i]),
+                (unsigned char *)ASN1_STRING_get0_data(ip2[i]))))
             goto end;
     }
 

--- a/test/x509_time_test.c
+++ b/test/x509_time_test.c
@@ -17,8 +17,6 @@
 #include "testutil.h"
 #include "internal/nelem.h"
 
-#include <crypto/asn1.h>
-
 typedef struct {
     const char *data;
     int type;
@@ -407,24 +405,26 @@ static TESTDATA x509_cmp_tests[] = {
 
 static int test_x509_cmp_time(int idx)
 {
-    ASN1_TIME t;
-    int result;
+    ASN1_TIME *t = NULL;
+    int result, rv = 0;
 
-    memset(&t, 0, sizeof(t));
-    t.type = x509_cmp_tests[idx].type;
-    t.data = (unsigned char *)(x509_cmp_tests[idx].data);
-    t.length = (int)strlen(x509_cmp_tests[idx].data);
-    t.flags = 0;
+    if (!TEST_ptr(t = ASN1_STRING_type_new(x509_cmp_tests[idx].type))
+        || !TEST_true(ASN1_STRING_set(t, x509_cmp_tests[idx].data,
+            (int)strlen(x509_cmp_tests[idx].data))))
+        goto out;
 
     OSSL_BEGIN_ALLOW_DEPRECATED
-    result = X509_cmp_time(&t, &x509_cmp_tests[idx].cmp_time);
+    result = X509_cmp_time(t, &x509_cmp_tests[idx].cmp_time);
     OSSL_END_ALLOW_DEPRECATED
     if (!TEST_int_eq(result, x509_cmp_tests[idx].expected)) {
         TEST_info("test_x509_cmp_time(%d) failed: expected %d, got %d\n",
             idx, x509_cmp_tests[idx].expected, result);
-        return 0;
+        goto out;
     }
-    return 1;
+    rv = 1;
+out:
+    ASN1_TIME_free(t);
+    return rv;
 }
 
 static int test_x509_cmp_time_current(void)
@@ -539,21 +539,23 @@ static int test_x509_time(int idx)
 
     /* if t is not NULL but expected_type is ignored(-1), it is an 'OK' case */
     if (t != NULL && x509_format_tests[idx].expected_type != -1) {
-        if (!TEST_int_eq(t->type, x509_format_tests[idx].expected_type)) {
+        if (!TEST_int_eq(ASN1_STRING_type(t),
+                x509_format_tests[idx].expected_type)) {
             TEST_info("test_x509_time(%d) failed: expected_type %d, got %d\n",
-                idx, x509_format_tests[idx].expected_type, t->type);
+                idx, x509_format_tests[idx].expected_type, ASN1_STRING_type(t));
             goto out;
         }
     }
 
     /* if t is not NULL but expected_string is NULL, it is an 'OK' case too */
     if (t != NULL && x509_format_tests[idx].expected_string) {
-        if (!TEST_mem_eq((const char *)t->data, t->length,
+        if (!TEST_mem_eq((const char *)ASN1_STRING_get0_data(t),
+                ASN1_STRING_length(t),
                 x509_format_tests[idx].expected_string,
                 strlen(x509_format_tests[idx].expected_string))) {
             TEST_info("test_x509_time(%d) failed: expected_string %s, got %.*s\n",
-                idx, x509_format_tests[idx].expected_string, t->length,
-                t->data);
+                idx, x509_format_tests[idx].expected_string,
+                ASN1_STRING_length(t), ASN1_STRING_get0_data(t));
             goto out;
         }
     }
@@ -644,75 +646,77 @@ static int test_days(int n)
     return r;
 }
 
-#define construct_asn1_time(s, t, e) \
-    { { sizeof(s) - 1, t, (unsigned char *)s, 0 }, e }
-
 static const struct {
-    ASN1_TIME asn1;
+    const char *timestring;
+    int type;
     const char *readable;
 } x509_print_tests_rfc_822[] = {
     /* Generalized Time */
-    construct_asn1_time("20170731222050Z", V_ASN1_GENERALIZEDTIME,
-        "Jul 31 22:20:50 2017 GMT"),
+    { "20170731222050Z", V_ASN1_GENERALIZEDTIME,
+        "Jul 31 22:20:50 2017 GMT" },
     /* Generalized Time, no seconds */
-    construct_asn1_time("201707312220Z", V_ASN1_GENERALIZEDTIME,
-        "Bad time value"),
+    { "201707312220Z", V_ASN1_GENERALIZEDTIME,
+        "Bad time value" },
     /* Generalized Time, fractional seconds (3 digits) */
-    construct_asn1_time("20170731222050.123Z", V_ASN1_GENERALIZEDTIME,
-        "Jul 31 22:20:50.123 2017 GMT"),
+    { "20170731222050.123Z", V_ASN1_GENERALIZEDTIME,
+        "Jul 31 22:20:50.123 2017 GMT" },
     /* Generalized Time, fractional seconds (1 digit) */
-    construct_asn1_time("20170731222050.1Z", V_ASN1_GENERALIZEDTIME,
-        "Jul 31 22:20:50.1 2017 GMT"),
+    { "20170731222050.1Z", V_ASN1_GENERALIZEDTIME,
+        "Jul 31 22:20:50.1 2017 GMT" },
     /* Generalized Time, fractional seconds (0 digit) */
-    construct_asn1_time("20170731222050.Z", V_ASN1_GENERALIZEDTIME,
-        "Bad time value"),
+    { "20170731222050.Z", V_ASN1_GENERALIZEDTIME,
+        "Bad time value" },
     /* UTC Time */
-    construct_asn1_time("170731222050Z", V_ASN1_UTCTIME,
-        "Jul 31 22:20:50 2017 GMT"),
+    { "170731222050Z", V_ASN1_UTCTIME,
+        "Jul 31 22:20:50 2017 GMT" },
     /* UTC Time, no seconds */
-    construct_asn1_time("1707312220Z", V_ASN1_UTCTIME,
-        "Bad time value"),
+    { "1707312220Z", V_ASN1_UTCTIME,
+        "Bad time value" },
 };
 
 static const struct {
-    ASN1_TIME asn1;
+    const char *timestring;
+    int type;
     const char *readable;
 } x509_print_tests_iso_8601[] = {
     /* Generalized Time */
-    construct_asn1_time("20170731222050Z", V_ASN1_GENERALIZEDTIME,
-        "2017-07-31 22:20:50Z"),
+    { "20170731222050Z", V_ASN1_GENERALIZEDTIME,
+        "2017-07-31 22:20:50Z" },
     /* Generalized Time, no seconds */
-    construct_asn1_time("201707312220Z", V_ASN1_GENERALIZEDTIME,
-        "Bad time value"),
+    { "201707312220Z", V_ASN1_GENERALIZEDTIME,
+        "Bad time value" },
     /* Generalized Time, fractional seconds (3 digits) */
-    construct_asn1_time("20170731222050.123Z", V_ASN1_GENERALIZEDTIME,
-        "2017-07-31 22:20:50.123Z"),
+    { "20170731222050.123Z", V_ASN1_GENERALIZEDTIME,
+        "2017-07-31 22:20:50.123Z" },
     /* Generalized Time, fractional seconds (1 digit) */
-    construct_asn1_time("20170731222050.1Z", V_ASN1_GENERALIZEDTIME,
-        "2017-07-31 22:20:50.1Z"),
+    { "20170731222050.1Z", V_ASN1_GENERALIZEDTIME,
+        "2017-07-31 22:20:50.1Z" },
     /* Generalized Time, fractional seconds (0 digit) */
-    construct_asn1_time("20170731222050.Z", V_ASN1_GENERALIZEDTIME,
-        "Bad time value"),
+    { "20170731222050.Z", V_ASN1_GENERALIZEDTIME,
+        "Bad time value" },
     /* UTC Time */
-    construct_asn1_time("170731222050Z", V_ASN1_UTCTIME,
-        "2017-07-31 22:20:50Z"),
+    { "170731222050Z", V_ASN1_UTCTIME,
+        "2017-07-31 22:20:50Z" },
     /* UTC Time, no seconds */
-    construct_asn1_time("1707312220Z", V_ASN1_UTCTIME,
-        "Bad time value"),
+    { "1707312220Z", V_ASN1_UTCTIME,
+        "Bad time value" },
 };
 
-static int test_x509_time_print_rfc_822(int idx)
+static int run_time_print_test(const char *timestring, int type,
+    const char *readable, unsigned long flags)
 {
-    BIO *m;
+    BIO *m = NULL;
+    ASN1_TIME *t = NULL;
     int ret = 0, rv;
     char *pp;
-    const char *readable;
 
-    if (!TEST_ptr(m = BIO_new(BIO_s_mem())))
+    if (!TEST_ptr(m = BIO_new(BIO_s_mem()))
+        || !TEST_ptr(t = ASN1_STRING_type_new(type))
+        || !TEST_true(ASN1_STRING_set(t, timestring,
+            (int)strlen(timestring))))
         goto err;
 
-    rv = ASN1_TIME_print_ex(m, &x509_print_tests_rfc_822[idx].asn1, ASN1_DTFLGS_RFC822);
-    readable = x509_print_tests_rfc_822[idx].readable;
+    rv = ASN1_TIME_print_ex(m, t, flags);
 
     if (rv == 0 && !TEST_str_eq(readable, "Bad time value")) {
         /* only if the test case intends to fail... */
@@ -726,35 +730,24 @@ static int test_x509_time_print_rfc_822(int idx)
     ret = 1;
 err:
     BIO_free(m);
+    ASN1_TIME_free(t);
     return ret;
+}
+
+static int test_x509_time_print_rfc_822(int idx)
+{
+    return run_time_print_test(x509_print_tests_rfc_822[idx].timestring,
+        x509_print_tests_rfc_822[idx].type,
+        x509_print_tests_rfc_822[idx].readable,
+        ASN1_DTFLGS_RFC822);
 }
 
 static int test_x509_time_print_iso_8601(int idx)
 {
-    BIO *m;
-    int ret = 0, rv;
-    char *pp;
-    const char *readable;
-
-    if (!TEST_ptr(m = BIO_new(BIO_s_mem())))
-        goto err;
-
-    rv = ASN1_TIME_print_ex(m, &x509_print_tests_iso_8601[idx].asn1, ASN1_DTFLGS_ISO8601);
-    readable = x509_print_tests_iso_8601[idx].readable;
-
-    if (rv == 0 && !TEST_str_eq(readable, "Bad time value")) {
-        /* only if the test case intends to fail... */
-        goto err;
-    }
-    if (!TEST_int_ne(rv = BIO_get_mem_data(m, &pp), 0)
-        || !TEST_int_eq(rv, (int)strlen(readable))
-        || !TEST_strn_eq(pp, readable, rv))
-        goto err;
-
-    ret = 1;
-err:
-    BIO_free(m);
-    return ret;
+    return run_time_print_test(x509_print_tests_iso_8601[idx].timestring,
+        x509_print_tests_iso_8601[idx].type,
+        x509_print_tests_iso_8601[idx].readable,
+        ASN1_DTFLGS_ISO8601);
 }
 
 int setup_tests(void)


### PR DESCRIPTION
## Summary

Replace direct `ASN1_STRING` struct member access (`->data`, `->length`,
`->type`) with public accessor functions across 7 files in `test/`.
Stack-allocated and static-aggregate `ASN1_TIME` / `ASN1_OCTET_STRING`
objects are converted to heap allocations, which is required now that
`struct asn1_string_st` is opaque (#29862).

Partially addresses #29861. **Split out of #30685** per @bob-beck's
review request that the test/ changes be reviewed separately. Also
fixes the `asn1_time_test` ubsan failure in #30685 that couldn't be
reproduced locally — that test's `struct compare_testdata` embedded an
`ASN1_TIME` by value, which is no longer valid with the opaque struct.

## Files

| File | Change | Internal include |
|------|--------|------|
| test/asn1_time_test.c | Static `gtime` and stack `atime` → heap. Removed `struct compare_testdata`, the `TODAY_*`/`TOMORROW_*` initializer macros, and the `tbl_compare_testdata` table. `test_table_compare` replaced with a new `test_asn1_time_compare` unit test covering: the 4×4 today/tomorrow pairwise matrix across UTCTIME and GENERALIZEDTIME, the -2 error return on malformed input (previously untested), and min/max POSIX time boundary comparisons. | Retained (needs `OPENSSL_gmtime_diff`, `ossl_asn1_time_from_tm`, `test_asn1_string_to_time_t`) |
| test/x509_time_test.c | Killed the `construct_asn1_time` initializer macro. The `x509_print_tests_rfc_822` and `x509_print_tests_iso_8601` arrays now hold `{timestring, type, readable}` records; both test drivers are factored through a single `run_time_print_test` helper that builds the `ASN1_TIME` at loop time. `test_x509_cmp_time` converts stack `ASN1_TIME` → heap. | Removed |
| test/time_offset_test.c | Static `the_asn1_time` aggregate and stack `at` converted to heap via `ASN1_STRING_type_new` + `ASN1_STRING_set`. Added `cleanup_tests` to free the shared baseline. | Removed |
| test/v3ext.c | `ip->data`/`ip->length` reads on `ASN1_OCTET_STRING` → `ASN1_STRING_get0_data` / `ASN1_STRING_length`. `X509v3_addr_add_range`'s `unsigned char *min, *max` parameters are read-only on those pointers but not const-typed; a `(unsigned char *)` cast is used at the call sites since adjusting the public API is out of scope for a test-only PR. | N/A |
| test/tls-provider.c | `xorx_pki_priv_to_der` had a stack `ASN1_OCTET_STRING oct` with direct field writes. Converted to `ASN1_OCTET_STRING_new` + `ASN1_OCTET_STRING_set`. Uses `ASN1_STRING_clear_free(oct)` (not `_free`) to cleanse the internal copy of the XOR private key before free, matching the original's `OPENSSL_secure_clear_free(buf)` intent. | N/A |
| test/cmp_ctx_test.c | `DEFINE_SET_GET1_STR_FN` macro internals: `bytes->data` / `bytes->length` → accessors. | N/A |
| test/cmp_status_test.c | `statusString->data` / `statusString->length` in `TEST_mem_eq` → accessors. | N/A |

## Behavioral notes

- `test/tls-provider.c`: the stack→heap conversion introduces a second
  transient copy of the XOR private key inside the heap
  `ASN1_OCTET_STRING` (the original aliased). The new copy is cleansed
  before free via `ASN1_STRING_clear_free`, so the original's
  secure-clear intent is preserved end-to-end.
- `test/v3ext.c`: the `(unsigned char *)ASN1_STRING_get0_data(ip)` casts
  are pointer-equivalent to the prior `ip->data`; the cast is the price
  of the accessor returning `const`. Zero runtime delta.
- `test_asn1_time_compare` covers the old `test_table_compare`'s 16
  pairwise subtests as a subset and adds error-return and boundary
  coverage.

## Test plan

- [x] `make test HARNESS_VERBOSE=1` — 4373 tests pass on Linux x86_64
- [x] `TESTS=test_asn1_time test`, `TESTS=test_x509_time test`,
      `TESTS=test_time_offset test` each pass individually
- [x] `clang-query` confirms zero remaining `memberExpr` on
      `asn1_string_st` across `test/*.c`

## References

Follow-up to #29862 (opaque `ASN1_STRING`), #30126 (crypto/asn1/),
#30223 (crypto/cmp,ct,sm2,ts), #30525 (crypto/rsa,crmf,pkcs7,cms,x509).
Split from #30685 per bob-beck's review.

Tagging @bbbrumley.
