### PR TITLE
Replace missing reason code with another one

### DIFF
--- a/providers/implementations/macs/cmac_prov.c.in
+++ b/providers/implementations/macs/cmac_prov.c.in
@@ -290,7 +290,7 @@ static int cmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
                 && !EVP_CIPHER_is_a(cipher, "AES-192-CBC")
                 && !EVP_CIPHER_is_a(cipher, "AES-128-CBC")
                 && !EVP_CIPHER_is_a(cipher, "DES-EDE3-CBC")) {
-                ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_CIPHER);
+                ERR_raise(ERR_LIB_PROV, PROV_R_NOT_SUPPORTED);
                 return 0;
             }
         }


### PR DESCRIPTION
There is no PROV_R_INVALID_CIPHER on 3.6 use PROV_R_NOT_SUPPORTED instead.

Fixes 73807b38a355ffb2b4cebcb938b0a452166474b7
