### PR TITLE
Fix CMS_decrypt_set1_pkey returning 0 with empty error queue 

### DIFF
--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -796,6 +796,13 @@ int CMS_decrypt_set1_pkey_and_peer(CMS_ContentInfo *cms, EVP_PKEY *pk,
 
     if (!match_ri)
         ERR_raise(ERR_LIB_CMS, CMS_R_NO_MATCHING_RECIPIENT);
+    else
+        /*
+         * Recipients of the right key type exist but none matched the
+         * provided certificate. Raise a meaningful error so callers can
+         * determine the reason for failure via ERR_get_error().
+         */
+        ERR_raise(ERR_LIB_CMS, CMS_R_NO_MATCHING_RECIPIENT);
     return 0;
 }
 

--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -275,6 +275,59 @@ static int test_encrypt_decrypt_aes_256_gcm(void)
     return test_encrypt_decrypt(EVP_aes_256_gcm());
 }
 
+static int test_encrypt_decrypt_no_matching_recipient(void)
+{
+    int testresult = 0;
+    STACK_OF(X509) *certstack = sk_X509_new_null();
+    const char *msg = "Hello world";
+    BIO *msgbio = BIO_new_mem_buf(msg, (int)strlen(msg));
+    BIO *outmsgbio = BIO_new(BIO_s_mem());
+    CMS_ContentInfo *content = NULL;
+    const EVP_CIPHER *cipher = EVP_aes_128_cbc();
+    X509 *cert2 = NULL;
+    ASN1_INTEGER *sn = NULL;
+    unsigned long err = 0;
+
+    if (!TEST_ptr(certstack) || !TEST_ptr(msgbio) || !TEST_ptr(outmsgbio))
+        goto end;
+
+    if (!TEST_int_gt(sk_X509_push(certstack, cert), 0))
+        goto end;
+
+    content = CMS_encrypt(certstack, msgbio, cipher, CMS_TEXT);
+    if (!TEST_ptr(content))
+        goto end;
+
+    /* Create a certificate with a different serial number */
+    if (!TEST_ptr(cert2 = X509_dup(cert))
+        || !TEST_ptr(sn = ASN1_INTEGER_new())
+        || !TEST_true(ASN1_INTEGER_set(sn, 100)) /* assuming 100 is different */
+        || !TEST_true(X509_set1_serialNumber(cert2, sn)))
+        goto end;
+
+    /* This decryption should fail because of cert mismatch */
+    if (!TEST_false(CMS_decrypt(content, privkey, cert2, NULL, outmsgbio, CMS_TEXT)))
+        goto end;
+
+    err = ERR_peek_last_error();
+    if (!TEST_int_eq(ERR_GET_LIB(err), ERR_LIB_CMS)
+        || !TEST_int_eq(ERR_GET_REASON(err), CMS_R_NO_MATCHING_RECIPIENT))
+        goto end;
+
+    testresult = 1;
+    ERR_clear_error();
+end:
+    ASN1_INTEGER_free(sn);
+    X509_free(cert2);
+    sk_X509_free(certstack);
+    BIO_free(msgbio);
+    BIO_free(outmsgbio);
+    CMS_ContentInfo_free(content);
+
+    return testresult;
+}
+
+
 static int test_CMS_add1_cert(void)
 {
     CMS_ContentInfo *cms = NULL;
@@ -785,6 +838,7 @@ int setup_tests(void)
     ADD_TEST(test_encrypt_decrypt_aes_128_gcm);
     ADD_TEST(test_encrypt_decrypt_aes_192_gcm);
     ADD_TEST(test_encrypt_decrypt_aes_256_gcm);
+    ADD_TEST(test_encrypt_decrypt_no_matching_recipient);
     ADD_TEST(test_non_aead_on_auth_envelope_enc);
     ADD_TEST(test_non_aead_on_auth_envelope_dec);
     ADD_TEST(test_short_mac_on_auth_envelope_data);


### PR DESCRIPTION
…31632)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated


### Description
This PR addresses **Issue #31632**, where `CMS_decrypt_set1_pkey` would return `0` on failure (such as when the wrong certificate is provided) but leave the OpenSSL error queue entirely empty. This prevented callers from diagnosing the reason for the failure (e.g., via `ERR_get_error()`).

### Root Cause
In `cms_smime.c`, inside `CMS_decrypt_set1_pkey_and_peer()`, the `match_ri` variable was being set to `1` as soon as a recipient of the correct *key type* was found, regardless of whether the *certificate* matched. If a certificate was provided but failed the comparison check (`CMS_RecipientInfo_ktri_cert_cmp`) for all recipients, the decryption loop would exit normally. Because `match_ri` was `1`, the fallback check at the bottom of the function (`if (!match_ri)`) was skipped, causing the function to silently return `0` without queueing a `CMS_R_NO_MATCHING_RECIPIENT` error.

### Changes Made:
- Modified the error-raising logic at the end of `CMS_decrypt_set1_pkey_and_peer()`.
- Added an explicit `else` branch to the `if (!match_ri)` check. Now, if `match_ri` is set (meaning recipients of the right key type exist) but none of them matched the provided certificate (meaning the function fell through to the end), we correctly raise `ERR_raise(ERR_LIB_CMS, CMS_R_NO_MATCHING_RECIPIENT)`.
- This ensures that failures due to "no matching recipient" are reliably reported through the standard OpenSSL error APIs, restoring the expected behavior that existed in OpenSSL 1.1.1.

Fixes #31632

