### PR TITLE
evp: Fix potential double free on error path in m_sigver.c

### DIFF
--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -131,7 +131,9 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
          * iteration we're on.
          */
         EVP_SIGNATURE_free(signature);
+        signature = NULL;
         EVP_KEYMGMT_free(tmp_keymgmt);
+        tmp_keymgmt = NULL;
 
         switch (iter) {
         case 1:


### PR DESCRIPTION
In do_sigver_init(), if the for loop proceeds to its second iteration (iter = 2), the results from the first iteration (signature and tmp_keymgmt) are explicitly freed at the beginning of the loop. However, the pointers are not set to NULL after being freed.

If an error occurs subsequently during this second iteration (for example, if evp_signature_fetch_from_prov() returns NULL, triggering a goto notsupported), the control flow jumps to the generic cleanup block at the end of the function. This cleanup block calls EVP_KEYMGMT_free(tmp_keymgmt) again on the dangling pointer, resulting in a Double Free.

This PR resolves the issue by explicitly nullifying these pointers immediately after they are freed at the start of the loop iteration.

(Note: This issue was discussed with the OpenSSL Security Team, who classified it as a regular bug due to lack of attacker control and requested a public PR.)
