### PR TITLE
CHANGES.md: reissue session ticket on ciphersuite mismatch [4.0]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,10 @@ OpenSSL Releases
 
 ### Changes between 4.0.0 and 4.0.1 [xx XXX xxxx]
 
- * none yet
+ * TLS 1.3: Fix server not sending NewSessionTicket after ciphersuite mismatch.
+   <!-- https://github.com/openssl/openssl/pull/30626 -->
+
+   *Daniel Kubec*
 
 ### Changes between 3.6 and 4.0.0 [14 Apr 2026]
 


### PR DESCRIPTION
Complements: c64fa2f3af "TLSv1.3: reissue session ticket after full handshake on ciphersuite mismatch"
References: #30626
