### PR TITLE
Guard memcmp for ub in X509_vpm.c

### DIFF
--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -110,6 +110,8 @@ static int buffer_cmp(const X509_BUFFER *const *a, const X509_BUFFER *const *b)
         return -1;
     if ((*a)->len > (*b)->len)
         return 1;
+    if ((*b)->len == 0)
+        return 0;
     return memcmp((*a)->data, (*b)->data, (*b)->len);
 }
 


### PR DESCRIPTION
Technically unnecessary, since this thing won't let you add NULL data to it, but this is harmless and then obviously following the correct paradigm.  so just a cleanup to look like https://github.com/openssl/openssl/pull/30943
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
