### PR TITLE
Make sure we always check return of CRYPTO_UP_REF which can fail.

### DIFF
--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -188,7 +188,7 @@ int BIO_up_ref(BIO *a)
 {
     int i;
 
-    if (CRYPTO_UP_REF(&a->references, &i) <= 0)
+    if (!CRYPTO_UP_REF(&a->references, &i))
         return 0;
 
     REF_PRINT_COUNT("BIO", i, a);

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -142,7 +142,7 @@ int DH_up_ref(DH *r)
 {
     int i;
 
-    if (CRYPTO_UP_REF(&r->references, &i) <= 0)
+    if (!CRYPTO_UP_REF(&r->references, &i))
         return 0;
 
     REF_PRINT_COUNT("DH", i, r);

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -215,7 +215,7 @@ int DSA_up_ref(DSA *r)
 {
     int i;
 
-    if (CRYPTO_UP_REF(&r->references, &i) <= 0)
+    if (!CRYPTO_UP_REF(&r->references, &i))
         return 0;
 
     REF_PRINT_COUNT("DSA", i, r);

--- a/crypto/dso/dso_lib.c
+++ b/crypto/dso/dso_lib.c
@@ -93,7 +93,7 @@ int DSO_up_ref(DSO *dso)
         return 0;
     }
 
-    if (CRYPTO_UP_REF(&dso->references, &i) <= 0)
+    if (!CRYPTO_UP_REF(&dso->references, &i))
         return 0;
 
     REF_PRINT_COUNT("DSO", i, dso);

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -176,7 +176,7 @@ int EC_KEY_up_ref(EC_KEY *r)
 {
     int i;
 
-    if (CRYPTO_UP_REF(&r->references, &i) <= 0)
+    if (!CRYPTO_UP_REF(&r->references, &i))
         return 0;
 
     REF_PRINT_COUNT("EC_KEY", i, r);

--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -72,8 +72,8 @@ static EC_PRE_COMP *ec_pre_comp_new(const EC_GROUP *group)
 EC_PRE_COMP *EC_ec_pre_comp_dup(EC_PRE_COMP *pre)
 {
     int i;
-    if (pre != NULL)
-        CRYPTO_UP_REF(&pre->references, &i);
+    if (pre == NULL || !CRYPTO_UP_REF(&pre->references, &i))
+        return NULL;
     return pre;
 }
 

--- a/crypto/ec/ecp_nistp224.c
+++ b/crypto/ec/ecp_nistp224.c
@@ -1234,8 +1234,8 @@ static NISTP224_PRE_COMP *nistp224_pre_comp_new(void)
 NISTP224_PRE_COMP *EC_nistp224_pre_comp_dup(NISTP224_PRE_COMP *p)
 {
     int i;
-    if (p != NULL)
-        CRYPTO_UP_REF(&p->references, &i);
+    if (p == NULL || !CRYPTO_UP_REF(&p->references, &i))
+        return NULL;
     return p;
 }
 

--- a/crypto/ec/ecp_nistp256.c
+++ b/crypto/ec/ecp_nistp256.c
@@ -1852,8 +1852,8 @@ static NISTP256_PRE_COMP *nistp256_pre_comp_new(void)
 NISTP256_PRE_COMP *EC_nistp256_pre_comp_dup(NISTP256_PRE_COMP *p)
 {
     int i;
-    if (p != NULL)
-        CRYPTO_UP_REF(&p->references, &i);
+    if (p == NULL || !CRYPTO_UP_REF(&p->references, &i))
+        return NULL;
     return p;
 }
 

--- a/crypto/ec/ecp_nistp384.c
+++ b/crypto/ec/ecp_nistp384.c
@@ -1576,8 +1576,8 @@ NISTP384_PRE_COMP *ossl_ec_nistp384_pre_comp_dup(NISTP384_PRE_COMP *p)
 {
     int i;
 
-    if (p != NULL)
-        CRYPTO_UP_REF(&p->references, &i);
+    if (p == NULL || !CRYPTO_UP_REF(&p->references, &i))
+        return NULL;
     return p;
 }
 

--- a/crypto/ec/ecp_nistp521.c
+++ b/crypto/ec/ecp_nistp521.c
@@ -1667,8 +1667,8 @@ static NISTP521_PRE_COMP *nistp521_pre_comp_new(void)
 NISTP521_PRE_COMP *EC_nistp521_pre_comp_dup(NISTP521_PRE_COMP *p)
 {
     int i;
-    if (p != NULL)
-        CRYPTO_UP_REF(&p->references, &i);
+    if (p == NULL || !CRYPTO_UP_REF(&p->references, &i))
+        return NULL;
     return p;
 }
 

--- a/crypto/ec/ecp_nistz256.c
+++ b/crypto/ec/ecp_nistz256.c
@@ -1208,8 +1208,8 @@ static NISTZ256_PRE_COMP *ecp_nistz256_pre_comp_new(const EC_GROUP *group)
 NISTZ256_PRE_COMP *EC_nistz256_pre_comp_dup(NISTZ256_PRE_COMP *p)
 {
     int i;
-    if (p != NULL)
-        CRYPTO_UP_REF(&p->references, &i);
+    if (p == NULL || !CRYPTO_UP_REF(&p->references, &i))
+        return NULL;
     return p;
 }
 

--- a/crypto/ec/ecx_key.c
+++ b/crypto/ec/ecx_key.c
@@ -92,7 +92,7 @@ int ossl_ecx_key_up_ref(ECX_KEY *key)
 {
     int i;
 
-    if (CRYPTO_UP_REF(&key->references, &i) <= 0)
+    if (!CRYPTO_UP_REF(&key->references, &i))
         return 0;
 
     REF_PRINT_COUNT("ECX_KEY", i, key);

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -47,8 +47,7 @@ static int ossl_decoder_up_ref(void *data)
     OSSL_DECODER *decoder = (OSSL_DECODER *)data;
     int ref = 0;
 
-    CRYPTO_UP_REF(&decoder->base.refcnt, &ref);
-    return 1;
+    return CRYPTO_UP_REF(&decoder->base.refcnt, &ref);;
 }
 
 /* Simple method structure constructor and destructor */

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -47,7 +47,7 @@ static int ossl_decoder_up_ref(void *data)
     OSSL_DECODER *decoder = (OSSL_DECODER *)data;
     int ref = 0;
 
-    return CRYPTO_UP_REF(&decoder->base.refcnt, &ref);;
+    return CRYPTO_UP_REF(&decoder->base.refcnt, &ref);
 }
 
 /* Simple method structure constructor and destructor */

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -19,8 +19,6 @@
 #include "encoder_local.h"
 #include "crypto/context.h"
 
-#include <stdbool.h>
-
 /*
  * Decoder can have multiple names, separated with colons in a name string
  */
@@ -44,7 +42,7 @@ static void ossl_decoder_free(void *data)
     OPENSSL_free(decoder);
 }
 
-static bool ossl_decoder_up_ref(void *data)
+static int ossl_decoder_up_ref(void *data)
 {
     OSSL_DECODER *decoder = (OSSL_DECODER *)data;
     int ref = 0;

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -19,6 +19,8 @@
 #include "encoder_local.h"
 #include "crypto/context.h"
 
+#include <stdbool.h>
+
 /*
  * Decoder can have multiple names, separated with colons in a name string
  */
@@ -42,7 +44,7 @@ static void ossl_decoder_free(void *data)
     OPENSSL_free(decoder);
 }
 
-static int ossl_decoder_up_ref(void *data)
+static bool ossl_decoder_up_ref(void *data)
 {
     OSSL_DECODER *decoder = (OSSL_DECODER *)data;
     int ref = 0;

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -48,8 +48,7 @@ static int ossl_encoder_up_ref(void *data)
     OSSL_ENCODER *encoder = (OSSL_ENCODER *)data;
     int ref = 0;
 
-    CRYPTO_UP_REF(&encoder->base.refcnt, &ref);
-    return 1;
+    return CRYPTO_UP_REF(&encoder->base.refcnt, &ref);
 }
 
 /* Simple method structure constructor and destructor */

--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -38,8 +38,7 @@ static int evp_asym_cipher_up_ref(void *data)
     EVP_ASYM_CIPHER *cipher = (EVP_ASYM_CIPHER *)data;
     int ref = 0;
 
-    CRYPTO_UP_REF(&cipher->refcnt, &ref);
-    return 1;
+    return CRYPTO_UP_REF(&cipher->refcnt, &ref);
 }
 
 static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation,

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -977,7 +977,7 @@ static int evp_md_up_ref(void *m)
     int ref = 0;
 
     if (md->origin == EVP_ORIG_DYNAMIC)
-        CRYPTO_UP_REF(&md->refcnt, &ref);
+        return CRYPTO_UP_REF(&md->refcnt, &ref);
     return 1;
 }
 

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1346,7 +1346,7 @@ static int evp_cipher_up_ref(void *c)
     int ref = 0;
 
     if (cipher->origin == EVP_ORIG_DYNAMIC)
-        CRYPTO_UP_REF(&cipher->refcnt, &ref);
+        return CRYPTO_UP_REF(&cipher->refcnt, &ref);
     return 1;
 }
 

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -40,8 +40,7 @@ static int evp_keyexch_up_ref(void *data)
     EVP_KEYEXCH *exchange = (EVP_KEYEXCH *)data;
     int ref = 0;
 
-    CRYPTO_UP_REF(&exchange->refcnt, &ref);
-    return 1;
+    return CRYPTO_UP_REF(&exchange->refcnt, &ref);
 }
 
 static EVP_KEYEXCH *evp_keyexch_new(OSSL_PROVIDER *prov)

--- a/crypto/evp/kdf_meth.c
+++ b/crypto/evp/kdf_meth.c
@@ -22,8 +22,7 @@ static int evp_kdf_up_ref(void *vkdf)
     EVP_KDF *kdf = (EVP_KDF *)vkdf;
     int ref = 0;
 
-    CRYPTO_UP_REF(&kdf->refcnt, &ref);
-    return 1;
+    return CRYPTO_UP_REF(&kdf->refcnt, &ref);
 }
 
 static void evp_kdf_free(void *vkdf)

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -39,8 +39,7 @@ static int evp_kem_up_ref(void *data)
     EVP_KEM *kem = (EVP_KEM *)data;
     int ref = 0;
 
-    CRYPTO_UP_REF(&kem->refcnt, &ref);
-    return 1;
+    return CRYPTO_UP_REF(&kem->refcnt, &ref);
 }
 
 static int evp_kem_init(EVP_PKEY_CTX *ctx, int operation,

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -39,8 +39,7 @@ static int evp_keymgmt_up_ref(void *data)
     EVP_KEYMGMT *keymgmt = (EVP_KEYMGMT *)data;
     int ref = 0;
 
-    CRYPTO_UP_REF(&keymgmt->refcnt, &ref);
-    return 1;
+    return CRYPTO_UP_REF(&keymgmt->refcnt, &ref);
 }
 
 static void *keymgmt_new(void)

--- a/crypto/evp/mac_meth.c
+++ b/crypto/evp/mac_meth.c
@@ -21,8 +21,7 @@ static int evp_mac_up_ref(void *vmac)
     EVP_MAC *mac = vmac;
     int ref = 0;
 
-    CRYPTO_UP_REF(&mac->refcnt, &ref);
-    return 1;
+    return CRYPTO_UP_REF(&mac->refcnt, &ref);
 }
 
 static void evp_mac_free(void *vmac)

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1630,7 +1630,7 @@ int EVP_PKEY_up_ref(EVP_PKEY *pkey)
 {
     int i;
 
-    if (CRYPTO_UP_REF(&pkey->references, &i) <= 0)
+    if (!CRYPTO_UP_REF(&pkey->references, &i))
         return 0;
 
     REF_PRINT_COUNT("EVP_PKEY", i, pkey);

--- a/crypto/evp/s_lib.c
+++ b/crypto/evp/s_lib.c
@@ -196,7 +196,7 @@ int EVP_SKEY_up_ref(EVP_SKEY *skey)
 {
     int i;
 
-    if (CRYPTO_UP_REF(&skey->references, &i) <= 0)
+    if (!CRYPTO_UP_REF(&skey->references, &i))
         return 0;
 
     REF_PRINT_COUNT("EVP_SKEY", i, skey);

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -41,8 +41,7 @@ static int evp_signature_up_ref(void *data)
     EVP_SIGNATURE *signature = (EVP_SIGNATURE *)data;
     int ref = 0;
 
-    CRYPTO_UP_REF(&signature->refcnt, &ref);
-    return 1;
+    return CRYPTO_UP_REF(&signature->refcnt, &ref);
 }
 
 static EVP_SIGNATURE *evp_signature_new(OSSL_PROVIDER *prov)

--- a/crypto/evp/skeymgmt_meth.c
+++ b/crypto/evp/skeymgmt_meth.c
@@ -134,8 +134,7 @@ static int evp_skeymgmt_up_ref(void *s)
     EVP_SKEYMGMT *skeymgmt = (EVP_SKEYMGMT *)s;
     int ref = 0;
 
-    CRYPTO_UP_REF(&skeymgmt->refcnt, &ref);
-    return 1;
+    return CRYPTO_UP_REF(&skeymgmt->refcnt, &ref);
 }
 
 static void evp_skeymgmt_free(void *s)

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -486,7 +486,7 @@ int ossl_provider_up_ref(OSSL_PROVIDER *prov)
 {
     int ref = 0;
 
-    if (CRYPTO_UP_REF(&prov->refcnt, &ref) <= 0)
+    if (!CRYPTO_UP_REF(&prov->refcnt, &ref))
         return 0;
 
 #ifndef FIPS_MODULE
@@ -1576,7 +1576,7 @@ int ossl_provider_doall_activated(OSSL_LIB_CTX *ctx,
              * to avoid upping the ref count on the parent provider, which we
              * must not do while holding locks.
              */
-            if (CRYPTO_UP_REF(&prov->refcnt, &ref) <= 0) {
+            if (!CRYPTO_UP_REF(&prov->refcnt, &ref)) {
                 CRYPTO_THREAD_unlock(prov->flag_lock);
                 goto err_unlock;
             }

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -163,7 +163,7 @@ int RSA_up_ref(RSA *r)
 {
     int i;
 
-    if (CRYPTO_UP_REF(&r->references, &i) <= 0)
+    if (!CRYPTO_UP_REF(&r->references, &i))
         return 0;
 
     REF_PRINT_COUNT("RSA", i, r);

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -22,7 +22,7 @@ static int up_ref_loader(void *method)
     int ref = 0;
 
     if (loader->prov != NULL)
-        CRYPTO_UP_REF(&loader->refcnt, &ref);
+        return CRYPTO_UP_REF(&loader->refcnt, &ref);
     return 1;
 }
 

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -287,7 +287,7 @@ int X509_STORE_up_ref(X509_STORE *xs)
 {
     int i;
 
-    if (CRYPTO_UP_REF(&xs->references, &i) <= 0)
+    if (!CRYPTO_UP_REF(&xs->references, &i))
         return 0;
 
     REF_PRINT_COUNT("X509_STORE", i, xs);

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -117,7 +117,7 @@ int X509_up_ref(X509 *x)
 {
     int i;
 
-    if (CRYPTO_UP_REF(&x->references, &i) <= 0)
+    if (!CRYPTO_UP_REF(&x->references, &i))
         return 0;
 
     REF_PRINT_COUNT("X509", i, x);

--- a/crypto/x509/x509cset.c
+++ b/crypto/x509/x509cset.c
@@ -75,7 +75,7 @@ int X509_CRL_up_ref(X509_CRL *crl)
 {
     int i;
 
-    if (CRYPTO_UP_REF(&crl->references, &i) <= 0)
+    if (!CRYPTO_UP_REF(&crl->references, &i))
         return 0;
 
     REF_PRINT_COUNT("X509_CRL", i, crl);

--- a/doc/internal/man3/evp_generic_fetch.pod
+++ b/doc/internal/man3/evp_generic_fetch.pod
@@ -187,8 +187,7 @@ And here's the implementation of the FOO method fetcher:
         EVP_FOO *foo = vfoo;
         int ref = 0;
 
-        CRYPTO_UP_REF(&foo->refcnt, &ref);
-        return 1;
+        return CRYPTO_UP_REF(&foo->refcnt, &ref);
     }
 
     static void foo_free(void *vfoo)

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -14,6 +14,8 @@
 #include <openssl/trace.h>
 #include <openssl/err.h>
 
+#include <stdbool.h>
+
 #if defined(OPENSSL_THREADS) && !defined(OPENSSL_DEV_NO_ATOMICS)
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L \
     && !defined(__STDC_NO_ATOMICS__)
@@ -36,10 +38,10 @@ typedef struct {
     _Atomic int val;
 } CRYPTO_REF_COUNT;
 
-static inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
+static inline bool CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
     *ret = atomic_fetch_add_explicit(&refcnt->val, 1, memory_order_relaxed) + 1;
-    return 1;
+    return true;
 }
 
 /*
@@ -82,10 +84,10 @@ typedef struct {
     int val;
 } CRYPTO_REF_COUNT;
 
-static __inline__ int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
+static __inline__ bool CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
     *ret = __atomic_fetch_add(&refcnt->val, 1, __ATOMIC_RELAXED) + 1;
-    return 1;
+    return true;
 }
 
 static __inline__ int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
@@ -109,10 +111,10 @@ typedef struct {
     volatile int val;
 } CRYPTO_REF_COUNT;
 
-static __inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
+static __inline bool CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
     *ret = _InterlockedExchangeAdd((void *)&refcnt->val, 1) + 1;
-    return 1;
+    return true;
 }
 
 static __inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
@@ -141,10 +143,10 @@ typedef struct {
 #define _ARM_BARRIER_ISH _ARM64_BARRIER_ISH
 #endif
 
-static __inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
+static __inline bool CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
     *ret = _InterlockedExchangeAdd_nf(&refcnt->val, 1) + 1;
-    return 1;
+    return true;
 }
 
 static __inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
@@ -162,10 +164,10 @@ static __inline int CRYPTO_GET_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 #else
 #pragma intrinsic(_InterlockedExchangeAdd)
 
-static __inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
+static __inline bool CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
 {
     *ret = _InterlockedExchangeAdd(&refcnt->val, 1) + 1;
-    return 1;
+    return true;
 }
 
 static __inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt, int *ret)
@@ -201,10 +203,10 @@ typedef struct {
 
 #ifdef OPENSSL_THREADS
 
-static ossl_unused ossl_inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt,
+static ossl_unused ossl_inline bool CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt,
     int *ret)
 {
-    return CRYPTO_atomic_add(&refcnt->val, 1, ret, refcnt->lock);
+    return CRYPTO_atomic_add(&refcnt->val, 1, ret, refcnt->lock) ? true : false;
 }
 
 static ossl_unused ossl_inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt,
@@ -239,12 +241,12 @@ static ossl_unused ossl_inline void CRYPTO_FREE_REF(CRYPTO_REF_COUNT *refcnt)
 
 #else /* OPENSSL_THREADS */
 
-static ossl_unused ossl_inline int CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt,
+static ossl_unused ossl_inline bool CRYPTO_UP_REF(CRYPTO_REF_COUNT *refcnt,
     int *ret)
 {
     refcnt->val++;
     *ret = refcnt->val;
-    return 1;
+    return true;
 }
 
 static ossl_unused ossl_inline int CRYPTO_DOWN_REF(CRYPTO_REF_COUNT *refcnt,

--- a/providers/implementations/keymgmt/kdf_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/kdf_legacy_kmgmt.c
@@ -75,8 +75,7 @@ int ossl_kdf_data_up_ref(KDF_DATA *kdfdata)
     if (!ossl_prov_is_running())
         return 0;
 
-    CRYPTO_UP_REF(&kdfdata->refcnt, &ref);
-    return 1;
+    return CRYPTO_UP_REF(&kdfdata->refcnt, &ref);
 }
 
 static void *kdf_newdata(void *provctx)

--- a/providers/implementations/keymgmt/mac_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/mac_legacy_kmgmt.c
@@ -110,8 +110,7 @@ int ossl_mac_key_up_ref(MAC_KEY *mackey)
     if (!ossl_prov_is_running())
         return 0;
 
-    CRYPTO_UP_REF(&mackey->refcnt, &ref);
-    return 1;
+    return CRYPTO_UP_REF(&mackey->refcnt, &ref);
 }
 
 static void *mac_new(void *provctx)

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -5422,6 +5422,7 @@ int ossl_quic_get_peer_token(SSL_CTX *ctx, BIO_ADDR *peer,
     QUIC_TOKEN *key = NULL;
     QUIC_TOKEN *tok = NULL;
     int ret;
+    int rc = 0;
 
     if (c == NULL)
         return 0;
@@ -5432,12 +5433,14 @@ int ossl_quic_get_peer_token(SSL_CTX *ctx, BIO_ADDR *peer,
 
     ossl_crypto_mutex_lock(c->mutex);
     tok = lh_QUIC_TOKEN_retrieve(c->cache, key);
-    if (tok != NULL && CRYPTO_UP_REF(&tok->references, &ret))
+    if (tok != NULL && CRYPTO_UP_REF(&tok->references, &ret)) {
         *token = tok;
+        rc = 1;
+    }
 
     ossl_crypto_mutex_unlock(c->mutex);
     ossl_quic_free_peer_token(key);
-    return 1;
+    return rc;
 }
 
 void ossl_quic_free_peer_token(QUIC_TOKEN *token)

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -5422,7 +5422,6 @@ int ossl_quic_get_peer_token(SSL_CTX *ctx, BIO_ADDR *peer,
     QUIC_TOKEN *key = NULL;
     QUIC_TOKEN *tok = NULL;
     int ret;
-    int rc = 0;
 
     if (c == NULL)
         return 0;
@@ -5433,14 +5432,12 @@ int ossl_quic_get_peer_token(SSL_CTX *ctx, BIO_ADDR *peer,
 
     ossl_crypto_mutex_lock(c->mutex);
     tok = lh_QUIC_TOKEN_retrieve(c->cache, key);
-    if (tok != NULL) {
+    if (tok != NULL && CRYPTO_UP_REF(&tok->references, &ret))
         *token = tok;
-        rc = CRYPTO_UP_REF(&tok->references, &ret);
-    }
 
     ossl_crypto_mutex_unlock(c->mutex);
     ossl_quic_free_peer_token(key);
-    return rc;
+    return 1;
 }
 
 void ossl_quic_free_peer_token(QUIC_TOKEN *token)

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -5435,8 +5435,7 @@ int ossl_quic_get_peer_token(SSL_CTX *ctx, BIO_ADDR *peer,
     tok = lh_QUIC_TOKEN_retrieve(c->cache, key);
     if (tok != NULL) {
         *token = tok;
-        CRYPTO_UP_REF(&tok->references, &ret);
-        rc = 1;
+        rc = CRYPTO_UP_REF(&tok->references, &ret);
     }
 
     ossl_crypto_mutex_unlock(c->mutex);

--- a/ssl/ssl_cert_comp.c
+++ b/ssl/ssl_cert_comp.c
@@ -151,7 +151,7 @@ int OSSL_COMP_CERT_up_ref(OSSL_COMP_CERT *cc)
 {
     int i;
 
-    if (CRYPTO_UP_REF(&cc->references, &i) <= 0)
+    if (!CRYPTO_UP_REF(&cc->references, &i))
         return 0;
 
     REF_PRINT_COUNT("OSSL_COMP_CERT", i, cc);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1025,7 +1025,7 @@ int SSL_up_ref(SSL *s)
 {
     int i;
 
-    if (CRYPTO_UP_REF(&s->references, &i) <= 0)
+    if (!CRYPTO_UP_REF(&s->references, &i))
         return 0;
 
     REF_PRINT_COUNT("SSL", i, s);
@@ -2102,7 +2102,9 @@ int SSL_copy_session_id(SSL *t, const SSL *f)
             return 0;
     }
 
-    CRYPTO_UP_REF(&fsc->cert->references, &i);
+    if (!CRYPTO_UP_REF(&fsc->cert->references, &i))
+        return 0;
+
     ssl_cert_free(tsc->cert);
     tsc->cert = fsc->cert;
     if (!SSL_set_session_id_context(t, fsc->sid_ctx, (int)fsc->sid_ctx_length)) {
@@ -4546,7 +4548,7 @@ int SSL_CTX_up_ref(SSL_CTX *ctx)
 {
     int i;
 
-    if (CRYPTO_UP_REF(&ctx->references, &i) <= 0)
+    if (!CRYPTO_UP_REF(&ctx->references, &i))
         return 0;
 
     REF_PRINT_COUNT("SSL_CTX", i, ctx);
@@ -5367,7 +5369,8 @@ SSL *SSL_dup(SSL *s)
 
     /* If we're not quiescent, just up_ref! */
     if (!SSL_in_init(s) || !SSL_in_before(s)) {
-        CRYPTO_UP_REF(&s->references, &i);
+        if (!CRYPTO_UP_REF(&s->references, &i))
+            return NULL;
         return s;
     }
 

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -903,7 +903,7 @@ int SSL_SESSION_up_ref(SSL_SESSION *ss)
 {
     int i;
 
-    if (CRYPTO_UP_REF(&ss->references, &i) <= 0)
+    if (!CRYPTO_UP_REF(&ss->references, &i))
         return 0;
 
     REF_PRINT_COUNT("SSL_SESSION", i, ss);

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -725,7 +725,7 @@ static int xor_key_up_ref(XORKEY *key)
 {
     int refcnt;
 
-    if (CRYPTO_UP_REF(&key->references, &refcnt) <= 0)
+    if (!CRYPTO_UP_REF(&key->references, &refcnt))
         return 0;
 
     assert(refcnt > 1);


### PR DESCRIPTION
Adds return code checks of calls to `CRYPTO_UP_REF` which can fail on platforms without atomic support. Also changes `CRYPTO_UP_REF` return type to express the boolean nature of the return.