### PR TITLE
Use %zu for printing size_t values

### DIFF
--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -704,7 +704,7 @@ void msg_cb(int write_p, int version, int content_type, const void *buf,
         str_version = tmpbuf;
     }
 
-    BIO_printf(bio, "%s %s%s [length %04zu]%s%s\n", str_write_p, str_version,
+    BIO_printf(bio, "%s %s%s [length %04zx]%s%s\n", str_write_p, str_version,
         str_content_type, len, str_details1,
         str_details2);
 

--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -704,8 +704,8 @@ void msg_cb(int write_p, int version, int content_type, const void *buf,
         str_version = tmpbuf;
     }
 
-    BIO_printf(bio, "%s %s%s [length %04lx]%s%s\n", str_write_p, str_version,
-        str_content_type, (unsigned long)len, str_details1,
+    BIO_printf(bio, "%s %s%s [length %04zu]%s%s\n", str_write_p, str_version,
+        str_content_type, len, str_details1,
         str_details2);
 
     if (len > 0) {

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -187,8 +187,8 @@ static unsigned int psk_server_cb(SSL *ssl, const char *identity,
         goto out_err;
     }
     if (s_debug)
-        BIO_printf(bio_s_out, "identity_len=%d identity=%s\n",
-            (int)strlen(identity), identity);
+        BIO_printf(bio_s_out, "identity_len=%zu identity=%s\n",
+            strlen(identity), identity);
 
     /* here we could lookup the given identity e.g. from a database */
     if (strcmp(identity, psk_identity) != 0) {

--- a/demos/digest/EVP_MD_demo.c
+++ b/demos/digest/EVP_MD_demo.c
@@ -147,8 +147,8 @@ static int demonstrate_digest(void)
     fprintf(stdout, "\n");
     /* Check digest_value against the known answer */
     if ((size_t)digest_length != sizeof(known_answer)) {
-        fprintf(stdout, "Digest length(%d) not equal to known answer length(%lu).\n",
-            digest_length, (unsigned long)sizeof(known_answer));
+        fprintf(stdout, "Digest length(%u) not equal to known answer length(%zu).\n",
+            digest_length, sizeof(known_answer));
     } else if (memcmp(digest_value, known_answer, digest_length) != 0) {
         for (j = 0; j < sizeof(known_answer); j++) {
             fprintf(stdout, "%02x", known_answer[j]);

--- a/demos/http3/ossl-nghttp3-demo-server.c
+++ b/demos/http3/ossl-nghttp3-demo-server.c
@@ -323,7 +323,7 @@ static int on_recv_data(nghttp3_conn *conn, int64_t stream_id,
     const uint8_t *data, size_t datalen,
     void *conn_user_data, void *stream_user_data)
 {
-    fprintf(stderr, "on_recv_data! %ld\n", (unsigned long)datalen);
+    fprintf(stderr, "on_recv_data! %zu\n", datalen);
     fprintf(stderr, "on_recv_data! %.*s\n", (int)datalen, data);
     return 0;
 }
@@ -502,7 +502,7 @@ static int read_from_ssl_ids(nghttp3_conn **curh3conn, struct h3ssl *h3ssl)
         printf("SSL_poll failed\n");
         return -1; /* something is wrong */
     }
-    printf("read_from_ssl_ids %ld events\n", (unsigned long)result_count);
+    printf("read_from_ssl_ids %zu events\n", result_count);
     if (result_count == 0) {
         /* Timeout may be something somewhere */
         return 0;
@@ -862,12 +862,12 @@ static int quic_server_write(struct h3ssl *h3ssl, uint64_t streamid,
                 ERR_print_errors_fp(stderr);
                 return 0;
             }
-            printf("written %lld on %lld flags %lld\n", (unsigned long long)len,
+            printf("written %zu on %llu flags %llu\n", len,
                 (unsigned long long)streamid, (unsigned long long)flags);
             return 1;
         }
     }
-    printf("quic_server_write %lld on %lld (NOT FOUND!)\n", (unsigned long long)len,
+    printf("quic_server_write %zu on %llu (NOT FOUND!)\n", len,
         (unsigned long long)streamid);
     return 0;
 }
@@ -1226,8 +1226,8 @@ static int run_quic_server(SSL_CTX *ctx, int fd)
                 size_t numbytes = vec[i].len;
                 int flagwrite = 0;
 
-                printf("quic_server_write on %llu for %ld\n",
-                    (unsigned long long)streamid, (unsigned long)vec[i].len);
+                printf("quic_server_write on %llu for %zu\n",
+                    (unsigned long long)streamid, vec[i].len);
                 if (fin && i == sveccnt - 1)
                     flagwrite = SSL_WRITE_FLAG_CONCLUDE;
                 if (!quic_server_write(&h3ssl, streamid, vec[i].base,

--- a/ssl/ech/ech_internal.c
+++ b/ssl/ech/ech_internal.c
@@ -39,9 +39,9 @@ void ossl_ech_pbuf(const char *msg, const unsigned char *buf, const size_t blen)
             BIO_printf(trc_out, "msg is NULL\n");
         } else if (buf == NULL || blen == 0) {
             BIO_printf(trc_out, "%s: buf is %p\n", msg, (void *)buf);
-            BIO_printf(trc_out, "%s: blen is %lu\n", msg, (unsigned long)blen);
+            BIO_printf(trc_out, "%s: blen is %zu\n", msg, blen);
         } else {
-            BIO_printf(trc_out, "%s (%lu)\n", msg, (unsigned long)blen);
+            BIO_printf(trc_out, "%s (%zu)\n", msg, blen);
             BIO_dump_indent(trc_out, buf, (int)blen, 4);
         }
     }

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -824,7 +824,7 @@ int tls_get_more_records(OSSL_RECORD_LAYER *rl)
     }
     OSSL_TRACE_BEGIN(TLS)
     {
-        BIO_printf(trc_out, "dec %lu\n", (unsigned long)rr[0].length);
+        BIO_printf(trc_out, "dec %zu\n", rr[0].length);
         BIO_dump_indent(trc_out, rr[0].data, (int)rr[0].length, 4);
     }
     OSSL_TRACE_END(TLS);

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -674,7 +674,7 @@ static void ssl_print_hex(BIO *bio, int indent, const char *name,
     size_t i;
 
     BIO_indent(bio, indent, 80);
-    BIO_printf(bio, "%s (len=%d): ", name, (int)msglen);
+    BIO_printf(bio, "%s (len=%zu): ", name, msglen);
     for (i = 0; i < msglen; i++)
         BIO_printf(bio, "%02X", msg[i]);
     BIO_puts(bio, "\n");
@@ -769,8 +769,8 @@ static int ssl_print_extension(BIO *bio, int indent, int server,
     uint32_t max_early_data;
 
     BIO_indent(bio, indent, 80);
-    BIO_printf(bio, "extension_type=%s(%d), length=%d\n",
-        ssl_trace_str(extype, ssl_exts_tbl), extype, (int)extlen);
+    BIO_printf(bio, "extension_type=%s(%d), length=%zu\n",
+        ssl_trace_str(extype, ssl_exts_tbl), extype, extlen);
     switch (extype) {
     case TLSEXT_TYPE_compress_certificate:
         if (extlen < 1)
@@ -996,7 +996,7 @@ static int ssl_print_extensions(BIO *bio, int indent, int server,
     }
     if (extslen > msglen)
         return 0;
-    BIO_printf(bio, "extensions, length = %d\n", (int)extslen);
+    BIO_printf(bio, "extensions, length = %zu\n", extslen);
     msglen -= extslen;
     while (extslen > 0) {
         int extype;
@@ -1006,8 +1006,8 @@ static int ssl_print_extensions(BIO *bio, int indent, int server,
         extype = (msg[0] << 8) | msg[1];
         extlen = (msg[2] << 8) | msg[3];
         if (extslen < extlen + 4) {
-            BIO_printf(bio, "extensions, extype = %d, extlen = %d\n", extype,
-                (int)extlen);
+            BIO_printf(bio, "extensions, extype = %d, extlen = %zu\n", extype,
+                extlen);
             BIO_dump_indent(bio, (const char *)msg, (int)extslen, indent + 2);
             return 0;
         }
@@ -1046,7 +1046,7 @@ static int ssl_print_client_hello(BIO *bio, const SSL_CONNECTION *sc, int indent
     msg += 2;
     msglen -= 2;
     BIO_indent(bio, indent, 80);
-    BIO_printf(bio, "cipher_suites (len=%d)\n", (int)len);
+    BIO_printf(bio, "cipher_suites (len=%zu)\n", len);
     if (msglen < len || len & 1)
         return 0;
     while (len > 0) {
@@ -1066,7 +1066,7 @@ static int ssl_print_client_hello(BIO *bio, const SSL_CONNECTION *sc, int indent
     if (msglen < len)
         return 0;
     BIO_indent(bio, indent, 80);
-    BIO_printf(bio, "compression_methods (len=%d)\n", (int)len);
+    BIO_printf(bio, "compression_methods (len=%zu)\n", len);
     while (len > 0) {
         BIO_indent(bio, indent + 2, 80);
         BIO_printf(bio, "%s (0x%02X)\n",
@@ -1306,7 +1306,7 @@ static int ssl_print_certificate(BIO *bio, const SSL_CONNECTION *sc, int indent,
         return 0;
     q = p + 3;
     BIO_indent(bio, indent, 80);
-    BIO_printf(bio, "ASN.1Cert, length=%d", (int)clen);
+    BIO_printf(bio, "ASN.1Cert, length=%zu", clen);
     x = X509_new_ex(ctx->libctx, ctx->propq);
     if (x != NULL && d2i_X509(&x, &q, (long)clen) == NULL) {
         X509_free(x);
@@ -1362,7 +1362,7 @@ static int ssl_print_raw_public_key(BIO *bio, const SSL_CONNECTION *sc,
     }
 
     BIO_indent(bio, indent, 80);
-    BIO_printf(bio, "raw_public_key, length=%d\n", (int)clen);
+    BIO_printf(bio, "raw_public_key, length=%zu\n", clen);
 
     pkey = d2i_PUBKEY_ex(NULL, &msg, (long)clen,
         sc->ssl.ctx->libctx, sc->ssl.ctx->propq);
@@ -1400,7 +1400,7 @@ static int ssl_print_certificates(BIO *bio, const SSL_CONNECTION *sc, int server
         return 1;
     }
     BIO_indent(bio, indent, 80);
-    BIO_printf(bio, "certificate_list, length=%d\n", (int)clen);
+    BIO_printf(bio, "certificate_list, length=%zu\n", clen);
     while (clen > 0) {
         if (!ssl_print_certificate(bio, sc, indent + 2, &msg, &clen))
             return 0;
@@ -1440,12 +1440,12 @@ static int ssl_print_compressed_certificates(BIO *bio, const SSL_CONNECTION *sc,
     BIO_indent(bio, indent, 80);
     BIO_printf(bio, "Compression type=%s (0x%04x)\n", ssl_trace_str(alg, ssl_comp_cert_tbl), alg);
     BIO_indent(bio, indent, 80);
-    BIO_printf(bio, "Uncompressed length=%d\n", (int)uclen);
+    BIO_printf(bio, "Uncompressed length=%zu\n", uclen);
     BIO_indent(bio, indent, 80);
     if (clen > 0)
-        BIO_printf(bio, "Compressed length=%d, Ratio=%f:1\n", (int)clen, (float)uclen / (float)clen);
+        BIO_printf(bio, "Compressed length=%zu, Ratio=%f:1\n", clen, (float)uclen / (float)clen);
     else
-        BIO_printf(bio, "Compressed length=%d, Ratio=unknown\n", (int)clen);
+        BIO_printf(bio, "Compressed length=%zu, Ratio=unknown\n", clen);
 
     BIO_dump_indent(bio, (const char *)msg, (int)clen, indent);
 
@@ -1506,7 +1506,7 @@ static int ssl_print_cert_request(BIO *bio, int indent, const SSL_CONNECTION *sc
             return 0;
         msg++;
         BIO_indent(bio, indent, 80);
-        BIO_printf(bio, "certificate_types (len=%d)\n", (int)xlen);
+        BIO_printf(bio, "certificate_types (len=%zu)\n", xlen);
         if (!ssl_trace_list(bio, indent + 2, msg, xlen, 1, ssl_ctype_tbl))
             return 0;
         msg += xlen;
@@ -1521,7 +1521,7 @@ static int ssl_print_cert_request(BIO *bio, int indent, const SSL_CONNECTION *sc
         msg += 2;
         msglen -= xlen + 2;
         BIO_indent(bio, indent, 80);
-        BIO_printf(bio, "signature_algorithms (len=%d)\n", (int)xlen);
+        BIO_printf(bio, "signature_algorithms (len=%zu)\n", xlen);
         while (xlen > 0) {
             BIO_indent(bio, indent + 2, 80);
             sigalg = (msg[0] << 8) | msg[1];
@@ -1541,7 +1541,7 @@ static int ssl_print_cert_request(BIO *bio, int indent, const SSL_CONNECTION *sc
         return 0;
     msg += 2;
     msglen -= 2 + xlen;
-    BIO_printf(bio, "certificate_authorities (len=%d)\n", (int)xlen);
+    BIO_printf(bio, "certificate_authorities (len=%zu)\n", xlen);
     while (xlen > 0) {
         size_t dlen;
         X509_NAME *nm;
@@ -1553,7 +1553,7 @@ static int ssl_print_cert_request(BIO *bio, int indent, const SSL_CONNECTION *sc
             return 0;
         msg += 2;
         BIO_indent(bio, indent + 2, 80);
-        BIO_printf(bio, "DistinguishedName (len=%d): ", (int)dlen);
+        BIO_printf(bio, "DistinguishedName (len=%zu): ", dlen);
         p = msg;
         nm = d2i_X509_NAME(NULL, &p, (long)dlen);
         if (!nm) {
@@ -1634,8 +1634,8 @@ static int ssl_print_handshake(BIO *bio, const SSL_CONNECTION *sc, int server,
     htype = msg[0];
     hlen = (msg[1] << 16) | (msg[2] << 8) | msg[3];
     BIO_indent(bio, indent, 80);
-    BIO_printf(bio, "%s, Length=%d\n",
-        ssl_trace_str(htype, ssl_handshake_tbl), (int)hlen);
+    BIO_printf(bio, "%s, Length=%zu\n",
+        ssl_trace_str(htype, ssl_handshake_tbl), hlen);
     msg += 4;
     msglen -= 4;
     if (SSL_CONNECTION_IS_DTLS(sc)) {

--- a/test/bftest.c
+++ b/test/bftest.c
@@ -267,8 +267,8 @@ static int print_test_data(void)
     printf("\niv[8]     = ");
     for (j = 0; j < 8; j++)
         printf("%02X", cbc_iv[j]);
-    printf("\ndata[%d]  = '%s'", (int)strlen(cbc_data) + 1, cbc_data);
-    printf("\ndata[%d]  = ", (int)strlen(cbc_data) + 1);
+    printf("\ndata[%zu]  = '%s'", strlen(cbc_data) + 1, cbc_data);
+    printf("\ndata[%zu]  = ", strlen(cbc_data) + 1);
     for (j = 0; j < strlen(cbc_data) + 1; j++)
         printf("%02X", cbc_data[j]);
     printf("\n");
@@ -279,13 +279,13 @@ static int print_test_data(void)
     printf("\n");
 
     printf("cfb64 cipher text\n");
-    printf("cipher[%d]= ", (int)strlen(cbc_data) + 1);
+    printf("cipher[%zu]= ", strlen(cbc_data) + 1);
     for (j = 0; j < strlen(cbc_data) + 1; j++)
         printf("%02X", cfb64_ok[j]);
     printf("\n");
 
     printf("ofb64 cipher text\n");
-    printf("cipher[%d]= ", (int)strlen(cbc_data) + 1);
+    printf("cipher[%zu]= ", strlen(cbc_data) + 1);
     for (j = 0; j < strlen(cbc_data) + 1; j++)
         printf("%02X", ofb64_ok[j]);
     printf("\n");

--- a/test/dtls_mtu_test.c
+++ b/test/dtls_mtu_test.c
@@ -83,9 +83,9 @@ static int mtu_test(SSL_CTX *ctx, const char *cs, int no_etm)
         SSL_set_mtu(clnt_ssl, 500 + i);
         mtus[i] = DTLS_get_data_mtu(clnt_ssl);
         if (debug)
-            TEST_info("%s%s MTU for record mtu %d = %lu",
+            TEST_info("%s%s MTU for record mtu %d = %zu",
                 cs, no_etm ? "-noEtM" : "",
-                500 + i, (unsigned long)mtus[i]);
+                500 + i, mtus[i]);
         if (!TEST_size_t_ne(mtus[i], 0)) {
             TEST_info("Cipher %s MTU %d", cs, 500 + i);
             goto end;
@@ -116,9 +116,8 @@ static int mtu_test(SSL_CTX *ctx, const char *cs, int no_etm)
                  * We sent a packet smaller than or equal to mtus[j] and
                  * that made a record *larger* than the record MTU 500+j!
                  */
-                TEST_error("%s: s=%lu, mtus[i]=%lu, reclen=%lu, i=%d",
-                    cs, (unsigned long)s, (unsigned long)mtus[i],
-                    (unsigned long)reclen, 500 + i);
+                TEST_error("%s: s=%zu, mtus[i]=%zu, reclen=%zu, i=%d",
+                    cs, s, mtus[i], reclen, 500 + i);
                 goto end;
             }
             if (!TEST_false(s > mtus[i] && reclen <= (size_t)(500 + i))) {
@@ -127,9 +126,8 @@ static int mtu_test(SSL_CTX *ctx, const char *cs, int no_etm)
                  * fits within the record MTU 500+i, so DTLS_get_data_mtu()
                  * was overly pessimistic.
                  */
-                TEST_error("%s: s=%lu, mtus[i]=%lu, reclen=%lu, i=%d",
-                    cs, (unsigned long)s, (unsigned long)mtus[i],
-                    (unsigned long)reclen, 500 + i);
+                TEST_error("%s: s=%zu, mtus[i]=%zu, reclen=%zu, i=%d",
+                    cs, s, mtus[i], reclen, 500 + i);
                 goto end;
             }
         }

--- a/test/ech_corrupt_test.c
+++ b/test/ech_corrupt_test.c
@@ -1767,7 +1767,7 @@ static int ech_retry_config_test(int idx)
         if (!TEST_int_ne((int)retryconfiglen, 0))
             goto end;
         if (verbose)
-            TEST_info("ech_retry_config_test: retryconfglen: %d\n", (int)retryconfiglen);
+            TEST_info("ech_retry_config_test: retryconfglen: %zu\n", retryconfiglen);
         /* we kow the size to expect as the configs are hard-coded above */
         if (!TEST_size_t_eq(retryconfiglen, 64))
             goto end;

--- a/test/ech_test.c
+++ b/test/ech_test.c
@@ -1924,7 +1924,7 @@ static int ech_grease_test(int idx)
     if (!TEST_int_ne((int)retryconfiglen, 0))
         goto end;
     if (verbose)
-        TEST_info("ech_grease_test: retryconfglen: %d\n", (int)retryconfiglen);
+        TEST_info("ech_grease_test: retryconfglen: %zu\n", retryconfiglen);
     /* we kow the sizes to expect as the configs are hard-coded above */
     if (idx == 2 && !TEST_size_t_eq(retryconfiglen, 141))
         goto end;

--- a/test/modes_internal_test.c
+++ b/test/modes_internal_test.c
@@ -197,7 +197,7 @@ static int execute_cts128(const CTS128_FIXTURE *fixture, int num)
     unsigned char cleartext[64], ciphertext[64], vector[64];
     size_t tail, size;
 
-    TEST_info("%s_vector_%lu", fixture->case_name, (unsigned long)len);
+    TEST_info("%s_vector_%zu", fixture->case_name, len);
 
     tail = fixture->last_blocks_correction(orig_vector, vector, len);
 

--- a/test/params_test.c
+++ b/test/params_test.c
@@ -648,9 +648,9 @@ static int check_int_from_text(const struct int_from_text_test_st a)
         return 0;
     }
     if (param.data_size != a.expected_bufsize) {
-        TEST_error("unexpected size for %s \"%s\":  %d != %d",
+        TEST_error("unexpected size for %s \"%s\":  %zu != %zu",
             a.argname, a.strval,
-            (int)a.expected_bufsize, (int)param.data_size);
+            a.expected_bufsize, param.data_size);
         return 0;
     }
 

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -1705,12 +1705,12 @@ static int test_bw_limit(void)
                     sendlen > TEST_SINGLE_WRITE_SIZE ? TEST_SINGLE_WRITE_SIZE
                                                      : sendlen,
                     &written)) {
-                TEST_info("Retrying to send: %llu", (unsigned long long)sendlen);
+                TEST_info("Retrying to send: %zu", sendlen);
                 if (!TEST_int_eq(SSL_get_error(clientquic, 0), SSL_ERROR_WANT_WRITE))
                     goto err;
             } else {
                 sendlen -= written;
-                TEST_info("Remaining to send: %llu", (unsigned long long)sendlen);
+                TEST_info("Remaining to send: %zu", sendlen);
             }
         } else {
             SSL_handle_events(clientquic);
@@ -1722,9 +1722,9 @@ static int test_bw_limit(void)
                 &readbytes)
             && readbytes > 1) {
             recvlen -= readbytes;
-            TEST_info("Remaining to recv: %llu", (unsigned long long)recvlen);
+            TEST_info("Remaining to recv: %zu", recvlen);
         } else {
-            TEST_info("No progress on recv: %llu", (unsigned long long)recvlen);
+            TEST_info("No progress on recv: %zu", recvlen);
         }
         ossl_quic_tserver_tick(qtserv);
     }

--- a/test/ssl_old_test.c
+++ b/test/ssl_old_test.c
@@ -2478,7 +2478,7 @@ int doit_biopair(SSL *s_ssl, SSL *c_ssl, long count,
                     progress = 1;
 
                     if (debug)
-                        printf((io1 == client_io) ? "C->S relaying: %d bytes\n" : "S->C relaying: %d bytes\n", (int)num);
+                        printf((io1 == client_io) ? "C->S relaying: %zu bytes\n" : "S->C relaying: %zu bytes\n", num);
                 }
             } while (r1 && r2);
 
@@ -2525,7 +2525,7 @@ int doit_biopair(SSL *s_ssl, SSL *c_ssl, long count,
                     }
 
                     if (debug)
-                        printf((io2 == client_io) ? "C->S relaying: %d bytes\n" : "S->C relaying: %d bytes\n", (int)num);
+                        printf((io2 == client_io) ? "C->S relaying: %zu bytes\n" : "S->C relaying: %zu bytes\n", num);
                 }
             } /* no loop, BIO_ctrl_get_read_request now
                * returns 0 anyway */

--- a/test/tls12psk.c
+++ b/test/tls12psk.c
@@ -51,7 +51,7 @@ static void hello_session_id(const unsigned char *p, size_t len)
         return;
 
     str = OPENSSL_buf2hexstr(p + HELLO_SID_OFF, (long)sid_len);
-    TEST_info("session_id(%u): <%s>", (unsigned int)sid_len, str);
+    TEST_info("session_id(%zu): <%s>", sid_len, str);
     OPENSSL_free(str);
 }
 


### PR DESCRIPTION
Replace `%d`/`%ld`/`%llu` with explicit casts with the correct %zu format specifier across all files. This avoids relying on integer conversions that can truncate on platforms where `size_t` is wider than `int` or `unsigned long`. 

Fixes https://github.com/openssl/openssl/issues/31387