### PR TITLE
file_store_any2obj.c: validate bitlen before allocating MSBLOB buffer

### DIFF
--- a/providers/implementations/storemgmt/file_store_any2obj.c
+++ b/providers/implementations/storemgmt/file_store_any2obj.c
@@ -193,6 +193,11 @@ static int msblob2obj_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
 
     ok = 0;
     mem_want = ossl_blob_length(bitlen, isdss, ispub);
+
+    if (mem_want > BLOB_MAX_LENGTH) {
+        ERR_raise(ERR_LIB_PEM, PEM_R_HEADER_TOO_LONG);
+        goto next;
+    }
     if (!BUF_MEM_grow(mem, mem_len + mem_want)) {
         ERR_raise(ERR_LIB_PEM, ERR_R_BUF_LIB);
         goto err;
@@ -261,6 +266,10 @@ static int pvk2obj_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
 
     ok = 0;
     mem_want = saltlen + keylen;
+    if (mem_want > BLOB_MAX_LENGTH) {
+        ERR_raise(ERR_LIB_PEM, PEM_R_HEADER_TOO_LONG);
+        goto next;
+    }
     if (!BUF_MEM_grow(mem, mem_len + mem_want)) {
         ERR_raise(ERR_LIB_PEM, ERR_R_BUF_LIB);
         goto err;

--- a/providers/implementations/storemgmt/file_store_any2obj.c
+++ b/providers/implementations/storemgmt/file_store_any2obj.c
@@ -194,11 +194,9 @@ static int msblob2obj_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
     ok = 0;
     mem_want = ossl_blob_length(bitlen, isdss, ispub);
 
-    if (bitlen > BLOB_MAX_LENGTH) {
-        ERR_raise(ERR_LIB_PEM, PEM_R_HEADER_TOO_LONG);
-        goto err;
+    if (mem_want > BLOB_MAX_LENGTH) {
+        goto next;
     }
-
     if (!BUF_MEM_grow(mem, mem_len + mem_want)) {
         ERR_raise(ERR_LIB_PEM, ERR_R_BUF_LIB);
         goto err;


### PR DESCRIPTION
`msblob2obj_decode()` did not check `bitlen` before passing it to ossl_blob_length(), allowing a malformed MSBLOB header to trigger an oversized allocation. Add a bounds check against BLOB_MAX_LENGTH and raise PEM_R_HEADER_TOO_LONG on violation.

Resolves #31684

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
