### PR TITLE
Fix spelling mistakes in documentation

### DIFF
--- a/doc/man3/ASN1_aux_cb.pod
+++ b/doc/man3/ASN1_aux_cb.pod
@@ -59,7 +59,7 @@ Arbitrary application data
 
 =item I<flags>
 
-Flags which indicate the auxiliarly functionality supported.
+Flags which indicate the auxiliary functionality supported.
 
 The B<ASN1_AFLG_REFCOUNT> flag indicates that objects support reference counting.
 

--- a/doc/man3/BIO_s_datagram.pod
+++ b/doc/man3/BIO_s_datagram.pod
@@ -65,7 +65,7 @@ the underlying socket is configured and how it is to be used; see below.
 
 =item
 
-Use of BIO_s_datagram() with an unconnected network socket is hazardous hecause
+Use of BIO_s_datagram() with an unconnected network socket is hazardous because
 any successful call to BIO_read() results in the peer address used for any
 subsequent call to BIO_write() being set to the source address of the datagram
 received by that call to BIO_read(). Thus, unless the caller calls

--- a/doc/man3/CMS_EncryptedData_decrypt.pod
+++ b/doc/man3/CMS_EncryptedData_decrypt.pod
@@ -46,7 +46,7 @@ are used when retrieving algorithms from providers.
 CMS_EncryptedData_decrypt() returns 0 if an error occurred otherwise returns 1.
 
 CMS_EnvelopedData_decrypt() returns NULL if an error occurred,
-otherwise a BIO containing the decypted content.
+otherwise a BIO containing the decrypted content.
 
 =head1 SEE ALSO
 

--- a/doc/man3/SSL_CTX_set1_curves.pod
+++ b/doc/man3/SSL_CTX_set1_curves.pod
@@ -113,7 +113,7 @@ levels, and can specify which predicted key shares should be sent by a client.
 Group tuples are used by OpenSSL TLS servers to decide whether to request a
 stronger keyshare than those predicted by sending a Hello Retry Request
 (B<HRR>) even if some of the predicted groups are supported.
-OpenSSL clients largely ignore tuple boundaries, and pay attenion only to the
+OpenSSL clients largely ignore tuple boundaries, and pay attention only to the
 overall order of I<list> elements and which groups are selected as predicted
 keyshares as described below.
 Tuple boundaries do however affect the behaviour of keyshare predictions

--- a/doc/man3/SSL_CTX_set_msg_callback.pod
+++ b/doc/man3/SSL_CTX_set_msg_callback.pod
@@ -92,7 +92,7 @@ The SSL_trace() function can be used as a pre-written callback in a call to
 SSL_CTX_set_msg_callback() or SSL_set_msg_callback(). It requires a BIO to be
 set as the callback argument via SSL_CTX_set_msg_callback_arg() or
 SSL_set_msg_callback_arg(). Setting this callback will cause human readable
-diagostic tracing information about an SSL/TLS/QUIC connection to be written to
+diagnostic tracing information about an SSL/TLS/QUIC connection to be written to
 the BIO.
 
 =head1 NOTES

--- a/doc/man3/X509_get_default_cert_file.pod
+++ b/doc/man3/X509_get_default_cert_file.pod
@@ -24,7 +24,7 @@ the default path when it is asked to load trusted CA certificates
 from a file and no other path is specified. If the file exists, CA certificates
 are loaded from the file.
 
-The X509_get_default_cert_dir() function returns a default delimeter-separated
+The X509_get_default_cert_dir() function returns a default delimiter-separated
 list of paths to a directories containing trusted CA certificates named in the
 hashed format. OpenSSL will use this as the default list of paths when it is
 asked to load trusted CA certificates from a directory and no other path is

--- a/doc/man7/openssl-core_dispatch.h.pod
+++ b/doc/man7/openssl-core_dispatch.h.pod
@@ -24,7 +24,7 @@ are named as follows:
 
 These macros have the form C<OSSL_OP_I<opname>>.
 
-=item dipatch numbers
+=item dispatch numbers
 
 These macros have the form C<OSSL_FUNC_I<opname>_I<funcname>>, where
 C<I<opname>> is the same as in the macro for the operation this


### PR DESCRIPTION
Corrects a number of spelling mistakes found in the man pages. Documentation only, no functional changes.

| File | Before | After |
|---|---|---|
| `doc/man3/SSL_CTX_set1_curves.pod` | attenion | attention |
| `doc/man3/CMS_EncryptedData_decrypt.pod` | decypted | decrypted |
| `doc/man3/X509_get_default_cert_file.pod` | delimeter | delimiter |
| `doc/man3/SSL_CTX_set_msg_callback.pod` | diagostic | diagnostic |
| `doc/man7/openssl-core_dispatch.h.pod` | dipatch | dispatch |
| `doc/man3/BIO_s_datagram.pod` | hecause | because |
| `doc/man3/ASN1_aux_cb.pod` | auxiliarly | auxiliary |

The commit is marked `CLA: trivial`.