### PR TITLE
avoid signed-to-unsigned integer conversion

### DIFF
--- a/demos/digest/EVP_MD_demo.c
+++ b/demos/digest/EVP_MD_demo.c
@@ -135,6 +135,7 @@ static int demonstrate_digest(void)
     const char *option_properties = NULL;
     EVP_MD *message_digest = NULL;
     EVP_MD_CTX *digest_context = NULL;
+    int sz = 0;
     unsigned int digest_length;
     unsigned char *digest_value = NULL;
     unsigned int j;
@@ -157,11 +158,12 @@ static int demonstrate_digest(void)
         goto cleanup;
     }
     /* Determine the length of the fetched digest type */
-    digest_length = EVP_MD_get_size(message_digest);
-    if (digest_length <= 0) {
+    sz = EVP_MD_get_size(message_digest);
+    if (sz <= 0) {
         fprintf(stderr, "EVP_MD_get_size returned invalid size.\n");
         goto cleanup;
     }
+    digest_length = (unsigned int)sz;
 
     digest_value = OPENSSL_malloc(digest_length);
     if (digest_value == NULL) {

--- a/test/tls13secretstest.c
+++ b/test/tls13secretstest.c
@@ -290,6 +290,7 @@ static int test_handshake_secrets(void)
     SSL *ssl = NULL;
     SSL_CONNECTION *s;
     int ret = 0;
+    int sz;
     size_t hashsize;
     unsigned char out_master_secret[EVP_MAX_MD_SIZE];
     size_t master_secret_length;
@@ -328,7 +329,10 @@ static int test_handshake_secrets(void)
             handshake_secret, sizeof(handshake_secret)))
         goto err;
 
-    hashsize = EVP_MD_get_size(ssl_handshake_md(s));
+    sz = EVP_MD_get_size(ssl_handshake_md(s));
+    if (sz < 0)
+        goto err;
+    hashsize = (size_t)sz;
     if (!TEST_size_t_eq(sizeof(client_hts), hashsize))
         goto err;
     if (!TEST_size_t_eq(sizeof(client_hts_key), KEYLEN))


### PR DESCRIPTION
Should EVP_MD_size() return -1, the size_t len variable would wrap, causing any subsequent error checks to not trigger. Change to type int (which is what EVP_MD_size() returns).

While this is just in test/demo code, that's the kind of code that people might copy and reuse elsewhere, and that AI vuln scanners trigger on, so might as well try to eliminate that noise.

(Edit: removed  "CLA: trivial" per below discussion.)