### PR TITLE
25-test_verify_store.t: Add missing capture for bare run()

### DIFF
--- a/test/recipes/25-test_verify_store.t
+++ b/test/recipes/25-test_verify_store.t
@@ -72,9 +72,11 @@ SKIP: {
                 -CAstore => $CAcert,
                 $CAcert );
 
+    # Put a pubkey and DH params to the store to test
+    # that other things in the store are just ignored
     open(my $out, '>', $CAobjects) or die $!;
-    my $pubkey = run(app(["openssl", "x509", "-pubkey", "-noout", "-in", $CAcert]));
-    print $out $pubkey;
+    my @pubkey = run(app([qw(openssl x509 -pubkey -noout -in), $CAcert]), capture => 1);
+    print $out @pubkey;
     my @files;
     push @files, srctop_file("test", "certs", "dhp2048.pem")
         unless disabled("dh");


### PR DESCRIPTION
We want to add the printed out pubkey and not
just 1.

Fixes 77c979faf47b
