### PR TITLE
s_client: skip TCP shutdown drain for datagram protocols

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3522,29 +3522,32 @@ shut:
         print_stuff(bio_c_out, con, full_log);
     do_ssl_shutdown(con);
 
-    /*
-     * If we ended with an alert being sent, but still with data in the
-     * network buffer to be read, then calling BIO_closesocket() will
-     * result in a TCP-RST being sent. On some platforms (notably
-     * Windows) then this will result in the peer immediately abandoning
-     * the connection including any buffered alert data before it has
-     * had a chance to be read. Shutting down the sending side first,
-     * and then closing the socket sends TCP-FIN first followed by
-     * TCP-RST. This seems to allow the peer to read the alert data.
-     */
-    shutdown(SSL_get_fd(con), 1); /* SHUT_WR */
-    /*
-     * We just said we have nothing else to say, but it doesn't mean that
-     * the other side has nothing. It's even recommended to consume incoming
-     * data. [In testing context this ensures that alerts are passed on...]
-     */
-    timeout.tv_sec = 0;
-    timeout.tv_usec = 500000; /* some extreme round-trip */
-    do {
-        FD_ZERO(&readfds);
-        openssl_fdset(sock, &readfds);
-    } while (select(sock + 1, &readfds, NULL, NULL, &timeout) > 0
-        && BIO_read(sbio, sbuf, BUFSIZZ) > 0);
+    /* The following half-close/drain workaround is TCP-specific. */
+    if (!isdtls && !isquic) {
+        /*
+         * If we ended with an alert being sent, but still with data in the
+         * network buffer to be read, then calling BIO_closesocket() will
+         * result in a TCP-RST being sent. On some platforms (notably
+         * Windows) then this will result in the peer immediately abandoning
+         * the connection including any buffered alert data before it has
+         * had a chance to be read. Shutting down the sending side first,
+         * and then closing the socket sends TCP-FIN first followed by
+         * TCP-RST. This seems to allow the peer to read the alert data.
+         */
+        shutdown(SSL_get_fd(con), 1); /* SHUT_WR */
+        /*
+         * We just said we have nothing else to say, but it doesn't mean that
+         * the other side has nothing. It's even recommended to consume incoming
+         * data. [In testing context this ensures that alerts are passed on...]
+         */
+        timeout.tv_sec = 0;
+        timeout.tv_usec = 500000; /* some extreme round-trip */
+        do {
+            FD_ZERO(&readfds);
+            openssl_fdset(sock, &readfds);
+        } while (select(sock + 1, &readfds, NULL, NULL, &timeout) > 0
+            && BIO_read(sbio, sbuf, BUFSIZZ) > 0);
+    }
 
     BIO_closesocket(SSL_get_fd(con));
 end:


### PR DESCRIPTION
   ## Problem                                                                                                                                                                                                     
                                                                                                                                                                                                                  
   `openssl s_client -dtls1_2` waits ~500 ms after connection work is done.                                                                                                                                       
                                                                                                                                                                                                                  
   ## Root Cause                                                                                                                                                                                                  
                                                                                                                                                                                                                  
   Not DTLS retransmission timer.                                                                                                                                                                                 
                                                                                                                                                                                                                  
   `s_client` shutdown path always ran TCP half-close/drain workaround:                                                                                                                                           
                                                                                                                                                                                                                  
   ```c                                                                                                                                                                                                           
   shutdown(..., SHUT_WR);                                                                                                                                                                                        
   select(..., timeout = 500ms);                                                                                                                                                                                  
   BIO_read(...);                                                                                                                                                                                                 
 ```                                                                                                                                                                                                              
                                                                                                                                                                                                                  
 This workaround is TCP-specific, but ran for DTLS UDP too. Result: unnecessary 500 ms wait.                                                                                                                      
                                                                                                                                                                                                                  
 Strace evidence:                                                                                                                                                                                                 
                                                                                                                                                                                                                  
 ```text                                                                                                                                                                                                          
   shutdown(3, SHUT_WR) = 0                                                                                                                                                                                       
   pselect6(4, [3], NULL, NULL, {tv_sec=0, tv_nsec=500000000}, NULL) = 0 (Timeout)                                                                                                                                
 ```                                                                                                                                                                                                              
                                                                                                                                                                                                                  
 Fix                                                                                                                                                                                                              
                                                                                                                                                                                                                  
 Skip TCP shutdown drain for DTLS and QUIC:                                                                                                                                                                       
                                                                                                                                                                                                                  
 ```c                                                                                                                                                                                                             
   if (!isdtls && !isquic) {                                                                                                                                                                                      
       ...                                                                                                                                                                                                        
   }                                                                                                                                                                                                              
 ```                                                                                                                                                                                                              
                                                                                                                                                                                                                  
 Timing                                                                                                                                                                                                           
                                                                                                                                                                                                                  
 Before:                                                                                                                                                                                                          
                                                                                                                                                                                                                  
 ```text                                                                                                                                                                                                          
   real 0.509                                                                                                                                                                                                     
 ```                                                                                                                                                                                                              
                                                                                                                                                                                                                  
 After:                                                                                                                                                                                                           
                                                                                                                                                                                                                  
 ```text                                                                                                                                                                                                          
   real 0.019                                                                                                                                                                                                     
 ```                                                                                                                                                                                                              
                                                                                                                                                                                                                  
 Tests                                                                                                                                                                                                            
                                                                                                                                                                                                                  
 ```text                                                                                                                                                                                                          
   git diff --check                                                                                                                                                                                               
   make -j2 apps/openssl                                                                                                                                                                                          
   make test TESTS=test_dtls V=0                                                                                                                                                                                  
 ```                                                                                                                                                                                                              
                                                                                                                                                                                                                  
 CLA: trivial                                                                                                                                                                                                     