### PR TITLE
doc: document that HMAC_Update cannot be called after HMAC_Final

### DIFF
--- a/doc/man3/HMAC.pod
+++ b/doc/man3/HMAC.pod
@@ -112,6 +112,9 @@ be authenticated (I<len> bytes at I<data>).
 
 HMAC_Final() places the message authentication code in I<md>, which
 must have space for the hash function output.
+After calling HMAC_Final() no calls to HMAC_Update() or HMAC_Final() can be
+made, but HMAC_Init_ex() can be called to initialize a new HMAC
+operation.
 
 HMAC_CTX_copy() copies all of the internal state from I<sctx> into I<dctx>.
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

The documentation was missing the restriction that HMAC_Update() must not be called after HMAC_Final().

This is already enforced by the implementation (via `EVP_MD_CTX_FLAG_FINALISED`, added in #20375) and tested (test_hmac_final_update_fail in `test/hmactest.c`, added in #13210).

This PR adds a documentation note to HMAC_Final, in the same style as the note for EVP_DigestFinal_ex in `doc/man3/EVP_DigestInit.pod`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
- [ ] tests are added or updated
