### PR TITLE
doc: update signature_dupctx usage note

### DIFF
--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -269,7 +269,6 @@ OSSL_FUNC_signature_gettable_ctx_params() functions,
 as well as the "md_params" functions.
 
 The OSSL_FUNC_signature_dupctx() function is optional.
-It is not yet used by OpenSSL.
 
 The OSSL_FUNC_signature_query_key_types() function is optional.
 When present, it should return a NULL-terminated array of strings


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
Remove the outdated statement that `OSSL_FUNC_signature_dupctx()` is not used by OpenSSL.

`EVP_DigestSignFinal()` and `EVP_DigestVerifyFinal()` may duplicate an `EVP_PKEY_CTX`.
`EVP_PKEY_CTX_dup()` uses the provider signature `dupctx` callback when available.

Documentation-only change.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
