### PR TITLE
FIPS: EC keygen - remove unnecessary self tests.

### DIFF
--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -215,56 +215,6 @@ int ossl_ec_key_gen(EC_KEY *eckey)
 }
 
 /*
- * Refer: FIPS 140-3 IG 10.3.A Additional Comment 1
- * Perform a KAT by duplicating the public key generation.
- *
- * NOTE: This issue requires a background understanding, provided in a separate
- * document; the current IG 10.3.A AC1 is insufficient regarding the PCT for
- * the key agreement scenario.
- *
- * Currently IG 10.3.A requires PCT in the mode of use prior to use of the
- * key pair, citing the PCT defined in the associated standard. For key
- * agreement, the only PCT defined in SP 800-56A is that of Section 5.6.2.4:
- * the comparison of the original public key to a newly calculated public key.
- */
-static int ecdsa_keygen_knownanswer_test(EC_KEY *eckey, BN_CTX *ctx,
-    OSSL_CALLBACK *cb, void *cbarg)
-{
-    int len, ret = 0;
-    OSSL_SELF_TEST *st = NULL;
-    unsigned char bytes[512] = { 0 };
-    EC_POINT *pub_key2 = NULL;
-
-    st = OSSL_SELF_TEST_new(cb, cbarg);
-    if (st == NULL)
-        return 0;
-
-    OSSL_SELF_TEST_onbegin(st, OSSL_SELF_TEST_TYPE_PCT_KAT,
-        OSSL_SELF_TEST_DESC_PCT_ECDSA);
-
-    if ((pub_key2 = EC_POINT_new(eckey->group)) == NULL)
-        goto err;
-
-    /* pub_key = priv_key * G (where G is a point on the curve) */
-    if (!EC_POINT_mul(eckey->group, pub_key2, eckey->priv_key, NULL, NULL, ctx))
-        goto err;
-
-    if (BN_num_bytes(pub_key2->X) > (int)sizeof(bytes))
-        goto err;
-    len = BN_bn2bin(pub_key2->X, bytes);
-    if (OSSL_SELF_TEST_oncorrupt_byte(st, bytes)
-        && BN_bin2bn(bytes, len, pub_key2->X) == NULL)
-        goto err;
-    ret = !EC_POINT_cmp(eckey->group, eckey->pub_key, pub_key2, ctx);
-
-err:
-    OSSL_SELF_TEST_onend(st, ret);
-    OSSL_SELF_TEST_free(st);
-    EC_POINT_free(pub_key2);
-    return ret;
-}
-
-/*
  * ECC Key generation.
  * See SP800-56AR3 5.6.1.2.2 "Key Pair Generation by Testing Candidates"
  *
@@ -360,8 +310,7 @@ static int ec_generate_key(EC_KEY *eckey, int pairwise_test)
         void *cbarg = NULL;
 
         OSSL_SELF_TEST_get_callback(eckey->libctx, &cb, &cbarg);
-        ok = ecdsa_keygen_pairwise_test(eckey, cb, cbarg)
-            && ecdsa_keygen_knownanswer_test(eckey, ctx, cb, cbarg);
+        ok = ecdsa_keygen_pairwise_test(eckey, cb, cbarg);
     }
 err:
     /* Step (9): If there is an error return an invalid keypair. */

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -1316,18 +1316,6 @@ static void *ec_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
 
     if (gctx->group_check != NULL)
         ret = ret && ossl_ec_set_check_group_type_from_name(ec, gctx->group_check);
-#ifdef FIPS_MODULE
-    if (ret > 0
-        && !ossl_fips_self_testing()
-        && EC_KEY_get0_public_key(ec) != NULL
-        && EC_KEY_get0_private_key(ec) != NULL
-        && EC_KEY_get0_group(ec) != NULL) {
-        BN_CTX *bnctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(ec));
-
-        ret = bnctx != NULL && ossl_ec_key_pairwise_check(ec, bnctx);
-        BN_CTX_free(bnctx);
-    }
-#endif /* FIPS_MODULE */
 
     if (ret > 0)
         return ec;

--- a/test/pairwise_fail_test.c
+++ b/test/pairwise_fail_test.c
@@ -99,8 +99,6 @@ static int test_keygen_pairwise_failure(void)
         if (!TEST_ptr_null(pkey = EVP_PKEY_Q_keygen(libctx, NULL, "RSA", (size_t)2048)))
             goto err;
     } else if (strncmp(pairwise_name, "ec", 2) == 0) {
-        if (strcmp(pairwise_name, "eckat") == 0)
-            type = OSSL_SELF_TEST_TYPE_PCT_KAT;
         if (!TEST_true(setup_selftest_pairwise_failure(type)))
             goto err;
         if (!TEST_ptr_null(pkey = EVP_PKEY_Q_keygen(libctx, NULL, "EC", "P-256")))

--- a/test/recipes/30-test_pairwise_fail.t
+++ b/test/recipes/30-test_pairwise_fail.t
@@ -22,7 +22,7 @@ use lib bldtop_dir('.');
 plan skip_all => "These tests are unsupported in a non fips build"
     if disabled("fips");
 
-plan tests => 9;
+plan tests => 8;
 my $provconf = srctop_file("test", "fips-and-base.cnf");
 
 run(test(["fips_version_test", "-config", $provconf, ">=3.1.0"]),
@@ -37,17 +37,11 @@ SKIP: {
 }
 
 SKIP: {
-    skip "Skip EC test because of no ec in this build", 2
+    skip "Skip EC test because of no ec in this build", 1
         if disabled("ec");
     ok(run(test(["pairwise_fail_test", "-config", $provconf,
                  "-pairwise", "ec"])),
        "fips provider ec keygen pairwise failure test");
-
-    skip "FIPS provider version is too old", 1
-        if !$fips_exit;
-    ok(run(test(["pairwise_fail_test", "-config", $provconf,
-                 "-pairwise", "eckat"])),
-       "fips provider ec keygen kat failure test");
 }
 
 SKIP: {


### PR DESCRIPTION
In FIPS mode EC keygen was doing 3 self tests.
ec_generate_key() was calling both ecdsa_keygen_pairwise_test() and ecdsa_keygen_knownanswer_test(). The KAT did a key recomputation and comparison with the generated key, as per Sp80056Ar3 section 5.6.2.1.4. These tests covered both Keygen PCT for Key Agreement and Signatures. ossl_ec_key_pairwise_check() was also being called from within ec_gen(). The advice from Atsec (lab) is that the sign/verify test within ecdsa_keygen_pairwise_test() is sufficient according to the updated rules in FIPS 140-3 IG 10.3.A Additional comment 1, Since the usage of the generated key is unknown at the time of key generation.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
