### PR TITLE
Fix macro staircase formatting issue

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1375,6 +1375,10 @@ StatementMacros:
   - "static_ASN1_SEQUENCE_END_cb"
   - "static_ASN1_SEQUENCE_END_name"
   - "static_ASN1_SEQUENCE_END_ref"
+  - "PROV_CIPHER_HW_aria_mode"
+  - "PROV_CIPHER_HW_camellia_mode"
+  - "PROV_CIPHER_HW_des_mode"
+  - "PROV_CIPHER_HW_sm4_mode"
   # This isn't quite right, but it causes clang-format to do a slightly better
   # job formatting this macro.
   - "ASN1_EX_TEMPLATE_TYPE"

--- a/crypto/bn/bn_nist.c
+++ b/crypto/bn/bn_nist.c
@@ -281,7 +281,7 @@ static void nist_cp_bn(BN_ULONG *dst, const BN_ULONG *src, int top)
 }
 
 #if BN_BITS2 == 64
-#define bn_cp_64(to, n, from, m) (to)[n] = (m >= 0) ? ((from)[m]) : 0
+#define bn_cp_64(to, n, from, m) ((to)[n] = ((m) >= 0) ? ((from)[m]) : 0)
 #define bn_64_set_0(to, n) (to)[n] = (BN_ULONG)0
 /*
  * two following macros are implemented under assumption that they
@@ -309,7 +309,7 @@ static void nist_cp_bn(BN_ULONG *dst, const BN_ULONG *src, int top)
         bn_32_set_0(to, (n) * 2);     \
         bn_32_set_0(to, (n) * 2 + 1); \
     }
-#define bn_cp_32(to, n, from, m) (to)[n] = (m >= 0) ? ((from)[m]) : 0
+#define bn_cp_32(to, n, from, m) ((to)[n] = ((m) >= 0) ? ((from)[m]) : 0)
 #define bn_32_set_0(to, n) (to)[n] = (BN_ULONG)0;
 #if defined(_WIN32) && !defined(__GNUC__)
 #define NIST_INT64 __int64

--- a/crypto/bn/bn_nist.c
+++ b/crypto/bn/bn_nist.c
@@ -309,7 +309,7 @@ static void nist_cp_bn(BN_ULONG *dst, const BN_ULONG *src, int top)
         bn_32_set_0(to, (n) * 2);     \
         bn_32_set_0(to, (n) * 2 + 1); \
     }
-#define bn_cp_32(to, n, from, m) (to)[n] = (m >= 0) ? ((from)[m]) : 0;
+#define bn_cp_32(to, n, from, m) (to)[n] = (m >= 0) ? ((from)[m]) : 0
 #define bn_32_set_0(to, n) (to)[n] = (BN_ULONG)0;
 #if defined(_WIN32) && !defined(__GNUC__)
 #define NIST_INT64 __int64
@@ -340,12 +340,14 @@ static ossl_inline void store_lo32(void *ptr, NIST_INT64 val)
 }
 #endif /* NIST_INT64 */
 
+/* clang-format off */
 #define nist_set_192(to, from, a1, a2, a3)      \
     {                                           \
         bn_cp_64(to, 0, from, (a3) - 3)         \
-            bn_cp_64(to, 1, from, (a2) - 3)     \
-                bn_cp_64(to, 2, from, (a1) - 3) \
+        bn_cp_64(to, 1, from, (a2) - 3)         \
+        bn_cp_64(to, 2, from, (a1) - 3)         \
     }
+/* clang-format on */
 
 int BN_nist_mod_192(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
     BN_CTX *ctx)
@@ -471,15 +473,15 @@ int BN_nist_mod_192(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
 typedef BN_ULONG (*bn_addsub_f)(BN_ULONG *, const BN_ULONG *,
     const BN_ULONG *, int);
 
-#define nist_set_224(to, from, a1, a2, a3, a4, a5, a6, a7)      \
-    {                                                           \
-        bn_cp_32(to, 0, from, (a7) - 7)                         \
-            bn_cp_32(to, 1, from, (a6) - 7)                     \
-                bn_cp_32(to, 2, from, (a5) - 7)                 \
-                    bn_cp_32(to, 3, from, (a4) - 7)             \
-                        bn_cp_32(to, 4, from, (a3) - 7)         \
-                            bn_cp_32(to, 5, from, (a2) - 7)     \
-                                bn_cp_32(to, 6, from, (a1) - 7) \
+#define nist_set_224(to, from, a1, a2, a3, a4, a5, a6, a7) \
+    {                                                      \
+        bn_cp_32(to, 0, from, (a7) - 7);                   \
+        bn_cp_32(to, 1, from, (a6) - 7);                   \
+        bn_cp_32(to, 2, from, (a5) - 7);                   \
+        bn_cp_32(to, 3, from, (a4) - 7);                   \
+        bn_cp_32(to, 4, from, (a3) - 7);                   \
+        bn_cp_32(to, 5, from, (a2) - 7);                   \
+        bn_cp_32(to, 6, from, (a1) - 7);                   \
     }
 
 int BN_nist_mod_224(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
@@ -636,16 +638,16 @@ int BN_nist_mod_224(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
     return 1;
 }
 
-#define nist_set_256(to, from, a1, a2, a3, a4, a5, a6, a7, a8)      \
-    {                                                               \
-        bn_cp_32(to, 0, from, (a8) - 8)                             \
-            bn_cp_32(to, 1, from, (a7) - 8)                         \
-                bn_cp_32(to, 2, from, (a6) - 8)                     \
-                    bn_cp_32(to, 3, from, (a5) - 8)                 \
-                        bn_cp_32(to, 4, from, (a4) - 8)             \
-                            bn_cp_32(to, 5, from, (a3) - 8)         \
-                                bn_cp_32(to, 6, from, (a2) - 8)     \
-                                    bn_cp_32(to, 7, from, (a1) - 8) \
+#define nist_set_256(to, from, a1, a2, a3, a4, a5, a6, a7, a8) \
+    {                                                          \
+        bn_cp_32(to, 0, from, (a8) - 8);                       \
+        bn_cp_32(to, 1, from, (a7) - 8);                       \
+        bn_cp_32(to, 2, from, (a6) - 8);                       \
+        bn_cp_32(to, 3, from, (a5) - 8);                       \
+        bn_cp_32(to, 4, from, (a4) - 8);                       \
+        bn_cp_32(to, 5, from, (a3) - 8);                       \
+        bn_cp_32(to, 6, from, (a2) - 8);                       \
+        bn_cp_32(to, 7, from, (a1) - 8);                       \
     }
 
 int BN_nist_mod_256(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
@@ -865,20 +867,20 @@ int BN_nist_mod_256(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
     return 1;
 }
 
-#define nist_set_384(to, from, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)     \
-    {                                                                                 \
-        bn_cp_32(to, 0, from, (a12) - 12)                                             \
-            bn_cp_32(to, 1, from, (a11) - 12)                                         \
-                bn_cp_32(to, 2, from, (a10) - 12)                                     \
-                    bn_cp_32(to, 3, from, (a9) - 12)                                  \
-                        bn_cp_32(to, 4, from, (a8) - 12)                              \
-                            bn_cp_32(to, 5, from, (a7) - 12)                          \
-                                bn_cp_32(to, 6, from, (a6) - 12)                      \
-                                    bn_cp_32(to, 7, from, (a5) - 12)                  \
-                                        bn_cp_32(to, 8, from, (a4) - 12)              \
-                                            bn_cp_32(to, 9, from, (a3) - 12)          \
-                                                bn_cp_32(to, 10, from, (a2) - 12)     \
-                                                    bn_cp_32(to, 11, from, (a1) - 12) \
+#define nist_set_384(to, from, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) \
+    {                                                                             \
+        bn_cp_32(to, 0, from, (a12) - 12);                                        \
+        bn_cp_32(to, 1, from, (a11) - 12);                                        \
+        bn_cp_32(to, 2, from, (a10) - 12);                                        \
+        bn_cp_32(to, 3, from, (a9) - 12);                                         \
+        bn_cp_32(to, 4, from, (a8) - 12);                                         \
+        bn_cp_32(to, 5, from, (a7) - 12);                                         \
+        bn_cp_32(to, 6, from, (a6) - 12);                                         \
+        bn_cp_32(to, 7, from, (a5) - 12);                                         \
+        bn_cp_32(to, 8, from, (a4) - 12);                                         \
+        bn_cp_32(to, 9, from, (a3) - 12);                                         \
+        bn_cp_32(to, 10, from, (a2) - 12);                                        \
+        bn_cp_32(to, 11, from, (a1) - 12);                                        \
     }
 
 int BN_nist_mod_384(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,

--- a/crypto/bn/bn_nist.c
+++ b/crypto/bn/bn_nist.c
@@ -281,8 +281,8 @@ static void nist_cp_bn(BN_ULONG *dst, const BN_ULONG *src, int top)
 }
 
 #if BN_BITS2 == 64
-#define bn_cp_64(to, n, from, m) (to)[n] = (m >= 0) ? ((from)[m]) : 0;
-#define bn_64_set_0(to, n) (to)[n] = (BN_ULONG)0;
+#define bn_cp_64(to, n, from, m) (to)[n] = (m >= 0) ? ((from)[m]) : 0
+#define bn_64_set_0(to, n) (to)[n] = (BN_ULONG)0
 /*
  * two following macros are implemented under assumption that they
  * are called in a sequence with *ascending* n, i.e. as they are...
@@ -340,14 +340,12 @@ static ossl_inline void store_lo32(void *ptr, NIST_INT64 val)
 }
 #endif /* NIST_INT64 */
 
-/* clang-format off */
-#define nist_set_192(to, from, a1, a2, a3)      \
-    {                                           \
-        bn_cp_64(to, 0, from, (a3) - 3)         \
-        bn_cp_64(to, 1, from, (a2) - 3)         \
-        bn_cp_64(to, 2, from, (a1) - 3)         \
+#define nist_set_192(to, from, a1, a2, a3) \
+    {                                      \
+        bn_cp_64(to, 0, from, (a3) - 3);   \
+        bn_cp_64(to, 1, from, (a2) - 3);   \
+        bn_cp_64(to, 2, from, (a1) - 3);   \
     }
-/* clang-format on */
 
 int BN_nist_mod_192(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
     BN_CTX *ctx)

--- a/providers/implementations/ciphers/cipher_aria_hw.c
+++ b/providers/implementations/ciphers/cipher_aria_hw.c
@@ -43,10 +43,12 @@ IMPLEMENT_CIPHER_HW_COPYCTX(cipher_hw_aria_copyctx, PROV_ARIA_CTX)
         return &aria_##mode;                                              \
     }
 
+/* clang-format off */
 PROV_CIPHER_HW_aria_mode(cbc)
-    PROV_CIPHER_HW_aria_mode(ecb)
-        PROV_CIPHER_HW_aria_mode(ofb128)
-            PROV_CIPHER_HW_aria_mode(cfb128)
-                PROV_CIPHER_HW_aria_mode(cfb1)
-                    PROV_CIPHER_HW_aria_mode(cfb8)
-                        PROV_CIPHER_HW_aria_mode(ctr)
+PROV_CIPHER_HW_aria_mode(ecb)
+PROV_CIPHER_HW_aria_mode(ofb128)
+PROV_CIPHER_HW_aria_mode(cfb128)
+PROV_CIPHER_HW_aria_mode(cfb1)
+PROV_CIPHER_HW_aria_mode(cfb8)
+PROV_CIPHER_HW_aria_mode(ctr)
+    /* clang-format on */

--- a/providers/implementations/ciphers/cipher_aria_hw.c
+++ b/providers/implementations/ciphers/cipher_aria_hw.c
@@ -43,7 +43,6 @@ IMPLEMENT_CIPHER_HW_COPYCTX(cipher_hw_aria_copyctx, PROV_ARIA_CTX)
         return &aria_##mode;                                              \
     }
 
-/* clang-format off */
 PROV_CIPHER_HW_aria_mode(cbc)
 PROV_CIPHER_HW_aria_mode(ecb)
 PROV_CIPHER_HW_aria_mode(ofb128)
@@ -51,4 +50,3 @@ PROV_CIPHER_HW_aria_mode(cfb128)
 PROV_CIPHER_HW_aria_mode(cfb1)
 PROV_CIPHER_HW_aria_mode(cfb8)
 PROV_CIPHER_HW_aria_mode(ctr)
-    /* clang-format on */

--- a/providers/implementations/ciphers/cipher_camellia_hw.c
+++ b/providers/implementations/ciphers/cipher_camellia_hw.c
@@ -63,7 +63,6 @@ IMPLEMENT_CIPHER_HW_COPYCTX(cipher_hw_camellia_copyctx, PROV_CAMELLIA_CTX)
         PROV_CIPHER_HW_select(mode) return &camellia_##mode; \
     }
 
-/* clang-format off */
 PROV_CIPHER_HW_camellia_mode(cbc)
 PROV_CIPHER_HW_camellia_mode(ecb)
 PROV_CIPHER_HW_camellia_mode(ofb128)
@@ -71,4 +70,3 @@ PROV_CIPHER_HW_camellia_mode(cfb128)
 PROV_CIPHER_HW_camellia_mode(cfb1)
 PROV_CIPHER_HW_camellia_mode(cfb8)
 PROV_CIPHER_HW_camellia_mode(ctr)
-    /* clang-format on */

--- a/providers/implementations/ciphers/cipher_camellia_hw.c
+++ b/providers/implementations/ciphers/cipher_camellia_hw.c
@@ -63,10 +63,12 @@ IMPLEMENT_CIPHER_HW_COPYCTX(cipher_hw_camellia_copyctx, PROV_CAMELLIA_CTX)
         PROV_CIPHER_HW_select(mode) return &camellia_##mode; \
     }
 
+/* clang-format off */
 PROV_CIPHER_HW_camellia_mode(cbc)
-    PROV_CIPHER_HW_camellia_mode(ecb)
-        PROV_CIPHER_HW_camellia_mode(ofb128)
-            PROV_CIPHER_HW_camellia_mode(cfb128)
-                PROV_CIPHER_HW_camellia_mode(cfb1)
-                    PROV_CIPHER_HW_camellia_mode(cfb8)
-                        PROV_CIPHER_HW_camellia_mode(ctr)
+PROV_CIPHER_HW_camellia_mode(ecb)
+PROV_CIPHER_HW_camellia_mode(ofb128)
+PROV_CIPHER_HW_camellia_mode(cfb128)
+PROV_CIPHER_HW_camellia_mode(cfb1)
+PROV_CIPHER_HW_camellia_mode(cfb8)
+PROV_CIPHER_HW_camellia_mode(ctr)
+    /* clang-format on */

--- a/providers/implementations/ciphers/cipher_des_hw.c
+++ b/providers/implementations/ciphers/cipher_des_hw.c
@@ -186,9 +186,11 @@ static int cipher_hw_des_cfb8_cipher(PROV_CIPHER_CTX *ctx, unsigned char *out,
         return &des_##mode;                                    \
     }
 
+/* clang-format off */
 PROV_CIPHER_HW_des_mode(ecb)
-    PROV_CIPHER_HW_des_mode(cbc)
-        PROV_CIPHER_HW_des_mode(ofb64)
-            PROV_CIPHER_HW_des_mode(cfb64)
-                PROV_CIPHER_HW_des_mode(cfb1)
-                    PROV_CIPHER_HW_des_mode(cfb8)
+PROV_CIPHER_HW_des_mode(cbc)
+PROV_CIPHER_HW_des_mode(ofb64)
+PROV_CIPHER_HW_des_mode(cfb64)
+PROV_CIPHER_HW_des_mode(cfb1)
+PROV_CIPHER_HW_des_mode(cfb8)
+    /* clang-format on */

--- a/providers/implementations/ciphers/cipher_des_hw.c
+++ b/providers/implementations/ciphers/cipher_des_hw.c
@@ -186,11 +186,9 @@ static int cipher_hw_des_cfb8_cipher(PROV_CIPHER_CTX *ctx, unsigned char *out,
         return &des_##mode;                                    \
     }
 
-/* clang-format off */
 PROV_CIPHER_HW_des_mode(ecb)
 PROV_CIPHER_HW_des_mode(cbc)
 PROV_CIPHER_HW_des_mode(ofb64)
 PROV_CIPHER_HW_des_mode(cfb64)
 PROV_CIPHER_HW_des_mode(cfb1)
 PROV_CIPHER_HW_des_mode(cfb8)
-    /* clang-format on */

--- a/providers/implementations/ciphers/cipher_sm4_hw.c
+++ b/providers/implementations/ciphers/cipher_sm4_hw.c
@@ -144,8 +144,10 @@ IMPLEMENT_CIPHER_HW_COPYCTX(cipher_hw_sm4_copyctx, PROV_SM4_CTX)
 #define PROV_CIPHER_HW_select(mode)
 #endif
 
+/* clang-format off */
 PROV_CIPHER_HW_sm4_mode(cbc)
-    PROV_CIPHER_HW_sm4_mode(ecb)
-        PROV_CIPHER_HW_sm4_mode(ofb128)
-            PROV_CIPHER_HW_sm4_mode(cfb128)
-                PROV_CIPHER_HW_sm4_mode(ctr)
+PROV_CIPHER_HW_sm4_mode(ecb)
+PROV_CIPHER_HW_sm4_mode(ofb128)
+PROV_CIPHER_HW_sm4_mode(cfb128)
+PROV_CIPHER_HW_sm4_mode(ctr)
+    /* clang-format on */

--- a/providers/implementations/ciphers/cipher_sm4_hw.c
+++ b/providers/implementations/ciphers/cipher_sm4_hw.c
@@ -144,10 +144,8 @@ IMPLEMENT_CIPHER_HW_COPYCTX(cipher_hw_sm4_copyctx, PROV_SM4_CTX)
 #define PROV_CIPHER_HW_select(mode)
 #endif
 
-/* clang-format off */
 PROV_CIPHER_HW_sm4_mode(cbc)
 PROV_CIPHER_HW_sm4_mode(ecb)
 PROV_CIPHER_HW_sm4_mode(ofb128)
 PROV_CIPHER_HW_sm4_mode(cfb128)
 PROV_CIPHER_HW_sm4_mode(ctr)
-    /* clang-format on */

--- a/test/json_test.c
+++ b/test/json_test.c
@@ -64,11 +64,11 @@ struct script_word {
     void (*fp)(void);
 };
 
-#define OP_P(x) { (x) },
-#define OP_U64(x) { NULL, (x) },
-#define OP_I64(x) { NULL, 0, (x) },
-#define OP_D(x) { NULL, 0, 0, (x) },
-#define OP_FP(x) { NULL, 0, 0, 0, (void (*)(void))(x) },
+#define OP_P(x) { (x) }
+#define OP_U64(x) { NULL, (x) }
+#define OP_I64(x) { NULL, 0, (x) }
+#define OP_D(x) { NULL, 0, 0, (x) }
+#define OP_FP(x) { NULL, 0, 0, 0, (void (*)(void))(x) }
 
 struct script_info {
     const char *name, *title;
@@ -102,28 +102,28 @@ typedef void (*fp_d_type)(OSSL_JSON_ENC *, double);
 typedef void (*fp_pz_type)(OSSL_JSON_ENC *, const void *, size_t);
 
 #define OP_END() OP_U64(OPK_END)
-#define OP_CALL(f) OP_U64(OPK_CALL) OP_FP(f)
-#define OP_CALL_P(f, x) OP_U64(OPK_CALL_P) OP_FP(f) OP_P(x)
-#define OP_CALL_I(f, x) OP_U64(OPK_CALL_I) OP_FP(f) OP_I64(x)
-#define OP_CALL_U64(f, x) OP_U64(OPK_CALL_U64) OP_FP(f) OP_U64(x)
-#define OP_CALL_I64(f, x) OP_U64(OPK_CALL_I64) OP_FP(f) OP_I64(x)
-#define OP_CALL_D(f, x) OP_U64(OPK_CALL_D) OP_FP(f) OP_D(x)
-#define OP_CALL_PZ(f, x, xl) OP_U64(OPK_CALL_PZ) OP_FP(f) OP_P(x) OP_U64(xl)
-#define OP_ASSERT_ERROR(err) OP_U64(OPK_ASSERT_ERROR) OP_U64(err)
-#define OP_INIT_FLAGS(flags) OP_U64(OPK_INIT_FLAGS) OP_U64(flags)
+#define OP_CALL(f) OP_U64(OPK_CALL), OP_FP(f)
+#define OP_CALL_P(f, x) OP_U64(OPK_CALL_P), OP_FP(f), OP_P(x)
+#define OP_CALL_I(f, x) OP_U64(OPK_CALL_I), OP_FP(f), OP_I64(x)
+#define OP_CALL_U64(f, x) OP_U64(OPK_CALL_U64), OP_FP(f), OP_U64(x)
+#define OP_CALL_I64(f, x) OP_U64(OPK_CALL_I64), OP_FP(f), OP_I64(x)
+#define OP_CALL_D(f, x) OP_U64(OPK_CALL_D), OP_FP(f), OP_D(x)
+#define OP_CALL_PZ(f, x, xl) OP_U64(OPK_CALL_PZ), OP_FP(f), OP_P(x), OP_U64(xl)
+#define OP_ASSERT_ERROR(err) OP_U64(OPK_ASSERT_ERROR), OP_U64(err),
+#define OP_INIT_FLAGS(flags) OP_U64(OPK_INIT_FLAGS), OP_U64(flags)
 
-#define OPJ_BEGIN_O() OP_CALL(ossl_json_object_begin)
-#define OPJ_END_O() OP_CALL(ossl_json_object_end)
-#define OPJ_BEGIN_A() OP_CALL(ossl_json_array_begin)
-#define OPJ_END_A() OP_CALL(ossl_json_array_end)
-#define OPJ_NULL() OP_CALL(ossl_json_null)
-#define OPJ_BOOL(x) OP_CALL_I(ossl_json_bool, (x))
-#define OPJ_U64(x) OP_CALL_U64(ossl_json_u64, (x))
-#define OPJ_I64(x) OP_CALL_I64(ossl_json_i64, (x))
-#define OPJ_KEY(x) OP_CALL_P(ossl_json_key, (x))
-#define OPJ_STR(x) OP_CALL_P(ossl_json_str, (x))
-#define OPJ_STR_LEN(x, xl) OP_CALL_PZ(ossl_json_str_len, (x), (xl))
-#define OPJ_STR_HEX(x, xl) OP_CALL_PZ(ossl_json_str_hex, (x), (xl))
+#define OPJ_BEGIN_O() OP_CALL(ossl_json_object_begin),
+#define OPJ_END_O() OP_CALL(ossl_json_object_end),
+#define OPJ_BEGIN_A() OP_CALL(ossl_json_array_begin),
+#define OPJ_END_A() OP_CALL(ossl_json_array_end),
+#define OPJ_NULL() OP_CALL(ossl_json_null),
+#define OPJ_BOOL(x) OP_CALL_I(ossl_json_bool, (x)),
+#define OPJ_U64(x) OP_CALL_U64(ossl_json_u64, (x)),
+#define OPJ_I64(x) OP_CALL_I64(ossl_json_i64, (x)),
+#define OPJ_KEY(x) OP_CALL_P(ossl_json_key, (x)),
+#define OPJ_STR(x) OP_CALL_P(ossl_json_str, (x)),
+#define OPJ_STR_LEN(x, xl) OP_CALL_PZ(ossl_json_str_len, (x), (xl)),
+#define OPJ_STR_HEX(x, xl) OP_CALL_PZ(ossl_json_str_hex, (x), (xl)),
 
 #define BEGIN_SCRIPT(name, title, flags)                     \
     static const struct script_info *get_script_##name(void) \
@@ -132,10 +132,10 @@ typedef void (*fp_pz_type)(OSSL_JSON_ENC *, const void *, size_t);
         static const char script_title[] = #title;           \
                                                              \
         static const struct script_word script_words[] = {   \
-            OP_INIT_FLAGS(flags)
+            OP_INIT_FLAGS(flags),
 
 #define END_SCRIPT_EXPECTING(s, slen)                                      \
-    OP_END()                                                               \
+    OP_END(),                                                              \
     }                                                                      \
     ;                                                                      \
     static const struct script_info script_info = {                        \
@@ -157,7 +157,7 @@ typedef void (*fp_pz_type)(OSSL_JSON_ENC *, const void *, size_t);
 #define END_SCRIPT_EXPECTING_S(s) END_SCRIPT_EXPECTING(s, SIZE_MAX)
 #define END_SCRIPT_EXPECTING_Q(s) END_SCRIPT_EXPECTING(#s, sizeof(#s) - 1)
 
-#define SCRIPT(name) get_script_##name,
+#define SCRIPT(name) get_script_##name
 
 BEGIN_SCRIPT(null, "serialize a single null", 0)
 OPJ_NULL()
@@ -492,56 +492,56 @@ END_SCRIPT_EXPECTING_S("\x1Enull\n"
                        "\x1E{\"x\":1,\"y\":{}}\n")
 
 static const info_func scripts[] = {
-    SCRIPT(null)
-        SCRIPT(obj_empty)
-            SCRIPT(array_empty)
-                SCRIPT(bool_false)
-                    SCRIPT(bool_true)
-                        SCRIPT(u64_0)
-                            SCRIPT(u64_1)
-                                SCRIPT(u64_10)
-                                    SCRIPT(u64_12345)
-                                        SCRIPT(u64_18446744073709551615)
-                                            SCRIPT(i64_0)
-                                                SCRIPT(i64_1)
-                                                    SCRIPT(i64_2)
-                                                        SCRIPT(i64_10)
-                                                            SCRIPT(i64_12345)
-                                                                SCRIPT(i64_9223372036854775807)
-                                                                    SCRIPT(i64_m1)
-                                                                        SCRIPT(i64_m2)
-                                                                            SCRIPT(i64_m10)
-                                                                                SCRIPT(i64_m12345)
-                                                                                    SCRIPT(i64_m9223372036854775807)
-                                                                                        SCRIPT(i64_m9223372036854775808)
-                                                                                            SCRIPT(str_empty)
-                                                                                                SCRIPT(str_a)
-                                                                                                    SCRIPT(str_abc)
-                                                                                                        SCRIPT(str_quote)
-                                                                                                            SCRIPT(str_quote2)
-                                                                                                                SCRIPT(str_escape)
-                                                                                                                    SCRIPT(str_len)
-                                                                                                                        SCRIPT(str_len0)
-                                                                                                                            SCRIPT(str_len_nul)
-                                                                                                                                SCRIPT(hex_data0)
-                                                                                                                                    SCRIPT(hex_data)
-                                                                                                                                        SCRIPT(array_nest1)
-                                                                                                                                            SCRIPT(array_nest2)
-                                                                                                                                                SCRIPT(array_nest3)
-                                                                                                                                                    SCRIPT(array_nest4)
-                                                                                                                                                        SCRIPT(obj_nontrivial1)
-                                                                                                                                                            SCRIPT(obj_nontrivial2)
-                                                                                                                                                                SCRIPT(obj_nest1)
-                                                                                                                                                                    SCRIPT(err_obj_no_key)
-                                                                                                                                                                        SCRIPT(err_obj_multi_key)
-                                                                                                                                                                            SCRIPT(err_obj_no_value)
-                                                                                                                                                                                SCRIPT(err_utf8)
-                                                                                                                                                                                    SCRIPT(utf8_2)
-                                                                                                                                                                                        SCRIPT(utf8_3)
-                                                                                                                                                                                            SCRIPT(utf8_4)
-                                                                                                                                                                                                SCRIPT(ijson_int)
-                                                                                                                                                                                                    SCRIPT(multi_item)
-                                                                                                                                                                                                        SCRIPT(seq)
+    SCRIPT(null),
+    SCRIPT(obj_empty),
+    SCRIPT(array_empty),
+    SCRIPT(bool_false),
+    SCRIPT(bool_true),
+    SCRIPT(u64_0),
+    SCRIPT(u64_1),
+    SCRIPT(u64_10),
+    SCRIPT(u64_12345),
+    SCRIPT(u64_18446744073709551615),
+    SCRIPT(i64_0),
+    SCRIPT(i64_1),
+    SCRIPT(i64_2),
+    SCRIPT(i64_10),
+    SCRIPT(i64_12345),
+    SCRIPT(i64_9223372036854775807),
+    SCRIPT(i64_m1),
+    SCRIPT(i64_m2),
+    SCRIPT(i64_m10),
+    SCRIPT(i64_m12345),
+    SCRIPT(i64_m9223372036854775807),
+    SCRIPT(i64_m9223372036854775808),
+    SCRIPT(str_empty),
+    SCRIPT(str_a),
+    SCRIPT(str_abc),
+    SCRIPT(str_quote),
+    SCRIPT(str_quote2),
+    SCRIPT(str_escape),
+    SCRIPT(str_len),
+    SCRIPT(str_len0),
+    SCRIPT(str_len_nul),
+    SCRIPT(hex_data0),
+    SCRIPT(hex_data),
+    SCRIPT(array_nest1),
+    SCRIPT(array_nest2),
+    SCRIPT(array_nest3),
+    SCRIPT(array_nest4),
+    SCRIPT(obj_nontrivial1),
+    SCRIPT(obj_nontrivial2),
+    SCRIPT(obj_nest1),
+    SCRIPT(err_obj_no_key),
+    SCRIPT(err_obj_multi_key),
+    SCRIPT(err_obj_no_value),
+    SCRIPT(err_utf8),
+    SCRIPT(utf8_2),
+    SCRIPT(utf8_3),
+    SCRIPT(utf8_4),
+    SCRIPT(ijson_int),
+    SCRIPT(multi_item),
+    SCRIPT(seq),
 };
 
 /* Test runner. */
@@ -637,7 +637,7 @@ static int run_script(const struct script_info *info)
 
             break;
         }
-#define OP_ASSERT_ERROR(err) OP_U64(OPK_ASSERT_ERROR) OP_U64(err)
+#define OP_ASSERT_ERROR(err) OP_U64(OPK_ASSERT_ERROR), OP_U64(err),
 
         default:
             TEST_error("unknown opcode");

--- a/test/quic_ackm_test.c
+++ b/test/quic_ackm_test.c
@@ -495,11 +495,11 @@ struct tx_ack_time_op {
 };
 
 #define TX_OP_PKT(advance, pn, num_pn) \
-    { TX_ACK_TIME_OP_PKT, (advance) * OSSL_TIME_MS, (pn), (num_pn), NULL },
+    { TX_ACK_TIME_OP_PKT, (advance) * OSSL_TIME_MS, (pn), (num_pn), NULL }
 #define TX_OP_ACK(advance, pn, num_pn) \
-    { TX_ACK_TIME_OP_ACK, (advance) * OSSL_TIME_MS, (pn), (num_pn), NULL },
+    { TX_ACK_TIME_OP_ACK, (advance) * OSSL_TIME_MS, (pn), (num_pn), NULL }
 #define TX_OP_EXPECT(expect) \
-    { TX_ACK_TIME_OP_EXPECT, 0, 0, 0, (expect) },
+    { TX_ACK_TIME_OP_EXPECT, 0, 0, 0, (expect) }
 #define TX_OP_END { TX_ACK_TIME_OP_END }
 
 static const char tx_ack_time_script_1_expect[] = {
@@ -507,11 +507,11 @@ static const char tx_ack_time_script_1_expect[] = {
 };
 
 static const struct tx_ack_time_op tx_ack_time_script_1[] = {
-    TX_OP_PKT(0, 0, 1)
-        TX_OP_PKT(3600000, 1, 1)
-            TX_OP_ACK(1000, 1, 1)
-                TX_OP_EXPECT(tx_ack_time_script_1_expect)
-                    TX_OP_END
+    TX_OP_PKT(0, 0, 1),
+    TX_OP_PKT(3600000, 1, 1),
+    TX_OP_ACK(1000, 1, 1),
+    TX_OP_EXPECT(tx_ack_time_script_1_expect),
+    TX_OP_END
 };
 
 static const struct tx_ack_time_op *const tx_ack_time_scripts[] = {
@@ -648,55 +648,55 @@ struct rx_test_op {
     {                                                         \
         RX_OPK_PKT, (advance) * OSSL_TIME_MS, (pn), (num_pn), \
         0, 0, NULL, 0, 0                                      \
-    },
+    }
 
 #define RX_OP_CHECK_UNPROC(advance, pn, num_pn)                        \
     {                                                                  \
         RX_OPK_CHECK_UNPROC, (advance) * OSSL_TIME_MS, (pn), (num_pn), \
         0, 0, NULL, 0, 0                                               \
-    },
+    }
 
 #define RX_OP_CHECK_PROC(advance, pn, num_pn)                        \
     {                                                                \
         RX_OPK_CHECK_PROC, (advance) * OSSL_TIME_MS, (pn), (num_pn), \
         0, 0, NULL, 0, 0                                             \
-    },
+    }
 
 #define RX_OP_CHECK_STATE(advance, expect_desired, expect_deadline) \
     {                                                               \
         RX_OPK_CHECK_STATE, (advance) * OSSL_TIME_MS, 0, 0,         \
         (expect_desired), (expect_deadline), NULL, 0, 0             \
-    },
+    }
 
 #define RX_OP_CHECK_ACKS(advance, ack_ranges)              \
     {                                                      \
         RX_OPK_CHECK_ACKS, (advance) * OSSL_TIME_MS, 0, 0, \
         0, 0, (ack_ranges), OSSL_NELEM(ack_ranges), 0      \
-    },
+    }
 
 #define RX_OP_CHECK_NO_ACKS(advance)                       \
     {                                                      \
         RX_OPK_CHECK_ACKS, (advance) * OSSL_TIME_MS, 0, 0, \
         0, 0, NULL, 0, 0                                   \
-    },
+    }
 
 #define RX_OP_TX(advance, pn, largest_acked)          \
     {                                                 \
         RX_OPK_TX, (advance) * OSSL_TIME_MS, (pn), 1, \
         0, 0, NULL, 0, (largest_acked)                \
-    },
+    }
 
 #define RX_OP_RX_ACK(advance, pn, num_pn)                        \
     {                                                            \
         RX_OPK_RX_ACK, (advance) * OSSL_TIME_MS, (pn), (num_pn), \
         0, 0, NULL, 0, 0                                         \
-    },
+    }
 
 #define RX_OP_SKIP_IF_PN_SPACE(pn_space)           \
     {                                              \
         RX_OPK_SKIP_IF_PN_SPACE, 0, (pn_space), 0, \
         0, 0, NULL, 0, 0                           \
-    },
+    }
 
 #define RX_OP_END \
     { RX_OPK_END }
@@ -707,23 +707,23 @@ static const OSSL_QUIC_ACK_RANGE rx_ack_ranges_1a[] = {
 };
 
 static const struct rx_test_op rx_script_1[] = {
-    RX_OP_CHECK_STATE(0, 0, 0) /* no threshold yet */
-    RX_OP_CHECK_PROC(0, 0, 3)
+    RX_OP_CHECK_STATE(0, 0, 0), /* no threshold yet */
+    RX_OP_CHECK_PROC(0, 0, 3),
 
-        RX_OP_PKT(0, 0, 2) /* two packets, threshold */
-    RX_OP_CHECK_UNPROC(0, 0, 2)
-        RX_OP_CHECK_PROC(0, 2, 1)
-            RX_OP_CHECK_STATE(0, 1, 0) /* threshold met, immediate */
-    RX_OP_CHECK_ACKS(0, rx_ack_ranges_1a)
+    RX_OP_PKT(0, 0, 2), /* two packets, threshold */
+    RX_OP_CHECK_UNPROC(0, 0, 2),
+    RX_OP_CHECK_PROC(0, 2, 1),
+    RX_OP_CHECK_STATE(0, 1, 0), /* threshold met, immediate */
+    RX_OP_CHECK_ACKS(0, rx_ack_ranges_1a),
 
     /* At this point we would generate e.g. a packet with an ACK. */
-    RX_OP_TX(0, 0, 1) /* ACKs both */
-    RX_OP_CHECK_ACKS(0, rx_ack_ranges_1a) /* not provably ACKed yet */
-    RX_OP_RX_ACK(0, 0, 1) /* TX'd packet is ACK'd */
+    RX_OP_TX(0, 0, 1), /* ACKs both */
+    RX_OP_CHECK_ACKS(0, rx_ack_ranges_1a), /* not provably ACKed yet */
+    RX_OP_RX_ACK(0, 0, 1), /* TX'd packet is ACK'd */
 
-    RX_OP_CHECK_NO_ACKS(0) /* nothing more to ACK */
-    RX_OP_CHECK_UNPROC(0, 0, 2) /* still unprocessable */
-    RX_OP_CHECK_PROC(0, 2, 1) /* still processable */
+    RX_OP_CHECK_NO_ACKS(0), /* nothing more to ACK */
+    RX_OP_CHECK_UNPROC(0, 0, 2), /* still unprocessable */
+    RX_OP_CHECK_PROC(0, 2, 1), /* still processable */
 
     RX_OP_END
 };
@@ -743,42 +743,42 @@ static const struct rx_test_op rx_script_2[] = {
      * (rx_script_4) for those spaces as those spaces should not delay ACK
      * generation, so a different RX_OP_CHECK_STATE test is needed.
      */
-    RX_OP_SKIP_IF_PN_SPACE(QUIC_PN_SPACE_INITIAL)
-        RX_OP_SKIP_IF_PN_SPACE(QUIC_PN_SPACE_HANDSHAKE)
+    RX_OP_SKIP_IF_PN_SPACE(QUIC_PN_SPACE_INITIAL),
+    RX_OP_SKIP_IF_PN_SPACE(QUIC_PN_SPACE_HANDSHAKE),
 
-            RX_OP_CHECK_STATE(0, 0, 0) /* no threshold yet */
-    RX_OP_CHECK_PROC(0, 0, 3)
+    RX_OP_CHECK_STATE(0, 0, 0), /* no threshold yet */
+    RX_OP_CHECK_PROC(0, 0, 3),
 
     /* First packet always generates an ACK so get it out of the way. */
-    RX_OP_PKT(0, 0, 1)
-        RX_OP_CHECK_UNPROC(0, 0, 1)
-            RX_OP_CHECK_PROC(0, 1, 1)
-                RX_OP_CHECK_STATE(0, 1, 0) /* first packet always causes ACK */
-    RX_OP_CHECK_ACKS(0, rx_ack_ranges_2a) /* clears packet counter */
-    RX_OP_CHECK_STATE(0, 0, 0) /* desired state should have been cleared */
+    RX_OP_PKT(0, 0, 1),
+    RX_OP_CHECK_UNPROC(0, 0, 1),
+    RX_OP_CHECK_PROC(0, 1, 1),
+    RX_OP_CHECK_STATE(0, 1, 0), /* first packet always causes ACK */
+    RX_OP_CHECK_ACKS(0, rx_ack_ranges_2a), /* clears packet counter */
+    RX_OP_CHECK_STATE(0, 0, 0), /* desired state should have been cleared */
 
     /* Second packet should not cause ACK-desired state */
-    RX_OP_PKT(0, 1, 1) /* just one packet, threshold is 2 */
-    RX_OP_CHECK_UNPROC(0, 0, 2)
-        RX_OP_CHECK_PROC(0, 2, 1)
-            RX_OP_CHECK_STATE(0, 0, 1) /* threshold not yet met, so deadline */
+    RX_OP_PKT(0, 1, 1), /* just one packet, threshold is 2 */
+    RX_OP_CHECK_UNPROC(0, 0, 2),
+    RX_OP_CHECK_PROC(0, 2, 1),
+    RX_OP_CHECK_STATE(0, 0, 1), /* threshold not yet met, so deadline */
     /* Don't check ACKs here, as it would reset our threshold counter. */
 
     /* Now receive a second packet, triggering the threshold */
-    RX_OP_PKT(0, 2, 1) /* second packet meets threshold */
-    RX_OP_CHECK_UNPROC(0, 0, 3)
-        RX_OP_CHECK_PROC(0, 3, 1)
-            RX_OP_CHECK_STATE(0, 1, 0) /* desired immediately */
-    RX_OP_CHECK_ACKS(0, rx_ack_ranges_2b)
+    RX_OP_PKT(0, 2, 1), /* second packet meets threshold */
+    RX_OP_CHECK_UNPROC(0, 0, 3),
+    RX_OP_CHECK_PROC(0, 3, 1),
+    RX_OP_CHECK_STATE(0, 1, 0), /* desired immediately */
+    RX_OP_CHECK_ACKS(0, rx_ack_ranges_2b),
 
     /* At this point we would generate e.g. a packet with an ACK. */
-    RX_OP_TX(0, 0, 2) /* ACKs all */
-    RX_OP_CHECK_ACKS(0, rx_ack_ranges_2b) /* not provably ACKed yet */
-    RX_OP_RX_ACK(0, 0, 1) /* TX'd packet is ACK'd */
+    RX_OP_TX(0, 0, 2), /* ACKs all */
+    RX_OP_CHECK_ACKS(0, rx_ack_ranges_2b), /* not provably ACKed yet */
+    RX_OP_RX_ACK(0, 0, 1), /* TX'd packet is ACK'd */
 
-    RX_OP_CHECK_NO_ACKS(0) /* nothing more to ACK */
-    RX_OP_CHECK_UNPROC(0, 0, 3) /* still unprocessable */
-    RX_OP_CHECK_PROC(0, 3, 1) /* still processable */
+    RX_OP_CHECK_NO_ACKS(0), /* nothing more to ACK */
+    RX_OP_CHECK_UNPROC(0, 0, 3), /* still unprocessable */
+    RX_OP_CHECK_PROC(0, 3, 1), /* still processable */
 
     RX_OP_END
 };
@@ -797,52 +797,52 @@ static const OSSL_QUIC_ACK_RANGE rx_ack_ranges_3c[] = {
 };
 
 static const struct rx_test_op rx_script_3[] = {
-    RX_OP_CHECK_STATE(0, 0, 0) /* no threshold yet */
-    RX_OP_CHECK_PROC(0, 0, 11)
+    RX_OP_CHECK_STATE(0, 0, 0), /* no threshold yet */
+    RX_OP_CHECK_PROC(0, 0, 11),
 
     /* First packet always generates an ACK so get it out of the way. */
-    RX_OP_PKT(0, 0, 1)
-        RX_OP_CHECK_UNPROC(0, 0, 1)
-            RX_OP_CHECK_PROC(0, 1, 1)
-                RX_OP_CHECK_STATE(0, 1, 0) /* first packet always causes ACK */
-    RX_OP_CHECK_ACKS(0, rx_ack_ranges_3a) /* clears packet counter */
-    RX_OP_CHECK_STATE(0, 0, 0) /* desired state should have been cleared */
+    RX_OP_PKT(0, 0, 1),
+    RX_OP_CHECK_UNPROC(0, 0, 1),
+    RX_OP_CHECK_PROC(0, 1, 1),
+    RX_OP_CHECK_STATE(0, 1, 0), /* first packet always causes ACK */
+    RX_OP_CHECK_ACKS(0, rx_ack_ranges_3a), /* clears packet counter */
+    RX_OP_CHECK_STATE(0, 0, 0), /* desired state should have been cleared */
 
     /* Generate ten packets, exceeding the threshold. */
-    RX_OP_PKT(0, 1, 10) /* ten packets, threshold is 2 */
-    RX_OP_CHECK_UNPROC(0, 0, 11)
-        RX_OP_CHECK_PROC(0, 11, 1)
-            RX_OP_CHECK_STATE(0, 1, 0) /* threshold met, immediate */
-    RX_OP_CHECK_ACKS(0, rx_ack_ranges_3b)
+    RX_OP_PKT(0, 1, 10), /* ten packets, threshold is 2 */
+    RX_OP_CHECK_UNPROC(0, 0, 11),
+    RX_OP_CHECK_PROC(0, 11, 1),
+    RX_OP_CHECK_STATE(0, 1, 0), /* threshold met, immediate */
+    RX_OP_CHECK_ACKS(0, rx_ack_ranges_3b),
 
     /*
      * Test TX'ing a packet which doesn't ACK anything.
      */
-    RX_OP_TX(0, 0, QUIC_PN_INVALID)
-        RX_OP_RX_ACK(0, 0, 1)
+    RX_OP_TX(0, 0, QUIC_PN_INVALID),
+    RX_OP_RX_ACK(0, 0, 1),
 
     /*
      * At this point we would generate a packet with an ACK immediately.
      * TX a packet which when ACKed makes [0,5] provably ACKed.
      */
-    RX_OP_TX(0, 1, 5)
-        RX_OP_CHECK_ACKS(0, rx_ack_ranges_3b) /* not provably ACKed yet */
-    RX_OP_RX_ACK(0, 1, 1)
+    RX_OP_TX(0, 1, 5),
+    RX_OP_CHECK_ACKS(0, rx_ack_ranges_3b), /* not provably ACKed yet */
+    RX_OP_RX_ACK(0, 1, 1),
 
-        RX_OP_CHECK_ACKS(0, rx_ack_ranges_3c) /* provably ACKed now gone */
-    RX_OP_CHECK_UNPROC(0, 0, 11) /* still unprocessable */
-    RX_OP_CHECK_PROC(0, 11, 1) /* still processable */
+    RX_OP_CHECK_ACKS(0, rx_ack_ranges_3c), /* provably ACKed now gone */
+    RX_OP_CHECK_UNPROC(0, 0, 11), /* still unprocessable */
+    RX_OP_CHECK_PROC(0, 11, 1), /* still processable */
 
     /*
      * Now TX another packet which provably ACKs the rest when ACKed.
      */
-    RX_OP_TX(0, 2, 10)
-        RX_OP_CHECK_ACKS(0, rx_ack_ranges_3c) /* not provably ACKed yet */
-    RX_OP_RX_ACK(0, 2, 1)
+    RX_OP_TX(0, 2, 10),
+    RX_OP_CHECK_ACKS(0, rx_ack_ranges_3c), /* not provably ACKed yet */
+    RX_OP_RX_ACK(0, 2, 1),
 
-        RX_OP_CHECK_NO_ACKS(0) /* provably ACKed now gone */
-    RX_OP_CHECK_UNPROC(0, 0, 11) /* still unprocessable */
-    RX_OP_CHECK_PROC(0, 11, 1) /* still processable */
+    RX_OP_CHECK_NO_ACKS(0), /* provably ACKed now gone */
+    RX_OP_CHECK_UNPROC(0, 0, 11), /* still unprocessable */
+    RX_OP_CHECK_PROC(0, 11, 1), /* still processable */
 
     RX_OP_END
 };
@@ -857,38 +857,38 @@ static const OSSL_QUIC_ACK_RANGE rx_ack_ranges_4a[] = {
 
 static const struct rx_test_op rx_script_4[] = {
     /* The application PN space is tested in rx_script_2. */
-    RX_OP_SKIP_IF_PN_SPACE(QUIC_PN_SPACE_APP)
+    RX_OP_SKIP_IF_PN_SPACE(QUIC_PN_SPACE_APP),
 
-        RX_OP_CHECK_STATE(0, 0, 0) /* no threshold yet */
-    RX_OP_CHECK_PROC(0, 0, 3)
+    RX_OP_CHECK_STATE(0, 0, 0), /* no threshold yet */
+    RX_OP_CHECK_PROC(0, 0, 3),
 
     /* First packet always generates an ACK so get it out of the way. */
-    RX_OP_PKT(0, 0, 1)
-        RX_OP_CHECK_UNPROC(0, 0, 1)
-            RX_OP_CHECK_PROC(0, 1, 1)
-                RX_OP_CHECK_STATE(0, 1, 0) /* first packet always causes ACK */
-    RX_OP_CHECK_ACKS(0, rx_ack_ranges_2a) /* clears packet counter */
-    RX_OP_CHECK_STATE(0, 0, 0) /* desired state should have been cleared */
+    RX_OP_PKT(0, 0, 1),
+    RX_OP_CHECK_UNPROC(0, 0, 1),
+    RX_OP_CHECK_PROC(0, 1, 1),
+    RX_OP_CHECK_STATE(0, 1, 0), /* first packet always causes ACK */
+    RX_OP_CHECK_ACKS(0, rx_ack_ranges_2a), /* clears packet counter */
+    RX_OP_CHECK_STATE(0, 0, 0), /* desired state should have been cleared */
 
     /*
      * Second packet should cause ACK-desired state because we are
      * INITIAL/HANDSHAKE (RFC 9000 s. 13.2.1)
      */
-    RX_OP_PKT(0, 1, 1) /* just one packet, threshold is 2 */
-    RX_OP_CHECK_UNPROC(0, 0, 2)
-        RX_OP_CHECK_PROC(0, 2, 1)
-            RX_OP_CHECK_STATE(0, 1, 1)
-                RX_OP_CHECK_ACKS(0, rx_ack_ranges_4a)
-                    RX_OP_CHECK_STATE(0, 0, 0) /* desired state should have been cleared */
+    RX_OP_PKT(0, 1, 1), /* just one packet, threshold is 2 */
+    RX_OP_CHECK_UNPROC(0, 0, 2),
+    RX_OP_CHECK_PROC(0, 2, 1),
+    RX_OP_CHECK_STATE(0, 1, 1),
+    RX_OP_CHECK_ACKS(0, rx_ack_ranges_4a),
+    RX_OP_CHECK_STATE(0, 0, 0), /* desired state should have been cleared */
 
     /* At this point we would generate e.g. a packet with an ACK. */
-    RX_OP_TX(0, 0, 1) /* ACKs all */
-    RX_OP_CHECK_ACKS(0, rx_ack_ranges_4a) /* not provably ACKed yet */
-    RX_OP_RX_ACK(0, 0, 1) /* TX'd packet is ACK'd */
+    RX_OP_TX(0, 0, 1), /* ACKs all */
+    RX_OP_CHECK_ACKS(0, rx_ack_ranges_4a), /* not provably ACKed yet */
+    RX_OP_RX_ACK(0, 0, 1), /* TX'd packet is ACK'd */
 
-    RX_OP_CHECK_NO_ACKS(0) /* nothing more to ACK */
-    RX_OP_CHECK_UNPROC(0, 0, 2) /* still unprocessable */
-    RX_OP_CHECK_PROC(0, 2, 1) /* still processable */
+    RX_OP_CHECK_NO_ACKS(0), /* nothing more to ACK */
+    RX_OP_CHECK_UNPROC(0, 0, 2), /* still unprocessable */
+    RX_OP_CHECK_PROC(0, 2, 1), /* still processable */
 
     RX_OP_END
 };

--- a/test/quic_record_test.c
+++ b/test/quic_record_test.c
@@ -51,39 +51,39 @@ struct rx_test_op {
 #define RX_OP_END \
     { RX_TEST_OP_END }
 #define RX_OP_SET_SCID_LEN(scid_len) \
-    { RX_TEST_OP_SET_SCID_LEN, 0, NULL, 0, NULL, (scid_len), 0, 0, NULL, NULL },
+    { RX_TEST_OP_SET_SCID_LEN, 0, NULL, 0, NULL, (scid_len), 0, 0, NULL, NULL }
 #define RX_OP_SET_INIT_LARGEST_PN(largest_pn) \
-    { RX_TEST_OP_SET_INIT_LARGEST_PN, 0, NULL, 0, NULL, 0, 0, (largest_pn), NULL, NULL },
+    { RX_TEST_OP_SET_INIT_LARGEST_PN, 0, NULL, 0, NULL, 0, 0, (largest_pn), NULL, NULL }
 #define RX_OP_SET_RX_DCID(dcid) \
-    { RX_TEST_OP_SET_RX_DCID, 0, NULL, 0, NULL, 0, 0, 0, &(dcid), NULL },
+    { RX_TEST_OP_SET_RX_DCID, 0, NULL, 0, NULL, 0, 0, 0, &(dcid), NULL }
 #define RX_OP_INJECT(dgram) \
-    { RX_TEST_OP_INJECT, 0, (dgram), sizeof(dgram), NULL, 0, 0, 0, NULL },
+    { RX_TEST_OP_INJECT, 0, (dgram), sizeof(dgram), NULL, 0, 0, 0, NULL }
 #define RX_OP_PROVIDE_SECRET(el, suite, key)              \
     {                                                     \
         RX_TEST_OP_PROVIDE_SECRET, 0, (key), sizeof(key), \
         NULL, (el), (suite), 0, NULL, NULL                \
-    },
+    }
 #define RX_OP_PROVIDE_SECRET_INITIAL(dcid) \
-    { RX_TEST_OP_PROVIDE_SECRET_INITIAL, 0, NULL, 0, NULL, 0, 0, 0, &(dcid), NULL },
+    { RX_TEST_OP_PROVIDE_SECRET_INITIAL, 0, NULL, 0, NULL, 0, 0, 0, &(dcid), NULL }
 #define RX_OP_DISCARD_EL(el) \
-    { RX_TEST_OP_DISCARD_EL, 0, NULL, 0, NULL, (el), 0, 0, NULL, NULL },
+    { RX_TEST_OP_DISCARD_EL, 0, NULL, 0, NULL, (el), 0, 0, NULL, NULL }
 #define RX_OP_CHECK_PKT(expect_hdr, expect_body)                     \
     {                                                                \
         RX_TEST_OP_CHECK_PKT, 0, (expect_body), sizeof(expect_body), \
         &(expect_hdr), 0, 0, 0, NULL, NULL                           \
-    },
+    }
 #define RX_OP_CHECK_NO_PKT() \
-    { RX_TEST_OP_CHECK_NO_PKT, 0, NULL, 0, NULL, 0, 0, 0, NULL, NULL },
+    { RX_TEST_OP_CHECK_NO_PKT, 0, NULL, 0, NULL, 0, 0, 0, NULL, NULL }
 #define RX_OP_CHECK_KEY_EPOCH(expected) \
-    { RX_TEST_OP_CHECK_KEY_EPOCH, 0, NULL, 0, NULL, 0, 0, (expected), NULL },
+    { RX_TEST_OP_CHECK_KEY_EPOCH, 0, NULL, 0, NULL, 0, 0, (expected), NULL }
 #define RX_OP_KEY_UPDATE_TIMEOUT(normal) \
-    { RX_TEST_OP_KEY_UPDATE_TIMEOUT, 0, NULL, 0, NULL, (normal), 0, 0, NULL },
+    { RX_TEST_OP_KEY_UPDATE_TIMEOUT, 0, NULL, 0, NULL, (normal), 0, 0, NULL }
 #define RX_OP_SET_INIT_KEY_PHASE(kp_bit) \
-    { RX_TEST_OP_SET_INIT_KEY_PHASE, 0, NULL, 0, NULL, (kp_bit), 0, 0, NULL },
+    { RX_TEST_OP_SET_INIT_KEY_PHASE, 0, NULL, 0, NULL, (kp_bit), 0, 0, NULL }
 #define RX_OP_CHECK_PKT_EPOCH(expected) \
-    { RX_TEST_OP_CHECK_PKT_EPOCH, 0, NULL, 0, NULL, 0, 0, (expected), NULL },
+    { RX_TEST_OP_CHECK_PKT_EPOCH, 0, NULL, 0, NULL, 0, 0, (expected), NULL }
 #define RX_OP_ALLOW_1RTT() \
-    { RX_TEST_OP_ALLOW_1RTT, 0, NULL, 0, NULL, 0, 0, 0, NULL },
+    { RX_TEST_OP_ALLOW_1RTT, 0, NULL, 0, NULL, 0, 0, 0, NULL }
 
 #define RX_OP_INJECT_N(n) \
     RX_OP_INJECT(rx_script_##n##_in)
@@ -91,8 +91,7 @@ struct rx_test_op {
     RX_OP_CHECK_PKT(rx_script_##n##_expect_hdr, rx_script_##n##_body)
 
 #define RX_OP_INJECT_CHECK(n) \
-    RX_OP_INJECT_N(n)         \
-    RX_OP_CHECK_PKT_N(n)
+    RX_OP_INJECT_N(n), RX_OP_CHECK_PKT_N(n)
 
 /* 1. RFC 9001 - A.3 Server Initial */
 static const unsigned char rx_script_1_in[] = {
@@ -136,13 +135,13 @@ static const QUIC_PKT_HDR rx_script_1_expect_hdr = {
 };
 
 static const struct rx_test_op rx_script_1[] = {
-    RX_OP_SET_SCID_LEN(2)
-        RX_OP_SET_INIT_LARGEST_PN(0)
-            RX_OP_SET_RX_DCID(empty_conn_id)
-                RX_OP_PROVIDE_SECRET_INITIAL(rx_script_1_dcid)
-                    RX_OP_INJECT_CHECK(1)
-                        RX_OP_CHECK_NO_PKT()
-                            RX_OP_END
+    RX_OP_SET_SCID_LEN(2),
+    RX_OP_SET_INIT_LARGEST_PN(0),
+    RX_OP_SET_RX_DCID(empty_conn_id),
+    RX_OP_PROVIDE_SECRET_INITIAL(rx_script_1_dcid),
+    RX_OP_INJECT_CHECK(1),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_END
 };
 
 /* 2. RFC 9001 - A.5 ChaCha20-Poly1305 Short Header Packet */
@@ -171,14 +170,13 @@ static const QUIC_PKT_HDR rx_script_2_expect_hdr = {
 };
 
 static const struct rx_test_op rx_script_2[] = {
-    RX_OP_ALLOW_1RTT()
-        RX_OP_SET_INIT_LARGEST_PN(654360560)
-            RX_OP_SET_RX_DCID(empty_conn_id)
-                RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_CHACHA20POLY1305,
-                    rx_script_2_secret)
-                    RX_OP_INJECT_CHECK(2)
-                        RX_OP_CHECK_NO_PKT()
-                            RX_OP_END
+    RX_OP_ALLOW_1RTT(),
+    RX_OP_SET_INIT_LARGEST_PN(654360560),
+    RX_OP_SET_RX_DCID(empty_conn_id),
+    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_CHACHA20POLY1305, rx_script_2_secret),
+    RX_OP_INJECT_CHECK(2),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_END
 };
 #endif /* !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305) */
 
@@ -218,15 +216,15 @@ static const unsigned char rx_script_3_body[] = {
 };
 
 static const struct rx_test_op rx_script_3[] = {
-    RX_OP_SET_RX_DCID(empty_conn_id)
+    RX_OP_SET_RX_DCID(empty_conn_id),
     /*
      * This is a version negotiation packet, so doesn't have any frames.
      * However, the depacketizer still handles this sort of packet, so
      * we still pass the packet to it, to exercise what it does.
      */
-    RX_OP_INJECT_CHECK(3)
-        RX_OP_CHECK_NO_PKT()
-            RX_OP_END
+    RX_OP_INJECT_CHECK(3),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_END
 };
 
 /* 4. Real World - Retry (S2C) */
@@ -281,10 +279,10 @@ static const unsigned char rx_script_4_body[] = {
 };
 
 static const struct rx_test_op rx_script_4[] = {
-    RX_OP_SET_RX_DCID(empty_conn_id)
-        RX_OP_INJECT_CHECK(4)
-            RX_OP_CHECK_NO_PKT()
-                RX_OP_END
+    RX_OP_SET_RX_DCID(empty_conn_id),
+    RX_OP_INJECT_CHECK(4),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_END
 };
 
 /*
@@ -652,66 +650,62 @@ static const unsigned char rx_script_5c_body[] = {
 };
 
 static const struct rx_test_op rx_script_5[] = {
-    RX_OP_ALLOW_1RTT()
-        RX_OP_SET_RX_DCID(empty_conn_id)
-            RX_OP_PROVIDE_SECRET_INITIAL(rx_script_5_c2s_init_dcid)
-                RX_OP_INJECT_N(5)
-                    RX_OP_CHECK_PKT_N(5a)
-                        RX_OP_CHECK_NO_PKT() /* not got secret for next packet yet */
-    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE,
-        QRL_SUITE_AES128GCM, rx_script_5_handshake_secret)
-        RX_OP_CHECK_PKT_N(5b)
-            RX_OP_CHECK_NO_PKT() /* not got secret for next packet yet */
-    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT,
-        QRL_SUITE_AES128GCM, rx_script_5_1rtt_secret)
-        RX_OP_CHECK_PKT_N(5c)
-            RX_OP_CHECK_NO_PKT()
+    RX_OP_ALLOW_1RTT(),
+    RX_OP_SET_RX_DCID(empty_conn_id),
+    RX_OP_PROVIDE_SECRET_INITIAL(rx_script_5_c2s_init_dcid),
+    RX_OP_INJECT_N(5),
+    RX_OP_CHECK_PKT_N(5a),
+    RX_OP_CHECK_NO_PKT(), /* not got secret for next packet yet */
+    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE, QRL_SUITE_AES128GCM, rx_script_5_handshake_secret),
+    RX_OP_CHECK_PKT_N(5b),
+    RX_OP_CHECK_NO_PKT(), /* not got secret for next packet yet */
+    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, rx_script_5_1rtt_secret),
+    RX_OP_CHECK_PKT_N(5c),
+    RX_OP_CHECK_NO_PKT(),
 
     /* Discard Initial EL and try injecting the packet again */
-    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_INITIAL)
-        RX_OP_INJECT_N(5)
+    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_INITIAL),
+    RX_OP_INJECT_N(5),
     /* Initial packet is not output because we have discarded Initial keys */
-    RX_OP_CHECK_PKT_N(5b)
-        RX_OP_CHECK_PKT_N(5c)
-            RX_OP_CHECK_NO_PKT()
+    RX_OP_CHECK_PKT_N(5b),
+    RX_OP_CHECK_PKT_N(5c),
+    RX_OP_CHECK_NO_PKT(),
     /* Try again with discarded keys */
-    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_HANDSHAKE)
-        RX_OP_INJECT_N(5)
-            RX_OP_CHECK_PKT_N(5c)
-                RX_OP_CHECK_NO_PKT()
+    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_HANDSHAKE),
+    RX_OP_INJECT_N(5),
+    RX_OP_CHECK_PKT_N(5c),
+    RX_OP_CHECK_NO_PKT(),
     /* Try again */
-    RX_OP_INJECT_N(5)
-        RX_OP_CHECK_PKT_N(5c)
-            RX_OP_CHECK_NO_PKT()
+    RX_OP_INJECT_N(5),
+    RX_OP_CHECK_PKT_N(5c),
+    RX_OP_CHECK_NO_PKT(),
     /* Try again with discarded 1-RTT keys */
-    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_1RTT)
-        RX_OP_INJECT_N(5)
-            RX_OP_CHECK_NO_PKT()
+    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_1RTT),
+    RX_OP_INJECT_N(5),
+    RX_OP_CHECK_NO_PKT(),
 
     /* Recreate QRL, test reading packets received before key */
-    RX_OP_SET_SCID_LEN(0)
-        RX_OP_SET_RX_DCID(empty_conn_id)
-            RX_OP_INJECT_N(5)
-                RX_OP_CHECK_NO_PKT()
-                    RX_OP_PROVIDE_SECRET_INITIAL(rx_script_5_c2s_init_dcid)
-                        RX_OP_CHECK_PKT_N(5a)
-                            RX_OP_CHECK_NO_PKT()
-                                RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE,
-                                    QRL_SUITE_AES128GCM, rx_script_5_handshake_secret)
-                                    RX_OP_CHECK_PKT_N(5b)
-                                        RX_OP_CHECK_NO_PKT()
-                                            RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT,
-                                                QRL_SUITE_AES128GCM, rx_script_5_1rtt_secret)
-                                                RX_OP_CHECK_PKT_N(5c)
-                                                    RX_OP_CHECK_NO_PKT()
+    RX_OP_SET_SCID_LEN(0),
+    RX_OP_SET_RX_DCID(empty_conn_id),
+    RX_OP_INJECT_N(5),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_PROVIDE_SECRET_INITIAL(rx_script_5_c2s_init_dcid),
+    RX_OP_CHECK_PKT_N(5a),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE, QRL_SUITE_AES128GCM, rx_script_5_handshake_secret),
+    RX_OP_CHECK_PKT_N(5b),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, rx_script_5_1rtt_secret),
+    RX_OP_CHECK_PKT_N(5c),
+    RX_OP_CHECK_NO_PKT(),
 
-                                                        RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_INITIAL)
-                                                            RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_HANDSHAKE)
-                                                                RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_1RTT)
-                                                                    RX_OP_INJECT_N(5)
-                                                                        RX_OP_CHECK_NO_PKT()
+    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_INITIAL),
+    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_HANDSHAKE),
+    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_1RTT),
+    RX_OP_INJECT_N(5),
+    RX_OP_CHECK_NO_PKT(),
 
-                                                                            RX_OP_END
+    RX_OP_END
 };
 
 /*
@@ -1082,60 +1076,56 @@ static const unsigned char rx_script_6c_body[] = {
 };
 
 static const struct rx_test_op rx_script_6[] = {
-    RX_OP_ALLOW_1RTT()
-        RX_OP_SET_RX_DCID(empty_conn_id)
-            RX_OP_PROVIDE_SECRET_INITIAL(rx_script_6_c2s_init_dcid)
-                RX_OP_INJECT_N(6)
-                    RX_OP_CHECK_PKT_N(6a)
-                        RX_OP_CHECK_NO_PKT() /* not got secret for next packet yet */
-    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE,
-        QRL_SUITE_AES256GCM, rx_script_6_handshake_secret)
-        RX_OP_CHECK_PKT_N(6b)
-            RX_OP_CHECK_NO_PKT() /* not got secret for next packet yet */
-    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT,
-        QRL_SUITE_AES256GCM, rx_script_6_1rtt_secret)
-        RX_OP_CHECK_PKT_N(6c)
-            RX_OP_CHECK_NO_PKT()
+    RX_OP_ALLOW_1RTT(),
+    RX_OP_SET_RX_DCID(empty_conn_id),
+    RX_OP_PROVIDE_SECRET_INITIAL(rx_script_6_c2s_init_dcid),
+    RX_OP_INJECT_N(6),
+    RX_OP_CHECK_PKT_N(6a),
+    RX_OP_CHECK_NO_PKT(), /* not got secret for next packet yet */
+    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE, QRL_SUITE_AES256GCM, rx_script_6_handshake_secret),
+    RX_OP_CHECK_PKT_N(6b),
+    RX_OP_CHECK_NO_PKT(), /* not got secret for next packet yet */
+    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES256GCM, rx_script_6_1rtt_secret),
+    RX_OP_CHECK_PKT_N(6c),
+    RX_OP_CHECK_NO_PKT(),
 
     /* Discard Initial EL and try injecting the packet again */
-    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_INITIAL)
-        RX_OP_INJECT_N(6)
+    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_INITIAL),
+    RX_OP_INJECT_N(6),
     /* Initial packet is not output because we have discarded Initial keys */
-    RX_OP_CHECK_PKT_N(6b)
-        RX_OP_CHECK_PKT_N(6c)
-            RX_OP_CHECK_NO_PKT()
+    RX_OP_CHECK_PKT_N(6b),
+    RX_OP_CHECK_PKT_N(6c),
+    RX_OP_CHECK_NO_PKT(),
     /* Try again with discarded keys */
-    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_HANDSHAKE)
-        RX_OP_INJECT_N(6)
-            RX_OP_CHECK_PKT_N(6c)
-                RX_OP_CHECK_NO_PKT()
+    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_HANDSHAKE),
+    RX_OP_INJECT_N(6),
+    RX_OP_CHECK_PKT_N(6c),
+    RX_OP_CHECK_NO_PKT(),
     /* Try again */
-    RX_OP_INJECT_N(6)
-        RX_OP_CHECK_PKT_N(6c)
-            RX_OP_CHECK_NO_PKT()
+    RX_OP_INJECT_N(6),
+    RX_OP_CHECK_PKT_N(6c),
+    RX_OP_CHECK_NO_PKT(),
     /* Try again with discarded 1-RTT keys */
-    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_1RTT)
-        RX_OP_INJECT_N(6)
-            RX_OP_CHECK_NO_PKT()
+    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_1RTT),
+    RX_OP_INJECT_N(6),
+    RX_OP_CHECK_NO_PKT(),
 
     /* Recreate QRL, test reading packets received before key */
-    RX_OP_SET_SCID_LEN(0)
-        RX_OP_SET_RX_DCID(empty_conn_id)
-            RX_OP_INJECT_N(6)
-                RX_OP_CHECK_NO_PKT()
-                    RX_OP_PROVIDE_SECRET_INITIAL(rx_script_6_c2s_init_dcid)
-                        RX_OP_CHECK_PKT_N(6a)
-                            RX_OP_CHECK_NO_PKT()
-                                RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE,
-                                    QRL_SUITE_AES256GCM, rx_script_6_handshake_secret)
-                                    RX_OP_CHECK_PKT_N(6b)
-                                        RX_OP_CHECK_NO_PKT()
-                                            RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT,
-                                                QRL_SUITE_AES256GCM, rx_script_6_1rtt_secret)
-                                                RX_OP_CHECK_PKT_N(6c)
-                                                    RX_OP_CHECK_NO_PKT()
+    RX_OP_SET_SCID_LEN(0),
+    RX_OP_SET_RX_DCID(empty_conn_id),
+    RX_OP_INJECT_N(6),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_PROVIDE_SECRET_INITIAL(rx_script_6_c2s_init_dcid),
+    RX_OP_CHECK_PKT_N(6a),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE, QRL_SUITE_AES256GCM, rx_script_6_handshake_secret),
+    RX_OP_CHECK_PKT_N(6b),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES256GCM, rx_script_6_1rtt_secret),
+    RX_OP_CHECK_PKT_N(6c),
+    RX_OP_CHECK_NO_PKT(),
 
-                                                        RX_OP_END
+    RX_OP_END
 };
 
 /*
@@ -1506,60 +1496,56 @@ static const unsigned char rx_script_7c_body[] = {
 };
 
 static const struct rx_test_op rx_script_7[] = {
-    RX_OP_ALLOW_1RTT()
-        RX_OP_SET_RX_DCID(empty_conn_id)
-            RX_OP_PROVIDE_SECRET_INITIAL(rx_script_7_c2s_init_dcid)
-                RX_OP_INJECT_N(7)
-                    RX_OP_CHECK_PKT_N(7a)
-                        RX_OP_CHECK_NO_PKT() /* not got secret for next packet yet */
-    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE,
-        QRL_SUITE_CHACHA20POLY1305, rx_script_7_handshake_secret)
-        RX_OP_CHECK_PKT_N(7b)
-            RX_OP_CHECK_NO_PKT() /* not got secret for next packet yet */
-    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT,
-        QRL_SUITE_CHACHA20POLY1305, rx_script_7_1rtt_secret)
-        RX_OP_CHECK_PKT_N(7c)
-            RX_OP_CHECK_NO_PKT()
+    RX_OP_ALLOW_1RTT(),
+    RX_OP_SET_RX_DCID(empty_conn_id),
+    RX_OP_PROVIDE_SECRET_INITIAL(rx_script_7_c2s_init_dcid),
+    RX_OP_INJECT_N(7),
+    RX_OP_CHECK_PKT_N(7a),
+    RX_OP_CHECK_NO_PKT(), /* not got secret for next packet yet */
+    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE, QRL_SUITE_CHACHA20POLY1305, rx_script_7_handshake_secret),
+    RX_OP_CHECK_PKT_N(7b),
+    RX_OP_CHECK_NO_PKT(), /* not got secret for next packet yet */
+    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_CHACHA20POLY1305, rx_script_7_1rtt_secret),
+    RX_OP_CHECK_PKT_N(7c),
+    RX_OP_CHECK_NO_PKT(),
 
     /* Discard Initial EL and try injecting the packet again */
-    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_INITIAL)
-        RX_OP_INJECT_N(7)
+    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_INITIAL),
+    RX_OP_INJECT_N(7),
     /* Initial packet is not output because we have discarded Initial keys */
-    RX_OP_CHECK_PKT_N(7b)
-        RX_OP_CHECK_PKT_N(7c)
-            RX_OP_CHECK_NO_PKT()
+    RX_OP_CHECK_PKT_N(7b),
+    RX_OP_CHECK_PKT_N(7c),
+    RX_OP_CHECK_NO_PKT(),
     /* Try again with discarded keys */
-    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_HANDSHAKE)
-        RX_OP_INJECT_N(7)
-            RX_OP_CHECK_PKT_N(7c)
-                RX_OP_CHECK_NO_PKT()
+    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_HANDSHAKE),
+    RX_OP_INJECT_N(7),
+    RX_OP_CHECK_PKT_N(7c),
+    RX_OP_CHECK_NO_PKT(),
     /* Try again */
-    RX_OP_INJECT_N(7)
-        RX_OP_CHECK_PKT_N(7c)
-            RX_OP_CHECK_NO_PKT()
+    RX_OP_INJECT_N(7),
+    RX_OP_CHECK_PKT_N(7c),
+    RX_OP_CHECK_NO_PKT(),
     /* Try again with discarded 1-RTT keys */
-    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_1RTT)
-        RX_OP_INJECT_N(7)
-            RX_OP_CHECK_NO_PKT()
+    RX_OP_DISCARD_EL(QUIC_ENC_LEVEL_1RTT),
+    RX_OP_INJECT_N(7),
+    RX_OP_CHECK_NO_PKT(),
 
     /* Recreate QRL, test reading packets received before key */
-    RX_OP_SET_SCID_LEN(0)
-        RX_OP_SET_RX_DCID(empty_conn_id)
-            RX_OP_INJECT_N(7)
-                RX_OP_CHECK_NO_PKT()
-                    RX_OP_PROVIDE_SECRET_INITIAL(rx_script_7_c2s_init_dcid)
-                        RX_OP_CHECK_PKT_N(7a)
-                            RX_OP_CHECK_NO_PKT()
-                                RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE,
-                                    QRL_SUITE_CHACHA20POLY1305, rx_script_7_handshake_secret)
-                                    RX_OP_CHECK_PKT_N(7b)
-                                        RX_OP_CHECK_NO_PKT()
-                                            RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT,
-                                                QRL_SUITE_CHACHA20POLY1305, rx_script_7_1rtt_secret)
-                                                RX_OP_CHECK_PKT_N(7c)
-                                                    RX_OP_CHECK_NO_PKT()
+    RX_OP_SET_SCID_LEN(0),
+    RX_OP_SET_RX_DCID(empty_conn_id),
+    RX_OP_INJECT_N(7),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_PROVIDE_SECRET_INITIAL(rx_script_7_c2s_init_dcid),
+    RX_OP_CHECK_PKT_N(7a),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE, QRL_SUITE_CHACHA20POLY1305, rx_script_7_handshake_secret),
+    RX_OP_CHECK_PKT_N(7b),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_CHACHA20POLY1305, rx_script_7_1rtt_secret),
+    RX_OP_CHECK_PKT_N(7c),
+    RX_OP_CHECK_NO_PKT(),
 
-                                                        RX_OP_END
+    RX_OP_END
 };
 #endif /* !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305) */
 
@@ -1778,118 +1764,115 @@ static const unsigned char rx_script_8f_body[] = {
 };
 
 static const struct rx_test_op rx_script_8[] = {
-    RX_OP_ALLOW_1RTT()
-        RX_OP_SET_RX_DCID(empty_conn_id)
+    RX_OP_ALLOW_1RTT(),
+    RX_OP_SET_RX_DCID(empty_conn_id),
     /* Inject before we get the keys */
-    RX_OP_INJECT_N(8a)
+    RX_OP_INJECT_N(8a),
     /* Nothing yet */
-    RX_OP_CHECK_NO_PKT()
+    RX_OP_CHECK_NO_PKT(),
     /* Provide keys */
-    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT,
-        QRL_SUITE_AES128GCM, rx_script_8_1rtt_secret)
+    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, rx_script_8_1rtt_secret),
     /* Now the injected packet is successfully returned */
-    RX_OP_CHECK_PKT_N(8a)
-        RX_OP_CHECK_NO_PKT()
-            RX_OP_CHECK_KEY_EPOCH(0)
-                RX_OP_CHECK_PKT_EPOCH(0)
+    RX_OP_CHECK_PKT_N(8a),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_CHECK_KEY_EPOCH(0),
+    RX_OP_CHECK_PKT_EPOCH(0),
 
     /* Packet with new key phase */
-    RX_OP_INJECT_N(8b)
+    RX_OP_INJECT_N(8b),
     /* Packet is successfully decrypted and returned */
-    RX_OP_CHECK_PKT_N(8b)
-        RX_OP_CHECK_NO_PKT()
+    RX_OP_CHECK_PKT_N(8b),
+    RX_OP_CHECK_NO_PKT(),
     /* Key epoch has increased */
-    RX_OP_CHECK_KEY_EPOCH(1)
-        RX_OP_CHECK_PKT_EPOCH(1)
+    RX_OP_CHECK_KEY_EPOCH(1),
+    RX_OP_CHECK_PKT_EPOCH(1),
 
     /*
      * Now inject an old packet with the old keys (perhaps reordered in
      * network).
      */
-    RX_OP_INJECT_N(8c)
+    RX_OP_INJECT_N(8c),
     /* Should still be decrypted OK */
-    RX_OP_CHECK_PKT_N(8c)
-        RX_OP_CHECK_NO_PKT()
+    RX_OP_CHECK_PKT_N(8c),
+    RX_OP_CHECK_NO_PKT(),
     /* Epoch has not changed */
-    RX_OP_CHECK_KEY_EPOCH(1)
-        RX_OP_CHECK_PKT_EPOCH(0)
+    RX_OP_CHECK_KEY_EPOCH(1),
+    RX_OP_CHECK_PKT_EPOCH(0),
 
     /* Another packet with the new keys. */
-    RX_OP_INJECT_N(8d)
-        RX_OP_CHECK_PKT_N(8d)
-            RX_OP_CHECK_NO_PKT()
-                RX_OP_CHECK_KEY_EPOCH(1)
-                    RX_OP_CHECK_PKT_EPOCH(1)
+    RX_OP_INJECT_N(8d),
+    RX_OP_CHECK_PKT_N(8d),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_CHECK_KEY_EPOCH(1),
+    RX_OP_CHECK_PKT_EPOCH(1),
 
     /* We can inject the old packet multiple times and it still works */
-    RX_OP_INJECT_N(8c)
-        RX_OP_CHECK_PKT_N(8c)
-            RX_OP_CHECK_NO_PKT()
-                RX_OP_CHECK_KEY_EPOCH(1)
-                    RX_OP_CHECK_PKT_EPOCH(0)
+    RX_OP_INJECT_N(8c),
+    RX_OP_CHECK_PKT_N(8c),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_CHECK_KEY_EPOCH(1),
+    RX_OP_CHECK_PKT_EPOCH(0),
 
     /* Until we move from UPDATING to COOLDOWN */
-    RX_OP_KEY_UPDATE_TIMEOUT(0)
-        RX_OP_INJECT_N(8c)
-            RX_OP_CHECK_NO_PKT()
-                RX_OP_CHECK_KEY_EPOCH(1)
+    RX_OP_KEY_UPDATE_TIMEOUT(0),
+    RX_OP_INJECT_N(8c),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_CHECK_KEY_EPOCH(1),
 
     /*
      * Injecting a packet from the next epoch (epoch 2) while in COOLDOWN
      * doesn't work
      */
-    RX_OP_INJECT_N(8e)
-        RX_OP_CHECK_NO_PKT()
-            RX_OP_CHECK_KEY_EPOCH(1)
+    RX_OP_INJECT_N(8e),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_CHECK_KEY_EPOCH(1),
 
     /* Move from COOLDOWN to NORMAL and try again */
-    RX_OP_KEY_UPDATE_TIMEOUT(1)
-        RX_OP_INJECT_N(8e)
-            RX_OP_CHECK_PKT_N(8e)
-                RX_OP_CHECK_NO_PKT()
-                    RX_OP_CHECK_KEY_EPOCH(2)
-                        RX_OP_CHECK_PKT_EPOCH(2)
+    RX_OP_KEY_UPDATE_TIMEOUT(1),
+    RX_OP_INJECT_N(8e),
+    RX_OP_CHECK_PKT_N(8e),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_CHECK_KEY_EPOCH(2),
+    RX_OP_CHECK_PKT_EPOCH(2),
 
     /* Can still receive old packet */
-    RX_OP_INJECT_N(8d)
-        RX_OP_CHECK_PKT_N(8d)
-            RX_OP_CHECK_NO_PKT()
-                RX_OP_CHECK_KEY_EPOCH(2)
-                    RX_OP_CHECK_PKT_EPOCH(1)
+    RX_OP_INJECT_N(8d),
+    RX_OP_CHECK_PKT_N(8d),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_CHECK_KEY_EPOCH(2),
+    RX_OP_CHECK_PKT_EPOCH(1),
 
     /* Move straight from UPDATING to NORMAL */
-    RX_OP_KEY_UPDATE_TIMEOUT(1)
+    RX_OP_KEY_UPDATE_TIMEOUT(1),
 
     /* Try a packet from epoch 3 */
-    RX_OP_INJECT_N(8f)
-        RX_OP_CHECK_PKT_N(8f)
-            RX_OP_CHECK_NO_PKT()
-                RX_OP_CHECK_KEY_EPOCH(3)
-                    RX_OP_CHECK_PKT_EPOCH(3)
+    RX_OP_INJECT_N(8f),
+    RX_OP_CHECK_PKT_N(8f),
+    RX_OP_CHECK_NO_PKT(),
+    RX_OP_CHECK_KEY_EPOCH(3),
+    RX_OP_CHECK_PKT_EPOCH(3),
 
-                        RX_OP_END
+    RX_OP_END
 };
 
 /* 9. 1-RTT Deferral Test */
 static const struct rx_test_op rx_script_9[] = {
-    RX_OP_SET_RX_DCID(empty_conn_id)
-        RX_OP_PROVIDE_SECRET_INITIAL(rx_script_5_c2s_init_dcid)
-            RX_OP_INJECT_N(5)
+    RX_OP_SET_RX_DCID(empty_conn_id),
+    RX_OP_PROVIDE_SECRET_INITIAL(rx_script_5_c2s_init_dcid),
+    RX_OP_INJECT_N(5),
 
-                RX_OP_CHECK_PKT_N(5a)
-                    RX_OP_CHECK_NO_PKT() /* not got secret for next packet yet */
-    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE,
-        QRL_SUITE_AES128GCM, rx_script_5_handshake_secret)
-        RX_OP_CHECK_PKT_N(5b)
-            RX_OP_CHECK_NO_PKT() /* not got secret for next packet yet */
-    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT,
-        QRL_SUITE_AES128GCM, rx_script_5_1rtt_secret)
-        RX_OP_CHECK_NO_PKT() /* still nothing - 1-RTT not enabled */
-    RX_OP_ALLOW_1RTT()
-        RX_OP_CHECK_PKT_N(5c) /* now we get the 1-RTT packet */
-    RX_OP_CHECK_NO_PKT()
+    RX_OP_CHECK_PKT_N(5a),
+    RX_OP_CHECK_NO_PKT(), /* not got secret for next packet yet */
+    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE, QRL_SUITE_AES128GCM, rx_script_5_handshake_secret),
+    RX_OP_CHECK_PKT_N(5b),
+    RX_OP_CHECK_NO_PKT(), /* not got secret for next packet yet */
+    RX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, rx_script_5_1rtt_secret),
+    RX_OP_CHECK_NO_PKT(), /* still nothing - 1-RTT not enabled */
+    RX_OP_ALLOW_1RTT(),
+    RX_OP_CHECK_PKT_N(5c), /* now we get the 1-RTT packet */
+    RX_OP_CHECK_NO_PKT(),
 
-        RX_OP_END
+    RX_OP_END
 };
 
 static const struct rx_test_op *rx_scripts[] = {
@@ -3211,24 +3194,24 @@ struct tx_test_op {
 #define TX_OP_END \
     { TX_TEST_OP_END }
 #define TX_OP_WRITE(pkt) \
-    { TX_TEST_OP_WRITE, NULL, 0, &(pkt), 0, 0, NULL },
+    { TX_TEST_OP_WRITE, NULL, 0, &(pkt), 0, 0, NULL }
 #define TX_OP_PROVIDE_SECRET(el, suite, key)           \
     {                                                  \
         TX_TEST_OP_PROVIDE_SECRET, (key), sizeof(key), \
         NULL, (el), (suite), NULL                      \
-    },
+    }
 #define TX_OP_PROVIDE_SECRET_INITIAL(dcid, is_server) \
     { TX_TEST_OP_PROVIDE_SECRET_INITIAL,              \
-        NULL, 0, NULL, 0, (is_server), &(dcid) },
+        NULL, 0, NULL, 0, (is_server), &(dcid) }
 #define TX_OP_DISCARD_EL(el) \
-    { TX_TEST_OP_DISCARD_EL, NULL, 0, NULL, (el), 0, NULL },
+    { TX_TEST_OP_DISCARD_EL, NULL, 0, NULL, (el), 0, NULL }
 #define TX_OP_CHECK_DGRAM(expect_dgram)                               \
     {                                                                 \
         TX_TEST_OP_CHECK_DGRAM, (expect_dgram), sizeof(expect_dgram), \
         NULL, 0, 0, NULL                                              \
-    },
+    }
 #define TX_OP_CHECK_NO_DGRAM() \
-    { TX_TEST_OP_CHECK_NO_PKT, NULL, 0, NULL, 0, 0, NULL },
+    { TX_TEST_OP_CHECK_NO_PKT, NULL, 0, NULL, 0, 0, NULL }
 
 #define TX_OP_WRITE_N(n) \
     TX_OP_WRITE(tx_script_##n##_pkt)
@@ -3236,11 +3219,10 @@ struct tx_test_op {
     TX_OP_CHECK_DGRAM(tx_script_##n##_dgram)
 
 #define TX_OP_WRITE_CHECK(n) \
-    TX_OP_WRITE_N(n)         \
-    TX_OP_CHECK_DGRAM_N(n)
+    TX_OP_WRITE_N(n), TX_OP_CHECK_DGRAM_N(n)
 
 #define TX_OP_KEY_UPDATE() \
-    { TX_TEST_OP_KEY_UPDATE, NULL, 0, NULL, 0, 0, NULL },
+    { TX_TEST_OP_KEY_UPDATE, NULL, 0, NULL, 0, 0, NULL }
 
 /* 1. RFC 9001 - A.2 Client Initial */
 static const unsigned char tx_script_1_body[1162] = {
@@ -3401,9 +3383,9 @@ static const OSSL_QTX_PKT tx_script_1_pkt = {
 };
 
 static const struct tx_test_op tx_script_1[] = {
-    TX_OP_PROVIDE_SECRET_INITIAL(tx_script_1_hdr.dst_conn_id, 0)
-        TX_OP_WRITE_CHECK(1)
-            TX_OP_END
+    TX_OP_PROVIDE_SECRET_INITIAL(tx_script_1_hdr.dst_conn_id, 0),
+    TX_OP_WRITE_CHECK(1),
+    TX_OP_END
 };
 
 /* 2. RFC 9001 - A.3 Server Initial */
@@ -3466,9 +3448,9 @@ static const OSSL_QTX_PKT tx_script_2_pkt = {
 };
 
 static const struct tx_test_op tx_script_2[] = {
-    TX_OP_PROVIDE_SECRET_INITIAL(tx_script_1_hdr.dst_conn_id, 1)
-        TX_OP_WRITE_CHECK(2)
-            TX_OP_END
+    TX_OP_PROVIDE_SECRET_INITIAL(tx_script_1_hdr.dst_conn_id, 1),
+    TX_OP_WRITE_CHECK(2),
+    TX_OP_END
 };
 
 #if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
@@ -3518,9 +3500,9 @@ static const OSSL_QTX_PKT tx_script_3_pkt = {
 };
 
 static const struct tx_test_op tx_script_3[] = {
-    TX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_CHACHA20POLY1305, tx_script_3_secret)
-        TX_OP_WRITE_CHECK(3)
-            TX_OP_END
+    TX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_CHACHA20POLY1305, tx_script_3_secret),
+    TX_OP_WRITE_CHECK(3),
+    TX_OP_END
 };
 #endif /* !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305) */
 
@@ -3669,13 +3651,13 @@ static const OSSL_QTX_PKT tx_script_4c_pkt = {
 };
 
 static const struct tx_test_op tx_script_4[] = {
-    TX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, tx_script_4_secret)
-        TX_OP_WRITE_CHECK(4a)
-            TX_OP_KEY_UPDATE()
-                TX_OP_WRITE_CHECK(4b)
-                    TX_OP_KEY_UPDATE()
-                        TX_OP_WRITE_CHECK(4c)
-                            TX_OP_END
+    TX_OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, tx_script_4_secret),
+    TX_OP_WRITE_CHECK(4a),
+    TX_OP_KEY_UPDATE(),
+    TX_OP_WRITE_CHECK(4b),
+    TX_OP_KEY_UPDATE(),
+    TX_OP_WRITE_CHECK(4c),
+    TX_OP_END
 };
 
 /* 5. Real World - Retry Packet */
@@ -3743,8 +3725,8 @@ static const OSSL_QTX_PKT tx_script_5_pkt = {
 };
 
 static const struct tx_test_op tx_script_5[] = {
-    TX_OP_WRITE_CHECK(5)
-        TX_OP_END
+    TX_OP_WRITE_CHECK(5),
+    TX_OP_END
 };
 
 /* 6. Real World - Version Negotiation Packet */
@@ -3795,8 +3777,8 @@ static const OSSL_QTX_PKT tx_script_6_pkt = {
 };
 
 static const struct tx_test_op tx_script_6[] = {
-    TX_OP_WRITE_CHECK(6)
-        TX_OP_END
+    TX_OP_WRITE_CHECK(6),
+    TX_OP_END
 };
 
 static const struct tx_test_op *const tx_scripts[] = {

--- a/test/quic_txp_test.c
+++ b/test/quic_txp_test.c
@@ -286,51 +286,51 @@ struct script_op {
 #define OP_END \
     { OPK_END }
 #define OP_TXP_GENERATE() \
-    { OPK_TXP_GENERATE },
+    { OPK_TXP_GENERATE }
 #define OP_TXP_GENERATE_NONE() \
-    { OPK_TXP_GENERATE_NONE },
+    { OPK_TXP_GENERATE_NONE }
 #define OP_RX_PKT() \
-    { OPK_RX_PKT },
+    { OPK_RX_PKT }
 #define OP_RX_PKT_NONE() \
-    { OPK_RX_PKT_NONE },
+    { OPK_RX_PKT_NONE }
 #define OP_EXPECT_DGRAM_LEN(lo, hi) \
-    { OPK_EXPECT_DGRAM_LEN, (lo), (hi) },
+    { OPK_EXPECT_DGRAM_LEN, (lo), (hi) }
 #define OP_EXPECT_FRAME(frame_type) \
-    { OPK_EXPECT_FRAME, (frame_type) },
+    { OPK_EXPECT_FRAME, (frame_type) }
 #define OP_EXPECT_INITIAL_TOKEN(buf) \
-    { OPK_EXPECT_INITIAL_TOKEN, sizeof(buf), 0, buf },
+    { OPK_EXPECT_INITIAL_TOKEN, sizeof(buf), 0, buf }
 #define OP_EXPECT_HDR(hdr) \
-    { OPK_EXPECT_HDR, 0, 0, &(hdr) },
+    { OPK_EXPECT_HDR, 0, 0, &(hdr) }
 #define OP_CHECK(func) \
-    { OPK_CHECK, 0, 0, NULL, 0, (func) },
+    { OPK_CHECK, 0, 0, NULL, 0, (func) }
 #define OP_NEXT_FRAME() \
-    { OPK_NEXT_FRAME },
+    { OPK_NEXT_FRAME }
 #define OP_EXPECT_NO_FRAME() \
-    { OPK_EXPECT_NO_FRAME },
+    { OPK_EXPECT_NO_FRAME }
 #define OP_PROVIDE_SECRET(el, suite, secret) \
-    { OPK_PROVIDE_SECRET, (el), (suite), (secret), sizeof(secret) },
+    { OPK_PROVIDE_SECRET, (el), (suite), (secret), sizeof(secret) }
 #define OP_DISCARD_EL(el) \
-    { OPK_DISCARD_EL, (el) },
+    { OPK_DISCARD_EL, (el) }
 #define OP_CRYPTO_SEND(pn_space, buf) \
-    { OPK_CRYPTO_SEND, (pn_space), 0, (buf), sizeof(buf) },
+    { OPK_CRYPTO_SEND, (pn_space), 0, (buf), sizeof(buf) }
 #define OP_STREAM_NEW(id) \
-    { OPK_STREAM_NEW, (id) },
+    { OPK_STREAM_NEW, (id) }
 #define OP_STREAM_SEND(id, buf) \
-    { OPK_STREAM_SEND, (id), 0, (buf), sizeof(buf) },
+    { OPK_STREAM_SEND, (id), 0, (buf), sizeof(buf) }
 #define OP_STREAM_FIN(id) \
-    { OPK_STREAM_FIN, (id) },
+    { OPK_STREAM_FIN, (id) }
 #define OP_STOP_SENDING(id, aec) \
-    { OPK_STOP_SENDING, (id), (aec) },
+    { OPK_STOP_SENDING, (id), (aec) }
 #define OP_RESET_STREAM(id, aec) \
-    { OPK_RESET_STREAM, (id), (aec) },
+    { OPK_RESET_STREAM, (id), (aec) }
 #define OP_CONN_TXFC_BUMP(cwm) \
-    { OPK_CONN_TXFC_BUMP, (cwm) },
+    { OPK_CONN_TXFC_BUMP, (cwm) }
 #define OP_STREAM_TXFC_BUMP(id, cwm) \
-    { OPK_STREAM_TXFC_BUMP, (cwm), (id) },
+    { OPK_STREAM_TXFC_BUMP, (cwm), (id) }
 #define OP_HANDSHAKE_COMPLETE() \
-    { OPK_HANDSHAKE_COMPLETE },
+    { OPK_HANDSHAKE_COMPLETE }
 #define OP_NOP() \
-    { OPK_NOP },
+    { OPK_NOP }
 
 static int schedule_handshake_done(struct helper *h)
 {
@@ -346,37 +346,37 @@ static int schedule_ack_eliciting_app(struct helper *h)
 
 /* 1. 1-RTT, Single Handshake Done Frame */
 static const struct script_op script_1[] = {
-    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1)
-        OP_TXP_GENERATE_NONE()
-            OP_CHECK(schedule_handshake_done)
-                OP_TXP_GENERATE()
-                    OP_RX_PKT()
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1),
+    OP_TXP_GENERATE_NONE(),
+    OP_CHECK(schedule_handshake_done),
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
     /* Should not be long */
-    OP_EXPECT_DGRAM_LEN(21, 32)
-        OP_NEXT_FRAME()
-            OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_HANDSHAKE_DONE)
-                OP_EXPECT_NO_FRAME()
-                    OP_RX_PKT_NONE()
-                        OP_TXP_GENERATE_NONE()
-                            OP_END
+    OP_EXPECT_DGRAM_LEN(21, 32),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_HANDSHAKE_DONE),
+    OP_EXPECT_NO_FRAME(),
+    OP_RX_PKT_NONE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_END
 };
 
 /* 2. 1-RTT, Forced ACK-Eliciting Frame */
 static const struct script_op script_2[] = {
-    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1)
-        OP_TXP_GENERATE_NONE()
-            OP_CHECK(schedule_ack_eliciting_app)
-                OP_TXP_GENERATE()
-                    OP_RX_PKT()
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1),
+    OP_TXP_GENERATE_NONE(),
+    OP_CHECK(schedule_ack_eliciting_app),
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
     /* Should not be long */
-    OP_EXPECT_DGRAM_LEN(21, 32)
+    OP_EXPECT_DGRAM_LEN(21, 32),
     /* A PING frame should have been added */
-    OP_NEXT_FRAME()
-        OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_PING)
-            OP_EXPECT_NO_FRAME()
-                OP_RX_PKT_NONE()
-                    OP_TXP_GENERATE_NONE()
-                        OP_END
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_PING),
+    OP_EXPECT_NO_FRAME(),
+    OP_RX_PKT_NONE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_END
 };
 
 /* 3. 1-RTT, MAX_DATA */
@@ -395,20 +395,20 @@ static int schedule_max_data(struct helper *h)
 }
 
 static const struct script_op script_3[] = {
-    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1)
-        OP_TXP_GENERATE_NONE()
-            OP_CHECK(schedule_max_data)
-                OP_TXP_GENERATE()
-                    OP_RX_PKT()
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1),
+    OP_TXP_GENERATE_NONE(),
+    OP_CHECK(schedule_max_data),
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
     /* Should not be long */
-    OP_EXPECT_DGRAM_LEN(21, 40)
+    OP_EXPECT_DGRAM_LEN(21, 40),
     /* A PING frame should have been added */
-    OP_NEXT_FRAME()
-        OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_MAX_DATA)
-            OP_EXPECT_NO_FRAME()
-                OP_RX_PKT_NONE()
-                    OP_TXP_GENERATE_NONE()
-                        OP_END
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_MAX_DATA),
+    OP_EXPECT_NO_FRAME(),
+    OP_RX_PKT_NONE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_END
 };
 
 /* 4. 1-RTT, CFQ (NEW_CONN_ID) */
@@ -478,19 +478,19 @@ static int check_cfq_new_conn_id(struct helper *h)
 }
 
 static const struct script_op script_4[] = {
-    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1)
-        OP_TXP_GENERATE_NONE()
-            OP_CHECK(schedule_cfq_new_conn_id)
-                OP_TXP_GENERATE()
-                    OP_RX_PKT()
-                        OP_EXPECT_DGRAM_LEN(21, 128)
-                            OP_NEXT_FRAME()
-                                OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_NEW_CONN_ID)
-                                    OP_CHECK(check_cfq_new_conn_id)
-                                        OP_EXPECT_NO_FRAME()
-                                            OP_RX_PKT_NONE()
-                                                OP_TXP_GENERATE_NONE()
-                                                    OP_END
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1),
+    OP_TXP_GENERATE_NONE(),
+    OP_CHECK(schedule_cfq_new_conn_id),
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
+    OP_EXPECT_DGRAM_LEN(21, 128),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_NEW_CONN_ID),
+    OP_CHECK(check_cfq_new_conn_id),
+    OP_EXPECT_NO_FRAME(),
+    OP_RX_PKT_NONE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_END
 };
 
 /* 5. 1-RTT, CFQ (NEW_TOKEN) */
@@ -550,19 +550,19 @@ static int check_cfq_new_token(struct helper *h)
 }
 
 static const struct script_op script_5[] = {
-    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1)
-        OP_TXP_GENERATE_NONE()
-            OP_CHECK(schedule_cfq_new_token)
-                OP_TXP_GENERATE()
-                    OP_RX_PKT()
-                        OP_EXPECT_DGRAM_LEN(21, 512)
-                            OP_NEXT_FRAME()
-                                OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_NEW_TOKEN)
-                                    OP_CHECK(check_cfq_new_token)
-                                        OP_EXPECT_NO_FRAME()
-                                            OP_RX_PKT_NONE()
-                                                OP_TXP_GENERATE_NONE()
-                                                    OP_END
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1),
+    OP_TXP_GENERATE_NONE(),
+    OP_CHECK(schedule_cfq_new_token),
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
+    OP_EXPECT_DGRAM_LEN(21, 512),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_NEW_TOKEN),
+    OP_CHECK(check_cfq_new_token),
+    OP_EXPECT_NO_FRAME(),
+    OP_RX_PKT_NONE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_END
 };
 
 /* 6. 1-RTT, ACK */
@@ -586,38 +586,38 @@ static int schedule_ack(struct helper *h)
 }
 
 static const struct script_op script_6[] = {
-    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1)
-        OP_TXP_GENERATE_NONE()
-            OP_CHECK(schedule_ack)
-                OP_TXP_GENERATE()
-                    OP_RX_PKT()
-                        OP_EXPECT_DGRAM_LEN(21, 512)
-                            OP_NEXT_FRAME()
-                                OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_ACK_WITHOUT_ECN)
-                                    OP_EXPECT_NO_FRAME()
-                                        OP_RX_PKT_NONE()
-                                            OP_TXP_GENERATE_NONE()
-                                                OP_END
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1),
+    OP_TXP_GENERATE_NONE(),
+    OP_CHECK(schedule_ack),
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
+    OP_EXPECT_DGRAM_LEN(21, 512),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_ACK_WITHOUT_ECN),
+    OP_EXPECT_NO_FRAME(),
+    OP_RX_PKT_NONE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_END
 };
 
 /* 7. 1-RTT, ACK, NEW_TOKEN */
 static const struct script_op script_7[] = {
-    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1)
-        OP_TXP_GENERATE_NONE()
-            OP_CHECK(schedule_cfq_new_token)
-                OP_CHECK(schedule_ack)
-                    OP_TXP_GENERATE()
-                        OP_RX_PKT()
-                            OP_EXPECT_DGRAM_LEN(21, 512)
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1),
+    OP_TXP_GENERATE_NONE(),
+    OP_CHECK(schedule_cfq_new_token),
+    OP_CHECK(schedule_ack),
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
+    OP_EXPECT_DGRAM_LEN(21, 512),
     /* ACK must come before NEW_TOKEN */
-    OP_NEXT_FRAME()
-        OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_ACK_WITHOUT_ECN)
-            OP_NEXT_FRAME()
-                OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_NEW_TOKEN)
-                    OP_EXPECT_NO_FRAME()
-                        OP_RX_PKT_NONE()
-                            OP_TXP_GENERATE_NONE()
-                                OP_END
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_ACK_WITHOUT_ECN),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_NEW_TOKEN),
+    OP_EXPECT_NO_FRAME(),
+    OP_RX_PKT_NONE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_END
 };
 
 /* 8. 1-RTT, CRYPTO */
@@ -626,18 +626,18 @@ static const unsigned char crypto_1[] = {
 };
 
 static const struct script_op script_8[] = {
-    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1)
-        OP_TXP_GENERATE_NONE()
-            OP_CRYPTO_SEND(QUIC_PN_SPACE_APP, crypto_1)
-                OP_TXP_GENERATE()
-                    OP_RX_PKT()
-                        OP_EXPECT_DGRAM_LEN(21, 512)
-                            OP_NEXT_FRAME()
-                                OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_CRYPTO)
-                                    OP_EXPECT_NO_FRAME()
-                                        OP_RX_PKT_NONE()
-                                            OP_TXP_GENERATE_NONE()
-                                                OP_END
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1),
+    OP_TXP_GENERATE_NONE(),
+    OP_CRYPTO_SEND(QUIC_PN_SPACE_APP, crypto_1),
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
+    OP_EXPECT_DGRAM_LEN(21, 512),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_CRYPTO),
+    OP_EXPECT_NO_FRAME(),
+    OP_RX_PKT_NONE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_END
 };
 
 /* 9. 1-RTT, STREAM */
@@ -655,26 +655,26 @@ static int check_stream_9(struct helper *h)
 }
 
 static const struct script_op script_9[] = {
-    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1)
-        OP_HANDSHAKE_COMPLETE()
-            OP_TXP_GENERATE_NONE()
-                OP_STREAM_NEW(42)
-                    OP_STREAM_SEND(42, stream_9)
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1),
+    OP_HANDSHAKE_COMPLETE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_STREAM_NEW(42),
+    OP_STREAM_SEND(42, stream_9),
     /* Still no output because of TXFC */
-    OP_TXP_GENERATE_NONE()
+    OP_TXP_GENERATE_NONE(),
     /* Now grant a TXFC budget */
-    OP_CONN_TXFC_BUMP(1000)
-        OP_STREAM_TXFC_BUMP(42, 1000)
-            OP_TXP_GENERATE()
-                OP_RX_PKT()
-                    OP_EXPECT_DGRAM_LEN(21, 512)
-                        OP_NEXT_FRAME()
-                            OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_STREAM)
-                                OP_CHECK(check_stream_9)
-                                    OP_EXPECT_NO_FRAME()
-                                        OP_RX_PKT_NONE()
-                                            OP_TXP_GENERATE_NONE()
-                                                OP_END
+    OP_CONN_TXFC_BUMP(1000),
+    OP_STREAM_TXFC_BUMP(42, 1000),
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
+    OP_EXPECT_DGRAM_LEN(21, 512),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_STREAM),
+    OP_CHECK(check_stream_9),
+    OP_EXPECT_NO_FRAME(),
+    OP_RX_PKT_NONE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_END
 };
 
 /* 10. 1-RTT, STREAM, round robin */
@@ -964,67 +964,67 @@ static int check_stream_10d(struct helper *h)
 }
 
 static const struct script_op script_10[] = {
-    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1)
-        OP_HANDSHAKE_COMPLETE()
-            OP_TXP_GENERATE_NONE()
-                OP_STREAM_NEW(42)
-                    OP_STREAM_NEW(43)
-                        OP_CONN_TXFC_BUMP(10000)
-                            OP_STREAM_TXFC_BUMP(42, 5000)
-                                OP_STREAM_TXFC_BUMP(43, 5000)
-                                    OP_STREAM_SEND(42, stream_10a)
-                                        OP_STREAM_SEND(43, stream_10b)
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1),
+    OP_HANDSHAKE_COMPLETE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_STREAM_NEW(42),
+    OP_STREAM_NEW(43),
+    OP_CONN_TXFC_BUMP(10000),
+    OP_STREAM_TXFC_BUMP(42, 5000),
+    OP_STREAM_TXFC_BUMP(43, 5000),
+    OP_STREAM_SEND(42, stream_10a),
+    OP_STREAM_SEND(43, stream_10b),
 
     /* First packet containing data from stream 42 */
-    OP_TXP_GENERATE()
-        OP_RX_PKT()
-            OP_EXPECT_DGRAM_LEN(1100, 1200)
-                OP_NEXT_FRAME()
-                    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_STREAM)
-                        OP_CHECK(check_stream_10a)
-                            OP_EXPECT_NO_FRAME()
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
+    OP_EXPECT_DGRAM_LEN(1100, 1200),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_STREAM),
+    OP_CHECK(check_stream_10a),
+    OP_EXPECT_NO_FRAME(),
 
     /* Second packet containing data from stream 43 */
-    OP_TXP_GENERATE()
-        OP_RX_PKT()
-            OP_EXPECT_DGRAM_LEN(1100, 1200)
-                OP_NEXT_FRAME()
-                    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_STREAM)
-                        OP_CHECK(check_stream_10b)
-                            OP_EXPECT_NO_FRAME()
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
+    OP_EXPECT_DGRAM_LEN(1100, 1200),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_STREAM),
+    OP_CHECK(check_stream_10b),
+    OP_EXPECT_NO_FRAME(),
 
     /* Third packet containing data from stream 42 */
-    OP_TXP_GENERATE()
-        OP_RX_PKT()
-            OP_EXPECT_DGRAM_LEN(200, 500)
-                OP_NEXT_FRAME()
-                    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_STREAM_OFF_LEN)
-                        OP_CHECK(check_stream_10c)
-                            OP_NEXT_FRAME()
-                                OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_STREAM_OFF)
-                                    OP_CHECK(check_stream_10d)
-                                        OP_EXPECT_NO_FRAME()
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
+    OP_EXPECT_DGRAM_LEN(200, 500),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_STREAM_OFF_LEN),
+    OP_CHECK(check_stream_10c),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_STREAM_OFF),
+    OP_CHECK(check_stream_10d),
+    OP_EXPECT_NO_FRAME(),
 
-                                            OP_RX_PKT_NONE()
-                                                OP_TXP_GENERATE_NONE()
+    OP_RX_PKT_NONE(),
+    OP_TXP_GENERATE_NONE(),
 
-                                                    OP_END
+    OP_END
 };
 
 /* 11. Initial, CRYPTO */
 static const struct script_op script_11[] = {
-    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_INITIAL, QRL_SUITE_AES128GCM, secret_1)
-        OP_TXP_GENERATE_NONE()
-            OP_CRYPTO_SEND(QUIC_PN_SPACE_INITIAL, crypto_1)
-                OP_TXP_GENERATE()
-                    OP_RX_PKT()
-                        OP_EXPECT_DGRAM_LEN(1200, 1200)
-                            OP_NEXT_FRAME()
-                                OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_CRYPTO)
-                                    OP_EXPECT_NO_FRAME()
-                                        OP_RX_PKT_NONE()
-                                            OP_TXP_GENERATE_NONE()
-                                                OP_END
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_INITIAL, QRL_SUITE_AES128GCM, secret_1),
+    OP_TXP_GENERATE_NONE(),
+    OP_CRYPTO_SEND(QUIC_PN_SPACE_INITIAL, crypto_1),
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
+    OP_EXPECT_DGRAM_LEN(1200, 1200),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_CRYPTO),
+    OP_EXPECT_NO_FRAME(),
+    OP_RX_PKT_NONE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_END
 };
 
 /* 12. 1-RTT, STOP_SENDING */
@@ -1038,21 +1038,21 @@ static int check_stream_12(struct helper *h)
 }
 
 static const struct script_op script_12[] = {
-    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1)
-        OP_HANDSHAKE_COMPLETE()
-            OP_TXP_GENERATE_NONE()
-                OP_STREAM_NEW(42)
-                    OP_STOP_SENDING(42, 4568)
-                        OP_TXP_GENERATE()
-                            OP_RX_PKT()
-                                OP_EXPECT_DGRAM_LEN(21, 128)
-                                    OP_NEXT_FRAME()
-                                        OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_STOP_SENDING)
-                                            OP_CHECK(check_stream_12)
-                                                OP_EXPECT_NO_FRAME()
-                                                    OP_RX_PKT_NONE()
-                                                        OP_TXP_GENERATE_NONE()
-                                                            OP_END
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1),
+    OP_HANDSHAKE_COMPLETE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_STREAM_NEW(42),
+    OP_STOP_SENDING(42, 4568),
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
+    OP_EXPECT_DGRAM_LEN(21, 128),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_STOP_SENDING),
+    OP_CHECK(check_stream_12),
+    OP_EXPECT_NO_FRAME(),
+    OP_RX_PKT_NONE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_END
 };
 
 /* 13. 1-RTT, RESET_STREAM */
@@ -1071,25 +1071,25 @@ static ossl_unused int check_stream_13(struct helper *h)
 }
 
 static const struct script_op script_13[] = {
-    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1)
-        OP_HANDSHAKE_COMPLETE()
-            OP_TXP_GENERATE_NONE()
-                OP_STREAM_NEW(42)
-                    OP_CONN_TXFC_BUMP(8)
-                        OP_STREAM_TXFC_BUMP(42, 8)
-                            OP_STREAM_SEND(42, stream_13)
-                                OP_RESET_STREAM(42, 4568)
-                                    OP_TXP_GENERATE()
-                                        OP_RX_PKT()
-                                            OP_EXPECT_DGRAM_LEN(21, 128)
-                                                OP_NEXT_FRAME()
-                                                    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_RESET_STREAM)
-                                                        OP_CHECK(check_stream_13)
-                                                            OP_NEXT_FRAME()
-                                                                OP_EXPECT_NO_FRAME()
-                                                                    OP_RX_PKT_NONE()
-                                                                        OP_TXP_GENERATE_NONE()
-                                                                            OP_END
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1),
+    OP_HANDSHAKE_COMPLETE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_STREAM_NEW(42),
+    OP_CONN_TXFC_BUMP(8),
+    OP_STREAM_TXFC_BUMP(42, 8),
+    OP_STREAM_SEND(42, stream_13),
+    OP_RESET_STREAM(42, 4568),
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
+    OP_EXPECT_DGRAM_LEN(21, 128),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_RESET_STREAM),
+    OP_CHECK(check_stream_13),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_NO_FRAME(),
+    OP_RX_PKT_NONE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_END
 };
 
 /* 14. 1-RTT, CONNECTION_CLOSE */
@@ -1122,19 +1122,19 @@ static int check_14(struct helper *h)
 }
 
 static const struct script_op script_14[] = {
-    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1)
-        OP_HANDSHAKE_COMPLETE()
-            OP_TXP_GENERATE_NONE()
-                OP_CHECK(gen_conn_close)
-                    OP_TXP_GENERATE()
-                        OP_RX_PKT()
-                            OP_EXPECT_DGRAM_LEN(21, 512)
-                                OP_NEXT_FRAME()
-                                    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_CONN_CLOSE_TRANSPORT)
-                                        OP_CHECK(check_14)
-                                            OP_EXPECT_NO_FRAME()
-                                                OP_RX_PKT_NONE()
-                                                    OP_END
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1),
+    OP_HANDSHAKE_COMPLETE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_CHECK(gen_conn_close),
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
+    OP_EXPECT_DGRAM_LEN(21, 512),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_CONN_CLOSE_TRANSPORT),
+    OP_CHECK(check_14),
+    OP_EXPECT_NO_FRAME(),
+    OP_RX_PKT_NONE(),
+    OP_END
 };
 
 /* 15. INITIAL, Anti-Deadlock Probe Simulation */
@@ -1151,18 +1151,18 @@ static int gen_probe_initial(struct helper *h)
 }
 
 static const struct script_op script_15[] = {
-    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_INITIAL, QRL_SUITE_AES128GCM, secret_1)
-        OP_TXP_GENERATE_NONE()
-            OP_CHECK(gen_probe_initial)
-                OP_TXP_GENERATE()
-                    OP_RX_PKT()
-                        OP_EXPECT_DGRAM_LEN(1200, 1200)
-                            OP_NEXT_FRAME()
-                                OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_PING)
-                                    OP_EXPECT_NO_FRAME()
-                                        OP_RX_PKT_NONE()
-                                            OP_TXP_GENERATE_NONE()
-                                                OP_END
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_INITIAL, QRL_SUITE_AES128GCM, secret_1),
+    OP_TXP_GENERATE_NONE(),
+    OP_CHECK(gen_probe_initial),
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
+    OP_EXPECT_DGRAM_LEN(1200, 1200),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_PING),
+    OP_EXPECT_NO_FRAME(),
+    OP_RX_PKT_NONE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_END
 };
 
 /* 16. HANDSHAKE, Anti-Deadlock Probe Simulation */
@@ -1179,19 +1179,19 @@ static int gen_probe_handshake(struct helper *h)
 }
 
 static const struct script_op script_16[] = {
-    OP_DISCARD_EL(QUIC_ENC_LEVEL_INITIAL)
-        OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE, QRL_SUITE_AES128GCM, secret_1)
-            OP_TXP_GENERATE_NONE()
-                OP_CHECK(gen_probe_handshake)
-                    OP_TXP_GENERATE()
-                        OP_RX_PKT()
-                            OP_EXPECT_DGRAM_LEN(21, 512)
-                                OP_NEXT_FRAME()
-                                    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_PING)
-                                        OP_EXPECT_NO_FRAME()
-                                            OP_RX_PKT_NONE()
-                                                OP_TXP_GENERATE_NONE()
-                                                    OP_END
+    OP_DISCARD_EL(QUIC_ENC_LEVEL_INITIAL),
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE, QRL_SUITE_AES128GCM, secret_1),
+    OP_TXP_GENERATE_NONE(),
+    OP_CHECK(gen_probe_handshake),
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
+    OP_EXPECT_DGRAM_LEN(21, 512),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_PING),
+    OP_EXPECT_NO_FRAME(),
+    OP_RX_PKT_NONE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_END
 };
 
 /* 17. 1-RTT, Probe Simulation */
@@ -1208,20 +1208,20 @@ static int gen_probe_1rtt(struct helper *h)
 }
 
 static const struct script_op script_17[] = {
-    OP_DISCARD_EL(QUIC_ENC_LEVEL_INITIAL)
-        OP_DISCARD_EL(QUIC_ENC_LEVEL_HANDSHAKE)
-            OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1)
-                OP_TXP_GENERATE_NONE()
-                    OP_CHECK(gen_probe_1rtt)
-                        OP_TXP_GENERATE()
-                            OP_RX_PKT()
-                                OP_EXPECT_DGRAM_LEN(21, 512)
-                                    OP_NEXT_FRAME()
-                                        OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_PING)
-                                            OP_EXPECT_NO_FRAME()
-                                                OP_RX_PKT_NONE()
-                                                    OP_TXP_GENERATE_NONE()
-                                                        OP_END
+    OP_DISCARD_EL(QUIC_ENC_LEVEL_INITIAL),
+    OP_DISCARD_EL(QUIC_ENC_LEVEL_HANDSHAKE),
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_1RTT, QRL_SUITE_AES128GCM, secret_1),
+    OP_TXP_GENERATE_NONE(),
+    OP_CHECK(gen_probe_1rtt),
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
+    OP_EXPECT_DGRAM_LEN(21, 512),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_PING),
+    OP_EXPECT_NO_FRAME(),
+    OP_RX_PKT_NONE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_END
 };
 
 /* 18. Big Token Rejection */
@@ -1256,20 +1256,20 @@ static int try_big_token(struct helper *h)
 }
 
 static const struct script_op script_18[] = {
-    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_INITIAL, QRL_SUITE_AES128GCM, secret_1)
-        OP_TXP_GENERATE_NONE()
-            OP_CHECK(try_big_token)
-                OP_TXP_GENERATE_NONE()
-                    OP_CRYPTO_SEND(QUIC_PN_SPACE_INITIAL, crypto_1)
-                        OP_TXP_GENERATE()
-                            OP_RX_PKT()
-                                OP_EXPECT_DGRAM_LEN(1200, 1200)
-                                    OP_NEXT_FRAME()
-                                        OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_CRYPTO)
-                                            OP_EXPECT_NO_FRAME()
-                                                OP_RX_PKT_NONE()
-                                                    OP_TXP_GENERATE_NONE()
-                                                        OP_END
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_INITIAL, QRL_SUITE_AES128GCM, secret_1),
+    OP_TXP_GENERATE_NONE(),
+    OP_CHECK(try_big_token),
+    OP_TXP_GENERATE_NONE(),
+    OP_CRYPTO_SEND(QUIC_PN_SPACE_INITIAL, crypto_1),
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
+    OP_EXPECT_DGRAM_LEN(1200, 1200),
+    OP_NEXT_FRAME(),
+    OP_EXPECT_FRAME(OSSL_QUIC_FRAME_TYPE_CRYPTO),
+    OP_EXPECT_NO_FRAME(),
+    OP_RX_PKT_NONE(),
+    OP_TXP_GENERATE_NONE(),
+    OP_END
 };
 
 static const struct script_op *const scripts[] = {
@@ -1652,17 +1652,17 @@ static int check_is_handshake(struct helper *h)
 }
 
 static struct script_op dyn_script_1[] = {
-    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_INITIAL, QRL_SUITE_AES128GCM, secret_1)
-        OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE, QRL_SUITE_AES128GCM, secret_1)
-            OP_TXP_GENERATE_NONE()
-                OP_CRYPTO_SEND(QUIC_PN_SPACE_INITIAL, dyn_script_1_crypto_1a) /* [crypto_idx] */
-    OP_CRYPTO_SEND(QUIC_PN_SPACE_HANDSHAKE, dyn_script_1_crypto_1b)
-        OP_TXP_GENERATE()
-            OP_RX_PKT()
-                OP_EXPECT_DGRAM_LEN(1200, 1200)
-                    OP_CHECK(check_is_initial)
-                        OP_NOP() /* [pkt_idx] */
-    OP_NOP() /* [check_idx] */
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_INITIAL, QRL_SUITE_AES128GCM, secret_1),
+    OP_PROVIDE_SECRET(QUIC_ENC_LEVEL_HANDSHAKE, QRL_SUITE_AES128GCM, secret_1),
+    OP_TXP_GENERATE_NONE(),
+    OP_CRYPTO_SEND(QUIC_PN_SPACE_INITIAL, dyn_script_1_crypto_1a), /* [crypto_idx] */
+    OP_CRYPTO_SEND(QUIC_PN_SPACE_HANDSHAKE, dyn_script_1_crypto_1b),
+    OP_TXP_GENERATE(),
+    OP_RX_PKT(),
+    OP_EXPECT_DGRAM_LEN(1200, 1200),
+    OP_CHECK(check_is_initial),
+    OP_NOP(), /* [pkt_idx] */
+    OP_NOP(), /* [check_idx] */
     OP_END
 };
 

--- a/test/quic_wire_test.c
+++ b/test/quic_wire_test.c
@@ -1246,33 +1246,33 @@ static const unsigned char encode_case_23_expect[] = {
         encode_case_##n##_expect,             \
         OSSL_NELEM(encode_case_##n##_expect), \
         encode_case_##n##_dec                 \
-    },
+    }
 
 static const struct encode_test_case encode_cases[] = {
-    ENCODE_CASE(1)
-        ENCODE_CASE(2)
-            ENCODE_CASE(3)
-                ENCODE_CASE(4)
-                    ENCODE_CASE(5)
-                        ENCODE_CASE(6)
-                            ENCODE_CASE(7)
-                                ENCODE_CASE(8)
-                                    ENCODE_CASE(9)
-                                        ENCODE_CASE(10)
-                                            ENCODE_CASE(11)
-                                                ENCODE_CASE(12)
-                                                    ENCODE_CASE(13)
-                                                        ENCODE_CASE(14)
-                                                            ENCODE_CASE(15)
-                                                                ENCODE_CASE(16)
-                                                                    ENCODE_CASE(16b)
-                                                                        ENCODE_CASE(17)
-                                                                            ENCODE_CASE(18)
-                                                                                ENCODE_CASE(19)
-                                                                                    ENCODE_CASE(20)
-                                                                                        ENCODE_CASE(21)
-                                                                                            ENCODE_CASE(22)
-                                                                                                ENCODE_CASE(23)
+    ENCODE_CASE(1),
+    ENCODE_CASE(2),
+    ENCODE_CASE(3),
+    ENCODE_CASE(4),
+    ENCODE_CASE(5),
+    ENCODE_CASE(6),
+    ENCODE_CASE(7),
+    ENCODE_CASE(8),
+    ENCODE_CASE(9),
+    ENCODE_CASE(10),
+    ENCODE_CASE(11),
+    ENCODE_CASE(12),
+    ENCODE_CASE(13),
+    ENCODE_CASE(14),
+    ENCODE_CASE(15),
+    ENCODE_CASE(16),
+    ENCODE_CASE(16b),
+    ENCODE_CASE(17),
+    ENCODE_CASE(18),
+    ENCODE_CASE(19),
+    ENCODE_CASE(20),
+    ENCODE_CASE(21),
+    ENCODE_CASE(22),
+    ENCODE_CASE(23),
 };
 
 static int test_wire_encode(int idx)
@@ -1466,16 +1466,16 @@ static int ack_generic_decode(PACKET *pkt)
         sizeof(ack_case_##n##_input), \
         (dec),                        \
         (expect_fail)                 \
-    },
+    }
 
 static const struct ack_test_case ack_cases[] = {
-    ACK_CASE(1, 1, ack_generic_decode)
-        ACK_CASE(2, 0, ack_generic_decode)
-            ACK_CASE(3, 1, ack_generic_decode)
-                ACK_CASE(4, 0, ack_generic_decode)
-                    ACK_CASE(5, 1, ack_generic_decode)
-                        ACK_CASE(6, 1, ack_generic_decode)
-                            ACK_CASE(7, 0, ack_generic_decode)
+    ACK_CASE(1, 1, ack_generic_decode),
+    ACK_CASE(2, 0, ack_generic_decode),
+    ACK_CASE(3, 1, ack_generic_decode),
+    ACK_CASE(4, 0, ack_generic_decode),
+    ACK_CASE(5, 1, ack_generic_decode),
+    ACK_CASE(6, 1, ack_generic_decode),
+    ACK_CASE(7, 0, ack_generic_decode),
 };
 
 static int test_wire_ack(int idx)


### PR DESCRIPTION
![](https://getwallpapers.com/wallpaper/full/a/c/4/1328694-stairway-to-heaven-wallpaper-1920x1080-for-windows-10.jpg)

When the macro contains a comma (',') as a trailer character, then
clang-format doesn't get the correct formatting

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
