### PR TITLE
Reject TLS 1.3 early data on PSK ciphersuite mismatch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,12 @@ OpenSSL Releases
 
    *Jakub Zelenka*
 
+ * Fixed TLS 1.3 servers to reject early data when the selected ciphersuite
+   differs from the ciphersuite associated with the selected PSK. Same-hash
+   PSK resumption can still continue without accepting 0-RTT data.
+
+   *Mounir IDRASSI*
+
  * Added support for Ed25519 and Ed448 certificates in DTLS 1.2. Previously,
    these certificate types were only supported in TLS 1.2 and TLS 1.3.
 

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -1530,6 +1530,14 @@ int tls_parse_ctos_psk(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
             s->ext.ticket_expected = 1;
             continue;
         }
+        /*
+         * Same-hash ciphersuite changes are allowed for TLSv1.3 PSK
+         * resumption, but RFC 8446 Section 4.2.10 requires the selected
+         * ciphersuite to match the selected PSK before accepting early data.
+         */
+        if (s->ext.early_data_ok
+            && sess->cipher->id != s->s3.tmp.new_cipher->id)
+            s->ext.early_data_ok = 0;
         break;
     }
 

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -5290,6 +5290,83 @@ end:
     return testresult;
 }
 
+static int test_early_data_psk_cipher_mismatch(int idx)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    int testresult = 0;
+    SSL_SESSION *sess = NULL;
+    const SSL_CIPHER *cipher = NULL;
+    unsigned char buf[20];
+    size_t readbytes, written;
+    const char *negotiated_cipher[] = {
+        TLS1_3_RFC_AES_128_CCM_8_SHA256 ":" TLS1_3_RFC_AES_128_CCM_SHA256,
+        TLS1_3_RFC_AES_128_CCM_SHA256 ":" TLS1_3_RFC_AES_128_CCM_8_SHA256
+    };
+    const unsigned char *psk_cipher_id[] = {
+        TLS13_AES_128_CCM_SHA256_BYTES,
+        TLS13_AES_128_CCM_8_SHA256_BYTES
+    };
+
+    if (!TEST_true(setupearly_data_test(&cctx, &sctx, &clientssl,
+            &serverssl, &sess, 2,
+            SHA256_DIGEST_LENGTH)))
+        goto end;
+
+    /*
+     * CCM8 is below the default security level, and each test case uses it
+     * either as the selected ciphersuite or as the PSK ciphersuite.
+     */
+    SSL_set_security_level(clientssl, 0);
+    SSL_set_security_level(serverssl, 0);
+
+    if (!TEST_true(SSL_set_ciphersuites(clientssl, negotiated_cipher[idx]))
+        || !TEST_true(SSL_set_ciphersuites(serverssl, negotiated_cipher[idx])))
+        goto end;
+
+    cipher = SSL_CIPHER_find(clientssl, psk_cipher_id[idx]);
+    if (!TEST_ptr(cipher)
+        || !TEST_true(SSL_SESSION_set_cipher(sess, cipher)))
+        goto end;
+
+    SSL_set_connect_state(clientssl);
+    if (!TEST_true(SSL_write_early_data(clientssl, MSG1, strlen(MSG1),
+            &written))
+        || !TEST_size_t_eq(written, strlen(MSG1)))
+        goto end;
+
+    if (!TEST_int_eq(SSL_read_early_data(serverssl, buf, sizeof(buf),
+                         &readbytes),
+            SSL_READ_EARLY_DATA_FINISH)
+        || !TEST_size_t_eq(readbytes, 0)
+        || !TEST_int_eq(SSL_get_early_data_status(serverssl),
+            SSL_EARLY_DATA_REJECTED))
+        goto end;
+
+    ERR_clear_error();
+    if (!TEST_true(SSL_write_ex(clientssl, MSG2, strlen(MSG2), &written))
+        || !TEST_size_t_eq(written, strlen(MSG2))
+        || !TEST_int_eq(SSL_get_early_data_status(clientssl),
+            SSL_EARLY_DATA_REJECTED)
+        || !TEST_true(SSL_read_ex(serverssl, buf, sizeof(buf), &readbytes))
+        || !TEST_mem_eq(buf, readbytes, MSG2, strlen(MSG2))
+        || !TEST_true(SSL_session_reused(clientssl))
+        || !TEST_long_eq(ERR_peek_error(), 0))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_SESSION_free(sess);
+    SSL_SESSION_free(clientpsk);
+    SSL_SESSION_free(serverpsk);
+    clientpsk = serverpsk = NULL;
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
 /*
  * Test that a server that doesn't try to read early data can handle a
  * client sending some.
@@ -15269,6 +15346,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_early_data_not_sent, 3);
     ADD_ALL_TESTS(test_early_data_psk, 8);
     ADD_ALL_TESTS(test_early_data_psk_with_all_ciphers, 7);
+    ADD_ALL_TESTS(test_early_data_psk_cipher_mismatch, 2);
     ADD_ALL_TESTS(test_early_data_not_expected, 3);
 #ifndef OPENSSL_NO_TLS1_2
     ADD_ALL_TESTS(test_early_data_tls1_2, 3);


### PR DESCRIPTION
Fixes #31406 

TLS 1.3 allows PSK resumption with a ciphersuite using the same hash as the PSK session, but 0-RTT is stricter: the selected ciphersuite must match the ciphersuite associated with the selected PSK.

OpenSSL currently checks only hash compatibility in `tls_parse_ctos_psk`. This allows early data to be accepted when, for example, a PSK for `TLS_AES_128_CCM_SHA256` is resumed while the server selects `TLS_AES_128_CCM_8_SHA256`, or the reverse. These ciphersuites both use SHA-256 but have different CCM tag lengths, so accepted early data fails later with `bad_record_mac`.

This change keeps existing same-hash PSK resumption behavior, but disables `early_data_ok` when the selected TLS 1.3 ciphersuite id differs from the PSK/session ciphersuite id.

A regression test covers both CCM/CCM_8 mismatch directions and verifies that early data is rejected, PSK resumption still succeeds, normal 1-RTT application data can be exchanged, and no error remains on the queue.

Testing:

- `make -j$(nproc)`
- `make test TESTS=test_sslapi`
- `make test`

Full Linux Ubuntu 24.04 test result: `Files=366, Tests=4374, Result: PASS`