### PR TITLE
doc: document SSL_set_*_state SSL argument

### DIFF
--- a/doc/man3/SSL_set_connect_state.pod
+++ b/doc/man3/SSL_set_connect_state.pod
@@ -23,6 +23,8 @@ SSL_set_accept_state() sets B<ssl> to work in server mode.
 
 SSL_is_server() checks if B<ssl> is working in server mode.
 
+B<ssl> must point to a valid SSL object and B<MUST NOT> be NULL.
+
 =head1 NOTES
 
 When the SSL_CTX object was created with L<SSL_CTX_new(3)>,


### PR DESCRIPTION
SSL_set_connect_state() and SSL_set_accept_state() have no return value to report argument errors, but their documentation did not state the precondition for the SSL argument. Passing NULL, or a pointer that is not a valid SSL object, is a programmer error rather than a recoverable API error. Document that the ssl argument must point to a valid SSL object and must not be NULL.
