### PR TITLE
uni2utf8: reject negative length like uni2asc

### DIFF
--- a/crypto/pkcs12/p12_utl.c
+++ b/crypto/pkcs12/p12_utl.c
@@ -188,6 +188,8 @@ char *OPENSSL_uni2utf8(const unsigned char *uni, int unilen)
     /* string must contain an even number of bytes */
     if (unilen & 1)
         return NULL;
+    if (unilen < 0)
+        return NULL;
 
     for (asclen = 0, i = 0; i < unilen;) {
         j = bmp_to_utf8(NULL, uni + i, unilen - i);


### PR DESCRIPTION
OPENSSL_uni2utf8 only rejects odd lengths, but its sibling OPENSSL_uni2asc also rejects negative ones. A negative even unilen skips the conversion loop and the trailing-zero probe then reads uni[unilen - 2] and uni[unilen - 1], two bytes before the buffer. Add the same unilen < 0 guard.