### PR TITLE
quic: add mfail test for QUIC SRT generator

### DIFF
--- a/test/quic_srt_gen_test.c
+++ b/test/quic_srt_gen_test.c
@@ -70,8 +70,30 @@ err:
     return testresult;
 }
 
+static int test_srt_gen_new_mfail(int idx)
+{
+    const struct test_case *t = &tests[idx];
+    QUIC_SRT_GEN *srt_gen = NULL;
+
+    MFAIL_start();
+    srt_gen = ossl_quic_srt_gen_new(NULL, NULL, t->key, t->key_len);
+    MFAIL_end();
+
+    if (srt_gen == NULL) {
+        return 0;
+    }
+
+    ossl_quic_srt_gen_free(srt_gen);
+    return 1;
+}
+
 int setup_tests(void)
 {
     ADD_ALL_TESTS(test_srt_gen, OSSL_NELEM(tests));
+#ifdef OPENSSL_NO_CACHED_FETCH
+    ADD_MFAIL_ALL_NO_CHECK_TESTS(test_srt_gen_new_mfail, OSSL_NELEM(tests));
+#else
+    ADD_MFAIL_ALL_TESTS(test_srt_gen_new_mfail, OSSL_NELEM(tests));
+#endif
     return 1;
 }


### PR DESCRIPTION
This slightly improves SRT coverage.

I was actually more up to covering failure paths in ossl_quic_srt_gen_calculate_token but it doesn't do any allocation and cannot really fail.
