### PR TITLE
rsa_sig: reject short buffers in raw verify_recover

### DIFF
--- a/providers/implementations/signature/rsa_sig.c
+++ b/providers/implementations/signature/rsa_sig.c
@@ -1016,6 +1016,14 @@ static int rsa_verify_recover(void *vprsactx,
             return 0;
         }
     } else {
+        int rsasize = RSA_size(prsactx->rsa);
+
+        if (routsize < (size_t)rsasize) {
+            ERR_raise_data(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL,
+                "buffer size is %d, should be %d",
+                routsize, rsasize);
+            return 0;
+        }
         ret = RSA_public_decrypt((int)siglen, sig, rout, prsactx->rsa,
             prsactx->pad_mode);
         if (ret <= 0) {


### PR DESCRIPTION
The md==NULL path of rsa_verify_recover hands the caller buffer to RSA_public_decrypt without checking routsize, unlike the X9.31 and PKCS#1 paths which already reject undersized output. RSA_public_decrypt writes up to RSA_size() bytes, so a short rout overflows (a 16-byte buffer against a 2048-bit key crashes on the write). Validate routsize against RSA_size() before the call, matching the sibling paths.

CLA: trivial