### PR TITLE
doc: Clarify EVP_CipherInit enc parameter handling of other values

### DIFF
--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -453,6 +453,9 @@ These functions can be used for decryption or encryption. The operation
 performed depends on the value of the I<enc> parameter. It should be set to 1
 for encryption, 0 for decryption and -1 to leave the value unchanged
 (the actual value of 'enc' being supplied in a previous call).
+For compatibility, any other nonzero value of I<enc> is currently treated as 1
+(encryption), but relying on this is discouraged: only 1, 0 and -1 should be
+used, as other values are undocumented and may be rejected in a future release.
 
 =item EVP_CipherInit_SKEY()
 


### PR DESCRIPTION
Fixes #31357

### What
Documents how the `enc` parameter of `EVP_CipherInit_ex2()` / `EVP_CipherInit_ex()` (and friends) behaves for values other than the documented `1`, `0` and `-1`.

### Why
The manual states `enc` should be set to `1` (encrypt), `0` (decrypt) or `-1` (leave unchanged), but says nothing about other values. The implementation in `crypto/evp/evp_enc.c` treats any nonzero value other than `-1` as `1` (encryption):

```c
if (enc == -1) {
    enc = ctx->encrypt;
} else {
    if (enc)
        enc = 1;
    ctx->encrypt = enc;
}
```

This surprised a user who observed an application passing `enc == 2` and it being silently accepted as encryption (#31357). This patch documents the current behaviour while explicitly discouraging reliance on undocumented values, leaving room to reject them in a future release.

### Change
A 3-line clarification added to the `EVP_CipherInit_ex2()` item in `doc/man3/EVP_EncryptInit.pod`. Documentation only; no behavioural change.

### Testing
`make doc-nits` was run before and after the change; the nit set for `EVP_EncryptInit.pod` is identical, so this introduces no new documentation nits. The rendered man page output was checked.

CLA: trivial