### PR TITLE
Fix OOB read in EC_GROUP_new_from_params() with zero-length generator

### DIFF
--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -1731,7 +1731,8 @@ EC_GROUP *EC_GROUP_new_from_params(const OSSL_PARAM params[],
     /* generator base point */
     ptmp = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_EC_GENERATOR);
     if (ptmp == NULL
-        || ptmp->data_type != OSSL_PARAM_OCTET_STRING) {
+        || ptmp->data_type != OSSL_PARAM_OCTET_STRING
+        || ptmp->data_size == 0) {
         ERR_raise(ERR_LIB_EC, EC_R_INVALID_GENERATOR);
         goto err;
     }


### PR DESCRIPTION
When OSSL_PKEY_PARAM_EC_GENERATOR is provided as an octet string of length 0, buf[0] is read before validating data_size, causing a heap-buffer-overflow detectable under ASan.

Reject zero-length generator octet strings before the dereference.

Fixes #31125

CLA: trivial