### PR TITLE
.github/workflows/backport.yml: show diff on cherry-pick failure

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -52,7 +52,7 @@ jobs:
            git config user.name "OpenSSL Machine"
            git config user.email "openssl-machine@openssl.org"
            echo Cherry-picking $REFSTART..$REFEND
-           git cherry-pick $REFSTART..$REFEND
+           git cherry-pick $REFSTART..$REFEND || { git diff | head -n1000; exit 1; }
     - name: config
       if: ${{ contains(join(github.event.pull_request.labels.*.name,','),matrix.release.branch) }}
       run: ${{ matrix.release.cppflags }} ./config --strict-warnings --banner=Configured no-asm enable-fips --strict-warnings -D_DEFAULT_SOURCE && perl configdata.pm --dump


### PR DESCRIPTION
Having the diff available right away in the CI run logs aids evaluation of severity of the merge conflicts.