### PR TITLE
[test] check tag abuse for AEAD ciphers

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_gcm_siv.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm_siv.c
@@ -182,8 +182,11 @@ static int ossl_aes_gcm_siv_get_ctx_params(void *vctx, OSSL_PARAM params[])
         return 0;
 
     if (p.tag != NULL && p.tag->data_type == OSSL_PARAM_OCTET_STRING) {
-        if (!ctx->enc || !ctx->generated_tag
-            || p.tag->data_size != sizeof(ctx->tag)
+        if (!ctx->enc || !ctx->generated_tag) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_TAG_NOT_SET);
+            return 0;
+        }
+        if (p.tag->data_size != sizeof(ctx->tag)
             || !OSSL_PARAM_set_octet_string(p.tag, ctx->tag,
                 sizeof(ctx->tag))) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
@@ -227,6 +230,9 @@ static int ossl_aes_gcm_siv_set_ctx_params(void *vctx, const OSSL_PARAM params[]
         if (!ctx->enc) {
             memcpy(ctx->user_tag, p.tag->data, sizeof(ctx->tag));
             ctx->have_user_tag = 1;
+        } else if (p.tag->data != NULL) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_TAG_NOT_NEEDED);
+            return 0;
         }
     }
 

--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -376,7 +376,7 @@ static int aes_ocb_set_ctx_params(void *vctx, const OSSL_PARAM params[])
             ctx->taglen = p.tag->data_size;
         } else {
             if (ctx->base.enc) {
-                ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_INVALID_ARGUMENT);
+                ERR_raise(ERR_LIB_PROV, PROV_R_TAG_NOT_NEEDED);
                 return 0;
             }
             if (p.tag->data_size != ctx->taglen) {
@@ -476,7 +476,11 @@ static int aes_ocb_get_ctx_params(void *vctx, OSSL_PARAM params[])
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
             return 0;
         }
-        if (!ctx->base.enc || p.tag->data_size != ctx->taglen) {
+        if (!ctx->base.enc) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_TAG_NOT_SET);
+            return 0;
+        }
+        if (p.tag->data_size != ctx->taglen) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG_LENGTH);
             return 0;
         }

--- a/providers/implementations/ciphers/ciphercommon_gcm.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c
@@ -215,7 +215,7 @@ int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
     if (p.tag != NULL) {
         sz = p.tag->data_size;
         if (!ctx->enc || ctx->taglen == UNINITIALISED_SIZET) {
-            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG);
+            ERR_raise(ERR_LIB_PROV, PROV_R_TAG_NOT_SET);
             return 0;
         }
         if (p.tag->data != NULL && (sz > EVP_GCM_TLS_TAG_LEN || sz == 0)) {
@@ -264,7 +264,8 @@ int ossl_gcm_set_ctx_params(void *vctx, const OSSL_PARAM params[])
             return 0;
         }
         if (sz == 0 || ctx->enc) {
-            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG);
+            ERR_raise(ERR_LIB_PROV,
+                ctx->enc ? PROV_R_TAG_NOT_NEEDED : PROV_R_INVALID_TAG);
             return 0;
         }
         ctx->taglen = sz;

--- a/providers/implementations/ciphers/ciphercommon_gcm.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c
@@ -263,9 +263,12 @@ int ossl_gcm_set_ctx_params(void *vctx, const OSSL_PARAM params[])
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
             return 0;
         }
-        if (sz == 0 || ctx->enc) {
-            ERR_raise(ERR_LIB_PROV,
-                ctx->enc ? PROV_R_TAG_NOT_NEEDED : PROV_R_INVALID_TAG);
+        if (ctx->enc) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_TAG_NOT_NEEDED);
+            return 0;
+        }
+        if (sz == 0) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG);
             return 0;
         }
         ctx->taglen = sz;

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -5955,7 +5955,6 @@ static int test_evp_aead_tag_direction(int idx)
 
     /* filter out various modes */
     if (info->taglen == 0
-        || info->mode == EVP_CIPH_GCM_SIV_MODE
         /* skip TLS stitched MTE cipher */
         || EVP_CIPHER_is_a(info->ciph, "AES-128-CBC-HMAC-SHA1")
         /* skip TLS stitched MTE cipher */

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -5949,7 +5949,7 @@ static int test_evp_aead_tag_direction(int idx)
     unsigned char iv[EVP_MAX_IV_LENGTH] = { 0 };
     unsigned char tag[EVPTEST_TAG_LEN_MAX] = { 0 };
 
-    int i = 0, testresult = 1;
+    int i = 0, testresult = 1, expected = 0;
     char *errmsg = NULL;
     unsigned long err_code = 0;
 
@@ -5983,17 +5983,21 @@ static int test_evp_aead_tag_direction(int idx)
     tagparams[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG,
         tag, taglen);
     tagparams[1] = OSSL_PARAM_construct_end();
-    ERR_clear_error();
+    ERR_set_mark();
     if (!TEST_false(EVP_CIPHER_CTX_set_params(ctx_enc, tagparams))) {
+        ERR_clear_last_mark();
         errmsg = "ENC_SET_TAG_NOT_REJECTED";
         goto err;
     }
     err_code = ERR_peek_last_error();
     if (!TEST_int_eq(ERR_GET_LIB(err_code), ERR_LIB_PROV)
         || !TEST_int_eq(ERR_GET_REASON(err_code), PROV_R_TAG_NOT_NEEDED)) {
+        ERR_clear_last_mark();
+        expected = PROV_R_TAG_NOT_NEEDED;
         errmsg = "ENC_SET_TAG_WRONG_REASON";
         goto err;
     }
+    ERR_pop_to_mark();
 
     /* a tag read while decrypting must be rejected */
     if (!TEST_ptr(ctx_dec = EVP_CIPHER_CTX_new())) {
@@ -6007,22 +6011,32 @@ static int test_evp_aead_tag_direction(int idx)
     tagparams[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG,
         tag, taglen);
     tagparams[1] = OSSL_PARAM_construct_end();
-    ERR_clear_error();
+    ERR_set_mark();
     if (!TEST_false(EVP_CIPHER_CTX_get_params(ctx_dec, tagparams))) {
+        ERR_clear_last_mark();
         errmsg = "DEC_GET_TAG_NOT_REJECTED";
         goto err;
     }
     err_code = ERR_peek_last_error();
     if (!TEST_int_eq(ERR_GET_LIB(err_code), ERR_LIB_PROV)
         || !TEST_int_eq(ERR_GET_REASON(err_code), PROV_R_TAG_NOT_SET)) {
+        ERR_clear_last_mark();
+        expected = PROV_R_TAG_NOT_SET;
         errmsg = "DEC_GET_TAG_WRONG_REASON";
         goto err;
     }
+    ERR_pop_to_mark();
 
 err:
     if (errmsg != NULL) {
-        TEST_info("test_evp_aead_tag_direction %d, %s: %s",
-            idx, errmsg, info->name);
+        if (expected != 0)
+            TEST_info("test_evp_aead_tag_direction %d, %s: %s"
+                      " (expected reason %d, got %d)",
+                idx, errmsg, info->name,
+                expected, ERR_GET_REASON(err_code));
+        else
+            TEST_info("test_evp_aead_tag_direction %d, %s: %s",
+                idx, errmsg, info->name);
         testresult = 0;
     }
     EVP_CIPHER_CTX_free(ctx_enc);

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -5955,7 +5955,6 @@ static int test_evp_aead_tag_direction(int idx)
 
     /* filter out various modes */
     if (info->taglen == 0
-        || info->mode == EVP_CIPH_GCM_MODE
         || info->mode == EVP_CIPH_OCB_MODE
         || info->mode == EVP_CIPH_GCM_SIV_MODE
         /* skip TLS stitched MTE cipher */

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -5955,7 +5955,6 @@ static int test_evp_aead_tag_direction(int idx)
 
     /* filter out various modes */
     if (info->taglen == 0
-        || info->mode == EVP_CIPH_OCB_MODE
         || info->mode == EVP_CIPH_GCM_SIV_MODE
         /* skip TLS stitched MTE cipher */
         || EVP_CIPHER_is_a(info->ciph, "AES-128-CBC-HMAC-SHA1")

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -5944,7 +5944,6 @@ static int test_evp_aead_tag_direction(int idx)
 
     OSSL_PARAM tagparams[2];
 
-    int taglen = info->taglen;
     unsigned char key[EVP_MAX_KEY_LENGTH] = { 0 };
     unsigned char iv[EVP_MAX_IV_LENGTH] = { 0 };
     unsigned char tag[EVPTEST_TAG_LEN_MAX] = { 0 };
@@ -5965,12 +5964,6 @@ static int test_evp_aead_tag_direction(int idx)
         || EVP_CIPHER_is_a(info->ciph, "AES-256-CBC-HMAC-SHA256"))
         return 1;
 
-    /* bound the tag buffer, should never happen but helps static analysis */
-    if (taglen > EVPTEST_TAG_LEN_MAX) {
-        errmsg = "TAGLEN_EXCEEDS_BUF";
-        goto err;
-    }
-
     for (i = 0; i < info->keylen && i < (int)sizeof(key); i++)
         key[i] = (unsigned char)(0xA0 + i);
     for (i = 0; i < info->ivlen && i < (int)sizeof(iv); i++)
@@ -5989,7 +5982,7 @@ static int test_evp_aead_tag_direction(int idx)
         goto err;
     }
     tagparams[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG,
-        tag, taglen);
+        tag, info->taglen);
     tagparams[1] = OSSL_PARAM_construct_end();
     ERR_set_mark();
     if (!TEST_false(EVP_CIPHER_CTX_set_params(ctx_enc, tagparams))) {
@@ -6017,7 +6010,7 @@ static int test_evp_aead_tag_direction(int idx)
         goto err;
     }
     tagparams[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG,
-        tag, taglen);
+        tag, info->taglen);
     tagparams[1] = OSSL_PARAM_construct_end();
     ERR_set_mark();
     if (!TEST_false(EVP_CIPHER_CTX_get_params(ctx_dec, tagparams))) {

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -5948,7 +5948,7 @@ static int test_evp_aead_tag_direction(int idx)
     unsigned char iv[EVP_MAX_IV_LENGTH] = { 0 };
     unsigned char tag[EVPTEST_TAG_LEN_MAX] = { 0 };
 
-    int i = 0, testresult = 1, expected = 0;
+    int i = 0, testresult = 0, expected = 0;
     char *errmsg = NULL;
     unsigned long err_code = 0;
 
@@ -6028,6 +6028,8 @@ static int test_evp_aead_tag_direction(int idx)
     }
     ERR_pop_to_mark();
 
+    testresult = 1;
+
 err:
     if (errmsg != NULL) {
         if (expected != 0)
@@ -6038,7 +6040,6 @@ err:
         else
             TEST_info("test_evp_aead_tag_direction %d, %s: %s",
                 idx, errmsg, info->name);
-        testresult = 0;
     }
     EVP_CIPHER_CTX_free(ctx_enc);
     EVP_CIPHER_CTX_free(ctx_dec);

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -5930,6 +5930,107 @@ err:
 }
 
 /*
+ * With AEAD ciphers, a tag is an input for decryption (the value to verify)
+ * and an output of encryption (the generated value). Therefore:
+ *   - supplying a tag value while encrypting must fail
+ *   - reading a tag while decrypting must fail
+ *   - error codes should be consistent across all AEADs
+ */
+static int test_evp_aead_tag_direction(int idx)
+{
+    const EVP_CIPHER_TEST_INFO *info = &cipher_list[idx];
+    EVP_CIPHER_CTX *ctx_enc = NULL; /* set tag while encrypting: must fail */
+    EVP_CIPHER_CTX *ctx_dec = NULL; /* get tag while decrypting: must fail */
+
+    OSSL_PARAM tagparams[2];
+
+    int taglen = info->taglen;
+    unsigned char key[EVP_MAX_KEY_LENGTH] = { 0 };
+    unsigned char iv[EVP_MAX_IV_LENGTH] = { 0 };
+    unsigned char tag[EVPTEST_TAG_LEN_MAX] = { 0 };
+
+    int i = 0, testresult = 1;
+    char *errmsg = NULL;
+    unsigned long err_code = 0;
+
+    /* only AEADs have a tag to misuse */
+    if (info->taglen == 0)
+        return 1;
+
+    /* bound the tag buffer, should never happen but helps static analysis */
+    if (taglen > EVPTEST_TAG_LEN_MAX) {
+        errmsg = "TAGLEN_EXCEEDS_BUF";
+        goto err;
+    }
+
+    for (i = 0; i < info->keylen && i < (int)sizeof(key); i++)
+        key[i] = (unsigned char)(0xA0 + i);
+    for (i = 0; i < info->ivlen && i < (int)sizeof(iv); i++)
+        iv[i] = (unsigned char)(0xB0 + i);
+
+    /*
+     * a tag value supplied while encrypting must be rejected. data is non-NULL
+     * so this is a value-set, not the data == NULL tag-length query.
+     */
+    if (!TEST_ptr(ctx_enc = EVP_CIPHER_CTX_new())) {
+        errmsg = "ENC_ALLOC";
+        goto err;
+    }
+    if (!TEST_true(EVP_EncryptInit_ex2(ctx_enc, info->ciph, key, iv, NULL))) {
+        errmsg = "ENC_INIT";
+        goto err;
+    }
+    tagparams[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG,
+        tag, taglen);
+    tagparams[1] = OSSL_PARAM_construct_end();
+    ERR_clear_error();
+    if (!TEST_false(EVP_CIPHER_CTX_set_params(ctx_enc, tagparams))) {
+        errmsg = "ENC_SET_TAG_NOT_REJECTED";
+        goto err;
+    }
+    err_code = ERR_peek_last_error();
+    if (!TEST_int_eq(ERR_GET_LIB(err_code), ERR_LIB_PROV)
+        || !TEST_int_eq(ERR_GET_REASON(err_code), PROV_R_TAG_NOT_NEEDED)) {
+        errmsg = "ENC_SET_TAG_WRONG_REASON";
+        goto err;
+    }
+
+    /* a tag read while decrypting must be rejected */
+    if (!TEST_ptr(ctx_dec = EVP_CIPHER_CTX_new())) {
+        errmsg = "DEC_ALLOC";
+        goto err;
+    }
+    if (!TEST_true(EVP_DecryptInit_ex2(ctx_dec, info->ciph, key, iv, NULL))) {
+        errmsg = "DEC_INIT";
+        goto err;
+    }
+    tagparams[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG,
+        tag, taglen);
+    tagparams[1] = OSSL_PARAM_construct_end();
+    ERR_clear_error();
+    if (!TEST_false(EVP_CIPHER_CTX_get_params(ctx_dec, tagparams))) {
+        errmsg = "DEC_GET_TAG_NOT_REJECTED";
+        goto err;
+    }
+    err_code = ERR_peek_last_error();
+    if (!TEST_int_eq(ERR_GET_LIB(err_code), ERR_LIB_PROV)
+        || !TEST_int_eq(ERR_GET_REASON(err_code), PROV_R_TAG_NOT_SET)) {
+        errmsg = "DEC_GET_TAG_WRONG_REASON";
+        goto err;
+    }
+
+err:
+    if (errmsg != NULL) {
+        TEST_info("test_evp_aead_tag_direction %d, %s: %s",
+            idx, errmsg, info->name);
+        testresult = 0;
+    }
+    EVP_CIPHER_CTX_free(ctx_enc);
+    EVP_CIPHER_CTX_free(ctx_dec);
+    return testresult;
+}
+
+/*
  * Verify stale key is not being used after providing a new key in multiple steps.
  * This test performs a full round of encryption and then changes the
  * key and then the IV in a multi-step init.
@@ -8937,6 +9038,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_evp_stale_key_reinit, cipher_list_n);
     ADD_ALL_TESTS(test_evp_decrypt_roundtrip_multistep, cipher_list_n);
     ADD_ALL_TESTS(test_evp_oneshot_aead_zerolen, cipher_list_n);
+    ADD_ALL_TESTS(test_evp_aead_tag_direction, cipher_list_n);
 
     ADD_ALL_TESTS(test_evp_init_seq, OSSL_NELEM(evp_init_tests));
     ADD_ALL_TESTS(test_evp_reset, OSSL_NELEM(evp_reset_tests));

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -5953,8 +5953,19 @@ static int test_evp_aead_tag_direction(int idx)
     char *errmsg = NULL;
     unsigned long err_code = 0;
 
-    /* only AEADs have a tag to misuse */
-    if (info->taglen == 0)
+    /* filter out various modes */
+    if (info->taglen == 0
+        || info->mode == EVP_CIPH_GCM_MODE
+        || info->mode == EVP_CIPH_OCB_MODE
+        || info->mode == EVP_CIPH_GCM_SIV_MODE
+        /* skip TLS stitched MTE cipher */
+        || EVP_CIPHER_is_a(info->ciph, "AES-128-CBC-HMAC-SHA1")
+        /* skip TLS stitched MTE cipher */
+        || EVP_CIPHER_is_a(info->ciph, "AES-256-CBC-HMAC-SHA1")
+        /* skip TLS stitched MTE cipher */
+        || EVP_CIPHER_is_a(info->ciph, "AES-128-CBC-HMAC-SHA256")
+        /* skip TLS stitched MTE cipher */
+        || EVP_CIPHER_is_a(info->ciph, "AES-256-CBC-HMAC-SHA256"))
         return 1;
 
     /* bound the tag buffer, should never happen but helps static analysis */


### PR DESCRIPTION
With AEAD ciphers, a tag is an input for decryption (the value to verify) and an output of encryption (the generated value). Therefore:
- supplying a tag value while encrypting must fail
- reading a tag while decrypting must fail
- error codes should be consistent across all AEADs

##### Checklist
- [x] tests are added or updated
