### PR TITLE
aes_wrap: prevent crash on update without a key

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_wrp.c
+++ b/providers/implementations/ciphers/cipher_aes_wrp.c
@@ -144,6 +144,7 @@ static int aes_wrap_init(void *vctx, const unsigned char *key,
             AES_set_decrypt_key(key, (int)(keylen * 8), &wctx->ks.ks);
             ctx->block = (block128_f)AES_decrypt;
         }
+        ctx->key_set = 1;
     }
     return aes_wrap_set_ctx_params(ctx, params);
 }
@@ -215,6 +216,10 @@ static int aes_wrap_cipher_internal(void *vctx, unsigned char *out,
      */
     if (wctx->updated) {
         ERR_raise(ERR_LIB_PROV, EVP_R_UPDATE_ERROR);
+        return -1;
+    }
+    if (!ctx->key_set) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_NO_KEY_SET);
         return -1;
     }
     wctx->updated = 1;

--- a/test/aeswrap_test.c
+++ b/test/aeswrap_test.c
@@ -8,6 +8,7 @@
  */
 
 #include "testutil.h"
+#include "internal/nelem.h"
 
 /* Test that calling EVP_CipherUpdate() twice fails for AES_WRAP_PAD */
 static int aeswrap_multi_update_fail_test(void)
@@ -56,9 +57,37 @@ err:
     return ret;
 }
 
+static const char *aeswrap_null_key_ciphers[] = {
+    "AES-256-WRAP", "AES-256-WRAP-PAD", "AES-256-WRAP-INV"
+};
+
+/* Test that EVP_CipherUpdate fails after EVP_CipherInit_ex2 with NULL key */
+static int aeswrap_null_key_init_fail_test(int idx)
+{
+    int ret = 0;
+    EVP_CIPHER_CTX *ctx = NULL;
+    EVP_CIPHER *cipher = NULL;
+    uint8_t in[32] = { 0 };
+    uint8_t out[64];
+    int outlen = sizeof(in) + 8;
+
+    if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new())
+        || !TEST_ptr(cipher = EVP_CIPHER_fetch(NULL, aeswrap_null_key_ciphers[idx], NULL))
+        || !TEST_int_eq(EVP_CipherInit_ex2(ctx, cipher, NULL, NULL, 1, NULL), 1)
+        || !TEST_int_eq(EVP_CipherUpdate(ctx, out, &outlen, in, sizeof(in)), 0))
+        goto err;
+    ret = 1;
+err:
+    EVP_CIPHER_free(cipher);
+    EVP_CIPHER_CTX_free(ctx);
+    return ret;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(aeswrap_input_size_fail_test);
     ADD_TEST(aeswrap_multi_update_fail_test);
+    ADD_ALL_TESTS(aeswrap_null_key_init_fail_test,
+        OSSL_NELEM(aeswrap_null_key_ciphers));
     return 1;
 }


### PR DESCRIPTION
EVP_CipherInit_ex2 with NULL key followed by EVP_CipherUpdate on
AES-WRAP/WRAP-PAD/WRAP-INV ciphers dereferences an uninitialised
function pointer because aes_wrap_init installs ctx->block only
when a key is supplied.

Track key state in ctx->key_set, matching OCB/CCM/GCM/Poly1305,
and refuse update if no key has been installed.

##### Checklist
- [ ] documentation is added or updated
- [x] tests are added or updated