### PR TITLE
Fix #31015: Return value documentation of i2d_* functions doesn't seem to match reality w.r.t. error handling

### DIFF
--- a/doc/man3/X509_PUBKEY_new.pod
+++ b/doc/man3/X509_PUBKEY_new.pod
@@ -141,8 +141,8 @@ X509_PUBKEY_get0(), X509_PUBKEY_get(), d2i_PUBKEY_ex(), d2i_PUBKEY(),
 d2i_PUBKEY_ex_bio(), d2i_PUBKEY_bio(), d2i_PUBKEY_ex_fp() and d2i_PUBKEY_fp()
 return a pointer to an B<EVP_PKEY> structure or NULL if an error occurs.
 
-i2d_PUBKEY() returns the number of bytes successfully encoded or a
-negative value if an error occurs.
+i2d_PUBKEY() returns the number of bytes successfully encoded or
+<= 0 if an error occurs.
 
 i2d_PUBKEY_fp() and i2d_PUBKEY_bio() return 1 if successfully
 encoded or 0 if an error occurs.

--- a/doc/man3/d2i_PrivateKey.pod
+++ b/doc/man3/d2i_PrivateKey.pod
@@ -110,7 +110,7 @@ and d2i_KeyParams_bio() functions return a valid B<EVP_PKEY> structure or NULL i
 an error occurs. The error code can be obtained by calling L<ERR_get_error(3)>.
 
 i2d_PrivateKey(), i2d_PKCS8PrivateKey(), i2d_PublicKey() and i2d_KeyParams()
-return the number of bytes successfully encoded or a negative value if an error
+return the number of bytes successfully encoded or <= 0 if an error
 occurs. The error code can be obtained by calling L<ERR_get_error(3)>.
 
 i2d_PrivateKey_bio(), i2d_PrivateKey_fp() and i2d_KeyParams_bio() return 1 if

--- a/doc/man3/d2i_RSAPrivateKey.pod
+++ b/doc/man3/d2i_RSAPrivateKey.pod
@@ -291,8 +291,8 @@ B<I<TYPE>> structure or NULL if an error occurs.  If the "reuse" capability has
 been used with a valid structure being passed in via I<a>, then the object is
 freed in the event of error and I<*a> is set to NULL.
 
-B<i2d_I<TYPE>>() returns the number of bytes successfully encoded or a negative
-value if an error occurs.
+B<i2d_I<TYPE>>() returns the number of bytes successfully encoded or <= 0
+if an error occurs.
 
 B<i2d_I<TYPE>_bio>() and B<i2d_I<TYPE>_fp>() return 1 for success and 0 if an
 error occurs.

--- a/doc/man3/d2i_X509.pod
+++ b/doc/man3/d2i_X509.pod
@@ -496,8 +496,8 @@ to parse data from FILE pointer I<fp>.
 B<i2d_I<TYPE>>() encodes the structure pointed to by I<a> into DER format.
 If I<ppout> is not NULL, it writes the DER encoded data to the buffer
 at I<*ppout>, and increments it to point after the data just written.
-If the return value is negative an error occurred, otherwise it
-returns the length of the encoded data.
+A positive return value contains the length of the encoded data.
+A zero or negative return value indicates that an error occurred.
 
 If I<*ppout> is NULL memory will be allocated for a buffer and the encoded
 data written to it. In this case I<*ppout> is not incremented and it points
@@ -585,8 +585,8 @@ B<I<TYPE>> structure or NULL if an error occurs.  If the "reuse" capability has
 been used with a valid structure being passed in via I<a>, then the object is
 freed in the event of error and I<*a> is set to NULL.
 
-B<i2d_I<TYPE>>() returns the number of bytes successfully encoded or a negative
-value if an error occurs.
+B<i2d_I<TYPE>>() returns the number of bytes successfully encoded or <= 0
+if an error occurs.
 
 B<i2d_I<TYPE>_bio>() and B<i2d_I<TYPE>_fp>(),
 as well as i2d_ASN1_bio_stream(),
@@ -605,7 +605,7 @@ Allocate and encode the DER encoding of an X509 structure:
 
  buf = NULL;
  len = i2d_X509(x, &buf);
- if (len < 0)
+ if (len <= 0)
      /* error */
 
 Attempt to decode a buffer:

--- a/doc/man3/i2d_re_X509_tbs.pod
+++ b/doc/man3/i2d_re_X509_tbs.pod
@@ -52,10 +52,10 @@ i2d_re_X509_tbs().
 
 d2i_X509_AUX() returns a valid B<X509> structure or NULL if an error occurred.
 
-i2d_X509_AUX() returns the length of encoded data or -1 on error.
+i2d_X509_AUX() returns the length of encoded data or <= 0 on error.
 
 i2d_re_X509_tbs(), i2d_re_X509_CRL_tbs() and i2d_re_X509_REQ_tbs() return the
-length of encoded data or <=0 on error.
+length of encoded data or <= 0 on error.
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
This fixes the example and return value sections of the i2d_* functions as described in the GitHub issue. Some examples were already correct so those did not need any modifications.

Fixes #31015

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

I can make the code consistent later after this is agreed on and approved.