### PR TITLE
Remove unused crl_dir setting from config files

### DIFF
--- a/VMS/VMSify-conf.pl
+++ b/VMS/VMSify-conf.pl
@@ -10,7 +10,7 @@
 use strict;
 use warnings;
 
-my @directory_vars = ( "dir", "certs", "crl_dir", "new_certs_dir" );
+my @directory_vars = ( "dir", "certs", "new_certs_dir" );
 my @file_vars = ( "database", "certificate", "serial", "crlnumber",
 		  "crl", "private_key", "RANDFILE" );
 while(<STDIN>) {

--- a/apps/openssl-vms.cnf
+++ b/apps/openssl-vms.cnf
@@ -91,7 +91,6 @@ default_ca	= CA_default		# The default ca section
 
 dir		= sys\$disk:[.demoCA		# Where everything is kept
 certs		= $dir.certs]		# Where the issued certs are kept
-crl_dir		= $dir.crl]		# Where the issued crl are kept
 database	= $dir]index.txt	# database index file.
 #unique_subject	= no			# Set to 'no' to allow creation of
 					# several certs with same subject.

--- a/apps/openssl.cnf
+++ b/apps/openssl.cnf
@@ -91,7 +91,6 @@ default_ca	= CA_default		# The default ca section
 
 dir		= ./demoCA		# Where everything is kept
 certs		= $dir/certs		# Where the issued certs are kept
-crl_dir		= $dir/crl		# Where the issued crl are kept
 database	= $dir/index.txt	# database index file.
 #unique_subject	= no			# Set to 'no' to allow creation of
 					# several certs with same subject.

--- a/test/ca-and-certs.cnf
+++ b/test/ca-and-certs.cnf
@@ -75,7 +75,6 @@ default_ca	= CA_default
 [ CA_default ]
 dir		= ./demoCA
 certs		= $dir/certs
-crl_dir		= $dir/crl
 database	= $dir/index.txt
 new_certs_dir	= $dir/newcerts
 certificate	= $dir/cacert.pem

--- a/test/recipes/90-test_includes_data/conf-includes/includes1.cnf
+++ b/test/recipes/90-test_includes_data/conf-includes/includes1.cnf
@@ -13,7 +13,6 @@ default_ca	= CA_default		# The default ca section
 
 dir		= ./demoCA		# Where everything is kept
 certs		= $dir/certs		# Where the issued certs are kept
-crl_dir		= $dir/crl		# Where the issued crl are kept
 database	= $dir/index.txt	# database index file.
 new_certs_dir	= $dir/new_certs	# default place for new certs.
 

--- a/test/test.cnf
+++ b/test/test.cnf
@@ -8,7 +8,6 @@ default_ca	= CA_default		# The default ca section
 
 dir		= ./demoCA		# Where everything is kept
 certs		= $dir/certs		# Where the issued certs are kept
-crl_dir		= $dir/crl		# Where the issued crl are kept
 database	= $dir/index.txt	# database index file.
 new_certs_dir	= $dir/new_certs	# default place for new certs.
 


### PR DESCRIPTION
The crl_dir setting in CA_default section is not used anywhere. Remove it from the example config and test configs, update the VMSify-conf.pl path conversion script to no longer reference it, and regenerate openssl-vms.cnf.

Fixes #31103

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

