### PR TITLE
build: make enable-asan work for VC targets

### DIFF
--- a/Configure
+++ b/Configure
@@ -1626,12 +1626,12 @@ unless ($disabled{threads}) {
     }
 }
 
-# Find out if clang's sanitizers have been enabled with -fsanitize
-# flags and ensure that the corresponding %disabled elements area
-# removed to reflect that the sanitizers are indeed enabled.
+# Find out if clang's sanitizers have been enabled with -fsanitize (or
+# /fsanitize for VC targets) flags and ensure that the corresponding %disabled
+# elements area removed to reflect that the sanitizers are indeed enabled.
 my %detected_sanitizers = ();
-foreach (grep /^-fsanitize=/, @{$config{CFLAGS} || []}) {
-    (my $checks = $_) =~ s/^-fsanitize=//;
+foreach (grep { /^[-\/]fsanitize=/ } @{$config{CFLAGS} || []}) {
+    (my $checks = $_) =~ s|^[-/]fsanitize=||;
     foreach (split /,/, $checks) {
         my $d = { address       => 'asan',
                   undefined     => 'ubsan',
@@ -1666,7 +1666,8 @@ if (($target{shared_target} // '') eq "")
         }
 
 unless ($disabled{asan} || defined $detected_sanitizers{asan}) {
-    push @{$config{cflags}}, "-fsanitize=address";
+    push @{$config{cflags}},
+        $config{target} =~ /^VC-/ ? "/fsanitize=address" : "-fsanitize=address";
 }
 
 unless ($disabled{ubsan} || defined $detected_sanitizers{ubsan}) {
@@ -1679,8 +1680,10 @@ unless ($disabled{msan} || defined $detected_sanitizers{msan}) {
 
 unless ($disabled{"fuzz-libfuzzer"} && $disabled{"fuzz-afl"}
         && $disabled{asan} && $disabled{ubsan} && $disabled{msan}) {
-    push @{$config{cflags}}, "-fno-omit-frame-pointer", "-g";
-    push @{$config{cxxflags}}, "-fno-omit-frame-pointer", "-g" if $config{CXX};
+    unless ($config{target} =~ /^VC-/) {
+        push @{$config{cflags}}, "-fno-omit-frame-pointer", "-g";
+        push @{$config{cxxflags}}, "-fno-omit-frame-pointer", "-g" if $config{CXX};
+    }
 }
 
 # Valgrind-based constant-time validation: marks secret data as "undefined"


### PR DESCRIPTION
Configure assumed GCC/Clang sanitizer spellings, so enable-asan was a no-op on MSVC. Emit /fsanitize=address instead of -fsanitize=address on VC targets.

I needed this to get proper backtraces when debugging mfail and asan works nicely after this change.