### PR TITLE
According to RFC8446 there must always be one identity in the list

### DIFF
--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -1340,6 +1340,11 @@ int tls_parse_ctos_psk(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
         SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_BAD_EXTENSION);
         return 0;
     }
+    /* There must always be at least one identity in the list */
+    if (PACKET_remaining(&identities) == 0) {
+        SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_BAD_EXTENSION);
+        goto err;
+    }
 
     s->ext.ticket_expected = 0;
     for (id = 0; PACKET_remaining(&identities) != 0 && id < MAX_PRE_SHARED_KEYS; id++) {


### PR DESCRIPTION
We were silently accepting a list with zero identities. Technically this is a syntax error so we should fail with a decode_error in this case.

Fixes #31006
