### PR TITLE
ossl_rcu_call skips cb call on failed allocation

### DIFF
--- a/crypto/hashtable/hashtable.c
+++ b/crypto/hashtable/hashtable.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2024-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -311,6 +311,7 @@ static int ossl_ht_flush_internal(HT *h)
 {
     struct ht_mutable_data_st *newmd = NULL;
     struct ht_mutable_data_st *oldmd = NULL;
+    CRYPTO_RCU_CB_ITEM *cbi = NULL;
 
     newmd = OPENSSL_zalloc(sizeof(*newmd));
     if (newmd == NULL)
@@ -325,8 +326,15 @@ static int ossl_ht_flush_internal(HT *h)
 
     newmd->neighborhood_mask = DEFAULT_NEIGH_LEN - 1;
 
-    /* Swap the old and new mutable data sets */
     if (!h->config.no_rcu) {
+        cbi = ossl_rcu_cb_item_new();
+        if (cbi == NULL) {
+            OPENSSL_free(newmd->neighborhood_ptr_to_free);
+            OPENSSL_free(newmd);
+            return 0;
+        }
+
+        /* Swap the old and new mutable data sets */
         oldmd = ossl_rcu_deref(&h->md);
         ossl_rcu_assign_ptr(&h->md, &newmd);
     } else {
@@ -339,11 +347,11 @@ static int ossl_ht_flush_internal(HT *h)
     h->wpd.neighborhood_len = DEFAULT_NEIGH_LEN;
 
     if (!h->config.no_rcu) {
-        ossl_rcu_call(h->lock, free_oldmd, oldmd);
+        ossl_rcu_call(h->lock, cbi, free_oldmd, oldmd);
+        h->wpd.need_sync = 1;
     } else {
         free_oldmd(oldmd);
     }
-    h->wpd.need_sync = 1;
 
     return 1;
 }
@@ -461,6 +469,7 @@ static int grow_hashtable(HT *h, size_t oldsize)
 {
     struct ht_mutable_data_st *newmd;
     struct ht_mutable_data_st *oldmd = ossl_rcu_deref(&h->md);
+    CRYPTO_RCU_CB_ITEM *cbi = NULL;
     int rc = 0;
     uint64_t oldi, oldj, newi, newj;
     uint64_t oldhash;
@@ -513,6 +522,16 @@ static int grow_hashtable(HT *h, size_t oldsize)
             }
         }
     }
+
+    /*
+     * Pre allocate the rcu callback item before assigning the newmd.
+     */
+    if (!h->config.no_rcu) {
+        cbi = ossl_rcu_cb_item_new();
+        if (cbi == NULL)
+            goto out_free;
+    }
+
     /*
      * Now that our entries are all hashed into the new bucket list
      * update our bucket_len and target_max_load
@@ -524,7 +543,7 @@ static int grow_hashtable(HT *h, size_t oldsize)
      */
     if (!h->config.no_rcu) {
         ossl_rcu_assign_ptr(&h->md, &newmd);
-        ossl_rcu_call(h->lock, free_old_neigh_table, oldmd);
+        ossl_rcu_call(h->lock, cbi, free_old_neigh_table, oldmd);
         h->wpd.need_sync = 1;
     } else {
         h->md = newmd;
@@ -612,13 +631,18 @@ static int ossl_ht_insert_locked(HT *h, uint64_t hash,
                 }
                 /* Do a replacement */
                 if (!h->config.no_rcu) {
-                    if (!CRYPTO_atomic_store(&md->neighborhoods[neigh_idx].entries[j].hash,
-                            hash, h->atomic_lock))
+                    CRYPTO_RCU_CB_ITEM *cbi = ossl_rcu_cb_item_new();
+                    if (cbi == NULL)
                         return 0;
+                    if (!CRYPTO_atomic_store(&md->neighborhoods[neigh_idx].entries[j].hash,
+                            hash, h->atomic_lock)) {
+                        ossl_rcu_cb_item_free(cbi);
+                        return 0;
+                    }
                     *olddata = (HT_VALUE *)md->neighborhoods[neigh_idx].entries[j].value;
                     ossl_rcu_assign_ptr(&md->neighborhoods[neigh_idx].entries[j].value,
                         &newval);
-                    ossl_rcu_call(h->lock, free_old_ht_value, *olddata);
+                    ossl_rcu_call(h->lock, cbi, free_old_ht_value, *olddata);
                 } else {
                     md->neighborhoods[neigh_idx].entries[j].hash = hash;
                     *olddata = (HT_VALUE *)md->neighborhoods[neigh_idx].entries[j].value;
@@ -812,25 +836,26 @@ int ossl_ht_delete(HT *h, HT_KEY *key)
         if (compare_hash(hash, h->md->neighborhoods[neigh_idx].entries[j].hash)
             && match_key(key, &v->value.key)) {
             if (!h->config.no_rcu) {
-                if (!CRYPTO_atomic_store(&h->md->neighborhoods[neigh_idx].entries[j].hash,
-                        0, h->atomic_lock))
+                CRYPTO_RCU_CB_ITEM *cbi = ossl_rcu_cb_item_new();
+                if (cbi == NULL)
                     break;
+                if (!CRYPTO_atomic_store(&h->md->neighborhoods[neigh_idx].entries[j].hash,
+                        0, h->atomic_lock)) {
+                    ossl_rcu_cb_item_free(cbi);
+                    break;
+                }
                 ossl_rcu_assign_ptr(&h->md->neighborhoods[neigh_idx].entries[j].value, &nv);
+                ossl_rcu_call(h->lock, cbi, free_old_entry, v);
             } else {
                 h->md->neighborhoods[neigh_idx].entries[j].hash = 0;
                 h->md->neighborhoods[neigh_idx].entries[j].value = NULL;
+                free_old_entry(v);
             }
             h->wpd.value_count--;
+            h->wpd.need_sync = 1;
             rc = 1;
             break;
         }
-    }
-    if (rc == 1) {
-        if (!h->config.no_rcu)
-            ossl_rcu_call(h->lock, free_old_entry, v);
-        else
-            free_old_entry(v);
-        h->wpd.need_sync = 1;
     }
 
     return rc;

--- a/crypto/threads_none.c
+++ b/crypto/threads_none.c
@@ -72,18 +72,23 @@ void ossl_synchronize_rcu(CRYPTO_RCU_LOCK *lock)
     }
 }
 
-int ossl_rcu_call(CRYPTO_RCU_LOCK *lock, rcu_cb_fn cb, void *data)
+CRYPTO_RCU_CB_ITEM *ossl_rcu_cb_item_new(void)
 {
-    struct rcu_cb_item *new = OPENSSL_zalloc(sizeof(*new));
+    return OPENSSL_zalloc(sizeof(CRYPTO_RCU_CB_ITEM));
+}
 
-    if (new == NULL)
-        return 0;
+void ossl_rcu_cb_item_free(CRYPTO_RCU_CB_ITEM *item)
+{
+    OPENSSL_free(item);
+}
 
-    new->fn = cb;
-    new->data = data;
-    new->next = lock->cb_items;
-    lock->cb_items = new;
-    return 1;
+void ossl_rcu_call(CRYPTO_RCU_LOCK *lock, CRYPTO_RCU_CB_ITEM *item,
+    rcu_cb_fn cb, void *data)
+{
+    item->fn = cb;
+    item->data = data;
+    item->next = lock->cb_items;
+    lock->cb_items = item;
 }
 
 void *ossl_rcu_uptr_deref(void **p)

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -517,24 +517,27 @@ void ossl_synchronize_rcu(CRYPTO_RCU_LOCK *lock)
     }
 }
 
+CRYPTO_RCU_CB_ITEM *ossl_rcu_cb_item_new(void)
+{
+    return OPENSSL_zalloc(sizeof(CRYPTO_RCU_CB_ITEM));
+}
+
+void ossl_rcu_cb_item_free(CRYPTO_RCU_CB_ITEM *item)
+{
+    OPENSSL_free(item);
+}
+
 /*
  * Note: This call assumes its made under the protection of
  * ossl_rcu_write_lock
  */
-int ossl_rcu_call(CRYPTO_RCU_LOCK *lock, rcu_cb_fn cb, void *data)
+void ossl_rcu_call(CRYPTO_RCU_LOCK *lock, CRYPTO_RCU_CB_ITEM *item,
+    rcu_cb_fn cb, void *data)
 {
-    struct rcu_cb_item *new = OPENSSL_zalloc(sizeof(*new));
-
-    if (new == NULL)
-        return 0;
-
-    new->data = data;
-    new->fn = cb;
-
-    new->next = lock->cb_items;
-    lock->cb_items = new;
-
-    return 1;
+    item->fn = cb;
+    item->data = data;
+    item->next = lock->cb_items;
+    lock->cb_items = item;
 }
 
 void *ossl_rcu_uptr_deref(void **p)

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -394,23 +394,26 @@ void ossl_synchronize_rcu(CRYPTO_RCU_LOCK *lock)
     return;
 }
 
+CRYPTO_RCU_CB_ITEM *ossl_rcu_cb_item_new(void)
+{
+    return OPENSSL_zalloc(sizeof(CRYPTO_RCU_CB_ITEM));
+}
+
+void ossl_rcu_cb_item_free(CRYPTO_RCU_CB_ITEM *item)
+{
+    OPENSSL_free(item);
+}
+
 /*
  * Note, must be called under the protection of ossl_rcu_write_lock
  */
-int ossl_rcu_call(CRYPTO_RCU_LOCK *lock, rcu_cb_fn cb, void *data)
+void ossl_rcu_call(CRYPTO_RCU_LOCK *lock, CRYPTO_RCU_CB_ITEM *item,
+    rcu_cb_fn cb, void *data)
 {
-    struct rcu_cb_item *new;
-
-    new = OPENSSL_zalloc(sizeof(struct rcu_cb_item));
-    if (new == NULL)
-        return 0;
-    new->data = data;
-    new->fn = cb;
-
-    new->next = lock->cb_items;
-    lock->cb_items = new;
-
-    return 1;
+    item->fn = cb;
+    item->data = data;
+    item->next = lock->cb_items;
+    lock->cb_items = item;
 }
 
 void *ossl_rcu_uptr_deref(void **p)

--- a/doc/internal/man3/ossl_rcu_lock_new.pod
+++ b/doc/internal/man3/ossl_rcu_lock_new.pod
@@ -6,6 +6,7 @@ ossl_rcu_lock_new,
 ossl_rcu_lock_free, ossl_rcu_read_lock,
 ossl_rcu_read_unlock, ossl_rcu_write_lock,
 ossl_rcu_write_unlock, ossl_synchronize_rcu,
+ossl_rcu_cb_item_new, ossl_rcu_cb_item_free,
 ossl_rcu_call, ossl_rcu_deref,
 ossl_rcu_assign_ptr, ossl_rcu_uptr_deref,
 ossl_rcu_assign_uptr
@@ -19,7 +20,10 @@ ossl_rcu_assign_uptr
  void ossl_rcu_write_unlock(CRYPTO_RCU_LOCK *lock);
  void ossl_rcu_read_unlock(CRYPTO_RCU_LOCK *lock);
  void ossl_synchronize_rcu(CRYPTO_RCU_LOCK *lock);
- void ossl_rcu_call(CRYPTO_RCU_LOCK *lock, rcu_cb_fn cb, void *data);
+ CRYPTO_RCU_CB_ITEM *ossl_rcu_cb_item_new(void);
+ void ossl_rcu_cb_item_free(CRYPTO_RCU_CB_ITEM *item);
+ void ossl_rcu_call(CRYPTO_RCU_LOCK *lock, CRYPTO_RCU_CB_ITEM *item,
+                    rcu_cb_fn cb, void *data);
  void *ossl_rcu_deref(void **p);
  void ossl_rcu_uptr_deref(void **p);
  void ossl_rcu_assign_ptr(void **p, void **v);
@@ -96,10 +100,29 @@ the write side thread is safe to free.
 
 =item *
 
-ossl_rcu_call() enqueues a callback function to the lock, to be called
-when the next synchronization completes.  Note: It is not guaranteed that the
-thread which enqueued the callback will be the thread which executes the
-callback
+ossl_rcu_cb_item_new() allocates a callback item suitable for use with
+ossl_rcu_call().  Returns NULL on allocation failure.  The item is owned by
+the caller until it is passed to ossl_rcu_call(), at which point ownership
+transfers to the lock and the item must not be touched again by the caller.
+
+=item *
+
+ossl_rcu_cb_item_free() frees a callback item that was allocated by
+ossl_rcu_cb_item_new() but never passed to ossl_rcu_call().  Use this to
+release the item on the failure path of an operation that decided not to
+publish its update.
+
+=item *
+
+ossl_rcu_call() enqueues a callback function I<cb> to the lock, to be
+called with I<data> when the next synchronization completes.  The caller
+must provide a callback item I<item> previously obtained from
+ossl_rcu_cb_item_new().  After this call the lock owns the item and will
+free it after invoking the callback.  This function does not allocate and
+cannot fail, which lets callers allocate the item before performing any
+publish (assign_ptr) and bail cleanly if allocation fails.  Note: it is
+not guaranteed that the thread which enqueued the callback will be the
+thread which executes the callback.
 
 =item *
 
@@ -120,6 +143,9 @@ ossl_rcu_lock_free() frees an allocated RCU lock
 =head1 RETURN VALUES
 
 ossl_rcu_lock_new() returns a pointer to a newly created RCU lock structure.
+
+ossl_rcu_cb_item_new() returns a pointer to a newly created callback item,
+or NULL on allocation failure.
 
 ossl_rcu_deref() and ossl_rcu_uptr_deref() return the value pointed
 to by the passed in value v.
@@ -152,7 +178,7 @@ This example safely initializes and uses a lock.
 
  static void myinit(void)
  {
-     lock = ossl_rcu_lock_new(1);
+     lock = ossl_rcu_lock_new(1, NULL);
  }
 
  static int initlock(void)
@@ -162,10 +188,16 @@ This example safely initializes and uses a lock.
      return 1;
  }
 
- static void writer_thread()
+ static void free_old_foo(void *data)
+ {
+     OPENSSL_free(data);
+ }
+
+ static int writer_thread(void)
  {
     struct foo *newfoo;
     struct foo *oldfoo;
+    CRYPTO_RCU_CB_ITEM *cbi;
 
     initlock();
 
@@ -177,48 +209,60 @@ This example safely initializes and uses a lock.
      * 1) create a new shared object
      */
     newfoo = OPENSSL_zalloc(sizeof(struct foo));
+    if (newfoo == NULL)
+        return 0;
 
     /*
-     * acquire the write side lock
+     * 2) Pre allocate the rcu callback item before any publish.
+     */
+    cbi = ossl_rcu_cb_item_new();
+    if (cbi == NULL) {
+        OPENSSL_free(newfoo);
+        return 0;
+    }
+
+    /*
+     * 3) acquire the write side lock
      */
     ossl_rcu_write_lock(lock);
 
     /*
-     * 2) read the old pointer
+     * 4) read the old pointer
      */
     oldfoo = ossl_rcu_deref(&fooptr);
 
     /*
-     * 3) Copy the old pointer to the new object, and
+     * 5) Copy the old pointer to the new object, and
      *    make any needed adjustments
      */
     memcpy(newfoo, oldfoo, sizeof(struct foo));
     newfoo->aval++;
 
     /*
-     * 4) Update the shared pointer to the new value
+     * 6) Update the shared pointer to the new value
      */
     ossl_rcu_assign_ptr(&fooptr, &newfoo);
 
     /*
-     * 5) Release the write side lock
+     * 7) Schedule the old pointer to be freed when readers are done.
+     */
+    ossl_rcu_call(lock, cbi, free_old_foo, oldfoo);
+
+    /*
+     * 8) Release the write side lock
      */
     ossl_rcu_write_unlock(lock);
 
     /*
-     * 6) wait for any read side holds on the old data
-     *    to be released
+     * 9) wait for any read side holds on the old data
+     *    to be released, after which free_old_foo will run
      */
     ossl_synchronize_rcu(lock);
 
-    /*
-     * 7) free the old pointer, now that there are no
-     *    further readers
-     */
-    OPENSSL_free(oldfoo);
+    return 1;
  }
 
- static void reader_thread()
+ static void reader_thread(void)
  {
     struct foo *myfoo = NULL;
     int a;
@@ -249,7 +293,7 @@ L<crypto(7)>, L<openssl-threads(7)>.
 
 =head1 COPYRIGHT
 
-Copyright 2023-2024 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2023-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/internal/rcu.h
+++ b/include/internal/rcu.h
@@ -17,6 +17,8 @@ typedef void (*rcu_cb_fn)(void *data);
 
 typedef struct rcu_lock_st CRYPTO_RCU_LOCK;
 
+typedef struct rcu_cb_item CRYPTO_RCU_CB_ITEM;
+
 CRYPTO_RCU_LOCK *ossl_rcu_lock_new(int num_writers, OSSL_LIB_CTX *ctx);
 void ossl_rcu_lock_free(CRYPTO_RCU_LOCK *lock);
 int ossl_rcu_read_lock(CRYPTO_RCU_LOCK *lock);
@@ -24,7 +26,10 @@ void ossl_rcu_write_lock(CRYPTO_RCU_LOCK *lock);
 void ossl_rcu_write_unlock(CRYPTO_RCU_LOCK *lock);
 void ossl_rcu_read_unlock(CRYPTO_RCU_LOCK *lock);
 void ossl_synchronize_rcu(CRYPTO_RCU_LOCK *lock);
-int ossl_rcu_call(CRYPTO_RCU_LOCK *lock, rcu_cb_fn cb, void *data);
+CRYPTO_RCU_CB_ITEM *ossl_rcu_cb_item_new(void);
+void ossl_rcu_cb_item_free(CRYPTO_RCU_CB_ITEM *item);
+void ossl_rcu_call(CRYPTO_RCU_LOCK *lock, CRYPTO_RCU_CB_ITEM *item,
+    rcu_cb_fn cb, void *data);
 void *ossl_rcu_uptr_deref(void **p);
 void ossl_rcu_assign_uptr(void **p, void **v);
 #define ossl_rcu_deref(p) ossl_rcu_uptr_deref((void **)p)

--- a/test/lhash_test.c
+++ b/test/lhash_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2017-2026 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2017, Oracle and/or its affiliates.  All rights reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
@@ -302,6 +302,43 @@ static int test_int_hashtable(int idx)
 end:
     ossl_ht_free(ht);
     return rc;
+}
+
+/*
+ * MFAIL coverage for the RCU replacement branch of ossl_ht_insert_locked.
+ */
+static int test_hashtable_insert_replace_mfail(void)
+{
+    HT_CONFIG hash_conf = {
+        .collision_check = 1,
+        .no_rcu = 0, /* RCU enabled - exercises cbi pre-alloc on replace */
+    };
+    INTKEY key;
+    HT *ht = NULL;
+    int *old = NULL;
+    int ret = 0;
+    static int v1 = 100;
+    static int v2 = 200;
+
+    if (!TEST_ptr(ht = ossl_ht_new(&hash_conf)))
+        goto end;
+
+    /* Seed the table outside MFAIL for later replacement */
+    HT_INIT_KEY(&key);
+    HT_KEY_RESET(&key);
+    HT_SET_KEY_FIELD(&key, mykey, int_tests[0]);
+    if (!TEST_int_eq(ossl_ht_test_int_insert(ht, TO_HT_KEY(&key), &v1, NULL),
+            1))
+        goto end;
+
+    /* Replacement under MFAIL. */
+    MFAIL_start();
+    ret = ossl_ht_test_int_insert(ht, TO_HT_KEY(&key), &v2, &old);
+    MFAIL_end();
+
+end:
+    ossl_ht_free(ht);
+    return ret > 0 ? 1 : 0;
 }
 
 static unsigned long int stress_hash(const int *p)
@@ -799,5 +836,6 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_int_hashtable, 2);
     ADD_ALL_TESTS(test_hashtable_stress, 4);
     ADD_ALL_TESTS(test_hashtable_multithread, 2);
+    ADD_MFAIL_TEST(test_hashtable_insert_replace_mfail);
     return 1;
 }

--- a/test/namemap_internal_test.c
+++ b/test/namemap_internal_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2019-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -170,6 +170,27 @@ static int test_digest_is_a(void)
     return rv;
 }
 
+/*
+ * Test memory failures for ossl_namemap_add_name.
+ */
+static int test_namemap_add_name_mfail(void)
+{
+    OSSL_NAMEMAP *nm = NULL;
+    int ret = 0;
+
+    nm = ossl_namemap_new(NULL);
+    if (!TEST_ptr(nm))
+        goto err;
+
+    MFAIL_start();
+    ret = ossl_namemap_add_name(nm, 0, "mfail_test_name");
+    MFAIL_end();
+
+err:
+    ossl_namemap_free(nm);
+    return ret;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(test_namemap_empty);
@@ -179,5 +200,6 @@ int setup_tests(void)
     ADD_TEST(test_cipherbyname);
     ADD_TEST(test_digest_is_a);
     ADD_TEST(test_cipher_is_a);
+    ADD_MFAIL_TEST(test_namemap_add_name_mfail);
     return 1;
 }

--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2025 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -320,6 +320,7 @@ static void writer_fn(int id, int *iterations)
     int count;
     OSSL_TIME t1, t2;
     uint64_t *old, *new;
+    CRYPTO_RCU_CB_ITEM *cbi = NULL;
 
     t1 = ossl_time_now();
 
@@ -327,6 +328,12 @@ static void writer_fn(int id, int *iterations)
         new = OPENSSL_zalloc(sizeof(uint64_t));
         OPENSSL_assert(new != NULL);
         *new = (uint64_t)0xBAD;
+
+        if (contention == 0) {
+            cbi = ossl_rcu_cb_item_new();
+            OPENSSL_assert(cbi != NULL);
+        }
+
         if (contention == 0)
             OSSL_sleep(1000);
         ossl_rcu_write_lock(rcu_lock);
@@ -335,7 +342,7 @@ static void writer_fn(int id, int *iterations)
         *new = global_ctr++;
         ossl_rcu_assign_ptr(&writer_ptr, &new);
         if (contention == 0)
-            ossl_rcu_call(rcu_lock, free_old_rcu_data, old);
+            ossl_rcu_call(rcu_lock, cbi, free_old_rcu_data, old);
         ossl_rcu_write_unlock(rcu_lock);
         if (contention != 0) {
             ossl_synchronize_rcu(rcu_lock);

--- a/test/x509_load_cert_file_test.c
+++ b/test/x509_load_cert_file_test.c
@@ -172,6 +172,32 @@ err:
     return ret;
 }
 
+/*
+ * Test to trigger memory failures in X509_STORE_add_cert.
+ */
+static int test_x509_store_add_mfail(void)
+{
+    X509 *cert = NULL;
+    X509_STORE *store = NULL;
+    int ret = 0;
+
+    cert = X509_from_strings(cn_cert1);
+    if (!TEST_ptr(cert))
+        goto err;
+    store = X509_STORE_new();
+    if (!TEST_ptr(store))
+        goto err;
+
+    MFAIL_start();
+    ret = X509_STORE_add_cert(store, cert);
+    MFAIL_end();
+
+err:
+    X509_STORE_free(store);
+    X509_free(cert);
+    return ret;
+}
+
 OPT_TEST_DECLARE_USAGE("cert.pem [crl.pem]\n")
 
 int setup_tests(void)
@@ -189,6 +215,7 @@ int setup_tests(void)
 
     ADD_TEST(test_load_cert_file);
     ADD_TEST(test_load_same_cn_certs);
+    ADD_MFAIL_TEST(test_x509_store_add_mfail);
 
     return 1;
 }


### PR DESCRIPTION
Currently when allocation of cb item fails, the actual cb function is not called. The is used just in hashtable when the cb function frees the old item which result in memory leak.

To fix this, the allocation needs to be separated and happen before the assign operation is done.

Couple of MFAIL tests are added to excercise ht insertion. Although just the lhash actually recreate the issue (namemap never does replace and x509 store add does not use rcu but I kept both as they test some new paths so improving coverage - they are also really quick using just few allocations). The lhash memleak report is following:

```
Direct leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x713057cfd9c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x5dc036c59805 in mfail_malloc test/testutil/mfail.c:45
    #2 0x5dc036d6c62a in CRYPTO_malloc crypto/mem.c:196
    #3 0x5dc036d50761 in alloc_new_value crypto/hashtable/hashtable.c:665
    #4 0x5dc036d50e3d in ossl_ht_insert crypto/hashtable/hashtable.c:699
    #5 0x5dc036c4d748 in ossl_ht_test_int_insert test/lhash_test.c:195
    #6 0x5dc036c4f449 in test_hashtable_insert_replace_mfail test/lhash_test.c:330
    #7 0x5dc036c59dd9 in mfail_run_test test/testutil/mfail.c:170
    #8 0x5dc036c56ac4 in run_tests test/testutil/driver.c:359
    #9 0x5dc036c59347 in main test/testutil/main.c:49
    #10 0x71305702a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #11 0x71305702a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #12 0x5dc036c4b924 in _start (/home/jakub/prog/openssl/master/test/lhash_test+0xd65924) (BuildId: 7bb571d78ca9df9f1afee2a82d1d0efbbbcd3dbd)
```

This was originaly found by #30944 where the failure is visible in hashtable fuzz test. I confirmed that this fixes it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
