### PR TITLE
[3.6] Configure: update `$apitable` with the recent versions

### DIFF
--- a/Configure
+++ b/Configure
@@ -221,16 +221,9 @@ our $BSDthreads="-pthread -D_THREAD_SAFE -D_REENTRANT";
 #
 # API compatibility name to version number mapping.
 #
+
+# This table expresses when API additions or changes can occur
 my $apitable = {
-    # This table expresses when API additions or changes can occur.
-    # The numbering used changes from 3.0 and on because we updated
-    # (solidified) our version numbering scheme at that point.
-
-    # From 3.0 and on, we internalise the given version number in decimal
-    # as MAJOR * 10000 + MINOR * 100 + 0
-    "3.0.0" => 30000,
-    "3.0"   => 30000,
-
     # Note that before 3.0, we didn't have the same version number scheme.
     # Still, the numbering we use here covers what we need.
     "1.1.1" => 10101,
@@ -240,6 +233,18 @@ my $apitable = {
     "1.0.0" => 10000,
     "0.9.8" =>   908,
 };
+
+# From 3.0 and on, we internalise the given version number in decimal
+# as MAJOR * 10000 + MINOR * 100 + 0
+my @post30_versions = ([3, 0], [3, 1], [3, 2], [3, 3], [3, 4], [3, 5], [3, 6],
+                       );
+
+# The numbering used changes from 3.0 and on because we updated
+# (solidified) our version numbering scheme at that point.
+foreach (@post30_versions) {
+    my ($x, $y) = @{$_};
+    $apitable->{"$x.$y.0"} = $apitable->{"$x.$y"} = $x * 10000 + $y * 100;
+}
 
 # For OpenSSL::config::get_platform
 my %guess_opts = ();


### PR DESCRIPTION
Fill `$apitable` with all the major.minor.0 versions up to the current one. Note that while 3.5 hasn't had any APIs deprecated, it still makes sense to support passing it as an "API level".

This is a backport of [1] to `openssl-3.6`.

[1] https://github.com/openssl/openssl/pull/31198