### PR TITLE
doc: clarify pkeyutl -rawin and -digest for no-prehash signatures

### DIFF
--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -677,8 +677,10 @@ L<EVP_PKEY_CTX_set_tls1_prf_md(3)>,
 =head1 HISTORY
 
 Since OpenSSL 3.5,
-the B<-digest> option implies B<-rawin>, and these two options are
-no longer required when signing or verifying with an Ed25519 or Ed448 key.
+the B<-digest> option implies B<-rawin>. The B<-rawin> option is no longer
+required when signing or verifying with a key type that does not support a
+prehash digest, such as Ed25519, Ed448, ML-DSA, or SLH-DSA. For these key
+types, B<-digest> is not supported.
 
 Also since OpenSSL 3.5, the B<-kemop> option is no longer required for any of
 the supported algorithms, the only supported B<mode> is now the default.


### PR DESCRIPTION
Update the `openssl-pkeyutl(1)` documentation to describe the generic `-rawin` behavior for signature algorithms that do not support a prehash digest.

The current history note only mentions `Ed25519` and `Ed448`. However, since OpenSSL 3.5, pkeyutl implies `-rawin` for any key type that does not support a prehash digest, such as `Ed25519`, `Ed448`, `ML-DSA`, and `SLH-DSA`.

The text is also clarified to avoid implying that `-digest` is optional for these key types. For no-prehash signature algorithms,
`-digest` is not supported.

Documentation-only change.

Complements: 5421423 "Flexible encoders for ML-DSA"

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
