### PR TITLE
[3.0] crypto/http/http_lib.c: add check for empty server host in use_proxy

### DIFF
--- a/crypto/http/http_lib.c
+++ b/crypto/http/http_lib.c
@@ -275,6 +275,9 @@ static int use_proxy(const char *no_proxy, const char *server)
         server = host;
     }
 
+    if (sl == 0)
+        return 1;
+
     /*
      * using environment variable names, both lowercase and uppercase variants,
      * compatible with other HTTP client implementations like wget, curl and git

--- a/doc/man3/OSSL_HTTP_parse_url.pod
+++ b/doc/man3/OSSL_HTTP_parse_url.pod
@@ -32,7 +32,9 @@ see L<openssl_user_macros(7)>:
 
 =head1 DESCRIPTION
 
-OSSL_HTTP_adapt_proxy() takes an optional proxy hostname I<proxy>
+OSSL_HTTP_adapt_proxy() determines whether a proxy should be used
+when connecting to the given I<server>.
+It takes an optional proxy hostname I<proxy>
 and returns it transformed according to the optional I<no_proxy> parameter,
 I<server>, I<use_ssl>, and the applicable environment variable, as follows.
 If I<proxy> is NULL, take any default value from the C<http_proxy>
@@ -40,11 +42,13 @@ environment variable, or from C<https_proxy> if I<use_ssl> is nonzero.
 If this still does not yield a proxy hostname,
 take any further default value from the C<HTTP_PROXY>
 environment variable, or from C<HTTPS_PROXY> if I<use_ssl> is nonzero.
-If I<no_proxy> is NULL, take any default exclusion value from the C<no_proxy>
-environment variable, or else from C<NO_PROXY>.
-Return the determined proxy host unless the exclusion value,
-which is a list of proxy hosts separated by C<,> and/or whitespace,
-contains I<server>.
+Return the determined proxy host if I<server> is the empty string
+or I<server> is not in the exclusion list.
+The exclusion list is a list of server hosts separated by C<,>
+and/or whitespace.
+They may be given via the I<no_proxy> parameter.
+If it is NULL, the exclusion list is taken from the C<no_proxy>
+environment variable if set, otherwise from C<NO_PROXY>.
 Otherwise return NULL.
 When I<server> is a string delimited by C<[> and C<]>, which are used for IPv6
 addresses, the enclosing C<[> and C<]> are stripped prior to comparison.

--- a/test/http_test.c
+++ b/test/http_test.c
@@ -379,6 +379,14 @@ static int test_http_keep_alive_1_require_no(void)
     return test_http_keep_alive('1', 2, 0);
 }
 
+static int test_http_adapt_proxy_empty_server(void)
+{
+    const char *proxy = "http://proxy.local:8080";
+
+    return TEST_str_eq(OSSL_HTTP_adapt_proxy(proxy, "abc", "", 0), proxy)
+        && TEST_str_eq(OSSL_HTTP_adapt_proxy(proxy, "abc", "[]", 0), proxy);
+}
+
 void cleanup_tests(void)
 {
     X509_free(x509);
@@ -414,5 +422,6 @@ int setup_tests(void)
     ADD_TEST(test_http_keep_alive_1_require_yes);
     ADD_TEST(test_http_keep_alive_0_require_no);
     ADD_TEST(test_http_keep_alive_1_require_no);
+    ADD_TEST(test_http_adapt_proxy_empty_server);
     return 1;
 }


### PR DESCRIPTION
This is a backport of [1] to `openssl-3.0`.

[1] https://github.com/openssl/openssl/pull/30848

Fixes: afe554c2d244 "Chunk 10 of CMP contribution to OpenSSL: CMP http client and related tests"