### PR TITLE
Fixed missing pointers in SSL_CTX_set_session_cache_mode synopsis

### DIFF
--- a/doc/man3/SSL_CTX_set_session_cache_mode.pod
+++ b/doc/man3/SSL_CTX_set_session_cache_mode.pod
@@ -8,8 +8,8 @@ SSL_CTX_set_session_cache_mode, SSL_CTX_get_session_cache_mode - enable/disable 
 
  #include <openssl/ssl.h>
 
- long SSL_CTX_set_session_cache_mode(SSL_CTX ctx, long mode);
- long SSL_CTX_get_session_cache_mode(SSL_CTX ctx);
+ long SSL_CTX_set_session_cache_mode(SSL_CTX *ctx, long mode);
+ long SSL_CTX_get_session_cache_mode(SSL_CTX *ctx);
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
SSL_CTX_set_session_cache_mode and SSL_CTX_get_session_cache_mode were documented with SSL_CTX ctx instead of SSL_CTX *ctx in their synopsis.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
