### PR TITLE
sparse_array: avoid ubsan violation in typed doall

### DIFF
--- a/include/crypto/sparse_array.h
+++ b/include/crypto/sparse_array.h
@@ -22,6 +22,8 @@ extern "C" {
 
 #define DEFINE_SPARSE_ARRAY_OF_INTERNAL(type, ctype)                                                               \
     SPARSE_ARRAY_OF(type);                                                                                         \
+    typedef void (*sa_##type##_leaffunc)(ossl_uintmax_t idx, type *t);                                             \
+    typedef void (*sa_##type##_leaffunc_arg)(ossl_uintmax_t idx, type *t, void *arg);                              \
     static ossl_unused ossl_inline SPARSE_ARRAY_OF(type) * ossl_sa_##type##_new(void)                              \
     {                                                                                                              \
         return (SPARSE_ARRAY_OF(type) *)ossl_sa_new();                                                             \
@@ -41,20 +43,40 @@ extern "C" {
     {                                                                                                              \
         return ossl_sa_num((OPENSSL_SA *)sa);                                                                      \
     }                                                                                                              \
+    static ossl_unused void                                                                                        \
+    ossl_sa_##type##_doall_thunk(ossl_uintmax_t idx, void *leaf, void *arg)                                        \
+    {                                                                                                              \
+        sa_##type##_leaffunc fn = *(sa_##type##_leaffunc *)arg;                                                    \
+        (*fn)(idx, (type *)leaf);                                                                                  \
+    }                                                                                                              \
     static ossl_unused ossl_inline void                                                                            \
     ossl_sa_##type##_doall(const SPARSE_ARRAY_OF(type) * sa,                                                       \
         void (*leaf)(ossl_uintmax_t, type *))                                                                      \
     {                                                                                                              \
-        ossl_sa_doall((OPENSSL_SA *)sa,                                                                            \
-            (void (*)(ossl_uintmax_t, void *))leaf);                                                               \
+        ossl_sa_doall_arg((OPENSSL_SA *)sa, ossl_sa_##type##_doall_thunk, &leaf);                                  \
+    }                                                                                                              \
+    struct ossl_sa_##type##_doall_thunk {                                                                          \
+        sa_##type##_leaffunc_arg fn;                                                                               \
+        void *arg;                                                                                                 \
+    };                                                                                                             \
+    static ossl_unused void                                                                                        \
+    ossl_sa_##type##_doall_arg_thunk(ossl_uintmax_t idx, void *leaf, void *arg)                                    \
+    {                                                                                                              \
+        struct ossl_sa_##type##_doall_thunk *t = arg;                                                              \
+                                                                                                                   \
+        (*t->fn)(idx, (type *)leaf, t->arg);                                                                       \
     }                                                                                                              \
     static ossl_unused ossl_inline void                                                                            \
     ossl_sa_##type##_doall_arg(const SPARSE_ARRAY_OF(type) * sa,                                                   \
         void (*leaf)(ossl_uintmax_t, type *, void *),                                                              \
         void *arg)                                                                                                 \
     {                                                                                                              \
+        struct ossl_sa_##type##_doall_thunk t;                                                                     \
+                                                                                                                   \
+        t.fn = leaf;                                                                                               \
+        t.arg = arg;                                                                                               \
         ossl_sa_doall_arg((OPENSSL_SA *)sa,                                                                        \
-            (void (*)(ossl_uintmax_t, void *, void *))leaf, arg);                                                  \
+            ossl_sa_##type##_doall_arg_thunk, &t);                                                                 \
     }                                                                                                              \
     static ossl_unused ossl_inline ctype *ossl_sa_##type##_get(const SPARSE_ARRAY_OF(type) * sa, ossl_uintmax_t n) \
     {                                                                                                              \


### PR DESCRIPTION
clang-22 with enable-asan and enable-ubsan enabled fails with error

  crypto/sparse_array.c:93:21: runtime error: call to function alg_copy
  through pointer to incorrect function type 'void (*)(unsigned long, void *, void *)'

    ossl_sa_##type##_doall(const SPARSE_ARRAY_OF(type) * sa,
        void (*leaf)(ossl_uintmax_t, type *))
    {
        ossl_sa_doall((OPENSSL_SA *)sa,
            (void (*)(ossl_uintmax_t, void *))leaf);
    }

typed doall(_arg) expect leaf to have type, but generic code is using void *, and the type-casting cases the error.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
