### PR TITLE
ensure writes are syncronized on windows in CRYPTO_THREAD_run_once

### DIFF
--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -536,12 +536,12 @@ int CRYPTO_THREAD_run_once(CRYPTO_ONCE *once, void (*init)(void))
              * below completes prior to some writes in whatever the init()
              * callback routine above may do.  In this case, other threads
              * entering here may see unsynchronized data in whatever the init
-             * routine initializes, leading to errneous behavior.
+             * routine initializes, leading to erroneous behavior.
              *
-             * We should Use InitOnceExecuteOnce here to implement this, but
+             * We should use InitOnceExecuteOnce here to implement this, but
              * doing so requires that we modify the definition of the
              * CRYPTO_ONCE type, which is an ABI breakage.  So instead
-             * Just insert a memory barrier here to ensure that any pending
+             * just insert a memory barrier here to ensure that any pending
              * writes are flushed to memory prior to setting ONCE_DONE below
              */
             MemoryBarrier();

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -536,7 +536,7 @@ int CRYPTO_THREAD_run_once(CRYPTO_ONCE *once, void (*init)(void))
              * below completes prior to some writes in whatever the init()
              * callback routine above may do.  In this case, other threads
              * entering here may see unsynchronized data in whatever the init
-             * routine initalizes, leading to errneous behavior.
+             * routine initializes, leading to errneous behavior.
              *
              * We should Use InitOnceExecuteOnce here to implement this, but
              * doing so requires that we modify the definition of the

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -540,7 +540,7 @@ int CRYPTO_THREAD_run_once(CRYPTO_ONCE *once, void (*init)(void))
              *
              * We should Use InitOnceExecuteOnce here to implement this, but
              * doing so requires that we modify the definition of the
-             * CRYPTO_ONCE type, which is an abi breakage.  So instead
+             * CRYPTO_ONCE type, which is an ABI breakage.  So instead
              * Just insert a memory barrier here to ensure that any pending
              * writes are flushed to memory prior to setting ONCE_DONE below
              */

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -531,6 +531,20 @@ int CRYPTO_THREAD_run_once(CRYPTO_ONCE *once, void (*init)(void))
         result = InterlockedCompareExchange(lock, ONCE_ININIT, ONCE_UNINITED);
         if (result == ONCE_UNINITED) {
             init();
+            /*
+             * On weakly ordered systems, it may happen that the write to *lock
+             * below completes prior to some writes in whatever the init()
+             * callback routine above may do.  In this case, other threads
+             * entering here may see unsynchronized data in whatever the init
+             * routine initalizes, leading to errneous behavior.
+             *
+             * We should Use InitOnceExecuteOnce here to implement this, but
+             * doing so requires that we modify the definition of the
+             * CRYPTO_ONCE type, which is an abi breakage.  So instead
+             * Just insert a memory barrier here to ensure that any pending
+             * writes are flushed to memory prior to setting ONCE_DONE below
+             */
+            MemoryBarrier();
             *lock = ONCE_DONE;
             return 1;
         }


### PR DESCRIPTION
We've tried to fix this properly using InitOnceExecuteOnce, but it results in an ABI breakage, so we're doing it this way.

on windows, CRYPTO_THREAD_run_once, on weakly memory ordered systems, may complete the write of the run once variable lock before some of the writes made by the init callback routine complete.  The result is that on a heavily multithreaded application, other therads may see the data that was meant to be in an initalized state, as in some erroneous in-between state, leading to errors.

Fix it by inserting a full memory barrier after we return from the init callback, and prior to setting the run once variable to ONCE_DONE.

