### PR TITLE
Fix memleak in hashtable free if flush fails

### DIFF
--- a/crypto/hashtable/hashtable.c
+++ b/crypto/hashtable/hashtable.c
@@ -363,19 +363,25 @@ int ossl_ht_flush(HT *h)
 
 void ossl_ht_free(HT *h)
 {
+    int flush_ok;
+
     if (h == NULL)
         return;
 
     ossl_ht_write_lock(h);
-    ossl_ht_flush_internal(h);
+    flush_ok = ossl_ht_flush_internal(h);
     ossl_ht_write_unlock(h);
     /* Freeing the lock does a final sync for us */
     if (!h->config.no_rcu) {
         CRYPTO_THREAD_lock_free(h->atomic_lock);
         ossl_rcu_lock_free(h->lock);
     }
-    OPENSSL_free(h->md->neighborhood_ptr_to_free);
-    OPENSSL_free(h->md);
+    if (flush_ok) {
+        OPENSSL_free(h->md->neighborhood_ptr_to_free);
+        OPENSSL_free(h->md);
+    } else {
+        free_oldmd(h->md);
+    }
     OPENSSL_free(h);
     return;
 }


### PR DESCRIPTION
This happens because free_oldmd is not run when flush fails.

The leak was found in #30944 and the issue fixes failed x509 fuzz test where this is visible. The mfail test will be done in a separate PR so it doesn't introduce accidentaly build failures in lower branches...

I chose a bit safer approach as a bug fix which is to fall back to the explicit `ossl_synchronize_rcu` and direct `free_oldmd` call only if flush fails so the logic is pretty much unchanged as flush can really fail when there is memory failure.

What I have been wondering is whether there is a need to do flush at all. The thing is that currently the flush does ossl_rcu_call (async rcu) and then immediately sets `h->wpd.need_sync = 1` which means that `ossl_synchronize_rcu` is called shortly after in unlock. This is how flush works and it makes sense for flushes elsewhere but for free it means that free actually needs to first allocate data which might not be an ideal thing. So it might be potentially worth to go with something simpler later (probs not as a bug fix but just for master):

```c
void ossl_ht_free(HT *h)
{
    if (h == NULL)
        return;

    if (!h->config.no_rcu) {
        ossl_synchronize_rcu(h->lock);
        CRYPTO_THREAD_lock_free(h->atomic_lock);
        ossl_rcu_lock_free(h->lock);
    }
    free_oldmd(h->md);
    OPENSSL_free(h);
    return;
}
```