### PR TITLE
pvkfmt: check keylen before copying the BLOBHEADER

### DIFF
--- a/crypto/pem/pvkfmt.c
+++ b/crypto/pem/pvkfmt.c
@@ -893,13 +893,13 @@ static void *do_PVK_body_key(const unsigned char **in,
                 (unsigned char *)psbuf, inlen, libctx, propq))
             goto err;
         p += saltlen;
-        /* Copy BLOBHEADER across, decrypt rest */
-        memcpy(enctmp, p, 8);
-        p += 8;
         if (keylen < 8) {
             ERR_raise(ERR_LIB_PEM, PEM_R_PVK_TOO_SHORT);
             goto err;
         }
+        /* Copy BLOBHEADER across, decrypt rest */
+        memcpy(enctmp, p, 8);
+        p += 8;
         inlen = keylen - 8;
         q = enctmp + 8;
         if ((rc4 = EVP_CIPHER_fetch(libctx, "RC4", propq)) == NULL)


### PR DESCRIPTION
do_PVK_body_key reads the 8-byte BLOBHEADER with memcpy(enctmp, p, 8) before checking keylen, but the input buffer only holds saltlen + keylen bytes; an encrypted PVK file whose header sets keylen < 8 over-reads the heap by up to 7 bytes. Move the existing keylen < 8 check ahead of the copy so the read happens only once at least 8 key bytes are present. Reachable via b2i_PVK_bio and b2i_RSA/DSA_PVK_bio.