### PR TITLE
demos/http3: fix missing NUL terminator on h3ssl->url

### DIFF
--- a/demos/http3/ossl-nghttp3-demo-server.c
+++ b/demos/http3/ossl-nghttp3-demo-server.c
@@ -291,7 +291,7 @@ static int on_recv_header(nghttp3_conn *conn, int64_t stream_id, int32_t token,
     fprintf(stdout, "\n");
 
     if (token == NGHTTP3_QPACK_TOKEN__PATH) {
-        int len = (((vvalue.len) < (MAXURL)) ? (vvalue.len) : (MAXURL));
+        int len = (((vvalue.len) < (MAXURL)) ? (vvalue.len) : (MAXURL - 1));
 
         memset(h3ssl->url, 0, sizeof(h3ssl->url));
         if (vvalue.base[0] == '/') {


### PR DESCRIPTION
Fixes a heap out-of-bounds read in the HTTP/3 demo server. The :path
handler in demos/http3/ossl-nghttp3-demo-server.c can leave h3ssl->url
unterminated when the path value does not start with '/' and is >= MAXURL
bytes; the buffer is later used with strcat()/strcmp(). Capping the copy
length at MAXURL - 1 keeps the memset's trailing zero, guaranteeing
termination in all of the branches. The commit message has more details :)
Fixes #31516

- [ ] documentation added/updated
- [ ] tests added/updated