### PR TITLE
Various fixes, refactoring, and improvements across ASN1, compression BIOs, QUIC, CMS, and build config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -439,3 +439,4 @@ lcov.info
 run_tests
 depend
 
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -439,4 +439,4 @@ lcov.info
 run_tests
 depend
 
-build/
+build*/

--- a/crypto/asn1/a_dup.c
+++ b/crypto/asn1/a_dup.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #include <openssl/asn1t.h>
+#include "asn1_local.h"
 
 #ifndef NO_OLD_ASN1
 
@@ -49,7 +50,7 @@ void *ASN1_dup(i2d_of_void *i2d, d2i_of_void *d2i, const void *x)
 
 void *ASN1_item_dup(const ASN1_ITEM *it, const void *x)
 {
-    ASN1_aux_cb *asn1_cb = NULL;
+    const ASN1_AUX *aux = NULL;
     unsigned char *b = NULL;
     const unsigned char *p;
     long i;
@@ -61,18 +62,13 @@ void *ASN1_item_dup(const ASN1_ITEM *it, const void *x)
         return NULL;
 
     if (it->itype == ASN1_ITYPE_SEQUENCE || it->itype == ASN1_ITYPE_CHOICE
-        || it->itype == ASN1_ITYPE_NDEF_SEQUENCE) {
-        const ASN1_AUX *aux = it->funcs;
+        || it->itype == ASN1_ITYPE_NDEF_SEQUENCE)
+        aux = it->funcs;
 
-        asn1_cb = aux != NULL ? aux->asn1_cb : NULL;
-    }
-
-    if (asn1_cb != NULL) {
-        if (!asn1_cb(ASN1_OP_DUP_PRE, (ASN1_VALUE **)&x, it, NULL)
-            || !asn1_cb(ASN1_OP_GET0_LIBCTX, (ASN1_VALUE **)&x, it, &libctx)
-            || !asn1_cb(ASN1_OP_GET0_PROPQ, (ASN1_VALUE **)&x, it, &propq))
-            goto auxerr;
-    }
+    if (!ossl_asn1_call_aux_cb(aux, ASN1_OP_DUP_PRE, (const ASN1_VALUE **)&x, it, NULL)
+        || !ossl_asn1_call_aux_cb(aux, ASN1_OP_GET0_LIBCTX, (const ASN1_VALUE **)&x, it, &libctx)
+        || !ossl_asn1_call_aux_cb(aux, ASN1_OP_GET0_PROPQ, (const ASN1_VALUE **)&x, it, &propq))
+        goto auxerr;
 
     i = ASN1_item_i2d(x, &b, it);
     if (i < 0 || b == NULL) {
@@ -83,8 +79,7 @@ void *ASN1_item_dup(const ASN1_ITEM *it, const void *x)
     ret = ASN1_item_d2i_ex(NULL, &p, i, it, libctx, propq);
     OPENSSL_free(b);
 
-    if (asn1_cb != NULL
-        && !asn1_cb(ASN1_OP_DUP_POST, &ret, it, (void *)x))
+    if (!ossl_asn1_call_aux_cb(aux, ASN1_OP_DUP_POST, (const ASN1_VALUE **)&ret, it, (void *)x))
         goto auxerr;
 
     return ret;

--- a/crypto/asn1/tasn_dec.c
+++ b/crypto/asn1/tasn_dec.c
@@ -194,7 +194,6 @@ int asn1_item_embed_d2i(ASN1_VALUE **pval, const unsigned char **in,
     const ASN1_TEMPLATE *tt, *errtt = NULL;
     const ASN1_EXTERN_FUNCS *ef;
     const ASN1_AUX *aux;
-    ASN1_aux_cb *asn1_cb;
     const unsigned char *p = NULL, *q;
     unsigned char oclass;
     char seq_eoc, seq_nolen, cst, isopt;
@@ -213,10 +212,6 @@ int asn1_item_embed_d2i(ASN1_VALUE **pval, const unsigned char **in,
         return 0;
     }
     aux = it->funcs;
-    if (aux && aux->asn1_cb)
-        asn1_cb = aux->asn1_cb;
-    else
-        asn1_cb = 0;
 
     if (++depth > ASN1_MAX_CONSTRUCTED_NEST) {
         ERR_raise(ERR_LIB_ASN1, ASN1_R_NESTED_TOO_DEEP);
@@ -299,7 +294,7 @@ int asn1_item_embed_d2i(ASN1_VALUE **pval, const unsigned char **in,
             goto err;
         }
 
-        if (asn1_cb && !asn1_cb(ASN1_OP_D2I_PRE, pval, it, NULL))
+        if (!ossl_asn1_call_aux_cb(aux, ASN1_OP_D2I_PRE, (const ASN1_VALUE **)pval, it, NULL))
             goto auxerr;
         if (*pval) {
             /* Free up and zero CHOICE value if initialised */
@@ -353,7 +348,7 @@ int asn1_item_embed_d2i(ASN1_VALUE **pval, const unsigned char **in,
 
         ossl_asn1_set_choice_selector(pval, i, it);
 
-        if (asn1_cb && !asn1_cb(ASN1_OP_D2I_POST, pval, it, NULL))
+        if (!ossl_asn1_call_aux_cb(aux, ASN1_OP_D2I_POST, (const ASN1_VALUE **)pval, it, NULL))
             goto auxerr;
         *in = p;
         return 1;
@@ -394,7 +389,7 @@ int asn1_item_embed_d2i(ASN1_VALUE **pval, const unsigned char **in,
             goto err;
         }
 
-        if (asn1_cb && !asn1_cb(ASN1_OP_D2I_PRE, pval, it, NULL))
+        if (!ossl_asn1_call_aux_cb(aux, ASN1_OP_D2I_PRE, (const ASN1_VALUE **)pval, it, NULL))
             goto auxerr;
 
         /* Free up and zero any ADB found */
@@ -495,7 +490,7 @@ int asn1_item_embed_d2i(ASN1_VALUE **pval, const unsigned char **in,
         /* Save encoding */
         if (!ossl_asn1_enc_save(pval, *in, (long)(p - *in), it))
             goto auxerr;
-        if (asn1_cb && !asn1_cb(ASN1_OP_D2I_POST, pval, it, NULL))
+        if (!ossl_asn1_call_aux_cb(aux, ASN1_OP_D2I_POST, (const ASN1_VALUE **)pval, it, NULL))
             goto auxerr;
         *in = p;
         return 1;

--- a/crypto/asn1/tasn_fre.c
+++ b/crypto/asn1/tasn_fre.c
@@ -30,17 +30,12 @@ void ossl_asn1_item_embed_free(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed
     const ASN1_TEMPLATE *tt = NULL, *seqtt;
     const ASN1_EXTERN_FUNCS *ef;
     const ASN1_AUX *aux = it->funcs;
-    ASN1_aux_cb *asn1_cb;
     int i;
 
     if (pval == NULL)
         return;
     if ((it->itype != ASN1_ITYPE_PRIMITIVE) && *pval == NULL)
         return;
-    if (aux && aux->asn1_cb)
-        asn1_cb = aux->asn1_cb;
-    else
-        asn1_cb = 0;
 
     switch (it->itype) {
 
@@ -56,11 +51,9 @@ void ossl_asn1_item_embed_free(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed
         break;
 
     case ASN1_ITYPE_CHOICE:
-        if (asn1_cb) {
-            i = asn1_cb(ASN1_OP_FREE_PRE, pval, it, NULL);
-            if (i == 2)
-                return;
-        }
+        i = ossl_asn1_call_aux_cb(aux, ASN1_OP_FREE_PRE, (const ASN1_VALUE **)pval, it, NULL);
+        if (i == 2)
+            return;
         i = ossl_asn1_get_choice_selector(pval, it);
         if ((i >= 0) && (i < it->tcount)) {
             ASN1_VALUE **pchval;
@@ -69,8 +62,7 @@ void ossl_asn1_item_embed_free(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed
             pchval = ossl_asn1_get_field_ptr(pval, tt);
             ossl_asn1_template_free(pchval, tt);
         }
-        if (asn1_cb)
-            asn1_cb(ASN1_OP_FREE_POST, pval, it, NULL);
+        ossl_asn1_call_aux_cb(aux, ASN1_OP_FREE_POST, (const ASN1_VALUE **)pval, it, NULL);
         if (embed == 0) {
             OPENSSL_free(*pval);
             *pval = NULL;
@@ -91,11 +83,9 @@ void ossl_asn1_item_embed_free(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed
             *pval = NULL;
             return;
         }
-        if (asn1_cb) {
-            i = asn1_cb(ASN1_OP_FREE_PRE, pval, it, NULL);
-            if (i == 2)
-                return;
-        }
+        i = ossl_asn1_call_aux_cb(aux, ASN1_OP_FREE_PRE, (const ASN1_VALUE **)pval, it, NULL);
+        if (i == 2)
+            return;
         ossl_asn1_enc_free(pval, it);
         /*
          * If we free up as normal we will invalidate any ANY DEFINED BY
@@ -113,8 +103,7 @@ void ossl_asn1_item_embed_free(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed
             pseqval = ossl_asn1_get_field_ptr(pval, seqtt);
             ossl_asn1_template_free(pseqval, seqtt);
         }
-        if (asn1_cb)
-            asn1_cb(ASN1_OP_FREE_POST, pval, it, NULL);
+        ossl_asn1_call_aux_cb(aux, ASN1_OP_FREE_POST, (const ASN1_VALUE **)pval, it, NULL);
         if (embed == 0) {
             OPENSSL_free(*pval);
             *pval = NULL;

--- a/crypto/asn1/tasn_new.c
+++ b/crypto/asn1/tasn_new.c
@@ -62,13 +62,8 @@ int asn1_item_embed_new(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed,
     const ASN1_TEMPLATE *tt = NULL;
     const ASN1_EXTERN_FUNCS *ef;
     const ASN1_AUX *aux = it->funcs;
-    ASN1_aux_cb *asn1_cb;
     ASN1_VALUE **pseqval;
     int i;
-    if (aux && aux->asn1_cb)
-        asn1_cb = aux->asn1_cb;
-    else
-        asn1_cb = 0;
 
     switch (it->itype) {
 
@@ -99,14 +94,11 @@ int asn1_item_embed_new(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed,
         break;
 
     case ASN1_ITYPE_CHOICE:
-        if (asn1_cb) {
-            i = asn1_cb(ASN1_OP_NEW_PRE, pval, it, NULL);
-            if (!i)
-                goto auxerr;
-            if (i == 2) {
-                return 1;
-            }
-        }
+        i = ossl_asn1_call_aux_cb(aux, ASN1_OP_NEW_PRE, (const ASN1_VALUE **)pval, it, NULL);
+        if (!i)
+            goto auxerr;
+        if (i == 2)
+            return 1;
         if (embed) {
             memset(*pval, 0, it->size);
         } else {
@@ -115,20 +107,17 @@ int asn1_item_embed_new(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed,
                 return 0;
         }
         ossl_asn1_set_choice_selector(pval, -1, it);
-        if (asn1_cb && !asn1_cb(ASN1_OP_NEW_POST, pval, it, NULL))
+        if (!ossl_asn1_call_aux_cb(aux, ASN1_OP_NEW_POST, (const ASN1_VALUE **)pval, it, NULL))
             goto auxerr2;
         break;
 
     case ASN1_ITYPE_NDEF_SEQUENCE:
     case ASN1_ITYPE_SEQUENCE:
-        if (asn1_cb) {
-            i = asn1_cb(ASN1_OP_NEW_PRE, pval, it, NULL);
-            if (!i)
-                goto auxerr;
-            if (i == 2) {
-                return 1;
-            }
-        }
+        i = ossl_asn1_call_aux_cb(aux, ASN1_OP_NEW_PRE, (const ASN1_VALUE **)pval, it, NULL);
+        if (!i)
+            goto auxerr;
+        if (i == 2)
+            return 1;
         if (embed) {
             memset(*pval, 0, it->size);
         } else {
@@ -150,7 +139,7 @@ int asn1_item_embed_new(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed,
             if (!asn1_template_new(pseqval, tt, libctx, propq))
                 goto asn1err2;
         }
-        if (asn1_cb && !asn1_cb(ASN1_OP_NEW_POST, pval, it, NULL))
+        if (!ossl_asn1_call_aux_cb(aux, ASN1_OP_NEW_POST, (const ASN1_VALUE **)pval, it, NULL))
             goto auxerr2;
         break;
     }

--- a/crypto/cms/cms_kari.c
+++ b/crypto/cms/cms_kari.c
@@ -238,9 +238,7 @@ err:
     if (!rv)
         OPENSSL_free(out);
     EVP_CIPHER_CTX_reset(kari->ctx);
-    /* FIXME: WHY IS kari->pctx freed here?  /RL */
-    EVP_PKEY_CTX_free(kari->pctx);
-    kari->pctx = NULL;
+    /* FIXME: kari->pctx is managed by CMS_KeyAgreeRecipientInfo ASN1 callback */
     return rv;
 }
 

--- a/crypto/comp/c_brotli.c
+++ b/crypto/comp/c_brotli.c
@@ -413,12 +413,10 @@ static long bio_brotli_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp);
 static const BIO_METHOD bio_meth_brotli = {
     BIO_TYPE_COMP,
     "brotli",
-    /* TODO: Convert to new style write function */
-    bwrite_conv,
     bio_brotli_write,
-    /* TODO: Convert to new style read function */
-    bread_conv,
+    NULL,
     bio_brotli_read,
+    NULL,
     NULL, /* bio_brotli_puts, */
     NULL, /* bio_brotli_gets, */
     bio_brotli_ctrl,
@@ -497,23 +495,21 @@ static int bio_brotli_free(BIO *bi)
     return 1;
 }
 
-static int bio_brotli_read(BIO *b, char *out, int outl)
+static int bio_brotli_read(BIO *b, char *out, size_t outl, size_t *readbytes)
 {
     BIO_BROTLI_CTX *ctx;
     BrotliDecoderResult bret;
     int ret;
     BIO *next = BIO_next(b);
 
-    if (out == NULL || outl <= 0) {
+    if (out == NULL || readbytes == NULL) {
         ERR_raise(ERR_LIB_COMP, ERR_R_PASSED_INVALID_ARGUMENT);
+        return -1;
+    }
+    if (outl == 0) {
+        *readbytes = 0;
         return 0;
     }
-#if INT_MAX > SIZE_MAX
-    if ((unsigned int)outl > SIZE_MAX) {
-        ERR_raise(ERR_LIB_COMP, ERR_R_PASSED_INVALID_ARGUMENT);
-        return 0;
-    }
-#endif
 
     ctx = BIO_get_data(b);
     BIO_clear_retry_flags(b);
@@ -529,7 +525,7 @@ static int bio_brotli_read(BIO *b, char *out, int outl)
 
     /* Copy output data directly to supplied buffer */
     ctx->decode.next_out = (unsigned char *)out;
-    ctx->decode.avail_out = (size_t)outl;
+    ctx->decode.avail_out = outl;
     for (;;) {
         /* Decompress while data available */
         while (ctx->decode.avail_in > 0 || BrotliDecoderHasMoreOutput(ctx->decode.state)) {
@@ -541,13 +537,17 @@ static int bio_brotli_read(BIO *b, char *out, int outl)
                 return 0;
             }
             /* If EOF or we've read everything then return */
-            if (BrotliDecoderIsFinished(ctx->decode.state) || ctx->decode.avail_out == 0)
-                return (int)(outl - ctx->decode.avail_out);
+            if (BrotliDecoderIsFinished(ctx->decode.state) || ctx->decode.avail_out == 0) {
+                *readbytes = outl - ctx->decode.avail_out;
+                return 1;
+            }
         }
 
         /* If EOF */
-        if (BrotliDecoderIsFinished(ctx->decode.state))
+        if (BrotliDecoderIsFinished(ctx->decode.state)) {
+            *readbytes = 0;
             return 0;
+        }
 
         /*
          * No data in input buffer try to read some in, if an error then
@@ -556,45 +556,46 @@ static int bio_brotli_read(BIO *b, char *out, int outl)
         ret = BIO_read(next, ctx->decode.buf, (int)ctx->decode.bufsize);
         if (ret <= 0) {
             /* Total data read */
-            int tot = outl - (int)ctx->decode.avail_out;
+            size_t tot = outl - ctx->decode.avail_out;
 
             BIO_copy_next_retry(b);
-            if (ret < 0)
-                return (tot > 0) ? tot : ret;
-            return tot;
+            if (ret < 0) {
+                *readbytes = tot;
+                return (tot > 0) ? 1 : ret;
+            }
+            *readbytes = tot;
+            return (tot > 0) ? 1 : 0;
         }
         ctx->decode.avail_in = ret;
         ctx->decode.next_in = ctx->decode.buf;
     }
 }
 
-static int bio_brotli_write(BIO *b, const char *in, int inl)
+static int bio_brotli_write(BIO *b, const char *in, size_t inl, size_t *written)
 {
     BIO_BROTLI_CTX *ctx;
     BROTLI_BOOL brret;
     int ret;
     BIO *next = BIO_next(b);
 
-    if (in == NULL || inl <= 0) {
-        ERR_raise(ERR_LIB_COMP, ERR_R_PASSED_INVALID_ARGUMENT);
+    if (in == NULL || written == NULL || inl == 0) {
+        if (written != NULL)
+            *written = 0;
         return 0;
     }
-#if INT_MAX > SIZE_MAX
-    if ((unsigned int)inl > SIZE_MAX) {
-        ERR_raise(ERR_LIB_COMP, ERR_R_PASSED_INVALID_ARGUMENT);
-        return 0;
-    }
-#endif
 
     ctx = BIO_get_data(b);
-    if (ctx->encode.done)
+    if (ctx->encode.done) {
+        *written = 0;
         return 0;
+    }
 
     BIO_clear_retry_flags(b);
     if (ctx->encode.buf == NULL) {
         ctx->encode.buf = OPENSSL_malloc(ctx->encode.bufsize);
         if (ctx->encode.buf == NULL) {
             ERR_raise(ERR_LIB_COMP, ERR_R_MALLOC_FAILURE);
+            *written = 0;
             return 0;
         }
         ctx->encode.ptr = ctx->encode.buf;
@@ -604,27 +605,32 @@ static int bio_brotli_write(BIO *b, const char *in, int inl)
     }
     /* Obtain input data directly from supplied buffer */
     ctx->encode.next_in = (unsigned char *)in;
-    ctx->encode.avail_in = (size_t)inl;
+    ctx->encode.avail_in = inl;
     for (;;) {
         /* If data in output buffer write it first */
         while (ctx->encode.count > 0) {
             ret = BIO_write(next, ctx->encode.ptr, (int)ctx->encode.count);
             if (ret <= 0) {
                 /* Total data written */
-                int tot = inl - (int)ctx->encode.avail_in;
+                size_t tot = inl - ctx->encode.avail_in;
 
                 BIO_copy_next_retry(b);
-                if (ret < 0)
-                    return (tot > 0) ? tot : ret;
-                return tot;
+                if (ret < 0) {
+                    *written = tot;
+                    return (tot > 0) ? 1 : ret;
+                }
+                *written = tot;
+                return 1;
             }
             ctx->encode.ptr += ret;
             ctx->encode.count -= ret;
         }
 
         /* Have we consumed all supplied data? */
-        if (ctx->encode.avail_in == 0 && !BrotliEncoderHasMoreOutput(ctx->encode.state))
-            return inl;
+        if (ctx->encode.avail_in == 0 && !BrotliEncoderHasMoreOutput(ctx->encode.state)) {
+            *written = inl;
+            return 1;
+        }
 
         /* Compress some more */
 
@@ -638,6 +644,7 @@ static int bio_brotli_write(BIO *b, const char *in, int inl)
         if (brret != BROTLI_TRUE) {
             ERR_raise(ERR_LIB_COMP, COMP_R_BROTLI_ENCODE_ERROR);
             ERR_add_error_data(1, "brotli encoder error");
+            *written = inl - ctx->encode.avail_in;
             return 0;
         }
         ctx->encode.count = ctx->encode.bufsize - ctx->encode.avail_out;

--- a/crypto/comp/c_brotli.c
+++ b/crypto/comp/c_brotli.c
@@ -402,8 +402,8 @@ typedef struct {
 
 static int bio_brotli_new(BIO *bi);
 static int bio_brotli_free(BIO *bi);
-static int bio_brotli_read(BIO *b, char *out, int outl);
-static int bio_brotli_write(BIO *b, const char *in, int inl);
+static int bio_brotli_read(BIO *b, char *out, size_t outl, size_t *readbytes);
+static int bio_brotli_write(BIO *b, const char *in, size_t inl, size_t *written);
 static long bio_brotli_ctrl(BIO *b, int cmd, long num, void *ptr);
 static long bio_brotli_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp);
 

--- a/crypto/comp/c_zstd.c
+++ b/crypto/comp/c_zstd.c
@@ -478,12 +478,10 @@ static long bio_zstd_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp);
 static const BIO_METHOD bio_meth_zstd = {
     BIO_TYPE_COMP,
     "zstd",
-    /* TODO: Convert to new style write function */
-    bwrite_conv,
     bio_zstd_write,
-    /* TODO: Convert to new style read function */
-    bread_conv,
+    NULL,
     bio_zstd_read,
+    NULL,
     NULL, /* bio_zstd_puts, */
     NULL, /* bio_zstd_gets, */
     bio_zstd_ctrl,
@@ -573,7 +571,7 @@ static int bio_zstd_free(BIO *bi)
     return 1;
 }
 
-static int bio_zstd_read(BIO *b, char *out, int outl)
+static int bio_zstd_read(BIO *b, char *out, size_t outl, size_t *readbytes)
 {
     BIO_ZSTD_CTX *ctx;
     size_t zret;
@@ -581,12 +579,14 @@ static int bio_zstd_read(BIO *b, char *out, int outl)
     ZSTD_outBuffer outBuf;
     BIO *next = BIO_next(b);
 
-    if (out == NULL) {
+    if (out == NULL || readbytes == NULL) {
         ERR_raise(ERR_LIB_COMP, ERR_R_PASSED_NULL_PARAMETER);
         return -1;
     }
-    if (outl <= 0)
+    if (outl == 0) {
+        *readbytes = 0;
         return 0;
+    }
 
     ctx = BIO_get_data(b);
     BIO_clear_retry_flags(b);
@@ -603,7 +603,7 @@ static int bio_zstd_read(BIO *b, char *out, int outl)
 
     /* Copy output data directly to supplied buffer */
     outBuf.dst = out;
-    outBuf.size = (size_t)outl;
+    outBuf.size = outl;
     outBuf.pos = 0;
     for (;;) {
         /* Decompress while data available */
@@ -615,8 +615,10 @@ static int bio_zstd_read(BIO *b, char *out, int outl)
                 return -1;
             }
             /* No more output space */
-            if (outBuf.pos == outBuf.size)
-                return (int)outBuf.pos;
+            if (outBuf.pos == outBuf.size) {
+                *readbytes = outBuf.pos;
+                return 1;
+            }
         } while (ctx->decompress.inbuf.pos < ctx->decompress.inbuf.size);
 
         /*
@@ -628,14 +630,15 @@ static int bio_zstd_read(BIO *b, char *out, int outl)
             BIO_copy_next_retry(b);
             if (ret < 0 && outBuf.pos == 0)
                 return ret;
-            return (int)outBuf.pos;
+            *readbytes = outBuf.pos;
+            return (outBuf.pos == 0) ? 0 : 1;
         }
         ctx->decompress.inbuf.size = ret;
         ctx->decompress.inbuf.pos = 0;
     }
 }
 
-static int bio_zstd_write(BIO *b, const char *in, int inl)
+static int bio_zstd_write(BIO *b, const char *in, size_t inl, size_t *written)
 {
     BIO_ZSTD_CTX *ctx;
     size_t zret;
@@ -644,8 +647,11 @@ static int bio_zstd_write(BIO *b, const char *in, int inl)
     int done = 0;
     BIO *next = BIO_next(b);
 
-    if (in == NULL || inl <= 0)
+    if (in == NULL || written == NULL || inl == 0) {
+        if (written != NULL)
+            *written = 0;
         return 0;
+    }
 
     ctx = BIO_get_data(b);
 
@@ -654,6 +660,7 @@ static int bio_zstd_write(BIO *b, const char *in, int inl)
         ctx->compress.outbuf.dst = OPENSSL_malloc(ctx->compress.bufsize);
         if (ctx->compress.outbuf.dst == NULL) {
             ERR_raise(ERR_LIB_COMP, ERR_R_MALLOC_FAILURE);
+            *written = 0;
             return 0;
         }
         ctx->compress.outbuf.size = ctx->compress.bufsize;
@@ -671,16 +678,21 @@ static int bio_zstd_write(BIO *b, const char *in, int inl)
                 (int)(ctx->compress.outbuf.pos - ctx->compress.write_pos));
             if (ret <= 0) {
                 BIO_copy_next_retry(b);
-                if (ret < 0 && inBuf.pos == 0)
+                if (ret < 0 && inBuf.pos == 0) {
+                    *written = 0;
                     return ret;
-                return (int)inBuf.pos;
+                }
+                *written = inBuf.pos;
+                return 1;
             }
             ctx->compress.write_pos += ret;
         }
 
         /* Have we consumed all supplied data? */
-        if (done)
-            return (int)inBuf.pos;
+        if (done) {
+            *written = inBuf.pos;
+            return 1;
+        }
 
         /* Reset buffer */
         ctx->compress.outbuf.pos = 0;
@@ -691,6 +703,7 @@ static int bio_zstd_write(BIO *b, const char *in, int inl)
         if (ZSTD_isError(zret)) {
             ERR_raise(ERR_LIB_COMP, COMP_R_ZSTD_COMPRESS_ERROR);
             ERR_add_error_data(1, ZSTD_getErrorName(zret));
+            *written = inBuf.pos;
             return 0;
         } else if (zret == 0) {
             done = 1;

--- a/crypto/comp/c_zstd.c
+++ b/crypto/comp/c_zstd.c
@@ -461,8 +461,8 @@ typedef struct {
 
 static int bio_zstd_new(BIO *bi);
 static int bio_zstd_free(BIO *bi);
-static int bio_zstd_read(BIO *b, char *out, int outl);
-static int bio_zstd_write(BIO *b, const char *in, int inl);
+static int bio_zstd_read(BIO *b, char *out, size_t outl, size_t *readbytes);
+static int bio_zstd_write(BIO *b, const char *in, size_t inl, size_t *written);
 static long bio_zstd_ctrl(BIO *b, int cmd, long num, void *ptr);
 static long bio_zstd_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp);
 

--- a/include/internal/threads_common.h
+++ b/include/internal/threads_common.h
@@ -81,7 +81,7 @@ void CRYPTO_THREAD_clean_local(void);
 #endif
 
 #if defined(__GNUC__) && defined(__ATOMIC_ACQUIRE) && !defined(BROKEN_CLANG_ATOMICS) \
-    && !defined(USE_ATOMIC_FALLBACKS)
+    && !defined(OSSL_USE_ATOMIC_FALLBACKS)
 #define OSSL_USE_GCC_ATOMICS
 #elif defined(__sun) && (defined(__SunOS_5_10) || defined(__SunOS_5_11))
 #define OSSL_USE_SOLARIS_ATOMICS

--- a/ssl/quic/quic_stream_map.c
+++ b/ssl/quic/quic_stream_map.c
@@ -299,7 +299,11 @@ static ossl_unused int qsm_send_part_permits_gc(const QUIC_STREAM *qs)
 
 static int qsm_ready_for_gc(QUIC_STREAM_MAP *qsm, QUIC_STREAM *qs)
 {
-    int recv_stream_fully_drained = 0; /* TODO(QUIC FUTURE): Optimisation */
+    int recv_stream_fully_drained =
+        qs->recv_state == QUIC_RSTREAM_STATE_DATA_RECVD
+        || qs->recv_state == QUIC_RSTREAM_STATE_DATA_READ
+        || qs->recv_state == QUIC_RSTREAM_STATE_RESET_RECVD
+        || qs->recv_state == QUIC_RSTREAM_STATE_RESET_READ;
 
     /*
      * If sstream has no FIN, we auto-reset it at marked-for-deletion time, so


### PR DESCRIPTION
## ASN1 aux callback dispatch consolidation
Follow up to `asn1: centralize aux const-callback dispatch to avoid function pointer cast`.

Extend `ossl_asn1_call_aux_cb()` to `tasn_new.c`, `tasn_fre.c`, `tasn_dec.c`, and `a_dup.c`, replacing the old inline `asn1_cb` dispatch pattern in all four files. Removes ~30 lines of duplicated conditional dispatch and four `ASN1_aux_cb` local variable declarations.

## Compression BIO: migrate to new-style read/write API
Convert `c_brotli.c` and `c_zstd.c` from the old `int`-based BIO read/write interface (`int (*read)(BIO*, char*, int)`) to the new `size_t`-based interface (`int (*read)(BIO*, char*, size_t, size_t*)`). Removes the `bwrite_conv`/`bread_conv` wrapper indirection and related INT_MAX size checks.

## QUIC stream map GC optimization
In `quic_stream_map.c`, populate `recv_stream_fully_drained` with actual stream state checks instead of the TODO placeholder of always 0, enabling garbage collection of fully-received streams.

## CMS key agreement fix
Don't free `kari->pctx` in the error path of `cms_kari.c` — it is managed by the CMS_KeyAgreeRecipientInfo ASN1 callback, not owned by this function.

## Build config
Ignore `build*/` directories in `.gitignore` for out-of-tree builds.

## Macro naming consistency
Fix `USE_ATOMIC_FALLBACKS` → `OSSL_USE_ATOMIC_FALLBACKS` in `threads_common.h` for consistency with other `OSSL_USE_*` macros.

## Files changed
- `.gitignore`
- `crypto/asn1/a_dup.c`
- `crypto/asn1/tasn_dec.c`
- `crypto/asn1/tasn_fre.c`
- `crypto/asn1/tasn_new.c`
- `crypto/cms/cms_kari.c`
- `crypto/comp/c_brotli.c`
- `crypto/comp/c_zstd.c`
- `include/internal/threads_common.h`
- `ssl/quic/quic_stream_map.c`

---

Note: This fork will continue to be updated and follow the main codebase to ensure full merge compatibility at all times.