### PR TITLE
Add size_t variants of EVP cipher Update/Final and dedicated AAD API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,19 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * Added size_t variants of the symmetric cipher update and final APIs:
+     EVP_EncryptUpdate_ex(), EVP_EncryptFinal_ex2(),
+     EVP_DecryptUpdate_ex(), EVP_DecryptFinal_ex2(),
+     EVP_CipherUpdate_ex(),  EVP_CipherFinal_ex2(),
+     EVP_CipherUpdateAAD().
+   The new functions take and return size_t lengths and require the
+   caller to declare the size of the output buffer explicitly through
+   a max_outl argument.  They reject a NULL output buffer.
+   Additional authenticated data (AAD) must be passed through
+   EVP_CipherUpdateAAD() instead of the legacy "out == NULL".
+
+   *Milan Brož*
+
  * SubjectPublicKeyInfo blobs whose AlgorithmIdentifier uses id-RSAES-OAEP
    (NID_rsaesOaep, 1.2.840.113549.1.1.7) with a plain RSAPublicKey body
    are now decoded as RSA keys.  This is required for interoperability

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1132,6 +1132,37 @@ int EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *ctx, int pad)
     return ok != 0;
 }
 
+size_t EVP_CIPHER_CTX_max_update_output(const EVP_CIPHER_CTX *ctx, size_t inl)
+{
+    int blocksize;
+
+    if (ctx == NULL || EVP_CIPHER_CTX_get0_cipher(ctx) == NULL)
+        return 0;
+
+    blocksize = EVP_CIPHER_CTX_get_block_size(ctx);
+    if (blocksize < 1)
+        return 0;
+
+    /* Stream ciphers */
+    if (blocksize == 1)
+        return inl;
+
+    if (inl > SIZE_MAX - (size_t)blocksize)
+        return 0;
+
+    /* Block and wrrapped ciphers */
+    return inl + (size_t)blocksize;
+}
+
+size_t EVP_CIPHER_CTX_max_final_output(const EVP_CIPHER_CTX *ctx)
+{
+    /*
+     * EVP final output is currently equivalent to update with inl = 0.
+     * Once the provider API can report specific value, this is a safe way.
+     */
+    return EVP_CIPHER_CTX_max_update_output(ctx, 0);
+}
+
 int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 {
     int ret = EVP_CTRL_RET_UNSUPPORTED;

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -474,6 +474,16 @@ int EVP_CipherPipelineDecryptInit(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
         NULL);
 }
 
+int EVP_CipherUpdate_ex(EVP_CIPHER_CTX *ctx, unsigned char *out,
+    size_t *outl, size_t max_outl,
+    const unsigned char *in, size_t inl)
+{
+    if (ctx->encrypt)
+        return EVP_EncryptUpdate_ex(ctx, out, outl, max_outl, in, inl);
+    else
+        return EVP_DecryptUpdate_ex(ctx, out, outl, max_outl, in, inl);
+}
+
 int EVP_CipherUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
     const unsigned char *in, int inl)
 {
@@ -481,6 +491,50 @@ int EVP_CipherUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
         return EVP_EncryptUpdate(ctx, out, outl, in, inl);
     else
         return EVP_DecryptUpdate(ctx, out, outl, in, inl);
+}
+
+int EVP_CipherUpdateAAD(EVP_CIPHER_CTX *ctx, const unsigned char *in,
+    size_t inl)
+{
+    size_t soutl = 0;
+    size_t outsize;
+    int blocksize;
+    int ret;
+
+    if (ossl_unlikely(in == NULL && inl > 0)) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
+    if (ossl_unlikely(ctx->cipher == NULL)) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_NO_CIPHER_SET);
+        return 0;
+    }
+
+    blocksize = ctx->cipher->block_size;
+    if (ossl_unlikely(ctx->cipher->cupdate == NULL || blocksize < 1)) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_UPDATE_ERROR);
+        return 0;
+    }
+
+    /*
+     * The provider's OSSL_FUNC_cipher_update() distinguishes AAD from
+     * plaintext/ciphertext by out == NULL.
+     * Pass the same outsize as the legacy EVP_EncryptUpdate() AAD path.
+     */
+    outsize = inl + (size_t)(blocksize == 1 ? 0 : blocksize);
+    ret = ctx->cipher->cupdate(ctx->algctx, NULL, &soutl, outsize, in, inl);
+
+    /*
+     * AAD calls should not produce output length.
+     * However, providers return processed input length here.
+     */
+    if (ossl_unlikely(ret && (soutl != 0 && soutl != inl))) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_UPDATE_ERROR);
+        return 0;
+    }
+
+    return ret;
 }
 
 int EVP_CipherPipelineUpdate(EVP_CIPHER_CTX *ctx,
@@ -516,6 +570,15 @@ int EVP_CipherPipelineUpdate(EVP_CIPHER_CTX *ctx,
     return ctx->cipher->p_cupdate(ctx->algctx, ctx->numpipes,
         out, outl, outsize,
         in, inl);
+}
+
+int EVP_CipherFinal_ex2(EVP_CIPHER_CTX *ctx, unsigned char *out,
+    size_t *outl, size_t max_outl)
+{
+    if (ctx->encrypt)
+        return EVP_EncryptFinal_ex2(ctx, out, outl, max_outl);
+    else
+        return EVP_DecryptFinal_ex2(ctx, out, outl, max_outl);
 }
 
 int EVP_CipherFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
@@ -647,6 +710,49 @@ int ossl_is_partially_overlapping(const void *ptr1, const void *ptr2, int len)
     return overlapped;
 }
 
+int EVP_EncryptUpdate_ex(EVP_CIPHER_CTX *ctx, unsigned char *out,
+    size_t *outl, size_t max_outl,
+    const unsigned char *in, size_t inl)
+{
+    if (ossl_unlikely(outl == NULL)) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+    *outl = 0;
+
+    /*
+     * Setting out == NULL is no longer a way to pass AAD.
+     * Callers must use EVP_CipherUpdateAAD() instead.
+     */
+    if (ossl_unlikely(out == NULL)) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
+    if (ossl_unlikely(in == NULL && inl > 0)) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
+    /* Prevent accidental use of decryption context when encrypting */
+    if (ossl_unlikely(!ctx->encrypt)) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_OPERATION);
+        return 0;
+    }
+
+    if (ossl_unlikely(ctx->cipher == NULL)) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_NO_CIPHER_SET);
+        return 0;
+    }
+
+    if (ossl_unlikely(ctx->cipher->cupdate == NULL)) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_UPDATE_ERROR);
+        return 0;
+    }
+
+    return ctx->cipher->cupdate(ctx->algctx, out, outl, max_outl, in, inl);
+}
+
 int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
     const unsigned char *in, int inl)
 {
@@ -702,11 +808,37 @@ int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
     return ret;
 }
 
-int EVP_EncryptFinal(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
+int EVP_EncryptFinal_ex2(EVP_CIPHER_CTX *ctx, unsigned char *out,
+    size_t *outl, size_t max_outl)
 {
-    int ret;
-    ret = EVP_EncryptFinal_ex(ctx, out, outl);
-    return ret;
+    if (outl == NULL) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+    *outl = 0;
+
+    if (out == NULL) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
+    /* Prevent accidental use of decryption context when encrypting */
+    if (!ctx->encrypt) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_OPERATION);
+        return 0;
+    }
+
+    if (ctx->cipher == NULL) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_NO_CIPHER_SET);
+        return 0;
+    }
+
+    if (ctx->cipher->cfinal == NULL) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_FINAL_ERROR);
+        return 0;
+    }
+
+    return ctx->cipher->cfinal(ctx->algctx, out, outl, max_outl);
 }
 
 int EVP_EncryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
@@ -756,6 +888,52 @@ int EVP_EncryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
     }
 
     return ret;
+}
+
+int EVP_EncryptFinal(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
+{
+    int ret;
+    ret = EVP_EncryptFinal_ex(ctx, out, outl);
+    return ret;
+}
+
+int EVP_DecryptUpdate_ex(EVP_CIPHER_CTX *ctx, unsigned char *out,
+    size_t *outl, size_t max_outl,
+    const unsigned char *in, size_t inl)
+{
+    if (ossl_unlikely(outl == NULL)) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+    *outl = 0;
+
+    if (ossl_unlikely(out == NULL)) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
+    if (ossl_unlikely(in == NULL && inl > 0)) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
+    /* Prevent accidental use of encryption context when decrypting */
+    if (ossl_unlikely(ctx->encrypt)) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_OPERATION);
+        return 0;
+    }
+
+    if (ossl_unlikely(ctx->cipher == NULL)) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_NO_CIPHER_SET);
+        return 0;
+    }
+
+    if (ossl_unlikely(ctx->cipher->cupdate == NULL)) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_UPDATE_ERROR);
+        return 0;
+    }
+
+    return ctx->cipher->cupdate(ctx->algctx, out, outl, max_outl, in, inl);
 }
 
 int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
@@ -813,11 +991,37 @@ int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
     return ret;
 }
 
-int EVP_DecryptFinal(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
+int EVP_DecryptFinal_ex2(EVP_CIPHER_CTX *ctx, unsigned char *out,
+    size_t *outl, size_t max_outl)
 {
-    int ret;
-    ret = EVP_DecryptFinal_ex(ctx, out, outl);
-    return ret;
+    if (outl == NULL) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+    *outl = 0;
+
+    if (out == NULL) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
+    /* Prevent accidental use of encryption context when decrypting */
+    if (ctx->encrypt) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_OPERATION);
+        return 0;
+    }
+
+    if (ctx->cipher == NULL) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_NO_CIPHER_SET);
+        return 0;
+    }
+
+    if (ctx->cipher->cfinal == NULL) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_FINAL_ERROR);
+        return 0;
+    }
+
+    return ctx->cipher->cfinal(ctx->algctx, out, outl, max_outl);
 }
 
 int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
@@ -867,6 +1071,13 @@ int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
         *outl = (int)soutl;
     }
 
+    return ret;
+}
+
+int EVP_DecryptFinal(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
+{
+    int ret;
+    ret = EVP_DecryptFinal_ex(ctx, out, outl);
     return ret;
 }
 

--- a/doc/man3/BF_encrypt.pod
+++ b/doc/man3/BF_encrypt.pod
@@ -34,8 +34,8 @@ see L<openssl_user_macros(7)>:
 =head1 DESCRIPTION
 
 All of the functions described on this page are deprecated. Applications should
-instead use L<EVP_EncryptInit_ex(3)>, L<EVP_EncryptUpdate(3)> and
-L<EVP_EncryptFinal_ex(3)> or the equivalently named decrypt functions.
+instead use L<EVP_EncryptInit_ex(3)>, L<EVP_EncryptUpdate_ex(3)> and
+L<EVP_EncryptFinal_ex2(3)> or the equivalently named decrypt functions.
 
 This library implements the Blowfish cipher, which was invented and described
 by Counterpane (see http://www.counterpane.com/blowfish.html ).

--- a/doc/man3/DES_random_key.pod
+++ b/doc/man3/DES_random_key.pod
@@ -99,8 +99,8 @@ see L<openssl_user_macros(7)>:
 =head1 DESCRIPTION
 
 All of the functions described on this page are deprecated. Applications should
-instead use L<EVP_EncryptInit_ex(3)>, L<EVP_EncryptUpdate(3)> and
-L<EVP_EncryptFinal_ex(3)> or the equivalently named decrypt functions.
+instead use L<EVP_EncryptInit_ex(3)>, L<EVP_EncryptUpdate_ex(3)> and
+L<EVP_EncryptFinal_ex2(3)> or the equivalently named decrypt functions.
 
 This library contains a fast implementation of the DES encryption
 algorithm.

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -13,16 +13,23 @@ EVP_CIPHER_CTX_copy,
 EVP_EncryptInit_ex,
 EVP_EncryptInit_ex2,
 EVP_EncryptUpdate,
+EVP_EncryptUpdate_ex,
 EVP_EncryptFinal_ex,
+EVP_EncryptFinal_ex2,
 EVP_DecryptInit_ex,
 EVP_DecryptInit_ex2,
 EVP_DecryptUpdate,
+EVP_DecryptUpdate_ex,
 EVP_DecryptFinal_ex,
+EVP_DecryptFinal_ex2,
 EVP_CipherInit_ex,
 EVP_CipherInit_ex2,
 EVP_CipherInit_SKEY,
 EVP_CipherUpdate,
+EVP_CipherUpdate_ex,
+EVP_CipherUpdateAAD,
 EVP_CipherFinal_ex,
+EVP_CipherFinal_ex2,
 EVP_CIPHER_CTX_set_key_length,
 EVP_CIPHER_CTX_ctrl,
 EVP_EncryptInit,
@@ -125,8 +132,12 @@ EVP_CIPHER_CTX_mode
                          const OSSL_PARAM params[]);
  int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out,
                        int *outl, const unsigned char *in, int inl);
+ int EVP_EncryptUpdate_ex(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                          size_t *outl, size_t max_outl,
+                          const unsigned char *in, size_t inl);
  int EVP_EncryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl);
-
+ int EVP_EncryptFinal_ex2(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                          size_t *outl, size_t max_outl);
  int EVP_DecryptInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
                         ENGINE *impl, const unsigned char *key, const unsigned char *iv);
  int EVP_DecryptInit_ex2(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
@@ -134,7 +145,12 @@ EVP_CIPHER_CTX_mode
                          const OSSL_PARAM params[]);
  int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out,
                        int *outl, const unsigned char *in, int inl);
+ int EVP_DecryptUpdate_ex(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                          size_t *outl, size_t max_outl,
+                          const unsigned char *in, size_t inl);
  int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *outm, int *outl);
+ int EVP_DecryptFinal_ex2(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                          size_t *outl, size_t max_outl);
 
  int EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
                        ENGINE *impl, const unsigned char *key, const unsigned char *iv, int enc);
@@ -146,7 +162,14 @@ EVP_CIPHER_CTX_mode
                          int enc, const OSSL_PARAM params[]);
  int EVP_CipherUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out,
                       int *outl, const unsigned char *in, int inl);
+ int EVP_CipherUpdate_ex(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                         size_t *outl, size_t max_outl,
+                         const unsigned char *in, size_t inl);
+ int EVP_CipherUpdateAAD(EVP_CIPHER_CTX *ctx,
+                         const unsigned char *in, size_t inl);
  int EVP_CipherFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *outm, int *outl);
+ int EVP_CipherFinal_ex2(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                         size_t *outl, size_t max_outl);
 
  int EVP_EncryptInit(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
                      const unsigned char *key, const unsigned char *iv);
@@ -399,10 +422,12 @@ specified.
 This legacy function is the same as EVP_EncryptInit_ex2() except B<params> will
 be NULL. I<impl> B<must> be NULL.
 
-=item EVP_EncryptUpdate()
+=item EVP_EncryptUpdate_ex()
 
 Encrypts I<inl> bytes from the buffer I<in> and writes the encrypted version to
-I<out>. The pointers I<out> and I<in> may point to the same location, in which
+I<out>. The function takes an explicit I<max_outl> argument that specifies the
+size, in bytes, of the output buffer.
+The pointers I<out> and I<in> may point to the same location, in which
 case the encryption will be done in-place. However, in-place encryption is
 guaranteed to work only if the encryption context (I<ctx>) has processed data in
 multiples of the block size. If the context contains an incomplete data block
@@ -422,10 +447,11 @@ bytes.
 For stream ciphers, the amount of data written can be anything from zero
 bytes to inl bytes.
 Thus, the buffer pointed to by I<out> must contain sufficient room for the
-operation being performed.
+operation being performed. The call fails if operation produces more
+than I<max_outl> bytes.
 The actual number of bytes written is placed in I<outl>.
 
-If padding is enabled (the default) then EVP_EncryptFinal_ex() encrypts
+If padding is enabled (the default) then EVP_EncryptFinal_ex2() encrypts
 the "final" data, that is any data that remains in a partial block.
 It uses standard block padding (aka PKCS padding) as described in
 the NOTES section, below. The encrypted
@@ -434,20 +460,26 @@ one cipher block. The number of bytes written is placed in I<outl>. After
 this function is called the encryption operation is finished and no further
 calls to EVP_EncryptUpdate() should be made.
 
-If padding is disabled then EVP_EncryptFinal_ex() will not encrypt any more
+If padding is disabled then EVP_EncryptFinal_ex2() will not encrypt any more
 data and it will return an error if any data remains in a partial block:
 that is if the total data length is not a multiple of the block size.
 
-=item EVP_DecryptInit_ex2(), EVP_DecryptInit_ex(), EVP_DecryptUpdate()
-and EVP_DecryptFinal_ex()
+=item EVP_EncryptUpdate(), EncryptFinal_ex()
+
+These legacy functions are the same as EVP_EncryptUpdate_ex() and
+EVP_EncryptFinal_ex() except all length arguments are I<int> instead of I<size_t>
+and have omitted I<max_outl> argument.
+
+=item EVP_DecryptInit_ex2(), EVP_DecryptInit_ex(), EVP_DecryptUpdate_ex()
+and EVP_DecryptFinal_ex2()
 
 These functions are the corresponding decryption operations.
 EVP_DecryptFinal() will return an error code if padding is enabled and the
 final block is not correctly formatted. The parameters and restrictions are
 identical to the encryption operations. I<ctx> B<MUST NOT> be NULL.
 
-=item EVP_CipherInit_ex2(), EVP_CipherInit_ex(), EVP_CipherUpdate() and
-EVP_CipherFinal_ex()
+=item EVP_CipherInit_ex2(), EVP_CipherInit_ex(), EVP_CipherUpdate_ex() and
+EVP_CipherFinal_ex2()
 
 These functions can be used for decryption or encryption. The operation
 performed depends on the value of the I<enc> parameter. It should be set to 1
@@ -1402,15 +1434,15 @@ EVP_CIPHER_CTX_dup() returns a new EVP_CIPHER_CTX if successful or NULL on failu
 
 EVP_CIPHER_CTX_copy() returns 1 if successful or 0 for failure.
 
-EVP_EncryptInit_ex2(), EVP_EncryptUpdate() and EVP_EncryptFinal_ex()
+EVP_EncryptInit_ex2(), EVP_EncryptUpdate_ex() and EVP_EncryptFinal_ex2()
 return 1 for success and 0 for failure.
 
-EVP_DecryptInit_ex2() and EVP_DecryptUpdate() return 1 for success and 0 for failure.
-EVP_DecryptFinal_ex() returns 0 if the decrypt failed or 1 for success.
+EVP_DecryptInit_ex2() and EVP_DecryptUpdate_ex() return 1 for success and 0 for failure.
+EVP_DecryptFinal_ex2() returns 0 if the decrypt failed or 1 for success.
 
-EVP_CipherInit_ex2(), EVP_CipherInit_SKEY() and EVP_CipherUpdate() return 1 for
+EVP_CipherInit_ex2(), EVP_CipherInit_SKEY() and EVP_CipherUpdate_ex() return 1 for
 success and 0 for failure.
-EVP_CipherFinal_ex() returns 0 for an encryption/decryption failure or 1 for
+EVP_CipherFinal_ex2() returns 0 for an encryption/decryption failure or 1 for
 success.
 
 EVP_Cipher() returns 1 on success and <= 0 on failure, if the flag
@@ -1500,9 +1532,12 @@ The EVP interface for Authenticated Encryption with Associated Data (AEAD)
 modes are subtly altered and several additional I<ctrl> operations are supported
 depending on the mode specified.
 
-To specify additional authenticated data (AAD), a call to EVP_CipherUpdate(),
-EVP_EncryptUpdate() or EVP_DecryptUpdate() should be made with the output
-parameter I<out> set to NULL. In this case, on success, the parameter
+To specify additional authenticated data (AAD) should be made using
+EVP_CipherUpdateAAD() call.
+
+The legacy EVP_CipherUpdate() EVP_EncryptUpdate() or EVP_DecryptUpdate()
+used for AAD the output parameter I<out> set to NULL.
+In this case, on success, the parameter
 I<outl> is set to the number of AAD bytes processed in that call
 (that is, the value of I<inl>), and does not include any plaintext
 or ciphertext bytes processed by other calls.
@@ -1510,19 +1545,19 @@ or ciphertext bytes processed by other calls.
 If no AAD is used, this call can be omitted. See the mode-specific notes
 below for any exceptions.
 
-When decrypting, the return value of EVP_DecryptFinal() or EVP_CipherFinal()
+When decrypting, the return value of EVP_DecryptFinal_ex2() or EVP_CipherFinal_ex2()
 indicates whether the operation was successful. If it does not indicate success,
 the authentication operation has failed and any output data B<MUST NOT> be used
 as it is corrupted.
 
 Please note that the number of authenticated bytes returned by
-EVP_CipherUpdate() depends on the cipher used. Stream ciphers, such as ChaCha20
+EVP_CipherUpdate_ex() depends on the cipher used. Stream ciphers, such as ChaCha20
 or ciphers in GCM mode, can handle 1 byte at a time, resulting in an effective
 "block" size of 1. Conversely, ciphers in OCB mode must process data one block
 at a time, and the block size is returned.
 
 Regardless of the returned size, it is safe to pass unpadded data to an
-EVP_CipherUpdate() call in a single operation.
+EVP_CipherUpdate_ex() call in a single operation.
 
 =head2 GCM and OCB Modes
 
@@ -1611,14 +1646,16 @@ For SIV mode ciphers the behaviour of the EVP interface is subtly
 altered and several additional ctrl operations are supported.
 
 To specify any additional authenticated data (AAD) and/or a Nonce, a call to
-EVP_CipherUpdate(), EVP_EncryptUpdate() or EVP_DecryptUpdate() should be made
-with the output parameter I<out> set to NULL.
+EVP_CipherUpdateAAD() should be made.
+
+The legacy EVP_CipherUpdate(), EVP_EncryptUpdate() or EVP_DecryptUpdate()
+used for AAD the output parameter I<out> set to NULL.
 
 RFC5297 states that the Nonce is the last piece of AAD before the actual
 encrypt/decrypt takes place. The API does not differentiate the Nonce from
 other AAD.
 
-When decrypting the return value of EVP_DecryptFinal() or EVP_CipherFinal()
+When decrypting the return value of EVP_DecryptFinal_ex2() or EVP_CipherFinal_ex2()
 indicates if the operation was successful. If it does not indicate success
 the authentication operation has failed and any output data B<MUST NOT>
 be used as it is corrupted.
@@ -1716,13 +1753,16 @@ If padding is disabled then the decryption operation will always succeed if
 the total amount of data decrypted is a multiple of the block size.
 
 The functions EVP_EncryptInit(), EVP_EncryptInit_ex(),
-EVP_EncryptFinal(), EVP_DecryptInit(), EVP_DecryptInit_ex(),
-EVP_CipherInit(), EVP_CipherInit_ex() and EVP_CipherFinal() are obsolete
-but are retained for compatibility with existing code. New code should
-use EVP_EncryptInit_ex2(), EVP_EncryptFinal_ex(), EVP_DecryptInit_ex2(),
-EVP_DecryptFinal_ex(), EVP_CipherInit_ex2() and EVP_CipherFinal_ex()
-because they can reuse an existing context without allocating and freeing
-it up on each call.
+EVP_EncryptFinal(), EVP_EncryptFinal_ex(), EVP_EncryptUpdate(), EVP_DecryptInit(),
+EVP_DecryptInit_ex(), EVP_DecryptUpdate(), EVP_CipherInit(), EVP_CipherInit_ex(),
+EVP_CipherUpdate(), EVP_CipherFinal(), and EVP_CipherFinal_ex() are obsolete but
+are retained for compatibility with existing code.
+New code should use EVP_EncryptInit_ex2(), EVP_EncryptUpdate_ex(),
+EVP_EncryptFinal_ex2(), EVP_DecryptInit_ex2(), EVP_DecryptUpdate_ex(),
+EVP_DecryptFinal_ex2(), EVP_CipherInit_ex2(), EVP_CipherUpdate_ex() and
+EVP_CipherFinal_ex2() because they can reuse an existing context without allocating
+and freeing it up on each call. Also they use size_t length parameters.
+New code should prefer the size_t variant of API.
 
 There are some differences between functions EVP_CipherInit() and
 EVP_CipherInit_ex(), significant in some circumstances. EVP_CipherInit() fills
@@ -1777,7 +1817,8 @@ Encrypt a string using IDEA:
          return 0;
      }
 
-     if (!EVP_EncryptUpdate(ctx, outbuf, &outlen, intext, strlen(intext))) {
+     if (!EVP_EncryptUpdate_ex(ctx, outbuf, &outlen, sizeof(outbuf),
+                               intext, strlen(intext))) {
          /* Error */
          EVP_CIPHER_CTX_free(ctx);
          return 0;
@@ -1786,7 +1827,8 @@ Encrypt a string using IDEA:
       * Buffer passed to EVP_EncryptFinal() must be after data just
       * encrypted to avoid overwriting it.
       */
-     if (!EVP_EncryptFinal_ex(ctx, outbuf + outlen, &tmplen)) {
+     if (!EVP_EncryptFinal_ex2(ctx, outbuf + outlen, &tmplen,
+                               sizeof(outbuf) - outlen)) {
          /* Error */
          EVP_CIPHER_CTX_free(ctx);
          return 0;
@@ -1853,14 +1895,15 @@ with a 128-bit key:
          inlen = fread(inbuf, 1, 1024, in);
          if (inlen <= 0)
              break;
-         if (!EVP_CipherUpdate(ctx, outbuf, &outlen, inbuf, inlen)) {
+         if (!EVP_CipherUpdate_ex(ctx, outbuf, &outlen, sizeof(outbuf),
+                                  inbuf, inlen)) {
              /* Error */
              EVP_CIPHER_CTX_free(ctx);
              return 0;
          }
          fwrite(outbuf, 1, outlen, out);
      }
-     if (!EVP_CipherFinal_ex(ctx, outbuf, &outlen)) {
+     if (!EVP_CipherFinal_ex2(ctx, outbuf, &outlen, sizeof(outbuf))) {
          /* Error */
          EVP_CIPHER_CTX_free(ctx);
          return 0;
@@ -1874,7 +1917,8 @@ with a 128-bit key:
 Encryption using AES-CBC with a 256-bit key with "CS1" ciphertext stealing.
 
  int encrypt(const unsigned char *key, const unsigned char *iv,
-             const unsigned char *msg, size_t msg_len, unsigned char *out)
+             const unsigned char *msg, size_t msg_len, unsigned char *out,
+             size_t out_max)
  {
     /*
      * This assumes that key size is 32 bytes and the iv is 16 bytes.
@@ -1904,9 +1948,9 @@ Encryption using AES-CBC with a 256-bit key with "CS1" ciphertext stealing.
          goto err;
 
      /* NOTE: CTS mode does not support multiple calls to EVP_CipherUpdate() */
-     if (!EVP_CipherUpdate(ctx, out, &outlen, msg, msg_len))
+     if (!EVP_CipherUpdate_ex(ctx, out, &outlen, out_max, msg, msg_len))
          goto err;
-      if (!EVP_CipherFinal_ex(ctx, out + outlen, &len))
+      if (!EVP_CipherFinal_ex2(ctx, out + outlen, &len, out_max - outlen))
          goto err;
      ret = 1;
  err:
@@ -1987,6 +2031,10 @@ EVP_CipherInit_SKEY() was added in OpenSSL 3.5.
 Prior to OpenSSL 3.5, passing a NULL I<ctx> to
 B<EVP_CIPHER_CTX_get_block_size()> would result in a NULL pointer dereference,
 rather than a 0 return value indicating an error.
+
+The EVP_EncryptUpdate_ex(), EVP_EncryptFinal_ex2(), EVP_DecryptUpdate_ex(),
+EVP_DecryptFinal_ex2(), EVP_CipherUpdate_ex(), EVP_CipherFinal_ex2(), and
+EVP_CipherUpdateAAD() were added in OpenSSL 4.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -32,6 +32,8 @@ EVP_CipherFinal_ex,
 EVP_CipherFinal_ex2,
 EVP_CIPHER_CTX_set_key_length,
 EVP_CIPHER_CTX_ctrl,
+EVP_CIPHER_CTX_max_update_output,
+EVP_CIPHER_CTX_max_final_output,
 EVP_EncryptInit,
 EVP_EncryptFinal,
 EVP_DecryptInit,
@@ -212,6 +214,9 @@ EVP_CIPHER_CTX_mode
  void EVP_CIPHER_CTX_set_flags(EVP_CIPHER_CTX *ctx, int flags);
  void EVP_CIPHER_CTX_clear_flags(EVP_CIPHER_CTX *ctx, int flags);
  int EVP_CIPHER_CTX_test_flags(const EVP_CIPHER_CTX *ctx, int flags);
+
+ size_t EVP_CIPHER_CTX_max_update_output(const EVP_CIPHER_CTX *ctx, size_t inl);
+ size_t EVP_CIPHER_CTX_max_final_output(const EVP_CIPHER_CTX *ctx);
 
  const EVP_CIPHER *EVP_get_cipherbyname(const char *name);
  const EVP_CIPHER *EVP_get_cipherbynid(int nid);
@@ -451,6 +456,9 @@ operation being performed. The call fails if operation produces more
 than I<max_outl> bytes.
 The actual number of bytes written is placed in I<outl>.
 
+The required size of the output buffer can be obtained in advance with
+EVP_CIPHER_CTX_max_update_output().
+
 If padding is enabled (the default) then EVP_EncryptFinal_ex2() encrypts
 the "final" data, that is any data that remains in a partial block.
 It uses standard block padding (aka PKCS padding) as described in
@@ -459,6 +467,9 @@ final data is written to I<out> which should have sufficient space for
 one cipher block. The number of bytes written is placed in I<outl>. After
 this function is called the encryption operation is finished and no further
 calls to EVP_EncryptUpdate() should be made.
+
+The required size of the output buffer can be obtained in advance with
+EVP_CIPHER_CTX_max_final_output().
 
 If padding is disabled then EVP_EncryptFinal_ex2() will not encrypt any more
 data and it will return an error if any data remains in a partial block:
@@ -623,6 +634,14 @@ padding is checked and removed when decrypting. If the I<pad> parameter is zero
 then no padding is performed, the total amount of data encrypted or decrypted
 must then be a multiple of the block size or an error will occur. I<x> B<MUST
 NOT> be NULL.
+
+=item EVP_CIPHER_CTX_max_update_output() and EVP_CIPHER_CTX_max_final_output()
+
+Return the maximum number of bytes that a subsequent Update or Final
+call may write to the output buffer for cipher context I<ctx> and input
+length I<inl>. They replace the legacy idiom of calling EVP_*Update()
+with a NULL output buffer to query the required size, which is no
+longer supported by the I<_ex> variants. Both return 0 on error.
 
 =item EVP_CIPHER_get_key_length() and EVP_CIPHER_CTX_get_key_length()
 
@@ -2033,8 +2052,9 @@ B<EVP_CIPHER_CTX_get_block_size()> would result in a NULL pointer dereference,
 rather than a 0 return value indicating an error.
 
 The EVP_EncryptUpdate_ex(), EVP_EncryptFinal_ex2(), EVP_DecryptUpdate_ex(),
-EVP_DecryptFinal_ex2(), EVP_CipherUpdate_ex(), EVP_CipherFinal_ex2(), and
-EVP_CipherUpdateAAD() were added in OpenSSL 4.1.
+EVP_DecryptFinal_ex2(), EVP_CipherUpdate_ex(), EVP_CipherFinal_ex2(),
+EVP_CipherUpdateAAD(), EVP_CIPHER_CTX_max_update_output(), and
+EVP_CIPHER_CTX_max_final_output() were added in OpenSSL 4.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/RC4_set_key.pod
+++ b/doc/man3/RC4_set_key.pod
@@ -20,8 +20,8 @@ see L<openssl_user_macros(7)>:
 =head1 DESCRIPTION
 
 All of the functions described on this page are deprecated. Applications should
-instead use L<EVP_EncryptInit_ex(3)>, L<EVP_EncryptUpdate(3)> and
-L<EVP_EncryptFinal_ex(3)> or the equivalently named decrypt functions.
+instead use L<EVP_EncryptInit_ex(3)>, L<EVP_EncryptUpdate_ex(3)> and
+L<EVP_EncryptFinal_ex2(3)> or the equivalently named decrypt functions.
 
 This library implements the Alleged RC4 cipher, which is described for
 example in I<Applied Cryptography>.  It is believed to be compatible

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -849,6 +849,8 @@ int EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX *c);
 void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *c);
 int EVP_CIPHER_CTX_set_key_length(EVP_CIPHER_CTX *x, int keylen);
 int EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *c, int pad);
+size_t EVP_CIPHER_CTX_max_update_output(const EVP_CIPHER_CTX *ctx, size_t inl);
+size_t EVP_CIPHER_CTX_max_final_output(const EVP_CIPHER_CTX *ctx);
 int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr);
 int EVP_CIPHER_CTX_rand_key(EVP_CIPHER_CTX *ctx, unsigned char *key);
 int EVP_CIPHER_get_params(EVP_CIPHER *cipher, OSSL_PARAM params[]);

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -692,10 +692,15 @@ __owur int EVP_EncryptInit_ex2(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
     const OSSL_PARAM params[]);
 __owur int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out,
     int *outl, const unsigned char *in, int inl);
+__owur int EVP_EncryptUpdate_ex(EVP_CIPHER_CTX *ctx, unsigned char *out,
+    size_t *outl, size_t max_outl,
+    const unsigned char *in, size_t inl);
 __owur int EVP_EncryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out,
     int *outl);
 __owur int EVP_EncryptFinal(EVP_CIPHER_CTX *ctx, unsigned char *out,
     int *outl);
+__owur int EVP_EncryptFinal_ex2(EVP_CIPHER_CTX *ctx, unsigned char *out,
+    size_t *outl, size_t max_outl);
 
 __owur int EVP_DecryptInit(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
     const unsigned char *key, const unsigned char *iv);
@@ -710,10 +715,15 @@ __owur int EVP_DecryptInit_ex2(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
     const OSSL_PARAM params[]);
 __owur int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out,
     int *outl, const unsigned char *in, int inl);
+__owur int EVP_DecryptUpdate_ex(EVP_CIPHER_CTX *ctx, unsigned char *out,
+    size_t *outl, size_t max_outl,
+    const unsigned char *in, size_t inl);
 __owur int EVP_DecryptFinal(EVP_CIPHER_CTX *ctx, unsigned char *outm,
     int *outl);
 __owur int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *outm,
     int *outl);
+__owur int EVP_DecryptFinal_ex2(EVP_CIPHER_CTX *ctx, unsigned char *out,
+    size_t *outl, size_t max_outl);
 
 __owur int EVP_CipherInit(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
     const unsigned char *key, const unsigned char *iv,
@@ -731,6 +741,11 @@ __owur int EVP_CipherInit_ex2(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
     int enc, const OSSL_PARAM params[]);
 __owur int EVP_CipherUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out,
     int *outl, const unsigned char *in, int inl);
+__owur int EVP_CipherUpdate_ex(EVP_CIPHER_CTX *ctx, unsigned char *out,
+    size_t *outl, size_t max_outl,
+    const unsigned char *in, size_t inl);
+__owur int EVP_CipherUpdateAAD(EVP_CIPHER_CTX *ctx, const unsigned char *in,
+    size_t inl);
 __owur int EVP_CipherFinal(EVP_CIPHER_CTX *ctx, unsigned char *outm,
     int *outl);
 __owur int EVP_CipherPipelineEncryptInit(EVP_CIPHER_CTX *ctx,
@@ -752,6 +767,8 @@ __owur int EVP_CipherPipelineFinal(EVP_CIPHER_CTX *ctx,
     const size_t *outsize);
 __owur int EVP_CipherFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *outm,
     int *outl);
+__owur int EVP_CipherFinal_ex2(EVP_CIPHER_CTX *ctx, unsigned char *out,
+    size_t *outl, size_t max_outl);
 
 __owur int EVP_SignFinal(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s,
     EVP_PKEY *pkey);

--- a/test/build.info
+++ b/test/build.info
@@ -71,7 +71,7 @@ IF[{- !$disabled{tests} -}]
           fips_version_test x509_test hpke_test pairwise_fail_test \
           nodefltctxtest evp_xof_test x509_load_cert_file_test bio_meth_test \
           x509_acert_test x509_req_test strtoultest bio_pw_callback_test \
-          engine_stubs_test base64_simdutf_test bio_eof_test ech_test
+          engine_stubs_test base64_simdutf_test bio_eof_test ech_test evp_sizet_test
 
   IF[{- !$disabled{'ech'} -}]
     PROGRAMS{noinst}=ech_corrupt_test
@@ -259,6 +259,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[evp_fetch_prov_test]=evp_fetch_prov_test.c fake_cipherprov.c
   INCLUDE[evp_fetch_prov_test]=../include ../apps/include
   DEPEND[evp_fetch_prov_test]=../libcrypto libtestutil.a
+
+  SOURCE[evp_sizet_test]=evp_sizet_test.c
+  INCLUDE[evp_sizet_test]=../include ../apps/include
+  DEPEND[evp_sizet_test]=../libcrypto libtestutil.a
 
   SOURCE[provfetchtest]=provfetchtest.c
   INCLUDE[provfetchtest]=../include ../apps/include

--- a/test/evp_sizet_test.c
+++ b/test/evp_sizet_test.c
@@ -15,11 +15,13 @@
 #define MAX_CT_LEN 256
 
 static const unsigned char ptext_pad[] = "The quick brown fox with a padding";
-static const unsigned char key[32] = {
+static const unsigned char key[64] = {
     0x60, 0x3d, 0xeb, 0x10, 0x15, 0xca, 0x71, 0xbe, 0x2b, 0x73, 0xae, 0xf0, 0x85, 0x7d, 0x77, 0x81,
-    0x1f, 0x35, 0x2c, 0x07, 0x3b, 0x61, 0x08, 0xd7, 0x2d, 0x98, 0x10, 0xa3, 0x09, 0x14, 0xdf, 0xf4
+    0x1f, 0x35, 0x2c, 0x07, 0x3b, 0x61, 0x08, 0xd7, 0x2d, 0x98, 0x10, 0xa3, 0x09, 0x14, 0xdf, 0xf4,
+    /* Second key for modes like AES=256-XTS or AES-256-SIV */
+    0x3d, 0x47, 0x42, 0xa2, 0xf5, 0x8f, 0xc2, 0x8d, 0xd4, 0x08, 0x90, 0xf8, 0x01, 0x98, 0x10, 0x41,
+    0x06, 0x23, 0xa7, 0xa0, 0x57, 0x27, 0x2a, 0x29, 0x39, 0x2a, 0xcf, 0xfe, 0x8b, 0xe3, 0x9c, 0xaf
 };
-
 static const unsigned char cbc_iv[16] = {
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
 };
@@ -45,7 +47,86 @@ static const unsigned char gcm_tag[16] = {
     0x7e, 0x7c, 0x34, 0x66, 0x77, 0x92, 0x2b, 0x36, 0xaf, 0xd1, 0xff, 0xdd, 0x48, 0x52, 0x19, 0x53
 };
 
-static EVP_CIPHER_CTX *new_ctx(const char *name, const unsigned char *iv, int enc)
+static const unsigned char fake_iv[64] = {
+    0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+static const struct {
+    const char *name;
+    int is_wrap;
+} ciphers[] = {
+    /* noop cipher */
+    { "NULL", 0 },
+    { "AES-128-CBC", 0 },
+    { "AES-192-CBC", 0 },
+    { "AES-256-CBC", 0 },
+    { "AES-128-ECB", 0 },
+    { "AES-256-ECB", 0 },
+    { "AES-128-CTR", 0 },
+    { "AES-256-CTR", 0 },
+    { "AES-128-GCM", 0 },
+    { "AES-256-GCM", 0 },
+    { "AES-128-CCM", 0 },
+    { "AES-256-CCM", 0 },
+    { "AES-128-OFB", 0 },
+    { "AES-128-CFB", 0 },
+    { "AES-128-CFB1", 0 },
+    { "AES-128-CFB8", 0 },
+    { "AES-128-XTS", 0 },
+    { "AES-256-XTS", 0 },
+    { "AES-128-WRAP", 1 },
+    { "AES-192-WRAP", 1 },
+    { "AES-256-WRAP", 1 },
+    { "AES-128-WRAP-PAD", 1 },
+    { "AES-192-WRAP-PAD", 1 },
+    { "AES-256-WRAP-PAD", 1 },
+#ifndef OPENSSL_NO_OCB
+    { "AES-128-OCB", 0 },
+    { "AES-256-OCB", 0 },
+#endif
+#ifndef OPENSSL_NO_SIV
+    { "AES-128-SIV", 0 },
+    { "AES-256-SIV", 0 },
+#endif
+#ifndef OPENSSL_NO_CHACHA
+    { "ChaCha20", 0 },
+#ifndef OPENSSL_NO_POLY1305
+    { "ChaCha20-Poly1305", 0 },
+#endif
+#endif
+#ifndef OPENSSL_NO_DES
+    { "DES-EDE3-CBC", 0 },
+    { "DES-EDE-CBC", 0 },
+    { "DES-EDE3-ECB", 0 },
+    { "DES-EDE3-CFB1", 0 },
+    { "DES-EDE3-CFB8", 0 },
+    { "DES-EDE3-OFB", 0 },
+#endif
+#ifndef OPENSSL_NO_CAMELLIA
+    { "CAMELLIA-128-CBC", 0 },
+    { "CAMELLIA-256-CBC", 0 },
+    { "CAMELLIA-128-CTR", 0 },
+#endif
+#ifndef OPENSSL_NO_ARIA
+    { "ARIA-128-CBC", 0 },
+    { "ARIA-256-CBC", 0 },
+    { "ARIA-128-CTR", 0 },
+    { "ARIA-128-GCM", 0 },
+    { "ARIA-128-CCM", 0 },
+#endif
+#ifndef OPENSSL_NO_SM4
+    { "SM4-CBC", 0 },
+    { "SM4-ECB", 0 },
+    { "SM4-CTR", 0 },
+    { "SM4-OFB", 0 },
+    { "SM4-CFB", 0 },
+#endif
+};
+
+static EVP_CIPHER_CTX *new_ctx(const char *name, const unsigned char *iv, int enc, int flags)
 {
     EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
     EVP_CIPHER *cipher = NULL;
@@ -55,6 +136,8 @@ static EVP_CIPHER_CTX *new_ctx(const char *name, const unsigned char *iv, int en
     cipher = EVP_CIPHER_fetch(NULL, name, NULL);
     if (!TEST_ptr(cipher))
         goto err;
+    if (iv == NULL && EVP_CIPHER_get_iv_length(cipher) > 0)
+        iv = fake_iv;
     if (!TEST_int_eq(EVP_CipherInit_ex2(ctx, cipher, key, iv, enc, NULL), 1))
         goto err;
     EVP_CIPHER_free(cipher);
@@ -72,7 +155,7 @@ static int test_roundtrip_cbc(void)
     size_t ct_len = 0, pt_len = 0, n;
     int ok = 0;
 
-    ctx = new_ctx("AES-256-CBC", cbc_iv, 1);
+    ctx = new_ctx("AES-256-CBC", cbc_iv, 1, 0);
     if (ctx == NULL)
         goto err;
 
@@ -88,7 +171,7 @@ static int test_roundtrip_cbc(void)
         goto err;
     EVP_CIPHER_CTX_free(ctx);
 
-    ctx = new_ctx("AES-256-CBC", cbc_iv, 0);
+    ctx = new_ctx("AES-256-CBC", cbc_iv, 0, 0);
     if (ctx == NULL)
         goto err;
 
@@ -117,7 +200,7 @@ static int test_roundtrip_cipher_cbc(void)
     size_t ct_len = 0, pt_len = 0, n;
     int ok = 0;
 
-    ctx = new_ctx("AES-256-CBC", cbc_iv, 1);
+    ctx = new_ctx("AES-256-CBC", cbc_iv, 1, 0);
     if (ctx == NULL)
         goto err;
     if (!TEST_int_eq(EVP_CipherUpdate_ex(ctx, ct, &n, sizeof(ct), ptext_pad, sizeof(ptext_pad)), 1))
@@ -133,7 +216,7 @@ static int test_roundtrip_cipher_cbc(void)
 
     EVP_CIPHER_CTX_free(ctx);
 
-    ctx = new_ctx("AES-256-CBC", cbc_iv, 0);
+    ctx = new_ctx("AES-256-CBC", cbc_iv, 0, 0);
     if (ctx == NULL)
         goto err;
 
@@ -160,7 +243,7 @@ static int test_roundtrip_gcm(void)
     size_t ct_len = 0, pt_len = 0, n;
     int ok = 0;
 
-    ctx = new_ctx("AES-256-GCM", gcm_iv, 1);
+    ctx = new_ctx("AES-256-GCM", gcm_iv, 1, 0);
     if (ctx == NULL)
         goto err;
 
@@ -186,7 +269,7 @@ static int test_roundtrip_gcm(void)
     EVP_CIPHER_CTX_free(ctx);
 
     /* Decrypt + verify */
-    ctx = new_ctx("AES-256-GCM", gcm_iv, 0);
+    ctx = new_ctx("AES-256-GCM", gcm_iv, 0, 0);
     if (ctx == NULL)
         goto err;
     if (!TEST_int_eq(EVP_CipherUpdateAAD(ctx, gcm_aad, sizeof(gcm_aad)), 1))
@@ -218,7 +301,7 @@ static int test_rejected_gcm(void)
     size_t n;
     int ok = 0;
 
-    ctx = new_ctx("AES-256-GCM", cbc_iv, 1);
+    ctx = new_ctx("AES-256-GCM", cbc_iv, 1, 0);
     if (ctx == NULL)
         goto err;
 
@@ -259,7 +342,7 @@ static int test_rejected_gcm(void)
     ERR_clear_error();
     EVP_CIPHER_CTX_free(ctx);
 
-    ctx = new_ctx("AES-256-GCM", cbc_iv, 0);
+    ctx = new_ctx("AES-256-GCM", cbc_iv, 0, 0);
     if (ctx == NULL)
         goto err;
 
@@ -311,7 +394,7 @@ static int test_short_buffer_cbc(void)
     size_t n;
     int ok = 0;
 
-    ctx = new_ctx("AES-256-CBC", cbc_iv, 1);
+    ctx = new_ctx("AES-256-CBC", cbc_iv, 1, 0);
     if (ctx == NULL)
         goto err;
 
@@ -341,7 +424,7 @@ static int test_short_buffer_cbc(void)
     ERR_clear_error();
     EVP_CIPHER_CTX_free(ctx);
 
-    ctx = new_ctx("AES-256-CBC", cbc_iv, 0);
+    ctx = new_ctx("AES-256-CBC", cbc_iv, 0, 0);
     if (ctx == NULL)
         goto err;
 
@@ -375,6 +458,78 @@ err:
     return ok;
 }
 
+static int max_output_cipher(const char *name, int is_wrap)
+{
+    const size_t test_inl[] = { 0, 1, 15, 16, 17, 100, 1024 };
+    EVP_CIPHER_CTX *ctx = NULL;
+    int blocksize, ret = 0;
+    size_t bs_add, i;
+
+    ctx = new_ctx(name, NULL, 1, is_wrap ? EVP_CIPHER_CTX_FLAG_WRAP_ALLOW : 0);
+    if (ctx == NULL)
+        return 0;
+
+    blocksize = EVP_CIPHER_CTX_get_block_size(ctx);
+    bs_add = (blocksize == 1) ? 0 : (size_t)blocksize;
+
+    if (!TEST_size_t_eq(EVP_CIPHER_CTX_max_final_output(ctx), bs_add))
+        goto err;
+
+    for (i = 0; i < OSSL_NELEM(test_inl); i++)
+        if (!TEST_size_t_eq(EVP_CIPHER_CTX_max_update_output(ctx, test_inl[i]), test_inl[i] + bs_add))
+            goto err;
+    ret = 1;
+err:
+    if (ret == 0)
+        TEST_info("cipher = %s, blocksize = %d", name, blocksize);
+    EVP_CIPHER_CTX_free(ctx);
+    return ret;
+}
+
+static int test_evp_cipher_ctx_max_output(int idx)
+{
+    return max_output_cipher(ciphers[idx].name, ciphers[idx].is_wrap);
+}
+
+static int test_evp_cipher_ctx_max_output_limits(void)
+{
+    EVP_CIPHER_CTX *ctx = NULL;
+    int ret = 0;
+
+    if (!TEST_size_t_eq(EVP_CIPHER_CTX_max_update_output(NULL, 42), 0))
+        return 0;
+
+    if (!TEST_size_t_eq(EVP_CIPHER_CTX_max_final_output(NULL), 0))
+        return 0;
+
+    ctx = EVP_CIPHER_CTX_new();
+    if (!TEST_ptr(ctx))
+        return 0;
+
+    if (!TEST_size_t_eq(EVP_CIPHER_CTX_max_update_output(ctx, 100), 0))
+        goto err;
+    if (!TEST_size_t_eq(EVP_CIPHER_CTX_max_final_output(ctx), 0))
+        goto err;
+    EVP_CIPHER_CTX_free(ctx);
+
+    ctx = new_ctx("AES-128-CBC", NULL, 1, 0);
+    if (ctx == NULL)
+        return 0;
+
+    if (!TEST_size_t_eq(EVP_CIPHER_CTX_max_update_output(ctx, SIZE_MAX), 0))
+        goto err;
+
+    if (!TEST_size_t_eq(EVP_CIPHER_CTX_max_update_output(ctx, SIZE_MAX - 16), SIZE_MAX))
+        goto err;
+
+    if (!TEST_size_t_eq(EVP_CIPHER_CTX_max_update_output(ctx, SIZE_MAX - 15), 0))
+        goto err;
+    ret = 1;
+err:
+    EVP_CIPHER_CTX_free(ctx);
+    return ret;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(test_roundtrip_cbc);
@@ -382,5 +537,9 @@ int setup_tests(void)
     ADD_TEST(test_roundtrip_gcm);
     ADD_TEST(test_rejected_gcm);
     ADD_TEST(test_short_buffer_cbc);
+
+    ADD_ALL_TESTS(test_evp_cipher_ctx_max_output, OSSL_NELEM(ciphers));
+    ADD_TEST(test_evp_cipher_ctx_max_output_limits);
+
     return 1;
 }

--- a/test/evp_sizet_test.c
+++ b/test/evp_sizet_test.c
@@ -1,0 +1,386 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/evp.h>
+#include <openssl/err.h>
+
+#include "testutil.h"
+
+#define MAX_CT_LEN 256
+
+static const unsigned char ptext_pad[] = "The quick brown fox with a padding";
+static const unsigned char key[32] = {
+    0x60, 0x3d, 0xeb, 0x10, 0x15, 0xca, 0x71, 0xbe, 0x2b, 0x73, 0xae, 0xf0, 0x85, 0x7d, 0x77, 0x81,
+    0x1f, 0x35, 0x2c, 0x07, 0x3b, 0x61, 0x08, 0xd7, 0x2d, 0x98, 0x10, 0xa3, 0x09, 0x14, 0xdf, 0xf4
+};
+
+static const unsigned char cbc_iv[16] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+};
+static const unsigned char cbc_ct[48] = {
+    0x99, 0x3f, 0x48, 0xc8, 0x17, 0x94, 0x6d, 0x0c, 0xcb, 0xa1, 0xd7, 0xc5, 0x38, 0x13, 0xcf, 0x84,
+    0x85, 0x4f, 0x2b, 0xfe, 0x1b, 0xc5, 0xdb, 0x05, 0x45, 0x29, 0xde, 0x2b, 0x4d, 0x34, 0x3d, 0x77,
+    0x45, 0xe6, 0x7d, 0xf6, 0x85, 0x17, 0xba, 0x81, 0xbd, 0x4c, 0xd2, 0x79, 0x4b, 0xfc, 0x13, 0x63
+};
+
+static const unsigned char gcm_iv[12] = {
+    0xca, 0xfe, 0xba, 0xbe, 0xfa, 0xce, 0xdb, 0xad, 0xde, 0xca, 0xf8, 0x88
+};
+static const unsigned char gcm_aad[20] = {
+    0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef, 0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef,
+    0xab, 0xad, 0xda, 0xd2
+};
+static const unsigned char gcm_ct[35] = {
+    0xf3, 0x4f, 0x8d, 0x50, 0x9e, 0x33, 0xb8, 0x18, 0xfd, 0xbe, 0x18, 0x09, 0xb8, 0x8f, 0xa1, 0xe0,
+    0x61, 0x85, 0x58, 0xee, 0x62, 0x25, 0x4e, 0x7f, 0x10, 0x55, 0x85, 0x3b, 0x0c, 0x0b, 0xa5, 0xb4,
+    0x5b, 0x0e, 0x93
+};
+static const unsigned char gcm_tag[16] = {
+    0x7e, 0x7c, 0x34, 0x66, 0x77, 0x92, 0x2b, 0x36, 0xaf, 0xd1, 0xff, 0xdd, 0x48, 0x52, 0x19, 0x53
+};
+
+static EVP_CIPHER_CTX *new_ctx(const char *name, const unsigned char *iv, int enc)
+{
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    EVP_CIPHER *cipher = NULL;
+
+    if (!TEST_ptr(ctx))
+        goto err;
+    cipher = EVP_CIPHER_fetch(NULL, name, NULL);
+    if (!TEST_ptr(cipher))
+        goto err;
+    if (!TEST_int_eq(EVP_CipherInit_ex2(ctx, cipher, key, iv, enc, NULL), 1))
+        goto err;
+    EVP_CIPHER_free(cipher);
+    return ctx;
+err:
+    EVP_CIPHER_free(cipher);
+    EVP_CIPHER_CTX_free(ctx);
+    return NULL;
+}
+
+static int test_roundtrip_cbc(void)
+{
+    EVP_CIPHER_CTX *ctx = NULL;
+    unsigned char ct[MAX_CT_LEN], pt[MAX_CT_LEN];
+    size_t ct_len = 0, pt_len = 0, n;
+    int ok = 0;
+
+    ctx = new_ctx("AES-256-CBC", cbc_iv, 1);
+    if (ctx == NULL)
+        goto err;
+
+    if (!TEST_int_eq(EVP_EncryptUpdate_ex(ctx, ct, &n, sizeof(ct), ptext_pad, sizeof(ptext_pad)), 1))
+        goto err;
+    ct_len = n;
+    if (!TEST_int_eq(EVP_EncryptFinal_ex2(ctx, ct + ct_len, &n, sizeof(ct) - ct_len), 1))
+        goto err;
+    ct_len += n;
+    if (!TEST_size_t_eq(ct_len, sizeof(cbc_ct)))
+        goto err;
+    if (!TEST_mem_eq(ct, ct_len, cbc_ct, sizeof(cbc_ct)))
+        goto err;
+    EVP_CIPHER_CTX_free(ctx);
+
+    ctx = new_ctx("AES-256-CBC", cbc_iv, 0);
+    if (ctx == NULL)
+        goto err;
+
+    if (!TEST_int_eq(EVP_DecryptUpdate_ex(ctx, pt, &n, sizeof(pt), ct, ct_len), 1))
+        goto err;
+    pt_len = n;
+    if (!TEST_int_eq(EVP_DecryptFinal_ex2(ctx, pt + pt_len, &n, sizeof(pt) - pt_len), 1))
+        goto err;
+    pt_len += n;
+
+    if (!TEST_size_t_eq(pt_len, sizeof(ptext_pad)))
+        goto err;
+    if (!TEST_mem_eq(pt, pt_len, ptext_pad, sizeof(ptext_pad)))
+        goto err;
+
+    ok = 1;
+err:
+    EVP_CIPHER_CTX_free(ctx);
+    return ok;
+}
+
+static int test_roundtrip_cipher_cbc(void)
+{
+    EVP_CIPHER_CTX *ctx = NULL;
+    unsigned char ct[MAX_CT_LEN], pt[MAX_CT_LEN];
+    size_t ct_len = 0, pt_len = 0, n;
+    int ok = 0;
+
+    ctx = new_ctx("AES-256-CBC", cbc_iv, 1);
+    if (ctx == NULL)
+        goto err;
+    if (!TEST_int_eq(EVP_CipherUpdate_ex(ctx, ct, &n, sizeof(ct), ptext_pad, sizeof(ptext_pad)), 1))
+        goto err;
+    ct_len = n;
+    if (!TEST_int_eq(EVP_CipherFinal_ex2(ctx, ct + ct_len, &n, sizeof(ct) - ct_len), 1))
+        goto err;
+    ct_len += n;
+    if (!TEST_size_t_eq(ct_len, sizeof(cbc_ct)))
+        goto err;
+    if (!TEST_mem_eq(ct, ct_len, cbc_ct, sizeof(cbc_ct)))
+        goto err;
+
+    EVP_CIPHER_CTX_free(ctx);
+
+    ctx = new_ctx("AES-256-CBC", cbc_iv, 0);
+    if (ctx == NULL)
+        goto err;
+
+    if (!TEST_int_eq(EVP_CipherUpdate_ex(ctx, pt, &n, sizeof(pt), ct, ct_len), 1))
+        goto err;
+    pt_len = n;
+    if (!TEST_int_eq(EVP_CipherFinal_ex2(ctx, pt + pt_len, &n, sizeof(pt) - pt_len), 1))
+        goto err;
+    pt_len += n;
+
+    if (!TEST_mem_eq(pt, pt_len, ptext_pad, sizeof(ptext_pad)))
+        goto err;
+
+    ok = 1;
+err:
+    EVP_CIPHER_CTX_free(ctx);
+    return ok;
+}
+
+static int test_roundtrip_gcm(void)
+{
+    EVP_CIPHER_CTX *ctx = NULL;
+    unsigned char ct[MAX_CT_LEN], pt[MAX_CT_LEN], tag[16];
+    size_t ct_len = 0, pt_len = 0, n;
+    int ok = 0;
+
+    ctx = new_ctx("AES-256-GCM", gcm_iv, 1);
+    if (ctx == NULL)
+        goto err;
+
+    if (!TEST_int_eq(EVP_CipherUpdateAAD(ctx, gcm_aad, sizeof(gcm_aad)), 1))
+        goto err;
+    if (!TEST_int_eq(EVP_EncryptUpdate_ex(ctx, ct, &n, sizeof(ct), ptext_pad, sizeof(ptext_pad)), 1))
+        goto err;
+    ct_len = n;
+    if (!TEST_int_eq(EVP_EncryptFinal_ex2(ctx, ct + ct_len, &n, sizeof(ct) - ct_len), 1))
+        goto err;
+    ct_len += n;
+
+    if (!TEST_int_eq(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, (int)sizeof(tag), tag), 1))
+        goto err;
+    if (!TEST_size_t_eq(ct_len, sizeof(gcm_ct)))
+        goto err;
+    if (!TEST_mem_eq(ct, ct_len, gcm_ct, sizeof(gcm_ct)))
+        goto err;
+    if (!TEST_size_t_eq(sizeof(tag), sizeof(gcm_tag)))
+        goto err;
+    if (!TEST_mem_eq(tag, sizeof(tag), gcm_tag, sizeof(gcm_tag)))
+        goto err;
+    EVP_CIPHER_CTX_free(ctx);
+
+    /* Decrypt + verify */
+    ctx = new_ctx("AES-256-GCM", gcm_iv, 0);
+    if (ctx == NULL)
+        goto err;
+    if (!TEST_int_eq(EVP_CipherUpdateAAD(ctx, gcm_aad, sizeof(gcm_aad)), 1))
+        goto err;
+    if (!TEST_int_eq(EVP_DecryptUpdate_ex(ctx, pt, &n, sizeof(pt), ct, ct_len), 1))
+        goto err;
+    pt_len = n;
+    if (!TEST_int_eq(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG, (int)sizeof(tag), tag), 1))
+        goto err;
+    if (!TEST_int_eq(EVP_DecryptFinal_ex2(ctx, pt + pt_len, &n, sizeof(pt) - pt_len), 1))
+        goto err;
+    pt_len += n;
+
+    if (!TEST_size_t_eq(pt_len, sizeof(ptext_pad)))
+        goto err;
+    if (!TEST_mem_eq(pt, pt_len, ptext_pad, sizeof(ptext_pad)))
+        goto err;
+
+    ok = 1;
+err:
+    EVP_CIPHER_CTX_free(ctx);
+    return ok;
+}
+
+static int test_rejected_gcm(void)
+{
+    EVP_CIPHER_CTX *ctx;
+    unsigned char buf[MAX_CT_LEN];
+    size_t n;
+    int ok = 0;
+
+    ctx = new_ctx("AES-256-GCM", cbc_iv, 1);
+    if (ctx == NULL)
+        goto err;
+
+    /* NULL in */
+    if (!TEST_int_eq(EVP_CipherUpdateAAD(ctx, NULL, sizeof(gcm_aad)), 0))
+        goto err;
+
+    /* NULL out */
+    if (!TEST_int_eq(EVP_EncryptUpdate_ex(ctx, NULL, &n, 0, ptext_pad, sizeof(ptext_pad)), 0))
+        goto err;
+    if (!TEST_int_eq(EVP_EncryptFinal_ex2(ctx, NULL, &n, 0), 0))
+        goto err;
+    if (!TEST_int_eq(EVP_CipherUpdate_ex(ctx, NULL, &n, 0, ptext_pad, sizeof(ptext_pad)), 0))
+        goto err;
+    if (!TEST_int_eq(EVP_CipherFinal_ex2(ctx, NULL, &n, 0), 0))
+        goto err;
+
+    /* NULL outl */
+    if (!TEST_int_eq(EVP_EncryptUpdate_ex(ctx, buf, NULL, sizeof(buf), ptext_pad, sizeof(ptext_pad)), 0))
+        goto err;
+    if (!TEST_int_eq(EVP_EncryptFinal_ex2(ctx, buf, NULL, sizeof(buf)), 0))
+        goto err;
+    if (!TEST_int_eq(EVP_CipherUpdate_ex(ctx, buf, NULL, sizeof(buf), ptext_pad, sizeof(ptext_pad)), 0))
+        goto err;
+    if (!TEST_int_eq(EVP_CipherFinal_ex2(ctx, buf, NULL, sizeof(buf)), 0))
+        goto err;
+
+    /* NULL out, zero inl */
+    if (!TEST_int_eq(EVP_EncryptUpdate_ex(ctx, NULL, &n, 0, NULL, 0), 0))
+        goto err;
+    if (!TEST_int_eq(EVP_CipherUpdate_ex(ctx, NULL, &n, 0, NULL, 0), 0))
+        goto err;
+
+    /* Decrypt function on an encryption context */
+    if (!TEST_int_eq(EVP_DecryptUpdate_ex(ctx, buf, &n, sizeof(buf), ptext_pad, sizeof(ptext_pad)), 0))
+        goto err;
+
+    ERR_clear_error();
+    EVP_CIPHER_CTX_free(ctx);
+
+    ctx = new_ctx("AES-256-GCM", cbc_iv, 0);
+    if (ctx == NULL)
+        goto err;
+
+    /* NULL in */
+    if (!TEST_int_eq(EVP_CipherUpdateAAD(ctx, NULL, sizeof(gcm_aad)), 0))
+        goto err;
+
+    /* NULL out */
+    if (!TEST_int_eq(EVP_DecryptUpdate_ex(ctx, NULL, &n, 0, ptext_pad, sizeof(ptext_pad)), 0))
+        goto err;
+    if (!TEST_int_eq(EVP_DecryptFinal_ex2(ctx, NULL, &n, 0), 0))
+        goto err;
+    if (!TEST_int_eq(EVP_CipherUpdate_ex(ctx, NULL, &n, 0, ptext_pad, sizeof(ptext_pad)), 0))
+        goto err;
+    if (!TEST_int_eq(EVP_CipherFinal_ex2(ctx, NULL, &n, 0), 0))
+        goto err;
+
+    /* NULL outl */
+    if (!TEST_int_eq(EVP_DecryptUpdate_ex(ctx, buf, NULL, sizeof(buf), ptext_pad, sizeof(ptext_pad)), 0))
+        goto err;
+    if (!TEST_int_eq(EVP_DecryptFinal_ex2(ctx, buf, NULL, sizeof(buf)), 0))
+        goto err;
+    if (!TEST_int_eq(EVP_CipherUpdate_ex(ctx, buf, NULL, sizeof(buf), ptext_pad, sizeof(ptext_pad)), 0))
+        goto err;
+    if (!TEST_int_eq(EVP_CipherFinal_ex2(ctx, buf, NULL, sizeof(buf)), 0))
+        goto err;
+
+    /* NULL out, zero inl */
+    if (!TEST_int_eq(EVP_DecryptUpdate_ex(ctx, NULL, &n, 0, NULL, 0), 0))
+        goto err;
+    if (!TEST_int_eq(EVP_CipherUpdate_ex(ctx, NULL, &n, 0, NULL, 0), 0))
+        goto err;
+
+    /* Encrypt function on an decryption context */
+    if (!TEST_int_eq(EVP_EncryptUpdate_ex(ctx, buf, &n, sizeof(buf), ptext_pad, sizeof(ptext_pad)), 0))
+        goto err;
+
+    ERR_clear_error();
+    ok = 1;
+err:
+    EVP_CIPHER_CTX_free(ctx);
+    return ok;
+}
+
+static int test_short_buffer_cbc(void)
+{
+    EVP_CIPHER_CTX *ctx;
+    unsigned char ct[MAX_CT_LEN], pt[MAX_CT_LEN];
+    size_t n;
+    int ok = 0;
+
+    ctx = new_ctx("AES-256-CBC", cbc_iv, 1);
+    if (ctx == NULL)
+        goto err;
+
+    /* Write one block, limit out buffer, avoid padding */
+    n = 0xdeadbeef;
+    if (!TEST_int_eq(EVP_CIPHER_CTX_set_padding(ctx, 0), 1))
+        goto err;
+    if (!TEST_int_eq(EVP_EncryptUpdate_ex(ctx, ct, &n, 0, ptext_pad, 16), 0))
+        goto err;
+    if (!TEST_size_t_eq(n, 0))
+        goto err;
+    n = 0xdeadbeef;
+    if (!TEST_int_eq(EVP_EncryptUpdate_ex(ctx, ct, &n, 15, ptext_pad, 16), 0))
+        goto err;
+    if (!TEST_size_t_eq(n, 0))
+        goto err;
+
+    /* Encrypt exactly one block */
+    n = 0xdeadbeef;
+    if (!TEST_int_eq(EVP_EncryptUpdate_ex(ctx, ct, &n, 16, ptext_pad, 16), 1))
+        goto err;
+    if (!TEST_size_t_eq(n, 16))
+        goto err;
+    if (!TEST_mem_eq(ct, 16, cbc_ct, 16))
+        goto err;
+
+    ERR_clear_error();
+    EVP_CIPHER_CTX_free(ctx);
+
+    ctx = new_ctx("AES-256-CBC", cbc_iv, 0);
+    if (ctx == NULL)
+        goto err;
+
+    /* Write one block, limit out buffer, avoid padding */
+    n = 0xdeadbeef;
+    if (!TEST_int_eq(EVP_CIPHER_CTX_set_padding(ctx, 0), 1))
+        goto err;
+    if (!TEST_int_eq(EVP_DecryptUpdate_ex(ctx, pt, &n, 0, ct, 16), 0))
+        goto err;
+    if (!TEST_size_t_eq(n, 0))
+        goto err;
+    n = 0xdeadbeef;
+    if (!TEST_int_eq(EVP_DecryptUpdate_ex(ctx, pt, &n, 15, ct, 16), 0))
+        goto err;
+    if (!TEST_size_t_eq(n, 0))
+        goto err;
+
+    /* Encrypt exactly one block */
+    n = 0xdeadbeef;
+    if (!TEST_int_eq(EVP_DecryptUpdate_ex(ctx, pt, &n, 16, ct, 16), 1))
+        goto err;
+    if (!TEST_size_t_eq(n, 16))
+        goto err;
+    if (!TEST_mem_eq(pt, 16, ptext_pad, 16))
+        goto err;
+
+    ERR_clear_error();
+    ok = 1;
+err:
+    EVP_CIPHER_CTX_free(ctx);
+    return ok;
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(test_roundtrip_cbc);
+    ADD_TEST(test_roundtrip_cipher_cbc);
+    ADD_TEST(test_roundtrip_gcm);
+    ADD_TEST(test_rejected_gcm);
+    ADD_TEST(test_short_buffer_cbc);
+    return 1;
+}

--- a/test/recipes/30-test_evp_sizet.t
+++ b/test/recipes/30-test_evp_sizet.t
@@ -1,0 +1,11 @@
+#! /usr/bin/env perl
+# Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_evp_sizet", "evp_sizet_test");

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5721,3 +5721,10 @@ CRYPTO_atomic_store_ptr                 ?	4_1_0	EXIST::FUNCTION:
 CRYPTO_atomic_cmp_exch_ptr              ?	4_1_0	EXIST::FUNCTION:
 EVP_EC_affine2oct                       ?	4_1_0	EXIST::FUNCTION:
 OPENSSL_sk_set_copy_thunks              ?	4_1_0	EXIST::FUNCTION:
+EVP_CipherFinal_ex2                     ?	4_1_0	EXIST::FUNCTION:
+EVP_CipherUpdateAAD                     ?	4_1_0	EXIST::FUNCTION:
+EVP_CipherUpdate_ex                     ?	4_1_0	EXIST::FUNCTION:
+EVP_DecryptFinal_ex2                    ?	4_1_0	EXIST::FUNCTION:
+EVP_DecryptUpdate_ex                    ?	4_1_0	EXIST::FUNCTION:
+EVP_EncryptFinal_ex2                    ?	4_1_0	EXIST::FUNCTION:
+EVP_EncryptUpdate_ex                    ?	4_1_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5728,3 +5728,5 @@ EVP_DecryptFinal_ex2                    ?	4_1_0	EXIST::FUNCTION:
 EVP_DecryptUpdate_ex                    ?	4_1_0	EXIST::FUNCTION:
 EVP_EncryptFinal_ex2                    ?	4_1_0	EXIST::FUNCTION:
 EVP_EncryptUpdate_ex                    ?	4_1_0	EXIST::FUNCTION:
+EVP_CIPHER_CTX_max_update_output        ?	4_1_0	EXIST::FUNCTION:
+EVP_CIPHER_CTX_max_final_output         ?	4_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
This patch adds new public functions:
 - EVP_EncryptUpdate_ex()
 - EVP_EncryptFinal_ex2()
 - EVP_DecryptUpdate_ex()
 - EVP_DecryptFinal_ex2()
 - EVP_CipherUpdate_ex()
 - EVP_CipherFinal_ex2()
 - EVP_CipherUpdateAAD()
    
The *_ex/_ex2 variants take size_t in/out lengths (instead of int) and require the caller to pass the output buffer size via an explicit max_outl argument.
    
AAD input is no longer signalled by out == NULL; callers must use EVP_CipherUpdateAAD(). The legacy *Update() functions keep the out == NULL AAD behaviour for compatibility.

EDIT: I also added  two new API calls (last patch)
- EVP_CIPHER_CTX_max_update_output and
- EVP_CIPHER_CTX_max_final_output

Tests are added in the second patch.

Fixes #22628

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
