### PR TITLE
Revert "Add various MFAIL tests to excercise ht insert"

### DIFF
--- a/test/lhash_test.c
+++ b/test/lhash_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2026 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2017-2025 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2017, Oracle and/or its affiliates.  All rights reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
@@ -300,43 +300,6 @@ static int test_int_hashtable(int idx)
 end:
     ossl_ht_free(ht);
     return rc;
-}
-
-/*
- * MFAIL coverage for the RCU replacement branch of ossl_ht_insert_locked.
- */
-static int test_hashtable_insert_replace_mfail(void)
-{
-    HT_CONFIG hash_conf = {
-        .collision_check = 1,
-        .no_rcu = 0, /* RCU enabled - exercises cbi pre-alloc on replace */
-    };
-    INTKEY key;
-    HT *ht = NULL;
-    int *old = NULL;
-    int ret = 0;
-    static int v1 = 100;
-    static int v2 = 200;
-
-    if (!TEST_ptr(ht = ossl_ht_new(&hash_conf)))
-        goto end;
-
-    /* Seed the table outside MFAIL for later replacement */
-    HT_INIT_KEY(&key);
-    HT_KEY_RESET(&key);
-    HT_SET_KEY_FIELD(&key, mykey, int_tests[0]);
-    if (!TEST_int_eq(ossl_ht_test_int_insert(ht, TO_HT_KEY(&key), &v1, NULL),
-            1))
-        goto end;
-
-    /* Replacement under MFAIL. */
-    MFAIL_start();
-    ret = ossl_ht_test_int_insert(ht, TO_HT_KEY(&key), &v2, &old);
-    MFAIL_end();
-
-end:
-    ossl_ht_free(ht);
-    return ret > 0 ? 1 : 0;
 }
 
 static unsigned long int stress_hash(const int *p)
@@ -832,6 +795,5 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_int_hashtable, 2);
     ADD_ALL_TESTS(test_hashtable_stress, 4);
     ADD_ALL_TESTS(test_hashtable_multithread, 2);
-    ADD_MFAIL_TEST(test_hashtable_insert_replace_mfail);
     return 1;
 }

--- a/test/namemap_internal_test.c
+++ b/test/namemap_internal_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2026 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2019-2024 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -170,27 +170,6 @@ static int test_digest_is_a(void)
     return rv;
 }
 
-/*
- * Test memory failures for ossl_namemap_add_name.
- */
-static int test_namemap_add_name_mfail(void)
-{
-    OSSL_NAMEMAP *nm = NULL;
-    int ret = 0;
-
-    nm = ossl_namemap_new(NULL);
-    if (!TEST_ptr(nm))
-        goto err;
-
-    MFAIL_start();
-    ret = ossl_namemap_add_name(nm, 0, "mfail_test_name");
-    MFAIL_end();
-
-err:
-    ossl_namemap_free(nm);
-    return ret;
-}
-
 int setup_tests(void)
 {
     ADD_TEST(test_namemap_empty);
@@ -200,6 +179,5 @@ int setup_tests(void)
     ADD_TEST(test_cipherbyname);
     ADD_TEST(test_digest_is_a);
     ADD_TEST(test_cipher_is_a);
-    ADD_MFAIL_TEST(test_namemap_add_name_mfail);
     return 1;
 }

--- a/test/x509_load_cert_file_test.c
+++ b/test/x509_load_cert_file_test.c
@@ -172,32 +172,6 @@ err:
     return ret;
 }
 
-/*
- * Test to trigger memory failures in X509_STORE_add_cert.
- */
-static int test_x509_store_add_mfail(void)
-{
-    X509 *cert = NULL;
-    X509_STORE *store = NULL;
-    int ret = 0;
-
-    cert = X509_from_strings(cn_cert1);
-    if (!TEST_ptr(cert))
-        goto err;
-    store = X509_STORE_new();
-    if (!TEST_ptr(store))
-        goto err;
-
-    MFAIL_start();
-    ret = X509_STORE_add_cert(store, cert);
-    MFAIL_end();
-
-err:
-    X509_STORE_free(store);
-    X509_free(cert);
-    return ret;
-}
-
 OPT_TEST_DECLARE_USAGE("cert.pem [crl.pem]\n")
 
 int setup_tests(void)
@@ -215,7 +189,6 @@ int setup_tests(void)
 
     ADD_TEST(test_load_cert_file);
     ADD_TEST(test_load_same_cn_certs);
-    ADD_MFAIL_TEST(test_x509_store_add_mfail);
 
     return 1;
 }


### PR DESCRIPTION
This reverts commit 97388384996138d9b4e70aba58c0de9f4de3e1e2.

The mfail framework is not present in 4.0 branch.

This is urgent as the CI is broken.