### PR TITLE
Fix missing dependency on ml_kem_kmgmt.c

### DIFF
--- a/providers/implementations/keymgmt/build.info
+++ b/providers/implementations/keymgmt/build.info
@@ -47,7 +47,7 @@ IF[{- !$disabled{'ml-kem'} -}]
     SOURCE[$TLS_ML_KEM_HYBRID_GOAL]=mlx_kmgmt.c
   ENDIF
   SOURCE[$ML_KEM_GOAL]=ml_kem_kmgmt.c
-  DEPEND[ml_kem_kmgmt.o]=../../common/include/prov/der_hkdf.h
+  DEPEND[ml_kem_kmgmt.o]=../../common/include/prov/der_hkdf.h ../../common/include/prov/der_wrap.h
 ENDIF
 
 SOURCE[$RSA_GOAL]=rsa_kmgmt.c


### PR DESCRIPTION
ml_kem_keymgmt.c includes der_wrap.h, which is a generated file, but doesn't include a depdency in its build.info file, meaning that if the dependencies aren't run in the right order, ml_kem_keymgmt.c gets compiled before der_wrap.h is generated, leading to a build break.

Fix it by including the needed dependency.

Fixes #31379


