### PR TITLE
ech: enforce encoded_inner_len <= clear_len locally in ossl_ech_aad_and_encrypt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,6 +73,18 @@ OpenSSL Releases
 
    *Jakub Zelenka*
 
+ * Hardened `ossl_ech_aad_and_encrypt()` against a future invariant
+   break between `tls_construct_ctos_ech()` (which sets
+   `s->ext.ech.encoded_inner_len` from `ossl_ech_encode_inner()` and
+   `s->ext.ech.clearlen` from `ossl_ech_calc_padding()`) and the
+   `memcpy(clear, encoded_inner, encoded_inner_len)` site, by
+   verifying `encoded_inner_len <= clear_len` locally before the
+   copy.  The relationship holds today by `ossl_ech_calc_padding()`
+   arithmetic, but the local function should not rely on a
+   cross-translation-unit invariant for memory safety.
+
+   *Bee Rosa Davis*
+
  * Added support for Ed25519 and Ed448 certificates in DTLS 1.2. Previously,
    these certificate types were only supported in TLS 1.2 and TLS 1.3.
 

--- a/ssl/ech/ech_internal.c
+++ b/ssl/ech/ech_internal.c
@@ -729,6 +729,24 @@ int ossl_ech_aad_and_encrypt(SSL_CONNECTION *s, WPACKET *pkt)
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;
     }
+    /*
+     * Defense-in-depth: encoded_inner_len and clear_len are computed
+     * independently in tls_construct_ctos_ech() (encoded_inner_len
+     * from ossl_ech_encode_inner(), clear_len from
+     * ossl_ech_calc_padding()) which guarantees
+     * clear_len >= encoded_inner_len by the padding arithmetic.
+     * The relationship is not enforced locally, however --- a future
+     * widening of any intermediate type in calc_padding (which uses
+     * mixed size_t / int arithmetic) or a refactor that decouples
+     * the two computations would silently break the invariant and
+     * turn the memcpy below into a heap-buffer overflow.  Check it
+     * here so the function does not depend on cross-file invariants.
+     */
+    if (encoded_inner_len > clear_len) {
+        OPENSSL_free(clear);
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        goto err;
+    }
     memcpy(clear, encoded_inner, encoded_inner_len);
 #ifdef OSSL_ECH_SUPERVERBOSE
     ossl_ech_pbuf("EAAE: padded clear", clear, clear_len);


### PR DESCRIPTION
## Summary

`ossl_ech_aad_and_encrypt()` in `ssl/ech/ech_internal.c` performs
`memcpy(clear, encoded_inner, encoded_inner_len)` into a buffer of size
`clear_len`, where the relationship
`clear_len >= encoded_inner_len` is established **upstream in a
different translation unit** (in `tls_construct_ctos_ech()` in
`ssl/statem/extensions_clnt.c`) and then trusted by the local
function without verification.

The upstream sets:

```c
encoded_inner_len = s->ext.ech.encoded_inner_len;   // from ossl_ech_encode_inner()
clear_len         = s->ext.ech.clearlen;            // from ossl_ech_calc_padding()
```

`ossl_ech_calc_padding()` math currently guarantees
`clear_len >= encoded_len`, so the invariant holds today.

## Why we should still check it locally

- The padding computation in `ossl_ech_calc_padding()` uses mixed
  `size_t` / `int` arithmetic (see `(int)encoded_len` cast at
  `ssl/ech/ech_internal.c:643`), currently safe because ClientHello
  is bounded to ≤ 64 KB by TLS framing limits but a brittle dependency.
- A future widening of any intermediate type, a refactor that
  decouples `ossl_ech_encode_inner()` from `ossl_ech_calc_padding()`,
  or a hostile ECHConfig that drove either value abnormally could
  silently break the invariant.
- Breaking it would turn the local `memcpy` into a heap-buffer
  overflow in the client-side ECH path.
- ECH (TLSEXT_TYPE_ech, RFC 9849) is recently-merged code with
  fewer deployment hours than the rest of the TLS state machine,
  which makes local hardening especially valuable.

## Fix

Add an explicit `if (encoded_inner_len > clear_len)` check before
the memcpy, freeing `clear` and raising `SSLfatal` on the new
error path.

## How I found this

While ranking `openssl/ssl/` functions under the
`memcpy_in_tls_path_no_size_check` compound rule of the Davis
Manifold geometric vulnerability detector (scj-hunt). The function
was flagged because it does an attacker-influenced-size memcpy
without a local size check, even though the upstream invariant
ensures correctness today.

## Relationship to PR #31436

This is the same "brick-wall defense" template as
[`#31436`](https://github.com/openssl/openssl/pull/31436)
(`EC_POINT_point2hex`): the local computation is correct under the
current upstream invariants but should not depend on cross-file
invariants for memory safety.

## Test plan

- [x] Builds clean under `gcc -Wall -Wextra` against current master.
- [x] No new warnings.
- [x] No change in behavior on the happy path (`encoded_inner_len <= clear_len`).
- [x] On the new error path, the existing `OPENSSL_free(clear)` +
      `SSLfatal()` infrastructure is reused.
- [x] `CHANGES.md` entry added under "Changes between 4.0 and 4.1".

The error path is currently unreachable on the in-tree ECH code, so
a runtime regression test would require either a synthetic mock or
a hostile ECHConfig that intentionally breaks the calc_padding
invariant; happy to add a unit test if reviewers want one.