### PR TITLE
Initalize arrays to protect against access to uninitialized data

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -4656,7 +4656,7 @@ static void multiblock_speed(const EVP_CIPHER *evp_cipher, int lengths_single,
     const int *mblengths = mblengths_list;
     int j, count, keylen, num = OSSL_NELEM(mblengths_list), ciph_success = 1;
     const char *alg_name;
-    unsigned char *inp = NULL, *out = NULL, *key, no_key[32], no_iv[16];
+    unsigned char *inp = NULL, *out = NULL, *key, no_key[32] = {0}, no_iv[16] = {0};
     EVP_CIPHER_CTX *ctx = NULL;
     double d = 0.0;
 

--- a/crypto/asn1/p5_pbev2.c
+++ b/crypto/asn1/p5_pbev2.c
@@ -56,7 +56,7 @@ X509_ALGOR *PKCS5_pbe2_set_iv_ex(const EVP_CIPHER *cipher, int iter,
     X509_ALGOR *scheme = NULL, *ret = NULL;
     int alg_nid, keylen, ivlen;
     EVP_CIPHER_CTX *ctx = NULL;
-    unsigned char iv[EVP_MAX_IV_LENGTH];
+    unsigned char iv[EVP_MAX_IV_LENGTH] = {0};
     PBE2PARAM *pbe2 = NULL;
 
     alg_nid = EVP_CIPHER_get_type(cipher);

--- a/crypto/asn1/p5_scrypt.c
+++ b/crypto/asn1/p5_scrypt.c
@@ -49,7 +49,7 @@ X509_ALGOR *PKCS5_pbe2_set_scrypt(const EVP_CIPHER *cipher,
     int alg_nid, ivlen;
     size_t keylen = 0;
     EVP_CIPHER_CTX *ctx = NULL;
-    unsigned char iv[EVP_MAX_IV_LENGTH];
+    unsigned char iv[EVP_MAX_IV_LENGTH] = {0};
     PBE2PARAM *pbe2 = NULL;
 
     if (!cipher) {

--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -309,8 +309,8 @@ BIO *PKCS7_dataInit(PKCS7 *p7, BIO *bio)
         goto err;
 
     if (evp_cipher != NULL) {
-        unsigned char key[EVP_MAX_KEY_LENGTH];
-        unsigned char iv[EVP_MAX_IV_LENGTH];
+        unsigned char key[EVP_MAX_KEY_LENGTH] = {0};
+        unsigned char iv[EVP_MAX_IV_LENGTH] = {0};
         int keylen, ivlen;
         EVP_CIPHER_CTX *ctx;
 

--- a/crypto/slh_dsa/slh_dsa.c
+++ b/crypto/slh_dsa/slh_dsa.c
@@ -48,7 +48,7 @@ static int slh_sign_internal(SLH_DSA_HASH_CTX *hctx,
     const SLH_DSA_KEY *priv = hctx->key;
     const SLH_DSA_PARAMS *params = priv->params;
     size_t sig_len_expected = params->sig_len;
-    uint8_t m_digest[SLH_MAX_M];
+    uint8_t m_digest[SLH_MAX_M] = {0};
     const uint8_t *md; /* The first md_len bytes of m_digest */
     size_t md_len = MD_LEN(params); /* The size of the digest |md| */
     /* Points to |m_digest| buffer, it is also reused to point to |sig_fors| */

--- a/providers/implementations/signature/dsa_sig.c
+++ b/providers/implementations/signature/dsa_sig.c
@@ -390,7 +390,7 @@ static int dsa_sign_message_final(void *vpdsactx, unsigned char *sig,
     size_t *siglen, size_t sigsize)
 {
     PROV_DSA_CTX *pdsactx = (PROV_DSA_CTX *)vpdsactx;
-    unsigned char digest[EVP_MAX_MD_SIZE];
+    unsigned char digest[EVP_MAX_MD_SIZE] = {0};
     unsigned int dlen = 0;
 
     if (!ossl_prov_is_running() || pdsactx == NULL || pdsactx->mdctx == NULL)

--- a/providers/implementations/signature/ecdsa_sig.c
+++ b/providers/implementations/signature/ecdsa_sig.c
@@ -411,7 +411,7 @@ static int ecdsa_sign_message_final(void *vctx, unsigned char *sig,
     size_t *siglen, size_t sigsize)
 {
     PROV_ECDSA_CTX *ctx = (PROV_ECDSA_CTX *)vctx;
-    unsigned char digest[EVP_MAX_MD_SIZE];
+    unsigned char digest[EVP_MAX_MD_SIZE] = {0};
     unsigned int dlen = 0;
 
     if (!ossl_prov_is_running() || ctx == NULL)

--- a/providers/implementations/signature/ml_dsa_sig.c
+++ b/providers/implementations/signature/ml_dsa_sig.c
@@ -256,7 +256,7 @@ static int ml_dsa_sign_msg_final(void *vctx, unsigned char *sig,
 {
     PROV_ML_DSA_CTX *ctx = (PROV_ML_DSA_CTX *)vctx;
     uint8_t rand_tmp[ML_DSA_ENTROPY_LEN], *rnd = NULL;
-    uint8_t mu[ML_DSA_MU_BYTES];
+    uint8_t mu[ML_DSA_MU_BYTES] = {0};
     int ret = 0;
 
     if (ctx == NULL)

--- a/providers/implementations/signature/rsa_sig.c
+++ b/providers/implementations/signature/rsa_sig.c
@@ -856,7 +856,7 @@ static int rsa_sign_message_final(void *vprsactx, unsigned char *sig,
     size_t *siglen, size_t sigsize)
 {
     PROV_RSA_CTX *prsactx = (PROV_RSA_CTX *)vprsactx;
-    unsigned char digest[EVP_MAX_MD_SIZE];
+    unsigned char digest[EVP_MAX_MD_SIZE] = {0};
     unsigned int dlen = 0;
 
     if (!ossl_prov_is_running() || prsactx == NULL)

--- a/providers/implementations/signature/sm2_sig.c
+++ b/providers/implementations/signature/sm2_sig.c
@@ -298,7 +298,7 @@ int sm2sig_digest_sign_final(void *vpsm2ctx, unsigned char *sig, size_t *siglen,
     size_t sigsize)
 {
     PROV_SM2_CTX *psm2ctx = (PROV_SM2_CTX *)vpsm2ctx;
-    unsigned char digest[EVP_MAX_MD_SIZE];
+    unsigned char digest[EVP_MAX_MD_SIZE] = {0};
     unsigned int dlen = 0;
 
     if (psm2ctx == NULL || psm2ctx->mdctx == NULL)

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -4268,7 +4268,7 @@ static CON_FUNC_RETURN construct_stateless_ticket(SSL_CONNECTION *s,
     size_t hlen;
     SSL_CTX *tctx = s->session_ctx;
     unsigned char iv[EVP_MAX_IV_LENGTH];
-    unsigned char key_name[TLSEXT_KEYNAME_LENGTH];
+    unsigned char key_name[TLSEXT_KEYNAME_LENGTH] = {0};
     int iv_len;
     CON_FUNC_RETURN ok = CON_FUNC_ERROR;
     size_t macoffset, macendoffset;


### PR DESCRIPTION
Reference:
- https://stackoverflow.com/questions/21442539/misra-9-2-initializing-float-and-unsigned-arrays
