### PR TITLE
Fix Solaris X64 stack_test compiler error

### DIFF
--- a/test/stack_test.c
+++ b/test/stack_test.c
@@ -29,17 +29,17 @@
 typedef struct {
     int n;
     char c;
-} SS;
+} TST_SS;
 
 typedef union {
     int n;
     char c;
-} SU;
+} TST_SU;
 
 DEFINE_SPECIAL_STACK_OF(sint, int)
 DEFINE_SPECIAL_STACK_OF_CONST(uchar, unsigned char)
-DEFINE_STACK_OF(SS)
-DEFINE_STACK_OF_CONST(SU)
+DEFINE_STACK_OF(TST_SS)
+DEFINE_STACK_OF_CONST(TST_SU)
 
 static int int_compare(const int *const *a, const int *const *b)
 {
@@ -325,25 +325,25 @@ end:
     return testresult;
 }
 
-static SS *SS_copy(const SS *p)
+static TST_SS *SS_copy(const TST_SS *p)
 {
-    SS *q = OPENSSL_malloc(sizeof(*q));
+    TST_SS *q = OPENSSL_malloc(sizeof(*q));
 
     if (q != NULL)
         memcpy(q, p, sizeof(*q));
     return q;
 }
 
-static void SS_free(SS *p)
+static void SS_free(TST_SS *p)
 {
     OPENSSL_free(p);
 }
 
 static int test_SS_stack(void)
 {
-    STACK_OF(SS) *s = sk_SS_new_null();
-    STACK_OF(SS) *r = NULL;
-    SS *v[10], *p;
+    STACK_OF(TST_SS) *s = sk_TST_SS_new_null();
+    STACK_OF(TST_SS) *r = NULL;
+    TST_SS *v[10], *p;
     const int n = OSSL_NELEM(v);
     int i;
     int testresult = 0;
@@ -356,25 +356,25 @@ static int test_SS_stack(void)
             goto end;
         v[i]->n = i;
         v[i]->c = 'A' + i;
-        if (!TEST_int_eq(sk_SS_num(s), i)) {
+        if (!TEST_int_eq(sk_TST_SS_num(s), i)) {
             TEST_info("SS stack size %d", i);
             goto end;
         }
-        sk_SS_push(s, v[i]);
+        sk_TST_SS_push(s, v[i]);
     }
-    if (!TEST_int_eq(sk_SS_num(s), n))
+    if (!TEST_int_eq(sk_TST_SS_num(s), n))
         goto end;
 
     /* deepcopy */
-    r = sk_SS_deep_copy(NULL, &SS_copy, &SS_free);
-    if (sk_SS_num(r) != 0)
+    r = sk_TST_SS_deep_copy(NULL, &SS_copy, &SS_free);
+    if (sk_TST_SS_num(r) != 0)
         goto end;
-    sk_SS_free(r);
-    r = sk_SS_deep_copy(s, &SS_copy, &SS_free);
+    sk_TST_SS_free(r);
+    r = sk_TST_SS_deep_copy(s, &SS_copy, &SS_free);
     if (!TEST_ptr(r))
         goto end;
     for (i = 0; i < n; i++) {
-        p = sk_SS_value(r, i);
+        p = sk_TST_SS_value(r, i);
         if (!TEST_ptr_ne(p, v[i])) {
             TEST_info("SS deepcopy non-copy %d", i);
             goto end;
@@ -390,33 +390,33 @@ static int test_SS_stack(void)
     }
 
     /* pop_free - we rely on the malloc debug to catch the leak */
-    sk_SS_pop_free(r, &SS_free);
+    sk_TST_SS_pop_free(r, &SS_free);
     r = NULL;
 
     /* delete_ptr */
-    p = sk_SS_delete_ptr(s, v[3]);
+    p = sk_TST_SS_delete_ptr(s, v[3]);
     if (!TEST_ptr(p))
         goto end;
     SS_free(p);
-    if (!TEST_int_eq(sk_SS_num(s), n - 1))
+    if (!TEST_int_eq(sk_TST_SS_num(s), n - 1))
         goto end;
     for (i = 0; i < n - 1; i++)
-        if (!TEST_ptr_eq(sk_SS_value(s, i), v[i < 3 ? i : 1 + i])) {
+        if (!TEST_ptr_eq(sk_TST_SS_value(s, i), v[i < 3 ? i : 1 + i])) {
             TEST_info("SS delete ptr item %d", i);
             goto end;
         }
 
     testresult = 1;
 end:
-    sk_SS_pop_free(r, &SS_free);
-    sk_SS_pop_free(s, &SS_free);
+    sk_TST_SS_pop_free(r, &SS_free);
+    sk_TST_SS_pop_free(s, &SS_free);
     return testresult;
 }
 
 static int test_SU_stack(void)
 {
-    STACK_OF(SU) *s = sk_SU_new_null();
-    SU v[10];
+    STACK_OF(TST_SU) *s = sk_TST_SU_new_null();
+    TST_SU v[10];
     const int n = OSSL_NELEM(v);
     int i;
     int testresult = 0;
@@ -427,25 +427,25 @@ static int test_SU_stack(void)
             v[i].n = i;
         else
             v[i].c = 'A' + i;
-        if (!TEST_int_eq(sk_SU_num(s), i)) {
+        if (!TEST_int_eq(sk_TST_SU_num(s), i)) {
             TEST_info("SU stack size %d", i);
             goto end;
         }
-        sk_SU_push(s, v + i);
+        sk_TST_SU_push(s, v + i);
     }
-    if (!TEST_int_eq(sk_SU_num(s), n))
+    if (!TEST_int_eq(sk_TST_SU_num(s), n))
         goto end;
 
     /* check the pointers are correct */
     for (i = 0; i < n; i++)
-        if (!TEST_ptr_eq(sk_SU_value(s, i), v + i)) {
+        if (!TEST_ptr_eq(sk_TST_SU_value(s, i), v + i)) {
             TEST_info("SU pointer check %d", i);
             goto end;
         }
 
     testresult = 1;
 end:
-    sk_SU_free(s);
+    sk_TST_SU_free(s);
     return testresult;
 }
 


### PR DESCRIPTION
Building OpenSSL with Solaris X64 causes a compiler error at test/stack_test.c.

This test defines structure type name "SS" which is defined in Solaris header
/usr/include/sys/regset.h #define    SS              18 
as well. This causes a compiler error.
This pull request renames the structure type name in the stack_test source file.

Checklist
- Test case fixes don't require documentation change.
