### PR TITLE
RISC-V: GHASH: Add multi-block aggregation for Zbc/Zvbc/Zvkg

### DIFF
--- a/crypto/modes/asm/ghash-riscv64-zvkb-zvbc.pl
+++ b/crypto/modes/asm/ghash-riscv64-zvkb-zvbc.pl
@@ -2,7 +2,7 @@
 # This file is dual-licensed, meaning that you can use it under your
 # choice of either of the following two licenses:
 #
-# Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2023-2026 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License"). You can obtain
 # a copy in the file LICENSE in the source distribution or at
@@ -11,6 +11,7 @@
 # or
 #
 # Copyright (c) 2023, Christoph Müllner <christoph.muellner@vrull.eu>
+# Copyright (c) 2026, Julian Zhu <julian.oerv@isrc.iscas.ac.cn>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -58,6 +59,12 @@ my $code=<<___;
 .text
 ___
 
+my ($V0, $V1, $V2, $V3, $V4, $V5, $V6, $V7,
+    $V8, $V9, $V10, $V11, $V12, $V13, $V14, $V15,
+    $V16, $V17, $V18, $V19, $V20, $V21, $V22, $V23,
+    $V24, $V25, $V26, $V27, $V28, $V29, $V30, $V31,
+) = map("v$_",(0..31));
+
 ################################################################################
 # void gcm_init_rv64i_zvkb_zvbc(u128 Htable[16], const u64 H[2]);
 #
@@ -65,8 +72,7 @@ ___
 # output:	Htable: Preprocessed key data for gcm_gmult_rv64i_zvkb_zvbc and
 #                       gcm_ghash_rv64i_zvkb_zvbc
 {
-my ($Htable,$H,$TMP0,$TMP1,$TMP2) = ("a0","a1","t0","t1","t2");
-my ($V0,$V1,$V2,$V3,$V4,$V5,$V6) = ("v0","v1","v2","v3","v4","v5","v6");
+my ($Htable,$H,$TMP0,$TMP1,$TMP2,$TMP3) = ("a0","a1","t0","t1","t2","t3");
 
 $code .= <<___;
 .p2align 3
@@ -108,7 +114,139 @@ gcm_init_rv64i_zvkb_zvbc:
 
     @{[vxor_vv_v0t $V1, $V1, $V2]}   # vxor.vv v1, v1, v2, v0.t
 
-    @{[vse64_v $V1, $Htable]}        # vse64.v v1, (a0)
+    @{[vse64_v $V1, $Htable]}        # vse64.v v1, (a0)  -- store H
+
+    # --- Compute H^2 = H * H for multi-block aggregation ---
+    ld      $TMP0, 0($Htable)
+    ld      $TMP1, 8($Htable)
+    la      $TMP3, Lpolymod
+    ld      $TMP3, 8($TMP3)
+
+    @{[vmv_v_v $V5, $V1]}           # copy H to v5
+
+    # Schoolbook multiply: H * H
+    @{[vclmul_vx  $V1, $V5, $TMP0]}
+    @{[vclmulh_vx $V3, $V5, $TMP0]}
+    @{[vclmul_vx  $V4, $V5, $TMP1]}
+    @{[vclmulh_vx $V2, $V5, $TMP1]}
+
+    @{[vslideup_vi   $V5, $V3, 1]}
+    @{[vslideup_vi   $V6, $V4, 1]}
+    @{[vslidedown_vi $V3, $V3, 1]}
+    @{[vslidedown_vi $V4, $V4, 1]}
+
+    @{[vmv_v_i $V0, 1]}
+    @{[vxor_vv_v0t $V2, $V2, $V3]}
+    @{[vxor_vv_v0t $V2, $V2, $V4]}
+
+    @{[vmv_v_i $V0, 2]}
+    @{[vxor_vv_v0t $V1, $V1, $V5]}
+    @{[vxor_vv_v0t $V1, $V1, $V6]}
+
+    # Gueron reduction
+    @{[vslideup_vi_v0t $V3, $V1, 1]}
+    @{[vclmul_vx_v0t $V3, $V3, $TMP3]}
+    @{[vxor_vv_v0t $V1, $V1, $V3]}
+
+    @{[vclmul_vx_v0t $V3, $V1, $TMP3]}
+    @{[vclmulh_vx $V4, $V1, $TMP3]}
+
+    @{[vmv_v_i $V0, 1]}
+    @{[vslidedown_vi $V3, $V3, 1]}
+
+    @{[vxor_vv $V1, $V1, $V4]}
+    @{[vxor_vv_v0t $V1, $V1, $V3]}
+
+    @{[vxor_vv $V2, $V2, $V1]}
+
+    # Store H^2 at Htable+16
+    addi    $Htable, $Htable, 16
+    @{[vse64_v $V2, $Htable]}
+
+    # --- Compute H^3 = H^2 * H ---
+    @{[vmv_v_v $V5, $V2]}           # v5 = H^2
+
+    @{[vclmul_vx  $V1, $V5, $TMP0]}
+    @{[vclmulh_vx $V3, $V5, $TMP0]}
+    @{[vclmul_vx  $V4, $V5, $TMP1]}
+    @{[vclmulh_vx $V2, $V5, $TMP1]}
+
+    @{[vslideup_vi   $V5, $V3, 1]}
+    @{[vslideup_vi   $V6, $V4, 1]}
+    @{[vslidedown_vi $V3, $V3, 1]}
+    @{[vslidedown_vi $V4, $V4, 1]}
+
+    @{[vmv_v_i $V0, 1]}
+    @{[vxor_vv_v0t $V2, $V2, $V3]}
+    @{[vxor_vv_v0t $V2, $V2, $V4]}
+
+    @{[vmv_v_i $V0, 2]}
+    @{[vxor_vv_v0t $V1, $V1, $V5]}
+    @{[vxor_vv_v0t $V1, $V1, $V6]}
+
+    @{[vslideup_vi_v0t $V3, $V1, 1]}
+    @{[vclmul_vx_v0t $V3, $V3, $TMP3]}
+    @{[vxor_vv_v0t $V1, $V1, $V3]}
+
+    @{[vclmul_vx_v0t $V3, $V1, $TMP3]}
+    @{[vclmulh_vx $V4, $V1, $TMP3]}
+
+    @{[vmv_v_i $V0, 1]}
+    @{[vslidedown_vi $V3, $V3, 1]}
+
+    @{[vxor_vv $V1, $V1, $V4]}
+    @{[vxor_vv_v0t $V1, $V1, $V3]}
+
+    @{[vxor_vv $V2, $V2, $V1]}
+
+    # Store H^3 at Htable+32
+    addi    $Htable, $Htable, 16
+    @{[vse64_v $V2, $Htable]}
+
+    # --- Compute H^4 = H^2 * H^2 ---
+    # Load H^2 vector and scalar halves from Htable-16
+    addi    $TMP2, $Htable, -16
+    ld      $TMP0, 0($TMP2)
+    ld      $TMP1, 8($TMP2)
+    @{[vle64_v $V5, $TMP2]}
+
+    @{[vclmul_vx  $V1, $V5, $TMP0]}
+    @{[vclmulh_vx $V3, $V5, $TMP0]}
+    @{[vclmul_vx  $V4, $V5, $TMP1]}
+    @{[vclmulh_vx $V2, $V5, $TMP1]}
+
+    @{[vslideup_vi   $V5, $V3, 1]}
+    @{[vslideup_vi   $V6, $V4, 1]}
+    @{[vslidedown_vi $V3, $V3, 1]}
+    @{[vslidedown_vi $V4, $V4, 1]}
+
+    @{[vmv_v_i $V0, 1]}
+    @{[vxor_vv_v0t $V2, $V2, $V3]}
+    @{[vxor_vv_v0t $V2, $V2, $V4]}
+
+    @{[vmv_v_i $V0, 2]}
+    @{[vxor_vv_v0t $V1, $V1, $V5]}
+    @{[vxor_vv_v0t $V1, $V1, $V6]}
+
+    @{[vslideup_vi_v0t $V3, $V1, 1]}
+    @{[vclmul_vx_v0t $V3, $V3, $TMP3]}
+    @{[vxor_vv_v0t $V1, $V1, $V3]}
+
+    @{[vclmul_vx_v0t $V3, $V1, $TMP3]}
+    @{[vclmulh_vx $V4, $V1, $TMP3]}
+
+    @{[vmv_v_i $V0, 1]}
+    @{[vslidedown_vi $V3, $V3, 1]}
+
+    @{[vxor_vv $V1, $V1, $V4]}
+    @{[vxor_vv_v0t $V1, $V1, $V3]}
+
+    @{[vxor_vv $V2, $V2, $V1]}
+
+    # Store H^4 at Htable+48
+    addi    $Htable, $Htable, 16
+    @{[vse64_v $V2, $Htable]}
+
     ret
 .size gcm_init_rv64i_zvkb_zvbc,.-gcm_init_rv64i_zvkb_zvbc
 ___
@@ -122,7 +260,6 @@ ___
 # output:	Xi: next hash value Xi = (Xi * H mod f)
 {
 my ($Xi,$Htable,$TMP0,$TMP1,$TMP2,$TMP3,$TMP4) = ("a0","a1","t0","t1","t2","t3","t4");
-my ($V0,$V1,$V2,$V3,$V4,$V5,$V6) = ("v0","v1","v2","v3","v4","v5","v6");
 
 $code .= <<___;
 .text
@@ -243,123 +380,324 @@ ___
 # output:	Xi: Xi+1 (next hash value Xi)
 {
 my ($Xi,$Htable,$inp,$len,$TMP0,$TMP1,$TMP2,$TMP3,$M8,$TMP5,$TMP6) = ("a0","a1","a2","a3","t0","t1","t2","t3","t4","t5","t6");
-my ($V0,$V1,$V2,$V3,$V4,$V5,$V6,$Vinp) = ("v0","v1","v2","v3","v4","v5","v6","v7");
+my ($s0,$s1,$s2,$s3) = ("s0","s1","s2","s3");
 
 $code .= <<___;
 .p2align 3
 .globl gcm_ghash_rv64i_zvkb_zvbc
 .type gcm_ghash_rv64i_zvkb_zvbc,\@function
 gcm_ghash_rv64i_zvkb_zvbc:
+    # Load H (for single-block and second multiply in 2-block)
     ld $TMP0, ($Htable)
     ld $TMP1, 8($Htable)
-    li $TMP2, 63
+    # Load H^2 (for first multiply in 2-block)
+    ld $TMP2, 16($Htable)
+    ld $TMP5, 24($Htable)
     la $TMP3, Lpolymod
     ld $TMP3, 8($TMP3)
 
-    # Load/store data in reverse order.
-    # This is needed as a part of endianness swap.
+    # Load/store data in reverse order for endianness swap.
     add $Xi, $Xi, 8
     add $inp, $inp, 8
     li $M8, -8
 
     @{[vsetivli__x0_2_e64_m1_tu_mu]} # vsetivli x0, 2, e64, m1, tu, mu
 
-    @{[vlse64_v $V5, $Xi, $M8]}      # vlse64.v v5, (a0), t4
+    @{[vlse64_v $V5, $Xi, $M8]}      # load Xi (word-swapped)
 
-Lstep:
-    # Read input data
-    @{[vlse64_v $Vinp, $inp, $M8]}   # vle64.v v0, (a2)
+    # Check for 4-block path (len >= 64)
+    li $TMP6, 64
+    blt $len, $TMP6, Lcheck_2x
+
+    # --- 4-block aggregation path ---
+    # Save callee-saved registers
+    addi sp, sp, -32
+    sd   s0, 0(sp)
+    sd   s1, 8(sp)
+    sd   s2, 16(sp)
+    sd   s3, 24(sp)
+
+    # Load H^3, H^4
+    ld s0, 32($Htable)              # H^3_lo
+    ld s1, 40($Htable)              # H^3_hi
+    ld s2, 48($Htable)              # H^4_lo
+    ld s3, 56($Htable)              # H^4_hi
+
+Lstep_4x:
+    # === Block 1: (Xi ^ C1) * H^4 ===
+    @{[vlse64_v $V7, $inp, $M8]}
+    add $inp, $inp, 16
+    @{[vxor_vv $V5, $V5, $V7]}
+    @{[vrev8_v $V5, $V5]}
+
+    @{[vclmul_vx  $V1, $V5, $s2]}
+    @{[vclmulh_vx $V3, $V5, $s2]}
+    @{[vclmul_vx  $V4, $V5, $s3]}
+    @{[vclmulh_vx $V2, $V5, $s3]}
+
+    @{[vslideup_vi   $V5, $V3, 1]}
+    @{[vslideup_vi   $V6, $V4, 1]}
+    @{[vslidedown_vi $V3, $V3, 1]}
+    @{[vslidedown_vi $V4, $V4, 1]}
+
+    @{[vmv_v_i $V0, 1]}
+    @{[vxor_vv_v0t $V2, $V2, $V3]}
+    @{[vxor_vv_v0t $V2, $V2, $V4]}
+    @{[vmv_v_i $V0, 2]}
+    @{[vxor_vv_v0t $V1, $V1, $V5]}
+    @{[vxor_vv_v0t $V1, $V1, $V6]}
+
+    # Save product 1
+    @{[vmv_v_v $V8, $V2]}
+    @{[vmv_v_v $V9, $V1]}
+
+    # === Block 2: C2 * H^3 ===
+    @{[vlse64_v $V7, $inp, $M8]}
+    add $inp, $inp, 16
+    @{[vrev8_v $V5, $V7]}
+
+    @{[vclmul_vx  $V1, $V5, $s0]}
+    @{[vclmulh_vx $V3, $V5, $s0]}
+    @{[vclmul_vx  $V4, $V5, $s1]}
+    @{[vclmulh_vx $V2, $V5, $s1]}
+
+    @{[vslideup_vi   $V5, $V3, 1]}
+    @{[vslideup_vi   $V6, $V4, 1]}
+    @{[vslidedown_vi $V3, $V3, 1]}
+    @{[vslidedown_vi $V4, $V4, 1]}
+
+    @{[vmv_v_i $V0, 1]}
+    @{[vxor_vv_v0t $V2, $V2, $V3]}
+    @{[vxor_vv_v0t $V2, $V2, $V4]}
+    @{[vmv_v_i $V0, 2]}
+    @{[vxor_vv_v0t $V1, $V1, $V5]}
+    @{[vxor_vv_v0t $V1, $V1, $V6]}
+
+    # Accumulate product 2
+    @{[vxor_vv $V8, $V8, $V2]}
+    @{[vxor_vv $V9, $V9, $V1]}
+
+    # === Block 3: C3 * H^2 ===
+    @{[vlse64_v $V7, $inp, $M8]}
+    add $inp, $inp, 16
+    @{[vrev8_v $V5, $V7]}
+
+    @{[vclmul_vx  $V1, $V5, $TMP2]}
+    @{[vclmulh_vx $V3, $V5, $TMP2]}
+    @{[vclmul_vx  $V4, $V5, $TMP5]}
+    @{[vclmulh_vx $V2, $V5, $TMP5]}
+
+    @{[vslideup_vi   $V5, $V3, 1]}
+    @{[vslideup_vi   $V6, $V4, 1]}
+    @{[vslidedown_vi $V3, $V3, 1]}
+    @{[vslidedown_vi $V4, $V4, 1]}
+
+    @{[vmv_v_i $V0, 1]}
+    @{[vxor_vv_v0t $V2, $V2, $V3]}
+    @{[vxor_vv_v0t $V2, $V2, $V4]}
+    @{[vmv_v_i $V0, 2]}
+    @{[vxor_vv_v0t $V1, $V1, $V5]}
+    @{[vxor_vv_v0t $V1, $V1, $V6]}
+
+    # Accumulate product 3
+    @{[vxor_vv $V8, $V8, $V2]}
+    @{[vxor_vv $V9, $V9, $V1]}
+
+    # === Block 4: C4 * H ===
+    @{[vlse64_v $V7, $inp, $M8]}
+    add $inp, $inp, 16
+    add $len, $len, -64
+    @{[vrev8_v $V5, $V7]}
+
+    @{[vclmul_vx  $V1, $V5, $TMP0]}
+    @{[vclmulh_vx $V3, $V5, $TMP0]}
+    @{[vclmul_vx  $V4, $V5, $TMP1]}
+    @{[vclmulh_vx $V2, $V5, $TMP1]}
+
+    @{[vslideup_vi   $V5, $V3, 1]}
+    @{[vslideup_vi   $V6, $V4, 1]}
+    @{[vslidedown_vi $V3, $V3, 1]}
+    @{[vslidedown_vi $V4, $V4, 1]}
+
+    @{[vmv_v_i $V0, 1]}
+    @{[vxor_vv_v0t $V2, $V2, $V3]}
+    @{[vxor_vv_v0t $V2, $V2, $V4]}
+    @{[vmv_v_i $V0, 2]}
+    @{[vxor_vv_v0t $V1, $V1, $V5]}
+    @{[vxor_vv_v0t $V1, $V1, $V6]}
+
+    # Combine all 4 products
+    @{[vxor_vv $V2, $V2, $V8]}
+    @{[vxor_vv $V1, $V1, $V9]}
+
+    # Single Gueron reduction for all 4 blocks
+    # v0 = 2 from above
+    @{[vslideup_vi_v0t $V3, $V1, 1]}
+    @{[vclmul_vx_v0t $V3, $V3, $TMP3]}
+    @{[vxor_vv_v0t $V1, $V1, $V3]}
+
+    @{[vclmul_vx_v0t $V3, $V1, $TMP3]}
+    @{[vclmulh_vx $V4, $V1, $TMP3]}
+
+    @{[vmv_v_i $V0, 1]}
+    @{[vslidedown_vi $V3, $V3, 1]}
+
+    @{[vxor_vv $V1, $V1, $V4]}
+    @{[vxor_vv_v0t $V1, $V1, $V3]}
+
+    @{[vxor_vv $V2, $V2, $V1]}
+
+    @{[vrev8_v $V5, $V2]}
+
+    li $TMP6, 64
+    bge $len, $TMP6, Lstep_4x
+
+    # Restore callee-saved registers
+    ld   s0, 0(sp)
+    ld   s1, 8(sp)
+    ld   s2, 16(sp)
+    ld   s3, 24(sp)
+    addi sp, sp, 32
+
+Lcheck_2x:
+    # Check for 2-block path (len >= 32)
+    li $TMP6, 32
+    blt $len, $TMP6, Lcheck_1x
+
+Lstep_2x:
+    # === 2-block iteration: (Xi ^ C1) * H^2 + C2 * H ===
+
+    # Block 1: load C1, XOR with Xi
+    @{[vlse64_v $V7, $inp, $M8]}
     add $inp, $inp, 16
     add $len, $len, -16
-    # XOR them into Xi
-    @{[vxor_vv $V5, $V5, $Vinp]}       # vxor.vv v0, v0, v1
+    @{[vxor_vv $V5, $V5, $V7]}
+    @{[vrev8_v $V5, $V5]}
 
-    @{[vrev8_v $V5, $V5]}            # vrev8.v v5, v5
+    # Schoolbook multiply (Xi ^ C1) * H^2 -> product in (v2, v1)
+    @{[vclmul_vx  $V1, $V5, $TMP2]}
+    @{[vclmulh_vx $V3, $V5, $TMP2]}
+    @{[vclmul_vx  $V4, $V5, $TMP5]}
+    @{[vclmulh_vx $V2, $V5, $TMP5]}
 
-    # Multiplication
+    @{[vslideup_vi   $V5, $V3, 1]}
+    @{[vslideup_vi   $V6, $V4, 1]}
+    @{[vslidedown_vi $V3, $V3, 1]}
+    @{[vslidedown_vi $V4, $V4, 1]}
 
-    # Do two 64x64 multiplications in one go to save some time
-    # and simplify things.
+    @{[vmv_v_i $V0, 1]}
+    @{[vxor_vv_v0t $V2, $V2, $V3]}
+    @{[vxor_vv_v0t $V2, $V2, $V4]}
+    @{[vmv_v_i $V0, 2]}
+    @{[vxor_vv_v0t $V1, $V1, $V5]}
+    @{[vxor_vv_v0t $V1, $V1, $V6]}
 
-    # A = a1a0 (t1, t0)
-    # B = b1b0 (v5)
-    # C = c1c0 (256 bit)
-    # c1 = a1b1 + (a0b1)h + (a1b0)h
-    # c0 = a0b0 + (a0b1)l + (a1b0)h
+    # Save first product
+    @{[vmv_v_v $V8, $V2]}
+    @{[vmv_v_v $V9, $V1]}
 
-    # v1 = (a0b1)l,(a0b0)l
-    @{[vclmul_vx $V1, $V5, $TMP0]}   # vclmul.vx v1, v5, t0
-    # v3 = (a0b1)h,(a0b0)h
-    @{[vclmulh_vx $V3, $V5, $TMP0]}  # vclmulh.vx v3, v5, t0
+    # Block 2: load C2 (no XOR with Xi)
+    @{[vlse64_v $V7, $inp, $M8]}
+    add $inp, $inp, 16
+    add $len, $len, -16
+    @{[vrev8_v $V5, $V7]}
 
-    # v4 = (a1b1)l,(a1b0)l
-    @{[vclmul_vx $V4, $V5, $TMP1]}   # vclmul.vx v4, v5, t1
-    # v2 = (a1b1)h,(a1b0)h
-    @{[vclmulh_vx $V2, $V5, $TMP1]}   # vclmulh.vx v2, v5, t1
+    # Schoolbook multiply C2 * H -> product in (v2, v1)
+    @{[vclmul_vx  $V1, $V5, $TMP0]}
+    @{[vclmulh_vx $V3, $V5, $TMP0]}
+    @{[vclmul_vx  $V4, $V5, $TMP1]}
+    @{[vclmulh_vx $V2, $V5, $TMP1]}
 
-    # Is there a better way to do this?
-    # Would need to swap the order of elements within a vector register.
-    @{[vslideup_vi $V5, $V3, 1]}     # vslideup.vi v5, v3, 1
-    @{[vslideup_vi $V6, $V4, 1]}     # vslideup.vi v6, v4, 1
-    @{[vslidedown_vi $V3, $V3, 1]}   # vslidedown.vi v3, v3, 1
-    @{[vslidedown_vi $V4, $V4, 1]}   # vslidedown.vi v4, v4, 1
+    @{[vslideup_vi   $V5, $V3, 1]}
+    @{[vslideup_vi   $V6, $V4, 1]}
+    @{[vslidedown_vi $V3, $V3, 1]}
+    @{[vslidedown_vi $V4, $V4, 1]}
 
-    @{[vmv_v_i $V0, 1]}              # vmv.v.i v0, 1
-    # v2 += (a0b1)h
-    @{[vxor_vv_v0t $V2, $V2, $V3]}   # vxor.vv v2, v2, v3, v0.t
-    # v2 += (a1b1)l
-    @{[vxor_vv_v0t $V2, $V2, $V4]}   # vxor.vv v2, v2, v4, v0.t
+    @{[vmv_v_i $V0, 1]}
+    @{[vxor_vv_v0t $V2, $V2, $V3]}
+    @{[vxor_vv_v0t $V2, $V2, $V4]}
+    @{[vmv_v_i $V0, 2]}
+    @{[vxor_vv_v0t $V1, $V1, $V5]}
+    @{[vxor_vv_v0t $V1, $V1, $V6]}
 
-    @{[vmv_v_i $V0, 2]}              # vmv.v.i v0, 2
-    # v1 += (a0b0)h,0
-    @{[vxor_vv_v0t $V1, $V1, $V5]}   # vxor.vv v1, v1, v5, v0.t
-    # v1 += (a1b0)l,0
-    @{[vxor_vv_v0t $V1, $V1, $V6]}   # vxor.vv v1, v1, v6, v0.t
+    # Combine products: (v2,v1) += (v8,v9)
+    @{[vxor_vv $V2, $V2, $V8]}
+    @{[vxor_vv $V1, $V1, $V9]}
 
-    # Now the 256bit product should be stored in (v2,v1)
-    # v1 = (a0b1)l + (a0b0)h + (a1b0)l, (a0b0)l
-    # v2 = (a1b1)h, (a1b0)h + (a0b1)h + (a1b1)l
+    # Single Gueron reduction for both blocks
+    # v0 = 2 from above
+    @{[vslideup_vi_v0t $V3, $V1, 1]}
+    @{[vclmul_vx_v0t $V3, $V3, $TMP3]}
+    @{[vxor_vv_v0t $V1, $V1, $V3]}
 
-    # Reduction
-    # Let C := A*B = c3,c2,c1,c0 = v2[1],v2[0],v1[1],v1[0]
-    # This is a slight variation of the Gueron's Montgomery reduction.
-    # The difference being the order of some operations has been changed,
-    # to make a better use of vclmul(h) instructions.
+    @{[vclmul_vx_v0t $V3, $V1, $TMP3]}
+    @{[vclmulh_vx $V4, $V1, $TMP3]}
 
-    # First step:
-    # c1 += (c0 * P)l
-    # vmv.v.i v0, 2
-    @{[vslideup_vi_v0t $V3, $V1, 1]} # vslideup.vi v3, v1, 1, v0.t
-    @{[vclmul_vx_v0t $V3, $V3, $TMP3]} # vclmul.vx v3, v3, t3, v0.t
-    @{[vxor_vv_v0t $V1, $V1, $V3]}   # vxor.vv v1, v1, v3, v0.t
+    @{[vmv_v_i $V0, 1]}
+    @{[vslidedown_vi $V3, $V3, 1]}
 
-    # Second step:
-    # D = d1,d0 is final result
-    # We want:
-    # m1 = c1 + (c1 * P)h
-    # m0 = (c1 * P)l + (c0 * P)h + c0
-    # d1 = c3 + m1
-    # d0 = c2 + m0
+    @{[vxor_vv $V1, $V1, $V4]}
+    @{[vxor_vv_v0t $V1, $V1, $V3]}
 
-    #v3 = (c1 * P)l, 0
-    @{[vclmul_vx_v0t $V3, $V1, $TMP3]} # vclmul.vx v3, v1, t3, v0.t
-    #v4 = (c1 * P)h, (c0 * P)h
-    @{[vclmulh_vx $V4, $V1, $TMP3]}   # vclmulh.vx v4, v1, t3
+    @{[vxor_vv $V2, $V2, $V1]}
 
-    @{[vmv_v_i $V0, 1]}              # vmv.v.i v0, 1
-    @{[vslidedown_vi $V3, $V3, 1]}   # vslidedown.vi v3, v3, 1
+    @{[vrev8_v $V5, $V2]}
 
-    @{[vxor_vv $V1, $V1, $V4]}       # vxor.vv v1, v1, v4
-    @{[vxor_vv_v0t $V1, $V1, $V3]}   # vxor.vv v1, v1, v3, v0.t
+    li $TMP6, 32
+    bge $len, $TMP6, Lstep_2x
 
-    # XOR in the upper upper part of the product
-    @{[vxor_vv $V2, $V2, $V1]}       # vxor.vv v2, v2, v1
+Lcheck_1x:
+    # Check for remaining single block
+    beqz $len, Ldone
 
-    @{[vrev8_v $V5, $V2]}            # vrev8.v v2, v2
+Lstep:
+    # === Single-block: (Xi ^ block) * H ===
+    @{[vlse64_v $V7, $inp, $M8]}
+    add $inp, $inp, 16
+    add $len, $len, -16
+    @{[vxor_vv $V5, $V5, $V7]}
+    @{[vrev8_v $V5, $V5]}
+
+    # Schoolbook multiply * H
+    @{[vclmul_vx  $V1, $V5, $TMP0]}
+    @{[vclmulh_vx $V3, $V5, $TMP0]}
+    @{[vclmul_vx  $V4, $V5, $TMP1]}
+    @{[vclmulh_vx $V2, $V5, $TMP1]}
+
+    @{[vslideup_vi   $V5, $V3, 1]}
+    @{[vslideup_vi   $V6, $V4, 1]}
+    @{[vslidedown_vi $V3, $V3, 1]}
+    @{[vslidedown_vi $V4, $V4, 1]}
+
+    @{[vmv_v_i $V0, 1]}
+    @{[vxor_vv_v0t $V2, $V2, $V3]}
+    @{[vxor_vv_v0t $V2, $V2, $V4]}
+    @{[vmv_v_i $V0, 2]}
+    @{[vxor_vv_v0t $V1, $V1, $V5]}
+    @{[vxor_vv_v0t $V1, $V1, $V6]}
+
+    # Gueron reduction
+    @{[vslideup_vi_v0t $V3, $V1, 1]}
+    @{[vclmul_vx_v0t $V3, $V3, $TMP3]}
+    @{[vxor_vv_v0t $V1, $V1, $V3]}
+
+    @{[vclmul_vx_v0t $V3, $V1, $TMP3]}
+    @{[vclmulh_vx $V4, $V1, $TMP3]}
+
+    @{[vmv_v_i $V0, 1]}
+    @{[vslidedown_vi $V3, $V3, 1]}
+
+    @{[vxor_vv $V1, $V1, $V4]}
+    @{[vxor_vv_v0t $V1, $V1, $V3]}
+
+    @{[vxor_vv $V2, $V2, $V1]}
+
+    @{[vrev8_v $V5, $V2]}
 
     bnez $len, Lstep
 
-    @{[vsse64_v $V5, $Xi, $M8]}    # vsse64.v v2, (a0), t4
+Ldone:
+    @{[vsse64_v $V5, $Xi, $M8]}
     ret
 .size gcm_ghash_rv64i_zvkb_zvbc,.-gcm_ghash_rv64i_zvkb_zvbc
 ___

--- a/crypto/modes/asm/ghash-riscv64-zvkg.pl
+++ b/crypto/modes/asm/ghash-riscv64-zvkg.pl
@@ -2,7 +2,7 @@
 # This file is dual-licensed, meaning that you can use it under your
 # choice of either of the following two licenses:
 #
-# Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2023-2026 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License"). You can obtain
 # a copy in the file LICENSE in the source distribution or at
@@ -11,6 +11,7 @@
 # or
 #
 # Copyright (c) 2023, Christoph Müllner <christoph.muellner@vrull.eu>
+# Copyright (c) 2026, Julian Zhu <julian.oerv@isrc.iscas.ac.cn>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -60,6 +61,12 @@ my $code=<<___;
 .text
 ___
 
+my ($V0, $V1, $V2, $V3, $V4, $V5, $V6, $V7,
+    $V8, $V9, $V10, $V11, $V12, $V13, $V14, $V15,
+    $V16, $V17, $V18, $V19, $V20, $V21, $V22, $V23,
+    $V24, $V25, $V26, $V27, $V28, $V29, $V30, $V31,
+) = map("v$_",(0..31));
+
 ################################################################################
 # void gcm_init_rv64i_zvkg(u128 Htable[16], const u64 H[2]);
 # void gcm_init_rv64i_zvkg_zvkb(u128 Htable[16], const u64 H[2]);
@@ -77,27 +84,61 @@ $code .= <<___;
 .globl gcm_init_rv64i_zvkg
 .type gcm_init_rv64i_zvkg,\@function
 gcm_init_rv64i_zvkg:
-    ld      $VAL0, 0($H)
-    ld      $VAL1, 8($H)
+    # Store byte-reversed H at Htable[0]
+    ld     $VAL0, 0($H)
+    ld     $VAL1, 8($H)
     @{[sd_rev8_rv64i $VAL0, $Htable, 0, $TMP0]}
     @{[sd_rev8_rv64i $VAL1, $Htable, 8, $TMP0]}
+
+    # Precompute H^2, H^3, H^4 for multi-block aggregation
+    @{[vsetivli__x0_4_e32_m1_tu_mu]}
+    @{[vle32_v $V1, $Htable]}         # v1 = H
+    @{[vmv_v_v $V2, $V1]}
+    @{[vgmul_vv $V2, $V1]}           # v2 = H * H = H^2
+    addi $TMP0, $Htable, 16
+    @{[vse32_v $V2, $TMP0]}           # Htable[16] = H^2
+    @{[vmv_v_v $V3, $V2]}
+    @{[vgmul_vv $V3, $V1]}           # v3 = H^2 * H = H^3
+    addi $TMP0, $TMP0, 16
+    @{[vse32_v $V3, $TMP0]}           # Htable[32] = H^3
+    @{[vmv_v_v $V4, $V2]}
+    @{[vgmul_vv $V4, $V2]}           # v4 = H^2 * H^2 = H^4
+    addi $TMP0, $TMP0, 16
+    @{[vse32_v $V4, $TMP0]}           # Htable[48] = H^4
     ret
 .size gcm_init_rv64i_zvkg,.-gcm_init_rv64i_zvkg
 ___
 }
 
 {
-my ($Htable,$H,$V0) = ("a0","a1","v0");
+my ($Htable,$H) = ("a0","a1");
 
 $code .= <<___;
 .p2align 3
 .globl gcm_init_rv64i_zvkg_zvkb
 .type gcm_init_rv64i_zvkg_zvkb,\@function
 gcm_init_rv64i_zvkg_zvkb:
-    @{[vsetivli__x0_2_e64_m1_tu_mu]} # vsetivli x0, 2, e64, m1, tu, mu
-    @{[vle64_v $V0, $H]}             # vle64.v v0, (a1)
-    @{[vrev8_v $V0, $V0]}            # vrev8.v v0, v0
-    @{[vse64_v $V0, $Htable]}        # vse64.v v0, (a0)
+    # Store byte-reversed H at Htable[0]
+    @{[vsetivli__x0_2_e64_m1_tu_mu]}
+    @{[vle64_v $V0, $H]}
+    @{[vrev8_v $V0, $V0]}
+    @{[vse64_v $V0, $Htable]}
+
+    # Precompute H^2, H^3, H^4 for multi-block aggregation
+    @{[vsetivli__x0_4_e32_m1_tu_mu]}
+    # v0 already holds H (same bits, reinterpreted as 4×e32)
+    @{[vmv_v_v $V1, $V0]}
+    @{[vgmul_vv $V1, $V0]}           # v1 = H^2
+    addi t0, $Htable, 16
+    @{[vse32_v $V1, "t0"]}           # Htable[16] = H^2
+    @{[vmv_v_v $V2, $V1]}
+    @{[vgmul_vv $V2, $V0]}           # v2 = H^2 * H = H^3
+    addi t0, t0, 16
+    @{[vse32_v $V2, "t0"]}           # Htable[32] = H^3
+    @{[vmv_v_v $V3, $V1]}
+    @{[vgmul_vv $V3, $V1]}          # v3 = H^2 * H^2 = H^4
+    addi t0, t0, 16
+    @{[vse32_v $V3, "t0"]}           # Htable[48] = H^4
     ret
 .size gcm_init_rv64i_zvkg_zvkb,.-gcm_init_rv64i_zvkg_zvkb
 ___
@@ -107,7 +148,7 @@ ___
 # void gcm_gmult_rv64i_zvkg(u64 Xi[2], const u128 Htable[16]);
 #
 # input: Xi: current hash value
-#        Htable: copy of H
+#       Htable: copy of H
 # output: Xi: next hash value Xi
 {
 my ($Xi,$Htable) = ("a0","a1");
@@ -130,16 +171,24 @@ ___
 
 ################################################################################
 # void gcm_ghash_rv64i_zvkg(u64 Xi[2], const u128 Htable[16],
-#                           const u8 *inp, size_t len);
+#                      const u8 *inp, size_t len);
 #
 # input: Xi: current hash value
-#        Htable: copy of H
-#        inp: pointer to input data
-#        len: length of input data in bytes (multiple of block size)
+#       Htable: copy of H, H^2, H^3, H^4
+#       inp: pointer to input data
+#       len: length of input data in bytes (multiple of block size)
 # output: Xi: Xi+1 (next hash value Xi)
+#
+# Uses 4-block aggregation when len >= 64:
+#   4 independent accumulators (v20-v23), each using vghsh.vv with m1.
+#   Main loop: all 4 lanes multiply by H^4.
+#   Last 4-block set: lanes multiply by [H^4, H^3, H^2, H].
+#   Result = XOR of all 4 lanes.
+#   Tail: single-block loop for remaining 1-3 blocks.
+#   This approach is VLEN-independent (always uses m1 with vl=4).
 {
 my ($Xi,$Htable,$inp,$len) = ("a0","a1","a2","a3");
-my ($vXi,$vH,$vinp,$Vzero) = ("v1","v2","v3","v4");
+my ($vXi,$vH,$vinp) = ("v1","v2","v3");
 
 $code .= <<___;
 .p2align 3
@@ -147,16 +196,84 @@ $code .= <<___;
 .type gcm_ghash_rv64i_zvkg,\@function
 gcm_ghash_rv64i_zvkg:
     @{[vsetivli__x0_4_e32_m1_tu_mu]}
-    @{[vle32_v $vH, $Htable]}
-    @{[vle32_v $vXi, $Xi]}
+    @{[vle32_v $vH, $Htable]}          # v2 = H
+    @{[vle32_v $vXi, $Xi]}            # v1 = Xi
 
-Lstep:
+    # Check for 4-block path (need at least 64 bytes)
+    li     t0, 64
+    blt    $len, t0, .Lstep_zvkg
+
+    # --- 4-block aggregation path ---
+    # Load H powers: H^4, H^3, H^2 (H already in v2)
+    addi    t0, $Htable, 48
+    @{[vle32_v $V5, "t0"]}            # v5 = H^4
+    addi    t0, $Htable, 32
+    @{[vle32_v $V6, "t0"]}            # v6 = H^3
+    addi    t0, $Htable, 16
+    @{[vle32_v $V7, "t0"]}            # v7 = H^2
+
+    # Initialize 4 accumulator lanes: v20=Xi, v21=v22=v23=0
+    @{[vmv_v_v $V20, $vXi]}
+    @{[vmv_v_i $V21, 0]}
+    @{[vmv_v_i $V22, 0]}
+    @{[vmv_v_i $V23, 0]}
+
+    # Need >= 128 bytes for main loop (at least 2 sets of 4 blocks)
+    li     t0, 128
+    blt    $len, t0, .Llast_4x_zvkg
+
+.Lghash_4x_zvkg:
+    # Load 4 blocks
+    @{[vle32_v $V8, $inp]}
+    addi    $inp, $inp, 16
+    @{[vle32_v $V9, $inp]}
+    addi    $inp, $inp, 16
+    @{[vle32_v $V10, $inp]}
+    addi    $inp, $inp, 16
+    @{[vle32_v $V11, $inp]}
+    addi    $inp, $inp, 16
+    add     $len, $len, -64
+    # 4 independent GHASH operations with H^4
+    @{[vghsh_vv $V20, $V5, $V8]}
+    @{[vghsh_vv $V21, $V5, $V9]}
+    @{[vghsh_vv $V22, $V5, $V10]}
+    @{[vghsh_vv $V23, $V5, $V11]}
+    li     t0, 128
+    bge    $len, t0, .Lghash_4x_zvkg
+
+.Llast_4x_zvkg:
+    # Process last 4-block set with [H^4, H^3, H^2, H]
+    @{[vle32_v $V8, $inp]}
+    addi    $inp, $inp, 16
+    @{[vle32_v $V9, $inp]}
+    addi    $inp, $inp, 16
+    @{[vle32_v $V10, $inp]}
+    addi    $inp, $inp, 16
+    @{[vle32_v $V11, $inp]}
+    addi    $inp, $inp, 16
+    add     $len, $len, -64
+    @{[vghsh_vv $V20, $V5, $V8]}     # lane 0 x H^4
+    @{[vghsh_vv $V21, $V6, $V9]}     # lane 1 x H^3
+    @{[vghsh_vv $V22, $V7, $V10]}    # lane 2 x H^2
+    @{[vghsh_vv $V23, $vH, $V11]}    # lane 3 x H
+
+    # Combine 4 lanes: result = S0 ^ S1 ^ S2 ^ S3
+    @{[vxor_vv $V20, $V20, $V21]}
+    @{[vxor_vv $V20, $V20, $V22]}
+    @{[vxor_vv $V20, $V20, $V23]}
+
+    @{[vmv_v_v $vXi, $V20]}          # v1 = combined result
+    beqz    $len, .Ldone_zvkg
+
+.Lstep_zvkg:
+    # Single-block loop for remaining 1-3 blocks
     @{[vle32_v $vinp, $inp]}
-    add $inp, $inp, 16
-    add $len, $len, -16
+    add    $inp, $inp, 16
+    add    $len, $len, -16
     @{[vghsh_vv $vXi, $vH, $vinp]}
-    bnez $len, Lstep
+    bnez    $len, .Lstep_zvkg
 
+.Ldone_zvkg:
     @{[vse32_v $vXi, $Xi]}
     ret
 

--- a/crypto/modes/asm/ghash-riscv64.pl
+++ b/crypto/modes/asm/ghash-riscv64.pl
@@ -2,7 +2,7 @@
 # This file is dual-licensed, meaning that you can use it under your
 # choice of either of the following two licenses:
 #
-# Copyright 2022-2023 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2022-2026 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License"). You can obtain
 # a copy in the file LICENSE in the source distribution or at
@@ -11,6 +11,7 @@
 # or
 #
 # Copyright (c) 2023, Christoph Müllner <christoph.muellner@vrull.eu>
+# Copyright (c) 2026, Julian Zhu <julian.oerv@isrc.iscas.ac.cn>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -68,6 +69,7 @@ ___
 
 {
 my ($Htable,$H,$VAL0,$VAL1,$TMP0,$TMP1,$TMP2) = ("a0","a1","a2","a3","t0","t1","t2");
+my ($z0,$z1,$z2,$z3,$r0,$r1,$polymod) = ("a4","a5","a6","a7","t3","t4","t5");
 
 $code .= <<___;
 .p2align 3
@@ -80,6 +82,73 @@ gcm_init_rv64i_zbc:
     @{[brev8_rv64i   $VAL1, $TMP0, $TMP1, $TMP2]}
     @{[sd_rev8_rv64i $VAL0, $Htable, 0, $TMP0]}
     @{[sd_rev8_rv64i $VAL1, $Htable, 8, $TMP0]}
+
+    # Compute H^2 = H*H for 2-block ghash aggregation.
+    # Re-load H in multiply-ready format.
+    ld        $VAL0, 0($Htable)
+    ld        $VAL1, 8($Htable)
+    la        $polymod, Lpolymod
+    lbu       $polymod, 0($polymod)
+    # Squaring in GF(2): cross terms cancel, only 4 clmul needed.
+    @{[clmulh $z3, $VAL1, $VAL1]}
+    @{[clmul  $z2, $VAL1, $VAL1]}
+    @{[clmulh $z1, $VAL0, $VAL0]}
+    @{[clmul  $z0, $VAL0, $VAL0]}
+    @{[clmulh $r1, $z3, $polymod]}
+    @{[clmul  $r0, $z3, $polymod]}
+    xor       $z2, $z2, $r1
+    xor       $z1, $z1, $r0
+    @{[clmulh $r1, $z2, $polymod]}
+    @{[clmul  $r0, $z2, $polymod]}
+    xor       $VAL1, $z1, $r1
+    xor       $VAL0, $z0, $r0
+    sd        $VAL0, 16($Htable)
+    sd        $VAL1, 24($Htable)
+
+    # Compute H^3 = H^2 * H for 4-block ghash aggregation.
+    ld        $TMP0, 0($Htable)
+    ld        $TMP1, 8($Htable)
+    @{[clmulh $z3, $VAL1, $TMP1]}
+    @{[clmul  $z2, $VAL1, $TMP1]}
+    @{[clmulh $r1, $VAL0, $TMP1]}
+    @{[clmul  $z1, $VAL0, $TMP1]}
+    xor       $z2, $z2, $r1
+    @{[clmulh $r1, $VAL1, $TMP0]}
+    @{[clmul  $r0, $VAL1, $TMP0]}
+    xor       $z2, $z2, $r1
+    xor       $z1, $z1, $r0
+    @{[clmulh $r1, $VAL0, $TMP0]}
+    @{[clmul  $z0, $VAL0, $TMP0]}
+    xor       $z1, $z1, $r1
+    @{[clmulh $r1, $z3, $polymod]}
+    @{[clmul  $r0, $z3, $polymod]}
+    xor       $z2, $z2, $r1
+    xor       $z1, $z1, $r0
+    @{[clmulh $r1, $z2, $polymod]}
+    @{[clmul  $r0, $z2, $polymod]}
+    xor       $VAL1, $z1, $r1
+    xor       $VAL0, $z0, $r0
+    sd        $VAL0, 32($Htable)
+    sd        $VAL1, 40($Htable)
+
+    # Compute H^4 = (H^2)^2.
+    ld        $TMP0, 16($Htable)
+    ld        $TMP1, 24($Htable)
+    @{[clmulh $z3, $TMP1, $TMP1]}
+    @{[clmul  $z2, $TMP1, $TMP1]}
+    @{[clmulh $z1, $TMP0, $TMP0]}
+    @{[clmul  $z0, $TMP0, $TMP0]}
+    @{[clmulh $r1, $z3, $polymod]}
+    @{[clmul  $r0, $z3, $polymod]}
+    xor       $z2, $z2, $r1
+    xor       $z1, $z1, $r0
+    @{[clmulh $r1, $z2, $polymod]}
+    @{[clmul  $r0, $z2, $polymod]}
+    xor       $VAL1, $z1, $r1
+    xor       $VAL0, $z0, $r0
+    sd        $VAL0, 48($Htable)
+    sd        $VAL1, 56($Htable)
+
     ret
 .size gcm_init_rv64i_zbc,.-gcm_init_rv64i_zbc
 ___
@@ -87,6 +156,7 @@ ___
 
 {
 my ($Htable,$H,$VAL0,$VAL1,$TMP0,$TMP1,$TMP2) = ("a0","a1","a2","a3","t0","t1","t2");
+my ($z0,$z1,$z2,$z3,$r0,$r1,$polymod) = ("a4","a5","a6","a7","t3","t4","t5");
 
 $code .= <<___;
 .p2align 3
@@ -101,6 +171,69 @@ gcm_init_rv64i_zbc__zbb:
     @{[rev8 $VAL1, $VAL1]}
     sd      $VAL0,0($Htable)
     sd      $VAL1,8($Htable)
+
+    # Compute H^2. VAL0/VAL1 are already in loaded format.
+    la        $polymod, Lpolymod
+    lbu       $polymod, 0($polymod)
+    @{[clmulh $z3, $VAL1, $VAL1]}
+    @{[clmul  $z2, $VAL1, $VAL1]}
+    @{[clmulh $z1, $VAL0, $VAL0]}
+    @{[clmul  $z0, $VAL0, $VAL0]}
+    @{[clmulh $r1, $z3, $polymod]}
+    @{[clmul  $r0, $z3, $polymod]}
+    xor       $z2, $z2, $r1
+    xor       $z1, $z1, $r0
+    @{[clmulh $r1, $z2, $polymod]}
+    @{[clmul  $r0, $z2, $polymod]}
+    xor       $VAL1, $z1, $r1
+    xor       $VAL0, $z0, $r0
+    sd        $VAL0, 16($Htable)
+    sd        $VAL1, 24($Htable)
+
+    # Compute H^3 = H^2 * H for 4-block ghash aggregation.
+    ld        $TMP0, 0($Htable)
+    ld        $TMP1, 8($Htable)
+    @{[clmulh $z3, $VAL1, $TMP1]}
+    @{[clmul  $z2, $VAL1, $TMP1]}
+    @{[clmulh $r1, $VAL0, $TMP1]}
+    @{[clmul  $z1, $VAL0, $TMP1]}
+    xor       $z2, $z2, $r1
+    @{[clmulh $r1, $VAL1, $TMP0]}
+    @{[clmul  $r0, $VAL1, $TMP0]}
+    xor       $z2, $z2, $r1
+    xor       $z1, $z1, $r0
+    @{[clmulh $r1, $VAL0, $TMP0]}
+    @{[clmul  $z0, $VAL0, $TMP0]}
+    xor       $z1, $z1, $r1
+    @{[clmulh $r1, $z3, $polymod]}
+    @{[clmul  $r0, $z3, $polymod]}
+    xor       $z2, $z2, $r1
+    xor       $z1, $z1, $r0
+    @{[clmulh $r1, $z2, $polymod]}
+    @{[clmul  $r0, $z2, $polymod]}
+    xor       $VAL1, $z1, $r1
+    xor       $VAL0, $z0, $r0
+    sd        $VAL0, 32($Htable)
+    sd        $VAL1, 40($Htable)
+
+    # Compute H^4 = (H^2)^2.
+    ld        $TMP0, 16($Htable)
+    ld        $TMP1, 24($Htable)
+    @{[clmulh $z3, $TMP1, $TMP1]}
+    @{[clmul  $z2, $TMP1, $TMP1]}
+    @{[clmulh $z1, $TMP0, $TMP0]}
+    @{[clmul  $z0, $TMP0, $TMP0]}
+    @{[clmulh $r1, $z3, $polymod]}
+    @{[clmul  $r0, $z3, $polymod]}
+    xor       $z2, $z2, $r1
+    xor       $z1, $z1, $r0
+    @{[clmulh $r1, $z2, $polymod]}
+    @{[clmul  $r0, $z2, $polymod]}
+    xor       $VAL1, $z1, $r1
+    xor       $VAL0, $z0, $r0
+    sd        $VAL0, 48($Htable)
+    sd        $VAL1, 56($Htable)
+
     ret
 .size gcm_init_rv64i_zbc__zbb,.-gcm_init_rv64i_zbc__zbb
 ___
@@ -108,6 +241,7 @@ ___
 
 {
 my ($Htable,$H,$TMP0,$TMP1) = ("a0","a1","t0","t1");
+my ($z0,$z1,$z2,$z3,$r0,$r1,$polymod) = ("a2","a3","a4","a5","t2","t3","t4");
 
 $code .= <<___;
 .p2align 3
@@ -122,6 +256,72 @@ gcm_init_rv64i_zbc__zbkb:
     @{[rev8 $TMP1, $TMP1]}
     sd      $TMP0,0($Htable)
     sd      $TMP1,8($Htable)
+
+    # Compute H^2. TMP0/TMP1 are already in loaded format.
+    la        $polymod, Lpolymod
+    lbu       $polymod, 0($polymod)
+    @{[clmulh $z3, $TMP1, $TMP1]}
+    @{[clmul  $z2, $TMP1, $TMP1]}
+    @{[clmulh $z1, $TMP0, $TMP0]}
+    @{[clmul  $z0, $TMP0, $TMP0]}
+    @{[clmulh $r1, $z3, $polymod]}
+    @{[clmul  $r0, $z3, $polymod]}
+    xor       $z2, $z2, $r1
+    xor       $z1, $z1, $r0
+    @{[clmulh $r1, $z2, $polymod]}
+    @{[clmul  $r0, $z2, $polymod]}
+    xor       $TMP1, $z1, $r1
+    xor       $TMP0, $z0, $r0
+    sd        $TMP0, 16($Htable)
+    sd        $TMP1, 24($Htable)
+
+    # Compute H^3 = H^2 * H for 4-block ghash aggregation.
+    # H^2 is in TMP0:TMP1. Load H into z0:H (a2:a1).
+    ld        $z0, 0($Htable)
+    ld        $H, 8($Htable)
+    # Schoolbook multiply (TMP0:TMP1) * (z0:H).
+    # Order: read z0 as input before overwriting as product.
+    @{[clmulh $z3, $TMP1, $H]}
+    @{[clmul  $z2, $TMP1, $H]}
+    @{[clmulh $r1, $TMP0, $H]}
+    @{[clmul  $z1, $TMP0, $H]}
+    xor       $z2, $z2, $r1
+    @{[clmulh $r1, $TMP1, $z0]}
+    @{[clmul  $r0, $TMP1, $z0]}
+    xor       $z2, $z2, $r1
+    xor       $z1, $z1, $r0
+    @{[clmulh $r1, $TMP0, $z0]}
+    @{[clmul  $z0, $TMP0, $z0]}
+    xor       $z1, $z1, $r1
+    @{[clmulh $r1, $z3, $polymod]}
+    @{[clmul  $r0, $z3, $polymod]}
+    xor       $z2, $z2, $r1
+    xor       $z1, $z1, $r0
+    @{[clmulh $r1, $z2, $polymod]}
+    @{[clmul  $r0, $z2, $polymod]}
+    xor       $TMP1, $z1, $r1
+    xor       $TMP0, $z0, $r0
+    sd        $TMP0, 32($Htable)
+    sd        $TMP1, 40($Htable)
+
+    # Compute H^4 = (H^2)^2.
+    ld        $TMP0, 16($Htable)
+    ld        $TMP1, 24($Htable)
+    @{[clmulh $z3, $TMP1, $TMP1]}
+    @{[clmul  $z2, $TMP1, $TMP1]}
+    @{[clmulh $z1, $TMP0, $TMP0]}
+    @{[clmul  $z0, $TMP0, $TMP0]}
+    @{[clmulh $r1, $z3, $polymod]}
+    @{[clmul  $r0, $z3, $polymod]}
+    xor       $z2, $z2, $r1
+    xor       $z1, $z1, $r0
+    @{[clmulh $r1, $z2, $polymod]}
+    @{[clmul  $r0, $z2, $polymod]}
+    xor       $TMP1, $z1, $r1
+    xor       $TMP0, $z0, $r0
+    sd        $TMP0, 48($Htable)
+    sd        $TMP1, 56($Htable)
+
     ret
 .size gcm_init_rv64i_zbc__zbkb,.-gcm_init_rv64i_zbc__zbkb
 ___
@@ -269,30 +469,34 @@ ___
 #         len: length of input data in bytes (multiple of block size)
 # output: Xi: Xi+1 (next hash value Xi)
 {
-my ($Xi,$Htable,$inp,$len,$x0,$x1,$y0,$y1) = ("a0","a1","a2","a3","a4","a5","a6","a7");
+my ($Xi,$Htable,$inp,$len) = ("a0","a1","a2","a3");
+my ($x0,$x1,$y0,$y1) = ("a4","a5","a6","a7");
 my ($z0,$z1,$z2,$z3,$t0,$t1,$polymod) = ("t0","t1","t2","t3","t4","t5","t6");
+# Additional regs for 2-block aggregation path
+my ($sXi,$sH0,$sH1,$sH2_0,$sH2_1,$sP) = ("s0","s1","s2","s3","s4","s5");
+# Additional regs for 4-block aggregation path
+my ($sH3_0,$sH3_1,$sH4_0,$sH4_1) = ("s6","s7","s8","s9");
 
 $code .= <<___;
 .p2align 3
 .globl gcm_ghash_rv64i_zbc
 .type gcm_ghash_rv64i_zbc,\@function
 gcm_ghash_rv64i_zbc:
-    # Load Xi and bit-reverse it
+    # Fast path: skip s-reg setup for small inputs (< 128 bytes)
+    li      $z0, 128
+    bge     $len, $z0, Lghash_2x_enter
+
+    # --- Original single-block path (no s-reg overhead) ---
     ld        $x0, 0($Xi)
     ld        $x1, 8($Xi)
     @{[brev8_rv64i $x0, $z0, $z1, $z2]}
     @{[brev8_rv64i $x1, $z0, $z1, $z2]}
-
-    # Load the key (already bit-reversed)
     ld        $y0, 0($Htable)
     ld        $y1, 8($Htable)
-
-    # Load the reduction constant
     la        $polymod, Lpolymod
     lbu       $polymod, 0($polymod)
 
-Lstep:
-    # Load the input data, bit-reverse them, and XOR them with Xi
+Lghash_orig_loop:
     ld        $t0, 0($inp)
     ld        $t1, 8($inp)
     add       $inp, $inp, 16
@@ -302,7 +506,6 @@ Lstep:
     xor       $x0, $x0, $t0
     xor       $x1, $x1, $t1
 
-    # Multiplication (without Karatsuba)
     @{[clmulh $z3, $x1, $y1]}
     @{[clmul  $z2, $x1, $y1]}
     @{[clmulh $t1, $x0, $y1]}
@@ -316,7 +519,6 @@ Lstep:
     @{[clmul  $z0, $x0, $y0]}
     xor       $z1, $z1, $t1
 
-    # Reduction with clmul
     @{[clmulh $t1, $z3, $polymod]}
     @{[clmul  $t0, $z3, $polymod]}
     xor       $z2, $z2, $t1
@@ -326,44 +528,335 @@ Lstep:
     xor       $x1, $z1, $t1
     xor       $x0, $z0, $t0
 
-    # Iterate over all blocks
-    bnez      $len, Lstep
+    bnez      $len, Lghash_orig_loop
 
-    # Bit-reverse final Xi back and store it
     @{[brev8_rv64i $x0, $z0, $z1, $z2]}
     @{[brev8_rv64i $x1, $z0, $z1, $z2]}
     sd        $x0, 0($Xi)
     sd        $x1, 8($Xi)
+    ret
+
+Lghash_2x_enter:
+    # --- Multi-block aggregation path ---
+    addi    sp, sp, -48
+    sd      $sXi, 0(sp)
+    sd      $sH0, 8(sp)
+    sd      $sH1, 16(sp)
+    sd      $sH2_0, 24(sp)
+    sd      $sH2_1, 32(sp)
+    sd      $sP, 40(sp)
+
+    mv      $sXi, $Xi
+    ld      $sH0, 0($Htable)
+    ld      $sH1, 8($Htable)
+    ld      $sH2_0, 16($Htable)
+    ld      $sH2_1, 24($Htable)
+    la      $sP, Lpolymod
+    lbu     $sP, 0($sP)
+
+    ld      $x0, 0($sXi)
+    ld      $x1, 8($sXi)
+    @{[brev8_rv64i $x0, $z0, $z1, $z2]}
+    @{[brev8_rv64i $x1, $z0, $z1, $z2]}
+
+    # Check if 4-block aggregation is possible (>= 64 bytes = 4 blocks)
+    li      $z0, 64
+    blt     $len, $z0, Lghash_2x
+
+    # Save additional s6-s9, load H^3 and H^4
+    addi    sp, sp, -32
+    sd      $sH3_0, 0(sp)
+    sd      $sH3_1, 8(sp)
+    sd      $sH4_0, 16(sp)
+    sd      $sH4_1, 24(sp)
+    ld      $sH3_0, 32($Htable)
+    ld      $sH3_1, 40($Htable)
+    ld      $sH4_0, 48($Htable)
+    ld      $sH4_1, 56($Htable)
+
+Lghash_4x:
+    # --- 4-block iteration: processes 64 bytes ---
+    # Phase 1: A = (Xi^C1)*H^4, B = C2*H^3
+
+    ld      $z3, 0($inp)
+    ld      $t0, 8($inp)
+    @{[brev8_rv64i $z3, $z0, $z1, $z2]}
+    @{[brev8_rv64i $t0, $z0, $z1, $z2]}
+    xor     $x0, $x0, $z3
+    xor     $x1, $x1, $t0
+
+    ld      $y0, 16($inp)
+    ld      $y1, 24($inp)
+    @{[brev8_rv64i $y0, $z0, $z1, $z2]}
+    @{[brev8_rv64i $y1, $z0, $z1, $z2]}
+
+    # Interleaved multiply A = (x1:x0)*H^4, B = (y1:y0)*H^3
+    @{[clmulh $z3, $x1, $sH4_1]}
+    @{[clmulh $t1, $y1, $sH3_1]}
+    @{[clmul  $z2, $x1, $sH4_1]}
+    @{[clmul  $t0, $y1, $sH3_1]}
+    xor     $z3, $z3, $t1
+    xor     $z2, $z2, $t0
+
+    @{[clmulh $t1, $x0, $sH4_1]}
+    @{[clmulh $t0, $y0, $sH3_1]}
+    xor     $z2, $z2, $t1
+    xor     $z2, $z2, $t0
+    @{[clmul  $z1, $x0, $sH4_1]}
+    @{[clmul  $t1, $y0, $sH3_1]}
+    xor     $z1, $z1, $t1
+
+    @{[clmulh $t1, $x1, $sH4_0]}
+    @{[clmulh $t0, $y1, $sH3_0]}
+    xor     $z2, $z2, $t1
+    xor     $z2, $z2, $t0
+    @{[clmul  $t1, $x1, $sH4_0]}
+    @{[clmul  $t0, $y1, $sH3_0]}
+    xor     $z1, $z1, $t1
+    xor     $z1, $z1, $t0
+
+    @{[clmulh $t1, $x0, $sH4_0]}
+    @{[clmulh $t0, $y0, $sH3_0]}
+    xor     $z1, $z1, $t1
+    xor     $z1, $z1, $t0
+    @{[clmul  $z0, $x0, $sH4_0]}
+    @{[clmul  $t1, $y0, $sH3_0]}
+    xor     $z0, $z0, $t1
+
+    # Phase 1 product in z3:z2:z1:z0 = t3:t2:t1:t0.
+    # Load C3, C4 — use $t0/$t1/$polymod (t4/t5/t6) as brev8 temps
+    # to avoid clobbering Phase 1 product in t0-t3.
+    ld      $x0, 32($inp)
+    ld      $x1, 40($inp)
+    @{[brev8_rv64i $x0, $t0, $t1, $polymod]}
+    @{[brev8_rv64i $x1, $t0, $t1, $polymod]}
+
+    ld      $y0, 48($inp)
+    ld      $y1, 56($inp)
+    @{[brev8_rv64i $y0, $t0, $t1, $polymod]}
+    @{[brev8_rv64i $y1, $t0, $t1, $polymod]}
+
+    addi    $inp, $inp, 64
+    addi    $len, $len, -64
+
+    # Phase 2: C = C3*H^2, D = C4*H (single-temp interleave)
+    # Product in w3:w2:w1:w0 = $t1:$t0:$Htable:$Xi
+    # Scratch: $polymod (t6)
+
+    @{[clmulh $t1, $x1, $sH2_1]}
+    @{[clmulh $polymod, $y1, $sH1]}
+    xor     $t1, $t1, $polymod
+    @{[clmul  $t0, $x1, $sH2_1]}
+    @{[clmul  $polymod, $y1, $sH1]}
+    xor     $t0, $t0, $polymod
+
+    @{[clmulh $polymod, $x0, $sH2_1]}
+    xor     $t0, $t0, $polymod
+    @{[clmulh $polymod, $y0, $sH1]}
+    xor     $t0, $t0, $polymod
+    @{[clmul  $Htable, $x0, $sH2_1]}
+    @{[clmul  $polymod, $y0, $sH1]}
+    xor     $Htable, $Htable, $polymod
+
+    @{[clmulh $polymod, $x1, $sH2_0]}
+    xor     $t0, $t0, $polymod
+    @{[clmulh $polymod, $y1, $sH0]}
+    xor     $t0, $t0, $polymod
+    @{[clmul  $polymod, $x1, $sH2_0]}
+    xor     $Htable, $Htable, $polymod
+    @{[clmul  $polymod, $y1, $sH0]}
+    xor     $Htable, $Htable, $polymod
+
+    @{[clmulh $polymod, $x0, $sH2_0]}
+    xor     $Htable, $Htable, $polymod
+    @{[clmulh $polymod, $y0, $sH0]}
+    xor     $Htable, $Htable, $polymod
+    @{[clmul  $Xi, $x0, $sH2_0]}
+    @{[clmul  $polymod, $y0, $sH0]}
+    xor     $Xi, $Xi, $polymod
+
+    # Combine Phase 1 + Phase 2 products
+    xor     $z0, $z0, $Xi
+    xor     $z1, $z1, $Htable
+    xor     $z2, $z2, $t0
+    xor     $z3, $z3, $t1
+
+    # Single reduction for all 4 blocks
+    @{[clmulh $t1, $z3, $sP]}
+    @{[clmul  $t0, $z3, $sP]}
+    xor     $z2, $z2, $t1
+    xor     $z1, $z1, $t0
+    @{[clmulh $t1, $z2, $sP]}
+    @{[clmul  $t0, $z2, $sP]}
+    xor     $x1, $z1, $t1
+    xor     $x0, $z0, $t0
+
+    li      $z0, 64
+    bge     $len, $z0, Lghash_4x
+
+    # Restore s6-s9
+    ld      $sH3_0, 0(sp)
+    ld      $sH3_1, 8(sp)
+    ld      $sH4_0, 16(sp)
+    ld      $sH4_1, 24(sp)
+    addi    sp, sp, 32
+
+Lghash_2x:
+    # Guard: skip 2-block loop if len < 32 (e.g. after 4-block consumed all data)
+    li      $z0, 32
+    blt     $len, $z0, Lghash_2x_tail_check
+
+    # Load first input block, bit-reverse, XOR with Xi
+    ld      $z3, 0($inp)
+    ld      $t0, 8($inp)
+    @{[brev8_rv64i $z3, $z0, $z1, $z2]}
+    @{[brev8_rv64i $t0, $z0, $z1, $z2]}
+    xor     $x0, $x0, $z3
+    xor     $x1, $x1, $t0
+
+    # Load second input block, bit-reverse
+    ld      $y0, 16($inp)
+    ld      $y1, 24($inp)
+    @{[brev8_rv64i $y0, $z0, $z1, $z2]}
+    @{[brev8_rv64i $y1, $z0, $z1, $z2]}
+
+    addi    $inp, $inp, 32
+    addi    $len, $len, -32
+
+    # Interleaved multiplication (A + B accumulated into z3:z2:z1:z0):
+    #   A = (x1:x0) * (sH2_1:sH2_0) = (Xi^C1) * H^2
+    #   B = (y1:y0) * (sH1:sH0)      = C2 * H
+
+    # high * high
+    @{[clmulh $z3, $x1, $sH2_1]}
+    @{[clmulh $t1, $y1, $sH1]}
+    @{[clmul  $z2, $x1, $sH2_1]}
+    @{[clmul  $t0, $y1, $sH1]}
+    xor     $z3, $z3, $t1
+    xor     $z2, $z2, $t0
+
+    # low * high
+    @{[clmulh $t1, $x0, $sH2_1]}
+    @{[clmulh $t0, $y0, $sH1]}
+    xor     $z2, $z2, $t1
+    xor     $z2, $z2, $t0
+    @{[clmul  $z1, $x0, $sH2_1]}
+    @{[clmul  $t1, $y0, $sH1]}
+    xor     $z1, $z1, $t1
+
+    # high * low
+    @{[clmulh $t1, $x1, $sH2_0]}
+    @{[clmulh $t0, $y1, $sH0]}
+    xor     $z2, $z2, $t1
+    xor     $z2, $z2, $t0
+    @{[clmul  $t1, $x1, $sH2_0]}
+    @{[clmul  $t0, $y1, $sH0]}
+    xor     $z1, $z1, $t1
+    xor     $z1, $z1, $t0
+
+    # low * low
+    @{[clmulh $t1, $x0, $sH2_0]}
+    @{[clmulh $t0, $y0, $sH0]}
+    xor     $z1, $z1, $t1
+    xor     $z1, $z1, $t0
+    @{[clmul  $z0, $x0, $sH2_0]}
+    @{[clmul  $t1, $y0, $sH0]}
+    xor     $z0, $z0, $t1
+
+    # Reduction with clmul
+    @{[clmulh $t1, $z3, $sP]}
+    @{[clmul  $t0, $z3, $sP]}
+    xor     $z2, $z2, $t1
+    xor     $z1, $z1, $t0
+    @{[clmulh $t1, $z2, $sP]}
+    @{[clmul  $t0, $z2, $sP]}
+    xor     $x1, $z1, $t1
+    xor     $x0, $z0, $t0
+
+    li      $z0, 32
+    bge     $len, $z0, Lghash_2x
+
+    # Handle remaining single block (if any)
+Lghash_2x_tail_check:
+    beqz    $len, Lghash_2x_done
+
+Lghash_1x_tail:
+    ld      $z3, 0($inp)
+    ld      $t0, 8($inp)
+    addi    $inp, $inp, 16
+    addi    $len, $len, -16
+    @{[brev8_rv64i $z3, $z0, $z1, $z2]}
+    @{[brev8_rv64i $t0, $z0, $z1, $z2]}
+    xor     $x0, $x0, $z3
+    xor     $x1, $x1, $t0
+
+    @{[clmulh $z3, $x1, $sH1]}
+    @{[clmul  $z2, $x1, $sH1]}
+    @{[clmulh $t1, $x0, $sH1]}
+    @{[clmul  $z1, $x0, $sH1]}
+    xor     $z2, $z2, $t1
+    @{[clmulh $t1, $x1, $sH0]}
+    @{[clmul  $t0, $x1, $sH0]}
+    xor     $z2, $z2, $t1
+    xor     $z1, $z1, $t0
+    @{[clmulh $t1, $x0, $sH0]}
+    @{[clmul  $z0, $x0, $sH0]}
+    xor     $z1, $z1, $t1
+
+    @{[clmulh $t1, $z3, $sP]}
+    @{[clmul  $t0, $z3, $sP]}
+    xor     $z2, $z2, $t1
+    xor     $z1, $z1, $t0
+    @{[clmulh $t1, $z2, $sP]}
+    @{[clmul  $t0, $z2, $sP]}
+    xor     $x1, $z1, $t1
+    xor     $x0, $z0, $t0
+
+Lghash_2x_done:
+    @{[brev8_rv64i $x0, $z0, $z1, $z2]}
+    @{[brev8_rv64i $x1, $z0, $z1, $z2]}
+    sd      $x0, 0($sXi)
+    sd      $x1, 8($sXi)
+
+    ld      $sXi, 0(sp)
+    ld      $sH0, 8(sp)
+    ld      $sH1, 16(sp)
+    ld      $sH2_0, 24(sp)
+    ld      $sH2_1, 32(sp)
+    ld      $sP, 40(sp)
+    addi    sp, sp, 48
     ret
 .size gcm_ghash_rv64i_zbc,.-gcm_ghash_rv64i_zbc
 ___
 }
 
 {
-my ($Xi,$Htable,$inp,$len,$x0,$x1,$y0,$y1) = ("a0","a1","a2","a3","a4","a5","a6","a7");
+my ($Xi,$Htable,$inp,$len) = ("a0","a1","a2","a3");
+my ($x0,$x1,$y0,$y1) = ("a4","a5","a6","a7");
 my ($z0,$z1,$z2,$z3,$t0,$t1,$polymod) = ("t0","t1","t2","t3","t4","t5","t6");
+my ($sXi,$sH0,$sH1,$sH2_0,$sH2_1,$sP) = ("s0","s1","s2","s3","s4","s5");
+my ($sH3_0,$sH3_1,$sH4_0,$sH4_1) = ("s6","s7","s8","s9");
 
 $code .= <<___;
 .p2align 3
 .globl gcm_ghash_rv64i_zbc__zbkb
 .type gcm_ghash_rv64i_zbc__zbkb,\@function
 gcm_ghash_rv64i_zbc__zbkb:
-    # Load Xi and bit-reverse it
+    # Fast path: skip s-reg setup for small inputs (< 128 bytes)
+    li      $z0, 128
+    bge     $len, $z0, Lghash_2x_enter_zbkb
+
+    # --- Original single-block path (no s-reg overhead) ---
     ld        $x0, 0($Xi)
     ld        $x1, 8($Xi)
     @{[brev8  $x0, $x0]}
     @{[brev8  $x1, $x1]}
-
-    # Load the key (already bit-reversed)
     ld        $y0, 0($Htable)
     ld        $y1, 8($Htable)
-
-    # Load the reduction constant
     la        $polymod, Lpolymod
     lbu       $polymod, 0($polymod)
 
-Lstep_zkbk:
-    # Load the input data, bit-reverse them, and XOR them with Xi
+Lghash_orig_loop_zbkb:
     ld        $t0, 0($inp)
     ld        $t1, 8($inp)
     add       $inp, $inp, 16
@@ -373,7 +866,6 @@ Lstep_zkbk:
     xor       $x0, $x0, $t0
     xor       $x1, $x1, $t1
 
-    # Multiplication (without Karatsuba)
     @{[clmulh $z3, $x1, $y1]}
     @{[clmul  $z2, $x1, $y1]}
     @{[clmulh $t1, $x0, $y1]}
@@ -387,7 +879,6 @@ Lstep_zkbk:
     @{[clmul  $z0, $x0, $y0]}
     xor       $z1, $z1, $t1
 
-    # Reduction with clmul
     @{[clmulh $t1, $z3, $polymod]}
     @{[clmul  $t0, $z3, $polymod]}
     xor       $z2, $z2, $t1
@@ -397,14 +888,289 @@ Lstep_zkbk:
     xor       $x1, $z1, $t1
     xor       $x0, $z0, $t0
 
-    # Iterate over all blocks
-    bnez      $len, Lstep_zkbk
+    bnez      $len, Lghash_orig_loop_zbkb
 
-    # Bit-reverse final Xi back and store it
     @{[brev8  $x0, $x0]}
     @{[brev8  $x1, $x1]}
-    sd $x0,  0($Xi)
-    sd $x1,  8($Xi)
+    sd        $x0, 0($Xi)
+    sd        $x1, 8($Xi)
+    ret
+
+Lghash_2x_enter_zbkb:
+    # --- Multi-block aggregation path ---
+    addi    sp, sp, -48
+    sd      $sXi, 0(sp)
+    sd      $sH0, 8(sp)
+    sd      $sH1, 16(sp)
+    sd      $sH2_0, 24(sp)
+    sd      $sH2_1, 32(sp)
+    sd      $sP, 40(sp)
+
+    mv      $sXi, $Xi
+    ld      $sH0, 0($Htable)
+    ld      $sH1, 8($Htable)
+    ld      $sH2_0, 16($Htable)
+    ld      $sH2_1, 24($Htable)
+    la      $sP, Lpolymod
+    lbu     $sP, 0($sP)
+
+    ld      $x0, 0($sXi)
+    ld      $x1, 8($sXi)
+    @{[brev8 $x0, $x0]}
+    @{[brev8 $x1, $x1]}
+
+    # Check if 4-block aggregation is possible (>= 64 bytes)
+    li      $z0, 64
+    blt     $len, $z0, Lghash_2x_zbkb
+
+    # Save additional s6-s9, load H^3 and H^4
+    addi    sp, sp, -32
+    sd      $sH3_0, 0(sp)
+    sd      $sH3_1, 8(sp)
+    sd      $sH4_0, 16(sp)
+    sd      $sH4_1, 24(sp)
+    ld      $sH3_0, 32($Htable)
+    ld      $sH3_1, 40($Htable)
+    ld      $sH4_0, 48($Htable)
+    ld      $sH4_1, 56($Htable)
+
+Lghash_4x_zbkb:
+    # --- 4-block iteration: processes 64 bytes ---
+    # Phase 1: A = (Xi^C1)*H^4, B = C2*H^3
+
+    ld      $z3, 0($inp)
+    ld      $t0, 8($inp)
+    @{[brev8 $z3, $z3]}
+    @{[brev8 $t0, $t0]}
+    xor     $x0, $x0, $z3
+    xor     $x1, $x1, $t0
+
+    ld      $y0, 16($inp)
+    ld      $y1, 24($inp)
+    @{[brev8 $y0, $y0]}
+    @{[brev8 $y1, $y1]}
+
+    # Interleaved multiply A = (x1:x0)*H^4, B = (y1:y0)*H^3
+    @{[clmulh $z3, $x1, $sH4_1]}
+    @{[clmulh $t1, $y1, $sH3_1]}
+    @{[clmul  $z2, $x1, $sH4_1]}
+    @{[clmul  $t0, $y1, $sH3_1]}
+    xor     $z3, $z3, $t1
+    xor     $z2, $z2, $t0
+
+    @{[clmulh $t1, $x0, $sH4_1]}
+    @{[clmulh $t0, $y0, $sH3_1]}
+    xor     $z2, $z2, $t1
+    xor     $z2, $z2, $t0
+    @{[clmul  $z1, $x0, $sH4_1]}
+    @{[clmul  $t1, $y0, $sH3_1]}
+    xor     $z1, $z1, $t1
+
+    @{[clmulh $t1, $x1, $sH4_0]}
+    @{[clmulh $t0, $y1, $sH3_0]}
+    xor     $z2, $z2, $t1
+    xor     $z2, $z2, $t0
+    @{[clmul  $t1, $x1, $sH4_0]}
+    @{[clmul  $t0, $y1, $sH3_0]}
+    xor     $z1, $z1, $t1
+    xor     $z1, $z1, $t0
+
+    @{[clmulh $t1, $x0, $sH4_0]}
+    @{[clmulh $t0, $y0, $sH3_0]}
+    xor     $z1, $z1, $t1
+    xor     $z1, $z1, $t0
+    @{[clmul  $z0, $x0, $sH4_0]}
+    @{[clmul  $t1, $y0, $sH3_0]}
+    xor     $z0, $z0, $t1
+
+    # Phase 1 product in z3:z2:z1:z0.
+    # Load C3, C4 — zbkb brev8 is in-place, no temp conflict.
+    ld      $x0, 32($inp)
+    ld      $x1, 40($inp)
+    @{[brev8 $x0, $x0]}
+    @{[brev8 $x1, $x1]}
+
+    ld      $y0, 48($inp)
+    ld      $y1, 56($inp)
+    @{[brev8 $y0, $y0]}
+    @{[brev8 $y1, $y1]}
+
+    addi    $inp, $inp, 64
+    addi    $len, $len, -64
+
+    # Phase 2: C = C3*H^2, D = C4*H (single-temp interleave)
+    # Product in w3:w2:w1:w0 = $t1:$t0:$Htable:$Xi
+    # Scratch: $polymod (t6)
+
+    @{[clmulh $t1, $x1, $sH2_1]}
+    @{[clmulh $polymod, $y1, $sH1]}
+    xor     $t1, $t1, $polymod
+    @{[clmul  $t0, $x1, $sH2_1]}
+    @{[clmul  $polymod, $y1, $sH1]}
+    xor     $t0, $t0, $polymod
+
+    @{[clmulh $polymod, $x0, $sH2_1]}
+    xor     $t0, $t0, $polymod
+    @{[clmulh $polymod, $y0, $sH1]}
+    xor     $t0, $t0, $polymod
+    @{[clmul  $Htable, $x0, $sH2_1]}
+    @{[clmul  $polymod, $y0, $sH1]}
+    xor     $Htable, $Htable, $polymod
+
+    @{[clmulh $polymod, $x1, $sH2_0]}
+    xor     $t0, $t0, $polymod
+    @{[clmulh $polymod, $y1, $sH0]}
+    xor     $t0, $t0, $polymod
+    @{[clmul  $polymod, $x1, $sH2_0]}
+    xor     $Htable, $Htable, $polymod
+    @{[clmul  $polymod, $y1, $sH0]}
+    xor     $Htable, $Htable, $polymod
+
+    @{[clmulh $polymod, $x0, $sH2_0]}
+    xor     $Htable, $Htable, $polymod
+    @{[clmulh $polymod, $y0, $sH0]}
+    xor     $Htable, $Htable, $polymod
+    @{[clmul  $Xi, $x0, $sH2_0]}
+    @{[clmul  $polymod, $y0, $sH0]}
+    xor     $Xi, $Xi, $polymod
+
+    # Combine Phase 1 + Phase 2 products
+    xor     $z0, $z0, $Xi
+    xor     $z1, $z1, $Htable
+    xor     $z2, $z2, $t0
+    xor     $z3, $z3, $t1
+
+    # Single reduction for all 4 blocks
+    @{[clmulh $t1, $z3, $sP]}
+    @{[clmul  $t0, $z3, $sP]}
+    xor     $z2, $z2, $t1
+    xor     $z1, $z1, $t0
+    @{[clmulh $t1, $z2, $sP]}
+    @{[clmul  $t0, $z2, $sP]}
+    xor     $x1, $z1, $t1
+    xor     $x0, $z0, $t0
+
+    li      $z0, 64
+    bge     $len, $z0, Lghash_4x_zbkb
+
+    # Restore s6-s9
+    ld      $sH3_0, 0(sp)
+    ld      $sH3_1, 8(sp)
+    ld      $sH4_0, 16(sp)
+    ld      $sH4_1, 24(sp)
+    addi    sp, sp, 32
+
+Lghash_2x_zbkb:
+    # Guard: skip 2-block loop if len < 32
+    li      $z0, 32
+    blt     $len, $z0, Lghash_2x_tail_check_zbkb
+
+    ld      $z3, 0($inp)
+    ld      $t0, 8($inp)
+    @{[brev8 $z3, $z3]}
+    @{[brev8 $t0, $t0]}
+    xor     $x0, $x0, $z3
+    xor     $x1, $x1, $t0
+
+    ld      $y0, 16($inp)
+    ld      $y1, 24($inp)
+    @{[brev8 $y0, $y0]}
+    @{[brev8 $y1, $y1]}
+
+    addi    $inp, $inp, 32
+    addi    $len, $len, -32
+
+    @{[clmulh $z3, $x1, $sH2_1]}
+    @{[clmulh $t1, $y1, $sH1]}
+    @{[clmul  $z2, $x1, $sH2_1]}
+    @{[clmul  $t0, $y1, $sH1]}
+    xor     $z3, $z3, $t1
+    xor     $z2, $z2, $t0
+
+    @{[clmulh $t1, $x0, $sH2_1]}
+    @{[clmulh $t0, $y0, $sH1]}
+    xor     $z2, $z2, $t1
+    xor     $z2, $z2, $t0
+    @{[clmul  $z1, $x0, $sH2_1]}
+    @{[clmul  $t1, $y0, $sH1]}
+    xor     $z1, $z1, $t1
+
+    @{[clmulh $t1, $x1, $sH2_0]}
+    @{[clmulh $t0, $y1, $sH0]}
+    xor     $z2, $z2, $t1
+    xor     $z2, $z2, $t0
+    @{[clmul  $t1, $x1, $sH2_0]}
+    @{[clmul  $t0, $y1, $sH0]}
+    xor     $z1, $z1, $t1
+    xor     $z1, $z1, $t0
+
+    @{[clmulh $t1, $x0, $sH2_0]}
+    @{[clmulh $t0, $y0, $sH0]}
+    xor     $z1, $z1, $t1
+    xor     $z1, $z1, $t0
+    @{[clmul  $z0, $x0, $sH2_0]}
+    @{[clmul  $t1, $y0, $sH0]}
+    xor     $z0, $z0, $t1
+
+    @{[clmulh $t1, $z3, $sP]}
+    @{[clmul  $t0, $z3, $sP]}
+    xor     $z2, $z2, $t1
+    xor     $z1, $z1, $t0
+    @{[clmulh $t1, $z2, $sP]}
+    @{[clmul  $t0, $z2, $sP]}
+    xor     $x1, $z1, $t1
+    xor     $x0, $z0, $t0
+
+    li      $z0, 32
+    bge     $len, $z0, Lghash_2x_zbkb
+
+Lghash_2x_tail_check_zbkb:
+    beqz    $len, Lghash_2x_done_zbkb
+
+    ld      $z3, 0($inp)
+    ld      $t0, 8($inp)
+    addi    $inp, $inp, 16
+    addi    $len, $len, -16
+    @{[brev8 $z3, $z3]}
+    @{[brev8 $t0, $t0]}
+    xor     $x0, $x0, $z3
+    xor     $x1, $x1, $t0
+
+    @{[clmulh $z3, $x1, $sH1]}
+    @{[clmul  $z2, $x1, $sH1]}
+    @{[clmulh $t1, $x0, $sH1]}
+    @{[clmul  $z1, $x0, $sH1]}
+    xor     $z2, $z2, $t1
+    @{[clmulh $t1, $x1, $sH0]}
+    @{[clmul  $t0, $x1, $sH0]}
+    xor     $z2, $z2, $t1
+    xor     $z1, $z1, $t0
+    @{[clmulh $t1, $x0, $sH0]}
+    @{[clmul  $z0, $x0, $sH0]}
+    xor     $z1, $z1, $t1
+
+    @{[clmulh $t1, $z3, $sP]}
+    @{[clmul  $t0, $z3, $sP]}
+    xor     $z2, $z2, $t1
+    xor     $z1, $z1, $t0
+    @{[clmulh $t1, $z2, $sP]}
+    @{[clmul  $t0, $z2, $sP]}
+    xor     $x1, $z1, $t1
+    xor     $x0, $z0, $t0
+
+Lghash_2x_done_zbkb:
+    @{[brev8 $x0, $x0]}
+    @{[brev8 $x1, $x1]}
+    sd      $x0, 0($sXi)
+    sd      $x1, 8($sXi)
+
+    ld      $sXi, 0(sp)
+    ld      $sH0, 8(sp)
+    ld      $sH1, 16(sp)
+    ld      $sH2_0, 24(sp)
+    ld      $sH2_1, 32(sp)
+    ld      $sP, 40(sp)
+    addi    sp, sp, 48
     ret
 .size gcm_ghash_rv64i_zbc__zbkb,.-gcm_ghash_rv64i_zbc__zbkb
 ___


### PR DESCRIPTION

Tested on Spacemit(R) X100

For Zbc multi-block aggregation:

| Implementation | 16 bytes | 64 bytes | 256 bytes | 1024 bytes | 8192 bytes | 16384 bytes |
|----------------|----------|----------|-----------|------------|------------|-------------|
| Before | 178357.78k | 507594.38k | 950276.78k | 1211885.23k | 1315291.14k | 1328304.03k |
| After | 173990.49k | 498263.95k | 987812.52k | 1316625.07k | 1447930.54k | 1463441.89k |
| Before | 100% | 100% | 100% | 100% | 100% | 100% |
| After | 97.55% | 98.16% | 103.95% | 108.64% | 110.08% | 110.18% |

For Zvbc multi-block aggregation:

| Implementation | 16 bytes | 64 bytes | 256 bytes | 1024 bytes | 8192 bytes | 16384 bytes |
|----------------|----------|----------|-----------|------------|------------|-------------|
| Before | 182697.79k | 379132.93k | 521388.03k | 577319.21k | 593278.29k | 594624.51k |
| After | 186904.47k | 475188.50k | 719048.26k | 821124.44k | 857475.75k | 859963.39k |
| Before | 100% | 100% | 100% | 100% | 100% | 100% |
| After | 102.30% | 125.33% | 137.90% | 142.23% | 144.54% | 144.62% |

For Zvkg multi-block aggregation:

| Implementation | 16 bytes | 64 bytes | 256 bytes | 1024 bytes | 8192 bytes | 16384 bytes |
|----------------|----------|----------|-----------|------------|------------|-------------|
| Before | 234397.80k | 880794.05k | 3057454.34k | 6001178.62k | 8191440.21k | 8508961.91k |
| After | 229197.43k | 873059.70k | 3186966.44k | 8357659.99k | 15499861.28k | 16278197.59k |
| Before | 100% | 100% | 100% | 100% | 100% | 100% |
| After | 97.78% | 99.12% | 104.23% | 139.27% | 189.22% | 191.31% |



also ping @cmuellner @JerryShih 