### PR TITLE
Don't call remove_session_cb under a lock

### DIFF
--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -22,7 +22,7 @@
 
 static void SSL_SESSION_list_remove(SSL_CTX *ctx, SSL_SESSION *s);
 static void SSL_SESSION_list_add(SSL_CTX *ctx, SSL_SESSION *s);
-static int remove_session_lock(SSL_CTX *ctx, SSL_SESSION *c, int lck);
+static SSL_SESSION *remove_session_locked(SSL_CTX *ctx, SSL_SESSION *c);
 
 DEFINE_STACK_OF(SSL_SESSION)
 
@@ -798,6 +798,14 @@ int SSL_CTX_add_session(SSL_CTX *ctx, SSL_SESSION *c)
         ssl_session_calculate_timeout(c);
     }
 
+    /*
+     * evicted_head is a singly-linked list (via the next pointer, which
+     * SSL_SESSION_list_remove zeroes out) of sessions evicted from the cache
+     * that need their remove_session_cb called and their reference dropped
+     * once the lock is released.
+     */
+    SSL_SESSION *evicted_head = NULL;
+
     if (s == NULL) {
         /*
          * new cache entry -- remove old ones if cache has become too large
@@ -808,10 +816,13 @@ int SSL_CTX_add_session(SSL_CTX *ctx, SSL_SESSION *c)
 
         if (SSL_CTX_sess_get_cache_size(ctx) > 0) {
             while (SSL_CTX_sess_number(ctx) >= SSL_CTX_sess_get_cache_size(ctx)) {
-                if (!remove_session_lock(ctx, ctx->session_cache_tail, 0))
+                SSL_SESSION *r = remove_session_locked(ctx, ctx->session_cache_tail);
+
+                if (r == NULL)
                     break;
-                else
-                    ssl_tsan_counter(ctx, &ctx->stats.sess_cache_full);
+                ssl_tsan_counter(ctx, &ctx->stats.sess_cache_full);
+                r->next = evicted_head;
+                evicted_head = r;
             }
         }
 
@@ -828,41 +839,59 @@ int SSL_CTX_add_session(SSL_CTX *ctx, SSL_SESSION *c)
         ret = 0;
     }
     CRYPTO_THREAD_unlock(ctx->lock);
+
+    while (evicted_head != NULL) {
+        SSL_SESSION *next = evicted_head->next;
+
+        evicted_head->next = NULL;
+        if (ctx->remove_session_cb != NULL)
+            ctx->remove_session_cb(ctx, evicted_head);
+        SSL_SESSION_free(evicted_head);
+        evicted_head = next;
+    }
+
     return ret;
 }
 
 int SSL_CTX_remove_session(SSL_CTX *ctx, SSL_SESSION *c)
 {
-    return remove_session_lock(ctx, c, 1);
+    SSL_SESSION *r;
+
+    if (c == NULL || c->session_id_length == 0)
+        return 0;
+    if (!CRYPTO_THREAD_write_lock(ctx->lock))
+        return 0;
+    r = remove_session_locked(ctx, c);
+    CRYPTO_THREAD_unlock(ctx->lock);
+
+    /*
+     * The callback is invoked even when the session is not in the internal
+     * cache so that external caches can be notified.
+     */
+    if (ctx->remove_session_cb != NULL)
+        ctx->remove_session_cb(ctx, c);
+    SSL_SESSION_free(r);
+    return r != NULL;
 }
 
-static int remove_session_lock(SSL_CTX *ctx, SSL_SESSION *c, int lck)
+/*
+ * Removes c from the session cache. Caller must hold ctx->lock.
+ * Returns the removed session (caller must invoke remove_session_cb and
+ * SSL_SESSION_free), or NULL if not found.
+ */
+static SSL_SESSION *remove_session_locked(SSL_CTX *ctx, SSL_SESSION *c)
 {
-    SSL_SESSION *r;
-    int ret = 0;
+    SSL_SESSION *r = NULL;
 
-    if ((c != NULL) && (c->session_id_length != 0)) {
-        if (lck) {
-            if (!CRYPTO_THREAD_write_lock(ctx->lock))
-                return 0;
-        }
-        if ((r = lh_SSL_SESSION_retrieve(ctx->sessions, c)) != NULL) {
-            ret = 1;
+    if (c != NULL && c->session_id_length != 0) {
+        r = lh_SSL_SESSION_retrieve(ctx->sessions, c);
+        if (r != NULL) {
             r = lh_SSL_SESSION_delete(ctx->sessions, r);
             SSL_SESSION_list_remove(ctx, r);
         }
         c->not_resumable = 1;
-
-        if (lck)
-            CRYPTO_THREAD_unlock(ctx->lock);
-
-        if (ctx->remove_session_cb != NULL)
-            ctx->remove_session_cb(ctx, c);
-
-        if (ret)
-            SSL_SESSION_free(r);
     }
-    return ret;
+    return r;
 }
 
 void SSL_SESSION_free(SSL_SESSION *ss)
@@ -1242,9 +1271,10 @@ void SSL_CTX_flush_sessions_ex(SSL_CTX *s, time_t t)
     /*
      * Iterate over the list from the back (oldest), and stop
      * when a session can no longer be removed.
-     * Add the session to a temporary list to be freed outside
-     * the SSL_CTX lock.
-     * But still do the remove_session_cb() within the lock.
+     * Collect removed sessions on a stack to be processed outside the lock,
+     * so that remove_session_cb is never invoked while holding ctx->lock.
+     * If the stack failed to create, or a push fails, free the session
+     * immediately (without invoking the callback).
      */
     while (s->session_cache_tail != NULL) {
         current = s->session_cache_tail;
@@ -1252,15 +1282,6 @@ void SSL_CTX_flush_sessions_ex(SSL_CTX *s, time_t t)
             lh_SSL_SESSION_delete(s->sessions, current);
             SSL_SESSION_list_remove(s, current);
             current->not_resumable = 1;
-            if (s->remove_session_cb != NULL)
-                s->remove_session_cb(s, current);
-            /*
-             * Throw the session on a stack, it's entirely plausible
-             * that while freeing outside the critical section, the
-             * session could be re-added, so avoid using the next/prev
-             * pointers. If the stack failed to create, or the session
-             * couldn't be put on the stack, just free it here
-             */
             if (sk == NULL || !sk_SSL_SESSION_push(sk, current))
                 SSL_SESSION_free(current);
         } else {
@@ -1271,7 +1292,13 @@ void SSL_CTX_flush_sessions_ex(SSL_CTX *s, time_t t)
     lh_SSL_SESSION_set_down_load(s->sessions, i);
     CRYPTO_THREAD_unlock(s->lock);
 
-    sk_SSL_SESSION_pop_free(sk, SSL_SESSION_free);
+    while (sk_SSL_SESSION_num(sk) > 0) {
+        current = sk_SSL_SESSION_pop(sk);
+        if (s->remove_session_cb != NULL)
+            s->remove_session_cb(s, current);
+        SSL_SESSION_free(current);
+    }
+    sk_SSL_SESSION_free(sk);
 }
 
 int ssl_clear_bad_session(SSL_CONNECTION *s)

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -3029,6 +3029,58 @@ static int test_session_with_both_cache(void)
 #endif
 }
 
+/*
+ * Test that remove_session_cb is not invoked while ctx->lock is held.
+ * The callback calls SSL_CTX_flush_sessions_ex(), which itself tries to
+ * acquire ctx->lock; if the lock is already held when the callback fires,
+ * the nested acquisition deadlocks immediately.  t = 1 (Unix epoch + 1s) is
+ * used so that no current sessions are flushed and the callback is not
+ * re-entered.
+ */
+static void remove_session_lock_test_cb(SSL_CTX *ctx, SSL_SESSION *sess)
+{
+    SSL_CTX_flush_sessions_ex(ctx, 1);
+}
+
+static int test_remove_session_cb_not_under_lock(void)
+{
+    SSL_CTX *ctx = NULL;
+    SSL_SESSION *sess1 = NULL, *sess2 = NULL;
+    static const unsigned char sid1[] = { 1 };
+    static const unsigned char sid2[] = { 2 };
+    int testresult = 0;
+
+    if (!TEST_ptr(ctx = SSL_CTX_new_ex(libctx, NULL, TLS_server_method())))
+        goto end;
+
+    SSL_CTX_sess_set_cache_size(ctx, 1);
+    SSL_CTX_sess_set_remove_cb(ctx, remove_session_lock_test_cb);
+
+    if (!TEST_ptr(sess1 = SSL_SESSION_new())
+        || !TEST_true(SSL_SESSION_set1_id(sess1, sid1, sizeof(sid1)))
+        || !TEST_true(SSL_CTX_add_session(ctx, sess1)))
+        goto end;
+
+    if (!TEST_ptr(sess2 = SSL_SESSION_new())
+        || !TEST_true(SSL_SESSION_set1_id(sess2, sid2, sizeof(sid2))))
+        goto end;
+
+    /*
+     * Adding sess2 evicts sess1 (cache is full), firing remove_session_cb.
+     * If the callback is invoked while holding ctx->lock the flush call
+     * inside it will deadlock.
+     */
+    if (!TEST_true(SSL_CTX_add_session(ctx, sess2)))
+        goto end;
+
+    testresult = 1;
+end:
+    SSL_SESSION_free(sess1);
+    SSL_SESSION_free(sess2);
+    SSL_CTX_free(ctx);
+    return testresult;
+}
+
 static int test_session_wo_ca_names(void)
 {
 #ifndef OSSL_NO_USABLE_TLS1_3
@@ -15179,6 +15231,7 @@ int setup_tests(void)
     ADD_TEST(test_session_with_only_int_cache);
     ADD_TEST(test_session_with_only_ext_cache);
     ADD_TEST(test_session_with_both_cache);
+    ADD_TEST(test_remove_session_cb_not_under_lock);
     ADD_TEST(test_session_wo_ca_names);
 #ifndef OSSL_NO_USABLE_TLS1_3
     ADD_ALL_TESTS(test_stateful_tickets, 3);


### PR DESCRIPTION
The `remove_session_cb` callback, set via `SSL_CTX_sess_set_remove_cb()`, was being invoked while `ctx->lock` was held in two places: the cache-eviction loop inside `SSL_CTX_add_session()`, and the flush loop inside `SSL_CTX_flush_sessions_ex()` (which is also called by `SSL_CTX_free()`). Any callback that re-entered an OpenSSL API requiring the same lock — for example, to query or modify the session cache — would deadlock.

The fix ensures the callback is always invoked after ctx->lock has been released. `SSL_CTX_add_session()` now collects evicted sessions in a temporary list and processes them post-unlock. `SSL_CTX_flush_sessions_ex()` already deferred `SSL_SESSION_free()` to after the lock via a stack; the callback call is now deferred in the same way. `SSL_CTX_remove_session()` already released the lock before calling the callback in the `lck = 1` path, but the internal `remove_session_lock()` function has been refactored into `remove_session_locked()` (lock managed by caller) to make this structure explicit and avoid the previous `lck` parameter ambiguity.

A regression test is included that installs a callback which calls `SSL_CTX_flush_sessions_ex()`, exercising the eviction and flush paths; the nested lock acquisition deadlocks immediately if either path regresses.

Assisted-by: Claude:claude-sonnet-4-6
