### PR TITLE
quic: fix missing call to ossl_ackm_on_rx_packet fix #31134

### DIFF
--- a/ssl/quic/quic_rx_depack.c
+++ b/ssl/quic/quic_rx_depack.c
@@ -1465,15 +1465,16 @@ int ossl_quic_handle_frames(QUIC_CHANNEL *ch, OSSL_QRX_PKT *qpacket)
     else
         ossl_quic_tx_packetiser_add_unvalidated_credit(ch->txp, dgram_len);
 
+    int ok = 1;
     /* Now that special cases are out of the way, parse frames */
     if (!PACKET_buf_init(&pkt, qpacket->hdr->data, qpacket->hdr->len)
         || !depack_process_frames(ch, &pkt, qpacket,
             enc_level,
             qpacket->time,
             &ackm_data))
-        return 0;
+        ok = 0;
 
     ossl_ackm_on_rx_packet(ch->ackm, &ackm_data);
 
-    return 1;
+    return ok;
 }


### PR DESCRIPTION
Minimum fix to restore performance in QUIC after 9c047dc1361a75f808749b3267d67b1bc16d82fd.

Tested in 3.5.x and 3.6.x.

This is my first patch for this tree, please let me know of any changes required for the project style.