### PR TITLE
ktls: Fix invalid memory access on retry with moving write buffer

### DIFF
--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -473,10 +473,15 @@ static int ktls_initialise_write_packets(OSSL_RECORD_LAYER *rl,
     wb->type = templates[0].type;
 
     /*
+     * Free any internal buffer allocated during a previous write retry
+     * (see tls_retry_write_records).  App buffers are not ours to free.
+     */
+    if (!TLS_BUFFER_is_app_buffer(wb))
+        OPENSSL_free(TLS_BUFFER_get_buf(wb));
+
+    /*
      * ktls doesn't modify the buffer, but to avoid a warning we need
      * to discard the const qualifier.
-     * This doesn't leak memory because the buffers have never been allocated
-     * with KTLS
      */
     TLS_BUFFER_set_buf(wb, (unsigned char *)templates[0].buf);
     TLS_BUFFER_set_offset(wb, 0);
@@ -549,10 +554,7 @@ static int ktls_alloc_buffers(OSSL_RECORD_LAYER *rl)
 
 static int ktls_free_buffers(OSSL_RECORD_LAYER *rl)
 {
-    /* We use the application buffer directly for writing */
-    if (rl->direction == OSSL_RECORD_DIRECTION_WRITE)
-        return 1;
-
+    /* Write buffer may be an app buffer or an internally allocated copy */
     return tls_free_buffers(rl);
 }
 

--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -552,12 +552,6 @@ static int ktls_alloc_buffers(OSSL_RECORD_LAYER *rl)
     return tls_alloc_buffers(rl);
 }
 
-static int ktls_free_buffers(OSSL_RECORD_LAYER *rl)
-{
-    /* Write buffer may be an app buffer or an internally allocated copy */
-    return tls_free_buffers(rl);
-}
-
 static struct record_functions_st ossl_ktls_funcs = {
     ktls_set_crypto_state,
     ktls_cipher,
@@ -604,5 +598,5 @@ const OSSL_RECORD_METHOD ossl_ktls_record_method = {
     NULL,
     tls_increment_sequence_ctr,
     ktls_alloc_buffers,
-    ktls_free_buffers
+    tls_free_buffers
 };

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1918,6 +1918,28 @@ int tls_retry_write_records(OSSL_RECORD_LAYER *rl)
                 tls_release_write_buffer(rl);
             return OSSL_RECORD_RETURN_SUCCESS;
         } else if (i <= 0) {
+            /*
+             * If the app buffer is used directly (kTLS) and the caller is
+             * allowed to move it, copy the unsent data so the original
+             * buffer can be safely released.
+             */
+            if (TLS_BUFFER_is_app_buffer(thiswb)
+                && (rl->mode & SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER) != 0) {
+                size_t left = TLS_BUFFER_get_left(thiswb);
+                unsigned char *buf;
+
+                buf = OPENSSL_malloc(left);
+                if (buf == NULL) {
+                    RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+                    return OSSL_RECORD_RETURN_FATAL;
+                }
+                memcpy(buf,
+                    TLS_BUFFER_get_buf(thiswb) + TLS_BUFFER_get_offset(thiswb),
+                    left);
+                TLS_BUFFER_set_buf(thiswb, buf);
+                TLS_BUFFER_set_offset(thiswb, 0);
+                TLS_BUFFER_set_app_buffer(thiswb, 0);
+            }
             if (rl->isdtls) {
                 /*
                  * For DTLS, just drop it. That's kind of the whole point in

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1461,6 +1461,7 @@ end:
     return testresult;
 }
 
+#ifndef OSSL_NO_USABLE_TLS1_3
 /*
  * Test kTLS with SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER: retry SSL_write() after
  * SSL_ERROR_WANT_WRITE using a different buffer pointer (same content) and
@@ -1596,6 +1597,7 @@ end:
         close(sfd);
     return testresult;
 }
+#endif /* !defined(OSSL_NO_USABLE_TLS1_3) */
 
 static struct ktls_test_cipher {
     int tls_version;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1579,11 +1579,11 @@ static int test_ktls_moving_write_buffer(void)
 end:
     OPENSSL_free(buf_orig);
     OPENSSL_free(buf_retry);
-    if (clientssl) {
+    if (clientssl != NULL) {
         SSL_shutdown(clientssl);
         SSL_free(clientssl);
     }
-    if (serverssl) {
+    if (serverssl != NULL) {
         SSL_shutdown(serverssl);
         SSL_free(serverssl);
     }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1461,6 +1461,144 @@ end:
     return testresult;
 }
 
+/*
+ * Test kTLS with SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER: retry SSL_write() after
+ * SSL_ERROR_WANT_WRITE using a different buffer pointer (same content) and
+ * verify that the data arrives intact.
+ */
+static int test_ktls_moving_write_buffer(void)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    SSL_CONNECTION *clientsc;
+    BIO *bretry = NULL, *tmp = NULL;
+    int testresult = 0, cfd = -1, sfd = -1;
+    unsigned char *buf_orig = NULL, *buf_retry = NULL;
+    unsigned char outbuf[1024];
+    const size_t bufsz = sizeof(outbuf);
+    size_t written, readbytes, totread = 0, i;
+
+    /* kTLS requires real sockets */
+    if (!TEST_true(create_test_sockets(&cfd, &sfd, SOCK_STREAM, NULL)))
+        goto end;
+
+    /* Skip if the kernel does not support kTLS */
+    if (!ktls_chk_platform(cfd)) {
+        testresult = TEST_skip("Kernel does not support KTLS");
+        goto end;
+    }
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx,
+            TLS_server_method(), TLS_client_method(),
+            TLS1_3_VERSION, TLS1_3_VERSION,
+            &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    if (!TEST_true(SSL_CTX_set_ciphersuites(cctx, "TLS_AES_128_GCM_SHA256"))
+        || !TEST_true(SSL_CTX_set_ciphersuites(sctx, "TLS_AES_128_GCM_SHA256")))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects2(sctx, cctx, &serverssl,
+            &clientssl, sfd, cfd)))
+        goto end;
+
+    if (!TEST_ptr(clientsc = SSL_CONNECTION_FROM_SSL_ONLY(clientssl)))
+        goto end;
+
+    /* Enable kTLS on the writing side (client) */
+    if (!TEST_true(SSL_set_options(clientssl, SSL_OP_ENABLE_KTLS)))
+        goto end;
+
+    SSL_set_mode(clientssl, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+    SSL_set_mode(clientssl, SSL_MODE_ENABLE_PARTIAL_WRITE);
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
+        goto end;
+
+    /* Skip if kTLS TX was not activated for this cipher */
+    if (!BIO_get_ktls_send(clientsc->wbio)) {
+        testresult = TEST_skip("kTLS send not supported");
+        goto end;
+    }
+
+    /* Allocate two buffers with identical content but different addresses */
+    buf_orig = OPENSSL_malloc(bufsz);
+    buf_retry = OPENSSL_malloc(bufsz);
+    if (!TEST_ptr(buf_orig) || !TEST_ptr(buf_retry))
+        goto end;
+
+    for (i = 0; i < bufsz; i++)
+        buf_orig[i] = buf_retry[i] = (unsigned char)(i & 0xff);
+
+    /* Swap write BIO to force WANT_WRITE */
+    bretry = BIO_new(bio_s_always_retry());
+    if (!TEST_ptr(bretry))
+        goto end;
+
+    tmp = SSL_get_wbio(clientssl);
+    if (!TEST_ptr(tmp) || !TEST_true(BIO_up_ref(tmp))) {
+        tmp = NULL;
+        goto end;
+    }
+    SSL_set0_wbio(clientssl, bretry);
+    bretry = NULL; /* ownership transferred to clientssl */
+
+    /* First write attempt - will fail with WANT_WRITE */
+    if (!TEST_false(SSL_write_ex(clientssl, buf_orig, bufsz, &written))
+        || !TEST_int_eq(SSL_get_error(clientssl, 0), SSL_ERROR_WANT_WRITE))
+        goto end;
+
+    /* Restore the real socket BIO so the retry can actually send data */
+    SSL_set0_wbio(clientssl, tmp);
+    tmp = NULL;
+
+    /* Poison and free the original buffer */
+    memset(buf_orig, 0xDE, bufsz);
+    OPENSSL_free(buf_orig);
+    buf_orig = NULL;
+
+    /* Retry with a different buffer pointer */
+    if (!TEST_true(SSL_write_ex(clientssl, buf_retry, bufsz, &written)))
+        goto end;
+
+    /* Read the data on the server side */
+    totread = 0;
+    while (totread < bufsz) {
+        if (!SSL_read_ex(serverssl, outbuf + totread, bufsz - totread,
+                &readbytes)) {
+            if (!TEST_int_eq(SSL_get_error(serverssl, 0), SSL_ERROR_WANT_READ))
+                goto end;
+        } else {
+            totread += readbytes;
+        }
+    }
+
+    /* Verify data integrity */
+    if (!TEST_mem_eq(buf_retry, bufsz, outbuf, totread))
+        goto end;
+
+    testresult = 1;
+end:
+    OPENSSL_free(buf_orig);
+    OPENSSL_free(buf_retry);
+    if (clientssl) {
+        SSL_shutdown(clientssl);
+        SSL_free(clientssl);
+    }
+    if (serverssl) {
+        SSL_shutdown(serverssl);
+        SSL_free(serverssl);
+    }
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    BIO_free_all(tmp);
+    if (cfd != -1)
+        close(cfd);
+    if (sfd != -1)
+        close(sfd);
+    return testresult;
+}
+
 static struct ktls_test_cipher {
     int tls_version;
     const char *cipher;
@@ -14851,6 +14989,9 @@ int setup_tests(void)
 #if !defined(OPENSSL_NO_TLS1_2) || !defined(OSSL_NO_USABLE_TLS1_3)
     ADD_ALL_TESTS(test_ktls, NUM_KTLS_TEST_CIPHERS * 4);
     ADD_ALL_TESTS(test_ktls_sendfile, NUM_KTLS_TEST_CIPHERS * 2);
+#endif
+#ifndef OSSL_NO_USABLE_TLS1_3
+    ADD_TEST(test_ktls_moving_write_buffer);
 #endif
 #endif
     ADD_TEST(test_large_message_tls);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1470,8 +1470,7 @@ static int test_ktls_moving_write_buffer(void)
 {
     SSL_CTX *cctx = NULL, *sctx = NULL;
     SSL *clientssl = NULL, *serverssl = NULL;
-    SSL_CONNECTION *clientsc;
-    BIO *bretry = NULL, *tmp = NULL;
+    BIO *bio_retry = NULL, *bio_orig = NULL;
     int testresult = 0, cfd = -1, sfd = -1;
     unsigned char *buf_orig = NULL, *buf_retry = NULL;
     unsigned char outbuf[1024];
@@ -1502,9 +1501,6 @@ static int test_ktls_moving_write_buffer(void)
             &clientssl, sfd, cfd)))
         goto end;
 
-    if (!TEST_ptr(clientsc = SSL_CONNECTION_FROM_SSL_ONLY(clientssl)))
-        goto end;
-
     /* Enable kTLS on the writing side (client) */
     if (!TEST_true(SSL_set_options(clientssl, SSL_OP_ENABLE_KTLS)))
         goto end;
@@ -1515,11 +1511,26 @@ static int test_ktls_moving_write_buffer(void)
     if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
         goto end;
 
+    /* Get a reference to the original BIO to replace it later. */
+    bio_orig = SSL_get_wbio(clientssl);
+    if (!TEST_ptr(bio_orig) || !TEST_true(BIO_up_ref(bio_orig))) {
+        bio_orig = NULL;
+        goto end;
+    }
+
     /* Skip if kTLS TX was not activated for this cipher */
-    if (!BIO_get_ktls_send(clientsc->wbio)) {
+    if (!BIO_get_ktls_send(bio_orig)) {
         testresult = TEST_skip("kTLS send not supported");
         goto end;
     }
+
+    /* Swap write BIO to force WANT_WRITE */
+    bio_retry = BIO_new(bio_s_always_retry());
+    if (!TEST_ptr(bio_retry))
+        goto end;
+
+    SSL_set0_wbio(clientssl, bio_retry);
+    bio_retry = NULL; /* ownership transferred to clientssl */
 
     /* Allocate two buffers with identical content but different addresses */
     buf_orig = OPENSSL_malloc(bufsz);
@@ -1530,27 +1541,14 @@ static int test_ktls_moving_write_buffer(void)
     for (i = 0; i < bufsz; i++)
         buf_orig[i] = buf_retry[i] = (unsigned char)(i & 0xff);
 
-    /* Swap write BIO to force WANT_WRITE */
-    bretry = BIO_new(bio_s_always_retry());
-    if (!TEST_ptr(bretry))
-        goto end;
-
-    tmp = SSL_get_wbio(clientssl);
-    if (!TEST_ptr(tmp) || !TEST_true(BIO_up_ref(tmp))) {
-        tmp = NULL;
-        goto end;
-    }
-    SSL_set0_wbio(clientssl, bretry);
-    bretry = NULL; /* ownership transferred to clientssl */
-
     /* First write attempt - will fail with WANT_WRITE */
     if (!TEST_false(SSL_write_ex(clientssl, buf_orig, bufsz, &written))
         || !TEST_int_eq(SSL_get_error(clientssl, 0), SSL_ERROR_WANT_WRITE))
         goto end;
 
     /* Restore the real socket BIO so the retry can actually send data */
-    SSL_set0_wbio(clientssl, tmp);
-    tmp = NULL;
+    SSL_set0_wbio(clientssl, bio_orig);
+    bio_orig = NULL;
 
     /* Poison and free the original buffer */
     memset(buf_orig, 0xDE, bufsz);
@@ -1591,7 +1589,7 @@ end:
     }
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
-    BIO_free_all(tmp);
+    BIO_free_all(bio_orig);
     if (cfd != -1)
         close(cfd);
     if (sfd != -1)


### PR DESCRIPTION
kTLS write is using application buffer always without a memory copy. And it completely ignores `SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER` as a result.  If the user frees or re-uses the original buffer and retries the send on `SSL_ERROR_WANT_WRITE`, the code will read and send the data from the original already freed buffer sending whatever happens to be in that memory now and corrupting the message, potentially crashing the application as well.

Fix by making a copy if we can't send the whole thing right away and the moving write buffer is configured.

This preserves the zero-copy semantics for the happy path and avoids the invalid memory access and data corruption when retry is necessary. The copy is done in the common code as it is hard to preserve the zero-copy behavior otherwise.

Test is added that reproduces the issue.  It may be possible to modify the existing kTLS test to conditionally enable the modes and do the BIO swap, but it feels like the issue deserves a separate one.

The test doesn't rely on any specific cypher or TLS version, so only one combination is checked, but it should be enough.

There is no `TLS_BUFFER_set_len()` and the original kTLS code never sets the length, so not setting it on the copy either for now.

Fixes: 50ec750567e0 "ssl: Linux TLS Tx Offload"
Fixes #21202

Assisted-by: claude-opus-4.6
(Used claude to debug the issue and sketch up the initial fix and the test based on my prior reproducer.)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
