### PR TITLE
asn1_d2i_read_bio(): Fix shadowing of declaration of i [3.5]

### DIFF
--- a/crypto/asn1/a_d2i_fp.c
+++ b/crypto/asn1/a_d2i_fp.c
@@ -166,15 +166,15 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
 
         diff--;
         if ((*(q++) & V_ASN1_PRIMITIVE_TAG) == V_ASN1_PRIMITIVE_TAG) {
-            unsigned int i = 0;
+            unsigned int n = 0;
             /* Multi-byte tag.  See if we have the whole thing yet */
             do {
-                if (i > 4) {
+                if (n > 4) {
                     /* The tag value must fit into int */
                     ERR_raise(ERR_LIB_ASN1, ASN1_R_HEADER_TOO_LONG);
                     goto err;
                 }
-                ++i;
+                ++n;
                 diff--;
             } while (diff > 0 && *(q++) & 0x80);
 


### PR DESCRIPTION
Rename inner declaration of `i` variable to `n`.

This is urgent fix to for broken CI on 3.5 and older branches.