### PR TITLE
pkcs7: null-guard enveloped and signedAndEnveloped arms in PKCS7_stream

### DIFF
--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -727,6 +727,10 @@ int PKCS7_stream(unsigned char ***boundary, PKCS7 *p7)
         break;
 
     case NID_pkcs7_signedAndEnveloped:
+        if (p7->d.signed_and_enveloped == NULL || p7->d.signed_and_enveloped->enc_data == NULL) {
+            ERR_raise(ERR_LIB_PKCS7, PKCS7_R_NO_CONTENT);
+            break;
+        }
         os = p7->d.signed_and_enveloped->enc_data->enc_data;
         if (os == NULL) {
             os = ASN1_OCTET_STRING_new();
@@ -735,6 +739,10 @@ int PKCS7_stream(unsigned char ***boundary, PKCS7 *p7)
         break;
 
     case NID_pkcs7_enveloped:
+        if (p7->d.enveloped == NULL || p7->d.enveloped->enc_data == NULL) {
+            ERR_raise(ERR_LIB_PKCS7, PKCS7_R_NO_CONTENT);
+            break;
+        }
         os = p7->d.enveloped->enc_data->enc_data;
         if (os == NULL) {
             os = ASN1_OCTET_STRING_new();

--- a/test/pkcs7_test.c
+++ b/test/pkcs7_test.c
@@ -411,6 +411,54 @@ end:
 }
 #endif /* OPENSSL_NO_EC */
 
+static int pkcs7_stream_enveloped_no_content_test(void)
+{
+    int ret = 0;
+    PKCS7 *p7 = NULL;
+    BIO *sink = NULL;
+    BIO *bio = NULL;
+
+    const unsigned char data_enveloped_no_body[] = { 0x30, 0x0b, 0x06, 0x09,
+        0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x07, 0x03 };
+    const unsigned char *ptr_env_no_body = data_enveloped_no_body;
+
+    ret = TEST_ptr(p7 = d2i_PKCS7(NULL, &ptr_env_no_body,
+                       sizeof(data_enveloped_no_body)))
+        && TEST_ptr(sink = BIO_new(BIO_s_null()))
+        && TEST_ptr_null(bio = BIO_new_PKCS7(sink, p7))
+        && TEST_int_eq(ERR_GET_REASON(ERR_peek_last_error()),
+            PKCS7_R_NO_CONTENT);
+
+    BIO_free(bio);
+    BIO_free(sink);
+    PKCS7_free(p7);
+    return ret;
+}
+
+static int pkcs7_stream_enveloped_signed_no_content_test(void)
+{
+    int ret = 0;
+    PKCS7 *p7 = NULL;
+    BIO *sink = NULL;
+    BIO *bio = NULL;
+
+    const unsigned char data_enveloped_signed_no_body[] = { 0x30, 0x0b, 0x06,
+        0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x07, 0x04 };
+    const unsigned char *ptr_env_signed_no_body = data_enveloped_signed_no_body;
+
+    ret = TEST_ptr(p7 = d2i_PKCS7(NULL, &ptr_env_signed_no_body,
+                       sizeof(data_enveloped_signed_no_body)))
+        && TEST_ptr(sink = BIO_new(BIO_s_null()))
+        && TEST_ptr_null(bio = BIO_new_PKCS7(sink, p7))
+        && TEST_int_eq(ERR_GET_REASON(ERR_peek_last_error()),
+            PKCS7_R_NO_CONTENT);
+
+    BIO_free(bio);
+    BIO_free(sink);
+    PKCS7_free(p7);
+    return ret;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(pkcs7_issuer_and_serial_negative_idx_test);
@@ -418,5 +466,7 @@ int setup_tests(void)
     ADD_TEST(pkcs7_verify_test);
     ADD_TEST(pkcs7_inner_content_verify_test);
 #endif /* OPENSSL_NO_EC */
+    ADD_TEST(pkcs7_stream_enveloped_no_content_test);
+    ADD_TEST(pkcs7_stream_enveloped_signed_no_content_test);
     return 1;
 }


### PR DESCRIPTION
Dereferences of `p7->d.enveloped->enc_data` and
`p7->d.signed_and_enveloped->enc_data` crash with UBSan when the union member is NULL after parsing a minimal/malformed input. Mirror the guard added for the signed arm in PR #30351.

Fixes: #31682

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
