### PR TITLE
Refactor BN_mod() and BN_nnmod() arguments to match documentation

### DIFF
--- a/crypto/bn/bn_mod.c
+++ b/crypto/bn/bn_mod.c
@@ -11,24 +11,24 @@
 #include "internal/nelem.h"
 #include "bn_local.h"
 
-int BN_nnmod(BIGNUM *r, const BIGNUM *m, const BIGNUM *d, BN_CTX *ctx)
+int BN_nnmod(BIGNUM *r, const BIGNUM *a, const BIGNUM *m, BN_CTX *ctx)
 {
     /*
-     * like BN_mod, but returns non-negative remainder (i.e., 0 <= r < |d|
+     * like BN_mod, but returns non-negative remainder (i.e., 0 <= r < |m|
      * always holds)
      */
 
-    if (r == d) {
+    if (r == m) {
         ERR_raise(ERR_LIB_BN, ERR_R_PASSED_INVALID_ARGUMENT);
         return 0;
     }
 
-    if (!(BN_mod(r, m, d, ctx)))
+    if (!(BN_mod(r, a, m, ctx)))
         return 0;
     if (!r->neg)
         return 1;
-    /* now   -|d| < r < 0,  so we have to set  r := r + |d| */
-    return (d->neg ? BN_sub : BN_add)(r, r, d);
+    /* now   -|m| < r < 0,  so we have to set  r := r + |m| */
+    return (m->neg ? BN_sub : BN_add)(r, r, m);
 }
 
 int BN_mod_add(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, const BIGNUM *m,

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -273,8 +273,8 @@ int BN_is_negative(const BIGNUM *b);
 
 int BN_div(BIGNUM *dv, BIGNUM *rem, const BIGNUM *m, const BIGNUM *d,
     BN_CTX *ctx);
-#define BN_mod(rem, m, d, ctx) BN_div(NULL, (rem), (m), (d), (ctx))
-int BN_nnmod(BIGNUM *r, const BIGNUM *m, const BIGNUM *d, BN_CTX *ctx);
+#define BN_mod(rem, a, m, ctx) BN_div(NULL, (rem), (a), (m), (ctx))
+int BN_nnmod(BIGNUM *r, const BIGNUM *a, const BIGNUM *m, BN_CTX *ctx);
 int BN_mod_add(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, const BIGNUM *m,
     BN_CTX *ctx);
 int BN_mod_add_quick(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,


### PR DESCRIPTION
The documentation has this signature for that function:

    int BN_mod(BIGNUM *r, const BIGNUM *a, const BIGNUM *m, BN_CTX *ctx);
    int BN_nnmod(BIGNUM *r, const BIGNUM *a, const BIGNUM *m, BN_CTX *ctx);

The implementation, however, had this signature:

    #define BN_mod(rem, m, d, ctx) BN_div(NULL, (rem), (m), (d), (ctx))
    int BN_nnmod(BIGNUM *r, const BIGNUM *m, const BIGNUM *d, BN_CTX *ctx);

That pattern alone trips up anyone who associates *m* with modulus, and
and finds themselves using `BN_nnmod()` incorrectly.

This change modifies the argument names to match documentation.
