### PR TITLE
doc: Add a missing comma in -traditional option explanation of openssl-pkcs8

### DIFF
--- a/doc/man1/openssl-pkcs8.pod.in
+++ b/doc/man1/openssl-pkcs8.pod.in
@@ -74,7 +74,7 @@ is included.
 
 =item B<-traditional>
 
-When this option is present and B<-topk8> is not a traditional format private
+When this option is present and B<-topk8> is not, a traditional format private
 key is written.
 
 =item B<-in> I<filename>


### PR DESCRIPTION
Stumbled over a missing comma while reading the man page for openssl-pkcs8 and its -traditional option.
Had to read the sentence multiple times until it made sense to me, so I guess a comma might help.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
