### PR TITLE
s390x: Disable mod-expo offloading to a crypto card for small exponents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,17 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * s390x: Disable mod-expo offloading to a crypto card for small exponents.
+   Add a new keyword `cex_min_bits:<bits>` for the `OPENSSL_s390xcap`
+   environment variable to specify the minimum number of bits that the
+   exponent must have to offload the operation to the crypto card.
+   Operations with smaller exponents fall back to software calculation.
+   Mod-expo operations with small exponents are faster in software than
+   via the crypto card. The default minimum exponent size is 2048 bits,
+   but this can be changed via the `OPENSSL_s390xcap` environment variable.
+
+   *Ingo Franzki*
+
  * Fixed TLS 1.3 external PSK connections being wrongly rejected when
    the client sets a non-empty session ID context.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,17 @@ OpenSSL Releases
 
 ### Changes between 4.0 and 4.1 [xx XXX xxxx]
 
+ * s390x: Disable mod-expo offloading to a crypto card for small exponents.
+   Add a new keyword `cex_min_bits:<bits>` for the `OPENSSL_s390xcap`
+   environment variable to specify the minimum number of bits that the
+   exponent must have to offload the operation to the crypto card.
+   Operations with smaller exponents fall back to software calculation.
+   Mod-expo operations with small exponents are faster in software than
+   via the crypto card. The default minimum exponent size is 2048 bits,
+   but this can be changed via the `OPENSSL_s390xcap` environment variable.
+
+   *Ingo Franzki*
+
  * Repeated fields in the `basicConstraints`, `basicAttConstraints`,
    and `policyConstraints` X.509v3 extension configurations are now rejected
    instead of silently using the last value.

--- a/crypto/bn/bn_s390x.c
+++ b/crypto/bn/bn_s390x.c
@@ -34,7 +34,11 @@ static int s390x_mod_exp_hw(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
 
     if (OPENSSL_s390xcex == -1 || OPENSSL_s390xcex_nodev)
         return -1;
+    if (BN_num_bits(p) < (int)OPENSSL_s390xcex_min_bits)
+        return -1;
     size = BN_num_bytes(m);
+    if (size > 4096 / 8) /* Acceleration only works up to 4096 bits modulus */
+        return -1;
     buffer = OPENSSL_calloc(size, 4);
     if (buffer == NULL)
         return 0;
@@ -92,7 +96,7 @@ int s390x_mod_exp(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
  * SW-fallback.
  */
 int s390x_crt(BIGNUM *r, const BIGNUM *i, const BIGNUM *p, const BIGNUM *q,
-    const BIGNUM *dmp, const BIGNUM *dmq, const BIGNUM *iqmp)
+    const BIGNUM *dmp, const BIGNUM *dmq, const BIGNUM *iqmp, const BIGNUM *n)
 {
     struct ica_rsa_modexpo_crt crt;
     unsigned char *buffer, *part;
@@ -100,6 +104,11 @@ int s390x_crt(BIGNUM *r, const BIGNUM *i, const BIGNUM *p, const BIGNUM *q,
     int res = -1;
 
     if (OPENSSL_s390xcex == -1 || OPENSSL_s390xcex_nodev)
+        return -1;
+    size = BN_num_bits(n);
+    if (size < OPENSSL_s390xcex_min_bits)
+        return -1;
+    if (size > 4096) /* Acceleration only works up to 4096 bits modulus */
         return -1;
     /*-
      * Hardware-accelerated CRT can only deal with p>q.  Fall back to
@@ -172,7 +181,7 @@ int s390x_mod_exp(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
 }
 
 int s390x_crt(BIGNUM *r, const BIGNUM *i, const BIGNUM *p, const BIGNUM *q,
-    const BIGNUM *dmp, const BIGNUM *dmq, const BIGNUM *iqmp)
+    const BIGNUM *dmp, const BIGNUM *dmq, const BIGNUM *iqmp, const BIGNUM *n)
 {
     return 0;
 }

--- a/crypto/info.c
+++ b/crypto/info.c
@@ -118,7 +118,9 @@ DEFINE_RUN_ONCE_STATIC(init_info_strings)
                                    "prno:0x%llx:0x%llx:"
                                    "kma:0x%llx:0x%llx:"
                                    "pcc:0x%llx:0x%llx:"
-                                   "kdsa:0x%llx:0x%llx",
+                                   "kdsa:0x%llx:0x%llx:"
+                                   "cex_min_bits:%u"
+                                   "%s",
         OPENSSL_s390xcap_P.stfle[0], OPENSSL_s390xcap_P.stfle[1],
         OPENSSL_s390xcap_P.stfle[2], OPENSSL_s390xcap_P.stfle[3],
         OPENSSL_s390xcap_P.kimd[0], OPENSSL_s390xcap_P.kimd[1],
@@ -132,7 +134,13 @@ DEFINE_RUN_ONCE_STATIC(init_info_strings)
         OPENSSL_s390xcap_P.prno[0], OPENSSL_s390xcap_P.prno[1],
         OPENSSL_s390xcap_P.kma[0], OPENSSL_s390xcap_P.kma[1],
         OPENSSL_s390xcap_P.pcc[0], OPENSSL_s390xcap_P.pcc[1],
-        OPENSSL_s390xcap_P.kdsa[0], OPENSSL_s390xcap_P.kdsa[1]);
+        OPENSSL_s390xcap_P.kdsa[0], OPENSSL_s390xcap_P.kdsa[1],
+#ifdef S390X_MOD_EXP
+        OPENSSL_s390xcex_min_bits,
+        (OPENSSL_s390xcex == -1 || OPENSSL_s390xcex_nodev) ? ":nocex" : "");
+#else
+        0, "");
+#endif
     if ((env = getenv("OPENSSL_s390xcap")) != NULL)
         cpu_info_append(" env:%s", env);
 #elif defined(__riscv)

--- a/crypto/rsa/rsa_ossl.c
+++ b/crypto/rsa/rsa_ossl.c
@@ -1187,7 +1187,7 @@ static int rsa_ossl_s390x_mod_exp(BIGNUM *r0, const BIGNUM *i, RSA *rsa,
     int rc;
 
     if (rsa->version != RSA_ASN1_VERSION_MULTI) {
-        rc = s390x_crt(r0, i, rsa->p, rsa->q, rsa->dmp1, rsa->dmq1, rsa->iqmp);
+        rc = s390x_crt(r0, i, rsa->p, rsa->q, rsa->dmp1, rsa->dmq1, rsa->iqmp, rsa->n);
         if (rc >= 0)
             return rc;
     }

--- a/crypto/rsa/rsa_ossl.c
+++ b/crypto/rsa/rsa_ossl.c
@@ -1184,7 +1184,7 @@ static int rsa_ossl_s390x_mod_exp(BIGNUM *r0, const BIGNUM *i, RSA *rsa,
     int rc;
 
     if (rsa->version != RSA_ASN1_VERSION_MULTI) {
-        rc = s390x_crt(r0, i, rsa->p, rsa->q, rsa->dmp1, rsa->dmq1, rsa->iqmp);
+        rc = s390x_crt(r0, i, rsa->p, rsa->q, rsa->dmp1, rsa->dmq1, rsa->iqmp, rsa->n);
         if (rc >= 0)
             return rc;
     }

--- a/crypto/s390xcap.c
+++ b/crypto/s390xcap.c
@@ -82,7 +82,8 @@ void OPENSSL_vx_probe(void);
 #endif
 
 static const char *env;
-static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex);
+static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex,
+    unsigned int *cex_min_bits);
 
 void OPENSSL_s390x_facilities(void);
 void OPENSSL_s390x_functions(void);
@@ -92,6 +93,7 @@ struct OPENSSL_s390xcap_st OPENSSL_s390xcap_P;
 #ifdef S390X_MOD_EXP
 int OPENSSL_s390xcex;
 int OPENSSL_s390xcex_nodev;
+unsigned int OPENSSL_s390xcex_min_bits;
 
 #if defined(__GNUC__)
 __attribute__((visibility("hidden")))
@@ -117,6 +119,7 @@ void OPENSSL_cpuid_setup(void)
 {
     struct OPENSSL_s390xcap_st cap;
     int cex = 1;
+    unsigned int cex_min_bits = S390X_CEX_MIN_BITS_DEFAULT;
 
     if (OPENSSL_s390xcap_P.stfle[0])
         return;
@@ -177,7 +180,7 @@ void OPENSSL_cpuid_setup(void)
 
     env = getenv("OPENSSL_s390xcap");
     if (env != NULL) {
-        if (!parse_env(&cap, &cex))
+        if (!parse_env(&cap, &cex, &cex_min_bits))
             env = NULL;
     }
 
@@ -223,10 +226,12 @@ void OPENSSL_cpuid_setup(void)
         OPENSSL_s390xcex = open("/dev/z90crypt", O_RDWR | O_CLOEXEC);
     }
     OPENSSL_s390xcex_nodev = 0;
+    OPENSSL_s390xcex_min_bits = cex_min_bits;
 #endif
 }
 
-static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex)
+static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex,
+    unsigned int *cex_min_bits)
 {
     /* clang-format off */
     /*-
@@ -831,6 +836,7 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex)
 
     char *tok_begin, *tok_end, *buff, tok[S390X_STFLE_MAX][LEN + 1];
     int rc, off, i, n;
+    unsigned int val;
 
     buff = malloc(strlen(env) + 1);
     if (buff == NULL)
@@ -892,6 +898,12 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap, int *cex)
                      tok[0], tok[1]) == 1
             && !strcmp(tok[0], "nocex")) {
             *cex = 0;
+        }
+
+        /* cex_min_bits to deactivate cex support for small key sizes */
+        else if (sscanf(tok_begin, " cex_min_bits : %u %" STR(LEN) "s ",
+                     &val, tok[0]) == 1) {
+            *cex_min_bits = val;
         }
 
         /* whitespace(ignored) or invalid tokens */

--- a/doc/man3/OPENSSL_s390xcap.pod
+++ b/doc/man3/OPENSSL_s390xcap.pod
@@ -56,6 +56,13 @@ instruction is set to the specified 192-bit mask.
 Deactivate modular exponentiation and CRT operation offloading to
 Crypto Express Adapters.
 
+=item cex_min_bits:<bits>
+
+Deactivate modular exponentiation and CRT operation offloading to
+Crypto Express Adapters for exponents less than the specified bit size.
+The default is to only offload operations with an exponent of at least 2048
+bits.
+
 =back
 
 The 64-bit masks are specified in hexadecimal notation. The 0x prefix is

--- a/include/arch/s390x_arch.h
+++ b/include/arch/s390x_arch.h
@@ -89,7 +89,13 @@ extern int OPENSSL_s390xcex;
 __attribute__((visibility("hidden")))
 #endif
 extern int OPENSSL_s390xcex_nodev;
+#if defined(__GNUC__) && defined(__linux)
+__attribute__((visibility("hidden")))
 #endif
+extern unsigned int OPENSSL_s390xcex_min_bits;
+#endif
+
+#define S390X_CEX_MIN_BITS_DEFAULT 2048
 
 /* Max number of 64-bit words currently returned by STFLE */
 #define S390X_STFLE_MAX 3

--- a/include/crypto/bn.h
+++ b/include/crypto/bn.h
@@ -135,7 +135,7 @@ extern const BIGNUM ossl_bn_inv_sqrt_2;
 int s390x_mod_exp(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
     const BIGNUM *m, BN_CTX *ctx, BN_MONT_CTX *m_ctx);
 int s390x_crt(BIGNUM *r, const BIGNUM *i, const BIGNUM *p, const BIGNUM *q,
-    const BIGNUM *dmp, const BIGNUM *dmq, const BIGNUM *iqmp);
+    const BIGNUM *dmp, const BIGNUM *dmq, const BIGNUM *iqmp, const BIGNUM *n);
 
 #endif
 


### PR DESCRIPTION
Add a new keyword `cex_min_bits:<bits>` for the `OPENSSL_s390xcap` environment variable to specify the minimum number of bits that the exponent must have to offload the operation to the crypto card. Operations with smaller exponents fall back to software calculation. Mod-expo operations with small exponents are faster in software than via the crypto card.

The default minimum exponent size is 2048 bits, but this can be changed via the `OPENSSL_s390xcap` environment variable.

For mod-expo operations the exponent is checked, and for RSA CRT operations the modulus is checked to have the minimum bit size. RSA public key operations usually have small exponents, so they are most likely always performed in software.

Checking the bit size of a BIGNUM may or may not be constant-time, dependent on the BN_FLG_CONSTTIME flag of the BIGNUM. For RSA CRT operations, the bit size of the modulus is checked. The modulus is public information, so no constant-time issue here. For mod-expo operations with the public exponent it is also not a constant-time issue, because the public exponent is also public information. For mod-expo operations with the private exponent, the size of the private exponent is usually the same as the size of the modulus, which is public information. For DH mod-expo operations with the private key, the size of the private key is usually dependent on the DH group that is used, and this is also public information. Nevertheless, private exponents better have the BN_FLG_CONSTTIME flag set. For RSA this is the case, and for DH it is also the case when flag DH_FLAG_CACHE_MONT_P is set, which is always done (dh_init() sets the flag unconditionally). Furthermore, flag BN_FLG_CONSTTIME is set for the private key in ossl_dh_generate_public_key().

