### PR TITLE
Revert "Fix up mismatched error reason codes"

### DIFF
--- a/crypto/ct/ct_b64.c
+++ b/crypto/ct/ct_b64.c
@@ -84,7 +84,7 @@ SCT *SCT_new_from_base64(unsigned char version, const char *logid_base64,
 
     declen = ct_base64_decode(logid_base64, &dec);
     if (declen < 0) {
-        ERR_raise(ERR_LIB_CT, CT_R_BASE64_DECODE_ERROR);
+        ERR_raise(ERR_LIB_CT, X509_R_BASE64_DECODE_ERROR);
         goto err;
     }
     if (!SCT_set0_log_id(sct, dec, declen))
@@ -93,7 +93,7 @@ SCT *SCT_new_from_base64(unsigned char version, const char *logid_base64,
 
     declen = ct_base64_decode(extensions_base64, &dec);
     if (declen < 0) {
-        ERR_raise(ERR_LIB_CT, CT_R_BASE64_DECODE_ERROR);
+        ERR_raise(ERR_LIB_CT, X509_R_BASE64_DECODE_ERROR);
         goto err;
     }
     SCT_set0_extensions(sct, dec, declen);
@@ -101,7 +101,7 @@ SCT *SCT_new_from_base64(unsigned char version, const char *logid_base64,
 
     declen = ct_base64_decode(signature_base64, &dec);
     if (declen < 0) {
-        ERR_raise(ERR_LIB_CT, CT_R_BASE64_DECODE_ERROR);
+        ERR_raise(ERR_LIB_CT, X509_R_BASE64_DECODE_ERROR);
         goto err;
     }
 

--- a/crypto/dh/dh_backend.c
+++ b/crypto/dh/dh_backend.c
@@ -232,7 +232,7 @@ DH *ossl_dh_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
     goto done;
 
 decerr:
-    ERR_raise(ERR_LIB_DH, DH_R_DECODE_ERROR);
+    ERR_raise(ERR_LIB_DH, EVP_R_DECODE_ERROR);
 dherr:
     DH_free(dh);
     dh = NULL;

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -224,7 +224,7 @@ static int x509_pubkey_ex_d2i_ex(ASN1_VALUE **pval,
                      * bytes.
                      */
                     ERR_clear_last_mark();
-                    ERR_raise(ERR_LIB_ASN1, ASN1_R_DECODE_ERROR);
+                    ERR_raise(ERR_LIB_ASN1, EVP_R_DECODE_ERROR);
                     goto end;
                 }
             }

--- a/providers/implementations/macs/cmac_prov.c.in
+++ b/providers/implementations/macs/cmac_prov.c.in
@@ -290,7 +290,7 @@ static int cmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
                 && !EVP_CIPHER_is_a(cipher, "AES-192-CBC")
                 && !EVP_CIPHER_is_a(cipher, "AES-128-CBC")
                 && !EVP_CIPHER_is_a(cipher, "DES-EDE3-CBC")) {
-                ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_CIPHER);
+                ERR_raise(ERR_LIB_PROV, EVP_R_UNSUPPORTED_CIPHER);
                 return 0;
             }
         }

--- a/providers/implementations/rands/test_rng.c.in
+++ b/providers/implementations/rands/test_rng.c.in
@@ -310,7 +310,7 @@ static int test_rng_enable_locking(void *vtest)
     if (t != NULL && t->lock == NULL) {
         t->lock = CRYPTO_THREAD_lock_new();
         if (t->lock == NULL) {
-            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_CREATE_LOCK);
+            ERR_raise(ERR_LIB_PROV, RAND_R_FAILED_TO_CREATE_LOCK);
             return 0;
         }
     }

--- a/providers/implementations/signature/rsa_sig.c.in
+++ b/providers/implementations/signature/rsa_sig.c.in
@@ -596,7 +596,7 @@ rsa_signverify_init(PROV_RSA_CTX *prsactx, void *vrsa,
 
         break;
     default:
-        ERR_raise(ERR_LIB_PROV, PROV_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
+        ERR_raise(ERR_LIB_RSA, PROV_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
         return 0;
     }
 
@@ -1942,7 +1942,7 @@ static int rsa_sigalg_signverify_init(void *vprsactx, void *vrsa,
 
     /* PSS is currently not supported as a sigalg */
     if (prsactx->pad_mode == RSA_PKCS1_PSS_PADDING) {
-        ERR_raise(ERR_LIB_PROV, PROV_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
+        ERR_raise(ERR_LIB_RSA, PROV_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
         return 0;
     }
 


### PR DESCRIPTION
This reverts commit 24cf73167057fa7802ca9641976e01a84a9ffb36.

Build breakage introduced from merging https://github.com/openssl/openssl/pull/31390

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
