### PR TITLE
ssl_ciph: restore comp->method and comp->name assignments

### DIFF
--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -2003,11 +2003,13 @@ int SSL_COMP_add_compression_method(int id, COMP_METHOD *cm)
         return 1;
     }
 
-    comp = OPENSSL_malloc(sizeof(*comp));
+    comp = OPENSSL_zalloc(sizeof(*comp));
     if (comp == NULL)
         return 1;
 
     comp->id = id;
+    comp->method = cm;
+    comp->name = COMP_get_name(cm);
     if (sk_SSL_COMP_find(comp_methods, comp) >= 0) {
         OPENSSL_free(comp);
         ERR_raise(ERR_LIB_SSL, SSL_R_DUPLICATE_COMPRESSION_ID);


### PR DESCRIPTION
PR#24414 moved the SSL_COMP stack to a per-OSSL_LIB_CTX structure but accidentally dropped the `comp->method` and `comp->name` field assignments, leaving them uninitialised after `OPENSSL_malloc`. The validated cm argument was silently discarded, causing a wild-pointer dereference in `COMP_CTX_new (comp_lib.c:28)` when the registered method was later used.

Restore both assignments and switch to `OPENSSL_zalloc` as a secondary defensive measure.

Fixes #31690

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
