### PR TITLE
Sync markdownlint.rb with newer branches [3.0]

### DIFF
--- a/util/markdownlint.rb
+++ b/util/markdownlint.rb
@@ -12,6 +12,10 @@ rule 'MD046', :style => :consistent
 # Bug in mdl, https://github.com/markdownlint/markdownlint/issues/313
 exclude_rule 'MD007'
 
+# Not possible to line-break tables (:tables => false)
+# Not possible to line-break headers (currently cannot be selectively exempted)
+exclude_rule 'MD013'
+
 exclude_rule 'MD004' # Unordered list style TODO(fix?)
 exclude_rule 'MD005' # Inconsistent indentation for list items at the same level
 exclude_rule 'MD006' # Consider starting bulleted lists at the beginning of the line
@@ -22,3 +26,4 @@ exclude_rule 'MD025' # Multiple top level headers in the same document
 exclude_rule 'MD026' # Trailing punctuation in header
 exclude_rule 'MD029' # Ordered list item prefix
 exclude_rule 'MD030' # Spaces after list markers (default: 1!)
+exclude_rule 'MD033' # Allow inline HTML (complex tables are impossible without it)


### PR DESCRIPTION
This fixes failing doc nits CI.
