### PR TITLE
test/load_key_certs_crls_memfail: count in app_create_libctx setup

### DIFF
--- a/test/load_key_certs_crls_memfail.c
+++ b/test/load_key_certs_crls_memfail.c
@@ -34,6 +34,8 @@ static int do_load_key_certs_crls(int allow_failure)
 
     if (certfile == NULL)
         return 0;
+    if (app_create_libctx() == NULL)
+        goto err;
 
     (void)snprintf(uri, sizeof(uri), "file:%s", certfile);
     if (!TEST_true(load_key_certs_crls(uri, FORMAT_UNDEF, 0, NULL, "cert",
@@ -68,9 +70,6 @@ int setup_tests(void)
 {
     int ret = 0;
     char *opmode = NULL;
-
-    if (app_create_libctx() == NULL)
-        return 0;
 
     if (!TEST_ptr(opmode = test_get_argument(0)))
         goto err;


### PR DESCRIPTION
move app_create_libctx() out of setup_tests() and into the tested workload so OPENSSL_MALLOC_FAILURES can fail it within the counted allocation window instead of aborting test setup early.

  #   Failed test at test/recipes/90-test_memfail.t line 86.
      # Failed to create library context
      # Usage: load_key_certs_crls_memfail [options]
      # Valid options are:
      #  -help         Display this summary
      #  -list         Display the list of tests available
      #  -test val     Run a single test by id or name
      #  -iter int     Run a single iteration of a test
      #  -indent +int  Number of tabs added to output
      #  -seed int     Seed value to randomize tests with
  ../../util/wrap.pl ../../test/load_key_certs_crls_memfail run ../../test/certs/servercert.pem => 1
  not ok 24403

Fix CI: https://github.com/openssl/openssl/actions/runs/24814915512/job/72627204978
