### PR TITLE
Check wrlmethod existence before sending alert

### DIFF
--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -152,7 +152,7 @@ void ossl_statem_send_fatal(SSL_CONNECTION *s, int al)
         return;
     ossl_statem_set_in_init(s, 1);
     s->statem.state = MSG_FLOW_ERROR;
-    if (al != SSL_AD_NO_ALERT)
+    if (al != SSL_AD_NO_ALERT && s->rlayer.wrlmethod != NULL)
         ssl3_send_alert(s, SSL3_AL_FATAL, al);
 }
 


### PR DESCRIPTION
If there is a memory failure during record wrlmethod allocation, then the alert is attemted but it crashes because wrlmethod is NULL.

Found using memfail integration to fuzz tests: GH-30944

To give a bit more details, I found it in dtls client fuzz test during this memory failure:
```
#0  should_fail () at test/mfail/mfail.c:63
#1  0x00005555577028a2 in mf_malloc (num=4432, file=0x5555577892e0 "ssl/record/methods/tls_common.c", line=1213) at test/mfail/mfail.c:72
#2  0x0000555556e443d4 in CRYPTO_malloc (num=4432, file=0x5555577892e0 "ssl/record/methods/tls_common.c", line=1213) at crypto/mem.c:195
#3  0x0000555556e44486 in CRYPTO_zalloc (num=4432, file=0x5555577892e0 "ssl/record/methods/tls_common.c", line=1213) at crypto/mem.c:226
#4  0x0000555556a0989b in tls_int_new_record_layer (libctx=0x0, propq=0x0, vers=131071, role=0, direction=0, level=0, ciph=0x0, taglen=0, md=0x0, comp=0x0, prev=0x0, transport=0x0, 
    next=0x50c000027640, settings=0x7ffff4b32610, options=0x7ffff4b32500, fns=0x7ffff4b32490, cbarg=0x523000007100, retrl=0x7ffff4b32470) at ssl/record/methods/tls_common.c:1213
#5  0x00005555569f3639 in dtls_new_record_layer (libctx=0x0, propq=0x0, vers=131071, role=0, direction=0, level=0, epoch=0, secret=0x0, secretlen=0, key=0x0, keylen=0, iv=0x0, ivlen=0, 
    mackey=0x0, mackeylen=0, ciph=0x0, taglen=0, mactype=0, md=0x0, comp=0x0, kdfdigest=0x0, prev=0x0, transport=0x0, next=0x50c000027640, local=0x0, peer=0x0, settings=0x7ffff4b32610, 
    options=0x7ffff4b32500, fns=0x7ffff4b32490, cbarg=0x523000007100, rlarg=0x0, retrl=0x7ffff4b32470) at ssl/record/methods/dtls_meth.c:647
#6  0x00005555569ea733 in ssl_set_new_record_layer (s=0x523000007100, version=131071, direction=0, level=0, secret=0x0, secretlen=0, key=0x0, keylen=0, iv=0x0, ivlen=0, mackey=0x0, 
    mackeylen=0, ciph=0x0, taglen=0, mactype=0, md=0x0, comp=0x0, kdfdigest=0x0) at ssl/record/rec_layer_s3.c:1440
#7  0x00005555569d9405 in RECORD_LAYER_reset (rl=0x523000007f28) at ssl/record/rec_layer_s3.c:79
#8  0x000055555684e8e4 in ossl_ssl_connection_reset (s=0x523000007100) at ssl/ssl_lib.c:648
#9  0x0000555556854a8d in ossl_ssl_connection_new_int (ctx=0x51c000002080, user_ssl=0x0, method=0x555557cbadc0 <DTLS_client_method_data.0>) at ssl/ssl_lib.c:913
#10 0x0000555556855bff in ossl_ssl_connection_new (ctx=0x51c000002080) at ssl/ssl_lib.c:974
#11 0x000055555684f082 in SSL_new (ctx=0x51c000002080) at ssl/ssl_lib.c:694
#12 0x0000555556809bca in FuzzerTestOneInput (buf=0x502000001bf0 "\003\376\257\377\024\377\377\257\377\024\377\377\377", len=13) at fuzz/dtlsclient.c:76
#13 0x000055555680a5f6 in run_mfail (buf=0x502000001bf0 "\003\376\257\377\024\377\377\257\377\024\377\377\377", s=13, 
    path=0x7fffffffd5dc "./fuzz/corpora/dtlsclient/b49a37a7873ca9bc732583f0714a2c9b9fdefd28", file_idx=0) at fuzz/test-corpus.c:56
#14 0x000055555680aa03 in testfile (pathname=0x7fffffffd5dc "./fuzz/corpora/dtlsclient/b49a37a7873ca9bc732583f0714a2c9b9fdefd28", file_idx=0) at fuzz/test-corpus.c:94
#15 0x000055555680b236 in main (argc=2, argv=0x7fffffffd118) at fuzz/test-corpus.c:151
```

Then I tracked the flow up to `ssl_set_new_record_layer` that calls fatal if the return value is 
OSSL_RECORD_RETURN_FATAL (which is the case for memory failure) and it eventually crashes here.

```
663	    ret = HANDLE_RLAYER_WRITE_RETURN(sc,
(gdb) bt
#0  do_dtls1_write (sc=0x523000007100, type=21 '\025', buf=0x7ffff48bd3c0 "\002P", len=2, written=0x7ffff48bd3a0) at ssl/record/rec_layer_d1.c:663
#1  0x0000555556b50bee in dtls1_dispatch_alert (ssl=0x523000007100) at ssl/d1_msg.c:58
#2  0x0000555556824313 in ssl3_send_alert (s=0x523000007100, level=2, desc=80) at ssl/s3_msg.c:67
#3  0x0000555556a7127b in ossl_statem_send_fatal (s=0x523000007100, al=80) at ssl/statem/statem.c:156
#4  0x0000555556a713c4 in ossl_statem_fatal (s=0x523000007100, al=80, reason=313, fmt=0x0) at ssl/statem/statem.c:174
#5  0x00005555569ea7c6 in ssl_set_new_record_layer (s=0x523000007100, version=131071, direction=0, level=0, secret=0x0, secretlen=0, key=0x0, keylen=0, iv=0x0, ivlen=0, mackey=0x0, 
    mackeylen=0, ciph=0x0, taglen=0, mactype=0, md=0x0, comp=0x0, kdfdigest=0x0) at ssl/record/rec_layer_s3.c:1451
#6  0x00005555569d9405 in RECORD_LAYER_reset (rl=0x523000007f28) at ssl/record/rec_layer_s3.c:79
#7  0x000055555684e8e4 in ossl_ssl_connection_reset (s=0x523000007100) at ssl/ssl_lib.c:648
#8  0x0000555556854a8d in ossl_ssl_connection_new_int (ctx=0x51c000002080, user_ssl=0x0, method=0x555557cbadc0 <DTLS_client_method_data.0>) at ssl/ssl_lib.c:913
#9  0x0000555556855bff in ossl_ssl_connection_new (ctx=0x51c000002080) at ssl/ssl_lib.c:974
#10 0x000055555684f082 in SSL_new (ctx=0x51c000002080) at ssl/ssl_lib.c:694
#11 0x0000555556809bca in FuzzerTestOneInput (buf=0x502000001bf0 "\003\376\257\377\024\377\377\257\377\024\377\377\377", len=13) at fuzz/dtlsclient.c:76
#12 0x000055555680a5f6 in run_mfail (buf=0x502000001bf0 "\003\376\257\377\024\377\377\257\377\024\377\377\377", s=13, 
    path=0x7fffffffd5dc "./fuzz/corpora/dtlsclient/b49a37a7873ca9bc732583f0714a2c9b9fdefd28", file_idx=0) at fuzz/test-corpus.c:56
#13 0x000055555680aa03 in testfile (pathname=0x7fffffffd5dc "./fuzz/corpora/dtlsclient/b49a37a7873ca9bc732583f0714a2c9b9fdefd28", file_idx=0) at fuzz/test-corpus.c:94
#14 0x000055555680b236 in main (argc=2, argv=0x7fffffffd118) at fuzz/test-corpus.c:151
```

I assume this might impact more places so I added the check to `ossl_statem_send_fatal` to cover it hopefully all.