### PR TITLE
Address `allocfail` test failures

### DIFF
--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -191,6 +191,7 @@ void *CRYPTO_malloc(size_t num, const char *file, int line)
     void *ptr;
 
     INCREMENT(malloc_count);
+    FAILTEST();
     if (malloc_impl != CRYPTO_malloc) {
         ptr = malloc_impl(num, file, line);
         if (ptr != NULL || num == 0)
@@ -201,7 +202,6 @@ void *CRYPTO_malloc(size_t num, const char *file, int line)
     if (ossl_unlikely(num == 0))
         return NULL;
 
-    FAILTEST();
     if (allow_customize) {
         /*
          * Disallow customization after the first allocation. We only set this
@@ -266,6 +266,7 @@ void *CRYPTO_realloc(void *str, size_t num, const char *file, int line)
     void *ret;
 
     INCREMENT(realloc_count);
+    FAILTEST();
     if (realloc_impl != CRYPTO_realloc) {
         ret = realloc_impl(str, num, file, line);
 
@@ -283,7 +284,6 @@ void *CRYPTO_realloc(void *str, size_t num, const char *file, int line)
         return NULL;
     }
 
-    FAILTEST();
     ret = realloc(str, num);
 
 err:

--- a/doc/man3/OPENSSL_malloc.pod
+++ b/doc/man3/OPENSSL_malloc.pod
@@ -321,6 +321,10 @@ the caller may need to fall back to a non-aligned memory allocation
 Before OpenSSL 4.0, the call to OPENSSL_aligned_alloc() did not have
 an explicit upper limit on the value of I<alignment>.
 
+Before OpenSSL 4.1, allocations done by custom memory functions
+and zero-sized allocations did not progress allocation counter
+used against B<OPENSSL_MALLOC_FAILURES> specification.
+
 =head1 COPYRIGHT
 
 Copyright 2016-2025 The OpenSSL Project Authors. All Rights Reserved.

--- a/test/handshake-memfail.c
+++ b/test/handshake-memfail.c
@@ -29,10 +29,11 @@
  * - rcount:   Number of reallocs counted
  * - fcount:   Number of frees counted
  * - scount:   Number of mallocs counted prior to workload
+ * - srcount:  Number of reallocs counted prior to workload
  */
 static char *cert = NULL;
 static char *privkey = NULL;
-static int mcount, rcount, fcount, scount;
+static int mcount, rcount, fcount, scount, srcount;
 
 /**
  * @brief Performs an SSL/TLS handshake between a test client and server.
@@ -135,15 +136,16 @@ static int test_report_alloc_counts(void)
     CRYPTO_get_alloc_counts(&mcount, &rcount, &fcount);
     /*
      * Report our memory allocations from the count run
-     * NOTE: We report a number of allocations to skip here
-     * (the scount value).  These are the allocations that took
-     * place while the test harness itself was getting setup
-     * (i.e. calling OPENSSL_init_crypto/etc).  We can't fail
+     * NOTE: We report a number of (re)allocations to skip here
+     * (the scount + srcount value).  These are the allocations
+     * that took place while the test harness itself was getting
+     * setup (i.e. calling OPENSSL_init_crypto/etc).  We can't fail
      * those allocations as they will cause the test to fail before
      * we have even run the workload.  So report them so we can
      * allow them to function before we start doing any real testing
      */
-    TEST_info("skip: %d count %d\n", scount, mcount - scount);
+    TEST_info("skip: %d count %d\n",
+        scount + srcount, mcount + rcount - scount - srcount);
     return 1;
 }
 
@@ -167,7 +169,7 @@ int setup_tests(void)
         goto err;
 
     if (strcmp(opmode, "count") == 0) {
-        CRYPTO_get_alloc_counts(&scount, &rcount, &fcount);
+        CRYPTO_get_alloc_counts(&scount, &srcount, &fcount);
         ADD_TEST(test_record_alloc_counts);
         ADD_TEST(test_report_alloc_counts);
     } else {

--- a/test/load_key_certs_crls_memfail.c
+++ b/test/load_key_certs_crls_memfail.c
@@ -24,7 +24,7 @@
 char *default_config_file = NULL;
 
 static char *certfile = NULL;
-static int mcount, rcount, fcount, scount;
+static int mcount, rcount, fcount, scount, srcount;
 
 static int do_load_key_certs_crls(int allow_failure)
 {
@@ -60,7 +60,8 @@ static int test_alloc_failures(void)
 static int test_report_alloc_counts(void)
 {
     CRYPTO_get_alloc_counts(&mcount, &rcount, &fcount);
-    TEST_info("skip: %d count %d\n", scount, mcount - scount);
+    TEST_info("skip: %d count %d\n",
+        scount + srcount, mcount + rcount - scount - srcount);
     return 1;
 }
 
@@ -79,7 +80,7 @@ int setup_tests(void)
         goto err;
 
     if (strcmp(opmode, "count") == 0) {
-        CRYPTO_get_alloc_counts(&scount, &rcount, &fcount);
+        CRYPTO_get_alloc_counts(&scount, &srcount, &fcount);
         ADD_TEST(test_record_alloc_counts);
         ADD_TEST(test_report_alloc_counts);
     } else {

--- a/test/recipes/90-test_memfail.t
+++ b/test/recipes/90-test_memfail.t
@@ -73,7 +73,7 @@ plan tests => $total_malloccount;
 
 sub run_memfail_test {
     my $skipcount = $_[0];
-    my @mallocseq = (1..$_[1]);
+    my @mallocseq = (0..$_[1] - 1);
     my @cmd = $_[2];
 
     for my $idx (@mallocseq) {

--- a/test/recipes/90-test_memfail.t
+++ b/test/recipes/90-test_memfail.t
@@ -26,6 +26,9 @@ plan skip_all => "$test_name requires allocfail-tests to be enabled"
 # and parse that to figure out what our values are
 #
 my $resultdir = result_dir();
+
+$ENV{OPENSSL_TEST_MFAIL_DISABLE} = "1";
+
 run(test(["handshake-memfail", "count", srctop_dir("test", "certs")], stderr => "$resultdir/hscountinfo.txt"));
 
 run(test(["x509-memfail", "count", srctop_file("test", "certs", "servercert.pem")], stderr => "$resultdir/x509countinfo.txt"));
@@ -67,8 +70,6 @@ plan skip_all => "could not get malloc counts (one or more count runs failed or 
 # test
 #
 plan tests => $total_malloccount;
-
-$ENV{OPENSSL_TEST_MFAIL_DISABLE} = "1";
 
 sub run_memfail_test {
     my $skipcount = $_[0];

--- a/test/recipes/90-test_memfail.t
+++ b/test/recipes/90-test_memfail.t
@@ -86,7 +86,8 @@ sub run_memfail_test {
         # passing
         #
         $ENV{OPENSSL_MALLOC_FAILURES} = "$skipcount\@0;$idx\@0;1\@100;0\@0";
-        ok(run(test(@cmd)));
+        ok(run(test(@cmd))) || \
+            print STDERR "# OPENSSL_MALLOC_FAILURES=$ENV{OPENSSL_MALLOC_FAILURES}\n";
     }
 }
 

--- a/test/x509_memfail.c
+++ b/test/x509_memfail.c
@@ -21,7 +21,7 @@
 #include "testutil.h"
 
 static char *certfile = NULL;
-static int mcount, rcount, fcount, scount;
+static int mcount, rcount, fcount, scount, srcount;
 
 static int do_x509(int allow_failure)
 {
@@ -91,15 +91,16 @@ static int test_report_alloc_counts(void)
     CRYPTO_get_alloc_counts(&mcount, &rcount, &fcount);
     /*
      * Report our memory allocations from the count run
-     * NOTE: We report a number of allocations to skip here
-     * (the scount value).  These are the allocations that took
-     * place while the test harness itself was getting setup
-     * (i.e. calling OPENSSL_init_crypto/etc).  We can't fail
+     * NOTE: We report a number of (re)allocations to skip here
+     * (the scount + srcount value).  These are the allocations
+     * that took place while the test harness itself was getting
+     * setup (i.e. calling OPENSSL_init_crypto/etc).  We can't fail
      * those allocations as they will cause the test to fail before
      * we have even run the workload.  So report them so we can
      * allow them to function before we start doing any real testing
      */
-    TEST_info("skip: %d count %d\n", scount, mcount - scount);
+    TEST_info("skip: %d count %d\n",
+        scount + srcount, mcount + rcount - scount - srcount);
     return 1;
 }
 
@@ -115,7 +116,7 @@ int setup_tests(void)
         goto err;
 
     if (strcmp(opmode, "count") == 0) {
-        CRYPTO_get_alloc_counts(&scount, &rcount, &fcount);
+        CRYPTO_get_alloc_counts(&scount, &srcount, &fcount);
         ADD_TEST(test_record_alloc_counts);
         ADD_TEST(test_report_alloc_counts);
     } else {


### PR DESCRIPTION
This patch set addresses the following issues:
 * Recently introduced `mfail` test framework [1] disabled itself too late in `0-test_memfail.t`, leading to incorrect allocation counting.
 * Allocation failure testing/triggering was done too late in `CRYPTO_malloc` and `CRYPTO_realloc` functions, leading to diverging of allocation counts.
 * The tests didn't account for `realloc` calls in their counts.

Technically, the second point is a change in behaviour, so I'm hesitant about backporting it.

[1] https://github.com/openssl/openssl/pull/30871