### PR TITLE
Fix win32_joiner buffer sizing for dir-only paths

### DIFF
--- a/crypto/dso/dso_win32.c
+++ b/crypto/dso/dso_win32.c
@@ -321,7 +321,7 @@ static char *win32_joiner(DSO *dso, const struct file_st *file_split)
         len++; /* 1 for ending \ */
     }
     len += file_split->dirlen;
-    if (file_split->dir && file_split->file) {
+    if (file_split->dir) {
         len++; /* 1 for ending \ */
     }
     len += file_split->filelen;


### PR DESCRIPTION
win32_joiner() always emits a trailing '\' when file_split->dir is present, even if file_split->file is NULL. The previous length calculation only reserved that byte when file_split->file was also non-NULL, which could cause a one-byte overflow.

Fixes #31260

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated