### PR TITLE
non-atomic variant CRYPTO_atomic_cmp_exch_ptr() returns success/failure

### DIFF
--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -1283,10 +1283,10 @@ int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_R
         return -1;
     if (*ptr == *expect) {
         *ptr = desire;
-         ret = 1;
+        ret = 1;
     } else {
         *expect = *ptr;
-         ret = 0;
+        ret = 0;
     }
     if (!CRYPTO_THREAD_unlock(lock))
         return -1;

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -1275,14 +1275,23 @@ int CRYPTO_atomic_store_ptr(void **dst, void **val, CRYPTO_RWLOCK *lock)
 int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock)
 {
 #if defined(__GNUC__) && defined(__ATOMIC_RELAXED) && !defined(BROKEN_CLANG_ATOMICS)
-    return __atomic_compare_exchange_n(ptr, expect, desire, 0, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED) ? 1 : 0;
+    int swapped;
+    swapped = __atomic_compare_exchange_n(ptr, expect, desire, 0, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED);
+    if (swapped) {
+        *expect = desire;   /* 'return' what we wanted to store */
+    } /* leave expect intact on failure caller must retry  then */
+    /*
+     * non-atomic version function returns success of operation on lock,
+     * because there is no lock, function must always succeed.
+     */
+    return 1;
 #else
     if (lock == NULL || !CRYPTO_THREAD_write_lock(lock))
         return 0;
-    if (*ptr == *expect)
+    if (*ptr == *expect) {
         *ptr = desire;
-    else
-        *expect = *ptr;
+        *expect = desire;
+    }
     if (!CRYPTO_THREAD_unlock(lock))
         return 0;
     return 1;

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -1275,26 +1275,23 @@ int CRYPTO_atomic_store_ptr(void **dst, void **val, CRYPTO_RWLOCK *lock)
 int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock)
 {
 #if defined(__GNUC__) && defined(__ATOMIC_RELAXED) && !defined(BROKEN_CLANG_ATOMICS)
-    int swapped;
-    swapped = __atomic_compare_exchange_n(ptr, expect, desire, 0, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED);
-    if (swapped) {
-        *expect = desire;   /* 'return' what we wanted to store */
-    } /* leave expect intact on failure caller must retry  then */
-    /*
-     * non-atomic version function returns success of operation on lock,
-     * because there is no lock, function must always succeed.
-     */
-    return 1;
+    return __atomic_compare_exchange_n(ptr, expect, desire, 0, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED) ? 1 : 0;
 #else
+    int ret;
+
     if (lock == NULL || !CRYPTO_THREAD_write_lock(lock))
-        return 0;
+        return -1;
     if (*ptr == *expect) {
         *ptr = desire;
-        *expect = desire;
+         ret = 1;
+    } else {
+        *expect = *ptr;
+         ret = 0;
     }
     if (!CRYPTO_THREAD_unlock(lock))
-        return 0;
-    return 1;
+        return -1;
+
+    return ret;
 #endif
 }
 

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -769,10 +769,12 @@ int CRYPTO_atomic_store_ptr(void **dst, void **val, CRYPTO_RWLOCK *lock)
 
 int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock)
 {
-    InterlockedCompareExchangePointer(ptr, desire, *expect);
-    if (*ptr == desire)
+    void *initial;
+
+    initial = InterlockedCompareExchangePointer(ptr, desire, *expect);
+    if (initial == *expect)
         return 1;
-    *expect = *ptr;
+    *expect = initial;
     return 0;
 }
 

--- a/doc/man3/CRYPTO_THREAD_run_once.pod
+++ b/doc/man3/CRYPTO_THREAD_run_once.pod
@@ -179,9 +179,9 @@ atomic operations.
 int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock);
 
 CRYPTO_atomic_cmp_exch_ptr() atomically performs a read-modify-write operation.  If the contents of
-I<*ptr> matches the contents of I<*expect> then the value of I<desire> is stored in I<*ptr> and the
-function returns 1.  If I<*ptr> does not match the contents of I<*expect>, then the contents of
-I<*ptr> are atomically loaded to the contents of I<*expect> and the function returns 0.
+I<*ptr> matches the contents of I<*expect> then the value of I<desire> is stored in I<*ptr>
+If I<*ptr> does not match the contents of I<*expect>, then the contents of
+I<*ptr> is loaded to the contents of I<*expect> and the function returns 0.
 I<lock> will be used to emulate atomic operations on platforms that do not support
 atomic operations.
 

--- a/doc/man3/CRYPTO_THREAD_run_once.pod
+++ b/doc/man3/CRYPTO_THREAD_run_once.pod
@@ -179,11 +179,12 @@ atomic operations.
 int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock);
 
 CRYPTO_atomic_cmp_exch_ptr() atomically performs a read-modify-write operation.  If the contents of
-I<*ptr> matches the contents of I<*expect> then the value of I<desire> is stored in I<*ptr>
-If I<*ptr> does not match the contents of I<*expect>, then the contents of
-I<*ptr> is loaded to the contents of I<*expect> and the function returns 0.
+I<*ptr> matches the contents of I<*expect> then the value of I<desire> is stored in I<*ptr> and the
+function returns 1.  If I<*ptr> does not match the contents of I<*expect>, then the contents of
+I<*ptr> are atomically loaded to the contents of I<*expect> and the function returns 0.
 I<lock> will be used to emulate atomic operations on platforms that do not support
-atomic operations.
+atomic operations. On those platforms the function may return -1 to indicate error
+from acquisition (or release) operation on I<lock>.
 
 =item *
 


### PR DESCRIPTION
on lock operation, this tells nothing about the CAS (compare-and-swap) was successfull.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
