### PR TITLE
Enforce RFC 8446 ticket lifetime limit for TLS 1.3 client

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -194,6 +194,18 @@ OpenSSL Releases
 
    *Timo Keller*
 
+ * Add client-side validation for TLS 1.3 session ticket lifetimes.
+
+   In accordance with [RFC 8446 Section 4.6.1](https://datatracker.ietf.org/doc/html/rfc8446#section-4.6.1),
+   TLS 1.3 clients must not cache session tickets
+   for longer than 7 days (604800 seconds).
+   When processing a new session ticket message with a
+   `ticket_lifetime_hint` value greater than 7 days,
+   the client now caps the lifetime to the
+   maximum permitted value of 7 days (604800 seconds).
+
+   *Abel Thomas*
+
 ### Changes between 3.6 and 4.0.0 [14 Apr 2026]
 
  * Added `-expected-rpks` option to the `openssl s_client`

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -3172,6 +3172,14 @@ MSG_PROCESS_RETURN tls_process_new_session_ticket(SSL_CONNECTION *s,
     if (SSL_CONNECTION_IS_TLS13(s)) {
         PACKET extpkt;
 
+        /*
+         * Fulfilling RFC8446:4.6.1 requirement: Clients MUST NOT cache
+         * tickets for longer than 7 days.
+         */
+        if (ticket_lifetime_hint > 604800) {
+            ticket_lifetime_hint = 604800;
+        }
+
         if (!PACKET_as_length_prefixed_2(pkt, &extpkt)
             || PACKET_remaining(pkt) != 0) {
             SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_LENGTH_MISMATCH);


### PR DESCRIPTION
Add validation to reject session ticket lifetime hints exceeding 604800 seconds (7 days) in TLS 1.3 connections, as required by RFC 8446 Section 4.6.1.

TLS 1.3 client validates the lifetime value received from the server.

Fixes #30808

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
