### PR TITLE
`cmp_client_test.c`: fix partly too generous `total_timeout` limit for IR session with polling

### DIFF
--- a/test/cmp_client_test.c
+++ b/test/cmp_client_test.c
@@ -254,7 +254,9 @@ static int test_exec_REQ_ses_poll(int req_type, int check_after,
     return result;
 }
 
-static int checkAfter = 1;
+static const int checkAfter = 1;
+static const int pollCount = 3;
+
 static int test_exec_IR_ses_poll_ok(void)
 {
     return test_exec_REQ_ses_poll(OSSL_CMP_PKIBODY_IR, checkAfter, 2, 0,
@@ -272,7 +274,7 @@ static int test_exec_IR_ses_poll_no_timeout(void)
 static int test_exec_IR_ses_poll_total_timeout(void)
 {
     return test_exec_REQ_ses_poll(OSSL_CMP_PKIBODY_IR, checkAfter,
-        3 /* pollCount */, checkAfter + 4,
+        pollCount, (pollCount - 1) * checkAfter,
         OSSL_CMP_PKISTATUS_trans);
 }
 
@@ -482,7 +484,7 @@ static int test_exec_GENM_ses_poll_no_timeout(void)
 static int test_exec_GENM_ses_poll_total_timeout(void)
 {
     return test_exec_REQ_ses_poll(OSSL_CMP_PKIBODY_GENM, checkAfter,
-        3 /* pollCount */, checkAfter + 2,
+        pollCount, (pollCount - 1) * checkAfter,
         OSSL_CMP_PKISTATUS_trans);
 }
 


### PR DESCRIPTION
This fixes a rare race condition (which occasionally occurs apparently mostly with Windows builds)
causing `test_exec_IR_ses_poll_total_timeout()` to fail when the `total_timeout` limit is not reached.

This happened today as [mentioned here](https://github.com/openssl/openssl/pull/31106#issuecomment-4397088437), leading to a f[ailed CI run](https://github.com/openssl/openssl/actions/runs/25493155133/job/74806033039?pr=31106) with this log output:
```
    # CMP info: received IP
    # CMP info: received 'waiting' PKIStatus, starting to poll for response
    # CMP info: received POLLREP
    # CMP info: received polling response; checkAfter = 2 seconds
    # CMP info: received POLLREP
    # CMP info: received polling response; checkAfter = 2 seconds
    # CMP error: total timeout
    # CMP error: polling failed
    # OPENSSL_TEST_RAND_SEED=1778154728
    not ok 9 - test_exec_IR_ses_poll_total_timeout
```

The fix is to tighten the timeout limit such that there is no chance for the given number of polling round-trips to finish before.

On this occasion, introducing the named constant `static int pollCount = 3`
and using it in the calculation of the limit value.
Note that for `test_exec_GENM_ses_poll_total_timeout()` the value does not actually change because there it was already tight enough.
