### PR TITLE
aes: make riscv64 no-Zkn fallback constant time

### DIFF
--- a/crypto/aes/build.info
+++ b/crypto/aes/build.info
@@ -131,7 +131,6 @@ GENERATE[aes-parisc.s]=asm/aes-parisc.pl
 GENERATE[aes-mips.S]=asm/aes-mips.pl
 INCLUDE[aes-mips.o]=..
 
-GENERATE[aes-riscv64.s]=asm/aes-riscv64.pl
 GENERATE[aes-riscv64-zkn.s]=asm/aes-riscv64-zkn.pl
 GENERATE[aes-riscv32-zkn.s]=asm/aes-riscv32-zkn.pl
 GENERATE[aes-riscv64-zvkb-zvkned.s]=asm/aes-riscv64-zvkb-zvkned.pl

--- a/crypto/aes/build.info
+++ b/crypto/aes/build.info
@@ -54,8 +54,10 @@ IF[{- !$disabled{asm} -}]
   # aes-c64xplus.s implements AES_ctr32_encrypt
   $AESDEF_c64xplus=AES_ASM AES_CTR_ASM
 
-  $AESASM_riscv64=aes_cbc.c aes-riscv64.s aes-riscv64-zkn.s aes-riscv64-zvkb-zvkned.s aes-riscv64-zvkned.s aes-riscv64-zvbb-zvkg-zvkned.s
-  $AESDEF_riscv64=AES_ASM
+  # Keep the RISC-V Zkn/Zvkned assembly fast paths, but route the generic
+  # low-level AES APIs through the constant-time C implementation.
+  $AESASM_riscv64=aes_core.c aes_cbc.c aes-riscv64-zkn.s aes-riscv64-zvkb-zvkned.s aes-riscv64-zvkned.s aes-riscv64-zvbb-zvkg-zvkned.s
+  $AESDEF_riscv64=OPENSSL_AES_CONST_TIME
   $AESASM_riscv32=aes_core.c aes_cbc.c aes-riscv32-zkn.s
 
   $AESASM_loongarch64=aes_core.c aes_cbc.c vpaes-loongarch64.S


### PR DESCRIPTION
## Related issue

Part of #20980.

## Summary

For riscv64 builds, stop binding the generic low-level `AES_*` APIs to the
table-based `aes-riscv64.s` fallback.

Keep the existing `rv64i_zkn*` and `rv64i_zvkned*` assembly fast paths, but
route the generic low-level AES implementation through the constant-time C path
by building riscv64 with `OPENSSL_AES_CONST_TIME` instead of `AES_ASM`.

## Problem

Without `Zkn` / `Zvkned`, provider dispatch falls back to generic low-level
`AES_set_*_key`, `AES_encrypt`, and `AES_decrypt`.

On riscv64, those low-level symbols were coming from the table-based
`aes-riscv64.s` fallback, so no-crypto-ISA systems did not get a constant-time
AES fallback.

## Change

- remove generic `aes-riscv64.s` from the riscv64 AES build
- enable `OPENSSL_AES_CONST_TIME` for riscv64
- keep `aes-riscv64-zkn.s`, `aes-riscv64-zvkned.s`,
  `aes-riscv64-zvkb-zvkned.s`, and `aes-riscv64-zvbb-zvkg-zvkned.s`

This leaves the capability-gated RISC-V fast paths intact while moving the
generic low-level AES fallback onto the constant-time C implementation.

## Validation

Built `linux64-riscv64` with:

- `CFLAGS="-g -O2 -march=rv64gc -mabi=lp64d"`
- `--cross-compile-prefix=riscv64-linux-gnu-`
- `no-shared no-tests`

Validated under `qemu-riscv64` on a no-`Zkn` target reporting:

```text
OPENSSL_riscvcap=RV64GC_ZBA_ZBB_ZBS_V vlen:128
```

Checks:

- `libcrypto-lib-aes-riscv64.o` is no longer built
- `libcrypto-lib-aes_core.o` now exports:
  - `AES_set_encrypt_key`
  - `AES_set_decrypt_key`
  - `AES_encrypt`
  - `AES_decrypt`
- `aes_core.o` no longer carries `Te/Td` table symbols or string references
- direct low-level AES-128/192/256 KAT passes via `AES_set_*_key`,
  `AES_encrypt`, and `AES_decrypt`

## Follow-up

This PR intentionally does not address the no-clmul / no-vector GHASH fallback.
That will be handled as a separate follow-up PR.
