### PR TITLE
Fix example EB for RFC 7468 compliance

### DIFF
--- a/doc/man1/openssl-format-options.pod
+++ b/doc/man1/openssl-format-options.pod
@@ -73,11 +73,11 @@ a block of base-64 encoding (defined in IETF RFC 4648), with specific
 lines used to mark the start and end:
 
  Text before the BEGIN line is ignored.
- ----- BEGIN object-type -----
+ -----BEGIN object-type-----
  OT43gQKBgQC/2OHZoko6iRlNOAQ/tMVFNq7fL81GivoQ9F1U0Qr+DH3ZfaH8eIkX
  xT0ToMPJUzWAn8pZv0snA0um6SIgvkCuxO84OkANCVbttzXImIsL7pFzfcwV/ERK
  UM6j0ZuSMFOCr/lGPAoOQU0fskidGEHi1/kW+suSr28TqsyYZpwBDQ==
- ----- END object-type -----
+ -----END object-type-----
  Text after the END line is also ignored
 
 The I<object-type> must match the type of object that is expected.


### PR DESCRIPTION
The encapsulation boundaries as given in the example should comply to the referenced RFC 7468, as well as match other places in openssl.

First introduced in #10142.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
