### PR TITLE
clean up a few bugs in ossl_method_store

### DIFF
--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -976,7 +976,7 @@ static int ossl_method_store_atomic_archive(STORED_ALGORITHMS *sa, QUERY *old)
 static ossl_inline int ossl_method_store_put_in_archive(STORED_ALGORITHMS *sa, QUERY *old)
 {
     /*
-     * point the item we're remoing's next pointer to the top of the archive list
+     * point the item we're removing's next pointer to the top of the archive list
      * Note: We're writing to the old->next here which is shared, so that's suspicious, but
      * because we've already removed old from the cache_list in ossl_method_store_clean_archive
      * this is safe for the following reasons:

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -15,7 +15,6 @@
 #include <openssl/provider.h>
 #include "internal/property.h"
 #include "internal/provider.h"
-#include "internal/hashfunc.h"
 #include "internal/tsan_assist.h"
 #include "internal/threads_common.h"
 #include "internal/list.h"
@@ -63,7 +62,7 @@ typedef struct query_st {
     int nid; /* nid of this query */
     int archived; /* Mark entry as no longer findable */
     OSSL_PROVIDER *prov; /*provider this belongs to */
-    uint64_t prop_hash; /* hash of the property string */
+    char *prop_query; /* query string */
     METHOD method; /* METHOD for this query */
 } QUERY;
 
@@ -93,7 +92,7 @@ typedef struct {
 static int ossl_method_store_atomic_insert_to_list(STORED_ALGORITHMS *sa, QUERY *new);
 static int ossl_method_store_atomic_archive(STORED_ALGORITHMS *sa, QUERY *old);
 static QUERY *ossl_method_store_atomic_find_in_list(STORED_ALGORITHMS *sa, int nid,
-    OSSL_PROVIDER *prov, uint64_t prop_hash);
+    OSSL_PROVIDER *prov, const char *prop_query);
 static void ossl_cache_lists_flush(STORED_ALGORITHMS *sa);
 static void ossl_cache_lists_free(STORED_ALGORITHMS *sa);
 static void ossl_method_store_atomic_clean_archive(STORED_ALGORITHMS *sa);
@@ -126,6 +125,27 @@ typedef struct ossl_global_properties_st {
 static void ossl_method_cache_flush_alg(STORED_ALGORITHMS *sa,
     ALGORITHM *alg);
 static void ossl_method_cache_flush(STORED_ALGORITHMS *sa, int nid);
+
+static ossl_inline QUERY *QUERY_new(size_t prop_query_len)
+{
+    /*
+     * allocate a new QUERY with the associated property query buffer
+     * immediately following it
+     */
+    QUERY *new = OPENSSL_malloc(sizeof(QUERY) + prop_query_len + 1);
+    if (new != NULL)
+        new->prop_query = (char *)(new + 1);
+    return new;
+}
+
+static ossl_inline void QUERY_free(QUERY *q)
+{
+    /*
+     * because we allocate the QUERY with its property query string
+     * as one contiguous chunk, this frees both
+     */
+    OPENSSL_free(q);
+}
 
 /* Global properties are stored per library context */
 void ossl_ctx_global_properties_free(void *vglobp)
@@ -213,7 +233,7 @@ static ossl_inline void impl_cache_free_unlinked(QUERY *elem)
 {
     if (elem != NULL) {
         ossl_method_free(&elem->method);
-        OPENSSL_free(elem);
+        QUERY_free(elem);
     }
 }
 
@@ -913,13 +933,10 @@ int ossl_method_store_cache_flush_all(OSSL_METHOD_STORE *store)
 static ossl_inline int ossl_method_store_cache_get_atomic(OSSL_METHOD_STORE *store, OSSL_PROVIDER *prov,
     int nid, const char *prop_query, STORED_ALGORITHMS *sa, void **method)
 {
-    uint64_t prop_hash;
     QUERY *r = NULL;
     int res = 0;
 
-    prop_hash = ossl_fnv1a_hash((uint8_t *)prop_query, strlen(prop_query));
-
-    r = ossl_method_store_atomic_find_in_list(sa, nid, prov, prop_hash);
+    r = ossl_method_store_atomic_find_in_list(sa, nid, prov, prop_query);
 
     if (r != NULL && ossl_method_up_ref(&r->method)) {
         *method = r->method.method;
@@ -1082,7 +1099,7 @@ static void ossl_method_store_atomic_clean_archive(STORED_ALGORITHMS *sa)
 }
 
 static QUERY *ossl_method_store_atomic_find_in_list(STORED_ALGORITHMS *sa, int nid,
-    OSSL_PROVIDER *prov, uint64_t prop_hash)
+    OSSL_PROVIDER *prov, const char *prop_query)
 {
     int nididx = (nid >> NUM_SHARDS_BITS) & (MAX_CACHE_LINES - 1);
     int archived;
@@ -1095,7 +1112,8 @@ static QUERY *ossl_method_store_atomic_find_in_list(STORED_ALGORITHMS *sa, int n
     while (idx != NULL) {
         if (!CRYPTO_atomic_load_int(&idx->archived, &archived, sa->alock))
             goto out;
-        if (archived == 0 && idx->nid == nid && idx->prop_hash == prop_hash && idx->prov == prov) {
+        if (archived == 0 && idx->nid == nid && idx->prov == prov
+            && !strcmp(idx->prop_query, prop_query)) {
             ret = idx;
             break;
         }
@@ -1135,31 +1153,30 @@ static ossl_inline int ossl_method_store_cache_set_atomic(OSSL_METHOD_STORE *sto
     void (*method_destruct)(void *))
 {
     QUERY *p = NULL;
-    uint64_t prop_hash = ossl_fnv1a_hash((uint8_t *)prop_query, strlen(prop_query));
     int res = 1;
 
     if (method == NULL) {
-        p = ossl_method_store_atomic_find_in_list(sa, nid, prov, prop_hash);
+        p = ossl_method_store_atomic_find_in_list(sa, nid, prov, prop_query);
         if (p != NULL)
             ossl_method_store_atomic_archive(sa, p);
         goto end;
     }
 
-    p = ossl_method_store_atomic_find_in_list(sa, nid, prov, prop_hash);
+    p = ossl_method_store_atomic_find_in_list(sa, nid, prov, prop_query);
     if (p != NULL) {
         ossl_method_store_atomic_archive(sa, p);
-        p = ossl_method_store_atomic_find_in_list(sa, nid, NULL, prop_hash);
+        p = ossl_method_store_atomic_find_in_list(sa, nid, NULL, prop_query);
         if (p != NULL)
             ossl_method_store_atomic_archive(sa, p);
     }
-    p = OPENSSL_malloc(sizeof(*p));
+    p = QUERY_new(strlen(prop_query));
     if (p != NULL) {
         TSAN_BENIGN(p, "Unpublished value is safe on subsequent read");
         p->saptr = sa;
         p->nid = nid;
         p->prov = prov;
         p->archived = 0;
-        p->prop_hash = prop_hash;
+        strcpy(p->prop_query, prop_query);
         p->method.method = method;
         p->method.up_ref = method_up_ref;
         p->method.free = method_destruct;
@@ -1176,11 +1193,18 @@ static ossl_inline int ossl_method_store_cache_set_atomic(OSSL_METHOD_STORE *sto
          * from nid and property query.  This lets us match in the event someone does a lookup
          * against a NULL provider (i.e. the "any provided alg will do" match
          */
-        p = OPENSSL_memdup(p, sizeof(*p));
+        p = QUERY_new(strlen(prop_query));
         if (p == NULL)
             goto err;
         TSAN_BENIGN(p, "Unpublished value is safe on subsequent read");
+        p->saptr = sa;
+        p->nid = nid;
         p->prov = NULL;
+        p->archived = 0;
+        strcpy(p->prop_query, prop_query);
+        p->method.method = method;
+        p->method.up_ref = method_up_ref;
+        p->method.free = method_destruct;
         if (!ossl_method_up_ref(&p->method))
             goto err;
         if (!ossl_method_store_atomic_insert_to_list(sa, p)) {
@@ -1192,7 +1216,7 @@ static ossl_inline int ossl_method_store_cache_set_atomic(OSSL_METHOD_STORE *sto
     }
 err:
     res = 0;
-    OPENSSL_free(p);
+    QUERY_free(p);
 end:
     return res;
 }

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -1190,6 +1190,7 @@ static ossl_inline int ossl_method_store_cache_set_atomic(OSSL_METHOD_STORE *sto
 {
     QUERY *p = NULL;
     int res = 1;
+    int skip_providerless = 0;
 
     if (method == NULL) {
         p = ossl_method_store_atomic_find_in_list(sa, nid, prov, prop_query);
@@ -1202,8 +1203,15 @@ static ossl_inline int ossl_method_store_cache_set_atomic(OSSL_METHOD_STORE *sto
     if (p != NULL) {
         ossl_method_store_atomic_archive(sa, p);
         p = ossl_method_store_atomic_find_in_list(sa, nid, NULL, prop_query);
+        /*
+         * Note: We want to preserve previous behavior here.  Namely, if we load multiple
+         * providers we don't want to change the algorithm implementation we return if we've
+         * already potentially returned one from another provider.  So if an alg exists for
+         * a given nid/prop query with a NULL provider, don't replace the one we have.
+         * Instead, let the oldest one win
+         */
         if (p != NULL)
-            ossl_method_store_atomic_archive(sa, p);
+            skip_providerless = 1;
     }
     p = QUERY_new(strlen(prop_query));
     if (p != NULL) {
@@ -1224,30 +1232,31 @@ static ossl_inline int ossl_method_store_cache_set_atomic(OSSL_METHOD_STORE *sto
             goto err;
         }
 
-        /*
-         * We also want to add this method into the cache against a key computed _only_
-         * from nid and property query.  This lets us match in the event someone does a lookup
-         * against a NULL provider (i.e. the "any provided alg will do" match
-         */
-        p = QUERY_new(strlen(prop_query));
-        if (p == NULL)
-            goto err;
-        TSAN_BENIGN(p, "Unpublished value is safe on subsequent read");
-        p->saptr = sa;
-        p->nid = nid;
-        p->prov = NULL;
-        p->archived = 0;
-        strcpy(p->prop_query, prop_query);
-        p->method.method = method;
-        p->method.up_ref = method_up_ref;
-        p->method.free = method_destruct;
-        if (!ossl_method_up_ref(&p->method))
-            goto err;
-        if (!ossl_method_store_atomic_insert_to_list(sa, p)) {
-            ossl_method_free(&p->method);
-            goto err;
+        if (skip_providerless == 0) {
+            /*
+             * We also want to add this method into the cache against a key computed _only_
+             * from nid and property query.  This lets us match in the event someone does a lookup
+             * against a NULL provider (i.e. the "any provided alg will do" match
+             */
+            p = QUERY_new(strlen(prop_query));
+            if (p == NULL)
+                goto err;
+            TSAN_BENIGN(p, "Unpublished value is safe on subsequent read");
+            p->saptr = sa;
+            p->nid = nid;
+            p->prov = NULL;
+            p->archived = 0;
+            strcpy(p->prop_query, prop_query);
+            p->method.method = method;
+            p->method.up_ref = method_up_ref;
+            p->method.free = method_destruct;
+            if (!ossl_method_up_ref(&p->method))
+                goto err;
+            if (!ossl_method_store_atomic_insert_to_list(sa, p)) {
+                ossl_method_free(&p->method);
+                goto err;
+            }
         }
-
         goto end;
     }
 err:

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -977,7 +977,7 @@ static ossl_inline int ossl_method_store_put_in_archive(STORED_ALGORITHMS *sa, Q
 {
     /*
      * point the item we're remoing's next pointer to the top of the archive list
-     * Note: We're writing to the old->next here which is shared, so thats suspicious, but
+     * Note: We're writing to the old->next here which is shared, so that's suspicious, but
      * because we've already removed old from the cache_list in ossl_method_store_clean_archive
      * this is safe for the following reasons:
      * 1) the clean path is done under a write lock, so sa->archive is guaranteed stable
@@ -985,7 +985,7 @@ static ossl_inline int ossl_method_store_put_in_archive(STORED_ALGORITHMS *sa, Q
      * while we're moving it, will either read the true next value (pointing to the next element
      * in the cache_list), or the one we write here (the next list in the archive)
      *
-     * Reading the true next value is fine, as thats the normal traversal anyway.
+     * Reading the true next value is fine, as that's the normal traversal anyway.
      * Reading the next pointer as pointing into the archive list is not great, but in the worst
      * case this results in a transient failed cache lookup, which just means a temporary slow path
      * retrieval of an algorithm.

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -1149,7 +1149,7 @@ static QUERY *ossl_method_store_atomic_find_in_list(STORED_ALGORITHMS *sa, int n
         if (!CRYPTO_atomic_load_int(&idx->archived, &archived, sa->alock))
             goto out;
         if (archived == 0 && idx->nid == nid && idx->prov == prov
-            && !strcmp(idx->prop_query, prop_query)) {
+            && (strcmp(idx->prop_query, prop_query) == 0)) {
             ret = idx;
             break;
         }

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -977,6 +977,18 @@ static ossl_inline int ossl_method_store_put_in_archive(STORED_ALGORITHMS *sa, Q
 {
     /*
      * point the item we're remoing's next pointer to the top of the archive list
+     * Note: We're writing to the old->next here which is shared, so thats suspicious, but
+     * because we've already removed old from the cache_list in ossl_method_store_clean_archive
+     * this is safe for the following reasons:
+     * 1) the clean path is done under a write lock, so sa->archive is guaranteed stable
+     * 2) any concurrent reader (ie ossl_method_store_cache_set|get, if visiting the old node
+     * while we're moving it, will either read the true next value (pointing to the next element
+     * in the cache_list), or the one we write here (the next list in the archive)
+     *
+     * Reading the true next value is fine, as thats the normal traversal anyway.
+     * Reading the next pointer as pointing into the archive list is not great, but in the worst
+     * case this results in a transient failed cache lookup, which just means a temporary slow path
+     * retrieval of an algorithm.
      */
     if (!CRYPTO_atomic_load_ptr((void **)&sa->archive, (void **)&old->next, sa->alock))
         return 0;
@@ -994,7 +1006,7 @@ static ossl_inline int ossl_method_store_put_in_archive(STORED_ALGORITHMS *sa, Q
  */
 static void ossl_method_store_atomic_clean_archive(STORED_ALGORITHMS *sa)
 {
-    QUERY *idx, *idxn;
+    QUERY *idx, *idxn, *tmp;
     int archived;
     int i;
     int lock_failed;
@@ -1066,9 +1078,33 @@ static void ossl_method_store_atomic_clean_archive(STORED_ALGORITHMS *sa)
                 if (archived == 1) {
                     /*
                      * Start by making idx skip idxn in the list
+                     * First load the expected next value of idx->next
                      */
-                    if (!CRYPTO_atomic_load_ptr((void **)&idxn->next, (void **)&idx->next, sa->alock))
+                    if (!CRYPTO_atomic_load_ptr((void **)&idx->next, (void **)&tmp, sa->alock))
                         break;
+
+                    /*
+                     * Now compare the value of idx->next to what we just loaded to tmp above
+                     * if they match, we can safely update idx->next to skip the idxn entry
+                     * by pointing idx->next to idxn->next.
+                     * If the comparison fails, then we need to start the list traversal over again.
+                     * Note: This should never happen, as once an item is in the list, this is the
+                     * only path in which an in-list item has its next pointer mutated, and this
+                     * occurs under a write lock, but we should be safe here
+                     */
+                    if (!CRYPTO_atomic_cmp_exch_ptr((void **)&idx->next,
+                            (void **)&tmp, (void *)idxn->next,
+                            sa->alock, &lock_failed)) {
+                        if (lock_failed)
+                            break;
+                        /*
+                         * The list was mutated while we were trying to mutate it
+                         * Normally we would just use the reloaded value of tmp here to re-attempt
+                         * the removal, but since idx was changed underneath us, we don't know where
+                         * we are in the list anymore.  Its safer to just restart the whole traversal
+                         */
+                        goto restart_list;
+                    }
 
                     if (!ossl_method_store_put_in_archive(sa, idxn))
                         break;

--- a/test/property_test.c
+++ b/test/property_test.c
@@ -634,8 +634,8 @@ static int test_query_cache_stochastic(void)
             || result != v + i)
             errors++;
     }
-    /* There is a tiny probability that this will fail when it shouldn't */
-    res = !TEST_int_gt(errors, 0);
+
+    res = TEST_int_eq(errors, 0);
 
 err:
     ossl_method_store_free(store);
@@ -672,7 +672,7 @@ static int test_query_cache_set_duplicate(void)
      */
     ossl_method_store_cache_set(store, &prov, 1, "", &refs, counted_up_ref,
         counted_down_ref);
-    if (!TEST_int_eq(refs, 5)
+    if (!TEST_int_eq(refs, 4)
         || !TEST_true(ossl_method_store_cache_get(store, &prov, 1, "",
             &result))
         || !TEST_ptr_eq(result, &refs))


### PR DESCRIPTION
@mattcaswell noted a few bugs in the ossl_method_store changes that recently got merged. None have been actively observed, but manual analysis suggests they should be fixed.

This pr fixes two things:
1)
```
@mattcaswell noted that while cleaning QUERY items and moving them to
    the archive list, we do an atomic load of a QUERY's next pointer to
    another shared query's next pointer.  While its not been observed, it
    may be possible for the clean operation to move an element to the
    archive while a concurrent thread is prepending to the list, the result
    being that the active (cache_list) list has a head pointer whos next
    pointer points into the archive list.
    
    The result of this would be subsequent lookups fail to find anything not
    archived in the cache, and need to go through the slow
    ossl_method_construct path again to slowly rebuild the cache.  Thats not
    catastrophic, but its definately a bug that will result in additional
    memory allocations, along with entries that never get used again, and
    possible memory leaks.
    
    Switch the load_ptr call to be an atomic cmp_exch_ptr call to ensure
    that the node being visited isn't mutated concurrently by both a thread
    doing a clean and a list insert.  This ensures that only one thread wins
    the update, while the other restarts their operation.

```

2)
```
@mattcaswell noted that while cleaning QUERY items and moving them to
    the archive list, we do an atomic load of a QUERY's next pointer to
    another shared query's next pointer.  While its not been observed, it
    may be possible for the clean operation to move an element to the
    archive while a concurrent thread is prepending to the list, the result
    being that the active (cache_list) list has a head pointer whos next
    pointer points into the archive list.
    
    The result of this would be subsequent lookups fail to find anything not
    archived in the cache, and need to go through the slow
    ossl_method_construct path again to slowly rebuild the cache.  Thats not
    catastrophic, but its definately a bug that will result in additional
    memory allocations, along with entries that never get used again, and
    possible memory leaks.
    
    Switch the load_ptr call to be an atomic cmp_exch_ptr call to ensure
    that the node being visited isn't mutated concurrently by both a thread
    doing a clean and a list insert.  This ensures that only one thread wins
    the update, while the other restarts their operation.
```




