### PR TITLE
demos/guide/tls-client-block.c: switch to HTTP/1.1

### DIFF
--- a/demos/guide/quic-client-block.c
+++ b/demos/guide/quic-client-block.c
@@ -109,8 +109,8 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
 }
 
 /*
- * Simple application to send a basic HTTP/1.0 request to a server and
- * print the response on the screen. Note that HTTP/1.0 over QUIC is
+ * Simple application to send a basic HTTP/1.1 request to a server and
+ * print the response on the screen. Note that HTTP/1.1 over QUIC is
  * non-standard and will not typically be supported by real world servers. This
  * is for demonstration purposes only.
  */
@@ -121,8 +121,8 @@ int main(int argc, char *argv[])
     BIO *bio = NULL;
     int res = EXIT_FAILURE;
     int ret;
-    unsigned char alpn[] = { 8, 'h', 't', 't', 'p', '/', '1', '.', '0' };
-    const char *request_start = "GET / HTTP/1.0\r\nConnection: close\r\nHost: ";
+    unsigned char alpn[] = { 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
+    const char *request_start = "GET / HTTP/1.1\r\nConnection: close\r\nHost: ";
     const char *request_end = "\r\n\r\n";
     size_t written, readbytes;
     char buf[160];

--- a/demos/guide/quic-client-non-block.c
+++ b/demos/guide/quic-client-non-block.c
@@ -216,8 +216,8 @@ static int handle_io_failure(SSL *ssl, int res)
     }
 }
 /*
- * Simple application to send a basic HTTP/1.0 request to a server and
- * print the response on the screen. Note that HTTP/1.0 over QUIC is
+ * Simple application to send a basic HTTP/1.1 request to a server and
+ * print the response on the screen. Note that HTTP/1.1 over QUIC is
  * non-standard and will not typically be supported by real world servers. This
  * is for demonstration purposes only.
  */
@@ -228,8 +228,8 @@ int main(int argc, char *argv[])
     BIO *bio = NULL;
     int res = EXIT_FAILURE;
     int ret;
-    unsigned char alpn[] = { 8, 'h', 't', 't', 'p', '/', '1', '.', '0' };
-    const char *request_start = "GET / HTTP/1.0\r\nConnection: close\r\nHost: ";
+    unsigned char alpn[] = { 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
+    const char *request_start = "GET / HTTP/1.1\r\nConnection: close\r\nHost: ";
     const char *request_end = "\r\n\r\n";
     size_t written, readbytes = 0;
     char buf[160];

--- a/demos/guide/quic-multi-stream.c
+++ b/demos/guide/quic-multi-stream.c
@@ -126,8 +126,8 @@ static int write_a_request(SSL *stream, const char *request_start,
 }
 
 /*
- * Simple application to send basic HTTP/1.0 requests to a server and print the
- * response on the screen. Note that HTTP/1.0 over QUIC is not a real protocol
+ * Simple application to send basic HTTP/1.1 requests to a server and print the
+ * response on the screen. Note that HTTP/1.1 over QUIC is not a real protocol
  * and will not be supported by real world servers. This is for demonstration
  * purposes only.
  */
@@ -139,9 +139,9 @@ int main(int argc, char *argv[])
     BIO *bio = NULL;
     int res = EXIT_FAILURE;
     int ret;
-    unsigned char alpn[] = { 8, 'h', 't', 't', 'p', '/', '1', '.', '0' };
-    const char *request1_start = "GET /request1.html HTTP/1.0\r\nConnection: close\r\nHost: ";
-    const char *request2_start = "GET /request2.html HTTP/1.0\r\nConnection: close\r\nHost: ";
+    unsigned char alpn[] = { 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
+    const char *request1_start = "GET /request1.html HTTP/1.1\r\nConnection: close\r\nHost: ";
+    const char *request2_start = "GET /request2.html HTTP/1.1\r\nConnection: close\r\nHost: ";
     size_t readbytes;
     char buf[160];
     BIO_ADDR *peer_addr = NULL;
@@ -351,7 +351,7 @@ int main(int argc, char *argv[])
     }
 
     /*
-     * In our hypothetical HTTP/1.0 over QUIC protocol that we are using we
+     * In our hypothetical HTTP/1.1 over QUIC protocol that we are using we
      * assume that the server will respond with a server initiated stream
      * containing the data requested in our uni-directional stream. This doesn't
      * really make sense to do in a real protocol, but its just for

--- a/demos/guide/quic-server-block.c
+++ b/demos/guide/quic-server-block.c
@@ -277,7 +277,7 @@ err:
     return ok;
 }
 
-/* Minimal QUIC HTTP/1.0 server. */
+/* Minimal QUIC HTTP/1.1 server. */
 int main(int argc, char *argv[])
 {
     int res = EXIT_FAILURE;

--- a/demos/guide/quic-server-non-block.c
+++ b/demos/guide/quic-server-non-block.c
@@ -463,7 +463,7 @@ err:
     return ok;
 }
 
-/* Minimal QUIC HTTP/1.0 server. */
+/* Minimal QUIC HTTP/1.1 server. */
 int main(int argc, char *argv[])
 {
     int res = EXIT_FAILURE;

--- a/demos/guide/tls-client-block.c
+++ b/demos/guide/tls-client-block.c
@@ -94,7 +94,7 @@ static BIO *create_socket_bio(const char *hostname, const char *port, int family
 }
 
 /*
- * Simple application to send a basic HTTP/1.0 request to a server and
+ * Simple application to send a basic HTTP/1.1 request to a server and
  * print the response on the screen.
  */
 int main(int argc, char *argv[])
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
     BIO *bio = NULL;
     int res = EXIT_FAILURE;
     int ret;
-    const char *request_start = "GET / HTTP/1.0\r\nConnection: close\r\nHost: ";
+    const char *request_start = "GET / HTTP/1.1\r\nConnection: close\r\nHost: ";
     const char *request_end = "\r\n\r\n";
     size_t written, readbytes;
     char buf[160];

--- a/demos/guide/tls-client-non-block.c
+++ b/demos/guide/tls-client-non-block.c
@@ -171,7 +171,7 @@ static int handle_io_failure(SSL *ssl, int res)
 }
 
 /*
- * Simple application to send a basic HTTP/1.0 request to a server and
+ * Simple application to send a basic HTTP/1.1 request to a server and
  * print the response on the screen.
  */
 int main(int argc, char *argv[])
@@ -181,7 +181,7 @@ int main(int argc, char *argv[])
     BIO *bio = NULL;
     int res = EXIT_FAILURE;
     int ret;
-    const char *request_start = "GET / HTTP/1.0\r\nConnection: close\r\nHost: ";
+    const char *request_start = "GET / HTTP/1.1\r\nConnection: close\r\nHost: ";
     const char *request_end = "\r\n\r\n";
     size_t written, readbytes = 0;
     char buf[160];

--- a/doc/man7/ossl-guide-quic-client-block.pod
+++ b/doc/man7/ossl-guide-quic-client-block.pod
@@ -16,7 +16,7 @@ ossl-guide-quic-client-block
 
 This page will present various source code samples demonstrating how to write
 a simple blocking QUIC client application which connects to a server, sends an
-HTTP/1.0 request to it, and reads back the response. Note that HTTP/1.0 over
+HTTP/1.1 request to it, and reads back the response. Note that HTTP/1.1 over
 QUIC is non-standard and will not be supported by real world servers. This is
 for demonstration purposes only.
 
@@ -205,7 +205,7 @@ simple client that we developed in L<ossl-guide-tls-client-block(7)> did not use
 it. However QUIC mandates that the TLS handshake used in establishing a QUIC
 connection must use ALPN.
 
-    unsigned char alpn[] = { 8, 'h', 't', 't', 'p', '/', '1', '.', '0' };
+    unsigned char alpn[] = { 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
 
     /* SSL_set_alpn_protos returns 0 for success! */
     if (SSL_set_alpn_protos(ssl, alpn, sizeof(alpn)) != 0) {
@@ -215,7 +215,7 @@ connection must use ALPN.
 
 The ALPN is specified using a length prefixed array of unsigned chars (it is not
 a NUL terminated string). Our original TLS blocking client demo was using
-HTTP/1.0. We will use the same for this example. Unlike most OpenSSL functions
+HTTP/1.1. We will use the same for this example. Unlike most OpenSSL functions
 L<SSL_set_alpn_protos(3)> returns zero for success and nonzero for failure.
 
 =head2 Setting the peer address

--- a/doc/man7/ossl-guide-quic-multi-stream.pod
+++ b/doc/man7/ossl-guide-quic-multi-stream.pod
@@ -159,7 +159,7 @@ object it will return NULL.
 
 This section will present various source code samples demonstrating how to write
 a simple multi-stream QUIC client application which connects to a server, send
-some HTTP/1.0 requests to it, and read back the responses. Note that HTTP/1.0
+some HTTP/1.1 requests to it, and read back the responses. Note that HTTP/1.1
 over QUIC is non-standard and will not be supported by real world servers. This
 is for demonstration purposes only.
 
@@ -349,7 +349,7 @@ arrived and is available for us to accept. In the event of an error it will
 return B<NULL>.
 
     /*
-     * In our hypothetical HTTP/1.0 over QUIC protocol that we are using we
+     * In our hypothetical HTTP/1.1 over QUIC protocol that we are using we
      * assume that the server will respond with a server initiated stream
      * containing the data requested in our uni-directional stream. This doesn't
      * really make sense to do in a real protocol, but its just for

--- a/doc/man7/ossl-guide-quic-server-block.pod
+++ b/doc/man7/ossl-guide-quic-server-block.pod
@@ -19,7 +19,7 @@ simple, non-concurrent, QUIC "echo" server application which accepts one client
 connection at a time, echoing input from the client back to the same client.
 Once the current client disconnects, the next client connection is accepted.
 
-The server only accepts HTTP/1.0 requests, which is non-standard and will not
+The server only accepts HTTP/1.1 requests, which is non-standard and will not
 be supported by real world servers.  This is for demonstration purposes only.
 
 Both the accepting socket and client connections are "blocking".  A more typical
@@ -130,14 +130,14 @@ select an ALPN the server considers acceptable.
     /* Setup ALPN negotiation callback to decide which ALPN is accepted. */
     SSL_CTX_set_alpn_select_cb(ctx, select_alpn, NULL);
 
-In this case, we only accept "http/1.0" and "hq-interop".
+In this case, we only accept "http/1.1" and "hq-interop".
 
     /*
-    * ALPN strings for TLS handshake. Only 'http/1.0' and 'hq-interop'
+    * ALPN strings for TLS handshake. Only 'http/1.1' and 'hq-interop'
     * are accepted.
     */
     static const unsigned char alpn_ossltest[] = {
-        8,  'h', 't', 't', 'p', '/', '1', '.', '0',
+        8,  'h', 't', 't', 'p', '/', '1', '.', '1',
         10, 'h', 'q', '-', 'i', 'n', 't', 'e', 'r', 'o', 'p',
     };
 

--- a/doc/man7/ossl-guide-quic-server-non-block.pod
+++ b/doc/man7/ossl-guide-quic-server-non-block.pod
@@ -19,14 +19,14 @@ simple, non-concurrent, QUIC "echo" server application which accepts one client
 connection at a time, echoing input from the client back to the same client.
 Once the current client disconnects, the next client connection is accepted.
 
-The server only accepts C<http/1.0> and C<hq-interop> ALPN's and doesn't actually
+The server only accepts C<http/1.1> and C<hq-interop> ALPN's and doesn't actually
 implement HTTP but only does a simple echo.  This is non-standard and will not
 be supported by real world servers.  This is for demonstration purposes only.
 
 There are various methods to test this server: B<quic-client-block.c> and
-B<quic-client-non-block.c> will send a basic HTTP/1.0 request, which the server
+B<quic-client-non-block.c> will send a basic HTTP/1.1 request, which the server
 will echo back.  You can also test this server by running
-C<openssl s_client -connect localhost:4443 -4 -quic -alpn http/1.0> and entering
+C<openssl s_client -connect localhost:4443 -4 -quic -alpn http/1.1> and entering
 text that will be echoed back by the server.
 
 Both the listening socket and connected socket are "nonblocking".  However,
@@ -140,14 +140,14 @@ select an ALPN the server considers acceptable.
     /* Setup ALPN negotiation callback to decide which ALPN is accepted. */
     SSL_CTX_set_alpn_select_cb(ctx, select_alpn, NULL);
 
-In this case, we only accept "http/1.0" and "hq-interop".
+In this case, we only accept "http/1.1" and "hq-interop".
 
     /*
-    * ALPN strings for TLS handshake. Only 'http/1.0' and 'hq-interop'
+    * ALPN strings for TLS handshake. Only 'http/1.1' and 'hq-interop'
     * are accepted.
     */
     static const unsigned char alpn_ossltest[] = {
-        8,  'h', 't', 't', 'p', '/', '1', '.', '0',
+        8,  'h', 't', 't', 'p', '/', '1', '.', '1',
         10, 'h', 'q', '-', 'i', 'n', 't', 'e', 'r', 'o', 'p',
     };
 

--- a/doc/man7/ossl-guide-tls-client-block.pod
+++ b/doc/man7/ossl-guide-tls-client-block.pod
@@ -15,7 +15,7 @@ ossl-guide-tls-client-block
 =head1 SIMPLE BLOCKING TLS CLIENT EXAMPLE
 
 This page will present various source code samples demonstrating how to write
-a simple TLS client application which connects to a server, sends an HTTP/1.0
+a simple TLS client application which connects to a server, sends an HTTP/1.1
 request to it, and reads back the response.
 
 We use a blocking socket for the purposes of this example. This means that
@@ -353,7 +353,7 @@ chunks. First we write the start of the request. Secondly we write the hostname
 we are sending the request to. Finally we send the end of the request.
 
     size_t written;
-    const char *request_start = "GET / HTTP/1.0\r\nConnection: close\r\nHost: ";
+    const char *request_start = "GET / HTTP/1.1\r\nConnection: close\r\nHost: ";
     const char *request_end = "\r\n\r\n";
 
     /* Write an HTTP GET request to the peer */


### PR DESCRIPTION
The Host Header comes with HTTP/1.1, not 1.0, and some Web Server now doesn't want to answer to such requests.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

