### PR TITLE
test: run RIO notifier smoke test on all QUIC builds

### DIFF
--- a/test/build.info
+++ b/test/build.info
@@ -87,10 +87,7 @@ IF[{- !$disabled{tests} -}]
 
   IF[{- !$disabled{quic} -}]
     PROGRAMS{noinst}=priority_queue_test quicfaultstest quicapitest \
-                     quic_newcid_test quic_srt_gen_test
-    IF[{- $config{target} =~ /^(?:VC-|mingw|BC-)/ -}]
-      PROGRAMS{noinst}=rio_notifier_test
-    ENDIF
+                     quic_newcid_test quic_srt_gen_test rio_notifier_test
   ENDIF
 
   IF[{- !$disabled{quic} && !$disabled{qlog} -}]
@@ -392,11 +389,9 @@ IF[{- !$disabled{tests} -}]
   DEPEND[packettest]=../libcrypto libtestutil.a
 
   IF[{- !$disabled{'quic'} -}]
-    IF[{- $config{target} =~ /^(?:VC-|mingw|BC-)/ -}]
       SOURCE[rio_notifier_test]=rio_notifier_test.c
       INCLUDE[rio_notifier_test]=.. ../include ../apps/include
       DEPEND[rio_notifier_test]=../libcrypto.a ../libssl.a libtestutil.a
-    ENDIF
 
       SOURCE[quic_wire_test]=quic_wire_test.c
       INCLUDE[quic_wire_test]=../include ../apps/include

--- a/test/recipes/70-test_rio_notifier.t
+++ b/test/recipes/70-test_rio_notifier.t
@@ -14,9 +14,6 @@ setup("test_rio_notifier");
 plan skip_all => "RIO notifier tests require QUIC"
     if disabled("quic");
 
-plan skip_all => "RIO notifier WSA tests are only available on Windows"
-    if config("target") !~ /^(?:VC-|mingw|BC-)/i;
-
 plan tests => 1;
 
 ok(run(test(["rio_notifier_test"])));


### PR DESCRIPTION
The RIO notifier smoke test is currently limited to Windows targets in both the build metadata and the test recipe.
The test exercises the notifier abstraction and can run on other platforms as well, so this removes the Windows-only guards.

The test remains conditional on QUIC being enabled.

Follow-up to #30918.

##### Checklist
- [x] tests are added or updated