### PR TITLE
pkcs11-provider: enable and update [3.5]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -714,9 +714,37 @@ jobs:
         ./util/opensslwrap.sh version -c
     - name: test external oqs-provider
       run: make test TESTS="test_external_oqsprovider"
-    # Disabled temporarily: https://github.com/latchset/pkcs11-provider/pull/525#discussion_r1982805969
-    # - name: test external pkcs11-provider
-    #   run: make test TESTS="test_external_pkcs11_provider" VERBOSE=1
+  
+  external-tests-pkcs11-provider:
+    runs-on: ubuntu-latest
+    container: fedora:latest
+    steps:
+    - name: package installs
+      run: |
+        dnf install -y perl-FindBin perl-IPC-Cmd perl-File-Compare perl-File-Copy perl-Test-Simple perl-Test-Harness python3 make g++ perl git meson opensc expect kryoptic xxd
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+    - name: checkout fuzz/corpora and pkcs11-provider submodule
+      run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        git submodule update --init --depth 1 fuzz/corpora
+        git submodule update --init --depth 1 pkcs11-provider
+    - name: config
+      run: ./config --strict-warnings --banner=Configured --debug enable-external-tests no-fips && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    # Run all tests except external tests to make sure they work fine on Fedora because
+    # this is the only job running on Fedora, only then execute pkcs11-provider external
+    # test.
+    - name: test (except external tests)
+      run: make test TESTS="-test_external_*"
+    - name: test external pkcs11-provider
+      run: make test TESTS="test_external_pkcs11_provider" VERBOSE=1
+    - name: get cpu info
+      run: |
+        cat /proc/cpuinfo
+        ./util/opensslwrap.sh version -c
 
   external-tests-pyca:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The pkcs11-provider was disabled due to fixed issues in PQC sigalgs.

This re-enables it and update provider to the latest version to also fix the TLS test has been failing due to changes in kryoptic introduced in https://github.com/latchset/kryoptic/pull/436 . This was a bug in pkcs11-provider that was fixed in
https://github.com/openssl-projects/pkcs11-provider/pull/722 .
