### PR TITLE
siv128.c: Assigned -1 to final_ret(ctx) variable on auth. failure.

### DIFF
--- a/crypto/modes/siv128.c
+++ b/crypto/modes/siv128.c
@@ -276,23 +276,29 @@ int ossl_siv128_encrypt(SIV128_CONTEXT *ctx,
     size_t len)
 {
     SIV_BLOCK q;
+    int ret = 0;
+    int final_ret_value = -1;
 
     /* can only do one crypto operation */
     if (ctx->crypto_ok == 0)
-        return 0;
+        goto end;
     ctx->crypto_ok--;
 
     if (!siv128_do_s2v_p(ctx, &q, in, len))
-        return 0;
+        goto end;
 
     memcpy(ctx->tag.byte, &q, SIV_LEN);
     q.byte[8] &= 0x7f;
     q.byte[12] &= 0x7f;
 
     if (!siv128_do_encrypt(ctx->cipher_ctx, out, in, len, &q))
-        return 0;
-    ctx->final_ret = 0;
-    return 1;
+        goto end;
+
+    ret = 1;
+    final_ret_value = 0;
+end:
+    ctx->final_ret = final_ret_value;
+    return ret;
 }
 
 /*
@@ -305,10 +311,12 @@ int ossl_siv128_decrypt(SIV128_CONTEXT *ctx,
     unsigned char *p;
     SIV_BLOCK t, q;
     int i;
+    int ret = 0;
+    int final_ret_value = -1;
 
     /* can only do one crypto operation */
     if (ctx->crypto_ok == 0)
-        return 0;
+        goto end;
     ctx->crypto_ok--;
 
     memcpy(&q, ctx->tag.byte, SIV_LEN);
@@ -317,7 +325,7 @@ int ossl_siv128_decrypt(SIV128_CONTEXT *ctx,
 
     if (!siv128_do_encrypt(ctx->cipher_ctx, out, in, len, &q)
         || !siv128_do_s2v_p(ctx, &t, out, len))
-        return 0;
+        goto end;
 
     p = ctx->tag.byte;
     for (i = 0; i < SIV_LEN; i++)
@@ -325,10 +333,13 @@ int ossl_siv128_decrypt(SIV128_CONTEXT *ctx,
 
     if ((t.word[0] | t.word[1]) != 0) {
         OPENSSL_cleanse(out, len);
-        return 0;
+        goto end;
     }
-    ctx->final_ret = 0;
-    return 1;
+    ret = 1;
+    final_ret_value = 0;
+end:
+    ctx->final_ret = final_ret_value;
+    return ret;
 }
 
 /*

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -8009,6 +8009,94 @@ err:
     return ret;
 }
 
+static int test_aes_siv_ctx_dec_retval(void)
+{
+    unsigned char key[32] = { 7 };
+    unsigned char in[6] = "input";
+    unsigned char ct[6] = { 0 };
+
+    unsigned char tagbuf[16], out[16] = { 0 };
+    int len, ret = 0;
+    EVP_CIPHER_CTX *enc_ctx = NULL;
+    EVP_CIPHER_CTX *dec_ctx = NULL;
+
+    EVP_CIPHER *cipher = EVP_CIPHER_fetch(NULL, "AES-128-SIV", NULL);
+
+    if (cipher == NULL)
+        return TEST_skip("AES-128-SIV cipher is not available");
+
+    enc_ctx = EVP_CIPHER_CTX_new();
+    if (!TEST_ptr(enc_ctx)
+        || !TEST_true(EVP_EncryptInit_ex(enc_ctx, cipher, NULL, key, NULL))
+        || !TEST_true(EVP_EncryptUpdate(enc_ctx, ct, &len, in, sizeof(in)))
+        || !TEST_true(EVP_CIPHER_CTX_ctrl(enc_ctx, EVP_CTRL_AEAD_GET_TAG, sizeof(tagbuf), tagbuf))
+        || !TEST_true(EVP_EncryptFinal_ex(enc_ctx, ct + len, &len)))
+        goto err;
+
+    dec_ctx = EVP_CIPHER_CTX_new();
+    if (!TEST_ptr(dec_ctx)
+        || !TEST_true(EVP_DecryptInit_ex(dec_ctx, cipher, NULL, key, NULL))
+        || !TEST_true(EVP_CIPHER_CTX_ctrl(dec_ctx, EVP_CTRL_AEAD_SET_TAG,
+            sizeof(tagbuf), tagbuf))
+        || !TEST_true(EVP_DecryptUpdate(dec_ctx, out, &len, ct, sizeof(in)))
+        || !TEST_true(EVP_DecryptFinal_ex(dec_ctx, out + len, &len))
+        || !TEST_true(0 == memcmp(out, in, sizeof(in)))) {
+        goto err;
+    }
+
+    /*
+     * Positive usecase successful,
+     * provoke the error, by repeating decrypt on same context.
+     */
+    if (!TEST_false(EVP_DecryptUpdate(dec_ctx, out, &len, ct, sizeof(ct)))
+        || (!TEST_false(EVP_DecryptFinal_ex(dec_ctx, out + len, &len))))
+        goto err;
+
+    ret = 1;
+
+err:
+    EVP_CIPHER_CTX_free(dec_ctx);
+    EVP_CIPHER_CTX_free(enc_ctx);
+    EVP_CIPHER_free(cipher);
+    return ret;
+}
+
+static int test_aes_siv_ctx_enc_retval(void)
+{
+    unsigned char key[32] = { 7 };
+    unsigned char in[6] = "input";
+    unsigned char ct[6] = { 0 };
+
+    unsigned char tagbuf[16];
+    int len, ret = 0;
+    EVP_CIPHER_CTX *enc_ctx = NULL;
+
+    EVP_CIPHER *cipher = EVP_CIPHER_fetch(NULL, "AES-128-SIV", NULL);
+
+    if (cipher == NULL)
+        return TEST_skip("AES-128-SIV cipher is not available");
+
+    enc_ctx = EVP_CIPHER_CTX_new();
+    if (!TEST_ptr(enc_ctx)
+        || !TEST_true(EVP_EncryptInit_ex(enc_ctx, cipher, NULL, key, NULL))
+        || !TEST_true(EVP_EncryptUpdate(enc_ctx, ct, &len, in, sizeof(in)))
+        || !TEST_true(EVP_CIPHER_CTX_ctrl(enc_ctx, EVP_CTRL_AEAD_GET_TAG, sizeof(tagbuf), tagbuf))
+        || !TEST_true(EVP_EncryptFinal_ex(enc_ctx, ct + len, &len)))
+        goto err;
+
+    /*
+     * Encryption is fine, provoke error by repeating encrypt on same context. */
+    if (!TEST_false(EVP_EncryptUpdate(enc_ctx, ct, &len, in, sizeof(in)))
+        || !TEST_false(EVP_EncryptFinal_ex(enc_ctx, ct + len, &len)))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_CIPHER_CTX_free(enc_ctx);
+    EVP_CIPHER_free(cipher);
+    return ret;
+}
+
 static int test_invalid_ctx_for_digest(void)
 {
     int ret;
@@ -9319,6 +9407,8 @@ int setup_tests(void)
     /* Test cases for CVE-2026-45446 */
     ADD_TEST(test_aes_gcm_siv_empty_data);
     ADD_TEST(test_aes_siv_ctx_reuse);
+    ADD_TEST(test_aes_siv_ctx_dec_retval);
+    ADD_TEST(test_aes_siv_ctx_enc_retval);
 
     ADD_TEST(test_invalid_ctx_for_digest);
 


### PR DESCRIPTION
siv128.siv128.c: refactor encrypt/decrypt to a single exit point
`ossl_siv128_encrypt()` and `ossl_siv128_decrypt()` previously set
`ctx->final_ret = 0` only on the success path, leaving it unmodified
on early returns. In speed mode, where the context is reused, this
caused `ossl_siv128_finish()` to return a stale success value after
a failed authentication.

Refactor both functions to use a single err: label exit point.
`final_ret_value` is initialised to -1 and set to 0 only on
success, then assigned to `ctx->final_ret` unconditionally on exit.

Fixes https://github.com/openssl/openssl/issues/31584

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
