### PR TITLE
Fix sizet wraparound pmethlib

### DIFF
--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -817,6 +817,11 @@ static int evp_pkey_ctx_add1_octet_string(EVP_PKEY_CTX *ctx, int fallback,
     if (os_params[0].return_size == OSSL_PARAM_UNMODIFIED)
         return 0;
 
+    /* Prevent overflowed value landing in variable info_alloc */
+    if (os_params[0].return_size > (SIZE_MAX - datalen)) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_LENGTH);
+        return 0;
+    }
     info_alloc = os_params[0].return_size + datalen;
     if (info_alloc == 0)
         return 0;


### PR DESCRIPTION

pmeth_lib.c: Prevent overflow in evp_pkey_ctx_add1_ctet_string()
Check for size_t overflow before calculating the combined
buffer size used for the existing and appended
octet string data.

Fixes https://github.com/openssl/openssl/issues/31554
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
