### PR TITLE
Fix coverity issues stemming from making `EVP_*_free` no-ops

### DIFF
--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -453,7 +453,7 @@ static void *evp_asym_cipher_from_algorithm(int name_id,
 
     return cipher;
 err:
-    EVP_ASYM_CIPHER_free(cipher);
+    evp_asym_cipher_free(cipher);
     return NULL;
 }
 

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -169,7 +169,7 @@ static void *evp_keyexch_from_algorithm(int name_id,
     return exchange;
 
 err:
-    EVP_KEYEXCH_free(exchange);
+    evp_keyexch_free(exchange);
     return NULL;
 }
 

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -442,7 +442,7 @@ static void *evp_kem_from_algorithm(int name_id, const OSSL_ALGORITHM *algodef,
 
     return kem;
 err:
-    EVP_KEM_free(kem);
+    evp_kem_free(kem);
     return NULL;
 }
 

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -93,7 +93,7 @@ static void *keymgmt_from_algorithm(int name_id,
 
     keymgmt->name_id = name_id;
     if ((keymgmt->type_name = ossl_algorithm_get1_first_name(algodef)) == NULL) {
-        EVP_KEYMGMT_free(keymgmt);
+        evp_keymgmt_free(keymgmt);
         return NULL;
     }
     keymgmt->description = algodef->algorithm_description;
@@ -269,13 +269,13 @@ static void *keymgmt_from_algorithm(int name_id,
         || (keymgmt->gen != NULL
             && (keymgmt->gen_init == NULL
                 || keymgmt->gen_cleanup == NULL))) {
-        EVP_KEYMGMT_free(keymgmt);
+        evp_keymgmt_free(keymgmt);
         ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_PROVIDER_FUNCTIONS);
         return NULL;
     }
     keymgmt->prov = prov;
     if (prov != NULL && !ossl_provider_up_ref(prov)) {
-        EVP_KEYMGMT_free(keymgmt);
+        evp_keymgmt_free(keymgmt);
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         return NULL;
     }

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -50,7 +50,7 @@ static void *keymgmt_new(void)
     if ((keymgmt = OPENSSL_zalloc(sizeof(*keymgmt))) == NULL)
         return NULL;
     if (!CRYPTO_NEW_REF(&keymgmt->refcnt, 1)) {
-        EVP_KEYMGMT_free(keymgmt);
+        OPENSSL_free(keymgmt);
         return NULL;
     }
     return keymgmt;

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -463,7 +463,7 @@ static void *evp_signature_from_algorithm(int name_id,
 
     return signature;
 err:
-    EVP_SIGNATURE_free(signature);
+    evp_signature_free(signature);
     return NULL;
 }
 


### PR DESCRIPTION
Several coverity issues reported:

https://scan5.scan.coverity.com/#/project-view/60762/10222?selectedIssue=1695449
https://scan5.scan.coverity.com/#/project-view/60762/10222?selectedIssue=1695450
https://scan5.scan.coverity.com/#/project-view/60762/10222?selectedIssue=1695452
https://scan5.scan.coverity.com/#/project-view/60762/10222?selectedIssue=1695455
https://scan5.scan.coverity.com/#/project-view/60762/10222?selectedIssue=1695456


All stemming from the same pattern.  With the migration to `EVP_*_free` being no-ops now, the corresponding from_algorithm functions used in alg construction should use the internal variants `evp_*_free` to actually free these objects on their error path, so as to avoid leakage.