### PR TITLE
Limit job count on compiler zoo builds

### DIFF
--- a/.github/workflows/compiler-zoo.yml
+++ b/.github/workflows/compiler-zoo.yml
@@ -37,7 +37,7 @@ jobs:
     - name: config dump
       run: ./configdata.pm --dump
     - name: make
-      run: make -s -j
+      run: make -s -j4
     - name: get cpu info
       run: |
         cat /proc/cpuinfo
@@ -73,7 +73,7 @@ jobs:
     - name: config dump
       run: ./configdata.pm --dump
     - name: make
-      run: make -s -j
+      run: make -s -j4
     - name: get cpu info
       run: |
         cat /proc/cpuinfo


### PR DESCRIPTION
The security repo keeps failing our compiler zoo jobs, consistently.  It appears to be happening because our compiler zoo jobs use make -j without any limit on the number of jobs, leading to github aborting them all when the workload gets too high.  I suspect that we're using a smaller runner in the security repo than we are in our public repo, which is why we don't see it there.

Our other CI jobs all limit the job count to 4 during make, do the same here.

