### PR TITLE
quic: delay el keyslot teardown after creation in setup

### DIFF
--- a/ssl/quic/quic_record_shared.c
+++ b/ssl/quic/quic_record_shared.c
@@ -98,26 +98,18 @@ static void el_teardown_keyslot(OSSL_QRL_ENC_LEVEL_SET *els,
     OPENSSL_cleanse(el->iv[keyslot], sizeof(el->iv[keyslot]));
 }
 
-static int el_setup_keyslot(OSSL_QRL_ENC_LEVEL_SET *els,
-    uint32_t enc_level,
-    unsigned char tgt_state,
-    size_t keyslot,
-    const unsigned char *secret,
-    size_t secret_len)
+static int el_build_keyslot(OSSL_QRL_ENC_LEVEL *el,
+    const unsigned char *secret, size_t secret_len,
+    EVP_CIPHER_CTX **out_cctx, unsigned char *out_iv, size_t *out_iv_len)
 {
-    OSSL_QRL_ENC_LEVEL *el = ossl_qrl_enc_level_set_get(els, enc_level, 0);
     unsigned char key[EVP_MAX_KEY_LENGTH];
     size_t key_len = 0, iv_len = 0;
     const char *cipher_name = NULL;
     EVP_CIPHER *cipher = NULL;
     EVP_CIPHER_CTX *cctx = NULL;
 
-    if (!ossl_assert(el != NULL
-            && ossl_qrl_enc_level_set_has_keyslot(els, enc_level,
-                tgt_state, keyslot))) {
-        ERR_raise(ERR_LIB_SSL, ERR_R_PASSED_INVALID_ARGUMENT);
-        return 0;
-    }
+    *out_cctx = NULL;
+    *out_iv_len = 0;
 
     cipher_name = ossl_qrl_get_suite_cipher_name(el->suite_id);
     iv_len = ossl_qrl_get_suite_cipher_iv_len(el->suite_id);
@@ -133,25 +125,15 @@ static int el_setup_keyslot(OSSL_QRL_ENC_LEVEL_SET *els,
         return 0;
     }
 
-    assert(el->cctx[keyslot] == NULL);
-
-    /* Derive "quic iv" key. */
-    if (!tls13_hkdf_expand_ex(el->libctx, el->propq,
-            el->md,
-            secret,
-            quic_v1_iv_label,
-            sizeof(quic_v1_iv_label),
-            NULL, 0,
-            el->iv[keyslot], iv_len, 1))
+    /* Derive "quic iv" into caller's buffer. */
+    if (!tls13_hkdf_expand_ex(el->libctx, el->propq, el->md, secret,
+            quic_v1_iv_label, sizeof(quic_v1_iv_label), NULL, 0,
+            out_iv, iv_len, 1))
         goto err;
 
-    /* Derive "quic key" key. */
-    if (!tls13_hkdf_expand_ex(el->libctx, el->propq,
-            el->md,
-            secret,
-            quic_v1_key_label,
-            sizeof(quic_v1_key_label),
-            NULL, 0,
+    /* Derive "quic key" into local. */
+    if (!tls13_hkdf_expand_ex(el->libctx, el->propq, el->md, secret,
+            quic_v1_key_label, sizeof(quic_v1_key_label), NULL, 0,
             key, key_len, 1))
         goto err;
 
@@ -173,12 +155,13 @@ static int el_setup_keyslot(OSSL_QRL_ENC_LEVEL_SET *els,
     }
 
     /* IV will be changed on RX/TX so we don't need to use a real value here. */
-    if (!EVP_CipherInit_ex(cctx, cipher, NULL, key, el->iv[keyslot], 0)) {
+    if (!EVP_CipherInit_ex(cctx, cipher, NULL, key, out_iv, 0)) {
         ERR_raise(ERR_LIB_SSL, ERR_R_EVP_LIB);
         goto err;
     }
 
-    el->cctx[keyslot] = cctx;
+    *out_cctx = cctx;
+    *out_iv_len = iv_len;
 
     /* Zeroize intermediate keys. */
     OPENSSL_cleanse(key, sizeof(key));
@@ -188,9 +171,45 @@ static int el_setup_keyslot(OSSL_QRL_ENC_LEVEL_SET *els,
 err:
     EVP_CIPHER_CTX_free(cctx);
     EVP_CIPHER_free(cipher);
-    OPENSSL_cleanse(el->iv[keyslot], sizeof(el->iv[keyslot]));
     OPENSSL_cleanse(key, sizeof(key));
+    OPENSSL_cleanse(out_iv, *out_iv_len);
     return 0;
+}
+
+static void el_install_keyslot(OSSL_QRL_ENC_LEVEL *el, size_t keyslot,
+    EVP_CIPHER_CTX *new_cctx, const unsigned char *new_iv, size_t new_iv_len)
+{
+    assert(el->cctx[keyslot] == NULL);
+    assert(new_iv_len <= sizeof(el->iv[keyslot]));
+
+    el->cctx[keyslot] = new_cctx;
+    memcpy(el->iv[keyslot], new_iv, new_iv_len);
+}
+
+static int el_setup_keyslot(OSSL_QRL_ENC_LEVEL_SET *els, uint32_t enc_level,
+    unsigned char tgt_state, size_t keyslot, const unsigned char *secret,
+    size_t secret_len)
+{
+    OSSL_QRL_ENC_LEVEL *el = ossl_qrl_enc_level_set_get(els, enc_level, 0);
+    EVP_CIPHER_CTX *new_cctx = NULL;
+    unsigned char new_iv[EVP_MAX_IV_LENGTH];
+    size_t new_iv_len = EVP_MAX_IV_LENGTH;
+
+    if (!ossl_assert(el != NULL
+            && ossl_qrl_enc_level_set_has_keyslot(els, enc_level,
+                tgt_state, keyslot))) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_PASSED_INVALID_ARGUMENT);
+        return 0;
+    }
+
+    if (!el_build_keyslot(el, secret, secret_len, &new_cctx, new_iv,
+            &new_iv_len))
+        return 0;
+
+    el_install_keyslot(el, keyslot, new_cctx, new_iv, new_iv_len);
+
+    OPENSSL_cleanse(new_iv, sizeof(new_iv));
+    return 1;
 }
 
 int ossl_qrl_enc_level_set_provide_secret(OSSL_QRL_ENC_LEVEL_SET *els,
@@ -346,6 +365,9 @@ int ossl_qrl_enc_level_set_key_update(OSSL_QRL_ENC_LEVEL_SET *els,
     uint32_t enc_level)
 {
     OSSL_QRL_ENC_LEVEL *el = ossl_qrl_enc_level_set_get(els, enc_level, 0);
+    EVP_CIPHER_CTX *new_cctx = NULL;
+    unsigned char new_iv[EVP_MAX_IV_LENGTH];
+    size_t new_iv_len = EVP_MAX_IV_LENGTH;
     size_t secret_len;
     unsigned char new_ku[EVP_MAX_KEY_LENGTH];
 
@@ -383,12 +405,14 @@ int ossl_qrl_enc_level_set_key_update(OSSL_QRL_ENC_LEVEL_SET *els,
             new_ku, secret_len, 1))
         return 0;
 
-    el_teardown_keyslot(els, enc_level, 0);
-
-    /* Setup keyslot for CURRENT "quic ku" key. */
-    if (!el_setup_keyslot(els, enc_level, QRL_EL_STATE_PROV_NORMAL,
-            0, el->ku, secret_len))
+    /* Build new keyslot first so if it fails, teardown is not done. */
+    if (!el_build_keyslot(el, el->ku, secret_len, &new_cctx, new_iv,
+            &new_iv_len))
         return 0;
+
+    el_teardown_keyslot(els, enc_level, 0);
+    el_install_keyslot(el, 0, new_cctx, new_iv, new_iv_len);
+    OPENSSL_cleanse(new_iv, sizeof(new_iv));
 
     ++el->key_epoch;
     el->op_count = 0;


### PR DESCRIPTION
There is an issue for key update in TX path if any of the operation fails during keyslot setup (e.g. due to memory failure), the cctx stays set to NULL which results in failed assertion in qtx_encrypt_into_txe.

The fix splits the build and installation steps in ossl_qrl_enc_level_set_key_update so the cctx teardown is done only
after the build is successful. The install is then non fallible so it cannot end up with empty cctx.

This was found using #30944 with the following failure:

```
# - reproduce: OPENSSL_TEST_MFAIL_POINT=1733 /home/jakub/prog/openssl/master/fuzz/quic-client-test /home/jakub/prog/openssl/master/fuzz/corpora/quic-client/95a57518dd57e3c5262893d24615bae9021ccb69
# # MFAIL_BEGIN file_idx=11 point=1733/2000
# ssl/quic/quic_record_tx.c:496: OpenSSL internal error: Assertion failed: cctx != NULL
../../util/wrap.pl ../../fuzz/quic-client-test ../../fuzz/corpora/quic-client/95a57518dd57e3c5262893d24615bae9021ccb69 2> ./quic-client-backtrace.stderr.log => 134
# - backtrace at injection point:
#   # CORPUS_FILE file_idx=0 size=8374 path=../../fuzz/corpora/quic-client/95a57518dd57e3c5262893d24615bae9021ccb69
#   # MFAIL_BEGIN file_idx=0 phase=count
#   # ../../fuzz/corpora/quic-client/95a57518dd57e3c5262893d24615bae9021ccb69: 9938 allocations
#   # MFAIL_BEGIN file_idx=0 point=1733/9938
#   # MFAIL_BT (failure injection point)
#       #0 0x73a55290b5a7 in __sanitizer_print_stack_trace ../../../../src/libsanitizer/asan/asan_stack.cpp:87
#       #1 0x611a560ca695 in mfail_print_bt test/mfail/mfail.c:75
#       #2 0x611a560ca723 in should_fail test/mfail/mfail.c:109
#       #3 0x611a560ca75b in mf_malloc test/mfail/mfail.c:119
#       #4 0x611a5670488b in CRYPTO_malloc crypto/mem.c:196
#       #5 0x611a5670493d in CRYPTO_zalloc crypto/mem.c:226
#       #6 0x611a5663b32d in EVP_MD_CTX_new crypto/evp/digest.c:107
#       #7 0x611a566d708e in hmac_ctx_alloc_mds crypto/hmac/hmac.c:208
#       #8 0x611a566d734f in HMAC_CTX_reset crypto/hmac/hmac.c:221
#       #9 0x611a566d6a9a in HMAC_CTX_new crypto/hmac/hmac.c:170
#       #10 0x611a56a105d9 in HKDF_Expand providers/implementations/kdfs/hkdf.c:721
#       #11 0x611a56a10bee in prov_tls13_hkdf_expand providers/implementations/kdfs/hkdf.c:805
#       #12 0x611a56a119d8 in kdf_tls1_3_derive providers/implementations/kdfs/hkdf.c:961
#       #13 0x611a566772ff in EVP_KDF_derive crypto/evp/kdf_lib.c:145
#       #14 0x611a561929b5 in tls13_hkdf_expand_ex ssl/tls13_enc.c:93
#       #15 0x611a562023a1 in el_setup_keyslot ssl/quic/quic_record_shared.c:139
#       #16 0x611a562043c6 in ossl_qrl_enc_level_set_key_update ssl/quic/quic_record_shared.c:389
#       #17 0x611a5620f693 in ossl_qtx_trigger_key_update ssl/quic/quic_record_tx.c:1061
#       #18 0x611a56455536 in ch_trigger_txku ssl/quic/quic_channel.c:792
#       #19 0x611a564569f5 in rxku_detected ssl/quic/quic_channel.c:957
#       #20 0x611a561fad14 in qrx_key_update_initiated ssl/quic/quic_record_rx.c:1007
#       #21 0x611a561fd6d6 in qrx_process_pkt ssl/quic/quic_record_rx.c:1253
#       #22 0x611a561feb78 in qrx_process_datagram ssl/quic/quic_record_rx.c:1381
#       #23 0x611a561fed59 in qrx_process_one_urxe ssl/quic/quic_record_rx.c:1404
#       #24 0x611a561ff409 in qrx_process_pending_urxl ssl/quic/quic_record_rx.c:1435
#       #25 0x611a561ff4b6 in ossl_qrx_read_pkt ssl/quic/quic_record_rx.c:1446
#       #26 0x611a564616b8 in ch_rx ssl/quic/quic_channel.c:2302
#       #27 0x611a5645fdd9 in ossl_quic_channel_subtick ssl/quic/quic_channel.c:2141
#       #28 0x611a561e1dac in ossl_quic_port_subtick ssl/quic/quic_port.c:813
#       #29 0x611a5647c12c in qeng_tick ssl/quic/quic_engine.c:192
#       #30 0x611a561ed0c4 in ossl_quic_reactor_tick ssl/quic/quic_reactor.c:188
#       #31 0x611a561c47e8 in qctx_maybe_autotick ssl/quic/quic_impl.c:4038
#       #32 0x611a561b5d7f in qc_wait_for_default_xso_for_read ssl/quic/quic_impl.c:2211
#       #33 0x611a561bd2cc in quic_read ssl/quic/quic_impl.c:3108
#       #34 0x611a561bda6b in ossl_quic_read ssl/quic/quic_impl.c:3182
#       #35 0x611a5610b086 in ssl_read_internal ssl/ssl_lib.c:2420
#       #36 0x611a5610bde1 in SSL_read ssl/ssl_lib.c:2486
#       #37 0x611a560c8568 in FuzzerTestOneInput fuzz/quic-client.c:165
#       #38 0x611a560c9546 in run_mfail fuzz/test-corpus.c:64
#       #39 0x611a560c99e5 in testfile fuzz/test-corpus.c:102
#       #40 0x611a560ca2ed in main fuzz/test-corpus.c:164
#       #41 0x73a551c2a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
#       #42 0x73a551c2a28a in __libc_start_main_impl ../csu/libc-start.c:360
#       #43 0x611a560c6964 in _start (/home/jakub/prog/openssl/master/fuzz/quic-client-test+0x12b8964) (BuildId: 33a7281a2098a3b53073f379de56f3d4733e4512)
#   
#   ssl/quic/quic_record_tx.c:496: OpenSSL internal error: Assertion failed: cctx != NULL
```
