### PR TITLE
Fix buffer overflow in kem_name using width limiter

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3739,7 +3739,7 @@ int speed_main(int argc, char **argv)
 
             /* no string after rsa<bitcnt> permitted: */
             if (strlen(kem_name) < MAX_ALGNAME_SUFFIX + 4 /* rsa+digit */
-                && sscanf(kem_name, "rsa%u%s", &bits, sfx) == 1)
+                && sscanf(kem_name, "rsa%u%99s", &bits, sfx) == 1)
                 kem_type = KEM_RSA;
             else if (strncmp(kem_name, "EC", 2) == 0)
                 kem_type = KEM_EC;
@@ -3938,7 +3938,7 @@ int speed_main(int argc, char **argv)
 
             /* no string after rsa<bitcnt> permitted: */
             if (strlen(sig_name) < MAX_ALGNAME_SUFFIX + 4 /* rsa+digit */
-                && sscanf(sig_name, "rsa%u%s", &bits, sfx) == 1) {
+                && sscanf(sig_name, "rsa%u%99s", &bits, sfx) == 1) {
                 params[0] = OSSL_PARAM_construct_uint(OSSL_PKEY_PARAM_RSA_BITS,
                     &bits);
                 use_params = 1;


### PR DESCRIPTION
This is an uncritical flaw is not included in openssl core.
In lines 3742 and 3942 sscanf function %s specifier was used without specifying width. This could lead to an overflow sfx buffer.
I added %99s width limiter to prevent this, based on define macro MAX_ALGNAME_SUFFIX buffer size, which is 100

https://github.com/openssl/openssl/blob/7fb28b9cd05ba89cbbe038dfa85804fe22bc146a/apps/speed.c#L3741-L3745

https://github.com/openssl/openssl/blob/7fb28b9cd05ba89cbbe038dfa85804fe22bc146a/apps/speed.c#L3940-L3946
