### PR TITLE
Fix dangeours truncating memsize to 32bit

### DIFF
--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -222,7 +222,7 @@ static int handle_symlink(const char *filename, const char *fullpath)
         return -1;
 
     n = readlink(fullpath, linktarget, sizeof(linktarget));
-    if (n < 0 || n >= sizeof(linktarget))
+    if (n < 0 || n >= (ssize_t)sizeof(linktarget))
         return -1;
     linktarget[n] = 0;
 

--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -222,7 +222,7 @@ static int handle_symlink(const char *filename, const char *fullpath)
         return -1;
 
     n = readlink(fullpath, linktarget, sizeof(linktarget));
-    if (n < 0 || n >= (int)sizeof(linktarget))
+    if (n < 0 || n >= sizeof(linktarget))
         return -1;
     linktarget[n] = 0;
 

--- a/crypto/asn1/a_bitstr.c
+++ b/crypto/asn1/a_bitstr.c
@@ -94,11 +94,11 @@ ASN1_BIT_STRING *ossl_c2i_ASN1_BIT_STRING(ASN1_BIT_STRING **a,
     ossl_asn1_bit_string_set_unused_bits(ret, i);
 
     if (len-- > 1) { /* using one because of the bits left byte */
-        s = OPENSSL_malloc((int)len);
+        s = OPENSSL_malloc(len);
         if (s == NULL) {
             goto err;
         }
-        memcpy(s, p, (int)len);
+        memcpy(s, p, len);
         s[len - 1] &= (0xff << i);
         p += len;
     } else

--- a/crypto/asn1/a_d2i_fp.c
+++ b/crypto/asn1/a_d2i_fp.c
@@ -162,7 +162,7 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
         diff = len - off;
         if (diff == 0)
             goto err;
-        inf = ASN1_get_object(&q, &slen, &tag, &xclass, diff);
+        inf = ASN1_get_object(&q, &slen, &tag, &xclass, (long)diff);
         if (inf & 0x80) {
             unsigned long e;
 

--- a/crypto/asn1/a_d2i_fp.c
+++ b/crypto/asn1/a_d2i_fp.c
@@ -162,7 +162,7 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
         diff = len - off;
         if (diff == 0)
             goto err;
-        inf = ASN1_get_object(&q, &slen, &tag, &xclass, (int)diff);
+        inf = ASN1_get_object(&q, &slen, &tag, &xclass, diff);
         if (inf & 0x80) {
             unsigned long e;
 

--- a/crypto/bio/bf_buff.c
+++ b/crypto/bio/bf_buff.c
@@ -303,7 +303,7 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         }
         ctx->ibuf_off = 0;
         ctx->ibuf_len = (int)num;
-        memcpy(ctx->ibuf, ptr, (int)num);
+        memcpy(ctx->ibuf, ptr, num);
         ret = 1;
         break;
     case BIO_C_SET_BUFF_SIZE:

--- a/crypto/bio/bss_bio.c
+++ b/crypto/bio/bss_bio.c
@@ -694,12 +694,12 @@ int BIO_new_bio_pair(BIO **bio1_p, size_t writebuf1,
         goto err;
 
     if (writebuf1) {
-        r = BIO_set_write_buf_size(bio1, (long)writebuf1);
+        r = BIO_set_write_buf_size(bio1, writebuf1);
         if (!r)
             goto err;
     }
     if (writebuf2) {
-        r = BIO_set_write_buf_size(bio2, (long)writebuf2);
+        r = BIO_set_write_buf_size(bio2, writebuf2);
         if (!r)
             goto err;
     }

--- a/crypto/bio/bss_dgram_pair.c
+++ b/crypto/bio/bss_dgram_pair.c
@@ -740,7 +740,7 @@ static long dgram_mem_ctrl(BIO *bio, int cmd, long num, void *ptr)
 
     /* BIO_dgram_set_mtu */
     case BIO_CTRL_DGRAM_SET_MTU: /* Non-threadsafe */
-        ret = (long)dgram_pair_ctrl_set_mtu(bio, (uint32_t)num);
+        ret = (long)dgram_pair_ctrl_set_mtu(bio, num);
         break;
 
     case BIO_CTRL_DGRAM_SET0_LOCAL_ADDR:
@@ -817,13 +817,13 @@ int BIO_new_bio_dgram_pair(BIO **pbio1, size_t writebuf1,
         goto err;
 
     if (writebuf1 > 0) {
-        r = BIO_set_write_buf_size(bio1, (long)writebuf1);
+        r = BIO_set_write_buf_size(bio1, writebuf1);
         if (r == 0)
             goto err;
     }
 
     if (writebuf2 > 0) {
-        r = BIO_set_write_buf_size(bio2, (long)writebuf2);
+        r = BIO_set_write_buf_size(bio2, writebuf2);
         if (r == 0)
             goto err;
     }

--- a/crypto/des/str2key.c
+++ b/crypto/des/str2key.c
@@ -41,7 +41,7 @@ void DES_string_to_key(const char *str, DES_cblock *key)
     }
     DES_set_odd_parity(key);
     DES_set_key_unchecked(key, &ks);
-    DES_cbc_cksum((const unsigned char *)str, key, (int)length, &ks, key);
+    DES_cbc_cksum((const unsigned char *)str, key, length, &ks, key);
     OPENSSL_cleanse(&ks, sizeof(ks));
     DES_set_odd_parity(key);
 }
@@ -80,9 +80,9 @@ void DES_string_to_2keys(const char *str, DES_cblock *key1, DES_cblock *key2)
     DES_set_odd_parity(key1);
     DES_set_odd_parity(key2);
     DES_set_key_unchecked(key1, &ks);
-    DES_cbc_cksum((const unsigned char *)str, key1, (int)length, &ks, key1);
+    DES_cbc_cksum((const unsigned char *)str, key1, length, &ks, key1);
     DES_set_key_unchecked(key2, &ks);
-    DES_cbc_cksum((const unsigned char *)str, key2, (int)length, &ks, key2);
+    DES_cbc_cksum((const unsigned char *)str, key2, length, &ks, key2);
     OPENSSL_cleanse(&ks, sizeof(ks));
     DES_set_odd_parity(key1);
     DES_set_odd_parity(key2);

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -570,7 +570,7 @@ char *ERR_error_string(unsigned long e, char *ret)
 
     if (ret == NULL)
         ret = buf;
-    ERR_error_string_n(e, ret, (int)sizeof(buf));
+    ERR_error_string_n(e, ret, sizeof(buf));
     return ret;
 }
 

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -1115,9 +1115,7 @@ int EVP_CIPHER_CTX_get_algor_params(EVP_CIPHER_CTX *ctx, X509_ALGOR *alg)
         params[i] = OSSL_PARAM_construct_octet_string(derk, der, derl);
         if (EVP_CIPHER_CTX_get_params(ctx, params)
             && OSSL_PARAM_modified(&params[i])
-            && d2i_ASN1_TYPE(&type, (const unsigned char **)&derp,
-                   (int)derl)
-                != NULL) {
+            && d2i_ASN1_TYPE(&type, (const unsigned char **)&derp, derl) != NULL) {
             /*
              * Don't free alg->parameter, see comment further up.
              * Worst case, alg->parameter gets assigned its own value.

--- a/crypto/txt_db/txt_db.c
+++ b/crypto/txt_db/txt_db.c
@@ -203,7 +203,7 @@ long TXT_DB_write(BIO *out, TXT_DB *db)
             if (pp[j] != NULL)
                 l += (long)strlen(pp[j]);
         }
-        if (!BUF_MEM_grow_clean(buf, (int)(l * 2 + nn)))
+        if (!BUF_MEM_grow_clean(buf, (l * 2 + nn)))
             goto err;
 
         p = buf->data;

--- a/crypto/ui/ui_lib.c
+++ b/crypto/ui/ui_lib.c
@@ -375,9 +375,9 @@ char *UI_construct_prompt(UI *ui, const char *phrase_desc,
 
         if (phrase_desc == NULL)
             return NULL;
-        len = sizeof(prompt1) - 1 + (int)strlen(phrase_desc);
+        len = sizeof(prompt1) - 1 + strlen(phrase_desc);
         if (object_name != NULL)
-            len += sizeof(prompt2) - 1 + (int)strlen(object_name);
+            len += sizeof(prompt2) - 1 + strlen(object_name);
         len += sizeof(prompt3) - 1;
 
         if ((prompt = OPENSSL_malloc(len + 1)) == NULL)

--- a/crypto/x509/v3_pci.c
+++ b/crypto/x509/v3_pci.c
@@ -202,7 +202,7 @@ static int process_pci_value(CONF_VALUE *val,
                 goto err;
             }
         } else if (CHECK_AND_SKIP_PREFIX(valp, "text:")) {
-            val_len = (int)strlen(valp);
+            val_len = strlen(valp);
             tmp_data = OPENSSL_realloc((*policy)->data,
                 (*policy)->length + val_len + 1);
             if (tmp_data) {

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha1_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha1_hw.c
@@ -634,7 +634,7 @@ static void aesni_cbc_hmac_sha1_set_mac_key(void *vctx,
 
     memset(hmac_key, 0, sizeof(hmac_key));
 
-    if (len > (int)sizeof(hmac_key)) {
+    if (len > sizeof(hmac_key)) {
         SHA1_Init(&ctx->head);
         sha1_update(&ctx->head, mac, len);
         SHA1_Final(hmac_key, &ctx->head);

--- a/providers/implementations/ciphers/cipher_rc4_hmac_md5_hw.c
+++ b/providers/implementations/ciphers/cipher_rc4_hmac_md5_hw.c
@@ -197,7 +197,7 @@ static void cipher_hw_rc4_hmac_md5_init_mackey(PROV_CIPHER_CTX *bctx,
 
     memset(hmac_key, 0, sizeof(hmac_key));
 
-    if (len > (int)sizeof(hmac_key)) {
+    if (len > sizeof(hmac_key)) {
         MD5_Init(&ctx->head);
         MD5_Update(&ctx->head, key, len);
         MD5_Final(hmac_key, &ctx->head);

--- a/providers/implementations/ciphers/ciphercommon_gcm.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c
@@ -522,7 +522,7 @@ static int gcm_tls_iv_set_fixed(PROV_GCM_CTX *ctx, unsigned char *iv,
     }
     /* Fixed field must be at least 4 bytes and invocation field at least 8 */
     if ((len < EVP_GCM_TLS_FIXED_IV_LEN)
-        || (ctx->ivlen - (int)len) < EVP_GCM_TLS_EXPLICIT_IV_LEN)
+        || (ctx->ivlen - len) < EVP_GCM_TLS_EXPLICIT_IV_LEN)
         return 0;
     if (len > 0)
         memcpy(ctx->iv, iv, len);

--- a/ssl/ech/ech_internal.c
+++ b/ssl/ech/ech_internal.c
@@ -521,7 +521,7 @@ int ossl_ech_encode_inner(SSL_CONNECTION *s, unsigned char **encoded,
     }
     /* now copy the rest, as "proper" exts, into encoded inner */
     for (ind = 0; ind < TLSEXT_IDX_num_builtins; ind++) {
-        if (raws[ind].present == 0 || ossl_ech_2bcompressed((int)ind) == 1)
+        if (raws[ind].present == 0 || ossl_ech_2bcompressed(ind) == 1)
             continue;
         if (!WPACKET_put_bytes_u16(&inner, raws[ind].type)
             || !WPACKET_sub_memcpy_u16(&inner, PACKET_data(&raws[ind].data),
@@ -646,9 +646,9 @@ size_t ossl_ech_calc_padding(SSL_CONNECTION *s, OSSL_ECHSTORE_ENTRY *ee,
         }
     }
     /* padding is after the inner client hello has been encoded */
-    length_with_snipadding = innersnipadding + (int)encoded_len;
+    length_with_snipadding = innersnipadding + encoded_len;
     length_of_padding = 31 - ((length_with_snipadding - 1) % 32);
-    length_with_padding = (int)encoded_len + length_of_padding
+    length_with_padding = encoded_len + length_of_padding
         + innersnipadding;
     /*
      * Finally - make sure final result is longer than padding target

--- a/ssl/ech/ech_store.c
+++ b/ssl/ech/ech_store.c
@@ -370,7 +370,7 @@ static int ech_decode_one_entry(OSSL_ECHSTORE_ENTRY **rent, PACKET *pkt,
         ERR_raise(ERR_LIB_SSL, SSL_R_ECH_DECODE_ERROR);
         goto err;
     }
-    ech_content_length = (unsigned int)PACKET_remaining(&ver_pkt);
+    ech_content_length = PACKET_remaining(&ver_pkt);
     switch (ee->version) {
     case OSSL_ECH_RFC9849_VERSION:
         break;

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4227,7 +4227,7 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
                     cptr[i] = TLSEXT_nid_unknown | clist[i];
             }
         }
-        return (int)clistlen;
+        return clistlen;
     }
 
     case SSL_CTRL_SET_GROUPS:
@@ -4359,14 +4359,14 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         if (sc->ext.peer_ecpointformats == NULL)
             return 0;
         *pformat = sc->ext.peer_ecpointformats;
-        return (int)sc->ext.peer_ecpointformats_len;
+        return sc->ext.peer_ecpointformats_len;
     }
 
     case SSL_CTRL_GET_IANA_GROUPS: {
         if (parg != NULL) {
             *(uint16_t **)parg = (uint16_t *)sc->ext.peer_supportedgroups;
         }
-        return (int)sc->ext.peer_supportedgroups_len;
+        return sc->ext.peer_supportedgroups_len;
     }
 
     case SSL_CTRL_SET_MSG_CALLBACK_ARG:

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3222,7 +3222,7 @@ long ossl_ctrl_internal(SSL *s, int cmd, long larg, void *parg, int no_quic)
             if (sc->s3.tmp.ciphers_raw == NULL)
                 return 0;
             *(unsigned char **)parg = sc->s3.tmp.ciphers_raw;
-            return (int)sc->s3.tmp.ciphers_rawlen;
+            return sc->s3.tmp.ciphers_rawlen;
         } else {
             return TLS_CIPHER_LEN;
         }

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1119,7 +1119,7 @@ int tls_construct_extensions(SSL_CONNECTION *s, WPACKET *pkt,
 
 #ifndef OPENSSL_NO_ECH
             /* do compressed in pass 0, non-compressed in pass 1 */
-            if (ossl_ech_2bcompressed((int)i) == pass)
+            if (ossl_ech_2bcompressed(i) == pass)
                 continue;
             /* stash index - needed for COMPRESS ECH handling */
             s->ext.ech.ext_ind = (int)i;

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -2848,7 +2848,7 @@ int tls_parse_stoc_ech(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
         return 0;
     }
     rval = PACKET_data(&rcfgs_pkt);
-    rlen = (unsigned int)PACKET_remaining(&rcfgs_pkt);
+    rlen = PACKET_remaining(&rcfgs_pkt);
     OPENSSL_free(s->ext.ech.returned);
     s->ext.ech.returned = NULL;
     srval = OPENSSL_malloc(rlen + 2);

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -402,8 +402,7 @@ int tls_parse_ctos_status_request(SSL_CONNECTION *s, PACKET *pkt,
         }
 
         id_data = PACKET_data(&responder_id);
-        id = d2i_OCSP_RESPID(NULL, &id_data,
-            (int)PACKET_remaining(&responder_id));
+        id = d2i_OCSP_RESPID(NULL, &id_data, PACKET_remaining(&responder_id));
         if (id == NULL) {
             SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_BAD_EXTENSION);
             return 0;
@@ -435,7 +434,7 @@ int tls_parse_ctos_status_request(SSL_CONNECTION *s, PACKET *pkt,
 
         sk_X509_EXTENSION_pop_free(s->ext.ocsp.exts,
             X509_EXTENSION_free);
-        s->ext.ocsp.exts = d2i_X509_EXTENSIONS(NULL, &ext_data, (int)PACKET_remaining(&exts));
+        s->ext.ocsp.exts = d2i_X509_EXTENSIONS(NULL, &ext_data, PACKET_remaining(&exts));
         if (s->ext.ocsp.exts == NULL || ext_data != PACKET_end(&exts)) {
             SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_BAD_EXTENSION);
             return 0;

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -258,7 +258,7 @@ int dtls1_do_write(SSL_CONNECTION *s, uint8_t type)
         /*
          * We just checked that s->init_num > 0 so this cast should be safe
          */
-        if (((unsigned int)s->init_num) > curr_mtu)
+        if (s->init_num > curr_mtu)
             len = curr_mtu;
         else
             len = s->init_num;
@@ -1227,12 +1227,12 @@ int dtls1_buffer_message(SSL_CONNECTION *s, int is_ccs)
     if (is_ccs) {
         /* For DTLS1_BAD_VER the header length is non-standard */
         if (!ossl_assert(s->d1->w_msg_hdr.msg_len + ((s->version == DTLS1_BAD_VER) ? 3 : DTLS1_CCS_HEADER_LENGTH)
-                == (unsigned int)s->init_num)) {
+                == s->init_num)) {
             dtls1_hm_fragment_free(frag);
             return 0;
         }
     } else {
-        if (!ossl_assert(s->d1->w_msg_hdr.msg_len + DTLS1_HM_HEADER_LENGTH == (unsigned int)s->init_num)) {
+        if (!ossl_assert(s->d1->w_msg_hdr.msg_len + DTLS1_HM_HEADER_LENGTH == s->init_num)) {
             dtls1_hm_fragment_free(frag);
             return 0;
         }
@@ -1437,7 +1437,7 @@ int dtls1_close_construct_packet(SSL_CONNECTION *s, WPACKET *pkt, int htype)
         s->d1->w_msg_hdr.msg_len = msglen - DTLS1_HM_HEADER_LENGTH;
         s->d1->w_msg_hdr.frag_len = msglen - DTLS1_HM_HEADER_LENGTH;
     }
-    s->init_num = (int)msglen;
+    s->init_num = msglen;
     s->init_off = 0;
 
     if (htype != DTLS1_MT_HELLO_VERIFY_REQUEST) {

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -132,7 +132,7 @@ int tls_close_construct_packet(SSL_CONNECTION *s, WPACKET *pkt, int htype)
         || !WPACKET_get_length(pkt, &msglen)
         || msglen > INT_MAX)
         return 0;
-    s->init_num = (int)msglen;
+    s->init_num = msglen;
     s->init_off = 0;
 
     return 1;


### PR DESCRIPTION
Hello everynyan,
enabling compiler warning made it possible to identify many very dangerous type memsize truncations, perhaps these are remnants of the old 32bit code, since most everything is already compiled for 64bit platforms.

## More info about memsize truncation
Memsize truncation is a potentially dangerous operation that occurs very often when porting code from 32-bit systems to 64-bit systems.
In 64-bit mode, memsize type stores a large value (for example, a memory address > 4 GB). When converting it to a 32-bit type (for example, int), the upper 32 bits are discarded (truncated), which leads to data loss and an incorrect value.