### PR TITLE
TLS 1.x: Bind resumed session lifetime to full handshake

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,20 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * TLS 1.3 servers now bind the lifetime of a resumed session to the initial
+   full handshake: a ticket issued for a resumed session restarts the session
+   lifetime, but is capped by the remaining lifetime of the session it was
+   resumed from, so that repeated resumption can no longer prolong a session
+   indefinitely. Tickets issued after a fresh external-PSK authentication are
+   not capped. A negative timeout passed to `SSL_CTX_set_timeout()` or
+   `SSL_SESSION_set_timeout()` now selects an unlimited session lifetime,
+   opting out of expiry entirely; the corresponding getters (and the
+   previous-value return of the setters) report an unlimited timeout as -1.
+   A new `SessionTimeout` (`-session_timeout`) configuration command exposes
+   the same control, including the value `infinite`.
+
+   *Daniel Kubec*
+
  * Fixed TLS 1.3 clients to encrypt 0-RTT early data with the first offered
    PSK identity (RFC 9846 section 4.3.10) when a 0-RTT-capable resumption
    ticket has aged out and an external PSK is offered in its place. The early

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,8 +35,7 @@ OpenSSL Releases
    full handshake: a ticket issued for a resumed session restarts the session
    lifetime, but is capped by the remaining lifetime of the session it was
    resumed from, so that repeated resumption can no longer prolong a session
-   indefinitely. Tickets issued after a fresh external-PSK authentication are
-   not capped. A negative timeout passed to `SSL_CTX_set_timeout()` or
+   indefinitely. A negative timeout passed to `SSL_CTX_set_timeout()` or
    `SSL_SESSION_set_timeout()` now selects an unlimited session lifetime,
    opting out of expiry entirely; the corresponding getters (and the
    previous-value return of the setters) report an unlimited timeout as -1.

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -302,6 +302,13 @@ Padding attempts to pad TLSv1.3 records so that they are a multiple of the set
 length on send. A value of 0 or 1 turns off padding as relevant. Otherwise, the
 values must be >1 or <=16384.
 
+=item B<-session_timeout> I<timeout>
+
+Sets the timeout for newly created sessions to I<timeout> seconds. The value
+B<infinite> (or any negative number) selects an unlimited session lifetime:
+such sessions never expire and can be resumed indefinitely. See
+L<SSL_CTX_set_timeout(3)>. This command is only supported for servers.
+
 =item B<-debug_broken_protocol>
 
 Ignored.
@@ -447,6 +454,13 @@ Note that, for QUIC objects, padding is always performed at the
 packet level, and so cannot be done at the record level.  Given that, when the
 config file is created, there is no knowledge of what kind of SSL objects are
 being created, this option is silently ignored for QUIC objects.
+
+=item B<SessionTimeout>
+
+Sets the timeout for newly created sessions to B<value> seconds. The value
+B<infinite> (or any negative number) selects an unlimited session lifetime:
+such sessions never expire and can be resumed indefinitely. See
+L<SSL_CTX_set_timeout(3)>. This option is only supported for servers.
 
 =item B<SignatureAlgorithms>
 

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -269,6 +269,13 @@ Padding attempts to pad TLSv1.3 records so that they are a multiple of the set
 length on send. A value of 0 or 1 turns off padding as relevant. Otherwise, the
 values must be >1 or <=16384.
 
+=item B<-session_timeout> I<timeout>
+
+Sets the timeout for newly created sessions to I<timeout> seconds. The value
+B<infinite> (or any negative number) selects an unlimited session lifetime:
+such sessions never expire and can be resumed indefinitely. See
+L<SSL_CTX_set_timeout(3)>. This command is only supported for servers.
+
 =item B<-debug_broken_protocol>
 
 Ignored.
@@ -414,6 +421,13 @@ Note that, for QUIC objects, padding is always performed at the
 packet level, and so cannot be done at the record level.  Given that, when the
 config file is created, there is no knowledge of what kind of SSL objects are
 being created, this option is silently ignored for QUIC objects.
+
+=item B<SessionTimeout>
+
+Sets the timeout for newly created sessions to B<value> seconds. The value
+B<infinite> (or any negative number) selects an unlimited session lifetime:
+such sessions never expire and can be resumed indefinitely. See
+L<SSL_CTX_set_timeout(3)>. This option is only supported for servers.
 
 =item B<SignatureAlgorithms>
 
@@ -886,6 +900,8 @@ exchange group as specified in RFC8998, and B<curveSM2MLKEM768>, which is a
 hybrid of the B<curveSM2> group with B<ML-KEM-768>.
 
 As of OpenSSL 3.5 key exchange group names are case-insensitive.
+
+B<SessionTimeout> (B<-session_timeout>) was added in OpenSSL 4.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set_timeout.pod
+++ b/doc/man3/SSL_CTX_set_timeout.pod
@@ -59,11 +59,7 @@ lifetime hint.
 For TLSv1.3, a ticket issued for a resumed session restarts the session
 lifetime, but the new lifetime is capped by the remaining lifetime of the
 session it was resumed from, so that resumption cannot be used to prolong a
-session beyond its originally intended lifetime. This does not apply to
-external pre-shared keys: a handshake authenticated by an external PSK is a
-fresh authentication rather than a resumption, so tickets issued for it
-carry the full timeout. If the timeout is unlimited the lifetime is
-restarted in full on each resumption.
+session beyond its originally intended lifetime.
 
 For TLSv1.3, an unlimited timeout is transmitted in a ticket lifetime hint
 as the RFC8446 1 week maximum, but the session stored or re-created from

--- a/doc/man3/SSL_CTX_set_timeout.pod
+++ b/doc/man3/SSL_CTX_set_timeout.pod
@@ -14,8 +14,8 @@ SSL_CTX_set_timeout, SSL_CTX_get_timeout - manipulate timeout values for session
 =head1 DESCRIPTION
 
 SSL_CTX_set_timeout() sets the timeout for newly created sessions for
-B<ctx> to B<t>. The timeout value B<t> must be given in seconds. A negative
-value for B<t> selects an unlimited timeout: sessions then never expire and
+I<ctx> to I<t>. The timeout value B<t> must be given in seconds. A negative
+value for I<t> selects an unlimited timeout: sessions then never expire and
 can be resumed indefinitely.
 
 SSL_CTX_get_timeout() returns the currently set timeout value for B<ctx>,

--- a/doc/man3/SSL_CTX_set_timeout.pod
+++ b/doc/man3/SSL_CTX_set_timeout.pod
@@ -14,9 +14,12 @@ SSL_CTX_set_timeout, SSL_CTX_get_timeout - manipulate timeout values for session
 =head1 DESCRIPTION
 
 SSL_CTX_set_timeout() sets the timeout for newly created sessions for
-B<ctx> to B<t>. The timeout value B<t> must be given in seconds.
+B<ctx> to B<t>. The timeout value B<t> must be given in seconds. A negative
+value for B<t> selects an unlimited timeout: sessions then never expire and
+can be resumed indefinitely.
 
-SSL_CTX_get_timeout() returns the currently set timeout value for B<ctx>.
+SSL_CTX_get_timeout() returns the currently set timeout value for B<ctx>,
+or -1 if the timeout is unlimited.
 
 =head1 NOTES
 
@@ -49,14 +52,36 @@ For TLSv1.3, RFC8446 limits transmission of this value to 1 week (604800
 seconds).
 
 For TLSv1.2, tickets generated during an initial handshake use the value
-as specified. Tickets generated during a resumed handshake have a value
-of 0 for the ticket lifetime hint.
+as specified. Tickets generated during a resumed handshake, and tickets for
+sessions with an unlimited timeout, have a value of 0 for the ticket
+lifetime hint.
+
+For TLSv1.3, a ticket issued for a resumed session restarts the session
+lifetime, but the new lifetime is capped by the remaining lifetime of the
+session it was resumed from, so that resumption cannot be used to prolong a
+session beyond its originally intended lifetime. This does not apply to
+external pre-shared keys: a handshake authenticated by an external PSK is a
+fresh authentication rather than a resumption, so tickets issued for it
+carry the full timeout. If the timeout is unlimited the lifetime is
+restarted in full on each resumption.
+
+For TLSv1.3, an unlimited timeout is transmitted in a ticket lifetime hint
+as the RFC8446 1 week maximum, but the session stored or re-created from
+such a ticket retains its unlimited timeout.
+
+Note that if B<SSL_SESS_CACHE_UPDATE_TIME> is set in the session cache mode
+(see L<SSL_CTX_set_session_cache_mode(3)>) the session's timestamp is
+refreshed each time the session is used, which moves its expiry forward and
+so still allows a regularly resumed session to be prolonged beyond the cap
+described above.
 
 =head1 RETURN VALUES
 
-SSL_CTX_set_timeout() returns the previously set timeout value.
+SSL_CTX_set_timeout() returns the previously set timeout value, or -1 if the
+previously set timeout was unlimited.
 
-SSL_CTX_get_timeout() returns the currently set timeout value.
+SSL_CTX_get_timeout() returns the currently set timeout value, or -1 if the
+timeout is unlimited.
 
 =head1 SEE ALSO
 
@@ -68,7 +93,7 @@ L<SSL_get_default_timeout(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2001-2022 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2001-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/SSL_CTX_set_timeout.pod
+++ b/doc/man3/SSL_CTX_set_timeout.pod
@@ -14,9 +14,12 @@ SSL_CTX_set_timeout, SSL_CTX_get_timeout - manipulate timeout values for session
 =head1 DESCRIPTION
 
 SSL_CTX_set_timeout() sets the timeout for newly created sessions for
-B<ctx> to B<t>. The timeout value B<t> must be given in seconds.
+B<ctx> to B<t>. The timeout value B<t> must be given in seconds. A negative
+value for B<t> selects an unlimited timeout: sessions then never expire and
+can be resumed indefinitely.
 
-SSL_CTX_get_timeout() returns the currently set timeout value for B<ctx>.
+SSL_CTX_get_timeout() returns the currently set timeout value for B<ctx>,
+or -1 if the timeout is unlimited.
 
 =head1 NOTES
 
@@ -52,11 +55,23 @@ For TLSv1.2, tickets generated during an initial handshake use the value
 as specified. Tickets generated during a resumed handshake have a value
 of 0 for the ticket lifetime hint.
 
+For TLSv1.3, a ticket issued for a resumed session restarts the session
+lifetime, but the new lifetime is capped by the remaining lifetime of the
+session it was resumed from, so that resumption cannot be used to prolong a
+session beyond its originally intended lifetime. If the timeout is unlimited
+the lifetime is restarted in full on each resumption.
+
+An unlimited timeout is transmitted in a ticket lifetime hint as the RFC8446
+1 week maximum, but the session stored or re-created from such a ticket
+retains its unlimited timeout.
+
 =head1 RETURN VALUES
 
-SSL_CTX_set_timeout() returns the previously set timeout value.
+SSL_CTX_set_timeout() returns the previously set timeout value, or -1 if the
+previously set timeout was unlimited.
 
-SSL_CTX_get_timeout() returns the currently set timeout value.
+SSL_CTX_get_timeout() returns the currently set timeout value, or -1 if the
+timeout is unlimited.
 
 =head1 SEE ALSO
 
@@ -68,7 +83,7 @@ L<SSL_get_default_timeout(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2001-2022 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2001-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/SSL_SESSION_get_time.pod
+++ b/doc/man3/SSL_SESSION_get_time.pod
@@ -42,7 +42,7 @@ SSL_SESSION_get_timeout() returns the timeout value set for session B<s>
 in seconds, or -1 if the timeout is unlimited.
 
 SSL_SESSION_set_timeout() sets the timeout value for session B<s> in seconds
-to B<tm>. A negative value for B<tm> selects an unlimited timeout: the
+to I<tm>. A negative value for I<tm> selects an unlimited timeout: the
 session then never expires.
 
 SSL_SESSION_get_time() and SSL_SESSION_set_time() functions use

--- a/doc/man3/SSL_SESSION_get_time.pod
+++ b/doc/man3/SSL_SESSION_get_time.pod
@@ -39,10 +39,11 @@ SSL_SESSION_set_time_ex() replaces the creation time of the session B<s> with
 the chosen value B<tm>.
 
 SSL_SESSION_get_timeout() returns the timeout value set for session B<s>
-in seconds.
+in seconds, or -1 if the timeout is unlimited.
 
 SSL_SESSION_set_timeout() sets the timeout value for session B<s> in seconds
-to B<tm>.
+to B<tm>. A negative value for B<tm> selects an unlimited timeout: the
+session then never expires.
 
 SSL_SESSION_get_time() and SSL_SESSION_set_time() functions use
 the long datatype instead of time_t and are therefore deprecated due to not

--- a/ssl/ssl_asn1.c
+++ b/ssl/ssl_asn1.c
@@ -328,10 +328,16 @@ SSL_SESSION *d2i_SSL_SESSION_ex(SSL_SESSION **a, const unsigned char **pp,
     else
         ret->time = ossl_time_now();
 
-    if (as->timeout != 0)
-        ret->timeout = ossl_seconds2time(as->timeout);
-    else
+    if (as->timeout != 0) {
+        uint64_t infinite_secs = ossl_time2seconds(ossl_time_infinite());
+
+        if (as->timeout < 0 || (uint64_t)as->timeout >= infinite_secs)
+            ret->timeout = ossl_time_infinite();
+        else
+            ret->timeout = ossl_seconds2time(as->timeout);
+    } else {
         ret->timeout = ossl_seconds2time(3);
+    }
     ssl_session_calculate_timeout(ret);
 
     X509_free(ret->peer);

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -740,6 +740,7 @@ static int cmd_NumTickets(SSL_CONF_CTX *cctx, const char *value)
 
 static int cmd_SessionTimeout(SSL_CONF_CTX *cctx, const char *value)
 {
+    ossl_unused long prev;
     long t;
     char *endptr = NULL;
 
@@ -758,8 +759,8 @@ static int cmd_SessionTimeout(SSL_CONF_CTX *cctx, const char *value)
             return 0;
     }
 
-    /* SSL_CTX_set_timeout() returns the previous timeout, not a status */
-    SSL_CTX_set_timeout(cctx->ctx, t);
+    /* Returns the previous timeout rather than a status; cannot fail here */
+    prev = SSL_CTX_set_timeout(cctx->ctx, t);
     return 1;
 }
 

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -737,6 +737,30 @@ static int cmd_NumTickets(SSL_CONF_CTX *cctx, const char *value)
     return rv;
 }
 
+static int cmd_SessionTimeout(SSL_CONF_CTX *cctx, const char *value)
+{
+    long t;
+    char *endptr = NULL;
+
+    if (cctx->ctx == NULL)
+        return 1;
+
+    if (value == NULL || *value == '\0')
+        return 0;
+
+    if (OPENSSL_strcasecmp(value, "infinite") == 0)
+        t = -1;
+    else {
+        t = strtol(value, &endptr, 0);
+        if (endptr == value || (endptr != NULL && *endptr != '\0'))
+            return 0;
+    }
+
+    if (SSL_CTX_set_timeout(cctx->ctx, t) == 0)
+        return 0;
+    return 1;
+}
+
 typedef struct {
     int (*cmd)(SSL_CONF_CTX *cctx, const char *value);
     const char *str_file;
@@ -841,6 +865,7 @@ static const ssl_conf_cmd_tbl ssl_conf_cmds[] = {
         SSL_CONF_TYPE_FILE),
     SSL_CONF_CMD_STRING(RecordPadding, "record_padding", 0),
     SSL_CONF_CMD_STRING(NumTickets, "num_tickets", SSL_CONF_FLAG_SERVER),
+    SSL_CONF_CMD_STRING(SessionTimeout, "session_timeout", SSL_CONF_FLAG_SERVER),
 };
 
 /* Supported switches: must match order of switches in ssl_conf_cmds */

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -9,6 +9,7 @@
 
 #include "internal/e_os.h"
 
+#include <errno.h>
 #include <limits.h>
 #include <stdio.h>
 #include "ssl_local.h"
@@ -737,6 +738,31 @@ static int cmd_NumTickets(SSL_CONF_CTX *cctx, const char *value)
     return rv;
 }
 
+static int cmd_SessionTimeout(SSL_CONF_CTX *cctx, const char *value)
+{
+    long t;
+    char *endptr = NULL;
+
+    if (cctx->ctx == NULL)
+        return 1;
+
+    if (value == NULL || *value == '\0')
+        return 0;
+
+    if (OPENSSL_strcasecmp(value, "infinite") == 0) {
+        t = -1;
+    } else {
+        errno = 0;
+        t = strtol(value, &endptr, 0);
+        if (endptr == value || *endptr != '\0' || errno != 0)
+            return 0;
+    }
+
+    /* SSL_CTX_set_timeout() returns the previous timeout, not a status */
+    SSL_CTX_set_timeout(cctx->ctx, t);
+    return 1;
+}
+
 typedef struct {
     int (*cmd)(SSL_CONF_CTX *cctx, const char *value);
     const char *str_file;
@@ -841,6 +867,7 @@ static const ssl_conf_cmd_tbl ssl_conf_cmds[] = {
         SSL_CONF_TYPE_FILE),
     SSL_CONF_CMD_STRING(RecordPadding, "record_padding", 0),
     SSL_CONF_CMD_STRING(NumTickets, "num_tickets", SSL_CONF_FLAG_SERVER),
+    SSL_CONF_CMD_STRING(SessionTimeout, "session_timeout", SSL_CONF_FLAG_SERVER),
 };
 
 /* Supported switches: must match order of switches in ssl_conf_cmds */

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -997,10 +997,15 @@ int SSL_SESSION_set1_id(SSL_SESSION *s, const unsigned char *sid,
 
 long SSL_SESSION_set_timeout(SSL_SESSION *s, long t)
 {
-    OSSL_TIME new_timeout = ossl_seconds2time(t);
+    OSSL_TIME new_timeout;
 
-    if (s == NULL || t < 0)
+    if (s == NULL)
         return 0;
+    /* A negative |t| selects an unlimited ("infinite") session lifetime. */
+    if (t < 0)
+        new_timeout = ossl_time_infinite();
+    else
+        new_timeout = ossl_seconds2time(t);
     if (s->owner != NULL) {
         if (!CRYPTO_THREAD_write_lock(s->owner->lock))
             return 0;
@@ -1019,6 +1024,8 @@ long SSL_SESSION_get_timeout(const SSL_SESSION *s)
 {
     if (s == NULL)
         return 0;
+    if (ossl_time_is_infinite(s->timeout))
+        return -1;
     return (long)ossl_time_to_time_t(s->timeout);
 }
 
@@ -1199,8 +1206,14 @@ long SSL_CTX_set_timeout(SSL_CTX *s, long t)
 
     if (s == NULL)
         return 0;
-    l = (long)ossl_time2seconds(s->session_timeout);
-    s->session_timeout = ossl_seconds2time(t);
+    if (ossl_time_is_infinite(s->session_timeout))
+        l = -1;
+    else
+        l = (long)ossl_time2seconds(s->session_timeout);
+    if (t < 0)
+        s->session_timeout = ossl_time_infinite();
+    else
+        s->session_timeout = ossl_seconds2time(t);
     return l;
 }
 
@@ -1208,6 +1221,8 @@ long SSL_CTX_get_timeout(const SSL_CTX *s)
 {
     if (s == NULL)
         return 0;
+    if (ossl_time_is_infinite(s->session_timeout))
+        return -1;
     return (long)ossl_time2seconds(s->session_timeout);
 }
 

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -12,6 +12,7 @@
 #include <spthread.h>
 #include <spt_extensions.h> /* timeval */
 #endif
+#include <limits.h>
 #include <stdio.h>
 #include <openssl/rand.h>
 #include "internal/refcount.h"
@@ -997,12 +998,41 @@ int SSL_SESSION_set1_id(SSL_SESSION *s, const unsigned char *sid,
     return 1;
 }
 
+/*
+ * A negative timeout selects an unlimited ("infinite") session lifetime.
+ * Values too large to represent as an OSSL_TIME saturate to unlimited as
+ * well, matching the treatment of oversized encoded timeouts in
+ * d2i_SSL_SESSION_ex().
+ */
+static OSSL_TIME sess_timeout_from_seconds(long t)
+{
+    if (t < 0 || (uint64_t)t >= ossl_time2seconds(ossl_time_infinite()))
+        return ossl_time_infinite();
+    return ossl_seconds2time(t);
+}
+
+/*
+ * An unlimited timeout is reported as -1. A finite timeout is clamped to
+ * LONG_MAX so that it cannot truncate into a negative value and be mistaken
+ * for the -1 sentinel on platforms with a 32 bit long.
+ */
+static long sess_timeout_to_seconds(OSSL_TIME timeout)
+{
+    uint64_t secs;
+
+    if (ossl_time_is_infinite(timeout))
+        return -1;
+    secs = ossl_time2seconds(timeout);
+    return secs > LONG_MAX ? LONG_MAX : (long)secs;
+}
+
 long SSL_SESSION_set_timeout(SSL_SESSION *s, long t)
 {
-    OSSL_TIME new_timeout = ossl_seconds2time(t);
+    OSSL_TIME new_timeout;
 
-    if (s == NULL || t < 0)
+    if (s == NULL)
         return 0;
+    new_timeout = sess_timeout_from_seconds(t);
     if (s->owner != NULL) {
         if (!CRYPTO_THREAD_write_lock(s->owner->lock))
             return 0;
@@ -1021,7 +1051,7 @@ long SSL_SESSION_get_timeout(const SSL_SESSION *s)
 {
     if (s == NULL)
         return 0;
-    return (long)ossl_time_to_time_t(s->timeout);
+    return sess_timeout_to_seconds(s->timeout);
 }
 
 #ifndef OPENSSL_NO_DEPRECATED_3_4
@@ -1201,8 +1231,8 @@ long SSL_CTX_set_timeout(SSL_CTX *s, long t)
 
     if (s == NULL)
         return 0;
-    l = (long)ossl_time2seconds(s->session_timeout);
-    s->session_timeout = ossl_seconds2time(t);
+    l = sess_timeout_to_seconds(s->session_timeout);
+    s->session_timeout = sess_timeout_from_seconds(t);
     return l;
 }
 
@@ -1210,7 +1240,7 @@ long SSL_CTX_get_timeout(const SSL_CTX *s)
 {
     if (s == NULL)
         return 0;
-    return (long)ossl_time2seconds(s->session_timeout);
+    return sess_timeout_to_seconds(s->session_timeout);
 }
 
 int SSL_set_session_secret_cb(SSL *s,

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -4240,24 +4240,33 @@ CON_FUNC_RETURN tls_construct_server_compressed_certificate(SSL_CONNECTION *sc, 
 static int create_ticket_prequel(SSL_CONNECTION *s, WPACKET *pkt,
     uint32_t age_add, unsigned char *tick_nonce)
 {
-    uint32_t timeout = (uint32_t)ossl_time2seconds(s->session->timeout);
+    uint64_t timeout_secs = ossl_time2seconds(s->session->timeout);
+    uint32_t timeout;
 
     /*
      * Ticket lifetime hint:
      * In TLSv1.3 we reset the "time" field above, and always specify the
-     * timeout, limited to a 1 week period per RFC9846.
+     * timeout, limited to a 1 week period per RFC9846. An unlimited timeout
+     * is transmitted as the 1 week maximum too.
      * For TLSv1.2 this is advisory only and we leave this unspecified for
-     * resumed session (for simplicity).
+     * resumed sessions (for simplicity) and for unlimited timeouts, which
+     * have no finite representation on the wire; other values that do not
+     * fit the 32 bit field are saturated.
      */
 #define ONE_WEEK_SEC (7 * 24 * 60 * 60)
 
     if (SSL_CONNECTION_IS_TLS13(s)) {
-        if (ossl_time_compare(s->session->timeout,
-                ossl_seconds2time(ONE_WEEK_SEC))
-            > 0)
+        if (timeout_secs > ONE_WEEK_SEC)
             timeout = ONE_WEEK_SEC;
-    } else if (s->hit)
+        else
+            timeout = (uint32_t)timeout_secs;
+    } else if (s->hit || ossl_time_is_infinite(s->session->timeout)) {
         timeout = 0;
+    } else if (timeout_secs > UINT32_MAX) {
+        timeout = UINT32_MAX;
+    } else {
+        timeout = (uint32_t)timeout_secs;
+    }
 
     if (!WPACKET_put_bytes_u32(pkt, timeout)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
@@ -4525,6 +4534,7 @@ CON_FUNC_RETURN tls_construct_new_session_ticket(SSL_CONNECTION *s, WPACKET *pkt
     if (SSL_CONNECTION_IS_TLS13(s)) {
         size_t i, hashlen;
         uint64_t nonce;
+        OSSL_TIME expiry;
         /* ASCII: "resumption", in hex for EBCDIC compatibility */
         static const unsigned char nonce_label[] = { 0x72, 0x65, 0x73, 0x75, 0x6D,
             0x70, 0x74, 0x69, 0x6F, 0x6E };
@@ -4537,6 +4547,21 @@ CON_FUNC_RETURN tls_construct_new_session_ticket(SSL_CONNECTION *s, WPACKET *pkt
             goto err;
         }
         hashlen = (size_t)hashleni;
+
+        /*
+         * Establish the bound for the new ticket's lifetime before the
+         * session is (possibly) duplicated below: the duplicate does not
+         * retain |psk_external|. A ticket issued for a resumed session must
+         * not push the expiry beyond that of the session it was resumed
+         * from, so that resumption cannot be used to prolong a session
+         * indefinitely. An external PSK is not a resumption: it is a fresh
+         * authentication of an application-provided key, so it (re)starts
+         * the ticket lifetime in full.
+         */
+        if (s->hit && !s->session->psk_external)
+            expiry = ossl_time_add(s->session->time, s->session->timeout);
+        else
+            expiry = ossl_time_infinite();
 
         /*
          * If we already sent one NewSessionTicket, or we resumed then
@@ -4585,7 +4610,34 @@ CON_FUNC_RETURN tls_construct_new_session_ticket(SSL_CONNECTION *s, WPACKET *pkt
         }
         s->session->master_key_length = hashlen;
 
+        /*
+         * Each ticket carries its own lifetime, restarted at issuance time
+         * but capped by the |expiry| bound established above.
+         */
         s->session->time = ossl_time_now();
+        if (!ossl_time_is_infinite(expiry)) {
+            OSSL_TIME remaining = ossl_time_subtract(expiry, s->session->time);
+            uint64_t secs;
+
+            /*
+             * The ticket only encodes whole seconds, so round the remainder
+             * up: rounding down would issue a ticket that expires before its
+             * advertised lifetime, and a session serialised with a zero
+             * timeout would be re-created with a small default timeout
+             * instead, outliving the intended bound. A remainder that is (or
+             * rounds up to) zero still becomes a one second ticket: the
+             * session was still valid when this handshake was accepted.
+             */
+            secs = ossl_time2seconds(ossl_time_add(remaining,
+                ossl_ticks2time(OSSL_TIME_SECOND - 1)));
+            if (secs == 0)
+                secs = 1;
+            if (secs < ossl_time2seconds(ossl_time_infinite())
+                && ossl_time_compare(ossl_seconds2time(secs),
+                       s->session->timeout)
+                    < 0)
+                s->session->timeout = ossl_seconds2time(secs);
+        }
         ssl_session_calculate_timeout(s->session);
         if (s->s3.alpn_selected != NULL) {
             OPENSSL_free(s->session->ext.alpn_selected);

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -4523,6 +4523,7 @@ CON_FUNC_RETURN tls_construct_new_session_ticket(SSL_CONNECTION *s, WPACKET *pkt
     if (SSL_CONNECTION_IS_TLS13(s)) {
         size_t i, hashlen;
         uint64_t nonce;
+        OSSL_TIME expiry;
         /* ASCII: "resumption", in hex for EBCDIC compatibility */
         static const unsigned char nonce_label[] = { 0x72, 0x65, 0x73, 0x75, 0x6D,
             0x70, 0x74, 0x69, 0x6F, 0x6E };
@@ -4583,7 +4584,20 @@ CON_FUNC_RETURN tls_construct_new_session_ticket(SSL_CONNECTION *s, WPACKET *pkt
         }
         s->session->master_key_length = hashlen;
 
+        /*
+         * Each ticket carries its own lifetime, restarted at issuance time.
+         * If this ticket is issued for a resumed session, cap the new
+         * lifetime by the remaining lifetime of the session we resumed from,
+         * so that resumption cannot be used to prolong a session.
+         */
+        expiry = ossl_time_add(s->session->time, s->session->timeout);
         s->session->time = ossl_time_now();
+        if (s->hit && !ossl_time_is_infinite(expiry)) {
+            OSSL_TIME remaining = ossl_time_subtract(expiry, s->session->time);
+
+            if (ossl_time_compare(remaining, s->session->timeout) < 0)
+                s->session->timeout = remaining;
+        }
         ssl_session_calculate_timeout(s->session);
         if (s->s3.alpn_selected != NULL) {
             OPENSSL_free(s->session->ext.alpn_selected);

--- a/test/tls13tickettest.c
+++ b/test/tls13tickettest.c
@@ -283,6 +283,21 @@ static int ticket_disable(SSL_CTX *ctx)
 }
 
 /*
+ * TLSv1.3 stateful tickets for a server: the NewSessionTicket then only
+ * carries a session id resolved through the server's internal session cache,
+ * so the server-side session object (and thus its time and timeout) is
+ * directly reachable for a test via SSL_get1_session() on the server SSL.
+ * This lets lifetime tests age a session deterministically with
+ * SSL_SESSION_set_time_ex() instead of sleeping through real time.
+ */
+static int ticket_enable_stateful(SSL_CTX *ctx)
+{
+    SSL_CTX_set_options(ctx, SSL_OP_NO_TICKET);
+    SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_SERVER);
+    return 1;
+}
+
+/*
  * A fixed, 0-RTT-capable external PSK (RFC 9846), offered via the
  * psk_use_session (client) and psk_find_session (server) callbacks. Used to
  * exercise 0-RTT keyed off an external PSK while a retired resumption ticket is
@@ -1297,6 +1312,486 @@ static int test_tls13_external_psk_sid_ctx_not_shared(void)
     return test;
 }
 
+/* Encode a session with i2d_SSL_SESSION and decode it again */
+static SSL_SESSION *session_roundtrip(SSL_SESSION *in)
+{
+    unsigned char *der = NULL, *p;
+    const unsigned char *q;
+    SSL_SESSION *out = NULL;
+    int len = i2d_SSL_SESSION(in, NULL);
+
+    if (len <= 0 || (der = OPENSSL_malloc(len)) == NULL)
+        return NULL;
+    p = der;
+    if (i2d_SSL_SESSION(in, &p) == len) {
+        q = der;
+        out = d2i_SSL_SESSION(NULL, &q, len);
+    }
+    OPENSSL_free(der);
+    return out;
+}
+
+/*
+ * Verify that a ticket issued for a resumed TLSv1.3 session does not extend
+ * the session lifetime beyond the bound established by the initial full
+ * handshake. The NewSessionTicket lifetime hint mirrors the (possibly capped)
+ * session timeout computed by the server, so it is used to observe the cap:
+ * the initial handshake advertises the full configured timeout, a resumed
+ * handshake advertises at most the remaining lifetime, and once the original
+ * lifetime has elapsed the client no longer offers the ticket, forcing a full
+ * handshake that restarts the lifetime in full.
+ *
+ * Stateful tickets are used so that the passing of time can be simulated by
+ * backdating the server's cached session instead of sleeping through real
+ * lifetime; the cap itself is shared with the stateless ticket path.
+ */
+#define BOUND_TIMEOUT 5 /* seconds */
+#define BOUND_ELAPSED 3 /* how far the server-side session is backdated */
+#define DEFAULT_TIMEOUT (2 * 60 * 60) /* tls1_default_timeout() */
+
+static int test_tls13_ticket_lifetime_bound(void)
+{
+    SSL_CTX *c = NULL, *s = NULL;
+    struct tls13_channel initial = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel resumed = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel expired = { .c.ssl = NULL, .s.ssl = NULL };
+    SSL_SESSION *sess = NULL, *sess2 = NULL, *sess3 = NULL, *srvsess = NULL;
+    unsigned long hint;
+    int test;
+
+    test = TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(),
+               TLS1_3_VERSION, TLS1_3_VERSION, &s, &c, cert, pkey))
+        && TEST_true(set_ctx_callbacks(c, s))
+        && TEST_true(ticket_enable_stateful(s))
+        && TEST_true(ticket_enable(c))
+        && TEST_long_eq(SSL_CTX_set_timeout(s, BOUND_TIMEOUT), DEFAULT_TIMEOUT)
+        && TEST_long_eq(SSL_CTX_get_timeout(s), BOUND_TIMEOUT)
+        && TEST_true(tls_channel_init(c, s, &initial))
+        && TEST_true(create_ssl_connection(initial.s.ssl, initial.c.ssl, SSL_ERROR_NONE))
+        && TEST_true(tls_shutdown(&initial))
+        && TEST_ptr(sess = SSL_get1_session(initial.c.ssl))
+        && TEST_ulong_eq(SSL_SESSION_get_ticket_lifetime_hint(sess), BOUND_TIMEOUT)
+        /* Consume a noticeable part of the server-side session lifetime */
+        && TEST_ptr(srvsess = SSL_get1_session(initial.s.ssl))
+        && TEST_time_t_gt(SSL_SESSION_set_time_ex(srvsess,
+                time(NULL) - BOUND_ELAPSED), 0);
+
+    if (test) {
+        test = TEST_true(tls_channel_init(c, s, &resumed))
+            && TEST_true(SSL_set_session(resumed.c.ssl, sess))
+            && TEST_true(create_ssl_connection(resumed.s.ssl, resumed.c.ssl, SSL_ERROR_NONE))
+            && TEST_true(SSL_session_reused(resumed.c.ssl))
+            && TEST_uint_eq(resumed.s.stats.ch_has_psk, 1)
+            && TEST_true(tls_shutdown(&resumed))
+            && TEST_ptr(sess2 = SSL_get1_session(resumed.c.ssl));
+    }
+
+    if (test) {
+        /*
+         * The new ticket only carries what was left of the lifetime,
+         * plus/minus one second for the whole-second granularity of both
+         * the backdating above and the encoded lifetime.
+         */
+        hint = SSL_SESSION_get_ticket_lifetime_hint(sess2);
+        test = TEST_ulong_ge(hint, BOUND_TIMEOUT - BOUND_ELAPSED - 1)
+            && TEST_ulong_le(hint, BOUND_TIMEOUT - BOUND_ELAPSED);
+    }
+
+    if (test) {
+        /* Let the capped lifetime elapse completely, client side */
+        test = TEST_time_t_gt(SSL_SESSION_set_time_ex(sess2,
+                    time(NULL) - BOUND_TIMEOUT), 0)
+            && TEST_true(tls_channel_init(c, s, &expired))
+            && TEST_true(SSL_set_session(expired.c.ssl, sess2))
+            && TEST_true(create_ssl_connection(expired.s.ssl, expired.c.ssl, SSL_ERROR_NONE))
+            /* The ticket has expired: no PSK offered, full handshake */
+            && TEST_false(SSL_session_reused(expired.c.ssl))
+            && TEST_uint_eq(expired.s.stats.ch_has_psk, 0)
+            && TEST_true(tls_shutdown(&expired))
+            && TEST_ptr(sess3 = SSL_get1_session(expired.c.ssl))
+            /* The full handshake re-establishes the lifetime in full */
+            && TEST_ulong_eq(SSL_SESSION_get_ticket_lifetime_hint(sess3),
+                BOUND_TIMEOUT);
+    }
+
+    SSL_SESSION_free(sess);
+    SSL_SESSION_free(sess2);
+    SSL_SESSION_free(sess3);
+    SSL_SESSION_free(srvsess);
+    tls_channel_fini(&initial);
+    tls_channel_fini(&resumed);
+    tls_channel_fini(&expired);
+    SSL_CTX_free(c);
+    SSL_CTX_free(s);
+    return test;
+}
+
+/*
+ * An unlimited session timeout, selected with a negative value, is advertised
+ * in the ticket lifetime hint as the RFC8446 1 week maximum and, unlike a
+ * finite timeout, is restarted in full on each resumption rather than being
+ * capped by the remaining lifetime.
+ */
+#define ONE_WEEK_SECS (7 * 24 * 60 * 60)
+
+static int test_tls13_ticket_lifetime_unlimited(void)
+{
+    SSL_CTX *c = NULL, *s = NULL;
+    struct tls13_channel initial = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel resumed = { .c.ssl = NULL, .s.ssl = NULL };
+    SSL_SESSION *sess = NULL, *sess2 = NULL, *srvsess = NULL;
+    int test;
+
+    test = TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(),
+               TLS1_3_VERSION, TLS1_3_VERSION, &s, &c, cert, pkey))
+        && TEST_true(set_ctx_callbacks(c, s))
+        && TEST_true(ticket_enable_stateful(s))
+        && TEST_true(ticket_enable(c))
+        && TEST_long_eq(SSL_CTX_set_timeout(s, -1), DEFAULT_TIMEOUT)
+        && TEST_long_eq(SSL_CTX_get_timeout(s), -1)
+        /* The setter reports a previously unlimited timeout as -1 */
+        && TEST_long_eq(SSL_CTX_set_timeout(s, 300), -1)
+        && TEST_long_eq(SSL_CTX_set_timeout(s, -1), 300)
+        && TEST_true(tls_channel_init(c, s, &initial))
+        && TEST_true(create_ssl_connection(initial.s.ssl, initial.c.ssl, SSL_ERROR_NONE))
+        && TEST_true(tls_shutdown(&initial))
+        && TEST_ptr(sess = SSL_get1_session(initial.c.ssl))
+        && TEST_ulong_eq(SSL_SESSION_get_ticket_lifetime_hint(sess), ONE_WEEK_SECS)
+        /*
+         * Age the server-side session so that a finite timeout would be
+         * capped to the remaining lifetime and thus advertise less than the
+         * full week.
+         */
+        && TEST_ptr(srvsess = SSL_get1_session(initial.s.ssl))
+        && TEST_time_t_gt(SSL_SESSION_set_time_ex(srvsess, time(NULL) - 2), 0);
+
+    if (test) {
+        test = TEST_true(tls_channel_init(c, s, &resumed))
+            && TEST_true(SSL_set_session(resumed.c.ssl, sess))
+            && TEST_true(create_ssl_connection(resumed.s.ssl, resumed.c.ssl, SSL_ERROR_NONE))
+            && TEST_true(SSL_session_reused(resumed.c.ssl))
+            && TEST_true(tls_shutdown(&resumed))
+            && TEST_ptr(sess2 = SSL_get1_session(resumed.c.ssl))
+            /* Unlimited lifetime is restarted in full, not capped */
+            && TEST_ulong_eq(SSL_SESSION_get_ticket_lifetime_hint(sess2),
+                ONE_WEEK_SECS);
+    }
+
+    SSL_SESSION_free(sess);
+    SSL_SESSION_free(sess2);
+    SSL_SESSION_free(srvsess);
+    tls_channel_fini(&initial);
+    tls_channel_fini(&resumed);
+    SSL_CTX_free(c);
+    SSL_CTX_free(s);
+    return test;
+}
+
+/*
+ * An unlimited session timeout survives i2d_SSL_SESSION/d2i_SSL_SESSION,
+ * which is the same encoding used inside stateless session tickets, so a
+ * session re-created from such a ticket retains its unlimited timeout.
+ */
+static int test_tls13_ticket_timeout_encoding(void)
+{
+    SSL_CTX *c = NULL, *s = NULL;
+    struct tls13_channel initial = { .c.ssl = NULL, .s.ssl = NULL };
+    SSL_SESSION *sess = NULL, *rt1 = NULL, *rt2 = NULL, *rt3 = NULL;
+    int test;
+
+    test = TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(),
+               TLS1_3_VERSION, TLS1_3_VERSION, &s, &c, cert, pkey))
+        && TEST_true(set_ctx_callbacks(c, s))
+        && TEST_true(ticket_enable(s))
+        && TEST_true(ticket_enable(c))
+        && TEST_true(tls_channel_init(c, s, &initial))
+        && TEST_true(create_ssl_connection(initial.s.ssl, initial.c.ssl, SSL_ERROR_NONE))
+        && TEST_true(tls_shutdown(&initial))
+        && TEST_ptr(sess = SSL_get1_session(initial.c.ssl))
+        && TEST_long_eq(SSL_SESSION_set_timeout(sess, -1), 1)
+        && TEST_long_eq(SSL_SESSION_get_timeout(sess), -1)
+        && TEST_ptr(rt1 = session_roundtrip(sess))
+        && TEST_long_eq(SSL_SESSION_get_timeout(rt1), -1)
+        && TEST_long_eq(SSL_SESSION_set_timeout(sess, 12345), 1)
+        && TEST_ptr(rt2 = session_roundtrip(sess))
+        && TEST_long_eq(SSL_SESSION_get_timeout(rt2), 12345);
+
+    if (test && sizeof(long) > 4) {
+        /*
+         * A finite value too large to represent as an OSSL_TIME saturates
+         * to unlimited on the way in, matching the treatment of oversized
+         * encoded timeouts in d2i_SSL_SESSION_ex(), rather than silently
+         * wrapping to a near-zero timeout.
+         */
+        long big = (long)(((uint64_t)1) << 62);
+
+        test = TEST_long_eq(SSL_SESSION_set_timeout(sess, big), 1)
+            && TEST_long_eq(SSL_SESSION_get_timeout(sess), -1)
+            && TEST_ptr(rt3 = session_roundtrip(sess))
+            && TEST_long_eq(SSL_SESSION_get_timeout(rt3), -1);
+    }
+
+    SSL_SESSION_free(sess);
+    SSL_SESSION_free(rt1);
+    SSL_SESSION_free(rt2);
+    SSL_SESSION_free(rt3);
+    tls_channel_fini(&initial);
+    SSL_CTX_free(c);
+    SSL_CTX_free(s);
+    return test;
+}
+
+/*
+ * The server must not resume an expired session even if the client offers the
+ * ticket. The ticket lifetime communicated in NewSessionTicket is only a
+ * hint: a non-conforming client can ignore it and keep offering the ticket,
+ * so the lifetime bound established by the initial full handshake has to be
+ * enforced server side from the state embedded in the ticket itself. The
+ * enforcement lives in ssl_get_prev_session(), which rejects a timed out
+ * session for TLSv1.3 tickets as well.
+ *
+ * Simulate such a client by backdating the client's session past the
+ * lifetime and overwriting the lifetime hint stored in it with a large
+ * value, so that the client offers a PSK whose server-side lifetime (aged
+ * by backdating the server's cached session) has already expired.
+ */
+#define EXPIRE_TIMEOUT 1 /* seconds */
+
+static int test_tls13_ticket_expired_no_resume(void)
+{
+    SSL_CTX *c = NULL, *s = NULL;
+    struct tls13_channel initial = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel expired = { .c.ssl = NULL, .s.ssl = NULL };
+    SSL_SESSION *sess = NULL, *sess2 = NULL, *srvsess = NULL;
+    int test;
+
+    test = TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(),
+               TLS1_3_VERSION, TLS1_3_VERSION, &s, &c, cert, pkey))
+        && TEST_true(set_ctx_callbacks(c, s))
+        && TEST_true(ticket_enable_stateful(s))
+        && TEST_true(ticket_enable(c))
+        && TEST_long_eq(SSL_CTX_set_timeout(s, EXPIRE_TIMEOUT), DEFAULT_TIMEOUT)
+        && TEST_true(tls_channel_init(c, s, &initial))
+        && TEST_true(create_ssl_connection(initial.s.ssl, initial.c.ssl, SSL_ERROR_NONE))
+        && TEST_true(tls_shutdown(&initial))
+        && TEST_ptr(sess = SSL_get1_session(initial.c.ssl))
+        && TEST_ulong_eq(SSL_SESSION_get_ticket_lifetime_hint(sess), EXPIRE_TIMEOUT)
+        /* Let the session lifetime expire, with ample margin */
+        && TEST_ptr(srvsess = SSL_get1_session(initial.s.ssl))
+        && TEST_time_t_gt(SSL_SESSION_set_time_ex(srvsess,
+                time(NULL) - (EXPIRE_TIMEOUT + 2)), 0)
+        && TEST_time_t_gt(SSL_SESSION_set_time_ex(sess,
+                time(NULL) - (EXPIRE_TIMEOUT + 2)), 0);
+
+    if (test) {
+        /* Pretend the client did not honour the ticket lifetime hint */
+        sess->ext.tick_lifetime_hint = ONE_WEEK_SECS;
+
+        test = TEST_true(tls_channel_init(c, s, &expired))
+            && TEST_true(SSL_set_session(expired.c.ssl, sess))
+            && TEST_true(create_ssl_connection(expired.s.ssl, expired.c.ssl, SSL_ERROR_NONE))
+            /* The client offered the expired ticket ... */
+            && TEST_uint_eq(expired.s.stats.ch_has_psk, 1)
+            /* ... but the server must refuse it and do a full handshake */
+            && TEST_false(SSL_session_reused(expired.c.ssl))
+            && TEST_uint_eq(expired.s.stats.sh_has_psk, 0)
+            && TEST_true(tls_shutdown(&expired))
+            /* The fallback full handshake issues fresh full-lifetime tickets */
+            && TEST_uint_eq(expired.s.stats.nst_msgs, 2)
+            && TEST_ptr(sess2 = SSL_get1_session(expired.c.ssl))
+            && TEST_ulong_eq(SSL_SESSION_get_ticket_lifetime_hint(sess2),
+                EXPIRE_TIMEOUT);
+    }
+
+    SSL_SESSION_free(sess);
+    SSL_SESSION_free(sess2);
+    SSL_SESSION_free(srvsess);
+    tls_channel_fini(&initial);
+    tls_channel_fini(&expired);
+    SSL_CTX_free(c);
+    SSL_CTX_free(s);
+    return test;
+}
+
+/*
+ * Coverage for the SessionTimeout (-session_timeout) configuration command:
+ * plain seconds, "infinite" (case-insensitive) and negative values are
+ * accepted, malformed values are rejected, and the command is only available
+ * to servers.
+ */
+static int test_tls13_ticket_session_timeout_conf(void)
+{
+    SSL_CTX *s = NULL;
+    SSL_CONF_CTX *cctx = NULL;
+    int test;
+
+    test = TEST_ptr(s = SSL_CTX_new(TLS_server_method()))
+        && TEST_ptr(cctx = SSL_CONF_CTX_new());
+
+    if (test) {
+        SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_FILE | SSL_CONF_FLAG_SERVER);
+        SSL_CONF_CTX_set_ssl_ctx(cctx, s);
+
+        test = TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout", "1234"), 2)
+            && TEST_long_eq(SSL_CTX_get_timeout(s), 1234)
+            && TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout", "Infinite"), 2)
+            && TEST_long_eq(SSL_CTX_get_timeout(s), -1)
+            && TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout", "-30"), 2)
+            && TEST_long_eq(SSL_CTX_get_timeout(s), -1)
+            /* A previous timeout of 0 must not read as a command failure */
+            && TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout", "0"), 2)
+            && TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout", "300"), 2)
+            && TEST_long_eq(SSL_CTX_get_timeout(s), 300)
+            /* Values that overflow the parser are rejected, not wrapped */
+            && TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout",
+                    "99999999999999999999"), 0)
+            && TEST_long_eq(SSL_CTX_get_timeout(s), 300)
+            && TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout", "12abc"), 0)
+            && TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout", ""), 0);
+
+        if (test && sizeof(long) > 4) {
+            /*
+             * Parseable values too large to represent as an OSSL_TIME (here
+             * 2^62 seconds) saturate to an unlimited timeout instead of
+             * wrapping to a near-zero one.
+             */
+            test = TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout",
+                        "4611686018427387904"), 2)
+                && TEST_long_eq(SSL_CTX_get_timeout(s), -1);
+        }
+
+        test = test && TEST_true(SSL_CONF_CTX_finish(cctx));
+    }
+
+    if (test) {
+        /* The command must not be recognised in a client-only context */
+        test = TEST_uint_eq(SSL_CONF_CTX_clear_flags(cctx, SSL_CONF_FLAG_SERVER)
+                & SSL_CONF_FLAG_SERVER,
+            0);
+        SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_CLIENT);
+        test = test
+            && TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout", "10"), -2);
+    }
+
+    SSL_CONF_CTX_free(cctx);
+    SSL_CTX_free(s);
+    return test;
+}
+
+/*
+ * The resumed-session lifetime cap keys off the server having accepted a
+ * PSK, but a handshake authenticated by an external PSK is a fresh
+ * authentication, not a resumption: the lifetime of tickets issued for it
+ * must not be capped by the age of the application-provided PSK session.
+ * The server-side find callback hands back a session created a while ago
+ * (backdated), whose remaining lifetime is well below its timeout; the
+ * issued ticket must still carry the full timeout.
+ */
+#define EXT_PSK_TIMEOUT 300 /* seconds */
+#define EXT_PSK_AGE 100 /* seconds */
+
+static int ext_psk_find_aged_cb(SSL *ssl, const unsigned char *id, size_t idlen,
+    SSL_SESSION **sess)
+{
+    if (!ext_psk_find_cb(ssl, id, idlen, sess))
+        return 0;
+    if (*sess != NULL
+        && (SSL_SESSION_set_timeout(*sess, EXT_PSK_TIMEOUT) != 1
+            || SSL_SESSION_set_time_ex(*sess, time(NULL) - EXT_PSK_AGE) == 0)) {
+        SSL_SESSION_free(*sess);
+        *sess = NULL;
+        return 0;
+    }
+    return 1;
+}
+
+static int test_tls13_external_psk_lifetime_uncapped(void)
+{
+    SSL_CTX *c = NULL, *s = NULL;
+    struct tls13_channel psk = { .c.ssl = NULL, .s.ssl = NULL };
+    SSL_SESSION *sess = NULL;
+    int test;
+
+    test = TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(),
+               TLS1_3_VERSION, TLS1_3_VERSION, &s, &c, cert, pkey))
+        && TEST_true(set_ctx_callbacks(c, s))
+        && TEST_true(ticket_enable(s))
+        && TEST_true(ticket_enable(c))
+        /* Pin the ciphersuite to the external PSK's committed cipher */
+        && TEST_true(SSL_CTX_set_ciphersuites(s, "TLS_AES_128_GCM_SHA256"))
+        && TEST_true(SSL_CTX_set_ciphersuites(c, "TLS_AES_128_GCM_SHA256"))
+        && TEST_true(tls_channel_init(c, s, &psk));
+
+    if (test) {
+        SSL_set_psk_use_session_callback(psk.c.ssl, ext_psk_use_cb);
+        SSL_set_psk_find_session_callback(psk.s.ssl, ext_psk_find_aged_cb);
+
+        test = TEST_true(create_ssl_connection(psk.s.ssl, psk.c.ssl, SSL_ERROR_NONE))
+            && TEST_true(SSL_session_reused(psk.c.ssl))
+            && TEST_uint_eq(psk.s.stats.ch_has_psk, 1)
+            && TEST_uint_eq(psk.s.stats.sh_has_psk, 1)
+            && TEST_true(tls_shutdown(&psk))
+            && TEST_ptr(sess = SSL_get1_session(psk.c.ssl))
+            /* The full timeout, not EXT_PSK_TIMEOUT - EXT_PSK_AGE */
+            && TEST_ulong_eq(SSL_SESSION_get_ticket_lifetime_hint(sess),
+                EXT_PSK_TIMEOUT);
+    }
+
+    SSL_SESSION_free(sess);
+    tls_channel_fini(&psk);
+    SSL_CTX_free(c);
+    SSL_CTX_free(s);
+    return test;
+}
+
+/*
+ * TLSv1.2 ticket lifetime hint (RFC 5077): an initial handshake advertises
+ * the configured timeout; an unlimited timeout has no finite representation
+ * in the 32 bit field, so it is sent as 0 ("unspecified"), not as a
+ * truncation artefact.
+ */
+#define TLS12_TIMEOUT 7777 /* seconds */
+
+static int test_tls12_ticket_lifetime_hint(void)
+{
+    SSL_CTX *c = NULL, *s = NULL;
+    struct tls13_channel finite = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel unlimited = { .c.ssl = NULL, .s.ssl = NULL };
+    SSL_SESSION *sess = NULL, *sess2 = NULL;
+    int test;
+
+    test = TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(),
+               TLS1_2_VERSION, TLS1_2_VERSION, &s, &c, cert, pkey))
+        && TEST_true(set_ctx_callbacks(c, s))
+        && TEST_true(ticket_enable(s))
+        && TEST_true(ticket_enable(c))
+        && TEST_long_eq(SSL_CTX_set_timeout(s, TLS12_TIMEOUT), DEFAULT_TIMEOUT)
+        && TEST_true(tls_channel_init(c, s, &finite))
+        && TEST_true(create_ssl_connection(finite.s.ssl, finite.c.ssl, SSL_ERROR_NONE))
+        && TEST_true(tls_shutdown(&finite))
+        && TEST_ptr(sess = SSL_get1_session(finite.c.ssl))
+        && TEST_ulong_eq(SSL_SESSION_get_ticket_lifetime_hint(sess),
+            TLS12_TIMEOUT);
+
+    if (test) {
+        test = TEST_long_eq(SSL_CTX_set_timeout(s, -1), TLS12_TIMEOUT)
+            && TEST_true(tls_channel_init(c, s, &unlimited))
+            && TEST_true(create_ssl_connection(unlimited.s.ssl, unlimited.c.ssl,
+                SSL_ERROR_NONE))
+            && TEST_true(tls_shutdown(&unlimited))
+            && TEST_ptr(sess2 = SSL_get1_session(unlimited.c.ssl))
+            && TEST_ulong_eq(SSL_SESSION_get_ticket_lifetime_hint(sess2), 0);
+    }
+
+    SSL_SESSION_free(sess);
+    SSL_SESSION_free(sess2);
+    tls_channel_fini(&finite);
+    tls_channel_fini(&unlimited);
+    SSL_CTX_free(c);
+    SSL_CTX_free(s);
+    return test;
+}
+
 int setup_tests(void)
 {
     if (!test_skip_common_options()) {
@@ -1323,6 +1818,13 @@ int setup_tests(void)
     ADD_TEST(test_tls13_ticket_server_age_mismatch_reject_early_data);
     ADD_TEST(test_tls13_aged_ticket_external_psk_early_data);
     ADD_TEST(test_tls13_external_psk_sid_ctx_not_shared);
+    ADD_TEST(test_tls13_ticket_lifetime_bound);
+    ADD_TEST(test_tls13_ticket_lifetime_unlimited);
+    ADD_TEST(test_tls13_ticket_timeout_encoding);
+    ADD_TEST(test_tls13_ticket_expired_no_resume);
+    ADD_TEST(test_tls13_ticket_session_timeout_conf);
+    ADD_TEST(test_tls13_external_psk_lifetime_uncapped);
+    ADD_TEST(test_tls12_ticket_lifetime_hint);
 
     return 1;
 }

--- a/test/tls13tickettest.c
+++ b/test/tls13tickettest.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <openssl/crypto.h>
 #include <openssl/ssl.h>
 #include <openssl/ssl3.h>
 #include <openssl/tls1.h>
@@ -652,6 +653,316 @@ static int test_tls13_ticket_no_decrypt(void)
     return test;
 }
 
+/* Encode a session with i2d_SSL_SESSION and decode it again */
+static SSL_SESSION *session_roundtrip(SSL_SESSION *in)
+{
+    unsigned char *der = NULL, *p;
+    const unsigned char *q;
+    SSL_SESSION *out = NULL;
+    int len = i2d_SSL_SESSION(in, NULL);
+
+    if (len <= 0 || (der = OPENSSL_malloc(len)) == NULL)
+        return NULL;
+    p = der;
+    if (i2d_SSL_SESSION(in, &p) == len) {
+        q = der;
+        out = d2i_SSL_SESSION(NULL, &q, len);
+    }
+    OPENSSL_free(der);
+    return out;
+}
+
+/*
+ * Verify that a ticket issued for a resumed TLSv1.3 session does not extend
+ * the session lifetime beyond the bound established by the initial full
+ * handshake. The NewSessionTicket lifetime hint mirrors the (possibly capped)
+ * session timeout computed by the server, so it is used to observe the cap:
+ * the initial handshake advertises the full configured timeout, a resumed
+ * handshake advertises at most the remaining lifetime, and once the original
+ * lifetime has elapsed the client no longer offers the ticket, forcing a full
+ * handshake that restarts the lifetime in full.
+ */
+#define BOUND_TIMEOUT 5 /* seconds */
+#define DEFAULT_TIMEOUT (2 * 60 * 60) /* tls1_default_timeout() */
+
+static int test_tls13_ticket_lifetime_bound(void)
+{
+    SSL_CTX *c = NULL, *s = NULL;
+    struct tls13_channel initial = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel resumed = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel expired = { .c.ssl = NULL, .s.ssl = NULL };
+    SSL_SESSION *sess = NULL, *sess2 = NULL, *sess3 = NULL;
+    int test;
+
+    test = TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(),
+               TLS1_3_VERSION, TLS1_3_VERSION, &s, &c, cert, pkey))
+        && TEST_true(set_ctx_callbacks(c, s))
+        && TEST_true(ticket_enable(s))
+        && TEST_true(ticket_enable(c))
+        && TEST_long_eq(SSL_CTX_set_timeout(s, BOUND_TIMEOUT), DEFAULT_TIMEOUT)
+        && TEST_long_eq(SSL_CTX_get_timeout(s), BOUND_TIMEOUT)
+        && TEST_true(tls_channel_init(c, s, &initial))
+        && TEST_true(create_ssl_connection(initial.s.ssl, initial.c.ssl, SSL_ERROR_NONE))
+        && TEST_true(tls_shutdown(&initial))
+        && TEST_ptr(sess = SSL_get1_session(initial.c.ssl))
+        && TEST_ulong_eq(SSL_SESSION_get_ticket_lifetime_hint(sess), BOUND_TIMEOUT);
+
+    if (test) {
+        /* Consume a noticeable part of the session lifetime */
+        OSSL_sleep(3000);
+
+        test = TEST_true(tls_channel_init(c, s, &resumed))
+            && TEST_true(SSL_set_session(resumed.c.ssl, sess))
+            && TEST_true(create_ssl_connection(resumed.s.ssl, resumed.c.ssl, SSL_ERROR_NONE))
+            && TEST_true(SSL_session_reused(resumed.c.ssl))
+            && TEST_uint_eq(resumed.s.stats.ch_has_psk, 1)
+            && TEST_true(tls_shutdown(&resumed))
+            && TEST_ptr(sess2 = SSL_get1_session(resumed.c.ssl))
+            /* The new ticket only carries what was left of the lifetime */
+            && TEST_ulong_le(SSL_SESSION_get_ticket_lifetime_hint(sess2),
+                BOUND_TIMEOUT - 3);
+    }
+
+    if (test) {
+        /* Let the originally established lifetime elapse completely */
+        OSSL_sleep(4000);
+
+        test = TEST_true(tls_channel_init(c, s, &expired))
+            && TEST_true(SSL_set_session(expired.c.ssl, sess2))
+            && TEST_true(create_ssl_connection(expired.s.ssl, expired.c.ssl, SSL_ERROR_NONE))
+            /* The ticket has expired: no PSK offered, full handshake */
+            && TEST_false(SSL_session_reused(expired.c.ssl))
+            && TEST_uint_eq(expired.s.stats.ch_has_psk, 0)
+            && TEST_true(tls_shutdown(&expired))
+            && TEST_ptr(sess3 = SSL_get1_session(expired.c.ssl))
+            /* The full handshake re-establishes the lifetime in full */
+            && TEST_ulong_eq(SSL_SESSION_get_ticket_lifetime_hint(sess3),
+                BOUND_TIMEOUT);
+    }
+
+    SSL_SESSION_free(sess);
+    SSL_SESSION_free(sess2);
+    SSL_SESSION_free(sess3);
+    tls_channel_fini(&initial);
+    tls_channel_fini(&resumed);
+    tls_channel_fini(&expired);
+    SSL_CTX_free(c);
+    SSL_CTX_free(s);
+    return test;
+}
+
+/*
+ * An unlimited session timeout, selected with a negative value, is advertised
+ * in the ticket lifetime hint as the RFC8446 1 week maximum and, unlike a
+ * finite timeout, is restarted in full on each resumption rather than being
+ * capped by the remaining lifetime.
+ */
+#define ONE_WEEK_SECS (7 * 24 * 60 * 60)
+
+static int test_tls13_ticket_lifetime_unlimited(void)
+{
+    SSL_CTX *c = NULL, *s = NULL;
+    struct tls13_channel initial = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel resumed = { .c.ssl = NULL, .s.ssl = NULL };
+    SSL_SESSION *sess = NULL, *sess2 = NULL;
+    int test;
+
+    test = TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(),
+               TLS1_3_VERSION, TLS1_3_VERSION, &s, &c, cert, pkey))
+        && TEST_true(set_ctx_callbacks(c, s))
+        && TEST_true(ticket_enable(s))
+        && TEST_true(ticket_enable(c))
+        && TEST_long_eq(SSL_CTX_set_timeout(s, -1), DEFAULT_TIMEOUT)
+        && TEST_long_eq(SSL_CTX_get_timeout(s), -1)
+        /* The setter reports a previously unlimited timeout as -1 */
+        && TEST_long_eq(SSL_CTX_set_timeout(s, 300), -1)
+        && TEST_long_eq(SSL_CTX_set_timeout(s, -1), 300)
+        && TEST_true(tls_channel_init(c, s, &initial))
+        && TEST_true(create_ssl_connection(initial.s.ssl, initial.c.ssl, SSL_ERROR_NONE))
+        && TEST_true(tls_shutdown(&initial))
+        && TEST_ptr(sess = SSL_get1_session(initial.c.ssl))
+        && TEST_ulong_eq(SSL_SESSION_get_ticket_lifetime_hint(sess), ONE_WEEK_SECS);
+
+    if (test) {
+        /*
+         * Let some time pass so that a finite timeout would be capped to the
+         * remaining lifetime and thus advertise less than the full week.
+         */
+        OSSL_sleep(2000);
+
+        test = TEST_true(tls_channel_init(c, s, &resumed))
+            && TEST_true(SSL_set_session(resumed.c.ssl, sess))
+            && TEST_true(create_ssl_connection(resumed.s.ssl, resumed.c.ssl, SSL_ERROR_NONE))
+            && TEST_true(SSL_session_reused(resumed.c.ssl))
+            && TEST_true(tls_shutdown(&resumed))
+            && TEST_ptr(sess2 = SSL_get1_session(resumed.c.ssl))
+            /* Unlimited lifetime is restarted in full, not capped */
+            && TEST_ulong_eq(SSL_SESSION_get_ticket_lifetime_hint(sess2),
+                ONE_WEEK_SECS);
+    }
+
+    SSL_SESSION_free(sess);
+    SSL_SESSION_free(sess2);
+    tls_channel_fini(&initial);
+    tls_channel_fini(&resumed);
+    SSL_CTX_free(c);
+    SSL_CTX_free(s);
+    return test;
+}
+
+/*
+ * An unlimited session timeout survives i2d_SSL_SESSION/d2i_SSL_SESSION,
+ * which is the same encoding used inside stateless session tickets, so a
+ * session re-created from such a ticket retains its unlimited timeout.
+ */
+static int test_tls13_ticket_timeout_encoding(void)
+{
+    SSL_CTX *c = NULL, *s = NULL;
+    struct tls13_channel initial = { .c.ssl = NULL, .s.ssl = NULL };
+    SSL_SESSION *sess = NULL, *rt1 = NULL, *rt2 = NULL;
+    int test;
+
+    test = TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(),
+               TLS1_3_VERSION, TLS1_3_VERSION, &s, &c, cert, pkey))
+        && TEST_true(set_ctx_callbacks(c, s))
+        && TEST_true(ticket_enable(s))
+        && TEST_true(ticket_enable(c))
+        && TEST_true(tls_channel_init(c, s, &initial))
+        && TEST_true(create_ssl_connection(initial.s.ssl, initial.c.ssl, SSL_ERROR_NONE))
+        && TEST_true(tls_shutdown(&initial))
+        && TEST_ptr(sess = SSL_get1_session(initial.c.ssl))
+        && TEST_long_eq(SSL_SESSION_set_timeout(sess, -1), 1)
+        && TEST_long_eq(SSL_SESSION_get_timeout(sess), -1)
+        && TEST_ptr(rt1 = session_roundtrip(sess))
+        && TEST_long_eq(SSL_SESSION_get_timeout(rt1), -1)
+        && TEST_long_eq(SSL_SESSION_set_timeout(sess, 12345), 1)
+        && TEST_ptr(rt2 = session_roundtrip(sess))
+        && TEST_long_eq(SSL_SESSION_get_timeout(rt2), 12345);
+
+    SSL_SESSION_free(sess);
+    SSL_SESSION_free(rt1);
+    SSL_SESSION_free(rt2);
+    tls_channel_fini(&initial);
+    SSL_CTX_free(c);
+    SSL_CTX_free(s);
+    return test;
+}
+
+/*
+ * The server must not resume an expired session even if the client offers the
+ * ticket. The ticket lifetime communicated in NewSessionTicket is only a
+ * hint: a non-conforming client can ignore it and keep offering the ticket,
+ * so the lifetime bound established by the initial full handshake has to be
+ * enforced server side from the state embedded in the ticket itself. The
+ * enforcement lives in ssl_get_prev_session(), which rejects a timed out
+ * session for TLSv1.3 tickets as well.
+ *
+ * Simulate such a client by overwriting the lifetime hint stored in the
+ * client's session with a large value, so that the client offers a PSK whose
+ * server-side lifetime has already expired.
+ */
+#define EXPIRE_TIMEOUT 1 /* seconds */
+
+static int test_tls13_ticket_expired_no_resume(void)
+{
+    SSL_CTX *c = NULL, *s = NULL;
+    struct tls13_channel initial = { .c.ssl = NULL, .s.ssl = NULL };
+    struct tls13_channel expired = { .c.ssl = NULL, .s.ssl = NULL };
+    SSL_SESSION *sess = NULL, *sess2 = NULL;
+    int test;
+
+    test = TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(),
+               TLS1_3_VERSION, TLS1_3_VERSION, &s, &c, cert, pkey))
+        && TEST_true(set_ctx_callbacks(c, s))
+        && TEST_true(ticket_enable(s))
+        && TEST_true(ticket_enable(c))
+        && TEST_long_eq(SSL_CTX_set_timeout(s, EXPIRE_TIMEOUT), DEFAULT_TIMEOUT)
+        && TEST_true(tls_channel_init(c, s, &initial))
+        && TEST_true(create_ssl_connection(initial.s.ssl, initial.c.ssl, SSL_ERROR_NONE))
+        && TEST_true(tls_shutdown(&initial))
+        && TEST_ptr(sess = SSL_get1_session(initial.c.ssl))
+        && TEST_ulong_eq(SSL_SESSION_get_ticket_lifetime_hint(sess), EXPIRE_TIMEOUT);
+
+    if (test) {
+        /*
+         * Let the session lifetime expire, with ample margin for the second
+         * granularity of the serialised session time inside the ticket.
+         */
+        OSSL_sleep(3000);
+
+        /* Pretend the client did not honour the ticket lifetime hint */
+        sess->ext.tick_lifetime_hint = ONE_WEEK_SECS;
+
+        test = TEST_true(tls_channel_init(c, s, &expired))
+            && TEST_true(SSL_set_session(expired.c.ssl, sess))
+            && TEST_true(create_ssl_connection(expired.s.ssl, expired.c.ssl, SSL_ERROR_NONE))
+            /* The client offered the expired ticket ... */
+            && TEST_uint_eq(expired.s.stats.ch_has_psk, 1)
+            /* ... but the server must refuse it and do a full handshake */
+            && TEST_false(SSL_session_reused(expired.c.ssl))
+            && TEST_uint_eq(expired.s.stats.sh_has_psk, 0)
+            && TEST_true(tls_shutdown(&expired))
+            /* The fallback full handshake issues fresh full-lifetime tickets */
+            && TEST_uint_eq(expired.s.stats.nst_msgs, 2)
+            && TEST_ptr(sess2 = SSL_get1_session(expired.c.ssl))
+            && TEST_ulong_eq(SSL_SESSION_get_ticket_lifetime_hint(sess2),
+                EXPIRE_TIMEOUT);
+    }
+
+    SSL_SESSION_free(sess);
+    SSL_SESSION_free(sess2);
+    tls_channel_fini(&initial);
+    tls_channel_fini(&expired);
+    SSL_CTX_free(c);
+    SSL_CTX_free(s);
+    return test;
+}
+
+/*
+ * Coverage for the SessionTimeout (-session_timeout) configuration command:
+ * plain seconds, "infinite" (case-insensitive) and negative values are
+ * accepted, malformed values are rejected, and the command is only available
+ * to servers.
+ */
+static int test_tls13_ticket_session_timeout_conf(void)
+{
+    SSL_CTX *s = NULL;
+    SSL_CONF_CTX *cctx = NULL;
+    int test;
+
+    test = TEST_ptr(s = SSL_CTX_new(TLS_server_method()))
+        && TEST_ptr(cctx = SSL_CONF_CTX_new());
+
+    if (test) {
+        SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_FILE | SSL_CONF_FLAG_SERVER);
+        SSL_CONF_CTX_set_ssl_ctx(cctx, s);
+
+        test = TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout", "1234"), 2)
+            && TEST_long_eq(SSL_CTX_get_timeout(s), 1234)
+            && TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout", "Infinite"), 2)
+            && TEST_long_eq(SSL_CTX_get_timeout(s), -1)
+            && TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout", "-30"), 2)
+            && TEST_long_eq(SSL_CTX_get_timeout(s), -1)
+            && TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout", "12abc"), 0)
+            && TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout", ""), 0)
+            && TEST_true(SSL_CONF_CTX_finish(cctx));
+    }
+
+    if (test) {
+        /* The command must not be recognised in a client-only context */
+        test = TEST_uint_eq(SSL_CONF_CTX_clear_flags(cctx, SSL_CONF_FLAG_SERVER)
+                & SSL_CONF_FLAG_SERVER,
+            0);
+        SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_CLIENT);
+        test = test
+            && TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout", "10"), -2);
+    }
+
+    SSL_CONF_CTX_free(cctx);
+    SSL_CTX_free(s);
+    return test;
+}
+
 OPT_TEST_DECLARE_USAGE("\n")
 
 int setup_tests(void)
@@ -674,6 +985,11 @@ int setup_tests(void)
     ADD_TEST(test_tls13_ticket_resumed_set_num_tickets_zero);
     ADD_TEST(test_tls13_ticket_disable_server);
     ADD_TEST(test_tls13_ticket_no_decrypt);
+    ADD_TEST(test_tls13_ticket_lifetime_bound);
+    ADD_TEST(test_tls13_ticket_lifetime_unlimited);
+    ADD_TEST(test_tls13_ticket_timeout_encoding);
+    ADD_TEST(test_tls13_ticket_expired_no_resume);
+    ADD_TEST(test_tls13_ticket_session_timeout_conf);
 
     return 1;
 }

--- a/test/tls13tickettest.c
+++ b/test/tls13tickettest.c
@@ -1374,7 +1374,8 @@ static int test_tls13_ticket_lifetime_bound(void)
         /* Consume a noticeable part of the server-side session lifetime */
         && TEST_ptr(srvsess = SSL_get1_session(initial.s.ssl))
         && TEST_time_t_gt(SSL_SESSION_set_time_ex(srvsess,
-                time(NULL) - BOUND_ELAPSED), 0);
+                              time(NULL) - BOUND_ELAPSED),
+            0);
 
     if (test) {
         test = TEST_true(tls_channel_init(c, s, &resumed))
@@ -1400,7 +1401,8 @@ static int test_tls13_ticket_lifetime_bound(void)
     if (test) {
         /* Let the capped lifetime elapse completely, client side */
         test = TEST_time_t_gt(SSL_SESSION_set_time_ex(sess2,
-                    time(NULL) - BOUND_TIMEOUT), 0)
+                                  time(NULL) - BOUND_TIMEOUT),
+                   0)
             && TEST_true(tls_channel_init(c, s, &expired))
             && TEST_true(SSL_set_session(expired.c.ssl, sess2))
             && TEST_true(create_ssl_connection(expired.s.ssl, expired.c.ssl, SSL_ERROR_NONE))
@@ -1579,9 +1581,11 @@ static int test_tls13_ticket_expired_no_resume(void)
         /* Let the session lifetime expire, with ample margin */
         && TEST_ptr(srvsess = SSL_get1_session(initial.s.ssl))
         && TEST_time_t_gt(SSL_SESSION_set_time_ex(srvsess,
-                time(NULL) - (EXPIRE_TIMEOUT + 2)), 0)
+                              time(NULL) - (EXPIRE_TIMEOUT + 2)),
+            0)
         && TEST_time_t_gt(SSL_SESSION_set_time_ex(sess,
-                time(NULL) - (EXPIRE_TIMEOUT + 2)), 0);
+                              time(NULL) - (EXPIRE_TIMEOUT + 2)),
+            0);
 
     if (test) {
         /* Pretend the client did not honour the ticket lifetime hint */
@@ -1644,7 +1648,8 @@ static int test_tls13_ticket_session_timeout_conf(void)
             && TEST_long_eq(SSL_CTX_get_timeout(s), 300)
             /* Values that overflow the parser are rejected, not wrapped */
             && TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout",
-                    "99999999999999999999"), 0)
+                               "99999999999999999999"),
+                0)
             && TEST_long_eq(SSL_CTX_get_timeout(s), 300)
             && TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout", "12abc"), 0)
             && TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout", ""), 0);
@@ -1656,7 +1661,8 @@ static int test_tls13_ticket_session_timeout_conf(void)
              * wrapping to a near-zero one.
              */
             test = TEST_int_eq(SSL_CONF_cmd(cctx, "SessionTimeout",
-                        "4611686018427387904"), 2)
+                                   "4611686018427387904"),
+                       2)
                 && TEST_long_eq(SSL_CTX_get_timeout(s), -1);
         }
 


### PR DESCRIPTION
TLS 1.x: Bind resumed session lifetime to full handshake with app-level override

Under the prior behavior, each act of successive resumption extended a TLS session's effective lifetime, such that the session could be perpetuated indefinitely. This change anchors the lifetime of a resumed session to that of the originating session, so that resumption can no longer extend a session's validity beyond the bound established at initial authentication.

In deployments that authenticate peers via X.509 certificates, the validity of that authentication is not necessarily permanent: certificates can be revoked, trust anchors can change, and security policy can be updated after the fact. TLS resumption mechanism, by design, allows a peer to remain connected without repeating full authentication. If resumption is also allowed to extend the session lifetime indefinitely, a peer could remain connected under an identity that should no longer be trusted without ever being forced back through a full handshake that would catch that condition.

- Applications with a legitimate requirement for sessions of effectively unbounded or very long lifetime, under a different authentication topology remain free to configure this themselves. Doing so is an explicit application-level decision, and the application then takes on responsibility for the implications, e.g., ensuring its own well-defined mechanisms re-authentication, or policy enforcement are sufficient to cover the extended lifetime, since OpenSSL's session-timeout mechanism is no longer providing that bound implicitly.  An unlimited timeout applies to sessions of all protocol versions. Note that for TLSv1.2 and below, sessions kept in the internal cache then never expire and are only removed when the cache size limit is exceeded, and a session ticket remains usable for as long as the ticket key that protects it. Applications that need a version-specific timeout policy can adjust the timeout of individual sessions with L<SSL_SESSION_set_timeout(3)>, for example from the callback set via L<SSL_CTX_sess_set_new_cb(3)>.

- Applications that require the previous behaviour can explicitly configure an unlimited session lifetime by passing a negative value to SSL_CTX_set_timeout() or SSL_SESSION_set_timeout(), or by using the SessionTimeout (-session_timeout) configuration command with the value infinite.

Fixed #19341