### PR TITLE
Fix function pointer type mismatch in MSBLOB/PVK key encoder

### DIFF
--- a/providers/implementations/encode_decode/encode_key2ms.c
+++ b/providers/implementations/encode_decode/encode_key2ms.c
@@ -68,10 +68,11 @@ static int write_pvk(struct key2ms_ctx_st *ctx, OSSL_CORE_BIO *cout,
     return ret;
 }
 
+static OSSL_FUNC_encoder_newctx_fn key2ms_newctx;
 static OSSL_FUNC_encoder_freectx_fn key2ms_freectx;
 static OSSL_FUNC_encoder_does_selection_fn key2ms_does_selection;
 
-static struct key2ms_ctx_st *key2ms_newctx(void *provctx)
+static void *key2ms_newctx(void *provctx)
 {
     struct key2ms_ctx_st *ctx = OPENSSL_zalloc(sizeof(*ctx));
 


### PR DESCRIPTION
Follow-up to #31078: same `-fsanitize=function` pointer type mismatch,
missed in the MSBLOB/PVK encoder newctx. `key2ms_newctx` returned
`struct key2ms_ctx_st *` but is dispatched as `OSSL_FUNC_encoder_newctx_fn`
(`void *(*)(void *)`).

Dispatch-only, no typed callers (sibling `key2any_newctx` already returns
`void *`), so the fix is a direct return-type correction plus the missing
self-check forward declaration -- no forwarding wrapper needed.

CLA: trivial