### PR TITLE
siv128: return 1 on success and 0 on failure from ossl_siv128_finish

### DIFF
--- a/crypto/modes/siv128.c
+++ b/crypto/modes/siv128.c
@@ -210,7 +210,7 @@ int ossl_siv128_init(SIV128_CONTEXT *ctx, const unsigned char *key, int klen,
     }
     EVP_MAC_CTX_free(mac_ctx);
 
-    ctx->final_ret = -1;
+    ctx->final_ret = 0;
     ctx->crypto_ok = 1;
 
     return 1;
@@ -291,7 +291,7 @@ int ossl_siv128_encrypt(SIV128_CONTEXT *ctx,
 
     if (!siv128_do_encrypt(ctx->cipher_ctx, out, in, len, &q))
         return 0;
-    ctx->final_ret = 0;
+    ctx->final_ret = 1;
     return 1;
 }
 
@@ -327,12 +327,13 @@ int ossl_siv128_decrypt(SIV128_CONTEXT *ctx,
         OPENSSL_cleanse(out, len);
         return 0;
     }
-    ctx->final_ret = 0;
+    ctx->final_ret = 1;
     return 1;
 }
 
 /*
  * Return the already calculated final result.
+ * Returns 1 on success and 0 on failure.
  */
 int ossl_siv128_finish(SIV128_CONTEXT *ctx)
 {
@@ -379,7 +380,7 @@ int ossl_siv128_cleanup(SIV128_CONTEXT *ctx)
         ctx->mac = NULL;
         OPENSSL_cleanse(&ctx->d, sizeof(ctx->d));
         OPENSSL_cleanse(&ctx->tag, sizeof(ctx->tag));
-        ctx->final_ret = -1;
+        ctx->final_ret = 0;
         ctx->crypto_ok = 1;
     }
     return 1;

--- a/providers/implementations/ciphers/cipher_aes_siv.c
+++ b/providers/implementations/ciphers/cipher_aes_siv.c
@@ -227,7 +227,7 @@ static int aes_siv_set_ctx_params(void *vctx, const OSSL_PARAM params[])
         if (keylen != ctx->keylen)
             return 0;
     }
-    sctx->final_ret = -1;
+    sctx->final_ret = 0;
 
     return 1;
 }

--- a/providers/implementations/ciphers/cipher_aes_siv_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_siv_hw.c
@@ -112,7 +112,7 @@ static int aes_siv_cipher(void *vctx, unsigned char *out,
 
     /* EncryptFinal or DecryptFinal */
     if (in == NULL)
-        return ossl_siv128_finish(sctx) == 0;
+        return ossl_siv128_finish(sctx);
 
     /* Deal with associated data */
     if (out == NULL)

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -7662,7 +7662,7 @@ static int test_chacha20_poly1305_late_aad(void)
 #endif
 /*
  * AES-SIV reuse-without-rekey:
- *   msg1: legit non-empty CT, tag verifies, final_ret=0
+ *   msg1: legit non-empty CT, tag verifies, final_ret=1
  *   msg2: no reinit (or reinit with key=NULL), set forged tag,
  *         AAD only, DecryptFinal -> does stale final_ret leak through?
  */


### PR DESCRIPTION
### Summary

`ossl_siv128_finish()` returned the internal `final_ret` value, which used `-1` for failure and `0` for success — the opposite of OpenSSL's usual `1` for success / `0` for failure convention. Since this is an internal, non-public function (declared in `include/crypto/siv.h`), its return value can be aligned with the rest of the codebase.

Fixes #31711.

### Changes

- `crypto/modes/siv128.c`: store `final_ret = 1` on the successful encrypt/decrypt paths and `0` for the failure/uninitialised states (init and cleanup). The failure default now also matches a zero-initialised context. Documented the return values on `ossl_siv128_finish()`.
- `providers/implementations/ciphers/cipher_aes_siv.c`: the per-operation reset now uses `0` for the failure default.
- `providers/implementations/ciphers/cipher_aes_siv_hw.c`: the only internal caller now returns `ossl_siv128_finish()` directly instead of comparing against `0`.
- `test/evp_extra_test.c`: updated a stale comment describing the internal value.

No public API or behaviour changes: the EVP-level `*Final` result (success/failure) is unchanged.

### Testing

```
./test/evp_test test/recipes/30-test_evp_data/evpciph_aes_siv.txt      # 450 vectors, 0 errors
./test/evp_test test/recipes/30-test_evp_data/evpciph_aes_gcm_siv.txt  # 50 vectors, 0 errors
./test/evp_extra_test                                                  # passes, incl. test_aes_siv_ctx_reuse
```
