### PR TITLE
Reject IP address literals in X509_check_host()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,16 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * X509_check_host() no longer matches an IP address literal against a
+   dNSName subjectAltName entry or the subject CommonName. Per section 6.1.1
+   of RFC 9525, an IP address reference identifier must only be matched
+   against an explicitly marked iPAddress SAN entry. Previously a name such
+   as "127.0.0.1" would match a certificate that (incorrectly) carried the
+   address as a dNSName. Use X509_check_ip() or X509_check_ip_asc() to match
+   an IP address.
+
+   *Samaresh Kumar Singh*
+
  * Added support for Ed25519 and Ed448 certificates in DTLS 1.2. Previously,
    these certificate types were only supported in TLS 1.2 and TLS 1.3.
 

--- a/crypto/x509/v3_utl.c
+++ b/crypto/x509/v3_utl.c
@@ -902,6 +902,28 @@ static int do_x509_check(const X509 *x, const char *chk, size_t chklen,
     if (chklen == 0)
         chklen = strlen(chk);
 
+    /*
+     * RFC 9525 (Section 6.1.1): a reference identifier that is an IP address
+     * is an IP-ID and MUST only be matched against iPAddress subjectAltName
+     * entries, never against a dNSName or the subject Common Name.  When an
+     * IP-address literal is supplied to the DNS matcher (X509_check_host()),
+     * decline to match it so that a certificate carrying an IP address that
+     * was mistakenly encoded as a dNSName (or placed in the CN) does not yield
+     * a false positive via plain string comparison.  Callers that want to
+     * match an IP address must use X509_check_ip()/X509_check_ip_asc().  The
+     * longest textual IPv6 address is 45 characters, so anything that does not
+     * fit the buffer cannot be an IP literal.
+     */
+    if (check_type == GEN_DNS && chklen != 0 && chklen < 64) {
+        char ipasc[64];
+        unsigned char ipout[16];
+
+        memcpy(ipasc, chk, chklen);
+        ipasc[chklen] = '\0';
+        if (ossl_a2i_ipadd(ipout, ipasc) != 0)
+            return 0;
+    }
+
     gens = X509_get_ext_d2i(x, NID_subject_alt_name, NULL, NULL);
     if (gens) {
         for (i = 0; i < sk_GENERAL_NAME_num(gens); i++) {

--- a/doc/man3/X509_check_host.pod
+++ b/doc/man3/X509_check_host.pod
@@ -41,6 +41,13 @@ with a dot (e.g. ".example.com"), it will be matched by a certificate
 valid for any sub-domain of B<name>, (see also
 B<X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS> below).
 
+If B<name> is an IPv4 or IPv6 address in textual form, X509_check_host()
+does not report a match, because an IP address is not a DNS name.  Per
+section 6.1.1 of RFC 9525, an IP address reference identifier must only be
+matched against an explicitly marked iPAddress SAN entry, never against a
+dNSName or the Subject CommonName.  Use X509_check_ip() or
+X509_check_ip_asc() to match an IP address.
+
 When the certificate is matched, and B<peername> is not NULL, a
 pointer to a copy of the matching SAN or CN from the peer certificate
 is stored at the address passed in B<peername>.  The application

--- a/test/v3nametest.c
+++ b/test/v3nametest.c
@@ -365,6 +365,65 @@ static int call_run_cert(int i)
     }
     return failed == 0;
 }
+
+/*
+ * Regression test for GitHub issue #31377: X509_check_host() must not match an
+ * IP-address literal against a dNSName SAN or the subject CN.  Per RFC 9525
+ * (Section 6.1.1) an IP-address reference identifier is an IP-ID and may only
+ * match an iPAddress SAN.
+ */
+static int test_ip_not_matched_as_dns(void)
+{
+    X509 *crt = NULL;
+    int ret = 0;
+
+    /*
+     * Certificate that (incorrectly) encodes IP addresses as dNSName SAN
+     * entries and as the subject CN.
+     */
+    if (!TEST_ptr(crt = make_cert())
+        || !TEST_true(set_cn(crt, NID_commonName, "127.0.0.1", 0))
+        || !TEST_true(set_altname(crt, GEN_DNS, "127.0.0.1",
+            GEN_DNS, "::1", 0)))
+        goto end;
+
+    /* IPv4 literal must not match a dNSName. */
+    if (!TEST_int_eq(X509_check_host(crt, "127.0.0.1", 0, 0, NULL), 0))
+        goto end;
+    /* IPv6 literal must not match a dNSName. */
+    if (!TEST_int_eq(X509_check_host(crt, "::1", 0, 0, NULL), 0))
+        goto end;
+    /* The CN must not provide a fallback match either. */
+    if (!TEST_int_eq(X509_check_host(crt, "127.0.0.1", 0,
+                         X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT, NULL),
+            0))
+        goto end;
+    /* The correct IP API also must not match a misencoded dNSName cert. */
+    if (!TEST_int_eq(X509_check_ip_asc(crt, "127.0.0.1", 0), 0))
+        goto end;
+
+    X509_free(crt);
+    crt = NULL;
+
+    /*
+     * Positive control: genuine DNS-IDs, including names whose labels are
+     * purely numeric, must still match.  The guard only rejects full IP
+     * literals, not hostnames that merely contain digits.
+     */
+    if (!TEST_ptr(crt = make_cert())
+        || !TEST_true(set_altname(crt, GEN_DNS, "www.example.com",
+            GEN_DNS, "1.example.com", 0)))
+        goto end;
+    if (!TEST_int_eq(X509_check_host(crt, "www.example.com", 0, 0, NULL), 1))
+        goto end;
+    if (!TEST_int_eq(X509_check_host(crt, "1.example.com", 0, 0, NULL), 1))
+        goto end;
+
+    ret = 1;
+end:
+    X509_free(crt);
+    return ret;
+}
 OSSL_END_ALLOW_DEPRECATED
 #endif /* !defined(OPENSSL_NO_DEPRECATED_4_1) */
 
@@ -668,6 +727,7 @@ int setup_tests(void)
 {
 #if !defined(OPENSSL_NO_DEPRECATED_4_1)
     ADD_ALL_TESTS(call_run_cert, OSSL_NELEM(name_fns));
+    ADD_TEST(test_ip_not_matched_as_dns);
 #endif /* !defined(OPENSSL_NO_DEPRECATED_4_1) */
     ADD_TEST(test_GENERAL_NAME_cmp);
     return 1;


### PR DESCRIPTION
##### Description

`X509_check_host()` performed a plain string comparison between the caller-supplied name and `dNSName` subjectAltName entries (and the subject CommonName) without checking whether the supplied name was actually a DNS name. As a result, a certificate that encoded an IP address as a `dNSName` (e.g. `DNS:127.0.0.1` instead of `IP:127.0.0.1`) was reported as a match for the name `"127.0.0.1"`.

Per [RFC 9525, Section 6.1.1](https://datatracker.ietf.org/doc/rfc9525/), an IP address reference identifier is an IP-ID and must only be matched against an `iPAddress` SAN entry, never against a `dNSName` or the subject CommonName.

This change detects an IP-address literal supplied to the DNS matcher in `do_x509_check()` and declines to match it. This also prevents the equivalent false positive against an IP address placed in the CN. The correct `iPAddress` matching via `X509_check_ip()` / `X509_check_ip_asc()` is unchanged. The behaviour now agrees with Go's `crypto/x509` and BoringSSL, both of which reject this case.

Note: this also covers the `X509_VERIFY_PARAM` host path, since `X509_VERIFY_PARAM_set1_host()` accepts all-numeric labels and the eventual match runs through the same `do_x509_check()` code.

A regression test was added to `test/v3nametest.c` (it fails without the source change and passes with it), and the man page and `CHANGES.md` were updated.

Fixes #31377

##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated
