### PR TITLE
fix cmp mock server to not depend on NUL bytes in ASN1_STRING

### DIFF
--- a/apps/lib/cmp_mock_srv.c
+++ b/apps/lib/cmp_mock_srv.c
@@ -345,6 +345,7 @@ static OSSL_CMP_PKISI *process_cert_request(OSSL_CMP_SRV_CTX *srv_ctx,
             STACK_OF(ASN1_UTF8STRING) *strs;
             ASN1_UTF8STRING *str;
             const char *data;
+            int len;
 
             if (OBJ_obj2nid(obj) == NID_id_it_certProfile) {
                 if (!OSSL_CMP_ITAV_get0_certProfile(itav, &strs))
@@ -359,7 +360,8 @@ static OSSL_CMP_PKISI *process_cert_request(OSSL_CMP_SRV_CTX *srv_ctx,
                     ERR_raise(ERR_LIB_CMP, ERR_R_PASSED_INVALID_ARGUMENT);
                     return NULL;
                 }
-                if (strcmp(data, "profile1") != 0) {
+                if (((len = ASN1_STRING_length(str)) != (int)sizeof("profile1") - 1)
+                    || memcmp(data, "profile1", len) != 0) {
                     ERR_raise(ERR_LIB_CMP, CMP_R_UNEXPECTED_CERTPROFILE);
                     return NULL;
                 }


### PR DESCRIPTION
ASN1_STRING is documented that the behavior of NUL byte addition should not be depended upon.

The mock server calls strcmp on the bare data from an ASN1_STRING. This only works if the data is NUL terminated.

For: https://github.com/openssl/openssl/issues/31203

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
