### PR TITLE
Fix/x509 policy nc leaks

### DIFF
--- a/crypto/x509/pcy_cache.c
+++ b/crypto/x509/pcy_cache.c
@@ -134,6 +134,7 @@ static int policy_cache_new(X509 *x)
         /* If not absent some problem with extension */
         if (i != -1)
             goto bad_cache;
+        POLICY_CONSTRAINTS_free(ext_pcons);
         return 1;
     }
 
@@ -141,8 +142,10 @@ static int policy_cache_new(X509 *x)
 
     /* NB: ext_cpols freed by policy_cache_set_policies */
 
-    if (i <= 0)
+    if (i <= 0) {
+        POLICY_CONSTRAINTS_free(ext_pcons);
         return i;
+    }
 
     ext_pmaps = X509_get_ext_d2i(x, NID_policy_mappings, &i, NULL);
 

--- a/crypto/x509/v3_ncons.c
+++ b/crypto/x509/v3_ncons.c
@@ -791,6 +791,7 @@ static int nc_uri(ASN1_IA5STRING *uri, ASN1_IA5STRING *base)
     if (scheme == NULL || *scheme == '\0') {
         ERR_raise_data(ERR_LIB_X509V3, X509_V_ERR_UNSUPPORTED_NAME_SYNTAX,
             "x509: missing scheme in URI: %s\n", uri_copy);
+        OPENSSL_free(scheme);
         OPENSSL_free(uri_copy);
         ret = X509_V_ERR_UNSUPPORTED_NAME_SYNTAX;
         goto end;


### PR DESCRIPTION
Two memory leaks in x509 certificate processing:

- pcy_cache.c: ext_pcons (POLICY_CONSTRAINTS) leaked on two early-return paths in policy_cache_new() that bypass just_cleanup

- v3_ncons.c: 1-byte scheme buffer leaked in nc_uri() when OSSL_parse_url() returns an empty scheme for schemeless URIs

Both found via ASan; reproducers verified before and after the fix.