### PR TITLE
Document trailing data handling for DER input

### DIFF
--- a/doc/man1/openssl-format-options.pod
+++ b/doc/man1/openssl-format-options.pod
@@ -60,6 +60,11 @@ is described in each command documentation.
 A binary format, encoded or parsed according to Distinguished Encoding Rules
 (DER) of the ASN.1 data language.
 
+When a command reads a single DER object, it may stop after successfully
+decoding that object. Any trailing data in the input is not necessarily
+examined or rejected. Therefore, a successful command does not by itself
+confirm that the entire input consists of one valid DER object.
+
 =item B<P12>
 
 A DER-encoded file containing a PKCS#12 object.
@@ -124,7 +129,7 @@ Note that the parsing is simple and might fail to parse some legal data.
 
 =head1 COPYRIGHT
 
-Copyright 2000-2021 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2026 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy


### PR DESCRIPTION
## Summary

Document that commands reading a single DER object may stop after decoding that object and may not examine or reject trailing input. This makes clear that a successful `x509`, `pkey`, or `pkcs8` invocation is not, by itself, a full-input DER validation check.

The clarification lives in `openssl-format-options(1)`, which is the shared format reference linked by the affected commands.

## Validation

- `./Configure darwin64-arm64-cc --strict-warnings no-shared`
- `make -j8`
- `make doc-nits`
- `Pod::Checker` on `doc/man1/openssl-format-options.pod`
- Reproduced malformed trailing ASN.1 data: `x509`, `pkey`, and `pkcs8` returned success while `asn1parse` rejected the complete stream
- `git diff --check`

##### Checklist

- [x] documentation is added or updated