### PR TITLE
Fix const qualifier warning in `OBJ_bsearch_ex_` 

### DIFF
--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -616,8 +616,8 @@ const void *OBJ_bsearch_ex_(const void *key, const void *base, int num,
      */
     if (p == NULL) {
         const char *base_ = base;
-        int l, h, i = 0, c = 0;
-        char *p1;
+        int i = 0, c = 0;
+        const char *p1;
 
         for (i = 0; i < num; ++i) {
             p1 = &(base_[i * size]);


### PR DESCRIPTION

Fixes #31161

When building with CHARSET_EBCDIC defined,the compiler warns about discarding the 'const' qualifier when assigning from base_[i * size] to the non-const pointer p1:

`warning: assignment discards 'const' qualifier from pointer target type`

Change p1 from `char *` to `const char *` to maintain const-correctness since the data being pointed to should not be modified through this pointer.

Additionally, remove the unused variables l and h that were left over from a previous implementation of the fallback linear search. These variables served no purpose and only generated unused variable warnings.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
