### PR TITLE
fix: call BN_CTX_end before BN_CTX_free in ossl_sm2_encrypt

### DIFF
--- a/crypto/sm2/sm2_crypt.c
+++ b/crypto/sm2/sm2_crypt.c
@@ -271,6 +271,7 @@ done:
     OPENSSL_free(x2y2);
     OPENSSL_free(C3);
     EVP_MD_CTX_free(hash);
+    BN_CTX_end(ctx);
     BN_CTX_free(ctx);
     EC_POINT_free(kG);
     EC_POINT_free(kP);


### PR DESCRIPTION
Resolves openssl issue 30979. BN_CTX_start was called with BN_CTX_get values obtained, but in the done label BN_CTX_free was called directly without BN_CTX_end first.