### PR TITLE
Fix OSSL_ATOMICS_LOCKLESS detection for Windows toolchains.

### DIFF
--- a/include/internal/threads_common.h
+++ b/include/internal/threads_common.h
@@ -88,7 +88,7 @@ void CRYPTO_THREAD_clean_local(void);
 #endif
 
 /* Allow us to know if atomics will be implemented with a fallback lock or not. */
-#if defined(OSSL_USE_GCC_ATOMICS) || defined(OSSL_USE_SOLARIS_ATOMICS) || defined(USE_INTERLOCKEDOR64)
+#if defined(OSSL_USE_GCC_ATOMICS) || defined(OSSL_USE_SOLARIS_ATOMICS) || defined(OSSL_USE_INTERLOCKEDOR64)
 #define OSSL_ATOMICS_LOCKLESS
 #endif
 


### PR DESCRIPTION
The check referenced USE_INTERLOCKEDOR64 but the macro defined above for MSVC (with the right architecture/version) and 64-bit MinGW is OSSL_USE_INTERLOCKEDOR64.  As a result OSSL_ATOMICS_LOCKLESS was never defined on Windows even though those toolchains do provide lockless atomics.

Spotted by idrassi while reviewing #31580

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
