### PR TITLE
bn: Add BN_FLG_CONSTTIME to Miller-Rabin operands

### DIFF
--- a/crypto/bn/bn_prime.c
+++ b/crypto/bn/bn_prime.c
@@ -412,8 +412,14 @@ int ossl_bn_miller_rabin_is_prime(const BIGNUM *w, int iterations, BN_CTX *ctx,
             }
         }
         /* (Step 4.5) z = b^m mod w */
-        if (!BN_mod_exp_mont(z, b, m, w, ctx, mont))
-            goto err;
+        {
+            BIGNUM local_w;
+            BN_set_flags(b, BN_FLG_CONSTTIME);
+            BN_set_flags(m, BN_FLG_CONSTTIME);
+            BN_with_flags(&local_w, w, BN_FLG_CONSTTIME);
+            if (!BN_mod_exp_mont(z, b, m, &local_w, ctx, mont))
+                goto err;
+        }
         /* (Step 4.6) if (z = 1 or z = w-1) */
         if (BN_is_one(z) || BN_cmp(z, w1) == 0)
             goto outer_loop;


### PR DESCRIPTION
Ensure that the witness (b), exponent (m), and modulus (w) used in the Miller-Rabin primality test have BN_FLG_CONSTTIME set before calling BN_mod_exp_mont. This prevents cache-timing side-channel leakage during RSA key generation.

The modulus w is const, so use BN_with_flags to create a local alias with the CONSTTIME flag.

Assisted-by: OpenCode:DeepSeek-V4-flesh-free

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
