### PR TITLE
`doc/man7/ossl-guide-migration.pod`: reword `DESCRIPTION` section a bit

### DIFF
--- a/doc/man7/ossl-guide-migration.pod
+++ b/doc/man7/ossl-guide-migration.pod
@@ -11,10 +11,11 @@ See the individual manual pages for details.
 
 =head1 DESCRIPTION
 
-This guide details the changes required to migrate to new versions of OpenSSL.
-Currently this covers OpenSSL 3.0 & 3.1. For earlier versions refer to
+This guide details the changes required to migrate to new versions of OpenSSL,
+covering OpenSSL 3.0 and later versions.
+For earlier versions, refer to
 L<https://github.com/openssl/openssl/blob/master/CHANGES.md>.
-For an overview of some of the key concepts introduced in OpenSSL 3.0 see
+For an overview of some of the key concepts introduced since OpenSSL 3.0, see
 L<crypto(7)>.
 
 =head1 OPENSSL 4.1


### PR DESCRIPTION
Update the wording in the `DESCRIPTION` section, so it is no longer implied that OpenSSL 3.0 is something new.