### PR TITLE
CHANGES.md: reissue session ticket on ciphersuite mismatch [3.5]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,10 @@ OpenSSL 3.5
 
 ### Changes between 3.5.6 and 3.5.7 [xx XXX xxxx]
 
- * none yet
+ * TLS 1.3: Fix server not sending NewSessionTicket after ciphersuite mismatch.
+   <!-- https://github.com/openssl/openssl/pull/30626 -->
+
+   *Daniel Kubec*
 
 ### Changes between 3.5.5 and 3.5.6 [7 Apr 2026]
 


### PR DESCRIPTION
Complements: 232ddedb8d "TLSv1.3: reissue session ticket after full handshake on ciphersuite mismatch"
References: #30626