### PR TITLE
Fix integer overflow due to incorrect cast size_t type

### DIFF
--- a/ssl/quic/quic_port.c
+++ b/ssl/quic/quic_port.c
@@ -1092,7 +1092,7 @@ static int decrypt_validation_token(const QUIC_PORT *port,
         goto err;
 
     /* Prevent decryption of a buffer that is not within reasonable bounds */
-    if (ct_len < (size_t)(iv_len + tag_len) || ct_len > ENCRYPTED_TOKEN_MAX_LEN)
+    if (ct_len < (size_t)iv_len + tag_len || ct_len > ENCRYPTED_TOKEN_MAX_LEN)
         goto err;
 
     *pt_len = ct_len - iv_len - tag_len;

--- a/ssl/record/methods/tls13_meth.c
+++ b/ssl/record/methods/tls13_meth.c
@@ -236,7 +236,7 @@ static int tls13_cipher(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *recs,
                (unsigned int)rec->length)
             <= 0
         || EVP_CipherFinal_ex(enc_ctx, rec->data + lenu, &lenf) <= 0
-        || (size_t)(lenu + lenf) != rec->length) {
+        || (size_t)lenu + lenf != rec->length) {
         return 0;
     }
     if (sending) {


### PR DESCRIPTION
Fixed possible integer overflow instead of reducing the sum (lenu + lenf) to size_t, now each operand of lenu and lenf is reduced to size_t before addition to avoid int overflow.