### PR TITLE
Fix use-after-free issue in radix test framework for QUIC.

### DIFF
--- a/test/crltest.c
+++ b/test/crltest.c
@@ -1521,6 +1521,7 @@ err:
  */
 static int test_crl_sigalg_mismatch(void)
 {
+#if 0
     X509 *root = X509_from_strings(kRoot);
     X509_CRL *good = CRL_from_strings(kCrlRootCA);
     X509_CRL *bad = CRL_from_strings(kCrlMismatchedSigAlg);
@@ -1552,6 +1553,8 @@ end:
     X509_CRL_free(bad);
     X509_free(root);
     return ret;
+#endif
+    return 1;
 }
 
 int setup_tests(void)

--- a/test/crltest.c
+++ b/test/crltest.c
@@ -1521,7 +1521,6 @@ err:
  */
 static int test_crl_sigalg_mismatch(void)
 {
-#if 0
     X509 *root = X509_from_strings(kRoot);
     X509_CRL *good = CRL_from_strings(kCrlRootCA);
     X509_CRL *bad = CRL_from_strings(kCrlMismatchedSigAlg);
@@ -1553,8 +1552,6 @@ end:
     X509_CRL_free(bad);
     X509_free(root);
     return ret;
-#endif
-    return 1;
 }
 
 int setup_tests(void)

--- a/test/radix/quic_ops.c
+++ b/test/radix/quic_ops.c
@@ -142,45 +142,6 @@ static int ssl_attach_bio_dgram(SSL *ssl,
     return 1;
 }
 
-/*
- * Test to make sure that SSL_accept_connection returns the same ssl object
- * that is used in the various TLS callbacks
- *
- * Unlike TCP, QUIC processes new connections independently from their
- * acceptance, and so we need to pre-allocate tls objects to return during
- * connection acceptance via the user_ssl.  This is just a quic test to validate
- * that:
- * 1) The new callback to inform the user of a new pending ssl acceptance works
- *    properly
- * 2) That the object returned from SSL_accept_connection matches the one passed
- *    to various callbacks
- *
- * It would be better as its own test, but currently the tserver used in the
- * other quic_tests doesn't actually accept connections (it pre-creates them
- * and fixes them up in place), so testing there is not feasible at the moment
- *
- * For details on this issue see:
- * https://github.com/openssl/project/issues/918
- */
-static SSL *pending_ssl_obj = NULL;
-static SSL *client_hello_ssl_obj = NULL;
-static int check_pending_match = 0;
-static int pending_cb_called = 0;
-static int hello_cb_called = 0;
-static int new_pending_cb(SSL_CTX *ctx, SSL *new_ssl, void *arg)
-{
-    pending_ssl_obj = new_ssl;
-    pending_cb_called = 1;
-    return 1;
-}
-
-static int client_hello_cb(SSL *s, int *al, void *arg)
-{
-    client_hello_ssl_obj = s;
-    hello_cb_called = 1;
-    return 1;
-}
-
 DEF_FUNC(hf_new_ssl)
 {
     int ok = 0;
@@ -215,9 +176,6 @@ DEF_FUNC(hf_new_ssl)
             goto err;
 
     } else if (is_server) {
-        SSL_CTX_set_new_pending_conn_cb(ctx, new_pending_cb, NULL);
-        SSL_CTX_set_client_hello_cb(ctx, client_hello_cb, NULL);
-        check_pending_match = 1;
         if (!TEST_ptr(ssl = SSL_new_listener(ctx, 0)))
             goto err;
     } else {
@@ -351,23 +309,6 @@ DEF_FUNC(hf_accept_conn)
         goto err;
     }
 
-    if (check_pending_match) {
-        if (!pending_cb_called || !hello_cb_called) {
-            TEST_info("Callbacks not called, skipping user_ssl check\n");
-        } else {
-            if (!TEST_ptr_eq(pending_ssl_obj, client_hello_ssl_obj)) {
-                SSL_free(conn);
-                goto err;
-            }
-            if (!TEST_ptr_eq(pending_ssl_obj, conn)) {
-                SSL_free(conn);
-                goto err;
-            }
-        }
-        pending_ssl_obj = client_hello_ssl_obj = NULL;
-        check_pending_match = 0;
-        pending_cb_called = hello_cb_called = 0;
-    }
     ok = 1;
 err:
     return ok;

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -494,6 +494,141 @@ DEF_SCRIPT(check_pc_flood, "check path challenge flood")
 }
 
 /*
+ * Test to make sure that SSL_accept_connection returns the same ssl object
+ * that is used in the various TLS callbacks
+ *
+ * Unlike TCP, QUIC processes new connections independently from their
+ * acceptance, and so we need to pre-allocate tls objects to return during
+ * connection acceptance via the user_ssl.  This is just a quic test to validate
+ * that:
+ * 1) The new callback to inform the user of a new pending ssl acceptance works
+ *    properly
+ * 2) That the object returned from SSL_accept_connection matches the one passed
+ *    to various callbacks
+ *
+ * It would be better as its own test, but currently the tserver used in the
+ * other quic_tests doesn't actually accept connections (it pre-creates them
+ * and fixes them up in place), so testing there is not feasible at the moment
+ *
+ * For details on this issue see:
+ * https://github.com/openssl/project/issues/918
+ */
+static SSL *pending_ssl_obj = NULL;
+static SSL *client_hello_ssl_obj = NULL;
+static int check_pending_match = 0;
+static int pending_cb_called = 0;
+static int hello_cb_called = 0;
+
+static int new_pending_cb(SSL_CTX *ctx, SSL *new_ssl, void *arg)
+{
+    pending_ssl_obj = new_ssl;
+    pending_cb_called = 1;
+    return 1;
+}
+
+static int client_hello_cb(SSL *s, int *al, void *arg)
+{
+    client_hello_ssl_obj = s;
+    hello_cb_called = 1;
+    return 1;
+}
+
+DEF_FUNC(init_pending_test)
+{
+    pending_ssl_obj = NULL;
+    client_hello_ssl_obj = NULL;
+    check_pending_match = 0;
+    pending_cb_called = 0;
+    hello_cb_called = 0;
+
+    return 1;
+}
+
+DEF_FUNC(check_pending)
+{
+    int ok = 0;
+    SSL *conn;
+
+    REQUIRE_SSL(conn);
+
+    if (check_pending_match) {
+        if (!pending_cb_called || !hello_cb_called) {
+            TEST_info("Callbacks not called, skipping user_ssl check\n");
+        } else {
+            if (!TEST_ptr_eq(pending_ssl_obj, client_hello_ssl_obj))
+                goto err;
+
+            if (!TEST_ptr_eq(pending_ssl_obj, conn))
+                goto err;
+        }
+        pending_ssl_obj = client_hello_ssl_obj = NULL;
+        check_pending_match = 0;
+        pending_cb_called = hello_cb_called = 0;
+    }
+
+    ok = 1;
+err:
+    return ok;
+}
+
+DEF_FUNC(new_listener)
+{
+    int ok = 0;
+    SSL_CTX *ctx = NULL;
+    SSL *listener;
+    const char *name;
+
+    F_POP(name);
+
+    if (!TEST_ptr(ctx = SSL_CTX_new(OSSL_QUIC_server_method())))
+        goto err;
+
+#if defined(OPENSSL_THREADS)
+    if (!TEST_true(SSL_CTX_set_domain_flags(ctx,
+            SSL_DOMAIN_FLAG_MULTI_THREAD
+                | SSL_DOMAIN_FLAG_BLOCKING)))
+        goto err;
+#endif
+
+    if (!TEST_true(ssl_ctx_configure(ctx, 1)))
+        goto err;
+
+    SSL_CTX_set_new_pending_conn_cb(ctx, new_pending_cb, NULL);
+    SSL_CTX_set_client_hello_cb(ctx, client_hello_cb, NULL);
+    check_pending_match = 1;
+    if (!TEST_ptr(listener = SSL_new_listener(ctx, 0)))
+        goto err;
+
+    if (!TEST_true(ssl_attach_bio_dgram(listener, 0, NULL)))
+        goto err;
+
+    if (!TEST_true(RADIX_PROCESS_set_ssl(RP(), name, listener))) {
+        SSL_free(listener);
+        goto err;
+    }
+
+    ok = 1;
+err:
+    /* SSL object will hold ref, we don't need it */
+    SSL_CTX_free(ctx);
+    return ok;
+}
+
+DEF_SCRIPT(check_ctx_cbks, "Check new_pending and client_hello callbacks")
+{
+    OP_FUNC(init_pending_test);
+    OP_PUSH_PZ("L");
+    OP_FUNC(new_listener);
+    OP_LISTEN(L);
+    OP_NEW_SSL_C(C);
+    OP_SET_PEER_ADDR_FROM(C, L);
+    OP_CONNECT_WAIT(C);
+    OP_ACCEPT_CONN_WAIT(L, S, 0);
+    OP_SELECT_SSL(0, S);
+    OP_FUNC(check_pending);
+}
+
+/*
  * List of Test Scripts
  * ============================================================================
  */
@@ -504,4 +639,5 @@ static SCRIPT_INFO *const scripts[] = {
     USE(ssl_poll),
     USE(check_cwm),
     USE(check_pc_flood),
+    USE(check_ctx_cbks),
 };

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -599,8 +599,10 @@ DEF_FUNC(new_listener)
     if (!TEST_ptr(listener = SSL_new_listener(ctx, 0)))
         goto err;
 
-    if (!TEST_true(ssl_attach_bio_dgram(listener, 0, NULL)))
+    if (!TEST_true(ssl_attach_bio_dgram(listener, 0, NULL))) {
+        SSL_free(listener);
         goto err;
+    }
 
     if (!TEST_true(RADIX_PROCESS_set_ssl(RP(), name, listener))) {
         SSL_free(listener);

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -552,15 +552,18 @@ DEF_FUNC(check_pending)
     REQUIRE_SSL(conn);
 
     if (check_pending_match) {
-        if (!pending_cb_called || !hello_cb_called) {
-            TEST_info("Callbacks not called, skipping user_ssl check\n");
-        } else {
-            if (!TEST_ptr_eq(pending_ssl_obj, client_hello_ssl_obj))
-                goto err;
+        if (TEST_false(pending_cb_called))
+            goto err;
 
-            if (!TEST_ptr_eq(pending_ssl_obj, conn))
-                goto err;
-        }
+        if (TEST_false(hello_cb_called))
+            goto err;
+
+        if (!TEST_ptr_eq(pending_ssl_obj, client_hello_ssl_obj))
+            goto err;
+
+        if (!TEST_ptr_eq(pending_ssl_obj, conn))
+            goto err;
+
         pending_ssl_obj = client_hello_ssl_obj = NULL;
         check_pending_match = 0;
         pending_cb_called = hello_cb_called = 0;

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -552,10 +552,10 @@ DEF_FUNC(check_pending)
     REQUIRE_SSL(conn);
 
     if (check_pending_match) {
-        if (TEST_false(pending_cb_called))
+        if (!TEST_true(pending_cb_called))
             goto err;
 
-        if (TEST_false(hello_cb_called))
+        if (!TEST_true(hello_cb_called))
             goto err;
 
         if (!TEST_ptr_eq(pending_ssl_obj, client_hello_ssl_obj))


### PR DESCRIPTION
hf_accept_conn() tests if SSL_accept() works for QUIC. Currently the function accepts connection, then binds the `conn` object to radix framework and then proceeds to further tests. If further tests fail, then connection is freed and function returns to caller without ubbinding the conn object from radix framework. The framework then keeps dengling pointer.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
