### PR TITLE
Fix up mismatched error reason codes

### DIFF
--- a/crypto/ct/ct_b64.c
+++ b/crypto/ct/ct_b64.c
@@ -84,7 +84,7 @@ SCT *SCT_new_from_base64(unsigned char version, const char *logid_base64,
 
     declen = ct_base64_decode(logid_base64, &dec);
     if (declen < 0) {
-        ERR_raise(ERR_LIB_CT, X509_R_BASE64_DECODE_ERROR);
+        ERR_raise(ERR_LIB_CT, CT_R_BASE64_DECODE_ERROR);
         goto err;
     }
     if (!SCT_set0_log_id(sct, dec, declen))
@@ -93,7 +93,7 @@ SCT *SCT_new_from_base64(unsigned char version, const char *logid_base64,
 
     declen = ct_base64_decode(extensions_base64, &dec);
     if (declen < 0) {
-        ERR_raise(ERR_LIB_CT, X509_R_BASE64_DECODE_ERROR);
+        ERR_raise(ERR_LIB_CT, CT_R_BASE64_DECODE_ERROR);
         goto err;
     }
     SCT_set0_extensions(sct, dec, declen);
@@ -101,7 +101,7 @@ SCT *SCT_new_from_base64(unsigned char version, const char *logid_base64,
 
     declen = ct_base64_decode(signature_base64, &dec);
     if (declen < 0) {
-        ERR_raise(ERR_LIB_CT, X509_R_BASE64_DECODE_ERROR);
+        ERR_raise(ERR_LIB_CT, CT_R_BASE64_DECODE_ERROR);
         goto err;
     }
 

--- a/crypto/dh/dh_backend.c
+++ b/crypto/dh/dh_backend.c
@@ -235,7 +235,7 @@ DH *ossl_dh_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
     goto done;
 
 decerr:
-    ERR_raise(ERR_LIB_DH, EVP_R_DECODE_ERROR);
+    ERR_raise(ERR_LIB_DH, DH_R_DECODE_ERROR);
 dherr:
     DH_free(dh);
     dh = NULL;

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -233,7 +233,7 @@ static int x509_pubkey_ex_d2i_ex(ASN1_VALUE **pval,
                      * bytes.
                      */
                     ERR_clear_last_mark();
-                    ERR_raise(ERR_LIB_ASN1, EVP_R_DECODE_ERROR);
+                    ERR_raise(ERR_LIB_ASN1, ASN1_R_DECODE_ERROR);
                     goto end;
                 }
             }

--- a/providers/implementations/ciphers/cipher_aes_wrp.c
+++ b/providers/implementations/ciphers/cipher_aes_wrp.c
@@ -215,7 +215,7 @@ static int aes_wrap_cipher_internal(void *vctx, unsigned char *out,
      * relies on all fields being present.
      */
     if (wctx->updated) {
-        ERR_raise(ERR_LIB_PROV, EVP_R_UPDATE_ERROR);
+        ERR_raise(ERR_LIB_PROV, PROV_R_UPDATE_CALL_OUT_OF_ORDER);
         return -1;
     }
     if (!ctx->key_set) {

--- a/providers/implementations/macs/cmac_prov.c
+++ b/providers/implementations/macs/cmac_prov.c
@@ -266,7 +266,7 @@ static int cmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
                 && !EVP_CIPHER_is_a(cipher, "AES-192-CBC")
                 && !EVP_CIPHER_is_a(cipher, "AES-128-CBC")
                 && !EVP_CIPHER_is_a(cipher, "DES-EDE3-CBC")) {
-                ERR_raise(ERR_LIB_PROV, EVP_R_UNSUPPORTED_CIPHER);
+                ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_CIPHER);
                 return 0;
             }
         }

--- a/providers/implementations/rands/test_rng.c
+++ b/providers/implementations/rands/test_rng.c
@@ -286,7 +286,7 @@ static int test_rng_enable_locking(void *vtest)
     if (t != NULL && t->lock == NULL) {
         t->lock = CRYPTO_THREAD_lock_new();
         if (t->lock == NULL) {
-            ERR_raise(ERR_LIB_PROV, RAND_R_FAILED_TO_CREATE_LOCK);
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_CREATE_LOCK);
             return 0;
         }
     }

--- a/providers/implementations/signature/rsa_sig.c
+++ b/providers/implementations/signature/rsa_sig.c
@@ -602,7 +602,7 @@ rsa_signverify_init(PROV_RSA_CTX *prsactx, void *vrsa,
 
         break;
     default:
-        ERR_raise(ERR_LIB_RSA, PROV_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
+        ERR_raise(ERR_LIB_PROV, PROV_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
         return 0;
     }
 
@@ -1903,7 +1903,7 @@ static int rsa_sigalg_signverify_init(void *vprsactx, void *vrsa,
 
     /* PSS is currently not supported as a sigalg */
     if (prsactx->pad_mode == RSA_PKCS1_PSS_PADDING) {
-        ERR_raise(ERR_LIB_RSA, PROV_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
+        ERR_raise(ERR_LIB_PROV, PROV_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
         return 0;
     }
 


### PR DESCRIPTION
Found in 4.0.0.

Noticed this while debugging an error in AES Keywrap, which was returning a strange and unexpected reason:

```
00708A6B01000000:error:1C8000BD:Provider routines:aes_wrap_cipher_internal:error retrieving entropy:providers/implementations/ciphers/cipher_aes_wrp.c:217:
```

Some code inspection found a few more mismatches which needed fixing.