### PR TITLE
chacha_poly: Use IV_STATE guard to prevent IV reuse

### DIFF
--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.c
@@ -36,7 +36,6 @@ static OSSL_FUNC_cipher_final_fn chacha20_poly1305_final;
 static OSSL_FUNC_cipher_gettable_ctx_params_fn chacha20_poly1305_gettable_ctx_params;
 static OSSL_FUNC_cipher_settable_ctx_params_fn chacha20_poly1305_settable_ctx_params;
 #define chacha20_poly1305_gettable_params ossl_cipher_generic_gettable_params
-#define chacha20_poly1305_update chacha20_poly1305_cipher
 
 static void *chacha20_poly1305_newctx(void *provctx)
 {
@@ -190,6 +189,7 @@ static int chacha20_poly1305_set_ctx_params(void *vctx,
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
             return 0;
         }
+        ctx->iv_state = IV_STATE_UNINITIALISED;
     }
 
     if (p.tag != NULL) {
@@ -249,9 +249,11 @@ static int chacha20_poly1305_einit(void *vctx, const unsigned char *key,
     ret = ossl_cipher_generic_einit(vctx, key, keylen, iv, ivlen, NULL);
     if (ret && iv != NULL) {
         PROV_CIPHER_CTX *ctx = (PROV_CIPHER_CTX *)vctx;
+        PROV_CHACHA20_POLY1305_CTX *cctx = (PROV_CHACHA20_POLY1305_CTX *)vctx;
         PROV_CIPHER_HW_CHACHA20_POLY1305 *hw = (PROV_CIPHER_HW_CHACHA20_POLY1305 *)ctx->hw;
 
         hw->initiv(ctx);
+        cctx->iv_state = IV_STATE_BUFFERED;
     }
     if (ret && !chacha20_poly1305_set_ctx_params(vctx, params))
         ret = 0;
@@ -268,9 +270,11 @@ static int chacha20_poly1305_dinit(void *vctx, const unsigned char *key,
     ret = ossl_cipher_generic_dinit(vctx, key, keylen, iv, ivlen, NULL);
     if (ret && iv != NULL) {
         PROV_CIPHER_CTX *ctx = (PROV_CIPHER_CTX *)vctx;
+        PROV_CHACHA20_POLY1305_CTX *cctx = (PROV_CHACHA20_POLY1305_CTX *)vctx;
         PROV_CIPHER_HW_CHACHA20_POLY1305 *hw = (PROV_CIPHER_HW_CHACHA20_POLY1305 *)ctx->hw;
 
         hw->initiv(ctx);
+        cctx->iv_state = IV_STATE_BUFFERED;
     }
     if (ret && !chacha20_poly1305_set_ctx_params(vctx, params))
         ret = 0;
@@ -303,6 +307,18 @@ static int chacha20_poly1305_cipher(void *vctx, unsigned char *out,
     return 1;
 }
 
+static int chacha20_poly1305_update(void *vctx, unsigned char *out,
+    size_t *outl, size_t outsize,
+    const unsigned char *in, size_t inl)
+{
+    PROV_CHACHA20_POLY1305_CTX *ctx = (PROV_CHACHA20_POLY1305_CTX *)vctx;
+
+    if (ctx->iv_state == IV_STATE_FINISHED)
+        return 0;
+
+    return chacha20_poly1305_cipher(vctx, out, outl, outsize, in, inl);
+}
+
 static int chacha20_poly1305_final(void *vctx, unsigned char *out, size_t *outl,
     size_t outsize)
 {
@@ -322,6 +338,9 @@ static int chacha20_poly1305_final(void *vctx, unsigned char *out, size_t *outl,
         return 0;
 
     *outl = 0;
+
+    /* Don't reuse the IV */
+    ctx->iv_state = IV_STATE_FINISHED;
     return 1;
 }
 

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.h
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.h
@@ -33,6 +33,7 @@ typedef struct {
     size_t tag_len;
     size_t tls_payload_length;
     size_t tls_aad_pad_sz;
+    unsigned int iv_state; /* set to one of IV_STATE_XXX */
 } PROV_CHACHA20_POLY1305_CTX;
 
 typedef struct prov_cipher_hw_chacha_aead_st {

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -6463,6 +6463,59 @@ err:
     return res;
 }
 
+static const char *iv_state_ciphers[] = {
+    "AES-256-GCM",
+#ifndef OPENSSL_NO_OCB
+    "AES-256-OCB",
+#endif
+#if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
+    "ChaCha20-Poly1305",
+#endif
+};
+
+/* Negative test for IV_STATE_FINISHED (avoid IV reuse) */
+static int test_iv_reuse(int idx)
+{
+    int outlen;
+    int res = 0;
+    unsigned char outbuf[64];
+    EVP_CIPHER_CTX *ctx = NULL;
+    EVP_CIPHER *ciph = NULL;
+
+    if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new()))
+        goto err;
+
+    if (!TEST_ptr(ciph = EVP_CIPHER_fetch(testctx, iv_state_ciphers[idx],
+                      testpropq)))
+        goto err;
+
+    /* Use the cipher: Init, Update, Final. */
+    if (!TEST_true(EVP_EncryptInit_ex2(ctx, ciph, kGCMDefaultKey,
+            iGCMDefaultIV, NULL)))
+        goto err;
+    if (!TEST_true(EVP_EncryptUpdate(ctx, outbuf, &outlen, gcmDefaultPlaintext,
+            sizeof(gcmDefaultPlaintext))))
+        goto err;
+    if (!TEST_true(EVP_EncryptFinal_ex(ctx, outbuf, &outlen)))
+        goto err;
+
+    /* Without IV change, EncryptUpdate must be rejected */
+    ERR_set_mark();
+    if (!TEST_false(EVP_EncryptUpdate(ctx, outbuf, &outlen,
+            gcmDefaultPlaintext,
+            sizeof(gcmDefaultPlaintext)))) {
+        ERR_clear_last_mark();
+        goto err;
+    }
+    ERR_pop_to_mark();
+
+    res = 1;
+err:
+    EVP_CIPHER_CTX_free(ctx);
+    EVP_CIPHER_free(ciph);
+    return res;
+}
+
 static const char *keylen_change_ciphers[] = {
 #ifndef OPENSSL_NO_BF
     "BF-ECB",
@@ -7960,6 +8013,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_evp_final_no_tag, OSSL_NELEM(evp_final_no_tag));
 
     ADD_ALL_TESTS(test_ivlen_change, OSSL_NELEM(ivlen_change_ciphers));
+    ADD_ALL_TESTS(test_iv_reuse, OSSL_NELEM(iv_state_ciphers));
     if (OSSL_NELEM(keylen_change_ciphers) - 1 > 0)
         ADD_ALL_TESTS(test_keylen_change, OSSL_NELEM(keylen_change_ciphers) - 1);
 


### PR DESCRIPTION
If IV was set for Chacha20-Poly1305, code should not allow reusing IV after calling CipherFinal.
Use iv_state (as used in GCM or OCB mode) to prevent that.

The second patch adds test for IV reuse in AEAD providers.

