### PR TITLE
asn1: prevent OOB read in do_create()

### DIFF
--- a/crypto/asn1/asn_moid.c
+++ b/crypto/asn1/asn_moid.c
@@ -81,10 +81,12 @@ static int do_create(const char *value, const char *name)
         while (ossl_isspace(*ln))
             ln++;
         p--;
-        while (ossl_isspace(*p)) {
-            if (p == ln)
+        while (p >= ln && ossl_isspace(*p)) {
+            if (ln == p)
                 return 0;
             p--;
+            if (p < ln)
+                return 0;
         }
         p++;
         if ((lntmp = OPENSSL_malloc((p - ln) + 1)) == NULL)

--- a/test/recipes/04-test_asn1_parse.t
+++ b/test/recipes/04-test_asn1_parse.t
@@ -12,7 +12,7 @@ use OpenSSL::Test::Utils;
 
 setup("test_asn1_parse");
 
-plan tests => 4;
+plan tests => 8;
 
 $ENV{OPENSSL_CONF} = srctop_file("test", "test_asn1_parse.cnf");
 
@@ -24,6 +24,18 @@ ok(run(app(([ 'openssl', 'asn1parse',
 
 ok(run(app(([ 'openssl', 'asn1parse',
               '-genstr', 'OID:1.2.3.4.3']))));
+
+ok(run(app(([ 'openssl', 'asn1parse',
+              '-genstr', 'OID:1.2.3.4.4']))));
+
+ok(run(app(([ 'openssl', 'asn1parse',
+              '-genstr', 'OID:1.2.3.4.5']))));
+
+ok(run(app(([ 'openssl', 'asn1parse',
+              '-genstr', 'OID:1.2.3.4.6']))));
+
+ok(run(app(([ 'openssl', 'asn1parse',
+              '-genstr', 'OID:1.2.3.4.7']))));
 
 ok(run(app(([ 'openssl', 'asn1parse',
               '-genconf', srctop_file("test", "test_asn1_genconf.cnf")]))));

--- a/test/test_asn1_parse.cnf
+++ b/test/test_asn1_parse.cnf
@@ -10,3 +10,7 @@ oid_section = oids
 testoid1 = 1.2.3.4.1
 testoid2 = A Very Long OID Name, 1.2.3.4.2
 testoid3 = ,1.2.3.4.3
+testoid4 =         OID Name     ,1.2.3.4.4
+testoid5 = "         ",1.2.3.4.5
+testoid6 = "      e    ",1.2.3.4.6
+testoid7 =           ,1.2.3.4.7


### PR DESCRIPTION
Avoid pointer underflow when trimming trailing whitespace from the OID long name in do_create(). An all-whitespace long name could cause the backward scan to move before the start of the buffer, resulting in an out-of-bounds read.

Reject empty long names after whitespace trimming.

Fixes #31261

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
