### PR TITLE
pkcs11-provider: update to latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -786,7 +786,7 @@ jobs:
     steps:
     - name: package installs
       run: |
-        dnf install -y perl-FindBin perl-IPC-Cmd perl-File-Compare perl-File-Copy perl-Test-Simple perl-Test-Harness python3 make g++ perl git meson opensc expect kryoptic
+        dnf install -y perl-FindBin perl-IPC-Cmd perl-File-Compare perl-File-Copy perl-Test-Simple perl-Test-Harness python3 make g++ perl git meson opensc expect kryoptic xxd
     - uses: actions/checkout@v6
       with:
         persist-credentials: false


### PR DESCRIPTION
This fixes accidental version update in e2bd9f8c28 which is causing CI failure for pkcs11-provider tests.

It needs to add xxd tool which used in new hkdf test.