### PR TITLE
crypto/objects/obj_dat.c: avoid negative signed to unsigned cast in OBJ_obj2txt

### DIFF
--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -393,6 +393,9 @@ int OBJ_obj2txt(char *buf, int buf_len, const ASN1_OBJECT *a, int no_name)
     if (a == NULL || a->data == NULL)
         return 0;
 
+    if (buf_len < 0)
+        buf_len = 0;
+
     if (!no_name && (nid = OBJ_obj2nid(a)) != NID_undef) {
         s = OBJ_nid2ln(nid);
         if (s == NULL)


### PR DESCRIPTION
While most of the code paths check that `buf_len` is positive or non-negative, and avoid running it under 0, there are two `OPENSSL_strlcpy()` calls that use `buf_len` as is, which may lead to an OOB write if the caller has passed a negative value in the first place, together with a non-NULL `buf`.

Fixes: 452ae49db544 "Extensive OID code enhancement and fixes."