### PR TITLE
`demos`: wire up `echecho`, `pkread`, `pkwrite`, and `tls-server-block`

### DIFF
--- a/demos/README.txt
+++ b/demos/README.txt
@@ -84,4 +84,5 @@ rsa_pss_hash.c            Compute and verify an RSA-PSS signature over a buffer
 smime:                 Demonstrations related to S/MIME
 
 sslecho:
+echecho.c              Simple SSL/TLS echo client/server that uses ECH.
 main.c                 Simple SSL/TLS echo client/server.

--- a/demos/README.txt
+++ b/demos/README.txt
@@ -38,6 +38,7 @@ quic-client-non-block.c: A simple non-blocking QUIC client
 quic-multi-stream.c:     A simple QUIC client using multiple streams
 tls-client-block.c:      A simple blocking SSL/TLS client
 tls-client-non-block.c:  A simple non-blocking SSL/TLS client
+tls-server-block.c:      A simple blocking SSL/TLS server
 
 http3:                 Demonstration of how to use OpenSSL's QUIC capabilities
                        for HTTP/3.

--- a/demos/README.txt
+++ b/demos/README.txt
@@ -36,6 +36,8 @@ guide:                   Sample code from the OpenSSL Guide tutorials. See
 quic-client-block.c:     A simple blocking QUIC client
 quic-client-non-block.c: A simple non-blocking QUIC client
 quic-multi-stream.c:     A simple QUIC client using multiple streams
+quic-server-block.c:     A simple blocking QUIC server
+quic-server-non-block.c: A simple non-blocking QUIC server
 tls-client-block.c:      A simple blocking SSL/TLS client
 tls-client-non-block.c:  A simple non-blocking SSL/TLS client
 tls-server-block.c:      A simple blocking SSL/TLS server

--- a/demos/build.info
+++ b/demos/build.info
@@ -1,4 +1,4 @@
-SUBDIRS=bio cipher digest info keyexch mac kdf pkey signature \
+SUBDIRS=bio cipher digest info keyexch mac kdf pkcs12 pkey signature \
         encrypt encode sslecho
 
 IF[{- !$disabled{"h3demo"} -}]

--- a/demos/guide/build.info
+++ b/demos/guide/build.info
@@ -5,6 +5,7 @@
 #    LD_LIBRARY_PATH=../.. ./tls-client-block www.example.com 443
 
 PROGRAMS{noinst} = tls-client-block \
+                   tls-server-block \
                    quic-client-block \
                    quic-multi-stream \
                    tls-client-non-block \
@@ -16,6 +17,10 @@ PROGRAMS{noinst} = tls-client-block \
 INCLUDE[tls-client-block]=../../include
 SOURCE[tls-client-block]=tls-client-block.c
 DEPEND[tls-client-block]=../../libcrypto ../../libssl
+
+INCLUDE[tls-server-block]=../../include
+SOURCE[tls-server-block]=tls-server-block.c
+DEPEND[tls-server-block]=../../libcrypto ../../libssl
 
 INCLUDE[quic-client-block]=../../include
 SOURCE[quic-client-block]=quic-client-block.c

--- a/demos/guide/tls-server-block.c
+++ b/demos/guide/tls-server-block.c
@@ -64,6 +64,7 @@ int main(int argc, char *argv[])
 {
     int res = EXIT_FAILURE;
     long opts;
+    long old_timeout;
     const char *hostport;
     SSL_CTX *ctx = NULL;
     BIO *acceptor_bio;
@@ -174,7 +175,11 @@ int main(int argc, char *argv[])
      * byte array, that identifies the server application, and reduces the
      * chance of inappropriate cache sharing.
      */
-    SSL_CTX_set_session_id_context(ctx, (void *)cache_id, sizeof(cache_id));
+    if (SSL_CTX_set_session_id_context(ctx, (void *)cache_id, sizeof(cache_id)) <= 0) {
+        SSL_CTX_free(ctx);
+        ERR_print_errors_fp(stderr);
+        errx(res, "Failed to set server session ID context");
+    }
     SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_SERVER);
 
     /*
@@ -191,7 +196,9 @@ int main(int argc, char *argv[])
      * loaded servers with sporadic connections from any given client, a longer
      * time may be appropriate.
      */
-    SSL_CTX_set_timeout(ctx, 3600);
+    old_timeout = SSL_CTX_set_timeout(ctx, 3600);
+    if (old_timeout != 3600)
+        warnx("Changing session timeout from %ld to 3600", old_timeout);
 
     /*
      * Clients rarely employ certificate-based authentication, and so we don't

--- a/demos/pkcs12/build.info
+++ b/demos/pkcs12/build.info
@@ -1,0 +1,16 @@
+#
+# To run the demos when linked with a shared library (default) ensure that
+# libcrypto is on the library path. For example:
+#
+#    LD_LIBRARY_PATH=../.. ./pkread
+
+PROGRAMS{noinst} = pkread \
+                   pkwrite
+
+INCLUDE[pkread]=../../include
+SOURCE[pkread]=pkread.c
+DEPEND[pkread]=../../libcrypto
+
+INCLUDE[pkwrite]=../../include
+SOURCE[pkwrite]=pkwrite.c
+DEPEND[pkwrite]=../../libcrypto

--- a/demos/pkcs12/pkwrite.c
+++ b/demos/pkcs12/pkwrite.c
@@ -25,8 +25,6 @@ int main(int argc, char **argv)
         fprintf(stderr, "Usage: pkwrite infile password name p12file\n");
         exit(EXIT_FAILURE);
     }
-    OpenSSL_add_all_algorithms();
-    ERR_load_crypto_strings();
     if ((fp = fopen(argv[1], "r")) == NULL) {
         fprintf(stderr, "Error opening file %s\n", argv[1]);
         exit(EXIT_FAILURE);

--- a/demos/sslecho/build.info
+++ b/demos/sslecho/build.info
@@ -6,6 +6,15 @@
 
 PROGRAMS{noinst} = sslecho
 
+
 INCLUDE[sslecho]=../../include
 SOURCE[sslecho]=main.c
 DEPEND[sslecho]=../../libcrypto ../../libssl
+
+IF[{- !$disabled{"ech"} -}]
+    PROGRAMS{noinst} = echecho
+
+    INCLUDE[echecho]=../../include
+    SOURCE[echecho]=echecho.c
+    DEPEND[echecho]=../../libcrypto ../../libssl
+ENDIF

--- a/demos/sslecho/echecho.c
+++ b/demos/sslecho/echecho.c
@@ -36,7 +36,7 @@ static const char echprivbuf[]
  */
 static volatile bool server_running = true;
 
-int create_socket(bool isServer)
+static int create_socket(bool isServer)
 {
     int s;
     int optval = 1;
@@ -74,7 +74,7 @@ int create_socket(bool isServer)
     return s;
 }
 
-SSL_CTX *create_context(bool isServer)
+static SSL_CTX *create_context(bool isServer)
 {
     const SSL_METHOD *method;
     SSL_CTX *ctx;
@@ -116,7 +116,7 @@ err:
     return 0;
 }
 
-void configure_server_context(SSL_CTX *ctx)
+static void configure_server_context(SSL_CTX *ctx)
 {
     /* Set the key and cert */
     if (SSL_CTX_use_certificate_chain_file(ctx, "cert.pem") <= 0) {
@@ -137,7 +137,7 @@ void configure_server_context(SSL_CTX *ctx)
     }
 }
 
-void configure_client_context(SSL_CTX *ctx)
+static void configure_client_context(SSL_CTX *ctx)
 {
     /*
      * Configure the client to abort the handshake if certificate verification
@@ -163,7 +163,7 @@ void configure_client_context(SSL_CTX *ctx)
     }
 }
 
-void usage()
+static void usage(void)
 {
     printf("Usage: echecho s\n");
     printf("       --or--\n");

--- a/demos/sslecho/echecho.c
+++ b/demos/sslecho/echecho.c
@@ -7,6 +7,7 @@
  *  https://www.openssl.org/source/license.html
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <string.h>
@@ -28,10 +29,6 @@ static const char echprivbuf[]
       "AD7+DQA65wAgACA8wVN2BtscOl3vQheUzHeIkVmKIiydUhDCliA4iyQRCwAEAAEA"
       "AQALZXhhbXBsZS5jb20AAA==\n"
       "-----END ECHCONFIG-----\n";
-
-typedef unsigned char bool;
-#define true 1
-#define false 0
 
 /*
  * This flag won't be useful until both accept/read (TCP & SSL) methods

--- a/demos/sslecho/echecho.c
+++ b/demos/sslecho/echecho.c
@@ -336,7 +336,7 @@ int main(int argc, char **argv)
         /* Set hostname for SNI */
         SSL_set_tlsext_host_name(ssl, rem_server_ip);
         /* Configure server hostname check */
-        SSL_set1_host(ssl, rem_server_ip);
+        SSL_set1_ipaddr(ssl, rem_server_ip);
 
         /* Now do SSL connect with server */
         if (SSL_connect(ssl) == 1) {

--- a/demos/sslecho/echecho.c
+++ b/demos/sslecho/echecho.c
@@ -17,13 +17,17 @@
 
 static const int server_port = 4433;
 
-static const char echconfig[] = "AD7+DQA65wAgACA8wVN2BtscOl3vQheUzHeIkVmKIiydUhDCliA4iyQRCwAEAAEAAQALZXhhbXBsZS5jb20AAA==";
-static const char echprivbuf[] = "-----BEGIN PRIVATE KEY-----\n"
-                                 "MC4CAQAwBQYDK2VuBCIEICjd4yGRdsoP9gU7YT7My8DHx1Tjme8GYDXrOMCi8v1V\n"
-                                 "-----END PRIVATE KEY-----\n"
-                                 "-----BEGIN ECHCONFIG-----\n"
-                                 "AD7+DQA65wAgACA8wVN2BtscOl3vQheUzHeIkVmKIiydUhDCliA4iyQRCwAEAAEAAQALZXhhbXBsZS5jb20AAA==\n"
-                                 "-----END ECHCONFIG-----\n";
+static const char echconfig[]
+    = "AD7+DQA65wAgACA8wVN2BtscOl3vQheUzHeIkVmKIiydUhDCliA4iyQRCwAEAAEA"
+      "AQALZXhhbXBsZS5jb20AAA==";
+static const char echprivbuf[]
+    = "-----BEGIN PRIVATE KEY-----\n"
+      "MC4CAQAwBQYDK2VuBCIEICjd4yGRdsoP9gU7YT7My8DHx1Tjme8GYDXrOMCi8v1V\n"
+      "-----END PRIVATE KEY-----\n"
+      "-----BEGIN ECHCONFIG-----\n"
+      "AD7+DQA65wAgACA8wVN2BtscOl3vQheUzHeIkVmKIiydUhDCliA4iyQRCwAEAAEA"
+      "AQALZXhhbXBsZS5jb20AAA==\n"
+      "-----END ECHCONFIG-----\n";
 
 typedef unsigned char bool;
 #define true 1
@@ -144,9 +148,11 @@ void configure_client_context(SSL_CTX *ctx)
      */
     SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
     /*
-     * In a real application you would probably just use the default system certificate trust store and call:
+     * In a real application you would probably just use the default system
+     * certificate trust store and call:
      *     SSL_CTX_set_default_verify_paths(ctx);
-     * In this demo though we are using a self-signed certificate, so the client must trust it directly.
+     * In this demo though we are using a self-signed certificate,
+     * so the client must trust it directly.
      */
     if (!SSL_CTX_load_verify_locations(ctx, "cert.pem", NULL)) {
         ERR_print_errors_fp(stderr);
@@ -268,7 +274,10 @@ int main(int argc, char **argv)
 
                 /* Echo loop */
                 while (true) {
-                    /* Get message from client; will fail if client closes connection */
+                    /*
+                     * Get message from client; will fail if client closes
+                     * connection
+                     */
                     if ((rxlen = SSL_read(ssl, rxbuf, rxcap)) <= 0) {
                         if (rxlen == 0) {
                             printf("Client closed connection\n");

--- a/demos/sslecho/echecho.c
+++ b/demos/sslecho/echecho.c
@@ -9,12 +9,22 @@
 
 #include <stdbool.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <string.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+
+#if !defined(OPENSSL_SYS_WINDOWS)
+#include <unistd.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+
+#define SOCKET int
+#define INVALID_SOCKET -1
+#define closesocket(s) close(s)
+#else /* defined(OPENSSL_SYS_WINDOWS) */
+#include <winsock.h>
+#include <ws2tcpip.h>
+#endif /* !defined(OPENSSL_SYS_WINDOWS) */
 
 static const int server_port = 4433;
 
@@ -36,14 +46,14 @@ static const char echprivbuf[]
  */
 static volatile bool server_running = true;
 
-static int create_socket(bool isServer)
+static SOCKET create_socket(bool isServer)
 {
-    int s;
+    SOCKET s;
     int optval = 1;
     struct sockaddr_in addr = { 0 };
 
     s = socket(AF_INET, SOCK_STREAM, 0);
-    if (s < 0) {
+    if (s == INVALID_SOCKET) {
         perror("Unable to create socket");
         exit(EXIT_FAILURE);
     }
@@ -54,7 +64,7 @@ static int create_socket(bool isServer)
         addr.sin_addr.s_addr = INADDR_ANY;
 
         /* Reuse the address; good for quick restarts */
-        if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval))
+        if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (void *)&optval, sizeof(optval))
             < 0) {
             perror("setsockopt(SO_REUSEADDR) failed");
             exit(EXIT_FAILURE);
@@ -98,7 +108,7 @@ static int configure_ech(SSL_CTX *ctx, int server,
     unsigned char *buf, size_t len)
 {
     OSSL_ECHSTORE *es = NULL;
-    BIO *es_in = BIO_new_mem_buf(buf, len);
+    BIO *es_in = BIO_new_mem_buf(buf, (int)len);
 
     if (es_in == NULL || (es = OSSL_ECHSTORE_new(NULL, NULL)) == NULL)
         goto err;
@@ -172,6 +182,7 @@ static void usage(void)
     exit(1);
 }
 
+#define BUFFERSIZE 1024
 int main(int argc, char **argv)
 {
     bool isServer;
@@ -180,13 +191,13 @@ int main(int argc, char **argv)
     SSL_CTX *ssl_ctx = NULL;
     SSL *ssl = NULL;
 
-    int server_skt = -1;
-    int client_skt = -1;
+    SOCKET server_skt = INVALID_SOCKET;
+    SOCKET client_skt = INVALID_SOCKET;
 
-    /* used by getline relying on realloc, can't be statically allocated */
+    /* used by fgets */
+    char buffer[BUFFERSIZE];
     char *txbuf = NULL;
     size_t txcap = 0;
-    int txlen;
 
     char rxbuf[128];
     size_t rxcap = sizeof(rxbuf);
@@ -195,7 +206,7 @@ int main(int argc, char **argv)
     char *rem_server_ip = NULL;
 
     struct sockaddr_in addr = { 0 };
-    unsigned int addr_len = sizeof(addr);
+    socklen_t addr_len = (socklen_t)sizeof(addr);
 
     char *outer_sni = NULL, *inner_sni = NULL;
     int ech_status;
@@ -242,7 +253,7 @@ int main(int argc, char **argv)
             /* Wait for TCP connection from client */
             client_skt = accept(server_skt, (struct sockaddr *)&addr,
                 &addr_len);
-            if (client_skt < 0) {
+            if (client_skt == INVALID_SOCKET) {
                 perror("Unable to accept");
                 exit(EXIT_FAILURE);
             }
@@ -251,7 +262,7 @@ int main(int argc, char **argv)
 
             /* Create server SSL structure using newly accepted client socket */
             ssl = SSL_new(ssl_ctx);
-            if (SSL_set_fd(ssl, client_skt) <= 0) {
+            if (SSL_set_fd(ssl, (int)client_skt) <= 0) {
                 puts("Unable to set fd for the SSL object");
                 ERR_print_errors_fp(stderr);
                 exit(EXIT_FAILURE);
@@ -279,7 +290,7 @@ int main(int argc, char **argv)
                      * Get message from client; will fail if client closes
                      * connection
                      */
-                    if ((rxlen = SSL_read(ssl, rxbuf, rxcap)) <= 0) {
+                    if ((rxlen = SSL_read(ssl, rxbuf, (int)rxcap)) <= 0) {
                         if (rxlen == 0) {
                             printf("Client closed connection\n");
                         }
@@ -307,7 +318,12 @@ int main(int argc, char **argv)
                 /* Cleanup for next client */
                 SSL_shutdown(ssl);
                 SSL_free(ssl);
-                close(client_skt);
+                closesocket(client_skt);
+                /*
+                 * Set client_skt to INVALID_SOCKET to avoid double close when
+                 * server_running become false before next accept
+                 */
+                client_skt = INVALID_SOCKET;
             }
         }
         printf("Server exiting...\n");
@@ -336,7 +352,7 @@ int main(int argc, char **argv)
 
         /* Create client SSL structure using dedicated client socket */
         ssl = SSL_new(ssl_ctx);
-        if (SSL_set_fd(ssl, client_skt) <= 0) {
+        if (SSL_set_fd(ssl, (int)client_skt) <= 0) {
             puts("Unable to set fd for the SSL object");
             ERR_print_errors_fp(stderr);
             exit(EXIT_FAILURE);
@@ -366,9 +382,11 @@ int main(int argc, char **argv)
             /* Loop to send input from keyboard */
             while (true) {
                 /* Get a line of input */
-                txlen = getline(&txbuf, &txcap, stdin);
+                memset(buffer, 0, BUFFERSIZE);
+                txbuf = fgets(buffer, BUFFERSIZE, stdin);
+
                 /* Exit loop on error */
-                if (txlen < 0 || txbuf == NULL) {
+                if (txbuf == NULL) {
                     break;
                 }
                 /* Exit loop if just a carriage return */
@@ -376,14 +394,14 @@ int main(int argc, char **argv)
                     break;
                 }
                 /* Send it to the server */
-                if ((result = SSL_write(ssl, txbuf, txlen)) <= 0) {
+                if ((result = SSL_write(ssl, txbuf, (int)strlen(txbuf))) <= 0) {
                     printf("Server closed connection\n");
                     ERR_print_errors_fp(stderr);
                     break;
                 }
 
                 /* Wait for the echo */
-                rxlen = SSL_read(ssl, rxbuf, rxcap);
+                rxlen = SSL_read(ssl, rxbuf, (int)rxcap);
                 if (rxlen <= 0) {
                     printf("Server closed connection\n");
                     ERR_print_errors_fp(stderr);
@@ -410,10 +428,10 @@ exit:
     }
     SSL_CTX_free(ssl_ctx);
 
-    if (client_skt != -1)
-        close(client_skt);
-    if (server_skt != -1)
-        close(server_skt);
+    if (client_skt != INVALID_SOCKET)
+        closesocket(client_skt);
+    if (server_skt != INVALID_SOCKET)
+        closesocket(server_skt);
 
     if (txbuf != NULL && txcap > 0)
         free(txbuf);

--- a/demos/sslecho/echecho.c
+++ b/demos/sslecho/echecho.c
@@ -251,7 +251,11 @@ int main(int argc, char **argv)
 
             /* Create server SSL structure using newly accepted client socket */
             ssl = SSL_new(ssl_ctx);
-            SSL_set_fd(ssl, client_skt);
+            if (SSL_set_fd(ssl, client_skt) <= 0) {
+                puts("Unable to set fd for the SSL object");
+                ERR_print_errors_fp(stderr);
+                exit(EXIT_FAILURE);
+            }
 
             /* Wait for SSL connection from the client */
             if (SSL_accept(ssl) <= 0) {
@@ -332,11 +336,19 @@ int main(int argc, char **argv)
 
         /* Create client SSL structure using dedicated client socket */
         ssl = SSL_new(ssl_ctx);
-        SSL_set_fd(ssl, client_skt);
+        if (SSL_set_fd(ssl, client_skt) <= 0) {
+            puts("Unable to set fd for the SSL object");
+            ERR_print_errors_fp(stderr);
+            exit(EXIT_FAILURE);
+        }
         /* Set hostname for SNI */
         SSL_set_tlsext_host_name(ssl, rem_server_ip);
         /* Configure server hostname check */
-        SSL_set1_ipaddr(ssl, rem_server_ip);
+        if (SSL_set1_ipaddr(ssl, rem_server_ip) <= 0) {
+            puts("Unable to set IP address for the SSL object");
+            ERR_print_errors_fp(stderr);
+            exit(EXIT_FAILURE);
+        }
 
         /* Now do SSL connect with server */
         if (SSL_connect(ssl) == 1) {


### PR DESCRIPTION
For various reasons, these demos were omitted from wiring up to the build system. Rescind this omission.

Reported by @fwh-dc in [1].

[1] https://github.com/openssl/openssl/pull/31718#issuecomment-4799356733