### PR TITLE
Refcount mitigation and opportunistic removal for EVP objects

### DIFF
--- a/crypto/context.c
+++ b/crypto/context.c
@@ -255,12 +255,6 @@ err:
 
 static void context_deinit_objs(OSSL_LIB_CTX *ctx)
 {
-    /* P2. We want evp_method_store to be cleaned up before the provider store */
-    if (ctx->evp_method_store != NULL) {
-        ossl_method_store_free(ctx->evp_method_store);
-        ctx->evp_method_store = NULL;
-    }
-
     /* P2. */
     if (ctx->drbg != NULL) {
         ossl_rand_ctx_free(ctx->drbg);
@@ -278,13 +272,13 @@ static void context_deinit_objs(OSSL_LIB_CTX *ctx)
      * P2. We want decoder_store/decoder_cache to be cleaned up before the
      * provider store
      */
-    if (ctx->decoder_store != NULL) {
-        ossl_method_store_free(ctx->decoder_store);
-        ctx->decoder_store = NULL;
-    }
     if (ctx->decoder_cache != NULL) {
         ossl_decoder_cache_free(ctx->decoder_cache);
         ctx->decoder_cache = NULL;
+    }
+    if (ctx->decoder_store != NULL) {
+        ossl_method_store_free(ctx->decoder_store);
+        ctx->decoder_store = NULL;
     }
 
     /* P2. We want encoder_store to be cleaned up before the provider store */
@@ -304,6 +298,12 @@ static void context_deinit_objs(OSSL_LIB_CTX *ctx)
     if (ctx->provider_store != NULL) {
         ossl_provider_store_free(ctx->provider_store);
         ctx->provider_store = NULL;
+    }
+
+    /* P2. We want evp_method_store to be cleaned up before the provider store */
+    if (ctx->evp_method_store != NULL) {
+        ossl_method_store_free(ctx->evp_method_store);
+        ctx->evp_method_store = NULL;
     }
 
     /* Default priority. */

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -26,12 +26,29 @@
 
 static void ossl_decoder_free(void *data)
 {
-    OSSL_DECODER_free(data);
+    OSSL_DECODER *decoder = (OSSL_DECODER *)data;
+    int ref = 0;
+
+    if (decoder == NULL)
+        return;
+
+    CRYPTO_DOWN_REF(&decoder->base.refcnt, &ref);
+    if (ref > 0)
+        return;
+    OPENSSL_free(decoder->base.name);
+    ossl_property_free(decoder->base.parsed_propdef);
+    ossl_provider_free(decoder->base.prov);
+    CRYPTO_FREE_REF(&decoder->base.refcnt);
+    OPENSSL_free(decoder);
 }
 
 static int ossl_decoder_up_ref(void *data)
 {
-    return OSSL_DECODER_up_ref(data);
+    OSSL_DECODER *decoder = (OSSL_DECODER *)data;
+    int ref = 0;
+
+    CRYPTO_UP_REF(&decoder->base.refcnt, &ref);
+    return 1;
 }
 
 /* Simple method structure constructor and destructor */
@@ -51,27 +68,23 @@ static OSSL_DECODER *ossl_decoder_new(void)
 
 int OSSL_DECODER_up_ref(OSSL_DECODER *decoder)
 {
-    int ref = 0;
-
-    CRYPTO_UP_REF(&decoder->base.refcnt, &ref);
+#ifdef OSSL_DECODER_fetch
+    return ossl_decoder_up_ref(decoder);
+#else
+    if (decoder->base.id == 0)
+        return ossl_decoder_up_ref(decoder);
     return 1;
+#endif
 }
 
 void OSSL_DECODER_free(OSSL_DECODER *decoder)
 {
-    int ref = 0;
-
-    if (decoder == NULL)
-        return;
-
-    CRYPTO_DOWN_REF(&decoder->base.refcnt, &ref);
-    if (ref > 0)
-        return;
-    OPENSSL_free(decoder->base.name);
-    ossl_property_free(decoder->base.parsed_propdef);
-    ossl_provider_free(decoder->base.prov);
-    CRYPTO_FREE_REF(&decoder->base.refcnt);
-    OPENSSL_free(decoder);
+#ifdef OSSL_DECODER_fetch
+    ossl_decoder_free(decoder);
+#else
+    if (decoder != NULL && decoder->base.id == 0)
+        ossl_decoder_free(decoder);
+#endif
 }
 
 /* Data to be passed through ossl_method_construct() */

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -59,7 +59,7 @@ static OSSL_DECODER *ossl_decoder_new(void)
     if ((decoder = OPENSSL_zalloc(sizeof(*decoder))) == NULL)
         return NULL;
     if (!CRYPTO_NEW_REF(&decoder->base.refcnt, 1)) {
-        OSSL_DECODER_free(decoder);
+        ossl_decoder_free(decoder);
         return NULL;
     }
 
@@ -68,9 +68,17 @@ static OSSL_DECODER *ossl_decoder_new(void)
 
 int OSSL_DECODER_up_ref(OSSL_DECODER *decoder)
 {
-#ifdef OSSL_DECODER_fetch
+#ifdef OPENSSL_NO_CACHED_FETCH
     return ossl_decoder_up_ref(decoder);
 #else
+    /*
+     * DECODERS do something weird.  They manually build methods rather than
+     * attempt to fetch them from the method store or construct them through
+     * the ossl_generic_fetch mechanism.  As such they don't make use of the refcounting
+     * that we rely on in the method store, and so we always need to refcount them here
+     * We can identify them based on the fact that they never have a registered nid (i.e.
+     * its always zero)
+     */
     if (decoder->base.id == 0)
         return ossl_decoder_up_ref(decoder);
     return 1;
@@ -79,7 +87,7 @@ int OSSL_DECODER_up_ref(OSSL_DECODER *decoder)
 
 void OSSL_DECODER_free(OSSL_DECODER *decoder)
 {
-#ifdef OSSL_DECODER_fetch
+#ifdef OPENSSL_NO_CACHED_FETCH
     ossl_decoder_free(decoder);
 #else
     if (decoder != NULL && decoder->base.id == 0)
@@ -230,14 +238,14 @@ void *ossl_decoder_from_algorithm(int id, const OSSL_ALGORITHM *algodef,
         return NULL;
     decoder->base.id = id;
     if ((decoder->base.name = ossl_algorithm_get1_first_name(algodef)) == NULL) {
-        OSSL_DECODER_free(decoder);
+        ossl_decoder_free(decoder);
         return NULL;
     }
     decoder->base.algodef = algodef;
     if ((decoder->base.parsed_propdef
             = ossl_parse_property(libctx, algodef->property_definition))
         == NULL) {
-        OSSL_DECODER_free(decoder);
+        ossl_decoder_free(decoder);
         return NULL;
     }
 
@@ -289,13 +297,13 @@ void *ossl_decoder_from_algorithm(int id, const OSSL_ALGORITHM *algodef,
     if (!((decoder->newctx == NULL && decoder->freectx == NULL)
             || (decoder->newctx != NULL && decoder->freectx != NULL))
         || decoder->decode == NULL) {
-        OSSL_DECODER_free(decoder);
+        ossl_decoder_free(decoder);
         ERR_raise(ERR_LIB_OSSL_DECODER, ERR_R_INVALID_PROVIDER_FUNCTIONS);
         return NULL;
     }
 
     if (prov != NULL && !ossl_provider_up_ref(prov)) {
-        OSSL_DECODER_free(decoder);
+        ossl_decoder_free(decoder);
         return NULL;
     }
 
@@ -341,17 +349,7 @@ static void *construct_decoder(const OSSL_ALGORITHM *algodef,
 /* Intermediary function to avoid ugly casts, used below */
 static void destruct_decoder(void *method, void *data)
 {
-    OSSL_DECODER_free(method);
-}
-
-static int up_ref_decoder(void *method)
-{
-    return OSSL_DECODER_up_ref(method);
-}
-
-static void free_decoder(void *method)
-{
-    OSSL_DECODER_free(method);
+    ossl_decoder_free(method);
 }
 
 /* Fetching support.  Can fetch by numeric identity or by name */
@@ -409,7 +407,7 @@ inner_ossl_decoder_fetch(struct decoder_data_st *methdata,
                 id = ossl_namemap_name2num(namemap, name);
             if (id != 0)
                 ossl_method_store_cache_set(store, prov, id, propq, method,
-                    up_ref_decoder, free_decoder);
+                    ossl_decoder_up_ref, ossl_decoder_free);
         }
 
         /*

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -27,12 +27,29 @@
 
 static void ossl_encoder_free(void *data)
 {
-    OSSL_ENCODER_free(data);
+    OSSL_ENCODER *encoder = (OSSL_ENCODER *)data;
+    int ref = 0;
+
+    if (encoder == NULL)
+        return;
+
+    CRYPTO_DOWN_REF(&encoder->base.refcnt, &ref);
+    if (ref > 0)
+        return;
+    OPENSSL_free(encoder->base.name);
+    ossl_property_free(encoder->base.parsed_propdef);
+    ossl_provider_free(encoder->base.prov);
+    CRYPTO_FREE_REF(&encoder->base.refcnt);
+    OPENSSL_free(encoder);
 }
 
 static int ossl_encoder_up_ref(void *data)
 {
-    return OSSL_ENCODER_up_ref(data);
+    OSSL_ENCODER *encoder = (OSSL_ENCODER *)data;
+    int ref = 0;
+
+    CRYPTO_UP_REF(&encoder->base.refcnt, &ref);
+    return 1;
 }
 
 /* Simple method structure constructor and destructor */
@@ -56,6 +73,7 @@ int OSSL_ENCODER_up_ref(OSSL_ENCODER *encoder)
     return ossl_encoder_up_ref(encoder);
 #else
     return 1;
+#endif
 }
 
 void OSSL_ENCODER_free(OSSL_ENCODER *encoder)
@@ -208,14 +226,14 @@ static void *encoder_from_algorithm(int id, const OSSL_ALGORITHM *algodef,
         return NULL;
     encoder->base.id = id;
     if ((encoder->base.name = ossl_algorithm_get1_first_name(algodef)) == NULL) {
-        OSSL_ENCODER_free(encoder);
+        ossl_encoder_free(encoder);
         return NULL;
     }
     encoder->base.algodef = algodef;
     if ((encoder->base.parsed_propdef
             = ossl_parse_property(libctx, algodef->property_definition))
         == NULL) {
-        OSSL_ENCODER_free(encoder);
+        ossl_encoder_free(encoder);
         return NULL;
     }
 
@@ -273,13 +291,13 @@ static void *encoder_from_algorithm(int id, const OSSL_ALGORITHM *algodef,
             || (encoder->import_object != NULL && encoder->free_object != NULL)
             || (encoder->import_object == NULL && encoder->free_object == NULL))
         || encoder->encode == NULL) {
-        OSSL_ENCODER_free(encoder);
+        ossl_encoder_free(encoder);
         ERR_raise(ERR_LIB_OSSL_ENCODER, ERR_R_INVALID_PROVIDER_FUNCTIONS);
         return NULL;
     }
 
     if (prov != NULL && !ossl_provider_up_ref(prov)) {
-        OSSL_ENCODER_free(encoder);
+        ossl_encoder_free(encoder);
         return NULL;
     }
 
@@ -325,17 +343,7 @@ static void *construct_encoder(const OSSL_ALGORITHM *algodef,
 /* Intermediary function to avoid ugly casts, used below */
 static void destruct_encoder(void *method, void *data)
 {
-    OSSL_ENCODER_free(method);
-}
-
-static int up_ref_encoder(void *method)
-{
-    return OSSL_ENCODER_up_ref(method);
-}
-
-static void free_encoder(void *method)
-{
-    OSSL_ENCODER_free(method);
+    ossl_encoder_free(method);
 }
 
 /* Fetching support.  Can fetch by numeric identity or by name */
@@ -392,7 +400,7 @@ inner_ossl_encoder_fetch(struct encoder_data_st *methdata,
             if (id == 0)
                 id = ossl_namemap_name2num(namemap, name);
             ossl_method_store_cache_set(store, prov, id, propq, method,
-                up_ref_encoder, free_encoder);
+                ossl_encoder_up_ref, ossl_encoder_free);
         }
 
         /*

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -52,27 +52,17 @@ static OSSL_ENCODER *ossl_encoder_new(void)
 
 int OSSL_ENCODER_up_ref(OSSL_ENCODER *encoder)
 {
-    int ref = 0;
-
-    CRYPTO_UP_REF(&encoder->base.refcnt, &ref);
+#ifdef OPENSSL_NO_CACHED_FETCH
+    return ossl_encoder_up_ref(encoder);
+#else
     return 1;
 }
 
 void OSSL_ENCODER_free(OSSL_ENCODER *encoder)
 {
-    int ref = 0;
-
-    if (encoder == NULL)
-        return;
-
-    CRYPTO_DOWN_REF(&encoder->base.refcnt, &ref);
-    if (ref > 0)
-        return;
-    OPENSSL_free(encoder->base.name);
-    ossl_property_free(encoder->base.parsed_propdef);
-    ossl_provider_free(encoder->base.prov);
-    CRYPTO_FREE_REF(&encoder->base.refcnt);
-    OPENSSL_free(encoder);
+#ifdef OPENSSL_NO_CACHED_FETCH
+    ossl_encoder_free(encoder);
+#endif
 }
 
 /* Data to be passed through ossl_method_construct() */

--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -19,12 +19,27 @@
 
 static void evp_asym_cipher_free(void *data)
 {
-    EVP_ASYM_CIPHER_free(data);
+    EVP_ASYM_CIPHER *cipher = (EVP_ASYM_CIPHER *)data;
+    int i;
+
+    if (cipher == NULL)
+        return;
+    CRYPTO_DOWN_REF(&cipher->refcnt, &i);
+    if (i > 0)
+        return;
+    OPENSSL_free(cipher->type_name);
+    ossl_provider_free(cipher->prov);
+    CRYPTO_FREE_REF(&cipher->refcnt);
+    OPENSSL_free(cipher);
 }
 
 static int evp_asym_cipher_up_ref(void *data)
 {
-    return EVP_ASYM_CIPHER_up_ref(data);
+    EVP_ASYM_CIPHER *cipher = (EVP_ASYM_CIPHER *)data;
+    int ref = 0;
+
+    CRYPTO_UP_REF(&cipher->refcnt, &ref);
+    return 1;
 }
 
 static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation,
@@ -444,25 +459,18 @@ err:
 
 void EVP_ASYM_CIPHER_free(EVP_ASYM_CIPHER *cipher)
 {
-    int i;
-
-    if (cipher == NULL)
-        return;
-    CRYPTO_DOWN_REF(&cipher->refcnt, &i);
-    if (i > 0)
-        return;
-    OPENSSL_free(cipher->type_name);
-    ossl_provider_free(cipher->prov);
-    CRYPTO_FREE_REF(&cipher->refcnt);
-    OPENSSL_free(cipher);
+#ifdef OPENSSL_NO_CACHED_FETCH
+    evp_asym_cipher_free(cipher);
+#endif
 }
 
 int EVP_ASYM_CIPHER_up_ref(EVP_ASYM_CIPHER *cipher)
 {
-    int ref = 0;
-
-    CRYPTO_UP_REF(&cipher->refcnt, &ref);
+#ifdef OPENSSL_NO_CACHED_FETCH
+    return evp_asym_cipher_up_ref(cipher);
+#else
     return 1;
+#endif
 }
 
 OSSL_PROVIDER *EVP_ASYM_CIPHER_get0_provider(const EVP_ASYM_CIPHER *cipher)

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -23,6 +23,8 @@
 
 #include <crypto/asn1.h>
 
+static void evp_md_free(void *m);
+
 void evp_md_ctx_clear_digest(EVP_MD_CTX *ctx, int force, int keep_fetched)
 {
     if (ctx->algctx != NULL) {
@@ -965,31 +967,13 @@ static void *evp_md_from_algorithm(int name_id,
     return md;
 
 err:
-    EVP_MD_free(md);
+    evp_md_free(md);
     return NULL;
 }
 
-static int evp_md_up_ref(void *md)
+static int evp_md_up_ref(void *m)
 {
-    return EVP_MD_up_ref(md);
-}
-
-static void evp_md_free(void *md)
-{
-    EVP_MD_free(md);
-}
-
-EVP_MD *EVP_MD_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
-    const char *properties)
-{
-    EVP_MD *md = evp_generic_fetch(ctx, OSSL_OP_DIGEST, algorithm, properties,
-        evp_md_from_algorithm, evp_md_up_ref, evp_md_free);
-
-    return md;
-}
-
-int EVP_MD_up_ref(EVP_MD *md)
-{
+    EVP_MD *md = (EVP_MD *)m;
     int ref = 0;
 
     if (md->origin == EVP_ORIG_DYNAMIC)
@@ -997,8 +981,9 @@ int EVP_MD_up_ref(EVP_MD *md)
     return 1;
 }
 
-void EVP_MD_free(EVP_MD *md)
+static void evp_md_free(void *m)
 {
+    EVP_MD *md = (EVP_MD *)m;
     int i;
 
     if (md == NULL || md->origin != EVP_ORIG_DYNAMIC)
@@ -1012,6 +997,33 @@ void EVP_MD_free(EVP_MD *md)
     ossl_provider_free(md->prov);
     CRYPTO_FREE_REF(&md->refcnt);
     OPENSSL_free(md);
+}
+
+EVP_MD *EVP_MD_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
+    const char *properties)
+{
+    EVP_MD *md = evp_generic_fetch(ctx, OSSL_OP_DIGEST, algorithm, properties,
+        evp_md_from_algorithm, evp_md_up_ref, evp_md_free);
+
+    return md;
+}
+
+int EVP_MD_up_ref(EVP_MD *md)
+{
+#ifdef OPENSSL_NO_CACHED_FETCH
+    return evp_md_up_ref(md);
+#else
+    return 1;
+#endif
+}
+
+void EVP_MD_free(EVP_MD *md)
+{
+#ifdef OPENSSL_NO_CACHED_FETCH
+    evp_md_free(md);
+#else
+    return;
+#endif
 }
 
 void EVP_MD_do_all_provided(OSSL_LIB_CTX *libctx,

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1340,6 +1340,30 @@ static void set_legacy_nid(const char *name, void *vlegacy_nid)
 }
 #endif
 
+static int evp_cipher_up_ref(void *c)
+{
+    EVP_CIPHER *cipher = (EVP_CIPHER *)c;
+    int ref = 0;
+
+    if (cipher->origin == EVP_ORIG_DYNAMIC)
+        CRYPTO_UP_REF(&cipher->refcnt, &ref);
+    return 1;
+}
+
+static void evp_cipher_free(void *c)
+{
+    EVP_CIPHER *cipher = (EVP_CIPHER *)c;
+    int i;
+
+    if (cipher == NULL || cipher->origin != EVP_ORIG_DYNAMIC)
+        return;
+
+    CRYPTO_DOWN_REF(&cipher->refcnt, &i);
+    if (i > 0)
+        return;
+    evp_cipher_free_int(cipher);
+}
+
 static void *evp_cipher_from_algorithm(const int name_id,
     const OSSL_ALGORITHM *algodef,
     OSSL_PROVIDER *prov)
@@ -1511,18 +1535,8 @@ static void *evp_cipher_from_algorithm(const int name_id,
     return cipher;
 
 err:
-    EVP_CIPHER_free(cipher);
+    evp_cipher_free(cipher);
     return NULL;
-}
-
-static int evp_cipher_up_ref(void *cipher)
-{
-    return EVP_CIPHER_up_ref(cipher);
-}
-
-static void evp_cipher_free(void *cipher)
-{
-    EVP_CIPHER_free(cipher);
 }
 
 EVP_CIPHER *EVP_CIPHER_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
@@ -1557,11 +1571,11 @@ int EVP_CIPHER_can_pipeline(const EVP_CIPHER *cipher, int enc)
 
 int EVP_CIPHER_up_ref(EVP_CIPHER *cipher)
 {
-    int ref = 0;
-
-    if (cipher->origin == EVP_ORIG_DYNAMIC)
-        CRYPTO_UP_REF(&cipher->refcnt, &ref);
+#ifdef OPENSSL_NO_CACHED_FETCH
+    return evp_cipher_up_ref(cipher);
+#else
     return 1;
+#endif
 }
 
 void evp_cipher_free_int(EVP_CIPHER *cipher)
@@ -1574,15 +1588,9 @@ void evp_cipher_free_int(EVP_CIPHER *cipher)
 
 void EVP_CIPHER_free(EVP_CIPHER *cipher)
 {
-    int i;
-
-    if (cipher == NULL || cipher->origin != EVP_ORIG_DYNAMIC)
-        return;
-
-    CRYPTO_DOWN_REF(&cipher->refcnt, &i);
-    if (i > 0)
-        return;
-    evp_cipher_free_int(cipher);
+#ifdef OPENSSL_NO_CACHED_FETCH
+    evp_cipher_free(cipher);
+#endif
 }
 
 void EVP_CIPHER_do_all_provided(OSSL_LIB_CTX *libctx,

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -351,7 +351,9 @@ inner_evp_generic_fetch(struct evp_method_data_st *methdata,
             if (name_id == 0) {
                 ERR_raise_data(ERR_LIB_EVP, ERR_R_FETCH_FAILED,
                     "Algorithm %s cannot be found", name != NULL ? name : "<null>");
+#ifdef OPENSSL_NO_CACHED_FETCH
                 free_method(method);
+#endif
                 method = NULL;
             } else {
                 meth_id = evp_method_id(name_id, operation_id);

--- a/crypto/evp/evp_rand.c
+++ b/crypto/evp/evp_rand.c
@@ -289,12 +289,18 @@ EVP_RAND *EVP_RAND_fetch(OSSL_LIB_CTX *libctx, const char *algorithm,
 
 int EVP_RAND_up_ref(EVP_RAND *rand)
 {
+#ifdef OPENSSL_NO_CACHED_FETCH
     return evp_rand_up_ref(rand);
+#else
+    return 1;
+#endif
 }
 
 void EVP_RAND_free(EVP_RAND *rand)
 {
+#ifdef OPENSSL_NO_CACHED_FETCH
     evp_rand_free(rand);
+#endif
 }
 
 int evp_rand_get_number(const EVP_RAND *rand)

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -21,12 +21,27 @@
 
 static void evp_keyexch_free(void *data)
 {
-    EVP_KEYEXCH_free(data);
+    EVP_KEYEXCH *exchange = (EVP_KEYEXCH *)data;
+    int i;
+
+    if (exchange == NULL)
+        return;
+    CRYPTO_DOWN_REF(&exchange->refcnt, &i);
+    if (i > 0)
+        return;
+    OPENSSL_free(exchange->type_name);
+    ossl_provider_free(exchange->prov);
+    CRYPTO_FREE_REF(&exchange->refcnt);
+    OPENSSL_free(exchange);
 }
 
 static int evp_keyexch_up_ref(void *data)
 {
-    return EVP_KEYEXCH_up_ref(data);
+    EVP_KEYEXCH *exchange = (EVP_KEYEXCH *)data;
+    int ref = 0;
+
+    CRYPTO_UP_REF(&exchange->refcnt, &ref);
+    return 1;
 }
 
 static EVP_KEYEXCH *evp_keyexch_new(OSSL_PROVIDER *prov)
@@ -160,25 +175,18 @@ err:
 
 void EVP_KEYEXCH_free(EVP_KEYEXCH *exchange)
 {
-    int i;
-
-    if (exchange == NULL)
-        return;
-    CRYPTO_DOWN_REF(&exchange->refcnt, &i);
-    if (i > 0)
-        return;
-    OPENSSL_free(exchange->type_name);
-    ossl_provider_free(exchange->prov);
-    CRYPTO_FREE_REF(&exchange->refcnt);
-    OPENSSL_free(exchange);
+#ifdef OPENSSL_NO_CACHED_FETCH
+    evp_keyexch_free(exchange);
+#endif
 }
 
 int EVP_KEYEXCH_up_ref(EVP_KEYEXCH *exchange)
 {
-    int ref = 0;
-
-    CRYPTO_UP_REF(&exchange->refcnt, &ref);
+#ifdef OPENSSL_NO_CACHED_FETCH
+    return evp_keyexch_up_ref(exchange);
+#else
     return 1;
+#endif
 }
 
 OSSL_PROVIDER *EVP_KEYEXCH_get0_provider(const EVP_KEYEXCH *exchange)

--- a/crypto/evp/kdf_meth.c
+++ b/crypto/evp/kdf_meth.c
@@ -176,12 +176,18 @@ EVP_KDF *EVP_KDF_fetch(OSSL_LIB_CTX *libctx, const char *algorithm,
 
 int EVP_KDF_up_ref(EVP_KDF *kdf)
 {
+#ifdef OPENSSL_NO_CACHED_FETCH
     return evp_kdf_up_ref(kdf);
+#else
+    return 1;
+#endif
 }
 
 void EVP_KDF_free(EVP_KDF *kdf)
 {
+#ifdef OPENSSL_NO_CACHED_FETCH
     evp_kdf_free(kdf);
+#endif
 }
 
 const OSSL_PARAM *EVP_KDF_gettable_params(const EVP_KDF *kdf)

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -19,12 +19,28 @@
 
 static void evp_kem_free(void *data)
 {
-    EVP_KEM_free(data);
+    EVP_KEM *kem = (EVP_KEM *)data;
+    int i;
+
+    if (kem == NULL)
+        return;
+
+    CRYPTO_DOWN_REF(&kem->refcnt, &i);
+    if (i > 0)
+        return;
+    OPENSSL_free(kem->type_name);
+    ossl_provider_free(kem->prov);
+    CRYPTO_FREE_REF(&kem->refcnt);
+    OPENSSL_free(kem);
 }
 
 static int evp_kem_up_ref(void *data)
 {
-    return EVP_KEM_up_ref(data);
+    EVP_KEM *kem = (EVP_KEM *)data;
+    int ref = 0;
+
+    CRYPTO_UP_REF(&kem->refcnt, &ref);
+    return 1;
 }
 
 static int evp_kem_init(EVP_PKEY_CTX *ctx, int operation,
@@ -432,26 +448,18 @@ err:
 
 void EVP_KEM_free(EVP_KEM *kem)
 {
-    int i;
-
-    if (kem == NULL)
-        return;
-
-    CRYPTO_DOWN_REF(&kem->refcnt, &i);
-    if (i > 0)
-        return;
-    OPENSSL_free(kem->type_name);
-    ossl_provider_free(kem->prov);
-    CRYPTO_FREE_REF(&kem->refcnt);
-    OPENSSL_free(kem);
+#ifdef OPENSSL_NO_CACHED_FETCH
+    evp_kem_free(kem);
+#endif
 }
 
 int EVP_KEM_up_ref(EVP_KEM *kem)
 {
-    int ref = 0;
-
-    CRYPTO_UP_REF(&kem->refcnt, &ref);
+#ifdef OPENSSL_NO_CACHED_FETCH
+    return evp_kem_up_ref(kem);
+#else
     return 1;
+#endif
 }
 
 OSSL_PROVIDER *EVP_KEM_get0_provider(const EVP_KEM *kem)

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -19,12 +19,28 @@
 
 static void evp_keymgmt_free(void *data)
 {
-    EVP_KEYMGMT_free(data);
+    EVP_KEYMGMT *keymgmt = (EVP_KEYMGMT *)data;
+    int ref = 0;
+
+    if (keymgmt == NULL)
+        return;
+
+    CRYPTO_DOWN_REF(&keymgmt->refcnt, &ref);
+    if (ref > 0)
+        return;
+    OPENSSL_free(keymgmt->type_name);
+    ossl_provider_free(keymgmt->prov);
+    CRYPTO_FREE_REF(&keymgmt->refcnt);
+    OPENSSL_free(keymgmt);
 }
 
 static int evp_keymgmt_up_ref(void *data)
 {
-    return EVP_KEYMGMT_up_ref(data);
+    EVP_KEYMGMT *keymgmt = (EVP_KEYMGMT *)data;
+    int ref = 0;
+
+    CRYPTO_UP_REF(&keymgmt->refcnt, &ref);
+    return 1;
 }
 
 static void *keymgmt_new(void)
@@ -293,26 +309,18 @@ EVP_KEYMGMT *EVP_KEYMGMT_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
 
 int EVP_KEYMGMT_up_ref(EVP_KEYMGMT *keymgmt)
 {
-    int ref = 0;
-
-    CRYPTO_UP_REF(&keymgmt->refcnt, &ref);
+#ifdef OPENSSL_NO_CACHED_FETCH
+    return evp_keymgmt_up_ref(keymgmt);
+#else
     return 1;
+#endif
 }
 
 void EVP_KEYMGMT_free(EVP_KEYMGMT *keymgmt)
 {
-    int ref = 0;
-
-    if (keymgmt == NULL)
-        return;
-
-    CRYPTO_DOWN_REF(&keymgmt->refcnt, &ref);
-    if (ref > 0)
-        return;
-    OPENSSL_free(keymgmt->type_name);
-    ossl_provider_free(keymgmt->prov);
-    CRYPTO_FREE_REF(&keymgmt->refcnt);
-    OPENSSL_free(keymgmt);
+#ifdef OPENSSL_NO_CACHED_FETCH
+    evp_keymgmt_free(keymgmt);
+#endif
 }
 
 const OSSL_PROVIDER *EVP_KEYMGMT_get0_provider(const EVP_KEYMGMT *keymgmt)

--- a/crypto/evp/mac_meth.c
+++ b/crypto/evp/mac_meth.c
@@ -182,12 +182,18 @@ EVP_MAC *EVP_MAC_fetch(OSSL_LIB_CTX *libctx, const char *algorithm,
 
 int EVP_MAC_up_ref(EVP_MAC *mac)
 {
+#ifdef OPENSSL_NO_CACHED_FETCH
     return evp_mac_up_ref(mac);
+#else
+    return 1;
+#endif
 }
 
 void EVP_MAC_free(EVP_MAC *mac)
 {
+#ifdef OPENSSL_NO_CACHED_FETCH
     evp_mac_free(mac);
+#endif
 }
 
 const OSSL_PROVIDER *EVP_MAC_get0_provider(const EVP_MAC *mac)

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -22,12 +22,27 @@
 
 static void evp_signature_free(void *data)
 {
-    EVP_SIGNATURE_free(data);
+    EVP_SIGNATURE *signature = (EVP_SIGNATURE *)data;
+    int i;
+
+    if (signature == NULL)
+        return;
+    CRYPTO_DOWN_REF(&signature->refcnt, &i);
+    if (i > 0)
+        return;
+    OPENSSL_free(signature->type_name);
+    ossl_provider_free(signature->prov);
+    CRYPTO_FREE_REF(&signature->refcnt);
+    OPENSSL_free(signature);
 }
 
 static int evp_signature_up_ref(void *data)
 {
-    return EVP_SIGNATURE_up_ref(data);
+    EVP_SIGNATURE *signature = (EVP_SIGNATURE *)data;
+    int ref = 0;
+
+    CRYPTO_UP_REF(&signature->refcnt, &ref);
+    return 1;
 }
 
 static EVP_SIGNATURE *evp_signature_new(OSSL_PROVIDER *prov)
@@ -454,25 +469,18 @@ err:
 
 void EVP_SIGNATURE_free(EVP_SIGNATURE *signature)
 {
-    int i;
-
-    if (signature == NULL)
-        return;
-    CRYPTO_DOWN_REF(&signature->refcnt, &i);
-    if (i > 0)
-        return;
-    OPENSSL_free(signature->type_name);
-    ossl_provider_free(signature->prov);
-    CRYPTO_FREE_REF(&signature->refcnt);
-    OPENSSL_free(signature);
+#ifdef OPENSSL_NO_CACHED_FETCH
+    evp_signature_free(signature);
+#endif
 }
 
 int EVP_SIGNATURE_up_ref(EVP_SIGNATURE *signature)
 {
-    int ref = 0;
-
-    CRYPTO_UP_REF(&signature->refcnt, &ref);
+#ifdef OPENSSL_NO_CACHED_FETCH
+    return evp_signature_up_ref(signature);
+#else
     return 1;
+#endif
 }
 
 OSSL_PROVIDER *EVP_SIGNATURE_get0_provider(const EVP_SIGNATURE *signature)

--- a/crypto/evp/skeymgmt_meth.c
+++ b/crypto/evp/skeymgmt_meth.c
@@ -163,8 +163,8 @@ EVP_SKEYMGMT *evp_skeymgmt_fetch_from_prov(OSSL_PROVIDER *prov,
         OSSL_OP_SKEYMGMT,
         name, properties,
         skeymgmt_from_algorithm,
-        (int (*)(void *))evp_skeymgmt_up_ref,
-        (void (*)(void *))evp_skeymgmt_free);
+        evp_skeymgmt_up_ref,
+        evp_skeymgmt_free);
 }
 
 EVP_SKEYMGMT *EVP_SKEYMGMT_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
@@ -172,8 +172,8 @@ EVP_SKEYMGMT *EVP_SKEYMGMT_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
 {
     return evp_generic_fetch(ctx, OSSL_OP_SKEYMGMT, algorithm, properties,
         skeymgmt_from_algorithm,
-        (int (*)(void *))evp_skeymgmt_up_ref,
-        (void (*)(void *))evp_skeymgmt_free);
+        evp_skeymgmt_up_ref,
+        evp_skeymgmt_free);
 }
 
 int EVP_SKEYMGMT_up_ref(EVP_SKEYMGMT *skeymgmt)

--- a/crypto/evp/skeymgmt_meth.c
+++ b/crypto/evp/skeymgmt_meth.c
@@ -17,6 +17,8 @@
 #include "crypto/evp.h"
 #include "evp_local.h"
 
+static void evp_skeymgmt_free(void *s);
+
 void *evp_skeymgmt_generate(const EVP_SKEYMGMT *skeymgmt, const OSSL_PARAM params[])
 {
     void *provctx = ossl_provider_ctx(EVP_SKEYMGMT_get0_provider(skeymgmt));
@@ -45,16 +47,6 @@ void evp_skeymgmt_freedata(const EVP_SKEYMGMT *skeymgmt, void *keydata)
     skeymgmt->free(keydata);
 }
 
-static int evp_skeymgmt_up_ref(void *skeymgmt)
-{
-    return EVP_SKEYMGMT_up_ref(skeymgmt);
-}
-
-static void evp_skeymgmt_free(void *skeymgmt)
-{
-    EVP_SKEYMGMT_free(skeymgmt);
-}
-
 static void *skeymgmt_new(void)
 {
     EVP_SKEYMGMT *skeymgmt = NULL;
@@ -62,7 +54,7 @@ static void *skeymgmt_new(void)
     if ((skeymgmt = OPENSSL_zalloc(sizeof(*skeymgmt))) == NULL)
         return NULL;
     if (!CRYPTO_NEW_REF(&skeymgmt->refcnt, 1)) {
-        EVP_SKEYMGMT_free(skeymgmt);
+        evp_skeymgmt_free(skeymgmt);
         return NULL;
     }
     return skeymgmt;
@@ -80,7 +72,7 @@ static void *skeymgmt_from_algorithm(int name_id,
 
     skeymgmt->name_id = name_id;
     if ((skeymgmt->type_name = ossl_algorithm_get1_first_name(algodef)) == NULL) {
-        EVP_SKEYMGMT_free(skeymgmt);
+        evp_skeymgmt_free(skeymgmt);
         return NULL;
     }
     skeymgmt->description = algodef->algorithm_description;
@@ -122,13 +114,13 @@ static void *skeymgmt_from_algorithm(int name_id,
     if (skeymgmt->free == NULL
         || skeymgmt->import == NULL
         || skeymgmt->export == NULL) {
-        EVP_SKEYMGMT_free(skeymgmt);
+        evp_skeymgmt_free(skeymgmt);
         ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_PROVIDER_FUNCTIONS);
         return NULL;
     }
 
     if (!ossl_provider_up_ref(prov)) {
-        EVP_SKEYMGMT_free(skeymgmt);
+        evp_skeymgmt_free(skeymgmt);
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         return NULL;
     }
@@ -137,37 +129,18 @@ static void *skeymgmt_from_algorithm(int name_id,
     return skeymgmt;
 }
 
-EVP_SKEYMGMT *evp_skeymgmt_fetch_from_prov(OSSL_PROVIDER *prov,
-    const char *name,
-    const char *properties)
+static int evp_skeymgmt_up_ref(void *s)
 {
-    return evp_generic_fetch_from_prov(prov,
-        OSSL_OP_SKEYMGMT,
-        name, properties,
-        skeymgmt_from_algorithm,
-        evp_skeymgmt_up_ref,
-        evp_skeymgmt_free);
-}
-
-EVP_SKEYMGMT *EVP_SKEYMGMT_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
-    const char *properties)
-{
-    return evp_generic_fetch(ctx, OSSL_OP_SKEYMGMT, algorithm, properties,
-        skeymgmt_from_algorithm,
-        evp_skeymgmt_up_ref,
-        evp_skeymgmt_free);
-}
-
-int EVP_SKEYMGMT_up_ref(EVP_SKEYMGMT *skeymgmt)
-{
+    EVP_SKEYMGMT *skeymgmt = (EVP_SKEYMGMT *)s;
     int ref = 0;
 
     CRYPTO_UP_REF(&skeymgmt->refcnt, &ref);
     return 1;
 }
 
-void EVP_SKEYMGMT_free(EVP_SKEYMGMT *skeymgmt)
+static void evp_skeymgmt_free(void *s)
 {
+    EVP_SKEYMGMT *skeymgmt = (EVP_SKEYMGMT *)s;
     int ref = 0;
 
     if (skeymgmt == NULL)
@@ -180,6 +153,43 @@ void EVP_SKEYMGMT_free(EVP_SKEYMGMT *skeymgmt)
     ossl_provider_free(skeymgmt->prov);
     CRYPTO_FREE_REF(&skeymgmt->refcnt);
     OPENSSL_free(skeymgmt);
+}
+
+EVP_SKEYMGMT *evp_skeymgmt_fetch_from_prov(OSSL_PROVIDER *prov,
+    const char *name,
+    const char *properties)
+{
+    return evp_generic_fetch_from_prov(prov,
+        OSSL_OP_SKEYMGMT,
+        name, properties,
+        skeymgmt_from_algorithm,
+        (int (*)(void *))evp_skeymgmt_up_ref,
+        (void (*)(void *))evp_skeymgmt_free);
+}
+
+EVP_SKEYMGMT *EVP_SKEYMGMT_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
+    const char *properties)
+{
+    return evp_generic_fetch(ctx, OSSL_OP_SKEYMGMT, algorithm, properties,
+        skeymgmt_from_algorithm,
+        (int (*)(void *))evp_skeymgmt_up_ref,
+        (void (*)(void *))evp_skeymgmt_free);
+}
+
+int EVP_SKEYMGMT_up_ref(EVP_SKEYMGMT *skeymgmt)
+{
+#ifdef OPENSSL_NO_CACHED_FETCH
+    return evp_skeymgmt_up_ref(skeymgmt);
+#else
+    return 1;
+#endif
+}
+
+void EVP_SKEYMGMT_free(EVP_SKEYMGMT *skeymgmt)
+{
+#ifdef OPENSSL_NO_CACHED_FETCH
+    evp_skeymgmt_free(skeymgmt);
+#endif
 }
 
 const OSSL_PROVIDER *EVP_SKEYMGMT_get0_provider(const EVP_SKEYMGMT *skeymgmt)

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -810,10 +810,18 @@ int ossl_method_store_fetch(OSSL_METHOD_STORE *store,
         }
     }
 fin:
-    if (ret && ossl_method_up_ref(&best_impl->method)) {
+    if (ret) {
         *method = best_impl->method.method;
         if (prov_rw != NULL)
             *prov_rw = best_impl->provider;
+#ifdef OPENSSL_NO_CACHED_FETCH
+        if (!ossl_method_up_ref(&best_impl->method)) {
+            ret = 0;
+            *method = NULL;
+            if (prov_rw != NULL)
+                *prov_rw = NULL;
+        }
+#endif
     } else {
         ret = 0;
     }
@@ -921,9 +929,15 @@ static ossl_inline int ossl_method_store_cache_get_atomic(OSSL_METHOD_STORE *sto
 
     r = ossl_method_store_atomic_find_in_list(sa, nid, prov, prop_hash);
 
-    if (r != NULL && ossl_method_up_ref(&r->method)) {
+    if (r != NULL) {
         *method = r->method.method;
         res = 1;
+#ifdef OPENSSL_NO_CACHED_FETCH
+        if (!ossl_method_up_ref(&r->method)) {
+            *method = NULL;
+            res = 0;
+        }
+#endif
     }
 
     return res;

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -16,8 +16,9 @@
 #include "store_local.h"
 #include "crypto/context.h"
 
-int OSSL_STORE_LOADER_up_ref(OSSL_STORE_LOADER *loader)
+static int up_ref_loader(void *method)
 {
+    OSSL_STORE_LOADER *loader = (OSSL_STORE_LOADER *)method;
     int ref = 0;
 
     if (loader->prov != NULL)
@@ -25,8 +26,10 @@ int OSSL_STORE_LOADER_up_ref(OSSL_STORE_LOADER *loader)
     return 1;
 }
 
-void OSSL_STORE_LOADER_free(OSSL_STORE_LOADER *loader)
+static void free_loader(void *method)
 {
+    OSSL_STORE_LOADER *loader = (OSSL_STORE_LOADER *)method;
+
     if (loader != NULL && loader->prov != NULL) {
         int i;
 
@@ -37,6 +40,22 @@ void OSSL_STORE_LOADER_free(OSSL_STORE_LOADER *loader)
         CRYPTO_FREE_REF(&loader->refcnt);
     }
     OPENSSL_free(loader);
+}
+
+int OSSL_STORE_LOADER_up_ref(OSSL_STORE_LOADER *loader)
+{
+#ifdef OPENSSL_NO_CACHED_FETCH
+    return up_ref_loader(loader);
+#else
+    return 1;
+#endif
+}
+
+void OSSL_STORE_LOADER_free(OSSL_STORE_LOADER *loader)
+{
+#ifdef OPENSSL_NO_CACHED_FETCH
+    free_loader(loader);
+#endif
 }
 
 /*
@@ -59,16 +78,6 @@ static OSSL_STORE_LOADER *new_loader(OSSL_PROVIDER *prov)
     loader->prov = prov;
 
     return loader;
-}
-
-static int up_ref_loader(void *method)
-{
-    return OSSL_STORE_LOADER_up_ref(method);
-}
-
-static void free_loader(void *method)
-{
-    OSSL_STORE_LOADER_free(method);
 }
 
 /* Data to be passed through ossl_method_construct() */
@@ -237,7 +246,7 @@ static void *loader_from_algorithm(int scheme_id, const OSSL_ALGORITHM *algodef,
         || loader->p_eof == NULL
         || loader->p_close == NULL) {
         /* Only set_ctx_params is optional */
-        OSSL_STORE_LOADER_free(loader);
+        free_loader(loader);
         ERR_raise(ERR_LIB_OSSL_STORE, OSSL_STORE_R_LOADER_INCOMPLETE);
         return NULL;
     }
@@ -282,7 +291,7 @@ static void *construct_loader(const OSSL_ALGORITHM *algodef,
 /* Intermediary function to avoid ugly casts, used below */
 static void destruct_loader(void *method, void *data)
 {
-    OSSL_STORE_LOADER_free(method);
+    free_loader(method);
 }
 
 /* Fetching support.  Can fetch by numeric identity or by scheme */

--- a/test/property_test.c
+++ b/test/property_test.c
@@ -678,7 +678,9 @@ static int test_query_cache_set_duplicate(void)
         || !TEST_ptr_eq(result, &refs))
         goto err;
 
+#ifdef OPENSSL_NO_CACHED_FETCH
     counted_down_ref(result);
+#endif
     result = NULL;
     res = 1;
 


### PR DESCRIPTION
as part of @mattcaswell s work on https://github.com/openssl/openssl/issues/30659, one of the things we noticed is that refcounting accounts for a significant portion of the work done on the EVP_*_fetch path.  this stems from two primary issues:

1) The up ref operation is done via an __ATOMIC_RELAXED constraints, which is good, however the down ref is done with __ATOMIC_RELEASE, which is potentially very costly in terms of latency.  @bernd-edlinger has a PR here https://github.com/openssl/openssl/pull/28643 to attempt to mitigate this by converting them all into __ATOMIC_RELAXED operations, which has some outstanding issues to resolve.

2) Even by only using __ATOMIC_RELAXED, we still suffer from the possibility that multiple threads will be interleaving up ref/down ref operations, which invalidates cache lines on each cpu leading to additional latency.

I'd like to propose an additional solution, at least for the `EVP_*` objects returned from `EVP_*_fetch`.  Based on the changes in https://github.com/openssl/openssl/pull/31018 (which this PR depends on), we have modified the ossl_method_store so that any object returned from it (which all EVP objects are), are now guaranteed to have a lifetime that matches the associated libctx from which they were fetched.  The implication of that is that, no matter how many reference counts are added/subtracted by external callers via `EVP_*_up_ref` and `EVP_*_free`, that objects reference count will never drop below 1 until such time as the method store cache associated with the libctx from whence it was fetched is itself removed.

This gives us an opportunity, which is the subject of this PR.  Since PR https://github.com/openssl/openssl/pull/31018 guarantees us that the life of an EVP object matches that of the libctx, we can simply make external calls to EVP_*up_ref and EVP_*_free no-ops (subject to the constraints below).  This allows us to only do internal refcounting within the method store, while eliminating all external reference counting, improving performance.

**Notes/Constraints:**

There are three issues I encountered while developing this, that I think need to be called out here in the interests of transparency:

1) This doesn't work for no-cached-fetch.  Because, by definition enabling no-cached-fetch means that objects are fetched all the way from the provider on each fetch, external callers (i.e. those that use the EVP_*_fetch and EVP_*_free apis) still need to be responsible for freeing the object when they are done, and so the no-op-ing of those apis need to be gated on this config option.  I think this is likely ok, and in fact gives us the opportunity to ensure that users are still using the api correctly going forward

2) Decoders in the file_store.  This code path kind of cheats, building its own EVP objects outside of the method store.  Because of that we have to add an extra check in the OSSL_DECODER_free and up_ref apis for unnamed objects (i.e. with a nid of 0)

3) This is important to note.  This change makes a subtle change of behavior.  If a user does the following (as an example):
```
#include <stdlib.h>
#include <stdio.h>
#include <openssl/evp.h>
#include <openssl/kdf.h>


int main (int argc, char **argv)
{
    OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new();
    EVP_KEYEXCH *kex = EVP_KEYEXCH_fetch(libctx, "HKDF", NULL);

    OSSL_LIB_CTX_free(libctx);

    EVP_KEYEXCH_settable_ctx_params(kex);
    return 0;
}
```

The use of an EVP object now results in a crash after the associated libctx is freed, whereas previously, the call was allowed to continue (because the caller legitimately held a refcount on the EVP object).  However, I'm asserting the above is a programming error, due to the fact that the provider may make use of the (now freed) libctx via the PROV_LIBCTX_OF macro.  In fact running the above code on the master branch of our tree (without these changes) under asan already results in an error when the associated HKDF KEYEXCH mechanism attempts to dereference the attached libctx via the aforementioned macro.  As such, I believe this change is ok in this situtation.

**Performance:**

Performance is _good_.  Using evp_hash -o evp_isolated to measure the execution time of a fetch/digest/free cycle, we can observe the following:
<img width="2714" height="2074" alt="image" src="https://github.com/user-attachments/assets/471b3b73-58a8-4251-92f4-5f74bc266b6b" />

That represents a 0.4% speedup at single threaded performance, up to a 71% improvement at 132 threads.


