### PR TITLE
Check BIO_write return values in asn_mime multi split

### DIFF
--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -665,16 +665,18 @@ static int multi_split(BIO *bio, int flags, const char *bound, STACK_OF(BIO) **r
 #else
                     1
 #endif
-                    || (flags & SMIME_CRLFEOL) != 0)
-                    BIO_write(bpart, "\r\n", 2);
-                else
-                    BIO_write(bpart, "\n", 1);
+                    || (flags & SMIME_CRLFEOL) != 0) {
+                    if (BIO_write(bpart, "\r\n", 2) < 2)
+                        goto err;
+                } else if (BIO_write(bpart, "\n", 1) < 1)
+                    goto err;
             }
             eol = next_eol;
-            if (len > 0)
-                BIO_write(bpart, linebuf, len);
+            if (len > 0 && BIO_write(bpart, linebuf, len) < len)
+                goto err;
         }
     }
+err:
     BIO_free(bpart);
     return 0;
 }


### PR DESCRIPTION
This is sort of #31033 backport for 3.5- but it's not actually leak fix because it's not leaking there but the error is ingored so it could technically produce incorrect parts if any of the operations fail. This should apply cleanly to 3.4 and 3.0 as well. 3.6 and master have different code that is already addressed.