### PR TITLE
Fix unqualified reference to openssl in 25-test_verify_store.t

### DIFF
--- a/test/recipes/25-test_verify_store.t
+++ b/test/recipes/25-test_verify_store.t
@@ -73,7 +73,7 @@ SKIP: {
                 $CAcert );
 
     open(my $out, '>', $CAobjects) or die $!;
-    my $pubkey = qx(openssl x509 -pubkey -noout -in $CAcert);
+    my $pubkey = run(app(["openssl", "x509", "-pubkey", "-noout", "-in", $CAcert]));
     print $out $pubkey;
     my @files;
     push @files, srctop_file("test", "certs", "dhp2048.pem")


### PR DESCRIPTION
This problem resulted in the wrong location of openssl being used for one step in subtest 7. The error condition is hidden if openssl appears in the PATH.

Fixes: #31496
