### PR TITLE
Fix unhandled memfail in QUIC tx pkt history map insert

### DIFF
--- a/ssl/quic/quic_ackm.c
+++ b/ssl/quic/quic_ackm.c
@@ -117,6 +117,8 @@ tx_pkt_history_add_actual(struct tx_pkt_history_st *h,
         return 0;
 
     lh_OSSL_ACKM_TX_PKT_insert(h->map, pkt);
+    if (lh_OSSL_ACKM_TX_PKT_error(h->map))
+        return 0;
 
     ossl_list_tx_history_insert_tail(&h->packets, pkt);
     return 1;


### PR DESCRIPTION
This can cause error when freeing txpim as it can be still in use so the assert in it fails.

This was found using #30944 where it failed in the following way:

```
# fuzz quic-client failed: non-zero exit
# - full stderr: ./quic-client-mfail.stderr.log
# - reproduce: OPENSSL_TEST_MFAIL_POINT=639 /home/jakub/prog/openssl/master/fuzz/quic-client-test /home/jakub/prog/openssl/master/fuzz/corpora/quic-client/ff3d660c7cd60f3e8b6ab30a2ee32d9e76413045
# # MFAIL_BEGIN file_idx=298 point=639/1707
# quic-client-test: ssl/quic/quic_txpim.c:63: ossl_quic_txpim_free: Assertion `txpim->in_use == 0' failed.
../../util/wrap.pl ../../fuzz/quic-client-test ../../fuzz/corpora/quic-client/ff3d660c7cd60f3e8b6ab30a2ee32d9e76413045 2> ./quic-client-backtrace.stderr.log => 134
# - backtrace at injection point:
#   # CORPUS_FILE file_idx=0 size=1698 path=../../fuzz/corpora/quic-client/ff3d660c7cd60f3e8b6ab30a2ee32d9e76413045
#   # MFAIL_BEGIN file_idx=0 phase=count
#   # ../../fuzz/corpora/quic-client/ff3d660c7cd60f3e8b6ab30a2ee32d9e76413045: 9653 allocations
#   # MFAIL_BEGIN file_idx=0 point=639/9653
#   # MFAIL_BT (failure injection point)
#       #0 0x74ef1610b5a7 in __sanitizer_print_stack_trace ../../../../src/libsanitizer/asan/asan_stack.cpp:87
#       #1 0x59a2b977d695 in mfail_print_bt test/mfail/mfail.c:75
#       #2 0x59a2b977d723 in should_fail test/mfail/mfail.c:109
#       #3 0x59a2b977d75b in mf_malloc test/mfail/mfail.c:119
#       #4 0x59a2b9db774b in CRYPTO_malloc crypto/mem.c:196
#       #5 0x59a2b9d9e232 in OPENSSL_LH_insert crypto/lhash/lhash.c:130
#       #6 0x59a2b9ae6d77 in lh_OSSL_ACKM_TX_PKT_insert ssl/quic/quic_ackm.c:60
#       #7 0x59a2b9ae7589 in tx_pkt_history_add_actual ssl/quic/quic_ackm.c:119
#       #8 0x59a2b9ae76ec in tx_pkt_history_add ssl/quic/quic_ackm.c:133
#       #9 0x59a2b9aeeef1 in ossl_ackm_on_tx_packet ssl/quic/quic_ackm.c:1115
#       #10 0x59a2b9b38b2d in ossl_quic_fifd_pkt_commit ssl/quic/quic_fifd.c:304
#       #11 0x59a2b9907f50 in txp_pkt_commit ssl/quic/quic_txp.c:3031
#       #12 0x59a2b98f661b in ossl_quic_tx_packetiser_generate ssl/quic/quic_txp.c:1012
#       #13 0x59a2b9b192ed in ch_tx ssl/quic/quic_channel.c:2718
#       #14 0x59a2b9b136eb in ossl_quic_channel_subtick ssl/quic/quic_channel.c:2206
#       #15 0x59a2b9894d18 in ossl_quic_port_subtick ssl/quic/quic_port.c:813
#       #16 0x59a2b9b2eff2 in qeng_tick ssl/quic/quic_engine.c:192
#       #17 0x59a2b98a0030 in ossl_quic_reactor_tick ssl/quic/quic_reactor.c:188
#       #18 0x59a2b9b1b3fd in ossl_quic_channel_start ssl/quic/quic_channel.c:2931
#       #19 0x59a2b986696b in ensure_channel_started ssl/quic/quic_impl.c:1910
#       #20 0x59a2b98675e4 in quic_do_handshake ssl/quic/quic_impl.c:1996
#       #21 0x59a2b9867df5 in ossl_quic_do_handshake ssl/quic/quic_impl.c:2077
#       #22 0x59a2b97db0cd in SSL_do_handshake ssl/ssl_lib.c:5164
#       #23 0x59a2b977b528 in FuzzerTestOneInput fuzz/quic-client.c:159
#       #24 0x59a2b977c546 in run_mfail fuzz/test-corpus.c:64
#       #25 0x59a2b977c9e5 in testfile fuzz/test-corpus.c:102
#       #26 0x59a2b977d2ed in main fuzz/test-corpus.c:164
#       #27 0x74ef1542a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
#       #28 0x74ef1542a28a in __libc_start_main_impl ../csu/libc-start.c:360
#       #29 0x59a2b9779964 in _start (/home/jakub/prog/openssl/master/fuzz/quic-client-test+0x12b8964) (BuildId: acfae861005a03f0d4afb0d336d2548723938797)
#   
#   quic-client-test: ssl/quic/quic_txpim.c:63: ossl_quic_txpim_free: Assertion `txpim->in_use == 0' failed.
not ok 2 - Fuzzing quic-client (mfail count=5, per-test=32.258064516129s)
```

I got mfail test ready in https://github.com/openssl/openssl/compare/master...bukka:openssl:quic-ackm-tx-pkt-history-add-mfail-test . PR will be created after this is merged.