### PR TITLE
Don't rely on cmp of uninitialized values in obj_dat.pl

### DIFF
--- a/crypto/objects/obj_dat.pl
+++ b/crypto/objects/obj_dat.pl
@@ -209,11 +209,11 @@ printf "static const unsigned int obj_objs[NUM_OBJ] = {\n";
 # Compare DER; prefer shorter; if some length, use the "smaller" encoding.
 sub obj_cmp
 {
-    no warnings "uninitialized";
-    my $A = $obj_len{$obj{$nid{$a}}};
-    my $B = $obj_len{$obj{$nid{$b}}};
+    my $A = defined($obj_len{$obj{$nid{$a}}}) ? $obj_len{$obj{$nid{$a}}} : 0;
+    my $B = defined($obj_len{$obj{$nid{$b}}}) ? $obj_len{$obj{$nid{$b}}} : 0;
     my $r = $A - $B;
     return $r if $r != 0;
+    return 0 if $A == 0;
 
     $A = $obj_der{$obj{$nid{$a}}};
     $B = $obj_der{$obj{$nid{$b}}};

--- a/crypto/objects/obj_dat.pl
+++ b/crypto/objects/obj_dat.pl
@@ -209,8 +209,8 @@ printf "static const unsigned int obj_objs[NUM_OBJ] = {\n";
 # Compare DER; prefer shorter; if some length, use the "smaller" encoding.
 sub obj_cmp
 {
-    my $A = defined($obj_len{$obj{$nid{$a}}}) ? $obj_len{$obj{$nid{$a}}} : 0;
-    my $B = defined($obj_len{$obj{$nid{$b}}}) ? $obj_len{$obj{$nid{$b}}} : 0;
+    my $A = $obj_len{$obj{$nid{$a}}} // 0;
+    my $B = $obj_len{$obj{$nid{$b}}} // 0;
     my $r = $A - $B;
     return $r if $r != 0;
     return 0 if $A == 0;


### PR DESCRIPTION
Since we use this for a sort, in theory this could become inconsistent if we were to do a make update, re-generate the output, and check it in from a different development platform that returns different inconsistencies in how cmp behaves on uninitialized values.

Rather than ponder this, just make this consistent by ensuring undefined values have 0 length, and remove the disabling of the warnings in obj_cmp

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
