### PR TITLE
ISSUE-30831: Add X25519 scalar mode key parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,13 @@ OpenSSL Releases
 
    *Jakub Zelenka*
 
+ * Added an advanced X25519 key parameter, `x25519-scalar-mode`, to control
+   private scalar preprocessing. The default remains RFC 7748 clamping; the
+   additional `legacy-ed25519-compat` and `raw-unclamped` modes are available
+   in the default provider for specialized interoperability workflows.
+
+   *John Claus*
+
  * Improved DTLS handshake robustness under UDP reordering by buffering and
    replaying early ChangeCipherSpec (CCS) records at the expected state.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -227,6 +227,13 @@ OpenSSL 4.1
 
    *Bob Beck*
 
+ * Added an advanced X25519 key parameter, `x25519-scalar-mode`, to control
+   private scalar preprocessing. The default remains RFC 7748 clamping; the
+   additional `legacy-ed25519-compat` and `raw-unclamped` modes are available
+   in the default provider for specialized interoperability workflows.
+
+   *John Claus*
+
  * Improved DTLS handshake robustness under UDP reordering by buffering and
    replaying early ChangeCipherSpec (CCS) records at the expected state.
 

--- a/crypto/ec/curve25519.c
+++ b/crypto/ec/curve25519.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -20,6 +20,28 @@
 #include <openssl/sha.h>
 
 #include "internal/numbers.h"
+
+static ossl_inline void ossl_x25519_clamp_private(uint8_t e[32],
+    OSSL_X25519_SCALAR_MODE scalar_mode)
+{
+    /* Bit 255 always cleared: 254-bit scalar is required by the ladder. */
+    e[31] &= 0x7f;
+    switch (scalar_mode) {
+    case OSSL_X25519_SCALAR_MODE_RFC7748:
+        e[0] &= 0xf8;
+        e[31] |= 0x40;
+        break;
+    case OSSL_X25519_SCALAR_MODE_LEGACY_ED25519_COMPAT:
+        e[0] &= 0xf8;
+        break;
+    case OSSL_X25519_SCALAR_MODE_RAW_UNCLAMPED:
+        break;
+    default:
+        e[0] &= 0xf8;
+        e[31] |= 0x40;
+        break;
+    }
+}
 
 #if defined(X25519_ASM) && (defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64))
 
@@ -208,7 +230,7 @@ static void fe64_invert(fe64 out, const fe64 z)
  * fe64_* subroutines.
  */
 static void x25519_scalar_mulx(uint8_t out[32], const uint8_t scalar[32],
-    const uint8_t point[32])
+    const uint8_t point[32], OSSL_X25519_SCALAR_MODE scalar_mode)
 {
     fe64 x1, x2, z2, x3, z3, tmp0, tmp1;
     uint8_t e[32];
@@ -216,9 +238,7 @@ static void x25519_scalar_mulx(uint8_t out[32], const uint8_t scalar[32],
     int pos;
 
     memcpy(e, scalar, 32);
-    e[0] &= 0xf8;
-    e[31] &= 0x7f;
-    e[31] |= 0x40;
+    ossl_x25519_clamp_private(e, scalar_mode);
     fe64_frombytes(x1, point);
     fe64_1(x2);
     fe64_0(z2);
@@ -725,7 +745,7 @@ static void fe51_invert(fe51 out, const fe51 z)
  * fe51_* subroutines.
  */
 static void x25519_scalar_mult(uint8_t out[32], const uint8_t scalar[32],
-    const uint8_t point[32])
+    const uint8_t point[32], OSSL_X25519_SCALAR_MODE scalar_mode)
 {
     fe51 x1, x2, z2, x3, z3, tmp0, tmp1;
     uint8_t e[32];
@@ -734,15 +754,13 @@ static void x25519_scalar_mult(uint8_t out[32], const uint8_t scalar[32],
 
 #ifdef BASE_2_64_IMPLEMENTED
     if (x25519_fe64_eligible()) {
-        x25519_scalar_mulx(out, scalar, point);
+        x25519_scalar_mulx(out, scalar, point, scalar_mode);
         return;
     }
 #endif
 
     memcpy(e, scalar, 32);
-    e[0] &= 0xf8;
-    e[31] &= 0x7f;
-    e[31] |= 0x40;
+    ossl_x25519_clamp_private(e, scalar_mode);
     fe51_frombytes(x1, point);
     fe51_1(x2);
     fe51_0(z2);
@@ -4523,7 +4541,8 @@ static void fe_mul121666(fe h, fe f)
 
 static void x25519_scalar_mult_generic(uint8_t out[32],
     const uint8_t scalar[32],
-    const uint8_t point[32])
+    const uint8_t point[32],
+    OSSL_X25519_SCALAR_MODE scalar_mode)
 {
     fe x1, x2, z2, x3, z3, tmp0, tmp1;
     uint8_t e[32];
@@ -4531,9 +4550,7 @@ static void x25519_scalar_mult_generic(uint8_t out[32],
     int pos;
 
     memcpy(e, scalar, 32);
-    e[0] &= 248;
-    e[31] &= 127;
-    e[31] |= 64;
+    ossl_x25519_clamp_private(e, scalar_mode);
     fe_frombytes(x1, point);
     fe_1(x2);
     fe_0(z2);
@@ -4574,9 +4591,9 @@ static void x25519_scalar_mult_generic(uint8_t out[32],
 }
 
 static void x25519_scalar_mult(uint8_t out[32], const uint8_t scalar[32],
-    const uint8_t point[32])
+    const uint8_t point[32], OSSL_X25519_SCALAR_MODE scalar_mode)
 {
-    x25519_scalar_mult_generic(out, scalar, point);
+    x25519_scalar_mult_generic(out, scalar, point, scalar_mode);
 }
 #endif
 
@@ -5842,25 +5859,23 @@ int ossl_ed25519_public_from_private(OSSL_LIB_CTX *ctx, uint8_t out_public_key[3
 }
 
 int ossl_x25519(uint8_t out_shared_key[32], const uint8_t private_key[32],
-    const uint8_t peer_public_value[32])
+    const uint8_t peer_public_value[32], OSSL_X25519_SCALAR_MODE scalar_mode)
 {
     static const uint8_t kZeros[32] = { 0 };
-    x25519_scalar_mult(out_shared_key, private_key, peer_public_value);
+    x25519_scalar_mult(out_shared_key, private_key, peer_public_value, scalar_mode);
     /* The all-zero output results when the input is a point of small order. */
     return CRYPTO_memcmp(kZeros, out_shared_key, 32) != 0;
 }
 
 void ossl_x25519_public_from_private(uint8_t out_public_value[32],
-    const uint8_t private_key[32])
+    const uint8_t private_key[32], OSSL_X25519_SCALAR_MODE scalar_mode)
 {
     uint8_t e[32];
     ge_p3 A;
     fe zplusy, zminusy, zminusy_inv;
 
     memcpy(e, private_key, 32);
-    e[0] &= 248;
-    e[31] &= 127;
-    e[31] |= 64;
+    ossl_x25519_clamp_private(e, scalar_mode);
 
     ge_scalarmult_base(&A, e);
 

--- a/crypto/ec/curve25519.c
+++ b/crypto/ec/curve25519.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -20,6 +20,28 @@
 #include <openssl/sha.h>
 
 #include "internal/numbers.h"
+
+static ossl_inline void ossl_x25519_clamp_private(uint8_t e[32],
+    OSSL_X25519_SCALAR_MODE scalar_mode)
+{
+    /* Bit 255 always cleared: 254-bit scalar is required by the ladder. */
+    e[31] &= 0x7f;
+    switch (scalar_mode) {
+    case OSSL_X25519_SCALAR_MODE_RFC7748:
+        e[0] &= 0xf8;
+        e[31] |= 0x40;
+        break;
+    case OSSL_X25519_SCALAR_MODE_LEGACY_ED25519_COMPAT:
+        e[0] &= 0xf8;
+        break;
+    case OSSL_X25519_SCALAR_MODE_RAW_UNCLAMPED:
+        break;
+    default:
+        e[0] &= 0xf8;
+        e[31] |= 0x40;
+        break;
+    }
+}
 
 #if defined(X25519_ASM) && (defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64))
 
@@ -208,7 +230,7 @@ static void fe64_invert(fe64 out, const fe64 z)
  * fe64_* subroutines.
  */
 static void x25519_scalar_mulx(uint8_t out[32], const uint8_t scalar[32],
-    const uint8_t point[32])
+    const uint8_t point[32], OSSL_X25519_SCALAR_MODE scalar_mode)
 {
     fe64 x1, x2, z2, x3, z3, tmp0, tmp1;
     uint8_t e[32];
@@ -216,9 +238,7 @@ static void x25519_scalar_mulx(uint8_t out[32], const uint8_t scalar[32],
     int pos;
 
     memcpy(e, scalar, 32);
-    e[0] &= 0xf8;
-    e[31] &= 0x7f;
-    e[31] |= 0x40;
+    ossl_x25519_clamp_private(e, scalar_mode);
     fe64_frombytes(x1, point);
     fe64_1(x2);
     fe64_0(z2);
@@ -732,7 +752,7 @@ static void fe51_invert(fe51 out, const fe51 z)
  * fe51_* subroutines.
  */
 static void x25519_scalar_mult(uint8_t out[32], const uint8_t scalar[32],
-    const uint8_t point[32])
+    const uint8_t point[32], OSSL_X25519_SCALAR_MODE scalar_mode)
 {
     fe51 x1, x2, z2, x3, z3, tmp0, tmp1;
     uint8_t e[32];
@@ -741,15 +761,13 @@ static void x25519_scalar_mult(uint8_t out[32], const uint8_t scalar[32],
 
 #ifdef BASE_2_64_IMPLEMENTED
     if (x25519_fe64_eligible()) {
-        x25519_scalar_mulx(out, scalar, point);
+        x25519_scalar_mulx(out, scalar, point, scalar_mode);
         return;
     }
 #endif
 
     memcpy(e, scalar, 32);
-    e[0] &= 0xf8;
-    e[31] &= 0x7f;
-    e[31] |= 0x40;
+    ossl_x25519_clamp_private(e, scalar_mode);
     fe51_frombytes(x1, point);
     fe51_1(x2);
     fe51_0(z2);
@@ -4530,7 +4548,8 @@ static void fe_mul121666(fe h, fe f)
 
 static void x25519_scalar_mult_generic(uint8_t out[32],
     const uint8_t scalar[32],
-    const uint8_t point[32])
+    const uint8_t point[32],
+    OSSL_X25519_SCALAR_MODE scalar_mode)
 {
     fe x1, x2, z2, x3, z3, tmp0, tmp1;
     uint8_t e[32];
@@ -4538,9 +4557,7 @@ static void x25519_scalar_mult_generic(uint8_t out[32],
     int pos;
 
     memcpy(e, scalar, 32);
-    e[0] &= 248;
-    e[31] &= 127;
-    e[31] |= 64;
+    ossl_x25519_clamp_private(e, scalar_mode);
     fe_frombytes(x1, point);
     fe_1(x2);
     fe_0(z2);
@@ -4581,9 +4598,9 @@ static void x25519_scalar_mult_generic(uint8_t out[32],
 }
 
 static void x25519_scalar_mult(uint8_t out[32], const uint8_t scalar[32],
-    const uint8_t point[32])
+    const uint8_t point[32], OSSL_X25519_SCALAR_MODE scalar_mode)
 {
-    x25519_scalar_mult_generic(out, scalar, point);
+    x25519_scalar_mult_generic(out, scalar, point, scalar_mode);
 }
 #endif
 
@@ -5849,25 +5866,23 @@ int ossl_ed25519_public_from_private(OSSL_LIB_CTX *ctx, uint8_t out_public_key[3
 }
 
 int ossl_x25519(uint8_t out_shared_key[32], const uint8_t private_key[32],
-    const uint8_t peer_public_value[32])
+    const uint8_t peer_public_value[32], OSSL_X25519_SCALAR_MODE scalar_mode)
 {
     static const uint8_t kZeros[32] = { 0 };
-    x25519_scalar_mult(out_shared_key, private_key, peer_public_value);
+    x25519_scalar_mult(out_shared_key, private_key, peer_public_value, scalar_mode);
     /* The all-zero output results when the input is a point of small order. */
     return CRYPTO_memcmp(kZeros, out_shared_key, 32) != 0;
 }
 
 void ossl_x25519_public_from_private(uint8_t out_public_value[32],
-    const uint8_t private_key[32])
+    const uint8_t private_key[32], OSSL_X25519_SCALAR_MODE scalar_mode)
 {
     uint8_t e[32];
     ge_p3 A;
     fe zplusy, zminusy, zminusy_inv;
 
     memcpy(e, private_key, 32);
-    e[0] &= 248;
-    e[31] &= 127;
-    e[31] |= 64;
+    ossl_x25519_clamp_private(e, scalar_mode);
 
     ge_scalarmult_base(&A, e);
 

--- a/crypto/ec/ecx_backend.c
+++ b/crypto/ec/ecx_backend.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2020-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -29,7 +29,8 @@ int ossl_ecx_public_from_private(ECX_KEY *key)
 {
     switch (key->type) {
     case ECX_KEY_TYPE_X25519:
-        ossl_x25519_public_from_private(key->pubkey, key->privkey);
+        ossl_x25519_public_from_private(key->pubkey, key->privkey,
+            key->x25519_scalar_mode);
         break;
     case ECX_KEY_TYPE_ED25519:
         if (!ossl_ed25519_public_from_private(key->libctx, key->pubkey,
@@ -111,6 +112,7 @@ ECX_KEY *ossl_ecx_key_dup(const ECX_KEY *key, int selection)
     ret->haspubkey = 0;
     ret->keylen = key->keylen;
     ret->type = key->type;
+    ret->x25519_scalar_mode = key->x25519_scalar_mode;
 
     if (!CRYPTO_NEW_REF(&ret->references, 1))
         goto err;

--- a/crypto/ec/ecx_key.c
+++ b/crypto/ec/ecx_key.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2020-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -42,6 +42,7 @@ ECX_KEY *ossl_ecx_key_new(OSSL_LIB_CTX *libctx, ECX_KEY_TYPE type, int haspubkey
         break;
     }
     ret->type = type;
+    ret->x25519_scalar_mode = OSSL_X25519_SCALAR_MODE_RFC7748;
 
     if (!CRYPTO_NEW_REF(&ret->references, 1))
         goto err;
@@ -142,7 +143,9 @@ int ossl_ecx_compute_key(ECX_KEY *peer, ECX_KEY *priv, size_t keylen,
             }
         } else
 #endif
-            if (ossl_x25519(secret, priv->privkey, peer->pubkey) == 0) {
+            if (ossl_x25519(secret, priv->privkey, peer->pubkey,
+                    priv->x25519_scalar_mode)
+                == 0) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_DURING_DERIVATION);
             return 0;
         }

--- a/doc/man7/EVP_PKEY-X25519.pod
+++ b/doc/man7/EVP_PKEY-X25519.pod
@@ -62,6 +62,59 @@ The public key value.
 
 The private key value.
 
+=item "x25519-scalar-mode" ("x25519-scalar-mode") <UTF8 string>
+
+Controls how X25519 private scalars are processed before scalar
+multiplication. This parameter is only supported for B<X25519> keys. The
+supported values are:
+
+=over 4
+
+=item B<"rfc7748">
+
+The default mode. Applies the standard RFC 7748 clamping: clears the three
+low bits, clears bit 255, and forces bit 254. This mode must be used for
+interoperable X25519 ECDH.
+
+=item B<"legacy-ed25519-compat">
+
+Applies low-bit (torsion) clearing and clears bit 255, but does not force
+bit 254. Provided for specialized workflows that require an unclamped
+position-254 bit (for example, scalar inversion) while still clearing the
+torsion subgroup.
+
+=item B<"raw-unclamped">
+
+Uses the raw private key bytes verbatim (other than clearing bit 255, which
+the X25519 ladder ignores). Non-standard; provided to allow Ed25519-style
+(unclamped) keypairs to be used directly with X25519 operations.
+
+=back
+
+The mode is part of the key's identity:
+
+=over 4
+
+=item *
+
+It is preserved by L<EVP_PKEY_dup(3)> and by L<EVP_PKEY_todata(3)> /
+L<EVP_PKEY_fromdata(3)> round-trips.
+
+=item *
+
+L<EVP_PKEY_eq(3)> returns false for two X25519 keys that differ only in
+this mode.
+
+=item *
+
+Setting the mode regenerates the derived public key, so the mode should
+be set before the public key is exported or before deriving a shared
+secret. The parameter cannot be set on a public-only X25519 key.
+
+=back
+
+In the OpenSSL FIPS provider, only B<"rfc7748"> is accepted.
+
 =back
 
 =head2 Parameters for X25519 and X448
@@ -123,6 +176,20 @@ An B<X25519> key can be generated like this:
 
 An B<X448>, B<ED25519>, or B<ED448> key can be generated likewise.
 
+The X25519 scalar mode can be selected at generation time:
+
+    OSSL_PARAM params[2];
+
+    params[0] = OSSL_PARAM_construct_utf8_string("x25519-scalar-mode",
+                                                 "raw-unclamped", 0);
+    params[1] = OSSL_PARAM_construct_end();
+
+    EVP_PKEY_CTX_set_params(pctx, params);
+    EVP_PKEY_generate(pctx, &pkey);
+
+It can also be changed on an existing X25519 key with a private component
+using L<EVP_PKEY_set_utf8_string_param(3)>.
+
 =head1 SEE ALSO
 
 L<EVP_KEYMGMT(3)>, L<EVP_PKEY(3)>, L<provider-keymgmt(7)>,
@@ -131,7 +198,7 @@ L<EVP_SIGNATURE-ED25519(7)>, L<EVP_SIGNATURE-ED448(7)>
 
 =head1 COPYRIGHT
 
-Copyright 2020-2025 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2020-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/crypto/ecx.h
+++ b/include/crypto/ecx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2020-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -53,6 +53,12 @@ typedef enum {
     ECX_KEY_TYPE_ED448
 } ECX_KEY_TYPE;
 
+typedef enum {
+    OSSL_X25519_SCALAR_MODE_RFC7748 = 0,
+    OSSL_X25519_SCALAR_MODE_LEGACY_ED25519_COMPAT = 1,
+    OSSL_X25519_SCALAR_MODE_RAW_UNCLAMPED = 2
+} OSSL_X25519_SCALAR_MODE;
+
 #define KEYTYPE2NID(type)                               \
     ((type) == ECX_KEY_TYPE_X25519                      \
             ? EVP_PKEY_X25519                           \
@@ -70,6 +76,7 @@ struct ecx_key_st {
     unsigned char *privkey;
     size_t keylen;
     ECX_KEY_TYPE type;
+    OSSL_X25519_SCALAR_MODE x25519_scalar_mode;
     CRYPTO_REF_COUNT references;
 };
 
@@ -86,9 +93,9 @@ int ossl_ecx_compute_key(ECX_KEY *peer, ECX_KEY *priv, size_t keylen,
     size_t outlen);
 
 int ossl_x25519(uint8_t out_shared_key[32], const uint8_t private_key[32],
-    const uint8_t peer_public_value[32]);
+    const uint8_t peer_public_value[32], OSSL_X25519_SCALAR_MODE scalar_mode);
 void ossl_x25519_public_from_private(uint8_t out_public_value[32],
-    const uint8_t private_key[32]);
+    const uint8_t private_key[32], OSSL_X25519_SCALAR_MODE scalar_mode);
 
 int ossl_ed25519_public_from_private(OSSL_LIB_CTX *ctx, uint8_t out_public_key[32],
     const uint8_t private_key[32],

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2020-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -84,7 +84,48 @@ struct ecx_gen_ctx {
     int selection;
     unsigned char *dhkem_ikm;
     size_t dhkem_ikmlen;
+    OSSL_X25519_SCALAR_MODE x25519_scalar_mode;
 };
+
+#define OSSL_PKEY_PARAM_X25519_SCALAR_MODE "x25519-scalar-mode"
+#define OSSL_PKEY_X25519_SCALAR_MODE_RFC7748 "rfc7748"
+#define OSSL_PKEY_X25519_SCALAR_MODE_LEGACY_ED25519_COMPAT "legacy-ed25519-compat"
+#define OSSL_PKEY_X25519_SCALAR_MODE_RAW_UNCLAMPED "raw-unclamped"
+
+static int x25519_scalar_mode_from_name(const char *name,
+    OSSL_X25519_SCALAR_MODE *mode)
+{
+    if (name == NULL || mode == NULL)
+        return 0;
+    if (OPENSSL_strcasecmp(name, OSSL_PKEY_X25519_SCALAR_MODE_RFC7748) == 0) {
+        *mode = OSSL_X25519_SCALAR_MODE_RFC7748;
+        return 1;
+    }
+    if (OPENSSL_strcasecmp(name,
+            OSSL_PKEY_X25519_SCALAR_MODE_LEGACY_ED25519_COMPAT)
+        == 0) {
+        *mode = OSSL_X25519_SCALAR_MODE_LEGACY_ED25519_COMPAT;
+        return 1;
+    }
+    if (OPENSSL_strcasecmp(name, OSSL_PKEY_X25519_SCALAR_MODE_RAW_UNCLAMPED) == 0) {
+        *mode = OSSL_X25519_SCALAR_MODE_RAW_UNCLAMPED;
+        return 1;
+    }
+    return 0;
+}
+
+static const char *x25519_scalar_mode_to_name(OSSL_X25519_SCALAR_MODE mode)
+{
+    switch (mode) {
+    case OSSL_X25519_SCALAR_MODE_LEGACY_ED25519_COMPAT:
+        return OSSL_PKEY_X25519_SCALAR_MODE_LEGACY_ED25519_COMPAT;
+    case OSSL_X25519_SCALAR_MODE_RAW_UNCLAMPED:
+        return OSSL_PKEY_X25519_SCALAR_MODE_RAW_UNCLAMPED;
+    case OSSL_X25519_SCALAR_MODE_RFC7748:
+    default:
+        return OSSL_PKEY_X25519_SCALAR_MODE_RFC7748;
+    }
+}
 
 #ifdef S390X_EC_ASM
 static void *s390x_ecx_keygen25519(struct ecx_gen_ctx *gctx);
@@ -169,6 +210,11 @@ static int ecx_match(const void *keydata1, const void *keydata2, int selection)
     if ((selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0) {
         int key_checked = 0;
 
+        if (key1->type == ECX_KEY_TYPE_X25519
+            && key2->type == ECX_KEY_TYPE_X25519
+            && key1->x25519_scalar_mode != key2->x25519_scalar_mode)
+            return 0;
+
         if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0) {
             const unsigned char *pa = key1->haspubkey ? key1->pubkey : NULL;
             const unsigned char *pb = key2->haspubkey ? key2->pubkey : NULL;
@@ -226,6 +272,7 @@ static int ecx_import(void *keydata, int selection, const OSSL_PARAM params[])
     int ok = 1;
     int include_private;
     struct ecx_imexport_types_st p;
+    const OSSL_PARAM *x25519_mode = NULL;
 
     if (!ossl_prov_is_running()
         || key == NULL
@@ -237,6 +284,20 @@ static int ecx_import(void *keydata, int selection, const OSSL_PARAM params[])
 
     include_private = selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY ? 1 : 0;
     ok = ok && ossl_ecx_key_fromdata(key, p.pub, p.priv, include_private);
+    if (ok && key->type == ECX_KEY_TYPE_X25519) {
+        OSSL_X25519_SCALAR_MODE mode = key->x25519_scalar_mode;
+
+        x25519_mode = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_X25519_SCALAR_MODE);
+        if (x25519_mode != NULL) {
+            ok = x25519_mode->data_type == OSSL_PARAM_UTF8_STRING
+                && x25519_scalar_mode_from_name(x25519_mode->data, &mode);
+#ifdef FIPS_MODULE
+            ok = ok && mode == OSSL_X25519_SCALAR_MODE_RFC7748;
+#endif
+            if (ok)
+                key->x25519_scalar_mode = mode;
+        }
+    }
 
     return ok;
 }
@@ -284,6 +345,11 @@ static int ecx_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
         int include_private = ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0);
 
         if (!key_to_params(key, tmpl, NULL, NULL, include_private))
+            goto err;
+        if (key->type == ECX_KEY_TYPE_X25519
+            && !ossl_param_build_set_utf8_string(tmpl, NULL,
+                OSSL_PKEY_PARAM_X25519_SCALAR_MODE,
+                x25519_scalar_mode_to_name(key->x25519_scalar_mode)))
             goto err;
     }
 
@@ -364,8 +430,19 @@ static int ed_get_params(void *key, OSSL_PARAM params[], int bits, int secbits,
 
 static int x25519_get_params(void *key, OSSL_PARAM params[])
 {
-    return ecx_get_params(key, params, X25519_BITS, X25519_SECURITY_BITS,
-        X25519_KEYLEN);
+    ECX_KEY *ecx = key;
+    OSSL_PARAM *p;
+
+    if (!ecx_get_params(key, params, X25519_BITS, X25519_SECURITY_BITS,
+            X25519_KEYLEN))
+        return 0;
+
+    p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_X25519_SCALAR_MODE);
+    if (p != NULL
+        && !OSSL_PARAM_set_utf8_string(p,
+            x25519_scalar_mode_to_name(ecx->x25519_scalar_mode)))
+        return 0;
+    return 1;
 }
 
 static int x448_get_params(void *key, OSSL_PARAM params[])
@@ -387,7 +464,22 @@ static int ed448_get_params(void *key, OSSL_PARAM params[])
 
 static const OSSL_PARAM *x25519_gettable_params(void *provctx)
 {
-    return ecx_get_params_list;
+    static const OSSL_PARAM x25519_gettable_params_list[] = {
+        OSSL_PARAM_int(OSSL_PKEY_PARAM_BITS, NULL),
+        OSSL_PARAM_int(OSSL_PKEY_PARAM_SECURITY_BITS, NULL),
+        OSSL_PARAM_int(OSSL_PKEY_PARAM_MAX_SIZE, NULL),
+        OSSL_PARAM_int(OSSL_PKEY_PARAM_SECURITY_CATEGORY, NULL),
+        OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_PUB_KEY, NULL, 0),
+        OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_PRIV_KEY, NULL, 0),
+        OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY, NULL, 0),
+#ifdef FIPS_MODULE
+        OSSL_PARAM_int(OSSL_PKEY_PARAM_FIPS_APPROVED_INDICATOR, NULL),
+#endif
+        OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_X25519_SCALAR_MODE, NULL, 0),
+        OSSL_PARAM_END
+    };
+
+    return x25519_gettable_params_list;
 }
 
 static const OSSL_PARAM *x448_gettable_params(void *provctx)
@@ -448,7 +540,32 @@ static int ecx_set_params(void *key, const OSSL_PARAM params[])
 
 static int x25519_set_params(void *key, const OSSL_PARAM params[])
 {
-    return ecx_set_params(key, params);
+    ECX_KEY *ecx = key;
+    const OSSL_PARAM *p;
+    OSSL_X25519_SCALAR_MODE mode;
+
+    if (!ecx_set_params(key, params))
+        return 0;
+
+    p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_X25519_SCALAR_MODE);
+    if (p == NULL)
+        return 1;
+    if (p->data_type != OSSL_PARAM_UTF8_STRING
+        || !x25519_scalar_mode_from_name(p->data, &mode))
+        return 0;
+#ifdef FIPS_MODULE
+    if (mode != OSSL_X25519_SCALAR_MODE_RFC7748)
+        return 0;
+#endif
+
+    if (ecx->privkey == NULL)
+        return 0;
+
+    ecx->x25519_scalar_mode = mode;
+    ossl_x25519_public_from_private(ecx->pubkey, ecx->privkey,
+        ecx->x25519_scalar_mode);
+    ecx->haspubkey = 1;
+    return 1;
 }
 
 static int x448_set_params(void *key, const OSSL_PARAM params[])
@@ -472,7 +589,14 @@ static const OSSL_PARAM ed_settable_params[] = {
 
 static const OSSL_PARAM *x25519_settable_params(void *provctx)
 {
-    return ecx_set_params_list;
+    static const OSSL_PARAM x25519_settable_params_list[] = {
+        OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_PROPERTIES, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_X25519_SCALAR_MODE, NULL, 0),
+        OSSL_PARAM_END
+    };
+
+    return x25519_settable_params_list;
 }
 
 static const OSSL_PARAM *x448_settable_params(void *provctx)
@@ -504,6 +628,7 @@ static void *ecx_gen_init(void *provctx, int selection,
         gctx->libctx = libctx;
         gctx->type = type;
         gctx->selection = selection;
+        gctx->x25519_scalar_mode = OSSL_X25519_SCALAR_MODE_RFC7748;
 #ifdef FIPS_MODULE
         /* X25519/X448 are not FIPS approved, (ED25519/ED448 are approved) */
         if (algdesc != NULL
@@ -550,9 +675,29 @@ static int ecx_gen_set_params(void *genctx, const OSSL_PARAM params[])
 {
     struct ecx_gen_ctx *gctx = genctx;
     struct ecx_gen_set_params_st p;
+    const OSSL_PARAM *x25519_mode = NULL;
 
     if (gctx == NULL || !ecx_gen_set_params_decoder(params, &p))
         return 0;
+
+    x25519_mode = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_X25519_SCALAR_MODE);
+    if (x25519_mode != NULL) {
+        OSSL_X25519_SCALAR_MODE mode;
+
+        if (gctx->type != ECX_KEY_TYPE_X25519
+            || x25519_mode->data_type != OSSL_PARAM_UTF8_STRING
+            || !x25519_scalar_mode_from_name(x25519_mode->data, &mode)) {
+            ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_INVALID_ARGUMENT);
+            return 0;
+        }
+#ifdef FIPS_MODULE
+        if (mode != OSSL_X25519_SCALAR_MODE_RFC7748) {
+            ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_INVALID_ARGUMENT);
+            return 0;
+        }
+#endif
+        gctx->x25519_scalar_mode = mode;
+    }
 
     if (p.group != NULL) {
         const char *groupname = NULL;
@@ -715,10 +860,23 @@ static void *ecx_gen(struct ecx_gen_ctx *gctx)
 
     switch (gctx->type) {
     case ECX_KEY_TYPE_X25519:
-        privkey[0] &= 248;
-        privkey[X25519_KEYLEN - 1] &= 127;
-        privkey[X25519_KEYLEN - 1] |= 64;
-        ossl_x25519_public_from_private(key->pubkey, privkey);
+        key->x25519_scalar_mode = gctx->x25519_scalar_mode;
+        switch (gctx->x25519_scalar_mode) {
+        case OSSL_X25519_SCALAR_MODE_RFC7748:
+            privkey[0] &= 248;
+            privkey[X25519_KEYLEN - 1] &= 127;
+            privkey[X25519_KEYLEN - 1] |= 64;
+            break;
+        case OSSL_X25519_SCALAR_MODE_LEGACY_ED25519_COMPAT:
+            privkey[0] &= 248;
+            privkey[X25519_KEYLEN - 1] &= 127;
+            break;
+        case OSSL_X25519_SCALAR_MODE_RAW_UNCLAMPED:
+            privkey[X25519_KEYLEN - 1] &= 127;
+            break;
+        }
+        ossl_x25519_public_from_private(key->pubkey, privkey,
+            key->x25519_scalar_mode);
         break;
     case ECX_KEY_TYPE_X448:
         privkey[0] &= 252;
@@ -751,7 +909,9 @@ static void *x25519_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
         return 0;
 
 #ifdef S390X_EC_ASM
-    if (OPENSSL_s390xcap_P.pcc[1] & S390X_CAPBIT(S390X_SCALAR_MULTIPLY_X25519))
+    if (gctx->x25519_scalar_mode == OSSL_X25519_SCALAR_MODE_RFC7748
+        && (OPENSSL_s390xcap_P.pcc[1]
+            & S390X_CAPBIT(S390X_SCALAR_MULTIPLY_X25519)))
         return s390x_ecx_keygen25519(gctx);
 #endif
     return ecx_gen(gctx);
@@ -877,7 +1037,8 @@ static int ecx_key_pairwise_check(const ECX_KEY *ecx, int type)
 
     switch (type) {
     case ECX_KEY_TYPE_X25519:
-        ossl_x25519_public_from_private(pub, ecx->privkey);
+        ossl_x25519_public_from_private(pub, ecx->privkey,
+            ecx->x25519_scalar_mode);
         break;
     case ECX_KEY_TYPE_X448:
         ossl_x448_public_from_private(pub, ecx->privkey);

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2020-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -85,7 +85,48 @@ struct ecx_gen_ctx {
     int selection;
     unsigned char *dhkem_ikm;
     size_t dhkem_ikmlen;
+    OSSL_X25519_SCALAR_MODE x25519_scalar_mode;
 };
+
+#define OSSL_PKEY_PARAM_X25519_SCALAR_MODE "x25519-scalar-mode"
+#define OSSL_PKEY_X25519_SCALAR_MODE_RFC7748 "rfc7748"
+#define OSSL_PKEY_X25519_SCALAR_MODE_LEGACY_ED25519_COMPAT "legacy-ed25519-compat"
+#define OSSL_PKEY_X25519_SCALAR_MODE_RAW_UNCLAMPED "raw-unclamped"
+
+static int x25519_scalar_mode_from_name(const char *name,
+    OSSL_X25519_SCALAR_MODE *mode)
+{
+    if (name == NULL || mode == NULL)
+        return 0;
+    if (OPENSSL_strcasecmp(name, OSSL_PKEY_X25519_SCALAR_MODE_RFC7748) == 0) {
+        *mode = OSSL_X25519_SCALAR_MODE_RFC7748;
+        return 1;
+    }
+    if (OPENSSL_strcasecmp(name,
+            OSSL_PKEY_X25519_SCALAR_MODE_LEGACY_ED25519_COMPAT)
+        == 0) {
+        *mode = OSSL_X25519_SCALAR_MODE_LEGACY_ED25519_COMPAT;
+        return 1;
+    }
+    if (OPENSSL_strcasecmp(name, OSSL_PKEY_X25519_SCALAR_MODE_RAW_UNCLAMPED) == 0) {
+        *mode = OSSL_X25519_SCALAR_MODE_RAW_UNCLAMPED;
+        return 1;
+    }
+    return 0;
+}
+
+static const char *x25519_scalar_mode_to_name(OSSL_X25519_SCALAR_MODE mode)
+{
+    switch (mode) {
+    case OSSL_X25519_SCALAR_MODE_LEGACY_ED25519_COMPAT:
+        return OSSL_PKEY_X25519_SCALAR_MODE_LEGACY_ED25519_COMPAT;
+    case OSSL_X25519_SCALAR_MODE_RAW_UNCLAMPED:
+        return OSSL_PKEY_X25519_SCALAR_MODE_RAW_UNCLAMPED;
+    case OSSL_X25519_SCALAR_MODE_RFC7748:
+    default:
+        return OSSL_PKEY_X25519_SCALAR_MODE_RFC7748;
+    }
+}
 
 #ifdef S390X_EC_ASM
 static void *s390x_ecx_keygen25519(struct ecx_gen_ctx *gctx);
@@ -170,6 +211,11 @@ static int ecx_match(const void *keydata1, const void *keydata2, int selection)
     if ((selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0) {
         int key_checked = 0;
 
+        if (key1->type == ECX_KEY_TYPE_X25519
+            && key2->type == ECX_KEY_TYPE_X25519
+            && key1->x25519_scalar_mode != key2->x25519_scalar_mode)
+            return 0;
+
         if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0) {
             const unsigned char *pa = key1->haspubkey ? key1->pubkey : NULL;
             const unsigned char *pb = key2->haspubkey ? key2->pubkey : NULL;
@@ -227,6 +273,7 @@ static int ecx_import(void *keydata, int selection, const OSSL_PARAM params[])
     int ok = 1;
     int include_private;
     struct ecx_imexport_types_st p;
+    const OSSL_PARAM *x25519_mode = NULL;
 
     if (!ossl_prov_is_running()
         || key == NULL
@@ -238,6 +285,20 @@ static int ecx_import(void *keydata, int selection, const OSSL_PARAM params[])
 
     include_private = selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY ? 1 : 0;
     ok = ok && ossl_ecx_key_fromdata(key, p.pub, p.priv, include_private);
+    if (ok && key->type == ECX_KEY_TYPE_X25519) {
+        OSSL_X25519_SCALAR_MODE mode = key->x25519_scalar_mode;
+
+        x25519_mode = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_X25519_SCALAR_MODE);
+        if (x25519_mode != NULL) {
+            ok = x25519_mode->data_type == OSSL_PARAM_UTF8_STRING
+                && x25519_scalar_mode_from_name(x25519_mode->data, &mode);
+#ifdef FIPS_MODULE
+            ok = ok && mode == OSSL_X25519_SCALAR_MODE_RFC7748;
+#endif
+            if (ok)
+                key->x25519_scalar_mode = mode;
+        }
+    }
 
     return ok;
 }
@@ -285,6 +346,11 @@ static int ecx_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
         int include_private = ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0);
 
         if (!key_to_params(key, tmpl, NULL, NULL, include_private))
+            goto err;
+        if (key->type == ECX_KEY_TYPE_X25519
+            && !ossl_param_build_set_utf8_string(tmpl, NULL,
+                OSSL_PKEY_PARAM_X25519_SCALAR_MODE,
+                x25519_scalar_mode_to_name(key->x25519_scalar_mode)))
             goto err;
     }
 
@@ -365,8 +431,19 @@ static int ed_get_params(void *key, OSSL_PARAM params[], int bits, int secbits,
 
 static int x25519_get_params(void *key, OSSL_PARAM params[])
 {
-    return ecx_get_params(key, params, X25519_BITS, X25519_SECURITY_BITS,
-        X25519_KEYLEN);
+    ECX_KEY *ecx = key;
+    OSSL_PARAM *p;
+
+    if (!ecx_get_params(key, params, X25519_BITS, X25519_SECURITY_BITS,
+            X25519_KEYLEN))
+        return 0;
+
+    p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_X25519_SCALAR_MODE);
+    if (p != NULL
+        && !OSSL_PARAM_set_utf8_string(p,
+            x25519_scalar_mode_to_name(ecx->x25519_scalar_mode)))
+        return 0;
+    return 1;
 }
 
 static int x448_get_params(void *key, OSSL_PARAM params[])
@@ -388,7 +465,22 @@ static int ed448_get_params(void *key, OSSL_PARAM params[])
 
 static const OSSL_PARAM *x25519_gettable_params(void *provctx)
 {
-    return ecx_get_params_list;
+    static const OSSL_PARAM x25519_gettable_params_list[] = {
+        OSSL_PARAM_int(OSSL_PKEY_PARAM_BITS, NULL),
+        OSSL_PARAM_int(OSSL_PKEY_PARAM_SECURITY_BITS, NULL),
+        OSSL_PARAM_int(OSSL_PKEY_PARAM_MAX_SIZE, NULL),
+        OSSL_PARAM_int(OSSL_PKEY_PARAM_SECURITY_CATEGORY, NULL),
+        OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_PUB_KEY, NULL, 0),
+        OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_PRIV_KEY, NULL, 0),
+        OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY, NULL, 0),
+#ifdef FIPS_MODULE
+        OSSL_PARAM_int(OSSL_PKEY_PARAM_FIPS_APPROVED_INDICATOR, NULL),
+#endif
+        OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_X25519_SCALAR_MODE, NULL, 0),
+        OSSL_PARAM_END
+    };
+
+    return x25519_gettable_params_list;
 }
 
 static const OSSL_PARAM *x448_gettable_params(void *provctx)
@@ -449,7 +541,32 @@ static int ecx_set_params(void *key, const OSSL_PARAM params[])
 
 static int x25519_set_params(void *key, const OSSL_PARAM params[])
 {
-    return ecx_set_params(key, params);
+    ECX_KEY *ecx = key;
+    const OSSL_PARAM *p;
+    OSSL_X25519_SCALAR_MODE mode;
+
+    if (!ecx_set_params(key, params))
+        return 0;
+
+    p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_X25519_SCALAR_MODE);
+    if (p == NULL)
+        return 1;
+    if (p->data_type != OSSL_PARAM_UTF8_STRING
+        || !x25519_scalar_mode_from_name(p->data, &mode))
+        return 0;
+#ifdef FIPS_MODULE
+    if (mode != OSSL_X25519_SCALAR_MODE_RFC7748)
+        return 0;
+#endif
+
+    if (ecx->privkey == NULL)
+        return 0;
+
+    ecx->x25519_scalar_mode = mode;
+    ossl_x25519_public_from_private(ecx->pubkey, ecx->privkey,
+        ecx->x25519_scalar_mode);
+    ecx->haspubkey = 1;
+    return 1;
 }
 
 static int x448_set_params(void *key, const OSSL_PARAM params[])
@@ -473,7 +590,14 @@ static const OSSL_PARAM ed_settable_params[] = {
 
 static const OSSL_PARAM *x25519_settable_params(void *provctx)
 {
-    return ecx_set_params_list;
+    static const OSSL_PARAM x25519_settable_params_list[] = {
+        OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_PROPERTIES, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_X25519_SCALAR_MODE, NULL, 0),
+        OSSL_PARAM_END
+    };
+
+    return x25519_settable_params_list;
 }
 
 static const OSSL_PARAM *x448_settable_params(void *provctx)
@@ -505,6 +629,7 @@ static void *ecx_gen_init(void *provctx, int selection,
         gctx->libctx = libctx;
         gctx->type = type;
         gctx->selection = selection;
+        gctx->x25519_scalar_mode = OSSL_X25519_SCALAR_MODE_RFC7748;
 #ifdef FIPS_MODULE
         /* X25519/X448 are not FIPS approved, (ED25519/ED448 are approved) */
         if (algdesc != NULL
@@ -551,9 +676,29 @@ static int ecx_gen_set_params(void *genctx, const OSSL_PARAM params[])
 {
     struct ecx_gen_ctx *gctx = genctx;
     struct ecx_gen_set_params_st p;
+    const OSSL_PARAM *x25519_mode = NULL;
 
     if (gctx == NULL || !ecx_gen_set_params_decoder(params, &p))
         return 0;
+
+    x25519_mode = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_X25519_SCALAR_MODE);
+    if (x25519_mode != NULL) {
+        OSSL_X25519_SCALAR_MODE mode;
+
+        if (gctx->type != ECX_KEY_TYPE_X25519
+            || x25519_mode->data_type != OSSL_PARAM_UTF8_STRING
+            || !x25519_scalar_mode_from_name(x25519_mode->data, &mode)) {
+            ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_INVALID_ARGUMENT);
+            return 0;
+        }
+#ifdef FIPS_MODULE
+        if (mode != OSSL_X25519_SCALAR_MODE_RFC7748) {
+            ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_INVALID_ARGUMENT);
+            return 0;
+        }
+#endif
+        gctx->x25519_scalar_mode = mode;
+    }
 
     if (p.group != NULL) {
         const char *groupname = NULL;
@@ -716,10 +861,23 @@ static void *ecx_gen(struct ecx_gen_ctx *gctx)
 
     switch (gctx->type) {
     case ECX_KEY_TYPE_X25519:
-        privkey[0] &= 248;
-        privkey[X25519_KEYLEN - 1] &= 127;
-        privkey[X25519_KEYLEN - 1] |= 64;
-        ossl_x25519_public_from_private(key->pubkey, privkey);
+        key->x25519_scalar_mode = gctx->x25519_scalar_mode;
+        switch (gctx->x25519_scalar_mode) {
+        case OSSL_X25519_SCALAR_MODE_RFC7748:
+            privkey[0] &= 248;
+            privkey[X25519_KEYLEN - 1] &= 127;
+            privkey[X25519_KEYLEN - 1] |= 64;
+            break;
+        case OSSL_X25519_SCALAR_MODE_LEGACY_ED25519_COMPAT:
+            privkey[0] &= 248;
+            privkey[X25519_KEYLEN - 1] &= 127;
+            break;
+        case OSSL_X25519_SCALAR_MODE_RAW_UNCLAMPED:
+            privkey[X25519_KEYLEN - 1] &= 127;
+            break;
+        }
+        ossl_x25519_public_from_private(key->pubkey, privkey,
+            key->x25519_scalar_mode);
         break;
     case ECX_KEY_TYPE_X448:
         privkey[0] &= 252;
@@ -752,7 +910,9 @@ static void *x25519_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
         return 0;
 
 #ifdef S390X_EC_ASM
-    if (OPENSSL_s390xcap_P.pcc[1] & S390X_CAPBIT(S390X_SCALAR_MULTIPLY_X25519))
+    if (gctx->x25519_scalar_mode == OSSL_X25519_SCALAR_MODE_RFC7748
+        && (OPENSSL_s390xcap_P.pcc[1]
+            & S390X_CAPBIT(S390X_SCALAR_MULTIPLY_X25519)))
         return s390x_ecx_keygen25519(gctx);
 #endif
     return ecx_gen(gctx);
@@ -876,7 +1036,8 @@ static int ecx_key_pairwise_check(const ECX_KEY *ecx, int type)
 
     switch (type) {
     case ECX_KEY_TYPE_X25519:
-        ossl_x25519_public_from_private(pub, ecx->privkey);
+        ossl_x25519_public_from_private(pub, ecx->privkey,
+            ecx->x25519_scalar_mode);
         break;
     case ECX_KEY_TYPE_X448:
         ossl_x448_public_from_private(pub, ecx->privkey);

--- a/test/evp_extra_test2.c
+++ b/test/evp_extra_test2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2015-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -1806,6 +1806,278 @@ static int test_ecx_tofrom_data_select(void)
     EVP_PKEY_free(key);
     return ret;
 }
+
+/*
+ * Byte 0: high bits exercise raw vs clamped. Byte 31: use 0xbf so the low
+ * 7 bits are 0x3f; RFC7748 then sets bit 6 (0x7f) but legacy leaves 0x3f,
+ * giving distinct scalars. (With 0xff, RFC |0x40 was a no-op on 0x7f.)
+ */
+static const unsigned char x25519_scalar_mode_priv[32] = {
+    0xff, 0x02, 0x03, 0x04, 0xaa, 0xbb, 0xcc, 0xdd,
+    0x11, 0x12, 0x13, 0x14, 0x21, 0x22, 0x23, 0x24,
+    0x31, 0x32, 0x33, 0x34, 0x41, 0x42, 0x43, 0x44,
+    0x51, 0x52, 0x53, 0x54, 0x61, 0x62, 0x63, 0xbf
+};
+
+static EVP_PKEY *x25519_key_with_mode(const char *mode_name,
+    unsigned char pub[32])
+{
+    EVP_PKEY *key;
+    size_t publen = 0;
+
+    key = EVP_PKEY_new_raw_private_key_ex(mainctx, "X25519", NULL,
+        x25519_scalar_mode_priv,
+        sizeof(x25519_scalar_mode_priv));
+    if (key == NULL)
+        return NULL;
+    if (mode_name != NULL
+        && !EVP_PKEY_set_utf8_string_param(key, "x25519-scalar-mode",
+            mode_name)) {
+        EVP_PKEY_free(key);
+        return NULL;
+    }
+    if (pub != NULL
+        && (!EVP_PKEY_get_octet_string_param(key,
+                OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY,
+                pub, 32, &publen)
+            || publen != 32)) {
+        EVP_PKEY_free(key);
+        return NULL;
+    }
+    return key;
+}
+
+/* Set/get plus distinct pubkey per mode for the same private bytes. */
+static int test_x25519_scalar_mode_param_basic(void)
+{
+    EVP_PKEY *key_rfc = NULL, *key_legacy = NULL, *key_raw = NULL;
+    EVP_PKEY *key_invalid = NULL;
+    unsigned char pub_rfc[32], pub_legacy[32], pub_raw[32];
+    char mode[64];
+    size_t modelen = 0;
+    int ret = 0;
+
+    if (!TEST_ptr(key_rfc = x25519_key_with_mode(NULL, pub_rfc))
+        || !TEST_true(EVP_PKEY_get_utf8_string_param(key_rfc,
+            "x25519-scalar-mode", mode, sizeof(mode), &modelen))
+        || !TEST_str_eq(mode, "rfc7748")
+        || !TEST_ptr(key_legacy = x25519_key_with_mode("legacy-ed25519-compat",
+                         pub_legacy))
+        || !TEST_true(EVP_PKEY_get_utf8_string_param(key_legacy,
+            "x25519-scalar-mode", mode, sizeof(mode), &modelen))
+        || !TEST_str_eq(mode, "legacy-ed25519-compat")
+        || !TEST_ptr(key_raw = x25519_key_with_mode("raw-unclamped", pub_raw))
+        || !TEST_true(EVP_PKEY_get_utf8_string_param(key_raw,
+            "x25519-scalar-mode", mode, sizeof(mode), &modelen))
+        || !TEST_str_eq(mode, "raw-unclamped")
+        || !TEST_mem_ne(pub_rfc, sizeof(pub_rfc),
+            pub_legacy, sizeof(pub_legacy))
+        || !TEST_mem_ne(pub_rfc, sizeof(pub_rfc), pub_raw, sizeof(pub_raw))
+        || !TEST_mem_ne(pub_legacy, sizeof(pub_legacy),
+            pub_raw, sizeof(pub_raw)))
+        goto err;
+
+    if (!TEST_ptr(key_invalid = x25519_key_with_mode(NULL, NULL))
+        || !TEST_false(EVP_PKEY_set_utf8_string_param(key_invalid,
+            "x25519-scalar-mode", "no-such-mode")))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_PKEY_free(key_invalid);
+    EVP_PKEY_free(key_raw);
+    EVP_PKEY_free(key_legacy);
+    EVP_PKEY_free(key_rfc);
+    return ret;
+}
+
+/* Mode survives dup and todata/fromdata; EVP_PKEY_eq honors it. */
+static int test_x25519_scalar_mode_round_trip(void)
+{
+    EVP_PKEY *src = NULL, *dup = NULL, *imp = NULL, *baseline = NULL;
+    EVP_PKEY_CTX *ctx = NULL;
+    OSSL_PARAM *params = NULL;
+    char mode[64];
+    size_t modelen = 0;
+    int ret = 0;
+
+    if (!TEST_ptr(src = x25519_key_with_mode("raw-unclamped", NULL))
+        || !TEST_ptr(dup = EVP_PKEY_dup(src))
+        || !TEST_true(EVP_PKEY_get_utf8_string_param(dup,
+            "x25519-scalar-mode", mode, sizeof(mode), &modelen))
+        || !TEST_str_eq(mode, "raw-unclamped")
+        || !TEST_int_eq(EVP_PKEY_eq(src, dup), 1))
+        goto err;
+
+    /* Same private bytes but default mode -> not equal. */
+    if (!TEST_ptr(baseline = x25519_key_with_mode(NULL, NULL))
+        || !TEST_int_ne(EVP_PKEY_eq(src, baseline), 1))
+        goto err;
+
+    if (!TEST_true(EVP_PKEY_todata(src, EVP_PKEY_KEYPAIR, &params))
+        || !TEST_ptr(ctx = EVP_PKEY_CTX_new_from_name(mainctx, "X25519", NULL))
+        || !TEST_int_gt(EVP_PKEY_fromdata_init(ctx), 0)
+        || !TEST_int_gt(EVP_PKEY_fromdata(ctx, &imp, EVP_PKEY_KEYPAIR, params),
+            0)
+        || !TEST_true(EVP_PKEY_get_utf8_string_param(imp,
+            "x25519-scalar-mode", mode, sizeof(mode), &modelen))
+        || !TEST_str_eq(mode, "raw-unclamped")
+        || !TEST_int_eq(EVP_PKEY_eq(src, imp), 1))
+        goto err;
+
+    ret = 1;
+err:
+    OSSL_PARAM_free(params);
+    EVP_PKEY_CTX_free(ctx);
+    EVP_PKEY_free(imp);
+    EVP_PKEY_free(baseline);
+    EVP_PKEY_free(dup);
+    EVP_PKEY_free(src);
+    return ret;
+}
+
+/* Matching modes derive equal secrets; differing local modes do not. */
+static int test_x25519_scalar_mode_derive(void)
+{
+    static const unsigned char priv_b[32] = {
+        0x77, 0x07, 0x6d, 0x0a, 0x73, 0x18, 0xa5, 0x7d,
+        0x3c, 0x16, 0xc1, 0x72, 0x51, 0xb2, 0x66, 0x45,
+        0xdf, 0x4c, 0x2f, 0x87, 0xeb, 0xc0, 0x99, 0x2a,
+        0xb1, 0x77, 0xfb, 0xa5, 0x1d, 0xb9, 0x2c, 0x2a
+    };
+    EVP_PKEY *a_rfc = NULL, *b_rfc = NULL;
+    EVP_PKEY *a_raw = NULL, *peer_rfc = NULL;
+    EVP_PKEY *a_local_rfc = NULL, *a_local_raw = NULL;
+    EVP_PKEY_CTX *dctx = NULL;
+    unsigned char shared_a[32], shared_b[32];
+    unsigned char shared_rfc_local[32], shared_raw_local[32];
+    unsigned char b_pub[32];
+    size_t shared_len;
+    size_t b_publen = 0;
+    int ret = 0;
+
+    /* Symmetric ECDH with matching modes. */
+    if (!TEST_ptr(a_rfc = x25519_key_with_mode(NULL, NULL))
+        || !TEST_ptr(b_rfc = EVP_PKEY_new_raw_private_key_ex(mainctx,
+                         "X25519", NULL, priv_b, sizeof(priv_b)))
+        || !TEST_ptr(dctx = EVP_PKEY_CTX_new_from_pkey(mainctx, a_rfc, NULL))
+        || !TEST_int_gt(EVP_PKEY_derive_init(dctx), 0)
+        || !TEST_int_gt(EVP_PKEY_derive_set_peer(dctx, b_rfc), 0)
+        || (shared_len = sizeof(shared_a),
+            !TEST_int_gt(EVP_PKEY_derive(dctx, shared_a, &shared_len), 0))
+        || !TEST_size_t_eq(shared_len, sizeof(shared_a)))
+        goto err;
+    EVP_PKEY_CTX_free(dctx);
+    dctx = NULL;
+    if (!TEST_ptr(dctx = EVP_PKEY_CTX_new_from_pkey(mainctx, b_rfc, NULL))
+        || !TEST_int_gt(EVP_PKEY_derive_init(dctx), 0)
+        || !TEST_int_gt(EVP_PKEY_derive_set_peer(dctx, a_rfc), 0)
+        || (shared_len = sizeof(shared_b),
+            !TEST_int_gt(EVP_PKEY_derive(dctx, shared_b, &shared_len), 0))
+        || !TEST_size_t_eq(shared_len, sizeof(shared_b))
+        || !TEST_mem_eq(shared_a, sizeof(shared_a),
+            shared_b, sizeof(shared_b)))
+        goto err;
+    EVP_PKEY_CTX_free(dctx);
+    dctx = NULL;
+
+    /* Same priv bytes, rfc7748 vs raw-unclamped: different shared secrets. */
+    if (!TEST_ptr(a_local_rfc = x25519_key_with_mode(NULL, NULL))
+        || !TEST_ptr(a_local_raw = x25519_key_with_mode("raw-unclamped", NULL))
+        || !TEST_true(EVP_PKEY_get_octet_string_param(b_rfc,
+            OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY,
+            b_pub, sizeof(b_pub), &b_publen))
+        || !TEST_size_t_eq(b_publen, sizeof(b_pub))
+        || !TEST_ptr(peer_rfc = EVP_PKEY_new_raw_public_key_ex(mainctx,
+                         "X25519", NULL, b_pub, sizeof(b_pub)))
+        || !TEST_ptr(dctx = EVP_PKEY_CTX_new_from_pkey(mainctx, a_local_rfc,
+                         NULL))
+        || !TEST_int_gt(EVP_PKEY_derive_init(dctx), 0)
+        || !TEST_int_gt(EVP_PKEY_derive_set_peer(dctx, peer_rfc), 0)
+        || (shared_len = sizeof(shared_rfc_local),
+            !TEST_int_gt(EVP_PKEY_derive(dctx, shared_rfc_local, &shared_len),
+                0)))
+        goto err;
+    EVP_PKEY_CTX_free(dctx);
+    dctx = NULL;
+    if (!TEST_ptr(dctx = EVP_PKEY_CTX_new_from_pkey(mainctx, a_local_raw,
+                      NULL))
+        || !TEST_int_gt(EVP_PKEY_derive_init(dctx), 0)
+        || !TEST_int_gt(EVP_PKEY_derive_set_peer(dctx, peer_rfc), 0)
+        || (shared_len = sizeof(shared_raw_local),
+            !TEST_int_gt(EVP_PKEY_derive(dctx, shared_raw_local, &shared_len),
+                0))
+        || !TEST_mem_ne(shared_rfc_local, sizeof(shared_rfc_local),
+            shared_raw_local, sizeof(shared_raw_local)))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_PKEY_CTX_free(dctx);
+    EVP_PKEY_free(peer_rfc);
+    EVP_PKEY_free(a_local_raw);
+    EVP_PKEY_free(a_local_rfc);
+    EVP_PKEY_free(a_raw);
+    EVP_PKEY_free(b_rfc);
+    EVP_PKEY_free(a_rfc);
+    return ret;
+}
+
+/* Mode set at keygen via OSSL_PARAM. */
+static int test_x25519_scalar_mode_keygen(void)
+{
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *key = NULL;
+    OSSL_PARAM params[2];
+    char mode[64];
+    size_t modelen = 0;
+    int ret = 0;
+
+    params[0] = OSSL_PARAM_construct_utf8_string("x25519-scalar-mode",
+        (char *)"raw-unclamped", 0);
+    params[1] = OSSL_PARAM_construct_end();
+
+    if (!TEST_ptr(ctx = EVP_PKEY_CTX_new_from_name(mainctx, "X25519", NULL))
+        || !TEST_int_gt(EVP_PKEY_keygen_init(ctx), 0)
+        || !TEST_int_eq(EVP_PKEY_CTX_set_params(ctx, params), 1)
+        || !TEST_int_gt(EVP_PKEY_generate(ctx, &key), 0)
+        || !TEST_true(EVP_PKEY_get_utf8_string_param(key,
+            "x25519-scalar-mode", mode, sizeof(mode), &modelen))
+        || !TEST_str_eq(mode, "raw-unclamped"))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_PKEY_free(key);
+    EVP_PKEY_CTX_free(ctx);
+    return ret;
+}
+
+/* Mode set fails on a public-only X25519 key. */
+static int test_x25519_scalar_mode_public_only(void)
+{
+    EVP_PKEY *priv_key = NULL, *pub_key = NULL;
+    unsigned char pub[32];
+    size_t publen = 0;
+    int ret = 0;
+
+    if (!TEST_ptr(priv_key = x25519_key_with_mode(NULL, NULL))
+        || !TEST_true(EVP_PKEY_get_octet_string_param(priv_key,
+            OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY,
+            pub, sizeof(pub), &publen))
+        || !TEST_size_t_eq(publen, sizeof(pub))
+        || !TEST_ptr(pub_key = EVP_PKEY_new_raw_public_key_ex(mainctx,
+                         "X25519", NULL, pub, sizeof(pub)))
+        || !TEST_false(EVP_PKEY_set_utf8_string_param(pub_key,
+            "x25519-scalar-mode", "raw-unclamped")))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_PKEY_free(pub_key);
+    EVP_PKEY_free(priv_key);
+    return ret;
+}
 #endif
 #endif
 
@@ -3561,6 +3833,11 @@ int setup_tests(void)
     ADD_TEST(test_ec_tofrom_data_select);
 #ifndef OPENSSL_NO_ECX
     ADD_TEST(test_ecx_tofrom_data_select);
+    ADD_TEST(test_x25519_scalar_mode_param_basic);
+    ADD_TEST(test_x25519_scalar_mode_round_trip);
+    ADD_TEST(test_x25519_scalar_mode_derive);
+    ADD_TEST(test_x25519_scalar_mode_keygen);
+    ADD_TEST(test_x25519_scalar_mode_public_only);
 #endif
     ADD_TEST(test_ec_d2i_i2d_pubkey);
 #else

--- a/test/evp_extra_test2.c
+++ b/test/evp_extra_test2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2015-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -790,6 +790,279 @@ err:
     return ret;
 }
 
+#ifndef OPENSSL_NO_ECX
+/*
+ * Byte 0: high bits exercise raw vs clamped. Byte 31: use 0xbf so the low
+ * 7 bits are 0x3f; RFC7748 then sets bit 6 (0x7f) but legacy leaves 0x3f,
+ * giving distinct scalars. (With 0xff, RFC |0x40 was a no-op on 0x7f.)
+ */
+static const unsigned char x25519_scalar_mode_priv[32] = {
+    0xff, 0x02, 0x03, 0x04, 0xaa, 0xbb, 0xcc, 0xdd,
+    0x11, 0x12, 0x13, 0x14, 0x21, 0x22, 0x23, 0x24,
+    0x31, 0x32, 0x33, 0x34, 0x41, 0x42, 0x43, 0x44,
+    0x51, 0x52, 0x53, 0x54, 0x61, 0x62, 0x63, 0xbf
+};
+
+static EVP_PKEY *x25519_key_with_mode(const char *mode_name,
+    unsigned char pub[32])
+{
+    EVP_PKEY *key;
+    size_t publen = 0;
+
+    key = EVP_PKEY_new_raw_private_key_ex(mainctx, "X25519", NULL,
+        x25519_scalar_mode_priv,
+        sizeof(x25519_scalar_mode_priv));
+    if (key == NULL)
+        return NULL;
+    if (mode_name != NULL
+        && !EVP_PKEY_set_utf8_string_param(key, "x25519-scalar-mode",
+            mode_name)) {
+        EVP_PKEY_free(key);
+        return NULL;
+    }
+    if (pub != NULL
+        && (!EVP_PKEY_get_octet_string_param(key,
+                OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY,
+                pub, 32, &publen)
+            || publen != 32)) {
+        EVP_PKEY_free(key);
+        return NULL;
+    }
+    return key;
+}
+
+/* Set/get plus distinct pubkey per mode for the same private bytes. */
+static int test_x25519_scalar_mode_param_basic(void)
+{
+    EVP_PKEY *key_rfc = NULL, *key_legacy = NULL, *key_raw = NULL;
+    EVP_PKEY *key_invalid = NULL;
+    unsigned char pub_rfc[32], pub_legacy[32], pub_raw[32];
+    char mode[64];
+    size_t modelen = 0;
+    int ret = 0;
+
+    if (!TEST_ptr(key_rfc = x25519_key_with_mode(NULL, pub_rfc))
+        || !TEST_true(EVP_PKEY_get_utf8_string_param(key_rfc,
+            "x25519-scalar-mode", mode, sizeof(mode), &modelen))
+        || !TEST_str_eq(mode, "rfc7748")
+        || !TEST_ptr(key_legacy = x25519_key_with_mode("legacy-ed25519-compat",
+                         pub_legacy))
+        || !TEST_true(EVP_PKEY_get_utf8_string_param(key_legacy,
+            "x25519-scalar-mode", mode, sizeof(mode), &modelen))
+        || !TEST_str_eq(mode, "legacy-ed25519-compat")
+        || !TEST_ptr(key_raw = x25519_key_with_mode("raw-unclamped", pub_raw))
+        || !TEST_true(EVP_PKEY_get_utf8_string_param(key_raw,
+            "x25519-scalar-mode", mode, sizeof(mode), &modelen))
+        || !TEST_str_eq(mode, "raw-unclamped")
+        || !TEST_mem_ne(pub_rfc, sizeof(pub_rfc),
+            pub_legacy, sizeof(pub_legacy))
+        || !TEST_mem_ne(pub_rfc, sizeof(pub_rfc), pub_raw, sizeof(pub_raw))
+        || !TEST_mem_ne(pub_legacy, sizeof(pub_legacy),
+            pub_raw, sizeof(pub_raw)))
+        goto err;
+
+    if (!TEST_ptr(key_invalid = x25519_key_with_mode(NULL, NULL))
+        || !TEST_false(EVP_PKEY_set_utf8_string_param(key_invalid,
+            "x25519-scalar-mode", "no-such-mode")))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_PKEY_free(key_invalid);
+    EVP_PKEY_free(key_raw);
+    EVP_PKEY_free(key_legacy);
+    EVP_PKEY_free(key_rfc);
+    return ret;
+}
+
+/* Mode survives dup and todata/fromdata; EVP_PKEY_eq honors it. */
+static int test_x25519_scalar_mode_round_trip(void)
+{
+    EVP_PKEY *src = NULL, *dup = NULL, *imp = NULL, *baseline = NULL;
+    EVP_PKEY_CTX *ctx = NULL;
+    OSSL_PARAM *params = NULL;
+    char mode[64];
+    size_t modelen = 0;
+    int ret = 0;
+
+    if (!TEST_ptr(src = x25519_key_with_mode("raw-unclamped", NULL))
+        || !TEST_ptr(dup = EVP_PKEY_dup(src))
+        || !TEST_true(EVP_PKEY_get_utf8_string_param(dup,
+            "x25519-scalar-mode", mode, sizeof(mode), &modelen))
+        || !TEST_str_eq(mode, "raw-unclamped")
+        || !TEST_int_eq(EVP_PKEY_eq(src, dup), 1))
+        goto err;
+
+    /* Same private bytes but default mode -> not equal. */
+    if (!TEST_ptr(baseline = x25519_key_with_mode(NULL, NULL))
+        || !TEST_int_ne(EVP_PKEY_eq(src, baseline), 1))
+        goto err;
+
+    if (!TEST_true(EVP_PKEY_todata(src, EVP_PKEY_KEYPAIR, &params))
+        || !TEST_ptr(ctx = EVP_PKEY_CTX_new_from_name(mainctx, "X25519", NULL))
+        || !TEST_int_gt(EVP_PKEY_fromdata_init(ctx), 0)
+        || !TEST_int_gt(EVP_PKEY_fromdata(ctx, &imp, EVP_PKEY_KEYPAIR, params),
+            0)
+        || !TEST_true(EVP_PKEY_get_utf8_string_param(imp,
+            "x25519-scalar-mode", mode, sizeof(mode), &modelen))
+        || !TEST_str_eq(mode, "raw-unclamped")
+        || !TEST_int_eq(EVP_PKEY_eq(src, imp), 1))
+        goto err;
+
+    ret = 1;
+err:
+    OSSL_PARAM_free(params);
+    EVP_PKEY_CTX_free(ctx);
+    EVP_PKEY_free(imp);
+    EVP_PKEY_free(baseline);
+    EVP_PKEY_free(dup);
+    EVP_PKEY_free(src);
+    return ret;
+}
+
+/* Matching modes derive equal secrets; differing local modes do not. */
+static int test_x25519_scalar_mode_derive(void)
+{
+    static const unsigned char priv_b[32] = {
+        0x77, 0x07, 0x6d, 0x0a, 0x73, 0x18, 0xa5, 0x7d,
+        0x3c, 0x16, 0xc1, 0x72, 0x51, 0xb2, 0x66, 0x45,
+        0xdf, 0x4c, 0x2f, 0x87, 0xeb, 0xc0, 0x99, 0x2a,
+        0xb1, 0x77, 0xfb, 0xa5, 0x1d, 0xb9, 0x2c, 0x2a
+    };
+    EVP_PKEY *a_rfc = NULL, *b_rfc = NULL;
+    EVP_PKEY *a_raw = NULL, *peer_rfc = NULL;
+    EVP_PKEY *a_local_rfc = NULL, *a_local_raw = NULL;
+    EVP_PKEY_CTX *dctx = NULL;
+    unsigned char shared_a[32], shared_b[32];
+    unsigned char shared_rfc_local[32], shared_raw_local[32];
+    unsigned char b_pub[32];
+    size_t shared_len;
+    size_t b_publen = 0;
+    int ret = 0;
+
+    /* Symmetric ECDH with matching modes. */
+    if (!TEST_ptr(a_rfc = x25519_key_with_mode(NULL, NULL))
+        || !TEST_ptr(b_rfc = EVP_PKEY_new_raw_private_key_ex(mainctx,
+                         "X25519", NULL, priv_b, sizeof(priv_b)))
+        || !TEST_ptr(dctx = EVP_PKEY_CTX_new_from_pkey(mainctx, a_rfc, NULL))
+        || !TEST_int_gt(EVP_PKEY_derive_init(dctx), 0)
+        || !TEST_int_gt(EVP_PKEY_derive_set_peer(dctx, b_rfc), 0)
+        || (shared_len = sizeof(shared_a),
+            !TEST_int_gt(EVP_PKEY_derive(dctx, shared_a, &shared_len), 0))
+        || !TEST_size_t_eq(shared_len, sizeof(shared_a)))
+        goto err;
+    EVP_PKEY_CTX_free(dctx);
+    dctx = NULL;
+    if (!TEST_ptr(dctx = EVP_PKEY_CTX_new_from_pkey(mainctx, b_rfc, NULL))
+        || !TEST_int_gt(EVP_PKEY_derive_init(dctx), 0)
+        || !TEST_int_gt(EVP_PKEY_derive_set_peer(dctx, a_rfc), 0)
+        || (shared_len = sizeof(shared_b),
+            !TEST_int_gt(EVP_PKEY_derive(dctx, shared_b, &shared_len), 0))
+        || !TEST_size_t_eq(shared_len, sizeof(shared_b))
+        || !TEST_mem_eq(shared_a, sizeof(shared_a),
+            shared_b, sizeof(shared_b)))
+        goto err;
+    EVP_PKEY_CTX_free(dctx);
+    dctx = NULL;
+
+    /* Same priv bytes, rfc7748 vs raw-unclamped: different shared secrets. */
+    if (!TEST_ptr(a_local_rfc = x25519_key_with_mode(NULL, NULL))
+        || !TEST_ptr(a_local_raw = x25519_key_with_mode("raw-unclamped", NULL))
+        || !TEST_true(EVP_PKEY_get_octet_string_param(b_rfc,
+            OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY,
+            b_pub, sizeof(b_pub), &b_publen))
+        || !TEST_size_t_eq(b_publen, sizeof(b_pub))
+        || !TEST_ptr(peer_rfc = EVP_PKEY_new_raw_public_key_ex(mainctx,
+                         "X25519", NULL, b_pub, sizeof(b_pub)))
+        || !TEST_ptr(dctx = EVP_PKEY_CTX_new_from_pkey(mainctx, a_local_rfc,
+                         NULL))
+        || !TEST_int_gt(EVP_PKEY_derive_init(dctx), 0)
+        || !TEST_int_gt(EVP_PKEY_derive_set_peer(dctx, peer_rfc), 0)
+        || (shared_len = sizeof(shared_rfc_local),
+            !TEST_int_gt(EVP_PKEY_derive(dctx, shared_rfc_local, &shared_len),
+                0)))
+        goto err;
+    EVP_PKEY_CTX_free(dctx);
+    dctx = NULL;
+    if (!TEST_ptr(dctx = EVP_PKEY_CTX_new_from_pkey(mainctx, a_local_raw,
+                      NULL))
+        || !TEST_int_gt(EVP_PKEY_derive_init(dctx), 0)
+        || !TEST_int_gt(EVP_PKEY_derive_set_peer(dctx, peer_rfc), 0)
+        || (shared_len = sizeof(shared_raw_local),
+            !TEST_int_gt(EVP_PKEY_derive(dctx, shared_raw_local, &shared_len),
+                0))
+        || !TEST_mem_ne(shared_rfc_local, sizeof(shared_rfc_local),
+            shared_raw_local, sizeof(shared_raw_local)))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_PKEY_CTX_free(dctx);
+    EVP_PKEY_free(peer_rfc);
+    EVP_PKEY_free(a_local_raw);
+    EVP_PKEY_free(a_local_rfc);
+    EVP_PKEY_free(a_raw);
+    EVP_PKEY_free(b_rfc);
+    EVP_PKEY_free(a_rfc);
+    return ret;
+}
+
+/* Mode set at keygen via OSSL_PARAM. */
+static int test_x25519_scalar_mode_keygen(void)
+{
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *key = NULL;
+    OSSL_PARAM params[2];
+    char mode[64];
+    size_t modelen = 0;
+    int ret = 0;
+
+    params[0] = OSSL_PARAM_construct_utf8_string("x25519-scalar-mode",
+        (char *)"raw-unclamped", 0);
+    params[1] = OSSL_PARAM_construct_end();
+
+    if (!TEST_ptr(ctx = EVP_PKEY_CTX_new_from_name(mainctx, "X25519", NULL))
+        || !TEST_int_gt(EVP_PKEY_keygen_init(ctx), 0)
+        || !TEST_int_eq(EVP_PKEY_CTX_set_params(ctx, params), 1)
+        || !TEST_int_gt(EVP_PKEY_generate(ctx, &key), 0)
+        || !TEST_true(EVP_PKEY_get_utf8_string_param(key,
+            "x25519-scalar-mode", mode, sizeof(mode), &modelen))
+        || !TEST_str_eq(mode, "raw-unclamped"))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_PKEY_free(key);
+    EVP_PKEY_CTX_free(ctx);
+    return ret;
+}
+
+/* Mode set fails on a public-only X25519 key. */
+static int test_x25519_scalar_mode_public_only(void)
+{
+    EVP_PKEY *priv_key = NULL, *pub_key = NULL;
+    unsigned char pub[32];
+    size_t publen = 0;
+    int ret = 0;
+
+    if (!TEST_ptr(priv_key = x25519_key_with_mode(NULL, NULL))
+        || !TEST_true(EVP_PKEY_get_octet_string_param(priv_key,
+            OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY,
+            pub, sizeof(pub), &publen))
+        || !TEST_size_t_eq(publen, sizeof(pub))
+        || !TEST_ptr(pub_key = EVP_PKEY_new_raw_public_key_ex(mainctx,
+                         "X25519", NULL, pub, sizeof(pub)))
+        || !TEST_false(EVP_PKEY_set_utf8_string_param(pub_key,
+            "x25519-scalar-mode", "raw-unclamped")))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_PKEY_free(pub_key);
+    EVP_PKEY_free(priv_key);
+    return ret;
+}
+#endif /* OPENSSL_NO_ECX */
 #endif /* OPENSSL_NO_EC */
 
 /* This is the equivalent of test_d2i_AutoPrivateKey in evp_extra_test */
@@ -1843,6 +2116,13 @@ int setup_tests(void)
     ADD_TEST(test_new_keytype);
 #ifndef OPENSSL_NO_EC
     ADD_ALL_TESTS(test_d2i_PrivateKey_ex, 2);
+#ifndef OPENSSL_NO_ECX
+    ADD_TEST(test_x25519_scalar_mode_param_basic);
+    ADD_TEST(test_x25519_scalar_mode_round_trip);
+    ADD_TEST(test_x25519_scalar_mode_derive);
+    ADD_TEST(test_x25519_scalar_mode_keygen);
+    ADD_TEST(test_x25519_scalar_mode_public_only);
+#endif
     ADD_TEST(test_ec_d2i_i2d_pubkey);
 #else
     ADD_ALL_TESTS(test_d2i_PrivateKey_ex, 1);


### PR DESCRIPTION
## Description

Add an advanced X25519 key parameter to control scalar preprocessing mode while keeping RFC7748 behavior as the default.  
Fixes #30831.

## Implementation Details

- Added key-level `x25519-scalar-mode` handling for X25519 in `include/crypto/ecx.h`, `crypto/ec/curve25519.c`, `crypto/ec/ecx_key.c`, `crypto/ec/ecx_backend.c`, and `providers/implementations/keymgmt/ecx_kmgmt.c`.
- Kept default mode as RFC7748 and added constrained alternatives (`legacy-ed25519-compat`, `raw-unclamped`) with FIPS guardrails.
- Updated `doc/man7/EVP_PKEY-X25519.pod` and added regression coverage in `test/evp_extra_test2.c`.
- Added a user-visible note in `CHANGES.md`.

## Checklist

- Code follows existing style and keeps default X25519 behavior unchanged.
- Tests added for mode set/get and mode-dependent public key derivation.
- Documentation updated for new user-visible key parameter and provider behavior.
