### PR TITLE
Drop Windows CE support.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,11 @@ OpenSSL Releases
 
    *Jakub Zelenka*
 
+ * Windows CE support was dropped - Windows CE has been unsupported since
+   2018 and does not have a modern C99 toolchain.
+
+   *Bob Beck*
+
  * Improved DTLS handshake robustness under UDP reordering by buffering and
    replaying early ChangeCipherSpec (CCS) records at the expected state.
 

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -61,70 +61,6 @@ sub vc_win32_info {
     return $vc_win32_info;
 }
 
-my $vc_wince_info = {};
-sub vc_wince_info {
-    unless (%$vc_wince_info) {
-        # sanity check
-        $die->('%OSVERSION% is not defined') if (!defined(env('OSVERSION')));
-        $die->('%PLATFORM% is not defined')  if (!defined(env('PLATFORM')));
-        $die->('%TARGETCPU% is not defined') if (!defined(env('TARGETCPU')));
-
-        #
-        # Idea behind this is to mimic flags set by eVC++ IDE...
-        #
-        my $wcevers = env('OSVERSION');                     # WCENNN
-	my $wcevernum;
-	my $wceverdotnum;
-	if ($wcevers =~ /^WCE([1-9])([0-9]{2})$/) {
-	    $wcevernum = "$1$2";
-	    $wceverdotnum = "$1.$2";
-	} else {
-	    $die->('%OSVERSION% value is insane');
-	    $wcevernum = "{unknown}";
-	    $wceverdotnum = "{unknown}";
-	}
-        my $wcecdefs = "-D_WIN32_WCE=$wcevernum -DUNDER_CE=$wcevernum"; # -D_WIN32_WCE=NNN
-        my $wcelflag = "/subsystem:windowsce,$wceverdotnum";        # ...,N.NN
-
-        my $wceplatf =  env('PLATFORM');
-
-        $wceplatf =~ tr/a-z0-9 /A-Z0-9_/;
-        $wcecdefs .= " -DWCE_PLATFORM_$wceplatf";
-
-        my $wcetgt = env('TARGETCPU');                      # just shorter name...
-      SWITCH: for($wcetgt) {
-          /^X86/        && do { $wcecdefs.=" -Dx86 -D_X86_ -D_i386_ -Di_386_";
-                                $wcelflag.=" /machine:X86";     last; };
-          /^ARMV4[IT]/  && do { $wcecdefs.=" -DARM -D_ARM_ -D$wcetgt";
-                                $wcecdefs.=" -DTHUMB -D_THUMB_" if($wcetgt=~/T$/);
-                                $wcecdefs.=" -QRarch4T -QRinterwork-return";
-                                $wcelflag.=" /machine:THUMB";   last; };
-          /^ARM/        && do { $wcecdefs.=" -DARM -D_ARM_ -D$wcetgt";
-                                $wcelflag.=" /machine:ARM";     last; };
-          /^MIPSIV/     && do { $wcecdefs.=" -DMIPS -D_MIPS_ -DR4000 -D$wcetgt";
-                                $wcecdefs.=" -D_MIPS64 -QMmips4 -QMn32";
-                                $wcelflag.=" /machine:MIPSFPU"; last; };
-          /^MIPS16/     && do { $wcecdefs.=" -DMIPS -D_MIPS_ -DR4000 -D$wcetgt";
-                                $wcecdefs.=" -DMIPSII -QMmips16";
-                                $wcelflag.=" /machine:MIPS16";  last; };
-          /^MIPSII/     && do { $wcecdefs.=" -DMIPS -D_MIPS_ -DR4000 -D$wcetgt";
-                                $wcecdefs.=" -QMmips2";
-                                $wcelflag.=" /machine:MIPS";    last; };
-          /^R4[0-9]{3}/ && do { $wcecdefs.=" -DMIPS -D_MIPS_ -DR4000";
-                                $wcelflag.=" /machine:MIPS";    last; };
-          /^SH[0-9]/    && do { $wcecdefs.=" -D$wcetgt -D_${wcetgt}_ -DSHx";
-                                $wcecdefs.=" -Qsh4" if ($wcetgt =~ /^SH4/);
-                                $wcelflag.=" /machine:$wcetgt"; last; };
-          { $wcecdefs.=" -D$wcetgt -D_${wcetgt}_";
-            $wcelflag.=" /machine:$wcetgt";                     last; };
-      }
-
-        $vc_wince_info = { cppflags => $wcecdefs,
-                           lflags => $wcelflag };
-    }
-    return $vc_wince_info;
-}
-
 # Helper functions for the VMS configs
 my $vms_info = {};
 sub vms_info {
@@ -1645,53 +1581,6 @@ my %targets = (
         # some installation path heuristics in windows-makefile.tmpl...
         build_scheme     => add("VC-WOW", { separator => undef }),
     },
-    "VC-CE" => {
-        inherit_from     => [ "VC-common" ],
-        CFLAGS           => add(picker(debug   => "/Od",
-                                       release => "/O1i")),
-        CPPDEFINES       => picker(debug   => [ "DEBUG", "_DEBUG" ]),
-        LDFLAGS          => add("/nologo /opt:ref"),
-        cflags           =>
-            combine('/GF /Gy',
-                    sub { vc_wince_info()->{cflags}; },
-                    sub { `cl 2>&1` =~ /Version ([0-9]+)\./ && $1>=14
-                              ? ($disabled{shared} ? " /MT" : ($disabled{"static-vcruntime"} ? " /MD" : ""))
-                              : " /MC"; }),
-        cppflags         => sub { vc_wince_info()->{cppflags}; },
-        lib_defines      => add("NO_CHMOD", "OPENSSL_SMALL_FOOTPRINT"),
-        lib_cppflags     => sub { vc_wince_info()->{cppflags}; },
-        includes         =>
-            add(combine(sub { defined(env('WCECOMPAT'))
-                              ? '$(WCECOMPAT)/include' : (); },
-                        sub { defined(env('PORTSDK_LIBPATH'))
-                                  ? '$(PORTSDK_LIBPATH)/../../include'
-                                  : (); })),
-        lflags           => add(combine(sub { vc_wince_info()->{lflags}; },
-                                        sub { defined(env('PORTSDK_LIBPATH'))
-                                                  ? "/entry:mainCRTstartup" : (); })),
-        sys_id           => "WINCE",
-        bn_ops           => add("BN_LLONG"),
-        ex_libs          => add(sub {
-            my @ex_libs = ();
-            push @ex_libs, 'ws2.lib' unless $disabled{sock};
-            push @ex_libs, 'crypt32.lib';
-            if (defined(env('WCECOMPAT'))) {
-                my $x = '$(WCECOMPAT)/lib';
-                if (-f "$x/env('TARGETCPU')/wcecompatex.lib") {
-                    $x .= '/$(TARGETCPU)/wcecompatex.lib';
-                } else {
-                    $x .= '/wcecompatex.lib';
-                }
-                push @ex_libs, $x;
-            }
-            push @ex_libs, '$(PORTSDK_LIBPATH)/portlib.lib'
-                if (defined(env('PORTSDK_LIBPATH')));
-            push @ex_libs, '/nodefaultlib coredll.lib corelibc.lib'
-                if (env('TARGETCPU') =~ /^X86|^ARMV4[IT]/);
-            return join(" ", @ex_libs);
-        }),
-    },
-
 #### MinGW
     "mingw-common" => {
         inherit_from     => [ 'BASE_unix' ],

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -169,13 +169,12 @@ issue the following commands to build OpenSSL.
     $ nmake test
 
 As mentioned in the [Choices](#choices) section, you need to pick one
-of the four Configure targets in the first command.
+of the Configure targets in the first command.
 
 Most likely you will be using the `VC-WIN64A`/`VC-WIN64A-HYBRIDCRT` target for
 64bit Windows binaries (AMD64) or `VC-WIN32`/`VC-WIN32-HYBRIDCRT` for 32bit
-Windows binaries (X86).
-The other two options are `VC-WIN64I` (Intel IA64, Itanium) and
-`VC-CE` (Windows CE) are rather uncommon nowadays.
+Windows binaries (X86).  `VC-WIN64I` (Intel IA64, Itanium) is also available
+but rather uncommon nowadays.
 
 Installing OpenSSL
 ------------------

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -3117,14 +3117,10 @@ static int WIN32_rename(const char *from, const char *to)
         if (tfrom == NULL)
             goto err;
         tto = tfrom + flen;
-#if !defined(_WIN32_WCE) || _WIN32_WCE >= 101
         if (!MultiByteToWideChar(CP_ACP, 0, from, (int)flen, (WCHAR *)tfrom, (int)flen))
-#endif
             for (i = 0; i < flen; i++)
                 tfrom[i] = (TCHAR)from[i];
-#if !defined(_WIN32_WCE) || _WIN32_WCE >= 101
         if (!MultiByteToWideChar(CP_ACP, 0, to, (int)tlen, (WCHAR *)tto, (int)tlen))
-#endif
             for (i = 0; i < tlen; i++)
                 tto[i] = (TCHAR)to[i];
     }

--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -1236,9 +1236,7 @@ int opt_isdir(const char *name)
     if (len_0 > MAX_PATH)
         return -1;
 
-#if !defined(_WIN32_WCE) || _WIN32_WCE >= 101
     if (!MultiByteToWideChar(CP_ACP, 0, name, (int)len_0, tempname, MAX_PATH))
-#endif
         for (i = 0; i < len_0; i++)
             tempname[i] = (WCHAR)name[i];
 

--- a/crypto/LPdir_win.c
+++ b/crypto/LPdir_win.c
@@ -43,18 +43,6 @@
 #include "LPdir.h"
 #endif
 
-/*
- * We're most likely overcautious here, but let's reserve for broken WinCE
- * headers and explicitly opt for UNICODE call. Keep in mind that our WinCE
- * builds are compiled with -DUNICODE [as well as -D_UNICODE].
- */
-#if defined(LP_SYS_WINCE) && !defined(FindFirstFile)
-#define FindFirstFile FindFirstFileW
-#endif
-#if defined(LP_SYS_WINCE) && !defined(FindNextFile)
-#define FindNextFile FindNextFileW
-#endif
-
 #ifndef NAME_MAX
 #define NAME_MAX 255
 #endif

--- a/crypto/bio/bss_log.c
+++ b/crypto/bio/bss_log.c
@@ -22,8 +22,7 @@
 #include "bio_local.h"
 #include "internal/cryptlib.h"
 
-#if defined(OPENSSL_SYS_WINCE)
-#elif defined(OPENSSL_SYS_WIN32)
+#if defined(OPENSSL_SYS_WIN32)
 #elif defined(__wasi__)
 #define NO_SYSLOG
 #elif defined(OPENSSL_SYS_VMS)

--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -89,15 +89,6 @@ const BIGNUM *BN_value_one(void)
     return &const_one;
 }
 
-/*
- * Old Visual Studio ARM compiler miscompiles BN_num_bits_word()
- * https://mta.openssl.org/pipermail/openssl-users/2018-August/008465.html
- */
-#if defined(_MSC_VER) && defined(_ARM_) && defined(_WIN32_WCE) \
-    && _MSC_VER >= 1400 && _MSC_VER < 1501
-#define MS_BROKEN_BN_num_bits_word
-#pragma optimize("", off)
-#endif
 int BN_num_bits_word(BN_ULONG l)
 {
     BN_ULONG x, mask;
@@ -142,9 +133,6 @@ int BN_num_bits_word(BN_ULONG l)
 
     return bits;
 }
-#ifdef MS_BROKEN_BN_num_bits_word
-#pragma optimize("", on)
-#endif
 
 /*
  * This function still leaks `a->dmax`: it's caller's responsibility to

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -110,8 +110,6 @@ void OPENSSL_showfatal(const char *fmta, ...)
     /*
      * First check if it's a console application, in which case the
      * error message would be printed to standard error.
-     * Windows CE does not have a concept of a console application,
-     * so we need to guard the check.
      */
 #ifdef STD_ERROR_HANDLE
     HANDLE h;
@@ -260,9 +258,7 @@ void OPENSSL_die(const char *message, const char *file, int line)
     /*
      * Win32 abort() customarily shows a dialog, but we just did that...
      */
-#if !defined(_WIN32_WCE)
     raise(SIGABRT);
-#endif
     _exit(3);
 #endif
 }

--- a/crypto/dso/dso_win32.c
+++ b/crypto/dso/dso_win32.c
@@ -12,49 +12,6 @@
 
 #if defined(DSO_WIN32)
 
-#ifdef _WIN32_WCE
-#if _WIN32_WCE < 300
-static FARPROC GetProcAddressA(HMODULE hModule, LPCSTR lpProcName)
-{
-    WCHAR lpProcNameW[64];
-    int i;
-
-    for (i = 0; lpProcName[i] && i < 64; i++)
-        lpProcNameW[i] = (WCHAR)lpProcName[i];
-    if (i == 64)
-        return NULL;
-    lpProcNameW[i] = 0;
-
-    return GetProcAddressW(hModule, lpProcNameW);
-}
-#endif
-#undef GetProcAddress
-#define GetProcAddress GetProcAddressA
-
-static HINSTANCE LoadLibraryA(LPCSTR lpLibFileName)
-{
-    WCHAR *fnamw;
-    size_t len_0 = strlen(lpLibFileName) + 1, i;
-
-#ifdef _MSC_VER
-    fnamw = (WCHAR *)_alloca(len_0 * sizeof(WCHAR));
-#else
-    fnamw = (WCHAR *)alloca(len_0 * sizeof(WCHAR));
-#endif
-    if (fnamw == NULL) {
-        SetLastError(ERROR_NOT_ENOUGH_MEMORY);
-        return NULL;
-    }
-#if defined(_WIN32_WCE) && _WIN32_WCE >= 101
-    if (!MultiByteToWideChar(CP_ACP, 0, lpLibFileName, len_0, fnamw, len_0))
-#endif
-        for (i = 0; i < len_0; i++)
-            fnamw[i] = (WCHAR)lpLibFileName[i];
-
-    return LoadLibraryW(fnamw);
-}
-#endif
-
 #define GETPROCADDRESS(h, name, type) ((type)(void (*)(void))GetProcAddress((h), (name)))
 
 /* Part of the hack in "win32_load" ... */
@@ -472,14 +429,10 @@ static const char *openssl_strnchr(const char *string, int c, size_t len)
 }
 
 #include <tlhelp32.h>
-#ifdef _WIN32_WCE
-#define DLLNAME "TOOLHELP.DLL"
-#else
 #ifdef MODULEENTRY32
 #undef MODULEENTRY32 /* unmask the ASCII version! */
 #endif
 #define DLLNAME "KERNEL32.DLL"
-#endif
 
 typedef HANDLE(WINAPI *CREATETOOLHELP32SNAPSHOT)(DWORD, DWORD);
 typedef BOOL(WINAPI *CLOSETOOLHELP32SNAPSHOT)(HANDLE);
@@ -582,11 +535,7 @@ static void *win32_globallookup(const char *name)
         return NULL;
     }
     /* We take the rest for granted... */
-#ifdef _WIN32_WCE
-    close_snap = GETPROCADDRESS(dll, "CloseToolhelp32Snapshot", CLOSETOOLHELP32SNAPSHOT);
-#else
     close_snap = (CLOSETOOLHELP32SNAPSHOT)CloseHandle;
-#endif
     module_first = GETPROCADDRESS(dll, "Module32First", MODULE32);
     module_next = GETPROCADDRESS(dll, "Module32Next", MODULE32);
 

--- a/crypto/getenv.c
+++ b/crypto/getenv.c
@@ -17,7 +17,7 @@
 
 char *ossl_safe_getenv(const char *name)
 {
-#if defined(_WIN32) && defined(CP_UTF8) && !defined(_WIN32_WCE)
+#if defined(_WIN32) && defined(CP_UTF8)
     if (GetEnvironmentVariableW(L"OPENSSL_WIN32_UTF8", NULL, 0) != 0) {
         char *val = NULL;
         int vallen = 0;

--- a/crypto/o_dir.c
+++ b/crypto/o_dir.c
@@ -31,8 +31,6 @@
 # include "LPdir_vms.c"
 #elif defined OPENSSL_SYS_WIN32
 # include "LPdir_win32.c"
-#elif defined OPENSSL_SYS_WINCE
-# include "LPdir_wince.c"
 #else
 # include "LPdir_nyi.c"
 #endif

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -377,7 +377,7 @@ char *OPENSSL_buf2hexstr(const unsigned char *buf, long buflen)
 
 int openssl_strerror_r(int errnum, char *buf, size_t buflen)
 {
-#if defined(_MSC_VER) && _MSC_VER >= 1400 && !defined(_WIN32_WCE)
+#if defined(_MSC_VER) && _MSC_VER >= 1400
     return !strerror_s(buf, buflen, errnum);
 #elif defined(_GNU_SOURCE)
     char *err;

--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -35,7 +35,7 @@
 #ifndef OPENSSL_NO_POSIX_IO
 #include <sys/stat.h>
 #include <fcntl.h>
-#if defined(_WIN32) && !defined(_WIN32_WCE)
+#if defined(_WIN32)
 #include <io.h>
 #define stat _stat
 #define chmod _chmod
@@ -69,7 +69,8 @@
  * This declaration is a nasty hack to get around vms' extension to fopen for
  * passing in sharing options being disabled by /STANDARD=ANSI89
  */
-static __FILE_ptr32 (*const vms_fopen)(const char *, const char *, ...) = (__FILE_ptr32 (*)(const char *, const char *, ...))fopen;
+static __FILE_ptr32 (*const vms_fopen)(const char *, const char *, ...)
+    = (__FILE_ptr32 (*)(const char *, const char *, ...))fopen;
 #define VMS_OPEN_ATTRS \
     "shr=get,put,upd,del", "ctx=bin,stm", "rfm=stm", "rat=none", "mrs=0"
 #define openssl_fopen(fname, mode) vms_fopen((fname), (mode), VMS_OPEN_ATTRS)
@@ -271,7 +272,7 @@ const char *RAND_file_name(char *buf, size_t size)
     size_t len;
     int use_randfile = 1;
 
-#if defined(_WIN32) && defined(CP_UTF8) && !defined(_WIN32_WCE)
+#if defined(_WIN32) && defined(CP_UTF8)
     DWORD envlen;
     WCHAR *var;
 

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -442,15 +442,11 @@ CRYPTO_RWLOCK *CRYPTO_THREAD_lock_new(void)
         /* Don't set error, to avoid recursion blowup. */
         return NULL;
 
-#if !defined(_WIN32_WCE)
     /* 0x400 is the spin count value suggested in the documentation */
     if (!InitializeCriticalSectionAndSpinCount(lock, 0x400)) {
         OPENSSL_free(lock);
         return NULL;
     }
-#else
-    InitializeCriticalSection(lock);
-#endif
 #endif
 
     return lock;

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -60,9 +60,7 @@
 #endif
 
 #ifdef WIN_CONSOLE_BUG
-#ifndef OPENSSL_SYS_WINCE
 #include <wincon.h>
-#endif
 #endif
 
 /*
@@ -165,7 +163,7 @@ static long tty_orig[3], tty_new[3]; /* XXX Is there any guarantee that this
                                       * structures? */
 static long status;
 static unsigned short channel = 0;
-#elif defined(_WIN32) && !defined(_WIN32_WCE)
+#elif defined(_WIN32)
 static DWORD tty_orig, tty_new;
 #else
 #if !defined(OPENSSL_SYS_MSDOS) || defined(__DJGPP__)
@@ -176,12 +174,10 @@ static FILE *tty_in, *tty_out;
 static int is_a_tty;
 
 /* Declare static functions */
-#if !defined(OPENSSL_SYS_WINCE)
 static int read_till_nl(FILE *);
 static void recsig(int);
 static void pushsig(void);
 static void popsig(void);
-#endif
 #if defined(OPENSSL_SYS_MSDOS) && !defined(_WIN32)
 static int noecho_fgets(char *buf, int size, FILE *tty);
 #endif
@@ -255,7 +251,6 @@ static int read_string(UI *ui, UI_STRING *uis)
     return 1;
 }
 
-#if !defined(OPENSSL_SYS_WINCE)
 /* Internal functions to read a string without echoing */
 static int read_till_nl(FILE *in)
 {
@@ -270,7 +265,6 @@ static int read_till_nl(FILE *in)
 }
 
 static volatile sig_atomic_t intr_signal;
-#endif
 
 static int read_string_inner(UI *ui, UI_STRING *uis, int echo, int strip_nl)
 {
@@ -278,7 +272,6 @@ static int read_string_inner(UI *ui, UI_STRING *uis, int echo, int strip_nl)
     int ok;
     char result[BUFSIZ];
     int maxsize = BUFSIZ - 1;
-#if !defined(OPENSSL_SYS_WINCE)
     char *p = NULL;
     int echo_eol = !echo;
 
@@ -358,9 +351,6 @@ error:
 
     if (ps >= 1)
         popsig();
-#else
-    ok = 1;
-#endif
 
     OPENSSL_cleanse(result, BUFSIZ);
     return ok;
@@ -376,7 +366,7 @@ static int open_console(UI *ui)
 #if defined(OPENSSL_SYS_VXWORKS)
     tty_in = stdin;
     tty_out = stderr;
-#elif defined(_WIN32) && !defined(_WIN32_WCE)
+#elif defined(_WIN32)
     if ((tty_out = fopen("conout$", "w")) == NULL)
         tty_out = stderr;
 
@@ -505,7 +495,7 @@ static int noecho_console(UI *ui)
         }
     }
 #endif
-#if defined(_WIN32) && !defined(_WIN32_WCE)
+#if defined(_WIN32)
     if (is_a_tty) {
         tty_new = tty_orig;
         tty_new &= ~ENABLE_ECHO_INPUT;
@@ -537,7 +527,7 @@ static int echo_console(UI *ui)
         }
     }
 #endif
-#if defined(_WIN32) && !defined(_WIN32_WCE)
+#if defined(_WIN32)
     if (is_a_tty) {
         tty_new = tty_orig;
         SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), tty_new);
@@ -567,7 +557,6 @@ static int close_console(UI *ui)
     return ret;
 }
 
-#if !defined(OPENSSL_SYS_WINCE)
 /* Internal functions to handle signals and act on them */
 static void pushsig(void)
 {
@@ -648,7 +637,6 @@ static void recsig(int i)
 {
     intr_signal = i;
 }
-#endif
 
 /* Internal functions specific for Windows */
 #if defined(OPENSSL_SYS_MSDOS) && !defined(_WIN32)

--- a/include/internal/e_os.h
+++ b/include/internal/e_os.h
@@ -83,7 +83,7 @@
 #endif
 
 #ifdef WINDOWS
-#if !defined(_WIN32_WCE) && !defined(_WIN32_WINNT)
+#if !defined(_WIN32_WINNT)
 /*
  * The _WIN32_WINNT is described here:
  * https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-170
@@ -115,12 +115,9 @@
 #include <stdio.h>
 #include <stddef.h>
 #include <errno.h>
-#if defined(_WIN32_WCE) && !defined(EACCES)
-#define EACCES 13
-#endif
 #include <string.h>
 #include <malloc.h>
-#if defined(_MSC_VER) && !defined(_WIN32_WCE) && !defined(_DLL) && defined(stdin)
+#if defined(_MSC_VER) && !defined(_DLL) && defined(stdin)
 #if _MSC_VER >= 1300 && _MSC_VER < 1600
 #undef stdin
 #undef stdout
@@ -136,10 +133,6 @@ FILE *__iob_func(void);
 #include <io.h>
 #include <fcntl.h>
 
-#ifdef OPENSSL_SYS_WINCE
-#define OPENSSL_NO_POSIX_IO
-#endif
-
 #define EXIT(n) exit(n)
 #define LIST_SEPARATOR_CHAR ';'
 #ifndef W_OK
@@ -148,11 +141,7 @@ FILE *__iob_func(void);
 #ifndef R_OK
 #define R_OK 4
 #endif
-#ifdef OPENSSL_SYS_WINCE
-#define DEFAULT_HOME ""
-#else
 #define DEFAULT_HOME "C:"
-#endif
 
 /* Avoid Visual Studio 13 GetVersion deprecated problems */
 #if defined(_MSC_VER) && _MSC_VER >= 1800
@@ -232,7 +221,7 @@ FILE *__iob_func(void);
 /***********************************************/
 
 #if defined(OPENSSL_SYS_WINDOWS)
-#if defined(_MSC_VER) && (_MSC_VER >= 1310) && !defined(_WIN32_WCE)
+#if defined(_MSC_VER) && (_MSC_VER >= 1310)
 #define open _open
 #define fdopen _fdopen
 #define close _close

--- a/include/internal/e_winsock.h
+++ b/include/internal/e_winsock.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #ifdef WINDOWS
-#if !defined(_WIN32_WCE) && !defined(_WIN32_WINNT)
+#if !defined(_WIN32_WINNT)
 /*
  * The _WIN32_WINNT is described here:
  * https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-170
@@ -40,7 +40,7 @@
  */
 #define _WIN32_WINNT 0x0501
 #endif
-#if defined(_WIN32_WINNT) || defined(_WIN32_WCE)
+#if defined(_WIN32_WINNT)
 /*
  * Just like defining _WIN32_WINNT including winsock2.h implies
  * certain "discipline" for maintaining [broad] binary compatibility.

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -135,7 +135,7 @@ typedef struct {
     volatile int val;
 } CRYPTO_REF_COUNT;
 
-#if (defined(_M_ARM) && _M_ARM >= 7 && !defined(_WIN32_WCE)) || defined(_M_ARM64)
+#if (defined(_M_ARM) && _M_ARM >= 7) || defined(_M_ARM64)
 #include <intrin.h>
 #if defined(_M_ARM64) && !defined(_ARM_BARRIER_ISH)
 #define _ARM_BARRIER_ISH _ARM64_BARRIER_ISH
@@ -160,17 +160,7 @@ static __inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 }
 
 #else
-#if !defined(_WIN32_WCE)
 #pragma intrinsic(_InterlockedExchangeAdd)
-#else
-#if _WIN32_WCE >= 0x600
-extern long __cdecl _InterlockedExchangeAdd(long volatile *, long);
-#else
-/* under Windows CE we still have old-style Interlocked* functions */
-extern long __cdecl InterlockedExchangeAdd(long volatile *, long);
-#define _InterlockedExchangeAdd InterlockedExchangeAdd
-#endif
-#endif
 
 static __inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {

--- a/include/internal/sockets.h
+++ b/include/internal/sockets.h
@@ -37,17 +37,10 @@
 #include <netdb.h>
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
-#elif defined(_WIN32_WCE) && _WIN32_WCE < 410
-#define getservbyname _masked_declaration_getservbyname
 #endif
 #if !defined(IPPROTO_IP)
 /* winsock[2].h was included already? */
 #include "internal/e_winsock.h"
-#endif
-#ifdef getservbyname
-/* this is used to be wcecompat/include/winsock_extras.h */
-#undef getservbyname
-struct servent *PASCAL getservbyname(const char *, const char *);
 #endif
 
 #ifdef _WIN64
@@ -230,7 +223,7 @@ static ossl_inline int writesocket_ex(int s, const void *b, int n, int f)
 #endif
 
 /* also in apps/include/apps.h */
-#if defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_WINCE)
+#if defined(OPENSSL_SYS_WIN32)
 #define openssl_fdset(a, b) FD_SET((unsigned int)(a), b)
 #else
 #define openssl_fdset(a, b) FD_SET(a, b)

--- a/include/internal/tsan_assist.h
+++ b/include/internal/tsan_assist.h
@@ -78,7 +78,7 @@
 #endif
 
 #elif defined(_MSC_VER) && _MSC_VER >= 1200 \
-    && (defined(_M_IX86) || defined(_M_AMD64) || defined(_M_X64) || defined(_M_ARM64) || (defined(_M_ARM) && _M_ARM >= 7 && !defined(_WIN32_WCE)))
+    && (defined(_M_IX86) || defined(_M_AMD64) || defined(_M_X64) || defined(_M_ARM64) || (defined(_M_ARM) && _M_ARM >= 7))
 /*
  * There is subtle dependency on /volatile:<iso|ms> command-line option.
  * "ms" implies same semantic as memory_order_acquire for loads and

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -72,14 +72,11 @@ extern "C" {
 #if defined(OPENSSL_SYS_WINNT)
 #undef OPENSSL_SYS_UNIX
 #endif
-#if defined(OPENSSL_SYS_WINCE)
-#undef OPENSSL_SYS_UNIX
-#endif
 #endif
 #endif
 
 /* Anything that tries to look like Microsoft is "Windows" */
-#if defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_WIN64) || defined(OPENSSL_SYS_WINNT) || defined(OPENSSL_SYS_WINCE)
+#if defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_WIN64) || defined(OPENSSL_SYS_WINNT)
 #undef OPENSSL_SYS_UNIX
 #define OPENSSL_SYS_WINDOWS
 #ifndef OPENSSL_SYS_MSDOS


### PR DESCRIPTION
Windows CE has been out of mainstream support since 2018 and will not have a modern toolchain capable of compiling a modern OpenSSL.

The vc_wince_info Perl helper, the crypto/LPdir_wince.c directory backend, and a long tail of _WIN32_WCE
 / OPENSSL_SYS_WINCE guards across the Windows code paths are pulled out.

Spotted by idrassi while reviewing https://github.com/openssl/openssl/pull/31580
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
