### PR TITLE
use OPENSSL_strlcat instead of strcat

### DIFF
--- a/crypto/cmp/cmp_genm.c
+++ b/crypto/cmp/cmp_genm.c
@@ -144,7 +144,7 @@ static OSSL_CMP_ITAV *get_genm_itav(OSSL_CMP_CTX *ctx,
         }
 
         if (OBJ_obj2txt(name + offset, (int)(sizeof(name) - offset), obj, 0) < 0)
-            strcat(name, "<unknown>");
+            OPENSSL_strlcat(name, "<unknown>", sizeof(name));
         ossl_cmp_log2(WARN, ctx, "%s' while expecting 'id-it-%s'", name, desc);
         OSSL_CMP_ITAV_free(itav);
     }


### PR DESCRIPTION
This prevents a possible buffer overflow should OBJ_obj2txt encounter an error after partially filling the buffer.

(Previously reported and fixed in quictls:
https://github.com/quictls/quictls/pull/337 )

CLA: trivial