### PR TITLE
CHANGES.md: reissue session ticket on ciphersuite mismatch [master]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,10 @@ OpenSSL Releases
 
    *Jakub Zelenka*
 
+ * TLS 1.3: Fix server not sending NewSessionTicket after ciphersuite mismatch.
+
+   *Daniel Kubec*
+
  * Improved DTLS handshake robustness under UDP reordering by buffering and
    replaying early ChangeCipherSpec (CCS) records at the expected state.
 


### PR DESCRIPTION
Complements: 6115286faeb8 "TLSv1.3: reissue session ticket after full handshake on ciphersuite mismatch"
References: https://github.com/openssl/openssl/pull/30626