### PR TITLE
Make test/quic_fc_test.c clang-format friendly

### DIFF
--- a/test/quic_fc_test.c
+++ b/test/quic_fc_test.c
@@ -229,242 +229,242 @@ struct rx_test_op {
 #define RX_OP_END \
     { RX_OPC_END }
 #define RX_OP_INIT_CONN(init_window_size, max_window_size) \
-    { RX_OPC_INIT_CONN, 0, (init_window_size), (max_window_size) },
+    { RX_OPC_INIT_CONN, 0, (init_window_size), (max_window_size) }
 #define RX_OP_INIT_STREAM(stream_idx, init_window_size, max_window_size) \
-    { RX_OPC_INIT_STREAM, (stream_idx), (init_window_size), (max_window_size) },
+    { RX_OPC_INIT_STREAM, (stream_idx), (init_window_size), (max_window_size) }
 #define RX_OP_RX(stream_idx, end, is_fin) \
-    { RX_OPC_RX, (stream_idx), (end), (is_fin) },
+    { RX_OPC_RX, (stream_idx), (end), (is_fin) }
 #define RX_OP_RETIRE(stream_idx, num_bytes, rtt, expect_fail) \
-    { RX_OPC_RETIRE, (stream_idx), (num_bytes), (rtt), (expect_fail) },
+    { RX_OPC_RETIRE, (stream_idx), (num_bytes), (rtt), (expect_fail) }
 #define RX_OP_CHECK_CWM_CONN(expected) \
-    { RX_OPC_CHECK_CWM_CONN, 0, (expected) },
+    { RX_OPC_CHECK_CWM_CONN, 0, (expected) }
 #define RX_OP_CHECK_CWM_STREAM(stream_id, expected) \
-    { RX_OPC_CHECK_CWM_STREAM, (stream_id), (expected) },
+    { RX_OPC_CHECK_CWM_STREAM, (stream_id), (expected) }
 #define RX_OP_CHECK_SWM_CONN(expected) \
-    { RX_OPC_CHECK_SWM_CONN, 0, (expected) },
+    { RX_OPC_CHECK_SWM_CONN, 0, (expected) }
 #define RX_OP_CHECK_SWM_STREAM(stream_id, expected) \
-    { RX_OPC_CHECK_SWM_STREAM, (stream_id), (expected) },
+    { RX_OPC_CHECK_SWM_STREAM, (stream_id), (expected) }
 #define RX_OP_CHECK_RWM_CONN(expected) \
-    { RX_OPC_CHECK_RWM_CONN, 0, (expected) },
+    { RX_OPC_CHECK_RWM_CONN, 0, (expected) }
 #define RX_OP_CHECK_RWM_STREAM(stream_id, expected) \
-    { RX_OPC_CHECK_RWM_STREAM, (stream_id), (expected) },
+    { RX_OPC_CHECK_RWM_STREAM, (stream_id), (expected) }
 #define RX_OP_CHECK_CHANGED_CONN(expected, clear) \
-    { RX_OPC_CHECK_CHANGED_CONN, 0, (expected), (clear) },
+    { RX_OPC_CHECK_CHANGED_CONN, 0, (expected), (clear) }
 #define RX_OP_CHECK_CHANGED_STREAM(stream_id, expected, clear) \
-    { RX_OPC_CHECK_CHANGED_STREAM, (stream_id), (expected), (clear) },
+    { RX_OPC_CHECK_CHANGED_STREAM, (stream_id), (expected), (clear) }
 #define RX_OP_CHECK_ERROR_CONN(expected, clear) \
-    { RX_OPC_CHECK_ERROR_CONN, 0, (expected), (clear) },
+    { RX_OPC_CHECK_ERROR_CONN, 0, (expected), (clear) }
 #define RX_OP_CHECK_ERROR_STREAM(stream_id, expected, clear) \
-    { RX_OPC_CHECK_ERROR_STREAM, (stream_id), (expected), (clear) },
+    { RX_OPC_CHECK_ERROR_STREAM, (stream_id), (expected), (clear) }
 #define RX_OP_STEP_TIME(t) \
-    { RX_OPC_STEP_TIME, 0, (t) },
+    { RX_OPC_STEP_TIME, 0, (t) }
 #define RX_OP_MSG(msg) \
-    { RX_OPC_MSG, 0, 0, 0, 0, (msg) },
+    { RX_OPC_MSG, 0, 0, 0, 0, (msg) }
 
-#define RX_OP_INIT(init_window_size, max_window_size)  \
-    RX_OP_INIT_CONN(init_window_size, max_window_size) \
-    RX_OP_INIT_STREAM(0, init_window_size, max_window_size)
-#define RX_OP_CHECK_CWM(expected)  \
-    RX_OP_CHECK_CWM_CONN(expected) \
-    RX_OP_CHECK_CWM_STREAM(0, expected)
-#define RX_OP_CHECK_SWM(expected)  \
-    RX_OP_CHECK_SWM_CONN(expected) \
-    RX_OP_CHECK_SWM_STREAM(0, expected)
-#define RX_OP_CHECK_RWM(expected)  \
-    RX_OP_CHECK_RWM_CONN(expected) \
-    RX_OP_CHECK_RWM_STREAM(0, expected)
-#define RX_OP_CHECK_CHANGED(expected, clear)  \
-    RX_OP_CHECK_CHANGED_CONN(expected, clear) \
-    RX_OP_CHECK_CHANGED_STREAM(0, expected, clear)
-#define RX_OP_CHECK_ERROR(expected, clear)  \
-    RX_OP_CHECK_ERROR_CONN(expected, clear) \
-    RX_OP_CHECK_ERROR_STREAM(0, expected, clear)
+#define RX_OP_INIT(init_window_size, max_window_size)   \
+    RX_OP_INIT_CONN(init_window_size, max_window_size), \
+        RX_OP_INIT_STREAM(0, init_window_size, max_window_size)
+#define RX_OP_CHECK_CWM(expected)   \
+    RX_OP_CHECK_CWM_CONN(expected), \
+        RX_OP_CHECK_CWM_STREAM(0, expected)
+#define RX_OP_CHECK_SWM(expected)   \
+    RX_OP_CHECK_SWM_CONN(expected), \
+        RX_OP_CHECK_SWM_STREAM(0, expected)
+#define RX_OP_CHECK_RWM(expected)   \
+    RX_OP_CHECK_RWM_CONN(expected), \
+        RX_OP_CHECK_RWM_STREAM(0, expected)
+#define RX_OP_CHECK_CHANGED(expected, clear)   \
+    RX_OP_CHECK_CHANGED_CONN(expected, clear), \
+        RX_OP_CHECK_CHANGED_STREAM(0, expected, clear)
+#define RX_OP_CHECK_ERROR(expected, clear)   \
+    RX_OP_CHECK_ERROR_CONN(expected, clear), \
+        RX_OP_CHECK_ERROR_STREAM(0, expected, clear)
 
 #define INIT_WINDOW_SIZE (1 * 1024 * 1024)
 #define INIT_S_WINDOW_SIZE (384 * 1024)
 
 /* 1. Basic RXFC Tests (stream window == connection window) */
 static const struct rx_test_op rx_script_1[] = {
-    RX_OP_STEP_TIME(1000 * OSSL_TIME_MS)
-        RX_OP_INIT(INIT_WINDOW_SIZE, 10 * INIT_WINDOW_SIZE)
+    RX_OP_STEP_TIME(1000 * OSSL_TIME_MS),
+    RX_OP_INIT(INIT_WINDOW_SIZE, 10 * INIT_WINDOW_SIZE),
     /* Check initial state. */
-    RX_OP_CHECK_CWM(INIT_WINDOW_SIZE)
-        RX_OP_CHECK_ERROR(0, 0)
-            RX_OP_CHECK_CHANGED(0, 0)
+    RX_OP_CHECK_CWM(INIT_WINDOW_SIZE),
+    RX_OP_CHECK_ERROR(0, 0),
+    RX_OP_CHECK_CHANGED(0, 0),
     /* We cannot retire what we have not received. */
-    RX_OP_RETIRE(0, 1, 0, 1)
+    RX_OP_RETIRE(0, 1, 0, 1),
     /* Zero bytes is a no-op and always valid. */
-    RX_OP_RETIRE(0, 0, 0, 0)
+    RX_OP_RETIRE(0, 0, 0, 0),
     /* Consume some window. */
-    RX_OP_RX(0, 50, 0)
+    RX_OP_RX(0, 50, 0),
     /* CWM has not changed. */
-    RX_OP_CHECK_CWM(INIT_WINDOW_SIZE)
-        RX_OP_CHECK_SWM(50)
+    RX_OP_CHECK_CWM(INIT_WINDOW_SIZE),
+    RX_OP_CHECK_SWM(50),
 
     /* RX, Partial retire */
-    RX_OP_RX(0, 60, 0)
-        RX_OP_CHECK_SWM(60)
-            RX_OP_RETIRE(0, 20, 50 * OSSL_TIME_MS, 0)
-                RX_OP_CHECK_RWM(20)
-                    RX_OP_CHECK_SWM(60)
-                        RX_OP_CHECK_CWM(INIT_WINDOW_SIZE)
-                            RX_OP_CHECK_CHANGED(0, 0)
-                                RX_OP_CHECK_ERROR(0, 0)
+    RX_OP_RX(0, 60, 0),
+    RX_OP_CHECK_SWM(60),
+    RX_OP_RETIRE(0, 20, 50 * OSSL_TIME_MS, 0),
+    RX_OP_CHECK_RWM(20),
+    RX_OP_CHECK_SWM(60),
+    RX_OP_CHECK_CWM(INIT_WINDOW_SIZE),
+    RX_OP_CHECK_CHANGED(0, 0),
+    RX_OP_CHECK_ERROR(0, 0),
 
     /* Fully retired */
-    RX_OP_RETIRE(0, 41, 0, 1)
-        RX_OP_RETIRE(0, 40, 0, 0)
-            RX_OP_CHECK_SWM(60)
-                RX_OP_CHECK_RWM(60)
-                    RX_OP_CHECK_CWM(INIT_WINDOW_SIZE)
-                        RX_OP_CHECK_CHANGED(0, 0)
-                            RX_OP_CHECK_ERROR(0, 0)
+    RX_OP_RETIRE(0, 41, 0, 1),
+    RX_OP_RETIRE(0, 40, 0, 0),
+    RX_OP_CHECK_SWM(60),
+    RX_OP_CHECK_RWM(60),
+    RX_OP_CHECK_CWM(INIT_WINDOW_SIZE),
+    RX_OP_CHECK_CHANGED(0, 0),
+    RX_OP_CHECK_ERROR(0, 0),
 
     /* Exhaustion of window - we do not enlarge the window this epoch */
-    RX_OP_STEP_TIME(201 * OSSL_TIME_MS)
-        RX_OP_RX(0, INIT_WINDOW_SIZE, 0)
-            RX_OP_RETIRE(0, INIT_WINDOW_SIZE - 60, 50 * OSSL_TIME_MS, 0)
-                RX_OP_CHECK_SWM(INIT_WINDOW_SIZE)
-                    RX_OP_CHECK_CHANGED(1, 0)
-                        RX_OP_CHECK_CHANGED(1, 1)
-                            RX_OP_CHECK_CHANGED(0, 0)
-                                RX_OP_CHECK_ERROR(0, 0)
-                                    RX_OP_CHECK_CWM(INIT_WINDOW_SIZE * 2)
+    RX_OP_STEP_TIME(201 * OSSL_TIME_MS),
+    RX_OP_RX(0, INIT_WINDOW_SIZE, 0),
+    RX_OP_RETIRE(0, INIT_WINDOW_SIZE - 60, 50 * OSSL_TIME_MS, 0),
+    RX_OP_CHECK_SWM(INIT_WINDOW_SIZE),
+    RX_OP_CHECK_CHANGED(1, 0),
+    RX_OP_CHECK_CHANGED(1, 1),
+    RX_OP_CHECK_CHANGED(0, 0),
+    RX_OP_CHECK_ERROR(0, 0),
+    RX_OP_CHECK_CWM(INIT_WINDOW_SIZE * 2),
 
     /* Second epoch - we still do not enlarge the window this epoch */
-    RX_OP_RX(0, INIT_WINDOW_SIZE + 1, 0)
-        RX_OP_STEP_TIME(201 * OSSL_TIME_MS)
-            RX_OP_RX(0, INIT_WINDOW_SIZE * 2, 0)
-                RX_OP_RETIRE(0, INIT_WINDOW_SIZE, 50 * OSSL_TIME_MS, 0)
-                    RX_OP_CHECK_SWM(INIT_WINDOW_SIZE * 2)
-                        RX_OP_CHECK_CHANGED(1, 0)
-                            RX_OP_CHECK_CHANGED(1, 1)
-                                RX_OP_CHECK_CHANGED(0, 0)
-                                    RX_OP_CHECK_ERROR(0, 0)
-                                        RX_OP_CHECK_CWM(INIT_WINDOW_SIZE * 3)
+    RX_OP_RX(0, INIT_WINDOW_SIZE + 1, 0),
+    RX_OP_STEP_TIME(201 * OSSL_TIME_MS),
+    RX_OP_RX(0, INIT_WINDOW_SIZE * 2, 0),
+    RX_OP_RETIRE(0, INIT_WINDOW_SIZE, 50 * OSSL_TIME_MS, 0),
+    RX_OP_CHECK_SWM(INIT_WINDOW_SIZE * 2),
+    RX_OP_CHECK_CHANGED(1, 0),
+    RX_OP_CHECK_CHANGED(1, 1),
+    RX_OP_CHECK_CHANGED(0, 0),
+    RX_OP_CHECK_ERROR(0, 0),
+    RX_OP_CHECK_CWM(INIT_WINDOW_SIZE * 3),
 
     /* Third epoch - we enlarge the window */
-    RX_OP_RX(0, INIT_WINDOW_SIZE * 2 + 1, 0)
-        RX_OP_STEP_TIME(199 * OSSL_TIME_MS)
-            RX_OP_RX(0, INIT_WINDOW_SIZE * 3, 0)
-                RX_OP_RETIRE(0, INIT_WINDOW_SIZE, 50 * OSSL_TIME_MS, 0)
-                    RX_OP_CHECK_SWM(INIT_WINDOW_SIZE * 3)
-                        RX_OP_CHECK_CHANGED(1, 0)
-                            RX_OP_CHECK_CHANGED(1, 1)
-                                RX_OP_CHECK_CHANGED(0, 0)
-                                    RX_OP_CHECK_ERROR(0, 0)
-                                        RX_OP_CHECK_CWM(INIT_WINDOW_SIZE * 5)
+    RX_OP_RX(0, INIT_WINDOW_SIZE * 2 + 1, 0),
+    RX_OP_STEP_TIME(199 * OSSL_TIME_MS),
+    RX_OP_RX(0, INIT_WINDOW_SIZE * 3, 0),
+    RX_OP_RETIRE(0, INIT_WINDOW_SIZE, 50 * OSSL_TIME_MS, 0),
+    RX_OP_CHECK_SWM(INIT_WINDOW_SIZE * 3),
+    RX_OP_CHECK_CHANGED(1, 0),
+    RX_OP_CHECK_CHANGED(1, 1),
+    RX_OP_CHECK_CHANGED(0, 0),
+    RX_OP_CHECK_ERROR(0, 0),
+    RX_OP_CHECK_CWM(INIT_WINDOW_SIZE * 5),
 
     /* Fourth epoch - peer violates flow control */
-    RX_OP_RX(0, INIT_WINDOW_SIZE * 5 - 5, 0)
-        RX_OP_STEP_TIME(250 * OSSL_TIME_MS)
-            RX_OP_RX(0, INIT_WINDOW_SIZE * 5 + 1, 0)
-                RX_OP_CHECK_SWM(INIT_WINDOW_SIZE * 5)
-                    RX_OP_CHECK_ERROR(OSSL_QUIC_ERR_FLOW_CONTROL_ERROR, 0)
-                        RX_OP_CHECK_ERROR(OSSL_QUIC_ERR_FLOW_CONTROL_ERROR, 1)
-                            RX_OP_CHECK_ERROR(0, 0)
-                                RX_OP_CHECK_CWM(INIT_WINDOW_SIZE * 5)
+    RX_OP_RX(0, INIT_WINDOW_SIZE * 5 - 5, 0),
+    RX_OP_STEP_TIME(250 * OSSL_TIME_MS),
+    RX_OP_RX(0, INIT_WINDOW_SIZE * 5 + 1, 0),
+    RX_OP_CHECK_SWM(INIT_WINDOW_SIZE * 5),
+    RX_OP_CHECK_ERROR(OSSL_QUIC_ERR_FLOW_CONTROL_ERROR, 0),
+    RX_OP_CHECK_ERROR(OSSL_QUIC_ERR_FLOW_CONTROL_ERROR, 1),
+    RX_OP_CHECK_ERROR(0, 0),
+    RX_OP_CHECK_CWM(INIT_WINDOW_SIZE * 5),
     /*
      * No window expansion due to flow control violation; window expansion is
      * triggered by retirement only.
      */
-    RX_OP_CHECK_CHANGED(0, 0)
+    RX_OP_CHECK_CHANGED(0, 0),
 
-        RX_OP_END
+    RX_OP_END,
 };
 
 /* 2. Interaction between connection and stream-level flow control */
 static const struct rx_test_op rx_script_2[] = {
-    RX_OP_STEP_TIME(1000 * OSSL_TIME_MS)
-        RX_OP_INIT_CONN(INIT_WINDOW_SIZE, 10 * INIT_WINDOW_SIZE)
-            RX_OP_INIT_STREAM(0, INIT_S_WINDOW_SIZE, 30 * INIT_S_WINDOW_SIZE)
-                RX_OP_INIT_STREAM(1, INIT_S_WINDOW_SIZE, 30 * INIT_S_WINDOW_SIZE)
+    RX_OP_STEP_TIME(1000 * OSSL_TIME_MS),
+    RX_OP_INIT_CONN(INIT_WINDOW_SIZE, 10 * INIT_WINDOW_SIZE),
+    RX_OP_INIT_STREAM(0, INIT_S_WINDOW_SIZE, 30 * INIT_S_WINDOW_SIZE),
+    RX_OP_INIT_STREAM(1, INIT_S_WINDOW_SIZE, 30 * INIT_S_WINDOW_SIZE),
 
-                    RX_OP_RX(0, 10, 0)
-                        RX_OP_CHECK_CWM_CONN(INIT_WINDOW_SIZE)
-                            RX_OP_CHECK_CWM_STREAM(0, INIT_S_WINDOW_SIZE)
-                                RX_OP_CHECK_CWM_STREAM(1, INIT_S_WINDOW_SIZE)
-                                    RX_OP_CHECK_SWM_CONN(10)
-                                        RX_OP_CHECK_SWM_STREAM(0, 10)
-                                            RX_OP_CHECK_SWM_STREAM(1, 0)
-                                                RX_OP_CHECK_RWM_CONN(0)
-                                                    RX_OP_CHECK_RWM_STREAM(0, 0)
-                                                        RX_OP_CHECK_RWM_STREAM(1, 0)
+    RX_OP_RX(0, 10, 0),
+    RX_OP_CHECK_CWM_CONN(INIT_WINDOW_SIZE),
+    RX_OP_CHECK_CWM_STREAM(0, INIT_S_WINDOW_SIZE),
+    RX_OP_CHECK_CWM_STREAM(1, INIT_S_WINDOW_SIZE),
+    RX_OP_CHECK_SWM_CONN(10),
+    RX_OP_CHECK_SWM_STREAM(0, 10),
+    RX_OP_CHECK_SWM_STREAM(1, 0),
+    RX_OP_CHECK_RWM_CONN(0),
+    RX_OP_CHECK_RWM_STREAM(0, 0),
+    RX_OP_CHECK_RWM_STREAM(1, 0),
 
-                                                            RX_OP_RX(1, 42, 0)
-                                                                RX_OP_RX(1, 42, 0) /* monotonic; equal or lower values ignored */
-    RX_OP_RX(1, 35, 0)
-        RX_OP_CHECK_CWM_CONN(INIT_WINDOW_SIZE)
-            RX_OP_CHECK_CWM_STREAM(0, INIT_S_WINDOW_SIZE)
-                RX_OP_CHECK_CWM_STREAM(1, INIT_S_WINDOW_SIZE)
-                    RX_OP_CHECK_SWM_CONN(52)
-                        RX_OP_CHECK_SWM_STREAM(0, 10)
-                            RX_OP_CHECK_SWM_STREAM(1, 42)
-                                RX_OP_CHECK_RWM_CONN(0)
-                                    RX_OP_CHECK_RWM_STREAM(0, 0)
-                                        RX_OP_CHECK_RWM_STREAM(1, 0)
+    RX_OP_RX(1, 42, 0),
+    RX_OP_RX(1, 42, 0) /* monotonic; equal or lower values ignored */,
+    RX_OP_RX(1, 35, 0),
+    RX_OP_CHECK_CWM_CONN(INIT_WINDOW_SIZE),
+    RX_OP_CHECK_CWM_STREAM(0, INIT_S_WINDOW_SIZE),
+    RX_OP_CHECK_CWM_STREAM(1, INIT_S_WINDOW_SIZE),
+    RX_OP_CHECK_SWM_CONN(52),
+    RX_OP_CHECK_SWM_STREAM(0, 10),
+    RX_OP_CHECK_SWM_STREAM(1, 42),
+    RX_OP_CHECK_RWM_CONN(0),
+    RX_OP_CHECK_RWM_STREAM(0, 0),
+    RX_OP_CHECK_RWM_STREAM(1, 0),
 
-                                            RX_OP_RETIRE(0, 10, 50 * OSSL_TIME_MS, 0)
-                                                RX_OP_CHECK_RWM_CONN(10)
-                                                    RX_OP_CHECK_RWM_STREAM(0, 10)
-                                                        RX_OP_CHECK_CWM_CONN(INIT_WINDOW_SIZE)
-                                                            RX_OP_CHECK_CWM_STREAM(0, INIT_S_WINDOW_SIZE)
-                                                                RX_OP_CHECK_CWM_STREAM(1, INIT_S_WINDOW_SIZE)
+    RX_OP_RETIRE(0, 10, 50 * OSSL_TIME_MS, 0),
+    RX_OP_CHECK_RWM_CONN(10),
+    RX_OP_CHECK_RWM_STREAM(0, 10),
+    RX_OP_CHECK_CWM_CONN(INIT_WINDOW_SIZE),
+    RX_OP_CHECK_CWM_STREAM(0, INIT_S_WINDOW_SIZE),
+    RX_OP_CHECK_CWM_STREAM(1, INIT_S_WINDOW_SIZE),
 
-                                                                    RX_OP_RETIRE(1, 42, 50 * OSSL_TIME_MS, 0)
-                                                                        RX_OP_CHECK_RWM_CONN(52)
-                                                                            RX_OP_CHECK_RWM_STREAM(1, 42)
-                                                                                RX_OP_CHECK_CWM_CONN(INIT_WINDOW_SIZE)
-                                                                                    RX_OP_CHECK_CWM_STREAM(0, INIT_S_WINDOW_SIZE)
-                                                                                        RX_OP_CHECK_CWM_STREAM(1, INIT_S_WINDOW_SIZE)
+    RX_OP_RETIRE(1, 42, 50 * OSSL_TIME_MS, 0),
+    RX_OP_CHECK_RWM_CONN(52),
+    RX_OP_CHECK_RWM_STREAM(1, 42),
+    RX_OP_CHECK_CWM_CONN(INIT_WINDOW_SIZE),
+    RX_OP_CHECK_CWM_STREAM(0, INIT_S_WINDOW_SIZE),
+    RX_OP_CHECK_CWM_STREAM(1, INIT_S_WINDOW_SIZE),
 
-                                                                                            RX_OP_CHECK_CHANGED_CONN(0, 0)
+    RX_OP_CHECK_CHANGED_CONN(0, 0),
 
     /* FC limited by stream but not connection */
-    RX_OP_STEP_TIME(1000 * OSSL_TIME_MS)
-        RX_OP_RX(0, INIT_S_WINDOW_SIZE, 0)
-            RX_OP_CHECK_SWM_CONN(INIT_S_WINDOW_SIZE + 42)
-                RX_OP_CHECK_SWM_STREAM(0, INIT_S_WINDOW_SIZE)
-                    RX_OP_CHECK_SWM_STREAM(1, 42)
-                        RX_OP_CHECK_CWM_CONN(INIT_WINDOW_SIZE)
-                            RX_OP_CHECK_CWM_STREAM(0, INIT_S_WINDOW_SIZE)
+    RX_OP_STEP_TIME(1000 * OSSL_TIME_MS),
+    RX_OP_RX(0, INIT_S_WINDOW_SIZE, 0),
+    RX_OP_CHECK_SWM_CONN(INIT_S_WINDOW_SIZE + 42),
+    RX_OP_CHECK_SWM_STREAM(0, INIT_S_WINDOW_SIZE),
+    RX_OP_CHECK_SWM_STREAM(1, 42),
+    RX_OP_CHECK_CWM_CONN(INIT_WINDOW_SIZE),
+    RX_OP_CHECK_CWM_STREAM(0, INIT_S_WINDOW_SIZE),
 
     /* We bump CWM when more than 1/4 of the window has been retired */
-    RX_OP_RETIRE(0, INIT_S_WINDOW_SIZE - 10, 50 * OSSL_TIME_MS, 0)
-        RX_OP_CHECK_CWM_STREAM(0, INIT_S_WINDOW_SIZE * 2)
-            RX_OP_CHECK_CHANGED_STREAM(0, 1, 0)
-                RX_OP_CHECK_CHANGED_STREAM(0, 1, 1)
-                    RX_OP_CHECK_CHANGED_STREAM(0, 0, 0)
+    RX_OP_RETIRE(0, INIT_S_WINDOW_SIZE - 10, 50 * OSSL_TIME_MS, 0),
+    RX_OP_CHECK_CWM_STREAM(0, INIT_S_WINDOW_SIZE * 2),
+    RX_OP_CHECK_CHANGED_STREAM(0, 1, 0),
+    RX_OP_CHECK_CHANGED_STREAM(0, 1, 1),
+    RX_OP_CHECK_CHANGED_STREAM(0, 0, 0),
 
     /*
      * This is more than 1/4 of the connection window, so CWM will
      * be bumped here too.
      */
-    RX_OP_CHECK_CWM_CONN(INIT_S_WINDOW_SIZE + INIT_WINDOW_SIZE + 42)
-        RX_OP_CHECK_RWM_CONN(INIT_S_WINDOW_SIZE + 42)
-            RX_OP_CHECK_RWM_STREAM(0, INIT_S_WINDOW_SIZE)
-                RX_OP_CHECK_RWM_STREAM(1, 42)
-                    RX_OP_CHECK_CHANGED_CONN(1, 0)
-                        RX_OP_CHECK_CHANGED_CONN(1, 1)
-                            RX_OP_CHECK_CHANGED_CONN(0, 0)
-                                RX_OP_CHECK_ERROR_CONN(0, 0)
-                                    RX_OP_CHECK_ERROR_STREAM(0, 0, 0)
-                                        RX_OP_CHECK_ERROR_STREAM(1, 0, 0)
+    RX_OP_CHECK_CWM_CONN(INIT_S_WINDOW_SIZE + INIT_WINDOW_SIZE + 42),
+    RX_OP_CHECK_RWM_CONN(INIT_S_WINDOW_SIZE + 42),
+    RX_OP_CHECK_RWM_STREAM(0, INIT_S_WINDOW_SIZE),
+    RX_OP_CHECK_RWM_STREAM(1, 42),
+    RX_OP_CHECK_CHANGED_CONN(1, 0),
+    RX_OP_CHECK_CHANGED_CONN(1, 1),
+    RX_OP_CHECK_CHANGED_CONN(0, 0),
+    RX_OP_CHECK_ERROR_CONN(0, 0),
+    RX_OP_CHECK_ERROR_STREAM(0, 0, 0),
+    RX_OP_CHECK_ERROR_STREAM(1, 0, 0),
 
     /* Test exceeding limit at stream level. */
-    RX_OP_RX(0, INIT_S_WINDOW_SIZE * 2 + 1, 0)
-        RX_OP_CHECK_ERROR_STREAM(0, OSSL_QUIC_ERR_FLOW_CONTROL_ERROR, 0)
-            RX_OP_CHECK_ERROR_STREAM(0, OSSL_QUIC_ERR_FLOW_CONTROL_ERROR, 1)
-                RX_OP_CHECK_ERROR_STREAM(0, 0, 0)
-                    RX_OP_CHECK_ERROR_CONN(0, 0) /* doesn't affect conn */
+    RX_OP_RX(0, INIT_S_WINDOW_SIZE * 2 + 1, 0),
+    RX_OP_CHECK_ERROR_STREAM(0, OSSL_QUIC_ERR_FLOW_CONTROL_ERROR, 0),
+    RX_OP_CHECK_ERROR_STREAM(0, OSSL_QUIC_ERR_FLOW_CONTROL_ERROR, 1),
+    RX_OP_CHECK_ERROR_STREAM(0, 0, 0),
+    RX_OP_CHECK_ERROR_CONN(0, 0) /* doesn't affect conn */,
 
     /* Test exceeding limit at connection level. */
-    RX_OP_RX(0, INIT_WINDOW_SIZE * 2, 0)
-        RX_OP_CHECK_ERROR_CONN(OSSL_QUIC_ERR_FLOW_CONTROL_ERROR, 0)
-            RX_OP_CHECK_ERROR_CONN(OSSL_QUIC_ERR_FLOW_CONTROL_ERROR, 1)
-                RX_OP_CHECK_ERROR_CONN(0, 0)
+    RX_OP_RX(0, INIT_WINDOW_SIZE * 2, 0),
+    RX_OP_CHECK_ERROR_CONN(OSSL_QUIC_ERR_FLOW_CONTROL_ERROR, 0),
+    RX_OP_CHECK_ERROR_CONN(OSSL_QUIC_ERR_FLOW_CONTROL_ERROR, 1),
+    RX_OP_CHECK_ERROR_CONN(0, 0),
 
-                    RX_OP_END
+    RX_OP_END,
 };
 
 static const struct rx_test_op *rx_scripts[] = {

--- a/test/quic_fc_test.c
+++ b/test/quic_fc_test.c
@@ -392,7 +392,7 @@ static const struct rx_test_op rx_script_2[] = {
     RX_OP_CHECK_RWM_STREAM(1, 0),
 
     RX_OP_RX(1, 42, 0),
-    RX_OP_RX(1, 42, 0) /* monotonic; equal or lower values ignored */,
+    RX_OP_RX(1, 42, 0), /* monotonic; equal or lower values ignored */
     RX_OP_RX(1, 35, 0),
     RX_OP_CHECK_CWM_CONN(INIT_WINDOW_SIZE),
     RX_OP_CHECK_CWM_STREAM(0, INIT_S_WINDOW_SIZE),
@@ -456,7 +456,7 @@ static const struct rx_test_op rx_script_2[] = {
     RX_OP_CHECK_ERROR_STREAM(0, OSSL_QUIC_ERR_FLOW_CONTROL_ERROR, 0),
     RX_OP_CHECK_ERROR_STREAM(0, OSSL_QUIC_ERR_FLOW_CONTROL_ERROR, 1),
     RX_OP_CHECK_ERROR_STREAM(0, 0, 0),
-    RX_OP_CHECK_ERROR_CONN(0, 0) /* doesn't affect conn */,
+    RX_OP_CHECK_ERROR_CONN(0, 0), /* doesn't affect conn */
 
     /* Test exceeding limit at connection level. */
     RX_OP_RX(0, INIT_WINDOW_SIZE * 2, 0),


### PR DESCRIPTION
found it while reading fc code and tests.
did two regexes and finishing touches by hand:
`s/},$/}/gc`
`%s/\(^    RX_OP_.*$\)/\1,/g`
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
