### PR TITLE
[backport 3.4] ssl/quic/quic_port.c: fix leak in port_make_channel()

### DIFF
--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -433,8 +433,9 @@ QUIC_CHANNEL *ossl_quic_channel_new(const QUIC_CHANNEL_ARGS *args)
     ch->use_qlog = args->use_qlog;
 
     if (ch->use_qlog && args->qlog_title != NULL) {
+        OPENSSL_free(ch->qlog_title);
         if ((ch->qlog_title = OPENSSL_strdup(args->qlog_title)) == NULL) {
-            OPENSSL_free(ch);
+            ossl_quic_channel_free(ch);
             return NULL;
         }
     }


### PR DESCRIPTION
Free pre-existing ch->qlog_title before OPENSSL_strdup to avoid leaking the value allocated in ossl_quic_channel_alloc(). Use ossl_quic_channel_free() on strdup failure to ensure proper cleanup.

Fixes #30440

Origin: https://github.com/openssl/openssl/pull/30441
