### PR TITLE
QUIC: send CONNECTION_CLOSE in all ELs during handshake close

### DIFF
--- a/ssl/quic/quic_txp.c
+++ b/ssl/quic/quic_txp.c
@@ -429,7 +429,7 @@ static int txp_should_try_staging(OSSL_QUIC_TX_PACKETISER *txp,
     uint32_t enc_level,
     uint32_t archetype,
     uint64_t cc_limit,
-    uint32_t *conn_close_enc_level);
+    uint32_t *conn_close_enc_level_mask);
 static size_t txp_determine_pn_len(OSSL_QUIC_TX_PACKETISER *txp);
 static int txp_determine_ppl_from_pl(OSSL_QUIC_TX_PACKETISER *txp,
     size_t pl,
@@ -868,7 +868,7 @@ int ossl_quic_tx_packetiser_generate(OSSL_QUIC_TX_PACKETISER *txp,
      */
     int res = 0, rc;
     uint32_t archetype, enc_level;
-    uint32_t conn_close_enc_level = QUIC_ENC_LEVEL_NUM;
+    uint32_t conn_close_enc_level_mask = 0;
     struct txp_pkt pkt[QUIC_ENC_LEVEL_NUM];
     size_t pkts_done = 0;
     uint64_t cc_limit = txp->args.cc_method->get_tx_allowance(txp->args.cc_data);
@@ -901,7 +901,7 @@ int ossl_quic_tx_packetiser_generate(OSSL_QUIC_TX_PACKETISER *txp,
         pkt[enc_level].geom.hwm = running_total;
 
         if (!txp_should_try_staging(txp, enc_level, archetype, cc_limit,
-                &conn_close_enc_level))
+                &conn_close_enc_level_mask))
             continue;
 
         if (!txp_pkt_init(&pkt[enc_level], txp, enc_level, archetype,
@@ -914,7 +914,7 @@ int ossl_quic_tx_packetiser_generate(OSSL_QUIC_TX_PACKETISER *txp,
             break;
 
         rc = txp_generate_for_el(txp, &pkt[enc_level],
-            conn_close_enc_level == enc_level);
+            (conn_close_enc_level_mask >> enc_level) & 1);
         if (rc != TXP_ERR_SUCCESS)
             goto out;
 
@@ -1434,7 +1434,7 @@ static int txp_should_try_staging(OSSL_QUIC_TX_PACKETISER *txp,
     uint32_t enc_level,
     uint32_t archetype,
     uint64_t cc_limit,
-    uint32_t *conn_close_enc_level)
+    uint32_t *conn_close_enc_level_mask)
 {
     struct archetype_data a;
     uint32_t pn_space = ossl_quic_enc_level_to_pn_space(enc_level);
@@ -1451,12 +1451,10 @@ static int txp_should_try_staging(OSSL_QUIC_TX_PACKETISER *txp,
         return 0;
 
     /*
-     * We can produce CONNECTION_CLOSE frames on any EL in principle, which
-     * means we need to choose which EL we would prefer to use. After a
+     * We can produce CONNECTION_CLOSE frames on any EL in principle. After a
      * connection is fully established we have only one provisioned EL and this
      * is a non-issue. Where multiple ELs are provisioned, it is possible the
-     * peer does not have the keys for the EL yet, which suggests in general it
-     * is preferable to use the lowest EL which is still provisioned.
+     * peer does not have the keys for all ELs yet.
      *
      * However (RFC 9000 s. 10.2.3 & 12.5) we are also required to not send
      * application CONNECTION_CLOSE frames in non-1-RTT ELs, so as to not
@@ -1464,25 +1462,23 @@ static int txp_should_try_staging(OSSL_QUIC_TX_PACKETISER *txp,
      * authenticated. Thus when we have an application CONNECTION_CLOSE frame
      * queued and need to send it on a non-1-RTT EL, we have to convert it
      * into a transport CONNECTION_CLOSE frame which contains no application
-     * data. Since this loses information, it suggests we should use the 1-RTT
-     * EL to avoid this if possible, even if a lower EL is also available.
+     * data; see txp_generate_pre_token.
      *
-     * At the same time, just because we have the 1-RTT EL provisioned locally
-     * does not necessarily mean the peer does, for example if a handshake
-     * CRYPTO frame has been lost. It is fairly important that CONNECTION_CLOSE
-     * is signalled in a way we know our peer can decrypt, as we stop processing
-     * connection retransmission logic for real after connection close and
-     * simply 'blindly' retransmit the same CONNECTION_CLOSE frame.
+     * Just because we have the 1-RTT EL provisioned locally does not
+     * necessarily mean the peer does, for example if a handshake CRYPTO frame
+     * has been lost. It is fairly important that CONNECTION_CLOSE is signalled
+     * in a way we know our peer can decrypt, as we stop processing connection
+     * retransmission logic for real after connection close and simply 'blindly'
+     * retransmit the same CONNECTION_CLOSE frame.
      *
      * This is not a major concern for clients, since if a client has a 1-RTT EL
      * provisioned the server is guaranteed to also have a 1-RTT EL provisioned.
      *
-     * TODO(QUIC FUTURE): Revisit this when when have reached a decision on how
-     * best to implement this
+     * Per RFC 9000 s. 10.2.3, we therefore send CONNECTION_CLOSE in all
+     * provisioned ELs, excluding 0-RTT which the RFC treats separately.
      */
-    if (*conn_close_enc_level > enc_level
-        && *conn_close_enc_level != QUIC_ENC_LEVEL_1RTT)
-        *conn_close_enc_level = enc_level;
+    if (a.allow_conn_close && enc_level != QUIC_ENC_LEVEL_0RTT)
+        *conn_close_enc_level_mask |= (1U << enc_level);
 
     /* Do we need to send a PTO probe? */
     if (a.allow_force_ack_eliciting) {
@@ -1529,12 +1525,12 @@ static int txp_should_try_staging(OSSL_QUIC_TX_PACKETISER *txp,
         return 1;
 
     /* Do we want to produce a CONNECTION_CLOSE frame? */
-    if (a.allow_conn_close && txp->want_conn_close && *conn_close_enc_level == enc_level)
+    if (txp->want_conn_close && ((*conn_close_enc_level_mask >> enc_level) & 1))
         /*
          * This is a bit of a special case since CONNECTION_CLOSE can appear in
          * most packet types, and when we decide we want to send it this status
-         * isn't tied to a specific EL. So if we want to send it, we send it
-         * only on the lowest non-dropped EL.
+         * isn't tied to a specific EL. Per RFC 9000 s. 10.2.3 we send it on
+         * all provisioned ELs (see above).
          */
         return 1;
 

--- a/test/quic_txp_test.c
+++ b/test/quic_txp_test.c
@@ -1286,6 +1286,77 @@ static const struct script_op script_18[] = {
                                                         OP_END
 };
 
+/*
+ * 19. Handshake + 1-RTT, CONNECTION_CLOSE in both ELs (RFC 9000 s. 10.2.3)
+ *
+ * When both Handshake and 1-RTT ELs are provisioned (e.g. server that has
+ * completed the TLS handshake but the client has not yet confirmed it),
+ * CONNECTION_CLOSE must be sent in both ELs so the peer can process at least
+ * one.
+ */
+static int check_19(struct helper *h)
+{
+    if (!TEST_int_eq(h->frame.conn_close.is_app, 0)
+        || !TEST_uint64_t_eq(h->frame.conn_close.error_code, 2345))
+        return 0;
+
+    return 1;
+}
+
+static const struct script_op script_19[] = {
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE, QRL_SUITE_AES128GCM, secret_1)
+        OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1)
+            OP_CHECK(gen_conn_close)
+                OP_TXP_GENERATE()
+    /* First packet: Handshake with CONNECTION_CLOSE */
+    OP_RX_PKT()
+        OP_NEXT_FRAME()
+            OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_CONN_CLOSE_TRANSPORT)
+                OP_CHECK(check_19)
+                    OP_EXPECT_NO_FRAME()
+    /* Second packet: 1-RTT with CONNECTION_CLOSE */
+    OP_RX_PKT()
+        OP_NEXT_FRAME()
+            OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_CONN_CLOSE_TRANSPORT)
+                OP_CHECK(check_19)
+                    OP_EXPECT_NO_FRAME()
+                        OP_RX_PKT_NONE()
+                            OP_END
+};
+
+/*
+ * 20. Initial + Handshake + 1-RTT, CONNECTION_CLOSE in all ELs (RFC 9000
+ * s. 10.2.3). A server before any EL has been discarded should send
+ * CONNECTION_CLOSE in all three provisioned ELs.
+ */
+static const struct script_op script_20[] = {
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_INITIAL, QRL_SUITE_AES128GCM, secret_1)
+        OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE, QRL_SUITE_AES128GCM, secret_1)
+            OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1)
+                OP_CHECK(gen_conn_close)
+                    OP_TXP_GENERATE()
+    /* First packet: Initial with CONNECTION_CLOSE */
+    OP_RX_PKT()
+        OP_NEXT_FRAME()
+            OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_CONN_CLOSE_TRANSPORT)
+                OP_CHECK(check_19)
+                    OP_EXPECT_NO_FRAME()
+    /* Second packet: Handshake with CONNECTION_CLOSE */
+    OP_RX_PKT()
+        OP_NEXT_FRAME()
+            OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_CONN_CLOSE_TRANSPORT)
+                OP_CHECK(check_19)
+                    OP_EXPECT_NO_FRAME()
+    /* Third packet: 1-RTT with CONNECTION_CLOSE */
+    OP_RX_PKT()
+        OP_NEXT_FRAME()
+            OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_CONN_CLOSE_TRANSPORT)
+                OP_CHECK(check_19)
+                    OP_EXPECT_NO_FRAME()
+                        OP_RX_PKT_NONE()
+                            OP_END
+};
+
 static const struct script_op *const scripts[] = {
     script_1,
     script_2,
@@ -1304,7 +1375,9 @@ static const struct script_op *const scripts[] = {
     script_15,
     script_16,
     script_17,
-    script_18
+    script_18,
+    script_19,
+    script_20
 };
 
 static void skip_padding(struct helper *h)


### PR DESCRIPTION
There is a case where a server closes a connection during the handshake. For example, after completing TLS but before the client has confirmed it (could happen if the HANDSHAKE_DONE packet was lost).

In this case, the server should send CONNECTION_CLOSE at both Handshake and Initial encryption levels so the client can decrypt at least one. OpenSSL was only sending at the lowest available level, but the client may have advanced past Handshake and can no longer decrypt those packets.

Previously, there was a single `conn_close_enc_level` that tracked only the lowest available EL to later send the CONNECTION_CLOSE packet in that EL. This was replaced with a `conn_close_enc_level_mask` bitmask. Every available non-0-RTT EL sets a bit in the mask, and so the resulting datagram contains CONNECTION_CLOSE for all of them.

Fixes https://github.com/openssl/project/issues/940

##### Checklist

- [x] tests are added or updated
