### PR TITLE
Elbrus2000 (e2k) architecture support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,11 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * Added various optimizations for the Elbrus2000 architecture in the
+   cryptographic and BN code.
+
+   *Gleb Popov*
+
  * Fixed TLS 1.3 external PSK connections being wrongly rejected when
    the client sets a non-empty session ID context.
 

--- a/Configurations/50-e2k.conf
+++ b/Configurations/50-e2k.conf
@@ -1,0 +1,20 @@
+## -*- mode: perl; -*-
+(
+    "linux-e2k" => {
+        inherit_from    => [ "linux-generic64" ],
+        cflags          => add("-m64"),
+        cxxflags        => add("-m64"),
+        lib_cppflags    => add("-DL_ENDIAN"),
+        multilib        => "64",
+        bn_ops          => "SIXTY_FOUR_BIT_LONG",
+        asm_arch        => "e2k",
+    },
+    "linux-e2kv6" => {
+        inherit_from    => [ "linux-e2k" ],
+        asm_arch        => "e2kv6",
+    },
+    "linux-e2kv7" => {
+        inherit_from    => [ "linux-e2k" ],
+        asm_arch        => "e2kv7",
+    },
+);

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,7 @@ OpenSSL 4.1
 
   * API calls `CRYPTO_atomic_load_ptr`, `CRYPTO_atomic_store_ptr`, and
     `CRYPTO_atomic_cmp_exch_ptr` have been added.
+  * Initial support for the Elbrus2000 (e2k) architecture
 
   * Fixed verification of DSA certificates signed with SHA-384 or SHA-512.
 

--- a/crypto/async/arch/async_posix.c
+++ b/crypto/async/arch/async_posix.c
@@ -116,7 +116,11 @@ int async_fibre_makecontext(async_fibre *fibre)
         if (fibre->fibre.uc_stack.ss_sp != NULL) {
             fibre->fibre.uc_stack.ss_size = num;
             fibre->fibre.uc_link = NULL;
+#ifndef __e2k__
             makecontext(&fibre->fibre, async_start_func, 0);
+#else
+            makecontext_e2k(&fibre->fibre, async_start_func, 0);
+#endif
             return 1;
         }
     } else {
@@ -129,6 +133,9 @@ void async_fibre_free(async_fibre *fibre)
 {
     stack_free_impl(fibre->fibre.uc_stack.ss_sp);
     fibre->fibre.uc_stack.ss_sp = NULL;
+#ifdef __e2k__
+    freecontext_e2k(&fibre->fibre);
+#endif
 }
 
 #endif

--- a/crypto/bn/asm/e2k-bn-asm.c
+++ b/crypto/bn/asm/e2k-bn-asm.c
@@ -1,0 +1,825 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "../bn_local.h"
+
+#include <assert.h>
+#include <e2kbuiltin.h>
+
+/*
+ * E2Kv5+ BIGNUM accelerator
+ *
+ * Implemented by Alexander Troosh <trush@yandex.ru>
+ *
+ */
+
+#undef mul_add
+#undef mul
+#undef sqr
+
+#if __iset__ < 5
+#define mul_add(r, a, w, c)                  \
+    {                                        \
+        BN_ULONG high, low, ret, tmp = (a);  \
+        ret = (r);                           \
+        high = __builtin_e2k_umulhd(w, tmp); \
+        ret += (c);                          \
+        low = (w) * tmp;                     \
+        (c) = (ret < (c)) ? 1 : 0;           \
+        (c) += high;                         \
+        ret += low;                          \
+        (c) += (ret < low) ? 1 : 0;          \
+        (r) = ret;                           \
+    }
+
+#define mul(r, a, w, c)                     \
+    {                                       \
+        BN_ULONG high, low, ret, ta = (a);  \
+        low = (w) * ta;                     \
+        high = __builtin_e2k_umulhd(w, ta); \
+        ret = low + (c);                    \
+        (c) = high;                         \
+        (c) += (ret < low) ? 1 : 0;         \
+        (r) = ret;                          \
+    }
+#else
+/* { c_out[64], r_out[64] } = (r[64] + c[64]) + a[64]*w[64] */
+#define mul_add(r, a, w, c)                             \
+    {                                                   \
+        BN_ULONG high, low, ret, ta = (a), tc = (c), q; \
+        ret = (r);                                      \
+        high = __builtin_e2k_umulhd(w, ta);             \
+        low = (w) * ta;                                 \
+        q = __builtin_e2k_addcd_c(ret, tc, 0);          \
+        ret += tc;                                      \
+        c = __builtin_e2k_addcd_c(ret, low, 0);         \
+        r = ret + low;                                  \
+        c += high + q;                                  \
+    }
+
+#define mul(r, a, w, c)                       \
+    {                                         \
+        BN_ULONG high, low, q, ta = (a);      \
+        low = (w) * ta;                       \
+        high = __builtin_e2k_umulhd(w, ta);   \
+        q = __builtin_e2k_addcd_c(low, c, 0); \
+        r = low + (c);                        \
+        c = high + q;                         \
+    }
+#endif
+
+#define sqr(r0, r1, a)                         \
+    {                                          \
+        BN_ULONG tmp = (a);                    \
+        (r0) = tmp * tmp;                      \
+        (r1) = __builtin_e2k_umulhd(tmp, tmp); \
+    }
+
+BN_ULONG bn_mul_add_words(BN_ULONG *rp, const BN_ULONG *ap, int num,
+    BN_ULONG w)
+{
+    BN_ULONG c1 = 0;
+
+    assert(num >= 0);
+    if (num <= 0)
+        return c1;
+
+#ifndef OPENSSL_SMALL_FOOTPRINT
+    while (num & ~3) {
+        mul_add(rp[0], ap[0], w, c1);
+        mul_add(rp[1], ap[1], w, c1);
+        mul_add(rp[2], ap[2], w, c1);
+        mul_add(rp[3], ap[3], w, c1);
+        ap += 4;
+        rp += 4;
+        num -= 4;
+    }
+#endif
+    while (num) {
+        mul_add(rp[0], ap[0], w, c1);
+        ap++;
+        rp++;
+        num--;
+    }
+
+    return c1;
+}
+
+BN_ULONG bn_mul_words(BN_ULONG *rp, const BN_ULONG *ap, int num, BN_ULONG w)
+{
+    BN_ULONG c1 = 0;
+
+    assert(num >= 0);
+    if (num <= 0)
+        return c1;
+
+#ifndef OPENSSL_SMALL_FOOTPRINT
+    while (num & ~3) {
+        mul(rp[0], ap[0], w, c1);
+        mul(rp[1], ap[1], w, c1);
+        mul(rp[2], ap[2], w, c1);
+        mul(rp[3], ap[3], w, c1);
+        ap += 4;
+        rp += 4;
+        num -= 4;
+    }
+#endif
+    while (num) {
+        mul(rp[0], ap[0], w, c1);
+        ap++;
+        rp++;
+        num--;
+    }
+    return c1;
+}
+
+void bn_sqr_words(BN_ULONG *r, const BN_ULONG *a, int n)
+{
+    assert(n >= 0);
+    if (n <= 0)
+        return;
+
+#ifndef OPENSSL_SMALL_FOOTPRINT
+    while (n & ~3) {
+        sqr(r[0], r[1], a[0]);
+        sqr(r[2], r[3], a[1]);
+        sqr(r[4], r[5], a[2]);
+        sqr(r[6], r[7], a[3]);
+        a += 4;
+        r += 8;
+        n -= 4;
+    }
+#endif
+    while (n) {
+        sqr(r[0], r[1], a[0]);
+        a++;
+        r += 2;
+        n--;
+    }
+}
+
+/* Divide h,l by d and return the result. */
+BN_ULONG bn_div_words(BN_ULONG h, BN_ULONG l, BN_ULONG d)
+{
+    BN_ULONG dh, dl, q, ret = 0, th, tl, t;
+    int i, count = 2;
+
+    if (d == 0)
+        return BN_MASK2;
+
+    i = BN_num_bits_word(d);
+    assert((i == BN_BITS2) || (h <= (BN_ULONG)1 << i));
+
+    i = BN_BITS2 - i;
+    if (h >= d)
+        h -= d;
+
+    if (i) {
+        d <<= i;
+        h = (h << i) | (l >> (BN_BITS2 - i));
+        l <<= i;
+    }
+    dh = (d & BN_MASK2h) >> BN_BITS4;
+    dl = (d & BN_MASK2l);
+    for (;;) {
+        if ((h >> BN_BITS4) == dh)
+            q = BN_MASK2l;
+        else
+            q = h / dh;
+
+        th = q * dh;
+        tl = dl * q;
+        for (;;) {
+            t = h - th;
+            if ((t & BN_MASK2h) || ((tl) <= ((t << BN_BITS4) | ((l & BN_MASK2h) >> BN_BITS4))))
+                break;
+            q--;
+            th -= dh;
+            tl -= dl;
+        }
+        t = (tl >> BN_BITS4);
+        tl = (tl << BN_BITS4) & BN_MASK2h;
+        th += t;
+
+        if (l < tl)
+            th++;
+        l -= tl;
+        if (h < th) {
+            h += d;
+            q--;
+        }
+        h -= th;
+
+        if (--count == 0)
+            break;
+
+        ret = q << BN_BITS4;
+        h = ((h << BN_BITS4) | (l >> BN_BITS4)) & BN_MASK2;
+        l = (l & BN_MASK2l) << BN_BITS4;
+    }
+    ret |= q;
+    return ret;
+}
+
+BN_ULONG bn_add_words(BN_ULONG *r, const BN_ULONG *a, const BN_ULONG *b,
+    int n)
+{
+    BN_ULONG c, l, t;
+
+    assert(n >= 0);
+    if (n <= 0)
+        return (BN_ULONG)0;
+
+    c = 0;
+#ifndef OPENSSL_SMALL_FOOTPRINT
+    while (n & ~3) {
+#if __iset__ < 5
+        t = a[0];
+        t = (t + c) & BN_MASK2;
+        c = (t < c);
+        l = (t + b[0]) & BN_MASK2;
+        c += (l < t);
+        r[0] = l;
+        t = a[1];
+        t = (t + c) & BN_MASK2;
+        c = (t < c);
+        l = (t + b[1]) & BN_MASK2;
+        c += (l < t);
+        r[1] = l;
+        t = a[2];
+        t = (t + c) & BN_MASK2;
+        c = (t < c);
+        l = (t + b[2]) & BN_MASK2;
+        c += (l < t);
+        r[2] = l;
+        t = a[3];
+        t = (t + c) & BN_MASK2;
+        c = (t < c);
+        l = (t + b[3]) & BN_MASK2;
+        c += (l < t);
+        r[3] = l;
+#else
+        BN_ULONG t = __builtin_e2k_addcd_c(a[0], b[0], c);
+        r[0] = __builtin_e2k_addcd(a[0], b[0], c);
+        c = t;
+        t = __builtin_e2k_addcd_c(a[1], b[1], c);
+        r[1] = __builtin_e2k_addcd(a[1], b[1], c);
+        c = t;
+        t = __builtin_e2k_addcd_c(a[2], b[2], c);
+        r[2] = __builtin_e2k_addcd(a[2], b[2], c);
+        c = t;
+        t = __builtin_e2k_addcd_c(a[3], b[3], c);
+        r[3] = __builtin_e2k_addcd(a[3], b[3], c);
+        c = t;
+#endif
+        a += 4;
+        b += 4;
+        r += 4;
+        n -= 4;
+    }
+#endif
+    while (n) {
+#if __iset__ < 5
+        t = a[0];
+        t = (t + c) & BN_MASK2;
+        c = (t < c);
+        l = (t + b[0]) & BN_MASK2;
+        c += (l < t);
+        r[0] = l;
+#else
+        BN_ULONG t = __builtin_e2k_addcd_c(a[0], b[0], c);
+        r[0] = __builtin_e2k_addcd(a[0], b[0], c);
+        c = t;
+#endif
+        a++;
+        b++;
+        r++;
+        n--;
+    }
+    return (BN_ULONG)c;
+}
+
+BN_ULONG bn_sub_words(BN_ULONG *r, const BN_ULONG *a, const BN_ULONG *b,
+    int n)
+{
+#if __iset__ < 5
+    BN_ULONG t1, t2;
+#endif
+    int c = 0;
+
+    assert(n >= 0);
+    if (n <= 0)
+        return (BN_ULONG)0;
+
+#ifndef OPENSSL_SMALL_FOOTPRINT
+    while (n & ~3) {
+#if __iset__ < 5
+        t1 = a[0];
+        t2 = (t1 - c) & BN_MASK2;
+        c = (t2 > t1);
+        t1 = b[0];
+        t1 = (t2 - t1) & BN_MASK2;
+        r[0] = t1;
+        c += (t1 > t2);
+        t1 = a[1];
+        t2 = (t1 - c) & BN_MASK2;
+        c = (t2 > t1);
+        t1 = b[1];
+        t1 = (t2 - t1) & BN_MASK2;
+        r[1] = t1;
+        c += (t1 > t2);
+        t1 = a[2];
+        t2 = (t1 - c) & BN_MASK2;
+        c = (t2 > t1);
+        t1 = b[2];
+        t1 = (t2 - t1) & BN_MASK2;
+        r[2] = t1;
+        c += (t1 > t2);
+        t1 = a[3];
+        t2 = (t1 - c) & BN_MASK2;
+        c = (t2 > t1);
+        t1 = b[3];
+        t1 = (t2 - t1) & BN_MASK2;
+        r[3] = t1;
+        c += (t1 > t2);
+#else
+        BN_ULONG t = __builtin_e2k_subcd_c(a[0], b[0], c);
+        r[0] = __builtin_e2k_subcd(a[0], b[0], c);
+        c = t;
+        t = __builtin_e2k_subcd_c(a[1], b[1], c);
+        r[1] = __builtin_e2k_subcd(a[1], b[1], c);
+        c = t;
+        t = __builtin_e2k_subcd_c(a[2], b[2], c);
+        r[2] = __builtin_e2k_subcd(a[2], b[2], c);
+        c = t;
+        t = __builtin_e2k_subcd_c(a[3], b[3], c);
+        r[3] = __builtin_e2k_subcd(a[3], b[3], c);
+        c = t;
+#endif
+        a += 4;
+        b += 4;
+        r += 4;
+        n -= 4;
+    }
+#endif
+    while (n) {
+#if __iset__ < 5
+        t1 = a[0];
+        t2 = (t1 - c) & BN_MASK2;
+        c = (t2 > t1);
+        t1 = b[0];
+        t1 = (t2 - t1) & BN_MASK2;
+        r[0] = t1;
+        c += (t1 > t2);
+#else
+        BN_ULONG t = __builtin_e2k_subcd_c(a[0], b[0], c);
+        r[0] = __builtin_e2k_subcd(a[0], b[0], c);
+        c = t;
+#endif
+        a++;
+        b++;
+        r++;
+        n--;
+    }
+    return c;
+}
+
+#ifndef OPENSSL_SMALL_FOOTPRINT
+
+/* mul_add_c(a,b,c0,c1,c2)  -- c+=a*b for three word number c=(c2,c1,c0) */
+/* mul_add_c2(a,b,c0,c1,c2) -- c+=2*a*b for three word number c=(c2,c1,c0) */
+/* sqr_add_c(a,i,c0,c1,c2)  -- c+=a[i]^2 for three word number c=(c2,c1,c0) */
+/*
+ * sqr_add_c2(a,i,c0,c1,c2) -- c+=2*a[i]*a[j] for three word number
+ * c=(c2,c1,c0)
+ */
+
+#if __iset__ < 5
+/*
+ * Keep in mind that carrying into high part of multiplication result
+ * can not overflow, because it cannot be all-ones.
+ */
+#define mul_add_c(a, b, c0, c1, c2)    \
+    do {                               \
+        BN_ULONG ta = (a), tb = (b);   \
+        BN_ULONG lo, hi;               \
+        BN_UMULT_LOHI(lo, hi, ta, tb); \
+        c0 += lo;                      \
+        hi += (c0 < lo);               \
+        c1 += hi;                      \
+        c2 += (c1 < hi);               \
+    } while (0)
+
+#define mul_add_c2(a, b, c0, c1, c2)   \
+    do {                               \
+        BN_ULONG ta = (a), tb = (b);   \
+        BN_ULONG lo, hi, tt;           \
+        BN_UMULT_LOHI(lo, hi, ta, tb); \
+        c0 += lo;                      \
+        tt = hi + (c0 < lo);           \
+        c1 += tt;                      \
+        c2 += (c1 < tt);               \
+        c0 += lo;                      \
+        hi += (c0 < lo);               \
+        c1 += hi;                      \
+        c2 += (c1 < hi);               \
+    } while (0)
+
+#define sqr_add_c(a, i, c0, c1, c2)    \
+    do {                               \
+        BN_ULONG ta = (a)[i];          \
+        BN_ULONG lo, hi;               \
+        BN_UMULT_LOHI(lo, hi, ta, ta); \
+        c0 += lo;                      \
+        hi += (c0 < lo);               \
+        c1 += hi;                      \
+        c2 += (c1 < hi);               \
+    } while (0)
+#else /* __iset__ >= 5 */
+#define mul_add_c(a, b, c0, c1, c2)             \
+    do {                                        \
+        BN_ULONG ta = (a), tb = (b);            \
+        BN_ULONG lo, hi;                        \
+        int q;                                  \
+        lo = ta * tb;                           \
+        hi = __builtin_e2k_umulhd(ta, tb);      \
+        q = __builtin_e2k_addcd_c(c0, lo, 0);   \
+        c0 += lo;                               \
+        c2 += __builtin_e2k_addcd_c(c1, hi, q); \
+        c1 = __builtin_e2k_addcd(c1, hi, q);    \
+    } while (0)
+
+#define mul_add_c2(a, b, c0, c1, c2)                \
+    do {                                            \
+        BN_ULONG ta = (a), tb = (b);                \
+        BN_ULONG lo, hi, lo_msb;                    \
+        int q;                                      \
+        lo = ta * tb;                               \
+        hi = __builtin_e2k_umulhd(ta, tb);          \
+                                                    \
+        lo_msb = lo >> 63;                          \
+        lo <<= 1;                                   \
+        c2 += hi >> 63;                             \
+        hi = __builtin_e2k_insfd(hi, 0x7f, lo_msb); \
+                                                    \
+        q = __builtin_e2k_addcd_c(c0, lo, 0);       \
+        c0 += lo;                                   \
+        c2 += __builtin_e2k_addcd_c(c1, hi, q);     \
+        c1 = __builtin_e2k_addcd(c1, hi, q);        \
+    } while (0)
+
+#define sqr_add_c(a, i, c0, c1, c2)             \
+    do {                                        \
+        BN_ULONG ta = (a)[i];                   \
+        BN_ULONG lo, hi;                        \
+        int q;                                  \
+        lo = ta * ta;                           \
+        hi = __builtin_e2k_umulhd(ta, ta);      \
+        q = __builtin_e2k_addcd_c(c0, lo, 0);   \
+        c0 += lo;                               \
+        c2 += __builtin_e2k_addcd_c(c1, hi, q); \
+        c1 = __builtin_e2k_addcd(c1, hi, q);    \
+    } while (0)
+#endif /* __iset__ */
+
+#define sqr_add_c2(a, i, j, c0, c1, c2) \
+    mul_add_c2((a)[i], (a)[j], c0, c1, c2)
+
+void bn_mul_comba8(BN_ULONG *r, BN_ULONG *a, BN_ULONG *b)
+{
+    BN_ULONG c1, c2, c3;
+
+    c1 = 0;
+    c2 = 0;
+    c3 = 0;
+    mul_add_c(a[0], b[0], c1, c2, c3);
+    r[0] = c1;
+    c1 = 0;
+    mul_add_c(a[0], b[1], c2, c3, c1);
+    mul_add_c(a[1], b[0], c2, c3, c1);
+    r[1] = c2;
+    c2 = 0;
+    mul_add_c(a[2], b[0], c3, c1, c2);
+    mul_add_c(a[1], b[1], c3, c1, c2);
+    mul_add_c(a[0], b[2], c3, c1, c2);
+    r[2] = c3;
+    c3 = 0;
+    mul_add_c(a[0], b[3], c1, c2, c3);
+    mul_add_c(a[1], b[2], c1, c2, c3);
+    mul_add_c(a[2], b[1], c1, c2, c3);
+    mul_add_c(a[3], b[0], c1, c2, c3);
+    r[3] = c1;
+    c1 = 0;
+    mul_add_c(a[4], b[0], c2, c3, c1);
+    mul_add_c(a[3], b[1], c2, c3, c1);
+    mul_add_c(a[2], b[2], c2, c3, c1);
+    mul_add_c(a[1], b[3], c2, c3, c1);
+    mul_add_c(a[0], b[4], c2, c3, c1);
+    r[4] = c2;
+    c2 = 0;
+    mul_add_c(a[0], b[5], c3, c1, c2);
+    mul_add_c(a[1], b[4], c3, c1, c2);
+    mul_add_c(a[2], b[3], c3, c1, c2);
+    mul_add_c(a[3], b[2], c3, c1, c2);
+    mul_add_c(a[4], b[1], c3, c1, c2);
+    mul_add_c(a[5], b[0], c3, c1, c2);
+    r[5] = c3;
+    c3 = 0;
+    mul_add_c(a[6], b[0], c1, c2, c3);
+    mul_add_c(a[5], b[1], c1, c2, c3);
+    mul_add_c(a[4], b[2], c1, c2, c3);
+    mul_add_c(a[3], b[3], c1, c2, c3);
+    mul_add_c(a[2], b[4], c1, c2, c3);
+    mul_add_c(a[1], b[5], c1, c2, c3);
+    mul_add_c(a[0], b[6], c1, c2, c3);
+    r[6] = c1;
+    c1 = 0;
+    mul_add_c(a[0], b[7], c2, c3, c1);
+    mul_add_c(a[1], b[6], c2, c3, c1);
+    mul_add_c(a[2], b[5], c2, c3, c1);
+    mul_add_c(a[3], b[4], c2, c3, c1);
+    mul_add_c(a[4], b[3], c2, c3, c1);
+    mul_add_c(a[5], b[2], c2, c3, c1);
+    mul_add_c(a[6], b[1], c2, c3, c1);
+    mul_add_c(a[7], b[0], c2, c3, c1);
+    r[7] = c2;
+    c2 = 0;
+    mul_add_c(a[7], b[1], c3, c1, c2);
+    mul_add_c(a[6], b[2], c3, c1, c2);
+    mul_add_c(a[5], b[3], c3, c1, c2);
+    mul_add_c(a[4], b[4], c3, c1, c2);
+    mul_add_c(a[3], b[5], c3, c1, c2);
+    mul_add_c(a[2], b[6], c3, c1, c2);
+    mul_add_c(a[1], b[7], c3, c1, c2);
+    r[8] = c3;
+    c3 = 0;
+    mul_add_c(a[2], b[7], c1, c2, c3);
+    mul_add_c(a[3], b[6], c1, c2, c3);
+    mul_add_c(a[4], b[5], c1, c2, c3);
+    mul_add_c(a[5], b[4], c1, c2, c3);
+    mul_add_c(a[6], b[3], c1, c2, c3);
+    mul_add_c(a[7], b[2], c1, c2, c3);
+    r[9] = c1;
+    c1 = 0;
+    mul_add_c(a[7], b[3], c2, c3, c1);
+    mul_add_c(a[6], b[4], c2, c3, c1);
+    mul_add_c(a[5], b[5], c2, c3, c1);
+    mul_add_c(a[4], b[6], c2, c3, c1);
+    mul_add_c(a[3], b[7], c2, c3, c1);
+    r[10] = c2;
+    c2 = 0;
+    mul_add_c(a[4], b[7], c3, c1, c2);
+    mul_add_c(a[5], b[6], c3, c1, c2);
+    mul_add_c(a[6], b[5], c3, c1, c2);
+    mul_add_c(a[7], b[4], c3, c1, c2);
+    r[11] = c3;
+    c3 = 0;
+    mul_add_c(a[7], b[5], c1, c2, c3);
+    mul_add_c(a[6], b[6], c1, c2, c3);
+    mul_add_c(a[5], b[7], c1, c2, c3);
+    r[12] = c1;
+    c1 = 0;
+    mul_add_c(a[6], b[7], c2, c3, c1);
+    mul_add_c(a[7], b[6], c2, c3, c1);
+    r[13] = c2;
+    c2 = 0;
+    mul_add_c(a[7], b[7], c3, c1, c2);
+    r[14] = c3;
+    r[15] = c1;
+}
+
+void bn_mul_comba4(BN_ULONG *r, BN_ULONG *a, BN_ULONG *b)
+{
+    BN_ULONG c1, c2, c3;
+
+    c1 = 0;
+    c2 = 0;
+    c3 = 0;
+    mul_add_c(a[0], b[0], c1, c2, c3);
+    r[0] = c1;
+    c1 = 0;
+    mul_add_c(a[0], b[1], c2, c3, c1);
+    mul_add_c(a[1], b[0], c2, c3, c1);
+    r[1] = c2;
+    c2 = 0;
+    mul_add_c(a[2], b[0], c3, c1, c2);
+    mul_add_c(a[1], b[1], c3, c1, c2);
+    mul_add_c(a[0], b[2], c3, c1, c2);
+    r[2] = c3;
+    c3 = 0;
+    mul_add_c(a[0], b[3], c1, c2, c3);
+    mul_add_c(a[1], b[2], c1, c2, c3);
+    mul_add_c(a[2], b[1], c1, c2, c3);
+    mul_add_c(a[3], b[0], c1, c2, c3);
+    r[3] = c1;
+    c1 = 0;
+    mul_add_c(a[3], b[1], c2, c3, c1);
+    mul_add_c(a[2], b[2], c2, c3, c1);
+    mul_add_c(a[1], b[3], c2, c3, c1);
+    r[4] = c2;
+    c2 = 0;
+    mul_add_c(a[2], b[3], c3, c1, c2);
+    mul_add_c(a[3], b[2], c3, c1, c2);
+    r[5] = c3;
+    c3 = 0;
+    mul_add_c(a[3], b[3], c1, c2, c3);
+    r[6] = c1;
+    r[7] = c2;
+}
+
+void bn_sqr_comba8(BN_ULONG *r, const BN_ULONG *a)
+{
+    BN_ULONG c1, c2, c3;
+
+    c1 = 0;
+    c2 = 0;
+    c3 = 0;
+    sqr_add_c(a, 0, c1, c2, c3);
+    r[0] = c1;
+    c1 = 0;
+    sqr_add_c2(a, 1, 0, c2, c3, c1);
+    r[1] = c2;
+    c2 = 0;
+    sqr_add_c(a, 1, c3, c1, c2);
+    sqr_add_c2(a, 2, 0, c3, c1, c2);
+    r[2] = c3;
+    c3 = 0;
+    sqr_add_c2(a, 3, 0, c1, c2, c3);
+    sqr_add_c2(a, 2, 1, c1, c2, c3);
+    r[3] = c1;
+    c1 = 0;
+    sqr_add_c(a, 2, c2, c3, c1);
+    sqr_add_c2(a, 3, 1, c2, c3, c1);
+    sqr_add_c2(a, 4, 0, c2, c3, c1);
+    r[4] = c2;
+    c2 = 0;
+    sqr_add_c2(a, 5, 0, c3, c1, c2);
+    sqr_add_c2(a, 4, 1, c3, c1, c2);
+    sqr_add_c2(a, 3, 2, c3, c1, c2);
+    r[5] = c3;
+    c3 = 0;
+    sqr_add_c(a, 3, c1, c2, c3);
+    sqr_add_c2(a, 4, 2, c1, c2, c3);
+    sqr_add_c2(a, 5, 1, c1, c2, c3);
+    sqr_add_c2(a, 6, 0, c1, c2, c3);
+    r[6] = c1;
+    c1 = 0;
+    sqr_add_c2(a, 7, 0, c2, c3, c1);
+    sqr_add_c2(a, 6, 1, c2, c3, c1);
+    sqr_add_c2(a, 5, 2, c2, c3, c1);
+    sqr_add_c2(a, 4, 3, c2, c3, c1);
+    r[7] = c2;
+    c2 = 0;
+    sqr_add_c(a, 4, c3, c1, c2);
+    sqr_add_c2(a, 5, 3, c3, c1, c2);
+    sqr_add_c2(a, 6, 2, c3, c1, c2);
+    sqr_add_c2(a, 7, 1, c3, c1, c2);
+    r[8] = c3;
+    c3 = 0;
+    sqr_add_c2(a, 7, 2, c1, c2, c3);
+    sqr_add_c2(a, 6, 3, c1, c2, c3);
+    sqr_add_c2(a, 5, 4, c1, c2, c3);
+    r[9] = c1;
+    c1 = 0;
+    sqr_add_c(a, 5, c2, c3, c1);
+    sqr_add_c2(a, 6, 4, c2, c3, c1);
+    sqr_add_c2(a, 7, 3, c2, c3, c1);
+    r[10] = c2;
+    c2 = 0;
+    sqr_add_c2(a, 7, 4, c3, c1, c2);
+    sqr_add_c2(a, 6, 5, c3, c1, c2);
+    r[11] = c3;
+    c3 = 0;
+    sqr_add_c(a, 6, c1, c2, c3);
+    sqr_add_c2(a, 7, 5, c1, c2, c3);
+    r[12] = c1;
+    c1 = 0;
+    sqr_add_c2(a, 7, 6, c2, c3, c1);
+    r[13] = c2;
+    c2 = 0;
+    sqr_add_c(a, 7, c3, c1, c2);
+    r[14] = c3;
+    r[15] = c1;
+}
+
+void bn_sqr_comba4(BN_ULONG *r, const BN_ULONG *a)
+{
+    BN_ULONG c1, c2, c3;
+
+    c1 = 0;
+    c2 = 0;
+    c3 = 0;
+    sqr_add_c(a, 0, c1, c2, c3);
+    r[0] = c1;
+    c1 = 0;
+    sqr_add_c2(a, 1, 0, c2, c3, c1);
+    r[1] = c2;
+    c2 = 0;
+    sqr_add_c(a, 1, c3, c1, c2);
+    sqr_add_c2(a, 2, 0, c3, c1, c2);
+    r[2] = c3;
+    c3 = 0;
+    sqr_add_c2(a, 3, 0, c1, c2, c3);
+    sqr_add_c2(a, 2, 1, c1, c2, c3);
+    r[3] = c1;
+    c1 = 0;
+    sqr_add_c(a, 2, c2, c3, c1);
+    sqr_add_c2(a, 3, 1, c2, c3, c1);
+    r[4] = c2;
+    c2 = 0;
+    sqr_add_c2(a, 3, 2, c3, c1, c2);
+    r[5] = c3;
+    c3 = 0;
+    sqr_add_c(a, 3, c1, c2, c3);
+    r[6] = c1;
+    r[7] = c2;
+}
+
+#include <alloca.h>
+/*
+ * This is essentially reference implementation, which may or may not
+ * result in performance improvement. E.g. on IA-32 this routine was
+ * observed to give 40% faster rsa1024 private key operations and 10%
+ * faster rsa4096 ones, while on AMD64 it improves rsa1024 sign only
+ * by 10% and *worsens* rsa4096 sign by 15%. Once again, it's a
+ * reference implementation, one to be used as starting point for
+ * platform-specific assembler. Mentioned numbers apply to compiler
+ * generated code compiled with and without -DOPENSSL_BN_ASM_MONT and
+ * can vary not only from platform to platform, but even for compiler
+ * versions. Assembler vs. assembler improvement coefficients can
+ * [and are known to] differ and are to be documented elsewhere.
+ */
+int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
+    const BN_ULONG *np, const BN_ULONG *n0p, int num)
+{
+    BN_ULONG c0, c1, ml, *tp, n0;
+    volatile BN_ULONG *vp;
+    int i = 0, j;
+
+#if 0 /* template for platform-specific \
+       * implementation */
+    if (ap == bp)
+        return bn_sqr_mont(rp, ap, np, n0p, num);
+#endif
+    vp = tp = alloca((num + 2) * sizeof(BN_ULONG));
+
+    n0 = *n0p;
+
+    c0 = 0;
+    ml = bp[0];
+
+    for (j = 0; j < num; ++j)
+        mul(tp[j], ap[j], ml, c0);
+
+    tp[num] = c0;
+    tp[num + 1] = 0;
+    goto enter;
+
+    for (i = 0; i < num; i++) {
+        c0 = 0;
+        ml = bp[i];
+
+        for (j = 0; j < num; ++j)
+            mul_add(tp[j], ap[j], ml, c0);
+
+        c1 = (tp[num] + c0) & BN_MASK2;
+        tp[num] = c1;
+        tp[num + 1] = (c1 < c0 ? 1 : 0);
+    enter:
+        c1 = tp[0];
+        ml = (c1 * n0) & BN_MASK2;
+        c0 = 0;
+
+        mul_add(c1, ml, np[0], c0);
+
+        for (j = 1; j < num; j++) {
+            c1 = tp[j];
+            mul_add(c1, ml, np[j], c0);
+            tp[j - 1] = c1 & BN_MASK2;
+        }
+        c1 = (tp[num] + c0) & BN_MASK2;
+        tp[num - 1] = c1;
+        tp[num] = tp[num + 1] + (c1 < c0 ? 1 : 0);
+    }
+
+    if (tp[num] != 0 || tp[num - 1] >= np[num - 1]) {
+        c0 = bn_sub_words(rp, tp, np, num);
+        if (tp[num] != 0 || c0 == 0) {
+            for (i = 0; i < num + 2; i++)
+                vp[i] = 0;
+            return 1;
+        }
+    }
+    for (i = 0; i < num; i++)
+        rp[i] = tp[i], vp[i] = 0;
+    vp[num] = 0;
+    vp[num + 1] = 0;
+    return 1;
+}
+#endif /* !OPENSSL_SMALL_FOOTPRINT */

--- a/crypto/bn/asm/e2kv6-gf2m.c
+++ b/crypto/bn/asm/e2kv6-gf2m.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <e2kintrin.h>
+
+#include "../bn_local.h"
+
+void bn_GF2m_mul_2x2(BN_ULONG *r, const BN_ULONG a1, const BN_ULONG a0,
+    const BN_ULONG b1, const BN_ULONG b0)
+{
+    BN_ULONG m1, m0;
+
+    r[3] = __builtin_e2k_clmulh(a1, b1);
+    r[2] = __builtin_e2k_clmull(a1, b1);
+
+    r[1] = __builtin_e2k_clmulh(a0, b0);
+    r[0] = __builtin_e2k_clmull(a0, b0);
+
+    m1 = __builtin_e2k_clmulh(a0 ^ a1, b0 ^ b1);
+    m0 = __builtin_e2k_clmull(a0 ^ a1, b0 ^ b1);
+
+    r[2] ^= __builtin_e2k_plog(0x96, m1, r[1], r[3]);
+    r[1] = __builtin_e2k_plog(0x96, r[3], r[2], __builtin_e2k_plog(0x96, r[0], m1, m0));
+}

--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -89,6 +89,7 @@ const BIGNUM *BN_value_one(void)
     return &const_one;
 }
 
+#ifndef __e2k__
 int BN_num_bits_word(BN_ULONG l)
 {
     BN_ULONG x, mask;
@@ -133,6 +134,20 @@ int BN_num_bits_word(BN_ULONG l)
 
     return bits;
 }
+#else /* __e2k__ */
+#include <x86gprintrin.h>
+int BN_num_bits_word(BN_ULONG l)
+{
+    /* clz(0) is well-defined on e2k, hence no if (l == 0) return 0;
+     * is required here.
+     */
+#if BN_BITS2 > 32
+    return 64 - __builtin_clzll(l);
+#else
+    return 32 - __builtin_clz(l);
+#endif
+}
+#endif /* __e2k__ */
 
 /*
  * This function still leaks `a->dmax`: it's caller's responsibility to

--- a/crypto/bn/bn_local.h
+++ b/crypto/bn/bn_local.h
@@ -443,6 +443,8 @@ unsigned __int64 _umul128(unsigned __int64 a, unsigned __int64 b,
              : "r"(a), "r"(b));         \
         ret; })
 #endif
+#elif defined(__e2k__) && __iset__ >= 5
+#define BN_UMULT_HIGH(a, b) __builtin_e2k_umulhd(a, b)
 #endif /* cpu */
 #endif /* OPENSSL_NO_ASM */
 

--- a/crypto/bn/build.info
+++ b/crypto/bn/build.info
@@ -90,10 +90,12 @@ IF[{- !$disabled{asm} -}]
   $BNASM_c64xplus_ec2m=c64xplus-gf2m.s
   $BNDEF_c64xplus_ec2m=OPENSSL_BN_ASM_GF2m
 
-  $BNASM_e2kv6=asm/e2kv6-gf2m.c
-  $BNDEF_e2kv6=OPENSSL_BN_ASM_GF2m
-  $BNASM_e2kv7=asm/e2kv6-gf2m.c
-  $BNDEF_e2kv7=OPENSSL_BN_ASM_GF2m
+  $BNASM_e2k=asm/e2k-bn-asm.c
+  $BNDEF_e2k=OPENSSL_BN_ASM_MONT
+  $BNASM_e2kv6=asm/e2kv6-gf2m.c $BNASM_e2k
+  $BNDEF_e2kv6=OPENSSL_BN_ASM_GF2m $BNDEF_e2k
+  $BNASM_e2kv7=asm/e2kv6-gf2m.c $BNASM_e2k
+  $BNDEF_e2kv7=OPENSSL_BN_ASM_GF2m $BNDEF_e2k
 
   # Now that we have defined all the arch specific variables, use the
   # appropriate ones, and define the appropriate macros

--- a/crypto/bn/build.info
+++ b/crypto/bn/build.info
@@ -90,6 +90,11 @@ IF[{- !$disabled{asm} -}]
   $BNASM_c64xplus_ec2m=c64xplus-gf2m.s
   $BNDEF_c64xplus_ec2m=OPENSSL_BN_ASM_GF2m
 
+  $BNASM_e2kv6=asm/e2kv6-gf2m.c
+  $BNDEF_e2kv6=OPENSSL_BN_ASM_GF2m
+  $BNASM_e2kv7=asm/e2kv6-gf2m.c
+  $BNDEF_e2kv7=OPENSSL_BN_ASM_GF2m
+
   # Now that we have defined all the arch specific variables, use the
   # appropriate ones, and define the appropriate macros
   IF[$BNASM_{- $target{asm_arch} -}]

--- a/crypto/chacha/build.info
+++ b/crypto/chacha/build.info
@@ -25,6 +25,10 @@ IF[{- !$disabled{asm} -}]
   $CHACHAASM_riscv64=chacha_riscv.c chacha_enc.c chacha-riscv64-v-zbb.s chacha-riscv64-v-zbb-zvkb.s
   $CHACHADEF_riscv64=INCLUDE_C_CHACHA20
 
+  $CHACHAASM_e2k=chacha_e2k.c
+  $CHACHAASM_e2kv6=chacha_e2k.c
+  $CHACHAASM_e2kv7=chacha_e2k.c
+
   # Now that we have defined all the arch specific variables, use the
   # appropriate one
   IF[$CHACHAASM_{- $target{asm_arch} -}]

--- a/crypto/chacha/chacha_e2k.c
+++ b/crypto/chacha/chacha_e2k.c
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <string.h>
+
+#include "internal/endian.h"
+#include "crypto/chacha.h"
+#include "crypto/ctype.h"
+
+typedef uint32_t u32;
+typedef uint8_t u8;
+
+#include <stdint.h>
+#include <e2kintrin.h>
+
+#if __iset__ >= 5 /* 128-bit SIMD */
+
+/* QUARTERROUND updates a, b, c, d with a ChaCha "quarter" round. */
+#define QUARTERROUND(a, b, c, d) (                                                                                  \
+    x[a] = __builtin_e2k_qpaddw(x[a], x[b]), x[d] = __builtin_e2k_qpsrcw(__builtin_e2k_qpxor(x[d], x[a]), 32 - 16), \
+    x[c] = __builtin_e2k_qpaddw(x[c], x[d]), x[b] = __builtin_e2k_qpsrcw(__builtin_e2k_qpxor(x[b], x[c]), 32 - 12), \
+    x[a] = __builtin_e2k_qpaddw(x[a], x[b]), x[d] = __builtin_e2k_qpsrcw(__builtin_e2k_qpxor(x[d], x[a]), 32 - 8),  \
+    x[c] = __builtin_e2k_qpaddw(x[c], x[d]), x[b] = __builtin_e2k_qpsrcw(__builtin_e2k_qpxor(x[b], x[c]), 32 - 7))
+
+/* chacha_core performs 20 rounds of ChaCha on the input words in
+ * |input| and writes the 64 output bytes to |output|.
+ */
+static inline __attribute__((__always_inline__)) void chacha20_core_x4(__v2di *output, const __v2di input[16])
+{
+    __v2di x[16];
+    int i;
+    memcpy(x, input, sizeof(x));
+
+    for (i = 20; i > 0; i -= 2) {
+        QUARTERROUND(0, 4, 8, 12);
+        QUARTERROUND(1, 5, 9, 13);
+        QUARTERROUND(2, 6, 10, 14);
+        QUARTERROUND(3, 7, 11, 15);
+        QUARTERROUND(0, 5, 10, 15);
+        QUARTERROUND(1, 6, 11, 12);
+        QUARTERROUND(2, 7, 8, 13);
+        QUARTERROUND(3, 4, 9, 14);
+    }
+
+    for (i = 0; i < 16; ++i)
+        output[i] = __builtin_e2k_qpaddw(x[i], input[i]);
+}
+
+void ChaCha20_ctr32(unsigned char *out, const unsigned char *inp, size_t len,
+    const unsigned int key[8], const unsigned int counter[4])
+{
+    u32 input[16];
+    __v2di input_x4[16];
+    __v2di buf[16];
+    size_t todo, i;
+
+    /* sigma constant "expand 32-byte k" in little-endian encoding */
+    input[0] = ((u32)('e')) | ((u32)('x') << 8) | ((u32)('p') << 16) | ((u32)('a') << 24);
+    input[1] = ((u32)('n')) | ((u32)('d') << 8) | ((u32)(' ') << 16) | ((u32)('3') << 24);
+    input[2] = ((u32)('2')) | ((u32)('-') << 8) | ((u32)('b') << 16) | ((u32)('y') << 24);
+    input[3] = ((u32)('t')) | ((u32)('e') << 8) | ((u32)(' ') << 16) | ((u32)('k') << 24);
+
+    input[4] = key[0];
+    input[5] = key[1];
+    input[6] = key[2];
+    input[7] = key[3];
+    input[8] = key[4];
+    input[9] = key[5];
+    input[10] = key[6];
+    input[11] = key[7];
+
+    input[12] = counter[0];
+    input[13] = counter[1];
+    input[14] = counter[2];
+    input[15] = counter[3];
+
+    for (i = 0; i < 16; i++) {
+        unsigned long long w = input[i] * 0x100000001LL;
+        input_x4[i] = __builtin_e2k_qppackdl(w, w);
+    }
+
+    input_x4[12] = __builtin_e2k_qpaddw(input_x4[12], (__v2di) { 0x100000000LL, 0x300000002LL });
+
+    while (len > 0) {
+        __v2di buf_tran[16];
+
+        chacha20_core_x4(buf, input_x4);
+
+        for (i = 0; i < 16; i += 4) {
+            const __v2di f1 = __builtin_e2k_qppackdl(0x1f1e1d1c0f0e0d0cLL, 0x1716151407060504LL);
+            const __v2di f0 = __builtin_e2k_qppackdl(0x1b1a19180b0a0908LL, 0x1312111003020100LL);
+
+            const __v2di f3 = __builtin_e2k_qppackdl(0x1f1e1d1c1b1a1918LL, 0x0f0e0d0c0b0a0908LL);
+            const __v2di f2 = __builtin_e2k_qppackdl(0x1716151413121110LL, 0x0706050403020100LL);
+
+            __v2di t0 = __builtin_e2k_qppermb(buf[i + 1], buf[i + 0], f0);
+            __v2di t1 = __builtin_e2k_qppermb(buf[i + 1], buf[i + 0], f1);
+            __v2di t2 = __builtin_e2k_qppermb(buf[i + 3], buf[i + 2], f0);
+            __v2di t3 = __builtin_e2k_qppermb(buf[i + 3], buf[i + 2], f1);
+
+            buf_tran[i / 4 + 0] = __builtin_e2k_qppermb(t2, t0, f2);
+            buf_tran[i / 4 + 4] = __builtin_e2k_qppermb(t3, t1, f2);
+            buf_tran[i / 4 + 8] = __builtin_e2k_qppermb(t2, t0, f3);
+            buf_tran[i / 4 + 12] = __builtin_e2k_qppermb(t3, t1, f3);
+        }
+
+        todo = sizeof(buf);
+        if (__builtin_expect(len < todo, 0)) {
+            todo = len & ~(size_t)15;
+
+            for (i = 0; i < todo; i += 16) {
+                *(__v2di *)&out[i] = __builtin_e2k_qpxor(*(__v2di *)&inp[i], buf_tran[i / 16]);
+            }
+            for (; i < len; i++) {
+                out[i] = inp[i] ^ ((u8 *)buf_tran)[i];
+            }
+            return;
+        }
+
+        for (i = 0; i < todo; i += 16) {
+            *(__v2di *)&out[i] = __builtin_e2k_qpxor(*(__v2di *)&inp[i], buf_tran[i / 16]);
+        }
+
+        /*
+         * Advance 32-bit counters. Note that as subroutine is so to
+         * say nonce-agnostic, this limited counter width doesn't
+         * prevent caller from implementing wider counter. It would
+         * simply take two calls split on counter overflow...
+         */
+        input_x4[12] = __builtin_e2k_qpaddw(input_x4[12], (__v2di) { 0x400000004LL, 0x400000004LL });
+
+        out += todo;
+        inp += todo;
+        len -= todo;
+    }
+}
+
+#else /* 64-bit SIMD */
+
+/* QUARTERROUND updates a, b, c, d with a ChaCha "quarter" round. */
+#define QUARTERROUND(a, b, c, d) (                                                                                                                                          \
+    x[a] = __builtin_e2k_paddw(x[a], x[b]), tt = __builtin_e2k_pxord(x[d], x[a]), x[d] = __builtin_e2k_pshufb(tt, tt, 0x0504070601000302ull),                               \
+    x[c] = __builtin_e2k_paddw(x[c], x[d]), tt = __builtin_e2k_pxord(x[b], x[c]), x[b] = __builtin_e2k_pord(__builtin_e2k_psllw(tt, 12), __builtin_e2k_psrlw(tt, 32 - 12)), \
+    x[a] = __builtin_e2k_paddw(x[a], x[b]), tt = __builtin_e2k_pxord(x[d], x[a]), x[d] = __builtin_e2k_pshufb(tt, tt, 0x0605040702010003ull),                               \
+    x[c] = __builtin_e2k_paddw(x[c], x[d]), tt = __builtin_e2k_pxord(x[b], x[c]), x[b] = __builtin_e2k_pord(__builtin_e2k_psllw(tt, 7), __builtin_e2k_psrlw(tt, 32 - 7)))
+
+/* chacha_core performs 20 rounds of ChaCha on the input words in *inp
+ * and writes the 64 output bytes to *out .
+ */
+void ChaCha20_ctr32(unsigned char *out, const unsigned char *inp,
+    size_t len, const unsigned int key[8],
+    const unsigned int counter[4])
+{
+    u32 input[16];
+    uint64_t input_x2[16];
+    uint64_t buf[16];
+    size_t todo, i;
+
+    /* sigma constant "expand 32-byte k" in little-endian encoding */
+    input[0] = ((u32)('e')) | ((u32)('x') << 8) | ((u32)('p') << 16) | ((u32)('a') << 24);
+    input[1] = ((u32)('n')) | ((u32)('d') << 8) | ((u32)(' ') << 16) | ((u32)('3') << 24);
+    input[2] = ((u32)('2')) | ((u32)('-') << 8) | ((u32)('b') << 16) | ((u32)('y') << 24);
+    input[3] = ((u32)('t')) | ((u32)('e') << 8) | ((u32)(' ') << 16) | ((u32)('k') << 24);
+
+    input[4] = key[0];
+    input[5] = key[1];
+    input[6] = key[2];
+    input[7] = key[3];
+    input[8] = key[4];
+    input[9] = key[5];
+    input[10] = key[6];
+    input[11] = key[7];
+
+    input[12] = counter[0];
+    input[13] = counter[1];
+    input[14] = counter[2];
+    input[15] = counter[3];
+
+#pragma unroll(16)
+    for (i = 0; i < 16; i++) {
+        input_x2[i] = input[i] * 0x100000001ull;
+    }
+
+    input_x2[12] = __builtin_e2k_paddw(input_x2[12], 0x100000000ull);
+
+    while (len > 0) {
+        uint64_t buf_tran[16];
+        uint64_t x[16], tt;
+        uint64_t *__restrict__ outw = (uint64_t *)out;
+
+        for (i = 0; i < 16; ++i)
+            x[i] = input_x2[i];
+
+        for (i = 20; i > 0; i -= 2) {
+            QUARTERROUND(0, 4, 8, 12);
+            QUARTERROUND(1, 5, 9, 13);
+            QUARTERROUND(2, 6, 10, 14);
+            QUARTERROUND(3, 7, 11, 15);
+            QUARTERROUND(0, 5, 10, 15);
+            QUARTERROUND(1, 6, 11, 12);
+            QUARTERROUND(2, 7, 8, 13);
+            QUARTERROUND(3, 4, 9, 14);
+        }
+
+        for (i = 0; i < 16; ++i)
+            buf[i] = __builtin_e2k_paddw(x[i], input_x2[i]);
+
+#pragma unroll(8)
+        for (i = 0; i < 16; i += 2) {
+            const uint64_t fmtl = 0x0b0a090803020100ull;
+            const uint64_t fmtr = 0x0f0e0d0c07060504ull;
+
+            buf_tran[i / 2 + 0] = __builtin_e2k_pshufb(buf[i + 1], buf[i + 0], fmtl);
+            buf_tran[i / 2 + 8] = __builtin_e2k_pshufb(buf[i + 1], buf[i + 0], fmtr);
+        }
+
+        todo = sizeof(buf);
+        if (__builtin_expect(len < todo, 0)) {
+            todo = len & ~(size_t)7;
+
+#pragma loop count(16)
+            for (i = 0; i < todo; i += 8) {
+                *(uint64_t *)&out[i] = __builtin_e2k_pxord(*(uint64_t *)&inp[i], buf_tran[i / 8]);
+            }
+#pragma loop count(7)
+            for (; i < len; i++) {
+                out[i] = inp[i] ^ ((u8 *)buf_tran)[i];
+            }
+            return;
+        }
+
+#pragma unroll(16)
+        for (i = 0; i < todo; i += 8) {
+            *outw++ = __builtin_e2k_pxord(*(uint64_t *)&inp[i], buf_tran[i / 8]);
+        }
+
+        /*
+         * Advance 32-bit counters. Note that as subroutine is so to
+         * say nonce-agnostic, this limited counter width doesn't
+         * prevent caller from implementing wider counter. It would
+         * simply take two calls split on counter overflow...
+         */
+        input_x2[12] = __builtin_e2k_paddw(input_x2[12], 0x200000002ull);
+
+        out += todo;
+        inp += todo;
+        len -= todo;
+    }
+}
+#endif

--- a/crypto/evp/enc_b64_avx2.c
+++ b/crypto/evp/enc_b64_avx2.c
@@ -5,7 +5,7 @@
 #include "crypto/evp.h"
 #include "evp_local.h"
 
-#if defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64)
+#if defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64) || defined(__e2k__)
 #if !defined(_M_ARM64EC)
 #if defined(HAVE_AVX2_INTRINSICS)
 #define STRINGIFY_IMPLEMENTATION_(a) #a

--- a/crypto/evp/enc_b64_avx2.h
+++ b/crypto/evp/enc_b64_avx2.h
@@ -12,7 +12,7 @@
 #define HAVE_AVX2_INTRINSICS 1
 #endif
 
-#if defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64)
+#if defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64) || defined(__e2k__)
 #if !defined(_M_ARM64EC)
 #if defined(HAVE_AVX2_INTRINSICS)
 size_t encode_base64_avx2(EVP_ENCODE_CTX *ctx,

--- a/crypto/modes/asm/ghash-e2kv6.c
+++ b/crypto/modes/asm/ghash-e2kv6.c
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdint.h>
+#include <e2kintrin.h>
+
+#include "crypto/modes.h"
+
+static __attribute__((__always_inline__)) inline __v2di reverse_vector(const __v2di in)
+{
+    __v2di fmt = __builtin_e2k_qppackdl(0x0001020304050607LL, 0x08090a0b0c0d0e0fLL);
+    return __builtin_e2k_qppermb(in, in, fmt);
+}
+
+static __attribute__((__always_inline__)) inline __v2di gcm_reduce(__v2di B0, __v2di B1)
+{
+    __v2di X0 = __builtin_e2k_qpsrlw(B1, 31);
+    __v2di X1 = __builtin_e2k_qpsllw(B1, 1);
+    __v2di X2 = __builtin_e2k_qpsrlw(B0, 31);
+    __v2di X3 = __builtin_e2k_qpsllw(B0, 1);
+
+    X3 = X3 | __builtin_e2k_qpshufb(X0, X0, __builtin_e2k_qppackdl(0x8080808080808080LL, 0x808080800f0e0d0cLL))
+        | __builtin_e2k_qpshufb(X2, X2, __builtin_e2k_qppackdl(0x0b0a090807060504LL, 0x0302010080808080LL));
+
+    X1 = X1 | __builtin_e2k_qpshufb(X0, X0, __builtin_e2k_qppackdl(0x0b0a090807060504LL, 0x0302010080808080LL));
+
+    X0 = __builtin_e2k_qpsllw(X1, 31) ^ __builtin_e2k_qpsllw(X1, 30) ^ __builtin_e2k_qpsllw(X1, 25);
+
+    X1 ^= __builtin_e2k_qpshufb(X0, X0, __builtin_e2k_qppackdl(0x0302010080808080LL, 0x8080808080808080LL));
+
+    X0 = X1 ^ X3 ^ __builtin_e2k_qpshufb(X0, X0, __builtin_e2k_qppackdl(0x808080800f0e0d0cLL, 0x0b0a090807060504LL));
+
+    X0 ^= __builtin_e2k_qpsrlw(X1, 7) ^ __builtin_e2k_qpsrlw(X1, 2) ^ __builtin_e2k_qpsrlw(X1, 1);
+
+    return X0;
+}
+
+static __attribute__((__always_inline__)) inline __v2di gcm_multiply(__v2di H, __v2di x)
+{
+    uint64_t Hh = H[1], Hl = H[0];
+    uint64_t xh = x[1], xl = x[0];
+
+    uint64_t T0h = __builtin_e2k_clmulh(Hh, xh), T0l = __builtin_e2k_clmull(Hh, xh);
+    uint64_t T1h = __builtin_e2k_clmulh(Hh, xl), T1l = __builtin_e2k_clmull(Hh, xl);
+    uint64_t T2h = __builtin_e2k_clmulh(Hl, xh), T2l = __builtin_e2k_clmull(Hl, xh);
+    uint64_t T3h = __builtin_e2k_clmulh(Hl, xl), T3l = __builtin_e2k_clmull(Hl, xl);
+
+    T1h = __builtin_e2k_pxord(T1h, T2h);
+    T1l = __builtin_e2k_pxord(T1l, T2l);
+
+    T0l = __builtin_e2k_pxord(T0l, T1h);
+    T3h = __builtin_e2k_pxord(T3h, T1l);
+
+    return gcm_reduce(__builtin_e2k_qppackdl(T0h, T0l), __builtin_e2k_qppackdl(T3h, T3l));
+}
+
+static __attribute__((__always_inline__)) inline __v2di gcm_multiply_x4(__v2di H1, __v2di H2, __v2di H3, __v2di H4,
+    __v2di X1, __v2di X2, __v2di X3, __v2di X4)
+{
+    /*
+     * Multiply with delayed reduction, algorithm by Krzysztof Jankowski
+     * and Pierre Laurent of Intel
+     */
+
+    const uint64_t loh = (__builtin_e2k_clmulh(H1[0], X1[0]) ^ __builtin_e2k_clmulh(H2[0], X2[0])) ^ (__builtin_e2k_clmulh(H3[0], X3[0]) ^ __builtin_e2k_clmulh(H4[0], X4[0]));
+    const uint64_t lol = (__builtin_e2k_clmull(H1[0], X1[0]) ^ __builtin_e2k_clmull(H2[0], X2[0])) ^ (__builtin_e2k_clmull(H3[0], X3[0]) ^ __builtin_e2k_clmull(H4[0], X4[0]));
+
+    const uint64_t hih = (__builtin_e2k_clmulh(H1[1], X1[1]) ^ __builtin_e2k_clmulh(H2[1], X2[1])) ^ (__builtin_e2k_clmulh(H3[1], X3[1]) ^ __builtin_e2k_clmulh(H4[1], X4[1]));
+    const uint64_t hil = (__builtin_e2k_clmull(H1[1], X1[1]) ^ __builtin_e2k_clmull(H2[1], X2[1])) ^ (__builtin_e2k_clmull(H3[1], X3[1]) ^ __builtin_e2k_clmull(H4[1], X4[1]));
+    uint64_t Th, Tl;
+
+    Th = __builtin_e2k_clmulh(H1[0] ^ H1[1], X1[0] ^ X1[1]);
+    Tl = __builtin_e2k_clmull(H1[0] ^ H1[1], X1[0] ^ X1[1]);
+
+    Th ^= __builtin_e2k_clmulh(H2[0] ^ H2[1], X2[0] ^ X2[1]);
+    Tl ^= __builtin_e2k_clmull(H2[0] ^ H2[1], X2[0] ^ X2[1]);
+
+    Th ^= __builtin_e2k_clmulh(H3[0] ^ H3[1], X3[0] ^ X3[1]);
+    Tl ^= __builtin_e2k_clmull(H3[0] ^ H3[1], X3[0] ^ X3[1]);
+
+    Th ^= __builtin_e2k_clmulh(H4[0] ^ H4[1], X4[0] ^ X4[1]);
+    Tl ^= __builtin_e2k_clmull(H4[0] ^ H4[1], X4[0] ^ X4[1]);
+
+    Th ^= loh;
+    Tl ^= lol;
+    Th ^= hih;
+    Tl ^= hil;
+
+    return gcm_reduce(__builtin_e2k_qppackdl(hih, hil ^ Th),
+        __builtin_e2k_qppackdl(loh ^ Tl, lol));
+}
+
+/*##############################################################################
+# void gcm_init_e2kv6_clmul(u128 Htable[16],const uint64_t H[2]);
+#
+# input:        128-bit H - secret parameter E(K,0^128)
+# output:       precomputed table filled with degrees of twisted H;
+#               H is twisted to handle reverse bitness of GHASH;
+#               only few of 16 slots of Htable[16] are used;
+#               data is opaque to outside world (which allows to
+#               optimize the code independently);
+#
+*/
+void gcm_init_e2kv6_clmul(u128 Htable[16], const uint64_t H[2])
+{
+    __v2di *Hp = (__v2di *)Htable;
+    __v2di H1 = (__v2di) { H[1], H[0] }; /* H in LE, but need swap hi/lo */
+    __v2di H2 = gcm_multiply(H1, H1);
+    __v2di H3 = gcm_multiply(H1, H2);
+    __v2di H4 = gcm_multiply(H2, H2);
+
+    Hp[0] = H1;
+    Hp[1] = H2;
+    Hp[2] = H3;
+    Hp[3] = H4;
+}
+
+/*##############################################################################
+# void gcm_gmult_e2kv6_clmul(uint64_t Xi[2],const u128 Htable[16]);
+#
+# input:        Xi - current hash value;
+#               Htable - table precomputed in gcm_init_e2kv6_clmul;
+# output:       Xi - next hash value Xi;
+*/
+void gcm_gmult_e2kv6_clmul(uint64_t Xi[2], const u128 Htable[16])
+{
+    __v2di *Xp = (__v2di *)Xi;
+    __v2di *Hp = (__v2di *)Htable;
+    *Xp = reverse_vector(gcm_multiply(Hp[0], reverse_vector(*Xp)));
+}
+
+/*##############################################################################
+# void gcm_ghash_e2kv6_clmul(uint64_t Xi[2], const u128 Htable[16],
+#                            const uint8_t *inp,size_t len);
+#
+# input:        table precomputed in gcm_init_e2kv6_clmul;
+#               current hash value Xi;
+#               pointer to input data;
+#               length of input data in bytes, but divisible by block size;
+# output:       next hash value Xi;
+*/
+void gcm_ghash_e2kv6_clmul(uint64_t Xi[2], const u128 Htable[16],
+    const uint8_t *inp, size_t len)
+{
+    __v2di *Hp = (__v2di *)Htable;
+    __v2di *input = (__v2di *)inp;
+    __v2di x;
+    size_t i, blocks = (len >> 4);
+
+    x = reverse_vector(*(__v2di *)Xi);
+
+    while (blocks >= 4) {
+        __v2di m0 = reverse_vector(input[0]);
+        __v2di m1 = reverse_vector(input[1]);
+        __v2di m2 = reverse_vector(input[2]);
+        __v2di m3 = reverse_vector(input[3]);
+
+        x ^= m0;
+        x = gcm_multiply_x4(Hp[0], Hp[1], Hp[2], Hp[3], m3, m2, m1, x);
+
+        input += 4;
+        blocks -= 4;
+    }
+
+#pragma loop count(3)
+    for (i = 0; i < blocks; i++) {
+        __v2di m = reverse_vector(input[i]);
+
+        x ^= m;
+        x = gcm_multiply(Hp[0], x);
+    }
+
+    *(__v2di *)Xi = reverse_vector(x);
+}

--- a/crypto/modes/build.info
+++ b/crypto/modes/build.info
@@ -46,6 +46,11 @@ IF[{- !$disabled{asm} -}]
   $MODESASM_riscv64=ghash-riscv64.s ghash-riscv64-zvkb-zvbc.s ghash-riscv64-zvkg.s aes-gcm-riscv64-zvkb-zvkg-zvkned.s
   $MODESDEF_riscv64=GHASH_ASM
 
+  $MODESASM_e2kv6=asm/ghash-e2kv6.c
+  $MODESDEF_e2kv6=GHASH_ASM
+  $MODESASM_e2kv7=asm/ghash-e2kv6.c
+  $MODESDEF_e2kv7=GHASH_ASM
+
   # Now that we have defined all the arch specific variables, use the
   # appropriate one, and define the appropriate macros
   IF[$MODESASM_{- $target{asm_arch} -}]

--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -422,6 +422,12 @@ void gcm_init_rv64i_zvkg_zvkb(u128 Htable[16], const uint64_t Xi[2]);
 void gcm_gmult_rv64i_zvkg(uint64_t Xi[2], const u128 Htable[16]);
 void gcm_ghash_rv64i_zvkg(uint64_t Xi[2], const u128 Htable[16],
     const uint8_t *inp, size_t len);
+#elif defined(__e2k__) && (__iset__ >= 6)
+#define GHASH_ASM_E2KV6
+void gcm_init_e2kv6_clmul(u128 Htable[16], const uint64_t Xi[2]);
+void gcm_gmult_e2kv6_clmul(uint64_t Xi[2], const u128 Htable[16]);
+void gcm_ghash_e2kv6_clmul(uint64_t Xi[2], const u128 Htable[16],
+    const uint8_t *inp, size_t len);
 #endif
 #endif
 
@@ -551,6 +557,11 @@ static void gcm_get_funcs(struct gcm_funcs_st *ctx)
             ctx->ghash = gcm_ghash_rv64i_zbc;
         }
     }
+    return;
+#elif defined(GHASH_ASM_E2KV6)
+    ctx->ginit = gcm_init_e2kv6_clmul;
+    ctx->gmult = gcm_gmult_e2kv6_clmul;
+    ctx->ghash = gcm_ghash_e2kv6_clmul;
     return;
 #elif defined(GHASH_ASM)
     /* all other architectures use the generic names */

--- a/crypto/sha/sha512.c
+++ b/crypto/sha/sha512.c
@@ -60,7 +60,7 @@
 #include "internal/cryptlib.h"
 #include "crypto/sha.h"
 
-#if defined(__i386) || defined(__i386__) || defined(_M_IX86) || defined(__x86_64) || defined(_M_AMD64) || defined(_M_X64) || defined(__s390__) || defined(__s390x__) || defined(__aarch64__) || defined(SHA512_ASM)
+#if defined(__i386) || defined(__i386__) || defined(_M_IX86) || defined(__x86_64) || defined(_M_AMD64) || defined(_M_X64) || defined(__s390__) || defined(__s390x__) || defined(__aarch64__) || defined(__e2k__) || defined(SHA512_ASM)
 #define SHA512_BLOCK_CAN_MANAGE_UNALIGNED_DATA
 #endif
 
@@ -405,6 +405,11 @@ static const SHA_LONG64 K512[80] = {
                         asm ("rev8 %0, %1"  \
                         : "=r"(ret)         \
                         : "r"(x)); ret; })
+#elif defined(__e2k__)
+#include <x86gprintrin.h>
+#define PULL64(x) __builtin_bswap64(x)
+#define ROTR(x, s) ((s) > 48 ? __rolq((x), 64 - (s)) \
+                             : __rorq((x), (s)))
 #endif
 #if defined(__riscv_zknh) && __riscv_xlen == 32
 #define Sigma0(x) ({ SHA_LONG64 ret; unsigned int *r = (unsigned int *)(&(ret));    \
@@ -487,6 +492,9 @@ static const SHA_LONG64 K512[80] = {
                         asm (".insn r4 0x33, 1, 0x3, %0, %2, %1, %3"\
                         : "=r"(ret)                                 \
                         : "r"(x^z), "r"(y), "r"(x)); ret; })
+#elif defined(__e2k__) && __iset__ >= 5
+#define sigma0(x) (__builtin_e2k_plog(0x96, ROTR((x), 1), ROTR((x), 8), ((x) >> 7)))
+#define sigma1(x) (__builtin_e2k_plog(0x96, ROTR((x), 19), ROTR((x), 61), ((x) >> 6)))
 #endif
 #elif defined(_MSC_VER)
 #if defined(_WIN64) /* applies to both IA-64 and AMD64 */

--- a/include/crypto/md32_common.inc
+++ b/include/crypto/md32_common.inc
@@ -120,6 +120,11 @@
                        : "=r"(ret)                    \
                        : "r"(x), "i"(32 - (n))); ret; })
 #endif
+#  elif defined(__e2k__)
+#   undef ROTATE
+#   define ROTATE(a,n)  ( (__builtin_constant_p(n) && (n) > 16) \
+                          ? __builtin_e2k_scrs((a), 32 - (n))   \
+                          : __builtin_e2k_scls((a),      (n))   )
 #endif
 #endif
 #endif

--- a/include/crypto/modes.h
+++ b/include/crypto/modes.h
@@ -25,7 +25,7 @@
 
 #define STRICT_ALIGNMENT 1
 #ifndef PEDANTIC
-#if defined(__i386) || defined(__i386__) || defined(__x86_64) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_AMD64) || defined(_M_X64) || defined(__aarch64__) || defined(__s390__) || defined(__s390x__)
+#if defined(__i386) || defined(__i386__) || defined(__x86_64) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_AMD64) || defined(_M_X64) || defined(__aarch64__) || defined(__s390__) || defined(__s390x__) || defined(__e2k__)
 #undef STRICT_ALIGNMENT
 #endif
 #endif
@@ -72,6 +72,9 @@
 #define BSWAP4(x) ({ uint32_t ret_=(x);                   \
                         asm ("rev8 %0,%0; srli %0,%0,32"\
                         : "+&r"(ret_));  ret_; })
+#elif defined(__e2k__)
+#define BSWAP8(x) __builtin_bswap64(x)
+#define BSWAP4(x) __builtin_bswap32(x)
 #endif
 #elif defined(_MSC_VER)
 #if _MSC_VER >= 1300


### PR DESCRIPTION
This PR adds e2k-specific bits to the build system, bn module, and some crypto stuff.

bn bits required copying some code from other places (bn_asm.c, for example), so suggestions on how to reorganize it and reduce duplication are welcome.

The test suite passes and we've been using this code in production for quite a time with previous OpenSSL versions.