### PR TITLE
`doc/man3/EVP_PKEY_get_size.pod`: add `man` formatting for the security categories table

### DIFF
--- a/doc/man3/EVP_PKEY_get_size.pod
+++ b/doc/man3/EVP_PKEY_get_size.pod
@@ -54,6 +54,24 @@ The post-quantum security category is an integer value from 0 to 5 that
 is based on an algorithm's classification on the range of security strengths
 offered by the existing standards in symmetric cryptography:
 
+=begin man
+
+.TS H
+box,center;
+cb lb
+c l.
+Security Category	Attack Type
+_
+0	Weak
+1	Key search on a block cipher with a 128-bit key
+2	Collision search on a 256-bit hash function
+3	Key search on a block cipher with a 192-bit key
+4	Collision search on a 384-bit hash function
+5	Key search on a block cipher with a 256-bit key
+.TE
+
+=end man
+
 =begin text
 
  Security       Attack


### PR DESCRIPTION
Commit 73188a01bd99 "doc: document EVP_PKEY_get_security_category function" has added security level definitions as a table, that has been implemented raw via `=begin` POD directives;  while the formatting for `html` and `text` (that is not even generated by the build system) has been provided, `man` (arguably, the most relevant one) has been omitted, surprisingly.  Rescind that omission by providing the respective table formatting for `man`.

Complements: 73188a01bd99 "doc: document EVP_PKEY_get_security_category function"