### PR TITLE
`rec_layer_s3.c`: prevent `max_early_data` overflow in `ossl_early_data_count_ok()`

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -150,7 +150,7 @@ static uint32_t ossl_get_max_early_data(SSL_CONNECTION *s)
 static int ossl_early_data_count_ok(SSL_CONNECTION *s, size_t length,
     size_t overhead, int send)
 {
-    uint32_t max_early_data;
+    uint64_t max_early_data;
 
     max_early_data = ossl_get_max_early_data(s);
 
@@ -161,7 +161,7 @@ static int ossl_early_data_count_ok(SSL_CONNECTION *s, size_t length,
     }
 
     /* If we are dealing with ciphertext we need to allow for the overhead */
-    max_early_data += (uint32_t)overhead;
+    max_early_data += overhead;
 
     if (s->early_data_count + length > max_early_data) {
         SSLfatal(s, send ? SSL_AD_INTERNAL_ERROR : SSL_AD_UNEXPECTED_MESSAGE,


### PR DESCRIPTION
Apply change similar to the one made in d41a9225196b "`tls_common.c`: prevent `max_early_data` overflow in `rlayer_early_data_count_ok()`" to `ossl_early_data_count_ok()`, that has similar logic in it (as `rlayer_early_data_count_ok()` has been copied from `ossl_early_data_count_ok()` in 9dd90232d537 "Move early data counting out of the SSL object and into the record layer").

This is a follow-up to [1].

Complements: d41a9225196b "`tls_common.c`: prevent `max_early_data` overflow in `rlayer_early_data_count_ok()`"
Fixes: 70ef40a05e06 "Check max_early_data against the amount of early data we actually receive"

[1] https://github.com/openssl/openssl/pull/31538