### PR TITLE
DTLS 1.3 Fixing No Integrity Ciphers CI

### DIFF
--- a/test/dtlstest.c
+++ b/test/dtlstest.c
@@ -254,6 +254,7 @@ static int test_dtls_drop_records_dtls1(int idx)
 #define DTLS13_TOTAL_RECORDS \
     (DTLS13_TOTAL_HAND_RECORDS_FULL + DTLS13_TOTAL_HAND_RECORDS_RESM)
 
+#if !defined(OPENSSL_NO_INTEGRITY_ONLY_CIPHERS)
 /**
  * test_dtls_drop_records_dtls13 tests DTLS 1.3 implementation robustness against
  * dropped records
@@ -314,6 +315,7 @@ static int test_dtls_drop_records_dtls13(int idx)
 
     return test_dtls_drop_records(serverwbio, DTLS1_3_VERSION, 0, doresumption, epoch, idx);
 }
+#endif /* !defined(OPENSSL_NO_INTEGRITY_ONLY_CIPHERS) */
 
 static int test_dtls_drop_records(int serverwbio, int minversion, int maxversion,
     int doresumption, int epoch, int idx)


### PR DESCRIPTION
The only integrity Ciphers CI is currently broken for dtlstest

These ciphers are needed so we have an unencrypted sequence number so we can swap records around.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
