### PR TITLE
Fix BIO_write on file BIOs to report partial writes.

### DIFF
--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -163,23 +163,16 @@ static int file_read(BIO *b, char *out, int outl)
 
 static int file_write(BIO *b, const char *in, int inl)
 {
-    int ret = 0;
+    size_t ret = 0;
 
-    if (b->init && (in != NULL)) {
+    if (inl < INT_MAX && inl >= 0 && b->init && (in != NULL)) {
         if (b->flags & BIO_FLAGS_UPLINK_INTERNAL)
-            ret = (int)UP_fwrite(in, inl, 1, b->ptr);
+            ret = (int)UP_fwrite(in, 1, (size_t)inl, b->ptr);
         else
-            ret = (int)fwrite(in, inl, 1, (FILE *)b->ptr);
-        if (ret)
-            ret = inl;
-        /* ret=fwrite(in,1,(int)inl,(FILE *)b->ptr); */
-        /*
-         * according to Tim Hudson <tjh@openssl.org>, the commented out
-         * version above can cause 'inl' write calls under some stupid stdio
-         * implementations (VMS)
-         */
+            ret = fwrite(in, 1, (size_t)inl, (FILE *)b->ptr);
     }
-    return ret;
+
+    return (int)ret;
 }
 
 static long file_ctrl(BIO *b, int cmd, long num, void *ptr)

--- a/test/bio_eof_test.c
+++ b/test/bio_eof_test.c
@@ -223,10 +223,42 @@ static int new_style_read_ex(void)
     return ok;
 }
 
+static int test_short_file_write(void)
+{
+#if defined(OPENSSL_SYS_MACOSX)
+    int ok = 0;
+    char *data = "If you liked it then you should have put a test on it";
+    char buf[20];
+    FILE *stream = NULL;
+    BIO *bp = NULL;
+
+    stream = fmemopen(buf, 20, "wb");
+    if (!TEST_ptr(stream))
+        goto err;
+
+    bp = BIO_new_fp(stream, BIO_NOCLOSE);
+    if (!TEST_ptr(bp))
+        goto err;
+
+    if (!TEST_int_eq(BIO_write(bp, data, strlen(data)), 20))
+        goto err;
+
+    ok = 1;
+
+err:
+    fclose(stream);
+    BIO_free(bp);
+    return ok;
+#else
+    return TEST_skip("short file write test not supported on this platform");
+#endif
+}
+
 int setup_tests(void)
 {
     ADD_TEST(old_style_read_without_eof_ctrl);
     ADD_TEST(old_style_read_with_eof_ctrl);
     ADD_TEST(new_style_read_ex);
+    ADD_TEST(test_short_file_write);
     return 1;
 }


### PR DESCRIPTION
This makes it have the same behaviour as it does on all other BIOs.

Due to a longstanding workaround that should no longer be needed a partial write of the data (before a write error or end of file) was reported as no data being written out.

Fixes: https://github.com/openssl/openssl/issues/31355

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
