### PR TITLE
Fix heap corruption in double free element property

### DIFF
--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -1318,7 +1318,8 @@ static ossl_inline int ossl_method_store_cache_set_locked(OSSL_METHOD_STORE *sto
     }
 err:
     res = 0;
-    OPENSSL_free(p);
+    if (p != NULL)
+        OPENSSL_free(p);
 end:
 #ifndef ALLOW_VLA
     OPENSSL_free(keybuf);


### PR DESCRIPTION
Call impl_cache_free(p) in 1284 line free p elem and `goto label err:` also free again p elem

References:
- https://owasp.org/www-community/vulnerabilities/Doubly_freeing_memory
- https://www.quora.com/What-is-the-problem-of-double-free-in-C-programming-Can-you-give-an-example