### PR TITLE
Fix DES_LONG alias

### DIFF
--- a/include/openssl/des.h
+++ b/include/openssl/des.h
@@ -25,7 +25,7 @@ extern "C" {
 #include <openssl/e_os2.h>
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
-typedef unsigned int DES_LONG;
+typedef uint32_t DES_LONG;
 
 #ifdef OPENSSL_BUILD_SHLIBCRYPTO
 #undef OPENSSL_EXTERN

--- a/include/openssl/des.h
+++ b/include/openssl/des.h
@@ -26,6 +26,7 @@ extern "C" {
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
 typedef unsigned int DES_LONG;
+typedef char unsigned_int_must_be_4_bytes[sizeof(unsigned int) == 4 ? 1 : -1];
 
 #ifdef OPENSSL_BUILD_SHLIBCRYPTO
 #undef OPENSSL_EXTERN


### PR DESCRIPTION
Set DES_LONG to 32bit type to accommodate the expression result

Found by Linux Verification Center (linuxtesting.org) with SVACE.