### PR TITLE
ssl/record/methods/tls_common.c: call BIO_free_all() on rl->bio in tls_int_free

### DIFF
--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1398,7 +1398,7 @@ err:
 static void tls_int_free(OSSL_RECORD_LAYER *rl)
 {
     BIO_free(rl->prev);
-    BIO_free(rl->bio);
+    BIO_free_all(rl->bio);
     BIO_free(rl->next);
     ossl_tls_buffer_release(&rl->rbuf);
 


### PR DESCRIPTION
I'm not going to pretend that I understand how refcounting and ownership for BIOs work, just wanted to act on [1], because otherwise we use `BIO_free()` in one place and `BIO_free_all()` in another without any justification.

[1] https://github.com/openssl/openssl/pull/30483#issuecomment-4326152021