### PR TITLE
Avoid NULL dereference if RSA_PSS_PARAMS_dup() fails in ossl_rsa_dup()

### DIFF
--- a/crypto/rsa/rsa_backend.c
+++ b/crypto/rsa/rsa_backend.c
@@ -532,7 +532,8 @@ RSA *ossl_rsa_dup(const RSA *rsa, int selection)
     }
 
     if (rsa->pss != NULL) {
-        dupkey->pss = RSA_PSS_PARAMS_dup(rsa->pss);
+        if ((dupkey->pss = RSA_PSS_PARAMS_dup(rsa->pss)) == NULL)
+            goto err;
         if (rsa->pss->maskGenAlgorithm != NULL
             && dupkey->pss->maskGenAlgorithm == NULL) {
             dupkey->pss->maskHash = ossl_x509_algor_mgf1_decode(rsa->pss->maskGenAlgorithm);


### PR DESCRIPTION
### Description

In `ossl_rsa_dup()` (crypto/rsa/rsa_backend.c) the return value of `RSA_PSS_PARAMS_dup()` was not checked before being dereferenced:

```c
dupkey->pss = RSA_PSS_PARAMS_dup(rsa->pss);
if (rsa->pss->maskGenAlgorithm != NULL
    && dupkey->pss->maskGenAlgorithm == NULL) {   /* dupkey->pss may be NULL */
```

`RSA_PSS_PARAMS_dup()` returns NULL on failure (e.g. memory allocation failure). When the source key carries PSS parameters with a `maskGenAlgorithm` (so the first condition is true), the subsequent access to `dupkey->pss->maskGenAlgorithm` dereferences a NULL pointer and crashes.

The path is reachable via `EVP_PKEY` duplication of an RSA-PSS key (`rsa_pkey_copy()` → `ossl_rsa_dup(rsa, OSSL_KEYMGMT_SELECT_ALL)`).

### Fix

Check the return value of `RSA_PSS_PARAMS_dup()` and jump to the existing error handling, which frees the partially constructed key.

### Verification

Exercised `ossl_rsa_dup()` on an RSA-PSS key under allocation-failure injection (custom allocator failing the N-th allocation). With the original code the duplication crashes with SIGSEGV for every failure landing inside `RSA_PSS_PARAMS_dup()`; with the fix applied all injected failures are handled gracefully (NULL returned, no crash). The normal (no-failure) path is unchanged.

### Notes

- Developed with the assistance of an AI coding tool; the change has been reviewed and understood by me, and the reasoning and test were verified manually.
- Individual CLA submitted to cla@openssl.org.
