### PR TITLE
Update openssl-s_client.pod.in

### DIFF
--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -726,9 +726,6 @@ The I<protocols> list is a comma-separated list of protocol names that
 the client should advertise support for. The list should contain the most
 desirable protocols first.  Protocol names are printable ASCII strings,
 for example "http/1.1" or "spdy/3".
-An empty list of protocols is treated specially and will cause the
-client to advertise support for the TLS extension but disconnect just
-after receiving ServerHello with a list of server supported protocols.
 The flag B<-nextprotoneg> cannot be specified if B<-tls1_3> is used.
 
 =item B<-ct>, B<-noct>


### PR DESCRIPTION
Removed "An empty list of protocols is treated specially and will cause the client to advertise support for the TLS extension but disconnect just after receiving ServerHello with a list of server supported protocols." from openssl-s_client documentation as this functionality was removed in [e78253f](https://github.com/openssl/openssl/commit/e78253f2d0c1a9fe6b023d867ee02342b4560150). 

Fixes issue #31088

CLA: trivial

- [x] documentation is added or updated
