### PR TITLE
asm: missing function alignment

### DIFF
--- a/crypto/aes/asm/aes-sha1-armv8.pl
+++ b/crypto/aes/asm/aes-sha1-armv8.pl
@@ -2395,6 +2395,7 @@ $code.=<<___;
 
 .global asm_sha1_hmac_aescbc_dec
 .type	asm_sha1_hmac_aescbc_dec,%function
+.align 4
 
 asm_sha1_hmac_aescbc_dec:
 	AARCH64_VALID_CALL_TARGET

--- a/crypto/aes/asm/aes-sha256-armv8.pl
+++ b/crypto/aes/asm/aes-sha256-armv8.pl
@@ -2555,6 +2555,7 @@ $code.=<<___;
 
 .global	asm_sha256_hmac_aescbc_dec
 .type	asm_sha256_hmac_aescbc_dec,%function
+.align  4
 
 asm_sha256_hmac_aescbc_dec:
 	AARCH64_VALID_CALL_TARGET


### PR DESCRIPTION
clang-22 reports missing alignment on MacOS.

ld: warning: arm64 function not 4-byte aligned: _asm_aescbc_sha1_hmac from libcrypto.a(libcrypto-lib-aes-sha1-armv8.o)
ld: warning: arm64 function not 4-byte aligned: _asm_aescbc_sha256_hmac from libcrypto.a(libcrypto-lib-aes-sha256-armv8.o)
ld: warning: arm64 function not 4-byte aligned: _asm_sha1_hmac_aescbc_dec from libcrypto.a(libcrypto-lib-aes-sha1-armv8.o)
ld: warning: arm64 function not 4-byte aligned: _asm_sha256_hmac_aescbc_dec from libcrypto.a(libcrypto-lib-aes-sha256-armv8.o)
