### PR TITLE
apps: cover the pkcs8 -inform/-outform DER options

### DIFF
--- a/test/recipes/25-test_pkcs8.t
+++ b/test/recipes/25-test_pkcs8.t
@@ -16,7 +16,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file ok_nofips is_nofips/;
 
 setup("test_pkcs8");
 
-plan tests => 18;
+plan tests => 19;
 
 my $pc5_key = srctop_file('test', 'certs', 'pc5-key.pem');
 
@@ -127,6 +127,38 @@ ok(run(app(([ 'openssl', 'asn1parse',
               '-offset', '34', '-length', '10']))),
    "Check the size of the PBKDF2 PARAM 'salt length' is 8");
 
+
+subtest 'PKCS#8 DER inform/outform round trip' => sub {
+    plan tests => 6;
+
+    # PEM -> DER, unencrypted PKCS#8 (exercises -outform DER)
+    ok(run(app(['openssl', 'pkcs8', '-topk8', '-nocrypt',
+                '-in', $pc5_key, '-outform', 'DER',
+                '-out', 'p8-nocrypt.der'])),
+       "write unencrypted PKCS#8 in DER form");
+    # DER -> PEM (exercises -inform DER)
+    ok(run(app(['openssl', 'pkcs8', '-nocrypt',
+                '-inform', 'DER', '-in', 'p8-nocrypt.der',
+                '-out', 'p8-roundtrip.pem'])),
+       "read unencrypted PKCS#8 from DER form");
+    # PEM -> DER again, the result must match the original DER output
+    ok(run(app(['openssl', 'pkcs8', '-topk8', '-nocrypt',
+                '-in', 'p8-roundtrip.pem', '-outform', 'DER',
+                '-out', 'p8-roundtrip.der'])),
+       "re-encode the round-tripped key to DER");
+    is(compare('p8-nocrypt.der', 'p8-roundtrip.der'), 0,
+       "DER output is identical after a PEM/DER round trip");
+
+    # The same for an encrypted PKCS#8 structure
+    ok(run(app(['openssl', 'pkcs8', '-topk8',
+                '-in', $pc5_key, '-outform', 'DER',
+                '-out', 'p8-enc.der', '-passout', 'pass:password'])),
+       "write encrypted PKCS#8 in DER form");
+    ok(run(app(['openssl', 'pkcs8',
+                '-inform', 'DER', '-in', 'p8-enc.der',
+                '-out', 'p8-dec.pem', '-passin', 'pass:password'])),
+       "read encrypted PKCS#8 from DER form");
+};
 
 SKIP: {
     skip "SM2, SM3 or SM4 is not supported by this OpenSSL build", 3


### PR DESCRIPTION
Only PEM input/output was exercised.  Add a subtest that round trips a key through DER, for both unencrypted and encrypted PKCS#8.

Assisted-by: Claude:claude-opus-4-8
