### PR TITLE
Prevent integer overflow in ASN1_mbstring_ncopy [backport]

### DIFF
--- a/crypto/asn1/a_mbstr.c
+++ b/crypto/asn1/a_mbstr.c
@@ -55,8 +55,10 @@ int ASN1_mbstring_ncopy(ASN1_STRING **out, const unsigned char *in, int len,
         len = strlen((const char *)in);
     if (!mask)
         mask = DIRSTRING_TYPE;
-    if (len < 0)
+    if (len < 0 || len >= INT_MAX) {
+        ERR_raise(ERR_LIB_ASN1, ERR_R_PASSED_INVALID_ARGUMENT);
         return -1;
+    }
 
     /* First do a string check and work out the number of characters */
     switch (inform) {
@@ -294,7 +296,7 @@ static int out_utf8(unsigned long value, void *arg)
         return len;
     }
     outlen = arg;
-    if (*outlen > INT_MAX - len) {
+    if (*outlen >= INT_MAX - len) {
         ERR_raise(ERR_LIB_ASN1, ASN1_R_STRING_TOO_LONG);
         return -1;
     }

--- a/crypto/asn1/a_mbstr.c
+++ b/crypto/asn1/a_mbstr.c
@@ -55,8 +55,11 @@ int ASN1_mbstring_ncopy(ASN1_STRING **out, const unsigned char *in, int len,
         len = strlen((const char *)in);
     if (!mask)
         mask = DIRSTRING_TYPE;
-    if (len < 0 || len >= INT_MAX) {
+    if (len < 0) {
         ERR_raise(ERR_LIB_ASN1, ERR_R_PASSED_INVALID_ARGUMENT);
+        return -1;
+    } else if (len >= INT_MAX) {
+        ERR_raise(ERR_LIB_ASN1, ASN1_R_STRING_TOO_LONG);
         return -1;
     }
 

--- a/crypto/asn1/a_mbstr.c
+++ b/crypto/asn1/a_mbstr.c
@@ -51,8 +51,15 @@ int ASN1_mbstring_ncopy(ASN1_STRING **out, const unsigned char *in, int len,
     unsigned char *p;
     int nchar;
     int (*cpyfunc)(unsigned long, void *) = NULL;
-    if (len == -1)
-        len = strlen((const char *)in);
+    if (len == -1) {
+        size_t len_s = strlen((const char *)in);
+
+        if (len_s >= INT_MAX) {
+            ERR_raise(ERR_LIB_ASN1, ASN1_R_STRING_TOO_LONG);
+            return -1;
+        }
+        len = (int)len_s;
+    }
     if (!mask)
         mask = DIRSTRING_TYPE;
     if (len < 0) {


### PR DESCRIPTION
This prevents a theoretically possible integer overflow in OPENSSL_malloc(outlen + 1) at the end of ASN1_mbstring_ncopy, when outlen is exactly INT_MAX.
That affects conversions from MBSTRING_ASC to MBSTRING_UTF8 and MBSTRING_UTF8 to MBSTRING_ASC,
because a terminating zero has to be added to the result. And also conversions MBSTRING_BMP to MBSTRING_UTF8 in cases when UTF8 characters 0x800..0xFFFF are encoded as 3-byte UTF8-characters and the resulting UTF8-string is exactly INT_MAX in size.

Fixes: 97f6b621f7af ("Reject oversized inputs in ASN1_mbstring_ncopy()")
