### PR TITLE
s390x: Fix AES-XTS hardware acceleration in IBM z17

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_hw_s390x.c
+++ b/providers/implementations/ciphers/cipher_aes_hw_s390x.c
@@ -856,18 +856,23 @@ static int cipher_hw_aes_xts_s390x_initkey(PROV_CIPHER_CTX *ctx,
     unsigned int dec = 0;
     int supported = 0;
 
-    switch (keylen) {
-    case 128 / 8 * 2:
-        fc = S390X_XTS_AES_128_MSA10;
-        offs = 32;
-        break;
-    case 256 / 8 * 2:
-        fc = S390X_XTS_AES_256_MSA10;
-        offs = 0;
-        break;
-    default:
-        fc = 0;
-        break;
+    if (key != NULL) {
+        switch (keylen) {
+        case 128 / 8 * 2:
+            fc = S390X_XTS_AES_128_MSA10;
+            offs = 32;
+            break;
+        case 256 / 8 * 2:
+            fc = S390X_XTS_AES_256_MSA10;
+            offs = 0;
+            break;
+        default:
+            fc = 0;
+            break;
+        }
+    } else {
+        fc = xctx->plat.s390x.fc & ~S390X_DECRYPT;
+        offs = xctx->plat.s390x.offset;
     }
 
     if (fc != 0)

--- a/providers/implementations/ciphers/cipher_aes_xts.c
+++ b/providers/implementations/ciphers/cipher_aes_xts.c
@@ -81,17 +81,6 @@ static int aes_xts_init(void *vctx, const unsigned char *key, size_t keylen,
     if (iv != NULL) {
         if (!ossl_cipher_generic_initiv(vctx, iv, ivlen))
             return 0;
-#ifdef AES_XTS_S390X
-        if (key == NULL) {
-            /* special handle iv-only update */
-            if (ivlen > sizeof(xctx->plat.s390x.param.km.tweak)) {
-                ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
-                return 0;
-            }
-            memcpy(xctx->plat.s390x.param.km.tweak, iv, ivlen);
-            xctx->plat.s390x.iv_set = 1;
-        }
-#endif
     }
     if (key != NULL) {
         if (keylen != ctx->keylen) {
@@ -103,6 +92,13 @@ static int aes_xts_init(void *vctx, const unsigned char *key, size_t keylen,
         if (!ctx->hw->init(ctx, key, keylen))
             return 0;
     }
+#ifdef AES_XTS_S390X
+    else if (xctx->plat.s390x.fc && ctx->iv_set) {
+        /* special handle iv-only update */
+        if (!ctx->hw->init(ctx, NULL, 0))
+            return 0;
+    }
+#endif
     return aes_xts_set_ctx_params(ctx, params);
 }
 


### PR DESCRIPTION
For the re-init case where only the IV is specified, but no key, the 'nap' field must also be initialized.

Instead of setting the s390 specific fields in a special case block, call ctx->hw->init() also in this case. It performs the necessary setup already (when the KM function code was once set already).

Adjust the cipher_hw_aes_xts_s390x_initkey() function so that it can also be called with a NULL key. It then only performs the IV setup as well as setting up the 'nap'.

Closes: https://github.com/openssl/openssl/issues/31766
