### PR TITLE
Eliminate CRYPTO_GET_REF

### DIFF
--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -116,24 +116,22 @@ BIO *BIO_new(const BIO_METHOD *method)
     return BIO_new_ex(NULL, method);
 }
 
-int BIO_free(BIO *a)
+static int BIO_free_int(BIO *a, int *ret)
 {
-    int ret;
 
     if (a == NULL)
         return 0;
 
-    if (CRYPTO_DOWN_REF(&a->references, &ret) <= 0)
+    if (CRYPTO_DOWN_REF(&a->references, ret) <= 0)
         return 0;
 
-    REF_PRINT_COUNT("BIO", ret, a);
-    if (ret > 0)
+    REF_PRINT_COUNT("BIO", *ret, a);
+    if (*ret > 0)
         return 1;
-    REF_ASSERT_ISNT(ret < 0);
+    REF_ASSERT_ISNT(*ret < 0);
 
     if (HAS_CALLBACK(a)) {
-        ret = (int)bio_call_callback(a, BIO_CB_FREE, NULL, 0, 0, 0L, 1L, NULL);
-        if (ret <= 0)
+        if ((int)bio_call_callback(a, BIO_CB_FREE, NULL, 0, 0, 0L, 1L, NULL) <= 0)
             return 0;
     }
 
@@ -147,6 +145,13 @@ int BIO_free(BIO *a)
     OPENSSL_free(a);
 
     return 1;
+}
+
+int BIO_free(BIO *b)
+{
+    int ref;
+
+    return BIO_free_int(b, &ref);
 }
 
 void BIO_set_data(BIO *a, void *ptr)
@@ -874,11 +879,11 @@ void BIO_free_all(BIO *bio)
 
     while (bio != NULL) {
         b = bio;
-        CRYPTO_GET_REF(&b->references, &ref);
         bio = bio->next_bio;
-        BIO_free(b);
-        /* Since ref count > 1, don't free anyone else. */
-        if (ref > 1)
+        ref = 0;
+        BIO_free_int(b, &ref);
+        /* Since ref count > 0, don't free anyone else. */
+        if (ref > 0)
             break;
     }
 }

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -68,12 +68,6 @@ static inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
     return 1;
 }
 
-static inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
-{
-    *ret = atomic_load_explicit(&refcnt->val, memory_order_acquire);
-    return 1;
-}
-
 #elif defined(__GNUC__) && defined(__ATOMIC_RELAXED) && __GCC_ATOMIC_INT_LOCK_FREE > 0
 
 #define HAVE_ATOMICS 1
@@ -96,12 +90,6 @@ static __inline__ int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
     return 1;
 }
 
-static __inline__ int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
-{
-    *ret = __atomic_load_n(&refcnt->val, __ATOMIC_RELAXED);
-    return 1;
-}
-
 #elif defined(__ICL) && defined(_WIN32)
 #define HAVE_ATOMICS 1
 
@@ -118,12 +106,6 @@ static __inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 static __inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
     *ret = _InterlockedExchangeAdd((void *)&refcnt->val, -1) - 1;
-    return 1;
-}
-
-static __inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
-{
-    *ret = _InterlockedExchangeAdd((void *)&refcnt->val, 0);
     return 1;
 }
 
@@ -153,12 +135,6 @@ static __inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
     return 1;
 }
 
-static __inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
-{
-    *ret = _InterlockedExchangeAdd_acq((void *)&refcnt->val, 0);
-    return 1;
-}
-
 #else
 #pragma intrinsic(_InterlockedExchangeAdd)
 
@@ -171,12 +147,6 @@ static __inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 static __inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
     *ret = _InterlockedExchangeAdd(&refcnt->val, -1) - 1;
-    return 1;
-}
-
-static __inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
-{
-    *ret = _InterlockedExchangeAdd(&refcnt->val, 0);
     return 1;
 }
 
@@ -213,12 +183,6 @@ static ossl_unused ossl_inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt,
     return CRYPTO_atomic_add(&refcnt->val, -1, ret, refcnt->lock);
 }
 
-static ossl_unused ossl_inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt,
-    int *ret)
-{
-    return CRYPTO_atomic_load_int(&refcnt->val, ret, refcnt->lock);
-}
-
 #define CRYPTO_NEW_FREE_DEFINED 1
 static ossl_unused ossl_inline int CRYPTO_NEW_REF(CRYPTO_REF_COUNT *refcnt, int n)
 {
@@ -251,13 +215,6 @@ static ossl_unused ossl_inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt,
     int *ret)
 {
     refcnt->val--;
-    *ret = refcnt->val;
-    return 1;
-}
-
-static ossl_unused ossl_inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt,
-    int *ret)
-{
     *ret = refcnt->val;
     return 1;
 }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -10601,7 +10601,6 @@ static int test_session_cache_overflow(int idx)
     SSL *serverssl = NULL, *clientssl = NULL;
     int testresult = 0;
     SSL_SESSION *sess = NULL;
-    int references;
 
 #ifdef OSSL_NO_USABLE_TLS1_3
     /* If no TLSv1.3 available then do nothing in this case */
@@ -10672,17 +10671,8 @@ static int test_session_cache_overflow(int idx)
      * The session we just negotiated may have been already removed from the
      * internal cache - but we will return it anyway from our external cache.
      */
-    get_sess_val = SSL_get_session(serverssl);
+    get_sess_val = SSL_get1_session(serverssl);
     if (!TEST_ptr(get_sess_val))
-        goto end;
-    /*
-     * Normally the session is also stored in the cache, thus we have more than
-     * one reference, but due to an out-of-memory error it can happen that this
-     * is the only reference, and in that case the SSL_free(serverssl) below
-     * would free the get_sess_val, causing a use-after-free error.
-     */
-    if (!TEST_true(CRYPTO_GET_REF(&get_sess_val->references, &references))
-        || !TEST_int_ge(references, 2))
         goto end;
     sess = SSL_get1_session(clientssl);
     if (!TEST_ptr(sess))
@@ -10707,6 +10697,7 @@ static int test_session_cache_overflow(int idx)
     testresult = 1;
 
 end:
+    SSL_SESSION_free(get_sess_val);
     SSL_free(serverssl);
     SSL_free(clientssl);
     SSL_CTX_free(sctx);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -10602,6 +10602,8 @@ static int test_session_cache_overflow(int idx)
     int testresult = 0;
     SSL_SESSION *sess = NULL;
 
+    get_sess_val = NULL;
+
 #ifdef OSSL_NO_USABLE_TLS1_3
     /* If no TLSv1.3 available then do nothing in this case */
     if (idx % 2 == 0)
@@ -10698,6 +10700,7 @@ static int test_session_cache_overflow(int idx)
 
 end:
     SSL_SESSION_free(get_sess_val);
+    get_sess_val = NULL;
     SSL_free(serverssl);
     SSL_free(clientssl);
     SSL_CTX_free(sctx);


### PR DESCRIPTION
in #28643 @bernd-edlinger noted some memory constraint problems in CRYPTO_GET_REF, and the conversation there turned to the fact that CRYPTO_GET_REF is in and of itself a really bad API in that its a TOCTOU just waiting to happen, and there's really no need for it.

Its an internal function, and we only have two use cases for it, both of which can be easily replaced with alternative implementations, so lets replace those, and send CRYPTO_GET_REF out to pasture.