### PR TITLE
s390x: Fix return code handling in HMAC_Init_ex()

### DIFF
--- a/crypto/hmac/hmac.c
+++ b/crypto/hmac/hmac.c
@@ -53,9 +53,11 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len,
         return 0;
 
 #ifdef OPENSSL_HMAC_S390X
-    rv = s390x_HMAC_init(ctx, key, len);
-    if (rv != -1)
-        return rv;
+    {
+        int ret = s390x_HMAC_init(ctx, key, len);
+        if (ret != -1) /* -1 means SW fallback */
+            return ret;
+    }
 #endif
 
     if (key != NULL) {


### PR DESCRIPTION
When running on the s390x platform `HMAC_Init_ex()` calls s`390x_HMAC_init()` to optionally allow hardware acceleration of the HMAC operation. In case the hardware acceleration is not available, `s390x_HMAC_init()` returns -1 to indicate that. In this case the software path is continued.

The problem is that `rv` was set to -1 by `s390x_HMAC_init()` and stays at this until the end of the function. In case the software path detects an error it goes to the `err` label which just returns `rv` as is, and thus `HMAC_Init_ex()` now returns -1 instead of 0 (`rv` was initialized to 0 at declaration).

The wrong return value might then be propagated through all layers, i.e. to `EVP_MAC_init()` which also returns -1 in this case. However, `EVP_MAC_init()` is defined as returning 1 on success, or 0 on error, i.e. a boolean kind of return value.

Typically, callers will do something like `if (!EVP_MAC_init(s....))` to check for errors. A return value of -1 is non-zero, and thus it is treated as successful return.

Fix this by setting `rv` back to 0 when `s390x_HMAC_init()` returned -1.

Fixes: https://github.com/openssl/openssl/commit/0499de5adda26b1ef09660f70c12b4710b5f7c8a
Closes: https://github.com/openssl/openssl/issues/31706

This should probably backported to releases >= 3.4, where the bug was introduced with commit https://github.com/openssl/openssl/commit/0499de5adda26b1ef09660f70c12b4710b5f7c8a .

A recent commit https://github.com/openssl/openssl/commit/036db3a8ef21cd5a5c1b89808b6ddab7cb5d4f0c changed the `if` condition after the `s390x_HMAC_init()` call slightly, but this does not make a change in regards of leaving `rv` at -1 for the rest of the code. It might produce an easy to resolve merge conflict though for the backports that do not have that commit.