### PR TITLE
Use more recent default for _WIN32_WINNT

### DIFF
--- a/include/internal/e_os.h
+++ b/include/internal/e_os.h
@@ -109,7 +109,7 @@
  *	0x0603 // Windows 8.1
  *	0x0A00 // Windows 10
  */
-#define _WIN32_WINNT 0x0501
+#define _WIN32_WINNT 0x0600
 #endif
 #include <windows.h>
 #include <stdio.h>

--- a/providers/implementations/rands/seeding/rand_win.c
+++ b/providers/implementations/rands/seeding/rand_win.c
@@ -70,7 +70,7 @@ size_t ossl_pool_acquire_entropy(RAND_POOL *pool)
     buffer = ossl_rand_pool_add_begin(pool, bytes_needed);
     if (buffer != NULL) {
         size_t bytes = 0;
-        if (BCryptGenRandom(NULL, buffer, bytes_needed,
+        if (BCryptGenRandom(NULL, buffer, (ULONG)bytes_needed,
                 BCRYPT_USE_SYSTEM_PREFERRED_RNG)
             == STATUS_SUCCESS)
             bytes = bytes_needed;

--- a/util/platform_symbols/windows-symbols.txt
+++ b/util/platform_symbols/windows-symbols.txt
@@ -1,5 +1,6 @@
 AcquireSRWLockExclusive
 AcquireSRWLockShared
+BCryptGenRandom
 CertCloseStore
 CertFindCertificateInStore
 CertFreeCertificateContext


### PR DESCRIPTION
After the windows.h include optimization introduced in commit 1eaf29ef6c, the _WIN32_WINNT default was changed, causing performance regressions.

Currently, _WIN32_WINNT is defined as 0x0501, which means WinXP.

This causes the code to be compiled with WinXP-compatible code, notably
 - without USE_RWLOCK
 - using legacy thread implementation
 - legacy RNG seeding (no BCryptGenRandom)

This patch increases the requirement to 0x600 (Windows Vista).

Note that code running on WinXP cannot currently be compiled with any default configuration, as supported compilers generate executables for Windows Vista and above.

If we provide some way to support WinXP, it can be done by redefining _WIN32_WINNT.

Resolves: https://github.com/openssl/project/issues/2010
Fixes: 1eaf29ef6c "Remove direct includes of windows.h where possible"
