### PR TITLE
CHANGES.md: reissue session ticket on ciphersuite mismatch [3.6]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,10 @@ OpenSSL 3.6
 
 ### Changes between 3.6.2 and 3.6.3 [xx XXX xxxx]
 
- * none yet
+ * TLS 1.3: Fix server not sending NewSessionTicket after ciphersuite mismatch.
+   <!-- https://github.com/openssl/openssl/pull/30626 -->
+
+   *Daniel Kubec*
 
 ### Changes between 3.6.1 and 3.6.2 [7 Apr 2026]
 


### PR DESCRIPTION
Complements: 7a1f7a385a "TLSv1.3: reissue session ticket after full handshake on ciphersuite mismatch"
References: #30626