### PR TITLE
Fix function pointer type mismatch when freeing ML-KEM and ECX keys

### DIFF
--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -35,6 +35,7 @@ static OSSL_FUNC_keymgmt_new_fn x25519_new_key;
 static OSSL_FUNC_keymgmt_new_fn x448_new_key;
 static OSSL_FUNC_keymgmt_new_fn ed25519_new_key;
 static OSSL_FUNC_keymgmt_new_fn ed448_new_key;
+static OSSL_FUNC_keymgmt_free_fn ecx_free_key;
 static OSSL_FUNC_keymgmt_gen_init_fn x25519_gen_init;
 static OSSL_FUNC_keymgmt_gen_init_fn x448_gen_init;
 static OSSL_FUNC_keymgmt_gen_init_fn ed25519_gen_init;
@@ -993,10 +994,15 @@ static int ed448_validate(const void *keydata, int selection, int checktype)
     return ecx_validate(keydata, selection, ECX_KEY_TYPE_ED448, ED448_KEYLEN);
 }
 
+static void ecx_free_key(void *keydata)
+{
+    ossl_ecx_key_free((ECX_KEY *)keydata);
+}
+
 #define MAKE_KEYMGMT_FUNCTIONS(alg)                                                   \
     const OSSL_DISPATCH ossl_##alg##_keymgmt_functions[] = {                          \
         { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))alg##_new_key },                     \
-        { OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))ossl_ecx_key_free },                \
+        { OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))ecx_free_key },                     \
         { OSSL_FUNC_KEYMGMT_GET_PARAMS, (void (*)(void))alg##_get_params },           \
         { OSSL_FUNC_KEYMGMT_GETTABLE_PARAMS, (void (*)(void))alg##_gettable_params }, \
         { OSSL_FUNC_KEYMGMT_SET_PARAMS, (void (*)(void))alg##_set_params },           \

--- a/providers/implementations/keymgmt/ml_kem_kmgmt.c
+++ b/providers/implementations/keymgmt/ml_kem_kmgmt.c
@@ -35,6 +35,7 @@
 static OSSL_FUNC_keymgmt_new_fn ml_kem_512_new;
 static OSSL_FUNC_keymgmt_new_fn ml_kem_768_new;
 static OSSL_FUNC_keymgmt_new_fn ml_kem_1024_new;
+static OSSL_FUNC_keymgmt_free_fn ml_kem_free_key;
 static OSSL_FUNC_keymgmt_gen_fn ml_kem_gen;
 static OSSL_FUNC_keymgmt_gen_init_fn ml_kem_512_gen_init;
 static OSSL_FUNC_keymgmt_gen_init_fn ml_kem_768_gen_init;
@@ -826,6 +827,11 @@ static void *ml_kem_dup(const void *vkey, int selection)
     return ossl_ml_kem_key_dup(key, selection);
 }
 
+static void ml_kem_free_key(void *keydata)
+{
+    ossl_ml_kem_key_free((ML_KEM_KEY *)keydata);
+}
+
 #ifndef FIPS_MODULE
 #define DISPATCH_LOAD_FN \
     { OSSL_FUNC_KEYMGMT_LOAD, (OSSL_FUNC)ml_kem_load },
@@ -848,7 +854,7 @@ static void *ml_kem_dup(const void *vkey, int selection)
     }                                                                                     \
     const OSSL_DISPATCH ossl_ml_kem_##bits##_keymgmt_functions[] = {                      \
         { OSSL_FUNC_KEYMGMT_NEW, (OSSL_FUNC)ml_kem_##bits##_new },                        \
-        { OSSL_FUNC_KEYMGMT_FREE, (OSSL_FUNC)ossl_ml_kem_key_free },                      \
+        { OSSL_FUNC_KEYMGMT_FREE, (OSSL_FUNC)ml_kem_free_key },                           \
         { OSSL_FUNC_KEYMGMT_GET_PARAMS, (OSSL_FUNC)ml_kem_get_params },                   \
         { OSSL_FUNC_KEYMGMT_GETTABLE_PARAMS, (OSSL_FUNC)ml_kem_gettable_params },         \
         { OSSL_FUNC_KEYMGMT_SET_PARAMS, (OSSL_FUNC)ml_kem_set_params },                   \


### PR DESCRIPTION
`ossl_ml_kem_key_free` is declared as `void(ML_KEM_KEY *)` but registered
directly in the ML-KEM keymgmt `OSSL_DISPATCH` table for
`OSSL_FUNC_KEYMGMT_FREE`, which is invoked through a `void(*)(void *)`
pointer in `evp_keymgmt_freedata`. Calling a function through a pointer
to an incompatible function type is undefined behavior and is reported
by UndefinedBehaviorSanitizer on every ML-KEM key free:

```
crypto/evp/keymgmt_meth.c:392:5: runtime error: call to function
  ossl_ml_kem_key_free through pointer to incorrect function type
  'void (*)(void *)'
crypto/ml_kem/ml_kem.c:1751: note: ossl_ml_kem_key_free defined here
```

Reproducible with a minimal program against `libcrypto.a` built with
`-fsanitize=undefined`:

```c
EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_from_name(NULL, "ML-KEM-1024", NULL);
EVP_PKEY *pkey = NULL;
EVP_PKEY_keygen_init(ctx);
EVP_PKEY_keygen(ctx, &pkey);
EVP_PKEY_free(pkey);   /* UBSan fires here */
```

Mirror the wrapper pattern used by `ml_dsa_free_key`, `slh_dsa_free_key`,
`dsa_freedata`, `ec_freedata`, and `lms_free_key`: add a small static
`ml_kem_free_key` with the correct `OSSL_FUNC_keymgmt_free_fn` signature
that forwards to `ossl_ml_kem_key_free`, and register the wrapper in the
dispatch table.

---

**Update (commit 9df88ff):** the same UB exists in `providers/implementations/keymgmt/ecx_kmgmt.c`,
where `ossl_ecx_key_free` (declared `void(ECX_KEY *)`) is registered
directly in the `MAKE_KEYMGMT_FUNCTIONS` dispatch macro covering X25519,
X448, Ed25519, and Ed448. UBSan reports:

```
crypto/evp/keymgmt_meth.c:392:5: runtime error: call to function
  ossl_ecx_key_free through pointer to incorrect function type
  'void (*)(void *)'
crypto/ec/ecx_key.c:65: note: ossl_ecx_key_free defined here
```

The follow-up commit applies the same wrapper pattern (`ecx_free_key`)
in `ecx_kmgmt.c`, which fixes all four algorithms in one place.
