### PR TITLE
s390x: Selectively re-format s390xcap.c

### DIFF
--- a/crypto/s390xcap.c
+++ b/crypto/s390xcap.c
@@ -228,6 +228,7 @@ void OPENSSL_cpuid_setup(void)
 
 static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex)
 {
+    /* clang-format off */
     /*-
      * CPU model data
      * (only the STFLE- and QUERY-bits relevant to libcrypto are set)
@@ -238,19 +239,19 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex)
      * Facility detection would fail on real hw (no STFLE).
      */
     static const struct OPENSSL_s390xcap_st z900 = {
-        /*.stfle  = */ { 0ULL, 0ULL, 0ULL, 0ULL },
-        /*.kimd   = */ { 0ULL, 0ULL },
-        /*.klmd   = */ { 0ULL, 0ULL },
-        /*.km     = */ { 0ULL, 0ULL },
-        /*.kmc    = */ { 0ULL, 0ULL },
-        /*.kmac   = */ { 0ULL, 0ULL },
-        /*.kmctr  = */ { 0ULL, 0ULL },
-        /*.kmo    = */ { 0ULL, 0ULL },
-        /*.kmf    = */ { 0ULL, 0ULL },
-        /*.prno   = */ { 0ULL, 0ULL },
-        /*.kma    = */ { 0ULL, 0ULL },
-        /*.pcc    = */ { 0ULL, 0ULL },
-        /*.kdsa   = */ { 0ULL, 0ULL },
+        .stfle  = { 0ULL, 0ULL, 0ULL, 0ULL },
+        .kimd   = { 0ULL, 0ULL },
+        .klmd   = { 0ULL, 0ULL },
+        .km     = { 0ULL, 0ULL },
+        .kmc    = { 0ULL, 0ULL },
+        .kmac   = { 0ULL, 0ULL },
+        .kmctr  = { 0ULL, 0ULL },
+        .kmo    = { 0ULL, 0ULL },
+        .kmf    = { 0ULL, 0ULL },
+        .prno   = { 0ULL, 0ULL },
+        .kma    = { 0ULL, 0ULL },
+        .pcc    = { 0ULL, 0ULL },
+        .kdsa   = { 0ULL, 0ULL },
     };
 
     /*-
@@ -258,20 +259,27 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex)
      * Implements MSA. Facility detection would fail on real hw (no STFLE).
      */
     static const struct OPENSSL_s390xcap_st z990 = {
-        /*.stfle  = */ { S390X_CAPBIT(S390X_MSA),
-            0ULL, 0ULL, 0ULL },
-        /*.kimd   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_1), 0ULL },
-        /*.klmd   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_1), 0ULL },
-        /*.km     = */ { S390X_CAPBIT(S390X_QUERY), 0ULL },
-        /*.kmc    = */ { S390X_CAPBIT(S390X_QUERY), 0ULL },
-        /*.kmac   = */ { S390X_CAPBIT(S390X_QUERY), 0ULL },
-        /*.kmctr  = */ { 0ULL, 0ULL },
-        /*.kmo    = */ { 0ULL, 0ULL },
-        /*.kmf    = */ { 0ULL, 0ULL },
-        /*.prno   = */ { 0ULL, 0ULL },
-        /*.kma    = */ { 0ULL, 0ULL },
-        /*.pcc    = */ { 0ULL, 0ULL },
-        /*.kdsa   = */ { 0ULL, 0ULL },
+        .stfle  = { S390X_CAPBIT(S390X_MSA),
+                    0ULL, 0ULL, 0ULL },
+        .kimd   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_1),
+                    0ULL },
+        .klmd   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_1),
+                    0ULL },
+        .km     = { S390X_CAPBIT(S390X_QUERY),
+                    0ULL },
+        .kmc    = { S390X_CAPBIT(S390X_QUERY),
+                    0ULL },
+        .kmac   = { S390X_CAPBIT(S390X_QUERY),
+                    0ULL },
+        .kmctr  = { 0ULL, 0ULL },
+        .kmo    = { 0ULL, 0ULL },
+        .kmf    = { 0ULL, 0ULL },
+        .prno   = { 0ULL, 0ULL },
+        .kma    = { 0ULL, 0ULL },
+        .pcc    = { 0ULL, 0ULL },
+        .kdsa   = { 0ULL, 0ULL },
     };
 
     /*-
@@ -279,21 +287,32 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex)
      * Implements MSA and MSA1.
      */
     static const struct OPENSSL_s390xcap_st z9 = {
-        /*.stfle  = */ { S390X_CAPBIT(S390X_MSA)
-                | S390X_CAPBIT(S390X_STCKF),
-            0ULL, 0ULL, 0ULL },
-        /*.kimd   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_1) | S390X_CAPBIT(S390X_SHA_256), 0ULL },
-        /*.klmd   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_1) | S390X_CAPBIT(S390X_SHA_256), 0ULL },
-        /*.km     = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128), 0ULL },
-        /*.kmc    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128), 0ULL },
-        /*.kmac   = */ { S390X_CAPBIT(S390X_QUERY), 0ULL },
-        /*.kmctr  = */ { 0ULL, 0ULL },
-        /*.kmo    = */ { 0ULL, 0ULL },
-        /*.kmf    = */ { 0ULL, 0ULL },
-        /*.prno   = */ { 0ULL, 0ULL },
-        /*.kma    = */ { 0ULL, 0ULL },
-        /*.pcc    = */ { 0ULL, 0ULL },
-        /*.kdsa   = */ { 0ULL, 0ULL },
+        .stfle  = { S390X_CAPBIT(S390X_MSA)
+                    | S390X_CAPBIT(S390X_STCKF),
+                    0ULL, 0ULL, 0ULL },
+        .kimd   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_1)
+                    | S390X_CAPBIT(S390X_SHA_256),
+                    0ULL },
+        .klmd   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_1)
+                    | S390X_CAPBIT(S390X_SHA_256),
+                    0ULL },
+        .km     = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128),
+                    0ULL },
+        .kmc    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128),
+                    0ULL },
+        .kmac   = { S390X_CAPBIT(S390X_QUERY),
+                    0ULL },
+        .kmctr  = { 0ULL, 0ULL },
+        .kmo    = { 0ULL, 0ULL },
+        .kmf    = { 0ULL, 0ULL },
+        .prno   = { 0ULL, 0ULL },
+        .kma    = { 0ULL, 0ULL },
+        .pcc    = { 0ULL, 0ULL },
+        .kdsa   = { 0ULL, 0ULL },
     };
 
     /*-
@@ -301,21 +320,38 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex)
      * Implements MSA and MSA1-2.
      */
     static const struct OPENSSL_s390xcap_st z10 = {
-        /*.stfle  = */ { S390X_CAPBIT(S390X_MSA)
-                | S390X_CAPBIT(S390X_STCKF),
-            0ULL, 0ULL, 0ULL },
-        /*.kimd   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_1) | S390X_CAPBIT(S390X_SHA_256) | S390X_CAPBIT(S390X_SHA_512), 0ULL },
-        /*.klmd   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_1) | S390X_CAPBIT(S390X_SHA_256) | S390X_CAPBIT(S390X_SHA_512), 0ULL },
-        /*.km     = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmc    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmac   = */ { S390X_CAPBIT(S390X_QUERY), 0ULL },
-        /*.kmctr  = */ { 0ULL, 0ULL },
-        /*.kmo    = */ { 0ULL, 0ULL },
-        /*.kmf    = */ { 0ULL, 0ULL },
-        /*.prno   = */ { 0ULL, 0ULL },
-        /*.kma    = */ { 0ULL, 0ULL },
-        /*.pcc    = */ { 0ULL, 0ULL },
-        /*.kdsa   = */ { 0ULL, 0ULL },
+        .stfle  = { S390X_CAPBIT(S390X_MSA)
+                    | S390X_CAPBIT(S390X_STCKF),
+                    0ULL, 0ULL, 0ULL },
+        .kimd   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_1)
+                    | S390X_CAPBIT(S390X_SHA_256)
+                    | S390X_CAPBIT(S390X_SHA_512),
+                    0ULL },
+        .klmd   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_1)
+                    | S390X_CAPBIT(S390X_SHA_256)
+                    | S390X_CAPBIT(S390X_SHA_512),
+                    0ULL },
+        .km     = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmc    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmac   = { S390X_CAPBIT(S390X_QUERY),
+                    0ULL },
+        .kmctr  = { 0ULL, 0ULL },
+        .kmo    = { 0ULL, 0ULL },
+        .kmf    = { 0ULL, 0ULL },
+        .prno   = { 0ULL, 0ULL },
+        .kma    = { 0ULL, 0ULL },
+        .pcc    = { 0ULL, 0ULL },
+        .kdsa   = { 0ULL, 0ULL },
     };
 
     /*-
@@ -323,23 +359,58 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex)
      * Implements MSA and MSA1-4.
      */
     static const struct OPENSSL_s390xcap_st z196 = {
-        /*.stfle  = */ { S390X_CAPBIT(S390X_MSA)
-                | S390X_CAPBIT(S390X_STCKF),
-            S390X_CAPBIT(S390X_MSA3)
-                | S390X_CAPBIT(S390X_MSA4),
-            0ULL, 0ULL },
-        /*.kimd   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_1) | S390X_CAPBIT(S390X_SHA_256) | S390X_CAPBIT(S390X_SHA_512), S390X_CAPBIT(S390X_GHASH) },
-        /*.klmd   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_1) | S390X_CAPBIT(S390X_SHA_256) | S390X_CAPBIT(S390X_SHA_512), 0ULL },
-        /*.km     = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256) | S390X_CAPBIT(S390X_XTS_AES_128) | S390X_CAPBIT(S390X_XTS_AES_256), 0ULL },
-        /*.kmc    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmac   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmctr  = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmo    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmf    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.prno   = */ { 0ULL, 0ULL },
-        /*.kma    = */ { 0ULL, 0ULL },
-        /*.pcc    = */ { S390X_CAPBIT(S390X_QUERY), 0ULL },
-        /*.kdsa   = */ { 0ULL, 0ULL },
+        .stfle  = { S390X_CAPBIT(S390X_MSA)
+                    | S390X_CAPBIT(S390X_STCKF),
+                    S390X_CAPBIT(S390X_MSA3)
+                    | S390X_CAPBIT(S390X_MSA4),
+                    0ULL, 0ULL },
+        .kimd   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_1)
+                    | S390X_CAPBIT(S390X_SHA_256)
+                    | S390X_CAPBIT(S390X_SHA_512),
+                    S390X_CAPBIT(S390X_GHASH) },
+        .klmd   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_1)
+                    | S390X_CAPBIT(S390X_SHA_256)
+                    | S390X_CAPBIT(S390X_SHA_512),
+                    0ULL },
+        .km     = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256)
+                    | S390X_CAPBIT(S390X_XTS_AES_128)
+                    | S390X_CAPBIT(S390X_XTS_AES_256),
+                    0ULL },
+        .kmc    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmac   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmctr  = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmo    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmf    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .prno   = { 0ULL, 0ULL },
+        .kma    = { 0ULL, 0ULL },
+        .pcc    = { S390X_CAPBIT(S390X_QUERY),
+                    0ULL },
+        .kdsa   = { 0ULL, 0ULL },
     };
 
     /*-
@@ -347,23 +418,58 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex)
      * Implements MSA and MSA1-4.
      */
     static const struct OPENSSL_s390xcap_st zEC12 = {
-        /*.stfle  = */ { S390X_CAPBIT(S390X_MSA)
-                | S390X_CAPBIT(S390X_STCKF),
-            S390X_CAPBIT(S390X_MSA3)
-                | S390X_CAPBIT(S390X_MSA4),
-            0ULL, 0ULL },
-        /*.kimd   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_1) | S390X_CAPBIT(S390X_SHA_256) | S390X_CAPBIT(S390X_SHA_512), S390X_CAPBIT(S390X_GHASH) },
-        /*.klmd   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_1) | S390X_CAPBIT(S390X_SHA_256) | S390X_CAPBIT(S390X_SHA_512), 0ULL },
-        /*.km     = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256) | S390X_CAPBIT(S390X_XTS_AES_128) | S390X_CAPBIT(S390X_XTS_AES_256), 0ULL },
-        /*.kmc    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmac   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmctr  = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmo    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmf    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.prno   = */ { 0ULL, 0ULL },
-        /*.kma    = */ { 0ULL, 0ULL },
-        /*.pcc    = */ { S390X_CAPBIT(S390X_QUERY), 0ULL },
-        /*.kdsa   = */ { 0ULL, 0ULL },
+        .stfle  = { S390X_CAPBIT(S390X_MSA)
+                    | S390X_CAPBIT(S390X_STCKF),
+                    S390X_CAPBIT(S390X_MSA3)
+                    | S390X_CAPBIT(S390X_MSA4),
+                    0ULL, 0ULL },
+        .kimd   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_1)
+                    | S390X_CAPBIT(S390X_SHA_256)
+                    | S390X_CAPBIT(S390X_SHA_512),
+                    S390X_CAPBIT(S390X_GHASH) },
+        .klmd   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_1)
+                    | S390X_CAPBIT(S390X_SHA_256)
+                    | S390X_CAPBIT(S390X_SHA_512),
+                    0ULL },
+        .km     = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256)
+                    | S390X_CAPBIT(S390X_XTS_AES_128)
+                    | S390X_CAPBIT(S390X_XTS_AES_256),
+                    0ULL },
+        .kmc    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmac   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmctr  = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmo    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmf    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .prno   = { 0ULL, 0ULL },
+        .kma    = { 0ULL, 0ULL },
+        .pcc    = { S390X_CAPBIT(S390X_QUERY),
+                    0ULL },
+        .kdsa   = { 0ULL, 0ULL },
     };
 
     /*-
@@ -371,25 +477,62 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex)
      * Implements MSA and MSA1-5.
      */
     static const struct OPENSSL_s390xcap_st z13 = {
-        /*.stfle  = */ { S390X_CAPBIT(S390X_MSA)
-                | S390X_CAPBIT(S390X_STCKF)
-                | S390X_CAPBIT(S390X_MSA5),
-            S390X_CAPBIT(S390X_MSA3)
-                | S390X_CAPBIT(S390X_MSA4),
-            S390X_CAPBIT(S390X_VX),
-            0ULL },
-        /*.kimd   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_1) | S390X_CAPBIT(S390X_SHA_256) | S390X_CAPBIT(S390X_SHA_512), S390X_CAPBIT(S390X_GHASH) },
-        /*.klmd   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_1) | S390X_CAPBIT(S390X_SHA_256) | S390X_CAPBIT(S390X_SHA_512), 0ULL },
-        /*.km     = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256) | S390X_CAPBIT(S390X_XTS_AES_128) | S390X_CAPBIT(S390X_XTS_AES_256), 0ULL },
-        /*.kmc    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmac   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmctr  = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmo    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmf    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.prno   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_512_DRNG), 0ULL },
-        /*.kma    = */ { 0ULL, 0ULL },
-        /*.pcc    = */ { S390X_CAPBIT(S390X_QUERY), 0ULL },
-        /*.kdsa   = */ { 0ULL, 0ULL },
+        .stfle  = { S390X_CAPBIT(S390X_MSA)
+                    | S390X_CAPBIT(S390X_STCKF)
+                    | S390X_CAPBIT(S390X_MSA5),
+                    S390X_CAPBIT(S390X_MSA3)
+                    | S390X_CAPBIT(S390X_MSA4),
+                    S390X_CAPBIT(S390X_VX),
+                    0ULL },
+        .kimd   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_1)
+                    | S390X_CAPBIT(S390X_SHA_256)
+                    | S390X_CAPBIT(S390X_SHA_512),
+                    S390X_CAPBIT(S390X_GHASH) },
+        .klmd   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_1)
+                    | S390X_CAPBIT(S390X_SHA_256)
+                    | S390X_CAPBIT(S390X_SHA_512),
+                    0ULL },
+        .km     = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256)
+                    | S390X_CAPBIT(S390X_XTS_AES_128)
+                    | S390X_CAPBIT(S390X_XTS_AES_256),
+                    0ULL },
+        .kmc    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmac   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmctr  = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmo    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmf    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .prno   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_512_DRNG),
+                    0ULL },
+        .kma    = { 0ULL, 0ULL },
+        .pcc    = { S390X_CAPBIT(S390X_QUERY),
+                    0ULL },
+        .kdsa   = { 0ULL, 0ULL },
     };
 
     /*-
@@ -397,28 +540,81 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex)
      * Implements MSA and MSA1-8.
      */
     static const struct OPENSSL_s390xcap_st z14 = {
-        /*.stfle  = */ { S390X_CAPBIT(S390X_MSA)
-                | S390X_CAPBIT(S390X_STCKF)
-                | S390X_CAPBIT(S390X_MSA5),
-            S390X_CAPBIT(S390X_MSA3)
-                | S390X_CAPBIT(S390X_MSA4),
-            S390X_CAPBIT(S390X_VX)
-                | S390X_CAPBIT(S390X_VXD)
-                | S390X_CAPBIT(S390X_VXE)
-                | S390X_CAPBIT(S390X_MSA8),
-            0ULL },
-        /*.kimd   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_1) | S390X_CAPBIT(S390X_SHA_256) | S390X_CAPBIT(S390X_SHA_512) | S390X_CAPBIT(S390X_SHA3_224) | S390X_CAPBIT(S390X_SHA3_256) | S390X_CAPBIT(S390X_SHA3_384) | S390X_CAPBIT(S390X_SHA3_512) | S390X_CAPBIT(S390X_SHAKE_128) | S390X_CAPBIT(S390X_SHAKE_256), S390X_CAPBIT(S390X_GHASH) },
-        /*.klmd   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_1) | S390X_CAPBIT(S390X_SHA_256) | S390X_CAPBIT(S390X_SHA_512) | S390X_CAPBIT(S390X_SHA3_224) | S390X_CAPBIT(S390X_SHA3_256) | S390X_CAPBIT(S390X_SHA3_384) | S390X_CAPBIT(S390X_SHA3_512) | S390X_CAPBIT(S390X_SHAKE_128) | S390X_CAPBIT(S390X_SHAKE_256), 0ULL },
-        /*.km     = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256) | S390X_CAPBIT(S390X_XTS_AES_128) | S390X_CAPBIT(S390X_XTS_AES_256), 0ULL },
-        /*.kmc    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmac   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmctr  = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmo    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmf    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.prno   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_512_DRNG), S390X_CAPBIT(S390X_TRNG) },
-        /*.kma    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.pcc    = */ { S390X_CAPBIT(S390X_QUERY), 0ULL },
-        /*.kdsa   = */ { 0ULL, 0ULL },
+        .stfle  = { S390X_CAPBIT(S390X_MSA)
+                    | S390X_CAPBIT(S390X_STCKF)
+                    | S390X_CAPBIT(S390X_MSA5),
+                    S390X_CAPBIT(S390X_MSA3)
+                    | S390X_CAPBIT(S390X_MSA4),
+                    S390X_CAPBIT(S390X_VX)
+                    | S390X_CAPBIT(S390X_VXD)
+                    | S390X_CAPBIT(S390X_VXE)
+                    | S390X_CAPBIT(S390X_MSA8),
+                    0ULL },
+        .kimd   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_1)
+                    | S390X_CAPBIT(S390X_SHA_256)
+                    | S390X_CAPBIT(S390X_SHA_512)
+                    | S390X_CAPBIT(S390X_SHA3_224)
+                    | S390X_CAPBIT(S390X_SHA3_256)
+                    | S390X_CAPBIT(S390X_SHA3_384)
+                    | S390X_CAPBIT(S390X_SHA3_512)
+                    | S390X_CAPBIT(S390X_SHAKE_128)
+                    | S390X_CAPBIT(S390X_SHAKE_256),
+                    S390X_CAPBIT(S390X_GHASH) },
+        .klmd   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_1)
+                    | S390X_CAPBIT(S390X_SHA_256)
+                    | S390X_CAPBIT(S390X_SHA_512)
+                    | S390X_CAPBIT(S390X_SHA3_224)
+                    | S390X_CAPBIT(S390X_SHA3_256)
+                    | S390X_CAPBIT(S390X_SHA3_384)
+                    | S390X_CAPBIT(S390X_SHA3_512)
+                    | S390X_CAPBIT(S390X_SHAKE_128)
+                    | S390X_CAPBIT(S390X_SHAKE_256),
+                    0ULL },
+        .km     = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256)
+                    | S390X_CAPBIT(S390X_XTS_AES_128)
+                    | S390X_CAPBIT(S390X_XTS_AES_256),
+                    0ULL },
+        .kmc    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmac   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmctr  = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmo    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmf    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .prno   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_512_DRNG),
+                    S390X_CAPBIT(S390X_TRNG) },
+        .kma    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .pcc    = { S390X_CAPBIT(S390X_QUERY),
+                    0ULL },
+        .kdsa   = { 0ULL, 0ULL },
     };
 
     /*-
@@ -426,29 +622,99 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex)
      * Implements MSA and MSA1-9.
      */
     static const struct OPENSSL_s390xcap_st z15 = {
-        /*.stfle  = */ { S390X_CAPBIT(S390X_MSA)
-                | S390X_CAPBIT(S390X_STCKF)
-                | S390X_CAPBIT(S390X_MSA5),
-            S390X_CAPBIT(S390X_MSA3)
-                | S390X_CAPBIT(S390X_MSA4),
-            S390X_CAPBIT(S390X_VX)
-                | S390X_CAPBIT(S390X_VXD)
-                | S390X_CAPBIT(S390X_VXE)
-                | S390X_CAPBIT(S390X_MSA8)
-                | S390X_CAPBIT(S390X_MSA9),
-            0ULL },
-        /*.kimd   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_1) | S390X_CAPBIT(S390X_SHA_256) | S390X_CAPBIT(S390X_SHA_512) | S390X_CAPBIT(S390X_SHA3_224) | S390X_CAPBIT(S390X_SHA3_256) | S390X_CAPBIT(S390X_SHA3_384) | S390X_CAPBIT(S390X_SHA3_512) | S390X_CAPBIT(S390X_SHAKE_128) | S390X_CAPBIT(S390X_SHAKE_256), S390X_CAPBIT(S390X_GHASH) },
-        /*.klmd   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_1) | S390X_CAPBIT(S390X_SHA_256) | S390X_CAPBIT(S390X_SHA_512) | S390X_CAPBIT(S390X_SHA3_224) | S390X_CAPBIT(S390X_SHA3_256) | S390X_CAPBIT(S390X_SHA3_384) | S390X_CAPBIT(S390X_SHA3_512) | S390X_CAPBIT(S390X_SHAKE_128) | S390X_CAPBIT(S390X_SHAKE_256), 0ULL },
-        /*.km     = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256) | S390X_CAPBIT(S390X_XTS_AES_128) | S390X_CAPBIT(S390X_XTS_AES_256), 0ULL },
-        /*.kmc    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmac   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmctr  = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmo    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmf    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.prno   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_512_DRNG), S390X_CAPBIT(S390X_TRNG) },
-        /*.kma    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.pcc    = */ { S390X_CAPBIT(S390X_QUERY), S390X_CAPBIT(S390X_SCALAR_MULTIPLY_P256) | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_P384) | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_P521) | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_ED25519) | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_ED448) | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_X25519) | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_X448) },
-        /*.kdsa   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_ECDSA_VERIFY_P256) | S390X_CAPBIT(S390X_ECDSA_VERIFY_P384) | S390X_CAPBIT(S390X_ECDSA_VERIFY_P521) | S390X_CAPBIT(S390X_ECDSA_SIGN_P256) | S390X_CAPBIT(S390X_ECDSA_SIGN_P384) | S390X_CAPBIT(S390X_ECDSA_SIGN_P521) | S390X_CAPBIT(S390X_EDDSA_VERIFY_ED25519) | S390X_CAPBIT(S390X_EDDSA_VERIFY_ED448) | S390X_CAPBIT(S390X_EDDSA_SIGN_ED25519) | S390X_CAPBIT(S390X_EDDSA_SIGN_ED448), 0ULL },
+        .stfle  = { S390X_CAPBIT(S390X_MSA)
+                    | S390X_CAPBIT(S390X_STCKF)
+                    | S390X_CAPBIT(S390X_MSA5),
+                    S390X_CAPBIT(S390X_MSA3)
+                    | S390X_CAPBIT(S390X_MSA4),
+                    S390X_CAPBIT(S390X_VX)
+                    | S390X_CAPBIT(S390X_VXD)
+                    | S390X_CAPBIT(S390X_VXE)
+                    | S390X_CAPBIT(S390X_MSA8)
+                    | S390X_CAPBIT(S390X_MSA9),
+                    0ULL },
+        .kimd   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_1)
+                    | S390X_CAPBIT(S390X_SHA_256)
+                    | S390X_CAPBIT(S390X_SHA_512)
+                    | S390X_CAPBIT(S390X_SHA3_224)
+                    | S390X_CAPBIT(S390X_SHA3_256)
+                    | S390X_CAPBIT(S390X_SHA3_384)
+                    | S390X_CAPBIT(S390X_SHA3_512)
+                    | S390X_CAPBIT(S390X_SHAKE_128)
+                    | S390X_CAPBIT(S390X_SHAKE_256),
+                    S390X_CAPBIT(S390X_GHASH) },
+        .klmd   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_1)
+                    | S390X_CAPBIT(S390X_SHA_256)
+                    | S390X_CAPBIT(S390X_SHA_512)
+                    | S390X_CAPBIT(S390X_SHA3_224)
+                    | S390X_CAPBIT(S390X_SHA3_256)
+                    | S390X_CAPBIT(S390X_SHA3_384)
+                    | S390X_CAPBIT(S390X_SHA3_512)
+                    | S390X_CAPBIT(S390X_SHAKE_128)
+                    | S390X_CAPBIT(S390X_SHAKE_256),
+                    0ULL },
+        .km     = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256)
+                    | S390X_CAPBIT(S390X_XTS_AES_128)
+                    | S390X_CAPBIT(S390X_XTS_AES_256),
+                    0ULL },
+        .kmc    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmac   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmctr  = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmo    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmf    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL},
+        .prno   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_512_DRNG),
+                    S390X_CAPBIT(S390X_TRNG) },
+        .kma    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .pcc    = { S390X_CAPBIT(S390X_QUERY),
+                    S390X_CAPBIT(S390X_SCALAR_MULTIPLY_P256)
+                    | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_P384)
+                    | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_P521)
+                    | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_ED25519)
+                    | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_ED448)
+                    | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_X25519)
+                    | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_X448) },
+        .kdsa   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_ECDSA_VERIFY_P256)
+                    | S390X_CAPBIT(S390X_ECDSA_VERIFY_P384)
+                    | S390X_CAPBIT(S390X_ECDSA_VERIFY_P521)
+                    | S390X_CAPBIT(S390X_ECDSA_SIGN_P256)
+                    | S390X_CAPBIT(S390X_ECDSA_SIGN_P384)
+                    | S390X_CAPBIT(S390X_ECDSA_SIGN_P521)
+                    | S390X_CAPBIT(S390X_EDDSA_VERIFY_ED25519)
+                    | S390X_CAPBIT(S390X_EDDSA_VERIFY_ED448)
+                    | S390X_CAPBIT(S390X_EDDSA_SIGN_ED25519)
+                    | S390X_CAPBIT(S390X_EDDSA_SIGN_ED448),
+                    0ULL },
     };
 
     /*-
@@ -461,31 +727,107 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex)
      * Implements MSA and MSA1-12.
      */
     static const struct OPENSSL_s390xcap_st z17 = {
-        /*.stfle  = */ { S390X_CAPBIT(S390X_MSA)
-                | S390X_CAPBIT(S390X_STCKF)
-                | S390X_CAPBIT(S390X_MSA5),
-            S390X_CAPBIT(S390X_MSA3)
-                | S390X_CAPBIT(S390X_MSA4)
-                | S390X_CAPBIT(S390X_MSA12),
-            S390X_CAPBIT(S390X_VX)
-                | S390X_CAPBIT(S390X_VXD)
-                | S390X_CAPBIT(S390X_VXE)
-                | S390X_CAPBIT(S390X_MSA8)
-                | S390X_CAPBIT(S390X_MSA9),
-            0ULL },
-        /*.kimd   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_1) | S390X_CAPBIT(S390X_SHA_256) | S390X_CAPBIT(S390X_SHA_512) | S390X_CAPBIT(S390X_SHA3_224) | S390X_CAPBIT(S390X_SHA3_256) | S390X_CAPBIT(S390X_SHA3_384) | S390X_CAPBIT(S390X_SHA3_512) | S390X_CAPBIT(S390X_SHAKE_128) | S390X_CAPBIT(S390X_SHAKE_256), S390X_CAPBIT(S390X_GHASH) },
-        /*.klmd   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_1) | S390X_CAPBIT(S390X_SHA_256) | S390X_CAPBIT(S390X_SHA_512) | S390X_CAPBIT(S390X_SHA3_224) | S390X_CAPBIT(S390X_SHA3_256) | S390X_CAPBIT(S390X_SHA3_384) | S390X_CAPBIT(S390X_SHA3_512) | S390X_CAPBIT(S390X_SHAKE_128) | S390X_CAPBIT(S390X_SHAKE_256), 0ULL },
-        /*.km     = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256) | S390X_CAPBIT(S390X_XTS_AES_128) | S390X_CAPBIT(S390X_XTS_AES_256), S390X_CAPBIT(S390X_XTS_AES_128_MSA10) | S390X_CAPBIT(S390X_XTS_AES_256_MSA10) },
-        /*.kmc    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmac   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), S390X_CAPBIT(S390X_HMAC_SHA_224) | S390X_CAPBIT(S390X_HMAC_SHA_256) | S390X_CAPBIT(S390X_HMAC_SHA_384) | S390X_CAPBIT(S390X_HMAC_SHA_512) },
-        /*.kmctr  = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmo    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.kmf    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.prno   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_SHA_512_DRNG), S390X_CAPBIT(S390X_TRNG) },
-        /*.kma    = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_AES_128) | S390X_CAPBIT(S390X_AES_192) | S390X_CAPBIT(S390X_AES_256), 0ULL },
-        /*.pcc    = */ { S390X_CAPBIT(S390X_QUERY), S390X_CAPBIT(S390X_SCALAR_MULTIPLY_P256) | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_P384) | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_P521) | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_ED25519) | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_ED448) | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_X25519) | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_X448) },
-        /*.kdsa   = */ { S390X_CAPBIT(S390X_QUERY) | S390X_CAPBIT(S390X_ECDSA_VERIFY_P256) | S390X_CAPBIT(S390X_ECDSA_VERIFY_P384) | S390X_CAPBIT(S390X_ECDSA_VERIFY_P521) | S390X_CAPBIT(S390X_ECDSA_SIGN_P256) | S390X_CAPBIT(S390X_ECDSA_SIGN_P384) | S390X_CAPBIT(S390X_ECDSA_SIGN_P521) | S390X_CAPBIT(S390X_EDDSA_VERIFY_ED25519) | S390X_CAPBIT(S390X_EDDSA_VERIFY_ED448) | S390X_CAPBIT(S390X_EDDSA_SIGN_ED25519) | S390X_CAPBIT(S390X_EDDSA_SIGN_ED448), 0ULL },
+        .stfle  = { S390X_CAPBIT(S390X_MSA)
+                    | S390X_CAPBIT(S390X_STCKF)
+                    | S390X_CAPBIT(S390X_MSA5),
+                    S390X_CAPBIT(S390X_MSA3)
+                    | S390X_CAPBIT(S390X_MSA4)
+                    | S390X_CAPBIT(S390X_MSA12),
+                    S390X_CAPBIT(S390X_VX)
+                    | S390X_CAPBIT(S390X_VXD)
+                    | S390X_CAPBIT(S390X_VXE)
+                    | S390X_CAPBIT(S390X_MSA8)
+                    | S390X_CAPBIT(S390X_MSA9),
+                    0ULL },
+        .kimd   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_1)
+                    | S390X_CAPBIT(S390X_SHA_256)
+                    | S390X_CAPBIT(S390X_SHA_512)
+                    | S390X_CAPBIT(S390X_SHA3_224)
+                    | S390X_CAPBIT(S390X_SHA3_256)
+                    | S390X_CAPBIT(S390X_SHA3_384)
+                    | S390X_CAPBIT(S390X_SHA3_512)
+                    | S390X_CAPBIT(S390X_SHAKE_128)
+                    | S390X_CAPBIT(S390X_SHAKE_256),
+                    S390X_CAPBIT(S390X_GHASH) },
+        .klmd   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_1)
+                    | S390X_CAPBIT(S390X_SHA_256)
+                    | S390X_CAPBIT(S390X_SHA_512)
+                    | S390X_CAPBIT(S390X_SHA3_224)
+                    | S390X_CAPBIT(S390X_SHA3_256)
+                    | S390X_CAPBIT(S390X_SHA3_384)
+                    | S390X_CAPBIT(S390X_SHA3_512)
+                    | S390X_CAPBIT(S390X_SHAKE_128)
+                    | S390X_CAPBIT(S390X_SHAKE_256),
+                    0ULL },
+        .km     = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256)
+                    | S390X_CAPBIT(S390X_XTS_AES_128)
+                    | S390X_CAPBIT(S390X_XTS_AES_256),
+                    S390X_CAPBIT(S390X_XTS_AES_128_MSA10)
+                    | S390X_CAPBIT(S390X_XTS_AES_256_MSA10) },
+        .kmc    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmac   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    S390X_CAPBIT(S390X_HMAC_SHA_224)
+                    | S390X_CAPBIT(S390X_HMAC_SHA_256)
+                    | S390X_CAPBIT(S390X_HMAC_SHA_384)
+                    | S390X_CAPBIT(S390X_HMAC_SHA_512) },
+        .kmctr  = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmo    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .kmf    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .prno   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_SHA_512_DRNG),
+                    S390X_CAPBIT(S390X_TRNG) },
+        .kma    = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_AES_128)
+                    | S390X_CAPBIT(S390X_AES_192)
+                    | S390X_CAPBIT(S390X_AES_256),
+                    0ULL },
+        .pcc    = { S390X_CAPBIT(S390X_QUERY),
+                    S390X_CAPBIT(S390X_SCALAR_MULTIPLY_P256)
+                    | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_P384)
+                    | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_P521)
+                    | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_ED25519)
+                    | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_ED448)
+                    | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_X25519)
+                    | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_X448) },
+        .kdsa   = { S390X_CAPBIT(S390X_QUERY)
+                    | S390X_CAPBIT(S390X_ECDSA_VERIFY_P256)
+                    | S390X_CAPBIT(S390X_ECDSA_VERIFY_P384)
+                    | S390X_CAPBIT(S390X_ECDSA_VERIFY_P521)
+                    | S390X_CAPBIT(S390X_ECDSA_SIGN_P256)
+                    | S390X_CAPBIT(S390X_ECDSA_SIGN_P384)
+                    | S390X_CAPBIT(S390X_ECDSA_SIGN_P521)
+                    | S390X_CAPBIT(S390X_EDDSA_VERIFY_ED25519)
+                    | S390X_CAPBIT(S390X_EDDSA_VERIFY_ED448)
+                    | S390X_CAPBIT(S390X_EDDSA_SIGN_ED25519)
+                    | S390X_CAPBIT(S390X_EDDSA_SIGN_ED448),
+                    0ULL },
     };
+
+    /* clang-format on */
 
     char *tok_begin, *tok_end, *buff, tok[S390X_STFLE_MAX][LEN + 1];
     int rc, off, i, n;
@@ -503,6 +845,7 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex)
     tok_end = strtok(NULL, ";");
 
     while (tok_begin != NULL) {
+        /* clang-format off */
         /* stfle token */
         if ((n = sscanf(tok_begin,
                  " stfle : %" STR(LEN) "[^:] : "
@@ -518,20 +861,38 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex)
         }
 
         /* query function tokens */
-        else if TOK_FUNC (kimd)
-            else if TOK_FUNC (klmd) else if TOK_FUNC (km) else if TOK_FUNC (kmc) else if TOK_FUNC (kmac) else if TOK_FUNC (kmctr) else if TOK_FUNC (kmo) else if TOK_FUNC (kmf) else if TOK_FUNC (prno) else if TOK_FUNC (kma) else if TOK_FUNC (pcc) else if TOK_FUNC (kdsa)
+        else if TOK_FUNC(kimd)
+        else if TOK_FUNC(klmd)
+        else if TOK_FUNC(km)
+        else if TOK_FUNC(kmc)
+        else if TOK_FUNC(kmac)
+        else if TOK_FUNC(kmctr)
+        else if TOK_FUNC(kmo)
+        else if TOK_FUNC(kmf)
+        else if TOK_FUNC(prno)
+        else if TOK_FUNC(kma)
+        else if TOK_FUNC(pcc)
+        else if TOK_FUNC(kdsa)
 
-                /* CPU model tokens */
-                else if TOK_CPU (z900) else if TOK_CPU (z990) else if TOK_CPU (z9) else if TOK_CPU (z10) else if TOK_CPU (z196) else if TOK_CPU (zEC12) else if TOK_CPU (z13) else if TOK_CPU (z14) else if TOK_CPU (z15) else if TOK_CPU_ALIAS (z16, z15) else if TOK_CPU (z17)
+        /* CPU model tokens */
+        else if TOK_CPU(z900)
+        else if TOK_CPU(z990)
+        else if TOK_CPU(z9)
+        else if TOK_CPU(z10)
+        else if TOK_CPU(z196)
+        else if TOK_CPU(zEC12)
+        else if TOK_CPU(z13)
+        else if TOK_CPU(z14)
+        else if TOK_CPU(z15)
+        else if TOK_CPU_ALIAS(z16, z15)
+        else if TOK_CPU(z17)
 
-                /* nocex to deactivate cex support */
-                else if (sscanf(tok_begin, " %" STR(LEN) "s %" STR(LEN) "s ",
-                             tok[0], tok[1])
-                        == 1
-                    && !strcmp(tok[0], "nocex"))
-            {
-                *cex = 0;
-            }
+        /* nocex to deactivate cex support */
+        else if (sscanf(tok_begin, " %" STR(LEN) "s %" STR(LEN) "s ",
+                     tok[0], tok[1]) == 1
+            && !strcmp(tok[0], "nocex")) {
+            *cex = 0;
+        }
 
         /* whitespace(ignored) or invalid tokens */
         else {
@@ -541,6 +902,7 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex)
                 tok_begin++;
             }
         }
+        /* clang-format on */
 
         tok_begin = tok_end;
         tok_end = strtok(NULL, ";");


### PR DESCRIPTION
The clang formatter made some code places unreadable. Selectively revert the formatting to how it was before the re-formatting, and mark those places with `/* clang-format off */` so that it does not get reformatted again.

No functional change intended.

Closes: https://github.com/openssl/openssl/issues/31247