### PR TITLE
Limit the number of OCSP responder IDs we will process

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -435,9 +435,9 @@ OpenSSL Releases
 
  * Added restrictions on the maximum number of TLS `key_share`s (16)
    that a server will pay attention to, as well as the maximum number
-   of supported `group`s (128) and `sig_alg`s (128).  Any sent beyond
-   these limits are ignored, in order to avoid clients sending excessively
-   long lists in these extensions.
+   of supported `group`s (128), `sig_alg`s (128) and OCSP responder ids (16).
+   Any sent beyond these limits are ignored, in order to avoid clients sending
+   excessively long lists in these extensions.
    <!-- https://github.com/openssl/openssl/pull/30263 -->
 
    *Matt Caswell*

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -22,6 +22,7 @@
 #define MAX_SUPPORTED_GROUPS 128
 #define MAX_KEY_SHARES 16
 #define MAX_PRE_SHARED_KEYS 16
+#define MAX_OCSP_RESPONDER_IDS 16
 
 /*
  * 2 bytes for packet length, 2 bytes for format version, 2 bytes for
@@ -339,6 +340,7 @@ int tls_parse_ctos_status_request(SSL_CONNECTION *s, PACKET *pkt,
     X509 *x, size_t chainidx)
 {
     PACKET responder_id_list, exts;
+    int i;
 
     /* We ignore this in a resumption handshake */
     if (s->hit)
@@ -390,7 +392,11 @@ int tls_parse_ctos_status_request(SSL_CONNECTION *s, PACKET *pkt,
         s->ext.ocsp.ids = NULL;
     }
 
-    while (PACKET_remaining(&responder_id_list) > 0) {
+    /*
+     * Limit the number of OCSP responder IDs we will process - we ignore any
+     * beyond the limit.
+     */
+    for (i = 0; i < MAX_OCSP_RESPONDER_IDS && PACKET_remaining(&responder_id_list) > 0; i++) {
         OCSP_RESPID *id;
         PACKET responder_id;
         const unsigned char *id_data;

--- a/test/recipes/70-test_sslcertstatus.t
+++ b/test/recipes/70-test_sslcertstatus.t
@@ -45,8 +45,16 @@ my $proxy = TLSProxy::Proxy->new(
 #ServerHello but then omitting the CertificateStatus message is valid
 $proxy->clientflags("-status -no_tls1_3");
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
-plan tests => 1;
+plan tests => 2;
 ok(TLSProxy::Message->success, "Missing CertificateStatus message");
+
+#Test 2: Sending a status_request extension with more than 16 OCSP responder IDs
+#should be fine. We should just ignore the ones beyond the first 16.
+$proxy->clear();
+$proxy->serverflags("-status");
+$proxy->filter(\&modify_cert_status_filter);
+$proxy->start();
+ok(TLSProxy::Message->success(), "Large number of OCSP responder IDs");
 
 sub certstatus_filter
 {
@@ -63,6 +71,34 @@ sub certstatus_filter
             #going to send a CertificateStatus message
             $message->set_extension(TLSProxy::Message::EXT_STATUS_REQUEST,
                                     "");
+
+            $message->repack();
+        }
+    }
+}
+
+sub modify_cert_status_filter
+{
+    my $proxy = shift;
+
+    # We're only interested in the initial ClientHello
+    if ($proxy->flight != 0) {
+        return;
+    }
+
+    foreach my $message (@{$proxy->message_list}) {
+        if ($message->mt == TLSProxy::Message::MT_CLIENT_HELLO) {
+            my $ext;
+
+            # We include 17 OCSP responder IDs (we only accept the first 16).
+            # We should just ignore them and still succeed
+            $ext = pack "C107",
+                0x01, # Status type OCSP
+                0x00, 0x66, #List Length (102 bytes)
+                (0x00, 0x04, 0xA2, 0x02, 0x04, 0x00)x17, #17 dummy OCSP responder IDs
+                0x00, 0x00; # No extensions
+
+            $message->set_extension(TLSProxy::Message::EXT_STATUS_REQUEST, $ext);
 
             $message->repack();
         }


### PR DESCRIPTION
To avoid excessive memory consumption on the server we place a limit
on the number of OCSP responder IDs we are willing to process. We set the
limit at 16 which should be more than enough for any real world scenario.