### PR TITLE
crypto/evp: fix double free of tmp_keymgmt in sig/kem/asym init

### DIFF
--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -102,7 +102,9 @@ static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation,
          * iteration we're on.
          */
         EVP_ASYM_CIPHER_free(cipher);
+        cipher = NULL;
         EVP_KEYMGMT_free(tmp_keymgmt);
+        tmp_keymgmt = NULL;
 
         switch (iter) {
         case 1:

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -97,7 +97,9 @@ static int evp_kem_init(EVP_PKEY_CTX *ctx, int operation,
          * iteration we're on.
          */
         EVP_KEM_free(kem);
+        kem = NULL;
         EVP_KEYMGMT_free(tmp_keymgmt);
+        tmp_keymgmt = NULL;
 
         switch (iter) {
         case 1:

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -736,7 +736,9 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, EVP_SIGNATURE *signature,
              * iteration we're on.
              */
             EVP_SIGNATURE_free(signature);
+            signature = NULL;
             EVP_KEYMGMT_free(tmp_keymgmt);
+            tmp_keymgmt = NULL;
 
             switch (iter) {
             case 1:


### PR DESCRIPTION
Follow-up to ecb4757 (#31276), which added `tmp_keymgmt = NULL` after the in-loop `EVP_KEYMGMT_free()` in do_sigver_init() to stop a double free. The same two-iteration fetch loop in evp_kem_init(), evp_pkey_asym_cipher_init() and evp_pkey_signature_init() still lacks it: if iteration 1 fetches tmp_keymgmt but evp_pkey_export_to_provider() returns NULL without clearing it, iteration 2 frees the stale pointer at the top of the loop and the err/notsupported label frees it again.