### PR TITLE
test_rng.c: Include proverr.h

### DIFF
--- a/providers/implementations/rands/test_rng.c
+++ b/providers/implementations/rands/test_rng.c
@@ -14,7 +14,7 @@
 #include <openssl/core_names.h>
 #include <openssl/evp.h>
 #include <openssl/err.h>
-#include <openssl/randerr.h>
+#include <openssl/proverr.h>
 #include "prov/providercommon.h"
 #include "prov/provider_ctx.h"
 #include "prov/provider_util.h"


### PR DESCRIPTION
Fixes a1d19889c19d924b32a3c89578e0310cf261523d
