### PR TITLE
modes: make riscv64 no-clmul GHASH fallback constant time

### DIFF
--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -157,6 +157,95 @@ static void gcm_init_4bit(u128 Htable[16], const uint64_t H[2])
 #endif
 }
 
+#if defined(__riscv) && __riscv_xlen == 64
+/*
+ * For riscv64 systems without scalar or vector carryless multiply support,
+ * prefer a 1-bit GHASH fallback over the 4-bit table-based fallback.
+ */
+static void gcm_init_1bit(u128 Htable[16], const u64 H[2])
+{
+    memset(Htable, 0, sizeof(*Htable) * 16);
+    Htable[0].hi = H[0];
+    Htable[0].lo = H[1];
+}
+
+static void gcm_gmult_1bit(u64 Xi[2], const u128 Htable[16])
+{
+    u128 V, Z = { 0, 0 };
+    long X;
+    int i, j;
+    const long *xi = (const long *)Xi;
+    DECLARE_IS_ENDIAN;
+
+    /* H is stored in host byte order, no byte swapping */
+    V.hi = Htable[0].hi;
+    V.lo = Htable[0].lo;
+
+    for (j = 0; j < 16 / sizeof(long); ++j) {
+        if (IS_LITTLE_ENDIAN) {
+            if (sizeof(long) == 8) {
+#ifdef BSWAP8
+                X = (long)(BSWAP8(xi[j]));
+#else
+                const u8 *p = (const u8 *)(xi + j);
+                X = (long)((u64)GETU32(p) << 32 | GETU32(p + 4));
+#endif
+            } else {
+                const u8 *p = (const u8 *)(xi + j);
+                X = (long)GETU32(p);
+            }
+        } else {
+            X = xi[j];
+        }
+
+        for (i = 0; i < 8 * sizeof(long); ++i, X <<= 1) {
+            u64 M = (u64)(X >> (8 * sizeof(long) - 1));
+            Z.hi ^= V.hi & M;
+            Z.lo ^= V.lo & M;
+
+            REDUCE1BIT(V);
+        }
+    }
+
+    if (IS_LITTLE_ENDIAN) {
+#ifdef BSWAP8
+        Xi[0] = BSWAP8(Z.hi);
+        Xi[1] = BSWAP8(Z.lo);
+#else
+        u8 *p = (u8 *)Xi;
+        u32 v;
+        v = (u32)(Z.hi >> 32);
+        PUTU32(p, v);
+        v = (u32)(Z.hi);
+        PUTU32(p + 4, v);
+        v = (u32)(Z.lo >> 32);
+        PUTU32(p + 8, v);
+        v = (u32)(Z.lo);
+        PUTU32(p + 12, v);
+#endif
+    } else {
+        Xi[0] = Z.hi;
+        Xi[1] = Z.lo;
+    }
+}
+
+static void gcm_ghash_1bit(u64 Xi[2], const u128 Htable[16],
+    const u8 *inp, size_t len)
+{
+    u64 tmp[2];
+
+    while (len > 0) {
+        memcpy(tmp, inp, sizeof(tmp));
+        Xi[0] ^= tmp[0];
+        Xi[1] ^= tmp[1];
+        gcm_gmult_1bit(Xi, Htable);
+
+        inp += 16;
+        len -= 16;
+    }
+}
+#endif
+
 #if !defined(GHASH_ASM) || defined(INCLUDE_C_GMULT_4BIT)
 static const size_t rem_4bit[16] = {
     PACK(0x0000), PACK(0x1C20), PACK(0x3840), PACK(0x2460),
@@ -428,6 +517,15 @@ void gcm_ghash_rv64i_zvkg(uint64_t Xi[2], const u128 Htable[16],
 static void gcm_get_funcs(struct gcm_funcs_st *ctx)
 {
     /* set defaults -- overridden below as needed */
+#if defined(__riscv) && __riscv_xlen == 64
+    ctx->ginit = gcm_init_1bit;
+    ctx->gmult = gcm_gmult_1bit;
+#if !defined(OPENSSL_SMALL_FOOTPRINT)
+    ctx->ghash = gcm_ghash_1bit;
+#else
+    ctx->ghash = NULL;
+#endif
+#else
     ctx->ginit = gcm_init_4bit;
 #if !defined(GHASH_ASM)
     ctx->gmult = gcm_gmult_4bit;
@@ -438,6 +536,7 @@ static void gcm_get_funcs(struct gcm_funcs_st *ctx)
     ctx->ghash = gcm_ghash_4bit;
 #else
     ctx->ghash = NULL;
+#endif
 #endif
 
 #if defined(GHASH_ASM_X86_OR_64)
@@ -521,10 +620,6 @@ static void gcm_get_funcs(struct gcm_funcs_st *ctx)
     }
     return;
 #elif defined(GHASH_ASM_RV64I)
-    /* RISCV defaults */
-    ctx->gmult = gcm_gmult_4bit;
-    ctx->ghash = gcm_ghash_4bit;
-
     if (RISCV_HAS_ZVKG() && riscv_vlen() >= 128) {
         if (RISCV_HAS_ZVKB())
             ctx->ginit = gcm_init_rv64i_zvkg_zvkb;

--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -85,6 +85,7 @@ typedef size_t size_t_aX;
  * Value of 1 is not appropriate for performance reasons.
  */
 
+#if !(defined(__riscv) && __riscv_xlen == 64)
 static void gcm_init_4bit(u128 Htable[16], const uint64_t H[2])
 {
     u128 V;
@@ -156,6 +157,7 @@ static void gcm_init_4bit(u128 Htable[16], const uint64_t H[2])
     }
 #endif
 }
+#endif
 
 #if defined(__riscv) && __riscv_xlen == 64
 /*
@@ -173,7 +175,7 @@ static void gcm_gmult_1bit(u64 Xi[2], const u128 Htable[16])
 {
     u128 V, Z = { 0, 0 };
     long X;
-    int i, j;
+    size_t i, j;
     const long *xi = (const long *)Xi;
     DECLARE_IS_ENDIAN;
 
@@ -246,7 +248,8 @@ static void gcm_ghash_1bit(u64 Xi[2], const u128 Htable[16],
 }
 #endif
 
-#if !defined(GHASH_ASM) || defined(INCLUDE_C_GMULT_4BIT)
+#if !defined(GHASH_ASM) || (defined(INCLUDE_C_GMULT_4BIT) \
+    && !(defined(__riscv) && __riscv_xlen == 64))
 static const size_t rem_4bit[16] = {
     PACK(0x0000), PACK(0x1C20), PACK(0x3840), PACK(0x2460),
     PACK(0x7080), PACK(0x6CA0), PACK(0x48C0), PACK(0x54E0),
@@ -323,7 +326,8 @@ static void gcm_gmult_4bit(uint64_t Xi[2], const u128 Htable[16])
 
 #endif
 
-#if !defined(GHASH_ASM) || defined(INCLUDE_C_GHASH_4BIT)
+#if !defined(GHASH_ASM) || (defined(INCLUDE_C_GHASH_4BIT) \
+    && !(defined(__riscv) && __riscv_xlen == 64))
 #if !defined(OPENSSL_SMALL_FOOTPRINT)
 /*
  * Streamed gcm_mult_4bit, see CRYPTO_gcm128_[en|de]crypt for

--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -164,14 +164,14 @@ static void gcm_init_4bit(u128 Htable[16], const uint64_t H[2])
  * For riscv64 systems without scalar or vector carryless multiply support,
  * prefer a 1-bit GHASH fallback over the 4-bit table-based fallback.
  */
-static void gcm_init_1bit(u128 Htable[16], const u64 H[2])
+static void gcm_init_1bit(u128 Htable[16], const uint64_t H[2])
 {
     memset(Htable, 0, sizeof(*Htable) * 16);
     Htable[0].hi = H[0];
     Htable[0].lo = H[1];
 }
 
-static void gcm_gmult_1bit(u64 Xi[2], const u128 Htable[16])
+static void gcm_gmult_1bit(uint64_t Xi[2], const u128 Htable[16])
 {
     u128 V, Z = { 0, 0 };
     long X;
@@ -189,11 +189,11 @@ static void gcm_gmult_1bit(u64 Xi[2], const u128 Htable[16])
 #ifdef BSWAP8
                 X = (long)(BSWAP8(xi[j]));
 #else
-                const u8 *p = (const u8 *)(xi + j);
-                X = (long)((u64)GETU32(p) << 32 | GETU32(p + 4));
+                const uint8_t *p = (const uint8_t *)(xi + j);
+                X = (long)((uint64_t)GETU32(p) << 32 | GETU32(p + 4));
 #endif
             } else {
-                const u8 *p = (const u8 *)(xi + j);
+                const uint8_t *p = (const uint8_t *)(xi + j);
                 X = (long)GETU32(p);
             }
         } else {
@@ -201,7 +201,7 @@ static void gcm_gmult_1bit(u64 Xi[2], const u128 Htable[16])
         }
 
         for (i = 0; i < 8 * sizeof(long); ++i, X <<= 1) {
-            u64 M = (u64)(X >> (8 * sizeof(long) - 1));
+            uint64_t M = (uint64_t)(X >> (8 * sizeof(long) - 1));
             Z.hi ^= V.hi & M;
             Z.lo ^= V.lo & M;
 
@@ -214,15 +214,15 @@ static void gcm_gmult_1bit(u64 Xi[2], const u128 Htable[16])
         Xi[0] = BSWAP8(Z.hi);
         Xi[1] = BSWAP8(Z.lo);
 #else
-        u8 *p = (u8 *)Xi;
-        u32 v;
-        v = (u32)(Z.hi >> 32);
+        uint8_t *p = (uint8_t *)Xi;
+        uint32_t v;
+        v = (uint32_t)(Z.hi >> 32);
         PUTU32(p, v);
-        v = (u32)(Z.hi);
+        v = (uint32_t)(Z.hi);
         PUTU32(p + 4, v);
-        v = (u32)(Z.lo >> 32);
+        v = (uint32_t)(Z.lo >> 32);
         PUTU32(p + 8, v);
-        v = (u32)(Z.lo);
+        v = (uint32_t)(Z.lo);
         PUTU32(p + 12, v);
 #endif
     } else {
@@ -231,10 +231,10 @@ static void gcm_gmult_1bit(u64 Xi[2], const u128 Htable[16])
     }
 }
 
-static void gcm_ghash_1bit(u64 Xi[2], const u128 Htable[16],
-    const u8 *inp, size_t len)
+static void gcm_ghash_1bit(uint64_t Xi[2], const u128 Htable[16],
+    const uint8_t *inp, size_t len)
 {
-    u64 tmp[2];
+    uint64_t tmp[2];
 
     while (len > 0) {
         memcpy(tmp, inp, sizeof(tmp));

--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -248,7 +248,7 @@ static void gcm_ghash_1bit(uint64_t Xi[2], const u128 Htable[16],
 }
 #endif
 
-#if !defined(GHASH_ASM) || (defined(INCLUDE_C_GMULT_4BIT) \
+#if (!defined(GHASH_ASM) || defined(INCLUDE_C_GMULT_4BIT)) \
     && !(defined(__riscv) && __riscv_xlen == 64))
 static const size_t rem_4bit[16] = {
     PACK(0x0000), PACK(0x1C20), PACK(0x3840), PACK(0x2460),

--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -174,9 +174,9 @@ static void gcm_init_1bit(u128 Htable[16], const uint64_t H[2])
 static void gcm_gmult_1bit(uint64_t Xi[2], const u128 Htable[16])
 {
     u128 V, Z = { 0, 0 };
-    long X;
+    uint64_t X;
     size_t i, j;
-    const long *xi = (const long *)Xi;
+    const unsigned long *xi = (const unsigned long *)Xi;
     DECLARE_IS_ENDIAN;
 
     /* H is stored in host byte order, no byte swapping */
@@ -187,21 +187,21 @@ static void gcm_gmult_1bit(uint64_t Xi[2], const u128 Htable[16])
         if (IS_LITTLE_ENDIAN) {
             if (sizeof(long) == 8) {
 #ifdef BSWAP8
-                X = (long)(BSWAP8(xi[j]));
+                X = BSWAP8((uint64_t)xi[j]);
 #else
                 const uint8_t *p = (const uint8_t *)(xi + j);
-                X = (long)((uint64_t)GETU32(p) << 32 | GETU32(p + 4));
+                X = (uint64_t)GETU32(p) << 32 | GETU32(p + 4);
 #endif
             } else {
                 const uint8_t *p = (const uint8_t *)(xi + j);
-                X = (long)GETU32(p);
+                X = GETU32(p);
             }
         } else {
             X = xi[j];
         }
 
         for (i = 0; i < 8 * sizeof(long); ++i, X <<= 1) {
-            uint64_t M = (uint64_t)(X >> (8 * sizeof(long) - 1));
+            uint64_t M = 0 - (X >> (8 * sizeof(long) - 1));
             Z.hi ^= V.hi & M;
             Z.lo ^= V.lo & M;
 
@@ -249,7 +249,7 @@ static void gcm_ghash_1bit(uint64_t Xi[2], const u128 Htable[16],
 #endif
 
 #if (!defined(GHASH_ASM) || defined(INCLUDE_C_GMULT_4BIT)) \
-    && !(defined(__riscv) && __riscv_xlen == 64))
+    && !(defined(__riscv) && __riscv_xlen == 64)
 static const size_t rem_4bit[16] = {
     PACK(0x0000), PACK(0x1C20), PACK(0x3840), PACK(0x2460),
     PACK(0x7080), PACK(0x6CA0), PACK(0x48C0), PACK(0x54E0),
@@ -326,8 +326,8 @@ static void gcm_gmult_4bit(uint64_t Xi[2], const u128 Htable[16])
 
 #endif
 
-#if !defined(GHASH_ASM) || (defined(INCLUDE_C_GHASH_4BIT) \
-    && !(defined(__riscv) && __riscv_xlen == 64))
+#if (!defined(GHASH_ASM) || defined(INCLUDE_C_GHASH_4BIT)) \
+    && !(defined(__riscv) && __riscv_xlen == 64)
 #if !defined(OPENSSL_SMALL_FOOTPRINT)
 /*
  * Streamed gcm_mult_4bit, see CRYPTO_gcm128_[en|de]crypt for
@@ -524,11 +524,7 @@ static void gcm_get_funcs(struct gcm_funcs_st *ctx)
 #if defined(__riscv) && __riscv_xlen == 64
     ctx->ginit = gcm_init_1bit;
     ctx->gmult = gcm_gmult_1bit;
-#if !defined(OPENSSL_SMALL_FOOTPRINT)
     ctx->ghash = gcm_ghash_1bit;
-#else
-    ctx->ghash = NULL;
-#endif
 #else
     ctx->ginit = gcm_init_4bit;
 #if !defined(GHASH_ASM)


### PR DESCRIPTION
## Summary

For riscv64 builds, use a 1-bit GHASH fallback when neither scalar nor vector
carryless multiply support is available.

Keep the existing `ZBC`, `Zvbc`, and `Zvkg` accelerated paths unchanged.

## Problem

On riscv64, current master has capability-gated GHASH fast paths for:

- `ZBC`
- `Zvbc`
- `Zvkg`

But when those extensions are unavailable, the fallback still defaults to the
generic 4-bit table-based GHASH path.

That leaves the no-clmul / no-vector fallback non-constant-time on riscv64.

## Change

- add riscv64-only 1-bit GHASH helpers in `crypto/modes/gcm128.c`
- make riscv64 defaults use the 1-bit fallback
- preserve existing runtime selection for `Zvkg`, `Zvbc`, and `ZBC`
- preserve `OPENSSL_SMALL_FOOTPRINT`'s compact state layout while providing a
  non-NULL 1-bit GHASH callback

This keeps the accelerated implementations intact while moving the generic
riscv64 no-clmul fallback onto a constant-time GHASH implementation.

## Validation

Built `linux64-riscv64` with:

- `CFLAGS="-g -O2 -march=rv64gc -mabi=lp64d"`
- `--cross-compile-prefix=riscv64-linux-gnu-`
- `no-shared no-tests`

Validated under `qemu-riscv64` on a no-`ZBC` / no-`Zvbc` / no-`Zvkg` target
reporting:

```text
OPENSSL_riscvcap=RV64GC_ZBA_ZBB_ZBS_V vlen:128
```

Checks:

- `gcm128.o` contains `gcm_gmult_1bit`
- `gcm128.o` contains `gcm_ghash_1bit`
- direct GHASH / AES-GCM known-answer test passes under `qemu-riscv64`

## Scope

This PR is the GHASH half of the fix for #20980.

The AES half was split into #31080.

## Review follow-up (2026-09-05)

- fixed the RV64 exclusion grouping for both 4-bit helpers
- assigned `gcm_ghash_1bit` for RV64 small-footprint builds so complete AAD
  blocks do not call through a NULL function pointer
- changed the 1-bit multiply loop to unsigned arithmetic
- `no-asm --strict-warnings` RV64GC build passes
- the small-footprint `gcm128.o` target passes `--strict-warnings`
- the 20-vector `modes_internal_test` passes under QEMU with `OPENSSL_riscvcap=RV64GC`

No physical RV64 system was available in this environment, so no QEMU result
is presented as a substitute for real-hardware throughput data.

Follow-up local verification on 2026-05-28: commit `db6e0a2` fixes the riscv64
warning failures and passes `./config --strict-warnings enable-lms
--cross-compile-prefix=riscv64-linux-gnu- linux64-riscv64 && make -s -j4` from a
clean tree.

## Review follow-up (latest)

- The reviewer-requested real-hardware RV64 throughput benchmark remains
  pending and is a maintainer-side merge gate; QEMU results are functional/KAT
  evidence only.
- The `OPENSSL_AES_CONST_TIME` / `no-asm` observation belongs to #31080. This
  PR changes only GHASH and does not claim combined AES+GHASH `no-asm`
  constant-time behavior.
