### PR TITLE
cms: reject Ed448 signedAttrs when digest is unavailable

### DIFF
--- a/crypto/asn1/x_algor.c
+++ b/crypto/asn1/x_algor.c
@@ -87,12 +87,25 @@ void X509_ALGOR_get0(const ASN1_OBJECT **paobj, int *pptype,
 /* Set up an X509_ALGOR DigestAlgorithmIdentifier from an EVP_MD */
 int X509_ALGOR_set_md(X509_ALGOR *alg, const EVP_MD *md)
 {
-    int type = md->flags & EVP_MD_FLAG_DIGALGID_ABSENT ? V_ASN1_UNDEF
-                                                       : V_ASN1_NULL;
-    int md_type = EVP_MD_type(md);
+    int type, md_type;
+    ASN1_OBJECT *obj;
 
-    ASN1_OBJECT *obj = (md_type == NID_undef) ? OBJ_txt2obj(EVP_MD_get0_name(md), 0) : OBJ_nid2obj(md_type);
-    return X509_ALGOR_set0(alg, obj, type, NULL);
+    if (alg == NULL || md == NULL)
+        return 0;
+
+    type = md->flags & EVP_MD_FLAG_DIGALGID_ABSENT ? V_ASN1_UNDEF
+                                                   : V_ASN1_NULL;
+    md_type = EVP_MD_type(md);
+
+    obj = (md_type == NID_undef) ? OBJ_txt2obj(EVP_MD_get0_name(md), 0)
+                                 : OBJ_nid2obj(md_type);
+    if (obj == NULL)
+        return 0;
+    if (!X509_ALGOR_set0(alg, obj, type, NULL)) {
+        ASN1_OBJECT_free(obj);
+        return 0;
+    }
+    return 1;
 }
 
 int X509_ALGOR_cmp(const X509_ALGOR *a, const X509_ALGOR *b)

--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -631,7 +631,7 @@ CMS_SignerInfo *CMS_add1_signer(CMS_ContentInfo *cms,
     if (!ossl_cms_set1_SignerIdentifier(si->sid, signer, type, ctx))
         goto err;
 
-    if (ossl_cms_adjust_md(ctx, pk, &md, &local_md, flags) != 1 && local_md != md)
+    if (ossl_cms_adjust_md(ctx, pk, &md, &local_md, flags) != 1)
         goto err;
 
     if (!X509_ALGOR_set_md(si->digestAlgorithm, md))

--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -19,6 +19,8 @@
 
 static X509 *cert = NULL;
 static EVP_PKEY *privkey = NULL;
+static X509 *ed448_cert = NULL;
+static EVP_PKEY *ed448_privkey = NULL;
 static char *derin = NULL;
 static char *too_long_iv_cms_in = NULL;
 static char *pwri_kek_oob_der_in = NULL;
@@ -286,6 +288,47 @@ static int test_CMS_add1_cert(void)
 
     CMS_ContentInfo_free(cms);
     return ret;
+}
+
+static int test_CMS_add1_signer_ed448(const EVP_MD *md, unsigned int flags,
+    int expect_success)
+{
+    CMS_ContentInfo *cms = NULL;
+    CMS_SignerInfo *si = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(cms = CMS_ContentInfo_new()))
+        goto end;
+
+    si = CMS_add1_signer(cms, ed448_cert, ed448_privkey, md, flags);
+    if (expect_success) {
+        if (!TEST_ptr(si))
+            goto end;
+    } else if (!TEST_ptr_null(si)) {
+        goto end;
+    }
+
+    ret = 1;
+end:
+    if (!expect_success && ret)
+        ERR_clear_error();
+    CMS_ContentInfo_free(cms);
+    return ret;
+}
+
+static int test_CMS_add1_signer_ed448_signed_attrs(void)
+{
+    return test_CMS_add1_signer_ed448(NULL, 0, 0);
+}
+
+static int test_CMS_add1_signer_ed448_signed_attrs_md(void)
+{
+    return test_CMS_add1_signer_ed448(EVP_shake256(), 0, 0);
+}
+
+static int test_CMS_add1_signer_ed448_noattr(void)
+{
+    return test_CMS_add1_signer_ed448(NULL, CMS_NOATTR, 1);
 }
 
 static int test_d2i_CMS_bio_NULL(void)
@@ -739,12 +782,12 @@ end:
     return ret;
 }
 
-OPT_TEST_DECLARE_USAGE("certfile privkeyfile derfile tooLongIVpem pwriKekOobDer\n")
+OPT_TEST_DECLARE_USAGE("certfile privkeyfile derfile tooLongIVpem pwriKekOobDer [ed448certfile ed448privkeyfile]\n")
 
 int setup_tests(void)
 {
     char *certin = NULL, *privkeyin = NULL;
-    BIO *certbio = NULL, *privkeybio = NULL;
+    char *ed448_certin = NULL, *ed448_privkeyin = NULL;
 
     if (!test_skip_common_options()) {
         TEST_error("Error parsing test options\n");
@@ -758,28 +801,28 @@ int setup_tests(void)
         || !TEST_ptr(pwri_kek_oob_der_in = test_get_argument(4)))
         return 0;
 
-    certbio = BIO_new_file(certin, "r");
-    if (!TEST_ptr(certbio))
-        return 0;
-    if (!TEST_true(PEM_read_bio_X509(certbio, &cert, NULL, NULL))) {
-        BIO_free(certbio);
+    if (!TEST_ptr(cert = load_cert_pem(certin, NULL))
+        || !TEST_ptr(privkey = load_pkey_pem(privkeyin, NULL))) {
+        X509_free(cert);
+        cert = NULL;
+        EVP_PKEY_free(privkey);
+        privkey = NULL;
         return 0;
     }
-    BIO_free(certbio);
 
-    privkeybio = BIO_new_file(privkeyin, "r");
-    if (!TEST_ptr(privkeybio)) {
-        X509_free(cert);
-        cert = NULL;
-        return 0;
+    if (test_get_argument_count() >= 7) {
+        ed448_certin = test_get_argument(5);
+        ed448_privkeyin = test_get_argument(6);
+
+        if (!TEST_ptr(ed448_cert = load_cert_pem(ed448_certin, NULL))
+            || !TEST_ptr(ed448_privkey = load_pkey_pem(ed448_privkeyin, NULL))) {
+            X509_free(ed448_cert);
+            ed448_cert = NULL;
+            EVP_PKEY_free(ed448_privkey);
+            ed448_privkey = NULL;
+            return 0;
+        }
     }
-    if (!TEST_true(PEM_read_bio_PrivateKey(privkeybio, &privkey, NULL, NULL))) {
-        BIO_free(privkeybio);
-        X509_free(cert);
-        cert = NULL;
-        return 0;
-    }
-    BIO_free(privkeybio);
 
     ADD_TEST(test_encrypt_decrypt_aes_cbc);
     ADD_TEST(test_encrypt_decrypt_aes_128_gcm);
@@ -796,6 +839,11 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_d2i_CMS_decode, 2);
     ADD_TEST(test_cms_aesgcm_iv_too_long);
     ADD_TEST(test_pwri_kek_unwrap_short_encrypted_key);
+    if (ed448_cert != NULL && ed448_privkey != NULL) {
+        ADD_TEST(test_CMS_add1_signer_ed448_signed_attrs);
+        ADD_TEST(test_CMS_add1_signer_ed448_signed_attrs_md);
+        ADD_TEST(test_CMS_add1_signer_ed448_noattr);
+    }
     return 1;
 }
 
@@ -803,4 +851,6 @@ void cleanup_tests(void)
 {
     X509_free(cert);
     EVP_PKEY_free(privkey);
+    X509_free(ed448_cert);
+    EVP_PKEY_free(ed448_privkey);
 }

--- a/test/recipes/80-test_cmsapi.t
+++ b/test/recipes/80-test_cmsapi.t
@@ -16,9 +16,14 @@ plan skip_all => "CMS is disabled in this build" if disabled("cms");
 
 plan tests => 1;
 
+my @ed448_args = disabled("ecx") ? () : (
+    srctop_file("test", "certs", "server-ed448-cert.pem"),
+    srctop_file("test", "certs", "server-ed448-key.pem"));
+
 ok(run(test(["cmsapitest", srctop_file("test", "certs", "servercert.pem"),
              srctop_file("test", "certs", "serverkey.pem"),
              srctop_file("test", "recipes", "80-test_cmsapi_data", "encryptedData.der"),
              srctop_file("test", "recipes", "80-test_cmsapi_data", "encDataWithTooLongIV.pem"),
-             srctop_file("test", "recipes", "80-test_cmsapi_data", "cms_pwri_kek_oob.der")])),
+             srctop_file("test", "recipes", "80-test_cmsapi_data", "cms_pwri_kek_oob.der"),
+             @ed448_args])),
              "running cmsapitest");

--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -688,6 +688,24 @@ err:
     return test;
 }
 
+static int test_X509_ALGOR_set_md_null(void)
+{
+    X509_ALGOR *alg = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(alg = X509_ALGOR_new()))
+        goto err;
+
+    if (!TEST_false(X509_ALGOR_set_md(alg, NULL)))
+        goto err;
+
+    ret = 1;
+
+err:
+    X509_ALGOR_free(alg);
+    return ret;
+}
+
 /* https://github.com/openssl/openssl/issues/26325 */
 static const char *kRootExtensionDuplicity[] = {
     "-----BEGIN CERTIFICATE-----\n",
@@ -948,6 +966,7 @@ int setup_tests(void)
     ADD_TEST(tests_X509_check_crypto);
     ADD_TEST(tests_x509_check_dpn);
     ADD_TEST(tests_x509_check_akid);
+    ADD_TEST(test_X509_ALGOR_set_md_null);
     ADD_TEST(tests_x509_check_ext_duplicity);
     ADD_TEST(tests_x509_check_ext_duplicity_nid_undef);
     ADD_TEST(tests_x509_check_ext_duplicity_nid_dynamic);


### PR DESCRIPTION
CMS signing with an Ed448 key and signed attributes can currently reach `X509_ALGOR_set_md` with a NULL digest.

`ossl_cms_adjust_md` returns failure when no digest can be determined for this case. This happens because RFC 8419 requires `id-shake256-len`, which OpenSSL doesn't yet support in this CMS path. However, `CMS_add1_signer` currently masks that failure when both `md` and `local_md` are NULL:

    ossl_cms_adjust_md(...) != 1 && local_md != md

Signing then continues until `X509_ALGOR_set_md` dereferences the NULL `EVP_MD`.

This changes `CMS_add1_signer` to treat any `ossl_cms_adjust_md` failure as fatal. It also adds a defensive NULL digest check in `X509_ALGOR_set_md`.

This PR only restores the invariant that CMS must not continue with a NULL digest, and hardens the lower-level helper against direct NULL input.

Regression coverage is added for:

- `CMS_add1_signer` with Ed448, signed attributes, and default digest selection: returns failure without dereferencing a NULL digest.
- `CMS_add1_signer` with Ed448, signed attributes, and explicit `EVP_shake256`: returns failure without dereferencing a NULL digest.
- `CMS_add1_signer` with Ed448 and `CMS_NOATTR`: still succeeds.
- Direct `X509_ALGOR_set_md(alg, NULL)`: returns failure.

Related issues and PRs:

- Refs #30291: tracks the Ed448 CMS signed-attributes regression and the missing id-shake256-len support.
- Related to #30312: documents/enforces the current unsupported Ed448 signed-attributes behavior, but does not cover this masked NULL digest path.
- Regression source: #30206 converted this path to provider-fetched digests and introduced the local_md handling plus the `&& local_md != md` condition that masks failure when both pointers are NULL.
- Background: #28923 introduced `ossl_cms_adjust_md()` and the EdDSA CMS default/no-attribute digest logic. Earlier NULL digest checks had been removed as redundant in #21473 and later in #29171/#29170.
- Related to #30431: adjacent `X509_ALGOR_set_md()` hardening for fetched digests with unresolvable OIDs; this PR covers the earlier `md == NULL` case.

##### Checklist

- [x] tests are added or updated