### PR TITLE
Remove QUIC_TSERVER: Move script_10 to script_14

### DIFF
--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2154,42 +2154,8 @@ static const struct script_op script_10[] = {
 };
 
 /* 11. Many threads accepted on the same client connection */
-static const struct script_op script_11_child[] = {
-    OP_C_ACCEPT_STREAM_WAIT(a),
-    OP_C_READ_EXPECT(a, "foo", 3),
-    OP_SLEEP(10),
-    OP_C_EXPECT_FIN(a),
-
-    OP_END
-};
-
 static const struct script_op script_11[] = {
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_NONE),
-
-    OP_NEW_THREAD(5, script_11_child),
-
-    OP_S_NEW_STREAM_BIDI(a, ANY_ID),
-    OP_S_WRITE(a, "foo", 3),
-    OP_S_CONCLUDE(a),
-
-    OP_S_NEW_STREAM_BIDI(b, ANY_ID),
-    OP_S_WRITE(b, "foo", 3),
-    OP_S_CONCLUDE(b),
-
-    OP_S_NEW_STREAM_BIDI(c, ANY_ID),
-    OP_S_WRITE(c, "foo", 3),
-    OP_S_CONCLUDE(c),
-
-    OP_S_NEW_STREAM_BIDI(d, ANY_ID),
-    OP_S_WRITE(d, "foo", 3),
-    OP_S_CONCLUDE(d),
-
-    OP_S_NEW_STREAM_BIDI(e, ANY_ID),
-    OP_S_WRITE(e, "foo", 3),
-    OP_S_CONCLUDE(e),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2149,17 +2149,7 @@ static const struct script_op script_9[] = {
 
 /* 10. Shutdown */
 static const struct script_op script_10[] = {
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-
-    OP_C_WRITE(DEFAULT, "apple", 5),
-    OP_S_BIND_STREAM_ID(a, C_BIDI_ID(0)),
-    OP_S_READ_EXPECT(a, "apple", 5),
-
-    OP_C_SHUTDOWN_WAIT(NULL, 0),
-    OP_C_EXPECT_CONN_CLOSE_INFO(0, 1, 0),
-    OP_S_EXPECT_CONN_CLOSE_INFO(0, 1, 1),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2172,35 +2172,8 @@ static const struct script_op script_13[] = {
 };
 
 /* 14. Many threads initiating on the same client connection (stress test) */
-static const struct script_op script_14_child[] = {
-    OP_BEGIN_REPEAT(10),
-
-    OP_C_NEW_STREAM_BIDI(a, ANY_ID),
-    OP_C_WRITE(a, "foo", 3),
-    OP_C_CONCLUDE(a),
-    OP_C_FREE_STREAM(a),
-
-    OP_END_REPEAT(),
-
-    OP_END
-};
-
 static const struct script_op script_14[] = {
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_NONE),
-
-    OP_NEW_THREAD(5, script_14_child),
-
-    OP_BEGIN_REPEAT(50),
-
-    OP_S_ACCEPT_STREAM_WAIT(a),
-    OP_S_READ_EXPECT(a, "foo", 3),
-    OP_S_EXPECT_FIN(a),
-    OP_S_UNBIND_STREAM_ID(a),
-
-    OP_END_REPEAT(),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2166,35 +2166,8 @@ static const struct script_op script_12[] = {
 };
 
 /* 13. Many threads accepted on the same client connection (stress test) */
-static const struct script_op script_13_child[] = {
-    OP_BEGIN_REPEAT(10),
-
-    OP_C_ACCEPT_STREAM_WAIT(a),
-    OP_C_READ_EXPECT(a, "foo", 3),
-    OP_C_EXPECT_FIN(a),
-    OP_C_FREE_STREAM(a),
-
-    OP_END_REPEAT(),
-
-    OP_END
-};
-
 static const struct script_op script_13[] = {
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_NONE),
-
-    OP_NEW_THREAD(5, script_13_child),
-
-    OP_BEGIN_REPEAT(50),
-
-    OP_S_NEW_STREAM_BIDI(a, ANY_ID),
-    OP_S_WRITE(a, "foo", 3),
-    OP_S_CONCLUDE(a),
-    OP_S_UNBIND_STREAM_ID(a),
-
-    OP_END_REPEAT(),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -2160,38 +2160,8 @@ static const struct script_op script_11[] = {
 };
 
 /* 12. Many threads initiated on the same client connection */
-static const struct script_op script_12_child[] = {
-    OP_C_NEW_STREAM_BIDI(a, ANY_ID),
-    OP_C_WRITE(a, "foo", 3),
-    OP_C_CONCLUDE(a),
-    OP_C_FREE_STREAM(a),
-
-    OP_END
-};
-
 static const struct script_op script_12[] = {
-    OP_C_SET_ALPN("ossltest"),
-    OP_C_CONNECT_WAIT(),
-    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_NONE),
-
-    OP_NEW_THREAD(5, script_12_child),
-
-    OP_S_BIND_STREAM_ID(a, C_BIDI_ID(0)),
-    OP_S_READ_EXPECT(a, "foo", 3),
-    OP_S_EXPECT_FIN(a),
-    OP_S_BIND_STREAM_ID(b, C_BIDI_ID(1)),
-    OP_S_READ_EXPECT(b, "foo", 3),
-    OP_S_EXPECT_FIN(b),
-    OP_S_BIND_STREAM_ID(c, C_BIDI_ID(2)),
-    OP_S_READ_EXPECT(c, "foo", 3),
-    OP_S_EXPECT_FIN(c),
-    OP_S_BIND_STREAM_ID(d, C_BIDI_ID(3)),
-    OP_S_READ_EXPECT(d, "foo", 3),
-    OP_S_EXPECT_FIN(d),
-    OP_S_BIND_STREAM_ID(e, C_BIDI_ID(4)),
-    OP_S_READ_EXPECT(e, "foo", 3),
-    OP_S_EXPECT_FIN(e),
-
+    /* test moved to test/radix/quic_tests.c */
     OP_END
 };
 

--- a/test/radix/quic_bindings.c
+++ b/test/radix/quic_bindings.c
@@ -502,12 +502,23 @@ static int RADIX_PROCESS_set_ssl(RADIX_PROCESS *rp, const char *name, SSL *ssl)
 
 static SSL *RADIX_PROCESS_get_ssl(RADIX_PROCESS *rp, const char *name)
 {
-    RADIX_OBJ *obj = RADIX_PROCESS_get_obj(rp, name);
+    RADIX_OBJ key;
+    RADIX_OBJ *obj;
+    SSL *ssl = NULL;
 
-    if (obj == NULL)
-        return NULL;
-
-    return obj->ssl;
+    key.name = (char *)name;
+#if defined(OPENSSL_THREADS)
+    ossl_crypto_mutex_lock(rp->gm);
+#endif
+    obj = lh_RADIX_OBJ_retrieve(rp->objs, &key);
+    if (obj != NULL) {
+        ssl = obj->ssl;
+        SSL_up_ref(ssl);
+    }
+#if defined(OPENSSL_THREADS)
+    ossl_crypto_mutex_unlock(rp->gm);
+#endif
+    return ssl;
 }
 
 static RADIX_THREAD *RADIX_THREAD_new(RADIX_PROCESS *rp)

--- a/test/radix/quic_bindings.c
+++ b/test/radix/quic_bindings.c
@@ -435,23 +435,37 @@ static void RADIX_PROCESS_cleanup(RADIX_PROCESS *rp)
 static RADIX_OBJ *RADIX_PROCESS_get_obj(RADIX_PROCESS *rp, const char *name)
 {
     RADIX_OBJ key;
+    RADIX_OBJ *obj;
 
     key.name = (char *)name;
-    return lh_RADIX_OBJ_retrieve(rp->objs, &key);
+#if defined(OPENSSL_THREADS)
+    ossl_crypto_mutex_lock(rp->gm);
+#endif
+    obj = lh_RADIX_OBJ_retrieve(rp->objs, &key);
+#if defined(OPENSSL_THREADS)
+    ossl_crypto_mutex_unlock(rp->gm);
+#endif
+    return obj;
 }
 
 static int RADIX_PROCESS_set_obj(RADIX_PROCESS *rp,
     const char *name, RADIX_OBJ *obj)
 {
+    RADIX_OBJ key;
     RADIX_OBJ *existing;
+    int ok = 0;
 
     if (obj != NULL && !TEST_false(obj->registered))
         return 0;
 
-    existing = RADIX_PROCESS_get_obj(rp, name);
+#if defined(OPENSSL_THREADS)
+    ossl_crypto_mutex_lock(rp->gm);
+#endif
+    key.name = (char *)name;
+    existing = lh_RADIX_OBJ_retrieve(rp->objs, &key);
     if (existing != NULL && obj != existing) {
         if (!TEST_true(existing->registered))
-            return 0;
+            goto err;
 
         lh_RADIX_OBJ_delete(rp->objs, existing);
         existing->registered = 0;
@@ -463,7 +477,12 @@ static int RADIX_PROCESS_set_obj(RADIX_PROCESS *rp,
         obj->registered = 1;
     }
 
-    return 1;
+    ok = 1;
+err:
+#if defined(OPENSSL_THREADS)
+    ossl_crypto_mutex_unlock(rp->gm);
+#endif
+    return ok;
 }
 
 static int RADIX_PROCESS_set_ssl(RADIX_PROCESS *rp, const char *name, SSL *ssl)
@@ -733,6 +752,7 @@ static int RADIX_THREAD_worker_run(RADIX_THREAD *rt)
     cfg.debug_bio = rt->debug_bio;
     if (!TEST_true(bindings_adjust_terp_config(&cfg)))
         goto err;
+    cfg.per_op_cb = NULL;
 
     if (!TERP_run(rt->child_script_info, &cfg))
         goto err;

--- a/test/radix/quic_bindings.c
+++ b/test/radix/quic_bindings.c
@@ -149,8 +149,9 @@ static int RADIX_PROCESS_init(RADIX_PROCESS *rp, size_t node_idx, size_t process
 {
     const char *keylog_path;
 
+    rp->gm = ossl_crypto_mutex_new();
 #if defined(OPENSSL_THREADS)
-    if (!TEST_ptr(rp->gm = ossl_crypto_mutex_new()))
+    if (!TEST_ptr(rp->gm))
         goto err;
 #endif
 
@@ -438,13 +439,9 @@ static RADIX_OBJ *RADIX_PROCESS_get_obj(RADIX_PROCESS *rp, const char *name)
     RADIX_OBJ *obj;
 
     key.name = (char *)name;
-#if defined(OPENSSL_THREADS)
     ossl_crypto_mutex_lock(rp->gm);
-#endif
     obj = lh_RADIX_OBJ_retrieve(rp->objs, &key);
-#if defined(OPENSSL_THREADS)
     ossl_crypto_mutex_unlock(rp->gm);
-#endif
     return obj;
 }
 
@@ -458,9 +455,7 @@ static int RADIX_PROCESS_set_obj(RADIX_PROCESS *rp,
     if (obj != NULL && !TEST_false(obj->registered))
         return 0;
 
-#if defined(OPENSSL_THREADS)
     ossl_crypto_mutex_lock(rp->gm);
-#endif
     key.name = (char *)name;
     existing = lh_RADIX_OBJ_retrieve(rp->objs, &key);
     if (existing != NULL && obj != existing) {
@@ -479,9 +474,7 @@ static int RADIX_PROCESS_set_obj(RADIX_PROCESS *rp,
 
     ok = 1;
 err:
-#if defined(OPENSSL_THREADS)
     ossl_crypto_mutex_unlock(rp->gm);
-#endif
     return ok;
 }
 
@@ -507,17 +500,13 @@ static SSL *RADIX_PROCESS_get_ssl(RADIX_PROCESS *rp, const char *name)
     SSL *ssl = NULL;
 
     key.name = (char *)name;
-#if defined(OPENSSL_THREADS)
     ossl_crypto_mutex_lock(rp->gm);
-#endif
     obj = lh_RADIX_OBJ_retrieve(rp->objs, &key);
     if (obj != NULL) {
         ssl = obj->ssl;
         SSL_up_ref(ssl);
     }
-#if defined(OPENSSL_THREADS)
     ossl_crypto_mutex_unlock(rp->gm);
-#endif
     return ssl;
 }
 
@@ -531,8 +520,9 @@ static RADIX_THREAD *RADIX_THREAD_new(RADIX_PROCESS *rp)
 
     rt->rp = rp;
 
+    rt->m = ossl_crypto_mutex_new();
 #if defined(OPENSSL_THREADS)
-    if (!TEST_ptr(rt->m = ossl_crypto_mutex_new())) {
+    if (!TEST_ptr(rt->m)) {
         OPENSSL_free(rt);
         return 0;
     }

--- a/test/radix/quic_ops.c
+++ b/test/radix/quic_ops.c
@@ -337,7 +337,7 @@ DEF_FUNC(hf_accept_stream_none)
     int ok = 0;
     const char *conn_name;
     uint64_t flags;
-    SSL *conn, *stream;
+    SSL *conn = NULL, *stream;
 
     F_POP2(conn_name, flags);
 
@@ -345,6 +345,8 @@ DEF_FUNC(hf_accept_stream_none)
         goto err;
 
     stream = SSL_accept_stream(conn, flags);
+    SSL_free(conn);
+    conn = NULL;
     if (!TEST_ptr_null(stream)) {
         SSL_free(stream);
         goto err;
@@ -352,6 +354,7 @@ DEF_FUNC(hf_accept_stream_none)
 
     ok = 1;
 err:
+    SSL_free(conn);
     return ok;
 }
 

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -798,8 +798,18 @@ DEF_SCRIPT(script_9, "place holder for multistrem script_9")
 {
 }
 
-DEF_SCRIPT(script_10, "place holder for multistrem script_10")
+/* 10. Shutdown */
+DEF_SCRIPT(script_10, "Shutdown test")
 {
+    OP_SIMPLE_PAIR_CONN();
+
+    OP_WRITE(C, "apple", 5);
+    OP_ACCEPT_CONN_WAIT(L, S, 0);
+    OP_READ_EXPECT(S, "apple", 5);
+
+    OP_SHUTDOWN_WAIT(C, 0, 0, NULL);
+    OP_EXPECT_CONN_CLOSE_INFO(C, 0, 1, 0);
+    OP_EXPECT_CONN_CLOSE_INFO(S, 0, 1, 1);
 }
 
 DEF_SCRIPT(script_11, "place holder for multistrem script_11")

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -812,8 +812,75 @@ DEF_SCRIPT(script_10, "Shutdown test")
     OP_EXPECT_CONN_CLOSE_INFO(S, 0, 1, 1);
 }
 
-DEF_SCRIPT(script_11, "place holder for multistrem script_11")
+DEF_FUNC(accept_stream_c_slot0_11)
 {
+    int ok = 0;
+    SSL *conn, *stream;
+
+    conn = RADIX_PROCESS_get_ssl(RP(), "C");
+    if (!TEST_ptr(conn))
+        goto err;
+
+    stream = SSL_accept_stream(conn, SSL_ACCEPT_STREAM_NO_BLOCK);
+    if (stream == NULL)
+        F_SPIN_AGAIN();
+
+    RT()->slot[0] = NULL;
+    RT()->ssl[0] = stream;
+    ok = 1;
+err:
+    return ok;
+}
+
+DEF_FUNC(free_slot0_stream_11)
+{
+    SSL_free(RT()->ssl[0]);
+    RT()->ssl[0] = NULL;
+    RT()->slot[0] = NULL;
+    return 1;
+}
+
+/* 11. Many threads accepted on the same client connection */
+DEF_SCRIPT(script_11_child,
+    "child: accept stream from C, read, sleep, expect FIN")
+{
+    OP_FUNC(accept_stream_c_slot0_11);
+    OP_PUSH_BUFP("foo", 3);
+    OP_FUNC(hf_read_expect);
+    OP_SLEEP(10);
+    OP_FUNC(hf_expect_fin);
+    OP_FUNC(free_slot0_stream_11);
+}
+
+DEF_SCRIPT(script_11, "Many threads accepted on same client connection")
+{
+    size_t i;
+
+    OP_SIMPLE_PAIR_CONN_ND();
+    OP_ACCEPT_CONN_WAIT_ND(L, S, 0);
+
+    for (i = 0; i < 5; ++i)
+        OP_SPAWN_THREAD(script_11_child);
+
+    OP_NEW_STREAM(S, Sa, 0 /* bidirectional */);
+    OP_WRITE(Sa, "foo", 3);
+    OP_CONCLUDE(Sa);
+
+    OP_NEW_STREAM(S, Sb, 0 /* bidirectional */);
+    OP_WRITE(Sb, "foo", 3);
+    OP_CONCLUDE(Sb);
+
+    OP_NEW_STREAM(S, Sc, 0 /* bidirectional */);
+    OP_WRITE(Sc, "foo", 3);
+    OP_CONCLUDE(Sc);
+
+    OP_NEW_STREAM(S, Sd, 0 /* bidirectional */);
+    OP_WRITE(Sd, "foo", 3);
+    OP_CONCLUDE(Sd);
+
+    OP_NEW_STREAM(S, Se, 0 /* bidirectional */);
+    OP_WRITE(Se, "foo", 3);
+    OP_CONCLUDE(Se);
 }
 
 DEF_SCRIPT(script_12, "place holder for multistrem script_12")

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -812,7 +812,7 @@ DEF_SCRIPT(script_10, "Shutdown test")
     OP_EXPECT_CONN_CLOSE_INFO(S, 0, 1, 1);
 }
 
-DEF_FUNC(accept_stream_c_slot0_11)
+DEF_FUNC(accept_stream_c_slot0)
 {
     int ok = 0;
     SSL *conn, *stream;
@@ -822,6 +822,8 @@ DEF_FUNC(accept_stream_c_slot0_11)
         goto err;
 
     stream = SSL_accept_stream(conn, SSL_ACCEPT_STREAM_NO_BLOCK);
+    SSL_free(conn);
+    conn = NULL;
     if (stream == NULL)
         F_SPIN_AGAIN();
 
@@ -829,10 +831,11 @@ DEF_FUNC(accept_stream_c_slot0_11)
     RT()->ssl[0] = stream;
     ok = 1;
 err:
+    SSL_free(conn);
     return ok;
 }
 
-DEF_FUNC(free_slot0_stream_11)
+DEF_FUNC(free_slot0_stream)
 {
     SSL_free(RT()->ssl[0]);
     RT()->ssl[0] = NULL;
@@ -844,12 +847,12 @@ DEF_FUNC(free_slot0_stream_11)
 DEF_SCRIPT(script_11_child,
     "child: accept stream from C, read, sleep, expect FIN")
 {
-    OP_FUNC(accept_stream_c_slot0_11);
+    OP_FUNC(accept_stream_c_slot0);
     OP_PUSH_BUFP("foo", 3);
     OP_FUNC(hf_read_expect);
     OP_SLEEP(10);
     OP_FUNC(hf_expect_fin);
-    OP_FUNC(free_slot0_stream_11);
+    OP_FUNC(free_slot0_stream);
 }
 
 DEF_SCRIPT(script_11, "Many threads accepted on same client connection")
@@ -883,7 +886,7 @@ DEF_SCRIPT(script_11, "Many threads accepted on same client connection")
     OP_CONCLUDE(Se);
 }
 
-DEF_FUNC(new_stream_c_slot0_12)
+DEF_FUNC(new_stream_c_slot0)
 {
     int ok = 0;
     SSL *conn, *stream;
@@ -893,6 +896,8 @@ DEF_FUNC(new_stream_c_slot0_12)
         goto err;
 
     stream = SSL_new_stream(conn, 0 /* bidirectional */);
+    SSL_free(conn);
+    conn = NULL;
     if (!TEST_ptr(stream))
         goto err;
 
@@ -900,6 +905,7 @@ DEF_FUNC(new_stream_c_slot0_12)
     RT()->ssl[0] = stream;
     ok = 1;
 err:
+    SSL_free(conn);
     return ok;
 }
 
@@ -907,11 +913,11 @@ err:
 DEF_SCRIPT(script_12_child,
     "child: create stream on C, write, conclude, free")
 {
-    OP_FUNC(new_stream_c_slot0_12);
+    OP_FUNC(new_stream_c_slot0);
     OP_PUSH_BUFP("foo", 3);
     OP_FUNC(hf_write);
     OP_FUNC(hf_conclude);
-    OP_FUNC(free_slot0_stream_11);
+    OP_FUNC(free_slot0_stream);
 }
 
 DEF_SCRIPT(script_12, "Many threads initiated on same client connection")
@@ -952,11 +958,11 @@ DEF_SCRIPT(script_13_child,
     size_t i;
 
     for (i = 0; i < 10; ++i) {
-        OP_FUNC(accept_stream_c_slot0_11);
+        OP_FUNC(accept_stream_c_slot0);
         OP_PUSH_BUFP("foo", 3);
         OP_FUNC(hf_read_expect);
         OP_FUNC(hf_expect_fin);
-        OP_FUNC(free_slot0_stream_11);
+        OP_FUNC(free_slot0_stream);
     }
 }
 
@@ -986,11 +992,11 @@ DEF_SCRIPT(script_14_child,
     size_t i;
 
     for (i = 0; i < 10; ++i) {
-        OP_FUNC(new_stream_c_slot0_12);
+        OP_FUNC(new_stream_c_slot0);
         OP_PUSH_BUFP("foo", 3);
         OP_FUNC(hf_write);
         OP_FUNC(hf_conclude);
-        OP_FUNC(free_slot0_stream_11);
+        OP_FUNC(free_slot0_stream);
     }
 }
 

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -979,8 +979,38 @@ DEF_SCRIPT(script_13,
     }
 }
 
-DEF_SCRIPT(script_14, "place holder for multistrem script_14")
+/* 14. Many threads initiating on the same client connection (stress test) */
+DEF_SCRIPT(script_14_child,
+    "child: 10x create stream on C, write, conclude, free")
 {
+    size_t i;
+
+    for (i = 0; i < 10; ++i) {
+        OP_FUNC(new_stream_c_slot0_12);
+        OP_PUSH_BUFP("foo", 3);
+        OP_FUNC(hf_write);
+        OP_FUNC(hf_conclude);
+        OP_FUNC(free_slot0_stream_11);
+    }
+}
+
+DEF_SCRIPT(script_14,
+    "Many threads initiating on same client connection (stress test)")
+{
+    size_t i;
+
+    OP_SIMPLE_PAIR_CONN_ND();
+    OP_ACCEPT_CONN_WAIT_ND(L, S, 0);
+
+    for (i = 0; i < 5; ++i)
+        OP_SPAWN_THREAD(script_14_child);
+
+    for (i = 0; i < 50; ++i) {
+        OP_ACCEPT_STREAM_WAIT(S, Sa, 0);
+        OP_READ_EXPECT(Sa, "foo", 3);
+        OP_EXPECT_FIN(Sa);
+        OP_UNBIND(Sa);
+    }
 }
 
 DEF_SCRIPT(script_15, "place holder for multistrem script_15")

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -883,8 +883,66 @@ DEF_SCRIPT(script_11, "Many threads accepted on same client connection")
     OP_CONCLUDE(Se);
 }
 
-DEF_SCRIPT(script_12, "place holder for multistrem script_12")
+DEF_FUNC(new_stream_c_slot0_12)
 {
+    int ok = 0;
+    SSL *conn, *stream;
+
+    conn = RADIX_PROCESS_get_ssl(RP(), "C");
+    if (!TEST_ptr(conn))
+        goto err;
+
+    stream = SSL_new_stream(conn, 0 /* bidirectional */);
+    if (!TEST_ptr(stream))
+        goto err;
+
+    RT()->slot[0] = NULL;
+    RT()->ssl[0] = stream;
+    ok = 1;
+err:
+    return ok;
+}
+
+/* 12. Many threads initiated on the same client connection */
+DEF_SCRIPT(script_12_child,
+    "child: create stream on C, write, conclude, free")
+{
+    OP_FUNC(new_stream_c_slot0_12);
+    OP_PUSH_BUFP("foo", 3);
+    OP_FUNC(hf_write);
+    OP_FUNC(hf_conclude);
+    OP_FUNC(free_slot0_stream_11);
+}
+
+DEF_SCRIPT(script_12, "Many threads initiated on same client connection")
+{
+    size_t i;
+
+    OP_SIMPLE_PAIR_CONN_ND();
+    OP_ACCEPT_CONN_WAIT_ND(L, S, 0);
+
+    for (i = 0; i < 5; ++i)
+        OP_SPAWN_THREAD(script_12_child);
+
+    OP_ACCEPT_STREAM_WAIT(S, Sa, 0);
+    OP_READ_EXPECT(Sa, "foo", 3);
+    OP_EXPECT_FIN(Sa);
+
+    OP_ACCEPT_STREAM_WAIT(S, Sb, 0);
+    OP_READ_EXPECT(Sb, "foo", 3);
+    OP_EXPECT_FIN(Sb);
+
+    OP_ACCEPT_STREAM_WAIT(S, Sc, 0);
+    OP_READ_EXPECT(Sc, "foo", 3);
+    OP_EXPECT_FIN(Sc);
+
+    OP_ACCEPT_STREAM_WAIT(S, Sd, 0);
+    OP_READ_EXPECT(Sd, "foo", 3);
+    OP_EXPECT_FIN(Sd);
+
+    OP_ACCEPT_STREAM_WAIT(S, Se, 0);
+    OP_READ_EXPECT(Se, "foo", 3);
+    OP_EXPECT_FIN(Se);
 }
 
 DEF_SCRIPT(script_13, "place holder for multistrem script_13")

--- a/test/radix/quic_tests.c
+++ b/test/radix/quic_tests.c
@@ -945,8 +945,38 @@ DEF_SCRIPT(script_12, "Many threads initiated on same client connection")
     OP_EXPECT_FIN(Se);
 }
 
-DEF_SCRIPT(script_13, "place holder for multistrem script_13")
+/* 13. Many threads accepted on the same client connection (stress test) */
+DEF_SCRIPT(script_13_child,
+    "child: 10x accept stream from C, read, expect FIN, free")
 {
+    size_t i;
+
+    for (i = 0; i < 10; ++i) {
+        OP_FUNC(accept_stream_c_slot0_11);
+        OP_PUSH_BUFP("foo", 3);
+        OP_FUNC(hf_read_expect);
+        OP_FUNC(hf_expect_fin);
+        OP_FUNC(free_slot0_stream_11);
+    }
+}
+
+DEF_SCRIPT(script_13,
+    "Many threads accepted on same client connection (stress test)")
+{
+    size_t i;
+
+    OP_SIMPLE_PAIR_CONN_ND();
+    OP_ACCEPT_CONN_WAIT_ND(L, S, 0);
+
+    for (i = 0; i < 5; ++i)
+        OP_SPAWN_THREAD(script_13_child);
+
+    for (i = 0; i < 50; ++i) {
+        OP_NEW_STREAM(S, Sa, 0 /* bidirectional */);
+        OP_WRITE(Sa, "foo", 3);
+        OP_CONCLUDE(Sa);
+        OP_UNBIND(Sa);
+    }
 }
 
 DEF_SCRIPT(script_14, "place holder for multistrem script_14")


### PR DESCRIPTION
Fixed some issues with threading when TSAN is enabled:
- Add locking around all `lh_RADIX_OBJ_*` calls
- Set `cfg.per_op_cb = NULL` in `RADIX_THREAD_worker_run` so only the main thread ticks SSL objects

Fixes https://github.com/openssl/project/issues/1986

##### Checklist

- [x] tests are added or updated