### PR TITLE
Disambiguate TLS cert slots by key group when sigalgs share a key type

### DIFF
--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -776,6 +776,20 @@ Otherwise, it's assumed to already exist in the object database, possibly
 done by the provider with the core_obj_create() upcall.
 This value is optional.
 
+=item "key-type-group" (B<OSSL_CAPABILITY_TLS_SIGALG_KEYTYPE_GROUP>) <UTF8 string>
+
+The name of the group/parameter set that binds this signature algorithm to a
+specific class of keys when several signature algorithms share the same
+"key-type", for example the GOST signature schemes from RFC 9367 which are
+distinguished only by the parameter set of the key. The name must resolve to
+a NID in the object database, possibly registered by the provider with the
+core_obj_create() upcall. When given, a certificate is assigned to this
+signature algorithm's certificate slot only if the group name of its public
+key (as reported by EVP_PKEY_get_group_name(3)) matches this value. When
+omitted, certificates are assigned by "key-type" alone with the historic
+first-match behaviour.
+This value is optional.
+
 =item "sec-bits" (B<OSSL_CAPABILITY_TLS_SIGALG_SECURITY_BITS>) <unsigned integer>
 
 The number of bits of security offered by keys of this algorithm. The number

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -783,11 +783,17 @@ specific class of keys when several signature algorithms share the same
 "key-type", for example the GOST signature schemes from RFC 9367 which are
 distinguished only by the parameter set of the key. The name must resolve to
 a NID in the object database, possibly registered by the provider with the
-core_obj_create() upcall. When given, a certificate is assigned to this
-signature algorithm's certificate slot only if the group name of its public
-key (as reported by EVP_PKEY_get_group_name(3)) matches this value. When
-omitted, certificates are assigned by "key-type" alone with the historic
-first-match behaviour.
+core_obj_create() upcall; a name that does not resolve is an error and the
+B<SSL_CTX> creation which discovered this capability fails. When given, a
+certificate is assigned to this signature algorithm's certificate slot only
+if the group name of its public key (as reported by
+EVP_PKEY_get_group_name(3)) matches this value. When omitted, certificates
+are assigned by "key-type" alone with the historic first-match behaviour.
+
+This slot is in addition to, not instead of, the slot the certificate would
+otherwise occupy: if the "key-type" is one that libssl has a built-in
+certificate slot for, the certificate is loaded into both, so that the paths
+which address the built-in slot by its static index continue to work.
 This value is optional.
 
 =item "sec-bits" (B<OSSL_CAPABILITY_TLS_SIGALG_SECURITY_BITS>) <unsigned integer>

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -1345,9 +1345,22 @@ int ssl_cert_lookup_by_nid(int nid, size_t *pidx, SSL_CTX *ctx)
     return 0;
 }
 
+static int ssl_pkey_group_nid(const EVP_PKEY *pk)
+{
+    char gname[256];
+
+    if (pk == NULL
+        || !EVP_PKEY_get_group_name(pk, gname, sizeof(gname), NULL))
+        return NID_undef;
+    return OBJ_txt2nid(gname);
+}
+
 const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk, size_t *pidx, SSL_CTX *ctx)
 {
     size_t i;
+    int pk_group_nid;
+    const SSL_CERT_LOOKUP *fallback = NULL;
+    size_t fallback_idx = 0;
 
     /* check classic pk types */
     for (i = 0; i < OSSL_NELEM(ssl_cert_info); i++) {
@@ -1360,16 +1373,34 @@ const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk, size_t *pidx,
             return tmp_lu;
         }
     }
-    /* check provider-loaded pk types */
+
+    pk_group_nid = ssl_pkey_group_nid(pk);
     for (i = 0; i < ctx->sigalg_list_len; i++) {
         SSL_CERT_LOOKUP *tmp_lu = &(ctx->ssl_cert_info[i]);
 
-        if (EVP_PKEY_is_a(pk, OBJ_nid2sn(tmp_lu->pkey_nid))
-            || EVP_PKEY_is_a(pk, OBJ_nid2ln(tmp_lu->pkey_nid))) {
-            if (pidx != NULL)
-                *pidx = SSL_PKEY_NUM + i;
-            return &ctx->ssl_cert_info[i];
+        if (!EVP_PKEY_is_a(pk, OBJ_nid2sn(tmp_lu->pkey_nid))
+            && !EVP_PKEY_is_a(pk, OBJ_nid2ln(tmp_lu->pkey_nid)))
+            continue;
+
+        if (tmp_lu->group_nid != NID_undef) {
+            if (tmp_lu->group_nid == pk_group_nid) {
+                if (pidx != NULL)
+                    *pidx = SSL_PKEY_NUM + i;
+                return tmp_lu;
+            }
+            continue;
         }
+
+        if (fallback == NULL) {
+            fallback = tmp_lu;
+            fallback_idx = SSL_PKEY_NUM + i;
+        }
+    }
+
+    if (fallback != NULL) {
+        if (pidx != NULL)
+            *pidx = fallback_idx;
+        return fallback;
     }
 
     return NULL;

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -1358,9 +1358,30 @@ static int ssl_pkey_group_nid(const EVP_PKEY *pk)
 const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk, size_t *pidx, SSL_CTX *ctx)
 {
     size_t i;
-    int pk_group_nid;
-    const SSL_CERT_LOOKUP *fallback = NULL;
-    size_t fallback_idx = 0;
+    int pk_group_nid = NID_undef;
+
+    /*
+     * Provider slots bound to the key's group/parameter set take priority
+     * over everything else: the built-in table below may contain entries
+     * with the same key type NIDs (for example the built-in GOST slots vs
+     * the RFC 9367 provider sigalgs) which would otherwise shadow the
+     * provider slots and make them unreachable.
+     */
+    if (ctx->sigalg_list_len > 0)
+        pk_group_nid = ssl_pkey_group_nid(pk);
+    if (pk_group_nid != NID_undef) {
+        for (i = 0; i < ctx->sigalg_list_len; i++) {
+            SSL_CERT_LOOKUP *tmp_lu = &(ctx->ssl_cert_info[i]);
+
+            if (tmp_lu->group_nid == pk_group_nid
+                && (EVP_PKEY_is_a(pk, OBJ_nid2sn(tmp_lu->pkey_nid))
+                    || EVP_PKEY_is_a(pk, OBJ_nid2ln(tmp_lu->pkey_nid)))) {
+                if (pidx != NULL)
+                    *pidx = SSL_PKEY_NUM + i;
+                return tmp_lu;
+            }
+        }
+    }
 
     /* check classic pk types */
     for (i = 0; i < OSSL_NELEM(ssl_cert_info); i++) {
@@ -1374,33 +1395,23 @@ const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk, size_t *pidx,
         }
     }
 
-    pk_group_nid = ssl_pkey_group_nid(pk);
+    /*
+     * Check provider-loaded pk types. Slots bound to a group were already
+     * tried above; a slot without a group binding keeps the legacy
+     * first-match-by-key-type behaviour.
+     */
     for (i = 0; i < ctx->sigalg_list_len; i++) {
         SSL_CERT_LOOKUP *tmp_lu = &(ctx->ssl_cert_info[i]);
 
-        if (!EVP_PKEY_is_a(pk, OBJ_nid2sn(tmp_lu->pkey_nid))
-            && !EVP_PKEY_is_a(pk, OBJ_nid2ln(tmp_lu->pkey_nid)))
+        if (tmp_lu->group_nid != NID_undef)
             continue;
 
-        if (tmp_lu->group_nid != NID_undef) {
-            if (tmp_lu->group_nid == pk_group_nid) {
-                if (pidx != NULL)
-                    *pidx = SSL_PKEY_NUM + i;
-                return tmp_lu;
-            }
-            continue;
+        if (EVP_PKEY_is_a(pk, OBJ_nid2sn(tmp_lu->pkey_nid))
+            || EVP_PKEY_is_a(pk, OBJ_nid2ln(tmp_lu->pkey_nid))) {
+            if (pidx != NULL)
+                *pidx = SSL_PKEY_NUM + i;
+            return tmp_lu;
         }
-
-        if (fallback == NULL) {
-            fallback = tmp_lu;
-            fallback_idx = SSL_PKEY_NUM + i;
-        }
-    }
-
-    if (fallback != NULL) {
-        if (pidx != NULL)
-            *pidx = fallback_idx;
-        return fallback;
     }
 
     return NULL;

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -1345,6 +1345,18 @@ int ssl_cert_lookup_by_nid(int nid, size_t *pidx, SSL_CTX *ctx)
     return 0;
 }
 
+/* amask of the built-in slot for this key type, SSL_aANY if there isn't one */
+uint32_t ssl_cert_builtin_amask_by_nid(int nid)
+{
+    size_t i;
+
+    for (i = 0; i < OSSL_NELEM(ssl_cert_info); i++) {
+        if (ssl_cert_info[i].pkey_nid == nid)
+            return ssl_cert_info[i].amask;
+    }
+    return SSL_aANY;
+}
+
 static int ssl_pkey_group_nid(const EVP_PKEY *pk)
 {
     char gname[256];
@@ -1355,59 +1367,47 @@ static int ssl_pkey_group_nid(const EVP_PKEY *pk)
     return OBJ_txt2nid(gname);
 }
 
-const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk, size_t *pidx, SSL_CTX *ctx)
+static int ssl_cert_pkey_is_a(const EVP_PKEY *pk, const SSL_CERT_LOOKUP *lu)
+{
+    return EVP_PKEY_is_a(pk, OBJ_nid2sn(lu->pkey_nid))
+        || EVP_PKEY_is_a(pk, OBJ_nid2ln(lu->pkey_nid));
+}
+
+/*
+ * Can this key go in this slot? Key type must match, and so must the group
+ * if the slot has one. Asking this way doesn't depend on lookup order.
+ */
+int ssl_cert_pkey_fits_slot(const EVP_PKEY *pk, const SSL_CERT_LOOKUP *lu)
+{
+    if (!ssl_cert_pkey_is_a(pk, lu))
+        return 0;
+    if (lu->group_nid != NID_undef && ssl_pkey_group_nid(pk) != lu->group_nid)
+        return 0;
+    return 1;
+}
+
+/*
+ * Find the provider slot bound to the group this key carries. This is what
+ * tells apart schemes sharing a key type OID, like the RFC 9367 GOST ones.
+ */
+const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey_group(const EVP_PKEY *pk,
+    size_t *pidx, SSL_CTX *ctx)
 {
     size_t i;
-    int pk_group_nid = NID_undef;
+    int pk_group_nid;
 
-    /*
-     * Provider slots bound to the key's group/parameter set take priority
-     * over everything else: the built-in table below may contain entries
-     * with the same key type NIDs (for example the built-in GOST slots vs
-     * the RFC 9367 provider sigalgs) which would otherwise shadow the
-     * provider slots and make them unreachable.
-     */
-    if (ctx->sigalg_list_len > 0)
-        pk_group_nid = ssl_pkey_group_nid(pk);
-    if (pk_group_nid != NID_undef) {
-        for (i = 0; i < ctx->sigalg_list_len; i++) {
-            SSL_CERT_LOOKUP *tmp_lu = &(ctx->ssl_cert_info[i]);
+    if (ctx->sigalg_list_len == 0)
+        return NULL;
 
-            if (tmp_lu->group_nid == pk_group_nid
-                && (EVP_PKEY_is_a(pk, OBJ_nid2sn(tmp_lu->pkey_nid))
-                    || EVP_PKEY_is_a(pk, OBJ_nid2ln(tmp_lu->pkey_nid)))) {
-                if (pidx != NULL)
-                    *pidx = SSL_PKEY_NUM + i;
-                return tmp_lu;
-            }
-        }
-    }
+    pk_group_nid = ssl_pkey_group_nid(pk);
+    if (pk_group_nid == NID_undef)
+        return NULL;
 
-    /* check classic pk types */
-    for (i = 0; i < OSSL_NELEM(ssl_cert_info); i++) {
-        const SSL_CERT_LOOKUP *tmp_lu = &ssl_cert_info[i];
-
-        if (EVP_PKEY_is_a(pk, OBJ_nid2sn(tmp_lu->pkey_nid))
-            || EVP_PKEY_is_a(pk, OBJ_nid2ln(tmp_lu->pkey_nid))) {
-            if (pidx != NULL)
-                *pidx = i;
-            return tmp_lu;
-        }
-    }
-
-    /*
-     * Check provider-loaded pk types. Slots bound to a group were already
-     * tried above; a slot without a group binding keeps the legacy
-     * first-match-by-key-type behaviour.
-     */
     for (i = 0; i < ctx->sigalg_list_len; i++) {
         SSL_CERT_LOOKUP *tmp_lu = &(ctx->ssl_cert_info[i]);
 
-        if (tmp_lu->group_nid != NID_undef)
-            continue;
-
-        if (EVP_PKEY_is_a(pk, OBJ_nid2sn(tmp_lu->pkey_nid))
-            || EVP_PKEY_is_a(pk, OBJ_nid2ln(tmp_lu->pkey_nid))) {
+        if (tmp_lu->group_nid == pk_group_nid
+            && ssl_cert_pkey_is_a(pk, tmp_lu)) {
             if (pidx != NULL)
                 *pidx = SSL_PKEY_NUM + i;
             return tmp_lu;
@@ -1415,6 +1415,64 @@ const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk, size_t *pidx,
     }
 
     return NULL;
+}
+
+const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk, size_t *pidx, SSL_CTX *ctx)
+{
+    const SSL_CERT_LOOKUP *lu;
+    size_t i;
+
+    /*
+     * Classic pk types first. If a key type has a built-in slot it must keep
+     * resolving to it, since TLS 1.2 and below address that slot by index.
+     */
+    for (i = 0; i < OSSL_NELEM(ssl_cert_info); i++) {
+        const SSL_CERT_LOOKUP *tmp_lu = &ssl_cert_info[i];
+
+        if (ssl_cert_pkey_is_a(pk, tmp_lu)) {
+            if (pidx != NULL)
+                *pidx = i;
+            return tmp_lu;
+        }
+    }
+
+    /* Then provider slots, by group first so shared key types still split */
+    lu = ssl_cert_lookup_by_pkey_group(pk, pidx, ctx);
+    if (lu != NULL)
+        return lu;
+
+    /* Slots with no group keep the old first-match behaviour */
+    for (i = 0; i < ctx->sigalg_list_len; i++) {
+        SSL_CERT_LOOKUP *tmp_lu = &(ctx->ssl_cert_info[i]);
+
+        if (ssl_cert_pkey_is_a(pk, tmp_lu)) {
+            if (pidx != NULL)
+                *pidx = SSL_PKEY_NUM + i;
+            return tmp_lu;
+        }
+    }
+
+    return NULL;
+}
+
+/*
+ * Every slot this key belongs in: the primary one, plus its group-bound
+ * provider slot if that's a different slot. Returns how many, 0 if unknown.
+ */
+size_t ssl_cert_lookup_slots_by_pkey(const EVP_PKEY *pk, size_t *pidx,
+    SSL_CTX *ctx)
+{
+    size_t n = 0, gidx;
+
+    if (ssl_cert_lookup_by_pkey(pk, &pidx[0], ctx) == NULL)
+        return 0;
+    n = 1;
+
+    if (ssl_cert_lookup_by_pkey_group(pk, &gidx, ctx) != NULL
+        && gidx != pidx[0])
+        pidx[n++] = gidx;
+
+    return n;
 }
 
 const SSL_CERT_LOOKUP *ssl_cert_lookup_by_idx(size_t idx, SSL_CTX *ctx)

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4634,6 +4634,7 @@ void SSL_CTX_free(SSL_CTX *a)
         OPENSSL_free(a->sigalg_list[j].hash_oid);
         OPENSSL_free(a->sigalg_list[j].keytype);
         OPENSSL_free(a->sigalg_list[j].keytype_oid);
+        OPENSSL_free(a->sigalg_list[j].keytype_group);
     }
     OPENSSL_free(a->sigalg_list);
     OPENSSL_free(a->ssl_cert_info);

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -793,6 +793,7 @@ typedef struct tls_sigalg_info_st {
     char *hash_oid; /* hash algorithm OID */
     char *keytype; /* keytype name */
     char *keytype_oid; /* keytype OID */
+    char *keytype_group; /* optional group/parameter set that binds this sigalg */
     unsigned int secbits; /* Bits of security (from SP800-57) */
     int mintls; /* Minimum TLS version, -1 unsupported */
     int maxtls; /* Maximum TLS version (or 0 for undefined) */
@@ -807,6 +808,13 @@ typedef struct tls_sigalg_info_st {
 typedef struct {
     int pkey_nid; /* NID of public key algorithm */
     uint32_t amask; /* authmask corresponding to key type */
+    /*
+     * Optional group/parameter set that binds this cert slot to a specific
+     * signature scheme when several schemes share one key type OID (for
+     * example GOST 256a/b/c/d per RFC 9367). NID_undef means "any group",
+     * which preserves the legacy first-match-by-key-type behaviour.
+     */
+    int group_nid;
 } SSL_CERT_LOOKUP;
 
 #if !defined(OPENSSL_NO_TLS1)      \

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -809,13 +809,14 @@ typedef struct {
     int pkey_nid; /* NID of public key algorithm */
     uint32_t amask; /* authmask corresponding to key type */
     /*
-     * Optional group/parameter set that binds this cert slot to a specific
-     * signature scheme when several schemes share one key type OID (for
-     * example GOST 256a/b/c/d per RFC 9367). NID_undef means "any group",
-     * which preserves the legacy first-match-by-key-type behaviour.
+     * Group/parameter set this slot is tied to, for when several schemes
+     * share a key type OID (GOST 256a/b/c/d). NID_undef means any group.
      */
     int group_nid;
 } SSL_CERT_LOOKUP;
+
+/* A key fits at most two slots: its primary one and a group-bound one */
+#define SSL_CERT_MAX_PKEY_SLOTS 2
 
 #if !defined(OPENSSL_NO_TLS1)      \
     || !defined(OPENSSL_NO_TLS1_1) \
@@ -2527,8 +2528,16 @@ __owur int ssl_ctx_security(const SSL_CTX *ctx, int op, int bits, int nid,
 int ssl_get_security_level_bits(const SSL *s, const SSL_CTX *ctx, int *levelp);
 
 __owur int ssl_cert_lookup_by_nid(int nid, size_t *pidx, SSL_CTX *ctx);
+__owur uint32_t ssl_cert_builtin_amask_by_nid(int nid);
 __owur const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk,
     size_t *pidx,
+    SSL_CTX *ctx);
+__owur int ssl_cert_pkey_fits_slot(const EVP_PKEY *pk,
+    const SSL_CERT_LOOKUP *lu);
+__owur const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey_group(const EVP_PKEY *pk,
+    size_t *pidx,
+    SSL_CTX *ctx);
+__owur size_t ssl_cert_lookup_slots_by_pkey(const EVP_PKEY *pk, size_t *pidx,
     SSL_CTX *ctx);
 __owur const SSL_CERT_LOOKUP *ssl_cert_lookup_by_idx(size_t idx, SSL_CTX *ctx);
 

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -132,22 +132,37 @@ int SSL_use_certificate_ASN1(SSL *ssl, const unsigned char *d, int len)
 
 static int ssl_set_pkey(CERT *c, EVP_PKEY *pkey, SSL_CTX *ctx)
 {
-    size_t i;
+    size_t idx[SSL_CERT_MAX_PKEY_SLOTS];
+    size_t nidx, n;
 
-    if (ssl_cert_lookup_by_pkey(pkey, &i, ctx) == NULL) {
+    /* See ssl_set_cert() for why there can be two slots */
+    nidx = ssl_cert_lookup_slots_by_pkey(pkey, idx, ctx);
+    if (nidx == 0) {
         ERR_raise(ERR_LIB_SSL, SSL_R_UNKNOWN_CERTIFICATE_TYPE);
         return 0;
     }
 
-    if (c->pkeys[i].x509 != NULL
-        && !X509_check_private_key(c->pkeys[i].x509, pkey))
-        return 0;
-    if (!EVP_PKEY_up_ref(pkey))
-        return 0;
+    for (n = 0; n < nidx; n++) {
+        if (c->pkeys[idx[n]].x509 != NULL
+            && !X509_check_private_key(c->pkeys[idx[n]].x509, pkey))
+            return 0;
+    }
 
-    EVP_PKEY_free(c->pkeys[i].privatekey);
-    c->pkeys[i].privatekey = pkey;
-    c->key = &c->pkeys[i];
+    /* Grab all the references first, so this is all or nothing */
+    for (n = 0; n < nidx; n++) {
+        if (!EVP_PKEY_up_ref(pkey)) {
+            while (n-- > 0)
+                EVP_PKEY_free(pkey);
+            return 0;
+        }
+    }
+
+    for (n = 0; n < nidx; n++) {
+        EVP_PKEY_free(c->pkeys[idx[n]].privatekey);
+        c->pkeys[idx[n]].privatekey = pkey;
+    }
+
+    c->key = &c->pkeys[idx[0]];
     return 1;
 }
 
@@ -255,27 +270,9 @@ int SSL_CTX_use_certificate(SSL_CTX *ctx, X509 *x)
     return ssl_set_cert(ctx->cert, x, ctx);
 }
 
-static int ssl_set_cert(CERT *c, X509 *x, SSL_CTX *ctx)
+/* Stores x in slot i, consuming one reference taken by the caller */
+static void ssl_set_cert_at(CERT *c, X509 *x, EVP_PKEY *pkey, size_t i)
 {
-    EVP_PKEY *pkey;
-    size_t i;
-
-    pkey = X509_get0_pubkey(x);
-    if (pkey == NULL) {
-        ERR_raise(ERR_LIB_SSL, SSL_R_X509_LIB);
-        return 0;
-    }
-
-    if (ssl_cert_lookup_by_pkey(pkey, &i, ctx) == NULL) {
-        ERR_raise(ERR_LIB_SSL, SSL_R_UNKNOWN_CERTIFICATE_TYPE);
-        return 0;
-    }
-
-    if (i == SSL_PKEY_ECC && !EVP_PKEY_can_sign(pkey)) {
-        ERR_raise(ERR_LIB_SSL, SSL_R_ECC_CERT_NOT_FOR_SIGNING);
-        return 0;
-    }
-
     if (c->pkeys[i].privatekey != NULL) {
         /*
          * The return code from EVP_PKEY_copy_parameters is deliberately
@@ -298,12 +295,50 @@ static int ssl_set_cert(CERT *c, X509 *x, SSL_CTX *ctx)
         }
     }
 
-    if (!X509_up_ref(x))
-        return 0;
-
     X509_free(c->pkeys[i].x509);
     c->pkeys[i].x509 = x;
-    c->key = &(c->pkeys[i]);
+}
+
+static int ssl_set_cert(CERT *c, X509 *x, SSL_CTX *ctx)
+{
+    EVP_PKEY *pkey;
+    size_t idx[SSL_CERT_MAX_PKEY_SLOTS];
+    size_t nidx, n;
+
+    pkey = X509_get0_pubkey(x);
+    if (pkey == NULL) {
+        ERR_raise(ERR_LIB_SSL, SSL_R_X509_LIB);
+        return 0;
+    }
+
+    /*
+     * A grouped key goes in its normal slot and in the sigalg's own slot,
+     * so both the old index-based paths and TLS 1.3 find the certificate.
+     */
+    nidx = ssl_cert_lookup_slots_by_pkey(pkey, idx, ctx);
+    if (nidx == 0) {
+        ERR_raise(ERR_LIB_SSL, SSL_R_UNKNOWN_CERTIFICATE_TYPE);
+        return 0;
+    }
+
+    if (idx[0] == SSL_PKEY_ECC && !EVP_PKEY_can_sign(pkey)) {
+        ERR_raise(ERR_LIB_SSL, SSL_R_ECC_CERT_NOT_FOR_SIGNING);
+        return 0;
+    }
+
+    /* Grab all the references first, so this is all or nothing */
+    for (n = 0; n < nidx; n++) {
+        if (!X509_up_ref(x)) {
+            while (n-- > 0)
+                X509_free(x);
+            return 0;
+        }
+    }
+
+    for (n = 0; n < nidx; n++)
+        ssl_set_cert_at(c, x, pkey, idx[n]);
+
+    c->key = &(c->pkeys[idx[0]]);
 
     return 1;
 }
@@ -981,10 +1016,13 @@ static int ssl_set_cert_and_key(SSL *ssl, SSL_CTX *ctx, X509 *x509, EVP_PKEY *pr
 {
     int ret = 0;
     size_t i;
+    size_t idx[SSL_CERT_MAX_PKEY_SLOTS];
+    size_t nidx, n;
     int j;
     int rv;
     CERT *c;
-    STACK_OF(X509) *dup_chain = NULL;
+    STACK_OF(X509) *dup_chains[SSL_CERT_MAX_PKEY_SLOTS] = { NULL };
+    size_t nx509refs = 0, npkeyrefs = 0;
     EVP_PKEY *pubkey = NULL;
     SSL_CONNECTION *sc = NULL;
 
@@ -1039,51 +1077,66 @@ static int ssl_set_cert_and_key(SSL *ssl, SSL_CTX *ctx, X509 *x509, EVP_PKEY *pr
             goto out;
         }
     }
-    if (ssl_cert_lookup_by_pkey(pubkey, &i,
-            sc != NULL ? SSL_CONNECTION_GET_CTX(sc) : ctx)
-        == NULL) {
+    /* See ssl_set_cert() for why there can be two slots */
+    nidx = ssl_cert_lookup_slots_by_pkey(pubkey, idx,
+        sc != NULL ? SSL_CONNECTION_GET_CTX(sc) : ctx);
+    if (nidx == 0) {
         ERR_raise(ERR_LIB_SSL, SSL_R_UNKNOWN_CERTIFICATE_TYPE);
         goto out;
     }
 
-    if (!override && (c->pkeys[i].x509 != NULL || c->pkeys[i].privatekey != NULL || c->pkeys[i].chain != NULL)) {
-        /* No override, and something already there */
-        ERR_raise(ERR_LIB_SSL, SSL_R_NOT_REPLACING_CERTIFICATE);
-        goto out;
-    }
-
-    if (chain != NULL) {
-        dup_chain = X509_chain_up_ref(chain);
-        if (dup_chain == NULL) {
-            ERR_raise(ERR_LIB_SSL, ERR_R_X509_LIB);
+    for (n = 0; n < nidx; n++) {
+        i = idx[n];
+        if (!override && (c->pkeys[i].x509 != NULL || c->pkeys[i].privatekey != NULL || c->pkeys[i].chain != NULL)) {
+            /* No override, and something already there */
+            ERR_raise(ERR_LIB_SSL, SSL_R_NOT_REPLACING_CERTIFICATE);
             goto out;
         }
     }
 
-    if (!X509_up_ref(x509)) {
-        OSSL_STACK_OF_X509_free(dup_chain);
-        goto out;
+    /* Grab all the references first, so a failure leaves the slots alone */
+    for (n = 0; n < nidx; n++) {
+        if (chain != NULL) {
+            dup_chains[n] = X509_chain_up_ref(chain);
+            if (dup_chains[n] == NULL) {
+                ERR_raise(ERR_LIB_SSL, ERR_R_X509_LIB);
+                goto out;
+            }
+        }
+        if (!X509_up_ref(x509))
+            goto out;
+        nx509refs++;
+        if (!EVP_PKEY_up_ref(privatekey))
+            goto out;
+        npkeyrefs++;
     }
 
-    if (!EVP_PKEY_up_ref(privatekey)) {
-        OSSL_STACK_OF_X509_free(dup_chain);
-        X509_free(x509);
-        goto out;
+    for (n = 0; n < nidx; n++) {
+        i = idx[n];
+
+        OSSL_STACK_OF_X509_free(c->pkeys[i].chain);
+        c->pkeys[i].chain = dup_chains[n];
+        dup_chains[n] = NULL;
+
+        X509_free(c->pkeys[i].x509);
+        c->pkeys[i].x509 = x509;
+
+        EVP_PKEY_free(c->pkeys[i].privatekey);
+        c->pkeys[i].privatekey = privatekey;
     }
+    nx509refs = npkeyrefs = 0;
 
-    OSSL_STACK_OF_X509_free(c->pkeys[i].chain);
-    c->pkeys[i].chain = dup_chain;
-
-    X509_free(c->pkeys[i].x509);
-    c->pkeys[i].x509 = x509;
-
-    EVP_PKEY_free(c->pkeys[i].privatekey);
-    c->pkeys[i].privatekey = privatekey;
-
-    c->key = &(c->pkeys[i]);
+    c->key = &(c->pkeys[idx[0]]);
 
     ret = 1;
 out:
+    /* Drop anything we took but didn't store; no-ops on success */
+    for (n = 0; n < OSSL_NELEM(dup_chains); n++)
+        OSSL_STACK_OF_X509_free(dup_chains[n]);
+    while (nx509refs-- > 0)
+        X509_free(x509);
+    while (npkeyrefs-- > 0)
+        EVP_PKEY_free(privatekey);
     EVP_PKEY_free(pubkey);
     return ret;
 }

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -553,6 +553,18 @@ static int add_provider_sigalgs(const OSSL_PARAM params[], void *data)
             goto err;
     }
 
+    p = OSSL_PARAM_locate_const(params, OSSL_CAPABILITY_TLS_SIGALG_KEYTYPE_GROUP);
+    if (p == NULL) {
+        sinf->keytype_group = NULL;
+    } else if (p->data_type != OSSL_PARAM_UTF8_STRING) {
+        goto err;
+    } else {
+        OPENSSL_free(sinf->keytype_group);
+        sinf->keytype_group = OPENSSL_strdup(p->data);
+        if (sinf->keytype_group == NULL)
+            goto err;
+    }
+
     /* Optional, not documented prior to 3.5 */
     sinf->mindtls = sinf->maxdtls = -1;
     p = OSSL_PARAM_locate_const(params, OSSL_CAPABILITY_TLS_SIGALG_MIN_DTLS);
@@ -673,6 +685,8 @@ err:
         sinf->keytype = NULL;
         OPENSSL_free(sinf->keytype_oid);
         sinf->keytype_oid = NULL;
+        OPENSSL_free(sinf->keytype_group);
+        sinf->keytype_group = NULL;
     }
     return ret;
 }
@@ -708,8 +722,17 @@ int ssl_load_sigalgs(SSL_CTX *ctx)
             return 0;
         for (i = 0; i < ctx->sigalg_list_len; i++) {
             const char *keytype = inferred_keytype(&ctx->sigalg_list[i]);
+            const char *group = ctx->sigalg_list[i].keytype_group;
+
             ctx->ssl_cert_info[i].pkey_nid = OBJ_txt2nid(keytype);
             ctx->ssl_cert_info[i].amask = SSL_aANY;
+            /*
+             * If the provider bound this sigalg to a group/parameter set,
+             * remember it so cert loading can disambiguate several schemes
+             * that share the same key type OID. NID_undef keeps the legacy
+             * first-match behaviour.
+             */
+            ctx->ssl_cert_info[i].group_nid = (group != NULL) ? OBJ_txt2nid(group) : NID_undef;
         }
     }
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -723,16 +723,32 @@ int ssl_load_sigalgs(SSL_CTX *ctx)
         for (i = 0; i < ctx->sigalg_list_len; i++) {
             const char *keytype = inferred_keytype(&ctx->sigalg_list[i]);
             const char *group = ctx->sigalg_list[i].keytype_group;
+            int pkey_nid = OBJ_txt2nid(keytype);
 
-            ctx->ssl_cert_info[i].pkey_nid = OBJ_txt2nid(keytype);
-            ctx->ssl_cert_info[i].amask = SSL_aANY;
+            ctx->ssl_cert_info[i].pkey_nid = pkey_nid;
             /*
-             * If the provider bound this sigalg to a group/parameter set,
-             * remember it so cert loading can disambiguate several schemes
-             * that share the same key type OID. NID_undef keeps the legacy
-             * first-match behaviour.
+             * Borrow the built-in slot's amask. SSL_aANY is zero, and every
+             * cert-vs-ciphersuite check is (amask & algorithm_auth) != 0, so
+             * leaving it zero rejects the slot everywhere below TLS 1.3.
              */
-            ctx->ssl_cert_info[i].group_nid = (group != NULL) ? OBJ_txt2nid(group) : NID_undef;
+            ctx->ssl_cert_info[i].amask = ssl_cert_builtin_amask_by_nid(pkey_nid);
+            /*
+             * Remember the group, if any, so cert loading can tell apart
+             * schemes sharing a key type OID. A name we can't resolve is an
+             * error: NID_undef means "any group", so accepting it would
+             * quietly make a grouped sigalg ungrouped.
+             */
+            ctx->ssl_cert_info[i].group_nid = NID_undef;
+            if (group != NULL) {
+                int group_nid = OBJ_txt2nid(group);
+
+                if (group_nid == NID_undef) {
+                    ERR_raise_data(ERR_LIB_SSL, SSL_R_UNSUPPORTED_CONFIG_VALUE,
+                        "unknown key-type-group \"%s\"", group);
+                    return 0;
+                }
+                ctx->ssl_cert_info[i].group_nid = group_nid;
+            }
         }
     }
 
@@ -2899,15 +2915,15 @@ int tls12_check_peer_sigalg(SSL_CONNECTION *s, uint16_t sig, EVP_PKEY *pkey)
         /*
          * Provider-defined sigalg: lu->sig is the NID of the combined
          * signature scheme while pkeyid is the key type NID, so the two can
-         * legitimately differ (for example the RFC 9367 GOST schemes).
-         * Instead check the key against the sigalg's own certificate slot.
-         * This also honours any group/parameter set binding of the slot, so
-         * a key whose parameter set does not match this sigalg is rejected.
+         * legitimately differ (for example the RFC 9367 GOST schemes). So
+         * ask whether the key fits this sigalg's slot instead of looking a
+         * slot up from the key, which would depend on lookup order. This
+         * also rejects a key whose paramset doesn't match the sigalg.
          */
-        const SSL_CERT_LOOKUP *scl = ssl_cert_lookup_by_pkey(pkey, &cidx,
+        const SSL_CERT_LOOKUP *scl = ssl_cert_lookup_by_idx(lu->sig_idx,
             SSL_CONNECTION_GET_CTX(s));
 
-        if (scl == NULL || lu->sig_idx != (int)cidx) {
+        if (scl == NULL || !ssl_cert_pkey_fits_slot(pkey, scl)) {
             SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_WRONG_SIGNATURE_TYPE);
             return 0;
         }

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2889,24 +2889,42 @@ int tls12_check_peer_sigalg(SSL_CONNECTION *s, uint16_t sig, EVP_PKEY *pkey)
         return -1;
     }
 
-    /*
-     * Check sigalgs is known. Disallow SHA1/SHA224 with TLS 1.3. Check key type
-     * is consistent with signature: RSA keys can be used for RSA-PSS
-     */
-    if ((SSL_CONNECTION_IS_TLS13(s)
-            && (lu->hash == NID_sha1 || lu->hash == NID_sha224))
-        || (pkeyid != lu->sig
-            && (lu->sig != EVP_PKEY_RSA_PSS || pkeyid != EVP_PKEY_RSA))) {
+    /* Check sigalgs is known. Disallow SHA1/SHA224 with TLS 1.3. */
+    if (SSL_CONNECTION_IS_TLS13(s)
+        && (lu->hash == NID_sha1 || lu->hash == NID_sha224)) {
         SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_WRONG_SIGNATURE_TYPE);
         return 0;
     }
-    /* Check the sigalg is consistent with the key OID */
-    if (!ssl_cert_lookup_by_nid(
-            (pkeyid == EVP_PKEY_RSA_PSS) ? EVP_PKEY_get_id(pkey) : pkeyid,
-            &cidx, SSL_CONNECTION_GET_CTX(s))
-        || lu->sig_idx != (int)cidx) {
-        SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_WRONG_SIGNATURE_TYPE);
-        return 0;
+    if (lu->sig_idx >= SSL_PKEY_NUM) {
+        /*
+         * Provider-defined sigalg: lu->sig is the NID of the combined
+         * signature scheme while pkeyid is the key type NID, so the two can
+         * legitimately differ (for example the RFC 9367 GOST schemes).
+         * Instead check the key against the sigalg's own certificate slot.
+         * This also honours any group/parameter set binding of the slot, so
+         * a key whose parameter set does not match this sigalg is rejected.
+         */
+        const SSL_CERT_LOOKUP *scl = ssl_cert_lookup_by_pkey(pkey, &cidx,
+            SSL_CONNECTION_GET_CTX(s));
+
+        if (scl == NULL || lu->sig_idx != (int)cidx) {
+            SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_WRONG_SIGNATURE_TYPE);
+            return 0;
+        }
+    } else {
+        if (pkeyid != lu->sig
+            && (lu->sig != EVP_PKEY_RSA_PSS || pkeyid != EVP_PKEY_RSA)) {
+            SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_WRONG_SIGNATURE_TYPE);
+            return 0;
+        }
+        /* Check the sigalg is consistent with the key OID */
+        if (!ssl_cert_lookup_by_nid(
+                (pkeyid == EVP_PKEY_RSA_PSS) ? EVP_PKEY_get_id(pkey) : pkeyid,
+                &cidx, SSL_CONNECTION_GET_CTX(s))
+            || lu->sig_idx != (int)cidx) {
+            SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_WRONG_SIGNATURE_TYPE);
+            return 0;
+        }
     }
 
     if (pkeyid == EVP_PKEY_EC) {

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -11667,6 +11667,159 @@ end:
 
     return testresult;
 }
+
+/*
+ * Like create_cert_key() but for the "xorhmacsig256" key type whose keys
+ * must be bound to a group/parameter set (RFC 9367 GOST style).
+ */
+static int create_cert_key_with_group(const char *group, char *certfilename,
+    char *privkeyfilename)
+{
+    EVP_PKEY_CTX *evpctx = EVP_PKEY_CTX_new_from_name(libctx,
+        "xorhmacsig256", NULL);
+    EVP_PKEY *pkey = NULL;
+    X509 *x509 = X509_new();
+    X509_NAME *name = NULL;
+    BIO *keybio = NULL, *certbio = NULL;
+    int ret = 1;
+
+    if (!TEST_ptr(evpctx)
+        || !TEST_int_gt(EVP_PKEY_keygen_init(evpctx), 0)
+        || !TEST_int_gt(EVP_PKEY_CTX_set_group_name(evpctx, group), 0)
+        || !TEST_true(EVP_PKEY_generate(evpctx, &pkey))
+        || !TEST_ptr(pkey)
+        || !TEST_ptr(x509)
+        || !TEST_true(ASN1_INTEGER_set(X509_get_serialNumber(x509), 1))
+        || !TEST_true(X509_gmtime_adj(X509_getm_notBefore(x509), 0))
+        || !TEST_true(X509_gmtime_adj(X509_getm_notAfter(x509), 31536000L))
+        || !TEST_true(X509_set_pubkey(x509, pkey))
+        || !TEST_ptr(name = X509_NAME_new())
+        || !TEST_true(X509_NAME_add_entry_by_txt(name, "C", MBSTRING_ASC,
+            (unsigned char *)"CH", -1, -1, 0))
+        || !TEST_true(X509_NAME_add_entry_by_txt(name, "O", MBSTRING_ASC,
+            (unsigned char *)"test.org", -1, -1, 0))
+        || !TEST_true(X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+            (unsigned char *)"localhost", -1, -1, 0))
+        || !TEST_true(X509_set_subject_name(x509, name))
+        || !TEST_true(X509_set_issuer_name(x509, name))
+        || !TEST_true(X509_sign(x509, pkey, EVP_sha1()))
+        || !TEST_ptr(keybio = BIO_new_file(privkeyfilename, "wb"))
+        || !TEST_true(PEM_write_bio_PrivateKey(keybio, pkey, NULL, NULL, 0, NULL, NULL))
+        || !TEST_ptr(certbio = BIO_new_file(certfilename, "wb"))
+        || !TEST_true(PEM_write_bio_X509(certbio, x509)))
+        ret = 0;
+
+    EVP_PKEY_free(pkey);
+    X509_free(x509);
+    X509_NAME_free(name);
+    EVP_PKEY_CTX_free(evpctx);
+    BIO_free(keybio);
+    BIO_free(certbio);
+    return ret;
+}
+
+/*
+ * Test the RFC 9367 GOST style setup where several provider signature
+ * schemes share a single key type OID and are told apart by the
+ * group/parameter set the key is bound to:
+ * - certificate/key loading must give each scheme its own certificate slot
+ *   (previously the second load would overwrite the first), and
+ * - a full TLS 1.3 handshake must select the certificate matching the
+ *   sigalg the client offered, sign CertificateVerify with it and have the
+ *   peer verify it.
+ * Test 0: client offers "xorhmacsig256a", expects the group-a certificate
+ * Test 1: client offers "xorhmacsig256b", expects the group-b certificate
+ */
+static int test_pluggable_sigalg_group_disambiguation(int idx)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    int testresult = 0;
+    OSSL_PROVIDER *tlsprov = OSSL_PROVIDER_load(libctx, "tls-provider");
+    OSSL_PROVIDER *defaultprov = OSSL_PROVIDER_load(libctx, "default");
+    char *certfilename_a = "tls-prov-cert256a.pem";
+    char *privkeyfilename_a = "tls-prov-key256a.pem";
+    char *certfilename_b = "tls-prov-cert256b.pem";
+    char *privkeyfilename_b = "tls-prov-key256b.pem";
+    const char *offered_sigalg = (idx == 0) ? "xorhmacsig256a"
+                                            : "xorhmacsig256b";
+    const char *expected_certfile = (idx == 0) ? certfilename_a
+                                               : certfilename_b;
+    const char *sigalg_name = NULL;
+    X509 *expected_cert = NULL;
+    X509 *peer_cert = NULL;
+
+    if (!TEST_ptr(tlsprov)
+        || !TEST_true(create_cert_key_with_group("xorgroup256a",
+            certfilename_a,
+            privkeyfilename_a))
+        || !TEST_true(create_cert_key_with_group("xorgroup256b",
+            certfilename_b,
+            privkeyfilename_b)))
+        goto end;
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(),
+            TLS1_3_VERSION,
+            TLS1_3_VERSION,
+            &sctx, &cctx, NULL, NULL)))
+        goto end;
+
+    if (!TEST_int_eq(SSL_CTX_use_certificate_file(sctx, certfilename_a,
+                         SSL_FILETYPE_PEM),
+            1)
+        || !TEST_int_eq(SSL_CTX_use_PrivateKey_file(sctx, privkeyfilename_a,
+                            SSL_FILETYPE_PEM),
+            1)
+        || !TEST_int_eq(SSL_CTX_check_private_key(sctx), 1))
+        goto end;
+
+    if (!TEST_int_eq(SSL_CTX_use_certificate_file(sctx, certfilename_b,
+                         SSL_FILETYPE_PEM),
+            1)
+        || !TEST_int_eq(SSL_CTX_use_PrivateKey_file(sctx, privkeyfilename_b,
+                            SSL_FILETYPE_PEM),
+            1)
+        || !TEST_int_eq(SSL_CTX_check_private_key(sctx), 1))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+            NULL, NULL)))
+        goto end;
+
+    /* This is necessary to pass minimal setup w/o other groups configured */
+    if (!TEST_true(SSL_set1_groups_list(serverssl, "xorgroup"))
+        || !TEST_true(SSL_set1_groups_list(clientssl, "xorgroup")))
+        goto end;
+
+    if (!TEST_true(SSL_set1_sigalgs_list(clientssl, offered_sigalg)))
+        goto end;
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
+        goto end;
+
+    if (!TEST_true(SSL_get0_peer_signature_name(clientssl, &sigalg_name))
+        || !TEST_str_eq(sigalg_name, offered_sigalg))
+        goto end;
+
+    if (!TEST_ptr(expected_cert = load_cert_pem(expected_certfile, libctx))
+        || !TEST_ptr(peer_cert = SSL_get0_peer_certificate(clientssl))
+        || !TEST_int_eq(X509_cmp(peer_cert, expected_cert), 0))
+        goto end;
+
+    testresult = 1;
+
+end:
+    X509_free(expected_cert);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    OSSL_PROVIDER_unload(tlsprov);
+    OSSL_PROVIDER_unload(defaultprov);
+
+    return testresult;
+}
 #endif
 
 #ifndef OPENSSL_NO_TLS1_2
@@ -15692,6 +15845,7 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_TLS1_3
     ADD_ALL_TESTS(test_pluggable_group, 2);
     ADD_ALL_TESTS(test_pluggable_signature, 6);
+    ADD_ALL_TESTS(test_pluggable_sigalg_group_disambiguation, 2);
 #endif
 #ifndef OPENSSL_NO_TLS1_2
     ADD_TEST(test_ssl_dup);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -60,6 +60,7 @@ int tls_provider_init(const OSSL_CORE_HANDLE *handle,
     const OSSL_DISPATCH *in,
     const OSSL_DISPATCH **out,
     void **provctx);
+void tls_provider_set_sigalg256b_group(const char *group);
 
 static OSSL_LIB_CTX *libctx = NULL;
 static OSSL_PROVIDER *defctxnull = NULL;
@@ -11669,14 +11670,14 @@ end:
 }
 
 /*
- * Like create_cert_key() but for the "xorhmacsig256" key type whose keys
- * must be bound to a group/parameter set (RFC 9367 GOST style).
+ * Like create_cert_key() but for the shared key type, whose keys carry a
+ * group (RFC 9367 GOST style). tls-provider registers it as gost2012_256.
  */
 static int create_cert_key_with_group(const char *group, char *certfilename,
     char *privkeyfilename)
 {
     EVP_PKEY_CTX *evpctx = EVP_PKEY_CTX_new_from_name(libctx,
-        "xorhmacsig256", NULL);
+        "gost2012_256", NULL);
     EVP_PKEY *pkey = NULL;
     X509 *x509 = X509_new();
     X509_NAME *name = NULL;
@@ -11748,6 +11749,9 @@ static int test_pluggable_sigalg_group_disambiguation(int idx)
     const char *sigalg_name = NULL;
     X509 *expected_cert = NULL;
     X509 *peer_cert = NULL;
+    X509 *last_loaded_cert = NULL;
+    X509 *first_slot_cert = NULL;
+    int nslots = 0;
 
     if (!TEST_ptr(tlsprov)
         || !TEST_true(create_cert_key_with_group("xorgroup256a",
@@ -11807,14 +11811,75 @@ static int test_pluggable_sigalg_group_disambiguation(int idx)
         || !TEST_int_eq(X509_cmp(peer_cert, expected_cert), 0))
         goto end;
 
+    /*
+     * This key type also has a built-in slot (SSL_PKEY_GOST12_256), and TLS
+     * 1.2 and below reach that slot by index. So loading should fill it as
+     * well as the two group slots: three in total.
+     */
+    while (SSL_CTX_set_current_cert(sctx,
+        nslots == 0 ? SSL_CERT_SET_FIRST : SSL_CERT_SET_NEXT)) {
+        if (nslots++ == 0)
+            first_slot_cert = SSL_CTX_get0_certificate(sctx);
+    }
+    if (!TEST_int_eq(nslots, 3))
+        goto end;
+
+    /*
+     * Built-in indices come before provider ones, so the walk starts at the
+     * built-in slot, which holds whichever cert was loaded last. Skip that
+     * slot and the walk would start at group a's instead.
+     */
+    if (!TEST_ptr(last_loaded_cert = load_cert_pem(certfilename_b, libctx))
+        || !TEST_ptr(first_slot_cert)
+        || !TEST_int_eq(X509_cmp(first_slot_cert, last_loaded_cert), 0))
+        goto end;
+
     testresult = 1;
 
 end:
+    X509_free(last_loaded_cert);
     X509_free(expected_cert);
     SSL_free(serverssl);
     SSL_free(clientssl);
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
+    OSSL_PROVIDER_unload(tlsprov);
+    OSSL_PROVIDER_unload(defaultprov);
+
+    return testresult;
+}
+
+/*
+ * A "key-type-group" we can't resolve must be rejected at sigalg load time,
+ * not quietly treated as NID_undef, which would mean "any group".
+ */
+static int test_pluggable_sigalg_bad_group(void)
+{
+    SSL_CTX *sctx = NULL;
+    int testresult = 0;
+    OSSL_PROVIDER *tlsprov = OSSL_PROVIDER_load(libctx, "tls-provider");
+    OSSL_PROVIDER *defaultprov = OSSL_PROVIDER_load(libctx, "default");
+
+    if (!TEST_ptr(tlsprov))
+        goto end;
+
+    /* With the real group name this works */
+    if (!TEST_ptr(sctx = SSL_CTX_new_ex(libctx, NULL, TLS_server_method())))
+        goto end;
+    SSL_CTX_free(sctx);
+    sctx = NULL;
+
+    tls_provider_set_sigalg256b_group("no-such-group-name");
+
+    sctx = SSL_CTX_new_ex(libctx, NULL, TLS_server_method());
+    if (!TEST_ptr_null(sctx))
+        goto end;
+
+    testresult = 1;
+
+end:
+    tls_provider_set_sigalg256b_group(NULL);
+    SSL_CTX_free(sctx);
     OSSL_PROVIDER_unload(tlsprov);
     OSSL_PROVIDER_unload(defaultprov);
 
@@ -15846,6 +15911,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_pluggable_group, 2);
     ADD_ALL_TESTS(test_pluggable_signature, 6);
     ADD_ALL_TESTS(test_pluggable_sigalg_group_disambiguation, 2);
+    ADD_TEST(test_pluggable_sigalg_bad_group);
 #endif
 #ifndef OPENSSL_NO_TLS1_2
     ADD_TEST(test_ssl_dup);

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -79,6 +79,12 @@ typedef struct xorkey_st {
     int hasprivkey;
     int haspubkey;
     char *tls_name;
+    /*
+     * Optional group/parameter set the key is bound to. Only used by the
+     * XORSIGALG256_KEYTYPE_NAME key type, whose sigalgs share one key type
+     * OID and are distinguished by this group, RFC 9367 GOST style.
+     */
+    char *group_name;
     CRYPTO_REF_COUNT references;
 } XORKEY;
 
@@ -295,6 +301,23 @@ struct tls_sigalg_st {
 #define XORSIGALG_HASH_OID "1.3.6.1.4.1.16604.998888.2"
 #define XORSIGALG12_NAME "xorhmacsig12"
 #define XORSIGALG12_OID "1.3.6.1.4.1.16604.998888.3"
+/*
+ * Two additional signature schemes that share a single key type, in the
+ * style of the RFC 9367 GOST schemes: the key type OID is the same for both
+ * and the schemes are told apart by the group/parameter set the key is
+ * bound to. The group OID is carried in the AlgorithmIdentifier parameters
+ * of encoded keys, like the GOST paramset.
+ */
+#define XORSIGALG256_KEYTYPE_NAME "xorhmacsig256"
+#define XORSIGALG256_KEYTYPE_OID "1.3.6.1.4.1.16604.998888.4"
+#define XORSIGALG256A_NAME "xorhmacsig256a"
+#define XORSIGALG256A_OID "1.3.6.1.4.1.16604.998888.5"
+#define XORSIGALG256B_NAME "xorhmacsig256b"
+#define XORSIGALG256B_OID "1.3.6.1.4.1.16604.998888.6"
+#define XORGROUP256A_NAME "xorgroup256a"
+#define XORGROUP256A_OID "1.3.6.1.4.1.16604.998888.7"
+#define XORGROUP256B_NAME "xorgroup256b"
+#define XORGROUP256B_OID "1.3.6.1.4.1.16604.998888.8"
 
 static struct tls_sigalg_st xor_sigalg = {
     0, /* alg id, set by randomize_tls_alg_id() */
@@ -315,6 +338,20 @@ static struct tls_sigalg_st xor_sigalg12 = {
     128, /* secbits */
     TLS1_2_VERSION, /* mintls */
     TLS1_2_VERSION, /* maxtls */
+};
+
+static struct tls_sigalg_st xor_sigalg256a = {
+    0, /* alg id, set by randomize_tls_alg_id() */
+    128, /* secbits */
+    TLS1_3_VERSION, /* mintls */
+    0, /* maxtls */
+};
+
+static struct tls_sigalg_st xor_sigalg256b = {
+    0, /* alg id, set by randomize_tls_alg_id() */
+    128, /* secbits */
+    TLS1_3_VERSION, /* mintls */
+    0, /* maxtls */
 };
 
 static const OSSL_PARAM xor_sig_nohash_params[] = {
@@ -376,6 +413,60 @@ static const OSSL_PARAM xor_sig_12_params[] = {
     OSSL_PARAM_END
 };
 
+static const OSSL_PARAM xor_sig_256a_params[] = {
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_IANA_NAME,
+        XORSIGALG256A_NAME, sizeof(XORSIGALG256A_NAME)),
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_NAME,
+        XORSIGALG256A_NAME,
+        sizeof(XORSIGALG256A_NAME)),
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_OID,
+        XORSIGALG256A_OID, sizeof(XORSIGALG256A_OID)),
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_KEYTYPE,
+        XORSIGALG256_KEYTYPE_NAME,
+        sizeof(XORSIGALG256_KEYTYPE_NAME)),
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_KEYTYPE_OID,
+        XORSIGALG256_KEYTYPE_OID,
+        sizeof(XORSIGALG256_KEYTYPE_OID)),
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_KEYTYPE_GROUP,
+        XORGROUP256A_NAME, sizeof(XORGROUP256A_NAME)),
+    OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_SIGALG_CODE_POINT,
+        &xor_sigalg256a.code_point),
+    OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_SIGALG_SECURITY_BITS,
+        &xor_sigalg256a.secbits),
+    OSSL_PARAM_int(OSSL_CAPABILITY_TLS_SIGALG_MIN_TLS,
+        &xor_sigalg256a.mintls),
+    OSSL_PARAM_int(OSSL_CAPABILITY_TLS_SIGALG_MAX_TLS,
+        &xor_sigalg256a.maxtls),
+    OSSL_PARAM_END
+};
+
+static const OSSL_PARAM xor_sig_256b_params[] = {
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_IANA_NAME,
+        XORSIGALG256B_NAME, sizeof(XORSIGALG256B_NAME)),
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_NAME,
+        XORSIGALG256B_NAME,
+        sizeof(XORSIGALG256B_NAME)),
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_OID,
+        XORSIGALG256B_OID, sizeof(XORSIGALG256B_OID)),
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_KEYTYPE,
+        XORSIGALG256_KEYTYPE_NAME,
+        sizeof(XORSIGALG256_KEYTYPE_NAME)),
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_KEYTYPE_OID,
+        XORSIGALG256_KEYTYPE_OID,
+        sizeof(XORSIGALG256_KEYTYPE_OID)),
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_KEYTYPE_GROUP,
+        XORGROUP256B_NAME, sizeof(XORGROUP256B_NAME)),
+    OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_SIGALG_CODE_POINT,
+        &xor_sigalg256b.code_point),
+    OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_SIGALG_SECURITY_BITS,
+        &xor_sigalg256b.secbits),
+    OSSL_PARAM_int(OSSL_CAPABILITY_TLS_SIGALG_MIN_TLS,
+        &xor_sigalg256b.mintls),
+    OSSL_PARAM_int(OSSL_CAPABILITY_TLS_SIGALG_MAX_TLS,
+        &xor_sigalg256b.maxtls),
+    OSSL_PARAM_END
+};
+
 static int tls_prov_get_capabilities(void *provctx, const char *capability,
     OSSL_CALLBACK *cb, void *arg)
 {
@@ -425,6 +516,8 @@ static int tls_prov_get_capabilities(void *provctx, const char *capability,
         ret = cb(xor_sig_nohash_params, arg);
         ret &= cb(xor_sig_hash_params, arg);
         ret &= cb(xor_sig_12_params, arg);
+        ret &= cb(xor_sig_256a_params, arg);
+        ret &= cb(xor_sig_256b_params, arg);
     }
     return ret;
 }
@@ -717,6 +810,8 @@ static void xor_freekey(void *keydata)
 
     OPENSSL_free(key->tls_name);
     key->tls_name = NULL;
+    OPENSSL_free(key->group_name);
+    key->group_name = NULL;
     CRYPTO_FREE_REF(&key->references);
     OPENSSL_free(key);
 }
@@ -775,6 +870,8 @@ static void *xor_dup(const void *vfromkey, int selection)
         }
         if (fromkey->tls_name != NULL)
             tokey->tls_name = OPENSSL_strdup(fromkey->tls_name);
+        if (fromkey->group_name != NULL)
+            tokey->group_name = OPENSSL_strdup(fromkey->group_name);
     }
     if (!ok) {
         xor_freekey(tokey);
@@ -806,6 +903,11 @@ static ossl_inline int xor_get_params(void *vkey, OSSL_PARAM params[])
             memcpy(p->data, key->pubkey, XOR_KEY_SIZE);
     }
 
+    if (key->group_name != NULL
+        && (p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_GROUP_NAME)) != NULL
+        && !OSSL_PARAM_set_utf8_string(p, key->group_name))
+        return 0;
+
     return 1;
 }
 
@@ -813,6 +915,7 @@ static const OSSL_PARAM xor_params[] = {
     OSSL_PARAM_int(OSSL_PKEY_PARAM_BITS, NULL),
     OSSL_PARAM_int(OSSL_PKEY_PARAM_SECURITY_BITS, NULL),
     OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, NULL, 0),
     OSSL_PARAM_END
 };
 
@@ -917,6 +1020,8 @@ static const OSSL_PARAM *xor_settable_params(void *provctx)
 struct xor_gen_ctx {
     int selection;
     OSSL_LIB_CTX *libctx;
+    /* group/parameter set for XORSIGALG256_KEYTYPE_NAME keygen */
+    char group_name[64];
 };
 
 static void *xor_gen_init(void *provctx, int selection,
@@ -950,10 +1055,16 @@ static int xor_gen_set_params(void *genctx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_GROUP_NAME);
     if (p != NULL) {
-        if (p->data_type != OSSL_PARAM_UTF8_STRING
-            || (strcmp(p->data, XORGROUP_NAME_INTERNAL) != 0
-                && strcmp(p->data, XORKEMGROUP_NAME_INTERNAL) != 0))
+        if (p->data_type != OSSL_PARAM_UTF8_STRING)
             return 0;
+        if (strcmp(p->data, XORGROUP256A_NAME) == 0
+            || strcmp(p->data, XORGROUP256B_NAME) == 0) {
+            OPENSSL_strlcpy(gctx->group_name, p->data,
+                sizeof(gctx->group_name));
+        } else if (strcmp(p->data, XORGROUP_NAME_INTERNAL) != 0
+            && strcmp(p->data, XORKEMGROUP_NAME_INTERNAL) != 0) {
+            return 0;
+        }
     }
 
     return 1;
@@ -1142,6 +1253,31 @@ static void *xor_xorhmacsha2sig_gen(void *genctx, OSSL_CALLBACK *osslcb, void *c
     return k;
 }
 
+static void *xor_xorhmacsig256_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
+{
+    struct xor_gen_ctx *gctx = genctx;
+    XORKEY *k;
+
+    /*
+     * The group/parameter set is mandatory for this key type, like the
+     * paramset is for GOST keys: without it the key cannot be bound to
+     * one of the sigalgs sharing the key type.
+     */
+    if (gctx == NULL || gctx->group_name[0] == '\0')
+        return NULL;
+
+    k = xor_gen(genctx, osslcb, cbarg);
+    if (k == NULL)
+        return NULL;
+    k->tls_name = OPENSSL_strdup(XORSIGALG256_KEYTYPE_NAME);
+    k->group_name = OPENSSL_strdup(gctx->group_name);
+    if (k->tls_name == NULL || k->group_name == NULL) {
+        xor_freekey(k);
+        return NULL;
+    }
+    return k;
+}
+
 static const OSSL_DISPATCH xor_xorhmacsig_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))xor_newkey },
     { OSSL_FUNC_KEYMGMT_GEN_INIT, (void (*)(void))xor_gen_init },
@@ -1190,6 +1326,30 @@ static const OSSL_DISPATCH xor_xorhmacsha2sig_keymgmt_functions[] = {
     OSSL_DISPATCH_END
 };
 
+static const OSSL_DISPATCH xor_xorhmacsig256_keymgmt_functions[] = {
+    { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))xor_newkey },
+    { OSSL_FUNC_KEYMGMT_GEN_INIT, (void (*)(void))xor_gen_init },
+    { OSSL_FUNC_KEYMGMT_GEN_SET_PARAMS, (void (*)(void))xor_gen_set_params },
+    { OSSL_FUNC_KEYMGMT_GEN_SETTABLE_PARAMS,
+        (void (*)(void))xor_gen_settable_params },
+    { OSSL_FUNC_KEYMGMT_GEN, (void (*)(void))xor_xorhmacsig256_gen },
+    { OSSL_FUNC_KEYMGMT_GEN_CLEANUP, (void (*)(void))xor_gen_cleanup },
+    { OSSL_FUNC_KEYMGMT_GET_PARAMS, (void (*)(void))xor_get_params },
+    { OSSL_FUNC_KEYMGMT_GETTABLE_PARAMS, (void (*)(void))xor_gettable_params },
+    { OSSL_FUNC_KEYMGMT_SET_PARAMS, (void (*)(void))xor_set_params },
+    { OSSL_FUNC_KEYMGMT_SETTABLE_PARAMS, (void (*)(void))xor_settable_params },
+    { OSSL_FUNC_KEYMGMT_HAS, (void (*)(void))xor_has },
+    { OSSL_FUNC_KEYMGMT_DUP, (void (*)(void))xor_dup },
+    { OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))xor_freekey },
+    { OSSL_FUNC_KEYMGMT_IMPORT, (void (*)(void))xor_import },
+    { OSSL_FUNC_KEYMGMT_IMPORT_TYPES, (void (*)(void))xor_import_types },
+    { OSSL_FUNC_KEYMGMT_EXPORT, (void (*)(void))xor_export },
+    { OSSL_FUNC_KEYMGMT_EXPORT_TYPES, (void (*)(void))xor_export_types },
+    { OSSL_FUNC_KEYMGMT_LOAD, (void (*)(void))xor_load },
+    { OSSL_FUNC_KEYMGMT_MATCH, (void (*)(void))xor_match },
+    OSSL_DISPATCH_END
+};
+
 typedef enum {
     KEY_OP_PUBLIC,
     KEY_OP_PRIVATE,
@@ -1204,13 +1364,24 @@ static XORKEY *xor_key_op(const X509_ALGOR *palg,
 {
     XORKEY *key = NULL;
     int nid = NID_undef;
+    int group_nid = NID_undef;
 
     if (palg != NULL) {
         int ptype;
+        const void *pval;
 
-        /* Algorithm parameters must be absent */
-        X509_ALGOR_get0(NULL, &ptype, NULL, palg);
-        if (ptype != V_ASN1_UNDEF || palg->algorithm == NULL) {
+        /*
+         * Algorithm parameters must either be absent, or carry the OID of
+         * the group/parameter set the key is bound to (GOST paramset style).
+         */
+        X509_ALGOR_get0(NULL, &ptype, &pval, palg);
+        if (ptype == V_ASN1_OBJECT) {
+            group_nid = OBJ_obj2nid((const ASN1_OBJECT *)pval);
+            if (group_nid == NID_undef) {
+                ERR_raise(ERR_LIB_USER, XORPROV_R_INVALID_ENCODING);
+                return 0;
+            }
+        } else if (ptype != V_ASN1_UNDEF || palg->algorithm == NULL) {
             ERR_raise(ERR_LIB_USER, XORPROV_R_INVALID_ENCODING);
             return 0;
         }
@@ -1244,6 +1415,12 @@ static XORKEY *xor_key_op(const X509_ALGOR *palg,
     key->tls_name = OPENSSL_strdup(OBJ_nid2sn(nid));
     if (key->tls_name == NULL)
         goto err;
+
+    if (group_nid != NID_undef) {
+        key->group_name = OPENSSL_strdup(OBJ_nid2sn(group_nid));
+        if (key->group_name == NULL)
+            goto err;
+    }
     return key;
 
 err:
@@ -1303,6 +1480,9 @@ static const OSSL_ALGORITHM tls_prov_keymgmt[] = {
     { XORSIGALG_HASH_NAME,
         "provider=tls-provider,fips=yes",
         xor_xorhmacsha2sig_keymgmt_functions },
+    { XORSIGALG256_KEYTYPE_NAME,
+        "provider=tls-provider,fips=yes",
+        xor_xorhmacsig256_keymgmt_functions },
     { NULL, NULL, NULL }
 };
 
@@ -1356,7 +1536,7 @@ static PKCS8_PRIV_KEY_INFO *key_to_p8info(const void *key, int key_nid,
     if ((p8info = PKCS8_PRIV_KEY_INFO_new()) == NULL
         || (derlen = k2d(key, &der)) <= 0
         || !PKCS8_pkey_set0(p8info, OBJ_nid2obj(key_nid), 0,
-            V_ASN1_UNDEF, NULL,
+            params_type, params,
             der, derlen)) {
         ERR_raise(ERR_LIB_USER, ERR_R_MALLOC_FAILURE);
         PKCS8_PRIV_KEY_INFO_free(p8info);
@@ -1418,7 +1598,7 @@ static X509_PUBKEY *xorx_key_to_pubkey(const void *key, int key_nid,
     if ((xpk = X509_PUBKEY_new()) == NULL
         || (derlen = k2d(key, &der)) <= 0
         || !X509_PUBKEY_set0_param(xpk, OBJ_nid2obj(key_nid),
-            V_ASN1_UNDEF, NULL,
+            params_type, params,
             der, derlen)) {
         ERR_raise(ERR_LIB_USER, ERR_R_MALLOC_FAILURE);
         X509_PUBKEY_free(xpk);
@@ -1633,16 +1813,25 @@ static int prepare_xorx_params(const void *xorxkey, int nid, int save,
         return 0;
     }
 
-    params = OBJ_nid2obj(nid);
-
-    if (params == NULL || OBJ_length(params) == 0) {
-        /* unexpected error */
-        ERR_raise(ERR_LIB_USER, XORPROV_R_MISSING_OID);
-        ASN1_OBJECT_free(params);
-        return 0;
+    /*
+     * Keys bound to a group/parameter set carry the group OID in the
+     * AlgorithmIdentifier parameters, like GOST keys carry their paramset.
+     * All other keys use absent parameters as before.
+     */
+    if (k->group_name != NULL) {
+        params = OBJ_txt2obj(k->group_name, 0);
+        if (params == NULL || OBJ_length(params) == 0) {
+            ERR_raise(ERR_LIB_USER, XORPROV_R_MISSING_OID);
+            ASN1_OBJECT_free(params);
+            return 0;
+        }
+        *pstr = params;
+        *pstrtype = V_ASN1_OBJECT;
+        return 1;
     }
-    *pstr = params;
-    *pstrtype = V_ASN1_OBJECT;
+
+    *pstr = NULL;
+    *pstrtype = V_ASN1_UNDEF;
     return 1;
 }
 
@@ -1711,6 +1900,9 @@ static int xorx_pki_priv_to_der(const void *vecxkey, unsigned char **pder)
 #define xorhmacsha2sig_evp_type 0
 #define xorhmacsha2sig_input_type XORSIGALG_HASH_NAME
 #define xorhmacsha2sig_pem_type XORSIGALG_HASH_NAME
+#define xorhmacsig256_evp_type 0
+#define xorhmacsig256_input_type XORSIGALG256_KEYTYPE_NAME
+#define xorhmacsig256_pem_type XORSIGALG256_KEYTYPE_NAME
 
 /* ---------------------------------------------------------------------- */
 
@@ -2027,6 +2219,12 @@ MAKE_ENCODER(xorhmacsha2sig, xorx, PrivateKeyInfo, der);
 MAKE_ENCODER(xorhmacsha2sig, xorx, PrivateKeyInfo, pem);
 MAKE_ENCODER(xorhmacsha2sig, xorx, SubjectPublicKeyInfo, der);
 MAKE_ENCODER(xorhmacsha2sig, xorx, SubjectPublicKeyInfo, pem);
+MAKE_ENCODER(xorhmacsig256, xorx, EncryptedPrivateKeyInfo, der);
+MAKE_ENCODER(xorhmacsig256, xorx, EncryptedPrivateKeyInfo, pem);
+MAKE_ENCODER(xorhmacsig256, xorx, PrivateKeyInfo, der);
+MAKE_ENCODER(xorhmacsig256, xorx, PrivateKeyInfo, pem);
+MAKE_ENCODER(xorhmacsig256, xorx, SubjectPublicKeyInfo, der);
+MAKE_ENCODER(xorhmacsig256, xorx, SubjectPublicKeyInfo, pem);
 
 static const OSSL_ALGORITHM tls_prov_encoder[] = {
 #define ENCODER_PROVIDER "tls-provider"
@@ -2090,6 +2288,18 @@ static const OSSL_ALGORITHM tls_prov_encoder[] = {
     ENCODER_w_structure(XORSIGALG_HASH_NAME, xorhmacsha2sig,
         der, SubjectPublicKeyInfo),
     ENCODER_w_structure(XORSIGALG_HASH_NAME, xorhmacsha2sig,
+        pem, SubjectPublicKeyInfo),
+    ENCODER_w_structure(XORSIGALG256_KEYTYPE_NAME, xorhmacsig256,
+        der, PrivateKeyInfo),
+    ENCODER_w_structure(XORSIGALG256_KEYTYPE_NAME, xorhmacsig256,
+        pem, PrivateKeyInfo),
+    ENCODER_w_structure(XORSIGALG256_KEYTYPE_NAME, xorhmacsig256,
+        der, EncryptedPrivateKeyInfo),
+    ENCODER_w_structure(XORSIGALG256_KEYTYPE_NAME, xorhmacsig256,
+        pem, EncryptedPrivateKeyInfo),
+    ENCODER_w_structure(XORSIGALG256_KEYTYPE_NAME, xorhmacsig256,
+        der, SubjectPublicKeyInfo),
+    ENCODER_w_structure(XORSIGALG256_KEYTYPE_NAME, xorhmacsig256,
         pem, SubjectPublicKeyInfo),
 #undef ENCODER_PROVIDER
     { NULL, NULL, NULL }
@@ -2534,6 +2744,8 @@ MAKE_DECODER(XORSIGALG_NAME, xorhmacsig, xor, PrivateKeyInfo);
 MAKE_DECODER(XORSIGALG_NAME, xorhmacsig, xor, SubjectPublicKeyInfo);
 MAKE_DECODER(XORSIGALG_HASH_NAME, xorhmacsha2sig, xor, PrivateKeyInfo);
 MAKE_DECODER(XORSIGALG_HASH_NAME, xorhmacsha2sig, xor, SubjectPublicKeyInfo);
+MAKE_DECODER(XORSIGALG256_KEYTYPE_NAME, xorhmacsig256, xor, PrivateKeyInfo);
+MAKE_DECODER(XORSIGALG256_KEYTYPE_NAME, xorhmacsig256, xor, SubjectPublicKeyInfo);
 
 static const OSSL_ALGORITHM tls_prov_decoder[] = {
 #define DECODER_PROVIDER "tls-provider"
@@ -2560,6 +2772,8 @@ static const OSSL_ALGORITHM tls_prov_decoder[] = {
     DECODER_w_structure(XORSIGALG_NAME, der, SubjectPublicKeyInfo, xorhmacsig),
     DECODER_w_structure(XORSIGALG_HASH_NAME, der, PrivateKeyInfo, xorhmacsha2sig),
     DECODER_w_structure(XORSIGALG_HASH_NAME, der, SubjectPublicKeyInfo, xorhmacsha2sig),
+    DECODER_w_structure(XORSIGALG256_KEYTYPE_NAME, der, PrivateKeyInfo, xorhmacsig256),
+    DECODER_w_structure(XORSIGALG256_KEYTYPE_NAME, der, SubjectPublicKeyInfo, xorhmacsig256),
 #undef DECODER_PROVIDER
     { NULL, NULL, NULL }
 };
@@ -3111,6 +3325,14 @@ static const OSSL_ALGORITHM tls_prov_signature[] = {
         xor_signature_functions },
     { XORSIGALG12_NAME, "provider=tls-provider,fips=yes",
         xor_signature_functions },
+    /*
+     * The two RFC 9367 style sigalgs share one implementation, which is
+     * also reachable under the common key type name so that certificate
+     * signing via X509_sign() can fetch it.
+     */
+    { XORSIGALG256_KEYTYPE_NAME ":" XORSIGALG256A_NAME ":" XORSIGALG256B_NAME,
+        "provider=tls-provider,fips=yes",
+        xor_signature_functions },
     { NULL, NULL, NULL }
 };
 
@@ -3213,6 +3435,8 @@ int tls_provider_init(const OSSL_CORE_HANDLE *handle,
     xor_kemgroup.group_id = randomize_tls_alg_id(libctx);
     xor_sigalg.code_point = randomize_tls_alg_id(libctx);
     xor_sigalg_hash.code_point = randomize_tls_alg_id(libctx);
+    xor_sigalg256a.code_point = randomize_tls_alg_id(libctx);
+    xor_sigalg256b.code_point = randomize_tls_alg_id(libctx);
 
     /* Retrieve registration functions */
     for (; in->function_id != 0; in++) {
@@ -3254,6 +3478,26 @@ int tls_provider_init(const OSSL_CORE_HANDLE *handle,
     }
 
     if (!c_obj_add_sigid(handle, XORSIGALG_HASH_OID, XORSIGALG_HASH, XORSIGALG_HASH_OID)) {
+        ERR_raise(ERR_LIB_USER, XORPROV_R_OBJ_CREATE_ERR);
+        goto err;
+    }
+
+    /*
+     * RFC 9367 style setup: one key type OID shared by two sigalgs, plus
+     * an OID for each group/parameter set a key can be bound to.
+     */
+    if (!c_obj_create(handle, XORSIGALG256_KEYTYPE_OID,
+            XORSIGALG256_KEYTYPE_NAME, XORSIGALG256_KEYTYPE_NAME)
+        || !c_obj_create(handle, XORSIGALG256A_OID, XORSIGALG256A_NAME, NULL)
+        || !c_obj_create(handle, XORSIGALG256B_OID, XORSIGALG256B_NAME, NULL)
+        || !c_obj_create(handle, XORGROUP256A_OID, XORGROUP256A_NAME, NULL)
+        || !c_obj_create(handle, XORGROUP256B_OID, XORGROUP256B_NAME, NULL)) {
+        ERR_raise(ERR_LIB_USER, XORPROV_R_OBJ_CREATE_ERR);
+        goto err;
+    }
+
+    if (!c_obj_add_sigid(handle, XORSIGALG256_KEYTYPE_OID, "",
+            XORSIGALG256_KEYTYPE_OID)) {
         ERR_raise(ERR_LIB_USER, XORPROV_R_OBJ_CREATE_ERR);
         goto err;
     }

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -58,6 +58,7 @@ int tls_provider_init(const OSSL_CORE_HANDLE *handle,
     const OSSL_DISPATCH *in,
     const OSSL_DISPATCH **out,
     void **provctx);
+void tls_provider_set_sigalg256b_group(const char *group);
 
 #define XOR_KEY_SIZE 32
 
@@ -307,9 +308,22 @@ struct tls_sigalg_st {
  * and the schemes are told apart by the group/parameter set the key is
  * bound to. The group OID is carried in the AlgorithmIdentifier parameters
  * of encoded keys, like the GOST paramset.
+ *
+ * We borrow the real GOST 2012-256 key type name and OID on purpose: that
+ * NID has a built-in cert slot, so these keys collide with the built-in
+ * table the way real RFC 9367 keys do. A made-up key type matches no
+ * built-in slot and so can't show the problem at all. Nothing else claims
+ * this key type here, as GOST itself lives in an external provider.
  */
-#define XORSIGALG256_KEYTYPE_NAME "xorhmacsig256"
-#define XORSIGALG256_KEYTYPE_OID "1.3.6.1.4.1.16604.998888.4"
+#define XORSIGALG256_KEYTYPE_NAME "gost2012_256"
+#define XORSIGALG256_KEYTYPE_OID "1.2.643.7.1.1.1.1"
+/*
+ * libcrypto already knows this OID, so lookups can come in under any of its
+ * names - X509_PUBKEY decoding uses the long one. Register all three.
+ */
+#define XORSIGALG256_KEYTYPE_LONG_NAME "GOST R 34.10-2012 with 256 bit modulus"
+#define XORSIGALG256_KEYTYPE_NAMES \
+    XORSIGALG256_KEYTYPE_LONG_NAME ":" XORSIGALG256_KEYTYPE_NAME ":" XORSIGALG256_KEYTYPE_OID
 #define XORSIGALG256A_NAME "xorhmacsig256a"
 #define XORSIGALG256A_OID "1.3.6.1.4.1.16604.998888.5"
 #define XORSIGALG256B_NAME "xorhmacsig256b"
@@ -353,6 +367,20 @@ static struct tls_sigalg_st xor_sigalg256b = {
     TLS1_3_VERSION, /* mintls */
     0, /* maxtls */
 };
+
+/*
+ * The group we advertise for XORSIGALG256B_NAME. Mutable so a test can point
+ * it at a bogus name. Pass NULL to the setter to put it back.
+ */
+static char xor_sigalg256b_group[64] = XORGROUP256B_NAME;
+
+void tls_provider_set_sigalg256b_group(const char *group)
+{
+    if (group == NULL)
+        group = XORGROUP256B_NAME;
+    OPENSSL_strlcpy(xor_sigalg256b_group, group,
+        sizeof(xor_sigalg256b_group));
+}
 
 static const OSSL_PARAM xor_sig_nohash_params[] = {
     OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_IANA_NAME,
@@ -455,7 +483,7 @@ static const OSSL_PARAM xor_sig_256b_params[] = {
         XORSIGALG256_KEYTYPE_OID,
         sizeof(XORSIGALG256_KEYTYPE_OID)),
     OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_KEYTYPE_GROUP,
-        XORGROUP256B_NAME, sizeof(XORGROUP256B_NAME)),
+        xor_sigalg256b_group, sizeof(xor_sigalg256b_group)),
     OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_SIGALG_CODE_POINT,
         &xor_sigalg256b.code_point),
     OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_SIGALG_SECURITY_BITS,
@@ -1480,7 +1508,7 @@ static const OSSL_ALGORITHM tls_prov_keymgmt[] = {
     { XORSIGALG_HASH_NAME,
         "provider=tls-provider,fips=yes",
         xor_xorhmacsha2sig_keymgmt_functions },
-    { XORSIGALG256_KEYTYPE_NAME,
+    { XORSIGALG256_KEYTYPE_NAMES,
         "provider=tls-provider,fips=yes",
         xor_xorhmacsig256_keymgmt_functions },
     { NULL, NULL, NULL }
@@ -2289,17 +2317,17 @@ static const OSSL_ALGORITHM tls_prov_encoder[] = {
         der, SubjectPublicKeyInfo),
     ENCODER_w_structure(XORSIGALG_HASH_NAME, xorhmacsha2sig,
         pem, SubjectPublicKeyInfo),
-    ENCODER_w_structure(XORSIGALG256_KEYTYPE_NAME, xorhmacsig256,
+    ENCODER_w_structure(XORSIGALG256_KEYTYPE_NAMES, xorhmacsig256,
         der, PrivateKeyInfo),
-    ENCODER_w_structure(XORSIGALG256_KEYTYPE_NAME, xorhmacsig256,
+    ENCODER_w_structure(XORSIGALG256_KEYTYPE_NAMES, xorhmacsig256,
         pem, PrivateKeyInfo),
-    ENCODER_w_structure(XORSIGALG256_KEYTYPE_NAME, xorhmacsig256,
+    ENCODER_w_structure(XORSIGALG256_KEYTYPE_NAMES, xorhmacsig256,
         der, EncryptedPrivateKeyInfo),
-    ENCODER_w_structure(XORSIGALG256_KEYTYPE_NAME, xorhmacsig256,
+    ENCODER_w_structure(XORSIGALG256_KEYTYPE_NAMES, xorhmacsig256,
         pem, EncryptedPrivateKeyInfo),
-    ENCODER_w_structure(XORSIGALG256_KEYTYPE_NAME, xorhmacsig256,
+    ENCODER_w_structure(XORSIGALG256_KEYTYPE_NAMES, xorhmacsig256,
         der, SubjectPublicKeyInfo),
-    ENCODER_w_structure(XORSIGALG256_KEYTYPE_NAME, xorhmacsig256,
+    ENCODER_w_structure(XORSIGALG256_KEYTYPE_NAMES, xorhmacsig256,
         pem, SubjectPublicKeyInfo),
 #undef ENCODER_PROVIDER
     { NULL, NULL, NULL }
@@ -2772,8 +2800,8 @@ static const OSSL_ALGORITHM tls_prov_decoder[] = {
     DECODER_w_structure(XORSIGALG_NAME, der, SubjectPublicKeyInfo, xorhmacsig),
     DECODER_w_structure(XORSIGALG_HASH_NAME, der, PrivateKeyInfo, xorhmacsha2sig),
     DECODER_w_structure(XORSIGALG_HASH_NAME, der, SubjectPublicKeyInfo, xorhmacsha2sig),
-    DECODER_w_structure(XORSIGALG256_KEYTYPE_NAME, der, PrivateKeyInfo, xorhmacsig256),
-    DECODER_w_structure(XORSIGALG256_KEYTYPE_NAME, der, SubjectPublicKeyInfo, xorhmacsig256),
+    DECODER_w_structure(XORSIGALG256_KEYTYPE_NAMES, der, PrivateKeyInfo, xorhmacsig256),
+    DECODER_w_structure(XORSIGALG256_KEYTYPE_NAMES, der, SubjectPublicKeyInfo, xorhmacsig256),
 #undef DECODER_PROVIDER
     { NULL, NULL, NULL }
 };

--- a/util/perl/OpenSSL/paramnames.pm
+++ b/util/perl/OpenSSL/paramnames.pm
@@ -596,6 +596,7 @@ my %params = (
     'OSSL_CAPABILITY_TLS_SIGALG_HASH_NAME' =>         "tls-sigalg-hash-name",
     'OSSL_CAPABILITY_TLS_SIGALG_HASH_OID' =>          "tls-sigalg-hash-oid",
     'OSSL_CAPABILITY_TLS_SIGALG_KEYTYPE' =>           "tls-sigalg-keytype",
+    'OSSL_CAPABILITY_TLS_SIGALG_KEYTYPE_GROUP' =>     "tls-sigalg-keytype-group",
     'OSSL_CAPABILITY_TLS_SIGALG_KEYTYPE_OID' =>       "tls-sigalg-keytype-oid",
     'OSSL_CAPABILITY_TLS_SIGALG_SECURITY_BITS' =>     "tls-sigalg-sec-bits",
     'OSSL_CAPABILITY_TLS_SIGALG_MIN_TLS' =>           "tls-min-tls",


### PR DESCRIPTION
This is a proof of concept for the cert slot collision described in #31330 where multiple TLS 1.3 signature schemes share a single key type OID. It keeps one keymgmt name per real key type so the X.509 and CMS paths stay untouched and adds a second lookup dimension in the TLS layer based on the EC group or parameter set that the key already carries. A new optional capability tls-sigalg-keytype-group lets a provider state which group a scheme uses, and ssl_cert_lookup_by_pkey uses it to route certificates to distinct slots with a fallback to the existing behaviour when no group is reported. I am opening this to get a direction call from the maintainers on whether this group based approach in the TLS layer is preferred over the X.509 verification rework before I extend it with the GOST provider side, docs, and tests.