### PR TITLE
DTLS 1.3 Buffer App Data received before ACK

### DIFF
--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -326,16 +326,24 @@ start:
     if ((sc->s3.change_cipher_spec /* set when we receive ChangeCipherSpec,
                                     * reset by ssl3_get_finished */
             && (rr->type != SSL3_RT_HANDSHAKE))
-        || (is_dtls13 && rr->epoch >= 3
+        || (is_dtls13 && rr->epoch >= 3 /* For DTLS 1.3 we can receive
+                                         * Application Data before we
+                                         * receive an expecting ACK
+                                         * message */
             && (current_state == TLS_ST_CW_FINISHED
                 || current_state == TLS_ST_CW_KEY_UPDATE
                 || current_state == TLS_ST_SW_KEY_UPDATE
                 || current_state == TLS_ST_SW_SESSION_TICKET)
             && rr->type == SSL3_RT_APPLICATION_DATA)) {
         /*
-         * We now have application data between CCS and Finished. Most likely
-         * the packets were reordered on their way, so buffer the application
-         * data for later processing rather than dropping the connection.
+         * For DTLS 1.3 we received Application Data while we are
+         * waiting for an Acknowledgement record. Buffer this data so
+         * it can be processed once we have received the Acknowledgement.
+         *
+         * For non-DTLS 1.3 we now have application data between CCS and
+         * Finished. Most likely the packets were reordered on their way,
+         * so buffer the application data for later processing rather than
+         * dropping the connection.
          */
         if (dtls_buffer_record(sc, rr) < 0) {
             /* SSLfatal() already called */

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -205,6 +205,7 @@ int dtls1_read_bytes(SSL *s, uint8_t type, uint8_t *recvd_type,
     SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
     int is_dtls13;
     int in_early_data;
+    int current_state;
 
     if (sc == NULL)
         return -1;
@@ -321,10 +322,16 @@ start:
         sc->rlayer.alert_count = 0;
 
     /* we now have a packet which can be read and processed */
-
-    if (sc->s3.change_cipher_spec /* set when we receive ChangeCipherSpec,
-                                   * reset by ssl3_get_finished */
-        && (rr->type != SSL3_RT_HANDSHAKE)) {
+    current_state = SSL_get_state(s);
+    if ((sc->s3.change_cipher_spec /* set when we receive ChangeCipherSpec,
+                                    * reset by ssl3_get_finished */
+            && (rr->type != SSL3_RT_HANDSHAKE))
+        || (is_dtls13 && rr->epoch >= 3
+            && (current_state == TLS_ST_CW_FINISHED
+                || current_state == TLS_ST_CW_KEY_UPDATE
+                || current_state == TLS_ST_SW_KEY_UPDATE
+                || current_state == TLS_ST_SW_SESSION_TICKET)
+            && rr->type == SSL3_RT_APPLICATION_DATA)) {
         /*
          * We now have application data between CCS and Finished. Most likely
          * the packets were reordered on their way, so buffer the application

--- a/test/dtlstest.c
+++ b/test/dtlstest.c
@@ -806,23 +806,10 @@ static int test_swap_records_dtls13(int idx)
             goto end;
     }
 
-    if (idx == 3) {
-        /*
-         * Now that we are processing APP Data before the ACK
-         * We can now read this data
-         */
-        if (!TEST_int_eq(SSL_read(cssl, buf, sizeof(buf)), (int)sizeof(msg)))
-            goto end;
-    }
     /*
      * Recv Server's ACK
      */
     if (!TEST_int_gt(SSL_connect(cssl), 0))
-        goto end;
-
-    /* App data was not received early, so it should not be pending */
-    if (!TEST_int_eq(SSL_pending(cssl), 0)
-        || !TEST_false(SSL_has_pending(cssl)))
         goto end;
 
     if (idx == 1 || idx == 2) {
@@ -834,6 +821,12 @@ static int test_swap_records_dtls13(int idx)
          * New Session Tickets are dropped/discarded. Thus we get into a
          * scenario where the server must resend the New Session Tickets.
          */
+
+        /* App data was not received early, so it should not be pending */
+        if (!TEST_int_eq(SSL_pending(cssl), 0)
+            || !TEST_false(SSL_has_pending(cssl)))
+            goto end;
+
         if (!TEST_int_le(ret = SSL_read(cssl, buf, sizeof(buf)), 0))
             goto end;
 
@@ -841,18 +834,23 @@ static int test_swap_records_dtls13(int idx)
         if (!TEST_int_le(ret = SSL_read(sssl, buf, sizeof(buf)), 0))
             goto end;
 
-        /* Client can should now read the new Session Ticket */
+        /* Client can now read the new Session Ticket */
         if (!TEST_int_le(ret = SSL_read(cssl, buf, sizeof(buf)), 0))
             goto end;
 
         if (!TEST_int_eq(SSL_write(sssl, msg, sizeof(msg)), (int)sizeof(msg)))
             goto end;
-    }
-    /*
-     * Recv flight 5 (app data)
-     */
-    if (idx != 3) {
+
         if (!TEST_int_eq(SSL_read(cssl, buf, sizeof(buf)), (int)sizeof(msg)))
+            goto end;
+    } else if (idx == 3) {
+        /*
+         * Recv flight 5 (app data)
+         */
+        if (!TEST_int_eq(SSL_read(cssl, buf, sizeof(buf)), (int)sizeof(msg)))
+            goto end;
+
+        if (!TEST_mem_eq(buf, sizeof(msg), msg, sizeof(msg)))
             goto end;
     }
 

--- a/test/dtlstest.c
+++ b/test/dtlstest.c
@@ -843,7 +843,7 @@ static int test_swap_records_dtls13(int idx)
 
         if (!TEST_int_eq(SSL_read(cssl, buf, sizeof(buf)), (int)sizeof(msg)))
             goto end;
-    } else if (idx == 3) {
+    } else {
         /*
          * Recv flight 5 (app data)
          */

--- a/test/dtlstest.c
+++ b/test/dtlstest.c
@@ -807,7 +807,11 @@ static int test_swap_records_dtls13(int idx)
     }
 
     if (idx == 3) {
-        if (!TEST_int_le(SSL_connect(cssl), 0))
+        /*
+         * Now that we are processing APP Data before the ACK
+         * We can now read this data
+         */
+        if (!TEST_int_eq(SSL_read(cssl, buf, sizeof(buf)), (int)sizeof(msg)))
             goto end;
     }
     /*
@@ -847,11 +851,7 @@ static int test_swap_records_dtls13(int idx)
     /*
      * Recv flight 5 (app data)
      */
-    if (idx == 3) {
-        /* Since App Data was inserted before the ACK it will be dropped */
-        if (!TEST_int_le(ret = SSL_read(cssl, buf, sizeof(buf)), 0))
-            goto end;
-    } else {
+    if (idx != 3) {
         if (!TEST_int_eq(SSL_read(cssl, buf, sizeof(buf)), (int)sizeof(msg)))
             goto end;
     }

--- a/test/recipes/70-test_tls13alerts.t
+++ b/test/recipes/70-test_tls13alerts.t
@@ -73,10 +73,23 @@ sub run_tests
     $proxy->clear();
     $proxy->filter(\&alert_filter);
     if ($run_test_as_dtls == 1) {
+        # Use a large MTU to prevent a race condition on IPv6. With the
+        # default MTU of 1500, the IPv6/UDP overhead (48 bytes) limits the
+        # usable datagram payload to 1452 bytes, causing the server's
+        # CertificateVerify to spill into a second datagram. This creates a
+        # race between that second server datagram and the client's fatal
+        # alert (triggered by the corrupted ServerHello) arriving at the
+        # proxy. If the client's alert arrives first, the proxy still holds
+        # a partial CertificateVerify fragment in $payload and dies with
+        # "Changed peer, but we still have fragment data". By using a large
+        # MTU the entire server flight fits in one datagram, $payload is
+        # always fully cleared before any client packet can arrive, and the
+        # race is eliminated.
+        $proxy->serverflags("-mtu 16384");
         if (disabled("ec")) {
-            $proxy->clientflags("-groups ffdhe2048:ffdhe3072");
+            $proxy->clientflags("-groups ffdhe2048:ffdhe3072 -mtu 16384");
         } else {
-            $proxy->clientflags("-groups P-256:P-384");
+            $proxy->clientflags("-groups P-256:P-384 -mtu 16384");
         }
     }
     $proxy_start_success = $proxy->start();


### PR DESCRIPTION
For DTLS 1.3 App Data may arrive before an expected ack message. We will now buffer it and process it after we process the ACK and end in_init.

Fixes: openssl/project#1908

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
