### PR TITLE
s390x: Don't ignore errors from s390x_HMAC_init(), s390x_mod_exp_hw() and s390x_crt()

### DIFF
--- a/crypto/bn/bn_s390x.c
+++ b/crypto/bn/bn_s390x.c
@@ -20,16 +20,20 @@
 #include <unistd.h>
 #include <errno.h>
 
+/*
+ * Returns 1 for success, 0 for failure, and -1 to tell the caller to use the
+ * SW-fallback.
+ */
 static int s390x_mod_exp_hw(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
     const BIGNUM *m)
 {
     struct ica_rsa_modexpo me;
     unsigned char *buffer;
     size_t size;
-    int res = 0;
+    int res = -1;
 
     if (OPENSSL_s390xcex == -1 || OPENSSL_s390xcex_nodev)
-        return 0;
+        return -1;
     size = BN_num_bytes(m);
     buffer = OPENSSL_calloc(size, 4);
     if (buffer == NULL)
@@ -42,11 +46,15 @@ static int s390x_mod_exp_hw(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
     me.n_modulus = buffer + 3 * size;
     if (BN_bn2binpad(a, me.inputdata, size) == -1
         || BN_bn2binpad(p, me.b_key, size) == -1
-        || BN_bn2binpad(m, me.n_modulus, size) == -1)
+        || BN_bn2binpad(m, me.n_modulus, size) == -1) {
+        res = 0;
         goto dealloc;
+    }
     if (ioctl(OPENSSL_s390xcex, ICARSAMODEXPO, &me) != -1) {
         if (BN_bin2bn(me.outputdata, size, r) != NULL)
             res = 1;
+        else
+            res = 0;
     } else if (errno == EBADF || errno == ENOTTY) {
         /*
          * In this cases, someone (e.g. a sandbox) closed the fd.
@@ -71,27 +79,34 @@ dealloc:
 int s390x_mod_exp(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
     const BIGNUM *m, BN_CTX *ctx, BN_MONT_CTX *m_ctx)
 {
-    if (s390x_mod_exp_hw(r, a, p, m) == 1)
-        return 1;
-    return BN_mod_exp_mont(r, a, p, m, ctx, m_ctx);
+    int rc;
+
+    rc = s390x_mod_exp_hw(r, a, p, m);
+    if (rc < 0)
+        return BN_mod_exp_mont(r, a, p, m, ctx, m_ctx);
+    return rc;
 }
 
+/*
+ * Returns 1 for success, 0 for failure, and -1 to tell the caller to use the
+ * SW-fallback.
+ */
 int s390x_crt(BIGNUM *r, const BIGNUM *i, const BIGNUM *p, const BIGNUM *q,
     const BIGNUM *dmp, const BIGNUM *dmq, const BIGNUM *iqmp)
 {
     struct ica_rsa_modexpo_crt crt;
     unsigned char *buffer, *part;
     size_t size, plen, qlen;
-    int res = 0;
+    int res = -1;
 
     if (OPENSSL_s390xcex == -1 || OPENSSL_s390xcex_nodev)
-        return 0;
+        return -1;
     /*-
      * Hardware-accelerated CRT can only deal with p>q.  Fall back to
      * software in the (hopefully rare) other cases.
      */
     if (BN_ucmp(p, q) != 1)
-        return 0;
+        return -1;
     plen = BN_num_bytes(p);
     qlen = BN_num_bytes(q);
     size = (plen > qlen ? plen : qlen);
@@ -119,11 +134,15 @@ int s390x_crt(BIGNUM *r, const BIGNUM *i, const BIGNUM *p, const BIGNUM *q,
         || BN_bn2binpad(q, crt.nq_prime, size) == -1
         || BN_bn2binpad(dmp, crt.bp_key, size + 8) == -1
         || BN_bn2binpad(dmq, crt.bq_key, size) == -1
-        || BN_bn2binpad(iqmp, crt.u_mult_inv, size + 8) == -1)
+        || BN_bn2binpad(iqmp, crt.u_mult_inv, size + 8) == -1) {
+        res = 0;
         goto dealloc;
+    }
     if (ioctl(OPENSSL_s390xcex, ICARSACRT, &crt) != -1) {
         if (BN_bin2bn(crt.outputdata, crt.outputdatalength, r) != NULL)
             res = 1;
+        else
+            res = 0;
     } else if (errno == EBADF || errno == ENOTTY) {
         /*
          * In this cases, someone (e.g. a sandbox) closed the fd.

--- a/crypto/hmac/hmac.c
+++ b/crypto/hmac/hmac.c
@@ -54,7 +54,7 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len,
 
 #ifdef OPENSSL_HMAC_S390X
     rv = s390x_HMAC_init(ctx, key, len);
-    if (rv >= 1)
+    if (rv != -1)
         return rv;
 #endif
 

--- a/crypto/rsa/rsa_ossl.c
+++ b/crypto/rsa/rsa_ossl.c
@@ -1184,9 +1184,12 @@ static int rsa_ossl_finish(RSA *rsa)
 static int rsa_ossl_s390x_mod_exp(BIGNUM *r0, const BIGNUM *i, RSA *rsa,
     BN_CTX *ctx)
 {
+    int rc;
+
     if (rsa->version != RSA_ASN1_VERSION_MULTI) {
-        if (s390x_crt(r0, i, rsa->p, rsa->q, rsa->dmp1, rsa->dmq1, rsa->iqmp) == 1)
-            return 1;
+        rc = s390x_crt(r0, i, rsa->p, rsa->q, rsa->dmp1, rsa->dmq1, rsa->iqmp);
+        if (rc >= 0)
+            return rc;
     }
     return rsa_ossl_mod_exp(r0, i, rsa, ctx);
 }


### PR DESCRIPTION
As reported in issue https://github.com/openssl/openssl/issues/31480 the `test_rsa_pkcs1_mfail` test case found that memory allocation failures in these functions got ignored. This does not really matter, because the operation is then performed using the software path. Nevertheless, such errors should not be ignored, but reported.

Only situations where the s390x specific acceleration is not supported or has been intentionally disabled should cause it to use the software fallback. 

Closes: https://github.com/openssl/openssl/issues/31480

