### PR TITLE
Fix old compilers when missing AVX2 intrinsics

### DIFF
--- a/crypto/evp/enc_b64_avx2.c
+++ b/crypto/evp/enc_b64_avx2.c
@@ -7,6 +7,7 @@
 
 #if defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64)
 #if !defined(_M_ARM64EC)
+#if defined(HAVE_AVX2_INTRINSICS)
 #define STRINGIFY_IMPLEMENTATION_(a) #a
 #define STRINGIFY(a) STRINGIFY_IMPLEMENTATION_(a)
 
@@ -668,5 +669,6 @@ size_t encode_base64_avx2(EVP_ENCODE_CTX *ctx, unsigned char *dst,
     return (size_t)(out - (uint8_t *)dst) + evp_encodeblock_int(ctx, out, src + i, srclen - i, final_wrap_cnt);
 }
 OPENSSL_UNTARGET_AVX2
+#endif /* defined(HAVE_AVX2_INTRINSICS) */
 #endif /* !defined(_M_ARM64EC) */
 #endif

--- a/crypto/evp/enc_b64_avx2.c
+++ b/crypto/evp/enc_b64_avx2.c
@@ -69,7 +69,7 @@ static __m256i lookup_pshufb_std(__m256i input)
 OPENSSL_UNTARGET_AVX2
 
 OPENSSL_TARGET_AVX2
-static inline __m256i lookup_pshufb_srp(__m256i input)
+static ossl_inline __m256i lookup_pshufb_srp(__m256i input)
 {
     const __m256i zero = _mm256_setzero_si256();
     const __m256i hi = _mm256_set1_epi8((char)0x80);
@@ -100,7 +100,7 @@ static inline __m256i lookup_pshufb_srp(__m256i input)
 OPENSSL_UNTARGET_AVX2
 
 OPENSSL_TARGET_AVX2
-static inline __m256i shift_right_zeros(__m256i v, int n)
+static ossl_inline __m256i shift_right_zeros(__m256i v, int n)
 {
     switch (n) {
     case 0:
@@ -142,7 +142,7 @@ static inline __m256i shift_right_zeros(__m256i v, int n)
 OPENSSL_UNTARGET_AVX2
 
 OPENSSL_TARGET_AVX2
-static inline __m256i shift_left_zeros(__m256i v, int n)
+static ossl_inline __m256i shift_left_zeros(__m256i v, int n)
 {
     switch (n) {
     case 0:
@@ -208,7 +208,7 @@ static const uint8_t shuffle_masks[16][16] = {
  * Insert a line feed character in the 64-byte input at index K in [0,32).
  */
 OPENSSL_TARGET_AVX2
-static inline __m256i insert_line_feed32(__m256i input, int K)
+static ossl_inline __m256i insert_line_feed32(__m256i input, int K)
 {
     __m256i line_feed_vector = _mm256_set1_epi8('\n');
     __m128i identity = _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
@@ -236,7 +236,7 @@ static inline __m256i insert_line_feed32(__m256i input, int K)
 OPENSSL_UNTARGET_AVX2
 
 OPENSSL_TARGET_AVX2
-static inline size_t ins_nl_gt32(__m256i v, uint8_t *out, int stride,
+static ossl_inline size_t ins_nl_gt32(__m256i v, uint8_t *out, int stride,
     int *wrap_cnt)
 {
     const int until_nl = stride - *wrap_cnt;
@@ -267,7 +267,7 @@ static inline size_t ins_nl_gt32(__m256i v, uint8_t *out, int stride,
 OPENSSL_UNTARGET_AVX2
 
 OPENSSL_TARGET_AVX2
-static inline size_t insert_nl_gt16(const __m256i v0,
+static ossl_inline size_t insert_nl_gt16(const __m256i v0,
     uint8_t *output,
     int wrap_max, int *wrap_cnt)
 {
@@ -345,7 +345,7 @@ static inline size_t insert_nl_gt16(const __m256i v0,
 OPENSSL_UNTARGET_AVX2
 
 OPENSSL_TARGET_AVX2
-static inline size_t insert_nl_2nd_vec_stride_12(const __m256i v0,
+static ossl_inline size_t insert_nl_2nd_vec_stride_12(const __m256i v0,
     uint8_t *output,
     int dummy_stride,
     int *wrap_cnt)
@@ -379,7 +379,7 @@ static inline size_t insert_nl_2nd_vec_stride_12(const __m256i v0,
 OPENSSL_UNTARGET_AVX2
 
 OPENSSL_TARGET_AVX2
-static inline __m256i insert_newlines_by_mask(__m256i data, __m256i mask)
+static ossl_inline __m256i insert_newlines_by_mask(__m256i data, __m256i mask)
 {
     __m256i newline = _mm256_set1_epi8('\n');
 
@@ -389,7 +389,7 @@ static inline __m256i insert_newlines_by_mask(__m256i data, __m256i mask)
 OPENSSL_UNTARGET_AVX2
 
 OPENSSL_TARGET_AVX2
-static inline size_t insert_nl_str4(const __m256i v0, uint8_t *output)
+static ossl_inline size_t insert_nl_str4(const __m256i v0, uint8_t *output)
 {
     __m256i shuffling_mask = _mm256_setr_epi8(0, 1, 2, 3, (char)0xFF, 4, 5, 6,
         7, (char)0xFF, 8, 9, 10, 11, (char)0xFF, 12,
@@ -447,7 +447,7 @@ static inline size_t insert_nl_str4(const __m256i v0, uint8_t *output)
 OPENSSL_UNTARGET_AVX2
 
 OPENSSL_TARGET_AVX2
-static inline size_t insert_nl_str8(const __m256i v0, uint8_t *output)
+static ossl_inline size_t insert_nl_str8(const __m256i v0, uint8_t *output)
 {
     __m256i shuffling_mask = _mm256_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, (char)0xFF,
         8, 9, 10, 11, 12, 13, 14,

--- a/crypto/evp/enc_b64_avx2.h
+++ b/crypto/evp/enc_b64_avx2.h
@@ -4,11 +4,21 @@
 #include <openssl/evp.h>
 #include <stddef.h>
 
+#if defined(__clang__)
+#define HAVE_AVX2_INTRINSICS 1
+#elif defined(__GNUC__) && (__GNUC__ >= 8)
+#define HAVE_AVX2_INTRINSICS 1
+#elif defined(_MSC_VER) && (_MSC_VER >= 1920) /* MSVC 2019 */
+#define HAVE_AVX2_INTRINSICS 1
+#endif
+
 #if defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64)
 #if !defined(_M_ARM64EC)
+#if defined(HAVE_AVX2_INTRINSICS)
 size_t encode_base64_avx2(EVP_ENCODE_CTX *ctx,
     unsigned char *out, const unsigned char *src, int srclen,
     int newlines, int *wrap_cnt);
+#endif /* defined(HAVE_AVX2_INTRINSICS) */
 #endif /* !defined(_M_ARM64EC) */
 #endif
 

--- a/crypto/evp/encode.c
+++ b/crypto/evp/encode.c
@@ -405,14 +405,14 @@ int EVP_EncodeUpdate(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl,
         j = evp_encodeblock_int(ctx, out, in, inl - (inl % EVP_ENCODE_B64_LENGTH),
             &wrap_cnt);
     } else {
-#if defined(__AVX2__)
+#if defined(__AVX2__) && defined(HAVE_AVX2_INTRINSICS)
         const int newlines = !(ctx->flags & EVP_ENCODE_CTX_NO_NEWLINES) ? EVP_ENCODE_B64_LENGTH : 0;
 
         j = encode_base64_avx2(ctx,
             (unsigned char *)out,
             (const unsigned char *)in,
             inl - (inl % EVP_ENCODE_B64_LENGTH), newlines, &wrap_cnt);
-#elif defined(HAS_IA32CAP_IS_64)
+#elif defined(HAS_IA32CAP_IS_64) && defined(HAVE_AVX2_INTRINSICS)
         if ((OPENSSL_ia32cap_P[2] & (1u << 5)) != 0) {
             const int newlines = !(ctx->flags & EVP_ENCODE_CTX_NO_NEWLINES) ? EVP_ENCODE_B64_LENGTH : 0;
 
@@ -473,9 +473,9 @@ int EVP_EncodeBlock(unsigned char *t, const unsigned char *f, int dlen)
 {
     int wrap_cnt = 0;
 
-#if defined(__AVX2__)
+#if defined(__AVX2__) && defined(HAVE_AVX2_INTRINSICS)
     return (int)encode_base64_avx2(NULL, t, f, dlen, 0, &wrap_cnt);
-#elif defined(HAS_IA32CAP_IS_64)
+#elif defined(HAS_IA32CAP_IS_64) && defined(HAVE_AVX2_INTRINSICS)
     if ((OPENSSL_ia32cap_P[2] & (1u << 5)) != 0)
         return (int)encode_base64_avx2(NULL, t, f, dlen, 0, &wrap_cnt);
     else


### PR DESCRIPTION
Two small things that allows to compile code with gcc 7.x and MSVC2013:

- use ossl_inline instead of inline in enc_b64_avx2.c

- do not compile AVX2 code if AVX2 intrinsics is not supported
    
Old and exotic compilers do not support AVX2 instrinsic.
Add guard for Clang, GCC >= 8 and MSVC >= 2019.
    
Fixes: #30958
