### PR TITLE
Fix format types for printf in crypto and apps

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -24,6 +24,7 @@
 #include <openssl/comp.h>
 #endif
 #include <ctype.h>
+#include <inttypes.h>
 
 #undef SIZE
 #undef BSIZE
@@ -826,8 +827,8 @@ int enc_main(int argc, char **argv)
 
     ret = 0;
     if (verbose) {
-        BIO_printf(bio_err, "bytes read   : %8ju\n"
-                            "bytes written: %8ju\n",
+        BIO_printf(bio_err, "bytes read   : %8" PRIu64 "\n"
+                            "bytes written: %8" PRIu64 "\n",
             BIO_number_read(in), BIO_number_written(out));
     }
 end:

--- a/apps/lib/app_params.c
+++ b/apps/lib/app_params.c
@@ -56,7 +56,7 @@ static int describe_param_type(char *buf, size_t bufsz, const OSSL_PARAM *param)
         bufsz -= printed_len;
     }
     if (show_type_number) {
-        printed_len = BIO_snprintf(buf, bufsz, " [%d]", param->data_type);
+        printed_len = BIO_snprintf(buf, bufsz, " [%u]", param->data_type);
         if (printed_len > 0) {
             buf += printed_len;
             bufsz -= printed_len;

--- a/apps/rand.c
+++ b/apps/rand.c
@@ -159,7 +159,7 @@ int rand_main(int argc, char **argv)
         if (shift != 0) {
             /* check for overflow */
             if ((UINT64_MAX >> shift) < (size_t)num) {
-                BIO_printf(bio_err, "%lu bytes with suffix overflows\n",
+                BIO_printf(bio_err, "%ld bytes with suffix overflows\n",
                     num);
                 goto opthelp;
             }

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -9,6 +9,7 @@
  */
 
 #include "internal/e_os.h"
+#include <inttypes.h>
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -186,7 +187,7 @@ static unsigned int psk_client_cb(SSL *ssl, const char *hint, char *identity,
     }
     if (max_psk_len > INT_MAX || key_len > (long)max_psk_len) {
         BIO_printf(bio_err,
-            "psk buffer of callback is too small (%d) for key (%ld)\n",
+            "psk buffer of callback is too small (%u) for key (%ld)\n",
             max_psk_len, key_len);
         OPENSSL_free(key);
         return 0;
@@ -340,7 +341,7 @@ static int serverinfo_cli_parse_cb(SSL *s, unsigned int ext_type,
     ext_buf[3] = (unsigned char)(inlen);
     memcpy(ext_buf + 4, in, inlen);
 
-    BIO_snprintf(pem_name, sizeof(pem_name), "SERVERINFO FOR EXTENSION %d",
+    BIO_snprintf(pem_name, sizeof(pem_name), "SERVERINFO FOR EXTENSION %u",
         ext_type);
     PEM_write_bio(bio_c_out, pem_name, "", ext_buf, (long)(4 + inlen));
     return 1;
@@ -1706,7 +1707,7 @@ int s_client_main(int argc, char **argv)
                 break;
             default:
                 BIO_printf(bio_err,
-                    "%s: Max Fragment Len %u is out of permitted values",
+                    "%s: Max Fragment Len %d is out of permitted values",
                     prog, len);
                 goto opthelp;
             }
@@ -3844,8 +3845,8 @@ static void print_stuff(BIO *bio, SSL *s, int full)
 #endif
 
         BIO_printf(bio,
-            "---\nSSL handshake has read %ju bytes "
-            "and written %ju bytes\n",
+            "---\nSSL handshake has read %" PRIu64 " bytes "
+            "and written %" PRIu64 " bytes\n",
             BIO_number_read(SSL_get_rbio(s)),
             BIO_number_written(SSL_get_wbio(s)));
     }

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -209,7 +209,7 @@ static unsigned int psk_server_cb(SSL *ssl, const char *identity,
     }
     if (key_len > (int)max_psk_len) {
         BIO_printf(bio_err,
-            "psk buffer of callback is too small (%d) for key (%ld)\n",
+            "psk buffer of callback is too small (%u) for key (%ld)\n",
             max_psk_len, key_len);
         OPENSSL_free(key);
         return 0;

--- a/crypto/asn1/x_int64.c
+++ b/crypto/asn1/x_int64.c
@@ -8,6 +8,7 @@
  */
 
 #include <stdio.h>
+#include <inttypes.h>
 #include "internal/cryptlib.h"
 #include "internal/numbers.h"
 #include <openssl/asn1t.h>
@@ -113,8 +114,8 @@ static int uint64_print(BIO *out, const ASN1_VALUE **pval, const ASN1_ITEM *it,
     int indent, const ASN1_PCTX *pctx)
 {
     if ((it->size & INTxx_FLAG_SIGNED) == INTxx_FLAG_SIGNED)
-        return BIO_printf(out, "%jd\n", **(int64_t **)pval);
-    return BIO_printf(out, "%ju\n", **(uint64_t **)pval);
+        return BIO_printf(out, "%" PRId64 "\n", **(int64_t **)pval);
+    return BIO_printf(out, "%" PRIu64 "\n", **(uint64_t **)pval);
 }
 
 /* 32-bit variants */

--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -10,6 +10,7 @@
  */
 
 #include "cmp_local.h"
+#include <inttypes.h>
 
 #define IS_CREP(t) ((t) == OSSL_CMP_PKIBODY_IP || (t) == OSSL_CMP_PKIBODY_CP \
     || (t) == OSSL_CMP_PKIBODY_KUP)
@@ -309,7 +310,7 @@ static int poll_for_response(OSSL_CMP_CTX *ctx, int sleep, int rid,
             }
             if (check_after < 0 || (uint64_t)check_after > (sleep ? ULONG_MAX / 1000 : INT_MAX)) {
                 ERR_raise(ERR_LIB_CMP, CMP_R_CHECKAFTER_OUT_OF_RANGE);
-                if (BIO_snprintf(str, OSSL_CMP_PKISI_BUFLEN, "value = %jd",
+                if (BIO_snprintf(str, OSSL_CMP_PKISI_BUFLEN, "value = %" PRId64,
                         check_after)
                     >= 0)
                     ERR_add_error_data(1, str);

--- a/crypto/ocsp/ocsp_prn.c
+++ b/crypto/ocsp/ocsp_prn.c
@@ -98,7 +98,7 @@ int OCSP_REQUEST_print(BIO *bp, OCSP_REQUEST *o, unsigned long flags)
     if (BIO_write(bp, "OCSP Request Data:\n", 19) <= 0)
         goto err;
     l = ASN1_INTEGER_get(inf->version);
-    if (BIO_printf(bp, "    Version: %lu (0x%lx)", l + 1, l) <= 0)
+    if (BIO_printf(bp, "    Version: %ld (0x%lx)", l + 1, l) <= 0)
         goto err;
     if (inf->requestorName != NULL) {
         if (BIO_write(bp, "\n    Requestor Name: ", 21) <= 0)
@@ -166,7 +166,7 @@ int OCSP_RESPONSE_print(BIO *bp, OCSP_RESPONSE *o, unsigned long flags)
         goto err;
     rd = &br->tbsResponseData;
     l = ASN1_INTEGER_get(rd->version);
-    if (BIO_printf(bp, "\n    Version: %lu (0x%lx)\n", l + 1, l) <= 0)
+    if (BIO_printf(bp, "\n    Version: %ld (0x%lx)\n", l + 1, l) <= 0)
         goto err;
     if (BIO_puts(bp, "    Responder Id: ") <= 0)
         goto err;

--- a/ssl/ssl_txt.c
+++ b/ssl/ssl_txt.c
@@ -104,7 +104,7 @@ int SSL_SESSION_print(BIO *bp, const SSL_SESSION *x)
 #endif
     if (x->ext.tick_lifetime_hint) {
         if (BIO_printf(bp,
-                "\n    TLS session ticket lifetime hint: %ld (seconds)",
+                "\n    TLS session ticket lifetime hint: %lu (seconds)",
                 x->ext.tick_lifetime_hint)
             <= 0)
             goto err;
@@ -123,7 +123,7 @@ int SSL_SESSION_print(BIO *bp, const SSL_SESSION *x)
         if (!ssl_cipher_get_evp(NULL, x, NULL, NULL, NULL, NULL, &comp, 0))
             goto err;
         if (comp == NULL) {
-            if (BIO_printf(bp, "\n    Compression: %d", x->compress_meth) <= 0)
+            if (BIO_printf(bp, "\n    Compression: %u", x->compress_meth) <= 0)
                 goto err;
         } else {
             if (BIO_printf(bp, "\n    Compression: %d (%s)", comp->id,


### PR DESCRIPTION
inttypes.h is also used for more accurate compatibility with all platforms, as it is the more correct choice according to C standard.