### PR TITLE
Fix heap buffer overflow read in gid_cb keyshare normalization

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1549,18 +1549,25 @@ static int gid_cb(const char *elem, int len, void *arg)
             if (!drop_ks) {
                 size_t end; /* End index of affected tuple */
 
-                /* Removing the first keyshare of an already completed tuple */
-                for (end = tpl_start_idx + garg->tuplcnt_arr[j]; i < end; ++i) {
-                    /* Any other keyshares for the same tuple? */
-                    if (k + 1 < garg->ksidcnt
-                        && garg->gid_arr[i] == garg->ksid_arr[k + 1])
-                        break;
-                }
-                /* Float keyshare to first group when no others found */
-                if (i >= end)
-                    garg->ksid_arr[k] = garg->gid_arr[tpl_start_idx];
-                else
+                /* Removing the first keyshare of an already completed tuple.*/
+                if (garg->tuplcnt_arr[j] == 0) {
                     drop_ks = 1;
+                } else {
+                    end = tpl_start_idx + garg->tuplcnt_arr[j];
+                    if (end > garg->gidcnt)
+                        end = garg->gidcnt;
+                    for (; i < end; ++i) {
+                        /* Any other keyshares for the same tuple? */
+                        if (k + 1 < garg->ksidcnt
+                            && garg->gid_arr[i] == garg->ksid_arr[k + 1])
+                            break;
+                    }
+                    /* Float keyshare to first group when no others found */
+                    if (i >= end && tpl_start_idx < garg->gidcnt)
+                        garg->ksid_arr[k] = garg->gid_arr[tpl_start_idx];
+                    else
+                        drop_ks = 1;
+                }
             }
             if (drop_ks) {
                 garg->ksidcnt--;
@@ -1573,11 +1580,15 @@ static int gid_cb(const char *elem, int len, void *arg)
          * Adjust closed or current tuple's group count, if a closed tuple
          * count reaches zero excise the resulting empty tuple.  The current
          * (not yet closed) tuple at the end of the list stays even if empty.
+         *
+         * The active tuple's group count lives at tuplcnt_arr[tplcnt]; the
+         * memmove range must include that slot so the active counter shifts
+         * down with the closed tuples after `j`.
          */
         if (garg->tuplcnt_arr[j] == 0 && j < garg->tplcnt) {
             garg->tplcnt--;
             memmove(garg->tuplcnt_arr + j, garg->tuplcnt_arr + j + 1,
-                (garg->tplcnt - j) * sizeof(size_t));
+                (garg->tplcnt - j + 1) * sizeof(size_t));
         }
     } else { /* Processing addition of a single new group */
 

--- a/test/build.info
+++ b/test/build.info
@@ -1183,6 +1183,11 @@ IF[{- !$disabled{tests} -}]
     SOURCE[algorithmid_test]=algorithmid_test.c
     INCLUDE[algorithmid_test]=../include ../apps/include
     DEPEND[algorithmid_test]=../libcrypto.a libtestutil.a
+
+    PROGRAMS{noinst}=groups_list_struct_test
+    SOURCE[groups_list_struct_test]=groups_list_struct_test.c
+    INCLUDE[groups_list_struct_test]=.. ../include ../apps/include
+    DEPEND[groups_list_struct_test]=../libcrypto.a ../libssl.a libtestutil.a
   ENDIF
 
   PROGRAMS{noinst}=asn1_time_test

--- a/test/groups_list_struct_test.c
+++ b/test/groups_list_struct_test.c
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "internal/nelem.h"
+#include "../ssl/ssl_local.h"
+#include "testutil.h"
+
+/*
+ * Sentinel used by the default-keyshare path in tls1_set_groups_list when a
+ * list ends up with groups but no explicit keyshares.  ksid_arr[0] is set to
+ * 0 to tell downstream code "send a keyshare for the first supported group".
+ */
+#define KS_IMPLICIT 0
+
+#define MAX_GROUPS 8
+#define MAX_TUPLES 4
+
+struct expected_state {
+    const char *list;
+    const char *groups[MAX_GROUPS];
+    size_t groups_len;
+    const char *keyshares[MAX_GROUPS];
+    size_t keyshares_len;
+    size_t tuples[MAX_TUPLES];
+    size_t tuples_len;
+};
+
+static const struct expected_state expected_states[] = {
+    {
+        .list = "X25519/prime256v1:-X25519",
+        .groups = { "secp256r1" },
+        .groups_len = 1,
+        .keyshares = { "" },
+        .keyshares_len = 1,
+        .tuples = { 1 },
+        .tuples_len = 1,
+    },
+    {
+        .list = "*X25519/prime256v1/-X25519",
+        .groups = { "secp256r1" },
+        .groups_len = 1,
+        .keyshares = { "" },
+        .keyshares_len = 1,
+        .tuples = { 1 },
+        .tuples_len = 1,
+    },
+    {
+        .list = "X25519/secp256r1:secp384r1:secp521r1/*X448:-X25519/-X448",
+        .groups = { "secp256r1", "secp384r1", "secp521r1" },
+        .groups_len = 3,
+        .keyshares = { "" },
+        .keyshares_len = 1,
+        .tuples = { 3 },
+        .tuples_len = 1,
+    },
+};
+
+static int verify_groups(SSL_CTX *ctx, const struct expected_state *st)
+{
+    size_t j;
+
+    if (!TEST_size_t_eq(ctx->ext.supportedgroups_len, st->groups_len))
+        return 0;
+    for (j = 0; j < st->groups_len; j++) {
+        const char *got = tls1_group_id2name(ctx, ctx->ext.supportedgroups[j]);
+
+        if (!TEST_ptr(got))
+            return 0;
+        if (!TEST_str_eq(got, st->groups[j]))
+            return 0;
+    }
+    return 1;
+}
+
+static int verify_keyshares(SSL_CTX *ctx, const struct expected_state *st)
+{
+    size_t j;
+
+    if (!TEST_size_t_eq(ctx->ext.keyshares_len, st->keyshares_len))
+        return 0;
+    for (j = 0; j < st->keyshares_len; j++) {
+        if (st->keyshares[j][0] == '\0') {
+            if (!TEST_uint_eq(ctx->ext.keyshares[j], KS_IMPLICIT))
+                return 0;
+        } else {
+            const char *got = tls1_group_id2name(ctx, ctx->ext.keyshares[j]);
+
+            if (!TEST_ptr(got))
+                return 0;
+            if (!TEST_str_eq(got, st->keyshares[j]))
+                return 0;
+        }
+    }
+    return 1;
+}
+
+static int verify_tuples(SSL_CTX *ctx, const struct expected_state *st)
+{
+    size_t j;
+    size_t sum = 0;
+
+    if (!TEST_size_t_eq(ctx->ext.tuples_len, st->tuples_len))
+        return 0;
+    for (j = 0; j < st->tuples_len; j++) {
+        if (!TEST_size_t_eq(ctx->ext.tuples[j], st->tuples[j]))
+            return 0;
+        sum += ctx->ext.tuples[j];
+    }
+
+    if (!TEST_size_t_eq(sum, ctx->ext.supportedgroups_len))
+        return 0;
+    return 1;
+}
+
+static int test_groups_list_state(int i)
+{
+    int ok = 0;
+    SSL_CTX *ctx = NULL;
+    const struct expected_state *st = &expected_states[i];
+
+    TEST_info("==> Verifying state for: %s", st->list);
+
+    if (!TEST_ptr(ctx = SSL_CTX_new(TLS_method())))
+        goto end;
+    if (!TEST_true(SSL_CTX_set1_groups_list(ctx, st->list)))
+        goto end;
+
+    if (!verify_groups(ctx, st))
+        goto end;
+    if (!verify_keyshares(ctx, st))
+        goto end;
+    if (!verify_tuples(ctx, st))
+        goto end;
+
+    ok = 1;
+end:
+    SSL_CTX_free(ctx);
+    return ok;
+}
+
+int setup_tests(void)
+{
+    ADD_ALL_TESTS(test_groups_list_state, OSSL_NELEM(expected_states));
+    return 1;
+}

--- a/test/recipes/70-test_tls13groupselection.t
+++ b/test/recipes/70-test_tls13groupselection.t
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2025-2026 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -19,8 +19,15 @@ plan skip_all => "needs ECX enabled"
     if disabled("ecx");
 
 
-plan tests => 1;
+plan tests => 2;
 
 ok(run(test(["tls13groupselection_test", srctop_file("apps", "server.pem"),
              srctop_file("apps", "server.pem")])),
    "running tls13groupselection_test");
+
+SKIP: {
+    skip "EC is disabled", 1 if disabled("ec");
+
+    ok(run(test(["groups_list_struct_test"])),
+       "running groups_list_struct_test");
+}


### PR DESCRIPTION
A malformed supported groups list with stacked remove, keyshare and ignore unknown prefixes on bogus tokens used to push gid_cb's inner loop past the live group count and read two bytes off the end of gid_arr. The access only crashes under ASan but it is still undefined behavior, and the call is reachable from openssl s_server -groups and openssl s_client -groups even though SSL_CTX_set1_groups_list is documented as administrator controlled rather than attacker controlled. The patch clamps the loop bound and the float keyshare write against gidcnt so the access stays in bounds when the parse bookkeeping drifts. The existing tls13groupselection test passes unchanged and the reporter's CLI invocation parses through the patched code without errors. Fixes #31315