### PR TITLE
ssl/t1_enc: validate keying material length calculations

### DIFF
--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -455,8 +455,16 @@ int tls1_export_keying_material(SSL_CONNECTION *s, unsigned char *out,
      * than passing separate values into the TLS PRF to ensure that the
      * concatenation of values does not create a prohibited label.
      */
+    if (llen > (SIZE_MAX - (SSL3_RANDOM_SIZE * 2))) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_PASSED_INVALID_ARGUMENT);
+        return 0;
+    }
     vallen = llen + SSL3_RANDOM_SIZE * 2;
     if (use_context) {
+        if (contextlen > (SIZE_MAX - 2)) {
+            ERR_raise(ERR_LIB_SSL, ERR_R_PASSED_INVALID_ARGUMENT);
+            return 0;
+        }
         vallen += 2 + contextlen;
     }
 


### PR DESCRIPTION
Add bounds checks in tls1_export_keying_material() before computing the size of the seed buffer used by the TLS PRF.

The values of llen, SSL3_RANDOM_SIZE, and contextlen are combined to determine the allocation size. Without validating the intermediate additions, sufficiently large input lengths could cause size_t arithmetic to wrap.

Reject invalid arguments that would result in an overflow before performing the calculations.

Fixes #31239

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
