### PR TITLE
[3.6, 3.5, 3.4, 3.0] Run CIFuzz workflow on schedule

### DIFF
--- a/.github/workflows/oss-fuzz.yml
+++ b/.github/workflows/oss-fuzz.yml
@@ -6,7 +6,10 @@
 # https://www.openssl.org/source/license.html
 
 name: CIFuzz
-on: [pull_request, push]
+on:
+  schedule:
+    - cron: '50 01 * * *'
+  workflow_dispatch:
 permissions:
   contents: read
 


### PR DESCRIPTION
This is a backport of [1] to `openssl-3.6` and earlier branches, that effectively disables CIFuzz workflow run on PRs there.  This path was elected to avoid unnecessary differences between `master` and stable branches.

[1] https://github.com/openssl/openssl/pull/29080