### PR TITLE
Fix quic_srt_gen mfail test on s390

### DIFF
--- a/crypto/hmac/hmac.c
+++ b/crypto/hmac/hmac.c
@@ -53,9 +53,21 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len,
         return 0;
 
 #ifdef OPENSSL_HMAC_S390X
+    /*
+     * Note: Error aliasing below.  s390_HMAC_init returns 0/1
+     * in the same way HMAC_Init_ex does, except in the case that
+     * the hardware doesn't have the needed support in the kmac
+     * instruction, in which case it returns -1
+     * In that case we fall through to the software implementation
+     * below, but we need to set rv to 0, so HMAC_Init_ex doesn't
+     * erroneously return -1, which is counter to our documentation
+     * for the function
+     */
     rv = s390x_HMAC_init(ctx, key, len);
     if (rv != -1)
         return rv;
+    else
+        rv = 0;
 #endif
 
     if (key != NULL) {


### PR DESCRIPTION
Nightly os-zoo CI is failing on S390, due to a broken mfail test

https://github.com/openssl/openssl/actions/runs/28216669004/job/83589067060

Its occuring because on s390, HMAC_Init_ex uses s390 hardware offload which returns -1 in the event that the platform we're running on doesn't support the needed offload.  In and of itself, thats fine, as we fall back to the software implementation, but if we encounter a subsequent error (such as those the mfail tests intoduce, the -1 value leaks back in the return from HMAC_Init_ex, and bubbles up the stack to EVP_MAC_init().

Because EVP_MAC_init is documented to return only 1 or 0, the check:

if (!EVP_MAC_init(...))

errneously passes when we don't expect it to, and the mfail tests fail.

Fix it by restoring a proper 0 return in the event that s390 doesn't support hardware offload.

