### PR TITLE
slh_dsa: cleanse generated add_random buffer

### DIFF
--- a/providers/implementations/signature/slh_dsa_sig.c
+++ b/providers/implementations/signature/slh_dsa_sig.c
@@ -241,8 +241,9 @@ static int slh_dsa_sign(void *vctx, unsigned char *sig, size_t *siglen,
         ctx->context_string, ctx->context_string_len,
         opt_rand, ctx->msg_encode,
         sig, siglen, sigsize);
-    if (opt_rand != add_rand)
-        OPENSSL_cleanse(opt_rand, n);
+    /* Only cleanse the temporary buffer generated for this signature. */
+    if (opt_rand == add_rand)
+        OPENSSL_cleanse(add_rand, sizeof(add_rand));
     return ret;
 }
 


### PR DESCRIPTION
Fix the inverted cleanse guard in the SLH DSA provider signing path.

When randomized signing populates the local `add_rand` buffer, the cleanup step currently skips that stack buffer. Other signing modes don't create this transient buffer, so they should not drive this cleanup. Swap the guard so only the transient per signature buffer is cleansed and cleanse the full fixed size buffer directly.

This doesn't change signature output and preserves the existing lifetime of provider context test entropy.

Fixes #30950
