### PR TITLE
prov: remove static globals from ossl_default_provider_init (TSAN race)

### DIFF
--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -34,10 +34,6 @@ static OSSL_FUNC_provider_query_operation_fn deflt_query;
 #define ALGC(NAMES, FUNC, CHECK) { { NAMES, "provider=default", FUNC }, CHECK }
 #define ALG(NAMES, FUNC) ALGC(NAMES, FUNC, NULL)
 
-/* Functions provided by the core */
-static OSSL_FUNC_core_gettable_params_fn *c_gettable_params = NULL;
-static OSSL_FUNC_core_get_params_fn *c_get_params = NULL;
-
 /* Parameters we provide to the core */
 static const OSSL_PARAM deflt_param_types[] = {
     OSSL_PARAM_DEFN(OSSL_PROV_PARAM_NAME, OSSL_PARAM_UTF8_PTR, NULL, 0),
@@ -799,6 +795,7 @@ int ossl_default_provider_init(const OSSL_CORE_HANDLE *handle,
     void **provctx)
 {
     OSSL_FUNC_core_get_libctx_fn *c_get_libctx = NULL;
+    OSSL_FUNC_core_get_params_fn *c_get_params = NULL;
     BIO_METHOD *corebiometh;
 
     if (!ossl_prov_bio_from_dispatch(in)
@@ -806,9 +803,6 @@ int ossl_default_provider_init(const OSSL_CORE_HANDLE *handle,
         return 0;
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
-        case OSSL_FUNC_CORE_GETTABLE_PARAMS:
-            c_gettable_params = OSSL_FUNC_core_gettable_params(in);
-            break;
         case OSSL_FUNC_CORE_GET_PARAMS:
             c_get_params = OSSL_FUNC_core_get_params(in);
             break;


### PR DESCRIPTION
## Summary

Remove the two file-scope statics in `providers/defltprov.c` that
backed the TSAN data race reported in #28935. `c_gettable_params` was
dead code; `c_get_params` is only consumed inside
`ossl_default_provider_init()` and is now a local there.

## Why this matters

Building OpenSSL 3.5.4 with `-fsanitize=thread` and calling
`OSSL_PROVIDER_load("default")` from multiple threads triggers a TSAN
report on the writes at `providers/defltprov.c` (the dispatch loop in
`ossl_default_provider_init`). The reporter walked through the race in
[#28935](https://github.com/openssl/openssl/issues/28935):

> It looks like `ossl_default_provider_init` always overwrites the
> global `c_get_params` and `c_gettable_params`. This leads to a data
> race when `OSSL_PROVIDER_load` is called by different threads.

Maintainer @t8m confirmed the direction in the same thread:

> Yes, these do not need to be global variables. Besides the
> `c_gettable_params` value is not used at all.

This PR follows that recipe.

## Changes

- Drop the file-scope `c_gettable_params` static and its
  `OSSL_FUNC_CORE_GETTABLE_PARAMS` dispatch case (dead storage; never
  read anywhere in the file).
- Move `c_get_params` from a file-scope `static` to a local in
  `ossl_default_provider_init()`. It is only used once, immediately
  below the dispatch loop, to seed the provider context via
  `ossl_prov_ctx_set0_core_get_params(*provctx, c_get_params)`.

Net diff: `1 file changed, 1 insertion(+), 7 deletions(-)`.

## Testing

- `./Configure --strict-warnings` and `make build_libs` complete cleanly
  on macOS (clang, `-Werror`).
- `clang-format --dry-run --Werror providers/defltprov.c` reports no
  diff.
- No behavior change for single-threaded callers; the concurrent-load
  race goes away because the shared mutable state is gone.

I did not include a focused TSAN regression test in this PR. The fix
is structural (removes the shared state entirely) and a TSAN-only test
would not run under default CI; happy to add one in `test/threadstest.c`
if reviewers prefer.

The same two-static pattern may exist in other built-in providers
(`baseprov.c`, `nullprov.c`, `legacyprov.c`, FIPS provider). Out of
scope for this PR; flagging as a possible follow-up.

Fixes #28935

AI was used for assistance.
