### PR TITLE
e_os2.h: Do not include windows.h

### DIFF
--- a/include/internal/thread_arch.h
+++ b/include/internal/thread_arch.h
@@ -10,12 +10,8 @@
 #ifndef OSSL_INTERNAL_THREAD_ARCH_H
 #define OSSL_INTERNAL_THREAD_ARCH_H
 #include <openssl/configuration.h>
-#include <openssl/e_os2.h>
+#include "internal/e_os.h"
 #include "internal/time.h"
-
-#if defined(_WIN32)
-#include <windows.h>
-#endif
 
 #if defined(OPENSSL_THREADS) && defined(OPENSSL_SYS_UNIX)
 #define OPENSSL_THREADS_POSIX

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -58,7 +58,6 @@ extern "C" {
 #define OPENSSL_SYS_WIN32_CYGWIN
 #else
 #if defined(_WIN32) || defined(OPENSSL_SYS_WIN32)
-#include "windows.h"
 #undef OPENSSL_SYS_UNIX
 #if !defined(OPENSSL_SYS_WIN32)
 #define OPENSSL_SYS_WIN32


### PR DESCRIPTION
Fixes #31514
