### PR TITLE
FFC params copy memory leak

### DIFF
--- a/crypto/ffc/ffc_params.c
+++ b/crypto/ffc/ffc_params.c
@@ -182,8 +182,10 @@ int ossl_ffc_params_copy(FFC_PARAMS *dst, const FFC_PARAMS *src)
     if (!ffc_bn_cpy(&dst->p, src->p)
         || !ffc_bn_cpy(&dst->g, src->g)
         || !ffc_bn_cpy(&dst->q, src->q)
-        || !ffc_bn_cpy(&dst->j, src->j))
+        || !ffc_bn_cpy(&dst->j, src->j)) {
+        ossl_ffc_params_cleanup(dst);
         return 0;
+    }
 
     dst->mdname = src->mdname;
     dst->mdprops = src->mdprops;
@@ -191,8 +193,10 @@ int ossl_ffc_params_copy(FFC_PARAMS *dst, const FFC_PARAMS *src)
     dst->seedlen = src->seedlen;
     if (src->seed != NULL) {
         dst->seed = OPENSSL_memdup(src->seed, src->seedlen);
-        if (dst->seed == NULL)
+        if (dst->seed == NULL) {
+            ossl_ffc_params_cleanup(dst);
             return 0;
+        }
     } else {
         dst->seed = NULL;
     }

--- a/test/ffc_internal_test.c
+++ b/test/ffc_internal_test.c
@@ -690,6 +690,47 @@ err:
     DH_free(dh);
     return ret;
 }
+
+static int ffc_params_copy_mfail(void)
+{
+    int ret = 0;
+    FFC_PARAMS params, copy;
+    BIGNUM *p = NULL, *q = NULL, *g = NULL;
+
+    ossl_ffc_params_init(&params);
+    ossl_ffc_params_init(&copy);
+
+    if (!TEST_ptr(p = BN_bin2bn(dsa_2048_224_sha256_p,
+                      sizeof(dsa_2048_224_sha256_p), NULL))
+        || !TEST_ptr(q = BN_bin2bn(dsa_2048_224_sha256_q,
+                         sizeof(dsa_2048_224_sha256_q), NULL))
+        || !TEST_ptr(g = BN_bin2bn(dsa_2048_224_sha256_g,
+                         sizeof(dsa_2048_224_sha256_g), NULL)))
+        goto err;
+
+    ossl_ffc_params_set0_pqg(&params, p, q, g);
+    p = q = g = NULL;
+    if (!TEST_true(ossl_ffc_params_set_seed(&params, dsa_2048_224_sha224_seed,
+            sizeof(dsa_2048_224_sha224_seed))))
+        goto err;
+
+    MFAIL_start();
+    ret = ossl_ffc_params_copy(&copy, &params);
+    MFAIL_end();
+
+    if (!ret)
+        goto err;
+
+    ret = 1;
+err:
+    ossl_ffc_params_cleanup(&params);
+    if (ret)
+        ossl_ffc_params_cleanup(&copy);
+    BN_free(p);
+    BN_free(q);
+    BN_free(g);
+    return ret;
+}
 #endif /* OPENSSL_NO_DH */
 
 int setup_tests(void)
@@ -706,6 +747,7 @@ int setup_tests(void)
     ADD_TEST(ffc_private_validate_test);
     ADD_ALL_TESTS(ffc_private_gen_test, 10);
     ADD_TEST(ffc_params_copy_test);
+    ADD_MFAIL_TEST(ffc_params_copy_mfail);
 #endif /* OPENSSL_NO_DH */
     return 1;
 }


### PR DESCRIPTION
If allocation fails in `ossl_ffc_params_copy`, then the params that were previously allocated are not freed. This results in a memory leak.

The mfail test is added which covers the leak. The fix should be backported but the test is only for master.

This was found using #30944 where it produced following backtraces:

```
# - backtrace at injection point:
#   # CORPUS_FILE file_idx=0 size=534 path=../../fuzz/corpora/decoder/4a3b0cf277bf14b30f9a04e03cb9579aa3d85d04
#   # MFAIL_BEGIN file_idx=0 phase=count
#   # ../../fuzz/corpora/decoder/4a3b0cf277bf14b30f9a04e03cb9579aa3d85d04: 8517 allocations
#   # MFAIL_BEGIN file_idx=0 point=1519/8517
#   # MFAIL_BT (failure injection point)
#       #0 0x7f9ec0f0b5a7 in __sanitizer_print_stack_trace ../../../../src/libsanitizer/asan/asan_stack.cpp:87
#       #1 0x5586b926eb5d in mfail_print_bt test/mfail/mfail.c:69
#       #2 0x5586b926ebeb in should_fail test/mfail/mfail.c:87
#       #3 0x5586b926ec23 in mf_malloc test/mfail/mfail.c:97
#       #4 0x5586b8850809 in CRYPTO_malloc crypto/mem.c:196
#       #5 0x5586b88508bb in CRYPTO_zalloc crypto/mem.c:226
#       #6 0x5586b883d5d7 in CRYPTO_calloc crypto/array_alloc.c:35
#       #7 0x5586b8cca4dd in bn_expand_internal crypto/bn/bn_lib.c:279
#       #8 0x5586b8cca7fb in bn_expand2 crypto/bn/bn_lib.c:301
#       #9 0x5586b8cd22fd in bn_wexpand crypto/bn/bn_lib.c:1147
#       #10 0x5586b8ccab62 in BN_copy crypto/bn/bn_lib.c:343
#       #11 0x5586b8cca9ce in BN_dup crypto/bn/bn_lib.c:325
#       #12 0x5586b8f193b5 in ffc_bn_cpy crypto/ffc/ffc_params.c:173
#       #13 0x5586b8f195fb in ossl_ffc_params_copy crypto/ffc/ffc_params.c:183
#       #14 0x5586b8f23681 in ossl_ffc_params_simple_validate crypto/ffc/ffc_params_validate.c:108
#       #15 0x5586b8f23c17 in ossl_ffc_params_full_validate crypto/ffc/ffc_params_validate.c:164
#       #16 0x5586b8d53cd0 in ossl_dsa_check_params crypto/dsa/dsa_check.c:59
#       #17 0x5586b8b35f96 in dsa_validate_domparams providers/implementations/keymgmt/dsa_kmgmt.c:397
#       #18 0x5586b8b3645c in dsa_validate providers/implementations/keymgmt/dsa_kmgmt.c:434
#       #19 0x5586b8802cd9 in evp_keymgmt_validate crypto/evp/keymgmt_meth.c:539
#       #20 0x5586b881777d in try_provided_check crypto/evp/pmeth_check.c:44
#       #21 0x5586b8817a46 in evp_pkey_param_check_combined crypto/evp/pmeth_check.c:86
#       #22 0x5586b8817ab8 in EVP_PKEY_param_check crypto/evp/pmeth_check.c:98
#       #23 0x5586b87b8e2e in FuzzerTestOneInput fuzz/decoder.c:78
#       #24 0x5586b87b9813 in run_mfail fuzz/test-corpus.c:64
#       #25 0x5586b87b9cb2 in testfile fuzz/test-corpus.c:102
#       #26 0x5586b87ba5b5 in main fuzz/test-corpus.c:164
#       #27 0x7f9ec022a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
#       #28 0x7f9ec022a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
#       #29 0x5586b87b88e4 in _start (/home/runner/work/openssl/openssl/fuzz/decoder-test+0xd448e4) (BuildId: 11c1813ce7a6612d66c7377c00cce34e36924175)
#   
#   # ../../fuzz/corpora/decoder/4a3b0cf277bf14b30f9a04e03cb9579aa3d85d04: point 1519/8517 hit
#   
#   =================================================================
#   ==130242==ERROR: LeakSanitizer: detected memory leaks
#   
#   Direct leak of 24 byte(s) in 1 object(s) allocated from:
#       #0 0x7f9ec0efd9c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
#       #1 0x5586b926ec3a in mf_malloc test/mfail/mfail.c:99
#       #2 0x5586b8850809 in CRYPTO_malloc crypto/mem.c:196
#       #3 0x5586b88508bb in CRYPTO_zalloc crypto/mem.c:226
#       #4 0x5586b8cca1f6 in BN_new crypto/bn/bn_lib.c:246
#       #5 0x5586b8cca9a9 in BN_dup crypto/bn/bn_lib.c:322
#       #6 0x5586b8f193b5 in ffc_bn_cpy crypto/ffc/ffc_params.c:173
#       #7 0x5586b8f19518 in ossl_ffc_params_copy crypto/ffc/ffc_params.c:182
#       #8 0x5586b8f23681 in ossl_ffc_params_simple_validate crypto/ffc/ffc_params_validate.c:108
#       #9 0x5586b8f23c17 in ossl_ffc_params_full_validate crypto/ffc/ffc_params_validate.c:164
#       #10 0x5586b8d53cd0 in ossl_dsa_check_params crypto/dsa/dsa_check.c:59
#       #11 0x5586b8b35f96 in dsa_validate_domparams providers/implementations/keymgmt/dsa_kmgmt.c:397
#       #12 0x5586b8b3645c in dsa_validate providers/implementations/keymgmt/dsa_kmgmt.c:434
#       #13 0x5586b8802cd9 in evp_keymgmt_validate crypto/evp/keymgmt_meth.c:539
#       #14 0x5586b881777d in try_provided_check crypto/evp/pmeth_check.c:44
#       #15 0x5586b8817a46 in evp_pkey_param_check_combined crypto/evp/pmeth_check.c:86
#       #16 0x5586b8817ab8 in EVP_PKEY_param_check crypto/evp/pmeth_check.c:98
#       #17 0x5586b87b8e2e in FuzzerTestOneInput fuzz/decoder.c:78
#       #18 0x5586b87b9813 in run_mfail fuzz/test-corpus.c:64
#       #19 0x5586b87b9cb2 in testfile fuzz/test-corpus.c:102
#       #20 0x5586b87ba5b5 in main fuzz/test-corpus.c:164
#       #21 0x7f9ec022a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
#       #22 0x7f9ec022a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
#       #23 0x5586b87b88e4 in _start (/home/runner/work/openssl/openssl/fuzz/decoder-test+0xd448e4) (BuildId: 11c1813ce7a6612d66c7377c00cce34e36924175)
#   
Indirect Leaks
#       #1 0x5586b926ec3a in mf_malloc test/mfail/mfail.c:99
#       #2 0x5586b8850809 in CRYPTO_malloc crypto/mem.c:196
#       #3 0x5586b88508bb in CRYPTO_zalloc crypto/mem.c:226
#       #4 0x5586b883d5d7 in CRYPTO_calloc crypto/array_alloc.c:35
#       #5 0x5586b8cca4dd in bn_expand_internal crypto/bn/bn_lib.c:279
#       #6 0x5586b8cca7fb in bn_expand2 crypto/bn/bn_lib.c:301
#       #7 0x5586b8cd22fd in bn_wexpand crypto/bn/bn_lib.c:1147
#       #8 0x5586b8ccab62 in BN_copy crypto/bn/bn_lib.c:343
#       #9 0x5586b8cca9ce in BN_dup crypto/bn/bn_lib.c:325
#       #10 0x5586b8f193b5 in ffc_bn_cpy crypto/ffc/ffc_params.c:173
#       #11 0x5586b8f19518 in ossl_ffc_params_copy crypto/ffc/ffc_params.c:182
#       #12 0x5586b8f23681 in ossl_ffc_params_simple_validate crypto/ffc/ffc_params_validate.c:108
#       #13 0x5586b8f23c17 in ossl_ffc_params_full_validate crypto/ffc/ffc_params_validate.c:164
#       #14 0x5586b8d53cd0 in ossl_dsa_check_params crypto/dsa/dsa_check.c:59
#       #15 0x5586b8b35f96 in dsa_validate_domparams providers/implementations/keymgmt/dsa_kmgmt.c:397
#       #16 0x5586b8b3645c in dsa_validate providers/implementations/keymgmt/dsa_kmgmt.c:434
#       #17 0x5586b8802cd9 in evp_keymgmt_validate crypto/evp/keymgmt_meth.c:539
#       #18 0x5586b881777d in try_provided_check crypto/evp/pmeth_check.c:44
#       #19 0x5586b8817a46 in evp_pkey_param_check_combined crypto/evp/pmeth_check.c:86
#       #20 0x5586b8817ab8 in EVP_PKEY_param_check crypto/evp/pmeth_check.c:98
#       #21 0x5586b87b8e2e in FuzzerTestOneInput fuzz/decoder.c:78
#       #22 0x5586b87b9813 in run_mfail fuzz/test-corpus.c:64
#       #23 0x5586b87b9cb2 in testfile fuzz/test-corpus.c:102
#       #24 0x5586b87ba5b5 in main fuzz/test-corpus.c:164
#       #25 0x7f9ec022a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
#       #26 0x7f9ec022a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
#       #27 0x5586b87b88e4 in _start (/home/runner/work/openssl/openssl/fuzz/decoder-test+0xd448e4) (BuildId: 11c1813ce7a6612d66c7377c00cce34e36924175)
#   
#   SUMMARY: AddressSanitizer: 536 byte(s) leaked in 2 allocation(s).

not ok 2 - Fuzzing decoder (mfail count=68, budget 154.838709677419s)
```

##### Checklist
- [x] tests are added or updated
