### PR TITLE
pkcs7: fix four more NULL contents dereferences

### DIFF
--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -269,6 +269,10 @@ BIO *PKCS7_dataInit(PKCS7 *p7, BIO *bio)
     switch (i) {
     case NID_pkcs7_signed:
         md_sk = p7->d.sign->md_algs;
+        if (p7->d.sign->contents == NULL) {
+            ERR_raise(ERR_LIB_PKCS7, PKCS7_R_NO_CONTENT);
+            goto err;
+        }
         os = pkcs7_get1_data(p7->d.sign->contents);
         break;
     case NID_pkcs7_signedAndEnveloped:
@@ -292,6 +296,10 @@ BIO *PKCS7_dataInit(PKCS7 *p7, BIO *bio)
         break;
     case NID_pkcs7_digest:
         xa = p7->d.digest->md;
+        if (p7->d.digest->contents == NULL) {
+            ERR_raise(ERR_LIB_PKCS7, PKCS7_R_NO_CONTENT);
+            goto err;
+        }
         os = pkcs7_get1_data(p7->d.digest->contents);
         break;
     case NID_pkcs7_data:
@@ -475,6 +483,10 @@ BIO *PKCS7_dataDecode(PKCS7 *p7, EVP_PKEY *pkey, BIO *in_bio, X509 *pcert)
          * data_body is NULL if that structure has no (=detached) content
          * or if the contentType is wrong (i.e., not "data").
          */
+        if (p7->d.sign->contents == NULL) {
+            ERR_raise(ERR_LIB_PKCS7, PKCS7_R_NO_CONTENT);
+            goto err;
+        }
         data_body = PKCS7_get_octet_string(p7->d.sign->contents);
         if (!PKCS7_is_detached(p7) && data_body == NULL) {
             ERR_raise(ERR_LIB_PKCS7, PKCS7_R_INVALID_SIGNED_DATA_TYPE);

--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -28,7 +28,7 @@ long PKCS7_ctrl(PKCS7 *p7, int cmd, long larg, char *parg)
     /* NOTE(emilia): does not support detached digested data. */
     case PKCS7_OP_SET_DETACHED_SIGNATURE:
         if (nid == NID_pkcs7_signed) {
-            if (p7->d.sign == NULL) {
+            if (p7->d.sign == NULL || p7->d.sign->contents == NULL) {
                 ERR_raise(ERR_LIB_PKCS7, PKCS7_R_NO_CONTENT);
                 ret = 0;
                 break;

--- a/test/pkcs7_test.c
+++ b/test/pkcs7_test.c
@@ -387,11 +387,64 @@ end:
 }
 #endif /* OPENSSL_NO_EC */
 
+/*
+ * Regression test for the NULL p7->d.<sign|digest>->contents handling fixed
+ * by PR #30351 and this commit. PKCS7_set_content(p7, NULL) is a public API
+ * that legitimately produces this state; the affected functions used to
+ * dereference NULL via PKCS7_get_octet_string -> PKCS7_type_is_data. They
+ * must now return cleanly with PKCS7_R_NO_CONTENT.
+ */
+static int pkcs7_null_contents_test(void)
+{
+    PKCS7 *p7 = NULL;
+    int ret = 0;
+
+    /* PKCS7_dataInit, NID_pkcs7_signed */
+    if (!TEST_ptr(p7 = PKCS7_new())
+        || !TEST_true(PKCS7_set_type(p7, NID_pkcs7_signed))
+        || !TEST_true(PKCS7_set_content(p7, NULL))
+        || !TEST_ptr_null(PKCS7_dataInit(p7, NULL)))
+        goto end;
+    PKCS7_free(p7);
+    p7 = NULL;
+
+    /* PKCS7_dataInit, NID_pkcs7_digest */
+    if (!TEST_ptr(p7 = PKCS7_new())
+        || !TEST_true(PKCS7_set_type(p7, NID_pkcs7_digest))
+        || !TEST_true(PKCS7_set_content(p7, NULL))
+        || !TEST_ptr_null(PKCS7_dataInit(p7, NULL)))
+        goto end;
+    PKCS7_free(p7);
+    p7 = NULL;
+
+    /* PKCS7_dataDecode, NID_pkcs7_signed */
+    if (!TEST_ptr(p7 = PKCS7_new())
+        || !TEST_true(PKCS7_set_type(p7, NID_pkcs7_signed))
+        || !TEST_true(PKCS7_set_content(p7, NULL))
+        || !TEST_ptr_null(PKCS7_dataDecode(p7, NULL, NULL, NULL)))
+        goto end;
+    PKCS7_free(p7);
+    p7 = NULL;
+
+    /* PKCS7_set_detached -> PKCS7_ctrl OP_SET_DETACHED_SIGNATURE */
+    if (!TEST_ptr(p7 = PKCS7_new())
+        || !TEST_true(PKCS7_set_type(p7, NID_pkcs7_signed))
+        || !TEST_true(PKCS7_set_content(p7, NULL))
+        || !TEST_int_eq(PKCS7_set_detached(p7, 1), 0))
+        goto end;
+
+    ret = 1;
+end:
+    PKCS7_free(p7);
+    return ret;
+}
+
 int setup_tests(void)
 {
 #ifndef OPENSSL_NO_EC
     ADD_TEST(pkcs7_verify_test);
     ADD_TEST(pkcs7_inner_content_verify_test);
 #endif /* OPENSSL_NO_EC */
+    ADD_TEST(pkcs7_null_contents_test);
     return 1;
 }


### PR DESCRIPTION
PR #30351 added NULL-contents guards in PKCS7_dataFinal, PKCS7_stream, and PKCS7_ctrl (OP_GET_DETACHED_SIGNATURE) but missed four sibling sites with the same crash signature:

  - PKCS7_dataInit, NID_pkcs7_signed   (pk7_doit.c)
  - PKCS7_dataInit, NID_pkcs7_digest   (pk7_doit.c)
  - PKCS7_dataDecode, NID_pkcs7_signed (pk7_doit.c)
  - PKCS7_ctrl OP_SET_DETACHED_SIGNATURE (pk7_lib.c, the case adjacent
    to the one fixed at OP_GET_DETACHED_SIGNATURE)

All four pass p7->d.<sign|digest>->contents (which may be NULL) to PKCS7_get_octet_string, which calls PKCS7_type_is_data on a NULL pointer, dereferencing NULL->type. Add the same guard pattern PR #30351 used.