### PR TITLE
v3_ncons: Reject embedded NUL bytes in URI name constraints

### DIFF
--- a/crypto/http/http_lib.c
+++ b/crypto/http/http_lib.c
@@ -56,8 +56,16 @@ int OSSL_parse_url(const char *url, char **pscheme, char **puser, char **phost,
     char **pport, int *pport_num,
     char **ppath, char **pquery, char **pfrag)
 {
-    const char *p, *tmp;
-    const char *authority_end;
+    return ossl_parse_url_internal(url, strlen(url), NULL, pscheme, puser, phost, pport, pport_num, ppath, pquery, pfrag);
+}
+
+int ossl_parse_url_internal(const char *url, size_t len, int *perr, char **pscheme, char **puser, char **phost,
+    char **pport, int *pport_num,
+    char **ppath, char **pquery, char **pfrag)
+{
+
+    const char *tmp = NULL;
+    const char *authority_end = NULL;
     const char *scheme, *scheme_end;
     const char *user, *user_end;
     const char *host, *host_end;
@@ -66,6 +74,9 @@ int OSSL_parse_url(const char *url, char **pscheme, char **puser, char **phost,
     const char *path, *path_end;
     const char *query, *query_end;
     const char *frag, *frag_end;
+
+    const char *current_pos = url;
+    const char *url_end = current_pos + len;
 
     init_pstring(pscheme);
     init_pstring(puser);
@@ -76,88 +87,153 @@ int OSSL_parse_url(const char *url, char **pscheme, char **puser, char **phost,
     init_pstring(pfrag);
     init_pstring(pquery);
 
+#define CHECK_URL_END(p)    \
+    do {                    \
+        if ((p) >= url_end) \
+            goto parse_err; \
+    } while (0)
+
     if (url == NULL) {
         ERR_raise(ERR_LIB_HTTP, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
 
+    if (perr != NULL)
+        *perr = X509_V_ERR_UNSUPPORTED_NAME_SYNTAX; /* default error */
+
+    if (len == 0)
+        goto parse_err;
+
+    if (memchr(url, '\0', len) != NULL)
+        goto parse_err;
+
     /* check for optional prefix "<scheme>://" as per RFC 3986 */
-    scheme = scheme_end = p = url;
-    if (ossl_isalpha(*p)) {
-        while (*p != '\0'
-            && (ossl_isalpha(*p)
-                || ossl_isdigit(*p)
-                || strchr("+-.", *p) != NULL))
-            p++;
-        if (HAS_PREFIX(p, OSSL_URL_SCHEME_SUFFIX)) {
-            scheme_end = p;
-            p += sizeof(OSSL_URL_SCHEME_SUFFIX) - 1;
+    scheme = scheme_end = current_pos;
+
+    CHECK_URL_END(current_pos);
+
+    if (ossl_isalpha(*current_pos)) {
+        while ((current_pos < url_end)
+            && (ossl_isalpha(*current_pos)
+                || ossl_isdigit(*current_pos)
+                || strchr("+-.", *current_pos) != NULL))
+            current_pos++;
+        if (HAS_PREFIX(current_pos, OSSL_URL_SCHEME_SUFFIX)) {
+            scheme_end = current_pos;
+            current_pos += sizeof(OSSL_URL_SCHEME_SUFFIX) - 1;
         } else {
-            p = url;
+            current_pos = url;
         }
     }
 
     /* parse optional "userinfo@" */
-    user = user_end = host = p;
-    authority_end = strpbrk(p, "/?#");
+    user = user_end = host = current_pos;
+    CHECK_URL_END(current_pos);
+    for (const char *q = current_pos; q < url_end; q++) {
+        if ((*q == '/') || (*q == '?') || (*q == '#')) {
+            authority_end = q;
+            break;
+        }
+    }
     if (authority_end == NULL)
-        authority_end = p + strlen(p);
-    host = memchr(p, '@', authority_end - p);
+        authority_end = url_end;
+
+    host = memchr(current_pos, '@', authority_end - current_pos);
     if (host != NULL)
         user_end = host++;
     else
-        host = p;
+        host = current_pos;
 
+    CHECK_URL_END(host);
     /* parse hostname/address as far as needed here */
     if (host[0] == '[') {
         /* IPv6 literal, which may include ':' */
         host_end = memchr(host + 1, ']', authority_end - host - 1);
         if (host_end == NULL)
             goto parse_err;
-        p = ++host_end;
+        current_pos = ++host_end;
     } else {
         /* look for start of optional port, path, query, or fragment */
-        host_end = strpbrk(host, ":/?#");
+        host_end = NULL;
+        for (const char *q = host; q < url_end; q++) {
+            if ((*q == ':') || (*q == '/') || (*q == '?') || (*q == '#')) {
+                host_end = q;
+                break;
+            }
+        }
         if (host_end == NULL) /* the remaining string is just the hostname */
-            host_end = host + strlen(host);
-        p = host_end;
+            host_end = url_end;
+        current_pos = host_end;
     }
 
     /* parse optional port specification starting with ':' */
     port = "0"; /* default */
-    if (*p == ':')
-        port = ++p;
-    /* remaining port spec handling is also done for the default values */
-    /* make sure a decimal port number is given */
-    if (sscanf(port, "%u", &portnum) <= 0 || portnum > 65535) {
-        ERR_raise_data(ERR_LIB_HTTP, HTTP_R_INVALID_PORT_NUMBER, "%s", port);
-        goto err;
+
+    /* port is explicitly given. */
+    if ((current_pos < url_end) && (*current_pos == ':')) {
+        const char *port_start;
+        port_start = port = ++current_pos;
+        /* remaining port spec handling is also done for the default values */
+        /* make sure a decimal port number is given */
+        while ((port < url_end) && ('0' <= *port) && (*port <= '9')) {
+            portnum = portnum * 10 + (*port - '0');
+            port++;
+        }
+        port_end = port;
+        current_pos += port_end - port_start;
+
+        /* Reset port so that the substring is copied correctly. */
+        port = port_start;
+
+        /* no digits found after ':' */
+        if (port_end == port_start) {
+            ERR_raise_data(ERR_LIB_HTTP, HTTP_R_INVALID_PORT_NUMBER, "empty port");
+            goto err;
+        }
+
+        /* Invalid port number. */
+        if (portnum > 65535) {
+            ERR_raise_data(ERR_LIB_HTTP, HTTP_R_INVALID_PORT_NUMBER, "%d", portnum);
+            goto err;
+        }
+    } else {
+        port_end = port + 1;
     }
-    for (port_end = port; '0' <= *port_end && *port_end <= '9'; port_end++)
-        ;
-    if (port == p) /* port was given explicitly */
-        p += port_end - port;
 
     /* check for optional path starting with '/' or '?'. Else must start '#' */
-    path = p;
-    if (*path != '\0' && *path != '/' && *path != '?' && *path != '#') {
+    path = current_pos;
+    if ((path < url_end) && (*path != '/') && (*path != '?') && (*path != '#')) {
         ERR_raise(ERR_LIB_HTTP, HTTP_R_INVALID_URL_PATH);
         goto parse_err;
     }
-    path_end = query = query_end = frag = frag_end = path + strlen(path);
+    path_end = query = query_end = frag = frag_end = url_end;
 
     /* parse optional "?query" */
-    tmp = strchr(p, '?');
-    if (tmp != NULL) {
-        p = tmp;
-        if (pquery != NULL) {
-            path_end = p;
-            query = p + 1;
+    for (const char *q = current_pos; q < url_end; q++) {
+        if (*q == '?') {
+            tmp = q;
+            break;
         }
     }
 
+    if (tmp != NULL) {
+        current_pos = tmp;
+        if (pquery != NULL) {
+            path_end = current_pos;
+            query = current_pos + 1;
+        }
+    }
+
+    /* Reset tmp to NULL*/
+    tmp = NULL;
+
     /* parse optional "#fragment" */
-    tmp = strchr(p, '#');
+    for (const char *q = current_pos; q < url_end; q++) {
+        if (*q == '#') {
+            tmp = q;
+            break;
+        }
+    }
     if (tmp != NULL) {
         if (query == path_end) /* we did not record a query component */
             path_end = tmp;
@@ -174,7 +250,7 @@ int OSSL_parse_url(const char *url, char **pscheme, char **puser, char **phost,
         goto err;
     if (pport_num != NULL)
         *pport_num = (int)portnum;
-    if (*path == '/') {
+    if ((path < url_end) && (*path == '/')) {
         if (!copy_substring(ppath, path, path_end))
             goto err;
     } else if (ppath != NULL) { /* must prepend '/' */
@@ -182,8 +258,11 @@ int OSSL_parse_url(const char *url, char **pscheme, char **puser, char **phost,
 
         if ((*ppath = OPENSSL_malloc(buflen)) == NULL)
             goto err;
-        BIO_snprintf(*ppath, buflen, "/%s", path);
+        BIO_snprintf(*ppath, buflen, "/%.*s", (int)(path_end - path), path);
     }
+
+    if (perr != NULL)
+        *perr = X509_V_OK;
     return 1;
 
 parse_err:
@@ -200,36 +279,6 @@ err:
     return 0;
 }
 
-int ossl_parse_url_internal(const char *url, size_t len, int *perr, char **pscheme, char **puser, char **phost,
-    char **pport, int *pport_num,
-    char **ppath, char **pquery, char **pfrag)
-{
-    if (perr != NULL)
-        *perr = X509_V_ERR_UNSUPPORTED_NAME_SYNTAX; /* default error */
-
-    if (len == 0)
-        return 0;
-
-    /* Embedded NUL check — only when caller provides explicit length */
-    if (len > 0) {
-
-        if (memchr(url, '\0', len) != NULL)
-            return 0;
-
-        /* Check for NUL terminator at the end */
-        if (url[len] != '\0')
-            return 0;
-    }
-
-    if (!OSSL_parse_url(url, pscheme, puser, phost, pport, pport_num,
-            ppath, pquery, pfrag))
-        return 0;
-
-    if (perr != NULL)
-        *perr = X509_V_OK;
-    return 1;
-}
-
 #ifndef OPENSSL_NO_HTTP
 
 int OSSL_HTTP_parse_url(const char *url, int *pssl, char **puser, char **phost,
@@ -237,15 +286,12 @@ int OSSL_HTTP_parse_url(const char *url, int *pssl, char **puser, char **phost,
     char **ppath, char **pquery, char **pfrag)
 {
     char *scheme, *port;
-    int ssl = 0, portnum;
+    int ssl = 0, portnum = 0;
 
     init_pstring(pport);
     if (pssl != NULL)
         *pssl = 0;
-    if (!ossl_parse_url_internal(url, strlen(url), NULL,
-            &scheme, puser, phost,
-            &port, pport_num,
-            ppath, pquery, pfrag))
+    if (!ossl_parse_url_internal(url, strlen(url), NULL, &scheme, puser, phost, &port, pport_num, ppath, pquery, pfrag))
         return 0;
 
     /* check for optional HTTP scheme "http[s]" */

--- a/crypto/http/http_lib.c
+++ b/crypto/http/http_lib.c
@@ -13,7 +13,7 @@
 #include <openssl/httperr.h>
 #include <openssl/bio.h> /* for BIO_snprintf() */
 #include <openssl/err.h>
-#include "internal/cryptlib.h" /* for ossl_assert() */
+#include "internal/cryptlib.h" /* for ossl_assert(), ossl_parse_url_internal() */
 #ifndef OPENSSL_NO_SOCK
 #include "internal/bio_addr.h" /* for NI_MAXHOST */
 #endif
@@ -21,6 +21,7 @@
 #define NI_MAXHOST 255
 #endif
 #include "crypto/ctype.h" /* for ossl_isspace() */
+#include "crypto/x509.h"
 #define OSSL_URL_SCHEME_SUFFIX "://"
 
 static void init_pstring(char **pstr)
@@ -199,6 +200,36 @@ err:
     return 0;
 }
 
+int ossl_parse_url_internal(const char *url, size_t len, int *perr, char **pscheme, char **puser, char **phost,
+    char **pport, int *pport_num,
+    char **ppath, char **pquery, char **pfrag)
+{
+    if (perr != NULL)
+        *perr = X509_V_ERR_UNSUPPORTED_NAME_SYNTAX; /* default error */
+
+    if (len == 0)
+        return 0;
+
+    /* Embedded NUL check — only when caller provides explicit length */
+    if (len > 0) {
+
+        if (memchr(url, '\0', len) != NULL)
+            return 0;
+
+        /* Check for NUL terminator at the end */
+        if (url[len] != '\0')
+            return 0;
+    }
+
+    if (!OSSL_parse_url(url, pscheme, puser, phost, pport, pport_num,
+            ppath, pquery, pfrag))
+        return 0;
+
+    if (perr != NULL)
+        *perr = X509_V_OK;
+    return 1;
+}
+
 #ifndef OPENSSL_NO_HTTP
 
 int OSSL_HTTP_parse_url(const char *url, int *pssl, char **puser, char **phost,
@@ -211,7 +242,9 @@ int OSSL_HTTP_parse_url(const char *url, int *pssl, char **puser, char **phost,
     init_pstring(pport);
     if (pssl != NULL)
         *pssl = 0;
-    if (!OSSL_parse_url(url, &scheme, puser, phost, &port, pport_num,
+    if (!ossl_parse_url_internal(url, strlen(url), NULL,
+            &scheme, puser, phost,
+            &port, pport_num,
             ppath, pquery, pfrag))
         return 0;
 

--- a/crypto/x509/v3_ncons.c
+++ b/crypto/x509/v3_ncons.c
@@ -785,6 +785,10 @@ static int nc_uri(ASN1_IA5STRING *uri, ASN1_IA5STRING *base)
     int hostlen;
     int ret;
 
+    /* Reject *embedded* NULs */
+    if (memchr(uri->data, '\0', uri->length) != NULL)
+        return X509_V_ERR_UNSUPPORTED_NAME_SYNTAX;
+
     if ((uri_copy = OPENSSL_strndup((const char *)uri->data, uri->length)) == NULL)
         return X509_V_ERR_UNSPECIFIED;
 

--- a/crypto/x509/v3_ncons.c
+++ b/crypto/x509/v3_ncons.c
@@ -779,37 +779,28 @@ static int nc_email(ASN1_IA5STRING *eml, ASN1_IA5STRING *base)
 static int nc_uri(ASN1_IA5STRING *uri, ASN1_IA5STRING *base)
 {
     const char *baseptr = (char *)base->data;
-    char *uri_copy;
     char *scheme;
     char *host;
     int hostlen;
     int ret;
+    int err;
 
-    /* Reject *embedded* NULs */
-    if (memchr(uri->data, '\0', uri->length) != NULL)
-        return X509_V_ERR_UNSUPPORTED_NAME_SYNTAX;
-
-    if ((uri_copy = OPENSSL_strndup((const char *)uri->data, uri->length)) == NULL)
-        return X509_V_ERR_UNSPECIFIED;
-
-    if (!OSSL_parse_url(uri_copy, &scheme, NULL, &host, NULL, NULL, NULL, NULL, NULL)) {
-        OPENSSL_free(uri_copy);
-        return X509_V_ERR_UNSUPPORTED_NAME_SYNTAX;
+    if (!ossl_parse_url_internal((const char *)uri->data, uri->length, &err,
+            &scheme, NULL, &host, NULL, NULL,
+            NULL, NULL, NULL)) {
+        return err;
     }
 
     /* Make sure the scheme is there */
     if (scheme == NULL || *scheme == '\0') {
         ERR_raise_data(ERR_LIB_X509V3, X509_V_ERR_UNSUPPORTED_NAME_SYNTAX,
-            "x509: missing scheme in URI: %s\n", uri_copy);
-        OPENSSL_free(scheme);
-        OPENSSL_free(uri_copy);
+            "x509: missing scheme in URI: %s\n", uri->data);
         ret = X509_V_ERR_UNSUPPORTED_NAME_SYNTAX;
         goto end;
     }
 
     /* We don't need these anymore */
     OPENSSL_free(scheme);
-    OPENSSL_free(uri_copy);
 
     hostlen = (int)strlen(host);
 

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -170,5 +170,8 @@ size_t ossl_to_hex(char *buf, uint8_t n);
 
 STACK_OF(SSL_COMP) *ossl_load_builtin_compressions(void);
 void ossl_free_compression_methods_int(STACK_OF(SSL_COMP) *methods);
-
+/* Expects a nul terminated C string as input.*/
+int ossl_parse_url_internal(const char *url, size_t len, int *perr, char **pscheme, char **puser, char **phost,
+    char **pport, int *pport_num,
+    char **ppath, char **pquery, char **pfrag);
 #endif

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -170,7 +170,7 @@ size_t ossl_to_hex(char *buf, uint8_t n);
 
 STACK_OF(SSL_COMP) *ossl_load_builtin_compressions(void);
 void ossl_free_compression_methods_int(STACK_OF(SSL_COMP) *methods);
-/* Expects a nul terminated C string as input.*/
+/* len specifies the length of url */
 int ossl_parse_url_internal(const char *url, size_t len, int *perr, char **pscheme, char **puser, char **phost,
     char **pport, int *pport_num,
     char **ppath, char **pquery, char **pfrag);

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -183,7 +183,7 @@ size_t ossl_to_hex(char *buf, uint8_t n);
 
 STACK_OF(SSL_COMP) *ossl_load_builtin_compressions(void);
 void ossl_free_compression_methods_int(STACK_OF(SSL_COMP) *methods);
-/* Expects a nul terminated C string as input.*/
+/* len specifies the length of url */
 int ossl_parse_url_internal(const char *url, size_t len, int *perr, char **pscheme, char **puser, char **phost,
     char **pport, int *pport_num,
     char **ppath, char **pquery, char **pfrag);

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -183,5 +183,8 @@ size_t ossl_to_hex(char *buf, uint8_t n);
 
 STACK_OF(SSL_COMP) *ossl_load_builtin_compressions(void);
 void ossl_free_compression_methods_int(STACK_OF(SSL_COMP) *methods);
-
+/* Expects a nul terminated C string as input.*/
+int ossl_parse_url_internal(const char *url, size_t len, int *perr, char **pscheme, char **puser, char **phost,
+    char **pport, int *pport_num,
+    char **ppath, char **pquery, char **pfrag);
 #endif


### PR DESCRIPTION
Add a memchr() check in nc_uri() to reject URI SAN values containing embedded NUL bytes before converting the ASN.1 IA5String into a C string.

This prevents truncation during OPENSSL_strndup() and ensures name constraint validation examines the complete URI value.

Fixes #31392.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
