### PR TITLE
`crypto/ctype.c`: fix off-by-one OOB in `ossl_toascii()`/`ossl_fromascii()`

### DIFF
--- a/crypto/ctype.c
+++ b/crypto/ctype.c
@@ -226,7 +226,7 @@ static const unsigned short ctype_char_map[128] = {
 #ifdef CHARSET_EBCDIC
 int ossl_toascii(int c)
 {
-    if (c < -128 || c > 256 || c == EOF)
+    if (c < -128 || c >= 256 || c == EOF)
         return c;
     /*
      * Adjust negatively signed characters.
@@ -241,7 +241,7 @@ int ossl_toascii(int c)
 
 int ossl_fromascii(int c)
 {
-    if (c < -128 || c > 256 || c == EOF)
+    if (c < -128 || c >= 256 || c == EOF)
         return c;
     if (c < 0)
         c += 256;


### PR DESCRIPTION
Incorrect check for the upper bound allowed the value of 256 to slip through, which could lead to OOB read one element beyond the end of the `os_toascii`/`os_toebcdic` arrays.  Fix that by changing the comparison with 256 from strictly great to great-or-equal.

Found by cppcheck.

Fixes: a1df06b36347 "This has been added to avoid the situation where some host ctype.h functions return true for characters > 127.  I.e. they are allowing extended ASCII characters through which then cause problems.  E.g. marking superscript '2' as a number then causes the common (ch - '0') conversion to number to fail miserably.  Likewise letters with diacritical marks can also cause problems."
