### PR TITLE
Removes unused member variable 'alloced' from SSL_MAC_BUF struct.

### DIFF
--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -113,7 +113,7 @@ static int dtls_process_record(OSSL_RECORD_LAYER *rl, DTLS_BITMAP *bitmap)
     int imac_size;
     size_t mac_size = 0;
     unsigned char md[EVP_MAX_MD_SIZE];
-    SSL_MAC_BUF macbuf = { NULL, 0 };
+    SSL_MAC_BUF macbuf = { NULL };
     int ret = 0;
 
     rr = &rl->rrec[0];
@@ -275,8 +275,6 @@ static int dtls_process_record(OSSL_RECORD_LAYER *rl, DTLS_BITMAP *bitmap)
 
     ret = 1;
 end:
-    if (macbuf.alloced)
-        OPENSSL_free(macbuf.mac);
     return ret;
 }
 

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -25,7 +25,6 @@ typedef struct dtls_bitmap_st {
 
 typedef struct ssl_mac_buf_st {
     unsigned char *mac;
-    int alloced;
 } SSL_MAC_BUF;
 
 typedef struct tls_buffer_st {

--- a/ssl/record/methods/tls1_meth.c
+++ b/ssl/record/methods/tls1_meth.c
@@ -388,8 +388,6 @@ static int tls1_cipher(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *recs,
             OSSL_PARAM params[2], *p = params;
 
             /* Get the MAC */
-            macs[0].alloced = 0;
-
             *p++ = OSSL_PARAM_construct_octet_ptr(OSSL_CIPHER_PARAM_TLS_MAC,
                 (void **)&macs[0].mac,
                 macsize);

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -917,13 +917,9 @@ int tls_get_more_records(OSSL_RECORD_LAYER *rl)
     rl->num_released = 0;
     ret = OSSL_RECORD_RETURN_SUCCESS;
 end:
-    if (macbufs != NULL) {
-        for (j = 0; j < num_recs; j++) {
-            if (macbufs[j].alloced)
-                OPENSSL_free(macbufs[j].mac);
-        }
+    if (macbufs != NULL)
         OPENSSL_free(macbufs);
-    }
+
     return ret;
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
