### PR TITLE
Suppress MSVC C4996 for legacy AppLink CRT calls

### DIFF
--- a/ms/applink.c
+++ b/ms/applink.c
@@ -103,6 +103,14 @@ static int app_fsetmod(FILE *fp, char mod)
 extern "C" {
 #endif
 
+/*
+ * The AppLink table exposes the legacy CRT signatures used by ms/uplink.h.
+ */
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
 __declspec(dllexport) void **
 #if defined(__BORLANDC__)
     /*
@@ -150,6 +158,10 @@ __declspec(dllexport) void **
 
     return OPENSSL_ApplinkTable;
 }
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop


### PR DESCRIPTION
This PR fixes the Windows AppLink build issue reported in #8241.

`ms/applink.c` deliberately exposes legacy CRT function pointers such as `fopen` and `_open`, because `ms/uplink.h` expects those existing signatures.
Replacing them with `fopen_s` or `_sopen_s` would not preserve the AppLink function table contract.

Instead, this change suppresses MSVC warning C4996 locally around `OPENSSL_Applink`, keeping the AppLink ABI unchanged while allowing applications that compile with `/W3 /WX /sdl` to include `applink.c` without failing on deprecated CRT warnings.

Fixes #8241

Testing performed:

- Confirmed the original failure with:
  `cl /nologo /W3 /WX /sdl /c ms\applink.c`
- Confirmed the same compile succeeds after the fix.
- Rebuilt the OpenSSL app target with:
  `nmake /nologo apps\openssl.exe`
- Ran:
  `apps\openssl.exe version -a`

