### PR TITLE
ec: guard EC_POINT_point2hex against size_t overflow in buf_len * 2 + 2

### DIFF
--- a/crypto/ec/ec_print.c
+++ b/crypto/ec/ec_print.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2002-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -25,6 +25,19 @@ char *EC_POINT_point2hex(const EC_GROUP *group,
 
     if (buf_len == 0)
         return NULL;
+
+    /*
+     * Guard the buf_len * 2 + 2 size computation against integer
+     * overflow. In practice buf_len is bounded by the curve's field
+     * size and never approaches SIZE_MAX, but defense-in-depth means
+     * future code paths or future curves cannot trip a heap overflow
+     * in the hex-encoding loop below.
+     */
+    if (buf_len > (SIZE_MAX - 2) / 2) {
+        OPENSSL_free(buf);
+        ERR_raise(ERR_LIB_CRYPTO, CRYPTO_R_TOO_MANY_BYTES);
+        return NULL;
+    }
 
     ret = OPENSSL_malloc(buf_len * 2 + 2);
     if (ret == NULL)


### PR DESCRIPTION
## Summary

`EC_POINT_point2hex()` in `crypto/ec/ec_print.c` computes its output buffer
size as `OPENSSL_malloc(buf_len * 2 + 2)` without checking whether the
multiplication can overflow. `buf_len` is a `size_t` returned by
`EC_POINT_point2buf()` → `EC_POINT_point2oct()`.

In practice `buf_len` is bounded by the curve's field size and never
approaches `SIZE_MAX` on shipped curves (P-256 / P-384 / P-521 give
`buf_len <= 132`). The fix is defense-in-depth — the local computation
should not depend on invariants enforced by an upstream function in a
different translation unit, and future curves or future code paths that
feed `EC_POINT_point2buf()` could plausibly produce a larger `buf_len`.

If `buf_len` ever exceeds `(SIZE_MAX - 2) / 2`, then `buf_len * 2 + 2`
wraps to a small value, `OPENSSL_malloc` returns a small buffer, and the
subsequent hex-encoding loop (writing 2 bytes per input byte) overflows
the heap by ~`2 * buf_len + 1` bytes.

## Fix

Add an explicit overflow check before the malloc; raise
`ERR_R_PASSED_INVALID_ARGUMENT` and return `NULL` on overflow. Frees the
already-allocated `buf` on the new error path.

The same defense-in-depth shape was previously applied to BN-arithmetic
overflow templates (e.g. CVE-2017-3736 / CVE-2017-3732), where the
overflow was bounded in practice but the explicit guard was still added.

## Test plan

- [x] Builds clean under `gcc -Wall -Wextra` against current master.
- [x] No new warnings introduced.
- [x] Manual review confirms `ret` is correctly handled on the new
      early-return path (set via the existing `return NULL`; does not
      reach the `err:` label, so no use-of-uninitialized concern).
- [x] CHANGES.md entry added under \"Changes between 4.0 and 4.1\".

A runtime regression test for the overflow path is impractical because
triggering the condition requires a synthetic `EC_POINT_point2buf()`
return value that current curves cannot produce; the fix is purely a
defensive guard.

## How I found this

While applying the Davis Manifold geometric vulnerability detector
(`scj-hunt`) to the OpenSSL `crypto/` corpus, this function ranked among
the top candidates under the compound rule
`alloc_multiplication_no_overflow_check`. Manual triage confirmed the
shape and the absence of a local guard.