### PR TITLE
Add OSSL_HPKE_CTX_set1_psk_ex() for PSK ids containing NUL bytes

### DIFF
--- a/crypto/hpke/hpke.c
+++ b/crypto/hpke/hpke.c
@@ -9,6 +9,9 @@
 
 /* An OpenSSL-based HPKE implementation of RFC9180 */
 
+/* This file implements the deprecated OSSL_HPKE_CTX_set1_psk(). */
+#include "internal/deprecated.h"
+
 #include <string.h>
 #include <openssl/rand.h>
 #include <openssl/kdf.h>
@@ -64,7 +67,8 @@ struct ossl_hpke_ctx_st {
     size_t noncelen;
     unsigned char *exportersec; /* exporter secret */
     size_t exporterseclen;
-    char *pskid; /* PSK stuff */
+    unsigned char *pskid; /* PSK identifier (an opaque byte string) */
+    size_t pskidlen;
     unsigned char *psk;
     size_t psklen;
     EVP_PKEY *authpriv; /* sender's authentication private key */
@@ -709,7 +713,7 @@ static int hpke_do_middle(OSSL_HPKE_CTX *ctx,
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
         return 0;
     }
-    pskidlen = (ctx->psk == NULL ? 0 : strlen(ctx->pskid));
+    pskidlen = (ctx->psk == NULL ? 0 : ctx->pskidlen);
     /* full suite details as per RFC9180 sec 5.1 */
     suitebuf[0] = ctx->suite.kem_id / 256;
     suitebuf[1] = ctx->suite.kem_id % 256;
@@ -722,7 +726,7 @@ static int hpke_do_middle(OSSL_HPKE_CTX *ctx,
             NULL, 0, OSSL_HPKE_SEC51LABEL,
             suitebuf, sizeof(suitebuf),
             OSSL_HPKE_PSKIDHASH_LABEL,
-            (unsigned char *)ctx->pskid, pskidlen)
+            ctx->pskid, pskidlen)
         != 1) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
         goto err;
@@ -879,8 +883,8 @@ void OSSL_HPKE_CTX_free(OSSL_HPKE_CTX *ctx)
     return;
 }
 
-int OSSL_HPKE_CTX_set1_psk(OSSL_HPKE_CTX *ctx,
-    const char *pskid,
+int OSSL_HPKE_CTX_set1_psk_ex(OSSL_HPKE_CTX *ctx,
+    const unsigned char *pskid, size_t pskidlen,
     const unsigned char *psk, size_t psklen)
 {
     if (ctx == NULL || pskid == NULL || psk == NULL || psklen == 0) {
@@ -895,11 +899,11 @@ int OSSL_HPKE_CTX_set1_psk(OSSL_HPKE_CTX *ctx,
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT);
         return 0;
     }
-    if (strlen(pskid) > OSSL_HPKE_MAX_PARMLEN) {
+    if (pskidlen > OSSL_HPKE_MAX_PARMLEN) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT);
         return 0;
     }
-    if (strlen(pskid) == 0) {
+    if (pskidlen == 0) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT);
         return 0;
     }
@@ -915,14 +919,28 @@ int OSSL_HPKE_CTX_set1_psk(OSSL_HPKE_CTX *ctx,
         return 0;
     ctx->psklen = psklen;
     OPENSSL_free(ctx->pskid);
-    ctx->pskid = OPENSSL_strdup(pskid);
+    ctx->pskidlen = 0;
+    ctx->pskid = OPENSSL_memdup(pskid, pskidlen);
     if (ctx->pskid == NULL) {
         OPENSSL_clear_free(ctx->psk, ctx->psklen);
         ctx->psk = NULL;
         ctx->psklen = 0;
         return 0;
     }
+    ctx->pskidlen = pskidlen;
     return 1;
+}
+
+int OSSL_HPKE_CTX_set1_psk(OSSL_HPKE_CTX *ctx,
+    const char *pskid,
+    const unsigned char *psk, size_t psklen)
+{
+    if (pskid == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT);
+        return 0;
+    }
+    return OSSL_HPKE_CTX_set1_psk_ex(ctx, (const unsigned char *)pskid,
+        strlen(pskid), psk, psklen);
 }
 
 int OSSL_HPKE_CTX_set1_ikme(OSSL_HPKE_CTX *ctx,

--- a/doc/man3/OSSL_HPKE_CTX_new.pod
+++ b/doc/man3/OSSL_HPKE_CTX_new.pod
@@ -9,7 +9,7 @@ OSSL_HPKE_suite_check, OSSL_HPKE_str2suite,
 OSSL_HPKE_keygen, OSSL_HPKE_get_grease_value,
 OSSL_HPKE_get_ciphertext_size, OSSL_HPKE_get_public_encap_size,
 OSSL_HPKE_get_recommended_ikmelen,
-OSSL_HPKE_CTX_set1_psk, OSSL_HPKE_CTX_set1_ikme,
+OSSL_HPKE_CTX_set1_psk_ex, OSSL_HPKE_CTX_set1_psk, OSSL_HPKE_CTX_set1_ikme,
 OSSL_HPKE_CTX_set1_authpriv, OSSL_HPKE_CTX_set1_authpub,
 OSSL_HPKE_CTX_get_seq, OSSL_HPKE_CTX_set_seq
 - Hybrid Public Key Encryption (HPKE) functions
@@ -57,9 +57,9 @@ OSSL_HPKE_CTX_get_seq, OSSL_HPKE_CTX_set_seq
  int OSSL_HPKE_CTX_set1_authpriv(OSSL_HPKE_CTX *ctx, EVP_PKEY *priv);
  int OSSL_HPKE_CTX_set1_authpub(OSSL_HPKE_CTX *ctx,
                                 unsigned char *pub, size_t publen);
- int OSSL_HPKE_CTX_set1_psk(OSSL_HPKE_CTX *ctx,
-                            const char *pskid,
-                            const unsigned char *psk, size_t psklen);
+ int OSSL_HPKE_CTX_set1_psk_ex(OSSL_HPKE_CTX *ctx,
+                               const unsigned char *pskid, size_t pskidlen,
+                               const unsigned char *psk, size_t psklen);
 
  int OSSL_HPKE_CTX_get_seq(OSSL_HPKE_CTX *ctx, uint64_t *seq);
  int OSSL_HPKE_CTX_set_seq(OSSL_HPKE_CTX *ctx, uint64_t seq);
@@ -78,6 +78,14 @@ OSSL_HPKE_CTX_get_seq, OSSL_HPKE_CTX_set_seq
  size_t OSSL_HPKE_get_ciphertext_size(OSSL_HPKE_SUITE suite, size_t clearlen);
  size_t OSSL_HPKE_get_public_encap_size(OSSL_HPKE_SUITE suite);
  size_t OSSL_HPKE_get_recommended_ikmelen(OSSL_HPKE_SUITE suite);
+
+The following function has been deprecated since OpenSSL 4.1, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
+
+ int OSSL_HPKE_CTX_set1_psk(OSSL_HPKE_CTX *ctx,
+                            const char *pskid,
+                            const unsigned char *psk, size_t psklen);
 
 =head1 DESCRIPTION
 
@@ -191,7 +199,7 @@ HPKE contexts have a role - either sender or receiver. This is used
 to control which functions can be called and so that senders do not
 reuse a key and nonce with different plaintexts.
 
-OSSL_HPKE_CTX_free(), OSSL_HPKE_export(), OSSL_HPKE_CTX_set1_psk(),
+OSSL_HPKE_CTX_free(), OSSL_HPKE_export(), OSSL_HPKE_CTX_set1_psk_ex()
 and OSSL_HPKE_CTX_get_seq() can be called regardless of role.
 
 =over 4
@@ -369,12 +377,19 @@ HPKE also defines a symmetric equivalent to the authentication described above
 using a pre-shared key (PSK) and a PSK identifier. PSKs can be used with the
 B<OSSL_HPKE_MODE_PSK> and B<OSSL_HPKE_MODE_PSKAUTH> modes.
 
-OSSL_HPKE_CTX_set1_psk() sets the PSK identifier I<pskid> string, and PSK buffer
-I<psk> of size I<psklen> into the I<ctx>. If required this must be called
-before OSSL_HPKE_encap() or OSSL_HPKE_decap().
-As per RFC9180, if required, both I<psk> and I<pskid> must be set to non-NULL values.
-As PSKs are symmetric the same calls must happen on both sender and receiver
-sides.
+OSSL_HPKE_CTX_set1_psk_ex() sets the PSK identifier I<pskid> of size
+I<pskidlen>, and PSK buffer I<psk> of size I<psklen> into the I<ctx>. If
+required this must be called before OSSL_HPKE_encap() or OSSL_HPKE_decap().
+As per RFC9180, if required, both I<psk> and I<pskid> must be set to non-NULL
+values. As PSKs are symmetric the same calls must happen on both sender and
+receiver sides. The PSK identifier is an opaque byte string and may contain
+NUL bytes.
+
+OSSL_HPKE_CTX_set1_psk() is a deprecated equivalent of
+OSSL_HPKE_CTX_set1_psk_ex() that takes the PSK identifier as a NUL-terminated
+string I<pskid>. It cannot be used with PSK identifiers that contain NUL bytes,
+as the identifier is truncated at the first NUL; use
+OSSL_HPKE_CTX_set1_psk_ex() for such identifiers.
 
 =head2 Deterministic key generation for senders
 
@@ -563,6 +578,9 @@ The RFC9180 specification: https://datatracker.ietf.org/doc/rfc9180/
 =head1 HISTORY
 
 This functionality described here was added in OpenSSL 3.2.
+
+OSSL_HPKE_CTX_set1_psk_ex() was added in OpenSSL 4.1, and
+OSSL_HPKE_CTX_set1_psk() was deprecated in OpenSSL 4.1.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/hpke.h
+++ b/include/openssl/hpke.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <openssl/types.h>
+#include <openssl/macros.h>
 
 /* HPKE modes */
 #define OSSL_HPKE_MODE_BASE 0 /* Base mode  */
@@ -141,9 +142,15 @@ int OSSL_HPKE_CTX_set1_authpriv(OSSL_HPKE_CTX *ctx, EVP_PKEY *priv);
 int OSSL_HPKE_CTX_set1_authpub(OSSL_HPKE_CTX *ctx,
     const unsigned char *pub,
     size_t publen);
+int OSSL_HPKE_CTX_set1_psk_ex(OSSL_HPKE_CTX *ctx,
+    const unsigned char *pskid, size_t pskidlen,
+    const unsigned char *psk, size_t psklen);
+#ifndef OPENSSL_NO_DEPRECATED_4_1
+OSSL_DEPRECATEDIN_4_1_FOR("OSSL_HPKE_CTX_set1_psk_ex")
 int OSSL_HPKE_CTX_set1_psk(OSSL_HPKE_CTX *ctx,
     const char *pskid,
     const unsigned char *psk, size_t psklen);
+#endif
 
 int OSSL_HPKE_CTX_set1_ikme(OSSL_HPKE_CTX *ctx,
     const unsigned char *ikme, size_t ikmelen);

--- a/test/hpke_test.c
+++ b/test/hpke_test.c
@@ -145,7 +145,8 @@ static int do_testhpke(const TEST_BASEDATA *base,
         goto end;
     if (base->mode == OSSL_HPKE_MODE_PSK
         || base->mode == OSSL_HPKE_MODE_PSKAUTH) {
-        if (!TEST_true(OSSL_HPKE_CTX_set1_psk(sealctx, base->pskid,
+        if (!TEST_true(OSSL_HPKE_CTX_set1_psk_ex(sealctx,
+                (const unsigned char *)base->pskid, strlen(base->pskid),
                 base->psk, base->psklen)))
             goto end;
     }
@@ -179,7 +180,8 @@ static int do_testhpke(const TEST_BASEDATA *base,
         if (!TEST_true(base->pskid != NULL && base->psk != NULL
                 && base->psklen > 0))
             goto end;
-        if (!TEST_true(OSSL_HPKE_CTX_set1_psk(openctx, base->pskid,
+        if (!TEST_true(OSSL_HPKE_CTX_set1_psk_ex(openctx,
+                (const unsigned char *)base->pskid, strlen(base->pskid),
                 base->psk, base->psklen)))
             goto end;
     }
@@ -989,7 +991,8 @@ static int test_hpke_modes_suites(void)
                         overallresult = 0;
                     if (hpke_mode == OSSL_HPKE_MODE_PSK
                         || hpke_mode == OSSL_HPKE_MODE_PSKAUTH) {
-                        if (!TEST_true(OSSL_HPKE_CTX_set1_psk(ctx, pskidp,
+                        if (!TEST_true(OSSL_HPKE_CTX_set1_psk_ex(ctx,
+                                (const unsigned char *)pskidp, strlen(pskidp),
                                 pskp, psklen)))
                             overallresult = 0;
                     }
@@ -1025,7 +1028,8 @@ static int test_hpke_modes_suites(void)
                         overallresult = 0;
                     if (hpke_mode == OSSL_HPKE_MODE_PSK
                         || hpke_mode == OSSL_HPKE_MODE_PSKAUTH) {
-                        if (!TEST_true(OSSL_HPKE_CTX_set1_psk(rctx, pskidp,
+                        if (!TEST_true(OSSL_HPKE_CTX_set1_psk_ex(rctx,
+                                (const unsigned char *)pskidp, strlen(pskidp),
                                 pskp, psklen)))
                             overallresult = 0;
                     }
@@ -1321,7 +1325,7 @@ static int test_hpke_oddcalls(void)
         goto end;
     if (!TEST_false(OSSL_HPKE_CTX_set1_ikme(NULL, NULL, 0)))
         goto end;
-    if (!TEST_false(OSSL_HPKE_CTX_set1_psk(NULL, NULL, NULL, 0)))
+    if (!TEST_false(OSSL_HPKE_CTX_set1_psk_ex(NULL, NULL, 0, NULL, 0)))
         goto end;
 
     /* bad suite calls */
@@ -1389,13 +1393,14 @@ static int test_hpke_oddcalls(void)
                       testctx, NULL)))
         goto end;
     /* set bad length psk */
-    if (!TEST_false(OSSL_HPKE_CTX_set1_psk(ctx, "foo",
-            (unsigned char *)"bar", -1)))
+    if (!TEST_false(OSSL_HPKE_CTX_set1_psk_ex(ctx,
+            (const unsigned char *)"foo", 3, (unsigned char *)"bar", -1)))
         goto end;
     /* set bad length pskid */
     memset(giant_pskid, 'A', sizeof(giant_pskid) - 1);
     giant_pskid[sizeof(giant_pskid) - 1] = '\0';
-    if (!TEST_false(OSSL_HPKE_CTX_set1_psk(ctx, giant_pskid,
+    if (!TEST_false(OSSL_HPKE_CTX_set1_psk_ex(ctx,
+            (const unsigned char *)giant_pskid, strlen(giant_pskid),
             (unsigned char *)"bar", 3)))
         goto end;
     /* still no psk really set so encap fails */
@@ -1434,8 +1439,8 @@ static int test_hpke_oddcalls(void)
     if (!TEST_false(OSSL_HPKE_CTX_set1_authpriv(ctx, privp)))
         goto end;
     /* bad mode for psk */
-    if (!TEST_false(OSSL_HPKE_CTX_set1_psk(ctx, "foo",
-            (unsigned char *)"bar", 3)))
+    if (!TEST_false(OSSL_HPKE_CTX_set1_psk_ex(ctx,
+            (const unsigned char *)"foo", 3, (unsigned char *)"bar", 3)))
         goto end;
     /* seal before encap */
     if (!TEST_false(OSSL_HPKE_seal(ctx, cipher, &cipherlen, NULL, 0,
@@ -1922,6 +1927,100 @@ end:
     return erv;
 }
 
+/*
+ * @brief check OSSL_HPKE_CTX_set1_psk_ex() honours the full PSK id length
+ *
+ * The PSK id is an opaque byte string and may contain NUL bytes. A buggy
+ * implementation that treated it as a C string would ignore everything from
+ * the first NUL onward, so two ids that share a prefix up to and including a
+ * NUL but differ afterwards would be wrongly treated as identical. Here the
+ * sender and a matching receiver interoperate, while a receiver whose id
+ * differs only *after* the NUL fails to decrypt.
+ */
+static int test_hpke_pskid_nul(void)
+{
+    int erv = 0;
+    EVP_PKEY *privp = NULL;
+    unsigned char pub[OSSL_HPKE_TSTSIZE];
+    size_t publen = sizeof(pub);
+    int hpke_mode = OSSL_HPKE_MODE_PSK;
+    OSSL_HPKE_SUITE hpke_suite = OSSL_HPKE_SUITE_DEFAULT;
+    OSSL_HPKE_CTX *sctx = NULL, *rctx = NULL;
+    /* two ids identical up to and including the NUL, differing after it */
+    static const unsigned char pskid_a[] = { 'i', 'd', 0x00, 'a', 'a' };
+    static const unsigned char pskid_b[] = { 'i', 'd', 0x00, 'b', 'b' };
+    static const unsigned char lpsk[] = {
+        0x02, 0x47, 0xfd, 0x33, 0xb9, 0x13, 0x76, 0x0f,
+        0xa1, 0xfa, 0x51, 0xe1, 0x89, 0x2d, 0x9f, 0x30,
+        0x7f, 0xbe, 0x65, 0xeb, 0x17, 0x1e, 0x81, 0x32,
+        0xc2, 0xaf, 0x18, 0x55, 0x5a, 0x73, 0x8b, 0x82
+    };
+    unsigned char plain[] = "quick brown fox";
+    size_t plainlen = sizeof(plain);
+    unsigned char enc[OSSL_HPKE_TSTSIZE];
+    size_t enclen = sizeof(enc);
+    unsigned char cipher[OSSL_HPKE_TSTSIZE];
+    size_t cipherlen = sizeof(cipher);
+    unsigned char clear[OSSL_HPKE_TSTSIZE];
+    size_t clearlen = sizeof(clear);
+
+    if (!TEST_true(OSSL_HPKE_keygen(hpke_suite, pub, &publen, &privp,
+            NULL, 0, testctx, NULL)))
+        goto end;
+    if (!TEST_ptr(sctx = OSSL_HPKE_CTX_new(hpke_mode, hpke_suite,
+                      OSSL_HPKE_ROLE_SENDER, testctx, NULL)))
+        goto end;
+    if (!TEST_true(OSSL_HPKE_CTX_set1_psk_ex(sctx, pskid_a, sizeof(pskid_a),
+            lpsk, sizeof(lpsk))))
+        goto end;
+    if (!TEST_true(OSSL_HPKE_encap(sctx, enc, &enclen, pub, publen, NULL, 0)))
+        goto end;
+    if (!TEST_true(OSSL_HPKE_seal(sctx, cipher, &cipherlen, NULL, 0,
+            plain, plainlen)))
+        goto end;
+
+    /* receiver using the same full id (including bytes after the NUL) works */
+    if (!TEST_ptr(rctx = OSSL_HPKE_CTX_new(hpke_mode, hpke_suite,
+                      OSSL_HPKE_ROLE_RECEIVER, testctx, NULL)))
+        goto end;
+    if (!TEST_true(OSSL_HPKE_CTX_set1_psk_ex(rctx, pskid_a, sizeof(pskid_a),
+            lpsk, sizeof(lpsk))))
+        goto end;
+    if (!TEST_true(OSSL_HPKE_decap(rctx, enc, enclen, privp, NULL, 0)))
+        goto end;
+    if (!TEST_true(OSSL_HPKE_open(rctx, clear, &clearlen, NULL, 0,
+            cipher, cipherlen)))
+        goto end;
+    if (!TEST_mem_eq(clear, clearlen, plain, plainlen))
+        goto end;
+    OSSL_HPKE_CTX_free(rctx);
+    rctx = NULL;
+
+    /*
+     * A receiver whose id differs only after the NUL must fail to decrypt;
+     * this is what distinguishes the fixed behaviour from the old strlen() one.
+     */
+    clearlen = sizeof(clear);
+    if (!TEST_ptr(rctx = OSSL_HPKE_CTX_new(hpke_mode, hpke_suite,
+                      OSSL_HPKE_ROLE_RECEIVER, testctx, NULL)))
+        goto end;
+    if (!TEST_true(OSSL_HPKE_CTX_set1_psk_ex(rctx, pskid_b, sizeof(pskid_b),
+            lpsk, sizeof(lpsk))))
+        goto end;
+    if (!TEST_true(OSSL_HPKE_decap(rctx, enc, enclen, privp, NULL, 0)))
+        goto end;
+    if (!TEST_false(OSSL_HPKE_open(rctx, clear, &clearlen, NULL, 0,
+            cipher, cipherlen)))
+        goto end;
+    erv = 1;
+
+end:
+    EVP_PKEY_free(privp);
+    OSSL_HPKE_CTX_free(sctx);
+    OSSL_HPKE_CTX_free(rctx);
+    return erv;
+}
+
 typedef enum OPTION_choice {
     OPT_ERR = -1,
     OPT_EOF = 0,
@@ -1973,6 +2072,7 @@ int setup_tests(void)
     ADD_TEST(test_hpke_oddcalls);
     ADD_TEST(test_hpke_compressed);
     ADD_TEST(test_hpke_noncereuse);
+    ADD_TEST(test_hpke_pskid_nul);
     return 1;
 }
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5722,3 +5722,4 @@ CRYPTO_atomic_cmp_exch_ptr              ?	4_1_0	EXIST::FUNCTION:
 EVP_EC_affine2oct                       ?	4_1_0	EXIST::FUNCTION:
 OPENSSL_sk_set_copy_thunks              ?	4_1_0	EXIST::FUNCTION:
 ASN1_STRING_new_not_owned               ?	4_1_0	EXIST::FUNCTION:
+OSSL_HPKE_CTX_set1_psk_ex               ?	4_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
RFC 9180 treats the PSK identifier as an opaque byte string that may contain
NUL bytes. `OSSL_HPKE_CTX_set1_psk()` takes the id as a NUL-terminated C string
and measures it with `strlen()`, so any id containing a NUL is silently
truncated at the first NUL, producing the wrong `psk_id_hash` (and hence the
wrong key schedule).

`OSSL_HPKE_CTX_set1_psk()` shipped in OpenSSL 3.2, so its signature cannot be
changed under the API/ABI compatibility policy. Instead this adds a new
`OSSL_HPKE_CTX_set1_psk_ex()` that takes an explicit `pskidlen` and stores the
id as a counted byte string, and uses that length in the key schedule instead
of `strlen()`. The `OSSL_HPKE_CTX` struct now records `pskidlen` and holds the
id as an opaque buffer.

`OSSL_HPKE_CTX_set1_psk()` is reimplemented as a thin wrapper around the new
function (preserving its exact C-string behaviour) and is deprecated from 4.1
via `OSSL_DEPRECATEDIN_4_1_FOR`. `crypto/hpke/hpke.c` includes
`internal/deprecated.h` so the wrapper still builds; the test suite uses
`OSSL_HPKE_CTX_set1_psk_ex()` throughout.

A new `test_hpke_pskid_nul()` seals under a PSK id containing a NUL and shows
that a receiver with the same full id interoperates, while one whose id differs
only after the NUL fails to decrypt. The `OSSL_HPKE_CTX_new(3)` documentation is
updated accordingly.

All HPKE tests pass (`make test TESTS=test_hpke`), and `make doc-nits` is clean.

Initial draft generated with Claude Opus 4.8.