### PR TITLE
quic: avoid one-byte over-read of conn close reason in copy_tcause

### DIFF
--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -3211,10 +3211,11 @@ static void copy_tcause(QUIC_TERMINATE_CAUSE *dst,
          * If this fails, dst->reason becomes NULL and we simply do not use a
          * reason. This ensures termination is infallible.
          */
-        dst->reason = r = OPENSSL_memdup(src->reason, l + 1);
+        dst->reason = r = OPENSSL_malloc(l + 1);
         if (r == NULL)
             return;
 
+        memcpy(r, src->reason, l);
         r[l] = '\0';
         dst->reason_len = l;
     }


### PR DESCRIPTION
Found while fuzzing the QUIC depacketizer with a CONNECTION_CLOSE whose reason phrase lands at the end of the datagram. copy_tcause memdup's reason_len + 1 bytes, but f->reason from ossl_quic_wire_decode_frame_conn_close points straight into the received packet and is exactly reason_len long, so the trailing byte is read past the buffer. The +1 is only needed for the NUL at r[l], so copy just the reason_len bytes.