### PR TITLE
TSAN: data race in ossl_default_provider_init in openssl

### DIFF
--- a/providers/baseprov.c
+++ b/providers/baseprov.c
@@ -29,10 +29,6 @@ static OSSL_FUNC_provider_gettable_params_fn base_gettable_params;
 static OSSL_FUNC_provider_get_params_fn base_get_params;
 static OSSL_FUNC_provider_query_operation_fn base_query;
 
-/* Functions provided by the core */
-static OSSL_FUNC_core_gettable_params_fn *c_gettable_params = NULL;
-static OSSL_FUNC_core_get_params_fn *c_get_params = NULL;
-
 /* Parameters we provide to the core */
 static const OSSL_PARAM base_param_types[] = {
     OSSL_PARAM_DEFN(OSSL_PROV_PARAM_NAME, OSSL_PARAM_UTF8_PTR, NULL, 0),
@@ -139,15 +135,13 @@ int ossl_base_provider_init(const OSSL_CORE_HANDLE *handle,
     void **provctx)
 {
     OSSL_FUNC_core_get_libctx_fn *c_get_libctx = NULL;
+    OSSL_FUNC_core_get_params_fn *c_get_params = NULL;
     BIO_METHOD *corebiometh;
 
     if (!ossl_prov_bio_from_dispatch(in))
         return 0;
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
-        case OSSL_FUNC_CORE_GETTABLE_PARAMS:
-            c_gettable_params = OSSL_FUNC_core_gettable_params(in);
-            break;
         case OSSL_FUNC_CORE_GET_PARAMS:
             c_get_params = OSSL_FUNC_core_get_params(in);
             break;

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -34,10 +34,6 @@ static OSSL_FUNC_provider_query_operation_fn deflt_query;
 #define ALGC(NAMES, FUNC, CHECK) { { NAMES, "provider=default", FUNC }, CHECK }
 #define ALG(NAMES, FUNC) ALGC(NAMES, FUNC, NULL)
 
-/* Functions provided by the core */
-static OSSL_FUNC_core_gettable_params_fn *c_gettable_params = NULL;
-static OSSL_FUNC_core_get_params_fn *c_get_params = NULL;
-
 /* Parameters we provide to the core */
 static const OSSL_PARAM deflt_param_types[] = {
     OSSL_PARAM_DEFN(OSSL_PROV_PARAM_NAME, OSSL_PARAM_UTF8_PTR, NULL, 0),
@@ -799,6 +795,7 @@ int ossl_default_provider_init(const OSSL_CORE_HANDLE *handle,
     void **provctx)
 {
     OSSL_FUNC_core_get_libctx_fn *c_get_libctx = NULL;
+    OSSL_FUNC_core_get_params_fn *c_get_params = NULL;
     BIO_METHOD *corebiometh;
 
     if (!ossl_prov_bio_from_dispatch(in)
@@ -806,9 +803,6 @@ int ossl_default_provider_init(const OSSL_CORE_HANDLE *handle,
         return 0;
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
-        case OSSL_FUNC_CORE_GETTABLE_PARAMS:
-            c_gettable_params = OSSL_FUNC_core_gettable_params(in);
-            break;
         case OSSL_FUNC_CORE_GET_PARAMS:
             c_get_params = OSSL_FUNC_core_get_params(in);
             break;

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -63,7 +63,6 @@ extern OSSL_FUNC_core_thread_start_fn *c_thread_start;
  */
 
 /* Functions provided by the core */
-static OSSL_FUNC_core_gettable_params_fn *c_gettable_params;
 static OSSL_FUNC_core_get_params_fn *c_get_params;
 OSSL_FUNC_core_thread_start_fn *c_thread_start;
 static OSSL_FUNC_core_new_error_fn *c_new_error;
@@ -839,9 +838,6 @@ int OSSL_provider_init_int(const OSSL_CORE_HANDLE *handle,
         switch (in->function_id) {
         case OSSL_FUNC_CORE_GET_LIBCTX:
             set_func(c_get_libctx, OSSL_FUNC_core_get_libctx(in));
-            break;
-        case OSSL_FUNC_CORE_GETTABLE_PARAMS:
-            set_func(c_gettable_params, OSSL_FUNC_core_gettable_params(in));
             break;
         case OSSL_FUNC_CORE_GET_PARAMS:
             set_func(c_get_params, OSSL_FUNC_core_get_params(in));

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -43,7 +43,6 @@ typedef struct p_test_ctx {
     OSSL_LIB_CTX *libctx;
 } P_TEST_CTX;
 
-static OSSL_FUNC_core_gettable_params_fn *c_gettable_params = NULL;
 static OSSL_FUNC_core_get_params_fn *c_get_params = NULL;
 static OSSL_FUNC_core_new_error_fn *c_new_error;
 static OSSL_FUNC_core_set_error_debug_fn *c_set_error_debug;
@@ -258,9 +257,6 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
 
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
-        case OSSL_FUNC_CORE_GETTABLE_PARAMS:
-            c_gettable_params = OSSL_FUNC_core_gettable_params(in);
-            break;
         case OSSL_FUNC_CORE_GET_PARAMS:
             c_get_params = OSSL_FUNC_core_get_params(in);
             break;


### PR DESCRIPTION
finishing @bbbrumley student ticket

Original issue: https://github.com/openssl/openssl/issues/28935. A small change was requested in the comment https://github.com/openssl/openssl/pull/31050#issuecomment-4552759810, and this PR uses the original commit, and on top of it fixes the requested change.