### PR TITLE
Fix NULL deref in DH paramgen type ctrl-to-provider translation

### DIFF
--- a/crypto/evp/ctrl_params_translate.c
+++ b/crypto/evp/ctrl_params_translate.c
@@ -1075,9 +1075,10 @@ static int fix_dh_paramgen_type(enum state state,
     if (ctx->action_type != OSSL_ACTION_SET)
         return 0;
 
-    if (state == PRE_CTRL_STR_TO_PARAMS) {
-        if ((ctx->p2 = (char *)ossl_dh_gen_type_id2name(atoi(ctx->p2)))
-            == NULL) {
+    if (state == PRE_CTRL_TO_PARAMS || state == PRE_CTRL_STR_TO_PARAMS) {
+        int gen_type = state == PRE_CTRL_TO_PARAMS ? ctx->p1 : atoi(ctx->p2);
+
+        if ((ctx->p2 = (char *)ossl_dh_gen_type_id2name(gen_type)) == NULL) {
             ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_VALUE);
             return 0;
         }


### PR DESCRIPTION
`fix_dh_paramgen_type()` only converts the DH generation type integer to a provider-side UTF8 string for the `PRE_CTRL_STR_TO_PARAMS` path. When `EVP_PKEY_CTX_set_dh_paramgen_type(ctx, 0)` is called through the integer ctrl path (`PRE_CTRL_TO_PARAMS`), the conversion is skipped, leaving `ctx->p2` as `NULL`. `default_fixup_args()` then constructs an `OSSL_PARAM` UTF8 string with `data=NULL`, and the provider calls `strcmp(NULL, "default")` in `dh_gen_type_name2id_w_default()`, causing a null pointer dereference (UBSan: `runtime error: null pointer passed as argument 1` at `dh_kmgmt.c:89`).

The value `0` is the documented constant `DH_PARAMGEN_TYPE_GENERATOR`: this is valid API usage, not misuse.

This patch extends `fix_dh_paramgen_type()` to also handle `PRE_CTRL_TO_PARAMS` by reading the integer type from `ctx->p1` and converting it via `ossl_dh_gen_type_id2name()`. Invalid type IDs are rejected with `EVP_R_INVALID_VALUE`.

Fixes #30921