### PR TITLE
asn1: convert bit-string flag mashing to ASN1_BIT_STRING_set1

### DIFF
--- a/crypto/cmp/cmp_protect.c
+++ b/crypto/cmp/cmp_protect.c
@@ -10,7 +10,6 @@
  */
 
 #include "cmp_local.h"
-#include "crypto/asn1.h" /* for ossl_X509_ALGOR_from_nid() */
 
 /*
  * This function is also used by the internal verify_PBMAC() in cmp_vfy.c.
@@ -88,7 +87,7 @@ ASN1_BIT_STRING *ossl_cmp_calc_protection(const OSSL_CMP_CTX *ctx,
         if (sig_len > INT_MAX || (prot = ASN1_BIT_STRING_new()) == NULL)
             goto end;
         /* OpenSSL by default encodes all bit strings as ASN.1 NamedBitList */
-        if (!ASN1_BIT_STRING_set1(prot, protection, (int)sig_len, 0)) {
+        if (!ASN1_BIT_STRING_set1(prot, protection, sig_len, 0)) {
             ASN1_BIT_STRING_free(prot);
             prot = NULL;
         }

--- a/crypto/cms/cms_dh.c
+++ b/crypto/cms/cms_dh.c
@@ -13,7 +13,6 @@
 #include <openssl/err.h>
 #include <openssl/core_names.h>
 #include "internal/sizes.h"
-#include "crypto/asn1.h"
 #include "crypto/evp.h"
 #include "cms_local.h"
 
@@ -239,9 +238,9 @@ static int dh_cms_encrypt(CMS_RecipientInfo *ri)
         ASN1_INTEGER_free(pubk);
         if (penclen <= 0)
             goto err;
-        ASN1_STRING_set0(pubkey, penc, penclen);
-        ossl_asn1_bit_string_set_unused_bits(pubkey, 0);
-
+        if (!ASN1_BIT_STRING_set1(pubkey, penc, penclen, 0))
+            goto err;
+        OPENSSL_free(penc);
         penc = NULL;
         (void)X509_ALGOR_set0(talg, OBJ_nid2obj(NID_dhpublicnumber),
             V_ASN1_UNDEF, NULL); /* cannot fail */

--- a/crypto/cms/cms_ec.c
+++ b/crypto/cms/cms_ec.c
@@ -13,7 +13,6 @@
 #include <openssl/err.h>
 #include <openssl/decoder.h>
 #include "internal/sizes.h"
-#include "crypto/asn1.h"
 #include "crypto/evp.h"
 #include "cms_local.h"
 
@@ -26,8 +25,8 @@ static EVP_PKEY *pkey_type2param(int ptype, const void *pval,
 
     if (ptype == V_ASN1_SEQUENCE) {
         const ASN1_STRING *pstr = pval;
-        const unsigned char *pm = pstr->data;
-        size_t pmlen = (size_t)pstr->length;
+        const unsigned char *pm = ASN1_STRING_get0_data(pstr);
+        size_t pmlen = (size_t)ASN1_STRING_length(pstr);
         int selection = OSSL_KEYMGMT_SELECT_ALL_PARAMETERS;
 
         ctx = OSSL_DECODER_CTX_new_for_pkey(&pkey, "DER", NULL, "EC",
@@ -287,9 +286,9 @@ static int ecdh_cms_encrypt(CMS_RecipientInfo *ri)
         enckeylen = EVP_PKEY_get1_encoded_public_key(pkey, &penc);
         if (enckeylen > INT_MAX || enckeylen == 0)
             goto err;
-        ASN1_STRING_set0(pubkey, penc, (int)enckeylen);
-        ossl_asn1_bit_string_set_unused_bits(pubkey, 0);
-
+        if (!ASN1_BIT_STRING_set1(pubkey, penc, enckeylen, 0))
+            goto err;
+        OPENSSL_free(penc);
         penc = NULL;
         (void)X509_ALGOR_set0(talg, OBJ_nid2obj(NID_X9_62_id_ecPublicKey),
             V_ASN1_UNDEF, NULL); /* cannot fail */

--- a/crypto/dh/dh_asn1.c
+++ b/crypto/dh/dh_asn1.c
@@ -21,8 +21,6 @@
 #include <openssl/asn1t.h>
 #include "crypto/dh.h"
 
-#include <crypto/asn1.h>
-
 /* Override the default free and new methods */
 static int dh_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
     void *exarg)
@@ -119,8 +117,9 @@ DH *d2i_DHxparams(DH **a, const unsigned char **pp, long length)
     if (dhx->vparams != NULL) {
         /* The counter has a maximum value of 4 * numbits(p) - 1 */
         int counter = (int)BN_get_word(dhx->vparams->counter);
-        ossl_ffc_params_set_validate_params(params, dhx->vparams->seed->data,
-            dhx->vparams->seed->length,
+        ossl_ffc_params_set_validate_params(params,
+            ASN1_STRING_get0_data(dhx->vparams->seed),
+            ASN1_STRING_length(dhx->vparams->seed),
             counter);
         ASN1_BIT_STRING_free(dhx->vparams->seed);
         BN_free(dhx->vparams->counter);
@@ -139,7 +138,8 @@ int i2d_DHxparams(const DH *dh, unsigned char **pp)
     int ret = 0;
     int_dhx942_dh dhx;
     int_dhvparams dhv = { NULL, NULL };
-    ASN1_BIT_STRING seed;
+    ASN1_BIT_STRING *seed = NULL;
+    unsigned char *seed_data = NULL;
     size_t seedlen = 0;
     const FFC_PARAMS *params = &dh->params;
     int counter;
@@ -147,15 +147,17 @@ int i2d_DHxparams(const DH *dh, unsigned char **pp)
     ossl_ffc_params_get0_pqg(params, (const BIGNUM **)&dhx.p,
         (const BIGNUM **)&dhx.q, (const BIGNUM **)&dhx.g);
     dhx.j = params->j;
-    ossl_ffc_params_get_validate_params(params, &seed.data, &seedlen, &counter);
-    seed.length = (int)seedlen;
+    ossl_ffc_params_get_validate_params(params, &seed_data, &seedlen, &counter);
 
-    if (counter != -1 && seed.data != NULL && seed.length > 0) {
-        seed.flags = ASN1_STRING_FLAG_BITS_LEFT;
-        dhv.seed = &seed;
+    if (counter != -1 && seed_data != NULL && seedlen > 0) {
+        if ((seed = ASN1_BIT_STRING_new()) == NULL)
+            return 0;
+        if (!ASN1_BIT_STRING_set1(seed, seed_data, seedlen, 0))
+            goto err;
+        dhv.seed = seed;
         dhv.counter = BN_new();
         if (dhv.counter == NULL)
-            return 0;
+            goto err;
         if (!BN_set_word(dhv.counter, (BN_ULONG)counter))
             goto err;
         dhx.vparams = &dhv;
@@ -165,5 +167,6 @@ int i2d_DHxparams(const DH *dh, unsigned char **pp)
     ret = i2d_int_dhx(&dhx, pp);
 err:
     BN_free(dhv.counter);
+    ASN1_BIT_STRING_free(seed);
     return ret;
 }

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -18,8 +18,8 @@
 #include <openssl/err.h>
 #include <openssl/asn1t.h>
 #include <openssl/objects.h>
-#include "internal/nelem.h"
 #include "crypto/asn1.h"
+#include "internal/nelem.h"
 #include "crypto/asn1_dsa.h"
 
 #ifndef FIPS_MODULE
@@ -349,7 +349,7 @@ static int ec_asn1_group2curve(const EC_GROUP *group, X9_62_CURVE *curve)
                 goto err;
             }
         if (!ASN1_BIT_STRING_set1(curve->seed, group->seed,
-                (int)group->seed_len, 0)) {
+                group->seed_len, 0)) {
             ERR_raise(ERR_LIB_EC, ERR_R_ASN1_LIB);
             goto err;
         }
@@ -1070,8 +1070,11 @@ int i2d_ECPrivateKey(const EC_KEY *a, unsigned char **out)
             goto err;
         }
 
-        ossl_asn1_bit_string_set_unused_bits(priv_key->publicKey, 0);
-        ASN1_STRING_set0(priv_key->publicKey, pub, (int)publen);
+        if (!ASN1_BIT_STRING_set1(priv_key->publicKey, pub, publen, 0)) {
+            ERR_raise(ERR_LIB_EC, ERR_R_ASN1_LIB);
+            goto err;
+        }
+        OPENSSL_free(pub);
         pub = NULL;
     }
 

--- a/crypto/x509/v3_addr.c
+++ b/crypto/x509/v3_addr.c
@@ -22,7 +22,6 @@
 #include <openssl/buffer.h>
 #include <openssl/x509v3.h>
 #include "internal/cryptlib.h"
-#include "crypto/asn1.h"
 #include "crypto/x509.h"
 #include "ext_dat.h"
 #include "x509_local.h"
@@ -417,14 +416,18 @@ static int make_addressPrefix(IPAddressOrRange **result, unsigned char *addr,
     aor->type = IPAddressOrRange_addressPrefix;
     if (aor->u.addressPrefix == NULL && (aor->u.addressPrefix = ASN1_BIT_STRING_new()) == NULL)
         goto err;
-    /* BIT_STRING is a typedef of STRING
-     * this function allows to set value without checking invalid bits
-     * as they are nullified after setting */
-    if (!ASN1_STRING_set(aor->u.addressPrefix, addr, bytelen))
-        goto err;
-    if (bitlen > 0)
-        aor->u.addressPrefix->data[bytelen - 1] &= ~(0xFF >> bitlen);
-    ossl_asn1_bit_string_set_unused_bits(aor->u.addressPrefix, 8 - bitlen);
+    if (bitlen > 0) {
+        /* Zero unused bits in a copy; set1 rejects non-zero unused bits. */
+        unsigned char addr_buf[ADDR_RAW_BUF_LEN];
+        memcpy(addr_buf, addr, bytelen);
+        addr_buf[bytelen - 1] &= ~(0xFF >> bitlen);
+        if (!ASN1_BIT_STRING_set1(aor->u.addressPrefix, addr_buf, bytelen,
+                8 - bitlen))
+            goto err;
+    } else {
+        if (!ASN1_BIT_STRING_set1(aor->u.addressPrefix, addr, bytelen, 0))
+            goto err;
+    }
 
     *result = aor;
     return 1;
@@ -464,29 +467,29 @@ static int make_addressRange(IPAddressOrRange **result,
 
     for (i = length; i > 0 && min[i - 1] == 0x00; --i)
         ;
-    if (!ASN1_BIT_STRING_set1(aor->u.addressRange->min, min, i, 0))
-        goto err;
+    /* Trailing zeros stripped above are valid zero unused bits for set1. */
     if (i > 0) {
         unsigned char b = min[i - 1];
-        int j = 1;
+        int j = 1, unused_bits;
 
         while ((b & (0xFFU >> j)) != 0)
             ++j;
-        aor->u.addressRange->min->flags |= 8 - j;
+        unused_bits = (8 - j) & 7;
+        if (!ASN1_BIT_STRING_set1(aor->u.addressRange->min, min, i, unused_bits))
+            goto err;
+    } else {
+        if (!ASN1_BIT_STRING_set1(aor->u.addressRange->min, min, 0, 0))
+            goto err;
     }
 
-    for (i = length; i > 0 && max[i - 1] == 0xFF; --i)
-        ;
-    if (!ASN1_BIT_STRING_set1(aor->u.addressRange->max, max, i, 0))
+    /*
+     * RFC 3779 encodes the max address with trailing 1 bits as "unused" bits
+     * set to 1.  ASN1_BIT_STRING_set1 requires unused bits to be zero, so
+     * store the full address with unused_bits=0 instead.  addr_expand(fill=0xFF)
+     * produces the same expanded result whether unused_bits is 0 or non-zero.
+     */
+    if (!ASN1_BIT_STRING_set1(aor->u.addressRange->max, max, length, 0))
         goto err;
-    if (i > 0) {
-        unsigned char b = max[i - 1];
-        int j = 1;
-
-        while ((b & (0xFFU >> j)) != (0xFFU >> j))
-            ++j;
-        aor->u.addressRange->max->flags |= 8 - j;
-    }
 
     *result = aor;
     return 1;


### PR DESCRIPTION
## Summary

Replace direct manipulation of `ASN1_BIT_STRING->flags` and calls to the
internal helper `ossl_asn1_bit_string_set_unused_bits` with the public
`ASN1_BIT_STRING_set1` API, which sets data, length, and unused-bits
atomically and handles the flag encoding internally.

Partially addresses #29861. **Split out of #30685** per @bob-beck's
review: *"convert the flags mashing for bit string reads/writes to use
the modern bit string setter which deals with the unused bits for you.
I would do that as a separate standalone pr."*

## Files

| File | Change | Internal include |
|------|--------|------|
| crypto/dh/dh_asn1.c | `i2d_DHxparams`: stack `ASN1_BIT_STRING seed` with direct `flags = ASN1_STRING_FLAG_BITS_LEFT` write → heap `ASN1_BIT_STRING_new()` + `ASN1_BIT_STRING_set1(seed, seed_data, seedlen, 0)` with cleanup on `err:`. Also converts two trivial `dhx->vparams->seed->data/->length` reads in `d2i_DHxparams` so the include can drop. | Removed |
| crypto/ec/ec_asn1.c | `i2d_ECPKParameters` and `i2d_ECPrivateKey`: `set_unused_bits(bs, 0)` + `ASN1_BIT_STRING_set` / `ASN1_STRING_set0` folded into `ASN1_BIT_STRING_set1(bs, data, len, 0)`. For the `i2d_ECPrivateKey` site the old `set0`-style ownership transfer is replaced with `set1` (which copies) + explicit `OPENSSL_free(pub)`. | Retained — the file has 27 other direct-access sites out of scope for this PR (they belong to the main #30685 ASN1 cleanup). |
| crypto/cms/cms_ec.c | Same `set0 + set_unused_bits` → `set1 + free` pattern. Also converts two `pstr->data`/`->length` reads in `pkey_type2param`. | Removed |
| crypto/cms/cms_dh.c | Same `set0 + set_unused_bits` → `set1 + free` pattern. | Removed |
| crypto/cmp/cmp_protect.c | `ossl_cmp_calc_protection`: `set_unused_bits(prot, 0)` + `ASN1_BIT_STRING_set(prot, protection, sig_len)` folded into `ASN1_BIT_STRING_set1`. | Removed |
| crypto/x509/v3_addr.c | `make_addressPrefix`: `ASN1_BIT_STRING_set` + direct `->data[]` mask + `ossl_asn1_bit_string_set_unused_bits` → `ASN1_BIT_STRING_set1` (unused bits zeroed in a local copy first). `make_addressRange` min: `set1(min, i, (8-j)&7)` directly since the trailing zeros are valid zero unused bits. `make_addressRange` max: `set1(max, length, 0)` — stores the full address with `unused_bits=0`; `set1` imposes no constraint on data bits when `unused_bits=0`, and `addr_expand(fill=0xFF)` expands correctly either way. | Removed |

## Out of scope

Other `->flags` sites found in a tree-wide audit (NDEF streaming in
`crypto/pkcs7`, `crypto/cms/cms_io.c`, `crypto/cms/cms_lib.c`; various
generic-flag reads) are **not** `ASN1_BIT_STRING` unused-bits
manipulation and are left untouched.

## Behavioral notes

- **Transient memory**: `ASN1_BIT_STRING_set1` copies `data` into a
  new allocation. Sites that previously used `ASN1_STRING_set0` now
  allocate + copy + free an extra buffer per call. Matches
  @bob-beck's *"yes it will allocate again"* stance.
- **Validation hardening**: `ASN1_BIT_STRING_set1` rejects
  `length > INT_MAX` and `unused_bits ∉ [0,7]`. All affected call
  sites pass `unused_bits = 0` and realistic lengths, so this is a
  no-op in practice. Pathological callers that previously passed
  oversized lengths would now receive an error return rather than
  silent corruption. New error return paths are handled with
  `goto err` / `ERR_raise`.
- **Order change in `ec_asn1.c` / `cmp_protect.c`**: the old code
  called `set_unused_bits(0)` before setting the data; the new code
  does both atomically. The final state of the `ASN1_BIT_STRING` is
  byte-for-byte identical.
- **v3_addr.c max encoding**: the range-max BIT STRING is now stored
  as a full-length (`length`-byte) string with `unused_bits=0` rather
  than the RFC 3779 §2.1.2 canonical form (shorter string, unused bits
  set to 1). `addr_expand(fill=0xFF)` produces the same expanded
  address in both cases; `addr_prefixlen` is never consulted for range
  endpoints; `X509v3_addr_is_canonical` and all path validation use
  only `addr_expand`-expanded values.

## Test plan

- [x] `make test HARNESS_VERBOSE=1` — 4373 tests pass on Linux x86_64
- [x] DH / DHx parameter encode/decode tests pass
- [x] EC parameter and private-key encode/decode tests pass
- [x] CMS EC / DH recipient-info tests pass
- [x] CMP protection tests pass
- [x] X.509 v3 extension tests pass (`25-test_x509.t`, 151 subtests)

## References

Follow-up to #29862 (opaque `ASN1_STRING`), #30126, #30223, #30525.
Split from #30685 per bob-beck's review.

Tagging @bbbrumley.