### PR TITLE
ossl_quic_new client mfail issues

### DIFF
--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -691,6 +691,9 @@ static void quic_unref_port_bios(QUIC_PORT *port)
 {
     BIO *b;
 
+    if (port == NULL)
+        return;
+
     b = ossl_quic_port_get_net_rbio(port);
     BIO_free_all(b);
 
@@ -1871,6 +1874,7 @@ static int create_channel(QUIC_CONNECTION *qc, SSL_CTX *ctx)
     if (qc->port == NULL) {
         QUIC_RAISE_NON_NORMAL_ERROR(NULL, ERR_R_INTERNAL_ERROR, NULL);
         ossl_quic_engine_free(qc->engine);
+        qc->engine = NULL;
         return 0;
     }
 
@@ -1878,7 +1882,9 @@ static int create_channel(QUIC_CONNECTION *qc, SSL_CTX *ctx)
     if (qc->ch == NULL) {
         QUIC_RAISE_NON_NORMAL_ERROR(NULL, ERR_R_INTERNAL_ERROR, NULL);
         ossl_quic_port_free(qc->port);
+        qc->port = NULL;
         ossl_quic_engine_free(qc->engine);
+        qc->engine = NULL;
         return 0;
     }
 


### PR DESCRIPTION
This fixes memory failure issues in ossl_quic_new.

There were two issues:
- UAF if QUIC channel init fails
- missing QUIC stream map lh result check

The MFAIL tests cover both cases but as usual the test is just for master. The actual fixes should be backported.

This was found using #30944 . The backtraces can be provided on request (they are quite big so not copying them to description).

##### Checklist
- [x] tests are added or updated
