### PR TITLE
Fix DTLS out-of-sequence message error code (#25698)

### DIFF
--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -781,8 +781,10 @@ static int dtls1_process_out_of_seq_message(SSL_CONNECTION *s,
     size_t readbytes;
     SSL *ssl = SSL_CONNECTION_GET_SSL(s);
 
-    if ((msg_hdr->frag_off + frag_len) > msg_hdr->msg_len)
+    if ((msg_hdr->frag_off + frag_len) > msg_hdr->msg_len) {
+        SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_EXCESSIVE_MESSAGE_SIZE);
         goto err;
+    }
 
     /* Try to find item in queue, to prevent duplicate entries */
     memset(seq64be, 0, sizeof(seq64be));
@@ -818,8 +820,10 @@ static int dtls1_process_out_of_seq_message(SSL_CONNECTION *s,
             return dtls1_reassemble_fragment(s, msg_hdr);
         }
 
-        if (frag_len > dtls1_max_handshake_message_len(s))
+        if (frag_len > dtls1_max_handshake_message_len(s)) {
+            SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_EXCESSIVE_MESSAGE_SIZE);
             goto err;
+        }
 
         frag = dtls1_hm_fragment_new(frag_len, 0);
         if (frag == NULL) {

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -822,8 +822,10 @@ static int dtls1_process_out_of_seq_message(SSL_CONNECTION *s,
             goto err;
 
         frag = dtls1_hm_fragment_new(frag_len, 0);
-        if (frag == NULL)
+        if (frag == NULL) {
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_MALLOC_FAILURE);
             goto err;
+        }
 
         memcpy(&(frag->msg_header), msg_hdr, sizeof(*msg_hdr));
 
@@ -841,8 +843,10 @@ static int dtls1_process_out_of_seq_message(SSL_CONNECTION *s,
         }
 
         item = pitem_new(seq64be, frag);
-        if (item == NULL)
+        if (item == NULL) {
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_MALLOC_FAILURE);
             goto err;
+        }
 
         item = pqueue_insert(s->d1->buffered_messages, item);
         /*
@@ -853,8 +857,10 @@ static int dtls1_process_out_of_seq_message(SSL_CONNECTION *s,
          * have been processed with |dtls1_reassemble_fragment|, above, or
          * the record will have been discarded.
          */
-        if (!ossl_assert(item != NULL))
+        if (!ossl_assert(item != NULL)) {
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
             goto err;
+        }
     }
 
     return DTLS1_HM_FRAGMENT_RETRY;

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -827,7 +827,7 @@ static int dtls1_process_out_of_seq_message(SSL_CONNECTION *s,
 
         frag = dtls1_hm_fragment_new(frag_len, 0);
         if (frag == NULL) {
-            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_MALLOC_FAILURE);
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_CRYPTO_LIB);
             goto err;
         }
 
@@ -848,7 +848,7 @@ static int dtls1_process_out_of_seq_message(SSL_CONNECTION *s,
 
         item = pitem_new(seq64be, frag);
         if (item == NULL) {
-            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_MALLOC_FAILURE);
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_CRYPTO_LIB);
             goto err;
         }
 

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -754,7 +754,6 @@ static int dtls1_reassemble_fragment(SSL_CONNECTION *s,
     if (item == NULL) {
         item = pitem_new(seq64be, frag);
         if (item == NULL) {
-            i = -1;
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_CRYPTO_LIB);
             goto err;
         }

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -674,8 +674,10 @@ static int dtls1_reassemble_fragment(SSL_CONNECTION *s,
     size_t readbytes;
     SSL *ssl = SSL_CONNECTION_GET_SSL(s);
 
-    if ((msg_hdr->frag_off + frag_len) > msg_hdr->msg_len || msg_hdr->msg_len > dtls1_max_handshake_message_len(s))
+    if ((msg_hdr->frag_off + frag_len) > msg_hdr->msg_len || msg_hdr->msg_len > dtls1_max_handshake_message_len(s)) {
+        SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_EXCESSIVE_MESSAGE_SIZE);
         goto err;
+    }
 
     if (frag_len == 0) {
         return DTLS1_HM_FRAGMENT_RETRY;
@@ -689,8 +691,10 @@ static int dtls1_reassemble_fragment(SSL_CONNECTION *s,
 
     if (item == NULL) {
         frag = dtls1_hm_fragment_new(msg_hdr->msg_len, 1);
-        if (frag == NULL)
+        if (frag == NULL) {
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_CRYPTO_LIB);
             goto err;
+        }
         memcpy(&(frag->msg_header), msg_hdr, sizeof(*msg_hdr));
         frag->msg_header.frag_len = frag->msg_header.msg_len;
         frag->msg_header.frag_off = 0;
@@ -699,6 +703,7 @@ static int dtls1_reassemble_fragment(SSL_CONNECTION *s,
         if (frag->msg_header.msg_len != msg_hdr->msg_len) {
             item = NULL;
             frag = NULL;
+            SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_BAD_LENGTH);
             goto err;
         }
     }
@@ -734,8 +739,10 @@ static int dtls1_reassemble_fragment(SSL_CONNECTION *s,
     RSMBLY_BITMASK_MARK(frag->reassembly, (long)msg_hdr->frag_off,
         (long)(msg_hdr->frag_off + frag_len));
 
-    if (!ossl_assert(msg_hdr->msg_len > 0))
+    if (!ossl_assert(msg_hdr->msg_len > 0)) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;
+    }
     RSMBLY_BITMASK_IS_COMPLETE(frag->reassembly, (long)msg_hdr->msg_len,
         is_complete);
 
@@ -748,6 +755,7 @@ static int dtls1_reassemble_fragment(SSL_CONNECTION *s,
         item = pitem_new(seq64be, frag);
         if (item == NULL) {
             i = -1;
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_CRYPTO_LIB);
             goto err;
         }
 
@@ -758,8 +766,10 @@ static int dtls1_reassemble_fragment(SSL_CONNECTION *s,
          * would have returned it and control would never have reached this
          * branch.
          */
-        if (!ossl_assert(item != NULL))
+        if (!ossl_assert(item != NULL)) {
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
             goto err;
+        }
     }
 
     return DTLS1_HM_FRAGMENT_RETRY;


### PR DESCRIPTION
When `dtls1_process_out_of_seq_message()` encounters an error (e.g., read failure, memory allocation failure), the function returns `0`. This causes `SSL_get_error()` to return `SSL_ERROR_SYSCALL`

The PR adjusts the error to be SSL_ERROR_SSL in fatal cases.

The ssl_read_bytes calls can fail with multiple causes (WANT_READ, fatal errors, syscall errors, EOF...) and it already sets the appropriate error state internally so we delegate fatal error handling to ssl_read_bytes.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- Haven't added a specific test as the existing test_dtls_drop_records and test_swap_records tests exercise the out-of-sequence code paths.

Fixes https://github.com/openssl/openssl/issues/25698
