### PR TITLE
aarch64: Add support for Armv9.4-A GCS in assembly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,17 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * Add support for AArch64 Guarded Control Stack (GCS) in assembly code.
+
+   When building with compilers that support GCS (Clang 18+, GCC 15+),
+   assembly modules are marked as compatible when branch protection is
+   enabled (e.g. -mbranch-protection=standard). No functional changes to
+   the assembly implementations are required, but compliance ensures
+   correct operation with shadow stack enforcement.
+
+   *Guillaume Gardet*
+   *Gowtham Suresh Kumar*
+
  * SubjectPublicKeyInfo blobs whose AlgorithmIdentifier uses id-RSAES-OAEP
    (NID_rsaesOaep, 1.2.840.113549.1.1.7) with a plain RSAPublicKey body
    are now decoded as RSA keys.  This is required for interoperability

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,17 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * Declare support for AArch64 Guarded Control Stack (GCS) in assembly code.
+
+   When building with compilers that support GCS (Clang 18+, GCC 15+),
+   assembly modules are marked as compatible when branch protection is
+   enabled (e.g. -mbranch-protection=standard). No functional changes to
+   the assembly implementations are required, but compliance ensures
+   correct operation with shadow stack enforcement.
+
+   *Guillaume Gardet*
+   *Gowtham Suresh Kumar*
+
  * Added support for DTLS 1.3 (RFC 9147). Refer to the ossl-guide-dtlsv13(7)
    manpage for details.
 

--- a/include/arch/arm_arch.h
+++ b/include/arch/arm_arch.h
@@ -194,7 +194,13 @@ extern unsigned int OPENSSL_armv8_rsa_neonized;
 #define AARCH64_VALIDATE_LINK_REGISTER
 #endif
 
-#if GNU_PROPERTY_AARCH64_POINTER_AUTH != 0 || GNU_PROPERTY_AARCH64_BTI != 0
+#if defined(__ARM_FEATURE_GCS_DEFAULT) && __ARM_FEATURE_GCS_DEFAULT == 1
+#define GNU_PROPERTY_AARCH64_GCS (1 << 2)
+#else
+#define GNU_PROPERTY_AARCH64_GCS 0 /* No GCS */
+#endif
+
+#if GNU_PROPERTY_AARCH64_POINTER_AUTH != 0 || GNU_PROPERTY_AARCH64_BTI != 0 || GNU_PROPERTY_AARCH64_GCS != 0
 /* clang-format off */
 .pushsection .note.gnu.property, "a";
 /* clang-format on */
@@ -205,7 +211,7 @@ extern unsigned int OPENSSL_armv8_rsa_neonized;
 .asciz "GNU";
 .long 0xc0000000; /* GNU_PROPERTY_AARCH64_FEATURE_1_AND */
 .long 4;
-.long(GNU_PROPERTY_AARCH64_POINTER_AUTH | GNU_PROPERTY_AARCH64_BTI);
+.long(GNU_PROPERTY_AARCH64_POINTER_AUTH | GNU_PROPERTY_AARCH64_BTI | GNU_PROPERTY_AARCH64_GCS);
 .long 0;
 .popsection;
 #endif

--- a/include/arch/arm_arch.h
+++ b/include/arch/arm_arch.h
@@ -159,8 +159,9 @@ extern unsigned int OPENSSL_armv8_rsa_neonized;
 
 /*
  * Support macros for
- *   - Armv8.3-A Pointer Authentication and
+ *   - Armv8.3-A Pointer Authentication
  *   - Armv8.5-A Branch Target Identification
+ *   - Armv9.4-A Guarded Control Stack
  * features which require emitting a .note.gnu.property section with the
  * appropriate architecture-dependent feature bits set.
  * Read more: "ELF for the Arm® 64-bit Architecture"
@@ -194,7 +195,13 @@ extern unsigned int OPENSSL_armv8_rsa_neonized;
 #define AARCH64_VALIDATE_LINK_REGISTER
 #endif
 
-#if GNU_PROPERTY_AARCH64_POINTER_AUTH != 0 || GNU_PROPERTY_AARCH64_BTI != 0
+#if defined(__ARM_FEATURE_GCS_DEFAULT) && __ARM_FEATURE_GCS_DEFAULT == 1
+#define GNU_PROPERTY_AARCH64_GCS (1 << 2)
+#else
+#define GNU_PROPERTY_AARCH64_GCS 0 /* No GCS */
+#endif
+
+#if GNU_PROPERTY_AARCH64_POINTER_AUTH != 0 || GNU_PROPERTY_AARCH64_BTI != 0 || GNU_PROPERTY_AARCH64_GCS != 0
 /* clang-format off */
 .pushsection .note.gnu.property, "a";
 /* clang-format on */
@@ -205,7 +212,7 @@ extern unsigned int OPENSSL_armv8_rsa_neonized;
 .asciz "GNU";
 .long 0xc0000000; /* GNU_PROPERTY_AARCH64_FEATURE_1_AND */
 .long 4;
-.long(GNU_PROPERTY_AARCH64_POINTER_AUTH | GNU_PROPERTY_AARCH64_BTI);
+.long(GNU_PROPERTY_AARCH64_POINTER_AUTH | GNU_PROPERTY_AARCH64_BTI | GNU_PROPERTY_AARCH64_GCS);
 .long 0;
 .popsection;
 #endif


### PR DESCRIPTION
Signal that AArch64 assembly code is compliant with the Armv9.4-A GCS feature by emitting the appropriate .gnu.note.property. GCS can be turned on using the toolchain flag -mbranch-protection=standard with Clang 18+ and GCC 15+.

The only requirement for the assembly code to be compliant with GCS is that all functions return to the expected call address - which is checked through a shadow stack.

Fixes #27712.