### PR TITLE
providers: Nullify BIO pointer after free to prevent double free

### DIFF
--- a/providers/implementations/storemgmt/file_store_any2obj.c
+++ b/providers/implementations/storemgmt/file_store_any2obj.c
@@ -336,6 +336,7 @@ static int raw2obj_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
     }
 
     BIO_free(in);
+    in = NULL;
 
     if (BUF_MEM_grow(mem, len) != len) {
         ERR_raise(ERR_LIB_PEM, ERR_R_BUF_LIB);


### PR DESCRIPTION
In providers/implementations/storemgmt/file_store_any2obj.c, if the control flow reaches the err label after BIO_free(in) is called, a double free will occur in the generic cleanup block.

Currently, the only path to this specific err jump is if BUF_MEM_grow(mem, len) fails. As noted by the OpenSSL Security Team, this failure is currently impossible because the buffer is being shrunk (max_len >= len).

However, as requested by the security team via email, this PR explicitly nullifies the in pointer after the first free to future-proof the function and prevent a double free in case the semantics of BUF_MEM_grow() or the surrounding logic change in the future.