### PR TITLE
ECH: force s_client to TLSv1.3 (fixes #31185)

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1231,6 +1231,9 @@ __owur CON_FUNC_RETURN tls_construct_client_hello(SSL_CONNECTION *s,
         s->ext.ech.attempted_type = TLSEXT_TYPE_ech;
         s->ext.ech.attempted_cid = ee->config_id;
         s->ext.ech.attempted = 1;
+        /* force TLSv1.3 if really doing ECH */
+        s->version = TLS1_3_VERSION;
+        s->min_proto_version = TLS1_3_VERSION;
         if (s->ext.ech.outer_hostname == NULL && ee->public_name != NULL) {
             s->ext.ech.outer_hostname = OPENSSL_strdup((char *)ee->public_name);
             if (s->ext.ech.outer_hostname == NULL) {
@@ -1489,7 +1492,7 @@ __owur CON_FUNC_RETURN tls_construct_client_hello(SSL_CONNECTION *s, WPACKET *pk
 #ifndef OPENSSL_NO_ECH
     /* same session ID is used for inner/outer when doing ECH */
     if (s->ext.ech.es != NULL) {
-        if (s->version != TLS1_3_VERSION) {
+        if (s->version != TLS1_3_VERSION || s->min_proto_version < TLS1_3_VERSION) {
             SSLfatal(s, SSL_AD_PROTOCOL_VERSION, SSL_R_UNSUPPORTED_SSL_VERSION);
             return CON_FUNC_ERROR;
         }

--- a/test/ech_test.c
+++ b/test/ech_test.c
@@ -67,6 +67,11 @@ static int ch_test_cb(SSL *ssl, int *al, void *arg)
     if (verbose)
         TEST_info("servername: %s", servername);
     OPENSSL_free(servername);
+    /* check supported versions is only TLSv1.3 */
+    if (!SSL_client_hello_get0_ext(ssl, TLSEXT_TYPE_supported_versions, &pos,
+            &remaining)
+        || remaining != 3 || pos[0] != 0x02 || pos[1] != 0x03 || pos[2] != 0x04)
+        goto give_up;
     /* signal to caller all is good */
     ch_test_cb_ok = 1;
     return 1;


### PR DESCRIPTION

This PR addresses #31185 (which shows up a bug), by having `s_client` force TLSv1.3 when any relevant ECH option is provided on the command line. 

There's also a library change to check if the `min_proto_version` is TLSv1.3 or better before really attempting ECH.

I tested this also with a local `curl` build and it's still ok there.

It's possible that other, better or more checks could also be added to the library, or that we could  have the library force use of TLSv1.3, but I think this more minimal change is maybe a little better.