### PR TITLE
Use CRYPTO_memcmp() when comparing the private keys

### DIFF
--- a/crypto/ml_dsa/ml_dsa_key.c
+++ b/crypto/ml_dsa/ml_dsa_key.c
@@ -293,7 +293,7 @@ int ossl_ml_dsa_key_equal(const ML_DSA_KEY *key1, const ML_DSA_KEY *key2,
         if (!key_checked
             && (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
             if (key1->priv_encoding != NULL && key2->priv_encoding != NULL) {
-                if (memcmp(key1->priv_encoding, key2->priv_encoding,
+                if (CRYPTO_memcmp(key1->priv_encoding, key2->priv_encoding,
                         key1->params->sk_len)
                     != 0)
                     return 0;

--- a/crypto/slh_dsa/slh_dsa_key.c
+++ b/crypto/slh_dsa/slh_dsa_key.c
@@ -202,7 +202,7 @@ int ossl_slh_dsa_key_equal(const SLH_DSA_KEY *key1, const SLH_DSA_KEY *key2,
         if (!key_checked
             && (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
             if (key1->has_priv && key2->has_priv) {
-                if (memcmp(key1->priv, key2->priv,
+                if (CRYPTO_memcmp(key1->priv, key2->priv,
                         key1->params->pk_len)
                     != 0)
                     return 0;


### PR DESCRIPTION
ML-DSA and SLH-DSA used regular memcmp, use CRYPTO_memcmp() just in case.
