### PR TITLE
Removes unused args for new record layers.

### DIFF
--- a/include/internal/recordmethod.h
+++ b/include/internal/recordmethod.h
@@ -132,8 +132,6 @@ struct ossl_record_method_st {
         BIO *prev,
         BIO *transport,
         BIO *next,
-        BIO_ADDR *local,
-        BIO_ADDR *peer,
         const OSSL_PARAM *settings,
         const OSSL_PARAM *options,
         const OSSL_DISPATCH *fns,

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -105,7 +105,7 @@ quic_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
     int mactype,
     const EVP_MD *md, COMP_METHOD *comp,
     const EVP_MD *kdfdigest, BIO *prev, BIO *transport,
-    BIO *next, BIO_ADDR *local, BIO_ADDR *peer,
+    BIO *next,
     const OSSL_PARAM *settings, const OSSL_PARAM *options,
     const OSSL_DISPATCH *fns, void *cbarg, void *rlarg,
     OSSL_RECORD_LAYER **retrl)

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -637,7 +637,7 @@ dtls_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
     int mactype,
     const EVP_MD *md, COMP_METHOD *comp,
     const EVP_MD *kdfdigest, BIO *prev, BIO *transport,
-    BIO *next, BIO_ADDR *local, BIO_ADDR *peer,
+    BIO *next,
     const OSSL_PARAM *settings, const OSSL_PARAM *options,
     const OSSL_DISPATCH *fns, void *cbarg, void *rlarg,
     OSSL_RECORD_LAYER **retrl)

--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -405,7 +405,7 @@ ktls_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
     int mactype,
     const EVP_MD *md, COMP_METHOD *comp,
     const EVP_MD *kdfdigest, BIO *prev, BIO *transport,
-    BIO *next, BIO_ADDR *local, BIO_ADDR *peer,
+    BIO *next,
     const OSSL_PARAM *settings, const OSSL_PARAM *options,
     const OSSL_DISPATCH *fns, void *cbarg, void *rlarg,
     OSSL_RECORD_LAYER **retrl)

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1349,7 +1349,7 @@ tls_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
     int mactype,
     const EVP_MD *md, COMP_METHOD *comp,
     const EVP_MD *kdfdigest, BIO *prev, BIO *transport,
-    BIO *next, BIO_ADDR *local, BIO_ADDR *peer,
+    BIO *next,
     const OSSL_PARAM *settings, const OSSL_PARAM *options,
     const OSSL_DISPATCH *fns, void *cbarg, void *rlarg,
     OSSL_RECORD_LAYER **retrl)

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1442,7 +1442,7 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
             secret, secretlen, key, keylen, iv,
             ivlen, mackey, mackeylen, ciph, taglen,
             mactype, md, compm, kdfdigest, prev,
-            thisbio, next, NULL, NULL, settings,
+            thisbio, next, settings,
             options, rlayer_dispatch_tmp, s,
             s->rlayer.rlarg, &newrl);
         BIO_free(prev);

--- a/test/tls13encryptiontest.c
+++ b/test/tls13encryptiontest.c
@@ -312,7 +312,7 @@ static int test_tls13_encryption(void)
                 OSSL_RECORD_PROTECTION_LEVEL_APPLICATION, 0, NULL, 0,
                 key, 16, iv, ivlen, NULL, 0, EVP_aes_128_gcm(),
                 EVP_GCM_TLS_TAG_LEN, 0, NULL, NULL, NULL, NULL, NULL,
-                NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+                NULL, NULL, NULL, NULL, NULL, NULL,
                 &wrl)))
             goto err;
         memcpy(wrl->sequence, seqbuf, sizeof(seqbuf));
@@ -335,7 +335,7 @@ static int test_tls13_encryption(void)
                 OSSL_RECORD_PROTECTION_LEVEL_APPLICATION, 0, NULL, 0,
                 key, 16, iv, ivlen, NULL, 0, EVP_aes_128_gcm(),
                 EVP_GCM_TLS_TAG_LEN, 0, NULL, NULL, NULL, NULL, NULL,
-                NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+                NULL, NULL, NULL, NULL, NULL, NULL,
                 &rrl)))
             goto err;
         memcpy(rrl->sequence, seqbuf, sizeof(seqbuf));


### PR DESCRIPTION
Stumbled upon some unused args in the record layer creation. Let's remove them.