### PR TITLE
Remove unused certs / crl config entries

### DIFF
--- a/VMS/VMSify-conf.pl
+++ b/VMS/VMSify-conf.pl
@@ -12,7 +12,7 @@ use warnings;
 
 my @directory_vars = ( "dir", "certs", "new_certs_dir" );
 my @file_vars = ( "database", "certificate", "serial", "crlnumber",
-		  "crl", "private_key", "RANDFILE" );
+		  "private_key", "RANDFILE" );
 while(<STDIN>) {
     s|\R$||;
     foreach my $d (@directory_vars) {

--- a/apps/openssl-vms.cnf
+++ b/apps/openssl-vms.cnf
@@ -99,7 +99,6 @@ certificate	= $dir]cacert.pem 	# The CA certificate
 serial		= $dir]serial. 		# The current serial number
 crlnumber	= $dir]crlnumber.	# the current crl number
 					# must be commented out to leave a V1 CRL
-crl		= $dir]crl.pem 		# The current CRL
 private_key	= $dir.private]cakey.pem # The private key
 
 x509_extensions	= usr_cert		# The extensions to add to the cert

--- a/apps/openssl-vms.cnf
+++ b/apps/openssl-vms.cnf
@@ -90,7 +90,6 @@ default_ca	= CA_default		# The default ca section
 [ CA_default ]
 
 dir		= sys\$disk:[.demoCA		# Where everything is kept
-certs		= $dir.certs]		# Where the issued certs are kept
 database	= $dir]index.txt	# database index file.
 #unique_subject	= no			# Set to 'no' to allow creation of
 					# several certs with same subject.

--- a/apps/openssl.cnf
+++ b/apps/openssl.cnf
@@ -90,7 +90,6 @@ default_ca	= CA_default		# The default ca section
 [ CA_default ]
 
 dir		= ./demoCA		# Where everything is kept
-certs		= $dir/certs		# Where the issued certs are kept
 database	= $dir/index.txt	# database index file.
 #unique_subject	= no			# Set to 'no' to allow creation of
 					# several certs with same subject.

--- a/apps/openssl.cnf
+++ b/apps/openssl.cnf
@@ -99,7 +99,6 @@ certificate	= $dir/cacert.pem 	# The CA certificate
 serial		= $dir/serial 		# The current serial number
 crlnumber	= $dir/crlnumber	# the current crl number
 					# must be commented out to leave a V1 CRL
-crl		= $dir/crl.pem 		# The current CRL
 private_key	= $dir/private/cakey.pem # The private key
 
 x509_extensions	= usr_cert		# The extensions to add to the cert

--- a/test/CAtsa.cnf
+++ b/test/CAtsa.cnf
@@ -26,7 +26,6 @@ default_ca	= CA_default		# The default ca section
 [ CA_default ]
 
 dir		= ./demoCA
-certs		= $dir/certs		# Where the issued certs are kept
 database	= $dir/index.txt	# database index file.
 new_certs_dir	= $dir/newcerts		# default place for new certs.
 

--- a/test/ca-and-certs.cnf
+++ b/test/ca-and-certs.cnf
@@ -74,7 +74,6 @@ default_ca	= CA_default
 
 [ CA_default ]
 dir		= ./demoCA
-certs		= $dir/certs
 database	= $dir/index.txt
 new_certs_dir	= $dir/newcerts
 certificate	= $dir/cacert.pem

--- a/test/ca-and-certs.cnf
+++ b/test/ca-and-certs.cnf
@@ -78,7 +78,6 @@ database	= $dir/index.txt
 new_certs_dir	= $dir/newcerts
 certificate	= $dir/cacert.pem
 serial		= $dir/serial
-crl		= $dir/crl.pem
 private_key	= $dir/private/cakey.pem
 x509_extensions	= v3_ca
 name_opt 	= ca_default

--- a/test/recipes/90-test_includes_data/conf-includes/includes1.cnf
+++ b/test/recipes/90-test_includes_data/conf-includes/includes1.cnf
@@ -12,7 +12,6 @@ default_ca	= CA_default		# The default ca section
 [ CA_default ]
 
 dir		= ./demoCA		# Where everything is kept
-certs		= $dir/certs		# Where the issued certs are kept
 database	= $dir/index.txt	# database index file.
 new_certs_dir	= $dir/new_certs	# default place for new certs.
 

--- a/test/recipes/90-test_includes_data/conf-includes/includes1.cnf
+++ b/test/recipes/90-test_includes_data/conf-includes/includes1.cnf
@@ -17,7 +17,6 @@ new_certs_dir	= $dir/new_certs	# default place for new certs.
 
 certificate	= $dir/CAcert.pem 	# The CA certificate
 serial		= $dir/serial 		# The current serial number
-crl		= $dir/crl.pem 		# The current CRL
 private_key	= $dir/private/CAkey.pem# The private key
 
 default_days	= 365			# how long to certify for

--- a/test/test.cnf
+++ b/test/test.cnf
@@ -12,7 +12,6 @@ new_certs_dir	= $dir/new_certs	# default place for new certs.
 
 certificate	= $dir/CAcert.pem 	# The CA certificate
 serial		= $dir/serial 		# The current serial number
-crl		= $dir/crl.pem 		# The current CRL
 private_key	= $dir/private/CAkey.pem# The private key
 
 default_days	= 365			# how long to certify for

--- a/test/test.cnf
+++ b/test/test.cnf
@@ -7,7 +7,6 @@ default_ca	= CA_default		# The default ca section
 [ CA_default ]
 
 dir		= ./demoCA		# Where everything is kept
-certs		= $dir/certs		# Where the issued certs are kept
 database	= $dir/index.txt	# database index file.
 new_certs_dir	= $dir/new_certs	# default place for new certs.
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

Remove the unused `certs` and `crl` settings from the CA_default section in example and test config files.

The `certs` and `crl` settings in CA_default section are not used anywhere in the codebase. The macros referencing them (`ENV_CERTS` and `ENV_CRL`) were removed from `apps/ca.c` in 2015 (commit 070c23325a) along with `crl_dir`.

This is a follow-up to the `crl_dir` removal in PR #31215 which addressed issue #31103.

All tests pass.

Fixes [#31218](https://github.com/openssl/openssl/issues/31218)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

