### PR TITLE
Remove QUIC_TSERVER: Move script_5 to script_9

### DIFF
--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2063,16 +2063,7 @@ static const struct script_op script_8[] = {
 
 /* 9. Unidirectional default stream mode test (server sends first on bidi) */
 static const struct script_op script_9[] = {
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-
-    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_AUTO_UNI),
-    OP_S_NEW_STREAM_BIDI(a, S_BIDI_ID(0)),
-    OP_S_WRITE(a, "apple", 5),
-    OP_C_READ_EXPECT(DEFAULT, "apple", 5),
-    OP_C_WRITE(DEFAULT, "orange", 6),
-    OP_S_READ_EXPECT(a, "orange", 6),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2051,16 +2051,7 @@ static const struct script_op script_6[] = {
 
 /* 7. Unidirectional default stream mode test (client sends first) */
 static const struct script_op script_7[] = {
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-
-    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_AUTO_UNI),
-    OP_C_WRITE(DEFAULT, "apple", 5),
-
-    OP_S_BIND_STREAM_ID(a, C_UNI_ID(0)),
-    OP_S_READ_EXPECT(a, "apple", 5),
-    OP_S_WRITE_FAIL(a),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -373,18 +373,6 @@ static void s_unlock(struct helper *h, struct helper_local *hl);
 #define ACQUIRE_S() s_lock(h, hl)
 #define ACQUIRE_S_NOHL() s_lock(h, NULL)
 
-static int check_stream_stopped(struct helper *h, struct helper_local *hl)
-{
-    uint64_t stream_id = hl->check_op->arg2;
-
-    if (!ossl_quic_tserver_stream_has_peer_stop_sending(ACQUIRE_S(), stream_id, NULL)) {
-        h->check_spin_again = 1;
-        return 0;
-    }
-
-    return 1;
-}
-
 static int override_key_update(struct helper *h, struct helper_local *hl)
 {
     QUIC_CHANNEL *ch = ossl_quic_conn_get_channel(h->c_conn);
@@ -2057,19 +2045,7 @@ static const struct script_op script_5[] = {
 
 /* 6. Test STOP_SENDING functionality */
 static const struct script_op script_6[] = {
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-
-    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_NONE),
-    OP_S_NEW_STREAM_BIDI(a, S_BIDI_ID(0)),
-    OP_S_WRITE(a, "apple", 5),
-
-    OP_C_ACCEPT_STREAM_WAIT(a),
-    OP_C_FREE_STREAM(a),
-    OP_C_ACCEPT_STREAM_NONE(),
-
-    OP_CHECK(check_stream_stopped, S_BIDI_ID(0)),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -373,18 +373,6 @@ static void s_unlock(struct helper *h, struct helper_local *hl);
 #define ACQUIRE_S() s_lock(h, hl)
 #define ACQUIRE_S_NOHL() s_lock(h, NULL)
 
-static int check_stream_reset(struct helper *h, struct helper_local *hl)
-{
-    uint64_t stream_id = hl->check_op->arg2, aec = 0;
-
-    if (!ossl_quic_tserver_stream_has_peer_reset_stream(ACQUIRE_S(), stream_id, &aec)) {
-        h->check_spin_again = 1;
-        return 0;
-    }
-
-    return TEST_uint64_t_eq(aec, 42);
-}
-
 static int check_stream_stopped(struct helper *h, struct helper_local *hl)
 {
     uint64_t stream_id = hl->check_op->arg2;
@@ -2063,25 +2051,7 @@ static const struct script_op script_4[] = {
 
 /* 5. Test stream reset functionality */
 static const struct script_op script_5[] = {
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-
-    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_NONE),
-    OP_C_NEW_STREAM_BIDI(a, C_BIDI_ID(0)),
-    OP_C_NEW_STREAM_BIDI(b, C_BIDI_ID(1)),
-
-    OP_C_WRITE(a, "apple", 5),
-    OP_C_STREAM_RESET(a, 42),
-
-    OP_C_WRITE(b, "strawberry", 10),
-
-    OP_S_BIND_STREAM_ID(a, C_BIDI_ID(0)),
-    OP_S_BIND_STREAM_ID(b, C_BIDI_ID(1)),
-    OP_S_READ_EXPECT(b, "strawberry", 10),
-    /* Reset disrupts read of already sent data */
-    OP_S_READ_FAIL(a, 0),
-    OP_CHECK(check_stream_reset, C_BIDI_ID(0)),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2057,15 +2057,7 @@ static const struct script_op script_7[] = {
 
 /* 8. Unidirectional default stream mode test (server sends first) */
 static const struct script_op script_8[] = {
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-
-    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_AUTO_UNI),
-    OP_S_NEW_STREAM_UNI(a, S_UNI_ID(0)),
-    OP_S_WRITE(a, "apple", 5),
-    OP_C_READ_EXPECT(DEFAULT, "apple", 5),
-    OP_C_WRITE_FAIL(DEFAULT),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/radix/quic_ops.c
+++ b/test/radix/quic_ops.c
@@ -1079,9 +1079,9 @@ err:
         OP_FUNC(hf_read_fail))
 
 #define OP_READ_FAIL_WAIT(name) \
-    (OP_SELECT_SSL(0, name),                                    \
-     OP_PUSH_U64(1),                                            \
-     OP_FUNC(hf_read_fail)
+    (OP_SELECT_SSL(0, name),    \
+        OP_PUSH_U64(1),         \
+        OP_FUNC(hf_read_fail))
 
 #define OP_POP_ERR() \
     OP_FUNC(hf_pop_err)

--- a/test/radix/quic_ops.c
+++ b/test/radix/quic_ops.c
@@ -1099,7 +1099,7 @@ err:
 
 #define OP_STREAM_RESET(name, error_code) \
     (OP_SELECT_SSL(0, name),              \
-        OP_PUSH_U64(flags),               \
+        OP_PUSH_PZ(#name),                \
         OP_PUSH_U64(error_code),          \
         OP_FUNC(hf_stream_reset))
 

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -827,8 +827,36 @@ DEF_SCRIPT(script_5, "Test stream reset functionality")
     OP_READ_EXPECT(Sb, "strawberry", 10);
 }
 
-DEF_SCRIPT(script_6, "place holder for multistram script_6")
+DEF_FUNC(check_stream_stopped_6)
 {
+    int ok = 0;
+    SSL *ssl;
+
+    REQUIRE_SSL(ssl);
+
+    if (SSL_get_stream_write_state(ssl) != SSL_STREAM_STATE_RESET_LOCAL)
+        F_SPIN_AGAIN();
+
+    ok = 1;
+err:
+    return ok;
+}
+
+/* 6. Test STOP_SENDING functionality */
+DEF_SCRIPT(script_6, "Test STOP_SENDING functionality")
+{
+    OP_SIMPLE_PAIR_CONN_ND();
+    OP_ACCEPT_CONN_WAIT_ND(L, S, 0);
+
+    OP_NEW_STREAM(S, Sa, 0 /* bidirectional */);
+    OP_WRITE(Sa, "apple", 5);
+
+    OP_ACCEPT_STREAM_WAIT(C, Ca, 0);
+    OP_UNBIND(Ca);
+    OP_ACCEPT_STREAM_NONE(C, 0);
+
+    OP_SELECT_SSL(0, Sa);
+    OP_FUNC(check_stream_stopped_6);
 }
 
 DEF_SCRIPT(script_7, "place holder for multistrem script_7")

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -871,8 +871,18 @@ DEF_SCRIPT(script_7, "Unidirectional default stream mode (client sends first)")
     OP_WRITE_FAIL(S);
 }
 
-DEF_SCRIPT(script_8, "place holder for multistrem script_8")
+/* 8. Unidirectional default stream mode test (server sends first) */
+DEF_SCRIPT(script_8, "Unidirectional default stream mode (server sends first)")
 {
+    OP_SIMPLE_PAIR_CONN();
+    OP_SET_DEFAULT_STREAM_MODE(C, SSL_DEFAULT_STREAM_MODE_AUTO_UNI);
+
+    OP_ACCEPT_CONN_WAIT(L, S, 0);
+    OP_NEW_STREAM(S, Sa, SSL_STREAM_FLAG_UNI);
+    OP_WRITE(Sa, "apple", 5);
+
+    OP_READ_EXPECT(C, "apple", 5);
+    OP_WRITE_FAIL(C);
 }
 
 DEF_SCRIPT(script_9, "place holder for multistrem script_9")

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -765,6 +765,30 @@ DEF_SCRIPT(check_ctx_cbks, "Check new_pending and client_hello callbacks")
     OP_FUNC(check_pending);
 }
 
+DEF_FUNC(check_stream_reset_5)
+{
+    int ok = 0;
+    SSL *ssl;
+    uint64_t aec = 0;
+    int state;
+
+    REQUIRE_SSL(ssl);
+
+    state = SSL_get_stream_read_state(ssl);
+    if (state != SSL_STREAM_STATE_RESET_REMOTE)
+        F_SPIN_AGAIN();
+
+    if (!TEST_true(SSL_get_stream_read_error_code(ssl, &aec)))
+        goto err;
+
+    if (!TEST_uint64_t_eq(aec, 42))
+        goto err;
+
+    ok = 1;
+err:
+    return ok;
+}
+
 /*
  * script_5 - script_106 are place holders for tests we
  * currently keep in test/quic_multistream_test.c.
@@ -778,8 +802,29 @@ DEF_SCRIPT(check_ctx_cbks, "Check new_pending and client_hello callbacks")
  * The scaffolding here hopes to avoid conflicts in 'scripts'
  * array below when more PRs will be in flight.
  */
-DEF_SCRIPT(script_5, "place holder for multistram script_5")
+
+/* 5. Test stream reset functionality */
+DEF_SCRIPT(script_5, "Test stream reset functionality")
 {
+    OP_SIMPLE_PAIR_CONN_ND();
+
+    OP_NEW_STREAM(C, Ca, 0 /* bidirectional */);
+    OP_NEW_STREAM(C, Cb, 0 /* bidirectional */);
+
+    OP_WRITE(Ca, "apple", 5);
+    OP_STREAM_RESET(Ca, 42);
+
+    OP_WRITE(Cb, "strawberry", 10);
+
+    OP_ACCEPT_CONN_WAIT_ND(L, S, 0);
+    OP_ACCEPT_STREAM_WAIT(S, Sa, 0); /* first stream = Ca */
+    OP_ACCEPT_STREAM_WAIT(S, Sb, 0); /* second stream = Cb */
+
+    /* Reset disrupts read of already-sent data */
+    OP_SELECT_SSL(0, Sa);
+    OP_FUNC(check_stream_reset_5);
+
+    OP_READ_EXPECT(Sb, "strawberry", 10);
 }
 
 DEF_SCRIPT(script_6, "place holder for multistram script_6")

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -885,8 +885,19 @@ DEF_SCRIPT(script_8, "Unidirectional default stream mode (server sends first)")
     OP_WRITE_FAIL(C);
 }
 
-DEF_SCRIPT(script_9, "place holder for multistrem script_9")
+/* 9. Unidirectional default stream mode test (server sends first on bidi) */
+DEF_SCRIPT(script_9, "Unidirectional default stream mode (server sends bidi first)")
 {
+    OP_SIMPLE_PAIR_CONN();
+    OP_SET_DEFAULT_STREAM_MODE(C, SSL_DEFAULT_STREAM_MODE_AUTO_UNI);
+
+    OP_ACCEPT_CONN_WAIT(L, S, 0);
+    OP_NEW_STREAM(S, Sa, 0 /* bidirectional */);
+    OP_WRITE(Sa, "apple", 5);
+
+    OP_READ_EXPECT(C, "apple", 5);
+    OP_WRITE(C, "orange", 6);
+    OP_READ_EXPECT(Sa, "orange", 6);
 }
 
 DEF_SCRIPT(script_10, "place holder for multistrem script_10")

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -859,8 +859,16 @@ DEF_SCRIPT(script_6, "Test STOP_SENDING functionality")
     OP_FUNC(check_stream_stopped_6);
 }
 
-DEF_SCRIPT(script_7, "place holder for multistrem script_7")
+/* 7. Unidirectional default stream mode test (client sends first) */
+DEF_SCRIPT(script_7, "Unidirectional default stream mode (client sends first)")
 {
+    OP_SIMPLE_PAIR_CONN();
+    OP_SET_DEFAULT_STREAM_MODE(C, SSL_DEFAULT_STREAM_MODE_AUTO_UNI);
+    OP_WRITE(C, "apple", 5);
+
+    OP_ACCEPT_CONN_WAIT(L, S, 0);
+    OP_READ_EXPECT(S, "apple", 5);
+    OP_WRITE_FAIL(S);
 }
 
 DEF_SCRIPT(script_8, "place holder for multistrem script_8")


### PR DESCRIPTION
Also fixes bugs in `OP_STREAM_RESET` and `OP_READ_FAIL_WAIT`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated

Fixes https://github.com/openssl/project/issues/1985