### PR TITLE
ossl_quic_new_listener memory failure issues

### DIFF
--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -4679,7 +4679,7 @@ SSL *ossl_quic_new_listener(SSL_CTX *ctx, uint64_t flags)
 
     if ((ql = OPENSSL_zalloc(sizeof(*ql))) == NULL) {
         QUIC_RAISE_NON_NORMAL_ERROR(NULL, ERR_R_CRYPTO_LIB, NULL);
-        goto err;
+        return NULL;
     }
 
 #if defined(OPENSSL_THREADS)
@@ -4727,8 +4727,8 @@ SSL *ossl_quic_new_listener(SSL_CTX *ctx, uint64_t flags)
     return &ql->obj.ssl;
 
 err:
-    if (ql != NULL)
-        ossl_quic_engine_free(ql->engine);
+    ossl_quic_port_free(ql->port);
+    ossl_quic_engine_free(ql->engine);
 
 #if defined(OPENSSL_THREADS)
     ossl_crypto_mutex_free(&ql->mutex);


### PR DESCRIPTION
This fixes null deref in ossl_quic_new_listener that is caused by incorrect err cleanup of mutex even if ql does not exist
(allocation failed).

It also fixes missing freeing of ports that result in assertion failure because engine port list is not empty.

The issue is present in 3.5 so the fix can be backported there but the test is just for master.

This was found using #30944 

##### Checklist
- [x] tests are added or updated
