### PR TITLE
move scripts script_3 and script_4 from multistream test to RADIX tests

### DIFF
--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2181,53 +2181,13 @@ static const struct script_op script_2[] = {
 
 /* 3. Default stream detach/reattach test */
 static const struct script_op script_3[] = {
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-
-    OP_C_WRITE(DEFAULT, "apple", 5),
-    OP_C_DETACH(a), /* DEFAULT becomes stream 'a' */
-    OP_C_WRITE_FAIL(DEFAULT),
-
-    OP_C_WRITE(a, "by", 2),
-
-    OP_S_BIND_STREAM_ID(a, C_BIDI_ID(0)),
-    OP_S_READ_EXPECT(a, "appleby", 7),
-
-    OP_S_WRITE(a, "hello", 5),
-    OP_C_READ_EXPECT(a, "hello", 5),
-
-    OP_C_WRITE_FAIL(DEFAULT),
-    OP_C_ATTACH(a),
-    OP_C_WRITE(DEFAULT, "is here", 7),
-    OP_S_READ_EXPECT(a, "is here", 7),
-
-    OP_C_DETACH(a),
-    OP_C_CONCLUDE(a),
-    OP_S_EXPECT_FIN(a),
-
+    /* script moved to detach_attach_stream in test/radix/quic_tests.c */
     OP_END
 };
 
 /* 4. Default stream mode test */
 static const struct script_op script_4[] = {
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-
-    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_NONE),
-    OP_C_WRITE_FAIL(DEFAULT),
-
-    OP_S_NEW_STREAM_BIDI(a, S_BIDI_ID(0)),
-    OP_S_WRITE(a, "apple", 5),
-
-    OP_C_READ_FAIL(DEFAULT),
-
-    OP_C_ACCEPT_STREAM_WAIT(a),
-    OP_C_READ_EXPECT(a, "apple", 5),
-
-    OP_C_ATTACH(a),
-    OP_C_WRITE(DEFAULT, "orange", 6),
-    OP_S_READ_EXPECT(a, "orange", 6),
-
+    /* script moved to default_stream_mode in test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/radix/quic_ops.c
+++ b/test/radix/quic_ops.c
@@ -750,21 +750,28 @@ err:
 DEF_FUNC(hf_detach)
 {
     int ok = 0;
-    const char *conn_name, *stream_name;
+    const char *stream_name;
     SSL *conn, *stream;
 
-    F_POP2(conn_name, stream_name);
-    if (!TEST_ptr(conn = RADIX_PROCESS_get_ssl(RP(), conn_name)))
-        goto err;
+    REQUIRE_SSL(conn);
 
     if (!TEST_ptr(stream = ossl_quic_detach_stream(conn)))
         goto err;
 
+    F_POP(stream_name);
     if (!TEST_true(RADIX_PROCESS_set_ssl(RP(), stream_name, stream))) {
         SSL_free(stream);
         goto err;
     }
-
+    /*
+     * Obtain reference for RADIX_PROCESS_set_ssl()
+     * the OP_unbind() we do later in hf_attach()
+     * calls SSL_free().
+     */
+    if (!TEST_true(SSL_up_ref(stream))) {
+        SSL_free(stream);
+        goto err;
+    }
     ok = 1;
 err:
     return ok;
@@ -773,21 +780,26 @@ err:
 DEF_FUNC(hf_attach)
 {
     int ok = 0;
-    const char *conn_name, *stream_name;
+    const char *stream_name;
     SSL *conn, *stream;
 
-    F_POP2(conn_name, stream_name);
+    REQUIRE_SSL(conn);
 
-    if (!TEST_ptr(conn = RADIX_PROCESS_get_ssl(RP(), conn_name)))
-        goto err;
-
+    F_POP(stream_name);
     if (!TEST_ptr(stream = RADIX_PROCESS_get_ssl(RP(), stream_name)))
         goto err;
 
-    if (!TEST_true(ossl_quic_attach_stream(conn, stream)))
-        goto err;
+    /*
+     * unbind, calls SSL_free() on stream we've retreived via
+     * RADIX_PROCESS_get_ssl() above.
+     */
+    RADIX_PROCESS_set_obj(RP(), stream_name, NULL);
 
-    if (!TEST_true(RADIX_PROCESS_set_ssl(RP(), stream_name, NULL)))
+    /*
+     * stream has one reference now. And this is good, because
+     * _attach_stream() below fails when refcount on stream is not 1.
+     */
+    if (!TEST_true(ossl_quic_attach_stream(conn, stream)))
         goto err;
 
     ok = 1;
@@ -1178,7 +1190,7 @@ err:
 #define OP_READ_EXPECT_B(name, buf) \
     OP_READ_EXPECT(name, (buf), sizeof(buf))
 
-#define OP_READ_FAIL()       \
+#define OP_READ_FAIL(name)       \
     (OP_SELECT_SSL(0, name), \
         OP_PUSH_U64(0),      \
         OP_FUNC(hf_read_fail))
@@ -1222,7 +1234,7 @@ err:
 
 #define OP_ATTACH(conn_name, stream_name) \
     (OP_SELECT_SSL(0, conn_name),         \
-        OP_PUSH_PZ(stream_name),          \
+        OP_PUSH_PZ(#stream_name),          \
         OP_FUNC(hf_attach))
 
 #define OP_EXPECT_FIN(name)  \

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -22,6 +22,80 @@
  * ============================================================================
  */
 
+DEF_SCRIPT(detach_attach_stream, "test detach/attach stream private API")
+{
+    OP_SIMPLE_PAIR_CONN();
+    OP_ACCEPT_CONN_WAIT(L, S, 0);
+
+    OP_WRITE_B(C, "apple");
+    OP_DETACH(C, C0); /* DEFAULT becomes stream 'C0' */
+    OP_WRITE_FAIL(C);
+
+    OP_WRITE_B(C0, "by");
+
+    /*
+     * OP_WRITE_B() writes string with NUL string terminator,
+     * hence the expected buffer is apple\0by
+     */
+    OP_READ_EXPECT_B(S, "apple\x00""by");
+
+    OP_WRITE_B(S, "hello");
+    OP_READ_EXPECT_B(C0, "hello");
+
+    OP_WRITE_FAIL(C);
+    OP_ATTACH(C, C0);
+    OP_WRITE_B(C, "is here");
+    OP_READ_EXPECT_B(S, "is here");
+
+    OP_DETACH(C, C0);
+    OP_CONCLUDE(C0);
+    OP_EXPECT_FIN(S);
+}
+
+DEF_FUNC(ssl_upref)
+{
+    int ok = 0;
+    SSL *ssl;
+
+    REQUIRE_SSL(ssl);
+    if (!TEST_true(SSL_up_ref(ssl)))
+        goto err;
+
+    ok = 1;
+err:
+    return ok;
+}
+
+DEF_SCRIPT(default_stream_mode, "Default stream mode test")
+{
+    OP_SIMPLE_PAIR_CONN_ND();
+    OP_ACCEPT_CONN_WAIT(L, S, 0);
+
+    OP_SET_DEFAULT_STREAM_MODE(C, SSL_DEFAULT_STREAM_MODE_NONE);
+    OP_WRITE_FAIL(C);
+    OP_NEW_STREAM(C, C0, 0);
+    OP_WRITE_B(S, "apple");
+
+    OP_READ_FAIL(C);
+
+    OP_ACCEPT_STREAM_WAIT(C, C1, 0);
+    OP_READ_EXPECT_B(C1, "apple");
+
+    /*
+     * The OP_ATTACH() assumes the C1 comes from OP_DETACH() operation.
+     * QUIC stream objects which come from OP_DETACH() have two references
+     *   - one reference to keep SSL object bound to radix process (RP)
+     *   - the other reference for object itself
+     * The OP_ATTACH() always unbinds QUIC stream object C1 from radix process
+     * therefore it needs the reference.
+     */
+    OP_SELECT_SSL(0, C1);
+    OP_FUNC(ssl_upref);
+    OP_ATTACH(C, C1);
+    OP_WRITE_B(C, "orange");
+    OP_READ_EXPECT_B(S, "orange");
+}
+
 /*
  * Test: simple_conn
  * -----------------
@@ -299,8 +373,14 @@ DEF_SCRIPT(check_cwm, "check stream obeys cwm")
  * ============================================================================
  */
 static SCRIPT_INFO *const scripts[] = {
+#if 0
+    USE(detach_attach_stream),
+#endif
+    USE(default_stream_mode),
+#if 0
     USE(simple_conn),
     USE(simple_thread),
     USE(ssl_poll),
     USE(check_cwm)
+#endif
 };


### PR DESCRIPTION
Both tests test SSL_attach_stream()/SSL_detach_stream() functions which are no longer part of public API.

Also the attach/detach functionality is currently used by test itself, no one else is using it.
it makes sense to remove the code.

This PR is draft and is going to stay in draft. As the change which moves script_3 and script_4 from multistream
to RADIX is useful exercise to better understand internals of radix test framework.

