### PR TITLE
[3.0] `ssl3_record.c`: prevent `max_early_data` overflow in `ossl_early_data_count_ok()`

### DIFF
--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -104,7 +104,7 @@ static int ssl3_record_app_data_waiting(SSL *s)
 
 int early_data_count_ok(SSL *s, size_t length, size_t overhead, int send)
 {
-    uint32_t max_early_data;
+    uint64_t max_early_data;
     SSL_SESSION *sess = s->session;
 
     /*


### PR DESCRIPTION
This is a backport of [1] to `openssl-3.0`.

Apply a change similar to the one made in d41a9225196b "`tls_common.c`: prevent `max_early_data` overflow in `rlayer_early_data_count_ok()`" to `ossl_early_data_count_ok()`, that has similar logic in it (as `rlayer_early_data_count_ok()` has been copied from `ossl_early_data_count_ok()` in 9dd90232d537 "Move early data counting out of the SSL object and into the record layer").

Complements: d41a9225196b "`tls_common.c`: prevent `max_early_data` overflow in `rlayer_early_data_count_ok()`"
Fixes: 70ef40a05e06 "Check max_early_data against the amount of early data we actually receive"

[1] https://github.com/openssl/openssl/pull/31628