### PR TITLE
apps/ocsp: preserve request serial in -rcid responses

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -1127,7 +1127,7 @@ static void make_ocsp_response(BIO *err, OCSP_RESPONSE **resp, OCSP_REQUEST *req
         one = OCSP_request_onereq_get0(req, i);
         cid = OCSP_onereq_get0_id(one);
 
-        OCSP_id_get0_info(NULL, &cert_id_md_oid, NULL, NULL, cid);
+        OCSP_id_get0_info(NULL, &cert_id_md_oid, NULL, &serial, cid);
 
         cert_id_md = EVP_MD_fetch(app_get0_libctx(), OBJ_nid2sn(OBJ_obj2nid(cert_id_md_oid)),
             app_get0_propq());
@@ -1149,13 +1149,22 @@ static void make_ocsp_response(BIO *err, OCSP_RESPONSE **resp, OCSP_REQUEST *req
 
             if (OCSP_id_issuer_cmp(ca_id, cid) == 0) {
                 found = 1;
-                if (resp_md != NULL)
-                    cid_resp_md = OCSP_cert_to_id(resp_md, NULL, ca_cert);
+                if (resp_md != NULL) {
+                    cid_resp_md = OCSP_cert_id_new(resp_md,
+                        X509_get_subject_name(ca_cert),
+                        X509_get0_pubkey_bitstr(ca_cert), serial);
+                    if (cid_resp_md == NULL) {
+                        *resp = OCSP_response_create(
+                            OCSP_RESPONSE_STATUS_INTERNALERROR, NULL);
+                        OCSP_CERTID_free(ca_id);
+                        EVP_MD_free(cert_id_md);
+                        goto end;
+                    }
+                }
             }
             OCSP_CERTID_free(ca_id);
         }
         EVP_MD_free(cert_id_md);
-        OCSP_id_get0_info(NULL, NULL, NULL, &serial, cid);
         inf = lookup_serial(db, serial);
 
         /* at this point, we can have cid be an alias of cid_resp_md */

--- a/test/recipes/80-test_ocsp.t
+++ b/test/recipes/80-test_ocsp.t
@@ -24,6 +24,7 @@ plan skip_all => "OCSP is not supported by this OpenSSL build"
     if disabled("ocsp");
 
 my $ocspdir=srctop_dir("test", "ocsp-tests");
+my $certsdir=srctop_dir("test", "certs");
 # 17 December 2012 so we don't get certificate expiry errors.
 my @check_time=("-attime", "1355875200");
 
@@ -54,7 +55,7 @@ sub test_ocsp {
                   $title); });
 }
 
-plan tests => 15;
+plan tests => 16;
 
 subtest "=== VALID OCSP RESPONSES ===" => sub {
     plan tests => 7;
@@ -244,6 +245,45 @@ subtest "=== UNTRUSTED ISSUER HINTS ===" => sub {
     test_ocsp("NON-DELEGATED; invalid issuer via -issuer",
               "ND1.ors", "ND1_Cross_Root.pem",
               "ISIC_ND1_Issuer_ICA.pem", 1, 0, "-issuer");
+};
+
+subtest "=== OCSP response -rcid preserves serial ===" => sub {
+    plan tests => 4;
+
+    my $serial = "73C8A0894488809AFE972FE0BAD3460318D1CCBF";
+    my $respout = "rcid-sha256.der";
+    my $ca = catfile($certsdir, "ca-cert.pem");
+    my @response = run(app(["openssl", "ocsp",
+                            "-index", catfile($ocspdir, "index.txt"),
+                            "-rsigner", $ca,
+                            "-rkey", catfile($certsdir, "ca-key.pem"),
+                            "-CA", $ca,
+                            "-sha256",
+                            "-issuer", $ca,
+                            "-serial", "0x$serial",
+                            "-no_nonce",
+                            "-rcid", "sha256",
+                            "-resp_text",
+                            "-respout", $respout]),
+                       capture => 1, statusvar => \my $created);
+
+    ok($created, "created OCSP response with -rcid");
+    ok(grep(/Hash Algorithm: sha256/, @response),
+       "response CertID uses requested digest");
+    ok(grep(/Serial Number: $serial/, @response),
+       "response CertID serial preserves request serial, not 0x00");
+
+    my @status = run(app(["openssl", "ocsp",
+                          "-sha256",
+                          "-issuer", $ca,
+                          "-serial", "0x$serial",
+                          "-no_nonce",
+                          "-respin", $respout,
+                          "-noverify"]),
+                     capture => 1, statusvar => \my $matched);
+
+    ok($matched && grep(/^0x$serial: good/, @status),
+       "client finds status from -rcid response");
 };
 
 subtest "=== OCSP handling of identical input and output files ===" => sub {


### PR DESCRIPTION
Fix `openssl ocsp -rcid` response generation so the response `CertID` preserves the serial number from the request.

When `-rcid` is used, the OCSP responder rebuilds the response `CertID` with the requested digest. The previous code used `OCSP_cert_to_id` without a subject certificate, which caused the generated response `CertID` to contain serial `00` instead of the requested certificate serial.

This change extracts the serial from the request `CertID` and builds the response `CertID` with the responder selected digest, the issuer name/key data and the original request serial.

This uses existing public OCSP/X509 APIs, including `OCSP_cert_id_new` and should be straightforward to backport to 3.x branches.

A regression test was added to verify that an `-rcid sha256` response:

- uses the requested digest in the response `CertID`
- preserves the request serial number
- can be consumed by the OCSP client when matching the original request

Fixes #31070

Tested:

- Windows:
```
  nmake
  perl -I.\util\perl .\test\recipes\80-test_ocsp.t
```
- Linux Ubuntu 24.04:
```
perl Configure linux-x86_64 no-fips no-shared --banner=Configured
make -s -j$(nproc)
make test TESTS=test_ocsp
```

##### Checklist
- [x] tests are added or updated
