### PR TITLE
Allow zero-length plaintexts in HPKE seal/open

### DIFF
--- a/crypto/hpke/hpke.c
+++ b/crypto/hpke/hpke.c
@@ -149,7 +149,7 @@ static int hpke_aead_dec(OSSL_HPKE_CTX *hctx, const unsigned char *iv,
     size_t taglen;
 
     taglen = hctx->aead_info->taglen;
-    if (ctlen <= taglen || *ptlen < ctlen - taglen
+    if (ctlen < taglen || *ptlen < ctlen - taglen
         || aadlen > INT_MAX || ctlen > INT_MAX) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT);
         return 0;
@@ -228,7 +228,7 @@ static int hpke_aead_enc(OSSL_HPKE_CTX *hctx, const unsigned char *iv,
     unsigned char tag[EVP_MAX_AEAD_TAG_LENGTH];
 
     taglen = hctx->aead_info->taglen;
-    if (*ctlen <= taglen || ptlen > *ctlen - taglen
+    if (*ctlen < taglen || ptlen > *ctlen - taglen
         || aadlen > INT_MAX || ptlen > INT_MAX) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT);
         return 0;
@@ -1171,7 +1171,7 @@ int OSSL_HPKE_seal(OSSL_HPKE_CTX *ctx,
     size_t seqlen = 0;
 
     if (ctx == NULL || ct == NULL || ctlen == NULL || *ctlen == 0
-        || pt == NULL || ptlen == 0) {
+        || (pt == NULL && ptlen != 0)) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT);
         return 0;
     }
@@ -1212,7 +1212,7 @@ int OSSL_HPKE_open(OSSL_HPKE_CTX *ctx,
     unsigned char seqbuf[OSSL_HPKE_MAX_NONCELEN];
     size_t seqlen = 0;
 
-    if (ctx == NULL || pt == NULL || ptlen == NULL || *ptlen == 0
+    if (ctx == NULL || ptlen == NULL || (pt == NULL && *ptlen != 0)
         || ct == NULL || ctlen == 0) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT);
         return 0;

--- a/doc/man3/OSSL_HPKE_CTX_new.pod
+++ b/doc/man3/OSSL_HPKE_CTX_new.pod
@@ -272,6 +272,9 @@ On input I<ctlen> should contain the maximum size of the I<ct> buffer, and retur
 the output size. An error will occur if the input I<ctlen> is
 smaller than the value returned from OSSL_HPKE_get_public_encap_size().
 
+A zero-length plaintext is permitted: if I<ptlen> is zero then I<pt> may be
+NULL and the resulting ciphertext I<ct> will consist of the AEAD tag only.
+
 OSSL_HPKE_encap() must be called before the OSSL_HPKE_seal().  OSSL_HPKE_seal()
 may be called multiple times, with an internal "nonce" being incremented by one
 after each call.
@@ -324,6 +327,8 @@ returns the output size. A I<pt> buffer that is the same size as the
 I<ct> buffer will suffice - generally the plaintext output will be
 a little smaller than the ciphertext input.
 An error will occur if the input I<ptlen> is too small.
+If the recovered plaintext is zero-length (i.e. the I<ct> input consists of the
+AEAD tag only) then on output I<ptlen> will be zero and I<pt> is unused.
 OSSL_HPKE_open() may be called multiple times, but as with OSSL_HPKE_seal()
 there is an internally incrementing nonce value so ciphertexts need to be
 presented in the same order as used by the OSSL_HPKE_seal().

--- a/test/hpke_test.c
+++ b/test/hpke_test.c
@@ -1462,12 +1462,6 @@ static int test_hpke_oddcalls(void)
     /* second encap fail */
     if (!TEST_false(OSSL_HPKE_encap(ctx, enc, &enclen, pub, publen, NULL, 0)))
         goto end;
-    plainlen = 0;
-    /* should fail for no plaintext */
-    if (!TEST_false(OSSL_HPKE_seal(ctx, cipher, &cipherlen, NULL, 0,
-            plain, plainlen)))
-        goto end;
-    plainlen = sizeof(plain);
     /* working seal */
     if (!TEST_true(OSSL_HPKE_seal(ctx, cipher, &cipherlen, NULL, 0,
             plain, plainlen)))
@@ -1922,6 +1916,63 @@ end:
     return erv;
 }
 
+/*
+ * @brief check a zero-length plaintext can be sealed and opened
+ *
+ * RFC9180 permits a zero-length plaintext: the resulting ciphertext is
+ * just the AEAD tag. This is a regression test for a bug where seal/open
+ * rejected zero-length plaintexts.
+ */
+static int test_hpke_zerolen(void)
+{
+    int erv = 0;
+    EVP_PKEY *privp = NULL;
+    unsigned char pub[OSSL_HPKE_TSTSIZE];
+    size_t publen = sizeof(pub);
+    int hpke_mode = OSSL_HPKE_MODE_BASE;
+    OSSL_HPKE_SUITE hpke_suite = OSSL_HPKE_SUITE_DEFAULT;
+    OSSL_HPKE_CTX *ctx = NULL;
+    OSSL_HPKE_CTX *rctx = NULL;
+    unsigned char enc[OSSL_HPKE_TSTSIZE];
+    size_t enclen = sizeof(enc);
+    unsigned char cipher[OSSL_HPKE_TSTSIZE];
+    size_t cipherlen = sizeof(cipher);
+    unsigned char clear[OSSL_HPKE_TSTSIZE];
+    size_t clearlen = sizeof(clear);
+    size_t taglen = 16; /* AES-128-GCM tag length for the default suite */
+
+    if (!TEST_true(OSSL_HPKE_keygen(hpke_suite, pub, &publen, &privp,
+            NULL, 0, testctx, NULL)))
+        goto end;
+    if (!TEST_ptr(ctx = OSSL_HPKE_CTX_new(hpke_mode, hpke_suite,
+                      OSSL_HPKE_ROLE_SENDER, testctx, NULL)))
+        goto end;
+    if (!TEST_true(OSSL_HPKE_encap(ctx, enc, &enclen, pub, publen, NULL, 0)))
+        goto end;
+    if (!TEST_true(OSSL_HPKE_seal(ctx, cipher, &cipherlen, NULL, 0, NULL, 0)))
+        goto end;
+    if (!TEST_size_t_eq(cipherlen, taglen))
+        goto end;
+
+    if (!TEST_ptr(rctx = OSSL_HPKE_CTX_new(hpke_mode, hpke_suite,
+                      OSSL_HPKE_ROLE_RECEIVER, testctx, NULL)))
+        goto end;
+    if (!TEST_true(OSSL_HPKE_decap(rctx, enc, enclen, privp, NULL, 0)))
+        goto end;
+    if (!TEST_true(OSSL_HPKE_open(rctx, clear, &clearlen, NULL, 0,
+            cipher, cipherlen)))
+        goto end;
+    if (!TEST_size_t_eq(clearlen, 0))
+        goto end;
+    erv = 1;
+
+end:
+    EVP_PKEY_free(privp);
+    OSSL_HPKE_CTX_free(ctx);
+    OSSL_HPKE_CTX_free(rctx);
+    return erv;
+}
+
 typedef enum OPTION_choice {
     OPT_ERR = -1,
     OPT_EOF = 0,
@@ -1973,6 +2024,7 @@ int setup_tests(void)
     ADD_TEST(test_hpke_oddcalls);
     ADD_TEST(test_hpke_compressed);
     ADD_TEST(test_hpke_noncereuse);
+    ADD_TEST(test_hpke_zerolen);
     return 1;
 }
 


### PR DESCRIPTION
RFC 9180 permits a zero-length plaintext: `HPKE_Seal` of an empty message
produces a ciphertext consisting of the AEAD tag only, and `HPKE_Open`
recovers an empty plaintext. The current implementation rejects this in two
places:

- `OSSL_HPKE_seal()` / `OSSL_HPKE_open()` reject `ptlen == 0` / `*ptlen == 0`
  outright; and
- `hpke_aead_enc()` / `hpke_aead_dec()` use `<= taglen` length guards, which
  also reject the legitimate ciphertext-equals-tag-length case (for an empty
  plaintext the ciphertext is exactly the tag).

This relaxes all four checks so an empty plaintext round-trips, while still
rejecting a NULL buffer paired with a non-zero length and a ciphertext shorter
than the tag.

The `OSSL_HPKE_CTX_new(3)` documentation is updated for both seal and open, and
a `test_hpke_zerolen()` round-trip test is added. The `test_hpke_oddcalls()`
case that asserted the old (incorrect) rejection of a zero-length plaintext is
removed.

All HPKE tests pass (`make test TESTS=test_hpke`).

Initial draft generated with Claude Opus 4.8.