### PR TITLE
Add validation for negative length in BIO buffer APIs

### DIFF
--- a/crypto/bio/bf_buff.c
+++ b/crypto/bio/bf_buff.c
@@ -292,6 +292,8 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         }
         break;
     case BIO_C_SET_BUFF_READ_DATA:
+        if (num < 0)
+            return 0;
         if (num > ctx->ibuf_size) {
             if (num <= 0)
                 return 0;
@@ -395,6 +397,8 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
             ret = 0;
         break;
     case BIO_CTRL_PEEK:
+        if (num < 0)
+            return 0;
         /* Ensure there's stuff in the input buffer */
         {
             char fake_buf[1];


### PR DESCRIPTION
## Summary
- Add early validation for negative length in `BIO_C_SET_BUFF_READ_DATA` and `BIO_CTRL_PEEK` control paths
- Prevents heap corruption from implicit cast of negative `long` to `size_t` in `memcpy()` calls

## Changes
| File | Change |
|------|--------|
| `crypto/bio/bf_buff.c` | Add `if (num < 0) return 0;` checks in two control paths |

## Problem
Two BIO control paths accepted a signed `long num` parameter but didn't validate negative values:
- `BIO_C_SET_BUFF_READ_DATA`: Negative values bypass guard conditions and reach `memcpy()` with a large `size_t` value, causing heap corruption
- `BIO_CTRL_PEEK`: Negative values reach `memcpy()` causing SIGSEGV

## Solution
Add early `if (num < 0) return 0;` checks before the existing logic in both paths.

## Test Plan
- [x] Code review: changes are minimal and isolated
- [ ] Build verification (pending)
- [ ] Run existing BIO buffer tests

Fixes #30725
