### PR TITLE
`include/internal/hashtable.h`: avoid OOB read in `ossl_ht_strcase()`

### DIFF
--- a/include/internal/hashtable.h
+++ b/include/internal/hashtable.h
@@ -357,7 +357,7 @@ static ossl_inline ossl_unused void ossl_ht_strcase(HT_KEY *key, char *tgt, cons
     if (key != NULL && key->keysize + len > key->bufsize)
         len = (size_t)(key->bufsize - key->keysize);
 
-    for (i = 0; src[i] != '\0' && i < len; i++)
+    for (i = 0; i < len && src[i] != '\0'; i++)
         tgt[i] = case_adjust & src[i];
 }
 


### PR DESCRIPTION
Avoid accessing `src[len]` by swapping the check order and bound check the iterator variable before the access.

Found by cppcheck.

Fixes: cc4ea5e00028 "Introduce new internal hashtable implementation"