### PR TITLE
Mention removed ERR macros in changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1268,7 +1268,9 @@ OpenSSL 4.0
    *Tomáš Mráz*
 
  * Removed deprecated functions `ERR_get_state()`, `ERR_remove_state()`
-   and `ERR_remove_thread_state()`. The `ERR_STATE` object is now always opaque.
+   and `ERR_remove_thread_state()`, as well as the `ERR_FLAG_MARK`,
+   `ERR_FLAG_CLEAR` and `ERR_NUM_ERRORS` macros. The `ERR_STATE` object is now
+   always opaque.
    <!-- https://github.com/openssl/openssl/pull/30005 -->
 
    *Tomáš Mráz*


### PR DESCRIPTION
## Summary

Update the existing OpenSSL 4.0 changelog entry for the ERR state cleanup to explicitly mention the removed `ERR_FLAG_MARK`, `ERR_FLAG_CLEAR`, and `ERR_NUM_ERRORS` macros.

Fixes #31056.

## Validation

- `PATH="$HOME/.gem/ruby/2.6.0/bin:$PATH" make md-nits`
- `git diff --check`

##### Checklist

- [x] documentation is added or updated
