### PR TITLE
asn1: handle NULL ASN1_STRING in ASN1_STRING_length

### DIFF
--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -825,6 +825,8 @@ int pkcs12_main(int argc, char **argv)
 
             if (pbkdf2_param == NULL) {
                 BIO_puts(bio_err, ", Unsupported KDF or params for PBMAC1\n");
+            } else if (pbkdf2_param->salt->type != V_ASN1_OCTET_STRING) {
+                BIO_printf(bio_err, "Invalid salt type %d (expected %d) in PBMAC1\n", pbkdf2_param->salt->type, V_ASN1_OCTET_STRING);
             } else {
                 const ASN1_OBJECT *prfobj;
                 int prfnid;

--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -408,6 +408,9 @@ int ASN1_STRING_cmp(const ASN1_STRING *a, const ASN1_STRING *b)
 
 int ASN1_STRING_length(const ASN1_STRING *x)
 {
+    if (x == NULL) {
+        return 0;
+    }
     return x->length;
 }
 


### PR DESCRIPTION
Return 0 when ASN1_STRING_length() is called with a NULL pointer instead of dereferencing it.

Also validate that the PBMAC1 PBKDF2 salt is encoded as an ASN1 OCTET STRING before accessing value.octet_string in the pkcs12 application.

Fixes #30581

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
