### PR TITLE
doc: update PEM examples from 3DES to AES-256-CBC

### DIFF
--- a/doc/man3/PEM_read_bio_PrivateKey.pod
+++ b/doc/man3/PEM_read_bio_PrivateKey.pod
@@ -443,8 +443,8 @@ the function.
 
 The pseudo code to derive the key would look similar to:
 
- EVP_CIPHER* cipher = EVP_des_ede3_cbc();
- EVP_MD* md = EVP_md5();
+ EVP_CIPHER* cipher = EVP_aes_256_cbc();
+ EVP_MD* md = EVP_sha256();
 
  unsigned int nkey = EVP_CIPHER_get_key_length(cipher);
  unsigned int niv = EVP_CIPHER_get_iv_length(cipher);
@@ -516,15 +516,15 @@ Write a certificate to a BIO:
      /* Error */
 
 Write a private key (using traditional format) to a BIO using
-triple DES encryption, the pass phrase is prompted for:
+AES-256-CBC encryption, the pass phrase is prompted for:
 
- if (!PEM_write_bio_PrivateKey(bp, key, EVP_des_ede3_cbc(), NULL, 0, 0, NULL))
+ if (!PEM_write_bio_PrivateKey(bp, key, EVP_aes_256_cbc(), NULL, 0, 0, NULL))
      /* Error */
 
-Write a private key (using PKCS#8 format) to a BIO using triple
-DES encryption, using the pass phrase "hello":
+Write a private key (using PKCS#8 format) to a BIO using
+AES-256-CBC encryption, using the pass phrase "hello":
 
- if (!PEM_write_bio_PKCS8PrivateKey(bp, key, EVP_des_ede3_cbc(),
+ if (!PEM_write_bio_PKCS8PrivateKey(bp, key, EVP_aes_256_cbc(),
                                     NULL, 0, 0, "hello"))
      /* Error */
 


### PR DESCRIPTION
## Summary
- Update documentation examples in `PEM_read_bio_PrivateKey.pod` to use modern AES-256-CBC instead of outdated 3DES

## Changes
| File | Change |
|------|--------|
| `doc/man3/PEM_read_bio_PrivateKey.pod` | Replace `EVP_des_ede3_cbc()` → `EVP_aes_256_cbc()`, `EVP_md5()` → `EVP_sha256()`, and update comments |

## Problem
The documentation examples used deprecated 3DES cipher and MD5 hash which are considered insecure. Updated to modern AES-256-CBC with SHA-256 as per current best practices.

## Test Plan
- [x] Code review: changes are documentation only
- [x] Verify no other outdated examples remain

Fixes #28665
