### PR TITLE
Fix potential UB memcmps in obj_dat.c

### DIFF
--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -162,8 +162,7 @@ static unsigned long added_obj_hash(const ADDED_OBJ *ca)
  */
 static int obj_equivalent(const ASN1_OBJECT *a, const ASN1_OBJECT *b)
 {
-    return a->length == b->length
-        && memcmp(a->data, b->data, (size_t)a->length) == 0
+    return OBJ_cmp(a, b) == 0
         && (a->sn == NULL) == (b->sn == NULL)
         && strcmp(a->sn ? a->sn : "", b->sn ? b->sn : "") == 0
         && (a->ln == NULL) == (b->ln == NULL)
@@ -182,10 +181,7 @@ static int added_obj_cmp(const ADDED_OBJ *ca, const ADDED_OBJ *cb)
     b = cb->obj;
     switch (ca->type) {
     case ADDED_DATA:
-        i = (a->length - b->length);
-        if (i)
-            return i;
-        return memcmp(a->data, b->data, (size_t)a->length);
+        return OBJ_cmp(a, b);
     case ADDED_SNAME:
         if (a->sn == NULL)
             return -1;
@@ -296,16 +292,7 @@ const char *OBJ_nid2ln(int n)
 
 static int obj_cmp(const ASN1_OBJECT *const *ap, const unsigned int *bp)
 {
-    int j;
-    const ASN1_OBJECT *a = *ap;
-    const ASN1_OBJECT *b = &nid_objs[*bp];
-
-    j = (a->length - b->length);
-    if (j)
-        return j;
-    if (a->length == 0)
-        return 0;
-    return memcmp(a->data, b->data, a->length);
+    return OBJ_cmp(*ap, &nid_objs[*bp]);
 }
 
 IMPLEMENT_OBJ_BSEARCH_CMP_FN(const ASN1_OBJECT *, unsigned int, obj);


### PR DESCRIPTION
By just calling the real OBJ_cmp where it is being fixed in https://github.com/openssl/openssl/pull/30943

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
