### PR TITLE
Make IPAddressFamily_cmp safe for 0 length objects with NULL data.

### DIFF
--- a/crypto/x509/v3_addr.c
+++ b/crypto/x509/v3_addr.c
@@ -678,17 +678,16 @@ int X509v3_addr_get_range(IPAddressOrRange *aor,
 static int IPAddressFamily_cmp(const IPAddressFamily *const *a_,
     const IPAddressFamily *const *b_)
 {
-    int cmp;
-
     const ASN1_OCTET_STRING *a = (*a_)->addressFamily;
     const ASN1_OCTET_STRING *b = (*b_)->addressFamily;
+    int cmp, len = (a->length <= b->length) ? a->length : b->length;
 
-    int len = (a->length <= b->length) ? a->length : b->length;
     if (len > 0) {
         cmp = memcmp(a->data, b->data, len);
         if (cmp != 0)
             return cmp;
     }
+
     return a->length - b->length;
 }
 

--- a/crypto/x509/v3_addr.c
+++ b/crypto/x509/v3_addr.c
@@ -683,13 +683,13 @@ static int IPAddressFamily_cmp(const IPAddressFamily *const *a_,
     const ASN1_OCTET_STRING *a = (*a_)->addressFamily;
     const ASN1_OCTET_STRING *b = (*b_)->addressFamily;
 
-    int len = ((a->length <= b->length) ? a->length : b->length);
+    int len = (a->length <= b->length) ? a->length : b->length;
     if (len > 0) {
         cmp = memcmp(a->data, b->data, len);
         if (cmp != 0)
             return cmp;
     }
-    return (a->length - b->length);
+    return a->length - b->length;
 }
 
 static int IPAddressFamily_check_len(const IPAddressFamily *f)

--- a/crypto/x509/v3_addr.c
+++ b/crypto/x509/v3_addr.c
@@ -678,12 +678,18 @@ int X509v3_addr_get_range(IPAddressOrRange *aor,
 static int IPAddressFamily_cmp(const IPAddressFamily *const *a_,
     const IPAddressFamily *const *b_)
 {
+    int cmp;
+
     const ASN1_OCTET_STRING *a = (*a_)->addressFamily;
     const ASN1_OCTET_STRING *b = (*b_)->addressFamily;
-    int len = ((a->length <= b->length) ? a->length : b->length);
-    int cmp = memcmp(a->data, b->data, len);
 
-    return cmp ? cmp : a->length - b->length;
+    int len = ((a->length <= b->length) ? a->length : b->length);
+    if (len > 0) {
+        cmp = memcmp(a->data, b->data, len);
+        if (cmp != 0)
+            return cmp;
+    }
+    return (a->length - b->length);
 }
 
 static int IPAddressFamily_check_len(const IPAddressFamily *f)


### PR DESCRIPTION
Found while adjusting the fuzzer to test for the requirement to add NUL bytes on the end of ASN1 Strings in [ 31194 ](https://github.com/openssl/openssl/pull/31194) If we end up with a 0 length object here we can end up in a crash with memcmp.

This makes this cmp function test comparison like our others that are 0 length object safe.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
