### PR TITLE
Fix OSSL_FN wrapper result sizing

### DIFF
--- a/crypto/bn/bn_add.c
+++ b/crypto/bn/bn_add.c
@@ -10,19 +10,14 @@
 #include "internal/cryptlib.h"
 #include "bn_local.h"
 
-static size_t calculate_max_limbs(const BIGNUM *a, const BIGNUM *b)
+static size_t calculate_max_top(const BIGNUM *a, const BIGNUM *b)
 {
-    OSSL_FN *af = a->data;
-    OSSL_FN *bf = b->data;
-
-    return (af->dsize > bf->dsize) ? af->dsize : bf->dsize;
+    return (a->top > b->top) ? a->top : b->top;
 }
 
 static bool is_highest_bit_set(const BIGNUM *a)
 {
-    OSSL_FN *af = a->data;
-
-    return (af->d[af->dsize - 1] & OSSL_FN_HIGH_BIT_MASK) != 0;
+    return a->top > 0 && (a->d[a->top - 1] & OSSL_FN_HIGH_BIT_MASK) != 0;
 }
 
 /* signed add of b to a. */
@@ -147,18 +142,18 @@ int BN_uadd(BIGNUM *r, const BIGNUM *a, const BIGNUM *b)
     bn_check_top(a);
     bn_check_top(b);
 
-    size_t max = calculate_max_limbs(a, b);
+    size_t top = calculate_max_top(a, b);
 
     /*
      * If either operands have the highest bit set the result may become
      * one limb larger.
      */
     if (is_highest_bit_set(a) || is_highest_bit_set(b))
-        max++;
+        top++;
 
-    OSSL_FN *rf = bn_acquire_ossl_fn(r, (int)max);
+    OSSL_FN *rf = bn_acquire_ossl_fn(r, (int)top);
     int ret = OSSL_FN_add(rf, a->data, b->data);
-    bn_release(r, (int)max);
+    bn_release(r, (int)top);
 
     return ret;
 }
@@ -226,11 +221,11 @@ int BN_usub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b)
         return 0;
     }
 
-    size_t max = calculate_max_limbs(a, b);
+    size_t top = calculate_max_top(a, b);
 
-    OSSL_FN *rf = bn_acquire_ossl_fn(r, (int)max);
+    OSSL_FN *rf = bn_acquire_ossl_fn(r, (int)top);
     int ret = OSSL_FN_sub(rf, a->data, b->data);
-    bn_release(r, (int)max);
+    bn_release(r, (int)top);
 
     return ret;
 }

--- a/crypto/bn/bn_mul.c
+++ b/crypto/bn/bn_mul.c
@@ -27,7 +27,14 @@ int BN_mul(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, BN_CTX *ctx)
     bn_check_top(b);
     bn_check_top(r);
 
+    /*
+     * Acquiring rf may make r larger.
+     * If r == a, then a will also become larger.  Therefore, max must
+     * be calculated after rf has been acquired.
+     */
     size_t top = a->top + b->top;
+    OSSL_FN *rf = bn_acquire_ossl_fn(r, (int)top);
+
     size_t max = a->dmax + b->dmax;
 
     /*
@@ -36,7 +43,6 @@ int BN_mul(BIGNUM *r, const BIGNUM *a, const BIGNUM *b, BN_CTX *ctx)
      * (OSSL_FN_CTX is only really useful within OSSL_FN functionality)
      */
     OSSL_FN_CTX *fnctx = OSSL_FN_CTX_new(NULL, 1, 1, max);
-    OSSL_FN *rf = bn_acquire_ossl_fn(r, (int)top);
     int ret = OSSL_FN_mul(rf, a->data, b->data, fnctx);
     bn_release(r, (int)top);
 

--- a/crypto/bn/bn_sqr.c
+++ b/crypto/bn/bn_sqr.c
@@ -29,7 +29,14 @@ int BN_sqr(BIGNUM *r, const BIGNUM *a, BN_CTX *ctx)
     bn_check_top(a);
     bn_check_top(r);
 
+    /*
+     * Acquiring rf may make r larger.
+     * If r == a, then a will also become larger.  Therefore, max must
+     * be calculated after rf has been acquired.
+     */
     size_t top = a->top * 2;
+    OSSL_FN *rf = bn_acquire_ossl_fn(r, (int)top);
+
     size_t max = a->dmax * 2;
 
     /*
@@ -38,7 +45,6 @@ int BN_sqr(BIGNUM *r, const BIGNUM *a, BN_CTX *ctx)
      * (OSSL_FN_CTX is only really useful within OSSL_FN functionality)
      */
     OSSL_FN_CTX *fnctx = OSSL_FN_CTX_new(NULL, 1, 2, max * 4);
-    OSSL_FN *rf = bn_acquire_ossl_fn(r, (int)top);
     int ret = OSSL_FN_sqr(rf, a->data, fnctx);
     bn_release(r, (int)top);
     r->neg = 0;


### PR DESCRIPTION
This adjusts the current `BN_` wrappers around `OSSL_FN_` functions so
result sizing and context sizing follow the intended split:

- Size acquired result `OSSL_FN`s from operand `top`.
- Keep `OSSL_FN_CTX` sizing based on allocated width (`dmax` /
  `data->dsize`).
- Acquire writable results before reading operand sizes used for
  `OSSL_FN_CTX` sizing, so aliasing result operands cannot make those
  reads stale.

Assisted-by: Pi:openai/gpt-5.5
