### PR TITLE
statem: fix missing fatal if valid_flags mfail in process cert req

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2966,8 +2966,10 @@ MSG_PROCESS_RETURN tls_process_certificate_request(SSL_CONNECTION *s,
         s->s3.tmp.valid_flags = OPENSSL_calloc(s->ssl_pkey_num, sizeof(uint32_t));
 
     /* Give up for good if allocation didn't work */
-    if (s->s3.tmp.valid_flags == NULL)
-        return 0;
+    if (s->s3.tmp.valid_flags == NULL) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_CRYPTO_LIB);
+        return MSG_PROCESS_ERROR;
+    }
 
     if (SSL_CONNECTION_IS_TLS13(s)) {
         PACKET reqctx, extensions;


### PR DESCRIPTION
It is a contract of tls process functions to trigger fatal error if they fail. This is not being done in checking result of `s->s3.tmp.valid_flags` allocation. If this happens, it triggers alert in read_state_machine() for READ_STATE_BODY state that calls this process function. It calls check_fatal() if MSG_PROCESS_ERROR is returned and the assert in it fails because no error is triggered.

The fix just adds the fatal and also uses MSG_PROCESS_ERROR macro as return value instead of hard coded 0.

This was found using #30944 which happened in QUIC client but this should apply for TLS client as well. The test will be mfail one and will come later once I figure out how to best test it.