### PR TITLE
Fix encrypt decrypt fetch for cms from provider side

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -1148,7 +1148,7 @@ int cms_main(int argc, char **argv)
 
             res = EVP_PKEY_CTX_ctrl(pctx, -1, -1,
                 EVP_PKEY_CTRL_CIPHER,
-                EVP_CIPHER_get_nid(cipher), NULL);
+                EVP_CIPHER_get_nid(cipher), cipher);
             if (res <= 0 && res != -2)
                 goto end;
 

--- a/crypto/cms/cms_enc.c
+++ b/crypto/cms/cms_enc.c
@@ -17,6 +17,7 @@
 #include "crypto/evp.h"
 #include "crypto/asn1.h"
 #include "cms_local.h"
+#include "internal/sizes.h"
 
 /* CMS EncryptedData Utilities */
 
@@ -65,9 +66,13 @@ BIO *ossl_cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec,
     if (cipher != NULL) {
         fetched_ciph = EVP_CIPHER_fetch(libctx, EVP_CIPHER_get0_name(cipher),
             propq);
-        if (fetched_ciph != NULL)
-            cipher = fetched_ciph;
+    } else {
+        char txtoid[OSSL_MAX_NAME_SIZE];
+        if (OBJ_obj2txt(txtoid, sizeof(txtoid), calg->algorithm, 1) > 0)
+            fetched_ciph = EVP_CIPHER_fetch(libctx, txtoid, propq);
     }
+    if (fetched_ciph != NULL)
+        cipher = fetched_ciph;
     if (cipher == NULL) {
         (void)ERR_clear_last_mark();
         ERR_raise(ERR_LIB_CMS, CMS_R_UNKNOWN_CIPHER);
@@ -81,8 +86,14 @@ BIO *ossl_cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec,
     }
 
     if (enc) {
+        (void)ERR_set_mark();
         calg->algorithm = OBJ_nid2obj(EVP_CIPHER_CTX_get_type(ctx));
-        if (calg->algorithm == NULL || calg->algorithm->nid == NID_undef) {
+        (void)ERR_pop_to_mark();
+
+        if (calg->algorithm == NULL || calg->algorithm->nid == NID_undef)
+            calg->algorithm = OBJ_txt2obj(EVP_CIPHER_get0_name(cipher), 0);
+
+        if (calg->algorithm == NULL || OBJ_length(calg->algorithm) == 0) {
             ERR_raise(ERR_LIB_CMS, CMS_R_UNSUPPORTED_CONTENT_ENCRYPTION_ALGORITHM);
             goto err;
         }


### PR DESCRIPTION
For algorithms without NID (without registration via the engine), cms_enc attempts to fetch via OBJ_obj2txt.

passing cipher instead of NULL in EVP_PKEY_CTX_ctrl in apps/cms.c

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
