### PR TITLE
ARGON2: Add a helper API that uses non OSSL_PARAM options for common params.

### DIFF
--- a/crypto/kdf/build.info
+++ b/crypto/kdf/build.info
@@ -1,2 +1,2 @@
 LIBS=../../libcrypto
-SOURCE[../../libcrypto]=kdf_err.c
+SOURCE[../../libcrypto]=kdf_err.c kdf_helper.c

--- a/crypto/kdf/kdf_helper.c
+++ b/crypto/kdf/kdf_helper.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/kdf.h>
+#include <openssl/err.h>
+#include <openssl/evperr.h>
+#include <openssl/core_names.h>
+#include <openssl/params.h>
+
+#ifndef OPENSSL_NO_ARGON2
+int EVP_KDF_argon2(uint8_t *out, size_t outlen,
+    int alg_type,
+    const uint8_t *pass, size_t passlen,
+    const uint8_t *salt, size_t saltlen,
+    uint32_t lanes, uint32_t memorycost, uint32_t iterations,
+    OSSL_LIB_CTX *libctx, const OSSL_PARAM *optionals)
+{
+    int ret = 0;
+    EVP_KDF_CTX *kctx = NULL;
+    EVP_KDF *kdf = NULL;
+    OSSL_PARAM params[7], *p = params;
+    const OSSL_PARAM *propq_param;
+    const char *propq = NULL;
+    const char *alg;
+
+    switch (alg_type) {
+    case EVP_KDF_ARGON2ID_TYPE:
+        alg = "argon2id";
+        break;
+    case EVP_KDF_ARGON2I_TYPE:
+        alg = "argon2i";
+        break;
+    case EVP_KDF_ARGON2D_TYPE:
+        alg = "argon2d";
+        break;
+    default:
+        ERR_raise(ERR_LIB_EVP, EVP_R_BAD_ALGORITHM_NAME);
+        return 0;
+    }
+    if (pass == NULL || passlen == 0) {
+        ERR_raise_data(ERR_LIB_EVP, EVP_R_INVALID_VALUE, "Password required");
+        return 0;
+    }
+    if (salt == NULL || saltlen == 0) {
+        ERR_raise_data(ERR_LIB_EVP, EVP_R_INVALID_VALUE, "Salt required");
+        return 0;
+    }
+
+    propq_param = OSSL_PARAM_locate_const(optionals, OSSL_ALG_PARAM_PROPERTIES);
+    if (propq_param != NULL && !OSSL_PARAM_get_utf8_string_ptr(propq_param, &propq))
+        return 0;
+
+    kdf = EVP_KDF_fetch(libctx, alg, propq);
+    kctx = EVP_KDF_CTX_new(kdf);
+    if (kctx == NULL)
+        goto err;
+
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_PASSWORD, (uint8_t *)pass, passlen);
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT, (uint8_t *)salt, saltlen);
+    *p++ = OSSL_PARAM_construct_uint32(OSSL_KDF_PARAM_ARGON2_LANES, &lanes);
+    *p++ = OSSL_PARAM_construct_uint32(OSSL_KDF_PARAM_ARGON2_MEMCOST, &memorycost);
+    *p++ = OSSL_PARAM_construct_uint32(OSSL_KDF_PARAM_ITER, &iterations);
+    *p = OSSL_PARAM_construct_end();
+
+    if (optionals != NULL && !EVP_KDF_CTX_set_params(kctx, optionals)) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_CANNOT_SET_PARAMETERS);
+        goto err;
+    }
+
+    if (EVP_KDF_derive(kctx, out, outlen, params) != 1)
+        goto err;
+    ret = 1;
+err:
+    EVP_KDF_free(kdf);
+    EVP_KDF_CTX_free(kctx);
+    return ret;
+}
+#endif /* OPENSSL_NO_ARGON2 */

--- a/crypto/kdf/kdf_helper.c
+++ b/crypto/kdf/kdf_helper.c
@@ -19,14 +19,13 @@ int EVP_KDF_argon2(uint8_t *out, size_t outlen,
     const uint8_t *pass, size_t passlen,
     const uint8_t *salt, size_t saltlen,
     uint32_t lanes, uint32_t memorycost, uint32_t iterations,
-    OSSL_LIB_CTX *libctx, const OSSL_PARAM *optionals)
+    OSSL_LIB_CTX *libctx, const char *propq,
+    const OSSL_PARAM *optionals)
 {
     int ret = 0;
     EVP_KDF_CTX *kctx = NULL;
     EVP_KDF *kdf = NULL;
     OSSL_PARAM params[7], *p = params;
-    const OSSL_PARAM *propq_param;
-    const char *propq = NULL;
     const char *alg;
 
     switch (alg_type) {
@@ -43,29 +42,24 @@ int EVP_KDF_argon2(uint8_t *out, size_t outlen,
         ERR_raise(ERR_LIB_EVP, EVP_R_BAD_ALGORITHM_NAME);
         return 0;
     }
-    if (pass == NULL || passlen == 0) {
-        ERR_raise_data(ERR_LIB_EVP, EVP_R_INVALID_VALUE, "Password required");
-        return 0;
-    }
     if (salt == NULL || saltlen == 0) {
         ERR_raise_data(ERR_LIB_EVP, EVP_R_INVALID_VALUE, "Salt required");
         return 0;
     }
 
-    propq_param = OSSL_PARAM_locate_const(optionals, OSSL_ALG_PARAM_PROPERTIES);
-    if (propq_param != NULL && !OSSL_PARAM_get_utf8_string_ptr(propq_param, &propq))
-        return 0;
-
     kdf = EVP_KDF_fetch(libctx, alg, propq);
     kctx = EVP_KDF_CTX_new(kdf);
     if (kctx == NULL)
         goto err;
-
-    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_PASSWORD, (uint8_t *)pass, passlen);
+    if (pass != NULL && passlen > 0)
+        *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_PASSWORD, (uint8_t *)pass, passlen);
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT, (uint8_t *)salt, saltlen);
     *p++ = OSSL_PARAM_construct_uint32(OSSL_KDF_PARAM_ARGON2_LANES, &lanes);
     *p++ = OSSL_PARAM_construct_uint32(OSSL_KDF_PARAM_ARGON2_MEMCOST, &memorycost);
     *p++ = OSSL_PARAM_construct_uint32(OSSL_KDF_PARAM_ITER, &iterations);
+    /* If there is no optional propq set it to the propq used by the fetch */
+    if (propq != NULL && OSSL_PARAM_locate_const(optionals, OSSL_KDF_PARAM_PROPERTIES) == NULL)
+        *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_PROPERTIES, (char *)propq, 0);
     *p = OSSL_PARAM_construct_end();
 
     if (optionals != NULL && !EVP_KDF_CTX_set_params(kctx, optionals)) {

--- a/doc/man3/EVP_KDF.pod
+++ b/doc/man3/EVP_KDF.pod
@@ -12,7 +12,8 @@ EVP_KDF_get0_name, EVP_KDF_names_do_all, EVP_KDF_get0_description,
 EVP_KDF_CTX_get_params, EVP_KDF_CTX_set_params, EVP_KDF_do_all_provided,
 EVP_KDF_get_params, EVP_KDF_gettable_params,
 EVP_KDF_gettable_ctx_params, EVP_KDF_settable_ctx_params,
-EVP_KDF_CTX_gettable_params, EVP_KDF_CTX_settable_params - EVP KDF routines
+EVP_KDF_CTX_gettable_params, EVP_KDF_CTX_settable_params,
+EVP_KDF_argon2 - EVP KDF routines
 
 =head1 SYNOPSIS
 
@@ -56,6 +57,11 @@ EVP_KDF_CTX_gettable_params, EVP_KDF_CTX_settable_params - EVP KDF routines
  const OSSL_PARAM *EVP_KDF_CTX_gettable_params(const EVP_KDF *kdf);
  const OSSL_PARAM *EVP_KDF_CTX_settable_params(const EVP_KDF *kdf);
  const OSSL_PROVIDER *EVP_KDF_get0_provider(const EVP_KDF *kdf);
+ int EVP_KDF_argon2(uint8_t *out, size_t outlen, int alg_type,
+                    const uint8_t *pass, size_t passlen,
+                    const uint8_t *salt, size_t saltlen,
+                    uint32_t lanes, uint32_t memorycost, uint32_t iterations,
+                    OSSL_LIB_CTX *libctx, const OSSL_PARAM *optionals);
 
 =head1 DESCRIPTION
 
@@ -197,6 +203,18 @@ EVP_KDF_get0_description() returns a description of the I<kdf>, meant for
 display and human consumption.  The description is at the discretion of
 the I<kdf> implementation.
 
+=head2 Helper functions
+
+These are one shot helper functions for KDF algorithms that contain typical
+parameters, but also allow less common optional parameters to be specified in a
+general form using OSSL_PARAM.
+
+EVP_KDF_argon2() uses the I<alg_type> (which is one of EVP_KDF_ARGON2ID_TYPE,
+EVP_KDF_ARGON2D_TYPE or EVP_KDF_ARGON2I_TYPE) and other parameters such as
+the password I<pass> and salt I<salt>, to derive I<outlen> bytes of key
+material into the buffer I<out>. See L<EVP_KDF-ARGON2(7)/Supported parameters>
+for more information related to parameters supported by Argon2.
+
 =head1 PARAMETERS
 
 The standard parameter names are:
@@ -324,9 +342,11 @@ This functionality was added in OpenSSL 3.0.
 EVP_KDF_derive_SKEY() and EVP_KDF_CTX_set_SKEY() functions were introduced in
 OpenSSL 3.6.
 
+EVP_KDF_argon2() was added in OpenSSL 4.1.
+
 =head1 COPYRIGHT
 
-Copyright 2019-2025 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2019-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/EVP_KDF.pod
+++ b/doc/man3/EVP_KDF.pod
@@ -12,7 +12,8 @@ EVP_KDF_get0_name, EVP_KDF_names_do_all, EVP_KDF_get0_description,
 EVP_KDF_CTX_get_params, EVP_KDF_CTX_set_params, EVP_KDF_do_all_provided,
 EVP_KDF_get_params, EVP_KDF_gettable_params,
 EVP_KDF_gettable_ctx_params, EVP_KDF_settable_ctx_params,
-EVP_KDF_CTX_gettable_params, EVP_KDF_CTX_settable_params - EVP KDF routines
+EVP_KDF_CTX_gettable_params, EVP_KDF_CTX_settable_params,
+EVP_KDF_argon2 - EVP KDF routines
 
 =head1 SYNOPSIS
 
@@ -57,6 +58,11 @@ EVP_KDF_CTX_gettable_params, EVP_KDF_CTX_settable_params - EVP KDF routines
  const OSSL_PARAM *EVP_KDF_CTX_gettable_params(const EVP_KDF *kdf);
  const OSSL_PARAM *EVP_KDF_CTX_settable_params(const EVP_KDF *kdf);
  const OSSL_PROVIDER *EVP_KDF_get0_provider(const EVP_KDF *kdf);
+ int EVP_KDF_argon2(uint8_t *out, size_t outlen, int alg_type,
+                    const uint8_t *pass, size_t passlen,
+                    const uint8_t *salt, size_t saltlen,
+                    uint32_t lanes, uint32_t memorycost, uint32_t iterations,
+                    OSSL_LIB_CTX *libctx, const OSSL_PARAM *optionals);
 
 The following functions have been deprecated since OpenSSL 4.1,
 and can be hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable
@@ -206,6 +212,18 @@ EVP_KDF_get0_description() returns a description of the I<kdf>, meant for
 display and human consumption.  The description is at the discretion of
 the I<kdf> implementation.
 
+=head2 Helper functions
+
+These are one shot helper functions for KDF algorithms that contain typical
+parameters, but also allow less common optional parameters to be specified in a
+general form using OSSL_PARAM.
+
+EVP_KDF_argon2() uses the I<alg_type> (which is one of EVP_KDF_ARGON2ID_TYPE,
+EVP_KDF_ARGON2D_TYPE or EVP_KDF_ARGON2I_TYPE) and other parameters such as
+the password I<pass> and salt I<salt>, to derive I<outlen> bytes of key
+material into the buffer I<out>. See L<EVP_KDF-ARGON2(7)/Supported parameters>
+for more information related to parameters supported by Argon2.
+
 =head1 PARAMETERS
 
 The standard parameter names are:
@@ -333,7 +351,7 @@ This functionality was added in OpenSSL 3.0.
 EVP_KDF_derive_SKEY() and EVP_KDF_CTX_set_SKEY() functions were introduced in
 OpenSSL 3.6.
 
-EVP_KDF_CTX_get0_kdf() and EVP_KDF_CTX_get1_kdf() functions were introduced
+EVP_KDF_argon2(), EVP_KDF_CTX_get0_kdf() and EVP_KDF_CTX_get1_kdf() functions were introduced
 in OpenSSL 4.1.
 
 EVP_KDF_CTX_kdf() function was deprecated in favour of EVP_KDF_CTX_get0_kdf()
@@ -341,7 +359,7 @@ in OpenSSL 4.1.
 
 =head1 COPYRIGHT
 
-Copyright 2019-2025 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2019-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/EVP_KDF.pod
+++ b/doc/man3/EVP_KDF.pod
@@ -62,7 +62,8 @@ EVP_KDF_argon2 - EVP KDF routines
                     const uint8_t *pass, size_t passlen,
                     const uint8_t *salt, size_t saltlen,
                     uint32_t lanes, uint32_t memorycost, uint32_t iterations,
-                    OSSL_LIB_CTX *libctx, const OSSL_PARAM *optionals);
+                    OSSL_LIB_CTX *libctx, const char *propq,
+                    const OSSL_PARAM *optionals);
 
 The following functions have been deprecated since OpenSSL 4.1,
 and can be hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable
@@ -221,12 +222,16 @@ general form using OSSL_PARAM.
 EVP_KDF_argon2() uses the I<alg_type> (which is one of EVP_KDF_ARGON2ID_TYPE,
 EVP_KDF_ARGON2D_TYPE or EVP_KDF_ARGON2I_TYPE) and other parameters such as
 the password I<pass> and salt I<salt>, to derive I<outlen> bytes of key
-material into the buffer I<out>. See L<EVP_KDF-ARGON2(7)/Supported parameters>
-for more information related to parameters supported by Argon2.
+material into the buffer I<out>. The I<libctx> and I<propq> parameters are used
+to fetch the EVP_KDF-ARGON2 algorithm. Note that I<propq> will also be used for
+internal fetches if OSSL_KDF_PARAM_PROPERTIES is not specified as an optional
+parameter. I<pass> is allowed to be NULL, but I<salt> must be set.
+See L<EVP_KDF-ARGON2(7)/Supported parameters> for more information
+related to parameters supported by Argon2 that can be set as I<optionals>.
 
 =head1 PARAMETERS
 
-The standard parameter names are:
+The standard KDF parameter names are:
 
 =over 4
 

--- a/doc/man7/EVP_KDF-ARGON2.pod
+++ b/doc/man7/EVP_KDF-ARGON2.pod
@@ -99,30 +99,46 @@ are to be generated from a single password and secret.
 
 =head1 EXAMPLES
 
-This example uses Argon2d with password "1234567890", salt "saltsalt",
-using 2 lanes, 2 threads, and memory cost of 65536:
+This example uses Argon2id with an input password, and salt,
+using 2 lanes, and memory cost of 65536 using a one shot function:
 
- #include <string.h>                 /* strlen               */
+ #include <openssl/kdf.h>            /* EVP_KDF_*            */
+
+ /* argon2 params, please refer to RFC9106 for recommended defaults */
+ uint32_t lanes = 2, memcost = 65536, iterations = 3;
+ size_t outlen = 128;
+ unsigned char result[outlen];
+
+ int do_argon2id(const unsigned char *pwd, size_t pwdlen,
+     const unsigned char *salt, size_t saltlen)
+ {
+
+     if (!EVP_KDF_argon2(result, outlen, EVP_KDF_ARGON2ID_TYPE,
+         pwd, pwdlen, salt, saltlen, lanes, memcost, iterations, NULL, NULL))
+        return 0;
+    printf("Output = %s\n", OPENSSL_buf2hexstr(result, outlen));
+    return 1
+ }
+
+This example uses Argon2id with an input password, and salt,
+using 2 lanes, 2 threads and a memory cost of 65536 using OSSL_PARAM:
+
  #include <openssl/core_names.h>     /* OSSL_KDF_*           */
  #include <openssl/params.h>         /* OSSL_PARAM_*         */
  #include <openssl/thread.h>         /* OSSL_set_max_threads */
- #include <openssl/kdf.h>            /* EVP_KDF_*            */
 
- int main(void)
+ int do_argon2id(const unsigned char *password, size_t passlen,
+     const unsigned char *salt, size_t saltlen)
  {
-     int retval = 1;
+     int ret = 0;
+     uint32 threads = 2;
 
      EVP_KDF *kdf = NULL;
      EVP_KDF_CTX *kctx = NULL;
-     OSSL_PARAM params[6], *p = params;
-
-     /* argon2 params, please refer to RFC9106 for recommended defaults */
-     uint32_t lanes = 2, threads = 2, memcost = 65536;
-     char pwd[] = "1234567890", salt[] = "saltsalt";
+     OSSL_PARAM params[7], *p = params;
 
      /* derive result */
-     size_t outlen = 128;
-     unsigned char result[outlen];
+
 
      /* required if threads > 1 */
      if (OSSL_set_max_threads(NULL, threads) != 1)
@@ -135,12 +151,11 @@ using 2 lanes, 2 threads, and memory cost of 65536:
      *p++ = OSSL_PARAM_construct_uint32(OSSL_KDF_PARAM_ARGON2_MEMCOST,
                                         &memcost);
      *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
-                                              salt,
-                                              strlen((const char *)salt));
+                                              salt, saltlen));
      *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_PASSWORD,
-                                              pwd,
-                                              strlen((const char *)pwd));
-     *p++ = OSSL_PARAM_construct_end();
+                                              pwd, pwdlen));
+     *p++ = OSSL_PARAM_construct_uint32(OSSL_KDF_PARAM_ITER, &iterations);
+     *p = OSSL_PARAM_construct_end();
 
      if ((kdf = EVP_KDF_fetch(NULL, "ARGON2D", NULL)) == NULL)
          goto fail;
@@ -150,21 +165,14 @@ using 2 lanes, 2 threads, and memory cost of 65536:
          goto fail;
 
      printf("Output = %s\n", OPENSSL_buf2hexstr(result, outlen));
-     retval = 0;
+     ret = 1;
 
  fail:
      EVP_KDF_free(kdf);
      EVP_KDF_CTX_free(kctx);
      OSSL_set_max_threads(NULL, 0);
-
-     return retval;
+     return ret;
  }
-
-This example uses a simpler one shot function using the same parameters:
-
- return EVP_KDF_argon2(result, outlen, EVP_KDF_ARGON2D_TYPE,
-     pwd, strlen((const char *)pwd), salt, strlen((const char *)salt),
-     lanes, memcost, 1, NULL, NULL);
 
 =head1 NOTES
 
@@ -188,10 +196,11 @@ L<EVP_KDF_argon2(3)>
 =head1 HISTORY
 
 This functionality was added to OpenSSL 3.2.
+The function EVP_KDF_argon2() was added in OpenSSL 4.1.
 
 =head1 COPYRIGHT
 
-Copyright 2022-2024 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2022-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man7/EVP_KDF-ARGON2.pod
+++ b/doc/man7/EVP_KDF-ARGON2.pod
@@ -160,6 +160,12 @@ using 2 lanes, 2 threads, and memory cost of 65536:
      return retval;
  }
 
+This example uses a simpler one shot function using the same parameters:
+
+ return EVP_KDF_argon2(result, outlen, EVP_KDF_ARGON2D_TYPE,
+     pwd, strlen((const char *)pwd), salt, strlen((const char *)salt),
+     lanes, memcost, 1, NULL, NULL);
+
 =head1 NOTES
 
 "ARGON2I", "ARGON2D", and "ARGON2ID" are the names for this implementation; it
@@ -177,6 +183,7 @@ L<EVP_KDF_CTX_free(3)>,
 L<EVP_KDF_CTX_set_params(3)>,
 L<EVP_KDF_derive(3)>,
 L<EVP_KDF(3)/PARAMETERS>
+L<EVP_KDF_argon2(3)>
 
 =head1 HISTORY
 

--- a/doc/man7/EVP_KDF-ARGON2.pod
+++ b/doc/man7/EVP_KDF-ARGON2.pod
@@ -114,7 +114,7 @@ using 2 lanes, and memory cost of 65536 using a one shot function:
  {
 
      if (!EVP_KDF_argon2(result, outlen, EVP_KDF_ARGON2ID_TYPE,
-         pwd, pwdlen, salt, saltlen, lanes, memcost, iterations, NULL, NULL))
+         pwd, pwdlen, salt, saltlen, lanes, memcost, iterations, NULL, NULL, NULL))
         return 0;
     printf("Output = %s\n", OPENSSL_buf2hexstr(result, outlen));
     return 1

--- a/include/openssl/kdf.h
+++ b/include/openssl/kdf.h
@@ -78,6 +78,19 @@ int EVP_KDF_names_do_all(const EVP_KDF *kdf,
 #define EVP_KDF_SSHKDF_TYPE_INTEGRITY_KEY_CLI_TO_SRV 69
 #define EVP_KDF_SSHKDF_TYPE_INTEGRITY_KEY_SRV_TO_CLI 70
 
+/* Helper API functions */
+
+#define EVP_KDF_ARGON2ID_TYPE 0
+#define EVP_KDF_ARGON2I_TYPE 1
+#define EVP_KDF_ARGON2D_TYPE 2
+
+int EVP_KDF_argon2(uint8_t *out, size_t outlen,
+    int alg_type,
+    const uint8_t *pass, size_t passlen,
+    const uint8_t *salt, size_t saltlen,
+    uint32_t lanes, uint32_t memorycost, uint32_t iterations,
+    OSSL_LIB_CTX *libctx, const OSSL_PARAM *optionals);
+
 /**** The legacy PKEY-based KDF API follows. ****/
 
 #define EVP_PKEY_CTRL_TLS_MD (EVP_PKEY_ALG_CTRL)

--- a/include/openssl/kdf.h
+++ b/include/openssl/kdf.h
@@ -95,7 +95,8 @@ int EVP_KDF_argon2(uint8_t *out, size_t outlen,
     const uint8_t *pass, size_t passlen,
     const uint8_t *salt, size_t saltlen,
     uint32_t lanes, uint32_t memorycost, uint32_t iterations,
-    OSSL_LIB_CTX *libctx, const OSSL_PARAM *optionals);
+    OSSL_LIB_CTX *libctx, const char *propq,
+    const OSSL_PARAM *optionals);
 
 /**** The legacy PKEY-based KDF API follows. ****/
 

--- a/include/openssl/kdf.h
+++ b/include/openssl/kdf.h
@@ -84,6 +84,19 @@ int EVP_KDF_names_do_all(const EVP_KDF *kdf,
 #define EVP_KDF_SSHKDF_TYPE_INTEGRITY_KEY_CLI_TO_SRV 69
 #define EVP_KDF_SSHKDF_TYPE_INTEGRITY_KEY_SRV_TO_CLI 70
 
+/* Helper API functions */
+
+#define EVP_KDF_ARGON2ID_TYPE 0
+#define EVP_KDF_ARGON2I_TYPE 1
+#define EVP_KDF_ARGON2D_TYPE 2
+
+int EVP_KDF_argon2(uint8_t *out, size_t outlen,
+    int alg_type,
+    const uint8_t *pass, size_t passlen,
+    const uint8_t *salt, size_t saltlen,
+    uint32_t lanes, uint32_t memorycost, uint32_t iterations,
+    OSSL_LIB_CTX *libctx, const OSSL_PARAM *optionals);
+
 /**** The legacy PKEY-based KDF API follows. ****/
 
 #define EVP_PKEY_CTRL_TLS_MD (EVP_PKEY_ALG_CTRL)

--- a/test/evp_kdf_test.c
+++ b/test/evp_kdf_test.c
@@ -2341,6 +2341,160 @@ err:
 }
 #endif /* OPENSSL_NO_KBKDF */
 
+#ifndef OPENSSL_NO_ARGON2
+
+/*
+ * Test vectors from
+ * https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-argon2
+ */
+static const uint8_t argon2_pass[] = {
+    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01
+};
+static const uint8_t argon2_salt[] = {
+    0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
+    0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02
+};
+static const uint8_t argon2_secret[] = {
+    0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03
+};
+static const uint8_t argon2_ad[] = {
+    0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04,
+    0x04, 0x04, 0x04, 0x04
+};
+const uint32_t argon2_lanes = 4;
+const uint32_t argon2_memcost = 32;
+const uint32_t argon2_iterations = 3;
+
+static int test_argon2_helper(void)
+{
+    int ret = 0;
+    uint8_t out[32];
+    size_t outlen = sizeof(out);
+
+    static const uint8_t expected1[] = {
+        0x51, 0x2b, 0x39, 0x1b, 0x6f, 0x11, 0x62, 0x97,
+        0x53, 0x71, 0xd3, 0x09, 0x19, 0x73, 0x42, 0x94,
+        0xf8, 0x68, 0xe3, 0xbe, 0x39, 0x84, 0xf3, 0xc1,
+        0xa1, 0x3a, 0x4d, 0xb9, 0xfa, 0xbe, 0x4a, 0xcb
+    };
+    static const uint8_t expected2[] = {
+        0xc8, 0x14, 0xd9, 0xd1, 0xdc, 0x7f, 0x37, 0xaa,
+        0x13, 0xf0, 0xd7, 0x7f, 0x24, 0x94, 0xbd, 0xa1,
+        0xc8, 0xde, 0x6b, 0x01, 0x6d, 0xd3, 0x88, 0xd2,
+        0x99, 0x52, 0xa4, 0xc4, 0x67, 0x2b, 0x6c, 0xe8
+    };
+    const uint8_t expected3[] = {
+        0x0d, 0x64, 0x0d, 0xf5, 0x8d, 0x78, 0x76, 0x6c,
+        0x08, 0xc0, 0x37, 0xa3, 0x4a, 0x8b, 0x53, 0xc9,
+        0xd0, 0x1e, 0xf0, 0x45, 0x2d, 0x75, 0xb6, 0x5e,
+        0xb5, 0x25, 0x20, 0xe9, 0x6b, 0x01, 0xe6, 0x59
+    };
+    OSSL_PARAM optionals[4];
+
+    optionals[0] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SECRET, (uint8_t *)argon2_secret, sizeof(argon2_secret));
+    optionals[1] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_ARGON2_AD, (uint8_t *)argon2_ad, sizeof(argon2_ad));
+    optionals[2] = OSSL_PARAM_construct_end();
+    optionals[3] = OSSL_PARAM_construct_end();
+
+    if (!TEST_true(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            4, 32, 3, NULL, optionals)))
+        goto err;
+    if (!TEST_mem_eq(out, outlen, expected1, sizeof(expected1)))
+        goto err;
+
+    if (!TEST_true(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2I_TYPE,
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            4, 32, 3, NULL, optionals)))
+        goto err;
+    if (!TEST_mem_eq(out, outlen, expected2, sizeof(expected2)))
+        goto err;
+
+    optionals[2] = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_PROPERTIES, "provider=default", 0);
+    if (!TEST_true(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2ID_TYPE,
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            4, 32, 3, NULL, optionals)))
+        goto err;
+    if (!TEST_mem_eq(out, outlen, expected3, sizeof(expected3)))
+        goto err;
+    ret = 1;
+err:
+    return ret;
+}
+
+static int test_argon2_helper_fail(void)
+{
+    int ret = 0;
+    int32_t rubbish = 1;
+    uint8_t out[32];
+    size_t outlen = 32;
+    OSSL_PARAM optionals[4];
+
+    ERR_set_mark();
+    optionals[0] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SECRET, (uint8_t *)argon2_secret, sizeof(argon2_secret));
+    optionals[1] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_ARGON2_AD, (uint8_t *)argon2_ad, sizeof(argon2_ad));
+    optionals[2] = OSSL_PARAM_construct_end();
+    optionals[3] = OSSL_PARAM_construct_end();
+
+    /* Bad algorithm type */
+    if (!TEST_false(EVP_KDF_argon2(out, outlen, 500,
+        argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+        4, 32, 3, NULL, optionals)))
+        goto err;
+
+    /* wrong type for properties */
+    optionals[2] = OSSL_PARAM_construct_int32(OSSL_ALG_PARAM_PROPERTIES, &rubbish);
+    if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+        argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+        4, 32, 3, NULL, optionals)))
+        goto err;
+    /* Unknown property query */
+    optionals[2] = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_PROPERTIES, "provider=error", 0);
+    if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+        argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+        4, 32, 3, NULL, optionals)))
+        goto err;
+    optionals[2] = OSSL_PARAM_construct_end();
+
+    /* Invalid argon2_password */
+    if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+        NULL, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+        4, 32, 3, NULL, optionals)))
+        goto err;
+    if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+        argon2_pass, 0, argon2_salt, sizeof(argon2_salt),
+        4, 32, 3, NULL, optionals)))
+        goto err;
+    /* Invalid argon2_salt */
+    if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+        argon2_pass, sizeof(argon2_pass), argon2_salt,
+        0, 4, 32, 3, NULL, optionals)))
+        goto err;
+    /* Invalid lane */
+    if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+         argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+         0, 32, 3, NULL, optionals)))
+         goto err;
+    /* Invalid memory cost */
+    if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+         argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+         4, 0, 3, NULL, optionals)))
+         goto err;
+    /* Invalid iterations */
+    if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+         argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+         4, 32, 0, NULL, optionals)))
+         goto err;
+    ret = 1;
+err:
+    ERR_pop_to_mark();
+    return ret;
+}
+#endif
+
 int setup_tests(void)
 {
     ADD_TEST(test_kdf_pbkdf1);
@@ -2424,6 +2578,10 @@ int setup_tests(void)
 #endif
 #ifndef OPENSSL_NO_KBKDF
     ADD_TEST(test_kbkdf_mac_change);
+#endif
+#ifndef OPENSSL_NO_ARGON2
+    ADD_TEST(test_argon2_helper);
+    ADD_TEST(test_argon2_helper_fail);
 #endif
     return 1;
 }

--- a/test/evp_kdf_test.c
+++ b/test/evp_kdf_test.c
@@ -2364,9 +2364,9 @@ static const uint8_t argon2_ad[] = {
     0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04,
     0x04, 0x04, 0x04, 0x04
 };
-const uint32_t argon2_lanes = 4;
-const uint32_t argon2_memcost = 32;
-const uint32_t argon2_iterations = 3;
+static const uint32_t argon2_lanes = 4;
+static const uint32_t argon2_memcost = 32;
+static const uint32_t argon2_iterations = 3;
 
 static int test_argon2_helper(void)
 {
@@ -2401,14 +2401,14 @@ static int test_argon2_helper(void)
 
     if (!TEST_true(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
             argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-            4, 32, 3, NULL, optionals)))
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
         goto err;
     if (!TEST_mem_eq(out, outlen, expected1, sizeof(expected1)))
         goto err;
 
     if (!TEST_true(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2I_TYPE,
             argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-            4, 32, 3, NULL, optionals)))
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
         goto err;
     if (!TEST_mem_eq(out, outlen, expected2, sizeof(expected2)))
         goto err;
@@ -2416,7 +2416,7 @@ static int test_argon2_helper(void)
     optionals[2] = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_PROPERTIES, "provider=default", 0);
     if (!TEST_true(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2ID_TYPE,
             argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-            4, 32, 3, NULL, optionals)))
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
         goto err;
     if (!TEST_mem_eq(out, outlen, expected3, sizeof(expected3)))
         goto err;
@@ -2441,53 +2441,53 @@ static int test_argon2_helper_fail(void)
 
     /* Bad algorithm type */
     if (!TEST_false(EVP_KDF_argon2(out, outlen, 500,
-        argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-        4, 32, 3, NULL, optionals)))
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
         goto err;
 
     /* wrong type for properties */
     optionals[2] = OSSL_PARAM_construct_int32(OSSL_ALG_PARAM_PROPERTIES, &rubbish);
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
-        argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-        4, 32, 3, NULL, optionals)))
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
         goto err;
     /* Unknown property query */
     optionals[2] = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_PROPERTIES, "provider=error", 0);
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
-        argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-        4, 32, 3, NULL, optionals)))
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
         goto err;
     optionals[2] = OSSL_PARAM_construct_end();
 
     /* Invalid argon2_password */
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
-        NULL, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-        4, 32, 3, NULL, optionals)))
+            NULL, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
         goto err;
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
-        argon2_pass, 0, argon2_salt, sizeof(argon2_salt),
-        4, 32, 3, NULL, optionals)))
+            argon2_pass, 0, argon2_salt, sizeof(argon2_salt),
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
         goto err;
     /* Invalid argon2_salt */
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
-        argon2_pass, sizeof(argon2_pass), argon2_salt,
-        0, 4, 32, 3, NULL, optionals)))
+            argon2_pass, sizeof(argon2_pass), argon2_salt,
+            0, argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
         goto err;
     /* Invalid lane */
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
-         argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-         0, 32, 3, NULL, optionals)))
-         goto err;
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            0, argon2_memcost, argon2_iterations, NULL, optionals)))
+        goto err;
     /* Invalid memory cost */
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
-         argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-         4, 0, 3, NULL, optionals)))
-         goto err;
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            argon2_lanes, 0, argon2_iterations, NULL, optionals)))
+        goto err;
     /* Invalid iterations */
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
-         argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-         4, 32, 0, NULL, optionals)))
-         goto err;
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            argon2_lanes, argon2_memcost, 0, NULL, optionals)))
+        goto err;
     ret = 1;
 err:
     ERR_pop_to_mark();

--- a/test/evp_kdf_test.c
+++ b/test/evp_kdf_test.c
@@ -2468,24 +2468,45 @@ static int test_argon2_helper(void)
 
     if (!TEST_true(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
             argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, NULL, optionals)))
         goto err;
     if (!TEST_mem_eq(out, outlen, expected1, sizeof(expected1)))
         goto err;
 
     if (!TEST_true(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2I_TYPE,
             argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, NULL, optionals)))
         goto err;
     if (!TEST_mem_eq(out, outlen, expected2, sizeof(expected2)))
         goto err;
 
-    optionals[2] = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_PROPERTIES, "provider=default", 0);
+    /* propq used for multiple levels */
     if (!TEST_true(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2ID_TYPE,
             argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, "provider=default", optionals)))
+        goto err;
+    optionals[2] = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_PROPERTIES, "provider=default", 0);
+    /* separate propq for fetch and optionals */
+    if (!TEST_true(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2ID_TYPE,
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, "provider=default", optionals)))
+        goto err;
+    /* propq for optionals */
+    if (!TEST_true(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2ID_TYPE,
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, NULL, optionals)))
         goto err;
     if (!TEST_mem_eq(out, outlen, expected3, sizeof(expected3)))
+        goto err;
+    /* NULL password is allowed */
+    if (!TEST_true(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+            NULL, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, NULL, optionals)))
+        goto err;
+    /* zero len password is allowed */
+    if (!TEST_true(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+            argon2_pass, 0, argon2_salt, sizeof(argon2_salt),
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, NULL, optionals)))
         goto err;
     ret = 1;
 err:
@@ -2509,51 +2530,47 @@ static int test_argon2_helper_fail(void)
     /* Bad algorithm type */
     if (!TEST_false(EVP_KDF_argon2(out, outlen, 500,
             argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, NULL, optionals)))
         goto err;
 
-    /* wrong type for properties */
+    /* Invalid propq */
+    if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, "provider=bad", optionals)))
+        goto err;
+    /* wrong type for optional propq */
     optionals[2] = OSSL_PARAM_construct_int32(OSSL_ALG_PARAM_PROPERTIES, &rubbish);
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
             argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, NULL, optionals)))
         goto err;
-    /* Unknown property query */
-    optionals[2] = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_PROPERTIES, "provider=error", 0);
+    /* Invalid optional propq */
+    optionals[2] = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_PROPERTIES, "provider=bad", 0);
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
             argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, NULL, optionals)))
         goto err;
     optionals[2] = OSSL_PARAM_construct_end();
 
-    /* Invalid argon2_password */
-    if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
-            NULL, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
-        goto err;
-    if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
-            argon2_pass, 0, argon2_salt, sizeof(argon2_salt),
-            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
-        goto err;
     /* Invalid argon2_salt */
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
             argon2_pass, sizeof(argon2_pass), argon2_salt,
-            0, argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
+            0, argon2_lanes, argon2_memcost, argon2_iterations, NULL, NULL, optionals)))
         goto err;
     /* Invalid lane */
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
             argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-            0, argon2_memcost, argon2_iterations, NULL, optionals)))
+            0, argon2_memcost, argon2_iterations, NULL, NULL, optionals)))
         goto err;
     /* Invalid memory cost */
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
             argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-            argon2_lanes, 0, argon2_iterations, NULL, optionals)))
+            argon2_lanes, 0, argon2_iterations, NULL, NULL, optionals)))
         goto err;
     /* Invalid iterations */
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
             argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-            argon2_lanes, argon2_memcost, 0, NULL, optionals)))
+            argon2_lanes, argon2_memcost, 0, NULL, NULL, optionals)))
         goto err;
     ret = 1;
 err:

--- a/test/evp_kdf_test.c
+++ b/test/evp_kdf_test.c
@@ -2431,9 +2431,9 @@ static const uint8_t argon2_ad[] = {
     0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04,
     0x04, 0x04, 0x04, 0x04
 };
-const uint32_t argon2_lanes = 4;
-const uint32_t argon2_memcost = 32;
-const uint32_t argon2_iterations = 3;
+static const uint32_t argon2_lanes = 4;
+static const uint32_t argon2_memcost = 32;
+static const uint32_t argon2_iterations = 3;
 
 static int test_argon2_helper(void)
 {
@@ -2468,14 +2468,14 @@ static int test_argon2_helper(void)
 
     if (!TEST_true(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
             argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-            4, 32, 3, NULL, optionals)))
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
         goto err;
     if (!TEST_mem_eq(out, outlen, expected1, sizeof(expected1)))
         goto err;
 
     if (!TEST_true(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2I_TYPE,
             argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-            4, 32, 3, NULL, optionals)))
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
         goto err;
     if (!TEST_mem_eq(out, outlen, expected2, sizeof(expected2)))
         goto err;
@@ -2483,7 +2483,7 @@ static int test_argon2_helper(void)
     optionals[2] = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_PROPERTIES, "provider=default", 0);
     if (!TEST_true(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2ID_TYPE,
             argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-            4, 32, 3, NULL, optionals)))
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
         goto err;
     if (!TEST_mem_eq(out, outlen, expected3, sizeof(expected3)))
         goto err;
@@ -2508,53 +2508,53 @@ static int test_argon2_helper_fail(void)
 
     /* Bad algorithm type */
     if (!TEST_false(EVP_KDF_argon2(out, outlen, 500,
-        argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-        4, 32, 3, NULL, optionals)))
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
         goto err;
 
     /* wrong type for properties */
     optionals[2] = OSSL_PARAM_construct_int32(OSSL_ALG_PARAM_PROPERTIES, &rubbish);
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
-        argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-        4, 32, 3, NULL, optionals)))
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
         goto err;
     /* Unknown property query */
     optionals[2] = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_PROPERTIES, "provider=error", 0);
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
-        argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-        4, 32, 3, NULL, optionals)))
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
         goto err;
     optionals[2] = OSSL_PARAM_construct_end();
 
     /* Invalid argon2_password */
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
-        NULL, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-        4, 32, 3, NULL, optionals)))
+            NULL, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
         goto err;
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
-        argon2_pass, 0, argon2_salt, sizeof(argon2_salt),
-        4, 32, 3, NULL, optionals)))
+            argon2_pass, 0, argon2_salt, sizeof(argon2_salt),
+            argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
         goto err;
     /* Invalid argon2_salt */
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
-        argon2_pass, sizeof(argon2_pass), argon2_salt,
-        0, 4, 32, 3, NULL, optionals)))
+            argon2_pass, sizeof(argon2_pass), argon2_salt,
+            0, argon2_lanes, argon2_memcost, argon2_iterations, NULL, optionals)))
         goto err;
     /* Invalid lane */
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
-         argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-         0, 32, 3, NULL, optionals)))
-         goto err;
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            0, argon2_memcost, argon2_iterations, NULL, optionals)))
+        goto err;
     /* Invalid memory cost */
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
-         argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-         4, 0, 3, NULL, optionals)))
-         goto err;
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            argon2_lanes, 0, argon2_iterations, NULL, optionals)))
+        goto err;
     /* Invalid iterations */
     if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
-         argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
-         4, 32, 0, NULL, optionals)))
-         goto err;
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            argon2_lanes, argon2_memcost, 0, NULL, optionals)))
+        goto err;
     ret = 1;
 err:
     ERR_pop_to_mark();

--- a/test/evp_kdf_test.c
+++ b/test/evp_kdf_test.c
@@ -2408,6 +2408,160 @@ err:
 }
 #endif /* OPENSSL_NO_KBKDF */
 
+#ifndef OPENSSL_NO_ARGON2
+
+/*
+ * Test vectors from
+ * https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-argon2
+ */
+static const uint8_t argon2_pass[] = {
+    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01
+};
+static const uint8_t argon2_salt[] = {
+    0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
+    0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02
+};
+static const uint8_t argon2_secret[] = {
+    0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03
+};
+static const uint8_t argon2_ad[] = {
+    0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04,
+    0x04, 0x04, 0x04, 0x04
+};
+const uint32_t argon2_lanes = 4;
+const uint32_t argon2_memcost = 32;
+const uint32_t argon2_iterations = 3;
+
+static int test_argon2_helper(void)
+{
+    int ret = 0;
+    uint8_t out[32];
+    size_t outlen = sizeof(out);
+
+    static const uint8_t expected1[] = {
+        0x51, 0x2b, 0x39, 0x1b, 0x6f, 0x11, 0x62, 0x97,
+        0x53, 0x71, 0xd3, 0x09, 0x19, 0x73, 0x42, 0x94,
+        0xf8, 0x68, 0xe3, 0xbe, 0x39, 0x84, 0xf3, 0xc1,
+        0xa1, 0x3a, 0x4d, 0xb9, 0xfa, 0xbe, 0x4a, 0xcb
+    };
+    static const uint8_t expected2[] = {
+        0xc8, 0x14, 0xd9, 0xd1, 0xdc, 0x7f, 0x37, 0xaa,
+        0x13, 0xf0, 0xd7, 0x7f, 0x24, 0x94, 0xbd, 0xa1,
+        0xc8, 0xde, 0x6b, 0x01, 0x6d, 0xd3, 0x88, 0xd2,
+        0x99, 0x52, 0xa4, 0xc4, 0x67, 0x2b, 0x6c, 0xe8
+    };
+    const uint8_t expected3[] = {
+        0x0d, 0x64, 0x0d, 0xf5, 0x8d, 0x78, 0x76, 0x6c,
+        0x08, 0xc0, 0x37, 0xa3, 0x4a, 0x8b, 0x53, 0xc9,
+        0xd0, 0x1e, 0xf0, 0x45, 0x2d, 0x75, 0xb6, 0x5e,
+        0xb5, 0x25, 0x20, 0xe9, 0x6b, 0x01, 0xe6, 0x59
+    };
+    OSSL_PARAM optionals[4];
+
+    optionals[0] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SECRET, (uint8_t *)argon2_secret, sizeof(argon2_secret));
+    optionals[1] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_ARGON2_AD, (uint8_t *)argon2_ad, sizeof(argon2_ad));
+    optionals[2] = OSSL_PARAM_construct_end();
+    optionals[3] = OSSL_PARAM_construct_end();
+
+    if (!TEST_true(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            4, 32, 3, NULL, optionals)))
+        goto err;
+    if (!TEST_mem_eq(out, outlen, expected1, sizeof(expected1)))
+        goto err;
+
+    if (!TEST_true(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2I_TYPE,
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            4, 32, 3, NULL, optionals)))
+        goto err;
+    if (!TEST_mem_eq(out, outlen, expected2, sizeof(expected2)))
+        goto err;
+
+    optionals[2] = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_PROPERTIES, "provider=default", 0);
+    if (!TEST_true(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2ID_TYPE,
+            argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+            4, 32, 3, NULL, optionals)))
+        goto err;
+    if (!TEST_mem_eq(out, outlen, expected3, sizeof(expected3)))
+        goto err;
+    ret = 1;
+err:
+    return ret;
+}
+
+static int test_argon2_helper_fail(void)
+{
+    int ret = 0;
+    int32_t rubbish = 1;
+    uint8_t out[32];
+    size_t outlen = 32;
+    OSSL_PARAM optionals[4];
+
+    ERR_set_mark();
+    optionals[0] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SECRET, (uint8_t *)argon2_secret, sizeof(argon2_secret));
+    optionals[1] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_ARGON2_AD, (uint8_t *)argon2_ad, sizeof(argon2_ad));
+    optionals[2] = OSSL_PARAM_construct_end();
+    optionals[3] = OSSL_PARAM_construct_end();
+
+    /* Bad algorithm type */
+    if (!TEST_false(EVP_KDF_argon2(out, outlen, 500,
+        argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+        4, 32, 3, NULL, optionals)))
+        goto err;
+
+    /* wrong type for properties */
+    optionals[2] = OSSL_PARAM_construct_int32(OSSL_ALG_PARAM_PROPERTIES, &rubbish);
+    if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+        argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+        4, 32, 3, NULL, optionals)))
+        goto err;
+    /* Unknown property query */
+    optionals[2] = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_PROPERTIES, "provider=error", 0);
+    if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+        argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+        4, 32, 3, NULL, optionals)))
+        goto err;
+    optionals[2] = OSSL_PARAM_construct_end();
+
+    /* Invalid argon2_password */
+    if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+        NULL, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+        4, 32, 3, NULL, optionals)))
+        goto err;
+    if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+        argon2_pass, 0, argon2_salt, sizeof(argon2_salt),
+        4, 32, 3, NULL, optionals)))
+        goto err;
+    /* Invalid argon2_salt */
+    if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+        argon2_pass, sizeof(argon2_pass), argon2_salt,
+        0, 4, 32, 3, NULL, optionals)))
+        goto err;
+    /* Invalid lane */
+    if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+         argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+         0, 32, 3, NULL, optionals)))
+         goto err;
+    /* Invalid memory cost */
+    if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+         argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+         4, 0, 3, NULL, optionals)))
+         goto err;
+    /* Invalid iterations */
+    if (!TEST_false(EVP_KDF_argon2(out, outlen, EVP_KDF_ARGON2D_TYPE,
+         argon2_pass, sizeof(argon2_pass), argon2_salt, sizeof(argon2_salt),
+         4, 32, 0, NULL, optionals)))
+         goto err;
+    ret = 1;
+err:
+    ERR_pop_to_mark();
+    return ret;
+}
+#endif
+
 int setup_tests(void)
 {
     ADD_TEST(test_kdf_pbkdf1);
@@ -2495,6 +2649,10 @@ int setup_tests(void)
 #endif
 #ifndef OPENSSL_NO_KBKDF
     ADD_TEST(test_kbkdf_mac_change);
+#endif
+#ifndef OPENSSL_NO_ARGON2
+    ADD_TEST(test_argon2_helper);
+    ADD_TEST(test_argon2_helper_fail);
 #endif
     return 1;
 }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5722,3 +5722,4 @@ CRYPTO_atomic_cmp_exch_ptr              ?	4_1_0	EXIST::FUNCTION:
 EVP_EC_affine2oct                       ?	4_1_0	EXIST::FUNCTION:
 OPENSSL_sk_set_copy_thunks              ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_new_not_owned               ?	4_1_0	EXIST::FUNCTION:
+EVP_KDF_argon2                          ?	4_1_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5733,3 +5733,4 @@ ASN1_STRING_set1_string                 ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_get_length                  ?	4_1_0	EXIST::FUNCTION:
 CMS_add_standard_smimecap_ex            ?	4_1_0	EXIST::FUNCTION:CMS
 BIO_socket_ready                        ?	4_1_0	EXIST::FUNCTION:SOCK
+EVP_KDF_argon2                          ?	4_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
OpenSSL previously used a ctrl mechanism to pass parameters, this was horrible enough that helper functions were used to hide some of the complexity.
Some users don't like OSSL_PARAM arrays (And I believe the purpose of these was to pass parameters to/from providers), For common algorithms we should consider adding support functions that hide the complexity of OSSL_PARAM from the user. 

This is an example API for one of the more complex KDF functions to see what this should look like. KDF's can be written as one shot operations.
I have gone with adding an optional OSSL_PARAM array on the end so that we can support all parameters.
It is sometimes difficult to determine which parameters should be listed.
e.g. 'propq' is optional, as well as 'threads'. 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
