### PR TITLE
slh_dsa: Remove redundant cleanup to prevent double free

### DIFF
--- a/crypto/slh_dsa/slh_dsa_key.c
+++ b/crypto/slh_dsa/slh_dsa_key.c
@@ -58,7 +58,6 @@ static int slh_dsa_key_hash_init(SLH_DSA_KEY *key)
     key->hash_func = ossl_slh_get_hash_fn(is_shake, security_category);
     return 1;
 err:
-    slh_dsa_key_hash_cleanup(key);
     return 0;
 }
 


### PR DESCRIPTION
Since SLH_DSA_KEY is allocated with OPENSSL_zalloc, its members are NULL-initialized. Removing the redundant slh_dsa_key_hash_cleanup() inside the err path of slh_dsa_key_hash_init() prevents the Double-Free while allowing the outer ossl_slh_dsa_key_free() to safely handle the cleanup.
