### PR TITLE
Fix unreachable nested preprocessor conditions

### DIFF
--- a/crypto/async/arch/async_posix.h
+++ b/crypto/async/arch/async_posix.h
@@ -49,11 +49,7 @@
  */
 #define USE_SWAPCONTEXT
 #endif
-#if defined(OPENSSL_SYS_TANDEM)
-#include <tdmsig.h>
-#else
 #include <ucontext.h>
-#endif
 #ifndef USE_SWAPCONTEXT
 #include <setjmp.h>
 #endif

--- a/crypto/bn/bn_nist.c
+++ b/crypto/bn/bn_nist.c
@@ -585,9 +585,6 @@ int BN_nist_mod_224(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
         rp[6] = (unsigned int)acc;
 
         carry = (int)(acc >> 32);
-#if BN_BITS2 == 64
-        rp[7] = carry;
-#endif
     }
 #else
     {

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -665,11 +665,7 @@ static int noecho_fgets(char *buf, int size, FILE *tty)
             break;
         }
         size--;
-#if defined(_WIN32)
-        i = _getch();
-#else
         i = getch();
-#endif
         if (i == '\r')
             i = '\n';
         *(p++) = i;


### PR DESCRIPTION
Fix three unreachable conditions:

- async_posix.h: remove unreachable defined OPENSSL_SYS_TANDEM (maybe it needs to add later in a proper place) 
- bn_nist.c: remove unreachable BN_BITS2 == 64
- ui_openssl.c: remove unreachable defined _WIN32

Trivial fixes analyzed with the help of Claude Code, but verified by me.

Fixes #31074