### PR TITLE
doc/man7/EVP_CIPHER-DES.pod: remove trailing whitespace

### DIFF
--- a/doc/man7/EVP_CIPHER-DES.pod
+++ b/doc/man7/EVP_CIPHER-DES.pod
@@ -62,11 +62,11 @@ This implementation supports the parameters described in
 L<EVP_EncryptInit(3)/PARAMETERS> including "encrypt-check" and "fips-indicator".
 
 =head1 NOTES
- 
+
 The DES3-WRAP implementation does not support streaming. That means to obtain
 correct results there can be only one L<EVP_EncryptUpdate(3)> or
 L<EVP_DecryptUpdate(3)> call after the initialization of the context.
- 
+
 When wrapping (encrypting) with DES3-WRAP, the output buffer must be at least
 I<input_length> + 16 bytes. The extra 16 bytes accommodate an 8-byte IV and an
 8-byte integrity check value (ICV) prepended and appended by the algorithm.


### PR DESCRIPTION
Remove trailing whitespace to address the following find-doc-nits warnings:

    WARNING: line containing nothing but whitespace in paragraph at line 65 in file doc/man7/EVP_CIPHER-DES.pod
    WARNING: line containing nothing but whitespace in paragraph at line 69 in file doc/man7/EVP_CIPHER-DES.pod

Fixes: 5ff19a7297ea "docs: Document required output buffer length in EVP_CIPHER-DES"