### PR TITLE
hpke: Fix non-spec-compliant handling of zero-length plaintexts

### DIFF
--- a/crypto/hpke/hpke.c
+++ b/crypto/hpke/hpke.c
@@ -149,7 +149,7 @@ static int hpke_aead_dec(OSSL_HPKE_CTX *hctx, const unsigned char *iv,
     size_t taglen;
 
     taglen = hctx->aead_info->taglen;
-    if (ctlen <= taglen || *ptlen < ctlen - taglen
+    if (ctlen < taglen || *ptlen < ctlen - taglen
         || aadlen > INT_MAX || ctlen > INT_MAX) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT);
         return 0;
@@ -228,7 +228,7 @@ static int hpke_aead_enc(OSSL_HPKE_CTX *hctx, const unsigned char *iv,
     unsigned char tag[EVP_MAX_AEAD_TAG_LENGTH];
 
     taglen = hctx->aead_info->taglen;
-    if (*ctlen <= taglen || ptlen > *ctlen - taglen
+    if (*ctlen < taglen || ptlen > *ctlen - taglen
         || aadlen > INT_MAX || ptlen > INT_MAX) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT);
         return 0;
@@ -1171,7 +1171,7 @@ int OSSL_HPKE_seal(OSSL_HPKE_CTX *ctx,
     size_t seqlen = 0;
 
     if (ctx == NULL || ct == NULL || ctlen == NULL || *ctlen == 0
-        || pt == NULL || ptlen == 0) {
+        || (pt == NULL && ptlen != 0)) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT);
         return 0;
     }
@@ -1212,7 +1212,7 @@ int OSSL_HPKE_open(OSSL_HPKE_CTX *ctx,
     unsigned char seqbuf[OSSL_HPKE_MAX_NONCELEN];
     size_t seqlen = 0;
 
-    if (ctx == NULL || pt == NULL || ptlen == NULL || *ptlen == 0
+    if (ctx == NULL || pt == NULL || (ptlen == NULL && *ptlen != 0)
         || ct == NULL || ctlen == 0) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT);
         return 0;

--- a/crypto/hpke/hpke.c
+++ b/crypto/hpke/hpke.c
@@ -1212,7 +1212,7 @@ int OSSL_HPKE_open(OSSL_HPKE_CTX *ctx,
     unsigned char seqbuf[OSSL_HPKE_MAX_NONCELEN];
     size_t seqlen = 0;
 
-    if (ctx == NULL || pt == NULL || (ptlen == NULL && *ptlen != 0)
+    if (ctx == NULL || ptlen == NULL || (pt == NULL && *ptlen != 0)
         || ct == NULL || ctlen == 0) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT);
         return 0;

--- a/crypto/hpke/hpke.c
+++ b/crypto/hpke/hpke.c
@@ -180,9 +180,13 @@ static int hpke_aead_dec(OSSL_HPKE_CTX *hctx, const unsigned char *iv,
             goto err;
         }
     }
-    if (EVP_DecryptUpdate(ctx, pt, &len, ct, (int)(ctlen - taglen)) != 1) {
-        ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
-        goto err;
+    if (ctlen > taglen) {
+        if (EVP_DecryptUpdate(ctx, pt, &len, ct, (int)(ctlen - taglen)) != 1) {
+            ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
+            goto err;
+        }
+    } else {
+        len = 0;
     }
     *ptlen = len;
     if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG,
@@ -190,11 +194,19 @@ static int hpke_aead_dec(OSSL_HPKE_CTX *hctx, const unsigned char *iv,
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
         goto err;
     }
-    /* Finalise decryption.  */
-    if (EVP_DecryptFinal_ex(ctx, pt + len, &len) <= 0) {
+    /*
+     * Finalise decryption, which checks the tag. Ideally, we would simply write
+     * pt + len here, but the caller may have passed a zero-length output buffer
+     * if ctlen == taglen. pt may be NULL for a zero-length buffer. However,
+     * before C2y, NULL + 0 was undefined. While this will be fixed and applied
+     * to old C versions retroactively, we support old compilers and sanitizers.
+     * https://developers.redhat.com/articles/2024/12/11/making-memcpynull-null-0-well-defined
+     */
+    if (EVP_DecryptFinal_ex(ctx, len ? pt + len : pt, &len) <= 0) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
         goto err;
     }
+    *ptlen += len;
     erv = 1;
 
 err:
@@ -263,9 +275,13 @@ static int hpke_aead_enc(OSSL_HPKE_CTX *hctx, const unsigned char *iv,
             goto err;
         }
     }
-    if (EVP_EncryptUpdate(ctx, ct, &len, pt, (int)ptlen) != 1) {
-        ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
-        goto err;
+    if (ptlen != 0) {
+        if (EVP_EncryptUpdate(ctx, ct, &len, pt, (int)ptlen) != 1) {
+            ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
+            goto err;
+        }
+    } else {
+        len = 0;
     }
     *ctlen = len;
     /* Finalise the encryption. */

--- a/crypto/mem_clr.c
+++ b/crypto/mem_clr.c
@@ -21,5 +21,13 @@ static volatile memset_t memset_func = memset;
 
 void OPENSSL_cleanse(void *ptr, size_t len)
 {
-    memset_func(ptr, 0, len);
+    /*
+     * If len is zero, ptr may be NULL. However, due to a C language bug, memset
+     * cannot be called with NULL and zero. This will be fixed in C2y and
+     * retroactively applied to older versions of C, but we still support older
+     * compilers and sanitizers, so explicitly check len. See
+     * https://developers.redhat.com/articles/2024/12/11/making-memcpynull-null-0-well-defined
+     */
+    if (len != 0)
+        memset_func(ptr, 0, len);
 }

--- a/doc/man3/OSSL_HPKE_CTX_new.pod
+++ b/doc/man3/OSSL_HPKE_CTX_new.pod
@@ -556,6 +556,13 @@ OSSL_HPKE_CTX_set1_ikme() or OSSL_HPKE_keygen()) creates the potential for
 leaking keys (or IKM values). Only use that if really needed and if you
 understand how keys or IKM values could be abused.
 
+OSSL_HPKE_CTX_set1_psk() has an additional limitation not supported by RFC9180.
+RFC9180 does not impose any limitation on the byte values in a PSK identifier.
+However, the I<pskid> parameter in OSSL_HPKE_CTX_set1_psk() can only represent
+non-zero bytes. Additionally, callers must take care that I<pskid> is
+NUL-terminated. Passing a value with an embedded NUL will silently truncate, and
+passing a non-NUL-terminated value will read out of bounds.
+
 =head1 SEE ALSO
 
 The RFC9180 specification: https://datatracker.ietf.org/doc/rfc9180/

--- a/doc/man3/OSSL_HPKE_CTX_new.pod
+++ b/doc/man3/OSSL_HPKE_CTX_new.pod
@@ -556,13 +556,6 @@ OSSL_HPKE_CTX_set1_ikme() or OSSL_HPKE_keygen()) creates the potential for
 leaking keys (or IKM values). Only use that if really needed and if you
 understand how keys or IKM values could be abused.
 
-OSSL_HPKE_CTX_set1_psk() has an additional limitation not supported by RFC9180.
-RFC9180 does not impose any limitation on the byte values in a PSK identifier.
-However, the I<pskid> parameter in OSSL_HPKE_CTX_set1_psk() can only represent
-non-zero bytes. Additionally, callers must take care that I<pskid> is
-NUL-terminated. Passing a value with an embedded NUL will silently truncate, and
-passing a non-NUL-terminated value will read out of bounds.
-
 =head1 SEE ALSO
 
 The RFC9180 specification: https://datatracker.ietf.org/doc/rfc9180/

--- a/test/hpke_test.c
+++ b/test/hpke_test.c
@@ -1462,6 +1462,17 @@ static int test_hpke_oddcalls(void)
     /* second encap fail */
     if (!TEST_false(OSSL_HPKE_encap(ctx, enc, &enclen, pub, publen, NULL, 0)))
         goto end;
+    /* seal with NULL pt and non-zero ptlen */
+    if (!TEST_false(OSSL_HPKE_seal(ctx, cipher, &cipherlen, NULL, 0, NULL, 1)))
+        goto end;
+    /* seal with NULL output buffer */
+    if (!TEST_false(OSSL_HPKE_seal(ctx, NULL, &cipherlen, NULL, 0,
+            plain, plainlen)))
+        goto end;
+    /* seal with NULL ctlen */
+    if (!TEST_false(OSSL_HPKE_seal(ctx, cipher, NULL, NULL, 0,
+            plain, plainlen)))
+        goto end;
     plainlen = sizeof(plain);
     /* working seal */
     if (!TEST_true(OSSL_HPKE_seal(ctx, cipher, &cipherlen, NULL, 0,
@@ -1503,6 +1514,14 @@ static int test_hpke_oddcalls(void)
             cipher, cipherlen)))
         goto end;
     clearlen = OSSL_HPKE_TSTSIZE;
+    /* open with non-empty NULL output buffer */
+    if (!TEST_false(OSSL_HPKE_open(rctx, NULL, &clearlen, NULL, 0,
+            cipher, cipherlen)))
+        goto end;
+    /* open with NULL ptlen */
+    if (!TEST_false(OSSL_HPKE_open(rctx, clear, NULL, NULL, 0,
+            cipher, cipherlen)))
+        goto end;
     /* seq wrap around test */
     if (!TEST_true(OSSL_HPKE_CTX_set_seq(rctx, -1)))
         goto end;
@@ -1534,6 +1553,25 @@ static int test_hpke_oddcalls(void)
             cipher, cipherlen)))
         goto end;
     if (!TEST_mem_eq(plain, plainlen, clear, clearlen))
+        goto end;
+    /* NULL is a valid way to express both the empty plaintext and the empty
+     * output buffer */
+    if (!TEST_true(OSSL_HPKE_seal(ctx, cipher, &cipherlen, NULL, 0,
+            NULL, 0)))
+        goto end;
+    clearlen = 0;
+    if (!TEST_true(OSSL_HPKE_open(rctx, NULL, &clearlen, NULL, 0,
+            cipher, cipherlen)))
+        goto end;
+    if (!TEST_size_t_eq(clearlen, 0))
+        goto end;
+    /* corrupt the tag of an encryption of the empty string */
+    if (!TEST_true(OSSL_HPKE_seal(ctx, cipher, &cipherlen, NULL, 0,
+            plain, plainlen)))
+        goto end;
+    cipher[cipherlen - 1] ^= 1;
+    if (!TEST_false(OSSL_HPKE_open(rctx, clear, &clearlen, NULL, 0,
+            cipher, cipherlen)))
         goto end;
 
     erv = 1;

--- a/test/hpke_test.c
+++ b/test/hpke_test.c
@@ -1462,11 +1462,6 @@ static int test_hpke_oddcalls(void)
     /* second encap fail */
     if (!TEST_false(OSSL_HPKE_encap(ctx, enc, &enclen, pub, publen, NULL, 0)))
         goto end;
-    plainlen = 0;
-    /* should fail for no plaintext */
-    if (!TEST_false(OSSL_HPKE_seal(ctx, cipher, &cipherlen, NULL, 0,
-            plain, plainlen)))
-        goto end;
     plainlen = sizeof(plain);
     /* working seal */
     if (!TEST_true(OSSL_HPKE_seal(ctx, cipher, &cipherlen, NULL, 0,
@@ -1521,6 +1516,26 @@ static int test_hpke_oddcalls(void)
         goto end;
     if (!TEST_mem_eq(plain, plainlen, clear, clearlen))
         goto end;
+    /* the zero-length plaintext is a valid input */
+    plainlen = 0;
+    if (!TEST_true(OSSL_HPKE_seal(ctx, cipher, &cipherlen, NULL, 0,
+            plain, plainlen)))
+        goto end;
+    if (!TEST_true(OSSL_HPKE_open(rctx, clear, &clearlen, NULL, 0,
+            cipher, cipherlen)))
+        goto end;
+    if (!TEST_mem_eq(plain, plainlen, clear, clearlen))
+        goto end;
+    /* repeat the test now that cipherlen and clearlen are tightly bounded */
+    if (!TEST_true(OSSL_HPKE_seal(ctx, cipher, &cipherlen, NULL, 0,
+            plain, plainlen)))
+        goto end;
+    if (!TEST_true(OSSL_HPKE_open(rctx, clear, &clearlen, NULL, 0,
+            cipher, cipherlen)))
+        goto end;
+    if (!TEST_mem_eq(plain, plainlen, clear, clearlen))
+        goto end;
+
     erv = 1;
 end:
     OSSL_HPKE_CTX_free(ctx);

--- a/test/hpke_test.c
+++ b/test/hpke_test.c
@@ -1573,6 +1573,10 @@ static int test_hpke_oddcalls(void)
     if (!TEST_false(OSSL_HPKE_open(rctx, clear, &clearlen, NULL, 0,
             cipher, cipherlen)))
         goto end;
+    /* same as above, but with a NULL output buffer */
+    if (!TEST_false(OSSL_HPKE_open(rctx, NULL, &clearlen, NULL, 0,
+            cipher, cipherlen)))
+        goto end;
 
     erv = 1;
 end:

--- a/test/sanitytest.c
+++ b/test/sanitytest.c
@@ -8,6 +8,7 @@
  */
 
 #include <string.h>
+#include <openssl/crypto.h>
 #include <openssl/types.h>
 #include "testutil.h"
 #include "internal/numbers.h"
@@ -238,6 +239,16 @@ static int test_sanity_memcmp(void)
     return CRYPTO_memcmp("ab", "cd", 2);
 }
 
+static int test_sanity_cleanse(void)
+{
+    /*
+     * Cleansing a zero-length buffer, while a no-op, is legal. (NULL, 0) is a
+     * legal representation of a zero-length buffer.
+     */
+    OPENSSL_cleanse(NULL, 0);
+    return 1;
+}
+
 static const struct sleep_test_vector {
     uint64_t val;
 } sleep_test_vectors[] = { { 0 }, { 1 }, { 999 }, { 1000 } };
@@ -318,6 +329,7 @@ int setup_tests(void)
     ADD_TEST(test_sanity_unsigned_conversion);
     ADD_TEST(test_sanity_range);
     ADD_TEST(test_sanity_memcmp);
+    ADD_TEST(test_sanity_cleanse);
     ADD_ALL_TESTS(test_sanity_sleep, OSSL_NELEM(sleep_test_vectors));
     return 1;
 }


### PR DESCRIPTION
The zero-length plaintext is as valid of a plaintext as any. OpenSSL's HPKE implementation incorrectly rejected it.

This behavior means OpenSSL-based HPKE applications are more prone to bugs than non-OpenSSL HPKE applications. If one were to read RFC 9180, one would expect that OSSL_HPKE_seal behaves uniformly on all byte strings and is basically infallible. However, OpenSSL's limitation means that it can fail on zero-length inputs.

See also this discussion:
https://mailarchive.ietf.org/arch/msg/hpke/74_7G35n6SOibkddgVIN7JYu_wM/

Fortunately, this is easy to fix without any API changes. No documentation update is needed, as far as I can tell, because this limitation was never documented.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x]  tests are added or updated
