### PR TITLE
test_dtls_drop_records_dtls13() must be dropped with no-integrity-only-ciphers

### DIFF
--- a/test/dtlstest.c
+++ b/test/dtlstest.c
@@ -254,6 +254,7 @@ static int test_dtls_drop_records_dtls1(int idx)
 #define DTLS13_TOTAL_RECORDS \
     (DTLS13_TOTAL_HAND_RECORDS_FULL + DTLS13_TOTAL_HAND_RECORDS_RESM)
 
+#ifndef OPENSSL_NO_INTEGRITY_ONLY_CIPHERS
 /**
  * test_dtls_drop_records_dtls13 tests DTLS 1.3 implementation robustness against
  * dropped records
@@ -314,6 +315,7 @@ static int test_dtls_drop_records_dtls13(int idx)
 
     return test_dtls_drop_records(serverwbio, DTLS1_3_VERSION, 0, doresumption, epoch, idx);
 }
+#endif
 
 static int test_dtls_drop_records(int serverwbio, int minversion, int maxversion,
     int doresumption, int epoch, int idx)


### PR DESCRIPTION
This fixes run-checker-merge CI breakage on the feature branch.
