### PR TITLE
apps: cover x509 DER key/cert input formats

### DIFF
--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -17,7 +17,7 @@ use File::Compare qw/compare_text/;
 
 setup("test_x509");
 
-plan tests => 151;
+plan tests => 152;
 
 # Prevent MSys2 filename munging for arguments that look like file paths but
 # aren't
@@ -709,3 +709,42 @@ ok(!run(app(["openssl", "x509", "-multi", "-checkend",
 # Bad parse still returns non-zero
 ok(!run(app(["openssl", "x509", "-checkend", "60", "-in", $c_key])),
     "Bad parse with -checkend returns non-zero");
+
+# Signing using DER-encoded key and CA cert/key inputs,
+# exercising -keyform, -CAform and -CAkeyform
+subtest 'x509 signing with DER -keyform, -CAform and -CAkeyform' => sub {
+    plan tests => 6;
+
+    my $csr = srctop_file(@certs, "x509-check.csr");
+    my $signkey_der = "x509-check-key.der";
+    my $cacert_der = "ca-cert.der";
+    my $cakey_der = "ca-key.der";
+
+    # self-sign the CSR with a DER-encoded signing key
+    ok(run(app(["openssl", "pkey",
+                "-in", srctop_file(@certs, "x509-check-key.pem"),
+                "-outform", "DER", "-out", $signkey_der])),
+       "convert signing key to DER");
+    ok(run(app(["openssl", "x509", "-req", "-in", $csr,
+                "-signkey", $signkey_der, "-keyform", "DER",
+                "-out", "x509-self-der.pem"])),
+       "self-sign CSR with -keyform DER");
+
+    # sign the CSR with a DER-encoded CA cert and CA key
+    ok(run(app(["openssl", "x509",
+                "-in", srctop_file(@certs, "ca-cert.pem"),
+                "-outform", "DER", "-out", $cacert_der])),
+       "convert CA cert to DER");
+    ok(run(app(["openssl", "pkey",
+                "-in", srctop_file(@certs, "ca-key.pem"),
+                "-outform", "DER", "-out", $cakey_der])),
+       "convert CA key to DER");
+    my $caout = "ca-issued-der.pem";
+    ok(run(app(["openssl", "x509", "-req", "-in", $csr,
+                "-CA", $cacert_der, "-CAform", "DER",
+                "-CAkey", $cakey_der, "-CAkeyform", "DER",
+                "-CAcreateserial", "-text", "-out", $caout])),
+       "sign CSR with -CAform DER and -CAkeyform DER");
+    ok(get_issuer($caout) =~ /CN=CA/,
+       "issuer of CA-signed cert matches DER CA cert");
+};


### PR DESCRIPTION
The -keyform, -CAform and -CAkeyform options were not covered. Add a test that self-signs a CSR with a DER-encoded key and signs a CSR with a DER-encoded CA cert and CA key.

Assisted-by: Claude:claude-opus-4-8
