### PR TITLE
DTLS 1.3 Remove SSL_stateless support

### DIFF
--- a/doc/man3/DTLSv1_listen.pod
+++ b/doc/man3/DTLSv1_listen.pod
@@ -16,7 +16,7 @@ DTLSv1_listen
 =head1 DESCRIPTION
 
 SSL_stateless() statelessly listens for new incoming TLSv1.3 connections.
-DTLSv1_listen() statelessly listens for new incoming DTLS DTLS 1.0 and DTLS 1.2
+DTLSv1_listen() statelessly listens for new incoming DTLS 1.0 and DTLS 1.2
 connections. B<DTLSv1_listen() does not support DTLS 1.3>; for DTLS 1.3 server
 applications, use L<SSL_new_listener(3)> instead. If a ClientHello is received 
 that does not contain a cookie, then they respond with a request for a new

--- a/doc/man3/DTLSv1_listen.pod
+++ b/doc/man3/DTLSv1_listen.pod
@@ -108,6 +108,7 @@ start.
 SSL_stateless() cannot be used with QUIC SSL objects and returns an error if
 called on such an object.
 
+<<<<<<< HEAD
 DTLSv1_listen() with an SSL object configured for a max of DTLSv1.3 will
 silently downgrade it to a max of DTLSv1.2.
 
@@ -117,6 +118,8 @@ DTLS 1.3), DTLSv1_listen() will fail. For DTLS 1.3 server applications that
 require address validation via HelloRetryRequest (HRR), use
 L<SSL_new_listener(3)> with the B<SSL_LISTENER_FLAG_REQUIRE_HRR> flag instead.
 
+=======
+>>>>>>> 750ee206d9 (fixup! DTLS 1.3 Remove SSL_stateless support)
 =head1 RETURN VALUES
 
 For SSL_stateless() a return value of 1 indicates success and the B<ssl> object
@@ -161,7 +164,7 @@ DTLS 1.3 applications should use L<SSL_new_listener(3)> instead.
 
 =head1 COPYRIGHT
 
-Copyright 2015-2023 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2015-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/DTLSv1_listen.pod
+++ b/doc/man3/DTLSv1_listen.pod
@@ -108,7 +108,6 @@ start.
 SSL_stateless() cannot be used with QUIC SSL objects and returns an error if
 called on such an object.
 
-<<<<<<< HEAD
 DTLSv1_listen() with an SSL object configured for a max of DTLSv1.3 will
 silently downgrade it to a max of DTLSv1.2.
 
@@ -118,8 +117,6 @@ DTLS 1.3), DTLSv1_listen() will fail. For DTLS 1.3 server applications that
 require address validation via HelloRetryRequest (HRR), use
 L<SSL_new_listener(3)> with the B<SSL_LISTENER_FLAG_REQUIRE_HRR> flag instead.
 
-=======
->>>>>>> 750ee206d9 (fixup! DTLS 1.3 Remove SSL_stateless support)
 =head1 RETURN VALUES
 
 For SSL_stateless() a return value of 1 indicates success and the B<ssl> object

--- a/doc/man3/DTLSv1_listen.pod
+++ b/doc/man3/DTLSv1_listen.pod
@@ -15,10 +15,10 @@ DTLSv1_listen
 
 =head1 DESCRIPTION
 
-SSL_stateless() statelessly listens for new incoming (D)TLSv1.3 connections.
-DTLSv1_listen() statelessly listens for new incoming DTLS 1.0 and DTLS 1.2
+SSL_stateless() statelessly listens for new incoming TLSv1.3 connections.
+DTLSv1_listen() statelessly listens for new incoming DTLS DTLS 1.0 and DTLS 1.2
 connections. B<DTLSv1_listen() does not support DTLS 1.3>; for DTLS 1.3 server
-applications, use L<SSL_new_listener(3)> instead. If a ClientHello is received
+applications, use L<SSL_new_listener(3)> instead. If a ClientHello is received 
 that does not contain a cookie, then they respond with a request for a new
 ClientHello that does contain a cookie. If a ClientHello is received with a
 cookie that is verified then the function returns in order to enable the
@@ -44,7 +44,7 @@ address. In this case a TLSv1.3 application would be susceptible to this attack.
 As a countermeasure to this issue TLSv1.3 and DTLS include a stateless cookie
 mechanism. The idea is that when a client attempts to connect to a server it
 sends a ClientHello message. The server responds with a HelloRetryRequest (in
-(D)TLSv1.3) or a HelloVerifyRequest (in DTLS) which contains a unique cookie. The
+TLSv1.3) or a HelloVerifyRequest (in DTLS) which contains a unique cookie. The
 client then resends the ClientHello, but this time includes the cookie in the
 message thus proving that the client is capable of receiving messages sent to
 that address. All of this can be done by the server without allocating any
@@ -99,8 +99,8 @@ For SSL_stateless() if an entire ClientHello message cannot be read without the
 application's responsibility to ensure that data read from the "read" BIO during
 a single SSL_stateless() call is all from the same peer.
 
-SSL_stateless() will fail (with a 0 return value) if some (D)TLS version less than
-(D)TLSv1.3 is used.
+SSL_stateless() will fail (with a 0 return value) if some TLS version less than
+TLSv1.3 is used.
 
 Both SSL_stateless() and DTLSv1_listen() will clear the error queue when they
 start.
@@ -161,7 +161,7 @@ DTLS 1.3 applications should use L<SSL_new_listener(3)> instead.
 
 =head1 COPYRIGHT
 
-Copyright 2015-2026 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2015-2023 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7628,60 +7628,14 @@ __owur unsigned int ssl_get_split_send_fragment(const SSL_CONNECTION *sc)
 int SSL_stateless(SSL *s)
 {
     int ret;
-    int dtls_hrr_pending = 0;
-    uint16_t dtls_handshake_read_seq = 0;
-    uint16_t dtls_next_handshake_write_seq = 0;
-    uint64_t dtls_rl_read_seq = 0;
-    uint64_t dtls_rl_write_seq = 0;
     SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL_ONLY(s);
 
     if (sc == NULL)
         return 0;
 
-    /*
-     * For DTLS, track whether we have already sent a HelloRetryRequest so
-     * that we can restore handshake_read_seq after SSL_clear() resets it.
-     * After an HRR the client's second ClientHello carries message seq=1;
-     * if handshake_read_seq is left at 0 the message would be treated as
-     * out-of-order and buffered rather than accepted.
-     */
-    if (SSL_CONNECTION_IS_DTLS(sc) && sc->hello_retry_request == SSL_HRR_PENDING
-        && !ossl_statem_in_error(sc)) {
-        dtls_hrr_pending = 1;
-        dtls_handshake_read_seq = sc->d1->handshake_read_seq;
-        dtls_next_handshake_write_seq = sc->d1->next_handshake_write_seq;
-
-        if (sc->rlayer.wrlmethod->get_sequence && sc->rlayer.rrlmethod->get_sequence) {
-            if (!sc->rlayer.rrlmethod->get_sequence(sc->rlayer.rrl, &dtls_rl_read_seq)
-                || !sc->rlayer.wrlmethod->get_sequence(sc->rlayer.wrl, &dtls_rl_write_seq))
-                return 0;
-        } else {
-            return 0;
-        }
-    }
-
     /* Ensure there is no state left over from a previous invocation */
     if (!SSL_clear(s))
         return 0;
-
-    /*
-     * If we previously sent a DTLS HelloRetryRequest, SSL_clear() has just
-     * reset handshake_read_seq and next_handshake_write_seq to 0.  Restore
-     * them to 1 so that the incoming ClientHello from HRR is recognised as
-     * the expected next message.
-     */
-    if (dtls_hrr_pending) {
-        sc->d1->handshake_read_seq = dtls_handshake_read_seq;
-        sc->d1->next_handshake_write_seq = dtls_next_handshake_write_seq;
-
-        if (sc->rlayer.wrlmethod->set_sequence && sc->rlayer.rrlmethod->set_sequence) {
-            if (!sc->rlayer.rrlmethod->set_sequence(sc->rlayer.rrl, dtls_rl_read_seq)
-                || !sc->rlayer.wrlmethod->set_sequence(sc->rlayer.wrl, dtls_rl_write_seq))
-                return 0;
-        } else {
-            return 0;
-        }
-    }
 
     ERR_clear_error();
 

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -7252,34 +7252,19 @@ static int verify_stateless_cookie_callback(SSL *ssl, const unsigned char *cooki
     return verify_cookie_callback(ssl, cookie, (unsigned int)cookie_len);
 }
 
-static int test_stateless(int idx)
+static int test_stateless(void)
 {
     SSL_CTX *sctx = NULL, *cctx = NULL;
     SSL *serverssl = NULL, *clientssl = NULL;
     int testresult = 0;
-    const SSL_METHOD *smeth, *cmeth;
-    int vermin, vermax = 0;
-    int testdtls = idx >= 1;
 
-    if (testdtls) {
-        smeth = DTLS_server_method();
-        cmeth = DTLS_client_method();
-        vermin = DTLS1_VERSION;
-#if defined(OSSL_NO_USABLE_DTLS1_3) || defined(OPENSSL_NO_DTLS1_2)
-        testresult = TEST_skip("DTLSv1.3 not usable or no DTLSv1.2");
-        goto end;
-#endif
-    } else {
-        smeth = TLS_server_method();
-        cmeth = TLS_client_method();
-        vermin = TLS1_VERSION;
 #if defined(OSSL_NO_USABLE_TLS1_3) || defined(OPENSSL_NO_TLS1_2)
-        testresult = TEST_skip("TLSv1.3 not usable or no TLSv1.2");
-        goto end;
+    testresult = TEST_skip("TLSv1.3 not usable or no TLSv1.2");
+    goto end;
 #endif
-    }
 
-    if (!TEST_true(create_ssl_ctx_pair(libctx, smeth, cmeth, vermin, vermax,
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(), TLS1_VERSION, 0,
             &sctx, &cctx, cert, privkey)))
         goto end;
 
@@ -7322,16 +7307,6 @@ static int test_stateless(int idx)
     /* Abandon the connection from this client */
     SSL_free(clientssl);
     clientssl = NULL;
-
-    /*
-     * Since we are using the same server object for multiple tests
-     * we need to clear it outside of SSL_stateless in this test
-     * to properly reset the handshake_req_seq
-     */
-    if (testdtls) {
-        if (!TEST_true(SSL_clear(serverssl)))
-            goto end;
-    }
 
     /*
      * Now create a connection from a new client but with the same server SSL
@@ -16412,7 +16387,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_custom_exts, 3);
 #endif
 #if !defined(OSSL_NO_USABLE_TLS1_3) || !defined(OSSL_NO_USABLE_DTLS1_3)
-    ADD_ALL_TESTS(test_stateless, 2);
+    ADD_TEST(test_stateless);
 #endif
     ADD_ALL_TESTS(test_export_key_mat, 6);
 #if !defined(OSSL_NO_USABLE_TLS1_3) || !defined(OSSL_NO_USABLE_DTLS1_3)

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -7211,6 +7211,7 @@ end:
     return testresult;
 }
 #endif /* !defined(OSSL_NO_USABLE_TLS1_3) || !defined(OSSL_NO_USABLE_DTLS1_3) */
+#ifndef OSSL_NO_USABLE_TLS1_3
 
 static unsigned char cookie_magic_value[] = "cookie magic";
 
@@ -7257,11 +7258,6 @@ static int test_stateless(void)
     SSL_CTX *sctx = NULL, *cctx = NULL;
     SSL *serverssl = NULL, *clientssl = NULL;
     int testresult = 0;
-
-#if defined(OSSL_NO_USABLE_TLS1_3) || defined(OPENSSL_NO_TLS1_2)
-    testresult = TEST_skip("TLSv1.3 not usable or no TLSv1.2");
-    goto end;
-#endif
 
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
             TLS_client_method(), TLS1_VERSION, 0,
@@ -7340,6 +7336,7 @@ end:
     SSL_CTX_free(cctx);
     return testresult;
 }
+#endif /* OSSL_NO_USABLE_TLS1_3 */
 #endif /* !defined(OSSL_NO_USABLE_TLS1_3) || !defined(OSSL_NO_USABLE_DTLS1_3) */
 
 static int clntaddoldcb = 0;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -16386,7 +16386,7 @@ int setup_tests(void)
 #else
     ADD_ALL_TESTS(test_custom_exts, 3);
 #endif
-#if !defined(OSSL_NO_USABLE_TLS1_3) || !defined(OSSL_NO_USABLE_DTLS1_3)
+#ifndef OSSL_NO_USABLE_TLS1_3
     ADD_TEST(test_stateless);
 #endif
     ADD_ALL_TESTS(test_export_key_mat, 6);


### PR DESCRIPTION
DTLSv1.3 suppport was added into SSL_stateless, but it doesn't work properly. The reason why it doesn't work properly is that it doesn't handle concurrent DTLS sessions being established at the same time.
If you want something that allows DTLS 1.3 connections being establish at the same time use DTLS SSL Listener.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
