### PR TITLE
Fix typecasting for ASN1 callbacks for ASN1_ITEM_ex_i2d

### DIFF
--- a/crypto/asn1/tasn_enc.c
+++ b/crypto/asn1/tasn_enc.c
@@ -78,6 +78,16 @@ static int asn1_item_flags_i2d(const ASN1_VALUE *val, unsigned char **out,
  * performs the normal item handling: it can be used in external types.
  */
 
+static ossl_inline int handle_asn1_cb(ASN1_aux_const_cb *const_cb, ASN1_aux_cb *cb,
+    int op, const ASN1_VALUE **pval, const ASN1_ITEM *it)
+{
+    if (const_cb != NULL)
+        return const_cb(op, pval, it, NULL);
+    else if (cb != NULL)
+        return cb(op, (ASN1_VALUE **)pval, it, NULL);
+    return -1;
+}
+
 int ASN1_item_ex_i2d(const ASN1_VALUE **pval, unsigned char **out,
     const ASN1_ITEM *it, int tag, int aclass)
 {
@@ -85,14 +95,17 @@ int ASN1_item_ex_i2d(const ASN1_VALUE **pval, unsigned char **out,
     int i, seqcontlen, seqlen, ndef = 1;
     const ASN1_EXTERN_FUNCS *ef;
     const ASN1_AUX *aux = it->funcs;
-    ASN1_aux_const_cb *asn1_cb = NULL;
+    ASN1_aux_const_cb *asn1_const_cb = NULL;
+    ASN1_aux_cb *asn1_cb = NULL;
 
     if ((it->itype != ASN1_ITYPE_PRIMITIVE) && *pval == NULL)
         return 0;
 
     if (aux != NULL) {
-        asn1_cb = ((aux->flags & ASN1_AFLG_CONST_CB) != 0) ? aux->asn1_const_cb
-                                                           : (ASN1_aux_const_cb *)aux->asn1_cb; /* backward compatibility */
+        if ((aux->flags & ASN1_AFLG_CONST_CB) != 0)
+            asn1_const_cb = aux->asn1_const_cb;
+        else
+            asn1_cb = aux->asn1_cb;
     }
 
     switch (it->itype) {
@@ -123,8 +136,10 @@ int ASN1_item_ex_i2d(const ASN1_VALUE **pval, unsigned char **out,
             ERR_raise(ERR_LIB_ASN1, ASN1_R_BAD_TEMPLATE);
             return -1;
         }
-        if (asn1_cb && !asn1_cb(ASN1_OP_I2D_PRE, pval, it, NULL))
+
+        if (handle_asn1_cb(asn1_const_cb, asn1_cb, ASN1_OP_I2D_PRE, pval, it) == 0)
             return 0;
+
         i = ossl_asn1_get_choice_selector_const(pval, it);
         if ((i >= 0) && (i < it->tcount)) {
             const ASN1_VALUE **pchval;
@@ -133,9 +148,11 @@ int ASN1_item_ex_i2d(const ASN1_VALUE **pval, unsigned char **out,
             pchval = ossl_asn1_get_const_field_ptr(pval, chtt);
             return asn1_template_ex_i2d(pchval, out, chtt, -1, aclass);
         }
+
         /* Fixme: error condition if selector out of range */
-        if (asn1_cb && !asn1_cb(ASN1_OP_I2D_POST, pval, it, NULL))
+        if (handle_asn1_cb(asn1_const_cb, asn1_cb, ASN1_OP_I2D_POST, pval, it) == 0)
             return 0;
+
         break;
 
     case ASN1_ITYPE_EXTERN:
@@ -166,8 +183,10 @@ int ASN1_item_ex_i2d(const ASN1_VALUE **pval, unsigned char **out,
             aclass = (aclass & ~ASN1_TFLG_TAG_CLASS)
                 | V_ASN1_UNIVERSAL;
         }
-        if (asn1_cb && !asn1_cb(ASN1_OP_I2D_PRE, pval, it, NULL))
+
+        if (handle_asn1_cb(asn1_const_cb, asn1_cb, ASN1_OP_I2D_PRE, pval, it) == 0)
             return 0;
+
         /* First work out sequence content length */
         for (i = 0, tt = it->templates; i < it->tcount; tt++, i++) {
             const ASN1_TEMPLATE *seqtt;
@@ -200,8 +219,10 @@ int ASN1_item_ex_i2d(const ASN1_VALUE **pval, unsigned char **out,
         }
         if (ndef == 2)
             ASN1_put_eoc(out);
-        if (asn1_cb && !asn1_cb(ASN1_OP_I2D_POST, pval, it, NULL))
+
+        if (handle_asn1_cb(asn1_const_cb, asn1_cb, ASN1_OP_I2D_POST, pval, it) == 0)
             return 0;
+
         return seqlen;
 
     default:


### PR DESCRIPTION
ASN1_ITEM_ex_i2d has 2 callback types, asn1_cb and asn1_const_cb, but internally casts them both the the const style function prototype as a pointer, selecting the appropriate one based on the stored flags.

However, using the asn1_cb as a const callback is a ubsan violation. The following functions are effected:

cms_ri_cb
cms_cb
crl_cb
crl_inf_cb
dh_cb
dsa_cb
pk7_cb
pkey_cb
req_cb
rinf_cb
rsa_cb
rsa_oaep_cb
ts_resp_cb
x509_cb
cms_cb
cms_ec_cb
cms_rek_cb
crl_cb
crl_inf_cb
dh_cb
dsa_cb
pk7_cb
pkey_cb
req_cb
ri_cb
rinf_cb
rsa_cb
rsa_oaep_cb
x509_cb

Fix this by altering the ASN1_ITEM_ex_d2i function to no longer alias the two stored function pointers to a single type, and select the appropriate one at run time.

Fixes openssl/project#1970

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

