### PR TITLE
apps: cover the smime multiple -signer parsing path

### DIFF
--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -121,6 +121,16 @@ my @smime_pkcs7_tests = (
       \&final_compare
     ],
 
+    [ "signed content DER format, two RSA signers with explicit -inkey",
+      [ "{cmd1}", @prov, "-sign", "-in", $smcont, "-outform", "DER", "-nodetach",
+        "-signer", catfile($smdir, "smrsa3-cert.pem"),
+        "-inkey", catfile($smdir, "smrsa3-key.pem"),
+        "-signer", $smrsa1, "-out", "{output}.cms" ],
+      [ "{cmd2}", @prov, "-verify", "-in", "{output}.cms", "-inform", "DER",
+        "-CAfile", $smroot, "-out", "{output}.txt" ],
+      \&final_compare
+    ],
+
     [ "signed content DER format, DSA key",
       [ "{cmd1}", @prov, "-sign", "-in", $smcont, "-outform", "DER", "-nodetach",
         "-signer", catfile($smdir, "smdsa1.pem"), "-out", "{output}.cms" ],


### PR DESCRIPTION
The signerfile != NULL block in smime_main(), reached when more than one -signer is given (including the case where a preceding -inkey leaves keyfile != NULL), was not exercised: the existing multi-signer tests run through the cms command, and the smime app was only ever run with a single signer.  Added a two-signer test, with an explicit -inkey, to the pkcs7 test set so it runs through smime when signing.

Assisted-by: Claude:claude-opus-4-8