### PR TITLE
ssl: guard ciphersuite_cb() against NULL elem from CONF_parse_list 

### DIFF
--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1234,6 +1234,10 @@ static int ciphersuite_cb(const char *elem, int len, void *arg)
     /* Arbitrary sized temp buffer for the cipher name. Should be big enough */
     char name[80];
 
+    /* CONF_parse_list signals empty elements with elem==NULL; skip them */
+    if (elem == NULL || len == 0)
+        return 1;
+
     if (len > (int)(sizeof(name) - 1))
         /* Anyway return 1 so we can parse rest of the list */
         return 1;

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1234,7 +1234,7 @@ static int ciphersuite_cb(const char *elem, int len, void *arg)
     /* Arbitrary sized temp buffer for the cipher name. Should be big enough */
     char name[80];
 
-    /* CONF_parse_list signals empty elements with elem==NULL; skip them */
+    /* CONF_parse_list signals empty elements with elem == NULL; skip them */
     if (elem == NULL || len == 0)
         return 1;
 

--- a/test/cipherlist_test.c
+++ b/test/cipherlist_test.c
@@ -258,11 +258,66 @@ end:
     return result;
 }
 
+/*
+ * SSL_CTX_set_ciphersuites() must not crash on empty list elements.
+ * CONF_parse_list() signals them with elem=NULL; ciphersuite_cb() must skip
+ * such entries rather than passing NULL to memcpy().
+ */
+#ifndef OPENSSL_NO_TLS1_3
+static int cipher_in_ctx(const SSL_CTX *ctx, uint32_t id)
+{
+    const STACK_OF(SSL_CIPHER) *sk = SSL_CTX_get_ciphers(ctx);
+    int i;
+
+    for (i = 0; i < sk_SSL_CIPHER_num(sk); i++)
+        if (SSL_CIPHER_get_id(sk_SSL_CIPHER_value(sk, i)) == id)
+            return 1;
+    return 0;
+}
+
+static int test_set_ciphersuites_empty_elem(void)
+{
+    SSL_CTX *ctx = NULL;
+    int result = 0;
+
+    if (!TEST_ptr(ctx = SSL_CTX_new(TLS_method())))
+        goto end;
+
+    /* Double colon: both surrounding valid suites must be applied */
+    if (!TEST_true(SSL_CTX_set_ciphersuites(ctx,
+            "TLS_AES_128_GCM_SHA256::TLS_AES_256_GCM_SHA384")))
+        goto end;
+    if (!TEST_true(cipher_in_ctx(ctx, TLS1_3_CK_AES_128_GCM_SHA256))
+        || !TEST_true(cipher_in_ctx(ctx, TLS1_3_CK_AES_256_GCM_SHA384)))
+        goto end;
+
+    /* Leading separator: empty first element, one valid suite must apply */
+    if (!TEST_true(SSL_CTX_set_ciphersuites(ctx, ":TLS_AES_128_GCM_SHA256")))
+        goto end;
+    if (!TEST_true(cipher_in_ctx(ctx, TLS1_3_CK_AES_128_GCM_SHA256)))
+        goto end;
+
+    /* Trailing separator: empty last element, one valid suite must apply */
+    if (!TEST_true(SSL_CTX_set_ciphersuites(ctx, "TLS_AES_128_GCM_SHA256:")))
+        goto end;
+    if (!TEST_true(cipher_in_ctx(ctx, TLS1_3_CK_AES_128_GCM_SHA256)))
+        goto end;
+
+    result = 1;
+end:
+    SSL_CTX_free(ctx);
+    return result;
+}
+#endif
+
 int setup_tests(void)
 {
     ADD_TEST(test_default_cipherlist_implicit);
     ADD_TEST(test_default_cipherlist_explicit);
     ADD_TEST(test_default_cipherlist_clear);
+#ifndef OPENSSL_NO_TLS1_3
+    ADD_TEST(test_set_ciphersuites_empty_elem);
+#endif
     ADD_TEST(test_stdname_cipherlist);
     return 1;
 }


### PR DESCRIPTION
CONF_parse_list() signals empty list elements by invoking its callback with elem = NULL and len = 0. This happens whenever the input string contains consecutive separators (e.g. "TLS_AES_128_GCM_SHA256::TLS_AES_256_GCM_SHA384"), a leading colon, or a trailing colon.
                                                                                                                                                                                                                                             
ciphersuite_cb() did not guard against this and passed elem unconditionally to memcpy(), triggering undefined behaviour (NULL pointer dereference) on any such malformed input to SSL_CTX_set_ciphersuites().                               

The fix adds an early-return guard at the top of ciphersuite_cb() that skips empty elements and continues parsing the rest of the list, consistent with how the function already handles other non-fatal cases (oversized names, unknown ciphersuite names).

A regression test covering the three empty-element shapes (double colon, leading colon, trailing colon) is added to test/cipherlist_test.c.                                                                                                 

Fixes #30919  
                                                                                                                                                                                                                              
 ##### Checklist
- [x] regression test covers three empty-element shapes: leading colon, trailing colon, double colon
- [x] tests verify valid ciphersuites in the same string are applied via SSL_CTX_get_ciphers()  
- [x] null guard added to ciphersuite_cb() before memcpy() to skip NULL elements from CONF_parse_list()