### PR TITLE
test: fix unreachable code in test_kdf_pbkdf2_large_output in evp_kdf_test.c

### DIFF
--- a/test/evp_kdf_test.c
+++ b/test/evp_kdf_test.c
@@ -988,7 +988,7 @@ static int test_kdf_pbkdf2_large_output(void)
     int mode = 0;
     OSSL_PARAM *params;
 
-    if (sizeof(len) > 32)
+    if (SIZE_MAX > 0xFFFFFFFFU)
         len = SIZE_MAX;
 
     params = construct_pbkdf2_params("passwordPASSWORDpassword", "sha256",


### PR DESCRIPTION

The condition `if (sizeof(len) > 32)` was intended to set `len` to SIZE_MAX on platforms where size_t can hold values larger than 32 bits. However, sizeof() returns the size in bytes, not bits. Since sizeof(size_t) is typically 4 or 8 bytes on all current platforms, the condition was always false, leaving len at 0 and skipping the large-output test.

This commit fixes the check by comparing SIZE_MAX directly against 0xFFFFFFFFU, which correctly detects whether size_t can represent values exceeding 32-bit range. This ensures the test properly validates PBKDF2 behavior when requested output length is excessively large.

Fixes: unreachable condition in evp_kdf_test.c

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>