### PR TITLE
pem: Add BN_FLG_CONSTTIME to PVK RSA private components

### DIFF
--- a/crypto/pem/pvkfmt.c
+++ b/crypto/pem/pvkfmt.c
@@ -478,6 +478,12 @@ RSA *ossl_b2i_RSA_after_header(const unsigned char **in, unsigned int bitlen,
             goto bnerr;
         if (!read_lebn(&pin, nbyte, &d))
             goto bnerr;
+        BN_set_flags(p, BN_FLG_CONSTTIME);
+        BN_set_flags(q, BN_FLG_CONSTTIME);
+        BN_set_flags(dmp1, BN_FLG_CONSTTIME);
+        BN_set_flags(dmq1, BN_FLG_CONSTTIME);
+        BN_set_flags(iqmp, BN_FLG_CONSTTIME);
+        BN_set_flags(d, BN_FLG_CONSTTIME);
         if (!RSA_set0_factors(rsa, p, q))
             goto rsaerr;
         p = q = NULL;


### PR DESCRIPTION
When importing RSA private keys from PVK format, ensure that all private components (d, p, q, dmp1, dmq1, iqmp) have BN_FLG_CONSTTIME flag set to protect against cache-timing side-channel attacks during BN_mod_exp operations.

This is a defense-in-depth measure for legacy PVK imports.

Assisted-by: OpenCode:DeepSeek-V4-flesh-free

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
