### PR TITLE
`test/asn1_string_test.c`: allocate `tmpstring` properly in `asn1_string_new_not_owned_test`

### DIFF
--- a/test/asn1_string_test.c
+++ b/test/asn1_string_test.c
@@ -428,7 +428,7 @@ asn1_string_new_not_owned_test(void)
     if (!TEST_ptr(tmp = ASN1_STRING_new_not_owned(V_ASN1_OCTET_STRING, data, sizeof(data))))
         goto err;
 
-    if (!TEST_ptr(tmpstring = strdup("puppet")))
+    if (!TEST_ptr(tmpstring = OPENSSL_strdup("puppet")))
         goto err;
 
     ASN1_STRING_set0(tmp, tmpstring, 4);
@@ -450,8 +450,8 @@ asn1_string_new_not_owned_test(void)
     if (!TEST_mem_eq(tmpstring, strlen("puppet"), "zzzzet", strlen("puppet")))
         goto err;
 
-    ASN1_STRING_clear_free(tmp);
     tmpstring = NULL;
+    ASN1_STRING_clear_free(tmp);
     tmp = NULL;
 
     if (!TEST_ptr_null(tmp = ASN1_STRING_new_not_owned(V_ASN1_BIT_STRING, data, sizeof(data))))
@@ -470,7 +470,6 @@ asn1_string_new_not_owned_test(void)
 
 err:
     ASN1_STRING_clear_free(tmp);
-    free(tmpstring);
 
     return success;
 }


### PR DESCRIPTION
Since `tmpstring`'s ownership is transferred to `tmp` in `ASN1_STRING_set0()`, it should be allocated using `OPENSSL_strdup()` and not `strdup()` (as it will be freed with `OPENSSL_free()` in `ASN1_STRING_clear_free()`). Also, don't try to free `tmpstring` on error, as at no point there is a jump to err when `tmpstring` is allocated and not owned by `tmp`.

Reported by Coverity, issue 1695274.

Resolves: https://scan5.scan.coverity.com/#/project-view/65248/10222?selectedIssue=1695274
Fixes: 68c0321e90d0 "Provide ASN1_STRING_new_not_owned()"