### PR TITLE
Provide independent lock failure signal on cmp_exch_ptr

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -246,6 +246,7 @@ int RAND_set_rand_method(const RAND_METHOD *meth)
 const RAND_METHOD *RAND_get_rand_method(void)
 {
     const RAND_METHOD *tmp_meth = NULL;
+    int lock_failed;
 
     if (!RUN_ONCE(&rand_init, do_rand_init))
         goto end;
@@ -267,8 +268,12 @@ const RAND_METHOD *RAND_get_rand_method(void)
      * which we can just return as is
      */
     if (CRYPTO_atomic_cmp_exch_ptr((void **)&default_RAND_meth, (void **)&tmp_meth,
-            (void *)&ossl_rand_meth, rand_meth_lock))
+            (void *)&ossl_rand_meth, rand_meth_lock, &lock_failed)) {
         tmp_meth = &ossl_rand_meth;
+    } else {
+        if (lock_failed == 1)
+            return NULL;
+    }
 end:
     return tmp_meth;
 }

--- a/crypto/threads_none.c
+++ b/crypto/threads_none.c
@@ -299,8 +299,9 @@ int CRYPTO_atomic_store_ptr(void **dst, void **val, CRYPTO_RWLOCK *lock)
     return 1;
 }
 
-int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock)
+int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock, int *lock_failed)
 {
+    *lock_failed = 0;
     if (*ptr == *expect) {
         *ptr = desire;
         return 1;

--- a/crypto/threads_none.c
+++ b/crypto/threads_none.c
@@ -301,6 +301,11 @@ int CRYPTO_atomic_store_ptr(void **dst, void **val, CRYPTO_RWLOCK *lock)
 
 int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock, int *lock_failed)
 {
+    int lock_sink;
+
+    if (lock_failed == NULL)
+        lock_failed = &lock_sink;
+
     *lock_failed = 0;
     if (*ptr == *expect) {
         *ptr = desire;

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -1280,12 +1280,12 @@ int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_R
     return __atomic_compare_exchange_n(ptr, expect, desire, 0, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED) ? 1 : 0;
 #else
     int lock_sink;
+    int ret = 0;
 
     if (lock_failed == NULL)
         lock_failed = &lock_sink;
 
     *lock_failed = 0;
-    int ret = 0;
     if (lock == NULL || !CRYPTO_THREAD_write_lock(lock)) {
         *lock_failed = 1;
         return 0;

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -1278,18 +1278,25 @@ int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_R
     *lock_failed = 0;
     return __atomic_compare_exchange_n(ptr, expect, desire, 0, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED) ? 1 : 0;
 #else
-    *lock_failed = 1;
+    int lock_sink;
+
+    if (lock_failed == NULL)
+        lock_failed = &lock_sink;
+
+    *lock_failed = 0;
     int ret = 0;
-    if (lock == NULL || !CRYPTO_THREAD_write_lock(lock))
+    if (lock == NULL || !CRYPTO_THREAD_write_lock(lock)) {
+        *lock_failed = 1;
         return 0;
+    }
     if (*ptr == *expect) {
         ret = 1;
         *ptr = desire;
     } else {
         *expect = *ptr;
     }
-    if (CRYPTO_THREAD_unlock(lock))
-        *lock_failed = 0;
+    if (!CRYPTO_THREAD_unlock(lock))
+        *lock_failed = 1;
     return ret;
 #endif
 }

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -1275,7 +1275,8 @@ int CRYPTO_atomic_store_ptr(void **dst, void **val, CRYPTO_RWLOCK *lock)
 int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock, int *lock_failed)
 {
 #if defined(__GNUC__) && defined(__ATOMIC_RELAXED) && !defined(BROKEN_CLANG_ATOMICS)
-    *lock_failed = 0;
+    if (lock_failed != NULL)
+        *lock_failed = 0;
     return __atomic_compare_exchange_n(ptr, expect, desire, 0, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED) ? 1 : 0;
 #else
     int lock_sink;

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -1272,20 +1272,25 @@ int CRYPTO_atomic_store_ptr(void **dst, void **val, CRYPTO_RWLOCK *lock)
 #endif
 }
 
-int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock)
+int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock, int *lock_failed)
 {
 #if defined(__GNUC__) && defined(__ATOMIC_RELAXED) && !defined(BROKEN_CLANG_ATOMICS)
+    *lock_failed = 0;
     return __atomic_compare_exchange_n(ptr, expect, desire, 0, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED) ? 1 : 0;
 #else
+    *lock_failed = 1;
+    int ret = 0;
     if (lock == NULL || !CRYPTO_THREAD_write_lock(lock))
         return 0;
-    if (*ptr == *expect)
+    if (*ptr == *expect) {
+        ret = 1;
         *ptr = desire;
-    else
+    } else {
         *expect = *ptr;
-    if (!CRYPTO_THREAD_unlock(lock))
-        return 0;
-    return 1;
+    }
+    if (CRYPTO_THREAD_unlock(lock))
+        *lock_failed = 0;
+    return ret;
 #endif
 }
 

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -769,13 +769,12 @@ int CRYPTO_atomic_store_ptr(void **dst, void **val, CRYPTO_RWLOCK *lock)
 
 int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock, int *lock_failed)
 {
-    void *prev, *initial;
+    void *initial;
 
     *lock_failed = 0;
     /* Load the current pointer value */
-    prev = InterlockedCompareExchangePointer(ptr, NULL, NULL);
     initial = InterlockedCompareExchangePointer(ptr, desire, *expect);
-    if (prev == initial)
+    if (*expect == initial)
         return 1;
     *expect = initial;
     return 0;

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -767,8 +767,9 @@ int CRYPTO_atomic_store_ptr(void **dst, void **val, CRYPTO_RWLOCK *lock)
     return 1;
 }
 
-int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock)
+int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock, int *lock_failed)
 {
+    *lock_failed = 0;
     InterlockedCompareExchangePointer(ptr, desire, *expect);
     if (*ptr == desire)
         return 1;

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -769,11 +769,15 @@ int CRYPTO_atomic_store_ptr(void **dst, void **val, CRYPTO_RWLOCK *lock)
 
 int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock, int *lock_failed)
 {
+    void *prev, *initial;
+
     *lock_failed = 0;
-    InterlockedCompareExchangePointer(ptr, desire, *expect);
-    if (*ptr == desire)
+    /* Load the current pointer value */
+    prev = InterlockedCompareExchange(ptr, NULL, NULL);
+    initial = InterlockedCompareExchangePointer(ptr, desire, *expect);
+    if (prev == initial)
         return 1;
-    *expect = *ptr;
+    *expect = initial;
     return 0;
 }
 

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -770,12 +770,10 @@ int CRYPTO_atomic_store_ptr(void **dst, void **val, CRYPTO_RWLOCK *lock)
 int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock, int *lock_failed)
 {
     void *initial;
-    int lock_sink;
 
-    if (lock_failed == NULL)
-        lock_failed = &lock_sink;
+    if (lock_failed != NULL)
+        lock_failed = 0;
 
-    *lock_failed = 0;
     /* Load the current pointer value */
     initial = InterlockedCompareExchangePointer(ptr, desire, *expect);
     if (*expect == initial)

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -773,7 +773,7 @@ int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_R
 
     *lock_failed = 0;
     /* Load the current pointer value */
-    prev = InterlockedCompareExchange(ptr, NULL, NULL);
+    prev = InterlockedCompareExchangePointer(ptr, NULL, NULL);
     initial = InterlockedCompareExchangePointer(ptr, desire, *expect);
     if (prev == initial)
         return 1;

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -770,6 +770,10 @@ int CRYPTO_atomic_store_ptr(void **dst, void **val, CRYPTO_RWLOCK *lock)
 int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock, int *lock_failed)
 {
     void *initial;
+    int lock_sink;
+
+    if (lock_failed == NULL)
+        lock_failed = &lock_sink;
 
     *lock_failed = 0;
     /* Load the current pointer value */

--- a/doc/man3/CRYPTO_THREAD_run_once.pod
+++ b/doc/man3/CRYPTO_THREAD_run_once.pod
@@ -187,8 +187,9 @@ I<*ptr> are atomically loaded to the contents of I<*expect> and the function ret
 I<lock> will be used to emulate atomic operations on platforms that do not support
 atomic operations.  Note that this function contains an additional parameter I<lock_failed> which
 this function will set to 0 (to indicate the lock functioned properly), or 1 (to indicate the lock
-encountered a failure).  This allows callers to independently determine if the comparison of I<*expect>
-to I<*ptr> was true.
+encountered a failure).  This parameter allows callers to determine if a failure was caused by a
+locking error (which is generally a permanent/fatal error), or because the compare and exchange
+operation itself failed (which is a transient error indicating the need to retry the operation.
 
 =item *
 

--- a/doc/man3/CRYPTO_THREAD_run_once.pod
+++ b/doc/man3/CRYPTO_THREAD_run_once.pod
@@ -39,7 +39,8 @@ OSSL_THREAD_SUPPORT_FLAG_DEFAULT_SPAWN - OpenSSL thread support
  int CRYPTO_atomic_store_int(int *dst, int val, CRYPTO_RWLOCK *lock);
  int CRYPTO_atomic_load_ptr(void **ptr, void **ret, CRYPTO_RWLOCK *lock);
  int CRYPTO_atomic_store_ptr(void **dst, void **val, CRYPTO_RWLOCK *lock);
- int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock);
+ int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock,
+                                int *lock_failed);
 
  int OSSL_set_max_threads(OSSL_LIB_CTX *ctx, uint64_t max_threads);
  uint64_t OSSL_get_max_threads(OSSL_LIB_CTX *ctx);
@@ -176,14 +177,18 @@ atomic operations.
 
 =item *
 
-int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock);
+int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock,
+                               int *lock_failed);
 
 CRYPTO_atomic_cmp_exch_ptr() atomically performs a read-modify-write operation.  If the contents of
 I<*ptr> matches the contents of I<*expect> then the value of I<desire> is stored in I<*ptr> and the
 function returns 1.  If I<*ptr> does not match the contents of I<*expect>, then the contents of
 I<*ptr> are atomically loaded to the contents of I<*expect> and the function returns 0.
 I<lock> will be used to emulate atomic operations on platforms that do not support
-atomic operations.
+atomic operations.  Note that this function contains an additional parameter I<lock_failed> which
+this function will set to 0 (to indicate the lock functioned properly), or 1 (to indicate the lock
+encountered a failure).  This allows callers to independently determine if the comparison of I<*expect>
+to I<*ptr> was true.
 
 =item *
 

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -100,7 +100,8 @@ int CRYPTO_atomic_store(uint64_t *dst, uint64_t val, CRYPTO_RWLOCK *lock);
 int CRYPTO_atomic_store_int(int *dst, int val, CRYPTO_RWLOCK *lock);
 int CRYPTO_atomic_load_ptr(void **ptr, void **ret, CRYPTO_RWLOCK *lock);
 int CRYPTO_atomic_store_ptr(void **dst, void **val, CRYPTO_RWLOCK *lock);
-int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock);
+int CRYPTO_atomic_cmp_exch_ptr(void **ptr, void **expect, void *desire, CRYPTO_RWLOCK *lock,
+    int *lock_failed);
 
 /* No longer needed, so this is a no-op */
 #define OPENSSL_malloc_init() \


### PR DESCRIPTION
Our CRYPTO atomic api has a somewhat consistent problem in that its possible in the case where locking fails to return an error while the actual operation (store_int, store_ptr, etc), actually succeded. cmp_exch is somewhat special here in that we may really need to know independently if the function failed due to lock failure and if the exchange occured (so we can know the output value of *expect).  Add a separate parameter to allow callers to be informed of these statuses independently.


##### Checklist
- [x] documentation is added or updated

