### PR TITLE
Changes internal prov_drbg_st member variable type

### DIFF
--- a/providers/implementations/include/prov/drbg.h
+++ b/providers/implementations/include/prov/drbg.h
@@ -46,13 +46,6 @@
 
 typedef struct prov_drbg_st PROV_DRBG;
 
-/* DRBG status values */
-typedef enum drbg_status_e {
-    DRBG_UNINITIALISED,
-    DRBG_READY,
-    DRBG_ERROR
-} DRBG_STATUS;
-
 /*
  * The state of all types of DRBGs.
  */
@@ -149,7 +142,11 @@ struct prov_drbg_st {
     unsigned int parent_reseed_counter;
 
     size_t seedlen;
-    DRBG_STATUS state;
+    /*
+     * state is one of: EVP_RAND_STATE_UNINITIALISED, EVP_RAND_STATE_ERROR,
+     * EVP_RAND_STATE_READY.
+     */
+    int state;
 
     /* DRBG specific data */
     void *data;

--- a/providers/implementations/include/prov/drbg.h
+++ b/providers/implementations/include/prov/drbg.h
@@ -23,10 +23,6 @@
 /* How many times to read the TSC as a randomness source. */
 #define TSC_READ_COUNT 4
 
-/* Maximum reseed intervals */
-#define MAX_RESEED_INTERVAL (1 << 24)
-#define MAX_RESEED_TIME_INTERVAL (1 << 20) /* approx. 12 days */
-
 /* Default reseed intervals */
 #define RESEED_INTERVAL (1 << 8)
 #define TIME_INTERVAL (60 * 60) /* 1 hour */

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -182,7 +182,7 @@ static int test_drbg_reseed(int expect_success,
     time_t reseed_when)
 {
     time_t before_reseed, after_reseed;
-    int expected_state = (expect_success ? DRBG_READY : DRBG_ERROR);
+    int expected_state = (expect_success ? EVP_RAND_STATE_READY : EVP_RAND_STATE_ERROR);
     unsigned int primary_reseed, public_reseed, private_reseed;
     unsigned char dummy[RANDOM_SIZE];
 


### PR DESCRIPTION
Turns out that `prov_drbg_st` member variable `state` is always set and checked with the macros `EVP_RAND_STATE_XXX` which luckily matched the enum values of `DRBG_STATUS`. `EVP_RAND_STATE_XXX` is part of the public interface which also exposes the `state` variable. So this removes the enum definition and changes the variable type to int.

Also removes some unused macros from drbg.h.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
