### PR TITLE
test: Invert bad TEST() condition calls

### DIFF
--- a/test/asn1_string_test.c
+++ b/test/asn1_string_test.c
@@ -454,13 +454,13 @@ asn1_string_new_not_owned_test(void)
     tmpstring = NULL;
     tmp = NULL;
 
-    if (TEST_ptr(tmp = ASN1_STRING_new_not_owned(V_ASN1_BIT_STRING, data, sizeof(data))))
+    if (!TEST_ptr_null(tmp = ASN1_STRING_new_not_owned(V_ASN1_BIT_STRING, data, sizeof(data))))
         goto err;
 
-    if (TEST_ptr(tmp = ASN1_STRING_new_not_owned(V_ASN1_OCTET_STRING, NULL, sizeof(data))))
+    if (!TEST_ptr_null(tmp = ASN1_STRING_new_not_owned(V_ASN1_OCTET_STRING, NULL, sizeof(data))))
         goto err;
 
-    if (TEST_ptr(tmp = ASN1_STRING_new_not_owned(V_ASN1_OCTET_STRING, data, 0)))
+    if (!TEST_ptr_null(tmp = ASN1_STRING_new_not_owned(V_ASN1_OCTET_STRING, data, 0)))
         goto err;
 
     if (!TEST_mem_eq(data, sizeof(data), data2, sizeof(data2)))

--- a/test/ca_internals_test.c
+++ b/test/ca_internals_test.c
@@ -49,13 +49,13 @@ static int test_do_updatedb(void)
     testdate = test_get_argument(2);
     if (!test_asn1_string_to_time_t(testdate, &testdateutc))
         return 0;
-    if (TEST_time_t_lt(testdateutc, 0)) {
+    if (!TEST_time_t_ge(testdateutc, 0)) {
         return 0;
     }
 
     indexfile = test_get_argument(1);
     db = load_index(indexfile, NULL);
-    if (TEST_ptr_null(db)) {
+    if (!TEST_ptr(db)) {
         return 0;
     }
 

--- a/test/evp_extra_test2.c
+++ b/test/evp_extra_test2.c
@@ -494,7 +494,7 @@ static int test_new_keytype(void)
     unsigned char *out = NULL, *secret = NULL, *secret2 = NULL;
 
     /* without tls-provider key should not be create-able */
-    if (TEST_ptr(key = EVP_PKEY_Q_keygen(mainctx, NULL, "XOR")))
+    if (!TEST_ptr_null(key = EVP_PKEY_Q_keygen(mainctx, NULL, "XOR")))
         goto err;
     /* prepare & load tls-provider */
     if (!TEST_true(OSSL_PROVIDER_add_builtin(mainctx, "tls-provider",

--- a/test/hpke_test.c
+++ b/test/hpke_test.c
@@ -949,10 +949,9 @@ static int test_hpke_modes_suites(void)
             hpke_suite.kem_id = kem_id;
             if (hpke_mode == OSSL_HPKE_MODE_AUTH
                 || hpke_mode == OSSL_HPKE_MODE_PSKAUTH) {
-                if (TEST_true(OSSL_HPKE_keygen(hpke_suite, authpub, &authpublen,
+                if (!TEST_true(OSSL_HPKE_keygen(hpke_suite, authpub, &authpublen,
                         &authpriv, NULL, 0,
-                        testctx, NULL))
-                    != 1) {
+                        testctx, NULL))) {
                     overallresult = 0;
                 }
                 authpubp = authpub;
@@ -1195,7 +1194,7 @@ static int test_hpke_suite_strs(void)
             for (aeadind = 0; aeadind != OSSL_NELEM(aead_str_list); aeadind++) {
                 BIO_snprintf(sstr, 128, "%s,%s,%s", kem_str_list[kemind],
                     kdf_str_list[kdfind], aead_str_list[aeadind]);
-                if (TEST_true(OSSL_HPKE_str2suite(sstr, &stirred)) != 1) {
+                if (!TEST_true(OSSL_HPKE_str2suite(sstr, &stirred))) {
                     if (verbose)
                         TEST_note("Unexpected str2suite fail for :%s",
                             bogus_suite_strs[sind]);
@@ -1205,9 +1204,8 @@ static int test_hpke_suite_strs(void)
         }
     }
     for (sind = 0; sind != OSSL_NELEM(bogus_suite_strs); sind++) {
-        if (TEST_false(OSSL_HPKE_str2suite(bogus_suite_strs[sind],
-                &stirred))
-            != 1) {
+        if (!TEST_false(OSSL_HPKE_str2suite(bogus_suite_strs[sind],
+                &stirred))) {
             if (verbose)
                 TEST_note("OSSL_HPKE_str2suite didn't fail for bogus[%d]:%s",
                     sind, bogus_suite_strs[sind]);
@@ -1250,20 +1248,18 @@ static int test_hpke_grease(void)
     /* GREASEing */
     /* check too short for public value */
     g_pub_len = 10;
-    if (TEST_false(OSSL_HPKE_get_grease_value(NULL, &g_suite,
+    if (!TEST_false(OSSL_HPKE_get_grease_value(NULL, &g_suite,
             g_pub, &g_pub_len,
             g_cipher, g_cipher_len,
-            testctx, NULL))
-        != 1) {
+            testctx, NULL))) {
         overallresult = 0;
     }
     /* reset to work */
     g_pub_len = OSSL_HPKE_TSTSIZE;
-    if (TEST_true(OSSL_HPKE_get_grease_value(NULL, &g_suite,
+    if (!TEST_true(OSSL_HPKE_get_grease_value(NULL, &g_suite,
             g_pub, &g_pub_len,
             g_cipher, g_cipher_len,
-            testctx, NULL))
-        != 1) {
+            testctx, NULL))) {
         overallresult = 0;
     }
     /* expansion */

--- a/test/http_test.c
+++ b/test/http_test.c
@@ -589,7 +589,7 @@ static int test_http_resp_hdr_limit(size_t limit)
     int res = 0;
     OSSL_HTTP_REQ_CTX *rctx = NULL;
 
-    if (TEST_ptr(wbio) == 0 || TEST_ptr(rbio) == 0)
+    if (!TEST_ptr(wbio) || !TEST_ptr(rbio))
         goto err;
 
     mock_args.txt = text1;
@@ -601,7 +601,7 @@ static int test_http_resp_hdr_limit(size_t limit)
     BIO_set_callback_arg(wbio, (char *)&mock_args);
 
     rctx = OSSL_HTTP_REQ_CTX_new(wbio, rbio, 8192);
-    if (TEST_ptr(rctx) == 0)
+    if (!TEST_ptr(rctx))
         goto err;
 
     if (!TEST_true(OSSL_HTTP_REQ_CTX_set_request_line(rctx, 0 /* GET */,

--- a/test/pkcs12_api_test.c
+++ b/test/pkcs12_api_test.c
@@ -175,7 +175,7 @@ static int pkcs12_create_ex2_test(int test)
             0, 0, 0,
             testctx, NULL,
             NULL, NULL);
-        if (TEST_ptr(ptr))
+        if (!TEST_ptr_null(ptr))
             goto err;
 
         /* Can't proceed without a valid cert at least */
@@ -201,7 +201,7 @@ static int pkcs12_create_ex2_test(int test)
             testctx, NULL,
             pkcs12_create_cb, (void *)&cb_ret);
         /* PKCS12 not created */
-        if (TEST_ptr(ptr))
+        if (!TEST_ptr_null(ptr))
             goto err;
     } else if (test == 2) {
         /* Specified call back called - return failure */

--- a/test/punycode_test.c
+++ b/test/punycode_test.c
@@ -188,7 +188,7 @@ static int test_puny_overrun(void)
     unsigned int bsize = OSSL_NELEM(buf) - 1;
 
     if (!TEST_false(ossl_punycode_decode(in, strlen(in), buf, &bsize))) {
-        if (TEST_mem_eq(buf, bsize * sizeof(*buf), out, sizeof(out)))
+        if (!TEST_mem_ne(buf, bsize * sizeof(*buf), out, sizeof(out)))
             TEST_error("CRITICAL: buffer overrun detected!");
         return 0;
     }

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -472,9 +472,9 @@ DEF_FUNC(check_flood_stats)
     path_challenge_count = ossl_quic_channel_get_path_challenge_count(ch);
     path_response_count = ossl_quic_channel_get_path_response_count(ch);
 
-    if (TEST_uint64_t_ne(path_challenge_count, 16))
+    if (!TEST_uint64_t_eq(path_challenge_count, 16))
         goto err;
-    if (TEST_uint64_t_ne(path_response_count, 1))
+    if (!TEST_uint64_t_eq(path_response_count, 1))
         goto err;
 
     ok = 1;

--- a/test/secmemtest.c
+++ b/test/secmemtest.c
@@ -81,7 +81,7 @@ static int test_sec_mem(void)
      * If init fails, then initialized should be false, if not, this
      * could cause an infinite loop secure_malloc, but we don't test it
      */
-    if (TEST_false(CRYPTO_secure_malloc_init(16, 16)) && !TEST_false(CRYPTO_secure_malloc_initialized())) {
+    if (!TEST_true(CRYPTO_secure_malloc_init(16, 16)) && !TEST_false(CRYPTO_secure_malloc_initialized())) {
         TEST_true(CRYPTO_secure_malloc_done());
         goto end;
     }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -2518,11 +2518,11 @@ static int test_tlsext_status_type_multi(void)
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(), TLS_client_method(),
             TLS1_VERSION, 0, &sctx, &cctx, leaf, skey)))
         goto end;
-    if (TEST_int_lt(SSL_CTX_use_certificate_chain_file(sctx, leaf_chain), 0))
+    if (!TEST_int_ge(SSL_CTX_use_certificate_chain_file(sctx, leaf_chain), 0))
         goto end;
     if (!TEST_true(SSL_CTX_load_verify_locations(cctx, root, NULL)))
         goto end;
-    if (TEST_int_ne(SSL_CTX_get_tlsext_status_type(cctx), -1))
+    if (!TEST_int_eq(SSL_CTX_get_tlsext_status_type(cctx), -1))
         goto end;
 
     /* set verify callback function */
@@ -12036,7 +12036,7 @@ static int test_no_shared_ffdhe_group(int idx)
      * Note that the server should not select the DHE ciphersuite if there are
      * no shared FFDHE groups, so if it was selected, that is an error.
      */
-    if (TEST_int_eq(TLS1_CK_DHE_RSA_WITH_AES_128_SHA256,
+    if (!TEST_int_ne(TLS1_CK_DHE_RSA_WITH_AES_128_SHA256,
             SSL_CIPHER_get_id(SSL_get_current_cipher(clientssl))))
         goto end;
 

--- a/test/verify_extra_test.c
+++ b/test/verify_extra_test.c
@@ -627,7 +627,7 @@ static int test_vpm_input_validation(void)
             goto err;
     }
     for (size_t i = 0; invalid_emails[i] != NULL; i++) {
-        if (TEST_true(X509_VERIFY_PARAM_set1_email(vpm, invalid_emails[i], 0)))
+        if (!TEST_false(X509_VERIFY_PARAM_set1_email(vpm, invalid_emails[i], 0)))
             goto err;
     }
     for (size_t i = 0; multiname_ips[i] != NULL; i++) {


### PR DESCRIPTION
False result of a TEST_xxx() call should always indicate erroneous condition.

Fix such calls. Also fix some calls which
treated TEST_xxx() result as non-boolean.
