### PR TITLE
Ignore memfail test binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,7 @@ providers/implementations/rands/test_rng.inc
 /test/gost2814789t
 /test/ssltest_old
 /test/*test
+/test/*memfail
 /test/fips_aesavs
 /test/fips_desmovs
 /test/fips_dhvs


### PR DESCRIPTION
This is just to ignore binaries of memfail tests so I don't accidentally commit them... I would normally ignore them locally but I can see that other test binaries are ignores so this is probably just an omission...