### PR TITLE
backport: `cmp_client_test.c`: fix partly too generous `total_timeout` limit for IR session with polling

### DIFF
--- a/test/cmp_client_test.c
+++ b/test/cmp_client_test.c
@@ -239,7 +239,9 @@ static int test_exec_REQ_ses_poll(int req_type, int check_after,
     return result;
 }
 
-static int checkAfter = 1;
+static const int checkAfter = 1;
+static const int pollCount = 3;
+
 static int test_exec_IR_ses_poll_ok(void)
 {
     return test_exec_REQ_ses_poll(OSSL_CMP_PKIBODY_IR, checkAfter, 2, 0,
@@ -256,8 +258,8 @@ static int test_exec_IR_ses_poll_no_timeout(void)
 
 static int test_exec_IR_ses_poll_total_timeout(void)
 {
-    return test_exec_REQ_ses_poll(OSSL_CMP_PKIBODY_IR, checkAfter + 1,
-        3 /* pollCount */, checkAfter + 6,
+    return test_exec_REQ_ses_poll(OSSL_CMP_PKIBODY_IR, checkAfter,
+        pollCount, (pollCount - 1) * checkAfter,
         OSSL_CMP_PKISTATUS_trans);
 }
 
@@ -466,8 +468,8 @@ static int test_exec_GENM_ses_poll_no_timeout(void)
 
 static int test_exec_GENM_ses_poll_total_timeout(void)
 {
-    return test_exec_REQ_ses_poll(OSSL_CMP_PKIBODY_GENM, checkAfter + 1,
-        3 /* pollCount */, checkAfter + 2,
+    return test_exec_REQ_ses_poll(OSSL_CMP_PKIBODY_GENM, checkAfter,
+        pollCount, (pollCount - 1) * checkAfter,
         OSSL_CMP_PKISTATUS_trans);
 }
 


### PR DESCRIPTION
As requested, this backports #31111 further, as far as it makes sense (to 3.6 and 3.5).
