### PR TITLE
Add /MTd build for debug configuration for VC-noCE-common

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1566,7 +1566,7 @@ my %targets = (
         cflags           => add(picker(default => '/Gs0 /GF /Gy',
                                        debug   =>
                                        sub {
-                                           ($disabled{shared} ? "" : ($disabled{"static-vcruntime"} ? "/MDd" : ($disabled{threads} ? "" : "/MT")));
+                                           ($disabled{shared} ? "" : ($disabled{"static-vcruntime"} ? "/MDd" : ($disabled{threads} ? "" : "/MTd")));
                                        },
                                        release =>
                                        sub {


### PR DESCRIPTION
Currently, the /MT flag is set for debugging, although there seem to be no obvious workarounds or reasons to set it, which is why this PR is intended to add a debug CRT debug version.

Fixes #30936

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
