### PR TITLE
get rid of SKM_DEFINE_STACK_OF_INTERNAL

### DIFF
--- a/include/openssl/safestack.h.in
+++ b/include/openssl/safestack.h.in
@@ -35,50 +35,6 @@ extern "C" {
 
 #define STACK_OF(type) struct stack_st_##type
 
-/* Helper macro for internal use */
-#define SKM_DEFINE_STACK_OF_INTERNAL(t1, t2, t3)                                                                         \
-    STACK_OF(t1);                                                                                                        \
-    typedef int (*sk_##t1##_compfunc)(const t3 *const *a, const t3 *const *b);                                           \
-    typedef void (*sk_##t1##_freefunc)(t3 * a);                                                                          \
-    typedef t3 *(*sk_##t1##_copyfunc)(const t3 *a);                                                                      \
-    static ossl_inline void sk_##t1##_freefunc_thunk(OPENSSL_sk_freefunc freefunc_arg, void *ptr)                        \
-    {                                                                                                                    \
-        sk_##t1##_freefunc freefunc = (sk_##t1##_freefunc)freefunc_arg;                                                  \
-        freefunc((t3 *)ptr);                                                                                             \
-    }                                                                                                                    \
-    static ossl_inline int sk_##t1##_cmpfunc_thunk(int (*cmp)(const void *, const void *), const void *a, const void *b) \
-    {                                                                                                                    \
-        int (*realcmp)(const t3 *const *a, const t3 *const *b) = (int (*)(const t3 *const *a, const t3 *const *b))(cmp); \
-        const t3 *const *at = (const t3 *const *)a;                                                                      \
-        const t3 *const *bt = (const t3 *const *)b;                                                                      \
-                                                                                                                         \
-        return realcmp(at, bt);                                                                                          \
-    }                                                                                                                    \
-    static ossl_unused ossl_inline t2 *ossl_check_##t1##_type(t2 *ptr)                                                   \
-    {                                                                                                                    \
-        return ptr;                                                                                                      \
-    }                                                                                                                    \
-    static ossl_unused ossl_inline const OPENSSL_STACK *ossl_check_const_##t1##_sk_type(const STACK_OF(t1) *sk)          \
-    {                                                                                                                    \
-        return (const OPENSSL_STACK *)sk;                                                                                \
-    }                                                                                                                    \
-    static ossl_unused ossl_inline OPENSSL_STACK *ossl_check_##t1##_sk_type(STACK_OF(t1) *sk)                            \
-    {                                                                                                                    \
-        return (OPENSSL_STACK *)sk;                                                                                      \
-    }                                                                                                                    \
-    static ossl_unused ossl_inline OPENSSL_sk_compfunc ossl_check_##t1##_compfunc_type(sk_##t1##_compfunc cmp)           \
-    {                                                                                                                    \
-        return (OPENSSL_sk_compfunc)cmp;                                                                                 \
-    }                                                                                                                    \
-    static ossl_unused ossl_inline OPENSSL_sk_copyfunc ossl_check_##t1##_copyfunc_type(sk_##t1##_copyfunc cpy)           \
-    {                                                                                                                    \
-        return (OPENSSL_sk_copyfunc)cpy;                                                                                 \
-    }                                                                                                                    \
-    static ossl_unused ossl_inline OPENSSL_sk_freefunc ossl_check_##t1##_freefunc_type(sk_##t1##_freefunc fr)            \
-    {                                                                                                                    \
-        return (OPENSSL_sk_freefunc)fr;                                                                                  \
-    }
-
 #define SKM_DEFINE_STACK_OF(t1, t2, t3)                                                                                    \
     STACK_OF(t1);                                                                                                          \
     typedef int (*sk_##t1##_compfunc)(const t3 *const *a, const t3 *const *b);                                             \

--- a/include/openssl/safestack.h.in
+++ b/include/openssl/safestack.h.in
@@ -35,6 +35,8 @@ extern "C" {
 
 #define STACK_OF(type) struct stack_st_##type
 
+#define SKM_DEFINE_STACK_OF_INTERNAL(t1, t2, t3) SKM_DEFINE_STACK_OF(t1, t2, t3)
+
 #define SKM_DEFINE_STACK_OF(t1, t2, t3)                                                                                    \
     STACK_OF(t1);                                                                                                          \
     typedef int (*sk_##t1##_compfunc)(const t3 *const *a, const t3 *const *b);                                             \

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -106,7 +106,6 @@ my $ignored = qr/(?| ^i2d_
                  |   ^IMPLEMENT_
                  |   ^_?DECLARE_
                  |   ^sk_
-                 |   ^SKM_DEFINE_STACK_OF_INTERNAL
                  |   ^lh_
                  |   ^DEFINE_LHASH_OF_(INTERNAL|DEPRECATED)
                  |   ^OSSL_HTO[BL]E(16|32|64)   # undefed

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -106,6 +106,7 @@ my $ignored = qr/(?| ^i2d_
                  |   ^IMPLEMENT_
                  |   ^_?DECLARE_
                  |   ^sk_
+                 |   ^SKM_DEFINE_STACK_OF_INTERNAL
                  |   ^lh_
                  |   ^DEFINE_LHASH_OF_(INTERNAL|DEPRECATED)
                  |   ^OSSL_HTO[BL]E(16|32|64)   # undefed

--- a/util/perl/OpenSSL/ParseC.pm
+++ b/util/perl/OpenSSL/ParseC.pm
@@ -393,21 +393,6 @@ static ossl_inline sk_$1_compfunc sk_$1_set_cmp_func(STACK_OF($1) *sk,
 EOF
       }
     },
-    { regexp   => qr/SKM_DEFINE_STACK_OF_INTERNAL<<<\((.*),\s*(.*),\s*(.*)\)>>>/,
-      massager => sub {
-          return (<<"EOF");
-STACK_OF($1);
-typedef int (*sk_$1_compfunc)(const $3 * const *a, const $3 *const *b);
-typedef void (*sk_$1_freefunc)($3 *a);
-typedef $3 * (*sk_$1_copyfunc)(const $3 *a);
-static ossl_unused ossl_inline $2 *ossl_check_$1_type($2 *ptr);
-static ossl_unused ossl_inline const OPENSSL_STACK *ossl_check_const_$1_sk_type(const STACK_OF($1) *sk);
-static ossl_unused ossl_inline OPENSSL_sk_compfunc ossl_check_$1_compfunc_type(sk_$1_compfunc cmp);
-static ossl_unused ossl_inline OPENSSL_sk_copyfunc ossl_check_$1_copyfunc_type(sk_$1_copyfunc cpy);
-static ossl_unused ossl_inline OPENSSL_sk_freefunc ossl_check_$1_freefunc_type(sk_$1_freefunc fr);
-EOF
-      }
-    },
     { regexp   => qr/DEFINE_SPECIAL_STACK_OF<<<\((.*),\s*(.*)\)>>>/,
       massager => sub { return ("SKM_DEFINE_STACK_OF($1,$2,$2)"); },
     },

--- a/util/perl/OpenSSL/stackhash.pm
+++ b/util/perl/OpenSSL/stackhash.pm
@@ -25,32 +25,7 @@ sub generate_stack_macros_int {
     my $plaintype = shift;
 
     my $macros = <<END_MACROS;
-SKM_DEFINE_STACK_OF_INTERNAL(${nametype}, ${realtype}, ${plaintype})
-#define sk_${nametype}_num(sk) OPENSSL_sk_num(ossl_check_const_${nametype}_sk_type(sk))
-#define sk_${nametype}_value(sk, idx) ((${realtype} *)OPENSSL_sk_value(ossl_check_const_${nametype}_sk_type(sk), (idx)))
-#define sk_${nametype}_new(cmp) ((STACK_OF(${nametype}) *)OPENSSL_sk_set_cmp_thunks(OPENSSL_sk_new(ossl_check_${nametype}_compfunc_type(cmp)), sk_${nametype}_cmpfunc_thunk))
-#define sk_${nametype}_new_null() ((STACK_OF(${nametype}) *)OPENSSL_sk_set_thunks(OPENSSL_sk_new_null(), sk_${nametype}_freefunc_thunk))
-#define sk_${nametype}_new_reserve(cmp, n) ((STACK_OF(${nametype}) *)OPENSSL_sk_set_cmp_thunks(OPENSSL_sk_new_reserve(ossl_check_${nametype}_compfunc_type(cmp), (n)), sk_${nametype}_cmpfunc_thunk))
-#define sk_${nametype}_reserve(sk, n) OPENSSL_sk_reserve(ossl_check_${nametype}_sk_type(sk), (n))
-#define sk_${nametype}_free(sk) OPENSSL_sk_free(ossl_check_${nametype}_sk_type(sk))
-#define sk_${nametype}_zero(sk) OPENSSL_sk_zero(ossl_check_${nametype}_sk_type(sk))
-#define sk_${nametype}_delete(sk, i) ((${realtype} *)OPENSSL_sk_delete(ossl_check_${nametype}_sk_type(sk), (i)))
-#define sk_${nametype}_delete_ptr(sk, ptr) ((${realtype} *)OPENSSL_sk_delete_ptr(ossl_check_${nametype}_sk_type(sk), ossl_check_${nametype}_type(ptr)))
-#define sk_${nametype}_push(sk, ptr) OPENSSL_sk_push(ossl_check_${nametype}_sk_type(sk), ossl_check_${nametype}_type(ptr))
-#define sk_${nametype}_unshift(sk, ptr) OPENSSL_sk_unshift(ossl_check_${nametype}_sk_type(sk), ossl_check_${nametype}_type(ptr))
-#define sk_${nametype}_pop(sk) ((${realtype} *)OPENSSL_sk_pop(ossl_check_${nametype}_sk_type(sk)))
-#define sk_${nametype}_shift(sk) ((${realtype} *)OPENSSL_sk_shift(ossl_check_${nametype}_sk_type(sk)))
-#define sk_${nametype}_pop_free(sk, freefunc) OPENSSL_sk_pop_free(ossl_check_${nametype}_sk_type(sk), ossl_check_${nametype}_freefunc_type(freefunc))
-#define sk_${nametype}_insert(sk, ptr, idx) OPENSSL_sk_insert(ossl_check_${nametype}_sk_type(sk), ossl_check_${nametype}_type(ptr), (idx))
-#define sk_${nametype}_set(sk, idx, ptr) ((${realtype} *)OPENSSL_sk_set(ossl_check_${nametype}_sk_type(sk), (idx), ossl_check_${nametype}_type(ptr)))
-#define sk_${nametype}_find(sk, ptr) OPENSSL_sk_find(ossl_check_${nametype}_sk_type(sk), ossl_check_${nametype}_type(ptr))
-#define sk_${nametype}_find_ex(sk, ptr) OPENSSL_sk_find_ex(ossl_check_${nametype}_sk_type(sk), ossl_check_${nametype}_type(ptr))
-#define sk_${nametype}_find_all(sk, ptr, pnum) OPENSSL_sk_find_all(ossl_check_${nametype}_sk_type(sk), ossl_check_${nametype}_type(ptr), pnum)
-#define sk_${nametype}_sort(sk) OPENSSL_sk_sort(ossl_check_${nametype}_sk_type(sk))
-#define sk_${nametype}_is_sorted(sk) OPENSSL_sk_is_sorted(ossl_check_const_${nametype}_sk_type(sk))
-#define sk_${nametype}_dup(sk) ((STACK_OF(${nametype}) *)OPENSSL_sk_dup(ossl_check_const_${nametype}_sk_type(sk)))
-#define sk_${nametype}_deep_copy(sk, copyfunc, freefunc) ((STACK_OF(${nametype}) *)OPENSSL_sk_deep_copy(ossl_check_const_${nametype}_sk_type(sk), ossl_check_${nametype}_copyfunc_type(copyfunc), ossl_check_${nametype}_freefunc_type(freefunc)))
-#define sk_${nametype}_set_cmp_func(sk, cmp) ((sk_${nametype}_compfunc)OPENSSL_sk_set_cmp_func(ossl_check_${nametype}_sk_type(sk), ossl_check_${nametype}_compfunc_type(cmp)))
+SKM_DEFINE_STACK_OF(${nametype}, ${realtype}, ${plaintype})
 END_MACROS
 
     return $macros;


### PR DESCRIPTION
remove a second, hand-maintained implementation of typed stack wrappers. Before this commit, OPENSSL_STRING, OPENSSL_CSTRING, and OPENSSL_BLOCK were generated as a separate pile of #define sk_* wrappers, while normal stacks used SKM_DEFINE_STACK_OF. That duplicated the same API surface and made it easy for bug fixes in the main stack macro to miss the special stack generator.

That divergence matters because the stack code uses callback thunks for typed callbacks. OPENSSL_sk_pop_free() checks st->free_thunk before invoking an element free callback. The canonical SKM_DEFINE_STACK_OF constructors install the free thunk and comparator thunk. The old generated string macros could lag behind those changes, meaning common paths such as sk_OPENSSL_STRING_new(...) followed by sk_OPENSSL_STRING_pop_free(...), were more likely to call typed callbacks through incompatible generic function pointer types.
