### PR TITLE
x509: fix OCSP BasicResponse leak during verification

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1307,9 +1307,19 @@ static int check_cert_ocsp_resp(X509_STORE_CTX *ctx)
         return X509_V_ERR_OCSP_NO_RESPONSE;
 
     if ((resp = sk_OCSP_RESPONSE_value(ctx->ocsp_resp, ctx->error_depth)) == NULL
-        || (bs = OCSP_response_get1_basic(resp)) == NULL
-        || (num = OCSP_resp_count(bs)) < 1)
+        || (bs = OCSP_response_get1_basic(resp)) == NULL)
         return X509_V_ERR_OCSP_NO_RESPONSE;
+
+    /*
+     * OCSP_response_get1_basic() returns an owning reference, so once bs is
+     * non-NULL it must be released via the end: cleanup label. Route an empty
+     * BasicResponse (no single responses) through end: rather than returning
+     * directly, otherwise bs leaks.
+     */
+    if ((num = OCSP_resp_count(bs)) < 1) {
+        ret = X509_V_ERR_OCSP_NO_RESPONSE;
+        goto end;
+    }
 
     if (OCSP_response_status(resp) != OCSP_RESPONSE_STATUS_SUCCESSFUL) {
         OCSP_BASICRESP_free(bs);


### PR DESCRIPTION
Fix a leak in `check_cert_ocsp_resp` when `OCSP_response_get1_basic` succeeds but the returned `OCSP_BASICRESP` contains no single responses.

That path previously returned directly from the `OCSP_resp_count(bs) < 1` check, bypassing the `end:` cleanup label that frees `bs`. Split the BasicResponse acquisition from the count check and route the empty response case through `end:` instead, preserving the existing `X509_V_ERR_OCSP_NO_RESPONSE` result while releasing the owned response.

This is reachable when OCSP response checking is enabled with `X509_V_FLAG_OCSP_RESP_CHECK` and the peer supplies TLS 1.3 stapled OCSP responses.

Issue reported by @geeknik in #31759 who also suggested the fix.

This change applies cleanly by cherry picking to the `openssl-3.6` and `openssl-4.0` branches.

Fixes #31759