### PR TITLE
Add dependency on crypto/perlasm/x86_64-xlate.pl

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1613,6 +1613,9 @@ EOF
           if ($gen0 =~ /\.pl$/) {
               $generator = 'CC="$(CC)" $(PERL)'.$gen_incs.' '.$gen0.$gen_args
                   .' "$(PERLASM_SCHEME)"'.$incs.' '.$cppflags.$defs.' $(PROCESSOR)';
+              if (defined($target{asm_arch}) && $target{asm_arch} eq "x86_64") {
+                  $deps .= " \$(SRCDIR)/crypto/perlasm/x86_64-xlate.pl";
+              }
           } elsif ($gen0 =~ /\.m4$/) {
               $generator = 'm4 -B 8192'.$gen_incs.' '.$gen0.$gen_args.' >'
           } elsif ($gen0 =~ /\.S$/) {

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -745,6 +745,9 @@ EOF
           if ($gen0 =~ /\.pl$/) {
               $generator = '"$(PERL)"'.$gen_incs.' "'.$gen0.'"'.$gen_args
                   .' "$(PERLASM_SCHEME)"'.$incs.' '.$cppflags.$defs.' $(PROCESSOR)';
+              if (defined($target{asm_arch}) && $target{asm_arch} eq "x86_64") {
+                  $deps .= " \"\$(SRCDIR)\\crypto\\perlasm\\x86_64-xlate.pl\"";
+              }
           } elsif ($gen0 =~ /\.S$/) {
               $generator = undef;
           } else {


### PR DESCRIPTION
Add dependency on crypto/perlasm/x86_64-xlate.pl to assembler generator script makefile recipies.

A trivial change that simplifies tinkering with x86_64-xlate.pl a lot.