### PR TITLE
DH: harden empty fromdata (3.0)

### DIFF
--- a/crypto/dh/dh_check.c
+++ b/crypto/dh/dh_check.c
@@ -73,6 +73,14 @@ int DH_check_params(const DH *dh, int *ret)
     BN_CTX *ctx = NULL;
 
     *ret = 0;
+    /*
+     * A DH with no modulus or generator cannot be checked.  Report
+     * the failure via |*ret| rather than dereferencing NULL below.
+     */
+    if (dh->params.p == NULL || dh->params.g == NULL) {
+        *ret = DH_NOT_SUITABLE_GENERATOR | DH_CHECK_P_NOT_PRIME;
+        return 1;
+    }
     ctx = BN_CTX_new_ex(dh->libctx);
     if (ctx == NULL)
         goto err;
@@ -149,6 +157,11 @@ int DH_check(const DH *dh, int *ret)
     int nid = DH_get_nid((DH *)dh);
 
     *ret = 0;
+    /* A DH with no modulus or generator cannot be checked. */
+    if (dh->params.p == NULL || dh->params.g == NULL) {
+        *ret = DH_NOT_SUITABLE_GENERATOR | DH_CHECK_P_NOT_PRIME;
+        return 1;
+    }
     if (nid != NID_undef)
         return 1;
 
@@ -249,6 +262,15 @@ int DH_check_pub_key_ex(const DH *dh, const BIGNUM *pub_key)
  */
 int DH_check_pub_key(const DH *dh, const BIGNUM *pub_key, int *ret)
 {
+    *ret = 0;
+    /*
+     * Without a modulus we cannot check anything; signal failure via
+     * |*ret| rather than crashing in BN_num_bits below.
+     */
+    if (dh->params.p == NULL) {
+        *ret = DH_CHECK_PUBKEY_INVALID;
+        return 1;
+    }
     /* Don't do any checks at all with an excessively large modulus */
     if (BN_num_bits(dh->params.p) > OPENSSL_DH_CHECK_MAX_MODULUS_BITS) {
         ERR_raise(ERR_LIB_DH, DH_R_MODULUS_TOO_LARGE);

--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -865,6 +865,383 @@ static int test_public_via_MSBLOB(const char *type, EVP_PKEY *key)
         test_mem, check_public_MSBLOB, dump_der, 0);
 }
 
+/*
+ * Build a public-only EVP_PKEY of the same algorithm as |src| by
+ * round-tripping the public component through OSSL_PARAMs.
+ */
+static EVP_PKEY *make_public_only_copy(EVP_PKEY *src)
+{
+    OSSL_PARAM *params = NULL;
+    EVP_PKEY_CTX *cctx = NULL;
+    EVP_PKEY *pub = NULL;
+
+    if (!EVP_PKEY_todata(src, EVP_PKEY_PUBLIC_KEY, &params))
+        goto end;
+    if ((cctx = EVP_PKEY_CTX_new_from_pkey(NULL, src, NULL)) == NULL
+        || EVP_PKEY_fromdata_init(cctx) <= 0
+        || EVP_PKEY_fromdata(cctx, &pub, EVP_PKEY_PUBLIC_KEY, params) <= 0) {
+        EVP_PKEY_free(pub);
+        pub = NULL;
+    }
+end:
+    OSSL_PARAM_free(params);
+    EVP_PKEY_CTX_free(cctx);
+    return pub;
+}
+
+/*
+ * Build an "embryonic" EVP_PKEY of the same algorithm as |src|: just
+ * the keymgmt-bound type and (where applicable) domain parameters,
+ * with no key material.
+ */
+static EVP_PKEY *make_embryonic_copy(EVP_PKEY *src)
+{
+    EVP_PKEY *embryo = EVP_PKEY_new();
+
+    if (embryo == NULL)
+        return NULL;
+    if (EVP_PKEY_copy_parameters(embryo, src) <= 0) {
+        EVP_PKEY_free(embryo);
+        return NULL;
+    }
+    return embryo;
+}
+
+/*
+ * Check that EVP_PKEY_dup() works for every supported provider-backed
+ * key type, and that the duplicate compares equal to the original.
+ *
+ * Exercised in three shapes:
+ *   1. The full keypair |key| (typically pub + priv).
+ *   2. A public-only key derived from |key|.
+ *   3. An "embryonic" key (algorithm + domain parameters only, no
+ *      key material) produced with EVP_PKEY_copy_parameters().
+ */
+static int test_dup(const char *type, EVP_PKEY *key)
+{
+    EVP_PKEY *dup = NULL;
+    EVP_PKEY *pub_only = NULL;
+    EVP_PKEY *embryo = NULL;
+    int ok = 0;
+
+    if (!TEST_ptr(key)) {
+        TEST_info("%s: no source key", type);
+        return 0;
+    }
+
+    /* 1. Dup the full keypair. */
+    if (!TEST_ptr(dup = EVP_PKEY_dup(key))) {
+        TEST_info("%s: EVP_PKEY_dup of keypair returned NULL", type);
+        goto end;
+    }
+    if (!TEST_int_eq(EVP_PKEY_eq(key, dup), 1)) {
+        TEST_info("%s: keypair dup does not compare equal to original", type);
+        goto end;
+    }
+    EVP_PKEY_free(dup);
+    dup = NULL;
+
+    /* 2. Dup a public-only copy of the same key. */
+    if (!TEST_ptr(pub_only = make_public_only_copy(key))) {
+        TEST_info("%s: could not derive a public-only key", type);
+        goto end;
+    }
+    if (!TEST_ptr(dup = EVP_PKEY_dup(pub_only))) {
+        TEST_info("%s: EVP_PKEY_dup of public-only key returned NULL", type);
+        goto end;
+    }
+    if (!TEST_int_eq(EVP_PKEY_eq(pub_only, dup), 1)) {
+        TEST_info("%s: public-only dup does not compare equal to original",
+            type);
+        goto end;
+    }
+    EVP_PKEY_free(dup);
+    dup = NULL;
+
+    /*
+     * 3. Dup an embryonic key (algorithm + domain parameters only,
+     * no key bits).  Some keymgmts (RSA, RSA-PSS) refuse to build
+     * such a key via EVP_PKEY_copy_parameters(); treat that as a
+     * graceful skip.  Where an embryo can be built we compare via
+     * EVP_PKEY_parameters_eq() since EVP_PKEY_eq() requires key
+     * bits to match.  Algorithms with no domain parameters may
+     * legitimately answer -2 ("nothing to compare").
+     */
+    embryo = make_embryonic_copy(key);
+    if (embryo != NULL) {
+        if (!TEST_ptr(dup = EVP_PKEY_dup(embryo))) {
+            TEST_info("%s: EVP_PKEY_dup of embryonic key returned NULL", type);
+            goto end;
+        }
+        {
+            int eq = EVP_PKEY_parameters_eq(embryo, dup);
+
+            if (!TEST_true(eq == 1 || eq == -2)) {
+                TEST_info("%s: embryonic dup parameters_eq %d (want 1 or -2)",
+                    type, eq);
+                goto end;
+            }
+        }
+    } else {
+        TEST_info("%s: skipping embryonic dup (no params-only key shape)",
+            type);
+    }
+
+    ok = 1;
+end:
+    EVP_PKEY_free(dup);
+    EVP_PKEY_free(pub_only);
+    EVP_PKEY_free(embryo);
+    return ok;
+}
+
+/*
+ * Drive EVP_PKEY_fromdata with the supplied OSSL_PARAM[] (NULL =
+ * empty array) for the given selection.  Either outcome is accepted:
+ * fromdata may reject the input, or it may succeed and yield a key
+ * with at most algorithm-bound parameters.  In the success case a
+ * battery of common consumer ops must not crash on the resulting
+ * key; their return values are not asserted.
+ */
+static int run_empty_fromdata_probe(const char *type, EVP_PKEY_CTX *cctx,
+    int selection, OSSL_PARAM *params, const char *selname)
+{
+    EVP_PKEY *pkey = NULL;
+    OSSL_PARAM empty[1];
+    int r;
+    int ok = 0;
+
+    if (params == NULL) {
+        empty[0] = OSSL_PARAM_construct_end();
+        params = empty;
+    }
+
+    if (!TEST_int_gt(EVP_PKEY_fromdata_init(cctx), 0)) {
+        TEST_info("%s: fromdata_init failed (%s)", type, selname);
+        goto end;
+    }
+    r = EVP_PKEY_fromdata(cctx, &pkey, selection, params);
+    if (r <= 0) {
+        /* Rejection is fine, but the out-pointer must remain NULL. */
+        if (!TEST_ptr_null(pkey)) {
+            TEST_info("%s: fromdata returned %d but pkey != NULL (%s)",
+                type, r, selname);
+            goto end;
+        }
+        ok = 1;
+        goto end;
+    }
+    if (!TEST_ptr(pkey)) {
+        TEST_info("%s: fromdata returned %d but pkey == NULL (%s)",
+            type, r, selname);
+        goto end;
+    }
+    /*
+     * Walk a battery of common consumer ops on the resulting key.
+     * Their return values are not asserted - a contentless key may
+     * fail every op - only crashing is forbidden.
+     */
+    (void)EVP_PKEY_get_bits(pkey);
+    (void)EVP_PKEY_get_security_bits(pkey);
+    (void)EVP_PKEY_get_size(pkey);
+    (void)EVP_PKEY_eq(pkey, pkey);
+    (void)EVP_PKEY_parameters_eq(pkey, pkey);
+    {
+        OSSL_PARAM *out = NULL;
+
+        if (EVP_PKEY_todata(pkey, selection, &out) > 0)
+            OSSL_PARAM_free(out);
+    }
+    {
+        EVP_PKEY *clone = EVP_PKEY_dup(pkey);
+
+        EVP_PKEY_free(clone);
+    }
+    {
+        BIO *bio = BIO_new(BIO_s_null());
+
+        if (bio != NULL) {
+            (void)EVP_PKEY_print_public(bio, pkey, 0, NULL);
+            (void)EVP_PKEY_print_private(bio, pkey, 0, NULL);
+            (void)EVP_PKEY_print_params(bio, pkey, 0, NULL);
+            BIO_free(bio);
+        }
+    }
+    {
+        /* The param/public/private/pairwise check family. */
+        EVP_PKEY_CTX *vctx = EVP_PKEY_CTX_new_from_pkey(NULL, pkey, NULL);
+
+        if (vctx != NULL) {
+            (void)EVP_PKEY_param_check(vctx);
+            (void)EVP_PKEY_param_check_quick(vctx);
+            (void)EVP_PKEY_public_check(vctx);
+            (void)EVP_PKEY_public_check_quick(vctx);
+            (void)EVP_PKEY_private_check(vctx);
+            (void)EVP_PKEY_pairwise_check(vctx);
+            EVP_PKEY_CTX_free(vctx);
+        }
+    }
+    ok = 1;
+end:
+    EVP_PKEY_free(pkey);
+    return ok;
+}
+
+static int probe_empty_fromdata(const char *type, EVP_PKEY *prototype,
+    int selection, const char *selname)
+{
+    EVP_PKEY_CTX *cctx = NULL;
+    int ok = 0;
+
+    if (!TEST_ptr(cctx = EVP_PKEY_CTX_new_from_pkey(NULL, prototype, NULL))) {
+        TEST_info("%s: CTX alloc failed for empty fromdata (%s)",
+            type, selname);
+        goto end;
+    }
+    ok = run_empty_fromdata_probe(type, cctx, selection, NULL, selname);
+end:
+    EVP_PKEY_CTX_free(cctx);
+    return ok;
+}
+
+/*
+ * Drive EVP_PKEY_fromdata with an empty OSSL_PARAM[] for both
+ * EVP_PKEY_PUBLIC_KEY and EVP_PKEY_KEYPAIR selections.  Either
+ * outcome is acceptable: fromdata rejects, or it succeeds and the
+ * resulting key survives the consumer-op battery without crashing.
+ */
+static int test_fromdata(const char *type, EVP_PKEY *prototype)
+{
+    if (!TEST_ptr(prototype)) {
+        TEST_info("%s: no prototype key", type);
+        return 0;
+    }
+    if (!probe_empty_fromdata(type, prototype, EVP_PKEY_PUBLIC_KEY,
+            "EVP_PKEY_PUBLIC_KEY"))
+        return 0;
+    if (!probe_empty_fromdata(type, prototype, EVP_PKEY_KEYPAIR,
+            "EVP_PKEY_KEYPAIR"))
+        return 0;
+    return 1;
+}
+
+/*
+ * Named-group-only partial-shape variants for prototype-matrix
+ * algorithms, plus any keymgmts without a keygen path.  Each entry
+ * is one (name, selection, params-builder) shape; a NULL builder
+ * means "use an empty OSSL_PARAM[]".  Algorithms not loadable under
+ * the active provider set are silently skipped.
+ */
+typedef int (*fromdata_shape_build_fn)(OSSL_PARAM_BLD *bld);
+
+struct fromdata_shape {
+    const char *name; /* keymgmt algorithm name */
+    int selection; /* EVP_PKEY_PUBLIC_KEY / KEYPAIR / etc. */
+    fromdata_shape_build_fn build; /* NULL -> empty OSSL_PARAM[] */
+    const char *label; /* diagnostic label */
+};
+
+#ifndef OPENSSL_NO_DH
+static int build_dh_named_group(OSSL_PARAM_BLD *bld)
+{
+    return OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_PKEY_PARAM_GROUP_NAME,
+        "ffdhe2048", 0);
+}
+#endif
+
+#ifndef OPENSSL_NO_EC
+static int build_ec_named_group(OSSL_PARAM_BLD *bld)
+{
+    return OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_PKEY_PARAM_GROUP_NAME,
+        "P-256", 0);
+}
+#ifndef OPENSSL_NO_SM2
+static int build_sm2_named_group(OSSL_PARAM_BLD *bld)
+{
+    return OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_PKEY_PARAM_GROUP_NAME,
+        "SM2", 0);
+}
+#endif
+#endif
+
+#if defined(OPENSSL_NO_DH) && defined(OPENSSL_NO_EC)
+#undef TEST_FROMDATA_NO_KEYGEN
+#else
+#define TEST_FROMDATA_NO_KEYGEN
+static const struct fromdata_shape no_keygen_shapes[] = {
+/* Named-group-only partial shapes. */
+#ifndef OPENSSL_NO_DH
+    { "DH", EVP_PKEY_KEYPAIR, build_dh_named_group,
+        "DH / named group only / KEYPAIR" },
+    { "DH", EVP_PKEY_PUBLIC_KEY, build_dh_named_group,
+        "DH / named group only / PUBLIC_KEY" },
+#endif
+#ifndef OPENSSL_NO_EC
+    { "EC", EVP_PKEY_KEYPAIR, build_ec_named_group,
+        "EC / group only / KEYPAIR" },
+    { "EC", EVP_PKEY_PUBLIC_KEY, build_ec_named_group,
+        "EC / group only / PUBLIC_KEY" },
+#ifndef OPENSSL_NO_SM2
+    { "SM2", EVP_PKEY_KEYPAIR, build_sm2_named_group,
+        "SM2 / group only / KEYPAIR" },
+#endif
+#endif
+};
+
+/*
+ * Probe An algorithm by name rather than a prototype key, for keymgmts without
+ * a keygen path.  Algorithms not loadable under the active provider set are
+ * silently skipped.  |params| may be NULL (= empty OSSL_PARAM[]) or a
+ * caller-built partial array.
+ */
+static int probe_fromdata_by_name(const char *name, int selection,
+    OSSL_PARAM *params, const char *selname)
+{
+    EVP_PKEY_CTX *cctx = NULL;
+    int ok = 1;
+
+    cctx = EVP_PKEY_CTX_new_from_name(NULL, name, NULL);
+    if (cctx == NULL)
+        return 1;
+    ok = run_empty_fromdata_probe(name, cctx, selection, params, selname);
+    EVP_PKEY_CTX_free(cctx);
+    return ok;
+}
+
+static int test_fromdata_no_keygen(void)
+{
+    size_t i;
+
+    for (i = 0; i < OSSL_NELEM(no_keygen_shapes); i++) {
+        const struct fromdata_shape *s = &no_keygen_shapes[i];
+        OSSL_PARAM_BLD *bld = NULL;
+        OSSL_PARAM *params = NULL;
+        int ok;
+
+        if (s->build != NULL) {
+            if (!TEST_ptr(bld = OSSL_PARAM_BLD_new()))
+                return 0;
+            if (!s->build(bld)) {
+                TEST_info("%s: builder failed", s->label);
+                OSSL_PARAM_BLD_free(bld);
+                return 0;
+            }
+            params = OSSL_PARAM_BLD_to_param(bld);
+            if (!TEST_ptr(params)) {
+                OSSL_PARAM_BLD_free(bld);
+                return 0;
+            }
+        }
+        ok = probe_fromdata_by_name(s->name, s->selection, params, s->label);
+        OSSL_PARAM_free(params);
+        OSSL_PARAM_BLD_free(bld);
+        if (!ok)
+            return 0;
+    }
+    return 1;
+}
+#endif
+
 #define KEYS(KEYTYPE) \
     static EVP_PKEY *key_##KEYTYPE = NULL
 #define MAKE_KEYS(KEYTYPE, KEYTYPEstr, params) \
@@ -908,6 +1285,14 @@ static int test_public_via_MSBLOB(const char *type, EVP_PKEY *key)
     static int test_public_##KEYTYPE##_via_PEM(void)                      \
     {                                                                     \
         return test_public_via_PEM(KEYTYPEstr, key_##KEYTYPE, fips);      \
+    }                                                                     \
+    static int test_dup_##KEYTYPE(void)                                   \
+    {                                                                     \
+        return test_dup(KEYTYPEstr, key_##KEYTYPE);                       \
+    }                                                                     \
+    static int test_fromdata_##KEYTYPE(void)                              \
+    {                                                                     \
+        return test_fromdata(KEYTYPEstr, key_##KEYTYPE);                  \
     }
 
 #define ADD_TEST_SUITE(KEYTYPE)                     \
@@ -916,7 +1301,9 @@ static int test_public_via_MSBLOB(const char *type, EVP_PKEY *key)
     ADD_TEST(test_protected_##KEYTYPE##_via_DER);   \
     ADD_TEST(test_protected_##KEYTYPE##_via_PEM);   \
     ADD_TEST(test_public_##KEYTYPE##_via_DER);      \
-    ADD_TEST(test_public_##KEYTYPE##_via_PEM)
+    ADD_TEST(test_public_##KEYTYPE##_via_PEM);      \
+    ADD_TEST(test_dup_##KEYTYPE);                   \
+    ADD_TEST(test_fromdata_##KEYTYPE)
 
 #define IMPLEMENT_TEST_SUITE_PARAMS(KEYTYPE, KEYTYPEstr)       \
     static int test_params_##KEYTYPE##_via_DER(void)           \
@@ -1501,6 +1888,14 @@ int setup_tests(void)
         ADD_TEST_SUITE_UNPROTECTED_PVK(RSA);
 #ifndef OPENSSL_NO_RC4
         ADD_TEST_SUITE_PROTECTED_PVK(RSA);
+#endif
+
+        /*
+         * Named-group-only partial shapes for DH and EC/SM2.  Each
+         * shape is silently skipped if the algorithm is not loadable.
+         */
+#ifdef TEST_FROMDATA_NO_KEYGEN
+        ADD_TEST(test_fromdata_no_keygen);
 #endif
     }
 


### PR DESCRIPTION
EVP_PKEY_fromdata for DH/DHX accepts an empty array and yields a DH with NULL params.p / params.g.  Several DH check entry points (DH_check, DH_check_params, DH_check_pub_key) then read dh->params.p / .g via BN_num_bits or BN_is_odd before any NULL check.  Add defensive guards at the top of each that report failure via *ret without dereferencing NULL; the existing return-1-with-flags contract is preserved.

A new test_fromdata in endecode_test drives every supported keymgmt with an empty OSSL_PARAM[] for both EVP_PKEY_PUBLIC_KEY and EVP_PKEY_KEYPAIR selections, and tests that any returned key is sufficiently well behaved.

Add a parameterised dup sweep to test/endecode_test.c covering every supported public-key algorithm in three shapes: full keypair, public-only, and embryonic (parameters-only).

While here, stop endecode_test from silently passing when key generation fails: setup_tests() now returns its accumulated status, MAKE_*KEYS no longer short-circuits, and each ADD_TEST_SUITE is now conditional on keygen success.  Guard the explicit-EC-curve tests with OPENSSL_NO_EC_EXPLICIT_CURVES.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated