### PR TITLE
BIO dgram pair leak

### DIFF
--- a/crypto/bio/bss_dgram_pair.c
+++ b/crypto/bio/bss_dgram_pair.c
@@ -305,6 +305,7 @@ static int dgram_mem_init(BIO *bio)
     b = bio->ptr;
 
     if (ring_buf_init(&b->rbuf, b->req_buf_len) == 0) {
+        dgram_pair_free(bio);
         ERR_raise(ERR_LIB_BIO, ERR_R_BIO_LIB);
         return 0;
     }

--- a/test/bio_dgram_test.c
+++ b/test/bio_dgram_test.c
@@ -776,6 +776,22 @@ err:
     return testresult;
 }
 #endif /* !defined(OPENSSL_NO_CHACHA) */
+
+static int test_bio_dgram_mfail(void)
+{
+    BIO *bio;
+
+    MFAIL_start();
+    bio = BIO_new(BIO_s_dgram_mem());
+    MFAIL_end();
+
+    if (bio == NULL)
+        return 0;
+
+    BIO_free(bio);
+    return 1;
+}
+
 #endif /* !defined(OPENSSL_NO_DGRAM) && !defined(OPENSSL_NO_SOCK) */
 
 int setup_tests(void)
@@ -790,6 +806,7 @@ int setup_tests(void)
 #if !defined(OPENSSL_NO_CHACHA)
     ADD_ALL_TESTS(test_bio_dgram_pair, 3);
 #endif
+    ADD_MFAIL_TEST(test_bio_dgram_mfail);
 #endif
 
     return 1;


### PR DESCRIPTION
The created pair in dgram_mem_init is not freed if ring buf init fails.

This was found using #30944 where the leak is visible for the DTLS client and server tests.

##### Checklist
- [x] tests are added or updated
