### PR TITLE
Fix missing function alignment for arm

### DIFF
--- a/crypto/aes/asm/aes-sha1-armv8.pl
+++ b/crypto/aes/asm/aes-sha1-armv8.pl
@@ -226,6 +226,7 @@ $code.=<<___;
 	.word	0xca62c1d6, 0xca62c1d6, 0xca62c1d6, 0xca62c1d6
 .text
 
+.align	4
 asm_aescbc_sha1_hmac:
 	AARCH64_VALID_CALL_TARGET
 	/* protect registers */

--- a/crypto/armv4cpuid.pl
+++ b/crypto/armv4cpuid.pl
@@ -73,6 +73,7 @@ OPENSSL_atomic_add:
 
 .global	OPENSSL_cleanse
 .type	OPENSSL_cleanse,%function
+.align	5
 OPENSSL_cleanse:
 	eor	ip,ip,ip
 	cmp	r1,#7
@@ -112,7 +113,7 @@ OPENSSL_cleanse:
 
 .global	CRYPTO_memcmp
 .type	CRYPTO_memcmp,%function
-.align	4
+.align	5
 CRYPTO_memcmp:
 	eor	ip,ip,ip
 	cmp	r2,#0
@@ -154,6 +155,7 @@ _armv7_neon_probe:
 
 .global	_armv7_tick
 .type	_armv7_tick,%function
+.align	5
 _armv7_tick:
 #ifdef	__APPLE__
 	mrrc	p15,0,r0,r1,c14		@ CNTPCT
@@ -165,6 +167,7 @@ _armv7_tick:
 
 .global	_armv8_aes_probe
 .type	_armv8_aes_probe,%function
+.align	5
 _armv8_aes_probe:
 #if defined(__thumb2__) && !defined(__APPLE__)
 	.byte	0xb0,0xff,0x00,0x03	@ aese.8	q0,q0
@@ -176,6 +179,7 @@ _armv8_aes_probe:
 
 .global	_armv8_sha1_probe
 .type	_armv8_sha1_probe,%function
+.align	5
 _armv8_sha1_probe:
 #if defined(__thumb2__) && !defined(__APPLE__)
 	.byte	0x00,0xef,0x40,0x0c	@ sha1c.32	q0,q0,q0
@@ -187,6 +191,7 @@ _armv8_sha1_probe:
 
 .global	_armv8_sha256_probe
 .type	_armv8_sha256_probe,%function
+.align	5
 _armv8_sha256_probe:
 #if defined(__thumb2__) && !defined(__APPLE__)
 	.byte	0x00,0xff,0x40,0x0c	@ sha256h.32	q0,q0,q0
@@ -197,6 +202,7 @@ _armv8_sha256_probe:
 .size	_armv8_sha256_probe,.-_armv8_sha256_probe
 .global	_armv8_pmull_probe
 .type	_armv8_pmull_probe,%function
+.align	5
 _armv8_pmull_probe:
 #if defined(__thumb2__) && !defined(__APPLE__)
 	.byte	0xa0,0xef,0x00,0x0e	@ vmull.p64	q0,d0,d0
@@ -209,6 +215,7 @@ _armv8_pmull_probe:
 
 .global	OPENSSL_instrument_bus
 .type	OPENSSL_instrument_bus,%function
+.align	5
 OPENSSL_instrument_bus:
 	eor	r0,r0,r0
 #if __ARM_ARCH__>=5
@@ -222,6 +229,7 @@ OPENSSL_instrument_bus:
 
 .global	OPENSSL_instrument_bus2
 .type	OPENSSL_instrument_bus2,%function
+.align	5
 OPENSSL_instrument_bus2:
 	eor	r0,r0,r0
 #if __ARM_ARCH__>=5

--- a/crypto/modes/asm/ghash-armv4.pl
+++ b/crypto/modes/asm/ghash-armv4.pl
@@ -296,6 +296,7 @@ $code.=<<___;
 
 .global	gcm_gmult_4bit
 .type	gcm_gmult_4bit,%function
+.align	4
 gcm_gmult_4bit:
 	stmdb	sp!,{r4-r11,lr}
 	ldrb	$nlo,[$Xi,#15]

--- a/crypto/sha/asm/sha512-armv4.pl
+++ b/crypto/sha/asm/sha512-armv4.pl
@@ -291,6 +291,7 @@ WORD64(0x5fcb6fab,0x3ad6faec, 0x6c44198c,0x4a475817)
 
 .global	sha512_block_data_order
 .type	sha512_block_data_order,%function
+.align 5
 sha512_block_data_order:
 .Lsha512_block_data_order:
 #if __ARM_ARCH__<7 && !defined(__thumb2__)


### PR DESCRIPTION
Apart from adding function alignment, there are two changes that move K256/K512 from .text to .rodata.