### PR TITLE
aes_wrap: prevent crash on update without a key (3.2 backport)

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_wrp.c
+++ b/providers/implementations/ciphers/cipher_aes_wrp.c
@@ -141,6 +141,7 @@ static int aes_wrap_init(void *vctx, const unsigned char *key,
             AES_set_decrypt_key(key, keylen * 8, &wctx->ks.ks);
             ctx->block = (block128_f)AES_decrypt;
         }
+        ctx->key_set = 1;
     }
     return aes_wrap_set_ctx_params(ctx, params);
 }
@@ -204,6 +205,11 @@ static int aes_wrap_cipher_internal(void *vctx, unsigned char *out,
              */
             return inlen - 8;
         }
+    }
+
+    if (!ctx->key_set) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_NO_KEY_SET);
+        return -1;
     }
 
     rv = wctx->wrapfn(&wctx->ks.ks, ctx->iv_set ? ctx->iv : NULL, out, in,


### PR DESCRIPTION
Backport of d099e33e57 (PR #31292) to `openssl-3.2`.

The original commit could not be cherry-picked cleanly because two prerequisite commits are not present on 3.2:

- `ca8a2bd618` ("AES-WRAP fixes.") which introduced the `wctx->updated` multi-update guard.
- `baf4156f70` ("AES-WRAP: Add tests") which created `test/aeswrap_test.c` and the build hookup.

Neither is the security fix, so this PR carries only the minimal source-only change from `d099e33e57`: track `ctx->key_set` in `aes_wrap_init` and refuse `aes_wrap_cipher_internal` when no key has been installed. The master regression test is omitted because the file does not exist on 3.2.

Without the fix, `EVP_CipherInit_ex2` with a `NULL` key followed by `EVP_CipherUpdate` on `AES-WRAP` / `AES-WRAP-PAD` / `AES-WRAP-INV` dereferences the uninitialised `ctx->block`.

CC @jogme — backport requested in https://github.com/openssl/openssl/pull/31292#issuecomment-4612045303

##### Checklist
- [x] tests are added or updated (master only — see note above)