### PR TITLE
Fix the no-deprecated symbol CI test

### DIFF
--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4687,8 +4687,8 @@ X509_CRL_print                          4684	4_0_0	EXIST::FUNCTION:
 X509_REQ_print_ex                       4685	4_0_0	EXIST::FUNCTION:
 X509_REQ_print                          4686	4_0_0	EXIST::FUNCTION:
 X509_NAME_entry_count                   4687	4_0_0	EXIST::FUNCTION:
-X509_NAME_get_text_by_NID               4688	4_0_0	EXIST::FUNCTION:DEPRECATED_4_0
-X509_NAME_get_text_by_OBJ               4689	4_0_0	EXIST::FUNCTION:DEPRECATED_4_0
+X509_NAME_get_text_by_NID               4688	4_0_0	EXIST::FUNCTION:DEPRECATEDIN_4_0
+X509_NAME_get_text_by_OBJ               4689	4_0_0	EXIST::FUNCTION:DEPRECATEDIN_4_0
 X509_NAME_get_index_by_NID              4690	4_0_0	EXIST::FUNCTION:
 X509_NAME_get_index_by_OBJ              4691	4_0_0	EXIST::FUNCTION:
 X509_NAME_get_entry                     4692	4_0_0	EXIST::FUNCTION:

--- a/util/perl/OpenSSL/ParseC.pm
+++ b/util/perl/OpenSSL/ParseC.pm
@@ -75,6 +75,22 @@ my @opensslcpphandlers = (
 #if$1 OPENSSL_NO_DEPRECATEDIN_$2
 EOF
       }
+    },
+    # Do the same for modern CPP definition tests.
+    { regexp   => qr/#if (\!defined).*OPENSSL_NO_DEPRECATED_(\d+_\d+(?:_\d+)?).*$/,
+      massager => sub {
+          return (<<"EOF");
+#ifndef OPENSSL_NO_DEPRECATEDIN_$2
+EOF
+      }
+    },
+    # Do the same for modern CPP definition tests.
+    { regexp   => qr/#if (defined).*OPENSSL_NO_DEPRECATED_(\d+_\d+(?:_\d+)?).*$/,
+      massager => sub {
+          return (<<"EOF");
+#ifdef OPENSSL_NO_DEPRECATEDIN_$2
+EOF
+      }
     }
 );
 my @cpphandlers = (


### PR DESCRIPTION
The symbol presence test fails for NO_DEPRECATED builds  if you use modern CPP practices for definitions.

This is because the perl preprocessing of the preprocessor input doesn't understand "#if !defined", which I suspected
but was avoiding figuring out. This is the result of my accepting that doing so will be as PTSD inducing as walking into my parents bedroom at an inopportune time, and fixing it. Better me who has less time left to live with the mental trauma than a younger developer.

<img width="640" height="406" alt="shrek-donkey" src="https://github.com/user-attachments/assets/0e8b4377-2594-4747-ab4e-6b189fa8a00a" />

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
