### PR TITLE
Fix policyMappings to support duplicate issuer policies in config 

### DIFF
--- a/crypto/x509/v3_pmaps.c
+++ b/crypto/x509/v3_pmaps.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2021 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2003-2026 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -77,14 +77,68 @@ static void *v2i_POLICY_MAPPINGS(const X509V3_EXT_METHOD *method,
     }
 
     for (i = 0; i < num; i++) {
+        const char *issuer_oid, *subject_oid;
+        char *colon, *name_copy = NULL;
+
         val = sk_CONF_VALUE_value(nval, i);
-        if (!val->value || !val->name) {
+        if (!val->name) {
             ERR_raise_data(ERR_LIB_X509V3, X509V3_R_INVALID_OBJECT_IDENTIFIER,
-                "%s", val->name);
+                "missing name");
             goto err;
         }
-        obj1 = OBJ_txt2obj(val->name, 0);
-        obj2 = OBJ_txt2obj(val->value, 0);
+
+        /*
+         * Support two config syntaxes for policyMappings:
+         *
+         * 1. Standard (inline or section with unique keys):
+         *       issuerDomainPolicy = subjectDomainPolicy
+         *    Here val->name is the issuer OID and val->value is subject OID.
+         *
+         * 2. Alternative (section with duplicate issuer policies):
+         *       issuerDomainPolicy:subjectDomainPolicy = <anything>
+         *    Here val->name contains "issuerOID:subjectOID" and val->value
+         *    is ignored. This form avoids the config parser deduplicating
+         *    entries that share the same issuer OID key.
+         *
+         * The alternative form is needed because the OpenSSL config file
+         * parser uses a hash table keyed by (section, name) and silently
+         * discards earlier entries when duplicate keys appear in a section.
+         * Encoding both OIDs in the key avoids this limitation.
+         */
+        colon = strchr(val->name, ':');
+        if (colon != NULL) {
+            /* Alternative syntax: name is "issuerOID:subjectOID" */
+            name_copy = OPENSSL_strdup(val->name);
+            if (name_copy == NULL) {
+                ERR_raise(ERR_LIB_X509V3, ERR_R_CRYPTO_LIB);
+                goto err;
+            }
+            /* Split at the colon */
+            name_copy[colon - val->name] = '\0';
+            issuer_oid = name_copy;
+            subject_oid = name_copy + (colon - val->name) + 1;
+            if (*issuer_oid == '\0' || *subject_oid == '\0') {
+                ERR_raise_data(ERR_LIB_X509V3, X509V3_R_INVALID_OBJECT_IDENTIFIER,
+                    "%s", val->name);
+                OPENSSL_free(name_copy);
+                goto err;
+            }
+        } else {
+            /* Standard syntax: name is issuer OID, value is subject OID */
+            if (!val->value) {
+                ERR_raise_data(ERR_LIB_X509V3, X509V3_R_INVALID_OBJECT_IDENTIFIER,
+                    "%s", val->name);
+                goto err;
+            }
+            issuer_oid = val->name;
+            subject_oid = val->value;
+            name_copy = NULL;
+        }
+
+        obj1 = OBJ_txt2obj(issuer_oid, 0);
+        obj2 = OBJ_txt2obj(subject_oid, 0);
+        OPENSSL_free(name_copy);
+        name_copy = NULL;
         if (!obj1 || !obj2) {
             ERR_raise_data(ERR_LIB_X509V3, X509V3_R_INVALID_OBJECT_IDENTIFIER,
                 "%s", val->name);
@@ -107,3 +161,4 @@ err:
     sk_POLICY_MAPPING_pop_free(pmaps, POLICY_MAPPING_free);
     return NULL;
 }
+


### PR DESCRIPTION
…sue #31087)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated


### Description
This PR addresses **Issue #31087**, where specifying `policyMappings` in `openssl.cnf` via a `@section` reference silently loses mappings when multiple subject policies map to the same issuer policy. 

### Root Cause
OpenSSL's config file parser uses a hash table keyed by `(section, name)` and deduplicates entries. When multiple entries in a section have the same key (the issuer OID), all but the last one are removed from the internal stack *before* `v2i_POLICY_MAPPINGS` ever sees them. Thus, something like:
```ini
[ cross_cert_mappings ]
2.16.840.1.999.2 = 2.16.840.1.666.2
2.16.840.1.999.2 = 2.16.840.1.777.1
