### PR TITLE
Avoid needless casting away of `const` in `X509_VERIFY_PARAM_get1_ip_asc`

### DIFF
--- a/crypto/x509/v3_utl.c
+++ b/crypto/x509/v3_utl.c
@@ -1081,7 +1081,7 @@ int X509_check_ip_asc(const X509 *x, const char *ipasc, unsigned int flags)
     return do_x509_check(x, (char *)ipout, iplen, flags, GEN_IPADD, 0, NULL);
 }
 
-char *ossl_ipaddr_to_asc(unsigned char *p, int len)
+char *ossl_ipaddr_to_asc(const unsigned char *p, int len)
 {
     /*
      * 40 is enough space for the longest IPv6 address + nul terminator byte

--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -864,8 +864,7 @@ static const unsigned char *int_X509_VERIFY_PARAM_get0_ip(X509_VERIFY_PARAM *par
 char *X509_VERIFY_PARAM_get1_ip_asc(X509_VERIFY_PARAM *param)
 {
     size_t iplen;
-    /* XXX casts away const */
-    unsigned char *ip = (unsigned char *)int_X509_VERIFY_PARAM_get0_ip(param, &iplen, 0);
+    const unsigned char *ip = int_X509_VERIFY_PARAM_get0_ip(param, &iplen, 0);
 
     return ip == NULL ? NULL : ossl_ipaddr_to_asc(ip, (int)iplen);
 }

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -156,7 +156,7 @@ const void *ossl_bsearch(const void *key, const void *base, int num,
 
 char *ossl_sk_ASN1_UTF8STRING2text(STACK_OF(ASN1_UTF8STRING) *text,
     const char *sep, size_t max_len);
-char *ossl_ipaddr_to_asc(unsigned char *p, int len);
+char *ossl_ipaddr_to_asc(const unsigned char *p, int len);
 
 char *ossl_buf2hexstr_sep(const unsigned char *buf, long buflen, char sep);
 unsigned char *ossl_hexstr2buf_sep(const char *str, long *buflen,


### PR DESCRIPTION
Instead of needlessly casting `const` away, simply update the prototype of `ossl_ipaddr_to_asc()`, that doesn't modify the passed data in any way anyway.

Fixes: f584ae959cbc "Let's support multiple names for certificate verification"