### PR TITLE
Fix memory leak in asn_mime multi_split

### DIFF
--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -660,10 +660,8 @@ static int multi_split(BIO *bio, int flags, const char *bound, STACK_OF(BIO) **r
                     return 0;
                 BIO_set_mem_eof_return(bpart, 0);
             }
-            if (!sk_BIO_push(parts, bpart)) {
-                BIO_free(bpart);
-                return 0;
-            }
+            if (!sk_BIO_push(parts, bpart))
+                goto err;
             return 1;
         } else if (part != 0) {
             /* Strip (possibly CR +) LF from linebuf */
@@ -671,10 +669,8 @@ static int multi_split(BIO *bio, int flags, const char *bound, STACK_OF(BIO) **r
             if (first) {
                 first = 0;
                 if (bpart)
-                    if (!sk_BIO_push(parts, bpart)) {
-                        BIO_free(bpart);
-                        return 0;
-                    }
+                    if (!sk_BIO_push(parts, bpart))
+                        goto err;
                 bpart = BIO_new(BIO_s_mem());
                 if (bpart == NULL)
                     return 0;
@@ -688,17 +684,18 @@ static int multi_split(BIO *bio, int flags, const char *bound, STACK_OF(BIO) **r
 #endif
                     || (flags & SMIME_CRLFEOL) != 0) {
                     if (BIO_puts(bpart, "\r\n") < 0)
-                        return 0;
+                        goto err;
                 } else {
                     if (BIO_puts(bpart, "\n") < 0)
-                        return 0;
+                        goto err;
                 }
             }
             eol = next_eol;
             if (len > 0 && BIO_write(bpart, linebuf, len) != len)
-                return 0;
+                goto err;
         }
     }
+err:
     BIO_free(bpart);
     return 0;
 }


### PR DESCRIPTION
The bpart is not freed if BIO_write or BIO_puts fails. It also makes the error handling of that case consistent with other parts freeing the bpart.

Found using memfail integration to fuzz tests: https://github.com/openssl/openssl/pull/30944