### PR TITLE
Cache decoded certs on client in CTX to avoid multiple asn1 parsing

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4732,8 +4732,8 @@ X509 *ssl_ctx_find_handshake_cert(SSL_CTX *sctx, const unsigned char *certbytes,
     return ret;
 }
 
-X509 *ssl_ctx_add_handshake_cert(SSL_CTX *sctx, X509 *cert, const unsigned char *certbytes,
-    unsigned long cert_len, unsigned char *sha1_hash)
+X509 *ssl_ctx_add_handshake_cert(SSL_CTX *sctx, X509 *cert,
+    unsigned char *sha1_hash)
 {
     X509_HS_CACHE_ENT *tmp, *del;
     X509 *ret = cert;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -33,7 +33,6 @@
 #include "internal/to_hex.h"
 #include "internal/ssl_unwrap.h"
 #include "quic/quic_local.h"
-#include "internal/hashfunc.h"
 
 #ifndef OPENSSL_NO_SSLKEYLOG
 #include <sys/stat.h>

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4702,7 +4702,7 @@ void SSL_CTX_free(SSL_CTX *a)
 }
 
 X509 *ssl_ctx_find_handshake_cert(SSL_CTX *sctx, const unsigned char *certbytes,
-    unsigned long cert_len, unsigned char *sha1_hash)
+    size_t cert_len, unsigned char *sha1_hash)
 {
     X509_HS_CACHE_ENT lookup;
     int idx;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4207,29 +4207,6 @@ static BIO *get_sslkeylog_bio(const char *keylogfile)
 }
 #endif
 
-static int x509_hs_cmp(const X509_HS_CACHE_ENT *const *a, const X509_HS_CACHE_ENT *const *b)
-{
-    /*
-     * This deserves a bit of explanation.
-     * Its obvious that we are doing comparisons of sha1_hash values between certificates
-     * here.  What's less obvious is why we are always returning either 0 (match) or -1 (i.e. less
-     * than/not match).  Its done because this STACK_OF is unsorted.
-     *
-     * Because the stack is unsorted, we need to search through every entry in the list for a match,
-     * And the STACK_OF api has an efficiency built in that aborts a lookup if 1 (greater than /
-     * not match) is returned.  This gives lookups a average search time of O(n/2), but means that
-     * we have to sort the list on each insert, or insert to exactly the right location.  Because
-     * the cache is capped at 64 entries, which is small, it seems like the better approach here is
-     * to accept a O(n) lookup time, in exchange for allowing a O(1) (always insert to head) insert
-     * semantic, which also gives us the ability to cull from the cache by eliminating the oldest
-     * entry by dropping index 63 from the stack.
-     *
-     * So this comparison is effectively implementing linear list traversal.  Are there better ways
-     * to do this?  Maybe, but this works pretty well right now
-     */
-    return memcmp((*a)->sha1_hash, (*b)->sha1_hash, SHA_DIGEST_LENGTH) == 0 ? 0 : -1;
-}
-
 SSL_CTX *SSL_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
     const SSL_METHOD *meth)
 {
@@ -4323,7 +4300,7 @@ SSL_CTX *SSL_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
     }
 
     if (!SSL_CTX_is_server(ret)) {
-        ret->handshake_certs = sk_X509_HS_CACHE_ENT_new(x509_hs_cmp);
+        ret->handshake_certs = sk_X509_HS_CACHE_ENT_new(NULL);
         if (ret->handshake_certs == NULL) {
             ERR_raise(ERR_LIB_SSL, ERR_R_CRYPTO_LIB);
             goto err;
@@ -4725,31 +4702,31 @@ void SSL_CTX_free(SSL_CTX *a)
 X509 *ssl_ctx_find_handshake_cert(SSL_CTX *sctx, const unsigned char *certbytes,
     size_t cert_len, unsigned char *sha1_hash)
 {
-    X509_HS_CACHE_ENT lookup;
     int idx;
     X509_HS_CACHE_ENT *find = NULL;
     X509 *ret = NULL;
     unsigned int len = SHA_DIGEST_LENGTH;
+    int cache_len;
 
     if (sctx->handshake_certs == NULL)
         return NULL;
 
-    lookup.cert = NULL;
-    if (!EVP_Digest(certbytes, cert_len, lookup.sha1_hash, &len, sctx->sha1, NULL))
+    if (!EVP_Digest(certbytes, cert_len, sha1_hash, &len, sctx->sha1, NULL))
         return NULL;
 
     if (len != SHA_DIGEST_LENGTH)
         return NULL;
 
-    memcpy(sha1_hash, lookup.sha1_hash, SHA_DIGEST_LENGTH);
     if (!CRYPTO_THREAD_read_lock(sctx->lock))
         return NULL;
-    idx = sk_X509_HS_CACHE_ENT_find(sctx->handshake_certs, &lookup);
-    if (idx != -1) {
+
+    cache_len = sk_X509_HS_CACHE_ENT_num(sctx->handshake_certs);
+    for (idx = 0; idx < cache_len; idx++) {
         find = sk_X509_HS_CACHE_ENT_value(sctx->handshake_certs, idx);
-        if (find != NULL) {
+        if (!memcmp(find->sha1_hash, sha1_hash, SHA_DIGEST_LENGTH)) {
             X509_up_ref(find->cert);
             ret = find->cert;
+            break;
         }
     }
     CRYPTO_THREAD_unlock(sctx->lock);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -33,6 +33,7 @@
 #include "internal/to_hex.h"
 #include "internal/ssl_unwrap.h"
 #include "quic/quic_local.h"
+#include "internal/hashfunc.h"
 
 #ifndef OPENSSL_NO_SSLKEYLOG
 #include <sys/stat.h>
@@ -4207,6 +4208,11 @@ static BIO *get_sslkeylog_bio(const char *keylogfile)
 }
 #endif
 
+static int x509_hs_cmp(const X509_HS_CACHE_ENT *const *a, const X509_HS_CACHE_ENT *const *b)
+{
+    return memcmp((*a)->sha1_hash, (*b)->sha1_hash, SHA_DIGEST_LENGTH) == 0 ? 0 : -1;
+}
+
 SSL_CTX *SSL_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
     const SSL_METHOD *meth)
 {
@@ -4294,6 +4300,14 @@ SSL_CTX *SSL_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
     if (ret->cert_store == NULL) {
         ERR_raise(ERR_LIB_SSL, ERR_R_X509_LIB);
         goto err;
+    }
+
+    if (!SSL_CTX_is_server(ret)) {
+        ret->handshake_certs = sk_X509_HS_CACHE_ENT_new(x509_hs_cmp);
+        if (ret->handshake_certs == NULL) {
+            ERR_raise(ERR_LIB_SSL, ERR_R_CRYPTO_LIB);
+            goto err;
+        }
     }
 #ifndef OPENSSL_NO_CT
     ret->ctlog_store = CTLOG_STORE_new_ex(libctx, propq);
@@ -4554,6 +4568,13 @@ int SSL_CTX_up_ref(SSL_CTX *ctx)
     return ((i > 1) ? 1 : 0);
 }
 
+static void free_hs_cache_ent(X509_HS_CACHE_ENT *entry)
+{
+    X509_free(entry->cert);
+    OPENSSL_free(entry);
+    return;
+}
+
 void SSL_CTX_free(SSL_CTX *a)
 {
     int i;
@@ -4657,6 +4678,7 @@ void SSL_CTX_free(SSL_CTX *a)
     OPENSSL_free(a->client_cert_type);
     OPENSSL_free(a->server_cert_type);
 
+    sk_X509_HS_CACHE_ENT_pop_free(a->handshake_certs, free_hs_cache_ent);
     CRYPTO_THREAD_lock_free(a->lock);
     CRYPTO_FREE_REF(&a->references);
 #ifdef TSAN_REQUIRES_LOCKING
@@ -4677,6 +4699,91 @@ void SSL_CTX_free(SSL_CTX *a)
 #endif
 
     OPENSSL_free(a);
+}
+
+X509 *ssl_ctx_find_handshake_cert(SSL_CTX *sctx, const unsigned char *certbytes,
+    unsigned long cert_len, unsigned char *sha1_hash)
+{
+    X509_HS_CACHE_ENT lookup;
+    int idx;
+    X509_HS_CACHE_ENT *find = NULL;
+    X509 *ret = NULL;
+
+    if (sctx->handshake_certs == NULL)
+        return NULL;
+
+    lookup.cert = NULL;
+    if (!EVP_Q_digest(sctx->libctx, "SHA1", NULL,
+            certbytes, cert_len, lookup.sha1_hash, NULL))
+        return NULL;
+
+    memcpy(sha1_hash, lookup.sha1_hash, SHA_DIGEST_LENGTH);
+    if (!CRYPTO_THREAD_read_lock(sctx->lock))
+        return NULL;
+    idx = sk_X509_HS_CACHE_ENT_find(sctx->handshake_certs, &lookup);
+    if (idx != -1) {
+        find = sk_X509_HS_CACHE_ENT_value(sctx->handshake_certs, idx);
+        if (find != NULL) {
+            X509_up_ref(find->cert);
+            ret = find->cert;
+        }
+    }
+    CRYPTO_THREAD_unlock(sctx->lock);
+    return ret;
+}
+
+X509 *ssl_ctx_add_handshake_cert(SSL_CTX *sctx, X509 *cert, const unsigned char *certbytes,
+    unsigned long cert_len, unsigned char *sha1_hash)
+{
+    X509_HS_CACHE_ENT *tmp, *del;
+    X509 *ret = cert;
+
+    if (sctx->handshake_certs == NULL)
+        return cert;
+
+    tmp = OPENSSL_malloc(sizeof(X509_HS_CACHE_ENT));
+    if (tmp == NULL)
+        return cert;
+    /*
+     * Force extension caching on the X509 now, while we still "own" it
+     * exclusively. From this point on the cached cert is treated as
+     * immutable by all readers (they only X509_up_ref it).
+     */
+    if (X509_check_purpose(cert, -1, 0) <= 0) {
+        OPENSSL_free(tmp);
+        return cert;
+    }
+
+    /*
+     * We had to compute the hash of the der string in the find routine, so
+     * we can reuse it here
+     */
+    memcpy(tmp->sha1_hash, sha1_hash, SHA_DIGEST_LENGTH);
+    tmp->cert = cert;
+    X509_up_ref(cert);
+
+    if (!CRYPTO_THREAD_write_lock(sctx->lock)) {
+        free_hs_cache_ent(tmp);
+        return cert;
+    }
+
+    if (sk_X509_HS_CACHE_ENT_num(sctx->handshake_certs) > 64) {
+        /*
+         * Evict the oldest entry (index 0). Deleting index 64 with
+         * num > 64 would remove the most-recently-pushed entry, which
+         * is the opposite of what we want.
+         */
+        del = sk_X509_HS_CACHE_ENT_delete(sctx->handshake_certs, 0);
+        if (del != NULL)
+            free_hs_cache_ent(del);
+    }
+    if (!sk_X509_HS_CACHE_ENT_push(sctx->handshake_certs, tmp)) {
+        free_hs_cache_ent(tmp);
+        ret = cert;
+    }
+
+    CRYPTO_THREAD_unlock(sctx->lock);
+    return ret;
 }
 
 void SSL_CTX_set_default_passwd_cb(SSL_CTX *ctx, pem_password_cb *cb)

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4765,18 +4765,17 @@ X509 *ssl_ctx_add_handshake_cert(SSL_CTX *sctx, X509 *cert,
     if (sctx->handshake_certs == NULL)
         return cert;
 
-    tmp = OPENSSL_malloc(sizeof(X509_HS_CACHE_ENT));
-    if (tmp == NULL)
-        return cert;
     /*
      * Force extension caching on the X509 now, while we still "own" it
      * exclusively. From this point on the cached cert is treated as
      * immutable by all readers (they only X509_up_ref it).
      */
-    if (X509_check_purpose(cert, -1, 0) <= 0) {
-        OPENSSL_free(tmp);
+    if (X509_check_purpose(cert, -1, 0) <= 0)
         return cert;
-    }
+
+    tmp = OPENSSL_malloc(sizeof(X509_HS_CACHE_ENT));
+    if (tmp == NULL)
+        return cert;
 
     /*
      * We had to compute the hash of the der string in the find routine, so

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4209,6 +4209,24 @@ static BIO *get_sslkeylog_bio(const char *keylogfile)
 
 static int x509_hs_cmp(const X509_HS_CACHE_ENT *const *a, const X509_HS_CACHE_ENT *const *b)
 {
+    /*
+     * This deserves a bit of explanation.
+     * Its obvious that we are doing comparisons of sha1_hash values between certificates
+     * here.  What's less obvious is why we are always returning either 0 (match) or -1 (i.e. less
+     * than/not match).  Its done because this STACK_OF is unsorted.
+     *
+     * Because the stack is unsorted, we need to search through every entry in the list for a match,
+     * And the STACK_OF api has an efficiency built in that aborts a lookup if 1 (greater than /
+     * not match) is returned.  This gives lookups a average search time of O(n/2), but means that
+     * we have to sort the list on each insert, or insert to exactly the right location.  Because
+     * the cache is capped at 64 entries, which is small, it seems like the better approach here is
+     * to accept a O(n) lookup time, in exchange for allowing a O(1) (always insert to head) insert
+     * semantic, which also gives us the ability to cull from the cache by eliminating the oldest
+     * entry by dropping index 63 from the stack.
+     *
+     * So this comparison is effectively implementing linear list traversal.  Are there better ways
+     * to do this?  Maybe, but this works pretty well right now
+     */
     return memcmp((*a)->sha1_hash, (*b)->sha1_hash, SHA_DIGEST_LENGTH) == 0 ? 0 : -1;
 }
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4292,6 +4292,9 @@ SSL_CTX *SSL_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
         goto err;
     if ((ret->tktenc = EVP_CIPHER_fetch(libctx, "AES-256-CBC", propq)) == NULL)
         goto err;
+    if ((ret->sha1 = EVP_MD_fetch(libctx, "SHA1", propq)) == NULL)
+        goto err;
+
 #if defined(OPENSSL_HAVE_TLS1PRF)
     if ((ret->tls1prf = EVP_KDF_fetch(libctx, OSSL_KDF_NAME_TLS1_PRF, propq)) == NULL)
         goto err;
@@ -4633,6 +4636,7 @@ void SSL_CTX_free(SSL_CTX *a)
     EVP_MAC_free(a->hmac);
     EVP_MD_free(a->sha256);
     EVP_CIPHER_free(a->tktenc);
+    EVP_MD_free(a->sha1);
 #ifdef OPENSSL_HAVE_TLS1PRF
     EVP_KDF_free(a->tls1prf);
 #endif
@@ -4725,13 +4729,16 @@ X509 *ssl_ctx_find_handshake_cert(SSL_CTX *sctx, const unsigned char *certbytes,
     int idx;
     X509_HS_CACHE_ENT *find = NULL;
     X509 *ret = NULL;
+    unsigned int len = SHA_DIGEST_LENGTH;
 
     if (sctx->handshake_certs == NULL)
         return NULL;
 
     lookup.cert = NULL;
-    if (!EVP_Q_digest(sctx->libctx, "SHA1", NULL,
-            certbytes, cert_len, lookup.sha1_hash, NULL))
+    if (!EVP_Digest(certbytes, cert_len, lookup.sha1_hash, &len, sctx->sha1, NULL))
+        return NULL;
+
+    if (len != SHA_DIGEST_LENGTH)
         return NULL;
 
     memcpy(sha1_hash, lookup.sha1_hash, SHA_DIGEST_LENGTH);

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1239,7 +1239,7 @@ struct ssl_ctx_st {
 };
 
 X509 *ssl_ctx_find_handshake_cert(SSL_CTX *sctx, const unsigned char *certbytes,
-    unsigned long cert_len, unsigned char *sha1_hash);
+    size_t cert_len, unsigned char *sha1_hash);
 X509 *ssl_ctx_add_handshake_cert(SSL_CTX *sctx, X509 *cert, unsigned char *sha1_hash);
 
 typedef struct ossl_quic_tls_callbacks_st {

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -815,6 +815,13 @@ typedef struct {
 #define OPENSSL_HAVE_TLS1PRF
 #endif
 
+typedef struct x509_hs_cache_entry_st {
+    unsigned char sha1_hash[SHA_DIGEST_LENGTH];
+    X509 *cert;
+} X509_HS_CACHE_ENT;
+
+DEFINE_STACK_OF(X509_HS_CACHE_ENT)
+
 struct ssl_ctx_st {
     OSSL_LIB_CTX *libctx;
 
@@ -826,6 +833,7 @@ struct ssl_ctx_st {
     STACK_OF(SSL_CIPHER) *tls13_ciphersuites;
     struct x509_store_st /* X509_STORE */ *cert_store;
     LHASH_OF(SSL_SESSION) *sessions;
+    STACK_OF(X509_HS_CACHE_ENT) *handshake_certs;
     EVP_MAC *hmac;
     EVP_MD *sha256;
     EVP_CIPHER *tktenc;
@@ -1229,6 +1237,11 @@ struct ssl_ctx_st {
     char *qlog_title; /* Session title for qlog */
 #endif
 };
+
+X509 *ssl_ctx_find_handshake_cert(SSL_CTX *sctx, const unsigned char *certbytes,
+    unsigned long cert_len, unsigned char *sha1_hash);
+X509 *ssl_ctx_add_handshake_cert(SSL_CTX *sctx, X509 *cert, const unsigned char *certbytes,
+    unsigned long cert_len, unsigned char *sha1_hash);
 
 typedef struct ossl_quic_tls_callbacks_st {
     int (*crypto_send_cb)(SSL *s, const unsigned char *buf, size_t buf_len,

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1240,8 +1240,7 @@ struct ssl_ctx_st {
 
 X509 *ssl_ctx_find_handshake_cert(SSL_CTX *sctx, const unsigned char *certbytes,
     unsigned long cert_len, unsigned char *sha1_hash);
-X509 *ssl_ctx_add_handshake_cert(SSL_CTX *sctx, X509 *cert, const unsigned char *certbytes,
-    unsigned long cert_len, unsigned char *sha1_hash);
+X509 *ssl_ctx_add_handshake_cert(SSL_CTX *sctx, X509 *cert, unsigned char *sha1_hash);
 
 typedef struct ossl_quic_tls_callbacks_st {
     int (*crypto_send_cb)(SSL *s, const unsigned char *buf, size_t buf_len,

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -934,7 +934,7 @@ struct ssl_ctx_st {
     CRYPTO_EX_DATA ex_data;
 
     const EVP_MD *md5; /* For SSLv3/TLSv1 'ssl3-md5' */
-    const EVP_MD *sha1; /* For SSLv3/TLSv1 'ssl3-sha1' */
+    EVP_MD *sha1; /* For SSLv3/TLSv1 'ssl3-sha1' */
 
     STACK_OF(X509) *extra_certs;
     STACK_OF(SSL_COMP) *comp_methods; /* stack of SSL_COMP, SSLv3/TLSv1 */

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2358,6 +2358,7 @@ MSG_PROCESS_RETURN tls_process_server_certificate(SSL_CONNECTION *s,
     const unsigned char *certstart, *certbytes;
     size_t chainidx;
     unsigned int context = 0;
+    unsigned char sha1_hash[SHA_DIGEST_LENGTH];
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 
     if (s->ext.server_cert_type == TLSEXT_cert_type_rpk)
@@ -2389,21 +2390,33 @@ MSG_PROCESS_RETURN tls_process_server_certificate(SSL_CONNECTION *s,
         }
 
         certstart = certbytes;
-        x = X509_new_ex(sctx->libctx, sctx->propq);
+        x = ssl_ctx_find_handshake_cert(sctx, certstart, cert_len, sha1_hash);
         if (x == NULL) {
-            SSLfatal(s, SSL_AD_DECODE_ERROR, ERR_R_ASN1_LIB);
-            goto err;
-        }
-        if (d2i_X509(&x, (const unsigned char **)&certbytes,
-                cert_len)
-            == NULL) {
-            SSLfatal(s, SSL_AD_BAD_CERTIFICATE, ERR_R_ASN1_LIB);
-            goto err;
-        }
+            x = X509_new_ex(sctx->libctx, sctx->propq);
+            if (x == NULL) {
+                SSLfatal(s, SSL_AD_DECODE_ERROR, ERR_R_ASN1_LIB);
+                goto err;
+            }
+            if (d2i_X509(&x, (const unsigned char **)&certbytes,
+                    cert_len)
+                == NULL) {
+                SSLfatal(s, SSL_AD_BAD_CERTIFICATE, ERR_R_ASN1_LIB);
+                goto err;
+            }
 
-        if (certbytes != (certstart + cert_len)) {
-            SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_CERT_LENGTH_MISMATCH);
-            goto err;
+            if (certbytes != (certstart + cert_len)) {
+                SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_CERT_LENGTH_MISMATCH);
+                goto err;
+            }
+
+            /*
+             * Hash the wire DER starting at certstart -- d2i_X509() has
+             * advanced certbytes past the end of this cert into the next
+             * one (or past the end of the list), so passing certbytes
+             * here would hash the wrong bytes and the insert hash would
+             * never match a subsequent lookup hash.
+             */
+            x = ssl_ctx_add_handshake_cert(sctx, x, certstart, cert_len, sha1_hash);
         }
 
         if (SSL_CONNECTION_IS_TLS13(s)) {

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2410,13 +2410,9 @@ MSG_PROCESS_RETURN tls_process_server_certificate(SSL_CONNECTION *s,
             }
 
             /*
-             * Hash the wire DER starting at certstart -- d2i_X509() has
-             * advanced certbytes past the end of this cert into the next
-             * one (or past the end of the list), so passing certbytes
-             * here would hash the wrong bytes and the insert hash would
-             * never match a subsequent lookup hash.
+             * Add the cert to our handshake cache
              */
-            x = ssl_ctx_add_handshake_cert(sctx, x, certstart, cert_len, sha1_hash);
+            x = ssl_ctx_add_handshake_cert(sctx, x, sha1_hash);
         }
 
         if (SSL_CONNECTION_IS_TLS13(s)) {


### PR DESCRIPTION
In looking for various handshake performance improvements, and chatting with claude about it, we came across the fact that our client has to do an ASN1 decode of the server certificate during every TLS connection.  Other implementations (like rustls) seem to try avoiding this by doing targeted der parsing, rather than a decode of the entire certificate.

We don't have the ability to do that without significant rewrites (and setting aside for the moment the loose concern that parsing that way may have several security implications), I thought perhaps there was something we could do to improve the situation.

If, after decoding the received der string on an initial connection, we cache it to a small limited size cache, we can on subsequent connections from the same SSL_CTX, reuse the X509 cert that we decoded previously, opportunistically avoiding the need for additional ASN1 parsing passes.  

openssl bench seems to indicate this is a fairly large win:


<img width="960" height="426" alt="image" src="https://github.com/user-attachments/assets/52996727-40bb-4911-9acb-4531038883f5" />


Thats between a 10%-56% gain in full handshakes completed on the client side of the connection

Some Notes:
1) This is a work in progress.  Its currently a pig on memory in the client as we store the entire der string for comparison purposes.  we might be able to get away with just storing the first 64 bytes (as RFC 5280 says the first 64 bytes should hold the serial number, sequence length tuple of the issuer, which should be unique for a given issuer, but I'm not sure on that.

2) Despite the gains, I'm not 100% sure this is worthwhile.  The speedup is nice, of course, but I'm not sure this is a valid real world use case.  The big win is in benchmarking of course, where a single client connects to a single server over and over again, so the benchmark numbers look good, and I think I can envision use cases like orchestrated service containers that frequent reconnect to the same server repeatedly, but outside of that, I'm not sure there is a common use case that this truly helps.

anywho, submitted for discussion.  Opinions appreciated.

