### PR TITLE
Add TEST_ALL memfail variants and some tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -192,8 +192,10 @@ Some tests use the `ADD_MFAIL_TEST` framework to exhaustively verify that
 functions handle every possible allocation failure gracefully. These tests
 run repeatedly, failing one allocation later each iteration. The
 `ADD_MFAIL_NO_CHECK_TEST` variant relaxes the requirement that the test
-return 0 when a failure was triggered. Behavior is controlled with the
-following environment variables:
+return 0 when a failure was triggered. The `ADD_MFAIL_ALL_TESTS` and
+`ADD_MFAIL_ALL_NO_CHECK_TESTS` variants apply the same cycle to each index
+of a parameterised test, the same way `ADD_ALL_TESTS` does. Behavior is
+controlled with the following environment variables:
 
     OPENSSL_TEST_MFAIL_DISABLE=1    Disable mfail custom allocator installation.
 

--- a/test/README.md
+++ b/test/README.md
@@ -194,8 +194,14 @@ run repeatedly, failing one allocation later each iteration. The
 `ADD_MFAIL_NO_CHECK_TEST` variant relaxes the requirement that the test
 return 0 when a failure was triggered. The `ADD_MFAIL_ALL_TESTS` and
 `ADD_MFAIL_ALL_NO_CHECK_TESTS` variants apply the same cycle to each index
-of a parameterised test, the same way `ADD_ALL_TESTS` does. Behavior is
-controlled with the following environment variables:
+of a parameterised test, the same way `ADD_ALL_TESTS` does.
+
+An mfail test returns 1 on success or 0 on failure; under `NO_CHECK` a 0 is
+tolerated since a function may legitimately fail when an allocation fails.
+Returning -1 forces a failure that is reported even under `NO_CHECK`, for
+assertions that must hold regardless of which allocation was made to fail.
+
+Behavior is controlled with the following environment variables:
 
     OPENSSL_TEST_MFAIL_DISABLE=1    Disable mfail custom allocator installation.
 

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -3414,6 +3414,49 @@ static int test_set_get_raw_keys(int tst)
         && test_set_get_raw_keys_int(tst, 1, 1);
 }
 
+static int test_set_get_raw_keys_mfail(int idx)
+{
+    const uint8_t *in;
+    size_t inlen, len = 0;
+    EVP_PKEY *pkey = NULL;
+    unsigned char *buf = NULL;
+    unsigned char *privalloc = NULL;
+    const char *name;
+    int ok = 0;
+    int ret = 0;
+
+    name = keys[idx].name != NULL ? keys[idx].name : OBJ_nid2sn(keys[idx].type);
+    inlen = keys[idx].privlen;
+    in = keys[idx].priv;
+#ifndef OPENSSL_NO_ML_KEM
+    if (in == ml_kem_seed) {
+        if (!TEST_true(ml_kem_seed_to_priv(name, in, inlen, &privalloc, &inlen)))
+            goto err;
+        in = privalloc;
+    }
+#endif
+
+    MFAIL_start();
+    pkey = EVP_PKEY_new_raw_private_key_ex(testctx, name, NULL, in, inlen);
+    if (pkey != NULL
+        && EVP_PKEY_get_raw_private_key(pkey, NULL, &len)
+        && (buf = OPENSSL_malloc(len == 0 ? 1 : len)) != NULL
+        && EVP_PKEY_get_raw_private_key(pkey, buf, &len))
+        ok = 1;
+    MFAIL_end();
+
+    if (!ok)
+        goto err;
+
+    ret = TEST_mem_eq(in, inlen, buf, len);
+
+err:
+    OPENSSL_free(privalloc);
+    OPENSSL_free(buf);
+    EVP_PKEY_free(pkey);
+    return ret;
+}
+
 static int test_EVP_PKEY_check(int i)
 {
     int ret = 0;
@@ -8043,6 +8086,12 @@ int setup_tests(void)
     ADD_TEST(test_EVP_SM2_verify);
 #endif
     ADD_ALL_TESTS(test_set_get_raw_keys, OSSL_NELEM(keys));
+#if defined(_MSC_VER) || defined(OPENSSL_NO_CACHED_FETCH)
+    ADD_MFAIL_ALL_NO_CHECK_TESTS(test_set_get_raw_keys_mfail,
+        OSSL_NELEM(keys));
+#else
+    ADD_MFAIL_ALL_TESTS(test_set_get_raw_keys_mfail, OSSL_NELEM(keys));
+#endif
     ADD_ALL_TESTS(test_EVP_PKEY_check, OSSL_NELEM(keycheckdata));
 #ifndef OPENSSL_NO_CMAC
     ADD_TEST(test_CMAC_keygen);

--- a/test/mfail/mfail.c
+++ b/test/mfail/mfail.c
@@ -54,6 +54,7 @@ static struct {
     int triggered;
     int counting;
     int slow_skipped;
+    int no_check;
 } mf;
 
 static int env_is_true(const char *name)
@@ -92,11 +93,14 @@ static void mfail_print_bt(void)
 #endif
 }
 
-static int should_fail(void)
+static int should_fail(const char *file)
 {
     int idx;
 
     if (!mf.counting)
+        return 0;
+    /* skip if checking errors and file is not set (debug and error parts) */
+    if (!mf.no_check && file == NULL)
         return 0;
 
     idx = mf.alloc_count++;
@@ -116,7 +120,7 @@ static void *mf_malloc(size_t num, const char *file, int line)
 {
     if (num == 0)
         return NULL;
-    if (should_fail())
+    if (should_fail(file))
         return NULL;
     return malloc(num);
 }
@@ -129,7 +133,7 @@ static void *mf_realloc(void *addr, size_t num, const char *file, int line)
         free(addr);
         return NULL;
     }
-    if (should_fail())
+    if (should_fail(file))
         return NULL;
     return realloc(addr, num);
 }
@@ -216,6 +220,7 @@ void mfail_init(int seq, int flags)
     mf.triggered = 0;
     mf.counting = 0;
     mf.slow_skipped = 0;
+    mf.no_check = flags & MFAIL_FLAG_NO_CHECK;
 
     if (mf.single_point >= 0) {
         mf.mode = MFAIL_MODE_SINGLE;

--- a/test/mfail/mfail.h
+++ b/test/mfail/mfail.h
@@ -12,6 +12,7 @@
 
 /* Flags for mfail_init(). */
 #define MFAIL_FLAG_COUNT (1 << 0)
+#define MFAIL_FLAG_NO_CHECK (1 << 1)
 
 /* Modes */
 #define MFAIL_MODE_EXHAUSTIVE 0

--- a/test/rsa_test.c
+++ b/test/rsa_test.c
@@ -302,6 +302,70 @@ err:
     return ret;
 }
 
+static int test_rsa_pkcs1_mfail(int idx)
+{
+    RSA *key = NULL;
+    unsigned char ctext[256];
+    unsigned char ptext[256];
+    static unsigned char ptext_ex[] = "\x54\x85\x9b\x34\x2c\x49\xea\x2a";
+    int plen = sizeof(ptext_ex) - 1;
+    int clen, enclen, declen = 0;
+    int ret = 0;
+
+    /* key construction is setup; only the round trip is under injection */
+    clen = rsa_setkey(&key, NULL, idx);
+    if (!TEST_ptr(key))
+        goto err;
+
+    MFAIL_start();
+    enclen = RSA_public_encrypt(plen, ptext_ex, ctext, key, RSA_PKCS1_PADDING);
+    if (enclen == clen)
+        declen = RSA_private_decrypt(enclen, ctext, ptext, key,
+            RSA_PKCS1_PADDING);
+    MFAIL_end();
+
+    if (enclen != clen || declen <= 0)
+        goto err;
+
+    ret = TEST_mem_eq(ptext, declen, ptext_ex, plen);
+
+err:
+    RSA_free(key);
+    return ret;
+}
+
+static int test_rsa_oaep_mfail(int idx)
+{
+    RSA *key = NULL;
+    unsigned char ctext[256];
+    unsigned char ptext[256];
+    static unsigned char ptext_ex[] = "\x54\x85\x9b\x34\x2c\x49\xea\x2a";
+    int plen = sizeof(ptext_ex) - 1;
+    int clen, enclen, declen = 0;
+    int ret = 0;
+
+    clen = rsa_setkey(&key, NULL, idx);
+    if (!TEST_ptr(key))
+        goto err;
+
+    MFAIL_start();
+    enclen = RSA_public_encrypt(plen, ptext_ex, ctext, key,
+        RSA_PKCS1_OAEP_PADDING);
+    if (enclen == clen)
+        declen = RSA_private_decrypt(enclen, ctext, ptext, key,
+            RSA_PKCS1_OAEP_PADDING);
+    MFAIL_end();
+
+    if (enclen != clen || declen <= 0)
+        goto err;
+
+    ret = TEST_mem_eq(ptext, declen, ptext_ex, plen);
+
+err:
+    RSA_free(key);
+    return ret;
+}
+
 static const struct {
     int bits;
     unsigned int r;
@@ -693,6 +757,13 @@ int setup_tests(void)
 {
     ADD_ALL_TESTS(test_rsa_pkcs1, 3);
     ADD_ALL_TESTS(test_rsa_oaep, 3);
+#if defined(_MSC_VER) || defined(OPENSSL_NO_CACHED_FETCH)
+    ADD_MFAIL_ALL_NO_CHECK_TESTS(test_rsa_pkcs1_mfail, 3);
+    ADD_MFAIL_ALL_NO_CHECK_TESTS(test_rsa_oaep_mfail, 3);
+#else
+    ADD_MFAIL_ALL_TESTS(test_rsa_pkcs1_mfail, 3);
+    ADD_MFAIL_ALL_TESTS(test_rsa_oaep_mfail, 3);
+#endif
     ADD_ALL_TESTS(test_rsa_security_bit, OSSL_NELEM(rsa_security_bits_cases));
     ADD_TEST(test_rsa_saos);
     ADD_TEST(test_EVP_rsa_legacy_key);

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -79,6 +79,12 @@
 #define ADD_MFAIL_NO_CHECK_TEST(test_fn) \
     add_mfail_test(#test_fn, test_fn, MFAIL_TEST_NO_CHECK)
 
+/* Runs the exhaustive mfail cycle for each 0 <= idx < num */
+#define ADD_MFAIL_ALL_TESTS(test_fn, num) \
+    add_mfail_all_tests(#test_fn, test_fn, num, 0)
+#define ADD_MFAIL_ALL_NO_CHECK_TESTS(test_fn, num) \
+    add_mfail_all_tests(#test_fn, test_fn, num, MFAIL_TEST_NO_CHECK)
+
 /*
  * A variant of the same without TAP output.
  */
@@ -251,6 +257,8 @@ void add_all_tests(const char *test_case_name, int (*test_fn)(int idx), int num,
     int subtest);
 void add_mfail_test(const char *test_case_name, int (*test_fn)(void),
     int flags);
+void add_mfail_all_tests(const char *test_case_name, int (*test_fn)(int idx),
+    int num, int flags);
 
 #define MFAIL_start mfail_start
 #define MFAIL_end mfail_end

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -96,6 +96,20 @@ void add_mfail_test(const char *test_case_name, int (*test_fn)(void), int flags)
     ++num_test_cases;
 }
 
+void add_mfail_all_tests(const char *test_case_name, int (*test_fn)(int idx),
+    int num, int flags)
+{
+    assert(num_tests != OSSL_NELEM(all_tests));
+    all_tests[num_tests].test_case_name = test_case_name;
+    all_tests[num_tests].param_test_fn = test_fn;
+    all_tests[num_tests].num = num;
+    all_tests[num_tests].subtest = 1;
+    all_tests[num_tests].mfail = 1;
+    all_tests[num_tests].mfail_flags = flags;
+    ++num_tests;
+    ++num_test_cases;
+}
+
 static int gcd(int a, int b)
 {
     while (b != 0) {
@@ -300,19 +314,18 @@ static double mfail_elapsed_secs(clock_t start)
     return (double)(clock() - start) / CLOCKS_PER_SEC;
 }
 
-static int mfail_run_test(const char *test_case_name,
-    int (*test_fn)(void), int flags)
+static int mfail_run_test(const TEST_INFO *t, int idx)
 {
     int counting_ok = 1;
     int injection_ok = 1;
     int injections = 0;
     int allocations = 0;
-    int no_check = (flags & MFAIL_TEST_NO_CHECK) != 0;
+    int no_check = (t->mfail_flags & MFAIL_TEST_NO_CHECK) != 0;
     clock_t start = clock();
 
     level += 4;
     test_adjust_streams_tap_level(level);
-    test_printf_stdout("Subtest: %s\n", test_case_name);
+    test_printf_stdout("Subtest: %s[%d]\n", t->test_case_name, idx);
     test_printf_tapout("1..2\n");
     test_flush_stdout();
     test_flush_tapout();
@@ -324,13 +337,13 @@ static int mfail_run_test(const char *test_case_name,
         int rv;
 
         ERR_clear_error();
-        rv = test_fn();
+        rv = t->param_test_fn != NULL ? t->param_test_fn(idx) : t->test_fn();
 
         if (phase == MFAIL_PHASE_COUNTING) {
             allocations = mfail_get_count();
             if (!TEST_int_eq(rv, 1)) {
                 TEST_error("mfail test '%s': counting iteration failed",
-                    test_case_name);
+                    t->test_case_name);
                 counting_ok = 0;
             }
             test_verdict(counting_ok, "1 - counting (%d allocations)",
@@ -343,7 +356,7 @@ static int mfail_run_test(const char *test_case_name,
                 if (!no_check && !TEST_int_eq(rv, 0)) {
                     TEST_error("mfail test '%s': allocation failure at "
                                "point %d not handled",
-                        test_case_name, mfail_get_point());
+                        t->test_case_name, mfail_get_point());
                     injection_ok = 0;
                 }
             } else if (mfail_get_mode() == MFAIL_MODE_SINGLE) {
@@ -353,7 +366,7 @@ static int mfail_run_test(const char *test_case_name,
                 test_flush_tapout();
             } else if (!TEST_int_eq(rv, 1)) {
                 TEST_error("mfail test '%s': no injection but test failed",
-                    test_case_name);
+                    t->test_case_name);
                 injection_ok = 0;
             }
         }
@@ -435,8 +448,7 @@ int run_tests(const char *test_prog_name)
             set_test_title(all_tests[i].test_case_name);
             ERR_clear_error();
             if (all_tests[i].mfail)
-                verdict = mfail_run_test(all_tests[i].test_case_name,
-                    all_tests[i].test_fn, all_tests[i].mfail_flags);
+                verdict = mfail_run_test(&all_tests[i], 0);
             else
                 verdict = all_tests[i].test_fn();
             finalize(verdict != 0);
@@ -473,7 +485,10 @@ int run_tests(const char *test_prog_name)
                 if (single_iter != -1 && ((jj + 1) != single_iter))
                     continue;
                 ERR_clear_error();
-                v = all_tests[i].param_test_fn(j);
+                if (all_tests[i].mfail)
+                    v = mfail_run_test(&all_tests[i], j);
+                else
+                    v = all_tests[i].param_test_fn(j);
 
                 if (v == 0) {
                     verdict = 0;

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -330,7 +330,7 @@ static int mfail_run_test(const TEST_INFO *t, int idx)
     test_flush_stdout();
     test_flush_tapout();
 
-    mfail_init(0, 0);
+    mfail_init(0, no_check ? MFAIL_FLAG_NO_CHECK : 0);
 
     while (mfail_has_next()) {
         int phase = mfail_get_phase();

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -352,7 +352,12 @@ static int mfail_run_test(const TEST_INFO *t, int idx)
                 break;
         } else {
             injections++;
-            if (mfail_was_triggered()) {
+            if (rv == -1) {
+                TEST_error("mfail test '%s': unconditional failure at "
+                           "point %d",
+                    t->test_case_name, mfail_get_point());
+                injection_ok = 0;
+            } else if (mfail_was_triggered()) {
                 if (!no_check && !TEST_int_eq(rv, 0)) {
                     TEST_error("mfail test '%s': allocation failure at "
                                "point %d not handled",


### PR DESCRIPTION
This extends mfail framework with ADD_MFAIL_ALL_TESTS and ADD_MFAIL_ALL_NO_CHECK_TESTS that work
in similar way as ADD_ALL_TESTS but with mfail testing.

In addition it now skips failing allocation for some debug and error handling failures when NO_CHECK is not set - those resulted in unhandled tests.

And also the contants for RC codes are added including new hard failure one that allows NO_CHECK variant fail which is useful if there is some unexpected issues outsided the mfail block.

To test this, one EVP and two RSA mfail ALL tests are added.
