### PR TITLE
Use SSL_ALERT_DISPATCH_XXX consistently and removes unused alert description struct member.

### DIFF
--- a/ssl/d1_msg.c
+++ b/ssl/d1_msg.c
@@ -41,8 +41,6 @@ int dtls1_dispatch_alert(SSL *ssl)
 {
     int i, j;
     void (*cb)(const SSL *ssl, int type, int val) = NULL;
-    unsigned char buf[DTLS1_AL_HEADER_LENGTH];
-    unsigned char *ptr = &buf[0];
     size_t written;
     SSL_CONNECTION *s = SSL_CONNECTION_FROM_SSL_ONLY(ssl);
 
@@ -51,20 +49,15 @@ int dtls1_dispatch_alert(SSL *ssl)
 
     s->s3.alert_dispatch = SSL_ALERT_DISPATCH_NONE;
 
-    memset(buf, 0, sizeof(buf));
-    *ptr++ = s->s3.send_alert[0];
-    *ptr++ = s->s3.send_alert[1];
-
-    i = do_dtls1_write(s, SSL3_RT_ALERT, &buf[0], sizeof(buf), &written);
+    i = do_dtls1_write(s, SSL3_RT_ALERT, s->s3.send_alert, sizeof(s->s3.send_alert), &written);
     if (i <= 0) {
-        s->s3.alert_dispatch = 1;
-        /* fprintf(stderr, "not done with alert\n"); */
+        s->s3.alert_dispatch = SSL_ALERT_DISPATCH_PENDING;
     } else {
         (void)BIO_flush(s->wbio);
 
         if (s->msg_callback)
             s->msg_callback(1, s->version, SSL3_RT_ALERT, s->s3.send_alert,
-                2, ssl, s->msg_callback_arg);
+                sizeof(s->s3.send_alert), ssl, s->msg_callback_arg);
 
         if (s->info_callback != NULL)
             cb = s->info_callback;

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -444,7 +444,6 @@ start:
             }
         } else if (alert_level == SSL3_AL_FATAL) {
             sc->rwstate = SSL_NOTHING;
-            sc->s3.fatal_alert = alert_descr;
             SSLfatal_data(sc, SSL_AD_NO_ALERT,
                 SSL_AD_REASON_OFFSET + alert_descr,
                 "SSL alert number %d", alert_descr);
@@ -631,7 +630,7 @@ int do_dtls1_write(SSL_CONNECTION *sc, uint8_t type, const unsigned char *buf,
     int ret;
 
     /* If we have an alert to send, lets send it */
-    if (sc->s3.alert_dispatch > 0) {
+    if (sc->s3.alert_dispatch != SSL_ALERT_DISPATCH_NONE) {
         i = s->method->ssl_dispatch_alert(s);
         if (i <= 0)
             return i;

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -366,7 +366,7 @@ int ssl3_write_bytes(SSL *ssl, uint8_t type, const void *buf_, size_t len,
     }
 
     /* If we have an alert to send, lets send it */
-    if (s->s3.alert_dispatch > 0) {
+    if (s->s3.alert_dispatch != SSL_ALERT_DISPATCH_NONE) {
         i = ssl->method->ssl_dispatch_alert(ssl);
         if (i <= 0) {
             /* SSLfatal() already called if appropriate */
@@ -919,7 +919,6 @@ start:
             return 0;
         } else if (alert_level == SSL3_AL_FATAL || is_tls13) {
             s->rwstate = SSL_NOTHING;
-            s->s3.fatal_alert = alert_descr;
             SSLfatal_data(s, SSL_AD_NO_ALERT,
                 SSL_AD_REASON_OFFSET + alert_descr,
                 "SSL alert number %d", alert_descr);

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -5081,11 +5081,11 @@ int ssl3_shutdown(SSL *s)
         ssl3_send_alert(sc, SSL3_AL_WARNING, SSL_AD_CLOSE_NOTIFY);
         /*
          * our shutdown alert has been sent now, and if it still needs to be
-         * written, s->s3.alert_dispatch will be > 0
+         * written, s->s3.alert_dispatch will be != SSL_ALERT_DISPATCH_NONE
          */
-        if (sc->s3.alert_dispatch > 0)
+        if (sc->s3.alert_dispatch != SSL_ALERT_DISPATCH_NONE)
             return -1; /* return WANT_WRITE */
-    } else if (sc->s3.alert_dispatch > 0) {
+    } else if (sc->s3.alert_dispatch != SSL_ALERT_DISPATCH_NONE) {
         /* resend it if not sent */
         ret = s->method->ssl_dispatch_alert(s);
         if (ret == -1) {

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2765,8 +2765,8 @@ ossl_ssize_t SSL_sendfile(SSL *s, int fd, off_t offset, size_t size, int flags)
     }
 
     /* If we have an alert to send, lets send it */
-    if (sc->s3.alert_dispatch > 0) {
-        ret = (ossl_ssize_t)s->method->ssl_dispatch_alert(s);
+    if (sc->s3.alert_dispatch != SSL_ALERT_DISPATCH_NONE) {
+        ret = s->method->ssl_dispatch_alert(s);
         ssl_update_error_state(sc);
         if (ret <= 0) {
             /* SSLfatal() already called if appropriate */

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1357,8 +1357,7 @@ struct ssl_connection_st {
          * Unexpected ChangeCipherSpec messages trigger a fatal alert.
          */
         int change_cipher_spec;
-        int warn_alert;
-        int fatal_alert;
+        unsigned int warn_alert;
         /*
          * we allow one fatal and one warning alert to be outstanding, send close
          * alert via the warning alert


### PR DESCRIPTION


<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
