### PR TITLE
Add utility APIs for HPKE suite introspection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -87,6 +87,11 @@ OpenSSL Releases
 
    *Jakub Zelenka*
 
+ * Added `OSSL_HPKE_get_suite()`, `OSSL_HPKE_get_public_key_size()`,
+   `OSSL_HPKE_mode_is_supported()`, and `OSSL_HPKE_suite2str()` functions.
+
+   *Shivam Kumar*
+
  * Added support for Ed25519 and Ed448 certificates in DTLS 1.2. Previously,
    these certificate types were only supported in TLS 1.2 and TLS 1.3.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -181,6 +181,11 @@ OpenSSL 4.1
 
    *Mounir IDRASSI*
 
+ * Added `OSSL_HPKE_get_suite()`, `OSSL_HPKE_get_public_key_size()`,
+   `OSSL_HPKE_mode_is_supported()`, and `OSSL_HPKE_suite2str()` functions.
+
+   *Shivam Kumar*
+
  * Added support for Ed25519 and Ed448 certificates in DTLS 1.2. Previously,
    these certificate types were only supported in TLS 1.2 and TLS 1.3.
 

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -143,4 +143,5 @@ ENDIF
 
 IF[{- $target{needs_c99_snprintf_compat} -}]
   SOURCE[../libcrypto]=msvc2013_snprintf.c
+  SOURCE[../providers/libfips.a]=msvc2013_snprintf.c
 ENDIF

--- a/crypto/hpke/hpke.c
+++ b/crypto/hpke/hpke.c
@@ -1476,3 +1476,47 @@ size_t OSSL_HPKE_get_recommended_ikmelen(OSSL_HPKE_SUITE suite)
 
     return kem_info->Nsk;
 }
+
+OSSL_HPKE_SUITE OSSL_HPKE_get_suite(const OSSL_HPKE_CTX *ctx)
+{
+    OSSL_HPKE_SUITE rv = { OSSL_HPKE_KEM_ID_RESERVED,
+        OSSL_HPKE_KDF_ID_RESERVED, OSSL_HPKE_AEAD_ID_RESERVED };
+
+    if (ctx == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
+        return rv;
+    }
+    return ctx->suite;
+}
+
+size_t OSSL_HPKE_get_public_key_size(OSSL_HPKE_SUITE suite)
+{
+    const OSSL_HPKE_KEM_INFO *kem_info = NULL;
+
+    if (hpke_suite_check(suite, &kem_info, NULL, NULL) != 1)
+        return 0;
+    if (kem_info == NULL)
+        return 0;
+
+    return kem_info->Npk;
+}
+
+int OSSL_HPKE_mode_is_supported(OSSL_HPKE_SUITE suite, int mode)
+{
+    if (hpke_mode_check(mode) != 1)
+        return 0;
+    if (hpke_suite_check(suite, NULL, NULL, NULL) != 1)
+        return 0;
+    /*
+     * All DHKEM-based KEMs support AuthEncap/AuthDecap, so all four
+     * modes (BASE, PSK, AUTH, PSKAUTH) are supported for all current
+     * KEMs. If a KEM is added in the future that does not support
+     * authenticated modes, this function should be updated.
+     */
+    return 1;
+}
+
+char *OSSL_HPKE_suite2str(OSSL_HPKE_SUITE suite)
+{
+    return ossl_hpke_suite2str(suite);
+}

--- a/crypto/hpke/hpke_util.c
+++ b/crypto/hpke/hpke_util.c
@@ -14,6 +14,7 @@
 #include <openssl/err.h>
 #include <openssl/proverr.h>
 #include <openssl/hpke.h>
+#include <openssl/bio.h>
 #include <openssl/sha.h>
 #include <openssl/rand.h>
 #include "crypto/ecx.h"
@@ -439,6 +440,57 @@ static uint16_t synonyms_name2id(const char *st, const synonymttab_t *synp,
         }
     }
     return 0;
+}
+
+/*
+ * @brief look for an id in the synonym tables, and return its name
+ * @param id is the id to look for
+ * @param synp is the synonyms labels array
+ * @param arrsize is the previous array size
+ * @return NULL when not found, else the canonical name string
+ */
+static const char *synonyms_id2name(uint16_t id, const synonymttab_t *synp,
+    size_t arrsize)
+{
+    size_t i;
+
+    for (i = 0; i < arrsize; ++i) {
+        if (synp[i].id == id)
+            return synp[i].synonyms[0];
+    }
+    return NULL;
+}
+
+/*
+ * @brief map a HPKE suite to a string based on synonym tables
+ * @param suite is the suite to convert
+ * @return a newly allocated string or NULL on failure
+ *
+ * The caller must OPENSSL_free() the returned string.
+ */
+char *ossl_hpke_suite2str(OSSL_HPKE_SUITE suite)
+{
+    const char *kemstr, *kdfstr, *aeadstr;
+    char *ret = NULL;
+    size_t len;
+
+    kemstr = synonyms_id2name(suite.kem_id, kemstrtab,
+        OSSL_NELEM(kemstrtab));
+    kdfstr = synonyms_id2name(suite.kdf_id, kdfstrtab,
+        OSSL_NELEM(kdfstrtab));
+    aeadstr = synonyms_id2name(suite.aead_id, aeadstrtab,
+        OSSL_NELEM(aeadstrtab));
+    if (kemstr == NULL || kdfstr == NULL || aeadstr == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT);
+        return NULL;
+    }
+    /* "KEM,KDF,AEAD" + NUL */
+    len = strlen(kemstr) + 1 + strlen(kdfstr) + 1 + strlen(aeadstr) + 1;
+    ret = OPENSSL_malloc(len);
+    if (ret == NULL)
+        return NULL;
+    BIO_snprintf(ret, len, "%s,%s,%s", kemstr, kdfstr, aeadstr);
+    return ret;
 }
 
 /*

--- a/crypto/hpke/hpke_util.c
+++ b/crypto/hpke/hpke_util.c
@@ -14,7 +14,6 @@
 #include <openssl/err.h>
 #include <openssl/proverr.h>
 #include <openssl/hpke.h>
-#include <openssl/bio.h>
 #include <openssl/sha.h>
 #include <openssl/rand.h>
 #include "crypto/ecx.h"
@@ -489,7 +488,7 @@ char *ossl_hpke_suite2str(OSSL_HPKE_SUITE suite)
     ret = OPENSSL_malloc(len);
     if (ret == NULL)
         return NULL;
-    BIO_snprintf(ret, len, "%s,%s,%s", kemstr, kdfstr, aeadstr);
+    snprintf(ret, len, "%s,%s,%s", kemstr, kdfstr, aeadstr);
     return ret;
 }
 

--- a/doc/man3/OSSL_HPKE_CTX_new.pod
+++ b/doc/man3/OSSL_HPKE_CTX_new.pod
@@ -9,6 +9,8 @@ OSSL_HPKE_suite_check, OSSL_HPKE_str2suite,
 OSSL_HPKE_keygen, OSSL_HPKE_get_grease_value,
 OSSL_HPKE_get_ciphertext_size, OSSL_HPKE_get_public_encap_size,
 OSSL_HPKE_get_recommended_ikmelen,
+OSSL_HPKE_get_suite, OSSL_HPKE_get_public_key_size,
+OSSL_HPKE_mode_is_supported, OSSL_HPKE_suite2str,
 OSSL_HPKE_CTX_set1_psk, OSSL_HPKE_CTX_set1_ikme,
 OSSL_HPKE_CTX_set1_authpriv, OSSL_HPKE_CTX_set1_authpub,
 OSSL_HPKE_CTX_get_seq, OSSL_HPKE_CTX_set_seq
@@ -75,9 +77,13 @@ OSSL_HPKE_CTX_get_seq, OSSL_HPKE_CTX_set_seq
                                 OSSL_LIB_CTX *libctx, const char *propq);
 
  int OSSL_HPKE_str2suite(const char *str, OSSL_HPKE_SUITE *suite);
+ char *OSSL_HPKE_suite2str(OSSL_HPKE_SUITE suite);
  size_t OSSL_HPKE_get_ciphertext_size(OSSL_HPKE_SUITE suite, size_t clearlen);
  size_t OSSL_HPKE_get_public_encap_size(OSSL_HPKE_SUITE suite);
  size_t OSSL_HPKE_get_recommended_ikmelen(OSSL_HPKE_SUITE suite);
+ OSSL_HPKE_SUITE OSSL_HPKE_get_suite(const OSSL_HPKE_CTX *ctx);
+ size_t OSSL_HPKE_get_public_key_size(OSSL_HPKE_SUITE suite);
+ int OSSL_HPKE_mode_is_supported(OSSL_HPKE_SUITE suite, int mode);
 
 =head1 DESCRIPTION
 
@@ -460,13 +466,44 @@ codepoints. Valid (case-insensitive) names are:
 String variants of the numbers listed in L</OSSL_HPKE_SUITE Identifiers>
 can also be used.
 
+OSSL_HPKE_suite2str() is the inverse of OSSL_HPKE_str2suite(). It takes an
+B<OSSL_HPKE_SUITE> I<suite> and returns a newly allocated string in the format
+"KEM,KDF,AEAD" using the canonical names for each component (e.g.,
+"X25519,hkdf-sha256,aes-128-gcm"). The caller must free the returned string
+using OPENSSL_free(3). Returns NULL on error.
+
+OSSL_HPKE_get_suite() retrieves the B<OSSL_HPKE_SUITE> associated with an
+existing B<OSSL_HPKE_CTX> I<ctx>. This allows callers to recover the suite
+from a context without separately tracking it after context creation.
+If I<ctx> is NULL, a zeroed suite with reserved identifiers is returned and an
+error is raised.
+
+OSSL_HPKE_get_public_key_size() returns the public key size (Npk) for the
+KEM identified by the I<suite>. Note that this returns the KEM public key size,
+which may differ from the encapsulated key size (Nenc) returned by
+OSSL_HPKE_get_public_encap_size() for some KEMs (e.g., hybrid KEMs).
+
+OSSL_HPKE_mode_is_supported() checks whether a given HPKE I<mode> is supported
+for the specified I<suite>. This can be used to determine whether authenticated
+modes (B<OSSL_HPKE_MODE_AUTH> and B<OSSL_HPKE_MODE_PSKAUTH>) are available
+for a particular KEM, since not all KEMs support AuthEncap/AuthDecap.
+
 =head1 RETURN VALUES
 
 OSSL_HPKE_CTX_new() returns an OSSL_HPKE_CTX pointer or NULL on error.
 
 OSSL_HPKE_get_ciphertext_size(), OSSL_HPKE_get_public_encap_size(),
-OSSL_HPKE_get_recommended_ikmelen() all return a size_t with the
-relevant value or zero on error.
+OSSL_HPKE_get_recommended_ikmelen() and OSSL_HPKE_get_public_key_size() all
+return a size_t with the relevant value or zero on error.
+
+OSSL_HPKE_get_suite() returns an B<OSSL_HPKE_SUITE>. If I<ctx> is NULL, the
+returned suite will contain reserved (zero) identifiers.
+
+OSSL_HPKE_suite2str() returns a newly allocated string that must be freed
+by the caller using OPENSSL_free(3), or NULL on error.
+
+OSSL_HPKE_mode_is_supported() returns 1 if the mode is supported for the
+given suite, or 0 otherwise.
 
 All other functions return 1 for success or zero for error.
 
@@ -563,6 +600,10 @@ The RFC9180 specification: https://datatracker.ietf.org/doc/rfc9180/
 =head1 HISTORY
 
 This functionality described here was added in OpenSSL 3.2.
+
+OSSL_HPKE_get_suite(), OSSL_HPKE_get_public_key_size(),
+OSSL_HPKE_mode_is_supported() and OSSL_HPKE_suite2str() were added in
+OpenSSL 4.1.
 
 =head1 COPYRIGHT
 

--- a/include/internal/hpke_util.h
+++ b/include/internal/hpke_util.h
@@ -102,4 +102,5 @@ EVP_KDF_CTX *ossl_kdf_ctx_create(const char *kdfname, const char *mdname,
     OSSL_LIB_CTX *libctx, const char *propq);
 
 int ossl_hpke_str2suite(const char *suitestr, OSSL_HPKE_SUITE *suite);
+char *ossl_hpke_suite2str(OSSL_HPKE_SUITE suite);
 #endif

--- a/include/openssl/hpke.h
+++ b/include/openssl/hpke.h
@@ -162,6 +162,11 @@ size_t OSSL_HPKE_get_ciphertext_size(OSSL_HPKE_SUITE suite, size_t clearlen);
 size_t OSSL_HPKE_get_public_encap_size(OSSL_HPKE_SUITE suite);
 size_t OSSL_HPKE_get_recommended_ikmelen(OSSL_HPKE_SUITE suite);
 
+OSSL_HPKE_SUITE OSSL_HPKE_get_suite(const OSSL_HPKE_CTX *ctx);
+size_t OSSL_HPKE_get_public_key_size(OSSL_HPKE_SUITE suite);
+int OSSL_HPKE_mode_is_supported(OSSL_HPKE_SUITE suite, int mode);
+char *OSSL_HPKE_suite2str(OSSL_HPKE_SUITE suite);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/hpke_test.c
+++ b/test/hpke_test.c
@@ -1181,10 +1181,10 @@ end:
 static int test_hpke_suite_strs(void)
 {
     int overallresult = 1;
-    int kemind = 0;
-    int kdfind = 0;
-    int aeadind = 0;
-    int sind = 0;
+    size_t kemind = 0;
+    size_t kdfind = 0;
+    size_t aeadind = 0;
+    size_t sind = 0;
     char sstr[128];
     OSSL_HPKE_SUITE stirred;
     char giant[2048];
@@ -1211,7 +1211,7 @@ static int test_hpke_suite_strs(void)
                 &stirred))) {
             if (verbose)
                 TEST_note("OSSL_HPKE_str2suite didn't fail for bogus[%d]:%s",
-                    sind, bogus_suite_strs[sind]);
+                    (int)sind, bogus_suite_strs[sind]);
             overallresult = 0;
         }
     }
@@ -2062,7 +2062,6 @@ end:
     OSSL_HPKE_CTX_free(rctx);
     return erv;
 }
-
 
 typedef enum OPTION_choice {
     OPT_ERR = -1,

--- a/test/hpke_test.c
+++ b/test/hpke_test.c
@@ -1188,6 +1188,9 @@ static int test_hpke_suite_strs(void)
     char sstr[128];
     OSSL_HPKE_SUITE stirred;
     char giant[2048];
+    OSSL_HPKE_SUITE suite;
+    char *suitestr = NULL;
+    OSSL_HPKE_SUITE bad_suite = { 0xbad, 0xbad, 0xbad };
 
     for (kemind = 0; kemind != OSSL_NELEM(kem_str_list); kemind++) {
         for (kdfind = 0; kdfind != OSSL_NELEM(kdf_str_list); kdfind++) {
@@ -1223,6 +1226,64 @@ static int test_hpke_suite_strs(void)
     giant[sizeof(giant) - 1] = '\0';
     if (!TEST_false(OSSL_HPKE_str2suite(giant, &stirred)))
         overallresult = 0;
+
+    /* Test OSSL_HPKE_suite2str with bad suite */
+    suitestr = OSSL_HPKE_suite2str(bad_suite);
+    if (!TEST_ptr_null(suitestr))
+        overallresult = 0;
+    OPENSSL_free(suitestr);
+    suitestr = NULL;
+
+    /* Test OSSL_HPKE_suite2str round-trip for all valid suites */
+    for (kemind = 0; kemind < OSSL_NELEM(hpke_kem_list); kemind++) {
+        for (kdfind = 0; kdfind < OSSL_NELEM(hpke_kdf_list); kdfind++) {
+            for (aeadind = 0; aeadind < OSSL_NELEM(hpke_aead_list); aeadind++) {
+                OSSL_HPKE_SUITE roundtrip;
+
+                suite.kem_id = hpke_kem_list[kemind];
+                suite.kdf_id = hpke_kdf_list[kdfind];
+                suite.aead_id = hpke_aead_list[aeadind];
+
+                suitestr = OSSL_HPKE_suite2str(suite);
+                if (!TEST_ptr(suitestr)) {
+                    overallresult = 0;
+                    continue;
+                }
+                /* round-trip: str2suite should recover the original suite */
+                if (!TEST_true(OSSL_HPKE_str2suite(suitestr, &roundtrip))) {
+                    overallresult = 0;
+                    OPENSSL_free(suitestr);
+                    suitestr = NULL;
+                    continue;
+                }
+                if (!TEST_uint_eq(roundtrip.kem_id, suite.kem_id)
+                    || !TEST_uint_eq(roundtrip.kdf_id, suite.kdf_id)
+                    || !TEST_uint_eq(roundtrip.aead_id, suite.aead_id)) {
+                    overallresult = 0;
+                }
+                OPENSSL_free(suitestr);
+                suitestr = NULL;
+            }
+        }
+    }
+
+    /* Test OSSL_HPKE_suite2str with export-only AEAD */
+    suite.kem_id = OSSL_HPKE_KEM_ID_P256;
+    suite.kdf_id = OSSL_HPKE_KDF_ID_HKDF_SHA256;
+    suite.aead_id = OSSL_HPKE_AEAD_ID_EXPORTONLY;
+    suitestr = OSSL_HPKE_suite2str(suite);
+    if (!TEST_ptr(suitestr))
+        overallresult = 0;
+    if (suitestr != NULL) {
+        OSSL_HPKE_SUITE roundtrip;
+
+        if (!TEST_true(OSSL_HPKE_str2suite(suitestr, &roundtrip)))
+            overallresult = 0;
+        else if (!TEST_uint_eq(roundtrip.aead_id, OSSL_HPKE_AEAD_ID_EXPORTONLY))
+            overallresult = 0;
+    }
+    OPENSSL_free(suitestr);
+    suitestr = NULL;
 
     return overallresult;
 }
@@ -1306,6 +1367,8 @@ static int test_hpke_oddcalls(void)
     uint64_t lseq = 0;
     char giant_pskid[OSSL_HPKE_MAX_PARMLEN + 10];
     unsigned char info[OSSL_HPKE_TSTSIZE];
+    OSSL_HPKE_SUITE suite, retrieved;
+    size_t kemind, kdfind, aeadind, mind;
 
     /* many of the calls below are designed to get better test coverage */
 
@@ -1342,6 +1405,84 @@ static int test_hpke_oddcalls(void)
         goto end;
     if (!TEST_false(OSSL_HPKE_keygen(bad_suite, pub, &publen, &privp,
             NULL, 0, testctx, NULL)))
+        goto end;
+
+    /* Test OSSL_HPKE_get_suite with NULL ctx */
+    retrieved = OSSL_HPKE_get_suite(NULL);
+    if (!TEST_uint_eq(retrieved.kem_id, OSSL_HPKE_KEM_ID_RESERVED)
+        || !TEST_uint_eq(retrieved.kdf_id, OSSL_HPKE_KDF_ID_RESERVED)
+        || !TEST_uint_eq(retrieved.aead_id, OSSL_HPKE_AEAD_ID_RESERVED))
+        goto end;
+
+    /* Test OSSL_HPKE_get_suite with valid context for each suite combo */
+    for (kemind = 0; kemind < OSSL_NELEM(hpke_kem_list); kemind++) {
+        for (kdfind = 0; kdfind < OSSL_NELEM(hpke_kdf_list); kdfind++) {
+            for (aeadind = 0; aeadind < OSSL_NELEM(hpke_aead_list); aeadind++) {
+                suite.kem_id = hpke_kem_list[kemind];
+                suite.kdf_id = hpke_kdf_list[kdfind];
+                suite.aead_id = hpke_aead_list[aeadind];
+
+                ctx = OSSL_HPKE_CTX_new(OSSL_HPKE_MODE_BASE, suite,
+                    OSSL_HPKE_ROLE_SENDER, testctx, NULL);
+                if (!TEST_ptr(ctx))
+                    goto end;
+                retrieved = OSSL_HPKE_get_suite(ctx);
+                if (!TEST_uint_eq(retrieved.kem_id, suite.kem_id)
+                    || !TEST_uint_eq(retrieved.kdf_id, suite.kdf_id)
+                    || !TEST_uint_eq(retrieved.aead_id, suite.aead_id))
+                    goto end;
+                OSSL_HPKE_CTX_free(ctx);
+                ctx = NULL;
+            }
+        }
+    }
+
+    /* Test OSSL_HPKE_get_public_key_size - known values */
+    suite.kdf_id = OSSL_HPKE_KDF_ID_HKDF_SHA256;
+    suite.aead_id = OSSL_HPKE_AEAD_ID_AES_GCM_128;
+
+    suite.kem_id = OSSL_HPKE_KEM_ID_P256;
+    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 65))
+        goto end;
+    suite.kem_id = OSSL_HPKE_KEM_ID_P384;
+    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 97))
+        goto end;
+    suite.kem_id = OSSL_HPKE_KEM_ID_P521;
+    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 133))
+        goto end;
+#ifndef OPENSSL_NO_ECX
+    suite.kem_id = OSSL_HPKE_KEM_ID_X25519;
+    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 32))
+        goto end;
+    suite.kem_id = OSSL_HPKE_KEM_ID_X448;
+    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 56))
+        goto end;
+#endif
+
+    /* Test OSSL_HPKE_get_public_key_size with bad suite */
+    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(bad_suite), 0))
+        goto end;
+
+    /* Test OSSL_HPKE_mode_is_supported - all modes for all suites */
+    for (kemind = 0; kemind < OSSL_NELEM(hpke_kem_list); kemind++) {
+        suite.kem_id = hpke_kem_list[kemind];
+        suite.kdf_id = OSSL_HPKE_KDF_ID_HKDF_SHA256;
+        suite.aead_id = OSSL_HPKE_AEAD_ID_AES_GCM_128;
+        for (mind = 0; mind < OSSL_NELEM(hpke_mode_list); mind++) {
+            if (!TEST_true(OSSL_HPKE_mode_is_supported(suite,
+                    hpke_mode_list[mind])))
+                goto end;
+        }
+    }
+
+    /* Test OSSL_HPKE_mode_is_supported with bad mode */
+    suite.kem_id = OSSL_HPKE_KEM_ID_P256;
+    if (!TEST_false(OSSL_HPKE_mode_is_supported(suite, bad_mode)))
+        goto end;
+
+    /* Test OSSL_HPKE_mode_is_supported with bad suite */
+    if (!TEST_false(OSSL_HPKE_mode_is_supported(bad_suite,
+            OSSL_HPKE_MODE_BASE)))
         goto end;
 
     /* dodgy keygen calls */
@@ -1922,162 +2063,6 @@ end:
     return erv;
 }
 
-/*
- * Test the new APIs: OSSL_HPKE_get_suite, OSSL_HPKE_get_public_key_size,
- * OSSL_HPKE_mode_is_supported, OSSL_HPKE_suite2str
- */
-static int test_hpke_new_apis(void)
-{
-    int overallresult = 1;
-    OSSL_HPKE_CTX *ctx = NULL;
-    OSSL_HPKE_SUITE suite, retrieved;
-    OSSL_HPKE_SUITE bad_suite = { 0xbad, 0xbad, 0xbad };
-    char *suitestr = NULL;
-    size_t kemind, kdfind, aeadind, mind;
-
-    /* Test OSSL_HPKE_get_suite with NULL ctx */
-    retrieved = OSSL_HPKE_get_suite(NULL);
-    if (!TEST_uint_eq(retrieved.kem_id, OSSL_HPKE_KEM_ID_RESERVED)
-        || !TEST_uint_eq(retrieved.kdf_id, OSSL_HPKE_KDF_ID_RESERVED)
-        || !TEST_uint_eq(retrieved.aead_id, OSSL_HPKE_AEAD_ID_RESERVED)) {
-        overallresult = 0;
-    }
-
-    /* Test OSSL_HPKE_get_suite with valid context for each suite combo */
-    for (kemind = 0; kemind < OSSL_NELEM(hpke_kem_list); kemind++) {
-        for (kdfind = 0; kdfind < OSSL_NELEM(hpke_kdf_list); kdfind++) {
-            for (aeadind = 0; aeadind < OSSL_NELEM(hpke_aead_list); aeadind++) {
-                suite.kem_id = hpke_kem_list[kemind];
-                suite.kdf_id = hpke_kdf_list[kdfind];
-                suite.aead_id = hpke_aead_list[aeadind];
-
-                ctx = OSSL_HPKE_CTX_new(OSSL_HPKE_MODE_BASE, suite,
-                    OSSL_HPKE_ROLE_SENDER, testctx, NULL);
-                if (!TEST_ptr(ctx)) {
-                    overallresult = 0;
-                    continue;
-                }
-                retrieved = OSSL_HPKE_get_suite(ctx);
-                if (!TEST_uint_eq(retrieved.kem_id, suite.kem_id)
-                    || !TEST_uint_eq(retrieved.kdf_id, suite.kdf_id)
-                    || !TEST_uint_eq(retrieved.aead_id, suite.aead_id)) {
-                    overallresult = 0;
-                }
-                OSSL_HPKE_CTX_free(ctx);
-                ctx = NULL;
-            }
-        }
-    }
-
-    /* Test OSSL_HPKE_get_public_key_size - known values */
-    suite.kdf_id = OSSL_HPKE_KDF_ID_HKDF_SHA256;
-    suite.aead_id = OSSL_HPKE_AEAD_ID_AES_GCM_128;
-
-    suite.kem_id = OSSL_HPKE_KEM_ID_P256;
-    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 65))
-        overallresult = 0;
-    suite.kem_id = OSSL_HPKE_KEM_ID_P384;
-    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 97))
-        overallresult = 0;
-    suite.kem_id = OSSL_HPKE_KEM_ID_P521;
-    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 133))
-        overallresult = 0;
-#ifndef OPENSSL_NO_ECX
-    suite.kem_id = OSSL_HPKE_KEM_ID_X25519;
-    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 32))
-        overallresult = 0;
-    suite.kem_id = OSSL_HPKE_KEM_ID_X448;
-    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 56))
-        overallresult = 0;
-#endif
-
-    /* Test OSSL_HPKE_get_public_key_size with bad suite */
-    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(bad_suite), 0))
-        overallresult = 0;
-
-    /* Test OSSL_HPKE_mode_is_supported - all modes for all suites */
-    for (kemind = 0; kemind < OSSL_NELEM(hpke_kem_list); kemind++) {
-        suite.kem_id = hpke_kem_list[kemind];
-        suite.kdf_id = OSSL_HPKE_KDF_ID_HKDF_SHA256;
-        suite.aead_id = OSSL_HPKE_AEAD_ID_AES_GCM_128;
-        for (mind = 0; mind < OSSL_NELEM(hpke_mode_list); mind++) {
-            if (!TEST_true(OSSL_HPKE_mode_is_supported(suite,
-                    hpke_mode_list[mind]))) {
-                overallresult = 0;
-            }
-        }
-    }
-
-    /* Test OSSL_HPKE_mode_is_supported with bad mode */
-    suite.kem_id = OSSL_HPKE_KEM_ID_P256;
-    if (!TEST_false(OSSL_HPKE_mode_is_supported(suite, 0xbad)))
-        overallresult = 0;
-
-    /* Test OSSL_HPKE_mode_is_supported with bad suite */
-    if (!TEST_false(OSSL_HPKE_mode_is_supported(bad_suite,
-            OSSL_HPKE_MODE_BASE)))
-        overallresult = 0;
-
-    /* Test OSSL_HPKE_suite2str with bad suite */
-    suitestr = OSSL_HPKE_suite2str(bad_suite);
-    if (!TEST_ptr_null(suitestr))
-        overallresult = 0;
-    OPENSSL_free(suitestr);
-    suitestr = NULL;
-
-    /* Test OSSL_HPKE_suite2str round-trip for all valid suites */
-    for (kemind = 0; kemind < OSSL_NELEM(hpke_kem_list); kemind++) {
-        for (kdfind = 0; kdfind < OSSL_NELEM(hpke_kdf_list); kdfind++) {
-            for (aeadind = 0; aeadind < OSSL_NELEM(hpke_aead_list); aeadind++) {
-                OSSL_HPKE_SUITE roundtrip;
-
-                suite.kem_id = hpke_kem_list[kemind];
-                suite.kdf_id = hpke_kdf_list[kdfind];
-                suite.aead_id = hpke_aead_list[aeadind];
-
-                suitestr = OSSL_HPKE_suite2str(suite);
-                if (!TEST_ptr(suitestr)) {
-                    overallresult = 0;
-                    continue;
-                }
-                /* round-trip: str2suite should recover the original suite */
-                if (!TEST_true(OSSL_HPKE_str2suite(suitestr, &roundtrip))) {
-                    overallresult = 0;
-                    OPENSSL_free(suitestr);
-                    suitestr = NULL;
-                    continue;
-                }
-                if (!TEST_uint_eq(roundtrip.kem_id, suite.kem_id)
-                    || !TEST_uint_eq(roundtrip.kdf_id, suite.kdf_id)
-                    || !TEST_uint_eq(roundtrip.aead_id, suite.aead_id)) {
-                    overallresult = 0;
-                }
-                OPENSSL_free(suitestr);
-                suitestr = NULL;
-            }
-        }
-    }
-
-    /* Test OSSL_HPKE_suite2str with export-only AEAD */
-    suite.kem_id = OSSL_HPKE_KEM_ID_P256;
-    suite.kdf_id = OSSL_HPKE_KDF_ID_HKDF_SHA256;
-    suite.aead_id = OSSL_HPKE_AEAD_ID_EXPORTONLY;
-    suitestr = OSSL_HPKE_suite2str(suite);
-    if (!TEST_ptr(suitestr))
-        overallresult = 0;
-    if (suitestr != NULL) {
-        OSSL_HPKE_SUITE roundtrip;
-
-        if (!TEST_true(OSSL_HPKE_str2suite(suitestr, &roundtrip)))
-            overallresult = 0;
-        else if (!TEST_uint_eq(roundtrip.aead_id, OSSL_HPKE_AEAD_ID_EXPORTONLY))
-            overallresult = 0;
-    }
-    OPENSSL_free(suitestr);
-    suitestr = NULL;
-
-    return overallresult;
-}
 
 typedef enum OPTION_choice {
     OPT_ERR = -1,
@@ -2130,7 +2115,6 @@ int setup_tests(void)
     ADD_TEST(test_hpke_oddcalls);
     ADD_TEST(test_hpke_compressed);
     ADD_TEST(test_hpke_noncereuse);
-    ADD_TEST(test_hpke_new_apis);
     return 1;
 }
 

--- a/test/hpke_test.c
+++ b/test/hpke_test.c
@@ -1922,6 +1922,163 @@ end:
     return erv;
 }
 
+/*
+ * Test the new APIs: OSSL_HPKE_get_suite, OSSL_HPKE_get_public_key_size,
+ * OSSL_HPKE_mode_is_supported, OSSL_HPKE_suite2str
+ */
+static int test_hpke_new_apis(void)
+{
+    int overallresult = 1;
+    OSSL_HPKE_CTX *ctx = NULL;
+    OSSL_HPKE_SUITE suite, retrieved;
+    OSSL_HPKE_SUITE bad_suite = { 0xbad, 0xbad, 0xbad };
+    char *suitestr = NULL;
+    size_t kemind, kdfind, aeadind, mind;
+
+    /* Test OSSL_HPKE_get_suite with NULL ctx */
+    retrieved = OSSL_HPKE_get_suite(NULL);
+    if (!TEST_uint_eq(retrieved.kem_id, OSSL_HPKE_KEM_ID_RESERVED)
+        || !TEST_uint_eq(retrieved.kdf_id, OSSL_HPKE_KDF_ID_RESERVED)
+        || !TEST_uint_eq(retrieved.aead_id, OSSL_HPKE_AEAD_ID_RESERVED)) {
+        overallresult = 0;
+    }
+
+    /* Test OSSL_HPKE_get_suite with valid context for each suite combo */
+    for (kemind = 0; kemind < OSSL_NELEM(hpke_kem_list); kemind++) {
+        for (kdfind = 0; kdfind < OSSL_NELEM(hpke_kdf_list); kdfind++) {
+            for (aeadind = 0; aeadind < OSSL_NELEM(hpke_aead_list); aeadind++) {
+                suite.kem_id = hpke_kem_list[kemind];
+                suite.kdf_id = hpke_kdf_list[kdfind];
+                suite.aead_id = hpke_aead_list[aeadind];
+
+                ctx = OSSL_HPKE_CTX_new(OSSL_HPKE_MODE_BASE, suite,
+                    OSSL_HPKE_ROLE_SENDER, testctx, NULL);
+                if (!TEST_ptr(ctx)) {
+                    overallresult = 0;
+                    continue;
+                }
+                retrieved = OSSL_HPKE_get_suite(ctx);
+                if (!TEST_uint_eq(retrieved.kem_id, suite.kem_id)
+                    || !TEST_uint_eq(retrieved.kdf_id, suite.kdf_id)
+                    || !TEST_uint_eq(retrieved.aead_id, suite.aead_id)) {
+                    overallresult = 0;
+                }
+                OSSL_HPKE_CTX_free(ctx);
+                ctx = NULL;
+            }
+        }
+    }
+
+    /* Test OSSL_HPKE_get_public_key_size - known values */
+    suite.kdf_id = OSSL_HPKE_KDF_ID_HKDF_SHA256;
+    suite.aead_id = OSSL_HPKE_AEAD_ID_AES_GCM_128;
+
+    suite.kem_id = OSSL_HPKE_KEM_ID_P256;
+    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 65))
+        overallresult = 0;
+    suite.kem_id = OSSL_HPKE_KEM_ID_P384;
+    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 97))
+        overallresult = 0;
+    suite.kem_id = OSSL_HPKE_KEM_ID_P521;
+    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 133))
+        overallresult = 0;
+#ifndef OPENSSL_NO_ECX
+    suite.kem_id = OSSL_HPKE_KEM_ID_X25519;
+    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 32))
+        overallresult = 0;
+    suite.kem_id = OSSL_HPKE_KEM_ID_X448;
+    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 56))
+        overallresult = 0;
+#endif
+
+    /* Test OSSL_HPKE_get_public_key_size with bad suite */
+    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(bad_suite), 0))
+        overallresult = 0;
+
+    /* Test OSSL_HPKE_mode_is_supported - all modes for all suites */
+    for (kemind = 0; kemind < OSSL_NELEM(hpke_kem_list); kemind++) {
+        suite.kem_id = hpke_kem_list[kemind];
+        suite.kdf_id = OSSL_HPKE_KDF_ID_HKDF_SHA256;
+        suite.aead_id = OSSL_HPKE_AEAD_ID_AES_GCM_128;
+        for (mind = 0; mind < OSSL_NELEM(hpke_mode_list); mind++) {
+            if (!TEST_true(OSSL_HPKE_mode_is_supported(suite,
+                    hpke_mode_list[mind]))) {
+                overallresult = 0;
+            }
+        }
+    }
+
+    /* Test OSSL_HPKE_mode_is_supported with bad mode */
+    suite.kem_id = OSSL_HPKE_KEM_ID_P256;
+    if (!TEST_false(OSSL_HPKE_mode_is_supported(suite, 0xbad)))
+        overallresult = 0;
+
+    /* Test OSSL_HPKE_mode_is_supported with bad suite */
+    if (!TEST_false(OSSL_HPKE_mode_is_supported(bad_suite,
+            OSSL_HPKE_MODE_BASE)))
+        overallresult = 0;
+
+    /* Test OSSL_HPKE_suite2str with bad suite */
+    suitestr = OSSL_HPKE_suite2str(bad_suite);
+    if (!TEST_ptr_null(suitestr))
+        overallresult = 0;
+    OPENSSL_free(suitestr);
+    suitestr = NULL;
+
+    /* Test OSSL_HPKE_suite2str round-trip for all valid suites */
+    for (kemind = 0; kemind < OSSL_NELEM(hpke_kem_list); kemind++) {
+        for (kdfind = 0; kdfind < OSSL_NELEM(hpke_kdf_list); kdfind++) {
+            for (aeadind = 0; aeadind < OSSL_NELEM(hpke_aead_list); aeadind++) {
+                OSSL_HPKE_SUITE roundtrip;
+
+                suite.kem_id = hpke_kem_list[kemind];
+                suite.kdf_id = hpke_kdf_list[kdfind];
+                suite.aead_id = hpke_aead_list[aeadind];
+
+                suitestr = OSSL_HPKE_suite2str(suite);
+                if (!TEST_ptr(suitestr)) {
+                    overallresult = 0;
+                    continue;
+                }
+                /* round-trip: str2suite should recover the original suite */
+                if (!TEST_true(OSSL_HPKE_str2suite(suitestr, &roundtrip))) {
+                    overallresult = 0;
+                    OPENSSL_free(suitestr);
+                    suitestr = NULL;
+                    continue;
+                }
+                if (!TEST_uint_eq(roundtrip.kem_id, suite.kem_id)
+                    || !TEST_uint_eq(roundtrip.kdf_id, suite.kdf_id)
+                    || !TEST_uint_eq(roundtrip.aead_id, suite.aead_id)) {
+                    overallresult = 0;
+                }
+                OPENSSL_free(suitestr);
+                suitestr = NULL;
+            }
+        }
+    }
+
+    /* Test OSSL_HPKE_suite2str with export-only AEAD */
+    suite.kem_id = OSSL_HPKE_KEM_ID_P256;
+    suite.kdf_id = OSSL_HPKE_KDF_ID_HKDF_SHA256;
+    suite.aead_id = OSSL_HPKE_AEAD_ID_EXPORTONLY;
+    suitestr = OSSL_HPKE_suite2str(suite);
+    if (!TEST_ptr(suitestr))
+        overallresult = 0;
+    if (suitestr != NULL) {
+        OSSL_HPKE_SUITE roundtrip;
+
+        if (!TEST_true(OSSL_HPKE_str2suite(suitestr, &roundtrip)))
+            overallresult = 0;
+        else if (!TEST_uint_eq(roundtrip.aead_id, OSSL_HPKE_AEAD_ID_EXPORTONLY))
+            overallresult = 0;
+    }
+    OPENSSL_free(suitestr);
+    suitestr = NULL;
+
+    return overallresult;
+}
+
 typedef enum OPTION_choice {
     OPT_ERR = -1,
     OPT_EOF = 0,
@@ -1973,6 +2130,7 @@ int setup_tests(void)
     ADD_TEST(test_hpke_oddcalls);
     ADD_TEST(test_hpke_compressed);
     ADD_TEST(test_hpke_noncereuse);
+    ADD_TEST(test_hpke_new_apis);
     return 1;
 }
 

--- a/test/hpke_test.c
+++ b/test/hpke_test.c
@@ -1380,7 +1380,6 @@ static int test_hpke_oddcalls(void)
     char giant_pskid[OSSL_HPKE_MAX_PARMLEN + 10];
     unsigned char info[OSSL_HPKE_TSTSIZE];
     OSSL_HPKE_SUITE suite, retrieved;
-    size_t kemind, kdfind, aeadind, mind;
 
     /* many of the calls below are designed to get better test coverage */
 

--- a/test/hpke_test.c
+++ b/test/hpke_test.c
@@ -114,6 +114,7 @@ static int do_testhpke(const TEST_BASEDATA *base,
     int ret = 0;
     size_t i;
     uint64_t lastseq = 0;
+    OSSL_HPKE_SUITE retrieved_suite;
 
     if (!TEST_true(OSSL_HPKE_keygen(base->suite, pub, &publen, &privE,
             base->ikmE, base->ikmElen, libctx, propq)))
@@ -124,6 +125,17 @@ static int do_testhpke(const TEST_BASEDATA *base,
                       OSSL_HPKE_ROLE_SENDER,
                       libctx, propq)))
         goto end;
+
+    if (!TEST_true(OSSL_HPKE_mode_is_supported(base->suite, base->mode)))
+        goto end;
+    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(base->suite), publen))
+        goto end;
+    retrieved_suite = OSSL_HPKE_get_suite(sealctx);
+    if (!TEST_uint_eq(retrieved_suite.kem_id, base->suite.kem_id)
+        || !TEST_uint_eq(retrieved_suite.kdf_id, base->suite.kdf_id)
+        || !TEST_uint_eq(retrieved_suite.aead_id, base->suite.aead_id))
+        goto end;
+
     if (!TEST_true(OSSL_HPKE_CTX_set1_ikme(sealctx, base->ikmE, base->ikmElen)))
         goto end;
     if (base->mode == OSSL_HPKE_MODE_AUTH
@@ -1414,66 +1426,9 @@ static int test_hpke_oddcalls(void)
         || !TEST_uint_eq(retrieved.aead_id, OSSL_HPKE_AEAD_ID_RESERVED))
         goto end;
 
-    /* Test OSSL_HPKE_get_suite with valid context for each suite combo */
-    for (kemind = 0; kemind < OSSL_NELEM(hpke_kem_list); kemind++) {
-        for (kdfind = 0; kdfind < OSSL_NELEM(hpke_kdf_list); kdfind++) {
-            for (aeadind = 0; aeadind < OSSL_NELEM(hpke_aead_list); aeadind++) {
-                suite.kem_id = hpke_kem_list[kemind];
-                suite.kdf_id = hpke_kdf_list[kdfind];
-                suite.aead_id = hpke_aead_list[aeadind];
-
-                ctx = OSSL_HPKE_CTX_new(OSSL_HPKE_MODE_BASE, suite,
-                    OSSL_HPKE_ROLE_SENDER, testctx, NULL);
-                if (!TEST_ptr(ctx))
-                    goto end;
-                retrieved = OSSL_HPKE_get_suite(ctx);
-                if (!TEST_uint_eq(retrieved.kem_id, suite.kem_id)
-                    || !TEST_uint_eq(retrieved.kdf_id, suite.kdf_id)
-                    || !TEST_uint_eq(retrieved.aead_id, suite.aead_id))
-                    goto end;
-                OSSL_HPKE_CTX_free(ctx);
-                ctx = NULL;
-            }
-        }
-    }
-
-    /* Test OSSL_HPKE_get_public_key_size - known values */
-    suite.kdf_id = OSSL_HPKE_KDF_ID_HKDF_SHA256;
-    suite.aead_id = OSSL_HPKE_AEAD_ID_AES_GCM_128;
-
-    suite.kem_id = OSSL_HPKE_KEM_ID_P256;
-    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 65))
-        goto end;
-    suite.kem_id = OSSL_HPKE_KEM_ID_P384;
-    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 97))
-        goto end;
-    suite.kem_id = OSSL_HPKE_KEM_ID_P521;
-    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 133))
-        goto end;
-#ifndef OPENSSL_NO_ECX
-    suite.kem_id = OSSL_HPKE_KEM_ID_X25519;
-    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 32))
-        goto end;
-    suite.kem_id = OSSL_HPKE_KEM_ID_X448;
-    if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(suite), 56))
-        goto end;
-#endif
-
     /* Test OSSL_HPKE_get_public_key_size with bad suite */
     if (!TEST_size_t_eq(OSSL_HPKE_get_public_key_size(bad_suite), 0))
         goto end;
-
-    /* Test OSSL_HPKE_mode_is_supported - all modes for all suites */
-    for (kemind = 0; kemind < OSSL_NELEM(hpke_kem_list); kemind++) {
-        suite.kem_id = hpke_kem_list[kemind];
-        suite.kdf_id = OSSL_HPKE_KDF_ID_HKDF_SHA256;
-        suite.aead_id = OSSL_HPKE_AEAD_ID_AES_GCM_128;
-        for (mind = 0; mind < OSSL_NELEM(hpke_mode_list); mind++) {
-            if (!TEST_true(OSSL_HPKE_mode_is_supported(suite,
-                    hpke_mode_list[mind])))
-                goto end;
-        }
-    }
 
     /* Test OSSL_HPKE_mode_is_supported with bad mode */
     suite.kem_id = OSSL_HPKE_KEM_ID_P256;

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5727,3 +5727,7 @@ EVP_KDF_CTX_get1_kdf                    ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_set_data                    ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_set_string                  ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_length_ex                   ?	4_1_0	EXIST::FUNCTION:
+OSSL_HPKE_get_suite                     ?	4_1_0	EXIST::FUNCTION:
+OSSL_HPKE_get_public_key_size           ?	4_1_0	EXIST::FUNCTION:
+OSSL_HPKE_mode_is_supported             ?	4_1_0	EXIST::FUNCTION:
+OSSL_HPKE_suite2str                     ?	4_1_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5730,4 +5730,8 @@ ASN1_STRING_set1_data                   ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_set1_string                 ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_get_length                  ?	4_1_0	EXIST::FUNCTION:
 CMS_add_standard_smimecap_ex            ?	4_1_0	EXIST::FUNCTION:CMS
+OSSL_HPKE_get_suite                     ?	4_1_0	EXIST::FUNCTION:
+OSSL_HPKE_get_public_key_size           ?	4_1_0	EXIST::FUNCTION:
+OSSL_HPKE_mode_is_supported             ?	4_1_0	EXIST::FUNCTION:
+OSSL_HPKE_suite2str                     ?	4_1_0	EXIST::FUNCTION:
 BIO_socket_ready                        ?	4_1_0	EXIST::FUNCTION:SOCK


### PR DESCRIPTION
Fixes #31205

This PR adds four HPKE utility APIs:

- OSSL_HPKE_get_suite()
- OSSL_HPKE_get_public_key_size()
- OSSL_HPKE_mode_is_supported()
- OSSL_HPKE_suite2str()

The implementation reuses existing HPKE metadata and validation paths and does not modify cryptographic behavior.

Changes include:
- Public API declarations
- Core implementations
- Symbol exports
- Documentation updates
- Unit tests covering success and error paths