### PR TITLE
fix: NULL pointer write in EVP_PKEY_CTX_get_rsa_padding/saltlen

### DIFF
--- a/crypto/evp/ctrl_params_translate.c
+++ b/crypto/evp/ctrl_params_translate.c
@@ -1277,6 +1277,11 @@ static int fix_rsa_padding_mode(enum state state,
          * of the rest for us, along with the POST_CTRL_TO_PARAMS && OSSL_ACTION_GET
          * code section further down.
          */
+        if (ctx->p2 == NULL) {
+            ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
+            return -1;
+        }
+
         ctx->orig_p2 = ctx->p2;
         ctx->p2 = ctx->name_buf;
         ctx->p1 = sizeof(ctx->name_buf);
@@ -1398,6 +1403,11 @@ static int fix_rsa_pss_saltlen(enum state state,
          * of the rest for us, along with the POST_CTRL_TO_PARAMS && OSSL_ACTION_GET
          * code section further down.
          */
+        if (ctx->p2 == NULL) {
+            ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
+            return -1;
+        }
+
         ctx->orig_p2 = ctx->p2;
         ctx->p2 = ctx->name_buf;
         ctx->p1 = sizeof(ctx->name_buf);


### PR DESCRIPTION
## Summary

Fixes #30911.

`EVP_PKEY_CTX_get_rsa_padding()` and `EVP_PKEY_CTX_get_rsa_pss_saltlen()` crash with SEGV when the output pointer argument is NULL. The ctrl-to-params translation layer caches the caller's `p2` into `ctx->orig_p2` without checking for NULL, then unconditionally writes through it in the POST phase (`*(int *)ctx->orig_p2 = ...`), causing a NULL pointer write.

## Data flow

The NULL propagates through four layers before crashing:

1. `EVP_PKEY_CTX_get_rsa_padding(ctx, NULL)` in `rsa_lib.c` passes `pad_mode=NULL` as `p2`
2. `RSA_pkey_ctx_ctrl()` → `EVP_PKEY_CTX_ctrl()` → `evp_pkey_ctx_ctrl_int()` → `evp_pkey_ctx_ctrl_to_param()` stores `ctx.p2 = p2` (NULL)
3. `fix_rsa_padding_mode()` PRE phase caches: `ctx->orig_p2 = ctx->p2` (NULL preserved)
4. POST phase writes: `*(int *)ctx->orig_p2 = str_value_map[i].id` → SEGV

Same path for `fix_rsa_pss_saltlen()`.

## Fix

The issue suggests two alternatives: (a) guard at the public wrapper in `rsa_lib.c`, or (b) guard at the POST-phase write site.

This patch guards at the **PRE phase** entry of both fixup functions, checking `ctx->p2 == NULL` before the pointer is cached into `orig_p2`. Reasons for this level:

1. **The bug is in the translation layer, not the wrapper.** The data-flow trace shows the contract violation is the unguarded `ctx->orig_p2 = ctx->p2` cache followed by an unconditional `*(int *)ctx->orig_p2 = ...` write. Fixing where the contract breaks is more precise than masking it upstream.

2. **The same `orig_p2` pattern exists in a third fixup function.** `fix_cipher_md()` (line 768/794) caches `ctx->orig_p2 = ctx->p2` and writes `*(void **)ctx->orig_p2 = ...` in its POST phase, which is the same vulnerability shape. A PRE-phase NULL guard is directly reusable there. A wrapper-level fix would not cover it.

3. **A wrapper-level fix would need guards in 5+ getters in `rsa_lib.c` alone** (`get_rsa_padding`, `get_rsa_oaep_md_name`, `get_rsa_mgf1_md_name`, `get0_rsa_oaep_label`, `get_rsa_pss_saltlen`) plus DH/EC getter wrappers that call `fix_cipher_md` through the same translation table. The translation table has 18 `EVP_PKEY_CTRL_GET_*` entries, and any getter that passes an output pointer through `p2` is exposed to the same crash.

The PRE-phase check also aborts before `p2` is repurposed to `name_buf` and the param conversion runs, so no translation work is wasted on a request that can never deliver a result.

## Verification

Tested in a clean container (`clang -fsanitize=address`, commit `11b7b6e` / tag `openssl-4.0.0`):

**Before patch**, ASan SEGV on NULL write:
```
Normal call (valid pointer): ret=5, padding=1
Calling EVP_PKEY_CTX_get_rsa_padding(ctx, NULL) ...
AddressSanitizer:DEADLYSIGNAL
=================================================================
==7659==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000
==7659==The signal is caused by a WRITE memory access.
==7659==Hint: address points to the zero page.
    #0 0x5594d7e6619b in fix_rsa_padding_mode ctrl_params_translate.c:1363:34
    #1 0x5594d7e602a8 in evp_pkey_ctx_ctrl_to_param ctrl_params_translate.c:2785:9
    #2 0x5594d7b58c39 in main harness.c:25:15
SUMMARY: AddressSanitizer: SEGV ctrl_params_translate.c:1363:34 in fix_rsa_padding_mode
==7659==ABORTING
pre_fix_exit=1
```

**Apply patch**, clean:
```
Checking patch crypto/evp/ctrl_params_translate.c...
Applied patch crypto/evp/ctrl_params_translate.c cleanly.
apply_exit=0
```

**Rebuild**, no errors:
```
rebuild_exit=0
```

**After patch**, both getters return `-1`, no crash:
```
Normal call (valid pointer): ret=5, padding=1
Calling EVP_PKEY_CTX_get_rsa_padding(ctx, NULL) ...
Returned -1 (should not reach here)
Calling EVP_PKEY_CTX_get_rsa_pss_saltlen(ctx, NULL) ...
Returned -1 (should not reach here)
post_fix_exit=0
```

No ASan output. Both functions now raise `ERR_R_PASSED_NULL_PARAMETER` and return `-1` instead of crashing.
