### PR TITLE
[4.0] Address `allocfail` test failures

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -19,6 +19,8 @@ on:
       extra_config:
         description: Extra options for configuration script
         default: ""
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
 
 permissions:
   contents: read
@@ -46,28 +48,7 @@ jobs:
           else
           MATRIX=$(cat << EOF
           [{
-              "branch": "openssl-3.6",
-              "extra_config": "no-afalgeng enable-fips enable-tfo"
-            },{
-              "branch": "openssl-3.5",
-              "extra_config": "no-afalgeng enable-fips enable-tfo"
-            },{
-              "branch": "openssl-3.4",
-              "extra_config": "no-afalgeng enable-fips enable-tfo"
-            }, {
-              "branch": "openssl-3.3",
-              "extra_config": "no-afalgeng enable-fips enable-tfo"
-            }, {
-              "branch": "openssl-3.2",
-              "extra_config": "no-afalgeng enable-fips enable-tfo"
-            }, {
-              "branch": "openssl-3.1",
-              "extra_config": "no-afalgeng enable-fips"
-            }, {
-              "branch": "openssl-3.0",
-              "extra_config": "no-afalgeng enable-fips"
-            }, {
-              "branch": "master",
+              "branch": "openssl-4.0",
               "extra_config": "enable-fips enable-tfo enable-lms enable-crypto-mdebug enable-allocfail-tests"
           }]
           EOF
@@ -90,7 +71,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         submodules: recursive
-        ref: ${{ matrix.branches.branch }}
+        ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
     - name: cache commit id
       run: |

--- a/test/handshake-memfail.c
+++ b/test/handshake-memfail.c
@@ -29,10 +29,11 @@
  * - rcount:   Number of reallocs counted
  * - fcount:   Number of frees counted
  * - scount:   Number of mallocs counted prior to workload
+ * - srcount:  Number of reallocs counted prior to workload
  */
 static char *cert = NULL;
 static char *privkey = NULL;
-static int mcount, rcount, fcount, scount;
+static int mcount, rcount, fcount, scount, srcount;
 
 /**
  * @brief Performs an SSL/TLS handshake between a test client and server.
@@ -135,15 +136,16 @@ static int test_report_alloc_counts(void)
     CRYPTO_get_alloc_counts(&mcount, &rcount, &fcount);
     /*
      * Report our memory allocations from the count run
-     * NOTE: We report a number of allocations to skip here
-     * (the scount value).  These are the allocations that took
-     * place while the test harness itself was getting setup
-     * (i.e. calling OPENSSL_init_crypto/etc).  We can't fail
+     * NOTE: We report a number of (re)allocations to skip here
+     * (the scount + srcount value).  These are the allocations
+     * that took place while the test harness itself was getting
+     * setup (i.e. calling OPENSSL_init_crypto/etc).  We can't fail
      * those allocations as they will cause the test to fail before
      * we have even run the workload.  So report them so we can
      * allow them to function before we start doing any real testing
      */
-    TEST_info("skip: %d count %d\n", scount, mcount - scount);
+    TEST_info("skip: %d count %d\n",
+        scount + srcount, mcount + rcount - scount - srcount);
     return 1;
 }
 
@@ -167,7 +169,7 @@ int setup_tests(void)
         goto err;
 
     if (strcmp(opmode, "count") == 0) {
-        CRYPTO_get_alloc_counts(&scount, &rcount, &fcount);
+        CRYPTO_get_alloc_counts(&scount, &srcount, &fcount);
         ADD_TEST(test_record_alloc_counts);
         ADD_TEST(test_report_alloc_counts);
     } else {

--- a/test/load_key_certs_crls_memfail.c
+++ b/test/load_key_certs_crls_memfail.c
@@ -24,7 +24,7 @@
 char *default_config_file = NULL;
 
 static char *certfile = NULL;
-static int mcount, rcount, fcount, scount;
+static int mcount, rcount, fcount, scount, srcount;
 
 static int do_load_key_certs_crls(int allow_failure)
 {
@@ -60,7 +60,8 @@ static int test_alloc_failures(void)
 static int test_report_alloc_counts(void)
 {
     CRYPTO_get_alloc_counts(&mcount, &rcount, &fcount);
-    TEST_info("skip: %d count %d\n", scount, mcount - scount);
+    TEST_info("skip: %d count %d\n",
+        scount + srcount, mcount + rcount - scount - srcount);
     return 1;
 }
 
@@ -79,7 +80,7 @@ int setup_tests(void)
         goto err;
 
     if (strcmp(opmode, "count") == 0) {
-        CRYPTO_get_alloc_counts(&scount, &rcount, &fcount);
+        CRYPTO_get_alloc_counts(&scount, &srcount, &fcount);
         ADD_TEST(test_record_alloc_counts);
         ADD_TEST(test_report_alloc_counts);
     } else {

--- a/test/recipes/90-test_memfail.t
+++ b/test/recipes/90-test_memfail.t
@@ -83,7 +83,8 @@ sub run_memfail_test {
         # passing
         #
         $ENV{OPENSSL_MALLOC_FAILURES} = "$skipcount\@0;$idx\@0;1\@100;0\@0";
-        ok(run(test(@cmd)));
+        ok(run(test(@cmd))) || \
+            print STDERR "# OPENSSL_MALLOC_FAILURES=$ENV{OPENSSL_MALLOC_FAILURES}\n";
     }
 }
 

--- a/test/recipes/90-test_memfail.t
+++ b/test/recipes/90-test_memfail.t
@@ -70,7 +70,7 @@ plan tests => $total_malloccount;
 
 sub run_memfail_test {
     my $skipcount = $_[0];
-    my @mallocseq = (1..$_[1]);
+    my @mallocseq = (0..$_[1] - 1);
     my @cmd = $_[2];
 
     for my $idx (@mallocseq) {

--- a/test/x509_memfail.c
+++ b/test/x509_memfail.c
@@ -21,7 +21,7 @@
 #include "testutil.h"
 
 static char *certfile = NULL;
-static int mcount, rcount, fcount, scount;
+static int mcount, rcount, fcount, scount, srcount;
 
 static int do_x509(int allow_failure)
 {
@@ -91,15 +91,16 @@ static int test_report_alloc_counts(void)
     CRYPTO_get_alloc_counts(&mcount, &rcount, &fcount);
     /*
      * Report our memory allocations from the count run
-     * NOTE: We report a number of allocations to skip here
-     * (the scount value).  These are the allocations that took
-     * place while the test harness itself was getting setup
-     * (i.e. calling OPENSSL_init_crypto/etc).  We can't fail
+     * NOTE: We report a number of (re)allocations to skip here
+     * (the scount + srcount value).  These are the allocations
+     * that took place while the test harness itself was getting
+     * setup (i.e. calling OPENSSL_init_crypto/etc).  We can't fail
      * those allocations as they will cause the test to fail before
      * we have even run the workload.  So report them so we can
      * allow them to function before we start doing any real testing
      */
-    TEST_info("skip: %d count %d\n", scount, mcount - scount);
+    TEST_info("skip: %d count %d\n",
+        scount + srcount, mcount + rcount - scount - srcount);
     return 1;
 }
 
@@ -115,7 +116,7 @@ int setup_tests(void)
         goto err;
 
     if (strcmp(opmode, "count") == 0) {
-        CRYPTO_get_alloc_counts(&scount, &rcount, &fcount);
+        CRYPTO_get_alloc_counts(&scount, &srcount, &fcount);
         ADD_TEST(test_record_alloc_counts);
         ADD_TEST(test_report_alloc_counts);
     } else {


### PR DESCRIPTION
This is a partial backport of [1] that includes `realloc` count in the `allocfail` skip count and fixes off-by-one error in the skip loop.

It also includes a commit that enables coverage CI for PRs (that is supposed to be dropped when the patch set is applied), in order to verify efficacy of the fixes.

[1] https://github.com/openssl/openssl/pull/30991