### PR TITLE
allow SSL_set_retry_verify on server session

### DIFF
--- a/doc/man3/SSL_CTX_set_cert_verify_callback.pod
+++ b/doc/man3/SSL_CTX_set_cert_verify_callback.pod
@@ -39,15 +39,17 @@ if the verification mode is B<SSL_VERIFY_NONE>.
 Otherwise, when the return value is less than or equal to 0, the handshake will
 fail.
 
-In client mode I<callback> may also call the L<SSL_set_retry_verify(3)>
-function on the B<SSL> object set in the I<x509_store_ctx> ex data (see
+In client or server mode I<callback> may also call the
+L<SSL_set_retry_verify(3)> function on the B<SSL> object set in the
+I<x509_store_ctx> ex data (see
 L<SSL_get_ex_data_X509_STORE_CTX_idx(3)>) and return 1. This would be
 typically done in case the certificate verification was not yet able
 to succeed. This makes the handshake suspend and return control to the
 calling application with B<SSL_ERROR_WANT_RETRY_VERIFY>. The app can for
 instance fetch further certificates or cert status information needed for
-the verification. Calling L<SSL_connect(3)> again resumes the connection
-attempt by retrying the server certificate verification step.
+the verification. Calling L<SSL_connect(3)>, L<SSL_accept(3)>, or
+L<SSL_do_handshake(3)> again resumes the connection attempt by retrying
+certificate verification.
 This process may even be repeated if need be.
 
 In any case a viable verification result value must be reflected

--- a/doc/man3/SSL_set_retry_verify.pod
+++ b/doc/man3/SSL_set_retry_verify.pod
@@ -13,7 +13,8 @@ SSL_set_retry_verify - indicate that certificate verification should be retried
 =head1 DESCRIPTION
 
 SSL_set_retry_verify() should be called from the certificate verification
-callback on a client when the application wants to indicate that the handshake
+callback on a client or server when the application wants to indicate that
+the handshake
 should be suspended and the control should be returned to the application.
 L<SSL_want_retry_verify(3)> will return 1 as a consequence until the handshake
 is resumed again by the application, retrying the verification step.
@@ -23,7 +24,7 @@ Please refer to L<SSL_CTX_set_cert_verify_callback(3)> for further details.
 =head1 NOTES
 
 The effect of calling SSL_set_retry_verify() outside of the certificate
-verification callback on the client side is undefined.
+verification callback is undefined.
 
 =head1 RETURN VALUES
 

--- a/ssl/statem/statem_local.h
+++ b/ssl/statem/statem_local.h
@@ -232,6 +232,8 @@ __owur CON_FUNC_RETURN tls_construct_server_done(SSL_CONNECTION *s,
     WPACKET *pkt);
 __owur MSG_PROCESS_RETURN tls_process_client_certificate(SSL_CONNECTION *s,
     PACKET *pkt);
+__owur WORK_STATE tls_post_process_client_certificate(SSL_CONNECTION *s,
+    WORK_STATE wst);
 #ifndef OPENSSL_NO_COMP_ALG
 __owur MSG_PROCESS_RETURN tls_process_client_compressed_certificate(SSL_CONNECTION *sc,
     PACKET *pkt);

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1490,6 +1490,12 @@ WORK_STATE ossl_statem_server_post_process_message(SSL_CONNECTION *s,
     case TLS_ST_SR_CLNT_HELLO:
         return tls_post_process_client_hello(s, wst);
 
+    case TLS_ST_SR_CERT:
+#ifndef OPENSSL_NO_COMP_ALG
+    case TLS_ST_SR_COMP_CERT:
+#endif
+        return tls_post_process_client_certificate(s, wst);
+
     case TLS_ST_SR_KEY_EXCH:
         return tls_post_process_client_key_exchange(s, wst);
     }
@@ -3966,7 +3972,6 @@ err:
 MSG_PROCESS_RETURN tls_process_client_certificate(SSL_CONNECTION *s,
     PACKET *pkt)
 {
-    int i;
     MSG_PROCESS_RETURN ret = MSG_PROCESS_ERROR;
     X509 *x = NULL;
     unsigned long l;
@@ -3974,7 +3979,6 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL_CONNECTION *s,
     STACK_OF(X509) *sk = NULL;
     PACKET spkt, context;
     size_t chainidx;
-    SSL_SESSION *new_sess = NULL;
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 
     /*
@@ -4064,31 +4068,73 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL_CONNECTION *s,
         x = NULL;
     }
 
-    if (sk_X509_num(sk) <= 0) {
+    /*
+     * Stash the parsed chain so that tls_post_process_client_certificate() can
+     * run verification and may pause the handshake via SSL_set_retry_verify().
+     */
+    OSSL_STACK_OF_X509_free(s->session->peer_chain);
+    s->session->peer_chain = sk;
+    sk = NULL;
+
+    return MSG_PROCESS_CONTINUE_PROCESSING;
+
+ err:
+    X509_free(x);
+    OSSL_STACK_OF_X509_free(sk);
+    return ret;
+}
+
+/*
+ * Verify s->session->peer_chain (parked by tls_process_client_certificate())
+ * and finalize the peer cert / TLS 1.3 handshake-hash bookkeeping.
+ * Allows the verify callback to defer via SSL_set_retry_verify(), in which
+ * case we return WORK_MORE_A and the state machine re-enters this function
+ * once the application has supplied a verdict.
+ */
+WORK_STATE tls_post_process_client_certificate(SSL_CONNECTION *s,
+    WORK_STATE wst)
+{
+    STACK_OF(X509) *sk = s->session->peer_chain;
+    SSL_SESSION *new_sess = NULL;
+    EVP_PKEY *pkey;
+    int i;
+
+    if (sk == NULL || sk_X509_num(sk) <= 0) {
         /* Fail only if we required a certificate */
-        if ((s->verify_mode & SSL_VERIFY_PEER) && (s->verify_mode & SSL_VERIFY_FAIL_IF_NO_PEER_CERT)) {
+        if ((s->verify_mode & SSL_VERIFY_PEER)
+                && (s->verify_mode & SSL_VERIFY_FAIL_IF_NO_PEER_CERT)) {
             SSLfatal(s, SSL_AD_CERTIFICATE_REQUIRED,
                 SSL_R_PEER_DID_NOT_RETURN_A_CERTIFICATE);
-            goto err;
+            return WORK_ERROR;
         }
         /* No client certificate so digest cached records */
         if (s->s3.handshake_buffer && !ssl3_digest_cached_records(s, 0)) {
             /* SSLfatal() already called */
-            goto err;
+            return WORK_ERROR;
         }
     } else {
-        EVP_PKEY *pkey;
+        if (s->rwstate == SSL_RETRY_VERIFY)
+            s->rwstate = SSL_NOTHING;
         i = ssl_verify_cert_chain(s, sk);
+        if (i > 0 && s->rwstate == SSL_RETRY_VERIFY) {
+            /*
+             * The application's verify callback asked us to pause via
+             * SSL_set_retry_verify(); SSL_do_handshake() will return
+             * SSL_ERROR_WANT_RETRY_VERIFY and the state machine resumes here
+             * once the callback is invoked again.
+             */
+            return WORK_MORE_A;
+        }
         if (i <= 0) {
             SSLfatal(s, ssl_x509err2alert(s->verify_result),
                 SSL_R_CERTIFICATE_VERIFY_FAILED);
-            goto err;
+            return WORK_ERROR;
         }
         pkey = X509_get0_pubkey(sk_X509_value(sk, 0));
         if (pkey == NULL) {
             SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE,
                 SSL_R_UNKNOWN_CERTIFICATE_TYPE);
-            goto err;
+            return WORK_ERROR;
         }
     }
 
@@ -4099,24 +4145,28 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL_CONNECTION *s,
      * a new certificate is received via post-handshake authentication, as the
      * session may have already gone into the session cache.
      */
-
     if (s->post_handshake_auth == SSL_PHA_REQUESTED) {
         if ((new_sess = ssl_session_dup(s->session, 0)) == 0) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_SSL_LIB);
-            goto err;
+            return WORK_ERROR;
         }
 
         SSL_SESSION_free(s->session);
         s->session = new_sess;
+        /* peer_chain follows the session via ssl_session_dup(); refresh sk. */
+        sk = s->session->peer_chain;
     }
 
-    X509_free(s->session->peer);
-    s->session->peer = sk_X509_shift(sk);
-    s->session->verify_result = s->verify_result;
+    if (sk != NULL && sk_X509_num(sk) > 0) {
+        X509_free(s->session->peer);
+        /*
+         * Inconsistency alert: cert_chain does *not* include the peer's own
+         * certificate, while we do include it in statem_clnt.c
+         */
+        s->session->peer = sk_X509_shift(sk);
+        s->session->verify_result = s->verify_result;
+    }
 
-    OSSL_STACK_OF_X509_free(s->session->peer_chain);
-    s->session->peer_chain = sk;
-    sk = NULL;
     /* Ensure there is no RPK */
     EVP_PKEY_free(s->session->peer_rpk);
     s->session->peer_rpk = NULL;
@@ -4127,13 +4177,8 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL_CONNECTION *s,
      */
     if (SSL_CONNECTION_IS_TLS13(s) && !ssl3_digest_cached_records(s, 1)) {
         /* SSLfatal() already called */
-        goto err;
+        return WORK_ERROR;
     }
-
-    /*
-     * Inconsistency alert: cert_chain does *not* include the peer's own
-     * certificate, while we do include it in statem_clnt.c
-     */
 
     /* Save the current hash state for when we receive the CertificateVerify */
     if (SSL_CONNECTION_IS_TLS13(s)) {
@@ -4141,19 +4186,14 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL_CONNECTION *s,
                 sizeof(s->cert_verify_hash),
                 &s->cert_verify_hash_len)) {
             /* SSLfatal() already called */
-            goto err;
+            return WORK_ERROR;
         }
 
         /* Resend session tickets */
         s->sent_tickets = 0;
     }
 
-    ret = MSG_PROCESS_CONTINUE_READING;
-
-err:
-    X509_free(x);
-    OSSL_STACK_OF_X509_free(sk);
-    return ret;
+    return WORK_FINISHED_CONTINUE;
 }
 
 #ifndef OPENSSL_NO_COMP_ALG

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -4078,7 +4078,7 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL_CONNECTION *s,
 
     return MSG_PROCESS_CONTINUE_PROCESSING;
 
- err:
+err:
     X509_free(x);
     OSSL_STACK_OF_X509_free(sk);
     return ret;

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -4079,7 +4079,6 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL_CONNECTION *s,
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_CRYPTO_LIB);
             goto err;
         }
-        x = NULL;
     }
 
     /*
@@ -4088,7 +4087,6 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL_CONNECTION *s,
      */
     OSSL_STACK_OF_X509_free(s->session->peer_chain);
     s->session->peer_chain = sk;
-    sk = NULL;
 
     return MSG_PROCESS_CONTINUE_PROCESSING;
 

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -4099,6 +4099,8 @@ WORK_STATE tls_post_process_client_certificate(SSL_CONNECTION *s,
     EVP_PKEY *pkey;
     int i;
 
+    (void)wst;
+
     if (sk == NULL || sk_X509_num(sk) <= 0) {
         /* Fail only if we required a certificate */
         if ((s->verify_mode & SSL_VERIFY_PEER)

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -4104,7 +4104,7 @@ WORK_STATE tls_post_process_client_certificate(SSL_CONNECTION *s,
     if (sk == NULL || sk_X509_num(sk) <= 0) {
         /* Fail only if we required a certificate */
         if ((s->verify_mode & SSL_VERIFY_PEER)
-                && (s->verify_mode & SSL_VERIFY_FAIL_IF_NO_PEER_CERT)) {
+            && (s->verify_mode & SSL_VERIFY_FAIL_IF_NO_PEER_CERT)) {
             SSLfatal(s, SSL_AD_CERTIFICATE_REQUIRED,
                 SSL_R_PEER_DID_NOT_RETURN_A_CERTIFICATE);
             return WORK_ERROR;

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3886,27 +3886,50 @@ WORK_STATE tls_post_process_client_key_exchange(SSL_CONNECTION *s,
 
 MSG_PROCESS_RETURN tls_process_client_rpk(SSL_CONNECTION *sc, PACKET *pkt)
 {
-    MSG_PROCESS_RETURN ret = MSG_PROCESS_ERROR;
-    SSL_SESSION *new_sess = NULL;
     EVP_PKEY *peer_rpk = NULL;
 
     if (!tls_process_rpk(sc, pkt, &peer_rpk)) {
         /* SSLfatal already called */
-        goto err;
+        return MSG_PROCESS_ERROR;
     }
+
+    /* Stash the parsed RPK; verification runs in the post-process step. */
+    EVP_PKEY_free(sc->session->peer_rpk);
+    sc->session->peer_rpk = peer_rpk;
+
+    return MSG_PROCESS_CONTINUE_PROCESSING;
+}
+
+/* Verify the parked RPK; may pause via SSL_set_retry_verify(). */
+static WORK_STATE tls_post_process_client_rpk(SSL_CONNECTION *sc,
+    WORK_STATE wst)
+{
+    EVP_PKEY *peer_rpk = sc->session->peer_rpk;
+    SSL_SESSION *new_sess = NULL;
+
+    (void)wst;
 
     if (peer_rpk == NULL) {
         if ((sc->verify_mode & SSL_VERIFY_FAIL_IF_NO_PEER_CERT)
             && (sc->verify_mode & SSL_VERIFY_PEER)) {
             SSLfatal(sc, SSL_AD_CERTIFICATE_REQUIRED,
                 SSL_R_PEER_DID_NOT_RETURN_A_CERTIFICATE);
-            goto err;
+            return WORK_ERROR;
         }
     } else {
-        if (ssl_verify_rpk(sc, peer_rpk) <= 0) {
+        int v_ok;
+
+        if (sc->rwstate == SSL_RETRY_VERIFY)
+            sc->rwstate = SSL_NOTHING;
+        v_ok = ssl_verify_rpk(sc, peer_rpk);
+        if (v_ok > 0 && sc->rwstate == SSL_RETRY_VERIFY) {
+            /* The verify callback asked to pause; resume here on retry. */
+            return WORK_MORE_A;
+        }
+        if (v_ok <= 0) {
             SSLfatal(sc, ssl_x509err2alert(sc->verify_result),
                 SSL_R_CERTIFICATE_VERIFY_FAILED);
-            goto err;
+            return WORK_ERROR;
         }
     }
 
@@ -3917,11 +3940,10 @@ MSG_PROCESS_RETURN tls_process_client_rpk(SSL_CONNECTION *sc, PACKET *pkt)
      * a new RPK (or certificate) is received via post-handshake authentication,
      * as the session may have already gone into the session cache.
      */
-
     if (sc->post_handshake_auth == SSL_PHA_REQUESTED) {
         if ((new_sess = ssl_session_dup(sc->session, 0)) == NULL) {
             SSLfatal(sc, SSL_AD_INTERNAL_ERROR, ERR_R_MALLOC_FAILURE);
-            goto err;
+            return WORK_ERROR;
         }
 
         SSL_SESSION_free(sc->session);
@@ -3933,10 +3955,6 @@ MSG_PROCESS_RETURN tls_process_client_rpk(SSL_CONNECTION *sc, PACKET *pkt)
     sc->session->peer = NULL;
     sk_X509_pop_free(sc->session->peer_chain, X509_free);
     sc->session->peer_chain = NULL;
-    /* Save RPK */
-    EVP_PKEY_free(sc->session->peer_rpk);
-    sc->session->peer_rpk = peer_rpk;
-    peer_rpk = NULL;
 
     sc->session->verify_result = sc->verify_result;
 
@@ -3947,26 +3965,22 @@ MSG_PROCESS_RETURN tls_process_client_rpk(SSL_CONNECTION *sc, PACKET *pkt)
     if (SSL_CONNECTION_IS_TLS13(sc)) {
         if (!ssl3_digest_cached_records(sc, 1)) {
             /* SSLfatal() already called */
-            goto err;
+            return WORK_ERROR;
         }
 
         /* Save the current hash state for when we receive the CertificateVerify */
         if (!ssl_handshake_hash(sc, sc->cert_verify_hash,
                 sizeof(sc->cert_verify_hash),
                 &sc->cert_verify_hash_len)) {
-            /* SSLfatal() already called */;
-            goto err;
+            /* SSLfatal() already called */
+            return WORK_ERROR;
         }
 
         /* resend session tickets */
         sc->sent_tickets = 0;
     }
 
-    ret = MSG_PROCESS_CONTINUE_READING;
-
-err:
-    EVP_PKEY_free(peer_rpk);
-    return ret;
+    return WORK_FINISHED_CONTINUE;
 }
 
 MSG_PROCESS_RETURN tls_process_client_certificate(SSL_CONNECTION *s,
@@ -4094,11 +4108,15 @@ err:
 WORK_STATE tls_post_process_client_certificate(SSL_CONNECTION *s,
     WORK_STATE wst)
 {
-    STACK_OF(X509) *sk = s->session->peer_chain;
+    STACK_OF(X509) *sk;
     SSL_SESSION *new_sess = NULL;
     EVP_PKEY *pkey;
     int i;
 
+    if (s->ext.client_cert_type == TLSEXT_cert_type_rpk)
+        return tls_post_process_client_rpk(s, wst);
+
+    sk = s->session->peer_chain;
     (void)wst;
 
     if (sk == NULL || sk_X509_num(sk) <= 0) {
@@ -4161,10 +4179,7 @@ WORK_STATE tls_post_process_client_certificate(SSL_CONNECTION *s,
 
     if (sk != NULL && sk_X509_num(sk) > 0) {
         X509_free(s->session->peer);
-        /*
-         * Inconsistency alert: cert_chain does *not* include the peer's own
-         * certificate, while we do include it in statem_clnt.c
-         */
+        /* Server keeps the EE cert in session->peer; peer_chain holds issuers only. */
         s->session->peer = sk_X509_shift(sk);
         s->session->verify_result = s->verify_result;
     }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -661,6 +661,111 @@ end:
     return testresult;
 }
 
+static int server_retry_state;
+
+static int server_verify_retry_cb(X509_STORE_CTX *ctx, void *arg)
+{
+    int idx = SSL_get_ex_data_X509_STORE_CTX_idx();
+    SSL *ssl;
+
+    if (idx < 0 || (ssl = X509_STORE_CTX_get_ex_data(ctx, idx)) == NULL)
+        return 0;
+
+    if (server_retry_state == 0) {
+        /* First call: ask the state machine to pause and retry. */
+        server_retry_state = 1;
+        return SSL_set_retry_verify(ssl);
+    }
+
+    /* Second call (after the app supplied a verdict): accept. */
+    server_retry_state = 2;
+    return 1;
+}
+
+static int test_server_cert_verify_cb(void)
+{
+    char *skey = test_mk_file_path(certsdir, "leaf.key");
+    char *leaf = test_mk_file_path(certsdir, "leaf.pem");
+    char *leaf_chain = test_mk_file_path(certsdir, "leaf-chain.pem");
+    char *root = test_mk_file_path(certsdir, "rootCA.pem");
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    int testresult = 0;
+
+    server_retry_state = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+                                       TLS_client_method(), TLS1_VERSION, 0,
+                                       &sctx, &cctx, NULL, NULL)))
+        goto end;
+
+    /* Server needs its own cert/key for the TLS handshake. */
+    if (!TEST_int_eq(SSL_CTX_use_certificate_chain_file(sctx, leaf_chain), 1)
+            || !TEST_int_eq(SSL_CTX_use_PrivateKey_file(sctx, skey,
+                                                        SSL_FILETYPE_PEM), 1)
+            || !TEST_int_eq(SSL_CTX_check_private_key(sctx), 1))
+        goto end;
+
+    /* Server requests and verifies a client certificate via the retry cb. */
+    SSL_CTX_set_verify(sctx,
+                       SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
+                       NULL);
+    SSL_CTX_set_cert_verify_callback(sctx, server_verify_retry_cb, NULL);
+
+    /* Client presents its cert (leaf signed by interCA/rootCA). */
+    if (!TEST_int_eq(SSL_CTX_use_certificate_file(cctx, leaf,
+                                                  SSL_FILETYPE_PEM), 1)
+            || !TEST_int_eq(SSL_CTX_use_PrivateKey_file(cctx, skey,
+                                                        SSL_FILETYPE_PEM), 1)
+            || !TEST_int_eq(SSL_CTX_check_private_key(cctx), 1))
+        goto end;
+    /* Client trusts the server's root so it accepts the server cert. */
+    if (!TEST_true(SSL_CTX_load_verify_locations(cctx, root, NULL)))
+        goto end;
+    SSL_CTX_set_verify(cctx, SSL_VERIFY_PEER, NULL);
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
+                                      &clientssl, NULL, NULL)))
+        goto end;
+
+    /*
+     * Driving the handshake the first time must surface
+     * SSL_ERROR_WANT_RETRY_VERIFY (proving the server state machine actually
+     * honored the callback's pause request rather than silently accepting -1).
+     */
+    if (!TEST_false(create_ssl_connection(serverssl, clientssl,
+                                          SSL_ERROR_WANT_RETRY_VERIFY)))
+        goto end;
+    if (!TEST_int_eq(server_retry_state, 1))
+        goto end;
+
+    /* Resuming the handshake must now complete cleanly. */
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl,
+                                         SSL_ERROR_NONE)))
+        goto end;
+    if (!TEST_int_eq(server_retry_state, 2))
+        goto end;
+
+    testresult = 1;
+
+end:
+    if (clientssl != NULL) {
+        SSL_shutdown(clientssl);
+        SSL_free(clientssl);
+    }
+    if (serverssl != NULL) {
+        SSL_shutdown(serverssl);
+        SSL_free(serverssl);
+    }
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    OPENSSL_free(skey);
+    OPENSSL_free(leaf);
+    OPENSSL_free(leaf_chain);
+    OPENSSL_free(root);
+    return testresult;
+}
+
 static int test_ssl_build_cert_chain(void)
 {
     int ret = 0;
@@ -15452,6 +15557,7 @@ int setup_tests(void)
     ADD_TEST(test_keylog_no_master_key);
 #endif
     ADD_TEST(test_client_cert_verify_cb);
+    ADD_TEST(test_server_cert_verify_cb);
     ADD_TEST(test_ssl_build_cert_chain);
     ADD_TEST(test_ssl_ctx_build_cert_chain);
 #ifndef OPENSSL_NO_TLS1_2

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -789,7 +789,7 @@ static int test_server_rpk_verify_cb(void)
     server_retry_state = 0;
 
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
-            TLS_client_method(), TLS1_3_VERSION, 0,
+            TLS_client_method(), TLS1_VERSION, 0,
             &sctx, &cctx, NULL, NULL)))
         goto end;
 

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -668,6 +668,8 @@ static int server_verify_retry_cb(X509_STORE_CTX *ctx, void *arg)
     int idx = SSL_get_ex_data_X509_STORE_CTX_idx();
     SSL *ssl;
 
+    (void)arg;
+
     if (idx < 0 || (ssl = X509_STORE_CTX_get_ex_data(ctx, idx)) == NULL)
         return 0;
 

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -697,29 +697,32 @@ static int test_server_cert_verify_cb(void)
     server_retry_state = 0;
 
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
-                                       TLS_client_method(), TLS1_VERSION, 0,
-                                       &sctx, &cctx, NULL, NULL)))
+            TLS_client_method(), TLS1_VERSION, 0,
+            &sctx, &cctx, NULL, NULL)))
         goto end;
 
     /* Server needs its own cert/key for the TLS handshake. */
     if (!TEST_int_eq(SSL_CTX_use_certificate_chain_file(sctx, leaf_chain), 1)
-            || !TEST_int_eq(SSL_CTX_use_PrivateKey_file(sctx, skey,
-                                                        SSL_FILETYPE_PEM), 1)
-            || !TEST_int_eq(SSL_CTX_check_private_key(sctx), 1))
+        || !TEST_int_eq(SSL_CTX_use_PrivateKey_file(sctx, skey,
+                            SSL_FILETYPE_PEM),
+            1)
+        || !TEST_int_eq(SSL_CTX_check_private_key(sctx), 1))
         goto end;
 
     /* Server requests and verifies a client certificate via the retry cb. */
     SSL_CTX_set_verify(sctx,
-                       SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
-                       NULL);
+        SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
+        NULL);
     SSL_CTX_set_cert_verify_callback(sctx, server_verify_retry_cb, NULL);
 
     /* Client presents its cert (leaf signed by interCA/rootCA). */
     if (!TEST_int_eq(SSL_CTX_use_certificate_file(cctx, leaf,
-                                                  SSL_FILETYPE_PEM), 1)
-            || !TEST_int_eq(SSL_CTX_use_PrivateKey_file(cctx, skey,
-                                                        SSL_FILETYPE_PEM), 1)
-            || !TEST_int_eq(SSL_CTX_check_private_key(cctx), 1))
+                         SSL_FILETYPE_PEM),
+            1)
+        || !TEST_int_eq(SSL_CTX_use_PrivateKey_file(cctx, skey,
+                            SSL_FILETYPE_PEM),
+            1)
+        || !TEST_int_eq(SSL_CTX_check_private_key(cctx), 1))
         goto end;
     /* Client trusts the server's root so it accepts the server cert. */
     if (!TEST_true(SSL_CTX_load_verify_locations(cctx, root, NULL)))
@@ -727,7 +730,7 @@ static int test_server_cert_verify_cb(void)
     SSL_CTX_set_verify(cctx, SSL_VERIFY_PEER, NULL);
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                      &clientssl, NULL, NULL)))
+            &clientssl, NULL, NULL)))
         goto end;
 
     /*
@@ -736,14 +739,14 @@ static int test_server_cert_verify_cb(void)
      * honored the callback's pause request rather than silently accepting -1).
      */
     if (!TEST_false(create_ssl_connection(serverssl, clientssl,
-                                          SSL_ERROR_WANT_RETRY_VERIFY)))
+            SSL_ERROR_WANT_RETRY_VERIFY)))
         goto end;
     if (!TEST_int_eq(server_retry_state, 1))
         goto end;
 
     /* Resuming the handshake must now complete cleanly. */
     if (!TEST_true(create_ssl_connection(serverssl, clientssl,
-                                         SSL_ERROR_NONE)))
+            SSL_ERROR_NONE)))
         goto end;
     if (!TEST_int_eq(server_retry_state, 2))
         goto end;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -661,6 +661,111 @@ end:
     return testresult;
 }
 
+static int server_retry_state;
+
+static int server_verify_retry_cb(X509_STORE_CTX *ctx, void *arg)
+{
+    int idx = SSL_get_ex_data_X509_STORE_CTX_idx();
+    SSL *ssl;
+
+    if (idx < 0 || (ssl = X509_STORE_CTX_get_ex_data(ctx, idx)) == NULL)
+        return 0;
+
+    if (server_retry_state == 0) {
+        /* First call: ask the state machine to pause and retry. */
+        server_retry_state = 1;
+        return SSL_set_retry_verify(ssl);
+    }
+
+    /* Second call (after the app supplied a verdict): accept. */
+    server_retry_state = 2;
+    return 1;
+}
+
+static int test_server_cert_verify_cb(void)
+{
+    char *skey = test_mk_file_path(certsdir, "leaf.key");
+    char *leaf = test_mk_file_path(certsdir, "leaf.pem");
+    char *leaf_chain = test_mk_file_path(certsdir, "leaf-chain.pem");
+    char *root = test_mk_file_path(certsdir, "rootCA.pem");
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    int testresult = 0;
+
+    server_retry_state = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+                                       TLS_client_method(), TLS1_VERSION, 0,
+                                       &sctx, &cctx, NULL, NULL)))
+        goto end;
+
+    /* Server needs its own cert/key for the TLS handshake. */
+    if (!TEST_int_eq(SSL_CTX_use_certificate_chain_file(sctx, leaf_chain), 1)
+            || !TEST_int_eq(SSL_CTX_use_PrivateKey_file(sctx, skey,
+                                                        SSL_FILETYPE_PEM), 1)
+            || !TEST_int_eq(SSL_CTX_check_private_key(sctx), 1))
+        goto end;
+
+    /* Server requests and verifies a client certificate via the retry cb. */
+    SSL_CTX_set_verify(sctx,
+                       SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
+                       NULL);
+    SSL_CTX_set_cert_verify_callback(sctx, server_verify_retry_cb, NULL);
+
+    /* Client presents its cert (leaf signed by interCA/rootCA). */
+    if (!TEST_int_eq(SSL_CTX_use_certificate_file(cctx, leaf,
+                                                  SSL_FILETYPE_PEM), 1)
+            || !TEST_int_eq(SSL_CTX_use_PrivateKey_file(cctx, skey,
+                                                        SSL_FILETYPE_PEM), 1)
+            || !TEST_int_eq(SSL_CTX_check_private_key(cctx), 1))
+        goto end;
+    /* Client trusts the server's root so it accepts the server cert. */
+    if (!TEST_true(SSL_CTX_load_verify_locations(cctx, root, NULL)))
+        goto end;
+    SSL_CTX_set_verify(cctx, SSL_VERIFY_PEER, NULL);
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
+                                      &clientssl, NULL, NULL)))
+        goto end;
+
+    /*
+     * Driving the handshake the first time must surface
+     * SSL_ERROR_WANT_RETRY_VERIFY (proving the server state machine actually
+     * honored the callback's pause request rather than silently accepting -1).
+     */
+    if (!TEST_false(create_ssl_connection(serverssl, clientssl,
+                                          SSL_ERROR_WANT_RETRY_VERIFY)))
+        goto end;
+    if (!TEST_int_eq(server_retry_state, 1))
+        goto end;
+
+    /* Resuming the handshake must now complete cleanly. */
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl,
+                                         SSL_ERROR_NONE)))
+        goto end;
+    if (!TEST_int_eq(server_retry_state, 2))
+        goto end;
+
+    testresult = 1;
+
+end:
+    if (clientssl != NULL) {
+        SSL_shutdown(clientssl);
+        SSL_free(clientssl);
+    }
+    if (serverssl != NULL) {
+        SSL_shutdown(serverssl);
+        SSL_free(serverssl);
+    }
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    OPENSSL_free(skey);
+    OPENSSL_free(leaf);
+    OPENSSL_free(leaf_chain);
+    OPENSSL_free(root);
+    return testresult;
+}
+
 static int test_ssl_build_cert_chain(void)
 {
     int ret = 0;
@@ -15646,6 +15751,7 @@ int setup_tests(void)
     ADD_TEST(test_keylog_no_master_key);
 #endif
     ADD_TEST(test_client_cert_verify_cb);
+    ADD_TEST(test_server_cert_verify_cb);
     ADD_TEST(test_ssl_build_cert_chain);
     ADD_TEST(test_ssl_ctx_build_cert_chain);
 #ifndef OPENSSL_NO_TLS1_2

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -771,6 +771,96 @@ end:
     return testresult;
 }
 
+/*
+ * Same as test_server_cert_verify_cb() but with the client sending its
+ * credentials as an RPK. Exercises tls_post_process_client_rpk() and the
+ * SSL_set_retry_verify() pause on the server-side RPK code path.
+ */
+static int test_server_rpk_verify_cb(void)
+{
+    static const unsigned char cert_type_rpk[] = { TLSEXT_cert_type_rpk };
+    char *skey = test_mk_file_path(certsdir, "leaf.key");
+    char *leaf = test_mk_file_path(certsdir, "leaf.pem");
+    char *leaf_chain = test_mk_file_path(certsdir, "leaf-chain.pem");
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    int testresult = 0;
+
+    server_retry_state = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+            TLS_client_method(), TLS1_3_VERSION, 0,
+            &sctx, &cctx, NULL, NULL)))
+        goto end;
+
+    /* Server needs its own cert/key for the TLS handshake. */
+    if (!TEST_int_eq(SSL_CTX_use_certificate_chain_file(sctx, leaf_chain), 1)
+        || !TEST_int_eq(SSL_CTX_use_PrivateKey_file(sctx, skey,
+                            SSL_FILETYPE_PEM),
+            1)
+        || !TEST_int_eq(SSL_CTX_check_private_key(sctx), 1))
+        goto end;
+
+    /* Server: require client auth as RPK, verify via retry callback. */
+    if (!TEST_true(SSL_CTX_set1_client_cert_type(sctx, cert_type_rpk,
+            sizeof(cert_type_rpk))))
+        goto end;
+    SSL_CTX_set_verify(sctx,
+        SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
+        NULL);
+    SSL_CTX_set_cert_verify_callback(sctx, server_verify_retry_cb, NULL);
+
+    /* Client presents its cert as RPK. */
+    if (!TEST_true(SSL_CTX_set1_client_cert_type(cctx, cert_type_rpk,
+            sizeof(cert_type_rpk))))
+        goto end;
+    if (!TEST_int_eq(SSL_CTX_use_certificate_file(cctx, leaf,
+                         SSL_FILETYPE_PEM),
+            1)
+        || !TEST_int_eq(SSL_CTX_use_PrivateKey_file(cctx, skey,
+                            SSL_FILETYPE_PEM),
+            1)
+        || !TEST_int_eq(SSL_CTX_check_private_key(cctx), 1))
+        goto end;
+    SSL_CTX_set_verify(cctx, SSL_VERIFY_NONE, NULL);
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
+            &clientssl, NULL, NULL)))
+        goto end;
+
+    /* First drive: callback returns retry, handshake must surface it. */
+    if (!TEST_false(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_WANT_RETRY_VERIFY)))
+        goto end;
+    if (!TEST_int_eq(server_retry_state, 1))
+        goto end;
+
+    /* Resume: callback accepts, handshake completes. */
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl,
+            SSL_ERROR_NONE)))
+        goto end;
+    if (!TEST_int_eq(server_retry_state, 2))
+        goto end;
+
+    testresult = 1;
+
+end:
+    if (clientssl != NULL) {
+        SSL_shutdown(clientssl);
+        SSL_free(clientssl);
+    }
+    if (serverssl != NULL) {
+        SSL_shutdown(serverssl);
+        SSL_free(serverssl);
+    }
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    OPENSSL_free(skey);
+    OPENSSL_free(leaf);
+    OPENSSL_free(leaf_chain);
+    return testresult;
+}
+
 static int test_ssl_build_cert_chain(void)
 {
     int ret = 0;
@@ -15757,6 +15847,7 @@ int setup_tests(void)
 #endif
     ADD_TEST(test_client_cert_verify_cb);
     ADD_TEST(test_server_cert_verify_cb);
+    ADD_TEST(test_server_rpk_verify_cb);
     ADD_TEST(test_ssl_build_cert_chain);
     ADD_TEST(test_ssl_ctx_build_cert_chain);
 #ifndef OPENSSL_NO_TLS1_2

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -842,6 +842,10 @@ static int test_server_rpk_verify_cb(void)
     if (!TEST_int_eq(server_retry_state, 2))
         goto end;
 
+    /* Confirm the connection actually used raw public keys. */
+    if (!TEST_ptr(SSL_get0_peer_rpk(serverssl)))
+        goto end;
+
     testresult = 1;
 
 end:


### PR DESCRIPTION
This work generally mimics the client side. [SSL_set_retry_verify](https://docs.openssl.org/3.0/man3/SSL_set_retry_verify/) claims it can be set on SSL context but the hidden caveat is that it only works on client side. The server may be even more important is it has no control over who connects two it and the verification can be tricky.


This change splist server-side client-certificate processing into a parse phase (tls_process_client_certificate) and a post-process verification phase (tls_post_process_client_certificate), mirroring the existing client-side tls_process_server_certificate / tls_post_process_server_certificate split.

This lets an application's verify callback call SSL_set_retry_verify() during server-side client-cert verification: the post-process step now returns WORK_MORE_A so SSL_accept()/SSL_do_handshake() returns SSL_ERROR_WANT_RETRY_VERIFY, and re-entry resumes verification once the application has supplied a verdict. Until now SSL_set_retry_verify was documented as supported but only worked on the client.

A new regression test (test_server_cert_verify_cb in test/sslapitest.c) exercises the server-side retry-verify path end-to-end.

Fixes #30068
cc: @rzikm


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is NOT added or updated. The documented behavior will now apply for both server & client side.
- [x ] tests are added or updated
