### PR TITLE
`apps/s_client.c`: read one byte less to avoid triggerring overflow protection

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3478,7 +3478,7 @@ re_start:
             if (crlf) {
                 int j, lf_num;
 
-                i = raw_read_stdin(cbuf, BUFSIZZ / 2);
+                i = raw_read_stdin(cbuf, (BUFSIZZ - 1) / 2);
                 lf_num = 0;
                 /* both loops are skipped when i <= 0 */
                 for (j = 0; j < i; j++)
@@ -3494,7 +3494,7 @@ re_start:
                 }
                 assert(lf_num == 0);
             } else
-                i = raw_read_stdin(cbuf, BUFSIZZ);
+                i = raw_read_stdin(cbuf, BUFSIZZ - 1);
 #if !defined(OPENSSL_SYS_WINDOWS) && !defined(OPENSSL_SYS_MSDOS)
             if (i == 0)
                 at_eof = 1;


### PR DESCRIPTION
Commit e0e276b50a1e "Fix a one byte buffer overflow in s_client" added a check for the buffer size before adding a terminating `\0`, which led to full reads of `BUFSIZZ` resulting in session termination.  Avoid that by requesting one byte less.

Resolves: https://github.com/openssl/openssl/issues/30925
Fixes: e0e276b50a1e "Fix a one byte buffer overflow in s_client"