### PR TITLE
server: client: fix possible memleak on BIO allocation failed

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1968,6 +1968,12 @@ int s_client_main(int argc, char **argv)
     if (bio_c_out == NULL) {
         if (c_quiet && !c_debug) {
             bio_c_out = BIO_new(BIO_s_null());
+
+            if (bio_c_out == NULL) {
+                BIO_puts(bio_err, "Out of memory\n");
+                goto end;
+            }
+
             if (c_msg && bio_c_msg == NULL) {
                 bio_c_msg = dup_bio_out(FORMAT_TEXT);
                 if (bio_c_msg == NULL) {

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -2585,6 +2585,12 @@ int s_server_main(int argc, char *argv[])
     if (bio_s_out == NULL) {
         if (s_quiet && !s_debug) {
             bio_s_out = BIO_new(BIO_s_null());
+
+            if (bio_s_out == NULL) {
+                BIO_puts(bio_err, "Out of memory\n");
+                goto end;
+            }
+
             if (s_msg && bio_s_msg == NULL) {
                 bio_s_msg = dup_bio_out(FORMAT_TEXT);
                 if (bio_s_msg == NULL) {


### PR DESCRIPTION
In other places of the code OpenSSL, pointer BIO_new() is checked everywhere, there may be a typo here and bio messages are checked. Although first of all it is very necessary to check the pointer of the selected alloc object.