### PR TITLE
Disentangle initial thread-local variable initialization.

### DIFF
--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -83,6 +83,16 @@ static GLOBAL_TEVENT_REGISTER *get_global_tevent_register(void)
 }
 #endif
 
+int CRYPTO_THREAD_init_local(CRYPTO_THREAD_LOCAL *key, void (*cleanup)(void *))
+{
+
+#ifndef FIPS_MODULE
+    if (!ossl_init_thread())
+        return 0;
+#endif
+    return ossl_thread_init_local(key, cleanup);
+}
+
 #ifndef FIPS_MODULE
 /*
  * Since per-thread-specific-data destructors are not universally
@@ -237,36 +247,18 @@ static void init_thread_destructor(void *hands)
 }
 
 static CRYPTO_ONCE ossl_init_thread_runonce = CRYPTO_ONCE_STATIC_INIT;
-/* MSVC linker can use other segment for uninitialized (zeroed) variables */
-#if defined(OPENSSL_SYS_WINDOWS)
-static CRYPTO_THREAD_ID recursion_guard = (CRYPTO_THREAD_ID)-1;
-#elif defined(OPENSSL_SYS_TANDEM) && (defined(_PUT_MODEL_) || defined(_KLT_MODEL_))
-static CRYPTO_THREAD_ID recursion_guard = { (void *)-1, (short)-1, (short)-1 };
-#else
-static CRYPTO_THREAD_ID recursion_guard = (CRYPTO_THREAD_ID)0;
-#endif
 
 DEFINE_RUN_ONCE_STATIC(ossl_init_thread_once)
 {
-    /* CRYPTO_THREAD_init_local() can call ossl_init_threads() again */
-    recursion_guard = CRYPTO_THREAD_get_current_id();
-    if (!CRYPTO_THREAD_init_local(&destructor_key.value,
+    if (!ossl_thread_init_local(&destructor_key.value,
             init_thread_destructor))
         return 0;
 
-#if defined(OPENSSL_SYS_TANDEM)
-    memset(&recursion_guard, 0, sizeof(recursion_guard));
-#else
-    recursion_guard = (CRYPTO_THREAD_ID)0;
-#endif
     return 1;
 }
 
 int ossl_init_thread(void)
 {
-    if (CRYPTO_THREAD_compare_id(recursion_guard,
-            CRYPTO_THREAD_get_current_id()))
-        return 1;
     if (!RUN_ONCE(&ossl_init_thread_runonce, ossl_init_thread_once))
         return 0;
     return 1;

--- a/crypto/threads_none.c
+++ b/crypto/threads_none.c
@@ -162,14 +162,9 @@ struct thread_local_storage_entry {
 
 static struct thread_local_storage_entry thread_local_storage[OPENSSL_CRYPTO_THREAD_LOCAL_KEY_MAX];
 
-int CRYPTO_THREAD_init_local(CRYPTO_THREAD_LOCAL *key, void (*cleanup)(void *))
+int ossl_thread_init_local(CRYPTO_THREAD_LOCAL *key, void (*cleanup)(void *))
 {
     int entry_idx = 0;
-
-#ifndef FIPS_MODULE
-    if (!ossl_init_thread())
-        return 0;
-#endif
 
     for (entry_idx = 0; entry_idx < OPENSSL_CRYPTO_THREAD_LOCAL_KEY_MAX; entry_idx++) {
         if (!thread_local_storage[entry_idx].used)

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -1012,13 +1012,8 @@ int CRYPTO_THREAD_run_once(CRYPTO_ONCE *once, void (*init)(void))
     return 1;
 }
 
-int CRYPTO_THREAD_init_local(CRYPTO_THREAD_LOCAL *key, void (*cleanup)(void *))
+int ossl_thread_init_local(CRYPTO_THREAD_LOCAL *key, void (*cleanup)(void *))
 {
-
-#ifndef FIPS_MODULE
-    if (!ossl_init_thread())
-        return 0;
-#endif
 
     if (pthread_key_create(key, cleanup) != 0)
         return 0;

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -548,13 +548,8 @@ int CRYPTO_THREAD_run_once(CRYPTO_ONCE *once, void (*init)(void))
     return (*lock == ONCE_DONE);
 }
 
-int CRYPTO_THREAD_init_local(CRYPTO_THREAD_LOCAL *key, void (*cleanup)(void *))
+int ossl_thread_init_local(CRYPTO_THREAD_LOCAL *key, void (*cleanup)(void *))
 {
-
-#ifndef FIPS_MODULE
-    if (!ossl_init_thread())
-        return 0;
-#endif
 
     *key = TlsAlloc();
     if (*key == TLS_OUT_OF_INDEXES)

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -132,6 +132,8 @@ OSSL_EX_DATA_GLOBAL *ossl_lib_ctx_get_ex_data_global(OSSL_LIB_CTX *ctx);
 
 const char *ossl_lib_ctx_get_descriptor(OSSL_LIB_CTX *libctx);
 
+int ossl_thread_init_local(CRYPTO_THREAD_LOCAL *key, void (*cleanup)(void *));
+
 OSSL_LIB_CTX *ossl_crypto_ex_data_get_ossl_lib_ctx(const CRYPTO_EX_DATA *ad);
 int ossl_crypto_new_ex_data_ex(OSSL_LIB_CTX *ctx, int class_index, void *obj,
     CRYPTO_EX_DATA *ad);


### PR DESCRIPTION
New internal routine ossl_thread_init_local implements the platform-specific part of CRYPTO_THREAD_init_local, which is now a wrapper that just does ossl_init_thread then ossl_thread_init_local. This avoids any need for a recursion guard in ossl_init_thread because the static call graph has no cycles:

```
CRYPTO_THREAD_init_local
=> ossl_init_thread
   => ossl_thread_init_local
=> ossl_thread_init_local
```

This avoids UB in pthread semantics, UB from data races, and platform-dependent #ifdefs.

fix https://github.com/openssl/openssl/issues/31166

(Adapted from https://github.com/openssl/openssl/pull/31167 on openssl-3.5 by resolving the trivial merge conflicts in crypto/initthread.c from cherry-pick into openssl-3.6.)