### PR TITLE
Fix delta CRL time-validity bypass in get_delta_sk() (RFC 5280 §5.2.4/§6.3.3)

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1648,16 +1648,23 @@ static void get_delta_sk(X509_STORE_CTX *ctx, X509_CRL **dcrl, int *pscore,
     for (i = 0; i < sk_X509_CRL_num(crls); i++) {
         delta = sk_X509_CRL_value(crls, i);
         if (check_delta_base(delta, base)) {
+            /* RFC 5280 s.5.2.4/6.3.3: a delta CRL is only current
+             * when the current time falls between its thisUpdate and
+             * nextUpdate fields.  Do not select an expired or not-yet-
+             * valid delta CRL, even if the base CRL is fresh.  Check
+             * validity before up_ref to avoid a needless refcount
+             * increment/decrement cycle for stale deltas.
+             */
+            if (!ossl_x509_check_crl_time(ctx, delta, 0))
+                continue;
+
             if (!X509_CRL_up_ref(delta)) {
                 *dcrl = NULL;
                 return;
             }
 
             *dcrl = delta;
-
-            if (ossl_x509_check_crl_time(ctx, delta, 0))
-                *pscore |= CRL_SCORE_TIME_DELTA;
-
+            *pscore |= CRL_SCORE_TIME_DELTA;
             return;
         }
     }


### PR DESCRIPTION
## Summary

Fix an expired/not-yet-valid delta CRL being accepted as current when paired with a fresh base CRL under `-use_deltas`.

## Root Cause

In `get_delta_sk()` (`crypto/x509/x509_vfy.c`), a delta CRL is selected and stored in `*dcrl` **unconditionally**, even when `ossl_x509_check_crl_time()` reports that the delta is expired or not yet valid. The time check only gates the `CRL_SCORE_TIME_DELTA` score bit; it does not prevent selection.

Later in `check_crl()` (line 2044), the delta's time validity is guarded by the base CRL's `CRL_SCORE_TIME` bit:

```c
if ((ctx->current_crl_score & CRL_SCORE_TIME) == 0
    && !ossl_x509_check_crl_time(ctx, crl, 1))
    return 0;
```

Because the **base** CRL is fresh (the common case), `CRL_SCORE_TIME` is set, the guard evaluates to false, and the delta's own expiry is **never enforced**.

## Impact

An expired or not-yet-valid delta CRL is accepted as authoritative when used with a fresh base CRL. An attacker who controls a delta CRL (e.g. by presenting a stale cached one) could replay revocation information from an old delta, causing a revoked certificate to appear as valid.

## Proof of Concept

Reported with a working PoC in issue #31297 that demonstrates:
- Expired CRL without `deltaCRLIndicator` → correctly rejected (exit 2)
- Fresh base + fresh delta → accepted (exit 0, correct)
- Fresh base + **expired delta** → **accepted (exit 0, BUG)**

## Fix

In `get_delta_sk()`, only select a delta CRL if its time validity check passes. If it fails, free the reference and continue searching:

```c
if (!ossl_x509_check_crl_time(ctx, delta, 0)) {
    X509_CRL_free(delta);
    continue;
}
*dcrl = delta;
*pscore |= CRL_SCORE_TIME_DELTA;
```

This matches RFC 5280 §5.2.4 and §6.3.3, which require that a delta CRL be current (i.e. between its `thisUpdate` and `nextUpdate`) to be used.

Fixes #31297.