### PR TITLE
Refactor OSSL_FN_CTX: peak usage, BN_CTX integration, and actual usage in BN_mul()/BN_sqr()

### DIFF
--- a/crypto/bn/bn_ctx.c
+++ b/crypto/bn/bn_ctx.c
@@ -75,6 +75,8 @@ struct bignum_ctx {
     int flags;
     /* The library context */
     OSSL_LIB_CTX *libctx;
+    /* OSSL_FN_CTX for OSSL_FN wrapper functions */
+    OSSL_FN_CTX *fn_ctx;
 };
 
 #ifndef FIPS_MODULE
@@ -179,6 +181,7 @@ void BN_CTX_free(BN_CTX *ctx)
 #endif
     BN_STACK_finish(&ctx->stack);
     BN_POOL_finish(&ctx->pool);
+    OSSL_FN_CTX_free(ctx->fn_ctx);
     OPENSSL_free(ctx);
 }
 
@@ -238,6 +241,49 @@ BIGNUM *BN_CTX_get(BN_CTX *ctx)
     ctx->used++;
     CTXDBG("LEAVE BN_CTX_get()", ctx);
     return ret;
+}
+
+OSSL_FN_CTX *bn_ctx_acquire_ossl_fn_ctx(BN_CTX *ctx, size_t max_n_frames,
+    size_t max_n_numbers, size_t max_n_limbs)
+{
+    size_t needed;
+
+    if (ctx == NULL)
+        return NULL;
+
+    needed = ossl_fn_ctx_calculate_arena_size(max_n_frames, max_n_numbers,
+        max_n_limbs);
+
+    if (ctx->fn_ctx != NULL) {
+        if (ctx->fn_ctx->msize >= needed) {
+            /*
+             * Existing context is large enough.  Ensure no frames are
+             * outstanding (callers are expected to have ended them).
+             */
+            assert(ctx->fn_ctx->last_frame == NULL);
+            return ctx->fn_ctx;
+        }
+        /* Too small, free and recreate */
+        OSSL_FN_CTX_free(ctx->fn_ctx);
+        ctx->fn_ctx = NULL;
+    }
+
+    if (ctx->flags & BN_FLG_SECURE)
+        ctx->fn_ctx = OSSL_FN_CTX_secure_new(ctx->libctx, max_n_frames,
+            max_n_numbers, max_n_limbs);
+    else
+        ctx->fn_ctx = OSSL_FN_CTX_new(ctx->libctx, max_n_frames,
+            max_n_numbers, max_n_limbs);
+
+    return ctx->fn_ctx;
+}
+
+void bn_ctx_release_ossl_fn_ctx(BN_CTX *ctx)
+{
+    if (ctx == NULL || ctx->fn_ctx == NULL)
+        return;
+
+    assert(ctx->fn_ctx->last_frame == NULL);
 }
 
 OSSL_LIB_CTX *ossl_bn_get_libctx(BN_CTX *ctx)

--- a/crypto/bn/bn_mul.c
+++ b/crypto/bn/bn_mul.c
@@ -30,12 +30,7 @@ int BN_mul(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, BN_CTX *ctx)
     size_t top = a->top + b->top;
     size_t max = a->dmax + b->dmax;
 
-    /*
-     * Unfortunately, OSSL_FN_CTX and BN_CTX are too wildly different to
-     * be interchangeable.  We must therefore create an OSSL_FN_CTX here.
-     * (OSSL_FN_CTX is only really useful within OSSL_FN functionality)
-     */
-    OSSL_FN_CTX *fnctx = OSSL_FN_CTX_new(NULL, 1, 1, max);
+    OSSL_FN_CTX *fnctx = bn_ctx_acquire_ossl_fn_ctx(ctx, 1, 1, max);
     OSSL_FN *rf = bn_acquire_ossl_fn(r, (int)top);
     int ret = OSSL_FN_mul(rf, a->data, b->data, fnctx);
     bn_release(r, (int)top);
@@ -43,7 +38,7 @@ int BN_mul(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, BN_CTX *ctx)
     if (ret && !BN_is_zero(r))
         r->neg = a->neg ^ b->neg;
 
-    OSSL_FN_CTX_free(fnctx);
+    bn_ctx_release_ossl_fn_ctx(ctx);
     return ret;
 }
 

--- a/crypto/bn/bn_sqr.c
+++ b/crypto/bn/bn_sqr.c
@@ -32,18 +32,13 @@ int BN_sqr(BIGNUM *r, const BIGNUM *a, BN_CTX *ctx)
     size_t top = a->top * 2;
     size_t max = a->dmax * 2;
 
-    /*
-     * Unfortunately, OSSL_FN_CTX and BN_CTX are too wildly different to
-     * be interchangeable.  We must therefore create an OSSL_FN_CTX here.
-     * (OSSL_FN_CTX is only really useful within OSSL_FN functionality)
-     */
-    OSSL_FN_CTX *fnctx = OSSL_FN_CTX_new(NULL, 1, 2, max * 4);
+    OSSL_FN_CTX *fnctx = bn_ctx_acquire_ossl_fn_ctx(ctx, 1, 2, max * 4);
     OSSL_FN *rf = bn_acquire_ossl_fn(r, (int)top);
     int ret = OSSL_FN_sqr(rf, a->data, fnctx);
     bn_release(r, (int)top);
     r->neg = 0;
 
-    OSSL_FN_CTX_free(fnctx);
+    bn_ctx_release_ossl_fn_ctx(ctx);
     return ret;
 }
 

--- a/crypto/fn/fn_ctx.c
+++ b/crypto/fn/fn_ctx.c
@@ -38,6 +38,20 @@ struct ossl_fn_ctx_st {
     unsigned int is_securely_allocated : 1;
 
     /*
+     * Current and peak usage tracking, by allocation components.
+     * The |n_*| fields hold the currently active counts; the |peak_n_*|
+     * fields hold the maximum each count has ever reached simultaneously.
+     * This allows callers to determine suitable arena parameters for a
+     * given workload without precise up-front prediction.
+     */
+    size_t n_frames;
+    size_t n_numbers;
+    size_t n_limbs;
+    size_t peak_n_frames;
+    size_t peak_n_numbers;
+    size_t peak_n_limbs;
+
+    /*
      * The arena itself.
      */
     size_t msize; /* Size of the arena, in bytes */
@@ -55,6 +69,12 @@ struct ossl_fn_ctx_frame_st {
      * to do its job.
      */
     struct ossl_fn_ctx_frame_st *previous_frame;
+    /*
+     * Tracking for peak usage instrumentation.  These count the OSSL_FN
+     * instances and total limbs allocated within this frame.
+     */
+    size_t n_numbers;
+    size_t n_limbs;
     /*
      * Every time OSSL_FN_CTX_get() is called, the current value of
      * |free_memory| is returned, and it's updated by incrementing it
@@ -99,6 +119,26 @@ OSSL_FN_CTX *OSSL_FN_CTX_secure_new(OSSL_LIB_CTX *libctx, size_t max_n_frames,
     return ctx;
 }
 
+void OSSL_FN_CTX_peak_usage(const OSSL_FN_CTX *ctx, size_t *peak_n_frames,
+    size_t *peak_n_numbers, size_t *peak_n_limbs)
+{
+    if (ctx == NULL) {
+        if (peak_n_frames != NULL)
+            *peak_n_frames = 0;
+        if (peak_n_numbers != NULL)
+            *peak_n_numbers = 0;
+        if (peak_n_limbs != NULL)
+            *peak_n_limbs = 0;
+        return;
+    }
+    if (peak_n_frames != NULL)
+        *peak_n_frames = ctx->peak_n_frames;
+    if (peak_n_numbers != NULL)
+        *peak_n_numbers = ctx->peak_n_numbers;
+    if (peak_n_limbs != NULL)
+        *peak_n_limbs = ctx->peak_n_limbs;
+}
+
 void OSSL_FN_CTX_free(OSSL_FN_CTX *ctx)
 {
     if (ctx == NULL)
@@ -133,6 +173,12 @@ const void *OSSL_FN_CTX_start(OSSL_FN_CTX *ctx)
     frame->previous_frame = last_frame;
     frame->free_memory = frame->memory;
     frame->msize = ctx->msize - used - sizeof(*frame);
+    frame->n_numbers = 0;
+    frame->n_limbs = 0;
+
+    ctx->n_frames++;
+    if (ctx->n_frames > ctx->peak_n_frames)
+        ctx->peak_n_frames = ctx->n_frames;
 
     return ctx->last_frame;
 }
@@ -147,6 +193,9 @@ int OSSL_FN_CTX_end(OSSL_FN_CTX *ctx, const void *token)
     if (last_frame != token)
         return 0;
 
+    ctx->n_numbers -= last_frame->n_numbers;
+    ctx->n_limbs -= last_frame->n_limbs;
+    ctx->n_frames--;
     ctx->last_frame = last_frame->previous_frame;
 
     return 1;
@@ -169,6 +218,15 @@ OSSL_FN *OSSL_FN_CTX_get_limbs(OSSL_FN_CTX *ctx, size_t limbs)
 
     OSSL_FN *fn = (OSSL_FN *)frame->free_memory;
     frame->free_memory += totalsize;
+    frame->n_numbers++;
+    frame->n_limbs += limbs;
+
+    ctx->n_numbers++;
+    ctx->n_limbs += limbs;
+    if (ctx->n_numbers > ctx->peak_n_numbers)
+        ctx->peak_n_numbers = ctx->n_numbers;
+    if (ctx->n_limbs > ctx->peak_n_limbs)
+        ctx->peak_n_limbs = ctx->n_limbs;
 
     memset(fn, 0, totalsize);
     fn->dsize = (int)limbs;

--- a/crypto/fn/fn_ctx.c
+++ b/crypto/fn/fn_ctx.c
@@ -24,79 +24,10 @@
  * it when it's done.
  */
 
-struct ossl_fn_ctx_st {
-    /*
-     * Pointer to the last OSSL_FN_CTX_start() location (a simple pointer into
-     * the memory area).  See the struct ossl_fn_ctx_frame_st definition below
-     * for details.
-     */
-    struct ossl_fn_ctx_frame_st *last_frame;
-
-    /*
-     * Flags
-     */
-    unsigned int is_securely_allocated : 1;
-
-    /*
-     * Current and peak usage tracking, by allocation components.
-     * The |n_*| fields hold the currently active counts; the |peak_n_*|
-     * fields hold the maximum each count has ever reached simultaneously.
-     * This allows callers to determine suitable arena parameters for a
-     * given workload without precise up-front prediction.
-     */
-    size_t n_frames;
-    size_t n_numbers;
-    size_t n_limbs;
-    size_t peak_n_frames;
-    size_t peak_n_numbers;
-    size_t peak_n_limbs;
-
-    /*
-     * The arena itself.
-     */
-    size_t msize; /* Size of the arena, in bytes */
-    unsigned char memory[];
-};
-
-struct ossl_fn_ctx_frame_st {
-    /*
-     * Pointer back to the whole arena where the frame is located,
-     * for |last_frame| bookkeeping.
-     */
-    struct ossl_fn_ctx_st *arena;
-    /*
-     * Pointer to the previous frame in the arena, allowing OSSL_FN_CTX_end()
-     * to do its job.
-     */
-    struct ossl_fn_ctx_frame_st *previous_frame;
-    /*
-     * Tracking for peak usage instrumentation.  These count the OSSL_FN
-     * instances and total limbs allocated within this frame.
-     */
-    size_t n_numbers;
-    size_t n_limbs;
-    /*
-     * Every time OSSL_FN_CTX_get() is called, the current value of
-     * |free_memory| is returned, and it's updated by incrementing it
-     * by the number of bytes given by OSSL_FN_CTX_get().
-     * The available number of bytes is limited by what's left in the arena.
-     */
-    unsigned char *free_memory; /* Pointer to the free area of the frame */
-    size_t msize; /* Size of the frame, in bytes */
-    unsigned char memory[];
-};
-
-static size_t calculate_arena_size(size_t max_n_frames, size_t max_n_numbers, size_t max_n_limbs)
-{
-    return max_n_frames * sizeof(struct ossl_fn_ctx_frame_st)
-        + max_n_numbers * sizeof(OSSL_FN)
-        + max_n_limbs * OSSL_FN_BYTES;
-}
-
 OSSL_FN_CTX *OSSL_FN_CTX_new(OSSL_LIB_CTX *libctx, size_t max_n_frames,
     size_t max_n_numbers, size_t max_n_limbs)
 {
-    size_t arena_size = calculate_arena_size(max_n_frames, max_n_numbers, max_n_limbs);
+    size_t arena_size = ossl_fn_ctx_calculate_arena_size(max_n_frames, max_n_numbers, max_n_limbs);
     OSSL_FN_CTX *ctx = OPENSSL_zalloc(sizeof(OSSL_FN_CTX) + arena_size);
 
     if (ctx != NULL)
@@ -108,7 +39,7 @@ OSSL_FN_CTX *OSSL_FN_CTX_new(OSSL_LIB_CTX *libctx, size_t max_n_frames,
 OSSL_FN_CTX *OSSL_FN_CTX_secure_new(OSSL_LIB_CTX *libctx, size_t max_n_frames,
     size_t max_n_numbers, size_t max_n_limbs)
 {
-    size_t arena_size = calculate_arena_size(max_n_frames, max_n_numbers, max_n_limbs);
+    size_t arena_size = ossl_fn_ctx_calculate_arena_size(max_n_frames, max_n_numbers, max_n_limbs);
     OSSL_FN_CTX *ctx = OPENSSL_secure_zalloc(sizeof(OSSL_FN_CTX) + arena_size);
 
     if (ctx != NULL) {

--- a/crypto/fn/fn_local.h
+++ b/crypto/fn/fn_local.h
@@ -112,4 +112,78 @@ static ossl_inline OSSL_FN *ossl_fn_copy_internal(OSSL_FN *dest,
     return dest;
 }
 
+/* OSSL_FN_CTX internals */
+
+struct ossl_fn_ctx_st {
+    /*
+     * Pointer to the last OSSL_FN_CTX_start() location (a simple pointer into
+     * the memory area).  See the struct ossl_fn_ctx_frame_st definition below
+     * for details.
+     */
+    struct ossl_fn_ctx_frame_st *last_frame;
+
+    /*
+     * Flags
+     */
+    unsigned int is_securely_allocated : 1;
+
+    /*
+     * Current and peak usage tracking, by allocation components.
+     * The |n_*| fields hold the currently active counts; the |peak_n_*|
+     * fields hold the maximum each count has ever reached simultaneously.
+     * This allows callers to determine suitable arena parameters for a
+     * given workload without precise up-front prediction.
+     */
+    size_t n_frames;
+    size_t n_numbers;
+    size_t n_limbs;
+    size_t peak_n_frames;
+    size_t peak_n_numbers;
+    size_t peak_n_limbs;
+
+    /*
+     * The arena itself.
+     */
+    size_t msize; /* Size of the arena, in bytes */
+    unsigned char memory[];
+};
+
+struct ossl_fn_ctx_frame_st {
+    /*
+     * Pointer back to the whole arena where the frame is located,
+     * for |last_frame| bookkeeping.
+     */
+    struct ossl_fn_ctx_st *arena;
+    /*
+     * Pointer to the previous frame in the arena, allowing OSSL_FN_CTX_end()
+     * to do its job.
+     */
+    struct ossl_fn_ctx_frame_st *previous_frame;
+    /*
+     * Tracking for peak usage instrumentation.  These count the OSSL_FN
+     * instances and total limbs allocated within this frame.
+     */
+    size_t n_numbers;
+    size_t n_limbs;
+    /*
+     * Every time OSSL_FN_CTX_get() is called, the current value of
+     * |free_memory| is returned, and it's updated by incrementing it
+     * by the number of bytes given by OSSL_FN_CTX_get().
+     * The available number of bytes is limited by what's left in the arena.
+     */
+    unsigned char *free_memory; /* Pointer to the free area of the frame */
+    size_t msize; /* Size of the frame, in bytes */
+    unsigned char memory[];
+};
+
+static ossl_inline size_t ossl_fn_ctx_calculate_arena_size(size_t max_n_frames,
+    size_t max_n_numbers, size_t max_n_limbs)
+{
+    return max_n_frames * sizeof(struct ossl_fn_ctx_frame_st)
+        + max_n_numbers * sizeof(OSSL_FN)
+        + max_n_limbs * OSSL_FN_BYTES;
+}
+
+/* end OSSL_FN_CTX internals */
+
 #endif

--- a/include/crypto/bn.h
+++ b/include/crypto/bn.h
@@ -126,6 +126,15 @@ int ossl_bn_rsa_fips186_5_derive_prime(BIGNUM *Y, BIGNUM *X, const BIGNUM *Xin,
 
 OSSL_LIB_CTX *ossl_bn_get_libctx(BN_CTX *ctx);
 
+/*
+ * bn_ctx_acquire_ossl_fn_ctx() and bn_ctx_release_ossl_fn_ctx() work
+ * in tandem.  They manage an OSSL_FN_CTX that is cached inside a BN_CTX
+ * for use by BIGNUM wrapper functions that delegate to OSSL_FN.
+ */
+OSSL_FN_CTX *bn_ctx_acquire_ossl_fn_ctx(BN_CTX *ctx, size_t max_n_frames,
+    size_t max_n_numbers, size_t max_n_limbs);
+void bn_ctx_release_ossl_fn_ctx(BN_CTX *ctx);
+
 extern const BIGNUM ossl_bn_inv_sqrt_2;
 
 #if defined(OPENSSL_SYS_LINUX) && !defined(FIPS_MODULE) && defined(__s390x__) \

--- a/include/crypto/fn.h
+++ b/include/crypto/fn.h
@@ -172,6 +172,23 @@ OSSL_FN_CTX *OSSL_FN_CTX_secure_new(OSSL_LIB_CTX *libctx, size_t max_n_frames,
     size_t max_n_numbers, size_t max_n_limbs);
 
 /**
+ * Report the peak number of frames, numbers, and limbs that were
+ * simultaneously active during the lifetime of the OSSL_FN_CTX.
+ * This can be used to determine suitable arena parameters for a
+ * given workload.
+ *
+ * @param[in]   ctx             The OSSL_FN_CTX to query.  This may be NULL.
+ * @param[out]  peak_n_frames   Peak number of simultaneously active frames
+ * @param[out]  peak_n_numbers  Peak number of simultaneously active OSSL_FNs
+ * @param[out]  peak_n_limbs    Peak total limbs across all active OSSL_FNs
+ *
+ * Any of the out parameters may be NULL.  If ctx is NULL, all out
+ * parameters that are non-NULL are set to 0.
+ */
+void OSSL_FN_CTX_peak_usage(const OSSL_FN_CTX *ctx, size_t *peak_n_frames,
+    size_t *peak_n_numbers, size_t *peak_n_limbs);
+
+/**
  * Free an OSSL_FN_CTX.
  *
  * @param[in]   ctx     The OSSL_FN_CTX to be freed.  This may be NULL.

--- a/test/bn_internal_test.c
+++ b/test/bn_internal_test.c
@@ -21,6 +21,8 @@
 #include "testutil.h"
 #include "bn_prime.h"
 #include "crypto/bn.h"
+#include "crypto/fn.h"
+#include "crypto/fn_intern.h"
 
 static BN_CTX *ctx;
 
@@ -86,6 +88,91 @@ err:
     return ret;
 }
 
+static int test_bn_ctx_fn_ctx(void)
+{
+    int ret = 1;
+    BN_CTX *bnctx = NULL;
+    OSSL_FN_CTX *fnctx = NULL;
+    OSSL_FN *fn = NULL;
+    const void *token = NULL;
+
+    /* Test non-secure BN_CTX */
+    if (!TEST_ptr(bnctx = BN_CTX_new()))
+        return 0;
+
+    /* Acquire should create a new OSSL_FN_CTX */
+    if (!TEST_ptr(fnctx = bn_ctx_acquire_ossl_fn_ctx(bnctx, 1, 1, 32)))
+        ret = 0;
+
+    /* The returned pointer should be cached inside BN_CTX */
+    if (ret && !TEST_ptr_eq(fnctx, bn_ctx_acquire_ossl_fn_ctx(bnctx, 1, 1, 32)))
+        ret = 0;
+
+    /* Re-acquire with same size should return the same cached context */
+    if (ret && !TEST_ptr_eq(fnctx, bn_ctx_acquire_ossl_fn_ctx(bnctx, 1, 1, 32)))
+        ret = 0;
+
+    /* Use the OSSL_FN_CTX */
+    if (ret) {
+        if (!TEST_ptr(token = OSSL_FN_CTX_start(fnctx))
+            || !TEST_ptr(fn = OSSL_FN_CTX_get_limbs(fnctx, 4))
+            || !TEST_true(OSSL_FN_CTX_end(fnctx, token)))
+            ret = 0;
+    }
+
+    /*
+     * Release does NOT free the cached OSSL_FN_CTX; it just asserts
+     * no frames are outstanding.  Re-acquire should return the same
+     * cached pointer.
+     */
+    bn_ctx_release_ossl_fn_ctx(bnctx);
+    if (ret && !TEST_ptr_eq(fnctx, bn_ctx_acquire_ossl_fn_ctx(bnctx, 1, 1, 32)))
+        ret = 0;
+
+    /*
+     * Re-acquire with a larger size should replace the cached context
+     * because the old one is too small.  (Free + alloc may reuse the
+     * same address, so only verify the new context satisfies the larger
+     * request.)
+     */
+    if (ret) {
+        OSSL_FN_CTX *small = bn_ctx_acquire_ossl_fn_ctx(bnctx, 1, 1, 8);
+        if (!TEST_ptr(small))
+            ret = 0;
+        else {
+            OSSL_FN_CTX *large = bn_ctx_acquire_ossl_fn_ctx(bnctx, 1, 1, 64);
+
+            if (!TEST_ptr(large)
+                || !TEST_ptr(token = OSSL_FN_CTX_start(large))
+                || !TEST_ptr(fn = OSSL_FN_CTX_get_limbs(large, 64))
+                || !TEST_true(OSSL_FN_CTX_end(large, token)))
+                ret = 0;
+        }
+    }
+
+    BN_CTX_free(bnctx);
+
+    /* Test secure BN_CTX */
+    if (ret) {
+        if (!TEST_ptr(bnctx = BN_CTX_secure_new()))
+            ret = 0;
+        else {
+            fn = NULL;
+            token = NULL;
+            fnctx = bn_ctx_acquire_ossl_fn_ctx(bnctx, 1, 1, 8);
+            if (!TEST_ptr(fnctx)
+                || !TEST_ptr(token = OSSL_FN_CTX_start(fnctx))
+                || !TEST_ptr(fn = OSSL_FN_CTX_get_limbs(fnctx, 1))
+                || !TEST_true(ossl_fn_is_securely_allocated(fn))
+                || !TEST_true(OSSL_FN_CTX_end(fnctx, token)))
+                ret = 0;
+            BN_CTX_free(bnctx);
+        }
+    }
+
+    return ret;
+}
+
 int setup_tests(void)
 {
     if (!TEST_ptr(ctx = BN_CTX_new()))
@@ -94,6 +181,7 @@ int setup_tests(void)
     ADD_TEST(test_is_prime_enhanced);
     ADD_ALL_TESTS(test_is_composite_enhanced, (int)OSSL_NELEM(composites));
     ADD_TEST(test_bn_small_factors);
+    ADD_TEST(test_bn_ctx_fn_ctx);
 
     return 1;
 }

--- a/test/fn_internal_test.c
+++ b/test/fn_internal_test.c
@@ -102,8 +102,8 @@ static int test_ctx(void)
     /*
      * Make a CTX that is likely to contain two 2048-bit or one 4096-bit OSSL_FN
      * and one frame (let's overestimate its size to 128 bytes).
-     * Note that OSSL_FN_CTX_new() takes a size in bytes, so we must ensure that
-     * we get that number right.
+     * Note that OSSL_FN_CTX_new() takes a maximum number of limbs in the last
+     * parameter, so we must ensure that we get that number right.
      */
     if (!TEST_ptr(ctx = OSSL_FN_CTX_new(NULL, 1, 2, 4096 / 8 / OSSL_FN_BYTES))) {
         ret = 0;
@@ -174,8 +174,8 @@ static int test_secure_ctx(void)
     /*
      * Make a CTX that is likely to contain two 2048-bit OSSL_FN and one frame
      * (let's overestimate its size to 128 bytes).
-     * Note that OSSL_FN_CTX_new() takes a size in bytes, so we must ensure that
-     * we get that number right.
+     * Note that OSSL_FN_CTX_new() takes a maximum number of limbs in the last
+     * parameter, so we must ensure that we get that number right.
      */
     if (!TEST_ptr(ctx = OSSL_FN_CTX_secure_new(NULL, 1, 2, 2048 / 8 / OSSL_FN_BYTES))) {
         ret = 0;
@@ -205,6 +205,138 @@ end:
     return ret;
 }
 
+static int test_ctx_peak_used(void)
+{
+    int ret = 1;
+    OSSL_FN_CTX *ctx = NULL;
+    OSSL_FN *f = NULL;
+    const void *token1 = NULL;
+    const void *token2 = NULL;
+    size_t frames, numbers, limbs;
+    size_t limbs_2048 = 2048 / 8 / OSSL_FN_BYTES;
+    size_t limbs_4096 = 4096 / 8 / OSSL_FN_BYTES;
+
+    if (!TEST_ptr(ctx = OSSL_FN_CTX_new(NULL, 2, 4, 256))) {
+        ret = 0;
+        goto end;
+    }
+
+    /*
+     * Fresh context.
+     */
+    OSSL_FN_CTX_peak_usage(ctx, &frames, &numbers, &limbs);
+    if (!TEST_size_t_eq(frames, 0)
+        || !TEST_size_t_eq(numbers, 0)
+        || !TEST_size_t_eq(limbs, 0))
+        ret = 0;
+
+    /*
+     * NULL context: all out parameters set to 0.
+     */
+    OSSL_FN_CTX_peak_usage(NULL, &frames, &numbers, &limbs);
+    if (!TEST_size_t_eq(frames, 0)
+        || !TEST_size_t_eq(numbers, 0)
+        || !TEST_size_t_eq(limbs, 0))
+        ret = 0;
+
+    /*
+     * NULL out parameters are tolerated.
+     */
+    OSSL_FN_CTX_peak_usage(ctx, NULL, NULL, NULL);
+
+    /*
+     * Start frame 1.
+     */
+    if (!TEST_ptr(token1 = OSSL_FN_CTX_start(ctx))) {
+        ret = 0;
+        goto end;
+    }
+    OSSL_FN_CTX_peak_usage(ctx, &frames, &numbers, &limbs);
+    if (!TEST_size_t_eq(frames, 1)
+        || !TEST_size_t_eq(numbers, 0)
+        || !TEST_size_t_eq(limbs, 0))
+        ret = 0;
+
+    /*
+     * Allocate one number in frame 1.
+     */
+    if (!TEST_ptr(f = OSSL_FN_CTX_get_bits(ctx, 2048)))
+        ret = 0;
+    OSSL_FN_CTX_peak_usage(ctx, &frames, &numbers, &limbs);
+    if (!TEST_size_t_eq(frames, 1)
+        || !TEST_size_t_eq(numbers, 1)
+        || !TEST_size_t_eq(limbs, limbs_2048))
+        ret = 0;
+
+    /*
+     * Start frame 2 (nested inside frame 1).
+     */
+    if (!TEST_ptr(token2 = OSSL_FN_CTX_start(ctx))) {
+        ret = 0;
+        goto end;
+    }
+    OSSL_FN_CTX_peak_usage(ctx, &frames, &numbers, &limbs);
+    if (!TEST_size_t_eq(frames, 2)
+        || !TEST_size_t_eq(numbers, 1)
+        || !TEST_size_t_eq(limbs, limbs_2048))
+        ret = 0;
+
+    /*
+     * Allocate one number in frame 2.
+     */
+    if (!TEST_ptr(f = OSSL_FN_CTX_get_bits(ctx, 4096)))
+        ret = 0;
+    OSSL_FN_CTX_peak_usage(ctx, &frames, &numbers, &limbs);
+    if (!TEST_size_t_eq(frames, 2)
+        || !TEST_size_t_eq(numbers, 2)
+        || !TEST_size_t_eq(limbs, limbs_2048 + limbs_4096))
+        ret = 0;
+
+    /*
+     * Allocate a second number in frame 2.
+     */
+    if (!TEST_ptr(f = OSSL_FN_CTX_get_bits(ctx, 2048)))
+        ret = 0;
+    OSSL_FN_CTX_peak_usage(ctx, &frames, &numbers, &limbs);
+    if (!TEST_size_t_eq(frames, 2)
+        || !TEST_size_t_eq(numbers, 3)
+        || !TEST_size_t_eq(limbs, limbs_2048 + limbs_4096 + limbs_2048))
+        ret = 0;
+
+    if (!TEST_true(OSSL_FN_CTX_end(ctx, token2))) {
+        ret = 0;
+        goto end;
+    }
+
+    /*
+     * After ending frame 2: peaks must not decrease.
+     */
+    OSSL_FN_CTX_peak_usage(ctx, &frames, &numbers, &limbs);
+    if (!TEST_size_t_eq(frames, 2)
+        || !TEST_size_t_eq(numbers, 3)
+        || !TEST_size_t_eq(limbs, limbs_2048 + limbs_4096 + limbs_2048))
+        ret = 0;
+
+    if (!TEST_true(OSSL_FN_CTX_end(ctx, token1))) {
+        ret = 0;
+        goto end;
+    }
+
+    /*
+     * After ending frame 1: peaks still preserved.
+     */
+    OSSL_FN_CTX_peak_usage(ctx, &frames, &numbers, &limbs);
+    if (!TEST_size_t_eq(frames, 2)
+        || !TEST_size_t_eq(numbers, 3)
+        || !TEST_size_t_eq(limbs, limbs_2048 + limbs_4096 + limbs_2048))
+        ret = 0;
+
+end:
+    OSSL_FN_CTX_free(ctx);
+
+    return ret;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(test_struct);
@@ -212,6 +344,7 @@ int setup_tests(void)
     ADD_TEST(test_secure_alloc);
     ADD_TEST(test_ctx);
     ADD_TEST(test_secure_ctx);
+    ADD_TEST(test_ctx_peak_used);
 
     return 1;
 }


### PR DESCRIPTION
This branch contains several related improvements to `OSSL_FN_CTX`:

### `OSSL_FN_CTX_peak_usage()` — arena usage instrumentation

Track the maximum number of frames, numbers, and limbs ever consumed from an `OSSL_FN_CTX` arena during its lifetime.  This allows callers to empirically size their contexts instead of predicting precise `max_n_frames / max_n_numbers / max_n_limbs` ahead of time.

### Expose internals via `fn_local.h`

Move `struct ossl_fn_ctx_st` and `struct ossl_fn_ctx_frame_st` from `fn_ctx.c` to `fn_local.h`, making them accessible to internal code.  Also expose `ossl_fn_ctx_calculate_arena_size()` as an inline helper.

### BN_CTX integration

Add an `OSSL_FN_CTX *` pointer to `struct bignum_ctx`, allowing a `BN_CTX` to cache an `OSSL_FN_CTX` for use by BIGNUM wrapper functions.  The pointer is freed automatically when `BN_CTX_free()` is called.

Also add `bn_ctx_acquire_ossl_fn_ctx()` and `bn_ctx_release_ossl_fn_ctx()`:
- acquire creates (or reuses if large enough) an `OSSL_FN_CTX` inside the `BN_CTX`, sizing it according to the caller's needs
- release checks that no frames remain in the cached `OSSL_FN_CTX`.

The acquire function respects `BN_FLG_SECURE`: if the `BN_CTX` was created with `BN_CTX_secure_new()`, the `OSSL_FN_CTX` is also allocated in secure memory.

### Actually use the cache in `BN_mul()` and `BN_sqr()`

`BN_mul()` and `BN_sqr()` were still creating and freeing their own temporary `OSSL_FN_CTX` on every call, ignoring the passed-in `BN_CTX` entirely.  Update both to acquire the `OSSL_FN_CTX` from the `BN_CTX` cache and release it afterwards.

---

Assisted-by: Pi:moonshotai/kimi-k2.6
