### PR TITLE
unix-makefile: make cleanup faster

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,11 @@
 repos:
+  - repo: "local"
+    hooks:
+      - id: "no-whitespace-in-filenames"
+        name: "Reject filenames containing whitespace"
+        entry: "filenames must not contain whitespace"
+        language: "fail"
+        files: '\s'
   - repo: "https://github.com/codespell-project/codespell"
     rev: "v2.4.1"
     hooks:

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -640,8 +640,8 @@ clean: libclean ## Clean the workspace, keep the configuration
 	$(RM) $(MANDOCS7)
 	$(RM) $(PROGRAMS) $(TESTPROGS) $(MODULES) $(FIPSMODULE) $(SCRIPTS)
 	$(RM) $(GENERATED_MANDATORY) $(GENERATED)
-	-find . -name '*{- platform->depext() -}' \! -name '.*' \! -type d -exec $(RM) {} \;
-	-find . -name '*{- platform->objext() -}' \! -name '.*' \! -type d -exec $(RM) {} \;
+	-find . \( -name '*{- platform->depext() -}' -o -name '*{- platform->objext() -}' \) \
+		\! -name '.*' \! -type d | xargs $(RM);
 	$(RM) core
 	$(RM) tags TAGS doc-nits md-nits
 	$(RM) -r $(RESULT_D)


### PR DESCRIPTION
walk the source tree once instead of twice when removing generated *.d and *.o files.
