### PR TITLE
ci: Switch to VS 2026 for windows-2025 image

### DIFF
--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -141,7 +141,7 @@ jobs:
           - os: windows-2022
             vcvars: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
           - os: windows-2025
-            vcvars: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+            vcvars: C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvars64.bat
     runs-on: ${{ matrix.platform.os }}
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,7 +25,7 @@ jobs:
           - arch: amd64
             os: windows-2025
             config: enable-lms enable-fips no-thread-pool no-quic
-            vcvars: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+            vcvars: C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvars64.bat
           - arch: x86
             os: windows-2022
             config: no-fips enable-lms


### PR DESCRIPTION
Current Windows CI builds are failing due to migration described in https://github.com/actions/runner-images/issues/14017

GitHub no longer supports Visual Studio 2022 on windows-2025 image, switch to VS 2026.

An alternative is to use windows-2022 image, but then the test matrix does no longer make sense (the goal was to test new Windows here).