### PR TITLE
ci: fix expression injection in check-news-changes workflow

### DIFF
--- a/.github/workflows/check-news-changes.yml
+++ b/.github/workflows/check-news-changes.yml
@@ -13,6 +13,9 @@ env:
   SKIP_NEWS_CHECK: "no"
   PR_NUMBER: ${{ github.event.number }}
   GH_TOKEN: ${{ github.token }}
+  BASE_SHA: ${{ github.event.pull_request.base.sha }}
+  HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+  HEAD_REF: ${{ github.head_ref }}
 permissions: {}
 
 jobs:
@@ -33,8 +36,8 @@ jobs:
       - name: "Check if we already have a NEWS/CHANGES entry"
         if: ${{ env.SKIP_NEWS_CHECK == 'no' }}
         run: |
-          git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} > ./names.txt
-          echo "changed files between ${{ github.event.pull_request.base.sha }} and ${{ github.event.pull_request.head.sha }}"
+          git diff --name-only $BASE_SHA..$HEAD_SHA > ./names.txt
+          echo "changed files between $BASE_SHA and $HEAD_SHA"
           cat ./names.txt
           set +e
           grep -q "NEWS\.md" names.txt
@@ -51,7 +54,7 @@ jobs:
       - name: "Check if this PR affects a CVE"
         if: ${{ env.FOUND_NEWS_CHANGES_ADDITION == 'no' && env.SKIP_NEWS_CHECK == 'no' }}
         run: |
-          git log ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} > ./log.txt
+          git log $BASE_SHA..$HEAD_SHA > ./log.txt
           set +e
           grep -q "CVE-" ./log.txt
           if [ $? -eq 0 ]; then
@@ -62,8 +65,8 @@ jobs:
         if: ${{ env.FOUND_NEWS_CHANGES_ADDITION == 'no' && env.SKIP_NEWS_CHECK == 'no' }}
         run: |
           set +e
-          git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} > ./names.txt
-          echo "changed files between ${{ github.event.pull_request.base.sha }} and ${{ github.event.pull_request.head.sha }}"
+          git diff --name-only $BASE_SHA..$HEAD_SHA > ./names.txt
+          echo "changed files between $BASE_SHA and $HEAD_SHA"
           cat ./names.txt
           grep -q "include/openssl" ./names.txt
           if [ $? -eq 0 ]; then
@@ -74,7 +77,7 @@ jobs:
         if: ${{ env.FOUND_NEWS_CHANGES_ADDITION == 'no' && env.SKIP_NEWS_CHECK == 'no' }}
         run: |
           set +e
-          echo ${{ github.head_ref }} | grep -q "feature"
+          echo "$HEAD_REF" | grep -q "feature"
           if [ $? -eq 0 ]; then
             echo "Feature branch found"
             echo "NEED_NEWS_CHANGES=yes" >> $GITHUB_ENV
@@ -82,10 +85,10 @@ jobs:
       - name: "Check if configuration options have changed"
         if: ${{ env.FOUND_NEWS_CHANGES_ADDITION == 'no' && env.SKIP_NEWS_CHECK == 'no' }}
         run: | 
-          git checkout ${{ github.event.pull_request.base.sha }}
+          git checkout $BASE_SHA
           set +e
           ./Configure --help > ./before.txt 2>&1
-          git checkout ${{ github.event.pull_request.head.sha }}
+          git checkout $HEAD_SHA
           ./Configure --help > ./after.txt 2>&1
           set -e
           CONF_CHANGE=$(diff ./before.txt ./after.txt | wc -l)


### PR DESCRIPTION
## Summary

The `check-news-changes.yml` workflow injects user-controlled values directly into shell `run` steps.

### Critical: `github.head_ref` injection

```yaml
run: |
  echo ${{ github.head_ref }} | grep -q "feature"
```

`github.head_ref` is the PR's source branch name — **fully controlled by the PR author**. Naming a branch `x$(malicious_command)` would execute arbitrary shell commands in the CI runner.

### Also fixed: PR SHA values inline in shell

Multiple steps used `${{ github.event.pull_request.base.sha }}` and `${{ github.event.pull_request.head.sha }}` directly in `git` commands. SHAs are hex-constrained but the pattern is flagged by zizmor/actionlint.

### Also fixed: pin `actions/checkout@v6` to full commit SHA

## Fix

Add `BASE_SHA`, `HEAD_SHA`, and `HEAD_REF` to the job-level `env` block, then reference the env vars in all shell steps.

Ref: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections