### PR TITLE
crypto/objects/obj_dat.c: return strlcpy result in OBJ_obj2txt()

### DIFF
--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -399,7 +399,7 @@ int OBJ_obj2txt(char *buf, int buf_len, const ASN1_OBJECT *a, int no_name)
             s = OBJ_nid2sn(nid);
         if (s != NULL) {
             if (buf != NULL)
-                OPENSSL_strlcpy(buf, s, buf_len);
+                return (int)OPENSSL_strlcpy(buf, s, buf_len);
             return (int)strlen(s);
         }
     }


### PR DESCRIPTION
strlcpy() (and OPENSSL_strlcpy() after it) returns the length of the input string as a result, don't throw it away just to calculate it once again on return.