### PR TITLE
lms: free previous encoded public key in ossl_lms_pubkey_decode

### DIFF
--- a/crypto/lms/lms_pubkey_decode.c
+++ b/crypto/lms/lms_pubkey_decode.c
@@ -95,7 +95,7 @@ int ossl_lms_pubkey_decode(const unsigned char *pub, size_t publen,
 {
     LMS_PUB_KEY *pkey = &lmskey->pub;
 
-    if (pkey->encoded != NULL && pkey->encodedlen != publen) {
+    if (pkey->encoded != NULL) {
         OPENSSL_free(pkey->encoded);
         pkey->encodedlen = 0;
     }
@@ -110,6 +110,7 @@ int ossl_lms_pubkey_decode(const unsigned char *pub, size_t publen,
 err:
     OPENSSL_free(pkey->encoded);
     pkey->encoded = NULL;
+    pkey->encodedlen = 0;
     return 0;
 }
 


### PR DESCRIPTION
ossl_lms_pubkey_decode() only frees the previous pkey->encoded buffer when the new public key has a different length. The function is documented to be called more than once, so re-decoding a key whose public key is the same length overwrites the old allocation without freeing it. Drop the length guard so any existing buffer is released first.