### PR TITLE
doc: fix rsa_oaep_md default digest documentation

### DIFF
--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -373,7 +373,7 @@ explicitly set in PSS mode then the signing digest is used.
 =item B<rsa_oaep_md:>I<digest>
 
 Sets the digest used for the OAEP hash function. If not explicitly set then
-SHA256 is used.
+SHA1 is used.
 
 =item B<rsa_pkcs1_implicit_rejection:>I<flag>
 


### PR DESCRIPTION
Fix the documented default value of `rsa_oaep_md` in `openssl-pkeyutl(1)`.

The manual currently states that `SHA256` is used by default, but the implementation falls back to `SHA1` when `rsa_oaep_md` is not explicitly set.

Note: SoftHSM currently supports only `SHA1`/`MGF1-SHA1` with `RSA-OAEP` encryption.

Related to: https://github.com/openssl/openssl/issues/26756

Documentation-only change.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
