### PR TITLE
crypto/evp: fix double free of tmp_keymgmt in evp_keyexch_init()

### DIFF
--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -295,7 +295,9 @@ int EVP_PKEY_derive_init_ex(EVP_PKEY_CTX *ctx, const OSSL_PARAM params[])
          * iteration we're on.
          */
         EVP_KEYEXCH_free(exchange);
+        exchange = NULL;
         EVP_KEYMGMT_free(tmp_keymgmt);
+        tmp_keymgmt = NULL;
 
         switch (iter) {
         case 1:


### PR DESCRIPTION
Commit a21f77dbc99c242b73b5b420714a2cd36bee084a fixed the double free of
tmp_keymgmt in the provider fallback loop for kem, signature and
asymcipher, but the identical pattern in evp_keyexch_init()
(crypto/evp/exchange.c) was missed.

At the top of the retry loop, EVP_KEYEXCH_free(exchange) and
EVP_KEYMGMT_free(tmp_keymgmt) are called before each attempt. When
evp_pkey_export_to_provider() sets tmp_keymgmt to NULL, the guard frees
tmp_keymgmt_tofree (PTR_B) but does not NULL out tmp_keymgmt. On the
next iteration, EVP_KEYMGMT_free(tmp_keymgmt) is called again on the
already-freed PTR_B — a double free.

Fix: add exchange = NULL and tmp_keymgmt = NULL after each free at the
top of the loop, consistent with the fix applied by a21f77d to kem.c,
asymcipher.c and signature.c.

Fixes: a21f77d ("crypto/evp: fix double free of tmp_keymgmt in sig/kem/asym init")

cc @nhorman @t8m